### PR TITLE
fix: bound firewall auth refresh requests

### DIFF
--- a/turbo/apps/api/src/lib/env.ts
+++ b/turbo/apps/api/src/lib/env.ts
@@ -77,11 +77,6 @@ const SCHEMA = {
   DB_POOL_MAX: z.coerce.number().int().min(1).default(10),
   DB_POOL_IDLE_TIMEOUT_MS: z.coerce.number().int().min(0).default(5000),
   DB_POOL_CONNECT_TIMEOUT_MS: z.coerce.number().int().min(0).optional(),
-  FIREWALL_AUTH_REFRESH_TIMEOUT_MS: z.coerce
-    .number()
-    .int()
-    .min(1)
-    .default(30_000),
   TELEGRAM_OFFICIAL_BOT_TOKEN: z.string().optional(),
   TELEGRAM_OFFICIAL_BOT_USERNAME: z.string().optional(),
   TELEGRAM_OFFICIAL_WEBHOOK_SECRET: z.string().optional(),

--- a/turbo/apps/api/src/lib/env.ts
+++ b/turbo/apps/api/src/lib/env.ts
@@ -77,6 +77,11 @@ const SCHEMA = {
   DB_POOL_MAX: z.coerce.number().int().min(1).default(10),
   DB_POOL_IDLE_TIMEOUT_MS: z.coerce.number().int().min(0).default(5000),
   DB_POOL_CONNECT_TIMEOUT_MS: z.coerce.number().int().min(0).optional(),
+  FIREWALL_AUTH_REFRESH_TIMEOUT_MS: z.coerce
+    .number()
+    .int()
+    .min(1)
+    .default(30_000),
   TELEGRAM_OFFICIAL_BOT_TOKEN: z.string().optional(),
   TELEGRAM_OFFICIAL_BOT_USERNAME: z.string().optional(),
   TELEGRAM_OFFICIAL_WEBHOOK_SECRET: z.string().optional(),

--- a/turbo/apps/api/src/signals/routes/__tests__/webhooks-agent-firewall-auth.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/webhooks-agent-firewall-auth.test.ts
@@ -19,12 +19,18 @@ import { secrets } from "@vm0/db/schema/secret";
 
 import { createApp } from "../../../app-factory";
 import { accept, setupApp, testContext } from "../../../__tests__/test-helpers";
-import { mockEnv, mockOptionalEnv } from "../../../lib/env";
+import { mockOptionalEnv } from "../../../lib/env";
 import { now } from "../../../lib/time";
 import { server } from "../../../mocks/server";
 import { signSandboxJwtForTests } from "../../auth/tokens";
 import { writeDb$ } from "../../external/db";
+import { setFirewallAuthRefreshTimeoutMsForTests } from "../../services/agent-webhook-firewall-auth.service";
 import { upsertOrgMultiAuthModelProvider$ } from "../../services/zero-model-provider.service";
+import {
+  decryptSecretForTests,
+  encryptSecretForTests,
+} from "./helpers/encrypt-secret";
+import { createFixtureTracker } from "./helpers/zero-route-test";
 import {
   deleteUsageInsightFixture$,
   seedCompose$,
@@ -32,11 +38,6 @@ import {
   seedUsageInsightFixture$,
   type UsageInsightFixture,
 } from "./helpers/zero-usage-insight";
-import { createFixtureTracker } from "./helpers/zero-route-test";
-import {
-  decryptSecretForTests,
-  encryptSecretForTests,
-} from "./helpers/encrypt-secret";
 
 const context = testContext();
 const store = createStore();
@@ -621,6 +622,7 @@ async function codexProviderState(fixture: FirewallFixture): Promise<{
 
 describe("POST /api/webhooks/agent/firewall/auth", () => {
   let restoreDynamicTestOAuthRefresh: (() => void) | undefined;
+  let restoreFirewallAuthRefreshTimeout: (() => void) | undefined;
 
   beforeEach(() => {
     mockOptionalEnv("NOTION_OAUTH_CLIENT_ID", "notion-client");
@@ -630,6 +632,8 @@ describe("POST /api/webhooks/agent/firewall/auth", () => {
   afterEach(() => {
     restoreDynamicTestOAuthRefresh?.();
     restoreDynamicTestOAuthRefresh = undefined;
+    restoreFirewallAuthRefreshTimeout?.();
+    restoreFirewallAuthRefreshTimeout = undefined;
   });
 
   it("rejects missing sandbox auth before parsing the body", async () => {
@@ -2635,7 +2639,8 @@ describe("POST /api/webhooks/agent/firewall/auth", () => {
   });
 
   it("classifies connector refresh timeouts as upstream without marking reconnect", async () => {
-    mockEnv("FIREWALL_AUTH_REFRESH_TIMEOUT_MS", 25);
+    restoreFirewallAuthRefreshTimeout =
+      setFirewallAuthRefreshTimeoutMsForTests(25);
     const fixture = await track(seedFixture());
     await seedExpiredNotionConnector(fixture);
     const providerAbortObserved = deferred();
@@ -3792,7 +3797,8 @@ describe("POST /api/webhooks/agent/firewall/auth", () => {
   });
 
   it("classifies model-provider refresh timeouts as upstream without marking reconnect", async () => {
-    mockEnv("FIREWALL_AUTH_REFRESH_TIMEOUT_MS", 25);
+    restoreFirewallAuthRefreshTimeout =
+      setFirewallAuthRefreshTimeoutMsForTests(25);
     const fixture = await track(seedFixture());
     await seedCodexModelProvider(fixture, {
       accessToken: "stale-chatgpt-token",

--- a/turbo/apps/api/src/signals/routes/__tests__/webhooks-agent-firewall-auth.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/webhooks-agent-firewall-auth.test.ts
@@ -19,7 +19,7 @@ import { secrets } from "@vm0/db/schema/secret";
 
 import { createApp } from "../../../app-factory";
 import { accept, setupApp, testContext } from "../../../__tests__/test-helpers";
-import { mockOptionalEnv } from "../../../lib/env";
+import { mockEnv, mockOptionalEnv } from "../../../lib/env";
 import { now } from "../../../lib/time";
 import { server } from "../../../mocks/server";
 import { signSandboxJwtForTests } from "../../auth/tokens";
@@ -103,6 +103,32 @@ function deferred(): {
     throw new Error("Failed to create deferred promise");
   }
   return { promise, resolve: resolvePromise };
+}
+
+function requestAbortError(signal: AbortSignal): Error {
+  if (signal.reason instanceof Error) {
+    return signal.reason;
+  }
+  const error = new Error("Provider refresh aborted");
+  error.name = "AbortError";
+  return error;
+}
+
+function rejectWhenRequestAborts(
+  request: Request,
+  onAbort: () => void,
+): Promise<never> {
+  return new Promise<never>((_resolve, reject) => {
+    const rejectAbort = () => {
+      onAbort();
+      reject(requestAbortError(request.signal));
+    };
+    if (request.signal.aborted) {
+      rejectAbort();
+      return;
+    }
+    request.signal.addEventListener("abort", rejectAbort, { once: true });
+  });
 }
 
 async function hasWaitingAdvisoryLock(lockKey: string): Promise<boolean> {
@@ -2608,6 +2634,46 @@ describe("POST /api/webhooks/agent/firewall/auth", () => {
     });
   });
 
+  it("classifies connector refresh timeouts as upstream without marking reconnect", async () => {
+    mockEnv("FIREWALL_AUTH_REFRESH_TIMEOUT_MS", 25);
+    const fixture = await track(seedFixture());
+    await seedExpiredNotionConnector(fixture);
+    const providerAbortObserved = deferred();
+    server.use(
+      http.post("https://api.notion.com/v1/oauth/token", ({ request }) => {
+        return rejectWhenRequestAborts(request, providerAbortObserved.resolve);
+      }),
+    );
+
+    const response = await accept(
+      firewallClient().resolve({
+        body: {
+          encryptedSecrets: encryptedSecrets({
+            NOTION_TOKEN: "stale-notion-token",
+          }),
+          authHeaders: {
+            Authorization: `Bearer ${secretTemplate("NOTION_TOKEN")}`,
+          },
+          secretConnectorMap: {
+            NOTION_TOKEN: "notion",
+          },
+        },
+        headers: authHeaders(fixture),
+      }),
+      [502],
+    );
+
+    await providerAbortObserved.promise;
+    expect(response.body.error).toMatchObject({
+      code: "TOKEN_REFRESH_FAILED",
+      connectors: ["notion"],
+      failureReason: "upstream_provider",
+    });
+    await expect(notionConnectorState(fixture)).resolves.toMatchObject({
+      needsReconnect: false,
+    });
+  });
+
   it.each(["temporarily_unavailable", "server_error"] as const)(
     "classifies standard OAuth %s refresh failures as upstream",
     async (oauthError) => {
@@ -3714,6 +3780,60 @@ describe("POST /api/webhooks/agent/firewall/auth", () => {
       [502],
     );
 
+    expect(response.body.error).toMatchObject({
+      code: "TOKEN_REFRESH_FAILED",
+      connectors: ["codex-oauth-token"],
+      failureReason: "upstream_provider",
+    });
+    await expect(codexProviderState(fixture)).resolves.toMatchObject({
+      needsReconnect: false,
+      lastRefreshErrorCode: null,
+    });
+  });
+
+  it("classifies model-provider refresh timeouts as upstream without marking reconnect", async () => {
+    mockEnv("FIREWALL_AUTH_REFRESH_TIMEOUT_MS", 25);
+    const fixture = await track(seedFixture());
+    await seedCodexModelProvider(fixture, {
+      accessToken: "stale-chatgpt-token",
+      refreshToken: "chatgpt-refresh-token",
+      tokenExpiresAt: new Date(now() - 60_000),
+      needsReconnect: false,
+      lastRefreshErrorCode: null,
+    });
+    const providerAbortObserved = deferred();
+    server.use(
+      http.post("https://auth.openai.com/oauth/token", ({ request }) => {
+        return rejectWhenRequestAborts(request, providerAbortObserved.resolve);
+      }),
+    );
+
+    const response = await accept(
+      firewallClient().resolve({
+        body: {
+          encryptedSecrets: encryptedSecrets({
+            CHATGPT_ACCESS_TOKEN: "stale-chatgpt-token",
+          }),
+          authHeaders: {
+            Authorization: `Bearer ${secretTemplate("CHATGPT_ACCESS_TOKEN")}`,
+          },
+          secretConnectorMap: {
+            CHATGPT_ACCESS_TOKEN: "codex-oauth-token",
+          },
+          secretConnectorMetadataMap: {
+            CHATGPT_ACCESS_TOKEN: {
+              sourceType: "model-provider",
+              sourceUserId: ORG_SENTINEL_USER_ID,
+              metadataKey: "codex-oauth-token",
+            },
+          },
+        },
+        headers: authHeaders(fixture),
+      }),
+      [502],
+    );
+
+    await providerAbortObserved.promise;
     expect(response.body.error).toMatchObject({
       code: "TOKEN_REFRESH_FAILED",
       connectors: ["codex-oauth-token"],

--- a/turbo/apps/api/src/signals/services/agent-webhook-firewall-auth.service.ts
+++ b/turbo/apps/api/src/signals/services/agent-webhook-firewall-auth.service.ts
@@ -43,9 +43,10 @@ import { modelProviders } from "@vm0/db/schema/model-provider";
 import { secrets as secretsTable } from "@vm0/db/schema/secret";
 import { and, eq, inArray, sql } from "drizzle-orm";
 
-import { env, optionalEnv } from "../../lib/env";
+import { optionalEnv } from "../../lib/env";
 import { badRequestMessage, insufficientCredits } from "../../lib/error";
 import { logger } from "../../lib/log";
+import { testOverride } from "../../lib/singleton";
 import { nowDate } from "../../lib/time";
 import type { SandboxAuth } from "../../types/auth";
 import type { Db } from "../external/db";
@@ -68,7 +69,20 @@ type SecretType = AccessSecretSource;
 const NORMAL_BILLABLE_FIREWALL_LEASE_SECONDS = 30;
 const LOW_BILLABLE_FIREWALL_LEASE_SECONDS = 5;
 const LOW_BILLABLE_FIREWALL_CREDIT_THRESHOLD = 1000;
+const FIREWALL_AUTH_REFRESH_TIMEOUT_MS = 30_000;
 const REFRESH_TIMEOUT_ERROR_CODE = "oauth_refresh_timeout";
+const refreshTimeoutMsForTests = testOverride<number | undefined>(() => {
+  return undefined;
+});
+
+export function setFirewallAuthRefreshTimeoutMsForTests(
+  timeoutMs: number,
+): () => void {
+  refreshTimeoutMsForTests.set(timeoutMs);
+  return () => {
+    refreshTimeoutMsForTests.clear();
+  };
+}
 
 interface FirewallAuthBody {
   readonly encryptedSecrets: string;
@@ -503,7 +517,9 @@ function isFetchAbortError(error: unknown): boolean {
 }
 
 function firewallAuthRefreshTimeoutSignal(): AbortSignal {
-  return AbortSignal.timeout(env("FIREWALL_AUTH_REFRESH_TIMEOUT_MS"));
+  return AbortSignal.timeout(
+    refreshTimeoutMsForTests.get() ?? FIREWALL_AUTH_REFRESH_TIMEOUT_MS,
+  );
 }
 
 function isReconnectRequiredRefreshErrorCode(

--- a/turbo/apps/api/src/signals/services/agent-webhook-firewall-auth.service.ts
+++ b/turbo/apps/api/src/signals/services/agent-webhook-firewall-auth.service.ts
@@ -459,8 +459,9 @@ function currentProviderEnv(): ProviderEnv {
 
 function refreshFailureReasonFromError(
   error: unknown,
+  refreshTimedOut: boolean,
 ): FirewallAuthFailureReason | undefined {
-  if (isFetchAbortError(error)) {
+  if (refreshTimedOut) {
     return "upstream_provider";
   }
   if (isChatgptRefreshError(error)) {
@@ -487,8 +488,11 @@ function refreshFailureReasonFromError(
   return undefined;
 }
 
-function refreshErrorCodeFromError(error: unknown): string | null {
-  if (isFetchAbortError(error)) {
+function refreshErrorCodeFromError(
+  error: unknown,
+  refreshTimedOut: boolean,
+): string | null {
+  if (refreshTimedOut) {
     return REFRESH_TIMEOUT_ERROR_CODE;
   }
   if (isChatgptRefreshError(error)) {
@@ -503,16 +507,37 @@ function refreshErrorCodeFromError(error: unknown): string | null {
   return null;
 }
 
+function classifyRefreshFailure(
+  error: unknown,
+  signal: AbortSignal,
+): {
+  readonly errorCode: string | null;
+  readonly failureReason: FirewallAuthFailureReason | undefined;
+} {
+  const refreshTimedOut = isRefreshTimeoutError(error, signal);
+  return {
+    errorCode: refreshErrorCodeFromError(error, refreshTimedOut),
+    failureReason: refreshFailureReasonFromError(error, refreshTimedOut),
+  };
+}
+
 function isFetchNetworkError(error: unknown): boolean {
   return (
     error instanceof TypeError && error.message.toLowerCase().includes("fetch")
   );
 }
 
-function isFetchAbortError(error: unknown): boolean {
+function isRefreshTimeoutError(error: unknown, signal: AbortSignal): boolean {
+  if (!signal.aborted || !(error instanceof Error)) {
+    return false;
+  }
+  if (error === signal.reason) {
+    return true;
+  }
   return (
-    error instanceof Error &&
-    (error.name === "AbortError" || error.name === "TimeoutError")
+    signal.reason instanceof Error &&
+    signal.reason.name === "TimeoutError" &&
+    (error.name === "TimeoutError" || error.name === "AbortError")
   );
 }
 
@@ -1282,6 +1307,25 @@ async function markRefreshTokenMissing(
   return refreshTokenMissingResult();
 }
 
+async function markAndReturnRefreshFailure(
+  args: RefreshAccessTokenArgs,
+  context: RefreshTokenContext,
+  error: unknown,
+  signal: AbortSignal,
+): Promise<RefreshAccessTokenResult> {
+  const message = error instanceof Error ? error.message : "Unknown error";
+  const { errorCode, failureReason } = classifyRefreshFailure(error, signal);
+  L.warn(`${args.connectorType} token refresh failed: ${message}`, {
+    connectorType: args.connectorType,
+    orgId: args.orgId,
+    userId: args.userId,
+    errorCode,
+    failureReason,
+  });
+  await markRefreshFailure(args, context, errorCode, failureReason);
+  return refreshFailedResult(failureReason);
+}
+
 async function refreshAccessTokenForSource(
   args: RefreshAccessTokenArgs,
 ): Promise<RefreshAccessTokenResult> {
@@ -1296,7 +1340,6 @@ async function refreshAccessTokenForSource(
     ? args.forceRefreshStartedAtMicros
     : await currentDatabaseTimestampMicros(args.db);
   const initialState = await loadRefreshState(args.db, args, prepared.context);
-
   return await args.db.transaction(async (tx) => {
     if (prepared.sourceType === "connector") {
       await lockConnectorState(tx, {
@@ -1311,7 +1354,6 @@ async function refreshAccessTokenForSource(
         type: args.metadataKey ?? prepared.providerKey,
       });
     }
-
     const lockedState = await loadRefreshState(tx, args, prepared.context);
     if (!lockedState) {
       L.warn(`${args.connectorType} token refresh source missing`, {
@@ -1322,7 +1364,6 @@ async function refreshAccessTokenForSource(
       });
       return markRefreshTokenMissing({ ...args, db: tx }, prepared.context);
     }
-
     const currentAccessToken = lockedState.accessToken;
     if (
       didLockedRefreshFailDuringRequest({
@@ -1339,7 +1380,6 @@ async function refreshAccessTokenForSource(
         }),
       );
     }
-
     if (
       currentAccessToken &&
       shouldUseLockedCurrentAccess({
@@ -1361,7 +1401,6 @@ async function refreshAccessTokenForSource(
       L.debug(`No ${args.connectorType} refresh token available, skipping`);
       return markRefreshTokenMissing({ ...args, db: tx }, prepared.context);
     }
-
     const refreshSignal = firewallAuthRefreshTimeoutSignal();
     const refreshPromise =
       prepared.sourceType === "connector"
@@ -1379,29 +1418,14 @@ async function refreshAccessTokenForSource(
             signal: refreshSignal,
           });
     const refreshResult = await settle(refreshPromise);
-
     if (!refreshResult.ok) {
-      const error = refreshResult.error;
-      const message = error instanceof Error ? error.message : "Unknown error";
-      const errorCode = refreshErrorCodeFromError(error);
-      const failureReason = refreshFailureReasonFromError(error);
-      L.warn(`${args.connectorType} token refresh failed: ${message}`, {
-        connectorType: args.connectorType,
-        orgId: args.orgId,
-        userId: args.userId,
-        errorCode,
-        failureReason,
-      });
-
-      await markRefreshFailure(
+      return markAndReturnRefreshFailure(
         { ...args, db: tx },
         prepared.context,
-        errorCode,
-        failureReason,
+        refreshResult.error,
+        refreshSignal,
       );
-      return refreshFailedResult(failureReason);
     }
-
     const result = refreshResult.value;
     await markRefreshSuccess({ ...args, db: tx }, prepared.context, result);
     args.connectorSecrets[prepared.context.accessTokenSecret] =

--- a/turbo/apps/api/src/signals/services/agent-webhook-firewall-auth.service.ts
+++ b/turbo/apps/api/src/signals/services/agent-webhook-firewall-auth.service.ts
@@ -1326,6 +1326,27 @@ async function markAndReturnRefreshFailure(
   return refreshFailedResult(failureReason);
 }
 
+function refreshPreparedAccessToken(args: {
+  readonly prepared: PreparedRefreshTokenContext;
+  readonly refreshToken: string;
+  readonly signal: AbortSignal;
+}) {
+  return args.prepared.sourceType === "connector"
+    ? refreshConnectorAuthProviderAccessToken({
+        type: args.prepared.connectorType,
+        authMethod: args.prepared.authMethod,
+        clientArgs: args.prepared.clientArgs,
+        refreshToken: args.refreshToken,
+        signal: args.signal,
+      })
+    : refreshModelProviderOAuthToken({
+        providerKey: args.prepared.providerKey,
+        currentEnv: args.prepared.currentEnv,
+        refreshToken: args.refreshToken,
+        signal: args.signal,
+      });
+}
+
 async function refreshAccessTokenForSource(
   args: RefreshAccessTokenArgs,
 ): Promise<RefreshAccessTokenResult> {
@@ -1402,22 +1423,13 @@ async function refreshAccessTokenForSource(
       return markRefreshTokenMissing({ ...args, db: tx }, prepared.context);
     }
     const refreshSignal = firewallAuthRefreshTimeoutSignal();
-    const refreshPromise =
-      prepared.sourceType === "connector"
-        ? refreshConnectorAuthProviderAccessToken({
-            type: prepared.connectorType,
-            authMethod: prepared.authMethod,
-            clientArgs: prepared.clientArgs,
-            refreshToken: lockedState.refreshToken,
-            signal: refreshSignal,
-          })
-        : refreshModelProviderOAuthToken({
-            providerKey: prepared.providerKey,
-            currentEnv: prepared.currentEnv,
-            refreshToken: lockedState.refreshToken,
-            signal: refreshSignal,
-          });
-    const refreshResult = await settle(refreshPromise);
+    const refreshResult = await settle(
+      refreshPreparedAccessToken({
+        prepared,
+        refreshToken: lockedState.refreshToken,
+        signal: refreshSignal,
+      }),
+    );
     if (!refreshResult.ok) {
       return markAndReturnRefreshFailure(
         { ...args, db: tx },

--- a/turbo/apps/api/src/signals/services/agent-webhook-firewall-auth.service.ts
+++ b/turbo/apps/api/src/signals/services/agent-webhook-firewall-auth.service.ts
@@ -43,7 +43,7 @@ import { modelProviders } from "@vm0/db/schema/model-provider";
 import { secrets as secretsTable } from "@vm0/db/schema/secret";
 import { and, eq, inArray, sql } from "drizzle-orm";
 
-import { optionalEnv } from "../../lib/env";
+import { env, optionalEnv } from "../../lib/env";
 import { badRequestMessage, insufficientCredits } from "../../lib/error";
 import { logger } from "../../lib/log";
 import { nowDate } from "../../lib/time";
@@ -68,6 +68,7 @@ type SecretType = AccessSecretSource;
 const NORMAL_BILLABLE_FIREWALL_LEASE_SECONDS = 30;
 const LOW_BILLABLE_FIREWALL_LEASE_SECONDS = 5;
 const LOW_BILLABLE_FIREWALL_CREDIT_THRESHOLD = 1000;
+const REFRESH_TIMEOUT_ERROR_CODE = "oauth_refresh_timeout";
 
 interface FirewallAuthBody {
   readonly encryptedSecrets: string;
@@ -445,6 +446,9 @@ function currentProviderEnv(): ProviderEnv {
 function refreshFailureReasonFromError(
   error: unknown,
 ): FirewallAuthFailureReason | undefined {
+  if (isFetchAbortError(error)) {
+    return "upstream_provider";
+  }
   if (isChatgptRefreshError(error)) {
     return isReconnectRequiredRefreshErrorCode(error.code)
       ? "reconnect_required"
@@ -470,6 +474,9 @@ function refreshFailureReasonFromError(
 }
 
 function refreshErrorCodeFromError(error: unknown): string | null {
+  if (isFetchAbortError(error)) {
+    return REFRESH_TIMEOUT_ERROR_CODE;
+  }
   if (isChatgptRefreshError(error)) {
     return error.code;
   }
@@ -486,6 +493,17 @@ function isFetchNetworkError(error: unknown): boolean {
   return (
     error instanceof TypeError && error.message.toLowerCase().includes("fetch")
   );
+}
+
+function isFetchAbortError(error: unknown): boolean {
+  return (
+    error instanceof Error &&
+    (error.name === "AbortError" || error.name === "TimeoutError")
+  );
+}
+
+function firewallAuthRefreshTimeoutSignal(): AbortSignal {
+  return AbortSignal.timeout(env("FIREWALL_AUTH_REFRESH_TIMEOUT_MS"));
 }
 
 function isReconnectRequiredRefreshErrorCode(
@@ -1328,6 +1346,7 @@ async function refreshAccessTokenForSource(
       return markRefreshTokenMissing({ ...args, db: tx }, prepared.context);
     }
 
+    const refreshSignal = firewallAuthRefreshTimeoutSignal();
     const refreshPromise =
       prepared.sourceType === "connector"
         ? refreshConnectorAuthProviderAccessToken({
@@ -1335,11 +1354,13 @@ async function refreshAccessTokenForSource(
             authMethod: prepared.authMethod,
             clientArgs: prepared.clientArgs,
             refreshToken: lockedState.refreshToken,
+            signal: refreshSignal,
           })
         : refreshModelProviderOAuthToken({
             providerKey: prepared.providerKey,
             currentEnv: prepared.currentEnv,
             refreshToken: lockedState.refreshToken,
+            signal: refreshSignal,
           });
     const refreshResult = await settle(refreshPromise);
 

--- a/turbo/packages/connectors/src/__tests__/connectors.test.ts
+++ b/turbo/packages/connectors/src/__tests__/connectors.test.ts
@@ -74,6 +74,10 @@ import { GOOGLE_OAUTH_CONNECTOR_TYPES } from "../auth-providers/oauth/google-con
 import { buildGoogleAuthorizationUrl } from "../auth-providers/oauth/google";
 import { getConnectorFirewall } from "../firewalls";
 
+function testRefreshSignal(): AbortSignal {
+  return new AbortController().signal;
+}
+
 function getApiTokenManualGrantFields(
   type: ConnectorType,
 ): Record<string, ConnectorManualGrantFieldConfig> | undefined {
@@ -536,6 +540,7 @@ describe("connector provider capability checks", () => {
         authMethod: "api-token",
         clientArgs: {},
         refreshToken: "stripe-refresh-token",
+        signal: testRefreshSignal(),
       }),
     ).rejects.toThrow(
       "stripe connector auth method api-token does not support token refresh",
@@ -1055,6 +1060,7 @@ describe("connector provider capability checks", () => {
         authMethod: "oauth",
         clientArgs: getConnectorAuthProviderClientArgs(oauthClient),
         refreshToken: "base44-refresh-rotation",
+        signal: testRefreshSignal(),
       }),
     ).resolves.toStrictEqual({
       accessToken: "base44-access-refreshed",
@@ -1067,6 +1073,7 @@ describe("connector provider capability checks", () => {
         authMethod: "oauth",
         clientArgs: getConnectorAuthProviderClientArgs(oauthClient),
         refreshToken: "base44-refresh-without-rotation",
+        signal: testRefreshSignal(),
       }),
     ).resolves.toStrictEqual({
       accessToken: "base44-access-refreshed",
@@ -1389,6 +1396,7 @@ describe("connector provider capability checks", () => {
       authMethod: "oauth",
       clientArgs: getConnectorAuthProviderClientArgs(oauthClient),
       refreshToken: "slock-refresh-token",
+      signal: testRefreshSignal(),
     });
     expect(refreshResult).toStrictEqual({
       accessToken: slockRefreshedAccessToken,
@@ -1409,6 +1417,7 @@ describe("connector provider capability checks", () => {
         authMethod: "oauth",
         clientArgs: getConnectorAuthProviderClientArgs(oauthClient),
         refreshToken: "slock-refresh-malformed",
+        signal: testRefreshSignal(),
       }),
     ).resolves.toStrictEqual({
       accessToken: slockMalformedAccessToken,

--- a/turbo/packages/connectors/src/auth-providers/connector-auth.ts
+++ b/turbo/packages/connectors/src/auth-providers/connector-auth.ts
@@ -458,6 +458,7 @@ export async function refreshConnectorAuthProviderAccessToken<
   readonly authMethod: string;
   readonly clientArgs: ConnectorAuthProviderClientArgs;
   readonly refreshToken: string;
+  readonly signal?: AbortSignal;
 }): Promise<OAuthRefreshResult> {
   if (
     !connectorAuthMethodSupportsRefreshTokenAccess(args.type, args.authMethod)
@@ -478,6 +479,7 @@ export async function refreshConnectorAuthProviderAccessToken<
   return await access.refreshToken({
     ...args.clientArgs,
     refreshToken: args.refreshToken,
+    signal: args.signal,
   } as ConnectorAuthProviderRefreshArgs<T>);
 }
 

--- a/turbo/packages/connectors/src/auth-providers/connector-auth.ts
+++ b/turbo/packages/connectors/src/auth-providers/connector-auth.ts
@@ -458,7 +458,7 @@ export async function refreshConnectorAuthProviderAccessToken<
   readonly authMethod: string;
   readonly clientArgs: ConnectorAuthProviderClientArgs;
   readonly refreshToken: string;
-  readonly signal?: AbortSignal;
+  readonly signal: AbortSignal;
 }): Promise<OAuthRefreshResult> {
   if (
     !connectorAuthMethodSupportsRefreshTokenAccess(args.type, args.authMethod)

--- a/turbo/packages/connectors/src/auth-providers/model-provider-auth.ts
+++ b/turbo/packages/connectors/src/auth-providers/model-provider-auth.ts
@@ -67,6 +67,7 @@ export async function refreshModelProviderOAuthToken(args: {
   readonly providerKey: ModelProviderOAuthProviderKey;
   readonly currentEnv: ProviderEnv;
   readonly refreshToken: string;
+  readonly signal?: AbortSignal;
 }): Promise<OAuthRefreshResult> {
   const access = MODEL_PROVIDER_OAUTH_PROVIDERS[args.providerKey].access;
 
@@ -86,6 +87,7 @@ export async function refreshModelProviderOAuthToken(args: {
         clientId,
         clientSecret: access.getClientSecret(args.currentEnv),
         refreshToken: args.refreshToken,
+        signal: args.signal,
       });
     }
   }

--- a/turbo/packages/connectors/src/auth-providers/model-provider-auth.ts
+++ b/turbo/packages/connectors/src/auth-providers/model-provider-auth.ts
@@ -67,7 +67,7 @@ export async function refreshModelProviderOAuthToken(args: {
   readonly providerKey: ModelProviderOAuthProviderKey;
   readonly currentEnv: ProviderEnv;
   readonly refreshToken: string;
-  readonly signal?: AbortSignal;
+  readonly signal: AbortSignal;
 }): Promise<OAuthRefreshResult> {
   const access = MODEL_PROVIDER_OAUTH_PROVIDERS[args.providerKey].access;
 

--- a/turbo/packages/connectors/src/auth-providers/oauth/google.ts
+++ b/turbo/packages/connectors/src/auth-providers/oauth/google.ts
@@ -124,7 +124,7 @@ export async function refreshGoogleToken(
   clientId: string,
   clientSecret: string,
   refreshToken: string,
-  signal?: AbortSignal,
+  signal: AbortSignal,
 ): Promise<GoogleRefreshResult> {
   const authCodeGrant = getAuthCodeGrantConfig(connectorType);
   const response = await fetch(authCodeGrant.tokenUrl, {

--- a/turbo/packages/connectors/src/auth-providers/oauth/google.ts
+++ b/turbo/packages/connectors/src/auth-providers/oauth/google.ts
@@ -124,9 +124,11 @@ export async function refreshGoogleToken(
   clientId: string,
   clientSecret: string,
   refreshToken: string,
+  signal?: AbortSignal,
 ): Promise<GoogleRefreshResult> {
   const authCodeGrant = getAuthCodeGrantConfig(connectorType);
   const response = await fetch(authCodeGrant.tokenUrl, {
+    signal,
     method: "POST",
     headers: {
       "Content-Type": "application/x-www-form-urlencoded",

--- a/turbo/packages/connectors/src/auth-providers/oauth/microsoft.ts
+++ b/turbo/packages/connectors/src/auth-providers/oauth/microsoft.ts
@@ -128,7 +128,7 @@ export async function refreshMicrosoftToken(
   clientId: string,
   clientSecret: string,
   refreshToken: string,
-  signal?: AbortSignal,
+  signal: AbortSignal,
 ): Promise<MicrosoftRefreshResult> {
   const authCodeGrant = getAuthCodeGrantConfig(connectorType);
   const response = await fetch(authCodeGrant.tokenUrl, {

--- a/turbo/packages/connectors/src/auth-providers/oauth/microsoft.ts
+++ b/turbo/packages/connectors/src/auth-providers/oauth/microsoft.ts
@@ -128,9 +128,11 @@ export async function refreshMicrosoftToken(
   clientId: string,
   clientSecret: string,
   refreshToken: string,
+  signal?: AbortSignal,
 ): Promise<MicrosoftRefreshResult> {
   const authCodeGrant = getAuthCodeGrantConfig(connectorType);
   const response = await fetch(authCodeGrant.tokenUrl, {
+    signal,
     method: "POST",
     headers: {
       "Content-Type": "application/x-www-form-urlencoded",

--- a/turbo/packages/connectors/src/auth-providers/oauth/providers/__tests__/codex-oauth.test.ts
+++ b/turbo/packages/connectors/src/auth-providers/oauth/providers/__tests__/codex-oauth.test.ts
@@ -14,6 +14,10 @@ import { server } from "./test-server";
 const TOKEN_URL = "https://auth.openai.com/oauth/token";
 const CODEX_PUBLIC_CLIENT_ID = "app_EMoamEEZ73f0CkXaXp7hrann";
 
+function testRefreshSignal(): AbortSignal {
+  return new AbortController().signal;
+}
+
 function getCodexRefreshAccess() {
   const access = codexOauthProvider.access;
   if (access.kind !== "refresh-token") {
@@ -39,7 +43,12 @@ describe("connector/providers/codex-oauth", () => {
       });
       server.use(handler);
 
-      const result = await refreshChatgptToken("x", "x", "old-rt");
+      const result = await refreshChatgptToken(
+        "x",
+        "x",
+        "old-rt",
+        testRefreshSignal(),
+      );
       expect(result.accessToken).toBe("new-at");
       expect(result.refreshToken).toBe("new-rt");
       expect(result.expiresIn).toBe(600000);
@@ -51,7 +60,12 @@ describe("connector/providers/codex-oauth", () => {
       });
       server.use(handler);
 
-      const result = await refreshChatgptToken("x", "x", "old-rt");
+      const result = await refreshChatgptToken(
+        "x",
+        "x",
+        "old-rt",
+        testRefreshSignal(),
+      );
       expect(result.accessToken).toBe("new-at");
       expect(result.refreshToken).toBeNull();
     });
@@ -71,7 +85,7 @@ describe("connector/providers/codex-oauth", () => {
       server.use(handler);
 
       await expect(
-        refreshChatgptToken("x", "x", "old-rt"),
+        refreshChatgptToken("x", "x", "old-rt", testRefreshSignal()),
       ).rejects.toMatchObject({
         name: "ChatgptRefreshError",
         code: "refresh_token_expired",
@@ -88,7 +102,7 @@ describe("connector/providers/codex-oauth", () => {
       server.use(handler);
 
       await expect(
-        refreshChatgptToken("x", "x", "old-rt"),
+        refreshChatgptToken("x", "x", "old-rt", testRefreshSignal()),
       ).rejects.toMatchObject({
         name: "ChatgptRefreshError",
         code: "refresh_token_reused",
@@ -109,11 +123,14 @@ describe("connector/providers/codex-oauth", () => {
       });
       server.use(handler);
 
-      const error = await refreshChatgptToken("x", "x", "old-rt").catch(
-        (e: unknown) => {
-          return e;
-        },
-      );
+      const error = await refreshChatgptToken(
+        "x",
+        "x",
+        "old-rt",
+        testRefreshSignal(),
+      ).catch((e: unknown) => {
+        return e;
+      });
       expect(isChatgptRefreshError(error)).toBe(true);
       expect((error as ChatgptRefreshError).code).toBe(
         "refresh_token_invalidated",
@@ -129,11 +146,14 @@ describe("connector/providers/codex-oauth", () => {
       });
       server.use(handler);
 
-      const error = await refreshChatgptToken("x", "x", "old-rt").catch(
-        (e: unknown) => {
-          return e;
-        },
-      );
+      const error = await refreshChatgptToken(
+        "x",
+        "x",
+        "old-rt",
+        testRefreshSignal(),
+      ).catch((e: unknown) => {
+        return e;
+      });
       expect(isChatgptRefreshError(error)).toBe(true);
       expect((error as ChatgptRefreshError).code).toBe("refresh_token_other");
     });
@@ -144,11 +164,14 @@ describe("connector/providers/codex-oauth", () => {
       });
       server.use(handler);
 
-      const error = await refreshChatgptToken("x", "x", "old-rt").catch(
-        (e: unknown) => {
-          return e;
-        },
-      );
+      const error = await refreshChatgptToken(
+        "x",
+        "x",
+        "old-rt",
+        testRefreshSignal(),
+      ).catch((e: unknown) => {
+        return e;
+      });
       expect(error).toBeInstanceOf(Error);
       expect(isChatgptRefreshError(error)).toBe(false);
     });
@@ -159,9 +182,9 @@ describe("connector/providers/codex-oauth", () => {
       });
       server.use(handler);
 
-      await expect(refreshChatgptToken("x", "x", "old-rt")).rejects.toThrow(
-        /No access token in ChatGPT refresh response/,
-      );
+      await expect(
+        refreshChatgptToken("x", "x", "old-rt", testRefreshSignal()),
+      ).rejects.toThrow(/No access token in ChatGPT refresh response/);
     });
   });
 

--- a/turbo/packages/connectors/src/auth-providers/oauth/providers/__tests__/google-ads.test.ts
+++ b/turbo/packages/connectors/src/auth-providers/oauth/providers/__tests__/google-ads.test.ts
@@ -8,6 +8,10 @@ import { server } from "./test-server";
 const TOKEN_URL = "https://oauth2.googleapis.com/token";
 const USER_INFO_URL = "https://www.googleapis.com/oauth2/v2/userinfo";
 
+function testRefreshSignal(): AbortSignal {
+  return new AbortController().signal;
+}
+
 describe("connector/providers/google-ads", () => {
   describe("googleAdsProvider", () => {
     it("registers google-ads as an auth-code grant provider", () => {
@@ -136,6 +140,7 @@ describe("connector/providers/google-ads", () => {
         clientId: "client-id",
         clientSecret: "client-secret",
         refreshToken: "refresh-token",
+        signal: testRefreshSignal(),
       });
 
       expect(result).toEqual({

--- a/turbo/packages/connectors/src/auth-providers/oauth/providers/__tests__/gumroad.test.ts
+++ b/turbo/packages/connectors/src/auth-providers/oauth/providers/__tests__/gumroad.test.ts
@@ -8,6 +8,10 @@ import {
 } from "../gumroad";
 import { server } from "./test-server";
 
+function testRefreshSignal(): AbortSignal {
+  return new AbortController().signal;
+}
+
 describe("connector/providers/gumroad", () => {
   describe("buildGumroadAuthorizationUrl", () => {
     it("builds URL with client_id, redirect_uri, state, and scope", () => {
@@ -132,6 +136,7 @@ describe("connector/providers/gumroad", () => {
         "client-id",
         "client-secret",
         "old-refresh-token",
+        testRefreshSignal(),
       );
 
       expect(result.accessToken).toBe("new-gumroad-token");
@@ -148,7 +153,12 @@ describe("connector/providers/gumroad", () => {
       server.use(handler);
 
       await expect(
-        refreshGumroadToken("client-id", "client-secret", "bad-refresh-token"),
+        refreshGumroadToken(
+          "client-id",
+          "client-secret",
+          "bad-refresh-token",
+          testRefreshSignal(),
+        ),
       ).rejects.toThrow("Refresh token revoked");
     });
 
@@ -159,7 +169,12 @@ describe("connector/providers/gumroad", () => {
       server.use(handler);
 
       await expect(
-        refreshGumroadToken("client-id", "client-secret", "refresh-token"),
+        refreshGumroadToken(
+          "client-id",
+          "client-secret",
+          "refresh-token",
+          testRefreshSignal(),
+        ),
       ).rejects.toThrow("No access token in Gumroad refresh response");
     });
 
@@ -170,7 +185,12 @@ describe("connector/providers/gumroad", () => {
       server.use(handler);
 
       await expect(
-        refreshGumroadToken("client-id", "client-secret", "refresh-token"),
+        refreshGumroadToken(
+          "client-id",
+          "client-secret",
+          "refresh-token",
+          testRefreshSignal(),
+        ),
       ).rejects.toThrow("Gumroad token refresh failed");
     });
   });

--- a/turbo/packages/connectors/src/auth-providers/oauth/providers/__tests__/spotify.test.ts
+++ b/turbo/packages/connectors/src/auth-providers/oauth/providers/__tests__/spotify.test.ts
@@ -8,6 +8,10 @@ import {
 } from "../spotify";
 import { server } from "./test-server";
 
+function testRefreshSignal(): AbortSignal {
+  return new AbortController().signal;
+}
+
 describe("connector/providers/spotify", () => {
   describe("buildSpotifyAuthorizationUrl", () => {
     it("builds URL with client_id, redirect_uri, state, and scope", () => {
@@ -145,6 +149,7 @@ describe("connector/providers/spotify", () => {
         "client-id",
         "client-secret",
         "old-refresh-token",
+        testRefreshSignal(),
       );
 
       expect(result.accessToken).toBe("new-spotify-token");
@@ -165,7 +170,12 @@ describe("connector/providers/spotify", () => {
       server.use(handler);
 
       await expect(
-        refreshSpotifyToken("client-id", "client-secret", "bad-refresh-token"),
+        refreshSpotifyToken(
+          "client-id",
+          "client-secret",
+          "bad-refresh-token",
+          testRefreshSignal(),
+        ),
       ).rejects.toThrow("Refresh token revoked");
     });
 
@@ -179,7 +189,12 @@ describe("connector/providers/spotify", () => {
       server.use(handler);
 
       await expect(
-        refreshSpotifyToken("client-id", "client-secret", "refresh-token"),
+        refreshSpotifyToken(
+          "client-id",
+          "client-secret",
+          "refresh-token",
+          testRefreshSignal(),
+        ),
       ).rejects.toThrow("No access token in Spotify refresh response");
     });
 
@@ -193,7 +208,12 @@ describe("connector/providers/spotify", () => {
       server.use(handler);
 
       await expect(
-        refreshSpotifyToken("client-id", "client-secret", "refresh-token"),
+        refreshSpotifyToken(
+          "client-id",
+          "client-secret",
+          "refresh-token",
+          testRefreshSignal(),
+        ),
       ).rejects.toThrow("Spotify token refresh failed");
     });
   });

--- a/turbo/packages/connectors/src/auth-providers/oauth/providers/__tests__/test-oauth.test.ts
+++ b/turbo/packages/connectors/src/auth-providers/oauth/providers/__tests__/test-oauth.test.ts
@@ -18,6 +18,10 @@ import {
 
 const server = setupServer();
 
+function testRefreshSignal(): AbortSignal {
+  return new AbortController().signal;
+}
+
 beforeAll(() => {
   server.listen({ onUnhandledRequest: "error" });
 });
@@ -117,6 +121,7 @@ describe("test-oauth provider URLs", () => {
       "test-oauth-client",
       "test-oauth-secret",
       "refresh-1",
+      testRefreshSignal(),
     );
 
     expect(tokenRequestHeaders?.get("x-vercel-protection-bypass")).toBe(

--- a/turbo/packages/connectors/src/auth-providers/oauth/providers/__tests__/zoom.test.ts
+++ b/turbo/packages/connectors/src/auth-providers/oauth/providers/__tests__/zoom.test.ts
@@ -8,6 +8,10 @@ import {
 } from "../zoom";
 import { server } from "./test-server";
 
+function testRefreshSignal(): AbortSignal {
+  return new AbortController().signal;
+}
+
 describe("connector/providers/zoom", () => {
   describe("buildZoomAuthorizationUrl", () => {
     it("builds URL with client_id, redirect_uri, state, and response_type", () => {
@@ -135,6 +139,7 @@ describe("connector/providers/zoom", () => {
         "client-id",
         "client-secret",
         "old-refresh-token",
+        testRefreshSignal(),
       );
 
       expect(result.accessToken).toBe("new-zoom-token");
@@ -152,7 +157,12 @@ describe("connector/providers/zoom", () => {
       server.use(handler);
 
       await expect(
-        refreshZoomToken("client-id", "client-secret", "bad-refresh-token"),
+        refreshZoomToken(
+          "client-id",
+          "client-secret",
+          "bad-refresh-token",
+          testRefreshSignal(),
+        ),
       ).rejects.toThrow("Refresh token revoked");
     });
 
@@ -163,7 +173,12 @@ describe("connector/providers/zoom", () => {
       server.use(handler);
 
       await expect(
-        refreshZoomToken("client-id", "client-secret", "refresh-token"),
+        refreshZoomToken(
+          "client-id",
+          "client-secret",
+          "refresh-token",
+          testRefreshSignal(),
+        ),
       ).rejects.toThrow("No access token in Zoom refresh response");
     });
 
@@ -174,7 +189,12 @@ describe("connector/providers/zoom", () => {
       server.use(handler);
 
       await expect(
-        refreshZoomToken("client-id", "client-secret", "refresh-token"),
+        refreshZoomToken(
+          "client-id",
+          "client-secret",
+          "refresh-token",
+          testRefreshSignal(),
+        ),
       ).rejects.toThrow("Zoom token refresh failed");
     });
   });

--- a/turbo/packages/connectors/src/auth-providers/oauth/providers/ahrefs-provider.ts
+++ b/turbo/packages/connectors/src/auth-providers/oauth/providers/ahrefs-provider.ts
@@ -47,7 +47,12 @@ export const ahrefsProvider: AuthCodeConnectorAuthProvider<"ahrefs"> = {
     },
     refreshToken: (args) => {
       const { clientId, clientSecret } = args;
-      return refreshAhrefsToken(clientId, clientSecret, args.refreshToken);
+      return refreshAhrefsToken(
+        clientId,
+        clientSecret,
+        args.refreshToken,
+        args.signal,
+      );
     },
   },
   revoke: { kind: "none" },

--- a/turbo/packages/connectors/src/auth-providers/oauth/providers/ahrefs.ts
+++ b/turbo/packages/connectors/src/auth-providers/oauth/providers/ahrefs.ts
@@ -115,9 +115,11 @@ export async function refreshAhrefsToken(
   clientId: string,
   clientSecret: string,
   refreshToken: string,
+  signal?: AbortSignal,
 ): Promise<AhrefsRefreshResult> {
   const authCodeGrant = getAuthCodeGrantConfig("ahrefs");
   const response = await fetch(authCodeGrant.tokenUrl, {
+    signal,
     method: "POST",
     headers: {
       "Content-Type": "application/x-www-form-urlencoded",

--- a/turbo/packages/connectors/src/auth-providers/oauth/providers/ahrefs.ts
+++ b/turbo/packages/connectors/src/auth-providers/oauth/providers/ahrefs.ts
@@ -115,7 +115,7 @@ export async function refreshAhrefsToken(
   clientId: string,
   clientSecret: string,
   refreshToken: string,
-  signal?: AbortSignal,
+  signal: AbortSignal,
 ): Promise<AhrefsRefreshResult> {
   const authCodeGrant = getAuthCodeGrantConfig("ahrefs");
   const response = await fetch(authCodeGrant.tokenUrl, {

--- a/turbo/packages/connectors/src/auth-providers/oauth/providers/airtable-provider.ts
+++ b/turbo/packages/connectors/src/auth-providers/oauth/providers/airtable-provider.ts
@@ -49,7 +49,12 @@ export const airtableProvider: AuthCodeConnectorAuthProvider<"airtable"> = {
     },
     refreshToken: (args) => {
       const { clientId, clientSecret } = args;
-      return refreshAirtableToken(clientId, clientSecret, args.refreshToken);
+      return refreshAirtableToken(
+        clientId,
+        clientSecret,
+        args.refreshToken,
+        args.signal,
+      );
     },
   },
   revoke: { kind: "none" },

--- a/turbo/packages/connectors/src/auth-providers/oauth/providers/airtable.ts
+++ b/turbo/packages/connectors/src/auth-providers/oauth/providers/airtable.ts
@@ -156,7 +156,7 @@ export async function refreshAirtableToken(
   clientId: string,
   clientSecret: string,
   refreshToken: string,
-  signal?: AbortSignal,
+  signal: AbortSignal,
 ): Promise<AirtableRefreshResult> {
   const authCodeGrant = getAuthCodeGrantConfig("airtable");
   const basicAuth = btoa(`${clientId}:${clientSecret}`);

--- a/turbo/packages/connectors/src/auth-providers/oauth/providers/airtable.ts
+++ b/turbo/packages/connectors/src/auth-providers/oauth/providers/airtable.ts
@@ -156,11 +156,13 @@ export async function refreshAirtableToken(
   clientId: string,
   clientSecret: string,
   refreshToken: string,
+  signal?: AbortSignal,
 ): Promise<AirtableRefreshResult> {
   const authCodeGrant = getAuthCodeGrantConfig("airtable");
   const basicAuth = btoa(`${clientId}:${clientSecret}`);
 
   const response = await fetch(authCodeGrant.tokenUrl, {
+    signal,
     method: "POST",
     headers: {
       "Content-Type": "application/x-www-form-urlencoded",

--- a/turbo/packages/connectors/src/auth-providers/oauth/providers/asana-provider.ts
+++ b/turbo/packages/connectors/src/auth-providers/oauth/providers/asana-provider.ts
@@ -43,7 +43,12 @@ export const asanaProvider: AuthCodeConnectorAuthProvider<"asana"> = {
     },
     refreshToken: (args) => {
       const { clientId, clientSecret } = args;
-      return refreshAsanaToken(clientId, clientSecret, args.refreshToken);
+      return refreshAsanaToken(
+        clientId,
+        clientSecret,
+        args.refreshToken,
+        args.signal,
+      );
     },
   },
   revoke: { kind: "none" },

--- a/turbo/packages/connectors/src/auth-providers/oauth/providers/asana.ts
+++ b/turbo/packages/connectors/src/auth-providers/oauth/providers/asana.ts
@@ -159,7 +159,7 @@ export async function refreshAsanaToken(
   clientId: string,
   clientSecret: string,
   refreshToken: string,
-  signal?: AbortSignal,
+  signal: AbortSignal,
 ): Promise<AsanaRefreshResult> {
   const authCodeGrant = getAuthCodeGrantConfig("asana");
   const response = await fetch(authCodeGrant.tokenUrl, {

--- a/turbo/packages/connectors/src/auth-providers/oauth/providers/asana.ts
+++ b/turbo/packages/connectors/src/auth-providers/oauth/providers/asana.ts
@@ -159,9 +159,11 @@ export async function refreshAsanaToken(
   clientId: string,
   clientSecret: string,
   refreshToken: string,
+  signal?: AbortSignal,
 ): Promise<AsanaRefreshResult> {
   const authCodeGrant = getAuthCodeGrantConfig("asana");
   const response = await fetch(authCodeGrant.tokenUrl, {
+    signal,
     method: "POST",
     headers: {
       "Content-Type": "application/x-www-form-urlencoded",

--- a/turbo/packages/connectors/src/auth-providers/oauth/providers/base44-provider.ts
+++ b/turbo/packages/connectors/src/auth-providers/oauth/providers/base44-provider.ts
@@ -38,6 +38,7 @@ export const base44Provider: DeviceAuthConnectorAuthProvider<"base44"> = {
       return await refreshBase44Token({
         clientId,
         refreshToken: args.refreshToken,
+        signal: args.signal,
       });
     },
   },

--- a/turbo/packages/connectors/src/auth-providers/oauth/providers/base44.ts
+++ b/turbo/packages/connectors/src/auth-providers/oauth/providers/base44.ts
@@ -188,8 +188,10 @@ export async function pollBase44DeviceAuth(args: {
 export async function refreshBase44Token(args: {
   readonly clientId: string;
   readonly refreshToken: string;
+  readonly signal?: AbortSignal;
 }): Promise<OAuthRefreshResult> {
   const response = await fetch(base44DeviceAuthGrant().tokenUrl, {
+    signal: args.signal,
     method: "POST",
     headers: {
       "Content-Type": "application/x-www-form-urlencoded",

--- a/turbo/packages/connectors/src/auth-providers/oauth/providers/base44.ts
+++ b/turbo/packages/connectors/src/auth-providers/oauth/providers/base44.ts
@@ -188,7 +188,7 @@ export async function pollBase44DeviceAuth(args: {
 export async function refreshBase44Token(args: {
   readonly clientId: string;
   readonly refreshToken: string;
-  readonly signal?: AbortSignal;
+  readonly signal: AbortSignal;
 }): Promise<OAuthRefreshResult> {
   const response = await fetch(base44DeviceAuthGrant().tokenUrl, {
     signal: args.signal,

--- a/turbo/packages/connectors/src/auth-providers/oauth/providers/canva-provider.ts
+++ b/turbo/packages/connectors/src/auth-providers/oauth/providers/canva-provider.ts
@@ -50,7 +50,12 @@ export const canvaProvider: AuthCodeConnectorAuthProvider<"canva"> = {
     },
     refreshToken: (args) => {
       const { clientId, clientSecret } = args;
-      return refreshCanvaToken(clientId, clientSecret, args.refreshToken);
+      return refreshCanvaToken(
+        clientId,
+        clientSecret,
+        args.refreshToken,
+        args.signal,
+      );
     },
   },
   revoke: { kind: "none" },

--- a/turbo/packages/connectors/src/auth-providers/oauth/providers/canva.ts
+++ b/turbo/packages/connectors/src/auth-providers/oauth/providers/canva.ts
@@ -95,7 +95,7 @@ export async function refreshCanvaToken(
   clientId: string,
   clientSecret: string,
   refreshToken: string,
-  signal?: AbortSignal,
+  signal: AbortSignal,
 ): Promise<CanvaRefreshResult> {
   const authCodeGrant = getAuthCodeGrantConfig("canva");
   const credentials = Buffer.from(`${clientId}:${clientSecret}`).toString(

--- a/turbo/packages/connectors/src/auth-providers/oauth/providers/canva.ts
+++ b/turbo/packages/connectors/src/auth-providers/oauth/providers/canva.ts
@@ -95,6 +95,7 @@ export async function refreshCanvaToken(
   clientId: string,
   clientSecret: string,
   refreshToken: string,
+  signal?: AbortSignal,
 ): Promise<CanvaRefreshResult> {
   const authCodeGrant = getAuthCodeGrantConfig("canva");
   const credentials = Buffer.from(`${clientId}:${clientSecret}`).toString(
@@ -102,6 +103,7 @@ export async function refreshCanvaToken(
   );
 
   const response = await fetch(authCodeGrant.tokenUrl, {
+    signal,
     method: "POST",
     headers: {
       Authorization: `Basic ${credentials}`,

--- a/turbo/packages/connectors/src/auth-providers/oauth/providers/close-provider.ts
+++ b/turbo/packages/connectors/src/auth-providers/oauth/providers/close-provider.ts
@@ -43,7 +43,12 @@ export const closeProvider: AuthCodeConnectorAuthProvider<"close"> = {
     },
     refreshToken: (args) => {
       const { clientId, clientSecret } = args;
-      return refreshCloseToken(clientId, clientSecret, args.refreshToken);
+      return refreshCloseToken(
+        clientId,
+        clientSecret,
+        args.refreshToken,
+        args.signal,
+      );
     },
   },
   revoke: { kind: "none" },

--- a/turbo/packages/connectors/src/auth-providers/oauth/providers/close.ts
+++ b/turbo/packages/connectors/src/auth-providers/oauth/providers/close.ts
@@ -115,7 +115,7 @@ export async function refreshCloseToken(
   clientId: string,
   clientSecret: string,
   refreshToken: string,
-  signal?: AbortSignal,
+  signal: AbortSignal,
 ): Promise<CloseRefreshResult> {
   const authCodeGrant = getAuthCodeGrantConfig("close");
   const response = await fetch(authCodeGrant.tokenUrl, {

--- a/turbo/packages/connectors/src/auth-providers/oauth/providers/close.ts
+++ b/turbo/packages/connectors/src/auth-providers/oauth/providers/close.ts
@@ -115,9 +115,11 @@ export async function refreshCloseToken(
   clientId: string,
   clientSecret: string,
   refreshToken: string,
+  signal?: AbortSignal,
 ): Promise<CloseRefreshResult> {
   const authCodeGrant = getAuthCodeGrantConfig("close");
   const response = await fetch(authCodeGrant.tokenUrl, {
+    signal,
     method: "POST",
     headers: {
       "Content-Type": "application/x-www-form-urlencoded",

--- a/turbo/packages/connectors/src/auth-providers/oauth/providers/codex-oauth-provider.ts
+++ b/turbo/packages/connectors/src/auth-providers/oauth/providers/codex-oauth-provider.ts
@@ -31,6 +31,7 @@ export const codexOauthProvider: ModelProviderAuthProvider = {
         args.clientId ?? CHATGPT_OAUTH_CLIENT_ID,
         args.clientSecret ?? "",
         args.refreshToken,
+        args.signal,
       );
     },
   },

--- a/turbo/packages/connectors/src/auth-providers/oauth/providers/codex-oauth.ts
+++ b/turbo/packages/connectors/src/auth-providers/oauth/providers/codex-oauth.ts
@@ -74,8 +74,10 @@ export async function refreshChatgptToken(
   _clientId: string,
   _clientSecret: string,
   refreshToken: string,
+  signal?: AbortSignal,
 ): Promise<ChatgptRefreshResult> {
   const response = await fetch(CHATGPT_OAUTH_TOKEN_URL, {
+    signal,
     method: "POST",
     headers: { "Content-Type": "application/json" },
     body: JSON.stringify({

--- a/turbo/packages/connectors/src/auth-providers/oauth/providers/codex-oauth.ts
+++ b/turbo/packages/connectors/src/auth-providers/oauth/providers/codex-oauth.ts
@@ -74,7 +74,7 @@ export async function refreshChatgptToken(
   _clientId: string,
   _clientSecret: string,
   refreshToken: string,
-  signal?: AbortSignal,
+  signal: AbortSignal,
 ): Promise<ChatgptRefreshResult> {
   const response = await fetch(CHATGPT_OAUTH_TOKEN_URL, {
     signal,

--- a/turbo/packages/connectors/src/auth-providers/oauth/providers/deel-provider.ts
+++ b/turbo/packages/connectors/src/auth-providers/oauth/providers/deel-provider.ts
@@ -50,7 +50,12 @@ export const deelProvider: AuthCodeConnectorAuthProvider<"deel"> = {
     },
     refreshToken: (args) => {
       const { clientId, clientSecret } = args;
-      return refreshDeelToken(clientId, clientSecret, args.refreshToken);
+      return refreshDeelToken(
+        clientId,
+        clientSecret,
+        args.refreshToken,
+        args.signal,
+      );
     },
   },
   revoke: { kind: "none" },

--- a/turbo/packages/connectors/src/auth-providers/oauth/providers/deel.ts
+++ b/turbo/packages/connectors/src/auth-providers/oauth/providers/deel.ts
@@ -95,6 +95,7 @@ export async function refreshDeelToken(
   clientId: string,
   clientSecret: string,
   refreshToken: string,
+  signal?: AbortSignal,
 ): Promise<DeelRefreshResult> {
   const authCodeGrant = getAuthCodeGrantConfig("deel");
   const credentials = Buffer.from(`${clientId}:${clientSecret}`).toString(
@@ -102,6 +103,7 @@ export async function refreshDeelToken(
   );
 
   const response = await fetch(authCodeGrant.tokenUrl, {
+    signal,
     method: "POST",
     headers: {
       Authorization: `Basic ${credentials}`,

--- a/turbo/packages/connectors/src/auth-providers/oauth/providers/deel.ts
+++ b/turbo/packages/connectors/src/auth-providers/oauth/providers/deel.ts
@@ -95,7 +95,7 @@ export async function refreshDeelToken(
   clientId: string,
   clientSecret: string,
   refreshToken: string,
-  signal?: AbortSignal,
+  signal: AbortSignal,
 ): Promise<DeelRefreshResult> {
   const authCodeGrant = getAuthCodeGrantConfig("deel");
   const credentials = Buffer.from(`${clientId}:${clientSecret}`).toString(

--- a/turbo/packages/connectors/src/auth-providers/oauth/providers/docusign-provider.ts
+++ b/turbo/packages/connectors/src/auth-providers/oauth/providers/docusign-provider.ts
@@ -54,7 +54,12 @@ export const docusignProvider: AuthCodeConnectorAuthProvider<"docusign"> = {
     },
     refreshToken: (args) => {
       const { clientId, clientSecret } = args;
-      return refreshDocuSignToken(clientId, clientSecret, args.refreshToken);
+      return refreshDocuSignToken(
+        clientId,
+        clientSecret,
+        args.refreshToken,
+        args.signal,
+      );
     },
   },
   revoke: { kind: "none" },

--- a/turbo/packages/connectors/src/auth-providers/oauth/providers/docusign.ts
+++ b/turbo/packages/connectors/src/auth-providers/oauth/providers/docusign.ts
@@ -160,7 +160,7 @@ export async function refreshDocuSignToken(
   clientId: string,
   clientSecret: string,
   refreshToken: string,
-  signal?: AbortSignal,
+  signal: AbortSignal,
 ): Promise<DocuSignRefreshResult> {
   const authCodeGrant = getAuthCodeGrantConfig("docusign");
   const basicAuth = Buffer.from(`${clientId}:${clientSecret}`).toString(

--- a/turbo/packages/connectors/src/auth-providers/oauth/providers/docusign.ts
+++ b/turbo/packages/connectors/src/auth-providers/oauth/providers/docusign.ts
@@ -160,6 +160,7 @@ export async function refreshDocuSignToken(
   clientId: string,
   clientSecret: string,
   refreshToken: string,
+  signal?: AbortSignal,
 ): Promise<DocuSignRefreshResult> {
   const authCodeGrant = getAuthCodeGrantConfig("docusign");
   const basicAuth = Buffer.from(`${clientId}:${clientSecret}`).toString(
@@ -167,6 +168,7 @@ export async function refreshDocuSignToken(
   );
 
   const response = await fetch(authCodeGrant.tokenUrl, {
+    signal,
     method: "POST",
     headers: {
       "Content-Type": "application/x-www-form-urlencoded",

--- a/turbo/packages/connectors/src/auth-providers/oauth/providers/dropbox-provider.ts
+++ b/turbo/packages/connectors/src/auth-providers/oauth/providers/dropbox-provider.ts
@@ -47,7 +47,12 @@ export const dropboxProvider: AuthCodeConnectorAuthProvider<"dropbox"> = {
     },
     refreshToken: (args) => {
       const { clientId, clientSecret } = args;
-      return refreshDropboxToken(clientId, clientSecret, args.refreshToken);
+      return refreshDropboxToken(
+        clientId,
+        clientSecret,
+        args.refreshToken,
+        args.signal,
+      );
     },
   },
   revoke: { kind: "none" },

--- a/turbo/packages/connectors/src/auth-providers/oauth/providers/dropbox.ts
+++ b/turbo/packages/connectors/src/auth-providers/oauth/providers/dropbox.ts
@@ -118,9 +118,11 @@ export async function refreshDropboxToken(
   clientId: string,
   clientSecret: string,
   refreshToken: string,
+  signal?: AbortSignal,
 ): Promise<DropboxRefreshResult> {
   const authCodeGrant = getAuthCodeGrantConfig("dropbox");
   const response = await fetch(authCodeGrant.tokenUrl, {
+    signal,
     method: "POST",
     headers: {
       "Content-Type": "application/x-www-form-urlencoded",

--- a/turbo/packages/connectors/src/auth-providers/oauth/providers/dropbox.ts
+++ b/turbo/packages/connectors/src/auth-providers/oauth/providers/dropbox.ts
@@ -118,7 +118,7 @@ export async function refreshDropboxToken(
   clientId: string,
   clientSecret: string,
   refreshToken: string,
-  signal?: AbortSignal,
+  signal: AbortSignal,
 ): Promise<DropboxRefreshResult> {
   const authCodeGrant = getAuthCodeGrantConfig("dropbox");
   const response = await fetch(authCodeGrant.tokenUrl, {

--- a/turbo/packages/connectors/src/auth-providers/oauth/providers/figma-provider.ts
+++ b/turbo/packages/connectors/src/auth-providers/oauth/providers/figma-provider.ts
@@ -43,7 +43,12 @@ export const figmaProvider: AuthCodeConnectorAuthProvider<"figma"> = {
     },
     refreshToken: (args) => {
       const { clientId, clientSecret } = args;
-      return refreshFigmaToken(clientId, clientSecret, args.refreshToken);
+      return refreshFigmaToken(
+        clientId,
+        clientSecret,
+        args.refreshToken,
+        args.signal,
+      );
     },
   },
   revoke: { kind: "none" },

--- a/turbo/packages/connectors/src/auth-providers/oauth/providers/figma.ts
+++ b/turbo/packages/connectors/src/auth-providers/oauth/providers/figma.ts
@@ -118,6 +118,7 @@ export async function refreshFigmaToken(
   clientId: string,
   clientSecret: string,
   refreshToken: string,
+  signal?: AbortSignal,
 ): Promise<FigmaRefreshResult> {
   const authCodeGrant = getAuthCodeGrantConfig("figma");
   const credentials = Buffer.from(`${clientId}:${clientSecret}`).toString(
@@ -125,6 +126,7 @@ export async function refreshFigmaToken(
   );
 
   const response = await fetch(authCodeGrant.tokenUrl, {
+    signal,
     method: "POST",
     headers: {
       Authorization: `Basic ${credentials}`,

--- a/turbo/packages/connectors/src/auth-providers/oauth/providers/figma.ts
+++ b/turbo/packages/connectors/src/auth-providers/oauth/providers/figma.ts
@@ -118,7 +118,7 @@ export async function refreshFigmaToken(
   clientId: string,
   clientSecret: string,
   refreshToken: string,
-  signal?: AbortSignal,
+  signal: AbortSignal,
 ): Promise<FigmaRefreshResult> {
   const authCodeGrant = getAuthCodeGrantConfig("figma");
   const credentials = Buffer.from(`${clientId}:${clientSecret}`).toString(

--- a/turbo/packages/connectors/src/auth-providers/oauth/providers/garmin-connect-provider.ts
+++ b/turbo/packages/connectors/src/auth-providers/oauth/providers/garmin-connect-provider.ts
@@ -57,6 +57,7 @@ export const garminConnectProvider: AuthCodeConnectorAuthProvider<"garmin-connec
           clientId,
           clientSecret,
           args.refreshToken,
+          args.signal,
         );
       },
     },

--- a/turbo/packages/connectors/src/auth-providers/oauth/providers/garmin-connect.ts
+++ b/turbo/packages/connectors/src/auth-providers/oauth/providers/garmin-connect.ts
@@ -156,9 +156,11 @@ export async function refreshGarminConnectToken(
   clientId: string,
   clientSecret: string,
   refreshToken: string,
+  signal?: AbortSignal,
 ): Promise<GarminConnectRefreshResult> {
   const authCodeGrant = getAuthCodeGrantConfig("garmin-connect");
   const response = await fetch(authCodeGrant.tokenUrl, {
+    signal,
     method: "POST",
     headers: {
       "Content-Type": "application/x-www-form-urlencoded",

--- a/turbo/packages/connectors/src/auth-providers/oauth/providers/garmin-connect.ts
+++ b/turbo/packages/connectors/src/auth-providers/oauth/providers/garmin-connect.ts
@@ -156,7 +156,7 @@ export async function refreshGarminConnectToken(
   clientId: string,
   clientSecret: string,
   refreshToken: string,
-  signal?: AbortSignal,
+  signal: AbortSignal,
 ): Promise<GarminConnectRefreshResult> {
   const authCodeGrant = getAuthCodeGrantConfig("garmin-connect");
   const response = await fetch(authCodeGrant.tokenUrl, {

--- a/turbo/packages/connectors/src/auth-providers/oauth/providers/gmail-provider.ts
+++ b/turbo/packages/connectors/src/auth-providers/oauth/providers/gmail-provider.ts
@@ -44,7 +44,13 @@ export const gmailProvider: AuthCodeConnectorAuthProvider<"gmail"> = {
     refreshToken: (args) => {
       const { clientId, clientSecret } = args;
       const refreshToken = args.refreshToken;
-      return refreshGoogleToken("gmail", clientId, clientSecret, refreshToken);
+      return refreshGoogleToken(
+        "gmail",
+        clientId,
+        clientSecret,
+        refreshToken,
+        args.signal,
+      );
     },
   },
   revoke: { kind: "none" },

--- a/turbo/packages/connectors/src/auth-providers/oauth/providers/google-ads-provider.ts
+++ b/turbo/packages/connectors/src/auth-providers/oauth/providers/google-ads-provider.ts
@@ -58,6 +58,7 @@ export const googleAdsProvider: AuthCodeConnectorAuthProvider<"google-ads"> = {
         clientId,
         clientSecret,
         refreshToken,
+        args.signal,
       );
     },
   },

--- a/turbo/packages/connectors/src/auth-providers/oauth/providers/google-calendar-provider.ts
+++ b/turbo/packages/connectors/src/auth-providers/oauth/providers/google-calendar-provider.ts
@@ -59,6 +59,7 @@ export const googleCalendarProvider: AuthCodeConnectorAuthProvider<"google-calen
           clientId,
           clientSecret,
           refreshToken,
+          args.signal,
         );
       },
     },

--- a/turbo/packages/connectors/src/auth-providers/oauth/providers/google-docs-provider.ts
+++ b/turbo/packages/connectors/src/auth-providers/oauth/providers/google-docs-provider.ts
@@ -59,6 +59,7 @@ export const googleDocsProvider: AuthCodeConnectorAuthProvider<"google-docs"> =
           clientId,
           clientSecret,
           refreshToken,
+          args.signal,
         );
       },
     },

--- a/turbo/packages/connectors/src/auth-providers/oauth/providers/google-drive-provider.ts
+++ b/turbo/packages/connectors/src/auth-providers/oauth/providers/google-drive-provider.ts
@@ -59,6 +59,7 @@ export const googleDriveProvider: AuthCodeConnectorAuthProvider<"google-drive"> 
           clientId,
           clientSecret,
           refreshToken,
+          args.signal,
         );
       },
     },

--- a/turbo/packages/connectors/src/auth-providers/oauth/providers/google-meet-provider.ts
+++ b/turbo/packages/connectors/src/auth-providers/oauth/providers/google-meet-provider.ts
@@ -59,6 +59,7 @@ export const googleMeetProvider: AuthCodeConnectorAuthProvider<"google-meet"> =
           clientId,
           clientSecret,
           refreshToken,
+          args.signal,
         );
       },
     },

--- a/turbo/packages/connectors/src/auth-providers/oauth/providers/google-sheets-provider.ts
+++ b/turbo/packages/connectors/src/auth-providers/oauth/providers/google-sheets-provider.ts
@@ -59,6 +59,7 @@ export const googleSheetsProvider: AuthCodeConnectorAuthProvider<"google-sheets"
           clientId,
           clientSecret,
           refreshToken,
+          args.signal,
         );
       },
     },

--- a/turbo/packages/connectors/src/auth-providers/oauth/providers/gumroad-provider.ts
+++ b/turbo/packages/connectors/src/auth-providers/oauth/providers/gumroad-provider.ts
@@ -47,7 +47,12 @@ export const gumroadProvider: AuthCodeConnectorAuthProvider<"gumroad"> = {
     },
     refreshToken: (args) => {
       const { clientId, clientSecret } = args;
-      return refreshGumroadToken(clientId, clientSecret, args.refreshToken);
+      return refreshGumroadToken(
+        clientId,
+        clientSecret,
+        args.refreshToken,
+        args.signal,
+      );
     },
   },
   revoke: { kind: "none" },

--- a/turbo/packages/connectors/src/auth-providers/oauth/providers/gumroad.ts
+++ b/turbo/packages/connectors/src/auth-providers/oauth/providers/gumroad.ts
@@ -103,9 +103,11 @@ export async function refreshGumroadToken(
   clientId: string,
   clientSecret: string,
   refreshToken: string,
+  signal?: AbortSignal,
 ): Promise<GumroadRefreshResult> {
   const authCodeGrant = getAuthCodeGrantConfig("gumroad");
   const response = await fetch(authCodeGrant.tokenUrl, {
+    signal,
     method: "POST",
     headers: {
       "Content-Type": "application/x-www-form-urlencoded",

--- a/turbo/packages/connectors/src/auth-providers/oauth/providers/gumroad.ts
+++ b/turbo/packages/connectors/src/auth-providers/oauth/providers/gumroad.ts
@@ -103,7 +103,7 @@ export async function refreshGumroadToken(
   clientId: string,
   clientSecret: string,
   refreshToken: string,
-  signal?: AbortSignal,
+  signal: AbortSignal,
 ): Promise<GumroadRefreshResult> {
   const authCodeGrant = getAuthCodeGrantConfig("gumroad");
   const response = await fetch(authCodeGrant.tokenUrl, {

--- a/turbo/packages/connectors/src/auth-providers/oauth/providers/hubspot-provider.ts
+++ b/turbo/packages/connectors/src/auth-providers/oauth/providers/hubspot-provider.ts
@@ -47,7 +47,12 @@ export const hubspotProvider: AuthCodeConnectorAuthProvider<"hubspot"> = {
     },
     refreshToken: (args) => {
       const { clientId, clientSecret } = args;
-      return refreshHubSpotToken(clientId, clientSecret, args.refreshToken);
+      return refreshHubSpotToken(
+        clientId,
+        clientSecret,
+        args.refreshToken,
+        args.signal,
+      );
     },
   },
   revoke: { kind: "none" },

--- a/turbo/packages/connectors/src/auth-providers/oauth/providers/hubspot.ts
+++ b/turbo/packages/connectors/src/auth-providers/oauth/providers/hubspot.ts
@@ -111,7 +111,7 @@ export async function refreshHubSpotToken(
   clientId: string,
   clientSecret: string,
   refreshToken: string,
-  signal?: AbortSignal,
+  signal: AbortSignal,
 ): Promise<HubSpotRefreshResult> {
   const authCodeGrant = getAuthCodeGrantConfig("hubspot");
   const response = await fetch(authCodeGrant.tokenUrl, {

--- a/turbo/packages/connectors/src/auth-providers/oauth/providers/hubspot.ts
+++ b/turbo/packages/connectors/src/auth-providers/oauth/providers/hubspot.ts
@@ -111,9 +111,11 @@ export async function refreshHubSpotToken(
   clientId: string,
   clientSecret: string,
   refreshToken: string,
+  signal?: AbortSignal,
 ): Promise<HubSpotRefreshResult> {
   const authCodeGrant = getAuthCodeGrantConfig("hubspot");
   const response = await fetch(authCodeGrant.tokenUrl, {
+    signal,
     method: "POST",
     headers: {
       "Content-Type": "application/x-www-form-urlencoded",

--- a/turbo/packages/connectors/src/auth-providers/oauth/providers/linear-provider.ts
+++ b/turbo/packages/connectors/src/auth-providers/oauth/providers/linear-provider.ts
@@ -48,7 +48,12 @@ export const linearProvider: AuthCodeConnectorAuthProvider<"linear"> = {
     },
     refreshToken: (args) => {
       const { clientId, clientSecret } = args;
-      return refreshLinearToken(clientId, clientSecret, args.refreshToken);
+      return refreshLinearToken(
+        clientId,
+        clientSecret,
+        args.refreshToken,
+        args.signal,
+      );
     },
   },
   revoke: {

--- a/turbo/packages/connectors/src/auth-providers/oauth/providers/linear.ts
+++ b/turbo/packages/connectors/src/auth-providers/oauth/providers/linear.ts
@@ -119,9 +119,11 @@ export async function refreshLinearToken(
   clientId: string,
   clientSecret: string,
   refreshToken: string,
+  signal?: AbortSignal,
 ): Promise<LinearRefreshResult> {
   const authCodeGrant = getAuthCodeGrantConfig("linear");
   const response = await fetch(authCodeGrant.tokenUrl, {
+    signal,
     method: "POST",
     headers: {
       "Content-Type": "application/x-www-form-urlencoded",

--- a/turbo/packages/connectors/src/auth-providers/oauth/providers/linear.ts
+++ b/turbo/packages/connectors/src/auth-providers/oauth/providers/linear.ts
@@ -119,7 +119,7 @@ export async function refreshLinearToken(
   clientId: string,
   clientSecret: string,
   refreshToken: string,
-  signal?: AbortSignal,
+  signal: AbortSignal,
 ): Promise<LinearRefreshResult> {
   const authCodeGrant = getAuthCodeGrantConfig("linear");
   const response = await fetch(authCodeGrant.tokenUrl, {

--- a/turbo/packages/connectors/src/auth-providers/oauth/providers/mercury-provider.ts
+++ b/turbo/packages/connectors/src/auth-providers/oauth/providers/mercury-provider.ts
@@ -47,7 +47,12 @@ export const mercuryProvider: AuthCodeConnectorAuthProvider<"mercury"> = {
     },
     refreshToken: (args) => {
       const { clientId, clientSecret } = args;
-      return refreshMercuryToken(clientId, clientSecret, args.refreshToken);
+      return refreshMercuryToken(
+        clientId,
+        clientSecret,
+        args.refreshToken,
+        args.signal,
+      );
     },
   },
   revoke: { kind: "none" },

--- a/turbo/packages/connectors/src/auth-providers/oauth/providers/mercury.ts
+++ b/turbo/packages/connectors/src/auth-providers/oauth/providers/mercury.ts
@@ -115,7 +115,7 @@ export async function refreshMercuryToken(
   clientId: string,
   clientSecret: string,
   refreshToken: string,
-  signal?: AbortSignal,
+  signal: AbortSignal,
 ): Promise<MercuryRefreshResult> {
   const authCodeGrant = getAuthCodeGrantConfig("mercury");
   const response = await fetch(authCodeGrant.tokenUrl, {

--- a/turbo/packages/connectors/src/auth-providers/oauth/providers/mercury.ts
+++ b/turbo/packages/connectors/src/auth-providers/oauth/providers/mercury.ts
@@ -115,9 +115,11 @@ export async function refreshMercuryToken(
   clientId: string,
   clientSecret: string,
   refreshToken: string,
+  signal?: AbortSignal,
 ): Promise<MercuryRefreshResult> {
   const authCodeGrant = getAuthCodeGrantConfig("mercury");
   const response = await fetch(authCodeGrant.tokenUrl, {
+    signal,
     method: "POST",
     headers: {
       "Content-Type": "application/x-www-form-urlencoded",

--- a/turbo/packages/connectors/src/auth-providers/oauth/providers/monday-provider.ts
+++ b/turbo/packages/connectors/src/auth-providers/oauth/providers/monday-provider.ts
@@ -47,7 +47,12 @@ export const mondayProvider: AuthCodeConnectorAuthProvider<"monday"> = {
     },
     refreshToken: (args) => {
       const { clientId, clientSecret } = args;
-      return refreshMondayToken(clientId, clientSecret, args.refreshToken);
+      return refreshMondayToken(
+        clientId,
+        clientSecret,
+        args.refreshToken,
+        args.signal,
+      );
     },
   },
   revoke: { kind: "none" },

--- a/turbo/packages/connectors/src/auth-providers/oauth/providers/monday.ts
+++ b/turbo/packages/connectors/src/auth-providers/oauth/providers/monday.ts
@@ -114,7 +114,7 @@ export async function refreshMondayToken(
   clientId: string,
   clientSecret: string,
   refreshToken: string,
-  signal?: AbortSignal,
+  signal: AbortSignal,
 ): Promise<MondayRefreshResult> {
   const authCodeGrant = getAuthCodeGrantConfig("monday");
   const response = await fetch(authCodeGrant.tokenUrl, {

--- a/turbo/packages/connectors/src/auth-providers/oauth/providers/monday.ts
+++ b/turbo/packages/connectors/src/auth-providers/oauth/providers/monday.ts
@@ -114,9 +114,11 @@ export async function refreshMondayToken(
   clientId: string,
   clientSecret: string,
   refreshToken: string,
+  signal?: AbortSignal,
 ): Promise<MondayRefreshResult> {
   const authCodeGrant = getAuthCodeGrantConfig("monday");
   const response = await fetch(authCodeGrant.tokenUrl, {
+    signal,
     method: "POST",
     headers: {
       "Content-Type": "application/x-www-form-urlencoded",

--- a/turbo/packages/connectors/src/auth-providers/oauth/providers/neon-provider.ts
+++ b/turbo/packages/connectors/src/auth-providers/oauth/providers/neon-provider.ts
@@ -43,7 +43,12 @@ export const neonProvider: AuthCodeConnectorAuthProvider<"neon"> = {
     },
     refreshToken: (args) => {
       const { clientId, clientSecret } = args;
-      return refreshNeonToken(clientId, clientSecret, args.refreshToken);
+      return refreshNeonToken(
+        clientId,
+        clientSecret,
+        args.refreshToken,
+        args.signal,
+      );
     },
   },
   revoke: { kind: "none" },

--- a/turbo/packages/connectors/src/auth-providers/oauth/providers/neon.ts
+++ b/turbo/packages/connectors/src/auth-providers/oauth/providers/neon.ts
@@ -116,9 +116,11 @@ export async function refreshNeonToken(
   clientId: string,
   clientSecret: string,
   refreshToken: string,
+  signal?: AbortSignal,
 ): Promise<NeonRefreshResult> {
   const authCodeGrant = getAuthCodeGrantConfig("neon");
   const response = await fetch(authCodeGrant.tokenUrl, {
+    signal,
     method: "POST",
     headers: {
       "Content-Type": "application/x-www-form-urlencoded",

--- a/turbo/packages/connectors/src/auth-providers/oauth/providers/neon.ts
+++ b/turbo/packages/connectors/src/auth-providers/oauth/providers/neon.ts
@@ -116,7 +116,7 @@ export async function refreshNeonToken(
   clientId: string,
   clientSecret: string,
   refreshToken: string,
-  signal?: AbortSignal,
+  signal: AbortSignal,
 ): Promise<NeonRefreshResult> {
   const authCodeGrant = getAuthCodeGrantConfig("neon");
   const response = await fetch(authCodeGrant.tokenUrl, {

--- a/turbo/packages/connectors/src/auth-providers/oauth/providers/notion-provider.ts
+++ b/turbo/packages/connectors/src/auth-providers/oauth/providers/notion-provider.ts
@@ -43,7 +43,12 @@ export const notionProvider: AuthCodeConnectorAuthProvider<"notion"> = {
     },
     refreshToken: (args) => {
       const { clientId, clientSecret } = args;
-      return refreshNotionToken(clientId, clientSecret, args.refreshToken);
+      return refreshNotionToken(
+        clientId,
+        clientSecret,
+        args.refreshToken,
+        args.signal,
+      );
     },
   },
   revoke: { kind: "none" },

--- a/turbo/packages/connectors/src/auth-providers/oauth/providers/notion.ts
+++ b/turbo/packages/connectors/src/auth-providers/oauth/providers/notion.ts
@@ -131,9 +131,11 @@ export async function refreshNotionToken(
   clientId: string,
   clientSecret: string,
   refreshToken: string,
+  signal?: AbortSignal,
 ): Promise<NotionRefreshResult> {
   const authCodeGrant = getAuthCodeGrantConfig("notion");
   const response = await fetch(authCodeGrant.tokenUrl, {
+    signal,
     method: "POST",
     headers: {
       Authorization: `Basic ${encodeBasicAuth(clientId, clientSecret)}`,

--- a/turbo/packages/connectors/src/auth-providers/oauth/providers/notion.ts
+++ b/turbo/packages/connectors/src/auth-providers/oauth/providers/notion.ts
@@ -131,7 +131,7 @@ export async function refreshNotionToken(
   clientId: string,
   clientSecret: string,
   refreshToken: string,
-  signal?: AbortSignal,
+  signal: AbortSignal,
 ): Promise<NotionRefreshResult> {
   const authCodeGrant = getAuthCodeGrantConfig("notion");
   const response = await fetch(authCodeGrant.tokenUrl, {

--- a/turbo/packages/connectors/src/auth-providers/oauth/providers/outlook-calendar-provider.ts
+++ b/turbo/packages/connectors/src/auth-providers/oauth/providers/outlook-calendar-provider.ts
@@ -59,6 +59,7 @@ export const outlookCalendarProvider: AuthCodeConnectorAuthProvider<"outlook-cal
           clientId,
           clientSecret,
           refreshToken,
+          args.signal,
         );
       },
     },

--- a/turbo/packages/connectors/src/auth-providers/oauth/providers/outlook-mail-provider.ts
+++ b/turbo/packages/connectors/src/auth-providers/oauth/providers/outlook-mail-provider.ts
@@ -59,6 +59,7 @@ export const outlookMailProvider: AuthCodeConnectorAuthProvider<"outlook-mail"> 
           clientId,
           clientSecret,
           refreshToken,
+          args.signal,
         );
       },
     },

--- a/turbo/packages/connectors/src/auth-providers/oauth/providers/posthog-provider.ts
+++ b/turbo/packages/connectors/src/auth-providers/oauth/providers/posthog-provider.ts
@@ -47,7 +47,12 @@ export const posthogProvider: AuthCodeConnectorAuthProvider<"posthog"> = {
     },
     refreshToken: (args) => {
       const { clientId, clientSecret } = args;
-      return refreshPosthogToken(clientId, clientSecret, args.refreshToken);
+      return refreshPosthogToken(
+        clientId,
+        clientSecret,
+        args.refreshToken,
+        args.signal,
+      );
     },
   },
   revoke: { kind: "none" },

--- a/turbo/packages/connectors/src/auth-providers/oauth/providers/posthog.ts
+++ b/turbo/packages/connectors/src/auth-providers/oauth/providers/posthog.ts
@@ -113,9 +113,11 @@ export async function refreshPosthogToken(
   clientId: string,
   clientSecret: string,
   refreshToken: string,
+  signal?: AbortSignal,
 ): Promise<PosthogRefreshResult> {
   const authCodeGrant = getAuthCodeGrantConfig("posthog");
   const response = await fetch(authCodeGrant.tokenUrl, {
+    signal,
     method: "POST",
     headers: {
       "Content-Type": "application/x-www-form-urlencoded",

--- a/turbo/packages/connectors/src/auth-providers/oauth/providers/posthog.ts
+++ b/turbo/packages/connectors/src/auth-providers/oauth/providers/posthog.ts
@@ -113,7 +113,7 @@ export async function refreshPosthogToken(
   clientId: string,
   clientSecret: string,
   refreshToken: string,
-  signal?: AbortSignal,
+  signal: AbortSignal,
 ): Promise<PosthogRefreshResult> {
   const authCodeGrant = getAuthCodeGrantConfig("posthog");
   const response = await fetch(authCodeGrant.tokenUrl, {

--- a/turbo/packages/connectors/src/auth-providers/oauth/providers/reddit-provider.ts
+++ b/turbo/packages/connectors/src/auth-providers/oauth/providers/reddit-provider.ts
@@ -47,7 +47,12 @@ export const redditProvider: AuthCodeConnectorAuthProvider<"reddit"> = {
     },
     refreshToken: (args) => {
       const { clientId, clientSecret } = args;
-      return refreshRedditToken(clientId, clientSecret, args.refreshToken);
+      return refreshRedditToken(
+        clientId,
+        clientSecret,
+        args.refreshToken,
+        args.signal,
+      );
     },
   },
   revoke: { kind: "none" },

--- a/turbo/packages/connectors/src/auth-providers/oauth/providers/reddit.ts
+++ b/turbo/packages/connectors/src/auth-providers/oauth/providers/reddit.ts
@@ -160,9 +160,11 @@ export async function refreshRedditToken(
   clientId: string,
   clientSecret: string,
   refreshToken: string,
+  signal?: AbortSignal,
 ): Promise<RedditRefreshResult> {
   const authCodeGrant = getAuthCodeGrantConfig("reddit");
   const response = await fetch(authCodeGrant.tokenUrl, {
+    signal,
     method: "POST",
     headers: {
       Authorization: `Basic ${encodeBasicAuth(clientId, clientSecret)}`,

--- a/turbo/packages/connectors/src/auth-providers/oauth/providers/reddit.ts
+++ b/turbo/packages/connectors/src/auth-providers/oauth/providers/reddit.ts
@@ -160,7 +160,7 @@ export async function refreshRedditToken(
   clientId: string,
   clientSecret: string,
   refreshToken: string,
-  signal?: AbortSignal,
+  signal: AbortSignal,
 ): Promise<RedditRefreshResult> {
   const authCodeGrant = getAuthCodeGrantConfig("reddit");
   const response = await fetch(authCodeGrant.tokenUrl, {

--- a/turbo/packages/connectors/src/auth-providers/oauth/providers/sentry-provider.ts
+++ b/turbo/packages/connectors/src/auth-providers/oauth/providers/sentry-provider.ts
@@ -47,7 +47,12 @@ export const sentryProvider: AuthCodeConnectorAuthProvider<"sentry"> = {
     },
     refreshToken: (args) => {
       const { clientId, clientSecret } = args;
-      return refreshSentryToken(clientId, clientSecret, args.refreshToken);
+      return refreshSentryToken(
+        clientId,
+        clientSecret,
+        args.refreshToken,
+        args.signal,
+      );
     },
   },
   revoke: { kind: "none" },

--- a/turbo/packages/connectors/src/auth-providers/oauth/providers/sentry.ts
+++ b/turbo/packages/connectors/src/auth-providers/oauth/providers/sentry.ts
@@ -126,7 +126,7 @@ export async function refreshSentryToken(
   clientId: string,
   clientSecret: string,
   refreshToken: string,
-  signal?: AbortSignal,
+  signal: AbortSignal,
 ): Promise<SentryRefreshResult> {
   const authCodeGrant = getAuthCodeGrantConfig("sentry");
   const response = await fetch(authCodeGrant.tokenUrl, {

--- a/turbo/packages/connectors/src/auth-providers/oauth/providers/sentry.ts
+++ b/turbo/packages/connectors/src/auth-providers/oauth/providers/sentry.ts
@@ -126,9 +126,11 @@ export async function refreshSentryToken(
   clientId: string,
   clientSecret: string,
   refreshToken: string,
+  signal?: AbortSignal,
 ): Promise<SentryRefreshResult> {
   const authCodeGrant = getAuthCodeGrantConfig("sentry");
   const response = await fetch(authCodeGrant.tokenUrl, {
+    signal,
     method: "POST",
     headers: {
       "Content-Type": "application/x-www-form-urlencoded",

--- a/turbo/packages/connectors/src/auth-providers/oauth/providers/slock-provider.ts
+++ b/turbo/packages/connectors/src/auth-providers/oauth/providers/slock-provider.ts
@@ -30,6 +30,7 @@ export const slockProvider: DeviceAuthConnectorAuthProvider<"slock"> = {
     refreshToken: async (args) => {
       return await refreshSlockToken({
         refreshToken: args.refreshToken,
+        signal: args.signal,
       });
     },
   },

--- a/turbo/packages/connectors/src/auth-providers/oauth/providers/slock.ts
+++ b/turbo/packages/connectors/src/auth-providers/oauth/providers/slock.ts
@@ -408,8 +408,10 @@ export async function pollSlockDeviceAuth(args: {
 
 export async function refreshSlockToken(args: {
   readonly refreshToken: string;
+  readonly signal?: AbortSignal;
 }): Promise<OAuthRefreshResult> {
   const response = await fetch(`${SLOCK_API_BASE_URL}/api/auth/refresh`, {
+    signal: args.signal,
     method: "POST",
     headers: {
       "Content-Type": "application/json",

--- a/turbo/packages/connectors/src/auth-providers/oauth/providers/slock.ts
+++ b/turbo/packages/connectors/src/auth-providers/oauth/providers/slock.ts
@@ -408,7 +408,7 @@ export async function pollSlockDeviceAuth(args: {
 
 export async function refreshSlockToken(args: {
   readonly refreshToken: string;
-  readonly signal?: AbortSignal;
+  readonly signal: AbortSignal;
 }): Promise<OAuthRefreshResult> {
   const response = await fetch(`${SLOCK_API_BASE_URL}/api/auth/refresh`, {
     signal: args.signal,

--- a/turbo/packages/connectors/src/auth-providers/oauth/providers/spotify-provider.ts
+++ b/turbo/packages/connectors/src/auth-providers/oauth/providers/spotify-provider.ts
@@ -47,7 +47,12 @@ export const spotifyProvider: AuthCodeConnectorAuthProvider<"spotify"> = {
     },
     refreshToken: (args) => {
       const { clientId, clientSecret } = args;
-      return refreshSpotifyToken(clientId, clientSecret, args.refreshToken);
+      return refreshSpotifyToken(
+        clientId,
+        clientSecret,
+        args.refreshToken,
+        args.signal,
+      );
     },
   },
   revoke: { kind: "none" },

--- a/turbo/packages/connectors/src/auth-providers/oauth/providers/spotify.ts
+++ b/turbo/packages/connectors/src/auth-providers/oauth/providers/spotify.ts
@@ -117,7 +117,7 @@ export async function refreshSpotifyToken(
   clientId: string,
   clientSecret: string,
   refreshToken: string,
-  signal?: AbortSignal,
+  signal: AbortSignal,
 ): Promise<SpotifyRefreshResult> {
   const authCodeGrant = getAuthCodeGrantConfig("spotify");
   const basicAuth = Buffer.from(`${clientId}:${clientSecret}`).toString(

--- a/turbo/packages/connectors/src/auth-providers/oauth/providers/spotify.ts
+++ b/turbo/packages/connectors/src/auth-providers/oauth/providers/spotify.ts
@@ -117,6 +117,7 @@ export async function refreshSpotifyToken(
   clientId: string,
   clientSecret: string,
   refreshToken: string,
+  signal?: AbortSignal,
 ): Promise<SpotifyRefreshResult> {
   const authCodeGrant = getAuthCodeGrantConfig("spotify");
   const basicAuth = Buffer.from(`${clientId}:${clientSecret}`).toString(
@@ -124,6 +125,7 @@ export async function refreshSpotifyToken(
   );
 
   const response = await fetch(authCodeGrant.tokenUrl, {
+    signal,
     method: "POST",
     headers: {
       "Content-Type": "application/x-www-form-urlencoded",

--- a/turbo/packages/connectors/src/auth-providers/oauth/providers/strava-provider.ts
+++ b/turbo/packages/connectors/src/auth-providers/oauth/providers/strava-provider.ts
@@ -41,7 +41,12 @@ export const stravaProvider: AuthCodeConnectorAuthProvider<"strava"> = {
     },
     refreshToken: (args) => {
       const { clientId, clientSecret } = args;
-      return refreshStravaToken(clientId, clientSecret, args.refreshToken);
+      return refreshStravaToken(
+        clientId,
+        clientSecret,
+        args.refreshToken,
+        args.signal,
+      );
     },
   },
   revoke: { kind: "none" },

--- a/turbo/packages/connectors/src/auth-providers/oauth/providers/strava.ts
+++ b/turbo/packages/connectors/src/auth-providers/oauth/providers/strava.ts
@@ -133,9 +133,11 @@ export async function refreshStravaToken(
   clientId: string,
   clientSecret: string,
   refreshToken: string,
+  signal?: AbortSignal,
 ): Promise<StravaRefreshResult> {
   const authCodeGrant = getAuthCodeGrantConfig("strava");
   const response = await fetch(authCodeGrant.tokenUrl, {
+    signal,
     method: "POST",
     headers: {
       "Content-Type": "application/x-www-form-urlencoded",

--- a/turbo/packages/connectors/src/auth-providers/oauth/providers/strava.ts
+++ b/turbo/packages/connectors/src/auth-providers/oauth/providers/strava.ts
@@ -133,7 +133,7 @@ export async function refreshStravaToken(
   clientId: string,
   clientSecret: string,
   refreshToken: string,
-  signal?: AbortSignal,
+  signal: AbortSignal,
 ): Promise<StravaRefreshResult> {
   const authCodeGrant = getAuthCodeGrantConfig("strava");
   const response = await fetch(authCodeGrant.tokenUrl, {

--- a/turbo/packages/connectors/src/auth-providers/oauth/providers/stripe-provider.ts
+++ b/turbo/packages/connectors/src/auth-providers/oauth/providers/stripe-provider.ts
@@ -40,7 +40,12 @@ export const stripeProvider: AuthCodeConnectorAuthProvider<"stripe"> = {
     },
     refreshToken: (args) => {
       const { clientId, clientSecret } = args;
-      return refreshStripeToken(clientId, clientSecret, args.refreshToken);
+      return refreshStripeToken(
+        clientId,
+        clientSecret,
+        args.refreshToken,
+        args.signal,
+      );
     },
   },
   revoke: { kind: "none" },

--- a/turbo/packages/connectors/src/auth-providers/oauth/providers/stripe.ts
+++ b/turbo/packages/connectors/src/auth-providers/oauth/providers/stripe.ts
@@ -116,7 +116,7 @@ export async function refreshStripeToken(
   _clientId: string,
   clientSecret: string,
   refreshToken: string,
-  signal?: AbortSignal,
+  signal: AbortSignal,
 ): Promise<StripeRefreshResult> {
   const authCodeGrant = getAuthCodeGrantConfig("stripe");
   const response = await fetch(authCodeGrant.tokenUrl, {

--- a/turbo/packages/connectors/src/auth-providers/oauth/providers/stripe.ts
+++ b/turbo/packages/connectors/src/auth-providers/oauth/providers/stripe.ts
@@ -116,9 +116,11 @@ export async function refreshStripeToken(
   _clientId: string,
   clientSecret: string,
   refreshToken: string,
+  signal?: AbortSignal,
 ): Promise<StripeRefreshResult> {
   const authCodeGrant = getAuthCodeGrantConfig("stripe");
   const response = await fetch(authCodeGrant.tokenUrl, {
+    signal,
     method: "POST",
     headers: {
       "Content-Type": "application/x-www-form-urlencoded",

--- a/turbo/packages/connectors/src/auth-providers/oauth/providers/supabase-provider.ts
+++ b/turbo/packages/connectors/src/auth-providers/oauth/providers/supabase-provider.ts
@@ -54,7 +54,12 @@ export const supabaseProvider: AuthCodeConnectorAuthProvider<"supabase"> = {
     },
     refreshToken: (args) => {
       const { clientId, clientSecret } = args;
-      return refreshSupabaseToken(clientId, clientSecret, args.refreshToken);
+      return refreshSupabaseToken(
+        clientId,
+        clientSecret,
+        args.refreshToken,
+        args.signal,
+      );
     },
   },
   revoke: { kind: "none" },

--- a/turbo/packages/connectors/src/auth-providers/oauth/providers/supabase.ts
+++ b/turbo/packages/connectors/src/auth-providers/oauth/providers/supabase.ts
@@ -95,7 +95,7 @@ export async function refreshSupabaseToken(
   clientId: string,
   clientSecret: string,
   refreshToken: string,
-  signal?: AbortSignal,
+  signal: AbortSignal,
 ): Promise<SupabaseRefreshResult> {
   const authCodeGrant = getAuthCodeGrantConfig("supabase");
   const credentials = Buffer.from(`${clientId}:${clientSecret}`).toString(

--- a/turbo/packages/connectors/src/auth-providers/oauth/providers/supabase.ts
+++ b/turbo/packages/connectors/src/auth-providers/oauth/providers/supabase.ts
@@ -95,6 +95,7 @@ export async function refreshSupabaseToken(
   clientId: string,
   clientSecret: string,
   refreshToken: string,
+  signal?: AbortSignal,
 ): Promise<SupabaseRefreshResult> {
   const authCodeGrant = getAuthCodeGrantConfig("supabase");
   const credentials = Buffer.from(`${clientId}:${clientSecret}`).toString(
@@ -102,6 +103,7 @@ export async function refreshSupabaseToken(
   );
 
   const response = await fetch(authCodeGrant.tokenUrl, {
+    signal,
     method: "POST",
     headers: {
       Authorization: `Basic ${credentials}`,

--- a/turbo/packages/connectors/src/auth-providers/oauth/providers/test-oauth-provider.ts
+++ b/turbo/packages/connectors/src/auth-providers/oauth/providers/test-oauth-provider.ts
@@ -53,6 +53,7 @@ export const testOauthProvider: AuthCodeConnectorAuthProvider<"test-oauth"> = {
         clientId,
         clientSecret,
         refreshToken,
+        args.signal,
       );
       return {
         accessToken: result.accessToken,

--- a/turbo/packages/connectors/src/auth-providers/oauth/providers/test-oauth.ts
+++ b/turbo/packages/connectors/src/auth-providers/oauth/providers/test-oauth.ts
@@ -170,7 +170,7 @@ const tokenResponseSchema = z.object({
 async function postToken(
   body: URLSearchParams,
   operation: "exchange" | "refresh",
-  signal?: AbortSignal,
+  signal: AbortSignal | undefined,
 ): Promise<TokenResponse> {
   const response = await fetch(getTestOAuthTokenUrl(), {
     signal,
@@ -211,6 +211,7 @@ export async function exchangeTestOAuthCode(
       redirect_uri: redirectUri,
     }),
     "exchange",
+    undefined,
   );
 }
 
@@ -218,7 +219,7 @@ export async function refreshTestOAuthToken(
   clientId: string,
   clientSecret: string,
   refreshToken: string,
-  signal?: AbortSignal,
+  signal: AbortSignal,
 ): Promise<TokenResponse> {
   return postToken(
     new URLSearchParams({

--- a/turbo/packages/connectors/src/auth-providers/oauth/providers/test-oauth.ts
+++ b/turbo/packages/connectors/src/auth-providers/oauth/providers/test-oauth.ts
@@ -170,8 +170,10 @@ const tokenResponseSchema = z.object({
 async function postToken(
   body: URLSearchParams,
   operation: "exchange" | "refresh",
+  signal?: AbortSignal,
 ): Promise<TokenResponse> {
   const response = await fetch(getTestOAuthTokenUrl(), {
+    signal,
     method: "POST",
     headers: {
       "Content-Type": "application/x-www-form-urlencoded",
@@ -216,6 +218,7 @@ export async function refreshTestOAuthToken(
   clientId: string,
   clientSecret: string,
   refreshToken: string,
+  signal?: AbortSignal,
 ): Promise<TokenResponse> {
   return postToken(
     new URLSearchParams({
@@ -225,6 +228,7 @@ export async function refreshTestOAuthToken(
       refresh_token: refreshToken,
     }),
     "refresh",
+    signal,
   );
 }
 

--- a/turbo/packages/connectors/src/auth-providers/oauth/providers/x-provider.ts
+++ b/turbo/packages/connectors/src/auth-providers/oauth/providers/x-provider.ts
@@ -48,7 +48,12 @@ export const xProvider: AuthCodeConnectorAuthProvider<"x"> = {
     },
     refreshToken: (args) => {
       const { clientId, clientSecret } = args;
-      return refreshXToken(clientId, clientSecret, args.refreshToken);
+      return refreshXToken(
+        clientId,
+        clientSecret,
+        args.refreshToken,
+        args.signal,
+      );
     },
   },
   revoke: { kind: "none" },

--- a/turbo/packages/connectors/src/auth-providers/oauth/providers/x.ts
+++ b/turbo/packages/connectors/src/auth-providers/oauth/providers/x.ts
@@ -95,6 +95,7 @@ export async function refreshXToken(
   clientId: string,
   clientSecret: string,
   refreshToken: string,
+  signal?: AbortSignal,
 ): Promise<XRefreshResult> {
   const authCodeGrant = getAuthCodeGrantConfig("x");
   const credentials = Buffer.from(`${clientId}:${clientSecret}`).toString(
@@ -102,6 +103,7 @@ export async function refreshXToken(
   );
 
   const response = await fetch(authCodeGrant.tokenUrl, {
+    signal,
     method: "POST",
     headers: {
       Authorization: `Basic ${credentials}`,

--- a/turbo/packages/connectors/src/auth-providers/oauth/providers/x.ts
+++ b/turbo/packages/connectors/src/auth-providers/oauth/providers/x.ts
@@ -95,7 +95,7 @@ export async function refreshXToken(
   clientId: string,
   clientSecret: string,
   refreshToken: string,
-  signal?: AbortSignal,
+  signal: AbortSignal,
 ): Promise<XRefreshResult> {
   const authCodeGrant = getAuthCodeGrantConfig("x");
   const credentials = Buffer.from(`${clientId}:${clientSecret}`).toString(

--- a/turbo/packages/connectors/src/auth-providers/oauth/providers/xero-provider.ts
+++ b/turbo/packages/connectors/src/auth-providers/oauth/providers/xero-provider.ts
@@ -43,7 +43,12 @@ export const xeroProvider: AuthCodeConnectorAuthProvider<"xero"> = {
     },
     refreshToken: (args) => {
       const { clientId, clientSecret } = args;
-      return refreshXeroToken(clientId, clientSecret, args.refreshToken);
+      return refreshXeroToken(
+        clientId,
+        clientSecret,
+        args.refreshToken,
+        args.signal,
+      );
     },
   },
   revoke: { kind: "none" },

--- a/turbo/packages/connectors/src/auth-providers/oauth/providers/xero.ts
+++ b/turbo/packages/connectors/src/auth-providers/oauth/providers/xero.ts
@@ -117,7 +117,7 @@ export async function refreshXeroToken(
   clientId: string,
   clientSecret: string,
   refreshToken: string,
-  signal?: AbortSignal,
+  signal: AbortSignal,
 ): Promise<XeroRefreshResult> {
   const authCodeGrant = getAuthCodeGrantConfig("xero");
   const response = await fetch(authCodeGrant.tokenUrl, {

--- a/turbo/packages/connectors/src/auth-providers/oauth/providers/xero.ts
+++ b/turbo/packages/connectors/src/auth-providers/oauth/providers/xero.ts
@@ -117,9 +117,11 @@ export async function refreshXeroToken(
   clientId: string,
   clientSecret: string,
   refreshToken: string,
+  signal?: AbortSignal,
 ): Promise<XeroRefreshResult> {
   const authCodeGrant = getAuthCodeGrantConfig("xero");
   const response = await fetch(authCodeGrant.tokenUrl, {
+    signal,
     method: "POST",
     headers: {
       "Content-Type": "application/x-www-form-urlencoded",

--- a/turbo/packages/connectors/src/auth-providers/oauth/providers/zoom-provider.ts
+++ b/turbo/packages/connectors/src/auth-providers/oauth/providers/zoom-provider.ts
@@ -43,7 +43,12 @@ export const zoomProvider: AuthCodeConnectorAuthProvider<"zoom"> = {
     },
     refreshToken: (args) => {
       const { clientId, clientSecret } = args;
-      return refreshZoomToken(clientId, clientSecret, args.refreshToken);
+      return refreshZoomToken(
+        clientId,
+        clientSecret,
+        args.refreshToken,
+        args.signal,
+      );
     },
   },
   revoke: { kind: "none" },

--- a/turbo/packages/connectors/src/auth-providers/oauth/providers/zoom.ts
+++ b/turbo/packages/connectors/src/auth-providers/oauth/providers/zoom.ts
@@ -120,6 +120,7 @@ export async function refreshZoomToken(
   clientId: string,
   clientSecret: string,
   refreshToken: string,
+  signal?: AbortSignal,
 ): Promise<ZoomRefreshResult> {
   const authCodeGrant = getAuthCodeGrantConfig("zoom");
   const basicAuth = Buffer.from(`${clientId}:${clientSecret}`).toString(
@@ -127,6 +128,7 @@ export async function refreshZoomToken(
   );
 
   const response = await fetch(authCodeGrant.tokenUrl, {
+    signal,
     method: "POST",
     headers: {
       "Content-Type": "application/x-www-form-urlencoded",

--- a/turbo/packages/connectors/src/auth-providers/oauth/providers/zoom.ts
+++ b/turbo/packages/connectors/src/auth-providers/oauth/providers/zoom.ts
@@ -120,7 +120,7 @@ export async function refreshZoomToken(
   clientId: string,
   clientSecret: string,
   refreshToken: string,
-  signal?: AbortSignal,
+  signal: AbortSignal,
 ): Promise<ZoomRefreshResult> {
   const authCodeGrant = getAuthCodeGrantConfig("zoom");
   const basicAuth = Buffer.from(`${clientId}:${clientSecret}`).toString(

--- a/turbo/packages/connectors/src/auth-providers/oauth/types.ts
+++ b/turbo/packages/connectors/src/auth-providers/oauth/types.ts
@@ -41,7 +41,7 @@ interface OAuthExchangeFlowArgs {
 
 interface OAuthRefreshFlowArgs {
   readonly refreshToken: string;
-  readonly signal?: AbortSignal;
+  readonly signal: AbortSignal;
 }
 
 interface OAuthRevokeFlowArgs {

--- a/turbo/packages/connectors/src/auth-providers/oauth/types.ts
+++ b/turbo/packages/connectors/src/auth-providers/oauth/types.ts
@@ -41,6 +41,7 @@ interface OAuthExchangeFlowArgs {
 
 interface OAuthRefreshFlowArgs {
   readonly refreshToken: string;
+  readonly signal?: AbortSignal;
 }
 
 interface OAuthRevokeFlowArgs {

--- a/turbo/packages/connectors/src/auth-providers/types.ts
+++ b/turbo/packages/connectors/src/auth-providers/types.ts
@@ -110,6 +110,7 @@ interface ModelProviderOAuthRefreshArgs {
   readonly clientId?: string;
   readonly clientSecret?: string;
   readonly refreshToken: string;
+  readonly signal?: AbortSignal;
 }
 
 interface ModelProviderRefreshTokenAccessProvider {

--- a/turbo/packages/connectors/src/auth-providers/types.ts
+++ b/turbo/packages/connectors/src/auth-providers/types.ts
@@ -110,7 +110,7 @@ interface ModelProviderOAuthRefreshArgs {
   readonly clientId?: string;
   readonly clientSecret?: string;
   readonly refreshToken: string;
-  readonly signal?: AbortSignal;
+  readonly signal: AbortSignal;
 }
 
 interface ModelProviderRefreshTokenAccessProvider {


### PR DESCRIPTION
## Summary
- Add a fixed 30s firewall auth refresh timeout signal.
- Thread the required abort signal through connector and model-provider OAuth refresh paths into provider fetch calls.
- Classify only refresh-timeout aborts as upstream provider failures without forcing reconnect.
- Add deterministic connector and model-provider timeout coverage.

Closes #15537

## Tests
- pnpm -F api exec vitest run src/signals/routes/__tests__/webhooks-agent-firewall-auth.test.ts
- pnpm -F @vm0/connectors exec vitest run src/__tests__/connectors.test.ts src/auth-providers/oauth/providers/__tests__/codex-oauth.test.ts src/auth-providers/oauth/providers/__tests__/google-ads.test.ts src/auth-providers/oauth/providers/__tests__/gumroad.test.ts src/auth-providers/oauth/providers/__tests__/spotify.test.ts src/auth-providers/oauth/providers/__tests__/test-oauth.test.ts src/auth-providers/oauth/providers/__tests__/zoom.test.ts
- pnpm -F api check-types
- pnpm -F @vm0/connectors check-types
- pnpm -F api lint
- pnpm -F @vm0/connectors lint
- git diff --check
- pre-commit: pnpm check-types
- pre-commit: pnpm knip

## Note
- A full @vm0/connectors vitest run currently fails on an unrelated cronlytic firewall secret consistency issue.