### PR TITLE
refactor(mitm-addon): store HTTP timing on flows

### DIFF
--- a/crates/runner/mitm-addon/src/flow_metadata_keys.py
+++ b/crates/runner/mitm-addon/src/flow_metadata_keys.py
@@ -12,6 +12,10 @@ NETWORK_LOG_TARGET: Final = "network_log_target"
 CAPTURE_BODY: Final = "capture_body"
 CLI_AGENT_TYPE: Final = "cli_agent_type"
 
+# Timing metadata
+HTTP_REQUEST_START_MONOTONIC: Final = "http_request_start_monotonic"
+TCP_START_MONOTONIC: Final = "tcp_start_monotonic"
+
 # Firewall and auth metadata
 FIREWALL_BASE: Final = "firewall_base"
 FIREWALL_API_ID: Final = "firewall_api_id"

--- a/crates/runner/mitm-addon/src/mitm_addon.py
+++ b/crates/runner/mitm-addon/src/mitm_addon.py
@@ -168,7 +168,7 @@ def get_registry_path() -> str:
 
 
 def _elapsed_ms(start_time: float | None) -> int:
-    if start_time is None:
+    if not start_time:
         return 0
     return max(0, int((time.monotonic() - start_time) * 1000))
 

--- a/crates/runner/mitm-addon/src/mitm_addon.py
+++ b/crates/runner/mitm-addon/src/mitm_addon.py
@@ -167,8 +167,10 @@ def get_registry_path() -> str:
     return ctx.options.vm0_proxy_registry_path
 
 
-# Track request start times for latency calculation
-_request_start_times: dict = {}
+def _elapsed_ms(start_time: float | None) -> int:
+    if start_time is None:
+        return 0
+    return max(0, int((time.monotonic() - start_time) * 1000))
 
 
 def _set_network_log_target(flow: http.HTTPFlow, *, url: str, host: str, port: int) -> None:
@@ -337,8 +339,8 @@ async def request(flow: http.HTTPFlow) -> None:
 
     run_id = vm_info.get("runId", "")
 
-    # Track request start time (after early returns to avoid leaking entries)
-    _request_start_times[flow.id] = time.time()
+    # Track request start time after early returns so unregistered flows do not carry it.
+    flow.metadata[metadata_keys.HTTP_REQUEST_START_MONOTONIC] = time.monotonic()
 
     try:
         # Store info for response handler
@@ -456,7 +458,7 @@ async def request(flow: http.HTTPFlow) -> None:
         # No firewall match — pass through directly
         flow.metadata[metadata_keys.FIREWALL_ACTION] = "ALLOW"
     except Exception:
-        _request_start_times.pop(flow.id, None)
+        flow.metadata.pop(metadata_keys.HTTP_REQUEST_START_MONOTONIC, None)
         _release_tracked_usage_flow(flow)
         raise
 
@@ -555,11 +557,8 @@ def response(flow: http.HTTPFlow) -> None:
     """
     Handle response and log network activity.
     """
-    # Pop the start-time tracking entry before any early return so that
-    # flows the request handler tracked (line 181) but whose metadata
-    # indicates we should skip (e.g. registry entry without a runId) do
-    # not leak into ``_request_start_times``. Mirrors ``error()``.
-    start_time = _request_start_times.pop(flow.id, None)
+    # Pop before any early return so tracked flows consume timing exactly once.
+    start_time = flow.metadata.pop(metadata_keys.HTTP_REQUEST_START_MONOTONIC, None)
 
     run_id = flow.metadata.get(metadata_keys.VM_RUN_ID, "")
     if not run_id:
@@ -567,7 +566,7 @@ def response(flow: http.HTTPFlow) -> None:
         # metadata, so none of this handler's work applies.
         return
 
-    latency_ms = int((time.time() - start_time) * 1000) if start_time else 0
+    latency_ms = _elapsed_ms(start_time)
     original_url = flow.metadata[metadata_keys.ORIGINAL_URL]
     firewall_action = flow.metadata.get(metadata_keys.FIREWALL_ACTION, "ALLOW")
 
@@ -682,7 +681,7 @@ def error(flow: http.HTTPFlow) -> None:
     Log connection-level errors (timeout, RST, TLS failure) to the
     per-run JSONL network log and clean up request tracking state.
     """
-    start_time = _request_start_times.pop(flow.id, None)
+    start_time = flow.metadata.pop(metadata_keys.HTTP_REQUEST_START_MONOTONIC, None)
 
     run_id = flow.metadata.get(metadata_keys.VM_RUN_ID, "")
     network_log_path = flow.metadata.get(metadata_keys.VM_NETWORK_LOG_PATH, "")
@@ -691,7 +690,7 @@ def error(flow: http.HTTPFlow) -> None:
     if not run_id or not network_log_path:
         return
 
-    latency_ms = int((time.time() - start_time) * 1000) if start_time else 0
+    latency_ms = _elapsed_ms(start_time)
     original_url = flow.metadata[metadata_keys.ORIGINAL_URL]
     firewall_action = flow.metadata.get(metadata_keys.FIREWALL_ACTION, "ALLOW")
 
@@ -780,7 +779,7 @@ def tcp_start(flow: tcp.TCPFlow) -> None:
     flow.metadata[metadata_keys.VM_RUN_ID] = vm_info.get("runId", "")
     flow.metadata[metadata_keys.VM_NETWORK_LOG_PATH] = vm_info.get("networkLogPath", "")
     flow.metadata[metadata_keys.VM_PROXY_LOG_PATH] = vm_info.get("proxyLogPath", "")
-    flow.metadata["tcp_start_time"] = time.time()
+    flow.metadata[metadata_keys.TCP_START_MONOTONIC] = time.monotonic()
 
 
 def tcp_end(flow: tcp.TCPFlow) -> None:
@@ -799,8 +798,8 @@ def _log_tcp(flow: tcp.TCPFlow) -> None:
     if not run_id or not network_log_path:
         return
 
-    start_time = flow.metadata.get("tcp_start_time")
-    latency_ms = int((time.time() - start_time) * 1000) if start_time else 0
+    start_time = flow.metadata.get(metadata_keys.TCP_START_MONOTONIC)
+    latency_ms = _elapsed_ms(start_time)
 
     request_size = sum(len(m.content) for m in flow.messages if m.from_client)
     response_size = sum(len(m.content) for m in flow.messages if not m.from_client)

--- a/crates/runner/mitm-addon/tests/conftest.py
+++ b/crates/runner/mitm-addon/tests/conftest.py
@@ -38,13 +38,11 @@ def _reset_module_state() -> Iterator[None]:
 
     ``registry`` and ``auth`` cache registry data and firewall header
     lookups in module-level dicts.  Without a reset, earlier tests leak
-    entries that change later tests' behaviour (e.g. a request from IP X
-    in test A primes ``_request_start_times`` seen by test B).
+    entries that change later tests' behaviour.
 
     The usage buffer owns a background timer in production, so tests reset
     it before and after each case to avoid cross-test callbacks.
     """
-    mitm_addon._request_start_times.clear()
     registry.reset_cache_for_tests()
     clear_auth_state()
     _usage_connectors._unregistered_handler_warned.clear()

--- a/crates/runner/mitm-addon/tests/test_connection_hooks.py
+++ b/crates/runner/mitm-addon/tests/test_connection_hooks.py
@@ -9,6 +9,7 @@ from unittest.mock import MagicMock, patch
 import pytest
 from mitmproxy.flow import Error
 
+import flow_metadata_keys as metadata_keys
 import mitm_addon
 import usage
 from tests.pending_helpers import assert_pending
@@ -355,7 +356,7 @@ class TestTcpStart:
 
         assert flow.metadata["vm_run_id"] == "run-abc-123"
         assert "vm_network_log_path" in flow.metadata
-        assert "tcp_start_time" in flow.metadata
+        assert metadata_keys.TCP_START_MONOTONIC in flow.metadata
 
     def test_skips_when_no_client_ip(self, registry_file, mitm_ctx, real_tcp_flow):
         flow = real_tcp_flow()
@@ -385,7 +386,7 @@ class TestTcpLog:
         log_path = str(tmp_path / "network.jsonl")
         flow.metadata["vm_run_id"] = "run-abc-123"
         flow.metadata["vm_network_log_path"] = log_path
-        flow.metadata["tcp_start_time"] = time.time() - 0.05
+        flow.metadata[metadata_keys.TCP_START_MONOTONIC] = time.monotonic() - 0.05
 
         with mitm_ctx():
             mitm_addon.tcp_end(flow)
@@ -407,7 +408,7 @@ class TestTcpLog:
         log_path = str(tmp_path / "network.jsonl")
         flow.metadata["vm_run_id"] = "run-abc-123"
         flow.metadata["vm_network_log_path"] = log_path
-        flow.metadata["tcp_start_time"] = time.time()
+        flow.metadata[metadata_keys.TCP_START_MONOTONIC] = time.monotonic()
         flow.error = Error("connection reset by peer")
 
         with mitm_ctx():
@@ -433,7 +434,7 @@ class TestTcpLog:
         log_path = str(tmp_path / "network.jsonl")
         flow.metadata["vm_run_id"] = "run-abc-123"
         flow.metadata["vm_network_log_path"] = log_path
-        flow.metadata["tcp_start_time"] = time.time()
+        flow.metadata[metadata_keys.TCP_START_MONOTONIC] = time.monotonic()
         flow.server_conn = None
 
         with mitm_ctx():

--- a/crates/runner/mitm-addon/tests/test_connector_usage.py
+++ b/crates/runner/mitm-addon/tests/test_connector_usage.py
@@ -1299,7 +1299,6 @@ class TestReportConnectorUsage:
         flow.response = tutils.tresp(status_code=200)
         flow.response.headers = header_map({"content-type": "application/json"})
         flow.response.stream = False
-        mitm_addon._request_start_times[flow.id] = time.time()
 
         mitm_addon.responseheaders(flow)
         callback = response_stream(flow)

--- a/crates/runner/mitm-addon/tests/test_connector_usage.py
+++ b/crates/runner/mitm-addon/tests/test_connector_usage.py
@@ -2,7 +2,6 @@
 
 import gzip
 import json
-import time
 from pathlib import Path
 from unittest.mock import MagicMock, patch
 
@@ -439,7 +438,6 @@ class TestReportConnectorUsage:
         callback(b'"}],"includes":{"users":[{"id":"u1"}]},"meta":{"result_count":1}}')
         assert len(flow.metadata["stream_buffer"]) == body_utils.STREAM_BUFFER_LIMIT
         assert flow.metadata["stream_buffer_state"]["truncated"] is True
-        mitm_addon._request_start_times[flow.id] = time.time()
 
         with (
             mitm_ctx(),
@@ -477,7 +475,6 @@ class TestReportConnectorUsage:
 
         mitm_addon.responseheaders(flow)
         response_stream(flow)(b'{"data":{"id":"1","text":"hello"}}')
-        mitm_addon._request_start_times[flow.id] = time.time()
 
         with (
             mitm_ctx(),
@@ -527,7 +524,6 @@ class TestReportConnectorUsage:
                 }
             ).encode()
         )
-        mitm_addon._request_start_times[flow.id] = time.time()
 
         with (
             mitm_ctx(),
@@ -563,7 +559,6 @@ class TestReportConnectorUsage:
 
         mitm_addon.responseheaders(flow)
         response_stream(flow)(b'[{"id":"1"}]')
-        mitm_addon._request_start_times[flow.id] = time.time()
 
         with (
             mitm_ctx(),
@@ -1247,7 +1242,6 @@ class TestReportConnectorUsage:
         # X streams return application/json with chunked transfer, not x-ndjson.
         flow.response.headers = header_map({"content-type": "application/json"})
         flow.response.stream = False
-        mitm_addon._request_start_times[flow.id] = time.time()
 
         # 1. responseheaders - registers NDJSON parser
         mitm_addon.responseheaders(flow)
@@ -1362,7 +1356,6 @@ class TestReportConnectorUsage:
         mitm_addon.responseheaders(flow)
         response_stream(flow)(b'{"data":[{"id":"1"}')
         assert "connector_response_finish" in flow.metadata
-        mitm_addon._request_start_times[flow.id] = time.time()
 
         with (
             mitm_ctx(api_url="https://app.test"),
@@ -1408,7 +1401,6 @@ class TestReportConnectorUsage:
         mitm_addon.responseheaders(flow)
         response_stream(flow)(b'{"data":[{"id":"1"},' + b" " * body_utils.STREAM_BUFFER_LIMIT)
         assert flow.metadata["stream_buffer_state"]["truncated"] is True
-        mitm_addon._request_start_times[flow.id] = time.time()
 
         with (
             mitm_ctx(api_url="https://app.test"),
@@ -1453,7 +1445,6 @@ class TestReportConnectorUsage:
         mitm_addon.responseheaders(flow)
         response_stream(flow)(b'{"data":[{"id":"1"}')
         assert "connector_response_finish" in flow.metadata
-        mitm_addon._request_start_times[flow.id] = time.time()
 
         with (
             mitm_ctx(api_url="https://app.test"),

--- a/crates/runner/mitm-addon/tests/test_error_handler.py
+++ b/crates/runner/mitm-addon/tests/test_error_handler.py
@@ -22,7 +22,6 @@ from tests.usage_helpers import (
 class TestErrorHandler:
     def test_cleans_up_start_time(self, tmp_path, real_flow, mitm_ctx):
         flow = real_flow(with_response=False)
-        flow.id = "flow-err-1"
         flow.metadata["vm_run_id"] = "run-abc-123"
         flow.metadata["vm_network_log_path"] = str(tmp_path / "net.jsonl")
         # Matches the request handler's invariant: original_url is set

--- a/crates/runner/mitm-addon/tests/test_error_handler.py
+++ b/crates/runner/mitm-addon/tests/test_error_handler.py
@@ -9,6 +9,7 @@ from unittest.mock import MagicMock, patch
 from mitmproxy.flow import Error
 from mitmproxy.test import tutils
 
+import flow_metadata_keys as metadata_keys
 import mitm_addon
 import usage
 from tests.flow_helpers import header_map, response_stream
@@ -28,12 +29,12 @@ class TestErrorHandler:
         # alongside vm_run_id.
         flow.metadata["original_url"] = "https://example.com/"
         flow.error = Error("connection reset")
-        mitm_addon._request_start_times["flow-err-1"] = 12345.0
+        flow.metadata[metadata_keys.HTTP_REQUEST_START_MONOTONIC] = time.monotonic()
 
         with mitm_ctx():
             mitm_addon.error(flow)
 
-        assert "flow-err-1" not in mitm_addon._request_start_times
+        assert metadata_keys.HTTP_REQUEST_START_MONOTONIC not in flow.metadata
 
     def test_error_releases_unfinished_json_streaming_state(self, tmp_path, real_flow, mitm_ctx):
         """Connection errors should drop unfinished JSON parser closures."""
@@ -140,7 +141,7 @@ class TestErrorHandler:
         flow.metadata["original_url"] = raw_url
         flow.metadata["firewall_action"] = "ALLOW"
         flow.error = Error("connection reset by peer")
-        mitm_addon._request_start_times[flow.id] = time.time() - 1.5
+        flow.metadata[metadata_keys.HTTP_REQUEST_START_MONOTONIC] = time.monotonic() - 1.5
 
         with mitm_ctx():
             mitm_addon.error(flow)
@@ -186,7 +187,7 @@ class TestErrorHandler:
         assert entry["url"] == "https://api.anthropic.com:8443/v1/messages"
         assert entry["status"] == 0
         assert entry["error"] == "connection reset by peer"
-        assert flow.id not in mitm_addon._request_start_times
+        assert metadata_keys.HTTP_REQUEST_START_MONOTONIC not in flow.metadata
 
     def test_error_logs_legacy_target_when_original_url_port_is_invalid(
         self, tmp_path, real_flow, mitm_ctx
@@ -373,7 +374,6 @@ class TestErrorHandler:
             "tokens.input": 80,
         }
         flow.error = Error("connection reset by peer")
-        mitm_addon._request_start_times[flow.id] = time.time()
 
         with (
             mitm_ctx(api_url="https://api.vm0.ai"),

--- a/crates/runner/mitm-addon/tests/test_model_provider_response_usage.py
+++ b/crates/runner/mitm-addon/tests/test_model_provider_response_usage.py
@@ -2,7 +2,6 @@
 
 import gzip
 import json
-import time
 import zlib
 from pathlib import Path
 from unittest.mock import MagicMock, patch
@@ -51,7 +50,6 @@ class TestModelProviderResponseUsage:
                 {"content-type": "application/json", "content-length": str(len(body))}
             ),
         )
-        mitm_addon._request_start_times[flow.id] = time.time()
 
         with (
             mitm_ctx(),
@@ -103,7 +101,6 @@ class TestModelProviderResponseUsage:
                 {"content-type": "application/json", "content-length": str(len(body))}
             ),
         )
-        mitm_addon._request_start_times[flow.id] = time.time()
 
         with (
             mitm_ctx(),
@@ -149,7 +146,6 @@ class TestModelProviderResponseUsage:
             status_code=200,
             headers=header_map({"content-type": "application/json"}),
         )
-        mitm_addon._request_start_times[flow.id] = time.time()
 
         with (
             mitm_ctx(),
@@ -197,7 +193,6 @@ class TestModelProviderResponseUsage:
             status_code=200,
             headers=header_map({"content-type": "application/json"}),
         )
-        mitm_addon._request_start_times[flow.id] = time.time()
 
         with (
             mitm_ctx(),
@@ -240,7 +235,6 @@ class TestModelProviderResponseUsage:
             status_code=200,
             headers=header_map({"content-type": "application/json"}),
         )
-        mitm_addon._request_start_times[flow.id] = time.time()
 
         with (
             mitm_ctx(),
@@ -361,7 +355,6 @@ class TestModelProviderResponseUsage:
                 }
             ),
         )
-        mitm_addon._request_start_times[flow.id] = time.time()
 
         with (
             mitm_ctx(),
@@ -433,7 +426,6 @@ class TestModelProviderResponseUsage:
                 }
             ),
         )
-        mitm_addon._request_start_times[flow.id] = time.time()
 
         with (
             mitm_ctx(),
@@ -522,7 +514,6 @@ class TestModelProviderResponseUsage:
                 }
             ),
         )
-        mitm_addon._request_start_times[flow.id] = time.time()
 
         with (
             mitm_ctx(),
@@ -578,7 +569,6 @@ class TestModelProviderResponseUsage:
             status_code=200,
             headers=header_map({"content-type": "application/json"}),
         )
-        mitm_addon._request_start_times[flow.id] = time.time()
 
         with (
             mitm_ctx(),
@@ -615,7 +605,6 @@ class TestModelProviderResponseUsage:
             status_code=200,
             headers=header_map({"content-type": "application/json"}),
         )
-        mitm_addon._request_start_times[flow.id] = time.time()
 
         with (
             mitm_ctx(),
@@ -677,7 +666,6 @@ class TestModelProviderResponseUsage:
         flow.metadata["vm_sandbox_token"] = "tok-xyz"
         set_stream_buffer(flow, body)
         flow.response = tutils.tresp(status_code=200, headers=header_map(response_headers))
-        mitm_addon._request_start_times[flow.id] = time.time()
 
         with (
             mitm_ctx(),
@@ -713,7 +701,6 @@ class TestModelProviderResponseUsage:
             status_code=200,
             headers=header_map({"content-type": "application/json"}),
         )
-        mitm_addon._request_start_times[flow.id] = time.time()
 
         with (
             mitm_ctx(),
@@ -781,7 +768,6 @@ class TestModelProviderResponseUsage:
             status_code=200,
             headers=header_map({"content-type": "application/json"}),
         )
-        mitm_addon._request_start_times[flow.id] = time.time()
 
         with (
             mitm_ctx(),
@@ -829,7 +815,6 @@ class TestModelProviderResponseUsage:
                 {"content-type": "application/json", "content-length": str(len(body))}
             ),
         )
-        mitm_addon._request_start_times[flow.id] = time.time()
 
         with (
             mitm_ctx(),
@@ -878,7 +863,6 @@ class TestModelProviderResponseUsage:
             status_code=200,
             headers=header_map({"content-type": "application/json"}),
         )
-        mitm_addon._request_start_times[flow.id] = time.time()
 
         with (
             mitm_ctx(),
@@ -913,7 +897,6 @@ class TestModelProviderResponseUsage:
             status_code=200,
             headers=header_map({"content-type": "application/json"}),
         )
-        mitm_addon._request_start_times[flow.id] = time.time()
 
         with (
             mitm_ctx(),
@@ -955,7 +938,6 @@ class TestModelProviderResponseUsage:
         callback(b'"}],"usage":{"input_tokens":50,"output_tokens":200}}')
         assert len(flow.metadata["stream_buffer"]) == body_utils.STREAM_BUFFER_LIMIT
         assert flow.metadata["stream_buffer_state"]["truncated"] is True
-        mitm_addon._request_start_times[flow.id] = time.time()
 
         with (
             mitm_ctx(),
@@ -1019,7 +1001,6 @@ class TestModelProviderResponseUsage:
         midpoint = len(compressed) // 2
         response_stream(flow)(compressed[:midpoint])
         response_stream(flow)(compressed[midpoint:])
-        mitm_addon._request_start_times[flow.id] = time.time()
 
         with (
             mitm_ctx(),
@@ -1072,7 +1053,6 @@ class TestModelProviderResponseUsage:
             b'{"id":"msg_1","model":"claude-sonnet-4-6",'
             b'"usage":{"input_tokens":50,"output_tokens":200}'
         )
-        mitm_addon._request_start_times[flow.id] = time.time()
 
         with (
             mitm_ctx(),
@@ -1122,7 +1102,6 @@ class TestModelProviderResponseUsage:
 
         mitm_addon.responseheaders(flow)
         response_stream(flow)(raw_json)
-        mitm_addon._request_start_times[flow.id] = time.time()
 
         with (
             mitm_ctx(),
@@ -1164,7 +1143,6 @@ class TestModelProviderResponseUsage:
 
         mitm_addon.responseheaders(flow)
         response_stream(flow)(body)
-        mitm_addon._request_start_times[flow.id] = time.time()
 
         with (
             mitm_ctx(),
@@ -1196,7 +1174,6 @@ class TestModelProviderResponseUsage:
         flow.response = tutils.tresp(
             status_code=200, headers=header_map({"content-type": "application/json"})
         )
-        mitm_addon._request_start_times[flow.id] = time.time()
 
         with (
             mitm_ctx(),
@@ -1237,7 +1214,6 @@ class TestModelProviderResponseUsage:
         flow.response = tutils.tresp(
             status_code=200, headers=header_map({"content-type": "text/event-stream"})
         )
-        mitm_addon._request_start_times[flow.id] = time.time()
 
         with (
             mitm_ctx(api_url="https://api.vm0.ai"),

--- a/crates/runner/mitm-addon/tests/test_model_provider_stream_usage.py
+++ b/crates/runner/mitm-addon/tests/test_model_provider_stream_usage.py
@@ -1,7 +1,6 @@
 """Tests for model-provider streaming usage reporting paths."""
 
 import json
-import time
 import uuid
 from collections.abc import Callable
 from pathlib import Path
@@ -146,7 +145,6 @@ class TestModelProviderStreamUsage:
             b'"usage":{"input_tokens":50,"output_tokens":20,'
             b'"input_tokens_details":{"cached_tokens":10}}}}'
         )
-        mitm_addon._request_start_times[flow.id] = time.time()
 
         with (
             mitm_ctx(),
@@ -175,7 +173,6 @@ class TestModelProviderStreamUsage:
             b'"usage":{"input_tokens":8000,"output_tokens":1024,'
             b'"input_tokens_details":{"cached_tokens":2000}}}}\n\n'
         )
-        mitm_addon._request_start_times[flow.id] = time.time()
 
         with (
             mitm_ctx(),
@@ -208,7 +205,6 @@ class TestModelProviderStreamUsage:
         response_stream(flow)(
             b'event: message_start\ndata: {"type":"message_start","message":{"id":"msg_1","mod'
         )
-        mitm_addon._request_start_times[flow.id] = time.time()
 
         with (
             mitm_ctx(),
@@ -240,7 +236,6 @@ class TestModelProviderStreamUsage:
             b'event: message_start\ndata: {"type":"message_start","message":{"id":"msg_1","mod'
         )
         flow.error = Error("connection reset by peer")
-        mitm_addon._request_start_times[flow.id] = time.time()
 
         with (
             mitm_ctx(),
@@ -269,7 +264,6 @@ class TestModelProviderStreamUsage:
             firewall_name="model-provider:anthropic-api-key",
         )
         response_stream(flow)(b"event: message_start\ndata: {invalid json}\n\n")
-        mitm_addon._request_start_times[flow.id] = time.time()
 
         with (
             mitm_ctx(),
@@ -304,7 +298,6 @@ class TestModelProviderStreamUsage:
             b"event: message_delta\n"
             b'data: {"type":"message_delta","usage":{"output_tokens":'
         )
-        mitm_addon._request_start_times[flow.id] = time.time()
 
         with (
             mitm_ctx(),
@@ -333,7 +326,6 @@ class TestModelProviderStreamUsage:
             b"event: response.completed\n"
             b'data: {"type":"response.completed","response":{"id":"resp_1","model":"gpt'
         )
-        mitm_addon._request_start_times[flow.id] = time.time()
 
         with (
             mitm_ctx(),
@@ -359,7 +351,6 @@ class TestModelProviderStreamUsage:
             b'data: {"type":"response.completed","response":{"id":"resp_1","model":"gpt\n'
             b"event: response.completed\n\n"
         )
-        mitm_addon._request_start_times[flow.id] = time.time()
 
         with (
             mitm_ctx(),
@@ -390,7 +381,6 @@ class TestModelProviderStreamUsage:
         response_stream(flow)(
             b'data: {"type":"message_start","message":{"id":"msg_1","model":"claude'
         )
-        mitm_addon._request_start_times[flow.id] = time.time()
 
         with (
             mitm_ctx(),
@@ -422,7 +412,6 @@ class TestModelProviderStreamUsage:
             b"event: content_block_delta\n"
             b'data: {"type":"content_block_delta","delta":{"text":"hello'
         )
-        mitm_addon._request_start_times[flow.id] = time.time()
 
         with (
             mitm_ctx(),
@@ -443,7 +432,6 @@ class TestModelProviderStreamUsage:
         response_stream(flow)(
             b'data: {"type":"response.completed","response":{"id":"resp_1","model":"gpt'
         )
-        mitm_addon._request_start_times[flow.id] = time.time()
 
         with (
             mitm_ctx(),
@@ -465,7 +453,6 @@ class TestModelProviderStreamUsage:
             b"event: response.in_progress\n"
             b'data: {"type":"response.in_progress","response":{"id":"resp_1","model":"gpt'
         )
-        mitm_addon._request_start_times[flow.id] = time.time()
 
         with (
             mitm_ctx(),
@@ -491,7 +478,6 @@ class TestModelProviderStreamUsage:
             b'data: {"response":{"id":"resp_sse_empty","model":"gpt-5.4",'
             b'"usage":{"input_tokens":0,"output_tokens":0}}}\n\n'
         )
-        mitm_addon._request_start_times[flow.id] = time.time()
 
         with (
             mitm_ctx(),

--- a/crates/runner/mitm-addon/tests/test_request_handler_authority_validation.py
+++ b/crates/runner/mitm-addon/tests/test_request_handler_authority_validation.py
@@ -97,7 +97,7 @@ async def test_authority_validation_deny_response_logs_network_target(
     assert "code=secret" not in entry["url"]
     assert "#frag" not in entry["url"]
     assert entry["status"] == 403
-    assert flow.id not in mitm_addon._request_start_times
+    assert metadata_keys.HTTP_REQUEST_START_MONOTONIC not in flow.metadata
 
 
 async def test_matching_sni_and_host_allows_firewall_auth(

--- a/crates/runner/mitm-addon/tests/test_request_handler_passthrough.py
+++ b/crates/runner/mitm-addon/tests/test_request_handler_passthrough.py
@@ -1,5 +1,6 @@
 """Pass-through and auto-allow tests for the request hook."""
 
+import flow_metadata_keys as metadata_keys
 import mitm_addon
 from tests.request_handler_helpers import _single_firewall_vm, _write_registry
 
@@ -72,7 +73,7 @@ async def test_tracks_start_time(registry_file, real_flow, mitm_ctx):
     ):
         await mitm_addon.request(flow)
 
-    assert flow.id in mitm_addon._request_start_times
+    assert metadata_keys.HTTP_REQUEST_START_MONOTONIC in flow.metadata
 
 
 async def test_unregistered_vm_passes_through(registry_file, real_flow, mitm_ctx):

--- a/crates/runner/mitm-addon/tests/test_request_handler_usage_tracking.py
+++ b/crates/runner/mitm-addon/tests/test_request_handler_usage_tracking.py
@@ -7,6 +7,7 @@ from unittest.mock import AsyncMock, patch
 import pytest
 
 import auth
+import flow_metadata_keys as metadata_keys
 import mitm_addon
 import usage
 from tests.pending_helpers import assert_pending
@@ -155,7 +156,7 @@ async def test_unexpected_request_exception_releases_tracking(
     ):
         await mitm_addon.request(flow)
 
-    assert flow.id not in mitm_addon._request_start_times
+    assert metadata_keys.HTTP_REQUEST_START_MONOTONIC not in flow.metadata
     assert "_usage_flow_tracked" not in flow.metadata
     usage.write_pending_snapshot(flush_request_id="request-1")
     assert_pending(

--- a/crates/runner/mitm-addon/tests/test_response_handler.py
+++ b/crates/runner/mitm-addon/tests/test_response_handler.py
@@ -52,13 +52,13 @@ class TestResponseHandler:
         )
 
         # Simulate tracked start time
-        mitm_addon._request_start_times[flow.id] = time.time() - 0.1
+        flow.metadata[metadata_keys.HTTP_REQUEST_START_MONOTONIC] = time.monotonic() - 0.1
 
         with mitm_ctx():
             mitm_addon.response(flow)
 
         # Start time should be cleaned up
-        assert flow.id not in mitm_addon._request_start_times
+        assert metadata_keys.HTTP_REQUEST_START_MONOTONIC not in flow.metadata
 
         # Network log should be written
         lines = Path(log_path).read_text().splitlines()
@@ -171,7 +171,6 @@ class TestResponseHandler:
         mitm_addon.responseheaders(flow)
         response_stream(flow)(b"x" * 40)
         response_stream(flow)(b"y" * 60)
-        mitm_addon._request_start_times[flow.id] = time.time()
 
         with mitm_ctx():
             mitm_addon.response(flow)
@@ -203,7 +202,6 @@ class TestResponseHandler:
         response_stream(flow)(body[123:])
         assert flow.metadata["stream_buffer_state"]["truncated"] is True
         assert len(flow.metadata["stream_buffer"]) == body_utils.STREAM_BUFFER_LIMIT
-        mitm_addon._request_start_times[flow.id] = time.time()
 
         with mitm_ctx():
             mitm_addon.response(flow)
@@ -228,8 +226,6 @@ class TestResponseHandler:
             status_code=200, headers=header_map({"content-length": "50000"})
         )
 
-        mitm_addon._request_start_times[flow.id] = time.time()
-
         with mitm_ctx():
             mitm_addon.response(flow)
 
@@ -252,8 +248,6 @@ class TestResponseHandler:
         flow.response = tutils.tresp(
             status_code=200, headers=header_map({"content-type": "application/json"})
         )
-
-        mitm_addon._request_start_times[flow.id] = time.time()
 
         with mitm_ctx():
             mitm_addon.response(flow)
@@ -278,7 +272,6 @@ class TestResponseHandler:
         )
 
         mitm_addon.responseheaders(flow)
-        mitm_addon._request_start_times[flow.id] = time.time()
 
         with mitm_ctx():
             mitm_addon.response(flow)
@@ -307,7 +300,6 @@ class TestResponseHandler:
         mitm_addon.responseheaders(flow)
         response_stream(flow)(body[:123])
         response_stream(flow)(body[123:])
-        mitm_addon._request_start_times[flow.id] = time.time()
 
         with mitm_ctx():
             mitm_addon.response(flow)
@@ -446,15 +438,14 @@ class TestResponseHandler:
     def test_pops_start_time_even_when_run_id_absent(self, real_flow, mitm_ctx):
         # If the request handler tracked this flow's start time but the
         # metadata ended up without vm_run_id (registry missing runId),
-        # response() must still pop the entry to avoid leaking into
-        # ``_request_start_times``.
+        # response() must still pop the timing state.
         flow = real_flow(with_response=False)
-        mitm_addon._request_start_times[flow.id] = 12345.0
+        flow.metadata[metadata_keys.HTTP_REQUEST_START_MONOTONIC] = time.monotonic()
 
         with mitm_ctx():
             mitm_addon.response(flow)
 
-        assert flow.id not in mitm_addon._request_start_times
+        assert metadata_keys.HTTP_REQUEST_START_MONOTONIC not in flow.metadata
 
     def test_response_releases_streaming_state(self, tmp_path, real_flow, mitm_ctx):
         """The completed response hook must not retain parser/buffer closures."""
@@ -473,7 +464,6 @@ class TestResponseHandler:
 
         mitm_addon.responseheaders(flow)
         response_stream(flow)(b'{"model":"claude-sonnet-4-6"}')
-        mitm_addon._request_start_times[flow.id] = time.time()
 
         with mitm_ctx():
             mitm_addon.response(flow)
@@ -573,7 +563,6 @@ class TestResponseHandler:
         vm0_stream = response_stream(flow)
         vm0_stream(b'{"model":"claude-sonnet-4-6"}')
         flow.response.stream = external_stream
-        mitm_addon._request_start_times[flow.id] = time.time()
 
         with mitm_ctx():
             mitm_addon.response(flow)

--- a/crates/runner/mitm-addon/tests/test_usage_reporting_idempotency.py
+++ b/crates/runner/mitm-addon/tests/test_usage_reporting_idempotency.py
@@ -9,6 +9,7 @@ from unittest.mock import MagicMock, patch
 from mitmproxy.flow import Error
 from mitmproxy.test import tutils
 
+import flow_metadata_keys as metadata_keys
 import mitm_addon
 import usage
 from tests.flow_helpers import header_map
@@ -42,7 +43,7 @@ class TestUsageReportingIdempotency:
             status_code=200,
             headers=header_map({"content-type": "application/json"}),
         )
-        mitm_addon._request_start_times[flow.id] = time.time()
+        flow.metadata[metadata_keys.HTTP_REQUEST_START_MONOTONIC] = time.monotonic()
 
         with (
             mitm_ctx(),
@@ -50,6 +51,7 @@ class TestUsageReportingIdempotency:
         ):
             mock_opener.open.return_value = MagicMock()
             mitm_addon.response(flow)
+            assert metadata_keys.HTTP_REQUEST_START_MONOTONIC not in flow.metadata
             flow.error = Error("connection reset after response")
             mitm_addon.error(flow)
             usage.flush_usage_events(trigger="test")
@@ -84,7 +86,6 @@ class TestUsageReportingIdempotency:
             status_code=200,
             headers=header_map({"content-type": "application/json"}),
         )
-        mitm_addon._request_start_times[flow.id] = time.time()
 
         with (
             mitm_ctx(),
@@ -130,7 +131,6 @@ class TestUsageReportingIdempotency:
         flow.response = tutils.tresp(
             status_code=200, headers=header_map({"content-type": "text/event-stream"})
         )
-        mitm_addon._request_start_times[flow.id] = time.time()
 
         with (
             mitm_ctx(api_url="https://api.vm0.ai"),
@@ -170,7 +170,6 @@ class TestUsageReportingIdempotency:
         flow.response = tutils.tresp(
             status_code=200, headers=header_map({"content-type": "text/event-stream"})
         )
-        mitm_addon._request_start_times[flow.id] = time.time()
 
         with (
             mitm_ctx(api_url="https://api.vm0.ai"),

--- a/docs/testing/mitm-addon-testing.md
+++ b/docs/testing/mitm-addon-testing.md
@@ -110,12 +110,10 @@ The addon uses module-level caches. Reset between tests:
 
 ```python
 import pytest
-import mitm_addon
 import registry
 
 @pytest.fixture(autouse=True)
 def _reset_module_state():
-    mitm_addon._request_start_times.clear()
     registry.reset_cache_for_tests()
     yield
 ```


### PR DESCRIPTION
## Summary

- move HTTP request start timing from the module-level `_request_start_times` dict onto `flow.metadata`
- use monotonic elapsed time for HTTP and TCP latency calculations
- centralize HTTP/TCP timing metadata keys and remove test fixture cleanup for the old global dict

Fixes #15522

## Tests

- `PYTHONPATH="/tmp/vm2-mitm-addon-pydeps-15522:src" python3 -m pytest tests/test_request_handler_passthrough.py tests/test_request_handler_usage_tracking.py tests/test_request_handler_authority_validation.py tests/test_response_handler.py tests/test_error_handler.py tests/test_usage_reporting_idempotency.py tests/test_connection_hooks.py -q`
- `PYTHONPATH="/tmp/vm2-mitm-addon-pydeps-15522:src" python3 -m pytest tests/test_model_provider_response_usage.py tests/test_model_provider_stream_usage.py tests/test_connector_usage.py -q`
- `PATH="/tmp/vm2-mitm-addon-pydeps-15522/bin:$PATH" PYTHONPATH="/tmp/vm2-mitm-addon-pydeps-15522:src" python3 -m ruff format src tests`
- `PATH="/tmp/vm2-mitm-addon-pydeps-15522/bin:$PATH" PYTHONPATH="/tmp/vm2-mitm-addon-pydeps-15522:src" python3 -m ruff check src tests`
- `python3 -m py_compile src/mitm_addon.py src/flow_metadata_keys.py tests/conftest.py tests/test_response_handler.py tests/test_error_handler.py tests/test_request_handler_passthrough.py tests/test_request_handler_usage_tracking.py tests/test_request_handler_authority_validation.py tests/test_usage_reporting_idempotency.py tests/test_connection_hooks.py tests/test_model_provider_response_usage.py tests/test_model_provider_stream_usage.py tests/test_connector_usage.py`

Note: full `python3 -m pytest tests -q` currently reaches `1234 passed` before failing in `tests/test_x_billing.py` because local `turbo/packages/connectors/src/firewalls/index.ts` imports missing generated file `./tripo.generated`. That failure is unrelated to this Python timing refactor.
