### PR TITLE
fix(mitm-addon): redact query strings from logs

### DIFF
--- a/crates/runner/mitm-addon/src/mitm_addon.py
+++ b/crates/runner/mitm-addon/src/mitm_addon.py
@@ -197,6 +197,22 @@ def _set_network_log_target_from_url(flow: http.HTTPFlow, url: str) -> None:
     _set_network_log_target(flow, url=url, host=host, port=port)
 
 
+def _sanitize_url_for_log(url: str) -> str:
+    """Return a URL string safe for persistent logs.
+
+    Runtime metadata keeps the raw URL because firewall/auth and connector
+    billing can need query parameters. Persistent logs do not.
+    """
+    try:
+        parts = urllib.parse.urlsplit(url)
+    except ValueError:
+        cut_points = [index for marker in ("?", "#") if (index := url.find(marker)) != -1]
+        if not cut_points:
+            return url
+        return url[: min(cut_points)]
+    return urllib.parse.urlunsplit((parts.scheme, parts.netloc, parts.path, "", ""))
+
+
 def _network_log_target(flow: http.HTTPFlow, original_url: str) -> tuple[str, str, int]:
     target = flow.metadata.get(metadata_keys.NETWORK_LOG_TARGET)
     if target is not None:
@@ -223,7 +239,7 @@ def _http_network_log_entry(
         "host": host,
         "port": port,
         "method": flow.request.method,
-        "url": url,
+        "url": _sanitize_url_for_log(url),
         "status": status_code,
         "latency_ms": latency_ms,
         "request_size": request_size,
@@ -650,10 +666,11 @@ def response(flow: http.HTTPFlow) -> None:
 
     # Log errors to per-job proxy log and mitmproxy console
     if flow.response and flow.response.status_code >= _HTTP_STATUS_ERROR_MIN:
+        safe_url = _sanitize_url_for_log(original_url)
         log_proxy_entry(
             proxy_log_path,
             "warn",
-            f"Response {flow.response.status_code}: {original_url}",
+            f"Response {flow.response.status_code}: {safe_url}",
             type="http_error",
             status=flow.response.status_code,
         )
@@ -718,7 +735,7 @@ def error(flow: http.HTTPFlow) -> None:
     log_proxy_entry(
         proxy_log_path,
         "warn",
-        f"Error: {error_msg}: {original_url}",
+        f"Error: {error_msg}: {_sanitize_url_for_log(original_url)}",
         type="connection_error",
         error=error_msg,
     )

--- a/crates/runner/mitm-addon/tests/test_error_handler.py
+++ b/crates/runner/mitm-addon/tests/test_error_handler.py
@@ -134,9 +134,10 @@ class TestErrorHandler:
         flow = real_flow(with_response=False, host="slack.com", path="/api/chat.postMessage")
         flow.request.method = "POST"
         log_path = str(tmp_path / "network.jsonl")
+        raw_url = "https://slack.com/api/chat.postMessage?token=secret#frag"
         flow.metadata["vm_run_id"] = "run-abc-123"
         flow.metadata["vm_network_log_path"] = log_path
-        flow.metadata["original_url"] = "https://slack.com/api/chat.postMessage"
+        flow.metadata["original_url"] = raw_url
         flow.metadata["firewall_action"] = "ALLOW"
         flow.error = Error("connection reset by peer")
         mitm_addon._request_start_times[flow.id] = time.time() - 1.5
@@ -151,11 +152,13 @@ class TestErrorHandler:
         assert entry["action"] == "ALLOW"
         assert entry["host"] == "slack.com"
         assert entry["method"] == "POST"
+        assert entry["url"] == "https://slack.com/api/chat.postMessage"
         assert entry["status"] == 0
         assert entry["response_size"] == 0
         assert entry["error"] == "connection reset by peer"
         assert entry["latency_ms"] > 0
         assert_utc_millisecond_timestamp(entry["timestamp"])
+        assert flow.metadata["original_url"] == raw_url
 
     async def test_request_classified_error_logs_network_target(
         self, registry_file, real_flow, mitm_ctx, headers
@@ -236,15 +239,16 @@ class TestErrorHandler:
         flow.metadata["vm_run_id"] = "run-abc-123"
         flow.metadata["vm_network_log_path"] = log_path
         flow.metadata["vm_proxy_log_path"] = str(proxy_log)
-        flow.metadata["original_url"] = "https://slack.com/api/test"
+        flow.metadata["original_url"] = "https://slack.com/api/test?api_key=secret#frag"
         flow.error = Error("connection reset by peer")
 
         mitm_addon.error(flow)
 
         assert proxy_log.exists()
-        content = proxy_log.read_text()
-        assert "connection reset by peer" in content
-        assert "slack.com" in content
+        entry = json.loads(proxy_log.read_text().strip())
+        assert entry["message"] == "Error: connection reset by peer: https://slack.com/api/test"
+        assert "api_key=secret" not in entry["message"]
+        assert "#frag" not in entry["message"]
 
     def test_error_logs_connector_usage_for_x_stream(
         self, tmp_path, real_flow, mitm_ctx, headers, fresh_usage_executor

--- a/crates/runner/mitm-addon/tests/test_request_handler_authority_validation.py
+++ b/crates/runner/mitm-addon/tests/test_request_handler_authority_validation.py
@@ -62,13 +62,14 @@ async def test_authority_validation_deny_response_logs_network_target(
     tmp_path, real_flow, mitm_ctx, fake_firewall_headers, headers
 ):
     reg_path = _write_github_firewall_registry(tmp_path)
+    raw_url = "https://attacker.example.com:8443/repos?code=secret#frag"
     flow = real_flow(
         with_response=False,
         client_ip="10.200.0.5",
         host="203.0.113.10",
         port=8443,
         sni="attacker.example.com",
-        path="/repos",
+        path="/repos?code=secret#frag",
         request_headers=headers(("Host", "api.github.com")),
     )
 
@@ -81,6 +82,8 @@ async def test_authority_validation_deny_response_logs_network_target(
     assert flow.response is not None
     assert flow.response.status_code == 403
     auth_fetch.assert_not_called()
+    assert flow.metadata["original_url"] == raw_url
+    assert flow.metadata[metadata_keys.NETWORK_LOG_TARGET]["url"] == raw_url
 
     with mitm_ctx():
         mitm_addon.response(flow)
@@ -91,6 +94,8 @@ async def test_authority_validation_deny_response_logs_network_target(
     assert entry["host"] == "attacker.example.com"
     assert entry["port"] == 8443
     assert entry["url"] == "https://attacker.example.com:8443/repos"
+    assert "code=secret" not in entry["url"]
+    assert "#frag" not in entry["url"]
     assert entry["status"] == 403
     assert flow.id not in mitm_addon._request_start_times
 

--- a/crates/runner/mitm-addon/tests/test_response_handler.py
+++ b/crates/runner/mitm-addon/tests/test_response_handler.py
@@ -4,6 +4,7 @@ import json
 import time
 from pathlib import Path
 
+import pytest
 from mitmproxy import http
 from mitmproxy.test import tutils
 
@@ -92,6 +93,46 @@ class TestResponseHandler:
         assert entry["port"] == 9443
         assert entry["url"] == "https://target.example.com:9443/path"
 
+    @pytest.mark.parametrize(
+        ("raw_url", "expected_url"),
+        [
+            (
+                "https://target.example.com:9443/path?access_token=secret#fragment",
+                "https://target.example.com:9443/path",
+            ),
+            (
+                "https://[invalid.example.com/path?access_token=secret#fragment",
+                "https://[invalid.example.com/path",
+            ),
+        ],
+    )
+    def test_network_log_target_url_strips_query_and_fragment(
+        self, tmp_path, real_flow, mitm_ctx, raw_url, expected_url
+    ):
+        flow = real_flow(with_response=False, host="request.example.com")
+        log_path = str(tmp_path / "network.jsonl")
+
+        flow.metadata["vm_run_id"] = "run-abc-123"
+        flow.metadata["vm_network_log_path"] = log_path
+        flow.metadata["firewall_action"] = "ALLOW"
+        flow.metadata["original_url"] = raw_url
+        flow.metadata[metadata_keys.NETWORK_LOG_TARGET] = {
+            "url": raw_url,
+            "host": "target.example.com",
+            "port": 9443,
+        }
+        flow.response = tutils.tresp(status_code=200, headers=header_map({"content-length": "0"}))
+
+        with mitm_ctx():
+            mitm_addon.response(flow)
+
+        entry = json.loads(Path(log_path).read_text().strip())
+        assert entry["host"] == "target.example.com"
+        assert entry["port"] == 9443
+        assert entry["url"] == expected_url
+        assert flow.metadata["original_url"] == raw_url
+        assert flow.metadata[metadata_keys.NETWORK_LOG_TARGET]["url"] == raw_url
+
     def test_logs_legacy_target_when_original_url_port_is_invalid(
         self, tmp_path, real_flow, mitm_ctx
     ):
@@ -101,7 +142,7 @@ class TestResponseHandler:
         flow.metadata["vm_run_id"] = "run-abc-123"
         flow.metadata["vm_network_log_path"] = log_path
         flow.metadata["firewall_action"] = "ALLOW"
-        flow.metadata["original_url"] = "https://invalid.example.com:bad/path"
+        flow.metadata["original_url"] = "https://invalid.example.com:bad/path?secret=value#frag"
         flow.response = tutils.tresp(status_code=200, headers=header_map({"content-length": "0"}))
 
         with mitm_ctx():
@@ -390,16 +431,17 @@ class TestResponseHandler:
         flow.metadata["vm_proxy_log_path"] = str(proxy_log)
         flow.metadata["firewall_action"] = "ALLOW"
         flow.metadata["firewall_rule"] = "domain:*.example.com"
-        flow.metadata["original_url"] = "https://api.example.com/"
+        flow.metadata["original_url"] = "https://api.example.com/fail?api_key=secret#frag"
 
         flow.response = tutils.tresp(status_code=500, headers=http.Headers())
 
         mitm_addon.response(flow)
 
         assert proxy_log.exists()
-        content = proxy_log.read_text()
-        assert "500" in content
-        assert "api.example.com" in content
+        entry = json.loads(proxy_log.read_text().strip())
+        assert entry["message"] == "Response 500: https://api.example.com/fail"
+        assert "api_key=secret" not in entry["message"]
+        assert "#frag" not in entry["message"]
 
     def test_pops_start_time_even_when_run_id_absent(self, real_flow, mitm_ctx):
         # If the request handler tracked this flow's start time but the


### PR DESCRIPTION
## Summary

- strip query strings and fragments from mitm HTTP network log URLs
- use the same log-safe URL in HTTP error and connection error proxy messages
- preserve raw runtime URL metadata for firewall/auth behavior and connector billing

Fixes #15533

## Tests

- `pytest crates/runner/mitm-addon/tests/test_response_handler.py crates/runner/mitm-addon/tests/test_error_handler.py crates/runner/mitm-addon/tests/test_request_handler_authority_validation.py`
- `pytest crates/runner/mitm-addon/tests`
- `ruff check crates/runner/mitm-addon/src/mitm_addon.py crates/runner/mitm-addon/tests/test_response_handler.py crates/runner/mitm-addon/tests/test_error_handler.py crates/runner/mitm-addon/tests/test_request_handler_authority_validation.py`
- `python3 -m py_compile crates/runner/mitm-addon/src/mitm_addon.py`
- `git diff --check -- crates/runner/mitm-addon/src/mitm_addon.py crates/runner/mitm-addon/tests/test_response_handler.py crates/runner/mitm-addon/tests/test_error_handler.py crates/runner/mitm-addon/tests/test_request_handler_authority_validation.py`
