### PR TITLE
fix: block unsafe firewall dot-segment paths

### DIFF
--- a/crates/runner/mitm-addon/src/matching.py
+++ b/crates/runner/mitm-addon/src/matching.py
@@ -8,6 +8,8 @@ from types import MappingProxyType
 from typing import Literal, NamedTuple
 from urllib.parse import urlsplit
 
+from path_security import has_unsafe_dot_segment
+
 _SEGMENT_ERROR_HINT = 'use "{name}", "prefix{name}", "{name}suffix", or "prefix{name}suffix"'
 
 # A segment with two or more ``{`` braces contains more than one parameter,
@@ -935,6 +937,7 @@ FirewallBlockReason = Literal[
     "unknown_endpoint",
     "malformed_firewall_config",
     "malformed_network_policy",
+    "unsafe_path",
 ]
 
 
@@ -992,6 +995,16 @@ def match_compiled_firewall_request(
                 continue
 
             rel_path, base_params = base_result
+
+            if has_unsafe_dot_segment(url_parts.path):
+                return FirewallBlock(
+                    api_entry.base.raw,
+                    fw_entry.name,
+                    upper_method,
+                    rel_path,
+                    (),
+                    "unsafe_path",
+                )
 
             if blocked_match is None:
                 blocked_match = (
@@ -1124,6 +1137,10 @@ def match_firewall_request(
     if not vm_firewalls:
         return None
 
+    url_parts = _split_base_match_url(url)
+    if url_parts is None:
+        return None
+
     compiled_network_policies = _ensure_compiled_network_policies(network_policies)
 
     # Track the first matched base URL and api_entry for unknown endpoint auth.
@@ -1152,6 +1169,16 @@ def match_firewall_request(
                 continue
 
             rel_path, base_params = base_result
+
+            if has_unsafe_dot_segment(url_parts.path):
+                return FirewallBlock(
+                    base,
+                    fw_name,
+                    upper_method,
+                    rel_path,
+                    (),
+                    "unsafe_path",
+                )
 
             # Base URL matched
             if blocked_match is None:

--- a/crates/runner/mitm-addon/src/matching.py
+++ b/crates/runner/mitm-addon/src/matching.py
@@ -963,7 +963,7 @@ def match_compiled_firewall_request(
     Returns:
       FirewallAllow — granted permission matched or unknown endpoint allowed
       FirewallBlock — permission denied, unknown endpoint blocked, or matched
-        malformed firewall/network policy config failed closed
+        malformed firewall/network policy config or unsafe path failed closed
       None — no base URL match (not a firewall request)
 
     ``unknownPolicy="ask"`` is treated as block at the proxy layer.
@@ -1131,7 +1131,7 @@ def match_firewall_request(
     Returns:
       FirewallAllow — granted permission matched or unknown endpoint allowed
       FirewallBlock — base URL matched but permission denied, unknown blocked,
-        or malformed network policy failed closed
+        unsafe path blocked, or malformed network policy failed closed
       None — no base URL match (not a firewall request)
     """
     if not vm_firewalls:

--- a/crates/runner/mitm-addon/src/mitm_addon.py
+++ b/crates/runner/mitm-addon/src/mitm_addon.py
@@ -383,16 +383,15 @@ async def request(flow: http.HTTPFlow) -> None:
             )
             if isinstance(result, matching.FirewallBlock):
                 proxy_log_path = flow.metadata.get(metadata_keys.VM_PROXY_LOG_PATH, "")
-                block_message = (
-                    "malformed network policy"
-                    if result.reason == "malformed_network_policy"
-                    else "no matching permission"
-                )
-                response_message = (
-                    "Request blocked: malformed network policy"
-                    if result.reason == "malformed_network_policy"
-                    else "Request blocked: no matching permission rule"
-                )
+                if result.reason == "malformed_network_policy":
+                    block_message = "malformed network policy"
+                    response_message = "Request blocked: malformed network policy"
+                elif result.reason == "unsafe_path":
+                    block_message = "unsafe path"
+                    response_message = "Request blocked: unsafe path"
+                else:
+                    block_message = "no matching permission"
+                    response_message = "Request blocked: no matching permission rule"
                 log_proxy_entry(
                     proxy_log_path,
                     "warn",

--- a/crates/runner/mitm-addon/src/path_security.py
+++ b/crates/runner/mitm-addon/src/path_security.py
@@ -1,0 +1,17 @@
+"""URL path safety helpers."""
+
+import urllib.parse
+
+_DOT_SEGMENTS = {".", ".."}
+
+
+def has_unsafe_dot_segment(path: str) -> bool:
+    """Return True when a URL path contains dot-segment traversal."""
+    return any(_segment_has_unsafe_dot(raw_segment) for raw_segment in path.split("/"))
+
+
+def _segment_has_unsafe_dot(raw_segment: str) -> bool:
+    decoded = urllib.parse.unquote(raw_segment)
+    if decoded in _DOT_SEGMENTS:
+        return True
+    return any(part in _DOT_SEGMENTS for part in decoded.split("/"))

--- a/crates/runner/mitm-addon/src/url_utils.py
+++ b/crates/runner/mitm-addon/src/url_utils.py
@@ -11,6 +11,8 @@ from typing import Literal
 from mitmproxy import http
 from mitmproxy.net.http import url as mitm_url
 
+from path_security import has_unsafe_dot_segment
+
 # Well-known IANA ports for HTTP and HTTPS.  When the connection uses the
 # default port for its scheme we omit ``:port`` from the reconstructed URL.
 _HTTP_DEFAULT_PORT = 80
@@ -340,6 +342,9 @@ def build_rewrite_url(
     incoming request (no leading ``?``). Query key precedence is
     ``resolved_query`` > resolved base query > original request query.
     """
+    if has_unsafe_dot_segment(rel_path):
+        raise ValueError("Unsafe rewrite path: dot segments are not allowed")
+
     base_parsed = urllib.parse.urlsplit(resolved_base)
 
     # Append rel_path to the base path portion

--- a/crates/runner/mitm-addon/src/url_utils.py
+++ b/crates/runner/mitm-addon/src/url_utils.py
@@ -340,7 +340,9 @@ def build_rewrite_url(
     path from the firewall match, and query strings from trusted auth data
     and the original request. ``orig_query`` is the raw query string of the
     incoming request (no leading ``?``). Query key precedence is
-    ``resolved_query`` > resolved base query > original request query.
+    ``resolved_query`` > resolved base query > original request query. Dot
+    segments in ``rel_path`` are rejected as an invariant; firewall matching
+    should already have blocked them before auth is applied.
     """
     if has_unsafe_dot_segment(rel_path):
         raise ValueError("Unsafe rewrite path: dot segments are not allowed")

--- a/crates/runner/mitm-addon/tests/test_compiled_firewall_matching.py
+++ b/crates/runner/mitm-addon/tests/test_compiled_firewall_matching.py
@@ -233,6 +233,70 @@ class TestCompiledFirewallMatching:
         assert isinstance(compiled, matching.FirewallBlock)
         assert compiled.reason == "unknown_endpoint"
 
+    @pytest.mark.parametrize(
+        "url",
+        [
+            "https://api.example.com/items/../admin",
+            "https://api.example.com/items/%2e%2e/admin",
+        ],
+    )
+    def test_matches_raw_for_unsafe_path_block(self, url):
+        fws = wrap_firewalls(
+            [
+                {
+                    "base": "https://api.example.com",
+                    "auth": {"headers": {"Authorization": "Bearer token"}},
+                    "permissions": [
+                        {"name": "full-access", "rules": ["ANY /{path+}"]},
+                    ],
+                }
+            ],
+            name="example",
+        )
+        policies = {"example": {"allow": ["full-access"], "deny": [], "unknownPolicy": "allow"}}
+
+        raw = matching.match_firewall_request(url, "GET", fws, policies)
+        compiled = matching.match_compiled_firewall_request(
+            url,
+            "GET",
+            self._compiled(fws),
+            policies,
+        )
+
+        self._assert_same_result(raw, compiled)
+        assert isinstance(compiled, matching.FirewallBlock)
+        assert compiled.reason == "unsafe_path"
+        assert compiled.permissions == ()
+
+    def test_matches_raw_for_unsafe_path_consumed_by_parameterized_base(self):
+        fws = wrap_firewalls(
+            [
+                {
+                    "base": "https://api.example.com/api/{tenant}",
+                    "auth": {"headers": {"Authorization": "Bearer token"}},
+                    "permissions": [
+                        {"name": "admin", "rules": ["GET /admin"]},
+                    ],
+                }
+            ],
+            name="example",
+        )
+        url = "https://api.example.com/api/%2e%2e/admin"
+        policies = {"example": {"allow": ["admin"], "deny": [], "unknownPolicy": "allow"}}
+
+        raw = matching.match_firewall_request(url, "GET", fws, policies)
+        compiled = matching.match_compiled_firewall_request(
+            url,
+            "GET",
+            self._compiled(fws),
+            policies,
+        )
+
+        self._assert_same_result(raw, compiled)
+        assert isinstance(compiled, matching.FirewallBlock)
+        assert compiled.reason == "unsafe_path"
+        assert compiled.path == "/admin"
+
     def test_matches_raw_for_ask_permission_block(self):
         fws = wrap_firewalls(
             [

--- a/crates/runner/mitm-addon/tests/test_firewall_matching.py
+++ b/crates/runner/mitm-addon/tests/test_firewall_matching.py
@@ -73,6 +73,91 @@ class TestMatchFirewallRequest:
         assert isinstance(result, matching.FirewallAllow)
         assert result.permission == "full-access"
 
+    def test_unsafe_path_blocks_before_greedy_permission_allow(self, headers):
+        fw_configs = wrap_firewalls(
+            [
+                {
+                    "base": "https://api.github.com",
+                    "auth": {"headers": {}},
+                    "permissions": [{"name": "full-access", "rules": ["ANY /{path+}"]}],
+                }
+            ],
+            name="github",
+        )
+        result = matching.match_firewall_request(
+            "https://api.github.com/repos/../admin",
+            "GET",
+            fw_configs,
+            network_policies=grant_all(fw_configs, unknown_policy="allow"),
+        )
+        assert isinstance(result, matching.FirewallBlock)
+        assert result.reason == "unsafe_path"
+        assert result.path == "/repos/../admin"
+        assert result.permissions == ()
+
+    def test_encoded_unsafe_path_blocks_before_unknown_policy_allow(self, headers):
+        fw_configs = wrap_firewalls(
+            [
+                {
+                    "base": "https://api.github.com",
+                    "auth": {"headers": {}},
+                    "permissions": [{"name": "repo-read", "rules": ["GET /repos/{owner}"]}],
+                }
+            ],
+            name="github",
+        )
+        result = matching.match_firewall_request(
+            "https://api.github.com/users/%2e%2e/admin",
+            "GET",
+            fw_configs,
+            network_policies=grant_all(fw_configs, unknown_policy="allow"),
+        )
+        assert isinstance(result, matching.FirewallBlock)
+        assert result.reason == "unsafe_path"
+        assert result.path == "/users/%2e%2e/admin"
+        assert result.permissions == ()
+
+    def test_unsafe_path_consumed_by_parameterized_base_blocks(self, headers):
+        fw_configs = wrap_firewalls(
+            [
+                {
+                    "base": "https://api.example.com/api/{tenant}",
+                    "auth": {"headers": {}},
+                    "permissions": [{"name": "admin", "rules": ["GET /admin"]}],
+                }
+            ],
+            name="example",
+        )
+        result = matching.match_firewall_request(
+            "https://api.example.com/api/%2e%2e/admin",
+            "GET",
+            fw_configs,
+            network_policies=grant_all(fw_configs, unknown_policy="allow"),
+        )
+        assert isinstance(result, matching.FirewallBlock)
+        assert result.reason == "unsafe_path"
+        assert result.path == "/admin"
+
+    def test_dot_like_regular_segments_can_still_allow(self, headers):
+        fw_configs = wrap_firewalls(
+            [
+                {
+                    "base": "https://api.github.com",
+                    "auth": {"headers": {}},
+                    "permissions": [{"name": "full-access", "rules": ["ANY /{path+}"]}],
+                }
+            ],
+            name="github",
+        )
+        result = matching.match_firewall_request(
+            "https://api.github.com/repos/..hidden/a..b",
+            "GET",
+            fw_configs,
+            network_policies=grant_all(fw_configs),
+        )
+        assert isinstance(result, matching.FirewallAllow)
+        assert result.permission == "full-access"
+
     def test_method_case_insensitive(self, headers):
         fw_configs = wrap_firewalls(
             [

--- a/crates/runner/mitm-addon/tests/test_path_security.py
+++ b/crates/runner/mitm-addon/tests/test_path_security.py
@@ -1,0 +1,36 @@
+"""Tests for URL path safety helpers."""
+
+import pytest
+
+import path_security
+
+
+@pytest.mark.parametrize(
+    "path",
+    [
+        "/api/./admin",
+        "/api/../admin",
+        "/api/%2e/admin",
+        "/api/%2e%2e/admin",
+        "/api/%2E%2E/admin",
+        "/api/%2e%2e%2fadmin",
+        "/api/foo%2F..",
+    ],
+)
+def test_has_unsafe_dot_segment_blocks_dot_segments(path):
+    assert path_security.has_unsafe_dot_segment(path) is True
+
+
+@pytest.mark.parametrize(
+    "path",
+    [
+        "/",
+        "/api/users",
+        "/api/..hidden/admin",
+        "/api/a..b/admin",
+        "/api/foo%2Fbar",
+        "/api/%2e%2ehidden",
+    ],
+)
+def test_has_unsafe_dot_segment_allows_regular_segments(path):
+    assert path_security.has_unsafe_dot_segment(path) is False

--- a/crates/runner/mitm-addon/tests/test_request_handler_firewall_dispatch.py
+++ b/crates/runner/mitm-addon/tests/test_request_handler_firewall_dispatch.py
@@ -376,3 +376,65 @@ async def test_firewall_unknown_policy_allow_writes_empty_permission_metadata(
     assert flow.metadata["firewall_rule_match"] == ""
     assert flow.metadata["firewall_params"] == {"region": "us"}
     assert flow.request.headers["Authorization"] == "Bearer x"
+
+
+async def test_firewall_unsafe_path_blocks_before_auth_injection(
+    tmp_path, real_flow, mitm_ctx, fake_firewall_headers, headers
+):
+    """Unsafe dot-segment paths block before trusted auth is injected."""
+    reg_path = _write_registry(
+        tmp_path,
+        vm_info=_single_firewall_vm(
+            tmp_path,
+            api_entry={
+                "base": "https://api.github.com",
+                "auth": {"headers": {"Authorization": "Bearer ${{ secrets.GITHUB_TOKEN }}"}},
+                "permissions": [
+                    {
+                        "name": "full-access",
+                        "rules": ["ANY /{path+}"],
+                    },
+                ],
+            },
+            network_policy={
+                "allow": ["full-access"],
+                "deny": [],
+                "ask": [],
+                "unknownPolicy": "allow",
+            },
+        ),
+    )
+
+    flow = real_flow(
+        with_response=False,
+        client_ip="10.200.0.5",
+        host="api.github.com",
+        path="/repos/%2e%2e/admin",
+    )
+
+    with (
+        mitm_ctx(registry_path=str(reg_path), api_url="https://api.vm0.ai"),
+        fake_firewall_headers() as mock_headers,
+    ):
+        await mitm_addon.request(flow)
+
+    mock_headers.assert_not_called()
+    assert flow.response is not None
+    assert flow.response.status_code == 403
+    assert flow.metadata["firewall_action"] == "DENY"
+    assert flow.metadata["firewall_base"] == "https://api.github.com"
+    assert flow.metadata["firewall_name"] == "github"
+    assert "Authorization" not in flow.request.headers
+    body = json.loads(flow.response.content)
+    assert body["error"] == "permission_denied"
+    assert body["message"] == "Request blocked: unsafe path"
+    assert body["method"] == "GET"
+    assert body["path"] == "/repos/%2e%2e/admin"
+    assert body["name"] == "github"
+    assert body["permissions"] == []
+    assert body["reason"] == "unsafe_path"
+    assert body["base"] == "https://api.github.com"
+    proxy_log_entry = json.loads((tmp_path / "proxy.jsonl").read_text().splitlines()[0])
+    assert proxy_log_entry["type"] == "firewall_block"
+    assert proxy_log_entry["name"] == "github"
+    assert proxy_log_entry["reason"] == "unsafe_path"

--- a/crates/runner/mitm-addon/tests/test_url_utils.py
+++ b/crates/runner/mitm-addon/tests/test_url_utils.py
@@ -1,5 +1,7 @@
 """Tests for URL reconstruction and rewrite utilities."""
 
+import pytest
+
 import url_utils
 
 
@@ -296,3 +298,21 @@ class TestBuildRewriteUrl:
             "",
         )
         assert url == "https://example.com/hook"
+
+    @pytest.mark.parametrize(
+        "rel_path",
+        [
+            "/./admin",
+            "/../admin",
+            "/%2e/admin",
+            "/%2e%2e/admin",
+            "/%2e%2e%2fadmin",
+        ],
+    )
+    def test_unsafe_rel_path_is_rejected(self, rel_path):
+        with pytest.raises(ValueError, match="Unsafe rewrite path"):
+            url_utils.build_rewrite_url(
+                "https://example.com/hook",
+                rel_path,
+                "",
+            )


### PR DESCRIPTION
## Summary

- block firewall-matched requests with unsafe literal or percent-encoded dot segments before permission matching or auth injection
- add `unsafe_path` firewall block reason and user-facing 403 message
- reject unsafe `auth.base` rewrite rel paths as a defense-in-depth invariant
- cover raw/compiled matcher parity, request dispatch, rewrite utility, and helper edge cases

Fixes #15532

## Tests

- `python3 -m pytest tests/test_path_security.py tests/test_firewall_matching.py tests/test_compiled_firewall_matching.py tests/test_request_handler_firewall_dispatch.py tests/test_url_utils.py`
- `python3 -m ruff check src/path_security.py src/matching.py src/mitm_addon.py src/url_utils.py tests/test_path_security.py tests/test_firewall_matching.py tests/test_compiled_firewall_matching.py tests/test_request_handler_firewall_dispatch.py tests/test_url_utils.py`
- `pnpm -F @vm0/firewalls-generator generate`
- `python3 -m pytest tests`
- `python3 -m ruff check src tests`
