### PR TITLE
test: return future from sync usage executor

### DIFF
--- a/crates/runner/mitm-addon/tests/conftest.py
+++ b/crates/runner/mitm-addon/tests/conftest.py
@@ -15,8 +15,8 @@ Fixtures here exist for two reasons:
 
 import contextlib
 import json
-from collections.abc import Iterator
-from concurrent.futures import ThreadPoolExecutor
+from collections.abc import Callable, Iterator
+from concurrent.futures import Future, ThreadPoolExecutor
 from typing import Any
 from unittest.mock import AsyncMock, MagicMock, patch
 
@@ -304,21 +304,54 @@ def sync_usage_executor():
     appear on the mock by the time they inspect it need submission to
     happen inline rather than on a background thread — otherwise they
     have to thread ``fresh_usage_executor`` + ``shutdown(wait=True)``
-    boilerplate through every caller.  The stub's ``submit`` just runs
-    the function synchronously; the original executor is restored on
-    teardown.
+    boilerplate through every caller.  The inline executor returns real
+    ``Future`` objects while still running the function synchronously;
+    the original executor is restored on teardown.
     """
 
-    class _SyncExecutor:
-        def submit(self, fn, *args, **kwargs):
-            fn(*args, **kwargs)
+    class _InlineExecutor:
+        def __init__(self) -> None:
+            self._futures: list[Future[Any]] = []
+            self._shutdown = False
+
+        def submit(
+            self,
+            fn: Callable[..., Any],
+            *args: Any,
+            **kwargs: Any,
+        ) -> Future[Any]:
+            if self._shutdown:
+                raise RuntimeError("cannot schedule new futures after shutdown")
+
+            future: Future[Any] = Future()
+            self._futures.append(future)
+            try:
+                result = fn(*args, **kwargs)
+            except Exception as error:
+                future.set_exception(error)
+            else:
+                future.set_result(result)
+            return future
+
+        def shutdown(self, wait: bool = True, *, cancel_futures: bool = False) -> None:
+            self._shutdown = True
+            if not wait:
+                return
+            futures = self._futures
+            self._futures = []
+            for future in futures:
+                future.result()
 
     original = usage.webhook.usage_executor
-    usage.webhook.usage_executor = _SyncExecutor()
+    executor = _InlineExecutor()
+    usage.webhook.usage_executor = executor
     try:
-        yield usage.webhook.usage_executor
+        yield executor
     finally:
-        usage.webhook.usage_executor = original
+        try:
+            executor.shutdown(wait=True)
+        finally:
+            usage.webhook.usage_executor = original
 
 
 @pytest.fixture

--- a/crates/runner/mitm-addon/tests/test_sync_usage_executor.py
+++ b/crates/runner/mitm-addon/tests/test_sync_usage_executor.py
@@ -1,0 +1,42 @@
+"""Tests for the synchronous usage executor fixture."""
+
+from concurrent.futures import Future
+
+import pytest
+
+
+def test_sync_usage_executor_returns_future_and_runs_inline(sync_usage_executor):
+    calls: list[str] = []
+
+    def record(value: str) -> str:
+        calls.append(value)
+        return f"result-{value}"
+
+    future = sync_usage_executor.submit(record, "alpha")
+
+    assert calls == ["alpha"]
+    assert isinstance(future, Future)
+    assert future.done()
+    assert future.result() == "result-alpha"
+    assert future.exception() is None
+
+
+def test_sync_usage_executor_captures_callable_exceptions(sync_usage_executor):
+    def fail() -> None:
+        raise ValueError("boom")
+
+    future = sync_usage_executor.submit(fail)
+
+    assert future.done()
+    assert isinstance(future.exception(), ValueError)
+    with pytest.raises(ValueError, match="boom"):
+        future.result()
+    with pytest.raises(ValueError, match="boom"):
+        sync_usage_executor.shutdown(wait=True)
+
+
+def test_sync_usage_executor_rejects_submit_after_shutdown(sync_usage_executor):
+    sync_usage_executor.shutdown(wait=True)
+
+    with pytest.raises(RuntimeError, match="shutdown"):
+        sync_usage_executor.submit(lambda: None)


### PR DESCRIPTION
## Summary
- Replace the mitm-addon `sync_usage_executor` stub with an inline executor that returns real `Future` objects.
- Capture callable results/exceptions on the returned future while preserving inline execution for deterministic tests.
- Drain submitted futures on shutdown/fixture teardown and add focused contract tests for success, exception, and shutdown behavior.

Closes #15481

## Tests
- `PYTHONPATH=/tmp/vm0-mitm-addon-deps:src python3 -m pytest tests/test_sync_usage_executor.py -v`
- `PYTHONPATH=/tmp/vm0-mitm-addon-deps:src python3 -m pytest tests/test_webhook.py tests/test_connector_usage.py tests/test_error_handler.py tests/test_counters.py tests/test_sync_usage_executor.py -v`
- `PYTHONPATH=/tmp/vm0-mitm-addon-deps python3 -m ruff check tests/conftest.py tests/test_webhook.py tests/test_connector_usage.py tests/test_error_handler.py tests/test_counters.py tests/test_sync_usage_executor.py`
- `PYTHONPATH=/tmp/vm0-mitm-addon-deps python3 -m ruff format --check tests/conftest.py tests/test_sync_usage_executor.py`
- `PYTHONPATH=/tmp/vm0-mitm-addon-deps python3 -m basedpyright -p .`
- `git diff --check`
