### PR TITLE
test: assert model provider warning log content

### DIFF
--- a/crates/runner/mitm-addon/tests/test_model_provider_usage.py
+++ b/crates/runner/mitm-addon/tests/test_model_provider_usage.py
@@ -222,7 +222,10 @@ class TestReportModelProviderUsage:
 
         mock_opener.open.assert_not_called()  # urllib external boundary (#9991)
         assert proxy_log.exists()
-        assert "missing sandbox_token or api_url" in proxy_log.read_text()
+        [entry] = [json.loads(line) for line in proxy_log.read_text().splitlines()]
+        assert entry["level"] == "warn"
+        assert entry["message"] == "Cannot report usage event: missing sandbox_token or api_url"
+        assert entry["type"] == "usage_event"
 
     def test_warns_when_missing_api_url(self, tmp_path, real_flow, fresh_usage_executor):
         """Should write to proxy log and skip when api_url is empty."""
@@ -244,6 +247,10 @@ class TestReportModelProviderUsage:
 
         mock_opener.open.assert_not_called()  # urllib external boundary (#9991)
         assert proxy_log.exists()
+        [entry] = [json.loads(line) for line in proxy_log.read_text().splitlines()]
+        assert entry["level"] == "warn"
+        assert entry["message"] == "Cannot report usage event: missing sandbox_token or api_url"
+        assert entry["type"] == "usage_event"
 
     def test_source_dedupe_uses_flow_id_when_message_id_missing(
         self, real_flow, fresh_usage_executor


### PR DESCRIPTION
## Summary
- parse proxy JSONL entries in missing model-provider setup tests
- assert warning level, message, and usage_event type for missing sandbox token and API URL cases

## Tests
- pytest crates/runner/mitm-addon/tests/test_model_provider_usage.py
- pytest crates/runner/mitm-addon/tests/test_model_provider_usage.py crates/runner/mitm-addon/tests/test_webhook.py
- pytest crates/runner/mitm-addon/tests
- ruff check crates/runner/mitm-addon/tests/test_model_provider_usage.py
- ruff format --check crates/runner/mitm-addon/tests/test_model_provider_usage.py
- git diff --check origin/main...HEAD

Closes #15479