### PR TITLE
test: preserve sync executor future semantics

### DIFF
--- a/crates/runner/mitm-addon/tests/conftest.py
+++ b/crates/runner/mitm-addon/tests/conftest.py
@@ -298,7 +298,7 @@ def fake_firewall_headers():
 def sync_usage_executor():
     """Swap ``usage.webhook.usage_executor`` for a synchronous stub.
 
-    Tests that mock ``usage._opener`` and want the webhook payloads to
+    Tests that mock ``usage.webhook._opener`` and want the webhook payloads to
     appear on the mock by the time they inspect it need submission to
     happen inline rather than on a background thread — otherwise they
     have to thread ``fresh_usage_executor`` + ``shutdown(wait=True)``

--- a/crates/runner/mitm-addon/tests/test_webhook.py
+++ b/crates/runner/mitm-addon/tests/test_webhook.py
@@ -233,6 +233,28 @@ class TestUsageWebhookDelivery:
         assert entry["payload"]["error"] == "payload-error"
         assert entry["payload"]["attempt"] == 99
 
+    def test_sync_executor_worker_error_preserves_other_pending_reports(
+        self, tmp_path, sync_usage_executor
+    ):
+        """Synchronous executor fixture should store worker exceptions on its Future."""
+        proxy_log = tmp_path / "proxy.jsonl"
+        usage.set_pending_path(str(tmp_path / "usage-pending"))
+        usage.counters.increment_pending_reports()
+
+        with patch.object(usage.webhook, "_opener") as mock_opener:
+            mock_opener.open.side_effect = TypeError("boom")
+            usage.webhook._enqueue_webhook(
+                "https://api.vm0.ai/api/webhooks/agent/usage-event",
+                "tok",
+                {"runId": "run-1", "events": []},
+                str(proxy_log),
+                "usage",
+            )
+
+        assert mock_opener.open.call_count == 1  # urllib external boundary (#9991)
+        assert usage.counters._pending_reports == 1
+        assert "non-retryable" in proxy_log.read_text()
+
     def test_sleeps_between_retries(self, tmp_path, real_flow, fresh_usage_executor):
         flow = self._model_flow(real_flow, tmp_path)
         with (

--- a/crates/runner/mitm-addon/tests/test_webhook.py
+++ b/crates/runner/mitm-addon/tests/test_webhook.py
@@ -254,6 +254,8 @@ class TestUsageWebhookDelivery:
         assert mock_opener.open.call_count == 1  # urllib external boundary (#9991)
         assert usage.counters._pending_reports == 1
         assert "non-retryable" in proxy_log.read_text()
+        with pytest.raises(TypeError, match="boom"):
+            sync_usage_executor.shutdown(wait=True)
 
     def test_sleeps_between_retries(self, tmp_path, real_flow, fresh_usage_executor):
         flow = self._model_flow(real_flow, tmp_path)


### PR DESCRIPTION
## Summary

- make `sync_usage_executor` execute inline while returning a `Future`, matching `ThreadPoolExecutor.submit()` worker exception semantics
- add shutdown tracking so submit-after-shutdown still raises like a real executor submit failure
- cover non-retryable webhook worker failures so unrelated pending reports are not double-decremented

Fixes #15480

## Tests

- `python3 -m pytest tests/test_webhook.py::TestUsageWebhookDelivery::test_sync_executor_worker_error_preserves_other_pending_reports`
- `python3 -m pytest tests/test_webhook.py tests/test_counters.py tests/test_connector_usage.py tests/test_error_handler.py`
- `python3 -m pytest tests`
- `python3 -m ruff check src tests`
- `python3 -m ruff format --check tests/conftest.py tests/test_webhook.py`
- `git diff --check`
