### PR TITLE
perf(nbd-cow): reuse dispatch payload buffers

### DIFF
--- a/crates/nbd-cow/src/server.rs
+++ b/crates/nbd-cow/src/server.rs
@@ -106,12 +106,22 @@ async fn handle_read(
     }
     let len = request.length as usize;
     if len <= MAX_REUSABLE_PAYLOAD_LENGTH {
-        payload_buf.resize(len, 0);
+        resize_reusable_payload(payload_buf, len);
         read_and_reply(request, cow, writer, payload_buf.as_mut_slice()).await
     } else {
         let mut data = vec![0u8; len];
         read_and_reply(request, cow, writer, data.as_mut_slice()).await
     }
+}
+
+fn resize_reusable_payload(payload_buf: &mut Vec<u8>, len: usize) {
+    debug_assert!(len <= MAX_REUSABLE_PAYLOAD_LENGTH);
+    if payload_buf.capacity() < len {
+        *payload_buf = vec![0u8; len];
+    } else {
+        payload_buf.resize(len, 0);
+    }
+    debug_assert!(payload_buf.capacity() <= MAX_REUSABLE_PAYLOAD_LENGTH);
 }
 
 async fn read_and_reply(
@@ -156,7 +166,7 @@ async fn handle_write(
     }
     let len = request.length as usize;
     if len <= MAX_REUSABLE_PAYLOAD_LENGTH {
-        payload_buf.resize(len, 0);
+        resize_reusable_payload(payload_buf, len);
         read_and_apply_write(request, reader, cow, writer, payload_buf.as_mut_slice()).await
     } else {
         let mut data = vec![0u8; len];

--- a/crates/nbd-cow/src/server.rs
+++ b/crates/nbd-cow/src/server.rs
@@ -20,6 +20,10 @@ use crate::protocol::{self, Command, NbdReply, NbdRequest, REQUEST_HEADER_SIZE};
 /// with an I/O error to prevent OOM from malformed requests.
 const MAX_REQUEST_LENGTH: u32 = 32 * 1024 * 1024;
 
+/// Maximum payload buffer capacity retained by one dispatch connection.
+/// Larger legal requests use temporary buffers to avoid long-lived 32 MB buffers.
+const MAX_REUSABLE_PAYLOAD_LENGTH: usize = 1024 * 1024;
+
 /// Run the NBD dispatch loop on a Unix stream.
 ///
 /// Reads NBD requests from the socket, dispatches to the COW layer,
@@ -42,6 +46,7 @@ pub async fn dispatch(
     let (mut reader, mut writer) = stream.into_split();
 
     let mut header_buf = [0u8; REQUEST_HEADER_SIZE];
+    let mut payload_buf = Vec::with_capacity(crate::BLOCK_SIZE);
 
     loop {
         // Wait for either a request or shutdown signal
@@ -69,10 +74,10 @@ pub async fn dispatch(
 
         match request.command {
             Command::Read => {
-                handle_read(&request, &cow, &mut writer).await?;
+                handle_read(&request, &cow, &mut writer, &mut payload_buf).await?;
             }
             Command::Write => {
-                handle_write(&request, &mut reader, &cow, &mut writer).await?;
+                handle_write(&request, &mut reader, &cow, &mut writer, &mut payload_buf).await?;
             }
             Command::Flush => {
                 handle_flush(&request, &cow, &mut writer).await?;
@@ -93,15 +98,31 @@ async fn handle_read(
     request: &NbdRequest,
     cow: &Arc<RwLock<CowLayer>>,
     writer: &mut tokio::net::unix::OwnedWriteHalf,
+    payload_buf: &mut Vec<u8>,
 ) -> Result<()> {
     if request.length > MAX_REQUEST_LENGTH {
         send_error_reply(writer, request.handle, libc::EIO as u32).await?;
         return Ok(());
     }
-    let mut data = vec![0u8; request.length as usize];
+    let len = request.length as usize;
+    if len <= MAX_REUSABLE_PAYLOAD_LENGTH {
+        payload_buf.resize(len, 0);
+        read_and_reply(request, cow, writer, payload_buf.as_mut_slice()).await
+    } else {
+        let mut data = vec![0u8; len];
+        read_and_reply(request, cow, writer, data.as_mut_slice()).await
+    }
+}
+
+async fn read_and_reply(
+    request: &NbdRequest,
+    cow: &Arc<RwLock<CowLayer>>,
+    writer: &mut tokio::net::unix::OwnedWriteHalf,
+    data: &mut [u8],
+) -> Result<()> {
     let result = {
         let cow = cow.read().await;
-        cow.read(request.offset, &mut data)
+        cow.read(request.offset, data)
     };
     if let Err(e) = result {
         tracing::warn!(
@@ -116,7 +137,7 @@ async fn handle_read(
     let reply = success_reply(request.handle);
     let reply_buf = protocol::serialize_reply(&reply);
     writer.write_all(&reply_buf).await?;
-    writer.write_all(&data).await?;
+    writer.write_all(data).await?;
     Ok(())
 }
 
@@ -125,6 +146,7 @@ async fn handle_write(
     reader: &mut tokio::net::unix::OwnedReadHalf,
     cow: &Arc<RwLock<CowLayer>>,
     writer: &mut tokio::net::unix::OwnedWriteHalf,
+    payload_buf: &mut Vec<u8>,
 ) -> Result<()> {
     if request.length > MAX_REQUEST_LENGTH {
         // Must consume the payload to keep the protocol stream in sync
@@ -132,13 +154,28 @@ async fn handle_write(
         send_error_reply(writer, request.handle, libc::EIO as u32).await?;
         return Ok(());
     }
-    // Read the write payload from the socket
-    let mut data = vec![0u8; request.length as usize];
-    reader.read_exact(&mut data).await?;
+    let len = request.length as usize;
+    if len <= MAX_REUSABLE_PAYLOAD_LENGTH {
+        payload_buf.resize(len, 0);
+        read_and_apply_write(request, reader, cow, writer, payload_buf.as_mut_slice()).await
+    } else {
+        let mut data = vec![0u8; len];
+        read_and_apply_write(request, reader, cow, writer, data.as_mut_slice()).await
+    }
+}
+
+async fn read_and_apply_write(
+    request: &NbdRequest,
+    reader: &mut tokio::net::unix::OwnedReadHalf,
+    cow: &Arc<RwLock<CowLayer>>,
+    writer: &mut tokio::net::unix::OwnedWriteHalf,
+    data: &mut [u8],
+) -> Result<()> {
+    reader.read_exact(data).await?;
 
     let failed = {
         let mut cow = cow.write().await;
-        match cow.write(request.offset, &data) {
+        match cow.write(request.offset, data) {
             Ok(needs_flush) => {
                 if needs_flush && let Err(e) = cow.flush() {
                     tracing::warn!("flush error after write: {e}");
@@ -399,6 +436,118 @@ mod tests {
             protocol::REPLY_MAGIC
         );
         u32::from_be_bytes([reply_buf[4], reply_buf[5], reply_buf[6], reply_buf[7]])
+    }
+
+    async fn send_write_and_recv_reply(
+        reader: &mut tokio::net::unix::OwnedReadHalf,
+        writer: &mut tokio::net::unix::OwnedWriteHalf,
+        req: &NbdRequest,
+        data: &[u8],
+    ) -> u32 {
+        assert_eq!(data.len(), req.length as usize);
+        writer.write_all(&serialize_request(req)).await.unwrap();
+        writer.write_all(data).await.unwrap();
+        let mut reply_buf = [0u8; 16];
+        reader.read_exact(&mut reply_buf).await.unwrap();
+        assert_eq!(
+            u32::from_be_bytes([reply_buf[0], reply_buf[1], reply_buf[2], reply_buf[3]]),
+            protocol::REPLY_MAGIC
+        );
+        u32::from_be_bytes([reply_buf[4], reply_buf[5], reply_buf[6], reply_buf[7]])
+    }
+
+    async fn read_payload(reader: &mut tokio::net::unix::OwnedReadHalf, len: usize) -> Vec<u8> {
+        let mut data = vec![0u8; len];
+        reader.read_exact(&mut data).await.unwrap();
+        data
+    }
+
+    #[tokio::test]
+    async fn dispatch_large_then_small_requests_keep_stream_aligned() {
+        let large_len = MAX_REUSABLE_PAYLOAD_LENGTH + crate::BLOCK_SIZE;
+        let small_len = 512usize;
+        let small_offset = large_len as u64;
+        let alignment_offset = (large_len + crate::BLOCK_SIZE) as u64;
+        let mut base_data = vec![0x11; large_len + 2 * crate::BLOCK_SIZE];
+        base_data[large_len + crate::BLOCK_SIZE..].fill(0x33);
+        let (_base, _cow_file, cow) = create_test_cow(&base_data);
+        let cow = Arc::new(RwLock::new(cow));
+
+        let (mut reader, mut writer, task, _shutdown) = setup_dispatch(cow).await;
+
+        let large_write = NbdRequest {
+            flags: 0,
+            command: Command::Write,
+            handle: 1,
+            offset: 0,
+            length: large_len as u32,
+        };
+        let large_write_data = vec![0x44; large_len];
+        let error =
+            send_write_and_recv_reply(&mut reader, &mut writer, &large_write, &large_write_data)
+                .await;
+        assert_eq!(error, 0, "large write should succeed");
+
+        let small_write = NbdRequest {
+            flags: 0,
+            command: Command::Write,
+            handle: 2,
+            offset: small_offset,
+            length: small_len as u32,
+        };
+        let small_write_data = vec![0x55; small_len];
+        let error =
+            send_write_and_recv_reply(&mut reader, &mut writer, &small_write, &small_write_data)
+                .await;
+        assert_eq!(error, 0, "small write after large write should succeed");
+
+        let large_read = NbdRequest {
+            flags: 0,
+            command: Command::Read,
+            handle: 3,
+            offset: 0,
+            length: large_len as u32,
+        };
+        let error = send_and_recv_reply(&mut reader, &mut writer, &large_read).await;
+        assert_eq!(error, 0, "large read should succeed");
+        let large_read_data = read_payload(&mut reader, large_len).await;
+        assert!(large_read_data.iter().all(|&b| b == 0x44));
+
+        let small_read = NbdRequest {
+            flags: 0,
+            command: Command::Read,
+            handle: 4,
+            offset: small_offset,
+            length: small_len as u32,
+        };
+        let error = send_and_recv_reply(&mut reader, &mut writer, &small_read).await;
+        assert_eq!(error, 0, "small read after large read should succeed");
+        let small_read_data = read_payload(&mut reader, small_len).await;
+        assert_eq!(small_read_data, small_write_data);
+
+        // If the previous small read emitted stale bytes from the earlier large
+        // payload, this next reply header would be misaligned.
+        let alignment_read = NbdRequest {
+            flags: 0,
+            command: Command::Read,
+            handle: 5,
+            offset: alignment_offset,
+            length: crate::BLOCK_SIZE as u32,
+        };
+        let error = send_and_recv_reply(&mut reader, &mut writer, &alignment_read).await;
+        assert_eq!(error, 0, "read after small read should stay aligned");
+        let alignment_data = read_payload(&mut reader, crate::BLOCK_SIZE).await;
+        assert!(alignment_data.iter().all(|&b| b == 0x33));
+
+        let disc = NbdRequest {
+            flags: 0,
+            command: Command::Disconnect,
+            handle: 6,
+            offset: 0,
+            length: 0,
+        };
+        writer.write_all(&serialize_request(&disc)).await.unwrap();
+        task.await.unwrap().unwrap();
     }
 
     #[tokio::test]

--- a/crates/nbd-cow/src/server.rs
+++ b/crates/nbd-cow/src/server.rs
@@ -557,8 +557,9 @@ mod tests {
         let max_reusable_data = read_payload(&mut reader, MAX_REUSABLE_PAYLOAD_LENGTH).await;
         assert!(max_reusable_data.iter().all(|&b| b == 0x44));
 
-        // If the previous small read emitted stale bytes from the earlier large
-        // payload, this next reply header would be misaligned.
+        // The max reusable request above proves the stream stayed aligned after
+        // the small read. This next request proves it also stays aligned after
+        // a max-size reusable payload.
         let alignment_read = NbdRequest {
             flags: 0,
             command: Command::Read,
@@ -567,7 +568,7 @@ mod tests {
             length: crate::BLOCK_SIZE as u32,
         };
         let error = send_and_recv_reply(&mut reader, &mut writer, &alignment_read).await;
-        assert_eq!(error, 0, "read after small read should stay aligned");
+        assert_eq!(error, 0, "read after max reusable read should stay aligned");
         let alignment_data = read_payload(&mut reader, crate::BLOCK_SIZE).await;
         assert!(alignment_data.iter().all(|&b| b == 0x33));
 

--- a/crates/nbd-cow/src/server.rs
+++ b/crates/nbd-cow/src/server.rs
@@ -20,7 +20,7 @@ use crate::protocol::{self, Command, NbdReply, NbdRequest, REQUEST_HEADER_SIZE};
 /// with an I/O error to prevent OOM from malformed requests.
 const MAX_REQUEST_LENGTH: u32 = 32 * 1024 * 1024;
 
-/// Maximum payload buffer capacity retained by one dispatch connection.
+/// Maximum reusable payload buffer capacity retained between requests.
 /// Larger legal requests use temporary buffers to avoid long-lived 32 MB buffers.
 const MAX_REUSABLE_PAYLOAD_LENGTH: usize = 1024 * 1024;
 
@@ -107,7 +107,9 @@ async fn handle_read(
     let len = request.length as usize;
     if len <= MAX_REUSABLE_PAYLOAD_LENGTH {
         resize_reusable_payload(payload_buf, len);
-        read_and_reply(request, cow, writer, payload_buf.as_mut_slice()).await
+        let result = read_and_reply(request, cow, writer, payload_buf.as_mut_slice()).await;
+        reset_reusable_payload_if_oversized(payload_buf);
+        result
     } else {
         let mut data = vec![0u8; len];
         read_and_reply(request, cow, writer, data.as_mut_slice()).await
@@ -121,7 +123,12 @@ fn resize_reusable_payload(payload_buf: &mut Vec<u8>, len: usize) {
     } else {
         payload_buf.resize(len, 0);
     }
-    debug_assert!(payload_buf.capacity() <= MAX_REUSABLE_PAYLOAD_LENGTH);
+}
+
+fn reset_reusable_payload_if_oversized(payload_buf: &mut Vec<u8>) {
+    if payload_buf.capacity() > MAX_REUSABLE_PAYLOAD_LENGTH {
+        *payload_buf = Vec::with_capacity(crate::BLOCK_SIZE);
+    }
 }
 
 async fn read_and_reply(
@@ -167,7 +174,10 @@ async fn handle_write(
     let len = request.length as usize;
     if len <= MAX_REUSABLE_PAYLOAD_LENGTH {
         resize_reusable_payload(payload_buf, len);
-        read_and_apply_write(request, reader, cow, writer, payload_buf.as_mut_slice()).await
+        let result =
+            read_and_apply_write(request, reader, cow, writer, payload_buf.as_mut_slice()).await;
+        reset_reusable_payload_if_oversized(payload_buf);
+        result
     } else {
         let mut data = vec![0u8; len];
         read_and_apply_write(request, reader, cow, writer, data.as_mut_slice()).await
@@ -535,12 +545,24 @@ mod tests {
         let small_read_data = read_payload(&mut reader, small_len).await;
         assert_eq!(small_read_data, small_write_data);
 
+        let max_reusable_read = NbdRequest {
+            flags: 0,
+            command: Command::Read,
+            handle: 5,
+            offset: 0,
+            length: MAX_REUSABLE_PAYLOAD_LENGTH as u32,
+        };
+        let error = send_and_recv_reply(&mut reader, &mut writer, &max_reusable_read).await;
+        assert_eq!(error, 0, "max reusable read should succeed");
+        let max_reusable_data = read_payload(&mut reader, MAX_REUSABLE_PAYLOAD_LENGTH).await;
+        assert!(max_reusable_data.iter().all(|&b| b == 0x44));
+
         // If the previous small read emitted stale bytes from the earlier large
         // payload, this next reply header would be misaligned.
         let alignment_read = NbdRequest {
             flags: 0,
             command: Command::Read,
-            handle: 5,
+            handle: 6,
             offset: alignment_offset,
             length: crate::BLOCK_SIZE as u32,
         };
@@ -552,7 +574,7 @@ mod tests {
         let disc = NbdRequest {
             flags: 0,
             command: Command::Disconnect,
-            handle: 6,
+            handle: 7,
             offset: 0,
             length: 0,
         };


### PR DESCRIPTION
## Summary
- reuse one payload buffer per NBD dispatch connection for common read/write requests
- cap retained payload capacity at 1MiB and use temporary buffers for larger legal requests
- add dispatch regression coverage for large-then-small read/write requests on the same connection

## Tests
- cargo fmt --manifest-path crates/Cargo.toml --all --check
- cargo test --manifest-path crates/Cargo.toml -p nbd-cow server::tests
- cargo test --manifest-path crates/Cargo.toml -p nbd-cow
- cargo clippy --manifest-path crates/Cargo.toml -p nbd-cow --all-targets -- -D warnings

Closes #15460