### PR TITLE
perf(guest-agent): move event payloads without cloning

### DIFF
--- a/crates/guest-agent/src/cli/mod.rs
+++ b/crates/guest-agent/src/cli/mod.rs
@@ -280,7 +280,7 @@ pub async fn execute_cli(
                             continue;
                         }
 
-                        if let Ok(mut event) = serde_json::from_str::<serde_json::Value>(stripped) {
+                        if let Ok(event) = serde_json::from_str::<serde_json::Value>(stripped) {
                             last_read_event_at = Some(Instant::now());
                             // First event is the CLI init (system/init or thread.started)
                             if seq == 0 {
@@ -348,13 +348,13 @@ pub async fn execute_cli(
                                 }
                             }
                             // Capture checkpoint metadata before event payload preparation
-                            // mutates the event through masking.
+                            // consumes and masks the event.
                             events::capture_session_metadata(&event);
 
                             // Prepare event payload (mask secrets, add seq) and enqueue
                             // for background sending. Network I/O stays off the reading loop.
                             if should_send_events {
-                                let payload = events::prepare_event(&mut event, seq, masker);
+                                let payload = events::prepare_event_payload(event, seq, masker);
                                 if event_tx
                                     .send(PreparedEvent {
                                         sequence: seq,

--- a/crates/guest-agent/src/events.rs
+++ b/crates/guest-agent/src/events.rs
@@ -12,7 +12,7 @@ use crate::masker::SecretMasker;
 use crate::paths;
 use agent_diagnostics::FailureReason;
 use guest_common::{log_error, log_info};
-use serde_json::{Value, json};
+use serde_json::{Map, Value, json};
 
 const LOG_TAG: &str = "sandbox:guest-agent";
 const FAILURE_DIAGNOSTIC_MAX_BYTES: usize = 4096;
@@ -37,40 +37,42 @@ pub(crate) struct ClaudeFailureDiagnostic {
 /// checkpoints before preparing the webhook payload.
 pub async fn send_event(
     http: &HttpClient,
-    event: &mut Value,
+    event: Value,
     seq: u32,
     masker: &SecretMasker,
 ) -> Result<(), AgentError> {
-    capture_session_metadata(event);
+    capture_session_metadata(&event);
 
     if !http.has_api() {
         return Ok(());
     }
 
-    let payload = prepare_event(event, seq, masker);
+    let payload = prepare_event_payload(event, seq, masker);
     post_event(http, &payload).await
 }
 
-/// Prepare an event webhook payload by adding a sequence number, masking
-/// secrets, and wrapping the event in the HTTP payload shape.
+/// Prepare an event webhook payload by adding a sequence number, masking secrets,
+/// and moving the event into the HTTP payload shape.
 ///
 /// This function does not perform filesystem or network I/O; session metadata
 /// capture is handled separately before payload preparation, and network
 /// delivery happens in `post_event` / `send_event`.
-pub fn prepare_event(event: &mut Value, seq: u32, masker: &SecretMasker) -> Value {
+pub fn prepare_event_payload(mut event: Value, seq: u32, masker: &SecretMasker) -> Value {
     // Add sequence number
     if let Some(obj) = event.as_object_mut() {
         obj.insert("sequenceNumber".to_string(), json!(seq));
     }
 
     // Mask secrets
-    masker.mask_value(event);
+    masker.mask_value(&mut event);
 
-    // Build payload
-    json!({
-        "runId": env::run_id(),
-        "events": [event],
-    })
+    let mut payload = Map::new();
+    payload.insert(
+        "runId".to_string(),
+        Value::String(env::run_id().to_string()),
+    );
+    payload.insert("events".to_string(), Value::Array(vec![event]));
+    Value::Object(payload)
 }
 
 /// Extract a secret-masked Codex failure diagnostic from stdout JSONL.
@@ -387,6 +389,31 @@ fn extract_codex_thread_id(event: &Value) -> Option<(String, String)> {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn prepare_event_payload_adds_sequence_and_masks_object_event() {
+        let event = serde_json::json!({
+            "type": "test",
+            "data": "contains secret-value"
+        });
+        let masker = SecretMasker::from_raw("c2VjcmV0LXZhbHVl");
+
+        let payload = prepare_event_payload(event, 7, &masker);
+
+        assert_eq!(payload["events"][0]["type"], "test");
+        assert_eq!(payload["events"][0]["sequenceNumber"], 7);
+        assert_eq!(payload["events"][0]["data"], "contains ***");
+    }
+
+    #[test]
+    fn prepare_event_payload_wraps_non_object_event_without_sequence_number() {
+        let event = serde_json::json!("contains secret-value");
+        let masker = SecretMasker::from_raw("c2VjcmV0LXZhbHVl");
+
+        let payload = prepare_event_payload(event, 7, &masker);
+
+        assert_eq!(payload["events"][0], "contains ***");
+    }
 
     #[test]
     fn extract_tool_use() {

--- a/crates/guest-agent/tests/codex_session_resume.rs
+++ b/crates/guest-agent/tests/codex_session_resume.rs
@@ -108,14 +108,14 @@ async fn send_event_extracts_codex_thread_id_and_writes_marker() {
     reset_session_files();
 
     let masker = SecretMasker::from_raw("");
-    let mut event = json!({
+    let event = json!({
         "type": "thread.started",
         "thread_id": "0193abcd-ef01-7234-89ab-cdef01234567"
     });
 
     // No API token → send_event skips the HTTP POST but still captures
     // session metadata, which is the part we want to assert.
-    let result = guest_agent::events::send_event(&http_client!(), &mut event, 1, &masker).await;
+    let result = guest_agent::events::send_event(&http_client!(), event, 1, &masker).await;
     assert!(
         result.is_ok(),
         "send_event should succeed when no API token"
@@ -148,8 +148,8 @@ async fn send_event_codex_ignores_non_thread_started_event() {
     reset_session_files();
 
     let masker = SecretMasker::from_raw("");
-    let mut event = json!({"type": "turn.completed"});
-    let result = guest_agent::events::send_event(&http_client!(), &mut event, 1, &masker).await;
+    let event = json!({"type": "turn.completed"});
+    let result = guest_agent::events::send_event(&http_client!(), event, 1, &masker).await;
     assert!(result.is_ok());
 
     assert!(
@@ -165,8 +165,8 @@ async fn send_event_codex_ignores_empty_thread_id() {
     reset_session_files();
 
     let masker = SecretMasker::from_raw("");
-    let mut event = json!({"type": "thread.started", "thread_id": ""});
-    let result = guest_agent::events::send_event(&http_client!(), &mut event, 1, &masker).await;
+    let event = json!({"type": "thread.started", "thread_id": ""});
+    let result = guest_agent::events::send_event(&http_client!(), event, 1, &masker).await;
     assert!(result.is_ok());
 
     assert!(
@@ -182,8 +182,8 @@ async fn send_event_codex_ignores_malformed_thread_id() {
     reset_session_files();
 
     let masker = SecretMasker::from_raw("");
-    let mut event = json!({"type": "thread.started", "thread_id": "abc"});
-    let result = guest_agent::events::send_event(&http_client!(), &mut event, 1, &masker).await;
+    let event = json!({"type": "thread.started", "thread_id": "abc"});
+    let result = guest_agent::events::send_event(&http_client!(), event, 1, &masker).await;
     assert!(result.is_ok());
 
     assert!(

--- a/crates/guest-agent/tests/integration.rs
+++ b/crates/guest-agent/tests/integration.rs
@@ -257,22 +257,22 @@ async fn for_current_env_uses_env_api_url_for_webhook_routes()
             .path("/api/webhooks/agent/events")
             .header("Authorization", "Bearer test-token-abc123")
             .header("x-vercel-protection-bypass", "test-bypass-value")
-            .json_body_includes(r#"{"runId": "test-run-001"}"#);
+            .json_body_includes(r#"{"runId": "test-run-001"}"#)
+            .body_includes(r#""sequenceNumber":7"#);
         then.status(200);
     });
 
     let masker = SecretMasker::from_raw("");
-    let mut event = json!({"type": "test", "data": "env route"});
+    let event = json!({"type": "test", "data": "env route"});
     guest_agent::events::send_event(
         &guest_agent::http::HttpClient::for_current_env()?,
-        &mut event,
+        event,
         7,
         &masker,
     )
     .await?;
 
     mock.assert_calls_async(1).await;
-    assert_eq!(event["sequenceNumber"], 7);
     mock.delete_async().await;
     Ok(())
 }
@@ -464,7 +464,8 @@ async fn send_event_uses_explicit_api_config_route_instead_of_env_route()
     let explicit_mock = explicit_server.mock(|when, then| {
         when.method(POST)
             .path("/api/webhooks/agent/events")
-            .header("Authorization", "Bearer explicit-token");
+            .header("Authorization", "Bearer explicit-token")
+            .body_includes(r#""sequenceNumber":3"#);
         then.respond_with(|req| {
             if request_header_absent(req, "x-vercel-protection-bypass") {
                 http_status(200)
@@ -481,12 +482,11 @@ async fn send_event_uses_explicit_api_config_route_instead_of_env_route()
         Duration::ZERO,
     )?;
     let masker = SecretMasker::from_raw("");
-    let mut event = json!({"type": "test", "data": "explicit route"});
-    guest_agent::events::send_event(&http, &mut event, 3, &masker).await?;
+    let event = json!({"type": "test", "data": "explicit route"});
+    guest_agent::events::send_event(&http, event, 3, &masker).await?;
 
     explicit_mock.assert_calls_async(1).await;
     env_mock.assert_calls_async(0).await;
-    assert_eq!(event["sequenceNumber"], 3);
     explicit_mock.delete_async().await;
     env_mock.delete_async().await;
     Ok(())
@@ -1083,17 +1083,17 @@ async fn send_event_correct_payload() {
     let mock = server.mock(|when, then| {
         when.method(POST)
             .path("/api/webhooks/agent/events")
-            .json_body_includes(r#"{"runId": "test-run-001"}"#);
+            .json_body_includes(r#"{"runId": "test-run-001"}"#)
+            .body_includes(r#""sequenceNumber":42"#);
         then.status(200);
     });
 
     let masker = SecretMasker::from_raw("");
-    let mut event = json!({"type": "test", "data": "hello"});
-    let result = guest_agent::events::send_event(&http_client!(), &mut event, 42, &masker).await;
+    let event = json!({"type": "test", "data": "hello"});
+    let result = guest_agent::events::send_event(&http_client!(), event, 42, &masker).await;
 
     assert!(result.is_ok());
     mock.assert_calls_async(1).await;
-    assert_eq!(event["sequenceNumber"], 42);
     mock.delete_async().await;
 }
 
@@ -1103,7 +1103,9 @@ async fn send_event_masks_secrets() {
     let server = &*MOCK_SERVER;
 
     let mock = server.mock(|when, then| {
-        when.method(POST).path("/api/webhooks/agent/events");
+        when.method(POST)
+            .path("/api/webhooks/agent/events")
+            .body_includes(r#""data":"contains *** here""#);
         then.status(200);
     });
 
@@ -1111,13 +1113,11 @@ async fn send_event_masks_secrets() {
     let encoded_secret = engine.encode("super-secret-value");
     let masker = SecretMasker::from_raw(&encoded_secret);
 
-    let mut event = json!({"type": "test", "data": "contains super-secret-value here"});
-    let result = guest_agent::events::send_event(&http_client!(), &mut event, 1, &masker).await;
+    let event = json!({"type": "test", "data": "contains super-secret-value here"});
+    let result = guest_agent::events::send_event(&http_client!(), event, 1, &masker).await;
 
     assert!(result.is_ok());
     mock.assert_calls_async(1).await;
-    // The event is mutated in-place; the secret must be replaced.
-    assert_eq!(event["data"], "contains *** here");
     mock.delete_async().await;
 }
 
@@ -1141,20 +1141,16 @@ async fn send_event_captures_session_metadata_before_masking() {
     let engine = base64::engine::general_purpose::STANDARD;
     let encoded_session_id = engine.encode(session_id);
     let masker = SecretMasker::from_raw(&encoded_session_id);
-    let mut event = json!({
+    let event = json!({
         "type": "system",
         "subtype": "init",
         "session_id": session_id
     });
 
-    let result = guest_agent::events::send_event(&http_client!(), &mut event, 1, &masker).await;
+    let result = guest_agent::events::send_event(&http_client!(), event, 1, &masker).await;
 
     assert!(result.is_ok());
     mock.assert_calls_async(1).await;
-    assert_eq!(
-        event["session_id"], "***",
-        "send_event should leave the caller's event masked after payload preparation"
-    );
 
     let stored = std::fs::read_to_string(sid_file).unwrap();
     assert_eq!(
@@ -1184,14 +1180,15 @@ async fn prepare_event_does_not_capture_session_metadata() {
     let hist_file = guest_agent::paths::session_history_path_file();
 
     let masker = SecretMasker::from_raw("");
-    let mut event = json!({
+    let event = json!({
         "type": "system",
         "subtype": "init",
         "session_id": "ses-prepare-only"
     });
-    let payload = guest_agent::events::prepare_event(&mut event, 1, &masker);
+    let payload = guest_agent::events::prepare_event_payload(event, 1, &masker);
 
     assert_eq!(payload["runId"], "test-run-001");
+    assert_eq!(payload["events"][0]["sequenceNumber"], 1);
     assert!(
         !std::path::Path::new(sid_file).exists(),
         "prepare_event must not write the session ID file"
@@ -1219,12 +1216,12 @@ async fn send_event_keeps_existing_session_metadata() {
     });
 
     let masker = SecretMasker::from_raw("");
-    let mut event = json!({
+    let event = json!({
         "type": "system",
         "subtype": "init",
         "session_id": "second-session"
     });
-    let result = guest_agent::events::send_event(&http_client!(), &mut event, 1, &masker).await;
+    let result = guest_agent::events::send_event(&http_client!(), event, 1, &masker).await;
 
     assert!(result.is_ok());
     mock.assert_calls_async(1).await;
@@ -1265,12 +1262,12 @@ async fn send_event_extracts_claude_session_id() {
     let masker = SecretMasker::from_raw("");
     // CLI_AGENT_TYPE defaults to "claude-code", so the Claude path is taken:
     // type == "system" && subtype == "init" → reads session_id field.
-    let mut event = json!({
+    let event = json!({
         "type": "system",
         "subtype": "init",
         "session_id": "ses-abc-123"
     });
-    let result = guest_agent::events::send_event(&http_client!(), &mut event, 1, &masker).await;
+    let result = guest_agent::events::send_event(&http_client!(), event, 1, &masker).await;
 
     assert!(result.is_ok());
     mock.assert_calls_async(1).await;
@@ -1310,8 +1307,8 @@ async fn send_event_skips_session_id_for_non_init() {
     });
 
     let masker = SecretMasker::from_raw("");
-    let mut event = json!({"type": "assistant", "data": "hello"});
-    let result = guest_agent::events::send_event(&http_client!(), &mut event, 1, &masker).await;
+    let event = json!({"type": "assistant", "data": "hello"});
+    let result = guest_agent::events::send_event(&http_client!(), event, 1, &masker).await;
 
     assert!(result.is_ok());
     mock.assert_calls_async(1).await;
@@ -1546,8 +1543,8 @@ async fn send_event_failure_writes_error_flag() {
     });
 
     let masker = SecretMasker::from_raw("");
-    let mut event = json!({"type": "test"});
-    let result = guest_agent::events::send_event(&http_client!(), &mut event, 1, &masker).await;
+    let event = json!({"type": "test"});
+    let result = guest_agent::events::send_event(&http_client!(), event, 1, &masker).await;
 
     assert!(result.is_err());
     assert!(

--- a/crates/guest-agent/tests/no_api_mode.rs
+++ b/crates/guest-agent/tests/no_api_mode.rs
@@ -101,13 +101,13 @@ async fn no_api_mode_drains_background_webhook_users_without_network_client()
         .expect("heartbeat should exit promptly after shutdown in no-API mode")
         .expect("heartbeat task should not panic")?;
 
-    let mut event = json!({
+    let event = json!({
         "type": "system",
         "subtype": "init",
         "session_id": "session-no-api",
         "cwd": tmp.path().to_string_lossy(),
     });
-    guest_agent::events::send_event(&http, &mut event, 1, &masker).await?;
+    guest_agent::events::send_event(&http, event, 1, &masker).await?;
     assert_eq!(
         std::fs::read_to_string(guest_agent::paths::session_id_file())?,
         "session-no-api"


### PR DESCRIPTION
## Summary
- Replace borrowed event payload preparation with an owned `prepare_event_payload` builder that moves the event into `events`.
- Update the CLI stdout hot path to move parsed events into prepared payloads after diagnostics, tool tracking, and session metadata capture.
- Update guest-agent tests to assert emitted webhook payload behavior instead of caller-visible event mutation.

Closes #15461

## Tests
- `cargo test --manifest-path crates/Cargo.toml -p guest-agent --lib prepare_event_payload`
- `cargo test --manifest-path crates/Cargo.toml -p guest-agent --test integration send_event`
- `cargo test --manifest-path crates/Cargo.toml -p guest-agent --test integration for_current_env_uses_env_api_url_for_webhook_routes -- --exact`
- `cargo test --manifest-path crates/Cargo.toml -p guest-agent --test integration prepare_event_does_not_capture_session_metadata -- --exact`
- `cargo test --manifest-path crates/Cargo.toml -p guest-agent --test codex_session_resume send_event`
- `cargo test --manifest-path crates/Cargo.toml -p guest-agent --test no_api_mode no_api_mode_drains_background_webhook_users_without_network_client -- --exact`
- `cargo test --manifest-path crates/Cargo.toml -p guest-agent --jobs 1`
- `cargo fmt --manifest-path crates/Cargo.toml --all --check`
- `cargo clippy --manifest-path crates/Cargo.toml -p guest-agent --all-targets --jobs 1`
- `git diff --check`

Note: the first all-target cargo test/clippy attempts without `--jobs 1` hit local target metadata/cache errors; rerunning with one cargo job passed.
