### PR TITLE
fix: allow nbd dispatch shutdown during socket io

### DIFF
--- a/crates/nbd-cow/src/server.rs
+++ b/crates/nbd-cow/src/server.rs
@@ -24,6 +24,18 @@ const MAX_REQUEST_LENGTH: u32 = 32 * 1024 * 1024;
 /// Larger legal requests use temporary buffers to avoid long-lived 32 MB buffers.
 const MAX_REUSABLE_PAYLOAD_LENGTH: usize = 1024 * 1024;
 
+#[derive(Clone, Copy)]
+enum IoOutcome {
+    Complete,
+    Shutdown,
+}
+
+#[derive(Clone, Copy)]
+enum HandlerOutcome {
+    Continue,
+    Shutdown,
+}
+
 /// Run the NBD dispatch loop on a Unix stream.
 ///
 /// Reads NBD requests from the socket, dispatches to the COW layer,
@@ -49,49 +61,118 @@ pub async fn dispatch(
     let mut payload_buf = Vec::with_capacity(crate::BLOCK_SIZE);
 
     loop {
-        // Wait for either a request or shutdown signal
-        tokio::select! {
-            biased;
-            () = shutdown.cancelled() => {
-                // Graceful shutdown: flush remaining data
-                let mut cow = cow.write().await;
-                cow.sync()?;
+        match read_exact_or_shutdown(&mut reader, &mut header_buf, &shutdown).await {
+            Ok(IoOutcome::Complete) => {}
+            Ok(IoOutcome::Shutdown) => {
+                sync_cow_on_shutdown(&cow).await?;
                 return Ok(());
             }
-            result = reader.read_exact(&mut header_buf) => {
-                match result {
-                    Ok(_) => {}
-                    Err(e) if e.kind() == std::io::ErrorKind::UnexpectedEof => {
-                        // Connection closed
-                        return Ok(());
-                    }
-                    Err(e) => return Err(e.into()),
-                }
+            Err(NbdCowError::Io(e)) if e.kind() == std::io::ErrorKind::UnexpectedEof => {
+                return Ok(());
             }
+            Err(e) => return Err(e),
         }
 
         let request = protocol::parse_request(&header_buf)?;
 
-        match request.command {
+        let outcome = match request.command {
             Command::Read => {
-                handle_read(&request, &cow, &mut writer, &mut payload_buf).await?;
+                handle_read(&request, &cow, &mut writer, &mut payload_buf, &shutdown).await?
             }
             Command::Write => {
-                handle_write(&request, &mut reader, &cow, &mut writer, &mut payload_buf).await?;
+                handle_write(
+                    &request,
+                    &mut reader,
+                    &cow,
+                    &mut writer,
+                    &mut payload_buf,
+                    &shutdown,
+                )
+                .await?
             }
-            Command::Flush => {
-                handle_flush(&request, &cow, &mut writer).await?;
-            }
-            Command::Trim => {
-                handle_trim(&request, &mut writer).await?;
-            }
+            Command::Flush => handle_flush(&request, &cow, &mut writer, &shutdown).await?,
+            Command::Trim => handle_trim(&request, &mut writer, &shutdown).await?,
             Command::Disconnect => {
-                let mut cow = cow.write().await;
-                cow.sync()?;
+                sync_cow_on_shutdown(&cow).await?;
                 return Ok(());
+            }
+        };
+
+        if let HandlerOutcome::Shutdown = outcome {
+            sync_cow_on_shutdown(&cow).await?;
+            return Ok(());
+        }
+    }
+}
+
+async fn sync_cow_on_shutdown(cow: &Arc<RwLock<CowLayer>>) -> Result<()> {
+    let mut cow = cow.write().await;
+    cow.sync()
+}
+
+fn handler_outcome(outcome: IoOutcome) -> HandlerOutcome {
+    match outcome {
+        IoOutcome::Complete => HandlerOutcome::Continue,
+        IoOutcome::Shutdown => HandlerOutcome::Shutdown,
+    }
+}
+
+async fn read_exact_or_shutdown(
+    reader: &mut tokio::net::unix::OwnedReadHalf,
+    buf: &mut [u8],
+    shutdown: &CancellationToken,
+) -> Result<IoOutcome> {
+    let mut filled = 0usize;
+    while filled < buf.len() {
+        let dest = buf.get_mut(filled..).ok_or_else(|| {
+            NbdCowError::Io(std::io::Error::other("read buffer slice out of bounds"))
+        })?;
+        tokio::select! {
+            biased;
+            () = shutdown.cancelled() => {
+                return Ok(IoOutcome::Shutdown);
+            }
+            result = reader.read(dest) => {
+                let count = result?;
+                if count == 0 {
+                    return Err(std::io::Error::new(
+                        std::io::ErrorKind::UnexpectedEof,
+                        "failed to fill whole buffer",
+                    ).into());
+                }
+                filled += count;
             }
         }
     }
+    Ok(IoOutcome::Complete)
+}
+
+async fn write_all_or_shutdown(
+    writer: &mut tokio::net::unix::OwnedWriteHalf,
+    mut buf: &[u8],
+    shutdown: &CancellationToken,
+) -> Result<IoOutcome> {
+    while !buf.is_empty() {
+        tokio::select! {
+            biased;
+            () = shutdown.cancelled() => {
+                return Ok(IoOutcome::Shutdown);
+            }
+            result = writer.write(buf) => {
+                let count = result?;
+                if count == 0 {
+                    return Err(std::io::Error::new(
+                        std::io::ErrorKind::WriteZero,
+                        "failed to write whole buffer",
+                    ).into());
+                }
+                buf = buf.get(count..).ok_or_else(|| {
+                    NbdCowError::Io(std::io::Error::other("write buffer slice out of bounds"))
+                })?;
+            }
+        }
+    }
+    Ok(IoOutcome::Complete)
 }
 
 async fn handle_read(
@@ -99,20 +180,23 @@ async fn handle_read(
     cow: &Arc<RwLock<CowLayer>>,
     writer: &mut tokio::net::unix::OwnedWriteHalf,
     payload_buf: &mut Vec<u8>,
-) -> Result<()> {
+    shutdown: &CancellationToken,
+) -> Result<HandlerOutcome> {
     if request.length > MAX_REQUEST_LENGTH {
-        send_error_reply(writer, request.handle, libc::EIO as u32).await?;
-        return Ok(());
+        return send_error_reply(writer, request.handle, libc::EIO as u32, shutdown)
+            .await
+            .map(handler_outcome);
     }
     let len = request.length as usize;
     if len <= MAX_REUSABLE_PAYLOAD_LENGTH {
         resize_reusable_payload(payload_buf, len);
-        let result = read_and_reply(request, cow, writer, payload_buf.as_mut_slice()).await;
+        let result =
+            read_and_reply(request, cow, writer, payload_buf.as_mut_slice(), shutdown).await;
         reset_reusable_payload_if_oversized(payload_buf);
         result
     } else {
         let mut data = vec![0u8; len];
-        read_and_reply(request, cow, writer, data.as_mut_slice()).await
+        read_and_reply(request, cow, writer, data.as_mut_slice(), shutdown).await
     }
 }
 
@@ -136,7 +220,8 @@ async fn read_and_reply(
     cow: &Arc<RwLock<CowLayer>>,
     writer: &mut tokio::net::unix::OwnedWriteHalf,
     data: &mut [u8],
-) -> Result<()> {
+    shutdown: &CancellationToken,
+) -> Result<HandlerOutcome> {
     let result = {
         let cow = cow.read().await;
         cow.read(request.offset, data)
@@ -147,15 +232,19 @@ async fn read_and_reply(
             len = request.length,
             "read error: {e}"
         );
-        send_error_reply(writer, request.handle, libc::EIO as u32).await?;
-        return Ok(());
+        return send_error_reply(writer, request.handle, libc::EIO as u32, shutdown)
+            .await
+            .map(handler_outcome);
     }
 
     let reply = success_reply(request.handle);
     let reply_buf = protocol::serialize_reply(&reply);
-    writer.write_all(&reply_buf).await?;
-    writer.write_all(data).await?;
-    Ok(())
+    if let IoOutcome::Shutdown = write_all_or_shutdown(writer, &reply_buf, shutdown).await? {
+        return Ok(HandlerOutcome::Shutdown);
+    }
+    write_all_or_shutdown(writer, data, shutdown)
+        .await
+        .map(handler_outcome)
 }
 
 async fn handle_write(
@@ -164,23 +253,34 @@ async fn handle_write(
     cow: &Arc<RwLock<CowLayer>>,
     writer: &mut tokio::net::unix::OwnedWriteHalf,
     payload_buf: &mut Vec<u8>,
-) -> Result<()> {
+    shutdown: &CancellationToken,
+) -> Result<HandlerOutcome> {
     if request.length > MAX_REQUEST_LENGTH {
         // Must consume the payload to keep the protocol stream in sync
-        discard_bytes(reader, request.length as u64).await?;
-        send_error_reply(writer, request.handle, libc::EIO as u32).await?;
-        return Ok(());
+        if let IoOutcome::Shutdown = discard_bytes(reader, request.length as u64, shutdown).await? {
+            return Ok(HandlerOutcome::Shutdown);
+        }
+        return send_error_reply(writer, request.handle, libc::EIO as u32, shutdown)
+            .await
+            .map(handler_outcome);
     }
     let len = request.length as usize;
     if len <= MAX_REUSABLE_PAYLOAD_LENGTH {
         resize_reusable_payload(payload_buf, len);
-        let result =
-            read_and_apply_write(request, reader, cow, writer, payload_buf.as_mut_slice()).await;
+        let result = read_and_apply_write(
+            request,
+            reader,
+            cow,
+            writer,
+            payload_buf.as_mut_slice(),
+            shutdown,
+        )
+        .await;
         reset_reusable_payload_if_oversized(payload_buf);
         result
     } else {
         let mut data = vec![0u8; len];
-        read_and_apply_write(request, reader, cow, writer, data.as_mut_slice()).await
+        read_and_apply_write(request, reader, cow, writer, data.as_mut_slice(), shutdown).await
     }
 }
 
@@ -190,8 +290,11 @@ async fn read_and_apply_write(
     cow: &Arc<RwLock<CowLayer>>,
     writer: &mut tokio::net::unix::OwnedWriteHalf,
     data: &mut [u8],
-) -> Result<()> {
-    reader.read_exact(data).await?;
+    shutdown: &CancellationToken,
+) -> Result<HandlerOutcome> {
+    if let IoOutcome::Shutdown = read_exact_or_shutdown(reader, data, shutdown).await? {
+        return Ok(HandlerOutcome::Shutdown);
+    }
 
     let failed = {
         let mut cow = cow.write().await;
@@ -215,79 +318,97 @@ async fn read_and_apply_write(
         }
     };
     if failed {
-        send_error_reply(writer, request.handle, libc::EIO as u32).await?;
-        return Ok(());
+        return send_error_reply(writer, request.handle, libc::EIO as u32, shutdown)
+            .await
+            .map(handler_outcome);
     }
 
-    send_success_reply(writer, request.handle).await
+    send_success_reply(writer, request.handle, shutdown)
+        .await
+        .map(handler_outcome)
 }
 
 async fn handle_flush(
     request: &NbdRequest,
     cow: &Arc<RwLock<CowLayer>>,
     writer: &mut tokio::net::unix::OwnedWriteHalf,
-) -> Result<()> {
+    shutdown: &CancellationToken,
+) -> Result<HandlerOutcome> {
     let result = {
         let mut cow = cow.write().await;
         cow.sync()
     };
     if let Err(e) = result {
         tracing::warn!("sync error: {e}");
-        send_error_reply(writer, request.handle, libc::EIO as u32).await?;
-        return Ok(());
+        return send_error_reply(writer, request.handle, libc::EIO as u32, shutdown)
+            .await
+            .map(handler_outcome);
     }
 
-    send_success_reply(writer, request.handle).await
+    send_success_reply(writer, request.handle, shutdown)
+        .await
+        .map(handler_outcome)
 }
 
 async fn handle_trim(
     request: &NbdRequest,
     writer: &mut tokio::net::unix::OwnedWriteHalf,
-) -> Result<()> {
+    shutdown: &CancellationToken,
+) -> Result<HandlerOutcome> {
     // Trim is a no-op for now (COW file is sparse, unused blocks are holes)
-    send_success_reply(writer, request.handle).await
+    send_success_reply(writer, request.handle, shutdown)
+        .await
+        .map(handler_outcome)
 }
 
 fn success_reply(handle: u64) -> NbdReply {
     NbdReply { error: 0, handle }
 }
 
-async fn send_reply(writer: &mut tokio::net::unix::OwnedWriteHalf, reply: &NbdReply) -> Result<()> {
+async fn send_reply(
+    writer: &mut tokio::net::unix::OwnedWriteHalf,
+    reply: &NbdReply,
+    shutdown: &CancellationToken,
+) -> Result<IoOutcome> {
     let buf = protocol::serialize_reply(reply);
-    writer.write_all(&buf).await?;
-    Ok(())
+    write_all_or_shutdown(writer, &buf, shutdown).await
 }
 
 async fn send_success_reply(
     writer: &mut tokio::net::unix::OwnedWriteHalf,
     handle: u64,
-) -> Result<()> {
-    send_reply(writer, &success_reply(handle)).await
+    shutdown: &CancellationToken,
+) -> Result<IoOutcome> {
+    send_reply(writer, &success_reply(handle), shutdown).await
 }
 
 async fn send_error_reply(
     writer: &mut tokio::net::unix::OwnedWriteHalf,
     handle: u64,
     error: u32,
-) -> Result<()> {
-    send_reply(writer, &NbdReply { error, handle }).await
+    shutdown: &CancellationToken,
+) -> Result<IoOutcome> {
+    send_reply(writer, &NbdReply { error, handle }, shutdown).await
 }
 
 /// Discard `n` bytes from the reader to keep the protocol stream in sync.
 async fn discard_bytes(
     reader: &mut tokio::net::unix::OwnedReadHalf,
     mut remaining: u64,
-) -> Result<()> {
+    shutdown: &CancellationToken,
+) -> Result<IoOutcome> {
     let mut buf = [0u8; 4096];
     while remaining > 0 {
         let to_read = (remaining as usize).min(buf.len());
         let dest = buf
             .get_mut(..to_read)
             .ok_or_else(|| NbdCowError::Io(std::io::Error::other("discard slice error")))?;
-        reader.read_exact(dest).await?;
+        if let IoOutcome::Shutdown = read_exact_or_shutdown(reader, dest, shutdown).await? {
+            return Ok(IoOutcome::Shutdown);
+        }
         remaining -= to_read as u64;
     }
-    Ok(())
+    Ok(IoOutcome::Complete)
 }
 
 #[cfg(test)]
@@ -840,6 +961,128 @@ mod tests {
                 "shutdown should flush buffer"
             );
         }
+    }
+
+    async fn assert_dispatch_exits_after_shutdown(
+        task: tokio::task::JoinHandle<crate::error::Result<()>>,
+    ) {
+        tokio::time::timeout(std::time::Duration::from_secs(1), task)
+            .await
+            .expect("dispatch should exit after shutdown")
+            .expect("dispatch task should join")
+            .expect("dispatch should not fail");
+    }
+
+    async fn yield_to_dispatch() {
+        for _ in 0..10 {
+            tokio::task::yield_now().await;
+        }
+    }
+
+    #[tokio::test]
+    async fn dispatch_shutdown_while_write_payload_pending_exits() {
+        let base_data = vec![0x00; 8192];
+        let (_base, _cow_file, cow) = create_test_cow(&base_data);
+        let cow = Arc::new(RwLock::new(cow));
+
+        let (_reader, mut writer, task, shutdown) = setup_dispatch(cow).await;
+
+        let write_req = NbdRequest {
+            flags: 0,
+            command: Command::Write,
+            handle: 1,
+            offset: 0,
+            length: 4096,
+        };
+        writer
+            .write_all(&serialize_request(&write_req))
+            .await
+            .unwrap();
+        writer.write_all(&vec![0xAA; 512]).await.unwrap();
+        yield_to_dispatch().await;
+
+        shutdown.cancel();
+        assert_dispatch_exits_after_shutdown(task).await;
+    }
+
+    #[tokio::test]
+    async fn dispatch_shutdown_while_oversized_write_discard_pending_exits() {
+        let base_data = vec![0x00; 8192];
+        let (_base, _cow_file, cow) = create_test_cow(&base_data);
+        let cow = Arc::new(RwLock::new(cow));
+
+        let (_reader, mut writer, task, shutdown) = setup_dispatch(cow).await;
+
+        let write_req = NbdRequest {
+            flags: 0,
+            command: Command::Write,
+            handle: 1,
+            offset: 0,
+            length: 33 * 1024 * 1024,
+        };
+        writer
+            .write_all(&serialize_request(&write_req))
+            .await
+            .unwrap();
+        writer.write_all(&vec![0xAA; 64 * 1024]).await.unwrap();
+        yield_to_dispatch().await;
+
+        shutdown.cancel();
+        assert_dispatch_exits_after_shutdown(task).await;
+    }
+
+    #[tokio::test]
+    async fn dispatch_shutdown_during_partial_write_flushes_accepted_data() {
+        let base_data = vec![0x00; 8192];
+        let (_base, _cow_file, cow) = create_test_cow(&base_data);
+        let cow = Arc::new(RwLock::new(cow));
+
+        let (mut reader, mut writer, task, shutdown) = setup_dispatch(cow.clone()).await;
+
+        let accepted_write = NbdRequest {
+            flags: 0,
+            command: Command::Write,
+            handle: 1,
+            offset: 0,
+            length: 4096,
+        };
+        writer
+            .write_all(&serialize_request(&accepted_write))
+            .await
+            .unwrap();
+        writer.write_all(&vec![0xDD; 4096]).await.unwrap();
+        let mut reply_buf = [0u8; 16];
+        reader.read_exact(&mut reply_buf).await.unwrap();
+        assert_eq!(
+            u32::from_be_bytes([reply_buf[4], reply_buf[5], reply_buf[6], reply_buf[7]]),
+            0,
+            "accepted write should succeed"
+        );
+        {
+            let cow = cow.read().await;
+            assert_eq!(cow.buffered_block_count(), 1);
+        }
+
+        let partial_write = NbdRequest {
+            flags: 0,
+            command: Command::Write,
+            handle: 2,
+            offset: 4096,
+            length: 4096,
+        };
+        writer
+            .write_all(&serialize_request(&partial_write))
+            .await
+            .unwrap();
+        writer.write_all(&vec![0xEE; 512]).await.unwrap();
+        yield_to_dispatch().await;
+
+        shutdown.cancel();
+        assert_dispatch_exits_after_shutdown(task).await;
+
+        let cow = cow.read().await;
+        assert_eq!(cow.buffered_block_count(), 0);
+        assert_eq!(cow.dirty_block_count(), 1);
     }
 
     #[tokio::test]


### PR DESCRIPTION
## Summary

- make NBD dispatch socket reads and writes observe the shutdown token after request headers are parsed
- centralize clean-shutdown COW syncing when handlers report shutdown
- add regression coverage for shutdown while normal write payloads and oversized discard payloads are incomplete

Fixes #15463

## Tests

- Before fix: `cargo test -p nbd-cow dispatch_shutdown` failed with timeout in the three new pending-payload shutdown tests
- `cargo test -p nbd-cow dispatch_shutdown`
- `cargo test -p nbd-cow server::tests::dispatch_oversized_write_discards_and_returns_error`
- `cargo test -p nbd-cow server::tests::dispatch_read_write_disconnect`
- `cargo test -p nbd-cow server::tests::dispatch_shutdown_flushes_data`
- `cargo test -p nbd-cow --lib`
- `cargo clippy -p nbd-cow --all-targets --all-features`
- `cargo test -p nbd-cow`
- `cargo fmt --all -- --check`
- `cargo doc -p nbd-cow --all-features --no-deps`

## Notes

Pre-commit also ran workspace cargo fmt, clippy, and doc checks.
