### PR TITLE
fix(mitm-addon): normalize firewall metadata logs

### DIFF
--- a/crates/runner/mitm-addon/src/logging_utils.py
+++ b/crates/runner/mitm-addon/src/logging_utils.py
@@ -6,6 +6,7 @@ log entries, and extracting firewall metadata.
 
 import json
 import os
+from collections.abc import Mapping
 from datetime import datetime, timezone
 
 from mitmproxy import ctx, http
@@ -61,27 +62,27 @@ def log_proxy_entry(
     _write_jsonl_entry(proxy_log_path, entry, "proxy")
 
 
-def _metadata_str(meta: dict, key: str, default: str = "") -> str:
+def _metadata_str(meta: Mapping[str, object], key: str, default: str = "") -> str:
     value = meta.get(key)
     return value if isinstance(value, str) else default
 
 
-def _metadata_optional_str(meta: dict, key: str) -> str | None:
+def _metadata_optional_str(meta: Mapping[str, object], key: str) -> str | None:
     value = meta.get(key)
     return value if isinstance(value, str) else None
 
 
-def _metadata_bool(meta: dict, key: str, default: bool = False) -> bool:
+def _metadata_bool(meta: Mapping[str, object], key: str, default: bool = False) -> bool:
     value = meta.get(key)
     return value if isinstance(value, bool) else default
 
 
-def _metadata_optional_bool(meta: dict, key: str) -> bool | None:
+def _metadata_optional_bool(meta: Mapping[str, object], key: str) -> bool | None:
     value = meta.get(key)
     return value if isinstance(value, bool) else None
 
 
-def _metadata_str_list(meta: dict, key: str) -> list[str] | None:
+def _metadata_str_list(meta: Mapping[str, object], key: str) -> list[str] | None:
     value = meta.get(key)
     if not isinstance(value, list):
         return None
@@ -93,7 +94,7 @@ def _metadata_str_list(meta: dict, key: str) -> list[str] | None:
     return result
 
 
-def _metadata_str_record(meta: dict, key: str) -> dict[str, str] | None:
+def _metadata_str_record(meta: Mapping[str, object], key: str) -> dict[str, str] | None:
     value = meta.get(key)
     if not isinstance(value, dict):
         return None

--- a/crates/runner/mitm-addon/src/logging_utils.py
+++ b/crates/runner/mitm-addon/src/logging_utils.py
@@ -61,26 +61,78 @@ def log_proxy_entry(
     _write_jsonl_entry(proxy_log_path, entry, "proxy")
 
 
+def _metadata_str(meta: dict, key: str, default: str = "") -> str:
+    value = meta.get(key)
+    return value if isinstance(value, str) else default
+
+
+def _metadata_optional_str(meta: dict, key: str) -> str | None:
+    value = meta.get(key)
+    return value if isinstance(value, str) else None
+
+
+def _metadata_bool(meta: dict, key: str, default: bool = False) -> bool:
+    value = meta.get(key)
+    return value if isinstance(value, bool) else default
+
+
+def _metadata_optional_bool(meta: dict, key: str) -> bool | None:
+    value = meta.get(key)
+    return value if isinstance(value, bool) else None
+
+
+def _metadata_str_list(meta: dict, key: str) -> list[str] | None:
+    value = meta.get(key)
+    if not isinstance(value, list):
+        return None
+    result: list[str] = []
+    for item in value:
+        if not isinstance(item, str):
+            return None
+        result.append(item)
+    return result
+
+
+def _metadata_str_record(meta: dict, key: str) -> dict[str, str] | None:
+    value = meta.get(key)
+    if not isinstance(value, dict):
+        return None
+    result: dict[str, str] = {}
+    for item_key, item_value in value.items():
+        if not isinstance(item_key, str) or not isinstance(item_value, str):
+            return None
+        result[item_key] = item_value
+    return result
+
+
 def add_firewall_metadata(flow: http.HTTPFlow, log_entry: dict) -> None:
     """Copy firewall and auth metadata from flow into a log entry."""
     # [NETWORK_LOG_FIELDS] — keep in sync with all network log schemas
     meta = flow.metadata
-    log_entry["firewall_base"] = meta.get(metadata_keys.FIREWALL_BASE, "")
-    log_entry["firewall_name"] = meta.get(metadata_keys.FIREWALL_NAME, "")
-    log_entry["firewall_permission"] = meta.get(metadata_keys.FIREWALL_PERMISSION, "")
-    log_entry["firewall_rule_match"] = meta.get(metadata_keys.FIREWALL_RULE_MATCH, "")
-    log_entry["firewall_billable"] = meta.get(metadata_keys.FIREWALL_BILLABLE, False)
+    log_entry["firewall_base"] = _metadata_str(meta, metadata_keys.FIREWALL_BASE)
+    log_entry["firewall_name"] = _metadata_str(meta, metadata_keys.FIREWALL_NAME)
+    log_entry["firewall_permission"] = _metadata_str(meta, metadata_keys.FIREWALL_PERMISSION)
+    log_entry["firewall_rule_match"] = _metadata_str(meta, metadata_keys.FIREWALL_RULE_MATCH)
+    log_entry["firewall_billable"] = _metadata_bool(meta, metadata_keys.FIREWALL_BILLABLE)
 
-    # Optional fields — only include when present
-    for metadata_key, log_key in (
-        (metadata_keys.FIREWALL_PARAMS, "firewall_params"),
-        (metadata_keys.FIREWALL_ERROR, "firewall_error"),
-        (metadata_keys.AUTH_RESOLVED_SECRETS, "auth_resolved_secrets"),
-        (metadata_keys.AUTH_REFRESHED_CONNECTORS, "auth_refreshed_connectors"),
-        (metadata_keys.AUTH_REFRESHED_SECRETS, "auth_refreshed_secrets"),
-        (metadata_keys.AUTH_CACHE_HIT, "auth_cache_hit"),
-        (metadata_keys.AUTH_URL_REWRITE, "auth_url_rewrite"),
+    # Optional fields — only include when present with the network-log schema type.
+    for log_key, value in (
+        ("firewall_params", _metadata_str_record(meta, metadata_keys.FIREWALL_PARAMS)),
+        ("firewall_error", _metadata_optional_str(meta, metadata_keys.FIREWALL_ERROR)),
+        (
+            "auth_resolved_secrets",
+            _metadata_str_list(meta, metadata_keys.AUTH_RESOLVED_SECRETS),
+        ),
+        (
+            "auth_refreshed_connectors",
+            _metadata_str_list(meta, metadata_keys.AUTH_REFRESHED_CONNECTORS),
+        ),
+        (
+            "auth_refreshed_secrets",
+            _metadata_str_list(meta, metadata_keys.AUTH_REFRESHED_SECRETS),
+        ),
+        ("auth_cache_hit", _metadata_optional_bool(meta, metadata_keys.AUTH_CACHE_HIT)),
+        ("auth_url_rewrite", _metadata_optional_bool(meta, metadata_keys.AUTH_URL_REWRITE)),
     ):
-        value = meta.get(metadata_key)
         if value is not None:
             log_entry[log_key] = value

--- a/crates/runner/mitm-addon/tests/test_registry.py
+++ b/crates/runner/mitm-addon/tests/test_registry.py
@@ -4,6 +4,7 @@ import json
 from pathlib import Path
 from unittest.mock import MagicMock, patch
 
+import flow_metadata_keys as metadata_keys
 import logging_utils
 import matching
 import registry
@@ -651,3 +652,123 @@ class TestLogNetworkEntry:
         log.warn.assert_called_once()
         assert "Failed to write network log:" in log.warn.call_args.args[0]
         assert not log_path.exists()
+
+
+class TestAddFirewallMetadata:
+    def test_copies_valid_firewall_metadata(self):
+        flow = MagicMock()
+        flow.metadata = {
+            metadata_keys.FIREWALL_BASE: "https://api.example.com",
+            metadata_keys.FIREWALL_NAME: "example",
+            metadata_keys.FIREWALL_PERMISSION: "read",
+            metadata_keys.FIREWALL_RULE_MATCH: "GET /items",
+            metadata_keys.FIREWALL_BILLABLE: True,
+            metadata_keys.FIREWALL_PARAMS: {"owner": "vm0-ai", "repo": "vm0"},
+            metadata_keys.FIREWALL_ERROR: "TOKEN_REFRESH_FAILED",
+            metadata_keys.AUTH_RESOLVED_SECRETS: ["GITHUB_TOKEN"],
+            metadata_keys.AUTH_REFRESHED_CONNECTORS: ["github"],
+            metadata_keys.AUTH_REFRESHED_SECRETS: ["GITHUB_TOKEN"],
+            metadata_keys.AUTH_CACHE_HIT: False,
+            metadata_keys.AUTH_URL_REWRITE: True,
+        }
+        log_entry = {}
+
+        logging_utils.add_firewall_metadata(flow, log_entry)
+
+        assert log_entry == {
+            "firewall_base": "https://api.example.com",
+            "firewall_name": "example",
+            "firewall_permission": "read",
+            "firewall_rule_match": "GET /items",
+            "firewall_billable": True,
+            "firewall_params": {"owner": "vm0-ai", "repo": "vm0"},
+            "firewall_error": "TOKEN_REFRESH_FAILED",
+            "auth_resolved_secrets": ["GITHUB_TOKEN"],
+            "auth_refreshed_connectors": ["github"],
+            "auth_refreshed_secrets": ["GITHUB_TOKEN"],
+            "auth_cache_hit": False,
+            "auth_url_rewrite": True,
+        }
+
+    def test_defaults_missing_required_firewall_metadata(self):
+        flow = MagicMock()
+        flow.metadata = {}
+        log_entry = {}
+
+        logging_utils.add_firewall_metadata(flow, log_entry)
+
+        assert log_entry == {
+            "firewall_base": "",
+            "firewall_name": "",
+            "firewall_permission": "",
+            "firewall_rule_match": "",
+            "firewall_billable": False,
+        }
+
+    def test_defaults_malformed_required_firewall_metadata(self):
+        for billable in (None, "true", 1):
+            flow = MagicMock()
+            flow.metadata = {
+                metadata_keys.FIREWALL_BASE: None,
+                metadata_keys.FIREWALL_NAME: 42,
+                metadata_keys.FIREWALL_PERMISSION: False,
+                metadata_keys.FIREWALL_RULE_MATCH: ["GET /items"],
+                metadata_keys.FIREWALL_BILLABLE: billable,
+            }
+            log_entry = {}
+
+            logging_utils.add_firewall_metadata(flow, log_entry)
+
+            assert log_entry == {
+                "firewall_base": "",
+                "firewall_name": "",
+                "firewall_permission": "",
+                "firewall_rule_match": "",
+                "firewall_billable": False,
+            }
+
+    def test_omits_optional_none_metadata(self):
+        flow = MagicMock()
+        flow.metadata = {
+            metadata_keys.FIREWALL_PARAMS: None,
+            metadata_keys.FIREWALL_ERROR: None,
+            metadata_keys.AUTH_RESOLVED_SECRETS: None,
+            metadata_keys.AUTH_REFRESHED_CONNECTORS: None,
+            metadata_keys.AUTH_REFRESHED_SECRETS: None,
+            metadata_keys.AUTH_CACHE_HIT: None,
+            metadata_keys.AUTH_URL_REWRITE: None,
+        }
+        log_entry = {}
+
+        logging_utils.add_firewall_metadata(flow, log_entry)
+
+        assert log_entry == {
+            "firewall_base": "",
+            "firewall_name": "",
+            "firewall_permission": "",
+            "firewall_rule_match": "",
+            "firewall_billable": False,
+        }
+
+    def test_omits_malformed_optional_metadata(self):
+        flow = MagicMock()
+        flow.metadata = {
+            metadata_keys.FIREWALL_PARAMS: {"owner": "vm0-ai", "branch": None},
+            metadata_keys.FIREWALL_ERROR: 123,
+            metadata_keys.AUTH_RESOLVED_SECRETS: ["GITHUB_TOKEN", None],
+            metadata_keys.AUTH_REFRESHED_CONNECTORS: "github",
+            metadata_keys.AUTH_REFRESHED_SECRETS: [1],
+            metadata_keys.AUTH_CACHE_HIT: "false",
+            metadata_keys.AUTH_URL_REWRITE: 1,
+        }
+        log_entry = {}
+
+        logging_utils.add_firewall_metadata(flow, log_entry)
+
+        assert log_entry == {
+            "firewall_base": "",
+            "firewall_name": "",
+            "firewall_permission": "",
+            "firewall_rule_match": "",
+            "firewall_billable": False,
+        }


### PR DESCRIPTION
## Summary

- normalize firewall/auth metadata at the mitm-addon network-log boundary
- default malformed required firewall fields to schema-safe values
- omit malformed optional firewall/auth metadata instead of emitting invalid telemetry fields
- add focused pytest coverage for valid, missing, null, and malformed metadata

Closes #15483

## Tests

- `/tmp/vm0-mitm-addon-test-venv/bin/python -m pytest tests/test_registry.py -v`
- `/tmp/vm0-mitm-addon-test-venv/bin/python -m pytest tests/test_response_handler.py tests/test_error_handler.py -v`
- `/tmp/vm0-mitm-addon-test-venv/bin/python -m pytest tests/`
- `/tmp/vm0-mitm-addon-test-venv/bin/ruff check .`
- `/tmp/vm0-mitm-addon-test-venv/bin/ruff format --check .`
- `/tmp/vm0-mitm-addon-test-venv/bin/basedpyright -p . --pythonpath /tmp/vm0-mitm-addon-test-venv/bin/python`
- `git diff --check`
