### PR TITLE
test: assert auth cache hit distribution

### DIFF
--- a/crates/runner/mitm-addon/tests/test_auth_cache.py
+++ b/crates/runner/mitm-addon/tests/test_auth_cache.py
@@ -43,7 +43,9 @@ class TestFirewallHeaderCache:
 
         assert fetch_count == 1
         assert all(r["headers"] == {"Authorization": "Bearer token"} for r in results)
-        assert all(r["cache_hit"] is False or r["cache_hit"] is True for r in results)
+        cache_hit_flags = [result["cache_hit"] for result in results]
+        assert sum(flag is False for flag in cache_hit_flags) == 1
+        assert sum(flag is True for flag in cache_hit_flags) == 2
 
     async def test_different_keys_fetch_independently(self, headers):
         """Different (run_id, api_id) pairs should fetch independently."""


### PR DESCRIPTION
## Summary
- tighten the concurrent firewall auth cache test to assert the expected cache-hit distribution
- verify one cache miss and two cache hits without depending on result order
- keep the change test-only with no timing or synchronization machinery

Fixes #15474

## Tests
- `python3 -m pytest tests/test_auth_cache.py -q`
- `python3 -m ruff check tests/test_auth_cache.py`
- `python3 -m ruff format --check tests/test_auth_cache.py`
- `python3 -m basedpyright -p .`