### PR TITLE
fix(mitm-addon): distinguish log failure diagnostics

### DIFF
--- a/crates/runner/mitm-addon/src/logging_utils.py
+++ b/crates/runner/mitm-addon/src/logging_utils.py
@@ -26,13 +26,18 @@ def _write_jsonl_entry(log_path: str, entry: dict, log_name: str) -> None:
         return
     try:
         line = (json.dumps(entry) + "\n").encode()
+    except Exception as e:
+        ctx.log.warn(f"Failed to encode {log_name} log: {type(e).__name__}: {e}")
+        return
+
+    try:
         fd = os.open(log_path, os.O_CREAT | os.O_APPEND | os.O_WRONLY, 0o644)
         try:
             os.write(fd, line)
         finally:
             os.close(fd)
     except Exception as e:
-        ctx.log.warn(f"Failed to write {log_name} log: {e}")
+        ctx.log.warn(f"Failed to write {log_name} log: {type(e).__name__}: {e}")
 
 
 def log_network_entry(log_path: str, entry: dict) -> None:

--- a/crates/runner/mitm-addon/tests/test_registry.py
+++ b/crates/runner/mitm-addon/tests/test_registry.py
@@ -640,7 +640,9 @@ class TestLogNetworkEntry:
             logging_utils.log_network_entry(str(log_path), {"action": "ALLOW"})
 
         log.warn.assert_called_once()
-        assert "Failed to write network log:" in log.warn.call_args.args[0]
+        warning = log.warn.call_args.args[0]
+        assert "Failed to write network log:" in warning
+        assert "FileNotFoundError" in warning
 
     def test_non_serializable_entry_warns_without_creating_file(self, tmp_path):
         log_path = tmp_path / "net.jsonl"
@@ -650,7 +652,8 @@ class TestLogNetworkEntry:
             logging_utils.log_network_entry(str(log_path), {"payload": b"binary"})
 
         log.warn.assert_called_once()
-        assert "Failed to write network log:" in log.warn.call_args.args[0]
+        warning = log.warn.call_args.args[0]
+        assert "Failed to encode network log: TypeError:" in warning
         assert not log_path.exists()
 
 

--- a/crates/runner/mitm-addon/tests/test_utils.py
+++ b/crates/runner/mitm-addon/tests/test_utils.py
@@ -143,7 +143,9 @@ class TestLogProxyEntry:
             )
 
         log.warn.assert_called_once()
-        assert "Failed to write proxy log:" in log.warn.call_args.args[0]
+        warning = log.warn.call_args.args[0]
+        assert "Failed to write proxy log:" in warning
+        assert "FileNotFoundError" in warning
 
     def test_directory_path_warns_and_does_not_raise(self, tmp_path):
         log = MagicMock()
@@ -152,7 +154,9 @@ class TestLogProxyEntry:
             logging_utils.log_proxy_entry(str(tmp_path), "warn", "message")
 
         log.warn.assert_called_once()
-        assert "Failed to write proxy log:" in log.warn.call_args.args[0]
+        warning = log.warn.call_args.args[0]
+        assert "Failed to write proxy log:" in warning
+        assert "IsADirectoryError" in warning
 
     def test_non_serializable_extra_warns_without_creating_file(self, tmp_path):
         proxy_path = tmp_path / "proxy-test.jsonl"
@@ -164,7 +168,8 @@ class TestLogProxyEntry:
             )
 
         log.warn.assert_called_once()
-        assert "Failed to write proxy log:" in log.warn.call_args.args[0]
+        warning = log.warn.call_args.args[0]
+        assert "Failed to encode proxy log: TypeError:" in warning
         assert not proxy_path.exists()
 
     def test_extra_cannot_override_reserved_fields(self, tmp_path):


### PR DESCRIPTION
## Summary
- split mitm-addon JSONL logging diagnostics into encode and write failure phases
- include exception class names in best-effort warning messages
- update proxy and network log tests for representative serialization and filesystem failures

## Tests
- python3 -m pytest tests/test_utils.py tests/test_registry.py
- python3 -m ruff check src/logging_utils.py tests/test_utils.py tests/test_registry.py

Fixes #15484