### PR TITLE
refactor: deduplicate x response field extraction

### DIFF
--- a/crates/runner/mitm-addon/src/usage/providers/connectors/x.py
+++ b/crates/runner/mitm-addon/src/usage/providers/connectors/x.py
@@ -20,7 +20,7 @@ from logging_utils import log_proxy_entry
 
 from ...buffer import UsageEvent, buffer_usage_events
 from ...idempotency import USAGE_EVENT_NAMESPACE_CONNECTOR
-from ...json_selective import JsonSelectiveExtractor, ScalarField
+from ...json_selective import JsonExtractionResult, JsonSelectiveExtractor, ScalarField
 from .response_parser import ConnectorResponseParser
 from .x_billing import (
     classify_bucket,
@@ -72,6 +72,52 @@ _X_JSON_RESULT_COUNT_FIELDS = {
     ("meta", "result_count"): ScalarField("int", max_bytes=64),
     ("meta", "total_tweet_count"): ScalarField("int", max_bytes=64),
 }
+
+
+def _create_x_json_selective_extractor() -> JsonSelectiveExtractor:
+    return JsonSelectiveExtractor(
+        scalar_fields=_X_JSON_RESULT_COUNT_FIELDS,
+        array_count_paths={("data",), ("errors",)},
+        wildcard_array_count_paths={("includes", "*")},
+        object_presence_paths={(), ("data",)},
+    )
+
+
+def _parse_x_json_response_fields(extracted: JsonExtractionResult) -> dict:
+    result: dict = {}
+
+    data_count = extracted.array_counts.get(("data",))
+    if data_count is not None:
+        result["response_data_count"] = data_count
+    elif ("data",) in extracted.object_present:
+        result["response_data_count"] = 1
+
+    errors_count = extracted.array_counts.get(("errors",), 0)
+    if errors_count:
+        result["response_errors_count"] = errors_count
+
+    includes = extracted.wildcard_array_counts.get(("includes", "*"), {})
+    if includes:
+        result["response_includes"] = dict(includes)
+
+    rcs = [
+        value
+        for path in (("meta", "result_count"), ("meta", "total_tweet_count"))
+        if isinstance((value := extracted.values.get(path)), int) and not isinstance(value, bool)
+    ]
+    if rcs:
+        result["response_result_count"] = max(rcs)
+
+    return result
+
+
+def _parse_x_json_response_fields_from_body(body: bytes) -> dict | None:
+    extractor = _create_x_json_selective_extractor()
+    extractor.feed(body)
+    extracted = extractor.finish()
+    if not extracted.complete or () not in extracted.object_present:
+        return None
+    return _parse_x_json_response_fields(extracted)
 
 
 class NdjsonState(TypedDict):
@@ -193,12 +239,7 @@ class XJsonResponseExtractor:
     """Incrementally extract billing metadata from non-streaming X JSON."""
 
     def __init__(self) -> None:
-        self._extractor = JsonSelectiveExtractor(
-            scalar_fields=_X_JSON_RESULT_COUNT_FIELDS,
-            array_count_paths={("data",), ("errors",)},
-            wildcard_array_count_paths={("includes", "*")},
-            object_presence_paths={(), ("data",)},
-        )
+        self._extractor = _create_x_json_selective_extractor()
 
     def feed(self, chunk: bytes) -> None:
         self._extractor.feed(chunk)
@@ -212,28 +253,7 @@ class XJsonResponseExtractor:
             return result, None
 
         result["body_parsed"] = True
-        data_count = extracted.array_counts.get(("data",))
-        if data_count is not None:
-            result["response_data_count"] = data_count
-        elif ("data",) in extracted.object_present:
-            result["response_data_count"] = 1
-
-        errors_count = extracted.array_counts.get(("errors",), 0)
-        if errors_count:
-            result["response_errors_count"] = errors_count
-
-        includes = extracted.wildcard_array_counts.get(("includes", "*"), {})
-        if includes:
-            result["response_includes"] = dict(includes)
-
-        rcs = [
-            value
-            for path in (("meta", "result_count"), ("meta", "total_tweet_count"))
-            if isinstance((value := extracted.values.get(path)), int)
-        ]
-        if rcs:
-            result["response_result_count"] = max(rcs)
-
+        result.update(_parse_x_json_response_fields(extracted))
         return result, None
 
 
@@ -340,7 +360,7 @@ def _parse_response_metadata(flow: http.HTTPFlow) -> dict:
     incremental parser that populates ``flow.metadata[metadata_keys.X_NDJSON_STATE]``
     as response bytes arrive.  When that state is present we return its
     accumulated counters directly (``body_format: "ndjson"``) and skip
-    the legacy buffered ``json.loads`` fallback, since stream buffers are
+    the legacy buffered fallback, since stream buffers are
     capped at ``STREAM_BUFFER_LIMIT`` and don't contain the full response.
     For streams ``body_truncated`` is always ``False`` — the incremental
     parser saw every byte even if the forensic ``stream_buffer`` filled up.
@@ -388,43 +408,12 @@ def _parse_response_metadata(flow: http.HTTPFlow) -> dict:
     body = body_utils.decompress_body(
         bytes(buf), flow.response.headers, max_output=body_utils.LARGE_RESPONSE_DECOMPRESS_LIMIT
     )
-    try:
-        data = json.loads(body)
-    except (json.JSONDecodeError, UnicodeDecodeError, ValueError):
-        return result
-    if not isinstance(data, dict):
+    fields = _parse_x_json_response_fields_from_body(body)
+    if fields is None:
         return result
 
     result["body_parsed"] = True
-
-    payload = data.get("data")
-    if isinstance(payload, list):
-        result["response_data_count"] = len(payload)
-    elif isinstance(payload, dict):
-        result["response_data_count"] = 1
-
-    errors = data.get("errors")
-    if isinstance(errors, list) and errors:
-        result["response_errors_count"] = len(errors)
-
-    includes = data.get("includes")
-    if isinstance(includes, dict):
-        counts = {k: len(v) for k, v in includes.items() if isinstance(v, list)}
-        if counts:
-            result["response_includes"] = counts
-
-    meta = data.get("meta")
-    if isinstance(meta, dict):
-        # ``result_count`` is the standard search/paginated field;
-        # ``total_tweet_count`` is the counts-endpoint variant where
-        # ``data`` is time buckets rather than tweets.  Prefer whichever
-        # is present (mutually exclusive in practice; if both appear,
-        # take the larger to stay on the safe side of billing).
-        candidates = [meta.get("result_count"), meta.get("total_tweet_count")]
-        rcs = [c for c in candidates if isinstance(c, int)]
-        if rcs:
-            result["response_result_count"] = max(rcs)
-
+    result.update(fields)
     return result
 
 

--- a/crates/runner/mitm-addon/tests/test_connector_usage.py
+++ b/crates/runner/mitm-addon/tests/test_connector_usage.py
@@ -883,6 +883,62 @@ class TestReportConnectorUsage:
 
     # ---- fallback / unparseable cases ----
 
+    def test_legacy_x_json_metadata_extracts_selective_fields(self, tmp_path, real_flow):
+        """Buffered fallback should share X JSON field semantics with the selective parser."""
+        body = json.dumps(
+            {
+                "data": [{"id": "1"}, {"id": "2"}],
+                "errors": [{"title": "partial failure"}],
+                "includes": {
+                    "users": [{"id": "u1"}],
+                    "media": [],
+                    "topics": "ignored",
+                },
+                "meta": {"result_count": 2, "total_tweet_count": 3},
+            }
+        ).encode()
+        flow = self._make_x_flow(real_flow, tmp_path, body=body)
+
+        metadata = usage_x_connector._parse_response_metadata(flow)
+
+        assert metadata == {
+            "body_parsed": True,
+            "body_truncated": False,
+            "response_data_count": 2,
+            "response_errors_count": 1,
+            "response_includes": {"users": 1, "media": 0},
+            "response_result_count": 3,
+        }
+
+    def test_legacy_x_json_metadata_preserves_truncated_state(self, tmp_path, real_flow):
+        body = json.dumps({"data": [{"id": "1"}]}).encode()
+        flow = self._make_x_flow(real_flow, tmp_path, body=body)
+        flow.metadata["stream_buffer_state"] = {"truncated": True}
+
+        metadata = usage_x_connector._parse_response_metadata(flow)
+
+        assert metadata["body_parsed"] is True
+        assert metadata["body_truncated"] is True
+        assert metadata["response_data_count"] == 1
+
+    @pytest.mark.parametrize("body", [b"not json", b"[1,2,3]"])
+    def test_legacy_x_json_metadata_keeps_unparseable_bodies_unparsed(
+        self, tmp_path, real_flow, body
+    ):
+        flow = self._make_x_flow(real_flow, tmp_path, body=body)
+
+        metadata = usage_x_connector._parse_response_metadata(flow)
+
+        assert metadata == {"body_parsed": False, "body_truncated": False}
+
+    def test_legacy_x_json_metadata_ignores_boolean_result_count(self, tmp_path, real_flow):
+        body = json.dumps({"meta": {"result_count": True}}).encode()
+        flow = self._make_x_flow(real_flow, tmp_path, body=body)
+
+        metadata = usage_x_connector._parse_response_metadata(flow)
+
+        assert metadata == {"body_parsed": True, "body_truncated": False}
+
     def test_truncated_buffer_with_no_hints_skips_billing(self, tmp_path, real_flow):
         """Unparseable body + no URL hints → skip emission and log an
         error.  The previous blind fallback of 100 units was removed;

--- a/crates/runner/mitm-addon/tests/test_connector_usage.py
+++ b/crates/runner/mitm-addon/tests/test_connector_usage.py
@@ -243,7 +243,7 @@ class TestReportConnectorUsage:
         payloads = self._call_and_get_billing(flow)
         assert payloads == []
 
-    def test_soft_error_emits_no_billing(self, tmp_path, real_flow):
+    def test_soft_error_with_request_hints_emits_no_billing(self, tmp_path, real_flow):
         """HTTP 200 + errors array + no data field emits no usage_event
         row (issue #9620)."""
         body = json.dumps(
@@ -263,9 +263,10 @@ class TestReportConnectorUsage:
         flow = self._make_x_flow(
             real_flow,
             tmp_path,
-            path="/2/tweets/999999999999999999",
+            path="/2/tweets",
+            query="ids=999999999999999999",
             body=body,
-            rule="GET /2/tweets/{id}",
+            rule="GET /2/tweets",
         )
         payloads = self._call_and_get_billing(flow)
         assert payloads == []
@@ -883,7 +884,7 @@ class TestReportConnectorUsage:
 
     # ---- fallback / unparseable cases ----
 
-    def test_legacy_x_json_metadata_extracts_selective_fields(self, tmp_path, real_flow):
+    def test_legacy_x_json_fallback_extracts_selective_field_counts(self, tmp_path, real_flow):
         """Buffered fallback should share X JSON field semantics with the selective parser."""
         body = json.dumps(
             {
@@ -899,45 +900,23 @@ class TestReportConnectorUsage:
         ).encode()
         flow = self._make_x_flow(real_flow, tmp_path, body=body)
 
-        metadata = usage_x_connector._parse_response_metadata(flow)
+        payloads = self._call_and_get_billing(flow)
 
-        assert metadata == {
-            "body_parsed": True,
-            "body_truncated": False,
-            "response_data_count": 2,
-            "response_errors_count": 1,
-            "response_includes": {"users": 1, "media": 0},
-            "response_result_count": 3,
-        }
+        by_cat = {p["category"]: p["quantity"] for p in payloads}
+        assert by_cat == {"posts.read": 3, "user.read": 1}
 
-    def test_legacy_x_json_metadata_preserves_truncated_state(self, tmp_path, real_flow):
-        body = json.dumps({"data": [{"id": "1"}]}).encode()
-        flow = self._make_x_flow(real_flow, tmp_path, body=body)
-        flow.metadata["stream_buffer_state"] = {"truncated": True}
-
-        metadata = usage_x_connector._parse_response_metadata(flow)
-
-        assert metadata["body_parsed"] is True
-        assert metadata["body_truncated"] is True
-        assert metadata["response_data_count"] == 1
-
-    @pytest.mark.parametrize("body", [b"not json", b"[1,2,3]"])
-    def test_legacy_x_json_metadata_keeps_unparseable_bodies_unparsed(
-        self, tmp_path, real_flow, body
-    ):
-        flow = self._make_x_flow(real_flow, tmp_path, body=body)
-
-        metadata = usage_x_connector._parse_response_metadata(flow)
-
-        assert metadata == {"body_parsed": False, "body_truncated": False}
-
-    def test_legacy_x_json_metadata_ignores_boolean_result_count(self, tmp_path, real_flow):
+    def test_legacy_x_json_fallback_ignores_boolean_result_count(self, tmp_path, real_flow):
         body = json.dumps({"meta": {"result_count": True}}).encode()
         flow = self._make_x_flow(real_flow, tmp_path, body=body)
+        proxy_log = tmp_path / "proxy.jsonl"
 
-        metadata = usage_x_connector._parse_response_metadata(flow)
+        payloads = self._call_and_get_billing(flow)
 
-        assert metadata == {"body_parsed": True, "body_truncated": False}
+        assert payloads == []
+        if proxy_log.exists():
+            entries = [json.loads(line) for line in proxy_log.read_text().splitlines()]
+            assert all(entry["level"] != "error" for entry in entries)
+            assert all("unparseable" not in entry["message"].lower() for entry in entries)
 
     def test_truncated_buffer_with_no_hints_skips_billing(self, tmp_path, real_flow):
         """Unparseable body + no URL hints → skip emission and log an


### PR DESCRIPTION
## Summary

- Share X JSON response field extraction through the selective parser result conversion.
- Keep incremental parser lifecycle state separate from legacy buffered fallback state.
- Replace the legacy buffered `json.loads` field traversal with one-shot selective extraction.
- Add regression coverage for fallback field extraction, truncation state, malformed/non-object bodies, and boolean result counts.

Closes #15472

## Tests

- `python3 -m pytest tests/test_connector_usage.py -q -k 'legacy_x_json_fallback or truncated_buffer_with_no_hints or invalid_json_with_no_hints or non_dict_json_with_no_hints'`
- `python3 -m pytest tests/test_connector_usage.py -q -k 'soft_error_with_request_hints or legacy_x_json_fallback or truncated_buffer_with_no_hints or invalid_json_with_no_hints or non_dict_json_with_no_hints'`
- `python3 -m pytest tests/test_connector_usage.py -q`
- `python3 -m pytest tests/test_response_streaming.py::TestXJsonFinalize -q`
- `python3 -m pytest tests/test_response_headers_handler.py -q -k 'x_non_stream_endpoint or x_stream_endpoint or x_stream_rules or x_stream_error_response'`
- `python3 -m ruff check src/usage/providers/connectors/x.py tests/test_connector_usage.py`
- `python3 -m ruff format --check src/usage/providers/connectors/x.py tests/test_connector_usage.py`
- `python3 -m basedpyright -p .`
