### PR TITLE
refactor: bind connector grant providers to auth methods

### DIFF
--- a/turbo/apps/api/src/signals/routes/connector-auth-code-start.ts
+++ b/turbo/apps/api/src/signals/routes/connector-auth-code-start.ts
@@ -1,4 +1,5 @@
 import {
+  connectorAuthMethodHasGrantKind,
   getConnectorAuthMethod,
   resolveConnectorAuthClientForMethod,
   type ConnectorAuthClient,
@@ -7,6 +8,7 @@ import {
 import type {
   AuthCodeGrantConnectorType,
   ConnectorAuthMethodId,
+  ConnectorAuthMethodIdsByGrantKind,
 } from "@vm0/connectors/connectors";
 import {
   buildConnectorAuthCodeAuthorizationUrl,
@@ -31,7 +33,10 @@ type ResolveConnectorAuthCodeStartMethodResult =
   | {
       readonly ok: true;
       readonly type: AuthCodeGrantConnectorType;
-      readonly authMethod: ConnectorAuthMethodId;
+      readonly authMethod: ConnectorAuthMethodIdsByGrantKind<
+        AuthCodeGrantConnectorType,
+        "auth-code"
+      >;
     }
   | {
       readonly ok: false;
@@ -50,7 +55,7 @@ export function resolveConnectorAuthCodeStartMethod(
   if (!method) {
     return { ok: false, reason: "missing_auth_method" };
   }
-  if (method.grant.kind !== "auth-code") {
+  if (!connectorAuthMethodHasGrantKind(type, authMethod, "auth-code")) {
     return { ok: false, reason: "wrong_grant_kind" };
   }
 
@@ -61,7 +66,10 @@ export function resolveConnectorAuthCodeStartMethod(
 // the selected auth method for this auth-code flow.
 export function prepareResolvedConnectorAuthCodeStart(args: {
   readonly type: AuthCodeGrantConnectorType;
-  readonly authMethod: ConnectorAuthMethodId;
+  readonly authMethod: ConnectorAuthMethodIdsByGrantKind<
+    AuthCodeGrantConnectorType,
+    "auth-code"
+  >;
   readonly origin: string;
   readonly readEnv: ConnectorEnvReader;
 }): PrepareResolvedConnectorAuthCodeStartResult {
@@ -86,6 +94,10 @@ export function prepareResolvedConnectorAuthCodeStart(args: {
 
 export async function buildResolvedConnectorAuthCodeAuthUrl(args: {
   readonly type: AuthCodeGrantConnectorType;
+  readonly authMethod: ConnectorAuthMethodIdsByGrantKind<
+    AuthCodeGrantConnectorType,
+    "auth-code"
+  >;
   readonly authClient: ConnectorAuthClient;
   readonly redirectUri: string;
   readonly state: string;
@@ -93,6 +105,7 @@ export async function buildResolvedConnectorAuthCodeAuthUrl(args: {
   return normalizeAuthUrlResult(
     await buildConnectorAuthCodeAuthorizationUrl({
       type: args.type,
+      authMethod: args.authMethod,
       authClient: args.authClient,
       redirectUri: args.redirectUri,
       state: args.state,

--- a/turbo/apps/api/src/signals/routes/connector-auth-code-start.ts
+++ b/turbo/apps/api/src/signals/routes/connector-auth-code-start.ts
@@ -7,8 +7,8 @@ import {
 } from "@vm0/connectors/connector-utils";
 import type {
   AuthCodeGrantConnectorType,
+  ConnectorAuthCodeGrantAuthMethodId,
   ConnectorAuthMethodId,
-  ConnectorAuthMethodIdsByGrantKind,
 } from "@vm0/connectors/connectors";
 import {
   buildConnectorAuthCodeAuthorizationUrl,
@@ -33,10 +33,7 @@ type ResolveConnectorAuthCodeStartMethodResult =
   | {
       readonly ok: true;
       readonly type: AuthCodeGrantConnectorType;
-      readonly authMethod: ConnectorAuthMethodIdsByGrantKind<
-        AuthCodeGrantConnectorType,
-        "auth-code"
-      >;
+      readonly authMethod: ConnectorAuthCodeGrantAuthMethodId;
     }
   | {
       readonly ok: false;
@@ -66,10 +63,7 @@ export function resolveConnectorAuthCodeStartMethod(
 // the selected auth method for this auth-code flow.
 export function prepareResolvedConnectorAuthCodeStart(args: {
   readonly type: AuthCodeGrantConnectorType;
-  readonly authMethod: ConnectorAuthMethodIdsByGrantKind<
-    AuthCodeGrantConnectorType,
-    "auth-code"
-  >;
+  readonly authMethod: ConnectorAuthCodeGrantAuthMethodId;
   readonly origin: string;
   readonly readEnv: ConnectorEnvReader;
 }): PrepareResolvedConnectorAuthCodeStartResult {
@@ -94,10 +88,7 @@ export function prepareResolvedConnectorAuthCodeStart(args: {
 
 export async function buildResolvedConnectorAuthCodeAuthUrl(args: {
   readonly type: AuthCodeGrantConnectorType;
-  readonly authMethod: ConnectorAuthMethodIdsByGrantKind<
-    AuthCodeGrantConnectorType,
-    "auth-code"
-  >;
+  readonly authMethod: ConnectorAuthCodeGrantAuthMethodId;
   readonly authClient: ConnectorAuthClient;
   readonly redirectUri: string;
   readonly state: string;

--- a/turbo/apps/api/src/signals/routes/connectors-type-callback.ts
+++ b/turbo/apps/api/src/signals/routes/connectors-type-callback.ts
@@ -1,6 +1,7 @@
 import { command } from "ccstate";
 import { connectorsTypeCallbackContract } from "@vm0/api-contracts/contracts/connectors-type-callback";
 import {
+  connectorAuthMethodHasGrantKind,
   getConnectorAuthMethod,
   resolveConnectorAuthClientForMethod,
   getConnectorAuthMethodGrantScopes,
@@ -10,7 +11,7 @@ import {
   connectorAuthMethodIdSchema,
   connectorTypeSchema,
   type AuthCodeGrantConnectorType,
-  type ConnectorAuthMethodId,
+  type ConnectorAuthMethodIdsByGrantKind,
 } from "@vm0/connectors/connectors";
 import {
   exchangeConnectorAuthCode,
@@ -51,9 +52,14 @@ type CallbackIdentity = {
   readonly orgId: string;
 };
 
+type AuthCodeGrantAuthMethod = ConnectorAuthMethodIdsByGrantKind<
+  AuthCodeGrantConnectorType,
+  "auth-code"
+>;
+
 type CompleteOAuthCallbackInput = {
   readonly connectorType: AuthCodeGrantConnectorType;
-  readonly authMethod: ConnectorAuthMethodId;
+  readonly authMethod: AuthCodeGrantAuthMethod;
   readonly code: string;
   readonly redirectUri: string;
   readonly state: string;
@@ -77,7 +83,7 @@ type ResolvedCallbackState =
       readonly ok: true;
       readonly identity: CallbackIdentity;
       readonly sessionId: string | undefined;
-      readonly authMethod: ConnectorAuthMethodId;
+      readonly authMethod: AuthCodeGrantAuthMethod;
       readonly codeVerifier: string | undefined;
       readonly oauthContext: string | undefined;
       readonly redirectUri: string;
@@ -146,7 +152,7 @@ function missingStateRedirectResponse(origin: string, type: string): Response {
 
 async function exchangeTokenForConnector(args: {
   readonly connectorType: AuthCodeGrantConnectorType;
-  readonly authMethod: ConnectorAuthMethodId;
+  readonly authMethod: AuthCodeGrantAuthMethod;
   readonly code: string;
   readonly redirectUri: string;
   readonly state: string | undefined;
@@ -164,6 +170,7 @@ async function exchangeTokenForConnector(args: {
 
   return await exchangeConnectorAuthCode({
     type: args.connectorType,
+    authMethod: args.authMethod,
     authClient,
     code: args.code,
     redirectUri: args.redirectUri,
@@ -175,7 +182,7 @@ async function exchangeTokenForConnector(args: {
 
 function getRequestedScopes(
   connectorType: AuthCodeGrantConnectorType,
-  authMethod: ConnectorAuthMethodId,
+  authMethod: AuthCodeGrantAuthMethod,
 ): readonly string[] {
   return getConnectorAuthMethodGrantScopes(connectorType, authMethod);
 }
@@ -314,7 +321,7 @@ function validateStoredAuthCodeMethod(args: {
   readonly origin: string;
   readonly type: string;
 }):
-  | { readonly ok: true; readonly authMethod: ConnectorAuthMethodId }
+  | { readonly ok: true; readonly authMethod: AuthCodeGrantAuthMethod }
   | { readonly ok: false; readonly response: Response } {
   const authMethodResult = connectorAuthMethodIdSchema.safeParse(
     args.authMethod,
@@ -330,7 +337,19 @@ function validateStoredAuthCodeMethod(args: {
     args.connectorType,
     authMethodResult.data,
   );
-  if (!method || method.grant.kind !== "auth-code") {
+  if (!method) {
+    return {
+      ok: false,
+      response: invalidStoredAuthMethodResponse(args.origin, args.type),
+    };
+  }
+  if (
+    !connectorAuthMethodHasGrantKind(
+      args.connectorType,
+      authMethodResult.data,
+      "auth-code",
+    )
+  ) {
     return {
       ok: false,
       response: invalidStoredAuthMethodResponse(args.origin, args.type),
@@ -348,7 +367,7 @@ async function resolveTrustedCallbackAuthMethod(args: {
   readonly type: string;
   readonly signal: AbortSignal;
 }): Promise<
-  | { readonly ok: true; readonly authMethod: ConnectorAuthMethodId }
+  | { readonly ok: true; readonly authMethod: AuthCodeGrantAuthMethod }
   | { readonly ok: false; readonly response: Response }
 > {
   const storedAuthMethod = validateStoredAuthCodeMethod({

--- a/turbo/apps/api/src/signals/routes/connectors-type-callback.ts
+++ b/turbo/apps/api/src/signals/routes/connectors-type-callback.ts
@@ -11,7 +11,7 @@ import {
   connectorAuthMethodIdSchema,
   connectorTypeSchema,
   type AuthCodeGrantConnectorType,
-  type ConnectorAuthMethodIdsByGrantKind,
+  type ConnectorAuthCodeGrantAuthMethodId,
 } from "@vm0/connectors/connectors";
 import {
   exchangeConnectorAuthCode,
@@ -52,14 +52,9 @@ type CallbackIdentity = {
   readonly orgId: string;
 };
 
-type AuthCodeGrantAuthMethod = ConnectorAuthMethodIdsByGrantKind<
-  AuthCodeGrantConnectorType,
-  "auth-code"
->;
-
 type CompleteOAuthCallbackInput = {
   readonly connectorType: AuthCodeGrantConnectorType;
-  readonly authMethod: AuthCodeGrantAuthMethod;
+  readonly authMethod: ConnectorAuthCodeGrantAuthMethodId;
   readonly code: string;
   readonly redirectUri: string;
   readonly state: string;
@@ -83,7 +78,7 @@ type ResolvedCallbackState =
       readonly ok: true;
       readonly identity: CallbackIdentity;
       readonly sessionId: string | undefined;
-      readonly authMethod: AuthCodeGrantAuthMethod;
+      readonly authMethod: ConnectorAuthCodeGrantAuthMethodId;
       readonly codeVerifier: string | undefined;
       readonly oauthContext: string | undefined;
       readonly redirectUri: string;
@@ -152,7 +147,7 @@ function missingStateRedirectResponse(origin: string, type: string): Response {
 
 async function exchangeTokenForConnector(args: {
   readonly connectorType: AuthCodeGrantConnectorType;
-  readonly authMethod: AuthCodeGrantAuthMethod;
+  readonly authMethod: ConnectorAuthCodeGrantAuthMethodId;
   readonly code: string;
   readonly redirectUri: string;
   readonly state: string | undefined;
@@ -182,7 +177,7 @@ async function exchangeTokenForConnector(args: {
 
 function getRequestedScopes(
   connectorType: AuthCodeGrantConnectorType,
-  authMethod: AuthCodeGrantAuthMethod,
+  authMethod: ConnectorAuthCodeGrantAuthMethodId,
 ): readonly string[] {
   return getConnectorAuthMethodGrantScopes(connectorType, authMethod);
 }
@@ -321,7 +316,10 @@ function validateStoredAuthCodeMethod(args: {
   readonly origin: string;
   readonly type: string;
 }):
-  | { readonly ok: true; readonly authMethod: AuthCodeGrantAuthMethod }
+  | {
+      readonly ok: true;
+      readonly authMethod: ConnectorAuthCodeGrantAuthMethodId;
+    }
   | { readonly ok: false; readonly response: Response } {
   const authMethodResult = connectorAuthMethodIdSchema.safeParse(
     args.authMethod,
@@ -367,7 +365,10 @@ async function resolveTrustedCallbackAuthMethod(args: {
   readonly type: string;
   readonly signal: AbortSignal;
 }): Promise<
-  | { readonly ok: true; readonly authMethod: AuthCodeGrantAuthMethod }
+  | {
+      readonly ok: true;
+      readonly authMethod: ConnectorAuthCodeGrantAuthMethodId;
+    }
   | { readonly ok: false; readonly response: Response }
 > {
   const storedAuthMethod = validateStoredAuthCodeMethod({

--- a/turbo/apps/api/src/signals/routes/github-oauth.ts
+++ b/turbo/apps/api/src/signals/routes/github-oauth.ts
@@ -742,10 +742,12 @@ const callbackGithubUserOauth$ = command(
       return worksErrorRedirect("GitHub OAuth is not configured");
     }
 
+    const authMethod = getGithubConnectorAuthCodeMethod();
     const origin = getOAuthWebOrigin(request);
     const redirectUri = githubUserConnectCallbackRedirectUri(origin);
     const token = await exchangeConnectorAuthCode({
       type: "github",
+      authMethod,
       authClient,
       code: query.code,
       redirectUri,
@@ -765,7 +767,6 @@ const callbackGithubUserOauth$ = command(
       return worksErrorRedirect("No GitHub installation found");
     }
 
-    const authMethod = getGithubConnectorAuthCodeMethod();
     await set(
       upsertConnectorTokenConnection$,
       {

--- a/turbo/apps/api/src/signals/routes/zero-connectors.ts
+++ b/turbo/apps/api/src/signals/routes/zero-connectors.ts
@@ -534,6 +534,7 @@ export function createAuthorizeConnectorInner(route: ConnectorAuthorizeRoute) {
     }
     const authResult = await buildResolvedConnectorAuthCodeAuthUrl({
       type: authCodeStartType.type,
+      authMethod: authCodeStartType.authMethod,
       authClient: prepared.authClient,
       redirectUri: prepared.redirectUri,
       state: prepared.state,
@@ -636,6 +637,7 @@ const startConnectorOauthInner$ = command(
     }
     const authResult = await buildResolvedConnectorAuthCodeAuthUrl({
       type: authCodeStartType.type,
+      authMethod: authCodeStartType.authMethod,
       authClient: prepared.authClient,
       redirectUri: prepared.redirectUri,
       state: prepared.state,

--- a/turbo/apps/api/src/signals/services/connector-oauth-device-auth.service.ts
+++ b/turbo/apps/api/src/signals/services/connector-oauth-device-auth.service.ts
@@ -8,7 +8,7 @@ import type {
 import {
   connectorAuthMethodIdSchema,
   type ConnectorAuthMethodId,
-  type ConnectorAuthMethodIdsByGrantKind,
+  type ConnectorDeviceAuthGrantAuthMethodId,
   type ConnectorType,
   type DeviceAuthGrantConnectorType,
 } from "@vm0/connectors/connectors";
@@ -89,7 +89,7 @@ type PollClaimedSessionArgs = {
   readonly orgId: string;
   readonly userId: string;
   readonly type: DeviceAuthGrantConnectorType;
-  readonly authMethod: DeviceAuthGrantAuthMethod;
+  readonly authMethod: ConnectorDeviceAuthGrantAuthMethodId;
   readonly authClient: ConnectorAuthClient;
   readonly session: DeviceAuthSessionRow;
   readonly claimStartedAt: Date;
@@ -103,14 +103,9 @@ type ResolvedDeviceAuthType = {
   readonly type: DeviceAuthGrantConnectorType;
 };
 
-type DeviceAuthGrantAuthMethod = ConnectorAuthMethodIdsByGrantKind<
-  DeviceAuthGrantConnectorType,
-  "device-auth"
->;
-
 type ResolvedDeviceAuthMethod = {
   readonly type: DeviceAuthGrantConnectorType;
-  readonly authMethod: DeviceAuthGrantAuthMethod;
+  readonly authMethod: ConnectorDeviceAuthGrantAuthMethodId;
 };
 
 const connectorOauthDeviceAuthDisabled = Object.freeze({
@@ -258,7 +253,7 @@ function resolveStoredDeviceAuthMethod(
 
 function resolveRequiredAuthClient(
   type: DeviceAuthGrantConnectorType,
-  authMethod: DeviceAuthGrantAuthMethod,
+  authMethod: ConnectorDeviceAuthGrantAuthMethodId,
 ): ConnectorAuthClient | ReturnType<typeof internalServerError> {
   const authClient = resolveConnectorAuthClientForMethod(
     type,

--- a/turbo/apps/api/src/signals/services/connector-oauth-device-auth.service.ts
+++ b/turbo/apps/api/src/signals/services/connector-oauth-device-auth.service.ts
@@ -8,10 +8,12 @@ import type {
 import {
   connectorAuthMethodIdSchema,
   type ConnectorAuthMethodId,
+  type ConnectorAuthMethodIdsByGrantKind,
   type ConnectorType,
   type DeviceAuthGrantConnectorType,
 } from "@vm0/connectors/connectors";
 import {
+  connectorAuthMethodHasGrantKind,
   getConnectorAuthMethod,
   resolveConnectorAuthClientForMethod,
   hasConnectorAuthCodeGrant,
@@ -87,6 +89,7 @@ type PollClaimedSessionArgs = {
   readonly orgId: string;
   readonly userId: string;
   readonly type: DeviceAuthGrantConnectorType;
+  readonly authMethod: DeviceAuthGrantAuthMethod;
   readonly authClient: ConnectorAuthClient;
   readonly session: DeviceAuthSessionRow;
   readonly claimStartedAt: Date;
@@ -100,9 +103,14 @@ type ResolvedDeviceAuthType = {
   readonly type: DeviceAuthGrantConnectorType;
 };
 
+type DeviceAuthGrantAuthMethod = ConnectorAuthMethodIdsByGrantKind<
+  DeviceAuthGrantConnectorType,
+  "device-auth"
+>;
+
 type ResolvedDeviceAuthMethod = {
   readonly type: DeviceAuthGrantConnectorType;
-  readonly authMethod: ConnectorAuthMethodId;
+  readonly authMethod: DeviceAuthGrantAuthMethod;
 };
 
 const connectorOauthDeviceAuthDisabled = Object.freeze({
@@ -222,7 +230,13 @@ function resolveDeviceAuthMethod(
       `${type} connector does not have ${authMethod} auth method`,
     );
   }
-  if (method.grant.kind !== "device-auth") {
+  if (
+    !connectorAuthMethodHasGrantKind(
+      resolvedType.type,
+      authMethodResult.data,
+      "device-auth",
+    )
+  ) {
     return badRequestMessage(
       `${type} ${authMethod} auth method does not use a device-auth grant`,
     );
@@ -244,7 +258,7 @@ function resolveStoredDeviceAuthMethod(
 
 function resolveRequiredAuthClient(
   type: DeviceAuthGrantConnectorType,
-  authMethod: ConnectorAuthMethodId,
+  authMethod: DeviceAuthGrantAuthMethod,
 ): ConnectorAuthClient | ReturnType<typeof internalServerError> {
   const authClient = resolveConnectorAuthClientForMethod(
     type,
@@ -642,6 +656,7 @@ async function runClaimedSession(
   });
   const pollResult = await pollConnectorDeviceAuthorization({
     type: args.type,
+    authMethod: args.authMethod,
     authClient: args.authClient,
     deviceCode: providerState.deviceCode,
   });
@@ -760,6 +775,7 @@ export const startConnectorOauthDeviceAuthSession$ = command(
 
     const startResult = await startConnectorDeviceAuthorization({
       type: resolvedMethod.type,
+      authMethod: resolvedMethod.authMethod,
       authClient,
     });
     signal.throwIfAborted();
@@ -951,6 +967,7 @@ export const pollConnectorOauthDeviceAuthSession$ = command(
       orgId: args.orgId,
       userId: args.userId,
       type: resolvedMethod.type,
+      authMethod: resolvedMethod.authMethod,
       authClient,
       session: claimedSession,
       claimStartedAt,

--- a/turbo/apps/api/src/signals/services/github-oauth.service.ts
+++ b/turbo/apps/api/src/signals/services/github-oauth.service.ts
@@ -18,7 +18,7 @@ import {
   isStaticConfidentialConnectorAuthClient,
   type ConnectorEnvReader,
 } from "@vm0/connectors/connector-utils";
-import type { ConnectorAuthMethodIdsByGrantKind } from "@vm0/connectors/connectors";
+import type { ConnectorAuthCodeGrantAuthMethodId } from "@vm0/connectors/connectors";
 import type { FeatureSwitchContext } from "@vm0/core/feature-switch";
 import { agentComposes } from "@vm0/db/schema/agent-compose";
 import { connectors } from "@vm0/db/schema/connector";
@@ -60,10 +60,7 @@ interface GithubOAuthState {
   readonly sig: string | null;
 }
 
-export function getGithubConnectorAuthCodeMethod(): ConnectorAuthMethodIdsByGrantKind<
-  "github",
-  "auth-code"
-> {
+export function getGithubConnectorAuthCodeMethod(): ConnectorAuthCodeGrantAuthMethodId<"github"> {
   const authMethod = getConnectorAuthMethodIdForGrantKind(
     "github",
     "auth-code",

--- a/turbo/apps/api/src/signals/services/github-oauth.service.ts
+++ b/turbo/apps/api/src/signals/services/github-oauth.service.ts
@@ -12,12 +12,13 @@ import {
   type AuthUrlResult,
 } from "@vm0/connectors/auth-providers";
 import {
+  connectorAuthMethodHasGrantKind,
   getConnectorAuthMethodIdForGrantKind,
   resolveConnectorAuthClientForMethod,
   isStaticConfidentialConnectorAuthClient,
   type ConnectorEnvReader,
 } from "@vm0/connectors/connector-utils";
-import type { ConnectorAuthMethodId } from "@vm0/connectors/connectors";
+import type { ConnectorAuthMethodIdsByGrantKind } from "@vm0/connectors/connectors";
 import type { FeatureSwitchContext } from "@vm0/core/feature-switch";
 import { agentComposes } from "@vm0/db/schema/agent-compose";
 import { connectors } from "@vm0/db/schema/connector";
@@ -59,12 +60,18 @@ interface GithubOAuthState {
   readonly sig: string | null;
 }
 
-export function getGithubConnectorAuthCodeMethod(): ConnectorAuthMethodId {
+export function getGithubConnectorAuthCodeMethod(): ConnectorAuthMethodIdsByGrantKind<
+  "github",
+  "auth-code"
+> {
   const authMethod = getConnectorAuthMethodIdForGrantKind(
     "github",
     "auth-code",
   );
-  if (!authMethod) {
+  if (
+    !authMethod ||
+    !connectorAuthMethodHasGrantKind("github", authMethod, "auth-code")
+  ) {
     throw new Error("github connector has no auth-code auth method");
   }
   return authMethod;
@@ -398,6 +405,7 @@ export async function buildGithubUserConnectAuthorizationUrl(args: {
   const authResult = normalizeAuthUrlResult(
     await buildConnectorAuthCodeAuthorizationUrl({
       type: "github",
+      authMethod,
       authClient,
       redirectUri,
       state,

--- a/turbo/packages/connectors/src/__tests__/connectors.test.ts
+++ b/turbo/packages/connectors/src/__tests__/connectors.test.ts
@@ -449,6 +449,14 @@ describe("connector provider capability checks", () => {
       expect(hasConnectorDeviceAuthGrantProvider(type)).toBe(
         deviceAuthGrantTypes.has(type),
       );
+      for (const authMethod of getConfiguredConnectorAuthMethods(type)) {
+        expect(hasConnectorAuthCodeGrantProvider(type, authMethod)).toBe(
+          connectorAuthMethodHasGrantKind(type, authMethod, "auth-code"),
+        );
+        expect(hasConnectorDeviceAuthGrantProvider(type, authMethod)).toBe(
+          connectorAuthMethodHasGrantKind(type, authMethod, "device-auth"),
+        );
+      }
     }
   });
 
@@ -668,6 +676,7 @@ describe("connector provider capability checks", () => {
         }
         const authResult = await buildConnectorAuthCodeAuthorizationUrl({
           type,
+          authMethod: "oauth",
           authClient: oauthClient,
           redirectUri: "https://app.test/callback",
           state: "state-123",
@@ -770,6 +779,7 @@ describe("connector provider capability checks", () => {
 
     const startResult = await startConnectorDeviceAuthorization({
       type: "test-oauth-device",
+      authMethod: "oauth",
       authClient: oauthClient,
     });
     expect(startResult).toStrictEqual({
@@ -785,6 +795,7 @@ describe("connector provider capability checks", () => {
     await expect(
       pollConnectorDeviceAuthorization({
         type: "test-oauth-device",
+        authMethod: "oauth",
         authClient: oauthClient,
         deviceCode: "pending",
       }),
@@ -792,6 +803,7 @@ describe("connector provider capability checks", () => {
     await expect(
       pollConnectorDeviceAuthorization({
         type: "test-oauth-device",
+        authMethod: "oauth",
         authClient: oauthClient,
         deviceCode: "slow-down",
       }),
@@ -799,6 +811,7 @@ describe("connector provider capability checks", () => {
     await expect(
       pollConnectorDeviceAuthorization({
         type: "test-oauth-device",
+        authMethod: "oauth",
         authClient: oauthClient,
         deviceCode: "denied",
       }),
@@ -810,6 +823,7 @@ describe("connector provider capability checks", () => {
     await expect(
       pollConnectorDeviceAuthorization({
         type: "test-oauth-device",
+        authMethod: "oauth",
         authClient: oauthClient,
         deviceCode: "expired",
       }),
@@ -821,6 +835,7 @@ describe("connector provider capability checks", () => {
     await expect(
       pollConnectorDeviceAuthorization({
         type: "test-oauth-device",
+        authMethod: "oauth",
         authClient: oauthClient,
         deviceCode: "error",
       }),
@@ -832,6 +847,7 @@ describe("connector provider capability checks", () => {
     await expect(
       pollConnectorDeviceAuthorization({
         type: "test-oauth-device",
+        authMethod: "oauth",
         authClient: oauthClient,
         deviceCode: "invalid-grant",
       }),
@@ -843,6 +859,7 @@ describe("connector provider capability checks", () => {
     await expect(
       pollConnectorDeviceAuthorization({
         type: "test-oauth-device",
+        authMethod: "oauth",
         authClient: oauthClient,
         deviceCode: startResult.deviceCode,
       }),
@@ -974,6 +991,7 @@ describe("connector provider capability checks", () => {
     await expect(
       startConnectorDeviceAuthorization({
         type: "base44",
+        authMethod: "oauth",
         authClient: oauthClient,
       }),
     ).resolves.toStrictEqual({
@@ -989,6 +1007,7 @@ describe("connector provider capability checks", () => {
     await expect(
       pollConnectorDeviceAuthorization({
         type: "base44",
+        authMethod: "oauth",
         authClient: oauthClient,
         deviceCode: "pending",
       }),
@@ -996,6 +1015,7 @@ describe("connector provider capability checks", () => {
     await expect(
       pollConnectorDeviceAuthorization({
         type: "base44",
+        authMethod: "oauth",
         authClient: oauthClient,
         deviceCode: "slow-down",
       }),
@@ -1003,6 +1023,7 @@ describe("connector provider capability checks", () => {
     await expect(
       pollConnectorDeviceAuthorization({
         type: "base44",
+        authMethod: "oauth",
         authClient: oauthClient,
         deviceCode: "denied",
       }),
@@ -1014,6 +1035,7 @@ describe("connector provider capability checks", () => {
     await expect(
       pollConnectorDeviceAuthorization({
         type: "base44",
+        authMethod: "oauth",
         authClient: oauthClient,
         deviceCode: "expired",
       }),
@@ -1025,6 +1047,7 @@ describe("connector provider capability checks", () => {
     await expect(
       pollConnectorDeviceAuthorization({
         type: "base44",
+        authMethod: "oauth",
         authClient: oauthClient,
         deviceCode: "temporarily-unavailable",
       }),
@@ -1036,6 +1059,7 @@ describe("connector provider capability checks", () => {
     await expect(
       pollConnectorDeviceAuthorization({
         type: "base44",
+        authMethod: "oauth",
         authClient: oauthClient,
         deviceCode: "base44-device-code",
       }),
@@ -1258,6 +1282,7 @@ describe("connector provider capability checks", () => {
     await expect(
       startConnectorDeviceAuthorization({
         type: "slock",
+        authMethod: "oauth",
         authClient: oauthClient,
       }),
     ).resolves.toStrictEqual({
@@ -1272,6 +1297,7 @@ describe("connector provider capability checks", () => {
     await expect(
       pollConnectorDeviceAuthorization({
         type: "slock",
+        authMethod: "oauth",
         authClient: oauthClient,
         deviceCode: "pending",
       }),
@@ -1279,6 +1305,7 @@ describe("connector provider capability checks", () => {
     await expect(
       pollConnectorDeviceAuthorization({
         type: "slock",
+        authMethod: "oauth",
         authClient: oauthClient,
         deviceCode: "denied",
       }),
@@ -1290,6 +1317,7 @@ describe("connector provider capability checks", () => {
     await expect(
       pollConnectorDeviceAuthorization({
         type: "slock",
+        authMethod: "oauth",
         authClient: oauthClient,
         deviceCode: "expired",
       }),
@@ -1301,6 +1329,7 @@ describe("connector provider capability checks", () => {
     await expect(
       pollConnectorDeviceAuthorization({
         type: "slock",
+        authMethod: "oauth",
         authClient: oauthClient,
         deviceCode: "no-servers",
       }),
@@ -1312,6 +1341,7 @@ describe("connector provider capability checks", () => {
     await expect(
       pollConnectorDeviceAuthorization({
         type: "slock",
+        authMethod: "oauth",
         authClient: oauthClient,
         deviceCode: "missing-refresh",
       }),
@@ -1322,6 +1352,7 @@ describe("connector provider capability checks", () => {
     await expect(
       pollConnectorDeviceAuthorization({
         type: "slock",
+        authMethod: "oauth",
         authClient: oauthClient,
         deviceCode: "server-error",
       }),
@@ -1334,6 +1365,7 @@ describe("connector provider capability checks", () => {
     await expect(
       pollConnectorDeviceAuthorization({
         type: "slock",
+        authMethod: "oauth",
         authClient: oauthClient,
         deviceCode: "userinfo-error",
       }),
@@ -1345,6 +1377,7 @@ describe("connector provider capability checks", () => {
     });
     const completeResult = await pollConnectorDeviceAuthorization({
       type: "slock",
+      authMethod: "oauth",
       authClient: oauthClient,
       deviceCode: "slock-device-code",
     });
@@ -1379,6 +1412,7 @@ describe("connector provider capability checks", () => {
 
     const malformedCompleteResult = await pollConnectorDeviceAuthorization({
       type: "slock",
+      authMethod: "oauth",
       authClient: oauthClient,
       deviceCode: "malformed-token",
     });

--- a/turbo/packages/connectors/src/auth-providers/connector-auth.ts
+++ b/turbo/packages/connectors/src/auth-providers/connector-auth.ts
@@ -5,6 +5,7 @@ import {
   type ConnectorAuthProviderType,
   type DeviceAuthGrantConnectorType,
   type ConnectorAuthMethodIdsByAccessKind,
+  type ConnectorAuthMethodIdsByGrantKind,
   type RefreshTokenAccessConnectorType,
   type TokenRevokeConnectorType,
 } from "@vm0/connectors/connectors";
@@ -12,6 +13,7 @@ import {
   connectorAuthMethodSupportsRefreshTokenAccess,
   connectorAuthMethodSupportsTokenRevoke,
   getConfiguredConnectorAuthMethods,
+  getConnectorAuthMethodGrantScopes,
   isStaticConfidentialConnectorAuthClient,
   isStaticConnectorAuthClient,
   resolveConnectorAuthClientForMethod,
@@ -40,7 +42,6 @@ import {
   type OAuthRefreshResult,
   type OAuthTokenResult,
 } from "./oauth/types";
-import { getDeviceAuthGrantConfig } from "./oauth/grant-config";
 import { providerEnvFromObject, type ProviderEnv } from "./provider-env";
 import { ahrefsProvider } from "./oauth/providers/ahrefs-provider";
 import { airtableProvider } from "./oauth/providers/airtable-provider";
@@ -110,12 +111,30 @@ export type ConnectorAuthProviderAccessTokenRevokeResult =
   | { readonly status: "revoked" }
   | { readonly status: "unsupported" };
 
+type ConnectorAuthCodeGrantProviderEntries<
+  Type extends AuthCodeGrantConnectorType,
+> = {
+  readonly [Method in ConnectorAuthMethodIdsByGrantKind<
+    Type,
+    "auth-code"
+  >]: AuthCodeConnectorAuthProvider<Type>;
+};
+
 type AuthCodeConnectorAuthProviderMap = {
-  readonly [Type in AuthCodeGrantConnectorType]: AuthCodeConnectorAuthProvider<Type>;
+  readonly [Type in AuthCodeGrantConnectorType]: ConnectorAuthCodeGrantProviderEntries<Type>;
+};
+
+type ConnectorDeviceAuthGrantProviderEntries<
+  Type extends DeviceAuthGrantConnectorType,
+> = {
+  readonly [Method in ConnectorAuthMethodIdsByGrantKind<
+    Type,
+    "device-auth"
+  >]: DeviceAuthConnectorAuthProvider<Type>;
 };
 
 type DeviceAuthConnectorAuthProviderMap = {
-  readonly [Type in DeviceAuthGrantConnectorType]: DeviceAuthConnectorAuthProvider<Type>;
+  readonly [Type in DeviceAuthGrantConnectorType]: ConnectorDeviceAuthGrantProviderEntries<Type>;
 };
 
 type ConnectorRefreshTokenAccessProviderEntries<
@@ -142,6 +161,28 @@ function connectorRefreshTokenAccessProviderFor<
   const providers = CONNECTOR_REFRESH_TOKEN_ACCESS_PROVIDERS[type] as Readonly<
     Record<string, RefreshTokenAccessProvider<T>>
   >;
+  return providers[authMethod];
+}
+
+function connectorAuthCodeGrantProviderFor<
+  T extends AuthCodeGrantConnectorType,
+>(
+  type: T,
+  authMethod: ConnectorAuthMethodIdsByGrantKind<T, "auth-code">,
+): AuthCodeConnectorAuthProvider<T> {
+  const providers: ConnectorAuthCodeGrantProviderEntries<T> =
+    AUTH_CODE_CONNECTOR_AUTH_PROVIDERS[type];
+  return providers[authMethod];
+}
+
+function connectorDeviceAuthGrantProviderFor<
+  T extends DeviceAuthGrantConnectorType,
+>(
+  type: T,
+  authMethod: ConnectorAuthMethodIdsByGrantKind<T, "device-auth">,
+): DeviceAuthConnectorAuthProvider<T> {
+  const providers: ConnectorDeviceAuthGrantProviderEntries<T> =
+    DEVICE_AUTH_CONNECTOR_AUTH_PROVIDERS[type];
   return providers[authMethod];
 }
 
@@ -226,58 +267,58 @@ async function revokeTokenRevokeConnectorAccessToken(args: {
 }
 
 const AUTH_CODE_CONNECTOR_AUTH_PROVIDERS: AuthCodeConnectorAuthProviderMap = {
-  ahrefs: ahrefsProvider,
-  airtable: airtableProvider,
-  asana: asanaProvider,
-  canva: canvaProvider,
-  close: closeProvider,
-  deel: deelProvider,
-  docusign: docusignProvider,
-  dropbox: dropboxProvider,
-  figma: figmaProvider,
-  "garmin-connect": garminConnectProvider,
-  gumroad: gumroadProvider,
-  github: githubProvider,
-  gmail: gmailProvider,
-  hubspot: hubspotProvider,
-  "google-ads": googleAdsProvider,
-  "google-calendar": googleCalendarProvider,
-  "google-docs": googleDocsProvider,
-  "google-drive": googleDriveProvider,
-  "google-meet": googleMeetProvider,
-  "google-sheets": googleSheetsProvider,
-  linear: linearProvider,
-  mailchimp: mailchimpProvider,
-  mercury: mercuryProvider,
-  monday: mondayProvider,
-  neon: neonProvider,
-  notion: notionProvider,
-  "outlook-calendar": outlookCalendarProvider,
-  "outlook-mail": outlookMailProvider,
-  reddit: redditProvider,
-  "intervals-icu": intervalsIcuProvider,
-  sentry: sentryProvider,
-  slack: slackProvider,
-  strava: stravaProvider,
-  stripe: stripeProvider,
-  todoist: todoistProvider,
-  vercel: vercelProvider,
-  webflow: webflowProvider,
-  supabase: supabaseProvider,
-  "meta-ads": metaAdsProvider,
-  posthog: posthogProvider,
-  spotify: spotifyProvider,
-  x: xProvider,
-  xero: xeroProvider,
-  zoom: zoomProvider,
-  "test-oauth": testOauthProvider,
+  ahrefs: { oauth: ahrefsProvider },
+  airtable: { oauth: airtableProvider },
+  asana: { oauth: asanaProvider },
+  canva: { oauth: canvaProvider },
+  close: { oauth: closeProvider },
+  deel: { oauth: deelProvider },
+  docusign: { oauth: docusignProvider },
+  dropbox: { oauth: dropboxProvider },
+  figma: { oauth: figmaProvider },
+  "garmin-connect": { oauth: garminConnectProvider },
+  gumroad: { oauth: gumroadProvider },
+  github: { oauth: githubProvider },
+  gmail: { oauth: gmailProvider },
+  hubspot: { oauth: hubspotProvider },
+  "google-ads": { oauth: googleAdsProvider },
+  "google-calendar": { oauth: googleCalendarProvider },
+  "google-docs": { oauth: googleDocsProvider },
+  "google-drive": { oauth: googleDriveProvider },
+  "google-meet": { oauth: googleMeetProvider },
+  "google-sheets": { oauth: googleSheetsProvider },
+  linear: { oauth: linearProvider },
+  mailchimp: { oauth: mailchimpProvider },
+  mercury: { oauth: mercuryProvider },
+  monday: { oauth: mondayProvider },
+  neon: { oauth: neonProvider },
+  notion: { oauth: notionProvider },
+  "outlook-calendar": { oauth: outlookCalendarProvider },
+  "outlook-mail": { oauth: outlookMailProvider },
+  reddit: { oauth: redditProvider },
+  "intervals-icu": { oauth: intervalsIcuProvider },
+  sentry: { oauth: sentryProvider },
+  slack: { oauth: slackProvider },
+  strava: { oauth: stravaProvider },
+  stripe: { oauth: stripeProvider },
+  todoist: { oauth: todoistProvider },
+  vercel: { oauth: vercelProvider },
+  webflow: { oauth: webflowProvider },
+  supabase: { oauth: supabaseProvider },
+  "meta-ads": { oauth: metaAdsProvider },
+  posthog: { oauth: posthogProvider },
+  spotify: { oauth: spotifyProvider },
+  x: { oauth: xProvider },
+  xero: { oauth: xeroProvider },
+  zoom: { oauth: zoomProvider },
+  "test-oauth": { oauth: testOauthProvider },
 };
 
 const DEVICE_AUTH_CONNECTOR_AUTH_PROVIDERS: DeviceAuthConnectorAuthProviderMap =
   {
-    base44: base44Provider,
-    slock: slockProvider,
-    "test-oauth-device": testOauthDeviceProvider,
+    base44: { oauth: base44Provider },
+    slock: { oauth: slockProvider },
+    "test-oauth-device": { oauth: testOauthDeviceProvider },
   };
 
 const CONNECTOR_REFRESH_TOKEN_ACCESS_PROVIDERS: ConnectorRefreshTokenAccessProviderMap =
@@ -334,14 +375,82 @@ export function hasConnectorAuthProvider(
 
 export function hasConnectorAuthCodeGrantProvider(
   type: string,
-): type is AuthCodeGrantConnectorType {
-  return Object.hasOwn(AUTH_CODE_CONNECTOR_AUTH_PROVIDERS, type);
+): type is AuthCodeGrantConnectorType;
+export function hasConnectorAuthCodeGrantProvider<
+  T extends AuthCodeGrantConnectorType,
+>(
+  type: T,
+  authMethod: string,
+): authMethod is ConnectorAuthMethodIdsByGrantKind<T, "auth-code">;
+export function hasConnectorAuthCodeGrantProvider(
+  type: string,
+  authMethod: string,
+): boolean;
+export function hasConnectorAuthCodeGrantProvider(
+  type: string,
+  authMethod?: string,
+): boolean {
+  if (authMethod === undefined) {
+    return Object.hasOwn(AUTH_CODE_CONNECTOR_AUTH_PROVIDERS, type);
+  }
+  return hasConnectorAuthCodeGrantProviderForMethod(type, authMethod);
+}
+
+function hasConnectorAuthCodeGrantProviderForMethod(
+  type: string,
+  authMethod: string,
+): boolean {
+  const connectorType = connectorTypeSchema.safeParse(type);
+  if (!connectorType.success) {
+    return false;
+  }
+  if (!hasConnectorAuthCodeGrantProvider(connectorType.data)) {
+    return false;
+  }
+  return Object.hasOwn(
+    AUTH_CODE_CONNECTOR_AUTH_PROVIDERS[connectorType.data],
+    authMethod,
+  );
 }
 
 export function hasConnectorDeviceAuthGrantProvider(
   type: string,
-): type is DeviceAuthGrantConnectorType {
-  return Object.hasOwn(DEVICE_AUTH_CONNECTOR_AUTH_PROVIDERS, type);
+): type is DeviceAuthGrantConnectorType;
+export function hasConnectorDeviceAuthGrantProvider<
+  T extends DeviceAuthGrantConnectorType,
+>(
+  type: T,
+  authMethod: string,
+): authMethod is ConnectorAuthMethodIdsByGrantKind<T, "device-auth">;
+export function hasConnectorDeviceAuthGrantProvider(
+  type: string,
+  authMethod: string,
+): boolean;
+export function hasConnectorDeviceAuthGrantProvider(
+  type: string,
+  authMethod?: string,
+): boolean {
+  if (authMethod === undefined) {
+    return Object.hasOwn(DEVICE_AUTH_CONNECTOR_AUTH_PROVIDERS, type);
+  }
+  return hasConnectorDeviceAuthGrantProviderForMethod(type, authMethod);
+}
+
+function hasConnectorDeviceAuthGrantProviderForMethod(
+  type: string,
+  authMethod: string,
+): boolean {
+  const connectorType = connectorTypeSchema.safeParse(type);
+  if (!connectorType.success) {
+    return false;
+  }
+  if (!hasConnectorDeviceAuthGrantProvider(connectorType.data)) {
+    return false;
+  }
+  return Object.hasOwn(
+    DEVICE_AUTH_CONNECTOR_AUTH_PROVIDERS[connectorType.data],
+    authMethod,
+  );
 }
 
 export function hasConnectorRefreshTokenAccessProvider(
@@ -385,23 +494,27 @@ export async function buildConnectorAuthCodeAuthorizationUrl<
   T extends AuthCodeGrantConnectorType,
 >(args: {
   readonly type: T;
+  readonly authMethod: ConnectorAuthMethodIdsByGrantKind<T, "auth-code">;
   readonly authClient: ConnectorAuthClient;
   readonly redirectUri: string;
   readonly state: string;
 }): Promise<string | AuthUrlResult> {
-  return await AUTH_CODE_CONNECTOR_AUTH_PROVIDERS[args.type].grant.buildAuthUrl(
-    {
-      ...connectorAuthProviderClientArgs(args.authClient),
-      redirectUri: args.redirectUri,
-      state: args.state,
-    } as ConnectorAuthCodeAuthorizeArgs<T>,
+  const provider = connectorAuthCodeGrantProviderFor(
+    args.type,
+    args.authMethod,
   );
+  return await provider.grant.buildAuthUrl({
+    ...connectorAuthProviderClientArgs(args.authClient),
+    redirectUri: args.redirectUri,
+    state: args.state,
+  } as ConnectorAuthCodeAuthorizeArgs<T>);
 }
 
 export async function exchangeConnectorAuthCode<
   T extends AuthCodeGrantConnectorType,
 >(args: {
   readonly type: T;
+  readonly authMethod: ConnectorAuthMethodIdsByGrantKind<T, "auth-code">;
   readonly authClient: ConnectorAuthClient;
   readonly code: string;
   readonly redirectUri: string;
@@ -409,30 +522,34 @@ export async function exchangeConnectorAuthCode<
   readonly codeVerifier: string | undefined;
   readonly oauthContext: string | undefined;
 }): Promise<OAuthTokenResult> {
-  return await AUTH_CODE_CONNECTOR_AUTH_PROVIDERS[args.type].grant.exchangeCode(
-    {
-      ...connectorAuthProviderClientArgs(args.authClient),
-      code: args.code,
-      redirectUri: args.redirectUri,
-      state: args.state,
-      codeVerifier: args.codeVerifier,
-      oauthContext: args.oauthContext,
-    } as ConnectorAuthCodeExchangeArgs<T>,
+  const provider = connectorAuthCodeGrantProviderFor(
+    args.type,
+    args.authMethod,
   );
+  return await provider.grant.exchangeCode({
+    ...connectorAuthProviderClientArgs(args.authClient),
+    code: args.code,
+    redirectUri: args.redirectUri,
+    state: args.state,
+    codeVerifier: args.codeVerifier,
+    oauthContext: args.oauthContext,
+  } as ConnectorAuthCodeExchangeArgs<T>);
 }
 
 export async function startConnectorDeviceAuthorization<
   T extends DeviceAuthGrantConnectorType,
 >(args: {
   readonly type: T;
+  readonly authMethod: ConnectorAuthMethodIdsByGrantKind<T, "device-auth">;
   readonly authClient: ConnectorAuthClient;
 }): Promise<OAuthDeviceAuthStartResult> {
-  const grant = getDeviceAuthGrantConfig(args.type);
-  return await DEVICE_AUTH_CONNECTOR_AUTH_PROVIDERS[
-    args.type
-  ].grant.startDeviceAuth({
+  const provider = connectorDeviceAuthGrantProviderFor(
+    args.type,
+    args.authMethod,
+  );
+  return await provider.grant.startDeviceAuth({
     ...connectorAuthProviderClientArgs(args.authClient),
-    scopes: grant.scopes,
+    scopes: getConnectorAuthMethodGrantScopes(args.type, args.authMethod),
   } as ConnectorDeviceAuthorizationStartArgs<T>);
 }
 
@@ -440,12 +557,15 @@ export async function pollConnectorDeviceAuthorization<
   T extends DeviceAuthGrantConnectorType,
 >(args: {
   readonly type: T;
+  readonly authMethod: ConnectorAuthMethodIdsByGrantKind<T, "device-auth">;
   readonly authClient: ConnectorAuthClient;
   readonly deviceCode: string;
 }): Promise<OAuthDeviceAuthPollResult> {
-  return await DEVICE_AUTH_CONNECTOR_AUTH_PROVIDERS[
-    args.type
-  ].grant.pollDeviceAuth({
+  const provider = connectorDeviceAuthGrantProviderFor(
+    args.type,
+    args.authMethod,
+  );
+  return await provider.grant.pollDeviceAuth({
     ...connectorAuthProviderClientArgs(args.authClient),
     deviceCode: args.deviceCode,
   } as ConnectorDeviceAuthorizationPollArgs<T>);

--- a/turbo/packages/connectors/src/auth-providers/connector-auth.ts
+++ b/turbo/packages/connectors/src/auth-providers/connector-auth.ts
@@ -1,11 +1,12 @@
 import {
   connectorTypeSchema,
-  type ConnectorType,
+  type ConnectorAuthCodeGrantAuthMethodId,
   type AuthCodeGrantConnectorType,
+  type ConnectorType,
   type ConnectorAuthProviderType,
+  type ConnectorDeviceAuthGrantAuthMethodId,
   type DeviceAuthGrantConnectorType,
   type ConnectorAuthMethodIdsByAccessKind,
-  type ConnectorAuthMethodIdsByGrantKind,
   type RefreshTokenAccessConnectorType,
   type TokenRevokeConnectorType,
 } from "@vm0/connectors/connectors";
@@ -114,10 +115,7 @@ export type ConnectorAuthProviderAccessTokenRevokeResult =
 type ConnectorAuthCodeGrantProviderEntries<
   Type extends AuthCodeGrantConnectorType,
 > = {
-  readonly [Method in ConnectorAuthMethodIdsByGrantKind<
-    Type,
-    "auth-code"
-  >]: AuthCodeConnectorAuthProvider<Type>;
+  readonly [Method in ConnectorAuthCodeGrantAuthMethodId<Type>]: AuthCodeConnectorAuthProvider<Type>;
 };
 
 type AuthCodeConnectorAuthProviderMap = {
@@ -127,10 +125,7 @@ type AuthCodeConnectorAuthProviderMap = {
 type ConnectorDeviceAuthGrantProviderEntries<
   Type extends DeviceAuthGrantConnectorType,
 > = {
-  readonly [Method in ConnectorAuthMethodIdsByGrantKind<
-    Type,
-    "device-auth"
-  >]: DeviceAuthConnectorAuthProvider<Type>;
+  readonly [Method in ConnectorDeviceAuthGrantAuthMethodId<Type>]: DeviceAuthConnectorAuthProvider<Type>;
 };
 
 type DeviceAuthConnectorAuthProviderMap = {
@@ -168,7 +163,7 @@ function connectorAuthCodeGrantProviderFor<
   T extends AuthCodeGrantConnectorType,
 >(
   type: T,
-  authMethod: ConnectorAuthMethodIdsByGrantKind<T, "auth-code">,
+  authMethod: ConnectorAuthCodeGrantAuthMethodId<T>,
 ): AuthCodeConnectorAuthProvider<T> {
   const providers: ConnectorAuthCodeGrantProviderEntries<T> =
     AUTH_CODE_CONNECTOR_AUTH_PROVIDERS[type];
@@ -179,7 +174,7 @@ function connectorDeviceAuthGrantProviderFor<
   T extends DeviceAuthGrantConnectorType,
 >(
   type: T,
-  authMethod: ConnectorAuthMethodIdsByGrantKind<T, "device-auth">,
+  authMethod: ConnectorDeviceAuthGrantAuthMethodId<T>,
 ): DeviceAuthConnectorAuthProvider<T> {
   const providers: ConnectorDeviceAuthGrantProviderEntries<T> =
     DEVICE_AUTH_CONNECTOR_AUTH_PROVIDERS[type];
@@ -381,7 +376,7 @@ export function hasConnectorAuthCodeGrantProvider<
 >(
   type: T,
   authMethod: string,
-): authMethod is ConnectorAuthMethodIdsByGrantKind<T, "auth-code">;
+): authMethod is ConnectorAuthCodeGrantAuthMethodId<T>;
 export function hasConnectorAuthCodeGrantProvider(
   type: string,
   authMethod: string,
@@ -421,7 +416,7 @@ export function hasConnectorDeviceAuthGrantProvider<
 >(
   type: T,
   authMethod: string,
-): authMethod is ConnectorAuthMethodIdsByGrantKind<T, "device-auth">;
+): authMethod is ConnectorDeviceAuthGrantAuthMethodId<T>;
 export function hasConnectorDeviceAuthGrantProvider(
   type: string,
   authMethod: string,
@@ -494,7 +489,7 @@ export async function buildConnectorAuthCodeAuthorizationUrl<
   T extends AuthCodeGrantConnectorType,
 >(args: {
   readonly type: T;
-  readonly authMethod: ConnectorAuthMethodIdsByGrantKind<T, "auth-code">;
+  readonly authMethod: ConnectorAuthCodeGrantAuthMethodId<T>;
   readonly authClient: ConnectorAuthClient;
   readonly redirectUri: string;
   readonly state: string;
@@ -514,7 +509,7 @@ export async function exchangeConnectorAuthCode<
   T extends AuthCodeGrantConnectorType,
 >(args: {
   readonly type: T;
-  readonly authMethod: ConnectorAuthMethodIdsByGrantKind<T, "auth-code">;
+  readonly authMethod: ConnectorAuthCodeGrantAuthMethodId<T>;
   readonly authClient: ConnectorAuthClient;
   readonly code: string;
   readonly redirectUri: string;
@@ -540,7 +535,7 @@ export async function startConnectorDeviceAuthorization<
   T extends DeviceAuthGrantConnectorType,
 >(args: {
   readonly type: T;
-  readonly authMethod: ConnectorAuthMethodIdsByGrantKind<T, "device-auth">;
+  readonly authMethod: ConnectorDeviceAuthGrantAuthMethodId<T>;
   readonly authClient: ConnectorAuthClient;
 }): Promise<OAuthDeviceAuthStartResult> {
   const provider = connectorDeviceAuthGrantProviderFor(
@@ -557,7 +552,7 @@ export async function pollConnectorDeviceAuthorization<
   T extends DeviceAuthGrantConnectorType,
 >(args: {
   readonly type: T;
-  readonly authMethod: ConnectorAuthMethodIdsByGrantKind<T, "device-auth">;
+  readonly authMethod: ConnectorDeviceAuthGrantAuthMethodId<T>;
   readonly authClient: ConnectorAuthClient;
   readonly deviceCode: string;
 }): Promise<OAuthDeviceAuthPollResult> {

--- a/turbo/packages/connectors/src/connector-utils.ts
+++ b/turbo/packages/connectors/src/connector-utils.ts
@@ -4,6 +4,7 @@ import {
   type ConnectorAuthMethodConfig,
   type ConnectorAuthMethodId,
   type ConnectorAuthMethodIds,
+  type ConnectorAuthMethodIdsByGrantKind,
   type ConnectorAuthMethodClientConfig,
   type ConnectorAccessConfig,
   type ConnectorAuthCodeGrantConfig,
@@ -86,7 +87,7 @@ export function getConnectorAuthMethodIdForGrantKind(
   grantKind: ConnectorGrantKind,
 ): ConnectorAuthMethodId | undefined {
   for (const authMethod of getConfiguredConnectorAuthMethods(type)) {
-    if (getConnectorAuthMethod(type, authMethod)?.grant.kind === grantKind) {
+    if (connectorAuthMethodHasGrantKind(type, authMethod, grantKind)) {
       return authMethod;
     }
   }
@@ -258,11 +259,14 @@ function getConnectorScopeBearingGrantConfig(
   return undefined;
 }
 
-export function connectorAuthMethodHasGrantKind(
-  type: ConnectorType,
+export function connectorAuthMethodHasGrantKind<
+  Type extends ConnectorType,
+  Kind extends ConnectorGrantKind,
+>(
+  type: Type,
   authMethod: string,
-  grantKind: ConnectorGrantKind,
-): boolean {
+  grantKind: Kind,
+): authMethod is ConnectorAuthMethodIdsByGrantKind<Type, Kind> {
   const method = getConnectorAuthMethod(type, authMethod);
   return method?.grant.kind === grantKind;
 }

--- a/turbo/packages/connectors/src/connectors.ts
+++ b/turbo/packages/connectors/src/connectors.ts
@@ -945,7 +945,7 @@ type InvalidAuthMethodRevokeKindConnectorType = {
 export type ConnectorAuthMethodRevokeKindsMatchKeys =
   AssertNever<InvalidAuthMethodRevokeKindConnectorType>;
 
-type ConnectorAuthMethodIdsByGrantKind<
+export type ConnectorAuthMethodIdsByGrantKind<
   Type extends ConnectorType,
   Kind extends ConnectorGrantKind,
 > = {

--- a/turbo/packages/connectors/src/connectors.ts
+++ b/turbo/packages/connectors/src/connectors.ts
@@ -1022,6 +1022,12 @@ export type ConnectorAuthProviderType = ConnectorTypesByGrantKind<
 export type AuthCodeGrantConnectorType = ConnectorTypesByGrantKind<"auth-code">;
 export type DeviceAuthGrantConnectorType =
   ConnectorTypesByGrantKind<"device-auth">;
+export type ConnectorAuthCodeGrantAuthMethodId<
+  Type extends AuthCodeGrantConnectorType = AuthCodeGrantConnectorType,
+> = ConnectorAuthMethodIdsByGrantKind<Type, "auth-code">;
+export type ConnectorDeviceAuthGrantAuthMethodId<
+  Type extends DeviceAuthGrantConnectorType = DeviceAuthGrantConnectorType,
+> = ConnectorAuthMethodIdsByGrantKind<Type, "device-auth">;
 export type RefreshTokenAccessConnectorType =
   ConnectorTypesByAccessKind<"refresh-token">;
 export type TokenRevokeConnectorType =


### PR DESCRIPTION
## Summary

- Bind auth-code and device-auth connector grant providers by `(connectorType, authMethod)` instead of connector type only.
- Thread selected auth methods through auth-code start/callback and device-auth start/poll provider calls.
- Add method-aware provider capability coverage while preserving existing connector behavior.

Closes #15551

## Validation

- `pnpm format`
- `pnpm -F @vm0/connectors check-types`
- `pnpm -F @vm0/connectors lint`
- `pnpm -F @vm0/connectors test`
- `pnpm -F api check-types`
- `pnpm -F api lint`
- `pnpm -F api test`
- `pnpm knip`
- `pnpm check-types`
- `pnpm -F web lint` after full `pnpm lint` hit local ENOMEM while oxlint read tabler icon files; all other full-lint tasks completed cleanly
