### PR TITLE
fix(vsock-guest): keep connection alive on malformed payloads

### DIFF
--- a/crates/vsock-guest/src/connection.rs
+++ b/crates/vsock-guest/src/connection.rs
@@ -12,7 +12,7 @@ use vsock_proto::{
 };
 
 use crate::error::to_io_error;
-use crate::exec_control::{ExecControlRegistry, handle_exec_control as route_exec_control};
+use crate::exec_control::{ExecControlRegistry, handle_decoded_exec_control as route_exec_control};
 use crate::exec_operation::{
     ExecOperationRegistry, ExecOperationWorkerRequest, cancel_exec_operation, send_error_response,
     start_exec_operation,
@@ -267,7 +267,15 @@ impl ConnectionDispatcher {
         if !require_non_zero_sequence(msg.seq, "exec cancel", &self.writer)? {
             return Ok(());
         }
-        vsock_proto::decode_exec_cancel(&msg.payload).map_err(to_io_error)?;
+        if let Err(error) = vsock_proto::decode_exec_cancel(&msg.payload) {
+            log(
+                "WARN",
+                &format!(
+                    "exec cancel: ignoring malformed payload seq={} error={error}",
+                    msg.seq
+                ),
+            );
+        }
         cancel_exec_operation(&self.exec_operation_registry, msg.seq);
         Ok(())
     }
@@ -276,19 +284,27 @@ impl ConnectionDispatcher {
         if !require_non_zero_sequence(msg.seq, "exec control", &self.writer)? {
             return Ok(());
         }
-        route_exec_control(
-            msg.seq,
-            &msg.payload,
-            &self.exec_control_registry,
-            &self.writer,
-        )
+        let decoded = match vsock_proto::decode_exec_control(&msg.payload) {
+            Ok(decoded) => decoded,
+            Err(error) => {
+                send_error_response(msg.seq, &error.to_string(), &self.writer)?;
+                return Ok(());
+            }
+        };
+        route_exec_control(msg.seq, decoded, &self.exec_control_registry, &self.writer)
     }
 
     fn handle_write_file(&self, msg: &RawMessage) -> io::Result<()> {
         if reject_operation_if_quiescing(&self.operation_state, msg.seq, &self.writer)? {
             return Ok(());
         }
-        let decoded = decode_write_file_message(msg)?;
+        let decoded = match decode_write_file_message(msg) {
+            Ok(decoded) => decoded,
+            Err(error) => {
+                send_error_response(msg.seq, &error.to_string(), &self.writer)?;
+                return Ok(());
+            }
+        };
         let Some(operation_guard) =
             acquire_operation_guard(&self.operation_state, msg.seq, &self.writer)?
         else {

--- a/crates/vsock-guest/src/exec_control.rs
+++ b/crates/vsock-guest/src/exec_control.rs
@@ -841,6 +841,7 @@ fn encode_control_result(
     )
 }
 
+#[cfg(test)]
 pub(crate) fn handle_exec_control(
     seq: u32,
     payload: &[u8],
@@ -848,6 +849,15 @@ pub(crate) fn handle_exec_control(
     writer: &GuestWriter,
 ) -> io::Result<()> {
     let request = vsock_proto::decode_exec_control(payload).map_err(to_io_error)?;
+    handle_decoded_exec_control(seq, request, registry, writer)
+}
+
+pub(crate) fn handle_decoded_exec_control(
+    seq: u32,
+    request: vsock_proto::DecodedExecControl<'_>,
+    registry: &ExecControlRegistry,
+    writer: &GuestWriter,
+) -> io::Result<()> {
     let owned = OwnedExecControlRequest {
         response_seq: seq,
         target_seq: request.target_seq,

--- a/crates/vsock-guest/src/handlers.rs
+++ b/crates/vsock-guest/src/handlers.rs
@@ -223,9 +223,8 @@ pub(crate) fn set_debug_guest_write_file_path(path: PathBuf) {
 
 pub(crate) fn decode_write_file_message(
     msg: &RawMessage,
-) -> io::Result<DecodedWriteFileMessage<'_>> {
-    let (path, content, use_sudo, append) =
-        vsock_proto::decode_write_file(&msg.payload).map_err(to_io_error)?;
+) -> Result<DecodedWriteFileMessage<'_>, vsock_proto::ProtocolError> {
+    let (path, content, use_sudo, append) = vsock_proto::decode_write_file(&msg.payload)?;
     Ok(DecodedWriteFileMessage {
         path,
         content,

--- a/crates/vsock-guest/tests/connection/exec_operation.rs
+++ b/crates/vsock-guest/tests/connection/exec_operation.rs
@@ -90,7 +90,7 @@ fn malformed_exec_control_payload_returns_error_and_keeps_connection_open() {
 
     send_control_payload(&mut host_stream, MSG_EXEC_CONTROL, 121, b"bad");
     let error = read_error_response(&mut host_stream, 121);
-    assert!(error.contains("exec_control"));
+    assert_eq!(error, "invalid payload: exec_control target_seq truncated");
 
     assert_ping_pong(&mut host_stream, 122);
 

--- a/crates/vsock-guest/tests/connection/exec_operation.rs
+++ b/crates/vsock-guest/tests/connection/exec_operation.rs
@@ -5,8 +5,9 @@ use std::time::Duration;
 use vsock_proto::{
     self, ExecControlNonce, ExecControlPolicy, ExecControlStatus, ExecLifecyclePolicy,
     ExecOutputPolicy, ExecOutputStream, ExecStartEncodeRequest, ExecTermination, ExecTimeoutPolicy,
-    MSG_ERROR, MSG_EXEC_CONTROL, MSG_EXEC_CONTROL_RESULT, MSG_EXEC_OUTPUT, MSG_EXEC_RESULT,
-    MSG_EXEC_START, MSG_EXEC_STARTED, MSG_OPERATIONS_QUIESCED, MSG_OPERATIONS_RESUMED,
+    MSG_ERROR, MSG_EXEC_CANCEL, MSG_EXEC_CONTROL, MSG_EXEC_CONTROL_RESULT, MSG_EXEC_OUTPUT,
+    MSG_EXEC_RESULT, MSG_EXEC_START, MSG_EXEC_STARTED, MSG_OPERATIONS_QUIESCED,
+    MSG_OPERATIONS_RESUMED,
 };
 
 use super::support::*;
@@ -81,6 +82,19 @@ fn send_exec_control(
             .unwrap();
     let msg = vsock_proto::encode(MSG_EXEC_CONTROL, request_seq, &payload).unwrap();
     stream.write_all(&msg).unwrap();
+}
+
+#[test]
+fn malformed_exec_control_payload_returns_error_and_keeps_connection_open() {
+    let (handle, mut host_stream) = start_guest_connection();
+
+    send_control_payload(&mut host_stream, MSG_EXEC_CONTROL, 121, b"bad");
+    let error = read_error_response(&mut host_stream, 121);
+    assert!(error.contains("exec_control"));
+
+    assert_ping_pong(&mut host_stream, 122);
+
+    finish_guest_connection(handle, host_stream);
 }
 
 fn assert_exec_control_result(
@@ -1466,6 +1480,38 @@ fn exec_operation_explicit_cancel_kills_child_and_returns_cancelled() {
     assert_eq!(result.termination, ExecTermination::Cancelled);
     wait_for_pid_exit(pid, "exec operation explicit cancel");
     child_guard.disarm();
+
+    finish_guest_connection(handle, host_stream);
+}
+
+#[test]
+fn malformed_exec_cancel_payload_still_cancels_and_keeps_connection_open() {
+    let pid_path = unique_pid_path("exec-operation-malformed-cancel");
+    let mut child_guard = ProcessGroupFileGuard::new(pid_path.as_str());
+    let (handle, mut host_stream) = start_guest_connection();
+
+    let command = format!("echo $$ > '{}'; sleep 60", pid_path.as_str());
+    send_exec_start(
+        &mut host_stream,
+        115,
+        &command,
+        LONG_RUNNING_EXEC_TIMEOUT_MS,
+        ExecOutputPolicy::Capture { limit_bytes: 64 },
+        ExecOutputPolicy::Capture { limit_bytes: 64 },
+    );
+    let pid = child_guard.read_pid();
+    assert!(
+        pid_alive(pid),
+        "exec operation child should be running before malformed cancel"
+    );
+
+    send_control_payload(&mut host_stream, MSG_EXEC_CANCEL, 115, b"unexpected");
+    let (_chunks, result) = read_exec_result(&mut host_stream, 115);
+
+    assert_eq!(result.termination, ExecTermination::Cancelled);
+    wait_for_pid_exit(pid, "exec operation malformed cancel");
+    child_guard.disarm();
+    assert_ping_pong(&mut host_stream, 116);
 
     finish_guest_connection(handle, host_stream);
 }

--- a/crates/vsock-guest/tests/connection/support.rs
+++ b/crates/vsock-guest/tests/connection/support.rs
@@ -8,8 +8,8 @@ use std::time::{Duration, Instant};
 use vsock_guest::handle_connection;
 use vsock_proto::{
     self, ExecCapturedOutput, ExecOutputPolicy, ExecOutputStream, ExecTermination, MSG_ERROR,
-    MSG_EXEC_CANCEL, MSG_EXEC_OUTPUT, MSG_EXEC_RESULT, MSG_EXEC_START, MSG_QUIESCE_OPERATIONS,
-    MSG_RESUME_OPERATIONS,
+    MSG_EXEC_CANCEL, MSG_EXEC_OUTPUT, MSG_EXEC_RESULT, MSG_EXEC_START, MSG_PING, MSG_PONG,
+    MSG_QUIESCE_OPERATIONS, MSG_RESUME_OPERATIONS,
 };
 
 pub(crate) const DRAIN_DEADLINE_SECS: u64 = 5;
@@ -220,6 +220,18 @@ pub(crate) fn read_error_response(stream: &mut impl std::io::Read, seq: u32) -> 
     assert_eq!(msg.msg_type, MSG_ERROR);
     assert_eq!(msg.seq, seq);
     vsock_proto::decode_error(&msg.payload).unwrap().to_owned()
+}
+
+pub(crate) fn assert_ping_pong<T>(stream: &mut T, seq: u32)
+where
+    T: std::io::Read + std::io::Write,
+{
+    let ping = vsock_proto::encode(MSG_PING, seq, &[]).unwrap();
+    stream.write_all(&ping).unwrap();
+    let pong = read_message(stream);
+    assert_eq!(pong.msg_type, MSG_PONG);
+    assert_eq!(pong.seq, seq);
+    assert!(pong.payload.is_empty());
 }
 
 pub(crate) fn send_exec_cancel(stream: &mut impl std::io::Write, seq: u32) {

--- a/crates/vsock-guest/tests/connection/write_file.rs
+++ b/crates/vsock-guest/tests/connection/write_file.rs
@@ -3,7 +3,8 @@ use std::io::Write;
 use vsock_proto::{self, MSG_WRITE_FILE, MSG_WRITE_FILE_RESULT};
 
 use super::support::{
-    finish_guest_connection, read_message, start_guest_connection, unique_tmp_path,
+    assert_ping_pong, finish_guest_connection, read_error_response, read_message,
+    send_control_payload, start_guest_connection, unique_tmp_path,
 };
 
 #[test]
@@ -23,6 +24,19 @@ fn write_file_seq_zero_is_not_rejected_as_invalid_sequence() {
         !error.contains("non-zero sequence"),
         "write_file seq=0 should reach the write_file handler, got: {error}"
     );
+
+    finish_guest_connection(handle, host_stream);
+}
+
+#[test]
+fn malformed_write_file_payload_returns_error_and_keeps_connection_open() {
+    let (handle, mut host_stream) = start_guest_connection();
+
+    send_control_payload(&mut host_stream, MSG_WRITE_FILE, 31, b"bad");
+    let error = read_error_response(&mut host_stream, 31);
+    assert!(error.contains("write_file"));
+
+    assert_ping_pong(&mut host_stream, 32);
 
     finish_guest_connection(handle, host_stream);
 }

--- a/crates/vsock-guest/tests/connection/write_file.rs
+++ b/crates/vsock-guest/tests/connection/write_file.rs
@@ -34,7 +34,7 @@ fn malformed_write_file_payload_returns_error_and_keeps_connection_open() {
 
     send_control_payload(&mut host_stream, MSG_WRITE_FILE, 31, b"bad");
     let error = read_error_response(&mut host_stream, 31);
-    assert!(error.contains("write_file"));
+    assert_eq!(error, "invalid payload: write_file path truncated");
 
     assert_ping_pong(&mut host_stream, 32);
 


### PR DESCRIPTION
## Summary

- Return protocol `MSG_ERROR` responses for malformed `write_file` and `exec_control` payloads without closing the guest connection.
- Treat non-empty `exec_cancel` payloads as cancel requests after validating the target sequence, avoiding target-sequence `MSG_ERROR` state divergence.
- Add connection-level regression coverage for malformed `write_file`, `exec_control`, and `exec_cancel` payloads.

## Tests

- `cargo test --manifest-path crates/vsock-guest/Cargo.toml --test connection`
- `cargo fmt --manifest-path crates/vsock-guest/Cargo.toml --check`
- `cargo clippy --manifest-path crates/vsock-guest/Cargo.toml --all-targets --all-features -- -D warnings`
- `cargo test -p vsock-guest --test connection` from `crates/`
- `cargo test --manifest-path crates/vsock-guest/Cargo.toml`
- `git diff --check`

Closes #15464
