### PR TITLE
feat(web): allow *.vm6.ai redirect origins on the staging preview domain

### DIFF
--- a/turbo/apps/web/src/lib/zero/url.test.ts
+++ b/turbo/apps/web/src/lib/zero/url.test.ts
@@ -1,0 +1,33 @@
+import { describe, expect, it, vi } from "vitest";
+import { reloadEnv } from "../../env";
+import { getAllowedRedirectOrigins } from "./url";
+
+// NEXT_PUBLIC_APP_URL is stubbed to http://localhost:3001 in the test setup.
+// Each case stubs NEXT_PUBLIC_PAID_ONBOARDING_URL and reloads the env cache;
+// unstubEnvs + the setup beforeEach restore defaults between tests.
+describe("getAllowedRedirectOrigins", () => {
+  it("appends the *.vm6.ai wildcard for a staging preview onboarding origin", () => {
+    vi.stubEnv("NEXT_PUBLIC_PAID_ONBOARDING_URL", "https://pr-1234-so.vm6.ai");
+    reloadEnv();
+    expect(getAllowedRedirectOrigins()).toEqual([
+      "http://localhost:3001",
+      "https://pr-1234-so.vm6.ai",
+      "https://*.vm6.ai",
+    ]);
+  });
+
+  it("keeps the exact origin with no wildcard for production so.vm0.ai", () => {
+    vi.stubEnv("NEXT_PUBLIC_PAID_ONBOARDING_URL", "https://so.vm0.ai");
+    reloadEnv();
+    expect(getAllowedRedirectOrigins()).toEqual([
+      "http://localhost:3001",
+      "https://so.vm0.ai",
+    ]);
+  });
+
+  it("returns the app URL only when no paid-onboarding origin is configured", () => {
+    vi.stubEnv("NEXT_PUBLIC_PAID_ONBOARDING_URL", undefined);
+    reloadEnv();
+    expect(getAllowedRedirectOrigins()).toEqual(["http://localhost:3001"]);
+  });
+});

--- a/turbo/apps/web/src/lib/zero/url.ts
+++ b/turbo/apps/web/src/lib/zero/url.ts
@@ -10,5 +10,20 @@ export function getAppUrl(): string {
 // sibling *.vm0.ai subdomain can run auth on www and return to itself.
 export function getAllowedRedirectOrigins(): string[] {
   const paidOnboardingUrl = env().NEXT_PUBLIC_PAID_ONBOARDING_URL;
-  return paidOnboardingUrl ? [getAppUrl(), paidOnboardingUrl] : [getAppUrl()];
+  if (!paidOnboardingUrl) {
+    return [getAppUrl()];
+  }
+  const origins = [getAppUrl(), paidOnboardingUrl];
+  // On the staging preview domain the paid LP/onboarding surface is deployed
+  // per preview (pr-N-so.vm6.ai, or the raw <hash>.vm6.ai). Allow the whole
+  // *.vm6.ai family so each preview can run auth on staging-www and return to
+  // itself. Production keeps the exact origin (so.vm0.ai), never a wildcard.
+  try {
+    if (new URL(paidOnboardingUrl).hostname.endsWith(".vm6.ai")) {
+      origins.push("https://*.vm6.ai");
+    }
+  } catch {
+    // Ignore a malformed paid-onboarding URL; the exact origin above still applies.
+  }
+  return origins;
 }


### PR DESCRIPTION
## What

`getAllowedRedirectOrigins()` returned a single exact paid-onboarding origin (`[appUrl, NEXT_PUBLIC_PAID_ONBOARDING_URL]`), so Clerk on **staging-www** only allowed redirecting back to `staging-so.vm6.ai`. Per-PR / raw preview deployments of the paid landing pages + onboarding (in `vm0-ai/vm0-marketing`) land on other `*.vm6.ai` subdomains (`pr-N-so.vm6.ai`, `<hash>.vm6.ai`) and were rejected by Clerk, falling back to the app instead of returning to the preview.

This unblocks driving `/staging-browser` against **any** so.vm0.ai preview (onboarding + LP verification) using the staging-www auth flow, not just the single `staging-so.vm6.ai`.

## Change

`turbo/apps/web/src/lib/zero/url.ts`: when the paid-onboarding origin is on `.vm6.ai` (staging only), also push the Clerk wildcard `https://*.vm6.ai` into `allowedRedirectOrigins`. Clerk's single-label wildcard matches `pr-1234-so.vm6.ai` and the raw `<hash>.vm6.ai`.

- **Production is unaffected**: prod's paid-onboarding origin is `https://so.vm0.ai` (host `vm0.ai`), so the `.vm6.ai` branch is never taken — it keeps the exact origin, never a wildcard.
- `NEXT_PUBLIC_PAID_ONBOARDING_URL` is validated as `z.url()`, so the wildcard can't be injected via env; it has to be added in code here.

## Why wildcard is acceptable here

`*.vm6.ai` is the staging/preview domain only (test Clerk instance, `informed-calf-6.clerk.accounts.dev`). Allowing any `*.vm6.ai` sibling to receive the post-auth redirect on staging is the intended behavior for ephemeral previews; production trust boundaries are unchanged.

## Companion (no vm0 change)

`vm0-marketing` galleries preview env now ships the dev Clerk key + `staging-app.vm6.ai` on all preview branches, so every preview shares the `.vm6.ai` test cookie. This PR is the matching redirect-origin allowlist.

🤖 Generated with [Claude Code](https://claude.com/claude-code)