### PR TITLE
test(mitm-addon): cover x parser through responseheaders

### DIFF
--- a/crates/runner/mitm-addon/tests/test_connector_usage.py
+++ b/crates/runner/mitm-addon/tests/test_connector_usage.py
@@ -53,6 +53,7 @@ class TestXStreamPathRouting:
             "/2/tweets/search/recent",
             "/2/users/by",
             "/2/tweets/1",
+            "",
             "/",
         ],
     )

--- a/crates/runner/mitm-addon/tests/test_connector_usage.py
+++ b/crates/runner/mitm-addon/tests/test_connector_usage.py
@@ -11,7 +11,6 @@ import body_utils
 import mitm_addon
 import usage
 from tests.flow_helpers import header_map, response_stream
-from usage.providers.connectors import x as usage_x_connector
 
 
 class TestXStreamPathRouting:

--- a/crates/runner/mitm-addon/tests/test_connector_usage.py
+++ b/crates/runner/mitm-addon/tests/test_connector_usage.py
@@ -14,26 +14,55 @@ from tests.flow_helpers import header_map, response_stream
 from usage.providers.connectors import x as usage_x_connector
 
 
-class TestIsStreamPath:
-    """Tests for _is_stream_path predicate (issue #9534)."""
+class TestXStreamPathRouting:
+    """Tests for stream path routing through responseheaders (issue #9534)."""
 
-    def test_all_five_stream_endpoints_match(self):
-        assert usage_x_connector._is_stream_path("/2/tweets/search/stream") is True
-        assert usage_x_connector._is_stream_path("/2/tweets/sample/stream") is True
-        assert usage_x_connector._is_stream_path("/2/tweets/sample10/stream") is True
-        assert usage_x_connector._is_stream_path("/2/tweets/compliance/stream") is True
-        assert usage_x_connector._is_stream_path("/2/users/compliance/stream") is True
+    def _make_x_response_flow(self, real_flow, path: str):
+        flow = real_flow(with_response=False, host="api.x.com", path=path)
+        flow.metadata["firewall_name"] = "x"
+        flow.metadata["firewall_billable"] = True
+        flow.metadata["original_url"] = f"https://api.x.com{path}"
+        flow.response = tutils.tresp(
+            status_code=200,
+            headers=header_map({"content-type": "application/json"}),
+        )
+        return flow
 
-    def test_stream_rules_is_not_stream(self):
-        # Rules management is a regular JSON request/response endpoint.
-        assert usage_x_connector._is_stream_path("/2/tweets/search/stream/rules") is False
+    @pytest.mark.parametrize(
+        "path",
+        [
+            "/2/tweets/search/stream",
+            "/2/tweets/sample/stream",
+            "/2/tweets/sample10/stream",
+            "/2/tweets/compliance/stream",
+            "/2/users/compliance/stream",
+        ],
+    )
+    def test_stream_endpoints_register_ndjson_parser(self, real_flow, path):
+        flow = self._make_x_response_flow(real_flow, path)
 
-    def test_non_stream_paths_do_not_match(self):
-        assert usage_x_connector._is_stream_path("/2/tweets/search/recent") is False
-        assert usage_x_connector._is_stream_path("/2/users/by") is False
-        assert usage_x_connector._is_stream_path("/2/tweets/1") is False
-        assert usage_x_connector._is_stream_path("") is False
-        assert usage_x_connector._is_stream_path("/") is False
+        mitm_addon.responseheaders(flow)
+
+        assert "x_ndjson_state" in flow.metadata
+        assert "connector_response_finish" not in flow.metadata
+
+    @pytest.mark.parametrize(
+        "path",
+        [
+            "/2/tweets/search/stream/rules",
+            "/2/tweets/search/recent",
+            "/2/users/by",
+            "/2/tweets/1",
+            "/",
+        ],
+    )
+    def test_non_stream_paths_register_json_parser(self, real_flow, path):
+        flow = self._make_x_response_flow(real_flow, path)
+
+        mitm_addon.responseheaders(flow)
+
+        assert "x_ndjson_state" not in flow.metadata
+        assert "connector_response_finish" in flow.metadata
 
 
 class TestReportConnectorUsage:

--- a/crates/runner/mitm-addon/tests/test_response_streaming.py
+++ b/crates/runner/mitm-addon/tests/test_response_streaming.py
@@ -5,11 +5,12 @@ import gzip
 import pytest
 from mitmproxy.test import tutils
 
+import body_utils
 import mitm_addon
 import response_streaming
 from tests.flow_helpers import header_map, response_stream
 
-_OVERSIZED_NDJSON_LINE_BYTES = 6 * 1024 * 1024
+_OVERSIZED_NDJSON_LINE_BYTES = body_utils.LARGE_RESPONSE_DECOMPRESS_LIMIT + 1024
 
 
 class TestNdjsonExtractor:

--- a/crates/runner/mitm-addon/tests/test_response_streaming.py
+++ b/crates/runner/mitm-addon/tests/test_response_streaming.py
@@ -8,38 +8,53 @@ from mitmproxy.test import tutils
 import mitm_addon
 import response_streaming
 from tests.flow_helpers import header_map, response_stream
-from usage.providers.connectors import x as usage_x_connector
+
+_OVERSIZED_NDJSON_LINE_BYTES = 6 * 1024 * 1024
 
 
 class TestNdjsonExtractor:
-    """Tests for _create_ndjson_extractor incremental parser (issue #9534)."""
+    """Tests for X NDJSON extraction through responseheaders (issue #9534)."""
 
-    def test_single_line(self):
-        parse, state = usage_x_connector._create_ndjson_extractor()
+    def _stream_parser(self, real_flow):
+        flow = real_flow(with_response=False, host="api.x.com", path="/2/tweets/search/stream")
+        flow.metadata["firewall_name"] = "x"
+        flow.metadata["firewall_billable"] = True
+        flow.metadata["original_url"] = "https://api.x.com/2/tweets/search/stream"
+        flow.response = tutils.tresp(
+            status_code=200,
+            headers=header_map({"content-type": "application/json"}),
+        )
+
+        mitm_addon.responseheaders(flow)
+
+        return response_stream(flow), flow.metadata["x_ndjson_state"]
+
+    def test_single_line(self, real_flow):
+        parse, state = self._stream_parser(real_flow)
         parse(b'{"data":{"id":"1"},"includes":{"users":[{"id":"u1"}]}}\n')
         assert state["data_count"] == 1
         assert state["includes"] == {"users": 1}
         assert state["lines_parsed"] == 1
         assert state["lines_failed"] == 0
 
-    def test_multiple_lines_aggregate_counts(self):
-        parse, state = usage_x_connector._create_ndjson_extractor()
+    def test_multiple_lines_aggregate_counts(self, real_flow):
+        parse, state = self._stream_parser(real_flow)
         parse(b'{"data":{"id":"1"},"includes":{"users":[{"id":"u1"}]}}\n')
         parse(b'{"data":{"id":"2"},"includes":{"users":[{"id":"u2"},{"id":"u3"}]}}\n')
         assert state["data_count"] == 2
         assert state["includes"] == {"users": 3}
         assert state["lines_parsed"] == 2
 
-    def test_chunked_line_split_mid_json(self):
-        parse, state = usage_x_connector._create_ndjson_extractor()
+    def test_chunked_line_split_mid_json(self, real_flow):
+        parse, state = self._stream_parser(real_flow)
         parse(b'{"data":{"id":"1"},"include')
         parse(b's":{"users":[{"id":"u1"}]}}\n')
         assert state["data_count"] == 1
         assert state["includes"] == {"users": 1}
         assert state["lines_parsed"] == 1
 
-    def test_keep_alive_blank_lines(self):
-        parse, state = usage_x_connector._create_ndjson_extractor()
+    def test_keep_alive_blank_lines(self, real_flow):
+        parse, state = self._stream_parser(real_flow)
         parse(b"\n\n")
         parse(b'{"data":{"id":"1"}}\n')
         parse(b"\n")
@@ -47,14 +62,14 @@ class TestNdjsonExtractor:
         assert state["data_count"] == 2
         assert state["lines_parsed"] == 2
 
-    def test_crlf_line_endings(self):
-        parse, state = usage_x_connector._create_ndjson_extractor()
+    def test_crlf_line_endings(self, real_flow):
+        parse, state = self._stream_parser(real_flow)
         parse(b'{"data":{"id":"1"}}\r\n{"data":{"id":"2"}}\r\n')
         assert state["data_count"] == 2
         assert state["lines_parsed"] == 2
 
-    def test_malformed_line_increments_failures(self):
-        parse, state = usage_x_connector._create_ndjson_extractor()
+    def test_malformed_line_increments_failures(self, real_flow):
+        parse, state = self._stream_parser(real_flow)
         parse(b'{"data":{"id":"1"}}\n')
         parse(b"not json at all\n")
         parse(b'{"data":{"id":"2"}}\n')
@@ -62,32 +77,32 @@ class TestNdjsonExtractor:
         assert state["lines_parsed"] == 2
         assert state["lines_failed"] == 1
 
-    def test_invalid_utf8_line_increments_failures_and_continues(self):
-        parse, state = usage_x_connector._create_ndjson_extractor()
+    def test_invalid_utf8_line_increments_failures_and_continues(self, real_flow):
+        parse, state = self._stream_parser(real_flow)
         parse(b'\x80{"data":{"id":"bad"}}\n{"data":{"id":"after"}}\n')
 
         assert state["data_count"] == 1
         assert state["lines_parsed"] == 1
         assert state["lines_failed"] == 1
 
-    def test_truncated_trailing_line_not_counted(self):
+    def test_truncated_trailing_line_not_counted(self, real_flow):
         """Connection drops mid-line — partial trailing line stays in buf, not counted."""
-        parse, state = usage_x_connector._create_ndjson_extractor()
+        parse, state = self._stream_parser(real_flow)
         parse(b'{"data":{"id":"1"}}\n{"data":{"id":"2"}')  # no trailing \n
         assert state["data_count"] == 1
         assert state["lines_parsed"] == 1
 
-    def test_empty_chunks_safe(self):
-        parse, state = usage_x_connector._create_ndjson_extractor()
+    def test_empty_chunks_safe(self, real_flow):
+        parse, state = self._stream_parser(real_flow)
         parse(b"")
         parse(b'{"data":{"id":"1"}}\n')
         parse(b"")
         assert state["data_count"] == 1
 
-    def test_oversized_line_dropped(self):
-        """Line > _MAX_NDJSON_LINE_BYTES is dropped; subsequent lines parse normally."""
-        parse, state = usage_x_connector._create_ndjson_extractor()
-        big = b"x" * (usage_x_connector._MAX_NDJSON_LINE_BYTES + 1024)
+    def test_oversized_line_dropped(self, real_flow):
+        """Oversized line is dropped; subsequent lines parse normally."""
+        parse, state = self._stream_parser(real_flow)
+        big = b"x" * _OVERSIZED_NDJSON_LINE_BYTES
         parse(big)
         parse(b"\n")
         parse(b'{"data":{"id":"after"}}\n')
@@ -95,10 +110,10 @@ class TestNdjsonExtractor:
         assert state["lines_parsed"] == 1
         assert state["lines_failed"] == 1
 
-    def test_oversized_line_discards_until_newline(self):
+    def test_oversized_line_discards_until_newline(self, real_flow):
         """A valid-looking tail of an overlong line must not be counted as its own row."""
-        parse, state = usage_x_connector._create_ndjson_extractor()
-        big = b"x" * (usage_x_connector._MAX_NDJSON_LINE_BYTES + 1024)
+        parse, state = self._stream_parser(real_flow)
+        big = b"x" * _OVERSIZED_NDJSON_LINE_BYTES
         parse(big)
         parse(b'{"data":{"id":"tail"}}\n')
         parse(b'{"data":{"id":"next"}}\n')
@@ -107,18 +122,18 @@ class TestNdjsonExtractor:
         assert state["lines_parsed"] == 1
         assert state["lines_failed"] == 1
 
-    def test_oversized_line_with_newline_continues_in_same_chunk(self):
+    def test_oversized_line_with_newline_continues_in_same_chunk(self, real_flow):
         """Dropping an overlong row should not discard valid later rows in the same chunk."""
-        parse, state = usage_x_connector._create_ndjson_extractor()
-        big = b"x" * (usage_x_connector._MAX_NDJSON_LINE_BYTES + 1024)
+        parse, state = self._stream_parser(real_flow)
+        big = b"x" * _OVERSIZED_NDJSON_LINE_BYTES
         parse(big + b'\n{"data":{"id":"after"}}\n')
 
         assert state["data_count"] == 1
         assert state["lines_parsed"] == 1
         assert state["lines_failed"] == 1
 
-    def test_includes_multiple_keys(self):
-        parse, state = usage_x_connector._create_ndjson_extractor()
+    def test_includes_multiple_keys(self, real_flow):
+        parse, state = self._stream_parser(real_flow)
         parse(
             b'{"data":{"id":"1"},"includes":'
             b'{"users":[{"id":"u1"}],'
@@ -127,15 +142,15 @@ class TestNdjsonExtractor:
         )
         assert state["includes"] == {"users": 1, "tweets": 2, "media": 1}
 
-    def test_data_array_not_counted(self):
+    def test_data_array_not_counted(self, real_flow):
         """Line where top-level ``data`` is an array (not a dict) contributes 0 to data_count."""
-        parse, state = usage_x_connector._create_ndjson_extractor()
+        parse, state = self._stream_parser(real_flow)
         parse(b'{"data":[1,2,3]}\n')
         assert state["data_count"] == 0
         assert state["lines_parsed"] == 1
 
-    def test_non_dict_top_level_skipped(self):
-        parse, state = usage_x_connector._create_ndjson_extractor()
+    def test_non_dict_top_level_skipped(self, real_flow):
+        parse, state = self._stream_parser(real_flow)
         parse(b'"some string"\n')
         parse(b"42\n")
         parse(b'{"data":{"id":"1"}}\n')


### PR DESCRIPTION
## Summary

- route X NDJSON parser edge-case coverage through `responseheaders()` and the installed stream callback instead of direct private helper imports
- cover stream and non-stream X path routing through the public mitm addon hook
- remove the stale direct X connector test import left after the parser internals were made private

Related #15471

## Tests

```bash
cd crates/runner/mitm-addon
python3 -m pytest tests/test_response_streaming.py tests/test_response_headers_handler.py tests/test_connector_usage.py
python3 -m pytest tests/
python3 -m ruff check .
```
