### PR TITLE
refactor: clarify x parser internals

### DIFF
--- a/crates/runner/mitm-addon/src/usage/providers/connectors/x.py
+++ b/crates/runner/mitm-addon/src/usage/providers/connectors/x.py
@@ -52,7 +52,7 @@ _STREAM_ENDPOINTS = frozenset(
 )
 
 
-def is_stream_path(path: str) -> bool:
+def _is_stream_path(path: str) -> bool:
     """Return True when *path* is one of the X v2 NDJSON streaming endpoints.
 
     Exact match only — ``/2/tweets/search/stream/rules`` (rules management)
@@ -66,7 +66,7 @@ def is_stream_path(path: str) -> bool:
 # ``matching_rules`` with full expansion) should never approach this size;
 # exceeding it indicates malformed or hostile upstream data, so the parser
 # discards that row through its terminating newline to protect memory.
-MAX_NDJSON_LINE_BYTES = 5 * 1024 * 1024  # 5 MB
+_MAX_NDJSON_LINE_BYTES = 5 * 1024 * 1024  # 5 MB
 
 _X_JSON_RESULT_COUNT_FIELDS = {
     ("meta", "result_count"): ScalarField("int", max_bytes=64),
@@ -120,10 +120,10 @@ def _parse_x_json_response_fields_from_body(body: bytes) -> dict | None:
     return _parse_x_json_response_fields(extracted)
 
 
-class NdjsonState(TypedDict):
+class _NdjsonState(TypedDict):
     """Accumulated parser state for an X NDJSON stream.
 
-    Populated by :func:`create_ndjson_extractor`'s ``parse_chunk`` and
+    Populated by :func:`_create_ndjson_extractor`'s ``parse_chunk`` and
     read by :func:`_parse_response_metadata` when emitting the billing
     log entry.
     """
@@ -138,7 +138,7 @@ class NdjsonState(TypedDict):
     """Lines that failed JSON decoding or exceeded the single-line safety cap."""
 
 
-def create_ndjson_extractor() -> tuple[Callable[[bytes], None], NdjsonState]:
+def _create_ndjson_extractor() -> tuple[Callable[[bytes], None], _NdjsonState]:
     """Create an incremental NDJSON parser for X v2 streaming responses.
 
     X v2 streaming endpoints deliver one JSON object per line separated by
@@ -162,12 +162,12 @@ def create_ndjson_extractor() -> tuple[Callable[[bytes], None], NdjsonState]:
 
     The parser keeps a ``line_buf`` holding the in-flight partial line
     across chunk boundaries.  If a single line ever exceeds
-    :data:`MAX_NDJSON_LINE_BYTES` the whole line is discarded until its
+    :data:`_MAX_NDJSON_LINE_BYTES` the whole line is discarded until its
     terminating newline (malformed / hostile upstream).  A truncated
     trailing line at connection close (no final ``\\n``) stays in the buffer
     uncounted — worst-case under-count is 1.
     """
-    state: NdjsonState = {
+    state: _NdjsonState = {
         "data_count": 0,
         "includes": {},
         "lines_parsed": 0,
@@ -195,7 +195,7 @@ def create_ndjson_extractor() -> tuple[Callable[[bytes], None], NdjsonState]:
                 start = newline + 1
                 continue
 
-            if len(line_buf) + fragment_len > MAX_NDJSON_LINE_BYTES:
+            if len(line_buf) + fragment_len > _MAX_NDJSON_LINE_BYTES:
                 line_buf[:] = b""
                 state["lines_failed"] += 1
                 if newline == -1:
@@ -235,7 +235,7 @@ def create_ndjson_extractor() -> tuple[Callable[[bytes], None], NdjsonState]:
     return parse_chunk, state
 
 
-class XJsonResponseExtractor:
+class _XJsonResponseExtractor:
     """Incrementally extract billing metadata from non-streaming X JSON."""
 
     def __init__(self) -> None:
@@ -257,10 +257,6 @@ class XJsonResponseExtractor:
         return result, None
 
 
-def create_json_response_extractor() -> XJsonResponseExtractor:
-    return XJsonResponseExtractor()
-
-
 def create_response_parser(flow: http.HTTPFlow) -> ConnectorResponseParser | None:
     """Create the X response-body parser needed for this flow, if any."""
     if not flow.response:
@@ -274,8 +270,8 @@ def create_response_parser(flow: http.HTTPFlow) -> ConnectorResponseParser | Non
         # firewall flow, ``request()`` has already populated ``original_url``
         # before ``responseheaders`` fires.
         stream_path = urllib.parse.urlparse(flow.metadata.get(metadata_keys.ORIGINAL_URL, "")).path
-        if is_stream_path(stream_path):
-            parser_fn, ndjson_state = create_ndjson_extractor()
+        if _is_stream_path(stream_path):
+            parser_fn, ndjson_state = _create_ndjson_extractor()
             # Deliberately NOT "model_provider_usage" — that key routes through
             # report_model_provider_usage and triggers the model-provider webhook.
             # x_ndjson_state is only consumed by report_connector_usage.
@@ -285,7 +281,7 @@ def create_response_parser(flow: http.HTTPFlow) -> ConnectorResponseParser | Non
     if not (_HTTP_STATUS_OK_MIN <= status_code < _HTTP_STATUS_REDIRECT_MIN):
         return None
 
-    extractor = create_json_response_extractor()
+    extractor = _XJsonResponseExtractor()
 
     def finish_json_state() -> None:
         state, error = extractor.finish()
@@ -336,7 +332,7 @@ def _parse_request_metadata(flow: http.HTTPFlow) -> dict:
         "request_ids_count": ids_count,
         "has_expansions": "expansions" in qs,
         "max_results": max_results,
-        "is_stream": is_stream_path(parsed.path),
+        "is_stream": _is_stream_path(parsed.path),
     }
 
 

--- a/crates/runner/mitm-addon/tests/test_connector_usage.py
+++ b/crates/runner/mitm-addon/tests/test_connector_usage.py
@@ -20,25 +20,25 @@ from usage.providers.connectors import x as usage_x_connector
 
 
 class TestIsStreamPath:
-    """Tests for is_stream_path predicate (issue #9534)."""
+    """Tests for _is_stream_path predicate (issue #9534)."""
 
     def test_all_five_stream_endpoints_match(self):
-        assert usage_x_connector.is_stream_path("/2/tweets/search/stream") is True
-        assert usage_x_connector.is_stream_path("/2/tweets/sample/stream") is True
-        assert usage_x_connector.is_stream_path("/2/tweets/sample10/stream") is True
-        assert usage_x_connector.is_stream_path("/2/tweets/compliance/stream") is True
-        assert usage_x_connector.is_stream_path("/2/users/compliance/stream") is True
+        assert usage_x_connector._is_stream_path("/2/tweets/search/stream") is True
+        assert usage_x_connector._is_stream_path("/2/tweets/sample/stream") is True
+        assert usage_x_connector._is_stream_path("/2/tweets/sample10/stream") is True
+        assert usage_x_connector._is_stream_path("/2/tweets/compliance/stream") is True
+        assert usage_x_connector._is_stream_path("/2/users/compliance/stream") is True
 
     def test_stream_rules_is_not_stream(self):
         # Rules management is a regular JSON request/response endpoint.
-        assert usage_x_connector.is_stream_path("/2/tweets/search/stream/rules") is False
+        assert usage_x_connector._is_stream_path("/2/tweets/search/stream/rules") is False
 
     def test_non_stream_paths_do_not_match(self):
-        assert usage_x_connector.is_stream_path("/2/tweets/search/recent") is False
-        assert usage_x_connector.is_stream_path("/2/users/by") is False
-        assert usage_x_connector.is_stream_path("/2/tweets/1") is False
-        assert usage_x_connector.is_stream_path("") is False
-        assert usage_x_connector.is_stream_path("/") is False
+        assert usage_x_connector._is_stream_path("/2/tweets/search/recent") is False
+        assert usage_x_connector._is_stream_path("/2/users/by") is False
+        assert usage_x_connector._is_stream_path("/2/tweets/1") is False
+        assert usage_x_connector._is_stream_path("") is False
+        assert usage_x_connector._is_stream_path("/") is False
 
 
 class TestReportConnectorUsage:

--- a/crates/runner/mitm-addon/tests/test_response_streaming.py
+++ b/crates/runner/mitm-addon/tests/test_response_streaming.py
@@ -12,10 +12,10 @@ from usage.providers.connectors import x as usage_x_connector
 
 
 class TestNdjsonExtractor:
-    """Tests for create_ndjson_extractor incremental parser (issue #9534)."""
+    """Tests for _create_ndjson_extractor incremental parser (issue #9534)."""
 
     def test_single_line(self):
-        parse, state = usage_x_connector.create_ndjson_extractor()
+        parse, state = usage_x_connector._create_ndjson_extractor()
         parse(b'{"data":{"id":"1"},"includes":{"users":[{"id":"u1"}]}}\n')
         assert state["data_count"] == 1
         assert state["includes"] == {"users": 1}
@@ -23,7 +23,7 @@ class TestNdjsonExtractor:
         assert state["lines_failed"] == 0
 
     def test_multiple_lines_aggregate_counts(self):
-        parse, state = usage_x_connector.create_ndjson_extractor()
+        parse, state = usage_x_connector._create_ndjson_extractor()
         parse(b'{"data":{"id":"1"},"includes":{"users":[{"id":"u1"}]}}\n')
         parse(b'{"data":{"id":"2"},"includes":{"users":[{"id":"u2"},{"id":"u3"}]}}\n')
         assert state["data_count"] == 2
@@ -31,7 +31,7 @@ class TestNdjsonExtractor:
         assert state["lines_parsed"] == 2
 
     def test_chunked_line_split_mid_json(self):
-        parse, state = usage_x_connector.create_ndjson_extractor()
+        parse, state = usage_x_connector._create_ndjson_extractor()
         parse(b'{"data":{"id":"1"},"include')
         parse(b's":{"users":[{"id":"u1"}]}}\n')
         assert state["data_count"] == 1
@@ -39,7 +39,7 @@ class TestNdjsonExtractor:
         assert state["lines_parsed"] == 1
 
     def test_keep_alive_blank_lines(self):
-        parse, state = usage_x_connector.create_ndjson_extractor()
+        parse, state = usage_x_connector._create_ndjson_extractor()
         parse(b"\n\n")
         parse(b'{"data":{"id":"1"}}\n')
         parse(b"\n")
@@ -48,13 +48,13 @@ class TestNdjsonExtractor:
         assert state["lines_parsed"] == 2
 
     def test_crlf_line_endings(self):
-        parse, state = usage_x_connector.create_ndjson_extractor()
+        parse, state = usage_x_connector._create_ndjson_extractor()
         parse(b'{"data":{"id":"1"}}\r\n{"data":{"id":"2"}}\r\n')
         assert state["data_count"] == 2
         assert state["lines_parsed"] == 2
 
     def test_malformed_line_increments_failures(self):
-        parse, state = usage_x_connector.create_ndjson_extractor()
+        parse, state = usage_x_connector._create_ndjson_extractor()
         parse(b'{"data":{"id":"1"}}\n')
         parse(b"not json at all\n")
         parse(b'{"data":{"id":"2"}}\n')
@@ -63,7 +63,7 @@ class TestNdjsonExtractor:
         assert state["lines_failed"] == 1
 
     def test_invalid_utf8_line_increments_failures_and_continues(self):
-        parse, state = usage_x_connector.create_ndjson_extractor()
+        parse, state = usage_x_connector._create_ndjson_extractor()
         parse(b'\x80{"data":{"id":"bad"}}\n{"data":{"id":"after"}}\n')
 
         assert state["data_count"] == 1
@@ -72,22 +72,22 @@ class TestNdjsonExtractor:
 
     def test_truncated_trailing_line_not_counted(self):
         """Connection drops mid-line — partial trailing line stays in buf, not counted."""
-        parse, state = usage_x_connector.create_ndjson_extractor()
+        parse, state = usage_x_connector._create_ndjson_extractor()
         parse(b'{"data":{"id":"1"}}\n{"data":{"id":"2"}')  # no trailing \n
         assert state["data_count"] == 1
         assert state["lines_parsed"] == 1
 
     def test_empty_chunks_safe(self):
-        parse, state = usage_x_connector.create_ndjson_extractor()
+        parse, state = usage_x_connector._create_ndjson_extractor()
         parse(b"")
         parse(b'{"data":{"id":"1"}}\n')
         parse(b"")
         assert state["data_count"] == 1
 
     def test_oversized_line_dropped(self):
-        """Line > MAX_NDJSON_LINE_BYTES is dropped; subsequent lines parse normally."""
-        parse, state = usage_x_connector.create_ndjson_extractor()
-        big = b"x" * (usage_x_connector.MAX_NDJSON_LINE_BYTES + 1024)
+        """Line > _MAX_NDJSON_LINE_BYTES is dropped; subsequent lines parse normally."""
+        parse, state = usage_x_connector._create_ndjson_extractor()
+        big = b"x" * (usage_x_connector._MAX_NDJSON_LINE_BYTES + 1024)
         parse(big)
         parse(b"\n")
         parse(b'{"data":{"id":"after"}}\n')
@@ -97,8 +97,8 @@ class TestNdjsonExtractor:
 
     def test_oversized_line_discards_until_newline(self):
         """A valid-looking tail of an overlong line must not be counted as its own row."""
-        parse, state = usage_x_connector.create_ndjson_extractor()
-        big = b"x" * (usage_x_connector.MAX_NDJSON_LINE_BYTES + 1024)
+        parse, state = usage_x_connector._create_ndjson_extractor()
+        big = b"x" * (usage_x_connector._MAX_NDJSON_LINE_BYTES + 1024)
         parse(big)
         parse(b'{"data":{"id":"tail"}}\n')
         parse(b'{"data":{"id":"next"}}\n')
@@ -109,8 +109,8 @@ class TestNdjsonExtractor:
 
     def test_oversized_line_with_newline_continues_in_same_chunk(self):
         """Dropping an overlong row should not discard valid later rows in the same chunk."""
-        parse, state = usage_x_connector.create_ndjson_extractor()
-        big = b"x" * (usage_x_connector.MAX_NDJSON_LINE_BYTES + 1024)
+        parse, state = usage_x_connector._create_ndjson_extractor()
+        big = b"x" * (usage_x_connector._MAX_NDJSON_LINE_BYTES + 1024)
         parse(big + b'\n{"data":{"id":"after"}}\n')
 
         assert state["data_count"] == 1
@@ -118,7 +118,7 @@ class TestNdjsonExtractor:
         assert state["lines_failed"] == 1
 
     def test_includes_multiple_keys(self):
-        parse, state = usage_x_connector.create_ndjson_extractor()
+        parse, state = usage_x_connector._create_ndjson_extractor()
         parse(
             b'{"data":{"id":"1"},"includes":'
             b'{"users":[{"id":"u1"}],'
@@ -129,13 +129,13 @@ class TestNdjsonExtractor:
 
     def test_data_array_not_counted(self):
         """Line where top-level ``data`` is an array (not a dict) contributes 0 to data_count."""
-        parse, state = usage_x_connector.create_ndjson_extractor()
+        parse, state = usage_x_connector._create_ndjson_extractor()
         parse(b'{"data":[1,2,3]}\n')
         assert state["data_count"] == 0
         assert state["lines_parsed"] == 1
 
     def test_non_dict_top_level_skipped(self):
-        parse, state = usage_x_connector.create_ndjson_extractor()
+        parse, state = usage_x_connector._create_ndjson_extractor()
         parse(b'"some string"\n')
         parse(b"42\n")
         parse(b'{"data":{"id":"1"}}\n')


### PR DESCRIPTION
## Summary
- remove the internal X JSON response extractor thin factory
- mark X response parser internals with private names while keeping `report_usage` and `create_response_parser` as the external connector boundary
- update focused tests to reference the renamed internals without changing parser behavior

Closes #15471

## Tests
- `python3 -m pytest tests/test_response_streaming.py tests/test_response_headers_handler.py tests/test_connector_usage.py`
- `python3 -m ruff check .`
- `python3 -m basedpyright`
- `git diff --check`