### PR TITLE
perf(mitm-addon): avoid json loads for string decoding

### DIFF
--- a/crates/runner/mitm-addon/src/usage/json_selective.py
+++ b/crates/runner/mitm-addon/src/usage/json_selective.py
@@ -23,6 +23,7 @@ Path = tuple[str, ...]
 WildcardPath = tuple[str, ...]
 ScalarKind = Literal["string", "int"]
 _JsonStringScanner = Callable[[str, int, bool], tuple[str, int]]
+# `scanstring` is the stdlib JSON string scanner, but typeshed does not expose it.
 _SCAN_JSON_STRING = cast(_JsonStringScanner, vars(json.decoder)["scanstring"])
 _UNKNOWN_KEY = "\0__vm0_json_unknown_key__"
 _ARRAY_ELEMENT = "\0__vm0_json_array_element__"
@@ -798,11 +799,10 @@ def _is_hex_byte(b: int) -> bool:
 
 
 def _decode_json_string(raw: bytearray, *, has_escape: bool) -> str:
-    raw_bytes = bytes(raw)
+    text = raw.decode("utf-8")
     if not has_escape:
-        return raw_bytes.decode("utf-8")
+        return text
 
-    text = raw_bytes.decode("utf-8")
     scan_input = f'{text}"'
     value, end = _SCAN_JSON_STRING(scan_input, 0, True)
     if end != len(scan_input):

--- a/crates/runner/mitm-addon/src/usage/json_selective.py
+++ b/crates/runner/mitm-addon/src/usage/json_selective.py
@@ -14,12 +14,16 @@ for keys such as ``includes.users`` and ``includes.tweets``.
 """
 
 import json
+import json.decoder
+from collections.abc import Callable
 from dataclasses import dataclass, field
-from typing import Literal
+from typing import Literal, cast
 
 Path = tuple[str, ...]
 WildcardPath = tuple[str, ...]
 ScalarKind = Literal["string", "int"]
+_JsonStringScanner = Callable[[str, int, bool], tuple[str, int]]
+_SCAN_JSON_STRING = cast(_JsonStringScanner, vars(json.decoder)["scanstring"])
 _UNKNOWN_KEY = "\0__vm0_json_unknown_key__"
 _ARRAY_ELEMENT = "\0__vm0_json_array_element__"
 _INTERNAL_PATH_MARKERS = frozenset((_UNKNOWN_KEY, _ARRAY_ELEMENT))
@@ -105,6 +109,7 @@ class _StringState:
     max_bytes: int
     raw: bytearray | None
     escape: bool = False
+    has_escape: bool = False
     unicode_remaining: int = 0
     utf8_remaining: int = 0
     utf8_codepoint: int = 0
@@ -555,6 +560,7 @@ class JsonSelectiveExtractor:
                 self._accept_string_byte(state, b)
                 if self._error:
                     return i
+                state.has_escape = True
                 state.escape = True
                 continue
 
@@ -625,9 +631,11 @@ class JsonSelectiveExtractor:
             return
         try:
             value = (
-                _UNKNOWN_KEY if state.raw is None else json.loads(b'"' + bytes(state.raw) + b'"')
+                _UNKNOWN_KEY
+                if state.raw is None
+                else _decode_json_string(state.raw, has_escape=state.has_escape)
             )
-        except (json.JSONDecodeError, UnicodeDecodeError):
+        except (json.JSONDecodeError, UnicodeDecodeError, ValueError):
             self._error = "invalid string"
             return
         if state.role == "key":
@@ -787,6 +795,19 @@ class JsonSelectiveExtractor:
 
 def _is_hex_byte(b: int) -> bool:
     return ord("0") <= b <= ord("9") or ord("a") <= b <= ord("f") or ord("A") <= b <= ord("F")
+
+
+def _decode_json_string(raw: bytearray, *, has_escape: bool) -> str:
+    raw_bytes = bytes(raw)
+    if not has_escape:
+        return raw_bytes.decode("utf-8")
+
+    text = raw_bytes.decode("utf-8")
+    scan_input = f'{text}"'
+    value, end = _SCAN_JSON_STRING(scan_input, 0, True)
+    if end != len(scan_input):
+        raise ValueError("json string scanner did not consume full token")
+    return value
 
 
 def _is_json_value_start(b: int) -> bool:

--- a/crates/runner/mitm-addon/tests/test_json_selective.py
+++ b/crates/runner/mitm-addon/tests/test_json_selective.py
@@ -274,6 +274,41 @@ def test_extracts_selected_scalars_across_chunks():
     }
 
 
+@pytest.mark.parametrize(
+    ("payload", "expected"),
+    [
+        (b'{"model":"plain-ascii"}', "plain-ascii"),
+        (b'{"model":"snowman \xe2\x98\x83"}', "snowman \u2603"),
+    ],
+)
+def test_decodes_selected_unescaped_strings(payload, expected):
+    extractor = JsonSelectiveExtractor(scalar_fields={("model",): ScalarField("string")})
+
+    extractor.feed(payload)
+    result = _finish(extractor)
+
+    assert result.complete is True
+    assert result.values == {("model",): expected}
+
+
+@pytest.mark.parametrize(
+    ("payload", "expected"),
+    [
+        (rb'{"model":"quote:\" backslash:\\ solidus:\/"}', 'quote:" backslash:\\ solidus:/'),
+        (rb'{"model":"\b\f\n\r\t"}', "\b\f\n\r\t"),
+        (rb'{"model":"\u2603"}', "\u2603"),
+    ],
+)
+def test_decodes_selected_json_escapes(payload, expected):
+    extractor = JsonSelectiveExtractor(scalar_fields={("model",): ScalarField("string")})
+
+    extractor.feed(payload)
+    result = _finish(extractor)
+
+    assert result.complete is True
+    assert result.values == {("model",): expected}
+
+
 def test_decodes_selected_escaped_strings():
     extractor = JsonSelectiveExtractor(scalar_fields={("model",): ScalarField("string")})
 
@@ -331,6 +366,18 @@ def test_decodes_escaped_object_keys_for_path_matching():
 
     assert result.complete is True
     assert result.values == {("usage", "input_tokens"): 5}
+
+
+def test_decodes_escaped_punctuation_object_keys_for_path_matching():
+    extractor = JsonSelectiveExtractor(
+        scalar_fields={('us"age', "input_tokens"): ScalarField("int")}
+    )
+
+    extractor.feed(rb'{"us\"age":{"input_tokens":5}}')
+    result = _finish(extractor)
+
+    assert result.complete is True
+    assert result.values == {('us"age', "input_tokens"): 5}
 
 
 def test_decodes_escaped_object_keys_across_chunks():
@@ -438,6 +485,19 @@ def test_rejects_oversized_selected_string():
     )
 
     extractor.feed(b'{"model":"abcd"}')
+    result = _finish(extractor)
+
+    assert result.complete is False
+    assert result.error == "string limit exceeded"
+    assert result.values == {}
+
+
+def test_selected_string_limit_counts_escape_bytes():
+    extractor = JsonSelectiveExtractor(
+        scalar_fields={("model",): ScalarField("string", max_bytes=1)}
+    )
+
+    extractor.feed(rb'{"model":"\n"}')
     result = _finish(extractor)
 
     assert result.complete is False


### PR DESCRIPTION
## Summary
- track whether collected JSON strings contain escape sequences in the selective extractor
- decode unescaped collected strings directly as UTF-8 and use the stdlib JSON string scanner only for escaped strings
- add regression coverage for unescaped UTF-8, JSON escapes, escaped keys, and raw-byte string limits

## Tests
- python3 -m pytest tests/test_json_selective.py
- python3 -m pytest tests/test_anthropic_messages.py tests/test_openai_responses_event_json.py tests/test_body_capture.py tests/test_model_provider_response_usage.py tests/test_model_provider_stream_usage.py tests/test_connector_usage.py
- python3 -m pytest
- python3 -m ruff check src/usage/json_selective.py tests/test_json_selective.py
- python3 -m basedpyright src/usage/json_selective.py tests/test_json_selective.py

Fixes #15530