### PR TITLE
fix: enforce reconnect-required firewall auth state

### DIFF
--- a/turbo/apps/api/src/signals/routes/__tests__/webhooks-agent-firewall-auth.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/webhooks-agent-firewall-auth.test.ts
@@ -2610,6 +2610,69 @@ describe("POST /api/webhooks/agent/firewall/auth", () => {
     });
   });
 
+  it("recovers reconnect-required connector tokens when refresh succeeds", async () => {
+    const fixture = await track(seedFixture());
+    await seedNotionConnector(fixture, {
+      accessToken: "current-recoverable-notion-token",
+      refreshToken: "recoverable-notion-refresh-token",
+      tokenExpiresAt: new Date(now() + 3_600_000),
+      needsReconnect: true,
+    });
+
+    server.use(
+      http.post("https://api.notion.com/v1/oauth/token", () => {
+        return HttpResponse.json({
+          access_token: "fresh-recovered-notion-token",
+          refresh_token: "rotated-recovered-notion-refresh-token",
+          expires_in: 3600,
+        });
+      }),
+    );
+
+    const response = await accept(
+      firewallClient().resolve({
+        body: {
+          encryptedSecrets: encryptedSecrets({
+            NOTION_TOKEN: "stale-snapshot-notion-token",
+          }),
+          authHeaders: {
+            Authorization: `Bearer ${secretTemplate("NOTION_TOKEN")}`,
+          },
+          secretConnectorMap: {
+            NOTION_TOKEN: "notion",
+          },
+        },
+        headers: authHeaders(fixture),
+      }),
+      [200],
+    );
+
+    expect(response.body.headers.Authorization).toBe(
+      "Bearer fresh-recovered-notion-token",
+    );
+    expect(response.body.refreshedConnectors).toStrictEqual(["notion"]);
+    expect(response.body.refreshedSecrets).toStrictEqual(["NOTION_TOKEN"]);
+    await expect(notionConnectorState(fixture)).resolves.toMatchObject({
+      needsReconnect: false,
+    });
+    await expect(
+      readSecret({
+        orgId: fixture.orgId,
+        userId: fixture.userId,
+        name: "NOTION_ACCESS_TOKEN",
+        type: "connector",
+      }),
+    ).resolves.toBe("fresh-recovered-notion-token");
+    await expect(
+      readSecret({
+        orgId: fixture.orgId,
+        userId: fixture.userId,
+        name: "NOTION_REFRESH_TOKEN",
+        type: "connector",
+      }),
+    ).resolves.toBe("rotated-recovered-notion-refresh-token");
+  });
+
   it("classifies upstream connector refresh failures without marking reconnect", async () => {
     const fixture = await track(seedFixture());
     await seedExpiredNotionConnector(fixture);
@@ -3806,6 +3869,82 @@ describe("POST /api/webhooks/agent/firewall/auth", () => {
       needsReconnect: true,
       lastRefreshErrorCode: "refresh_token_expired",
     });
+  });
+
+  it("recovers reconnect-required model-provider tokens when refresh succeeds", async () => {
+    const fixture = await track(seedFixture());
+    await seedCodexModelProvider(fixture, {
+      accessToken: "current-recoverable-chatgpt-token",
+      refreshToken: "recoverable-chatgpt-refresh-token",
+      tokenExpiresAt: new Date(now() + 3_600_000),
+      needsReconnect: true,
+      lastRefreshErrorCode: "refresh_token_expired",
+    });
+
+    server.use(
+      http.post("https://auth.openai.com/oauth/token", () => {
+        return HttpResponse.json({
+          access_token: "fresh-recovered-chatgpt-token",
+          refresh_token: "rotated-recovered-chatgpt-refresh-token",
+          expires_in: 3600,
+        });
+      }),
+    );
+
+    const response = await accept(
+      firewallClient().resolve({
+        body: {
+          encryptedSecrets: encryptedSecrets({
+            CHATGPT_ACCESS_TOKEN: "stale-snapshot-chatgpt-token",
+          }),
+          authHeaders: {
+            Authorization: `Bearer ${secretTemplate("CHATGPT_ACCESS_TOKEN")}`,
+          },
+          secretConnectorMap: {
+            CHATGPT_ACCESS_TOKEN: "codex-oauth-token",
+          },
+          secretConnectorMetadataMap: {
+            CHATGPT_ACCESS_TOKEN: {
+              sourceType: "model-provider",
+              sourceUserId: ORG_SENTINEL_USER_ID,
+              metadataKey: "codex-oauth-token",
+            },
+          },
+        },
+        headers: authHeaders(fixture),
+      }),
+      [200],
+    );
+
+    expect(response.body.headers.Authorization).toBe(
+      "Bearer fresh-recovered-chatgpt-token",
+    );
+    expect(response.body.refreshedConnectors).toStrictEqual([
+      "codex-oauth-token",
+    ]);
+    expect(response.body.refreshedSecrets).toStrictEqual([
+      "CHATGPT_ACCESS_TOKEN",
+    ]);
+    await expect(codexProviderState(fixture)).resolves.toMatchObject({
+      needsReconnect: false,
+      lastRefreshErrorCode: null,
+    });
+    await expect(
+      readSecret({
+        orgId: fixture.orgId,
+        userId: ORG_SENTINEL_USER_ID,
+        name: "CHATGPT_ACCESS_TOKEN",
+        type: "model-provider",
+      }),
+    ).resolves.toBe("fresh-recovered-chatgpt-token");
+    await expect(
+      readSecret({
+        orgId: fixture.orgId,
+        userId: ORG_SENTINEL_USER_ID,
+        name: "CHATGPT_REFRESH_TOKEN",
+        type: "model-provider",
+      }),
+    ).resolves.toBe("rotated-recovered-chatgpt-refresh-token");
   });
 
   it("preserves standard OAuth reconnect error codes on model-provider refresh failure", async () => {

--- a/turbo/apps/api/src/signals/routes/__tests__/webhooks-agent-firewall-auth.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/webhooks-agent-firewall-auth.test.ts
@@ -325,6 +325,7 @@ async function seedNotionConnector(
     readonly accessToken: string;
     readonly refreshToken: string;
     readonly tokenExpiresAt: Date | null;
+    readonly needsReconnect?: boolean;
   },
 ): Promise<void> {
   const db = store.set(writeDb$);
@@ -338,6 +339,7 @@ async function seedNotionConnector(
     externalEmail: "notion@example.com",
     oauthScopes: JSON.stringify([]),
     tokenExpiresAt: args.tokenExpiresAt,
+    needsReconnect: args.needsReconnect ?? false,
   });
   await seedSecret({
     orgId: fixture.orgId,
@@ -2559,6 +2561,55 @@ describe("POST /api/webhooks/agent/firewall/auth", () => {
     });
   });
 
+  it("refreshes reconnect-required connector tokens even when expiry is still valid", async () => {
+    const fixture = await track(seedFixture());
+    await seedNotionConnector(fixture, {
+      accessToken: "current-reconnect-required-notion-token",
+      refreshToken: "reconnect-required-notion-refresh-token",
+      tokenExpiresAt: new Date(now() + 3_600_000),
+      needsReconnect: true,
+    });
+
+    let refreshCallCount = 0;
+    server.use(
+      http.post("https://api.notion.com/v1/oauth/token", () => {
+        refreshCallCount += 1;
+        return HttpResponse.json(
+          { error: "invalid_grant", error_description: "revoked" },
+          { status: 400 },
+        );
+      }),
+    );
+
+    const response = await accept(
+      firewallClient().resolve({
+        body: {
+          encryptedSecrets: encryptedSecrets({
+            NOTION_TOKEN: "stale-snapshot-notion-token",
+          }),
+          authHeaders: {
+            Authorization: `Bearer ${secretTemplate("NOTION_TOKEN")}`,
+          },
+          secretConnectorMap: {
+            NOTION_TOKEN: "notion",
+          },
+        },
+        headers: authHeaders(fixture),
+      }),
+      [502],
+    );
+
+    expect(refreshCallCount).toBe(1);
+    expect(response.body.error).toMatchObject({
+      code: "TOKEN_REFRESH_FAILED",
+      connectors: ["notion"],
+      failureReason: "reconnect_required",
+    });
+    await expect(notionConnectorState(fixture)).resolves.toMatchObject({
+      needsReconnect: true,
+    });
+  });
+
   it("classifies upstream connector refresh failures without marking reconnect", async () => {
     const fixture = await track(seedFixture());
     await seedExpiredNotionConnector(fixture);
@@ -3683,6 +3734,69 @@ describe("POST /api/webhooks/agent/firewall/auth", () => {
       [502],
     );
 
+    expect(response.body.error).toMatchObject({
+      code: "TOKEN_REFRESH_FAILED",
+      connectors: ["codex-oauth-token"],
+      failureReason: "reconnect_required",
+    });
+    await expect(codexProviderState(fixture)).resolves.toMatchObject({
+      needsReconnect: true,
+      lastRefreshErrorCode: "refresh_token_expired",
+    });
+  });
+
+  it("refreshes reconnect-required model-provider tokens even when expiry is still valid", async () => {
+    const fixture = await track(seedFixture());
+    await seedCodexModelProvider(fixture, {
+      accessToken: "current-reconnect-required-chatgpt-token",
+      refreshToken: "reconnect-required-chatgpt-refresh",
+      tokenExpiresAt: new Date(now() + 3_600_000),
+      needsReconnect: true,
+      lastRefreshErrorCode: null,
+    });
+
+    let refreshCallCount = 0;
+    server.use(
+      http.post("https://auth.openai.com/oauth/token", () => {
+        refreshCallCount += 1;
+        return HttpResponse.json(
+          {
+            error: {
+              code: "refresh_token_expired",
+              message: "expired refresh token",
+            },
+          },
+          { status: 401 },
+        );
+      }),
+    );
+
+    const response = await accept(
+      firewallClient().resolve({
+        body: {
+          encryptedSecrets: encryptedSecrets({
+            CHATGPT_ACCESS_TOKEN: "stale-snapshot-chatgpt-token",
+          }),
+          authHeaders: {
+            Authorization: `Bearer ${secretTemplate("CHATGPT_ACCESS_TOKEN")}`,
+          },
+          secretConnectorMap: {
+            CHATGPT_ACCESS_TOKEN: "codex-oauth-token",
+          },
+          secretConnectorMetadataMap: {
+            CHATGPT_ACCESS_TOKEN: {
+              sourceType: "model-provider",
+              sourceUserId: ORG_SENTINEL_USER_ID,
+              metadataKey: "codex-oauth-token",
+            },
+          },
+        },
+        headers: authHeaders(fixture),
+      }),
+      [502],
+    );
+
+    expect(refreshCallCount).toBe(1);
     expect(response.body.error).toMatchObject({
       code: "TOKEN_REFRESH_FAILED",
       connectors: ["codex-oauth-token"],

--- a/turbo/apps/api/src/signals/routes/__tests__/webhooks-agent-firewall-auth.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/webhooks-agent-firewall-auth.test.ts
@@ -3947,6 +3947,94 @@ describe("POST /api/webhooks/agent/firewall/auth", () => {
     ).resolves.toBe("rotated-recovered-chatgpt-refresh-token");
   });
 
+  it("rejects skipped model-provider tokens that become reconnect-required during another refresh", async () => {
+    const fixture = await track(seedFixture());
+    await seedExpiredNotionConnector(fixture);
+    await seedCodexModelProvider(fixture, {
+      accessToken: "current-racing-chatgpt-token",
+      refreshToken: "racing-chatgpt-refresh-token",
+      tokenExpiresAt: new Date(now() + 3_600_000),
+      needsReconnect: false,
+      lastRefreshErrorCode: null,
+    });
+
+    let notionRefreshCallCount = 0;
+    server.use(
+      http.post("https://api.notion.com/v1/oauth/token", async () => {
+        notionRefreshCallCount += 1;
+        const db = store.set(writeDb$);
+        await db
+          .update(modelProviders)
+          .set({
+            needsReconnect: true,
+            lastRefreshErrorCode: "refresh_token_expired",
+            updatedAt: sql`clock_timestamp()`,
+          })
+          .where(
+            and(
+              eq(modelProviders.orgId, fixture.orgId),
+              eq(modelProviders.userId, ORG_SENTINEL_USER_ID),
+              eq(modelProviders.type, "codex-oauth-token"),
+            ),
+          );
+        return HttpResponse.json({
+          access_token: "fresh-racing-notion-token",
+          refresh_token: "rotated-racing-notion-refresh-token",
+          expires_in: 3600,
+        });
+      }),
+    );
+
+    const response = await accept(
+      firewallClient().resolve({
+        body: {
+          encryptedSecrets: encryptedSecrets({
+            NOTION_TOKEN: "stale-notion-token",
+            CHATGPT_ACCESS_TOKEN: "stale-snapshot-chatgpt-token",
+          }),
+          authHeaders: {
+            Authorization: [
+              `Bearer ${secretTemplate("NOTION_TOKEN")}`,
+              secretTemplate("CHATGPT_ACCESS_TOKEN"),
+            ].join(" "),
+          },
+          secretConnectorMap: {
+            NOTION_TOKEN: "notion",
+            CHATGPT_ACCESS_TOKEN: "codex-oauth-token",
+          },
+          secretConnectorMetadataMap: {
+            CHATGPT_ACCESS_TOKEN: {
+              sourceType: "model-provider",
+              sourceUserId: ORG_SENTINEL_USER_ID,
+              metadataKey: "codex-oauth-token",
+            },
+          },
+        },
+        headers: authHeaders(fixture),
+      }),
+      [502],
+    );
+
+    expect(notionRefreshCallCount).toBe(1);
+    expect(response.body.error).toMatchObject({
+      code: "TOKEN_REFRESH_FAILED",
+      connectors: ["codex-oauth-token"],
+      failureReason: "reconnect_required",
+    });
+    await expect(codexProviderState(fixture)).resolves.toMatchObject({
+      needsReconnect: true,
+      lastRefreshErrorCode: "refresh_token_expired",
+    });
+    await expect(
+      readSecret({
+        orgId: fixture.orgId,
+        userId: fixture.userId,
+        name: "NOTION_ACCESS_TOKEN",
+        type: "connector",
+      }),
+    ).resolves.toBe("fresh-racing-notion-token");
+  });
+
   it("preserves standard OAuth reconnect error codes on model-provider refresh failure", async () => {
     const fixture = await track(seedFixture());
     await seedExpiredCodexModelProvider(fixture);

--- a/turbo/apps/api/src/signals/services/agent-webhook-firewall-auth.service.ts
+++ b/turbo/apps/api/src/signals/services/agent-webhook-firewall-auth.service.ts
@@ -385,10 +385,14 @@ interface RefreshBatchContext {
   readonly featureSwitchContext: FeatureSwitchContext;
 }
 
-interface ConnectorAccessState {
+interface RefreshSourceState {
+  readonly tokenExpiresAt: number | null;
+  readonly needsReconnect: boolean;
+}
+
+interface ConnectorAccessState extends RefreshSourceState {
   readonly authMethod: string;
   readonly accessMetadata: ConnectorAuthMethodAccessMetadata;
-  readonly tokenExpiresAt: number | null;
 }
 
 interface BasicArgContext extends BasicAuthTemplateArg {
@@ -702,6 +706,7 @@ async function loadConnectorAccessStates(
       type: connectors.type,
       authMethod: connectors.authMethod,
       tokenExpiresAt: connectors.tokenExpiresAt,
+      needsReconnect: connectors.needsReconnect,
     })
     .from(connectors)
     .where(
@@ -727,62 +732,122 @@ async function loadConnectorAccessStates(
     result.set(row.type, {
       authMethod: row.authMethod,
       accessMetadata,
-      tokenExpiresAt: row.tokenExpiresAt
-        ? Math.floor(row.tokenExpiresAt.getTime() / 1000)
-        : null,
+      ...refreshSourceStateFromRow(row),
     });
   }
   return result;
 }
 
-async function getModelProviderExpiry(
-  db: Db,
-  orgId: string,
-  userId: string,
-  modelProviderTypes: readonly string[],
-  options: { readonly sourceUserId?: string } = {},
-): Promise<Map<string, number | null>> {
-  const result = new Map<string, number | null>();
-  if (modelProviderTypes.length === 0) {
+interface ModelProviderSourceLookup {
+  readonly providerKey: string;
+  readonly providerType: string;
+  readonly userId: string;
+}
+
+interface SourceStateSnapshot {
+  readonly sourceStateMap: Map<string, RefreshSourceState>;
+  readonly connectorAccessByType: ReadonlyMap<string, ConnectorAccessState>;
+}
+
+function modelProviderSourceLookup(args: {
+  readonly providerKey: string;
+  readonly userId: string;
+  readonly metadataByConnector: Map<string, SecretConnectorMetadata>;
+}): ModelProviderSourceLookup {
+  const metadata = resolveRefreshMetadata(
+    args.providerKey,
+    args.metadataByConnector.get(args.providerKey),
+  );
+  return {
+    providerKey: args.providerKey,
+    providerType:
+      metadata.metadataKey ??
+      modelProviderTypeForOAuthProviderKey(args.providerKey) ??
+      args.providerKey,
+    userId: resolveSecretUserId(
+      "model-provider",
+      args.userId,
+      metadata.sourceUserId,
+    ),
+  };
+}
+
+async function loadModelProviderSourceStates(args: {
+  readonly db: Db;
+  readonly orgId: string;
+  readonly userId: string;
+  readonly providerKeys: readonly string[];
+  readonly metadataByConnector: Map<string, SecretConnectorMetadata>;
+}): Promise<Map<string, RefreshSourceState>> {
+  const result = new Map<string, RefreshSourceState>();
+  if (args.providerKeys.length === 0) {
     return result;
   }
 
-  const rows = await db
-    .select({
-      type: modelProviders.type,
-      tokenExpiresAt: modelProviders.tokenExpiresAt,
-    })
-    .from(modelProviders)
-    .where(
-      and(
-        eq(modelProviders.orgId, orgId),
-        eq(
-          modelProviders.userId,
-          resolveSecretUserId("model-provider", userId, options.sourceUserId),
-        ),
-        inArray(modelProviders.type, [...modelProviderTypes]),
-      ),
-    );
+  const lookupsByUserId = new Map<string, ModelProviderSourceLookup[]>();
+  for (const providerKey of args.providerKeys) {
+    const lookup = modelProviderSourceLookup({
+      providerKey,
+      userId: args.userId,
+      metadataByConnector: args.metadataByConnector,
+    });
+    const lookups = lookupsByUserId.get(lookup.userId) ?? [];
+    lookups.push(lookup);
+    lookupsByUserId.set(lookup.userId, lookups);
+  }
 
-  for (const row of rows) {
-    result.set(
-      row.type,
-      row.tokenExpiresAt
-        ? Math.floor(row.tokenExpiresAt.getTime() / 1000)
-        : null,
-    );
+  const stateEntries = await Promise.all(
+    [...lookupsByUserId].map(async ([sourceUserId, lookups]) => {
+      const providerTypes = [
+        ...new Set(
+          lookups.map((lookup) => {
+            return lookup.providerType;
+          }),
+        ),
+      ];
+      const rows = await args.db
+        .select({
+          type: modelProviders.type,
+          tokenExpiresAt: modelProviders.tokenExpiresAt,
+          needsReconnect: modelProviders.needsReconnect,
+        })
+        .from(modelProviders)
+        .where(
+          and(
+            eq(modelProviders.orgId, args.orgId),
+            eq(modelProviders.userId, sourceUserId),
+            inArray(modelProviders.type, providerTypes),
+          ),
+        );
+
+      const stateByType = new Map<string, RefreshSourceState>();
+      for (const row of rows) {
+        stateByType.set(row.type, refreshSourceStateFromRow(row));
+      }
+
+      return lookups.flatMap((lookup) => {
+        const state = stateByType.get(lookup.providerType);
+        return state ? [[lookup.providerKey, state] as const] : [];
+      });
+    }),
+  );
+
+  for (const entries of stateEntries) {
+    for (const [providerKey, state] of entries) {
+      result.set(providerKey, state);
+    }
   }
   return result;
 }
 
-async function getExpiryByProviderKey(args: {
+async function getSourceStateByProviderKey(args: {
   readonly db: Db;
   readonly orgId: string;
   readonly userId: string;
   readonly connectorTypes: readonly string[];
   readonly metadataByConnector: Map<string, SecretConnectorMetadata>;
   readonly connectorAccessByType: ReadonlyMap<string, ConnectorAccessState>;
-}): Promise<Map<string, number | null>> {
+}): Promise<Map<string, RefreshSourceState>> {
   const connectorOnly = args.connectorTypes.filter((connectorType) => {
     return (
       resolveRefreshMetadata(
@@ -802,38 +867,59 @@ async function getExpiryByProviderKey(args: {
     },
   );
 
-  const modelProviderEntries = await Promise.all(
-    modelProviderOAuthProviderKeys.map(async (providerKey) => {
-      const metadata = resolveRefreshMetadata(
-        providerKey,
-        args.metadataByConnector.get(providerKey),
-      );
-      const metadataKey =
-        metadata.metadataKey ??
-        modelProviderTypeForOAuthProviderKey(providerKey) ??
-        providerKey;
-      const expiryMap = await getModelProviderExpiry(
-        args.db,
-        args.orgId,
-        args.userId,
-        [metadataKey],
-        { sourceUserId: metadata.sourceUserId },
-      );
-      return [providerKey, expiryMap.get(metadataKey) ?? null] as const;
-    }),
-  );
-
-  const merged = new Map<string, number | null>();
+  const merged = new Map<string, RefreshSourceState>();
   for (const connectorType of connectorOnly) {
     const state = args.connectorAccessByType.get(connectorType);
     if (state) {
-      merged.set(connectorType, state.tokenExpiresAt);
+      merged.set(connectorType, state);
     }
   }
-  for (const [providerKey, expiry] of modelProviderEntries) {
-    merged.set(providerKey, expiry);
+
+  const modelProviderStates = await loadModelProviderSourceStates({
+    db: args.db,
+    orgId: args.orgId,
+    userId: args.userId,
+    providerKeys: modelProviderOAuthProviderKeys,
+    metadataByConnector: args.metadataByConnector,
+  });
+  for (const [providerKey, state] of modelProviderStates) {
+    merged.set(providerKey, state);
   }
   return merged;
+}
+
+async function loadCurrentSourceStateSnapshot(args: {
+  readonly db: Db;
+  readonly orgId: string;
+  readonly userId: string;
+  readonly connectorTypes: readonly string[];
+  readonly metadataByConnector: Map<string, SecretConnectorMetadata>;
+}): Promise<SourceStateSnapshot> {
+  const connectorOnly = args.connectorTypes.filter((connectorType) => {
+    return (
+      resolveRefreshMetadata(
+        connectorType,
+        args.metadataByConnector.get(connectorType),
+      ).sourceType === "connector"
+    );
+  });
+  const connectorAccessByType = await loadConnectorAccessStates(
+    args.db,
+    args.orgId,
+    args.userId,
+    connectorOnly,
+  );
+  return {
+    connectorAccessByType,
+    sourceStateMap: await getSourceStateByProviderKey({
+      db: args.db,
+      orgId: args.orgId,
+      userId: args.userId,
+      connectorTypes: args.connectorTypes,
+      metadataByConnector: args.metadataByConnector,
+      connectorAccessByType,
+    }),
+  };
 }
 
 function prepareRefreshTokenContext(
@@ -955,6 +1041,18 @@ function tokenExpiresAtNeedsRefresh(tokenExpiresAt: Date | null): boolean {
 
 function currentSecond(): number {
   return Math.floor(nowDate().getTime() / 1000);
+}
+
+function refreshSourceStateFromRow(args: {
+  readonly tokenExpiresAt: Date | null;
+  readonly needsReconnect: boolean;
+}): RefreshSourceState {
+  return {
+    tokenExpiresAt: args.tokenExpiresAt
+      ? Math.floor(args.tokenExpiresAt.getTime() / 1000)
+      : null,
+    needsReconnect: args.needsReconnect,
+  };
 }
 
 async function currentDatabaseTimestampMicros(db: Db): Promise<bigint> {
@@ -1958,7 +2056,7 @@ async function decryptFirewallAuthSecrets(
 
 function connectorTypesNeedingRefresh(args: {
   readonly connectorTypes: readonly string[];
-  readonly expiryMap: Map<string, number | null>;
+  readonly sourceStateMap: Map<string, RefreshSourceState>;
   readonly forceRefresh: boolean;
 }): readonly string[] {
   const nowSeconds = Math.floor(nowDate().getTime() / 1000);
@@ -1966,11 +2064,14 @@ function connectorTypesNeedingRefresh(args: {
     if (args.forceRefresh) {
       return true;
     }
-    const tokenExpiry = args.expiryMap.get(connectorType);
-    if (tokenExpiry === undefined || tokenExpiry === null) {
+    const sourceState = args.sourceStateMap.get(connectorType);
+    if (!sourceState) {
       return true;
     }
-    return tokenExpiry <= nowSeconds + REFRESH_BUFFER_SECS;
+    if (sourceState.needsReconnect || sourceState.tokenExpiresAt === null) {
+      return true;
+    }
+    return sourceState.tokenExpiresAt <= nowSeconds + REFRESH_BUFFER_SECS;
   });
 }
 
@@ -2045,9 +2146,25 @@ async function refreshSelectedTokens(
 async function syncSkippedTokens(
   context: RefreshBatchContext,
   skippedTypes: readonly string[],
-): Promise<void> {
+  sourceStateMap: Map<string, RefreshSourceState>,
+): Promise<readonly RefreshExecutionResult[]> {
+  const results: RefreshExecutionResult[] = [];
   const currentTokens = await Promise.all(
     skippedTypes.map(async (connectorType) => {
+      const sourceState = sourceStateMap.get(connectorType);
+      if (!sourceState) {
+        return {
+          connectorType,
+          token: null,
+        };
+      }
+      if (sourceState?.needsReconnect) {
+        return {
+          connectorType,
+          token: null,
+          failureReason: "reconnect_required" as const,
+        };
+      }
       const metadata = resolveRefreshMetadata(
         connectorType,
         context.metadataByConnector.get(connectorType),
@@ -2068,7 +2185,22 @@ async function syncSkippedTokens(
       };
     }),
   );
-  for (const { connectorType, token } of currentTokens) {
+  for (const { connectorType, token, failureReason } of currentTokens) {
+    if (failureReason) {
+      L.warn(
+        `[${context.auth.runId}] Skipped connector ${connectorType} still requires reconnect`,
+      );
+      for (const envVar of context.envVarsByConnector.get(connectorType) ??
+        []) {
+        delete context.secrets[envVar];
+      }
+      results.push({
+        connectorType,
+        status: "failed",
+        failureReason,
+      });
+      continue;
+    }
     if (!token) {
       L.warn(
         `[${context.auth.runId}] No DB token for skipped connector ${connectorType}, marking access unresolved`,
@@ -2083,6 +2215,7 @@ async function syncSkippedTokens(
       context.secrets[envVar] = token;
     }
   }
+  return results;
 }
 
 function summarizeRefreshResults(
@@ -2135,11 +2268,11 @@ function summarizeRefreshResults(
 
 function earliestConnectorExpiry(
   connectorTypes: readonly string[],
-  finalExpiryMap: Map<string, number | null>,
+  finalSourceStateMap: Map<string, RefreshSourceState>,
 ): number | null {
   let earliestExpiry: number | null = null;
   for (const connectorType of connectorTypes) {
-    const expiry = finalExpiryMap.get(connectorType);
+    const expiry = finalSourceStateMap.get(connectorType)?.tokenExpiresAt;
     if (expiry !== undefined && expiry !== null) {
       earliestExpiry =
         earliestExpiry === null ? expiry : Math.min(earliestExpiry, expiry);
@@ -2166,7 +2299,7 @@ async function refreshExpiredTokens(
     refreshable,
     args.secretConnectorMetadataMap,
   );
-  const expiryMap = await getExpiryByProviderKey({
+  const sourceStateMap = await getSourceStateByProviderKey({
     db: args.db,
     orgId: args.orgId,
     userId: args.auth.userId,
@@ -2176,7 +2309,7 @@ async function refreshExpiredTokens(
   });
   const toRefresh = connectorTypesNeedingRefresh({
     connectorTypes,
-    expiryMap,
+    sourceStateMap,
     forceRefresh: args.forceRefresh,
   });
   const envVarsByConnector = buildEnvVarsByConnector(refreshable);
@@ -2194,11 +2327,32 @@ async function refreshExpiredTokens(
     envVarsByConnector,
     featureSwitchContext: args.featureSwitchContext,
   } satisfies RefreshBatchContext;
-  const refreshResults = await refreshSelectedTokens(context, toRefresh);
+  const selectedRefreshResults = await refreshSelectedTokens(
+    context,
+    toRefresh,
+  );
   const skippedTypes = connectorTypes.filter((connectorType) => {
     return !toRefresh.includes(connectorType);
   });
-  await syncSkippedTokens(context, skippedTypes);
+  const skippedStateSnapshot =
+    skippedTypes.length === 0
+      ? { connectorAccessByType: context.connectorAccessByType, sourceStateMap }
+      : await loadCurrentSourceStateSnapshot({
+          db: args.db,
+          orgId: args.orgId,
+          userId: args.auth.userId,
+          connectorTypes: skippedTypes,
+          metadataByConnector,
+        });
+  const skippedResults = await syncSkippedTokens(
+    {
+      ...context,
+      connectorAccessByType: skippedStateSnapshot.connectorAccessByType,
+    },
+    skippedTypes,
+    skippedStateSnapshot.sourceStateMap,
+  );
+  const refreshResults = [...selectedRefreshResults, ...skippedResults];
 
   const summary = summarizeRefreshResults(refreshResults, envVarsByConnector);
   const hasCurrentOrRefreshed = refreshResults.some((result) => {
@@ -2215,8 +2369,8 @@ async function refreshExpiredTokens(
         )),
       ])
     : args.connectorAccessByType;
-  const finalExpiryMap = hasCurrentOrRefreshed
-    ? await getExpiryByProviderKey({
+  const finalSourceStateMap = hasCurrentOrRefreshed
+    ? await getSourceStateByProviderKey({
         db: args.db,
         orgId: args.orgId,
         userId: args.auth.userId,
@@ -2224,10 +2378,10 @@ async function refreshExpiredTokens(
         metadataByConnector,
         connectorAccessByType: finalConnectorAccessByType,
       })
-    : expiryMap;
+    : new Map([...sourceStateMap, ...skippedStateSnapshot.sourceStateMap]);
 
   return {
-    expiresAt: earliestConnectorExpiry(connectorTypes, finalExpiryMap),
+    expiresAt: earliestConnectorExpiry(connectorTypes, finalSourceStateMap),
     ...summary,
   };
 }


### PR DESCRIPTION
## Summary
- Treat `needsReconnect` as part of firewall auth refresh source state for connectors and model-provider OAuth sources.
- Refresh reconnect-required sources even when their stored expiry is still valid, instead of injecting the stale DB access token.
- Reload skipped source state before syncing current DB tokens so a later reconnect-required state cannot be skipped.
- Add connector and model-provider regression coverage for future-expiry reconnect-required tokens.

Fixes #15538

## Verification
- `pnpm exec prettier --write apps/api/src/signals/services/agent-webhook-firewall-auth.service.ts apps/api/src/signals/routes/__tests__/webhooks-agent-firewall-auth.test.ts`
- `pnpm -F api exec tsc --noEmit --pretty false`
- `pnpm -F api exec vitest run src/signals/routes/__tests__/webhooks-agent-firewall-auth.test.ts -t "reconnect-required"`
- `pnpm -F api exec vitest run src/signals/routes/__tests__/webhooks-agent-firewall-auth.test.ts`
- `pnpm turbo run lint`
- `pnpm check-types`
- `pnpm -F @vm0/db db:migrate`
- `pnpm knip`
- `pnpm vitest` fails in unrelated/local areas: app ENOMEM import suites, app network-insights date assertions, desktop macOS accessibility-native tests on Linux, and cronlytic firewall secret consistency.