### PR TITLE
fix(api): return config error for missing model providers

### DIFF
--- a/turbo/apps/api/src/signals/routes/__tests__/webhooks-agent-firewall-auth.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/webhooks-agent-firewall-auth.test.ts
@@ -3450,6 +3450,62 @@ describe("POST /api/webhooks/agent/firewall/auth", () => {
     });
   });
 
+  it("does not fall back to an org model-provider row for user-owned access", async () => {
+    const fixture = await track(seedFixture());
+    await seedCodexModelProvider(fixture, {
+      accessToken: "org-current-chatgpt-token",
+      refreshToken: "org-current-chatgpt-refresh-token",
+      tokenExpiresAt: new Date(now() + 60 * 60 * 1000),
+      needsReconnect: false,
+      lastRefreshErrorCode: null,
+    });
+    let refreshCallCount = 0;
+    server.use(
+      http.post("https://auth.openai.com/oauth/token", () => {
+        refreshCallCount += 1;
+        return HttpResponse.json({
+          access_token: "unexpected-chatgpt-token",
+          refresh_token: "unexpected-chatgpt-refresh",
+          expires_in: 3600,
+        });
+      }),
+    );
+
+    const response = await accept(
+      firewallClient().resolve({
+        body: {
+          encryptedSecrets: encryptedSecrets({
+            CHATGPT_ACCESS_TOKEN: "stale-user-chatgpt-token",
+          }),
+          authHeaders: {
+            Authorization: `Bearer ${secretTemplate("CHATGPT_ACCESS_TOKEN")}`,
+          },
+          secretConnectorMap: {
+            CHATGPT_ACCESS_TOKEN: "codex-oauth-token",
+          },
+          secretConnectorMetadataMap: {
+            CHATGPT_ACCESS_TOKEN: {
+              sourceType: "model-provider",
+              sourceUserId: fixture.userId,
+              metadataKey: "codex-oauth-token",
+            },
+          },
+          firewallBillable: true,
+        },
+        headers: authHeaders(fixture),
+      }),
+      [424],
+    );
+
+    expect(response.body).toStrictEqual({
+      error: {
+        message: "Connector not configured",
+        code: "CONNECTOR_NOT_CONFIGURED",
+      },
+    });
+    expect(refreshCallCount).toBe(0);
+  });
+
   it("returns missing configuration when a model-provider OAuth row is absent", async () => {
     const fixture = await track(seedFixture());
     let refreshCallCount = 0;

--- a/turbo/apps/api/src/signals/routes/__tests__/webhooks-agent-firewall-auth.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/webhooks-agent-firewall-auth.test.ts
@@ -179,6 +179,23 @@ async function waitForConnectorStateLockWaiter(args: {
   );
 }
 
+async function holdConnectorStateLock(args: {
+  readonly orgId: string;
+  readonly userId: string;
+  readonly connectorType: string;
+  readonly release: Promise<void>;
+  readonly onAcquired: () => void;
+}): Promise<void> {
+  const db = store.set(writeDb$);
+  await db.transaction(async (tx) => {
+    await tx.execute(
+      sql`SELECT pg_advisory_xact_lock(hashtext('connector_state:' || ${args.orgId} || ':' || ${args.userId} || ':' || ${args.connectorType}))`,
+    );
+    args.onAcquired();
+    await args.release;
+  });
+}
+
 async function waitForModelProviderStateLockWaiter(args: {
   readonly orgId: string;
   readonly userId: string;
@@ -2155,6 +2172,83 @@ describe("POST /api/webhooks/agent/firewall/auth", () => {
         code: "CONNECTOR_NOT_CONFIGURED",
       },
     });
+  });
+
+  it("returns missing configuration when a connector row disappears before locked refresh", async () => {
+    const fixture = await track(seedFixture());
+    await seedExpiredNotionConnector(fixture);
+    let refreshCallCount = 0;
+    server.use(
+      http.post("https://api.notion.com/v1/oauth/token", () => {
+        refreshCallCount += 1;
+        return HttpResponse.json({
+          access_token: "unexpected-notion-token",
+          refresh_token: "unexpected-notion-refresh-token",
+          expires_in: 3600,
+        });
+      }),
+    );
+
+    const lockAcquired = deferred();
+    const releaseLock = deferred();
+    const lockPromise = holdConnectorStateLock({
+      orgId: fixture.orgId,
+      userId: fixture.userId,
+      connectorType: "notion",
+      release: releaseLock.promise,
+      onAcquired: lockAcquired.resolve,
+    });
+    await lockAcquired.promise;
+
+    const responsePromise = accept(
+      firewallClient().resolve({
+        body: {
+          encryptedSecrets: encryptedSecrets({
+            NOTION_TOKEN: "stale-notion-token",
+          }),
+          authHeaders: {
+            Authorization: `Bearer ${secretTemplate("NOTION_TOKEN")}`,
+          },
+          secretConnectorMap: {
+            NOTION_TOKEN: "notion",
+          },
+        },
+        headers: authHeaders(fixture),
+      }),
+      [424],
+    );
+    const response = await waitForConnectorStateLockWaiter({
+      orgId: fixture.orgId,
+      userId: fixture.userId,
+      connectorType: "notion",
+    })
+      .then(async () => {
+        const db = store.set(writeDb$);
+        await db
+          .delete(connectors)
+          .where(
+            and(
+              eq(connectors.orgId, fixture.orgId),
+              eq(connectors.userId, fixture.userId),
+              eq(connectors.type, "notion"),
+            ),
+          );
+        releaseLock.resolve();
+
+        return responsePromise;
+      })
+      .finally(async () => {
+        releaseLock.resolve();
+        await Promise.allSettled([lockPromise, responsePromise]);
+      });
+
+    expect(response.body).toStrictEqual({
+      error: {
+        message: "Connector not configured",
+        code: "CONNECTOR_NOT_CONFIGURED",
+      },
+    });
+    expect(refreshCallCount).toBe(0);
   });
 
   it("returns a refresh failure when selected connector refresh tokens are missing", async () => {

--- a/turbo/apps/api/src/signals/routes/__tests__/webhooks-agent-firewall-auth.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/webhooks-agent-firewall-auth.test.ts
@@ -4362,6 +4362,86 @@ describe("POST /api/webhooks/agent/firewall/auth", () => {
     ).resolves.toBe("fresh-racing-notion-token");
   });
 
+  it("returns missing configuration when a skipped model-provider row disappears during another refresh", async () => {
+    const fixture = await track(seedFixture());
+    await seedExpiredNotionConnector(fixture);
+    await seedCodexModelProvider(fixture, {
+      accessToken: "current-deleted-chatgpt-token",
+      refreshToken: "deleted-chatgpt-refresh-token",
+      tokenExpiresAt: new Date(now() + 3_600_000),
+      needsReconnect: false,
+      lastRefreshErrorCode: null,
+    });
+
+    let notionRefreshCallCount = 0;
+    server.use(
+      http.post("https://api.notion.com/v1/oauth/token", async () => {
+        notionRefreshCallCount += 1;
+        const db = store.set(writeDb$);
+        await db
+          .delete(modelProviders)
+          .where(
+            and(
+              eq(modelProviders.orgId, fixture.orgId),
+              eq(modelProviders.userId, ORG_SENTINEL_USER_ID),
+              eq(modelProviders.type, "codex-oauth-token"),
+            ),
+          );
+        return HttpResponse.json({
+          access_token: "fresh-deleted-notion-token",
+          refresh_token: "rotated-deleted-notion-refresh-token",
+          expires_in: 3600,
+        });
+      }),
+    );
+
+    const response = await accept(
+      firewallClient().resolve({
+        body: {
+          encryptedSecrets: encryptedSecrets({
+            NOTION_TOKEN: "stale-notion-token",
+            CHATGPT_ACCESS_TOKEN: "stale-snapshot-chatgpt-token",
+          }),
+          authHeaders: {
+            Authorization: [
+              `Bearer ${secretTemplate("NOTION_TOKEN")}`,
+              secretTemplate("CHATGPT_ACCESS_TOKEN"),
+            ].join(" "),
+          },
+          secretConnectorMap: {
+            NOTION_TOKEN: "notion",
+            CHATGPT_ACCESS_TOKEN: "codex-oauth-token",
+          },
+          secretConnectorMetadataMap: {
+            CHATGPT_ACCESS_TOKEN: {
+              sourceType: "model-provider",
+              sourceUserId: ORG_SENTINEL_USER_ID,
+              metadataKey: "codex-oauth-token",
+            },
+          },
+        },
+        headers: authHeaders(fixture),
+      }),
+      [424],
+    );
+
+    expect(notionRefreshCallCount).toBe(1);
+    expect(response.body).toStrictEqual({
+      error: {
+        message: "Connector not configured",
+        code: "CONNECTOR_NOT_CONFIGURED",
+      },
+    });
+    await expect(
+      readSecret({
+        orgId: fixture.orgId,
+        userId: fixture.userId,
+        name: "NOTION_ACCESS_TOKEN",
+        type: "connector",
+      }),
+    ).resolves.toBe("fresh-deleted-notion-token");
+  });
+
   it("preserves standard OAuth reconnect error codes on model-provider refresh failure", async () => {
     const fixture = await track(seedFixture());
     await seedExpiredCodexModelProvider(fixture);

--- a/turbo/apps/api/src/signals/routes/__tests__/webhooks-agent-firewall-auth.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/webhooks-agent-firewall-auth.test.ts
@@ -549,12 +549,14 @@ async function seedCodexModelProvider(
     readonly tokenExpiresAt: Date;
     readonly needsReconnect: boolean;
     readonly lastRefreshErrorCode: string | null;
+    readonly sourceUserId?: string;
   },
 ): Promise<void> {
   const db = store.set(writeDb$);
+  const sourceUserId = args.sourceUserId ?? ORG_SENTINEL_USER_ID;
   await db.insert(modelProviders).values({
     orgId: fixture.orgId,
-    userId: ORG_SENTINEL_USER_ID,
+    userId: sourceUserId,
     type: "codex-oauth-token",
     authMethod: "auth_json",
     tokenExpiresAt: args.tokenExpiresAt,
@@ -563,14 +565,14 @@ async function seedCodexModelProvider(
   });
   await seedSecret({
     orgId: fixture.orgId,
-    userId: ORG_SENTINEL_USER_ID,
+    userId: sourceUserId,
     name: "CHATGPT_ACCESS_TOKEN",
     value: args.accessToken,
     type: "model-provider",
   });
   await seedSecret({
     orgId: fixture.orgId,
-    userId: ORG_SENTINEL_USER_ID,
+    userId: sourceUserId,
     name: "CHATGPT_REFRESH_TOKEN",
     value: args.refreshToken,
     type: "model-provider",
@@ -612,7 +614,10 @@ function notionConnectorState(fixture: FirewallFixture): Promise<{
   return connectorState(fixture, "notion");
 }
 
-async function codexProviderState(fixture: FirewallFixture): Promise<{
+async function codexProviderState(
+  fixture: FirewallFixture,
+  sourceUserId = ORG_SENTINEL_USER_ID,
+): Promise<{
   readonly needsReconnect: boolean;
   readonly lastRefreshErrorCode: string | null;
   readonly tokenExpiresAt: Date | null;
@@ -628,7 +633,7 @@ async function codexProviderState(fixture: FirewallFixture): Promise<{
     .where(
       and(
         eq(modelProviders.orgId, fixture.orgId),
-        eq(modelProviders.userId, ORG_SENTINEL_USER_ID),
+        eq(modelProviders.userId, sourceUserId),
         eq(modelProviders.type, "codex-oauth-token"),
       ),
     )
@@ -3268,6 +3273,84 @@ describe("POST /api/webhooks/agent/firewall/auth", () => {
       }),
     ).resolves.toBe("fresh-chatgpt-token");
     await expect(codexProviderState(fixture)).resolves.toMatchObject({
+      needsReconnect: false,
+      lastRefreshErrorCode: null,
+    });
+  });
+
+  it("refreshes user-owned codex model-provider OAuth tokens", async () => {
+    const fixture = await track(seedFixture());
+    await seedCodexModelProvider(fixture, {
+      sourceUserId: fixture.userId,
+      accessToken: "stale-user-chatgpt-token",
+      refreshToken: "user-chatgpt-refresh-token",
+      tokenExpiresAt: new Date(now() - 60_000),
+      needsReconnect: true,
+      lastRefreshErrorCode: "refresh_token_expired",
+    });
+    server.use(
+      http.post("https://auth.openai.com/oauth/token", () => {
+        return HttpResponse.json({
+          access_token: "fresh-user-chatgpt-token",
+          refresh_token: "rotated-user-chatgpt-refresh",
+          expires_in: 3600,
+        });
+      }),
+    );
+
+    const response = await accept(
+      firewallClient().resolve({
+        body: {
+          encryptedSecrets: encryptedSecrets({
+            CHATGPT_ACCESS_TOKEN: "stale-user-chatgpt-token",
+          }),
+          authHeaders: {
+            Authorization: `Bearer ${secretTemplate("CHATGPT_ACCESS_TOKEN")}`,
+          },
+          secretConnectorMap: {
+            CHATGPT_ACCESS_TOKEN: "codex-oauth-token",
+          },
+          secretConnectorMetadataMap: {
+            CHATGPT_ACCESS_TOKEN: {
+              sourceType: "model-provider",
+              sourceUserId: fixture.userId,
+              metadataKey: "codex-oauth-token",
+            },
+          },
+        },
+        headers: authHeaders(fixture),
+      }),
+      [200],
+    );
+
+    expect(response.body.headers.Authorization).toBe(
+      "Bearer fresh-user-chatgpt-token",
+    );
+    expect(response.body.refreshedConnectors).toStrictEqual([
+      "codex-oauth-token",
+    ]);
+    expect(response.body.refreshedSecrets).toStrictEqual([
+      "CHATGPT_ACCESS_TOKEN",
+    ]);
+    await expect(
+      readSecret({
+        orgId: fixture.orgId,
+        userId: fixture.userId,
+        name: "CHATGPT_ACCESS_TOKEN",
+        type: "model-provider",
+      }),
+    ).resolves.toBe("fresh-user-chatgpt-token");
+    await expect(
+      readSecret({
+        orgId: fixture.orgId,
+        userId: fixture.userId,
+        name: "CHATGPT_REFRESH_TOKEN",
+        type: "model-provider",
+      }),
+    ).resolves.toBe("rotated-user-chatgpt-refresh");
+    await expect(
+      codexProviderState(fixture, fixture.userId),
+    ).resolves.toMatchObject({
       needsReconnect: false,
       lastRefreshErrorCode: null,
     });

--- a/turbo/apps/api/src/signals/routes/__tests__/webhooks-agent-firewall-auth.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/webhooks-agent-firewall-auth.test.ts
@@ -189,6 +189,23 @@ async function waitForModelProviderStateLockWaiter(args: {
   );
 }
 
+async function holdModelProviderStateLock(args: {
+  readonly orgId: string;
+  readonly userId: string;
+  readonly providerType: string;
+  readonly release: Promise<void>;
+  readonly onAcquired: () => void;
+}): Promise<void> {
+  const db = store.set(writeDb$);
+  await db.transaction(async (tx) => {
+    await tx.execute(
+      sql`SELECT pg_advisory_xact_lock(hashtext('model_provider_state:' || ${args.orgId} || ':' || ${args.userId} || ':' || ${args.providerType}))`,
+    );
+    args.onAcquired();
+    await args.release;
+  });
+}
+
 function firewallClient() {
   return setupApp({ context })(webhookFirewallAuthContract);
 }
@@ -3256,6 +3273,55 @@ describe("POST /api/webhooks/agent/firewall/auth", () => {
     });
   });
 
+  it("returns missing configuration when a model-provider OAuth row is absent", async () => {
+    const fixture = await track(seedFixture());
+    let refreshCallCount = 0;
+    server.use(
+      http.post("https://auth.openai.com/oauth/token", () => {
+        refreshCallCount += 1;
+        return HttpResponse.json({
+          access_token: "unexpected-chatgpt-token",
+          refresh_token: "unexpected-chatgpt-refresh",
+          expires_in: 3600,
+        });
+      }),
+    );
+
+    const response = await accept(
+      firewallClient().resolve({
+        body: {
+          encryptedSecrets: encryptedSecrets({
+            CHATGPT_ACCESS_TOKEN: "stale-chatgpt-token",
+          }),
+          authHeaders: {
+            Authorization: `Bearer ${secretTemplate("CHATGPT_ACCESS_TOKEN")}`,
+          },
+          secretConnectorMap: {
+            CHATGPT_ACCESS_TOKEN: "codex-oauth-token",
+          },
+          secretConnectorMetadataMap: {
+            CHATGPT_ACCESS_TOKEN: {
+              sourceType: "model-provider",
+              sourceUserId: ORG_SENTINEL_USER_ID,
+              metadataKey: "codex-oauth-token",
+            },
+          },
+          firewallBillable: true,
+        },
+        headers: authHeaders(fixture),
+      }),
+      [424],
+    );
+
+    expect(response.body).toStrictEqual({
+      error: {
+        message: "Connector not configured",
+        code: "CONNECTOR_NOT_CONFIGURED",
+      },
+    });
+    expect(refreshCallCount).toBe(0);
+  });
+
   it("serializes concurrent model-provider OAuth refreshes for rotated refresh tokens", async () => {
     const fixture = await track(seedFixture());
     await seedExpiredCodexModelProvider(fixture);
@@ -3444,6 +3510,90 @@ describe("POST /api/webhooks/agent/firewall/auth", () => {
       needsReconnect: true,
       lastRefreshErrorCode: "refresh_token_expired",
     });
+  });
+
+  it("returns missing configuration when a model-provider row disappears before locked refresh", async () => {
+    const fixture = await track(seedFixture());
+    await seedExpiredCodexModelProvider(fixture);
+    let refreshCallCount = 0;
+    server.use(
+      http.post("https://auth.openai.com/oauth/token", () => {
+        refreshCallCount += 1;
+        return HttpResponse.json({
+          access_token: "unexpected-chatgpt-token",
+          refresh_token: "unexpected-chatgpt-refresh",
+          expires_in: 3600,
+        });
+      }),
+    );
+
+    const lockAcquired = deferred();
+    const releaseLock = deferred();
+    const lockPromise = holdModelProviderStateLock({
+      orgId: fixture.orgId,
+      userId: ORG_SENTINEL_USER_ID,
+      providerType: "codex-oauth-token",
+      release: releaseLock.promise,
+      onAcquired: lockAcquired.resolve,
+    });
+    await lockAcquired.promise;
+
+    const responsePromise = accept(
+      firewallClient().resolve({
+        body: {
+          encryptedSecrets: encryptedSecrets({
+            CHATGPT_ACCESS_TOKEN: "stale-chatgpt-token",
+          }),
+          authHeaders: {
+            Authorization: `Bearer ${secretTemplate("CHATGPT_ACCESS_TOKEN")}`,
+          },
+          secretConnectorMap: {
+            CHATGPT_ACCESS_TOKEN: "codex-oauth-token",
+          },
+          secretConnectorMetadataMap: {
+            CHATGPT_ACCESS_TOKEN: {
+              sourceType: "model-provider",
+              sourceUserId: ORG_SENTINEL_USER_ID,
+              metadataKey: "codex-oauth-token",
+            },
+          },
+        },
+        headers: authHeaders(fixture),
+      }),
+      [424],
+    );
+    const response = await waitForModelProviderStateLockWaiter({
+      orgId: fixture.orgId,
+      userId: ORG_SENTINEL_USER_ID,
+      providerType: "codex-oauth-token",
+    })
+      .then(async () => {
+        const db = store.set(writeDb$);
+        await db
+          .delete(modelProviders)
+          .where(
+            and(
+              eq(modelProviders.orgId, fixture.orgId),
+              eq(modelProviders.userId, ORG_SENTINEL_USER_ID),
+              eq(modelProviders.type, "codex-oauth-token"),
+            ),
+          );
+        releaseLock.resolve();
+
+        return responsePromise;
+      })
+      .finally(async () => {
+        releaseLock.resolve();
+        await Promise.allSettled([lockPromise, responsePromise]);
+      });
+
+    expect(response.body).toStrictEqual({
+      error: {
+        message: "Connector not configured",
+        code: "CONNECTOR_NOT_CONFIGURED",
+      },
+    });
+    expect(refreshCallCount).toBe(0);
   });
 
   it("preserves model-provider reauth that races with runtime OAuth refresh", async () => {

--- a/turbo/apps/api/src/signals/services/agent-webhook-firewall-auth.service.ts
+++ b/turbo/apps/api/src/signals/services/agent-webhook-firewall-auth.service.ts
@@ -3,6 +3,7 @@ import { Buffer } from "node:buffer";
 import {
   getModelProviderEnvBindings,
   modelProviderTypeSchema,
+  type ModelProviderType,
 } from "@vm0/api-contracts/contracts/model-providers";
 import type { SecretConnectorMetadata } from "@vm0/api-contracts/contracts/runners";
 import {
@@ -101,12 +102,13 @@ interface RefreshResult {
   readonly refreshedConnectors: readonly string[];
   readonly refreshedSecrets: readonly string[];
   readonly failedConnectors: readonly string[];
+  readonly unavailableConnectors: readonly string[];
   readonly failureReason?: FirewallAuthFailureReason;
 }
 
 interface RefreshExecutionResult {
   readonly connectorType: string;
-  readonly status: "current" | "refreshed" | "failed";
+  readonly status: "current" | "refreshed" | "failed" | "source-missing";
   readonly failureReason?: FirewallAuthFailureReason;
 }
 
@@ -293,6 +295,13 @@ interface RefreshState {
   readonly updatedAtMicros: bigint;
 }
 
+interface RefreshStateRow {
+  readonly tokenExpiresAt: Date | null;
+  readonly needsReconnect: boolean;
+  readonly lastRefreshErrorCode: string | null;
+  readonly updatedAtMicros: bigint | number | string;
+}
+
 type PreparedRefreshTokenContext =
   | {
       readonly sourceType: "connector";
@@ -333,7 +342,8 @@ type RefreshAccessTokenResult =
         | "client-unconfigured"
         | "not-refreshable"
         | "refresh-failed"
-        | "refresh-token-missing";
+        | "refresh-token-missing"
+        | "source-missing";
       readonly failureReason?: FirewallAuthFailureReason;
     };
 
@@ -342,6 +352,13 @@ function refreshTokenMissingResult(): RefreshAccessTokenResult {
     ok: false,
     reason: "refresh-token-missing",
     failureReason: "reconnect_required",
+  };
+}
+
+function sourceMissingResult(): RefreshAccessTokenResult {
+  return {
+    ok: false,
+    reason: "source-missing",
   };
 }
 
@@ -448,6 +465,18 @@ function resolveRefreshMetadata(
           modelProviderTypeForOAuthProviderKey(connectorType))
         : undefined,
   };
+}
+
+function modelProviderTypeForMetadata(
+  connectorType: string,
+  metadata: SecretConnectorMetadata,
+): ModelProviderType | undefined {
+  const providerType =
+    metadata.metadataKey ?? modelProviderTypeForOAuthProviderKey(connectorType);
+  const parsedProviderType = providerType
+    ? modelProviderTypeSchema.safeParse(providerType)
+    : undefined;
+  return parsedProviderType?.success ? parsedProviderType.data : undefined;
 }
 
 function currentProviderEnv(): ProviderEnv {
@@ -1210,45 +1239,74 @@ function sameTokenExpiresAt(left: Date | null, right: Date | null): boolean {
   return (left?.getTime() ?? null) === (right?.getTime() ?? null);
 }
 
+async function loadModelProviderRefreshStateRow(
+  db: Db,
+  args: RefreshAccessTokenArgs,
+  context: RefreshTokenContext,
+  lockRow: boolean,
+): Promise<RefreshStateRow | null> {
+  const query = db
+    .select({
+      tokenExpiresAt: modelProviders.tokenExpiresAt,
+      needsReconnect: modelProviders.needsReconnect,
+      lastRefreshErrorCode: modelProviders.lastRefreshErrorCode,
+      updatedAtMicros: sql<string>`(EXTRACT(EPOCH FROM ${modelProviders.updatedAt}) * 1000000)::bigint`,
+    })
+    .from(modelProviders)
+    .where(
+      and(
+        eq(modelProviders.orgId, args.orgId),
+        eq(modelProviders.userId, context.secretUserId),
+        eq(modelProviders.type, args.metadataKey ?? ""),
+      ),
+    );
+  const rows = lockRow
+    ? await query.for("update").limit(1)
+    : await query.limit(1);
+  return rows[0] ?? null;
+}
+
+async function loadConnectorRefreshStateRow(
+  db: Db,
+  args: RefreshAccessTokenArgs,
+  lockRow: boolean,
+): Promise<RefreshStateRow | null> {
+  const query = db
+    .select({
+      tokenExpiresAt: connectors.tokenExpiresAt,
+      needsReconnect: connectors.needsReconnect,
+      lastRefreshErrorCode: sql<string | null>`NULL`,
+      updatedAtMicros: sql<string>`(EXTRACT(EPOCH FROM ${connectors.updatedAt}) * 1000000)::bigint`,
+    })
+    .from(connectors)
+    .where(
+      and(
+        eq(connectors.orgId, args.orgId),
+        eq(connectors.userId, args.userId),
+        eq(connectors.type, args.connectorType),
+      ),
+    );
+  const rows = lockRow
+    ? await query.for("update").limit(1)
+    : await query.limit(1);
+  return rows[0] ?? null;
+}
+
 async function loadRefreshState(
   db: Db,
   args: RefreshAccessTokenArgs,
   context: RefreshTokenContext,
+  options: { readonly lockRow?: boolean } = {},
 ): Promise<RefreshState | null> {
-  const [row] =
+  const row =
     args.sourceType === "model-provider"
-      ? await db
-          .select({
-            tokenExpiresAt: modelProviders.tokenExpiresAt,
-            needsReconnect: modelProviders.needsReconnect,
-            lastRefreshErrorCode: modelProviders.lastRefreshErrorCode,
-            updatedAtMicros: sql<string>`(EXTRACT(EPOCH FROM ${modelProviders.updatedAt}) * 1000000)::bigint`,
-          })
-          .from(modelProviders)
-          .where(
-            and(
-              eq(modelProviders.orgId, args.orgId),
-              eq(modelProviders.userId, context.secretUserId),
-              eq(modelProviders.type, args.metadataKey ?? ""),
-            ),
-          )
-          .limit(1)
-      : await db
-          .select({
-            tokenExpiresAt: connectors.tokenExpiresAt,
-            needsReconnect: connectors.needsReconnect,
-            lastRefreshErrorCode: sql<string | null>`NULL`,
-            updatedAtMicros: sql<string>`(EXTRACT(EPOCH FROM ${connectors.updatedAt}) * 1000000)::bigint`,
-          })
-          .from(connectors)
-          .where(
-            and(
-              eq(connectors.orgId, args.orgId),
-              eq(connectors.userId, args.userId),
-              eq(connectors.type, args.connectorType),
-            ),
-          )
-          .limit(1);
+      ? await loadModelProviderRefreshStateRow(
+          db,
+          args,
+          context,
+          options.lockRow === true,
+        )
+      : await loadConnectorRefreshStateRow(db, args, options.lockRow === true);
 
   if (!row) {
     return null;
@@ -1473,7 +1531,9 @@ async function refreshAccessTokenForSource(
         type: args.metadataKey ?? prepared.providerKey,
       });
     }
-    const lockedState = await loadRefreshState(tx, args, prepared.context);
+    const lockedState = await loadRefreshState(tx, args, prepared.context, {
+      lockRow: true,
+    });
     if (!lockedState) {
       L.warn(`${args.connectorType} token refresh source missing`, {
         connectorType: args.connectorType,
@@ -1481,7 +1541,7 @@ async function refreshAccessTokenForSource(
         userId: args.userId,
         sourceType: args.sourceType,
       });
-      return markRefreshTokenMissing({ ...args, db: tx }, prepared.context);
+      return sourceMissingResult();
     }
     const currentAccessToken = lockedState.accessToken;
     if (
@@ -1608,6 +1668,7 @@ const emptyRefreshResult = Object.freeze({
   refreshedConnectors: [],
   refreshedSecrets: [],
   failedConnectors: [],
+  unavailableConnectors: [],
 }) satisfies RefreshResult;
 
 function buildRefreshableMap(
@@ -1694,21 +1755,57 @@ function modelProviderAccessSecretName(args: {
     return undefined;
   }
 
-  const providerType =
-    args.metadata.metadataKey ??
-    modelProviderTypeForOAuthProviderKey(args.connectorType);
-  const parsedProviderType = providerType
-    ? modelProviderTypeSchema.safeParse(providerType)
-    : undefined;
-  if (!parsedProviderType?.success) {
+  const providerType = modelProviderTypeForMetadata(
+    args.connectorType,
+    args.metadata,
+  );
+  if (!providerType) {
     return undefined;
   }
 
-  const envBindings = getModelProviderEnvBindings(parsedProviderType.data);
+  const envBindings = getModelProviderEnvBindings(providerType);
   return envBindings?.[args.key] ===
     `${CONNECTOR_SECRET_REF_PREFIX}${secretMetadata.accessSecretName}`
     ? secretMetadata.accessSecretName
     : undefined;
+}
+
+function referencedModelProviderAccessMap(args: {
+  readonly secretConnectorMap: Record<string, string> | undefined;
+  readonly secretConnectorMetadataMap:
+    | Record<string, SecretConnectorMetadata>
+    | undefined;
+  readonly referencedKeys: Set<string>;
+}): Map<string, string> {
+  const refreshable = new Map<string, string>();
+  if (!args.secretConnectorMap) {
+    return refreshable;
+  }
+
+  for (const key of args.referencedKeys) {
+    const connectorType = args.secretConnectorMap[key];
+    if (!connectorType) {
+      continue;
+    }
+    const metadata = resolveRefreshMetadata(
+      connectorType,
+      args.secretConnectorMetadataMap?.[key],
+    );
+    if (metadata.sourceType !== "model-provider") {
+      continue;
+    }
+    if (
+      modelProviderAccessSecretName({
+        key,
+        connectorType,
+        metadata,
+      }) === undefined
+    ) {
+      continue;
+    }
+    refreshable.set(key, connectorType);
+  }
+  return refreshable;
 }
 
 async function syncStaticConnectorAccessSecrets(args: {
@@ -1860,6 +1957,10 @@ function hasUnavailableAccessSource(args: {
     | undefined;
   readonly referencedKeys: Set<string>;
   readonly connectorAccessByType: ReadonlyMap<string, ConnectorAccessState>;
+  readonly modelProviderSourceStateByConnector: ReadonlyMap<
+    string,
+    RefreshSourceState
+  >;
 }): boolean {
   if (!args.secretConnectorMap) {
     return false;
@@ -1874,13 +1975,16 @@ function hasUnavailableAccessSource(args: {
       args.secretConnectorMetadataMap?.[key],
     );
     if (metadata.sourceType === "model-provider") {
-      return (
+      if (
         modelProviderAccessSecretName({
           key,
           connectorType,
           metadata,
         }) === undefined
-      );
+      ) {
+        return true;
+      }
+      return !args.modelProviderSourceStateByConnector.has(connectorType);
     }
 
     const accessMetadata =
@@ -1928,6 +2032,17 @@ async function prepareFirewallAuthResolutionContext(args: {
     args.body.authQuery,
   );
   const vars = args.body.vars ?? {};
+  if (
+    args.body.secretConnectorMap &&
+    hasForbiddenModelProviderOwner(
+      args.auth,
+      args.body.secretConnectorMap,
+      args.body.secretConnectorMetadataMap,
+      referenced.secrets,
+    )
+  ) {
+    return { ok: false, response: forbiddenModelProviderOwner() };
+  }
   const connectorAccessByType = await loadConnectorAccessStates(
     args.db,
     args.orgId,
@@ -1938,6 +2053,36 @@ async function prepareFirewallAuthResolutionContext(args: {
       referencedKeys: referenced.secrets,
     }),
   );
+  const modelProviderRefreshable = referencedModelProviderAccessMap({
+    secretConnectorMap: args.body.secretConnectorMap,
+    secretConnectorMetadataMap: args.body.secretConnectorMetadataMap,
+    referencedKeys: referenced.secrets,
+  });
+  const modelProviderSourceStateByConnector =
+    modelProviderRefreshable.size === 0
+      ? new Map<string, RefreshSourceState>()
+      : await getSourceStateByProviderKey({
+          db: args.db,
+          orgId: args.orgId,
+          userId: args.auth.userId,
+          connectorTypes: [...new Set(modelProviderRefreshable.values())],
+          metadataByConnector: buildMetadataByConnector(
+            modelProviderRefreshable,
+            args.body.secretConnectorMetadataMap,
+          ),
+          connectorAccessByType,
+        });
+  if (
+    hasUnavailableAccessSource({
+      secretConnectorMap: args.body.secretConnectorMap,
+      secretConnectorMetadataMap: args.body.secretConnectorMetadataMap,
+      referencedKeys: referenced.secrets,
+      connectorAccessByType,
+      modelProviderSourceStateByConnector,
+    })
+  ) {
+    return { ok: false, response: connectorNotConfigured() };
+  }
   await syncStaticConnectorAccessSecrets({
     db: args.db,
     orgId: args.orgId,
@@ -1949,16 +2094,6 @@ async function prepareFirewallAuthResolutionContext(args: {
     connectorAccessByType,
     featureSwitchContext: args.featureSwitchContext,
   });
-  if (
-    hasUnavailableAccessSource({
-      secretConnectorMap: args.body.secretConnectorMap,
-      secretConnectorMetadataMap: args.body.secretConnectorMetadataMap,
-      referencedKeys: referenced.secrets,
-      connectorAccessByType,
-    })
-  ) {
-    return { ok: false, response: connectorNotConfigured() };
-  }
 
   const hasMissingSecrets = hasMissingUnresolvableSecrets({
     secrets: args.secrets,
@@ -1976,7 +2111,11 @@ async function prepareFirewallAuthResolutionContext(args: {
 
   return {
     ok: true,
-    context: { referenced, vars, connectorAccessByType },
+    context: {
+      referenced,
+      vars,
+      connectorAccessByType,
+    },
   };
 }
 
@@ -2125,6 +2264,12 @@ async function refreshSelectedTokens(
             reason: refreshResult.reason,
           },
         );
+        if (refreshResult.reason === "source-missing") {
+          return {
+            connectorType,
+            status: "source-missing",
+          };
+        }
         return {
           connectorType,
           status: "failed",
@@ -2156,6 +2301,7 @@ async function syncSkippedTokens(
         return {
           connectorType,
           token: null,
+          sourceMissing: true as const,
         };
       }
       if (sourceState?.needsReconnect) {
@@ -2185,7 +2331,26 @@ async function syncSkippedTokens(
       };
     }),
   );
-  for (const { connectorType, token, failureReason } of currentTokens) {
+  for (const {
+    connectorType,
+    token,
+    failureReason,
+    sourceMissing,
+  } of currentTokens) {
+    if (sourceMissing) {
+      L.warn(
+        `[${context.auth.runId}] Skipped connector ${connectorType} source missing`,
+      );
+      for (const envVar of context.envVarsByConnector.get(connectorType) ??
+        []) {
+        delete context.secrets[envVar];
+      }
+      results.push({
+        connectorType,
+        status: "source-missing",
+      });
+      continue;
+    }
     if (failureReason) {
       L.warn(
         `[${context.auth.runId}] Skipped connector ${connectorType} still requires reconnect`,
@@ -2224,6 +2389,7 @@ function summarizeRefreshResults(
 ): Pick<
   RefreshResult,
   | "failedConnectors"
+  | "unavailableConnectors"
   | "refreshedConnectors"
   | "refreshedSecrets"
   | "failureReason"
@@ -2247,6 +2413,13 @@ function summarizeRefreshResults(
     .map((result) => {
       return result.connectorType;
     });
+  const unavailableConnectors = refreshResults
+    .filter((result) => {
+      return result.status === "source-missing";
+    })
+    .map((result) => {
+      return result.connectorType;
+    });
   const failedResults = refreshResults.filter((result) => {
     return result.status === "failed";
   });
@@ -2262,6 +2435,7 @@ function summarizeRefreshResults(
     refreshedConnectors,
     refreshedSecrets,
     failedConnectors,
+    unavailableConnectors,
     ...(failureReason ? { failureReason } : {}),
   };
 }
@@ -2596,18 +2770,6 @@ export async function resolveFirewallAuth(
   }
   const { connectorAccessByType, referenced, vars } = prepared.context;
 
-  if (
-    body.secretConnectorMap &&
-    hasForbiddenModelProviderOwner(
-      auth,
-      body.secretConnectorMap,
-      body.secretConnectorMetadataMap,
-      referenced.secrets,
-    )
-  ) {
-    return forbiddenModelProviderOwner();
-  }
-
   const billableCacheExpiry = await resolveBillableFirewallCacheExpiry({
     db,
     auth,
@@ -2621,6 +2783,7 @@ export async function resolveFirewallAuth(
   let refreshedConnectors: readonly string[] = [];
   let refreshedSecrets: readonly string[] = [];
   let failedConnectors: readonly string[] = [];
+  let unavailableConnectors: readonly string[] = [];
   let failureReason: FirewallAuthFailureReason | undefined;
 
   if (body.secretConnectorMap) {
@@ -2641,7 +2804,12 @@ export async function resolveFirewallAuth(
     refreshedConnectors = result.refreshedConnectors;
     refreshedSecrets = result.refreshedSecrets;
     failedConnectors = result.failedConnectors;
+    unavailableConnectors = result.unavailableConnectors;
     failureReason = result.failureReason;
+  }
+
+  if (unavailableConnectors.length > 0) {
+    return connectorNotConfigured();
   }
 
   if (failedConnectors.length > 0) {


### PR DESCRIPTION
## Summary
- classify referenced model-provider OAuth sources without backing rows as `CONNECTOR_NOT_CONFIGURED`
- reuse prepared model-provider state for refresh expiry decisions
- map source rows that disappear before locked refresh to missing configuration instead of token refresh failure
- add route integration coverage for absent provider rows and locked-refresh deletion races

## Tests
- `pnpm -F api exec vitest run src/signals/routes/__tests__/webhooks-agent-firewall-auth.test.ts`
- `pnpm -F api lint`
- `pnpm -F api check-types`
- `pnpm -F @vm0/db db:migrate`
- `pnpm -F api test`
- pre-commit hook: prettier, knip, `pnpm check-types`

Closes #15539