### PR TITLE
test(mitm-addon): use local webhook boundary in usage tests

### DIFF
--- a/crates/runner/mitm-addon/src/usage/__init__.py
+++ b/crates/runner/mitm-addon/src/usage/__init__.py
@@ -13,10 +13,8 @@ Two paths:
 
 This package exposes the stable surface consumed by ``mitm_addon.py`` and
 ``response_streaming.py``.
-For test patching, target the submodule that **reads** the name (e.g.
-``usage.webhook._opener`` rather than ``usage._opener``) — Python's
-``from X import Y`` creates a module-local binding that facade-level
-patches can't reach.
+Tests should exercise these public hook/provider paths and the local HTTP
+webhook boundary instead of patching private transport internals.
 """
 
 from . import webhook

--- a/crates/runner/mitm-addon/tests/conftest.py
+++ b/crates/runner/mitm-addon/tests/conftest.py
@@ -29,6 +29,7 @@ import mitm_addon
 import registry
 import usage
 from tests.auth_state_helpers import clear_auth_state
+from tests.usage_helpers import UsageWebhookServer
 from usage.providers import connectors as _usage_connectors
 
 
@@ -295,16 +296,31 @@ def fake_firewall_headers():
 
 
 @pytest.fixture
+def usage_webhook_server() -> Iterator[UsageWebhookServer]:
+    server = UsageWebhookServer()
+    with server.run():
+        yield server
+
+
+@pytest.fixture
+def usage_webhook_api(usage_webhook_server, mitm_ctx):
+    @contextlib.contextmanager
+    def _api() -> Iterator[UsageWebhookServer]:
+        with mitm_ctx(api_url=usage_webhook_server.api_url):
+            yield usage_webhook_server
+
+    return _api
+
+
+@pytest.fixture
 def sync_usage_executor():
     """Swap ``usage.webhook.usage_executor`` for a synchronous stub.
 
-    Tests that mock ``usage.webhook._opener`` and want the webhook payloads to
-    appear on the mock by the time they inspect it need submission to
-    happen inline rather than on a background thread — otherwise they
-    have to thread ``fresh_usage_executor`` + ``shutdown(wait=True)``
-    boilerplate through every caller.  The inline executor returns real
-    ``Future`` objects while still running the function synchronously;
-    the original executor is restored on teardown.
+    Tests that want webhook side effects to complete before inline
+    assertions can use this instead of a background thread plus explicit
+    ``fresh_usage_executor`` + ``shutdown(wait=True)`` boilerplate.  The
+    inline executor returns real ``Future`` objects while still running the
+    function synchronously; the original executor is restored on teardown.
     """
 
     class _InlineExecutor:

--- a/crates/runner/mitm-addon/tests/conftest.py
+++ b/crates/runner/mitm-addon/tests/conftest.py
@@ -303,11 +303,12 @@ def usage_webhook_server() -> Iterator[UsageWebhookServer]:
 
 
 @pytest.fixture
-def usage_webhook_api(usage_webhook_server, mitm_ctx):
+def usage_webhook_api(mitm_ctx):
     @contextlib.contextmanager
     def _api() -> Iterator[UsageWebhookServer]:
-        with mitm_ctx(api_url=usage_webhook_server.api_url):
-            yield usage_webhook_server
+        server = UsageWebhookServer()
+        with server.run(), mitm_ctx(api_url=server.api_url):
+            yield server
 
     return _api
 

--- a/crates/runner/mitm-addon/tests/test_connector_usage.py
+++ b/crates/runner/mitm-addon/tests/test_connector_usage.py
@@ -3,7 +3,6 @@
 import gzip
 import json
 from pathlib import Path
-from unittest.mock import MagicMock, patch
 
 import pytest
 from mitmproxy.test import tutils
@@ -12,10 +11,6 @@ import body_utils
 import mitm_addon
 import usage
 from tests.flow_helpers import header_map, response_stream
-from tests.usage_helpers import (
-    request_bodies_from_calls,
-    usage_event_events_from_calls,
-)
 from usage.providers.connectors import x as usage_x_connector
 
 
@@ -45,11 +40,12 @@ class TestReportConnectorUsage:
     """Tests for report_connector_usage helper (issue #9504)."""
 
     @pytest.fixture(autouse=True)
-    def _sync_executor(self, sync_usage_executor):
+    def _sync_executor(self, sync_usage_executor, usage_webhook_api):
         """All tests here route billing through ``_call_and_get_billing`` which
-        inspects ``_opener.open`` inline; the sync executor makes that work
+        inspects webhook delivery inline; the sync executor makes that work
         without each test needing its own ``fresh_usage_executor`` + shutdown.
         """
+        self._usage_webhook_api = usage_webhook_api
 
     def _make_x_flow(
         self,
@@ -91,20 +87,16 @@ class TestReportConnectorUsage:
         """Call report_connector_usage and return the webhook payload(s).
 
         Relies on the class-level ``_sync_executor`` autouse fixture to
-        route submissions inline; only the urllib boundary is mocked here.
+        route submissions inline.
         """
-        with (
-            patch.object(usage_x_connector, "get_api_url", return_value="https://app.test"),
-            patch.object(
-                usage.webhook, "_opener"
-            ) as mock_opener,  # urllib external boundary (#9991)
-        ):
-            mock_opener.open.return_value = MagicMock()
+        with self._usage_webhook_api() as webhook:
+            start_count = webhook.request_count
             usage.report_connector_usage(flow, run_id)
             usage.flush_usage_events(trigger="test")
         return [
             event
-            for body in request_bodies_from_calls(mock_opener.open.call_args_list)
+            for request in webhook.requests[start_count:]
+            for body in [request.json_body()]
             for event in body["events"]
         ]
 
@@ -178,17 +170,13 @@ class TestReportConnectorUsage:
             body=body,
         )
 
-        with (
-            patch.object(usage_x_connector, "get_api_url", return_value="https://app.test"),
-            patch.object(usage.webhook, "_opener") as mock_opener,
-        ):
-            mock_opener.open.return_value = MagicMock()
+        with self._usage_webhook_api() as webhook:
             usage.report_connector_usage(flow, "run-abc-123")
-            mock_opener.open.assert_not_called()
+            assert webhook.request_count == 0
             usage.flush_usage_events(trigger="test")
 
-        mock_opener.open.assert_called_once()
-        [payload] = request_bodies_from_calls(mock_opener.open.call_args_list)
+        assert webhook.request_count == 1
+        [payload] = webhook.json_bodies()
         assert payload["runId"] == "run-abc-123"
         assert "idempotencyKey" not in payload
         by_cat = {event["category"]: event for event in payload["events"]}
@@ -208,15 +196,11 @@ class TestReportConnectorUsage:
         ).encode()
         flow = self._make_x_flow(real_flow, tmp_path, query="expansions=future", body=body)
 
-        with (
-            patch.object(usage_x_connector, "get_api_url", return_value="https://app.test"),
-            patch.object(usage.webhook, "_opener") as mock_opener,
-        ):
-            mock_opener.open.return_value = MagicMock()
+        with self._usage_webhook_api() as webhook:
             usage.report_connector_usage(flow, "run-abc-123")
             usage.flush_usage_events(trigger="test")
 
-        bodies = request_bodies_from_calls(mock_opener.open.call_args_list)
+        bodies = webhook.json_bodies()
         assert [len(body["events"]) for body in bodies] == [100, 1]
         assert {body["runId"] for body in bodies} == {"run-abc-123"}
         assert all(
@@ -440,16 +424,11 @@ class TestReportConnectorUsage:
         assert len(flow.metadata["stream_buffer"]) == body_utils.STREAM_BUFFER_LIMIT
         assert flow.metadata["stream_buffer_state"]["truncated"] is True
 
-        with (
-            mitm_ctx(),
-            patch.object(usage_x_connector, "get_api_url", return_value="https://app.test"),
-            patch.object(usage.webhook, "_opener") as mock_opener,
-        ):
-            mock_opener.open.return_value = MagicMock()
+        with self._usage_webhook_api() as webhook:
             mitm_addon.response(flow)
             usage.flush_usage_events(trigger="test")
 
-        events = usage_event_events_from_calls(mock_opener.open.call_args_list)
+        events = webhook.usage_events()
         by_category = {event["category"]: event["quantity"] for event in events}
         assert by_category == {"posts.read": 1, "user.read": 1}
 
@@ -477,16 +456,11 @@ class TestReportConnectorUsage:
         mitm_addon.responseheaders(flow)
         response_stream(flow)(b'{"data":{"id":"1","text":"hello"}}')
 
-        with (
-            mitm_ctx(),
-            patch.object(usage_x_connector, "get_api_url", return_value="https://app.test"),
-            patch.object(usage.webhook, "_opener") as mock_opener,
-        ):
-            mock_opener.open.return_value = MagicMock()
+        with self._usage_webhook_api() as webhook:
             mitm_addon.response(flow)
             usage.flush_usage_events(trigger="test")
 
-        events = usage_event_events_from_calls(mock_opener.open.call_args_list)
+        events = webhook.usage_events()
         assert len(events) == 1
         assert events[0]["category"] == "posts.read"
         assert events[0]["quantity"] == 1
@@ -526,16 +500,11 @@ class TestReportConnectorUsage:
             ).encode()
         )
 
-        with (
-            mitm_ctx(),
-            patch.object(usage_x_connector, "get_api_url", return_value="https://app.test"),
-            patch.object(usage.webhook, "_opener") as mock_opener,
-        ):
-            mock_opener.open.return_value = MagicMock()
+        with self._usage_webhook_api() as webhook:
             mitm_addon.response(flow)
             usage.flush_usage_events(trigger="test")
 
-        mock_opener.open.assert_not_called()
+        assert webhook.request_count == 0
 
     def test_full_response_pipeline_x_root_array_uses_request_hints(
         self, tmp_path, real_flow, mitm_ctx
@@ -561,16 +530,11 @@ class TestReportConnectorUsage:
         mitm_addon.responseheaders(flow)
         response_stream(flow)(b'[{"id":"1"}]')
 
-        with (
-            mitm_ctx(),
-            patch.object(usage_x_connector, "get_api_url", return_value="https://app.test"),
-            patch.object(usage.webhook, "_opener") as mock_opener,
-        ):
-            mock_opener.open.return_value = MagicMock()
+        with self._usage_webhook_api() as webhook:
             mitm_addon.response(flow)
             usage.flush_usage_events(trigger="test")
 
-        events = usage_event_events_from_calls(mock_opener.open.call_args_list)
+        events = webhook.usage_events()
         assert len(events) == 1
         assert events[0]["category"] == "posts.read"
         assert events[0]["quantity"] == 3
@@ -1296,19 +1260,13 @@ class TestReportConnectorUsage:
             callback(chunk)
 
         # 3. Simulated disconnect - response() fires and logs via webhook
-        with (
-            mitm_ctx(api_url="https://app.test"),
-            patch.object(
-                usage.webhook, "_opener"
-            ) as mock_opener,  # urllib external boundary (#9991)
-        ):
-            mock_opener.open.return_value = MagicMock()
+        with self._usage_webhook_api() as webhook:
             mitm_addon.response(flow)
             usage.flush_usage_events(trigger="test")
             usage.webhook.usage_executor.shutdown(wait=True)
 
         # 4. Verify billing payloads
-        payloads = usage_event_events_from_calls(mock_opener.open.call_args_list)
+        payloads = webhook.usage_events()
         by_cat = {p["category"]: p["quantity"] for p in payloads}
         # 3 tweets primary + 0 from includes.tweets (none here) = 3
         assert by_cat["posts.read"] == 3
@@ -1352,18 +1310,12 @@ class TestReportConnectorUsage:
         assert state["lines_parsed"] == 1
         assert state["lines_failed"] == 0
 
-        with (
-            mitm_ctx(api_url="https://app.test"),
-            patch.object(
-                usage.webhook, "_opener"
-            ) as mock_opener,  # urllib external boundary (#9991)
-        ):
-            mock_opener.open.return_value = MagicMock()
+        with self._usage_webhook_api() as webhook:
             mitm_addon.response(flow)
             usage.flush_usage_events(trigger="test")
             usage.webhook.usage_executor.shutdown(wait=True)
 
-        payloads = usage_event_events_from_calls(mock_opener.open.call_args_list)
+        payloads = webhook.usage_events()
         by_cat = {payload["category"]: payload["quantity"] for payload in payloads}
         assert by_cat == {"posts.read": 1, "media.read": 1}
 
@@ -1391,14 +1343,10 @@ class TestReportConnectorUsage:
         response_stream(flow)(b'{"data":[{"id":"1"}')
         assert "connector_response_finish" in flow.metadata
 
-        with (
-            mitm_ctx(api_url="https://app.test"),
-            patch.object(usage.webhook, "_opener") as mock_opener,
-        ):
-            mock_opener.open.return_value = MagicMock()
+        with self._usage_webhook_api() as webhook:
             mitm_addon.response(flow)
 
-        mock_opener.open.assert_not_called()
+        assert webhook.request_count == 0
         proxy_log = Path(flow.metadata["vm_proxy_log_path"])
         entries = [json.loads(line) for line in proxy_log.read_text().splitlines()]
         lost_visibility_entries = [
@@ -1436,14 +1384,10 @@ class TestReportConnectorUsage:
         response_stream(flow)(b'{"data":[{"id":"1"},' + b" " * body_utils.STREAM_BUFFER_LIMIT)
         assert flow.metadata["stream_buffer_state"]["truncated"] is True
 
-        with (
-            mitm_ctx(api_url="https://app.test"),
-            patch.object(usage.webhook, "_opener") as mock_opener,
-        ):
-            mock_opener.open.return_value = MagicMock()
+        with self._usage_webhook_api() as webhook:
             mitm_addon.response(flow)
 
-        mock_opener.open.assert_not_called()
+        assert webhook.request_count == 0
         proxy_log = Path(flow.metadata["vm_proxy_log_path"])
         entries = [json.loads(line) for line in proxy_log.read_text().splitlines()]
         lost_visibility_entries = [
@@ -1480,15 +1424,11 @@ class TestReportConnectorUsage:
         response_stream(flow)(b'{"data":[{"id":"1"}')
         assert "connector_response_finish" in flow.metadata
 
-        with (
-            mitm_ctx(api_url="https://app.test"),
-            patch.object(usage.webhook, "_opener") as mock_opener,
-        ):
-            mock_opener.open.return_value = MagicMock()
+        with self._usage_webhook_api() as webhook:
             mitm_addon.response(flow)
             usage.flush_usage_events(trigger="test")
 
-        events = usage_event_events_from_calls(mock_opener.open.call_args_list)
+        events = webhook.usage_events()
         assert len(events) == 1
         assert events[0]["category"] == "posts.read"
         assert events[0]["quantity"] == 3

--- a/crates/runner/mitm-addon/tests/test_counters.py
+++ b/crates/runner/mitm-addon/tests/test_counters.py
@@ -8,7 +8,6 @@ import pytest
 import mitm_addon
 import usage
 from tests.pending_helpers import assert_pending
-from usage.providers import model_provider as usage_model_provider
 
 
 class TestUsagePendingCounter:
@@ -106,7 +105,7 @@ class TestUsagePendingCounter:
         assert_pending(pending_path, flows=0, buffered=0, reports=0, flush_request_id="request-2")
 
     def test_buffered_usage_blocks_pending_until_flush(
-        self, tmp_path, real_flow, fresh_usage_executor
+        self, tmp_path, real_flow, fresh_usage_executor, usage_webhook_api
     ):
         pending_path = tmp_path / "usage-pending"
         usage.set_pending_path(str(pending_path))
@@ -118,17 +117,13 @@ class TestUsagePendingCounter:
         flow.metadata["vm_proxy_log_path"] = str(tmp_path / "proxy.jsonl")
         flow.metadata["model_provider_usage"] = {"tokens.input": 1}
 
-        with (
-            patch.object(usage_model_provider, "get_api_url", return_value="https://api.vm0.ai"),
-            patch.object(usage.webhook, "_opener") as mock_opener,
-        ):
-            mock_opener.open.return_value = MagicMock()
+        with usage_webhook_api() as webhook:
             usage.report_model_provider_usage(flow, "run-1")
             usage.write_pending_snapshot(flush_request_id="request-1")
             assert_pending(
                 pending_path, flows=0, buffered=1, reports=0, flush_request_id="request-1"
             )
-            mock_opener.open.assert_not_called()
+            assert webhook.request_count == 0
 
             usage.flush_usage_events(trigger="test")
             usage.webhook.usage_executor.shutdown(wait=True)
@@ -309,7 +304,9 @@ class TestUsagePendingCounter:
         ):
             usage.write_pending_snapshot(flush_request_id="request-1")  # should not raise
 
-    def test_report_decrements_after_completion(self, tmp_path, real_flow, fresh_usage_executor):
+    def test_report_decrements_after_completion(
+        self, tmp_path, real_flow, fresh_usage_executor, usage_webhook_api
+    ):
         """Retry exhaustion still runs the decrement finally-block."""
         pending_path = tmp_path / "usage-pending"
         usage.set_pending_path(str(pending_path))
@@ -322,10 +319,11 @@ class TestUsagePendingCounter:
         flow.metadata["model_provider_usage"] = {"tokens.input": 1}
 
         with (
-            patch.object(usage_model_provider, "get_api_url", return_value="https://api.vm0.ai"),
-            patch.object(usage.webhook, "_opener") as mock_opener,
+            usage_webhook_api() as webhook,
+            patch.object(usage.webhook.time, "sleep"),
         ):
-            mock_opener.open.side_effect = ConnectionError("boom")
+            webhook.queue_response(500)
+            webhook.queue_response(500)
             usage.report_model_provider_usage(flow, "run-1")
             usage.flush_usage_events(trigger="test")
             usage.webhook.usage_executor.shutdown(wait=True)
@@ -334,7 +332,9 @@ class TestUsagePendingCounter:
         usage.write_pending_snapshot(flush_request_id="request-1")
         assert_pending(pending_path, flows=0, buffered=0, reports=0, flush_request_id="request-1")
 
-    def test_enqueue_increments_and_drains_reports(self, tmp_path, real_flow, fresh_usage_executor):
+    def test_enqueue_increments_and_drains_reports(
+        self, tmp_path, real_flow, fresh_usage_executor, usage_webhook_api
+    ):
         """Public entry increments pending on enqueue; executor drain decrements to 0."""
         pending_path = tmp_path / "usage-pending"
         usage.set_pending_path(str(pending_path))
@@ -346,11 +346,7 @@ class TestUsagePendingCounter:
         flow.metadata["vm_proxy_log_path"] = str(tmp_path / "proxy.jsonl")
         flow.metadata["model_provider_usage"] = {"tokens.input": 1}
 
-        with (
-            patch.object(usage_model_provider, "get_api_url", return_value="https://api.vm0.ai"),
-            patch.object(usage.webhook, "_opener") as mock_opener,
-        ):
-            mock_opener.open.return_value = MagicMock()
+        with usage_webhook_api():
             usage.report_model_provider_usage(flow, "run-1")
             usage.flush_usage_events(trigger="test")
             usage.webhook.usage_executor.shutdown(wait=True)
@@ -394,7 +390,9 @@ class TestUsagePendingCounter:
         fake_handler(flow)
         assert usage.counters._in_flight_flows == 1  # unchanged
 
-    def test_sync_fallback_decrements_reports(self, tmp_path, real_flow, fresh_usage_executor):
+    def test_sync_fallback_decrements_reports(
+        self, tmp_path, real_flow, fresh_usage_executor, usage_webhook_api
+    ):
         """When the executor is already shut down, the sync fallback still decrements."""
         pending_path = tmp_path / "usage-pending"
         usage.set_pending_path(str(pending_path))
@@ -409,11 +407,7 @@ class TestUsagePendingCounter:
         flow.metadata["vm_proxy_log_path"] = str(tmp_path / "proxy.jsonl")
         flow.metadata["model_provider_usage"] = {"tokens.input": 1}
 
-        with (
-            patch.object(usage_model_provider, "get_api_url", return_value="https://api.vm0.ai"),
-            patch.object(usage.webhook, "_opener") as mock_opener,
-        ):
-            mock_opener.open.return_value = MagicMock()
+        with usage_webhook_api():
             usage.report_model_provider_usage(flow, "run-1")
             usage.flush_usage_events(trigger="test")
 

--- a/crates/runner/mitm-addon/tests/test_error_handler.py
+++ b/crates/runner/mitm-addon/tests/test_error_handler.py
@@ -4,7 +4,6 @@ import json
 import time
 import uuid
 from pathlib import Path
-from unittest.mock import MagicMock, patch
 
 from mitmproxy.flow import Error
 from mitmproxy.test import tutils
@@ -14,9 +13,6 @@ import mitm_addon
 import usage
 from tests.flow_helpers import header_map, response_stream
 from tests.timestamp_helpers import assert_utc_millisecond_timestamp
-from tests.usage_helpers import (
-    usage_event_events_from_calls,
-)
 
 
 class TestErrorHandler:
@@ -88,7 +84,7 @@ class TestErrorHandler:
         assert "connector_response_finish" not in flow.metadata
 
     def test_error_does_not_bill_partial_x_json_response(
-        self, tmp_path, real_flow, mitm_ctx, sync_usage_executor
+        self, tmp_path, real_flow, mitm_ctx, sync_usage_executor, usage_webhook_api
     ):
         """Interrupted non-stream JSON must not be billed via request-hint fallback."""
         flow = real_flow(with_response=False, host="api.x.com", path="/2/tweets?ids=1,2,3")
@@ -111,14 +107,10 @@ class TestErrorHandler:
         response_stream(flow)(b'{"data":[{"id":"1"}')
         flow.error = Error("connection reset")
 
-        with (
-            mitm_ctx(api_url="https://app.test"),
-            patch.object(usage.webhook, "_opener") as mock_opener,
-        ):
-            mock_opener.open.return_value = MagicMock()
+        with usage_webhook_api() as webhook:
             mitm_addon.error(flow)
 
-        mock_opener.open.assert_not_called()
+        assert webhook.request_count == 0
         assert flow.response.stream is False
         assert "stream_buffer" not in flow.metadata
         assert "connector_response_finish" not in flow.metadata
@@ -251,7 +243,7 @@ class TestErrorHandler:
         assert "#frag" not in entry["message"]
 
     def test_error_logs_connector_usage_for_x_stream(
-        self, tmp_path, real_flow, mitm_ctx, headers, fresh_usage_executor
+        self, tmp_path, real_flow, mitm_ctx, headers, fresh_usage_executor, usage_webhook_api
     ):
         """Mid-flight stream crash: partial counts still reported (issue #9534)."""
         flow = real_flow(with_response=False, host="api.x.com", path="/2/tweets/search/stream")
@@ -280,26 +272,19 @@ class TestErrorHandler:
         flow.error = Error("connection reset by peer")
         flow.metadata["vm_sandbox_token"] = "test-token"
 
-        with (
-            mitm_ctx(api_url="https://app.test"),
-            patch.object(
-                usage.webhook, "_opener"
-            ) as mock_opener,  # urllib external boundary (#9991)
-        ):
-            mock_opener.open.return_value = MagicMock()
+        with usage_webhook_api() as webhook:
             mitm_addon.error(flow)
             usage.flush_usage_events(trigger="test")
             usage.webhook.usage_executor.shutdown(wait=True)
 
-        # Connector billing webhook should have been posted to _opener.
-        assert mock_opener.open.called
-        payloads = usage_event_events_from_calls(mock_opener.open.call_args_list)
+        assert webhook.request_count > 0
+        payloads = webhook.usage_events()
         by_cat = {p["category"]: p["quantity"] for p in payloads}
         assert by_cat["posts.read"] == 23
         assert by_cat["user.read"] == 5
 
     def test_full_pipeline_stream_error_midflight(
-        self, tmp_path, real_flow, mitm_ctx, headers, fresh_usage_executor
+        self, tmp_path, real_flow, mitm_ctx, headers, fresh_usage_executor, usage_webhook_api
     ):
         """End-to-end: responseheaders → partial chunks → error() logs observed counts.
 
@@ -337,27 +322,23 @@ class TestErrorHandler:
         flow.error = Error("connection reset by peer")
         flow.metadata["vm_sandbox_token"] = "test-token"
 
-        with (
-            mitm_ctx(api_url="https://app.test"),
-            patch.object(
-                usage.webhook, "_opener"
-            ) as mock_opener,  # urllib external boundary (#9991)
-        ):
-            mock_opener.open.return_value = MagicMock()
+        with usage_webhook_api() as webhook:
             mitm_addon.error(flow)
             usage.flush_usage_events(trigger="test")
             usage.webhook.usage_executor.shutdown(wait=True)
 
         # 4. Billing must reflect the 2 complete tweets (partial 3rd is dropped)
-        payloads = usage_event_events_from_calls(mock_opener.open.call_args_list)
+        payloads = webhook.usage_events()
         by_cat = {p["category"]: p["quantity"] for p in payloads}
         assert by_cat["posts.read"] == 2  # not 3 — partial trailing dropped
         assert by_cat["user.read"] == 1
 
-    def test_full_path_error_to_opener(self, tmp_path, real_flow, mitm_ctx, fresh_usage_executor):
-        """Integration: error() → _maybe_report → _enqueue → _retry → _opener.
+    def test_full_path_error_to_webhook(
+        self, tmp_path, real_flow, mitm_ctx, fresh_usage_executor, usage_webhook_api
+    ):
+        """Integration: error() -> _maybe_report -> _enqueue -> _retry -> webhook.
 
-        Verifies that error() hook delivers partial usage all the way to _opener.
+        Verifies that error() hook delivers partial usage through loopback HTTP.
         """
         flow = real_flow(with_response=False, host="api.anthropic.com")
         log_path = str(tmp_path / "network.jsonl")
@@ -374,18 +355,13 @@ class TestErrorHandler:
         }
         flow.error = Error("connection reset by peer")
 
-        with (
-            mitm_ctx(api_url="https://api.vm0.ai"),
-            patch.object(usage.webhook, "_opener") as mock_opener,
-        ):
-            mock_opener.open.return_value = MagicMock()
+        with usage_webhook_api() as webhook:
             mitm_addon.error(flow)
             usage.flush_usage_events(trigger="test")
             usage.webhook.usage_executor.shutdown(wait=True)
 
-        mock_opener.open.assert_called_once()  # urllib external boundary (#9991)
-        req = mock_opener.open.call_args[0][0]
-        body = json.loads(req.data)
+        assert webhook.request_count == 1
+        body = webhook.requests[0].json_body()
         assert body["runId"] == "run-int-002"
         assert [
             {key: value for key, value in event.items() if key != "idempotencyKey"}

--- a/crates/runner/mitm-addon/tests/test_model_provider_response_usage.py
+++ b/crates/runner/mitm-addon/tests/test_model_provider_response_usage.py
@@ -4,7 +4,6 @@ import gzip
 import json
 import zlib
 from pathlib import Path
-from unittest.mock import MagicMock, patch
 
 import pytest
 import zstandard
@@ -14,14 +13,14 @@ import body_utils
 import mitm_addon
 import usage
 from tests.flow_helpers import header_map, response_stream
-from tests.usage_helpers import set_stream_buffer, usage_event_events_from_calls
+from tests.usage_helpers import set_stream_buffer
 
 
 class TestModelProviderResponseUsage:
     """Tests for model-provider JSON usage extraction and response reporting."""
 
     def test_non_streaming_json_fallback(
-        self, tmp_path, real_flow, mitm_ctx, headers, fresh_usage_executor
+        self, tmp_path, real_flow, mitm_ctx, headers, fresh_usage_executor, usage_webhook_api
     ):
         """Non-streaming JSON response should extract usage from buffer."""
         flow = real_flow(with_response=False, host="api.anthropic.com")
@@ -51,13 +50,7 @@ class TestModelProviderResponseUsage:
             ),
         )
 
-        with (
-            mitm_ctx(),
-            patch.object(
-                usage.webhook, "_opener"
-            ) as mock_opener,  # urllib external boundary (#9991)
-        ):
-            mock_opener.open.return_value = MagicMock()
+        with usage_webhook_api():
             mitm_addon.response(flow)
             usage.flush_usage_events(trigger="test")
             usage.webhook.usage_executor.shutdown(wait=True)
@@ -69,7 +62,7 @@ class TestModelProviderResponseUsage:
         assert extracted["tokens.output"] == 200
 
     def test_openai_non_streaming_json_fallback(
-        self, tmp_path, real_flow, mitm_ctx, headers, fresh_usage_executor
+        self, tmp_path, real_flow, mitm_ctx, headers, fresh_usage_executor, usage_webhook_api
     ):
         """Legacy JSON fallback should use OpenAI Responses mapping."""
         flow = real_flow(with_response=False, host="api.openai.com")
@@ -102,11 +95,7 @@ class TestModelProviderResponseUsage:
             ),
         )
 
-        with (
-            mitm_ctx(),
-            patch.object(usage.webhook, "_opener") as mock_opener,
-        ):
-            mock_opener.open.return_value = MagicMock()
+        with usage_webhook_api() as webhook:
             mitm_addon.response(flow)
             usage.flush_usage_events(trigger="test")
             usage.webhook.usage_executor.shutdown(wait=True)
@@ -117,7 +106,7 @@ class TestModelProviderResponseUsage:
         assert extracted["tokens.input"] == 40
         assert extracted["tokens.output"] == 200
         assert extracted["tokens.cache_read"] == 10
-        events = usage_event_events_from_calls(mock_opener.open.call_args_list)
+        events = webhook.usage_events()
         by_category = {event["category"]: event["quantity"] for event in events}
         assert by_category == {
             "tokens.input": 40,
@@ -126,7 +115,7 @@ class TestModelProviderResponseUsage:
         }
 
     def test_anthropic_json_fallback_parse_error_logs_proxy_warning(
-        self, tmp_path, real_flow, mitm_ctx, fresh_usage_executor
+        self, tmp_path, real_flow, mitm_ctx, fresh_usage_executor, usage_webhook_api
     ):
         """Legacy JSON fallback parse failures should be observable."""
         flow = real_flow(with_response=False, host="api.anthropic.com")
@@ -147,16 +136,12 @@ class TestModelProviderResponseUsage:
             headers=header_map({"content-type": "application/json"}),
         )
 
-        with (
-            mitm_ctx(),
-            patch.object(usage.webhook, "_opener") as mock_opener,
-        ):
-            mock_opener.open.return_value = MagicMock()
+        with usage_webhook_api() as webhook:
             mitm_addon.response(flow)
             usage.flush_usage_events(trigger="test")
             usage.webhook.usage_executor.shutdown(wait=True)
 
-        mock_opener.open.assert_not_called()
+        assert webhook.request_count == 0
         assert "model_provider_usage" not in flow.metadata
         entries = [json.loads(line) for line in proxy_log_path.read_text().splitlines()]
         assert len(entries) == 1
@@ -166,7 +151,7 @@ class TestModelProviderResponseUsage:
         assert entries[0]["error"] == "incomplete json"
 
     def test_json_fallback_parser_bound_error_logs_proxy_warning(
-        self, tmp_path, real_flow, mitm_ctx, fresh_usage_executor
+        self, tmp_path, real_flow, mitm_ctx, fresh_usage_executor, usage_webhook_api
     ):
         """Bounded parser failures should be observable without logging body content."""
         flow = real_flow(with_response=False, host="api.anthropic.com")
@@ -194,16 +179,12 @@ class TestModelProviderResponseUsage:
             headers=header_map({"content-type": "application/json"}),
         )
 
-        with (
-            mitm_ctx(),
-            patch.object(usage.webhook, "_opener") as mock_opener,
-        ):
-            mock_opener.open.return_value = MagicMock()
+        with usage_webhook_api() as webhook:
             mitm_addon.response(flow)
             usage.flush_usage_events(trigger="test")
             usage.webhook.usage_executor.shutdown(wait=True)
 
-        mock_opener.open.assert_not_called()
+        assert webhook.request_count == 0
         assert "model_provider_usage" not in flow.metadata
         entries = [json.loads(line) for line in proxy_log_path.read_text().splitlines()]
         assert len(entries) == 1
@@ -214,7 +195,7 @@ class TestModelProviderResponseUsage:
         assert oversized_model not in proxy_log_path.read_text()
 
     def test_openai_json_fallback_parse_error_logs_proxy_warning(
-        self, tmp_path, real_flow, mitm_ctx, fresh_usage_executor
+        self, tmp_path, real_flow, mitm_ctx, fresh_usage_executor, usage_webhook_api
     ):
         """OpenAI fallback parse failures should use the same proxy warning."""
         flow = real_flow(with_response=False, host="api.openai.com")
@@ -236,16 +217,12 @@ class TestModelProviderResponseUsage:
             headers=header_map({"content-type": "application/json"}),
         )
 
-        with (
-            mitm_ctx(),
-            patch.object(usage.webhook, "_opener") as mock_opener,
-        ):
-            mock_opener.open.return_value = MagicMock()
+        with usage_webhook_api() as webhook:
             mitm_addon.response(flow)
             usage.flush_usage_events(trigger="test")
             usage.webhook.usage_executor.shutdown(wait=True)
 
-        mock_opener.open.assert_not_called()
+        assert webhook.request_count == 0
         assert "model_provider_usage" not in flow.metadata
         entries = [json.loads(line) for line in proxy_log_path.read_text().splitlines()]
         assert len(entries) == 1
@@ -272,7 +249,14 @@ class TestModelProviderResponseUsage:
     )
     @pytest.mark.parametrize("provider_case", ["anthropic", "openai"])
     def test_json_fallback_compressed_body_parse_failure_logs_proxy_warning(
-        self, tmp_path, real_flow, mitm_ctx, fresh_usage_executor, encoding_case, provider_case
+        self,
+        tmp_path,
+        real_flow,
+        mitm_ctx,
+        fresh_usage_executor,
+        usage_webhook_api,
+        encoding_case,
+        provider_case,
     ):
         """One-shot decompression failures leave compressed bytes and log parse failure."""
         if provider_case == "openai":
@@ -356,16 +340,12 @@ class TestModelProviderResponseUsage:
             ),
         )
 
-        with (
-            mitm_ctx(),
-            patch.object(usage.webhook, "_opener") as mock_opener,
-        ):
-            mock_opener.open.return_value = MagicMock()
+        with usage_webhook_api() as webhook:
             mitm_addon.response(flow)
             usage.flush_usage_events(trigger="test")
             usage.webhook.usage_executor.shutdown(wait=True)
 
-        mock_opener.open.assert_not_called()
+        assert webhook.request_count == 0
         assert "model_provider_usage" not in flow.metadata
         entries = [json.loads(line) for line in proxy_log_path.read_text().splitlines()]
         assert len(entries) == 1
@@ -382,6 +362,7 @@ class TestModelProviderResponseUsage:
         real_flow,
         mitm_ctx,
         fresh_usage_executor,
+        usage_webhook_api,
         encoding_case,
         provider_case,
     ):
@@ -427,11 +408,7 @@ class TestModelProviderResponseUsage:
             ),
         )
 
-        with (
-            mitm_ctx(),
-            patch.object(usage.webhook, "_opener") as mock_opener,
-        ):
-            mock_opener.open.return_value = MagicMock()
+        with usage_webhook_api():
             mitm_addon.response(flow)
             usage.flush_usage_events(trigger="test")
             usage.webhook.usage_executor.shutdown(wait=True)
@@ -459,6 +436,7 @@ class TestModelProviderResponseUsage:
         real_flow,
         mitm_ctx,
         fresh_usage_executor,
+        usage_webhook_api,
         encoding_case,
         provider_case,
     ):
@@ -515,11 +493,7 @@ class TestModelProviderResponseUsage:
             ),
         )
 
-        with (
-            mitm_ctx(),
-            patch.object(usage.webhook, "_opener") as mock_opener,
-        ):
-            mock_opener.open.return_value = MagicMock()
+        with usage_webhook_api() as webhook:
             mitm_addon.response(flow)
             usage.flush_usage_events(trigger="test")
             usage.webhook.usage_executor.shutdown(wait=True)
@@ -532,7 +506,7 @@ class TestModelProviderResponseUsage:
         assert extracted["tokens.output"] == 200
         if provider_case == "openai":
             assert extracted["tokens.cache_read"] == 10
-        events = usage_event_events_from_calls(mock_opener.open.call_args_list)
+        events = webhook.usage_events()
         by_category = {event["category"]: event["quantity"] for event in events}
         expected = {
             "tokens.input": 40 if provider_case == "openai" else 50,
@@ -549,7 +523,7 @@ class TestModelProviderResponseUsage:
             )
 
     def test_json_fallback_valid_body_without_usage_stays_quiet(
-        self, tmp_path, real_flow, mitm_ctx, fresh_usage_executor
+        self, tmp_path, real_flow, mitm_ctx, fresh_usage_executor, usage_webhook_api
     ):
         """Valid JSON without usage is not a parser failure."""
         flow = real_flow(with_response=False, host="api.anthropic.com")
@@ -570,21 +544,17 @@ class TestModelProviderResponseUsage:
             headers=header_map({"content-type": "application/json"}),
         )
 
-        with (
-            mitm_ctx(),
-            patch.object(usage.webhook, "_opener") as mock_opener,
-        ):
-            mock_opener.open.return_value = MagicMock()
+        with usage_webhook_api() as webhook:
             mitm_addon.response(flow)
             usage.flush_usage_events(trigger="test")
             usage.webhook.usage_executor.shutdown(wait=True)
 
-        mock_opener.open.assert_not_called()
+        assert webhook.request_count == 0
         assert "model_provider_usage" not in flow.metadata
         assert not proxy_log_path.exists()
 
     def test_openai_json_fallback_valid_body_without_usage_stays_quiet(
-        self, tmp_path, real_flow, mitm_ctx, fresh_usage_executor
+        self, tmp_path, real_flow, mitm_ctx, fresh_usage_executor, usage_webhook_api
     ):
         """OpenAI fallback should also keep valid no-usage JSON quiet."""
         flow = real_flow(with_response=False, host="api.openai.com")
@@ -606,16 +576,12 @@ class TestModelProviderResponseUsage:
             headers=header_map({"content-type": "application/json"}),
         )
 
-        with (
-            mitm_ctx(),
-            patch.object(usage.webhook, "_opener") as mock_opener,
-        ):
-            mock_opener.open.return_value = MagicMock()
+        with usage_webhook_api() as webhook:
             mitm_addon.response(flow)
             usage.flush_usage_events(trigger="test")
             usage.webhook.usage_executor.shutdown(wait=True)
 
-        mock_opener.open.assert_not_called()
+        assert webhook.request_count == 0
         assert "model_provider_usage" not in flow.metadata
         assert not proxy_log_path.exists()
 
@@ -624,7 +590,14 @@ class TestModelProviderResponseUsage:
     )
     @pytest.mark.parametrize("provider_case", ["anthropic", "openai"])
     def test_json_fallback_empty_body_stays_quiet(
-        self, tmp_path, real_flow, mitm_ctx, fresh_usage_executor, encoding_case, provider_case
+        self,
+        tmp_path,
+        real_flow,
+        mitm_ctx,
+        fresh_usage_executor,
+        usage_webhook_api,
+        encoding_case,
+        provider_case,
     ):
         """Empty model-provider bodies are not JSON parser failures."""
         if provider_case == "openai":
@@ -667,21 +640,17 @@ class TestModelProviderResponseUsage:
         set_stream_buffer(flow, body)
         flow.response = tutils.tresp(status_code=200, headers=header_map(response_headers))
 
-        with (
-            mitm_ctx(),
-            patch.object(usage.webhook, "_opener") as mock_opener,
-        ):
-            mock_opener.open.return_value = MagicMock()
+        with usage_webhook_api() as webhook:
             mitm_addon.response(flow)
             usage.flush_usage_events(trigger="test")
             usage.webhook.usage_executor.shutdown(wait=True)
 
-        mock_opener.open.assert_not_called()
+        assert webhook.request_count == 0
         assert "model_provider_usage" not in flow.metadata
         assert not proxy_log_path.exists()
 
     def test_anthropic_json_fallback_metadata_only_usage_stays_quiet(
-        self, tmp_path, real_flow, mitm_ctx, fresh_usage_executor
+        self, tmp_path, real_flow, mitm_ctx, fresh_usage_executor, usage_webhook_api
     ):
         """Anthropic metadata without positive token usage is not a parser failure."""
         flow = real_flow(with_response=False, host="api.anthropic.com")
@@ -702,16 +671,12 @@ class TestModelProviderResponseUsage:
             headers=header_map({"content-type": "application/json"}),
         )
 
-        with (
-            mitm_ctx(),
-            patch.object(usage.webhook, "_opener") as mock_opener,
-        ):
-            mock_opener.open.return_value = MagicMock()
+        with usage_webhook_api() as webhook:
             mitm_addon.response(flow)
             usage.flush_usage_events(trigger="test")
             usage.webhook.usage_executor.shutdown(wait=True)
 
-        mock_opener.open.assert_not_called()
+        assert webhook.request_count == 0
         assert flow.metadata["model_provider_usage"] == {
             "message_id": "msg_1",
             "model": "claude-sonnet-4-6",
@@ -720,7 +685,7 @@ class TestModelProviderResponseUsage:
 
     @pytest.mark.parametrize("provider_case", ["anthropic", "openai"])
     def test_json_fallback_zero_token_usage_stays_quiet(
-        self, tmp_path, real_flow, mitm_ctx, fresh_usage_executor, provider_case
+        self, tmp_path, real_flow, mitm_ctx, fresh_usage_executor, usage_webhook_api, provider_case
     ):
         """Valid zero-token usage is not a parser failure and does not bill."""
         proxy_log_path = tmp_path / "proxy.jsonl"
@@ -769,21 +734,17 @@ class TestModelProviderResponseUsage:
             headers=header_map({"content-type": "application/json"}),
         )
 
-        with (
-            mitm_ctx(),
-            patch.object(usage.webhook, "_opener") as mock_opener,
-        ):
-            mock_opener.open.return_value = MagicMock()
+        with usage_webhook_api() as webhook:
             mitm_addon.response(flow)
             usage.flush_usage_events(trigger="test")
             usage.webhook.usage_executor.shutdown(wait=True)
 
-        mock_opener.open.assert_not_called()
+        assert webhook.request_count == 0
         assert flow.metadata["model_provider_usage"] == expected_usage
         assert not proxy_log_path.exists()
 
     def test_codex_oauth_non_streaming_json_fallback(
-        self, tmp_path, real_flow, mitm_ctx, fresh_usage_executor
+        self, tmp_path, real_flow, mitm_ctx, fresh_usage_executor, usage_webhook_api
     ):
         """Codex OAuth model-provider fallback uses OpenAI Responses mapping."""
         flow = real_flow(with_response=False, host="chatgpt.com")
@@ -816,11 +777,7 @@ class TestModelProviderResponseUsage:
             ),
         )
 
-        with (
-            mitm_ctx(),
-            patch.object(usage.webhook, "_opener") as mock_opener,
-        ):
-            mock_opener.open.return_value = MagicMock()
+        with usage_webhook_api() as webhook:
             mitm_addon.response(flow)
             usage.flush_usage_events(trigger="test")
             usage.webhook.usage_executor.shutdown(wait=True)
@@ -831,7 +788,7 @@ class TestModelProviderResponseUsage:
         assert extracted["tokens.input"] == 40
         assert extracted["tokens.output"] == 200
         assert extracted["tokens.cache_read"] == 10
-        events = usage_event_events_from_calls(mock_opener.open.call_args_list)
+        events = webhook.usage_events()
         by_category = {event["category"]: event["quantity"] for event in events}
         assert by_category == {
             "tokens.input": 40,
@@ -840,7 +797,7 @@ class TestModelProviderResponseUsage:
         }
 
     def test_non_billable_openai_json_does_not_report_usage(
-        self, tmp_path, real_flow, mitm_ctx, fresh_usage_executor
+        self, tmp_path, real_flow, mitm_ctx, fresh_usage_executor, usage_webhook_api
     ):
         flow = real_flow(with_response=False, host="api.openai.com")
         body = json.dumps(
@@ -864,20 +821,16 @@ class TestModelProviderResponseUsage:
             headers=header_map({"content-type": "application/json"}),
         )
 
-        with (
-            mitm_ctx(),
-            patch.object(usage.webhook, "_opener") as mock_opener,
-        ):
-            mock_opener.open.return_value = MagicMock()
+        with usage_webhook_api() as webhook:
             mitm_addon.response(flow)
             usage.flush_usage_events(trigger="test")
             usage.webhook.usage_executor.shutdown(wait=True)
 
-        mock_opener.open.assert_not_called()
+        assert webhook.request_count == 0
         assert "model_provider_usage" not in flow.metadata
 
     def test_non_billable_json_fallback_parse_error_stays_quiet(
-        self, tmp_path, real_flow, mitm_ctx, fresh_usage_executor
+        self, tmp_path, real_flow, mitm_ctx, fresh_usage_executor, usage_webhook_api
     ):
         """Non-billable model-provider fallback must not emit usage warnings."""
         flow = real_flow(with_response=False, host="api.openai.com")
@@ -898,21 +851,17 @@ class TestModelProviderResponseUsage:
             headers=header_map({"content-type": "application/json"}),
         )
 
-        with (
-            mitm_ctx(),
-            patch.object(usage.webhook, "_opener") as mock_opener,
-        ):
-            mock_opener.open.return_value = MagicMock()
+        with usage_webhook_api() as webhook:
             mitm_addon.response(flow)
             usage.flush_usage_events(trigger="test")
             usage.webhook.usage_executor.shutdown(wait=True)
 
-        mock_opener.open.assert_not_called()
+        assert webhook.request_count == 0
         assert "model_provider_usage" not in flow.metadata
         assert not proxy_log_path.exists()
 
     def test_full_pipeline_large_model_json_uses_bounded_buffer(
-        self, tmp_path, real_flow, mitm_ctx, headers, fresh_usage_executor
+        self, tmp_path, real_flow, mitm_ctx, headers, fresh_usage_executor, usage_webhook_api
     ):
         """responseheaders + response report model usage without full-body buffering."""
         flow = real_flow(with_response=False, host="api.anthropic.com")
@@ -939,22 +888,18 @@ class TestModelProviderResponseUsage:
         assert len(flow.metadata["stream_buffer"]) == body_utils.STREAM_BUFFER_LIMIT
         assert flow.metadata["stream_buffer_state"]["truncated"] is True
 
-        with (
-            mitm_ctx(),
-            patch.object(usage.webhook, "_opener") as mock_opener,
-        ):
-            mock_opener.open.return_value = MagicMock()
+        with usage_webhook_api() as webhook:
             mitm_addon.response(flow)
             usage.flush_usage_events(trigger="test")
             usage.webhook.usage_executor.shutdown(wait=True)
 
-        events = usage_event_events_from_calls(mock_opener.open.call_args_list)
+        events = webhook.usage_events()
         by_category = {event["category"]: event["quantity"] for event in events}
         assert by_category == {"tokens.input": 50, "tokens.output": 200}
 
     @pytest.mark.parametrize("provider_case", ["anthropic", "openai"])
     def test_full_pipeline_compressed_model_json_reports_usage(
-        self, tmp_path, real_flow, mitm_ctx, fresh_usage_executor, provider_case
+        self, tmp_path, real_flow, mitm_ctx, fresh_usage_executor, usage_webhook_api, provider_case
     ):
         """responseheaders parser should decompress non-SSE model JSON before extraction."""
         if provider_case == "openai":
@@ -1002,11 +947,7 @@ class TestModelProviderResponseUsage:
         response_stream(flow)(compressed[:midpoint])
         response_stream(flow)(compressed[midpoint:])
 
-        with (
-            mitm_ctx(),
-            patch.object(usage.webhook, "_opener") as mock_opener,
-        ):
-            mock_opener.open.return_value = MagicMock()
+        with usage_webhook_api() as webhook:
             mitm_addon.response(flow)
             usage.flush_usage_events(trigger="test")
             usage.webhook.usage_executor.shutdown(wait=True)
@@ -1019,7 +960,7 @@ class TestModelProviderResponseUsage:
         assert extracted["tokens.output"] == 200
         if provider_case == "openai":
             assert extracted["tokens.cache_read"] == 10
-        events = usage_event_events_from_calls(mock_opener.open.call_args_list)
+        events = webhook.usage_events()
         by_category = {event["category"]: event["quantity"] for event in events}
         expected = {
             "tokens.input": 40 if provider_case == "openai" else 50,
@@ -1030,7 +971,7 @@ class TestModelProviderResponseUsage:
         assert by_category == expected
 
     def test_full_pipeline_incomplete_model_json_does_not_report_partial_usage(
-        self, tmp_path, real_flow, mitm_ctx, headers, fresh_usage_executor
+        self, tmp_path, real_flow, mitm_ctx, headers, fresh_usage_executor, usage_webhook_api
     ):
         """Fields seen before EOF are ignored unless the JSON document completes."""
         flow = real_flow(with_response=False, host="api.anthropic.com")
@@ -1054,16 +995,12 @@ class TestModelProviderResponseUsage:
             b'"usage":{"input_tokens":50,"output_tokens":200}'
         )
 
-        with (
-            mitm_ctx(),
-            patch.object(usage.webhook, "_opener") as mock_opener,
-        ):
-            mock_opener.open.return_value = MagicMock()
+        with usage_webhook_api() as webhook:
             mitm_addon.response(flow)
             usage.flush_usage_events(trigger="test")
             usage.webhook.usage_executor.shutdown(wait=True)
 
-        mock_opener.open.assert_not_called()
+        assert webhook.request_count == 0
         proxy_log = Path(flow.metadata["vm_proxy_log_path"])
         entries = [json.loads(line) for line in proxy_log.read_text().splitlines()]
         usage_warnings = [
@@ -1075,7 +1012,7 @@ class TestModelProviderResponseUsage:
         assert usage_warnings[0]["error"] == "incomplete json"
 
     def test_full_pipeline_corrupt_model_json_encoding_does_not_fallback_to_raw_buffer(
-        self, tmp_path, real_flow, mitm_ctx, fresh_usage_executor
+        self, tmp_path, real_flow, mitm_ctx, fresh_usage_executor, usage_webhook_api
     ):
         """A bad Content-Encoding must not parse raw stream_buffer and bill usage."""
         raw_json = json.dumps(
@@ -1103,21 +1040,17 @@ class TestModelProviderResponseUsage:
         mitm_addon.responseheaders(flow)
         response_stream(flow)(raw_json)
 
-        with (
-            mitm_ctx(),
-            patch.object(usage.webhook, "_opener") as mock_opener,
-        ):
-            mock_opener.open.return_value = MagicMock()
+        with usage_webhook_api() as webhook:
             mitm_addon.response(flow)
             usage.flush_usage_events(trigger="test")
             usage.webhook.usage_executor.shutdown(wait=True)
 
-        mock_opener.open.assert_not_called()
+        assert webhook.request_count == 0
         assert "model_provider_usage" not in flow.metadata
         assert "stream_buffer" not in flow.metadata
 
     def test_full_pipeline_model_json_ignores_usage_array_shape(
-        self, tmp_path, real_flow, mitm_ctx, fresh_usage_executor
+        self, tmp_path, real_flow, mitm_ctx, fresh_usage_executor, usage_webhook_api
     ):
         """usage fields inside array elements must not be treated as usage object fields."""
         body = json.dumps(
@@ -1144,19 +1077,15 @@ class TestModelProviderResponseUsage:
         mitm_addon.responseheaders(flow)
         response_stream(flow)(body)
 
-        with (
-            mitm_ctx(),
-            patch.object(usage.webhook, "_opener") as mock_opener,
-        ):
-            mock_opener.open.return_value = MagicMock()
+        with usage_webhook_api() as webhook:
             mitm_addon.response(flow)
             usage.flush_usage_events(trigger="test")
             usage.webhook.usage_executor.shutdown(wait=True)
 
-        mock_opener.open.assert_not_called()
+        assert webhook.request_count == 0
 
     def test_no_usage_report_for_non_model_provider(
-        self, tmp_path, real_flow, mitm_ctx, headers, fresh_usage_executor
+        self, tmp_path, real_flow, mitm_ctx, headers, fresh_usage_executor, usage_webhook_api
     ):
         """Non-model-provider requests should not trigger usage reporting."""
         flow = real_flow(with_response=False, host="api.github.com")
@@ -1175,26 +1104,21 @@ class TestModelProviderResponseUsage:
             status_code=200, headers=header_map({"content-type": "application/json"})
         )
 
-        with (
-            mitm_ctx(),
-            # report_model_provider_usage early-returns on the firewall_name == "github"
-            # filter, so no urllib request should ever reach the external boundary.
-            patch.object(usage.webhook, "_opener") as mock_opener,
-        ):
+        with usage_webhook_api() as webhook:
             mitm_addon.response(flow)
             usage.flush_usage_events(trigger="test")
             usage.webhook.usage_executor.shutdown(wait=True)
 
-        assert mock_opener.open.call_count == 0  # urllib external boundary (#9991)
+        assert webhook.request_count == 0
         assert "model_provider_usage" not in flow.metadata
         assert not proxy_log_path.exists()
 
-    def test_full_path_response_to_opener(
-        self, tmp_path, real_flow, mitm_ctx, headers, fresh_usage_executor
+    def test_full_path_response_to_webhook(
+        self, tmp_path, real_flow, mitm_ctx, headers, fresh_usage_executor, usage_webhook_api
     ):
-        """Integration: response() → _maybe_report → _enqueue → _retry → _opener.
+        """Integration: response() -> _maybe_report -> _enqueue -> _retry -> webhook.
 
-        Only _opener is mocked — verifies wiring between all intermediate layers.
+        Verifies wiring between all intermediate layers through loopback HTTP.
         """
         flow = real_flow(with_response=False, host="api.anthropic.com")
         log_path = str(tmp_path / "network.jsonl")
@@ -1215,21 +1139,15 @@ class TestModelProviderResponseUsage:
             status_code=200, headers=header_map({"content-type": "text/event-stream"})
         )
 
-        with (
-            mitm_ctx(api_url="https://api.vm0.ai"),
-            patch.object(usage.webhook, "_opener") as mock_opener,
-        ):
-            mock_opener.open.return_value = MagicMock()
+        with usage_webhook_api() as webhook:
             mitm_addon.response(flow)
             # Flush the executor to ensure the background POST completes
             usage.flush_usage_events(trigger="test")
             usage.webhook.usage_executor.shutdown(wait=True)
 
-        # Verify the webhook POST reached _opener with correct payload
-        mock_opener.open.assert_called_once()  # urllib external boundary (#9991)
-        req = mock_opener.open.call_args[0][0]
-        assert req.full_url == "https://api.vm0.ai/api/webhooks/agent/usage-event"
-        body = json.loads(req.data)
+        assert webhook.request_count == 1
+        assert webhook.requests[0].path == "/api/webhooks/agent/usage-event"
+        body = webhook.requests[0].json_body()
         assert body["runId"] == "run-int-001"
         by_category = {event["category"]: event for event in body["events"]}
         assert by_category["tokens.input"]["quantity"] == 100

--- a/crates/runner/mitm-addon/tests/test_model_provider_stream_usage.py
+++ b/crates/runner/mitm-addon/tests/test_model_provider_stream_usage.py
@@ -4,7 +4,6 @@ import json
 import uuid
 from collections.abc import Callable
 from pathlib import Path
-from unittest.mock import MagicMock, patch
 
 from mitmproxy import http, websocket
 from mitmproxy.flow import Error
@@ -15,7 +14,6 @@ import mitm_addon
 import response_streaming
 import usage
 from tests.flow_helpers import header_map, response_stream
-from tests.usage_helpers import usage_event_events_from_calls
 
 
 def _openai_model_websocket_flow(
@@ -135,7 +133,7 @@ class TestModelProviderStreamUsage:
     """Tests for model-provider SSE and WebSocket usage reporting."""
 
     def test_full_pipeline_model_sse_finalizes_trailing_event(
-        self, tmp_path, real_flow, mitm_ctx, fresh_usage_executor
+        self, tmp_path, real_flow, mitm_ctx, fresh_usage_executor, usage_webhook_api
     ):
         """response() must flush a trailing SSE usage event before reporting."""
         flow = _openai_responses_sse_flow(tmp_path, real_flow)
@@ -146,16 +144,12 @@ class TestModelProviderStreamUsage:
             b'"input_tokens_details":{"cached_tokens":10}}}}'
         )
 
-        with (
-            mitm_ctx(),
-            patch.object(usage.webhook, "_opener") as mock_opener,
-        ):
-            mock_opener.open.return_value = MagicMock()
+        with usage_webhook_api() as webhook:
             mitm_addon.response(flow)
             usage.flush_usage_events(trigger="test")
             usage.webhook.usage_executor.shutdown(wait=True)
 
-        events = usage_event_events_from_calls(mock_opener.open.call_args_list)
+        events = webhook.usage_events()
         by_category = {event["category"]: event["quantity"] for event in events}
         assert by_category == {
             "tokens.input": 40,
@@ -164,7 +158,7 @@ class TestModelProviderStreamUsage:
         }
 
     def test_full_pipeline_model_sse_reports_response_incomplete_usage(
-        self, tmp_path, real_flow, mitm_ctx, fresh_usage_executor
+        self, tmp_path, real_flow, mitm_ctx, fresh_usage_executor, usage_webhook_api
     ):
         flow = _openai_responses_sse_flow(tmp_path, real_flow)
         response_stream(flow)(
@@ -174,16 +168,12 @@ class TestModelProviderStreamUsage:
             b'"input_tokens_details":{"cached_tokens":2000}}}}\n\n'
         )
 
-        with (
-            mitm_ctx(),
-            patch.object(usage.webhook, "_opener") as mock_opener,
-        ):
-            mock_opener.open.return_value = MagicMock()
+        with usage_webhook_api() as webhook:
             mitm_addon.response(flow)
             usage.flush_usage_events(trigger="test")
             usage.webhook.usage_executor.shutdown(wait=True)
 
-        events = usage_event_events_from_calls(mock_opener.open.call_args_list)
+        events = webhook.usage_events()
         by_category = {event["category"]: event["quantity"] for event in events}
         assert by_category == {
             "tokens.input": 6000,
@@ -193,7 +183,7 @@ class TestModelProviderStreamUsage:
         assert {event["provider"] for event in events} == {"gpt-5.5"}
 
     def test_full_pipeline_anthropic_sse_logs_truncated_message_start(
-        self, tmp_path, real_flow, mitm_ctx, fresh_usage_executor
+        self, tmp_path, real_flow, mitm_ctx, fresh_usage_executor, usage_webhook_api
     ):
         flow = _model_provider_sse_flow(
             tmp_path,
@@ -206,16 +196,12 @@ class TestModelProviderStreamUsage:
             b'event: message_start\ndata: {"type":"message_start","message":{"id":"msg_1","mod'
         )
 
-        with (
-            mitm_ctx(),
-            patch.object(usage.webhook, "_opener") as mock_opener,
-        ):
-            mock_opener.open.return_value = MagicMock()
+        with usage_webhook_api() as webhook:
             mitm_addon.response(flow)
             usage.flush_usage_events(trigger="test")
             usage.webhook.usage_executor.shutdown(wait=True)
 
-        mock_opener.open.assert_not_called()
+        assert webhook.request_count == 0
         _assert_single_model_sse_parse_warning(
             flow,
             usage_protocol="anthropic_messages_sse",
@@ -223,7 +209,7 @@ class TestModelProviderStreamUsage:
         )
 
     def test_full_pipeline_anthropic_sse_error_logs_truncated_message_start(
-        self, tmp_path, real_flow, mitm_ctx, fresh_usage_executor
+        self, tmp_path, real_flow, mitm_ctx, fresh_usage_executor, usage_webhook_api
     ):
         flow = _model_provider_sse_flow(
             tmp_path,
@@ -237,16 +223,12 @@ class TestModelProviderStreamUsage:
         )
         flow.error = Error("connection reset by peer")
 
-        with (
-            mitm_ctx(),
-            patch.object(usage.webhook, "_opener") as mock_opener,
-        ):
-            mock_opener.open.return_value = MagicMock()
+        with usage_webhook_api() as webhook:
             mitm_addon.error(flow)
             usage.flush_usage_events(trigger="test")
             usage.webhook.usage_executor.shutdown(wait=True)
 
-        mock_opener.open.assert_not_called()
+        assert webhook.request_count == 0
         _assert_single_model_sse_parse_warning(
             flow,
             usage_protocol="anthropic_messages_sse",
@@ -254,7 +236,7 @@ class TestModelProviderStreamUsage:
         )
 
     def test_full_pipeline_anthropic_sse_logs_malformed_message_start(
-        self, tmp_path, real_flow, mitm_ctx, fresh_usage_executor
+        self, tmp_path, real_flow, mitm_ctx, fresh_usage_executor, usage_webhook_api
     ):
         flow = _model_provider_sse_flow(
             tmp_path,
@@ -265,16 +247,12 @@ class TestModelProviderStreamUsage:
         )
         response_stream(flow)(b"event: message_start\ndata: {invalid json}\n\n")
 
-        with (
-            mitm_ctx(),
-            patch.object(usage.webhook, "_opener") as mock_opener,
-        ):
-            mock_opener.open.return_value = MagicMock()
+        with usage_webhook_api() as webhook:
             mitm_addon.response(flow)
             usage.flush_usage_events(trigger="test")
             usage.webhook.usage_executor.shutdown(wait=True)
 
-        mock_opener.open.assert_not_called()
+        assert webhook.request_count == 0
         _assert_single_model_sse_parse_warning(
             flow,
             usage_protocol="anthropic_messages_sse",
@@ -282,7 +260,7 @@ class TestModelProviderStreamUsage:
         )
 
     def test_full_pipeline_anthropic_sse_logs_truncated_message_delta_after_start(
-        self, tmp_path, real_flow, mitm_ctx, fresh_usage_executor
+        self, tmp_path, real_flow, mitm_ctx, fresh_usage_executor, usage_webhook_api
     ):
         flow = _model_provider_sse_flow(
             tmp_path,
@@ -299,16 +277,12 @@ class TestModelProviderStreamUsage:
             b'data: {"type":"message_delta","usage":{"output_tokens":'
         )
 
-        with (
-            mitm_ctx(),
-            patch.object(usage.webhook, "_opener") as mock_opener,
-        ):
-            mock_opener.open.return_value = MagicMock()
+        with usage_webhook_api() as webhook:
             mitm_addon.response(flow)
             usage.flush_usage_events(trigger="test")
             usage.webhook.usage_executor.shutdown(wait=True)
 
-        events = usage_event_events_from_calls(mock_opener.open.call_args_list)
+        events = webhook.usage_events()
         by_category = {event["category"]: event["quantity"] for event in events}
         assert by_category == {"tokens.input": 50}
         assert {event["provider"] for event in events} == {"claude-sonnet-4-6"}
@@ -319,7 +293,7 @@ class TestModelProviderStreamUsage:
         )
 
     def test_full_pipeline_openai_sse_logs_truncated_terminal_event(
-        self, tmp_path, real_flow, mitm_ctx, fresh_usage_executor
+        self, tmp_path, real_flow, mitm_ctx, fresh_usage_executor, usage_webhook_api
     ):
         flow = _openai_responses_sse_flow(tmp_path, real_flow)
         response_stream(flow)(
@@ -327,16 +301,12 @@ class TestModelProviderStreamUsage:
             b'data: {"type":"response.completed","response":{"id":"resp_1","model":"gpt'
         )
 
-        with (
-            mitm_ctx(),
-            patch.object(usage.webhook, "_opener") as mock_opener,
-        ):
-            mock_opener.open.return_value = MagicMock()
+        with usage_webhook_api() as webhook:
             mitm_addon.response(flow)
             usage.flush_usage_events(trigger="test")
             usage.webhook.usage_executor.shutdown(wait=True)
 
-        mock_opener.open.assert_not_called()
+        assert webhook.request_count == 0
         _assert_single_model_sse_parse_warning(
             flow,
             usage_protocol="openai_responses_sse",
@@ -344,7 +314,7 @@ class TestModelProviderStreamUsage:
         )
 
     def test_full_pipeline_openai_sse_logs_truncated_late_event_name(
-        self, tmp_path, real_flow, mitm_ctx, fresh_usage_executor
+        self, tmp_path, real_flow, mitm_ctx, fresh_usage_executor, usage_webhook_api
     ):
         flow = _openai_responses_sse_flow(tmp_path, real_flow)
         response_stream(flow)(
@@ -352,16 +322,12 @@ class TestModelProviderStreamUsage:
             b"event: response.completed\n\n"
         )
 
-        with (
-            mitm_ctx(),
-            patch.object(usage.webhook, "_opener") as mock_opener,
-        ):
-            mock_opener.open.return_value = MagicMock()
+        with usage_webhook_api() as webhook:
             mitm_addon.response(flow)
             usage.flush_usage_events(trigger="test")
             usage.webhook.usage_executor.shutdown(wait=True)
 
-        mock_opener.open.assert_not_called()
+        assert webhook.request_count == 0
         _assert_single_model_sse_parse_warning(
             flow,
             usage_protocol="openai_responses_sse",
@@ -369,7 +335,7 @@ class TestModelProviderStreamUsage:
         )
 
     def test_full_pipeline_eventless_incomplete_anthropic_usage_sse_warns(
-        self, tmp_path, real_flow, mitm_ctx, fresh_usage_executor
+        self, tmp_path, real_flow, mitm_ctx, fresh_usage_executor, usage_webhook_api
     ):
         flow = _model_provider_sse_flow(
             tmp_path,
@@ -382,16 +348,12 @@ class TestModelProviderStreamUsage:
             b'data: {"type":"message_start","message":{"id":"msg_1","model":"claude'
         )
 
-        with (
-            mitm_ctx(),
-            patch.object(usage.webhook, "_opener") as mock_opener,
-        ):
-            mock_opener.open.return_value = MagicMock()
+        with usage_webhook_api() as webhook:
             mitm_addon.response(flow)
             usage.flush_usage_events(trigger="test")
             usage.webhook.usage_executor.shutdown(wait=True)
 
-        mock_opener.open.assert_not_called()
+        assert webhook.request_count == 0
         _assert_single_model_sse_parse_warning(
             flow,
             usage_protocol="anthropic_messages_sse",
@@ -399,7 +361,7 @@ class TestModelProviderStreamUsage:
         )
 
     def test_full_pipeline_anthropic_non_usage_incomplete_sse_does_not_warn(
-        self, tmp_path, real_flow, mitm_ctx, fresh_usage_executor
+        self, tmp_path, real_flow, mitm_ctx, fresh_usage_executor, usage_webhook_api
     ):
         flow = _model_provider_sse_flow(
             tmp_path,
@@ -413,40 +375,32 @@ class TestModelProviderStreamUsage:
             b'data: {"type":"content_block_delta","delta":{"text":"hello'
         )
 
-        with (
-            mitm_ctx(),
-            patch.object(usage.webhook, "_opener") as mock_opener,
-        ):
-            mock_opener.open.return_value = MagicMock()
+        with usage_webhook_api() as webhook:
             mitm_addon.response(flow)
             usage.flush_usage_events(trigger="test")
             usage.webhook.usage_executor.shutdown(wait=True)
 
-        mock_opener.open.assert_not_called()
+        assert webhook.request_count == 0
         assert _model_sse_parse_warnings(flow) == []
 
     def test_full_pipeline_openai_eventless_incomplete_sse_does_not_warn(
-        self, tmp_path, real_flow, mitm_ctx, fresh_usage_executor
+        self, tmp_path, real_flow, mitm_ctx, fresh_usage_executor, usage_webhook_api
     ):
         flow = _openai_responses_sse_flow(tmp_path, real_flow)
         response_stream(flow)(
             b'data: {"type":"response.completed","response":{"id":"resp_1","model":"gpt'
         )
 
-        with (
-            mitm_ctx(),
-            patch.object(usage.webhook, "_opener") as mock_opener,
-        ):
-            mock_opener.open.return_value = MagicMock()
+        with usage_webhook_api() as webhook:
             mitm_addon.response(flow)
             usage.flush_usage_events(trigger="test")
             usage.webhook.usage_executor.shutdown(wait=True)
 
-        mock_opener.open.assert_not_called()
+        assert webhook.request_count == 0
         assert _model_sse_parse_warnings(flow) == []
 
     def test_full_pipeline_openai_non_terminal_incomplete_sse_does_not_warn(
-        self, tmp_path, real_flow, mitm_ctx, fresh_usage_executor
+        self, tmp_path, real_flow, mitm_ctx, fresh_usage_executor, usage_webhook_api
     ):
         flow = _openai_responses_sse_flow(tmp_path, real_flow)
         response_stream(flow)(
@@ -454,20 +408,16 @@ class TestModelProviderStreamUsage:
             b'data: {"type":"response.in_progress","response":{"id":"resp_1","model":"gpt'
         )
 
-        with (
-            mitm_ctx(),
-            patch.object(usage.webhook, "_opener") as mock_opener,
-        ):
-            mock_opener.open.return_value = MagicMock()
+        with usage_webhook_api() as webhook:
             mitm_addon.response(flow)
             usage.flush_usage_events(trigger="test")
             usage.webhook.usage_executor.shutdown(wait=True)
 
-        mock_opener.open.assert_not_called()
+        assert webhook.request_count == 0
         assert _model_sse_parse_warnings(flow) == []
 
     def test_full_pipeline_model_sse_zero_event_preserves_billed_usage_and_id(
-        self, tmp_path, real_flow, mitm_ctx, fresh_usage_executor
+        self, tmp_path, real_flow, mitm_ctx, fresh_usage_executor, usage_webhook_api
     ):
         flow = _openai_responses_sse_flow(tmp_path, real_flow)
         response_stream(flow)(
@@ -479,16 +429,12 @@ class TestModelProviderStreamUsage:
             b'"usage":{"input_tokens":0,"output_tokens":0}}}\n\n'
         )
 
-        with (
-            mitm_ctx(),
-            patch.object(usage.webhook, "_opener") as mock_opener,
-        ):
-            mock_opener.open.return_value = MagicMock()
+        with usage_webhook_api() as webhook:
             mitm_addon.response(flow)
             usage.flush_usage_events(trigger="test")
             usage.webhook.usage_executor.shutdown(wait=True)
 
-        events = usage_event_events_from_calls(mock_opener.open.call_args_list)
+        events = webhook.usage_events()
         by_category = {event["category"]: event["quantity"] for event in events}
         idempotency_by_category = {event["category"]: event["idempotencyKey"] for event in events}
         assert by_category == {
@@ -501,7 +447,7 @@ class TestModelProviderStreamUsage:
         assert {event["provider"] for event in events} == {"gpt-5.5"}
 
     def test_full_pipeline_model_websocket_reports_usage(
-        self, tmp_path, real_flow, mitm_ctx, fresh_usage_executor
+        self, tmp_path, real_flow, mitm_ctx, fresh_usage_executor, usage_webhook_api
     ):
         """Codex Responses WebSocket frames should bill like SSE events."""
         flow = _openai_model_websocket_flow(tmp_path, real_flow)
@@ -528,17 +474,13 @@ class TestModelProviderStreamUsage:
             ).encode(),
         )
 
-        with (
-            mitm_ctx(),
-            patch.object(usage.webhook, "_opener") as mock_opener,
-        ):
-            mock_opener.open.return_value = MagicMock()
+        with usage_webhook_api() as webhook:
             mitm_addon.websocket_message(flow)
             mitm_addon.websocket_end(flow)
             usage.flush_usage_events(trigger="test")
             usage.webhook.usage_executor.shutdown(wait=True)
 
-        events = usage_event_events_from_calls(mock_opener.open.call_args_list)
+        events = webhook.usage_events()
         by_category = {event["category"]: event["quantity"] for event in events}
         assert flow.metadata["model_provider_usage"]["message_id"] == "resp_ws_1"
         assert by_category == {
@@ -548,7 +490,7 @@ class TestModelProviderStreamUsage:
         }
 
     def test_full_pipeline_model_websocket_zero_frame_preserves_billed_usage_and_id(
-        self, tmp_path, real_flow, mitm_ctx, fresh_usage_executor
+        self, tmp_path, real_flow, mitm_ctx, fresh_usage_executor, usage_webhook_api
     ):
         flow = _openai_model_websocket_flow(tmp_path, real_flow)
 
@@ -586,16 +528,12 @@ class TestModelProviderStreamUsage:
             ).encode(),
         )
 
-        with (
-            mitm_ctx(),
-            patch.object(usage.webhook, "_opener") as mock_opener,
-        ):
-            mock_opener.open.return_value = MagicMock()
+        with usage_webhook_api() as webhook:
             mitm_addon.websocket_end(flow)
             usage.flush_usage_events(trigger="test")
             usage.webhook.usage_executor.shutdown(wait=True)
 
-        events = usage_event_events_from_calls(mock_opener.open.call_args_list)
+        events = webhook.usage_events()
         by_category = {event["category"]: event["quantity"] for event in events}
         idempotency_by_category = {event["category"]: event["idempotencyKey"] for event in events}
         assert by_category == {
@@ -822,7 +760,7 @@ class TestModelProviderStreamUsage:
         assert flow.metadata["model_provider_usage"] == "invalid"
 
     def test_model_websocket_ignores_client_messages(
-        self, tmp_path, real_flow, mitm_ctx, fresh_usage_executor
+        self, tmp_path, real_flow, mitm_ctx, fresh_usage_executor, usage_webhook_api
     ):
         flow = _openai_model_websocket_flow(tmp_path, real_flow)
         _set_websocket_message(
@@ -840,14 +778,11 @@ class TestModelProviderStreamUsage:
             ).encode(),
         )
 
-        with (
-            mitm_ctx(),
-            patch.object(usage.webhook, "_opener") as mock_opener,
-        ):
+        with usage_webhook_api() as webhook:
             mitm_addon.websocket_message(flow)
             mitm_addon.websocket_end(flow)
             usage.flush_usage_events(trigger="test")
             usage.webhook.usage_executor.shutdown(wait=True)
 
-        mock_opener.open.assert_not_called()
+        assert webhook.request_count == 0
         assert flow.metadata["model_provider_usage"] == {}

--- a/crates/runner/mitm-addon/tests/test_model_provider_usage.py
+++ b/crates/runner/mitm-addon/tests/test_model_provider_usage.py
@@ -2,17 +2,17 @@
 
 import json
 import uuid
-from unittest.mock import MagicMock, patch
 
 import usage
-from usage.providers import model_provider as usage_model_provider
 
 
 class TestReportModelProviderUsage:
     """Tests for report_model_provider_usage helper."""
 
-    def test_reports_usage_for_model_provider(self, real_flow, fresh_usage_executor):
-        """Model-provider usage reaches _opener with correct payload."""
+    def test_reports_usage_for_model_provider(
+        self, real_flow, fresh_usage_executor, usage_webhook_api
+    ):
+        """Model-provider usage reaches the webhook boundary with correct payload."""
         flow = real_flow(with_response=False, host="api.anthropic.com")
         flow.metadata["firewall_name"] = "model-provider:anthropic-api-key"
         flow.metadata["firewall_billable"] = True
@@ -27,20 +27,15 @@ class TestReportModelProviderUsage:
             "tokens.cache_creation": 10,
         }
 
-        with (
-            patch.object(usage_model_provider, "get_api_url", return_value="https://api.vm0.ai"),
-            patch.object(usage.webhook, "_opener") as mock_opener,
-        ):
-            mock_opener.open.return_value = MagicMock()
+        with usage_webhook_api() as webhook:
             usage.report_model_provider_usage(flow, "run-abc-123")
-            mock_opener.open.assert_not_called()
+            assert webhook.request_count == 0
             usage.flush_usage_events(trigger="test")
             usage.webhook.usage_executor.shutdown(wait=True)
 
-        mock_opener.open.assert_called_once()  # urllib external boundary (#9991)
-        req = mock_opener.open.call_args[0][0]
-        assert req.full_url == "https://api.vm0.ai/api/webhooks/agent/usage-event"
-        body = json.loads(req.data)
+        assert webhook.request_count == 1
+        assert webhook.requests[0].path == "/api/webhooks/agent/usage-event"
+        body = webhook.requests[0].json_body()
         assert body["runId"] == "run-abc-123"
         assert set(body) == {"runId", "events"}
         by_category = {event["category"]: event for event in body["events"]}
@@ -76,7 +71,9 @@ class TestReportModelProviderUsage:
         for event in body["events"]:
             uuid.UUID(event["idempotencyKey"])
 
-    def test_falls_back_to_response_model_then_unknown(self, real_flow, fresh_usage_executor):
+    def test_falls_back_to_response_model_then_unknown(
+        self, real_flow, fresh_usage_executor, usage_webhook_api
+    ):
         """Provider falls back only when selected vm0 model metadata is absent."""
         flow = real_flow(with_response=False, host="api.anthropic.com")
         flow.metadata["firewall_name"] = "model-provider:anthropic-api-key"
@@ -87,33 +84,27 @@ class TestReportModelProviderUsage:
             "tokens.input": 100,
         }
 
-        with (
-            patch.object(usage_model_provider, "get_api_url", return_value="https://api.vm0.ai"),
-            patch.object(usage.webhook, "_opener") as mock_opener,
-        ):
-            mock_opener.open.return_value = MagicMock()
+        with usage_webhook_api() as webhook:
             usage.report_model_provider_usage(flow, "run-abc-123")
             usage.flush_usage_events(trigger="test")
             usage.webhook.usage_executor.shutdown(wait=True)
 
-        body = json.loads(mock_opener.open.call_args[0][0].data)
+        body = webhook.requests[0].json_body()
         assert body["events"][0]["provider"] == "unknown"
 
         flow.metadata["model_provider_usage"]["message_id"] = "msg-usage-2"
         flow.metadata["model_provider_usage"]["model"] = "claude-sonnet-4-6"
-        with (
-            patch.object(usage_model_provider, "get_api_url", return_value="https://api.vm0.ai"),
-            patch.object(usage.webhook, "_opener") as mock_opener,
-        ):
-            mock_opener.open.return_value = MagicMock()
+        with usage_webhook_api() as webhook:
             usage.report_model_provider_usage(flow, "run-abc-123")
             usage.flush_usage_events(trigger="test")
             usage.webhook.usage_executor.shutdown(wait=True)
 
-        body = json.loads(mock_opener.open.call_args[0][0].data)
+        body = webhook.requests[-1].json_body()
         assert body["events"][0]["provider"] == "claude-sonnet-4-6"
 
-    def test_skips_when_no_positive_token_quantities(self, real_flow, fresh_usage_executor):
+    def test_skips_when_no_positive_token_quantities(
+        self, real_flow, fresh_usage_executor, usage_webhook_api
+    ):
         flow = real_flow(with_response=False, host="api.anthropic.com")
         flow.metadata["firewall_name"] = "model-provider:anthropic-api-key"
         flow.metadata["firewall_billable"] = True
@@ -126,17 +117,16 @@ class TestReportModelProviderUsage:
             "tokens.cache_creation": True,
         }
 
-        with (
-            patch.object(usage_model_provider, "get_api_url", return_value="https://api.vm0.ai"),
-            patch.object(usage.webhook, "_opener") as mock_opener,
-        ):
+        with usage_webhook_api() as webhook:
             usage.report_model_provider_usage(flow, "run-abc-123")
             usage.flush_usage_events(trigger="test")
             usage.webhook.usage_executor.shutdown(wait=True)
 
-        mock_opener.open.assert_not_called()  # urllib external boundary (#9991)
+        assert webhook.request_count == 0
 
-    def test_skips_when_firewall_not_billable(self, real_flow, fresh_usage_executor):
+    def test_skips_when_firewall_not_billable(
+        self, real_flow, fresh_usage_executor, usage_webhook_api
+    ):
         """Should NOT report usage when firewall_billable is False.
 
         Simulates a user supplying their own Anthropic key — the web layer
@@ -149,60 +139,58 @@ class TestReportModelProviderUsage:
         flow.metadata["vm_sandbox_token"] = "tok-xyz"
         flow.metadata["model_provider_usage"] = {"tokens.input": 100}
 
-        with (
-            patch.object(usage_model_provider, "get_api_url", return_value="https://api.vm0.ai"),
-            patch.object(usage.webhook, "_opener") as mock_opener,
-        ):
+        with usage_webhook_api() as webhook:
             usage.report_model_provider_usage(flow, "run-abc-123")
             usage.flush_usage_events(trigger="test")
             usage.webhook.usage_executor.shutdown(wait=True)
 
-        mock_opener.open.assert_not_called()  # urllib external boundary (#9991)
+        assert webhook.request_count == 0
 
-    def test_skips_non_model_provider(self, real_flow, fresh_usage_executor):
-        """Should NOT reach _opener for non-model-provider requests."""
+    def test_skips_non_model_provider(self, real_flow, fresh_usage_executor, usage_webhook_api):
+        """Should NOT reach the webhook boundary for non-model-provider requests."""
         flow = real_flow(with_response=False, host="api.github.com")
         flow.metadata["firewall_name"] = "github"
         flow.metadata["model_provider_usage"] = {"tokens.input": 50}
 
-        with patch.object(usage.webhook, "_opener") as mock_opener:
+        with usage_webhook_api() as webhook:
             usage.report_model_provider_usage(flow, "run-abc-123")
             usage.flush_usage_events(trigger="test")
             usage.webhook.usage_executor.shutdown(wait=True)
 
-        mock_opener.open.assert_not_called()  # urllib external boundary (#9991)
+        assert webhook.request_count == 0
 
-    def test_skips_when_no_model_provider_usage(self, real_flow, fresh_usage_executor):
-        """Should NOT reach _opener when model_provider_usage is absent."""
+    def test_skips_when_no_model_provider_usage(
+        self, real_flow, fresh_usage_executor, usage_webhook_api
+    ):
+        """Should NOT reach the webhook boundary when model_provider_usage is absent."""
         flow = real_flow(with_response=False, host="api.anthropic.com")
         flow.metadata["firewall_name"] = "model-provider:anthropic-api-key"
         flow.metadata["vm_sandbox_token"] = "tok-xyz"
         # No model_provider_usage in metadata
 
-        with (
-            patch.object(usage_model_provider, "get_api_url", return_value="https://api.vm0.ai"),
-            patch.object(usage.webhook, "_opener") as mock_opener,
-        ):
+        with usage_webhook_api() as webhook:
             usage.report_model_provider_usage(flow, "run-abc-123")
             usage.flush_usage_events(trigger="test")
             usage.webhook.usage_executor.shutdown(wait=True)
 
-        mock_opener.open.assert_not_called()  # urllib external boundary (#9991)
+        assert webhook.request_count == 0
 
-    def test_skips_when_no_run_id(self, real_flow, fresh_usage_executor):
-        """Should NOT reach _opener when run_id is empty."""
+    def test_skips_when_no_run_id(self, real_flow, fresh_usage_executor, usage_webhook_api):
+        """Should NOT reach the webhook boundary when run_id is empty."""
         flow = real_flow(with_response=False, host="api.anthropic.com")
         flow.metadata["firewall_name"] = "model-provider:anthropic-api-key"
         flow.metadata["model_provider_usage"] = {"tokens.input": 50}
 
-        with patch.object(usage.webhook, "_opener") as mock_opener:
+        with usage_webhook_api() as webhook:
             usage.report_model_provider_usage(flow, "")
             usage.flush_usage_events(trigger="test")
             usage.webhook.usage_executor.shutdown(wait=True)
 
-        mock_opener.open.assert_not_called()  # urllib external boundary (#9991)
+        assert webhook.request_count == 0
 
-    def test_warns_when_missing_sandbox_token(self, tmp_path, real_flow, fresh_usage_executor):
+    def test_warns_when_missing_sandbox_token(
+        self, tmp_path, real_flow, fresh_usage_executor, usage_webhook_api
+    ):
         """Should write to proxy log and skip when sandbox_token is empty."""
         flow = real_flow(with_response=False, host="api.anthropic.com")
         flow.metadata["firewall_name"] = "model-provider:anthropic-api-key"
@@ -212,22 +200,19 @@ class TestReportModelProviderUsage:
         proxy_log = tmp_path / "proxy-run-abc-123.jsonl"
         flow.metadata["vm_proxy_log_path"] = str(proxy_log)
 
-        with (
-            patch.object(usage_model_provider, "get_api_url", return_value="https://api.vm0.ai"),
-            patch.object(usage.webhook, "_opener") as mock_opener,
-        ):
+        with usage_webhook_api() as webhook:
             usage.report_model_provider_usage(flow, "run-abc-123")
             usage.flush_usage_events(trigger="test")
             usage.webhook.usage_executor.shutdown(wait=True)
 
-        mock_opener.open.assert_not_called()  # urllib external boundary (#9991)
+        assert webhook.request_count == 0
         assert proxy_log.exists()
         [entry] = [json.loads(line) for line in proxy_log.read_text().splitlines()]
         assert entry["level"] == "warn"
         assert entry["message"] == "Cannot report usage event: missing sandbox_token or api_url"
         assert entry["type"] == "usage_event"
 
-    def test_warns_when_missing_api_url(self, tmp_path, real_flow, fresh_usage_executor):
+    def test_warns_when_missing_api_url(self, tmp_path, real_flow, fresh_usage_executor, mitm_ctx):
         """Should write to proxy log and skip when api_url is empty."""
         flow = real_flow(with_response=False, host="api.anthropic.com")
         flow.metadata["firewall_name"] = "model-provider:anthropic-api-key"
@@ -237,15 +222,11 @@ class TestReportModelProviderUsage:
         proxy_log = tmp_path / "proxy-run-abc-123.jsonl"
         flow.metadata["vm_proxy_log_path"] = str(proxy_log)
 
-        with (
-            patch.object(usage_model_provider, "get_api_url", return_value=""),
-            patch.object(usage.webhook, "_opener") as mock_opener,
-        ):
+        with mitm_ctx(api_url=""):
             usage.report_model_provider_usage(flow, "run-abc-123")
             usage.flush_usage_events(trigger="test")
             usage.webhook.usage_executor.shutdown(wait=True)
 
-        mock_opener.open.assert_not_called()  # urllib external boundary (#9991)
         assert proxy_log.exists()
         [entry] = [json.loads(line) for line in proxy_log.read_text().splitlines()]
         assert entry["level"] == "warn"
@@ -253,7 +234,7 @@ class TestReportModelProviderUsage:
         assert entry["type"] == "usage_event"
 
     def test_source_dedupe_uses_flow_id_when_message_id_missing(
-        self, real_flow, fresh_usage_executor
+        self, real_flow, fresh_usage_executor, usage_webhook_api
     ):
         flow = real_flow(with_response=False, host="api.anthropic.com")
         flow.id = "flow-uuid-xyz-123"
@@ -265,21 +246,17 @@ class TestReportModelProviderUsage:
             "tokens.input": 10,
         }
 
-        with (
-            patch.object(usage_model_provider, "get_api_url", return_value="https://api.vm0.ai"),
-            patch.object(usage.webhook, "_opener") as mock_opener,
-        ):
-            mock_opener.open.return_value = MagicMock()
+        with usage_webhook_api() as webhook:
             usage.report_model_provider_usage(flow, "run-fallback")
             usage.report_model_provider_usage(flow, "run-fallback")
             usage.flush_usage_events(trigger="test")
             usage.webhook.usage_executor.shutdown(wait=True)
 
-        body = json.loads(mock_opener.open.call_args[0][0].data)
+        body = webhook.requests[0].json_body()
         assert body["events"][0]["quantity"] == 10
 
     def test_source_dedupe_separates_flows_when_message_id_missing(
-        self, real_flow, fresh_usage_executor
+        self, real_flow, fresh_usage_executor, usage_webhook_api
     ):
         first = real_flow(with_response=False, host="api.anthropic.com")
         first.id = "flow-first"
@@ -294,20 +271,18 @@ class TestReportModelProviderUsage:
                 "tokens.input": 10,
             }
 
-        with (
-            patch.object(usage_model_provider, "get_api_url", return_value="https://api.vm0.ai"),
-            patch.object(usage.webhook, "_opener") as mock_opener,
-        ):
-            mock_opener.open.return_value = MagicMock()
+        with usage_webhook_api() as webhook:
             usage.report_model_provider_usage(first, "run-fallback")
             usage.report_model_provider_usage(second, "run-fallback")
             usage.flush_usage_events(trigger="test")
             usage.webhook.usage_executor.shutdown(wait=True)
 
-        body = json.loads(mock_opener.open.call_args[0][0].data)
+        body = webhook.requests[0].json_body()
         assert body["events"][0]["quantity"] == 20
 
-    def test_source_dedupe_preserves_message_id_over_flow_id(self, real_flow, fresh_usage_executor):
+    def test_source_dedupe_preserves_message_id_over_flow_id(
+        self, real_flow, fresh_usage_executor, usage_webhook_api
+    ):
         first = real_flow(with_response=False, host="api.anthropic.com")
         first.id = "flow-first"
         second = real_flow(with_response=False, host="api.anthropic.com")
@@ -322,15 +297,11 @@ class TestReportModelProviderUsage:
                 "tokens.input": 10,
             }
 
-        with (
-            patch.object(usage_model_provider, "get_api_url", return_value="https://api.vm0.ai"),
-            patch.object(usage.webhook, "_opener") as mock_opener,
-        ):
-            mock_opener.open.return_value = MagicMock()
+        with usage_webhook_api() as webhook:
             usage.report_model_provider_usage(first, "run-preserved")
             usage.report_model_provider_usage(second, "run-preserved")
             usage.flush_usage_events(trigger="test")
             usage.webhook.usage_executor.shutdown(wait=True)
 
-        body = json.loads(mock_opener.open.call_args[0][0].data)
+        body = webhook.requests[0].json_body()
         assert body["events"][0]["quantity"] == 10

--- a/crates/runner/mitm-addon/tests/test_usage_reporting_idempotency.py
+++ b/crates/runner/mitm-addon/tests/test_usage_reporting_idempotency.py
@@ -4,7 +4,6 @@ import json
 import time
 import uuid
 from pathlib import Path
-from unittest.mock import MagicMock, patch
 
 from mitmproxy.flow import Error
 from mitmproxy.test import tutils
@@ -13,14 +12,14 @@ import flow_metadata_keys as metadata_keys
 import mitm_addon
 import usage
 from tests.flow_helpers import header_map
-from tests.usage_helpers import set_stream_buffer, usage_event_events_from_calls
+from tests.usage_helpers import set_stream_buffer
 
 
 class TestUsageReportingIdempotency:
     """Tests for duplicate-reporting guards and stable usage sources."""
 
     def test_response_then_error_does_not_enqueue_model_usage_twice(
-        self, tmp_path, real_flow, mitm_ctx, fresh_usage_executor
+        self, tmp_path, real_flow, mitm_ctx, fresh_usage_executor, usage_webhook_api
     ):
         """If mitmproxy fires both hooks for one flow, model usage reports once."""
         flow = real_flow(with_response=False, host="api.openai.com")
@@ -45,11 +44,7 @@ class TestUsageReportingIdempotency:
         )
         flow.metadata[metadata_keys.HTTP_REQUEST_START_MONOTONIC] = time.monotonic()
 
-        with (
-            mitm_ctx(),
-            patch.object(usage.webhook, "_opener") as mock_opener,
-        ):
-            mock_opener.open.return_value = MagicMock()
+        with usage_webhook_api() as webhook:
             mitm_addon.response(flow)
             assert metadata_keys.HTTP_REQUEST_START_MONOTONIC not in flow.metadata
             flow.error = Error("connection reset after response")
@@ -57,7 +52,7 @@ class TestUsageReportingIdempotency:
             usage.flush_usage_events(trigger="test")
             usage.webhook.usage_executor.shutdown(wait=True)
 
-        events = usage_event_events_from_calls(mock_opener.open.call_args_list)
+        events = webhook.usage_events()
         assert [event["category"] for event in events] == ["tokens.output"]
         proxy_log = Path(flow.metadata["vm_proxy_log_path"])
         if proxy_log.exists():
@@ -68,7 +63,7 @@ class TestUsageReportingIdempotency:
             )
 
     def test_empty_model_usage_does_not_block_later_error_usage(
-        self, tmp_path, real_flow, mitm_ctx, fresh_usage_executor
+        self, tmp_path, real_flow, mitm_ctx, fresh_usage_executor, usage_webhook_api
     ):
         """A no-event response pass must not mark the flow reported."""
         flow = real_flow(with_response=False, host="api.openai.com")
@@ -87,13 +82,9 @@ class TestUsageReportingIdempotency:
             headers=header_map({"content-type": "application/json"}),
         )
 
-        with (
-            mitm_ctx(),
-            patch.object(usage.webhook, "_opener") as mock_opener,
-        ):
-            mock_opener.open.return_value = MagicMock()
+        with usage_webhook_api() as webhook:
             mitm_addon.response(flow)
-            mock_opener.open.assert_not_called()
+            assert webhook.request_count == 0
 
             flow.metadata["model_provider_usage"]["tokens.output"] = 20
             flow.error = Error("connection reset after response")
@@ -101,11 +92,11 @@ class TestUsageReportingIdempotency:
             usage.flush_usage_events(trigger="test")
             usage.webhook.usage_executor.shutdown(wait=True)
 
-        events = usage_event_events_from_calls(mock_opener.open.call_args_list)
+        events = webhook.usage_events()
         assert [event["category"] for event in events] == ["tokens.output"]
 
     def test_uses_flow_id_when_message_id_missing(
-        self, tmp_path, real_flow, mitm_ctx, headers, fresh_usage_executor
+        self, tmp_path, real_flow, mitm_ctx, headers, fresh_usage_executor, usage_webhook_api
     ):
         """Missing message_id in model_provider_usage falls back to flow.id.
 
@@ -132,23 +123,18 @@ class TestUsageReportingIdempotency:
             status_code=200, headers=header_map({"content-type": "text/event-stream"})
         )
 
-        with (
-            mitm_ctx(api_url="https://api.vm0.ai"),
-            patch.object(usage.webhook, "_opener") as mock_opener,
-        ):
-            mock_opener.open.return_value = MagicMock()
+        with usage_webhook_api() as webhook:
             mitm_addon.response(flow)
             usage.flush_usage_events(trigger="test")
             usage.webhook.usage_executor.shutdown(wait=True)
 
-        mock_opener.open.assert_called_once()  # urllib external boundary (#9991)
-        req = mock_opener.open.call_args[0][0]
-        body = json.loads(req.data)
+        assert webhook.request_count == 1
+        body = webhook.requests[0].json_body()
         assert body["events"][0]["quantity"] == 10
         uuid.UUID(body["events"][0]["idempotencyKey"])
 
     def test_preserves_message_id_from_response(
-        self, tmp_path, real_flow, mitm_ctx, headers, fresh_usage_executor
+        self, tmp_path, real_flow, mitm_ctx, headers, fresh_usage_executor, usage_webhook_api
     ):
         """When model_provider_usage already has a message_id, flow.id fallback
         must not override it."""
@@ -171,17 +157,12 @@ class TestUsageReportingIdempotency:
             status_code=200, headers=header_map({"content-type": "text/event-stream"})
         )
 
-        with (
-            mitm_ctx(api_url="https://api.vm0.ai"),
-            patch.object(usage.webhook, "_opener") as mock_opener,
-        ):
-            mock_opener.open.return_value = MagicMock()
+        with usage_webhook_api() as webhook:
             mitm_addon.response(flow)
             usage.flush_usage_events(trigger="test")
             usage.webhook.usage_executor.shutdown(wait=True)
 
-        mock_opener.open.assert_called_once()  # urllib external boundary (#9991)
-        req = mock_opener.open.call_args[0][0]
-        body = json.loads(req.data)
+        assert webhook.request_count == 1
+        body = webhook.requests[0].json_body()
         assert body["events"][0]["quantity"] == 10
         uuid.UUID(body["events"][0]["idempotencyKey"])

--- a/crates/runner/mitm-addon/tests/test_webhook.py
+++ b/crates/runner/mitm-addon/tests/test_webhook.py
@@ -2,23 +2,18 @@
 
 import json
 import urllib.error
-import urllib.request
-import urllib.response
 import uuid
-from email.message import Message
-from io import BytesIO
 from pathlib import Path
-from unittest.mock import MagicMock, patch
+from unittest.mock import patch
 
 import pytest
 
 import auth
 import usage
-from usage.providers import model_provider as usage_model_provider
 
 
 class TestUsageWebhookDelivery:
-    """Webhook delivery behavior observed through report_model_provider_usage."""
+    """Webhook delivery behavior observed through the HTTP boundary."""
 
     @staticmethod
     def _model_flow(real_flow, tmp_path):
@@ -30,85 +25,40 @@ class TestUsageWebhookDelivery:
         flow.metadata["model_provider_usage"] = {"tokens.input": 100}
         return flow
 
-    def test_post_webhook_does_not_follow_redirects(self):
-        class FakeHttpResponse(urllib.response.addinfourl):
-            msg: str
+    def test_post_webhook_does_not_follow_redirects(self, usage_webhook_server):
+        usage_webhook_server.queue_response(
+            302,
+            headers=(("Location", usage_webhook_server.url("/redirected")),),
+        )
 
-            def __init__(
-                self,
-                body: bytes,
-                headers: Message,
-                url: str,
-                code: int,
-                msg: str,
-            ) -> None:
-                super().__init__(BytesIO(body), headers, url, code=code)
-                self.msg = msg
+        with pytest.raises(urllib.error.HTTPError) as exc:
+            usage.webhook._post_webhook(
+                usage_webhook_server.url("/webhook"),
+                "tok",
+                {"runId": "run-1"},
+            )
 
-        class RedirectingHttpHandler(urllib.request.BaseHandler):
-            handler_order = 0
+        assert exc.value.code == 302
+        assert [request.path for request in usage_webhook_server.requests] == ["/webhook"]
 
-            def __init__(self) -> None:
-                self.urls: list[str] = []
-
-            def http_open(self, req: urllib.request.Request):
-                self.urls.append(req.full_url)
-                headers = Message()
-                if req.full_url == "http://example.test/webhook":
-                    headers["Location"] = "http://example.test/redirected"
-                    return FakeHttpResponse(
-                        b"",
-                        headers,
-                        req.full_url,
-                        302,
-                        "Found",
-                    )
-                if req.full_url == "http://example.test/redirected":
-                    return FakeHttpResponse(
-                        b"ok",
-                        headers,
-                        req.full_url,
-                        200,
-                        "OK",
-                    )
-                raise AssertionError(f"unexpected URL: {req.full_url}")
-
-        handler = RedirectingHttpHandler()
-        production_handler_types = [
-            type(production_handler)
-            for production_handler in usage.webhook._opener.__dict__["handlers"]
-        ]
-        opener = urllib.request.build_opener(handler, *production_handler_types)
-        with patch.object(usage.webhook, "_opener", opener):
-            with pytest.raises(urllib.error.HTTPError) as exc:
-                usage.webhook._post_webhook(
-                    "http://example.test/webhook",
-                    "tok",
-                    {"runId": "run-1"},
-                )
-
-            assert exc.value.code == 302
-            assert handler.urls == ["http://example.test/webhook"]
-
-    def test_succeeds_on_first_attempt(self, tmp_path, real_flow, fresh_usage_executor):
+    def test_succeeds_on_first_attempt(
+        self, tmp_path, real_flow, fresh_usage_executor, usage_webhook_api
+    ):
         flow = self._model_flow(real_flow, tmp_path)
         flow.metadata["model_provider_usage"] = {"model": "claude-sonnet-4-6", "tokens.input": 100}
-        with (
-            patch.object(usage_model_provider, "get_api_url", return_value="https://api.vm0.ai"),
-            patch.object(usage.webhook, "_opener") as mock_opener,
-        ):
-            mock_opener.open.return_value = MagicMock()
+
+        with usage_webhook_api() as webhook:
             usage.report_model_provider_usage(flow, "run-1")
             usage.flush_usage_events(trigger="test")
             usage.webhook.usage_executor.shutdown(wait=True)
 
-        mock_opener.open.assert_called_once()  # urllib external boundary (#9991)
-        req = mock_opener.open.call_args[0][0]
-        assert req.full_url == "https://api.vm0.ai/api/webhooks/agent/usage-event"
-        assert req.get_header("Content-type") == "application/json"
-        assert req.get_header("Authorization") == "Bearer tok"
-        assert req.get_header("User-agent") == "vm0-mitm-addon/1.0"
-        body = json.loads(req.data)
+        assert webhook.request_count == 1
+        request = webhook.requests[0]
+        assert request.path == "/api/webhooks/agent/usage-event"
+        assert request.header("content-type") == "application/json"
+        assert request.header("authorization") == "Bearer tok"
+        assert request.header("user-agent") == "vm0-mitm-addon/1.0"
+        body = request.json_body()
         assert body["runId"] == "run-1"
         assert set(body) == {"runId", "events"}
         assert [
@@ -124,63 +74,61 @@ class TestUsageWebhookDelivery:
         ]
         uuid.UUID(body["events"][0]["idempotencyKey"])
 
-    def test_closes_http_error_response(self, tmp_path, real_flow, fresh_usage_executor):
-        """HTTPError sockets must be closed to avoid leaking; retries still apply."""
-        http_err = urllib.error.HTTPError(
-            "https://api.vm0.ai", 500, "Internal Server Error", Message(), None
-        )
-        http_err.close = MagicMock()
-        flow = self._model_flow(real_flow, tmp_path)
+    def test_closes_http_error_response(self, usage_webhook_server):
+        """HTTPError sockets must be closed to avoid leaking."""
+        usage_webhook_server.queue_response(500)
+
         with (
-            patch.object(usage_model_provider, "get_api_url", return_value="https://api.vm0.ai"),
-            patch.object(usage.webhook, "_opener") as mock_opener,
+            patch.object(urllib.error.HTTPError, "close", autospec=True) as close_mock,
+            pytest.raises(urllib.error.HTTPError),
         ):
-            mock_opener.open.side_effect = http_err
-            usage.report_model_provider_usage(flow, "run-1")
-            usage.flush_usage_events(trigger="test")
-            usage.webhook.usage_executor.shutdown(wait=True)
+            usage.webhook._post_webhook(
+                usage_webhook_server.url("/error"),
+                "tok",
+                {"runId": "run-1"},
+            )
 
-        # Cleanup must run once per HTTPError — tracks attempt count so the
-        # invariant survives future changes to max_retries.
-        assert http_err.close.call_count == mock_opener.open.call_count  # (#9991)
+        close_mock.assert_called_once()
 
-    def test_adds_vercel_bypass_header(self, tmp_path, real_flow, fresh_usage_executor):
+    def test_adds_vercel_bypass_header(
+        self, tmp_path, real_flow, fresh_usage_executor, usage_webhook_api
+    ):
         flow = self._model_flow(real_flow, tmp_path)
+
         with (
-            patch.object(usage_model_provider, "get_api_url", return_value="https://api.vm0.ai"),
             patch.object(auth, "VERCEL_BYPASS", "bypass-secret"),
-            patch.object(usage.webhook, "_opener") as mock_opener,
+            usage_webhook_api() as webhook,
         ):
-            mock_opener.open.return_value = MagicMock()
             usage.report_model_provider_usage(flow, "run-1")
             usage.flush_usage_events(trigger="test")
             usage.webhook.usage_executor.shutdown(wait=True)
 
-        req = mock_opener.open.call_args[0][0]
-        assert req.get_header("X-vercel-protection-bypass") == "bypass-secret"
+        assert webhook.requests[0].header("x-vercel-protection-bypass") == "bypass-secret"
 
-    def test_retries_on_failure(self, tmp_path, real_flow, fresh_usage_executor):
+    def test_retries_on_failure(self, tmp_path, real_flow, fresh_usage_executor, usage_webhook_api):
         flow = self._model_flow(real_flow, tmp_path)
-        with (
-            patch.object(usage_model_provider, "get_api_url", return_value="https://api.vm0.ai"),
-            patch.object(usage.webhook, "_opener") as mock_opener,
-        ):
-            mock_opener.open.side_effect = [ConnectionError("fail"), MagicMock()]
-            usage.report_model_provider_usage(flow, "run-1")
-            usage.flush_usage_events(trigger="test")
-            usage.webhook.usage_executor.shutdown(wait=True)
 
-        assert mock_opener.open.call_count == 2  # urllib external boundary (#9991)
-
-    def test_retry_with_payload_collision_logs_nested_payload(self, tmp_path):
-        proxy_log = tmp_path / "proxy.jsonl"
         with (
-            patch.object(usage.webhook, "_opener") as mock_opener,
+            usage_webhook_api() as webhook,
             patch.object(usage.webhook.time, "sleep") as mock_sleep,
         ):
-            mock_opener.open.side_effect = [ConnectionError("fail"), MagicMock()]
+            webhook.queue_response(500)
+            webhook.queue_response(204)
+            usage.report_model_provider_usage(flow, "run-1")
+            usage.flush_usage_events(trigger="test")
+            usage.webhook.usage_executor.shutdown(wait=True)
+
+        assert webhook.request_count == 2
+        mock_sleep.assert_called_once_with(0.5)
+
+    def test_retry_with_payload_collision_logs_nested_payload(self, tmp_path, usage_webhook_server):
+        proxy_log = tmp_path / "proxy.jsonl"
+        usage_webhook_server.queue_response(500)
+        usage_webhook_server.queue_response(204)
+
+        with patch.object(usage.webhook.time, "sleep") as mock_sleep:
             usage.webhook._do_post_webhook_attempts(
-                "https://api.vm0.ai/x",
+                usage_webhook_server.url("/x"),
                 "tok",
                 {"url": "payload-url", "type": "payload-type", "runId": "run-1", "events": []},
                 str(proxy_log),
@@ -188,48 +136,54 @@ class TestUsageWebhookDelivery:
                 max_retries=1,
             )
 
-        mock_sleep.assert_called_once_with(0.5)  # syscall boundary; pins retry backoff (#9991)
+        assert usage_webhook_server.request_count == 2
+        mock_sleep.assert_called_once_with(0.5)
         entries = [json.loads(line) for line in proxy_log.read_text().splitlines()]
         assert [entry["level"] for entry in entries] == ["warn", "info"]
         assert [entry["attempt"] for entry in entries] == [1, 2]
-        assert all(entry["url"] == "https://api.vm0.ai/x" for entry in entries)
+        assert all(entry["url"] == usage_webhook_server.url("/x") for entry in entries)
         assert all(entry["payload"]["url"] == "payload-url" for entry in entries)
         assert all(entry["payload"]["type"] == "payload-type" for entry in entries)
 
-    def test_gives_up_after_retry_budget(self, tmp_path, real_flow, fresh_usage_executor):
-        """Default max_retries=1 → 2 total attempts before giving up."""
+    def test_gives_up_after_retry_budget(
+        self, tmp_path, real_flow, fresh_usage_executor, usage_webhook_api
+    ):
+        """Default max_retries=1 -> 2 total attempts before giving up."""
         flow = self._model_flow(real_flow, tmp_path)
         proxy_log = Path(flow.metadata["vm_proxy_log_path"])
+
         with (
-            patch.object(usage_model_provider, "get_api_url", return_value="https://api.vm0.ai"),
-            patch.object(usage.webhook, "_opener") as mock_opener,
+            usage_webhook_api() as webhook,
+            patch.object(usage.webhook.time, "sleep"),
         ):
-            mock_opener.open.side_effect = ConnectionError("fail")
+            webhook.queue_response(500)
+            webhook.queue_response(500)
             usage.report_model_provider_usage(flow, "run-1")
             usage.flush_usage_events(trigger="test")
             usage.webhook.usage_executor.shutdown(wait=True)
 
-        assert mock_opener.open.call_count == 2  # urllib external boundary (#9991)
+        assert webhook.request_count == 2
         assert proxy_log.exists()
         assert "2 attempts" in proxy_log.read_text()
 
-    def test_give_up_with_payload_collision_logs_nested_payload(self, tmp_path):
+    def test_give_up_with_payload_collision_logs_nested_payload(
+        self, tmp_path, usage_webhook_server
+    ):
         proxy_log = tmp_path / "proxy.jsonl"
-        with patch.object(usage.webhook, "_opener") as mock_opener:
-            mock_opener.open.side_effect = ConnectionError("fail")
-            usage.webhook._do_post_webhook_attempts(
-                "https://api.vm0.ai/x",
-                "tok",
-                {"error": "payload-error", "attempt": 99, "runId": "run-1", "events": []},
-                str(proxy_log),
-                "usage",
-                max_retries=0,
-            )
+        usage_webhook_server.queue_response(500)
+
+        usage.webhook._do_post_webhook_attempts(
+            usage_webhook_server.url("/x"),
+            "tok",
+            {"error": "payload-error", "attempt": 99, "runId": "run-1", "events": []},
+            str(proxy_log),
+            "usage",
+            max_retries=0,
+        )
 
         [entry] = [json.loads(line) for line in proxy_log.read_text().splitlines()]
         assert entry["level"] == "error"
         assert entry["attempt"] == 1
-        assert entry["error"] == "fail"
         assert entry["payload"]["error"] == "payload-error"
         assert entry["payload"]["attempt"] == 99
 
@@ -241,97 +195,85 @@ class TestUsageWebhookDelivery:
         usage.set_pending_path(str(tmp_path / "usage-pending"))
         usage.counters.increment_pending_reports()
 
-        with patch.object(usage.webhook, "_opener") as mock_opener:
-            mock_opener.open.side_effect = TypeError("boom")
-            usage.webhook._enqueue_webhook(
-                "https://api.vm0.ai/api/webhooks/agent/usage-event",
-                "tok",
-                {"runId": "run-1", "events": []},
-                str(proxy_log),
-                "usage",
-            )
+        usage.webhook._enqueue_webhook(
+            "not-a-url",
+            "tok",
+            {"runId": "run-1", "events": []},
+            str(proxy_log),
+            "usage",
+        )
 
-        assert mock_opener.open.call_count == 1  # urllib external boundary (#9991)
         assert usage.counters._pending_reports == 1
         assert "non-retryable" in proxy_log.read_text()
-        with pytest.raises(TypeError, match="boom"):
+        with pytest.raises(ValueError, match="unknown url type"):
             sync_usage_executor.shutdown(wait=True)
 
-    def test_sleeps_between_retries(self, tmp_path, real_flow, fresh_usage_executor):
+    def test_sleeps_between_retries(
+        self, tmp_path, real_flow, fresh_usage_executor, usage_webhook_api
+    ):
         flow = self._model_flow(real_flow, tmp_path)
+
         with (
-            patch.object(usage_model_provider, "get_api_url", return_value="https://api.vm0.ai"),
-            patch.object(usage.webhook, "_opener") as mock_opener,
+            usage_webhook_api() as webhook,
             patch.object(usage.webhook.time, "sleep") as mock_sleep,
         ):
-            mock_opener.open.side_effect = [ConnectionError("fail"), MagicMock()]
+            webhook.queue_response(500)
+            webhook.queue_response(204)
             usage.report_model_provider_usage(flow, "run-1")
             usage.flush_usage_events(trigger="test")
             usage.webhook.usage_executor.shutdown(wait=True)
 
-        mock_sleep.assert_called_once_with(0.5)  # syscall boundary; pins retry backoff (#9991)
+        mock_sleep.assert_called_once_with(0.5)
 
     def test_programming_error_is_not_retried(self, tmp_path):
-        """Non-retryable error (TypeError, ...) from the urllib boundary
-        must propagate on the first attempt — no retry, no "giving up"
-        log, and a forensic "non-retryable" log line so the pool-path
-        Future swallow doesn't erase the breadcrumb."""
+        """Non-retryable request construction errors must propagate immediately."""
         proxy_log = tmp_path / "proxy.jsonl"
-        with patch.object(usage.webhook, "_opener") as mock_opener:
-            mock_opener.open.side_effect = TypeError("boom")
-            with pytest.raises(TypeError, match="boom"):
-                usage.webhook._do_post_webhook_attempts(
-                    "https://api.vm0.ai/x",
-                    "tok",
-                    {"k": "v"},
-                    str(proxy_log),
-                    "usage",
-                    max_retries=1,
-                )
-            assert mock_opener.open.call_count == 1  # urllib external boundary (#9991)
+        with pytest.raises(ValueError, match="unknown url type"):
+            usage.webhook._do_post_webhook_attempts(
+                "not-a-url",
+                "tok",
+                {"k": "v"},
+                str(proxy_log),
+                "usage",
+                max_retries=1,
+            )
+
         log_text = proxy_log.read_text()
         assert "giving up" not in log_text
         assert "non-retryable" in log_text
 
     def test_programming_error_with_payload_collision_preserves_original_error(self, tmp_path):
         proxy_log = tmp_path / "proxy.jsonl"
-        with patch.object(usage.webhook, "_opener") as mock_opener:
-            mock_opener.open.side_effect = TypeError("boom")
-            with pytest.raises(TypeError, match="boom"):
-                usage.webhook._do_post_webhook_attempts(
-                    "https://api.vm0.ai/x",
-                    "tok",
-                    {"url": "payload-url", "runId": "run-1", "events": []},
-                    str(proxy_log),
-                    "usage",
-                    max_retries=1,
-                )
-            assert mock_opener.open.call_count == 1  # urllib external boundary (#9991)
+        with pytest.raises(ValueError, match="unknown url type"):
+            usage.webhook._do_post_webhook_attempts(
+                "not-a-url",
+                "tok",
+                {"url": "payload-url", "runId": "run-1", "events": []},
+                str(proxy_log),
+                "usage",
+                max_retries=1,
+            )
 
         entry = json.loads(proxy_log.read_text())
-        assert entry["url"] == "https://api.vm0.ai/x"
+        assert entry["url"] == "not-a-url"
         assert entry["payload"]["url"] == "payload-url"
         assert "non-retryable" in entry["message"]
 
-    def test_falls_back_to_sync_after_shutdown(self, tmp_path, real_flow, fresh_usage_executor):
+    def test_falls_back_to_sync_after_shutdown(
+        self, tmp_path, real_flow, fresh_usage_executor, usage_webhook_api
+    ):
         """After executor shutdown, delivery happens synchronously before return."""
         flow = self._model_flow(real_flow, tmp_path)
         flow.metadata["model_provider_usage"] = {"tokens.input": 42}
         usage.flush_usage_events(trigger="test")
         usage.webhook.usage_executor.shutdown(wait=True)
 
-        with (
-            patch.object(usage_model_provider, "get_api_url", return_value="https://api.vm0.ai"),
-            patch.object(usage.webhook, "_opener") as mock_opener,
-        ):
-            mock_opener.open.return_value = MagicMock()
+        with usage_webhook_api() as webhook:
             usage.report_model_provider_usage(flow, "run-1")
             usage.flush_usage_events(trigger="test")
-            # Sync fallback: _opener must have been called before the call returned.
-            mock_opener.open.assert_called_once()  # urllib external boundary (#9991)
+            assert webhook.request_count == 1
 
-        req = mock_opener.open.call_args[0][0]
-        body = json.loads(req.data)
+        body = webhook.requests[0].json_body()
         assert body["runId"] == "run-1"
         assert body["events"][0]["quantity"] == 42
         assert body["events"][0]["category"] == "tokens.input"

--- a/crates/runner/mitm-addon/tests/test_webhook.py
+++ b/crates/runner/mitm-addon/tests/test_webhook.py
@@ -54,6 +54,7 @@ class TestUsageWebhookDelivery:
 
         assert webhook.request_count == 1
         request = webhook.requests[0]
+        assert request.method == "POST"
         assert request.path == "/api/webhooks/agent/usage-event"
         assert request.header("content-type") == "application/json"
         assert request.header("authorization") == "Bearer tok"
@@ -184,6 +185,7 @@ class TestUsageWebhookDelivery:
         [entry] = [json.loads(line) for line in proxy_log.read_text().splitlines()]
         assert entry["level"] == "error"
         assert entry["attempt"] == 1
+        assert "HTTP Error 500" in entry["error"]
         assert entry["payload"]["error"] == "payload-error"
         assert entry["payload"]["attempt"] == 99
 

--- a/crates/runner/mitm-addon/tests/usage_helpers.py
+++ b/crates/runner/mitm-addon/tests/usage_helpers.py
@@ -1,14 +1,161 @@
 """Shared usage test helpers for mitm-addon tests."""
 
+from __future__ import annotations
+
+import contextlib
 import json
+import threading
+from collections import deque
+from collections.abc import Iterator, Sequence
+from dataclasses import dataclass
+from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
+from typing import Any
 
 
-def request_bodies_from_calls(call_args_list):
-    return [json.loads(call[0][0].data) for call in call_args_list]
+@dataclass(frozen=True)
+class WebhookResponse:
+    status: int = 204
+    headers: tuple[tuple[str, str], ...] = ()
+    body: bytes = b""
 
 
-def usage_event_events_from_calls(call_args_list):
-    return [event for body in request_bodies_from_calls(call_args_list) for event in body["events"]]
+@dataclass(frozen=True)
+class CapturedWebhookRequest:
+    method: str
+    path: str
+    headers: dict[str, str]
+    body: bytes
+
+    def header(self, name: str) -> str | None:
+        return self.headers.get(name.lower())
+
+    def json_body(self) -> dict[str, Any]:
+        body = json.loads(self.body)
+        assert isinstance(body, dict)
+        return body
+
+
+class UsageWebhookServer:
+    def __init__(self) -> None:
+        self._condition = threading.Condition()
+        self._requests: list[CapturedWebhookRequest] = []
+        self._responses: deque[WebhookResponse] = deque()
+        self._server: ThreadingHTTPServer | None = None
+        self._thread: threading.Thread | None = None
+
+    @property
+    def api_url(self) -> str:
+        assert self._server is not None
+        host, port = self._server.server_address[:2]
+        return f"http://{host}:{port}"
+
+    @property
+    def requests(self) -> tuple[CapturedWebhookRequest, ...]:
+        with self._condition:
+            return tuple(self._requests)
+
+    @property
+    def request_count(self) -> int:
+        with self._condition:
+            return len(self._requests)
+
+    def url(self, path: str = "/api/webhooks/agent/usage-event") -> str:
+        if not path.startswith("/"):
+            path = f"/{path}"
+        return f"{self.api_url}{path}"
+
+    def queue_response(
+        self,
+        status: int,
+        *,
+        headers: Sequence[tuple[str, str]] = (),
+        body: bytes = b"",
+    ) -> None:
+        with self._condition:
+            self._responses.append(
+                WebhookResponse(status=status, headers=tuple(headers), body=body)
+            )
+
+    def json_bodies(self) -> list[dict[str, Any]]:
+        return [request.json_body() for request in self.requests]
+
+    def usage_events(self) -> list[dict[str, Any]]:
+        return [
+            event
+            for body in self.json_bodies()
+            for event in body.get("events", [])
+            if isinstance(event, dict)
+        ]
+
+    def wait_for_request_count(self, count: int, *, timeout: float = 2.0) -> None:
+        with self._condition:
+            received = self._condition.wait_for(
+                lambda: len(self._requests) >= count,
+                timeout=timeout,
+            )
+            assert received, (
+                f"expected at least {count} webhook requests, got {len(self._requests)}"
+            )
+
+    @contextlib.contextmanager
+    def run(self) -> Iterator[UsageWebhookServer]:
+        server_ref = self
+
+        class _Handler(BaseHTTPRequestHandler):
+            def do_POST(self) -> None:
+                server_ref._handle_request(self)
+
+            def log_message(self, message_format: str, *args: Any) -> None:
+                return None
+
+        self._server = ThreadingHTTPServer(("127.0.0.1", 0), _Handler)
+        self._thread = threading.Thread(
+            target=self._server.serve_forever,
+            name="usage-webhook-test-server",
+            daemon=True,
+        )
+        self._thread.start()
+        try:
+            yield self
+        finally:
+            self._server.shutdown()
+            self._thread.join(timeout=2.0)
+            self._server.server_close()
+            self._server = None
+            self._thread = None
+
+    def _next_response(self) -> WebhookResponse:
+        with self._condition:
+            if self._responses:
+                return self._responses.popleft()
+        return WebhookResponse()
+
+    def _record_request(self, request: CapturedWebhookRequest) -> None:
+        with self._condition:
+            self._requests.append(request)
+            self._condition.notify_all()
+
+    def _handle_request(self, handler: BaseHTTPRequestHandler) -> None:
+        content_length = int(handler.headers.get("content-length", "0"))
+        body = handler.rfile.read(content_length)
+        self._record_request(
+            CapturedWebhookRequest(
+                method=handler.command,
+                path=handler.path,
+                headers={key.lower(): value for key, value in handler.headers.items()},
+                body=body,
+            )
+        )
+
+        response = self._next_response()
+        handler.send_response(response.status)
+        for name, value in response.headers:
+            handler.send_header(name, value)
+        if response.body:
+            handler.send_header("Content-Length", str(len(response.body)))
+        handler.end_headers()
+        if response.body:
+            handler.wfile.write(response.body)
 
 
 def set_stream_buffer(flow, body: bytes) -> None:

--- a/crates/runner/mitm-addon/tests/usage_helpers.py
+++ b/crates/runner/mitm-addon/tests/usage_helpers.py
@@ -37,7 +37,7 @@ class CapturedWebhookRequest:
 
 class UsageWebhookServer:
     def __init__(self) -> None:
-        self._condition = threading.Condition()
+        self._lock = threading.Lock()
         self._requests: list[CapturedWebhookRequest] = []
         self._responses: deque[WebhookResponse] = deque()
         self._server: ThreadingHTTPServer | None = None
@@ -51,12 +51,12 @@ class UsageWebhookServer:
 
     @property
     def requests(self) -> tuple[CapturedWebhookRequest, ...]:
-        with self._condition:
+        with self._lock:
             return tuple(self._requests)
 
     @property
     def request_count(self) -> int:
-        with self._condition:
+        with self._lock:
             return len(self._requests)
 
     def url(self, path: str = "/api/webhooks/agent/usage-event") -> str:
@@ -71,7 +71,7 @@ class UsageWebhookServer:
         headers: Sequence[tuple[str, str]] = (),
         body: bytes = b"",
     ) -> None:
-        with self._condition:
+        with self._lock:
             self._responses.append(
                 WebhookResponse(status=status, headers=tuple(headers), body=body)
             )
@@ -86,16 +86,6 @@ class UsageWebhookServer:
             for event in body.get("events", [])
             if isinstance(event, dict)
         ]
-
-    def wait_for_request_count(self, count: int, *, timeout: float = 2.0) -> None:
-        with self._condition:
-            received = self._condition.wait_for(
-                lambda: len(self._requests) >= count,
-                timeout=timeout,
-            )
-            assert received, (
-                f"expected at least {count} webhook requests, got {len(self._requests)}"
-            )
 
     @contextlib.contextmanager
     def run(self) -> Iterator[UsageWebhookServer]:
@@ -125,15 +115,14 @@ class UsageWebhookServer:
             self._thread = None
 
     def _next_response(self) -> WebhookResponse:
-        with self._condition:
+        with self._lock:
             if self._responses:
                 return self._responses.popleft()
         return WebhookResponse()
 
     def _record_request(self, request: CapturedWebhookRequest) -> None:
-        with self._condition:
+        with self._lock:
             self._requests.append(request)
-            self._condition.notify_all()
 
     def _handle_request(self, handler: BaseHTTPRequestHandler) -> None:
         content_length = int(handler.headers.get("content-length", "0"))


### PR DESCRIPTION
Closes #15527.

## Summary
- add a loopback usage webhook capture server fixture for mitm-addon tests
- migrate usage webhook, provider, connector, counter, error, and idempotency tests away from private usage.webhook._opener mocks
- remove test guidance and helpers that encouraged private opener patching

## Verification
- cd crates/runner/mitm-addon && python3 -m ruff check src tests
- cd crates/runner/mitm-addon && python3 -m basedpyright src tests
- cd crates/runner/mitm-addon && python3 -m pytest