### PR TITLE
feat: show agent creators on agents page

### DIFF
--- a/turbo/apps/platform/src/views/agents-page/__tests__/agents-page.test.tsx
+++ b/turbo/apps/platform/src/views/agents-page/__tests__/agents-page.test.tsx
@@ -1,0 +1,87 @@
+import { screen, waitFor, within } from "@testing-library/react";
+import type { TeamComposeItem } from "@vm0/api-contracts/contracts/zero-team";
+import { describe, expect, it } from "vitest";
+
+import { detachedSetupPage } from "../../../__tests__/page-helper.ts";
+import { setMockTeam } from "../../../mocks/handlers/api-agents.ts";
+import { setMockOrgMembers } from "../../../mocks/handlers/api-org-members.ts";
+import { testContext } from "../../../signals/__tests__/test-helpers.ts";
+
+const context = testContext();
+
+function agentCard(name: string): HTMLElement {
+  const nameElement = screen.getAllByText(name).find((element) => {
+    return element.closest("main");
+  });
+  const card = nameElement?.closest("a");
+  if (!card) {
+    throw new Error(`Agent card not found: ${name}`);
+  }
+  return card;
+}
+
+const AGENTS = [
+  {
+    id: "c0000000-0000-4000-a000-000000000001",
+    ownerId: "user_alice",
+    displayName: "Research Agent",
+    description: "Tracks market updates",
+    sound: null,
+    avatarUrl: null,
+    visibility: "public",
+    headVersionId: "version_1",
+    updatedAt: "2024-01-01T00:00:00Z",
+  },
+  {
+    id: "c0000000-0000-4000-a000-000000000002",
+    ownerId: "user_bob",
+    displayName: "Private Ops",
+    description: "Handles internal tasks",
+    sound: null,
+    avatarUrl: null,
+    visibility: "private",
+    headVersionId: "version_2",
+    updatedAt: "2024-01-02T00:00:00Z",
+  },
+] satisfies TeamComposeItem[];
+
+describe("agents page", () => {
+  it("shows each agent creator from org members", async () => {
+    setMockTeam(AGENTS);
+    setMockOrgMembers({
+      members: [
+        {
+          userId: "user_alice",
+          email: "alice@example.com",
+          firstName: "Alice",
+          lastName: "Admin",
+          imageUrl: "https://example.com/alice.png",
+          role: "admin",
+          joinedAt: "2024-01-01T00:00:00Z",
+        },
+        {
+          userId: "user_bob",
+          email: "bob@example.com",
+          firstName: "Bob",
+          lastName: "Builder",
+          imageUrl: "",
+          role: "member",
+          joinedAt: "2024-01-01T00:00:00Z",
+        },
+      ],
+    });
+
+    detachedSetupPage({ context, path: "/agents" });
+
+    await waitFor(() => {
+      expect(agentCard("Research Agent")).toBeInTheDocument();
+    });
+
+    expect(
+      within(agentCard("Research Agent")).getByText("Alice Admin"),
+    ).toBeInTheDocument();
+    expect(
+      within(agentCard("Private Ops")).getByText("Bob Builder"),
+    ).toBeInTheDocument();
+  });
+});

--- a/turbo/apps/platform/src/views/agents-page/__tests__/agents-page.test.tsx
+++ b/turbo/apps/platform/src/views/agents-page/__tests__/agents-page.test.tsx
@@ -1,4 +1,5 @@
 import { screen, waitFor, within } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
 import type { TeamComposeItem } from "@vm0/api-contracts/contracts/zero-team";
 import { describe, expect, it } from "vitest";
 
@@ -45,8 +46,22 @@ const AGENTS = [
   },
 ] satisfies TeamComposeItem[];
 
+async function expectVisibleTooltip(text: string): Promise<void> {
+  const matches = await screen.findAllByText(text);
+  const visibleMatch = matches.find((element) => {
+    try {
+      expect(element).toBeVisible();
+      return true;
+    } catch {
+      return false;
+    }
+  });
+  expect(visibleMatch).toBeDefined();
+}
+
 describe("agents page", () => {
-  it("shows each agent creator from org members", async () => {
+  it("shows public agent creator on avatar hover", async () => {
+    const user = userEvent.setup();
     setMockTeam(AGENTS);
     setMockOrgMembers({
       members: [
@@ -78,10 +93,23 @@ describe("agents page", () => {
     });
 
     expect(
-      within(agentCard("Research Agent")).getByText("Alice Admin"),
-    ).toBeInTheDocument();
+      screen.queryByText("Created by Alice Admin"),
+    ).not.toBeInTheDocument();
     expect(
-      within(agentCard("Private Ops")).getByText("Bob Builder"),
-    ).toBeInTheDocument();
+      screen.queryByText("Created by Bob Builder"),
+    ).not.toBeInTheDocument();
+
+    const researchCreator = within(agentCard("Research Agent")).getByRole(
+      "img",
+      { name: "Created by Alice Admin" },
+    );
+    expect(
+      within(agentCard("Private Ops")).queryByRole("img", {
+        name: "Created by Bob Builder",
+      }),
+    ).not.toBeInTheDocument();
+
+    await user.hover(researchCreator);
+    await expectVisibleTooltip("Created by Alice Admin");
   });
 });

--- a/turbo/apps/platform/src/views/agents-page/agents-page.tsx
+++ b/turbo/apps/platform/src/views/agents-page/agents-page.tsx
@@ -24,6 +24,10 @@ import {
   defaultAgentName$,
   sortedAgents$,
 } from "../../signals/agent.ts";
+import {
+  orgMembers$,
+  type OrgMember,
+} from "../../signals/external/org-members.ts";
 import { toast } from "@vm0/ui/components/ui/sonner";
 import { onDomEventFn } from "../../signals/utils.ts";
 import { Link } from "../router/link.tsx";
@@ -135,9 +139,17 @@ function AgentSplitView({
   onCreate: (visibility: "public" | "private") => void;
 }) {
   const agentsLoadable = useLoadable(sortedAgents$);
+  const membersLoadable = useLoadable(orgMembers$);
   const loading = agentsLoadable.state === "loading";
   const agents =
     agentsLoadable.state === "hasData" ? agentsLoadable.data : null;
+  const members =
+    membersLoadable.state === "hasData" ? membersLoadable.data : [];
+  const membersById = new Map(
+    members.map((member) => {
+      return [member.userId, member];
+    }),
+  );
   const skeleton = loading && !agents;
 
   const publicAgents =
@@ -154,6 +166,7 @@ function AgentSplitView({
       <AgentSplitSection
         title="Public"
         agents={publicAgents}
+        membersById={membersById}
         skeleton={skeleton}
         headerAction={
           <div className="flex items-center gap-3">
@@ -189,6 +202,7 @@ function AgentSplitView({
       <AgentSplitSection
         title="Private"
         agents={privateAgents}
+        membersById={membersById}
         skeleton={skeleton}
         headerAction={
           <Button
@@ -211,11 +225,13 @@ function AgentSplitView({
 function AgentSplitSection({
   title,
   agents,
+  membersById,
   skeleton,
   headerAction,
 }: {
   title: string;
   agents: AgentProps["agent"][];
+  membersById: ReadonlyMap<string, OrgMember>;
   skeleton: boolean;
   headerAction: ReactNode;
 }) {
@@ -228,13 +244,19 @@ function AgentSplitSection({
       {skeleton ? (
         <AgentSplitSkeleton />
       ) : agents.length > 0 ? (
-        <AgentSplitBody agents={agents} />
+        <AgentSplitBody agents={agents} membersById={membersById} />
       ) : null}
     </section>
   );
 }
 
-function AgentSplitBody({ agents }: { agents: AgentProps["agent"][] }) {
+function AgentSplitBody({
+  agents,
+  membersById,
+}: {
+  agents: AgentProps["agent"][];
+  membersById: ReadonlyMap<string, OrgMember>;
+}) {
   return (
     <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-3">
       {agents.map((agent) => {
@@ -245,7 +267,10 @@ function AgentSplitBody({ agents }: { agents: AgentProps["agent"][] }) {
             options={{ pathParams: { agentId: agent.id } }}
             className="block no-underline text-inherit"
           >
-            <AgentCard agent={agent} />
+            <AgentCard
+              agent={agent}
+              creator={agentCreator(agent, membersById)}
+            />
           </Link>
         );
       })}
@@ -429,13 +454,61 @@ function CreateTeammateDialogContent({
 type AgentProps = {
   agent: {
     id: string;
+    ownerId?: string;
     displayName?: string | null;
     description?: string | null;
     visibility?: "public" | "private" | null;
   };
+  creator: AgentCreator;
 };
 
-function AgentCard({ agent }: AgentProps) {
+interface AgentCreator {
+  readonly name: string;
+  readonly imageUrl: string | null;
+}
+
+function orgMemberDisplayName(member: OrgMember): string {
+  const fullName = [member.firstName, member.lastName]
+    .filter((part): part is string => {
+      return Boolean(part);
+    })
+    .join(" ");
+  return fullName || member.email || member.userId;
+}
+
+function agentCreator(
+  agent: AgentProps["agent"],
+  membersById: ReadonlyMap<string, OrgMember>,
+): AgentCreator {
+  if (!agent.ownerId) {
+    return { name: "Unknown", imageUrl: null };
+  }
+
+  const member = membersById.get(agent.ownerId);
+  return member
+    ? { name: orgMemberDisplayName(member), imageUrl: member.imageUrl }
+    : { name: agent.ownerId, imageUrl: null };
+}
+
+function CreatorAvatar({ creator }: { creator: AgentCreator }) {
+  if (creator.imageUrl) {
+    return (
+      <img
+        src={creator.imageUrl}
+        alt={creator.name}
+        className="h-4 w-4 shrink-0 rounded-full object-cover"
+      />
+    );
+  }
+
+  return (
+    <span className="flex h-4 w-4 shrink-0 items-center justify-center rounded-full bg-muted text-[9px] font-medium text-muted-foreground">
+      {creator.name.charAt(0).toUpperCase()}
+    </span>
+  );
+}
+
+function AgentCard({ agent, creator }: AgentProps) {
   const defaultAgentId = useLastResolved(defaultAgentId$);
   const lead = agent.id === defaultAgentId;
   const displayName = agent.displayName ?? agent.id;
@@ -445,7 +518,7 @@ function AgentCard({ agent }: AgentProps) {
     : "";
   return (
     <Card className="zero-card cursor-pointer flex flex-col hover:bg-muted/30 transition-colors h-full">
-      <CardContent className="px-5 py-4 flex items-center gap-3">
+      <CardContent className="px-5 py-4 flex items-start gap-3">
         <AgentAvatarImg
           name={agent.id}
           alt={displayName}
@@ -468,6 +541,11 @@ function AgentCard({ agent }: AgentProps) {
           <p className="text-xs text-muted-foreground mt-0.5 line-clamp-1">
             {description}
           </p>
+          <div className="mt-2 flex min-w-0 items-center gap-1.5 text-xs text-muted-foreground">
+            <CreatorAvatar creator={creator} />
+            <span className="shrink-0">Creator</span>
+            <span className="truncate text-foreground/80">{creator.name}</span>
+          </div>
         </div>
       </CardContent>
     </Card>

--- a/turbo/apps/platform/src/views/agents-page/agents-page.tsx
+++ b/turbo/apps/platform/src/views/agents-page/agents-page.tsx
@@ -495,16 +495,38 @@ function CreatorAvatar({ creator }: { creator: AgentCreator }) {
     return (
       <img
         src={creator.imageUrl}
-        alt={creator.name}
-        className="h-4 w-4 shrink-0 rounded-full object-cover"
+        alt=""
+        aria-hidden="true"
+        className="h-full w-full rounded-full object-cover"
       />
     );
   }
 
   return (
-    <span className="flex h-4 w-4 shrink-0 items-center justify-center rounded-full bg-muted text-[9px] font-medium text-muted-foreground">
+    <span className="flex h-full w-full items-center justify-center rounded-full bg-muted text-[10px] font-medium text-muted-foreground">
       {creator.name.charAt(0).toUpperCase()}
     </span>
+  );
+}
+
+function CreatorBadge({ creator }: { creator: AgentCreator }) {
+  return (
+    <TooltipProvider delayDuration={200}>
+      <Tooltip>
+        <TooltipTrigger asChild>
+          <span
+            role="img"
+            aria-label={`Created by ${creator.name}`}
+            className="absolute right-3 top-3 flex h-5 w-5 items-center justify-center rounded-full border border-background bg-background shadow-sm"
+          >
+            <CreatorAvatar creator={creator} />
+          </span>
+        </TooltipTrigger>
+        <TooltipContent side="top" align="end">
+          <p className="text-xs">Created by {creator.name}</p>
+        </TooltipContent>
+      </Tooltip>
+    </TooltipProvider>
   );
 }
 
@@ -517,8 +539,15 @@ function AgentCard({ agent, creator }: AgentProps) {
     ? agent.description || (lead ? "Your core agent" : "Sub-agent")
     : "";
   return (
-    <Card className="zero-card cursor-pointer flex flex-col hover:bg-muted/30 transition-colors h-full">
-      <CardContent className="px-5 py-4 flex items-start gap-3">
+    <Card className="zero-card relative cursor-pointer flex flex-col hover:bg-muted/30 transition-colors h-full">
+      {!isPrivate && <CreatorBadge creator={creator} />}
+      <CardContent
+        className={
+          isPrivate
+            ? "px-5 py-4 flex items-center gap-3"
+            : "pl-5 pr-12 py-4 flex items-center gap-3"
+        }
+      >
         <AgentAvatarImg
           name={agent.id}
           alt={displayName}
@@ -541,11 +570,6 @@ function AgentCard({ agent, creator }: AgentProps) {
           <p className="text-xs text-muted-foreground mt-0.5 line-clamp-1">
             {description}
           </p>
-          <div className="mt-2 flex min-w-0 items-center gap-1.5 text-xs text-muted-foreground">
-            <CreatorAvatar creator={creator} />
-            <span className="shrink-0">Creator</span>
-            <span className="truncate text-foreground/80">{creator.name}</span>
-          </div>
         </div>
       </CardContent>
     </Card>


### PR DESCRIPTION
Fixes #15513

## Summary
- show each agent card creator on the /agents page using existing org member data
- render creator avatars or initials with owner-id fallback for unmatched agents
- cover public and private agent cards with an integration test

## Tests
- pnpm turbo run lint
- pnpm check-types
- pnpm format
- pnpm knip
- pnpm --dir turbo -F @vm0/app exec vitest src/views/agents-page/__tests__/agents-page.test.tsx --run
- pnpm vitest (local Linux run: 9785 passed, 4 failed in apps/desktop/src/computer-use-native.test.ts because vm0-computer reports accessibility_unavailable: Desktop Computer Use is currently implemented for macOS)