### PR TITLE
test(mitm-addon): cover usage idempotency edge cases

### DIFF
--- a/crates/runner/mitm-addon/tests/test_usage_idempotency.py
+++ b/crates/runner/mitm-addon/tests/test_usage_idempotency.py
@@ -21,14 +21,34 @@ def test_usage_event_namespaces_are_stable():
 @pytest.mark.parametrize(
     ("parts", "expected"),
     [
+        ((), ""),
         (("run", "msg", "tokens.input"), "3:run\x003:msg\x0012:tokens.input"),
         (("\u00e9",), "2:\u00e9"),
+        (("\0",), "1:\x00"),
+        (("\U0001f680",), "4:\U0001f680"),
         (("", "x"), "0:\x001:x"),
         (("a:b", "c\0d"), "3:a:b\x003:c\x00d"),
     ],
 )
 def test_encode_uuid_name_is_byte_stable(parts, expected):
     assert encode_uuid_name(parts) == expected
+
+
+def test_encode_uuid_name_outputs_unique_uuid5_names_for_diverse_parts():
+    values = ("", "run", "msg", "tokens.input", "a:b", "c\0d", "\0", "\U0001f680")
+    part_sets: list[tuple[str, ...]] = [(value,) for value in values]
+    part_sets.extend((left, right) for left in values for right in values)
+    part_sets.extend(
+        (values[index % len(values)], values[-(index % len(values)) - 1], str(index))
+        for index in range(50)
+    )
+
+    names = [encode_uuid_name(parts) for parts in part_sets]
+    keys = [uuid.uuid5(USAGE_EVENT_NAMESPACE_MODEL, name) for name in names]
+
+    assert len(part_sets) > 100
+    assert len(set(names)) == len(part_sets)
+    assert len(set(keys)) == len(part_sets)
 
 
 def test_model_usage_idempotency_key_is_stable():


### PR DESCRIPTION
## Summary

- Add byte-stable `encode_uuid_name` cases for empty tuples, NUL-only parts, and non-BMP Unicode
- Add a deterministic smoke test that diverse encoded names and UUIDv5 keys remain unique

## Tests

- `PYTHONPATH=/tmp/vm7-mitm-addon-deps:src python3 -m pytest tests/test_usage_idempotency.py`
- `PATH=/tmp/vm7-mitm-addon-deps/bin:$PATH PYTHONPATH=/tmp/vm7-mitm-addon-deps python3 -m ruff check tests/test_usage_idempotency.py`
- `PATH=/tmp/vm7-mitm-addon-deps/bin:$PATH PYTHONPATH=/tmp/vm7-mitm-addon-deps python3 -m ruff format --check tests/test_usage_idempotency.py`

Closes #15517