### PR TITLE
fix: reject zero run permission policy overrides

### DIFF
--- a/turbo/apps/api/src/signals/routes/__tests__/zero-runs-create.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/zero-runs-create.test.ts
@@ -405,6 +405,29 @@ describe("POST /api/zero/runs", () => {
     expect(response.body.error.message).toBe("agentId is required");
   });
 
+  it("rejects caller-provided permission policies", async () => {
+    await fixture();
+
+    const response = await accept(
+      zeroRunsClient().create({
+        headers: { authorization: "Bearer clerk-session" },
+        body: {
+          prompt: "hello",
+          agentId: randomUUID(),
+          permissionPolicies: {
+            x: {
+              policies: { "tweet.write": "allow" },
+            },
+          },
+        } as never,
+      }),
+      [400],
+    );
+
+    expect(response.body.error.code).toBe("BAD_REQUEST");
+    expect(response.body.error.message).toContain("permissionPolicies");
+  });
+
   it("rejects ambiguous Claude tool list entries", async () => {
     await fixture();
     const cases: {

--- a/turbo/apps/api/src/signals/services/zero-runs-create.service.ts
+++ b/turbo/apps/api/src/signals/services/zero-runs-create.service.ts
@@ -485,8 +485,7 @@ function createRunBody(args: {
     captureNetworkBodies: args.body.captureNetworkBodies,
     tools: args.body.tools,
     settings: args.body.settings,
-    permissionPolicies:
-      args.body.permissionPolicies ?? args.permissionPolicies ?? undefined,
+    permissionPolicies: args.permissionPolicies ?? undefined,
     triggerSource,
     appendSystemPrompt: [baseAppendSystemPrompt, args.appendSystemPrompt]
       .filter((part): part is string => {

--- a/turbo/packages/api-contracts/src/contracts/zero-runs.ts
+++ b/turbo/packages/api-contracts/src/contracts/zero-runs.ts
@@ -19,7 +19,7 @@ import { sandboxReuseResultSchema } from "./webhooks";
  * Server-side defaults are injected by createZeroRun():
  * artifacts, disallowedTools.
  * Fields not used by zero triggers are omitted:
- * triggerSource, vars, secrets, volumeVersions.
+ * triggerSource, vars, secrets, volumeVersions, permissionPolicies.
  */
 const zeroRunRequestSchema = unifiedRunRequestSchema
   .omit({
@@ -32,6 +32,7 @@ const zeroRunRequestSchema = unifiedRunRequestSchema
     agentComposeId: true,
     appendSystemPrompt: true,
     modelProviderType: true,
+    permissionPolicies: true,
   })
   .extend({
     agentId: z.string().optional(),


### PR DESCRIPTION
## Summary

- Reject `permissionPolicies` in `/api/zero/runs` request bodies at contract validation time.
- Ensure zero-managed run creation uses only server-derived permission policies.
- Add a route regression test for caller-provided zero run permission policies.

## Tests

- `pnpm -F api exec vitest run src/signals/routes/__tests__/zero-runs-create.test.ts --testNamePattern "rejects caller-provided permission policies"`
- `pnpm -F api exec vitest run src/signals/routes/__tests__/zero-runs-create.test.ts`
- `pnpm -F @vm0/api-contracts lint`
- `pnpm -F @vm0/api-contracts check-types`
- `pnpm -F api lint`
- `pnpm -F api check-types`
- pre-commit hook: prettier, knip, full `pnpm check-types`

Closes #15599
