### PR TITLE
test(mitm-addon): clarify auth cache result shape

### DIFF
--- a/crates/runner/mitm-addon/tests/test_auth_cache.py
+++ b/crates/runner/mitm-addon/tests/test_auth_cache.py
@@ -42,7 +42,10 @@ class TestFirewallHeaderCache:
             )
 
         assert fetch_count == 1
-        assert all(r["headers"] == {"Authorization": "Bearer token"} for r in results)
+        for result in results:
+            assert result["headers"] == {"Authorization": "Bearer token"}
+            assert "cache_hit" in result
+            assert type(result["cache_hit"]) is bool
         cache_hit_flags = [result["cache_hit"] for result in results]
         assert sum(flag is False for flag in cache_hit_flags) == 1
         assert sum(flag is True for flag in cache_hit_flags) == 2


### PR DESCRIPTION
## Summary

- Add explicit per-result `cache_hit` presence and bool-type assertions in the concurrent auth cache test
- Preserve the existing one-miss/two-hit distribution assertion from #15568
- Keep the change test-only with no auth cache behavior changes

## Tests

- `PYTHONPATH=/tmp/vm7-mitm-addon-deps:src python3 -m pytest tests/test_auth_cache.py -k test_concurrent_fetches_coalesce`
- `PYTHONPATH=/tmp/vm7-mitm-addon-deps:src python3 -m pytest tests/test_auth_cache.py`
- `PATH=/tmp/vm7-mitm-addon-deps/bin:$PATH PYTHONPATH=/tmp/vm7-mitm-addon-deps python3 -m ruff check tests/test_auth_cache.py`
- `PATH=/tmp/vm7-mitm-addon-deps/bin:$PATH PYTHONPATH=/tmp/vm7-mitm-addon-deps python3 -m ruff format --check tests/test_auth_cache.py`
- `PATH=/tmp/vm7-mitm-addon-deps/bin:$PATH PYTHONPATH=/tmp/vm7-mitm-addon-deps basedpyright -p .`

Closes #15473