### PR TITLE
test(mitm-addon): cover split crlf ndjson chunks

### DIFF
--- a/crates/runner/mitm-addon/tests/test_response_streaming.py
+++ b/crates/runner/mitm-addon/tests/test_response_streaming.py
@@ -69,6 +69,14 @@ class TestNdjsonExtractor:
         assert state["data_count"] == 2
         assert state["lines_parsed"] == 2
 
+    def test_crlf_line_ending_split_across_chunks(self, real_flow):
+        parse, state = self._stream_parser(real_flow)
+        parse(b'{"data":{"id":"1"}}\r')
+        parse(b'\n{"data":{"id":"2"}}\r\n')
+        assert state["data_count"] == 2
+        assert state["lines_parsed"] == 2
+        assert state["lines_failed"] == 0
+
     def test_malformed_line_increments_failures(self, real_flow):
         parse, state = self._stream_parser(real_flow)
         parse(b'{"data":{"id":"1"}}\n')


### PR DESCRIPTION
## Summary

- Add a regression test for X NDJSON streams where a CRLF delimiter is split across response chunks.
- Keep the change test-only; the existing parser already handles the case.

Closes #15489

## Tests

- `python3 -m pytest tests/test_response_streaming.py -k 'crlf'`
- `python3 -m pytest tests/test_response_streaming.py`
- `python3 -m ruff check tests/test_response_streaming.py`
- `python3 -m ruff format --check tests/test_response_streaming.py`
