### PR TITLE
fix(api): bound axiom log search run filters

### DIFF
--- a/turbo/apps/api/src/signals/routes/__tests__/helpers/zero-usage-insight.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/helpers/zero-usage-insight.ts
@@ -49,6 +49,10 @@ interface SeedRunArgs {
   readonly lastEventSequence?: number | null;
 }
 
+interface SeedRunsArgs extends SeedRunArgs {
+  readonly count: number;
+}
+
 interface SeedScheduleArgs {
   readonly orgId: string;
   readonly userId: string;
@@ -353,6 +357,98 @@ export const seedRun$ = command(
     });
     signal.throwIfAborted();
     return { runId: run.id };
+  },
+);
+
+export const seedRuns$ = command(
+  async (
+    { set },
+    args: SeedRunsArgs,
+    signal: AbortSignal,
+  ): Promise<{ runIds: string[] }> => {
+    if (args.count <= 0) {
+      return { runIds: [] };
+    }
+
+    const db = set(writeDb$);
+    const versionId = randomUUID();
+    await db.insert(agentComposeVersions).values({
+      id: versionId,
+      composeId: args.composeId,
+      content: {
+        version: "1.0",
+        agents: { "test-agent": { framework: "claude-code" } },
+      },
+      createdBy: args.userId,
+    });
+    signal.throwIfAborted();
+    await db
+      .update(agentComposes)
+      .set({ headVersionId: versionId })
+      .where(eq(agentComposes.id, args.composeId));
+    signal.throwIfAborted();
+
+    const sessionRows = Array.from({ length: args.count }, () => {
+      return {
+        userId: args.userId,
+        orgId: args.orgId,
+        agentComposeId: args.composeId,
+      };
+    });
+    const sessions = await db
+      .insert(agentSessions)
+      .values(sessionRows)
+      .returning({ id: agentSessions.id });
+    signal.throwIfAborted();
+    if (sessions.length !== args.count) {
+      throw new Error("seedRuns$: session inserts returned missing rows");
+    }
+
+    const runs = await db
+      .insert(agentRuns)
+      .values(
+        sessions.map((session) => {
+          return {
+            userId: args.userId,
+            orgId: args.orgId,
+            agentComposeVersionId: versionId,
+            prompt: args.prompt ?? "test prompt",
+            status: args.status ?? "pending",
+            sessionId: session.id,
+            createdAt: args.createdAt,
+            startedAt: args.startedAt,
+            completedAt: args.completedAt,
+            continuedFromSessionId: args.continuedFromSessionId,
+            sandboxReuseResult: args.sandboxReuseResult ?? null,
+            result: args.result ?? null,
+            error: args.error ?? null,
+            lastEventSequence: args.lastEventSequence ?? null,
+          };
+        }),
+      )
+      .returning({ id: agentRuns.id });
+    signal.throwIfAborted();
+    if (runs.length !== args.count) {
+      throw new Error("seedRuns$: run inserts returned missing rows");
+    }
+
+    await db.insert(zeroRuns).values(
+      runs.map((run) => {
+        return {
+          id: run.id,
+          triggerSource: args.triggerSource ?? "cli",
+          scheduleId: args.scheduleId ?? null,
+          chatThreadId: args.chatThreadId ?? null,
+        };
+      }),
+    );
+    signal.throwIfAborted();
+
+    return {
+      runIds: runs.map((run) => {
+        return run.id;
+      }),
+    };
   },
 );
 

--- a/turbo/apps/api/src/signals/routes/__tests__/zero-logs-search.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/zero-logs-search.test.ts
@@ -19,6 +19,7 @@ import {
   deleteUsageInsightFixture$,
   seedCompose$,
   seedRun$,
+  seedRuns$,
   seedUsageInsightFixture$,
   type UsageInsightFixture,
 } from "./helpers/zero-usage-insight";
@@ -29,6 +30,19 @@ const mocks = createZeroRouteMocks(context);
 
 function currentSecond(): number {
   return Math.floor(now() / 1000);
+}
+
+function zeroToken(userId: string, orgId: string): string {
+  const seconds = currentSecond();
+  return signSandboxJwtForTests({
+    scope: "zero",
+    userId,
+    orgId,
+    runId: `run_${randomUUID()}`,
+    capabilities: ["agent-run:read"],
+    iat: seconds,
+    exp: seconds + 600,
+  });
 }
 
 function makeAxiomEvent(
@@ -88,23 +102,12 @@ describe("GET /api/zero/logs/search", () => {
       ),
     );
 
-    const seconds = currentSecond();
-    const token = signSandboxJwtForTests({
-      scope: "zero",
-      userId: fixture.userId,
-      orgId: fixture.orgId,
-      runId: `run_${randomUUID()}`,
-      capabilities: ["agent-run:read"],
-      iat: seconds,
-      exp: seconds + 600,
-    });
-
     return {
       orgId: fixture.orgId,
       userId: fixture.userId,
       composeId,
       runId,
-      token,
+      token: zeroToken(fixture.userId, fixture.orgId),
     };
   }
 
@@ -153,6 +156,67 @@ describe("GET /api/zero/logs/search", () => {
     );
     expect(response.body.results).toStrictEqual([]);
     expect(response.body.hasMore).toBeFalsy();
+  });
+
+  it("splits large run ID searches into bounded Axiom queries", async () => {
+    const fixture = await trackUsage(
+      store.set(seedUsageInsightFixture$, undefined, context.signal),
+    );
+    const { composeId } = await store.set(
+      seedCompose$,
+      fixture,
+      context.signal,
+    );
+    const { runIds } = await store.set(
+      seedRuns$,
+      { ...fixture, composeId, count: 501 },
+      context.signal,
+    );
+    await trackOrg(
+      store.set(
+        seedOrgMembership$,
+        { orgId: fixture.orgId, userId: fixture.userId },
+        context.signal,
+      ),
+    );
+
+    const matchedRunId = runIds[runIds.length - 1]!;
+    context.mocks.axiom.query.mockImplementation((apl) => {
+      if (typeof apl !== "string") {
+        return Promise.resolve([]);
+      }
+      const events = apl.includes(matchedRunId)
+        ? [makeAxiomEvent(matchedRunId, 7, "chunked match")]
+        : [];
+      return Promise.resolve(events);
+    });
+
+    const client = setupApp({ context })(zeroLogsSearchContract);
+    const response = await accept(
+      client.searchLogs({
+        query: { keyword: "chunked" },
+        headers: {
+          authorization: `Bearer ${zeroToken(fixture.userId, fixture.orgId)}`,
+        },
+      }),
+      [200],
+    );
+
+    expect(response.body.results).toHaveLength(1);
+    expect(response.body.results[0]?.runId).toBe(matchedRunId);
+    expect(context.mocks.axiom.query).toHaveBeenCalledTimes(2);
+
+    for (const call of context.mocks.axiom.query.mock.calls) {
+      const apl = call[0];
+      expect(typeof apl).toBe("string");
+      if (typeof apl !== "string") {
+        throw new Error("Expected Axiom query to be a string");
+      }
+      const runIdCount = apl.match(
+        /[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}/g,
+      )?.length;
+      expect(runIdCount ?? 0).toBeLessThanOrEqual(500);
+    }
   });
 
   it("returns matched events without context", async () => {

--- a/turbo/apps/api/src/signals/services/zero-logs.service.ts
+++ b/turbo/apps/api/src/signals/services/zero-logs.service.ts
@@ -1,4 +1,4 @@
-import { computed, type Computed } from "ccstate";
+import { computed, type Computed, type Getter } from "ccstate";
 import {
   triggerSourceSchema,
   type LogDetail,
@@ -40,10 +40,13 @@ import { escapeAplString } from "../../lib/axiom-apl";
 import { now } from "../../lib/time";
 
 type ServiceDb = Pick<Db, "select" | "selectDistinct">;
+type ComputedGetter = Getter;
 
 const triggerAgentAlias = alias(zeroAgents, "trigger_agent");
 
 const SEVEN_DAYS_MS = 7 * 24 * 60 * 60 * 1000;
+const AXIOM_RUN_ID_FILTER_CHUNK_SIZE = 500;
+const AXIOM_SEARCH_QUERY_CONCURRENCY = 4;
 
 interface AgentComposeContent {
   agents: Record<string, { framework: string }>;
@@ -543,7 +546,7 @@ async function getUserRunIds(
   });
 }
 
-function buildRunIdFilter(runIds: string[]): string {
+function buildRunIdFilter(runIds: readonly string[]): string {
   return runIds.length === 1
     ? `| where runId == "${escapeAplString(runIds[0]!)}"`
     : `| where runId in (${runIds
@@ -551,6 +554,173 @@ function buildRunIdFilter(runIds: string[]): string {
           return `"${escapeAplString(id)}"`;
         })
         .join(", ")})`;
+}
+
+function chunkRunIds(runIds: readonly string[]): string[][] {
+  const chunks: string[][] = [];
+  for (
+    let index = 0;
+    index < runIds.length;
+    index += AXIOM_RUN_ID_FILTER_CHUNK_SIZE
+  ) {
+    chunks.push(runIds.slice(index, index + AXIOM_RUN_ID_FILTER_CHUNK_SIZE));
+  }
+  return chunks;
+}
+
+function buildSearchApl(params: {
+  readonly dataset: string;
+  readonly sinceISO: string;
+  readonly runIds: readonly string[];
+  readonly keyword: string;
+  readonly limit: number;
+}): string {
+  const runIdFilter = buildRunIdFilter(params.runIds);
+  return `['${params.dataset}']
+| where _time > datetime("${params.sinceISO}")
+${runIdFilter}
+| search "*${escapeAplString(params.keyword)}*"
+| order by _time desc
+| limit ${params.limit}`;
+}
+
+function compareAxiomSearchEventsDesc(
+  left: AxiomAgentEvent,
+  right: AxiomAgentEvent,
+): number {
+  const timeDiff = Date.parse(right._time) - Date.parse(left._time);
+  if (timeDiff !== 0) {
+    return timeDiff;
+  }
+
+  const runDiff = left.runId.localeCompare(right.runId);
+  if (runDiff !== 0) {
+    return runDiff;
+  }
+
+  return left.sequenceNumber - right.sequenceNumber;
+}
+
+async function queryMatchingEvents(
+  get: ComputedGetter,
+  params: {
+    readonly dataset: string;
+    readonly sinceISO: string;
+    readonly targetRunIds: readonly string[];
+    readonly keyword: string;
+    readonly limit: number;
+  },
+): Promise<AxiomAgentEvent[]> {
+  const matchedEvents: AxiomAgentEvent[] = [];
+  const runIdChunks = chunkRunIds(params.targetRunIds);
+  for (
+    let index = 0;
+    index < runIdChunks.length;
+    index += AXIOM_SEARCH_QUERY_CONCURRENCY
+  ) {
+    const batch = runIdChunks.slice(
+      index,
+      index + AXIOM_SEARCH_QUERY_CONCURRENCY,
+    );
+    const batchEvents = await Promise.all(
+      batch.map(async (runIdChunk) => {
+        const searchApl = buildSearchApl({
+          dataset: params.dataset,
+          sinceISO: params.sinceISO,
+          runIds: runIdChunk,
+          keyword: params.keyword,
+          limit: params.limit + 1,
+        });
+        return (
+          await get(queryAxiom(searchApl))
+        ).slice() as unknown as AxiomAgentEvent[];
+      }),
+    );
+
+    for (const events of batchEvents) {
+      matchedEvents.push(...events);
+    }
+  }
+
+  return matchedEvents.sort(compareAxiomSearchEventsDesc);
+}
+
+async function getSearchContextMap(
+  get: ComputedGetter,
+  params: {
+    readonly dataset: string;
+    readonly matches: readonly AxiomAgentEvent[];
+    readonly before: number;
+    readonly after: number;
+  },
+): Promise<Map<string, AxiomAgentEvent>> {
+  const contextMap = new Map<string, AxiomAgentEvent>();
+  if (params.before === 0 && params.after === 0) {
+    return contextMap;
+  }
+
+  const contextConditions = params.matches.map((match) => {
+    const seqMin = Math.max(0, match.sequenceNumber - params.before);
+    const seqMax = match.sequenceNumber + params.after;
+    return `(runId == "${escapeAplString(match.runId)}" and sequenceNumber >= ${seqMin} and sequenceNumber <= ${seqMax})`;
+  });
+
+  const contextApl = `['${params.dataset}']
+| where ${contextConditions.join("\n  or ")}
+| order by runId asc, sequenceNumber asc`;
+
+  const contextEvents = (
+    await get(queryAxiom(contextApl))
+  ).slice() as unknown as AxiomAgentEvent[];
+
+  for (const event of contextEvents) {
+    contextMap.set(`${event.runId}:${event.sequenceNumber}`, event);
+  }
+
+  return contextMap;
+}
+
+function buildSearchResults(params: {
+  readonly matches: readonly AxiomAgentEvent[];
+  readonly before: number;
+  readonly after: number;
+  readonly contextMap: Map<string, AxiomAgentEvent>;
+  readonly agentNames: Map<string, string>;
+}): LogsSearchResponse["results"] {
+  return params.matches.map((match) => {
+    const contextBefore: RunEvent[] = [];
+    const contextAfter: RunEvent[] = [];
+
+    for (
+      let i = match.sequenceNumber - params.before;
+      i < match.sequenceNumber;
+      i++
+    ) {
+      const event = params.contextMap.get(`${match.runId}:${i}`);
+      if (event) {
+        contextBefore.push(toRunEvent(event));
+      }
+    }
+
+    for (
+      let i = match.sequenceNumber + 1;
+      i <= match.sequenceNumber + params.after;
+      i++
+    ) {
+      const event = params.contextMap.get(`${match.runId}:${i}`);
+      if (event) {
+        contextAfter.push(toRunEvent(event));
+      }
+    }
+
+    return {
+      runId: match.runId,
+      agentName: params.agentNames.get(match.runId) || "unknown",
+      matchedEvent: toRunEvent(match),
+      contextBefore,
+      contextAfter,
+    };
+  });
 }
 
 async function getAgentNames(
@@ -638,20 +808,13 @@ export function zeroLogSearch(
       }
     }
 
-    const runIdFilter = buildRunIdFilter(targetRunIds);
-
-    // Search events in Axiom
-    const searchApl = `['${dataset}']
-| where _time > datetime("${sinceISO}")
-${runIdFilter}
-| search "*${escapeAplString(keyword)}*"
-| order by _time desc
-| limit ${limit + 1}`;
-
-    const matchedEvents = (
-      await get(queryAxiom(searchApl))
-    ).slice() as unknown as AxiomAgentEvent[];
-
+    const matchedEvents = await queryMatchingEvents(get, {
+      dataset,
+      sinceISO,
+      targetRunIds,
+      keyword,
+      limit,
+    });
     if (matchedEvents.length === 0) {
       return { results: [], hasMore: false };
     }
@@ -659,29 +822,12 @@ ${runIdFilter}
     const hasMore = matchedEvents.length > limit;
     const matches = hasMore ? matchedEvents.slice(0, limit) : matchedEvents;
 
-    // Fetch context events
-    const contextMap = new Map<string, AxiomAgentEvent>();
-    if (before > 0 || after > 0) {
-      const contextConditions = matches.map((match) => {
-        const seqMin = Math.max(0, match.sequenceNumber - before);
-        const seqMax = match.sequenceNumber + after;
-        return `(runId == "${escapeAplString(match.runId)}" and sequenceNumber >= ${seqMin} and sequenceNumber <= ${seqMax})`;
-      });
-
-      const contextApl = `['${dataset}']
-| where ${contextConditions.join("\n  or ")}
-| order by runId asc, sequenceNumber asc`;
-
-      const contextEvents = (
-        await get(queryAxiom(contextApl))
-      ).slice() as unknown as AxiomAgentEvent[];
-
-      for (const event of contextEvents) {
-        contextMap.set(`${event.runId}:${event.sequenceNumber}`, event);
-      }
-    }
-
-    // Resolve agent labels for the existing response field.
+    const contextMap = await getSearchContextMap(get, {
+      dataset,
+      matches,
+      before,
+      after,
+    });
     const matchedRunIds = [
       ...new Set(
         matches.map((e) => {
@@ -696,42 +842,13 @@ ${runIdFilter}
       params.orgId,
     );
 
-    // Assemble results
-    const results = matches.map((match) => {
-      const contextBefore: RunEvent[] = [];
-      const contextAfter: RunEvent[] = [];
-
-      for (
-        let i = match.sequenceNumber - before;
-        i < match.sequenceNumber;
-        i++
-      ) {
-        const event = contextMap.get(`${match.runId}:${i}`);
-        if (event) {
-          contextBefore.push(toRunEvent(event));
-        }
-      }
-
-      for (
-        let i = match.sequenceNumber + 1;
-        i <= match.sequenceNumber + after;
-        i++
-      ) {
-        const event = contextMap.get(`${match.runId}:${i}`);
-        if (event) {
-          contextAfter.push(toRunEvent(event));
-        }
-      }
-
-      return {
-        runId: match.runId,
-        agentName: agentNames.get(match.runId) || "unknown",
-        matchedEvent: toRunEvent(match),
-        contextBefore,
-        contextAfter,
-      };
+    const results = buildSearchResults({
+      matches,
+      before,
+      after,
+      contextMap,
+      agentNames,
     });
-
     return { results, hasMore };
   });
 }


### PR DESCRIPTION
## Summary

- split broad zero log searches into bounded Axiom run ID chunks
- merge and deterministically sort chunked Axiom matches before applying limit/context
- add route-level coverage for a large owned run set to prevent oversized `runId in (...)` predicates

Fixes #15612

## Tests

- `pnpm -F api exec vitest run src/signals/routes/__tests__/logs-search.test.ts src/signals/routes/__tests__/zero-logs-search.test.ts`
- `pnpm -F api lint`
- `pnpm -F api check-types`
- pre-commit: `pnpm knip --cache`
- pre-commit: `pnpm check-types`

## Notes

- `pnpm -F @vm0/db db:migrate` initially failed before dependency refresh because `postgres` was missing locally; `pnpm install --frozen-lockfile` restored the workspace install and the migration then completed.