### PR TITLE
fix: prevent lower-tier checkout replacement

### DIFF
--- a/turbo/apps/api/src/signals/routes/__tests__/webhooks-third-party.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/webhooks-third-party.test.ts
@@ -2209,6 +2209,41 @@ describe("POST /api/webhooks/stripe", () => {
       expect(billing.stripeSubscriptionId).toBe(subId);
     });
 
+    it("does not replace a higher current tier with a lower checkout", async () => {
+      const fixture = await trackStripe(
+        store.set(seedStripeFixture$, undefined, context.signal),
+      );
+      mockStripeWebhookEnv();
+      const teamSubId = stripeId("sub");
+      const proSubId = stripeId("sub");
+      await updateStripeOrg(fixture, {
+        stripeSubscriptionId: teamSubId,
+        subscriptionStatus: "active",
+        tier: "team",
+      });
+      context.mocks.stripe.subscriptions.retrieve.mockResolvedValue({
+        id: proSubId,
+        status: "active",
+        items: { data: [{ price: { id: STRIPE_PRICE_PRO } }] },
+      });
+
+      const response = await postStripeWebhookEvent({
+        type: "checkout.session.completed",
+        dataObject: {
+          id: stripeId("cs"),
+          subscription: proSubId,
+          customer: fixture.stripeCustomerId,
+          metadata: null,
+        },
+      });
+
+      expect(response.status).toBe(200);
+      const billing = await selectStripeBilling(fixture);
+      expect(billing.tier).toBe("team");
+      expect(billing.stripeSubscriptionId).toBe(teamSubId);
+      expect(billing.subscriptionStatus).toBe("active");
+    });
+
     it("does not grant one-time credits before checkout payment settles", async () => {
       const fixture = await trackStripe(
         store.set(seedStripeFixture$, undefined, context.signal),

--- a/turbo/apps/api/src/signals/routes/__tests__/webhooks-third-party.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/webhooks-third-party.test.ts
@@ -2449,6 +2449,50 @@ describe("POST /api/webhooks/stripe", () => {
       );
     });
 
+    it("skips lower subscription invoices when a higher subscription is current", async () => {
+      const fixture = await trackStripe(
+        store.set(seedStripeFixture$, undefined, context.signal),
+      );
+      mockStripeWebhookEnv();
+      const teamSubId = stripeId("sub");
+      const proSubId = stripeId("sub");
+      const invId = stripeId("inv");
+      const currentPeriodEnd = new Date("2026-04-26T07:24:12Z");
+      await updateStripeOrg(fixture, {
+        stripeSubscriptionId: teamSubId,
+        tier: "team",
+        currentPeriodEnd,
+      });
+      context.mocks.stripe.subscriptions.retrieve.mockResolvedValue({
+        id: proSubId,
+        status: "active",
+        items: { data: [{ price: { id: STRIPE_PRICE_PRO } }] },
+      });
+      const creditsBefore = (await selectStripeBilling(fixture)).credits;
+
+      const response = await postStripeWebhookEvent({
+        type: "invoice.paid",
+        dataObject: {
+          id: invId,
+          customer: fixture.stripeCustomerId,
+          metadata: null,
+          lines: invoiceLinesWithSubscriptionPeriod(1_800_000_000),
+          parent: { subscription_details: { subscription: proSubId } },
+        },
+      });
+
+      expect(response.status).toBe(200);
+      const billing = await selectStripeBilling(fixture);
+      expect(billing.credits).toBe(creditsBefore);
+      expect(billing.tier).toBe("team");
+      expect(billing.stripeSubscriptionId).toBe(teamSubId);
+      expect(billing.lastProcessedInvoiceId).toBeNull();
+      expect(billing.currentPeriodEnd).toStrictEqual(currentPeriodEnd);
+      await expect(
+        selectStripeCreditExpiresRecords(fixture),
+      ).resolves.toStrictEqual([]);
+    });
+
     it("adds renewal credits to an existing balance", async () => {
       const fixture = await trackStripe(
         store.set(seedStripeFixture$, undefined, context.signal),

--- a/turbo/apps/api/src/signals/routes/__tests__/zero-billing-checkout.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/zero-billing-checkout.test.ts
@@ -61,6 +61,9 @@ function zeroToken(args: {
 async function seedOrgRow(values?: {
   readonly onboardingPaymentPending?: boolean;
   readonly stripeCustomerId?: string;
+  readonly stripeSubscriptionId?: string;
+  readonly subscriptionStatus?: string;
+  readonly tier?: string;
 }): Promise<{
   readonly orgId: string;
   readonly userId: string;
@@ -72,6 +75,9 @@ async function seedOrgRow(values?: {
     orgId,
     onboardingPaymentPending: values?.onboardingPaymentPending ?? false,
     stripeCustomerId: values?.stripeCustomerId,
+    stripeSubscriptionId: values?.stripeSubscriptionId,
+    subscriptionStatus: values?.subscriptionStatus,
+    tier: values?.tier,
   });
   return { orgId, userId };
 }
@@ -109,6 +115,17 @@ describe("POST /api/zero/billing/checkout", () => {
 
   async function trackedSeed(): Promise<{ orgId: string; userId: string }> {
     const fixture = await seedOrgRow();
+    createdOrgIds.push(fixture.orgId);
+    return fixture;
+  }
+
+  async function trackedBillingSeed(values: {
+    readonly stripeCustomerId: string;
+    readonly stripeSubscriptionId: string;
+    readonly subscriptionStatus: string;
+    readonly tier: string;
+  }): Promise<{ orgId: string; userId: string }> {
+    const fixture = await seedOrgRow(values);
     createdOrgIds.push(fixture.orgId);
     return fixture;
   }
@@ -251,6 +268,76 @@ describe("POST /api/zero/billing/checkout", () => {
       metadata: { orgId: fixture.orgId },
       subscription_data: { metadata: { orgId: fixture.orgId } },
     });
+  });
+
+  it("returns 400 when checkout would downgrade the current tier", async () => {
+    const fixture = await trackedBillingSeed({
+      stripeCustomerId: `cus_${randomUUID().slice(0, 8)}`,
+      stripeSubscriptionId: `sub_${randomUUID().slice(0, 8)}`,
+      subscriptionStatus: "active",
+      tier: "team",
+    });
+    mocks.clerk.session(fixture.userId, fixture.orgId, "org:admin");
+
+    const client = setupApp({ context })(zeroBillingCheckoutContract);
+
+    const response = await accept(
+      client.create({
+        body: {
+          tier: "pro",
+          successUrl: `${APP_ORIGIN}/billing?billing=success`,
+          cancelUrl: `${APP_ORIGIN}/billing?billing=canceled`,
+        },
+        headers: { authorization: "Bearer clerk-session" },
+      }),
+      [400],
+    );
+
+    expect(response.body).toStrictEqual({
+      error: {
+        message:
+          "Cannot create Pro checkout while current tier is Team; use billing management to change plans",
+        code: "BAD_REQUEST",
+      },
+    });
+    expect(
+      context.mocks.stripe.checkout.sessions.create,
+    ).not.toHaveBeenCalled();
+  });
+
+  it("returns 400 when checkout would duplicate the current tier", async () => {
+    const fixture = await trackedBillingSeed({
+      stripeCustomerId: `cus_${randomUUID().slice(0, 8)}`,
+      stripeSubscriptionId: `sub_${randomUUID().slice(0, 8)}`,
+      subscriptionStatus: "active",
+      tier: "pro",
+    });
+    mocks.clerk.session(fixture.userId, fixture.orgId, "org:admin");
+
+    const client = setupApp({ context })(zeroBillingCheckoutContract);
+
+    const response = await accept(
+      client.create({
+        body: {
+          tier: "pro",
+          successUrl: `${APP_ORIGIN}/billing?billing=success`,
+          cancelUrl: `${APP_ORIGIN}/billing?billing=canceled`,
+        },
+        headers: { authorization: "Bearer clerk-session" },
+      }),
+      [400],
+    );
+
+    expect(response.body).toStrictEqual({
+      error: {
+        message:
+          "Cannot create Pro checkout while current tier is Pro; use billing management to change plans",
+        code: "BAD_REQUEST",
+      },
+    });
+    expect(
+      context.mocks.stripe.checkout.sessions.create,
+    ).not.toHaveBeenCalled();
   });
 
   it("attaches ad attribution to Stripe checkout and subscription metadata", async () => {
@@ -504,6 +591,9 @@ describe("POST /api/zero/billing/checkout/complete", () => {
   async function trackedSeed(values?: {
     readonly onboardingPaymentPending?: boolean;
     readonly stripeCustomerId?: string;
+    readonly stripeSubscriptionId?: string;
+    readonly subscriptionStatus?: string;
+    readonly tier?: string;
   }): Promise<{ orgId: string; userId: string }> {
     const fixture = await seedOrgRow(values);
     createdOrgIds.push(fixture.orgId);
@@ -571,6 +661,120 @@ describe("POST /api/zero/billing/checkout/complete", () => {
       subscriptionStatus: "trialing",
       onboardingPaymentPending: false,
       currentPeriodEnd: new Date(1_800_000_000 * 1000),
+    });
+  });
+
+  it("allows completion when the same subscription is already stored", async () => {
+    const customerId = `cus_${randomUUID().slice(0, 8)}`;
+    const subscriptionId = `sub_${randomUUID().slice(0, 8)}`;
+    const fixture = await trackedSeed({
+      stripeCustomerId: customerId,
+      stripeSubscriptionId: subscriptionId,
+      subscriptionStatus: "active",
+      tier: "team",
+    });
+    mocks.clerk.session(fixture.userId, fixture.orgId, "org:admin");
+
+    context.mocks.stripe.checkout.sessions.retrieve.mockResolvedValue({
+      id: "cs_test_completed",
+      mode: "subscription",
+      status: "complete",
+      customer: customerId,
+      subscription: subscriptionId,
+    });
+    context.mocks.stripe.subscriptions.retrieve.mockResolvedValue({
+      id: subscriptionId,
+      status: "active",
+      cancel_at_period_end: false,
+      items: {
+        data: [
+          {
+            price: { id: TEST_PRICE_TEAM },
+            current_period_end: 1_800_000_000,
+          },
+        ],
+      },
+    });
+
+    const client = setupApp({ context })(zeroBillingCheckoutContract);
+
+    const response = await accept(
+      client.complete({
+        body: { sessionId: "cs_test_completed" },
+        headers: { authorization: "Bearer clerk-session" },
+      }),
+      [200],
+    );
+
+    expect(response.body).toStrictEqual({ completed: true });
+  });
+
+  it("returns 400 when completed checkout would downgrade the current tier", async () => {
+    const customerId = `cus_${randomUUID().slice(0, 8)}`;
+    const existingSubscriptionId = `sub_${randomUUID().slice(0, 8)}`;
+    const checkoutSubscriptionId = `sub_${randomUUID().slice(0, 8)}`;
+    const fixture = await trackedSeed({
+      stripeCustomerId: customerId,
+      stripeSubscriptionId: existingSubscriptionId,
+      subscriptionStatus: "active",
+      tier: "team",
+    });
+    mocks.clerk.session(fixture.userId, fixture.orgId, "org:admin");
+
+    context.mocks.stripe.checkout.sessions.retrieve.mockResolvedValue({
+      id: "cs_test_completed",
+      mode: "subscription",
+      status: "complete",
+      customer: customerId,
+      subscription: checkoutSubscriptionId,
+    });
+    context.mocks.stripe.subscriptions.retrieve.mockResolvedValue({
+      id: checkoutSubscriptionId,
+      status: "active",
+      cancel_at_period_end: false,
+      items: {
+        data: [
+          {
+            price: { id: TEST_PRICE_PRO },
+            current_period_end: 1_800_000_000,
+          },
+        ],
+      },
+    });
+
+    const client = setupApp({ context })(zeroBillingCheckoutContract);
+
+    const response = await accept(
+      client.complete({
+        body: { sessionId: "cs_test_completed" },
+        headers: { authorization: "Bearer clerk-session" },
+      }),
+      [400],
+    );
+
+    expect(response.body).toStrictEqual({
+      error: {
+        message:
+          "Cannot create Pro checkout while current tier is Team; use billing management to change plans",
+        code: "BAD_REQUEST",
+      },
+    });
+
+    const writeDb = store.set(writeDb$);
+    const [row] = await writeDb
+      .select({
+        tier: orgMetadata.tier,
+        stripeSubscriptionId: orgMetadata.stripeSubscriptionId,
+        subscriptionStatus: orgMetadata.subscriptionStatus,
+      })
+      .from(orgMetadata)
+      .where(eq(orgMetadata.orgId, fixture.orgId))
+      .limit(1);
+
+    expect(row).toStrictEqual({
+      tier: "team",
+      stripeSubscriptionId: existingSubscriptionId,
+      subscriptionStatus: "active",
     });
   });
 

--- a/turbo/apps/api/src/signals/routes/zero-billing-checkout.ts
+++ b/turbo/apps/api/src/signals/routes/zero-billing-checkout.ts
@@ -12,6 +12,8 @@ import { db$ } from "../external/db";
 import {
   activePriceId,
   completeCheckoutSession$,
+  checkoutTierConflictMessage,
+  checkoutWouldReplaceWithSameOrLowerTier,
   createCheckoutSession$,
 } from "../services/zero-billing-checkout.service";
 import type { RouteEntry } from "../route";
@@ -58,19 +60,35 @@ const checkoutAuthed$ = command(async ({ get, set }, signal: AbortSignal) => {
     return badRequestMessage(`Price not configured for ${tier} tier`);
   }
 
+  const db = get(db$);
+  const [metadata] = await db
+    .select({
+      onboardingPaymentPending: orgMetadata.onboardingPaymentPending,
+      tier: orgMetadata.tier,
+    })
+    .from(orgMetadata)
+    .where(eq(orgMetadata.orgId, auth.orgId))
+    .limit(1);
+  signal.throwIfAborted();
+
+  if (
+    checkoutWouldReplaceWithSameOrLowerTier({
+      currentTier: metadata?.tier,
+      targetTier: tier,
+    })
+  ) {
+    return badRequestMessage(
+      checkoutTierConflictMessage({
+        currentTier: metadata?.tier,
+        targetTier: tier,
+      }),
+    );
+  }
+
   if (trialDays !== undefined) {
     if (tier !== "pro") {
       return badRequestMessage("Trial checkout is only available for Pro tier");
     }
-    const db = get(db$);
-    const [metadata] = await db
-      .select({
-        onboardingPaymentPending: orgMetadata.onboardingPaymentPending,
-      })
-      .from(orgMetadata)
-      .where(eq(orgMetadata.orgId, auth.orgId))
-      .limit(1);
-    signal.throwIfAborted();
     if (metadata?.onboardingPaymentPending !== true) {
       return badRequestMessage(
         "Pro trial checkout is only available during onboarding",
@@ -134,6 +152,14 @@ const checkoutCompleteAuthed$ = command(
     if (result.status === "customer_mismatch") {
       return badRequestMessage(
         "Checkout session does not belong to current organization",
+      );
+    }
+    if (result.status === "tier_conflict") {
+      return badRequestMessage(
+        checkoutTierConflictMessage({
+          currentTier: result.currentTier,
+          targetTier: result.targetTier,
+        }),
       );
     }
 

--- a/turbo/apps/api/src/signals/services/webhooks-stripe.service.ts
+++ b/turbo/apps/api/src/signals/services/webhooks-stripe.service.ts
@@ -466,6 +466,22 @@ async function shouldSkipCheckoutSubscriptionUpdate(
   return false;
 }
 
+function invoiceWouldReplaceWithSameOrLowerTier(args: {
+  readonly currentSubscriptionId: string | null;
+  readonly subscriptionId: string;
+  readonly currentTier: string;
+  readonly targetTier: SubscriptionCheckoutTier;
+}): boolean {
+  return (
+    args.currentSubscriptionId !== null &&
+    args.currentSubscriptionId !== args.subscriptionId &&
+    checkoutWouldReplaceWithSameOrLowerTier({
+      currentTier: args.currentTier,
+      targetTier: args.targetTier,
+    })
+  );
+}
+
 async function handleCheckoutCompleted(
   db: Db,
   session: CheckoutSessionInput,
@@ -549,6 +565,8 @@ async function handleInvoicePaid(db: Db, invoice: InvoiceInput): Promise<void> {
     .select({
       orgId: orgMetadata.orgId,
       lastProcessedInvoiceId: orgMetadata.lastProcessedInvoiceId,
+      stripeSubscriptionId: orgMetadata.stripeSubscriptionId,
+      tier: orgMetadata.tier,
     })
     .from(orgMetadata)
     .where(eq(orgMetadata.stripeCustomerId, customerId))
@@ -582,6 +600,29 @@ async function handleInvoicePaid(db: Db, invoice: InvoiceInput): Promise<void> {
   }
 
   const tier = tierFromPriceId(priceId);
+  if (
+    invoiceWouldReplaceWithSameOrLowerTier({
+      currentSubscriptionId: org.stripeSubscriptionId,
+      subscriptionId,
+      currentTier: org.tier,
+      targetTier: tier,
+    })
+  ) {
+    L.warn("invoice.paid rejected tier replacement", {
+      customerId,
+      invoiceId: invoice.id,
+      subscriptionId,
+      currentSubscriptionId: org.stripeSubscriptionId,
+      currentTier: org.tier,
+      targetTier: tier,
+      reason: checkoutTierConflictMessage({
+        currentTier: org.tier,
+        targetTier: tier,
+      }),
+    });
+    return;
+  }
+
   const credits = monthlyCreditsForTier(tier);
   if (credits <= 0) {
     L.warn("no credits to grant for tier", {

--- a/turbo/apps/api/src/signals/services/webhooks-stripe.service.ts
+++ b/turbo/apps/api/src/signals/services/webhooks-stripe.service.ts
@@ -10,7 +10,12 @@ import { now, nowDate } from "../../lib/time";
 import { writeDb$, type Db } from "../external/db";
 import { getStripeClient } from "../external/stripe-client";
 import { getCampaign } from "./one-time-products";
-import { tierFromPriceId } from "./zero-billing-checkout.service";
+import {
+  checkoutTierConflictMessage,
+  checkoutWouldReplaceWithSameOrLowerTier,
+  type SubscriptionCheckoutTier,
+  tierFromPriceId,
+} from "./zero-billing-checkout.service";
 
 const L = logger("WebhookStripe");
 const TRIALING_CREDIT_EXPIRY_DAYS = 7;
@@ -60,6 +65,11 @@ interface SubscriptionInput {
 
 interface SubscriptionDeletedInput {
   readonly id: string;
+}
+
+interface CheckoutSubscriptionContext {
+  readonly customerId: string;
+  readonly subscriptionId: string;
 }
 
 function subscriptionPeriodEnd(subscription: SubscriptionInput): Date | null {
@@ -383,6 +393,79 @@ async function handlePaidCheckoutPurpose(
   return true;
 }
 
+function checkoutSubscriptionContext(
+  session: CheckoutSessionInput,
+): CheckoutSubscriptionContext | null {
+  const subscriptionId =
+    typeof session.subscription === "string"
+      ? session.subscription
+      : session.subscription?.id;
+  if (!subscriptionId) {
+    L.warn("checkout.session.completed without subscription ID", {
+      sessionId: session.id,
+    });
+    return null;
+  }
+
+  const customerId =
+    typeof session.customer === "string"
+      ? session.customer
+      : session.customer?.id;
+  if (!customerId) {
+    L.warn("checkout.session.completed without customer ID", {
+      sessionId: session.id,
+    });
+    return null;
+  }
+
+  return { customerId, subscriptionId };
+}
+
+async function shouldSkipCheckoutSubscriptionUpdate(
+  db: Db,
+  args: {
+    readonly customerId: string;
+    readonly subscriptionId: string;
+    readonly tier: SubscriptionCheckoutTier;
+  },
+): Promise<boolean> {
+  const [existing] = await db
+    .select({
+      stripeSubscriptionId: orgMetadata.stripeSubscriptionId,
+      tier: orgMetadata.tier,
+    })
+    .from(orgMetadata)
+    .where(eq(orgMetadata.stripeCustomerId, args.customerId))
+    .limit(1);
+
+  if (existing?.stripeSubscriptionId === args.subscriptionId) {
+    L.debug("checkout.session.completed already processed", {
+      subscriptionId: args.subscriptionId,
+    });
+    return true;
+  }
+  if (
+    checkoutWouldReplaceWithSameOrLowerTier({
+      currentTier: existing?.tier,
+      targetTier: args.tier,
+    })
+  ) {
+    L.warn("checkout.session.completed rejected tier replacement", {
+      customerId: args.customerId,
+      subscriptionId: args.subscriptionId,
+      currentTier: existing?.tier ?? null,
+      targetTier: args.tier,
+      reason: checkoutTierConflictMessage({
+        currentTier: existing?.tier,
+        targetTier: args.tier,
+      }),
+    });
+    return true;
+  }
+
+  return false;
+}
+
 async function handleCheckoutCompleted(
   db: Db,
   session: CheckoutSessionInput,
@@ -395,27 +478,11 @@ async function handleCheckoutCompleted(
     return;
   }
 
-  const subscriptionId =
-    typeof session.subscription === "string"
-      ? session.subscription
-      : session.subscription?.id;
-  if (!subscriptionId) {
-    L.warn("checkout.session.completed without subscription ID", {
-      sessionId: session.id,
-    });
+  const checkoutContext = checkoutSubscriptionContext(session);
+  if (!checkoutContext) {
     return;
   }
-
-  const customerId =
-    typeof session.customer === "string"
-      ? session.customer
-      : session.customer?.id;
-  if (!customerId) {
-    L.warn("checkout.session.completed without customer ID", {
-      sessionId: session.id,
-    });
-    return;
-  }
+  const { customerId, subscriptionId } = checkoutContext;
 
   const stripe = getStripeClient();
   const subscription = await stripe.subscriptions.retrieve(subscriptionId);
@@ -426,14 +493,13 @@ async function handleCheckoutCompleted(
   }
 
   const tier = tierFromPriceId(priceId);
-  const [existing] = await db
-    .select({ stripeSubscriptionId: orgMetadata.stripeSubscriptionId })
-    .from(orgMetadata)
-    .where(eq(orgMetadata.stripeCustomerId, customerId))
-    .limit(1);
-
-  if (existing?.stripeSubscriptionId === subscriptionId) {
-    L.debug("checkout.session.completed already processed", { subscriptionId });
+  if (
+    await shouldSkipCheckoutSubscriptionUpdate(db, {
+      customerId,
+      subscriptionId,
+      tier,
+    })
+  ) {
     return;
   }
 

--- a/turbo/apps/api/src/signals/services/zero-billing-checkout.service.ts
+++ b/turbo/apps/api/src/signals/services/zero-billing-checkout.service.ts
@@ -1,5 +1,4 @@
 import { command } from "ccstate";
-import type { OrgTier } from "@vm0/api-contracts/contracts/orgs";
 import { orgMetadata } from "@vm0/db/schema/org-metadata";
 import { and, eq } from "drizzle-orm";
 import type { Stripe } from "stripe";
@@ -27,7 +26,12 @@ interface CompleteCheckoutSessionArgs {
 type CheckoutCompletionResult =
   | { readonly status: "completed" }
   | { readonly status: "pending" }
-  | { readonly status: "customer_mismatch" };
+  | { readonly status: "customer_mismatch" }
+  | {
+      readonly status: "tier_conflict";
+      readonly currentTier: string | null;
+      readonly targetTier: SubscriptionCheckoutTier;
+    };
 
 interface CreateCreditCheckoutSessionArgs {
   readonly orgId: string;
@@ -38,13 +42,17 @@ interface CreateCreditCheckoutSessionArgs {
 
 const CREDITS_PER_DOLLAR = 1000;
 const STRIPE_SUBSCRIPTION_PRICE_TIERS = ["pro", "team"] as const;
+export type SubscriptionCheckoutTier =
+  (typeof STRIPE_SUBSCRIPTION_PRICE_TIERS)[number];
 
 /** Returns the active (first) price ID for a given tier. */
-export function activePriceId(tier: "pro" | "team"): string | undefined {
+export function activePriceId(
+  tier: SubscriptionCheckoutTier,
+): string | undefined {
   return env("ZERO_PRICE")?.[tier]?.[0];
 }
 
-export function tierFromPriceId(priceId: string): OrgTier {
+export function tierFromPriceId(priceId: string): SubscriptionCheckoutTier {
   const priceMap = env("ZERO_PRICE");
   if (priceMap) {
     for (const tier of STRIPE_SUBSCRIPTION_PRICE_TIERS) {
@@ -54,6 +62,56 @@ export function tierFromPriceId(priceId: string): OrgTier {
     }
   }
   throw new Error(`Unknown Stripe price ID: ${priceId}`);
+}
+
+function billingTierRank(tier: string | null | undefined): number {
+  switch (tier) {
+    case "team": {
+      return 2;
+    }
+    case "pro": {
+      return 1;
+    }
+    case "free":
+    case "pro-suspend":
+    default: {
+      return 0;
+    }
+  }
+}
+
+function billingTierLabel(tier: string | null | undefined): string {
+  switch (tier) {
+    case "team": {
+      return "Team";
+    }
+    case "pro": {
+      return "Pro";
+    }
+    case "free": {
+      return "Free";
+    }
+    case "pro-suspend": {
+      return "Pro suspended";
+    }
+    default: {
+      return tier ?? "Pro suspended";
+    }
+  }
+}
+
+export function checkoutWouldReplaceWithSameOrLowerTier(args: {
+  readonly currentTier: string | null | undefined;
+  readonly targetTier: SubscriptionCheckoutTier;
+}): boolean {
+  return billingTierRank(args.currentTier) >= billingTierRank(args.targetTier);
+}
+
+export function checkoutTierConflictMessage(args: {
+  readonly currentTier: string | null | undefined;
+  readonly targetTier: SubscriptionCheckoutTier;
+}): string {
+  return `Cannot create ${billingTierLabel(args.targetTier)} checkout while current tier is ${billingTierLabel(args.currentTier)}; use billing management to change plans`;
 }
 
 export function activeCustomCreditPriceId(): string | undefined {
@@ -178,7 +236,11 @@ export const completeCheckoutSession$ = command(
   ): Promise<CheckoutCompletionResult> => {
     const db = set(writeDb$);
     const [org] = await db
-      .select({ stripeCustomerId: orgMetadata.stripeCustomerId })
+      .select({
+        stripeCustomerId: orgMetadata.stripeCustomerId,
+        stripeSubscriptionId: orgMetadata.stripeSubscriptionId,
+        tier: orgMetadata.tier,
+      })
       .from(orgMetadata)
       .where(eq(orgMetadata.orgId, args.orgId))
       .limit(1);
@@ -189,7 +251,7 @@ export const completeCheckoutSession$ = command(
     signal.throwIfAborted();
 
     const customerId = stripeObjectId(session.customer);
-    if (!customerId || customerId !== org?.stripeCustomerId) {
+    if (!org || !customerId || customerId !== org.stripeCustomerId) {
       return { status: "customer_mismatch" };
     }
 
@@ -211,6 +273,19 @@ export const completeCheckoutSession$ = command(
     }
 
     const tier = tierFromPriceId(priceId);
+    if (
+      org.stripeSubscriptionId !== subscription.id &&
+      checkoutWouldReplaceWithSameOrLowerTier({
+        currentTier: org.tier,
+        targetTier: tier,
+      })
+    ) {
+      return {
+        status: "tier_conflict",
+        currentTier: org.tier,
+        targetTier: tier,
+      };
+    }
     const periodEnd = subscriptionPeriodEnd(subscription);
 
     await db


### PR DESCRIPTION
## Summary
- block checkout creation when the requested tier is the same as or lower than the org current tier
- reject stale checkout completion and Stripe webhook events that would replace a higher local tier with a lower subscription
- keep same-subscription checkout completion idempotent and add regression coverage for checkout and webhook paths

## Tests
- pnpm format
- pnpm turbo run lint
- pnpm check-types
- pnpm knip
- pnpm -F api exec vitest src/signals/routes/__tests__/zero-billing-checkout.test.ts src/signals/routes/__tests__/webhooks-third-party.test.ts
- pnpm -F api exec vitest src/signals/routes/__tests__/webhooks-third-party.test.ts
- pnpm vitest (fails: desktop macOS-only vm0-computer CLI tests report accessibility_unavailable; 3 GitHub webhook tests fail only in the full parallel run, while webhooks-third-party.test.ts passes in isolation)