### PR TITLE
refactor: remove connector auth provider argument casts

### DIFF
--- a/turbo/packages/connectors/src/auth-providers/connector-auth.ts
+++ b/turbo/packages/connectors/src/auth-providers/connector-auth.ts
@@ -331,6 +331,13 @@ function connectorAuthProviderClientArgs(
   return { clientId: authClient.clientId };
 }
 
+function connectorAuthProviderArgs<Args>(args: unknown): Args {
+  // The runtime resolver already chose the client from the selected method's
+  // config; TypeScript cannot carry that conditional credential shape through
+  // the object assembled for the provider call.
+  return args as Args;
+}
+
 export function getConnectorAuthProviderClientArgs(
   authClient: ConnectorAuthClient,
 ): ConnectorAuthProviderClientArgs {
@@ -620,9 +627,10 @@ export function hasConnectorTokenRevokeProvider(
 
 export async function buildConnectorAuthCodeAuthorizationUrl<
   T extends AuthCodeGrantConnectorType,
+  Method extends ConnectorAuthCodeGrantAuthMethodId<T>,
 >(args: {
   readonly type: T;
-  readonly authMethod: ConnectorAuthCodeGrantAuthMethodId<T>;
+  readonly authMethod: Method;
   readonly authClient: ConnectorAuthClient;
   readonly redirectUri: string;
   readonly state: string;
@@ -635,19 +643,22 @@ export async function buildConnectorAuthCodeAuthorizationUrl<
     args.type,
     args.authMethod,
   );
-  return await provider.buildAuthUrl({
-    ...connectorAuthProviderClientArgs(args.authClient),
-    authCodeGrant,
-    redirectUri: args.redirectUri,
-    state: args.state,
-  } as ConnectorAuthCodeAuthorizeArgs<T>);
+  return await provider.buildAuthUrl(
+    connectorAuthProviderArgs<ConnectorAuthCodeAuthorizeArgs<T>>({
+      ...connectorAuthProviderClientArgs(args.authClient),
+      authCodeGrant,
+      redirectUri: args.redirectUri,
+      state: args.state,
+    }),
+  );
 }
 
 export async function exchangeConnectorAuthCode<
   T extends AuthCodeGrantConnectorType,
+  Method extends ConnectorAuthCodeGrantAuthMethodId<T>,
 >(args: {
   readonly type: T;
-  readonly authMethod: ConnectorAuthCodeGrantAuthMethodId<T>;
+  readonly authMethod: Method;
   readonly authClient: ConnectorAuthClient;
   readonly code: string;
   readonly redirectUri: string;
@@ -663,22 +674,25 @@ export async function exchangeConnectorAuthCode<
     args.type,
     args.authMethod,
   );
-  return await provider.exchangeCode({
-    ...connectorAuthProviderClientArgs(args.authClient),
-    authCodeGrant,
-    code: args.code,
-    redirectUri: args.redirectUri,
-    state: args.state,
-    codeVerifier: args.codeVerifier,
-    oauthContext: args.oauthContext,
-  } as ConnectorAuthCodeExchangeArgs<T>);
+  return await provider.exchangeCode(
+    connectorAuthProviderArgs<ConnectorAuthCodeExchangeArgs<T>>({
+      ...connectorAuthProviderClientArgs(args.authClient),
+      authCodeGrant,
+      code: args.code,
+      redirectUri: args.redirectUri,
+      state: args.state,
+      codeVerifier: args.codeVerifier,
+      oauthContext: args.oauthContext,
+    }),
+  );
 }
 
 export async function startConnectorDeviceAuthorization<
   T extends DeviceAuthGrantConnectorType,
+  Method extends ConnectorDeviceAuthGrantAuthMethodId<T>,
 >(args: {
   readonly type: T;
-  readonly authMethod: ConnectorDeviceAuthGrantAuthMethodId<T>;
+  readonly authMethod: Method;
   readonly authClient: ConnectorAuthClient;
 }): Promise<OAuthDeviceAuthStartResult> {
   const provider = connectorDeviceAuthGrantProviderFor(
@@ -689,18 +703,21 @@ export async function startConnectorDeviceAuthorization<
     args.type,
     args.authMethod,
   );
-  return await provider.startDeviceAuth({
-    ...connectorAuthProviderClientArgs(args.authClient),
-    deviceAuthGrant,
-    scopes: getConnectorAuthMethodGrantScopes(args.type, args.authMethod),
-  } as ConnectorDeviceAuthorizationStartArgs<T>);
+  return await provider.startDeviceAuth(
+    connectorAuthProviderArgs<ConnectorDeviceAuthorizationStartArgs<T>>({
+      ...connectorAuthProviderClientArgs(args.authClient),
+      deviceAuthGrant,
+      scopes: getConnectorAuthMethodGrantScopes(args.type, args.authMethod),
+    }),
+  );
 }
 
 export async function pollConnectorDeviceAuthorization<
   T extends DeviceAuthGrantConnectorType,
+  Method extends ConnectorDeviceAuthGrantAuthMethodId<T>,
 >(args: {
   readonly type: T;
-  readonly authMethod: ConnectorDeviceAuthGrantAuthMethodId<T>;
+  readonly authMethod: Method;
   readonly authClient: ConnectorAuthClient;
   readonly deviceCode: string;
 }): Promise<OAuthDeviceAuthPollResult> {
@@ -712,11 +729,13 @@ export async function pollConnectorDeviceAuthorization<
     args.type,
     args.authMethod,
   );
-  return await provider.pollDeviceAuth({
-    ...connectorAuthProviderClientArgs(args.authClient),
-    deviceAuthGrant,
-    deviceCode: args.deviceCode,
-  } as ConnectorDeviceAuthorizationPollArgs<T>);
+  return await provider.pollDeviceAuth(
+    connectorAuthProviderArgs<ConnectorDeviceAuthorizationPollArgs<T>>({
+      ...connectorAuthProviderClientArgs(args.authClient),
+      deviceAuthGrant,
+      deviceCode: args.deviceCode,
+    }),
+  );
 }
 
 export async function refreshConnectorAuthProviderAccessToken<
@@ -743,12 +762,14 @@ export async function refreshConnectorAuthProviderAccessToken<
       `${args.type} connector auth method ${args.authMethod} has no refresh-token access provider`,
     );
   }
-  return await access.refreshToken({
-    ...args.clientArgs,
-    tokenUrl: method.access.tokenUrl,
-    refreshToken: args.refreshToken,
-    signal: args.signal,
-  } as ConnectorAuthProviderRefreshArgs<T>);
+  return await access.refreshToken(
+    connectorAuthProviderArgs<ConnectorAuthProviderRefreshArgs<T>>({
+      ...args.clientArgs,
+      tokenUrl: method.access.tokenUrl,
+      refreshToken: args.refreshToken,
+      signal: args.signal,
+    }),
+  );
 }
 
 export async function revokeConnectorAuthMethodAccessToken<

--- a/turbo/packages/connectors/src/auth-providers/connector-auth.ts
+++ b/turbo/packages/connectors/src/auth-providers/connector-auth.ts
@@ -2,6 +2,8 @@ import {
   connectorTypeSchema,
   type ConnectorAuthCodeGrantAuthMethodId,
   type AuthCodeGrantConnectorType,
+  type ConnectorAuthCodeGrantConfig,
+  type ConnectorDeviceAuthGrantConfig,
   type ConnectorType,
   type ConnectorAuthProviderType,
   type ConnectorDeviceAuthGrantAuthMethodId,
@@ -331,11 +333,61 @@ function connectorAuthProviderClientArgs(
   return { clientId: authClient.clientId };
 }
 
-function connectorAuthProviderArgs<Args>(args: unknown): Args {
+function connectorAuthCodeAuthorizeProviderArgs<
+  T extends AuthCodeGrantConnectorType,
+>(
+  args: OAuthAuthorizeArgs & {
+    readonly authCodeGrant: ConnectorAuthCodeGrantConfig;
+  },
+): ConnectorAuthCodeAuthorizeArgs<T> {
   // The runtime resolver already chose the client from the selected method's
-  // config; TypeScript cannot carry that conditional credential shape through
-  // the object assembled for the provider call.
-  return args as Args;
+  // config; TypeScript cannot connect that resolved value back to the
+  // method-config conditional credential fields.
+  return args as ConnectorAuthCodeAuthorizeArgs<T>;
+}
+
+function connectorAuthCodeExchangeProviderArgs<
+  T extends AuthCodeGrantConnectorType,
+>(
+  args: OAuthExchangeArgs & {
+    readonly authCodeGrant: ConnectorAuthCodeGrantConfig;
+  },
+): ConnectorAuthCodeExchangeArgs<T> {
+  // See connectorAuthCodeAuthorizeProviderArgs.
+  return args as ConnectorAuthCodeExchangeArgs<T>;
+}
+
+function connectorDeviceAuthorizationStartProviderArgs<
+  T extends DeviceAuthGrantConnectorType,
+>(
+  args: OAuthDeviceAuthStartArgs & {
+    readonly deviceAuthGrant: ConnectorDeviceAuthGrantConfig;
+  },
+): ConnectorDeviceAuthorizationStartArgs<T> {
+  // See connectorAuthCodeAuthorizeProviderArgs.
+  return args as ConnectorDeviceAuthorizationStartArgs<T>;
+}
+
+function connectorDeviceAuthorizationPollProviderArgs<
+  T extends DeviceAuthGrantConnectorType,
+>(
+  args: OAuthDeviceAuthPollArgs & {
+    readonly deviceAuthGrant: ConnectorDeviceAuthGrantConfig;
+  },
+): ConnectorDeviceAuthorizationPollArgs<T> {
+  // See connectorAuthCodeAuthorizeProviderArgs.
+  return args as ConnectorDeviceAuthorizationPollArgs<T>;
+}
+
+function connectorRefreshTokenProviderArgs<
+  T extends RefreshTokenAccessConnectorType,
+>(
+  args: OAuthRefreshArgs & {
+    readonly tokenUrl: string;
+  },
+): ConnectorAuthProviderRefreshArgs<T> {
+  // See connectorAuthCodeAuthorizeProviderArgs.
+  return args as ConnectorAuthProviderRefreshArgs<T>;
 }
 
 export function getConnectorAuthProviderClientArgs(
@@ -644,7 +696,7 @@ export async function buildConnectorAuthCodeAuthorizationUrl<
     args.authMethod,
   );
   return await provider.buildAuthUrl(
-    connectorAuthProviderArgs<ConnectorAuthCodeAuthorizeArgs<T>>({
+    connectorAuthCodeAuthorizeProviderArgs<T>({
       ...connectorAuthProviderClientArgs(args.authClient),
       authCodeGrant,
       redirectUri: args.redirectUri,
@@ -675,7 +727,7 @@ export async function exchangeConnectorAuthCode<
     args.authMethod,
   );
   return await provider.exchangeCode(
-    connectorAuthProviderArgs<ConnectorAuthCodeExchangeArgs<T>>({
+    connectorAuthCodeExchangeProviderArgs<T>({
       ...connectorAuthProviderClientArgs(args.authClient),
       authCodeGrant,
       code: args.code,
@@ -704,7 +756,7 @@ export async function startConnectorDeviceAuthorization<
     args.authMethod,
   );
   return await provider.startDeviceAuth(
-    connectorAuthProviderArgs<ConnectorDeviceAuthorizationStartArgs<T>>({
+    connectorDeviceAuthorizationStartProviderArgs<T>({
       ...connectorAuthProviderClientArgs(args.authClient),
       deviceAuthGrant,
       scopes: getConnectorAuthMethodGrantScopes(args.type, args.authMethod),
@@ -730,7 +782,7 @@ export async function pollConnectorDeviceAuthorization<
     args.authMethod,
   );
   return await provider.pollDeviceAuth(
-    connectorAuthProviderArgs<ConnectorDeviceAuthorizationPollArgs<T>>({
+    connectorDeviceAuthorizationPollProviderArgs<T>({
       ...connectorAuthProviderClientArgs(args.authClient),
       deviceAuthGrant,
       deviceCode: args.deviceCode,
@@ -763,7 +815,7 @@ export async function refreshConnectorAuthProviderAccessToken<
     );
   }
   return await access.refreshToken(
-    connectorAuthProviderArgs<ConnectorAuthProviderRefreshArgs<T>>({
+    connectorRefreshTokenProviderArgs<T>({
       ...args.clientArgs,
       tokenUrl: method.access.tokenUrl,
       refreshToken: args.refreshToken,

--- a/turbo/packages/connectors/src/auth-providers/oauth/types.ts
+++ b/turbo/packages/connectors/src/auth-providers/oauth/types.ts
@@ -1,9 +1,13 @@
 import type {
   AuthCodeGrantConnectorType,
-  CONNECTOR_TYPES,
   ConnectorAuthCodeGrantConfig,
   ConnectorAuthClientConfig,
+  ConnectorAuthCodeGrantAuthMethodId,
   ConnectorDeviceAuthGrantConfig,
+  ConnectorDeviceAuthGrantAuthMethodId,
+  ConnectorAuthMethodClientConfig,
+  ConnectorAuthMethodIdsByAccessKind,
+  ConnectorAuthMethodIdsByRevokeKind,
   ConnectorAuthProviderType,
   DeviceAuthGrantConnectorType,
   RefreshTokenAccessConnectorType,
@@ -133,43 +137,15 @@ export type OAuthDeviceAuthPollResult =
   | OAuthDeviceAuthExpiredResult
   | OAuthDeviceAuthErrorResult;
 
-type ConnectorGrantProviderClientFor<T extends ConnectorAuthProviderType> = {
-  [Method in keyof (typeof CONNECTOR_TYPES)[T]["authMethods"]]: (typeof CONNECTOR_TYPES)[T]["authMethods"][Method] extends {
-    readonly client: infer Client;
-    readonly grant: {
-      readonly kind: "auth-code" | "device-auth";
-    };
-  }
-    ? Client
-    : never;
-}[keyof (typeof CONNECTOR_TYPES)[T]["authMethods"]] &
-  ConnectorAuthClientConfig;
-
 type ConnectorAccessProviderClientFor<
   T extends RefreshTokenAccessConnectorType,
-> = {
-  [Method in keyof (typeof CONNECTOR_TYPES)[T]["authMethods"]]: (typeof CONNECTOR_TYPES)[T]["authMethods"][Method] extends {
-    readonly client: infer Client;
-    readonly access: {
-      readonly kind: "refresh-token";
-    };
-  }
-    ? Client
-    : never;
-}[keyof (typeof CONNECTOR_TYPES)[T]["authMethods"]] &
-  ConnectorAuthClientConfig;
+  Method extends ConnectorAuthMethodIdsByAccessKind<T, "refresh-token">,
+> = ConnectorAuthMethodClientConfig<T, Method> & ConnectorAuthClientConfig;
 
-type ConnectorRevokeProviderClientFor<T extends ConnectorAuthProviderType> = {
-  [Method in keyof (typeof CONNECTOR_TYPES)[T]["authMethods"]]: (typeof CONNECTOR_TYPES)[T]["authMethods"][Method] extends {
-    readonly client: infer Client;
-    readonly revoke: {
-      readonly kind: "token-revoke";
-    };
-  }
-    ? Client
-    : never;
-}[keyof (typeof CONNECTOR_TYPES)[T]["authMethods"]] &
-  ConnectorAuthClientConfig;
+type ConnectorRevokeProviderClientFor<
+  T extends ConnectorAuthProviderType,
+  Method extends ConnectorAuthMethodIdsByRevokeKind<T, "token-revoke">,
+> = ConnectorAuthMethodClientConfig<T, Method> & ConnectorAuthClientConfig;
 
 type NoClientCredentialArgs = Record<never, never>;
 
@@ -193,40 +169,52 @@ type TokenCredentialArgs<Client extends ConnectorAuthClientConfig> =
 
 export type ConnectorAuthCodeAuthorizeArgs<
   T extends AuthCodeGrantConnectorType,
+  Method extends ConnectorAuthCodeGrantAuthMethodId<T> =
+    ConnectorAuthCodeGrantAuthMethodId<T>,
 > = OAuthAuthorizeFlowArgs &
-  StaticClientIdArgs<ConnectorGrantProviderClientFor<T>> & {
+  StaticClientIdArgs<ConnectorAuthMethodClientConfig<T, Method>> & {
     readonly authCodeGrant: ConnectorAuthCodeGrantConfig;
   };
 
 export type ConnectorAuthCodeExchangeArgs<
   T extends AuthCodeGrantConnectorType,
+  Method extends ConnectorAuthCodeGrantAuthMethodId<T> =
+    ConnectorAuthCodeGrantAuthMethodId<T>,
 > = OAuthExchangeFlowArgs &
-  TokenCredentialArgs<ConnectorGrantProviderClientFor<T>> & {
+  TokenCredentialArgs<ConnectorAuthMethodClientConfig<T, Method>> & {
     readonly authCodeGrant: ConnectorAuthCodeGrantConfig;
   };
 
 export type ConnectorAuthProviderRefreshArgs<
   T extends RefreshTokenAccessConnectorType,
+  Method extends ConnectorAuthMethodIdsByAccessKind<T, "refresh-token"> =
+    ConnectorAuthMethodIdsByAccessKind<T, "refresh-token">,
 > = OAuthRefreshFlowArgs &
-  TokenCredentialArgs<ConnectorAccessProviderClientFor<T>> & {
+  TokenCredentialArgs<ConnectorAccessProviderClientFor<T, Method>> & {
     readonly tokenUrl: string;
   };
 
 export type ConnectorAuthProviderRevokeArgs<
   T extends ConnectorAuthProviderType,
+  Method extends ConnectorAuthMethodIdsByRevokeKind<T, "token-revoke"> =
+    ConnectorAuthMethodIdsByRevokeKind<T, "token-revoke">,
 > = OAuthRevokeFlowArgs &
-  TokenCredentialArgs<ConnectorRevokeProviderClientFor<T>>;
+  TokenCredentialArgs<ConnectorRevokeProviderClientFor<T, Method>>;
 
 export type ConnectorDeviceAuthorizationStartArgs<
   T extends DeviceAuthGrantConnectorType,
+  Method extends ConnectorDeviceAuthGrantAuthMethodId<T> =
+    ConnectorDeviceAuthGrantAuthMethodId<T>,
 > = OAuthDeviceAuthStartFlowArgs &
-  StaticClientIdArgs<ConnectorGrantProviderClientFor<T>> & {
+  StaticClientIdArgs<ConnectorAuthMethodClientConfig<T, Method>> & {
     readonly deviceAuthGrant: ConnectorDeviceAuthGrantConfig;
   };
 
 export type ConnectorDeviceAuthorizationPollArgs<
   T extends DeviceAuthGrantConnectorType,
+  Method extends ConnectorDeviceAuthGrantAuthMethodId<T> =
+    ConnectorDeviceAuthGrantAuthMethodId<T>,
 > = OAuthDeviceAuthPollFlowArgs &
-  TokenCredentialArgs<ConnectorGrantProviderClientFor<T>> & {
+  TokenCredentialArgs<ConnectorAuthMethodClientConfig<T, Method>> & {
     readonly deviceAuthGrant: ConnectorDeviceAuthGrantConfig;
   };

--- a/turbo/packages/connectors/src/auth-providers/types.ts
+++ b/turbo/packages/connectors/src/auth-providers/types.ts
@@ -1,5 +1,8 @@
 import type {
   AuthCodeGrantConnectorType,
+  ConnectorAuthCodeGrantAuthMethodId,
+  ConnectorAuthMethodIdsByAccessKind,
+  ConnectorDeviceAuthGrantAuthMethodId,
   ConnectorAuthProviderType,
   ConnectorType,
   DeviceAuthGrantConnectorType,
@@ -25,25 +28,31 @@ interface NoneGrantProvider {
   readonly kind: "none";
 }
 
-export interface AuthCodeGrantProvider<T extends AuthCodeGrantConnectorType> {
+export interface AuthCodeGrantProvider<
+  T extends AuthCodeGrantConnectorType,
+  Method extends ConnectorAuthCodeGrantAuthMethodId<T> =
+    ConnectorAuthCodeGrantAuthMethodId<T>,
+> {
   readonly kind: "auth-code";
   buildAuthUrl(
-    args: ConnectorAuthCodeAuthorizeArgs<T>,
+    args: ConnectorAuthCodeAuthorizeArgs<T, Method>,
   ): string | AuthUrlResult | Promise<string | AuthUrlResult>;
   exchangeCode(
-    args: ConnectorAuthCodeExchangeArgs<T>,
+    args: ConnectorAuthCodeExchangeArgs<T, Method>,
   ): Promise<OAuthTokenResult>;
 }
 
 export interface DeviceAuthGrantProvider<
   T extends DeviceAuthGrantConnectorType,
+  Method extends ConnectorDeviceAuthGrantAuthMethodId<T> =
+    ConnectorDeviceAuthGrantAuthMethodId<T>,
 > {
   readonly kind: "device-auth";
   startDeviceAuth(
-    args: ConnectorDeviceAuthorizationStartArgs<T>,
+    args: ConnectorDeviceAuthorizationStartArgs<T, Method>,
   ): Promise<OAuthDeviceAuthStartResult>;
   pollDeviceAuth(
-    args: ConnectorDeviceAuthorizationPollArgs<T>,
+    args: ConnectorDeviceAuthorizationPollArgs<T, Method>,
   ): Promise<OAuthDeviceAuthPollResult>;
 }
 
@@ -54,12 +63,14 @@ export interface NoneAccessProvider {
 
 export interface RefreshTokenAccessProvider<
   T extends RefreshTokenAccessConnectorType,
+  Method extends ConnectorAuthMethodIdsByAccessKind<T, "refresh-token"> =
+    ConnectorAuthMethodIdsByAccessKind<T, "refresh-token">,
 > {
   readonly kind: "refresh-token";
   getAccessSecretName(): string;
   getRefreshSecretName(): string;
   refreshToken(
-    args: ConnectorAuthProviderRefreshArgs<T>,
+    args: ConnectorAuthProviderRefreshArgs<T, Method>,
   ): Promise<OAuthRefreshResult>;
 }
 
@@ -90,16 +101,20 @@ export interface AuthProvider<TGrant, TAccess, TRevoke> {
 
 export type AuthCodeConnectorAuthProvider<
   T extends AuthCodeGrantConnectorType,
+  Method extends ConnectorAuthCodeGrantAuthMethodId<T> =
+    ConnectorAuthCodeGrantAuthMethodId<T>,
 > = AuthProvider<
-  AuthCodeGrantProvider<T>,
+  AuthCodeGrantProvider<T, Method>,
   ConnectorAuthProviderAccess<T>,
   ConnectorAuthProviderRevoke<T>
 >;
 
 export type DeviceAuthConnectorAuthProvider<
   T extends DeviceAuthGrantConnectorType,
+  Method extends ConnectorDeviceAuthGrantAuthMethodId<T> =
+    ConnectorDeviceAuthGrantAuthMethodId<T>,
 > = AuthProvider<
-  DeviceAuthGrantProvider<T>,
+  DeviceAuthGrantProvider<T, Method>,
   ConnectorAuthProviderAccess<T>,
   ConnectorAuthProviderRevoke<T>
 >;


### PR DESCRIPTION
## Summary

- Make connector auth provider argument types generic over the selected auth method client config.
- Thread those method-aware argument types through grant/access provider interfaces while keeping runtime provider behavior unchanged.
- Replace the five scattered provider-call casts in `connector-auth.ts` with narrow per-flow provider-args builders for the TypeScript runtime-client credential-shape limitation.

The original provider-map assertions mentioned in #15501 were already removed on current `main`; this PR handles the remaining provider invocation argument casts.

Closes #15501.

## Tests

- `pnpm -F @vm0/connectors check-types`
- `pnpm -F @vm0/connectors lint`
- `pnpm -F @vm0/connectors test`
- `pnpm -F api check-types`
- pre-commit: `turbo run check-types --concurrency=1`
