### PR TITLE
fix(api): handle duplicate client message ids

### DIFF
--- a/turbo/apps/api/src/signals/routes/__tests__/zero-chat-messages.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/zero-chat-messages.test.ts
@@ -1194,6 +1194,55 @@ describe("POST /api/zero/chat/messages", () => {
     expect(messages).toStrictEqual([]);
   });
 
+  it("rejects clientMessageId reuse from a queued recall message", async () => {
+    const fixture = await track(seedFixture());
+    const first = await send({ agentId: fixture.agentId, prompt: "first" });
+    await clearAllDetached();
+    await send({
+      agentId: fixture.agentId,
+      prompt: "queued for recall",
+      threadId: first.body.threadId,
+    });
+
+    const [queued] = await store
+      .set(writeDb$)
+      .select({ id: chatMessages.id })
+      .from(chatMessages)
+      .where(
+        and(
+          eq(chatMessages.chatThreadId, first.body.threadId),
+          eq(chatMessages.content, "queued for recall"),
+          isNull(chatMessages.runId),
+        ),
+      )
+      .limit(1);
+    const recallClientMessageId = randomUUID();
+    await send({
+      agentId: fixture.agentId,
+      threadId: first.body.threadId,
+      revokesMessageId: queued!.id,
+      clientMessageId: recallClientMessageId,
+    });
+
+    const response = await accept(
+      client().send({
+        headers: authHeaders(),
+        body: {
+          agentId: fixture.agentId,
+          prompt: "normal retry with recall id",
+          threadId: first.body.threadId,
+          clientMessageId: recallClientMessageId,
+        },
+      }),
+      [409],
+    );
+
+    expect(response.body.error).toStrictEqual({
+      code: "CONFLICT",
+      message: "clientMessageId is already in use",
+    });
+  });
+
   it("creates a follow-up run on an existing thread and continues the last session", async () => {
     const fixture = await track(seedFixture());
     const first = await send({ agentId: fixture.agentId, prompt: "first" });

--- a/turbo/apps/api/src/signals/routes/__tests__/zero-chat-messages.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/zero-chat-messages.test.ts
@@ -1054,6 +1054,146 @@ describe("POST /api/zero/chat/messages", () => {
     });
   });
 
+  it("returns the existing queued user message for duplicate clientMessageId retries", async () => {
+    const fixture = await track(seedFixture());
+    const first = await send({ agentId: fixture.agentId, prompt: "first" });
+    await clearAllDetached();
+
+    const clientMessageId = randomUUID();
+    const queued = await send({
+      agentId: fixture.agentId,
+      prompt: "queued once",
+      threadId: first.body.threadId,
+      clientMessageId,
+    });
+    const retry = await send({
+      agentId: fixture.agentId,
+      prompt: "queued once",
+      threadId: first.body.threadId,
+      clientMessageId,
+    });
+
+    expect(queued.body.runId).toBeNull();
+    expect(retry.body).toStrictEqual(queued.body);
+    const messages = await store
+      .set(writeDb$)
+      .select({
+        id: chatMessages.id,
+        content: chatMessages.content,
+        runId: chatMessages.runId,
+      })
+      .from(chatMessages)
+      .where(eq(chatMessages.id, clientMessageId));
+    expect(messages).toStrictEqual([
+      {
+        id: clientMessageId,
+        content: "queued once",
+        runId: null,
+      },
+    ]);
+  });
+
+  it("returns the existing associated run for duplicate clientMessageId retries", async () => {
+    const fixture = await track(seedFixture());
+    const clientMessageId = randomUUID();
+    const first = await send({
+      agentId: fixture.agentId,
+      prompt: "first with client id",
+      clientMessageId,
+    });
+    await clearAllDetached();
+
+    const activeRetry = await send({
+      agentId: fixture.agentId,
+      prompt: "first with client id",
+      threadId: first.body.threadId,
+      clientMessageId,
+    });
+    expect(activeRetry.body).toStrictEqual(first.body);
+
+    await setRunStatus(first.body.runId!, "completed");
+    const completedRetry = await send({
+      agentId: fixture.agentId,
+      prompt: "first with client id",
+      threadId: first.body.threadId,
+      clientMessageId,
+    });
+    expect(completedRetry.body).toStrictEqual({
+      ...first.body,
+      status: "completed",
+    });
+
+    const writeDb = store.set(writeDb$);
+    const messages = await writeDb
+      .select({
+        id: chatMessages.id,
+        content: chatMessages.content,
+        runId: chatMessages.runId,
+      })
+      .from(chatMessages)
+      .where(eq(chatMessages.id, clientMessageId));
+    expect(messages).toStrictEqual([
+      {
+        id: clientMessageId,
+        content: "first with client id",
+        runId: first.body.runId,
+      },
+    ]);
+
+    const runs = await writeDb
+      .select({ id: agentRuns.id })
+      .from(agentRuns)
+      .where(eq(agentRuns.userId, fixture.userId));
+    expect(runs).toStrictEqual([{ id: first.body.runId }]);
+  });
+
+  it("rejects clientMessageId reuse from another user without leaking ownership", async () => {
+    const ownerFixture = await track(seedFixture());
+    const clientMessageId = randomUUID();
+    await send({
+      agentId: ownerFixture.agentId,
+      prompt: "owned message",
+      clientMessageId,
+    });
+    await clearAllDetached();
+
+    const otherFixture = await track(seedFixture());
+    const active = await send({
+      agentId: otherFixture.agentId,
+      prompt: "other active run",
+    });
+    await clearAllDetached();
+
+    const response = await accept(
+      client().send({
+        headers: authHeaders(),
+        body: {
+          agentId: otherFixture.agentId,
+          prompt: "cross-user retry",
+          threadId: active.body.threadId,
+          clientMessageId,
+        },
+      }),
+      [409],
+    );
+
+    expect(response.body.error).toStrictEqual({
+      code: "CONFLICT",
+      message: "clientMessageId is already in use",
+    });
+    const messages = await store
+      .set(writeDb$)
+      .select({ id: chatMessages.id })
+      .from(chatMessages)
+      .where(
+        and(
+          eq(chatMessages.chatThreadId, active.body.threadId),
+          eq(chatMessages.content, "cross-user retry"),
+        ),
+      );
+    expect(messages).toStrictEqual([]);
+  });
+
   it("creates a follow-up run on an existing thread and continues the last session", async () => {
     const fixture = await track(seedFixture());
     const first = await send({ agentId: fixture.agentId, prompt: "first" });

--- a/turbo/apps/api/src/signals/routes/zero-chat-messages.ts
+++ b/turbo/apps/api/src/signals/routes/zero-chat-messages.ts
@@ -37,7 +37,12 @@ import {
   publishUserSignal,
 } from "../external/realtime";
 import { now, nowDate } from "../external/time";
-import { badRequestMessage, notFound, providerDeleted } from "../../lib/error";
+import {
+  badRequestMessage,
+  conflict,
+  notFound,
+  providerDeleted,
+} from "../../lib/error";
 import { env } from "../../lib/env";
 import { buildArtifactKey } from "../../lib/file-url";
 import type { AuthContext } from "../../types/auth";
@@ -176,6 +181,7 @@ type NormalSendFailure =
   | ReturnType<typeof notFound>
   | ReturnType<typeof providerDeleted>
   | ReturnType<typeof forbidden>
+  | ReturnType<typeof conflict>
   | ReturnType<typeof badRequestMessage>;
 
 interface CreatedChatMessageResponse {
@@ -190,7 +196,7 @@ interface CreatedChatMessageResponse {
 
 type ClientSendResolution =
   | CreatedChatMessageResponse
-  | ReturnType<typeof badRequestMessage>;
+  | ReturnType<typeof conflict>;
 
 type CreateChatThreadResult =
   | {
@@ -209,6 +215,35 @@ type AppendMessageResult =
       readonly message: string;
     };
 
+type ClientMessageIdResolution =
+  | {
+      readonly kind: "available";
+    }
+  | {
+      readonly kind: "queued";
+      readonly createdAt: Date;
+      readonly inserted: boolean;
+    }
+  | {
+      readonly kind: "associated";
+      readonly runId: string;
+      readonly status: string;
+      readonly createdAt: Date;
+    }
+  | {
+      readonly kind: "conflict";
+    };
+
+interface ExistingClientMessageIdRow {
+  readonly chatThreadId: string;
+  readonly threadUserId: string;
+  readonly role: string;
+  readonly runId: string | null;
+  readonly messageCreatedAt: Date;
+  readonly runStatus: string | null;
+  readonly runCreatedAt: Date | null;
+}
+
 const sendBody$ = bodyResultOf(chatMessagesContract.send);
 // Existing web chat threads carry a small recent-run window in the system
 // prompt. Session compatibility is handled separately by forceNewSession.
@@ -221,6 +256,105 @@ function forbidden(message: string) {
   return {
     status: 403 as const,
     body: { error: { message, code: "FORBIDDEN" as const } },
+  };
+}
+
+function duplicateClientMessageIdResponse() {
+  return conflict("clientMessageId is already in use");
+}
+
+function resolveExistingClientMessageIdRow(
+  row: ExistingClientMessageIdRow | undefined,
+  params: {
+    readonly threadId: string;
+    readonly userId: string;
+  },
+): ClientMessageIdResolution {
+  if (!row) {
+    return { kind: "available" };
+  }
+  if (
+    row.chatThreadId !== params.threadId ||
+    row.threadUserId !== params.userId ||
+    row.role !== "user"
+  ) {
+    return { kind: "conflict" };
+  }
+  if (row.runId === null) {
+    return {
+      kind: "queued",
+      createdAt: row.messageCreatedAt,
+      inserted: false,
+    };
+  }
+  if (!row.runCreatedAt || !row.runStatus) {
+    return { kind: "conflict" };
+  }
+  return {
+    kind: "associated",
+    runId: row.runId,
+    status: row.runStatus,
+    createdAt: row.runCreatedAt,
+  };
+}
+
+async function resolveClientMessageId(
+  db: Db,
+  params: {
+    readonly clientMessageId: string;
+    readonly threadId: string;
+    readonly userId: string;
+  },
+): Promise<ClientMessageIdResolution> {
+  const [message] = await db
+    .select({
+      chatThreadId: chatMessages.chatThreadId,
+      threadUserId: chatThreads.userId,
+      role: chatMessages.role,
+      runId: chatMessages.runId,
+      messageCreatedAt: chatMessages.createdAt,
+      runStatus: agentRuns.status,
+      runCreatedAt: agentRuns.createdAt,
+    })
+    .from(chatMessages)
+    .innerJoin(chatThreads, eq(chatThreads.id, chatMessages.chatThreadId))
+    .leftJoin(agentRuns, eq(agentRuns.id, chatMessages.runId))
+    .where(eq(chatMessages.id, params.clientMessageId))
+    .limit(1);
+  return resolveExistingClientMessageIdRow(message, params);
+}
+
+function clientMessageIdResolutionResponse(
+  resolution: ClientMessageIdResolution,
+  threadId: string,
+):
+  | CreatedChatMessageResponse
+  | ReturnType<typeof duplicateClientMessageIdResponse>
+  | undefined {
+  if (resolution.kind === "available") {
+    return undefined;
+  }
+  if (resolution.kind === "conflict") {
+    return duplicateClientMessageIdResponse();
+  }
+  if (resolution.kind === "associated") {
+    return {
+      status: 201,
+      body: {
+        runId: resolution.runId,
+        threadId,
+        status: resolution.status,
+        createdAt: resolution.createdAt.toISOString(),
+      },
+    };
+  }
+  return {
+    status: 201,
+    body: {
+      runId: null,
+      threadId,
+      createdAt: resolution.createdAt.toISOString(),
+    },
   };
 }
 
@@ -727,44 +861,12 @@ async function resolveClientMessageSend(params: {
   if (!params.clientMessageId) {
     return undefined;
   }
-
-  const [message] = await params.db
-    .select({
-      chatThreadId: chatMessages.chatThreadId,
-      role: chatMessages.role,
-      runId: chatMessages.runId,
-      messageCreatedAt: chatMessages.createdAt,
-      threadUserId: chatThreads.userId,
-      runStatus: agentRuns.status,
-      runCreatedAt: agentRuns.createdAt,
-    })
-    .from(chatMessages)
-    .innerJoin(chatThreads, eq(chatThreads.id, chatMessages.chatThreadId))
-    .leftJoin(agentRuns, eq(agentRuns.id, chatMessages.runId))
-    .where(eq(chatMessages.id, params.clientMessageId))
-    .limit(1);
-  if (!message) {
-    return undefined;
-  }
-
-  if (
-    message.chatThreadId !== params.threadId ||
-    message.threadUserId !== params.userId ||
-    message.role !== "user"
-  ) {
-    return badRequestMessage("Client message id is already in use");
-  }
-
-  const createdAt = message.runCreatedAt ?? message.messageCreatedAt;
-  return {
-    status: 201,
-    body: {
-      runId: message.runId,
-      threadId: params.threadId,
-      ...(message.runStatus ? { status: message.runStatus } : {}),
-      createdAt: createdAt.toISOString(),
-    },
-  };
+  const resolution = await resolveClientMessageId(params.db, {
+    clientMessageId: params.clientMessageId,
+    threadId: params.threadId,
+    userId: params.userId,
+  });
+  return clientMessageIdResolutionResponse(resolution, params.threadId);
 }
 
 async function resolveClientThreadRetryRun(
@@ -1231,7 +1333,7 @@ function appendUnassociatedUserMessage(params: {
   readonly prompt: string;
   readonly attachFiles: readonly AttachFile[] | undefined;
   readonly clientMessageId: string | undefined;
-}): Promise<{ readonly createdAt: Date }> {
+}): Promise<ClientMessageIdResolution> {
   return params.db.transaction(async (tx) => {
     await tx
       .update(chatThreads)
@@ -1261,29 +1363,31 @@ function appendUnassociatedUserMessage(params: {
       .returning({ createdAt: chatMessages.createdAt });
     if (inserted) {
       await touchChatThreadLastMessageAt(tx, params.threadId);
-      return inserted;
+      return { kind: "queued", createdAt: inserted.createdAt, inserted: true };
     }
     if (!explicitId) {
       throw new Error("Failed to insert unassociated user message");
     }
     const [existing] = await tx
-      .select({ createdAt: chatMessages.createdAt })
+      .select({
+        chatThreadId: chatMessages.chatThreadId,
+        threadUserId: chatThreads.userId,
+        role: chatMessages.role,
+        runId: chatMessages.runId,
+        messageCreatedAt: chatMessages.createdAt,
+        runStatus: agentRuns.status,
+        runCreatedAt: agentRuns.createdAt,
+      })
       .from(chatMessages)
       .innerJoin(chatThreads, eq(chatThreads.id, chatMessages.chatThreadId))
-      .where(
-        and(
-          eq(chatMessages.id, explicitId),
-          eq(chatMessages.chatThreadId, params.threadId),
-          eq(chatThreads.userId, params.userId),
-          eq(chatMessages.role, "user"),
-          isNull(chatMessages.runId),
-        ),
-      )
+      .leftJoin(agentRuns, eq(agentRuns.id, chatMessages.runId))
+      .where(eq(chatMessages.id, explicitId))
       .limit(1);
-    if (!existing) {
-      throw new Error("Failed to resolve unassociated user message");
-    }
-    return existing;
+    const resolution = resolveExistingClientMessageIdRow(existing, {
+      threadId: params.threadId,
+      userId: params.userId,
+    });
+    return resolution.kind === "available" ? { kind: "conflict" } : resolution;
   });
 }
 
@@ -1725,7 +1829,10 @@ async function queueUnassociatedNormalMessage(params: {
   readonly prepared: PreparedNormalSend;
   readonly body: NormalSendBody;
   readonly userId: string;
-}): Promise<CreatedChatMessageResponse> {
+}): Promise<
+  | CreatedChatMessageResponse
+  | ReturnType<typeof duplicateClientMessageIdResponse>
+> {
   const message = await appendUnassociatedUserMessage({
     db: params.prepared.db,
     threadId: params.prepared.thread.threadId,
@@ -1734,18 +1841,20 @@ async function queueUnassociatedNormalMessage(params: {
     attachFiles: params.body.attachFiles,
     clientMessageId: params.body.clientMessageId,
   });
-  await publishChatMessageCreated(
-    params.userId,
+  if (message.kind === "queued" && message.inserted) {
+    await publishChatMessageCreated(
+      params.userId,
+      params.prepared.thread.threadId,
+    );
+  }
+  const response = clientMessageIdResolutionResponse(
+    message,
     params.prepared.thread.threadId,
   );
-  return {
-    status: 201,
-    body: {
-      runId: null,
-      threadId: params.prepared.thread.threadId,
-      createdAt: message.createdAt.toISOString(),
-    },
-  };
+  if (!response) {
+    return duplicateClientMessageIdResponse();
+  }
+  return response;
 }
 
 function scheduleChatTitleGeneration(params: {

--- a/turbo/apps/api/src/signals/routes/zero-chat-messages.ts
+++ b/turbo/apps/api/src/signals/routes/zero-chat-messages.ts
@@ -239,6 +239,8 @@ interface ExistingClientMessageIdRow {
   readonly threadUserId: string;
   readonly role: string;
   readonly runId: string | null;
+  readonly revokesMessageId: string | null;
+  readonly interruptsRunId: string | null;
   readonly messageCreatedAt: Date;
   readonly runStatus: string | null;
   readonly runCreatedAt: Date | null;
@@ -276,7 +278,9 @@ function resolveExistingClientMessageIdRow(
   if (
     row.chatThreadId !== params.threadId ||
     row.threadUserId !== params.userId ||
-    row.role !== "user"
+    row.role !== "user" ||
+    row.revokesMessageId !== null ||
+    row.interruptsRunId !== null
   ) {
     return { kind: "conflict" };
   }
@@ -312,6 +316,8 @@ async function resolveClientMessageId(
       threadUserId: chatThreads.userId,
       role: chatMessages.role,
       runId: chatMessages.runId,
+      revokesMessageId: chatMessages.revokesMessageId,
+      interruptsRunId: chatMessages.interruptsRunId,
       messageCreatedAt: chatMessages.createdAt,
       runStatus: agentRuns.status,
       runCreatedAt: agentRuns.createdAt,
@@ -1374,6 +1380,8 @@ function appendUnassociatedUserMessage(params: {
         threadUserId: chatThreads.userId,
         role: chatMessages.role,
         runId: chatMessages.runId,
+        revokesMessageId: chatMessages.revokesMessageId,
+        interruptsRunId: chatMessages.interruptsRunId,
         messageCreatedAt: chatMessages.createdAt,
         runStatus: agentRuns.status,
         runCreatedAt: agentRuns.createdAt,

--- a/turbo/packages/api-contracts/src/contracts/chat-threads.ts
+++ b/turbo/packages/api-contracts/src/contracts/chat-threads.ts
@@ -526,6 +526,7 @@ export const chatMessagesContract = c.router({
       402: apiErrorSchema,
       403: apiErrorSchema,
       404: apiErrorSchema,
+      409: apiErrorSchema,
       422: apiErrorSchema,
     },
     summary: "Send a chat message (create thread + run + association)",


### PR DESCRIPTION
## Summary

- handle duplicate `clientMessageId` retries before creating or queueing chat messages
- return existing queued messages and associated runs idempotently
- return a controlled 409 conflict when a duplicate message id belongs to another owner/scope
- add API route integration coverage for queued, associated, and cross-user duplicate cases

Closes #15616

## Test plan

- `pnpm -F @vm0/db db:migrate`
- `pnpm -F api exec vitest run src/signals/routes/__tests__/zero-chat-messages.test.ts`
- `pnpm -F api check-types`
- `pnpm -F @vm0/api-contracts check-types`
- `pnpm -F api lint`
- `pnpm -F @vm0/api-contracts lint`
- `pnpm exec prettier --check apps/api/src/signals/routes/zero-chat-messages.ts apps/api/src/signals/routes/__tests__/zero-chat-messages.test.ts packages/api-contracts/src/contracts/chat-threads.ts`
- `git diff --check`
