### PR TITLE
fix: gate desktop runtime startup

### DIFF
--- a/turbo/apps/desktop/src/computer-use-host.ts
+++ b/turbo/apps/desktop/src/computer-use-host.ts
@@ -10,6 +10,10 @@ import type {
   ComputerUsePermissionState,
   ComputerUseRuntimeAuditEvent,
 } from "./computer-use-types";
+import {
+  COMPUTER_USE_NEEDS_ORGANIZATION_MESSAGE,
+  COMPUTER_USE_UNAUTHENTICATED_MESSAGE,
+} from "./computer-use-startup-gate";
 
 const ONLINE_POLL_MS = 2_000;
 const AUTH_ME_PATH = "/api/auth/me";
@@ -274,14 +278,12 @@ export class ComputerUseHostRuntime {
       if (await this.hasAuthenticatedSession()) {
         this.setState({
           status: "needs_organization",
-          lastError:
-            "Zero Desktop is signed in but no workspace is active. Select a workspace and retry.",
+          lastError: COMPUTER_USE_NEEDS_ORGANIZATION_MESSAGE,
         });
       } else {
         this.setState({
           status: "unauthenticated",
-          lastError:
-            "Desktop host could not authenticate with the API session. Sign in and retry.",
+          lastError: COMPUTER_USE_UNAUTHENTICATED_MESSAGE,
         });
       }
       return null;
@@ -337,8 +339,7 @@ export class ComputerUseHostRuntime {
       this.setState({
         status: "unauthenticated",
         hostId: null,
-        lastError:
-          "Desktop host could not authenticate with the API session. Sign in and retry.",
+        lastError: COMPUTER_USE_UNAUTHENTICATED_MESSAGE,
       });
       return false;
     }

--- a/turbo/apps/desktop/src/computer-use-startup-gate.test.ts
+++ b/turbo/apps/desktop/src/computer-use-startup-gate.test.ts
@@ -1,0 +1,92 @@
+import { describe, expect, it } from "vitest";
+import type { DesktopAuthState } from "./desktop-bridge";
+import {
+  COMPUTER_USE_NEEDS_ORGANIZATION_MESSAGE,
+  COMPUTER_USE_UNAUTHENTICATED_MESSAGE,
+  hasReadyDesktopAuth,
+  resolveComputerUseStartupGate,
+} from "./computer-use-startup-gate";
+import type { ComputerUsePermissionState } from "./computer-use-types";
+
+const grantedPermissions: ComputerUsePermissionState = {
+  accessibility: true,
+  screenRecording: true,
+};
+
+const signedOutAuth: DesktopAuthState = {
+  status: "signed_out",
+  user: null,
+  organization: null,
+};
+
+const signedInAuth: DesktopAuthState = {
+  status: "signed_in",
+  user: { userId: "user-1", email: "user@example.com" },
+  organization: { id: "org-1", name: "Org One", slug: "org-one" },
+};
+
+describe("hasReadyDesktopAuth", () => {
+  it("requires a signed-in user with an active organization", () => {
+    expect(hasReadyDesktopAuth(null)).toBe(false);
+    expect(hasReadyDesktopAuth(signedOutAuth)).toBe(false);
+    expect(hasReadyDesktopAuth({ ...signedInAuth, organization: null })).toBe(
+      false,
+    );
+    expect(hasReadyDesktopAuth(signedInAuth)).toBe(true);
+  });
+});
+
+describe("resolveComputerUseStartupGate", () => {
+  it("blocks startup before host registration when signed out", () => {
+    const gate = resolveComputerUseStartupGate({
+      authState: signedOutAuth,
+      permissions: grantedPermissions,
+    });
+
+    expect(gate).toEqual({
+      status: "blocked",
+      host: {
+        status: "unauthenticated",
+        hostId: null,
+        lastHeartbeatAt: null,
+        lastCommandAt: null,
+        lastError: COMPUTER_USE_UNAUTHENTICATED_MESSAGE,
+        recentAuditEvents: [],
+        localCommandLog: [],
+      },
+    });
+  });
+
+  it("blocks startup before host registration when no organization is active", () => {
+    const gate = resolveComputerUseStartupGate({
+      authState: { ...signedInAuth, organization: null },
+      permissions: grantedPermissions,
+    });
+
+    expect(gate).toMatchObject({
+      status: "blocked",
+      host: {
+        status: "needs_organization",
+        lastError: COMPUTER_USE_NEEDS_ORGANIZATION_MESSAGE,
+      },
+    });
+  });
+
+  it("blocks startup when required local permissions are missing", () => {
+    expect(
+      resolveComputerUseStartupGate({
+        authState: signedInAuth,
+        permissions: { accessibility: true, screenRecording: false },
+      }),
+    ).toEqual({ status: "missing_permissions" });
+  });
+
+  it("allows startup only when auth and local permissions are ready", () => {
+    expect(
+      resolveComputerUseStartupGate({
+        authState: signedInAuth,
+        permissions: grantedPermissions,
+      }),
+    ).toEqual({ status: "ready" });
+  });
+});

--- a/turbo/apps/desktop/src/computer-use-startup-gate.ts
+++ b/turbo/apps/desktop/src/computer-use-startup-gate.ts
@@ -1,0 +1,64 @@
+import type { DesktopAuthState } from "./desktop-bridge";
+import {
+  IDLE_COMPUTER_USE_HOST_STATE,
+  hasRequiredComputerUsePermissions,
+  type ComputerUseHostRuntimeState,
+  type ComputerUsePermissionState,
+} from "./computer-use-types";
+
+export const COMPUTER_USE_UNAUTHENTICATED_MESSAGE =
+  "Desktop host could not authenticate with the API session. Sign in and retry.";
+
+export const COMPUTER_USE_NEEDS_ORGANIZATION_MESSAGE =
+  "Zero Desktop is signed in but no workspace is active. Select a workspace and retry.";
+
+export type ComputerUseStartupGate =
+  | {
+      readonly status: "ready";
+    }
+  | {
+      readonly status: "missing_permissions";
+    }
+  | {
+      readonly status: "blocked";
+      readonly host: ComputerUseHostRuntimeState;
+    };
+
+export function hasReadyDesktopAuth(
+  authState: DesktopAuthState | null,
+): boolean {
+  return authState?.status === "signed_in" && authState.organization !== null;
+}
+
+export function resolveComputerUseStartupGate(args: {
+  readonly authState: DesktopAuthState;
+  readonly permissions: ComputerUsePermissionState;
+}): ComputerUseStartupGate {
+  if (!hasRequiredComputerUsePermissions(args.permissions)) {
+    return { status: "missing_permissions" };
+  }
+
+  if (args.authState.status === "signed_out") {
+    return {
+      status: "blocked",
+      host: {
+        ...IDLE_COMPUTER_USE_HOST_STATE,
+        status: "unauthenticated",
+        lastError: COMPUTER_USE_UNAUTHENTICATED_MESSAGE,
+      },
+    };
+  }
+
+  if (!args.authState.organization) {
+    return {
+      status: "blocked",
+      host: {
+        ...IDLE_COMPUTER_USE_HOST_STATE,
+        status: "needs_organization",
+        lastError: COMPUTER_USE_NEEDS_ORGANIZATION_MESSAGE,
+      },
+    };
+  }
+
+  return { status: "ready" };
+}

--- a/turbo/apps/desktop/src/main.ts
+++ b/turbo/apps/desktop/src/main.ts
@@ -25,8 +25,13 @@ import {
   COMPUTER_USE_FEATURE_SWITCH_KEY,
   IDLE_COMPUTER_USE_HOST_STATE,
   hasRequiredComputerUsePermissions,
+  type ComputerUseHostRuntimeState,
   type DesktopComputerUseState,
 } from "./computer-use-types";
+import {
+  resolveComputerUseStartupGate,
+  type ComputerUseStartupGate,
+} from "./computer-use-startup-gate";
 import {
   getComputerUsePermissionState,
   refreshComputerUsePermissionState,
@@ -87,6 +92,7 @@ let appIsQuitting = false;
 let computerUseQuitStopStarted = false;
 const desktopAuthStartGate = createDesktopAuthStartGate();
 let computerUseRuntime: ComputerUseHostRuntime | null = null;
+let computerUseBlockedHostState: ComputerUseHostRuntimeState | null = null;
 const computerUseSnapshotStore = new ComputerUseSnapshotStore();
 const computerUseNativeBackend = createComputerUseNativeBackend();
 setComputerUsePermissionNativeBackend(computerUseNativeBackend);
@@ -195,12 +201,33 @@ function getComputerUseBridgeState(): DesktopComputerUseState {
     platform: process.platform,
     supported: process.platform === "darwin",
     permissions: getComputerUsePermissionState(),
-    host: computerUseRuntime?.getState() ?? IDLE_COMPUTER_USE_HOST_STATE,
+    host:
+      computerUseRuntime?.getState() ??
+      computerUseBlockedHostState ??
+      IDLE_COMPUTER_USE_HOST_STATE,
   };
 }
 
 async function startComputerUseRuntime(): Promise<DesktopComputerUseState> {
+  const permissions = await refreshComputerUsePermissionState();
+  let startupGate: ComputerUseStartupGate = { status: "missing_permissions" };
+  if (hasRequiredComputerUsePermissions(permissions)) {
+    const authState = await getAuthSession().getAuthState();
+    startupGate = resolveComputerUseStartupGate({ authState, permissions });
+  }
+  if (startupGate.status !== "ready") {
+    if (computerUseRuntime) {
+      await computerUseRuntime.stop();
+      computerUseRuntime = null;
+    }
+    computerUseBlockedHostState =
+      startupGate.status === "blocked" ? startupGate.host : null;
+    notifyDesktopComputerUseChanged();
+    return getComputerUseBridgeState();
+  }
+
   const desktopSession = session.fromPartition(config.sessionPartition);
+  computerUseBlockedHostState = null;
   if (!computerUseRuntime) {
     computerUseRuntime = new ComputerUseHostRuntime({
       platformUrl: config.platformUrl,
@@ -241,7 +268,10 @@ async function requestComputerUseScreenRecording(): Promise<DesktopComputerUseSt
 }
 
 async function refreshComputerUsePermissions(): Promise<DesktopComputerUseState> {
-  await refreshComputerUsePermissionState();
+  const permissions = await refreshComputerUsePermissionState();
+  if (!hasRequiredComputerUsePermissions(permissions)) {
+    computerUseBlockedHostState = null;
+  }
   notifyDesktopComputerUseChanged();
   return getComputerUseBridgeState();
 }
@@ -590,8 +620,10 @@ function waitForAuthConsumeWindow(window: BrowserWindow): Promise<void> {
 }
 
 async function maybeStartComputerUseAfterAuth(): Promise<void> {
-  computerUseRuntime?.stop();
+  const runtime = computerUseRuntime;
   computerUseRuntime = null;
+  computerUseBlockedHostState = null;
+  await runtime?.stop();
   notifyDesktopAuthChanged();
   notifyDesktopComputerUseChanged();
   const permissions = await refreshComputerUsePermissionState();

--- a/turbo/apps/desktop/src/renderer/App.tsx
+++ b/turbo/apps/desktop/src/renderer/App.tsx
@@ -20,6 +20,7 @@ import {
 import { useLastLoadable, useSet } from "ccstate-react";
 import { useLoadableSet } from "ccstate-react/experimental";
 import type { DesktopAuthState } from "../desktop-bridge";
+import { hasReadyDesktopAuth } from "../computer-use-startup-gate";
 import type { DesktopComputerUseState } from "../computer-use-types";
 import {
   computerUseData$,
@@ -88,14 +89,16 @@ function BridgeSubscription() {
 }
 
 function AutoStartRuntime({
+  authState,
   state,
 }: {
+  readonly authState: DesktopAuthState | null;
   readonly state: DesktopComputerUseState;
 }) {
   const maybeAutoStart = useSet(maybeAutoStartComputerUse$);
   useEffect(() => {
-    void maybeAutoStart(state);
-  }, [maybeAutoStart, state]);
+    void maybeAutoStart(state, authState);
+  }, [authState, maybeAutoStart, state]);
   return null;
 }
 
@@ -411,7 +414,15 @@ function PermissionsPanel({
   );
 }
 
-function RuntimePanel({ state }: { readonly state: DesktopComputerUseState }) {
+function RuntimePanel({
+  authLoading,
+  authState,
+  state,
+}: {
+  readonly authLoading: boolean;
+  readonly authState: DesktopAuthState | null;
+  readonly state: DesktopComputerUseState;
+}) {
   const [startLoadable, start] = useLoadableSet(startComputerUse$);
   const [refreshLoadable, refresh] = useLoadableSet(refreshComputerUse$);
   const [signInLoadable, signIn] = useLoadableSet(openDesktopSignIn$);
@@ -420,11 +431,18 @@ function RuntimePanel({ state }: { readonly state: DesktopComputerUseState }) {
   );
   const missingPermissions =
     !state.permissions.accessibility || !state.permissions.screenRecording;
+  const signedOut =
+    !authLoading && (!authState || authState.status === "signed_out");
+  const needsOrganization =
+    !authLoading &&
+    authState?.status === "signed_in" &&
+    authState.organization === null;
   const startDisabled =
+    authLoading ||
+    !hasReadyDesktopAuth(authState) ||
     missingPermissions ||
     state.host.status === "connecting" ||
     state.host.status === "online" ||
-    state.host.status === "needs_organization" ||
     startLoadable.state === "loading";
 
   return (
@@ -475,18 +493,19 @@ function RuntimePanel({ state }: { readonly state: DesktopComputerUseState }) {
         >
           Refresh
         </IconButton>
-        {state.host.status === "unauthenticated" && hasDesktopAuthBridge() && (
-          <IconButton
-            icon={<IconExternalLink size={15} />}
-            onClick={() => {
-              void signIn();
-            }}
-            disabled={signInLoadable.state === "loading"}
-          >
-            Sign in
-          </IconButton>
-        )}
-        {state.host.status === "needs_organization" &&
+        {(signedOut || state.host.status === "unauthenticated") &&
+          hasDesktopAuthBridge() && (
+            <IconButton
+              icon={<IconExternalLink size={15} />}
+              onClick={() => {
+                void signIn();
+              }}
+              disabled={signInLoadable.state === "loading"}
+            >
+              Sign in
+            </IconButton>
+          )}
+        {(needsOrganization || state.host.status === "needs_organization") &&
           hasDesktopAuthBridge() && (
             <IconButton
               icon={<IconBuilding size={15} />}
@@ -844,19 +863,27 @@ function UnsupportedPanel({ platform }: { readonly platform: string }) {
 }
 
 function ComputerUseContent({
+  authLoading,
+  authState,
   state,
 }: {
+  readonly authLoading: boolean;
+  readonly authState: DesktopAuthState | null;
   readonly state: DesktopComputerUseState;
 }) {
   return (
     <>
-      <AutoStartRuntime state={state} />
+      <AutoStartRuntime authState={authState} state={state} />
       {!state.supported ? (
         <UnsupportedPanel platform={state.platform} />
       ) : (
         <>
           <PermissionsPanel state={state} />
-          <RuntimePanel state={state} />
+          <RuntimePanel
+            authLoading={authLoading}
+            authState={authState}
+            state={state}
+          />
           <CommandLogPanel state={state} />
         </>
       )}
@@ -866,6 +893,9 @@ function ComputerUseContent({
 
 function ComputerUsePage() {
   const loadable = useLastLoadable(computerUseData$);
+  const authLoadable = useLastLoadable(desktopAuthData$);
+  const authState = authLoadable.state === "hasData" ? authLoadable.data : null;
+  const authLoading = authLoadable.state === "loading";
 
   if (!hasDesktopComputerUseBridge()) {
     return (
@@ -876,7 +906,13 @@ function ComputerUsePage() {
   }
 
   if (loadable.state === "hasData") {
-    return <ComputerUseContent state={loadable.data} />;
+    return (
+      <ComputerUseContent
+        authLoading={authLoading}
+        authState={authState}
+        state={loadable.data}
+      />
+    );
   }
 
   if (loadable.state === "hasError") {

--- a/turbo/apps/desktop/src/renderer/computer-use-state.test.ts
+++ b/turbo/apps/desktop/src/renderer/computer-use-state.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, it } from "vitest";
+import type { DesktopAuthState } from "../desktop-bridge";
 import {
   hasRequiredComputerUsePermissions,
   type DesktopComputerUseState,
@@ -26,6 +27,18 @@ function computerUseState(
   };
 }
 
+const signedOutAuth: DesktopAuthState = {
+  status: "signed_out",
+  user: null,
+  organization: null,
+};
+
+const signedInAuth: DesktopAuthState = {
+  status: "signed_in",
+  user: { userId: "user-1", email: "user@example.com" },
+  organization: { id: "org-1", name: "Org One", slug: "org-one" },
+};
+
 describe("hasRequiredComputerUsePermissions", () => {
   it("requires accessibility and screen recording before startup", () => {
     expect(
@@ -44,17 +57,33 @@ describe("hasRequiredComputerUsePermissions", () => {
 });
 
 describe("shouldAutoStartComputerUse", () => {
-  it("allows startup only when platform and permissions are ready", () => {
-    expect(shouldAutoStartComputerUse(computerUseState())).toBe(true);
+  it("allows startup only when auth, platform, and permissions are ready", () => {
+    expect(shouldAutoStartComputerUse(computerUseState(), signedInAuth)).toBe(
+      true,
+    );
+    expect(shouldAutoStartComputerUse(computerUseState(), null)).toBe(false);
+    expect(shouldAutoStartComputerUse(computerUseState(), signedOutAuth)).toBe(
+      false,
+    );
+    expect(
+      shouldAutoStartComputerUse(computerUseState(), {
+        ...signedInAuth,
+        organization: null,
+      }),
+    ).toBe(false);
     expect(
       shouldAutoStartComputerUse(
         computerUseState({
           permissions: { accessibility: true, screenRecording: false },
         }),
+        signedInAuth,
       ),
     ).toBe(false);
     expect(
-      shouldAutoStartComputerUse(computerUseState({ supported: false })),
+      shouldAutoStartComputerUse(
+        computerUseState({ supported: false }),
+        signedInAuth,
+      ),
     ).toBe(false);
   });
 
@@ -64,6 +93,7 @@ describe("shouldAutoStartComputerUse", () => {
         computerUseState({
           host: { ...computerUseState().host, status: "online" },
         }),
+        signedInAuth,
       ),
     ).toBe(false);
     expect(
@@ -71,6 +101,7 @@ describe("shouldAutoStartComputerUse", () => {
         computerUseState({
           host: { ...computerUseState().host, status: "connecting" },
         }),
+        signedInAuth,
       ),
     ).toBe(false);
     expect(
@@ -78,6 +109,7 @@ describe("shouldAutoStartComputerUse", () => {
         computerUseState({
           host: { ...computerUseState().host, status: "unauthenticated" },
         }),
+        signedInAuth,
       ),
     ).toBe(true);
     expect(
@@ -85,6 +117,7 @@ describe("shouldAutoStartComputerUse", () => {
         computerUseState({
           host: { ...computerUseState().host, status: "needs_organization" },
         }),
+        signedInAuth,
       ),
     ).toBe(false);
   });

--- a/turbo/apps/desktop/src/renderer/computer-use-state.ts
+++ b/turbo/apps/desktop/src/renderer/computer-use-state.ts
@@ -4,6 +4,7 @@ import type {
   DesktopAuthState,
   DesktopComputerUseApi,
 } from "../desktop-bridge";
+import { hasReadyDesktopAuth } from "../computer-use-startup-gate";
 import {
   hasRequiredComputerUsePermissions,
   type DesktopComputerUseState,
@@ -39,9 +40,11 @@ export function hasDesktopAuthBridge(): boolean {
 
 export function shouldAutoStartComputerUse(
   stateValue: DesktopComputerUseState,
+  authState: DesktopAuthState | null,
 ): boolean {
   return (
     stateValue.supported &&
+    hasReadyDesktopAuth(authState) &&
     hasRequiredComputerUsePermissions(stateValue.permissions) &&
     (stateValue.host.status === "idle" ||
       stateValue.host.status === "unauthenticated")
@@ -107,8 +110,15 @@ export const startComputerUse$ = command(async ({ set }) => {
 });
 
 export const maybeAutoStartComputerUse$ = command(
-  async ({ get, set }, stateValue: DesktopComputerUseState) => {
-    if (get(autoStartAttempted$) || !shouldAutoStartComputerUse(stateValue)) {
+  async (
+    { get, set },
+    stateValue: DesktopComputerUseState,
+    authState: DesktopAuthState | null,
+  ) => {
+    if (
+      get(autoStartAttempted$) ||
+      !shouldAutoStartComputerUse(stateValue, authState)
+    ) {
       return;
     }
     set(autoStartAttempted$, true);


### PR DESCRIPTION
## Summary

- Gate Desktop Computer Use runtime startup on signed-in auth, active organization, and required local macOS permissions before host registration.
- Make renderer autostart and manual Start use the same auth/org readiness requirements.
- Add focused tests for the shared startup gate and renderer autostart behavior.

Closes #15626

## Verification

- pnpm format
- pnpm -F @vm0/desktop lint
- pnpm -F @vm0/desktop check-types
- pnpm -F @vm0/desktop test
- pnpm -F @vm0/desktop build