### PR TITLE
fix(mitm-addon): validate platform api urls

### DIFF
--- a/crates/runner/mitm-addon/src/auth.py
+++ b/crates/runner/mitm-addon/src/auth.py
@@ -234,10 +234,13 @@ def make_api_request(url: str, data: bytes, sandbox_token: str) -> urllib.reques
     Centralises User-Agent, Authorization, Content-Type, and the optional
     Vercel bypass header so that callers cannot accidentally omit them.
     """
-    # S310 (suspicious-url-open-usage): `url` is always built by callers
-    # from `ctx.options.vm0_api_url` (operator-configured at mitmdump launch),
-    # never from user-controlled input, so the file:/custom-scheme risk S310
-    # guards against doesn't apply here.
+    parsed_url = urllib.parse.urlsplit(url)
+    if parsed_url.scheme not in {"http", "https"} or not parsed_url.netloc:
+        raise ValueError("Platform API URL must be an absolute http(s) URL")
+
+    # S310 (suspicious-url-open-usage): callers build `url` from the
+    # operator-configured platform API URL, and the scheme is validated above
+    # before urllib can consume the request.
     req = urllib.request.Request(  # noqa: S310
         url,
         data=data,
@@ -318,13 +321,6 @@ def _fetch_firewall_headers_sync(
         body["forceRefresh"] = True
     data = json.dumps(body).encode()
     req = make_api_request(url, data, sandbox_token)
-    # `req` always targets ctx.options.vm0_api_url (operator-set at mitmdump
-    # launch), never user-controlled input — so the file://-scheme risk that
-    # both S310 and Semgrep's dynamic-urllib-use-detected rule guard against
-    # does not apply. Defense in depth: reject anything that isn't an http(s)
-    # URL before opening it.
-    if not req.full_url.startswith(("http://", "https://")):
-        raise ValueError(f"Unexpected URL scheme: {req.full_url!r}")
     try:
         # nosemgrep: dynamic-urllib-use-detected
         with urllib.request.urlopen(req, timeout=10) as resp:  # noqa: S310

--- a/crates/runner/mitm-addon/tests/test_firewall_auth.py
+++ b/crates/runner/mitm-addon/tests/test_firewall_auth.py
@@ -1090,6 +1090,39 @@ class TestHandleFirewallRequest:
 # =========================================================================
 
 
+class TestMakeApiRequest:
+    def test_builds_platform_api_request_with_standard_headers(self):
+        with patch.object(auth, "VERCEL_BYPASS", ""):
+            req = auth.make_api_request(
+                "https://api.vm0.ai/api/webhooks/agent/firewall/auth",
+                b"{}",
+                "tok-xyz",
+            )
+
+        assert req.full_url == "https://api.vm0.ai/api/webhooks/agent/firewall/auth"
+        assert req.data == b"{}"
+        headers = dict(req.header_items())
+        assert headers["Content-type"] == "application/json"
+        assert headers["Authorization"] == "Bearer tok-xyz"
+        assert headers["User-agent"] == "vm0-mitm-addon/1.0"
+
+    @pytest.mark.parametrize(
+        "url",
+        [
+            pytest.param("file:///etc/passwd", id="file"),
+            pytest.param("ftp://example.com/api", id="ftp"),
+            pytest.param(
+                "//api.vm0.ai/api/webhooks/agent/firewall/auth",
+                id="scheme-relative",
+            ),
+            pytest.param("https:path-without-host", id="https-without-host"),
+        ],
+    )
+    def test_rejects_non_absolute_http_urls(self, url: str):
+        with pytest.raises(ValueError, match="absolute http"):
+            auth.make_api_request(url, b"{}", "tok-xyz")
+
+
 class TestFetchFirewallHeaders:
     def test_builds_correct_request(self, headers):
         mock_resp = MagicMock()
@@ -1123,6 +1156,15 @@ class TestFetchFirewallHeaders:
         assert "base" not in body
         assert call_args[1]["headers"]["Authorization"] == "Bearer tok-xyz"
         assert call_args[1]["headers"]["Content-Type"] == "application/json"
+
+    def test_invalid_api_url_raises_before_urlopen(self):
+        with (
+            patch("auth.urllib.request.urlopen") as mock_urlopen,
+            pytest.raises(ValueError, match="absolute http"),
+        ):
+            auth._fetch_firewall_headers_sync("iv:tag:data", {}, "tok-xyz", "file:///etc/passwd")
+
+        mock_urlopen.assert_not_called()
 
     def test_includes_vercel_bypass_header(self, headers):
         mock_resp = MagicMock()

--- a/crates/runner/mitm-addon/tests/test_webhook.py
+++ b/crates/runner/mitm-addon/tests/test_webhook.py
@@ -41,6 +41,19 @@ class TestUsageWebhookDelivery:
         assert exc.value.code == 302
         assert [request.path for request in usage_webhook_server.requests] == ["/webhook"]
 
+    def test_post_webhook_rejects_invalid_url_before_open(self):
+        with (
+            patch.object(usage.webhook._opener, "open") as mock_open,
+            pytest.raises(ValueError, match="absolute http"),
+        ):
+            usage.webhook._post_webhook(
+                "file:///etc/passwd",
+                "tok",
+                {"runId": "run-1"},
+            )
+
+        mock_open.assert_not_called()
+
     def test_succeeds_on_first_attempt(
         self, tmp_path, real_flow, fresh_usage_executor, usage_webhook_api
     ):
@@ -207,7 +220,7 @@ class TestUsageWebhookDelivery:
 
         assert usage.counters._pending_reports == 1
         assert "non-retryable" in proxy_log.read_text()
-        with pytest.raises(ValueError, match="unknown url type"):
+        with pytest.raises(ValueError, match="absolute http"):
             sync_usage_executor.shutdown(wait=True)
 
     def test_sleeps_between_retries(
@@ -230,7 +243,7 @@ class TestUsageWebhookDelivery:
     def test_programming_error_is_not_retried(self, tmp_path):
         """Non-retryable request construction errors must propagate immediately."""
         proxy_log = tmp_path / "proxy.jsonl"
-        with pytest.raises(ValueError, match="unknown url type"):
+        with pytest.raises(ValueError, match="absolute http"):
             usage.webhook._do_post_webhook_attempts(
                 "not-a-url",
                 "tok",
@@ -246,7 +259,7 @@ class TestUsageWebhookDelivery:
 
     def test_programming_error_with_payload_collision_preserves_original_error(self, tmp_path):
         proxy_log = tmp_path / "proxy.jsonl"
-        with pytest.raises(ValueError, match="unknown url type"):
+        with pytest.raises(ValueError, match="absolute http"):
             usage.webhook._do_post_webhook_attempts(
                 "not-a-url",
                 "tok",


### PR DESCRIPTION
## Summary

- validate platform API request URLs in `make_api_request` before urllib receives them
- remove the duplicate firewall-auth-only scheme guard
- cover invalid platform API URLs for firewall auth and usage webhook delivery

Closes #15487

## Tests

- `python3 -m pytest tests/test_firewall_auth.py::TestMakeApiRequest tests/test_firewall_auth.py::TestFetchFirewallHeaders::test_invalid_api_url_raises_before_urlopen`
- `python3 -m pytest tests/test_webhook.py -k "invalid"`
- `python3 -m pytest tests/test_firewall_auth.py tests/test_webhook.py`
- `python3 -m ruff check src/auth.py tests/test_firewall_auth.py tests/test_webhook.py`
- `python3 -m ruff format --check src/auth.py tests/test_firewall_auth.py tests/test_webhook.py`