### PR TITLE
refactor(api): model runners.ts helpers as command (#15638)

### DIFF
--- a/turbo/apps/api/src/signals/routes/runners.ts
+++ b/turbo/apps/api/src/signals/routes/runners.ts
@@ -1,4 +1,4 @@
-import { command, type Setter } from "ccstate";
+import { command } from "ccstate";
 import {
   elapsedSinceApiStartMs,
   runnersHeartbeatContract,
@@ -571,40 +571,44 @@ async function recordClaimApiToClaimMetric(args: {
   });
 }
 
-function scheduleClaimFailedSideEffects(args: {
-  readonly set: Setter;
-  readonly runId: string;
-  readonly userId: string;
-  readonly orgId: string;
-  readonly error: string;
-}): void {
-  const backgroundSignal = new AbortController().signal;
-  waitUntil(
-    publishRunChangedForUserSafely(args.userId, args.runId, {
-      status: "failed",
-    }),
-  );
-  waitUntil(
-    tapError(
-      args.set(
-        dispatchCompleteSideEffects$,
-        {
-          runId: args.runId,
-          orgId: args.orgId,
-          status: "failed",
-          error: args.error,
+const scheduleClaimFailedSideEffects$ = command(
+  (
+    { set },
+    args: {
+      readonly runId: string;
+      readonly userId: string;
+      readonly orgId: string;
+      readonly error: string;
+    },
+  ): void => {
+    const backgroundSignal = new AbortController().signal;
+    waitUntil(
+      publishRunChangedForUserSafely(args.userId, args.runId, {
+        status: "failed",
+      }),
+    );
+    waitUntil(
+      tapError(
+        set(
+          dispatchCompleteSideEffects$,
+          {
+            runId: args.runId,
+            orgId: args.orgId,
+            status: "failed",
+            error: args.error,
+          },
+          backgroundSignal,
+        ),
+        (error) => {
+          L.error("dispatchCompleteSideEffects failed", {
+            runId: args.runId,
+            error,
+          });
         },
-        backgroundSignal,
       ),
-      (error) => {
-        L.error("dispatchCompleteSideEffects failed", {
-          runId: args.runId,
-          error,
-        });
-      },
-    ),
-  );
-}
+    );
+  },
+);
 
 const claimInner$ = command(async ({ get, set }, signal: AbortSignal) => {
   const auth = await set(runnerAuth$, get(authorization$), signal);
@@ -655,8 +659,7 @@ const claimInner$ = command(async ({ get, set }, signal: AbortSignal) => {
       return notFound("Run not found");
     }
 
-    scheduleClaimFailedSideEffects({
-      set,
+    set(scheduleClaimFailedSideEffects$, {
       runId,
       userId: run.userId,
       orgId: run.orgId,


### PR DESCRIPTION
Closes #15638

## Summary
Removes the ccstate "get/set passed as a plain-function parameter" anti-pattern from `turbo/apps/api/src/signals/routes/runners.ts`.

- Convert `scheduleClaimFailedSideEffects` from a plain function that accepted a `readonly set: Setter` parameter into a ccstate `command` (`scheduleClaimFailedSideEffects$`). It performs side effects (`waitUntil` background dispatch via `dispatchCompleteSideEffects$`), so `command` is the correct model.
- Update its only caller in `claimInner$` to invoke it via `set(scheduleClaimFailedSideEffects$, { ... })`.
- Drop the now-unused `type Setter` import from `"ccstate"`.
- Internal `backgroundSignal` for the fire-and-forget side effects is preserved, so behavior is unchanged.

`scheduleClaimSucceededSideEffects` was left untouched — it never received `get`/`set`, so it is not a violation.

## Verification
- `pnpm -F api check-types` passes
- `pnpm -F api lint` passes (no `api/no-getter-setter-params` regressions)
- `vitest` for `runners.test.ts` (46) and `zero-runs-runner.test.ts` (7) all green

🤖 Generated with [Claude Code](https://claude.com/claude-code)