### PR TITLE
refactor(api): model cron-aggregate-insights.service.ts helpers as computed (#15645)

### DIFF
--- a/turbo/apps/api/src/signals/services/cron-aggregate-insights.service.ts
+++ b/turbo/apps/api/src/signals/services/cron-aggregate-insights.service.ts
@@ -10,7 +10,7 @@ import { orgMetadata } from "@vm0/db/schema/org-metadata";
 import { usageEvent } from "@vm0/db/schema/usage-event";
 import { userCache } from "@vm0/db/schema/user-cache";
 import { zeroAgents } from "@vm0/db/schema/zero-agent";
-import { command, type Computed } from "ccstate";
+import { command, computed, type Computed } from "ccstate";
 import { and, eq, gte, inArray, isNotNull, lt, sql } from "drizzle-orm";
 
 import { logger } from "../../lib/log";
@@ -205,11 +205,6 @@ interface NetworkQueryResult {
   readonly networkRows: number;
   readonly axiomDegraded: boolean;
 }
-
-type SignalGetter = {
-  <T>(source: Computed<T>): T;
-  <T>(source: Computed<Promise<T>>): Promise<T>;
-};
 
 function normalizeDbDate(value: Date | string): Date {
   return value instanceof Date ? value : new Date(value);
@@ -922,83 +917,84 @@ async function loadWindowUsageData(
   };
 }
 
-async function queryWindowNetworkData(
-  get: SignalGetter,
+function queryWindowNetworkData(
   db: Db,
   scope: WindowScope,
   signal: AbortSignal,
-): Promise<NetworkQueryResult> {
-  const dataset = getDatasetName("sandbox-telemetry-network");
-  const startIso = scope.dayStart.toISOString();
-  const endIso = scope.dayEnd.toISOString();
-  const apl = `['${dataset}']
+): Computed<Promise<NetworkQueryResult>> {
+  return computed(async (get): Promise<NetworkQueryResult> => {
+    const dataset = getDatasetName("sandbox-telemetry-network");
+    const startIso = scope.dayStart.toISOString();
+    const endIso = scope.dayEnd.toISOString();
+    const apl = `['${dataset}']
 | where _time >= datetime("${startIso}") and _time < datetime("${endIso}")
 | where isnotnull(firewall_name) and firewall_name != ""
 | project runId, host, firewall_name, firewall_permission, action
 | limit 100000`;
 
-  const axiomResult = await settle(
-    (async (): Promise<AxiomNetworkRow[]> => {
-      return [
-        ...((await get(
-          queryAxiom(apl),
-        )) as unknown as readonly AxiomNetworkRow[]),
-      ];
-    })(),
-  );
-  const networkRows = axiomResult.ok ? axiomResult.value : [];
-  const axiomDegraded = !axiomResult.ok;
-  if (!axiomResult.ok) {
-    L.error("Failed to query Axiom for network logs", {
-      error:
-        axiomResult.error instanceof Error
-          ? axiomResult.error.message
-          : String(axiomResult.error),
-    });
-  }
-  signal.throwIfAborted();
-
-  const networkRunIds = [
-    ...new Set(
-      networkRows
-        .map((row) => {
-          return row.runId;
-        })
-        .filter(Boolean),
-    ),
-  ];
-  const runAgentRows =
-    networkRunIds.length > 0
-      ? await queryNetworkRunAgentRows(
-          db,
-          scope.orgIds,
-          scope.userIds,
-          networkRunIds,
-          signal,
-        )
-      : [];
-
-  const runIdToInfo = new Map<
-    string,
-    {
-      readonly orgId: string;
-      readonly userId: string;
-      readonly agentName: string;
+    const axiomResult = await settle(
+      (async (): Promise<AxiomNetworkRow[]> => {
+        return [
+          ...((await get(
+            queryAxiom(apl),
+          )) as unknown as readonly AxiomNetworkRow[]),
+        ];
+      })(),
+    );
+    const networkRows = axiomResult.ok ? axiomResult.value : [];
+    const axiomDegraded = !axiomResult.ok;
+    if (!axiomResult.ok) {
+      L.error("Failed to query Axiom for network logs", {
+        error:
+          axiomResult.error instanceof Error
+            ? axiomResult.error.message
+            : String(axiomResult.error),
+      });
     }
-  >();
-  for (const row of runAgentRows) {
-    runIdToInfo.set(row.runId, {
-      orgId: row.orgId,
-      userId: row.userId,
-      agentName: row.agentName,
-    });
-  }
+    signal.throwIfAborted();
 
-  return {
-    userNetworkMap: aggregateNetworkDataPerUser(networkRows, runIdToInfo),
-    networkRows: networkRows.length,
-    axiomDegraded,
-  };
+    const networkRunIds = [
+      ...new Set(
+        networkRows
+          .map((row) => {
+            return row.runId;
+          })
+          .filter(Boolean),
+      ),
+    ];
+    const runAgentRows =
+      networkRunIds.length > 0
+        ? await queryNetworkRunAgentRows(
+            db,
+            scope.orgIds,
+            scope.userIds,
+            networkRunIds,
+            signal,
+          )
+        : [];
+
+    const runIdToInfo = new Map<
+      string,
+      {
+        readonly orgId: string;
+        readonly userId: string;
+        readonly agentName: string;
+      }
+    >();
+    for (const row of runAgentRows) {
+      runIdToInfo.set(row.runId, {
+        orgId: row.orgId,
+        userId: row.userId,
+        agentName: row.agentName,
+      });
+    }
+
+    return {
+      userNetworkMap: aggregateNetworkDataPerUser(networkRows, runIdToInfo),
+      networkRows: networkRows.length,
+      axiomDegraded,
+    };
+  });
 }
 
 async function upsertWindowInsights(
@@ -1039,24 +1035,31 @@ async function upsertWindowInsights(
   return upserted;
 }
 
-async function processWindowGroup(
-  get: SignalGetter,
+function processWindowGroup(
   db: Db,
   clerk: ClerkLike,
   group: WindowGroup,
   signal: AbortSignal,
-): Promise<{ readonly upserted: number; readonly networkRows: number }> {
-  const scope = windowScope(group);
-  const usageData = await loadWindowUsageData(db, clerk, scope, signal);
-  const networkData = await queryWindowNetworkData(get, db, scope, signal);
-  const upserted = await upsertWindowInsights(
-    db,
-    group,
-    usageData,
-    networkData,
-    signal,
+): Computed<
+  Promise<{ readonly upserted: number; readonly networkRows: number }>
+> {
+  return computed(
+    async (
+      get,
+    ): Promise<{ readonly upserted: number; readonly networkRows: number }> => {
+      const scope = windowScope(group);
+      const usageData = await loadWindowUsageData(db, clerk, scope, signal);
+      const networkData = await get(queryWindowNetworkData(db, scope, signal));
+      const upserted = await upsertWindowInsights(
+        db,
+        group,
+        usageData,
+        networkData,
+        signal,
+      );
+      return { upserted, networkRows: networkData.networkRows };
+    },
   );
-  return { upserted, networkRows: networkData.networkRows };
 }
 
 export const aggregateInsights$ = command(
@@ -1154,10 +1157,10 @@ export const aggregateInsights$ = command(
     let upserted = 0;
     let totalNetworkRows = 0;
     for (const group of windowGroups.values()) {
-      const result = await processWindowGroup(get, db, clerk, group, signal);
+      const result = await get(processWindowGroup(db, clerk, group, signal));
+      signal.throwIfAborted();
       upserted += result.upserted;
       totalNetworkRows += result.networkRows;
-      signal.throwIfAborted();
     }
 
     L.debug("Aggregated insights", {


### PR DESCRIPTION
Closes #15645

## Summary
Removes the ccstate "get passed as a plain-function parameter" anti-pattern from `turbo/apps/api/src/signals/services/cron-aggregate-insights.service.ts`.

Both violation sites were read-only (only `get`, no `set`), so they become parameterised `computed` factories:

- `queryWindowNetworkData(get: SignalGetter, db, scope, signal)` → `queryWindowNetworkData(db, scope, signal): Computed<Promise<NetworkQueryResult>>` (the `get` now lives inside the `computed` callback that reads `queryAxiom(apl)`).
- `processWindowGroup(get: SignalGetter, db, clerk, group, signal)` → `processWindowGroup(db, clerk, group, signal): Computed<Promise<{ upserted; networkRows }>>` (reads the network-data computed via `get(queryWindowNetworkData(...))`).

The single caller in `aggregateInsights$` now invokes `get(processWindowGroup(...))`. Deleted the local `SignalGetter` type alias. `AbortSignal` remains an explicit positional argument. Behavior is preserved.

## Verification
- `pnpm -F api check-types` — green
- `pnpm -F api lint` — green (no `api/no-getter-setter-params` or `api/signal-check-await` regressions)
- `pnpm -F api exec vitest run src/signals/routes/__tests__/cron-aggregate-insights.test.ts` — 14/14 passing

🤖 Generated with [Claude Code](https://claude.com/claude-code)