### PR TITLE
refactor(api): model integration-run-errors.service.ts helpers as command (#15649)

### DIFF
--- a/turbo/apps/api/src/signals/routes/zero-email-inbound.ts
+++ b/turbo/apps/api/src/signals/routes/zero-email-inbound.ts
@@ -14,7 +14,7 @@ import { clerk$ } from "../external/clerk";
 import { writeDb$ } from "../external/db";
 import { now } from "../external/time";
 import type { RouteEntry } from "../route";
-import { formatIntegrationRunError } from "../services/integration-run-errors.service";
+import { formatIntegrationRunError$ } from "../services/integration-run-errors.service";
 import { createZeroRun$ } from "../services/zero-runs-create.service";
 import {
   apiUrl,
@@ -231,14 +231,16 @@ function runError(args: {
       "code" in result.body.error && typeof result.body.error.code === "string"
         ? result.body.error.code
         : "INTERNAL_SERVER_ERROR";
-    return formatIntegrationRunError({
-      set: args.set,
-      orgId: args.context.orgId,
-      userId: args.context.userId,
-      code,
-      message: result.body.error.message,
-      signal: args.signal,
-    });
+    return args.set(
+      formatIntegrationRunError$,
+      {
+        orgId: args.context.orgId,
+        userId: args.context.userId,
+        code,
+        message: result.body.error.message,
+      },
+      args.signal,
+    );
   }
   return "Failed to create the agent run.";
 }

--- a/turbo/apps/api/src/signals/services/integration-run-errors.service.ts
+++ b/turbo/apps/api/src/signals/services/integration-run-errors.service.ts
@@ -1,5 +1,5 @@
 import { formatRunErrorForExternalSurface } from "@vm0/api-contracts/contracts/errors";
-import type { Setter } from "ccstate";
+import { command } from "ccstate";
 
 import { env } from "../../lib/env";
 import { getMemberRoleAndUpdateCache$ } from "./auth.service";
@@ -9,35 +9,39 @@ function addCreditsUrl(): string {
   return `${appUrl}/?settings=billing&billingView=credits`;
 }
 
-export async function formatIntegrationRunError(args: {
-  readonly set: Setter;
-  readonly orgId: string;
-  readonly userId: string;
-  readonly code: string;
-  readonly message: string;
-  readonly signal: AbortSignal;
-}): Promise<string> {
-  if (args.code !== "INSUFFICIENT_CREDITS") {
+export const formatIntegrationRunError$ = command(
+  async (
+    { set },
+    args: {
+      readonly orgId: string;
+      readonly userId: string;
+      readonly code: string;
+      readonly message: string;
+    },
+    signal: AbortSignal,
+  ): Promise<string> => {
+    if (args.code !== "INSUFFICIENT_CREDITS") {
+      return formatRunErrorForExternalSurface({
+        code: args.code,
+        message: args.message,
+      });
+    }
+
+    const membership = await set(
+      getMemberRoleAndUpdateCache$,
+      args.orgId,
+      args.userId,
+      signal,
+    );
+    signal.throwIfAborted();
+
     return formatRunErrorForExternalSurface({
       code: args.code,
       message: args.message,
+      insufficientCredits: {
+        canManageBilling: membership?.role === "admin",
+        addCreditsUrl: addCreditsUrl(),
+      },
     });
-  }
-
-  const membership = await args.set(
-    getMemberRoleAndUpdateCache$,
-    args.orgId,
-    args.userId,
-    args.signal,
-  );
-  args.signal.throwIfAborted();
-
-  return formatRunErrorForExternalSurface({
-    code: args.code,
-    message: args.message,
-    insufficientCredits: {
-      canManageBilling: membership?.role === "admin",
-      addCreditsUrl: addCreditsUrl(),
-    },
-  });
-}
+  },
+);

--- a/turbo/apps/api/src/signals/services/webhooks-github.service.ts
+++ b/turbo/apps/api/src/signals/services/webhooks-github.service.ts
@@ -31,7 +31,7 @@ import {
 import { getGithubInstallationAccessToken } from "./github-app.service";
 import { signGithubConnectParams } from "./github-oauth.service";
 import { canReuseIntegrationSessionForModelRoute } from "./integration-session-model-compatibility.service";
-import { formatIntegrationRunError } from "./integration-run-errors.service";
+import { formatIntegrationRunError$ } from "./integration-run-errors.service";
 import {
   resolveIntegrationModelRouteForUser$,
   type IntegrationModelRoutePin,
@@ -776,14 +776,16 @@ function routeErrorMessage(args: {
     "code" in error && typeof error.code === "string"
       ? error.code
       : "INTERNAL_SERVER_ERROR";
-  return formatIntegrationRunError({
-    set: args.set,
-    orgId: args.orgId,
-    userId: args.userId,
-    code,
-    message,
-    signal: args.signal,
-  });
+  return args.set(
+    formatIntegrationRunError$,
+    {
+      orgId: args.orgId,
+      userId: args.userId,
+      code,
+      message,
+    },
+    args.signal,
+  );
 }
 
 function stringField(body: unknown, key: string): string | undefined {

--- a/turbo/apps/api/src/signals/services/zero-agentphone.service.ts
+++ b/turbo/apps/api/src/signals/services/zero-agentphone.service.ts
@@ -40,7 +40,7 @@ import {
 } from "../external/agentphone-client";
 import { safeUrlParse, settle } from "../utils";
 import { canReuseIntegrationSessionForModelRoute } from "./integration-session-model-compatibility.service";
-import { formatIntegrationRunError } from "./integration-run-errors.service";
+import { formatIntegrationRunError$ } from "./integration-run-errors.service";
 import {
   resolveIntegrationModelRouteForUser$,
   type IntegrationModelRoutePin,
@@ -1915,14 +1915,16 @@ async function runAgentForAgentPhone(
 
   return {
     status: "failed",
-    response: await formatIntegrationRunError({
-      set,
-      orgId: args.auth.orgId,
-      userId: args.auth.userId,
-      code: result.body.error.code,
-      message: result.body.error.message,
+    response: await set(
+      formatIntegrationRunError$,
+      {
+        orgId: args.auth.orgId,
+        userId: args.auth.userId,
+        code: result.body.error.code,
+        message: result.body.error.message,
+      },
       signal,
-    }),
+    ),
   };
 }
 

--- a/turbo/apps/api/src/signals/services/zero-slack-webhooks.service.ts
+++ b/turbo/apps/api/src/signals/services/zero-slack-webhooks.service.ts
@@ -73,7 +73,7 @@ import {
   type IntegrationModelRoutePin,
 } from "./integration-model-route.service";
 import { canReuseIntegrationSessionForModelRoute } from "./integration-session-model-compatibility.service";
-import { formatIntegrationRunError } from "./integration-run-errors.service";
+import { formatIntegrationRunError$ } from "./integration-run-errors.service";
 import { zeroComposeList } from "./zero-compose-data.service";
 import { listOrgModelPolicies$ } from "./zero-model-policy.service";
 import {
@@ -1082,14 +1082,16 @@ async function runAgentForSlackOrg(
 
   return {
     status: "failed",
-    response: await formatIntegrationRunError({
-      set,
-      orgId: params.orgId,
-      userId: params.userId,
-      code: result.body.error.code,
-      message: result.body.error.message,
+    response: await set(
+      formatIntegrationRunError$,
+      {
+        orgId: params.orgId,
+        userId: params.userId,
+        code: result.body.error.code,
+        message: result.body.error.message,
+      },
       signal,
-    }),
+    ),
   };
 }
 

--- a/turbo/apps/api/src/signals/services/zero-telegram-post.service.ts
+++ b/turbo/apps/api/src/signals/services/zero-telegram-post.service.ts
@@ -63,7 +63,7 @@ import {
   type IntegrationModelRoutePin,
 } from "./integration-model-route.service";
 import { canReuseIntegrationSessionForModelRoute } from "./integration-session-model-compatibility.service";
-import { formatIntegrationRunError } from "./integration-run-errors.service";
+import { formatIntegrationRunError$ } from "./integration-run-errors.service";
 import { listOrgModelPolicies$ } from "./zero-model-policy.service";
 import { createZeroRun$ } from "./zero-runs-create.service";
 import { telegramIntegrationBotStatus } from "./zero-telegram-data.service";
@@ -1754,14 +1754,16 @@ async function runAgentForTelegram(
 
   return {
     status: "failed",
-    response: await formatIntegrationRunError({
-      set,
-      orgId: args.auth.orgId,
-      userId: args.auth.userId,
-      code: result.body.error.code,
-      message: result.body.error.message,
+    response: await set(
+      formatIntegrationRunError$,
+      {
+        orgId: args.auth.orgId,
+        userId: args.auth.userId,
+        code: result.body.error.code,
+        message: result.body.error.message,
+      },
       signal,
-    }),
+    ),
   };
 }
 


### PR DESCRIPTION
Closes #15649

Part of #15636.

## Summary
Removes the ccstate "get/set passed as a plain-function parameter" anti-pattern from `turbo/apps/api/src/signals/services/integration-run-errors.service.ts`.

- Converted `formatIntegrationRunError(args: { set: Setter, ... })` into the ccstate `command` `formatIntegrationRunError$`. It calls `set` (side effect) so it is a command, not a computed.
- Threaded `AbortSignal` as an explicit positional argument instead of nesting it in the args object.
- Dropped the now-unused `import type { Setter } from "ccstate"` and replaced it with `import { command } from "ccstate"`.
- Updated all 5 call sites to invoke via `set(formatIntegrationRunError$, args, signal)`:
  - `zero-slack-webhooks.service.ts`
  - `zero-agentphone.service.ts`
  - `zero-telegram-post.service.ts`
  - `webhooks-github.service.ts`
  - `routes/zero-email-inbound.ts`

Behavior-preserving; the only change is how `set` is obtained (command callback / existing `Setter` in scope) and how the helper is invoked.

## Verification
- `pnpm -F api check-types` passes
- `pnpm -F api lint` passes (no `api/no-getter-setter-params` regressions)
- Relevant vitest green: `zero-slack-events`, `zero-slack-commands`, `zero-slack-interactive`, `zero-telegram-data.service`

🤖 Generated with [Claude Code](https://claude.com/claude-code)