### PR TITLE
refactor(api): model webhooks-github.service.ts helpers as command (#15652)

### DIFF
--- a/turbo/apps/api/src/signals/services/webhooks-github.service.ts
+++ b/turbo/apps/api/src/signals/services/webhooks-github.service.ts
@@ -12,7 +12,7 @@ import { githubLabelListeners } from "@vm0/db/schema/github-label-listener";
 import { githubUserLinks } from "@vm0/db/schema/github-user-link";
 import { orgMembersCache } from "@vm0/db/schema/org-members-cache";
 import { zeroAgents } from "@vm0/db/schema/zero-agent";
-import { command, type Setter } from "ccstate";
+import { command } from "ccstate";
 import { and, asc, eq } from "drizzle-orm";
 import { z } from "zod";
 
@@ -753,40 +753,44 @@ async function resolveExistingSession(args: {
   };
 }
 
-function routeErrorMessage(args: {
-  readonly body: unknown;
-  readonly set: Setter;
-  readonly orgId: string;
-  readonly userId: string;
-  readonly signal: AbortSignal;
-}): string | Promise<string> | undefined {
-  const { body } = args;
-  if (typeof body !== "object" || body === null || !("error" in body)) {
-    return undefined;
-  }
-  const error = body.error;
-  if (typeof error !== "object" || error === null || !("message" in error)) {
-    return undefined;
-  }
-  const message = error.message;
-  if (typeof message !== "string") {
-    return undefined;
-  }
-  const code =
-    "code" in error && typeof error.code === "string"
-      ? error.code
-      : "INTERNAL_SERVER_ERROR";
-  return args.set(
-    formatIntegrationRunError$,
-    {
-      orgId: args.orgId,
-      userId: args.userId,
-      code,
-      message,
+const routeErrorMessage$ = command(
+  (
+    { set },
+    args: {
+      readonly body: unknown;
+      readonly orgId: string;
+      readonly userId: string;
     },
-    args.signal,
-  );
-}
+    signal: AbortSignal,
+  ): string | Promise<string> | undefined => {
+    const { body } = args;
+    if (typeof body !== "object" || body === null || !("error" in body)) {
+      return undefined;
+    }
+    const error = body.error;
+    if (typeof error !== "object" || error === null || !("message" in error)) {
+      return undefined;
+    }
+    const message = error.message;
+    if (typeof message !== "string") {
+      return undefined;
+    }
+    const code =
+      "code" in error && typeof error.code === "string"
+        ? error.code
+        : "INTERNAL_SERVER_ERROR";
+    return set(
+      formatIntegrationRunError$,
+      {
+        orgId: args.orgId,
+        userId: args.userId,
+        code,
+        message,
+      },
+      signal,
+    );
+  },
+);
 
 function stringField(body: unknown, key: string): string | undefined {
   if (typeof body !== "object" || body === null || !(key in body)) {
@@ -1029,83 +1033,90 @@ async function updateExistingSessionComment(args: {
     );
 }
 
-async function runAgentForGitHub(args: {
-  readonly set: Setter;
-  readonly userId: string;
-  readonly orgId: string;
-  readonly agentId: string;
-  readonly sessionId: string | undefined;
-  readonly prompt: string;
-  readonly appendSystemPrompt: string | undefined;
-  readonly modelRoute: IntegrationModelRoutePin | undefined;
-  readonly callbackPayload: GitHubIssuesCallbackPayload;
-  readonly apiStartTime: number;
-  readonly signal: AbortSignal;
-}): Promise<GitHubRunDispatchResult> {
-  const result = await args.set(
-    createZeroRun$,
-    {
-      auth: {
-        tokenType: "session",
-        userId: args.userId,
-        orgId: args.orgId,
-        orgRole: "member",
-      },
-      body: {
-        prompt: args.prompt,
-        agentId: args.agentId,
-        sessionId: args.sessionId,
-        ...(args.modelRoute?.modelProviderType
-          ? { modelProvider: args.modelRoute.modelProviderType }
-          : {}),
-      },
-      apiStartTime: args.apiStartTime,
-      triggerSource: "github",
-      appendSystemPrompt: args.appendSystemPrompt,
-      modelProviderId: args.modelRoute?.modelProviderId ?? undefined,
-      modelProviderCredentialScope:
-        args.modelRoute?.modelProviderCredentialScope,
-      selectedModelOverride: args.modelRoute?.selectedModel,
-      callbacks: [
-        {
-          url: `${env("VM0_API_URL")}/api/internal/callbacks/github/issues`,
-          secret: generateCallbackSecret(),
-          payload: args.callbackPayload,
-        },
-      ],
+const runAgentForGitHub$ = command(
+  async (
+    { set },
+    args: {
+      readonly userId: string;
+      readonly orgId: string;
+      readonly agentId: string;
+      readonly sessionId: string | undefined;
+      readonly prompt: string;
+      readonly appendSystemPrompt: string | undefined;
+      readonly modelRoute: IntegrationModelRoutePin | undefined;
+      readonly callbackPayload: GitHubIssuesCallbackPayload;
+      readonly apiStartTime: number;
     },
-    args.signal,
-  );
-  args.signal.throwIfAborted();
-
-  if (result.status !== 201) {
-    return {
-      status: "failed",
-      response:
-        (await routeErrorMessage({
-          body: result.body,
-          set: args.set,
-          orgId: args.orgId,
+    signal: AbortSignal,
+  ): Promise<GitHubRunDispatchResult> => {
+    const result = await set(
+      createZeroRun$,
+      {
+        auth: {
+          tokenType: "session",
           userId: args.userId,
-          signal: args.signal,
-        })) ?? RUN_START_FALLBACK_MESSAGE,
-    };
-  }
+          orgId: args.orgId,
+          orgRole: "member",
+        },
+        body: {
+          prompt: args.prompt,
+          agentId: args.agentId,
+          sessionId: args.sessionId,
+          ...(args.modelRoute?.modelProviderType
+            ? { modelProvider: args.modelRoute.modelProviderType }
+            : {}),
+        },
+        apiStartTime: args.apiStartTime,
+        triggerSource: "github",
+        appendSystemPrompt: args.appendSystemPrompt,
+        modelProviderId: args.modelRoute?.modelProviderId ?? undefined,
+        modelProviderCredentialScope:
+          args.modelRoute?.modelProviderCredentialScope,
+        selectedModelOverride: args.modelRoute?.selectedModel,
+        callbacks: [
+          {
+            url: `${env("VM0_API_URL")}/api/internal/callbacks/github/issues`,
+            secret: generateCallbackSecret(),
+            payload: args.callbackPayload,
+          },
+        ],
+      },
+      signal,
+    );
+    signal.throwIfAborted();
 
-  const status = stringField(result.body, "status");
-  const runId = stringField(result.body, "runId");
-  if (status === "queued") {
-    return { status: "queued", runId };
-  }
-  if (status === "failed") {
-    return {
-      status: "failed",
-      runId,
-      response: stringField(result.body, "error") ?? RUN_START_FALLBACK_MESSAGE,
-    };
-  }
-  return { status: "accepted", runId };
-}
+    if (result.status !== 201) {
+      return {
+        status: "failed",
+        response:
+          (await set(
+            routeErrorMessage$,
+            {
+              body: result.body,
+              orgId: args.orgId,
+              userId: args.userId,
+            },
+            signal,
+          )) ?? RUN_START_FALLBACK_MESSAGE,
+      };
+    }
+
+    const status = stringField(result.body, "status");
+    const runId = stringField(result.body, "runId");
+    if (status === "queued") {
+      return { status: "queued", runId };
+    }
+    if (status === "failed") {
+      return {
+        status: "failed",
+        runId,
+        response:
+          stringField(result.body, "error") ?? RUN_START_FALLBACK_MESSAGE,
+      };
+    }
+    return { status: "accepted", runId };
+  },
+);
 
 function labelsForAction(args: {
   readonly action: string;
@@ -1544,19 +1555,21 @@ const dispatchGithubAgentRun$ = command(
       reactionId,
     });
 
-    const dispatchResult = await runAgentForGitHub({
-      set,
-      userId: params.vm0UserId,
-      orgId: target.orgId,
-      agentId: target.zeroAgentId,
-      sessionId: existingSessionId,
-      prompt: promptParts.prompt,
-      appendSystemPrompt: promptParts.appendSystemPrompt,
-      modelRoute,
-      callbackPayload,
-      apiStartTime: params.apiStartTime,
+    const dispatchResult = await set(
+      runAgentForGitHub$,
+      {
+        userId: params.vm0UserId,
+        orgId: target.orgId,
+        agentId: target.zeroAgentId,
+        sessionId: existingSessionId,
+        prompt: promptParts.prompt,
+        appendSystemPrompt: promptParts.appendSystemPrompt,
+        modelRoute,
+        callbackPayload,
+        apiStartTime: params.apiStartTime,
+      },
       signal,
-    });
+    );
 
     if (dispatchResult.status === "failed") {
       if (!dispatchResult.runId) {


### PR DESCRIPTION
Closes #15652

## Summary
Removes the ccstate "get/set passed as a plain-function parameter" anti-pattern from `turbo/apps/api/src/signals/services/webhooks-github.service.ts`.

Both violation sites took `set: Setter` and have side effects (call `set`), so per the issue recipe they were converted to ccstate `command`s:

- `routeErrorMessage(args: { set, ... })` → `routeErrorMessage$` command
- `runAgentForGitHub(args: { set, ... })` → `runAgentForGitHub$` command

`AbortSignal` is now threaded as an explicit positional argument (no longer inside the args object). The only caller of each helper lives in this file (`dispatchGithubAgentRun$` for `runAgentForGitHub$`; `runAgentForGitHub$` for `routeErrorMessage$`) and was updated to the `set(x$, args, signal)` form. The now-unused `type Setter` import was dropped from "ccstate".

No external importers reference these file-private helpers, so no other files changed. Behavior is preserved.

## Verification
- `pnpm -F api check-types` passes
- `pnpm -F api lint` passes (no `api/no-getter-setter-params` regressions)
- Related vitest suites green (90 tests: `webhooks-third-party.test.ts`, `internal-callbacks-github-issues.test.ts`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)