### PR TITLE
fix(desktop): keep recovery clicks on background path

### DIFF
--- a/turbo/apps/desktop/native/computer-use-helper/Sources/ComputerUseHelper/main.swift
+++ b/turbo/apps/desktop/native/computer-use-helper/Sources/ComputerUseHelper/main.swift
@@ -2136,7 +2136,11 @@ func cgWindowCandidates(pid: pid_t, scope: CGWindowCandidateScope = .currentSpac
     }
     if let currentSpaceId {
         return candidates.filter { candidate in
-            candidate.spaceIds?.contains(currentSpaceId) ?? candidate.isOnScreen
+            isWindowCandidateReachableFromCurrentDisplayContext(
+                currentSpaceId: currentSpaceId,
+                windowSpaceIds: candidate.spaceIds,
+                isOnScreen: candidate.isOnScreen
+            )
         }
     }
     return candidates.filter { candidate in
@@ -3970,13 +3974,31 @@ func performElementMouseClick(
         }
     }
 
-    if foregroundRecovery != .always {
-        do {
-            return try currentSpaceClick()
-        } catch {
-            guard shouldAttemptForegroundRecovery(error, policy: foregroundRecovery) else {
-                throw error
+    if foregroundRecovery == .always {
+        return try withForegroundRecovery(
+            appName: appName,
+            policy: foregroundRecovery,
+            reason: foregroundRecoveryReason(policy: foregroundRecovery),
+            preferredScreenPoint: point,
+            dispatchMode: "foreground_mouse_event",
+            dispatchTarget: "element_point",
+            inputRisk: "foreground_app_pointer",
+            resolveTarget: {
+                guard let target = resolveWindowTarget(app: app, preferredScreenPoint: point) else {
+                    throw windowTargetUnavailableFailure(appName: appName, pid: app.processIdentifier)
+                }
+                return target
             }
+        ) { target in
+            try foregroundClickResult(target: target)
+        }
+    }
+
+    do {
+        return try currentSpaceClick()
+    } catch {
+        guard shouldAttemptForegroundRecovery(error, policy: foregroundRecovery) else {
+            throw error
         }
     }
 
@@ -3985,9 +4007,9 @@ func performElementMouseClick(
         policy: foregroundRecovery,
         reason: foregroundRecoveryReason(policy: foregroundRecovery),
         preferredScreenPoint: point,
-        dispatchMode: "foreground_mouse_event",
+        dispatchMode: "background_mouse_event",
         dispatchTarget: "element_point",
-        inputRisk: "foreground_app_pointer",
+        inputRisk: "background_app_pointer",
         resolveTarget: {
             guard let target = resolveWindowTarget(app: app, preferredScreenPoint: point) else {
                 throw windowTargetUnavailableFailure(appName: appName, pid: app.processIdentifier)
@@ -3995,7 +4017,7 @@ func performElementMouseClick(
             return target
         }
     ) { target in
-        try foregroundClickResult(target: target)
+        try clickResult(target: target)
     }
 }
 
@@ -4313,13 +4335,26 @@ func handleElementClickPoint(
         }
     }
 
-    if policy != .always {
-        do {
-            return try currentSpaceClick()
-        } catch {
-            guard shouldAttemptForegroundRecovery(error, policy: policy) else {
-                throw error
-            }
+    if policy == .always {
+        return try withForegroundRecovery(
+            appName: appName,
+            policy: policy,
+            reason: foregroundRecoveryReason(policy: policy),
+            preferredScreenPoint: point,
+            dispatchMode: "foreground_mouse_event",
+            dispatchTarget: "app_process",
+            inputRisk: "foreground_app_pointer",
+            resolveTarget: resolveSnapshotTarget
+        ) { target in
+            try foregroundClickResult(target: target)
+        }
+    }
+
+    do {
+        return try currentSpaceClick()
+    } catch {
+        guard shouldAttemptForegroundRecovery(error, policy: policy) else {
+            throw error
         }
     }
 
@@ -4328,12 +4363,12 @@ func handleElementClickPoint(
         policy: policy,
         reason: foregroundRecoveryReason(policy: policy),
         preferredScreenPoint: point,
-        dispatchMode: "foreground_mouse_event",
+        dispatchMode: "background_mouse_event",
         dispatchTarget: "app_process",
-        inputRisk: "foreground_app_pointer",
+        inputRisk: "background_app_pointer",
         resolveTarget: resolveSnapshotTarget
     ) { target in
-        try foregroundClickResult(target: target)
+        try clickResult(target: target)
     }
 }
 

--- a/turbo/apps/desktop/native/computer-use-helper/Sources/ComputerUseHelperCore/WindowVisibilityPolicy.swift
+++ b/turbo/apps/desktop/native/computer-use-helper/Sources/ComputerUseHelperCore/WindowVisibilityPolicy.swift
@@ -61,3 +61,15 @@ public func shouldShowVisualPointer(
     return topWindow.windowNumber == target.windowNumber ||
         topWindow.ownerPID == target.ownerPID
 }
+
+public func isWindowCandidateReachableFromCurrentDisplayContext(
+    currentSpaceId: UInt64?,
+    windowSpaceIds: [UInt64]?,
+    isOnScreen: Bool
+) -> Bool {
+    guard let currentSpaceId else {
+        return isOnScreen
+    }
+
+    return windowSpaceIds?.contains(currentSpaceId) == true || isOnScreen
+}

--- a/turbo/apps/desktop/native/computer-use-helper/Tests/ComputerUseHelperCoreTests/WindowVisibilityPolicyTests.swift
+++ b/turbo/apps/desktop/native/computer-use-helper/Tests/ComputerUseHelperCoreTests/WindowVisibilityPolicyTests.swift
@@ -117,4 +117,37 @@ struct WindowVisibilityPolicyTests {
 
         #expect(!shouldShowVisualPointer(target: target, point: point, windowStack: stack))
     }
+
+    @Test
+    func treatsVisibleWindowsOnAnotherDisplayAsReachable() {
+        #expect(
+            isWindowCandidateReachableFromCurrentDisplayContext(
+                currentSpaceId: 1,
+                windowSpaceIds: [2],
+                isOnScreen: true
+            )
+        )
+    }
+
+    @Test
+    func rejectsOffscreenWindowsOnAnotherSpace() {
+        #expect(
+            !isWindowCandidateReachableFromCurrentDisplayContext(
+                currentSpaceId: 1,
+                windowSpaceIds: [2],
+                isOnScreen: false
+            )
+        )
+    }
+
+    @Test
+    func acceptsWindowsOnTheCurrentSpaceEvenWithoutOnscreenMetadata() {
+        #expect(
+            isWindowCandidateReachableFromCurrentDisplayContext(
+                currentSpaceId: 1,
+                windowSpaceIds: [1],
+                isOnScreen: false
+            )
+        )
+    }
 }


### PR DESCRIPTION
## Summary

- keep default/on-window-unavailable mouse recovery on the background addressed click path after Space/window recovery
- keep explicit `foregroundRecovery: always` on the foreground HID click path
- treat on-screen windows as reachable even when their Space id differs from the main current Space, which covers visible windows on another display

Closes #15674.

## Testing

- `swift test` in `turbo/apps/desktop/native/computer-use-helper`
- `pnpm -F @vm0/desktop exec vitest src/window-policy.test.ts src/computer-use-native.test.ts`
- `pnpm -F @vm0/desktop build:native`