### PR TITLE
fix(mitm-addon): scope registry cache state by path

### DIFF
--- a/crates/runner/mitm-addon/src/registry.py
+++ b/crates/runner/mitm-addon/src/registry.py
@@ -1,6 +1,7 @@
 """Proxy registry loading and VM lookup cache."""
 
 import json
+from dataclasses import dataclass, field
 from pathlib import Path
 
 from mitmproxy import ctx
@@ -13,30 +14,43 @@ VmContext = tuple[
     matching.CompiledFirewallSet | None,
     matching.CompiledNetworkPolicies,
 ]
+_RegistryCacheKey = tuple[str, int, int, int, int]
 
-# Cache for proxy registry (invalidated by file stat change).
-_registry_cache: dict = {}
-_registry_compiled_cache: dict[str, matching.CompiledFirewallSet] = {}
-_registry_compiled_policy_cache: dict[str, matching.CompiledNetworkPolicies] = {}
-_registry_cache_key: tuple[int, int] = (0, 0)
-# One-shot guard for stat-path failures: no cache key is available in that
-# branch, so we fall back to a flag (mirrors counters.py:_pending_write_error_logged).
-# Parse-path failures use the cache key itself — recording the bad file's
-# (mtime_ns, size) as already-processed prevents re-parsing the same bytes
-# on every request and re-warning about them.
-_registry_load_error_logged = False
+
+@dataclass
+class _RegistryCacheState:
+    registry_path: str | None = None
+    registry: dict = field(default_factory=dict)
+    compiled_firewalls: dict[str, matching.CompiledFirewallSet] = field(default_factory=dict)
+    compiled_network_policies: dict[str, matching.CompiledNetworkPolicies] = field(
+        default_factory=dict
+    )
+    cache_key: _RegistryCacheKey | None = None
+    # One-shot guard for stat-path failures: no cache key is available in that
+    # branch, so we fall back to a flag (mirrors counters.py:_pending_write_error_logged).
+    # Parse-path failures use the cache key itself — recording the bad file state
+    # as already processed prevents re-parsing the same bytes on every request.
+    load_error_logged: bool = False
+
+
+_registry_state = _RegistryCacheState()
 
 
 def reset_cache_for_tests() -> None:
     """Reset module cache state between tests."""
-    global _registry_cache, _registry_compiled_cache, _registry_compiled_policy_cache
-    global _registry_cache_key
-    global _registry_load_error_logged
-    _registry_cache = {}
-    _registry_compiled_cache = {}
-    _registry_compiled_policy_cache = {}
-    _registry_cache_key = (0, 0)
-    _registry_load_error_logged = False
+    global _registry_state
+    _registry_state = _RegistryCacheState()
+
+
+def _path_key(path: Path) -> str:
+    return str(path.absolute())
+
+
+def _state_for_path(path_key: str) -> _RegistryCacheState:
+    global _registry_state
+    if _registry_state.registry_path != path_key:
+        _registry_state = _RegistryCacheState(registry_path=path_key)
+    return _registry_state
 
 
 def _compile_registry(
@@ -76,22 +90,21 @@ def load_registry(registry_path: str) -> dict:
     the error state. A successful reload also evicts firewall-auth cache
     entries for run IDs no longer present in the registry.
     """
-    global _registry_cache, _registry_compiled_cache, _registry_compiled_policy_cache
-    global _registry_cache_key
-    global _registry_load_error_logged
-
     path = Path(registry_path)
+    path_key = _path_key(path)
+    state = _state_for_path(path_key)
+
     try:
         st = path.stat()
     except OSError as e:
-        if not _registry_load_error_logged:
-            _registry_load_error_logged = True
+        if not state.load_error_logged:
+            state.load_error_logged = True
             ctx.log.warn(f"Failed to stat proxy registry: {e}")
-        return _registry_cache
+        return state.registry
 
-    key = (st.st_mtime_ns, st.st_size)
-    if key == _registry_cache_key:
-        return _registry_cache
+    key = (path_key, st.st_dev, st.st_ino, st.st_mtime_ns, st.st_size)
+    if key == state.cache_key:
+        return state.registry
 
     try:
         with path.open() as f:
@@ -109,19 +122,19 @@ def load_registry(registry_path: str) -> dict:
         }
         evict_stale_cache_keys(active_run_ids)
 
-        _registry_cache = new_registry
-        _registry_compiled_cache = new_compiled_registry
-        _registry_compiled_policy_cache = new_compiled_policy_registry
-        _registry_load_error_logged = False
+        state.registry = new_registry
+        state.compiled_firewalls = new_compiled_registry
+        state.compiled_network_policies = new_compiled_policy_registry
+        state.load_error_logged = False
     except Exception as e:
-        if not _registry_load_error_logged:
-            _registry_load_error_logged = True
+        if not state.load_error_logged:
+            state.load_error_logged = True
             ctx.log.warn(f"Failed to parse proxy registry: {e}")
 
     # Record this file state as already processed — success or parse failure —
     # so subsequent requests on the same bytes short-circuit at the key check.
-    _registry_cache_key = key
-    return _registry_cache
+    state.cache_key = key
+    return state.registry
 
 
 def get_vm_info(client_ip: str, registry_path: str) -> dict | None:
@@ -137,9 +150,9 @@ def get_vm_context(
     vm_info = load_registry(registry_path).get(client_ip)
     if vm_info is None:
         return None
-    compiled_network_policies = _registry_compiled_policy_cache.get(client_ip)
+    compiled_network_policies = _registry_state.compiled_network_policies.get(client_ip)
     if compiled_network_policies is None:
         compiled_network_policies = matching.compile_network_policies(
             vm_info.get("networkPolicies")
         )
-    return vm_info, _registry_compiled_cache.get(client_ip), compiled_network_policies
+    return vm_info, _registry_state.compiled_firewalls.get(client_ip), compiled_network_policies

--- a/crates/runner/mitm-addon/src/registry.py
+++ b/crates/runner/mitm-addon/src/registry.py
@@ -82,13 +82,14 @@ def _normalize_registry_vms(raw_registry: object) -> tuple[dict, int]:
 def load_registry(registry_path: str) -> dict:
     """Load the proxy registry, reusing cached data when possible.
 
-    The registry is reloaded only when file stat metadata changes. If stat
-    fails, the current registry cache is returned. If processing a changed file
+    Cache state is scoped to one active registry path. The registry is reloaded
+    only when file stat metadata changes for that path. If stat fails, the
+    current path's registry cache is returned. If processing a changed file
     fails, the current cache is preserved and returned, and that file state is
     recorded as processed so repeated reads short-circuit on the same stat key.
     Failures are warning-logged at most once until a successful reload clears
-    the error state. A successful reload also evicts firewall-auth cache
-    entries for run IDs no longer present in the registry.
+    the error state. A successful reload also evicts firewall-auth cache entries
+    for run IDs no longer present in the registry.
     """
     path = Path(registry_path)
     path_key = _path_key(path)

--- a/crates/runner/mitm-addon/tests/test_registry.py
+++ b/crates/runner/mitm-addon/tests/test_registry.py
@@ -1,6 +1,7 @@
 """Tests for registry loading, caching, and network logging."""
 
 import json
+import os
 from pathlib import Path
 from unittest.mock import MagicMock, patch
 
@@ -20,11 +21,25 @@ from tests.auth_state_helpers import (
 )
 from tests.timestamp_helpers import assert_utc_millisecond_timestamp
 
+_FIXED_MTIME_NS = 1_700_000_000_000_000_000
+
 
 def _reset_cache():
     """Reset the module-level registry cache between tests."""
     registry.reset_cache_for_tests()
     clear_auth_state()
+
+
+def _write_simple_registry(path, *, run_id="run-one"):
+    data = {
+        "vms": {"10.200.0.1": {"runId": run_id}},
+        "updatedAt": 0,
+    }
+    path.write_text(json.dumps(data, sort_keys=True))
+
+
+def _pin_mtime(path):
+    os.utime(path, ns=(_FIXED_MTIME_NS, _FIXED_MTIME_NS))
 
 
 def _write_firewall_registry(path, *, rule="/items"):
@@ -94,6 +109,54 @@ class TestLoadRegistry:
         result2 = registry.load_registry(str(registry_file))
         assert "10.200.0.99" in result2
         assert "10.200.0.1" not in result2
+
+    def test_cache_is_scoped_to_registry_path(self, tmp_path):
+        path_a = tmp_path / "registry-a.json"
+        path_b = tmp_path / "registry-b.json"
+        _write_simple_registry(path_a, run_id="run-one")
+        _write_simple_registry(path_b, run_id="run-two")
+        _pin_mtime(path_a)
+        _pin_mtime(path_b)
+        assert path_a.stat().st_size == path_b.stat().st_size
+
+        first = registry.load_registry(str(path_a))
+        second = registry.load_registry(str(path_b))
+
+        assert first["10.200.0.1"]["runId"] == "run-one"
+        assert second["10.200.0.1"]["runId"] == "run-two"
+        assert second is not first
+
+    def test_missing_different_path_does_not_return_previous_cache(self, tmp_path):
+        path_a = tmp_path / "registry-a.json"
+        missing_b = tmp_path / "registry-b.json"
+        _write_simple_registry(path_a)
+        registry.load_registry(str(path_a))
+
+        log = MagicMock()
+        with patch.object(registry.ctx, "log", log, create=True):
+            result = registry.load_registry(str(missing_b))
+
+        assert result == {}
+        assert log.warn.call_count == 1
+        assert "registry-b.json" in log.warn.call_args_list[0].args[0]
+
+    def test_atomic_replacement_reloads_same_size_same_mtime_registry(self, tmp_path):
+        path = tmp_path / "registry.json"
+        replacement = tmp_path / "registry.json.tmp"
+        _write_simple_registry(path, run_id="run-one")
+        _pin_mtime(path)
+        first = registry.load_registry(str(path))
+
+        _write_simple_registry(replacement, run_id="run-two")
+        assert replacement.stat().st_size == path.stat().st_size
+        _pin_mtime(replacement)
+        replacement.replace(path)
+
+        second = registry.load_registry(str(path))
+
+        assert first["10.200.0.1"]["runId"] == "run-one"
+        assert second["10.200.0.1"]["runId"] == "run-two"
+        assert second is not first
 
     def test_non_dict_vm_entries_are_filtered_without_blocking_valid_vms(self, tmp_path):
         path = tmp_path / "registry.json"
@@ -509,6 +572,44 @@ class TestGetVmContext:
         _, second_compiled, second_compiled_policies = second_context
         assert second_compiled is None
         assert second_compiled_policies is not first_compiled_policies
+
+    def test_compiled_context_is_scoped_to_registry_path(self, tmp_path):
+        path_a = tmp_path / "registry-a.json"
+        path_b = tmp_path / "registry-b.json"
+        _write_firewall_registry(path_a, rule="/items")
+        _write_firewall_registry(path_b, rule="/other")
+        _pin_mtime(path_a)
+        _pin_mtime(path_b)
+        assert path_a.stat().st_size == path_b.stat().st_size
+
+        first_context = registry.get_vm_context("10.200.0.1", str(path_a))
+        second_context = registry.get_vm_context("10.200.0.1", str(path_b))
+
+        assert first_context is not None
+        assert second_context is not None
+        first_vm_info, first_compiled, _ = first_context
+        second_vm_info, second_compiled, second_compiled_policies = second_context
+        assert first_vm_info is not second_vm_info
+        assert second_compiled is not None
+        assert second_compiled is not first_compiled
+        assert isinstance(
+            matching.match_compiled_firewall_request(
+                "https://api.example.com/items",
+                "GET",
+                second_compiled,
+                second_compiled_policies,
+            ),
+            matching.FirewallBlock,
+        )
+        assert isinstance(
+            matching.match_compiled_firewall_request(
+                "https://api.example.com/other",
+                "GET",
+                second_compiled,
+                second_compiled_policies,
+            ),
+            matching.FirewallAllow,
+        )
 
     def test_parse_failure_preserves_compiled_context(self, tmp_path):
         path = tmp_path / "registry.json"


### PR DESCRIPTION
## Summary

- group mitm-addon registry cache fields into a private state object
- scope registry cache state to one active registry path and include file identity in the cache key
- cover cross-path cache isolation and same-path atomic replacement reloads

Closes #15523

## Tests

- `python3 -m pytest tests/test_registry.py`
- `python3 -m ruff check src/registry.py tests/test_registry.py`
- `python3 -m ruff format --check src/registry.py tests/test_registry.py`
- `python3 -m pytest tests`