### PR TITLE
fix(mitm-addon): narrow registry cache fallback

### DIFF
--- a/crates/runner/mitm-addon/src/registry.py
+++ b/crates/runner/mitm-addon/src/registry.py
@@ -36,6 +36,8 @@ def _empty_snapshot() -> RegistrySnapshot:
 @dataclass
 class _RegistryCacheState:
     registry_path: str | None = None
+    # Successful registry state is stored in one snapshot so raw VM entries and
+    # compiled matcher sidecars are published together.
     snapshot: RegistrySnapshot = field(default_factory=_empty_snapshot)
     # Known-bad decoded registry input. Unlike the snapshot loaded key, this
     # means the current snapshot belongs to an older file state and this key
@@ -48,13 +50,20 @@ class _RegistryCacheState:
     read_error_key: _RegistryCacheKey | None = None
 
 
+    def reset(self) -> None:
+        self.registry_path = None
+        self.snapshot = _empty_snapshot()
+        self.failed_key = None
+        self.stat_error_logged = False
+        self.read_error_key = None
+
+
 _registry_state = _RegistryCacheState()
 
 
 def reset_cache_for_tests() -> None:
     """Reset module cache state between tests."""
-    global _registry_state
-    _registry_state = _RegistryCacheState()
+    _registry_state.reset()
 
 
 def _path_key(path: Path) -> str:

--- a/crates/runner/mitm-addon/src/registry.py
+++ b/crates/runner/mitm-addon/src/registry.py
@@ -17,20 +17,35 @@ VmContext = tuple[
 _RegistryCacheKey = tuple[str, int, int, int, int]
 
 
+class RegistryFormatError(ValueError):
+    """Registry JSON decoded successfully but does not have the expected shape."""
+
+
+@dataclass(frozen=True)
+class RegistrySnapshot:
+    vms: dict
+    compiled_firewalls: dict[str, matching.CompiledFirewallSet]
+    compiled_network_policies: dict[str, matching.CompiledNetworkPolicies]
+    loaded_key: _RegistryCacheKey | None
+
+
+def _empty_snapshot() -> RegistrySnapshot:
+    return RegistrySnapshot({}, {}, {}, None)
+
+
 @dataclass
 class _RegistryCacheState:
     registry_path: str | None = None
-    registry: dict = field(default_factory=dict)
-    compiled_firewalls: dict[str, matching.CompiledFirewallSet] = field(default_factory=dict)
-    compiled_network_policies: dict[str, matching.CompiledNetworkPolicies] = field(
-        default_factory=dict
-    )
-    cache_key: _RegistryCacheKey | None = None
-    # One-shot guard for stat-path failures: no cache key is available in that
-    # branch, so we fall back to a flag (mirrors counters.py:_pending_write_error_logged).
-    # Parse-path failures use the cache key itself — recording the bad file state
-    # as already processed prevents re-parsing the same bytes on every request.
-    load_error_logged: bool = False
+    snapshot: RegistrySnapshot = field(default_factory=_empty_snapshot)
+    # Known-bad decoded registry input. Unlike the snapshot loaded key, this
+    # means the current snapshot belongs to an older file state and this key
+    # should short-circuit until the file changes again.
+    failed_key: _RegistryCacheKey | None = None
+    # Stat failures do not provide a key, so use a one-shot guard. Open/read
+    # errors have a key but are retried on every call; track their last warning
+    # key only to avoid request-path log spam without poisoning the file state.
+    stat_error_logged: bool = False
+    read_error_key: _RegistryCacheKey | None = None
 
 
 _registry_state = _RegistryCacheState()
@@ -71,25 +86,32 @@ def _compile_registry(
     return compiled_firewall_registry, compiled_policy_registry
 
 
-def _normalize_registry_vms(raw_registry: object) -> tuple[dict, int]:
-    if not isinstance(raw_registry, dict):
-        raise TypeError("proxy registry vms must be an object")
-
+def _normalize_registry_vms(raw_registry: dict) -> tuple[dict, int]:
     new_registry = {client_ip: vm for client_ip, vm in raw_registry.items() if isinstance(vm, dict)}
     return new_registry, len(raw_registry) - len(new_registry)
+
+
+def _read_registry_vms(path: Path) -> dict:
+    with path.open() as f:
+        raw_registry = json.load(f)
+    if not isinstance(raw_registry, dict):
+        raise RegistryFormatError("proxy registry must be an object")
+    raw_vms = raw_registry.get("vms", {})
+    if not isinstance(raw_vms, dict):
+        raise RegistryFormatError("proxy registry vms must be an object")
+    return raw_vms
 
 
 def load_registry(registry_path: str) -> dict:
     """Load the proxy registry, reusing cached data when possible.
 
-    Cache state is scoped to one active registry path. The registry is reloaded
-    only when file stat metadata changes for that path. If stat fails, the
-    current path's registry cache is returned. If processing a changed file
-    fails, the current cache is preserved and returned, and that file state is
-    recorded as processed so repeated reads short-circuit on the same stat key.
-    Failures are warning-logged at most once until a successful reload clears
-    the error state. A successful reload also evicts firewall-auth cache entries
-    for run IDs no longer present in the registry.
+    Cache state is scoped to one active registry path. A successful load
+    publishes raw and compiled registry state together in a snapshot keyed by
+    file identity metadata. Malformed registry input is recorded separately as
+    a failed key so repeated reads of the same bad bytes do not reparse or
+    re-warn. File read errors preserve the last snapshot but keep retrying that
+    key, and internal compile/eviction errors are allowed to propagate instead
+    of being treated as stale-cache parse failures.
     """
     path = Path(registry_path)
     path_key = _path_key(path)
@@ -98,44 +120,51 @@ def load_registry(registry_path: str) -> dict:
     try:
         st = path.stat()
     except OSError as e:
-        if not state.load_error_logged:
-            state.load_error_logged = True
+        if not state.stat_error_logged:
+            state.stat_error_logged = True
             ctx.log.warn(f"Failed to stat proxy registry: {e}")
-        return state.registry
+        return state.snapshot.vms
 
     key = (path_key, st.st_dev, st.st_ino, st.st_mtime_ns, st.st_size)
-    if key == state.cache_key:
-        return state.registry
+    if key in (state.snapshot.loaded_key, state.failed_key):
+        return state.snapshot.vms
 
     try:
-        with path.open() as f:
-            raw_registry = json.load(f).get("vms", {})
-        new_registry, malformed_vm_count = _normalize_registry_vms(raw_registry)
-        if malformed_vm_count:
-            ctx.log.warn(f"Skipped {malformed_vm_count} malformed proxy registry VM entries")
-        new_compiled_registry, new_compiled_policy_registry = _compile_registry(new_registry)
-
-        # Evict cache entries for runs no longer in the registry.
-        active_run_ids = {
-            run_id
-            for vm in new_registry.values()
-            if isinstance(run_id := vm.get("runId"), str) and run_id
-        }
-        evict_stale_cache_keys(active_run_ids)
-
-        state.registry = new_registry
-        state.compiled_firewalls = new_compiled_registry
-        state.compiled_network_policies = new_compiled_policy_registry
-        state.load_error_logged = False
-    except Exception as e:
-        if not state.load_error_logged:
-            state.load_error_logged = True
+        raw_registry = _read_registry_vms(path)
+    except OSError as e:
+        if key != state.read_error_key:
+            state.read_error_key = key
             ctx.log.warn(f"Failed to parse proxy registry: {e}")
+        return state.snapshot.vms
+    except (json.JSONDecodeError, UnicodeDecodeError, RegistryFormatError) as e:
+        state.failed_key = key
+        state.read_error_key = None
+        ctx.log.warn(f"Failed to parse proxy registry: {e}")
+        return state.snapshot.vms
 
-    # Record this file state as already processed — success or parse failure —
-    # so subsequent requests on the same bytes short-circuit at the key check.
-    state.cache_key = key
-    return state.registry
+    new_registry, malformed_vm_count = _normalize_registry_vms(raw_registry)
+    if malformed_vm_count:
+        ctx.log.warn(f"Skipped {malformed_vm_count} malformed proxy registry VM entries")
+    new_compiled_registry, new_compiled_policy_registry = _compile_registry(new_registry)
+
+    # Evict cache entries for runs no longer in the registry.
+    active_run_ids = {
+        run_id
+        for vm in new_registry.values()
+        if isinstance(run_id := vm.get("runId"), str) and run_id
+    }
+    evict_stale_cache_keys(active_run_ids)
+
+    state.snapshot = RegistrySnapshot(
+        new_registry,
+        new_compiled_registry,
+        new_compiled_policy_registry,
+        key,
+    )
+    state.failed_key = None
+    state.stat_error_logged = False
+    state.read_error_key = None
+    return state.snapshot.vms
 
 
 def get_vm_info(client_ip: str, registry_path: str) -> dict | None:
@@ -151,9 +180,9 @@ def get_vm_context(
     vm_info = load_registry(registry_path).get(client_ip)
     if vm_info is None:
         return None
-    compiled_network_policies = _registry_state.compiled_network_policies.get(client_ip)
-    if compiled_network_policies is None:
-        compiled_network_policies = matching.compile_network_policies(
-            vm_info.get("networkPolicies")
-        )
-    return vm_info, _registry_state.compiled_firewalls.get(client_ip), compiled_network_policies
+    state = _state_for_path(_path_key(Path(registry_path)))
+    return (
+        vm_info,
+        state.snapshot.compiled_firewalls.get(client_ip),
+        state.snapshot.compiled_network_policies[client_ip],
+    )

--- a/crates/runner/mitm-addon/src/registry.py
+++ b/crates/runner/mitm-addon/src/registry.py
@@ -17,20 +17,20 @@ VmContext = tuple[
 _RegistryCacheKey = tuple[str, int, int, int, int]
 
 
-class RegistryFormatError(ValueError):
+class _RegistryFormatError(ValueError):
     """Registry JSON decoded successfully but does not have the expected shape."""
 
 
 @dataclass(frozen=True)
-class RegistrySnapshot:
+class _RegistrySnapshot:
     vms: dict
     compiled_firewalls: dict[str, matching.CompiledFirewallSet]
     compiled_network_policies: dict[str, matching.CompiledNetworkPolicies]
     loaded_key: _RegistryCacheKey | None
 
 
-def _empty_snapshot() -> RegistrySnapshot:
-    return RegistrySnapshot({}, {}, {}, None)
+def _empty_snapshot() -> _RegistrySnapshot:
+    return _RegistrySnapshot({}, {}, {}, None)
 
 
 @dataclass
@@ -38,7 +38,7 @@ class _RegistryCacheState:
     registry_path: str | None = None
     # Successful registry state is stored in one snapshot so raw VM entries and
     # compiled matcher sidecars are published together.
-    snapshot: RegistrySnapshot = field(default_factory=_empty_snapshot)
+    snapshot: _RegistrySnapshot = field(default_factory=_empty_snapshot)
     # Known-bad decoded registry input. Unlike the snapshot loaded key, this
     # means the current snapshot belongs to an older file state and this key
     # should short-circuit until the file changes again.
@@ -49,8 +49,8 @@ class _RegistryCacheState:
     stat_error_logged: bool = False
     read_error_key: _RegistryCacheKey | None = None
 
-    def reset(self) -> None:
-        self.registry_path = None
+    def reset(self, registry_path: str | None = None) -> None:
+        self.registry_path = registry_path
         self.snapshot = _empty_snapshot()
         self.failed_key = None
         self.stat_error_logged = False
@@ -70,9 +70,8 @@ def _path_key(path: Path) -> str:
 
 
 def _state_for_path(path_key: str) -> _RegistryCacheState:
-    global _registry_state
     if _registry_state.registry_path != path_key:
-        _registry_state = _RegistryCacheState(registry_path=path_key)
+        _registry_state.reset(path_key)
     return _registry_state
 
 
@@ -103,14 +102,14 @@ def _read_registry_vms(path: Path) -> dict:
     with path.open() as f:
         raw_registry = json.load(f)
     if not isinstance(raw_registry, dict):
-        raise RegistryFormatError("proxy registry must be an object")
+        raise _RegistryFormatError("proxy registry must be an object")
     raw_vms = raw_registry.get("vms", {})
     if not isinstance(raw_vms, dict):
-        raise RegistryFormatError("proxy registry vms must be an object")
+        raise _RegistryFormatError("proxy registry vms must be an object")
     return raw_vms
 
 
-def _load_registry_snapshot(registry_path: str) -> RegistrySnapshot:
+def _load_registry_snapshot(registry_path: str) -> _RegistrySnapshot:
     """Load the proxy registry snapshot, reusing cached data when possible.
 
     Cache state is scoped to one active registry path. A successful load
@@ -145,7 +144,7 @@ def _load_registry_snapshot(registry_path: str) -> RegistrySnapshot:
             state.read_error_key = key
             ctx.log.warn(f"Failed to read proxy registry: {e}")
         return state.snapshot
-    except (json.JSONDecodeError, UnicodeDecodeError, RegistryFormatError) as e:
+    except (json.JSONDecodeError, UnicodeDecodeError, _RegistryFormatError) as e:
         state.failed_key = key
         state.read_error_key = None
         ctx.log.warn(f"Failed to parse proxy registry: {e}")
@@ -164,7 +163,7 @@ def _load_registry_snapshot(registry_path: str) -> RegistrySnapshot:
     }
     evict_stale_cache_keys(active_run_ids)
 
-    state.snapshot = RegistrySnapshot(
+    state.snapshot = _RegistrySnapshot(
         new_registry,
         new_compiled_registry,
         new_compiled_policy_registry,

--- a/crates/runner/mitm-addon/src/registry.py
+++ b/crates/runner/mitm-addon/src/registry.py
@@ -49,7 +49,6 @@ class _RegistryCacheState:
     stat_error_logged: bool = False
     read_error_key: _RegistryCacheKey | None = None
 
-
     def reset(self) -> None:
         self.registry_path = None
         self.snapshot = _empty_snapshot()
@@ -111,8 +110,8 @@ def _read_registry_vms(path: Path) -> dict:
     return raw_vms
 
 
-def load_registry(registry_path: str) -> dict:
-    """Load the proxy registry, reusing cached data when possible.
+def _load_registry_snapshot(registry_path: str) -> RegistrySnapshot:
+    """Load the proxy registry snapshot, reusing cached data when possible.
 
     Cache state is scoped to one active registry path. A successful load
     publishes raw and compiled registry state together in a snapshot keyed by
@@ -132,11 +131,11 @@ def load_registry(registry_path: str) -> dict:
         if not state.stat_error_logged:
             state.stat_error_logged = True
             ctx.log.warn(f"Failed to stat proxy registry: {e}")
-        return state.snapshot.vms
+        return state.snapshot
 
     key = (path_key, st.st_dev, st.st_ino, st.st_mtime_ns, st.st_size)
     if key in (state.snapshot.loaded_key, state.failed_key):
-        return state.snapshot.vms
+        return state.snapshot
 
     try:
         raw_registry = _read_registry_vms(path)
@@ -145,12 +144,12 @@ def load_registry(registry_path: str) -> dict:
         if key != state.read_error_key:
             state.read_error_key = key
             ctx.log.warn(f"Failed to read proxy registry: {e}")
-        return state.snapshot.vms
+        return state.snapshot
     except (json.JSONDecodeError, UnicodeDecodeError, RegistryFormatError) as e:
         state.failed_key = key
         state.read_error_key = None
         ctx.log.warn(f"Failed to parse proxy registry: {e}")
-        return state.snapshot.vms
+        return state.snapshot
 
     new_registry, malformed_vm_count = _normalize_registry_vms(raw_registry)
     if malformed_vm_count:
@@ -174,7 +173,12 @@ def load_registry(registry_path: str) -> dict:
     state.failed_key = None
     state.stat_error_logged = False
     state.read_error_key = None
-    return state.snapshot.vms
+    return state.snapshot
+
+
+def load_registry(registry_path: str) -> dict:
+    """Load the proxy registry, reusing cached data when possible."""
+    return _load_registry_snapshot(registry_path).vms
 
 
 def get_vm_info(client_ip: str, registry_path: str) -> dict | None:
@@ -187,12 +191,12 @@ def get_vm_context(
     registry_path: str,
 ) -> VmContext | None:
     """Look up raw VM info with compiled firewall and policy matcher sidecars."""
-    vm_info = load_registry(registry_path).get(client_ip)
+    snapshot = _load_registry_snapshot(registry_path)
+    vm_info = snapshot.vms.get(client_ip)
     if vm_info is None:
         return None
-    state = _state_for_path(_path_key(Path(registry_path)))
     return (
         vm_info,
-        state.snapshot.compiled_firewalls.get(client_ip),
-        state.snapshot.compiled_network_policies[client_ip],
+        snapshot.compiled_firewalls.get(client_ip),
+        snapshot.compiled_network_policies[client_ip],
     )

--- a/crates/runner/mitm-addon/src/registry.py
+++ b/crates/runner/mitm-addon/src/registry.py
@@ -134,7 +134,7 @@ def load_registry(registry_path: str) -> dict:
     except OSError as e:
         if key != state.read_error_key:
             state.read_error_key = key
-            ctx.log.warn(f"Failed to parse proxy registry: {e}")
+            ctx.log.warn(f"Failed to read proxy registry: {e}")
         return state.snapshot.vms
     except (json.JSONDecodeError, UnicodeDecodeError, RegistryFormatError) as e:
         state.failed_key = key

--- a/crates/runner/mitm-addon/src/registry.py
+++ b/crates/runner/mitm-addon/src/registry.py
@@ -132,6 +132,7 @@ def load_registry(registry_path: str) -> dict:
     try:
         raw_registry = _read_registry_vms(path)
     except OSError as e:
+        state.failed_key = None
         if key != state.read_error_key:
             state.read_error_key = key
             ctx.log.warn(f"Failed to read proxy registry: {e}")

--- a/crates/runner/mitm-addon/tests/test_registry.py
+++ b/crates/runner/mitm-addon/tests/test_registry.py
@@ -3,6 +3,7 @@
 import json
 import os
 from pathlib import Path
+from types import SimpleNamespace
 from unittest.mock import MagicMock, patch
 
 import pytest
@@ -359,6 +360,37 @@ class TestLoadRegistry:
         assert spy.call_count == 2
         assert log.warn.call_count == 1
         assert "Failed to read" in log.warn.call_args_list[0].args[0]
+
+    def test_read_failure_clears_previous_failed_key(self, tmp_path):
+        path = tmp_path / "registry.json"
+        path.write_text("{}")
+        first_key = SimpleNamespace(st_dev=1, st_ino=1, st_mtime_ns=100, st_size=10)
+        second_key = SimpleNamespace(st_dev=1, st_ino=1, st_mtime_ns=200, st_size=20)
+        valid_registry = {"vms": {"10.0.0.1": {"runId": "r1"}}}
+
+        log = MagicMock()
+        with (
+            patch.object(registry.ctx, "log", log, create=True),
+            patch.object(registry.Path, "stat", side_effect=[first_key, second_key, first_key]),
+            patch.object(
+                registry.json,
+                "load",
+                side_effect=[
+                    json.JSONDecodeError("broken", "", 0),
+                    OSError("read failed"),
+                    valid_registry,
+                ],
+            ) as spy,
+        ):
+            assert registry.load_registry(str(path)) == {}
+            assert registry.load_registry(str(path)) == {}
+            recovered = registry.load_registry(str(path))
+
+        assert recovered == {"10.0.0.1": {"runId": "r1"}}
+        assert spy.call_count == 3
+        assert log.warn.call_count == 2
+        assert "Failed to parse" in log.warn.call_args_list[0].args[0]
+        assert "Failed to read" in log.warn.call_args_list[1].args[0]
 
     def test_recovery_after_parse_failure_rewarns_on_next_failure(self, tmp_path):
         """Successful load clears the flag so a later failure re-warns once."""

--- a/crates/runner/mitm-addon/tests/test_registry.py
+++ b/crates/runner/mitm-addon/tests/test_registry.py
@@ -358,7 +358,7 @@ class TestLoadRegistry:
         assert recovered == {"10.200.0.99": {"runId": "new-run"}}
         assert spy.call_count == 2
         assert log.warn.call_count == 1
-        assert "Failed to parse" in log.warn.call_args_list[0].args[0]
+        assert "Failed to read" in log.warn.call_args_list[0].args[0]
 
     def test_recovery_after_parse_failure_rewarns_on_next_failure(self, tmp_path):
         """Successful load clears the flag so a later failure re-warns once."""

--- a/crates/runner/mitm-addon/tests/test_registry.py
+++ b/crates/runner/mitm-addon/tests/test_registry.py
@@ -5,6 +5,8 @@ import os
 from pathlib import Path
 from unittest.mock import MagicMock, patch
 
+import pytest
+
 import flow_metadata_keys as metadata_keys
 import logging_utils
 import matching
@@ -268,6 +270,93 @@ class TestLoadRegistry:
         assert result2 is cached
         assert result1["10.200.0.1"]["runId"] == "run-abc-123"
         assert spy.call_count == 1
+        assert log.warn.call_count == 1
+        assert "Failed to parse" in log.warn.call_args_list[0].args[0]
+
+    def test_non_object_registry_after_success_returns_cached_registry(self, registry_file):
+        cached = registry.load_registry(str(registry_file))
+        registry_file.write_text(json.dumps(["broken"]))
+
+        log = MagicMock()
+        with (
+            patch.object(registry.ctx, "log", log, create=True),
+            patch.object(registry.json, "load", wraps=registry.json.load) as spy,
+        ):
+            result1 = registry.load_registry(str(registry_file))
+            result2 = registry.load_registry(str(registry_file))
+
+        assert result1 is cached
+        assert result2 is cached
+        assert spy.call_count == 1
+        assert log.warn.call_count == 1
+        assert "Failed to parse" in log.warn.call_args_list[0].args[0]
+
+    def test_new_bad_registry_key_rewarns_without_success_between_failures(self, tmp_path):
+        path = tmp_path / "registry.json"
+        path.write_text("{ broken")
+
+        log = MagicMock()
+        with patch.object(registry.ctx, "log", log, create=True):
+            registry.load_registry(str(path))
+            assert log.warn.call_count == 1
+
+            path.write_text("{ broken again, different size")
+            registry.load_registry(str(path))
+
+        assert log.warn.call_count == 2
+        assert all("Failed to parse" in call.args[0] for call in log.warn.call_args_list)
+
+    def test_compile_registry_failure_propagates(self, registry_file):
+        registry.load_registry(str(registry_file))
+        registry_file.write_text(json.dumps({"vms": {"10.200.0.99": {"runId": "new-run"}}}))
+
+        with (
+            patch.object(registry.ctx, "log", MagicMock(), create=True),
+            patch.object(
+                registry,
+                "_compile_registry",
+                side_effect=RuntimeError("compile failed"),
+            ),
+            pytest.raises(RuntimeError, match="compile failed"),
+        ):
+            registry.load_registry(str(registry_file))
+
+    def test_auth_cache_eviction_failure_propagates(self, registry_file):
+        registry.load_registry(str(registry_file))
+        registry_file.write_text(json.dumps({"vms": {"10.200.0.99": {"runId": "new-run"}}}))
+
+        with (
+            patch.object(registry.ctx, "log", MagicMock(), create=True),
+            patch.object(
+                registry,
+                "evict_stale_cache_keys",
+                side_effect=RuntimeError("evict failed"),
+            ),
+            pytest.raises(RuntimeError, match="evict failed"),
+        ):
+            registry.load_registry(str(registry_file))
+
+    def test_read_failure_after_stat_does_not_poison_file_key(self, registry_file):
+        cached = registry.load_registry(str(registry_file))
+        new_registry = {"vms": {"10.200.0.99": {"runId": "new-run"}}, "updatedAt": 0}
+        registry_file.write_text(json.dumps(new_registry))
+
+        log = MagicMock()
+        with (
+            patch.object(registry.ctx, "log", log, create=True),
+            patch.object(
+                registry.json,
+                "load",
+                side_effect=[OSError("read failed"), new_registry],
+            ) as spy,
+        ):
+            failed = registry.load_registry(str(registry_file))
+            recovered = registry.load_registry(str(registry_file))
+
+        assert failed is cached
+        assert recovered is not cached
+        assert recovered == {"10.200.0.99": {"runId": "new-run"}}
+        assert spy.call_count == 2
         assert log.warn.call_count == 1
         assert "Failed to parse" in log.warn.call_args_list[0].args[0]
 


### PR DESCRIPTION
## Summary

- replace split mitm registry globals with a single snapshot plus separate failed/read error keys
- keep stale-cache fallback for malformed registry input while letting compile and auth-cache eviction errors propagate
- add regression coverage for non-object registries, repeated bad keys, internal failures, and read-error recovery

Fixes #15524

## Tests

- `python3 -m pytest tests/test_registry.py`
- `python3 -m pytest tests/test_auth_cache.py tests/test_request_handler_firewall_dispatch.py`
- `python3 -m pytest`
- `python3 -m ruff check .`
- `python3 -m basedpyright`
