### PR TITLE
feat: add canonical workspace drive foundation

### DIFF
--- a/crates/guest-agent/src/cli/mod.rs
+++ b/crates/guest-agent/src/cli/mod.rs
@@ -40,6 +40,7 @@ use framework::CliFrameworkBehavior;
 use guest_common::telemetry::record_sandbox_op;
 use guest_common::{log_info, log_warn};
 use std::collections::HashMap;
+use std::path::Path;
 use std::process::Stdio;
 use std::time::{Duration, Instant};
 use termination::{TerminationReason, TerminationState};
@@ -134,6 +135,16 @@ pub async fn execute_cli(
         // If a future setup step fails after spawn, dropping `Child` must not
         // leave a CLI process running in the VM.
         .kill_on_drop(true);
+    // The runner mounts the workspace drive after guest-agent startup. Re-open
+    // the canonical path for the child so it does not inherit guest-agent's
+    // pre-mount cwd.
+    if !set_cli_current_dir_if_available(&mut cmd, paths::CANONICAL_WORKING_DIR) {
+        log_warn!(
+            LOG_TAG,
+            "Canonical working directory unavailable before CLI spawn: {}",
+            paths::CANONICAL_WORKING_DIR
+        );
+    }
 
     match framework {
         env::Framework::ClaudeCode => {
@@ -658,6 +669,15 @@ pub async fn execute_cli(
     })
 }
 
+fn set_cli_current_dir_if_available(cmd: &mut tokio::process::Command, path: &str) -> bool {
+    let path = Path::new(path);
+    if !path.is_dir() {
+        return false;
+    }
+    cmd.current_dir(path);
+    true
+}
+
 fn select_failure_diagnostic(
     existing: Option<&CliFailureDiagnostic>,
     candidate: CliFailureDiagnostic,
@@ -707,8 +727,42 @@ fn with_carried_failure_reason(
 
 #[cfg(test)]
 mod tests {
-    use super::{CliFailureDiagnostic, select_failure_diagnostic, with_carried_failure_reason};
+    use super::{
+        CliFailureDiagnostic, select_failure_diagnostic, set_cli_current_dir_if_available,
+        with_carried_failure_reason,
+    };
     use agent_diagnostics::{FailureDetailSource, FailureReason};
+
+    #[tokio::test]
+    async fn cli_current_dir_helper_sets_child_working_directory() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let mut cmd = tokio::process::Command::new("pwd");
+        cmd.stdout(std::process::Stdio::piped());
+
+        assert!(set_cli_current_dir_if_available(
+            &mut cmd,
+            dir.path().to_str().expect("utf8 temp path"),
+        ));
+        let output = cmd.output().await.expect("pwd");
+
+        assert!(output.status.success());
+        assert_eq!(
+            String::from_utf8_lossy(&output.stdout).trim(),
+            dir.path().to_string_lossy()
+        );
+    }
+
+    #[test]
+    fn cli_current_dir_helper_ignores_missing_directory() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let missing = dir.path().join("missing");
+        let mut cmd = tokio::process::Command::new("pwd");
+
+        assert!(!set_cli_current_dir_if_available(
+            &mut cmd,
+            missing.to_str().expect("utf8 temp path"),
+        ));
+    }
 
     #[test]
     fn specific_codex_failure_diagnostic_survives_later_generic_event() {

--- a/crates/guest-agent/src/cli/mod.rs
+++ b/crates/guest-agent/src/cli/mod.rs
@@ -135,9 +135,8 @@ pub async fn execute_cli(
         // If a future setup step fails after spawn, dropping `Child` must not
         // leave a CLI process running in the VM.
         .kill_on_drop(true);
-    // The runner mounts the workspace drive after guest-agent startup. Re-open
-    // the canonical path for the child so it does not inherit guest-agent's
-    // pre-mount cwd.
+    // Set the child cwd explicitly at spawn time so the CLI observes the
+    // current canonical workspace mount instead of relying on inherited cwd.
     if !set_cli_current_dir_if_available(&mut cmd, paths::CANONICAL_WORKING_DIR) {
         log_warn!(
             LOG_TAG,

--- a/crates/guest-agent/src/cli/mod.rs
+++ b/crates/guest-agent/src/cli/mod.rs
@@ -137,13 +137,7 @@ pub async fn execute_cli(
         .kill_on_drop(true);
     // Set the child cwd explicitly at spawn time so the CLI observes the
     // current canonical workspace mount instead of relying on inherited cwd.
-    if !set_cli_current_dir_if_available(&mut cmd, paths::CANONICAL_WORKING_DIR) {
-        log_warn!(
-            LOG_TAG,
-            "Canonical working directory unavailable before CLI spawn: {}",
-            paths::CANONICAL_WORKING_DIR
-        );
-    }
+    set_cli_current_dir(&mut cmd, paths::CANONICAL_WORKING_DIR)?;
 
     match framework {
         env::Framework::ClaudeCode => {
@@ -668,13 +662,22 @@ pub async fn execute_cli(
     })
 }
 
-fn set_cli_current_dir_if_available(cmd: &mut tokio::process::Command, path: &str) -> bool {
+fn set_cli_current_dir(cmd: &mut tokio::process::Command, path: &str) -> Result<(), AgentError> {
     let path = Path::new(path);
-    if !path.is_dir() {
-        return false;
+    let metadata = std::fs::metadata(path).map_err(|e| {
+        AgentError::Execution(format!(
+            "canonical working directory unavailable before CLI spawn: {}: {e}",
+            path.display()
+        ))
+    })?;
+    if !metadata.is_dir() {
+        return Err(AgentError::Execution(format!(
+            "canonical working directory is not a directory before CLI spawn: {}",
+            path.display()
+        )));
     }
     cmd.current_dir(path);
-    true
+    Ok(())
 }
 
 fn select_failure_diagnostic(
@@ -727,7 +730,7 @@ fn with_carried_failure_reason(
 #[cfg(test)]
 mod tests {
     use super::{
-        CliFailureDiagnostic, select_failure_diagnostic, set_cli_current_dir_if_available,
+        CliFailureDiagnostic, select_failure_diagnostic, set_cli_current_dir,
         with_carried_failure_reason,
     };
     use agent_diagnostics::{FailureDetailSource, FailureReason};
@@ -738,10 +741,8 @@ mod tests {
         let mut cmd = tokio::process::Command::new("pwd");
         cmd.stdout(std::process::Stdio::piped());
 
-        assert!(set_cli_current_dir_if_available(
-            &mut cmd,
-            dir.path().to_str().expect("utf8 temp path"),
-        ));
+        set_cli_current_dir(&mut cmd, dir.path().to_str().expect("utf8 temp path"))
+            .expect("set cwd");
         let output = cmd.output().await.expect("pwd");
 
         assert!(output.status.success());
@@ -752,15 +753,31 @@ mod tests {
     }
 
     #[test]
-    fn cli_current_dir_helper_ignores_missing_directory() {
+    fn cli_current_dir_helper_errors_for_missing_directory() {
         let dir = tempfile::tempdir().expect("tempdir");
         let missing = dir.path().join("missing");
         let mut cmd = tokio::process::Command::new("pwd");
 
-        assert!(!set_cli_current_dir_if_available(
-            &mut cmd,
-            missing.to_str().expect("utf8 temp path"),
-        ));
+        let err = set_cli_current_dir(&mut cmd, missing.to_str().expect("utf8 temp path"))
+            .expect_err("missing cwd should fail");
+
+        assert!(
+            err.to_string()
+                .contains("canonical working directory unavailable")
+        );
+    }
+
+    #[test]
+    fn cli_current_dir_helper_errors_for_non_directory() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let file = dir.path().join("workspace-file");
+        std::fs::write(&file, b"not a directory").expect("write file");
+        let mut cmd = tokio::process::Command::new("pwd");
+
+        let err = set_cli_current_dir(&mut cmd, file.to_str().expect("utf8 temp path"))
+            .expect_err("non-directory cwd should fail");
+
+        assert!(err.to_string().contains("is not a directory"));
     }
 
     #[test]

--- a/crates/guest-agent/tests/cli_setup_failure.rs
+++ b/crates/guest-agent/tests/cli_setup_failure.rs
@@ -3,6 +3,8 @@
 //! This test lives in its own binary because `guest_agent::env` and
 //! `guest_agent::paths` cache values in process-wide `LazyLock`s.
 
+mod common;
+
 use guest_agent::error::AgentError;
 use std::io::ErrorKind;
 use std::time::Duration;
@@ -27,6 +29,7 @@ async fn agent_log_open_failure_happens_before_cli_spawn() -> Result<(), Box<dyn
         );
         std::env::set_var("HOME", tmp.path());
     }
+    common::ensure_canonical_workspace_for_test()?;
 
     let masker = guest_agent::masker::SecretMasker::from_raw("");
     let heartbeat = tokio::spawn(async { Ok(()) });

--- a/crates/guest-agent/tests/codex_jsonl_failure_logging.rs
+++ b/crates/guest-agent/tests/codex_jsonl_failure_logging.rs
@@ -171,6 +171,7 @@ unsafe fn setup_codex_env(
         std::env::set_var("HOME", workdir);
     }
     std::fs::create_dir_all(workdir).map_err(|e| format!("create workdir: {e}"))?;
+    common::ensure_canonical_workspace_for_test()?;
     std::env::set_current_dir(workdir).map_err(|e| format!("set_current_dir: {e}"))?;
     Ok(())
 }

--- a/crates/guest-agent/tests/common/mod.rs
+++ b/crates/guest-agent/tests/common/mod.rs
@@ -43,6 +43,46 @@ pub const CLI_STDERR_RESULT_MAX_LINE_BYTES: usize = 16 * 1024;
 pub const CLI_STDERR_OMITTED_LONG_LINE: &str =
     "[stderr line omitted: exceeded diagnostic size limit]";
 
+/// Integration tests call `execute_cli` directly, bypassing the runner-side
+/// workspace-drive mount. Create the canonical mountpoint once at the host-test
+/// boundary so tests exercise the same cwd contract as production.
+pub fn ensure_canonical_workspace_for_test() -> Result<(), String> {
+    let path = Path::new(guest_agent::paths::CANONICAL_WORKING_DIR);
+    if path.is_dir() {
+        return Ok(());
+    }
+
+    match std::fs::create_dir_all(path) {
+        Ok(()) => return Ok(()),
+        Err(e) if e.kind() == std::io::ErrorKind::PermissionDenied => {}
+        Err(e) => {
+            return Err(format!(
+                "create canonical workspace {}: {e}",
+                path.display()
+            ));
+        }
+    }
+
+    let status = std::process::Command::new("sudo")
+        .args(["-n", "mkdir", "-p"])
+        .arg(path)
+        .status()
+        .map_err(|e| format!("invoke sudo mkdir for {}: {e}", path.display()))?;
+    if !status.success() {
+        return Err(format!(
+            "sudo mkdir failed for canonical workspace {} with status {status}",
+            path.display()
+        ));
+    }
+    if !path.is_dir() {
+        return Err(format!(
+            "canonical workspace was not created as a directory: {}",
+            path.display()
+        ));
+    }
+    Ok(())
+}
+
 /// Build the mock binary (idempotent when up to date) and resolve its
 /// filesystem path.
 ///
@@ -176,6 +216,7 @@ pub unsafe fn setup_env(
         std::env::set_var("HOME", workdir);
     }
     std::fs::create_dir_all(workdir).map_err(|e| format!("create workdir: {e}"))?;
+    ensure_canonical_workspace_for_test()?;
     std::env::set_current_dir(workdir).map_err(|e| format!("set_current_dir: {e}"))?;
     Ok(())
 }

--- a/crates/guest-agent/tests/execute_cli_api_mode.rs
+++ b/crates/guest-agent/tests/execute_cli_api_mode.rs
@@ -60,6 +60,7 @@ unsafe fn setup_api_env(mock_path: &Path, workdir: &Path, api_url: &str) -> Resu
         std::env::set_var("HOME", workdir);
     }
     std::fs::create_dir_all(workdir).map_err(|e| format!("create workdir: {e}"))?;
+    common::ensure_canonical_workspace_for_test()?;
     std::env::set_current_dir(workdir).map_err(|e| format!("set_current_dir: {e}"))?;
     Ok(())
 }

--- a/crates/runner/build.rs
+++ b/crates/runner/build.rs
@@ -11,6 +11,7 @@ fn main() {
     // but CI artifact caches may not — explicit rerun-if-changed ensures correctness).
     println!("cargo::rerun-if-changed=scripts/build-template.sh");
     println!("cargo::rerun-if-changed=scripts/customize-rootfs.sh");
+    println!("cargo::rerun-if-changed=scripts/mount-workspace-drive.sh");
     println!("cargo::rerun-if-changed=scripts/verify-rootfs.sh");
 
     generate_addon_files();

--- a/crates/runner/scripts/build-template.sh
+++ b/crates/runner/scripts/build-template.sh
@@ -30,7 +30,7 @@
 #     --debootstrap-dir /path/to/cache \
 #     --debootstrap-lock /path/to/cache/.lock \
 #     --hash <input-hash> \
-#     --disk-mb 16384 \
+#     --rootfs-disk-mb 8192 \
 #     [--mirror http://archive.ubuntu.com/ubuntu]
 
 set -euo pipefail
@@ -63,7 +63,7 @@ OUTPUT_DIR=""
 DEBOOTSTRAP_DIR=""
 DEBOOTSTRAP_LOCK=""
 INPUT_HASH=""
-DISK_MB=""
+ROOTFS_DISK_MB=""
 # Default mirror: archive.ubuntu.com only hosts amd64/i386;
 # arm64 and other ports use ports.ubuntu.com.
 if [[ "$(dpkg --print-architecture 2>/dev/null)" == "arm64" ]]; then
@@ -78,13 +78,13 @@ while [[ $# -gt 0 ]]; do
     --debootstrap-dir)   DEBOOTSTRAP_DIR="$2";   shift 2 ;;
     --debootstrap-lock)  DEBOOTSTRAP_LOCK="$2";  shift 2 ;;
     --hash)              INPUT_HASH="$2";        shift 2 ;;
-    --disk-mb)           DISK_MB="$2";           shift 2 ;;
+    --rootfs-disk-mb)    ROOTFS_DISK_MB="$2";    shift 2 ;;
     --mirror)            MIRROR="$2";            shift 2 ;;
     *) echo "error: unknown argument: $1" >&2; exit 1 ;;
   esac
 done
 
-for var in OUTPUT_DIR DEBOOTSTRAP_DIR DEBOOTSTRAP_LOCK INPUT_HASH DISK_MB; do
+for var in OUTPUT_DIR DEBOOTSTRAP_DIR DEBOOTSTRAP_LOCK INPUT_HASH ROOTFS_DISK_MB; do
   if [[ -z "${!var}" ]]; then
     echo "error: --$(echo "$var" | tr '_' '-' | tr '[:upper:]' '[:lower:]') is required" >&2
     exit 1
@@ -466,11 +466,11 @@ create_ext4() {
 
   local content_bytes
   content_bytes=$(sudo du -sb "$ROOTFS_DIR" | cut -f1)
-  local image_bytes=$(( DISK_MB * 1024 * 1024 ))
+  local image_bytes=$(( ROOTFS_DISK_MB * 1024 * 1024 ))
 
   if (( image_bytes < content_bytes )); then
     local content_mb=$(( content_bytes / 1024 / 1024 ))
-    echo "error: disk_mb (${DISK_MB} MiB) is smaller than rootfs content (${content_mb} MiB)" >&2
+    echo "error: rootfs_disk_mb (${ROOTFS_DISK_MB} MiB) is smaller than rootfs content (${content_mb} MiB)" >&2
     exit 1
   fi
 

--- a/crates/runner/scripts/mount-workspace-drive.sh
+++ b/crates/runner/scripts/mount-workspace-drive.sh
@@ -1,0 +1,55 @@
+set -eu
+
+refuse_workspace_symlink_path() {
+  check_path=
+  remaining=${workspace_dir#/}
+  while [ -n "$remaining" ]; do
+    component=${remaining%%/*}
+    if [ "$remaining" = "$component" ]; then
+      remaining=
+    else
+      remaining=${remaining#*/}
+    fi
+    check_path="$check_path/$component"
+    if [ -L "$check_path" ]; then
+      echo "refusing to use symlink workspace path component: $check_path" >&2
+      exit 64
+    fi
+  done
+}
+
+workspace_device_mounted_elsewhere() {
+  [ -n "$workspace_dev" ] || return 1
+  while IFS=' ' read -r _ _ mount_dev _ _ _; do
+    if [ "$mount_dev" = "$workspace_dev" ]; then
+      return 0
+    fi
+  done < /proc/self/mountinfo
+  return 1
+}
+
+ensure_workspace_owner() {
+  chown -h user:user -- "$workspace_dir"
+}
+
+refuse_workspace_symlink_path
+workspace_dev="$(mountpoint -x -- "$workspace_device" 2>/dev/null || true)"
+if mountpoint -q -- "$workspace_dir"; then
+  target_dev="$(mountpoint -d -- "$workspace_dir" 2>/dev/null || true)"
+  if [ -n "$workspace_dev" ] && [ "$target_dev" = "$workspace_dev" ]; then
+    ensure_workspace_owner
+    exit 0
+  fi
+  echo "refusing to mount workspace drive over existing mountpoint: $workspace_dir" >&2
+  exit 64
+fi
+
+if workspace_device_mounted_elsewhere; then
+  echo "refusing to mount workspace drive because $workspace_device is already mounted outside $workspace_dir" >&2
+  exit 64
+fi
+
+mkdir -p -- "$workspace_dir"
+refuse_workspace_symlink_path
+mount -t ext4 -- "$workspace_device" "$workspace_dir"
+ensure_workspace_owner

--- a/crates/runner/src/cmd/benchmark.rs
+++ b/crates/runner/src/cmd/benchmark.rs
@@ -157,7 +157,7 @@ pub async fn run_benchmark(
         },
         device_rate_limits: None,
         workspace_drive: Some(sandbox::WorkspaceDriveConfig {
-            size_bytes: u64::from(profile_config.disk_mb) * 1024 * 1024,
+            size_bytes: u64::from(profile_config.workspace_disk_mb) * 1024 * 1024,
         }),
     };
     let (result, timing) = run_sandbox(&args, &env_pairs, &*factory, &mitm, sandbox_config).await;

--- a/crates/runner/src/cmd/benchmark.rs
+++ b/crates/runner/src/cmd/benchmark.rs
@@ -16,6 +16,7 @@ use crate::executor;
 use crate::lock;
 use crate::paths::{HomePaths, RootfsPaths, RunnerPaths};
 use crate::prefetch;
+use crate::profile;
 use crate::proxy;
 use crate::workspace_mount::ensure_workspace_drive_mounted;
 
@@ -156,7 +157,7 @@ pub async fn run_benchmark(
         },
         device_rate_limits: None,
         workspace_drive: Some(sandbox::WorkspaceDriveConfig {
-            size_bytes: u64::from(profile_config.workspace_disk_mb) * 1024 * 1024,
+            size_bytes: profile::workspace_disk_mb_to_bytes(profile_config.workspace_disk_mb),
         }),
     };
     let (result, timing) = run_sandbox(&args, &env_pairs, &*factory, &mitm, sandbox_config).await;

--- a/crates/runner/src/cmd/benchmark.rs
+++ b/crates/runner/src/cmd/benchmark.rs
@@ -13,7 +13,6 @@ use crate::config;
 use crate::deps::MITMPROXY_VERSION;
 use crate::error::{RunnerError, RunnerResult};
 use crate::executor;
-use crate::ids::RunId;
 use crate::lock;
 use crate::paths::{HomePaths, RootfsPaths, RunnerPaths};
 use crate::prefetch;
@@ -315,19 +314,7 @@ async fn run_in_sandbox(
     }
 
     let t_mount = Instant::now();
-    let run_id = match sandbox.id().parse::<RunId>() {
-        Ok(run_id) => run_id,
-        Err(e) => {
-            timing.workspace_mount_ms = Some(t_mount.elapsed().as_millis());
-            return (
-                Err(RunnerError::Internal(format!(
-                    "parse benchmark sandbox id as run id: {e}"
-                ))),
-                timing,
-            );
-        }
-    };
-    let mount_result = ensure_workspace_drive_mounted(sandbox, run_id).await;
+    let mount_result = ensure_workspace_drive_mounted(sandbox, sandbox.id()).await;
     timing.workspace_mount_ms = Some(t_mount.elapsed().as_millis());
     if let Err(e) = mount_result {
         return (Err(e), timing);

--- a/crates/runner/src/cmd/benchmark.rs
+++ b/crates/runner/src/cmd/benchmark.rs
@@ -153,6 +153,9 @@ pub async fn run_benchmark(
             memory_mb: profile_config.memory_mb,
         },
         device_rate_limits: None,
+        workspace_drive: Some(sandbox::WorkspaceDriveConfig {
+            size_bytes: u64::from(profile_config.disk_mb) * 1024 * 1024,
+        }),
     };
     let (result, timing) = run_sandbox(&args, &env_pairs, &*factory, &mitm, sandbox_config).await;
     let total_ms = total.elapsed().as_millis();

--- a/crates/runner/src/cmd/benchmark.rs
+++ b/crates/runner/src/cmd/benchmark.rs
@@ -16,7 +16,6 @@ use crate::executor;
 use crate::lock;
 use crate::paths::{HomePaths, RootfsPaths, RunnerPaths};
 use crate::prefetch;
-use crate::profile;
 use crate::proxy;
 use crate::workspace_mount::ensure_workspace_drive_mounted;
 
@@ -157,7 +156,7 @@ pub async fn run_benchmark(
         },
         device_rate_limits: None,
         workspace_drive: Some(sandbox::WorkspaceDriveConfig {
-            size_bytes: profile::workspace_disk_mb_to_bytes(profile_config.workspace_disk_mb),
+            size_mb: profile_config.workspace_disk_mb,
         }),
     };
     let (result, timing) = run_sandbox(&args, &env_pairs, &*factory, &mitm, sandbox_config).await;

--- a/crates/runner/src/cmd/benchmark.rs
+++ b/crates/runner/src/cmd/benchmark.rs
@@ -13,14 +13,17 @@ use crate::config;
 use crate::deps::MITMPROXY_VERSION;
 use crate::error::{RunnerError, RunnerResult};
 use crate::executor;
+use crate::ids::RunId;
 use crate::lock;
 use crate::paths::{HomePaths, RootfsPaths, RunnerPaths};
 use crate::prefetch;
 use crate::proxy;
+use crate::workspace_mount::ensure_workspace_drive_mounted;
 
 #[derive(Default)]
 struct Timing {
     boot_ms: Option<u128>,
+    workspace_mount_ms: Option<u128>,
     clock_ms: Option<u128>,
     exec_ms: Option<u128>,
 }
@@ -169,6 +172,7 @@ pub async fn run_benchmark(
     // 5. Log timing summary (always, even on error)
     let Timing {
         boot_ms,
+        workspace_mount_ms,
         clock_ms,
         exec_ms,
     } = timing;
@@ -178,6 +182,7 @@ pub async fn run_benchmark(
                 proxy_ms,
                 factory_ms,
                 boot_ms = ?boot_ms,
+                workspace_mount_ms = ?workspace_mount_ms,
                 clock_ms = ?clock_ms,
                 exec_ms = ?exec_ms,
                 total_ms,
@@ -186,7 +191,7 @@ pub async fn run_benchmark(
             );
         }
         Err(e) => {
-            info!(proxy_ms, factory_ms, boot_ms = ?boot_ms, clock_ms = ?clock_ms, exec_ms = ?exec_ms, total_ms, error = %e, "benchmark failed");
+            info!(proxy_ms, factory_ms, boot_ms = ?boot_ms, workspace_mount_ms = ?workspace_mount_ms, clock_ms = ?clock_ms, exec_ms = ?exec_ms, total_ms, error = %e, "benchmark failed");
         }
     }
 
@@ -307,6 +312,25 @@ async fn run_in_sandbox(
     timing.boot_ms = Some(t_boot.elapsed().as_millis());
     if let Err(e) = start_result {
         return (Err(e.into()), timing);
+    }
+
+    let t_mount = Instant::now();
+    let run_id = match sandbox.id().parse::<RunId>() {
+        Ok(run_id) => run_id,
+        Err(e) => {
+            timing.workspace_mount_ms = Some(t_mount.elapsed().as_millis());
+            return (
+                Err(RunnerError::Internal(format!(
+                    "parse benchmark sandbox id as run id: {e}"
+                ))),
+                timing,
+            );
+        }
+    };
+    let mount_result = ensure_workspace_drive_mounted(sandbox, run_id).await;
+    timing.workspace_mount_ms = Some(t_mount.elapsed().as_millis());
+    if let Err(e) = mount_result {
+        return (Err(e), timing);
     }
 
     let t_clock = Instant::now();

--- a/crates/runner/src/cmd/build.rs
+++ b/crates/runner/src/cmd/build.rs
@@ -1307,7 +1307,7 @@ async fn build_template_locally(
         .arg(&debootstrap_lock_path)
         .arg("--hash")
         .arg(input.template_hash)
-        .arg("--disk-mb")
+        .arg("--rootfs-disk-mb")
         .arg(&rootfs_disk_mb_str);
     let status = run_rootfs_script(cmd, "build-template.sh").await?;
 

--- a/crates/runner/src/cmd/build.rs
+++ b/crates/runner/src/cmd/build.rs
@@ -506,12 +506,11 @@ pub async fn run_build(mut args: BuildArgs, provider: &dyn SnapshotProvider) -> 
                 def.rootfs_disk_mb,
             )
             .await?;
-            let workspace_size_bytes = workspace_image_size_bytes(def.workspace_disk_mb);
             let snapshot_hash = compute_snapshot_hash(
                 &rootfs_hash,
                 def.vcpu,
                 def.memory_mb,
-                workspace_size_bytes,
+                def.workspace_disk_mb,
                 FIRECRACKER_VERSION,
                 KERNEL_VERSION,
                 &provider.config_hash(),
@@ -715,7 +714,7 @@ async fn build_snapshot(
         output_dir: snapshot_dir.to_path_buf(),
         vcpu_count: def.vcpu,
         memory_mb: def.memory_mb,
-        workspace_image_size_bytes: workspace_image_size_bytes(def.workspace_disk_mb),
+        workspace_image_size_bytes: profile::workspace_disk_mb_to_bytes(def.workspace_disk_mb),
     };
 
     let pending = provider.create_uncommitted_snapshot(create_config).await?;
@@ -1634,14 +1633,14 @@ async fn compute_ca_cert_fingerprint(paths: &HomePaths) -> RunnerResult<String> 
 /// This hash is local-only (R2 stores only the shared template). It covers:
 ///   - `SNAPSHOT_CACHE_VERSION` — manual bump counter
 ///   - `rootfs_hash` — the rootfs this snapshot is built from
-///   - `vcpu`, `memory_mb`, `workspace_image_size_bytes` — VM resource config
+///   - `vcpu`, `memory_mb`, `workspace_disk_mb` — VM resource config
 ///   - `fc_version`, `kernel_version` — Firecracker and guest kernel versions
 ///   - `provider_config_hash` — sandbox-fc internal config (boot args, prewarm, etc.)
 fn compute_snapshot_hash(
     rootfs_hash: &str,
     vcpu: u32,
     memory_mb: u32,
-    workspace_image_size_bytes: u64,
+    workspace_disk_mb: u32,
     fc_version: &str,
     kernel_version: &str,
     provider_config_hash: &str,
@@ -1656,8 +1655,8 @@ fn compute_snapshot_hash(
     hasher.update(vcpu.to_le_bytes());
     hasher.update(b"memory_mb:");
     hasher.update(memory_mb.to_le_bytes());
-    hasher.update(b"workspace_image_size_bytes:");
-    hasher.update(workspace_image_size_bytes.to_le_bytes());
+    hasher.update(b"workspace_disk_mb:");
+    hasher.update(workspace_disk_mb.to_le_bytes());
     hasher.update(b"fc_version:");
     hasher.update(fc_version.as_bytes());
     hasher.update(b"kernel_version:");
@@ -1666,10 +1665,6 @@ fn compute_snapshot_hash(
     hasher.update(provider_config_hash.as_bytes());
 
     hex::encode(hasher.finalize())
-}
-
-fn workspace_image_size_bytes(workspace_disk_mb: u32) -> u64 {
-    u64::from(workspace_disk_mb) * 1024 * 1024
 }
 
 /// Return `(logical, disk)` as human-readable strings (e.g. "65.2 MiB").
@@ -3490,7 +3485,7 @@ exit 1
             "rootfs_aaa",
             2,
             4096,
-            workspace_image_size_bytes(16_384),
+            16_384,
             "v1.14.1",
             "6.1.155",
             "config_xxx",
@@ -3499,7 +3494,7 @@ exit 1
             "rootfs_aaa",
             2,
             4096,
-            workspace_image_size_bytes(16_384),
+            16_384,
             "v1.14.1",
             "6.1.155",
             "config_xxx",
@@ -3510,105 +3505,42 @@ exit 1
 
     #[test]
     fn compute_snapshot_hash_sensitive_to_each_field() {
-        let base = compute_snapshot_hash(
-            "rootfs_aaa",
-            2,
-            4096,
-            workspace_image_size_bytes(16_384),
-            "v1.14.1",
-            "6.1.155",
-            "cfg",
-        );
+        let base =
+            compute_snapshot_hash("rootfs_aaa", 2, 4096, 16_384, "v1.14.1", "6.1.155", "cfg");
 
         assert_ne!(
             base,
-            compute_snapshot_hash(
-                "rootfs_bbb",
-                2,
-                4096,
-                workspace_image_size_bytes(16_384),
-                "v1.14.1",
-                "6.1.155",
-                "cfg"
-            ),
+            compute_snapshot_hash("rootfs_bbb", 2, 4096, 16_384, "v1.14.1", "6.1.155", "cfg"),
             "must change with rootfs_hash"
         );
         assert_ne!(
             base,
-            compute_snapshot_hash(
-                "rootfs_aaa",
-                4,
-                4096,
-                workspace_image_size_bytes(16_384),
-                "v1.14.1",
-                "6.1.155",
-                "cfg"
-            ),
+            compute_snapshot_hash("rootfs_aaa", 4, 4096, 16_384, "v1.14.1", "6.1.155", "cfg"),
             "must change with vcpu"
         );
         assert_ne!(
             base,
-            compute_snapshot_hash(
-                "rootfs_aaa",
-                2,
-                8192,
-                workspace_image_size_bytes(16_384),
-                "v1.14.1",
-                "6.1.155",
-                "cfg"
-            ),
+            compute_snapshot_hash("rootfs_aaa", 2, 8192, 16_384, "v1.14.1", "6.1.155", "cfg"),
             "must change with memory_mb"
         );
         assert_ne!(
             base,
-            compute_snapshot_hash(
-                "rootfs_aaa",
-                2,
-                4096,
-                workspace_image_size_bytes(32_768),
-                "v1.14.1",
-                "6.1.155",
-                "cfg"
-            ),
-            "must change with workspace_image_size_bytes"
+            compute_snapshot_hash("rootfs_aaa", 2, 4096, 32_768, "v1.14.1", "6.1.155", "cfg"),
+            "must change with workspace_disk_mb"
         );
         assert_ne!(
             base,
-            compute_snapshot_hash(
-                "rootfs_aaa",
-                2,
-                4096,
-                workspace_image_size_bytes(16_384),
-                "v1.15.0",
-                "6.1.155",
-                "cfg"
-            ),
+            compute_snapshot_hash("rootfs_aaa", 2, 4096, 16_384, "v1.15.0", "6.1.155", "cfg"),
             "must change with fc_version"
         );
         assert_ne!(
             base,
-            compute_snapshot_hash(
-                "rootfs_aaa",
-                2,
-                4096,
-                workspace_image_size_bytes(16_384),
-                "v1.14.1",
-                "6.2.0",
-                "cfg"
-            ),
+            compute_snapshot_hash("rootfs_aaa", 2, 4096, 16_384, "v1.14.1", "6.2.0", "cfg"),
             "must change with kernel_version"
         );
         assert_ne!(
             base,
-            compute_snapshot_hash(
-                "rootfs_aaa",
-                2,
-                4096,
-                workspace_image_size_bytes(16_384),
-                "v1.14.1",
-                "6.1.155",
-                "cfg2"
-            ),
+            compute_snapshot_hash("rootfs_aaa", 2, 4096, 16_384, "v1.14.1", "6.1.155", "cfg2"),
             "must change with provider_config_hash"
         );
     }

--- a/crates/runner/src/cmd/build.rs
+++ b/crates/runner/src/cmd/build.rs
@@ -506,10 +506,12 @@ pub async fn run_build(mut args: BuildArgs, provider: &dyn SnapshotProvider) -> 
                 def.disk_mb,
             )
             .await?;
+            let workspace_size_bytes = workspace_image_size_bytes(def.disk_mb);
             let snapshot_hash = compute_snapshot_hash(
                 &rootfs_hash,
                 def.vcpu,
                 def.memory_mb,
+                workspace_size_bytes,
                 FIRECRACKER_VERSION,
                 KERNEL_VERSION,
                 &provider.config_hash(),
@@ -713,7 +715,7 @@ async fn build_snapshot(
         output_dir: snapshot_dir.to_path_buf(),
         vcpu_count: def.vcpu,
         memory_mb: def.memory_mb,
-        workspace_image_size_bytes: u64::from(def.disk_mb) * 1024 * 1024,
+        workspace_image_size_bytes: workspace_image_size_bytes(def.disk_mb),
     };
 
     let pending = provider.create_uncommitted_snapshot(create_config).await?;
@@ -1632,13 +1634,14 @@ async fn compute_ca_cert_fingerprint(paths: &HomePaths) -> RunnerResult<String> 
 /// This hash is local-only (R2 stores only the shared template). It covers:
 ///   - `SNAPSHOT_CACHE_VERSION` — manual bump counter
 ///   - `rootfs_hash` — the rootfs this snapshot is built from
-///   - `vcpu`, `memory_mb` — VM resource config
+///   - `vcpu`, `memory_mb`, `workspace_image_size_bytes` — VM resource config
 ///   - `fc_version`, `kernel_version` — Firecracker and guest kernel versions
 ///   - `provider_config_hash` — sandbox-fc internal config (boot args, prewarm, etc.)
 fn compute_snapshot_hash(
     rootfs_hash: &str,
     vcpu: u32,
     memory_mb: u32,
+    workspace_image_size_bytes: u64,
     fc_version: &str,
     kernel_version: &str,
     provider_config_hash: &str,
@@ -1653,6 +1656,8 @@ fn compute_snapshot_hash(
     hasher.update(vcpu.to_le_bytes());
     hasher.update(b"memory_mb:");
     hasher.update(memory_mb.to_le_bytes());
+    hasher.update(b"workspace_image_size_bytes:");
+    hasher.update(workspace_image_size_bytes.to_le_bytes());
     hasher.update(b"fc_version:");
     hasher.update(fc_version.as_bytes());
     hasher.update(b"kernel_version:");
@@ -1661,6 +1666,10 @@ fn compute_snapshot_hash(
     hasher.update(provider_config_hash.as_bytes());
 
     hex::encode(hasher.finalize())
+}
+
+fn workspace_image_size_bytes(disk_mb: u32) -> u64 {
+    u64::from(disk_mb) * 1024 * 1024
 }
 
 /// Return `(logical, disk)` as human-readable strings (e.g. "65.2 MiB").
@@ -3464,44 +3473,129 @@ exit 1
 
     #[test]
     fn compute_snapshot_hash_deterministic() {
-        let h1 = compute_snapshot_hash("rootfs_aaa", 2, 4096, "v1.14.1", "6.1.155", "config_xxx");
-        let h2 = compute_snapshot_hash("rootfs_aaa", 2, 4096, "v1.14.1", "6.1.155", "config_xxx");
+        let h1 = compute_snapshot_hash(
+            "rootfs_aaa",
+            2,
+            4096,
+            workspace_image_size_bytes(16_384),
+            "v1.14.1",
+            "6.1.155",
+            "config_xxx",
+        );
+        let h2 = compute_snapshot_hash(
+            "rootfs_aaa",
+            2,
+            4096,
+            workspace_image_size_bytes(16_384),
+            "v1.14.1",
+            "6.1.155",
+            "config_xxx",
+        );
         assert_eq!(h1, h2);
         assert_eq!(h1.len(), 64);
     }
 
     #[test]
     fn compute_snapshot_hash_sensitive_to_each_field() {
-        let base = compute_snapshot_hash("rootfs_aaa", 2, 4096, "v1.14.1", "6.1.155", "cfg");
+        let base = compute_snapshot_hash(
+            "rootfs_aaa",
+            2,
+            4096,
+            workspace_image_size_bytes(16_384),
+            "v1.14.1",
+            "6.1.155",
+            "cfg",
+        );
 
         assert_ne!(
             base,
-            compute_snapshot_hash("rootfs_bbb", 2, 4096, "v1.14.1", "6.1.155", "cfg"),
+            compute_snapshot_hash(
+                "rootfs_bbb",
+                2,
+                4096,
+                workspace_image_size_bytes(16_384),
+                "v1.14.1",
+                "6.1.155",
+                "cfg"
+            ),
             "must change with rootfs_hash"
         );
         assert_ne!(
             base,
-            compute_snapshot_hash("rootfs_aaa", 4, 4096, "v1.14.1", "6.1.155", "cfg"),
+            compute_snapshot_hash(
+                "rootfs_aaa",
+                4,
+                4096,
+                workspace_image_size_bytes(16_384),
+                "v1.14.1",
+                "6.1.155",
+                "cfg"
+            ),
             "must change with vcpu"
         );
         assert_ne!(
             base,
-            compute_snapshot_hash("rootfs_aaa", 2, 8192, "v1.14.1", "6.1.155", "cfg"),
+            compute_snapshot_hash(
+                "rootfs_aaa",
+                2,
+                8192,
+                workspace_image_size_bytes(16_384),
+                "v1.14.1",
+                "6.1.155",
+                "cfg"
+            ),
             "must change with memory_mb"
         );
         assert_ne!(
             base,
-            compute_snapshot_hash("rootfs_aaa", 2, 4096, "v1.15.0", "6.1.155", "cfg"),
+            compute_snapshot_hash(
+                "rootfs_aaa",
+                2,
+                4096,
+                workspace_image_size_bytes(32_768),
+                "v1.14.1",
+                "6.1.155",
+                "cfg"
+            ),
+            "must change with workspace_image_size_bytes"
+        );
+        assert_ne!(
+            base,
+            compute_snapshot_hash(
+                "rootfs_aaa",
+                2,
+                4096,
+                workspace_image_size_bytes(16_384),
+                "v1.15.0",
+                "6.1.155",
+                "cfg"
+            ),
             "must change with fc_version"
         );
         assert_ne!(
             base,
-            compute_snapshot_hash("rootfs_aaa", 2, 4096, "v1.14.1", "6.2.0", "cfg"),
+            compute_snapshot_hash(
+                "rootfs_aaa",
+                2,
+                4096,
+                workspace_image_size_bytes(16_384),
+                "v1.14.1",
+                "6.2.0",
+                "cfg"
+            ),
             "must change with kernel_version"
         );
         assert_ne!(
             base,
-            compute_snapshot_hash("rootfs_aaa", 2, 4096, "v1.14.1", "6.1.155", "cfg2"),
+            compute_snapshot_hash(
+                "rootfs_aaa",
+                2,
+                4096,
+                workspace_image_size_bytes(16_384),
+                "v1.14.1",
+                "6.1.155",
+                "cfg2"
+            ),
             "must change with provider_config_hash"
         );
     }

--- a/crates/runner/src/cmd/build.rs
+++ b/crates/runner/src/cmd/build.rs
@@ -714,7 +714,7 @@ async fn build_snapshot(
         output_dir: snapshot_dir.to_path_buf(),
         vcpu_count: def.vcpu,
         memory_mb: def.memory_mb,
-        workspace_image_size_bytes: profile::workspace_disk_mb_to_bytes(def.workspace_disk_mb),
+        workspace_disk_mb: def.workspace_disk_mb,
     };
 
     let pending = provider.create_uncommitted_snapshot(create_config).await?;
@@ -1706,7 +1706,7 @@ mod tests {
     use aws_smithy_mocks::{Rule, RuleMode, mock, mock_client};
     use std::sync::{
         Arc,
-        atomic::{AtomicBool, AtomicU64, Ordering},
+        atomic::{AtomicBool, AtomicU32, Ordering},
     };
 
     #[derive(clap::Parser)]
@@ -2008,7 +2008,7 @@ printf called >> "$script_dir/verify-rootfs-called"
         create_uncommitted_called: Arc<AtomicBool>,
         create_snapshot_called: Arc<AtomicBool>,
         committed: Arc<AtomicBool>,
-        workspace_image_size_bytes: Arc<AtomicU64>,
+        workspace_disk_mb: Arc<AtomicU32>,
     }
 
     #[async_trait::async_trait]
@@ -2018,8 +2018,8 @@ printf called >> "$script_dir/verify-rootfs-called"
             config: sandbox::SnapshotCreateConfig,
         ) -> Result<Box<dyn sandbox::PendingSnapshotPublish>, sandbox::SnapshotError> {
             self.create_uncommitted_called.store(true, Ordering::SeqCst);
-            self.workspace_image_size_bytes
-                .store(config.workspace_image_size_bytes, Ordering::SeqCst);
+            self.workspace_disk_mb
+                .store(config.workspace_disk_mb, Ordering::SeqCst);
             Ok(Box::new(RecordingPendingSnapshotPublish {
                 output_dir: config.output_dir,
                 committed: Arc::clone(&self.committed),
@@ -2416,12 +2416,12 @@ exit 1
         let create_uncommitted_called = Arc::new(AtomicBool::new(false));
         let create_snapshot_called = Arc::new(AtomicBool::new(false));
         let committed = Arc::new(AtomicBool::new(false));
-        let workspace_image_size_bytes = Arc::new(AtomicU64::new(0));
+        let workspace_disk_mb = Arc::new(AtomicU32::new(0));
         let provider = RecordingSnapshotProvider {
             create_uncommitted_called: Arc::clone(&create_uncommitted_called),
             create_snapshot_called: Arc::clone(&create_snapshot_called),
             committed: Arc::clone(&committed),
-            workspace_image_size_bytes: Arc::clone(&workspace_image_size_bytes),
+            workspace_disk_mb: Arc::clone(&workspace_disk_mb),
         };
         let def = profile::ProfileDef {
             vcpu: 1,
@@ -2445,9 +2445,9 @@ exit 1
         assert!(create_uncommitted_called.load(Ordering::SeqCst));
         assert!(committed.load(Ordering::SeqCst));
         assert_eq!(
-            workspace_image_size_bytes.load(Ordering::SeqCst),
-            16 * 1024 * 1024,
-            "snapshot workspace image size must use workspace_disk_mb, not rootfs_disk_mb"
+            workspace_disk_mb.load(Ordering::SeqCst),
+            16,
+            "snapshot workspace disk size must use workspace_disk_mb, not rootfs_disk_mb"
         );
         assert!(
             !create_snapshot_called.load(Ordering::SeqCst),

--- a/crates/runner/src/cmd/build.rs
+++ b/crates/runner/src/cmd/build.rs
@@ -142,7 +142,7 @@ pub struct BuildArgs {
         arg(long, help = "Path to guest-write-file binary (required)")
     )]
     guest_write_file: Option<PathBuf>,
-    /// Profile to build (determines VM resources and disk size)
+    /// Profile to build (determines VM resources and disk sizes)
     #[arg(long)]
     pub profile: String,
     /// Compute and print the image hash without building
@@ -264,7 +264,7 @@ struct TemplateInput<'a> {
     paths: &'a HomePaths,
     template_hash: &'a str,
     cache: TemplateCache<'a>,
-    disk_mb: u32,
+    rootfs_disk_mb: u32,
 }
 
 struct RootfsBuildInput<'a> {
@@ -483,7 +483,7 @@ pub async fn run_build(mut args: BuildArgs, provider: &dyn SnapshotProvider) -> 
         BuildMode::WarmRootfsCache => None,
     };
 
-    let template_hash = compute_template_hash(def.disk_mb);
+    let template_hash = compute_template_hash(def.rootfs_disk_mb);
     let hashes = match mode {
         BuildMode::WarmRootfsCache => BuildHashes {
             template_hash,
@@ -503,10 +503,10 @@ pub async fn run_build(mut args: BuildArgs, provider: &dyn SnapshotProvider) -> 
                 &template_hash,
                 &guests.hash_inputs(),
                 &ca_fingerprint,
-                def.disk_mb,
+                def.rootfs_disk_mb,
             )
             .await?;
-            let workspace_size_bytes = workspace_image_size_bytes(def.disk_mb);
+            let workspace_size_bytes = workspace_image_size_bytes(def.workspace_disk_mb);
             let snapshot_hash = compute_snapshot_hash(
                 &rootfs_hash,
                 def.vcpu,
@@ -600,7 +600,7 @@ pub async fn run_build(mut args: BuildArgs, provider: &dyn SnapshotProvider) -> 
         paths: &paths,
         template_hash: &hashes.template_hash,
         cache: template_cache,
-        disk_mb: def.disk_mb,
+        rootfs_disk_mb: def.rootfs_disk_mb,
     };
 
     match mode {
@@ -715,7 +715,7 @@ async fn build_snapshot(
         output_dir: snapshot_dir.to_path_buf(),
         vcpu_count: def.vcpu,
         memory_mb: def.memory_mb,
-        workspace_image_size_bytes: workspace_image_size_bytes(def.disk_mb),
+        workspace_image_size_bytes: workspace_image_size_bytes(def.workspace_disk_mb),
     };
 
     let pending = provider.create_uncommitted_snapshot(create_config).await?;
@@ -1297,7 +1297,7 @@ async fn build_template_locally(
         .map_err(|e| RunnerError::Internal(format!("create {}: {e}", debootstrap_dir.display())))?;
     let debootstrap_lock_path = input.paths.debootstrap_lock();
     drop(lock::open_lock_file(&debootstrap_lock_path)?);
-    let disk_mb_str = input.disk_mb.to_string();
+    let rootfs_disk_mb_str = input.rootfs_disk_mb.to_string();
 
     let mut cmd = rootfs_script_command(&work_dir.join("build-template.sh"));
     cmd.arg("--output-dir")
@@ -1309,7 +1309,7 @@ async fn build_template_locally(
         .arg("--hash")
         .arg(input.template_hash)
         .arg("--disk-mb")
-        .arg(&disk_mb_str);
+        .arg(&rootfs_disk_mb_str);
     let status = run_rootfs_script(cmd, "build-template.sh").await?;
 
     if !status.success() {
@@ -1563,13 +1563,13 @@ fn remove_file_if_exists_sync(path: &Path, label: &str) -> RunnerResult<()> {
 /// Inputs:
 ///   - `TEMPLATE_CACHE_VERSION` — bump to force invalidation
 ///   - `TEMPLATE_BUILD_SCRIPT` — template build script content
-///   - `disk_mb` — disk size from profile
+///   - `rootfs_disk_mb` — rootfs disk size from profile
 ///
 /// Guest binaries and host-local CA are deliberately excluded; those belong
 /// to the local rootfs hash.
 ///
 /// **Changing this function invalidates all shared template images.**
-fn compute_template_hash(disk_mb: u32) -> String {
+fn compute_template_hash(rootfs_disk_mb: u32) -> String {
     let mut hasher = Sha256::new();
 
     hasher.update(b"template_version:");
@@ -1578,8 +1578,8 @@ fn compute_template_hash(disk_mb: u32) -> String {
     hasher.update(TEMPLATE_BUILD_SCRIPT.as_bytes());
     hasher.update(b"arch:");
     hasher.update(std::env::consts::ARCH.as_bytes());
-    hasher.update(b"disk_mb:");
-    hasher.update(disk_mb.to_le_bytes());
+    hasher.update(b"rootfs_disk_mb:");
+    hasher.update(rootfs_disk_mb.to_le_bytes());
 
     hex::encode(hasher.finalize())
 }
@@ -1592,7 +1592,7 @@ async fn compute_rootfs_hash(
     template_hash: &str,
     guest_bins: &[(&Path, &str)],
     ca_fingerprint: &str,
-    disk_mb: u32,
+    rootfs_disk_mb: u32,
 ) -> RunnerResult<String> {
     let mut hasher = Sha256::new();
 
@@ -1602,8 +1602,8 @@ async fn compute_rootfs_hash(
     hasher.update(template_hash.as_bytes());
     hasher.update(b"customize_script:");
     hasher.update(CUSTOMIZE_SCRIPT.as_bytes());
-    hasher.update(b"disk_mb:");
-    hasher.update(disk_mb.to_le_bytes());
+    hasher.update(b"rootfs_disk_mb:");
+    hasher.update(rootfs_disk_mb.to_le_bytes());
     hasher.update(b"ca_fingerprint:");
     hasher.update(ca_fingerprint.as_bytes());
     hasher.update(b"dns_nameserver:");
@@ -1668,8 +1668,8 @@ fn compute_snapshot_hash(
     hex::encode(hasher.finalize())
 }
 
-fn workspace_image_size_bytes(disk_mb: u32) -> u64 {
-    u64::from(disk_mb) * 1024 * 1024
+fn workspace_image_size_bytes(workspace_disk_mb: u32) -> u64 {
+    u64::from(workspace_disk_mb) * 1024 * 1024
 }
 
 /// Return `(logical, disk)` as human-readable strings (e.g. "65.2 MiB").
@@ -1711,7 +1711,7 @@ mod tests {
     use aws_smithy_mocks::{Rule, RuleMode, mock, mock_client};
     use std::sync::{
         Arc,
-        atomic::{AtomicBool, Ordering},
+        atomic::{AtomicBool, AtomicU64, Ordering},
     };
 
     #[derive(clap::Parser)]
@@ -1779,7 +1779,7 @@ mod tests {
                 paths: home,
                 template_hash: "test-template-hash",
                 cache,
-                disk_mb: 16384,
+                rootfs_disk_mb: 8192,
             },
             rootfs_paths: rootfs,
             guests,
@@ -1808,7 +1808,7 @@ mod tests {
             paths: home,
             template_hash: "test-template-hash",
             cache,
-            disk_mb: 128,
+            rootfs_disk_mb: 128,
         }
     }
 
@@ -2013,6 +2013,7 @@ printf called >> "$script_dir/verify-rootfs-called"
         create_uncommitted_called: Arc<AtomicBool>,
         create_snapshot_called: Arc<AtomicBool>,
         committed: Arc<AtomicBool>,
+        workspace_image_size_bytes: Arc<AtomicU64>,
     }
 
     #[async_trait::async_trait]
@@ -2022,6 +2023,8 @@ printf called >> "$script_dir/verify-rootfs-called"
             config: sandbox::SnapshotCreateConfig,
         ) -> Result<Box<dyn sandbox::PendingSnapshotPublish>, sandbox::SnapshotError> {
             self.create_uncommitted_called.store(true, Ordering::SeqCst);
+            self.workspace_image_size_bytes
+                .store(config.workspace_image_size_bytes, Ordering::SeqCst);
             Ok(Box::new(RecordingPendingSnapshotPublish {
                 output_dir: config.output_dir,
                 committed: Arc::clone(&self.committed),
@@ -2418,15 +2421,18 @@ exit 1
         let create_uncommitted_called = Arc::new(AtomicBool::new(false));
         let create_snapshot_called = Arc::new(AtomicBool::new(false));
         let committed = Arc::new(AtomicBool::new(false));
+        let workspace_image_size_bytes = Arc::new(AtomicU64::new(0));
         let provider = RecordingSnapshotProvider {
             create_uncommitted_called: Arc::clone(&create_uncommitted_called),
             create_snapshot_called: Arc::clone(&create_snapshot_called),
             committed: Arc::clone(&committed),
+            workspace_image_size_bytes: Arc::clone(&workspace_image_size_bytes),
         };
         let def = profile::ProfileDef {
             vcpu: 1,
             memory_mb: 128,
-            disk_mb: 16,
+            rootfs_disk_mb: 8,
+            workspace_disk_mb: 16,
         };
 
         build_snapshot(
@@ -2443,6 +2449,11 @@ exit 1
 
         assert!(create_uncommitted_called.load(Ordering::SeqCst));
         assert!(committed.load(Ordering::SeqCst));
+        assert_eq!(
+            workspace_image_size_bytes.load(Ordering::SeqCst),
+            16 * 1024 * 1024,
+            "snapshot workspace image size must use workspace_disk_mb, not rootfs_disk_mb"
+        );
         assert!(
             !create_snapshot_called.load(Ordering::SeqCst),
             "build_snapshot should not use the compatibility create_snapshot path"
@@ -2470,7 +2481,8 @@ exit 1
         let def = profile::ProfileDef {
             vcpu: 1,
             memory_mb: 128,
-            disk_mb: 16,
+            rootfs_disk_mb: 8,
+            workspace_disk_mb: 16,
         };
 
         let err = build_snapshot(
@@ -2513,7 +2525,8 @@ exit 1
         let def = profile::ProfileDef {
             vcpu: 1,
             memory_mb: 128,
-            disk_mb: 16,
+            rootfs_disk_mb: 8,
+            workspace_disk_mb: 16,
         };
 
         let err = build_snapshot(
@@ -2704,7 +2717,7 @@ exit 1
             paths: &home,
             template_hash: "best-effort-hash",
             cache: TemplateCache::Disabled,
-            disk_mb: 16384,
+            rootfs_disk_mb: 8192,
         };
 
         upload_template_to_r2(&input, &template, false)
@@ -3438,7 +3451,7 @@ exit 1
         )
         .await
         .unwrap();
-        assert_ne!(base, different_disk, "hash must change with disk_mb");
+        assert_ne!(base, different_disk, "hash must change with rootfs_disk_mb");
 
         let different_dest = compute_rootfs_hash(
             "template-a",

--- a/crates/runner/src/cmd/build.rs
+++ b/crates/runner/src/cmd/build.rs
@@ -713,6 +713,7 @@ async fn build_snapshot(
         output_dir: snapshot_dir.to_path_buf(),
         vcpu_count: def.vcpu,
         memory_mb: def.memory_mb,
+        workspace_image_size_bytes: u64::from(def.disk_mb) * 1024 * 1024,
     };
 
     let pending = provider.create_uncommitted_snapshot(create_config).await?;

--- a/crates/runner/src/cmd/config.rs
+++ b/crates/runner/src/cmd/config.rs
@@ -102,7 +102,8 @@ pub async fn run_config(args: ConfigArgs) -> RunnerResult<()> {
                 snapshot_hash: snapshot_hash.clone(),
                 vcpu: def.vcpu,
                 memory_mb: def.memory_mb,
-                disk_mb: def.disk_mb,
+                rootfs_disk_mb: def.rootfs_disk_mb,
+                workspace_disk_mb: def.workspace_disk_mb,
             },
         );
     }

--- a/crates/runner/src/cmd/doctor.rs
+++ b/crates/runner/src/cmd/doctor.rs
@@ -1786,7 +1786,8 @@ mod tests {
                     "snapshot_hash": "snapshot",
                     "vcpu": 1,
                     "memory_mb": 512,
-                    "disk_mb": 1024,
+                    "rootfs_disk_mb": 512,
+                    "workspace_disk_mb": 1024,
                 },
             },
         });

--- a/crates/runner/src/cmd/setup.rs
+++ b/crates/runner/src/cmd/setup.rs
@@ -65,10 +65,17 @@ fn check_architecture() -> RunnerResult<&'static str> {
 
 /// Returns names of missing required dependencies.
 fn check_system_dependencies() -> Vec<&'static str> {
-    // Required by `runner start` (sandbox networking)
-    let required = ["ip", "iptables", "iptables-save", "sysctl", "dnsmasq"];
+    // Required by `runner start` (sandbox networking and workspace images).
+    let required = [
+        "ip",
+        "iptables",
+        "iptables-save",
+        "sysctl",
+        "dnsmasq",
+        "mkfs.ext4",
+    ];
     // Only needed by specific commands (rootfs, build, etc.)
-    let optional = ["pgrep", "mkfs.ext4", "debootstrap", "flock", "openssl"];
+    let optional = ["pgrep", "debootstrap", "flock", "openssl"];
 
     let missing_required: Vec<&str> = required
         .iter()
@@ -579,7 +586,14 @@ mod tests {
     #[test]
     fn check_system_dependencies_only_returns_known_deps() {
         let missing = check_system_dependencies();
-        let known = ["ip", "iptables", "iptables-save", "sysctl", "dnsmasq"];
+        let known = [
+            "ip",
+            "iptables",
+            "iptables-save",
+            "sysctl",
+            "dnsmasq",
+            "mkfs.ext4",
+        ];
         for dep in &missing {
             assert!(
                 known.contains(dep),

--- a/crates/runner/src/cmd/start/factory_lifecycle.rs
+++ b/crates/runner/src/cmd/start/factory_lifecycle.rs
@@ -186,7 +186,8 @@ mod tests {
             snapshot_hash: snapshot_hash.into(),
             vcpu: 2,
             memory_mb: 4096,
-            disk_mb: 10240,
+            rootfs_disk_mb: 8192,
+            workspace_disk_mb: 10240,
         }
     }
 

--- a/crates/runner/src/cmd/start/heartbeat.rs
+++ b/crates/runner/src/cmd/start/heartbeat.rs
@@ -143,7 +143,8 @@ mod tests {
                 snapshot_hash: "snap".into(),
                 vcpu: 2,
                 memory_mb: 4096,
-                disk_mb: 10240,
+                rootfs_disk_mb: 8192,
+                workspace_disk_mb: 10240,
             },
         );
         m

--- a/crates/runner/src/cmd/start/idle_lifecycle.rs
+++ b/crates/runner/src/cmd/start/idle_lifecycle.rs
@@ -279,6 +279,7 @@ mod tests {
                     memory_mb: 4096,
                 },
                 device_rate_limits: None,
+                workspace_drive: None,
             })
             .await
             .expect("create sandbox");
@@ -329,6 +330,7 @@ mod tests {
                     memory_mb: 4096,
                 },
                 device_rate_limits: None,
+                workspace_drive: None,
             })
             .await
             .expect("create sandbox");

--- a/crates/runner/src/cmd/start/job_discovery.rs
+++ b/crates/runner/src/cmd/start/job_discovery.rs
@@ -52,7 +52,7 @@ pub(super) async fn handle_discovered_job(job: DiscoveredJob, mut ctx: Discovere
     };
     let job_vcpu = profile_config.vcpu;
     let job_memory = profile_config.memory_mb;
-    let job_disk_mb = profile_config.disk_mb;
+    let job_workspace_disk_mb = profile_config.workspace_disk_mb;
     // Look up factory for this profile.
     let Some((factory, restore_guest_state)) = ctx.factories.get(&profile_name) else {
         warn!(run_id = %run_id, profile = %profile_name, "no factory for profile, skipping");
@@ -136,7 +136,7 @@ pub(super) async fn handle_discovered_job(job: DiscoveredJob, mut ctx: Discovere
         profile_name,
         vcpu: job_vcpu,
         memory_mb: job_memory,
-        disk_mb: job_disk_mb,
+        workspace_disk_mb: job_workspace_disk_mb,
         budget_lease: active_lease,
         restore_guest_state: *restore_guest_state,
         device_rate_limits,

--- a/crates/runner/src/cmd/start/job_discovery.rs
+++ b/crates/runner/src/cmd/start/job_discovery.rs
@@ -52,6 +52,7 @@ pub(super) async fn handle_discovered_job(job: DiscoveredJob, mut ctx: Discovere
     };
     let job_vcpu = profile_config.vcpu;
     let job_memory = profile_config.memory_mb;
+    let job_disk_mb = profile_config.disk_mb;
     // Look up factory for this profile.
     let Some((factory, restore_guest_state)) = ctx.factories.get(&profile_name) else {
         warn!(run_id = %run_id, profile = %profile_name, "no factory for profile, skipping");
@@ -135,6 +136,7 @@ pub(super) async fn handle_discovered_job(job: DiscoveredJob, mut ctx: Discovere
         profile_name,
         vcpu: job_vcpu,
         memory_mb: job_memory,
+        disk_mb: job_disk_mb,
         budget_lease: active_lease,
         restore_guest_state: *restore_guest_state,
         device_rate_limits,

--- a/crates/runner/src/cmd/start/job_spawn.rs
+++ b/crates/runner/src/cmd/start/job_spawn.rs
@@ -41,7 +41,7 @@ pub(super) struct JobProfile {
     pub(super) profile_name: String,
     pub(super) vcpu: u32,
     pub(super) memory_mb: u32,
-    pub(super) disk_mb: u32,
+    pub(super) workspace_disk_mb: u32,
     pub(super) budget_lease: BudgetLease,
     pub(super) restore_guest_state: bool,
     pub(super) device_rate_limits: Option<sandbox::DeviceRateLimits>,
@@ -106,7 +106,7 @@ pub(super) fn spawn_job(
     let params = executor::JobParams {
         vcpu,
         memory_mb,
-        disk_mb: job_profile.disk_mb,
+        workspace_disk_mb: job_profile.workspace_disk_mb,
         restore_guest_state: job_profile.restore_guest_state,
         device_rate_limits: job_profile.device_rate_limits.clone(),
     };

--- a/crates/runner/src/cmd/start/job_spawn.rs
+++ b/crates/runner/src/cmd/start/job_spawn.rs
@@ -41,6 +41,7 @@ pub(super) struct JobProfile {
     pub(super) profile_name: String,
     pub(super) vcpu: u32,
     pub(super) memory_mb: u32,
+    pub(super) disk_mb: u32,
     pub(super) budget_lease: BudgetLease,
     pub(super) restore_guest_state: bool,
     pub(super) device_rate_limits: Option<sandbox::DeviceRateLimits>,
@@ -105,6 +106,7 @@ pub(super) fn spawn_job(
     let params = executor::JobParams {
         vcpu,
         memory_mb,
+        disk_mb: job_profile.disk_mb,
         restore_guest_state: job_profile.restore_guest_state,
         device_rate_limits: job_profile.device_rate_limits.clone(),
     };

--- a/crates/runner/src/cmd/start/tests/support/env.rs
+++ b/crates/runner/src/cmd/start/tests/support/env.rs
@@ -17,7 +17,8 @@ pub(in super::super) fn test_profiles() -> BTreeMap<String, config::ProfileConfi
             snapshot_hash: "snap".into(),
             vcpu: 2,
             memory_mb: 4096,
-            disk_mb: 10240,
+            rootfs_disk_mb: 8192,
+            workspace_disk_mb: 10240,
         },
     );
     m
@@ -286,7 +287,8 @@ pub(in super::super) fn two_profiles() -> BTreeMap<String, config::ProfileConfig
             snapshot_hash: "snap".into(),
             vcpu: 2,
             memory_mb: 4096,
-            disk_mb: 10240,
+            rootfs_disk_mb: 8192,
+            workspace_disk_mb: 10240,
         },
     );
     m.insert(
@@ -296,7 +298,8 @@ pub(in super::super) fn two_profiles() -> BTreeMap<String, config::ProfileConfig
             snapshot_hash: "snap2".into(),
             vcpu: 4,
             memory_mb: 8192,
-            disk_mb: 20480,
+            rootfs_disk_mb: 8192,
+            workspace_disk_mb: 20480,
         },
     );
     m

--- a/crates/runner/src/cmd/start/tests/support/idle_pool.rs
+++ b/crates/runner/src/cmd/start/tests/support/idle_pool.rs
@@ -76,6 +76,7 @@ pub(in super::super) async fn seed_idle_pool_with_overrides(
                 memory_mb,
             },
             device_rate_limits: None,
+            workspace_drive: None,
         })
         .await
         .expect("create sandbox");

--- a/crates/runner/src/config.rs
+++ b/crates/runner/src/config.rs
@@ -35,7 +35,7 @@
 use std::collections::BTreeMap;
 use std::path::{Path, PathBuf};
 
-use serde::{Deserialize, Serialize};
+use serde::{Deserialize, Deserializer, Serialize};
 
 use crate::error::{RunnerError, RunnerResult};
 use crate::idle_pool::DEFAULT_IDLE_TIMEOUT_SECS;
@@ -100,7 +100,7 @@ pub struct FirecrackerConfig {
 ///
 /// See the module-level docs for the two-hash identity scheme
 /// (`rootfs_hash` covers the local rootfs, `snapshot_hash` is local-only).
-#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Serialize)]
 pub struct ProfileConfig {
     /// Content-addressed rootfs hash (shared across snapshot variants on this host).
     pub rootfs_hash: String,
@@ -110,9 +110,49 @@ pub struct ProfileConfig {
     pub vcpu: u32,
     /// Guest RAM in MiB. Must be non-zero and ≤ 1 TiB.
     pub memory_mb: u32,
-    /// Guest disk in MiB, used to size the rootfs image and workspace drive.
+    /// Rootfs disk in MiB. Used to size the bootable rootfs image.
     /// Must be non-zero and ≤ 1 TiB.
-    pub disk_mb: u32,
+    pub rootfs_disk_mb: u32,
+    /// Workspace disk in MiB. Used to size the writable workspace drive.
+    /// Must be non-zero and ≤ 1 TiB.
+    pub workspace_disk_mb: u32,
+}
+
+#[derive(Deserialize)]
+struct ProfileConfigWire {
+    rootfs_hash: String,
+    snapshot_hash: String,
+    vcpu: u32,
+    memory_mb: u32,
+    rootfs_disk_mb: Option<u32>,
+    workspace_disk_mb: Option<u32>,
+    disk_mb: Option<u32>,
+}
+
+impl<'de> Deserialize<'de> for ProfileConfig {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        let wire = ProfileConfigWire::deserialize(deserializer)?;
+        let rootfs_disk_mb = wire
+            .rootfs_disk_mb
+            .or(wire.disk_mb)
+            .ok_or_else(|| serde::de::Error::missing_field("rootfs_disk_mb"))?;
+        let workspace_disk_mb = wire
+            .workspace_disk_mb
+            .or(wire.disk_mb)
+            .ok_or_else(|| serde::de::Error::missing_field("workspace_disk_mb"))?;
+
+        Ok(Self {
+            rootfs_hash: wire.rootfs_hash,
+            snapshot_hash: wire.snapshot_hash,
+            vcpu: wire.vcpu,
+            memory_mb: wire.memory_mb,
+            rootfs_disk_mb,
+            workspace_disk_mb,
+        })
+    }
 }
 
 /// Sandbox-level knobs for concurrency and the idle-VM pool.
@@ -285,9 +325,13 @@ async fn validate(
     check_path_exists(&config.firecracker.kernel, "kernel").await?;
 
     for (name, profile) in &config.profiles {
-        if profile.vcpu == 0 || profile.memory_mb == 0 || profile.disk_mb == 0 {
+        if profile.vcpu == 0
+            || profile.memory_mb == 0
+            || profile.rootfs_disk_mb == 0
+            || profile.workspace_disk_mb == 0
+        {
             return Err(RunnerError::Config(format!(
-                "profile {name}: vcpu, memory_mb, and disk_mb must be non-zero"
+                "profile {name}: vcpu, memory_mb, rootfs_disk_mb, and workspace_disk_mb must be non-zero"
             )));
         }
         if profile.vcpu > MAX_VCPU {
@@ -302,10 +346,16 @@ async fn validate(
                 profile.memory_mb
             )));
         }
-        if profile.disk_mb > MAX_DISK_MB {
+        if profile.rootfs_disk_mb > MAX_DISK_MB {
             return Err(RunnerError::Config(format!(
-                "profile {name}: disk_mb ({}) exceeds maximum ({MAX_DISK_MB})",
-                profile.disk_mb
+                "profile {name}: rootfs_disk_mb ({}) exceeds maximum ({MAX_DISK_MB})",
+                profile.rootfs_disk_mb
+            )));
+        }
+        if profile.workspace_disk_mb > MAX_DISK_MB {
+            return Err(RunnerError::Config(format!(
+                "profile {name}: workspace_disk_mb ({}) exceeds maximum ({MAX_DISK_MB})",
+                profile.workspace_disk_mb
             )));
         }
         if validate_image_artifacts {

--- a/crates/runner/src/config.rs
+++ b/crates/runner/src/config.rs
@@ -19,10 +19,11 @@
 //! Each [`ProfileConfig`] carries two hashes with different scopes:
 //! - `rootfs_hash` — content hash of the bootable guest filesystem image on
 //!   this runner. Shared across snapshot variants on the same host.
-//! - `snapshot_hash` — content hash of the FC/kernel/vcpu/memory/provider
-//!   config used to capture the memory snapshot from that rootfs. Local-only:
-//!   snapshots are produced on each runner by booting the rootfs and
-//!   capturing state, since the captured memory binds to host-specific state.
+//! - `snapshot_hash` — content hash of the rootfs hash plus the
+//!   FC/kernel/vcpu/memory/provider config used to capture the memory snapshot.
+//!   Local-only: snapshots are produced on each runner by booting the rootfs
+//!   and capturing state, since the captured memory binds to host-specific
+//!   state.
 //!
 //! Together they identify an exact boot image on this host.
 //!
@@ -103,14 +104,14 @@ pub struct FirecrackerConfig {
 pub struct ProfileConfig {
     /// Content-addressed rootfs hash (shared across snapshot variants on this host).
     pub rootfs_hash: String,
-    /// Content-addressed snapshot hash (local-only, covers FC/kernel/vcpu/memory/provider config).
+    /// Content-addressed snapshot hash (local-only, covers rootfs plus VM/provider config).
     pub snapshot_hash: String,
     /// Guest vCPU count. Must be non-zero and ≤ 1024.
     pub vcpu: u32,
     /// Guest RAM in MiB. Must be non-zero and ≤ 1 TiB.
     pub memory_mb: u32,
-    /// Guest disk in MiB, used to size the COW overlay. Must be non-zero
-    /// and ≤ 1 TiB.
+    /// Guest disk in MiB, used to size the rootfs image and workspace drive.
+    /// Must be non-zero and ≤ 1 TiB.
     pub disk_mb: u32,
 }
 

--- a/crates/runner/src/config.rs
+++ b/crates/runner/src/config.rs
@@ -35,7 +35,7 @@
 use std::collections::BTreeMap;
 use std::path::{Path, PathBuf};
 
-use serde::{Deserialize, Deserializer, Serialize};
+use serde::{Deserialize, Serialize};
 
 use crate::error::{RunnerError, RunnerResult};
 use crate::idle_pool::DEFAULT_IDLE_TIMEOUT_SECS;
@@ -100,7 +100,7 @@ pub struct FirecrackerConfig {
 ///
 /// See the module-level docs for the two-hash identity scheme
 /// (`rootfs_hash` covers the local rootfs, `snapshot_hash` is local-only).
-#[derive(Debug, Clone, PartialEq, Serialize)]
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct ProfileConfig {
     /// Content-addressed rootfs hash (shared across snapshot variants on this host).
     pub rootfs_hash: String,
@@ -116,43 +116,6 @@ pub struct ProfileConfig {
     /// Workspace disk in MiB. Used to size the writable workspace drive.
     /// Must be non-zero and ≤ 1 TiB.
     pub workspace_disk_mb: u32,
-}
-
-#[derive(Deserialize)]
-struct ProfileConfigWire {
-    rootfs_hash: String,
-    snapshot_hash: String,
-    vcpu: u32,
-    memory_mb: u32,
-    rootfs_disk_mb: Option<u32>,
-    workspace_disk_mb: Option<u32>,
-    disk_mb: Option<u32>,
-}
-
-impl<'de> Deserialize<'de> for ProfileConfig {
-    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
-    where
-        D: Deserializer<'de>,
-    {
-        let wire = ProfileConfigWire::deserialize(deserializer)?;
-        let rootfs_disk_mb = wire
-            .rootfs_disk_mb
-            .or(wire.disk_mb)
-            .ok_or_else(|| serde::de::Error::missing_field("rootfs_disk_mb"))?;
-        let workspace_disk_mb = wire
-            .workspace_disk_mb
-            .or(wire.disk_mb)
-            .ok_or_else(|| serde::de::Error::missing_field("workspace_disk_mb"))?;
-
-        Ok(Self {
-            rootfs_hash: wire.rootfs_hash,
-            snapshot_hash: wire.snapshot_hash,
-            vcpu: wire.vcpu,
-            memory_mb: wire.memory_mb,
-            rootfs_disk_mb,
-            workspace_disk_mb,
-        })
-    }
 }
 
 /// Sandbox-level knobs for concurrency and the idle-VM pool.

--- a/crates/runner/src/config_tests.rs
+++ b/crates/runner/src/config_tests.rs
@@ -75,7 +75,8 @@ firecracker:
     snapshot_hash: {snapshot_hash}
     vcpu: 2
     memory_mb: 4096
-    disk_mb: 16384
+    rootfs_disk_mb: 8192
+    workspace_disk_mb: 16384
 {extra}"#,
             rootfs_hash = TEST_ROOTFS_HASH,
             snapshot_hash = TEST_SNAPSHOT_HASH,
@@ -147,7 +148,8 @@ fn make_profiles() -> BTreeMap<String, ProfileConfig> {
             snapshot_hash: TEST_SNAPSHOT_HASH.into(),
             vcpu: 2,
             memory_mb: 4096,
-            disk_mb: 16384,
+            rootfs_disk_mb: 8192,
+            workspace_disk_mb: 16384,
         },
     );
     profiles
@@ -167,7 +169,8 @@ profiles:
     snapshot_hash: {snap_hash}
     vcpu: 2
     memory_mb: 4096
-    disk_mb: 16384
+    rootfs_disk_mb: 8192
+    workspace_disk_mb: 16384
 sandbox:
   max_concurrent: 8
   concurrency_factor: 2.0
@@ -186,11 +189,36 @@ server:
     let default = &config.profiles["vm0/default"];
     assert_eq!(default.vcpu, 2);
     assert_eq!(default.rootfs_hash, TEST_ROOTFS_HASH);
+    assert_eq!(default.rootfs_disk_mb, 8192);
+    assert_eq!(default.workspace_disk_mb, 16384);
     assert_eq!(config.sandbox.max_concurrent, 8);
     assert!((config.sandbox.concurrency_factor - 2.0).abs() < f64::EPSILON);
     let server = config.server.unwrap();
     assert_eq!(server.url, "https://api.example.com");
     assert_eq!(server.token, "secret");
+}
+
+#[tokio::test]
+async fn load_maps_legacy_disk_mb_to_rootfs_and_workspace_disk_mb() {
+    let fixture = ConfigFixture::new().await;
+    let yaml = fixture.yaml(&format!(
+        r#"
+profiles:
+  vm0/default:
+    rootfs_hash: {hash}
+    snapshot_hash: {snap_hash}
+    vcpu: 2
+    memory_mb: 4096
+    disk_mb: 12288
+"#,
+        hash = TEST_ROOTFS_HASH,
+        snap_hash = TEST_SNAPSHOT_HASH,
+    ));
+
+    let config = fixture.load_config(&yaml, true).await.unwrap();
+    let default = &config.profiles["vm0/default"];
+    assert_eq!(default.rootfs_disk_mb, 12288);
+    assert_eq!(default.workspace_disk_mb, 12288);
 }
 
 #[tokio::test]
@@ -227,7 +255,8 @@ profiles:
     snapshot_hash: {snap_hash}
     vcpu: 2
     memory_mb: 4096
-    disk_mb: 16384
+    rootfs_disk_mb: 8192
+    workspace_disk_mb: 16384
 "#,
         hash = TEST_ROOTFS_HASH,
         snap_hash = TEST_SNAPSHOT_HASH,
@@ -255,7 +284,8 @@ profiles:
     snapshot_hash: {snap_hash}
     vcpu: 2
     memory_mb: 4096
-    disk_mb: 16384
+    rootfs_disk_mb: 8192
+    workspace_disk_mb: 16384
 "#,
         snap_hash = TEST_SNAPSHOT_HASH,
     ));
@@ -275,7 +305,8 @@ profiles:
     snapshot_hash: ../etc
     vcpu: 2
     memory_mb: 4096
-    disk_mb: 16384
+    rootfs_disk_mb: 8192
+    workspace_disk_mb: 16384
 "#,
         hash = TEST_ROOTFS_HASH,
     ));
@@ -295,7 +326,8 @@ profiles:
     snapshot_hash: {snap_hash}
     vcpu: 0
     memory_mb: 4096
-    disk_mb: 16384
+    rootfs_disk_mb: 8192
+    workspace_disk_mb: 16384
 "#,
         hash = TEST_ROOTFS_HASH,
         snap_hash = TEST_SNAPSHOT_HASH,
@@ -306,7 +338,7 @@ profiles:
 }
 
 #[tokio::test]
-async fn load_rejects_zero_disk_mb_in_profile() {
+async fn load_rejects_zero_rootfs_disk_mb_in_profile() {
     let fixture = ConfigFixture::without_image_artifacts().await;
     let yaml = fixture.yaml(&format!(
         r#"
@@ -316,7 +348,30 @@ profiles:
     snapshot_hash: {snap_hash}
     vcpu: 2
     memory_mb: 4096
-    disk_mb: 0
+    rootfs_disk_mb: 0
+    workspace_disk_mb: 16384
+"#,
+        hash = TEST_ROOTFS_HASH,
+        snap_hash = TEST_SNAPSHOT_HASH,
+    ));
+
+    let err = fixture.load_config(&yaml, true).await.unwrap_err();
+    assert!(err.to_string().contains("non-zero"), "got: {err}");
+}
+
+#[tokio::test]
+async fn load_rejects_zero_workspace_disk_mb_in_profile() {
+    let fixture = ConfigFixture::without_image_artifacts().await;
+    let yaml = fixture.yaml(&format!(
+        r#"
+profiles:
+  vm0/default:
+    rootfs_hash: {hash}
+    snapshot_hash: {snap_hash}
+    vcpu: 2
+    memory_mb: 4096
+    rootfs_disk_mb: 8192
+    workspace_disk_mb: 0
 "#,
         hash = TEST_ROOTFS_HASH,
         snap_hash = TEST_SNAPSHOT_HASH,
@@ -337,7 +392,8 @@ profiles:
     snapshot_hash: {snap_hash}
     vcpu: 1024
     memory_mb: 4096
-    disk_mb: 16384
+    rootfs_disk_mb: 8192
+    workspace_disk_mb: 16384
 "#,
         hash = TEST_ROOTFS_HASH,
         snap_hash = TEST_SNAPSHOT_HASH,
@@ -359,7 +415,8 @@ profiles:
     snapshot_hash: {snap_hash}
     vcpu: 2048
     memory_mb: 4096
-    disk_mb: 16384
+    rootfs_disk_mb: 8192
+    workspace_disk_mb: 16384
 "#,
         hash = TEST_ROOTFS_HASH,
         snap_hash = TEST_SNAPSHOT_HASH,
@@ -380,7 +437,8 @@ profiles:
     snapshot_hash: {snap_hash}
     vcpu: 2
     memory_mb: 2000000
-    disk_mb: 16384
+    rootfs_disk_mb: 8192
+    workspace_disk_mb: 16384
 "#,
         hash = TEST_ROOTFS_HASH,
         snap_hash = TEST_SNAPSHOT_HASH,
@@ -391,7 +449,7 @@ profiles:
 }
 
 #[tokio::test]
-async fn load_rejects_excessive_disk_mb_in_profile() {
+async fn load_rejects_excessive_rootfs_disk_mb_in_profile() {
     let fixture = ConfigFixture::without_image_artifacts().await;
     let yaml = fixture.yaml(&format!(
         r#"
@@ -401,7 +459,30 @@ profiles:
     snapshot_hash: {snap_hash}
     vcpu: 2
     memory_mb: 4096
-    disk_mb: 2000000
+    rootfs_disk_mb: 2000000
+    workspace_disk_mb: 16384
+"#,
+        hash = TEST_ROOTFS_HASH,
+        snap_hash = TEST_SNAPSHOT_HASH,
+    ));
+
+    let err = fixture.load_config(&yaml, true).await.unwrap_err();
+    assert!(err.to_string().contains("exceeds maximum"), "got: {err}");
+}
+
+#[tokio::test]
+async fn load_rejects_excessive_workspace_disk_mb_in_profile() {
+    let fixture = ConfigFixture::without_image_artifacts().await;
+    let yaml = fixture.yaml(&format!(
+        r#"
+profiles:
+  vm0/default:
+    rootfs_hash: {hash}
+    snapshot_hash: {snap_hash}
+    vcpu: 2
+    memory_mb: 4096
+    rootfs_disk_mb: 8192
+    workspace_disk_mb: 2000000
 "#,
         hash = TEST_ROOTFS_HASH,
         snap_hash = TEST_SNAPSHOT_HASH,
@@ -511,7 +592,8 @@ async fn validate_profile_image_artifacts_rejects_missing_cow_bitmap() {
         snapshot_hash: TEST_SNAPSHOT_HASH.into(),
         vcpu: 2,
         memory_mb: 4096,
-        disk_mb: 16384,
+        rootfs_disk_mb: 8192,
+        workspace_disk_mb: 16384,
     };
     let err = validate_profile_image_artifacts("vm0/default", &profile, &home)
         .await
@@ -633,6 +715,17 @@ async fn generate_then_load_round_trip() {
 
     generate(&config).await.unwrap();
 
+    let generated = tokio::fs::read_to_string(runner_dir.join("runner.yaml"))
+        .await
+        .unwrap();
+    assert!(generated.contains("rootfs_disk_mb: 8192"));
+    assert!(generated.contains("workspace_disk_mb: 16384"));
+    assert!(
+        generated
+            .lines()
+            .all(|line| !line.trim_start().starts_with("disk_mb:"))
+    );
+
     let loaded = load_with_home(&runner_dir.join("runner.yaml"), &fixture.home, true)
         .await
         .unwrap();
@@ -666,7 +759,8 @@ profiles:
     snapshot_hash: {snap_hash}
     vcpu: 2
     memory_mb: 4096
-    disk_mb: 16384
+    rootfs_disk_mb: 8192
+    workspace_disk_mb: 16384
 "#,
         hash = TEST_ROOTFS_HASH,
         snap_hash = TEST_SNAPSHOT_HASH,

--- a/crates/runner/src/config_tests.rs
+++ b/crates/runner/src/config_tests.rs
@@ -199,7 +199,7 @@ server:
 }
 
 #[tokio::test]
-async fn load_maps_legacy_disk_mb_to_rootfs_and_workspace_disk_mb() {
+async fn load_rejects_legacy_disk_mb_without_split_disk_fields() {
     let fixture = ConfigFixture::new().await;
     let yaml = fixture.yaml(&format!(
         r#"
@@ -215,10 +215,11 @@ profiles:
         snap_hash = TEST_SNAPSHOT_HASH,
     ));
 
-    let config = fixture.load_config(&yaml, true).await.unwrap();
-    let default = &config.profiles["vm0/default"];
-    assert_eq!(default.rootfs_disk_mb, 12288);
-    assert_eq!(default.workspace_disk_mb, 12288);
+    let err = fixture.load_config(&yaml, true).await.unwrap_err();
+    assert!(
+        err.to_string().contains("rootfs_disk_mb") || err.to_string().contains("workspace_disk_mb"),
+        "unexpected error: {err}"
+    );
 }
 
 #[tokio::test]

--- a/crates/runner/src/executor.rs
+++ b/crates/runner/src/executor.rs
@@ -78,6 +78,7 @@ use crate::network_log_drain::NetworkLogDrainCoordinator;
 use crate::network_log_manager::NetworkLogManager;
 use crate::network_log_manager::NetworkLogSession;
 use crate::paths::{HomePaths, LogPaths, guest};
+use crate::profile;
 use crate::proxy::{self, ProxyRegistryHandle};
 use crate::telemetry::JobTelemetry;
 use crate::types::{
@@ -544,7 +545,7 @@ async fn execute_new_sandbox(
         },
         device_rate_limits: params.device_rate_limits.clone(),
         workspace_drive: Some(sandbox::WorkspaceDriveConfig {
-            size_bytes: u64::from(params.workspace_disk_mb) * 1024 * 1024,
+            size_bytes: profile::workspace_disk_mb_to_bytes(params.workspace_disk_mb),
         }),
     };
 

--- a/crates/runner/src/executor.rs
+++ b/crates/runner/src/executor.rs
@@ -4990,6 +4990,55 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn execute_job_workspace_mount_failure_destroys_sandbox() {
+        let dir = tempfile::tempdir().unwrap();
+        let config = test_executor_config(dir.path()).await;
+        let overrides = Arc::new(sandbox_mock::MockSandboxOverrides::new());
+        overrides.add_exec_matcher(sandbox_mock::ExecMatcher {
+            pattern: "mount -t ext4".to_string(),
+            exit_code: 64,
+            stdout: Vec::new(),
+            stderr: b"mount denied".to_vec(),
+        });
+        let factory = MockSandboxFactory::with_overrides(Arc::clone(&overrides));
+
+        let (outcome, _telemetry) = execute_job(
+            &factory,
+            minimal_context(),
+            NewSandboxDispatch {
+                id: SandboxId::new_v4(),
+                reuse_result: SandboxReuseResult::PoolMiss,
+            },
+            &config,
+            &default_params(),
+            tokio_util::sync::CancellationToken::new(),
+        )
+        .await;
+
+        assert_eq!(outcome.exit_code(), 1);
+        let error = outcome.error().unwrap();
+        assert!(
+            error.contains("mount workspace drive failed"),
+            "got: {error}"
+        );
+        assert!(error.contains("mount denied"), "got: {error}");
+        assert!(
+            outcome.sandbox.is_none(),
+            "fresh mount failure should be destroyed inline"
+        );
+        assert!(
+            outcome.network_log_session.is_none(),
+            "network log session should be closed before returning"
+        );
+        assert_eq!(overrides.destroy_call_count(), 1);
+        assert!(
+            overrides.start_process_calls().is_empty(),
+            "agent must not start after workspace mount failure"
+        );
+        assert_proxy_registry_empty(dir.path()).await;
+    }
+
+    #[tokio::test]
     async fn execute_inner_appends_stream_overflow_marker() {
         let dir = tempfile::tempdir().unwrap();
         let config = test_executor_config(dir.path()).await;
@@ -5773,8 +5822,9 @@ mod tests {
         let dir = tempfile::tempdir().unwrap();
         let config = test_executor_config(dir.path()).await;
 
-        // Build a MockSandbox that fails on the first exec (fix_guest_clock)
+        // First exec mounts the workspace drive, second exec fixes the clock.
         let sandbox = MockSandbox::new("reuse-clock-fail");
+        sandbox.push_exec_result(Ok(ExecResult::new(0, Vec::new(), Vec::new())));
         sandbox.push_exec_result(Err(sandbox_exec_error("vsock broken")));
 
         let cancel = tokio_util::sync::CancellationToken::new();
@@ -5802,8 +5852,9 @@ mod tests {
         let dir = tempfile::tempdir().unwrap();
         let config = test_executor_config(dir.path()).await;
 
-        // First exec (fix_guest_clock) succeeds, second (reseed_guest_entropy) fails
+        // Workspace mount and clock fix succeed, then reseed_guest_entropy fails.
         let sandbox = MockSandbox::new("reuse-reseed-fail");
+        sandbox.push_exec_result(Ok(ExecResult::new(0, Vec::new(), Vec::new())));
         sandbox.push_exec_result(Ok(ExecResult::new(0, Vec::new(), Vec::new())));
         sandbox.push_exec_result(Err(sandbox_exec_error("reseed timeout")));
 
@@ -5819,6 +5870,42 @@ mod tests {
             outcome.sandbox.is_some(),
             "sandbox must be returned on reseed failure"
         );
+    }
+
+    #[tokio::test]
+    async fn execute_job_reuse_workspace_mount_failure_returns_sandbox() {
+        let dir = tempfile::tempdir().unwrap();
+        let config = test_executor_config(dir.path()).await;
+
+        let sandbox = MockSandbox::new("reuse-mount-fail");
+        sandbox.push_exec_result(Ok(ExecResult::new(
+            64,
+            Vec::new(),
+            b"mount denied".to_vec(),
+        )));
+
+        let cancel = tokio_util::sync::CancellationToken::new();
+        let (idle_sandbox, _lease) =
+            make_reusable_idle_sandbox(Box::new(sandbox), "10.0.0.1".into(), "sess-1").await;
+        let (outcome, _telemetry) =
+            execute_job_reuse(idle_sandbox, minimal_context(), &config, cancel).await;
+
+        assert_eq!(outcome.exit_code(), 1);
+        let error = outcome.error().unwrap();
+        assert!(
+            error.contains("mount workspace drive failed"),
+            "got: {error}"
+        );
+        assert!(error.contains("mount denied"), "got: {error}");
+        assert!(
+            outcome.sandbox.is_some(),
+            "sandbox must be returned on workspace mount failure"
+        );
+        assert!(
+            outcome.network_log_session.is_some(),
+            "network log session must be returned so finalization can close it"
+        );
+        assert_proxy_registry_empty(dir.path()).await;
     }
 
     /// Verify that session restore failure during reuse still returns the sandbox.

--- a/crates/runner/src/executor.rs
+++ b/crates/runner/src/executor.rs
@@ -101,7 +101,7 @@ pub struct ExecutorConfig {
 pub struct JobParams {
     pub vcpu: u32,
     pub memory_mb: u32,
-    pub disk_mb: u32,
+    pub workspace_disk_mb: u32,
     pub restore_guest_state: bool,
     pub device_rate_limits: Option<sandbox::DeviceRateLimits>,
 }
@@ -544,7 +544,7 @@ async fn execute_new_sandbox(
         },
         device_rate_limits: params.device_rate_limits.clone(),
         workspace_drive: Some(sandbox::WorkspaceDriveConfig {
-            size_bytes: u64::from(params.disk_mb) * 1024 * 1024,
+            size_bytes: u64::from(params.workspace_disk_mb) * 1024 * 1024,
         }),
     };
 
@@ -4481,7 +4481,7 @@ mod tests {
         JobParams {
             vcpu: 2,
             memory_mb: 2048,
-            disk_mb: 16_384,
+            workspace_disk_mb: 16_384,
             restore_guest_state: false,
             device_rate_limits: None,
         }
@@ -5128,7 +5128,7 @@ mod tests {
         let factory = MockSandboxFactory::with_overrides(Arc::clone(&overrides));
         let limits = test_device_rate_limits();
         let params = JobParams {
-            disk_mb: 512,
+            workspace_disk_mb: 512,
             device_rate_limits: Some(limits.clone()),
             ..default_params()
         };

--- a/crates/runner/src/executor.rs
+++ b/crates/runner/src/executor.rs
@@ -84,6 +84,7 @@ use crate::types::{
     ExecutionContext, GuestDownloadArtifactEntry, GuestDownloadManifest, GuestDownloadStorageEntry,
     ResumeSession, SandboxReuseResult,
 };
+use crate::workspace_mount::ensure_workspace_drive_mounted;
 
 /// Shared configuration for all executions (profile-independent).
 pub struct ExecutorConfig {
@@ -100,6 +101,7 @@ pub struct ExecutorConfig {
 pub struct JobParams {
     pub vcpu: u32,
     pub memory_mb: u32,
+    pub disk_mb: u32,
     pub restore_guest_state: bool,
     pub device_rate_limits: Option<sandbox::DeviceRateLimits>,
 }
@@ -541,6 +543,9 @@ async fn execute_new_sandbox(
             memory_mb: params.memory_mb,
         },
         device_rate_limits: params.device_rate_limits.clone(),
+        workspace_drive: Some(sandbox::WorkspaceDriveConfig {
+            size_bytes: u64::from(params.disk_mb) * 1024 * 1024,
+        }),
     };
 
     // Create and start sandbox
@@ -569,6 +574,23 @@ async fn execute_new_sandbox(
         return Err(e.into());
     }
     telemetry.record("vm_create", t.elapsed(), true, None);
+
+    let mount_started = Instant::now();
+    if let Err(e) = ensure_workspace_drive_mounted(sandbox.as_ref(), context.run_id).await {
+        telemetry.record(
+            "workspace_drive_mount",
+            mount_started.elapsed(),
+            false,
+            Some(&e.to_string()),
+        );
+        unregister_proxy_registry(config, context, &source_ip).await;
+        network_log_session
+            .close_for_upload(context.run_id, &config.network_log_drain)
+            .await;
+        destroy_sandbox_panic_safe(factory, sandbox).await;
+        return Err(e);
+    }
+    telemetry.record("workspace_drive_mount", mount_started.elapsed(), true, None);
 
     Ok(execute_prepared_sandbox_run(
         PreparedSandboxRun {
@@ -625,6 +647,25 @@ async fn execute_reused_sandbox(
 
     let source_ip = source_ip.to_string();
     let network_log_session = register_proxy(config, context, &source_ip).await;
+
+    let mount_started = Instant::now();
+    if let Err(e) = ensure_workspace_drive_mounted(sandbox.as_ref(), context.run_id).await {
+        telemetry.record(
+            "workspace_drive_mount",
+            mount_started.elapsed(),
+            false,
+            Some(&e.to_string()),
+        );
+        unregister_proxy_registry(config, context, &source_ip).await;
+        return ExecuteOutcome {
+            failure: Some(ExecutionFailure::from_error(e.to_string())),
+            sandbox: Some(sandbox),
+            source_ip,
+            network_log_session: Some(network_log_session),
+            guest_session_id: None,
+        };
+    }
+    telemetry.record("workspace_drive_mount", mount_started.elapsed(), true, None);
 
     execute_prepared_sandbox_run(
         PreparedSandboxRun {
@@ -4440,6 +4481,7 @@ mod tests {
         JobParams {
             vcpu: 2,
             memory_mb: 2048,
+            disk_mb: 16_384,
             restore_guest_state: false,
             device_rate_limits: None,
         }
@@ -4643,6 +4685,7 @@ mod tests {
                     memory_mb: 2048,
                 },
                 device_rate_limits: None,
+                workspace_drive: None,
             })
             .await
             .unwrap()
@@ -4709,6 +4752,7 @@ mod tests {
                         memory_mb: 2048,
                     },
                     device_rate_limits: None,
+                    workspace_drive: None,
                 })
                 .await
                 .unwrap(),
@@ -5035,6 +5079,7 @@ mod tests {
         let factory = MockSandboxFactory::with_overrides(Arc::clone(&overrides));
         let limits = test_device_rate_limits();
         let params = JobParams {
+            disk_mb: 512,
             device_rate_limits: Some(limits.clone()),
             ..default_params()
         };
@@ -5049,6 +5094,12 @@ mod tests {
         let configs = overrides.create_configs();
         assert_eq!(configs.len(), 1);
         assert_eq!(configs[0].device_rate_limits, Some(limits));
+        assert_eq!(
+            configs[0].workspace_drive,
+            Some(sandbox::WorkspaceDriveConfig {
+                size_bytes: 512 * 1024 * 1024,
+            })
+        );
     }
 
     #[tokio::test]

--- a/crates/runner/src/executor.rs
+++ b/crates/runner/src/executor.rs
@@ -78,7 +78,6 @@ use crate::network_log_drain::NetworkLogDrainCoordinator;
 use crate::network_log_manager::NetworkLogManager;
 use crate::network_log_manager::NetworkLogSession;
 use crate::paths::{HomePaths, LogPaths, guest};
-use crate::profile;
 use crate::proxy::{self, ProxyRegistryHandle};
 use crate::telemetry::JobTelemetry;
 use crate::types::{
@@ -545,7 +544,7 @@ async fn execute_new_sandbox(
         },
         device_rate_limits: params.device_rate_limits.clone(),
         workspace_drive: Some(sandbox::WorkspaceDriveConfig {
-            size_bytes: profile::workspace_disk_mb_to_bytes(params.workspace_disk_mb),
+            size_mb: params.workspace_disk_mb,
         }),
     };
 
@@ -5146,9 +5145,7 @@ mod tests {
         assert_eq!(configs[0].device_rate_limits, Some(limits));
         assert_eq!(
             configs[0].workspace_drive,
-            Some(sandbox::WorkspaceDriveConfig {
-                size_bytes: 512 * 1024 * 1024,
-            })
+            Some(sandbox::WorkspaceDriveConfig { size_mb: 512 })
         );
     }
 

--- a/crates/runner/src/idle_pool.rs
+++ b/crates/runner/src/idle_pool.rs
@@ -957,6 +957,7 @@ mod tests {
                     memory_mb: 4096,
                 },
                 device_rate_limits: None,
+                workspace_drive: None,
             })
             .await
             .expect("create sandbox");
@@ -980,6 +981,7 @@ mod tests {
                     memory_mb: budget_lease.memory_mb(),
                 },
                 device_rate_limits: None,
+                workspace_drive: None,
             })
             .await
             .expect("create sandbox");
@@ -1060,6 +1062,7 @@ mod tests {
                     memory_mb: budget_lease.memory_mb(),
                 },
                 device_rate_limits: None,
+                workspace_drive: None,
             })
             .await
             .expect("create sandbox");

--- a/crates/runner/src/io_limits.rs
+++ b/crates/runner/src/io_limits.rs
@@ -332,7 +332,8 @@ mod tests {
                         snapshot_hash: format!("{name}-snapshot"),
                         vcpu: *vcpu,
                         memory_mb: *memory_mb,
-                        disk_mb: 16_384,
+                        rootfs_disk_mb: 8192,
+                        workspace_disk_mb: 16_384,
                     },
                 )
             })

--- a/crates/runner/src/main.rs
+++ b/crates/runner/src/main.rs
@@ -34,6 +34,7 @@ mod status;
 mod storage_cache;
 mod telemetry;
 mod types;
+mod workspace_mount;
 
 use std::path::Path;
 use std::process::ExitCode;

--- a/crates/runner/src/profile.rs
+++ b/crates/runner/src/profile.rs
@@ -6,8 +6,10 @@ pub struct ProfileDef {
     pub vcpu: u32,
     /// Memory in MiB for VMs using this profile.
     pub memory_mb: u32,
-    /// Disk size in MiB for VMs using this profile.
-    pub disk_mb: u32,
+    /// Rootfs disk size in MiB for VMs using this profile.
+    pub rootfs_disk_mb: u32,
+    /// Workspace disk size in MiB for VMs using this profile.
+    pub workspace_disk_mb: u32,
 }
 
 pub const DEFAULT_PROFILE: &str = "vm0/default";
@@ -17,7 +19,8 @@ pub fn get(name: &str) -> RunnerResult<&'static ProfileDef> {
     static DEFAULT: ProfileDef = ProfileDef {
         vcpu: 2,
         memory_mb: 4096,
-        disk_mb: 16384,
+        rootfs_disk_mb: 8192,
+        workspace_disk_mb: 16384,
     };
 
     match name {
@@ -75,7 +78,8 @@ mod tests {
         let def = get("vm0/default").unwrap();
         assert_eq!(def.vcpu, 2);
         assert_eq!(def.memory_mb, 4096);
-        assert_eq!(def.disk_mb, 16384);
+        assert_eq!(def.rootfs_disk_mb, 8192);
+        assert_eq!(def.workspace_disk_mb, 16384);
     }
 
     #[test]

--- a/crates/runner/src/profile.rs
+++ b/crates/runner/src/profile.rs
@@ -14,6 +14,10 @@ pub struct ProfileDef {
 
 pub const DEFAULT_PROFILE: &str = "vm0/default";
 
+pub(crate) fn workspace_disk_mb_to_bytes(workspace_disk_mb: u32) -> u64 {
+    u64::from(workspace_disk_mb) * 1024 * 1024
+}
+
 /// Return the profile definition for a given profile name.
 pub fn get(name: &str) -> RunnerResult<&'static ProfileDef> {
     static DEFAULT: ProfileDef = ProfileDef {
@@ -80,6 +84,11 @@ mod tests {
         assert_eq!(def.memory_mb, 4096);
         assert_eq!(def.rootfs_disk_mb, 8192);
         assert_eq!(def.workspace_disk_mb, 16384);
+    }
+
+    #[test]
+    fn workspace_disk_mb_to_bytes_converts_mib_to_bytes() {
+        assert_eq!(workspace_disk_mb_to_bytes(16), 16 * 1024 * 1024);
     }
 
     #[test]

--- a/crates/runner/src/profile.rs
+++ b/crates/runner/src/profile.rs
@@ -14,10 +14,6 @@ pub struct ProfileDef {
 
 pub const DEFAULT_PROFILE: &str = "vm0/default";
 
-pub(crate) fn workspace_disk_mb_to_bytes(workspace_disk_mb: u32) -> u64 {
-    u64::from(workspace_disk_mb) * 1024 * 1024
-}
-
 /// Return the profile definition for a given profile name.
 pub fn get(name: &str) -> RunnerResult<&'static ProfileDef> {
     static DEFAULT: ProfileDef = ProfileDef {
@@ -84,11 +80,6 @@ mod tests {
         assert_eq!(def.memory_mb, 4096);
         assert_eq!(def.rootfs_disk_mb, 8192);
         assert_eq!(def.workspace_disk_mb, 16384);
-    }
-
-    #[test]
-    fn workspace_disk_mb_to_bytes_converts_mib_to_bytes() {
-        assert_eq!(workspace_disk_mb_to_bytes(16), 16 * 1024 * 1024);
     }
 
     #[test]

--- a/crates/runner/src/workspace_mount.rs
+++ b/crates/runner/src/workspace_mount.rs
@@ -7,32 +7,7 @@ use crate::error::{RunnerError, RunnerResult};
 
 const WORKSPACE_MOUNT_TIMEOUT: Duration = Duration::from_secs(30);
 const WORKSPACE_DEVICE: &str = "/dev/vdb";
-const REFUSE_WORKSPACE_SYMLINK_PATH_SHELL_FUNCTION: &str = r#"refuse_workspace_symlink_path() {
-  check_path=
-  remaining=${workspace_dir#/}
-  while [ -n "$remaining" ]; do
-    component=${remaining%%/*}
-    if [ "$remaining" = "$component" ]; then
-      remaining=
-    else
-      remaining=${remaining#*/}
-    fi
-    check_path="$check_path/$component"
-    if [ -L "$check_path" ]; then
-      echo "refusing to use symlink workspace path component: $check_path" >&2
-      exit 64
-    fi
-  done
-}"#;
-const WORKSPACE_DEVICE_MOUNTED_ELSEWHERE_SHELL_FUNCTION: &str = r#"workspace_device_mounted_elsewhere() {
-  [ -n "$workspace_dev" ] || return 1
-  while IFS=' ' read -r _ _ mount_dev _ _ _; do
-    if [ "$mount_dev" = "$workspace_dev" ]; then
-      return 0
-    fi
-  done < /proc/self/mountinfo
-  return 1
-}"#;
+const WORKSPACE_MOUNT_SCRIPT: &str = include_str!("../scripts/mount-workspace-drive.sh");
 
 pub(crate) async fn ensure_workspace_drive_mounted(
     sandbox: &dyn Sandbox,
@@ -72,7 +47,7 @@ fn workspace_mount_command() -> String {
     let workspace_dir = shell_quote(CANONICAL_WORKING_DIR);
     let workspace_device = shell_quote(WORKSPACE_DEVICE);
     format!(
-        "set -eu\nworkspace_dir={workspace_dir}\nworkspace_device={workspace_device}\n{REFUSE_WORKSPACE_SYMLINK_PATH_SHELL_FUNCTION}\n{WORKSPACE_DEVICE_MOUNTED_ELSEWHERE_SHELL_FUNCTION}\nensure_workspace_owner() {{\n  chown -h user:user -- \"$workspace_dir\"\n}}\nrefuse_workspace_symlink_path\nworkspace_dev=\"$(mountpoint -x -- \"$workspace_device\" 2>/dev/null || true)\"\nif mountpoint -q -- \"$workspace_dir\"; then\n  target_dev=\"$(mountpoint -d -- \"$workspace_dir\" 2>/dev/null || true)\"\n  if [ -n \"$workspace_dev\" ] && [ \"$target_dev\" = \"$workspace_dev\" ]; then\n    ensure_workspace_owner\n    exit 0\n  fi\n  echo \"refusing to mount workspace drive over existing mountpoint: $workspace_dir\" >&2\n  exit 64\nfi\nif workspace_device_mounted_elsewhere; then\n  echo \"refusing to mount workspace drive because $workspace_device is already mounted outside $workspace_dir\" >&2\n  exit 64\nfi\nmkdir -p -- \"$workspace_dir\"\nrefuse_workspace_symlink_path\nmount -t ext4 -- \"$workspace_device\" \"$workspace_dir\"\nensure_workspace_owner"
+        "workspace_dir={workspace_dir}\nworkspace_device={workspace_device}\n{WORKSPACE_MOUNT_SCRIPT}"
     )
 }
 

--- a/crates/runner/src/workspace_mount.rs
+++ b/crates/runner/src/workspace_mount.rs
@@ -7,7 +7,7 @@ use crate::error::{RunnerError, RunnerResult};
 
 const WORKSPACE_MOUNT_TIMEOUT: Duration = Duration::from_secs(30);
 const WORKSPACE_DEVICE: &str = "/dev/vdb";
-const WORKSPACE_SYMLINK_PATH_GUARD: &str = r#"refuse_workspace_symlink_path() {
+const REFUSE_WORKSPACE_SYMLINK_PATH_SHELL_FUNCTION: &str = r#"refuse_workspace_symlink_path() {
   check_path=
   remaining=${workspace_dir#/}
   while [ -n "$remaining" ]; do
@@ -24,7 +24,7 @@ const WORKSPACE_SYMLINK_PATH_GUARD: &str = r#"refuse_workspace_symlink_path() {
     fi
   done
 }"#;
-const WORKSPACE_DEVICE_MOUNT_GUARD: &str = r#"workspace_device_mounted_elsewhere() {
+const WORKSPACE_DEVICE_MOUNTED_ELSEWHERE_SHELL_FUNCTION: &str = r#"workspace_device_mounted_elsewhere() {
   [ -n "$workspace_dev" ] || return 1
   while IFS=' ' read -r _ _ mount_dev _ _ _; do
     if [ "$mount_dev" = "$workspace_dev" ]; then
@@ -72,7 +72,7 @@ fn workspace_mount_command() -> String {
     let workspace_dir = shell_quote(CANONICAL_WORKING_DIR);
     let workspace_device = shell_quote(WORKSPACE_DEVICE);
     format!(
-        "set -eu\nworkspace_dir={workspace_dir}\nworkspace_device={workspace_device}\n{WORKSPACE_SYMLINK_PATH_GUARD}\n{WORKSPACE_DEVICE_MOUNT_GUARD}\nensure_workspace_owner() {{\n  chown -h user:user -- \"$workspace_dir\"\n}}\nrefuse_workspace_symlink_path\nworkspace_dev=\"$(mountpoint -x -- \"$workspace_device\" 2>/dev/null || true)\"\nif mountpoint -q -- \"$workspace_dir\"; then\n  target_dev=\"$(mountpoint -d -- \"$workspace_dir\" 2>/dev/null || true)\"\n  if [ -n \"$workspace_dev\" ] && [ \"$target_dev\" = \"$workspace_dev\" ]; then\n    ensure_workspace_owner\n    exit 0\n  fi\n  echo \"refusing to mount workspace drive over existing mountpoint: $workspace_dir\" >&2\n  exit 64\nfi\nif workspace_device_mounted_elsewhere; then\n  echo \"refusing to mount workspace drive because $workspace_device is already mounted outside $workspace_dir\" >&2\n  exit 64\nfi\nmkdir -p -- \"$workspace_dir\"\nrefuse_workspace_symlink_path\nmount -t ext4 -- \"$workspace_device\" \"$workspace_dir\"\nensure_workspace_owner"
+        "set -eu\nworkspace_dir={workspace_dir}\nworkspace_device={workspace_device}\n{REFUSE_WORKSPACE_SYMLINK_PATH_SHELL_FUNCTION}\n{WORKSPACE_DEVICE_MOUNTED_ELSEWHERE_SHELL_FUNCTION}\nensure_workspace_owner() {{\n  chown -h user:user -- \"$workspace_dir\"\n}}\nrefuse_workspace_symlink_path\nworkspace_dev=\"$(mountpoint -x -- \"$workspace_device\" 2>/dev/null || true)\"\nif mountpoint -q -- \"$workspace_dir\"; then\n  target_dev=\"$(mountpoint -d -- \"$workspace_dir\" 2>/dev/null || true)\"\n  if [ -n \"$workspace_dev\" ] && [ \"$target_dev\" = \"$workspace_dev\" ]; then\n    ensure_workspace_owner\n    exit 0\n  fi\n  echo \"refusing to mount workspace drive over existing mountpoint: $workspace_dir\" >&2\n  exit 64\nfi\nif workspace_device_mounted_elsewhere; then\n  echo \"refusing to mount workspace drive because $workspace_device is already mounted outside $workspace_dir\" >&2\n  exit 64\nfi\nmkdir -p -- \"$workspace_dir\"\nrefuse_workspace_symlink_path\nmount -t ext4 -- \"$workspace_device\" \"$workspace_dir\"\nensure_workspace_owner"
     )
 }
 

--- a/crates/runner/src/workspace_mount.rs
+++ b/crates/runner/src/workspace_mount.rs
@@ -122,6 +122,34 @@ mod tests {
     }
 
     #[test]
+    fn mount_command_checks_elsewhere_mount_after_idempotent_path_and_before_mount() {
+        let cmd = workspace_mount_command();
+        let idempotent_check = cmd
+            .find("if mountpoint -q -- \"$workspace_dir\"")
+            .expect("canonical mountpoint check");
+        let elsewhere_check = cmd
+            .find("if workspace_device_mounted_elsewhere")
+            .expect("elsewhere device mount check");
+        let mkdir = cmd.find("mkdir -p -- \"$workspace_dir\"").expect("mkdir");
+        let mount = cmd
+            .find("mount -t ext4 -- \"$workspace_device\" \"$workspace_dir\"")
+            .expect("mount");
+
+        assert!(
+            idempotent_check < elsewhere_check,
+            "canonical idempotent mount check must run before elsewhere guard"
+        );
+        assert!(
+            elsewhere_check < mkdir,
+            "elsewhere guard must run before creating the workspace directory"
+        );
+        assert!(
+            elsewhere_check < mount,
+            "elsewhere guard must run before attempting a new mount"
+        );
+    }
+
+    #[test]
     fn mount_command_does_not_unmount_or_sync() {
         let cmd = workspace_mount_command();
 

--- a/crates/runner/src/workspace_mount.rs
+++ b/crates/runner/src/workspace_mount.rs
@@ -1,0 +1,120 @@
+use std::time::Duration;
+
+use api_contracts::generated::constants::runners::paths::CANONICAL_WORKING_DIR;
+use sandbox::{EXEC_OUTPUT_LIMIT_64_KIB, ExecRequest, Sandbox};
+
+use crate::error::{RunnerError, RunnerResult};
+use crate::ids::RunId;
+
+const WORKSPACE_MOUNT_TIMEOUT: Duration = Duration::from_secs(30);
+const WORKSPACE_DEVICE: &str = "/dev/vdb";
+const WORKSPACE_SYMLINK_PATH_GUARD: &str = r#"refuse_workspace_symlink_path() {
+  check_path=
+  remaining=${workspace_dir#/}
+  while [ -n "$remaining" ]; do
+    component=${remaining%%/*}
+    if [ "$remaining" = "$component" ]; then
+      remaining=
+    else
+      remaining=${remaining#*/}
+    fi
+    check_path="$check_path/$component"
+    if [ -L "$check_path" ]; then
+      echo "refusing to use symlink workspace path component: $check_path" >&2
+      exit 64
+    fi
+  done
+}"#;
+
+pub(crate) async fn ensure_workspace_drive_mounted(
+    sandbox: &dyn Sandbox,
+    run_id: RunId,
+) -> RunnerResult<()> {
+    let cmd = workspace_mount_command();
+    let result = sandbox
+        .exec(&ExecRequest {
+            cmd: &cmd,
+            timeout: WORKSPACE_MOUNT_TIMEOUT,
+            env: &[],
+            sudo: true,
+            stdin_bytes: None,
+            output_limits: EXEC_OUTPUT_LIMIT_64_KIB,
+        })
+        .await
+        .map_err(RunnerError::from)?;
+    if result.exit_code == 0 {
+        return Ok(());
+    }
+
+    let stderr = String::from_utf8_lossy(&result.stderr);
+    let stdout = String::from_utf8_lossy(&result.stdout);
+    Err(RunnerError::Internal(format!(
+        "mount workspace drive failed for {run_id} with exit code {}: stderr={} stdout={}",
+        result.exit_code,
+        stderr.trim(),
+        stdout.trim()
+    )))
+}
+
+fn shell_quote(value: &str) -> String {
+    format!("'{}'", value.replace('\'', "'\\''"))
+}
+
+fn workspace_mount_command() -> String {
+    let workspace_dir = shell_quote(CANONICAL_WORKING_DIR);
+    let workspace_device = shell_quote(WORKSPACE_DEVICE);
+    format!(
+        "set -eu\nworkspace_dir={workspace_dir}\nworkspace_device={workspace_device}\n{WORKSPACE_SYMLINK_PATH_GUARD}\nensure_workspace_owner() {{\n  chown -h user:user -- \"$workspace_dir\"\n}}\nrefuse_workspace_symlink_path\nif mountpoint -q -- \"$workspace_dir\"; then\n  target_dev=\"$(mountpoint -d -- \"$workspace_dir\" 2>/dev/null || true)\"\n  workspace_dev=\"$(mountpoint -x -- \"$workspace_device\" 2>/dev/null || true)\"\n  if [ -n \"$workspace_dev\" ] && [ \"$target_dev\" = \"$workspace_dev\" ]; then\n    ensure_workspace_owner\n    exit 0\n  fi\n  echo \"refusing to mount workspace drive over existing mountpoint: $workspace_dir\" >&2\n  exit 64\nfi\nmkdir -p -- \"$workspace_dir\"\nrefuse_workspace_symlink_path\nmount -t ext4 -- \"$workspace_device\" \"$workspace_dir\"\nensure_workspace_owner"
+    )
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn shell_quote_handles_single_quotes() {
+        assert_eq!(shell_quote("/tmp/a'b"), "'/tmp/a'\\''b'");
+    }
+
+    #[test]
+    fn mount_command_uses_canonical_workspace_and_workspace_device() {
+        let cmd = workspace_mount_command();
+
+        assert!(cmd.contains("workspace_dir='/home/user/workspace'"));
+        assert!(cmd.contains("workspace_device='/dev/vdb'"));
+        assert!(cmd.contains("mount -t ext4 -- \"$workspace_device\" \"$workspace_dir\""));
+    }
+
+    #[test]
+    fn mount_command_is_idempotent_for_existing_workspace_mount() {
+        let cmd = workspace_mount_command();
+
+        assert!(cmd.contains("mountpoint -q -- \"$workspace_dir\""));
+        assert!(cmd.contains("mountpoint -x -- \"$workspace_device\""));
+        assert!(cmd.contains("[ \"$target_dev\" = \"$workspace_dev\" ]"));
+        assert!(cmd.contains("exit 0"));
+    }
+
+    #[test]
+    fn mount_command_rejects_unrelated_mountpoints_and_symlink_components() {
+        let cmd = workspace_mount_command();
+
+        assert!(cmd.contains("refusing to mount workspace drive over existing mountpoint"));
+        assert!(cmd.contains("refuse_workspace_symlink_path()"));
+        assert!(cmd.contains("refusing to use symlink workspace path component"));
+        assert_eq!(
+            cmd.matches("refuse_workspace_symlink_path").count(),
+            3,
+            "definition plus pre-mount and post-mkdir checks should be present"
+        );
+    }
+
+    #[test]
+    fn mount_command_does_not_unmount_or_sync() {
+        let cmd = workspace_mount_command();
+
+        assert!(!cmd.contains("umount"));
+        assert!(!cmd.contains("\nsync"));
+    }
+}

--- a/crates/runner/src/workspace_mount.rs
+++ b/crates/runner/src/workspace_mount.rs
@@ -4,7 +4,6 @@ use api_contracts::generated::constants::runners::paths::CANONICAL_WORKING_DIR;
 use sandbox::{EXEC_OUTPUT_LIMIT_64_KIB, ExecRequest, Sandbox};
 
 use crate::error::{RunnerError, RunnerResult};
-use crate::ids::RunId;
 
 const WORKSPACE_MOUNT_TIMEOUT: Duration = Duration::from_secs(30);
 const WORKSPACE_DEVICE: &str = "/dev/vdb";
@@ -37,7 +36,7 @@ const WORKSPACE_DEVICE_MOUNT_GUARD: &str = r#"workspace_device_mounted_elsewhere
 
 pub(crate) async fn ensure_workspace_drive_mounted(
     sandbox: &dyn Sandbox,
-    run_id: RunId,
+    diagnostic_id: impl std::fmt::Display,
 ) -> RunnerResult<()> {
     let cmd = workspace_mount_command();
     let result = sandbox
@@ -58,7 +57,7 @@ pub(crate) async fn ensure_workspace_drive_mounted(
     let stderr = String::from_utf8_lossy(&result.stderr);
     let stdout = String::from_utf8_lossy(&result.stdout);
     Err(RunnerError::Internal(format!(
-        "mount workspace drive failed for {run_id} with exit code {}: stderr={} stdout={}",
+        "mount workspace drive failed for {diagnostic_id} with exit code {}: stderr={} stdout={}",
         result.exit_code,
         stderr.trim(),
         stdout.trim()

--- a/crates/runner/src/workspace_mount.rs
+++ b/crates/runner/src/workspace_mount.rs
@@ -25,6 +25,15 @@ const WORKSPACE_SYMLINK_PATH_GUARD: &str = r#"refuse_workspace_symlink_path() {
     fi
   done
 }"#;
+const WORKSPACE_DEVICE_MOUNT_GUARD: &str = r#"workspace_device_mounted_elsewhere() {
+  [ -n "$workspace_dev" ] || return 1
+  while IFS=' ' read -r _ _ mount_dev _ _ _; do
+    if [ "$mount_dev" = "$workspace_dev" ]; then
+      return 0
+    fi
+  done < /proc/self/mountinfo
+  return 1
+}"#;
 
 pub(crate) async fn ensure_workspace_drive_mounted(
     sandbox: &dyn Sandbox,
@@ -64,7 +73,7 @@ fn workspace_mount_command() -> String {
     let workspace_dir = shell_quote(CANONICAL_WORKING_DIR);
     let workspace_device = shell_quote(WORKSPACE_DEVICE);
     format!(
-        "set -eu\nworkspace_dir={workspace_dir}\nworkspace_device={workspace_device}\n{WORKSPACE_SYMLINK_PATH_GUARD}\nensure_workspace_owner() {{\n  chown -h user:user -- \"$workspace_dir\"\n}}\nrefuse_workspace_symlink_path\nif mountpoint -q -- \"$workspace_dir\"; then\n  target_dev=\"$(mountpoint -d -- \"$workspace_dir\" 2>/dev/null || true)\"\n  workspace_dev=\"$(mountpoint -x -- \"$workspace_device\" 2>/dev/null || true)\"\n  if [ -n \"$workspace_dev\" ] && [ \"$target_dev\" = \"$workspace_dev\" ]; then\n    ensure_workspace_owner\n    exit 0\n  fi\n  echo \"refusing to mount workspace drive over existing mountpoint: $workspace_dir\" >&2\n  exit 64\nfi\nmkdir -p -- \"$workspace_dir\"\nrefuse_workspace_symlink_path\nmount -t ext4 -- \"$workspace_device\" \"$workspace_dir\"\nensure_workspace_owner"
+        "set -eu\nworkspace_dir={workspace_dir}\nworkspace_device={workspace_device}\n{WORKSPACE_SYMLINK_PATH_GUARD}\n{WORKSPACE_DEVICE_MOUNT_GUARD}\nensure_workspace_owner() {{\n  chown -h user:user -- \"$workspace_dir\"\n}}\nrefuse_workspace_symlink_path\nworkspace_dev=\"$(mountpoint -x -- \"$workspace_device\" 2>/dev/null || true)\"\nif mountpoint -q -- \"$workspace_dir\"; then\n  target_dev=\"$(mountpoint -d -- \"$workspace_dir\" 2>/dev/null || true)\"\n  if [ -n \"$workspace_dev\" ] && [ \"$target_dev\" = \"$workspace_dev\" ]; then\n    ensure_workspace_owner\n    exit 0\n  fi\n  echo \"refusing to mount workspace drive over existing mountpoint: $workspace_dir\" >&2\n  exit 64\nfi\nif workspace_device_mounted_elsewhere; then\n  echo \"refusing to mount workspace drive because $workspace_device is already mounted outside $workspace_dir\" >&2\n  exit 64\nfi\nmkdir -p -- \"$workspace_dir\"\nrefuse_workspace_symlink_path\nmount -t ext4 -- \"$workspace_device\" \"$workspace_dir\"\nensure_workspace_owner"
     )
 }
 
@@ -103,6 +112,8 @@ mod tests {
         assert!(cmd.contains("refusing to mount workspace drive over existing mountpoint"));
         assert!(cmd.contains("refuse_workspace_symlink_path()"));
         assert!(cmd.contains("refusing to use symlink workspace path component"));
+        assert!(cmd.contains("workspace_device_mounted_elsewhere()"));
+        assert!(cmd.contains("already mounted outside"));
         assert_eq!(
             cmd.matches("refuse_workspace_symlink_path").count(),
             3,

--- a/crates/sandbox-fc/src/config.rs
+++ b/crates/sandbox-fc/src/config.rs
@@ -39,6 +39,8 @@ pub struct SnapshotConfig {
     pub cow_path: PathBuf,
     /// Drive path recorded in the snapshot's Firecracker config (bind mount target).
     pub drive_bind_path: PathBuf,
+    /// Workspace drive path recorded in the snapshot's Firecracker config.
+    pub workspace_drive_bind_path: PathBuf,
     /// Vsock directory recorded in the snapshot's Firecracker config (bind mount target).
     pub vsock_bind_dir: PathBuf,
 }
@@ -78,11 +80,11 @@ pub struct RateLimiterConfig {
 /// creation should use `sandbox::DeviceRateLimits`.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct FirecrackerDeviceRateLimits {
-    /// Rate limiter applied to the Firecracker root block device.
+    /// Sandbox-level block-device budget.
     ///
-    /// The provider-neutral conversion populates both bandwidth and ops
-    /// dimensions for this device.
-    pub drive: RateLimiterConfig,
+    /// Firecracker limiters are attached per drive, so callers must split this
+    /// budget across all block drives they attach for a sandbox.
+    pub block: sandbox::BlockRateLimits,
     /// Receive-side rate limiter applied to the Firecracker network interface.
     ///
     /// The provider-neutral conversion populates bandwidth only and leaves ops
@@ -99,17 +101,13 @@ impl TryFrom<&sandbox::DeviceRateLimits> for FirecrackerDeviceRateLimits {
     type Error = String;
 
     fn try_from(limits: &sandbox::DeviceRateLimits) -> Result<Self, Self::Error> {
+        validate_positive(
+            "block bandwidth_bytes_per_sec",
+            limits.block.bandwidth_bytes_per_sec,
+        )?;
+        validate_positive("block ops_per_sec", limits.block.ops_per_sec)?;
         Ok(Self {
-            drive: RateLimiterConfig {
-                bandwidth: Some(positive_token_bucket(
-                    "block bandwidth_bytes_per_sec",
-                    limits.block.bandwidth_bytes_per_sec,
-                )?),
-                ops: Some(positive_token_bucket(
-                    "block ops_per_sec",
-                    limits.block.ops_per_sec,
-                )?),
-            },
+            block: limits.block.clone(),
             net_rx: RateLimiterConfig {
                 bandwidth: Some(positive_token_bucket(
                     "network rx_bytes_per_sec",
@@ -126,6 +124,36 @@ impl TryFrom<&sandbox::DeviceRateLimits> for FirecrackerDeviceRateLimits {
             },
         })
     }
+}
+
+impl FirecrackerDeviceRateLimits {
+    /// Build the limiter applied to each writable block drive.
+    ///
+    /// `sandbox::DeviceRateLimits::block` is a sandbox-level budget. Since
+    /// Firecracker limiters are per-drive, split that budget across all block
+    /// drives to keep aggregate block I/O within the runner's per-sandbox
+    /// allocation.
+    pub(crate) fn block_drive_limiter(
+        &self,
+        drive_count: NonZeroU64,
+    ) -> Result<RateLimiterConfig, String> {
+        let drive_count = drive_count.get();
+        let bandwidth = self.block.bandwidth_bytes_per_sec / drive_count;
+        let ops = self.block.ops_per_sec / drive_count;
+        Ok(RateLimiterConfig {
+            bandwidth: Some(positive_token_bucket(
+                "per-drive block bandwidth_bytes_per_sec",
+                bandwidth,
+            )?),
+            ops: Some(positive_token_bucket("per-drive block ops_per_sec", ops)?),
+        })
+    }
+}
+
+fn validate_positive(name: &'static str, rate_per_sec: u64) -> Result<(), String> {
+    NonZeroU64::new(rate_per_sec)
+        .map(|_| ())
+        .ok_or_else(|| format!("{name} must be positive"))
 }
 
 fn positive_token_bucket(
@@ -191,13 +219,55 @@ mod tests {
         };
 
         let fc = FirecrackerDeviceRateLimits::try_from(&limits).unwrap();
+        let block_limiter = fc.block_drive_limiter(nonzero(1)).unwrap();
 
-        assert_eq!(fc.drive.bandwidth.unwrap().size, 10 * 1024 * 1024);
-        assert_eq!(fc.drive.ops.unwrap().size, 1_000);
+        assert_eq!(fc.block, limits.block);
+        assert_eq!(block_limiter.bandwidth.unwrap().size, 10 * 1024 * 1024);
+        assert_eq!(block_limiter.ops.unwrap().size, 1_000);
         assert_eq!(fc.net_rx.bandwidth.unwrap().size, 5 * 1024 * 1024);
         assert_eq!(fc.net_tx.bandwidth.unwrap().size, 2_621_440);
         assert_eq!(fc.net_rx.ops, None);
         assert_eq!(fc.net_tx.ops, None);
+    }
+
+    #[test]
+    fn block_drive_limiter_splits_budget_across_drives() {
+        let limits = sandbox::DeviceRateLimits {
+            block: sandbox::BlockRateLimits {
+                bandwidth_bytes_per_sec: 100 * 1024 * 1024,
+                ops_per_sec: 10_000,
+            },
+            network: sandbox::NetworkRateLimits {
+                rx_bytes_per_sec: 50 * 1024 * 1024,
+                tx_bytes_per_sec: 25 * 1024 * 1024,
+            },
+        };
+        let fc = FirecrackerDeviceRateLimits::try_from(&limits).unwrap();
+
+        let block_limiter = fc.block_drive_limiter(nonzero(2)).unwrap();
+
+        assert_eq!(block_limiter.bandwidth.unwrap().size, 5 * 1024 * 1024);
+        assert_eq!(block_limiter.ops.unwrap().size, 500);
+    }
+
+    #[test]
+    fn block_drive_limiter_rejects_budget_that_cannot_be_split() {
+        let limits = sandbox::DeviceRateLimits {
+            block: sandbox::BlockRateLimits {
+                bandwidth_bytes_per_sec: 1,
+                ops_per_sec: 1,
+            },
+            network: sandbox::NetworkRateLimits {
+                rx_bytes_per_sec: 1,
+                tx_bytes_per_sec: 1,
+            },
+        };
+        let fc = FirecrackerDeviceRateLimits::try_from(&limits).unwrap();
+
+        let err = fc.block_drive_limiter(nonzero(2)).unwrap_err();
+
+        assert!(err.contains("per-drive block bandwidth_bytes_per_sec"));
+        assert!(err.contains("positive"));
     }
 
     #[test]

--- a/crates/sandbox-fc/src/factory/invariant.rs
+++ b/crates/sandbox-fc/src/factory/invariant.rs
@@ -81,7 +81,7 @@ impl InvariantConfig {
                 stats_polling_interval_s: 5,
             },
             prewarm_script: PREWARM_SCRIPT,
-            drive_layout: "nbd-cow-v1",
+            drive_layout: "nbd-cow-workspace-v1",
         }
     }
 }

--- a/crates/sandbox-fc/src/factory/mod.rs
+++ b/crates/sandbox-fc/src/factory/mod.rs
@@ -5,6 +5,7 @@ mod invariant;
 mod leak_cleaner;
 
 use std::path::{Path, PathBuf};
+use std::time::Duration;
 
 use async_trait::async_trait;
 use sandbox::{
@@ -13,6 +14,7 @@ use sandbox::{
 };
 use tracing::{info, warn};
 
+use crate::command;
 use crate::config::{FirecrackerConfig, FirecrackerDeviceRateLimits};
 use crate::factory::cleanup_group::{FactoryCleanupGroup, FactoryCleanupTaskKind};
 use crate::factory::cow_cleanup::destroy_cow_device_with_retries;
@@ -260,6 +262,14 @@ impl SandboxFactory for FirecrackerFactory {
 
                 // Recompute cow_file path after rename (the slot path no longer exists).
                 let cow_file = target_workspace.join("cow.img");
+                let sandbox_paths = crate::paths::SandboxPaths::new(target_workspace.clone());
+                if let Some(workspace_drive) = config.workspace_drive.as_ref() {
+                    prepare_workspace_drive_image(
+                        &sandbox_paths.workspace_image(),
+                        workspace_drive,
+                    )
+                    .await?;
+                }
 
                 // Clean stale sock dir and create vsock directory.
                 let sock_paths = SockPaths::new(self.runtime_paths.sock_dir(&id));
@@ -404,6 +414,50 @@ fn convert_device_rate_limits(
 
 fn clean_stale_workspace_dir(id: &str, target_workspace: &Path) -> sandbox::Result<()> {
     clean_stale_create_dir(id, "target workspace", target_workspace)
+}
+
+pub(crate) async fn prepare_workspace_drive_image(
+    path: &Path,
+    config: &sandbox::WorkspaceDriveConfig,
+) -> sandbox::Result<()> {
+    if let Some(parent) = path.parent() {
+        tokio::fs::create_dir_all(parent)
+            .await
+            .map_err(|e| SandboxError::Initialization {
+                phase: SandboxInitializationPhase::SandboxAllocation,
+                message: format!("create workspace image dir: {e}"),
+            })?;
+    }
+
+    let file = tokio::fs::File::create(path)
+        .await
+        .map_err(|e| SandboxError::Initialization {
+            phase: SandboxInitializationPhase::SandboxAllocation,
+            message: format!("create workspace image {}: {e}", path.display()),
+        })?;
+    file.set_len(config.size_bytes)
+        .await
+        .map_err(|e| SandboxError::Initialization {
+            phase: SandboxInitializationPhase::SandboxAllocation,
+            message: format!("set workspace image size {}: {e}", path.display()),
+        })?;
+    drop(file);
+
+    let path_str = path.to_str().ok_or_else(|| SandboxError::Initialization {
+        phase: SandboxInitializationPhase::SandboxAllocation,
+        message: format!("workspace image path is not UTF-8: {}", path.display()),
+    })?;
+    command::exec_with_timeout(
+        "mkfs.ext4",
+        &["-F", "-q", path_str],
+        Duration::from_secs(60),
+    )
+    .await
+    .map_err(|e| SandboxError::Initialization {
+        phase: SandboxInitializationPhase::SandboxAllocation,
+        message: format!("format workspace image: {e}"),
+    })?;
+    Ok(())
 }
 
 fn clean_stale_sock_dir(id: &str, sock_dir: &Path) -> sandbox::Result<()> {
@@ -703,6 +757,7 @@ mod tests {
                 memory_mb: 512,
             },
             device_rate_limits: None,
+            workspace_drive: None,
         };
 
         let err = match factory.create(config).await {
@@ -736,6 +791,7 @@ mod tests {
                 memory_mb: 512,
             },
             device_rate_limits: None,
+            workspace_drive: None,
         };
         let err = match factory.create(config).await {
             Ok(_) => panic!("create should fail after shutdown"),

--- a/crates/sandbox-fc/src/factory/mod.rs
+++ b/crates/sandbox-fc/src/factory/mod.rs
@@ -435,7 +435,7 @@ pub(crate) async fn prepare_workspace_drive_image(
             phase: SandboxInitializationPhase::SandboxAllocation,
             message: format!("create workspace image {}: {e}", path.display()),
         })?;
-    file.set_len(config.size_bytes)
+    file.set_len(workspace_drive_size_bytes(config.size_mb))
         .await
         .map_err(|e| SandboxError::Initialization {
             phase: SandboxInitializationPhase::SandboxAllocation,
@@ -458,6 +458,10 @@ pub(crate) async fn prepare_workspace_drive_image(
         message: format!("format workspace image: {e}"),
     })?;
     Ok(())
+}
+
+fn workspace_drive_size_bytes(size_mb: u32) -> u64 {
+    u64::from(size_mb) * 1024 * 1024
 }
 
 fn clean_stale_sock_dir(id: &str, sock_dir: &Path) -> sandbox::Result<()> {
@@ -556,6 +560,11 @@ mod tests {
     use crate::network::{NetnsLease, NetnsPool};
     use std::path::PathBuf;
     use std::sync::{Arc, Mutex};
+
+    #[test]
+    fn workspace_drive_size_bytes_converts_mib_to_bytes() {
+        assert_eq!(workspace_drive_size_bytes(16), 16 * 1024 * 1024);
+    }
 
     #[tokio::test]
     async fn shutdown_cleans_owned_netns_pool_with_extra_arc_refs() {

--- a/crates/sandbox-fc/src/paths.rs
+++ b/crates/sandbox-fc/src/paths.rs
@@ -135,6 +135,17 @@ impl SandboxPaths {
     pub fn cow_device_bind(&self) -> PathBuf {
         self.workspace.join("cow-device-bind")
     }
+
+    /// Active workspace block image for this sandbox.
+    pub fn workspace_image(&self) -> PathBuf {
+        self.workspace.join("workspace.ext4")
+    }
+
+    /// Bind mount target for the workspace image during snapshot restore.
+    /// Must be a regular file (not a directory) so bind mount works.
+    pub fn workspace_device_bind(&self) -> PathBuf {
+        self.workspace.join("workspace-device-bind")
+    }
 }
 
 /// Per-sandbox runtime socket paths.
@@ -241,6 +252,7 @@ impl SnapshotOutputPaths {
             memory_path: self.memory(),
             cow_path: self.cow(),
             drive_bind_path: work.cow_device_bind(),
+            workspace_drive_bind_path: work.workspace_device_bind(),
             vsock_bind_dir: sock.vsock_dir(),
         }
     }

--- a/crates/sandbox-fc/src/paths.rs
+++ b/crates/sandbox-fc/src/paths.rs
@@ -106,7 +106,7 @@ impl FactoryPaths {
     }
 }
 
-/// Per-sandbox workspace paths (persistent data: config, COW).
+/// Per-sandbox workspace paths (persistent data: config, COW, workspace image).
 pub struct SandboxPaths {
     workspace: PathBuf,
 }

--- a/crates/sandbox-fc/src/prerequisites.rs
+++ b/crates/sandbox-fc/src/prerequisites.rs
@@ -48,24 +48,28 @@ enum HostCapability {
     NetworkSetup,
     SnapshotPrivateMountCreate,
     SnapshotPrivateMountRestore,
-    SparseCopy,
+    WorkspaceImageCreate,
 }
 
-const FACTORY_FRESH_CAPABILITIES: &[HostCapability] = &[HostCapability::NetworkSetup];
+const FACTORY_FRESH_CAPABILITIES: &[HostCapability] = &[
+    HostCapability::NetworkSetup,
+    HostCapability::WorkspaceImageCreate,
+];
 const FACTORY_SNAPSHOT_RESTORE_CAPABILITIES: &[HostCapability] = &[
     HostCapability::NetworkSetup,
-    HostCapability::SparseCopy,
+    HostCapability::WorkspaceImageCreate,
     HostCapability::SnapshotPrivateMountRestore,
 ];
 const SNAPSHOT_CREATE_CAPABILITIES: &[HostCapability] = &[
     HostCapability::NetworkSetup,
+    HostCapability::WorkspaceImageCreate,
     HostCapability::SnapshotPrivateMountCreate,
 ];
 
 const NETWORK_COMMANDS: &[&str] = &["ip", "iptables", "iptables-save", "sysctl"];
 const SNAPSHOT_PRIVATE_MOUNT_CREATE_COMMANDS: &[&str] = &["unshare", "bash", "mount"];
 const SNAPSHOT_PRIVATE_MOUNT_RESTORE_COMMANDS: &[&str] = &["unshare", "bash", "mount", "umount"];
-const SPARSE_COPY_COMMANDS: &[&str] = &["cp"];
+const WORKSPACE_IMAGE_CREATE_COMMANDS: &[&str] = &["mkfs.ext4"];
 
 /// Verify that all required system prerequisites are present.
 ///
@@ -163,7 +167,7 @@ fn commands_for_capability(capability: HostCapability) -> &'static [&'static str
         HostCapability::NetworkSetup => NETWORK_COMMANDS,
         HostCapability::SnapshotPrivateMountCreate => SNAPSHOT_PRIVATE_MOUNT_CREATE_COMMANDS,
         HostCapability::SnapshotPrivateMountRestore => SNAPSHOT_PRIVATE_MOUNT_RESTORE_COMMANDS,
-        HostCapability::SparseCopy => SPARSE_COPY_COMMANDS,
+        HostCapability::WorkspaceImageCreate => WORKSPACE_IMAGE_CREATE_COMMANDS,
     }
 }
 
@@ -190,22 +194,29 @@ mod tests {
             memory_path: PathBuf::from("/tmp/memory.bin"),
             cow_path: PathBuf::from("/tmp/cow.img"),
             drive_bind_path: PathBuf::from("/tmp/cow-device-bind"),
+            workspace_drive_bind_path: PathBuf::from("/tmp/workspace-device-bind"),
             vsock_bind_dir: PathBuf::from("/tmp/vsock"),
         }
     }
 
     #[test]
-    fn factory_fresh_capabilities_are_network_only() {
+    fn factory_fresh_capabilities_include_network_and_workspace_image_create() {
         let mode = PrerequisiteMode::FactoryFresh;
-        assert_eq!(mode.capabilities(), &[HostCapability::NetworkSetup]);
+        assert_eq!(
+            mode.capabilities(),
+            &[
+                HostCapability::NetworkSetup,
+                HostCapability::WorkspaceImageCreate,
+            ]
+        );
         assert_eq!(
             required_commands(mode),
-            vec!["ip", "iptables", "iptables-save", "sysctl"]
+            vec!["ip", "iptables", "iptables-save", "sysctl", "mkfs.ext4"]
         );
     }
 
     #[test]
-    fn snapshot_restore_capabilities_include_sparse_copy_and_private_mount_restore() {
+    fn snapshot_restore_capabilities_include_workspace_image_and_private_mount_restore() {
         let snapshot = snapshot_config();
         let mode = PrerequisiteMode::FactorySnapshotRestore {
             snapshot: &snapshot,
@@ -215,7 +226,7 @@ mod tests {
             mode.capabilities(),
             &[
                 HostCapability::NetworkSetup,
-                HostCapability::SparseCopy,
+                HostCapability::WorkspaceImageCreate,
                 HostCapability::SnapshotPrivateMountRestore,
             ]
         );
@@ -226,7 +237,7 @@ mod tests {
                 "iptables",
                 "iptables-save",
                 "sysctl",
-                "cp",
+                "mkfs.ext4",
                 "unshare",
                 "bash",
                 "mount",
@@ -244,6 +255,7 @@ mod tests {
             mode.capabilities(),
             &[
                 HostCapability::NetworkSetup,
+                HostCapability::WorkspaceImageCreate,
                 HostCapability::SnapshotPrivateMountCreate,
             ]
         );
@@ -254,12 +266,12 @@ mod tests {
                 "iptables",
                 "iptables-save",
                 "sysctl",
+                "mkfs.ext4",
                 "unshare",
                 "bash",
                 "mount",
             ]
         );
-        assert!(!commands.contains(&"cp"));
     }
 
     #[test]

--- a/crates/sandbox-fc/src/prerequisites.rs
+++ b/crates/sandbox-fc/src/prerequisites.rs
@@ -48,6 +48,7 @@ enum HostCapability {
     NetworkSetup,
     SnapshotPrivateMountCreate,
     SnapshotPrivateMountRestore,
+    SparseCopy,
     WorkspaceImageCreate,
 }
 
@@ -57,6 +58,7 @@ const FACTORY_FRESH_CAPABILITIES: &[HostCapability] = &[
 ];
 const FACTORY_SNAPSHOT_RESTORE_CAPABILITIES: &[HostCapability] = &[
     HostCapability::NetworkSetup,
+    HostCapability::SparseCopy,
     HostCapability::WorkspaceImageCreate,
     HostCapability::SnapshotPrivateMountRestore,
 ];
@@ -69,6 +71,7 @@ const SNAPSHOT_CREATE_CAPABILITIES: &[HostCapability] = &[
 const NETWORK_COMMANDS: &[&str] = &["ip", "iptables", "iptables-save", "sysctl"];
 const SNAPSHOT_PRIVATE_MOUNT_CREATE_COMMANDS: &[&str] = &["unshare", "bash", "mount"];
 const SNAPSHOT_PRIVATE_MOUNT_RESTORE_COMMANDS: &[&str] = &["unshare", "bash", "mount", "umount"];
+const SPARSE_COPY_COMMANDS: &[&str] = &["cp"];
 const WORKSPACE_IMAGE_CREATE_COMMANDS: &[&str] = &["mkfs.ext4"];
 
 /// Verify that all required system prerequisites are present.
@@ -167,6 +170,7 @@ fn commands_for_capability(capability: HostCapability) -> &'static [&'static str
         HostCapability::NetworkSetup => NETWORK_COMMANDS,
         HostCapability::SnapshotPrivateMountCreate => SNAPSHOT_PRIVATE_MOUNT_CREATE_COMMANDS,
         HostCapability::SnapshotPrivateMountRestore => SNAPSHOT_PRIVATE_MOUNT_RESTORE_COMMANDS,
+        HostCapability::SparseCopy => SPARSE_COPY_COMMANDS,
         HostCapability::WorkspaceImageCreate => WORKSPACE_IMAGE_CREATE_COMMANDS,
     }
 }
@@ -216,7 +220,7 @@ mod tests {
     }
 
     #[test]
-    fn snapshot_restore_capabilities_include_workspace_image_and_private_mount_restore() {
+    fn snapshot_restore_capabilities_include_cp_mkfs_and_private_mount_restore() {
         let snapshot = snapshot_config();
         let mode = PrerequisiteMode::FactorySnapshotRestore {
             snapshot: &snapshot,
@@ -226,6 +230,7 @@ mod tests {
             mode.capabilities(),
             &[
                 HostCapability::NetworkSetup,
+                HostCapability::SparseCopy,
                 HostCapability::WorkspaceImageCreate,
                 HostCapability::SnapshotPrivateMountRestore,
             ]
@@ -237,6 +242,7 @@ mod tests {
                 "iptables",
                 "iptables-save",
                 "sysctl",
+                "cp",
                 "mkfs.ext4",
                 "unshare",
                 "bash",

--- a/crates/sandbox-fc/src/prerequisites.rs
+++ b/crates/sandbox-fc/src/prerequisites.rs
@@ -33,45 +33,33 @@ impl<'a> PrerequisiteMode<'a> {
         }
     }
 
-    fn capabilities(self) -> &'static [HostCapability] {
+    fn command_groups(self) -> &'static [&'static [&'static str]] {
         match self {
-            Self::FactoryFresh => FACTORY_FRESH_CAPABILITIES,
-            Self::FactorySnapshotRestore { .. } => FACTORY_SNAPSHOT_RESTORE_CAPABILITIES,
-            Self::SnapshotCreate => SNAPSHOT_CREATE_CAPABILITIES,
+            Self::FactoryFresh => FACTORY_FRESH_COMMAND_GROUPS,
+            Self::FactorySnapshotRestore { .. } => FACTORY_SNAPSHOT_RESTORE_COMMAND_GROUPS,
+            Self::SnapshotCreate => SNAPSHOT_CREATE_COMMAND_GROUPS,
         }
     }
 }
 
-/// Host capability groups used to derive concrete command requirements.
-#[derive(Clone, Copy, Debug, PartialEq, Eq)]
-enum HostCapability {
-    NetworkSetup,
-    SnapshotPrivateMountCreate,
-    SnapshotPrivateMountRestore,
-    SparseCopy,
-    WorkspaceImageCreate,
-}
-
-const FACTORY_FRESH_CAPABILITIES: &[HostCapability] = &[
-    HostCapability::NetworkSetup,
-    HostCapability::WorkspaceImageCreate,
+const FACTORY_FRESH_COMMAND_GROUPS: &[&[&str]] =
+    &[NETWORK_COMMANDS, WORKSPACE_IMAGE_CREATE_COMMANDS];
+const FACTORY_SNAPSHOT_RESTORE_COMMAND_GROUPS: &[&[&str]] = &[
+    NETWORK_COMMANDS,
+    COW_POOL_SNAPSHOT_RESTORE_COMMANDS,
+    WORKSPACE_IMAGE_CREATE_COMMANDS,
+    SNAPSHOT_PRIVATE_MOUNT_RESTORE_COMMANDS,
 ];
-const FACTORY_SNAPSHOT_RESTORE_CAPABILITIES: &[HostCapability] = &[
-    HostCapability::NetworkSetup,
-    HostCapability::SparseCopy,
-    HostCapability::WorkspaceImageCreate,
-    HostCapability::SnapshotPrivateMountRestore,
-];
-const SNAPSHOT_CREATE_CAPABILITIES: &[HostCapability] = &[
-    HostCapability::NetworkSetup,
-    HostCapability::WorkspaceImageCreate,
-    HostCapability::SnapshotPrivateMountCreate,
+const SNAPSHOT_CREATE_COMMAND_GROUPS: &[&[&str]] = &[
+    NETWORK_COMMANDS,
+    WORKSPACE_IMAGE_CREATE_COMMANDS,
+    SNAPSHOT_PRIVATE_MOUNT_CREATE_COMMANDS,
 ];
 
 const NETWORK_COMMANDS: &[&str] = &["ip", "iptables", "iptables-save", "sysctl"];
 const SNAPSHOT_PRIVATE_MOUNT_CREATE_COMMANDS: &[&str] = &["unshare", "bash", "mount"];
 const SNAPSHOT_PRIVATE_MOUNT_RESTORE_COMMANDS: &[&str] = &["unshare", "bash", "mount", "umount"];
-const SPARSE_COPY_COMMANDS: &[&str] = &["cp"];
+const COW_POOL_SNAPSHOT_RESTORE_COMMANDS: &[&str] = &["cp"];
 const WORKSPACE_IMAGE_CREATE_COMMANDS: &[&str] = &["mkfs.ext4"];
 
 /// Verify that all required system prerequisites are present.
@@ -150,29 +138,19 @@ fn check_required_commands(commands: &[&str], errors: &mut Vec<String>) {
 }
 
 fn required_commands(mode: PrerequisiteMode<'_>) -> Vec<&'static str> {
-    required_commands_for_capabilities(mode.capabilities())
+    required_commands_for_groups(mode.command_groups())
 }
 
-fn required_commands_for_capabilities(capabilities: &[HostCapability]) -> Vec<&'static str> {
+fn required_commands_for_groups<'a>(command_groups: &[&'a [&'a str]]) -> Vec<&'a str> {
     let mut commands = Vec::new();
-    for capability in capabilities {
-        for &cmd in commands_for_capability(*capability) {
+    for group in command_groups {
+        for &cmd in *group {
             if !commands.contains(&cmd) {
                 commands.push(cmd);
             }
         }
     }
     commands
-}
-
-fn commands_for_capability(capability: HostCapability) -> &'static [&'static str] {
-    match capability {
-        HostCapability::NetworkSetup => NETWORK_COMMANDS,
-        HostCapability::SnapshotPrivateMountCreate => SNAPSHOT_PRIVATE_MOUNT_CREATE_COMMANDS,
-        HostCapability::SnapshotPrivateMountRestore => SNAPSHOT_PRIVATE_MOUNT_RESTORE_COMMANDS,
-        HostCapability::SparseCopy => SPARSE_COPY_COMMANDS,
-        HostCapability::WorkspaceImageCreate => WORKSPACE_IMAGE_CREATE_COMMANDS,
-    }
 }
 
 /// Create `/run/vm0` with mode 1777 (world-writable + sticky bit) if needed.
@@ -204,15 +182,8 @@ mod tests {
     }
 
     #[test]
-    fn factory_fresh_capabilities_include_network_and_workspace_image_create() {
+    fn factory_fresh_commands_include_network_and_workspace_image_create() {
         let mode = PrerequisiteMode::FactoryFresh;
-        assert_eq!(
-            mode.capabilities(),
-            &[
-                HostCapability::NetworkSetup,
-                HostCapability::WorkspaceImageCreate,
-            ]
-        );
         assert_eq!(
             required_commands(mode),
             vec!["ip", "iptables", "iptables-save", "sysctl", "mkfs.ext4"]
@@ -220,21 +191,12 @@ mod tests {
     }
 
     #[test]
-    fn snapshot_restore_capabilities_include_cp_mkfs_and_private_mount_restore() {
+    fn snapshot_restore_commands_include_cp_mkfs_and_private_mount_restore() {
         let snapshot = snapshot_config();
         let mode = PrerequisiteMode::FactorySnapshotRestore {
             snapshot: &snapshot,
         };
 
-        assert_eq!(
-            mode.capabilities(),
-            &[
-                HostCapability::NetworkSetup,
-                HostCapability::SparseCopy,
-                HostCapability::WorkspaceImageCreate,
-                HostCapability::SnapshotPrivateMountRestore,
-            ]
-        );
         assert_eq!(
             required_commands(mode),
             vec![
@@ -253,18 +215,10 @@ mod tests {
     }
 
     #[test]
-    fn snapshot_create_capabilities_include_private_mount_create_without_sparse_copy() {
+    fn snapshot_create_commands_include_private_mount_create_without_sparse_copy() {
         let mode = PrerequisiteMode::SnapshotCreate;
         let commands = required_commands(mode);
 
-        assert_eq!(
-            mode.capabilities(),
-            &[
-                HostCapability::NetworkSetup,
-                HostCapability::WorkspaceImageCreate,
-                HostCapability::SnapshotPrivateMountCreate,
-            ]
-        );
         assert_eq!(
             commands,
             vec![
@@ -317,7 +271,7 @@ mod tests {
     #[test]
     fn network_prerequisites_use_network_command_set() {
         assert_eq!(
-            required_commands_for_capabilities(&[HostCapability::NetworkSetup]),
+            required_commands_for_groups(&[NETWORK_COMMANDS]),
             vec!["ip", "iptables", "iptables-save", "sysctl"]
         );
     }

--- a/crates/sandbox-fc/src/runtime.rs
+++ b/crates/sandbox-fc/src/runtime.rs
@@ -87,6 +87,7 @@ impl FirecrackerRuntime {
             memory_path: output.memory(),
             cow_path: output.cow(),
             drive_bind_path: work.cow_device_bind(),
+            workspace_drive_bind_path: work.workspace_device_bind(),
             vsock_bind_dir: sock.vsock_dir(),
         }
     }

--- a/crates/sandbox-fc/src/sandbox.rs
+++ b/crates/sandbox-fc/src/sandbox.rs
@@ -1,6 +1,7 @@
 use std::ffi::OsString;
 use std::future::Future;
 use std::io;
+use std::num::NonZeroU64;
 use std::os::unix::ffi::OsStringExt;
 use std::path::Path;
 use std::sync::atomic::{AtomicU8, Ordering};
@@ -64,7 +65,7 @@ const GUEST_PARK_LIFECYCLE_TIMEOUT: Duration = Duration::from_secs(5);
 
 /// Bash command run inside `unshare --mount` for snapshot restore.
 /// Positional args are documented at the spawn site.
-const SNAPSHOT_RESTORE_INNER_CMD: &str = r#"umount "$4" 2>/dev/null; mount --bind "$1" "$2" && mount --bind "$3" "$4" && exec ip netns exec "$5" "$6" --api-sock "$7""#;
+const SNAPSHOT_RESTORE_INNER_CMD: &str = r#"umount -- "$4" 2>/dev/null; umount -- "$6" 2>/dev/null; mount --bind -- "$1" "$2" && mount --bind -- "$3" "$4" && mount --bind -- "$5" "$6" && exec ip netns exec "$7" "$8" --api-sock "$9""#;
 const UNSHARE_MOUNT_ARGS: &[&str] = &["--mount", "--propagation", "private"];
 
 async fn load_snapshot_and_apply_rate_limits(
@@ -82,11 +83,22 @@ async fn load_snapshot_and_apply_rate_limits(
             message: format!("snapshot load failed: {e}"),
         })?;
     if let Some(rate_limits) = rate_limits {
+        let drive_rate_limiter = rate_limits
+            .block_drive_limiter(nonzero_block_drive_count(2)?)
+            .map_err(|e| SandboxError::Start {
+                message: format!("build snapshot drive rate limiter: {e}"),
+            })?;
         client
-            .patch_drive_rate_limiter("rootfs", &rate_limits.drive)
+            .patch_drive_rate_limiter("rootfs", &drive_rate_limiter)
             .await
             .map_err(|e| SandboxError::Start {
                 message: format!("snapshot drive rate limiter patch failed: {e}"),
+            })?;
+        client
+            .patch_drive_rate_limiter("workspace", &drive_rate_limiter)
+            .await
+            .map_err(|e| SandboxError::Start {
+                message: format!("snapshot workspace drive rate limiter patch failed: {e}"),
             })?;
         let inv = InvariantConfig::new();
         client
@@ -107,6 +119,7 @@ fn build_fresh_boot_firecracker_config(
     resources: &sandbox::ResourceLimits,
     kernel_path: String,
     cow_device_path: String,
+    workspace_device_path: Option<String>,
     vsock_path: String,
     device_rate_limits: Option<&FirecrackerDeviceRateLimits>,
 ) -> sandbox::Result<serde_json::Value> {
@@ -120,18 +133,43 @@ fn build_fresh_boot_firecracker_config(
         ("is_root_device".to_string(), serde_json::json!(true)),
         ("is_read_only".to_string(), serde_json::json!(false)),
     ]);
+    let mut workspace_drive = workspace_device_path.map(|workspace_device_path| {
+        serde_json::Map::from_iter([
+            ("drive_id".to_string(), serde_json::json!("workspace")),
+            (
+                "path_on_host".to_string(),
+                serde_json::json!(workspace_device_path),
+            ),
+            ("is_root_device".to_string(), serde_json::json!(false)),
+            ("is_read_only".to_string(), serde_json::json!(false)),
+        ])
+    });
     let mut network_interface = serde_json::Map::from_iter([
         ("iface_id".to_string(), serde_json::json!(inv.iface_id)),
         ("guest_mac".to_string(), serde_json::json!(inv.guest_mac)),
         ("host_dev_name".to_string(), serde_json::json!(inv.tap_name)),
     ]);
     if let Some(rate_limits) = device_rate_limits {
+        let block_drive_count = if workspace_drive.is_some() { 2 } else { 1 };
+        let drive_rate_limiter = rate_limits
+            .block_drive_limiter(nonzero_block_drive_count(block_drive_count)?)
+            .map_err(|e| SandboxError::Start {
+                message: format!("build drive rate limiter: {e}"),
+            })?;
         drive.insert(
             "rate_limiter".to_string(),
-            serde_json::to_value(&rate_limits.drive).map_err(|e| SandboxError::Start {
+            serde_json::to_value(&drive_rate_limiter).map_err(|e| SandboxError::Start {
                 message: format!("serialize drive rate limiter: {e}"),
             })?,
         );
+        if let Some(workspace_drive) = workspace_drive.as_mut() {
+            workspace_drive.insert(
+                "rate_limiter".to_string(),
+                serde_json::to_value(&drive_rate_limiter).map_err(|e| SandboxError::Start {
+                    message: format!("serialize workspace drive rate limiter: {e}"),
+                })?,
+            );
+        }
         network_interface.insert(
             "rx_rate_limiter".to_string(),
             serde_json::to_value(&rate_limits.net_rx).map_err(|e| SandboxError::Start {
@@ -145,13 +183,17 @@ fn build_fresh_boot_firecracker_config(
             })?,
         );
     }
+    let mut drives = vec![serde_json::Value::Object(drive)];
+    if let Some(workspace_drive) = workspace_drive {
+        drives.push(serde_json::Value::Object(workspace_drive));
+    }
 
     Ok(serde_json::json!({
         "boot-source": {
             "kernel_image_path": kernel_path,
             "boot_args": inv.boot_args,
         },
-        "drives": [serde_json::Value::Object(drive)],
+        "drives": drives,
         "machine-config": {
             "vcpu_count": resources.cpu_count,
             "mem_size_mib": resources.memory_mb,
@@ -167,6 +209,12 @@ fn build_fresh_boot_firecracker_config(
             "stats_polling_interval_s": inv.balloon.stats_polling_interval_s,
         },
     }))
+}
+
+fn nonzero_block_drive_count(count: u64) -> sandbox::Result<NonZeroU64> {
+    NonZeroU64::new(count).ok_or_else(|| SandboxError::Start {
+        message: "block drive count must be non-zero".into(),
+    })
 }
 
 #[repr(u8)]
@@ -959,12 +1007,18 @@ impl FirecrackerSandbox {
     fn build_config(&self) -> sandbox::Result<serde_json::Value> {
         let kernel_path = self.factory_config.kernel_path.display().to_string();
         let cow_device_path = self.cow_device()?.device_path().display().to_string();
+        let workspace_device_path = self
+            .config
+            .workspace_drive
+            .as_ref()
+            .map(|_| self.sandbox_paths.workspace_image().display().to_string());
         let vsock_path = self.sock_paths.vsock().display().to_string();
 
         build_fresh_boot_firecracker_config(
             &self.config.resources,
             kernel_path,
             cow_device_path,
+            workspace_device_path,
             vsock_path,
             self.device_rate_limits.as_ref(),
         )
@@ -1055,6 +1109,11 @@ impl FirecrackerSandbox {
                 .ok_or_else(|| SandboxError::Start {
                     message: "missing snapshot config".into(),
                 })?;
+        if self.config.workspace_drive.is_none() {
+            return Err(SandboxError::Start {
+                message: "snapshot restore requires a workspace drive".into(),
+            });
+        }
 
         // Ensure bind mount target directories exist.
         tokio::fs::create_dir_all(&snapshot.vsock_bind_dir)
@@ -1064,6 +1123,7 @@ impl FirecrackerSandbox {
             })?;
 
         ensure_snapshot_drive_bind_target(&snapshot.drive_bind_path).await?;
+        ensure_snapshot_drive_bind_target(&snapshot.workspace_drive_bind_path).await?;
 
         // Verify sock dir exists before spawning — if this fails, we know
         // the directory was never created or was removed before spawn.
@@ -1076,20 +1136,22 @@ impl FirecrackerSandbox {
             });
         }
         let cow_device_path = self.cow_device()?.device_path();
+        let workspace_image_path = self.sandbox_paths.workspace_image();
         info!(
             id = %self.id,
             api_sock = %api_sock.display(),
             sock_dir = %sock_dir.display(),
             cow_device = %cow_device_path.display(),
+            workspace_image = %workspace_image_path.display(),
             netns = %self.network.name(),
             binary = %self.factory_config.binary_path.display(),
             "spawning firecracker (snapshot restore)"
         );
 
-        // Use positional args ($1..$7) to avoid shell injection from paths.
+        // Use positional args ($1..$9) to avoid shell injection from paths.
         //
-        // Bind mount targets ($2, $4) are snapshot-level paths shared by all
-        // sandboxes.  Each sandbox runs inside `unshare --mount`, so bind
+        // Bind mount targets ($2, $4, $6) are snapshot-level paths shared by
+        // all sandboxes. Each sandbox runs inside `unshare --mount`, so bind
         // mounts are per-namespace and don't conflict.
         //
         // IMPORTANT: we must NOT `rm -f` the bind mount target.  The target
@@ -1108,9 +1170,11 @@ impl FirecrackerSandbox {
             .arg(&snapshot.vsock_bind_dir) // $2
             .arg(cow_device_path) // $3
             .arg(&snapshot.drive_bind_path) // $4
-            .arg(self.network.name()) // $5
-            .arg(&self.factory_config.binary_path) // $6
-            .arg(&api_sock) // $7
+            .arg(&workspace_image_path) // $5
+            .arg(&snapshot.workspace_drive_bind_path) // $6
+            .arg(self.network.name()) // $7
+            .arg(&self.factory_config.binary_path) // $8
+            .arg(&api_sock) // $9
             .current_dir(self.sandbox_paths.workspace())
             .stdin(std::process::Stdio::null())
             .stdout(std::process::Stdio::piped())
@@ -2966,6 +3030,7 @@ mod tests {
                 id,
                 resources: test_resources(),
                 device_rate_limits: None,
+                workspace_drive: None,
             },
             factory_config: FirecrackerConfig {
                 binary_path: base_dir.join("firecracker"),
@@ -3318,15 +3383,9 @@ mod tests {
 
     fn test_rate_limits() -> FirecrackerDeviceRateLimits {
         FirecrackerDeviceRateLimits {
-            drive: RateLimiterConfig {
-                bandwidth: Some(TokenBucketConfig {
-                    size: 1024,
-                    refill_time: 100,
-                }),
-                ops: Some(TokenBucketConfig {
-                    size: 10,
-                    refill_time: 100,
-                }),
+            block: sandbox::BlockRateLimits {
+                bandwidth_bytes_per_sec: 10_240,
+                ops_per_sec: 100,
             },
             net_rx: RateLimiterConfig {
                 bandwidth: Some(TokenBucketConfig {
@@ -3351,6 +3410,7 @@ mod tests {
             &test_resources(),
             "/kernel".to_string(),
             "/dev/nbd0".to_string(),
+            None,
             "/run/vsock.sock".to_string(),
             None,
         )
@@ -3376,6 +3436,7 @@ mod tests {
             &test_resources(),
             "/kernel".to_string(),
             "/dev/nbd0".to_string(),
+            None,
             "/run/vsock.sock".to_string(),
             Some(&rate_limits),
         )
@@ -3399,6 +3460,37 @@ mod tests {
             serde_json::json!({
                 "bandwidth": { "size": 4096, "refill_time": 100 },
             })
+        );
+    }
+
+    #[test]
+    fn fresh_boot_config_includes_workspace_drive_and_splits_block_limiters() {
+        let rate_limits = test_rate_limits();
+        let config = build_fresh_boot_firecracker_config(
+            &test_resources(),
+            "/kernel".to_string(),
+            "/dev/nbd0".to_string(),
+            Some("/workspaces/test/workspace.ext4".to_string()),
+            "/run/vsock.sock".to_string(),
+            Some(&rate_limits),
+        )
+        .unwrap();
+
+        assert_eq!(config["drives"][0]["drive_id"], "rootfs");
+        assert_eq!(config["drives"][1]["drive_id"], "workspace");
+        assert_eq!(
+            config["drives"][1]["path_on_host"],
+            "/workspaces/test/workspace.ext4"
+        );
+        assert_eq!(config["drives"][1]["is_root_device"], false);
+        assert_eq!(config["drives"][1]["is_read_only"], false);
+        assert_eq!(
+            config["drives"][0]["rate_limiter"]["bandwidth"]["size"],
+            512
+        );
+        assert_eq!(
+            config["drives"][1]["rate_limiter"]["bandwidth"]["size"],
+            512
         );
     }
 
@@ -5826,14 +5918,14 @@ mod tests {
     #[test]
     fn snapshot_restore_inner_cmd_uses_positional_args_without_touch() {
         assert!(!SNAPSHOT_RESTORE_INNER_CMD.contains("$0"));
-        for arg in ["$1", "$2", "$3", "$4", "$5", "$6", "$7"] {
+        for arg in ["$1", "$2", "$3", "$4", "$5", "$6", "$7", "$8", "$9"] {
             let quoted = format!(r#""{arg}""#);
             assert!(
                 SNAPSHOT_RESTORE_INNER_CMD.contains(&quoted),
                 "expected quoted positional {arg} in inner_cmd: {SNAPSHOT_RESTORE_INNER_CMD}"
             );
         }
-        for unexpected in ["$8", "$9"] {
+        for unexpected in ["$10", "$11"] {
             assert!(
                 !SNAPSHOT_RESTORE_INNER_CMD.contains(unexpected),
                 "unexpected positional {unexpected} in inner_cmd: {SNAPSHOT_RESTORE_INNER_CMD}"
@@ -5841,13 +5933,16 @@ mod tests {
         }
 
         assert!(
-            SNAPSHOT_RESTORE_INNER_CMD.starts_with(r#"umount "$4" 2>/dev/null; mount --bind"#),
+            SNAPSHOT_RESTORE_INNER_CMD.starts_with(
+                r#"umount -- "$4" 2>/dev/null; umount -- "$6" 2>/dev/null; mount --bind"#
+            ),
             "inner_cmd must clear stale bind mount before binding: {SNAPSHOT_RESTORE_INNER_CMD}"
         );
         assert!(
-            SNAPSHOT_RESTORE_INNER_CMD
-                .contains(r#"&& mount --bind "$3" "$4" && exec ip netns exec"#),
-            "inner_cmd must bind COW device and exec firecracker: {SNAPSHOT_RESTORE_INNER_CMD}"
+            SNAPSHOT_RESTORE_INNER_CMD.contains(
+                r#"&& mount --bind -- "$3" "$4" && mount --bind -- "$5" "$6" && exec ip netns exec"#
+            ),
+            "inner_cmd must bind COW and workspace devices before execing firecracker: {SNAPSHOT_RESTORE_INNER_CMD}"
         );
         assert!(
             !SNAPSHOT_RESTORE_INNER_CMD.contains("touch"),
@@ -6135,8 +6230,8 @@ mod tests {
         let reqs = reqs.lock().await;
         assert_eq!(
             reqs.len(),
-            4,
-            "expected load, drive patch, network patch, resume"
+            5,
+            "expected load, rootfs drive patch, workspace drive patch, network patch, resume"
         );
         assert_eq!(reqs[0].method, "PUT");
         assert_eq!(reqs[0].path, "/snapshot/load");
@@ -6146,23 +6241,30 @@ mod tests {
         assert_eq!(reqs[1].path, "/drives/rootfs");
         assert_eq!(
             mock_request_body_json(&reqs[1])["rate_limiter"]["bandwidth"]["size"],
-            1024
+            512
         );
 
         assert_eq!(reqs[2].method, "PATCH");
-        assert_eq!(reqs[2].path, "/network-interfaces/eth0");
+        assert_eq!(reqs[2].path, "/drives/workspace");
         assert_eq!(
-            mock_request_body_json(&reqs[2])["rx_rate_limiter"]["bandwidth"]["size"],
-            2048
-        );
-        assert_eq!(
-            mock_request_body_json(&reqs[2])["tx_rate_limiter"]["bandwidth"]["size"],
-            4096
+            mock_request_body_json(&reqs[2])["rate_limiter"]["bandwidth"]["size"],
+            512
         );
 
         assert_eq!(reqs[3].method, "PATCH");
-        assert_eq!(reqs[3].path, "/vm");
-        assert!(reqs[3].body.contains("Resumed"));
+        assert_eq!(reqs[3].path, "/network-interfaces/eth0");
+        assert_eq!(
+            mock_request_body_json(&reqs[3])["rx_rate_limiter"]["bandwidth"]["size"],
+            2048
+        );
+        assert_eq!(
+            mock_request_body_json(&reqs[3])["tx_rate_limiter"]["bandwidth"]["size"],
+            4096
+        );
+
+        assert_eq!(reqs[4].method, "PATCH");
+        assert_eq!(reqs[4].path, "/vm");
+        assert!(reqs[4].body.contains("Resumed"));
     }
 
     #[tokio::test]
@@ -6212,7 +6314,7 @@ mod tests {
     #[tokio::test]
     async fn snapshot_restore_network_limiter_patch_failure_does_not_resume() {
         let (sock, reqs, _dir) =
-            spawn_mock_fc_api(std::collections::VecDeque::from(vec![204, 500]), None).await;
+            spawn_mock_fc_api(std::collections::VecDeque::from(vec![204, 204, 500]), None).await;
         let client = ApiClient::new(&sock);
         let rate_limits = test_rate_limits();
 
@@ -6228,11 +6330,12 @@ mod tests {
 
         assert!(err.contains("snapshot network rate limiter patch failed"));
         let reqs = reqs.lock().await;
-        assert_eq!(reqs.len(), 3, "resume must not be attempted");
+        assert_eq!(reqs.len(), 4, "resume must not be attempted");
         assert_eq!(reqs[0].path, "/snapshot/load");
         assert_eq!(mock_request_body_json(&reqs[0])["resume_vm"], false);
         assert_eq!(reqs[1].path, "/drives/rootfs");
-        assert_eq!(reqs[2].path, "/network-interfaces/eth0");
+        assert_eq!(reqs[2].path, "/drives/workspace");
+        assert_eq!(reqs[3].path, "/network-interfaces/eth0");
         assert!(reqs.iter().all(|request| request.path != "/vm"));
     }
 

--- a/crates/sandbox-fc/src/sandbox.rs
+++ b/crates/sandbox-fc/src/sandbox.rs
@@ -3464,6 +3464,30 @@ mod tests {
     }
 
     #[test]
+    fn fresh_boot_config_includes_workspace_drive_without_rate_limiters() {
+        let config = build_fresh_boot_firecracker_config(
+            &test_resources(),
+            "/kernel".to_string(),
+            "/dev/nbd0".to_string(),
+            Some("/workspaces/test/workspace.ext4".to_string()),
+            "/run/vsock.sock".to_string(),
+            None,
+        )
+        .unwrap();
+
+        assert_eq!(config["drives"][0]["drive_id"], "rootfs");
+        assert_eq!(config["drives"][1]["drive_id"], "workspace");
+        assert_eq!(
+            config["drives"][1]["path_on_host"],
+            "/workspaces/test/workspace.ext4"
+        );
+        assert_eq!(config["drives"][1]["is_root_device"], false);
+        assert_eq!(config["drives"][1]["is_read_only"], false);
+        assert!(config["drives"][0].get("rate_limiter").is_none());
+        assert!(config["drives"][1].get("rate_limiter").is_none());
+    }
+
+    #[test]
     fn fresh_boot_config_includes_workspace_drive_and_splits_block_limiters() {
         let rate_limits = test_rate_limits();
         let config = build_fresh_boot_firecracker_config(
@@ -6308,6 +6332,41 @@ mod tests {
         assert_eq!(mock_request_body_json(&reqs[0])["resume_vm"], false);
         assert_eq!(reqs[1].method, "PATCH");
         assert_eq!(reqs[1].path, "/drives/rootfs");
+        assert!(reqs.iter().all(|request| request.path != "/vm"));
+    }
+
+    #[tokio::test]
+    async fn snapshot_restore_workspace_limiter_patch_failure_does_not_resume() {
+        let (sock, reqs, _dir) =
+            spawn_mock_fc_api(std::collections::VecDeque::from(vec![204, 500]), None).await;
+        let client = ApiClient::new(&sock);
+        let rate_limits = test_rate_limits();
+
+        let err = load_snapshot_and_apply_rate_limits(
+            &client,
+            "/snap/state",
+            "/snap/memory",
+            Some(&rate_limits),
+        )
+        .await
+        .unwrap_err()
+        .to_string();
+
+        assert!(err.contains("snapshot workspace drive rate limiter patch failed"));
+        let reqs = reqs.lock().await;
+        assert_eq!(
+            reqs.len(),
+            3,
+            "network patch and resume must not be attempted"
+        );
+        assert_eq!(reqs[0].path, "/snapshot/load");
+        assert_eq!(mock_request_body_json(&reqs[0])["resume_vm"], false);
+        assert_eq!(reqs[1].path, "/drives/rootfs");
+        assert_eq!(reqs[2].path, "/drives/workspace");
+        assert!(
+            reqs.iter()
+                .all(|request| request.path != "/network-interfaces/eth0")
+        );
         assert!(reqs.iter().all(|request| request.path != "/vm"));
     }
 

--- a/crates/sandbox-fc/src/snapshot/attempt.rs
+++ b/crates/sandbox-fc/src/snapshot/attempt.rs
@@ -1,5 +1,5 @@
 use std::collections::VecDeque;
-use std::path::Path;
+use std::path::{Path, PathBuf};
 use std::sync::{Arc, Mutex};
 
 use nbd_cow::KeptCow;
@@ -16,7 +16,7 @@ use crate::process::kill_process_group;
 
 use super::SnapshotError;
 use super::cow::{destroy_snapshot_cow_after_error, destroy_snapshot_cow_and_cleanup_attempt_dir};
-use super::output::remove_dir_all_if_exists_sync;
+use super::output::{cleanup_workspace_image_file_sync, remove_dir_all_if_exists_sync};
 use super::publish::SnapshotPublishAttempt;
 use super::runtime::{
     SNAPSHOT_FINALIZER_CHILD_WAIT_TIMEOUT, SNAPSHOT_FINALIZER_PIPE_DRAIN_TIMEOUT, SPAWN_INNER_CMD,
@@ -79,11 +79,77 @@ async fn destroy_snapshot_cow_after_workflow_error(cow_device: PooledNbdCowDevic
     }
 }
 
+enum AttemptWorkspaceImage {
+    NotCreated(PathBuf),
+    Owned(PathBuf),
+    Cleaned,
+}
+
+impl Default for AttemptWorkspaceImage {
+    fn default() -> Self {
+        Self::Cleaned
+    }
+}
+
+impl AttemptWorkspaceImage {
+    fn new(path: PathBuf) -> Self {
+        Self::NotCreated(path)
+    }
+
+    fn mark_create_started(&mut self) -> Result<PathBuf, SnapshotError> {
+        match std::mem::replace(self, Self::Cleaned) {
+            Self::NotCreated(path) => {
+                let prepare_path = path.clone();
+                *self = Self::Owned(path);
+                Ok(prepare_path)
+            }
+            Self::Owned(path) => {
+                *self = Self::Owned(path);
+                Err(SnapshotError::Setup(
+                    "snapshot attempt workspace image creation already started".into(),
+                ))
+            }
+            Self::Cleaned => Err(SnapshotError::Setup(
+                "snapshot attempt workspace image already cleaned before prepare".into(),
+            )),
+        }
+    }
+
+    fn path_for_spawn(&self) -> Result<&Path, SnapshotError> {
+        match self {
+            Self::Owned(path) => Ok(path),
+            Self::NotCreated(_) => Err(SnapshotError::Setup(
+                "snapshot attempt workspace image not prepared before spawn".into(),
+            )),
+            Self::Cleaned => Err(SnapshotError::Setup(
+                "snapshot attempt workspace image already cleaned before spawn".into(),
+            )),
+        }
+    }
+
+    fn has_cleanup_work(&self) -> bool {
+        matches!(self, Self::Owned(_))
+    }
+
+    fn cleanup(&mut self, warning: &'static str) -> bool {
+        let Self::Owned(path) = self else {
+            return true;
+        };
+        let cleaned = cleanup_workspace_image_file_sync(path, warning);
+        if cleaned {
+            cleanup_empty_workspace_image_parent_dir(path);
+            *self = Self::Cleaned;
+        }
+        cleaned
+    }
+}
+
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
 struct SnapshotCleanupPresence {
     has_device_pool: bool,
     has_netns_pool: bool,
     has_cow_device: bool,
+    has_workspace_image: bool,
     has_publish_attempt: bool,
     has_network: bool,
     has_child: bool,
@@ -96,6 +162,7 @@ impl SnapshotCleanupPresence {
         self.has_device_pool
             || self.has_netns_pool
             || self.has_cow_device
+            || self.has_workspace_image
             || self.has_publish_attempt
             || self.has_network
             || self.has_child
@@ -109,6 +176,7 @@ struct SnapshotCleanupResources {
     netns_pool: Option<NetnsPool>,
     device_pool: Option<DevicePoolHandle>,
     cow_device: Option<PooledNbdCowDevice>,
+    workspace_image: AttemptWorkspaceImage,
     publish_attempt: Option<SnapshotPublishAttempt>,
     network: Option<NetnsLease>,
     child: Option<tokio::process::Child>,
@@ -121,19 +189,22 @@ impl SnapshotCleanupResources {
         netns_pool: NetnsPool,
         device_pool: DevicePoolHandle,
         cow_device: PooledNbdCowDevice,
+        workspace_image_path: PathBuf,
     ) -> Self {
         Self {
             netns_pool: Some(netns_pool),
             device_pool: Some(device_pool),
             cow_device: Some(cow_device),
+            workspace_image: AttemptWorkspaceImage::new(workspace_image_path),
             ..Self::default()
         }
     }
 
     #[cfg(test)]
-    fn without_cow_for_test() -> Self {
+    fn without_cow_for_test(workspace_image_path: PathBuf) -> Self {
         Self {
             netns_pool: Some(NetnsPool::inactive_for_test()),
+            workspace_image: AttemptWorkspaceImage::new(workspace_image_path),
             ..Self::default()
         }
     }
@@ -143,6 +214,7 @@ impl SnapshotCleanupResources {
             has_device_pool: self.device_pool.is_some(),
             has_netns_pool: self.netns_pool.is_some(),
             has_cow_device: self.cow_device.is_some(),
+            has_workspace_image: self.workspace_image.has_cleanup_work(),
             has_publish_attempt: self
                 .publish_attempt
                 .as_ref()
@@ -159,6 +231,9 @@ impl SnapshotCleanupResources {
     }
 
     async fn destroy_cow_after_setup_error(&mut self, context: &'static str) {
+        self.cleanup_workspace_image(
+            "failed to cleanup snapshot workspace image after setup error",
+        );
         if let Some(cow_device) = self.cow_device.take() {
             destroy_snapshot_cow_after_error(context, cow_device).await;
         }
@@ -185,7 +260,17 @@ impl SnapshotCleanupResources {
             SnapshotError::Teardown("snapshot attempt missing COW device before publish".into())
         })?;
         self.publish_attempt = Some(SnapshotPublishAttempt::new(cow_device));
-        self.resolve_success_publish().await
+        let kept_cow = match self.resolve_success_publish().await {
+            Ok(kept_cow) => kept_cow,
+            Err(err) => {
+                self.cleanup_workspace_image(
+                    "failed to cleanup snapshot workspace image after publish preparation error",
+                );
+                return Err(err);
+            }
+        };
+        self.cleanup_workspace_image("failed to cleanup snapshot workspace image after success");
+        Ok(kept_cow)
     }
 
     async fn resolve_success_publish(&mut self) -> Result<KeptCow, SnapshotError> {
@@ -198,10 +283,17 @@ impl SnapshotCleanupResources {
     }
 
     async fn cleanup_failure(&mut self) {
+        self.cleanup_workspace_image(
+            "failed to cleanup snapshot workspace image after workflow error",
+        );
         if let Some(cow_device) = self.cow_device.take() {
             destroy_snapshot_cow_after_workflow_error(cow_device).await;
         }
         self.cleanup_publish_attempt().await;
+    }
+
+    fn cleanup_workspace_image(&mut self, warning: &'static str) -> bool {
+        self.workspace_image.cleanup(warning)
     }
 
     async fn cleanup_publish_attempt(&mut self) -> bool {
@@ -301,12 +393,18 @@ impl SnapshotAttempt {
         netns_pool: NetnsPool,
         device_pool: DevicePoolHandle,
         cow_device: PooledNbdCowDevice,
+        workspace_image_path: PathBuf,
     ) -> Self {
         Self {
             paths,
             sock_paths: Some(sock_paths),
             output,
-            cleanup_resources: SnapshotCleanupResources::new(netns_pool, device_pool, cow_device),
+            cleanup_resources: SnapshotCleanupResources::new(
+                netns_pool,
+                device_pool,
+                cow_device,
+                workspace_image_path,
+            ),
             stderr_buf: Arc::new(Mutex::new(VecDeque::with_capacity(STDERR_BUF_LINES))),
             #[cfg(test)]
             cleanup_complete_tx: None,
@@ -318,12 +416,15 @@ impl SnapshotAttempt {
         paths: SandboxPaths,
         sock_paths: SockPaths,
         output: SnapshotOutputPaths,
+        workspace_image_path: PathBuf,
     ) -> Self {
         Self {
             paths,
             sock_paths: Some(sock_paths),
             output,
-            cleanup_resources: SnapshotCleanupResources::without_cow_for_test(),
+            cleanup_resources: SnapshotCleanupResources::without_cow_for_test(
+                workspace_image_path,
+            ),
             stderr_buf: Arc::new(Mutex::new(VecDeque::with_capacity(STDERR_BUF_LINES))),
             #[cfg(test)]
             cleanup_complete_tx: None,
@@ -360,6 +461,11 @@ impl SnapshotAttempt {
     }
 
     #[cfg(test)]
+    fn track_workspace_image_for_test(&mut self, workspace_image: PathBuf) {
+        self.cleanup_resources.workspace_image = AttemptWorkspaceImage::Owned(workspace_image);
+    }
+
+    #[cfg(test)]
     fn track_publish_attempt_for_test(&mut self, publish_attempt: SnapshotPublishAttempt) {
         self.cleanup_resources.publish_attempt = Some(publish_attempt);
     }
@@ -386,7 +492,10 @@ impl SnapshotAttempt {
         &self.output
     }
 
-    pub(super) async fn prepare_firecracker_files(&mut self) -> Result<(), SnapshotError> {
+    pub(super) async fn prepare_firecracker_files(
+        &mut self,
+        config: &SnapshotCreateConfig,
+    ) -> Result<(), SnapshotError> {
         // Filesystem pre-requisites that don't require the netns: do these
         // *before* `netns_pool.acquire()` so that a transient fs error
         // (mkdir, write) doesn't leak an acquired netns. A checked-out netns
@@ -409,6 +518,45 @@ impl SnapshotAttempt {
                 .destroy_cow_after_setup_error("create bind target")
                 .await;
             return Err(SnapshotError::Setup(format!("create bind target: {e}")));
+        }
+
+        let workspace_drive_bind = self.paths.workspace_device_bind();
+        if let Err(e) = tokio::fs::write(&workspace_drive_bind, b"").await {
+            self.cleanup_resources
+                .destroy_cow_after_setup_error("create workspace bind target")
+                .await;
+            return Err(SnapshotError::Setup(format!(
+                "create workspace bind target: {e}"
+            )));
+        }
+
+        let workspace_image_path = match self.cleanup_resources.workspace_image.mark_create_started()
+        {
+            Ok(path) => path,
+            Err(err) => {
+                self.cleanup_resources
+                    .destroy_cow_after_setup_error("prepare workspace image state")
+                    .await;
+                return Err(err);
+            }
+        };
+        if let Err(e) = crate::factory::prepare_workspace_drive_image(
+            &workspace_image_path,
+            &sandbox::WorkspaceDriveConfig {
+                size_mb: config.workspace_disk_mb,
+            },
+        )
+        .await
+        {
+            self.cleanup_resources.cleanup_workspace_image(
+                "failed to cleanup snapshot workspace image after prepare failure",
+            );
+            self.cleanup_resources
+                .destroy_cow_after_setup_error("prepare workspace image")
+                .await;
+            return Err(SnapshotError::Setup(format!(
+                "prepare workspace image: {e}"
+            )));
         }
 
         Ok(())
@@ -447,6 +595,22 @@ impl SnapshotAttempt {
     ) -> Result<(), SnapshotError> {
         let api_sock = self.sock_paths()?.api_sock();
         let drive_bind = self.paths.cow_device_bind();
+        let workspace_image = match self.cleanup_resources.workspace_image.path_for_spawn() {
+            Ok(path) => path.to_path_buf(),
+            Err(err) => {
+                self.cleanup_resources
+                    .release_network(
+                        "failed to release netns after workspace image state error",
+                        "snapshot attempt missing netns pool after workspace image state error",
+                    )
+                    .await;
+                self.cleanup_resources
+                    .destroy_cow_after_setup_error("workspace image state before spawn")
+                    .await;
+                return Err(err);
+            }
+        };
+        let workspace_drive_bind = self.paths.workspace_device_bind();
         let cow_device_path = self
             .cleanup_resources
             .cow_device
@@ -483,9 +647,11 @@ impl SnapshotAttempt {
             .args(["bash", "-c", SPAWN_INNER_CMD, "_"])
             .arg(&cow_device_path) // $1
             .arg(&drive_bind) // $2
-            .arg(&network_name) // $3
-            .arg(&config.binary_path) // $4
-            .arg(&api_sock) // $5
+            .arg(&workspace_image) // $3
+            .arg(&workspace_drive_bind) // $4
+            .arg(&network_name) // $5
+            .arg(&config.binary_path) // $6
+            .arg(&api_sock) // $7
             .current_dir(self.paths.workspace())
             .stdin(std::process::Stdio::null())
             .stdout(std::process::Stdio::piped())
@@ -603,6 +769,10 @@ impl SnapshotAttempt {
         self.cleanup_resources.cleanup_publish_attempt().await
     }
 
+    fn cleanup_workspace_image(&mut self, warning: &'static str) -> bool {
+        self.cleanup_resources.cleanup_workspace_image(warning)
+    }
+
     fn drop_forwarder_handles(&mut self) {
         self.cleanup_resources.drop_forwarder_handles();
     }
@@ -632,6 +802,7 @@ struct SnapshotCleanupReport {
     stderr_forwarder_finished: bool,
     network_released: bool,
     publish_cleaned: bool,
+    workspace_image_cleaned: bool,
     cow_destroyed: bool,
     device_pool_cleaned: bool,
     netns_pool_cleaned: bool,
@@ -676,6 +847,7 @@ impl SnapshotCleanupFinalizer {
                 "snapshot cancellation cleanup missing netns pool while releasing netns",
             )
             .await;
+        let workspace_image_cleaned = self.cleanup_workspace_image();
         let publish_cleaned = self.cleanup_publish_attempt().await;
         let cow_destroyed = self.resources.destroy_cow_during_cancellation().await;
         let device_pool_cleaned = self.cleanup_device_pool().await;
@@ -690,6 +862,7 @@ impl SnapshotCleanupFinalizer {
             stderr_forwarder_finished,
             network_released,
             publish_cleaned,
+            workspace_image_cleaned,
             cow_destroyed,
             device_pool_cleaned,
             netns_pool_cleaned,
@@ -703,6 +876,7 @@ impl SnapshotCleanupFinalizer {
             stderr_forwarder_finished = report.stderr_forwarder_finished,
             network_released = report.network_released,
             publish_cleaned = report.publish_cleaned,
+            workspace_image_cleaned = report.workspace_image_cleaned,
             cow_destroyed = report.cow_destroyed,
             device_pool_cleaned = report.device_pool_cleaned,
             netns_pool_cleaned = report.netns_pool_cleaned,
@@ -729,6 +903,17 @@ impl SnapshotCleanupFinalizer {
         self.resources.cleanup_publish_attempt().await
     }
 
+    fn cleanup_workspace_image(&mut self) -> bool {
+        if !self.resources.workspace_image.has_cleanup_work() {
+            return true;
+        }
+        #[cfg(test)]
+        self.cleanup_events.push("workspace_image");
+        self.resources.cleanup_workspace_image(
+            "failed to cleanup snapshot workspace image during cancellation cleanup",
+        )
+    }
+
     async fn cleanup_device_pool(&mut self) -> bool {
         if self.resources.device_pool.is_none() {
             return true;
@@ -743,6 +928,28 @@ impl SnapshotCleanupFinalizer {
     }
 }
 
+fn cleanup_empty_workspace_image_parent_dir(workspace_image: &Path) {
+    let Some(parent) = workspace_image.parent() else {
+        return;
+    };
+
+    match std::fs::remove_dir(parent) {
+        Ok(()) => {}
+        Err(e)
+            if matches!(
+                e.kind(),
+                std::io::ErrorKind::NotFound | std::io::ErrorKind::DirectoryNotEmpty
+            ) => {}
+        Err(e) => {
+            tracing::warn!(
+                error = %e,
+                dir = %parent.display(),
+                "failed to cleanup empty snapshot workspace image attempt dir"
+            );
+        }
+    }
+}
+
 impl Drop for SnapshotCleanupFinalizer {
     fn drop(&mut self) {
         if !self.has_cleanup_work() {
@@ -754,6 +961,7 @@ impl Drop for SnapshotCleanupFinalizer {
             has_device_pool = presence.has_device_pool,
             has_netns_pool = presence.has_netns_pool,
             has_cow_device = presence.has_cow_device,
+            has_workspace_image = presence.has_workspace_image,
             has_publish_attempt = presence.has_publish_attempt,
             has_network = presence.has_network,
             has_child = presence.has_child,
@@ -785,6 +993,7 @@ impl Drop for SnapshotAttempt {
                     has_device_pool = presence.has_device_pool,
                     has_netns_pool = presence.has_netns_pool,
                     has_cow_device = presence.has_cow_device,
+                    has_workspace_image = presence.has_workspace_image,
                     has_publish_attempt = presence.has_publish_attempt,
                     has_network = presence.has_network,
                     has_child = presence.has_child,
@@ -801,6 +1010,7 @@ impl Drop for SnapshotAttempt {
                 has_device_pool = presence.has_device_pool,
                 has_netns_pool = presence.has_netns_pool,
                 has_cow_device = presence.has_cow_device,
+                has_workspace_image = presence.has_workspace_image,
                 has_publish_attempt = presence.has_publish_attempt,
                 has_network = presence.has_network,
                 has_child = presence.has_child,
@@ -821,7 +1031,7 @@ mod tests {
     use nbd_cow::pool::DevicePoolHandle;
 
     use crate::paths::{SandboxPaths, SnapshotOutputPaths, SockPaths};
-    use crate::snapshot::cow::snapshot_attempt_cow_file;
+    use crate::snapshot::cow::{snapshot_attempt_cow_file, snapshot_attempt_workspace_image_file};
     use crate::snapshot::publish::SnapshotPublishAttempt;
 
     use super::*;
@@ -881,6 +1091,7 @@ mod tests {
                 has_device_pool: true,
                 has_netns_pool: true,
                 has_cow_device: false,
+                has_workspace_image: false,
                 has_publish_attempt: true,
                 has_network: true,
                 has_child: true,
@@ -899,6 +1110,7 @@ mod tests {
         assert!(report.stderr_forwarder_finished);
         assert!(report.network_released);
         assert!(report.publish_cleaned);
+        assert!(report.workspace_image_cleaned);
         assert!(report.device_pool_cleaned);
         assert!(report.netns_pool_cleaned);
     }
@@ -1016,7 +1228,10 @@ mod tests {
         let sock_dir = dir.path().join("sock");
         let sock_paths = SockPaths::new(sock_dir.clone());
         let stale_socket = sock_dir.join("api.sock");
-        let mut attempt = SnapshotAttempt::new_without_cow_for_test(paths, sock_paths, output);
+        let workspace_image =
+            snapshot_attempt_workspace_image_file(paths.workspace(), "socket-cleanup-test");
+        let mut attempt =
+            SnapshotAttempt::new_without_cow_for_test(paths, sock_paths, output, workspace_image);
 
         tokio::fs::create_dir_all(&sock_dir)
             .await
@@ -1039,8 +1254,10 @@ mod tests {
         let paths = SandboxPaths::new(output.work_dir());
         let sock_dir = dir.path().join("sock");
         let sock_paths = SockPaths::new(sock_dir.clone());
+        let workspace_image =
+            snapshot_attempt_workspace_image_file(paths.workspace(), "default-test");
         (
-            SnapshotAttempt::new_without_cow_for_test(paths, sock_paths, output),
+            SnapshotAttempt::new_without_cow_for_test(paths, sock_paths, output, workspace_image),
             sock_dir,
         )
     }

--- a/crates/sandbox-fc/src/snapshot/attempt.rs
+++ b/crates/sandbox-fc/src/snapshot/attempt.rs
@@ -1177,6 +1177,45 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn snapshot_workspace_image_cleanup_preserves_nonempty_attempt_dir() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let (mut attempt, _sock_dir) = snapshot_attempt_for_test(&dir);
+        let workspace_image = attempt.workspace_image_path.clone();
+        let attempt_dir = workspace_image
+            .parent()
+            .expect("workspace image parent")
+            .to_path_buf();
+        let cow_file = attempt_dir.join("cow.img");
+
+        tokio::fs::create_dir_all(&attempt_dir)
+            .await
+            .expect("create attempt dir");
+        tokio::fs::write(&workspace_image, b"workspace")
+            .await
+            .expect("write workspace image");
+        tokio::fs::write(&cow_file, b"cow")
+            .await
+            .expect("write cow");
+        attempt.track_workspace_image_for_test();
+
+        assert!(attempt.cleanup_workspace_image("failed to cleanup workspace image in test"));
+
+        assert!(
+            !tokio::fs::try_exists(&workspace_image).await.unwrap(),
+            "workspace image should be removed"
+        );
+        assert!(
+            tokio::fs::try_exists(&attempt_dir).await.unwrap(),
+            "attempt dir must remain while COW artifacts still exist"
+        );
+        assert_eq!(
+            tokio::fs::read(&cow_file).await.unwrap(),
+            b"cow",
+            "cleanup must not remove unrelated attempt files"
+        );
+    }
+
+    #[tokio::test]
     async fn snapshot_setup_error_cleanup_removes_workspace_image_inline() {
         let dir = tempfile::tempdir().expect("tempdir");
         let (mut attempt, _sock_dir) = snapshot_attempt_for_test(&dir);

--- a/crates/sandbox-fc/src/snapshot/attempt.rs
+++ b/crates/sandbox-fc/src/snapshot/attempt.rs
@@ -79,6 +79,8 @@ async fn destroy_snapshot_cow_after_workflow_error(cow_device: PooledNbdCowDevic
     }
 }
 
+// The path is known at attempt construction; cleanup is required only after
+// image creation starts.
 enum AttemptWorkspaceImage {
     NotCreated(PathBuf),
     Owned(PathBuf),
@@ -393,6 +395,7 @@ impl SnapshotAttempt {
         netns_pool: NetnsPool,
         device_pool: DevicePoolHandle,
         cow_device: PooledNbdCowDevice,
+        workspace_image_path: PathBuf,
     ) -> Self {
         Self {
             paths,
@@ -415,6 +418,7 @@ impl SnapshotAttempt {
         paths: SandboxPaths,
         sock_paths: SockPaths,
         output: SnapshotOutputPaths,
+        workspace_image_path: PathBuf,
     ) -> Self {
         Self {
             paths,
@@ -1374,7 +1378,10 @@ mod tests {
         let sock_dir = dir.path().join("sock");
         let sock_paths = SockPaths::new(sock_dir.clone());
         let stale_socket = sock_dir.join("api.sock");
-        let mut attempt = SnapshotAttempt::new_without_cow_for_test(paths, sock_paths, output);
+        let workspace_image =
+            snapshot_attempt_workspace_image_file(paths.workspace(), "socket-cleanup-test");
+        let mut attempt =
+            SnapshotAttempt::new_without_cow_for_test(paths, sock_paths, output, workspace_image);
 
         tokio::fs::create_dir_all(&sock_dir)
             .await
@@ -1397,8 +1404,10 @@ mod tests {
         let paths = SandboxPaths::new(output.work_dir());
         let sock_dir = dir.path().join("sock");
         let sock_paths = SockPaths::new(sock_dir.clone());
+        let workspace_image =
+            snapshot_attempt_workspace_image_file(paths.workspace(), "default-test");
         (
-            SnapshotAttempt::new_without_cow_for_test(paths, sock_paths, output),
+            SnapshotAttempt::new_without_cow_for_test(paths, sock_paths, output, workspace_image),
             sock_dir,
         )
     }

--- a/crates/sandbox-fc/src/snapshot/attempt.rs
+++ b/crates/sandbox-fc/src/snapshot/attempt.rs
@@ -393,7 +393,6 @@ impl SnapshotAttempt {
         netns_pool: NetnsPool,
         device_pool: DevicePoolHandle,
         cow_device: PooledNbdCowDevice,
-        workspace_image_path: PathBuf,
     ) -> Self {
         Self {
             paths,
@@ -416,7 +415,6 @@ impl SnapshotAttempt {
         paths: SandboxPaths,
         sock_paths: SockPaths,
         output: SnapshotOutputPaths,
-        workspace_image_path: PathBuf,
     ) -> Self {
         Self {
             paths,
@@ -1376,10 +1374,7 @@ mod tests {
         let sock_dir = dir.path().join("sock");
         let sock_paths = SockPaths::new(sock_dir.clone());
         let stale_socket = sock_dir.join("api.sock");
-        let workspace_image =
-            snapshot_attempt_workspace_image_file(paths.workspace(), "socket-cleanup-test");
-        let mut attempt =
-            SnapshotAttempt::new_without_cow_for_test(paths, sock_paths, output, workspace_image);
+        let mut attempt = SnapshotAttempt::new_without_cow_for_test(paths, sock_paths, output);
 
         tokio::fs::create_dir_all(&sock_dir)
             .await
@@ -1402,10 +1397,8 @@ mod tests {
         let paths = SandboxPaths::new(output.work_dir());
         let sock_dir = dir.path().join("sock");
         let sock_paths = SockPaths::new(sock_dir.clone());
-        let workspace_image =
-            snapshot_attempt_workspace_image_file(paths.workspace(), "default-test");
         (
-            SnapshotAttempt::new_without_cow_for_test(paths, sock_paths, output, workspace_image),
+            SnapshotAttempt::new_without_cow_for_test(paths, sock_paths, output),
             sock_dir,
         )
     }

--- a/crates/sandbox-fc/src/snapshot/attempt.rs
+++ b/crates/sandbox-fc/src/snapshot/attempt.rs
@@ -81,16 +81,12 @@ async fn destroy_snapshot_cow_after_workflow_error(cow_device: PooledNbdCowDevic
 
 // The path is known at attempt construction; cleanup is required only after
 // image creation starts.
+#[derive(Default)]
 enum AttemptWorkspaceImage {
     NotCreated(PathBuf),
     Owned(PathBuf),
+    #[default]
     Cleaned,
-}
-
-impl Default for AttemptWorkspaceImage {
-    fn default() -> Self {
-        Self::Cleaned
-    }
 }
 
 impl AttemptWorkspaceImage {
@@ -769,10 +765,6 @@ impl SnapshotAttempt {
         self.cleanup_resources.cleanup_publish_attempt().await
     }
 
-    fn cleanup_workspace_image(&mut self, warning: &'static str) -> bool {
-        self.cleanup_resources.cleanup_workspace_image(warning)
-    }
-
     fn drop_forwarder_handles(&mut self) {
         self.cleanup_resources.drop_forwarder_handles();
     }
@@ -1201,7 +1193,11 @@ mod tests {
             .expect("write cow");
         attempt.track_workspace_image_for_test(workspace_image.clone());
 
-        assert!(attempt.cleanup_workspace_image("failed to cleanup workspace image in test"));
+        assert!(
+            attempt
+                .cleanup_resources
+                .cleanup_workspace_image("failed to cleanup workspace image in test")
+        );
 
         assert!(
             !tokio::fs::try_exists(&workspace_image).await.unwrap(),

--- a/crates/sandbox-fc/src/snapshot/attempt.rs
+++ b/crates/sandbox-fc/src/snapshot/attempt.rs
@@ -422,9 +422,7 @@ impl SnapshotAttempt {
             paths,
             sock_paths: Some(sock_paths),
             output,
-            cleanup_resources: SnapshotCleanupResources::without_cow_for_test(
-                workspace_image_path,
-            ),
+            cleanup_resources: SnapshotCleanupResources::without_cow_for_test(workspace_image_path),
             stderr_buf: Arc::new(Mutex::new(VecDeque::with_capacity(STDERR_BUF_LINES))),
             #[cfg(test)]
             cleanup_complete_tx: None,
@@ -530,16 +528,16 @@ impl SnapshotAttempt {
             )));
         }
 
-        let workspace_image_path = match self.cleanup_resources.workspace_image.mark_create_started()
-        {
-            Ok(path) => path,
-            Err(err) => {
-                self.cleanup_resources
-                    .destroy_cow_after_setup_error("prepare workspace image state")
-                    .await;
-                return Err(err);
-            }
-        };
+        let workspace_image_path =
+            match self.cleanup_resources.workspace_image.mark_create_started() {
+                Ok(path) => path,
+                Err(err) => {
+                    self.cleanup_resources
+                        .destroy_cow_after_setup_error("prepare workspace image state")
+                        .await;
+                    return Err(err);
+                }
+            };
         if let Err(e) = crate::factory::prepare_workspace_drive_image(
             &workspace_image_path,
             &sandbox::WorkspaceDriveConfig {
@@ -1205,6 +1203,52 @@ mod tests {
         assert!(
             !tokio::fs::try_exists(&workspace_image).await.unwrap(),
             "setup error cleanup should remove temporary workspace image inline"
+        );
+    }
+
+    #[tokio::test]
+    async fn snapshot_cleanup_finalizer_removes_attempt_dir_after_workspace_and_publish_cleanup() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let output = SnapshotOutputPaths::new(dir.path().join("output"));
+        let paths = SandboxPaths::new(output.work_dir());
+        let sock_paths = SockPaths::new(dir.path().join("sock"));
+        let kept_cow = write_kept_cow_for_test(&output.work_dir(), "shared-attempt").await;
+        let attempt_dir = kept_cow
+            .cow_file
+            .parent()
+            .expect("attempt dir")
+            .to_path_buf();
+        let workspace_image = attempt_dir.join("workspace.ext4");
+        let (tx, rx) = tokio::sync::oneshot::channel();
+
+        tokio::fs::write(&workspace_image, b"workspace")
+            .await
+            .expect("write workspace image");
+        let mut attempt = SnapshotAttempt::new_without_cow_for_test(
+            paths,
+            sock_paths,
+            output,
+            workspace_image.clone(),
+        );
+        attempt.track_workspace_image_for_test(workspace_image);
+        attempt.track_publish_attempt_for_test(SnapshotPublishAttempt::new_with_kept_cow_for_test(
+            kept_cow,
+        ));
+        attempt.notify_cleanup_complete_for_test(tx);
+
+        drop(attempt);
+        let report = wait_for_snapshot_cleanup(rx).await;
+
+        assert!(report.workspace_image_cleaned);
+        assert!(report.publish_cleaned);
+        assert_eq!(
+            report.cleanup_events,
+            vec!["workspace_image", "publish"],
+            "workspace image must be removed before COW publish cleanup removes the attempt dir"
+        );
+        assert!(
+            !tokio::fs::try_exists(&attempt_dir).await.unwrap(),
+            "attempt dir should be removed after workspace image and kept COW cleanup"
         );
     }
 

--- a/crates/sandbox-fc/src/snapshot/attempt.rs
+++ b/crates/sandbox-fc/src/snapshot/attempt.rs
@@ -1145,6 +1145,70 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn snapshot_cleanup_finalizer_removes_workspace_image() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let (mut attempt, _sock_dir) = snapshot_attempt_for_test(&dir);
+        let workspace_image =
+            snapshot_attempt_workspace_image_file(attempt.paths().workspace(), "default-test");
+        let (tx, rx) = tokio::sync::oneshot::channel();
+
+        tokio::fs::create_dir_all(workspace_image.parent().expect("workspace image parent"))
+            .await
+            .expect("create workspace image parent");
+        tokio::fs::write(&workspace_image, b"workspace")
+            .await
+            .expect("write workspace image");
+        attempt.track_workspace_image_for_test(workspace_image.clone());
+        attempt.notify_cleanup_complete_for_test(tx);
+
+        drop(attempt);
+        let report = wait_for_snapshot_cleanup(rx).await;
+
+        assert!(report.workspace_image_cleaned);
+        assert_eq!(report.cleanup_events, vec!["workspace_image"]);
+        assert!(
+            !tokio::fs::try_exists(&workspace_image).await.unwrap(),
+            "detached cleanup should remove temporary workspace image"
+        );
+        assert!(
+            !tokio::fs::try_exists(workspace_image.parent().expect("workspace image parent"))
+                .await
+                .unwrap(),
+            "detached cleanup should remove the empty attempt dir"
+        );
+    }
+
+    #[tokio::test]
+    async fn snapshot_setup_error_cleanup_removes_workspace_image_inline() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let (mut attempt, _sock_dir) = snapshot_attempt_for_test(&dir);
+        let workspace_image =
+            snapshot_attempt_workspace_image_file(attempt.paths().workspace(), "default-test");
+
+        tokio::fs::create_dir_all(workspace_image.parent().expect("workspace image parent"))
+            .await
+            .expect("create workspace image parent");
+        tokio::fs::write(&workspace_image, b"workspace")
+            .await
+            .expect("write workspace image");
+        attempt.track_workspace_image_for_test(workspace_image.clone());
+
+        attempt
+            .cleanup_resources
+            .destroy_cow_after_setup_error("test setup error")
+            .await;
+
+        assert!(matches!(
+            attempt.cleanup_resources.workspace_image,
+            AttemptWorkspaceImage::Cleaned
+        ));
+        assert!(
+            !tokio::fs::try_exists(&workspace_image).await.unwrap(),
+            "setup error cleanup should remove temporary workspace image inline"
+        );
+    }
+
+    #[tokio::test]
     async fn snapshot_attempt_drop_handoff_cleans_publish_resolve_cancellation() {
         let dir = tempfile::tempdir().expect("tempdir");
         let (mut attempt, _sock_dir) = snapshot_attempt_for_test(&dir);

--- a/crates/sandbox-fc/src/snapshot/attempt.rs
+++ b/crates/sandbox-fc/src/snapshot/attempt.rs
@@ -1180,7 +1180,8 @@ mod tests {
     async fn snapshot_workspace_image_cleanup_preserves_nonempty_attempt_dir() {
         let dir = tempfile::tempdir().expect("tempdir");
         let (mut attempt, _sock_dir) = snapshot_attempt_for_test(&dir);
-        let workspace_image = attempt.workspace_image_path.clone();
+        let workspace_image =
+            snapshot_attempt_workspace_image_file(attempt.paths().workspace(), "default-test");
         let attempt_dir = workspace_image
             .parent()
             .expect("workspace image parent")
@@ -1196,7 +1197,7 @@ mod tests {
         tokio::fs::write(&cow_file, b"cow")
             .await
             .expect("write cow");
-        attempt.track_workspace_image_for_test();
+        attempt.track_workspace_image_for_test(workspace_image.clone());
 
         assert!(attempt.cleanup_workspace_image("failed to cleanup workspace image in test"));
 

--- a/crates/sandbox-fc/src/snapshot/cow.rs
+++ b/crates/sandbox-fc/src/snapshot/cow.rs
@@ -137,6 +137,10 @@ pub(super) fn snapshot_attempt_cow_file(work_dir: &Path, token: &str) -> PathBuf
     snapshot_attempt_dir(work_dir, token).join("cow.img")
 }
 
+pub(super) fn snapshot_attempt_workspace_image_file(work_dir: &Path, token: &str) -> PathBuf {
+    snapshot_attempt_dir(work_dir, token).join("workspace.ext4")
+}
+
 pub(super) struct SnapshotAttemptDirGuard {
     dir: Option<PathBuf>,
 }
@@ -207,6 +211,22 @@ mod tests {
         assert_ne!(
             snapshot_attempt_cow_file(work, "abc123ef"),
             work.join("cow.img")
+        );
+    }
+
+    #[test]
+    fn snapshot_attempt_workspace_image_file_is_attempt_scoped() {
+        let work = std::path::Path::new("/tmp/snapshot-work");
+
+        assert_eq!(
+            snapshot_attempt_workspace_image_file(work, "abc123ef"),
+            work.join("attempts")
+                .join("abc123ef")
+                .join("workspace.ext4")
+        );
+        assert_ne!(
+            snapshot_attempt_workspace_image_file(work, "abc123ef"),
+            work.join("workspace.ext4")
         );
     }
 

--- a/crates/sandbox-fc/src/snapshot/mod.rs
+++ b/crates/sandbox-fc/src/snapshot/mod.rs
@@ -23,7 +23,7 @@ use self::attempt::{
 };
 use self::cow::{
     SnapshotAttemptDirGuard, create_sparse_cow_file, snapshot_attempt_cow_file,
-    snapshot_attempt_dir, snapshot_attempt_token,
+    snapshot_attempt_dir, snapshot_attempt_token, snapshot_attempt_workspace_image_file,
 };
 use self::output::prepare_snapshot_output;
 use self::publish::FirecrackerPendingSnapshotPublish;
@@ -104,10 +104,11 @@ async fn create_uncommitted_snapshot(
         .map_err(|e| SnapshotError::Setup(format!("base image metadata: {e}")))?
         .len();
 
-    // The stable `work/cow-device-bind` path is baked into the snapshot for
-    // restore, but the temporary COW backing file is not. Keep the COW under an
-    // attempt-scoped directory so a cancelled attempt's detached finalizer cannot
-    // unlink a later rebuild's COW after the outer snapshot lock has been released.
+    // The stable `work/*-device-bind` paths are baked into the snapshot for
+    // restore, but the temporary COW and workspace backing files are not. Keep
+    // them under an attempt-scoped directory so a cancelled attempt's detached
+    // finalizer cannot unlink a later rebuild's files after the outer snapshot
+    // lock has been released.
     let attempt_token = snapshot_attempt_token();
     let attempt_dir = snapshot_attempt_dir(paths.workspace(), &attempt_token);
     tokio::fs::create_dir_all(&attempt_dir)
@@ -115,6 +116,8 @@ async fn create_uncommitted_snapshot(
         .map_err(|e| SnapshotError::Setup(format!("create snapshot attempt dir: {e}")))?;
     let mut attempt_dir_guard = SnapshotAttemptDirGuard::new(attempt_dir);
     let cow_file = snapshot_attempt_cow_file(paths.workspace(), &attempt_token);
+    let workspace_image_file =
+        snapshot_attempt_workspace_image_file(paths.workspace(), &attempt_token);
     create_sparse_cow_file(&cow_file, base_size)?;
 
     let device_pool =
@@ -142,6 +145,7 @@ async fn create_uncommitted_snapshot(
         netns_pool,
         device_pool,
         cow_device,
+        workspace_image_file,
     );
     attempt_dir_guard.disarm();
     let result = run_snapshot_workflow(&config, &mut attempt).await;

--- a/crates/sandbox-fc/src/snapshot/mod.rs
+++ b/crates/sandbox-fc/src/snapshot/mod.rs
@@ -37,7 +37,7 @@ use self::runtime::run_snapshot_workflow;
 ///  3. Create network namespace
 ///  4. Spawn Firecracker with `--api-sock`
 ///  5. Wait for API socket ready
-///  6. Configure VM via API (7 parallel PUT calls)
+///  6. Configure VM via API (ordered drives, then parallel remaining PUT calls)
 ///  7. Bind vsock listener
 ///  8. Start instance
 ///  9. Wait for guest vsock connection

--- a/crates/sandbox-fc/src/snapshot/mod.rs
+++ b/crates/sandbox-fc/src/snapshot/mod.rs
@@ -37,7 +37,7 @@ use self::runtime::run_snapshot_workflow;
 ///  3. Create network namespace
 ///  4. Spawn Firecracker with `--api-sock`
 ///  5. Wait for API socket ready
-///  6. Configure VM via API (6 parallel PUT calls)
+///  6. Configure VM via API (7 parallel PUT calls)
 ///  7. Bind vsock listener
 ///  8. Start instance
 ///  9. Wait for guest vsock connection

--- a/crates/sandbox-fc/src/snapshot/output.rs
+++ b/crates/sandbox-fc/src/snapshot/output.rs
@@ -42,6 +42,10 @@ pub(super) fn cleanup_remove_file_result(
     }
 }
 
+pub(super) fn cleanup_workspace_image_file_sync(path: &Path, warning: &'static str) -> bool {
+    cleanup_remove_file_result(std::fs::remove_file(path), path, warning)
+}
+
 pub(super) fn cleanup_remove_dir_result(
     result: std::io::Result<()>,
     dir: &Path,

--- a/crates/sandbox-fc/src/snapshot/runtime.rs
+++ b/crates/sandbox-fc/src/snapshot/runtime.rs
@@ -174,8 +174,7 @@ pub(super) async fn drain_or_abort_forwarder(
     }
 }
 
-pub(super) const SPAWN_INNER_CMD: &str =
-    r#"mount --bind "$1" "$2" && exec ip netns exec "$3" "$4" --api-sock "$5""#;
+pub(super) const SPAWN_INNER_CMD: &str = r#"mount --bind "$1" "$2" && mount --bind "$3" "$4" && exec ip netns exec "$5" "$6" --api-sock "$7""#;
 pub(super) const UNSHARE_MOUNT_ARGS: &[&str] = &["--mount", "--propagation", "private"];
 
 /// Number of recent stderr lines retained from the spawn chain, used to
@@ -260,7 +259,7 @@ pub(super) async fn run_snapshot_workflow(
     config: &SnapshotCreateConfig,
     attempt: &mut SnapshotAttempt,
 ) -> Result<SnapshotConfig, SnapshotError> {
-    attempt.prepare_firecracker_files().await?;
+    attempt.prepare_firecracker_files(config).await?;
     attempt.acquire_network().await?;
     attempt.spawn_firecracker(config).await?;
 
@@ -293,6 +292,7 @@ async fn run_with_firecracker(
     // at spawn time; `configure_drive` only needs the path string FC will
     // open inside its private mount namespace.
     let drive_bind_str = paths.cow_device_bind().display().to_string();
+    let workspace_drive_bind_str = paths.workspace_device_bind().display().to_string();
 
     // 6. Configure VM via API (6 parallel PUT calls).
     let inv = InvariantConfig::new();
@@ -304,6 +304,7 @@ async fn run_with_firecracker(
         client.configure_machine(config.vcpu_count, config.memory_mb),
         client.configure_boot_source(&kernel_path, &inv.boot_args),
         client.configure_drive("rootfs", &drive_bind_str, true, false, None),
+        client.configure_drive("workspace", &workspace_drive_bind_str, false, false, None),
         client.configure_network_interface(inv.iface_id, inv.guest_mac, inv.tap_name, None, None),
         client.configure_vsock(inv.guest_cid, &vsock_uds_str),
         client.configure_balloon(
@@ -597,6 +598,7 @@ mod tests {
             memory_path: "/tmp/memory.bin".into(),
             cow_path: "/tmp/cow.img".into(),
             drive_bind_path: "/tmp/cow-device-bind".into(),
+            workspace_drive_bind_path: "/tmp/workspace-device-bind".into(),
             vsock_bind_dir: "/tmp/vsock".into(),
         }
     }
@@ -751,17 +753,17 @@ mod tests {
     fn spawn_inner_cmd_uses_positional_args() {
         // Only positional args, no $0 or unquoted vars.
         assert!(!SPAWN_INNER_CMD.contains("$0"));
-        for arg in ["$1", "$2", "$3", "$4", "$5"] {
+        for arg in ["$1", "$2", "$3", "$4", "$5", "$6", "$7"] {
             let quoted = format!(r#""{arg}""#);
             assert!(
                 SPAWN_INNER_CMD.contains(&quoted),
                 "expected quoted positional {arg} in inner_cmd: {SPAWN_INNER_CMD}"
             );
         }
-        // Strictly 5 positional args — if someone adds a `$6`..`$9` without
+        // Strictly 7 positional args — if someone adds a `$8`..`$9` without
         // updating the spawn site's `.arg(...)` count, the bash call
         // silently expands to empty strings and fails at runtime.
-        for unexpected in ["$6", "$7", "$8", "$9"] {
+        for unexpected in ["$8", "$9"] {
             assert!(
                 !SPAWN_INNER_CMD.contains(unexpected),
                 "unexpected positional {unexpected} in inner_cmd: {SPAWN_INNER_CMD}"

--- a/crates/sandbox-fc/src/snapshot/runtime.rs
+++ b/crates/sandbox-fc/src/snapshot/runtime.rs
@@ -294,7 +294,7 @@ async fn run_with_firecracker(
     let drive_bind_str = paths.cow_device_bind().display().to_string();
     let workspace_drive_bind_str = paths.workspace_device_bind().display().to_string();
 
-    // 6. Configure VM via API (6 parallel PUT calls).
+    // 6. Configure VM via API (7 parallel PUT calls).
     let inv = InvariantConfig::new();
     let kernel_path = config.kernel_path.display().to_string();
     tokio::fs::create_dir_all(&sock_paths.vsock_dir()).await?;

--- a/crates/sandbox-fc/src/snapshot/runtime.rs
+++ b/crates/sandbox-fc/src/snapshot/runtime.rs
@@ -288,31 +288,8 @@ async fn run_with_firecracker(
 
     info!("firecracker API ready");
 
-    // The COW-device bind mount was established inside `unshare --mount`
-    // at spawn time; `configure_drive` only needs the path string FC will
-    // open inside its private mount namespace.
-    let drive_bind_str = paths.cow_device_bind().display().to_string();
-    let workspace_drive_bind_str = paths.workspace_device_bind().display().to_string();
-
-    // 6. Configure VM via API (7 parallel PUT calls).
     let inv = InvariantConfig::new();
-    let kernel_path = config.kernel_path.display().to_string();
-    tokio::fs::create_dir_all(&sock_paths.vsock_dir()).await?;
-    let vsock_uds_str = sock_paths.vsock().display().to_string();
-
-    tokio::try_join!(
-        client.configure_machine(config.vcpu_count, config.memory_mb),
-        client.configure_boot_source(&kernel_path, &inv.boot_args),
-        client.configure_drive("rootfs", &drive_bind_str, true, false, None),
-        client.configure_drive("workspace", &workspace_drive_bind_str, false, false, None),
-        client.configure_network_interface(inv.iface_id, inv.guest_mac, inv.tap_name, None, None),
-        client.configure_vsock(inv.guest_cid, &vsock_uds_str),
-        client.configure_balloon(
-            inv.balloon.amount_mib,
-            inv.balloon.deflate_on_oom,
-            inv.balloon.stats_polling_interval_s
-        ),
-    )?;
+    let vsock_uds_str = configure_snapshot_vm(&client, config, paths, sock_paths, &inv).await?;
 
     info!("VM configured");
 
@@ -398,17 +375,251 @@ async fn run_with_firecracker(
     Ok(output.snapshot_config(&config.id))
 }
 
+async fn configure_snapshot_vm(
+    client: &ApiClient<'_>,
+    config: &SnapshotCreateConfig,
+    paths: &SandboxPaths,
+    sock_paths: &SockPaths,
+    inv: &InvariantConfig,
+) -> Result<String, SnapshotError> {
+    // The COW-device bind mount was established inside `unshare --mount`
+    // at spawn time; `configure_drive` only needs the path string FC will
+    // open inside its private mount namespace.
+    let drive_bind_str = paths.cow_device_bind().display().to_string();
+    let workspace_drive_bind_str = paths.workspace_device_bind().display().to_string();
+
+    // 6. Configure VM via API. Keep drive requests ordered so snapshot creation
+    // matches the fresh-boot config path: rootfs first, workspace second.
+    let kernel_path = config.kernel_path.display().to_string();
+    tokio::fs::create_dir_all(&sock_paths.vsock_dir()).await?;
+    let vsock_uds_str = sock_paths.vsock().display().to_string();
+
+    client
+        .configure_drive("rootfs", &drive_bind_str, true, false, None)
+        .await?;
+    client
+        .configure_drive("workspace", &workspace_drive_bind_str, false, false, None)
+        .await?;
+
+    tokio::try_join!(
+        client.configure_machine(config.vcpu_count, config.memory_mb),
+        client.configure_boot_source(&kernel_path, &inv.boot_args),
+        client.configure_network_interface(inv.iface_id, inv.guest_mac, inv.tap_name, None, None),
+        client.configure_vsock(inv.guest_cid, &vsock_uds_str),
+        client.configure_balloon(
+            inv.balloon.amount_mib,
+            inv.balloon.deflate_on_oom,
+            inv.balloon.stats_polling_interval_s
+        ),
+    )?;
+
+    Ok(vsock_uds_str)
+}
+
 #[cfg(test)]
 mod tests {
     use std::collections::VecDeque;
+    use std::path::PathBuf;
     use std::sync::{Arc, Mutex};
     use std::time::Duration;
 
     use crate::api::ApiError;
     use crate::config::SnapshotConfig;
     use crate::snapshot::SnapshotError;
+    use tokio::io::{AsyncReadExt, AsyncWriteExt};
+    use tokio::net::{UnixListener, UnixStream};
+    use tokio::sync::mpsc;
 
     use super::*;
+
+    const MOCK_REQUEST_TIMEOUT: Duration = Duration::from_secs(5);
+
+    #[derive(Debug)]
+    struct RecordedRequest {
+        method: String,
+        path: String,
+    }
+
+    struct RecordingFirecrackerApi {
+        _dir: tempfile::TempDir,
+        socket_path: PathBuf,
+        requests: mpsc::UnboundedReceiver<RecordedRequest>,
+        server: tokio::task::JoinHandle<()>,
+    }
+
+    impl RecordingFirecrackerApi {
+        fn spawn() -> Self {
+            let dir = tempfile::tempdir().expect("tempdir");
+            let socket_path = dir.path().join("fc.sock");
+            let listener = UnixListener::bind(&socket_path).expect("bind mock Firecracker API");
+            let (tx, requests) = mpsc::unbounded_channel();
+            let server = tokio::spawn(async move {
+                serve_recording_api(listener, tx).await;
+            });
+
+            Self {
+                _dir: dir,
+                socket_path,
+                requests,
+                server,
+            }
+        }
+
+        fn socket_path(&self) -> &std::path::Path {
+            &self.socket_path
+        }
+
+        async fn next_request(&mut self) -> RecordedRequest {
+            tokio::time::timeout(MOCK_REQUEST_TIMEOUT, self.requests.recv())
+                .await
+                .expect("timed out waiting for Firecracker API request")
+                .expect("mock Firecracker API stopped before request")
+        }
+    }
+
+    impl Drop for RecordingFirecrackerApi {
+        fn drop(&mut self) {
+            self.server.abort();
+        }
+    }
+
+    async fn serve_recording_api(
+        listener: UnixListener,
+        tx: mpsc::UnboundedSender<RecordedRequest>,
+    ) {
+        loop {
+            let Ok((mut stream, _)) = listener.accept().await else {
+                break;
+            };
+            let Ok(request) = read_recorded_request(&mut stream).await else {
+                continue;
+            };
+            if tx.send(request).is_err() {
+                break;
+            }
+            let _ = stream
+                .write_all(b"HTTP/1.1 204 No Content\r\nContent-Length: 0\r\n\r\n")
+                .await;
+        }
+    }
+
+    async fn read_recorded_request(stream: &mut UnixStream) -> std::io::Result<RecordedRequest> {
+        let mut buf = Vec::with_capacity(4096);
+        while header_end(&buf).is_none() {
+            let read = stream.read_buf(&mut buf).await?;
+            if read == 0 {
+                break;
+            }
+        }
+        let header_end = header_end(&buf).ok_or_else(|| {
+            std::io::Error::new(
+                std::io::ErrorKind::InvalidData,
+                "request missing header terminator",
+            )
+        })?;
+        let headers = String::from_utf8_lossy(&buf[..header_end.saturating_sub(4)]);
+        let request_line = headers.lines().next().ok_or_else(|| {
+            std::io::Error::new(
+                std::io::ErrorKind::InvalidData,
+                "request missing request line",
+            )
+        })?;
+        let mut parts = request_line.split_whitespace();
+        let method = parts
+            .next()
+            .ok_or_else(|| std::io::Error::new(std::io::ErrorKind::InvalidData, "missing method"))?
+            .to_owned();
+        let path = parts
+            .next()
+            .ok_or_else(|| std::io::Error::new(std::io::ErrorKind::InvalidData, "missing path"))?
+            .to_owned();
+        let content_length = headers
+            .lines()
+            .find_map(|line| {
+                let (key, value) = line.split_once(':')?;
+                key.trim()
+                    .eq_ignore_ascii_case("content-length")
+                    .then(|| value.trim().parse::<usize>().ok())
+                    .flatten()
+            })
+            .unwrap_or(0);
+        let body_start = header_end;
+        let target_len = body_start + content_length;
+        while buf.len() < target_len {
+            let read = stream.read_buf(&mut buf).await?;
+            if read == 0 {
+                break;
+            }
+        }
+
+        Ok(RecordedRequest { method, path })
+    }
+
+    fn header_end(buf: &[u8]) -> Option<usize> {
+        buf.windows(4)
+            .position(|window| window == b"\r\n\r\n")
+            .map(|idx| idx + 4)
+    }
+
+    fn snapshot_create_config(output_dir: PathBuf) -> SnapshotCreateConfig {
+        SnapshotCreateConfig {
+            id: "snapshot-test".into(),
+            binary_path: PathBuf::from("/tmp/firecracker"),
+            kernel_path: PathBuf::from("/tmp/vmlinux"),
+            rootfs_path: PathBuf::from("/tmp/rootfs.ext4"),
+            output_dir,
+            vcpu_count: 2,
+            memory_mb: 512,
+            workspace_disk_mb: 1024,
+        }
+    }
+
+    #[tokio::test]
+    async fn configure_snapshot_vm_orders_rootfs_before_workspace_drive() {
+        let mut api = RecordingFirecrackerApi::spawn();
+        let dir = tempfile::tempdir().expect("tempdir");
+        let paths = SandboxPaths::new(dir.path().join("work"));
+        let sock_paths = SockPaths::new(dir.path().join("sock"));
+        let client = ApiClient::new(api.socket_path());
+        let config = snapshot_create_config(dir.path().join("snapshot-output"));
+        let inv = InvariantConfig::new();
+
+        tokio::time::timeout(
+            MOCK_REQUEST_TIMEOUT,
+            configure_snapshot_vm(&client, &config, &paths, &sock_paths, &inv),
+        )
+        .await
+        .expect("snapshot VM configuration should finish")
+        .expect("snapshot VM configuration should succeed");
+
+        let mut requests = Vec::new();
+        for _ in 0..7 {
+            requests.push(api.next_request().await);
+        }
+
+        assert_eq!(requests[0].method, "PUT");
+        assert_eq!(requests[0].path, "/drives/rootfs");
+        assert_eq!(requests[1].method, "PUT");
+        assert_eq!(requests[1].path, "/drives/workspace");
+
+        let mut paths: Vec<&str> = requests
+            .iter()
+            .map(|request| request.path.as_str())
+            .collect();
+        paths.sort_unstable();
+        assert_eq!(
+            paths,
+            [
+                "/balloon",
+                "/boot-source",
+                "/drives/rootfs",
+                "/drives/workspace",
+                "/machine-config",
+                "/network-interfaces/eth0",
+                "/vsock",
+            ]
+        );
+    }
 
     #[tokio::test]
     async fn abort_on_drop_task_aborts_vsock_listener() {

--- a/crates/sandbox-mock/src/lib.rs
+++ b/crates/sandbox-mock/src/lib.rs
@@ -1424,7 +1424,7 @@ mod tests {
             output_dir,
             vcpu_count: 2,
             memory_mb: 1024,
-            workspace_image_size_bytes: 16 * 1024 * 1024,
+            workspace_disk_mb: 16,
         }
     }
 
@@ -1530,7 +1530,7 @@ mod tests {
                 output_dir: output_dir.clone(),
                 vcpu_count: 1,
                 memory_mb: 128,
-                workspace_image_size_bytes: 16 * 1024 * 1024,
+                workspace_disk_mb: 16,
             })
             .await
             .expect("create snapshot");

--- a/crates/sandbox-mock/src/lib.rs
+++ b/crates/sandbox-mock/src/lib.rs
@@ -1424,6 +1424,7 @@ mod tests {
             output_dir,
             vcpu_count: 2,
             memory_mb: 1024,
+            workspace_image_size_bytes: 16 * 1024 * 1024,
         }
     }
 
@@ -1435,6 +1436,7 @@ mod tests {
                 memory_mb: 1024,
             },
             device_rate_limits: None,
+            workspace_drive: None,
         }
     }
 
@@ -1528,6 +1530,7 @@ mod tests {
                 output_dir: output_dir.clone(),
                 vcpu_count: 1,
                 memory_mb: 128,
+                workspace_image_size_bytes: 16 * 1024 * 1024,
             })
             .await
             .expect("create snapshot");

--- a/crates/sandbox/src/config.rs
+++ b/crates/sandbox/src/config.rs
@@ -104,8 +104,8 @@ pub struct DeviceRateLimits {
 /// block device.
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub struct WorkspaceDriveConfig {
-    /// Logical size for newly initialized workspace images.
-    pub size_bytes: u64,
+    /// Logical size in MiB for newly initialized workspace images.
+    pub size_mb: u32,
 }
 
 /// Per-sandbox creation configuration passed to [`crate::SandboxFactory::create`].

--- a/crates/sandbox/src/config.rs
+++ b/crates/sandbox/src/config.rs
@@ -97,6 +97,17 @@ pub struct DeviceRateLimits {
     pub network: NetworkRateLimits,
 }
 
+/// Provider-neutral workspace block image configuration for one sandbox.
+///
+/// The image is mounted by runner-controlled guest setup at the canonical
+/// execution workspace. Providers only need to expose it as a writable non-root
+/// block device.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct WorkspaceDriveConfig {
+    /// Logical size for newly initialized workspace images.
+    pub size_bytes: u64,
+}
+
 /// Per-sandbox creation configuration passed to [`crate::SandboxFactory::create`].
 ///
 /// Factory-wide configuration belongs in [`FactoryConfig`]; these values are
@@ -112,6 +123,8 @@ pub struct SandboxConfig {
     pub resources: ResourceLimits,
     /// Optional provider-neutral I/O limits to apply to this sandbox.
     pub device_rate_limits: Option<DeviceRateLimits>,
+    /// Optional writable workspace block image.
+    pub workspace_drive: Option<WorkspaceDriveConfig>,
 }
 
 /// Reference to a pre-built snapshot for fast VM boot.

--- a/crates/sandbox/src/lib.rs
+++ b/crates/sandbox/src/lib.rs
@@ -28,7 +28,7 @@ mod types;
 
 pub use config::{
     BlockRateLimits, DeviceRateLimits, FactoryConfig, NetworkRateLimits, ResourceLimits,
-    RuntimeConfig, SandboxConfig, SandboxId, SnapshotRef,
+    RuntimeConfig, SandboxConfig, SandboxId, SnapshotRef, WorkspaceDriveConfig,
 };
 pub use control::{RemoteExecResult, SandboxControl, SandboxControlError};
 pub use error::{

--- a/crates/sandbox/src/snapshot.rs
+++ b/crates/sandbox/src/snapshot.rs
@@ -19,8 +19,8 @@ pub struct SnapshotCreateConfig {
     pub vcpu_count: u32,
     /// Memory size in MiB for the VM.
     pub memory_mb: u32,
-    /// Logical size for the temporary workspace image used by the snapshot VM.
-    pub workspace_image_size_bytes: u64,
+    /// Workspace disk size in MiB for the temporary workspace image used by the snapshot VM.
+    pub workspace_disk_mb: u32,
 }
 
 /// Output paths from a successful snapshot creation.

--- a/crates/sandbox/src/snapshot.rs
+++ b/crates/sandbox/src/snapshot.rs
@@ -19,6 +19,8 @@ pub struct SnapshotCreateConfig {
     pub vcpu_count: u32,
     /// Memory size in MiB for the VM.
     pub memory_mb: u32,
+    /// Logical size for the temporary workspace image used by the snapshot VM.
+    pub workspace_image_size_bytes: u64,
 }
 
 /// Output paths from a successful snapshot creation.

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -138,7 +138,7 @@ Firecracker is an open-source VMM (Virtual Machine Monitor) developed by AWS tha
 - Cannot run on cloud VMs (nested virtualization limitations)
 
 **Software**:
-- Firecracker v1.14.1 binary
+- Firecracker v1.15.1 binary
 - Linux kernel v6.1.155 (for microVM)
 - Node.js 24.x, pnpm, pm2
 - mitmproxy (network observability)
@@ -152,14 +152,26 @@ Firecracker is an open-source VMM (Virtual Machine Monitor) developed by AWS tha
 **VM Configuration**:
 ```yaml
 # runner.yaml
+name: prod-1
+group: vm0/production
+base_dir: /var/lib/vm0-runner/runners/prod-1
+ca_dir: /var/lib/vm0-runner/ca
+
 firecracker:
   binary: /usr/local/bin/firecracker
   kernel: /opt/firecracker/vmlinux
 
 sandbox:
-  vcpu: 2
-  memory_mb: 2048
   max_concurrent: 1
+
+profiles:
+  vm0/default:
+    rootfs_hash: <rootfs_hash>
+    snapshot_hash: <snapshot_hash>
+    vcpu: 2
+    memory_mb: 4096
+    rootfs_disk_mb: 8192
+    workspace_disk_mb: 16384
 ```
 
 **Host-local runner overrides**:

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -199,7 +199,7 @@ sandbox:
 - Enables instant boot without rootfs copy
 
 **Per-VM Workspace Drive**:
-- Sparse ext4 image: `/var/lib/vm0-runner/workspaces/{sandbox_id}/workspace.ext4`
+- Sparse ext4 image: `{base_dir}/workspaces/{sandbox_id}/workspace.ext4`
 - Exposed to the guest as `/dev/vdb`
 - Mounted by the runner at `/home/user/workspace`
 - Sized from the runner profile `workspace_disk_mb`

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -202,7 +202,7 @@ sandbox:
 - Sparse ext4 image: `/var/lib/vm0-runner/workspaces/{sandbox_id}/workspace.ext4`
 - Exposed to the guest as `/dev/vdb`
 - Mounted by the runner at `/home/user/workspace`
-- Sized from the runner profile `disk_mb`
+- Sized from the runner profile `workspace_disk_mb`
 
 #### Network Architecture
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -142,6 +142,7 @@ Firecracker is an open-source VMM (Virtual Machine Monitor) developed by AWS tha
 - Linux kernel v6.1.155 (for microVM)
 - Node.js 24.x, pnpm, pm2
 - mitmproxy (network observability)
+- mkfs.ext4 / e2fsprogs (workspace drive image initialization)
 - debootstrap (rootfs build only)
 
 #### Architecture
@@ -196,6 +197,12 @@ sandbox:
 - Device: `/dev/nbdN` (writable block device)
 - Reads of unmodified blocks go to base image, writes captured in COW file
 - Enables instant boot without rootfs copy
+
+**Per-VM Workspace Drive**:
+- Sparse ext4 image: `/var/lib/vm0-runner/workspaces/{sandbox_id}/workspace.ext4`
+- Exposed to the guest as `/dev/vdb`
+- Mounted by the runner at `/home/user/workspace`
+- Sized from the runner profile `disk_mb`
 
 #### Network Architecture
 


### PR DESCRIPTION
## Summary
- add a provider-neutral workspace drive config and attach a writable Firecracker workspace drive at /home/user/workspace for runner-created sandboxes
- create and format per-sandbox workspace.ext4 images, wire fresh boot and snapshot create/restore layouts, and bump the Firecracker invariant hash
- mount the workspace drive before runner storage/agent work and split block I/O limits across rootfs/workspace drives

## Testing
- cargo test --manifest-path crates/Cargo.toml -p sandbox-fc --lib
- cargo test --manifest-path crates/Cargo.toml -p runner --bin runner
- cargo test --manifest-path crates/Cargo.toml -p sandbox-mock --lib
- cargo clippy --manifest-path crates/Cargo.toml -p runner --bin runner -p sandbox-fc -p sandbox-mock --all-targets --all-features -- -D warnings

## Notes
- cargo check --manifest-path crates/Cargo.toml --all-targets --all-features still fails in existing guest-agent integration tests with E0463 (can't find crate guest_agent), matching the pre-commit workspace clippy failure; relevant changed packages pass their tests and clippy.

Closes #15634