### PR TITLE
fix(desktop): prefer cookies before auth token refresh

### DIFF
--- a/turbo/apps/desktop/src/desktop-auth-session.test.ts
+++ b/turbo/apps/desktop/src/desktop-auth-session.test.ts
@@ -23,7 +23,11 @@ function createSession() {
     },
   };
   const runAuthWindow = vi.fn(
-    async (_request: { readonly url: string; readonly visible: boolean }) => {},
+    async (_request: {
+      readonly url: string;
+      readonly visible: boolean;
+      readonly allowInteractiveFallbacks: boolean;
+    }) => {},
   );
   const session = new DesktopAuthSession({
     apiBaseUrl: "https://api.vm0.ai",
@@ -53,6 +57,16 @@ describe("DesktopAuthSession", () => {
     expect(runAuthWindow).not.toHaveBeenCalled();
   });
 
+  it("exposes the cached token without refreshing", () => {
+    const { session, runAuthWindow } = createSession();
+
+    expect(session.getCachedToken()).toBeNull();
+    session.completeSignIn("cached");
+
+    expect(session.getCachedToken()).toBe("cached");
+    expect(runAuthWindow).not.toHaveBeenCalled();
+  });
+
   it("stores the token and fires onChange on completeSignIn", async () => {
     const { session, onChange } = createSession();
 
@@ -74,6 +88,7 @@ describe("DesktopAuthSession", () => {
     expect(runAuthWindow).toHaveBeenCalledWith({
       url: TOKEN_URL,
       visible: false,
+      allowInteractiveFallbacks: false,
     });
   });
 
@@ -136,6 +151,7 @@ describe("DesktopAuthSession", () => {
     expect(runAuthWindow).toHaveBeenCalledWith({
       url: "https://www.vm0.ai/desktop-auth/consume?code=code-123",
       visible: false,
+      allowInteractiveFallbacks: true,
     });
     expect(onAuthCompleted).toHaveBeenCalledOnce();
     expect(runAuthWindow.mock.invocationCallOrder[0]).toBeLessThan(
@@ -151,6 +167,7 @@ describe("DesktopAuthSession", () => {
     expect(runAuthWindow).toHaveBeenCalledWith({
       url: SELECT_ORG_URL,
       visible: true,
+      allowInteractiveFallbacks: true,
     });
     expect(onAuthCompleted).toHaveBeenCalledOnce();
   });
@@ -173,6 +190,35 @@ describe("DesktopAuthSession", () => {
       user: { userId: "u1", email: "u@example.com" },
       organization: { id: "o1", name: "Org One", slug: "org-one" },
     });
+  });
+
+  it("retries auth state with cookies when the cached token is rejected", async () => {
+    const { session } = createSession();
+    const observedAuthorization: (string | null)[] = [];
+    session.completeSignIn("stale");
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async (input: string | URL | Request, init?: RequestInit) => {
+        const headers = new Headers(init?.headers);
+        observedAuthorization.push(headers.get("authorization"));
+        const url = String(input);
+        if (url.endsWith("/api/auth/me") && headers.has("authorization")) {
+          return new Response(null, { status: 401 });
+        }
+        if (url.endsWith("/api/auth/me")) {
+          return jsonResponse({ userId: "u1", email: "u@example.com" });
+        }
+        return jsonResponse({ id: "o1", name: "Org One", slug: "org-one" });
+      }),
+    );
+
+    expect(await session.getAuthState()).toEqual({
+      status: "signed_in",
+      user: { userId: "u1", email: "u@example.com" },
+      organization: { id: "o1", name: "Org One", slug: "org-one" },
+    });
+    expect(observedAuthorization).toStrictEqual(["Bearer stale", null, null]);
+    expect(session.getCachedToken()).toBeNull();
   });
 
   it("derives signed-in state with a null organization on 404", async () => {

--- a/turbo/apps/desktop/src/desktop-auth-session.ts
+++ b/turbo/apps/desktop/src/desktop-auth-session.ts
@@ -29,6 +29,7 @@ interface ZeroOrgResponse {
 type RunAuthWindow = (request: {
   readonly url: string;
   readonly visible: boolean;
+  readonly allowInteractiveFallbacks: boolean;
 }) => Promise<void>;
 
 interface DesktopAuthSessionOptions {
@@ -107,13 +108,14 @@ export class DesktopAuthSession {
     return await this.refresh();
   }
 
+  getCachedToken(): string | null {
+    return this.token;
+  }
+
   async getAuthState(): Promise<DesktopAuthState> {
     const meUrl = new URL(AUTH_ME_PATH, this.apiBaseUrl);
-    const meResponse = await fetch(meUrl, {
-      headers: await this.headersFor(meUrl),
-    });
+    const meResponse = await this.fetchWithSessionAuth(meUrl);
     if (meResponse.status === 401) {
-      this.token = null;
       return signedOutDesktopAuthState();
     }
     if (!meResponse.ok) {
@@ -122,11 +124,8 @@ export class DesktopAuthSession {
 
     const user = (await meResponse.json()) as AuthMeResponse;
     const orgUrl = new URL(ZERO_ORG_PATH, this.apiBaseUrl);
-    const orgResponse = await fetch(orgUrl, {
-      headers: await this.headersFor(orgUrl),
-    });
+    const orgResponse = await this.fetchWithSessionAuth(orgUrl);
     if (orgResponse.status === 401) {
-      this.token = null;
       return signedOutDesktopAuthState();
     }
     if (orgResponse.status === 404) {
@@ -156,12 +155,20 @@ export class DesktopAuthSession {
   }
 
   async consumeCode(code: string): Promise<void> {
-    await this.runAuthWindow({ url: this.consumeUrl(code), visible: false });
+    await this.runAuthWindow({
+      url: this.consumeUrl(code),
+      visible: false,
+      allowInteractiveFallbacks: true,
+    });
     await this.onAuthCompleted();
   }
 
   async selectOrganization(): Promise<void> {
-    await this.runAuthWindow({ url: this.selectOrgUrl, visible: true });
+    await this.runAuthWindow({
+      url: this.selectOrgUrl,
+      visible: true,
+      allowInteractiveFallbacks: true,
+    });
     await this.onAuthCompleted();
   }
 
@@ -182,7 +189,11 @@ export class DesktopAuthSession {
 
     this.tokenRefresh = (async () => {
       const before = this.token;
-      await this.runAuthWindow({ url: this.tokenUrl, visible: false });
+      await this.runAuthWindow({
+        url: this.tokenUrl,
+        visible: false,
+        allowInteractiveFallbacks: false,
+      });
       const after = this.token;
       // completeSignIn() is the token's only write path. If the refresh window
       // reached a completion navigation without ever delivering a token, the
@@ -196,6 +207,20 @@ export class DesktopAuthSession {
     } finally {
       this.tokenRefresh = null;
     }
+  }
+
+  private async fetchWithSessionAuth(requestUrl: URL): Promise<Response> {
+    const response = await fetch(requestUrl, {
+      headers: await this.headersFor(requestUrl),
+    });
+    if (response.status !== 401 || !this.token) {
+      return response;
+    }
+
+    this.token = null;
+    return await fetch(requestUrl, {
+      headers: await this.headersFor(requestUrl),
+    });
   }
 
   private async headersFor(requestUrl: URL): Promise<Headers> {

--- a/turbo/apps/desktop/src/desktop-computer-use-api.test.ts
+++ b/turbo/apps/desktop/src/desktop-computer-use-api.test.ts
@@ -39,7 +39,7 @@ describe("createDesktopComputerUseSessionFetch", () => {
     const sessionFetch = createDesktopComputerUseSessionFetch({
       platformUrl: new URL("https://app.vm0.ai"),
       session,
-      getAuthToken: () => {
+      getCachedAuthToken: () => {
         return "desktop-token";
       },
     });
@@ -76,7 +76,13 @@ describe("createDesktopComputerUseSessionFetch", () => {
         },
       },
     };
-    const tokens: (string | null)[] = ["stale-token", "fresh-token"];
+    const cachedToken = "stale-token";
+    const refreshAuthToken = vi.fn(
+      (options?: { readonly forceRefresh?: boolean }) => {
+        expect(options?.forceRefresh).toBe(true);
+        return "fresh-token";
+      },
+    );
     const fetchMock = vi.fn(
       async (
         _input: string | URL | Request,
@@ -92,20 +98,85 @@ describe("createDesktopComputerUseSessionFetch", () => {
     const sessionFetch = createDesktopComputerUseSessionFetch({
       platformUrl: new URL("https://app.vm0.ai"),
       session,
-      getAuthToken: ({ forceRefresh } = {}) => {
-        expect(forceRefresh).toBe(fetchMock.mock.calls.length > 0);
-        return tokens.shift() ?? null;
+      getCachedAuthToken: () => {
+        return cachedToken;
       },
+      getAuthToken: refreshAuthToken,
     });
     await sessionFetch("https://api.vm0.ai/api/auth/me");
 
     expect(fetchMock).toHaveBeenCalledTimes(2);
+    expect(refreshAuthToken).toHaveBeenCalledOnce();
     expect(
       new Headers(fetchMock.mock.calls[0]?.[1]?.headers).get("authorization"),
     ).toBe("Bearer stale-token");
     expect(
       new Headers(fetchMock.mock.calls[1]?.[1]?.headers).get("authorization"),
     ).toBe("Bearer fresh-token");
+  });
+
+  it("uses cookies without refreshing auth when the first request succeeds", async () => {
+    const session: DesktopSessionCookieSource = {
+      cookies: {
+        async get() {
+          return [{ name: "session", value: "cookie-session" }];
+        },
+      },
+    };
+    const fetchMock = vi.fn(
+      async (
+        _input: string | URL | Request,
+        _init?: RequestInit,
+      ): Promise<Response> => {
+        return jsonResponse({});
+      },
+    );
+    const refreshAuthToken = vi.fn(async () => "fresh-token");
+    vi.stubGlobal("fetch", fetchMock);
+
+    const sessionFetch = createDesktopComputerUseSessionFetch({
+      platformUrl: new URL("https://app.vm0.ai"),
+      session,
+      getCachedAuthToken: () => null,
+      getAuthToken: refreshAuthToken,
+    });
+    await sessionFetch("https://api.vm0.ai/api/auth/me");
+
+    expect(fetchMock).toHaveBeenCalledOnce();
+    expect(refreshAuthToken).not.toHaveBeenCalled();
+    const headers = new Headers(fetchMock.mock.calls[0]?.[1]?.headers);
+    expect(headers.get("cookie")).toBe("session=cookie-session");
+    expect(headers.has("authorization")).toBe(false);
+  });
+
+  it("returns the first 401 when token refresh cannot produce a token", async () => {
+    const session: DesktopSessionCookieSource = {
+      cookies: {
+        async get() {
+          return [];
+        },
+      },
+    };
+    const fetchMock = vi.fn(
+      async (
+        _input: string | URL | Request,
+        _init?: RequestInit,
+      ): Promise<Response> => {
+        return new Response(null, { status: 401 });
+      },
+    );
+    vi.stubGlobal("fetch", fetchMock);
+
+    const sessionFetch = createDesktopComputerUseSessionFetch({
+      platformUrl: new URL("https://app.vm0.ai"),
+      session,
+      getCachedAuthToken: () => null,
+      getAuthToken: () => null,
+    });
+    const response = await sessionFetch("https://api.vm0.ai/api/auth/me");
+
+    expect(response.status).toBe(401);
+    expect(fetchMock).toHaveBeenCalledOnce();
   });
 });
 

--- a/turbo/apps/desktop/src/desktop-computer-use-api.ts
+++ b/turbo/apps/desktop/src/desktop-computer-use-api.ts
@@ -7,32 +7,42 @@ import {
 export function createDesktopComputerUseSessionFetch(params: {
   readonly platformUrl: URL;
   readonly session: DesktopSessionCookieSource;
+  readonly getCachedAuthToken?: () => Promise<string | null> | string | null;
   readonly getAuthToken?: (options?: {
     readonly forceRefresh?: boolean;
   }) => Promise<string | null> | string | null;
 }): ComputerUseHostFetch {
   return async (input, init) => {
     const requestUrl = new URL(input);
-    const buildHeaders = async (forceRefresh: boolean): Promise<Headers> => {
+    const buildHeaders = async (token: string | null): Promise<Headers> => {
       const headers = await headersWithSessionCookies(
         params.session,
         [params.platformUrl, requestUrl],
         init?.headers,
       );
-      const token = await params.getAuthToken?.({ forceRefresh });
       if (token) {
         headers.set("authorization", `Bearer ${token}`);
       }
       return headers;
     };
 
+    const cachedToken = (await params.getCachedAuthToken?.()) ?? null;
     const response = await fetch(input, {
       ...init,
-      headers: await buildHeaders(false),
+      headers: await buildHeaders(cachedToken),
     });
     if (response.status !== 401 || !params.getAuthToken) {
       return response;
     }
-    return fetch(input, { ...init, headers: await buildHeaders(true) });
+
+    const refreshedToken = await params.getAuthToken({ forceRefresh: true });
+    if (!refreshedToken) {
+      return response;
+    }
+
+    return fetch(input, {
+      ...init,
+      headers: await buildHeaders(refreshedToken),
+    });
   };
 }

--- a/turbo/apps/desktop/src/main.ts
+++ b/turbo/apps/desktop/src/main.ts
@@ -100,6 +100,7 @@ setComputerUsePermissionNativeBackend(computerUseNativeBackend);
 async function runAuthWindow(request: {
   readonly url: string;
   readonly visible: boolean;
+  readonly allowInteractiveFallbacks: boolean;
 }): Promise<void> {
   const authWindow = new BrowserWindow({
     ...browserWindowOptions(),
@@ -109,7 +110,9 @@ async function runAuthWindow(request: {
     skipTaskbar: !request.visible,
   });
   installAuthConsumeWindowPolicy(authWindow);
-  const pending = waitForAuthConsumeWindow(authWindow);
+  const pending = waitForAuthConsumeWindow(authWindow, {
+    allowInteractiveFallbacks: request.allowInteractiveFallbacks,
+  });
   await loadAuthUrl(authWindow, request.url);
   await pending;
 }
@@ -236,6 +239,7 @@ async function startComputerUseRuntime(): Promise<DesktopComputerUseState> {
       sessionFetch: createDesktopComputerUseSessionFetch({
         platformUrl: config.platformUrl,
         session: desktopSession,
+        getCachedAuthToken: () => getAuthSession().getCachedToken(),
         getAuthToken: (options) => getAuthSession().getToken(options),
       }),
       hostFetch: (input, init) => {
@@ -542,7 +546,10 @@ function installAuthConsumeWindowPolicy(window: BrowserWindow): void {
   });
 }
 
-function waitForAuthConsumeWindow(window: BrowserWindow): Promise<void> {
+function waitForAuthConsumeWindow(
+  window: BrowserWindow,
+  options: { readonly allowInteractiveFallbacks: boolean },
+): Promise<void> {
   return new Promise((resolve, reject) => {
     let settled = false;
     const timeout = setTimeout(() => {
@@ -581,8 +588,19 @@ function waitForAuthConsumeWindow(window: BrowserWindow): Promise<void> {
     };
 
     const handleNavigation = (_event: Electron.Event, url: string): void => {
+      if (
+        !options.allowInteractiveFallbacks &&
+        isDesktopAuthStartNavigation(url, config.allowedAppOrigins)
+      ) {
+        resolveAuth();
+        return;
+      }
       if (isDesktopAuthSelectOrgNavigation(url, config.allowedAppOrigins)) {
-        showAndFocusWindow(window);
+        if (options.allowInteractiveFallbacks) {
+          showAndFocusWindow(window);
+          return;
+        }
+        resolveAuth();
         return;
       }
       if (isDesktopAuthCompletionNavigation(url, config.allowedAppOrigins)) {


### PR DESCRIPTION
## Summary
- keep Computer Use session fetches cookie-first by using only the cached Desktop auth token before the first request
- force-refresh the Desktop auth token only after a 401, and skip the retry if refresh cannot produce a token
- prevent background token refresh from surfacing interactive sign-in or org-selection windows
- retry Desktop auth state cookie-only when a cached bearer token is rejected

## Testing
- `pnpm format`
- `pnpm -F @vm0/desktop lint`
- `pnpm -F @vm0/desktop check-types`
- `pnpm -F @vm0/desktop test`
- `pnpm -F @vm0/desktop build:electron`
