### PR TITLE
fix: validate chat thread path ids

### DIFF
--- a/turbo/apps/api/src/signals/routes/__tests__/zero-chat-threads-delete.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/zero-chat-threads-delete.test.ts
@@ -157,7 +157,7 @@ describe("DELETE /api/zero/chat-threads/:id", () => {
     );
   });
 
-  it("returns 404 for a malformed UUID without touching the DB", async () => {
+  it("returns 400 for a malformed UUID without touching the DB", async () => {
     const fixture = await track(
       store.set(seedZeroChatThread$, {}, context.signal),
     );
@@ -169,14 +169,13 @@ describe("DELETE /api/zero/chat-threads/:id", () => {
         params: { id: "not-a-uuid" },
         headers: { authorization: "Bearer clerk-session" },
       }),
-      [404],
+      [400],
     );
 
-    expect(response.body).toMatchObject({
-      error: { code: "NOT_FOUND", message: "Chat thread not found" },
-    });
+    expect(response.body.error.code).toBe("BAD_REQUEST");
+    expect(response.body.error.message).toContain("id");
 
-    // Seeded thread untouched (the malformed-id branch short-circuits before DB).
+    // Seeded thread untouched (path validation short-circuits before DB).
     await expect(getThreadRowExists(fixture.threadId)).resolves.toBeTruthy();
     expect(context.mocks.ably.publish).not.toHaveBeenCalled();
   });

--- a/turbo/apps/api/src/signals/routes/__tests__/zero-chat-threads-messages.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/zero-chat-threads-messages.test.ts
@@ -31,7 +31,7 @@ describe("GET /api/zero/chat-threads/:threadId/messages", () => {
     const client = setupApp({ context })(chatThreadMessagesContract);
     const response = await accept(
       client.list({
-        params: { threadId: "some-thread-id" },
+        params: { threadId: randomUUID() },
         query: {},
         headers: {},
       }),

--- a/turbo/apps/api/src/signals/routes/__tests__/zero-chat-threads-patch.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/zero-chat-threads-patch.test.ts
@@ -323,7 +323,7 @@ describe("PATCH /api/zero/chat-threads/:id", () => {
     );
   });
 
-  it("returns 404 for a malformed UUID without touching the DB", async () => {
+  it("returns 400 for a malformed UUID without touching the DB", async () => {
     const fixture = await track(
       store.set(seedZeroChatThread$, {}, context.signal),
     );
@@ -336,13 +336,12 @@ describe("PATCH /api/zero/chat-threads/:id", () => {
         body: { draftContent: "hello" },
         headers: { authorization: "Bearer clerk-session" },
       }),
-      [404],
+      [400],
     );
-    expect(response.body).toStrictEqual({
-      error: { message: "Chat thread not found", code: "NOT_FOUND" },
-    });
+    expect(response.body.error.code).toBe("BAD_REQUEST");
+    expect(response.body.error.message).toContain("id");
 
-    // Seeded thread untouched (the malformed-id branch short-circuits before DB).
+    // Seeded thread untouched (path validation short-circuits before DB).
     const row = await getThreadDraft(fixture.threadId);
     expect(row?.draftContent).toBeNull();
     expect(context.mocks.ably.publish).not.toHaveBeenCalled();

--- a/turbo/apps/api/src/signals/routes/__tests__/zero-chat-threads.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/zero-chat-threads.test.ts
@@ -1,5 +1,6 @@
 import { createStore } from "ccstate";
 import { randomUUID } from "node:crypto";
+import { createApp } from "../../../app-factory";
 import {
   chatThreadByIdContract,
   chatThreadMessagesContract,
@@ -29,6 +30,60 @@ import { seedRun$ } from "./helpers/zero-usage-insight";
 const context = testContext();
 const store = createStore();
 const mocks = createZeroRouteMocks(context);
+
+const malformedChatThreadIdCases = [
+  { method: "GET", path: "/api/zero/chat-threads/:id", paramName: "id" },
+  { method: "PATCH", path: "/api/zero/chat-threads/:id", paramName: "id" },
+  { method: "DELETE", path: "/api/zero/chat-threads/:id", paramName: "id" },
+  {
+    method: "POST",
+    path: "/api/zero/chat-threads/:id/mark-read",
+    paramName: "id",
+  },
+  { method: "POST", path: "/api/zero/chat-threads/:id/pin", paramName: "id" },
+  {
+    method: "POST",
+    path: "/api/zero/chat-threads/:id/unpin",
+    paramName: "id",
+  },
+  {
+    method: "POST",
+    path: "/api/zero/chat-threads/:id/rename",
+    paramName: "id",
+  },
+  {
+    method: "GET",
+    path: "/api/zero/chat-threads/:id/messages",
+    paramName: "threadId",
+  },
+  {
+    method: "GET",
+    path: "/api/zero/chat-threads/:id/artifacts",
+    paramName: "threadId",
+  },
+  {
+    method: "POST",
+    path: "/api/zero/chat-threads/:id/artifacts",
+    paramName: "threadId",
+  },
+] as const;
+
+describe("chat thread id path validation", () => {
+  it.each(malformedChatThreadIdCases)(
+    "$method $path returns 400 before auth or DB access",
+    async ({ method, path, paramName }) => {
+      const app = createApp({ signal: context.signal });
+      const response = await app.request(path, { method });
+
+      expect(response.status).toBe(400);
+      const body = (await response.json()) as {
+        readonly error: { readonly code: string; readonly message: string };
+      };
+      expect(body.error.code).toBe("BAD_REQUEST");
+      expect(body.error.message).toContain(paramName);
+    },
+  );
+});
 
 describe("GET /api/zero/chat-threads/:id", () => {
   const track = createFixtureTracker<ZeroChatThreadFixture>((fixture) => {
@@ -140,7 +195,7 @@ describe("GET /api/zero/chat-threads/:id", () => {
     });
   });
 
-  it("returns 404 for malformed thread id", async () => {
+  it("returns 400 for malformed thread id", async () => {
     mocks.clerk.session(`user_${randomUUID()}`, `org_${randomUUID()}`);
     const client = setupApp({ context })(chatThreadByIdContract);
     const response = await accept(
@@ -148,11 +203,10 @@ describe("GET /api/zero/chat-threads/:id", () => {
         params: { id: "123" },
         headers: { authorization: "Bearer clerk-session" },
       }),
-      [404],
+      [400],
     );
-    expect(response.body).toStrictEqual({
-      error: { message: "Chat thread not found", code: "NOT_FOUND" },
-    });
+    expect(response.body.error.code).toBe("BAD_REQUEST");
+    expect(response.body.error.message).toContain("id");
   });
 
   it("returns thread detail metadata only", async () => {

--- a/turbo/apps/api/src/signals/routes/zero-chat-threads-delete.ts
+++ b/turbo/apps/api/src/signals/routes/zero-chat-threads-delete.ts
@@ -1,5 +1,4 @@
 import { command } from "ccstate";
-import { z } from "zod";
 import { chatThreadByIdContract } from "@vm0/api-contracts/contracts/chat-threads";
 
 import { authContext$ } from "../auth/auth-context";
@@ -10,12 +9,6 @@ import { notFound } from "../../lib/error";
 import { deleteChatThread$ } from "../services/zero-chat-thread.service";
 import type { RouteEntry } from "../route";
 
-const chatThreadIdSchema = z.string().uuid();
-
-function isValidChatThreadId(id: string): boolean {
-  return chatThreadIdSchema.safeParse(id).success;
-}
-
 function chatThreadNotFound() {
   return notFound("Chat thread not found");
 }
@@ -23,10 +16,6 @@ function chatThreadNotFound() {
 const deleteInner$ = command(async ({ get, set }, signal: AbortSignal) => {
   const auth = get(authContext$);
   const params = get(pathParamsOf(chatThreadByIdContract.delete));
-
-  if (!isValidChatThreadId(params.id)) {
-    return chatThreadNotFound();
-  }
 
   const result = await set(
     deleteChatThread$,

--- a/turbo/apps/api/src/signals/routes/zero-chat-threads-patch.ts
+++ b/turbo/apps/api/src/signals/routes/zero-chat-threads-patch.ts
@@ -1,5 +1,4 @@
 import { command } from "ccstate";
-import { z } from "zod";
 import { chatThreadByIdContract } from "@vm0/api-contracts/contracts/chat-threads";
 
 import { authContext$ } from "../auth/auth-context";
@@ -9,12 +8,6 @@ import { notFound } from "../../lib/error";
 import { updateChatThreadDraft$ } from "../services/zero-chat-thread.service";
 import type { RouteEntry } from "../route";
 
-const chatThreadIdSchema = z.string().uuid();
-
-function isValidChatThreadId(id: string): boolean {
-  return chatThreadIdSchema.safeParse(id).success;
-}
-
 function chatThreadNotFound() {
   return notFound("Chat thread not found");
 }
@@ -22,10 +15,6 @@ function chatThreadNotFound() {
 const patchInner$ = command(async ({ get, set }, signal: AbortSignal) => {
   const auth = get(authContext$);
   const params = get(pathParamsOf(chatThreadByIdContract.patch));
-
-  if (!isValidChatThreadId(params.id)) {
-    return chatThreadNotFound();
-  }
 
   const bodyResult = await get(bodyResultOf(chatThreadByIdContract.patch));
   signal.throwIfAborted();

--- a/turbo/apps/api/src/signals/routes/zero-chat-threads.ts
+++ b/turbo/apps/api/src/signals/routes/zero-chat-threads.ts
@@ -6,7 +6,6 @@ import {
   chatThreadMessagesContract,
   chatThreadsContract,
 } from "@vm0/api-contracts/contracts/chat-threads";
-import { z } from "zod";
 
 import { authContext$, organizationAuthContext$ } from "../auth/auth-context";
 import { authRoute } from "../auth/auth-route";
@@ -34,23 +33,13 @@ import { zeroChatThreadPinRoutes } from "./zero-chat-threads-pin";
 import { zeroChatThreadRenameRoutes } from "./zero-chat-threads-rename";
 import { zeroChatThreadUnpinRoutes } from "./zero-chat-threads-unpin";
 
-const chatThreadIdSchema = z.string().uuid();
-
 function chatThreadNotFound() {
   return notFound("Chat thread not found");
-}
-
-function isValidChatThreadId(id: string): boolean {
-  return chatThreadIdSchema.safeParse(id).success;
 }
 
 const getChatThreadInner$ = computed(async (get) => {
   const auth = get(authContext$);
   const params = get(pathParamsOf(chatThreadByIdContract.get));
-
-  if (!isValidChatThreadId(params.id)) {
-    return chatThreadNotFound();
-  }
 
   const thread = await get(
     zeroChatThreadDetail({ threadId: params.id, userId: auth.userId }),

--- a/turbo/packages/api-contracts/src/contracts/chat-threads.ts
+++ b/turbo/packages/api-contracts/src/contracts/chat-threads.ts
@@ -293,14 +293,20 @@ export const chatThreadsContract = c.router({
 /**
  * Chat thread by ID route contract (/api/chat-threads/[id])
  */
+const chatThreadIdPathParamsSchema = z.object({ id: z.string().uuid() });
+const chatThreadThreadIdPathParamsSchema = z.object({
+  threadId: z.string().uuid(),
+});
+
 export const chatThreadByIdContract = c.router({
   get: {
     method: "GET",
     path: "/api/zero/chat-threads/:id",
     headers: authHeadersSchema,
-    pathParams: z.object({ id: z.string() }),
+    pathParams: chatThreadIdPathParamsSchema,
     responses: {
       200: chatThreadDetailSchema,
+      400: apiErrorSchema,
       401: apiErrorSchema,
       404: apiErrorSchema,
     },
@@ -310,7 +316,7 @@ export const chatThreadByIdContract = c.router({
     method: "PATCH",
     path: "/api/zero/chat-threads/:id",
     headers: authHeadersSchema,
-    pathParams: z.object({ id: z.string() }),
+    pathParams: chatThreadIdPathParamsSchema,
     body: z.object({
       draftContent: z.string().nullable().optional(),
       draftAttachments: z
@@ -320,6 +326,7 @@ export const chatThreadByIdContract = c.router({
     }),
     responses: {
       204: c.noBody(),
+      400: apiErrorSchema,
       401: apiErrorSchema,
       404: apiErrorSchema,
     },
@@ -329,9 +336,10 @@ export const chatThreadByIdContract = c.router({
     method: "DELETE",
     path: "/api/zero/chat-threads/:id",
     headers: authHeadersSchema,
-    pathParams: z.object({ id: z.string() }),
+    pathParams: chatThreadIdPathParamsSchema,
     responses: {
       204: c.noBody(),
+      400: apiErrorSchema,
       401: apiErrorSchema,
       404: apiErrorSchema,
     },
@@ -349,13 +357,14 @@ export const chatThreadMarkReadContract = c.router({
     method: "POST",
     path: "/api/zero/chat-threads/:id/mark-read",
     headers: authHeadersSchema,
-    pathParams: z.object({ id: z.string() }),
+    pathParams: chatThreadIdPathParamsSchema,
     body: c.noBody(),
     responses: {
       200: z.object({
         lastReadMessageId: z.string().nullable(),
         changed: z.boolean(),
       }),
+      400: apiErrorSchema,
       401: apiErrorSchema,
       404: apiErrorSchema,
     },
@@ -377,10 +386,11 @@ export const chatThreadPinContract = c.router({
     method: "POST",
     path: "/api/zero/chat-threads/:id/pin",
     headers: authHeadersSchema,
-    pathParams: z.object({ id: z.string() }),
+    pathParams: chatThreadIdPathParamsSchema,
     body: c.noBody(),
     responses: {
       204: c.noBody(),
+      400: apiErrorSchema,
       401: apiErrorSchema,
       404: apiErrorSchema,
     },
@@ -393,10 +403,11 @@ export const chatThreadUnpinContract = c.router({
     method: "POST",
     path: "/api/zero/chat-threads/:id/unpin",
     headers: authHeadersSchema,
-    pathParams: z.object({ id: z.string() }),
+    pathParams: chatThreadIdPathParamsSchema,
     body: c.noBody(),
     responses: {
       204: c.noBody(),
+      400: apiErrorSchema,
       401: apiErrorSchema,
       404: apiErrorSchema,
     },
@@ -418,10 +429,11 @@ export const chatThreadRenameContract = c.router({
     method: "POST",
     path: "/api/zero/chat-threads/:id/rename",
     headers: authHeadersSchema,
-    pathParams: z.object({ id: z.string() }),
+    pathParams: chatThreadIdPathParamsSchema,
     body: z.object({ title: z.string().min(1) }),
     responses: {
       204: c.noBody(),
+      400: apiErrorSchema,
       401: apiErrorSchema,
       404: apiErrorSchema,
     },
@@ -615,7 +627,7 @@ export const chatThreadMessagesContract = c.router({
     method: "GET",
     path: "/api/zero/chat-threads/:threadId/messages",
     headers: authHeadersSchema,
-    pathParams: z.object({ threadId: z.string() }),
+    pathParams: chatThreadThreadIdPathParamsSchema,
     query: z.object({
       sinceId: z.string().uuid().optional(),
       beforeId: z.string().uuid().optional(),
@@ -626,6 +638,7 @@ export const chatThreadMessagesContract = c.router({
         messages: z.array(pagedChatMessageSchema),
         hasHistoryBefore: z.boolean().optional(),
       }),
+      400: apiErrorSchema,
       401: apiErrorSchema,
       404: apiErrorSchema,
     },
@@ -638,11 +651,12 @@ export const chatThreadArtifactsContract = c.router({
     method: "GET",
     path: "/api/zero/chat-threads/:threadId/artifacts",
     headers: authHeadersSchema,
-    pathParams: z.object({ threadId: z.string() }),
+    pathParams: chatThreadThreadIdPathParamsSchema,
     responses: {
       200: z.object({
         runs: z.array(chatThreadArtifactRunSchema),
       }),
+      400: apiErrorSchema,
       401: apiErrorSchema,
       403: apiErrorSchema,
       404: apiErrorSchema,
@@ -653,7 +667,7 @@ export const chatThreadArtifactsContract = c.router({
     method: "POST",
     path: "/api/zero/chat-threads/:threadId/artifacts",
     headers: authHeadersSchema,
-    pathParams: z.object({ threadId: z.string() }),
+    pathParams: chatThreadThreadIdPathParamsSchema,
     body: z.object({
       runId: z.string(),
       fileId: z.string(),


### PR DESCRIPTION
## Summary

- validate every zero chat-thread path id through shared contract UUID schemas before auth or DB access
- remove duplicate handler-local UUID guards from get/patch/delete routes
- add malformed-id route coverage across chat-thread detail, mutation, messages, and artifacts subroutes

Fixes #15685

## Tests

- pnpm -F @vm0/db db:migrate
- pnpm -F api exec vitest run src/signals/routes/__tests__/zero-chat-threads.test.ts src/signals/routes/__tests__/zero-chat-threads-messages.test.ts src/signals/routes/__tests__/zero-chat-threads-patch.test.ts src/signals/routes/__tests__/zero-chat-threads-delete.test.ts src/signals/routes/__tests__/zero-chat-threads-mark-read.test.ts src/signals/routes/__tests__/zero-chat-threads-pin.test.ts src/signals/routes/__tests__/zero-chat-threads-unpin.test.ts src/signals/routes/__tests__/zero-chat-threads-rename.test.ts src/signals/routes/__tests__/zero-chat-threads-artifacts.test.ts src/signals/routes/__tests__/zero-chat-threads-artifacts-sync.test.ts
- pnpm -F @vm0/api-contracts check-types
- pnpm -F api check-types
- pnpm -F @vm0/api-contracts lint
- pnpm -F api lint
- git diff --check

Pre-commit also ran staged prettier, knip, and root turbo check-types.