### PR TITLE
chore: clean up web knip hygiene

### DIFF
--- a/turbo/apps/web/app/[locale]/presentation/__tests__/data.test.ts
+++ b/turbo/apps/web/app/[locale]/presentation/__tests__/data.test.ts
@@ -1,11 +1,6 @@
 import { describe, expect, it } from "vitest";
 
-import {
-  PRESENTATION_ATTRIBUTION_PARAM,
-  PRESENTATION_ATTRIBUTION_VALUE,
-  buildPresentationRemixHref,
-  type PresentationItem,
-} from "../data";
+import { buildPresentationRemixHref, type PresentationItem } from "../data";
 
 const item: PresentationItem = {
   slug: "test-deck",
@@ -24,9 +19,7 @@ describe("presentation remix links", () => {
     expect(url.pathname).toBe("/onboarding");
     expect(url.searchParams.get("prompt")).toBe(item.prompt);
     expect(url.searchParams.get("showcase")).toBe(item.embedUrl);
-    expect(url.searchParams.get(PRESENTATION_ATTRIBUTION_PARAM)).toBe(
-      PRESENTATION_ATTRIBUTION_VALUE,
-    );
+    expect(url.searchParams.get("vm0_source")).toBe("presentation");
   });
 
   it("carries paid search attribution to the app", () => {

--- a/turbo/apps/web/app/[locale]/presentation/data.ts
+++ b/turbo/apps/web/app/[locale]/presentation/data.ts
@@ -6,8 +6,8 @@ export interface PresentationItem {
   readonly previewImage: string;
 }
 
-export const PRESENTATION_ATTRIBUTION_PARAM = "vm0_source";
-export const PRESENTATION_ATTRIBUTION_VALUE = "presentation";
+const PRESENTATION_ATTRIBUTION_PARAM = "vm0_source";
+const PRESENTATION_ATTRIBUTION_VALUE = "presentation";
 
 const AD_ATTRIBUTION_PARAMS = [
   "gclid",

--- a/turbo/apps/web/app/[locale]/web-design/data.ts
+++ b/turbo/apps/web/app/[locale]/web-design/data.ts
@@ -24,22 +24,6 @@ export interface GalleryItem {
   readonly designSystemId?: string;
 }
 
-export const GALLERY_CATEGORIES: readonly (GalleryCategory | "all")[] = [
-  "all",
-  "website",
-];
-
-export const GALLERY_CATEGORY_LABELS: Record<GalleryCategory | "all", string> =
-  {
-    all: "All",
-    illustration: "Illustration",
-    presentation: "Presentation",
-    website: "Website Design",
-    report: "Report",
-    video: "Video",
-    audio: "Audio",
-  };
-
 export const GALLERY_ITEMS: readonly GalleryItem[] = [
   {
     slug: "spacex-mission-brief",

--- a/turbo/apps/web/app/lib/blog/__tests__/index.test.ts
+++ b/turbo/apps/web/app/lib/blog/__tests__/index.test.ts
@@ -6,7 +6,6 @@ import {
   getPost,
   getPostAvailableLocales,
   getPosts,
-  type BlogPost,
 } from "../index";
 
 describe("blog/index", () => {
@@ -17,19 +16,5 @@ describe("blog/index", () => {
     expect(getCategories).toBeTypeOf("function");
     expect(getPostAvailableLocales).toBeTypeOf("function");
     expect(getBlogBaseUrl).toBeTypeOf("function");
-
-    const examplePost: BlogPost = {
-      slug: "test-post",
-      title: "Test Post",
-      excerpt: "Example excerpt",
-      content: "Example content",
-      category: "Testing",
-      author: { name: "VM0" },
-      publishedAt: "2026-04-23T00:00:00.000Z",
-      readTime: "1 min read",
-      cover: "/cover.png",
-    };
-
-    expect(examplePost.slug).toBe("test-post");
   });
 });

--- a/turbo/apps/web/app/lib/blog/index.ts
+++ b/turbo/apps/web/app/lib/blog/index.ts
@@ -6,4 +6,3 @@ export {
   getPostAvailableLocales,
 } from "./data-source";
 export { getBlogBaseUrl } from "./config";
-export type { BlogPost } from "./types";

--- a/turbo/apps/web/src/__tests__/adAttribution.test.ts
+++ b/turbo/apps/web/src/__tests__/adAttribution.test.ts
@@ -1,14 +1,10 @@
 import { describe, expect, it } from "vitest";
-import {
-  acquisitionAttributionParams,
-  readAttributionCookie,
-  sourceType,
-  writeAcquisitionAttributionCookie,
-  type CookieJar,
-} from "../lib/adAttribution";
+import { writeAcquisitionAttributionCookie } from "../lib/adAttribution";
+import { ACQUISITION_ATTRIBUTION_COOKIE } from "@vm0/api-contracts/contracts/zero-attribution";
 
-function params(search: string): URLSearchParams {
-  return new URLSearchParams(search);
+interface CookieJar {
+  get(): string;
+  set(value: string): void;
 }
 
 // Emulates document.cookie: set() stores only the name=value pair (as a browser
@@ -37,76 +33,49 @@ function fakeJar(): { jar: CookieJar; writes: string[] } {
   };
 }
 
-describe("sourceType", () => {
-  it("classifies Google click ids as paid", () => {
-    expect(sourceType(params("gclid=abc"), "google.com")).toBe("paid");
-    expect(sourceType(params("gbraid=abc"), undefined)).toBe("paid");
-    expect(sourceType(params("wbraid=abc"), undefined)).toBe("paid");
-  });
+function attributionParams(jar: CookieJar): URLSearchParams {
+  const cookie = jar
+    .get()
+    .split(";")
+    .map((part) => {
+      return part.trim();
+    })
+    .find((part) => {
+      return part.startsWith(`${ACQUISITION_ATTRIBUTION_COOKIE}=`);
+    });
 
-  it("classifies paid utm mediums as paid", () => {
-    expect(sourceType(params("utm_medium=cpc"), undefined)).toBe("paid");
-    expect(sourceType(params("utm_medium=paid_social"), undefined)).toBe(
-      "paid",
-    );
-  });
-
-  it("classifies organic mediums and search referrers as organic_search", () => {
-    expect(sourceType(params("utm_medium=organic"), undefined)).toBe(
-      "organic_search",
-    );
-    expect(sourceType(params(""), "www.google.com")).toBe("organic_search");
-    expect(sourceType(params(""), "bing.com")).toBe("organic_search");
-  });
-
-  it("classifies utm-tagged non-paid traffic as referral", () => {
-    expect(sourceType(params("utm_source=newsletter"), undefined)).toBe(
-      "referral",
-    );
-  });
-
-  it("classifies no-param, no-referrer traffic as direct", () => {
-    expect(sourceType(params(""), undefined)).toBe("direct");
-  });
-
-  it("classifies vm0.ai referrers as internal", () => {
-    expect(sourceType(params(""), "app.vm0.ai")).toBe("internal");
-  });
-
-  it("falls back to referral for unknown external referrers", () => {
-    expect(sourceType(params(""), "news.ycombinator.com")).toBe("referral");
-  });
-});
-
-describe("acquisitionAttributionParams", () => {
-  it("stamps source, classification, landing context, and forwarded ad params", () => {
-    const result = acquisitionAttributionParams(
-      "?gclid=abc&utm_source=google",
-      {
-        referrer: "https://www.google.com/",
-        hostname: "www.vm0.ai",
-        pathname: "/pricing",
-      },
-    );
-
-    expect(result.get("vm0_source")).toBe("homepage");
-    expect(result.get("source_type")).toBe("paid");
-    expect(result.get("referrer_domain")).toBe("google.com");
-    expect(result.get("landing_host")).toBe("vm0.ai");
-    expect(result.get("landing_path")).toBe("/pricing");
-    expect(result.get("gclid")).toBe("abc");
-    expect(result.get("utm_source")).toBe("google");
-  });
-
-  it("omits absent optional fields", () => {
-    const result = acquisitionAttributionParams("", {});
-    expect(result.get("source_type")).toBe("direct");
-    expect(result.has("referrer_domain")).toBe(false);
-    expect(result.has("landing_host")).toBe(false);
-  });
-});
+  expect(cookie).toBeDefined();
+  return new URLSearchParams(
+    decodeURIComponent(cookie?.split("=").slice(1).join("=") ?? ""),
+  );
+}
 
 describe("writeAcquisitionAttributionCookie", () => {
+  it.each([
+    ["?gclid=abc", "https://www.google.com/", "paid"],
+    ["?gbraid=abc", "", "paid"],
+    ["?wbraid=abc", "", "paid"],
+    ["?utm_medium=cpc", "", "paid"],
+    ["?utm_medium=paid_social", "", "paid"],
+    ["?utm_medium=organic", "", "organic_search"],
+    ["", "https://www.google.com/", "organic_search"],
+    ["", "https://bing.com/", "organic_search"],
+    ["?utm_source=newsletter", "", "referral"],
+    ["", "", "direct"],
+    ["", "https://app.vm0.ai/", "internal"],
+    ["", "https://news.ycombinator.com/", "referral"],
+  ])("classifies %s / %s as %s", (landingSearch, referrer, sourceType) => {
+    const { jar } = fakeJar();
+
+    writeAcquisitionAttributionCookie(
+      { hostname: "www.vm0.ai", referrer },
+      landingSearch,
+      jar,
+    );
+
+    expect(attributionParams(jar).get("source_type")).toBe(sourceType);
+  });
+
   it("writes a first-touch .vm0.ai cookie with the expected attributes", () => {
     const { jar, writes } = fakeJar();
 
@@ -124,10 +93,12 @@ describe("writeAcquisitionAttributionCookie", () => {
     expect(raw).toContain("SameSite=Lax");
     expect(raw).toContain("Secure");
 
-    const value = readAttributionCookie(jar.get());
-    expect(value).not.toBeNull();
-    const parsed = new URLSearchParams(value ?? "");
+    const parsed = attributionParams(jar);
+    expect(parsed.get("vm0_source")).toBe("homepage");
     expect(parsed.get("source_type")).toBe("paid");
+    expect(parsed.get("referrer_domain")).toBeNull();
+    expect(parsed.get("landing_host")).toBe("vm0.ai");
+    expect(parsed.get("landing_path")).toBe("/");
     expect(parsed.get("gclid")).toBe("abc");
   });
 
@@ -150,7 +121,7 @@ describe("writeAcquisitionAttributionCookie", () => {
     ).toBe(false);
 
     expect(writes).toHaveLength(1);
-    const parsed = new URLSearchParams(readAttributionCookie(jar.get()) ?? "");
+    const parsed = attributionParams(jar);
     expect(parsed.get("utm_source")).toBe("first");
   });
 

--- a/turbo/apps/web/src/__tests__/gallery-data.test.ts
+++ b/turbo/apps/web/src/__tests__/gallery-data.test.ts
@@ -1,7 +1,5 @@
 import { describe, expect, it } from "vitest";
 import {
-  GALLERY_CATEGORIES,
-  GALLERY_CATEGORY_LABELS,
   GALLERY_ITEMS,
   buildGalleryRemixHref,
   type GalleryCategory,
@@ -19,16 +17,11 @@ describe("generation gallery data", () => {
         return item.category;
       }),
     );
-    const visibleCategories = GALLERY_CATEGORIES.filter((category) => {
-      return category !== "all";
-    });
 
-    expect([...itemCategories].sort()).toEqual([...visibleCategories].sort());
+    expect([...itemCategories].sort()).toEqual(["website"]);
   });
 
   it("only shows the website design gallery for now", () => {
-    expect(GALLERY_CATEGORIES).toEqual(["all", "website"]);
-    expect(GALLERY_CATEGORY_LABELS.website).toBe("Website Design");
     expect(GALLERY_ITEMS.length).toBe(159);
     expect(
       GALLERY_ITEMS.every((item) => {

--- a/turbo/apps/web/src/__tests__/setup.ts
+++ b/turbo/apps/web/src/__tests__/setup.ts
@@ -38,48 +38,10 @@ const resetEnv = vi.hoisted(() => {
       "test-artifacts-secret-key",
     );
     vi.stubEnv("PUBLIC_ARTIFACTS_BASE_URL", "https://cdn.vm7.io");
-    // Slack integration test vars
-    vi.stubEnv("SLACK_OAUTH_CLIENT_ID", "test-slack-client-id");
-    vi.stubEnv("SLACK_OAUTH_CLIENT_SECRET", "test-slack-client-secret");
-    vi.stubEnv("SLACK_SIGNING_SECRET", "test-slack-signing-secret");
-    // 64 hex chars = 32 bytes encryption key for sandbox token signing
-    vi.stubEnv(
-      "SECRETS_ENCRYPTION_KEY",
-      "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef",
-    );
-    // 64 hex chars = 32 bytes secret for official runner authentication
-    vi.stubEnv(
-      "OFFICIAL_RUNNER_SECRET",
-      "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef",
-    );
-    // Runner executor default group (runs dispatch to runner)
-    // Uses "vm0" org which is hardcoded as public in isOfficialRunnerGroup
-    vi.stubEnv("RUNNER_DEFAULT_GROUP", "vm0/default");
-    // Realtime pub/sub (Ably) — required env; tests use a mocked Ably client
-    vi.stubEnv("ABLY_API_KEY", "test-key:test-secret");
-    // OpenAI (STT, TTS) — required env
-    vi.stubEnv("OPENAI_API_KEY", "test-openai-key");
     // API URL for compose job webhooks
     vi.stubEnv("VM0_API_URL", "http://localhost:3000");
     // App UI URL
     vi.stubEnv("NEXT_PUBLIC_APP_URL", "http://localhost:3001");
-    // Email integration (Resend)
-    vi.stubEnv("RESEND_API_KEY", "re_test_api_key");
-    vi.stubEnv("RESEND_WEBHOOK_SECRET", "whsec_test_webhook_secret");
-    vi.stubEnv("RESEND_FROM_DOMAIN", "vm7.bot");
-    // AgentPhone official AgentPhone integration
-    vi.stubEnv("AGENTPHONE_API_KEY", "test-agentphone-api-key");
-    vi.stubEnv("AGENTPHONE_API_BASE_URL", "https://api.agentphone.to");
-    vi.stubEnv("AGENTPHONE_PHONE_NUMBER", "+19039853128");
-    vi.stubEnv("AGENTPHONE_WEBHOOK_SECRET", "test-agentphone-webhook-secret");
-    // GitHub App integration test vars
-    vi.stubEnv("GITHUB_APP_ID", "123456");
-    vi.stubEnv("GITHUB_APP_SLUG", "vm0-test-app");
-    // Base64-encoded RSA private key for JWT signing in tests (2048-bit test key, NOT a production secret)
-    vi.stubEnv(
-      "GITHUB_APP_PRIVATE_KEY",
-      "LS0tLS1CRUdJTiBQUklWQVRFIEtFWS0tLS0tCk1JSUV2UUlCQURBTkJna3Foa2lHOXcwQkFRRUZBQVNDQktjd2dnU2pBZ0VBQW9JQkFRQ2FkZ0VnSzU4SVAzV3gKNkFvbDRxR09iTHhUV2dVd3pOckVrT0Z3anFIUEN6a2VXaHZuVWhBaDc5bnpVT1l5MG12akF0NFJTSFdGck9aNQp4eXVqS3p3OGNrY3ZiVDBrNmYyMHVsUHJNQStUSGMrYmZHQ1lNRmJzVk0vbTQydldtSkdTMDJ1bTIyZzAxb3lZCmxROEhEUXhRMjBva2tzclJ5c0lqWWx3WHloVWpoVFZnNkpGWVlVUEhiT2t1bHlhVmZUcVNmNmN3QUVGWTUrMWgKaUhFMmtBQllsdUFiY2JQeTBzVUIzblRxa2NuV3laWVBSTHplcUtUN1hEaDltL2hGSVJPWEtTS01ZWXZCWVROcQpaOXl5cDJpVHJsenR1NkZWcG1rdUlMZGpGQlJSQjg1azd5amlyZlp4NjExbWE0V3g1M05FTFB4ekY0QVRaZkdGCmlvR2s2WVZsQWdNQkFBRUNnZ0VBQ014NGozSFVyeFpZV01CUVZheWxpZFN4WEtrbjJ3b01XejZxak93ZkZRbDkKWVRoK1Z1ekNqUUJhQU1XR3UzWG5uZWlqcUVYaHBmSDl0Z210dDIrRzBLV3MzdXVBM0dtMDRWYnM0VnlkUW9MagorT1k2cFdpNWh1Qms0SERiaTMrbzZUMkFhQ0tlK3NXUEFFRWJlRW9hdmI5a0o1V3lGb1hQamM3MFVvbVpMeXI0CmZ6ODRDVGpBUFpMT1dDendJOVB6YURNdTFkL2J3bWdWNnpMN2pGaDU5Tlhka1FXdVd4TG1KVjV5dTBYdW5iZE8KbGlJbGFLTG9yQ045bTV0dksrOFFPYVRiM0VKckdCdm9HR2FqTThFKzU5TnRiazAwNGxuN3BLTnVDVzZ5SDBRTgpPM1A1VEFaT09CQUVieVZVZm80eW5wZTQ3VStyd296OHB5aWdCOFFXZ1FLQmdRREExU0ZhajB2cDNxN0hMSXFMCmsySU92ejZnVkEyS1IyRVdRbk5HRFdjT0UrVXJ2aC93bjVYN0lKTkFkQU9ORFFDQWFEa2hlSTFUMXFjYStSRWkKTzNaaVhXUlZ0QWRTdTJmenAveFMySkVqV05qT2UyTHd4Q2RmRmk1cEhQdnZNZWpQL0NsaHZyWFQzOE5xZ3dmNgpVV2t1ckpvRFR0SEFKRjF1dWNVbzVpT3k1UUtCZ1FETkR3dmFjRjFXbUd4bVJnM2pBanl2OEJVd2FSTTZCazc3Cmc1NE91MTk1dG54dUdpS2NQUHcyU3V5SWQ0bm9aaWQ5SWhuSUZzd2xQSDI1eWU5dVBwYkhNR2Njc0xLNTU0S1IKelpUZEg3NVpVUmo2OXYzTStJQi9PWmY3citkUk85ZGFNYUF6TFdRYWhjdjFXSDVMb1FxZjhoV0k1eEI3RnFKawpUaWtTdEpUZ2dRS0JnR1I4ckd6c3o3cUgrTHlDVVpCNnRWYktBbkM2WEhQNnpuVXpHNjhkdk41eEw3T2oyREVrCmVKdnRWYzc0cGdFVERYZmMyQ2pCRWFUbTd4MzNQUjZCcmllRVU0ejF5L3NvL2ZyVFI0SkVxUjJxWnhEeTY1UmMKSThoQlh0NFg1Skc1aUlFWi90YVk4MWY5KzIrOTZLSmhXbGFnUzRIOXlRQS84eENJYmwzcDBDQ2hBb0dBQ01ZQQpCOVNPNmNtVHVieDlrNXpnNDlZdDBlaHMvaXFPN292dkUwcEpCM2diVXNxamVIUFRocThsOTZERnNiL05LTGx3CnlQTFF3VGNaV2YyZDFPV3dwYzBZWEUzakY3a2tDUUQyd1k4K0lhd3FtWEkvNGFrd05rRk1rMlF2VFhaMS9GSHIKUE1WUVp5SWFXK0R4Wm1MNWhXWmlMWDFWWXk3UXUrSHNOL1NwK2dFQ2dZRUFvS1dhV3JXM2VEVkl5WFVtazRoQgo2OGt5RG9iWldpTGlkU2FlUG1UYk91Mnp3YWt3eTIraDhyUGpuZXl1eWgyYzNsZjlqYnhQM2NhU2JwV1JZQjFoCnQwVThUZ3JwMDZ3TlBvSUNiWWI1OU12UTBscXVpeG9IejUvbUhEb2dtTWhkcEM4NHlpSVd6TmgvQmxRSlVrbFgKaEZnT3dkWFloQ250Qi9Nc0YxMTdtdHc9Ci0tLS0tRU5EIFBSSVZBVEUgS0VZLS0tLS0K",
-    );
   };
   fn(); // Initial call before imports
   return fn;

--- a/turbo/apps/web/src/env.ts
+++ b/turbo/apps/web/src/env.ts
@@ -129,6 +129,9 @@ export function env() {
   return _env;
 }
 
+/**
+ * @internal Test-only cache reset for env-sensitive web integration tests.
+ */
 export function reloadEnv() {
   _env = initEnv();
 }

--- a/turbo/apps/web/src/lib/adAttribution.ts
+++ b/turbo/apps/web/src/lib/adAttribution.ts
@@ -110,7 +110,7 @@ function truncate(value: string, maxLength: number): string {
   return value.length > maxLength ? value.slice(0, maxLength) : value;
 }
 
-export function sourceType(
+function sourceType(
   params: URLSearchParams,
   referrerHostname: string | undefined,
 ): SourceType {
@@ -153,7 +153,7 @@ export function sourceType(
 
 // Pure builder: derive the attribution param set from the landing URL + page
 // context. No DOM / storage access, so it is unit-testable in isolation.
-export function acquisitionAttributionParams(
+function acquisitionAttributionParams(
   landingSearch: string,
   context: LandingAttributionContext = {},
 ): URLSearchParams {
@@ -199,7 +199,7 @@ export function currentLandingAttributionContext(): LandingAttributionContext {
 
 // Cookie I/O is isolated behind this interface so the write path is testable
 // without a DOM (apps/web tests run in the node environment).
-export interface CookieJar {
+interface CookieJar {
   get(): string;
   set(value: string): void;
 }
@@ -215,7 +215,7 @@ function documentCookieJar(): CookieJar {
   };
 }
 
-export function readAttributionCookie(cookieString: string): string | null {
+function readAttributionCookie(cookieString: string): string | null {
   for (const part of cookieString.split(";")) {
     const trimmed = part.trim();
     if (!trimmed) {

--- a/turbo/knip.json
+++ b/turbo/knip.json
@@ -11,8 +11,7 @@
         "i18n.ts",
         "navigation.ts",
         "**/__tests__/**/*.{test,spec}.{ts,tsx}",
-        "**/*.{test,spec}.{ts,tsx}",
-        "src/__tests__/webhook-simulators/index.ts"
+        "**/*.{test,spec}.{ts,tsx}"
       ],
       "project": [
         "**/*.{ts,tsx}!",


### PR DESCRIPTION
## Summary
- remove stale web Knip entry for deleted webhook simulator helpers
- stop exporting test-only attribution/gallery/presentation/blog symbols from production web modules
- trim obsolete backend env stubs from the web test setup

## Verification
- pnpm knip --workspace web --production
- pnpm knip --workspace web
- pnpm -F web lint
- pnpm -F web check-types
- mise exec node@22 -- pnpm -F web exec vitest run src/__tests__/adAttribution.test.ts src/__tests__/gallery-data.test.ts app/[locale]/presentation/__tests__/data.test.ts app/lib/blog/__tests__/index.test.ts
- mise exec node@22 -- pnpm -F web exec vitest run