### PR TITLE
chore: update rootfs package versions

### DIFF
--- a/crates/runner/scripts/build-template.sh
+++ b/crates/runner/scripts/build-template.sh
@@ -232,16 +232,16 @@ trap cleanup EXIT
 trap 'echo "error: command failed at line ${LINENO}: ${BASH_COMMAND}" >&2' ERR
 
 # ---------------------------------------------------------------------------
-# Bootstrap Ubuntu 24.04 rootfs
+# Bootstrap Ubuntu 26.04 rootfs
 # ---------------------------------------------------------------------------
 
 debootstrap_cache_locked() {
   # Cache the base package tarball so repeated builds (e.g. after changing
   # a pinned version) skip the ~200 MB download from the Ubuntu mirror.
-  local cache_tar="${DEBOOTSTRAP_DIR}/noble-$(dpkg --print-architecture).tar"
+  local cache_tar="${DEBOOTSTRAP_DIR}/resolute-$(dpkg --print-architecture).tar"
   if [[ -f "$cache_tar" ]]; then
     echo "using cached debootstrap tarball: $cache_tar"
-    sudo debootstrap --unpack-tarball="$(realpath "$cache_tar")" noble "$ROOTFS_DIR" "$MIRROR"
+    sudo debootstrap --unpack-tarball="$(realpath "$cache_tar")" resolute "$ROOTFS_DIR" "$MIRROR"
     sudo touch "$cache_tar"
   else
     # --make-tarball downloads packages into a tarball without extracting.
@@ -251,19 +251,19 @@ debootstrap_cache_locked() {
     # partial tarball under the stable cache name that another runner may reuse.
     CACHE_TMP_TAR="${cache_tar}.tmp.$$"
     rm -f "$CACHE_TMP_TAR"
-    sudo debootstrap --make-tarball="$CACHE_TMP_TAR" noble "$ROOTFS_DIR" "$MIRROR" || true
+    sudo debootstrap --make-tarball="$CACHE_TMP_TAR" resolute "$ROOTFS_DIR" "$MIRROR" || true
     if [[ ! -s "$CACHE_TMP_TAR" ]]; then
       echo "error: debootstrap --make-tarball failed to create $CACHE_TMP_TAR" >&2
       exit 1
     fi
-    sudo debootstrap --unpack-tarball="$(realpath "$CACHE_TMP_TAR")" noble "$ROOTFS_DIR" "$MIRROR"
+    sudo debootstrap --unpack-tarball="$(realpath "$CACHE_TMP_TAR")" resolute "$ROOTFS_DIR" "$MIRROR"
     mv -f "$CACHE_TMP_TAR" "$cache_tar"
     CACHE_TMP_TAR=""
   fi
 }
 
 debootstrap_build() {
-  echo "bootstrapping Ubuntu 24.04 rootfs..."
+  echo "bootstrapping Ubuntu 26.04 rootfs..."
   ROOTFS_DIR="$(mktemp -d)"
 
   # Only the shared tarball cache needs fleet-wide serialization. Release the
@@ -345,7 +345,7 @@ install_packages() {
     php php-cli php-common php-curl php-mbstring php-xml php-zip \
     default-jdk maven gradle \
     gcc g++ clang make cmake \
-    postgresql-16 postgresql-contrib \
+    postgresql-18 postgresql-contrib \
     redis-server \
     gh
 
@@ -358,18 +358,18 @@ install_packages() {
   rm -rf /var/lib/apt/lists/* /var/cache/apt/*
   '
 
-  # Chromium from Debian Bookworm (Ubuntu 24.04 snap stub does not work).
+  # Chromium from Debian Trixie (Ubuntu 26.04 snap stub does not work).
   # Installed separately to avoid cross-distro dependency conflicts.
   sudo chroot "$ROOTFS_DIR" bash -c 'set -e
     export DEBIAN_FRONTEND=noninteractive
-    curl -fsSL https://ftp-master.debian.org/keys/archive-key-12.asc \
-      | gpg --dearmor -o /usr/share/keyrings/debian-bookworm.gpg
-    echo "deb [signed-by=/usr/share/keyrings/debian-bookworm.gpg] http://deb.debian.org/debian bookworm main" \
-      > /etc/apt/sources.list.d/debian-bookworm.list
+    curl -fsSL https://ftp-master.debian.org/keys/archive-key-13.asc \
+      | gpg --dearmor -o /usr/share/keyrings/debian-trixie.gpg
+    echo "deb [signed-by=/usr/share/keyrings/debian-trixie.gpg] http://deb.debian.org/debian trixie main" \
+      > /etc/apt/sources.list.d/debian-trixie.list
     apt-get update
-    apt-get install -y -t bookworm chromium
-    rm -f /etc/apt/sources.list.d/debian-bookworm.list \
-         /usr/share/keyrings/debian-bookworm.gpg
+    apt-get install -y -t trixie chromium
+    rm -f /etc/apt/sources.list.d/debian-trixie.list \
+         /usr/share/keyrings/debian-trixie.gpg
     rm -rf /var/lib/apt/lists/* /var/cache/apt/*
   '
 
@@ -391,7 +391,7 @@ install_packages() {
 install_runtimes() {
   echo "installing language runtimes and CLIs..."
 
-  # User account (Ubuntu 24.04 ships 'ubuntu' at UID 1000; remove it first)
+  # User account (Ubuntu 26.04 ships 'ubuntu' at UID 1000; remove it first)
   sudo chroot "$ROOTFS_DIR" bash -c '
     userdel -r ubuntu 2>/dev/null || true
     useradd -m -u 1000 -s /bin/bash user


### PR DESCRIPTION
Updates pinned rootfs dependency streams in crates/runner/scripts/build-template.sh.

Updated:
- Ubuntu rootfs: 24.04 (noble) -> 26.04 (resolute)
- PostgreSQL apt package stream: postgresql-16 -> postgresql-18
- Debian Chromium source: Bookworm / archive-key-12 -> Trixie / archive-key-13
- Chromium package source version: 147.0.7727.137-1~deb12u1 -> 147.0.7727.137-1~deb13u1

Checked and left unchanged because they are already current:
- Go: 1.26.3
- Claude Code CLI: 2.1.159
- Codex CLI: 0.135.0
- Google Workspace CLI: 0.22.5
- xurl: 1.0.3
- agent-browser: 0.27.0
- pnpm: 11.5.0
- Node.js: node_24.x remains the active LTS stream

Verification:
- bash -n crates/runner/scripts/build-template.sh
- Confirmed Ubuntu 26.04 resolute archive availability for amd64 and arm64
- Confirmed postgresql-18 exists in Ubuntu 26.04 for amd64 and arm64
- Confirmed Debian Trixie Chromium package availability for amd64 and arm64