### PR TITLE
fix(mitm-addon): keep websocket usage flows tracked

### DIFF
--- a/crates/runner/mitm-addon/src/mitm_addon.py
+++ b/crates/runner/mitm-addon/src/mitm_addon.py
@@ -517,8 +517,9 @@ def _maybe_track_usage_flow(flow: http.HTTPFlow, firewall_billable: bool) -> Non
 
     This closes the shutdown drain gap before standard upstream dispatch and
     before auth.base URL rewrites, where the addon itself forwards upstream.
-    The response/error decorator pops the metadata flag so decrement runs
-    exactly once.
+    Normal HTTP flows release from response/error.  Model-provider WebSocket
+    upgrades release from websocket_end/error because the 101 response does not
+    complete the billable usage lifecycle.
     """
     if flow.metadata.get(_USAGE_FLOW_TRACKED):
         return
@@ -574,12 +575,17 @@ def _response_size(flow: http.HTTPFlow) -> int:
     return int(flow.response.headers.get("content-length", 0))
 
 
-def _track_usage_flow(fn):
-    """Decorator ensuring decrement_in_flight_flows runs after response/error handlers.
+def _release_usage_hook_state(flow: http.HTTPFlow, *, release_tracking: bool) -> None:
+    response_streaming.release_response_stream_state(flow)
+    if release_tracking:
+        _release_tracked_usage_flow(flow)
 
-    Pairs with ``increment_in_flight_flows()`` in ``request()``.  Uses ``pop`` so
-    that even if both ``response()`` and ``error()`` fire for the same
-    flow, the decrement only happens once.
+
+def _track_usage_flow(fn):
+    """Decorator ensuring tracked usage flows release after terminal hooks.
+
+    Pairs with ``increment_in_flight_flows()`` in ``request()``. Uses ``pop`` so
+    duplicate terminal hooks decrement at most once.
     """
 
     @functools.wraps(fn)
@@ -587,8 +593,23 @@ def _track_usage_flow(fn):
         try:
             return fn(flow, *args, **kwargs)
         finally:
-            response_streaming.release_response_stream_state(flow)
-            _release_tracked_usage_flow(flow)
+            _release_usage_hook_state(flow, release_tracking=True)
+
+    return wrapper
+
+
+def _track_response_usage_flow(fn):
+    """Decorator for response() where a 101 WebSocket upgrade is not terminal."""
+
+    @functools.wraps(fn)
+    def wrapper(flow: http.HTTPFlow, *args, **kwargs):
+        release_tracking = True
+        try:
+            result = fn(flow, *args, **kwargs)
+            release_tracking = not response_streaming.is_model_websocket_usage_enabled(flow)
+            return result
+        finally:
+            _release_usage_hook_state(flow, release_tracking=release_tracking)
 
     return wrapper
 
@@ -601,7 +622,7 @@ def websocket_end(flow: http.HTTPFlow) -> None:
         _report_model_provider_usage_once(flow, run_id)
 
 
-@_track_usage_flow
+@_track_response_usage_flow
 def response(flow: http.HTTPFlow) -> None:
     """
     Handle response and log network activity.

--- a/crates/runner/mitm-addon/src/response_streaming.py
+++ b/crates/runner/mitm-addon/src/response_streaming.py
@@ -25,6 +25,10 @@ def uses_openai_responses_usage_protocol(flow: http.HTTPFlow) -> bool:
     return flow.metadata.get(metadata_keys.CLI_AGENT_TYPE) == "codex"
 
 
+def is_model_websocket_usage_enabled(flow: http.HTTPFlow) -> bool:
+    return bool(flow.metadata.get(_MODEL_WEBSOCKET_USAGE_ENABLED, False))
+
+
 def _make_response_chunk_parser(
     feed: _ResponseChunkParser,
     headers: http.Headers,
@@ -194,7 +198,7 @@ def finalize_model_sse_usage(flow: http.HTTPFlow) -> None:
 
 
 def feed_model_websocket_usage(flow: http.HTTPFlow, content: bytes | str) -> None:
-    if not flow.metadata.get(_MODEL_WEBSOCKET_USAGE_ENABLED, False):
+    if not is_model_websocket_usage_enabled(flow):
         return
     body = content.encode() if isinstance(content, str) else content
     usage_result = usage.extract_openai_responses_usage_from_event_json(body)

--- a/crates/runner/mitm-addon/tests/test_model_provider_stream_usage.py
+++ b/crates/runner/mitm-addon/tests/test_model_provider_stream_usage.py
@@ -14,6 +14,7 @@ import mitm_addon
 import response_streaming
 import usage
 from tests.flow_helpers import header_map, response_stream
+from tests.pending_helpers import assert_pending
 
 
 def _openai_model_websocket_flow(
@@ -488,6 +489,75 @@ class TestModelProviderStreamUsage:
             "tokens.output": 20,
             "tokens.cache_read": 10,
         }
+
+    def test_model_websocket_response_keeps_usage_flow_tracked_until_end(
+        self, tmp_path, real_flow, mitm_ctx, fresh_usage_executor, usage_webhook_api
+    ):
+        """The HTTP 101 response hook must not complete the WebSocket usage lifecycle."""
+        pending_path = tmp_path / "usage-pending"
+        usage.set_pending_path(str(pending_path), usage_state_id="test-usage-state-id")
+        usage.increment_in_flight_flows()
+
+        flow = _openai_model_websocket_flow(tmp_path, real_flow)
+        flow.metadata["_usage_flow_tracked"] = True
+        usage.write_pending_snapshot(flush_request_id="before-response")
+        assert_pending(
+            pending_path,
+            flows=1,
+            buffered=0,
+            reports=0,
+            flush_request_id="before-response",
+        )
+
+        with usage_webhook_api() as webhook:
+            mitm_addon.response(flow)
+            assert flow.metadata["_usage_flow_tracked"] is True
+            usage.write_pending_snapshot(flush_request_id="after-response")
+            assert_pending(
+                pending_path,
+                flows=1,
+                buffered=0,
+                reports=0,
+                flush_request_id="after-response",
+            )
+
+            _feed_websocket_server_message(
+                flow,
+                json.dumps(
+                    {
+                        "type": "response.completed",
+                        "response": {
+                            "id": "resp_ws_1",
+                            "model": "gpt-5.5",
+                            "usage": {
+                                "input_tokens": 50,
+                                "output_tokens": 20,
+                                "input_tokens_details": {"cached_tokens": 10},
+                            },
+                        },
+                    }
+                ).encode(),
+            )
+            mitm_addon.websocket_end(flow)
+            usage.flush_usage_events(trigger="test")
+            usage.webhook.usage_executor.shutdown(wait=True)
+
+        events = webhook.usage_events()
+        by_category = {event["category"]: event["quantity"] for event in events}
+        assert by_category == {
+            "tokens.input": 40,
+            "tokens.output": 20,
+            "tokens.cache_read": 10,
+        }
+        assert "_usage_flow_tracked" not in flow.metadata
+        usage.write_pending_snapshot(flush_request_id="after-websocket-end")
+        assert_pending(
+            pending_path,
+            flows=0,
+            buffered=0,
+            reports=0,
+            flush_request_id="after-websocket-end",
+        )
 
     def test_full_pipeline_model_websocket_zero_frame_preserves_billed_usage_and_id(
         self, tmp_path, real_flow, mitm_ctx, fresh_usage_executor, usage_webhook_api


### PR DESCRIPTION
## Summary

- defer tracked usage-flow release from the HTTP `response()` hook for model-provider WebSocket upgrade responses
- keep `websocket_end()` and `error()` on unconditional release so in-flight counters cannot leak after terminal hooks
- add a regression test covering `responseheaders()` -> `response()` for 101 -> WebSocket usage frame -> `websocket_end()` pending-counter lifecycle

Closes #15702

## Tests

- `PATH=/tmp/vm7-mitm-addon-deps/bin:$PATH ruff format src/mitm_addon.py src/response_streaming.py tests/test_model_provider_stream_usage.py`
- `PATH=/tmp/vm7-mitm-addon-deps/bin:$PATH ruff check src/mitm_addon.py src/response_streaming.py tests/test_model_provider_stream_usage.py`
- `PYTHONPATH=/tmp/vm7-mitm-addon-deps PATH=/tmp/vm7-mitm-addon-deps/bin:$PATH basedpyright -p .`
- `PYTHONPATH=/tmp/vm7-mitm-addon-deps PATH=/tmp/vm7-mitm-addon-deps/bin:$PATH pytest tests/test_model_provider_stream_usage.py::TestModelProviderStreamUsage::test_model_websocket_response_keeps_usage_flow_tracked_until_end -q` (failed before fix, passed after fix)
- `PYTHONPATH=/tmp/vm7-mitm-addon-deps PATH=/tmp/vm7-mitm-addon-deps/bin:$PATH pytest tests/test_model_provider_stream_usage.py tests/test_request_handler_usage_tracking.py tests/test_error_handler.py -q`
- `PYTHONPATH=/tmp/vm7-mitm-addon-deps PATH=/tmp/vm7-mitm-addon-deps/bin:$PATH pytest tests -q`
