### PR TITLE
fix(desktop): restore auth state on reopen

### DIFF
--- a/turbo/apps/desktop/src/desktop-auth-session.test.ts
+++ b/turbo/apps/desktop/src/desktop-auth-session.test.ts
@@ -159,6 +159,51 @@ describe("DesktopAuthSession", () => {
     );
   });
 
+  it("reports signing-in state while a consume flow is pending", async () => {
+    const { session, runAuthWindow, onAuthCompleted } = createSession();
+    let finishAuthWindow: () => void = () => {};
+    runAuthWindow.mockImplementationOnce(() => {
+      return new Promise<void>((resolve) => {
+        finishAuthWindow = resolve;
+      });
+    });
+
+    const consumePromise = session.consumeCode("code-123");
+
+    expect(await session.getAuthState()).toEqual({
+      status: "signing_in",
+      user: null,
+      organization: null,
+    });
+
+    session.completeSignIn("fresh");
+    finishAuthWindow();
+    await consumePromise;
+
+    expect(onAuthCompleted).toHaveBeenCalledOnce();
+  });
+
+  it("clears signing-in state when a consume flow fails", async () => {
+    const { session, runAuthWindow } = createSession();
+    runAuthWindow
+      .mockRejectedValueOnce(new Error("consume failed"))
+      .mockResolvedValueOnce(undefined);
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async () => new Response(null, { status: 401 })),
+    );
+
+    await expect(session.consumeCode("code-123")).rejects.toThrow(
+      "consume failed",
+    );
+
+    expect(await session.getAuthState()).toEqual({
+      status: "signed_out",
+      user: null,
+      organization: null,
+    });
+  });
+
   it("runs onAuthCompleted after a visible org-selection flow", async () => {
     const { session, runAuthWindow, onAuthCompleted } = createSession();
 
@@ -221,6 +266,48 @@ describe("DesktopAuthSession", () => {
     expect(session.getCachedToken()).toBeNull();
   });
 
+  it("refreshes the desktop token and retries auth state after a 401", async () => {
+    const { session, runAuthWindow } = createSession();
+    const observedAuthorization: (string | null)[] = [];
+    runAuthWindow.mockImplementation(async () => {
+      session.completeSignIn("fresh");
+    });
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async (input: string | URL | Request, init?: RequestInit) => {
+        const headers = new Headers(init?.headers);
+        observedAuthorization.push(headers.get("authorization"));
+        const url = String(input);
+        if (
+          url.endsWith("/api/auth/me") &&
+          headers.get("authorization") === "Bearer fresh"
+        ) {
+          return jsonResponse({ userId: "u1", email: "u@example.com" });
+        }
+        if (url.endsWith("/api/auth/me")) {
+          return new Response(null, { status: 401 });
+        }
+        return jsonResponse({ id: "o1", name: "Org One", slug: "org-one" });
+      }),
+    );
+
+    expect(await session.getAuthState()).toEqual({
+      status: "signed_in",
+      user: { userId: "u1", email: "u@example.com" },
+      organization: { id: "o1", name: "Org One", slug: "org-one" },
+    });
+    expect(runAuthWindow).toHaveBeenCalledWith({
+      url: TOKEN_URL,
+      visible: false,
+      allowInteractiveFallbacks: false,
+    });
+    expect(observedAuthorization).toStrictEqual([
+      null,
+      "Bearer fresh",
+      "Bearer fresh",
+    ]);
+  });
+
   it("derives signed-in state with a null organization on 404", async () => {
     const { session } = createSession();
     vi.stubGlobal(
@@ -256,8 +343,8 @@ describe("DesktopAuthSession", () => {
       user: null,
       organization: null,
     });
-    // Token was cleared, so a non-forced getToken now refreshes via the window.
-    await session.getToken();
+    // Auth-state checks now make one hidden refresh attempt before settling on
+    // signed out.
     expect(runAuthWindow).toHaveBeenCalledOnce();
   });
 });

--- a/turbo/apps/desktop/src/desktop-auth-session.ts
+++ b/turbo/apps/desktop/src/desktop-auth-session.ts
@@ -67,6 +67,14 @@ function signedOutDesktopAuthState(): DesktopAuthState {
   };
 }
 
+function signingInDesktopAuthState(): DesktopAuthState {
+  return {
+    status: "signing_in",
+    user: null,
+    organization: null,
+  };
+}
+
 /**
  * Owns the desktop auth token state machine, extracted from `main.ts` and kept
  * free of Electron imports so it can be integration-tested by injecting fakes,
@@ -86,6 +94,7 @@ export class DesktopAuthSession {
   private token: string | null = null;
   private tokenRefresh: Promise<string | null> | null = null;
   private pendingCode: string | null = null;
+  private signingIn = false;
 
   constructor(options: DesktopAuthSessionOptions) {
     this.apiBaseUrl = options.apiBaseUrl;
@@ -113,6 +122,24 @@ export class DesktopAuthSession {
   }
 
   async getAuthState(): Promise<DesktopAuthState> {
+    if (this.signingIn) {
+      return signingInDesktopAuthState();
+    }
+
+    const state = await this.fetchAuthState();
+    if (state.status !== "signed_out") {
+      return state;
+    }
+
+    const restoredToken = await this.getToken({ forceRefresh: true });
+    if (!restoredToken) {
+      return state;
+    }
+
+    return await this.fetchAuthState();
+  }
+
+  private async fetchAuthState(): Promise<DesktopAuthState> {
     const meUrl = new URL(AUTH_ME_PATH, this.apiBaseUrl);
     const meResponse = await this.fetchWithSessionAuth(meUrl);
     if (meResponse.status === 401) {
@@ -155,11 +182,17 @@ export class DesktopAuthSession {
   }
 
   async consumeCode(code: string): Promise<void> {
-    await this.runAuthWindow({
-      url: this.consumeUrl(code),
-      visible: false,
-      allowInteractiveFallbacks: true,
-    });
+    this.setSigningIn(true);
+    try {
+      await this.runAuthWindow({
+        url: this.consumeUrl(code),
+        visible: false,
+        allowInteractiveFallbacks: true,
+      });
+    } finally {
+      this.setSigningIn(false);
+    }
+
     await this.onAuthCompleted();
   }
 
@@ -207,6 +240,14 @@ export class DesktopAuthSession {
     } finally {
       this.tokenRefresh = null;
     }
+  }
+
+  private setSigningIn(value: boolean): void {
+    if (this.signingIn === value) {
+      return;
+    }
+    this.signingIn = value;
+    this.onChange();
   }
 
   private async fetchWithSessionAuth(requestUrl: URL): Promise<Response> {

--- a/turbo/apps/desktop/src/desktop-bridge.ts
+++ b/turbo/apps/desktop/src/desktop-bridge.ts
@@ -13,6 +13,11 @@ export interface DesktopAuthOrganization {
 
 export type DesktopAuthState =
   | {
+      readonly status: "signing_in";
+      readonly user: null;
+      readonly organization: null;
+    }
+  | {
       readonly status: "signed_out";
       readonly user: null;
       readonly organization: null;

--- a/turbo/apps/desktop/src/renderer/App.tsx
+++ b/turbo/apps/desktop/src/renderer/App.tsx
@@ -433,6 +433,7 @@ function RuntimePanel({
     !state.permissions.accessibility || !state.permissions.screenRecording;
   const signedOut =
     !authLoading && (!authState || authState.status === "signed_out");
+  const signingIn = authState?.status === "signing_in";
   const needsOrganization =
     !authLoading &&
     authState?.status === "signed_in" &&
@@ -500,9 +501,9 @@ function RuntimePanel({
               onClick={() => {
                 void signIn();
               }}
-              disabled={signInLoadable.state === "loading"}
+              disabled={signingIn || signInLoadable.state === "loading"}
             >
-              Sign in
+              {signingIn ? "Signing in..." : "Sign in"}
             </IconButton>
           )}
         {(needsOrganization || state.host.status === "needs_organization") &&
@@ -952,14 +953,20 @@ function AccountMenu({
   readonly orgSelectionLoading: boolean;
   readonly signInLoading: boolean;
 }) {
-  if (!authState || authState.status === "signed_out") {
+  if (
+    !authState ||
+    authState.status === "signed_out" ||
+    authState.status === "signing_in"
+  ) {
+    const signingIn =
+      authState?.status === "signing_in" || signInLoading === true;
     return (
       <IconButton
         icon={<IconExternalLink size={15} />}
         onClick={onSignIn}
-        disabled={loading || signInLoading}
+        disabled={loading || signingIn}
       >
-        {loading ? "Checking" : "Sign in"}
+        {signingIn ? "Signing in..." : loading ? "Checking" : "Sign in"}
       </IconButton>
     );
   }

--- a/turbo/apps/desktop/src/renderer/computer-use-state.test.ts
+++ b/turbo/apps/desktop/src/renderer/computer-use-state.test.ts
@@ -33,6 +33,12 @@ const signedOutAuth: DesktopAuthState = {
   organization: null,
 };
 
+const signingInAuth: DesktopAuthState = {
+  status: "signing_in",
+  user: null,
+  organization: null,
+};
+
 const signedInAuth: DesktopAuthState = {
   status: "signed_in",
   user: { userId: "user-1", email: "user@example.com" },
@@ -63,6 +69,9 @@ describe("shouldAutoStartComputerUse", () => {
     );
     expect(shouldAutoStartComputerUse(computerUseState(), null)).toBe(false);
     expect(shouldAutoStartComputerUse(computerUseState(), signedOutAuth)).toBe(
+      false,
+    );
+    expect(shouldAutoStartComputerUse(computerUseState(), signingInAuth)).toBe(
       false,
     );
     expect(


### PR DESCRIPTION
## Summary
- restore desktop auth by refreshing a persisted Electron Clerk session before returning signed out
- expose a transient desktop signing-in state while callback handoff is being consumed
- show Signing in... in the desktop header/runtime sign-in actions during that handoff

## Tests
- pnpm -F @vm0/desktop test
- pnpm -F @vm0/desktop check-types
- pnpm -F @vm0/desktop lint
- pnpm exec prettier --write apps/desktop/src/desktop-auth-session.ts apps/desktop/src/desktop-auth-session.test.ts apps/desktop/src/desktop-bridge.ts apps/desktop/src/renderer/App.tsx apps/desktop/src/renderer/computer-use-state.test.ts
- git diff --check