### PR TITLE
refactor(mitm-addon): unify firewall auth cache payload shape

### DIFF
--- a/crates/runner/mitm-addon/src/auth.py
+++ b/crates/runner/mitm-addon/src/auth.py
@@ -73,28 +73,32 @@ _STRUCTURED_FIREWALL_AUTH_ERROR_CODES = frozenset(
 _FIREWALL_AUTH_FAILURE_REASONS = frozenset({"upstream_provider", "reconnect_required"})
 
 
+@dataclass(frozen=True)
+class _FirewallAuthPayload:
+    """Cacheable /firewall/auth data applied to outbound requests."""
+
+    headers: dict[str, str]
+    resolved_secrets: list[str] = field(default_factory=list)
+    base: str | None = None
+    query: dict[str, str] | None = None
+
+
 @dataclass
 class _FirewallHeaderCacheEntry:
     """Cached /firewall/auth response data for a single firewall key."""
 
-    headers: dict[str, str]
+    payload: _FirewallAuthPayload
     expires_at: object = None
-    resolved_secrets: list[str] = field(default_factory=list)
-    base: str | None = None
-    query: dict[str, str] | None = None
 
 
 @dataclass(frozen=True)
 class _FirewallAuthSuccess:
     """Validated /firewall/auth success response consumed by the auth cache."""
 
-    headers: dict[str, str]
+    payload: _FirewallAuthPayload
     expires_at: object = None
-    resolved_secrets: list[str] = field(default_factory=list)
     refreshed_connectors: list[str] = field(default_factory=list)
     refreshed_secrets: list[str] = field(default_factory=list)
-    base: str | None = None
-    query: dict[str, str] | None = None
 
 
 @dataclass
@@ -350,14 +354,17 @@ def _parse_firewall_auth_success(decoded: object) -> _FirewallAuthSuccess:
     if base is not None and not isinstance(base, str):
         raise _malformed_firewall_auth_success("base must be a string")
 
-    return _FirewallAuthSuccess(
+    payload = _FirewallAuthPayload(
         headers=_parse_string_map(decoded_map["headers"], "headers"),
-        expires_at=decoded_map.get("expiresAt"),
         resolved_secrets=_parse_optional_string_list(decoded_map, "resolvedSecrets"),
-        refreshed_connectors=_parse_optional_string_list(decoded_map, "refreshedConnectors"),
-        refreshed_secrets=_parse_optional_string_list(decoded_map, "refreshedSecrets"),
         base=base,
         query=_parse_optional_string_map(decoded_map, "query"),
+    )
+    return _FirewallAuthSuccess(
+        payload=payload,
+        expires_at=decoded_map.get("expiresAt"),
+        refreshed_connectors=_parse_optional_string_list(decoded_map, "refreshedConnectors"),
+        refreshed_secrets=_parse_optional_string_list(decoded_map, "refreshedSecrets"),
     )
 
 
@@ -503,6 +510,29 @@ def _has_valid_expiry(value: object, now: float | None = None) -> bool:
     return (time.time() if now is None else now) < value
 
 
+def _build_token_meta(
+    payload: _FirewallAuthPayload,
+    *,
+    cache_hit: bool,
+    refreshed_connectors: list[str] | None = None,
+    refreshed_secrets: list[str] | None = None,
+) -> dict:
+    token_meta: dict = {
+        "headers": payload.headers,
+        "resolved_secrets": payload.resolved_secrets,
+        "cache_hit": cache_hit,
+    }
+    if refreshed_connectors is not None:
+        token_meta["refreshed_connectors"] = refreshed_connectors
+    if refreshed_secrets is not None:
+        token_meta["refreshed_secrets"] = refreshed_secrets
+    if payload.base is not None:
+        token_meta["base"] = payload.base
+    if payload.query is not None:
+        token_meta["query"] = payload.query
+    return token_meta
+
+
 def _build_cache_hit(
     cached: _FirewallHeaderCacheEntry, firewall_billable: bool = False
 ) -> dict | None:
@@ -514,16 +544,7 @@ def _build_cache_hit(
             return None
     elif not _has_valid_expiry(expires_at, now):
         return None
-    hit = {
-        "headers": cached.headers,
-        "resolved_secrets": cached.resolved_secrets,
-        "cache_hit": True,
-    }
-    if cached.base is not None:
-        hit["base"] = cached.base
-    if cached.query is not None:
-        hit["query"] = cached.query
-    return hit
+    return _build_token_meta(cached.payload, cache_hit=True)
 
 
 async def get_firewall_headers(
@@ -595,14 +616,9 @@ async def get_firewall_headers(
                 "Billable firewall auth response did not include a valid cache expiry"
             )
         cache_entry = _FirewallHeaderCacheEntry(
-            headers=result.headers,
+            payload=result.payload,
             expires_at=result.expires_at,
-            resolved_secrets=result.resolved_secrets,
         )
-        if result.base is not None:
-            cache_entry.base = result.base
-        if result.query is not None:
-            cache_entry.query = result.query
 
         # A 401 can request a forced refresh while this non-forced fetch is
         # in flight. Return the current result to this request, but do not let
@@ -611,18 +627,12 @@ async def get_firewall_headers(
         if not marker_appeared_during_non_forced_fetch:
             state.cache = cache_entry
 
-        ret: dict = {
-            "headers": result.headers,
-            "resolved_secrets": result.resolved_secrets,
-            "refreshed_connectors": result.refreshed_connectors,
-            "refreshed_secrets": result.refreshed_secrets,
-            "cache_hit": False,
-        }
-        if result.base is not None:
-            ret["base"] = result.base
-        if result.query is not None:
-            ret["query"] = result.query
-        return ret
+        return _build_token_meta(
+            result.payload,
+            cache_hit=False,
+            refreshed_connectors=result.refreshed_connectors,
+            refreshed_secrets=result.refreshed_secrets,
+        )
 
 
 def _record_firewall_auth_success_metadata(flow: http.HTTPFlow, token_meta: dict) -> None:

--- a/crates/runner/mitm-addon/src/auth.py
+++ b/crates/runner/mitm-addon/src/auth.py
@@ -354,17 +354,22 @@ def _parse_firewall_auth_success(decoded: object) -> _FirewallAuthSuccess:
     if base is not None and not isinstance(base, str):
         raise _malformed_firewall_auth_success("base must be a string")
 
+    headers = _parse_string_map(decoded_map["headers"], "headers")
+    resolved_secrets = _parse_optional_string_list(decoded_map, "resolvedSecrets")
+    refreshed_connectors = _parse_optional_string_list(decoded_map, "refreshedConnectors")
+    refreshed_secrets = _parse_optional_string_list(decoded_map, "refreshedSecrets")
+    query = _parse_optional_string_map(decoded_map, "query")
     payload = _FirewallAuthPayload(
-        headers=_parse_string_map(decoded_map["headers"], "headers"),
-        resolved_secrets=_parse_optional_string_list(decoded_map, "resolvedSecrets"),
+        headers=headers,
+        resolved_secrets=resolved_secrets,
         base=base,
-        query=_parse_optional_string_map(decoded_map, "query"),
+        query=query,
     )
     return _FirewallAuthSuccess(
         payload=payload,
         expires_at=decoded_map.get("expiresAt"),
-        refreshed_connectors=_parse_optional_string_list(decoded_map, "refreshedConnectors"),
-        refreshed_secrets=_parse_optional_string_list(decoded_map, "refreshedSecrets"),
+        refreshed_connectors=refreshed_connectors,
+        refreshed_secrets=refreshed_secrets,
     )
 
 

--- a/crates/runner/mitm-addon/tests/auth_state_helpers.py
+++ b/crates/runner/mitm-addon/tests/auth_state_helpers.py
@@ -21,11 +21,13 @@ def set_cached_headers(
     query: dict | None = None,
 ) -> None:
     auth._get_auth_state(cache_key).cache = auth._FirewallHeaderCacheEntry(
-        headers=headers,
+        payload=auth._FirewallAuthPayload(
+            headers=headers,
+            resolved_secrets=resolved_secrets or [],
+            base=base,
+            query=query,
+        ),
         expires_at=expires_at,
-        resolved_secrets=resolved_secrets or [],
-        base=base,
-        query=query,
     )
 
 

--- a/crates/runner/mitm-addon/tests/test_auth_cache.py
+++ b/crates/runner/mitm-addon/tests/test_auth_cache.py
@@ -17,7 +17,10 @@ from tests.auth_state_helpers import (
 
 
 def _auth_success(headers: dict[str, str], expires_at: object) -> auth._FirewallAuthSuccess:
-    return auth._FirewallAuthSuccess(headers=headers, expires_at=expires_at)
+    return auth._FirewallAuthSuccess(
+        payload=auth._FirewallAuthPayload(headers=headers),
+        expires_at=expires_at,
+    )
 
 
 class TestFirewallHeaderCache:

--- a/crates/runner/mitm-addon/tests/test_firewall_auth.py
+++ b/crates/runner/mitm-addon/tests/test_firewall_auth.py
@@ -48,13 +48,15 @@ def _auth_success(
     query: dict[str, str] | None = None,
 ) -> auth._FirewallAuthSuccess:
     return auth._FirewallAuthSuccess(
-        headers=headers,
+        payload=auth._FirewallAuthPayload(
+            headers=headers,
+            resolved_secrets=resolved_secrets or [],
+            base=base,
+            query=query,
+        ),
         expires_at=expires_at,
-        resolved_secrets=resolved_secrets or [],
         refreshed_connectors=refreshed_connectors or [],
         refreshed_secrets=refreshed_secrets or [],
-        base=base,
-        query=query,
     )
 
 
@@ -97,6 +99,8 @@ class TestGetFirewallHeaders:
 
         assert headers["headers"] == mock_headers
         assert headers["cache_hit"] is False
+        assert headers["refreshed_connectors"] == []
+        assert headers["refreshed_secrets"] == []
         mock_fetch.assert_called_once()
         assert mock_fetch.call_args.args == (encrypted, auth_templates, "tok-xyz")
         assert mock_fetch.call_args.kwargs == {
@@ -112,7 +116,7 @@ class TestGetFirewallHeaders:
         # Verify the cache was populated
         cache_key = ("run-1", "https://api.github.com")
         assert cached_headers(cache_key)
-        assert require_cached_headers(cache_key).headers == mock_headers
+        assert require_cached_headers(cache_key).payload.headers == mock_headers
 
     async def test_cache_hit_returns_cached(self, headers):
         cache_key = ("run-1", "https://api.github.com")
@@ -172,7 +176,7 @@ class TestGetFirewallHeaders:
         # fetch_firewall_headers wraps urllib; pins the TTL-expiry→re-fetch contract (#9991).
         mock_fetch.assert_called_once()
         # Verify cache was updated with new entry
-        assert require_cached_headers(cache_key).headers == fresh_headers
+        assert require_cached_headers(cache_key).payload.headers == fresh_headers
 
     async def test_cache_with_null_expires_at_never_evicts(self, headers):
         """Cached entry with expiresAt=None (non-expiring) should never be evicted by TTL."""
@@ -374,7 +378,7 @@ class TestGetFirewallHeaders:
         assert second["query"] == cached_query
         assert second["cache_hit"] is True
         mock_fetch.assert_called_once()
-        assert require_cached_headers(cache_key).query == cached_query
+        assert require_cached_headers(cache_key).payload.query == cached_query
 
     async def test_base_and_query_are_cached_together(self):
         """auth.base and auth.query survive the same cache entry."""
@@ -401,8 +405,8 @@ class TestGetFirewallHeaders:
         assert second["cache_hit"] is True
         mock_fetch.assert_called_once()
         cached = require_cached_headers(cache_key)
-        assert cached.base == cached_base
-        assert cached.query == cached_query
+        assert cached.payload.base == cached_base
+        assert cached.payload.query == cached_query
 
     async def test_cache_hit_omits_base_when_absent(self, headers):
         """Cached entry without 'base' does not include it in result."""
@@ -510,7 +514,7 @@ class TestGetFirewallHeaders:
         assert forced_result["cache_hit"] is False
         assert not force_refresh_pending(cache_key)
         assert require_last_force_refresh_at(cache_key) >= before_forced
-        assert require_cached_headers(cache_key).headers == forced_headers
+        assert require_cached_headers(cache_key).payload.headers == forced_headers
 
     async def test_waiting_request_force_refreshes_after_in_flight_marker(self, headers):
         """A same-key waiter must not reuse headers from the stale-prone leader fetch."""
@@ -555,7 +559,9 @@ class TestGetFirewallHeaders:
         assert force_refresh_values == [False, True]
         assert leader_result["headers"] == {"Authorization": "Bearer maybe-stale"}
         assert waiter_result["headers"] == {"Authorization": "Bearer refreshed"}
-        assert require_cached_headers(cache_key).headers == {"Authorization": "Bearer refreshed"}
+        assert require_cached_headers(cache_key).payload.headers == {
+            "Authorization": "Bearer refreshed"
+        }
         assert not force_refresh_pending(cache_key)
 
     async def test_force_refresh_absent_passes_false(self, headers):
@@ -1254,9 +1260,9 @@ class TestFetchFirewallHeaders:
                 "https://api.vm0.ai",
             )
 
-        assert result.headers == {"Authorization": "Bearer tok"}
-        assert result.base is None
-        assert result.query is None
+        assert result.payload.headers == {"Authorization": "Bearer tok"}
+        assert result.payload.base is None
+        assert result.payload.query is None
 
         # urllib.request.Request construction is the external boundary (#9991).
         mock_req_cls.assert_called_once()
@@ -1338,14 +1344,14 @@ class TestFetchFirewallHeaders:
             )
 
         assert isinstance(result, auth._FirewallAuthSuccess)
-        assert result.headers == {
+        assert result.payload.headers == {
             "Authorization": "Bearer tok",
             "X-Custom": "custom",
         }
-        assert result.base == "https://example.com/webhook/secret"
-        assert result.query == {"api_key": "resolved-key"}
+        assert result.payload.base == "https://example.com/webhook/secret"
+        assert result.payload.query == {"api_key": "resolved-key"}
         assert result.expires_at == expires_at
-        assert result.resolved_secrets == ["API_TOKEN"]
+        assert result.payload.resolved_secrets == ["API_TOKEN"]
         assert result.refreshed_connectors == ["notion"]
         assert result.refreshed_secrets == ["NOTION_TOKEN"]
         assert not hasattr(result, "futureField")
@@ -1414,7 +1420,7 @@ class TestFetchFirewallHeaders:
                 auth_base="${{ secrets.DISCORD_WEBHOOK_URL }}",
             )
 
-        assert result.base == "https://discord.com/api/webhooks/123/abc"
+        assert result.payload.base == "https://discord.com/api/webhooks/123/abc"
         body = json.loads(mock_req_cls.call_args[1]["data"])
         assert body["authBase"] == "${{ secrets.DISCORD_WEBHOOK_URL }}"
 
@@ -1443,8 +1449,8 @@ class TestFetchFirewallHeaders:
                 auth_query={"api_key": "${{ secrets.API_KEY }}"},
             )
 
-        assert result.base == "https://example.com/webhook/secret"
-        assert result.query == {"api_key": "resolved-key"}
+        assert result.payload.base == "https://example.com/webhook/secret"
+        assert result.payload.query == {"api_key": "resolved-key"}
         body = json.loads(mock_req_cls.call_args[1]["data"])
         assert body["authBase"] == "${{ secrets.WEBHOOK_URL }}"
         assert body["authQuery"] == {"api_key": "${{ secrets.API_KEY }}"}
@@ -1820,7 +1826,7 @@ class TestFetchFirewallHeaders:
         ):
             result = await auth.fetch_firewall_headers("enc", {}, "sandbox-tok")
 
-        assert result.headers == {"Auth": "tok"}
+        assert result.payload.headers == {"Auth": "tok"}
         # Verify the URL was built from the ctx-provided api_url
         call_args = mock_req_cls.call_args
         assert call_args[0][0] == "https://ctx-url.vm0.ai/api/webhooks/agent/firewall/auth"


### PR DESCRIPTION
## Summary

- Add a private firewall auth payload shape for cacheable request auth data.
- Keep cache policy and fresh-fetch refresh metadata separate.
- Build cache-hit and fresh-fetch token metadata through one helper while preserving existing dict behavior.

Closes #15700

## Tests

- `PATH=/tmp/vm7-mitm-addon-deps/bin:/home/vscode/.codex/tmp/arg0/codex-arg0oDPXXl:/home/vscode/.local/bin:/usr/local/go/bin:/home/vscode/go/bin:/home/vscode/.local/bin:/usr/local/go/bin:/home/vscode/go/bin:/home/vscode/.local/bin:/home/vscode/.local/share/pnpm:/usr/local/go/bin:/home/vscode/go/bin:/home/vscode/.cache/cargo/bin:/home/vscode/.local/bin:/workspaces/vm4/bin:/opt/aarch64--musl--stable-2025.08-1/bin:/usr/local/cargo/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin PYTHONPATH=src:/tmp/vm7-mitm-addon-deps python3 -m pytest tests/test_firewall_auth.py tests/test_auth_cache.py -q`
- `PATH=/tmp/vm7-mitm-addon-deps/bin:/home/vscode/.codex/tmp/arg0/codex-arg0oDPXXl:/home/vscode/.local/bin:/usr/local/go/bin:/home/vscode/go/bin:/home/vscode/.local/bin:/usr/local/go/bin:/home/vscode/go/bin:/home/vscode/.local/bin:/home/vscode/.local/share/pnpm:/usr/local/go/bin:/home/vscode/go/bin:/home/vscode/.cache/cargo/bin:/home/vscode/.local/bin:/workspaces/vm4/bin:/opt/aarch64--musl--stable-2025.08-1/bin:/usr/local/cargo/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin PYTHONPATH=src:/tmp/vm7-mitm-addon-deps python3 -m ruff format --check src/auth.py tests/test_firewall_auth.py tests/test_auth_cache.py tests/auth_state_helpers.py`
- `PATH=/tmp/vm7-mitm-addon-deps/bin:/home/vscode/.codex/tmp/arg0/codex-arg0oDPXXl:/home/vscode/.local/bin:/usr/local/go/bin:/home/vscode/go/bin:/home/vscode/.local/bin:/usr/local/go/bin:/home/vscode/go/bin:/home/vscode/.local/bin:/home/vscode/.local/share/pnpm:/usr/local/go/bin:/home/vscode/go/bin:/home/vscode/.cache/cargo/bin:/home/vscode/.local/bin:/workspaces/vm4/bin:/opt/aarch64--musl--stable-2025.08-1/bin:/usr/local/cargo/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin PYTHONPATH=src:/tmp/vm7-mitm-addon-deps python3 -m ruff check src/auth.py tests/test_firewall_auth.py tests/test_auth_cache.py tests/auth_state_helpers.py`
- `PATH=/tmp/vm7-mitm-addon-deps/bin:/home/vscode/.codex/tmp/arg0/codex-arg0oDPXXl:/home/vscode/.local/bin:/usr/local/go/bin:/home/vscode/go/bin:/home/vscode/.local/bin:/usr/local/go/bin:/home/vscode/go/bin:/home/vscode/.local/bin:/home/vscode/.local/share/pnpm:/usr/local/go/bin:/home/vscode/go/bin:/home/vscode/.cache/cargo/bin:/home/vscode/.local/bin:/workspaces/vm4/bin:/opt/aarch64--musl--stable-2025.08-1/bin:/usr/local/cargo/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin PYTHONPATH=src:/tmp/vm7-mitm-addon-deps basedpyright -p .`
- `PATH=/tmp/vm7-mitm-addon-deps/bin:/home/vscode/.codex/tmp/arg0/codex-arg0oDPXXl:/home/vscode/.local/bin:/usr/local/go/bin:/home/vscode/go/bin:/home/vscode/.local/bin:/usr/local/go/bin:/home/vscode/go/bin:/home/vscode/.local/bin:/home/vscode/.local/share/pnpm:/usr/local/go/bin:/home/vscode/go/bin:/home/vscode/.cache/cargo/bin:/home/vscode/.local/bin:/workspaces/vm4/bin:/opt/aarch64--musl--stable-2025.08-1/bin:/usr/local/cargo/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin PYTHONPATH=src:/tmp/vm7-mitm-addon-deps python3 -m pytest tests -q`