### PR TITLE
test: cover sandbox control request timeout

### DIFF
--- a/crates/sandbox-fc/src/control/client.rs
+++ b/crates/sandbox-fc/src/control/client.rs
@@ -44,7 +44,7 @@ mod tests {
     use super::*;
 
     #[tokio::test]
-    async fn send_exec_connect_timeout() {
+    async fn send_exec_missing_socket_returns_not_found() {
         let dir = tempfile::tempdir().unwrap();
         let sock_path = dir.path().join("nonexistent.sock");
 
@@ -55,6 +55,47 @@ mod tests {
         };
 
         let result = send_exec(&sock_path, &request, Duration::from_millis(100)).await;
-        assert!(result.is_err());
+        let error = result.unwrap_err();
+        assert_eq!(error.kind(), io::ErrorKind::NotFound);
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn send_exec_times_out_waiting_for_response() {
+        use tokio::net::UnixListener;
+        use tokio::sync::oneshot;
+
+        let dir = tempfile::tempdir().unwrap();
+        let sock_path = dir.path().join("control.sock");
+        let listener = UnixListener::bind(&sock_path).unwrap();
+        let (request_seen_tx, request_seen_rx) = oneshot::channel();
+        let (release_tx, release_rx) = oneshot::channel::<()>();
+        let server = tokio::spawn(async move {
+            let (mut stream, _) = listener.accept().await.unwrap();
+            let request_json = read_frame(&mut stream).await.unwrap();
+            let request: ExecRequest = serde_json::from_slice(&request_json).unwrap();
+            assert_eq!(request.command, "echo test");
+            request_seen_tx.send(()).unwrap();
+            let _stream = stream;
+            let _ = release_rx.await;
+        });
+
+        let client = tokio::spawn(async move {
+            let request = ExecRequest {
+                command: "echo test".into(),
+                timeout_secs: 5,
+                sudo: false,
+            };
+            send_exec(&sock_path, &request, Duration::from_secs(5)).await
+        });
+
+        request_seen_rx.await.unwrap();
+        tokio::time::advance(Duration::from_secs(5)).await;
+
+        let error = client.await.unwrap().unwrap_err();
+        assert_eq!(error.kind(), io::ErrorKind::TimedOut);
+        assert_eq!(error.to_string(), "request timed out");
+
+        release_tx.send(()).unwrap();
+        server.await.unwrap();
     }
 }

--- a/crates/sandbox-fc/src/control/provider.rs
+++ b/crates/sandbox-fc/src/control/provider.rs
@@ -40,9 +40,9 @@ impl SandboxControl for FirecrackerControl {
             sudo,
         };
 
-        // Add 5 seconds buffer for connection overhead beyond the command timeout.
-        let connect_timeout = timeout + Duration::from_secs(5);
-        let response = send_exec(&sock_path, &request, connect_timeout)
+        // Add 5 seconds for control socket overhead beyond the command timeout.
+        let control_timeout = timeout + Duration::from_secs(5);
+        let response = send_exec(&sock_path, &request, control_timeout)
             .await
             .map_err(|e| {
                 SandboxControlError::Connection(format!("failed to connect to sandbox: {e}"))


### PR DESCRIPTION
## Summary

- Split the misleading missing-socket control client test into a precise immediate-error assertion.
- Add deterministic request-timeout coverage using a real Unix listener that accepts and holds the connection open.
- Rename the provider-side timeout local to reflect the full control request budget.

Fixes #15704

## Tests

- `cargo test --manifest-path crates/Cargo.toml -p sandbox-fc control::client::tests::`
- `cargo fmt --manifest-path crates/sandbox-fc/Cargo.toml --check`
- `cargo clippy --manifest-path crates/Cargo.toml -p sandbox-fc --all-targets --all-features -- -D warnings`
- `cargo clippy --all-targets --all-features` from `crates/`
