### PR TITLE
feat: add user permission grants api

### DIFF
--- a/turbo/apps/api/src/signals/route.ts
+++ b/turbo/apps/api/src/signals/route.ts
@@ -150,6 +150,7 @@ import { zeroUsageInsightRoutes } from "./routes/zero-usage-insight";
 import { zeroUsageMembersRoutes } from "./routes/zero-usage-members";
 import { zeroUsageRunsRoutes } from "./routes/zero-usage-runs";
 import { zeroUserPreferencesRoutes } from "./routes/zero-user-preferences";
+import { zeroUserPermissionGrantsRoutes } from "./routes/zero-user-permission-grants";
 import { zeroUserModelPreferenceRoutes } from "./routes/zero-user-model-preference";
 import { zeroVoiceIoQuotaRoutes } from "./routes/zero-voice-io-quota";
 import { zeroVoiceIoSpeechRoutes } from "./routes/zero-voice-io-speech";
@@ -300,6 +301,7 @@ export const ROUTES: readonly RouteEntry[] = [
   ...zeroPermissionAccessRequestsRoutes,
   ...zeroPermissionPoliciesRoutes,
   ...zeroPushSubscriptionsRoutes,
+  ...zeroUserPermissionGrantsRoutes,
   ...zeroUserPreferencesRoutes,
   ...zeroUserModelPreferenceRoutes,
   ...zeroSecretsRoutes,

--- a/turbo/apps/api/src/signals/routes/__tests__/zero-user-permission-grants.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/zero-user-permission-grants.test.ts
@@ -1,0 +1,542 @@
+import { randomUUID } from "node:crypto";
+
+import { createStore } from "ccstate";
+import { and, eq, inArray } from "drizzle-orm";
+import { afterEach, describe, expect, it } from "vitest";
+
+import { zeroUserPermissionGrantsContract } from "@vm0/api-contracts/contracts/zero-user-permission-grants";
+import { FeatureSwitchKey } from "@vm0/connectors/feature-switch-key";
+import { UNKNOWN_PERMISSION_GRANT } from "@vm0/connectors/firewall-types";
+import { userFeatureSwitches } from "@vm0/db/schema/user-feature-switches";
+import { userPermissionGrants } from "@vm0/db/schema/user-permission-grant";
+
+import { accept, setupApp, testContext } from "../../../__tests__/test-helpers";
+import { createApp } from "../../../app-factory";
+import { writeDb$ } from "../../external/db";
+import {
+  foldUserPermissionGrantsToFirewallPolicies,
+  loadActiveUserPermissionGrants,
+} from "../../services/zero-user-permission-grants.service";
+import {
+  deleteOrgMembership$,
+  seedOrgMembership$,
+} from "./helpers/zero-org-membership";
+import { createZeroRouteMocks } from "./helpers/zero-route-test";
+import {
+  deleteUsageInsightFixture$,
+  seedCompose$,
+  seedUsageInsightFixture$,
+  type UsageInsightFixture,
+} from "./helpers/zero-usage-insight";
+
+const context = testContext();
+const store = createStore();
+const mocks = createZeroRouteMocks(context);
+
+const AUTH_HEADERS = { authorization: "Bearer clerk-session" } as const;
+const SLACK_CONNECTOR = "slack";
+const SLACK_READ_PERMISSION = "channels:read";
+const SLACK_WRITE_PERMISSION = "chat:write";
+
+async function seedMember(args: {
+  readonly orgId: string;
+  readonly userId: string;
+  readonly role?: "admin" | "member";
+}): Promise<void> {
+  await store.set(
+    seedOrgMembership$,
+    {
+      orgId: args.orgId,
+      userId: args.userId,
+      role: args.role ?? "member",
+      seedOrgCache: false,
+    },
+    context.signal,
+  );
+}
+
+async function enableUserPermissionGrants(
+  orgId: string,
+  userId: string,
+): Promise<void> {
+  const db = store.set(writeDb$);
+  await db
+    .insert(userFeatureSwitches)
+    .values({
+      orgId,
+      userId,
+      switches: { [FeatureSwitchKey.UserPermissionGrants]: true },
+    })
+    .onConflictDoUpdate({
+      target: [userFeatureSwitches.orgId, userFeatureSwitches.userId],
+      set: { switches: { [FeatureSwitchKey.UserPermissionGrants]: true } },
+    });
+}
+
+async function seedAgent(args: {
+  readonly orgId: string;
+  readonly userId: string;
+  readonly visibility?: "public" | "private";
+}): Promise<string> {
+  const { agentId } = await store.set(
+    seedCompose$,
+    {
+      orgId: args.orgId,
+      userId: args.userId,
+      visibility: args.visibility,
+    },
+    context.signal,
+  );
+  return agentId;
+}
+
+async function readStoredGrant(args: {
+  readonly orgId: string;
+  readonly userId: string;
+  readonly agentId: string;
+  readonly connectorRef: string;
+  readonly permission: string;
+}) {
+  const db = store.set(writeDb$);
+  const [row] = await db
+    .select()
+    .from(userPermissionGrants)
+    .where(
+      and(
+        eq(userPermissionGrants.orgId, args.orgId),
+        eq(userPermissionGrants.userId, args.userId),
+        eq(userPermissionGrants.agentId, args.agentId),
+        eq(userPermissionGrants.connectorRef, args.connectorRef),
+        eq(userPermissionGrants.permission, args.permission),
+      ),
+    )
+    .limit(1);
+  return row ?? null;
+}
+
+describe("zero user permission grants", () => {
+  const fixtures: UsageInsightFixture[] = [];
+  const trackedOrgIds: string[] = [];
+
+  async function createFixture(
+    role: "admin" | "member" = "member",
+  ): Promise<UsageInsightFixture> {
+    const fixture = await store.set(
+      seedUsageInsightFixture$,
+      undefined,
+      context.signal,
+    );
+    fixtures.push(fixture);
+    trackedOrgIds.push(fixture.orgId);
+    await store.set(
+      seedOrgMembership$,
+      { orgId: fixture.orgId, userId: fixture.userId, role },
+      context.signal,
+    );
+    return fixture;
+  }
+
+  afterEach(async () => {
+    const db = store.set(writeDb$);
+    if (trackedOrgIds.length > 0) {
+      await db
+        .delete(userPermissionGrants)
+        .where(inArray(userPermissionGrants.orgId, trackedOrgIds));
+      await db
+        .delete(userFeatureSwitches)
+        .where(inArray(userFeatureSwitches.orgId, trackedOrgIds));
+      trackedOrgIds.length = 0;
+    }
+
+    while (fixtures.length > 0) {
+      const fixture = fixtures.pop();
+      if (fixture) {
+        await store.set(deleteUsageInsightFixture$, fixture, context.signal);
+        await store.set(deleteOrgMembership$, fixture, context.signal);
+      }
+    }
+  });
+
+  it("blocks list and upsert while the feature is disabled", async () => {
+    const fixture = await createFixture();
+    const agentId = await seedAgent(fixture);
+    mocks.clerk.session(fixture.userId, fixture.orgId, "org:member");
+    const client = setupApp({ context })(zeroUserPermissionGrantsContract);
+
+    const listed = await accept(
+      client.list({
+        query: { agentId },
+        headers: AUTH_HEADERS,
+      }),
+      [403],
+    );
+    expect(listed.body.error.code).toBe("FORBIDDEN");
+
+    const upserted = await accept(
+      client.upsert({
+        body: {
+          agentId,
+          connectorRef: SLACK_CONNECTOR,
+          permission: SLACK_READ_PERMISSION,
+          action: "allow",
+          ttlSeconds: 300,
+        },
+        headers: AUTH_HEADERS,
+      }),
+      [403],
+    );
+    expect(upserted.body.error.code).toBe("FORBIDDEN");
+  });
+
+  it("upserts and lists only the authenticated user's active grants", async () => {
+    const fixture = await createFixture();
+    const otherUserId = `user_${randomUUID()}`;
+    await seedMember({ orgId: fixture.orgId, userId: otherUserId });
+    const agentId = await seedAgent(fixture);
+    await enableUserPermissionGrants(fixture.orgId, fixture.userId);
+    mocks.clerk.session(fixture.userId, fixture.orgId, "org:member");
+
+    const client = setupApp({ context })(zeroUserPermissionGrantsContract);
+    const upserted = await accept(
+      client.upsert({
+        body: {
+          agentId,
+          connectorRef: SLACK_CONNECTOR,
+          permission: SLACK_READ_PERMISSION,
+          action: "allow",
+          ttlSeconds: 300,
+        },
+        headers: AUTH_HEADERS,
+      }),
+      [200],
+    );
+
+    expect(upserted.body).toMatchObject({
+      agentId,
+      connectorRef: SLACK_CONNECTOR,
+      permission: SLACK_READ_PERMISSION,
+      action: "allow",
+    });
+    expect(upserted.body.expiresAt).not.toBeNull();
+
+    const db = store.set(writeDb$);
+    await db.insert(userPermissionGrants).values({
+      orgId: fixture.orgId,
+      userId: otherUserId,
+      agentId,
+      connectorRef: SLACK_CONNECTOR,
+      permission: SLACK_WRITE_PERMISSION,
+      action: "deny",
+      expiresAt: new Date("2099-01-01T00:00:00.000Z"),
+    });
+
+    const listed = await accept(
+      client.list({
+        query: { agentId },
+        headers: AUTH_HEADERS,
+      }),
+      [200],
+    );
+
+    expect(listed.body).toHaveLength(1);
+    expect(listed.body[0]).toMatchObject({
+      agentId,
+      connectorRef: SLACK_CONNECTOR,
+      permission: SLACK_READ_PERMISSION,
+      action: "allow",
+    });
+
+    const stored = await readStoredGrant({
+      orgId: fixture.orgId,
+      userId: fixture.userId,
+      agentId,
+      connectorRef: SLACK_CONNECTOR,
+      permission: SLACK_READ_PERMISSION,
+    });
+    expect(stored?.userId).toBe(fixture.userId);
+  });
+
+  it("uses visible-agent scope for private and cross-org agents", async () => {
+    const owner = await createFixture();
+    const otherOrgUser = await createFixture();
+    const sameOrgUserId = `user_${randomUUID()}`;
+    await seedMember({ orgId: owner.orgId, userId: sameOrgUserId });
+    const privateAgentId = await seedAgent({
+      orgId: owner.orgId,
+      userId: owner.userId,
+      visibility: "private",
+    });
+
+    await enableUserPermissionGrants(owner.orgId, owner.userId);
+    await enableUserPermissionGrants(owner.orgId, sameOrgUserId);
+    await enableUserPermissionGrants(otherOrgUser.orgId, otherOrgUser.userId);
+    const client = setupApp({ context })(zeroUserPermissionGrantsContract);
+
+    mocks.clerk.session(owner.userId, owner.orgId, "org:member");
+    const ownerResponse = await accept(
+      client.upsert({
+        body: {
+          agentId: privateAgentId,
+          connectorRef: SLACK_CONNECTOR,
+          permission: SLACK_READ_PERMISSION,
+          action: "allow",
+          ttlSeconds: 300,
+        },
+        headers: AUTH_HEADERS,
+      }),
+      [200],
+    );
+    expect(ownerResponse.body.agentId).toBe(privateAgentId);
+
+    mocks.clerk.session(sameOrgUserId, owner.orgId, "org:member");
+    const sameOrgResponse = await accept(
+      client.upsert({
+        body: {
+          agentId: privateAgentId,
+          connectorRef: SLACK_CONNECTOR,
+          permission: SLACK_READ_PERMISSION,
+          action: "allow",
+          ttlSeconds: 300,
+        },
+        headers: AUTH_HEADERS,
+      }),
+      [404],
+    );
+    expect(sameOrgResponse.body.error.code).toBe("NOT_FOUND");
+
+    mocks.clerk.session(otherOrgUser.userId, otherOrgUser.orgId, "org:member");
+    const crossOrgResponse = await accept(
+      client.list({
+        query: { agentId: privateAgentId },
+        headers: AUTH_HEADERS,
+      }),
+      [404],
+    );
+    expect(crossOrgResponse.body.error.code).toBe("NOT_FOUND");
+
+    const missingResponse = await accept(
+      client.list({
+        query: { agentId: randomUUID() },
+        headers: AUTH_HEADERS,
+      }),
+      [404],
+    );
+    expect(missingResponse.body.error.code).toBe("NOT_FOUND");
+  });
+
+  it("validates connector refs, permission names, ask, and __unknown__", async () => {
+    const fixture = await createFixture();
+    const agentId = await seedAgent(fixture);
+    await enableUserPermissionGrants(fixture.orgId, fixture.userId);
+    mocks.clerk.session(fixture.userId, fixture.orgId, "org:member");
+    const client = setupApp({ context })(zeroUserPermissionGrantsContract);
+
+    const unknownConnector = await accept(
+      client.upsert({
+        body: {
+          agentId,
+          connectorRef: "not-a-real-connector",
+          permission: SLACK_READ_PERMISSION,
+          action: "allow",
+          ttlSeconds: 300,
+        },
+        headers: AUTH_HEADERS,
+      }),
+      [400],
+    );
+    expect(unknownConnector.body.error.code).toBe("VALIDATION_ERROR");
+
+    const unknownPermission = await accept(
+      client.upsert({
+        body: {
+          agentId,
+          connectorRef: SLACK_CONNECTOR,
+          permission: "not-a-real-permission",
+          action: "allow",
+          ttlSeconds: 300,
+        },
+        headers: AUTH_HEADERS,
+      }),
+      [400],
+    );
+    expect(unknownPermission.body.error.code).toBe("VALIDATION_ERROR");
+
+    const unknownGrant = await accept(
+      client.upsert({
+        body: {
+          agentId,
+          connectorRef: SLACK_CONNECTOR,
+          permission: UNKNOWN_PERMISSION_GRANT,
+          action: "deny",
+          ttlSeconds: 300,
+        },
+        headers: AUTH_HEADERS,
+      }),
+      [200],
+    );
+    expect(unknownGrant.body).toMatchObject({
+      connectorRef: SLACK_CONNECTOR,
+      permission: UNKNOWN_PERMISSION_GRANT,
+      action: "deny",
+    });
+
+    const app = createApp({ signal: context.signal });
+    const askResponse = await app.request("/api/zero/user-permission-grants", {
+      method: "PUT",
+      headers: {
+        authorization: AUTH_HEADERS.authorization,
+        "content-type": "application/json",
+      },
+      body: JSON.stringify({
+        agentId,
+        connectorRef: SLACK_CONNECTOR,
+        permission: SLACK_READ_PERMISSION,
+        action: "ask",
+        ttlSeconds: 300,
+      }),
+    });
+    expect(askResponse.status).toBe(400);
+  });
+
+  it("filters expired grants and folds active grants into legacy policies", async () => {
+    const fixture = await createFixture();
+    const agentId = await seedAgent(fixture);
+    await enableUserPermissionGrants(fixture.orgId, fixture.userId);
+    mocks.clerk.session(fixture.userId, fixture.orgId, "org:member");
+    const db = store.set(writeDb$);
+
+    await db.insert(userPermissionGrants).values([
+      {
+        orgId: fixture.orgId,
+        userId: fixture.userId,
+        agentId,
+        connectorRef: SLACK_CONNECTOR,
+        permission: SLACK_READ_PERMISSION,
+        action: "allow",
+        expiresAt: new Date("2020-01-01T00:00:00.000Z"),
+      },
+      {
+        orgId: fixture.orgId,
+        userId: fixture.userId,
+        agentId,
+        connectorRef: SLACK_CONNECTOR,
+        permission: SLACK_WRITE_PERMISSION,
+        action: "deny",
+        expiresAt: new Date("2099-01-01T00:00:00.000Z"),
+      },
+      {
+        orgId: fixture.orgId,
+        userId: fixture.userId,
+        agentId,
+        connectorRef: SLACK_CONNECTOR,
+        permission: UNKNOWN_PERMISSION_GRANT,
+        action: "deny",
+        expiresAt: null,
+      },
+    ]);
+
+    const client = setupApp({ context })(zeroUserPermissionGrantsContract);
+    const listed = await accept(
+      client.list({
+        query: { agentId },
+        headers: AUTH_HEADERS,
+      }),
+      [200],
+    );
+    expect(
+      listed.body.map((grant) => {
+        return grant.permission;
+      }),
+    ).toStrictEqual([UNKNOWN_PERMISSION_GRANT, SLACK_WRITE_PERMISSION]);
+
+    const active = await loadActiveUserPermissionGrants(db, {
+      orgId: fixture.orgId,
+      userId: fixture.userId,
+      agentId,
+    });
+    expect(
+      active.map((grant) => {
+        return grant.permission;
+      }),
+    ).toStrictEqual([UNKNOWN_PERMISSION_GRANT, SLACK_WRITE_PERMISSION]);
+
+    expect(foldUserPermissionGrantsToFirewallPolicies(active)).toStrictEqual({
+      slack: {
+        policies: { [SLACK_WRITE_PERMISSION]: "deny" },
+        unknownPolicy: "deny",
+      },
+    });
+    expect(foldUserPermissionGrantsToFirewallPolicies([])).toBeNull();
+  });
+
+  it("updates action, expiresAt, and updatedAt without changing createdAt", async () => {
+    const fixture = await createFixture();
+    const agentId = await seedAgent(fixture);
+    await enableUserPermissionGrants(fixture.orgId, fixture.userId);
+    mocks.clerk.session(fixture.userId, fixture.orgId, "org:member");
+    const client = setupApp({ context })(zeroUserPermissionGrantsContract);
+
+    await accept(
+      client.upsert({
+        body: {
+          agentId,
+          connectorRef: SLACK_CONNECTOR,
+          permission: SLACK_READ_PERMISSION,
+          action: "allow",
+          ttlSeconds: 300,
+        },
+        headers: AUTH_HEADERS,
+      }),
+      [200],
+    );
+
+    const oldTimestamp = new Date("2024-01-01T00:00:00.000Z");
+    const oldExpiresAt = new Date("2024-01-01T00:05:00.000Z");
+    const db = store.set(writeDb$);
+    await db
+      .update(userPermissionGrants)
+      .set({
+        createdAt: oldTimestamp,
+        updatedAt: oldTimestamp,
+        expiresAt: oldExpiresAt,
+      })
+      .where(
+        and(
+          eq(userPermissionGrants.orgId, fixture.orgId),
+          eq(userPermissionGrants.userId, fixture.userId),
+          eq(userPermissionGrants.agentId, agentId),
+          eq(userPermissionGrants.connectorRef, SLACK_CONNECTOR),
+          eq(userPermissionGrants.permission, SLACK_READ_PERMISSION),
+        ),
+      );
+
+    const second = await accept(
+      client.upsert({
+        body: {
+          agentId,
+          connectorRef: SLACK_CONNECTOR,
+          permission: SLACK_READ_PERMISSION,
+          action: "deny",
+          ttlSeconds: 900,
+        },
+        headers: AUTH_HEADERS,
+      }),
+      [200],
+    );
+    expect(second.body.action).toBe("deny");
+
+    const stored = await readStoredGrant({
+      orgId: fixture.orgId,
+      userId: fixture.userId,
+      agentId,
+      connectorRef: SLACK_CONNECTOR,
+      permission: SLACK_READ_PERMISSION,
+    });
+    expect(stored?.action).toBe("deny");
+    expect(stored?.createdAt.getTime()).toBe(oldTimestamp.getTime());
+    expect(stored?.updatedAt.getTime()).toBeGreaterThan(oldTimestamp.getTime());
+    expect(stored?.expiresAt?.getTime()).toBeGreaterThan(
+      oldExpiresAt.getTime(),
+    );
+  });
+});

--- a/turbo/apps/api/src/signals/routes/__tests__/zero-user-permission-grants.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/zero-user-permission-grants.test.ts
@@ -366,6 +366,23 @@ describe("zero user permission grants", () => {
     );
     expect(unknownConnector.body.error.code).toBe("VALIDATION_ERROR");
 
+    const unknownPermissionForUnknownConnector = await accept(
+      client.upsert({
+        body: {
+          agentId,
+          connectorRef: "not-a-real-connector",
+          permission: UNKNOWN_PERMISSION_GRANT,
+          action: "allow",
+          ttlSeconds: 300,
+        },
+        headers: AUTH_HEADERS,
+      }),
+      [400],
+    );
+    expect(unknownPermissionForUnknownConnector.body.error.code).toBe(
+      "VALIDATION_ERROR",
+    );
+
     const unknownPermission = await accept(
       client.upsert({
         body: {
@@ -443,6 +460,7 @@ describe("zero user permission grants", () => {
     await enableUserPermissionGrants(fixture.orgId, fixture.userId);
     mocks.clerk.session(fixture.userId, fixture.orgId, "org:member");
     const db = store.set(writeDb$);
+    const checkedAt = new Date("2026-01-01T00:00:00.000Z");
 
     await db.insert(userPermissionGrants).values([
       {
@@ -452,7 +470,16 @@ describe("zero user permission grants", () => {
         connectorRef: SLACK_CONNECTOR,
         permission: SLACK_READ_PERMISSION,
         action: "allow",
-        expiresAt: new Date("2020-01-01T00:00:00.000Z"),
+        expiresAt: new Date("2025-12-31T23:59:59.000Z"),
+      },
+      {
+        orgId: fixture.orgId,
+        userId: fixture.userId,
+        agentId,
+        connectorRef: SLACK_CONNECTOR,
+        permission: "channels:history",
+        action: "allow",
+        expiresAt: checkedAt,
       },
       {
         orgId: fixture.orgId,
@@ -488,11 +515,15 @@ describe("zero user permission grants", () => {
       }),
     ).toStrictEqual([UNKNOWN_PERMISSION_GRANT, SLACK_WRITE_PERMISSION]);
 
-    const active = await loadActiveUserPermissionGrants(db, {
-      orgId: fixture.orgId,
-      userId: fixture.userId,
-      agentId,
-    });
+    const active = await loadActiveUserPermissionGrants(
+      db,
+      {
+        orgId: fixture.orgId,
+        userId: fixture.userId,
+        agentId,
+      },
+      checkedAt,
+    );
     expect(
       active.map((grant) => {
         return grant.permission;

--- a/turbo/apps/api/src/signals/routes/__tests__/zero-user-permission-grants.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/zero-user-permission-grants.test.ts
@@ -396,6 +396,25 @@ describe("zero user permission grants", () => {
       }),
     });
     expect(askResponse.status).toBe(400);
+
+    const unsupportedTtlResponse = await app.request(
+      "/api/zero/user-permission-grants",
+      {
+        method: "PUT",
+        headers: {
+          authorization: AUTH_HEADERS.authorization,
+          "content-type": "application/json",
+        },
+        body: JSON.stringify({
+          agentId,
+          connectorRef: SLACK_CONNECTOR,
+          permission: SLACK_READ_PERMISSION,
+          action: "allow",
+          ttlSeconds: 301,
+        }),
+      },
+    );
+    expect(unsupportedTtlResponse.status).toBe(400);
   });
 
   it("filters expired grants and folds active grants into legacy policies", async () => {

--- a/turbo/apps/api/src/signals/routes/__tests__/zero-user-permission-grants.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/zero-user-permission-grants.test.ts
@@ -261,6 +261,11 @@ describe("zero user permission grants", () => {
     const otherOrgUser = await createFixture();
     const sameOrgUserId = `user_${randomUUID()}`;
     await seedMember({ orgId: owner.orgId, userId: sameOrgUserId });
+    const publicAgentId = await seedAgent({
+      orgId: owner.orgId,
+      userId: owner.userId,
+      visibility: "public",
+    });
     const privateAgentId = await seedAgent({
       orgId: owner.orgId,
       userId: owner.userId,
@@ -289,6 +294,21 @@ describe("zero user permission grants", () => {
     expect(ownerResponse.body.agentId).toBe(privateAgentId);
 
     mocks.clerk.session(sameOrgUserId, owner.orgId, "org:member");
+    const sameOrgPublicResponse = await accept(
+      client.upsert({
+        body: {
+          agentId: publicAgentId,
+          connectorRef: SLACK_CONNECTOR,
+          permission: SLACK_READ_PERMISSION,
+          action: "allow",
+          ttlSeconds: 300,
+        },
+        headers: AUTH_HEADERS,
+      }),
+      [200],
+    );
+    expect(sameOrgPublicResponse.body.agentId).toBe(publicAgentId);
+
     const sameOrgResponse = await accept(
       client.upsert({
         body: {

--- a/turbo/apps/api/src/signals/routes/zero-user-permission-grants.ts
+++ b/turbo/apps/api/src/signals/routes/zero-user-permission-grants.ts
@@ -1,0 +1,120 @@
+import { command } from "ccstate";
+import { zeroUserPermissionGrantsContract } from "@vm0/api-contracts/contracts/zero-user-permission-grants";
+import { FeatureSwitchKey } from "@vm0/connectors/feature-switch-key";
+import { isFeatureEnabled } from "@vm0/core/feature-switch";
+
+import { organizationAuthContext$ } from "../auth/auth-context";
+import { authRoute } from "../auth/auth-route";
+import { bodyResultOf, queryOf } from "../context/request";
+import type { RouteEntry } from "../route";
+import { userFeatureSwitchOverrides } from "../services/feature-switches.service";
+import {
+  listUserPermissionGrants$,
+  upsertUserPermissionGrant$,
+} from "../services/zero-user-permission-grants.service";
+
+const userPermissionGrantsDisabled = Object.freeze({
+  status: 403 as const,
+  body: Object.freeze({
+    error: Object.freeze({
+      message: "User permission grants are not enabled",
+      code: "FORBIDDEN" as const,
+    }),
+  }),
+});
+
+const userPermissionGrantAuthOptions = {
+  requireOrganization: true,
+  missingOrganizationStatus: 401,
+} as const;
+
+const userPermissionGrantsEnabled$ = command(async ({ get }) => {
+  const auth = get(organizationAuthContext$);
+  const overrides = await get(
+    userFeatureSwitchOverrides(auth.orgId, auth.userId),
+  );
+  return isFeatureEnabled(FeatureSwitchKey.UserPermissionGrants, {
+    orgId: auth.orgId,
+    userId: auth.userId,
+    overrides,
+  });
+});
+
+const listQuery$ = queryOf(zeroUserPermissionGrantsContract.list);
+const upsertBody$ = bodyResultOf(zeroUserPermissionGrantsContract.upsert);
+
+const listUserPermissionGrantsInner$ = command(
+  async ({ get, set }, signal: AbortSignal) => {
+    const auth = get(organizationAuthContext$);
+    if (!(await set(userPermissionGrantsEnabled$))) {
+      return userPermissionGrantsDisabled;
+    }
+    signal.throwIfAborted();
+
+    const query = get(listQuery$);
+    const result = await set(
+      listUserPermissionGrants$,
+      {
+        orgId: auth.orgId,
+        userId: auth.userId,
+        agentId: query.agentId,
+      },
+      signal,
+    );
+    signal.throwIfAborted();
+
+    if ("kind" in result) {
+      return { status: 200 as const, body: [...result.grants] };
+    }
+    return result;
+  },
+);
+
+const upsertUserPermissionGrantInner$ = command(
+  async ({ get, set }, signal: AbortSignal) => {
+    const auth = get(organizationAuthContext$);
+    if (!(await set(userPermissionGrantsEnabled$))) {
+      return userPermissionGrantsDisabled;
+    }
+    signal.throwIfAborted();
+
+    const bodyResult = await get(upsertBody$);
+    signal.throwIfAborted();
+    if (!bodyResult.ok) {
+      return bodyResult.response;
+    }
+
+    const result = await set(
+      upsertUserPermissionGrant$,
+      {
+        orgId: auth.orgId,
+        userId: auth.userId,
+        grant: bodyResult.data,
+      },
+      signal,
+    );
+    signal.throwIfAborted();
+
+    if ("kind" in result) {
+      return { status: 200 as const, body: result.grant };
+    }
+    return result;
+  },
+);
+
+export const zeroUserPermissionGrantsRoutes: readonly RouteEntry[] = [
+  {
+    route: zeroUserPermissionGrantsContract.list,
+    handler: authRoute(
+      userPermissionGrantAuthOptions,
+      listUserPermissionGrantsInner$,
+    ),
+  },
+  {
+    route: zeroUserPermissionGrantsContract.upsert,
+    handler: authRoute(
+      userPermissionGrantAuthOptions,
+      upsertUserPermissionGrantInner$,
+    ),
+  },
+];

--- a/turbo/apps/api/src/signals/services/zero-user-permission-grants.service.ts
+++ b/turbo/apps/api/src/signals/services/zero-user-permission-grants.service.ts
@@ -217,7 +217,7 @@ async function visibleAgentOrNotFound(
     : notFound(`Agent not found: ${scope.agentId}`);
 }
 
-async function lockVisibleAgentForUpdate(
+async function lockVisibleAgentForGrantInsert(
   db: Pick<Db, "select">,
   scope: UserPermissionGrantScope,
 ): Promise<{ readonly id: string } | null> {
@@ -231,7 +231,9 @@ async function lockVisibleAgentForUpdate(
         visibleZeroAgentCondition(scope.userId),
       ),
     )
-    .for("update")
+    // A key-share lock is enough to make concurrent deletes wait while the
+    // grant row is inserted, without serializing unrelated grant upserts.
+    .for("key share")
     .limit(1);
   return agent ?? null;
 }
@@ -243,10 +245,9 @@ function expiresAtFromTtl(now: Date, ttlSeconds: number): Date {
 async function upsertVisibleGrantRow(
   db: Db,
   args: UpsertUserPermissionGrantArgs,
-  timestamp: Date,
 ): Promise<UserPermissionGrantRow | NotFoundResponse> {
   return await db.transaction(async (tx) => {
-    const visibleAgent = await lockVisibleAgentForUpdate(tx, {
+    const visibleAgent = await lockVisibleAgentForGrantInsert(tx, {
       orgId: args.orgId,
       userId: args.userId,
       agentId: args.grant.agentId,
@@ -255,6 +256,7 @@ async function upsertVisibleGrantRow(
       return notFound(`Agent not found: ${args.grant.agentId}`);
     }
 
+    const timestamp = nowDate();
     const expiresAt = expiresAtFromTtl(timestamp, args.grant.ttlSeconds);
     const [row] = await tx
       .insert(userPermissionGrants)
@@ -330,7 +332,7 @@ export const upsertUserPermissionGrant$ = command(
     }
 
     const writeDb = set(writeDb$);
-    const row = await upsertVisibleGrantRow(writeDb, args, nowDate());
+    const row = await upsertVisibleGrantRow(writeDb, args);
     signal.throwIfAborted();
 
     if ("status" in row) {

--- a/turbo/apps/api/src/signals/services/zero-user-permission-grants.service.ts
+++ b/turbo/apps/api/src/signals/services/zero-user-permission-grants.service.ts
@@ -1,0 +1,345 @@
+import { command } from "ccstate";
+import {
+  getConnectorFirewall,
+  isFirewallConnectorType,
+} from "@vm0/connectors/firewalls";
+import {
+  type FirewallPolicies,
+  UNKNOWN_PERMISSION_GRANT,
+} from "@vm0/connectors/firewall-types";
+import { userPermissionGrants } from "@vm0/db/schema/user-permission-grant";
+import { zeroAgents } from "@vm0/db/schema/zero-agent";
+import { and, asc, eq, gt, isNull, or } from "drizzle-orm";
+import type {
+  UpsertUserPermissionGrantRequest,
+  UserPermissionGrantResponse,
+} from "@vm0/api-contracts/contracts/zero-user-permission-grants";
+
+import { notFound } from "../../lib/error";
+import { db$, writeDb$, type Db, type ReadonlyDb } from "../external/db";
+import { nowDate } from "../external/time";
+
+type UserPermissionGrantRow = typeof userPermissionGrants.$inferSelect;
+
+interface UserPermissionGrantScope {
+  readonly orgId: string;
+  readonly userId: string;
+  readonly agentId: string;
+}
+
+interface UpsertUserPermissionGrantArgs {
+  readonly orgId: string;
+  readonly userId: string;
+  readonly grant: UpsertUserPermissionGrantRequest;
+}
+
+type NotFoundResponse = ReturnType<typeof notFound>;
+
+type ValidationErrorResponse = {
+  readonly status: 400;
+  readonly body: {
+    readonly error: {
+      readonly message: string;
+      readonly code: "VALIDATION_ERROR";
+    };
+  };
+};
+
+type ListUserPermissionGrantsResult =
+  | {
+      readonly kind: "ok";
+      readonly grants: readonly UserPermissionGrantResponse[];
+    }
+  | NotFoundResponse;
+
+type UpsertUserPermissionGrantResult =
+  | {
+      readonly kind: "ok";
+      readonly grant: UserPermissionGrantResponse;
+    }
+  | NotFoundResponse
+  | ValidationErrorResponse;
+
+function validationError(message: string): ValidationErrorResponse {
+  return {
+    status: 400 as const,
+    body: {
+      error: {
+        message,
+        code: "VALIDATION_ERROR" as const,
+      },
+    },
+  };
+}
+
+function visibleZeroAgentCondition(userId: string) {
+  return or(eq(zeroAgents.visibility, "public"), eq(zeroAgents.owner, userId));
+}
+
+async function findVisibleAgent(
+  db: ReadonlyDb,
+  scope: UserPermissionGrantScope,
+): Promise<{ readonly id: string } | null> {
+  const [agent] = await db
+    .select({ id: zeroAgents.id })
+    .from(zeroAgents)
+    .where(
+      and(
+        eq(zeroAgents.orgId, scope.orgId),
+        eq(zeroAgents.id, scope.agentId),
+        visibleZeroAgentCondition(scope.userId),
+      ),
+    )
+    .limit(1);
+  return agent ?? null;
+}
+
+function validPermissionNames(connectorRef: string): Set<string> | null {
+  if (!isFirewallConnectorType(connectorRef)) {
+    return null;
+  }
+
+  const config = getConnectorFirewall(connectorRef);
+  const names = new Set<string>();
+  for (const api of config.apis) {
+    for (const permission of api.permissions ?? []) {
+      names.add(permission.name);
+    }
+  }
+  return names;
+}
+
+function validateGrantTarget(
+  connectorRef: string,
+  permission: string,
+): ValidationErrorResponse | null {
+  const names = validPermissionNames(connectorRef);
+  if (!names) {
+    return validationError(`Unknown connector ref: ${connectorRef}`);
+  }
+
+  if (permission === UNKNOWN_PERMISSION_GRANT) {
+    return null;
+  }
+
+  if (!names.has(permission)) {
+    return validationError(
+      `Unknown permission "${permission}" for connector "${connectorRef}"`,
+    );
+  }
+
+  return null;
+}
+
+function activeGrantCondition(checkedAt: Date) {
+  return or(
+    isNull(userPermissionGrants.expiresAt),
+    gt(userPermissionGrants.expiresAt, checkedAt),
+  );
+}
+
+function formatUserPermissionGrant(
+  row: Pick<
+    UserPermissionGrantRow,
+    | "agentId"
+    | "connectorRef"
+    | "permission"
+    | "action"
+    | "expiresAt"
+    | "createdAt"
+    | "updatedAt"
+  >,
+): UserPermissionGrantResponse {
+  return {
+    agentId: row.agentId,
+    connectorRef: row.connectorRef,
+    permission: row.permission,
+    action: row.action,
+    expiresAt: row.expiresAt?.toISOString() ?? null,
+    createdAt: row.createdAt.toISOString(),
+    updatedAt: row.updatedAt.toISOString(),
+  };
+}
+
+export async function loadActiveUserPermissionGrants(
+  db: ReadonlyDb,
+  scope: UserPermissionGrantScope,
+  checkedAt: Date = nowDate(),
+): Promise<readonly UserPermissionGrantRow[]> {
+  return await db
+    .select()
+    .from(userPermissionGrants)
+    .where(
+      and(
+        eq(userPermissionGrants.orgId, scope.orgId),
+        eq(userPermissionGrants.userId, scope.userId),
+        eq(userPermissionGrants.agentId, scope.agentId),
+        activeGrantCondition(checkedAt),
+      ),
+    )
+    .orderBy(
+      asc(userPermissionGrants.connectorRef),
+      asc(userPermissionGrants.permission),
+    );
+}
+
+export function foldUserPermissionGrantsToFirewallPolicies(
+  grants: readonly Pick<
+    UserPermissionGrantRow,
+    "connectorRef" | "permission" | "action"
+  >[],
+): FirewallPolicies | null {
+  const policies: FirewallPolicies = {};
+
+  for (const grant of grants) {
+    const existing = policies[grant.connectorRef] ?? { policies: {} };
+    if (grant.permission === UNKNOWN_PERMISSION_GRANT) {
+      policies[grant.connectorRef] = {
+        ...existing,
+        unknownPolicy: grant.action,
+      };
+      continue;
+    }
+
+    existing.policies[grant.permission] = grant.action;
+    policies[grant.connectorRef] = existing;
+  }
+
+  return Object.keys(policies).length > 0 ? policies : null;
+}
+
+async function visibleAgentOrNotFound(
+  db: ReadonlyDb,
+  scope: UserPermissionGrantScope,
+): Promise<NotFoundResponse | null> {
+  return (await findVisibleAgent(db, scope))
+    ? null
+    : notFound(`Agent not found: ${scope.agentId}`);
+}
+
+async function lockVisibleAgentForUpdate(
+  db: Pick<Db, "select">,
+  scope: UserPermissionGrantScope,
+): Promise<{ readonly id: string } | null> {
+  const [agent] = await db
+    .select({ id: zeroAgents.id })
+    .from(zeroAgents)
+    .where(
+      and(
+        eq(zeroAgents.orgId, scope.orgId),
+        eq(zeroAgents.id, scope.agentId),
+        visibleZeroAgentCondition(scope.userId),
+      ),
+    )
+    .for("update")
+    .limit(1);
+  return agent ?? null;
+}
+
+function expiresAtFromTtl(now: Date, ttlSeconds: number): Date {
+  return new Date(now.getTime() + ttlSeconds * 1000);
+}
+
+async function upsertVisibleGrantRow(
+  db: Db,
+  args: UpsertUserPermissionGrantArgs,
+  timestamp: Date,
+): Promise<UserPermissionGrantRow | NotFoundResponse> {
+  return await db.transaction(async (tx) => {
+    const visibleAgent = await lockVisibleAgentForUpdate(tx, {
+      orgId: args.orgId,
+      userId: args.userId,
+      agentId: args.grant.agentId,
+    });
+    if (!visibleAgent) {
+      return notFound(`Agent not found: ${args.grant.agentId}`);
+    }
+
+    const expiresAt = expiresAtFromTtl(timestamp, args.grant.ttlSeconds);
+    const [row] = await tx
+      .insert(userPermissionGrants)
+      .values({
+        orgId: args.orgId,
+        userId: args.userId,
+        agentId: args.grant.agentId,
+        connectorRef: args.grant.connectorRef,
+        permission: args.grant.permission,
+        action: args.grant.action,
+        expiresAt,
+        createdAt: timestamp,
+        updatedAt: timestamp,
+      })
+      .onConflictDoUpdate({
+        target: [
+          userPermissionGrants.orgId,
+          userPermissionGrants.userId,
+          userPermissionGrants.agentId,
+          userPermissionGrants.connectorRef,
+          userPermissionGrants.permission,
+        ],
+        set: {
+          action: args.grant.action,
+          expiresAt,
+          updatedAt: timestamp,
+        },
+      })
+      .returning();
+
+    if (!row) {
+      throw new Error("User permission grant upsert did not return a row");
+    }
+    return row;
+  });
+}
+
+export const listUserPermissionGrants$ = command(
+  async (
+    { get },
+    scope: UserPermissionGrantScope,
+    signal: AbortSignal,
+  ): Promise<ListUserPermissionGrantsResult> => {
+    const db = get(db$);
+    const visibleError = await visibleAgentOrNotFound(db, scope);
+    signal.throwIfAborted();
+    if (visibleError) {
+      return visibleError;
+    }
+
+    const grants = await loadActiveUserPermissionGrants(db, scope);
+    signal.throwIfAborted();
+
+    return {
+      kind: "ok" as const,
+      grants: grants.map(formatUserPermissionGrant),
+    };
+  },
+);
+
+export const upsertUserPermissionGrant$ = command(
+  async (
+    { set },
+    args: UpsertUserPermissionGrantArgs,
+    signal: AbortSignal,
+  ): Promise<UpsertUserPermissionGrantResult> => {
+    const validation = validateGrantTarget(
+      args.grant.connectorRef,
+      args.grant.permission,
+    );
+    if (validation) {
+      return validation;
+    }
+
+    const writeDb = set(writeDb$);
+    const row = await upsertVisibleGrantRow(writeDb, args, nowDate());
+    signal.throwIfAborted();
+
+    if ("status" in row) {
+      return row;
+    }
+
+    return {
+      kind: "ok" as const,
+      grant: formatUserPermissionGrant(row),
+    };
+  },
+);

--- a/turbo/apps/api/src/signals/services/zero-user-permission-grants.service.ts
+++ b/turbo/apps/api/src/signals/services/zero-user-permission-grants.service.ts
@@ -217,7 +217,7 @@ async function visibleAgentOrNotFound(
     : notFound(`Agent not found: ${scope.agentId}`);
 }
 
-async function lockVisibleAgentForGrantInsert(
+async function lockVisibleAgentForUpdate(
   db: Pick<Db, "select">,
   scope: UserPermissionGrantScope,
 ): Promise<{ readonly id: string } | null> {
@@ -231,9 +231,7 @@ async function lockVisibleAgentForGrantInsert(
         visibleZeroAgentCondition(scope.userId),
       ),
     )
-    // A key-share lock is enough to make concurrent deletes wait while the
-    // grant row is inserted, without serializing unrelated grant upserts.
-    .for("key share")
+    .for("update")
     .limit(1);
   return agent ?? null;
 }
@@ -247,7 +245,7 @@ async function upsertVisibleGrantRow(
   args: UpsertUserPermissionGrantArgs,
 ): Promise<UserPermissionGrantRow | NotFoundResponse> {
   return await db.transaction(async (tx) => {
-    const visibleAgent = await lockVisibleAgentForGrantInsert(tx, {
+    const visibleAgent = await lockVisibleAgentForUpdate(tx, {
       orgId: args.orgId,
       userId: args.userId,
       agentId: args.grant.agentId,

--- a/turbo/apps/web/api-backend-rewrites.js
+++ b/turbo/apps/web/api-backend-rewrites.js
@@ -1015,6 +1015,7 @@ export const API_BACKEND_REWRITES = [
     "/api/zero/permission-access-requests",
     "/api/zero/permission-access-requests",
   ],
+  ["/api/zero/user-permission-grants", "/api/zero/user-permission-grants"],
   ["/api/zero/permission-policies", "/api/zero/permission-policies"],
   ["/api/zero/push-subscriptions", "/api/zero/push-subscriptions"],
   ["/api/zero/queue-position", "/api/zero/queue-position"],

--- a/turbo/packages/api-contracts/src/contracts/index.ts
+++ b/turbo/packages/api-contracts/src/contracts/index.ts
@@ -882,6 +882,20 @@ export {
   type ZeroUserConnectorsContract,
 } from "./user-connectors";
 export {
+  zeroUserPermissionGrantsContract,
+  userPermissionGrantActionSchema,
+  userPermissionGrantTtlSecondsSchema,
+  userPermissionGrantResponseSchema,
+  listUserPermissionGrantsQuerySchema,
+  upsertUserPermissionGrantRequestSchema,
+  type UserPermissionGrantAction,
+  type UserPermissionGrantTtlSeconds,
+  type UserPermissionGrantResponse,
+  type ListUserPermissionGrantsQuery,
+  type UpsertUserPermissionGrantRequest,
+  type ZeroUserPermissionGrantsContract,
+} from "./zero-user-permission-grants";
+export {
   zeroConnectorsMainContract,
   zeroConnectorsByTypeContract,
   zeroConnectorScopeDiffContract,

--- a/turbo/packages/api-contracts/src/contracts/zero-user-permission-grants.ts
+++ b/turbo/packages/api-contracts/src/contracts/zero-user-permission-grants.ts
@@ -1,0 +1,88 @@
+import { z } from "zod";
+import { authHeadersSchema, initContract } from "./base";
+import { apiErrorSchema } from "./errors";
+
+const c = initContract();
+
+const agentIdSchema = z.string().uuid();
+const connectorRefSchema = z.string().min(1).max(64);
+const permissionSchema = z.string().min(1).max(128);
+
+export const userPermissionGrantActionSchema = z.enum(["allow", "deny"]);
+export const userPermissionGrantTtlSecondsSchema = z.union([
+  z.literal(300),
+  z.literal(900),
+  z.literal(3600),
+  z.literal(86_400),
+]);
+
+export const userPermissionGrantResponseSchema = z.object({
+  agentId: agentIdSchema,
+  connectorRef: connectorRefSchema,
+  permission: permissionSchema,
+  action: userPermissionGrantActionSchema,
+  expiresAt: z.string().nullable(),
+  createdAt: z.string(),
+  updatedAt: z.string(),
+});
+
+export const listUserPermissionGrantsQuerySchema = z.object({
+  agentId: agentIdSchema,
+});
+
+export const upsertUserPermissionGrantRequestSchema = z.object({
+  agentId: agentIdSchema,
+  connectorRef: connectorRefSchema,
+  permission: permissionSchema,
+  action: userPermissionGrantActionSchema,
+  ttlSeconds: userPermissionGrantTtlSecondsSchema,
+});
+
+export const zeroUserPermissionGrantsContract = c.router({
+  list: {
+    method: "GET",
+    path: "/api/zero/user-permission-grants",
+    headers: authHeadersSchema,
+    query: listUserPermissionGrantsQuerySchema,
+    responses: {
+      200: z.array(userPermissionGrantResponseSchema),
+      400: apiErrorSchema,
+      401: apiErrorSchema,
+      403: apiErrorSchema,
+      404: apiErrorSchema,
+    },
+    summary: "List current user's active permission grants for an agent",
+  },
+  upsert: {
+    method: "PUT",
+    path: "/api/zero/user-permission-grants",
+    headers: authHeadersSchema,
+    body: upsertUserPermissionGrantRequestSchema,
+    responses: {
+      200: userPermissionGrantResponseSchema,
+      400: apiErrorSchema,
+      401: apiErrorSchema,
+      403: apiErrorSchema,
+      404: apiErrorSchema,
+    },
+    summary: "Upsert current user's permission grant for an agent",
+  },
+});
+
+export type UserPermissionGrantAction = z.infer<
+  typeof userPermissionGrantActionSchema
+>;
+export type UserPermissionGrantTtlSeconds = z.infer<
+  typeof userPermissionGrantTtlSecondsSchema
+>;
+export type UserPermissionGrantResponse = z.infer<
+  typeof userPermissionGrantResponseSchema
+>;
+export type ListUserPermissionGrantsQuery = z.infer<
+  typeof listUserPermissionGrantsQuerySchema
+>;
+export type UpsertUserPermissionGrantRequest = z.infer<
+  typeof upsertUserPermissionGrantRequestSchema
+>;
+export type ZeroUserPermissionGrantsContract =
+  typeof zeroUserPermissionGrantsContract;


### PR DESCRIPTION
## Summary
- add feature-gated user permission grant list/upsert contracts and API routes
- add service helpers to load active grants and fold them into legacy firewall policies
- cover feature gating, user isolation, private agent scope, validation, expiration, and upsert semantics
- route the new API path through the web backend rewrite table

## Tests
- pnpm -F api exec vitest run src/signals/routes/__tests__/zero-user-permission-grants.test.ts src/__tests__/web-api-compatibility.test.ts
- pnpm -F api check-types
- pnpm -F api lint
- pnpm -F web lint
- pnpm -F @vm0/api-contracts check-types
- pnpm -F @vm0/api-contracts lint
- pnpm knip
- pre-commit: prettier on staged files, pnpm knip --cache, pnpm check-types

Closes #15601