### PR TITLE
refactor: move google security warning helper to platform

### DIFF
--- a/turbo/apps/platform/src/lib/google-security-warning.ts
+++ b/turbo/apps/platform/src/lib/google-security-warning.ts
@@ -1,0 +1,20 @@
+import type { ConnectorType } from "@vm0/connectors/connectors";
+
+export function shouldShowGoogleSecurityWarningNotice(
+  type: ConnectorType,
+): boolean {
+  switch (type) {
+    case "gmail":
+    case "google-ads":
+    case "google-calendar":
+    case "google-docs":
+    case "google-drive":
+    case "google-meet":
+    case "google-sheets": {
+      return true;
+    }
+    default: {
+      return false;
+    }
+  }
+}

--- a/turbo/apps/platform/src/signals/zero-page/settings/connectors.ts
+++ b/turbo/apps/platform/src/signals/zero-page/settings/connectors.ts
@@ -15,9 +15,9 @@ import {
   getConfiguredConnectorAuthMethods,
   getConnectorTags,
   hasRequiredConnectorAuthMethodScopes,
-  isGoogleOAuthConnector,
   hasConnectorDeviceAuthGrant,
 } from "@vm0/connectors/connector-utils";
+import { shouldShowGoogleSecurityWarningNotice } from "../../../lib/google-security-warning.ts";
 import {
   zeroConnectorScopeDiffContract,
   zeroConnectorOauthDeviceAuthSessionContract,
@@ -118,11 +118,11 @@ function getAvailableConnectorConnectAuthMethods(
 export function getConnectorConnectLaunchMode({
   type,
   availableAuthMethods,
-  preferModalForGoogleOAuth = false,
+  preferModalForGoogleSecurityWarning = false,
 }: {
   readonly type: ConnectorType;
   readonly availableAuthMethods: readonly ConnectorAuthMethodId[];
-  readonly preferModalForGoogleOAuth?: boolean;
+  readonly preferModalForGoogleSecurityWarning?: boolean;
 }): ConnectorConnectLaunchMode {
   const [authMethod] = availableAuthMethods;
   if (availableAuthMethods.length !== 1 || !authMethod) {
@@ -131,7 +131,10 @@ export function getConnectorConnectLaunchMode({
   if (getConnectorAuthMethod(type, authMethod)?.grant.kind !== "auth-code") {
     return "modal";
   }
-  if (preferModalForGoogleOAuth && isGoogleOAuthConnector(type)) {
+  if (
+    preferModalForGoogleSecurityWarning &&
+    shouldShowGoogleSecurityWarningNotice(type)
+  ) {
     return "modal";
   }
   return "oauth-auth-code";

--- a/turbo/apps/platform/src/views/zero-page/__tests__/zero-connectors-page-interaction.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/zero-connectors-page-interaction.test.tsx
@@ -35,7 +35,7 @@ test("connect button opens api-token form (CONN-I-011)", async () => {
   expect(screen.getByText("Save")).toBeInTheDocument();
 });
 
-test("connect button on Google connector opens dialog with OAuth notice (CONN-I-020)", async () => {
+test("connect button on Google connector opens dialog with security warning notice (CONN-I-020)", async () => {
   detachedSetupPage({ context, path: "/connectors" });
 
   await waitFor(() => {
@@ -54,7 +54,7 @@ test("connect button on Google connector opens dialog with OAuth notice (CONN-I-
   expect(screen.getByText(/Go to vm0\.ai \(unsafe\)/)).toBeInTheDocument();
 });
 
-test("connect button on api-token-only connector opens dialog without OAuth notice (CONN-I-021)", async () => {
+test("connect button on api-token-only connector opens dialog without security warning notice (CONN-I-021)", async () => {
   detachedSetupPage({ context, path: "/connectors" });
 
   await waitFor(() => {

--- a/turbo/apps/platform/src/views/zero-page/__tests__/zero-directed-authorize-page.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/zero-directed-authorize-page.test.tsx
@@ -253,7 +253,7 @@ describe("directed authorize page", () => {
     expect(logoLink.closest("a")).toHaveAttribute("href", "/connectors");
   });
 
-  it("shows Google OAuth notice when Google connector is not yet connected (AUTH-D-060)", async () => {
+  it("shows Google security warning notice when Google connector is not yet connected (AUTH-D-060)", async () => {
     // No mockConnectorsConnected → connector not in the connected list
     detachedSetupPage({
       context,
@@ -273,7 +273,7 @@ describe("directed authorize page", () => {
     expect(screen.getByText(/Go to vm0\.ai \(unsafe\)/)).toBeInTheDocument();
   });
 
-  it("does not show Google OAuth notice when Google connector is already connected (AUTH-D-061)", async () => {
+  it("does not show Google security warning notice when Google connector is already connected (AUTH-D-061)", async () => {
     mockConnectorsConnected("gmail");
 
     detachedSetupPage({
@@ -292,7 +292,7 @@ describe("directed authorize page", () => {
     ).not.toBeInTheDocument();
   });
 
-  it("does not show Google OAuth notice when connector is already authorized (AUTH-D-062)", async () => {
+  it("does not show Google security warning notice when connector is already authorized (AUTH-D-062)", async () => {
     mockConnectorsConnected("gmail");
     server.use(
       mockApi(zeroUserConnectorsContract.get, ({ respond }) => {
@@ -314,7 +314,7 @@ describe("directed authorize page", () => {
     ).not.toBeInTheDocument();
   });
 
-  it("does not show Google OAuth notice for non-Google OAuth connectors (AUTH-D-063)", async () => {
+  it("does not show Google security warning notice for non-Google auth-code connectors (AUTH-D-063)", async () => {
     mockConnectorsConnected("github");
 
     detachedSetupPage({

--- a/turbo/apps/platform/src/views/zero-page/__tests__/zero-directed-connect-page.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/zero-directed-connect-page.test.tsx
@@ -767,7 +767,7 @@ describe("directed connect page", () => {
     });
   });
 
-  it("shows Google OAuth notice for a Google connector when not connected (CONN-D-060)", async () => {
+  it("shows Google security warning notice for a Google connector when not connected (CONN-D-060)", async () => {
     detachedSetupPage({ context, path: "/connectors/gmail/connect" });
 
     await waitFor(() => {
@@ -783,7 +783,7 @@ describe("directed connect page", () => {
     expect(screen.getByText(/Go to vm0\.ai \(unsafe\)/)).toBeInTheDocument();
   });
 
-  it("shows Google OAuth notice for other Google connectors (CONN-D-061)", async () => {
+  it("shows Google security warning notice for other Google connectors (CONN-D-061)", async () => {
     detachedSetupPage({ context, path: "/connectors/google-sheets/connect" });
 
     await waitFor(() => {
@@ -797,7 +797,7 @@ describe("directed connect page", () => {
     ).toBeInTheDocument();
   });
 
-  it("does not show Google OAuth notice for non-Google OAuth connectors (CONN-D-062)", async () => {
+  it("does not show Google security warning notice for non-Google auth-code connectors (CONN-D-062)", async () => {
     detachedSetupPage({ context, path: "/connectors/github/connect" });
 
     await waitFor(() => {
@@ -811,7 +811,7 @@ describe("directed connect page", () => {
     ).not.toBeInTheDocument();
   });
 
-  it("does not show Google OAuth notice when Google connector is already connected (CONN-D-063)", async () => {
+  it("does not show Google security warning notice when Google connector is already connected (CONN-D-063)", async () => {
     mockConnectors([{ type: "gmail" }]);
 
     detachedSetupPage({ context, path: "/connectors/gmail/connect" });

--- a/turbo/apps/platform/src/views/zero-page/components/settings/add-connection-dialog.tsx
+++ b/turbo/apps/platform/src/views/zero-page/components/settings/add-connection-dialog.tsx
@@ -17,10 +17,7 @@ import {
   type ConnectorType,
 } from "@vm0/connectors/connectors";
 import type { ReactElement } from "react";
-import {
-  getConnectorAuthMethod,
-  isGoogleOAuthConnector,
-} from "@vm0/connectors/connector-utils";
+import { getConnectorAuthMethod } from "@vm0/connectors/connector-utils";
 import {
   allConnectorTypes$,
   connectFlowType$,
@@ -44,7 +41,8 @@ import { hasTokenInputValue } from "../../../../signals/zero-page/settings/token
 import { pageSignal$ } from "../../../../signals/page-signal.ts";
 import { ConnectorIcon } from "./connector-icons.tsx";
 import { detach, onDomEventFn, Reason } from "../../../../signals/utils.ts";
-import { GoogleOAuthNotice } from "../../zero-directed-shared.tsx";
+import { shouldShowGoogleSecurityWarningNotice } from "../../../../lib/google-security-warning.ts";
+import { GoogleSecurityWarningNotice } from "../../zero-directed-shared.tsx";
 import { ConnectorHelpText } from "./connector-help-text.tsx";
 
 // ---------------------------------------------------------------------------
@@ -614,17 +612,17 @@ function StandardConnectMethodsContent({
   signal: AbortSignal;
   entries: readonly ConnectMethodContentEntry[];
 }) {
-  const isGoogleOAuth =
+  const showGoogleSecurityWarningNotice =
     hasAuthCodeGrant(
       item.type,
       entries.map((entry) => {
         return entry.authMethod;
       }),
-    ) && isGoogleOAuthConnector(item.type);
+    ) && shouldShowGoogleSecurityWarningNotice(item.type);
 
   return (
     <div className="flex flex-col gap-4">
-      {isGoogleOAuth && <GoogleOAuthNotice />}
+      {showGoogleSecurityWarningNotice && <GoogleSecurityWarningNotice />}
 
       <ConnectMethodsContent
         entries={entries}

--- a/turbo/apps/platform/src/views/zero-page/zero-connectors-page.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-connectors-page.tsx
@@ -19,7 +19,6 @@ import {
   CONNECTOR_TYPES,
   type ConnectorType,
 } from "@vm0/connectors/connectors";
-import { isGoogleOAuthConnector } from "@vm0/connectors/connector-utils";
 import { Tabs, TabsList, TabsTrigger } from "@vm0/ui/components/ui/tabs";
 import {
   connectorsPageTab$,
@@ -27,6 +26,7 @@ import {
   openCustomConnectorCreateDialog$,
 } from "../../signals/zero-page/settings/custom-connectors.ts";
 import { isOrgAdmin$ } from "../../signals/org.ts";
+import { shouldShowGoogleSecurityWarningNotice } from "../../lib/google-security-warning.ts";
 import { CustomConnectorsPanel } from "./components/settings/custom-connectors-panel.tsx";
 import { ConnectorIcon } from "./components/settings/connector-icons.tsx";
 import {
@@ -494,7 +494,7 @@ function AvailableConnectorCard({
           data-testid="connector-help-text"
           className="text-xs text-muted-foreground line-clamp-2"
         >
-          {isGoogleOAuthConnector(connector.type) ? (
+          {shouldShowGoogleSecurityWarningNotice(connector.type) ? (
             <>
               <TooltipProvider delayDuration={200}>
                 <Tooltip>
@@ -638,7 +638,7 @@ export function ZeroConnectorsPage() {
     const launchMode = getConnectorConnectLaunchMode({
       type,
       availableAuthMethods: ct.availableAuthMethods,
-      preferModalForGoogleOAuth: true,
+      preferModalForGoogleSecurityWarning: true,
     });
     if (launchMode === "modal") {
       setSelected(type);

--- a/turbo/apps/platform/src/views/zero-page/zero-directed-authorize-page.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-directed-authorize-page.tsx
@@ -5,7 +5,6 @@ import {
   type ConnectorAuthMethodId,
   type ConnectorType,
 } from "@vm0/connectors/connectors";
-import { isGoogleOAuthConnector } from "@vm0/connectors/connector-utils";
 import { ConnectorIcon } from "./components/settings/connector-icons.tsx";
 import {
   allConnectorTypes$,
@@ -27,7 +26,11 @@ import {
 } from "../../signals/connectors-page/directed-authorize-type.ts";
 import { pageSignal$ } from "../../signals/page-signal.ts";
 import { IconCheck, IconLoader2 } from "@tabler/icons-react";
-import { Vm0LogoLink, GoogleOAuthNotice } from "./zero-directed-shared.tsx";
+import { shouldShowGoogleSecurityWarningNotice } from "../../lib/google-security-warning.ts";
+import {
+  Vm0LogoLink,
+  GoogleSecurityWarningNotice,
+} from "./zero-directed-shared.tsx";
 import { ConnectModal } from "./components/settings/add-connection-dialog.tsx";
 
 // ---------------------------------------------------------------------------
@@ -176,8 +179,10 @@ function DirectedAuthorizeCard() {
         item.availableAuthMethods,
       )
     : null;
-  const showGoogleOAuthNotice =
-    !isAuthorized && !isConnected && isGoogleOAuthConnector(connectorType);
+  const showGoogleSecurityWarningNotice =
+    !isAuthorized &&
+    !isConnected &&
+    shouldShowGoogleSecurityWarningNotice(connectorType);
 
   const handleAuthorize = () => {
     if (!canAuthorize) {
@@ -225,7 +230,9 @@ function DirectedAuthorizeCard() {
                   <p className="w-60 text-sm text-muted-foreground">
                     {config.helpText}
                   </p>
-                  {showGoogleOAuthNotice && <GoogleOAuthNotice />}
+                  {showGoogleSecurityWarningNotice && (
+                    <GoogleSecurityWarningNotice />
+                  )}
                 </>
               )}
             </div>

--- a/turbo/apps/platform/src/views/zero-page/zero-directed-connect-page.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-directed-connect-page.tsx
@@ -7,10 +7,7 @@ import {
   type ConnectorManualGrantConfig,
   type ConnectorType,
 } from "@vm0/connectors/connectors";
-import {
-  getConnectorAuthMethod,
-  isGoogleOAuthConnector,
-} from "@vm0/connectors/connector-utils";
+import { getConnectorAuthMethod } from "@vm0/connectors/connector-utils";
 import { Input } from "@vm0/ui/components/ui/input";
 import {
   Dialog,
@@ -53,7 +50,11 @@ import {
 import { authorizeConnector$ } from "../../signals/connectors-page/directed-authorize-type.ts";
 import { pageSignal$ } from "../../signals/page-signal.ts";
 import { IconCheck, IconLoader2 } from "@tabler/icons-react";
-import { Vm0LogoLink, GoogleOAuthNotice } from "./zero-directed-shared.tsx";
+import { shouldShowGoogleSecurityWarningNotice } from "../../lib/google-security-warning.ts";
+import {
+  Vm0LogoLink,
+  GoogleSecurityWarningNotice,
+} from "./zero-directed-shared.tsx";
 import { ConnectModal } from "./components/settings/add-connection-dialog.tsx";
 
 type ManualGrantMethod = {
@@ -532,9 +533,10 @@ function DirectedConnectCard() {
                   <p className="w-60 text-sm text-muted-foreground">
                     {config.helpText}
                   </p>
-                  {!isConnected && isGoogleOAuthConnector(connectorType) && (
-                    <GoogleOAuthNotice />
-                  )}
+                  {!isConnected &&
+                    shouldShowGoogleSecurityWarningNotice(connectorType) && (
+                      <GoogleSecurityWarningNotice />
+                    )}
                 </>
               )}
             </div>

--- a/turbo/apps/platform/src/views/zero-page/zero-directed-shared.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-directed-shared.tsx
@@ -88,7 +88,7 @@ export function Vm0LogoLink() {
   );
 }
 
-export function GoogleOAuthNotice() {
+export function GoogleSecurityWarningNotice() {
   return (
     <div className="w-full mt-2 flex flex-col gap-3 rounded-lg bg-muted/50 px-4 py-4 text-left">
       <AvatarSvgPreview

--- a/turbo/apps/platform/src/views/zero-page/zero-onboarding.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-onboarding.tsx
@@ -277,7 +277,7 @@ function ConnectStepContent() {
     const launchMode = getConnectorConnectLaunchMode({
       type,
       availableAuthMethods: connector.availableAuthMethods,
-      preferModalForGoogleOAuth: true,
+      preferModalForGoogleSecurityWarning: true,
     });
     if (launchMode === "modal") {
       setSelectedConnector(type);

--- a/turbo/packages/api-contracts/src/contracts/index.ts
+++ b/turbo/packages/api-contracts/src/contracts/index.ts
@@ -712,7 +712,6 @@ export {
   getConnectorEnvBindingEntries,
   getConnectorEnvNamesForSecret,
   getConnectorTypeForSecretName,
-  isGoogleOAuthConnector,
   type ScopeDiff,
 } from "@vm0/connectors/connector-utils";
 export {

--- a/turbo/packages/connectors/src/__tests__/connectors.test.ts
+++ b/turbo/packages/connectors/src/__tests__/connectors.test.ts
@@ -56,7 +56,6 @@ import {
   hasConnectorDeviceAuthGrant,
   isStaticConfidentialConnectorAuthClient,
   isStaticConnectorAuthClient,
-  isGoogleOAuthConnector,
   type ConnectorEnvReader,
 } from "../connector-utils";
 import { FeatureSwitchKey } from "../feature-switch-key";
@@ -72,7 +71,10 @@ import {
   revokeConnectorAuthMethodAccessToken,
   startConnectorDeviceAuthorization,
 } from "../auth-providers/connector-auth";
-import { GOOGLE_OAUTH_CONNECTOR_TYPES } from "../auth-providers/oauth/google-connectors";
+import {
+  GOOGLE_OAUTH_CONNECTOR_TYPES,
+  isGoogleOAuthConnector,
+} from "../auth-providers/oauth/google-connectors";
 import { buildGoogleAuthorizationUrl } from "../auth-providers/oauth/google";
 import { getConnectorFirewall } from "../firewalls";
 

--- a/turbo/packages/connectors/src/connector-utils.ts
+++ b/turbo/packages/connectors/src/connector-utils.ts
@@ -33,7 +33,6 @@ import {
   type TokenRevokeConnectorType,
 } from "./connectors";
 import type { FeatureSwitchKey } from "./feature-switch-key";
-export { isGoogleOAuthConnector } from "./auth-providers/oauth/google-connectors";
 
 const CONNECTOR_AUTH_METHOD_PRIORITY = {
   oauth: 0,

--- a/turbo/packages/core/src/index.ts
+++ b/turbo/packages/core/src/index.ts
@@ -224,7 +224,6 @@ export {
   getConnectorEnvBindingEntries,
   getConnectorEnvNamesForSecret,
   getConnectorTypeForSecretName,
-  isGoogleOAuthConnector,
   connectorResponseSchema,
   connectorListResponseSchema,
   scopeDiffResponseSchema,


### PR DESCRIPTION
## Summary

- Move Google security warning notice/modal decisions into platform UI code.
- Remove `isGoogleOAuthConnector` from shared connector/core/api-contract exports.
- Keep lower-level Google OAuth provider helper usage at the provider boundary.
- Rename UI notice/test wording around Google security warning behavior.

Closes #15718

## Tests

- `pnpm -F @vm0/app exec vitest src/views/zero-page/__tests__/zero-directed-connect-page.test.tsx`
- `pnpm -F @vm0/app exec vitest src/views/zero-page/__tests__/zero-directed-authorize-page.test.tsx`
- `pnpm -F @vm0/app exec vitest src/views/zero-page/__tests__/zero-connectors-page-interaction.test.tsx`
- `pnpm -F @vm0/connectors exec vitest src/__tests__/connectors.test.ts`
- `pnpm -F @vm0/app lint`
- `pnpm -F @vm0/connectors lint`
- `pnpm -F @vm0/api-contracts lint`
- `pnpm -F @vm0/core lint`
- `pnpm check-types`
