### PR TITLE
fix(mitm-addon): bound x billing request body decoding

### DIFF
--- a/crates/runner/mitm-addon/src/body_utils.py
+++ b/crates/runner/mitm-addon/src/body_utils.py
@@ -5,6 +5,7 @@ Exports:
 - ``STREAM_BUFFER_LIMIT`` — 64 KB cap used by the responseheaders streaming
   buffer and by the decompression safety cap.
 - Streaming / one-shot decompression for gzip, deflate, br, zstd.
+- Conservative request-body decoding for billing inspection.
 - UTF-8-safe truncation, text/binary content detection and encoding.
 - Header redaction for sensitive names (auth, token, cookie, …).
 - ``add_capture_fields`` — composes capture-mode log entry fields.
@@ -216,6 +217,54 @@ def _decompress_brotli_bounded_with_finished(data: bytes, max_output: int) -> tu
 def _decompress_brotli_bounded(data: bytes, max_output: int) -> bytes:
     body, _finished = _decompress_brotli_bounded_with_finished(data, max_output)
     return body
+
+
+def _decode_zlib_request_body_for_billing(
+    data: bytes, encoding: Literal["gzip", "deflate"], max_output: int
+) -> bytes | None:
+    wbits_options = (
+        (16 + zlib.MAX_WBITS,) if encoding == "gzip" else (zlib.MAX_WBITS, -zlib.MAX_WBITS)
+    )
+    for wbits in wbits_options:
+        obj = zlib.decompressobj(wbits)
+        try:
+            decoded = obj.decompress(data, max_length=max_output + 1)
+        except zlib.error:
+            continue
+        if len(decoded) > max_output:
+            return None
+        if not obj.eof or obj.unused_data:
+            continue
+        return decoded
+    return None
+
+
+def decode_request_body_for_billing(
+    raw_content: bytes | None,
+    headers: http.Headers,
+    *,
+    max_raw: int = STREAM_BUFFER_LIMIT,
+    max_decoded: int = STREAM_BUFFER_LIMIT,
+) -> bytes | None:
+    """Decode a request body for conservative billing inspection.
+
+    Unlike response capture helpers, billing must fail closed: unsupported,
+    invalid, incomplete, or oversized encoded bodies are treated as
+    uninspectable rather than falling back to raw bytes.
+    """
+    if not raw_content:
+        return None
+    if len(raw_content) > max_raw:
+        return None
+
+    encoding = headers.get("content-encoding", "").strip().lower()
+    if not encoding or encoding == "identity":
+        return raw_content if len(raw_content) <= max_decoded else None
+    if encoding == "gzip":
+        return _decode_zlib_request_body_for_billing(raw_content, "gzip", max_decoded)
+    if encoding == "deflate":
+        return _decode_zlib_request_body_for_billing(raw_content, "deflate", max_decoded)
+    return None
 
 
 def _decompress_zlib_json_usage_body(

--- a/crates/runner/mitm-addon/src/usage/providers/connectors/x.py
+++ b/crates/runner/mitm-addon/src/usage/providers/connectors/x.py
@@ -7,7 +7,6 @@ through the X firewall and buffers them for aggregate platform upload.
 import json
 import urllib.parse
 import uuid
-import zlib
 from collections.abc import Callable, Iterable
 from typing import TypedDict
 
@@ -23,6 +22,7 @@ from ...idempotency import USAGE_EVENT_NAMESPACE_CONNECTOR
 from ...json_selective import JsonExtractionResult, JsonSelectiveExtractor, ScalarField
 from .response_parser import ConnectorResponseParser
 from .x_billing import (
+    bucket_needs_body_refinement,
     classify_bucket,
     classify_includes_bucket,
     refine_bucket_with_body,
@@ -67,6 +67,7 @@ def _is_stream_path(path: str) -> bool:
 # exceeding it indicates malformed or hostile upstream data, so the parser
 # discards that row through its terminating newline to protect memory.
 _MAX_NDJSON_LINE_BYTES = 5 * 1024 * 1024  # 5 MB
+_REQUEST_BODY_REFINEMENT_LIMIT = body_utils.STREAM_BUFFER_LIMIT
 
 _X_JSON_RESULT_COUNT_FIELDS = {
     ("meta", "result_count"): ScalarField("int", max_bytes=64),
@@ -530,19 +531,19 @@ def report_usage(flow: http.HTTPFlow, run_id: str) -> None:
     endpoint_bucket = classify_bucket(permission, flow.request.method, request_path)
     if endpoint_bucket is None:
         return
-    try:
-        request_body = flow.request.content
-    except (zlib.error, ValueError):
-        # Bogus Content-Encoding on the request: stay on the conservative
-        # (more expensive) bucket, matching refine_bucket_with_body's own
-        # "never under-charge" rule for parse failures.
-        request_body = None
-    endpoint_bucket = refine_bucket_with_body(
-        endpoint_bucket,
-        flow.request.method,
-        request_path,
-        request_body,
-    )
+    if bucket_needs_body_refinement(endpoint_bucket, flow.request.method, request_path):
+        request_body = body_utils.decode_request_body_for_billing(
+            flow.request.raw_content,
+            flow.request.headers,
+            max_raw=_REQUEST_BODY_REFINEMENT_LIMIT,
+            max_decoded=_REQUEST_BODY_REFINEMENT_LIMIT,
+        )
+        endpoint_bucket = refine_bucket_with_body(
+            endpoint_bucket,
+            flow.request.method,
+            request_path,
+            request_body,
+        )
 
     req_meta = _parse_request_metadata(flow)
     resp_meta = _parse_response_metadata(flow)

--- a/crates/runner/mitm-addon/src/usage/providers/connectors/x_billing.py
+++ b/crates/runner/mitm-addon/src/usage/providers/connectors/x_billing.py
@@ -389,6 +389,14 @@ _BODY_REFINEMENT_RULES: tuple[_BodyRefinementRule, ...] = (
 )
 
 
+def bucket_needs_body_refinement(bucket: str, method: str, path: str) -> bool:
+    """Return True when request body inspection can refine this bucket."""
+    return any(
+        bucket == rule.source_bucket and method == rule.method and path == rule.path
+        for rule in _BODY_REFINEMENT_RULES
+    )
+
+
 def refine_bucket_with_body(bucket: str, method: str, path: str, body: bytes | None) -> str:
     """Refine a bucket using the request body, when the body carries
     billing-relevant signal.

--- a/crates/runner/mitm-addon/tests/test_connector_usage.py
+++ b/crates/runner/mitm-addon/tests/test_connector_usage.py
@@ -2,7 +2,9 @@
 
 import gzip
 import json
+import zlib
 from pathlib import Path
+from unittest.mock import patch
 
 import pytest
 from mitmproxy.test import tutils
@@ -88,8 +90,16 @@ class TestReportConnectorUsage:
         permission="tweet.read",
         rule="GET /2/tweets",
         content_encoding="",
+        request_body: bytes | None = None,
+        request_encoding: str | None = None,
     ):
-        flow = real_flow(with_response=False, host="api.x.com", path=path)
+        flow = real_flow(
+            with_response=False,
+            host="api.x.com",
+            path=path,
+            request_body=request_body,
+            request_encoding=request_encoding,
+        )
         flow.metadata["original_url"] = (
             f"https://api.x.com{path}?{query}" if query else f"https://api.x.com{path}"
         )
@@ -632,6 +642,115 @@ class TestReportConnectorUsage:
         flow.request.content = json.dumps({"text": "hello world"}).encode()
         p = self._call_and_get_single_billing(flow)
         assert p["category"] == "content.create"
+        assert p["quantity"] == 1
+
+    @pytest.mark.parametrize(
+        ("request_encoding", "request_body"),
+        [
+            ("gzip", gzip.compress(json.dumps({"text": "hello world"}).encode())),
+            ("deflate", zlib.compress(json.dumps({"text": "hello world"}).encode())),
+        ],
+    )
+    def test_tweet_create_compressed_plain_text_downgrades_to_content_create(
+        self, tmp_path, real_flow, request_encoding, request_body
+    ):
+        """Small compressed tweet create bodies still refine to Content: Create."""
+        flow = self._make_x_flow(
+            real_flow,
+            tmp_path,
+            path="/2/tweets",
+            body=json.dumps({"data": {"id": "1"}}).encode(),
+            status=201,
+            permission="tweet.write",
+            rule="POST /2/tweets",
+            request_body=request_body,
+            request_encoding=request_encoding,
+        )
+        flow.request.method = "POST"
+        p = self._call_and_get_single_billing(flow)
+        assert p["category"] == "content.create"
+        assert p["quantity"] == 1
+
+    def test_tweet_create_gzip_decoded_body_over_cap_stays_conservative(self, tmp_path, real_flow):
+        """A gzip body that expands beyond the billing inspection cap is not refined."""
+        long_text = "x" * body_utils.STREAM_BUFFER_LIMIT
+        request_body = gzip.compress(json.dumps({"text": long_text}).encode())
+        flow = self._make_x_flow(
+            real_flow,
+            tmp_path,
+            path="/2/tweets",
+            body=json.dumps({"data": {"id": "1"}}).encode(),
+            status=201,
+            permission="tweet.write",
+            rule="POST /2/tweets",
+            request_body=request_body,
+            request_encoding="gzip",
+        )
+        flow.request.method = "POST"
+        p = self._call_and_get_single_billing(flow)
+        assert p["category"] == "content.create_with_url"
+        assert p["quantity"] == 1
+
+    def test_tweet_create_raw_body_over_cap_stays_conservative(self, tmp_path, real_flow):
+        """An oversized identity request body is not refined."""
+        request_body = b"{" + b'"text":"' + b"x" * body_utils.STREAM_BUFFER_LIMIT + b'"}'
+        flow = self._make_x_flow(
+            real_flow,
+            tmp_path,
+            path="/2/tweets",
+            body=json.dumps({"data": {"id": "1"}}).encode(),
+            status=201,
+            permission="tweet.write",
+            rule="POST /2/tweets",
+            request_body=request_body,
+        )
+        flow.request.method = "POST"
+        p = self._call_and_get_single_billing(flow)
+        assert p["category"] == "content.create_with_url"
+        assert p["quantity"] == 1
+
+    @pytest.mark.parametrize("request_encoding", ["gzip", "br", "zstd", "x-vm0-test"])
+    def test_tweet_create_invalid_or_unsupported_encoding_stays_conservative(
+        self, tmp_path, real_flow, request_encoding
+    ):
+        """Invalid compressed or unsupported encoded bodies are not refined."""
+        flow = self._make_x_flow(
+            real_flow,
+            tmp_path,
+            path="/2/tweets",
+            body=json.dumps({"data": {"id": "1"}}).encode(),
+            status=201,
+            permission="tweet.write",
+            rule="POST /2/tweets",
+            request_body=b'{"text":"hello world"}',
+            request_encoding=request_encoding,
+        )
+        flow.request.method = "POST"
+        p = self._call_and_get_single_billing(flow)
+        assert p["category"] == "content.create_with_url"
+        assert p["quantity"] == 1
+
+    def test_non_refinement_flow_does_not_decode_request_body(self, tmp_path, real_flow):
+        """Only body-refinement candidates should inspect request content."""
+        flow = self._make_x_flow(
+            real_flow,
+            tmp_path,
+            path="/2/tweets/123/retweeted_by?max_results=10",
+            body=json.dumps({"data": [{"id": "u1"}]}).encode(),
+            permission="tweet.read",
+            rule="GET /2/tweets/{id}/retweeted_by",
+            request_body=gzip.compress(b'{"unused": true}'),
+            request_encoding="gzip",
+        )
+        flow.metadata["original_url"] = "https://api.x.com/2/tweets/123/retweeted_by?max_results=10"
+
+        with patch(
+            "mitmproxy.net.encoding.decode",
+            side_effect=AssertionError("request body should not be decoded"),
+        ):
+            p = self._call_and_get_single_billing(flow)
+
+        assert p["category"] == "user.read"
         assert p["quantity"] == 1
 
     @pytest.mark.parametrize(


### PR DESCRIPTION
## Summary

- Gate X request-body inspection to body-refinement candidates instead of reading `flow.request.content` for every billable X flow.
- Add a conservative bounded request-body decoder for billing inspection that fails closed on unsupported, invalid, incomplete, or oversized bodies.
- Preserve existing tweet-create bucket refinement semantics for small valid bodies and add regression coverage for gzip/cap/fail-closed cases.

Closes #15705

## Tests

- `PYTHONPATH=/tmp/vm7-mitm-addon-deps PATH=/tmp/vm7-mitm-addon-deps/bin:$PATH ruff format src/body_utils.py src/usage/providers/connectors/x.py src/usage/providers/connectors/x_billing.py tests/test_connector_usage.py`
- `PYTHONPATH=/tmp/vm7-mitm-addon-deps PATH=/tmp/vm7-mitm-addon-deps/bin:$PATH ruff check src/body_utils.py src/usage/providers/connectors/x.py src/usage/providers/connectors/x_billing.py tests/test_connector_usage.py`
- `PYTHONPATH=/tmp/vm7-mitm-addon-deps PATH=/tmp/vm7-mitm-addon-deps/bin:$PATH basedpyright -p .`
- `PYTHONPATH=/tmp/vm7-mitm-addon-deps PATH=/tmp/vm7-mitm-addon-deps/bin:$PATH pytest tests/test_connector_usage.py::TestReportConnectorUsage::test_tweet_create_gzip_plain_text_downgrades_to_content_create tests/test_connector_usage.py::TestReportConnectorUsage::test_tweet_create_gzip_decoded_body_over_cap_stays_conservative tests/test_connector_usage.py::TestReportConnectorUsage::test_tweet_create_raw_body_over_cap_stays_conservative tests/test_connector_usage.py::TestReportConnectorUsage::test_tweet_create_invalid_or_unsupported_encoding_stays_conservative tests/test_connector_usage.py::TestReportConnectorUsage::test_non_refinement_flow_does_not_decode_request_body -q`
- `PYTHONPATH=/tmp/vm7-mitm-addon-deps PATH=/tmp/vm7-mitm-addon-deps/bin:$PATH pytest tests/test_connector_usage.py -q`
- `PYTHONPATH=/tmp/vm7-mitm-addon-deps PATH=/tmp/vm7-mitm-addon-deps/bin:$PATH pytest tests/test_response_streaming.py tests/test_body_capture.py -q`
- `PYTHONPATH=/tmp/vm7-mitm-addon-deps PATH=/tmp/vm7-mitm-addon-deps/bin:$PATH pytest tests -q`
