### PR TITLE
refactor: derive platform secrets from access config

### DIFF
--- a/turbo/apps/api/src/signals/routes/__tests__/connectors-type-callback.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/connectors-type-callback.test.ts
@@ -1015,7 +1015,7 @@ async function findDecryptedSecret(args: {
   return secret ? decryptSecretForTests(secret.encryptedValue) : undefined;
 }
 
-function staticAccessSecretName(
+function staticConnectorOwnedAccessSecretName(
   envBindings: Readonly<Record<string, string>>,
   platformSecretNames: ReadonlySet<string>,
 ): string | undefined {
@@ -1051,7 +1051,7 @@ function accessTokenSecretNameForAuthCodeMethod(
       return accessMetadata.accessToken;
     }
     case "static": {
-      const secretName = staticAccessSecretName(
+      const secretName = staticConnectorOwnedAccessSecretName(
         accessMetadata.envBindings,
         new Set(accessMetadata.platformSecrets),
       );

--- a/turbo/apps/api/src/signals/routes/__tests__/connectors-type-callback.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/connectors-type-callback.test.ts
@@ -1017,11 +1017,15 @@ async function findDecryptedSecret(args: {
 
 function staticAccessSecretName(
   envBindings: Readonly<Record<string, string>>,
+  platformSecretNames: ReadonlySet<string>,
 ): string | undefined {
   const secretNames = new Set<string>();
   for (const valueRef of Object.values(envBindings)) {
     if (valueRef.startsWith(SECRET_REF_PREFIX)) {
-      secretNames.add(valueRef.slice(SECRET_REF_PREFIX.length));
+      const secretName = valueRef.slice(SECRET_REF_PREFIX.length);
+      if (!platformSecretNames.has(secretName)) {
+        secretNames.add(secretName);
+      }
     }
   }
   return secretNames.size === 1 ? [...secretNames][0] : undefined;
@@ -1047,7 +1051,10 @@ function accessTokenSecretNameForAuthCodeMethod(
       return accessMetadata.accessToken;
     }
     case "static": {
-      const secretName = staticAccessSecretName(accessMetadata.envBindings);
+      const secretName = staticAccessSecretName(
+        accessMetadata.envBindings,
+        new Set(accessMetadata.platformSecrets),
+      );
       if (!secretName) {
         throw new Error(
           `${type}: auth-code auth method has no static access secret`,

--- a/turbo/apps/api/src/signals/routes/__tests__/zero-runs-create.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/zero-runs-create.test.ts
@@ -1860,7 +1860,8 @@ describe("POST /api/zero/runs", () => {
     );
   });
 
-  it("injects authorized Slock OAuth secrets through the runtime firewall", async () => {
+  it("injects authorized Slock OAuth secrets through the runtime firewall without platform secrets", async () => {
+    mockOptionalEnv("GOOGLE_ADS_DEVELOPER_TOKEN", "developer-token");
     const fx = await fixture();
     const db = store.set(writeDb$);
     const agent = await seedRunnableZeroAgent({ fixture: fx });
@@ -1947,6 +1948,7 @@ describe("POST /api/zero/runs", () => {
     });
     expect(decrypted).not.toHaveProperty("SLOCK_ACCESS_TOKEN");
     expect(decrypted).not.toHaveProperty("SLOCK_REFRESH_TOKEN");
+    expect(decrypted).not.toHaveProperty("GOOGLE_ADS_DEVELOPER_TOKEN");
     expect(executionContext.secretConnectorMap).toStrictEqual({
       SLOCK_TOKEN: "slock",
     });
@@ -1999,6 +2001,7 @@ describe("POST /api/zero/runs", () => {
       .from(runnerJobQueue)
       .where(eq(runnerJobQueue.runId, response.body.runId));
     const executionContext = job?.executionContext as {
+      readonly environment: Record<string, string>;
       readonly encryptedSecrets: string | null;
       readonly secretConnectorMap: Record<string, string> | null;
       readonly firewalls: readonly { readonly name: string }[];
@@ -2009,6 +2012,9 @@ describe("POST /api/zero/runs", () => {
       GOOGLE_ADS_TOKEN: "google-ads-access",
       GOOGLE_ADS_DEVELOPER_TOKEN: "developer-token",
     });
+    expect(executionContext.environment).not.toHaveProperty(
+      "GOOGLE_ADS_DEVELOPER_TOKEN",
+    );
     expect(executionContext.secretConnectorMap).toStrictEqual({
       GOOGLE_ADS_TOKEN: "google-ads",
     });

--- a/turbo/apps/api/src/signals/services/agent-run-create.service.ts
+++ b/turbo/apps/api/src/signals/services/agent-run-create.service.ts
@@ -153,7 +153,6 @@ function getEffectiveConcurrencyLimit(tier: keyof typeof TIER_LIMITS): number {
 
 const ORG_SENTINEL_USER_ID = "__org__";
 const CUSTOM_CONNECTOR_SECRET_PLACEHOLDER = "{{secret}}";
-const PLATFORM_ENV_SECRET_NAMES = ["GOOGLE_ADS_DEVELOPER_TOKEN"] as const;
 const L = logger("AgentRunCreate");
 const CONNECTOR_SECRET_REF_PREFIX = "$secrets.";
 const CONNECTOR_VAR_REF_PREFIX = "$vars.";
@@ -1554,6 +1553,7 @@ interface ConnectorEnvBindingSet {
   readonly connectorType: ConnectorType;
   readonly authMethod: string;
   readonly envBindings: Record<string, string>;
+  readonly platformSecretNames: ReadonlySet<string>;
   readonly optionalSecretNames: ReadonlySet<string>;
   readonly optionalVariableNames: ReadonlySet<string>;
 }
@@ -1603,6 +1603,10 @@ function connectorEnvBindingSets(
 ): readonly ConnectorEnvBindingSet[] {
   return rows.map((row) => {
     const method = getConnectorAuthMethod(row.connectorType, row.authMethod);
+    const accessMetadata = getConnectorAuthMethodAccessMetadata(
+      row.connectorType,
+      row.authMethod,
+    );
     if (!method) {
       throw new Error(
         `Invalid auth method "${row.authMethod}" for stored connector "${row.connectorType}"`,
@@ -1629,6 +1633,7 @@ function connectorEnvBindingSets(
         row.connectorType,
         row.authMethod,
       ),
+      platformSecretNames: new Set(accessMetadata?.platformSecrets ?? []),
       optionalSecretNames,
       optionalVariableNames,
     };
@@ -1641,10 +1646,13 @@ function collectStoredConnectorRequirements(
   const secretNames = new Set<string>();
   const variableNames = new Set<string>();
 
-  for (const { envBindings } of bindingSets) {
+  for (const { envBindings, platformSecretNames } of bindingSets) {
     for (const valueRef of Object.values(envBindings)) {
       if (valueRef.startsWith(CONNECTOR_SECRET_REF_PREFIX)) {
-        secretNames.add(valueRef.slice(CONNECTOR_SECRET_REF_PREFIX.length));
+        const secretName = valueRef.slice(CONNECTOR_SECRET_REF_PREFIX.length);
+        if (!platformSecretNames.has(secretName)) {
+          secretNames.add(secretName);
+        }
       } else if (valueRef.startsWith(CONNECTOR_VAR_REF_PREFIX)) {
         variableNames.add(valueRef.slice(CONNECTOR_VAR_REF_PREFIX.length));
       }
@@ -1724,6 +1732,23 @@ async function loadStoredConnectorVariables(
   );
 }
 
+function resolvePlatformSecretBinding(args: {
+  readonly secrets: Record<string, string>;
+  readonly envName: string;
+  readonly secretName: string;
+  readonly platformSecretNames: ReadonlySet<string>;
+}): boolean {
+  if (!args.platformSecretNames.has(args.secretName)) {
+    return false;
+  }
+
+  const secretValue = optionalEnv(args.secretName);
+  if (secretValue) {
+    args.secrets[args.envName] = secretValue;
+  }
+  return true;
+}
+
 function resolveStoredConnectorState(
   bindingSets: readonly ConnectorEnvBindingSet[],
   connectorSecrets: Record<string, string>,
@@ -1738,12 +1763,23 @@ function resolveStoredConnectorState(
     connectorType,
     authMethod,
     envBindings,
+    platformSecretNames,
     optionalSecretNames,
     optionalVariableNames,
   } of bindingSets) {
     for (const [envName, valueRef] of Object.entries(envBindings)) {
       if (valueRef.startsWith(CONNECTOR_SECRET_REF_PREFIX)) {
         const secretName = valueRef.slice(CONNECTOR_SECRET_REF_PREFIX.length);
+        if (
+          resolvePlatformSecretBinding({
+            secrets,
+            envName,
+            secretName,
+            platformSecretNames,
+          })
+        ) {
+          continue;
+        }
         const secretValue = connectorSecrets[secretName];
         if (secretValue !== undefined) {
           secrets[envName] = secretValue;
@@ -1782,9 +1818,14 @@ function resolveStoredConnectorState(
       for (const [envName, valueRef] of Object.entries(
         accessMetadata.envBindings,
       )) {
-        if (valueRef.startsWith(CONNECTOR_SECRET_REF_PREFIX)) {
-          secretConnectorMap[envName] = connectorType;
+        if (!valueRef.startsWith(CONNECTOR_SECRET_REF_PREFIX)) {
+          continue;
         }
+        const secretName = valueRef.slice(CONNECTOR_SECRET_REF_PREFIX.length);
+        if (platformSecretNames.has(secretName)) {
+          continue;
+        }
+        secretConnectorMap[envName] = connectorType;
       }
     }
   }
@@ -1860,23 +1901,6 @@ async function loadStoredConnectorContext(
       storedEnvironment: compactRecord(resolved.environment),
     };
   });
-}
-
-function injectPlatformEnvSecrets(
-  connectorTypes: readonly ConnectorType[],
-): Record<string, string> | undefined {
-  if (!connectorTypes.includes("google-ads")) {
-    return undefined;
-  }
-
-  const result: Record<string, string> = {};
-  for (const name of PLATFORM_ENV_SECRET_NAMES) {
-    const value = optionalEnv(name);
-    if (value) {
-      result[name] = value;
-    }
-  }
-  return compactRecord(result);
 }
 
 function customConnectorSecretKey(connectorId: string): string {
@@ -2993,16 +3017,12 @@ function buildStoredExecutionSecrets(args: {
   readonly bodySecrets: Record<string, string> | undefined;
   readonly customConnectorContext: CustomConnectorRuntimeContext;
 }): StoredExecutionSecrets {
-  const platformSecrets = injectPlatformEnvSecrets(
-    args.connectorContext.connectorTypes,
-  );
   const filteredConnectorMap = filterSecretConnectorMap({
     secretConnectorMap: args.connectorContext.secretConnectorMap,
     overriddenSecrets: [
       args.modelProvider?.secrets,
       args.bodySecrets,
       args.customConnectorContext.secrets,
-      platformSecrets,
     ],
   });
   // The merged map is the runtime `secrets.NAME` namespace consumed by firewall
@@ -3015,7 +3035,6 @@ function buildStoredExecutionSecrets(args: {
       args.modelProvider?.secrets,
       args.bodySecrets,
       args.customConnectorContext.secrets,
-      platformSecrets,
     ),
     secretConnectorMap:
       mergeRecords(

--- a/turbo/apps/api/src/signals/services/agent-run-create.service.ts
+++ b/turbo/apps/api/src/signals/services/agent-run-create.service.ts
@@ -347,9 +347,6 @@ interface CreateAgentRunArgs {
 
 interface ConnectorRuntimeContext {
   readonly secrets: Record<string, string> | undefined;
-  // Platform-owned connector secrets are kept separate so they preserve the old
-  // final-merge precedence and never enter connector refresh ownership maps.
-  readonly platformSecrets: Record<string, string> | undefined;
   readonly vars: Record<string, string> | undefined;
   readonly secretConnectorMap: Record<string, string> | undefined;
   readonly connectorTypes: readonly ConnectorType[];
@@ -1568,7 +1565,6 @@ interface StoredConnectorRequirements {
 
 interface ResolvedStoredConnectorState {
   readonly secrets: Record<string, string>;
-  readonly platformSecrets: Record<string, string>;
   readonly vars: Record<string, string>;
   readonly secretConnectorMap: Record<string, string>;
   readonly environment: Record<string, string>;
@@ -1577,7 +1573,6 @@ interface ResolvedStoredConnectorState {
 function emptyConnectorRuntimeContext(): ConnectorRuntimeContext {
   return {
     secrets: undefined,
-    platformSecrets: undefined,
     vars: undefined,
     secretConnectorMap: undefined,
     connectorTypes: [],
@@ -1737,8 +1732,8 @@ async function loadStoredConnectorVariables(
   );
 }
 
-function resolvePlatformSecretBinding(args: {
-  readonly platformSecrets: Record<string, string>;
+function handlePlatformSecretBinding(args: {
+  readonly secrets: Record<string, string>;
   readonly envName: string;
   readonly secretName: string;
   readonly platformSecretNames: ReadonlySet<string>;
@@ -1749,7 +1744,7 @@ function resolvePlatformSecretBinding(args: {
 
   const secretValue = optionalEnv(args.secretName);
   if (secretValue) {
-    args.platformSecrets[args.envName] = secretValue;
+    args.secrets[args.envName] = secretValue;
   }
   return true;
 }
@@ -1760,7 +1755,6 @@ function resolveStoredConnectorState(
   connectorVariables: Record<string, string>,
 ): ResolvedStoredConnectorState {
   const secrets: Record<string, string> = {};
-  const platformSecrets: Record<string, string> = {};
   const vars: Record<string, string> = {};
   const secretConnectorMap: Record<string, string> = {};
   const environment: Record<string, string> = {};
@@ -1777,8 +1771,8 @@ function resolveStoredConnectorState(
       if (valueRef.startsWith(CONNECTOR_SECRET_REF_PREFIX)) {
         const secretName = valueRef.slice(CONNECTOR_SECRET_REF_PREFIX.length);
         if (
-          resolvePlatformSecretBinding({
-            platformSecrets,
+          handlePlatformSecretBinding({
+            secrets,
             envName,
             secretName,
             platformSecretNames,
@@ -1838,7 +1832,6 @@ function resolveStoredConnectorState(
 
   return {
     secrets,
-    platformSecrets,
     vars,
     secretConnectorMap,
     environment,
@@ -1900,7 +1893,6 @@ async function loadStoredConnectorContext(
 
     return {
       secrets: compactRecord(resolved.secrets),
-      platformSecrets: compactRecord(resolved.platformSecrets),
       vars: compactRecord(resolved.vars),
       secretConnectorMap: compactRecord(resolved.secretConnectorMap),
       connectorTypes: allowedConnectorRows.map((row) => {
@@ -3031,7 +3023,6 @@ function buildStoredExecutionSecrets(args: {
       args.modelProvider?.secrets,
       args.bodySecrets,
       args.customConnectorContext.secrets,
-      args.connectorContext.platformSecrets,
     ],
   });
   // The merged map is the runtime `secrets.NAME` namespace consumed by firewall
@@ -3044,7 +3035,6 @@ function buildStoredExecutionSecrets(args: {
       args.modelProvider?.secrets,
       args.bodySecrets,
       args.customConnectorContext.secrets,
-      args.connectorContext.platformSecrets,
     ),
     secretConnectorMap:
       mergeRecords(

--- a/turbo/apps/api/src/signals/services/agent-run-create.service.ts
+++ b/turbo/apps/api/src/signals/services/agent-run-create.service.ts
@@ -347,6 +347,9 @@ interface CreateAgentRunArgs {
 
 interface ConnectorRuntimeContext {
   readonly secrets: Record<string, string> | undefined;
+  // Platform-owned connector secrets are kept separate so they preserve the old
+  // final-merge precedence and never enter connector refresh ownership maps.
+  readonly platformSecrets: Record<string, string> | undefined;
   readonly vars: Record<string, string> | undefined;
   readonly secretConnectorMap: Record<string, string> | undefined;
   readonly connectorTypes: readonly ConnectorType[];
@@ -1565,6 +1568,7 @@ interface StoredConnectorRequirements {
 
 interface ResolvedStoredConnectorState {
   readonly secrets: Record<string, string>;
+  readonly platformSecrets: Record<string, string>;
   readonly vars: Record<string, string>;
   readonly secretConnectorMap: Record<string, string>;
   readonly environment: Record<string, string>;
@@ -1573,6 +1577,7 @@ interface ResolvedStoredConnectorState {
 function emptyConnectorRuntimeContext(): ConnectorRuntimeContext {
   return {
     secrets: undefined,
+    platformSecrets: undefined,
     vars: undefined,
     secretConnectorMap: undefined,
     connectorTypes: [],
@@ -1733,7 +1738,7 @@ async function loadStoredConnectorVariables(
 }
 
 function resolvePlatformSecretBinding(args: {
-  readonly secrets: Record<string, string>;
+  readonly platformSecrets: Record<string, string>;
   readonly envName: string;
   readonly secretName: string;
   readonly platformSecretNames: ReadonlySet<string>;
@@ -1744,7 +1749,7 @@ function resolvePlatformSecretBinding(args: {
 
   const secretValue = optionalEnv(args.secretName);
   if (secretValue) {
-    args.secrets[args.envName] = secretValue;
+    args.platformSecrets[args.envName] = secretValue;
   }
   return true;
 }
@@ -1755,6 +1760,7 @@ function resolveStoredConnectorState(
   connectorVariables: Record<string, string>,
 ): ResolvedStoredConnectorState {
   const secrets: Record<string, string> = {};
+  const platformSecrets: Record<string, string> = {};
   const vars: Record<string, string> = {};
   const secretConnectorMap: Record<string, string> = {};
   const environment: Record<string, string> = {};
@@ -1772,7 +1778,7 @@ function resolveStoredConnectorState(
         const secretName = valueRef.slice(CONNECTOR_SECRET_REF_PREFIX.length);
         if (
           resolvePlatformSecretBinding({
-            secrets,
+            platformSecrets,
             envName,
             secretName,
             platformSecretNames,
@@ -1832,6 +1838,7 @@ function resolveStoredConnectorState(
 
   return {
     secrets,
+    platformSecrets,
     vars,
     secretConnectorMap,
     environment,
@@ -1893,6 +1900,7 @@ async function loadStoredConnectorContext(
 
     return {
       secrets: compactRecord(resolved.secrets),
+      platformSecrets: compactRecord(resolved.platformSecrets),
       vars: compactRecord(resolved.vars),
       secretConnectorMap: compactRecord(resolved.secretConnectorMap),
       connectorTypes: allowedConnectorRows.map((row) => {
@@ -3023,6 +3031,7 @@ function buildStoredExecutionSecrets(args: {
       args.modelProvider?.secrets,
       args.bodySecrets,
       args.customConnectorContext.secrets,
+      args.connectorContext.platformSecrets,
     ],
   });
   // The merged map is the runtime `secrets.NAME` namespace consumed by firewall
@@ -3035,6 +3044,7 @@ function buildStoredExecutionSecrets(args: {
       args.modelProvider?.secrets,
       args.bodySecrets,
       args.customConnectorContext.secrets,
+      args.connectorContext.platformSecrets,
     ),
     secretConnectorMap:
       mergeRecords(

--- a/turbo/apps/api/src/signals/services/zero-connector-data.service.ts
+++ b/turbo/apps/api/src/signals/services/zero-connector-data.service.ts
@@ -1180,7 +1180,7 @@ function connectorSecretNameFromRef(valueRef: string): string | undefined {
     : undefined;
 }
 
-function staticAccessSecretName(
+function staticConnectorOwnedAccessSecretName(
   envBindings: ConnectorEnvBindings,
   platformSecretNames: ReadonlySet<string>,
 ): string | undefined {
@@ -1216,7 +1216,7 @@ function connectorTokenSecretMetadataForAuthMethod(args: {
     }
 
     case "static": {
-      const accessSecretName = staticAccessSecretName(
+      const accessSecretName = staticConnectorOwnedAccessSecretName(
         accessMetadata.envBindings,
         new Set(accessMetadata.platformSecrets),
       );

--- a/turbo/apps/api/src/signals/services/zero-connector-data.service.ts
+++ b/turbo/apps/api/src/signals/services/zero-connector-data.service.ts
@@ -13,7 +13,7 @@ import {
   getConnectorAuthMethodEnvBindings,
   getConnectorAuthMethod,
   getConnectorManualGrantFieldNames,
-  getConnectorSecretNames,
+  getConnectorOwnedSecretNames,
   getConnectorVariableNames,
   getRuntimeAvailableConnectorTypes,
   type ManualGrantFieldNames,
@@ -676,7 +676,7 @@ export const deleteZeroConnectorLocalState$ = command(
       await deleteConnectorScopedSecretNames(tx, {
         orgId: args.orgId,
         userId: args.userId,
-        names: getConnectorSecretNames(args.type, existing.authMethod),
+        names: getConnectorOwnedSecretNames(args.type, existing.authMethod),
         signal,
       });
       await deleteConnectorScopedVariableNames(tx, {
@@ -968,7 +968,7 @@ async function cleanupExistingStoredConnectorForManualGrantConnect(
   await deleteConnectorScopedSecretNames(db, {
     orgId: args.orgId,
     userId: args.userId,
-    names: getConnectorSecretNames(args.type, existing.authMethod),
+    names: getConnectorOwnedSecretNames(args.type, existing.authMethod),
     signal: args.signal,
   });
   await deleteConnectorScopedVariableNames(db, {
@@ -1240,7 +1240,7 @@ function allowedConnectorTokenSecretNames(
   type: ConnectorAuthProviderType,
   authMethod: ConnectorAuthMethodId,
 ): Set<string> {
-  return new Set(getConnectorSecretNames(type, authMethod));
+  return new Set(getConnectorOwnedSecretNames(type, authMethod));
 }
 
 function isPrimaryConnectorTokenSecret(args: {
@@ -1478,9 +1478,9 @@ async function deleteObsoleteConnectorScopedStateForTokenConnect(
   }
 
   const targetSecretNames = new Set(
-    getConnectorSecretNames(args.type, args.authMethod),
+    getConnectorOwnedSecretNames(args.type, args.authMethod),
   );
-  const obsoleteSecretNames = getConnectorSecretNames(
+  const obsoleteSecretNames = getConnectorOwnedSecretNames(
     args.type,
     args.existingAuthMethod,
   ).filter((name) => {

--- a/turbo/apps/api/src/signals/services/zero-connector-data.service.ts
+++ b/turbo/apps/api/src/signals/services/zero-connector-data.service.ts
@@ -1182,11 +1182,12 @@ function connectorSecretNameFromRef(valueRef: string): string | undefined {
 
 function staticAccessSecretName(
   envBindings: ConnectorEnvBindings,
+  platformSecretNames: ReadonlySet<string>,
 ): string | undefined {
   const secretNames = new Set<string>();
   for (const valueRef of Object.values(envBindings)) {
     const secretName = connectorSecretNameFromRef(valueRef);
-    if (secretName) {
+    if (secretName && !platformSecretNames.has(secretName)) {
       secretNames.add(secretName);
     }
   }
@@ -1217,6 +1218,7 @@ function connectorTokenSecretMetadataForAuthMethod(args: {
     case "static": {
       const accessSecretName = staticAccessSecretName(
         accessMetadata.envBindings,
+        new Set(accessMetadata.platformSecrets),
       );
       return accessSecretName
         ? {

--- a/turbo/packages/api-contracts/src/contracts/index.ts
+++ b/turbo/packages/api-contracts/src/contracts/index.ts
@@ -708,7 +708,7 @@ export {
   type ConnectorEnvBindings,
 } from "@vm0/connectors/connectors";
 export {
-  getConnectorSecretNames,
+  getConnectorOwnedSecretNames,
   getConnectorEnvBindingEntries,
   getConnectorEnvNamesForSecret,
   getConnectorTypeForSecretName,

--- a/turbo/packages/connectors/src/__tests__/connectors.test.ts
+++ b/turbo/packages/connectors/src/__tests__/connectors.test.ts
@@ -50,7 +50,7 @@ import {
   getConnectorEnvBindingEntries,
   getConnectorManualGrantFieldNames,
   getRuntimeAvailableConnectorTypes,
-  getConnectorSecretNames,
+  getConnectorOwnedSecretNames,
   getConnectorVariableNames,
   hasConnectorAuthCodeGrant,
   hasConnectorDeviceAuthGrant,
@@ -459,7 +459,7 @@ describe("connector auth method config", () => {
 
     for (const type of CONNECTOR_TYPE_KEYS) {
       for (const authMethod of Object.keys(CONNECTOR_TYPES[type].authMethods)) {
-        for (const name of getConnectorSecretNames(type, authMethod)) {
+        for (const name of getConnectorOwnedSecretNames(type, authMethod)) {
           secretOwners.set(name, [
             ...(secretOwners.get(name) ?? []),
             `${type}:${authMethod}`,
@@ -1723,7 +1723,7 @@ describe("getConnectorAuthMethodAccessMetadata", () => {
   });
 
   it("excludes platform-owned sources from connector-owned secret names", () => {
-    expect(getConnectorSecretNames("google-ads", "oauth")).toStrictEqual([
+    expect(getConnectorOwnedSecretNames("google-ads", "oauth")).toStrictEqual([
       "GOOGLE_ADS_ACCESS_TOKEN",
       "GOOGLE_ADS_REFRESH_TOKEN",
     ]);
@@ -1845,7 +1845,7 @@ describe("getConnectorEnvBindingEntries", () => {
     for (const type of connectorTypeSchema.options) {
       if (!hasConnectorAuthorizationGrant(type)) continue;
 
-      const oauthSecrets = getConnectorSecretNames(type, "oauth");
+      const oauthSecrets = getConnectorOwnedSecretNames(type, "oauth");
       const prefix = oauthSecrets
         .find((s) => {
           return s.endsWith("_ACCESS_TOKEN");

--- a/turbo/packages/connectors/src/__tests__/connectors.test.ts
+++ b/turbo/packages/connectors/src/__tests__/connectors.test.ts
@@ -1705,10 +1705,31 @@ describe("getConnectorAuthMethodAccessMetadata", () => {
             `${type}/${authMethod}: platform secret ${secretName} must be exposed through envBindings`,
           ).toBe(true);
         }
+        const platformSecretNames: ReadonlySet<string> = new Set(
+          accessMetadata.platformSecrets,
+        );
+        const ownedSecretNames: ReadonlySet<string> = new Set(
+          getConnectorOwnedSecretNames(type, authMethod),
+        );
+        for (const secretName of platformSecretNames) {
+          expect(
+            ownedSecretNames.has(secretName),
+            `${type}/${authMethod}: platform secret ${secretName} must not be connector-owned`,
+          ).toBe(false);
+        }
+        const method = getConnectorAuthMethod(type, authMethod);
+        if (method?.grant.kind === "manual") {
+          for (const [name, field] of Object.entries(method.grant.fields)) {
+            if (field.storage === "variable") {
+              continue;
+            }
+            expect(
+              platformSecretNames.has(name),
+              `${type}/${authMethod}: manual grant secret ${name} must stay connector-owned`,
+            ).toBe(false);
+          }
+        }
         if (accessMetadata.kind === "refresh-token") {
-          const platformSecretNames: ReadonlySet<string> = new Set(
-            accessMetadata.platformSecrets,
-          );
           expect(
             platformSecretNames.has(accessMetadata.accessToken),
             `${type}/${authMethod}: access token storage must stay connector-owned`,

--- a/turbo/packages/connectors/src/__tests__/connectors.test.ts
+++ b/turbo/packages/connectors/src/__tests__/connectors.test.ts
@@ -1642,31 +1642,78 @@ describe("getConnectorAuthMethodEnvBindings", () => {
 
 describe("getConnectorAuthMethodAccessMetadata", () => {
   it("returns refresh-token access metadata for the selected OAuth method", () => {
-    expect(getConnectorAuthMethodAccessMetadata("stripe", "oauth")).toEqual({
+    expect(
+      getConnectorAuthMethodAccessMetadata("stripe", "oauth"),
+    ).toStrictEqual({
       kind: "refresh-token",
       accessToken: "STRIPE_ACCESS_TOKEN",
       refreshToken: "STRIPE_REFRESH_TOKEN",
       envBindings: {
         STRIPE_TOKEN: "$secrets.STRIPE_ACCESS_TOKEN",
       },
+      platformSecrets: [],
     });
   });
 
   it("returns static access metadata for the selected API-token method", () => {
-    expect(getConnectorAuthMethodAccessMetadata("stripe", "api-token")).toEqual(
-      {
-        kind: "static",
-        envBindings: {
-          STRIPE_TOKEN: "$secrets.STRIPE_TOKEN",
-        },
+    expect(
+      getConnectorAuthMethodAccessMetadata("stripe", "api-token"),
+    ).toStrictEqual({
+      kind: "static",
+      envBindings: {
+        STRIPE_TOKEN: "$secrets.STRIPE_TOKEN",
       },
-    );
+      platformSecrets: [],
+    });
+  });
+
+  it("returns platform-owned secret metadata for Google Ads", () => {
+    expect(
+      getConnectorAuthMethodAccessMetadata("google-ads", "oauth"),
+    ).toStrictEqual({
+      kind: "refresh-token",
+      accessToken: "GOOGLE_ADS_ACCESS_TOKEN",
+      refreshToken: "GOOGLE_ADS_REFRESH_TOKEN",
+      envBindings: {
+        GOOGLE_ADS_TOKEN: "$secrets.GOOGLE_ADS_ACCESS_TOKEN",
+        GOOGLE_ADS_DEVELOPER_TOKEN: "$secrets.GOOGLE_ADS_DEVELOPER_TOKEN",
+      },
+      platformSecrets: ["GOOGLE_ADS_DEVELOPER_TOKEN"],
+    });
   });
 
   it("returns undefined for an unknown auth method", () => {
     expect(
       getConnectorAuthMethodAccessMetadata("stripe", "missing"),
     ).toBeUndefined();
+  });
+
+  it("keeps platform-owned secrets referenced by selected env bindings", () => {
+    for (const type of connectorTypeSchema.options) {
+      for (const authMethod of getConfiguredConnectorAuthMethods(type)) {
+        const accessMetadata = getConnectorAuthMethodAccessMetadata(
+          type,
+          authMethod,
+        );
+        if (!accessMetadata) {
+          continue;
+        }
+        const secretRefs = new Set(Object.values(accessMetadata.envBindings));
+        for (const secretName of accessMetadata.platformSecrets) {
+          expect(
+            secretRefs.has(`$secrets.${secretName}`),
+            `${type}/${authMethod}: platform secret ${secretName} must be exposed through envBindings`,
+          ).toBe(true);
+        }
+      }
+    }
+  });
+
+  it("excludes platform-owned sources from connector-owned secret names", () => {
+    expect(getConnectorSecretNames("google-ads", "oauth")).toStrictEqual([
+      "GOOGLE_ADS_ACCESS_TOKEN",
+      "GOOGLE_ADS_REFRESH_TOKEN",
+    ]);
   });
 });
 
@@ -1780,7 +1827,7 @@ describe("getConnectorEnvBindingEntries", () => {
   it("authorization-grant auth methods have consistent secrets and envBindings naming", () => {
     // All naming derives from a single prefix XXX:
     //   oauth secrets:      XXX_ACCESS_TOKEN (required), XXX_REFRESH_TOKEN (optional)
-    //   envBindings: values -> declared connector secrets
+    //   envBindings: values -> declared connector secrets or platform sources
     //   api-token secrets:  XXX_TOKEN (if api-token auth method exists)
     for (const type of connectorTypeSchema.options) {
       if (!hasConnectorAuthorizationGrant(type)) continue;
@@ -1812,6 +1859,13 @@ describe("getConnectorEnvBindingEntries", () => {
       }
 
       const envBindings = getConnectorAuthMethodEnvBindings(type, "oauth");
+      const accessMetadata = getConnectorAuthMethodAccessMetadata(
+        type,
+        "oauth",
+      );
+      const platformSecretNames: ReadonlySet<string> = new Set(
+        accessMetadata?.platformSecrets ?? [],
+      );
       const mappedSecretNames = Object.values(envBindings).map((valueRef) => {
         expect(
           valueRef.startsWith("$secrets."),
@@ -1826,6 +1880,9 @@ describe("getConnectorEnvBindingEntries", () => {
       ).toContain(accessSecretName);
 
       for (const secretName of mappedSecretNames) {
+        if (platformSecretNames.has(secretName)) {
+          continue;
+        }
         expect(
           oauthSecrets,
           `${type}: mapped secret ${secretName} must be declared by OAuth auth method`,

--- a/turbo/packages/connectors/src/__tests__/connectors.test.ts
+++ b/turbo/packages/connectors/src/__tests__/connectors.test.ts
@@ -1705,6 +1705,19 @@ describe("getConnectorAuthMethodAccessMetadata", () => {
             `${type}/${authMethod}: platform secret ${secretName} must be exposed through envBindings`,
           ).toBe(true);
         }
+        if (accessMetadata.kind === "refresh-token") {
+          const platformSecretNames: ReadonlySet<string> = new Set(
+            accessMetadata.platformSecrets,
+          );
+          expect(
+            platformSecretNames.has(accessMetadata.accessToken),
+            `${type}/${authMethod}: access token storage must stay connector-owned`,
+          ).toBe(false);
+          expect(
+            platformSecretNames.has(accessMetadata.refreshToken),
+            `${type}/${authMethod}: refresh token storage must stay connector-owned`,
+          ).toBe(false);
+        }
       }
     }
   });

--- a/turbo/packages/connectors/src/__tests__/firewall-secret-consistency.test.ts
+++ b/turbo/packages/connectors/src/__tests__/firewall-secret-consistency.test.ts
@@ -14,12 +14,6 @@ import { getConnectorFirewall, isFirewallConnectorType } from "../firewalls";
 const CONNECTOR_SECRET_REF_PREFIX = "$secrets.";
 const CONNECTOR_VAR_REF_PREFIX = "$vars.";
 
-const PLATFORM_INJECTED_SECRET_NAMES: Partial<
-  Record<string, readonly string[]>
-> = {
-  "google-ads": ["GOOGLE_ADS_DEVELOPER_TOKEN"],
-};
-
 interface ConnectorAuthSources {
   readonly secretBackedKeys: ReadonlySet<string>;
   readonly variableBackedKeys: ReadonlySet<string>;
@@ -122,10 +116,6 @@ function connectorAuthSources(
     });
   }
 
-  for (const name of PLATFORM_INJECTED_SECRET_NAMES[connectorType] ?? []) {
-    secretBackedKeys.add(name);
-  }
-
   return { secretBackedKeys, variableBackedKeys };
 }
 
@@ -147,10 +137,6 @@ function connectorPlaceholderKeys(connectorType: ConnectorType): Set<string> {
     manualFields?.secrets.forEach((name) => {
       placeholderKeys.add(name);
     });
-  }
-
-  for (const name of PLATFORM_INJECTED_SECRET_NAMES[connectorType] ?? []) {
-    placeholderKeys.add(name);
   }
 
   return placeholderKeys;

--- a/turbo/packages/connectors/src/connector-utils.ts
+++ b/turbo/packages/connectors/src/connector-utils.ts
@@ -22,6 +22,7 @@ import {
   type ConnectorGrantConfig,
   type ConnectorGrantKind,
   type ConnectorManualGrantFieldConfig,
+  type ConnectorPlatformSecretName,
   type ConnectorRevokeKind,
   type ConnectorType,
   type AuthCodeGrantConnectorType,
@@ -227,20 +228,35 @@ function connectorAccessEnvBindings(
   }
 }
 
+function connectorAccessPlatformSecrets(
+  access: ConnectorAccessConfig,
+): readonly ConnectorPlatformSecretName[] {
+  switch (access.kind) {
+    case "static":
+    case "refresh-token":
+      return access.platformSecrets ?? [];
+    case "none":
+      return [];
+  }
+}
+
 export type ConnectorAuthMethodAccessMetadata =
   | {
       readonly kind: "static";
       readonly envBindings: ConnectorEnvBindings;
+      readonly platformSecrets: readonly ConnectorPlatformSecretName[];
     }
   | {
       readonly kind: "refresh-token";
       readonly accessToken: string;
       readonly refreshToken: string;
       readonly envBindings: ConnectorEnvBindings;
+      readonly platformSecrets: readonly ConnectorPlatformSecretName[];
     }
   | {
       readonly kind: "none";
       readonly envBindings: ConnectorEnvBindings;
+      readonly platformSecrets: readonly ConnectorPlatformSecretName[];
     };
 
 export function getConnectorAuthMethodAccessMetadata(
@@ -257,6 +273,7 @@ export function getConnectorAuthMethodAccessMetadata(
       return {
         kind: "static",
         envBindings: method.access.envBindings,
+        platformSecrets: method.access.platformSecrets ?? [],
       };
     case "refresh-token":
       return {
@@ -264,11 +281,13 @@ export function getConnectorAuthMethodAccessMetadata(
         accessToken: method.access.accessToken,
         refreshToken: method.access.refreshToken,
         envBindings: method.access.envBindings,
+        platformSecrets: method.access.platformSecrets ?? [],
       };
     case "none":
       return {
         kind: "none",
         envBindings: {},
+        platformSecrets: [],
       };
   }
 }
@@ -715,11 +734,17 @@ function connectorMethodSecretNames(
     }
   }
 
+  const platformSecretNames: ReadonlySet<string> = new Set(
+    connectorAccessPlatformSecrets(method.access),
+  );
   for (const valueRef of Object.values(
     connectorAccessEnvBindings(method.access),
   )) {
     if (valueRef.startsWith("$secrets.")) {
-      names.add(valueRef.slice("$secrets.".length));
+      const secretName = valueRef.slice("$secrets.".length);
+      if (!platformSecretNames.has(secretName)) {
+        names.add(secretName);
+      }
     }
   }
 

--- a/turbo/packages/connectors/src/connector-utils.ts
+++ b/turbo/packages/connectors/src/connector-utils.ts
@@ -743,17 +743,16 @@ function connectorMethodOwnedSecretNames(
     connectorAccessEnvBindings(method.access),
   )) {
     if (valueRef.startsWith("$secrets.")) {
-      names.add(valueRef.slice("$secrets.".length));
+      const secretName = valueRef.slice("$secrets.".length);
+      if (!platformSecretNames.has(secretName)) {
+        names.add(secretName);
+      }
     }
   }
 
   if (method.access.kind === "refresh-token") {
     names.add(method.access.accessToken);
     names.add(method.access.refreshToken);
-  }
-
-  for (const secretName of platformSecretNames) {
-    names.delete(secretName);
   }
 
   return [...names];

--- a/turbo/packages/connectors/src/connector-utils.ts
+++ b/turbo/packages/connectors/src/connector-utils.ts
@@ -736,9 +736,6 @@ function connectorMethodOwnedSecretNames(
     }
   }
 
-  const platformSecretNames: ReadonlySet<string> = new Set(
-    connectorAccessPlatformSecrets(method.access),
-  );
   for (const valueRef of Object.values(
     connectorAccessEnvBindings(method.access),
   )) {
@@ -752,6 +749,9 @@ function connectorMethodOwnedSecretNames(
     names.add(method.access.refreshToken);
   }
 
+  const platformSecretNames: ReadonlySet<string> = new Set(
+    connectorAccessPlatformSecrets(method.access),
+  );
   for (const secretName of platformSecretNames) {
     names.delete(secretName);
   }

--- a/turbo/packages/connectors/src/connector-utils.ts
+++ b/turbo/packages/connectors/src/connector-utils.ts
@@ -700,13 +700,15 @@ export function getRuntimeAvailableConnectorTypes(
 }
 
 /**
- * Get secret names for a specific auth method
+ * Get connector-owned secret storage names for a specific auth method.
  */
-export function getConnectorSecretNames(
+export function getConnectorOwnedSecretNames(
   type: ConnectorType,
   authMethod: string,
 ): string[] {
-  return connectorMethodSecretNames(getConnectorAuthMethod(type, authMethod));
+  return connectorMethodOwnedSecretNames(
+    getConnectorAuthMethod(type, authMethod),
+  );
 }
 
 /**
@@ -719,7 +721,7 @@ export function getConnectorVariableNames(
   return connectorMethodVariableNames(getConnectorAuthMethod(type, authMethod));
 }
 
-function connectorMethodSecretNames(
+function connectorMethodOwnedSecretNames(
   method: ConnectorAuthMethodConfig | undefined,
 ): string[] {
   if (!method) {
@@ -835,7 +837,7 @@ export function getConnectorEnvNamesForSecret(
     const config = CONNECTOR_TYPES[type];
 
     const found = Object.values(config.authMethods).some((method) => {
-      return connectorMethodSecretNames(method).includes(secretName);
+      return connectorMethodOwnedSecretNames(method).includes(secretName);
     });
     if (!found) {
       continue;
@@ -954,7 +956,7 @@ export function getConnectorTypeForSecretName(
       }
     }
     for (const method of Object.values(config.authMethods)) {
-      if (connectorMethodSecretNames(method).includes(name)) {
+      if (connectorMethodOwnedSecretNames(method).includes(name)) {
         return type;
       }
     }

--- a/turbo/packages/connectors/src/connector-utils.ts
+++ b/turbo/packages/connectors/src/connector-utils.ts
@@ -743,16 +743,17 @@ function connectorMethodOwnedSecretNames(
     connectorAccessEnvBindings(method.access),
   )) {
     if (valueRef.startsWith("$secrets.")) {
-      const secretName = valueRef.slice("$secrets.".length);
-      if (!platformSecretNames.has(secretName)) {
-        names.add(secretName);
-      }
+      names.add(valueRef.slice("$secrets.".length));
     }
   }
 
   if (method.access.kind === "refresh-token") {
     names.add(method.access.accessToken);
     names.add(method.access.refreshToken);
+  }
+
+  for (const secretName of platformSecretNames) {
+    names.delete(secretName);
   }
 
   return [...names];

--- a/turbo/packages/connectors/src/connectors.ts
+++ b/turbo/packages/connectors/src/connectors.ts
@@ -362,6 +362,10 @@ export type ConnectorPlatformSecretName =
 
 interface ConnectorEnvBindingAccessConfigBase {
   readonly envBindings: ConnectorEnvBindings;
+  /**
+   * `$secrets.NAME` backing sources read from platform env instead of connector
+   * DB storage. Runtime aliases must still be declared in `envBindings`.
+   */
   readonly platformSecrets?: readonly ConnectorPlatformSecretName[];
 }
 

--- a/turbo/packages/connectors/src/connectors.ts
+++ b/turbo/packages/connectors/src/connectors.ts
@@ -354,17 +354,26 @@ export type ConnectorAccessKind = "static" | "refresh-token" | "none";
 
 export type ConnectorEnvBindings = Record<string, string>;
 
-export interface ConnectorStaticAccessConfig {
-  readonly kind: "static";
+export const CONNECTOR_PLATFORM_SECRET_NAMES = [
+  "GOOGLE_ADS_DEVELOPER_TOKEN",
+] as const;
+export type ConnectorPlatformSecretName =
+  (typeof CONNECTOR_PLATFORM_SECRET_NAMES)[number];
+
+interface ConnectorEnvBindingAccessConfigBase {
   readonly envBindings: ConnectorEnvBindings;
+  readonly platformSecrets?: readonly ConnectorPlatformSecretName[];
 }
 
-export interface ConnectorRefreshTokenAccessConfig {
+export interface ConnectorStaticAccessConfig extends ConnectorEnvBindingAccessConfigBase {
+  readonly kind: "static";
+}
+
+export interface ConnectorRefreshTokenAccessConfig extends ConnectorEnvBindingAccessConfigBase {
   readonly kind: "refresh-token";
   readonly tokenUrl: string;
   readonly accessToken: string;
   readonly refreshToken: string;
-  readonly envBindings: ConnectorEnvBindings;
 }
 
 export interface ConnectorNoAccessConfig {

--- a/turbo/packages/connectors/src/connectors/google-ads.ts
+++ b/turbo/packages/connectors/src/connectors/google-ads.ts
@@ -33,8 +33,10 @@ export const googleAds = {
           tokenUrl: OAUTH_TOKEN_URL,
           accessToken: "GOOGLE_ADS_ACCESS_TOKEN",
           refreshToken: "GOOGLE_ADS_REFRESH_TOKEN",
+          platformSecrets: ["GOOGLE_ADS_DEVELOPER_TOKEN"],
           envBindings: {
             GOOGLE_ADS_TOKEN: "$secrets.GOOGLE_ADS_ACCESS_TOKEN",
+            GOOGLE_ADS_DEVELOPER_TOKEN: "$secrets.GOOGLE_ADS_DEVELOPER_TOKEN",
           },
         },
         revoke: { kind: "none" },

--- a/turbo/packages/core/src/index.ts
+++ b/turbo/packages/core/src/index.ts
@@ -220,7 +220,7 @@ export {
   triggerSourceSchema,
   connectorTypeSchema,
   CONNECTOR_TYPES,
-  getConnectorSecretNames,
+  getConnectorOwnedSecretNames,
   getConnectorEnvBindingEntries,
   getConnectorEnvNamesForSecret,
   getConnectorTypeForSecretName,


### PR DESCRIPTION
## Summary

- add selected access config metadata for platform-owned secret sources
- move Google Ads developer token injection from API special-casing into the selected Google Ads access config
- treat platform-owned access-stage secrets as runtime connector secrets while keeping them out of connector-owned DB loading and refresh ownership maps
- update connector/firewall/API coverage for Google Ads and non-Google connector runs

Closes #15719

## Follow-up

- Refresh semantics for platform-backed access-stage secrets may need separate cleanup; this PR keeps that out of scope.

## Tests

- pnpm -F @vm0/connectors exec vitest run src/__tests__/connectors.test.ts src/__tests__/firewall-secret-consistency.test.ts
- pnpm -F api exec vitest run src/signals/routes/__tests__/zero-runs-create.test.ts src/signals/routes/__tests__/connectors-type-callback.test.ts
- pnpm -F @vm0/connectors lint
- pnpm -F api lint
- pnpm check-types
