### PR TITLE
refactor(api): model zero-logs.service.ts helpers as computed (#15737)

### DIFF
--- a/turbo/apps/api/src/signals/services/zero-logs.service.ts
+++ b/turbo/apps/api/src/signals/services/zero-logs.service.ts
@@ -1,4 +1,4 @@
-import { computed, type Computed, type Getter } from "ccstate";
+import { computed, type Computed } from "ccstate";
 import {
   triggerSourceSchema,
   type LogDetail,
@@ -40,7 +40,6 @@ import { escapeAplString } from "../../lib/axiom-apl";
 import { now } from "../../lib/time";
 
 type ServiceDb = Pick<Db, "select" | "selectDistinct">;
-type ComputedGetter = Getter;
 
 const triggerAgentAlias = alias(zeroAgents, "trigger_agent");
 
@@ -601,83 +600,81 @@ function compareAxiomSearchEventsDesc(
   return left.sequenceNumber - right.sequenceNumber;
 }
 
-async function queryMatchingEvents(
-  get: ComputedGetter,
-  params: {
-    readonly dataset: string;
-    readonly sinceISO: string;
-    readonly targetRunIds: readonly string[];
-    readonly keyword: string;
-    readonly limit: number;
-  },
-): Promise<AxiomAgentEvent[]> {
-  const matchedEvents: AxiomAgentEvent[] = [];
-  const runIdChunks = chunkRunIds(params.targetRunIds);
-  for (
-    let index = 0;
-    index < runIdChunks.length;
-    index += AXIOM_SEARCH_QUERY_CONCURRENCY
-  ) {
-    const batch = runIdChunks.slice(
-      index,
-      index + AXIOM_SEARCH_QUERY_CONCURRENCY,
-    );
-    const batchEvents = await Promise.all(
-      batch.map(async (runIdChunk) => {
-        const searchApl = buildSearchApl({
-          dataset: params.dataset,
-          sinceISO: params.sinceISO,
-          runIds: runIdChunk,
-          keyword: params.keyword,
-          limit: params.limit + 1,
-        });
-        return (
-          await get(queryAxiom(searchApl))
-        ).slice() as unknown as AxiomAgentEvent[];
-      }),
-    );
+function queryMatchingEvents(params: {
+  readonly dataset: string;
+  readonly sinceISO: string;
+  readonly targetRunIds: readonly string[];
+  readonly keyword: string;
+  readonly limit: number;
+}): Computed<Promise<AxiomAgentEvent[]>> {
+  return computed(async (get): Promise<AxiomAgentEvent[]> => {
+    const matchedEvents: AxiomAgentEvent[] = [];
+    const runIdChunks = chunkRunIds(params.targetRunIds);
+    for (
+      let index = 0;
+      index < runIdChunks.length;
+      index += AXIOM_SEARCH_QUERY_CONCURRENCY
+    ) {
+      const batch = runIdChunks.slice(
+        index,
+        index + AXIOM_SEARCH_QUERY_CONCURRENCY,
+      );
+      const batchEvents = await Promise.all(
+        batch.map(async (runIdChunk) => {
+          const searchApl = buildSearchApl({
+            dataset: params.dataset,
+            sinceISO: params.sinceISO,
+            runIds: runIdChunk,
+            keyword: params.keyword,
+            limit: params.limit + 1,
+          });
+          return (
+            await get(queryAxiom(searchApl))
+          ).slice() as unknown as AxiomAgentEvent[];
+        }),
+      );
 
-    for (const events of batchEvents) {
-      matchedEvents.push(...events);
+      for (const events of batchEvents) {
+        matchedEvents.push(...events);
+      }
     }
-  }
 
-  return matchedEvents.sort(compareAxiomSearchEventsDesc);
+    return matchedEvents.sort(compareAxiomSearchEventsDesc);
+  });
 }
 
-async function getSearchContextMap(
-  get: ComputedGetter,
-  params: {
-    readonly dataset: string;
-    readonly matches: readonly AxiomAgentEvent[];
-    readonly before: number;
-    readonly after: number;
-  },
-): Promise<Map<string, AxiomAgentEvent>> {
-  const contextMap = new Map<string, AxiomAgentEvent>();
-  if (params.before === 0 && params.after === 0) {
-    return contextMap;
-  }
+function getSearchContextMap(params: {
+  readonly dataset: string;
+  readonly matches: readonly AxiomAgentEvent[];
+  readonly before: number;
+  readonly after: number;
+}): Computed<Promise<Map<string, AxiomAgentEvent>>> {
+  return computed(async (get): Promise<Map<string, AxiomAgentEvent>> => {
+    const contextMap = new Map<string, AxiomAgentEvent>();
+    if (params.before === 0 && params.after === 0) {
+      return contextMap;
+    }
 
-  const contextConditions = params.matches.map((match) => {
-    const seqMin = Math.max(0, match.sequenceNumber - params.before);
-    const seqMax = match.sequenceNumber + params.after;
-    return `(runId == "${escapeAplString(match.runId)}" and sequenceNumber >= ${seqMin} and sequenceNumber <= ${seqMax})`;
-  });
+    const contextConditions = params.matches.map((match) => {
+      const seqMin = Math.max(0, match.sequenceNumber - params.before);
+      const seqMax = match.sequenceNumber + params.after;
+      return `(runId == "${escapeAplString(match.runId)}" and sequenceNumber >= ${seqMin} and sequenceNumber <= ${seqMax})`;
+    });
 
-  const contextApl = `['${params.dataset}']
+    const contextApl = `['${params.dataset}']
 | where ${contextConditions.join("\n  or ")}
 | order by runId asc, sequenceNumber asc`;
 
-  const contextEvents = (
-    await get(queryAxiom(contextApl))
-  ).slice() as unknown as AxiomAgentEvent[];
+    const contextEvents = (
+      await get(queryAxiom(contextApl))
+    ).slice() as unknown as AxiomAgentEvent[];
 
-  for (const event of contextEvents) {
-    contextMap.set(`${event.runId}:${event.sequenceNumber}`, event);
-  }
+    for (const event of contextEvents) {
+      contextMap.set(`${event.runId}:${event.sequenceNumber}`, event);
+    }
 
-  return contextMap;
+    return contextMap;
+  });
 }
 
 function buildSearchResults(params: {
@@ -808,13 +805,15 @@ export function zeroLogSearch(
       }
     }
 
-    const matchedEvents = await queryMatchingEvents(get, {
-      dataset,
-      sinceISO,
-      targetRunIds,
-      keyword,
-      limit,
-    });
+    const matchedEvents = await get(
+      queryMatchingEvents({
+        dataset,
+        sinceISO,
+        targetRunIds,
+        keyword,
+        limit,
+      }),
+    );
     if (matchedEvents.length === 0) {
       return { results: [], hasMore: false };
     }
@@ -822,12 +821,14 @@ export function zeroLogSearch(
     const hasMore = matchedEvents.length > limit;
     const matches = hasMore ? matchedEvents.slice(0, limit) : matchedEvents;
 
-    const contextMap = await getSearchContextMap(get, {
-      dataset,
-      matches,
-      before,
-      after,
-    });
+    const contextMap = await get(
+      getSearchContextMap({
+        dataset,
+        matches,
+        before,
+        after,
+      }),
+    );
     const matchedRunIds = [
       ...new Set(
         matches.map((e) => {


### PR DESCRIPTION
Closes #15737

## Summary

Removes the ccstate get-as-parameter anti-pattern from `turbo/apps/api/src/signals/services/zero-logs.service.ts`.

- Converted the two read-only helpers `queryMatchingEvents` and `getSearchContextMap` (which previously took `get: ComputedGetter` and called `get(queryAxiom(...))`) into ccstate `computed` factories that return `Computed<Promise<...>>`.
- Deleted the local `type ComputedGetter = Getter` alias and dropped the now-unused `Getter` import from `ccstate`.
- Updated both callers in `zeroLogSearch` to read via `get(queryMatchingEvents(params))` / `get(getSearchContextMap(params))`.
- Factory functions follow the existing convention in this file (`zeroLogsList`/`zeroLogDetail`/`zeroLogSearch`): no `$` suffix, per the `api/no-fn-dollar-suffix` lint rule.

No `AbortSignal` threading was needed — neither helper nor `queryAxiom` accepts a signal.

## Verification

- `pnpm -F api check-types` — passes
- `pnpm -F api lint` — passes (0 warnings, 0 errors)
- `vitest` on `zero-logs-search`, `zero-logs-list`, `zero-logs-get-by-id` — 73 tests pass
- Guard greps return nothing:
  - `rg ':\s*(Getter|Setter|ComputedGetter|...)\b' <file>`
  - `rg 'type\s+\w+\s*=\s*(Getter|Setter)' <file>`

🤖 Generated with [Claude Code](https://claude.com/claude-code)