### PR TITLE
fix(web): route dotted docs urls through proxy

### DIFF
--- a/turbo/apps/web/__tests__/proxy.matcher.test.ts
+++ b/turbo/apps/web/__tests__/proxy.matcher.test.ts
@@ -1,0 +1,49 @@
+import { unstable_doesMiddlewareMatch } from "next/dist/experimental/testing/server/middleware-testing-utils";
+import { describe, expect, it, vi } from "vitest";
+import { config } from "../proxy";
+
+vi.mock("next-intl/middleware", () => {
+  return {
+    default: () => {
+      return () => {
+        return null;
+      };
+    },
+  };
+});
+
+function expectProxyMatch(url: string, expected: boolean): void {
+  expect(unstable_doesMiddlewareMatch({ config, url })).toBe(expected);
+}
+
+describe("proxy matcher", () => {
+  it("matches locale-prefixed docs routes with markdown-like suffixes", () => {
+    expectProxyMatch("/en/docs/quickstart.md", true);
+    expectProxyMatch("/de/docs/schedules.md", true);
+    expectProxyMatch("/ja/docs/what-zero-delivers/examples.md", true);
+    expectProxyMatch("/es/docs/a.b/c.md", true);
+  });
+
+  it("keeps canonical docs routes matched", () => {
+    expectProxyMatch("/en/docs", true);
+    expectProxyMatch("/en/docs/quickstart", true);
+  });
+
+  it("does not broaden matching for unsupported locale docs paths", () => {
+    expectProxyMatch("/foo/docs/quickstart.md", false);
+    expectProxyMatch("/docs/quickstart.md", false);
+  });
+
+  it("keeps static asset paths excluded from proxy", () => {
+    expectProxyMatch("/apple-touch-icon.png", false);
+    expectProxyMatch("/_next/static/chunks/app.js", false);
+    expectProxyMatch("/_next/image?url=%2Fog-image.png", false);
+    expectProxyMatch("/assets/vm0-logo.svg", false);
+  });
+
+  it("continues to match API and RPC routes", () => {
+    expectProxyMatch("/api/test.json", true);
+    expectProxyMatch("/v1/chat/completions", true);
+    expectProxyMatch("/trpc/foo.bar", true);
+  });
+});

--- a/turbo/apps/web/proxy.ts
+++ b/turbo/apps/web/proxy.ts
@@ -235,6 +235,9 @@ export default async function middleware(
 
 export const config = {
   matcher: [
+    // Keep locale-prefixed docs routes behind Clerk even when legacy crawlers
+    // request markdown-like URLs such as /en/docs/quickstart.md.
+    "/:locale(en|de|ja|es)/docs/(.*)",
     // Match all routes except:
     // - _next (Next.js internals)
     // - _vercel (Vercel internals)


### PR DESCRIPTION
## Summary

Fixes #15728.

Adds a docs-specific proxy matcher so locale-prefixed docs URLs with markdown-like suffixes, such as `/en/docs/quickstart.md`, run through Clerk middleware instead of bypassing proxy as static asset-like paths.

## Root cause

The broad proxy matcher intentionally excludes dotted paths with `.*\\..*` to avoid unnecessary middleware work for static assets. That also excluded docs URLs like `/en/docs/quickstart.md`, while App Router could still render the docs route and call Clerk `auth()` from docs access checks and `SiteHeader` without `clerkMiddleware()` context.

## Changes

- Added a narrow `/:locale(en|de|ja|es)/docs/(.*)` matcher ahead of the broad static asset exclusion.
- Added matcher regression coverage for dotted docs URLs, canonical docs URLs, unsupported locale docs paths, static assets, and API/RPC routes.

## Validation

- `pnpm -F web exec vitest run __tests__/proxy.matcher.test.ts`
- `pnpm -F web lint`
- `pnpm -F web check-types`
- `git diff --check`
- pre-commit hook: prettier, knip, repo `check-types`
