### PR TITLE
docs: document mitm usage flush lifecycle

### DIFF
--- a/crates/runner/mitm-addon/src/mitm_addon.py
+++ b/crates/runner/mitm-addon/src/mitm_addon.py
@@ -72,8 +72,8 @@ _USAGE_FLOW_TRACKED = "_usage_flow_tracked"
 #   flushRequestId, then sends SIGUSR1 to this addon process.
 # - This addon flushes buffered usage and writes `usage-pending` with the
 #   matching flushRequestId so the runner can observe a fresh snapshot.
-# - Rust waits until the acknowledged snapshot has zero flows, buffered events,
-#   and reports before stopping the proxy.
+# - Rust performs a bounded wait for the acknowledged snapshot to have zero
+#   flows, buffered events, and reports before stopping the proxy.
 #
 # Keep this in sync with usage/counters.py and the Rust wait path in
 # crates/runner/src/proxy.rs plus crates/runner/src/cmd/start/mod.rs.

--- a/crates/runner/mitm-addon/src/mitm_addon.py
+++ b/crates/runner/mitm-addon/src/mitm_addon.py
@@ -7,6 +7,8 @@ This addon runs on the runner HOST (not inside VMs) and:
 2. Looks up the source VM's runId from the proxy registry
 3. Injects auth headers for configured firewall rules (proxy-side token replacement)
 4. Logs network activity per-run to JSONL files
+5. Reports model-provider and connector usage
+6. Participates in runner-triggered usage drain before proxy shutdown
 """
 
 import functools
@@ -64,6 +66,17 @@ _BROWSER_USER_AGENT_MARKERS = (
 )
 _MODEL_PROVIDER_USAGE_REPORTED = "_model_provider_usage_reported"
 _USAGE_FLOW_TRACKED = "_usage_flow_tracked"
+
+# Runner-triggered usage drain protocol:
+# - Rust writes `usage-flush-request` with the active usageStateId and a fresh
+#   flushRequestId, then sends SIGUSR1 to this addon process.
+# - This addon flushes buffered usage and writes `usage-pending` with the
+#   matching flushRequestId so the runner can observe a fresh snapshot.
+# - Rust waits until the acknowledged snapshot has zero flows, buffered events,
+#   and reports before stopping the proxy.
+#
+# Keep this in sync with usage/counters.py and the Rust wait path in
+# crates/runner/src/proxy.rs plus crates/runner/src/cmd/start/mod.rs.
 _RUNNER_USAGE_FLUSH_SIGNAL = signal.SIGUSR1
 _usage_flush_requested = threading.Event()
 _usage_flush_signal_lock = threading.Lock()
@@ -122,12 +135,19 @@ def configure(updated: set[str]) -> None:
 
 
 def _handle_runner_usage_flush_signal(signum: int, _frame: object) -> None:
+    """Schedule runner-requested usage drain from the SIGUSR1 handler.
+
+    Keep this handler minimal: it may interrupt mitmproxy's event loop, so it
+    only records that work is needed and lets the background worker perform
+    file I/O and usage flushing.
+    """
     del signum
     _usage_flush_requested.set()
     _start_usage_flush_worker()
 
 
 def _start_usage_flush_worker() -> None:
+    """Start one usage-flush worker, coalescing repeated signals while active."""
     if not _usage_flush_signal_lock.acquire(blocking=False):
         return
 
@@ -146,6 +166,12 @@ def _start_usage_flush_worker() -> None:
 
 
 def _run_usage_flush_worker() -> None:
+    """Drain coalesced runner flush requests under the worker lock.
+
+    The event can be set again while a flush is running. Loop until no request
+    is pending, and restart after releasing the lock if a signal arrives during
+    the worker exit path.
+    """
     try:
         while True:
             _usage_flush_requested.clear()
@@ -159,6 +185,11 @@ def _run_usage_flush_worker() -> None:
 
 
 def _flush_usage_for_runner_request() -> None:
+    """Flush buffered usage and acknowledge the runner's current request.
+
+    The pending snapshot is written in ``finally`` so the runner can observe
+    fresh counters and the current flushRequestId even if usage flushing fails.
+    """
     flush_request_id = usage.read_usage_flush_request_id()
     try:
         usage.flush_usage_events(trigger="runner")
@@ -818,13 +849,15 @@ def error(flow: http.HTTPFlow) -> None:
 def done():
     """Flush pending usage reports before mitmproxy exits.
 
-    The runner requests fresh pending snapshots before stopping the proxy.
-    Buffered usage is converted into webhook reports before
-    ``shutdown(wait=True)`` drains already-submitted futures during graceful stop.
+    Runner-triggered flush workers and shutdown flush share
+    ``_usage_flush_signal_lock``. Waiting here keeps shutdown from closing the
+    executor while a SIGUSR1 worker is still converting buffered usage into
+    webhook reports. After that, ``shutdown(wait=True)`` drains submitted
+    webhook futures during graceful stop.
     """
     try:
-        # A SIGUSR1 flush can already have snapshotted buffered events but not
-        # yet enqueued them; wait before closing the executor.
+        # Wait for any in-flight runner-triggered flush before closing the
+        # executor used by webhook report delivery.
         with _usage_flush_signal_lock:
             usage.flush_usage_events(trigger="shutdown")
     finally:


### PR DESCRIPTION
## Summary

- document the mitm addon runner-triggered usage drain responsibilities
- explain the usage-flush-request / usage-pending protocol near the signal state
- add targeted docstrings for the SIGUSR1 handler, worker, flush helper, and shutdown hook

Closes #15711

## Tests

- cd crates/runner/mitm-addon && python3 -m pytest tests/test_connection_hooks.py tests/test_counters.py
- cd crates/runner/mitm-addon && python3 -m ruff check src/mitm_addon.py