### PR TITLE
fix(runner): skip unclaimed jobs during soft drain

### DIFF
--- a/crates/runner/src/cmd/start/job_discovery.rs
+++ b/crates/runner/src/cmd/start/job_discovery.rs
@@ -76,11 +76,25 @@ pub(super) async fn handle_discovered_job(job: DiscoveredJob, mut ctx: Discovere
         }
         tokens.insert(run_id, job_cancel.clone());
     }
-    // Close a TOCTOU race against hard shutdown: the signal handler sends
-    // Stopping before locking cancel_tokens. Re-read mode after inserting so a
-    // newly claimed job sees the stop and self-cancels.
-    if matches!(*ctx.mode_rx.borrow(), RunnerMode::Stopping) {
-        job_cancel.cancel();
+    // This is the last reversible point before provider-side ownership.
+    // Soft drain must stop new claims, while hard stop still claims and
+    // cancels so provider state is completed deterministically.
+    let mode = *ctx.mode_rx.borrow();
+    match mode {
+        RunnerMode::Running => {}
+        RunnerMode::Draining => {
+            ctx.cancel_tokens.lock().await.remove(&run_id);
+            drop(job_lease);
+            return;
+        }
+        RunnerMode::Stopping => {
+            job_cancel.cancel();
+        }
+        RunnerMode::Stopped => {
+            ctx.cancel_tokens.lock().await.remove(&run_id);
+            drop(job_lease);
+            return;
+        }
     }
     // claim() runs in the branch handler: non-interruptible, so a valid
     // successful claim is always paired with complete().

--- a/crates/runner/src/cmd/start/tests/main_loop.rs
+++ b/crates/runner/src/cmd/start/tests/main_loop.rs
@@ -877,6 +877,44 @@ async fn drain_then_hard_shutdown_upgrades() {
     .await;
 }
 
+/// TOCTOU regression: soft drain can arrive after the main loop has selected
+/// a discovered candidate but before claim. The candidate is still unowned at
+/// that point, so Draining must roll back local admission and skip claim.
+#[tokio::test]
+async fn claim_after_draining_sent_skips_unclaimed_job() {
+    let (config, env) = mock_run_config(test_profiles(), 8, 32768, 4);
+    let budget = Arc::clone(&config.capacity.budget);
+    let run_handle = tokio::spawn(run(config));
+
+    wait_discover_entered(&env, Duration::from_secs(2)).await;
+
+    assert!(env.parking_gate.soft_drain());
+    env.mode_tx.send_if_modified(|v| {
+        *v = RunnerMode::Draining;
+        false
+    });
+
+    let run_id = RunId::new_v4();
+    push_job(&env, run_id, "vm0/default", Some(minimal_context(run_id)));
+
+    assert_run_exits_within(
+        run_handle,
+        Duration::from_secs(3),
+        "draining should skip the discovered unclaimed job and exit",
+    )
+    .await;
+
+    wait_cancel_token_removed(&env.cancel_tokens, run_id, Duration::from_secs(5)).await;
+    wait_budget_count(&budget, 0, Duration::from_secs(5)).await;
+    let completions = env.handle.completions.lock().unwrap();
+    assert!(
+        !completions
+            .iter()
+            .any(|completion| completion.run_id == run_id),
+        "draining should not claim or complete a newly discovered job"
+    );
+}
+
 /// TOCTOU regression: a SIGTERM that iterates `cancel_tokens` *before*
 /// the main loop inserts a newly-claimed job's token would leave that
 /// job running uncancelled. The fix is a post-insert `mode_rx.borrow()`


### PR DESCRIPTION
## Summary

- add a pre-claim runner-mode admission check in job discovery
- skip unclaimed discovered jobs when the runner has entered Draining or Stopped
- keep Stopping behavior as claim-and-cancel so provider state is completed deterministically
- add a deterministic main-loop regression test for the soft-drain race

Closes #15710

## Tests

- cargo test claim_after_draining_sent_skips_unclaimed_job
- cargo test claim_after_stopping_sent_cancels_new_job
- cargo test cmd::start::tests::main_loop
- cargo fmt --check
- cargo clippy --all-targets --all-features -- -D warnings