### PR TITLE
chore: remove stale phone cleanup cron

### DIFF
--- a/turbo/apps/web/vercel.json
+++ b/turbo/apps/web/vercel.json
@@ -38,10 +38,6 @@
     {
       "path": "/api/cron/reconcile-billing-entitlements",
       "schedule": "0 0,12 * * *"
-    },
-    {
-      "path": "/api/cron/phone-cleanup",
-      "schedule": "0 2 * * *"
     }
   ]
 }


### PR DESCRIPTION
## Summary

- Remove the stale `/api/cron/phone-cleanup` Vercel cron entry from `apps/web`
- Leave the historical DB migration untouched; the cleanup target table was already dropped by the Agent Phone/iMessage/SMS removal

## Context

`/api/cron/phone-cleanup` was added in #9512 to clean old `pending_outbound_calls` rows. PR #10941 later removed the Agent Phone/iMessage/SMS integration, including the route implementation and the `pending_outbound_calls` table, but left the Vercel cron entry behind.

## Verification

- `pnpm format`
- `pnpm -F web lint`
- `pnpm -F web check-types`
- `node -e "const fs=require('fs'); const json=JSON.parse(fs.readFileSync('turbo/apps/web/vercel.json','utf8')); if (json.crons.some(c => c.path === '/api/cron/phone-cleanup')) process.exit(1); console.log('phone-cleanup cron absent');"`