### PR TITLE
feat(api): tighten no-getter-setter-params to catch aliased + object-field Getter/Setter (#15734)

### DIFF
--- a/turbo/apps/api/custom-eslint/__tests__/no-getter-setter-params.test.ts
+++ b/turbo/apps/api/custom-eslint/__tests__/no-getter-setter-params.test.ts
@@ -18,6 +18,10 @@ ruleTester.run("no-getter-setter-params", noGetterSetterParams, {
     { code: "command(({ get }) => { function inner(get: Getter) { } })" },
     { code: "function helper(get) { }" },
     { code: "function helper(get: lib.Getter) { }" },
+    // Non-Getter/Setter object-type members must not be flagged.
+    { code: "function helper(args: { readonly value: string }) { }" },
+    // A plain alias unrelated to ccstate must not be flagged.
+    { code: "type Id = string;" },
   ],
   invalid: [
     {
@@ -38,6 +42,45 @@ ruleTester.run("no-getter-setter-params", noGetterSetterParams, {
         { messageId: "noGetterSetterParam" },
         { messageId: "noGetterSetterParam" },
       ],
+    },
+    // (a) Aliased positional param: the alias declaration is banned at the
+    // root, killing the evasion vector even though the param uses the alias.
+    {
+      code: "type ComputedGetter = Getter; function helper(get: ComputedGetter) { }",
+      errors: [{ messageId: "noGetterSetterAlias" }],
+    },
+    // (b) Object-field typed via an alias: alias declaration is banned.
+    {
+      code: "type ComputedGetter = Getter; function helper(args: { get: ComputedGetter }) { }",
+      errors: [{ messageId: "noGetterSetterAlias" }],
+    },
+    // (c) Real Setter sitting inside an options-bag object type literal.
+    {
+      code: "function helper(args: { readonly stateSet: Setter }) { }",
+      errors: [{ messageId: "noGetterSetterParam" }],
+    },
+    // Object literal with both Getter and Setter members reports each.
+    {
+      code: "function helper(args: { readonly get: Getter; readonly set: Setter }) { }",
+      errors: [
+        { messageId: "noGetterSetterParam" },
+        { messageId: "noGetterSetterParam" },
+      ],
+    },
+    // Nested object literal: recurse into inner members.
+    {
+      code: "function helper(args: { nested: { get: Getter } }) { }",
+      errors: [{ messageId: "noGetterSetterParam" }],
+    },
+    // (d) Banned `type X = Getter` declaration on its own.
+    {
+      code: "type X = Getter;",
+      errors: [{ messageId: "noGetterSetterAlias" }],
+    },
+    // Union/intersection alias containing Getter/Setter is banned.
+    {
+      code: "type MaybeGetter = Getter | undefined;",
+      errors: [{ messageId: "noGetterSetterAlias" }],
     },
   ],
 });

--- a/turbo/apps/api/custom-eslint/rules/no-getter-setter-params.ts
+++ b/turbo/apps/api/custom-eslint/rules/no-getter-setter-params.ts
@@ -2,6 +2,11 @@ import { AST_NODE_TYPES, type TSESTree } from "@typescript-eslint/utils";
 
 import { createRule } from "../utils.ts";
 
+// Cap how deep we walk nested object type literals. ccstate options bags are
+// shallow in practice, so a small cap keeps the AST-only check cheap while
+// still catching the realistic `{ args: { get: Getter } }` nesting.
+const MAX_OBJECT_TYPE_DEPTH = 5;
+
 export const noGetterSetterParams = createRule({
   name: "no-getter-setter-params",
   defaultOptions: [],
@@ -16,37 +21,89 @@ export const noGetterSetterParams = createRule({
     messages: {
       noGetterSetterParam:
         "Parameter '{{name}}' has type '{{type}}' from ccstate. Use a computed/command factory instead of passing Getter/Setter to functions.",
+      noGetterSetterAlias:
+        "Do not alias ccstate Getter/Setter; model the helper as computed/command instead.",
     },
   },
   create(context) {
-    function getGetterSetterName(param: TSESTree.Parameter): string | null {
-      if (param.type !== AST_NODE_TYPES.Identifier) {
-        return null;
-      }
-
-      const annotation = param.typeAnnotation?.typeAnnotation;
+    // Returns the literal "Getter"/"Setter" name of a type-reference node, or
+    // null. Used for positional params, object-type members, and alias RHS.
+    function getGetterSetterName(node: TSESTree.TypeNode): string | null {
       if (
-        annotation?.type !== AST_NODE_TYPES.TSTypeReference ||
-        annotation.typeName.type !== AST_NODE_TYPES.Identifier
+        node.type === AST_NODE_TYPES.TSTypeReference &&
+        node.typeName.type === AST_NODE_TYPES.Identifier &&
+        (node.typeName.name === "Getter" || node.typeName.name === "Setter")
       ) {
-        return null;
+        return node.typeName.name;
       }
-
-      const { name } = annotation.typeName;
-      return name === "Getter" || name === "Setter" ? name : null;
+      return null;
     }
 
-    function checkParam(param: TSESTree.Parameter): void {
-      const typeName = getGetterSetterName(param);
-      if (typeName === null) {
+    // Walks an object type literal and reports any property signature whose
+    // type is literally `Getter`/`Setter`, recursing into nested object
+    // literals up to a small depth cap.
+    function checkObjectType(
+      node: TSESTree.TSTypeLiteral,
+      depth: number,
+    ): void {
+      if (depth > MAX_OBJECT_TYPE_DEPTH) {
         return;
       }
 
-      context.report({
-        node: param,
-        messageId: "noGetterSetterParam",
-        data: { name: (param as TSESTree.Identifier).name, type: typeName },
-      });
+      for (const member of node.members) {
+        if (member.type !== AST_NODE_TYPES.TSPropertySignature) {
+          continue;
+        }
+
+        const memberType = member.typeAnnotation?.typeAnnotation;
+        if (!memberType) {
+          continue;
+        }
+
+        const typeName = getGetterSetterName(memberType);
+        if (typeName !== null) {
+          const memberName =
+            member.key.type === AST_NODE_TYPES.Identifier
+              ? member.key.name
+              : "(member)";
+          context.report({
+            node: member,
+            messageId: "noGetterSetterParam",
+            data: { name: memberName, type: typeName },
+          });
+          continue;
+        }
+
+        if (memberType.type === AST_NODE_TYPES.TSTypeLiteral) {
+          checkObjectType(memberType, depth + 1);
+        }
+      }
+    }
+
+    function checkParam(param: TSESTree.Parameter): void {
+      if (param.type !== AST_NODE_TYPES.Identifier) {
+        return;
+      }
+
+      const annotation = param.typeAnnotation?.typeAnnotation;
+      if (!annotation) {
+        return;
+      }
+
+      const typeName = getGetterSetterName(annotation);
+      if (typeName !== null) {
+        context.report({
+          node: param,
+          messageId: "noGetterSetterParam",
+          data: { name: param.name, type: typeName },
+        });
+        return;
+      }
+
+      // Options-bag shape: `args: { readonly get: Getter; set: Setter; ... }`.
+      if (annotation.type === AST_NODE_TYPES.TSTypeLiteral) {
+        checkObjectType(annotation, 0);
+      }
     }
 
     const ccstatePrimitives = new Set(["command", "computed", "state"]);
@@ -81,10 +138,37 @@ export const noGetterSetterParams = createRule({
       }
     }
 
+    // Reports if an alias right-hand side is (or contains via union/
+    // intersection) a `Getter`/`Setter` type reference.
+    function aliasReferencesGetterSetter(node: TSESTree.TypeNode): boolean {
+      if (getGetterSetterName(node) !== null) {
+        return true;
+      }
+
+      if (
+        node.type === AST_NODE_TYPES.TSUnionType ||
+        node.type === AST_NODE_TYPES.TSIntersectionType
+      ) {
+        return node.types.some(aliasReferencesGetterSetter);
+      }
+
+      return false;
+    }
+
+    function checkTypeAlias(node: TSESTree.TSTypeAliasDeclaration): void {
+      if (aliasReferencesGetterSetter(node.typeAnnotation)) {
+        context.report({
+          node,
+          messageId: "noGetterSetterAlias",
+        });
+      }
+    }
+
     return {
       FunctionDeclaration: checkFunction,
       FunctionExpression: checkFunction,
       ArrowFunctionExpression: checkFunction,
+      TSTypeAliasDeclaration: checkTypeAlias,
     };
   },
 });


### PR DESCRIPTION
Closes #15734

Extends the existing custom ESLint rule `api/no-getter-setter-params` (single rule, no new registration) to close two evasion vectors found during the #15636 cleanup, while staying AST-only (`requiresTypeChecking: false` is preserved — no type-checking/projectService added).

## Behaviors added
1. **Ban alias declarations.** A new `TSTypeAliasDeclaration` visitor reports any `type <Name> = Getter | Setter` whose right-hand side is — or is a union/intersection containing — the type reference `Getter`/`Setter`. New `messageId` `noGetterSetterAlias` ("Do not alias ccstate Getter/Setter; model the helper as computed/command instead"). This kills the alias evasion mechanism at the root, so usage-site alias resolution is unnecessary.
2. **Recurse into object-type members.** Parameter checks now also walk object type literals (`TSTypeLiteral`) — including the common options-bag shape `args: { readonly get: Getter; readonly set: Setter; ... }` — and report any `TSPropertySignature` field typed `Getter`/`Setter`. Recurses into nested object literals with a small depth cap (`MAX_OBJECT_TYPE_DEPTH = 5`).

## Correctness
- The legitimate ccstate callback pattern (`command(({ get, set }, ...) => ...)` / `computed((get) => ...)`) is untouched: those destructure `get`/`set` with no `Getter`/`Setter` annotation. The existing `isInsideCcstateCallback` guard and explicit-annotation-only matching are preserved.
- Matches the literal type-reference names `Getter`/`Setter` (same as before).

## Tests
Extended the rule-tester suite (`custom-eslint/__tests__/no-getter-setter-params.test.ts`):
- Invalid: aliased positional param, aliased object-field, real-`Setter` object field (`readonly stateSet: Setter`), banned `type X = Getter`, both-members object literal, nested object literal, union alias (`Getter | undefined`).
- Valid: non-Getter/Setter object member, plain unrelated alias (`type Id = string`), plus the existing legit `command`/`computed` and plain-function cases.

## Verification (from `turbo`)
- `pnpm -F api exec vitest run custom-eslint` — 86 passed (was 77).
- `pnpm -F api check-types` — clean.
- `pnpm -F api lint` (whole package) — 0 warnings, 0 errors; the stricter rule surfaces no new violations on the already-cleaned codebase.
- `pnpm knip --workspace apps/api` — clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)