### PR TITLE
fix: keep computer-use heartbeat active during commands

### DIFF
--- a/turbo/apps/api/src/signals/routes/__tests__/zero-computer-use.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/zero-computer-use.test.ts
@@ -23,7 +23,7 @@ import { afterEach, describe, expect, it } from "vitest";
 import { accept, setupApp, testContext } from "../../../__tests__/test-helpers";
 import { createApp } from "../../../app-factory";
 import { mockEnv } from "../../../lib/env";
-import { now } from "../../../lib/time";
+import { clearMockNow, mockNow, now } from "../../../lib/time";
 import { signSandboxJwtForTests } from "../../auth/tokens";
 import { writeDb$ } from "../../external/db";
 import {
@@ -151,6 +151,7 @@ describe("desktop computer-use runtime", () => {
   }
 
   afterEach(async () => {
+    clearMockNow();
     const writeDb = store.set(writeDb$);
     if (trackedOrgIds.length > 0) {
       await writeDb
@@ -475,6 +476,88 @@ describe("desktop computer-use runtime", () => {
       status: "succeeded",
       result: { snapshotId: "snap_1" },
     });
+  });
+
+  it("times out stale running commands before claiming new work", async () => {
+    const baseTime = new Date("2026-06-01T00:00:00.000Z");
+    mockNow(baseTime);
+    const fixture = await createOrgFixture();
+    const hostToken = "host-token";
+    await seedComputerUseHost({
+      orgId: fixture.orgId,
+      userId: fixture.userId,
+      hostToken,
+      lastSeenAt: baseTime,
+    });
+    const commandClient = setupApp({ context })(zeroComputerUseCommandContract);
+    const hostClient = setupApp({ context })(
+      zeroComputerUseHostCommandsContract,
+    );
+    const token = mintZeroToken({
+      orgId: fixture.orgId,
+      userId: fixture.userId,
+      capabilities: ["computer-use:write"],
+    });
+
+    const first = await accept(
+      commandClient.create({
+        body: { kind: "app.state", app: "Safari", timeoutMs: 1000 },
+        headers: { authorization: `Bearer ${token}` },
+      }),
+      [200],
+    );
+    mockNow(new Date(baseTime.getTime() + 1));
+    const second = await accept(
+      commandClient.create({
+        body: { kind: "apps.list", timeoutMs: 15_000 },
+        headers: { authorization: `Bearer ${token}` },
+      }),
+      [200],
+    );
+
+    const claimedFirst = await accept(
+      hostClient.next({
+        body: { supportedCapabilities: [...supportedCapabilities] },
+        headers: { authorization: `Bearer ${hostToken}` },
+      }),
+      [200],
+    );
+    expect(claimedFirst.body.status).toBe("command");
+    if (claimedFirst.body.status !== "command") {
+      throw new Error("expected command");
+    }
+    expect(claimedFirst.body.command.id).toBe(first.body.commandId);
+
+    mockNow(new Date(baseTime.getTime() + 1002));
+    const claimedSecond = await accept(
+      hostClient.next({
+        body: { supportedCapabilities: [...supportedCapabilities] },
+        headers: { authorization: `Bearer ${hostToken}` },
+      }),
+      [200],
+    );
+
+    expect(claimedSecond.body.status).toBe("command");
+    if (claimedSecond.body.status !== "command") {
+      throw new Error("expected command");
+    }
+    expect(claimedSecond.body.command.id).toBe(second.body.commandId);
+
+    const timedOut = await accept(
+      commandClient.get({
+        params: { commandId: first.body.commandId },
+        headers: { authorization: `Bearer ${token}` },
+      }),
+      [200],
+    );
+    expect(timedOut.body).toMatchObject({
+      status: "failed",
+      error: {
+        code: "timeout",
+        message: "Computer-use command timed out after 1000ms",
+      },
+    });
+    expect(timedOut.body.completedAt).toBe("2026-06-01T00:00:01.002Z");
   });
 
   it("queues write commands without approval and audits completion", async () => {

--- a/turbo/apps/api/src/signals/services/zero-computer-use.service.ts
+++ b/turbo/apps/api/src/signals/services/zero-computer-use.service.ts
@@ -1,7 +1,17 @@
 import { createHash, randomBytes } from "node:crypto";
 
 import { command, computed, type Computed } from "ccstate";
-import { and, asc, desc, eq, inArray, isNull, or, sql } from "drizzle-orm";
+import {
+  and,
+  asc,
+  desc,
+  eq,
+  inArray,
+  isNull,
+  or,
+  sql,
+  type SQL,
+} from "drizzle-orm";
 import {
   isExpiredScreenshotPointer,
   isStoredScreenshotPointer,
@@ -27,6 +37,7 @@ import { writeDb$, type Db } from "../external/db";
 import { downloadS3Buffer, putS3Object } from "../external/s3";
 
 const COMPUTER_USE_HOST_CLOSED_AFTER_MS = 90 * 1000;
+const COMPUTER_USE_RUNNING_COMMAND_DEFAULT_TIMEOUT_MS = 120 * 1000;
 const L = logger("ZeroComputerUse");
 
 const COMPUTER_USE_READ_COMMANDS = [
@@ -453,6 +464,29 @@ function commandErrorFromRow(
   };
 }
 
+function runningCommandHasTimedOut(
+  row: ComputerUseCommandRow,
+  now: Date,
+): boolean {
+  if (!row.claimedAt) {
+    return false;
+  }
+  const timeoutMs =
+    row.timeoutMs ?? COMPUTER_USE_RUNNING_COMMAND_DEFAULT_TIMEOUT_MS;
+  return now.getTime() - row.claimedAt.getTime() > timeoutMs;
+}
+
+function timeoutErrorForCommand(
+  row: ComputerUseCommandRow,
+): ComputerUseCommandError {
+  const timeoutMs =
+    row.timeoutMs ?? COMPUTER_USE_RUNNING_COMMAND_DEFAULT_TIMEOUT_MS;
+  return {
+    code: "timeout",
+    message: `Computer-use command timed out after ${timeoutMs}ms`,
+  };
+}
+
 function serializeHost(row: ComputerUseHostRow, now: Date) {
   return {
     id: row.id,
@@ -519,6 +553,65 @@ async function insertComputerUseCommandAuditEvent(
     error: errorForAudit(params.error),
     createdAt: params.createdAt,
   });
+}
+
+async function failStaleRunningComputerUseCommands(
+  tx: ComputerUseTx,
+  params: {
+    readonly orgId: string;
+    readonly userId: string;
+    readonly hostId?: string;
+    readonly now: Date;
+  },
+  signal: AbortSignal,
+): Promise<void> {
+  const filters: SQL[] = [
+    eq(computerUseCommands.orgId, params.orgId),
+    eq(computerUseCommands.userId, params.userId),
+    eq(computerUseCommands.status, "running"),
+  ];
+  if (params.hostId) {
+    filters.push(eq(computerUseCommands.hostId, params.hostId));
+  }
+
+  const runningCommands = await tx
+    .select()
+    .from(computerUseCommands)
+    .where(and(...filters))
+    .for("update", { skipLocked: true });
+  signal.throwIfAborted();
+
+  for (const commandRow of runningCommands) {
+    if (!runningCommandHasTimedOut(commandRow, params.now)) {
+      continue;
+    }
+
+    const error = timeoutErrorForCommand(commandRow);
+    const [updated] = await tx
+      .update(computerUseCommands)
+      .set({
+        status: "failed",
+        result: { error },
+        error: error.code,
+        completedAt: params.now,
+        updatedAt: params.now,
+      })
+      .where(eq(computerUseCommands.id, commandRow.id))
+      .returning();
+    signal.throwIfAborted();
+
+    if (!updated) {
+      throw new Error("Failed to mark timed-out computer-use command");
+    }
+
+    await insertComputerUseCommandAuditEvent(tx, {
+      command: updated,
+      event: "completed",
+      error,
+      createdAt: params.now,
+    });
+    signal.throwIfAborted();
+  }
 }
 
 function resolveComputerUseCommandTargets(params: {
@@ -956,24 +1049,33 @@ export const getComputerUseCommand$ = command(
     signal: AbortSignal,
   ) => {
     const db = set(writeDb$);
-    const [row] = await db
-      .select({
-        command: computerUseCommands,
-        hostName: computerUseHosts.displayName,
-      })
-      .from(computerUseCommands)
-      .leftJoin(
-        computerUseHosts,
-        eq(computerUseCommands.hostId, computerUseHosts.id),
-      )
-      .where(
-        and(
-          eq(computerUseCommands.orgId, params.orgId),
-          eq(computerUseCommands.userId, params.userId),
-          eq(computerUseCommands.id, params.commandId),
-        ),
-      )
-      .limit(1);
+    const now = nowDate();
+    const row = await db.transaction(async (tx) => {
+      await failStaleRunningComputerUseCommands(
+        tx,
+        { orgId: params.orgId, userId: params.userId, now },
+        signal,
+      );
+      const [commandRow] = await tx
+        .select({
+          command: computerUseCommands,
+          hostName: computerUseHosts.displayName,
+        })
+        .from(computerUseCommands)
+        .leftJoin(
+          computerUseHosts,
+          eq(computerUseCommands.hostId, computerUseHosts.id),
+        )
+        .where(
+          and(
+            eq(computerUseCommands.orgId, params.orgId),
+            eq(computerUseCommands.userId, params.userId),
+            eq(computerUseCommands.id, params.commandId),
+          ),
+        )
+        .limit(1);
+      return commandRow;
+    });
     signal.throwIfAborted();
     return row ? serializeCommand(row.command, row.hostName) : null;
   },
@@ -1182,6 +1284,34 @@ export const claimNextComputerUseHostCommand$ = command(
         })
         .where(eq(computerUseHosts.id, host.id));
       signal.throwIfAborted();
+
+      await failStaleRunningComputerUseCommands(
+        tx,
+        {
+          orgId: host.orgId,
+          userId: host.userId,
+          hostId: host.id,
+          now,
+        },
+        signal,
+      );
+
+      const [runningCommand] = await tx
+        .select({ id: computerUseCommands.id })
+        .from(computerUseCommands)
+        .where(
+          and(
+            eq(computerUseCommands.orgId, host.orgId),
+            eq(computerUseCommands.userId, host.userId),
+            eq(computerUseCommands.hostId, host.id),
+            eq(computerUseCommands.status, "running"),
+          ),
+        )
+        .limit(1);
+      signal.throwIfAborted();
+      if (runningCommand) {
+        return { status: "idle" as const };
+      }
 
       const effectiveCapabilities =
         capabilities.length > 0 ? capabilities : host.supportedCapabilities;

--- a/turbo/apps/desktop/src/computer-use-host.test.ts
+++ b/turbo/apps/desktop/src/computer-use-host.test.ts
@@ -16,6 +16,17 @@ function jsonResponse(body: unknown, init: ResponseInit = {}): Response {
   });
 }
 
+function deferred<T>(): {
+  readonly promise: Promise<T>;
+  readonly resolve: (value: T) => void;
+} {
+  let resolve!: (value: T) => void;
+  const promise = new Promise<T>((next) => {
+    resolve = next;
+  });
+  return { promise, resolve };
+}
+
 function createRuntime(
   options: {
     readonly sessionFetch?: ComputerUseHostFetch;
@@ -229,6 +240,111 @@ describe("ComputerUseHostRuntime", () => {
         appState: "0 standard window Inbox",
         screenshot: "data:image/png;base64,abc123",
       },
+    });
+
+    await runtime.stop();
+  });
+
+  it("keeps heartbeats running while a command is executing", async () => {
+    vi.useFakeTimers();
+    const command: ComputerUseCommand = {
+      id: "cmd-1",
+      kind: "keyboard.type_text",
+      payload: { app: "Chrome", text: "https://mail.google.com/" },
+    };
+    const execution = deferred<ComputerUseCommandExecutionResult>();
+    let nextCalls = 0;
+    let completeCalls = 0;
+    const hostFetch = vi.fn<ComputerUseHostFetch>(async (url) => {
+      if (url.endsWith("/api/zero/computer-use/heartbeat")) {
+        return jsonResponse({ ok: true, hostId: "host-1" });
+      }
+      if (url.endsWith("/api/zero/computer-use/host/commands/next")) {
+        nextCalls++;
+        return nextCalls === 1
+          ? jsonResponse({ status: "command", command })
+          : jsonResponse({ status: "idle" });
+      }
+      if (url.endsWith("/api/zero/computer-use/host/commands/cmd-1/complete")) {
+        completeCalls++;
+        return jsonResponse({ ok: true });
+      }
+      throw new Error(`Unexpected host request: ${url}`);
+    });
+    const executeCommand = vi.fn<
+      (
+        command: ComputerUseCommand,
+        permissions: ComputerUsePermissionState,
+      ) => Promise<ComputerUseCommandExecutionResult>
+    >(async () => {
+      return await execution.promise;
+    });
+    const { runtime } = createRuntime({ hostFetch, executeCommand });
+
+    await runtime.start();
+    await vi.advanceTimersByTimeAsync(2_000);
+
+    expect(executeCommand).toHaveBeenCalledOnce();
+    expect(completeCalls).toBe(0);
+
+    await vi.advanceTimersByTimeAsync(90_000);
+
+    const heartbeatCalls = hostFetch.mock.calls.filter(([url]) => {
+      return url.endsWith("/api/zero/computer-use/heartbeat");
+    });
+    expect(heartbeatCalls.length).toBeGreaterThan(1);
+    expect(completeCalls).toBe(0);
+
+    execution.resolve({ status: "succeeded", result: {} });
+    await vi.advanceTimersByTimeAsync(0);
+
+    expect(completeCalls).toBe(1);
+
+    await runtime.stop();
+  });
+
+  it("retries transient command completion failures", async () => {
+    vi.useFakeTimers();
+    let nextCalls = 0;
+    let completeCalls = 0;
+    const hostFetch = vi.fn<ComputerUseHostFetch>(async (url) => {
+      if (url.endsWith("/api/zero/computer-use/heartbeat")) {
+        return jsonResponse({ ok: true, hostId: "host-1" });
+      }
+      if (url.endsWith("/api/zero/computer-use/host/commands/next")) {
+        nextCalls++;
+        return nextCalls === 1
+          ? jsonResponse({
+              status: "command",
+              command: {
+                id: "cmd-1",
+                kind: "app.state",
+                payload: { app: "Chrome" },
+              },
+            })
+          : jsonResponse({ status: "idle" });
+      }
+      if (url.endsWith("/api/zero/computer-use/host/commands/cmd-1/complete")) {
+        completeCalls++;
+        return completeCalls === 1
+          ? new Response("{}", { status: 503 })
+          : jsonResponse({ ok: true });
+      }
+      throw new Error(`Unexpected host request: ${url}`);
+    });
+    const { runtime } = createRuntime({ hostFetch });
+
+    await runtime.start();
+    await vi.advanceTimersByTimeAsync(2_000);
+
+    expect(completeCalls).toBe(1);
+
+    await vi.advanceTimersByTimeAsync(2_000);
+
+    expect(completeCalls).toBe(2);
+    expect(runtime.getState()).toMatchObject({
+      status: "online",
+      lastError: null,
     });
 
     await runtime.stop();

--- a/turbo/apps/desktop/src/computer-use-host.ts
+++ b/turbo/apps/desktop/src/computer-use-host.ts
@@ -16,6 +16,8 @@ import {
 } from "./computer-use-startup-gate";
 
 const ONLINE_POLL_MS = 2_000;
+const COMMAND_COMPLETION_RETRY_DELAY_MS = 2_000;
+const COMMAND_COMPLETION_MAX_ATTEMPTS = 3;
 const AUTH_ME_PATH = "/api/auth/me";
 
 export type ComputerUseHostFetch = (
@@ -63,6 +65,18 @@ type ComputerUseHostNextResponse =
   | ComputerUseHostNextIdleResponse
   | ComputerUseHostNextCommandResponse;
 
+function commandFailureFromError(
+  error: unknown,
+): ComputerUseCommandExecutionResult {
+  return {
+    status: "failed",
+    error: {
+      code: "accessibility_unavailable",
+      message: error instanceof Error ? error.message : String(error),
+    },
+  };
+}
+
 function replaceHostPrefix(hostname: string, target: string): string {
   return hostname.replace(/(^|-)(api|app|platform|www)\./, `$1${target}.`);
 }
@@ -99,7 +113,9 @@ export class ComputerUseHostRuntime {
   private readonly scheduleTimeout: typeof setTimeout;
   private readonly clearScheduledTimeout: typeof clearTimeout;
   private running = false;
-  private timer: NodeJS.Timeout | null = null;
+  private heartbeatTimer: NodeJS.Timeout | null = null;
+  private commandTimer: NodeJS.Timeout | null = null;
+  private commandExecutionRunning = false;
   private hostToken: string | null = null;
   private state: ComputerUseHostRuntimeState = {
     status: "idle",
@@ -129,15 +145,27 @@ export class ComputerUseHostRuntime {
       return;
     }
     this.running = true;
-    await this.tick();
+    try {
+      const nextDelay = await this.startHost();
+      if (nextDelay === null) {
+        this.running = false;
+        return;
+      }
+      this.scheduleHeartbeat(nextDelay);
+      this.scheduleCommandPoll(nextDelay);
+    } catch (error) {
+      this.setState({
+        status: "error",
+        lastError: error instanceof Error ? error.message : String(error),
+      });
+      this.running = false;
+    }
   }
 
   async stop(): Promise<void> {
     this.running = false;
-    if (this.timer) {
-      this.clearScheduledTimeout(this.timer);
-      this.timer = null;
-    }
+    this.clearHeartbeatTimer();
+    this.clearCommandTimer();
     const hostToken = this.hostToken;
     if (!hostToken) {
       return;
@@ -227,39 +255,78 @@ export class ComputerUseHostRuntime {
     });
   }
 
-  private schedule(delayMs: number): void {
+  private clearHeartbeatTimer(): void {
+    if (!this.heartbeatTimer) {
+      return;
+    }
+    this.clearScheduledTimeout(this.heartbeatTimer);
+    this.heartbeatTimer = null;
+  }
+
+  private clearCommandTimer(): void {
+    if (!this.commandTimer) {
+      return;
+    }
+    this.clearScheduledTimeout(this.commandTimer);
+    this.commandTimer = null;
+  }
+
+  private scheduleHeartbeat(delayMs: number): void {
     if (!this.running) {
       return;
     }
-    this.timer = this.scheduleTimeout(() => {
-      this.timer = null;
-      void this.tick();
+    this.heartbeatTimer = this.scheduleTimeout(() => {
+      this.heartbeatTimer = null;
+      void this.heartbeatLoop();
     }, delayMs);
   }
 
-  private async tick(): Promise<void> {
-    let nextDelay: number | null = ONLINE_POLL_MS;
+  private scheduleCommandPoll(delayMs: number): void {
+    if (!this.running || this.commandTimer) {
+      return;
+    }
+    this.commandTimer = this.scheduleTimeout(() => {
+      this.commandTimer = null;
+      void this.commandLoop();
+    }, delayMs);
+  }
+
+  private async heartbeatLoop(): Promise<void> {
     try {
-      if (!this.hostToken) {
-        nextDelay = await this.startHost();
-      } else {
-        if (await this.heartbeat()) {
-          await this.claimAndExecuteCommand();
-        } else {
-          nextDelay = null;
-        }
+      if (!this.hostToken || !(await this.heartbeat())) {
+        this.running = false;
+        this.clearCommandTimer();
+        return;
       }
+      this.scheduleHeartbeat(ONLINE_POLL_MS);
     } catch (error) {
       this.setState({
         status: "error",
         lastError: error instanceof Error ? error.message : String(error),
       });
-      nextDelay = null;
+      this.running = false;
+      this.clearCommandTimer();
+    }
+  }
+
+  private async commandLoop(): Promise<void> {
+    if (this.commandExecutionRunning) {
+      return;
+    }
+    this.commandExecutionRunning = true;
+    try {
+      await this.claimAndExecuteCommand();
+    } catch (error) {
+      if (this.running) {
+        this.setState({
+          status: "error",
+          lastError: error instanceof Error ? error.message : String(error),
+        });
+      }
     } finally {
-      if (nextDelay === null) {
-        this.running = false;
-      } else {
-        this.schedule(nextDelay);
+      this.commandExecutionRunning = false;
+      if (this.running && this.hostToken) {
+        this.scheduleCommandPoll(ONLINE_POLL_MS);
       }
     }
   }
@@ -423,18 +490,7 @@ export class ComputerUseHostRuntime {
         await this.getPermissions(),
       );
     } catch (error) {
-      const completedAtMs = Date.now();
-      this.finishLocalCommandLogEntry({
-        commandId: body.command.id,
-        status: "failed",
-        result: null,
-        error: {
-          message: error instanceof Error ? error.message : String(error),
-        },
-        completedAt: new Date(completedAtMs).toISOString(),
-        durationMs: completedAtMs - startedAtMs,
-      });
-      throw error;
+      completed = commandFailureFromError(error);
     }
     const completedAtMs = Date.now();
     this.finishLocalCommandLogEntry({
@@ -445,24 +501,63 @@ export class ComputerUseHostRuntime {
       completedAt: new Date(completedAtMs).toISOString(),
       durationMs: completedAtMs - startedAtMs,
     });
-    const response = await this.hostFetch(
-      `/api/zero/computer-use/host/commands/${body.command.id}/complete`,
-      {
-        method: "POST",
-        body: JSON.stringify(completed),
-      },
-    );
-    if (!response.ok) {
-      throw new Error(
-        `Computer Use command completion failed: ${response.status}`,
-      );
+    if (!this.running || !this.hostToken) {
+      return;
     }
+    await this.completeCommandWithRetry(body.command.id, completed);
     this.setState({
       status: "online",
       lastCommandAt: new Date().toISOString(),
       lastError: null,
     });
     await this.refreshAuditEvents();
+  }
+
+  private async completeCommandWithRetry(
+    commandId: string,
+    completed: ComputerUseCommandExecutionResult,
+  ): Promise<void> {
+    let lastError: Error | null = null;
+    for (
+      let attempt = 1;
+      attempt <= COMMAND_COMPLETION_MAX_ATTEMPTS;
+      attempt++
+    ) {
+      try {
+        const response = await this.hostFetch(
+          `/api/zero/computer-use/host/commands/${commandId}/complete`,
+          {
+            method: "POST",
+            body: JSON.stringify(completed),
+          },
+        );
+        if (response.ok) {
+          return;
+        }
+        lastError = new Error(
+          `Computer Use command completion failed: ${response.status}`,
+        );
+      } catch (error) {
+        lastError =
+          error instanceof Error
+            ? error
+            : new Error(
+                `Computer Use command completion failed: ${String(error)}`,
+              );
+      }
+
+      if (attempt < COMMAND_COMPLETION_MAX_ATTEMPTS) {
+        await this.sleep(COMMAND_COMPLETION_RETRY_DELAY_MS);
+      }
+    }
+
+    throw lastError ?? new Error("Computer Use command completion failed");
+  }
+
+  private sleep(delayMs: number): Promise<void> {
+    return new Promise((resolve) => {
+      this.scheduleTimeout(resolve, delayMs);
+    });
   }
 
   private hostFetch(path: string, init: RequestInit): Promise<Response> {


### PR DESCRIPTION
## Summary
- decouple Desktop Computer Use heartbeat from command polling/execution so a busy host stays online
- retry transient command-completion failures from the desktop host
- fail stale server-side running Computer Use commands using command timeoutMs/default timeout before reads or new claims

Fixes #15747

## Verification
- pnpm format
- pnpm turbo run lint
- pnpm check-types
- pnpm -F @vm0/desktop exec vitest run src/computer-use-host.test.ts
- pnpm -F api exec vitest run src/signals/routes/__tests__/zero-computer-use.test.ts

## Notes
- Full pnpm vitest --run currently fails in this local environment across unrelated @vm0/app/platform/web DOM/localStorage suites with `--localstorage-file was provided without a valid path` and `localStorage.getItem is not a function`. The changed desktop/API computer-use tests pass.
- scripts/prepare.sh could not complete because DATABASE_URL is unset and 1Password CLI is unavailable for env sync.
- pnpm knip reports existing repository-wide unused files/exports unrelated to this change.