### PR TITLE
refactor(sandbox-fc): centralize snapshot cleanup resources

### DIFF
--- a/crates/sandbox-fc/src/snapshot/attempt.rs
+++ b/crates/sandbox-fc/src/snapshot/attempt.rs
@@ -79,6 +79,194 @@ async fn destroy_snapshot_cow_after_workflow_error(cow_device: PooledNbdCowDevic
     }
 }
 
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+struct SnapshotCleanupPresence {
+    has_device_pool: bool,
+    has_netns_pool: bool,
+    has_cow_device: bool,
+    has_publish_attempt: bool,
+    has_network: bool,
+    has_child: bool,
+    has_stdout_forwarder: bool,
+    has_stderr_forwarder: bool,
+}
+
+impl SnapshotCleanupPresence {
+    fn has_cleanup_work(self) -> bool {
+        self.has_device_pool
+            || self.has_netns_pool
+            || self.has_cow_device
+            || self.has_publish_attempt
+            || self.has_network
+            || self.has_child
+            || self.has_stdout_forwarder
+            || self.has_stderr_forwarder
+    }
+}
+
+#[derive(Default)]
+struct SnapshotCleanupResources {
+    netns_pool: Option<NetnsPool>,
+    device_pool: Option<DevicePoolHandle>,
+    cow_device: Option<PooledNbdCowDevice>,
+    publish_attempt: Option<SnapshotPublishAttempt>,
+    network: Option<NetnsLease>,
+    child: Option<tokio::process::Child>,
+    stdout_handle: Option<JoinHandle<()>>,
+    stderr_handle: Option<JoinHandle<()>>,
+}
+
+impl SnapshotCleanupResources {
+    fn new(
+        netns_pool: NetnsPool,
+        device_pool: DevicePoolHandle,
+        cow_device: PooledNbdCowDevice,
+    ) -> Self {
+        Self {
+            netns_pool: Some(netns_pool),
+            device_pool: Some(device_pool),
+            cow_device: Some(cow_device),
+            ..Self::default()
+        }
+    }
+
+    #[cfg(test)]
+    fn without_cow_for_test() -> Self {
+        Self {
+            netns_pool: Some(NetnsPool::inactive_for_test()),
+            ..Self::default()
+        }
+    }
+
+    fn presence(&self) -> SnapshotCleanupPresence {
+        SnapshotCleanupPresence {
+            has_device_pool: self.device_pool.is_some(),
+            has_netns_pool: self.netns_pool.is_some(),
+            has_cow_device: self.cow_device.is_some(),
+            has_publish_attempt: self
+                .publish_attempt
+                .as_ref()
+                .is_some_and(SnapshotPublishAttempt::has_cleanup_work),
+            has_network: self.network.is_some(),
+            has_child: self.child.is_some(),
+            has_stdout_forwarder: self.stdout_handle.is_some(),
+            has_stderr_forwarder: self.stderr_handle.is_some(),
+        }
+    }
+
+    fn has_cleanup_work(&self) -> bool {
+        self.presence().has_cleanup_work()
+    }
+
+    async fn destroy_cow_after_setup_error(&mut self, context: &'static str) {
+        if let Some(cow_device) = self.cow_device.take() {
+            destroy_snapshot_cow_after_error(context, cow_device).await;
+        }
+    }
+
+    async fn release_network(
+        &mut self,
+        warning: &'static str,
+        missing_pool_warning: &'static str,
+    ) -> bool {
+        if self.network.is_none() {
+            return true;
+        }
+        let Some(netns_pool) = self.netns_pool.as_mut() else {
+            tracing::warn!("{missing_pool_warning}");
+            return false;
+        };
+        release_snapshot_netns(netns_pool, &mut self.network, warning).await;
+        self.network.is_none()
+    }
+
+    async fn prepare_success_publish(&mut self) -> Result<KeptCow, SnapshotError> {
+        let cow_device = self.cow_device.take().ok_or_else(|| {
+            SnapshotError::Teardown("snapshot attempt missing COW device before publish".into())
+        })?;
+        self.publish_attempt = Some(SnapshotPublishAttempt::new(cow_device));
+        self.resolve_success_publish().await
+    }
+
+    async fn resolve_success_publish(&mut self) -> Result<KeptCow, SnapshotError> {
+        let publish_attempt = self.publish_attempt.as_mut().ok_or_else(|| {
+            SnapshotError::Teardown("snapshot publish attempt missing before publish".into())
+        })?;
+        let kept_cow = publish_attempt.resolve_into_kept_cow().await?;
+        self.publish_attempt.take();
+        Ok(kept_cow)
+    }
+
+    async fn cleanup_failure(&mut self) {
+        if let Some(cow_device) = self.cow_device.take() {
+            destroy_snapshot_cow_after_workflow_error(cow_device).await;
+        }
+        self.cleanup_publish_attempt().await;
+    }
+
+    async fn cleanup_publish_attempt(&mut self) -> bool {
+        let Some(publish_attempt) = self.publish_attempt.as_mut() else {
+            return true;
+        };
+        let cleaned = publish_attempt.cleanup_after_cancellation().await;
+        if cleaned || !publish_attempt.has_cleanup_work() {
+            self.publish_attempt.take();
+        }
+        cleaned
+    }
+
+    async fn cleanup_device_pool(&mut self) -> bool {
+        let Some(device_pool) = self.device_pool.as_ref() else {
+            return true;
+        };
+        device_pool.cleanup().await;
+        self.device_pool.take();
+        true
+    }
+
+    async fn cleanup_netns_pool_after_explicit_teardown(&mut self) {
+        if let Some(netns_pool) = self.netns_pool.as_mut()
+            && let Err(e) = netns_pool.cleanup().await
+        {
+            tracing::warn!(error = %e, "failed to cleanup netns pool");
+        }
+        self.netns_pool.take();
+    }
+
+    async fn cleanup_netns_pool_during_cancellation(&mut self) -> bool {
+        let Some(netns_pool) = self.netns_pool.as_mut() else {
+            return true;
+        };
+        if let Err(e) = netns_pool.cleanup().await {
+            tracing::warn!(error = %e, "failed to cleanup netns pool during snapshot cancellation cleanup");
+            return false;
+        }
+        self.netns_pool.take();
+        true
+    }
+
+    async fn destroy_cow_during_cancellation(&mut self) -> bool {
+        let Some(cow_device) = self.cow_device.take() else {
+            return true;
+        };
+        match destroy_snapshot_cow_and_cleanup_attempt_dir(cow_device).await {
+            Ok(()) => true,
+            Err(e) => {
+                tracing::warn!(
+                    error = %e,
+                    "failed to destroy COW device during snapshot cancellation cleanup"
+                );
+                false
+            }
+        }
+    }
+
+    fn drop_forwarder_handles(&mut self) {
+        self.stdout_handle.take();
+        self.stderr_handle.take();
+    }
+}
+
 /// Snapshot-local owner for resources acquired while producing one snapshot.
 ///
 /// This owner centralizes the explicit success/failure cleanup path for
@@ -99,14 +287,7 @@ pub(super) struct SnapshotAttempt {
     // runner may already be rebuilding the same snapshot.
     sock_paths: Option<SockPaths>,
     output: SnapshotOutputPaths,
-    netns_pool: Option<NetnsPool>,
-    device_pool: Option<DevicePoolHandle>,
-    cow_device: Option<PooledNbdCowDevice>,
-    publish_attempt: Option<SnapshotPublishAttempt>,
-    network: Option<NetnsLease>,
-    child: Option<tokio::process::Child>,
-    stdout_handle: Option<JoinHandle<()>>,
-    stderr_handle: Option<JoinHandle<()>>,
+    cleanup_resources: SnapshotCleanupResources,
     stderr_buf: StderrBuf,
     #[cfg(test)]
     cleanup_complete_tx: Option<tokio::sync::oneshot::Sender<SnapshotCleanupReport>>,
@@ -125,14 +306,7 @@ impl SnapshotAttempt {
             paths,
             sock_paths: Some(sock_paths),
             output,
-            netns_pool: Some(netns_pool),
-            device_pool: Some(device_pool),
-            cow_device: Some(cow_device),
-            publish_attempt: None,
-            network: None,
-            child: None,
-            stdout_handle: None,
-            stderr_handle: None,
+            cleanup_resources: SnapshotCleanupResources::new(netns_pool, device_pool, cow_device),
             stderr_buf: Arc::new(Mutex::new(VecDeque::with_capacity(STDERR_BUF_LINES))),
             #[cfg(test)]
             cleanup_complete_tx: None,
@@ -149,14 +323,7 @@ impl SnapshotAttempt {
             paths,
             sock_paths: Some(sock_paths),
             output,
-            netns_pool: Some(NetnsPool::inactive_for_test()),
-            device_pool: None,
-            cow_device: None,
-            publish_attempt: None,
-            network: None,
-            child: None,
-            stdout_handle: None,
-            stderr_handle: None,
+            cleanup_resources: SnapshotCleanupResources::without_cow_for_test(),
             stderr_buf: Arc::new(Mutex::new(VecDeque::with_capacity(STDERR_BUF_LINES))),
             #[cfg(test)]
             cleanup_complete_tx: None,
@@ -165,36 +332,36 @@ impl SnapshotAttempt {
 
     #[cfg(test)]
     fn track_network_for_test(&mut self, name: &str) {
-        if let Some(netns_pool) = self.netns_pool.as_mut() {
+        if let Some(netns_pool) = self.cleanup_resources.netns_pool.as_mut() {
             let network = netns_pool.lease_for_test(name);
             netns_pool.track_lease_for_test(&network);
-            self.network = Some(network);
+            self.cleanup_resources.network = Some(network);
         }
     }
 
     #[cfg(test)]
     fn track_child_for_test(&mut self, child: tokio::process::Child) {
-        self.child = Some(child);
+        self.cleanup_resources.child = Some(child);
     }
 
     #[cfg(test)]
     fn track_stdout_handle_for_test(&mut self, handle: JoinHandle<()>) {
-        self.stdout_handle = Some(handle);
+        self.cleanup_resources.stdout_handle = Some(handle);
     }
 
     #[cfg(test)]
     fn track_stderr_handle_for_test(&mut self, handle: JoinHandle<()>) {
-        self.stderr_handle = Some(handle);
+        self.cleanup_resources.stderr_handle = Some(handle);
     }
 
     #[cfg(test)]
     fn track_device_pool_for_test(&mut self, device_pool: DevicePoolHandle) {
-        self.device_pool = Some(device_pool);
+        self.cleanup_resources.device_pool = Some(device_pool);
     }
 
     #[cfg(test)]
     fn track_publish_attempt_for_test(&mut self, publish_attempt: SnapshotPublishAttempt) {
-        self.publish_attempt = Some(publish_attempt);
+        self.cleanup_resources.publish_attempt = Some(publish_attempt);
     }
 
     #[cfg(test)]
@@ -230,13 +397,16 @@ impl SnapshotAttempt {
         // `unshare --mount` at spawn time; file content is irrelevant
         // because the bind overlay is what FC reads.
         if let Err(e) = tokio::fs::create_dir_all(self.sock_paths()?.dir()).await {
-            self.destroy_cow_after_setup_error("mkdir sock dir").await;
+            self.cleanup_resources
+                .destroy_cow_after_setup_error("mkdir sock dir")
+                .await;
             return Err(SnapshotError::Setup(format!("mkdir sock dir: {e}")));
         }
 
         let drive_bind = self.paths.cow_device_bind();
         if let Err(e) = tokio::fs::write(&drive_bind, b"").await {
-            self.destroy_cow_after_setup_error("create bind target")
+            self.cleanup_resources
+                .destroy_cow_after_setup_error("create bind target")
                 .await;
             return Err(SnapshotError::Setup(format!("create bind target: {e}")));
         }
@@ -245,10 +415,11 @@ impl SnapshotAttempt {
     }
 
     pub(super) async fn acquire_network(&mut self) -> Result<(), SnapshotError> {
-        let acquire_result = match self.netns_pool.as_mut() {
+        let acquire_result = match self.cleanup_resources.netns_pool.as_mut() {
             Some(netns_pool) => netns_pool.acquire().await,
             None => {
-                self.destroy_cow_after_setup_error("missing netns pool before acquire")
+                self.cleanup_resources
+                    .destroy_cow_after_setup_error("missing netns pool before acquire")
                     .await;
                 return Err(SnapshotError::Setup(
                     "snapshot attempt missing netns pool before acquire".into(),
@@ -258,13 +429,15 @@ impl SnapshotAttempt {
         let network = match acquire_result {
             Ok(network) => network,
             Err(e) => {
-                self.destroy_cow_after_setup_error("acquire netns").await;
+                self.cleanup_resources
+                    .destroy_cow_after_setup_error("acquire netns")
+                    .await;
                 return Err(SnapshotError::Setup(format!("acquire netns: {e}")));
             }
         };
 
         info!(netns = %network.info().name(), "namespace acquired");
-        self.network = Some(network);
+        self.cleanup_resources.network = Some(network);
         Ok(())
     }
 
@@ -275,6 +448,7 @@ impl SnapshotAttempt {
         let api_sock = self.sock_paths()?.api_sock();
         let drive_bind = self.paths.cow_device_bind();
         let cow_device_path = self
+            .cleanup_resources
             .cow_device
             .as_ref()
             .ok_or_else(|| {
@@ -283,6 +457,7 @@ impl SnapshotAttempt {
             .device_path()
             .to_path_buf();
         let network_name = self
+            .cleanup_resources
             .network
             .as_ref()
             .ok_or_else(|| {
@@ -327,7 +502,8 @@ impl SnapshotAttempt {
                 // already-acquired ones.
                 self.release_network("failed to release netns after spawn failure")
                     .await;
-                self.destroy_cow_after_setup_error("spawn firecracker")
+                self.cleanup_resources
+                    .destroy_cow_after_setup_error("spawn firecracker")
                     .await;
                 return Err(SnapshotError::Process(format!("spawn firecracker: {e}")));
             }
@@ -337,14 +513,14 @@ impl SnapshotAttempt {
         // Stderr is also retained in a bounded ring buffer so that an early
         // spawn-chain exit (mount failure inside unshare bash, etc.) can be
         // reported with its real cause instead of just an API timeout.
-        self.stdout_handle = spawn_stdout_forwarder(&mut child);
+        self.cleanup_resources.stdout_handle = spawn_stdout_forwarder(&mut child);
         // The stderr forwarder handle is retained so that, on detected early
         // exit, we can wait a bounded time for it to drain buffered lines
         // before snapshotting the ring buffer for the error message. Without
         // this join, the most informative lines (mount: bind failed, etc.)
         // can race the `try_wait` observation and be missed.
-        self.stderr_handle = spawn_stderr_forwarder(&mut child, &self.stderr_buf);
-        self.child = Some(child);
+        self.cleanup_resources.stderr_handle = spawn_stderr_forwarder(&mut child, &self.stderr_buf);
+        self.cleanup_resources.child = Some(child);
 
         Ok(())
     }
@@ -358,18 +534,22 @@ impl SnapshotAttempt {
         // issue" (try_wait → None) from "firecracker already died, error is
         // the downstream symptom of that" (try_wait → Some(non-zero)).
         let child_status = self
+            .cleanup_resources
             .child
             .as_mut()
             .map_or(Ok(None), tokio::process::Child::try_wait);
-        self.stderr_handle =
-            drain_stderr_forwarder_after_spawn_exit(&child_status, self.stderr_handle.take()).await;
+        self.cleanup_resources.stderr_handle = drain_stderr_forwarder_after_spawn_exit(
+            &child_status,
+            self.cleanup_resources.stderr_handle.take(),
+        )
+        .await;
         let result = rewrap_spawn_chain_exit(result, child_status, &self.stderr_buf);
 
         // Kill Firecracker first — it holds the NBD device fd open.
-        if let Some(child) = self.child.as_mut() {
+        if let Some(child) = self.cleanup_resources.child.as_mut() {
             kill_and_reap_firecracker(child).await;
         }
-        self.child.take();
+        self.cleanup_resources.child.take();
 
         // Release network namespace back to the pool before teardown.
         // Without this, the namespace resources (veth, iptables) leak because
@@ -386,19 +566,13 @@ impl SnapshotAttempt {
 
     pub(super) async fn cleanup_device_pool(&mut self) {
         self.cleanup_publish_attempt().await;
-        if let Some(device_pool) = self.device_pool.as_ref() {
-            device_pool.cleanup().await;
-        }
-        self.device_pool.take();
+        self.cleanup_resources.cleanup_device_pool().await;
     }
 
     pub(super) async fn cleanup_netns_pool(&mut self) {
-        if let Some(netns_pool) = self.netns_pool.as_mut()
-            && let Err(e) = netns_pool.cleanup().await
-        {
-            tracing::warn!(error = %e, "failed to cleanup netns pool");
-        }
-        self.netns_pool.take();
+        self.cleanup_resources
+            .cleanup_netns_pool_after_explicit_teardown()
+            .await;
     }
 
     pub(super) async fn cleanup_sock_dir(&mut self) {
@@ -408,74 +582,33 @@ impl SnapshotAttempt {
         self.sock_paths.take();
     }
 
-    async fn destroy_cow_after_setup_error(&mut self, context: &'static str) {
-        if let Some(cow_device) = self.cow_device.take() {
-            destroy_snapshot_cow_after_error(context, cow_device).await;
-        }
-    }
-
     async fn release_network(&mut self, warning: &'static str) {
-        if self.network.is_some() {
-            let Some(netns_pool) = self.netns_pool.as_mut() else {
-                tracing::warn!("snapshot attempt missing netns pool while releasing netns");
-                return;
-            };
-            release_snapshot_netns(netns_pool, &mut self.network, warning).await;
-        }
+        self.cleanup_resources
+            .release_network(
+                warning,
+                "snapshot attempt missing netns pool while releasing netns",
+            )
+            .await;
     }
 
     pub(super) async fn prepare_success_publish(&mut self) -> Result<KeptCow, SnapshotError> {
-        let cow_device = self.cow_device.take().ok_or_else(|| {
-            SnapshotError::Teardown("snapshot attempt missing COW device before publish".into())
-        })?;
-        self.publish_attempt = Some(SnapshotPublishAttempt::new(cow_device));
-        self.resolve_success_publish().await
-    }
-
-    async fn resolve_success_publish(&mut self) -> Result<KeptCow, SnapshotError> {
-        let publish_attempt = self.publish_attempt.as_mut().ok_or_else(|| {
-            SnapshotError::Teardown("snapshot publish attempt missing before publish".into())
-        })?;
-        let kept_cow = publish_attempt.resolve_into_kept_cow().await?;
-        self.publish_attempt.take();
-        Ok(kept_cow)
+        self.cleanup_resources.prepare_success_publish().await
     }
 
     async fn cleanup_failure(&mut self) {
-        if let Some(cow_device) = self.cow_device.take() {
-            destroy_snapshot_cow_after_workflow_error(cow_device).await;
-        }
-        self.cleanup_publish_attempt().await;
+        self.cleanup_resources.cleanup_failure().await;
     }
 
     async fn cleanup_publish_attempt(&mut self) -> bool {
-        let Some(publish_attempt) = self.publish_attempt.as_mut() else {
-            return true;
-        };
-        let cleaned = publish_attempt.cleanup_after_cancellation().await;
-        if cleaned || !publish_attempt.has_cleanup_work() {
-            self.publish_attempt.take();
-        }
-        cleaned
+        self.cleanup_resources.cleanup_publish_attempt().await
     }
 
     fn drop_forwarder_handles(&mut self) {
-        self.stdout_handle.take();
-        self.stderr_handle.take();
+        self.cleanup_resources.drop_forwarder_handles();
     }
 
     fn has_cleanup_work(&self) -> bool {
-        self.device_pool.is_some()
-            || self.netns_pool.is_some()
-            || self.cow_device.is_some()
-            || self
-                .publish_attempt
-                .as_ref()
-                .is_some_and(SnapshotPublishAttempt::has_cleanup_work)
-            || self.network.is_some()
-            || self.child.is_some()
-            || self.stdout_handle.is_some()
-            || self.stderr_handle.is_some()
+        self.cleanup_resources.has_cleanup_work()
     }
 
     fn take_cleanup_finalizer(&mut self) -> Option<SnapshotCleanupFinalizer> {
@@ -484,14 +617,7 @@ impl SnapshotAttempt {
         }
 
         Some(SnapshotCleanupFinalizer {
-            netns_pool: self.netns_pool.take(),
-            device_pool: self.device_pool.take(),
-            cow_device: self.cow_device.take(),
-            publish_attempt: self.publish_attempt.take(),
-            network: self.network.take(),
-            child: self.child.take(),
-            stdout_handle: self.stdout_handle.take(),
-            stderr_handle: self.stderr_handle.take(),
+            resources: std::mem::take(&mut self.cleanup_resources),
             #[cfg(test)]
             cleanup_complete_tx: self.cleanup_complete_tx.take(),
             #[cfg(test)]
@@ -514,14 +640,7 @@ struct SnapshotCleanupReport {
 }
 
 struct SnapshotCleanupFinalizer {
-    netns_pool: Option<NetnsPool>,
-    device_pool: Option<DevicePoolHandle>,
-    cow_device: Option<PooledNbdCowDevice>,
-    publish_attempt: Option<SnapshotPublishAttempt>,
-    network: Option<NetnsLease>,
-    child: Option<tokio::process::Child>,
-    stdout_handle: Option<JoinHandle<()>>,
-    stderr_handle: Option<JoinHandle<()>>,
+    resources: SnapshotCleanupResources,
     #[cfg(test)]
     cleanup_complete_tx: Option<tokio::sync::oneshot::Sender<SnapshotCleanupReport>>,
     #[cfg(test)]
@@ -530,31 +649,40 @@ struct SnapshotCleanupFinalizer {
 
 impl SnapshotCleanupFinalizer {
     async fn run(mut self) {
-        let child_reaped = if let Some(child) = self.child.as_mut() {
+        let child_reaped = if let Some(child) = self.resources.child.as_mut() {
             kill_and_reap_firecracker_bounded(child, SNAPSHOT_FINALIZER_CHILD_WAIT_TIMEOUT).await
         } else {
             true
         };
-        self.child.take();
+        self.resources.child.take();
 
         let stdout_forwarder_finished = drain_or_abort_forwarder(
-            &mut self.stdout_handle,
+            &mut self.resources.stdout_handle,
             "stdout",
             SNAPSHOT_FINALIZER_PIPE_DRAIN_TIMEOUT,
         )
         .await;
         let stderr_forwarder_finished = drain_or_abort_forwarder(
-            &mut self.stderr_handle,
+            &mut self.resources.stderr_handle,
             "stderr",
             SNAPSHOT_FINALIZER_PIPE_DRAIN_TIMEOUT,
         )
         .await;
 
-        let network_released = self.release_network().await;
+        let network_released = self
+            .resources
+            .release_network(
+                "failed to release netns during snapshot cancellation cleanup",
+                "snapshot cancellation cleanup missing netns pool while releasing netns",
+            )
+            .await;
         let publish_cleaned = self.cleanup_publish_attempt().await;
-        let cow_destroyed = self.destroy_cow().await;
+        let cow_destroyed = self.resources.destroy_cow_during_cancellation().await;
         let device_pool_cleaned = self.cleanup_device_pool().await;
-        let netns_pool_cleaned = self.cleanup_netns_pool().await;
+        let netns_pool_cleaned = self
+            .resources
+            .cleanup_netns_pool_during_cancellation()
+            .await;
 
         let report = SnapshotCleanupReport {
             child_reaped,
@@ -587,89 +715,31 @@ impl SnapshotCleanupFinalizer {
         }
     }
 
-    async fn release_network(&mut self) -> bool {
-        if self.network.is_none() {
+    async fn cleanup_publish_attempt(&mut self) -> bool {
+        let has_publish_attempt = self
+            .resources
+            .publish_attempt
+            .as_ref()
+            .is_some_and(SnapshotPublishAttempt::has_cleanup_work);
+        if !has_publish_attempt {
             return true;
         }
-        let Some(netns_pool) = self.netns_pool.as_mut() else {
-            tracing::warn!(
-                "snapshot cancellation cleanup missing netns pool while releasing netns"
-            );
-            return false;
-        };
-        release_snapshot_netns(
-            netns_pool,
-            &mut self.network,
-            "failed to release netns during snapshot cancellation cleanup",
-        )
-        .await;
-        self.network.is_none()
-    }
-
-    async fn cleanup_publish_attempt(&mut self) -> bool {
-        let Some(publish_attempt) = self.publish_attempt.as_mut() else {
-            return true;
-        };
         #[cfg(test)]
         self.cleanup_events.push("publish");
-        let cleaned = publish_attempt.cleanup_after_cancellation().await;
-        if cleaned || !publish_attempt.has_cleanup_work() {
-            self.publish_attempt.take();
-        }
-        cleaned
-    }
-
-    async fn destroy_cow(&mut self) -> bool {
-        let Some(cow_device) = self.cow_device.take() else {
-            return true;
-        };
-        match destroy_snapshot_cow_and_cleanup_attempt_dir(cow_device).await {
-            Ok(()) => true,
-            Err(e) => {
-                tracing::warn!(
-                    error = %e,
-                    "failed to destroy COW device during snapshot cancellation cleanup"
-                );
-                false
-            }
-        }
+        self.resources.cleanup_publish_attempt().await
     }
 
     async fn cleanup_device_pool(&mut self) -> bool {
-        let Some(device_pool) = self.device_pool.as_ref() else {
+        if self.resources.device_pool.is_none() {
             return true;
-        };
+        }
         #[cfg(test)]
         self.cleanup_events.push("device_pool");
-        device_pool.cleanup().await;
-        self.device_pool.take();
-        true
-    }
-
-    async fn cleanup_netns_pool(&mut self) -> bool {
-        let Some(netns_pool) = self.netns_pool.as_mut() else {
-            return true;
-        };
-        if let Err(e) = netns_pool.cleanup().await {
-            tracing::warn!(error = %e, "failed to cleanup netns pool during snapshot cancellation cleanup");
-            return false;
-        }
-        self.netns_pool.take();
-        true
+        self.resources.cleanup_device_pool().await
     }
 
     fn has_cleanup_work(&self) -> bool {
-        self.device_pool.is_some()
-            || self.netns_pool.is_some()
-            || self.cow_device.is_some()
-            || self
-                .publish_attempt
-                .as_ref()
-                .is_some_and(SnapshotPublishAttempt::has_cleanup_work)
-            || self.network.is_some()
-            || self.child.is_some()
-            || self.stdout_handle.is_some()
-            || self.stderr_handle.is_some()
+        self.resources.has_cleanup_work()
     }
 }
 
@@ -679,18 +749,16 @@ impl Drop for SnapshotCleanupFinalizer {
             return;
         }
 
+        let presence = self.resources.presence();
         tracing::warn!(
-            has_device_pool = self.device_pool.is_some(),
-            has_netns_pool = self.netns_pool.is_some(),
-            has_cow_device = self.cow_device.is_some(),
-            has_publish_attempt = self
-                .publish_attempt
-                .as_ref()
-                .is_some_and(SnapshotPublishAttempt::has_cleanup_work),
-            has_network = self.network.is_some(),
-            has_child = self.child.is_some(),
-            has_stdout_forwarder = self.stdout_handle.is_some(),
-            has_stderr_forwarder = self.stderr_handle.is_some(),
+            has_device_pool = presence.has_device_pool,
+            has_netns_pool = presence.has_netns_pool,
+            has_cow_device = presence.has_cow_device,
+            has_publish_attempt = presence.has_publish_attempt,
+            has_network = presence.has_network,
+            has_child = presence.has_child,
+            has_stdout_forwarder = presence.has_stdout_forwarder,
+            has_stderr_forwarder = presence.has_stderr_forwarder,
             "snapshot cancellation finalizer dropped before cleanup completed"
         );
     }
@@ -701,19 +769,9 @@ impl Drop for SnapshotAttempt {
         let Some(finalizer) = self.take_cleanup_finalizer() else {
             return;
         };
-        let has_device_pool = finalizer.device_pool.is_some();
-        let has_netns_pool = finalizer.netns_pool.is_some();
-        let has_cow_device = finalizer.cow_device.is_some();
-        let has_publish_attempt = finalizer
-            .publish_attempt
-            .as_ref()
-            .is_some_and(SnapshotPublishAttempt::has_cleanup_work);
-        let has_network = finalizer.network.is_some();
-        let has_child = finalizer.child.is_some();
-        let has_stdout_forwarder = finalizer.stdout_handle.is_some();
-        let has_stderr_forwarder = finalizer.stderr_handle.is_some();
+        let presence = finalizer.resources.presence();
 
-        if let Some(child) = finalizer.child.as_ref() {
+        if let Some(child) = finalizer.resources.child.as_ref() {
             // The outer snapshot build lock can be released as soon as the
             // cancelled future is dropped. Signal the process group before the
             // async handoff so a later build of the same snapshot does not race
@@ -724,14 +782,14 @@ impl Drop for SnapshotAttempt {
         match tokio::runtime::Handle::try_current() {
             Ok(runtime) => {
                 tracing::info!(
-                    has_device_pool,
-                    has_netns_pool,
-                    has_cow_device,
-                    has_publish_attempt,
-                    has_network,
-                    has_child,
-                    has_stdout_forwarder,
-                    has_stderr_forwarder,
+                    has_device_pool = presence.has_device_pool,
+                    has_netns_pool = presence.has_netns_pool,
+                    has_cow_device = presence.has_cow_device,
+                    has_publish_attempt = presence.has_publish_attempt,
+                    has_network = presence.has_network,
+                    has_child = presence.has_child,
+                    has_stdout_forwarder = presence.has_stdout_forwarder,
+                    has_stderr_forwarder = presence.has_stderr_forwarder,
                     "snapshot attempt dropped; scheduling cancellation cleanup"
                 );
                 runtime.spawn(async move {
@@ -740,14 +798,14 @@ impl Drop for SnapshotAttempt {
             }
             Err(e) => tracing::warn!(
                 error = %e,
-                has_device_pool,
-                has_netns_pool,
-                has_cow_device,
-                has_publish_attempt,
-                has_network,
-                has_child,
-                has_stdout_forwarder,
-                has_stderr_forwarder,
+                has_device_pool = presence.has_device_pool,
+                has_netns_pool = presence.has_netns_pool,
+                has_cow_device = presence.has_cow_device,
+                has_publish_attempt = presence.has_publish_attempt,
+                has_network = presence.has_network,
+                has_child = presence.has_child,
+                has_stdout_forwarder = presence.has_stdout_forwarder,
+                has_stderr_forwarder = presence.has_stderr_forwarder,
                 "snapshot attempt dropped outside Tokio runtime; async cancellation cleanup not scheduled"
             ),
         }
@@ -796,6 +854,53 @@ mod tests {
             cow_file,
             bitmap_file,
         }
+    }
+
+    #[tokio::test]
+    async fn snapshot_cleanup_resources_presence_tracks_all_handoff_resources() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let (mut attempt, _sock_dir) = snapshot_attempt_for_test(&dir);
+        let kept_cow =
+            write_kept_cow_for_test(&attempt.output().work_dir(), "presence-summary").await;
+        let (tx, rx) = tokio::sync::oneshot::channel();
+
+        attempt.track_publish_attempt_for_test(SnapshotPublishAttempt::new_with_kept_cow_for_test(
+            kept_cow,
+        ));
+        attempt.track_device_pool_for_test(DevicePoolHandle::new(
+            nbd_cow::pool::DevicePoolConfig::default(),
+        ));
+        attempt.track_network_for_test("test-snapshot-presence");
+        attempt.track_child_for_test(long_running_child_for_test());
+        attempt.track_stdout_handle_for_test(tokio::spawn(std::future::pending::<()>()));
+        attempt.track_stderr_handle_for_test(tokio::spawn(std::future::pending::<()>()));
+
+        assert_eq!(
+            attempt.cleanup_resources.presence(),
+            SnapshotCleanupPresence {
+                has_device_pool: true,
+                has_netns_pool: true,
+                has_cow_device: false,
+                has_publish_attempt: true,
+                has_network: true,
+                has_child: true,
+                has_stdout_forwarder: true,
+                has_stderr_forwarder: true,
+            }
+        );
+        assert!(attempt.cleanup_resources.has_cleanup_work());
+
+        attempt.notify_cleanup_complete_for_test(tx);
+        drop(attempt);
+        let report = wait_for_snapshot_cleanup(rx).await;
+
+        assert!(report.child_reaped);
+        assert!(report.stdout_forwarder_finished);
+        assert!(report.stderr_forwarder_finished);
+        assert!(report.network_released);
+        assert!(report.publish_cleaned);
+        assert!(report.device_pool_cleaned);
+        assert!(report.netns_pool_cleaned);
     }
 
     #[tokio::test]
@@ -851,7 +956,8 @@ mod tests {
         );
         attempt.notify_cleanup_complete_for_test(cleanup_tx);
 
-        let handle = tokio::spawn(async move { attempt.resolve_success_publish().await });
+        let handle =
+            tokio::spawn(async move { attempt.cleanup_resources.resolve_success_publish().await });
         started_rx
             .await
             .expect("keep-COW finalizer should be polled");


### PR DESCRIPTION
## Summary
- centralize snapshot cleanup-owned resources in `SnapshotCleanupResources`
- move success, failure, and cancellation cleanup helpers onto the shared owner
- keep `SnapshotAttempt` and detached finalizer handoff logging based on a single cleanup presence summary
- add coverage for presence tracking across all handoff resources

## Tests
- `cargo fmt --manifest-path crates/sandbox-fc/Cargo.toml --check`
- `cargo test --manifest-path crates/Cargo.toml -p sandbox-fc snapshot::attempt`
- `cargo test --manifest-path crates/Cargo.toml -p sandbox-fc snapshot::publish`
- `cargo clippy --manifest-path crates/Cargo.toml -p sandbox-fc --all-targets -- -D warnings`
- `cargo test --manifest-path crates/Cargo.toml -p sandbox-fc`
- `cargo doc --workspace --all-features --no-deps` from `crates/`

Closes #15715
