### PR TITLE
fix: add subscription checkout metadata

### DIFF
--- a/turbo/apps/api/src/signals/routes/__tests__/zero-billing-checkout.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/zero-billing-checkout.test.ts
@@ -265,8 +265,20 @@ describe("POST /api/zero/billing/checkout", () => {
       allow_promotion_codes: true,
       success_url: `${APP_ORIGIN}/billing?billing=success`,
       cancel_url: `${APP_ORIGIN}/billing?billing=canceled`,
-      metadata: { orgId: fixture.orgId },
-      subscription_data: { metadata: { orgId: fixture.orgId } },
+      metadata: {
+        orgId: fixture.orgId,
+        tier: "pro",
+        priceId: TEST_PRICE_PRO,
+        flow: "standard",
+      },
+      subscription_data: {
+        metadata: {
+          orgId: fixture.orgId,
+          tier: "pro",
+          priceId: TEST_PRICE_PRO,
+          flow: "standard",
+        },
+      },
     });
   });
 
@@ -378,6 +390,9 @@ describe("POST /api/zero/billing/checkout", () => {
     });
     const expectedMetadata = {
       orgId: fixture.orgId,
+      tier: "pro",
+      priceId: TEST_PRICE_PRO,
+      flow: "standard",
       vm0_source: "presentation",
       utm_source: "google",
       utm_medium: "cpc",
@@ -431,9 +446,19 @@ describe("POST /api/zero/billing/checkout", () => {
       allow_promotion_codes: true,
       success_url: `${APP_ORIGIN}/onboarding?billing=pro`,
       cancel_url: `${APP_ORIGIN}/onboarding?billing=canceled`,
-      metadata: { orgId: fixture.orgId },
+      metadata: {
+        orgId: fixture.orgId,
+        tier: "pro",
+        priceId: TEST_PRICE_PRO,
+        flow: "trial",
+      },
       subscription_data: {
-        metadata: { orgId: fixture.orgId },
+        metadata: {
+          orgId: fixture.orgId,
+          tier: "pro",
+          priceId: TEST_PRICE_PRO,
+          flow: "trial",
+        },
         trial_period_days: 7,
       },
     });

--- a/turbo/apps/api/src/signals/routes/zero-billing-checkout.ts
+++ b/turbo/apps/api/src/signals/routes/zero-billing-checkout.ts
@@ -100,6 +100,7 @@ const checkoutAuthed$ = command(async ({ get, set }, signal: AbortSignal) => {
     createCheckoutSession$,
     {
       orgId: auth.orgId,
+      tier,
       priceId,
       trialDays,
       successUrl,

--- a/turbo/apps/api/src/signals/services/zero-billing-checkout.service.ts
+++ b/turbo/apps/api/src/signals/services/zero-billing-checkout.service.ts
@@ -11,6 +11,7 @@ import { getOrCreateStripeCustomer$ } from "./billing-customer.service";
 
 interface CreateCheckoutSessionArgs {
   readonly orgId: string;
+  readonly tier: SubscriptionCheckoutTier;
   readonly priceId: string;
   readonly trialDays?: 7;
   readonly successUrl: string;
@@ -118,12 +119,22 @@ export function activeCustomCreditPriceId(): string | undefined {
   return env("ZERO_PRICE")?.customCredits?.[0];
 }
 
-function checkoutSessionMetadata(
-  orgId: string,
-  adAttribution: Readonly<Record<string, string | undefined>> | undefined,
-): Record<string, string> {
-  const metadata: Record<string, string> = { orgId };
-  for (const [key, value] of Object.entries(adAttribution ?? {})) {
+function checkoutSessionMetadata(args: {
+  readonly orgId: string;
+  readonly tier: SubscriptionCheckoutTier;
+  readonly priceId: string;
+  readonly trialDays?: 7;
+  readonly adAttribution:
+    | Readonly<Record<string, string | undefined>>
+    | undefined;
+}): Record<string, string> {
+  const metadata: Record<string, string> = {
+    orgId: args.orgId,
+    tier: args.tier,
+    priceId: args.priceId,
+    flow: args.trialDays === undefined ? "standard" : "trial",
+  };
+  for (const [key, value] of Object.entries(args.adAttribution ?? {})) {
     if (value) {
       metadata[key] = value;
     }
@@ -203,7 +214,13 @@ export const createCheckoutSession$ = command(
     signal.throwIfAborted();
 
     const stripe = getStripeClient();
-    const metadata = checkoutSessionMetadata(args.orgId, args.adAttribution);
+    const metadata = checkoutSessionMetadata({
+      orgId: args.orgId,
+      tier: args.tier,
+      priceId: args.priceId,
+      trialDays: args.trialDays,
+      adAttribution: args.adAttribution,
+    });
     const session = await stripe.checkout.sessions.create({
       mode: "subscription",
       customer: customerId,


### PR DESCRIPTION
## Summary
- include `tier`, `priceId`, and checkout `flow` in subscription checkout metadata
- write the enriched metadata to both the Checkout Session and `subscription_data.metadata`
- keep existing ad attribution metadata merged into the same Stripe metadata object

## Tests
- pnpm format
- pnpm -F api exec vitest src/signals/routes/__tests__/zero-billing-checkout.test.ts
- pnpm -F api lint
- pnpm -F api check-types
- pnpm knip --workspace api
- pre-commit: prettier, knip --cache, pnpm check-types, commitlint