### PR TITLE
feat: resolve zero run permissions from user grants

### DIFF
--- a/turbo/apps/api/src/signals/routes/__tests__/helpers/zero-schedules.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/helpers/zero-schedules.ts
@@ -8,6 +8,7 @@ import {
 import { agentRunCallbacks } from "@vm0/db/schema/agent-run-callback";
 import { agentRuns } from "@vm0/db/schema/agent-run";
 import { agentSessions } from "@vm0/db/schema/agent-session";
+import { connectors } from "@vm0/db/schema/connector";
 import { modelProviders } from "@vm0/db/schema/model-provider";
 import { orgMembersMetadata } from "@vm0/db/schema/org-members-metadata";
 import { orgMetadata } from "@vm0/db/schema/org-metadata";
@@ -15,6 +16,9 @@ import { orgModelPolicies } from "@vm0/db/schema/org-model-policy";
 import { runnerJobQueue } from "@vm0/db/schema/runner-job-queue";
 import { secrets } from "@vm0/db/schema/secret";
 import { userCache } from "@vm0/db/schema/user-cache";
+import { userConnectors } from "@vm0/db/schema/user-connector";
+import { userFeatureSwitches } from "@vm0/db/schema/user-feature-switches";
+import { userPermissionGrants } from "@vm0/db/schema/user-permission-grant";
 import { zeroAgents } from "@vm0/db/schema/zero-agent";
 import { zeroAgentSchedules } from "@vm0/db/schema/zero-agent-schedule";
 import { zeroRuns } from "@vm0/db/schema/zero-run";
@@ -257,6 +261,24 @@ export const deleteSchedulesScenario$ = command(
       .where(eq(agentComposeVersions.composeId, fixture.composeId));
     signal.throwIfAborted();
     await writeDb
+      .delete(userPermissionGrants)
+      .where(
+        and(
+          eq(userPermissionGrants.orgId, fixture.orgId),
+          eq(userPermissionGrants.userId, fixture.userId),
+        ),
+      );
+    signal.throwIfAborted();
+    await writeDb
+      .delete(userConnectors)
+      .where(
+        and(
+          eq(userConnectors.orgId, fixture.orgId),
+          eq(userConnectors.userId, fixture.userId),
+        ),
+      );
+    signal.throwIfAborted();
+    await writeDb
       .delete(zeroAgents)
       .where(eq(zeroAgents.id, fixture.composeId));
     signal.throwIfAborted();
@@ -264,7 +286,18 @@ export const deleteSchedulesScenario$ = command(
       .delete(modelProviders)
       .where(eq(modelProviders.orgId, fixture.orgId));
     signal.throwIfAborted();
+    await writeDb.delete(connectors).where(eq(connectors.orgId, fixture.orgId));
+    signal.throwIfAborted();
     await writeDb.delete(secrets).where(eq(secrets.orgId, fixture.orgId));
+    signal.throwIfAborted();
+    await writeDb
+      .delete(userFeatureSwitches)
+      .where(
+        and(
+          eq(userFeatureSwitches.orgId, fixture.orgId),
+          eq(userFeatureSwitches.userId, fixture.userId),
+        ),
+      );
     signal.throwIfAborted();
     await writeDb
       .delete(agentComposes)

--- a/turbo/apps/api/src/signals/routes/__tests__/helpers/zero-usage-insight.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/helpers/zero-usage-insight.ts
@@ -8,10 +8,14 @@ import {
 import { agentRuns } from "@vm0/db/schema/agent-run";
 import { agentSessions } from "@vm0/db/schema/agent-session";
 import { chatThreads } from "@vm0/db/schema/chat-thread";
+import { connectors } from "@vm0/db/schema/connector";
 import { orgMetadata } from "@vm0/db/schema/org-metadata";
+import { secrets } from "@vm0/db/schema/secret";
 import { storages, storageVersions } from "@vm0/db/schema/storage";
 import { usageEvent } from "@vm0/db/schema/usage-event";
+import { userConnectors } from "@vm0/db/schema/user-connector";
 import { userFeatureSwitches } from "@vm0/db/schema/user-feature-switches";
+import { userPermissionGrants } from "@vm0/db/schema/user-permission-grant";
 import { zeroAgents } from "@vm0/db/schema/zero-agent";
 import { zeroAgentSchedules } from "@vm0/db/schema/zero-agent-schedule";
 import { zeroRuns } from "@vm0/db/schema/zero-run";
@@ -157,6 +161,31 @@ export const deleteUsageInsightFixture$ = command(
           eq(userFeatureSwitches.userId, userId),
         ),
       );
+    signal.throwIfAborted();
+
+    await db
+      .delete(userPermissionGrants)
+      .where(
+        and(
+          eq(userPermissionGrants.orgId, orgId),
+          eq(userPermissionGrants.userId, userId),
+        ),
+      );
+    signal.throwIfAborted();
+
+    await db
+      .delete(userConnectors)
+      .where(
+        and(eq(userConnectors.orgId, orgId), eq(userConnectors.userId, userId)),
+      );
+    signal.throwIfAborted();
+
+    await db
+      .delete(connectors)
+      .where(and(eq(connectors.orgId, orgId), eq(connectors.userId, userId)));
+    signal.throwIfAborted();
+
+    await db.delete(secrets).where(eq(secrets.orgId, orgId));
     signal.throwIfAborted();
 
     await db.delete(orgMetadata).where(eq(orgMetadata.orgId, orgId));

--- a/turbo/apps/api/src/signals/routes/__tests__/zero-runs-create.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/zero-runs-create.test.ts
@@ -6,9 +6,10 @@ import {
 } from "@vm0/api-contracts/contracts/model-providers";
 import type { OrgTier } from "@vm0/api-contracts/contracts/orgs";
 import { zeroRunsMainContract } from "@vm0/api-contracts/contracts/zero-runs";
-import type {
-  FirewallPolicyValue,
-  RawPermissionPolicies,
+import {
+  type FirewallPolicyValue,
+  type RawPermissionPolicies,
+  UNKNOWN_PERMISSION_GRANT,
 } from "@vm0/connectors/firewall-types";
 import { getConnectorFirewall } from "@vm0/connectors/firewalls";
 import {
@@ -33,12 +34,16 @@ import { userCache } from "@vm0/db/schema/user-cache";
 import { userCustomConnectors } from "@vm0/db/schema/user-custom-connector";
 import { userConnectors } from "@vm0/db/schema/user-connector";
 import { userFeatureSwitches } from "@vm0/db/schema/user-feature-switches";
+import {
+  userPermissionGrants,
+  type UserPermissionGrantAction,
+} from "@vm0/db/schema/user-permission-grant";
 import { vm0ApiKeys } from "@vm0/db/schema/vm0-api-key";
 import { zeroAgents } from "@vm0/db/schema/zero-agent";
 import { zeroRuns } from "@vm0/db/schema/zero-run";
 import { FeatureSwitchKey } from "@vm0/core/feature-switch-key";
 import { command, createStore } from "ccstate";
-import { eq } from "drizzle-orm";
+import { and, eq } from "drizzle-orm";
 import { describe, expect, it } from "vitest";
 
 import { accept, setupApp, testContext } from "../../../__tests__/test-helpers";
@@ -48,9 +53,10 @@ import {
   verifyZeroToken,
 } from "../../auth/tokens";
 import { writeDb$ } from "../../external/db";
-import { now } from "../../external/time";
+import { now, nowDate } from "../../external/time";
 import { mockNow } from "../../../lib/time";
 import { drainOrgQueue$ } from "../../services/zero-run-queue.service";
+import { createZeroIntegrationRun$ } from "../../services/zero-runs-create.service";
 import { mockOptionalEnv } from "../../../lib/env";
 import {
   createFixtureTracker,
@@ -74,6 +80,16 @@ const context = testContext();
 const store = createStore();
 const mocks = createZeroRouteMocks(context);
 const ORG_SENTINEL_USER_ID = "__org__";
+const SLACK_CONNECTOR = "slack";
+const SLACK_READ_PERMISSION = "channels:read";
+const SLACK_WRITE_PERMISSION = "chat:write";
+
+interface QueuedNetworkPolicy {
+  readonly allow: readonly string[];
+  readonly deny: readonly string[];
+  readonly ask: readonly string[];
+  readonly unknownPolicy: string;
+}
 
 function modelProviderSecretPlaceholder(
   type: ModelProviderType,
@@ -250,6 +266,132 @@ async function fixture(): Promise<UsageInsightFixture> {
   );
   mockOptionalEnv("RUNNER_DEFAULT_GROUP", "vm0/test");
   return created;
+}
+
+async function enableUserPermissionGrants(
+  orgId: string,
+  userId: string,
+): Promise<void> {
+  const db = store.set(writeDb$);
+  await db
+    .insert(userFeatureSwitches)
+    .values({
+      orgId,
+      userId,
+      switches: { [FeatureSwitchKey.UserPermissionGrants]: true },
+    })
+    .onConflictDoUpdate({
+      target: [userFeatureSwitches.orgId, userFeatureSwitches.userId],
+      set: {
+        switches: { [FeatureSwitchKey.UserPermissionGrants]: true },
+        updatedAt: nowDate(),
+      },
+    });
+}
+
+async function seedSlackConnector(args: {
+  readonly fixture: UsageInsightFixture;
+  readonly agentId: string;
+  readonly userId?: string;
+}): Promise<void> {
+  const db = store.set(writeDb$);
+  const userId = args.userId ?? args.fixture.userId;
+  await db.insert(userConnectors).values({
+    orgId: args.fixture.orgId,
+    userId,
+    agentId: args.agentId,
+    connectorType: SLACK_CONNECTOR,
+  });
+  await db.insert(connectors).values({
+    orgId: args.fixture.orgId,
+    userId,
+    type: SLACK_CONNECTOR,
+    authMethod: "oauth",
+  });
+  await db.insert(secrets).values({
+    orgId: args.fixture.orgId,
+    userId,
+    name: "SLACK_ACCESS_TOKEN",
+    encryptedValue: encryptSecretForTests("xoxb-test-token"),
+    type: "connector",
+  });
+}
+
+async function insertUserPermissionGrant(args: {
+  readonly orgId: string;
+  readonly userId: string;
+  readonly agentId: string;
+  readonly permission: string;
+  readonly action: UserPermissionGrantAction;
+  readonly expiresAt?: Date | null;
+}): Promise<void> {
+  const db = store.set(writeDb$);
+  await db.insert(userPermissionGrants).values({
+    orgId: args.orgId,
+    userId: args.userId,
+    agentId: args.agentId,
+    connectorRef: SLACK_CONNECTOR,
+    permission: args.permission,
+    action: args.action,
+    expiresAt: args.expiresAt ?? null,
+  });
+}
+
+async function updateUserPermissionGrantAction(args: {
+  readonly orgId: string;
+  readonly userId: string;
+  readonly agentId: string;
+  readonly permission: string;
+  readonly action: UserPermissionGrantAction;
+}): Promise<void> {
+  const db = store.set(writeDb$);
+  await db
+    .update(userPermissionGrants)
+    .set({ action: args.action })
+    .where(
+      and(
+        eq(userPermissionGrants.orgId, args.orgId),
+        eq(userPermissionGrants.userId, args.userId),
+        eq(userPermissionGrants.agentId, args.agentId),
+        eq(userPermissionGrants.connectorRef, SLACK_CONNECTOR),
+        eq(userPermissionGrants.permission, args.permission),
+      ),
+    );
+}
+
+async function networkPolicyForRun(
+  runId: string,
+  connectorRef: string,
+): Promise<QueuedNetworkPolicy> {
+  const db = store.set(writeDb$);
+  const [job] = await db
+    .select({ executionContext: runnerJobQueue.executionContext })
+    .from(runnerJobQueue)
+    .where(eq(runnerJobQueue.runId, runId));
+  const executionContext = job?.executionContext as
+    | {
+        readonly networkPolicies?: Record<string, QueuedNetworkPolicy>;
+      }
+    | undefined;
+  const policy = executionContext?.networkPolicies?.[connectorRef];
+  if (!policy) {
+    throw new Error(`Expected network policy for ${connectorRef}`);
+  }
+  return policy;
+}
+
+async function createZeroRunNetworkPolicy(
+  agentId: string,
+  connectorRef: string = SLACK_CONNECTOR,
+): Promise<QueuedNetworkPolicy> {
+  const response = await accept(
+    zeroRunsClient().create({
+      headers: { authorization: "Bearer clerk-session" },
+      body: { prompt: "resolve runtime permissions", agentId },
+    }),
+    [201],
+  );
+  return await networkPolicyForRun(response.body.runId, connectorRef);
 }
 
 async function seedRunnableZeroAgent(
@@ -2479,6 +2621,220 @@ describe("POST /api/zero/runs", () => {
     expect(xPolicy.allow).toContain("tweet.read");
     expect(xPolicy.deny).toContain("tweet.write");
     expect(xPolicy.unknownPolicy).toBe("allow");
+  });
+
+  it("uses legacy agent permission policies when user grants are disabled", async () => {
+    const fx = await fixture();
+    const agent = await seedRunnableZeroAgent({
+      fixture: fx,
+      permissionPolicies: {
+        [SLACK_CONNECTOR]: {
+          [SLACK_WRITE_PERMISSION]: "allow",
+        },
+      },
+    });
+    await seedSlackConnector({ fixture: fx, agentId: agent.agentId });
+    await insertUserPermissionGrant({
+      orgId: fx.orgId,
+      userId: fx.userId,
+      agentId: agent.agentId,
+      permission: SLACK_WRITE_PERMISSION,
+      action: "deny",
+    });
+
+    const policy = await createZeroRunNetworkPolicy(agent.agentId);
+
+    expect(policy.allow).toContain(SLACK_WRITE_PERMISSION);
+    expect(policy.deny).not.toContain(SLACK_WRITE_PERMISSION);
+  });
+
+  it("uses connector defaults when user grants are enabled with no grants", async () => {
+    const fx = await fixture();
+    const agent = await seedRunnableZeroAgent({ fixture: fx });
+    await enableUserPermissionGrants(fx.orgId, fx.userId);
+    await seedSlackConnector({ fixture: fx, agentId: agent.agentId });
+
+    const policy = await createZeroRunNetworkPolicy(agent.agentId);
+
+    expect(policy.allow).toContain(SLACK_READ_PERMISSION);
+    expect(policy.allow).toContain("users:read");
+    expect(policy.deny).toContain(SLACK_WRITE_PERMISSION);
+    expect(policy.unknownPolicy).toBe("allow");
+  });
+
+  it("applies current-user grants when user grants are enabled", async () => {
+    const fx = await fixture();
+    const agent = await seedRunnableZeroAgent({ fixture: fx });
+    await enableUserPermissionGrants(fx.orgId, fx.userId);
+    await seedSlackConnector({ fixture: fx, agentId: agent.agentId });
+    await insertUserPermissionGrant({
+      orgId: fx.orgId,
+      userId: fx.userId,
+      agentId: agent.agentId,
+      permission: SLACK_WRITE_PERMISSION,
+      action: "allow",
+      expiresAt: new Date("2999-01-01T00:00:00.000Z"),
+    });
+
+    const policy = await createZeroRunNetworkPolicy(agent.agentId);
+
+    expect(policy.allow).toContain(SLACK_WRITE_PERMISSION);
+    expect(policy.deny).not.toContain(SLACK_WRITE_PERMISSION);
+  });
+
+  it("bakes the active grant result into the queued run context", async () => {
+    const fx = await fixture();
+    const agent = await seedRunnableZeroAgent({ fixture: fx });
+    await enableUserPermissionGrants(fx.orgId, fx.userId);
+    await seedSlackConnector({ fixture: fx, agentId: agent.agentId });
+    await insertUserPermissionGrant({
+      orgId: fx.orgId,
+      userId: fx.userId,
+      agentId: agent.agentId,
+      permission: SLACK_WRITE_PERMISSION,
+      action: "allow",
+    });
+    const response = await accept(
+      zeroRunsClient().create({
+        headers: { authorization: "Bearer clerk-session" },
+        body: {
+          prompt: "snapshot runtime permissions",
+          agentId: agent.agentId,
+        },
+      }),
+      [201],
+    );
+
+    await updateUserPermissionGrantAction({
+      orgId: fx.orgId,
+      userId: fx.userId,
+      agentId: agent.agentId,
+      permission: SLACK_WRITE_PERMISSION,
+      action: "deny",
+    });
+    const policy = await networkPolicyForRun(
+      response.body.runId,
+      SLACK_CONNECTOR,
+    );
+
+    expect(policy.allow).toContain(SLACK_WRITE_PERMISSION);
+    expect(policy.deny).not.toContain(SLACK_WRITE_PERMISSION);
+  });
+
+  it("ignores grants for other users on the same agent", async () => {
+    const fx = await fixture();
+    const agent = await seedRunnableZeroAgent({ fixture: fx });
+    await enableUserPermissionGrants(fx.orgId, fx.userId);
+    await seedSlackConnector({ fixture: fx, agentId: agent.agentId });
+    await insertUserPermissionGrant({
+      orgId: fx.orgId,
+      userId: `other-${fx.userId}`,
+      agentId: agent.agentId,
+      permission: SLACK_WRITE_PERMISSION,
+      action: "allow",
+    });
+
+    const policy = await createZeroRunNetworkPolicy(agent.agentId);
+
+    expect(policy.deny).toContain(SLACK_WRITE_PERMISSION);
+    expect(policy.allow).not.toContain(SLACK_WRITE_PERMISSION);
+  });
+
+  it("ignores expired grants for newly created runs", async () => {
+    const fx = await fixture();
+    const agent = await seedRunnableZeroAgent({ fixture: fx });
+    await enableUserPermissionGrants(fx.orgId, fx.userId);
+    await seedSlackConnector({ fixture: fx, agentId: agent.agentId });
+    await insertUserPermissionGrant({
+      orgId: fx.orgId,
+      userId: fx.userId,
+      agentId: agent.agentId,
+      permission: SLACK_WRITE_PERMISSION,
+      action: "allow",
+      expiresAt: new Date("2000-01-01T00:00:00.000Z"),
+    });
+
+    const policy = await createZeroRunNetworkPolicy(agent.agentId);
+
+    expect(policy.deny).toContain(SLACK_WRITE_PERMISSION);
+    expect(policy.allow).not.toContain(SLACK_WRITE_PERMISSION);
+  });
+
+  it("applies unknown-policy grants without changing named defaults", async () => {
+    const fx = await fixture();
+    const agent = await seedRunnableZeroAgent({ fixture: fx });
+    await enableUserPermissionGrants(fx.orgId, fx.userId);
+    await seedSlackConnector({ fixture: fx, agentId: agent.agentId });
+    await insertUserPermissionGrant({
+      orgId: fx.orgId,
+      userId: fx.userId,
+      agentId: agent.agentId,
+      permission: UNKNOWN_PERMISSION_GRANT,
+      action: "deny",
+    });
+
+    const policy = await createZeroRunNetworkPolicy(agent.agentId);
+
+    expect(policy.unknownPolicy).toBe("deny");
+    expect(policy.allow).toContain(SLACK_READ_PERMISSION);
+    expect(policy.deny).toContain(SLACK_WRITE_PERMISSION);
+  });
+
+  it("ignores legacy agent permission policies when user grants are enabled", async () => {
+    const fx = await fixture();
+    const agent = await seedRunnableZeroAgent({
+      fixture: fx,
+      permissionPolicies: {
+        [SLACK_CONNECTOR]: {
+          [SLACK_WRITE_PERMISSION]: "allow",
+        },
+      },
+    });
+    await enableUserPermissionGrants(fx.orgId, fx.userId);
+    await seedSlackConnector({ fixture: fx, agentId: agent.agentId });
+
+    const policy = await createZeroRunNetworkPolicy(agent.agentId);
+
+    expect(policy.deny).toContain(SLACK_WRITE_PERMISSION);
+    expect(policy.allow).not.toContain(SLACK_WRITE_PERMISSION);
+  });
+
+  it("resolves user grants for zero integration runs", async () => {
+    const fx = await fixture();
+    const agent = await seedRunnableZeroAgent({ fixture: fx });
+    await enableUserPermissionGrants(fx.orgId, fx.userId);
+    await seedSlackConnector({ fixture: fx, agentId: agent.agentId });
+    await insertUserPermissionGrant({
+      orgId: fx.orgId,
+      userId: fx.userId,
+      agentId: agent.agentId,
+      permission: SLACK_WRITE_PERMISSION,
+      action: "allow",
+    });
+
+    const result = await store.set(
+      createZeroIntegrationRun$,
+      {
+        userId: fx.userId,
+        orgId: fx.orgId,
+        agentId: agent.agentId,
+        prompt: "integration runtime permissions",
+        triggerSource: "slack",
+        apiStartTime: now(),
+      },
+      context.signal,
+    );
+
+    expect(result.status).toBe(201);
+    if (result.status !== 201) {
+      throw new Error("Expected zero integration run to be created");
+    }
+    const policy = await networkPolicyForRun(
+      result.body.runId,
+      SLACK_CONNECTOR,
+    );
+    expect(policy.allow).toContain(SLACK_WRITE_PERMISSION);
+    expect(policy.deny).not.toContain(SLACK_WRITE_PERMISSION);
   });
 
   it("uses the Codex skills mount path for codex zero agents", async () => {

--- a/turbo/apps/api/src/signals/routes/__tests__/zero-schedules-run.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/zero-schedules-run.test.ts
@@ -1,11 +1,18 @@
 import { randomUUID } from "node:crypto";
 
 import { apiErrorSchema } from "@vm0/api-contracts/contracts/errors";
+import { connectors } from "@vm0/db/schema/connector";
 import { agentRunCallbacks } from "@vm0/db/schema/agent-run-callback";
 import { agentRuns } from "@vm0/db/schema/agent-run";
 import { orgModelPolicies } from "@vm0/db/schema/org-model-policy";
+import { runnerJobQueue } from "@vm0/db/schema/runner-job-queue";
+import { secrets } from "@vm0/db/schema/secret";
+import { userConnectors } from "@vm0/db/schema/user-connector";
+import { userFeatureSwitches } from "@vm0/db/schema/user-feature-switches";
+import { userPermissionGrants } from "@vm0/db/schema/user-permission-grant";
 import { zeroAgentSchedules } from "@vm0/db/schema/zero-agent-schedule";
 import { zeroRuns } from "@vm0/db/schema/zero-run";
+import { FeatureSwitchKey } from "@vm0/core/feature-switch-key";
 import { createStore } from "ccstate";
 import { eq } from "drizzle-orm";
 import { z } from "zod";
@@ -14,6 +21,7 @@ import { createApp } from "../../../app-factory";
 import { testContext } from "../../../__tests__/test-helpers";
 import { mockOptionalEnv } from "../../../lib/env";
 import { writeDb$ } from "../../external/db";
+import { nowDate } from "../../external/time";
 import {
   type SchedulesFixture,
   deleteSchedulesScenario$,
@@ -24,11 +32,21 @@ import {
   createZeroRouteMocks,
 } from "./helpers/zero-route-test";
 import { seedOrgModelProvider$ } from "./helpers/zero-model-providers";
+import { encryptSecretForTests } from "./helpers/encrypt-secret";
 
 const context = testContext();
 const store = createStore();
 const mocks = createZeroRouteMocks(context);
 const runResponseSchema = z.object({ runId: z.string() });
+const SLACK_CONNECTOR = "slack";
+const SLACK_WRITE_PERMISSION = "chat:write";
+
+interface QueuedNetworkPolicy {
+  readonly allow: readonly string[];
+  readonly deny: readonly string[];
+  readonly ask: readonly string[];
+  readonly unknownPolicy: string;
+}
 
 const track = createFixtureTracker<SchedulesFixture>((fixture) => {
   return store.set(deleteSchedulesScenario$, fixture, context.signal);
@@ -61,6 +79,81 @@ async function seedFixture(): Promise<SchedulesFixture> {
   );
   mocks.clerk.session(fixture.userId, fixture.orgId);
   return fixture;
+}
+
+async function enableUserPermissionGrants(
+  orgId: string,
+  userId: string,
+): Promise<void> {
+  const db = store.set(writeDb$);
+  await db
+    .insert(userFeatureSwitches)
+    .values({
+      orgId,
+      userId,
+      switches: { [FeatureSwitchKey.UserPermissionGrants]: true },
+    })
+    .onConflictDoUpdate({
+      target: [userFeatureSwitches.orgId, userFeatureSwitches.userId],
+      set: {
+        switches: { [FeatureSwitchKey.UserPermissionGrants]: true },
+        updatedAt: nowDate(),
+      },
+    });
+}
+
+async function seedSlackGrantForScheduleOwner(
+  fixture: SchedulesFixture,
+): Promise<void> {
+  const db = store.set(writeDb$);
+  await db.insert(userConnectors).values({
+    orgId: fixture.orgId,
+    userId: fixture.userId,
+    agentId: fixture.composeId,
+    connectorType: SLACK_CONNECTOR,
+  });
+  await db.insert(connectors).values({
+    orgId: fixture.orgId,
+    userId: fixture.userId,
+    type: SLACK_CONNECTOR,
+    authMethod: "oauth",
+  });
+  await db.insert(secrets).values({
+    orgId: fixture.orgId,
+    userId: fixture.userId,
+    name: "SLACK_ACCESS_TOKEN",
+    encryptedValue: encryptSecretForTests("xoxb-schedule-token"),
+    type: "connector",
+  });
+  await db.insert(userPermissionGrants).values({
+    orgId: fixture.orgId,
+    userId: fixture.userId,
+    agentId: fixture.composeId,
+    connectorRef: SLACK_CONNECTOR,
+    permission: SLACK_WRITE_PERMISSION,
+    action: "allow",
+  });
+}
+
+async function networkPolicyForRun(
+  runId: string,
+  connectorRef: string,
+): Promise<QueuedNetworkPolicy> {
+  const db = store.set(writeDb$);
+  const [job] = await db
+    .select({ executionContext: runnerJobQueue.executionContext })
+    .from(runnerJobQueue)
+    .where(eq(runnerJobQueue.runId, runId));
+  const executionContext = job?.executionContext as
+    | {
+        readonly networkPolicies?: Record<string, QueuedNetworkPolicy>;
+      }
+    | undefined;
+  const policy = executionContext?.networkPolicies?.[connectorRef];
+  if (!policy) {
+    throw new Error(`Expected network policy for ${connectorRef}`);
+  }
+  return policy;
 }
 
 async function rawPostRun(body: unknown): Promise<{
@@ -161,6 +254,25 @@ describe("POST /api/zero/schedules/run", () => {
       /\/api\/internal\/callbacks\/schedule\/cron$/,
     );
     expect(callback?.payload).toMatchObject({ scheduleId });
+  });
+
+  it("resolves user grants for the schedule owner", async () => {
+    const fixture = await seedFixture();
+    const scheduleId = fixture.scheduleIds[0];
+    if (!scheduleId) {
+      throw new Error("Expected schedule fixture");
+    }
+    await enableUserPermissionGrants(fixture.orgId, fixture.userId);
+    await seedSlackGrantForScheduleOwner(fixture);
+    mocks.clerk.session(`trigger-${fixture.userId}`, fixture.orgId);
+
+    const response = await rawPostRun({ scheduleId });
+
+    expect(response.status).toBe(201);
+    const body = runResponseSchema.parse(response.body);
+    const policy = await networkPolicyForRun(body.runId, SLACK_CONNECTOR);
+    expect(policy.allow).toContain(SLACK_WRITE_PERMISSION);
+    expect(policy.deny).not.toContain(SLACK_WRITE_PERMISSION);
   });
 
   it("resolves the runtime model from the model-first default route", async () => {

--- a/turbo/apps/api/src/signals/services/zero-runs-create.service.ts
+++ b/turbo/apps/api/src/signals/services/zero-runs-create.service.ts
@@ -6,6 +6,7 @@ import {
   connectorTypeSchema,
   type ConnectorType,
 } from "@vm0/connectors/connectors";
+import { FeatureSwitchKey } from "@vm0/connectors/feature-switch-key";
 import type { ModelProviderCredentialScope } from "@vm0/api-contracts/contracts/model-providers";
 import { resolveFirewallPolicies } from "@vm0/connectors/firewalls";
 import {
@@ -13,6 +14,7 @@ import {
   type FirewallPolicyValue,
   type RawPermissionPolicies,
 } from "@vm0/connectors/firewall-types";
+import { isFeatureEnabled } from "@vm0/core/feature-switch";
 import { agentRuns } from "@vm0/db/schema/agent-run";
 import { agentSessions } from "@vm0/db/schema/agent-session";
 import {
@@ -33,6 +35,11 @@ import { badRequestMessage, notFound } from "../../lib/error";
 import type { AuthContext } from "../../types/auth";
 import { writeDb$, type Db } from "../external/db";
 import { createAgentRun$ } from "./agent-run-create.service";
+import { loadUserFeatureSwitchContext } from "./feature-switches.service";
+import {
+  foldUserPermissionGrantsToFirewallPolicies,
+  loadActiveUserPermissionGrants,
+} from "./zero-user-permission-grants.service";
 
 type ZeroRunCreateBody = z.infer<(typeof zeroRunsMainContract.create)["body"]>;
 
@@ -401,6 +408,56 @@ async function loadAllowedCustomConnectorIds(
   });
 }
 
+async function resolveZeroRunPermissionPolicies(
+  db: Db,
+  args: {
+    readonly orgId: string;
+    readonly userId: string;
+    readonly agent: ZeroAgentRunRecord;
+    readonly allowedConnectorTypes: readonly ConnectorType[];
+    readonly checkedAt: Date;
+  },
+  signal: AbortSignal,
+): Promise<ReturnType<typeof resolveFirewallPolicies>> {
+  const featureSwitchContext = await loadUserFeatureSwitchContext(
+    db,
+    args.orgId,
+    args.userId,
+  );
+  signal.throwIfAborted();
+
+  if (
+    !isFeatureEnabled(
+      FeatureSwitchKey.UserPermissionGrants,
+      featureSwitchContext,
+    )
+  ) {
+    return resolveFirewallPolicies(
+      toFirewallPolicies(
+        args.agent.permissionPolicies,
+        args.agent.unknownPermissionPolicies,
+      ),
+      [...args.allowedConnectorTypes],
+    );
+  }
+
+  const grants = await loadActiveUserPermissionGrants(
+    db,
+    {
+      orgId: args.orgId,
+      userId: args.userId,
+      agentId: args.agent.id,
+    },
+    args.checkedAt,
+  );
+  signal.throwIfAborted();
+
+  return resolveFirewallPolicies(
+    foldUserPermissionGrantsToFirewallPolicies(grants),
+    [...args.allowedConnectorTypes],
+  );
+}
+
 async function loadUserInfo(
   db: Db,
   args: {
@@ -594,12 +651,16 @@ export const createZeroIntegrationRun$ = command(
     });
     signal.throwIfAborted();
 
-    const agentPermissionPolicies = resolveFirewallPolicies(
-      toFirewallPolicies(
-        agent.permissionPolicies,
-        agent.unknownPermissionPolicies,
-      ),
-      [...allowedConnectorTypes],
+    const agentPermissionPolicies = await resolveZeroRunPermissionPolicies(
+      db,
+      {
+        orgId: args.orgId,
+        userId: args.userId,
+        agent,
+        allowedConnectorTypes,
+        checkedAt: new Date(args.apiStartTime),
+      },
+      signal,
     );
 
     return await set(
@@ -710,12 +771,16 @@ export const createZeroRun$ = command(
       agentId: agent.id,
     });
     signal.throwIfAborted();
-    const agentPermissionPolicies = resolveFirewallPolicies(
-      toFirewallPolicies(
-        agent.permissionPolicies,
-        agent.unknownPermissionPolicies,
-      ),
-      [...allowedConnectorTypes],
+    const agentPermissionPolicies = await resolveZeroRunPermissionPolicies(
+      db,
+      {
+        orgId: args.auth.orgId,
+        userId: args.auth.userId,
+        agent,
+        allowedConnectorTypes,
+        checkedAt: new Date(args.apiStartTime),
+      },
+      signal,
     );
 
     return await set(


### PR DESCRIPTION
## Summary

- add feature-gated zero run permission resolution from active user permission grants
- keep legacy zero agent permission policies as the feature-off path
- cover web, integration, schedule-owner, TTL, user isolation, unknown-policy, and run-start snapshot behavior

Closes #15602

## Testing

- pnpm format
- pnpm -F api lint
- pnpm -F api check-types
- pnpm -F api exec vitest run src/signals/routes/__tests__/zero-runs-create.test.ts src/signals/routes/__tests__/zero-schedules-run.test.ts
- pnpm check-types
- pre-commit: prettier, knip --cache, check-types
