### PR TITLE
fix(mitm-addon): bill x counts from total tweet count

### DIFF
--- a/crates/runner/mitm-addon/src/usage/providers/connectors/x.py
+++ b/crates/runner/mitm-addon/src/usage/providers/connectors/x.py
@@ -496,13 +496,16 @@ def _compute_billable_counts(
             # Soft errors (no data field) and empty searches correctly yield 0.
             primary = max(data, result)
     else:
-        # Body couldn't be parsed — fall back to request-side hints.
-        # With no hints at all we leave primary at 0 and let the caller
-        # log this loss of visibility; blind-guessing a quantity risks
-        # over-charging by a large factor on small real responses.
-        ids = req_meta.get("request_ids_count") or 0
-        max_r = req_meta.get("max_results") or 0
-        primary = max(ids, max_r, 1) if any((ids, max_r)) else 0
+        if req_meta.get("is_count_endpoint"):
+            primary = 0
+        else:
+            # Body couldn't be parsed — fall back to request-side hints.
+            # With no hints at all we leave primary at 0 and let the caller
+            # log this loss of visibility; blind-guessing a quantity risks
+            # over-charging by a large factor on small real responses.
+            ids = req_meta.get("request_ids_count") or 0
+            max_r = req_meta.get("max_results") or 0
+            primary = max(ids, max_r, 1) if any((ids, max_r)) else 0
 
     counts: dict[str, int] = {}
     if primary > 0:
@@ -608,17 +611,19 @@ def report_usage(flow: http.HTTPFlow, run_id: str) -> None:
         flow.request.method, req_meta, resp_meta, endpoint_bucket, log_warn=_log_warn
     )
 
-    # Loud-but-zero billing path: GET with an unparseable response body
-    # AND no URL-side count hints.  We deliberately emit nothing rather
-    # than blind-guess a quantity — the error log carries enough context
-    # for ops to audit and, if needed, back-charge manually.  Use
-    # ``is None`` so a legitimate ``?max_results=0`` (no-op query) is
-    # distinguished from the absent-field case.
+    # Loud-but-zero billing path: GET with an unparseable response body and
+    # no reliable count source.  We deliberately emit nothing rather than
+    # blind-guess a quantity — the error log carries enough context for ops
+    # to audit and, if needed, back-charge manually.  Use ``is None`` so a
+    # legitimate ``?max_results=0`` (no-op query) is distinguished from the
+    # absent-field case.
+    missing_count_visibility = bool(req_meta.get("is_count_endpoint")) or (
+        req_meta.get("request_ids_count") is None and req_meta.get("max_results") is None
+    )
     if (
         flow.request.method == "GET"
         and not resp_meta.get("body_parsed")
-        and req_meta.get("request_ids_count") is None
-        and req_meta.get("max_results") is None
+        and missing_count_visibility
     ):
         log_extra: dict[str, object] = {
             "body_truncated": bool(resp_meta.get("body_truncated")),
@@ -629,7 +634,11 @@ def report_usage(flow: http.HTTPFlow, run_id: str) -> None:
         log_proxy_entry(
             proxy_log_path,
             "error",
-            "X response unparseable and request carries no count hints — skipping billing",
+            (
+                "X count endpoint response unparseable — skipping billing"
+                if req_meta.get("is_count_endpoint")
+                else "X response unparseable and request carries no count hints — skipping billing"
+            ),
             **log_context,
             **log_extra,
         )

--- a/crates/runner/mitm-addon/src/usage/providers/connectors/x.py
+++ b/crates/runner/mitm-addon/src/usage/providers/connectors/x.py
@@ -51,6 +51,13 @@ _STREAM_ENDPOINTS = frozenset(
     }
 )
 
+_COUNT_ENDPOINTS = frozenset(
+    {
+        "/2/tweets/counts/recent",
+        "/2/tweets/counts/all",
+    }
+)
+
 
 def _is_stream_path(path: str) -> bool:
     """Return True when *path* is one of the X v2 NDJSON streaming endpoints.
@@ -59,6 +66,10 @@ def _is_stream_path(path: str) -> bool:
     must NOT match because it's a regular JSON request/response, not a stream.
     """
     return path in _STREAM_ENDPOINTS
+
+
+def _is_count_path(path: str) -> bool:
+    return path in _COUNT_ENDPOINTS
 
 
 # Single NDJSON line cap — matches ``LARGE_RESPONSE_DECOMPRESS_LIMIT`` in
@@ -73,6 +84,10 @@ _X_JSON_RESULT_COUNT_FIELDS = {
     ("meta", "result_count"): ScalarField("int", max_bytes=64),
     ("meta", "total_tweet_count"): ScalarField("int", max_bytes=64),
 }
+
+
+def _as_non_bool_int(value: object) -> int | None:
+    return value if isinstance(value, int) and not isinstance(value, bool) else None
 
 
 def _create_x_json_selective_extractor() -> JsonSelectiveExtractor:
@@ -101,13 +116,13 @@ def _parse_x_json_response_fields(extracted: JsonExtractionResult) -> dict:
     if includes:
         result["response_includes"] = dict(includes)
 
-    rcs = [
-        value
-        for path in (("meta", "result_count"), ("meta", "total_tweet_count"))
-        if isinstance((value := extracted.values.get(path)), int) and not isinstance(value, bool)
-    ]
-    if rcs:
-        result["response_result_count"] = max(rcs)
+    result_count = _as_non_bool_int(extracted.values.get(("meta", "result_count")))
+    if result_count is not None:
+        result["response_result_count"] = result_count
+
+    total_tweet_count = _as_non_bool_int(extracted.values.get(("meta", "total_tweet_count")))
+    if total_tweet_count is not None:
+        result["response_total_tweet_count"] = total_tweet_count
 
     return result
 
@@ -313,6 +328,9 @@ def _parse_request_metadata(flow: http.HTTPFlow) -> dict:
         as an upper-bound fallback when the response body cannot be parsed.
       - ``is_stream``: bool — True when the request path is one of the X v2
         NDJSON streaming endpoints (see :data:`_STREAM_ENDPOINTS`).
+      - ``is_count_endpoint``: bool — True when the request path is an X Post
+        Counts endpoint whose ``data`` array contains time buckets instead of
+        returned posts.
 
     Reads from ``flow.metadata[metadata_keys.ORIGINAL_URL]`` (set by the request handler
     via ``url_utils.get_original_url``) rather than ``pretty_url`` to stay
@@ -334,6 +352,7 @@ def _parse_request_metadata(flow: http.HTTPFlow) -> dict:
         "has_expansions": "expansions" in qs,
         "max_results": max_results,
         "is_stream": _is_stream_path(parsed.path),
+        "is_count_endpoint": _is_count_path(parsed.path),
     }
 
 
@@ -346,12 +365,11 @@ def _parse_response_metadata(flow: http.HTTPFlow) -> dict:
       - ``response_data_count``: int — ``len(data)`` for a list payload,
         ``1`` for a single object payload.
       - ``response_includes``: dict[str, int] — counts per ``includes.<key>``.
-      - ``response_result_count``: int — total matched count.  Sourced
-        from ``meta.result_count`` (search / paginated endpoints) or
-        ``meta.total_tweet_count`` (``/2/tweets/counts/*``, where ``data``
-        carries time buckets, not tweets, and the real count lives in
-        ``meta``).  Both fields are alternative spellings of the same
-        billing dimension, so we collapse them into one log key.
+      - ``response_result_count``: int — ``meta.result_count`` from search
+        / paginated endpoints.
+      - ``response_total_tweet_count``: int — ``meta.total_tweet_count``
+        from ``/2/tweets/counts/*`` endpoints, where ``data`` carries time
+        buckets, not tweets.
 
     For X NDJSON streaming endpoints, the responseheaders hook registers an
     incremental parser that populates ``flow.metadata[metadata_keys.X_NDJSON_STATE]``
@@ -437,11 +455,13 @@ def _compute_billable_counts(
     data are billed"), so the primary count must reflect what was
     actually in the response, not what was requested.
 
-    - **Body parsed**: ``max(data_count, result_count)`` — trust the
-      actual response.  Soft errors (HTTP 200 + ``errors`` array, no
-      ``data``) and zero-result searches yield primary 0, which is
-      skipped from the returned dict so no empty ``usage_event`` row
-      is created.
+    - **Body parsed, count endpoint**: use ``meta.total_tweet_count``.
+      ``data`` is a time-bucket array for count endpoints, not returned
+      posts.
+    - **Body parsed, other endpoints**: ``max(data_count, result_count)`` —
+      trust the actual response.  Soft errors (HTTP 200 + ``errors`` array,
+      no ``data``) and zero-result searches yield primary 0, which is skipped
+      from the returned dict so no empty ``usage_event`` row is created.
     - **Body NOT parsed**: fall back to request-side hints
       ``max(ids_count, max_results, 1)``.  When the URL also carries
       no hints we emit no ``usage_event`` row; :func:`report_usage`
@@ -458,9 +478,23 @@ def _compute_billable_counts(
     result = resp_meta.get("response_result_count") or 0
 
     if resp_meta.get("body_parsed"):
-        # Body was parsed — trust actual response counts.
-        # Soft errors (no data field) and empty searches correctly yield 0.
-        primary = max(data, result)
+        if req_meta.get("is_count_endpoint"):
+            total = _as_non_bool_int(resp_meta.get("response_total_tweet_count"))
+            if total is None:
+                log_warn(
+                    "X count endpoint response missing total_tweet_count; skipping primary billing",
+                    {
+                        "category": endpoint_bucket,
+                        "response_data_count": data,
+                    },
+                )
+                primary = 0
+            else:
+                primary = total
+        else:
+            # Body was parsed — trust actual response counts.
+            # Soft errors (no data field) and empty searches correctly yield 0.
+            primary = max(data, result)
     else:
         # Body couldn't be parsed — fall back to request-side hints.
         # With no hints at all we leave primary at 0 and let the caller
@@ -473,6 +507,9 @@ def _compute_billable_counts(
     counts: dict[str, int] = {}
     if primary > 0:
         counts[endpoint_bucket] = primary
+
+    if req_meta.get("is_count_endpoint"):
+        return counts
 
     includes = resp_meta.get("response_includes") or {}
     for key, n in includes.items():

--- a/crates/runner/mitm-addon/tests/test_connector_usage.py
+++ b/crates/runner/mitm-addon/tests/test_connector_usage.py
@@ -526,6 +526,27 @@ class TestReportConnectorUsage:
             for entry in entries
         )
 
+    def test_tweet_counts_unparseable_ignores_request_hints_and_logs_error(
+        self, tmp_path, real_flow
+    ):
+        """Count endpoint request hints do not represent returned post count."""
+        flow = self._make_x_flow(
+            real_flow,
+            tmp_path,
+            path="/2/tweets/counts/recent",
+            query="max_results=50",
+            body=b"not json",
+            rule="GET /2/tweets/counts/recent",
+        )
+
+        assert self._call_and_get_billing(flow) == []
+
+        proxy_log = tmp_path / "proxy.jsonl"
+        entries = [json.loads(line) for line in proxy_log.read_text().splitlines()]
+        assert any(
+            entry["level"] == "error" and "count endpoint" in entry["message"] for entry in entries
+        )
+
     def test_handles_gzip_body(self, tmp_path, real_flow):
         """gzip-encoded response body decompresses before parsing."""
         raw = json.dumps({"data": [{"id": "1"}], "meta": {"result_count": 1}}).encode()

--- a/crates/runner/mitm-addon/tests/test_connector_usage.py
+++ b/crates/runner/mitm-addon/tests/test_connector_usage.py
@@ -425,6 +425,107 @@ class TestReportConnectorUsage:
         assert p["category"] == "posts.read"
         assert p["quantity"] == 12567
 
+    def test_tweet_counts_zero_total_does_not_bill_buckets(self, tmp_path, real_flow):
+        """Count endpoint data arrays are time buckets, not returned posts."""
+        body = json.dumps(
+            {
+                "data": [
+                    {"start": "2026-04-14T00:00", "end": "2026-04-15T00:00", "tweet_count": 0},
+                    {"start": "2026-04-15T00:00", "end": "2026-04-16T00:00", "tweet_count": 0},
+                ],
+                "meta": {"total_tweet_count": 0},
+            }
+        ).encode()
+        flow = self._make_x_flow(
+            real_flow,
+            tmp_path,
+            path="/2/tweets/counts/recent",
+            query="query=nothing",
+            body=body,
+            rule="GET /2/tweets/counts/recent",
+        )
+
+        assert self._call_and_get_billing(flow) == []
+
+    @pytest.mark.parametrize(
+        "path",
+        ["/2/tweets/counts/recent", "/2/tweets/counts/all"],
+    )
+    def test_tweet_counts_total_lower_than_bucket_count_bills_total(
+        self, tmp_path, real_flow, path
+    ):
+        """Both count endpoints bill total_tweet_count, not time-bucket count."""
+        body = json.dumps(
+            {
+                "data": [
+                    {"start": "2026-04-14T00:00", "end": "2026-04-15T00:00", "tweet_count": 1},
+                    {"start": "2026-04-15T00:00", "end": "2026-04-16T00:00", "tweet_count": 0},
+                    {"start": "2026-04-16T00:00", "end": "2026-04-17T00:00", "tweet_count": 0},
+                ],
+                "meta": {"total_tweet_count": 1},
+            }
+        ).encode()
+        flow = self._make_x_flow(
+            real_flow,
+            tmp_path,
+            path=path,
+            query="query=rare",
+            body=body,
+            rule=f"GET {path}",
+        )
+
+        p = self._call_and_get_single_billing(flow)
+        assert p["category"] == "posts.read"
+        assert p["quantity"] == 1
+
+    def test_tweet_counts_path_matching_requires_exact_endpoint(self, tmp_path, real_flow):
+        body = json.dumps(
+            {
+                "data": [{"id": "1"}, {"id": "2"}, {"id": "3"}],
+                "meta": {"total_tweet_count": 1},
+            }
+        ).encode()
+        flow = self._make_x_flow(
+            real_flow,
+            tmp_path,
+            path="/2/tweets/counts/recent/extra",
+            body=body,
+            rule="GET /2/tweets/counts/recent/extra",
+        )
+
+        p = self._call_and_get_single_billing(flow)
+        assert p["category"] == "posts.read"
+        assert p["quantity"] == 3
+
+    def test_tweet_counts_missing_total_skips_billing_and_logs_warning(self, tmp_path, real_flow):
+        """Parsed count endpoint responses without total_tweet_count should not bill buckets."""
+        body = json.dumps(
+            {
+                "data": [
+                    {"start": "2026-04-14T00:00", "end": "2026-04-15T00:00", "tweet_count": 2},
+                    {"start": "2026-04-15T00:00", "end": "2026-04-16T00:00", "tweet_count": 3},
+                ],
+                "meta": {},
+            }
+        ).encode()
+        flow = self._make_x_flow(
+            real_flow,
+            tmp_path,
+            path="/2/tweets/counts/recent",
+            query="query=missing_total",
+            body=body,
+            rule="GET /2/tweets/counts/recent",
+        )
+
+        assert self._call_and_get_billing(flow) == []
+
+        proxy_log = tmp_path / "proxy.jsonl"
+        entries = [json.loads(line) for line in proxy_log.read_text().splitlines()]
+        assert any(
+            entry["level"] == "warn" and "total_tweet_count" in entry["message"]
+            for entry in entries
+        )
+
     def test_handles_gzip_body(self, tmp_path, real_flow):
         """gzip-encoded response body decompresses before parsing."""
         raw = json.dumps({"data": [{"id": "1"}], "meta": {"result_count": 1}}).encode()
@@ -1015,7 +1116,7 @@ class TestReportConnectorUsage:
         payloads = self._call_and_get_billing(flow)
 
         by_cat = {p["category"]: p["quantity"] for p in payloads}
-        assert by_cat == {"posts.read": 3, "user.read": 1}
+        assert by_cat == {"posts.read": 2, "user.read": 1}
 
     def test_legacy_x_json_fallback_ignores_boolean_result_count(self, tmp_path, real_flow):
         body = json.dumps({"meta": {"result_count": True}}).encode()

--- a/crates/runner/mitm-addon/tests/test_response_headers_handler.py
+++ b/crates/runner/mitm-addon/tests/test_response_headers_handler.py
@@ -360,7 +360,7 @@ class TestResponseHeadersHandler:
             {
                 "data": [{"id": "1"}, {"id": "2"}],
                 "includes": {"users": [{"id": "u1"}]},
-                "meta": {"result_count": 2},
+                "meta": {"result_count": 2, "total_tweet_count": 3},
             }
         ).encode()
         flow = real_flow(with_response=False, host="api.x.com", path="/2/tweets")
@@ -380,6 +380,7 @@ class TestResponseHeadersHandler:
         assert json_state["response_data_count"] == 2
         assert json_state["response_includes"] == {"users": 1}
         assert json_state["response_result_count"] == 2
+        assert json_state["response_total_tweet_count"] == 3
 
     def test_model_provider_uses_bounded_buffer_and_json_extractor(self, real_flow, headers):
         """Billable model provider JSON should parse usage without unbounded buffering."""


### PR DESCRIPTION
## Summary

- Split X `meta.result_count` and `meta.total_tweet_count` into separate response metadata fields.
- Treat `/2/tweets/counts/recent` and `/2/tweets/counts/all` as count endpoints that bill primary usage only from `total_tweet_count`.
- Skip request-hint fallbacks for unparseable count endpoint responses because those hints are not count semantics.
- Add regressions for zero totals, totals below bucket count, exact path matching, missing total visibility logging, and unparseable count endpoint fallback safety.

Fixes #15712

## Tests

- `/tmp/vm0-mitm-addon-venv/bin/python -m pytest tests/test_connector_usage.py::TestReportConnectorUsage::test_tweet_counts_unparseable_ignores_request_hints_and_logs_error tests/test_connector_usage.py::TestReportConnectorUsage::test_x_json_parse_error_with_request_hints_uses_fallback_without_error_log tests/test_connector_usage.py::TestReportConnectorUsage::test_billable_counts_fallback_only_when_no_max_results`
- `/tmp/vm0-mitm-addon-venv/bin/python -m pytest tests/test_connector_usage.py tests/test_response_headers_handler.py`
- `/tmp/vm0-mitm-addon-venv/bin/ruff check src tests && /tmp/vm0-mitm-addon-venv/bin/ruff format --check src tests && git diff --check`
- `/tmp/vm0-mitm-addon-venv/bin/python -m pytest tests` (2006 passed)