### PR TITLE
fix: classify x dm deep links as with-url posts

### DIFF
--- a/crates/runner/mitm-addon/src/usage/providers/connectors/x_billing.py
+++ b/crates/runner/mitm-addon/src/usage/providers/connectors/x_billing.py
@@ -351,6 +351,22 @@ def _tweet_text_likely_contains_url(text: str) -> bool:
     )
 
 
+def _tweet_create_body_has_rendered_link_signal(obj: dict[str, object]) -> bool:
+    # Quote tweets embed a link to the quoted post; X likely bills these
+    # as "with URL" on the rendered tweet.  Stay conservative.
+    if obj.get("quote_tweet_id") is not None:
+        return True
+    # Attached media renders as a t.co preview URL in the published tweet.
+    media = obj.get("media")
+    if isinstance(media, dict) and media.get("media_ids"):
+        return True
+    # A `card_uri` attaches a link preview card to the tweet.
+    if obj.get("card_uri"):
+        return True
+    direct_message_deep_link = obj.get("direct_message_deep_link")
+    return isinstance(direct_message_deep_link, str) and bool(direct_message_deep_link.strip())
+
+
 def _tweet_create_body_is_plain_text_without_url(body: bytes | None) -> bool:
     if not body:
         return False
@@ -360,19 +376,7 @@ def _tweet_create_body_is_plain_text_without_url(body: bytes | None) -> bool:
         return False
     if not isinstance(obj, dict):
         return False
-    # Quote tweets embed a link to the quoted post; X likely bills
-    # these as "with URL" on the rendered tweet.  Stay conservative.
-    if obj.get("quote_tweet_id") is not None:
-        return False
-    # Attached media renders as a t.co preview URL in the published
-    # tweet.  Stay conservative.
-    media = obj.get("media")
-    if isinstance(media, dict) and media.get("media_ids"):
-        return False
-    # A `card_uri` attaches a link preview card to the tweet — the
-    # published post always renders a URL.  Treat as with-URL even
-    # when the text itself is plain.
-    if obj.get("card_uri"):
+    if _tweet_create_body_has_rendered_link_signal(obj):
         return False
     text = obj.get("text")
     return isinstance(text, str) and not _tweet_text_likely_contains_url(text)

--- a/crates/runner/mitm-addon/src/usage/providers/connectors/x_billing.py
+++ b/crates/runner/mitm-addon/src/usage/providers/connectors/x_billing.py
@@ -407,9 +407,10 @@ def refine_bucket_with_body(bucket: str, method: str, path: str, body: bytes | N
 
     Current behaviour: for ``POST /2/tweets`` classified as
     ``content.create_with_url``, drop to ``content.create`` when the
-    tweet body is plain text with no URL, no quote reference and no
-    media attachment.  All parse failures or ambiguity → stay on the
-    more expensive bucket, matching the "never under-charge" rule.
+    tweet body is plain text with no URL and no rendered link signal
+    such as a quote reference, media attachment, card, or DM deep link.
+    All parse failures or ambiguity → stay on the more expensive bucket,
+    matching the "never under-charge" rule.
     """
     for rule in _BODY_REFINEMENT_RULES:
         if bucket != rule.source_bucket or method != rule.method or path != rule.path:

--- a/crates/runner/mitm-addon/tests/test_connector_usage.py
+++ b/crates/runner/mitm-addon/tests/test_connector_usage.py
@@ -834,8 +834,8 @@ class TestReportConnectorUsage:
         assert p["category"] == "content.create"
         assert p["quantity"] == 1
 
-    def test_tweet_create_quote_or_media_stays_on_with_url_bucket(self, tmp_path, real_flow):
-        """Quote tweets and attached media both render as link previews;
+    def test_tweet_create_rendered_link_signals_stay_on_with_url_bucket(self, tmp_path, real_flow):
+        """Quote tweets, attached media, cards, and DM deep links render links;
         we stay on the expensive bucket even when the text has no URL."""
         for req_body in [
             # quote tweet
@@ -844,6 +844,13 @@ class TestReportConnectorUsage:
             json.dumps({"text": "pic", "media": {"media_ids": ["42"]}}).encode(),
             # attached card
             json.dumps({"text": "card", "card_uri": "card://123"}).encode(),
+            # direct-message deep link
+            json.dumps(
+                {
+                    "text": "DM me for details",
+                    "direct_message_deep_link": "https://x.com/messages/compose?recipient_id=123",
+                }
+            ).encode(),
         ]:
             flow = self._make_x_flow(
                 real_flow,
@@ -858,6 +865,29 @@ class TestReportConnectorUsage:
             flow.request.content = req_body
             p = self._call_and_get_single_billing(flow)
             assert p["category"] == "content.create_with_url"
+            assert p["quantity"] == 1
+
+    @pytest.mark.parametrize("direct_message_deep_link", ["", "   ", None, 123, {"url": "x"}])
+    def test_tweet_create_invalid_direct_message_deep_link_downgrades_to_content_create(
+        self, tmp_path, real_flow, direct_message_deep_link
+    ):
+        """Invalid DM deep-link values do not block the plain-text downgrade."""
+        flow = self._make_x_flow(
+            real_flow,
+            tmp_path,
+            path="/2/tweets",
+            body=json.dumps({"data": {"id": "1"}}).encode(),
+            status=201,
+            permission="tweet.write",
+            rule="POST /2/tweets",
+        )
+        flow.request.method = "POST"
+        flow.request.content = json.dumps(
+            {"text": "DM me for details", "direct_message_deep_link": direct_message_deep_link}
+        ).encode()
+        p = self._call_and_get_single_billing(flow)
+        assert p["category"] == "content.create"
+        assert p["quantity"] == 1
 
     def test_tweet_create_unparseable_body_stays_conservative(self, tmp_path, real_flow):
         """A malformed request body keeps billing on the max bucket so


### PR DESCRIPTION
## Summary

- Treat non-empty `direct_message_deep_link` values as rendered/link signals for X `POST /2/tweets` billing refinement.
- Keep empty or non-string deep-link values eligible for the existing plain-text downgrade.
- Add regression coverage for deep-link with-url billing and invalid deep-link downgrade behavior.

## Tests

- `pytest tests/test_connector_usage.py -k 'tweet_create'`
- `pytest tests/test_connector_usage.py`
- `ruff check .`
- `ruff format --check .`
- `basedpyright -p .`

Closes #15714
