### PR TITLE
fix: sanitize captured network log headers

### DIFF
--- a/crates/runner/mitm-addon/src/body_utils.py
+++ b/crates/runner/mitm-addon/src/body_utils.py
@@ -7,7 +7,7 @@ Exports:
 - Streaming / one-shot decompression for gzip, deflate, br, zstd.
 - Conservative request-body decoding for billing inspection.
 - UTF-8-safe truncation, text/binary content detection and encoding.
-- Header redaction for sensitive names (auth, token, cookie, …).
+- Header sanitization for sensitive names and URL-bearing values.
 - ``add_capture_fields`` — composes capture-mode log entry fields.
 """
 
@@ -22,9 +22,11 @@ import zstandard
 from mitmproxy import ctx, http
 
 import flow_metadata_keys as metadata_keys
+import network_log_sanitization
 
 # Cap for non-model-provider response body buffering and decompression output.
 STREAM_BUFFER_LIMIT = 64 * 1024  # 64 KB
+_REDACTED_HEADER_VALUE = "***"
 
 # UTF-8 byte-boundary markers (RFC 3629).  Continuation bytes match
 # ``0b10xxxxxx`` → ``(byte & 0xC0) == _UTF8_CONT_MARK``.  Lead bytes fall
@@ -79,6 +81,14 @@ _SENSITIVE_HEADER_KEYWORDS = (
     "credential",
     "password",
     "cookie",
+)
+_URL_BEARING_CAPTURE_HEADER_NAMES = frozenset(
+    {
+        "location",
+        "content-location",
+        "referer",
+        "referrer",
+    }
 )
 
 
@@ -440,13 +450,25 @@ def _is_sensitive_header(name: str) -> bool:
     return any(kw in lower for kw in _SENSITIVE_HEADER_KEYWORDS)
 
 
-def _redact_headers(headers) -> dict:
-    """Build a dict of headers with sensitive values replaced by ***."""
+def _sanitize_header_value_for_capture(name: str, value: str) -> str:
+    lower_name = name.lower()
+    if _is_sensitive_header(name):
+        return _REDACTED_HEADER_VALUE
+    if lower_name in _URL_BEARING_CAPTURE_HEADER_NAMES:
+        return network_log_sanitization.sanitize_url_for_network_log(value)
+    if lower_name == "link":
+        sanitized_link = network_log_sanitization.sanitize_link_header_for_network_log(value)
+        return _REDACTED_HEADER_VALUE if sanitized_link is None else sanitized_link
+    return value
+
+
+def _sanitize_headers_for_capture(headers) -> dict:
+    """Build a dict of captured headers safe for persistent network logs."""
     result = {}
     for name, value in headers.items(multi=True):
         if name in result:
             continue  # keep first occurrence only (headers.items gives all)
-        result[name] = "***" if _is_sensitive_header(name) else value
+        result[name] = _sanitize_header_value_for_capture(name, value)
     return result
 
 
@@ -504,7 +526,7 @@ def add_capture_fields(flow: http.HTTPFlow, log_entry: dict) -> None:
     empty body and normally produces no body fields.
     """
     # Request headers (always available)
-    log_entry["request_headers"] = _redact_headers(flow.request.headers)
+    log_entry["request_headers"] = _sanitize_headers_for_capture(flow.request.headers)
 
     # Request body
     if flow.request.raw_content:
@@ -522,7 +544,7 @@ def add_capture_fields(flow: http.HTTPFlow, log_entry: dict) -> None:
 
     # Response headers
     if flow.response:
-        log_entry["response_headers"] = _redact_headers(flow.response.headers)
+        log_entry["response_headers"] = _sanitize_headers_for_capture(flow.response.headers)
 
     # Response body — read from stream_buffer (available for all responses).
     # The buffer contains raw wire bytes (possibly gzip/br/zstd compressed).

--- a/crates/runner/mitm-addon/src/mitm_addon.py
+++ b/crates/runner/mitm-addon/src/mitm_addon.py
@@ -34,6 +34,7 @@ from mitmproxy.addonmanager import Loader
 import body_utils
 import flow_metadata_keys as metadata_keys
 import matching
+import network_log_sanitization
 import registry
 import response_streaming
 import usage
@@ -239,22 +240,6 @@ def _record_browser_firewall_passthrough(
     flow.metadata[metadata_keys.FIREWALL_ACTION] = "ALLOW"
 
 
-def _sanitize_url_for_log(url: str) -> str:
-    """Return a URL string safe for persistent logs.
-
-    Runtime metadata keeps the raw URL because firewall/auth and connector
-    billing can need query parameters. Persistent logs do not.
-    """
-    try:
-        parts = urllib.parse.urlsplit(url)
-    except ValueError:
-        cut_points = [index for marker in ("?", "#") if (index := url.find(marker)) != -1]
-        if not cut_points:
-            return url
-        return url[: min(cut_points)]
-    return urllib.parse.urlunsplit((parts.scheme, parts.netloc, parts.path, "", ""))
-
-
 def _network_log_target(flow: http.HTTPFlow, original_url: str) -> tuple[str, str, int]:
     target = flow.metadata.get(metadata_keys.NETWORK_LOG_TARGET)
     if target is not None:
@@ -281,7 +266,7 @@ def _http_network_log_entry(
         "host": host,
         "port": port,
         "method": flow.request.method,
-        "url": _sanitize_url_for_log(url),
+        "url": network_log_sanitization.sanitize_url_for_network_log(url),
         "status": status_code,
         "latency_ms": latency_ms,
         "request_size": request_size,
@@ -735,7 +720,7 @@ def response(flow: http.HTTPFlow) -> None:
 
     # Log errors to per-job proxy log and mitmproxy console
     if flow.response and flow.response.status_code >= _HTTP_STATUS_ERROR_MIN:
-        safe_url = _sanitize_url_for_log(original_url)
+        safe_url = network_log_sanitization.sanitize_url_for_network_log(original_url)
         log_proxy_entry(
             proxy_log_path,
             "warn",
@@ -801,10 +786,11 @@ def error(flow: http.HTTPFlow) -> None:
     if flow.metadata.get(metadata_keys.X_NDJSON_STATE) is not None:
         usage.report_connector_usage(flow, run_id)
 
+    safe_url = network_log_sanitization.sanitize_url_for_network_log(original_url)
     log_proxy_entry(
         proxy_log_path,
         "warn",
-        f"Error: {error_msg}: {_sanitize_url_for_log(original_url)}",
+        f"Error: {error_msg}: {safe_url}",
         type="connection_error",
         error=error_msg,
     )

--- a/crates/runner/mitm-addon/src/network_log_sanitization.py
+++ b/crates/runner/mitm-addon/src/network_log_sanitization.py
@@ -9,6 +9,25 @@ def _sanitize_netloc_for_network_log(netloc: str) -> str:
     return netloc.rsplit("@", 1)[1]
 
 
+def _strip_query_fragment_for_network_log(value: str) -> str:
+    cut_points = [index for marker in ("?", "#") if (index := value.find(marker)) != -1]
+    if not cut_points:
+        return value
+    return value[: min(cut_points)]
+
+
+def _sanitize_url_text_fallback_for_network_log(value: str) -> str:
+    value = _strip_query_fragment_for_network_log(value)
+    scheme, scheme_sep, rest = value.partition("://")
+    if scheme_sep:
+        netloc, sep, path = rest.partition("/")
+        return f"{scheme}{scheme_sep}{_sanitize_netloc_for_network_log(netloc)}{sep}{path}"
+    if value.startswith("//"):
+        netloc, sep, path = value[2:].partition("/")
+        return f"//{_sanitize_netloc_for_network_log(netloc)}{sep}{path}"
+    return value
+
+
 def sanitize_url_for_network_log(value: str) -> str:
     """Return a URL string safe for persistent logs.
 
@@ -18,10 +37,7 @@ def sanitize_url_for_network_log(value: str) -> str:
     try:
         parts = urllib.parse.urlsplit(value)
     except ValueError:
-        cut_points = [index for marker in ("?", "#") if (index := value.find(marker)) != -1]
-        if not cut_points:
-            return value
-        return value[: min(cut_points)]
+        return _sanitize_url_text_fallback_for_network_log(value)
     netloc = _sanitize_netloc_for_network_log(parts.netloc)
     return urllib.parse.urlunsplit((parts.scheme, netloc, parts.path, "", ""))
 

--- a/crates/runner/mitm-addon/src/network_log_sanitization.py
+++ b/crates/runner/mitm-addon/src/network_log_sanitization.py
@@ -3,6 +3,12 @@
 import urllib.parse
 
 
+def _sanitize_netloc_for_network_log(netloc: str) -> str:
+    if "@" not in netloc:
+        return netloc
+    return netloc.rsplit("@", 1)[1]
+
+
 def sanitize_url_for_network_log(value: str) -> str:
     """Return a URL string safe for persistent logs.
 
@@ -16,7 +22,8 @@ def sanitize_url_for_network_log(value: str) -> str:
         if not cut_points:
             return value
         return value[: min(cut_points)]
-    return urllib.parse.urlunsplit((parts.scheme, parts.netloc, parts.path, "", ""))
+    netloc = _sanitize_netloc_for_network_log(parts.netloc)
+    return urllib.parse.urlunsplit((parts.scheme, netloc, parts.path, "", ""))
 
 
 def sanitize_link_header_for_network_log(value: str) -> str | None:
@@ -27,6 +34,7 @@ def sanitize_link_header_for_network_log(value: str) -> str | None:
     """
     output: list[str] = []
     index = 0
+    saw_uri_reference = False
     while index < len(value):
         char = value[index]
         if char == ">":
@@ -44,7 +52,8 @@ def sanitize_link_header_for_network_log(value: str) -> str | None:
         if "<" in raw_url:
             return None
 
+        saw_uri_reference = True
         output.append(f"<{sanitize_url_for_network_log(raw_url)}>")
         index = close_index + 1
 
-    return "".join(output)
+    return "".join(output) if saw_uri_reference or not value else None

--- a/crates/runner/mitm-addon/src/network_log_sanitization.py
+++ b/crates/runner/mitm-addon/src/network_log_sanitization.py
@@ -1,0 +1,50 @@
+"""Sanitizers for values written to persistent network logs."""
+
+import urllib.parse
+
+
+def sanitize_url_for_network_log(value: str) -> str:
+    """Return a URL string safe for persistent logs.
+
+    Runtime metadata can keep raw URLs because firewall/auth and connector
+    billing may need query parameters. Persistent logs do not.
+    """
+    try:
+        parts = urllib.parse.urlsplit(value)
+    except ValueError:
+        cut_points = [index for marker in ("?", "#") if (index := value.find(marker)) != -1]
+        if not cut_points:
+            return value
+        return value[: min(cut_points)]
+    return urllib.parse.urlunsplit((parts.scheme, parts.netloc, parts.path, "", ""))
+
+
+def sanitize_link_header_for_network_log(value: str) -> str | None:
+    """Sanitize complete URI references in a Link header value.
+
+    This is intentionally narrow: it preserves text outside ``<...>`` URI
+    references and fails closed on malformed bracket structure.
+    """
+    output: list[str] = []
+    index = 0
+    while index < len(value):
+        char = value[index]
+        if char == ">":
+            return None
+        if char != "<":
+            output.append(char)
+            index += 1
+            continue
+
+        close_index = value.find(">", index + 1)
+        if close_index == -1:
+            return None
+
+        raw_url = value[index + 1 : close_index]
+        if "<" in raw_url:
+            return None
+
+        output.append(f"<{sanitize_url_for_network_log(raw_url)}>")
+        index = close_index + 1
+
+    return "".join(output)

--- a/crates/runner/mitm-addon/tests/test_body_capture.py
+++ b/crates/runner/mitm-addon/tests/test_body_capture.py
@@ -221,7 +221,7 @@ class TestSanitizeHeadersForCapture:
 
     def test_url_bearing_headers_strip_query_and_fragment(self, headers):
         headers = headers(
-            ("Location", "https://client.example/callback?code=secret#fragment"),
+            ("Location", "https://user:pass@client.example/callback?code=secret#fragment"),
             ("Referer", "https://app.example/page?token=secret#fragment"),
             ("content-location", "/objects/123?signature=secret#fragment"),
             ("referrer", "/previous?pii=secret#fragment"),
@@ -245,6 +245,11 @@ class TestSanitizeHeadersForCapture:
 
     def test_malformed_link_header_redacts(self, headers):
         headers = headers(("Link", '<https://api.example/items?cursor=secret; rel="next"'))
+        result = _sanitize_headers_for_capture(headers)
+        assert result["Link"] == "***"
+
+    def test_link_header_without_uri_reference_redacts(self, headers):
+        headers = headers(("Link", 'https://api.example/items?cursor=secret; rel="next"'))
         result = _sanitize_headers_for_capture(headers)
         assert result["Link"] == "***"
 

--- a/crates/runner/mitm-addon/tests/test_body_capture.py
+++ b/crates/runner/mitm-addon/tests/test_body_capture.py
@@ -15,7 +15,7 @@ from body_utils import (
     _encode_body,
     _is_sensitive_header,
     _is_text_content,
-    _redact_headers,
+    _sanitize_headers_for_capture,
     _truncate_bytes_utf8_safe,
     add_capture_fields,
     create_stream_decompressor,
@@ -194,7 +194,7 @@ class TestIsSensitiveHeader:
         assert _is_sensitive_header("X-Password") is True
 
 
-class TestRedactHeaders:
+class TestSanitizeHeadersForCapture:
     def test_redacts_sensitive_keeps_others(self, headers):
         headers = headers(
             ("Content-Type", "application/json"),
@@ -202,7 +202,7 @@ class TestRedactHeaders:
             ("Host", "api.example.com"),
             ("Cookie", "session=abc"),
         )
-        result = _redact_headers(headers)
+        result = _sanitize_headers_for_capture(headers)
         assert result["Content-Type"] == "application/json"
         assert result["Authorization"] == "***"
         assert result["Host"] == "api.example.com"
@@ -214,10 +214,39 @@ class TestRedactHeaders:
             ("Set-Cookie", "b=2"),
             ("Host", "example.com"),
         )
-        result = _redact_headers(headers)
+        result = _sanitize_headers_for_capture(headers)
         assert result["Set-Cookie"] == "***"
         assert result["Host"] == "example.com"
         assert len(result) == 2
+
+    def test_url_bearing_headers_strip_query_and_fragment(self, headers):
+        headers = headers(
+            ("Location", "https://client.example/callback?code=secret#fragment"),
+            ("Referer", "https://app.example/page?token=secret#fragment"),
+            ("content-location", "/objects/123?signature=secret#fragment"),
+            ("referrer", "/previous?pii=secret#fragment"),
+        )
+        result = _sanitize_headers_for_capture(headers)
+        assert result["Location"] == "https://client.example/callback"
+        assert result["Referer"] == "https://app.example/page"
+        assert result["content-location"] == "/objects/123"
+        assert result["referrer"] == "/previous"
+
+    def test_link_header_sanitizes_uri_references(self, headers):
+        headers = headers(
+            (
+                "Link",
+                '<https://api.example/items?cursor=secret#fragment>; rel="next", '
+                '</local?token=secret#fragment>; rel="prev"',
+            ),
+        )
+        result = _sanitize_headers_for_capture(headers)
+        assert result["Link"] == '<https://api.example/items>; rel="next", </local>; rel="prev"'
+
+    def test_malformed_link_header_redacts(self, headers):
+        headers = headers(("Link", '<https://api.example/items?cursor=secret; rel="next"'))
+        result = _sanitize_headers_for_capture(headers)
+        assert result["Link"] == "***"
 
 
 class TestAddCaptureFields:
@@ -277,6 +306,23 @@ class TestAddCaptureFields:
         assert "response_headers" in entry
         assert entry["response_headers"]["Content-Type"] == "application/json"
         assert entry["response_headers"]["X-Request-Id"] == "req-123"
+
+    def test_captured_url_bearing_headers_are_sanitized(self, real_flow, headers):
+        flow = real_flow(
+            method="GET",
+            host="api.example.com",
+            request_headers=headers(
+                ("Host", "api.example.com"),
+                ("Referer", "https://app.example/page?token=secret#fragment"),
+            ),
+            response_headers=headers(
+                ("Location", "https://client.example/callback?code=secret#fragment"),
+            ),
+        )
+        entry = {}
+        add_capture_fields(flow, entry)
+        assert entry["request_headers"]["Referer"] == "https://app.example/page"
+        assert entry["response_headers"]["Location"] == "https://client.example/callback"
 
     def test_response_headers_redacts_sensitive(self, real_flow, headers):
         flow = real_flow(

--- a/crates/runner/mitm-addon/tests/test_response_handler.py
+++ b/crates/runner/mitm-addon/tests/test_response_handler.py
@@ -104,6 +104,10 @@ class TestResponseHandler:
                 "https://[invalid.example.com/path?access_token=secret#fragment",
                 "https://[invalid.example.com/path",
             ),
+            (
+                "https://user:pass@target.example.com:9443/path?access_token=secret#fragment",
+                "https://target.example.com:9443/path",
+            ),
         ],
     )
     def test_network_log_target_url_strips_query_and_fragment(

--- a/crates/runner/mitm-addon/tests/test_response_handler.py
+++ b/crates/runner/mitm-addon/tests/test_response_handler.py
@@ -105,6 +105,10 @@ class TestResponseHandler:
                 "https://[invalid.example.com/path",
             ),
             (
+                "https://user:pass@[invalid.example.com/path?access_token=secret#fragment",
+                "https://[invalid.example.com/path",
+            ),
+            (
                 "https://user:pass@target.example.com:9443/path?access_token=secret#fragment",
                 "https://target.example.com:9443/path",
             ),


### PR DESCRIPTION
## Summary

- move persistent network-log URL sanitization into a shared mitm-addon helper
- sanitize captured `Location`, `Content-Location`, `Referer`, `Referrer`, and `Link` header values before writing network logs
- keep sensitive-name redaction and first-value-wins duplicate header behavior unchanged

Closes #15713

## Tests

- `python3 -m pytest tests/test_body_capture.py tests/test_response_handler.py -v`
- `ruff check src tests/test_body_capture.py tests/test_response_handler.py`
- `ruff format --check src tests/test_body_capture.py tests/test_response_handler.py`
- `basedpyright -p .`
- `ruff check .`
- `ruff format --check .`
- `python3 -m pytest tests/ -v`
