### PR TITLE
fix: preserve signup attribution in stripe metadata

### DIFF
--- a/turbo/apps/api/src/signals/routes/__tests__/zero-billing-checkout.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/zero-billing-checkout.test.ts
@@ -388,11 +388,7 @@ describe("POST /api/zero/billing/checkout", () => {
     expect(response.body).toStrictEqual({
       url: "https://checkout.stripe.com/session/attributed",
     });
-    const expectedMetadata = {
-      orgId: fixture.orgId,
-      tier: "pro",
-      priceId: TEST_PRICE_PRO,
-      flow: "standard",
+    const expectedAttribution = {
       vm0_source: "presentation",
       utm_source: "google",
       utm_medium: "cpc",
@@ -401,6 +397,19 @@ describe("POST /api/zero/billing/checkout", () => {
       gclid: "test-gclid",
       gclid_present: "true",
     };
+    const expectedMetadata = {
+      orgId: fixture.orgId,
+      tier: "pro",
+      priceId: TEST_PRICE_PRO,
+      flow: "standard",
+      ...expectedAttribution,
+    };
+    expect(context.mocks.stripe.customers.create).toHaveBeenCalledWith({
+      metadata: {
+        orgId: fixture.orgId,
+        ...expectedAttribution,
+      },
+    });
     expect(context.mocks.stripe.checkout.sessions.create).toHaveBeenCalledWith(
       expect.objectContaining({
         metadata: expectedMetadata,

--- a/turbo/apps/api/src/signals/services/billing-customer.service.ts
+++ b/turbo/apps/api/src/signals/services/billing-customer.service.ts
@@ -6,6 +6,11 @@ import { writeDb$ } from "../external/db";
 import { nowDate } from "../external/time";
 import { getStripeClient } from "../external/stripe-client";
 
+interface GetOrCreateStripeCustomerArgs {
+  readonly orgId: string;
+  readonly metadata?: Readonly<Record<string, string | undefined>>;
+}
+
 /**
  * Get or create a Stripe customer for an org. Serializes per-org via
  * pg_advisory_xact_lock so concurrent checkout / redeem requests in the
@@ -15,18 +20,22 @@ import { getStripeClient } from "../external/stripe-client";
  * process races during the web→api cutover coordinate on the same lock.
  */
 export const getOrCreateStripeCustomer$ = command(
-  ({ set }, orgId: string, signal: AbortSignal): Promise<string> => {
+  (
+    { set },
+    args: GetOrCreateStripeCustomerArgs,
+    signal: AbortSignal,
+  ): Promise<string> => {
     const writeDb = set(writeDb$);
     return writeDb.transaction(async (tx) => {
       await tx.execute(
-        sql`SELECT pg_advisory_xact_lock(hashtext('stripe_customer_' || ${orgId}))`,
+        sql`SELECT pg_advisory_xact_lock(hashtext('stripe_customer_' || ${args.orgId}))`,
       );
       signal.throwIfAborted();
 
       const [row] = await tx
         .select({ stripeCustomerId: orgMetadata.stripeCustomerId })
         .from(orgMetadata)
-        .where(eq(orgMetadata.orgId, orgId))
+        .where(eq(orgMetadata.orgId, args.orgId))
         .limit(1);
       signal.throwIfAborted();
 
@@ -35,12 +44,22 @@ export const getOrCreateStripeCustomer$ = command(
       }
 
       const stripe = getStripeClient();
-      const customer = await stripe.customers.create({ metadata: { orgId } });
+      const metadata: Record<string, string> = { orgId: args.orgId };
+      for (const [key, value] of Object.entries(args.metadata ?? {})) {
+        if (value) {
+          metadata[key] = value;
+        }
+      }
+      const customer = await stripe.customers.create({ metadata });
       signal.throwIfAborted();
 
       await tx
         .insert(orgMetadata)
-        .values({ orgId, stripeCustomerId: customer.id, credits: 0 })
+        .values({
+          orgId: args.orgId,
+          stripeCustomerId: customer.id,
+          credits: 0,
+        })
         .onConflictDoUpdate({
           target: orgMetadata.orgId,
           set: { stripeCustomerId: customer.id, updatedAt: nowDate() },

--- a/turbo/apps/api/src/signals/services/zero-billing-checkout.service.ts
+++ b/turbo/apps/api/src/signals/services/zero-billing-checkout.service.ts
@@ -206,14 +206,6 @@ export const createCheckoutSession$ = command(
     args: CreateCheckoutSessionArgs,
     signal: AbortSignal,
   ): Promise<string> => {
-    const customerId = await set(
-      getOrCreateStripeCustomer$,
-      args.orgId,
-      signal,
-    );
-    signal.throwIfAborted();
-
-    const stripe = getStripeClient();
     const metadata = checkoutSessionMetadata({
       orgId: args.orgId,
       tier: args.tier,
@@ -221,6 +213,14 @@ export const createCheckoutSession$ = command(
       trialDays: args.trialDays,
       adAttribution: args.adAttribution,
     });
+    const customerId = await set(
+      getOrCreateStripeCustomer$,
+      { orgId: args.orgId, metadata: args.adAttribution },
+      signal,
+    );
+    signal.throwIfAborted();
+
+    const stripe = getStripeClient();
     const session = await stripe.checkout.sessions.create({
       mode: "subscription",
       customer: customerId,
@@ -336,7 +336,7 @@ export const createCreditCheckoutSession$ = command(
   ): Promise<string> => {
     const customerId = await set(
       getOrCreateStripeCustomer$,
-      args.orgId,
+      { orgId: args.orgId },
       signal,
     );
     signal.throwIfAborted();

--- a/turbo/apps/api/src/signals/services/zero-billing-redeem.service.ts
+++ b/turbo/apps/api/src/signals/services/zero-billing-redeem.service.ts
@@ -342,7 +342,7 @@ const createOneTimeCheckoutSession$ = command(
 
     const customerId = await set(
       getOrCreateStripeCustomer$,
-      args.orgId,
+      { orgId: args.orgId },
       signal,
     );
     signal.throwIfAborted();

--- a/turbo/apps/web/app/components/LandingPage.tsx
+++ b/turbo/apps/web/app/components/LandingPage.tsx
@@ -5,6 +5,7 @@ import NextLink from "next/link";
 import { useUser } from "@clerk/nextjs";
 import { useTranslations } from "next-intl";
 import { getAppUrl } from "../../src/lib/zero/url";
+import { buildSignupHref } from "../../src/lib/adAttribution";
 import { Footer } from "./Footer";
 import Image from "next/image";
 import { AvatarCustomizer } from "./AvatarCustomizer";
@@ -826,12 +827,14 @@ export function LandingPage({ initialIsSignedIn = false }: LandingPageProps) {
   const revealRef = useScrollReveal();
   const t = useTranslations("landing");
 
-  // Attribution is carried by the shared .vm0.ai cookie (AttributionCapture),
-  // so the signed-out CTA is a plain link.
   const appUrl = getAppUrl();
+  const [landingSearch, setLandingSearch] = useState("");
+  useEffect(() => {
+    setLandingSearch(window.location.search);
+  }, []);
 
   const ctaText = isSignedIn ? t("hero.ctaOpenApp") : t("hero.ctaGetStarted");
-  const ctaHref = isSignedIn ? appUrl : "/sign-up";
+  const ctaHref = isSignedIn ? appUrl : buildSignupHref(landingSearch);
 
   return (
     <div

--- a/turbo/apps/web/app/components/Navbar.tsx
+++ b/turbo/apps/web/app/components/Navbar.tsx
@@ -23,6 +23,7 @@ import { LanguageSwitcher } from "./LanguageSwitcher";
 import { NavMenu, type NavMenuItem } from "./NavMenu";
 import { useUser, useClerk } from "@clerk/nextjs";
 import { getAppUrl } from "../../src/lib/zero/url";
+import { buildSignupHref } from "../../src/lib/adAttribution";
 import { isBlogEnabled } from "../../src/env";
 
 interface NavbarProps {
@@ -305,9 +306,11 @@ export function Navbar({
   const { isSignedIn: clerkIsSignedIn, isLoaded } = useUser();
   const isSignedIn = isLoaded ? clerkIsSignedIn : initialIsSignedIn;
   const { signOut } = useClerk();
-  // Attribution is carried by the shared .vm0.ai cookie (AttributionCapture),
-  // so the signup CTAs are plain links.
-  const signupHref = "/sign-up";
+  const [landingSearch, setLandingSearch] = useState("");
+  useEffect(() => {
+    setLandingSearch(window.location.search);
+  }, []);
+  const signupHref = buildSignupHref(landingSearch);
   const [mobileMenuOpen, setMobileMenuOpen] = useState(false);
   const desktopNavRef = useRef<HTMLDivElement | null>(null);
   const {

--- a/turbo/apps/web/app/sign-up/[[...sign-up]]/SignUpClient.tsx
+++ b/turbo/apps/web/app/sign-up/[[...sign-up]]/SignUpClient.tsx
@@ -1,16 +1,28 @@
 "use client";
 
 import { SignUp } from "@clerk/nextjs";
+import { useSearchParams } from "next/navigation";
 import { useTheme } from "../../components/ThemeProvider";
 import { AuthLayout } from "../../components/auth/AuthLayout";
 import { getClerkAppearance } from "../../components/auth/clerk-appearance";
+import { buildSignupRedirectUrl } from "../../../src/lib/adAttribution";
+import { getAppUrl } from "../../../src/lib/zero/url";
 
 export function SignUpClient() {
   const { theme } = useTheme();
+  const searchParams = useSearchParams();
+  const redirectUrl = buildSignupRedirectUrl(
+    getAppUrl(),
+    searchParams.toString(),
+  );
 
   return (
     <AuthLayout>
-      <SignUp appearance={getClerkAppearance(theme)} />
+      <SignUp
+        appearance={getClerkAppearance(theme)}
+        fallbackRedirectUrl={redirectUrl}
+        forceRedirectUrl={redirectUrl}
+      />
     </AuthLayout>
   );
 }

--- a/turbo/apps/web/src/__tests__/adAttribution.test.ts
+++ b/turbo/apps/web/src/__tests__/adAttribution.test.ts
@@ -1,5 +1,9 @@
 import { describe, expect, it } from "vitest";
-import { writeAcquisitionAttributionCookie } from "../lib/adAttribution";
+import {
+  buildSignupHref,
+  buildSignupRedirectUrl,
+  writeAcquisitionAttributionCookie,
+} from "../lib/adAttribution";
 import { ACQUISITION_ATTRIBUTION_COOKIE } from "@vm0/api-contracts/contracts/zero-attribution";
 
 interface CookieJar {
@@ -135,5 +139,50 @@ describe("writeAcquisitionAttributionCookie", () => {
     );
 
     expect(writes[0]).not.toContain("Domain=");
+  });
+});
+
+describe("buildSignupHref", () => {
+  it("keeps organic signed-out CTA traffic on the web signup route", () => {
+    expect(buildSignupHref("")).toBe("/sign-up");
+    expect(buildSignupHref("?unused=value")).toBe("/sign-up");
+  });
+
+  it("keeps ad traffic on signup with attribution params", () => {
+    const href = buildSignupHref(
+      "?gclid=test-click&utm_source=google&utm_medium=cpc&utm_campaign=homepage_search&unused=value",
+    );
+    const url = new URL(href, "https://www.vm0.ai");
+
+    expect(url.pathname).toBe("/sign-up");
+    expect(url.searchParams.get("vm0_source")).toBe("homepage");
+    expect(url.searchParams.get("gclid")).toBe("test-click");
+    expect(url.searchParams.get("utm_source")).toBe("google");
+    expect(url.searchParams.get("utm_medium")).toBe("cpc");
+    expect(url.searchParams.get("utm_campaign")).toBe("homepage_search");
+    expect(url.searchParams.get("unused")).toBeNull();
+  });
+});
+
+describe("buildSignupRedirectUrl", () => {
+  it("keeps organic signup completion on the default app URL", () => {
+    expect(buildSignupRedirectUrl("https://app.vm0.ai", "")).toBe(
+      "https://app.vm0.ai",
+    );
+  });
+
+  it("routes attributed signup completion into app onboarding", () => {
+    const redirectUrl = buildSignupRedirectUrl(
+      "https://app.vm0.ai",
+      "vm0_source=homepage&gclid=test-click&utm_source=google&utm_campaign=homepage_search",
+    );
+    const url = new URL(redirectUrl);
+
+    expect(url.origin).toBe("https://app.vm0.ai");
+    expect(url.pathname).toBe("/onboarding");
+    expect(url.searchParams.get("vm0_source")).toBe("homepage");
+    expect(url.searchParams.get("gclid")).toBe("test-click");
+    expect(url.searchParams.get("utm_source")).toBe("google");
+    expect(url.searchParams.get("utm_campaign")).toBe("homepage_search");
   });
 });

--- a/turbo/apps/web/src/lib/adAttribution.ts
+++ b/turbo/apps/web/src/lib/adAttribution.ts
@@ -32,6 +32,14 @@ const ATTRIBUTION_SOURCE_PARAM = "vm0_source";
 const HOMEPAGE_ATTRIBUTION_VALUE = "homepage";
 const VM0_ROOT_DOMAIN = "vm0.ai";
 
+const AD_TRAFFIC_MARKERS = [
+  "gclid",
+  "gbraid",
+  "wbraid",
+  "utm_source",
+  "utm_campaign",
+] as const;
+
 // 90 days: covers the signup -> paid funnel, and is the standard ad
 // click-attribution window. First-touch, so it is never extended on revisit.
 const COOKIE_MAX_AGE_SECONDS = 90 * 24 * 60 * 60;
@@ -195,6 +203,53 @@ export function currentLandingAttributionContext(): LandingAttributionContext {
     hostname: window.location.hostname,
     pathname: window.location.pathname,
   };
+}
+
+function hasAdTraffic(params: URLSearchParams): boolean {
+  return AD_TRAFFIC_MARKERS.some((param) => {
+    return params.has(param);
+  });
+}
+
+function appendHomepageAttributionParams(
+  url: URLSearchParams,
+  landingSearch: string,
+): void {
+  const landingParams = new URLSearchParams(landingSearch);
+  url.set(ATTRIBUTION_SOURCE_PARAM, HOMEPAGE_ATTRIBUTION_VALUE);
+  for (const param of AD_ATTRIBUTION_PARAMS) {
+    for (const value of landingParams.getAll(param)) {
+      url.append(param, value);
+    }
+  }
+}
+
+// Build the signed-out homepage CTA href. Keep users on the normal web
+// /sign-up flow, but decorate ad/campaign visits so the sign-up page can carry
+// the same attribution into Clerk's final app redirect.
+export function buildSignupHref(landingSearch: string): string {
+  const params = new URLSearchParams(landingSearch);
+  if (!hasAdTraffic(params)) {
+    return "/sign-up";
+  }
+
+  const signupParams = new URLSearchParams();
+  appendHomepageAttributionParams(signupParams, landingSearch);
+  return `/sign-up?${signupParams.toString()}`;
+}
+
+export function buildSignupRedirectUrl(
+  appUrl: string,
+  signUpSearch: string,
+): string {
+  const params = new URLSearchParams(signUpSearch);
+  if (!hasAdTraffic(params)) {
+    return appUrl;
+  }
+
+  const url = new URL("/onboarding", appUrl);
+  appendHomepageAttributionParams(url.searchParams, signUpSearch);
+  return url.toString();
 }
 
 // Cookie I/O is isolated behind this interface so the write path is testable


### PR DESCRIPTION
## Summary

- keep paid/campaign homepage signup CTAs on the normal web `/sign-up` route while carrying attribution in the query string
- configure the web SignUp component to pass those attribution params into Clerk's final app redirect, landing attributed signups in app `/onboarding`
- include available ad attribution when creating new Stripe Customers, not only Checkout Sessions / Subscriptions
- update attribution and checkout metadata coverage so Stripe Customer metadata gets the same source fields when present

## Context

Live Stripe check over the previous 6 hours showed most recent Checkout Sessions had only `orgId` metadata and recent Customers had no source metadata. The code path after #15552 depended on Termly/cookie capture before the Clerk redirect, which can lose attribution on quick CTA clicks or blocked/unavailable cookies. Customer creation also always wrote only `{ orgId }`.

The CTA flow now remains: `www.vm0.ai -> /sign-up?... -> Clerk -> app.vm0.ai/onboarding?... -> sessionStorage attribution -> checkout request -> Stripe metadata`.

## Verification

- `pnpm exec prettier --write apps/web/src/lib/adAttribution.ts apps/web/src/__tests__/adAttribution.test.ts apps/web/app/components/LandingPage.tsx apps/web/app/components/Navbar.tsx apps/web/app/sign-up/[[...sign-up]]/SignUpClient.tsx apps/api/src/signals/services/billing-customer.service.ts apps/api/src/signals/services/zero-billing-checkout.service.ts apps/api/src/signals/services/zero-billing-redeem.service.ts apps/api/src/signals/routes/__tests__/zero-billing-checkout.test.ts`
- `pnpm -F web test src/__tests__/adAttribution.test.ts`
- `pnpm -F web check-types`
- `NODE_OPTIONS=--max-old-space-size=8192 pnpm -F api check-types`
- `pnpm -F web lint`
- `NODE_OPTIONS=--max-old-space-size=8192 pnpm -F api lint`

## Notes

- `pnpm -F api test src/signals/routes/__tests__/zero-billing-checkout.test.ts` was attempted, but this fresh agent environment has no local Postgres listening on `localhost:5432`, so the test failed before business assertions with `ECONNREFUSED`.
