### PR TITLE
refactor: share connector-owned access secret bindings

### DIFF
--- a/turbo/apps/api/src/signals/services/__tests__/zero-connector-data.service.test.ts
+++ b/turbo/apps/api/src/signals/services/__tests__/zero-connector-data.service.test.ts
@@ -114,6 +114,41 @@ describe("zeroConnectorList", () => {
     );
   });
 
+  it("does not report platform-backed connector env names from dirty connector secrets", async () => {
+    const orgId = `org_${randomUUID()}`;
+    const userId = `user_${randomUUID()}`;
+
+    await writeDb.insert(connectors).values({
+      orgId,
+      userId,
+      type: "google-ads",
+      authMethod: "oauth",
+    });
+    await writeDb.insert(secrets).values([
+      {
+        orgId,
+        userId,
+        name: "GOOGLE_ADS_ACCESS_TOKEN",
+        encryptedValue: "encrypted_google_ads_access_token",
+        type: "connector",
+      },
+      {
+        orgId,
+        userId,
+        name: "GOOGLE_ADS_DEVELOPER_TOKEN",
+        encryptedValue: "encrypted_google_ads_developer_token",
+        type: "connector",
+      },
+    ]);
+
+    const list = await store.get(zeroConnectorList({ orgId, userId }));
+
+    expect(list.connectorProvidedEnvNames).toContain("GOOGLE_ADS_TOKEN");
+    expect(list.connectorProvidedEnvNames).not.toContain(
+      "GOOGLE_ADS_DEVELOPER_TOKEN",
+    );
+  });
+
   it("does not report variable-backed connector env names as provided secrets", async () => {
     const orgId = `org_${randomUUID()}`;
     const userId = `user_${randomUUID()}`;

--- a/turbo/apps/api/src/signals/services/agent-run-create.service.ts
+++ b/turbo/apps/api/src/signals/services/agent-run-create.service.ts
@@ -27,6 +27,8 @@ import {
   getConnectorAuthMethod,
   getConnectorAuthMethodAccessMetadata,
   getConnectorAuthMethodEnvBindings,
+  getConnectorOwnedAccessSecretBindingEntries,
+  type ConnectorOwnedAccessSecretBindingEntry,
 } from "@vm0/connectors/connector-utils";
 import {
   connectorTypeSchema,
@@ -1552,6 +1554,7 @@ interface ConnectorEnvBindingSet {
   readonly connectorType: ConnectorType;
   readonly authMethod: string;
   readonly envBindings: Record<string, string>;
+  readonly ownedSecretBindings: readonly ConnectorOwnedAccessSecretBindingEntry[];
   readonly platformSecretNames: ReadonlySet<string>;
   readonly optionalSecretNames: ReadonlySet<string>;
   readonly optionalVariableNames: ReadonlySet<string>;
@@ -1632,6 +1635,9 @@ function connectorEnvBindingSets(
         row.connectorType,
         row.authMethod,
       ),
+      ownedSecretBindings: accessMetadata
+        ? getConnectorOwnedAccessSecretBindingEntries(accessMetadata)
+        : [],
       platformSecretNames: new Set(accessMetadata?.platformSecrets ?? []),
       optionalSecretNames,
       optionalVariableNames,
@@ -1645,14 +1651,12 @@ function collectStoredConnectorRequirements(
   const secretNames = new Set<string>();
   const variableNames = new Set<string>();
 
-  for (const { envBindings, platformSecretNames } of bindingSets) {
+  for (const { envBindings, ownedSecretBindings } of bindingSets) {
+    for (const { secretName } of ownedSecretBindings) {
+      secretNames.add(secretName);
+    }
     for (const valueRef of Object.values(envBindings)) {
-      if (valueRef.startsWith(CONNECTOR_SECRET_REF_PREFIX)) {
-        const secretName = valueRef.slice(CONNECTOR_SECRET_REF_PREFIX.length);
-        if (!platformSecretNames.has(secretName)) {
-          secretNames.add(secretName);
-        }
-      } else if (valueRef.startsWith(CONNECTOR_VAR_REF_PREFIX)) {
+      if (valueRef.startsWith(CONNECTOR_VAR_REF_PREFIX)) {
         variableNames.add(valueRef.slice(CONNECTOR_VAR_REF_PREFIX.length));
       }
     }
@@ -1762,6 +1766,7 @@ function resolveStoredConnectorState(
     connectorType,
     authMethod,
     envBindings,
+    ownedSecretBindings,
     platformSecretNames,
     optionalSecretNames,
     optionalVariableNames,
@@ -1808,22 +1813,16 @@ function resolveStoredConnectorState(
     // store the alias that points at the access secret, not the backing secret name.
     if (accessMetadata?.kind === "refresh-token") {
       const secretName = accessMetadata.accessToken;
-      for (const [envName, valueRef] of Object.entries(envBindings)) {
-        if (valueRef === `${CONNECTOR_SECRET_REF_PREFIX}${secretName}`) {
+      for (const {
+        envName,
+        secretName: boundSecretName,
+      } of ownedSecretBindings) {
+        if (boundSecretName === secretName) {
           secretConnectorMap[envName] = connectorType;
         }
       }
     } else if (accessMetadata?.kind === "static") {
-      for (const [envName, valueRef] of Object.entries(
-        accessMetadata.envBindings,
-      )) {
-        if (!valueRef.startsWith(CONNECTOR_SECRET_REF_PREFIX)) {
-          continue;
-        }
-        const secretName = valueRef.slice(CONNECTOR_SECRET_REF_PREFIX.length);
-        if (platformSecretNames.has(secretName)) {
-          continue;
-        }
+      for (const { envName } of ownedSecretBindings) {
         secretConnectorMap[envName] = connectorType;
       }
     }

--- a/turbo/apps/api/src/signals/services/agent-webhook-firewall-auth.service.ts
+++ b/turbo/apps/api/src/signals/services/agent-webhook-firewall-auth.service.ts
@@ -9,6 +9,7 @@ import type { SecretConnectorMetadata } from "@vm0/api-contracts/contracts/runne
 import {
   resolveConnectorAuthClientForMethod,
   getConnectorAuthMethodAccessMetadata,
+  getConnectorOwnedAccessSecretBindingEntries,
   type ConnectorAuthMethodAccessMetadata,
 } from "@vm0/connectors/connector-utils";
 import {
@@ -1723,19 +1724,21 @@ function connectorAccessSecretName(
 ): string | undefined {
   switch (accessMetadata.kind) {
     case "refresh-token": {
-      if (
-        accessMetadata.envBindings[key] ===
-        `${CONNECTOR_SECRET_REF_PREFIX}${accessMetadata.accessToken}`
-      ) {
-        return accessMetadata.accessToken;
-      }
-      return undefined;
+      const entry = getConnectorOwnedAccessSecretBindingEntries(
+        accessMetadata,
+      ).find((binding) => {
+        return binding.envName === key;
+      });
+      return entry?.secretName === accessMetadata.accessToken
+        ? accessMetadata.accessToken
+        : undefined;
     }
     case "static": {
-      const valueRef = accessMetadata.envBindings[key];
-      return valueRef?.startsWith(CONNECTOR_SECRET_REF_PREFIX) === true
-        ? valueRef.slice(CONNECTOR_SECRET_REF_PREFIX.length)
-        : undefined;
+      return getConnectorOwnedAccessSecretBindingEntries(accessMetadata).find(
+        (binding) => {
+          return binding.envName === key;
+        },
+      )?.secretName;
     }
     case "none": {
       return undefined;

--- a/turbo/apps/api/src/signals/services/zero-connector-data.service.ts
+++ b/turbo/apps/api/src/signals/services/zero-connector-data.service.ts
@@ -10,12 +10,13 @@ import {
   getAvailableConnectorAuthMethods,
   getConnectorAuthMethodAccessMetadata,
   getConnectorAuthMethodScopeDiff,
-  getConnectorAuthMethodEnvBindings,
   getConnectorAuthMethod,
   getConnectorManualGrantFieldNames,
+  getConnectorOwnedAccessSecretBindingEntries,
   getConnectorOwnedSecretNames,
   getConnectorVariableNames,
   getRuntimeAvailableConnectorTypes,
+  type ConnectorAuthMethodAccessMetadata,
   type ManualGrantFieldNames,
 } from "@vm0/connectors/connector-utils";
 import { revokeConnectorAuthMethodAccessToken } from "@vm0/connectors/auth-providers";
@@ -27,7 +28,6 @@ import {
   type ConnectorManualGrantFieldConfig,
   type ConnectorType,
   type ConnectorAuthProviderType,
-  type ConnectorEnvBindings,
   type TokenRevokeConnectorType,
 } from "@vm0/connectors/connectors";
 import {
@@ -73,7 +73,6 @@ interface ConnectorScopedSecretNames {
 
 const oauthScopesSchema = z.array(z.string());
 const DEFAULT_ACCESS_TOKEN_EXPIRES_IN_SECS = 15 * 60;
-const CONNECTOR_SECRET_REF_PREFIX = "$secrets.";
 type FeatureStates = ReturnType<typeof getAllFeatureStates>;
 
 interface ExternalUserInfo {
@@ -410,15 +409,17 @@ function connectorProvidedEnvNamesForStoredConnectors(
 ): Set<string> {
   const provided = new Set<string>();
   for (const connector of connectorList) {
-    const envBindings = getConnectorAuthMethodEnvBindings(
+    const accessMetadata = getConnectorAuthMethodAccessMetadata(
       connector.type,
       connector.authMethod,
     );
-    for (const [envName, valueRef] of Object.entries(envBindings)) {
-      if (!valueRef.startsWith(CONNECTOR_SECRET_REF_PREFIX)) {
-        continue;
-      }
-      const secretName = valueRef.slice(CONNECTOR_SECRET_REF_PREFIX.length);
+    if (!accessMetadata) {
+      continue;
+    }
+    for (const {
+      envName,
+      secretName,
+    } of getConnectorOwnedAccessSecretBindingEntries(accessMetadata)) {
       if (!connectorScopedSecretNames.secretNames.has(secretName)) {
         continue;
       }
@@ -1174,22 +1175,17 @@ function connectorTokenExpiresAt(args: {
     : new Date(nowDate().getTime() + expiresInSecs * 1000);
 }
 
-function connectorSecretNameFromRef(valueRef: string): string | undefined {
-  return valueRef.startsWith(CONNECTOR_SECRET_REF_PREFIX)
-    ? valueRef.slice(CONNECTOR_SECRET_REF_PREFIX.length)
-    : undefined;
-}
-
 function staticConnectorOwnedAccessSecretName(
-  envBindings: ConnectorEnvBindings,
-  platformSecretNames: ReadonlySet<string>,
+  accessMetadata: Extract<
+    ConnectorAuthMethodAccessMetadata,
+    { readonly kind: "static" }
+  >,
 ): string | undefined {
   const secretNames = new Set<string>();
-  for (const valueRef of Object.values(envBindings)) {
-    const secretName = connectorSecretNameFromRef(valueRef);
-    if (secretName && !platformSecretNames.has(secretName)) {
-      secretNames.add(secretName);
-    }
+  for (const { secretName } of getConnectorOwnedAccessSecretBindingEntries(
+    accessMetadata,
+  )) {
+    secretNames.add(secretName);
   }
   if (secretNames.size !== 1) {
     return undefined;
@@ -1216,10 +1212,8 @@ function connectorTokenSecretMetadataForAuthMethod(args: {
     }
 
     case "static": {
-      const accessSecretName = staticConnectorOwnedAccessSecretName(
-        accessMetadata.envBindings,
-        new Set(accessMetadata.platformSecrets),
-      );
+      const accessSecretName =
+        staticConnectorOwnedAccessSecretName(accessMetadata);
       return accessSecretName
         ? {
             accessSecretName,

--- a/turbo/packages/connectors/src/__tests__/connectors.test.ts
+++ b/turbo/packages/connectors/src/__tests__/connectors.test.ts
@@ -43,6 +43,7 @@ import {
   getConnectorAuthMethodAuthCodeGrantConfig,
   getConnectorAuthMethodDeviceAuthGrantConfig,
   getConnectorAuthMethodAccessMetadata,
+  getConnectorOwnedAccessSecretBindingEntries,
   resolveConnectorAuthClientForMethod,
   getConnectorAuthMethodEnvBindings,
   getConnectorAuthMethod,
@@ -1749,6 +1750,42 @@ describe("getConnectorAuthMethodAccessMetadata", () => {
     expect(getConnectorOwnedSecretNames("google-ads", "oauth")).toStrictEqual([
       "GOOGLE_ADS_ACCESS_TOKEN",
       "GOOGLE_ADS_REFRESH_TOKEN",
+    ]);
+  });
+
+  it("returns connector-owned access secret binding entries", () => {
+    const googleAdsAccess = getConnectorAuthMethodAccessMetadata(
+      "google-ads",
+      "oauth",
+    );
+    const slockAccess = getConnectorAuthMethodAccessMetadata("slock", "oauth");
+    const githubAccess = getConnectorAuthMethodAccessMetadata(
+      "github",
+      "oauth",
+    );
+    if (!googleAdsAccess || !slockAccess || !githubAccess) {
+      throw new Error("Expected access metadata for test connectors");
+    }
+
+    expect(
+      getConnectorOwnedAccessSecretBindingEntries(googleAdsAccess),
+    ).toStrictEqual([
+      {
+        envName: "GOOGLE_ADS_TOKEN",
+        secretName: "GOOGLE_ADS_ACCESS_TOKEN",
+      },
+    ]);
+    expect(
+      getConnectorOwnedAccessSecretBindingEntries(slockAccess),
+    ).toStrictEqual([
+      { envName: "SLOCK_TOKEN", secretName: "SLOCK_ACCESS_TOKEN" },
+      { envName: "SLOCK_SERVER_ID", secretName: "SLOCK_SERVER_ID" },
+    ]);
+    expect(
+      getConnectorOwnedAccessSecretBindingEntries(githubAccess),
+    ).toStrictEqual([
+      { envName: "GH_TOKEN", secretName: "GITHUB_ACCESS_TOKEN" },
+      { envName: "GITHUB_TOKEN", secretName: "GITHUB_ACCESS_TOKEN" },
     ]);
   });
 });

--- a/turbo/packages/connectors/src/connector-utils.ts
+++ b/turbo/packages/connectors/src/connector-utils.ts
@@ -40,6 +40,7 @@ const CONNECTOR_AUTH_METHOD_PRIORITY = {
   "api-token": 1,
   api: 2,
 } as const satisfies Record<ConnectorAuthMethodId, number>;
+const CONNECTOR_SECRET_REF_PREFIX = "$secrets.";
 
 function connectorAuthMethodPriority(
   authMethod: ConnectorAuthMethodId,
@@ -257,6 +258,41 @@ export type ConnectorAuthMethodAccessMetadata =
       readonly envBindings: ConnectorEnvBindings;
       readonly platformSecrets: readonly ConnectorPlatformSecretName[];
     };
+
+export interface ConnectorOwnedAccessSecretBindingEntry {
+  readonly envName: string;
+  readonly secretName: string;
+}
+
+function connectorOwnedAccessSecretBindingEntries(args: {
+  readonly envBindings: ConnectorEnvBindings;
+  readonly platformSecrets: readonly ConnectorPlatformSecretName[];
+}): ConnectorOwnedAccessSecretBindingEntry[] {
+  const platformSecretNames: ReadonlySet<string> = new Set(
+    args.platformSecrets,
+  );
+  const entries: ConnectorOwnedAccessSecretBindingEntry[] = [];
+  for (const [envName, valueRef] of Object.entries(args.envBindings)) {
+    if (!valueRef.startsWith(CONNECTOR_SECRET_REF_PREFIX)) {
+      continue;
+    }
+    const secretName = valueRef.slice(CONNECTOR_SECRET_REF_PREFIX.length);
+    if (platformSecretNames.has(secretName)) {
+      continue;
+    }
+    entries.push({ envName, secretName });
+  }
+  return entries;
+}
+
+export function getConnectorOwnedAccessSecretBindingEntries(
+  accessMetadata: ConnectorAuthMethodAccessMetadata,
+): ConnectorOwnedAccessSecretBindingEntry[] {
+  return connectorOwnedAccessSecretBindingEntries({
+    envBindings: accessMetadata.envBindings,
+    platformSecrets: accessMetadata.platformSecrets,
+  });
+}
 
 export function getConnectorAuthMethodAccessMetadata(
   type: ConnectorType,
@@ -735,12 +771,11 @@ function connectorMethodOwnedSecretNames(
     }
   }
 
-  for (const valueRef of Object.values(
-    connectorAccessEnvBindings(method.access),
-  )) {
-    if (valueRef.startsWith("$secrets.")) {
-      names.add(valueRef.slice("$secrets.".length));
-    }
+  for (const { secretName } of connectorOwnedAccessSecretBindingEntries({
+    envBindings: connectorAccessEnvBindings(method.access),
+    platformSecrets: connectorAccessPlatformSecrets(method.access),
+  })) {
+    names.add(secretName);
   }
 
   if (method.access.kind === "refresh-token") {


### PR DESCRIPTION
## Summary
- add a shared connector-owned access secret binding helper that returns env alias and storage name entries while excluding platform-backed secrets
- use the helper in run creation, connector list metadata, and webhook firewall auth without changing full connector-owned storage semantics
- add regression coverage for Google Ads platform-backed dirty connector secret rows and helper behavior for Google Ads, Slock, and GitHub

## Tests
- pnpm -F @vm0/connectors exec vitest run src/__tests__/connectors.test.ts
- pnpm -F api exec vitest run src/signals/services/__tests__/zero-connector-data.service.test.ts src/signals/routes/__tests__/zero-runs-create.test.ts
- pnpm -F @vm0/connectors lint
- pnpm -F api lint
- pnpm check-types
- pnpm format
- pnpm knip

Closes #15754