### PR TITLE
Respect paid onboarding signup redirect

### DIFF
--- a/turbo/apps/web/app/sign-up/[[...sign-up]]/SignUpClient.tsx
+++ b/turbo/apps/web/app/sign-up/[[...sign-up]]/SignUpClient.tsx
@@ -6,7 +6,10 @@ import { useTheme } from "../../components/ThemeProvider";
 import { AuthLayout } from "../../components/auth/AuthLayout";
 import { getClerkAppearance } from "../../components/auth/clerk-appearance";
 import { buildSignupRedirectUrl } from "../../../src/lib/adAttribution";
-import { getAppUrl } from "../../../src/lib/zero/url";
+import {
+  getAllowedRedirectOrigins,
+  getAppUrl,
+} from "../../../src/lib/zero/url";
 
 export function SignUpClient() {
   const { theme } = useTheme();
@@ -14,6 +17,7 @@ export function SignUpClient() {
   const redirectUrl = buildSignupRedirectUrl(
     getAppUrl(),
     searchParams.toString(),
+    getAllowedRedirectOrigins(),
   );
 
   return (

--- a/turbo/apps/web/src/__tests__/adAttribution.test.ts
+++ b/turbo/apps/web/src/__tests__/adAttribution.test.ts
@@ -185,4 +185,31 @@ describe("buildSignupRedirectUrl", () => {
     expect(url.searchParams.get("utm_source")).toBe("google");
     expect(url.searchParams.get("utm_campaign")).toBe("homepage_search");
   });
+
+  it("honors an allowed redirect_url over the attributed app fallback", () => {
+    const redirectUrl = buildSignupRedirectUrl(
+      "https://staging-app.vm6.ai",
+      "redirect_url=https%3A%2F%2Fpreview.vm6.ai%2Fonboarding%3Fgclid%3Dtest-click%26vm0_source%3Dpresentation&gclid=test-click&utm_source=google&utm_campaign=paid_onboarding",
+      ["https://staging-app.vm6.ai", "https://*.vm6.ai"],
+    );
+    const url = new URL(redirectUrl);
+
+    expect(url.origin).toBe("https://preview.vm6.ai");
+    expect(url.pathname).toBe("/onboarding");
+    expect(url.searchParams.get("gclid")).toBe("test-click");
+    expect(url.searchParams.get("vm0_source")).toBe("presentation");
+  });
+
+  it("ignores a disallowed redirect_url and keeps the attributed app fallback", () => {
+    const redirectUrl = buildSignupRedirectUrl(
+      "https://app.vm0.ai",
+      "redirect_url=https%3A%2F%2Fevil.example%2Fonboarding&gclid=test-click&utm_source=google&utm_campaign=homepage_search",
+      ["https://app.vm0.ai", "https://so.vm0.ai"],
+    );
+    const url = new URL(redirectUrl);
+
+    expect(url.origin).toBe("https://app.vm0.ai");
+    expect(url.pathname).toBe("/onboarding");
+    expect(url.searchParams.get("gclid")).toBe("test-click");
+  });
 });

--- a/turbo/apps/web/src/lib/adAttribution.ts
+++ b/turbo/apps/web/src/lib/adAttribution.ts
@@ -241,8 +241,14 @@ export function buildSignupHref(landingSearch: string): string {
 export function buildSignupRedirectUrl(
   appUrl: string,
   signUpSearch: string,
+  allowedRedirectOrigins: readonly string[] = [appUrl],
 ): string {
   const params = new URLSearchParams(signUpSearch);
+  const redirectUrl = readAllowedRedirectUrl(params, allowedRedirectOrigins);
+  if (redirectUrl) {
+    return redirectUrl;
+  }
+
   if (!hasAdTraffic(params)) {
     return appUrl;
   }
@@ -250,6 +256,46 @@ export function buildSignupRedirectUrl(
   const url = new URL("/onboarding", appUrl);
   appendHomepageAttributionParams(url.searchParams, signUpSearch);
   return url.toString();
+}
+
+function readAllowedRedirectUrl(
+  params: URLSearchParams,
+  allowedRedirectOrigins: readonly string[],
+): string | null {
+  const rawRedirectUrl = params.get("redirect_url");
+  if (!rawRedirectUrl) {
+    return null;
+  }
+
+  try {
+    const redirectUrl = new URL(rawRedirectUrl);
+    return isAllowedRedirectOrigin(redirectUrl, allowedRedirectOrigins)
+      ? redirectUrl.toString()
+      : null;
+  } catch {
+    return null;
+  }
+}
+
+function isAllowedRedirectOrigin(
+  redirectUrl: URL,
+  allowedRedirectOrigins: readonly string[],
+): boolean {
+  return allowedRedirectOrigins.some((allowedOrigin) => {
+    if (allowedOrigin.startsWith("https://*.")) {
+      const suffix = allowedOrigin.slice("https://*.".length);
+      return (
+        redirectUrl.protocol === "https:" &&
+        redirectUrl.hostname.endsWith(`.${suffix}`)
+      );
+    }
+
+    try {
+      return new URL(allowedOrigin).origin === redirectUrl.origin;
+    } catch {
+      return false;
+    }
+  });
 }
 
 // Cookie I/O is isolated behind this interface so the write path is testable

--- a/turbo/apps/web/src/lib/zero/url.test.ts
+++ b/turbo/apps/web/src/lib/zero/url.test.ts
@@ -25,6 +25,16 @@ describe("getAllowedRedirectOrigins", () => {
     ]);
   });
 
+  it("appends the *.vm6.ai wildcard for a staging app origin without paid onboarding env", () => {
+    vi.stubEnv("NEXT_PUBLIC_APP_URL", "https://pr-15762-app.vm6.ai");
+    vi.stubEnv("NEXT_PUBLIC_PAID_ONBOARDING_URL", undefined);
+    reloadEnv();
+    expect(getAllowedRedirectOrigins()).toEqual([
+      "https://pr-15762-app.vm6.ai",
+      "https://*.vm6.ai",
+    ]);
+  });
+
   it("returns the app URL only when no paid-onboarding origin is configured", () => {
     vi.stubEnv("NEXT_PUBLIC_PAID_ONBOARDING_URL", undefined);
     reloadEnv();

--- a/turbo/apps/web/src/lib/zero/url.ts
+++ b/turbo/apps/web/src/lib/zero/url.ts
@@ -9,21 +9,28 @@ export function getAppUrl(): string {
 // when configured per environment, so a paid onboarding flow hosted on a
 // sibling *.vm0.ai subdomain can run auth on www and return to itself.
 export function getAllowedRedirectOrigins(): string[] {
+  const appUrl = getAppUrl();
   const paidOnboardingUrl = env().NEXT_PUBLIC_PAID_ONBOARDING_URL;
-  if (!paidOnboardingUrl) {
-    return [getAppUrl()];
+  const origins = paidOnboardingUrl ? [appUrl, paidOnboardingUrl] : [appUrl];
+
+  // Any vm6.ai app/web preview is staging-only. Allow the whole *.vm6.ai
+  // family so paid onboarding previews can run auth on the paired web preview
+  // or staging-www and still return to themselves.
+  if (
+    origins.some((origin) => {
+      return isVm6Origin(origin);
+    })
+  ) {
+    origins.push("https://*.vm6.ai");
   }
-  const origins = [getAppUrl(), paidOnboardingUrl];
-  // On the staging preview domain the paid LP/onboarding surface is deployed
-  // per preview (pr-N-so.vm6.ai, or the raw <hash>.vm6.ai). Allow the whole
-  // *.vm6.ai family so each preview can run auth on staging-www and return to
-  // itself. Production keeps the exact origin (so.vm0.ai), never a wildcard.
-  try {
-    if (new URL(paidOnboardingUrl).hostname.endsWith(".vm6.ai")) {
-      origins.push("https://*.vm6.ai");
-    }
-  } catch {
-    // Ignore a malformed paid-onboarding URL; the exact origin above still applies.
-  }
+
   return origins;
+}
+
+function isVm6Origin(origin: string): boolean {
+  try {
+    return new URL(origin).hostname.endsWith(".vm6.ai");
+  } catch {
+    return false;
+  }
 }


### PR DESCRIPTION
## Summary
- honor an allowlisted `redirect_url` during web sign-up completion before falling back to app onboarding attribution routing
- pass Clerk's configured allowed redirect origins into the sign-up redirect helper
- cover allowed `*.vm6.ai` paid onboarding previews and disallowed redirect fallback with tests

## Verification
- `pnpm -F web test -- src/__tests__/adAttribution.test.ts`
- `git diff --check`

## Context
A staging-browser run from the vm0-marketing preview preserved `redirect_url` through `/sign-up/verify-email-address`, but after OTP the web sign-up forced the user to `staging-app.vm6.ai/onboarding`. The paid onboarding preview cannot complete fresh-user auth round-trip until this web-side redirect is deployed to staging-www.
