### PR TITLE
refactor: remove connector auth provider capability helpers

### DIFF
--- a/turbo/apps/api/src/signals/services/agent-webhook-firewall-auth.service.ts
+++ b/turbo/apps/api/src/signals/services/agent-webhook-firewall-auth.service.ts
@@ -10,6 +10,7 @@ import {
   resolveConnectorAuthClientForMethod,
   getConnectorAuthMethodAccessMetadata,
   getConnectorOwnedAccessSecretBindingEntries,
+  connectorAuthMethodSupportsRefreshTokenAccess,
   type ConnectorAuthMethodAccessMetadata,
 } from "@vm0/connectors/connector-utils";
 import {
@@ -25,7 +26,6 @@ import {
 import type { FeatureSwitchContext } from "@vm0/core/feature-switch";
 import {
   getConnectorAuthProviderClientArgs,
-  hasConnectorRefreshTokenAccessProvider,
   refreshConnectorAuthProviderAccessToken,
   type ConnectorAuthProviderClientArgs,
   type ProviderEnv,
@@ -1018,7 +1018,7 @@ function prepareRefreshTokenContext(
     return { ok: false, reason: "not-refreshable" };
   }
   if (
-    !hasConnectorRefreshTokenAccessProvider(
+    !connectorAuthMethodSupportsRefreshTokenAccess(
       parsedConnectorType.data,
       connectorAccess.authMethod,
     )

--- a/turbo/packages/connectors/src/__tests__/connectors.test.ts
+++ b/turbo/packages/connectors/src/__tests__/connectors.test.ts
@@ -63,10 +63,6 @@ import { FeatureSwitchKey } from "../feature-switch-key";
 import {
   buildConnectorAuthCodeAuthorizationUrl,
   getConnectorAuthProviderClientArgs,
-  hasConnectorAuthCodeGrantProvider,
-  hasConnectorDeviceAuthGrantProvider,
-  hasConnectorRefreshTokenAccessProvider,
-  hasConnectorTokenRevokeProvider,
   pollConnectorDeviceAuthorization,
   refreshConnectorAuthProviderAccessToken,
   revokeConnectorAuthMethodAccessToken,
@@ -489,60 +485,50 @@ describe("connector auth method config", () => {
   });
 });
 
-describe("connector provider capability checks", () => {
-  it("matches exactly the connector types that declare auth-code and device-auth grants", () => {
-    const authCodeGrantTypes = new Set<ConnectorType>(
-      connectorTypeSchema.options.filter(hasConnectorAuthCodeGrant),
-    );
-    const deviceAuthGrantTypes = new Set<ConnectorType>(
-      connectorTypeSchema.options.filter(hasConnectorDeviceAuthGrant),
-    );
-
+describe("connector selected auth method capability checks", () => {
+  it("matches exactly the auth methods that declare auth-code and device-auth grants", () => {
     for (const type of connectorTypeSchema.options) {
-      expect(hasConnectorAuthCodeGrantProvider(type)).toBe(
-        authCodeGrantTypes.has(type),
+      const authMethods = getConfiguredConnectorAuthMethods(type);
+      expect(hasConnectorAuthCodeGrant(type)).toBe(
+        authMethods.some((authMethod) => {
+          return connectorAuthMethodHasGrantKind(type, authMethod, "auth-code");
+        }),
       );
-      expect(hasConnectorDeviceAuthGrantProvider(type)).toBe(
-        deviceAuthGrantTypes.has(type),
+      expect(hasConnectorDeviceAuthGrant(type)).toBe(
+        authMethods.some((authMethod) => {
+          return connectorAuthMethodHasGrantKind(
+            type,
+            authMethod,
+            "device-auth",
+          );
+        }),
       );
       for (const authMethod of getConfiguredConnectorAuthMethods(type)) {
-        expect(hasConnectorAuthCodeGrantProvider(type, authMethod)).toBe(
+        expect(
           connectorAuthMethodHasGrantKind(type, authMethod, "auth-code"),
+        ).toBe(
+          getConnectorAuthMethod(type, authMethod)?.grant.kind === "auth-code",
         );
-        expect(hasConnectorDeviceAuthGrantProvider(type, authMethod)).toBe(
+        expect(
           connectorAuthMethodHasGrantKind(type, authMethod, "device-auth"),
+        ).toBe(
+          getConnectorAuthMethod(type, authMethod)?.grant.kind ===
+            "device-auth",
         );
       }
     }
   });
 
-  it("matches exactly the connector types that declare refresh-token access", () => {
+  it("matches exactly the auth methods that declare refresh-token access", () => {
     expectTypeOf<"base44">().toMatchTypeOf<RefreshTokenAccessConnectorType>();
     expectTypeOf<"notion">().toMatchTypeOf<RefreshTokenAccessConnectorType>();
     expectTypeOf<"github">().not.toMatchTypeOf<RefreshTokenAccessConnectorType>();
 
-    const refreshTokenAccessTypes = new Set<ConnectorType>(
-      connectorTypeSchema.options.filter((type) => {
-        return getConfiguredConnectorAuthMethods(type).some((authMethod) => {
-          return (
-            getConnectorAuthMethodAccessMetadata(type, authMethod)?.kind ===
-            "refresh-token"
-          );
-        });
-      }),
-    );
-
     for (const type of connectorTypeSchema.options) {
-      expect(hasConnectorRefreshTokenAccessProvider(type)).toBe(
-        refreshTokenAccessTypes.has(type),
-      );
       for (const authMethod of getConfiguredConnectorAuthMethods(type)) {
         const hasRefreshTokenAccess =
           getConnectorAuthMethodAccessMetadata(type, authMethod)?.kind ===
           "refresh-token";
-        expect(hasConnectorRefreshTokenAccessProvider(type, authMethod)).toBe(
-          hasRefreshTokenAccess,
-        );
         expect(
           connectorAuthMethodSupportsRefreshTokenAccess(type, authMethod),
         ).toBe(hasRefreshTokenAccess);
@@ -554,25 +540,15 @@ describe("connector provider capability checks", () => {
     expectTypeOf<"github">().toMatchTypeOf<TokenRevokeConnectorType>();
     expectTypeOf<"notion">().not.toMatchTypeOf<TokenRevokeConnectorType>();
 
-    const tokenRevokeTypes = new Set<ConnectorType>(
-      connectorTypeSchema.options.filter((type) => {
-        return getConfiguredConnectorAuthMethods(type).some((authMethod) => {
-          return connectorAuthMethodSupportsTokenRevoke(type, authMethod);
-        });
-      }),
-    );
-
     for (const type of connectorTypeSchema.options) {
-      expect(hasConnectorTokenRevokeProvider(type)).toBe(
-        tokenRevokeTypes.has(type),
-      );
       for (const authMethod of getConfiguredConnectorAuthMethods(type)) {
         const supportsTokenRevoke = connectorAuthMethodSupportsTokenRevoke(
           type,
           authMethod,
         );
-        expect(hasConnectorTokenRevokeProvider(type, authMethod)).toBe(
-          supportsTokenRevoke,
+        expect(supportsTokenRevoke).toBe(
+          getConnectorAuthMethod(type, authMethod)?.revoke.kind ===
+            "token-revoke",
         );
       }
     }
@@ -590,30 +566,36 @@ describe("connector provider capability checks", () => {
     );
   });
 
-  it("does not expose refresh-token access providers for non-refreshable auth methods", () => {
-    expect(hasConnectorRefreshTokenAccessProvider("github")).toBe(false);
+  it("does not mark non-refreshable auth methods as refresh-token access", () => {
+    expect(
+      connectorAuthMethodSupportsRefreshTokenAccess("github", "oauth"),
+    ).toBe(false);
     expect(
       getConnectorAuthMethodAccessMetadata("github", "oauth")?.kind,
     ).not.toBe("refresh-token");
   });
 
   it("supports multiple provider-backed auth-code methods for one connector", async () => {
-    expect(hasConnectorAuthCodeGrantProvider("test-oauth", "oauth")).toBe(true);
-    expect(hasConnectorAuthCodeGrantProvider("test-oauth", "api")).toBe(true);
-    expect(hasConnectorAuthCodeGrantProvider("test-oauth", "missing")).toBe(
-      false,
-    );
-    expect(hasConnectorDeviceAuthGrantProvider("test-oauth", "api")).toBe(
-      false,
-    );
-    expect(hasConnectorRefreshTokenAccessProvider("test-oauth", "oauth")).toBe(
-      true,
-    );
-    expect(hasConnectorRefreshTokenAccessProvider("test-oauth", "api")).toBe(
-      true,
-    );
     expect(
-      hasConnectorRefreshTokenAccessProvider("test-oauth", "missing"),
+      connectorAuthMethodHasGrantKind("test-oauth", "oauth", "auth-code"),
+    ).toBe(true);
+    expect(
+      connectorAuthMethodHasGrantKind("test-oauth", "api", "auth-code"),
+    ).toBe(true);
+    expect(
+      connectorAuthMethodHasGrantKind("test-oauth", "missing", "auth-code"),
+    ).toBe(false);
+    expect(
+      connectorAuthMethodHasGrantKind("test-oauth", "api", "device-auth"),
+    ).toBe(false);
+    expect(
+      connectorAuthMethodSupportsRefreshTokenAccess("test-oauth", "oauth"),
+    ).toBe(true);
+    expect(
+      connectorAuthMethodSupportsRefreshTokenAccess("test-oauth", "api"),
+    ).toBe(true);
+    expect(
+      connectorAuthMethodSupportsRefreshTokenAccess("test-oauth", "missing"),
     ).toBe(false);
     expect(
       getConnectorAuthMethodEnvBindings("test-oauth", "api"),

--- a/turbo/packages/connectors/src/auth-providers/connector-auth.ts
+++ b/turbo/packages/connectors/src/auth-providers/connector-auth.ts
@@ -1,5 +1,4 @@
 import {
-  connectorTypeSchema,
   type ConnectorAuthCodeGrantAuthMethodId,
   type AuthCodeGrantConnectorType,
   type ConnectorAuthCodeGrantConfig,
@@ -198,12 +197,6 @@ interface ConnectorAuthMethodProviderEntry<Type extends ConnectorType> {
     Type & RefreshTokenAccessConnectorType
   >;
   readonly revoke?: ConnectorTokenRevokeProvider;
-}
-
-interface ConnectorAuthMethodProviderCapabilities {
-  readonly grant?: { readonly kind: "auth-code" | "device-auth" };
-  readonly access?: { readonly kind: "refresh-token" };
-  readonly revoke?: { readonly kind: "token-revoke" };
 }
 
 type ConnectorProviderBackedAuthMethodEntries<
@@ -512,12 +505,6 @@ const CONNECTOR_AUTH_METHOD_PROVIDERS = {
 const CONNECTOR_AUTH_METHOD_PROVIDER_REGISTRY: ConnectorAuthMethodProviderRegistry =
   CONNECTOR_AUTH_METHOD_PROVIDERS;
 
-function isConnectorProviderBackedType(
-  type: ConnectorType,
-): type is ConnectorProviderBackedType {
-  return Object.hasOwn(CONNECTOR_AUTH_METHOD_PROVIDER_REGISTRY, type);
-}
-
 function connectorAuthMethodProviderEntryFor<
   Type extends ConnectorProviderBackedType,
 >(
@@ -528,153 +515,6 @@ function connectorAuthMethodProviderEntryFor<
     Record<string, ConnectorAuthMethodProviderEntry<Type>>
   > = CONNECTOR_AUTH_METHOD_PROVIDER_REGISTRY[type];
   return providers[authMethod];
-}
-
-function connectorAuthMethodProviderCapabilities(
-  type: string,
-  authMethod: string,
-): ConnectorAuthMethodProviderCapabilities | undefined {
-  const connectorType = connectorTypeSchema.safeParse(type);
-  if (
-    !connectorType.success ||
-    !isConnectorProviderBackedType(connectorType.data)
-  ) {
-    return undefined;
-  }
-  return connectorAuthMethodProviderEntryFor(connectorType.data, authMethod);
-}
-
-function connectorAuthMethodProviderCapabilityEntries(
-  type: string,
-): readonly ConnectorAuthMethodProviderCapabilities[] {
-  const connectorType = connectorTypeSchema.safeParse(type);
-  if (
-    !connectorType.success ||
-    !isConnectorProviderBackedType(connectorType.data)
-  ) {
-    return [];
-  }
-  const providers: Readonly<
-    Record<string, ConnectorAuthMethodProviderCapabilities>
-  > = CONNECTOR_AUTH_METHOD_PROVIDER_REGISTRY[connectorType.data];
-  return Object.values(providers);
-}
-
-export function hasConnectorAuthProvider(
-  type: string,
-): type is ConnectorAuthProviderType {
-  return (
-    hasConnectorAuthCodeGrantProvider(type) ||
-    hasConnectorDeviceAuthGrantProvider(type)
-  );
-}
-
-export function hasConnectorAuthCodeGrantProvider(
-  type: string,
-): type is AuthCodeGrantConnectorType;
-export function hasConnectorAuthCodeGrantProvider<
-  T extends AuthCodeGrantConnectorType,
->(
-  type: T,
-  authMethod: string,
-): authMethod is ConnectorAuthCodeGrantAuthMethodId<T>;
-export function hasConnectorAuthCodeGrantProvider(
-  type: string,
-  authMethod: string,
-): boolean;
-export function hasConnectorAuthCodeGrantProvider(
-  type: string,
-  authMethod?: string,
-): boolean {
-  if (authMethod === undefined) {
-    return connectorAuthMethodProviderCapabilityEntries(type).some(
-      (provider) => {
-        return provider.grant?.kind === "auth-code";
-      },
-    );
-  }
-  return hasConnectorAuthCodeGrantProviderForMethod(type, authMethod);
-}
-
-function hasConnectorAuthCodeGrantProviderForMethod(
-  type: string,
-  authMethod: string,
-): boolean {
-  return (
-    connectorAuthMethodProviderCapabilities(type, authMethod)?.grant?.kind ===
-    "auth-code"
-  );
-}
-
-export function hasConnectorDeviceAuthGrantProvider(
-  type: string,
-): type is DeviceAuthGrantConnectorType;
-export function hasConnectorDeviceAuthGrantProvider<
-  T extends DeviceAuthGrantConnectorType,
->(
-  type: T,
-  authMethod: string,
-): authMethod is ConnectorDeviceAuthGrantAuthMethodId<T>;
-export function hasConnectorDeviceAuthGrantProvider(
-  type: string,
-  authMethod: string,
-): boolean;
-export function hasConnectorDeviceAuthGrantProvider(
-  type: string,
-  authMethod?: string,
-): boolean {
-  if (authMethod === undefined) {
-    return connectorAuthMethodProviderCapabilityEntries(type).some(
-      (provider) => {
-        return provider.grant?.kind === "device-auth";
-      },
-    );
-  }
-  return hasConnectorDeviceAuthGrantProviderForMethod(type, authMethod);
-}
-
-function hasConnectorDeviceAuthGrantProviderForMethod(
-  type: string,
-  authMethod: string,
-): boolean {
-  return (
-    connectorAuthMethodProviderCapabilities(type, authMethod)?.grant?.kind ===
-    "device-auth"
-  );
-}
-
-export function hasConnectorRefreshTokenAccessProvider(
-  type: string,
-  authMethod?: string,
-): type is RefreshTokenAccessConnectorType {
-  if (authMethod === undefined) {
-    return connectorAuthMethodProviderCapabilityEntries(type).some(
-      (provider) => {
-        return provider.access?.kind === "refresh-token";
-      },
-    );
-  }
-  return (
-    connectorAuthMethodProviderCapabilities(type, authMethod)?.access?.kind ===
-    "refresh-token"
-  );
-}
-
-export function hasConnectorTokenRevokeProvider(
-  type: string,
-  authMethod?: string,
-): type is TokenRevokeConnectorType {
-  if (authMethod === undefined) {
-    return connectorAuthMethodProviderCapabilityEntries(type).some(
-      (provider) => {
-        return provider.revoke?.kind === "token-revoke";
-      },
-    );
-  }
-  return (
-    connectorAuthMethodProviderCapabilities(type, authMethod)?.revoke?.kind ===
-    "token-revoke"
-  );
 }
 
 export async function buildConnectorAuthCodeAuthorizationUrl<

--- a/turbo/packages/connectors/src/auth-providers/oauth/providers/__tests__/google-ads.test.ts
+++ b/turbo/packages/connectors/src/auth-providers/oauth/providers/__tests__/google-ads.test.ts
@@ -4,7 +4,6 @@ import {
   getConnectorAuthMethodAuthCodeGrantConfig,
   resolveConnectorAuthClientForMethod,
 } from "../../../../connector-utils";
-import { hasConnectorAuthCodeGrantProvider } from "../../../connector-auth";
 import { googleAdsProvider } from "../google-ads-provider";
 import { server } from "./test-server";
 
@@ -17,10 +16,6 @@ function testRefreshSignal(): AbortSignal {
 
 describe("connector/providers/google-ads", () => {
   describe("googleAdsProvider", () => {
-    it("registers google-ads as an auth-code grant provider", () => {
-      expect(hasConnectorAuthCodeGrantProvider("google-ads")).toBe(true);
-    });
-
     it("buildAuthUrl builds Google OAuth URL with Google Ads and userinfo scopes", () => {
       const url = googleAdsProvider.grant.buildAuthUrl({
         authCodeGrant: getConnectorAuthMethodAuthCodeGrantConfig(

--- a/turbo/packages/connectors/src/auth-providers/oauth/providers/__tests__/meta-ads.test.ts
+++ b/turbo/packages/connectors/src/auth-providers/oauth/providers/__tests__/meta-ads.test.ts
@@ -4,7 +4,6 @@ import {
   getConnectorAuthMethodAuthCodeGrantConfig,
   resolveConnectorAuthClientForMethod,
 } from "../../../../connector-utils";
-import { hasConnectorAuthCodeGrantProvider } from "../../../connector-auth";
 import {
   buildMetaAdsAuthorizationUrl,
   exchangeMetaAdsCode,
@@ -150,10 +149,6 @@ describe("connector/providers/meta-ads", () => {
   });
 
   describe("metaAdsProvider", () => {
-    it("registers meta-ads as an auth-code grant provider", () => {
-      expect(hasConnectorAuthCodeGrantProvider("meta-ads")).toBe(true);
-    });
-
     it("buildAuthUrl delegates to buildMetaAdsAuthorizationUrl", () => {
       const url = metaAdsProvider.grant.buildAuthUrl({
         authCodeGrant: getConnectorAuthMethodAuthCodeGrantConfig(


### PR DESCRIPTION
## Summary

- Remove exported connector auth provider capability helpers from the auth-provider public surface
- Use selected auth method config in firewall token refresh preparation
- Update connector/provider tests to avoid relying on removed type-level provider checks

## Testing

- pnpm -F @vm0/connectors exec vitest run src/__tests__/connectors.test.ts src/auth-providers/oauth/providers/__tests__/google-ads.test.ts src/auth-providers/oauth/providers/__tests__/meta-ads.test.ts
- pnpm -F @vm0/connectors lint
- pnpm -F api lint
- pnpm check-types
- pnpm format
- pnpm knip

Note: attempted the firewall auth route focused test, but local DB migration state is inconsistent: the test DB is missing user_permission_grants, and db:migrate fails because connector_oauth_device_authorization_sessions.auth_method already exists while the migration is not recorded. This is local environment drift, not a code failure.

Closes #15720