### PR TITLE
feat: add self-service permission grant ux

### DIFF
--- a/turbo/apps/api/src/signals/routes/__tests__/zero-user-permission-grants.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/zero-user-permission-grants.test.ts
@@ -177,7 +177,6 @@ describe("zero user permission grants", () => {
           connectorRef: SLACK_CONNECTOR,
           permission: SLACK_READ_PERMISSION,
           action: "allow",
-          ttlSeconds: 300,
         },
         headers: AUTH_HEADERS,
       }),
@@ -202,7 +201,6 @@ describe("zero user permission grants", () => {
           connectorRef: SLACK_CONNECTOR,
           permission: SLACK_READ_PERMISSION,
           action: "allow",
-          ttlSeconds: 300,
         },
         headers: AUTH_HEADERS,
       }),
@@ -215,7 +213,7 @@ describe("zero user permission grants", () => {
       permission: SLACK_READ_PERMISSION,
       action: "allow",
     });
-    expect(upserted.body.expiresAt).not.toBeNull();
+    expect(upserted.body.expiresAt).toBeNull();
 
     const db = store.set(writeDb$);
     await db.insert(userPermissionGrants).values({
@@ -283,7 +281,6 @@ describe("zero user permission grants", () => {
           connectorRef: SLACK_CONNECTOR,
           permission: SLACK_READ_PERMISSION,
           action: "allow",
-          ttlSeconds: 300,
         },
         headers: AUTH_HEADERS,
       }),
@@ -299,7 +296,6 @@ describe("zero user permission grants", () => {
           connectorRef: SLACK_CONNECTOR,
           permission: SLACK_READ_PERMISSION,
           action: "allow",
-          ttlSeconds: 300,
         },
         headers: AUTH_HEADERS,
       }),
@@ -314,7 +310,6 @@ describe("zero user permission grants", () => {
           connectorRef: SLACK_CONNECTOR,
           permission: SLACK_READ_PERMISSION,
           action: "allow",
-          ttlSeconds: 300,
         },
         headers: AUTH_HEADERS,
       }),
@@ -356,7 +351,6 @@ describe("zero user permission grants", () => {
           connectorRef: "not-a-real-connector",
           permission: SLACK_READ_PERMISSION,
           action: "allow",
-          ttlSeconds: 300,
         },
         headers: AUTH_HEADERS,
       }),
@@ -371,7 +365,6 @@ describe("zero user permission grants", () => {
           connectorRef: "not-a-real-connector",
           permission: UNKNOWN_PERMISSION_GRANT,
           action: "allow",
-          ttlSeconds: 300,
         },
         headers: AUTH_HEADERS,
       }),
@@ -388,7 +381,6 @@ describe("zero user permission grants", () => {
           connectorRef: SLACK_CONNECTOR,
           permission: "not-a-real-permission",
           action: "allow",
-          ttlSeconds: 300,
         },
         headers: AUTH_HEADERS,
       }),
@@ -403,7 +395,6 @@ describe("zero user permission grants", () => {
           connectorRef: SLACK_CONNECTOR,
           permission: UNKNOWN_PERMISSION_GRANT,
           action: "deny",
-          ttlSeconds: 300,
         },
         headers: AUTH_HEADERS,
       }),
@@ -427,29 +418,9 @@ describe("zero user permission grants", () => {
         connectorRef: SLACK_CONNECTOR,
         permission: SLACK_READ_PERMISSION,
         action: "ask",
-        ttlSeconds: 300,
       }),
     });
     expect(askResponse.status).toBe(400);
-
-    const unsupportedTtlResponse = await app.request(
-      "/api/zero/user-permission-grants",
-      {
-        method: "PUT",
-        headers: {
-          authorization: AUTH_HEADERS.authorization,
-          "content-type": "application/json",
-        },
-        body: JSON.stringify({
-          agentId,
-          connectorRef: SLACK_CONNECTOR,
-          permission: SLACK_READ_PERMISSION,
-          action: "allow",
-          ttlSeconds: 301,
-        }),
-      },
-    );
-    expect(unsupportedTtlResponse.status).toBe(400);
   });
 
   it("filters expired grants and folds active grants into legacy policies", async () => {
@@ -537,7 +508,7 @@ describe("zero user permission grants", () => {
     expect(permissionGrantsToFirewallPolicies([])).toBeNull();
   });
 
-  it("updates action, expiresAt, and updatedAt without changing createdAt", async () => {
+  it("updates action and updatedAt without changing createdAt", async () => {
     const fixture = await createFixture();
     const agentId = await seedAgent(fixture);
     await enableUserPermissionGrants(fixture.orgId, fixture.userId);
@@ -551,7 +522,6 @@ describe("zero user permission grants", () => {
           connectorRef: SLACK_CONNECTOR,
           permission: SLACK_READ_PERMISSION,
           action: "allow",
-          ttlSeconds: 300,
         },
         headers: AUTH_HEADERS,
       }),
@@ -585,13 +555,13 @@ describe("zero user permission grants", () => {
           connectorRef: SLACK_CONNECTOR,
           permission: SLACK_READ_PERMISSION,
           action: "deny",
-          ttlSeconds: 900,
         },
         headers: AUTH_HEADERS,
       }),
       [200],
     );
     expect(second.body.action).toBe("deny");
+    expect(second.body.expiresAt).toBeNull();
 
     const stored = await readStoredGrant({
       orgId: fixture.orgId,
@@ -603,8 +573,6 @@ describe("zero user permission grants", () => {
     expect(stored?.action).toBe("deny");
     expect(stored?.createdAt.getTime()).toBe(oldTimestamp.getTime());
     expect(stored?.updatedAt.getTime()).toBeGreaterThan(oldTimestamp.getTime());
-    expect(stored?.expiresAt?.getTime()).toBeGreaterThan(
-      oldExpiresAt.getTime(),
-    );
+    expect(stored?.expiresAt).toBeNull();
   });
 });

--- a/turbo/apps/api/src/signals/services/zero-user-permission-grants.service.ts
+++ b/turbo/apps/api/src/signals/services/zero-user-permission-grants.service.ts
@@ -208,10 +208,6 @@ async function lockVisibleAgentForUpdate(
   return agent ?? null;
 }
 
-function expiresAtFromTtl(now: Date, ttlSeconds: number): Date {
-  return new Date(now.getTime() + ttlSeconds * 1000);
-}
-
 async function upsertVisibleGrantRow(
   db: Db,
   args: UpsertUserPermissionGrantArgs,
@@ -227,7 +223,6 @@ async function upsertVisibleGrantRow(
     }
 
     const timestamp = nowDate();
-    const expiresAt = expiresAtFromTtl(timestamp, args.grant.ttlSeconds);
     const [row] = await tx
       .insert(userPermissionGrants)
       .values({
@@ -237,7 +232,7 @@ async function upsertVisibleGrantRow(
         connectorRef: args.grant.connectorRef,
         permission: args.grant.permission,
         action: args.grant.action,
-        expiresAt,
+        expiresAt: null,
         createdAt: timestamp,
         updatedAt: timestamp,
       })
@@ -251,7 +246,7 @@ async function upsertVisibleGrantRow(
         ],
         set: {
           action: args.grant.action,
-          expiresAt,
+          expiresAt: null,
           updatedAt: timestamp,
         },
       })

--- a/turbo/apps/platform/src/mocks/handlers/api-user-permission-grants.ts
+++ b/turbo/apps/platform/src/mocks/handlers/api-user-permission-grants.ts
@@ -24,7 +24,7 @@ export function createMockUserPermissionGrantResponse(
     connectorRef: "slack",
     permission: "channels:read",
     action: "allow",
-    expiresAt: "2099-01-01T00:00:00.000Z",
+    expiresAt: null,
     createdAt: now,
     updatedAt: now,
     ...overrides,
@@ -61,7 +61,7 @@ export const apiUserPermissionGrantsHandlers = [
       connectorRef: body.connectorRef,
       permission: body.permission,
       action: body.action,
-      expiresAt: new Date(now.getTime() + body.ttlSeconds * 1000).toISOString(),
+      expiresAt: null,
       createdAt: existing?.createdAt ?? now.toISOString(),
       updatedAt: now.toISOString(),
     };

--- a/turbo/apps/platform/src/mocks/handlers/api-user-permission-grants.ts
+++ b/turbo/apps/platform/src/mocks/handlers/api-user-permission-grants.ts
@@ -1,0 +1,78 @@
+import {
+  type UserPermissionGrantResponse,
+  zeroUserPermissionGrantsContract,
+} from "@vm0/api-contracts/contracts/zero-user-permission-grants";
+import { mockApi } from "../msw-contract.ts";
+
+let mockUserPermissionGrants: UserPermissionGrantResponse[] = [];
+
+function grantKey(
+  grant: Pick<
+    UserPermissionGrantResponse,
+    "agentId" | "connectorRef" | "permission"
+  >,
+): string {
+  return `${grant.agentId}:${grant.connectorRef}:${grant.permission}`;
+}
+
+export function createMockUserPermissionGrantResponse(
+  overrides: Partial<UserPermissionGrantResponse>,
+): UserPermissionGrantResponse {
+  const now = new Date().toISOString();
+  return {
+    agentId: "c0000000-0000-4000-a000-000000000001",
+    connectorRef: "slack",
+    permission: "channels:read",
+    action: "allow",
+    expiresAt: "2099-01-01T00:00:00.000Z",
+    createdAt: now,
+    updatedAt: now,
+    ...overrides,
+  };
+}
+
+export function setMockUserPermissionGrants(
+  grants: UserPermissionGrantResponse[],
+): void {
+  mockUserPermissionGrants = grants;
+}
+
+export function resetMockUserPermissionGrants(): void {
+  mockUserPermissionGrants = [];
+}
+
+export const apiUserPermissionGrantsHandlers = [
+  mockApi(zeroUserPermissionGrantsContract.list, ({ query, respond }) => {
+    return respond(
+      200,
+      mockUserPermissionGrants.filter((grant) => {
+        return grant.agentId === query.agentId;
+      }),
+    );
+  }),
+
+  mockApi(zeroUserPermissionGrantsContract.upsert, ({ body, respond }) => {
+    const now = new Date();
+    const existing = mockUserPermissionGrants.find((grant) => {
+      return grantKey(grant) === grantKey(body);
+    });
+    const grant: UserPermissionGrantResponse = {
+      agentId: body.agentId,
+      connectorRef: body.connectorRef,
+      permission: body.permission,
+      action: body.action,
+      expiresAt: new Date(now.getTime() + body.ttlSeconds * 1000).toISOString(),
+      createdAt: existing?.createdAt ?? now.toISOString(),
+      updatedAt: now.toISOString(),
+    };
+
+    mockUserPermissionGrants = [
+      ...mockUserPermissionGrants.filter((current) => {
+        return grantKey(current) !== grantKey(grant);
+      }),
+      grant,
+    ];
+
+    return respond(200, grant);
+  }),
+];

--- a/turbo/apps/platform/src/mocks/handlers/index.ts
+++ b/turbo/apps/platform/src/mocks/handlers/index.ts
@@ -86,6 +86,10 @@ import {
   resetMockPermissionRequests,
 } from "./api-permission-access-requests.ts";
 import { apiPermissionPoliciesHandlers } from "./api-permission-policies.ts";
+import {
+  apiUserPermissionGrantsHandlers,
+  resetMockUserPermissionGrants,
+} from "./api-user-permission-grants.ts";
 import { apiVoiceIoHandlers } from "./api-voice-io.ts";
 
 export const handlers = [
@@ -117,6 +121,7 @@ export const handlers = [
   ...apiRealtimeHandlers,
   ...apiPermissionAccessRequestsHandlers,
   ...apiPermissionPoliciesHandlers,
+  ...apiUserPermissionGrantsHandlers,
   ...apiSchedulesHandlers,
   ...apiInsightsHandlers,
   ...apiQueuePositionHandlers,
@@ -140,6 +145,7 @@ export function resetAllMockHandlers(): void {
   resetMockSlackConnect();
   resetAblySubscriptions();
   resetMockPermissionRequests();
+  resetMockUserPermissionGrants();
   resetMockComposesList();
   resetMockOrg();
   resetMockOrgLogo();

--- a/turbo/apps/platform/src/signals/permission-allow/permission-allow-signals.ts
+++ b/turbo/apps/platform/src/signals/permission-allow/permission-allow-signals.ts
@@ -30,8 +30,6 @@ import { FeatureSwitchKey } from "@vm0/connectors/feature-switch-key";
 const PERMISSION_ACCESS_REQUESTS_CHANGED_TOPIC =
   "permissionAccessRequestsChanged";
 
-const USER_PERMISSION_GRANT_TTL_SECONDS = 86_400;
-
 // ---------------------------------------------------------------------------
 // Route params
 // ---------------------------------------------------------------------------
@@ -412,7 +410,6 @@ export const upsertUserPermissionGrant$ = command(
       client.upsert({
         body: {
           ...params,
-          ttlSeconds: USER_PERMISSION_GRANT_TTL_SECONDS,
         },
         fetchOptions: { signal },
       }),

--- a/turbo/apps/platform/src/signals/permission-allow/permission-allow-signals.ts
+++ b/turbo/apps/platform/src/signals/permission-allow/permission-allow-signals.ts
@@ -10,13 +10,15 @@ import {
   type UserPermissionGrantResponse,
   zeroUserPermissionGrantsContract,
 } from "@vm0/api-contracts/contracts/zero-user-permission-grants";
-import type {
-  FirewallPolicies,
-  FirewallPolicyValue,
+import {
+  UNKNOWN_PERMISSION_GRANT,
+  type FirewallPolicies,
+  type FirewallPolicyValue,
 } from "@vm0/connectors/firewall-types";
 import {
   getConnectorFirewall,
   isFirewallConnectorType,
+  resolveFirewallPolicies,
 } from "@vm0/connectors/firewalls";
 import { delay } from "signal-timers";
 import { zeroClient$ } from "../api-client.ts";
@@ -237,24 +239,35 @@ export const userPermissionGrantsEnabled$ = computed((get) => {
   return get(featureSwitch$)[FeatureSwitchKey.UserPermissionGrants] ?? false;
 });
 
-function findMatchingUserPermissionGrant(
+export function userPermissionGrantsToFirewallPolicies(
+  grants: readonly UserPermissionGrantResponse[],
+): FirewallPolicies | null {
+  const policies: FirewallPolicies = {};
+  for (const grant of grants) {
+    const current = policies[grant.connectorRef] ?? { policies: {} };
+    if (grant.permission === UNKNOWN_PERMISSION_GRANT) {
+      policies[grant.connectorRef] = {
+        ...current,
+        unknownPolicy: grant.action,
+      };
+      continue;
+    }
+    current.policies[grant.permission] = grant.action;
+    policies[grant.connectorRef] = current;
+  }
+  return Object.keys(policies).length > 0 ? policies : null;
+}
+
+export function resolveUserPermissionGrantPolicy(
   grants: readonly UserPermissionGrantResponse[],
   connectorRef: string,
   permission: string,
-  action: UserPermissionGrantAction,
-): UserPermissionGrantResponse | null {
-  return (
-    grants.find((grant) => {
-      return (
-        grant.connectorRef === connectorRef &&
-        grant.permission === permission &&
-        grant.action === action
-      );
-    }) ?? null
-  );
+): FirewallPolicyValue | undefined {
+  return resolveFirewallPolicies(
+    userPermissionGrantsToFirewallPolicies(grants),
+    [connectorRef],
+  )?.[connectorRef]?.policies[permission];
 }
-
-export { findMatchingUserPermissionGrant };
 
 async function listUserPermissionGrants(
   get: <T>(atom: Computed<T>) => T,

--- a/turbo/apps/platform/src/signals/permission-allow/permission-allow-signals.ts
+++ b/turbo/apps/platform/src/signals/permission-allow/permission-allow-signals.ts
@@ -414,6 +414,7 @@ export const upsertUserPermissionGrant$ = command(
           ...params,
           ttlSeconds: USER_PERMISSION_GRANT_TTL_SECONDS,
         },
+        fetchOptions: { signal },
       }),
       [200],
     );

--- a/turbo/apps/platform/src/signals/permission-allow/permission-allow-signals.ts
+++ b/turbo/apps/platform/src/signals/permission-allow/permission-allow-signals.ts
@@ -5,6 +5,11 @@ import {
   permissionAccessRequestsResolveContract,
   zeroAgentPermissionPoliciesContract,
 } from "@vm0/api-contracts/contracts/zero-agents";
+import {
+  type UserPermissionGrantAction,
+  type UserPermissionGrantResponse,
+  zeroUserPermissionGrantsContract,
+} from "@vm0/api-contracts/contracts/zero-user-permission-grants";
 import type {
   FirewallPolicies,
   FirewallPolicyValue,
@@ -19,9 +24,13 @@ import { pathParams$, searchParams$, replaceSearchParams$ } from "../route.ts";
 import { setAblyLoop$ } from "../realtime.ts";
 import { accept } from "../../lib/accept.ts";
 import { agentById, reloadAgentById$ } from "../agent.ts";
+import { featureSwitch$ } from "../external/feature-switch.ts";
+import { FeatureSwitchKey } from "@vm0/connectors/feature-switch-key";
 
 const PERMISSION_ACCESS_REQUESTS_CHANGED_TOPIC =
   "permissionAccessRequestsChanged";
+
+const USER_PERMISSION_GRANT_TTL_SECONDS = 86_400;
 
 // ---------------------------------------------------------------------------
 // Route params
@@ -110,6 +119,7 @@ export function extractPermissions(ref: string): Permission[] {
 // ---------------------------------------------------------------------------
 
 const internalRequestsReload$ = state(0);
+const internalUserPermissionGrantsReload$ = state(0);
 
 type PermissionRequestAction = "allow" | "deny";
 
@@ -158,6 +168,9 @@ export const permissionRequestById$ = computed(async (get) => {
 /** Find existing request for same agent+ref+permission (doctor mode, member redirect) */
 export const permissionExistingRequest$ = computed(async (get) => {
   get(internalRequestsReload$);
+  if (get(userPermissionGrantsEnabled$)) {
+    return null;
+  }
   const agentId = get(permissionAllowAgentId$);
   const ref = get(permissionAllowRef$);
   const permission = get(permissionAllowPermission$);
@@ -217,6 +230,88 @@ function createPermissionExistingRequestByActionFactory(): (
 
 export const permissionExistingRequestByAction =
   createPermissionExistingRequestByActionFactory();
+
+// ---------------------------------------------------------------------------
+// Current-user permission grants
+// ---------------------------------------------------------------------------
+
+export const userPermissionGrantsEnabled$ = computed((get) => {
+  return get(featureSwitch$)[FeatureSwitchKey.UserPermissionGrants] ?? false;
+});
+
+function findMatchingUserPermissionGrant(
+  grants: readonly UserPermissionGrantResponse[],
+  connectorRef: string,
+  permission: string,
+  action: UserPermissionGrantAction,
+): UserPermissionGrantResponse | null {
+  return (
+    grants.find((grant) => {
+      return (
+        grant.connectorRef === connectorRef &&
+        grant.permission === permission &&
+        grant.action === action
+      );
+    }) ?? null
+  );
+}
+
+export { findMatchingUserPermissionGrant };
+
+async function listUserPermissionGrants(
+  get: <T>(atom: Computed<T>) => T,
+  agentId: string,
+): Promise<readonly UserPermissionGrantResponse[]> {
+  const client = get(zeroClient$)(zeroUserPermissionGrantsContract);
+  const result = await accept(client.list({ query: { agentId } }), [200]);
+  return result.body;
+}
+
+export const permissionAllowUserPermissionGrants$ = computed(async (get) => {
+  get(internalUserPermissionGrantsReload$);
+  if (!get(userPermissionGrantsEnabled$)) {
+    return [];
+  }
+  const agentId = get(permissionAllowAgentId$);
+  const requestId = get(permissionAllowRequestId$);
+  if (!agentId || requestId) {
+    return [];
+  }
+  return await listUserPermissionGrants(get, agentId);
+});
+
+interface UserPermissionGrantsByAgentParams {
+  agentId: string;
+  enabled: boolean;
+}
+
+function createUserPermissionGrantsByAgentFactory(): (
+  params: UserPermissionGrantsByAgentParams,
+) => Computed<Promise<readonly UserPermissionGrantResponse[]>> {
+  const cache = new Map<
+    string,
+    Computed<Promise<readonly UserPermissionGrantResponse[]>>
+  >();
+  return (params) => {
+    const key = JSON.stringify(params);
+    const existing = cache.get(key);
+    if (existing) {
+      return existing;
+    }
+    const atom$ = computed(async (get) => {
+      get(internalUserPermissionGrantsReload$);
+      if (!params.enabled) {
+        return [];
+      }
+      return await listUserPermissionGrants(get, params.agentId);
+    });
+    cache.set(key, atom$);
+    return atom$;
+  };
+}
+
+export const userPermissionGrantsByAgent =
+  createUserPermissionGrantsByAgentFactory();
 
 // ---------------------------------------------------------------------------
 // URL: update request ID in URL
@@ -298,6 +393,34 @@ const createAccessRequest$ = command(
       return prev + 1;
     });
     return result.body.id;
+  },
+);
+
+export const upsertUserPermissionGrant$ = command(
+  async (
+    { get, set },
+    params: {
+      agentId: string;
+      connectorRef: string;
+      permission: string;
+      action: UserPermissionGrantAction;
+    },
+    signal: AbortSignal,
+  ): Promise<void> => {
+    const client = get(zeroClient$)(zeroUserPermissionGrantsContract);
+    await accept(
+      client.upsert({
+        body: {
+          ...params,
+          ttlSeconds: USER_PERMISSION_GRANT_TTL_SECONDS,
+        },
+      }),
+      [200],
+    );
+    signal.throwIfAborted();
+    set(internalUserPermissionGrantsReload$, (prev) => {
+      return prev + 1;
+    });
   },
 );
 

--- a/turbo/apps/platform/src/signals/permission-allow/permission-allow-signals.ts
+++ b/turbo/apps/platform/src/signals/permission-allow/permission-allow-signals.ts
@@ -10,14 +10,14 @@ import {
   type UserPermissionGrantResponse,
   zeroUserPermissionGrantsContract,
 } from "@vm0/api-contracts/contracts/zero-user-permission-grants";
-import {
-  UNKNOWN_PERMISSION_GRANT,
-  type FirewallPolicies,
-  type FirewallPolicyValue,
+import type {
+  FirewallPolicies,
+  FirewallPolicyValue,
 } from "@vm0/connectors/firewall-types";
 import {
   getConnectorFirewall,
   isFirewallConnectorType,
+  permissionGrantsToFirewallPolicies,
   resolveFirewallPolicies,
 } from "@vm0/connectors/firewalls";
 import { delay } from "signal-timers";
@@ -239,34 +239,14 @@ export const userPermissionGrantsEnabled$ = computed((get) => {
   return get(featureSwitch$)[FeatureSwitchKey.UserPermissionGrants] ?? false;
 });
 
-export function userPermissionGrantsToFirewallPolicies(
-  grants: readonly UserPermissionGrantResponse[],
-): FirewallPolicies | null {
-  const policies: FirewallPolicies = {};
-  for (const grant of grants) {
-    const current = policies[grant.connectorRef] ?? { policies: {} };
-    if (grant.permission === UNKNOWN_PERMISSION_GRANT) {
-      policies[grant.connectorRef] = {
-        ...current,
-        unknownPolicy: grant.action,
-      };
-      continue;
-    }
-    current.policies[grant.permission] = grant.action;
-    policies[grant.connectorRef] = current;
-  }
-  return Object.keys(policies).length > 0 ? policies : null;
-}
-
 export function resolveUserPermissionGrantPolicy(
   grants: readonly UserPermissionGrantResponse[],
   connectorRef: string,
   permission: string,
 ): FirewallPolicyValue | undefined {
-  return resolveFirewallPolicies(
-    userPermissionGrantsToFirewallPolicies(grants),
-    [connectorRef],
-  )?.[connectorRef]?.policies[permission];
+  return resolveFirewallPolicies(permissionGrantsToFirewallPolicies(grants), [
+    connectorRef,
+  ])?.[connectorRef]?.policies[permission];
 }
 
 async function listUserPermissionGrants(

--- a/turbo/apps/platform/src/views/permission-allow/__tests__/permission-allow-page-interaction.test.tsx
+++ b/turbo/apps/platform/src/views/permission-allow/__tests__/permission-allow-page-interaction.test.tsx
@@ -295,7 +295,7 @@ describe("permission allow page - self-service user grants", () => {
 
     detachedSetupPage({
       context,
-      path: `/agents/${AGENT_ID}/permissions?ref=slack&permission=channels:read&action=allow`,
+      path: `/agents/${AGENT_ID}/permissions?ref=slack&permission=channels:write&action=allow`,
       featureSwitches: { [FeatureSwitchKey.UserPermissionGrants]: true },
     });
 
@@ -317,11 +317,48 @@ describe("permission allow page - self-service user grants", () => {
     expect(grantBody).toMatchObject({
       agentId: AGENT_ID,
       connectorRef: "slack",
-      permission: "channels:read",
+      permission: "channels:write",
       action: "allow",
     });
     expect(requestCreated).toBeFalsy();
     expect(requestsListed).toBeFalsy();
+  });
+
+  it("uses default connector policies for already-applied state when the feature is enabled", async () => {
+    let grantCalled = false;
+    let requestCreated = false;
+    server.use(
+      mockApi(zeroUserPermissionGrantsContract.upsert, ({ body, respond }) => {
+        grantCalled = true;
+        return respond(
+          200,
+          createMockUserPermissionGrantResponse({
+            agentId: body.agentId,
+            connectorRef: body.connectorRef,
+            permission: body.permission,
+            action: body.action,
+          }),
+        );
+      }),
+      mockApi(permissionAccessRequestsCreateContract.create, ({ respond }) => {
+        requestCreated = true;
+        return respond(201, pendingRequest());
+      }),
+    );
+    setupMemberContext();
+
+    detachedSetupPage({
+      context,
+      path: `/agents/${AGENT_ID}/permissions?ref=slack&permission=channels:read&action=allow`,
+      featureSwitches: { [FeatureSwitchKey.UserPermissionGrants]: true },
+    });
+
+    await waitFor(() => {
+      expect(screen.getByText("Permissions updated")).toBeInTheDocument();
+    });
+    expect(screen.queryByText("Confirm")).not.toBeInTheDocument();
+    expect(grantCalled).toBeFalsy();
+    expect(requestCreated).toBeFalsy();
   });
 
   it("uses current-user grants for already-applied state when the feature is enabled", async () => {

--- a/turbo/apps/platform/src/views/permission-allow/__tests__/permission-allow-page-interaction.test.tsx
+++ b/turbo/apps/platform/src/views/permission-allow/__tests__/permission-allow-page-interaction.test.tsx
@@ -265,7 +265,7 @@ describe("permission allow page - self-service user grants", () => {
     expect(policyCalled).toBeFalsy();
   });
 
-  it("writes a current-user grant for members without creating an approval request", async () => {
+  it("writes a current-user grant for members without showing approval request UI", async () => {
     let grantBody: unknown;
     let requestCreated = false;
     let requestsListed = false;
@@ -300,13 +300,15 @@ describe("permission allow page - self-service user grants", () => {
     });
 
     await waitFor(() => {
-      expect(screen.getByText("Request approval")).toBeInTheDocument();
+      expect(screen.getByText("Confirm")).toBeInTheDocument();
     });
 
+    expect(screen.queryByText("Request approval")).not.toBeInTheDocument();
+    expect(screen.queryByText("Reasons for request")).not.toBeInTheDocument();
     expect(screen.queryByText(/temporary/i)).not.toBeInTheDocument();
     expect(screen.queryByText(/permanent/i)).not.toBeInTheDocument();
 
-    click(screen.getByText("Request approval"));
+    click(screen.getByText("Confirm"));
 
     await waitFor(() => {
       expect(grantBody).toBeDefined();

--- a/turbo/apps/platform/src/views/permission-allow/__tests__/permission-allow-page-interaction.test.tsx
+++ b/turbo/apps/platform/src/views/permission-allow/__tests__/permission-allow-page-interaction.test.tsx
@@ -23,9 +23,15 @@ import {
   permissionAccessRequestsResolveContract,
   permissionAccessRequestsCreateContract,
 } from "@vm0/api-contracts/contracts/zero-agents";
+import { zeroUserPermissionGrantsContract } from "@vm0/api-contracts/contracts/zero-user-permission-grants";
+import { FeatureSwitchKey } from "@vm0/connectors/feature-switch-key";
 import { createMockApi } from "../../../mocks/msw-contract.ts";
 import { setMockPermissionRequests } from "../../../mocks/handlers/api-permission-access-requests.ts";
 import { setMockOrg } from "../../../mocks/handlers/api-org.ts";
+import {
+  createMockUserPermissionGrantResponse,
+  setMockUserPermissionGrants,
+} from "../../../mocks/handlers/api-user-permission-grants.ts";
 
 const context = testContext();
 const mockApi = createMockApi(context);
@@ -206,6 +212,143 @@ describe("permission allow page - admin doctor mode", () => {
     await waitFor(() => {
       expect(screen.getByText("Permissions denied")).toBeInTheDocument();
     });
+  });
+});
+
+describe("permission allow page - self-service user grants", () => {
+  it("writes a current-user grant for admins when the feature is enabled", async () => {
+    let grantBody: unknown;
+    let policyCalled = false;
+    server.use(
+      mockApi(zeroUserPermissionGrantsContract.upsert, ({ body, respond }) => {
+        grantBody = body;
+        return respond(
+          200,
+          createMockUserPermissionGrantResponse({
+            agentId: body.agentId,
+            connectorRef: body.connectorRef,
+            permission: body.permission,
+            action: body.action,
+          }),
+        );
+      }),
+      mockApi(zeroAgentPermissionPoliciesContract.update, ({ respond }) => {
+        policyCalled = true;
+        return respond(200, defaultAgentResponse());
+      }),
+    );
+    mockAgent();
+    mockPermissionRequests();
+
+    detachedSetupPage({
+      context,
+      path: `/agents/${AGENT_ID}/permissions?ref=slack&permission=channels:read&action=deny`,
+      featureSwitches: { [FeatureSwitchKey.UserPermissionGrants]: true },
+    });
+
+    await waitFor(() => {
+      expect(screen.getByText("Confirm")).toBeInTheDocument();
+    });
+
+    click(screen.getByText("Confirm"));
+
+    await waitFor(() => {
+      expect(grantBody).toBeDefined();
+    });
+
+    expect(grantBody).toMatchObject({
+      agentId: AGENT_ID,
+      connectorRef: "slack",
+      permission: "channels:read",
+      action: "deny",
+      ttlSeconds: 86_400,
+    });
+    expect(policyCalled).toBeFalsy();
+  });
+
+  it("writes a current-user grant for members without creating an approval request", async () => {
+    let grantBody: unknown;
+    let requestCreated = false;
+    let requestsListed = false;
+    server.use(
+      mockApi(zeroUserPermissionGrantsContract.upsert, ({ body, respond }) => {
+        grantBody = body;
+        return respond(
+          200,
+          createMockUserPermissionGrantResponse({
+            agentId: body.agentId,
+            connectorRef: body.connectorRef,
+            permission: body.permission,
+            action: body.action,
+          }),
+        );
+      }),
+      mockApi(permissionAccessRequestsCreateContract.create, ({ respond }) => {
+        requestCreated = true;
+        return respond(201, pendingRequest());
+      }),
+      mockApi(permissionAccessRequestsListContract.list, ({ respond }) => {
+        requestsListed = true;
+        return respond(200, []);
+      }),
+    );
+    setupMemberContext();
+
+    detachedSetupPage({
+      context,
+      path: `/agents/${AGENT_ID}/permissions?ref=slack&permission=channels:read&action=allow`,
+      featureSwitches: { [FeatureSwitchKey.UserPermissionGrants]: true },
+    });
+
+    await waitFor(() => {
+      expect(screen.getByText("Request approval")).toBeInTheDocument();
+    });
+
+    expect(screen.queryByText(/temporary/i)).not.toBeInTheDocument();
+    expect(screen.queryByText(/permanent/i)).not.toBeInTheDocument();
+
+    click(screen.getByText("Request approval"));
+
+    await waitFor(() => {
+      expect(grantBody).toBeDefined();
+    });
+
+    expect(grantBody).toMatchObject({
+      agentId: AGENT_ID,
+      connectorRef: "slack",
+      permission: "channels:read",
+      action: "allow",
+      ttlSeconds: 86_400,
+    });
+    expect(requestCreated).toBeFalsy();
+    expect(requestsListed).toBeFalsy();
+  });
+
+  it("uses current-user grants for already-applied state when the feature is enabled", async () => {
+    setupMemberContext({
+      permissionPolicies: {
+        slack: { policies: { "channels:read": "allow" } },
+      },
+    });
+    setMockUserPermissionGrants([
+      createMockUserPermissionGrantResponse({
+        agentId: AGENT_ID,
+        connectorRef: "slack",
+        permission: "channels:read",
+        action: "deny",
+      }),
+    ]);
+
+    detachedSetupPage({
+      context,
+      path: `/agents/${AGENT_ID}/permissions?ref=slack&permission=channels:read&action=deny`,
+      featureSwitches: { [FeatureSwitchKey.UserPermissionGrants]: true },
+    });
+
+    await waitFor(() => {
+      expect(screen.getByText("Permissions denied")).toBeInTheDocument();
+    });
+    expect(screen.queryByText("Request approval")).not.toBeInTheDocument();
   });
 });
 

--- a/turbo/apps/platform/src/views/permission-allow/__tests__/permission-allow-page-interaction.test.tsx
+++ b/turbo/apps/platform/src/views/permission-allow/__tests__/permission-allow-page-interaction.test.tsx
@@ -261,7 +261,6 @@ describe("permission allow page - self-service user grants", () => {
       connectorRef: "slack",
       permission: "channels:read",
       action: "deny",
-      ttlSeconds: 86_400,
     });
     expect(policyCalled).toBeFalsy();
   });
@@ -318,7 +317,6 @@ describe("permission allow page - self-service user grants", () => {
       connectorRef: "slack",
       permission: "channels:read",
       action: "allow",
-      ttlSeconds: 86_400,
     });
     expect(requestCreated).toBeFalsy();
     expect(requestsListed).toBeFalsy();

--- a/turbo/apps/platform/src/views/permission-allow/permission-allow-page.tsx
+++ b/turbo/apps/platform/src/views/permission-allow/permission-allow-page.tsx
@@ -708,10 +708,9 @@ function DoctorMemberRequestCard({
           <button
             type="button"
             onClick={onSubmit}
-            disabled={submitting}
             className="h-9 w-full rounded-[10px] bg-[#ED4E01] hover:bg-[#d44500] text-white font-medium text-sm transition-colors disabled:opacity-50"
           >
-            {submitting ? "Submitting..." : "Request approval"}
+            Request approval
           </button>
         </div>
       </div>

--- a/turbo/apps/platform/src/views/permission-allow/permission-allow-page.tsx
+++ b/turbo/apps/platform/src/views/permission-allow/permission-allow-page.tsx
@@ -580,6 +580,7 @@ function DoctorAdminConfirmCard({
   agentDisplayName,
   agentAvatarUrl,
   userName,
+  message,
   ref,
   permission,
   action,
@@ -589,6 +590,7 @@ function DoctorAdminConfirmCard({
   agentDisplayName: string;
   agentAvatarUrl: string | null;
   userName: string;
+  message?: string;
   ref: string;
   permission: { name: string; description?: string };
   action: "allow" | "deny";
@@ -602,7 +604,8 @@ function DoctorAdminConfirmCard({
 
         <div className="flex w-[500px] max-w-[calc(100vw-96px)] flex-col items-center gap-4 px-[26px]">
           <p className="text-center text-lg font-medium leading-7 text-foreground">
-            {`Hey ${userName}, you are going to change ${agentDisplayName}'s permissions.`}
+            {message ??
+              `Hey ${userName}, you are going to change ${agentDisplayName}'s permissions.`}
           </p>
 
           <AgentPill
@@ -804,17 +807,16 @@ function DoctorModeView({
     }
 
     return (
-      <DoctorMemberRequestCard
+      <DoctorAdminConfirmCard
         agentDisplayName={agentDisplayName}
         agentAvatarUrl={agent.avatarUrl}
         userName={userName}
+        message={`Hey ${userName}, you're updating your permissions for ${agentDisplayName}.`}
         ref={ref}
         permission={permission}
         action={action}
-        reason={reason}
-        submitting={grantSaving}
-        onSubmit={handleGrantSave}
-        onReasonChange={setReasonValue}
+        saving={grantSaving}
+        onSave={handleGrantSave}
       />
     );
   }

--- a/turbo/apps/platform/src/views/permission-allow/permission-allow-page.tsx
+++ b/turbo/apps/platform/src/views/permission-allow/permission-allow-page.tsx
@@ -18,6 +18,7 @@ import {
 } from "@vm0/connectors/firewalls";
 import { CONNECTOR_TYPES } from "@vm0/connectors/connectors";
 import type { FirewallPolicies } from "@vm0/connectors/firewall-types";
+import type { UserPermissionGrantResponse } from "@vm0/api-contracts/contracts/zero-user-permission-grants";
 import { user$ } from "../../signals/auth.ts";
 import { isOrgAdmin$ } from "../../signals/org.ts";
 import {
@@ -41,6 +42,10 @@ import {
   reason$,
   setReason$,
   submitAccessRequest$,
+  permissionAllowUserPermissionGrants$,
+  userPermissionGrantsEnabled$,
+  findMatchingUserPermissionGrant,
+  upsertUserPermissionGrant$,
 } from "../../signals/permission-allow/permission-allow-signals.ts";
 import { ConnectorIcon } from "../zero-page/components/settings/connector-icons.tsx";
 import { AvatarFromUrl } from "../zero-page/zero-sidebar-shared.tsx";
@@ -571,6 +576,146 @@ function RequestModeView() {
 // Doctor mode (no ?request param)
 // ---------------------------------------------------------------------------
 
+function DoctorAdminConfirmCard({
+  agentDisplayName,
+  agentAvatarUrl,
+  userName,
+  ref,
+  permission,
+  action,
+  saving,
+  onSave,
+}: {
+  agentDisplayName: string;
+  agentAvatarUrl: string | null;
+  userName: string;
+  ref: string;
+  permission: { name: string; description?: string };
+  action: "allow" | "deny";
+  saving: boolean;
+  onSave: () => void;
+}) {
+  return (
+    <div className="fixed inset-0 z-10 flex items-center justify-center pointer-events-none">
+      <div className="pointer-events-auto flex flex-col items-center gap-10 rounded-[20px] border border-border bg-background px-6 py-12">
+        <VM0Logo />
+
+        <div className="flex w-[500px] max-w-[calc(100vw-96px)] flex-col items-center gap-4 px-[26px]">
+          <p className="text-center text-lg font-medium leading-7 text-foreground">
+            {`Hey ${userName}, you are going to change ${agentDisplayName}'s permissions.`}
+          </p>
+
+          <AgentPill
+            avatarUrl={agentAvatarUrl}
+            displayName={agentDisplayName}
+          />
+
+          <div className="w-full flex flex-col gap-3">
+            <p className="text-sm font-medium text-foreground">Would like to</p>
+            <ConnectorPermissionCard
+              connectorRef={ref}
+              permission={permission}
+              action={action}
+            />
+          </div>
+        </div>
+
+        <div className="w-[500px] max-w-[calc(100vw-96px)] px-[26px]">
+          <button
+            type="button"
+            onClick={onSave}
+            disabled={saving}
+            className="h-9 w-full rounded-[10px] bg-[#ED4E01] hover:bg-[#d44500] text-white font-medium text-sm transition-colors disabled:opacity-50"
+          >
+            {saving ? "Saving..." : "Confirm"}
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+function DoctorMemberRequestCard({
+  agentDisplayName,
+  agentAvatarUrl,
+  userName,
+  ref,
+  permission,
+  action,
+  reason,
+  submitting,
+  onSubmit,
+  onReasonChange,
+}: {
+  agentDisplayName: string;
+  agentAvatarUrl: string | null;
+  userName: string;
+  ref: string;
+  permission: { name: string; description?: string };
+  action: "allow" | "deny";
+  reason: string;
+  submitting: boolean;
+  onSubmit: () => void;
+  onReasonChange: (value: string) => void;
+}) {
+  if (submitting) {
+    return <LoadingCard />;
+  }
+
+  return (
+    <div className="fixed inset-0 z-10 flex items-center justify-center pointer-events-none">
+      <div className="pointer-events-auto flex flex-col items-center gap-10 rounded-[20px] border border-border bg-background px-6 py-12">
+        <VM0Logo />
+
+        <div className="flex w-[500px] max-w-[calc(100vw-96px)] flex-col items-center gap-4 px-[26px]">
+          <p className="text-center text-lg font-medium leading-7 text-foreground">
+            {`Hey ${userName}, you're requesting approval to update ${agentDisplayName}'s permissions.`}
+          </p>
+
+          <AgentPill
+            avatarUrl={agentAvatarUrl}
+            displayName={agentDisplayName}
+          />
+
+          <div className="w-full flex flex-col gap-3">
+            <p className="text-sm font-medium text-foreground">Would like to</p>
+            <ConnectorPermissionCard
+              connectorRef={ref}
+              permission={permission}
+              action={action}
+            />
+          </div>
+
+          <div className="w-full flex flex-col gap-3">
+            <p className="text-sm font-medium text-foreground">
+              Reasons for request
+            </p>
+            <textarea
+              placeholder="I need this permission to run the task with this agent as part of a required compliance project."
+              value={reason}
+              onChange={(e) => {
+                return onReasonChange(e.target.value);
+              }}
+              className="text-sm w-full h-[100px] rounded-lg border border-input bg-background px-3 py-2 placeholder:text-muted-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring resize-y"
+            />
+          </div>
+        </div>
+
+        <div className="w-[500px] max-w-[calc(100vw-96px)] px-[26px]">
+          <button
+            type="button"
+            onClick={onSubmit}
+            disabled={submitting}
+            className="h-9 w-full rounded-[10px] bg-[#ED4E01] hover:bg-[#d44500] text-white font-medium text-sm transition-colors disabled:opacity-50"
+          >
+            {submitting ? "Submitting..." : "Request approval"}
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}
+
 function DoctorModeView({
   agentId,
   ref,
@@ -579,6 +724,8 @@ function DoctorModeView({
   method,
   path,
   canManagePermissions,
+  userPermissionGrantsEnabled,
+  userPermissionGrants,
   agent,
   userName,
 }: {
@@ -589,6 +736,8 @@ function DoctorModeView({
   method: string | null;
   path: string | null;
   canManagePermissions: boolean;
+  userPermissionGrantsEnabled: boolean;
+  userPermissionGrants: readonly UserPermissionGrantResponse[];
   agent: {
     permissionPolicies: FirewallPolicies | null;
     displayName: string | null;
@@ -599,12 +748,76 @@ function DoctorModeView({
   const pageSignal = useGet(pageSignal$);
   const [saveLoadable, savePolicies] = useLoadableSet(saveAdminFocusedPolicy$);
   const [submitLoadable, submitRequest] = useLoadableSet(submitAccessRequest$);
+  const [grantLoadable, upsertGrant] = useLoadableSet(
+    upsertUserPermissionGrant$,
+  );
   const reason = useGet(reason$);
   const setReasonValue = useSet(setReason$);
 
   const saving = saveLoadable.state === "loading";
   const submitting = submitLoadable.state === "loading";
+  const grantSaving = grantLoadable.state === "loading";
   const agentDisplayName = agent.displayName ?? agentId;
+  const resultCard =
+    action === "allow" ? <PermissionsUpdatedCard /> : <PermissionsDeniedCard />;
+
+  const handleGrantSave = () => {
+    detach(
+      upsertGrant(
+        {
+          agentId,
+          connectorRef: ref,
+          permission: permission.name,
+          action,
+        },
+        pageSignal,
+      ),
+      Reason.DomCallback,
+    );
+  };
+
+  if (userPermissionGrantsEnabled) {
+    const grantApplied = findMatchingUserPermissionGrant(
+      userPermissionGrants,
+      ref,
+      permission.name,
+      action,
+    );
+
+    if (grantApplied || grantLoadable.state === "hasData") {
+      return resultCard;
+    }
+
+    if (canManagePermissions) {
+      return (
+        <DoctorAdminConfirmCard
+          agentDisplayName={agentDisplayName}
+          agentAvatarUrl={agent.avatarUrl}
+          userName={userName}
+          ref={ref}
+          permission={permission}
+          action={action}
+          saving={grantSaving}
+          onSave={handleGrantSave}
+        />
+      );
+    }
+
+    return (
+      <DoctorMemberRequestCard
+        agentDisplayName={agentDisplayName}
+        agentAvatarUrl={agent.avatarUrl}
+        userName={userName}
+        ref={ref}
+        permission={permission}
+        action={action}
+        reason={reason}
+        submitting={grantSaving}
+        onSubmit={handleGrantSave}
+        onReasonChange={setReasonValue}
+      />
+    );
+  }
 
   // Check effective policy
   const resolved = resolveFirewallPolicies(agent.permissionPolicies, [ref]);
@@ -612,11 +825,7 @@ function DoctorModeView({
 
   // Policy already matches — show result
   if (effectivePolicy === action) {
-    return action === "allow" ? (
-      <PermissionsUpdatedCard />
-    ) : (
-      <PermissionsDeniedCard />
-    );
+    return resultCard;
   }
 
   // Policy doesn't match — admin: confirm card
@@ -638,52 +847,20 @@ function DoctorModeView({
     };
 
     if (saveLoadable.state === "hasData") {
-      return action === "allow" ? (
-        <PermissionsUpdatedCard />
-      ) : (
-        <PermissionsDeniedCard />
-      );
+      return resultCard;
     }
 
     return (
-      <div className="fixed inset-0 z-10 flex items-center justify-center pointer-events-none">
-        <div className="pointer-events-auto flex flex-col items-center gap-10 rounded-[20px] border border-border bg-background px-6 py-12">
-          <VM0Logo />
-
-          <div className="flex w-[500px] max-w-[calc(100vw-96px)] flex-col items-center gap-4 px-[26px]">
-            <p className="text-center text-lg font-medium leading-7 text-foreground">
-              {`Hey ${userName}, you are going to change ${agentDisplayName}'s permissions.`}
-            </p>
-
-            <AgentPill
-              avatarUrl={agent.avatarUrl}
-              displayName={agentDisplayName}
-            />
-
-            <div className="w-full flex flex-col gap-3">
-              <p className="text-sm font-medium text-foreground">
-                Would like to
-              </p>
-              <ConnectorPermissionCard
-                connectorRef={ref}
-                permission={permission}
-                action={action}
-              />
-            </div>
-          </div>
-
-          <div className="w-[500px] max-w-[calc(100vw-96px)] px-[26px]">
-            <button
-              type="button"
-              onClick={handleSave}
-              disabled={saving}
-              className="h-9 w-full rounded-[10px] bg-[#ED4E01] hover:bg-[#d44500] text-white font-medium text-sm transition-colors disabled:opacity-50"
-            >
-              {saving ? "Saving..." : "Confirm"}
-            </button>
-          </div>
-        </div>
-      </div>
+      <DoctorAdminConfirmCard
+        agentDisplayName={agentDisplayName}
+        agentAvatarUrl={agent.avatarUrl}
+        userName={userName}
+        ref={ref}
+        permission={permission}
+        action={action}
+        saving={saving}
+        onSave={handleSave}
+      />
     );
   }
 
@@ -711,56 +888,18 @@ function DoctorModeView({
   };
 
   return (
-    <div className="fixed inset-0 z-10 flex items-center justify-center pointer-events-none">
-      <div className="pointer-events-auto flex flex-col items-center gap-10 rounded-[20px] border border-border bg-background px-6 py-12">
-        <VM0Logo />
-
-        <div className="flex w-[500px] max-w-[calc(100vw-96px)] flex-col items-center gap-4 px-[26px]">
-          <p className="text-center text-lg font-medium leading-7 text-foreground">
-            {`Hey ${userName}, you're requesting approval to update ${agentDisplayName}'s permissions.`}
-          </p>
-
-          <AgentPill
-            avatarUrl={agent.avatarUrl}
-            displayName={agentDisplayName}
-          />
-
-          <div className="w-full flex flex-col gap-3">
-            <p className="text-sm font-medium text-foreground">Would like to</p>
-            <ConnectorPermissionCard
-              connectorRef={ref}
-              permission={permission}
-              action={action}
-            />
-          </div>
-
-          <div className="w-full flex flex-col gap-3">
-            <p className="text-sm font-medium text-foreground">
-              Reasons for request
-            </p>
-            <textarea
-              placeholder="I need this permission to run the task with this agent as part of a required compliance project."
-              value={reason}
-              onChange={(e) => {
-                return setReasonValue(e.target.value);
-              }}
-              className="text-sm w-full h-[100px] rounded-lg border border-input bg-background px-3 py-2 placeholder:text-muted-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring resize-y"
-            />
-          </div>
-        </div>
-
-        <div className="w-[500px] max-w-[calc(100vw-96px)] px-[26px]">
-          <button
-            type="button"
-            onClick={handleSubmit}
-            disabled={submitting}
-            className="h-9 w-full rounded-[10px] bg-[#ED4E01] hover:bg-[#d44500] text-white font-medium text-sm transition-colors disabled:opacity-50"
-          >
-            {submitting ? "Submitting..." : "Request approval"}
-          </button>
-        </div>
-      </div>
-    </div>
+    <DoctorMemberRequestCard
+      agentDisplayName={agentDisplayName}
+      agentAvatarUrl={agent.avatarUrl}
+      userName={userName}
+      ref={ref}
+      permission={permission}
+      action={action}
+      reason={reason}
+      submitting={submitting}
+      onSubmit={handleSubmit}
+      onReasonChange={setReasonValue}
+    />
   );
 }
 
@@ -817,6 +956,93 @@ function findPermission(
 // Main Page
 // ---------------------------------------------------------------------------
 
+function PermissionAllowDoctorPage({
+  agentId,
+  ref,
+  permission,
+  method,
+  path,
+  action,
+}: {
+  agentId: string;
+  ref: string;
+  permission: string;
+  method: string | null;
+  path: string | null;
+  action: "allow" | "deny";
+}) {
+  const agentLoadable = useLastLoadable(permissionAllowAgent$);
+  const userLoadable = useLastLoadable(user$);
+  const adminLoadable = useLoadable(isOrgAdmin$);
+  const existingRequestLoadable = useLoadable(permissionExistingRequest$);
+  const userPermissionGrantsEnabled = useGet(userPermissionGrantsEnabled$);
+  const userGrantsLoadable = useLoadable(permissionAllowUserPermissionGrants$);
+
+  if (
+    agentLoadable.state === "loading" ||
+    userLoadable.state === "loading" ||
+    adminLoadable.state === "loading" ||
+    (userPermissionGrantsEnabled && userGrantsLoadable.state === "loading")
+  ) {
+    return <LoadingCard />;
+  }
+
+  if (agentLoadable.state === "hasError") {
+    return <ErrorMessage message="Failed to load agent" />;
+  }
+  if (userPermissionGrantsEnabled && userGrantsLoadable.state === "hasError") {
+    return <ErrorMessage message="Failed to load permission grants" />;
+  }
+
+  const agent = agentLoadable.data;
+  if (!agent) {
+    return <ErrorMessage message="Agent not found" />;
+  }
+
+  const currentUser =
+    userLoadable.state === "hasData" ? userLoadable.data : undefined;
+  const isAdmin = adminLoadable.state === "hasData" && adminLoadable.data;
+  const canManagePermissions = isAdmin;
+  const userName = resolveUserName(currentUser);
+  const focusedPermission = findPermission(ref, permission);
+  const userPermissionGrants =
+    userGrantsLoadable.state === "hasData" ? userGrantsLoadable.data : [];
+
+  if (!focusedPermission) {
+    return <ErrorMessage message={`Unknown permission: ${permission}`} />;
+  }
+
+  // Member doctor mode: wait for existing-request check so page-setup
+  // can redirect to request mode before we render anything.
+  if (
+    !userPermissionGrantsEnabled &&
+    !canManagePermissions &&
+    existingRequestLoadable.state === "loading"
+  ) {
+    return <LoadingCard />;
+  }
+
+  return (
+    <DoctorModeView
+      agentId={agentId}
+      ref={ref}
+      permission={focusedPermission}
+      action={action}
+      method={method}
+      path={path}
+      canManagePermissions={canManagePermissions}
+      userPermissionGrantsEnabled={userPermissionGrantsEnabled}
+      userPermissionGrants={userPermissionGrants}
+      agent={{
+        permissionPolicies: agent.permissionPolicies,
+        displayName: agent.displayName,
+        avatarUrl: agent.avatarUrl,
+      }}
+      userName={userName}
+    />
+  );
+}
+
 export function PermissionAllowPage() {
   const agentId = useGet(permissionAllowAgentId$);
   const ref = useGet(permissionAllowRef$);
@@ -825,11 +1051,6 @@ export function PermissionAllowPage() {
   const path = useGet(permissionAllowPath$);
   const action = useGet(permissionAllowAction$);
   const requestId = useGet(permissionAllowRequestId$);
-
-  const agentLoadable = useLastLoadable(permissionAllowAgent$);
-  const userLoadable = useLastLoadable(user$);
-  const adminLoadable = useLoadable(isOrgAdmin$);
-  const existingRequestLoadable = useLoadable(permissionExistingRequest$);
 
   if (!agentId) {
     return <ErrorMessage message="Missing agent ID in URL parameters" />;
@@ -849,55 +1070,14 @@ export function PermissionAllowPage() {
     return <ErrorMessage message={`Unknown permission: ${ref}`} />;
   }
 
-  if (
-    agentLoadable.state === "loading" ||
-    userLoadable.state === "loading" ||
-    adminLoadable.state === "loading"
-  ) {
-    return <LoadingCard />;
-  }
-
-  if (agentLoadable.state === "hasError") {
-    return <ErrorMessage message="Failed to load agent" />;
-  }
-
-  const agent = agentLoadable.data;
-  if (!agent) {
-    return <ErrorMessage message="Agent not found" />;
-  }
-
-  const currentUser =
-    userLoadable.state === "hasData" ? userLoadable.data : undefined;
-  const isAdmin = adminLoadable.state === "hasData" && adminLoadable.data;
-  const canManagePermissions = isAdmin;
-  const userName = resolveUserName(currentUser);
-  const focusedPermission = findPermission(ref, permission);
-
-  if (!focusedPermission) {
-    return <ErrorMessage message={`Unknown permission: ${permission}`} />;
-  }
-
-  // Member doctor mode: wait for existing-request check so page-setup
-  // can redirect to request mode before we render anything.
-  if (!canManagePermissions && existingRequestLoadable.state === "loading") {
-    return <LoadingCard />;
-  }
-
   return (
-    <DoctorModeView
+    <PermissionAllowDoctorPage
       agentId={agentId}
       ref={ref}
-      permission={focusedPermission}
-      action={action ?? "allow"}
+      permission={permission}
       method={method}
       path={path}
-      canManagePermissions={canManagePermissions}
-      agent={{
-        permissionPolicies: agent.permissionPolicies,
-        displayName: agent.displayName,
-        avatarUrl: agent.avatarUrl,
-      }}
-      userName={userName}
+      action={action ?? "allow"}
     />
   );
 }

--- a/turbo/apps/platform/src/views/permission-allow/permission-allow-page.tsx
+++ b/turbo/apps/platform/src/views/permission-allow/permission-allow-page.tsx
@@ -44,7 +44,7 @@ import {
   submitAccessRequest$,
   permissionAllowUserPermissionGrants$,
   userPermissionGrantsEnabled$,
-  findMatchingUserPermissionGrant,
+  resolveUserPermissionGrantPolicy,
   upsertUserPermissionGrant$,
 } from "../../signals/permission-allow/permission-allow-signals.ts";
 import { ConnectorIcon } from "../zero-page/components/settings/connector-icons.tsx";
@@ -780,14 +780,13 @@ function DoctorModeView({
   };
 
   if (userPermissionGrantsEnabled) {
-    const grantApplied = findMatchingUserPermissionGrant(
+    const effectivePolicy = resolveUserPermissionGrantPolicy(
       userPermissionGrants,
       ref,
       permission.name,
-      action,
     );
 
-    if (grantApplied || grantLoadable.state === "hasData") {
+    if (effectivePolicy === action || grantLoadable.state === "hasData") {
       return resultCard;
     }
 

--- a/turbo/apps/platform/src/views/team-page/zero-job-detail-page.tsx
+++ b/turbo/apps/platform/src/views/team-page/zero-job-detail-page.tsx
@@ -99,6 +99,7 @@ import {
 import {
   upsertUserPermissionGrant$,
   userPermissionGrantsByAgent,
+  userPermissionGrantsToFirewallPolicies,
 } from "../../signals/permission-allow/permission-allow-signals.ts";
 import {
   allConnectorTypes$,
@@ -122,10 +123,7 @@ import {
   type FirewallPolicyValue,
 } from "@vm0/connectors/firewall-types";
 import { resolveFirewallPolicies } from "@vm0/connectors/firewalls";
-import type {
-  UserPermissionGrantAction,
-  UserPermissionGrantResponse,
-} from "@vm0/api-contracts/contracts/zero-user-permission-grants";
+import type { UserPermissionGrantAction } from "@vm0/api-contracts/contracts/zero-user-permission-grants";
 
 type UpsertUserPermissionGrant = (
   params: {
@@ -442,25 +440,6 @@ function userGrantAction(
     throw new Error("User permission grants do not support ask");
   }
   return policy;
-}
-
-function userGrantsToFirewallPolicies(
-  grants: readonly UserPermissionGrantResponse[],
-): FirewallPolicies | null {
-  const policies: FirewallPolicies = {};
-  for (const grant of grants) {
-    const current = policies[grant.connectorRef] ?? { policies: {} };
-    if (grant.permission === UNKNOWN_PERMISSION_GRANT) {
-      policies[grant.connectorRef] = {
-        ...current,
-        unknownPolicy: grant.action,
-      };
-      continue;
-    }
-    current.policies[grant.permission] = grant.action;
-    policies[grant.connectorRef] = current;
-  }
-  return Object.keys(policies).length > 0 ? policies : null;
 }
 
 function changedUserGrantPolicies({
@@ -821,7 +800,7 @@ function JobPermissionsTab({
   );
   const userGrantPolicies =
     userPermissionGrantsEnabled && userGrantsLoadable.state === "hasData"
-      ? userGrantsToFirewallPolicies(userGrantsLoadable.data)
+      ? userPermissionGrantsToFirewallPolicies(userGrantsLoadable.data)
       : null;
   const drawerInitialPolicies = userPermissionGrantsEnabled
     ? (userGrantPolicies ?? {})

--- a/turbo/apps/platform/src/views/team-page/zero-job-detail-page.tsx
+++ b/turbo/apps/platform/src/views/team-page/zero-job-detail-page.tsx
@@ -794,7 +794,7 @@ function JobPermissionsTab({
   const features = useLastResolved(featureSwitch$);
   const userPermissionGrantsEnabled =
     features?.[FeatureSwitchKey.UserPermissionGrants] ?? false;
-  const userGrantsLoadable = useLastLoadable(
+  const userGrantsLoadable = useLoadable(
     userPermissionGrantsByAgent({
       agentId,
       enabled: userPermissionGrantsEnabled,

--- a/turbo/apps/platform/src/views/team-page/zero-job-detail-page.tsx
+++ b/turbo/apps/platform/src/views/team-page/zero-job-detail-page.tsx
@@ -121,6 +121,7 @@ import {
   type FirewallPolicies,
   type FirewallPolicyValue,
 } from "@vm0/connectors/firewall-types";
+import { resolveFirewallPolicies } from "@vm0/connectors/firewalls";
 import type {
   UserPermissionGrantAction,
   UserPermissionGrantResponse,
@@ -462,51 +463,81 @@ function userGrantsToFirewallPolicies(
   return Object.keys(policies).length > 0 ? policies : null;
 }
 
+function changedUserGrantPolicies({
+  connectorType,
+  initialPolicies,
+  policies,
+}: {
+  connectorType: ConnectorType;
+  initialPolicies: FirewallPolicies;
+  policies: FirewallPolicies;
+}): {
+  readonly permission: string;
+  readonly action: UserPermissionGrantAction;
+}[] {
+  const initial = resolveFirewallPolicies(initialPolicies, [connectorType])?.[
+    connectorType
+  ];
+  const current = policies[connectorType];
+  const changes: {
+    permission: string;
+    action: UserPermissionGrantAction;
+  }[] = [];
+
+  for (const [permission, action] of Object.entries(current?.policies ?? {})) {
+    if (initial?.policies[permission] !== action) {
+      changes.push({ permission, action: userGrantAction(action) });
+    }
+  }
+
+  const unknownPolicy = current?.unknownPolicy;
+  if (unknownPolicy !== undefined && initial?.unknownPolicy !== unknownPolicy) {
+    changes.push({
+      permission: UNKNOWN_PERMISSION_GRANT,
+      action: userGrantAction(unknownPolicy),
+    });
+  }
+
+  return changes;
+}
+
 async function saveUserGrantPolicies({
   agentId,
   connectorType,
+  initialPolicies,
   policies,
   pageSignal,
   upsertGrant,
 }: {
   agentId: string;
   connectorType: ConnectorType;
+  initialPolicies: FirewallPolicies;
   policies: FirewallPolicies;
   pageSignal: AbortSignal;
   upsertGrant: UpsertUserPermissionGrant;
 }): Promise<void> {
-  const connectorPolicies = policies[connectorType];
-  const namedPolicies = connectorPolicies?.policies ?? {};
-  for (const [permission, action] of Object.entries(namedPolicies)) {
+  for (const { permission, action } of changedUserGrantPolicies({
+    connectorType,
+    initialPolicies,
+    policies,
+  })) {
     await upsertGrant(
       {
         agentId,
         connectorRef: connectorType,
         permission,
-        action: userGrantAction(action),
+        action,
       },
       pageSignal,
     );
   }
-  const unknownPolicy = connectorPolicies?.unknownPolicy;
-  if (unknownPolicy === undefined) {
-    return;
-  }
-  await upsertGrant(
-    {
-      agentId,
-      connectorRef: connectorType,
-      permission: UNKNOWN_PERMISSION_GRANT,
-      action: userGrantAction(unknownPolicy),
-    },
-    pageSignal,
-  );
 }
 
 async function saveDrawerPolicies({
   agentId,
   connectorType,
   userPermissionGrantsEnabled,
+  initialPolicies,
   policies,
   pageSignal,
   upsertGrant,
@@ -516,6 +547,7 @@ async function saveDrawerPolicies({
   agentId: string;
   connectorType: ConnectorType;
   userPermissionGrantsEnabled: boolean;
+  initialPolicies: FirewallPolicies;
   policies: FirewallPolicies;
   pageSignal: AbortSignal;
   upsertGrant: UpsertUserPermissionGrant;
@@ -526,6 +558,7 @@ async function saveDrawerPolicies({
     await saveUserGrantPolicies({
       agentId,
       connectorType,
+      initialPolicies,
       policies,
       pageSignal,
       upsertGrant,
@@ -790,6 +823,9 @@ function JobPermissionsTab({
     userPermissionGrantsEnabled && userGrantsLoadable.state === "hasData"
       ? userGrantsToFirewallPolicies(userGrantsLoadable.data)
       : null;
+  const drawerInitialPolicies = userPermissionGrantsEnabled
+    ? (userGrantPolicies ?? {})
+    : (permissionPolicies ?? {});
   const reloadDetail = useSet(reloadAgentDetail$);
   const savePermPol = useSet(savePermissionPolicies$);
   const [, upsertGrant] = useLoadableSet(upsertUserPermissionGrant$);
@@ -871,11 +907,7 @@ function JobPermissionsTab({
             agentId={agentId}
             connectorType={connectorType}
             displayName={displayName}
-            initialPolicies={
-              userPermissionGrantsEnabled
-                ? (userGrantPolicies ?? {})
-                : (permissionPolicies ?? {})
-            }
+            initialPolicies={drawerInitialPolicies}
             readOnly={!canManagePermissions}
             onApply={async (policies) => {
               if (connectorType === null) {
@@ -885,6 +917,7 @@ function JobPermissionsTab({
                 agentId,
                 connectorType,
                 userPermissionGrantsEnabled,
+                initialPolicies: drawerInitialPolicies,
                 policies,
                 pageSignal,
                 upsertGrant,

--- a/turbo/apps/platform/src/views/team-page/zero-job-detail-page.tsx
+++ b/turbo/apps/platform/src/views/team-page/zero-job-detail-page.tsx
@@ -99,7 +99,6 @@ import {
 import {
   upsertUserPermissionGrant$,
   userPermissionGrantsByAgent,
-  userPermissionGrantsToFirewallPolicies,
 } from "../../signals/permission-allow/permission-allow-signals.ts";
 import {
   allConnectorTypes$,
@@ -122,7 +121,10 @@ import {
   type FirewallPolicies,
   type FirewallPolicyValue,
 } from "@vm0/connectors/firewall-types";
-import { resolveFirewallPolicies } from "@vm0/connectors/firewalls";
+import {
+  permissionGrantsToFirewallPolicies,
+  resolveFirewallPolicies,
+} from "@vm0/connectors/firewalls";
 import type { UserPermissionGrantAction } from "@vm0/api-contracts/contracts/zero-user-permission-grants";
 
 type UpsertUserPermissionGrant = (
@@ -800,7 +802,7 @@ function JobPermissionsTab({
   );
   const userGrantPolicies =
     userPermissionGrantsEnabled && userGrantsLoadable.state === "hasData"
-      ? userPermissionGrantsToFirewallPolicies(userGrantsLoadable.data)
+      ? permissionGrantsToFirewallPolicies(userGrantsLoadable.data)
       : null;
   const drawerInitialPolicies = userPermissionGrantsEnabled
     ? (userGrantPolicies ?? {})

--- a/turbo/apps/platform/src/views/team-page/zero-job-detail-page.tsx
+++ b/turbo/apps/platform/src/views/team-page/zero-job-detail-page.tsx
@@ -85,6 +85,8 @@ import { openAvatarMaker$ } from "../../signals/zero-page/settings/avatar-maker.
 import { currentAgent$ } from "../../signals/agent.ts";
 import { isOrgAdmin$ } from "../../signals/org.ts";
 import { user$ } from "../../signals/auth.ts";
+import { featureSwitch$ } from "../../signals/external/feature-switch.ts";
+import { FeatureSwitchKey } from "@vm0/connectors/feature-switch-key";
 import { ZeroNoPermissionIllustration } from "../zero-page/components/zero-no-permission-illustration.tsx";
 import { ConnectorIcon } from "../zero-page/components/settings/connector-icons.tsx";
 import { PermissionsDrawer } from "../zero-page/components/settings/permissions-dialog.tsx";
@@ -94,6 +96,10 @@ import {
   hasConnectorPermissions,
   savePermissionPolicies$,
 } from "../../signals/zero-page/settings/permissions.ts";
+import {
+  upsertUserPermissionGrant$,
+  userPermissionGrantsByAgent,
+} from "../../signals/permission-allow/permission-allow-signals.ts";
 import {
   allConnectorTypes$,
   matchesConnectorSearch,
@@ -110,7 +116,31 @@ import {
   permSavingType$,
   setPermSavingType$,
 } from "../../signals/zero-page/zero-job-detail-page.ts";
-import type { FirewallPolicies } from "@vm0/connectors/firewall-types";
+import {
+  UNKNOWN_PERMISSION_GRANT,
+  type FirewallPolicies,
+  type FirewallPolicyValue,
+} from "@vm0/connectors/firewall-types";
+import type {
+  UserPermissionGrantAction,
+  UserPermissionGrantResponse,
+} from "@vm0/api-contracts/contracts/zero-user-permission-grants";
+
+type UpsertUserPermissionGrant = (
+  params: {
+    agentId: string;
+    connectorRef: string;
+    permission: string;
+    action: UserPermissionGrantAction;
+  },
+  signal: AbortSignal,
+) => Promise<void>;
+
+type SavePermissionPolicies = (
+  agentId: string,
+  policies: FirewallPolicies,
+  signal: AbortSignal,
+) => Promise<FirewallPolicies | null | undefined>;
 
 // ---------------------------------------------------------------------------
 // Page shell: skeleton, error, header
@@ -404,6 +434,110 @@ function PermissionRow({
   );
 }
 
+function userGrantAction(
+  policy: FirewallPolicyValue,
+): UserPermissionGrantAction {
+  if (policy === "ask") {
+    throw new Error("User permission grants do not support ask");
+  }
+  return policy;
+}
+
+function userGrantsToFirewallPolicies(
+  grants: readonly UserPermissionGrantResponse[],
+): FirewallPolicies | null {
+  const policies: FirewallPolicies = {};
+  for (const grant of grants) {
+    const current = policies[grant.connectorRef] ?? { policies: {} };
+    if (grant.permission === UNKNOWN_PERMISSION_GRANT) {
+      policies[grant.connectorRef] = {
+        ...current,
+        unknownPolicy: grant.action,
+      };
+      continue;
+    }
+    current.policies[grant.permission] = grant.action;
+    policies[grant.connectorRef] = current;
+  }
+  return Object.keys(policies).length > 0 ? policies : null;
+}
+
+async function saveUserGrantPolicies({
+  agentId,
+  connectorType,
+  policies,
+  pageSignal,
+  upsertGrant,
+}: {
+  agentId: string;
+  connectorType: ConnectorType;
+  policies: FirewallPolicies;
+  pageSignal: AbortSignal;
+  upsertGrant: UpsertUserPermissionGrant;
+}): Promise<void> {
+  const connectorPolicies = policies[connectorType];
+  const namedPolicies = connectorPolicies?.policies ?? {};
+  for (const [permission, action] of Object.entries(namedPolicies)) {
+    await upsertGrant(
+      {
+        agentId,
+        connectorRef: connectorType,
+        permission,
+        action: userGrantAction(action),
+      },
+      pageSignal,
+    );
+  }
+  const unknownPolicy = connectorPolicies?.unknownPolicy;
+  if (unknownPolicy === undefined) {
+    return;
+  }
+  await upsertGrant(
+    {
+      agentId,
+      connectorRef: connectorType,
+      permission: UNKNOWN_PERMISSION_GRANT,
+      action: userGrantAction(unknownPolicy),
+    },
+    pageSignal,
+  );
+}
+
+async function saveDrawerPolicies({
+  agentId,
+  connectorType,
+  userPermissionGrantsEnabled,
+  policies,
+  pageSignal,
+  upsertGrant,
+  savePermPol,
+  reloadDetail,
+}: {
+  agentId: string;
+  connectorType: ConnectorType;
+  userPermissionGrantsEnabled: boolean;
+  policies: FirewallPolicies;
+  pageSignal: AbortSignal;
+  upsertGrant: UpsertUserPermissionGrant;
+  savePermPol: SavePermissionPolicies;
+  reloadDetail: () => void;
+}): Promise<void> {
+  if (userPermissionGrantsEnabled) {
+    await saveUserGrantPolicies({
+      agentId,
+      connectorType,
+      policies,
+      pageSignal,
+      upsertGrant,
+    });
+    return;
+  }
+  const saved = await savePermPol(agentId, policies, pageSignal);
+  if (saved !== undefined) {
+    reloadDetail();
+  }
+}
+
 function PermissionListSkeleton() {
   return (
     <div className="mx-auto max-w-[900px]">
@@ -426,6 +560,16 @@ function PermissionListSkeleton() {
             </div>
           );
         })}
+      </div>
+    </div>
+  );
+}
+
+function PermissionGrantsError() {
+  return (
+    <div className="mx-auto max-w-[900px]">
+      <div className="zero-card px-5 py-4 text-sm text-destructive">
+        Failed to load permission grants
       </div>
     </div>
   );
@@ -633,8 +777,22 @@ function JobPermissionsTab({
   const saveConnectors = useSet(saveAgentConnectors$);
   const pageSignal = useGet(pageSignal$);
   const permissionPolicies = useLastResolved(agentPermissionPolicies$) ?? null;
+  const features = useLastResolved(featureSwitch$);
+  const userPermissionGrantsEnabled =
+    features?.[FeatureSwitchKey.UserPermissionGrants] ?? false;
+  const userGrantsLoadable = useLastLoadable(
+    userPermissionGrantsByAgent({
+      agentId,
+      enabled: userPermissionGrantsEnabled,
+    }),
+  );
+  const userGrantPolicies =
+    userPermissionGrantsEnabled && userGrantsLoadable.state === "hasData"
+      ? userGrantsToFirewallPolicies(userGrantsLoadable.data)
+      : null;
   const reloadDetail = useSet(reloadAgentDetail$);
   const savePermPol = useSet(savePermissionPolicies$);
+  const [, upsertGrant] = useLoadableSet(upsertUserPermissionGrant$);
   const connectorType = useGet(permConnectorType$);
   const setConnectorType = useSet(setPermConnectorType$);
   const search = useGet(permSearch$);
@@ -651,7 +809,7 @@ function JobPermissionsTab({
     allTypesLoadable.state === "hasData" ? allTypesLoadable.data : [];
   const adminLoadable = useLoadable(isOrgAdmin$);
   const isAdmin = adminLoadable.state === "hasData" && adminLoadable.data;
-  const canManagePermissions = isAdmin;
+  const canManagePermissions = userPermissionGrantsEnabled || isAdmin;
 
   const connectedConnectors = allConnectors.filter((c) => {
     return c.connected;
@@ -679,8 +837,16 @@ function JobPermissionsTab({
     setSavingType(null);
   };
 
-  if (allTypesLoadable.state !== "hasData" || connectorsLoading) {
+  if (
+    allTypesLoadable.state !== "hasData" ||
+    connectorsLoading ||
+    (userPermissionGrantsEnabled && userGrantsLoadable.state === "loading")
+  ) {
     return <PermissionListSkeleton />;
+  }
+
+  if (userPermissionGrantsEnabled && userGrantsLoadable.state === "hasError") {
+    return <PermissionGrantsError />;
   }
 
   return (
@@ -705,13 +871,26 @@ function JobPermissionsTab({
             agentId={agentId}
             connectorType={connectorType}
             displayName={displayName}
-            initialPolicies={permissionPolicies ?? {}}
+            initialPolicies={
+              userPermissionGrantsEnabled
+                ? (userGrantPolicies ?? {})
+                : (permissionPolicies ?? {})
+            }
             readOnly={!canManagePermissions}
             onApply={async (policies) => {
-              const saved = await savePermPol(agentId, policies, pageSignal);
-              if (saved !== undefined) {
-                reloadDetail();
+              if (connectorType === null) {
+                throw new Error("Cannot save permissions without a connector");
               }
+              await saveDrawerPolicies({
+                agentId,
+                connectorType,
+                userPermissionGrantsEnabled,
+                policies,
+                pageSignal,
+                upsertGrant,
+                savePermPol,
+                reloadDetail,
+              });
               toast.success("Permissions updated");
             }}
             onClose={() => {

--- a/turbo/apps/platform/src/views/zero-page/__tests__/zero-chat-thread-page-display.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/zero-chat-thread-page-display.test.tsx
@@ -535,7 +535,6 @@ describe("zero chat thread page display - permission action card", () => {
         connectorRef: "vercel",
         permission: "projects:write",
         action: "allow",
-        ttlSeconds: 86_400,
       });
     });
     expect(requestCreated).toBeFalsy();
@@ -627,7 +626,6 @@ describe("zero chat thread page display - permission action card", () => {
         connectorRef: "vercel",
         permission: "projects:write",
         action: "deny",
-        ttlSeconds: 86_400,
       });
     });
     expect(policyUpdated).toBeFalsy();

--- a/turbo/apps/platform/src/views/zero-page/__tests__/zero-chat-thread-page-display.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/zero-chat-thread-page-display.test.tsx
@@ -818,6 +818,79 @@ describe("zero chat thread page display - permission action card", () => {
 
     expect(grantCalled).toBeFalsy();
   });
+
+  it("disables chat permission actions when current-user grants fail to load", async () => {
+    let grantCalled = false;
+
+    setMockOrg({ role: "member" });
+    mockChatLifecycle({
+      chatMessages: [
+        {
+          role: "assistant",
+          content:
+            "https://app.vm0.ai/agents/4f189ea8-ada2-416d-83a9-9c25ddb960c9/permissions?ref=slack&permission=channels%3Aread&action=allow",
+          runId: "run-user-grant-load-failed",
+          status: "completed",
+          createdAt: "2026-03-10T00:00:00Z",
+        },
+      ],
+    });
+    server.use(
+      mockApi(zeroAgentsByIdContract.get, ({ respond }) => {
+        return respond(200, {
+          agentId: "4f189ea8-ada2-416d-83a9-9c25ddb960c9",
+          ownerId: "other-owner-id",
+          description: null,
+          displayName: null,
+          sound: null,
+          avatarUrl: null,
+          permissionPolicies: {
+            slack: { policies: { "channels:read": "deny" } },
+          },
+          customSkills: [],
+          modelProviderId: null,
+          selectedModel: null,
+          preferPersonalProvider: false,
+        });
+      }),
+      mockApi(zeroUserPermissionGrantsContract.list, ({ respond }) => {
+        return respond(404, {
+          error: { message: "Agent not found", code: "NOT_FOUND" },
+        });
+      }),
+      mockApi(zeroUserPermissionGrantsContract.upsert, ({ body, respond }) => {
+        grantCalled = true;
+        return respond(
+          200,
+          createMockUserPermissionGrantResponse({
+            agentId: body.agentId,
+            connectorRef: body.connectorRef,
+            permission: body.permission,
+            action: body.action,
+          }),
+        );
+      }),
+    );
+
+    detachedSetupPage({
+      context,
+      path: "/chats/thread-test-1",
+      featureSwitches: { [FeatureSwitchKey.UserPermissionGrants]: true },
+    });
+
+    const card = await waitFor(() => {
+      return screen.getByTestId("permission-action-card");
+    });
+    const button = queryAllByRoleFast("button", card).find((element) => {
+      return element.textContent === "Failed to load permissions";
+    });
+    expect(button).toBeDefined();
+    expect(button).toBeDisabled();
+
+    click(button!);
+
+    expect(grantCalled).toBeFalsy();
+  });
 });
 
 // CHAT-D-036: Attachment image previews render in ChatMessageRow

--- a/turbo/apps/platform/src/views/zero-page/__tests__/zero-chat-thread-page-display.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/zero-chat-thread-page-display.test.tsx
@@ -527,7 +527,7 @@ describe("zero chat thread page display - permission action card", () => {
       return screen.getByTestId("permission-action-card");
     });
     expect(hasSubscription("permissionAccessRequestsChanged")).toBeFalsy();
-    click(await within(card).findByText("Request approval"));
+    click(await within(card).findByText("Confirm"));
 
     await waitFor(() => {
       expect(grantBody).toMatchObject({

--- a/turbo/apps/platform/src/views/zero-page/__tests__/zero-chat-thread-page-display.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/zero-chat-thread-page-display.test.tsx
@@ -544,6 +544,96 @@ describe("zero chat thread page display - permission action card", () => {
     expect(within(card).getByText("Permissions updated")).toBeInTheDocument();
   });
 
+  it("writes a current-user grant for admins when user permission grants are enabled", async () => {
+    let grantBody: unknown;
+    let policyUpdated = false;
+
+    mockChatLifecycle({
+      chatMessages: [
+        {
+          role: "assistant",
+          content:
+            "https://app.vm0.ai/agents/4f189ea8-ada2-416d-83a9-9c25ddb960c9/permissions?ref=vercel&permission=projects%3Awrite&action=deny",
+          runId: "run-admin-user-grant-permission-action",
+          status: "completed",
+          createdAt: "2026-03-10T00:00:00Z",
+        },
+      ],
+    });
+    server.use(
+      mockApi(zeroAgentsByIdContract.get, ({ respond }) => {
+        return respond(200, {
+          agentId: "4f189ea8-ada2-416d-83a9-9c25ddb960c9",
+          ownerId: "test-user-123",
+          description: null,
+          displayName: null,
+          sound: null,
+          avatarUrl: null,
+          permissionPolicies: {
+            vercel: { policies: { "projects:write": "allow" } },
+          },
+          customSkills: [],
+          modelProviderId: null,
+          selectedModel: null,
+          preferPersonalProvider: false,
+        });
+      }),
+      mockApi(zeroUserPermissionGrantsContract.upsert, ({ body, respond }) => {
+        grantBody = body;
+        return respond(
+          200,
+          createMockUserPermissionGrantResponse({
+            agentId: body.agentId,
+            connectorRef: body.connectorRef,
+            permission: body.permission,
+            action: body.action,
+          }),
+        );
+      }),
+      mockApi(zeroAgentPermissionPoliciesContract.update, ({ respond }) => {
+        policyUpdated = true;
+        return respond(200, {
+          agentId: "4f189ea8-ada2-416d-83a9-9c25ddb960c9",
+          ownerId: "test-user-123",
+          description: null,
+          displayName: null,
+          sound: null,
+          avatarUrl: null,
+          permissionPolicies: {
+            vercel: { policies: { "projects:write": "deny" } },
+          },
+          customSkills: [],
+          modelProviderId: null,
+          selectedModel: null,
+          preferPersonalProvider: false,
+        });
+      }),
+    );
+
+    detachedSetupPage({
+      context,
+      path: "/chats/thread-test-1",
+      featureSwitches: { [FeatureSwitchKey.UserPermissionGrants]: true },
+    });
+
+    const card = await waitFor(() => {
+      return screen.getByTestId("permission-action-card");
+    });
+    click(await within(card).findByText("Confirm"));
+
+    await waitFor(() => {
+      expect(grantBody).toMatchObject({
+        agentId: "4f189ea8-ada2-416d-83a9-9c25ddb960c9",
+        connectorRef: "vercel",
+        permission: "projects:write",
+        action: "deny",
+        ttlSeconds: 86_400,
+      });
+    });
+    expect(policyUpdated).toBeFalsy();
+    expect(within(card).getByText("Permission denied")).toBeInTheDocument();
+  });
+
   it("uses current-user grants for already-applied chat permission actions", async () => {
     setMockOrg({ role: "member" });
     setMockUserPermissionGrants([

--- a/turbo/apps/platform/src/views/zero-page/__tests__/zero-chat-thread-page-display.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/zero-chat-thread-page-display.test.tsx
@@ -15,15 +15,22 @@ import { updateChatArtifacts } from "../../../mocks/mock-helpers.ts";
 import { chatThreadArtifactsContract } from "@vm0/api-contracts/contracts/chat-threads";
 import {
   permissionAccessRequestsCreateContract,
+  permissionAccessRequestsListContract,
   type PermissionAccessRequestResponse,
   zeroAgentPermissionPoliciesContract,
   zeroAgentsByIdContract,
 } from "@vm0/api-contracts/contracts/zero-agents";
+import { zeroUserPermissionGrantsContract } from "@vm0/api-contracts/contracts/zero-user-permission-grants";
 import { zeroConnectorOauthStartContract } from "@vm0/api-contracts/contracts/zero-connectors";
 import { zeroUserConnectorsContract } from "@vm0/api-contracts/contracts/user-connectors";
+import { FeatureSwitchKey } from "@vm0/connectors/feature-switch-key";
 import { setMockConnectors } from "../../../mocks/handlers/api-connectors.ts";
 import { setMockOrg } from "../../../mocks/handlers/api-org.ts";
 import { setMockPermissionRequests } from "../../../mocks/handlers/api-permission-access-requests.ts";
+import {
+  createMockUserPermissionGrantResponse,
+  setMockUserPermissionGrants,
+} from "../../../mocks/handlers/api-user-permission-grants.ts";
 import { mockChatLifecycle, PLACEHOLDER } from "./chat-test-helpers.ts";
 
 const context = testContext();
@@ -450,6 +457,217 @@ describe("zero chat thread page display - permission action card", () => {
     await waitFor(() => {
       expect(within(card).getByText("Permissions updated")).toBeInTheDocument();
     });
+  });
+
+  it("writes a current-user grant for members when user permission grants are enabled", async () => {
+    let grantBody: unknown;
+    let requestCreated = false;
+    let requestsListed = false;
+
+    setMockOrg({ role: "member" });
+    mockChatLifecycle({
+      chatMessages: [
+        {
+          role: "assistant",
+          content:
+            "https://app.vm0.ai/agents/4f189ea8-ada2-416d-83a9-9c25ddb960c9/permissions?ref=vercel&permission=projects%3Awrite&action=allow",
+          runId: "run-user-grant-permission-action",
+          status: "completed",
+          createdAt: "2026-03-10T00:00:00Z",
+        },
+      ],
+    });
+    server.use(
+      mockApi(zeroAgentsByIdContract.get, ({ respond }) => {
+        return respond(200, {
+          agentId: "4f189ea8-ada2-416d-83a9-9c25ddb960c9",
+          ownerId: "other-owner-id",
+          description: null,
+          displayName: null,
+          sound: null,
+          avatarUrl: null,
+          permissionPolicies: {
+            vercel: { policies: { "projects:write": "deny" } },
+          },
+          customSkills: [],
+          modelProviderId: null,
+          selectedModel: null,
+          preferPersonalProvider: false,
+        });
+      }),
+      mockApi(zeroUserPermissionGrantsContract.upsert, ({ body, respond }) => {
+        grantBody = body;
+        return respond(
+          200,
+          createMockUserPermissionGrantResponse({
+            agentId: body.agentId,
+            connectorRef: body.connectorRef,
+            permission: body.permission,
+            action: body.action,
+          }),
+        );
+      }),
+      mockApi(permissionAccessRequestsCreateContract.create, ({ respond }) => {
+        requestCreated = true;
+        return respond(201, pendingPermissionRequest());
+      }),
+      mockApi(permissionAccessRequestsListContract.list, ({ respond }) => {
+        requestsListed = true;
+        return respond(200, []);
+      }),
+    );
+
+    detachedSetupPage({
+      context,
+      path: "/chats/thread-test-1",
+      featureSwitches: { [FeatureSwitchKey.UserPermissionGrants]: true },
+    });
+
+    const card = await waitFor(() => {
+      return screen.getByTestId("permission-action-card");
+    });
+    expect(hasSubscription("permissionAccessRequestsChanged")).toBeFalsy();
+    click(await within(card).findByText("Request approval"));
+
+    await waitFor(() => {
+      expect(grantBody).toMatchObject({
+        agentId: "4f189ea8-ada2-416d-83a9-9c25ddb960c9",
+        connectorRef: "vercel",
+        permission: "projects:write",
+        action: "allow",
+        ttlSeconds: 86_400,
+      });
+    });
+    expect(requestCreated).toBeFalsy();
+    expect(requestsListed).toBeFalsy();
+    expect(hasSubscription("permissionAccessRequestsChanged")).toBeFalsy();
+    expect(within(card).getByText("Permissions updated")).toBeInTheDocument();
+  });
+
+  it("uses current-user grants for already-applied chat permission actions", async () => {
+    setMockOrg({ role: "member" });
+    setMockUserPermissionGrants([
+      createMockUserPermissionGrantResponse({
+        agentId: "4f189ea8-ada2-416d-83a9-9c25ddb960c9",
+        connectorRef: "vercel",
+        permission: "projects:write",
+        action: "allow",
+      }),
+    ]);
+    mockChatLifecycle({
+      chatMessages: [
+        {
+          role: "assistant",
+          content:
+            "https://app.vm0.ai/agents/4f189ea8-ada2-416d-83a9-9c25ddb960c9/permissions?ref=vercel&permission=projects%3Awrite&action=allow",
+          runId: "run-user-grant-permission-action-applied",
+          status: "completed",
+          createdAt: "2026-03-10T00:00:00Z",
+        },
+      ],
+    });
+    server.use(
+      mockApi(zeroAgentsByIdContract.get, ({ respond }) => {
+        return respond(200, {
+          agentId: "4f189ea8-ada2-416d-83a9-9c25ddb960c9",
+          ownerId: "other-owner-id",
+          description: null,
+          displayName: null,
+          sound: null,
+          avatarUrl: null,
+          permissionPolicies: {
+            vercel: { policies: { "projects:write": "deny" } },
+          },
+          customSkills: [],
+          modelProviderId: null,
+          selectedModel: null,
+          preferPersonalProvider: false,
+        });
+      }),
+    );
+
+    detachedSetupPage({
+      context,
+      path: "/chats/thread-test-1",
+      featureSwitches: { [FeatureSwitchKey.UserPermissionGrants]: true },
+    });
+
+    const card = await waitFor(() => {
+      return screen.getByTestId("permission-action-card");
+    });
+    expect(within(card).getByText("Permissions updated")).toBeInTheDocument();
+    const button = queryAllByRoleFast("button", card).find((element) => {
+      return element.textContent === "Permissions updated";
+    });
+    expect(button).toBeDefined();
+    expect(button).toBeDisabled();
+  });
+
+  it("does not write grants for unknown chat permission actions", async () => {
+    let grantCalled = false;
+
+    mockChatLifecycle({
+      chatMessages: [
+        {
+          role: "assistant",
+          content:
+            "https://app.vm0.ai/agents/4f189ea8-ada2-416d-83a9-9c25ddb960c9/permissions?ref=vercel&permission=unknown%3Apermission&action=allow",
+          runId: "run-user-grant-unknown-permission-action",
+          status: "completed",
+          createdAt: "2026-03-10T00:00:00Z",
+        },
+      ],
+    });
+    server.use(
+      mockApi(zeroAgentsByIdContract.get, ({ respond }) => {
+        return respond(200, {
+          agentId: "4f189ea8-ada2-416d-83a9-9c25ddb960c9",
+          ownerId: "test-user-123",
+          description: null,
+          displayName: null,
+          sound: null,
+          avatarUrl: null,
+          permissionPolicies: {
+            vercel: { policies: { "projects:write": "deny" } },
+          },
+          customSkills: [],
+          modelProviderId: null,
+          selectedModel: null,
+          preferPersonalProvider: false,
+        });
+      }),
+      mockApi(zeroUserPermissionGrantsContract.upsert, ({ body, respond }) => {
+        grantCalled = true;
+        return respond(
+          200,
+          createMockUserPermissionGrantResponse({
+            agentId: body.agentId,
+            connectorRef: body.connectorRef,
+            permission: body.permission,
+            action: body.action,
+          }),
+        );
+      }),
+    );
+
+    detachedSetupPage({
+      context,
+      path: "/chats/thread-test-1",
+      featureSwitches: { [FeatureSwitchKey.UserPermissionGrants]: true },
+    });
+
+    const card = await waitFor(() => {
+      return screen.getByTestId("permission-action-card");
+    });
+    const button = queryAllByRoleFast("button", card).find((element) => {
+      return element.textContent === "Unknown permission";
+    });
+    expect(button).toBeDefined();
+    expect(button).toBeDisabled();
+
+    click(button!);
+
+    expect(grantCalled).toBeFalsy();
   });
 });
 

--- a/turbo/apps/platform/src/views/zero-page/__tests__/zero-chat-thread-page-display.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/zero-chat-thread-page-display.test.tsx
@@ -470,7 +470,7 @@ describe("zero chat thread page display - permission action card", () => {
         {
           role: "assistant",
           content:
-            "https://app.vm0.ai/agents/4f189ea8-ada2-416d-83a9-9c25ddb960c9/permissions?ref=vercel&permission=projects%3Awrite&action=allow",
+            "https://app.vm0.ai/agents/4f189ea8-ada2-416d-83a9-9c25ddb960c9/permissions?ref=slack&permission=channels%3Awrite&action=allow",
           runId: "run-user-grant-permission-action",
           status: "completed",
           createdAt: "2026-03-10T00:00:00Z",
@@ -487,7 +487,7 @@ describe("zero chat thread page display - permission action card", () => {
           sound: null,
           avatarUrl: null,
           permissionPolicies: {
-            vercel: { policies: { "projects:write": "deny" } },
+            slack: { policies: { "channels:write": "deny" } },
           },
           customSkills: [],
           modelProviderId: null,
@@ -532,8 +532,8 @@ describe("zero chat thread page display - permission action card", () => {
     await waitFor(() => {
       expect(grantBody).toMatchObject({
         agentId: "4f189ea8-ada2-416d-83a9-9c25ddb960c9",
-        connectorRef: "vercel",
-        permission: "projects:write",
+        connectorRef: "slack",
+        permission: "channels:write",
         action: "allow",
       });
     });
@@ -632,13 +632,74 @@ describe("zero chat thread page display - permission action card", () => {
     expect(within(card).getByText("Permission denied")).toBeInTheDocument();
   });
 
+  it("uses default connector policies for already-applied chat permission actions", async () => {
+    let grantCalled = false;
+
+    setMockOrg({ role: "member" });
+    mockChatLifecycle({
+      chatMessages: [
+        {
+          role: "assistant",
+          content:
+            "https://app.vm0.ai/agents/4f189ea8-ada2-416d-83a9-9c25ddb960c9/permissions?ref=slack&permission=channels%3Aread&action=allow",
+          runId: "run-user-grant-permission-default-applied",
+          status: "completed",
+          createdAt: "2026-03-10T00:00:00Z",
+        },
+      ],
+    });
+    server.use(
+      mockApi(zeroAgentsByIdContract.get, ({ respond }) => {
+        return respond(200, {
+          agentId: "4f189ea8-ada2-416d-83a9-9c25ddb960c9",
+          ownerId: "other-owner-id",
+          description: null,
+          displayName: null,
+          sound: null,
+          avatarUrl: null,
+          permissionPolicies: {
+            slack: { policies: { "channels:read": "deny" } },
+          },
+          customSkills: [],
+          modelProviderId: null,
+          selectedModel: null,
+          preferPersonalProvider: false,
+        });
+      }),
+      mockApi(zeroUserPermissionGrantsContract.upsert, ({ body, respond }) => {
+        grantCalled = true;
+        return respond(
+          200,
+          createMockUserPermissionGrantResponse({
+            agentId: body.agentId,
+            connectorRef: body.connectorRef,
+            permission: body.permission,
+            action: body.action,
+          }),
+        );
+      }),
+    );
+
+    detachedSetupPage({
+      context,
+      path: "/chats/thread-test-1",
+      featureSwitches: { [FeatureSwitchKey.UserPermissionGrants]: true },
+    });
+
+    const card = await waitFor(() => {
+      return screen.getByTestId("permission-action-card");
+    });
+    expect(within(card).getByText("Permissions updated")).toBeInTheDocument();
+    expect(grantCalled).toBeFalsy();
+  });
+
   it("uses current-user grants for already-applied chat permission actions", async () => {
     setMockOrg({ role: "member" });
     setMockUserPermissionGrants([
       createMockUserPermissionGrantResponse({
         agentId: "4f189ea8-ada2-416d-83a9-9c25ddb960c9",
-        connectorRef: "vercel",
-        permission: "projects:write",
+        connectorRef: "slack",
+        permission: "channels:write",
         action: "allow",
       }),
     ]);
@@ -647,7 +708,7 @@ describe("zero chat thread page display - permission action card", () => {
         {
           role: "assistant",
           content:
-            "https://app.vm0.ai/agents/4f189ea8-ada2-416d-83a9-9c25ddb960c9/permissions?ref=vercel&permission=projects%3Awrite&action=allow",
+            "https://app.vm0.ai/agents/4f189ea8-ada2-416d-83a9-9c25ddb960c9/permissions?ref=slack&permission=channels%3Awrite&action=allow",
           runId: "run-user-grant-permission-action-applied",
           status: "completed",
           createdAt: "2026-03-10T00:00:00Z",
@@ -664,7 +725,7 @@ describe("zero chat thread page display - permission action card", () => {
           sound: null,
           avatarUrl: null,
           permissionPolicies: {
-            vercel: { policies: { "projects:write": "deny" } },
+            slack: { policies: { "channels:write": "deny" } },
           },
           customSkills: [],
           modelProviderId: null,

--- a/turbo/apps/platform/src/views/zero-page/__tests__/zero-job-detail-page-display.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/zero-job-detail-page-display.test.tsx
@@ -18,6 +18,7 @@ import { setMockConnectors } from "../../../mocks/handlers/api-connectors.ts";
 import { setMockOrg } from "../../../mocks/handlers/api-org.ts";
 import { setMockTeam } from "../../../mocks/handlers/api-agents.ts";
 import { pathname, search } from "../../../signals/location.ts";
+import { FeatureSwitchKey } from "@vm0/connectors/feature-switch-key";
 
 const context = testContext();
 const mockApi = createMockApi(context);
@@ -258,6 +259,27 @@ describe("zero job detail page - connector display", () => {
     expect(
       screen.queryByLabelText(/Manage Slack permissions/i),
     ).not.toBeInTheDocument();
+  });
+
+  it("should show connector permission management for non-admin members when user grants are enabled", async () => {
+    mockAPIsWithConnectors();
+    setMockOrg({ role: "member" });
+    detachedSetupPage({
+      context,
+      path: "/agents/my-agent",
+      featureSwitches: { [FeatureSwitchKey.UserPermissionGrants]: true },
+    });
+
+    await waitFor(() => {
+      expect(screen.getByText("Slack")).toBeInTheDocument();
+    });
+
+    expect(
+      screen.getByRole("switch", { name: /Slack access/i }),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByLabelText(/Manage Slack permissions/i),
+    ).toBeInTheDocument();
   });
 });
 

--- a/turbo/apps/platform/src/views/zero-page/__tests__/zero-job-detail-page-display.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/zero-job-detail-page-display.test.tsx
@@ -5,6 +5,7 @@ import {
   zeroAgentsByIdContract,
   zeroAgentInstructionsContract,
 } from "@vm0/api-contracts/contracts/zero-agents";
+import { zeroUserPermissionGrantsContract } from "@vm0/api-contracts/contracts/zero-user-permission-grants";
 import { zeroUserConnectorsContract } from "@vm0/api-contracts/contracts/user-connectors";
 import { server } from "../../../mocks/server.ts";
 import { testContext } from "../../../signals/__tests__/test-helpers.ts";
@@ -280,6 +281,33 @@ describe("zero job detail page - connector display", () => {
     expect(
       screen.getByLabelText(/Manage Slack permissions/i),
     ).toBeInTheDocument();
+  });
+
+  it("should show an error instead of permission management when user grants fail to load", async () => {
+    mockAPIsWithConnectors();
+    setMockOrg({ role: "member" });
+    server.use(
+      mockApi(zeroUserPermissionGrantsContract.list, ({ respond }) => {
+        return respond(404, {
+          error: { message: "Agent not found", code: "NOT_FOUND" },
+        });
+      }),
+    );
+
+    detachedSetupPage({
+      context,
+      path: "/agents/my-agent",
+      featureSwitches: { [FeatureSwitchKey.UserPermissionGrants]: true },
+    });
+
+    await waitFor(() => {
+      expect(
+        screen.getByText("Failed to load permission grants"),
+      ).toBeInTheDocument();
+    });
+    expect(
+      screen.queryByLabelText(/Manage Slack permissions/i),
+    ).not.toBeInTheDocument();
   });
 });
 

--- a/turbo/apps/platform/src/views/zero-page/__tests__/zero-job-detail-page-interaction.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/zero-job-detail-page-interaction.test.tsx
@@ -271,11 +271,25 @@ describe("zero job detail page - interaction and state", () => {
       ).toBeInTheDocument();
     });
 
-    const denyButton = queryAllByRoleFast("button").find((element) => {
+    const readGroupButton = queryAllByRoleFast("button").find((element) => {
+      return /^Read \(\d+\)$/.test(element.textContent ?? "");
+    });
+    expect(readGroupButton).toBeDefined();
+    click(readGroupButton!);
+
+    const permissionRow = screen
+      .getByText("channels:read")
+      .closest("div")?.parentElement;
+    expect(permissionRow).not.toBeNull();
+    const denyButton = queryAllByRoleFast(
+      "button",
+      permissionRow as HTMLElement,
+    ).find((element) => {
       return element.textContent === "Deny";
     });
     expect(denyButton).toBeDefined();
     click(denyButton!);
+
     const applyButton = queryAllByRoleFast("button").find((element) => {
       return element.textContent === "Apply";
     });
@@ -283,13 +297,13 @@ describe("zero job detail page - interaction and state", () => {
     click(applyButton!);
 
     await waitFor(() => {
-      expect(grantBodies).toContainEqual(
-        expect.objectContaining({
-          agentId: "e0000000-0000-4000-a000-000000000010",
-          connectorRef: "slack",
-          action: "deny",
-        }),
-      );
+      expect(grantBodies).toHaveLength(1);
+    });
+    expect(grantBodies[0]).toMatchObject({
+      agentId: "e0000000-0000-4000-a000-000000000010",
+      connectorRef: "slack",
+      permission: "channels:read",
+      action: "deny",
     });
     expect(policyUpdated).toBeFalsy();
   });

--- a/turbo/apps/platform/src/views/zero-page/__tests__/zero-job-detail-page-interaction.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/zero-job-detail-page-interaction.test.tsx
@@ -4,7 +4,9 @@ import userEvent from "@testing-library/user-event";
 import {
   zeroAgentsByIdContract,
   zeroAgentInstructionsContract,
+  zeroAgentPermissionPoliciesContract,
 } from "@vm0/api-contracts/contracts/zero-agents";
+import { zeroUserPermissionGrantsContract } from "@vm0/api-contracts/contracts/zero-user-permission-grants";
 import { zeroUserConnectorsContract } from "@vm0/api-contracts/contracts/user-connectors";
 import { server } from "../../../mocks/server.ts";
 import { testContext } from "../../../signals/__tests__/test-helpers.ts";
@@ -18,6 +20,9 @@ import { pathname } from "../../../signals/location.ts";
 import { createMockApi } from "../../../mocks/msw-contract.ts";
 import { setMockConnectors } from "../../../mocks/handlers/api-connectors.ts";
 import { setMockTeam } from "../../../mocks/handlers/api-agents.ts";
+import { setMockOrg } from "../../../mocks/handlers/api-org.ts";
+import { createMockUserPermissionGrantResponse } from "../../../mocks/handlers/api-user-permission-grants.ts";
+import { FeatureSwitchKey } from "@vm0/connectors/feature-switch-key";
 
 const context = testContext();
 const mockApi = createMockApi(context);
@@ -208,6 +213,85 @@ describe("zero job detail page - interaction and state", () => {
         screen.getByRole("heading", { name: /Slack permissions/i }),
       ).toBeInTheDocument();
     });
+  });
+
+  it("should save current-user grants from permissions drawer when user grants are enabled", async () => {
+    const grantBodies: unknown[] = [];
+    let policyUpdated = false;
+
+    mockAPIs();
+    setMockOrg({ role: "member" });
+    server.use(
+      mockApi(zeroUserPermissionGrantsContract.upsert, ({ body, respond }) => {
+        grantBodies.push(body);
+        return respond(
+          200,
+          createMockUserPermissionGrantResponse({
+            agentId: body.agentId,
+            connectorRef: body.connectorRef,
+            permission: body.permission,
+            action: body.action,
+          }),
+        );
+      }),
+      mockApi(zeroAgentPermissionPoliciesContract.update, ({ respond }) => {
+        policyUpdated = true;
+        return respond(200, {
+          agentId: "e0000000-0000-4000-a000-000000000010",
+          ownerId: "test-user-123",
+          description: "A helpful agent",
+          displayName: "My Agent",
+          sound: null,
+          avatarUrl: "preset:2",
+          permissionPolicies: {
+            slack: { policies: { "channels:read": "deny" } },
+          },
+          customSkills: [],
+        });
+      }),
+    );
+
+    detachedSetupPage({
+      context,
+      path: "/agents/my-agent",
+      featureSwitches: { [FeatureSwitchKey.UserPermissionGrants]: true },
+    });
+    await waitForPageLoad();
+
+    await waitFor(() => {
+      expect(
+        screen.getByLabelText(/Manage Slack permissions/i),
+      ).toBeInTheDocument();
+    });
+    click(screen.getByLabelText(/Manage Slack permissions/i));
+
+    await waitFor(() => {
+      expect(
+        screen.getByRole("heading", { name: /Slack permissions/i }),
+      ).toBeInTheDocument();
+    });
+
+    const denyButton = queryAllByRoleFast("button").find((element) => {
+      return element.textContent === "Deny";
+    });
+    expect(denyButton).toBeDefined();
+    click(denyButton!);
+    const applyButton = queryAllByRoleFast("button").find((element) => {
+      return element.textContent === "Apply";
+    });
+    expect(applyButton).toBeDefined();
+    click(applyButton!);
+
+    await waitFor(() => {
+      expect(grantBodies).toContainEqual(
+        expect.objectContaining({
+          agentId: "e0000000-0000-4000-a000-000000000010",
+          connectorRef: "slack",
+          action: "deny",
+        }),
+      );
+    });
+    expect(policyUpdated).toBeFalsy();
   });
 
   it("should filter connector list when searching (AGENT-D-032)", async () => {

--- a/turbo/apps/platform/src/views/zero-page/zero-chat-thread-page.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-chat-thread-page.tsx
@@ -64,6 +64,7 @@ import {
   CONNECTOR_TYPES,
   type ConnectorAuthMethodIdsByGrantKind,
 } from "@vm0/connectors/connectors";
+import type { FirewallPolicies } from "@vm0/connectors/firewall-types";
 import { featureSwitch$ } from "../../signals/external/feature-switch.ts";
 import { playTts$, stopTts$ } from "../../signals/voice-io/voice-io-tts.ts";
 import {
@@ -163,10 +164,13 @@ import { isOrgAdmin$ } from "../../signals/org.ts";
 import { agentById } from "../../signals/agent.ts";
 import {
   extractPermissions,
+  findMatchingUserPermissionGrant,
   permissionExistingRequestByAction,
   saveAdminFocusedPolicy$,
   subscribePermissionAccessRequestsChanged$,
   submitAccessRequest$,
+  upsertUserPermissionGrant$,
+  userPermissionGrantsByAgent,
 } from "../../signals/permission-allow/permission-allow-signals.ts";
 import {
   billingStatusAsync$,
@@ -2685,9 +2689,47 @@ interface PermissionActionButtonState {
   existingRequestStatus: "pending" | "approved" | "rejected" | null;
 }
 
+type PermissionAction = "allow" | "deny";
+
+type UpsertUserPermissionGrantFn = (
+  params: {
+    agentId: string;
+    connectorRef: string;
+    permission: string;
+    action: PermissionAction;
+  },
+  signal: AbortSignal,
+) => Promise<void>;
+
+type SaveAdminFocusedPolicyFn = (
+  params: {
+    agentId: string;
+    ref: string;
+    permissionName: string;
+    action: PermissionAction;
+    agentFirewallPolicies: FirewallPolicies | null;
+  },
+  signal: AbortSignal,
+) => Promise<void>;
+
+type SubmitAccessRequestFn = (
+  params: {
+    agentId: string;
+    connectorRef: string;
+    permission: string;
+    action: PermissionAction;
+    method?: string;
+    path?: string;
+    reason?: string;
+  },
+  signal: AbortSignal,
+) => Promise<void>;
+
+type SubscribePermissionRequestsFn = (signal: AbortSignal) => Promise<void>;
+
 function permissionActionButtonLabel(
   state: PermissionActionButtonState,
-  action: "allow" | "deny",
+  action: PermissionAction,
 ): string {
   if (state.loading) {
     return "Checking permissions";
@@ -2753,111 +2795,209 @@ function PermissionActionButton({
   );
 }
 
-function PermissionActionCard({ block }: { block: PermissionActionBlock }) {
-  const pageSignal = useGet(pageSignal$);
-  const config = CONNECTOR_TYPES[block.connectorRef];
-  const agentLoadable = useLastLoadable(agentById(block.agentId));
-  const adminLoadable = useLoadable(isOrgAdmin$);
-  const [saveLoadable, savePolicy] = useLoadableSet(saveAdminFocusedPolicy$);
-  const [submitLoadable, submitRequest] = useLoadableSet(submitAccessRequest$);
-  const subscribeRequests = useSet(subscribePermissionAccessRequestsChanged$);
-  const canManagePermissions =
-    adminLoadable.state === "hasData" && adminLoadable.data;
-  const existingRequestLoadable = useLoadable(
-    permissionExistingRequestByAction({
-      agentId: block.agentId,
-      connectorRef: block.connectorRef,
-      permission: block.permission,
-      action: block.action,
-      enabled: adminLoadable.state === "hasData" && !canManagePermissions,
-    }),
+function isPermissionActionLoading(params: {
+  userPermissionGrantsEnabled: boolean;
+  agentLoading: boolean;
+  adminLoading: boolean;
+  existingRequestLoading: boolean;
+  userGrantsLoading: boolean;
+}): boolean {
+  return (
+    params.agentLoading ||
+    params.adminLoading ||
+    (!params.userPermissionGrantsEnabled && params.existingRequestLoading) ||
+    (params.userPermissionGrantsEnabled && params.userGrantsLoading)
   );
-  const focusedPermission = extractPermissions(block.connectorRef).find((p) => {
-    return p.name === block.permission;
-  });
-  const actionLabel = block.action === "allow" ? "Allow" : "Deny";
-  const loading =
-    agentLoadable.state === "loading" ||
-    adminLoadable.state === "loading" ||
-    existingRequestLoadable.state === "loading";
-  const saving =
-    saveLoadable.state === "loading" || submitLoadable.state === "loading";
-  const agent = agentLoadable.state === "hasData" ? agentLoadable.data : null;
-  const existingRequest =
-    existingRequestLoadable.state === "hasData"
-      ? existingRequestLoadable.data
-      : null;
-  const storedPolicy =
-    agent?.permissionPolicies?.[block.connectorRef]?.policies?.[
-      block.permission
-    ];
-  const alreadyApplied = Boolean(agent) && storedPolicy === block.action;
-  const finished =
-    saveLoadable.state === "hasData" || submitLoadable.state === "hasData";
-  const buttonState: PermissionActionButtonState = {
-    hasAgent: Boolean(agent),
-    hasPermission: Boolean(focusedPermission),
-    loading,
-    saving,
-    saveDone: saveLoadable.state === "hasData",
-    submitDone: submitLoadable.state === "hasData",
-    alreadyApplied,
-    canManagePermissions,
-    existingRequestStatus: existingRequest?.status ?? null,
+}
+
+function isPermissionActionSaving(params: {
+  saveLoading: boolean;
+  submitLoading: boolean;
+  grantLoading: boolean;
+}): boolean {
+  return params.saveLoading || params.submitLoading || params.grantLoading;
+}
+
+function isPermissionActionFinished(params: {
+  saveDone: boolean;
+  submitDone: boolean;
+  grantDone: boolean;
+}): boolean {
+  return params.saveDone || params.submitDone || params.grantDone;
+}
+
+function isPermissionActionAlreadyApplied(params: {
+  hasAgent: boolean;
+  userPermissionGrantsEnabled: boolean;
+  hasMatchingGrant: boolean;
+  storedPolicy: string | undefined;
+  action: "allow" | "deny";
+}): boolean {
+  if (!params.hasAgent) {
+    return false;
+  }
+  return params.userPermissionGrantsEnabled
+    ? params.hasMatchingGrant
+    : params.storedPolicy === params.action;
+}
+
+function createPermissionActionButtonState(params: {
+  hasAgent: boolean;
+  hasPermission: boolean;
+  loading: boolean;
+  saving: boolean;
+  alreadyApplied: boolean;
+  canManagePermissions: boolean;
+  existingRequestStatus: "pending" | "approved" | "rejected" | null;
+  saveDone: boolean;
+  submitDone: boolean;
+}): PermissionActionButtonState {
+  return {
+    hasAgent: params.hasAgent,
+    hasPermission: params.hasPermission,
+    loading: params.loading,
+    saving: params.saving,
+    saveDone: params.saveDone,
+    submitDone: params.submitDone,
+    alreadyApplied: params.alreadyApplied,
+    canManagePermissions: params.canManagePermissions,
+    existingRequestStatus: params.existingRequestStatus,
   };
+}
 
-  const handlePermissionAction = () => {
-    if (
-      !agent ||
-      !focusedPermission ||
-      existingRequest ||
-      loading ||
-      saving ||
-      alreadyApplied ||
-      finished
-    ) {
-      return;
-    }
+function runPermissionAction(params: {
+  agent: { permissionPolicies: FirewallPolicies | null } | null;
+  focusedPermission: { name: string } | undefined;
+  existingRequest: { status: "pending" | "approved" | "rejected" } | null;
+  state: PermissionActionButtonState;
+  finished: boolean;
+  userPermissionGrantsEnabled: boolean;
+  canManagePermissions: boolean;
+  runUserGrant: () => void;
+  runAdminSave: () => void;
+  runAccessRequest: () => void;
+}): void {
+  if (
+    !params.agent ||
+    !params.focusedPermission ||
+    params.existingRequest ||
+    params.state.loading ||
+    params.state.saving ||
+    params.state.alreadyApplied ||
+    params.finished
+  ) {
+    return;
+  }
 
-    if (canManagePermissions) {
-      detach(
-        savePolicy(
-          {
-            agentId: block.agentId,
-            ref: block.connectorRef,
-            permissionName: focusedPermission.name,
-            action: block.action,
-            agentFirewallPolicies: agent.permissionPolicies,
-          },
-          pageSignal,
-        ),
-        Reason.DomCallback,
-      );
-      return;
-    }
+  if (params.userPermissionGrantsEnabled) {
+    params.runUserGrant();
+    return;
+  }
 
-    detach(
-      subscribeRequests(pageSignal),
-      Reason.Daemon,
-      "permission access request realtime subscription",
-    );
-    detach(
-      submitRequest(
-        {
-          agentId: block.agentId,
-          connectorRef: block.connectorRef,
-          permission: focusedPermission.name,
-          action: block.action,
-          method: block.method ?? undefined,
-          path: block.path ?? undefined,
-          reason: block.reason ?? undefined,
-        },
-        pageSignal,
-      ),
-      Reason.DomCallback,
-    );
+  if (params.canManagePermissions) {
+    params.runAdminSave();
+    return;
+  }
+
+  params.runAccessRequest();
+}
+
+function createPermissionActionHandler(params: {
+  block: PermissionActionBlock;
+  pageSignal: AbortSignal;
+  agent: { permissionPolicies: FirewallPolicies | null } | null;
+  focusedPermission: { name: string } | undefined;
+  existingRequest: { status: "pending" | "approved" | "rejected" } | null;
+  state: PermissionActionButtonState;
+  finished: boolean;
+  userPermissionGrantsEnabled: boolean;
+  canManagePermissions: boolean;
+  upsertGrant: UpsertUserPermissionGrantFn;
+  savePolicy: SaveAdminFocusedPolicyFn;
+  submitRequest: SubmitAccessRequestFn;
+  subscribeRequests: SubscribePermissionRequestsFn;
+}): () => void {
+  return () => {
+    const permissionName =
+      params.focusedPermission?.name ?? params.block.permission;
+    runPermissionAction({
+      agent: params.agent,
+      focusedPermission: params.focusedPermission,
+      existingRequest: params.existingRequest,
+      state: params.state,
+      finished: params.finished,
+      userPermissionGrantsEnabled: params.userPermissionGrantsEnabled,
+      canManagePermissions: params.canManagePermissions,
+      runUserGrant: () => {
+        detach(
+          params.upsertGrant(
+            {
+              agentId: params.block.agentId,
+              connectorRef: params.block.connectorRef,
+              permission: permissionName,
+              action: params.block.action,
+            },
+            params.pageSignal,
+          ),
+          Reason.DomCallback,
+        );
+      },
+      runAdminSave: () => {
+        detach(
+          params.savePolicy(
+            {
+              agentId: params.block.agentId,
+              ref: params.block.connectorRef,
+              permissionName,
+              action: params.block.action,
+              agentFirewallPolicies: params.agent?.permissionPolicies ?? null,
+            },
+            params.pageSignal,
+          ),
+          Reason.DomCallback,
+        );
+      },
+      runAccessRequest: () => {
+        detach(
+          params.subscribeRequests(params.pageSignal),
+          Reason.Daemon,
+          "permission access request realtime subscription",
+        );
+        detach(
+          params.submitRequest(
+            {
+              agentId: params.block.agentId,
+              connectorRef: params.block.connectorRef,
+              permission: permissionName,
+              action: params.block.action,
+              method: params.block.method ?? undefined,
+              path: params.block.path ?? undefined,
+              reason: params.block.reason ?? undefined,
+            },
+            params.pageSignal,
+          ),
+          Reason.DomCallback,
+        );
+      },
+    });
   };
+}
 
+function PermissionActionCardContent({
+  block,
+  connectorLabel,
+  actionLabel,
+  permissionName,
+  buttonState,
+  onClick,
+}: {
+  block: PermissionActionBlock;
+  connectorLabel: string;
+  actionLabel: string;
+  permissionName: string;
+  buttonState: PermissionActionButtonState;
+  onClick: () => void;
+}) {
   return (
     <div
       data-testid="permission-action-card"
@@ -2869,19 +3009,139 @@ function PermissionActionCard({ block }: { block: PermissionActionBlock }) {
         </div>
         <div className="min-w-0">
           <div className="truncate text-sm font-medium text-foreground">
-            {config.label} permissions
+            {connectorLabel} permissions
           </div>
           <div className="mt-0.5 line-clamp-2 text-xs leading-5 text-muted-foreground">
-            {actionLabel} {focusedPermission?.name ?? block.permission}
+            {actionLabel} {permissionName}
           </div>
         </div>
       </div>
       <PermissionActionButton
         state={buttonState}
         action={block.action}
-        onClick={handlePermissionAction}
+        onClick={onClick}
       />
     </div>
+  );
+}
+
+function PermissionActionCard({ block }: { block: PermissionActionBlock }) {
+  const pageSignal = useGet(pageSignal$);
+  const features = useLastResolved(featureSwitch$);
+  const userPermissionGrantsEnabled =
+    features?.[FeatureSwitchKey.UserPermissionGrants] ?? false;
+  const config = CONNECTOR_TYPES[block.connectorRef];
+  const agentLoadable = useLastLoadable(agentById(block.agentId));
+  const adminLoadable = useLoadable(isOrgAdmin$);
+  const [saveLoadable, savePolicy] = useLoadableSet(saveAdminFocusedPolicy$);
+  const [submitLoadable, submitRequest] = useLoadableSet(submitAccessRequest$);
+  const [grantLoadable, upsertGrant] = useLoadableSet(
+    upsertUserPermissionGrant$,
+  );
+  const subscribeRequests = useSet(subscribePermissionAccessRequestsChanged$);
+  const canManagePermissions =
+    adminLoadable.state === "hasData" && adminLoadable.data;
+  const existingRequestLoadable = useLoadable(
+    permissionExistingRequestByAction({
+      agentId: block.agentId,
+      connectorRef: block.connectorRef,
+      permission: block.permission,
+      action: block.action,
+      enabled:
+        !userPermissionGrantsEnabled &&
+        adminLoadable.state === "hasData" &&
+        !canManagePermissions,
+    }),
+  );
+  const userGrantsLoadable = useLoadable(
+    userPermissionGrantsByAgent({
+      agentId: block.agentId,
+      enabled: userPermissionGrantsEnabled,
+    }),
+  );
+  const focusedPermission = extractPermissions(block.connectorRef).find((p) => {
+    return p.name === block.permission;
+  });
+  const actionLabel = block.action === "allow" ? "Allow" : "Deny";
+  const loading = isPermissionActionLoading({
+    userPermissionGrantsEnabled,
+    agentLoading: agentLoadable.state === "loading",
+    adminLoading: adminLoadable.state === "loading",
+    existingRequestLoading: existingRequestLoadable.state === "loading",
+    userGrantsLoading: userGrantsLoadable.state === "loading",
+  });
+  const saving = isPermissionActionSaving({
+    saveLoading: saveLoadable.state === "loading",
+    submitLoading: submitLoadable.state === "loading",
+    grantLoading: grantLoadable.state === "loading",
+  });
+  const agent = agentLoadable.state === "hasData" ? agentLoadable.data : null;
+  const existingRequest =
+    !userPermissionGrantsEnabled && existingRequestLoadable.state === "hasData"
+      ? existingRequestLoadable.data
+      : null;
+  const userGrants =
+    userGrantsLoadable.state === "hasData" ? userGrantsLoadable.data : [];
+  const matchingGrant = findMatchingUserPermissionGrant(
+    userGrants,
+    block.connectorRef,
+    block.permission,
+    block.action,
+  );
+  const storedPolicy =
+    agent?.permissionPolicies?.[block.connectorRef]?.policies?.[
+      block.permission
+    ];
+  const alreadyApplied = isPermissionActionAlreadyApplied({
+    hasAgent: Boolean(agent),
+    userPermissionGrantsEnabled,
+    hasMatchingGrant: Boolean(matchingGrant),
+    storedPolicy,
+    action: block.action,
+  });
+  const saveDone =
+    saveLoadable.state === "hasData" || grantLoadable.state === "hasData";
+  const submitDone = submitLoadable.state === "hasData";
+  const finished = isPermissionActionFinished({
+    saveDone,
+    submitDone,
+    grantDone: grantLoadable.state === "hasData",
+  });
+  const buttonState = createPermissionActionButtonState({
+    hasAgent: Boolean(agent),
+    hasPermission: Boolean(focusedPermission),
+    loading,
+    saving,
+    saveDone,
+    submitDone,
+    alreadyApplied,
+    canManagePermissions,
+    existingRequestStatus: existingRequest?.status ?? null,
+  });
+
+  return (
+    <PermissionActionCardContent
+      block={block}
+      connectorLabel={config.label}
+      actionLabel={actionLabel}
+      permissionName={focusedPermission?.name ?? block.permission}
+      buttonState={buttonState}
+      onClick={createPermissionActionHandler({
+        block,
+        pageSignal,
+        agent,
+        focusedPermission,
+        existingRequest,
+        state: buttonState,
+        finished,
+        userPermissionGrantsEnabled,
+        canManagePermissions,
+        upsertGrant,
+        savePolicy,
+        submitRequest,
+        subscribeRequests,
+      })}
+    />
   );
 }
 

--- a/turbo/apps/platform/src/views/zero-page/zero-chat-thread-page.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-chat-thread-page.tsx
@@ -64,7 +64,10 @@ import {
   CONNECTOR_TYPES,
   type ConnectorAuthMethodIdsByGrantKind,
 } from "@vm0/connectors/connectors";
-import type { FirewallPolicies } from "@vm0/connectors/firewall-types";
+import type {
+  FirewallPolicies,
+  FirewallPolicyValue,
+} from "@vm0/connectors/firewall-types";
 import { featureSwitch$ } from "../../signals/external/feature-switch.ts";
 import { playTts$, stopTts$ } from "../../signals/voice-io/voice-io-tts.ts";
 import {
@@ -164,8 +167,8 @@ import { isOrgAdmin$ } from "../../signals/org.ts";
 import { agentById } from "../../signals/agent.ts";
 import {
   extractPermissions,
-  findMatchingUserPermissionGrant,
   permissionExistingRequestByAction,
+  resolveUserPermissionGrantPolicy,
   saveAdminFocusedPolicy$,
   subscribePermissionAccessRequestsChanged$,
   submitAccessRequest$,
@@ -2834,7 +2837,7 @@ function isPermissionActionFinished(params: {
 function isPermissionActionAlreadyApplied(params: {
   hasAgent: boolean;
   userPermissionGrantsEnabled: boolean;
-  hasMatchingGrant: boolean;
+  userGrantPolicy: FirewallPolicyValue | undefined;
   storedPolicy: string | undefined;
   action: "allow" | "deny";
 }): boolean {
@@ -2842,7 +2845,7 @@ function isPermissionActionAlreadyApplied(params: {
     return false;
   }
   return params.userPermissionGrantsEnabled
-    ? params.hasMatchingGrant
+    ? params.userGrantPolicy === params.action
     : params.storedPolicy === params.action;
 }
 
@@ -3089,11 +3092,10 @@ function PermissionActionCard({ block }: { block: PermissionActionBlock }) {
       : null;
   const userGrants =
     userGrantsLoadable.state === "hasData" ? userGrantsLoadable.data : [];
-  const matchingGrant = findMatchingUserPermissionGrant(
+  const userGrantPolicy = resolveUserPermissionGrantPolicy(
     userGrants,
     block.connectorRef,
     block.permission,
-    block.action,
   );
   const storedPolicy =
     agent?.permissionPolicies?.[block.connectorRef]?.policies?.[
@@ -3102,7 +3104,7 @@ function PermissionActionCard({ block }: { block: PermissionActionBlock }) {
   const alreadyApplied = isPermissionActionAlreadyApplied({
     hasAgent: Boolean(agent),
     userPermissionGrantsEnabled,
-    hasMatchingGrant: Boolean(matchingGrant),
+    userGrantPolicy,
     storedPolicy,
     action: block.action,
   });

--- a/turbo/apps/platform/src/views/zero-page/zero-chat-thread-page.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-chat-thread-page.tsx
@@ -2684,6 +2684,7 @@ interface PermissionActionButtonState {
   hasAgent: boolean;
   hasPermission: boolean;
   loading: boolean;
+  loadError: boolean;
   saving: boolean;
   saveDone: boolean;
   submitDone: boolean;
@@ -2738,6 +2739,9 @@ function permissionActionButtonLabel(
   if (state.loading) {
     return "Checking permissions";
   }
+  if (state.loadError) {
+    return "Failed to load permissions";
+  }
   if (!state.hasPermission) {
     return "Unknown permission";
   }
@@ -2771,6 +2775,7 @@ function permissionActionButtonDisabled(
 ): boolean {
   return (
     state.loading ||
+    state.loadError ||
     state.saving ||
     state.alreadyApplied ||
     state.saveDone ||
@@ -2818,12 +2823,39 @@ function isPermissionActionLoading(params: {
   );
 }
 
+function shouldLoadExistingPermissionRequest(params: {
+  userPermissionGrantsEnabled: boolean;
+  adminLoaded: boolean;
+  canManagePermissions: boolean;
+}): boolean {
+  return (
+    !params.userPermissionGrantsEnabled &&
+    params.adminLoaded &&
+    !params.canManagePermissions
+  );
+}
+
 function isPermissionActionSaving(params: {
   saveLoading: boolean;
   submitLoading: boolean;
   grantLoading: boolean;
 }): boolean {
   return params.saveLoading || params.submitLoading || params.grantLoading;
+}
+
+function isPermissionActionLoadError(params: {
+  userPermissionGrantsEnabled: boolean;
+  agentError: boolean;
+  adminError: boolean;
+  existingRequestError: boolean;
+  userGrantsError: boolean;
+}): boolean {
+  return (
+    params.agentError ||
+    params.adminError ||
+    (!params.userPermissionGrantsEnabled && params.existingRequestError) ||
+    (params.userPermissionGrantsEnabled && params.userGrantsError)
+  );
 }
 
 function isPermissionActionFinished(params: {
@@ -2853,6 +2885,7 @@ function createPermissionActionButtonState(params: {
   hasAgent: boolean;
   hasPermission: boolean;
   loading: boolean;
+  loadError: boolean;
   saving: boolean;
   alreadyApplied: boolean;
   canManagePermissions: boolean;
@@ -2865,6 +2898,7 @@ function createPermissionActionButtonState(params: {
     hasAgent: params.hasAgent,
     hasPermission: params.hasPermission,
     loading: params.loading,
+    loadError: params.loadError,
     saving: params.saving,
     saveDone: params.saveDone,
     submitDone: params.submitDone,
@@ -2892,6 +2926,7 @@ function runPermissionAction(params: {
     !params.focusedPermission ||
     params.existingRequest ||
     params.state.loading ||
+    params.state.loadError ||
     params.state.saving ||
     params.state.alreadyApplied ||
     params.finished
@@ -3057,10 +3092,11 @@ function PermissionActionCard({ block }: { block: PermissionActionBlock }) {
       connectorRef: block.connectorRef,
       permission: block.permission,
       action: block.action,
-      enabled:
-        !userPermissionGrantsEnabled &&
-        adminLoadable.state === "hasData" &&
-        !canManagePermissions,
+      enabled: shouldLoadExistingPermissionRequest({
+        userPermissionGrantsEnabled,
+        adminLoaded: adminLoadable.state === "hasData",
+        canManagePermissions,
+      }),
     }),
   );
   const userGrantsLoadable = useLoadable(
@@ -3080,6 +3116,13 @@ function PermissionActionCard({ block }: { block: PermissionActionBlock }) {
     existingRequestLoading: existingRequestLoadable.state === "loading",
     userGrantsLoading: userGrantsLoadable.state === "loading",
   });
+  const loadError = isPermissionActionLoadError({
+    userPermissionGrantsEnabled,
+    agentError: agentLoadable.state === "hasError",
+    adminError: adminLoadable.state === "hasError",
+    existingRequestError: existingRequestLoadable.state === "hasError",
+    userGrantsError: userGrantsLoadable.state === "hasError",
+  });
   const saving = isPermissionActionSaving({
     saveLoading: saveLoadable.state === "loading",
     submitLoading: submitLoadable.state === "loading",
@@ -3090,13 +3133,14 @@ function PermissionActionCard({ block }: { block: PermissionActionBlock }) {
     !userPermissionGrantsEnabled && existingRequestLoadable.state === "hasData"
       ? existingRequestLoadable.data
       : null;
-  const userGrants =
-    userGrantsLoadable.state === "hasData" ? userGrantsLoadable.data : [];
-  const userGrantPolicy = resolveUserPermissionGrantPolicy(
-    userGrants,
-    block.connectorRef,
-    block.permission,
-  );
+  const userGrantPolicy =
+    userPermissionGrantsEnabled && userGrantsLoadable.state === "hasData"
+      ? resolveUserPermissionGrantPolicy(
+          userGrantsLoadable.data,
+          block.connectorRef,
+          block.permission,
+        )
+      : undefined;
   const storedPolicy =
     agent?.permissionPolicies?.[block.connectorRef]?.policies?.[
       block.permission
@@ -3120,6 +3164,7 @@ function PermissionActionCard({ block }: { block: PermissionActionBlock }) {
     hasAgent: Boolean(agent),
     hasPermission: Boolean(focusedPermission),
     loading,
+    loadError,
     saving,
     saveDone,
     submitDone,

--- a/turbo/apps/platform/src/views/zero-page/zero-chat-thread-page.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-chat-thread-page.tsx
@@ -2686,6 +2686,7 @@ interface PermissionActionButtonState {
   submitDone: boolean;
   alreadyApplied: boolean;
   canManagePermissions: boolean;
+  selfServiceGrant: boolean;
   existingRequestStatus: "pending" | "approved" | "rejected" | null;
 }
 
@@ -2753,9 +2754,13 @@ function permissionActionButtonLabel(
     return "Request sent";
   }
   if (state.saving) {
-    return state.canManagePermissions ? "Saving..." : "Requesting...";
+    return state.canManagePermissions || state.selfServiceGrant
+      ? "Saving..."
+      : "Requesting...";
   }
-  return state.canManagePermissions ? "Confirm" : "Request approval";
+  return state.canManagePermissions || state.selfServiceGrant
+    ? "Confirm"
+    : "Request approval";
 }
 
 function permissionActionButtonDisabled(
@@ -2848,6 +2853,7 @@ function createPermissionActionButtonState(params: {
   saving: boolean;
   alreadyApplied: boolean;
   canManagePermissions: boolean;
+  selfServiceGrant: boolean;
   existingRequestStatus: "pending" | "approved" | "rejected" | null;
   saveDone: boolean;
   submitDone: boolean;
@@ -2861,6 +2867,7 @@ function createPermissionActionButtonState(params: {
     submitDone: params.submitDone,
     alreadyApplied: params.alreadyApplied,
     canManagePermissions: params.canManagePermissions,
+    selfServiceGrant: params.selfServiceGrant,
     existingRequestStatus: params.existingRequestStatus,
   };
 }
@@ -3116,6 +3123,7 @@ function PermissionActionCard({ block }: { block: PermissionActionBlock }) {
     submitDone,
     alreadyApplied,
     canManagePermissions,
+    selfServiceGrant: userPermissionGrantsEnabled,
     existingRequestStatus: existingRequest?.status ?? null,
   });
 

--- a/turbo/packages/api-contracts/src/contracts/index.ts
+++ b/turbo/packages/api-contracts/src/contracts/index.ts
@@ -882,12 +882,10 @@ export {
 export {
   zeroUserPermissionGrantsContract,
   userPermissionGrantActionSchema,
-  userPermissionGrantTtlSecondsSchema,
   userPermissionGrantResponseSchema,
   listUserPermissionGrantsQuerySchema,
   upsertUserPermissionGrantRequestSchema,
   type UserPermissionGrantAction,
-  type UserPermissionGrantTtlSeconds,
   type UserPermissionGrantResponse,
   type ListUserPermissionGrantsQuery,
   type UpsertUserPermissionGrantRequest,

--- a/turbo/packages/api-contracts/src/contracts/zero-user-permission-grants.ts
+++ b/turbo/packages/api-contracts/src/contracts/zero-user-permission-grants.ts
@@ -9,12 +9,6 @@ const connectorRefSchema = z.string().min(1).max(64);
 const permissionSchema = z.string().min(1).max(128);
 
 export const userPermissionGrantActionSchema = z.enum(["allow", "deny"]);
-export const userPermissionGrantTtlSecondsSchema = z.union([
-  z.literal(300),
-  z.literal(900),
-  z.literal(3600),
-  z.literal(86_400),
-]);
 
 export const userPermissionGrantResponseSchema = z.object({
   agentId: agentIdSchema,
@@ -35,7 +29,6 @@ export const upsertUserPermissionGrantRequestSchema = z.object({
   connectorRef: connectorRefSchema,
   permission: permissionSchema,
   action: userPermissionGrantActionSchema,
-  ttlSeconds: userPermissionGrantTtlSecondsSchema,
 });
 
 export const zeroUserPermissionGrantsContract = c.router({
@@ -71,9 +64,6 @@ export const zeroUserPermissionGrantsContract = c.router({
 
 export type UserPermissionGrantAction = z.infer<
   typeof userPermissionGrantActionSchema
->;
-export type UserPermissionGrantTtlSeconds = z.infer<
-  typeof userPermissionGrantTtlSecondsSchema
 >;
 export type UserPermissionGrantResponse = z.infer<
   typeof userPermissionGrantResponseSchema


### PR DESCRIPTION
## Summary

- gate Platform permission allow/change and chat permission action flows on `UserPermissionGrants`
- keep the existing UI shape while writing current-user grants when the switch is enabled
- keep legacy approval request and agent policy update flows intact when the switch is disabled
- add Platform MSW coverage and feature-on/off interaction tests

Closes #15603

## Tests

- `pnpm -F @vm0/app exec vitest src/views/permission-allow/__tests__/permission-allow-page-interaction.test.tsx src/views/zero-page/__tests__/zero-chat-thread-page-display.test.tsx`
- `pnpm -F @vm0/app lint`
- `pnpm -F @vm0/app check-types`
- pre-commit: prettier, knip, full `pnpm check-types`
