### PR TITLE
fix: match auth method when auth-code connect completes

### DIFF
--- a/turbo/apps/platform/src/signals/zero-page/settings/__tests__/connect-connector.test.ts
+++ b/turbo/apps/platform/src/signals/zero-page/settings/__tests__/connect-connector.test.ts
@@ -60,6 +60,30 @@ function makeGithubConnectorResponse(): ConnectorListResponse {
   };
 }
 
+function makeTestOauthConnectorResponse(
+  authMethod: "oauth" | "api",
+  updatedAt: string,
+): ConnectorListResponse {
+  return {
+    connectors: [
+      {
+        id: "00000000-0000-4000-8000-000000000125",
+        type: "test-oauth",
+        authMethod,
+        externalId: "test-oauth-user",
+        externalUsername: "test-oauth-user",
+        externalEmail: null,
+        oauthScopes: ["read"],
+        needsReconnect: false,
+        createdAt: "2026-01-01T00:00:00.000Z",
+        updatedAt,
+      },
+    ],
+    configuredTypes: ["test-oauth"],
+    connectorProvidedEnvNames: [],
+  };
+}
+
 function mockMatchMedia(standalone: boolean) {
   vi.spyOn(window, "matchMedia").mockReturnValue({
     matches: standalone,
@@ -155,6 +179,76 @@ describe("connectConnectorOAuthAuthCode$", () => {
 
     expect(result).toBeTruthy();
     expect(pollCount).toBeGreaterThanOrEqual(2);
+    expect(context.store.get(pollingOAuthAuthCodeConnectorType$)).toBeNull();
+  });
+
+  it("ignores same-type rows with a different auth method while waiting for auth-code completion", async () => {
+    detachedSetupPage({
+      context,
+      path: "/",
+      withoutRender: true,
+      featureSwitches: { [FeatureSwitchKey.TestOauthConnector]: true },
+    });
+
+    const mockWindow = createMockAuthWindow();
+    vi.spyOn(window, "open").mockReturnValue(mockWindow as unknown as Window);
+
+    let pollCount = 0;
+    server.use(
+      mockApi(zeroConnectorsMainContract.list, ({ respond }) => {
+        pollCount++;
+        if (pollCount <= 1) {
+          return respond(200, makeEmptyConnectorResponse());
+        }
+        if (pollCount === 2) {
+          return respond(
+            200,
+            makeTestOauthConnectorResponse("oauth", "2026-01-02T00:00:00.000Z"),
+          );
+        }
+        return respond(
+          200,
+          makeTestOauthConnectorResponse("api", "2026-01-03T00:00:00.000Z"),
+        );
+      }),
+    );
+
+    let completed = false;
+    const connectPromise = (async () => {
+      const result = await context.store.set(
+        connectConnectorOAuthAuthCode$,
+        "test-oauth",
+        "api",
+        {},
+        context.signal,
+      );
+      completed = true;
+      return result;
+    })();
+
+    await vi.waitFor(() => {
+      expect(pollCount).toBeGreaterThanOrEqual(1);
+      expect(hasSubscription("connector:changed")).toBeTruthy();
+    });
+
+    triggerAblyEvent("connector:changed");
+    await vi.waitFor(() => {
+      expect(pollCount).toBeGreaterThanOrEqual(2);
+    });
+    await Promise.resolve();
+
+    expect(completed).toBeFalsy();
+    expect(hasSubscription("connector:changed")).toBeTruthy();
+    expect(context.store.get(pollingOAuthAuthCodeConnectorType$)).toBe(
+      "test-oauth",
+    );
+
+    triggerAblyEvent("connector:changed");
+
+    const result = await connectPromise;
+
+    expect(result).toBeTruthy();
+    expect(pollCount).toBeGreaterThanOrEqual(3);
     expect(context.store.get(pollingOAuthAuthCodeConnectorType$)).toBeNull();
   });
 

--- a/turbo/apps/platform/src/signals/zero-page/settings/connectors.ts
+++ b/turbo/apps/platform/src/signals/zero-page/settings/connectors.ts
@@ -1282,6 +1282,14 @@ function assertConnectorUsesDeviceAuthMethod(
   }
 }
 
+function connectorMatchesAuthMethod(
+  connector: ConnectorResponse,
+  type: ConnectorType,
+  authMethod: ConnectorAuthMethodId,
+): boolean {
+  return connector.type === type && connector.authMethod === authMethod;
+}
+
 const openConnectorOAuthAuthCodeWindow$ = command(
   async (
     { get },
@@ -1367,7 +1375,7 @@ export const connectConnectorOAuthAuthCode$ = command(
             );
             const polled = (result.body as ConnectorListResponse).connectors;
             const current = polled.find((c) => {
-              return c.type === type;
+              return connectorMatchesAuthMethod(c, type, authMethod);
             });
 
             if (initialUpdatedAt === undefined) {
@@ -1452,7 +1460,7 @@ export const connectConnectorOAuthAuthCode$ = command(
         // Mark as optimistically connected before clearing polling so the UI
         // transitions directly from "Connecting…" to "Connected" without flash.
         const isConnected = connectors.some((c) => {
-          return c.type === type;
+          return connectorMatchesAuthMethod(c, type, authMethod);
         });
         if (isConnected) {
           set(finishConnectorConnection$, type, {


### PR DESCRIPTION
## Summary

- Match auth-code connect completion on both connector type and selected auth method.
- Add a regression test using `test-oauth`'s multiple auth-code methods so same-type/different-method rows do not complete the transaction.

Fixes #15764

## Tests

- `pnpm -F @vm0/app exec vitest run src/signals/zero-page/settings/__tests__/connect-connector.test.ts`
- `pnpm -F @vm0/app lint`
- pre-commit: `pnpm knip --cache`
- pre-commit: `pnpm check-types`
