### PR TITLE
analytics: frontend PostHog activation events

### DIFF
--- a/turbo/apps/platform/src/lib/__tests__/posthog.test.ts
+++ b/turbo/apps/platform/src/lib/__tests__/posthog.test.ts
@@ -1,0 +1,60 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const posthogMock = vi.hoisted(() => {
+  return {
+    init: vi.fn(),
+    identify: vi.fn(),
+    reset: vi.fn(),
+    capture: vi.fn(),
+    startSessionRecording: vi.fn(),
+    stopSessionRecording: vi.fn(),
+  };
+});
+
+vi.mock("posthog-js", () => {
+  return { posthog: posthogMock };
+});
+
+async function loadPostHog(posthogKey: string) {
+  vi.resetModules();
+  vi.stubEnv("VITE_POSTHOG_KEY", posthogKey);
+  return await import("../posthog.ts");
+}
+
+describe("posthog analytics helpers", () => {
+  beforeEach(() => {
+    vi.stubEnv("VITE_POSTHOG_KEY", "");
+  });
+
+  it("skips activation captures when PostHog is disabled", async () => {
+    const { captureOnboardingStep, captureTaskCompletedSuccessfully } =
+      await loadPostHog("");
+
+    captureOnboardingStep("1");
+    captureTaskCompletedSuccessfully();
+
+    expect(posthogMock.capture).not.toHaveBeenCalled();
+  });
+
+  it("captures onboarding step views", async () => {
+    const { captureOnboardingStep } = await loadPostHog("test-posthog-key");
+
+    captureOnboardingStep("2");
+
+    expect(posthogMock.capture).toHaveBeenCalledWith("onboarding_step_viewed", {
+      step: "2",
+    });
+  });
+
+  it("captures successful chat-thread task completions", async () => {
+    const { captureTaskCompletedSuccessfully } =
+      await loadPostHog("test-posthog-key");
+
+    captureTaskCompletedSuccessfully();
+
+    expect(posthogMock.capture).toHaveBeenCalledWith(
+      "task_completed_successfully",
+      { surface: "chat_thread" },
+    );
+  });
+});

--- a/turbo/apps/platform/src/lib/posthog.ts
+++ b/turbo/apps/platform/src/lib/posthog.ts
@@ -35,15 +35,13 @@ export function initPostHog(): void {
 
 interface PostHogUser {
   id: string;
-  email: string | undefined;
-  name: string | undefined;
 }
 
 export function setPostHogUser(user: PostHogUser): void {
   if (!POSTHOG_KEY) {
     return;
   }
-  posthog.identify(user.id, { email: user.email, name: user.name });
+  posthog.identify(user.id);
 }
 
 export function clearPostHogUser(): void {

--- a/turbo/apps/platform/src/lib/posthog.ts
+++ b/turbo/apps/platform/src/lib/posthog.ts
@@ -35,13 +35,15 @@ export function initPostHog(): void {
 
 interface PostHogUser {
   id: string;
+  email: string | undefined;
+  name: string | undefined;
 }
 
 export function setPostHogUser(user: PostHogUser): void {
   if (!POSTHOG_KEY) {
     return;
   }
-  posthog.identify(user.id);
+  posthog.identify(user.id, { email: user.email, name: user.name });
 }
 
 export function clearPostHogUser(): void {
@@ -61,6 +63,13 @@ export function captureOnboardingStep(step: string): void {
     return;
   }
   posthog.capture("onboarding_step_viewed", { step });
+}
+
+export function captureTaskCompletedSuccessfully(): void {
+  if (!POSTHOG_KEY) {
+    return;
+  }
+  posthog.capture("task_completed_successfully", { surface: "chat_thread" });
 }
 
 // ── Scoped session replay ──────────────────────────────────────────

--- a/turbo/apps/platform/src/lib/posthog.ts
+++ b/turbo/apps/platform/src/lib/posthog.ts
@@ -53,6 +53,18 @@ export function clearPostHogUser(): void {
   posthog.reset();
 }
 
+// ── Onboarding step funnel ─────────────────────────────────────────
+//
+// Fires on each onboarding step transition. The single choke point is
+// setZeroStep$ in zero-onboarding.ts, so one capture there gives us a
+// per-step funnel to see which onboarding step has the highest drop-off.
+export function captureOnboardingStep(step: string): void {
+  if (!POSTHOG_KEY) {
+    return;
+  }
+  posthog.capture("onboarding_step_viewed", { step });
+}
+
 // ── Scoped session replay ──────────────────────────────────────────
 //
 // Replay is disabled at init (see initPostHog). These helpers turn it on for a

--- a/turbo/apps/platform/src/signals/auth.ts
+++ b/turbo/apps/platform/src/signals/auth.ts
@@ -65,8 +65,6 @@ export const setupClerk$ = command(
       setSentryUser(clerk.user.id);
       setPostHogUser({
         id: clerk.user.id,
-        email: clerk.user.primaryEmailAddress?.emailAddress,
-        name: clerk.user.fullName ?? undefined,
       });
     }
 
@@ -80,8 +78,6 @@ export const setupClerk$ = command(
         setSentryUser(clerk.user.id);
         setPostHogUser({
           id: clerk.user.id,
-          email: clerk.user.primaryEmailAddress?.emailAddress,
-          name: clerk.user.fullName ?? undefined,
         });
       } else {
         clearSentryUser();

--- a/turbo/apps/platform/src/signals/auth.ts
+++ b/turbo/apps/platform/src/signals/auth.ts
@@ -65,6 +65,8 @@ export const setupClerk$ = command(
       setSentryUser(clerk.user.id);
       setPostHogUser({
         id: clerk.user.id,
+        email: clerk.user.primaryEmailAddress?.emailAddress,
+        name: clerk.user.fullName ?? undefined,
       });
     }
 
@@ -78,6 +80,8 @@ export const setupClerk$ = command(
         setSentryUser(clerk.user.id);
         setPostHogUser({
           id: clerk.user.id,
+          email: clerk.user.primaryEmailAddress?.emailAddress,
+          name: clerk.user.fullName ?? undefined,
         });
       } else {
         clearSentryUser();

--- a/turbo/apps/platform/src/signals/chat-page/create-chat-thread.ts
+++ b/turbo/apps/platform/src/signals/chat-page/create-chat-thread.ts
@@ -857,7 +857,7 @@ function createAppendServerMessages(
         return !reportedCompletedRunIds.has(runId);
       },
     );
-    for (let i = 0; i < newlyCompletedRunIds.length; i++) {
+    for (const _ of newlyCompletedRunIds) {
       captureTaskCompletedSuccessfully();
     }
     if (newlyCompletedRunIds.length > 0) {

--- a/turbo/apps/platform/src/signals/chat-page/create-chat-thread.ts
+++ b/turbo/apps/platform/src/signals/chat-page/create-chat-thread.ts
@@ -40,6 +40,7 @@ import {
 } from "@vm0/api-contracts/contracts/chat-threads";
 import type { ModelProviderSelection } from "../../views/zero-page/components/model-provider-picker.tsx";
 import { accept } from "../../lib/accept.ts";
+import { captureTaskCompletedSuccessfully } from "../../lib/posthog.ts";
 import { zeroClient$ } from "../api-client.ts";
 import { agentById } from "../agent.ts";
 import { orgModelPolicies$ } from "../external/org-model-policies.ts";
@@ -111,6 +112,23 @@ function isCancelledAssistantMessage(msg: PagedChatMessage): boolean {
     (msg.runLifecycleEvent === "cancelled" ||
       msg.error?.trim().toLowerCase() === "run cancelled")
   );
+}
+
+function completedRunIdsFromMessages(
+  messages: readonly PagedChatMessage[],
+): string[] {
+  const ids = new Set<string>();
+  for (const message of messages) {
+    if (
+      message.role === "assistant" &&
+      message.runId !== undefined &&
+      (message.runLifecycleEvent === "completed" ||
+        message.status === "completed")
+    ) {
+      ids.add(message.runId);
+    }
+  }
+  return Array.from(ids);
 }
 
 function isUnterminatedAssistantRunMessage(
@@ -827,10 +845,29 @@ type ServerMessages$ = State<PagedChatMessage[]>;
 function createAppendServerMessages(
   threadId: string,
   serverMessages$: ServerMessages$,
+  reportedCompletedRunIds$: State<Set<string>>,
 ) {
-  return command(({ set }, msgs: PagedChatMessage[]) => {
+  return command(({ get, set }, msgs: PagedChatMessage[]) => {
     if (msgs.length === 0) {
       return;
+    }
+    const reportedCompletedRunIds = get(reportedCompletedRunIds$);
+    const newlyCompletedRunIds = completedRunIdsFromMessages(msgs).filter(
+      (runId) => {
+        return !reportedCompletedRunIds.has(runId);
+      },
+    );
+    for (let i = 0; i < newlyCompletedRunIds.length; i++) {
+      captureTaskCompletedSuccessfully();
+    }
+    if (newlyCompletedRunIds.length > 0) {
+      set(reportedCompletedRunIds$, (prev) => {
+        const next = new Set(prev);
+        for (const runId of newlyCompletedRunIds) {
+          next.add(runId);
+        }
+        return next;
+      });
     }
     set(serverMessages$, (prev) => {
       const byId = new Map<string, PagedChatMessage>();
@@ -1016,12 +1053,14 @@ function createFetchNextPageCommand({
   initialPage$,
   nextCursorId$,
   appendServerMessages$,
+  reportedCompletedRunIds$,
   dataSource,
 }: {
   threadId: string;
   initialPage$: Computed<Promise<InitialPage>>;
   nextCursorId$: State<string | undefined>;
   appendServerMessages$: Command<void, [PagedChatMessage[]]>;
+  reportedCompletedRunIds$: State<Set<string>>;
   dataSource: ChatThreadDataSource;
 }): Command<Promise<boolean>, [AbortSignal]> {
   return command(async ({ get, set }, signal: AbortSignal) => {
@@ -1032,6 +1071,17 @@ function createFetchNextPageCommand({
       set(reconcileOptimisticChatMessages$, {
         threadId,
         messages: initial.messages,
+      });
+      set(reportedCompletedRunIds$, (prev) => {
+        const ids = completedRunIdsFromMessages(initial.messages);
+        if (ids.length === 0) {
+          return prev;
+        }
+        const next = new Set(prev);
+        for (const runId of ids) {
+          next.add(runId);
+        }
+        return next;
       });
       sinceId = initial.messages[initial.messages.length - 1]?.id;
       L.debug("fetchNextPage$ initialPage seeded sinceId", {
@@ -1088,9 +1138,11 @@ function createPagedMessages(
   const initialPage$ = createInitialPage(dataSource);
 
   const serverMessages$ = state<PagedChatMessage[]>([]);
+  const reportedCompletedRunIds$ = state(new Set<string>());
   const appendServerMessages$ = createAppendServerMessages(
     threadId,
     serverMessages$,
+    reportedCompletedRunIds$,
   );
   const optimisticMessages$ = createOptimisticChatMessagesForThread(threadId);
 
@@ -1150,6 +1202,7 @@ function createPagedMessages(
     initialPage$,
     nextCursorId$,
     appendServerMessages$,
+    reportedCompletedRunIds$,
     dataSource,
   });
 

--- a/turbo/apps/platform/src/signals/zero-page/zero-onboarding.ts
+++ b/turbo/apps/platform/src/signals/zero-page/zero-onboarding.ts
@@ -8,6 +8,7 @@ import { clerk$ } from "../auth.ts";
 import { zeroClient$ } from "../api-client.ts";
 import { logger } from "../log.ts";
 import { accept } from "../../lib/accept.ts";
+import { captureOnboardingStep } from "../../lib/posthog.ts";
 
 const L = logger("ZeroOnboarding");
 
@@ -129,6 +130,7 @@ export const zeroSelectedConnectors$ = computed((get) => {
 
 export const setZeroStep$ = command(({ set }, step: ZeroOnboardingStep) => {
   set(userStep$, step);
+  captureOnboardingStep(step);
 });
 
 export const setZeroAgentName$ = command(({ set }, name: string) => {


### PR DESCRIPTION
## What

Consolidates Sijia/Scarlett's frontend PostHog trend instrumentation into one PR.

Events added:

- `onboarding_step_viewed`
  - Fired from `setZeroStep$` in `zero-onboarding.ts`.
  - Properties: `step = 1|2|3|4|done`.
  - Purpose: see per-step onboarding funnel drop-off inside the single `/onboarding` route.

- `task_completed_successfully`
  - Fired from the frontend chat thread message stream when a newly observed assistant message indicates a run completed successfully.
  - Properties: `surface = chat_thread`.
  - Completed run ids are used only in local frontend state for de-duping; they are not sent to PostHog.

## Why

Product needs trend/funnel analytics, not a user-detail dashboard. This keeps the implementation frontend-only and avoids adding server-side PostHog infrastructure or API env vars.

## Scope / risk

- Frontend-only final PR diff.
- No new dependencies.
- No server env vars required.
- No prompt/result/error capture.
- Keeps existing PostHog identify behavior unchanged.
- Does not send run id or org id as event properties.
- Uses local in-memory run-id de-dupe so the same completed run is not counted repeatedly during one chat page lifecycle.

## Note

This supersedes #15770, which is no longer needed.