### PR TITLE
feat: show upstream usage/quota limit errors verbatim

### DIFF
--- a/turbo/apps/api/src/signals/routes/__tests__/internal-callbacks-chat.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/internal-callbacks-chat.test.ts
@@ -1078,12 +1078,10 @@ describe("POST /api/internal/callbacks/chat", () => {
     expect(context.mocks.axiom.query).not.toHaveBeenCalled();
   });
 
-  it("renders ChatGPT Codex usage limit errors with VM0 guidance", async () => {
+  it("shows Codex usage limit errors verbatim on failed callbacks", async () => {
     const fixture = await track(seedChatCallbackFixture());
     const codexUsageLimitError =
       "You've hit your usage limit. Visit https://chatgpt.com/codex/settings/usage to purchase more credits or try again at 6:17 AM.";
-    const expectedDisplayError =
-      "ChatGPT Codex usage limit reached. This limit resets at 6:17 AM. View details in [ChatGPT Codex usage settings](https://chatgpt.com/codex/settings/usage), or switch to another model to continue now.";
 
     const response = await postSignedCallback({
       callbackId: fixture.callbackId,
@@ -1100,9 +1098,37 @@ describe("POST /api/internal/callbacks/chat", () => {
     const errorMessage = messages.find((message) => {
       return message.role === "assistant" && message.runId === fixture.runId;
     });
-    expect(errorMessage?.error).toBe(expectedDisplayError);
-    expect(errorMessage?.content).toBe(expectedDisplayError);
-    expect(errorMessage?.error).not.toBe(codexUsageLimitError);
+    expect(errorMessage?.error).toBe(codexUsageLimitError);
+    expect(errorMessage?.content).toBe(codexUsageLimitError);
+    expect(errorMessage?.error).not.toContain("switch to another model");
+    expect(context.mocks.axiom.query).not.toHaveBeenCalled();
+  });
+
+  it("shows Claude session limit errors verbatim on failed callbacks", async () => {
+    const fixture = await track(seedChatCallbackFixture());
+    const sessionLimitError =
+      "You've hit your session limit · resets 12:50pm (Asia/Shanghai)";
+
+    const response = await postSignedCallback({
+      callbackId: fixture.callbackId,
+      runId: fixture.runId,
+      status: "failed",
+      error: sessionLimitError,
+      payload: { threadId: fixture.threadId, agentId: fixture.agentId },
+    });
+
+    expect(response.status).toBe(200);
+    await expect(response.json()).resolves.toStrictEqual({ success: true });
+
+    const messages = await listMessages(fixture.threadId);
+    const errorMessage = messages.find((message) => {
+      return message.role === "assistant" && message.runId === fixture.runId;
+    });
+    expect(errorMessage?.error).toBe(sessionLimitError);
+    expect(errorMessage?.content).toBe(sessionLimitError);
+    expect(errorMessage?.error).not.toBe(
+      "Oops, something went wrong. Please try again later.",
+    );
     expect(context.mocks.axiom.query).not.toHaveBeenCalled();
   });
 

--- a/turbo/packages/api-contracts/src/contracts/__tests__/errors.test.ts
+++ b/turbo/packages/api-contracts/src/contracts/__tests__/errors.test.ts
@@ -54,14 +54,37 @@ describe("formatRunErrorForExternalSurface", () => {
     ).toBe(INSUFFICIENT_CREDITS_ASK_ADMIN_MESSAGE);
   });
 
-  it("preserves ChatGPT Codex usage limit guidance", () => {
+  it("shows Codex usage limit errors verbatim", () => {
+    const codexUsageLimit =
+      "You've hit your usage limit. Visit https://chatgpt.com/codex/settings/usage to purchase more credits or try again at 6:17 AM.";
+    const formatted = formatRunErrorForExternalSurface({
+      code: "UNKNOWN",
+      message: codexUsageLimit,
+    });
+    expect(formatted).toBe(codexUsageLimit);
+    expect(formatted).not.toContain("switch to another model");
+  });
+
+  it("shows Claude session limit errors verbatim", () => {
+    const sessionLimit =
+      "You've hit your session limit · resets 12:50pm (Asia/Shanghai)";
     expect(
       formatRunErrorForExternalSurface({
         code: "UNKNOWN",
-        message:
-          "ChatGPT Codex usage limit reached. Visit chatgpt.com/codex/settings/usage.",
+        message: sessionLimit,
       }),
-    ).toContain("ChatGPT Codex usage limit reached.");
+    ).toBe(sessionLimit);
+  });
+
+  it("shows Claude weekly limit errors verbatim", () => {
+    const weeklyLimit =
+      "You've hit your weekly limit · resets 10am (Asia/Shanghai)";
+    expect(
+      formatRunErrorForExternalSurface({
+        code: "UNKNOWN",
+        message: weeklyLimit,
+      }),
+    ).toBe(weeklyLimit);
   });
 
   it("falls back to the Web generic message for unallowlisted errors", () => {

--- a/turbo/packages/api-contracts/src/contracts/errors.ts
+++ b/turbo/packages/api-contracts/src/contracts/errors.ts
@@ -129,10 +129,18 @@ export const ACTIONABLE_RUN_ERROR_SNIPPETS = [
   "Cannot continue session",
   "Invalid signature in thinking block",
   "Run cancelled",
+  // Upstream model usage/quota limits are shown verbatim (the CLI already
+  // emits clean, user-friendly copy with reset time and upgrade links).
+  // Codex: "You've hit your usage limit …"
   "usage limit",
   "usage_limit",
   "usage-limit",
   "UsageLimit",
+  // Claude Code subscription limits:
+  //   "You've hit your session limit · resets …"
+  //   "You've hit your weekly limit · resets …"
+  "session limit",
+  "weekly limit",
 ] as const;
 
 export function isActionableRunError(errorMessage: string): boolean {
@@ -144,10 +152,7 @@ export function isActionableRunError(errorMessage: string): boolean {
 
 export function isGenericRunErrorForDisplay(errorMessage: string): boolean {
   const normalizedErrorMessage = errorMessage.trim() || "Run failed";
-  return (
-    !formatChatgptCodexUsageLimitError(normalizedErrorMessage) &&
-    !isActionableRunError(normalizedErrorMessage)
-  );
+  return !isActionableRunError(normalizedErrorMessage);
 }
 
 /**
@@ -171,11 +176,6 @@ export function formatRunErrorForExternalSurface(params: {
       };
 }): string {
   const errorMessage = params.message.trim() || "Run failed";
-  const chatgptCodexUsageLimitMessage =
-    formatChatgptCodexUsageLimitError(errorMessage);
-  if (chatgptCodexUsageLimitMessage) {
-    return chatgptCodexUsageLimitMessage;
-  }
 
   if (
     params.code === "INSUFFICIENT_CREDITS" &&
@@ -193,49 +193,4 @@ export function formatRunErrorForExternalSurface(params: {
   return isGenericRunErrorForDisplay(errorMessage)
     ? CHAT_RUN_TRANSIENT_ERROR_MESSAGE
     : errorMessage;
-}
-
-const CHATGPT_CODEX_USAGE_DETAILS_URL =
-  "https://chatgpt.com/codex/settings/usage";
-
-function isChatgptCodexUsageLimitError(errorMessage: string): boolean {
-  const normalized = errorMessage.toLowerCase();
-  return (
-    normalized.includes("usage limit") &&
-    (normalized.includes("chatgpt.com/codex") ||
-      normalized.includes("codex/settings/usage") ||
-      normalized.includes("chatgpt codex"))
-  );
-}
-
-function extractChatgptCodexRetryPhrase(errorMessage: string): string | null {
-  const match = /\btry again\s+(at|after|in)\s+([^.;\n\r]+)/i.exec(
-    errorMessage,
-  );
-  if (!match) {
-    return null;
-  }
-
-  const preposition = match[1];
-  const retryAt = match[2]?.trim();
-  if (!preposition || !retryAt) {
-    return null;
-  }
-  if (retryAt.length > 80 || !/^[a-z0-9\s:,+/-]+$/i.test(retryAt)) {
-    return null;
-  }
-
-  return `${preposition.toLowerCase()} ${retryAt}`;
-}
-
-export function formatChatgptCodexUsageLimitError(
-  errorMessage: string,
-): string | null {
-  if (!isChatgptCodexUsageLimitError(errorMessage)) {
-    return null;
-  }
-
-  const retryPhrase = extractChatgptCodexRetryPhrase(errorMessage);
-  const retrySentence = retryPhrase ? ` This limit resets ${retryPhrase}.` : "";
-  return `ChatGPT Codex usage limit reached.${retrySentence} View details in [ChatGPT Codex usage settings](${CHATGPT_CODEX_USAGE_DETAILS_URL}), or switch to another model to continue now.`;
 }

--- a/turbo/packages/api-contracts/src/contracts/index.ts
+++ b/turbo/packages/api-contracts/src/contracts/index.ts
@@ -28,7 +28,6 @@ export {
   ApiError,
   CHAT_RUN_TRANSIENT_ERROR_MESSAGE,
   createErrorResponse,
-  formatChatgptCodexUsageLimitError,
   formatRunErrorForExternalSurface,
   isActionableRunError,
   isGenericRunErrorForDisplay,


### PR DESCRIPTION
## Summary

When a run fails because of an **upstream model usage/quota limit** (Claude Code session/weekly limit, Codex usage limit), the model's own error message is now shown to the user **verbatim** instead of being collapsed to the generic "Oops, something went wrong" message.

These CLI-produced limit messages are already clean, user-friendly copy (reset time + upgrade/credit links), so passing them through loses no information and needs no maintained copy.

## Changes (single shared function in `errors.ts`)

- Add `"session limit"` / `"weekly limit"` to `ACTIONABLE_RUN_ERROR_SNIPPETS` so Claude Code subscription limits are surfaced verbatim (`"usage limit"` already covered Codex).
- Remove the Codex usage-limit rewrite (`formatChatgptCodexUsageLimitError` + helpers + its calls in `formatRunErrorForExternalSurface` / `isGenericRunErrorForDisplay`, and the re-export in `index.ts`). Codex limits now show verbatim too, which **drops the previous "switch to another model" hint** and keeps Claude/Codex consistent.

One change covers web chat + Slack/Telegram/AgentPhone (all route through `formatRunErrorForExternalSurface`).

## Behavior (before → after)

| Error class | Before | After |
|---|---|---|
| Claude session/weekly limit | "Oops" | **verbatim** ✅ |
| Codex usage limit | rewritten "…switch to another model" | **verbatim** (hint removed) ✅ |
| 402 Insufficient credits | verbatim | verbatim (unchanged) |
| vm0 platform credits (pre-flight) | recharge card | recharge card (unchanged) |
| 529 overloaded / 401 invalid key / 400 bug / infra / proxy | "Oops" | "Oops" (unchanged) |

## Out of scope (not touched)

`failure_reason` / guest-agent classification / runner log-level routing; webhook contract / DB; mitm-addon proxy; vm0 recharge path; the "Oops" fallback for non-limit errors. (Note: the related observability gap #15360 — Claude session-limit still logged at `error` because classification is Codex-gated — is intentionally left for a separate change.)

## Testing

- `pnpm -F @vm0/api-contracts test src/contracts/__tests__/errors.test.ts` — 8 passed (incl. new Codex-verbatim, Claude session-limit, Claude weekly-limit cases)
- `pnpm -F api test src/signals/routes/__tests__/internal-callbacks-chat.test.ts` — 36 passed (Codex callback test updated to verbatim; new Claude session-limit callback test)
- `check-types`, `lint` (api-contracts + api), `prettier`, `knip` — all clean

Closes #15777

🤖 Generated with [Claude Code](https://claude.com/claude-code)