### PR TITLE
fix(api): move cron schedules to api deployment

### DIFF
--- a/turbo/apps/api/src/__tests__/vercel-crons.test.ts
+++ b/turbo/apps/api/src/__tests__/vercel-crons.test.ts
@@ -1,7 +1,18 @@
 import { readFileSync } from "node:fs";
 import { fileURLToPath } from "node:url";
 
-import { cronComputerUseScreenshotCleanupContract } from "@vm0/api-contracts/contracts/cron";
+import {
+  cronAggregateInsightsContract,
+  cronAggregateUsageContract,
+  cronCleanupSandboxesContract,
+  cronComputerUseScreenshotCleanupContract,
+  cronDrainEmailOutboxContract,
+  cronExecuteSchedulesContract,
+  cronProcessUsageEventsContract,
+  cronReconcileBillingEntitlementsContract,
+  cronSyncSkillsContract,
+  cronTelegramCleanupContract,
+} from "@vm0/api-contracts/contracts/cron";
 import { describe, expect, it } from "vitest";
 
 import { ROUTES } from "../signals/route";
@@ -22,14 +33,58 @@ function readVercelConfig(): VercelConfig {
   return JSON.parse(readFileSync(configPath, "utf8")) as VercelConfig;
 }
 
+const expectedVercelCrons = [
+  {
+    path: cronCleanupSandboxesContract.cleanup.path,
+    schedule: "* * * * *",
+  },
+  {
+    path: cronExecuteSchedulesContract.execute.path,
+    schedule: "* * * * *",
+  },
+  {
+    path: cronAggregateUsageContract.aggregate.path,
+    schedule: "5 0 * * *",
+  },
+  {
+    path: cronAggregateInsightsContract.aggregate.path,
+    schedule: "0 * * * *",
+  },
+  {
+    path: cronTelegramCleanupContract.cleanup.path,
+    schedule: "0 1 * * *",
+  },
+  {
+    path: cronDrainEmailOutboxContract.drain.path,
+    schedule: "* * * * *",
+  },
+  {
+    path: cronSyncSkillsContract.sync.path,
+    schedule: "* * * * *",
+  },
+  {
+    path: cronProcessUsageEventsContract.process.path,
+    schedule: "* * * * *",
+  },
+  {
+    path: cronReconcileBillingEntitlementsContract.reconcile.path,
+    schedule: "0 0,12 * * *",
+  },
+  {
+    path: cronComputerUseScreenshotCleanupContract.cleanup.path,
+    schedule: "30 2 * * *",
+  },
+  {
+    path: "/api/internal/cron/aggregate-model-stats",
+    schedule: "12 * * * *",
+  },
+] satisfies readonly VercelCron[];
+
 describe("vercel cron config", () => {
-  it("schedules computer-use screenshot cleanup", () => {
+  it("matches API-owned cron schedules", () => {
     const crons = readVercelConfig().crons ?? [];
 
-    expect(crons).toContainEqual({
-      path: cronComputerUseScreenshotCleanupContract.cleanup.path,
-      schedule: "30 2 * * *",
-    });
+    expect(crons).toStrictEqual(expectedVercelCrons);
   });
 
   it("targets existing API routes without duplicate paths", () => {

--- a/turbo/apps/api/vercel.json
+++ b/turbo/apps/api/vercel.json
@@ -5,6 +5,42 @@
   "installCommand": "cd ../.. && pnpm install",
   "crons": [
     {
+      "path": "/api/cron/cleanup-sandboxes",
+      "schedule": "* * * * *"
+    },
+    {
+      "path": "/api/cron/execute-schedules",
+      "schedule": "* * * * *"
+    },
+    {
+      "path": "/api/cron/aggregate-usage",
+      "schedule": "5 0 * * *"
+    },
+    {
+      "path": "/api/cron/aggregate-insights",
+      "schedule": "0 * * * *"
+    },
+    {
+      "path": "/api/cron/telegram-cleanup",
+      "schedule": "0 1 * * *"
+    },
+    {
+      "path": "/api/cron/drain-email-outbox",
+      "schedule": "* * * * *"
+    },
+    {
+      "path": "/api/cron/sync-skills",
+      "schedule": "* * * * *"
+    },
+    {
+      "path": "/api/cron/process-usage-events",
+      "schedule": "* * * * *"
+    },
+    {
+      "path": "/api/cron/reconcile-billing-entitlements",
+      "schedule": "0 0,12 * * *"
+    },
+    {
       "path": "/api/cron/computer-use-screenshot-cleanup",
       "schedule": "30 2 * * *"
     },

--- a/turbo/apps/web/__tests__/vercel-crons.test.ts
+++ b/turbo/apps/web/__tests__/vercel-crons.test.ts
@@ -1,0 +1,24 @@
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+
+import { describe, expect, it } from "vitest";
+
+interface VercelCron {
+  readonly path: string;
+  readonly schedule: string;
+}
+
+interface VercelConfig {
+  readonly crons?: readonly VercelCron[];
+}
+
+function readVercelConfig(): VercelConfig {
+  const configPath = fileURLToPath(new URL("../vercel.json", import.meta.url));
+  return JSON.parse(readFileSync(configPath, "utf8")) as VercelConfig;
+}
+
+describe("vercel cron config", () => {
+  it("does not register cron jobs from the web deployment", () => {
+    expect(readVercelConfig().crons ?? []).toStrictEqual([]);
+  });
+});

--- a/turbo/apps/web/vercel.json
+++ b/turbo/apps/web/vercel.json
@@ -1,43 +1,5 @@
 {
   "buildCommand": "cd ../.. && pnpm run build --filter=web",
   "installCommand": "cd ../.. && pnpm install",
-  "outputDirectory": ".next",
-  "crons": [
-    {
-      "path": "/api/cron/cleanup-sandboxes",
-      "schedule": "* * * * *"
-    },
-    {
-      "path": "/api/cron/execute-schedules",
-      "schedule": "* * * * *"
-    },
-    {
-      "path": "/api/cron/aggregate-usage",
-      "schedule": "5 0 * * *"
-    },
-    {
-      "path": "/api/cron/aggregate-insights",
-      "schedule": "0 * * * *"
-    },
-    {
-      "path": "/api/cron/telegram-cleanup",
-      "schedule": "0 1 * * *"
-    },
-    {
-      "path": "/api/cron/drain-email-outbox",
-      "schedule": "* * * * *"
-    },
-    {
-      "path": "/api/cron/sync-skills",
-      "schedule": "* * * * *"
-    },
-    {
-      "path": "/api/cron/process-usage-events",
-      "schedule": "* * * * *"
-    },
-    {
-      "path": "/api/cron/reconcile-billing-entitlements",
-      "schedule": "0 0,12 * * *"
-    }
-  ]
+  "outputDirectory": ".next"
 }


### PR DESCRIPTION
## Summary\n\nCloses #15783.\n\nMove the remaining Vercel cron schedules from the web deployment config to the API deployment config. The routes already resolve in apps/api, while apps/web keeps its API backend rewrites for compatibility with direct web-domain traffic.\n\n## Changes\n\n- Move the remaining /api/cron/* schedule entries from apps/web/vercel.json to apps/api/vercel.json\n- Keep the existing API-only cron schedules in apps/api/vercel.json\n- Expand API cron config tests to validate the complete API-owned schedule list and route registration\n- Add a web config test to ensure apps/web no longer registers cron jobs\n\n## Verification\n\n- pnpm -F api exec vitest run src/__tests__/vercel-crons.test.ts\n- pnpm -F web exec vitest run __tests__/vercel-crons.test.ts\n- pnpm -F api lint\n- pnpm -F web lint\n- pnpm -F api check-types\n- pnpm -F web check-types\n- pnpm --dir apps/api build\n- git diff --check\n\nThe API build output config includes the migrated cron list in apps/api/.vercel/output/config.json.