### PR TITLE
chore: update rootfs package versions

### DIFF
--- a/crates/runner/scripts/build-template.sh
+++ b/crates/runner/scripts/build-template.sh
@@ -111,11 +111,11 @@ CACHE_TMP_TAR=""
 
 # Pinned versions (changes here invalidate the template cache via script hash)
 GO_VERSION="1.26.3"
-CLAUDE_CODE_VERSION="2.1.159"
-CODEX_CLI_VERSION="0.135.0"
+CLAUDE_CODE_VERSION="2.1.160"
+CODEX_CLI_VERSION="0.136.0"
 GWS_CLI_VERSION="0.22.5"
 XURL_VERSION="1.0.3"
-AGENT_BROWSER_VERSION="0.27.0"
+AGENT_BROWSER_VERSION="0.27.1"
 PNPM_VERSION="11.5.0"
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Updates

Updated pinned rootfs tool versions in `crates/runner/scripts/build-template.sh`:

- Claude Code CLI: `2.1.159` -> `2.1.160`
- Codex CLI (`@openai/codex`): `0.135.0` -> `0.136.0`
- agent-browser: `0.27.0` -> `0.27.1`

## Checks

- Verified Go remains current at `1.26.3`.
- Verified Google Workspace CLI remains current at `0.22.5`.
- Verified xurl remains current at `1.0.3`.
- Verified pnpm remains current at `11.5.0`.
- Verified Node.js remains on the current LTS major line (`24.x`).
- Verified Ubuntu 24.04 package repositories still provide `postgresql-16` for the configured rootfs; Ubuntu was not updated.

## Validation

- `bash -n crates/runner/scripts/build-template.sh`