### PR TITLE
fix: reject invalid zero chat model selections

### DIFF
--- a/turbo/apps/api/src/signals/routes/__tests__/zero-chat-messages.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/zero-chat-messages.test.ts
@@ -1655,6 +1655,122 @@ describe("POST /api/zero/chat/messages", () => {
     expect(executionContext.modelUsageProvider).toBe("claude-sonnet-4-6");
   });
 
+  it("rejects unsupported model-first selections before creating a thread", async () => {
+    const fixture = await track(seedFixture());
+    const writeDb = store.set(writeDb$);
+    const clientThreadId = randomUUID();
+
+    const response = await accept(
+      client().send({
+        headers: authHeaders(),
+        body: {
+          agentId: fixture.agentId,
+          prompt: "do not persist invalid model",
+          clientThreadId,
+          modelSelection: {
+            modelProviderId: "00000000-0000-4000-8000-000000000000",
+            selectedModel: "codex",
+          },
+        },
+      }),
+      [400],
+    );
+
+    expect(response.body.error.code).toBe("BAD_REQUEST");
+    const [thread] = await writeDb
+      .select({ id: chatThreads.id })
+      .from(chatThreads)
+      .where(eq(chatThreads.id, clientThreadId))
+      .limit(1);
+    expect(thread).toBeUndefined();
+    const [preference] = await writeDb
+      .select({ selectedModel: orgMembersMetadata.selectedModel })
+      .from(orgMembersMetadata)
+      .where(
+        and(
+          eq(orgMembersMetadata.orgId, fixture.orgId),
+          eq(orgMembersMetadata.userId, fixture.userId),
+        ),
+      )
+      .limit(1);
+    expect(preference).toBeUndefined();
+  });
+
+  it("rejects invalid stored model-first thread pins before run creation", async () => {
+    const fixture = await track(seedFixture());
+    const writeDb = store.set(writeDb$);
+    const threadId = randomUUID();
+    await writeDb.insert(chatThreads).values({
+      id: threadId,
+      userId: fixture.userId,
+      agentComposeId: fixture.agentId,
+      title: null,
+      modelProviderId: null,
+      modelProviderType: null,
+      modelProviderCredentialScope: null,
+      selectedModel: "codex",
+    });
+
+    const response = await accept(
+      client().send({
+        headers: authHeaders(),
+        body: {
+          agentId: fixture.agentId,
+          prompt: "continue invalid stored model thread",
+          threadId,
+        },
+      }),
+      [400],
+    );
+
+    expect(response.body.error).toStrictEqual({
+      code: "BAD_REQUEST",
+      message: "Invalid model selection",
+    });
+    const [run] = await writeDb
+      .select({ id: agentRuns.id })
+      .from(agentRuns)
+      .where(eq(agentRuns.userId, fixture.userId))
+      .limit(1);
+    expect(run).toBeUndefined();
+  });
+
+  it("rejects unsupported selected models for explicit VM0 provider pins", async () => {
+    const fixture = await track(seedFixture());
+    const writeDb = store.set(writeDb$);
+    const providerId = await seedModelProvider(fixture, "claude-sonnet-4-6", {
+      type: "vm0",
+    });
+    const clientThreadId = randomUUID();
+
+    const response = await accept(
+      client().send({
+        headers: authHeaders(),
+        body: {
+          agentId: fixture.agentId,
+          prompt: "do not run invalid vm0 provider model",
+          clientThreadId,
+          modelSelection: {
+            modelProviderId: providerId,
+            selectedModel: "codex",
+          },
+        },
+      }),
+      [400],
+    );
+
+    expect(response.body.error).toStrictEqual({
+      code: "BAD_REQUEST",
+      message: "Invalid model selection",
+    });
+    const [thread] = await writeDb
+      .select({ id: chatThreads.id })
+      .from(chatThreads)
+      .where(eq(chatThreads.id, clientThreadId))
+      .limit(1);
+    expect(thread).toBeUndefined();
+  });
+
   it("passes explicit provider selection into the runner job context", async () => {
     const fixture = await track(seedFixture());
     const writeDb = store.set(writeDb$);

--- a/turbo/apps/api/src/signals/routes/zero-chat-messages.ts
+++ b/turbo/apps/api/src/signals/routes/zero-chat-messages.ts
@@ -1071,18 +1071,15 @@ async function validateModelSelection(params: {
   readonly modelSelection: IncomingModelSelection;
   readonly forceNewSession: boolean;
 }): Promise<ReturnType<typeof badRequestMessage> | undefined> {
-  if (
-    params.modelSelection &&
-    params.modelSelection.modelProviderId !== MODEL_FIRST_SELECTION_PROVIDER_ID
-  ) {
-    const available = await modelProviderPinAvailable({
+  if (params.modelSelection) {
+    const pin = await resolveModelSelectionPin({
       db: params.db,
       orgId: params.orgId,
       userId: params.userId,
-      modelProviderId: params.modelSelection.modelProviderId,
+      modelSelection: params.modelSelection,
     });
-    if (!available) {
-      return badRequestMessage("Unknown model provider for this workspace");
+    if ("status" in pin) {
+      return pin;
     }
   }
 

--- a/turbo/apps/api/src/signals/services/zero-model-selection.service.ts
+++ b/turbo/apps/api/src/signals/services/zero-model-selection.service.ts
@@ -1,4 +1,7 @@
-import type { ModelProviderCredentialScope } from "@vm0/api-contracts/contracts/model-providers";
+import {
+  isSupportedRunModel,
+  type ModelProviderCredentialScope,
+} from "@vm0/api-contracts/contracts/model-providers";
 import { modelProviders } from "@vm0/db/schema/model-provider";
 import { orgMembersMetadata } from "@vm0/db/schema/org-members-metadata";
 import { orgModelPolicies } from "@vm0/db/schema/org-model-policy";
@@ -23,6 +26,10 @@ export interface ModelFirstPin {
 interface ModelSelectionRequest {
   readonly modelProviderId: string;
   readonly selectedModel: string;
+}
+
+interface AvailableModelProviderPin {
+  readonly type: string;
 }
 
 function parseModelProviderCredentialScope(
@@ -112,8 +119,17 @@ export async function modelProviderPinAvailable(params: {
   readonly userId: string;
   readonly modelProviderId: string;
 }): Promise<boolean> {
+  return (await loadAvailableModelProviderPin(params)) !== null;
+}
+
+async function loadAvailableModelProviderPin(params: {
+  readonly db: Db;
+  readonly orgId: string;
+  readonly userId: string;
+  readonly modelProviderId: string;
+}): Promise<AvailableModelProviderPin | null> {
   const [provider] = await params.db
-    .select({ id: modelProviders.id })
+    .select({ type: modelProviders.type })
     .from(modelProviders)
     .where(
       and(
@@ -126,7 +142,7 @@ export async function modelProviderPinAvailable(params: {
       ),
     )
     .limit(1);
-  return provider !== undefined;
+  return provider ?? null;
 }
 
 export async function resolveModelSelectionPin(params: {
@@ -137,14 +153,20 @@ export async function resolveModelSelectionPin(params: {
 }): Promise<ModelFirstPin | ReturnType<typeof badRequestMessage>> {
   const { db, orgId, userId, modelSelection } = params;
   if (modelSelection.modelProviderId !== MODEL_FIRST_SELECTION_PROVIDER_ID) {
-    const available = await modelProviderPinAvailable({
+    const provider = await loadAvailableModelProviderPin({
       db,
       orgId,
       userId,
       modelProviderId: modelSelection.modelProviderId,
     });
-    if (!available) {
+    if (!provider) {
       return badRequestMessage("Unknown model provider for this workspace");
+    }
+    if (
+      provider.type === "vm0" &&
+      !isSupportedRunModel(modelSelection.selectedModel)
+    ) {
+      return badRequestMessage("Invalid model selection");
     }
     return {
       modelProviderId: modelSelection.modelProviderId,
@@ -152,6 +174,10 @@ export async function resolveModelSelectionPin(params: {
       modelProviderCredentialScope: null,
       selectedModel: modelSelection.selectedModel,
     };
+  }
+
+  if (!isSupportedRunModel(modelSelection.selectedModel)) {
+    return badRequestMessage("Invalid model selection");
   }
 
   await ensureOrgModelPolicies(db, orgId, userId);

--- a/turbo/packages/api-contracts/src/contracts/chat-threads.ts
+++ b/turbo/packages/api-contracts/src/contracts/chat-threads.ts
@@ -3,11 +3,14 @@ import { authHeadersSchema, initContract } from "./base";
 import { apiErrorSchema } from "./errors";
 import { runStatusSchema } from "./runs";
 import {
+  isSupportedRunModel,
   modelProviderCredentialScopeSchema,
   modelProviderTypeSchema,
 } from "./model-providers";
 
 const c = initContract();
+const MODEL_FIRST_SELECTION_PROVIDER_ID =
+  "00000000-0000-4000-8000-000000000000";
 
 /**
  * File attachment metadata stored alongside user messages.
@@ -207,10 +210,23 @@ const chatThreadDetailSchema = z.object({
  * the object is present; pass `null` to clear the thread's override and fall
  * back to the agent/org default; omit to leave the thread's override unchanged.
  */
-const modelSelectionRequestSchema = z.object({
-  modelProviderId: z.string().uuid(),
-  selectedModel: z.string().min(1),
-});
+const modelSelectionRequestSchema = z
+  .object({
+    modelProviderId: z.string().uuid(),
+    selectedModel: z.string().min(1),
+  })
+  .superRefine((value, ctx) => {
+    if (
+      value.modelProviderId === MODEL_FIRST_SELECTION_PROVIDER_ID &&
+      !isSupportedRunModel(value.selectedModel)
+    ) {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        path: ["selectedModel"],
+        message: "Invalid model selection",
+      });
+    }
+  });
 
 /**
  * Chat threads list route contract (/api/chat-threads)


### PR DESCRIPTION
## Summary

- Reject unsupported model-first `modelSelection.selectedModel` values at the chat message contract boundary.
- Validate Zero chat model selection pins before thread creation and run creation, including explicit `vm0` provider pins and stored model-first thread pins.
- Preserve compatibility for supported legacy built-in model pins that no longer have an org policy.

Closes #15785.

## Tests

- `pnpm -F @vm0/api-contracts check-types`
- `pnpm -F api check-types`
- `pnpm -F @vm0/api-contracts lint`
- `pnpm -F api lint`
- `pnpm -F api exec vitest run src/signals/routes/__tests__/zero-chat-messages.test.ts`
- `pnpm knip --workspace api --workspace @vm0/api-contracts`
- pre-commit hook: `prettier`, `knip --cache`, `turbo run check-types --concurrency=1`
