### PR TITLE
chore(rust): update dependencies

### DIFF
--- a/crates/Cargo.lock
+++ b/crates/Cargo.lock
@@ -376,9 +376,9 @@ dependencies = [
 
 [[package]]
 name = "aws-smithy-http-client"
-version = "1.1.12"
+version = "1.1.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6a2f165a7feee6f263028b899d0a181987f4fa7179a6411a32a439fba7c5f769"
+checksum = "5c3ef8931ad1c98aa6a55b4256f847f3116090819844e0dd41ea682cac5dd2d3"
 dependencies = [
  "aws-smithy-async",
  "aws-smithy-protocol-test",
@@ -410,9 +410,9 @@ dependencies = [
 
 [[package]]
 name = "aws-smithy-json"
-version = "0.62.6"
+version = "0.62.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "517089205f18ab4adc5a3e02888cb139bbbbb2e168eac9f396216925d1fbeaf5"
+checksum = "701a947f4797e52a911e114a898667c746c39feea467bbd1abd7b3721f702ffa"
 dependencies = [
  "aws-smithy-runtime-api",
  "aws-smithy-schema",
@@ -488,9 +488,9 @@ dependencies = [
 
 [[package]]
 name = "aws-smithy-runtime-api"
-version = "1.12.1"
+version = "1.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dc117c179ecf39a62a0a3f49f600e9ac26a7ad7dd172177999f83933af776c32"
+checksum = "9db177daa6ba8afb9ee1aefcf548c907abcf52065e394ee11a92780057fe0e8c"
 dependencies = [
  "aws-smithy-async",
  "aws-smithy-runtime-api-macros",
@@ -528,9 +528,9 @@ dependencies = [
 
 [[package]]
 name = "aws-smithy-types"
-version = "1.4.8"
+version = "1.4.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "056b66dbce2f81cc0c1e2b05bb402eb58f8a3530479d650efadd5bbae9a4050b"
+checksum = "53f93074121a1be41317b9aa607143ae17900631f7f59a99f2b905d519d6783b"
 dependencies = [
  "base64-simd",
  "bytes",
@@ -2648,9 +2648,9 @@ dependencies = [
 
 [[package]]
 name = "rustls-native-certs"
-version = "0.8.3"
+version = "0.8.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "612460d5f7bea540c490b2b6395d8e34a953e52b491accd6c86c8164c5932a63"
+checksum = "dab5152771c58876a2146916e53e35057e1a4dfa2b9df0f0305b07f611fdea4d"
 dependencies = [
  "openssl-probe",
  "rustls-pki-types",


### PR DESCRIPTION
## Summary

- Updated the Rust workspace lockfile under `crates/`.
- `cargo update --verbose` updated 5 transitive packages:
  - `aws-smithy-http-client` `1.1.12` -> `1.1.13`
  - `aws-smithy-json` `0.62.6` -> `0.62.7`
  - `aws-smithy-runtime-api` `1.12.1` -> `1.12.3`
  - `aws-smithy-types` `1.4.8` -> `1.4.9`
  - `rustls-native-certs` `0.8.3` -> `0.8.4`
- No `Cargo.toml` files were changed.

## Dependencies not updated

- `generic-array` stayed at `0.14.7` while `0.14.9` is available. A precise update attempt fails because `crypto-common v0.1.7` requires `generic-array = "=0.14.7"`; this is a transitive exact pin outside this repo's manifests.

## Manual version bumps

- None.

## Tests

- PASS: `env -u CLI_AGENT_TYPE -u VM0_PROMPT -u VM0_RUN_ID -u VM0_API_URL -u VM0_API_TOKEN -u VM0_SANDBOX_ID -u VM0_SANDBOX_REUSE_RESULT -u VM0_APPEND_SYSTEM_PROMPT -u VM0_RESUME_SESSION_ID -u VM0_SECRET_VALUES CARGO_TARGET_DIR=/home/user/workspace/vm0-rust-deps-target cargo test --workspace -j 1`
- Notes: initial test attempts hit local environment limits (`/tmp` disk exhaustion, then linker memory pressure). The passing run used a target directory on the larger workspace volume, single-job Cargo scheduling, and unset vm0 runtime env vars for a clean test process.
