### PR TITLE
refactor: scope legacy manual grant cleanup

### DIFF
--- a/turbo/apps/api/src/signals/routes/__tests__/connectors-type-callback.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/connectors-type-callback.test.ts
@@ -1,9 +1,11 @@
 import { randomUUID } from "node:crypto";
 
-import type {
-  AuthCodeGrantConnectorType,
-  ConnectorAuthMethodId,
-  ConnectorAuthClientConfig,
+import {
+  CONNECTOR_TYPES,
+  type AuthCodeGrantConnectorType,
+  type ConnectorAuthMethodId,
+  type ConnectorAuthClientConfig,
+  type ConnectorAuthMethodConfig,
 } from "@vm0/connectors/connectors";
 import {
   connectorAuthMethodHasGrantKind,
@@ -20,6 +22,7 @@ import { connectorOauthStates } from "@vm0/db/schema/connector-oauth-state";
 import { githubInstallations } from "@vm0/db/schema/github-installation";
 import { githubUserLinks } from "@vm0/db/schema/github-user-link";
 import { secrets } from "@vm0/db/schema/secret";
+import { variables } from "@vm0/db/schema/variable";
 import { createStore } from "ccstate";
 import { and, eq } from "drizzle-orm";
 import { http, HttpResponse } from "msw";
@@ -277,6 +280,71 @@ function configureDynamicTestOAuthExchange(
   return () => {
     mutableMethod.client = originalClient;
     provider.grant.exchangeCode = originalExchangeCode;
+  };
+}
+
+function testManualAuthMethod(args: {
+  readonly secretName: string;
+  readonly variableName: string;
+}): ConnectorAuthMethodConfig {
+  return {
+    label: `Manual ${args.secretName}`,
+    helpText: "Test-only manual grant.",
+    grant: {
+      kind: "manual",
+      fields: {
+        [args.secretName]: {
+          label: "Token",
+          required: true,
+        },
+        [args.variableName]: {
+          label: "Host",
+          required: false,
+          storage: "variable",
+        },
+      },
+    },
+    access: {
+      kind: "static",
+      envBindings: {
+        [args.secretName]: `$secrets.${args.secretName}`,
+        [args.variableName]: `$vars.${args.variableName}`,
+      },
+    },
+    revoke: { kind: "none" },
+  };
+}
+
+function configureTestOauthManualGrantAuthMethods(): () => void {
+  const authMethods = CONNECTOR_TYPES["test-oauth"].authMethods;
+  const originalApiDescriptor = Object.getOwnPropertyDescriptor(
+    authMethods,
+    "api",
+  );
+  Object.defineProperty(authMethods, "api-token", {
+    value: testManualAuthMethod({
+      secretName: "TEST_OAUTH_LEGACY_TOKEN",
+      variableName: "TEST_OAUTH_LEGACY_HOST",
+    }),
+    configurable: true,
+    enumerable: true,
+  });
+  Object.defineProperty(authMethods, "api", {
+    value: testManualAuthMethod({
+      secretName: "TEST_OAUTH_OTHER_TOKEN",
+      variableName: "TEST_OAUTH_OTHER_HOST",
+    }),
+    configurable: true,
+    enumerable: true,
+  });
+
+  return () => {
+    Reflect.deleteProperty(authMethods, "api-token");
+    if (originalApiDescriptor) {
+      Object.defineProperty(authMethods, "api", originalApiDescriptor);
+    } else {
+      Reflect.deleteProperty(authMethods, "api");
+    }
   };
 }
 
@@ -990,6 +1058,7 @@ async function findSecret(args: {
   readonly orgId: string;
   readonly userId: string;
   readonly name: string;
+  readonly type?: "connector" | "user";
 }) {
   const db = store.set(writeDb$);
   const [secret] = await db
@@ -1000,10 +1069,31 @@ async function findSecret(args: {
         eq(secrets.orgId, args.orgId),
         eq(secrets.userId, args.userId),
         eq(secrets.name, args.name),
-        eq(secrets.type, "connector"),
+        eq(secrets.type, args.type ?? "connector"),
       ),
     );
   return secret;
+}
+
+async function findVariable(args: {
+  readonly orgId: string;
+  readonly userId: string;
+  readonly name: string;
+  readonly type?: "connector" | "user";
+}) {
+  const db = store.set(writeDb$);
+  const [variable] = await db
+    .select()
+    .from(variables)
+    .where(
+      and(
+        eq(variables.orgId, args.orgId),
+        eq(variables.userId, args.userId),
+        eq(variables.name, args.name),
+        eq(variables.type, args.type ?? "connector"),
+      ),
+    );
+  return variable;
 }
 
 async function findDecryptedSecret(args: {
@@ -1235,6 +1325,7 @@ describe("GET /api/connectors/:type/callback", () => {
   const orgIds: string[] = [];
   const oauthStateIds: string[] = [];
   let restoreDynamicTestOAuthExchange: (() => void) | undefined;
+  let restoreTestOauthManualGrantAuthMethods: (() => void) | undefined;
 
   beforeEach(() => {
     mockEnv("VM0_WEB_URL", BASE_URL);
@@ -1250,6 +1341,8 @@ describe("GET /api/connectors/:type/callback", () => {
   }
 
   afterEach(async () => {
+    restoreTestOauthManualGrantAuthMethods?.();
+    restoreTestOauthManualGrantAuthMethods = undefined;
     restoreDynamicTestOAuthExchange?.();
     restoreDynamicTestOAuthExchange = undefined;
 
@@ -1264,6 +1357,7 @@ describe("GET /api/connectors/:type/callback", () => {
           .where(eq(githubInstallations.orgId, orgId));
         await db.delete(connectors).where(eq(connectors.orgId, orgId));
         await db.delete(secrets).where(eq(secrets.orgId, orgId));
+        await db.delete(variables).where(eq(variables.orgId, orgId));
         await db.delete(agentComposes).where(eq(agentComposes.orgId, orgId));
       }
     }
@@ -2084,6 +2178,118 @@ describe("GET /api/connectors/:type/callback", () => {
         name: "TEST_OAUTH_ACCESS_TOKEN",
       }),
     ).resolves.toBeUndefined();
+  });
+
+  it("deletes legacy manual grant rows only for the stored auth method", async () => {
+    restoreTestOauthManualGrantAuthMethods =
+      configureTestOauthManualGrantAuthMethods();
+    const dynamicOAuth = useDynamicTestOAuthExchange();
+    restoreDynamicTestOAuthExchange = dynamicOAuth.restore;
+    const orgId = `org_${randomUUID()}`;
+    const userId = `user_${randomUUID()}`;
+    orgIds.push(orgId);
+    authenticate({ userId, orgId });
+    const db = store.set(writeDb$);
+    await db.insert(connectors).values({
+      orgId,
+      userId,
+      type: "test-oauth",
+      authMethod: "api-token",
+    });
+    await db.insert(secrets).values([
+      {
+        orgId,
+        userId,
+        name: "TEST_OAUTH_LEGACY_TOKEN",
+        encryptedValue: "encrypted_legacy_token",
+        type: "user",
+      },
+      {
+        orgId,
+        userId,
+        name: "TEST_OAUTH_OTHER_TOKEN",
+        encryptedValue: "encrypted_other_token",
+        type: "user",
+      },
+    ]);
+    await db.insert(variables).values([
+      {
+        orgId,
+        userId,
+        name: "TEST_OAUTH_LEGACY_HOST",
+        value: "legacy.example.com",
+        type: "user",
+      },
+      {
+        orgId,
+        userId,
+        name: "TEST_OAUTH_OTHER_HOST",
+        value: "other.example.com",
+        type: "user",
+      },
+    ]);
+    await seedTrackedOauthState({
+      type: "test-oauth",
+      authMethod: "oauth",
+      userId,
+      orgId,
+      state: "state-123",
+    });
+
+    const response = await requestCallback({
+      type: "test-oauth",
+      query: { code: "code-123", state: "state-123" },
+      headers: callbackHeaders({ stateCookie: "state-123" }),
+    });
+
+    expect(response.status).toBe(307);
+    await expect(
+      findConnector({ orgId, userId, type: "test-oauth" }),
+    ).resolves.toMatchObject({
+      type: "test-oauth",
+      authMethod: "oauth",
+      externalId: "dynamic-user-id",
+      needsReconnect: false,
+    });
+    await expect(
+      findSecret({
+        orgId,
+        userId,
+        name: "TEST_OAUTH_ACCESS_TOKEN",
+      }),
+    ).resolves.toBeDefined();
+    await expect(
+      findSecret({
+        orgId,
+        userId,
+        name: "TEST_OAUTH_LEGACY_TOKEN",
+        type: "user",
+      }),
+    ).resolves.toBeUndefined();
+    await expect(
+      findVariable({
+        orgId,
+        userId,
+        name: "TEST_OAUTH_LEGACY_HOST",
+        type: "user",
+      }),
+    ).resolves.toBeUndefined();
+    await expect(
+      findSecret({
+        orgId,
+        userId,
+        name: "TEST_OAUTH_OTHER_TOKEN",
+        type: "user",
+      }),
+    ).resolves.toBeDefined();
+    await expect(
+      findVariable({
+        orgId,
+        userId,
+        name: "TEST_OAUTH_OTHER_HOST",
+        type: "user",
+      }),
+    ).resolves.toMatchObject({ value: "other.example.com" });
   });
 
   it("uses VM0_WEB_URL for token exchange and success redirects", async () => {

--- a/turbo/apps/api/src/signals/services/zero-connector-data.service.ts
+++ b/turbo/apps/api/src/signals/services/zero-connector-data.service.ts
@@ -11,7 +11,7 @@ import {
   getConnectorAuthMethodAccessMetadata,
   getConnectorAuthMethodScopeDiff,
   getConnectorAuthMethod,
-  getConnectorManualGrantFieldNames,
+  getConnectorManualGrantFieldNamesForAuthMethod,
   getConnectorOwnedAccessSecretBindingEntries,
   getConnectorOwnedSecretNames,
   getConnectorVariableNames,
@@ -605,6 +605,36 @@ async function deleteManualGrantConnectorLocalState(args: {
   }
 
   return deleted;
+}
+
+async function deleteManualGrantConnectorLocalStateForAuthMethods(args: {
+  readonly db: Db;
+  readonly orgId: string;
+  readonly userId: string;
+  readonly type: ConnectorType;
+  readonly authMethods: readonly (string | null)[];
+  readonly signal: AbortSignal;
+}): Promise<void> {
+  const cleanupAuthMethods = new Set<string>();
+  for (const authMethod of args.authMethods) {
+    if (authMethod) {
+      cleanupAuthMethods.add(authMethod);
+    }
+  }
+
+  for (const authMethod of cleanupAuthMethods) {
+    args.signal.throwIfAborted();
+    await deleteManualGrantConnectorLocalState({
+      db: args.db,
+      orgId: args.orgId,
+      userId: args.userId,
+      fields: getConnectorManualGrantFieldNamesForAuthMethod(
+        args.type,
+        authMethod,
+      ),
+      signal: args.signal,
+    });
+  }
 }
 
 export const deleteZeroConnectorLocalState$ = command(
@@ -1563,7 +1593,6 @@ export const upsertConnectorTokenConnection$ = command(
     );
     signal.throwIfAborted();
 
-    const manualGrantFields = getConnectorManualGrantFieldNames(args.type);
     let postCommitAbort: unknown = null;
     const connectorRow = await writeDb.transaction(async (tx) => {
       await lockConnectorState(tx, {
@@ -1609,11 +1638,12 @@ export const upsertConnectorTokenConnection$ = command(
         signal,
       });
 
-      await deleteManualGrantConnectorLocalState({
+      await deleteManualGrantConnectorLocalStateForAuthMethods({
         db: tx,
         orgId: args.orgId,
         userId: args.userId,
-        fields: manualGrantFields,
+        type: args.type,
+        authMethods: [existingAuthMethod, args.authMethod],
         signal,
       });
 

--- a/turbo/packages/connectors/src/__tests__/connectors.test.ts
+++ b/turbo/packages/connectors/src/__tests__/connectors.test.ts
@@ -50,6 +50,7 @@ import {
   getConnectorTypeForSecretName,
   getConnectorEnvBindingEntries,
   getConnectorManualGrantFieldNames,
+  getConnectorManualGrantFieldNamesForAuthMethod,
   getRuntimeAvailableConnectorTypes,
   getConnectorOwnedSecretNames,
   getConnectorVariableNames,
@@ -450,6 +451,98 @@ describe("connector auth method config", () => {
       variables: ["GITLAB_HOST"],
     });
     expect(getConnectorManualGrantFieldNames("github")).toBeNull();
+  });
+
+  it("gets manual grant field names for one auth method", () => {
+    const authMethods = CONNECTOR_TYPES.github.authMethods;
+    const apiTokenMethod = {
+      label: "API Token",
+      helpText: "Enter an API token.",
+      grant: {
+        kind: "manual",
+        fields: {
+          GITHUB_API_TOKEN: {
+            label: "Token",
+            required: true,
+          },
+          GITHUB_API_HOST: {
+            label: "Host",
+            required: false,
+            storage: "variable",
+          },
+        },
+      },
+      access: {
+        kind: "static",
+        envBindings: {
+          GITHUB_API_TOKEN: "$secrets.GITHUB_API_TOKEN",
+          GITHUB_API_HOST: "$vars.GITHUB_API_HOST",
+        },
+      },
+      revoke: { kind: "none" },
+    } satisfies ConnectorAuthMethodConfig;
+    const apiMethod = {
+      label: "Secondary API Token",
+      helpText: "Enter a secondary API token.",
+      grant: {
+        kind: "manual",
+        fields: {
+          GITHUB_SECONDARY_TOKEN: {
+            label: "Token",
+            required: true,
+          },
+          GITHUB_SECONDARY_HOST: {
+            label: "Host",
+            required: false,
+            storage: "variable",
+          },
+        },
+      },
+      access: {
+        kind: "static",
+        envBindings: {
+          GITHUB_SECONDARY_TOKEN: "$secrets.GITHUB_SECONDARY_TOKEN",
+          GITHUB_SECONDARY_HOST: "$vars.GITHUB_SECONDARY_HOST",
+        },
+      },
+      revoke: { kind: "none" },
+    } satisfies ConnectorAuthMethodConfig;
+
+    Object.defineProperty(authMethods, "api-token", {
+      value: apiTokenMethod,
+      configurable: true,
+      enumerable: true,
+    });
+    Object.defineProperty(authMethods, "api", {
+      value: apiMethod,
+      configurable: true,
+      enumerable: true,
+    });
+
+    try {
+      expect(
+        getConnectorManualGrantFieldNamesForAuthMethod("github", "oauth"),
+      ).toBeNull();
+      expect(
+        getConnectorManualGrantFieldNamesForAuthMethod("github", "api-token"),
+      ).toStrictEqual({
+        secrets: ["GITHUB_API_TOKEN"],
+        variables: ["GITHUB_API_HOST"],
+      });
+      expect(
+        getConnectorManualGrantFieldNamesForAuthMethod("github", "api"),
+      ).toStrictEqual({
+        secrets: ["GITHUB_SECONDARY_TOKEN"],
+        variables: ["GITHUB_SECONDARY_HOST"],
+      });
+      expect(getConnectorManualGrantFieldNames("github")).toStrictEqual({
+        secrets: ["GITHUB_API_TOKEN", "GITHUB_SECONDARY_TOKEN"],
+        variables: ["GITHUB_API_HOST", "GITHUB_SECONDARY_HOST"],
+      });
+    } finally {
+      Reflect.deleteProperty(authMethods, "api-token");
+      Reflect.deleteProperty(authMethods, "api");
+    }
   });
 
   it("keeps connector-scoped secret and variable names globally unique", () => {

--- a/turbo/packages/connectors/src/connector-utils.ts
+++ b/turbo/packages/connectors/src/connector-utils.ts
@@ -191,17 +191,27 @@ function manualGrantFieldNames(
   return { secrets: secretNames, variables: variableNames };
 }
 
+export function getConnectorManualGrantFieldNamesForAuthMethod(
+  type: ConnectorType,
+  authMethod: string,
+): ManualGrantFieldNames | null {
+  const fields = getManualGrantFields(getConnectorAuthMethod(type, authMethod));
+  return fields ? manualGrantFieldNames(fields) : null;
+}
+
 export function getConnectorManualGrantFieldNames(
   type: ConnectorType,
 ): ManualGrantFieldNames | null {
   const secretNames = new Set<string>();
   const variableNames = new Set<string>();
   for (const authMethod of getConfiguredConnectorAuthMethods(type)) {
-    const method = getConnectorAuthMethod(type, authMethod);
-    if (method?.grant.kind !== "manual") {
+    const fields = getConnectorManualGrantFieldNamesForAuthMethod(
+      type,
+      authMethod,
+    );
+    if (!fields) {
       continue;
     }
-    const fields = manualGrantFieldNames(method.grant.fields);
     fields.secrets.forEach((name) => {
       secretNames.add(name);
     });


### PR DESCRIPTION
## Summary
- add an auth-method-scoped manual grant field helper while preserving the connector-wide helper
- scope token connection legacy manual user-row cleanup to existing and selected auth methods
- add callback route regression coverage for multi-manual-method cleanup boundaries

## Tests
- pnpm -F @vm0/connectors exec vitest run src/__tests__/connectors.test.ts src/__tests__/firewall-secret-consistency.test.ts
- pnpm -F api exec vitest run src/signals/routes/__tests__/connectors-type-callback.test.ts
- pnpm -F api exec vitest run src/signals/routes/__tests__/zero-connectors-manual-grant-connect.test.ts
- pnpm -F @vm0/connectors lint
- pnpm -F @vm0/connectors check-types
- pnpm -F api lint
- pnpm -F api check-types
- pre-commit: prettier, knip, turbo check-types

Fixes #15766