### PR TITLE
refactor: centralize permission grant policy folding

### DIFF
--- a/turbo/apps/api/src/signals/routes/__tests__/zero-user-permission-grants.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/zero-user-permission-grants.test.ts
@@ -7,16 +7,14 @@ import { afterEach, describe, expect, it } from "vitest";
 import { zeroUserPermissionGrantsContract } from "@vm0/api-contracts/contracts/zero-user-permission-grants";
 import { FeatureSwitchKey } from "@vm0/connectors/feature-switch-key";
 import { UNKNOWN_PERMISSION_GRANT } from "@vm0/connectors/firewall-types";
+import { permissionGrantsToFirewallPolicies } from "@vm0/connectors/firewalls";
 import { userFeatureSwitches } from "@vm0/db/schema/user-feature-switches";
 import { userPermissionGrants } from "@vm0/db/schema/user-permission-grant";
 
 import { accept, setupApp, testContext } from "../../../__tests__/test-helpers";
 import { createApp } from "../../../app-factory";
 import { writeDb$ } from "../../external/db";
-import {
-  foldUserPermissionGrantsToFirewallPolicies,
-  loadActiveUserPermissionGrants,
-} from "../../services/zero-user-permission-grants.service";
+import { loadActiveUserPermissionGrants } from "../../services/zero-user-permission-grants.service";
 import {
   deleteOrgMembership$,
   seedOrgMembership$,
@@ -530,13 +528,13 @@ describe("zero user permission grants", () => {
       }),
     ).toStrictEqual([UNKNOWN_PERMISSION_GRANT, SLACK_WRITE_PERMISSION]);
 
-    expect(foldUserPermissionGrantsToFirewallPolicies(active)).toStrictEqual({
+    expect(permissionGrantsToFirewallPolicies(active)).toStrictEqual({
       slack: {
         policies: { [SLACK_WRITE_PERMISSION]: "deny" },
         unknownPolicy: "deny",
       },
     });
-    expect(foldUserPermissionGrantsToFirewallPolicies([])).toBeNull();
+    expect(permissionGrantsToFirewallPolicies([])).toBeNull();
   });
 
   it("updates action, expiresAt, and updatedAt without changing createdAt", async () => {

--- a/turbo/apps/api/src/signals/services/zero-runs-create.service.ts
+++ b/turbo/apps/api/src/signals/services/zero-runs-create.service.ts
@@ -8,7 +8,10 @@ import {
 } from "@vm0/connectors/connectors";
 import { FeatureSwitchKey } from "@vm0/connectors/feature-switch-key";
 import type { ModelProviderCredentialScope } from "@vm0/api-contracts/contracts/model-providers";
-import { resolveFirewallPolicies } from "@vm0/connectors/firewalls";
+import {
+  permissionGrantsToFirewallPolicies,
+  resolveFirewallPolicies,
+} from "@vm0/connectors/firewalls";
 import {
   toFirewallPolicies,
   type FirewallPolicyValue,
@@ -36,10 +39,7 @@ import type { AuthContext } from "../../types/auth";
 import { writeDb$, type Db } from "../external/db";
 import { createAgentRun$ } from "./agent-run-create.service";
 import { loadUserFeatureSwitchContext } from "./feature-switches.service";
-import {
-  foldUserPermissionGrantsToFirewallPolicies,
-  loadActiveUserPermissionGrants,
-} from "./zero-user-permission-grants.service";
+import { loadActiveUserPermissionGrants } from "./zero-user-permission-grants.service";
 
 type ZeroRunCreateBody = z.infer<(typeof zeroRunsMainContract.create)["body"]>;
 
@@ -452,10 +452,9 @@ async function resolveZeroRunPermissionPolicies(
   );
   signal.throwIfAborted();
 
-  return resolveFirewallPolicies(
-    foldUserPermissionGrantsToFirewallPolicies(grants),
-    [...args.allowedConnectorTypes],
-  );
+  return resolveFirewallPolicies(permissionGrantsToFirewallPolicies(grants), [
+    ...args.allowedConnectorTypes,
+  ]);
 }
 
 async function loadUserInfo(

--- a/turbo/apps/api/src/signals/services/zero-user-permission-grants.service.ts
+++ b/turbo/apps/api/src/signals/services/zero-user-permission-grants.service.ts
@@ -3,10 +3,7 @@ import {
   getConnectorFirewall,
   isFirewallConnectorType,
 } from "@vm0/connectors/firewalls";
-import {
-  type FirewallPolicies,
-  UNKNOWN_PERMISSION_GRANT,
-} from "@vm0/connectors/firewall-types";
+import { UNKNOWN_PERMISSION_GRANT } from "@vm0/connectors/firewall-types";
 import { userPermissionGrants } from "@vm0/db/schema/user-permission-grant";
 import { zeroAgents } from "@vm0/db/schema/zero-agent";
 import { and, asc, eq, gt, isNull, or } from "drizzle-orm";
@@ -181,31 +178,6 @@ export async function loadActiveUserPermissionGrants(
       asc(userPermissionGrants.connectorRef),
       asc(userPermissionGrants.permission),
     );
-}
-
-export function foldUserPermissionGrantsToFirewallPolicies(
-  grants: readonly Pick<
-    UserPermissionGrantRow,
-    "connectorRef" | "permission" | "action"
-  >[],
-): FirewallPolicies | null {
-  const policies: FirewallPolicies = {};
-
-  for (const grant of grants) {
-    const existing = policies[grant.connectorRef] ?? { policies: {} };
-    if (grant.permission === UNKNOWN_PERMISSION_GRANT) {
-      policies[grant.connectorRef] = {
-        ...existing,
-        unknownPolicy: grant.action,
-      };
-      continue;
-    }
-
-    existing.policies[grant.permission] = grant.action;
-    policies[grant.connectorRef] = existing;
-  }
-
-  return Object.keys(policies).length > 0 ? policies : null;
 }
 
 async function visibleAgentOrNotFound(

--- a/turbo/packages/connectors/src/__tests__/firewall-default-policies.test.ts
+++ b/turbo/packages/connectors/src/__tests__/firewall-default-policies.test.ts
@@ -1,8 +1,10 @@
 import { describe, it, expect } from "vitest";
+import { UNKNOWN_PERMISSION_GRANT } from "../firewall-types";
 import {
-  getDefaultFirewallPolicies,
-  resolveFirewallPolicies,
   getConnectorFirewall,
+  getDefaultFirewallPolicies,
+  permissionGrantsToFirewallPolicies,
+  resolveFirewallPolicies,
 } from "../firewalls/index";
 
 describe("getDefaultFirewallPolicies", () => {
@@ -138,5 +140,46 @@ describe("resolveFirewallPolicies", () => {
     expect(resolved).not.toBeNull();
     expect(resolved!["github"]!.policies).toEqual({});
     expect(resolved!["github"]!.unknownPolicy).toBe("allow");
+  });
+});
+
+describe("permissionGrantsToFirewallPolicies", () => {
+  it("should fold permission grant rows into firewall policies", () => {
+    expect(
+      permissionGrantsToFirewallPolicies([
+        {
+          connectorRef: "slack",
+          permission: "channels:write",
+          action: "allow",
+        },
+        {
+          connectorRef: "slack",
+          permission: UNKNOWN_PERMISSION_GRANT,
+          action: "deny",
+        },
+      ]),
+    ).toStrictEqual({
+      slack: {
+        policies: { "channels:write": "allow" },
+        unknownPolicy: "deny",
+      },
+    });
+  });
+
+  it("should leave connector defaults to resolveFirewallPolicies", () => {
+    const resolved = resolveFirewallPolicies(
+      permissionGrantsToFirewallPolicies([
+        {
+          connectorRef: "slack",
+          permission: "chat:write",
+          action: "allow",
+        },
+      ]),
+      ["slack"],
+    );
+
+    expect(resolved!["slack"]!.policies["channels:read"]).toBe("allow");
+    expect(resolved!["slack"]!.policies["admin"]).toBe("deny");
+    expect(resolved!["slack"]!.policies["chat:write"]).toBe("allow");
   });
 });

--- a/turbo/packages/connectors/src/__tests__/firewall-default-policies.test.ts
+++ b/turbo/packages/connectors/src/__tests__/firewall-default-policies.test.ts
@@ -144,6 +144,10 @@ describe("resolveFirewallPolicies", () => {
 });
 
 describe("permissionGrantsToFirewallPolicies", () => {
+  it("should return null for empty grant rows", () => {
+    expect(permissionGrantsToFirewallPolicies([])).toBeNull();
+  });
+
   it("should fold permission grant rows into firewall policies", () => {
     expect(
       permissionGrantsToFirewallPolicies([

--- a/turbo/packages/connectors/src/firewalls/index.ts
+++ b/turbo/packages/connectors/src/firewalls/index.ts
@@ -6,11 +6,12 @@
  * remote GitHub fetch.
  */
 
-import type {
-  FirewallConfig,
-  FirewallPolicy,
-  FirewallPolicies,
-  FirewallPolicyValue,
+import {
+  UNKNOWN_PERMISSION_GRANT,
+  type FirewallConfig,
+  type FirewallPolicy,
+  type FirewallPolicies,
+  type FirewallPolicyValue,
 } from "../firewall-types";
 import type { ConnectorType } from "../connectors";
 import { CONNECTOR_TYPES } from "../connectors";
@@ -819,6 +820,36 @@ export function resolveFirewallPolicies(
     };
   }
   return resolved;
+}
+
+export type FirewallPermissionGrantAction = Extract<
+  FirewallPolicyValue,
+  "allow" | "deny"
+>;
+
+export interface FirewallPermissionGrant {
+  readonly connectorRef: string;
+  readonly permission: string;
+  readonly action: FirewallPermissionGrantAction;
+}
+
+export function permissionGrantsToFirewallPolicies(
+  grants: readonly FirewallPermissionGrant[],
+): FirewallPolicies | null {
+  const policies: FirewallPolicies = {};
+  for (const grant of grants) {
+    const current = policies[grant.connectorRef] ?? { policies: {} };
+    if (grant.permission === UNKNOWN_PERMISSION_GRANT) {
+      policies[grant.connectorRef] = {
+        ...current,
+        unknownPolicy: grant.action,
+      };
+      continue;
+    }
+    current.policies[grant.permission] = grant.action;
+    policies[grant.connectorRef] = current;
+  }
+  return Object.keys(policies).length > 0 ? policies : null;
 }
 
 /**


### PR DESCRIPTION
## Summary
- Move user permission grant policy folding from the API service into the connectors firewall layer
- Reuse the shared helper when resolving run permission policies
- Add connector-level coverage for grant folding and default policy resolution

## Verification
- pnpm -F @vm0/connectors exec vitest src/__tests__/firewall-default-policies.test.ts
- pnpm -F api exec vitest src/signals/routes/__tests__/zero-user-permission-grants.test.ts
- pnpm -F @vm0/connectors lint
- pnpm -F @vm0/connectors check-types
- pnpm -F api lint
- pnpm -F api check-types
- pre-commit: prettier, knip, full check-types