### PR TITLE
fix: bound streaming usage decompression output

### DIFF
--- a/crates/runner/mitm-addon/src/body_utils.py
+++ b/crates/runner/mitm-addon/src/body_utils.py
@@ -141,19 +141,6 @@ def _make_streaming_decode_guard(
     return wrapper
 
 
-def _make_skipped_stream_decode_feed(encoding_label: str, reason: str) -> _StreamDecodeFeed:
-    logged = False
-
-    def decode(_chunk: bytes) -> None:
-        nonlocal logged
-        if logged:
-            return
-        logged = True
-        _log_streaming_decode_skipped(encoding_label, reason)
-
-    return decode
-
-
 def _feed_chunks(feed: _StreamDecodeFeed, data: bytes, max_decoded_chunk: int) -> None:
     for offset in range(0, len(data), max_decoded_chunk):
         feed(data[offset : offset + max_decoded_chunk])
@@ -218,13 +205,14 @@ def create_stream_decode_feed(
     feed: _StreamDecodeFeed,
     *,
     max_decoded_chunk: int = STREAM_DECODE_CHUNK_LIMIT,
-) -> _StreamDecodeFeed:
+) -> _StreamDecodeFeed | None:
     """Create a bounded streaming decoder that feeds decoded usage-parser chunks.
 
     Usage parsers are bounded-state scanners and may need to inspect long
     responses, so this helper does not enforce a total decoded-byte cap. It
     bounds each decoded chunk before parser entry to prevent high-ratio
-    compressed input from materialising one large ``bytes`` object.
+    compressed input from materialising one large ``bytes`` object. Returns
+    None when a content encoding cannot be safely decoded incrementally.
     """
     if max_decoded_chunk <= 0:
         raise ValueError("max_decoded_chunk must be positive")
@@ -238,10 +226,12 @@ def create_stream_decode_feed(
             max_decoded_chunk=max_decoded_chunk,
         )
     if encoding == "br":
-        return _make_skipped_stream_decode_feed("br", "brotli streaming output cannot be bounded")
+        _log_streaming_decode_skipped("br", "brotli streaming output cannot be bounded")
+        return None
     if encoding == "zstd":
         return _create_zstd_stream_decode_feed(feed, max_decoded_chunk=max_decoded_chunk)
-    return _make_skipped_stream_decode_feed(encoding, "unsupported content encoding")
+    _log_streaming_decode_skipped(encoding, "unsupported content encoding")
+    return None
 
 
 def decompress_body(

--- a/crates/runner/mitm-addon/src/body_utils.py
+++ b/crates/runner/mitm-addon/src/body_utils.py
@@ -4,7 +4,7 @@ Exports:
 
 - ``STREAM_BUFFER_LIMIT`` — 64 KB cap used by the responseheaders streaming
   buffer and by the decompression safety cap.
-- Streaming / one-shot decompression for gzip, deflate, br, zstd.
+- Streaming usage decoding and one-shot decompression for gzip, deflate, br, zstd.
 - Conservative request-body decoding for billing inspection.
 - UTF-8-safe truncation, text/binary content detection and encoding.
 - Header sanitization for sensitive names and URL-bearing values.
@@ -15,7 +15,7 @@ import base64
 import contextlib
 import zlib
 from collections.abc import Callable
-from typing import Literal, NamedTuple
+from typing import IO, Literal, NamedTuple
 
 import brotli  # type: ignore[import-untyped]
 import zstandard
@@ -26,6 +26,10 @@ import network_log_sanitization
 
 # Cap for non-model-provider response body buffering and decompression output.
 STREAM_BUFFER_LIMIT = 64 * 1024  # 64 KB
+# Maximum decoded chunk size fed to incremental usage parsers. This bounds
+# transient decompressor output without truncating the total response scanned by
+# bounded-state parsers.
+STREAM_DECODE_CHUNK_LIMIT = 64 * 1024  # 64 KB
 _REDACTED_HEADER_VALUE = "***"
 
 # UTF-8 byte-boundary markers (RFC 3629).  Continuation bytes match
@@ -55,6 +59,9 @@ class _BoundedDecodeResult(NamedTuple):
     body: bytes
     failed: bool
     error: Exception | None = None
+
+
+_StreamDecodeFeed = Callable[[bytes], None]
 
 
 # ---------------------------------------------------------------------------
@@ -92,59 +99,149 @@ _URL_BEARING_CAPTURE_HEADER_NAMES = frozenset(
 )
 
 
-def _make_streaming_decompressor(
-    decomp_fn: Callable[[bytes], bytes],
-    error_cls: type[Exception],
+def _log_streaming_decode_error(encoding_label: str, exc: Exception) -> None:
+    with contextlib.suppress(AttributeError):
+        # ctx.log unavailable outside mitmproxy runtime
+        ctx.log.debug(f"Streaming decompression failed ({encoding_label}): {exc}")
+
+
+def _log_streaming_decode_skipped(encoding_label: str, reason: str) -> None:
+    with contextlib.suppress(AttributeError):
+        # ctx.log unavailable outside mitmproxy runtime
+        ctx.log.debug(f"Streaming decompression skipped ({encoding_label}): {reason}")
+
+
+def _make_streaming_decode_guard(
+    decode_fn: _StreamDecodeFeed,
+    error_cls: type[Exception] | tuple[type[Exception], ...],
     encoding_label: str,
-) -> Callable[[bytes], bytes]:
-    """Wrap a chunk decompressor with log-once + short-circuit on failure.
+) -> _StreamDecodeFeed:
+    """Wrap a streaming decoder with log-once + short-circuit on failure.
 
     ``zlib`` / ``brotli`` / ``zstd`` streaming decompressors have internal
     state that becomes undefined after a decompression error — subsequent
-    ``decomp_fn(chunk)`` calls may keep raising or silently produce garbage
+    ``decode_fn(chunk)`` calls may keep raising or silently produce garbage
     plaintext.  On first error we log once (at debug, mirroring the
     non-streaming ``decompress_body`` pattern), latch a broken flag, and
-    return ``b""`` for every subsequent chunk so downstream parsers don't
+    ignore every subsequent chunk so downstream parsers don't
     consume corrupt output.
     """
     broken = False
 
-    def wrapper(chunk: bytes) -> bytes:
+    def wrapper(chunk: bytes) -> None:
         nonlocal broken
         if broken:
-            return b""
+            return
         try:
-            return decomp_fn(chunk)
+            decode_fn(chunk)
         except error_cls as exc:
             broken = True
-            with contextlib.suppress(AttributeError):
-                # ctx.log unavailable outside mitmproxy runtime
-                ctx.log.debug(f"Streaming decompression failed ({encoding_label}): {exc}")
-            return b""
+            _log_streaming_decode_error(encoding_label, exc)
 
     return wrapper
 
 
-def create_stream_decompressor(headers: http.Headers):
-    """Create an incremental decompressor for streaming chunks.
+def _make_skipped_stream_decode_feed(encoding_label: str, reason: str) -> _StreamDecodeFeed:
+    logged = False
 
-    Returns a callable that decompresses each chunk, maintaining state
-    across calls.  Returns None if the response is not compressed.
+    def decode(_chunk: bytes) -> None:
+        nonlocal logged
+        if logged:
+            return
+        logged = True
+        _log_streaming_decode_skipped(encoding_label, reason)
+
+    return decode
+
+
+def _feed_chunks(feed: _StreamDecodeFeed, data: bytes, max_decoded_chunk: int) -> None:
+    for offset in range(0, len(data), max_decoded_chunk):
+        feed(data[offset : offset + max_decoded_chunk])
+
+
+def _create_zlib_stream_decode_feed(
+    feed: _StreamDecodeFeed,
+    *,
+    encoding: Literal["gzip", "deflate"],
+    max_decoded_chunk: int,
+) -> _StreamDecodeFeed:
+    wbits = 16 + zlib.MAX_WBITS if encoding == "gzip" else zlib.MAX_WBITS
+    obj = zlib.decompressobj(wbits)
+
+    def decode(chunk: bytes) -> None:
+        data = chunk
+        while data:
+            decoded = obj.decompress(data, max_length=max_decoded_chunk)
+            if decoded:
+                feed(decoded)
+            next_data = obj.unconsumed_tail
+            if not next_data:
+                return
+            data = next_data
+
+    return _make_streaming_decode_guard(decode, zlib.error, encoding)
+
+
+class _ChunkedDecodeSink(IO[bytes]):
+    def __init__(self, feed: _StreamDecodeFeed, max_decoded_chunk: int) -> None:
+        self._feed = feed
+        self._max_decoded_chunk = max_decoded_chunk
+
+    def write(self, data: bytes) -> int:
+        _feed_chunks(self._feed, data, self._max_decoded_chunk)
+        return len(data)
+
+    def writable(self) -> bool:
+        return True
+
+    def flush(self) -> None:
+        return None
+
+    def close(self) -> None:
+        return None
+
+
+def _create_zstd_stream_decode_feed(
+    feed: _StreamDecodeFeed, *, max_decoded_chunk: int
+) -> _StreamDecodeFeed:
+    sink = _ChunkedDecodeSink(feed, max_decoded_chunk)
+    writer = zstandard.ZstdDecompressor().stream_writer(sink)
+
+    def decode(chunk: bytes) -> None:
+        writer.write(chunk)
+
+    return _make_streaming_decode_guard(decode, zstandard.ZstdError, "zstd")
+
+
+def create_stream_decode_feed(
+    headers: http.Headers,
+    feed: _StreamDecodeFeed,
+    *,
+    max_decoded_chunk: int = STREAM_DECODE_CHUNK_LIMIT,
+) -> _StreamDecodeFeed:
+    """Create a bounded streaming decoder that feeds decoded usage-parser chunks.
+
+    Usage parsers are bounded-state scanners and may need to inspect long
+    responses, so this helper does not enforce a total decoded-byte cap. It
+    bounds each decoded chunk before parser entry to prevent high-ratio
+    compressed input from materialising one large ``bytes`` object.
     """
+    if max_decoded_chunk <= 0:
+        raise ValueError("max_decoded_chunk must be positive")
     encoding = headers.get("content-encoding", "").strip().lower()
     if not encoding or encoding == "identity":
-        return None
+        return feed
     if encoding in ("gzip", "deflate"):
-        wbits = 16 + zlib.MAX_WBITS if encoding == "gzip" else zlib.MAX_WBITS
-        obj = zlib.decompressobj(wbits)
-        return _make_streaming_decompressor(obj.decompress, zlib.error, encoding)
+        return _create_zlib_stream_decode_feed(
+            feed,
+            encoding=encoding,
+            max_decoded_chunk=max_decoded_chunk,
+        )
     if encoding == "br":
-        dec = brotli.Decompressor()
-        return _make_streaming_decompressor(dec.process, brotli.error, "br")
+        return _make_skipped_stream_decode_feed("br", "brotli streaming output cannot be bounded")
     if encoding == "zstd":
-        obj = zstandard.ZstdDecompressor().decompressobj()
-        return _make_streaming_decompressor(obj.decompress, zstandard.ZstdError, "zstd")
-    return None
+        return _create_zstd_stream_decode_feed(feed, max_decoded_chunk=max_decoded_chunk)
+    return _make_skipped_stream_decode_feed(encoding, "unsupported content encoding")
 
 
 def decompress_body(

--- a/crates/runner/mitm-addon/src/body_utils.py
+++ b/crates/runner/mitm-addon/src/body_utils.py
@@ -4,7 +4,8 @@ Exports:
 
 - ``STREAM_BUFFER_LIMIT`` — 64 KB cap used by the responseheaders streaming
   buffer and by the decompression safety cap.
-- Streaming usage decoding and one-shot decompression for gzip, deflate, br, zstd.
+- Bounded streaming usage decoding for gzip, deflate, zstd; one-shot
+  decompression for gzip, deflate, br, zstd.
 - Conservative request-body decoding for billing inspection.
 - UTF-8-safe truncation, text/binary content detection and encoding.
 - Header sanitization for sensitive names and URL-bearing values.
@@ -118,10 +119,10 @@ def _make_streaming_decode_guard(
 ) -> _StreamDecodeFeed:
     """Wrap a streaming decoder with log-once + short-circuit on failure.
 
-    ``zlib`` / ``brotli`` / ``zstd`` streaming decompressors have internal
-    state that becomes undefined after a decompression error — subsequent
-    ``decode_fn(chunk)`` calls may keep raising or silently produce garbage
-    plaintext.  On first error we log once (at debug, mirroring the
+    ``zlib`` / ``zstd`` streaming decompressors have internal state that becomes
+    undefined after a decompression error — subsequent ``decode_fn(chunk)``
+    calls may keep raising or silently produce garbage plaintext. On first
+    error we log once (at debug, mirroring the
     non-streaming ``decompress_body`` pattern), latch a broken flag, and
     ignore every subsequent chunk so downstream parsers don't
     consume corrupt output.
@@ -200,6 +201,26 @@ def _create_zstd_stream_decode_feed(
     return _make_streaming_decode_guard(decode, zstandard.ZstdError, "zstd")
 
 
+def _stream_decode_skip_reason(encoding: str) -> str | None:
+    if not encoding or encoding == "identity":
+        return None
+    if encoding in ("gzip", "deflate", "zstd"):
+        return None
+    if encoding == "br":
+        return "brotli streaming output cannot be bounded"
+    return "unsupported content encoding"
+
+
+def can_stream_decode_usage(headers: http.Headers) -> bool:
+    """Return whether usage parsers can safely consume this response stream."""
+    encoding = headers.get("content-encoding", "").strip().lower()
+    reason = _stream_decode_skip_reason(encoding)
+    if reason is None:
+        return True
+    _log_streaming_decode_skipped(encoding, reason)
+    return False
+
+
 def create_stream_decode_feed(
     headers: http.Headers,
     feed: _StreamDecodeFeed,
@@ -217,6 +238,8 @@ def create_stream_decode_feed(
     if max_decoded_chunk <= 0:
         raise ValueError("max_decoded_chunk must be positive")
     encoding = headers.get("content-encoding", "").strip().lower()
+    if not can_stream_decode_usage(headers):
+        return None
     if not encoding or encoding == "identity":
         return feed
     if encoding in ("gzip", "deflate"):
@@ -225,12 +248,8 @@ def create_stream_decode_feed(
             encoding=encoding,
             max_decoded_chunk=max_decoded_chunk,
         )
-    if encoding == "br":
-        _log_streaming_decode_skipped("br", "brotli streaming output cannot be bounded")
-        return None
     if encoding == "zstd":
         return _create_zstd_stream_decode_feed(feed, max_decoded_chunk=max_decoded_chunk)
-    _log_streaming_decode_skipped(encoding, "unsupported content encoding")
     return None
 
 

--- a/crates/runner/mitm-addon/src/response_streaming.py
+++ b/crates/runner/mitm-addon/src/response_streaming.py
@@ -32,7 +32,7 @@ def is_model_websocket_usage_enabled(flow: http.HTTPFlow) -> bool:
 def _make_response_chunk_parser(
     feed: _ResponseChunkParser,
     headers: http.Headers,
-) -> _ResponseChunkParser:
+) -> _ResponseChunkParser | None:
     return body_utils.create_stream_decode_feed(headers, feed)
 
 
@@ -96,22 +96,31 @@ def _configure_response_usage_parser(flow: http.HTTPFlow) -> _ResponseChunkParse
                         usage_protocol="anthropic_messages_sse",
                     )
                 )
+            parser = _make_response_chunk_parser(parser_fn, flow.response.headers)
+            if parser is None:
+                return None
             flow.metadata[metadata_keys.MODEL_PROVIDER_USAGE] = usage_dict
             flow.metadata[_MODEL_SSE_USAGE_FINISH] = parser_fn.finish
-            return _make_response_chunk_parser(parser_fn, flow.response.headers)
+            return parser
 
         if uses_openai_responses_usage_protocol(flow):
             extractor = usage.create_openai_responses_json_usage_extractor()
         else:
             extractor = usage.create_anthropic_messages_json_usage_extractor()
+        parser = _make_response_chunk_parser(extractor.feed, flow.response.headers)
+        if parser is None:
+            return None
         flow.metadata[_MODEL_JSON_USAGE_FINISH] = extractor.finish
-        return _make_response_chunk_parser(extractor.feed, flow.response.headers)
+        return parser
 
     connector_parser = usage.create_connector_response_parser(flow)
     if connector_parser is not None:
+        parser = _make_response_chunk_parser(connector_parser.feed, flow.response.headers)
+        if parser is None:
+            return None
         if connector_parser.finish is not None:
             flow.metadata[_CONNECTOR_RESPONSE_FINISH] = connector_parser.finish
-        return _make_response_chunk_parser(connector_parser.feed, flow.response.headers)
+        return parser
 
     return None
 

--- a/crates/runner/mitm-addon/src/response_streaming.py
+++ b/crates/runner/mitm-addon/src/response_streaming.py
@@ -33,14 +33,7 @@ def _make_response_chunk_parser(
     feed: _ResponseChunkParser,
     headers: http.Headers,
 ) -> _ResponseChunkParser:
-    decompressor = body_utils.create_stream_decompressor(headers)
-    if decompressor is None:
-        return feed
-
-    def parse_chunk(chunk: bytes) -> None:
-        feed(decompressor(chunk))
-
-    return parse_chunk
+    return body_utils.create_stream_decode_feed(headers, feed)
 
 
 def _make_model_sse_parse_error_logger(

--- a/crates/runner/mitm-addon/src/response_streaming.py
+++ b/crates/runner/mitm-addon/src/response_streaming.py
@@ -80,6 +80,8 @@ def _configure_response_usage_parser(flow: http.HTTPFlow) -> _ResponseChunkParse
         flow.metadata[_MODEL_WEBSOCKET_USAGE_ENABLED] = True
         return None
     if is_billable_model_provider:
+        if not body_utils.can_stream_decode_usage(flow.response.headers):
+            return None
         content_type = flow.response.headers.get("content-type", "").lower()
         if "text/event-stream" in content_type:
             if uses_openai_responses_usage_protocol(flow):
@@ -113,6 +115,10 @@ def _configure_response_usage_parser(flow: http.HTTPFlow) -> _ResponseChunkParse
         flow.metadata[_MODEL_JSON_USAGE_FINISH] = extractor.finish
         return parser
 
+    if not is_billable_flow:
+        return None
+    if not body_utils.can_stream_decode_usage(flow.response.headers):
+        return None
     connector_parser = usage.create_connector_response_parser(flow)
     if connector_parser is not None:
         parser = _make_response_chunk_parser(connector_parser.feed, flow.response.headers)

--- a/crates/runner/mitm-addon/src/usage/providers/connectors/response_parser.py
+++ b/crates/runner/mitm-addon/src/usage/providers/connectors/response_parser.py
@@ -12,13 +12,14 @@ class ConnectorResponseParser(NamedTuple):
     connector usage extraction. The response streaming layer wires ``feed`` into
     the stream callback for that flow.
 
-    ``feed`` receives each streamed response-body chunk. For supported
-    ``Content-Encoding`` values (``gzip``, ``deflate``, ``br``, and ``zstd``),
-    the stream wrapper passes decompressed bytes to ``feed``. With no encoding,
-    ``identity``, or an unsupported encoding, the original chunk bytes are
-    passed through unchanged. Implementations must treat ``b""`` as a no-op:
-    incremental decompressors may produce no output for a source chunk, and
-    decompression failures intentionally suppress later parser input.
+    ``feed`` receives each streamed response-body chunk. For ``gzip``,
+    ``deflate``, and ``zstd``, the stream wrapper passes decompressed bytes to
+    ``feed``. With no encoding or ``identity``, the original chunk bytes are
+    passed through unchanged. Encodings that cannot be safely decoded with a
+    bounded incremental output, including ``br`` and unsupported values, skip
+    response-body parsing for that flow. Implementations must treat ``b""`` as
+    a no-op: incremental decompressors may produce no output for a source
+    chunk, and decompression failures intentionally suppress later parser input.
 
     ``finish`` is optional. When provided, normal completed-response
     finalization calls it once after streaming has fed all chunks and before

--- a/crates/runner/mitm-addon/tests/test_body_capture.py
+++ b/crates/runner/mitm-addon/tests/test_body_capture.py
@@ -1452,12 +1452,14 @@ class TestStreamDecodeFeed:
     def test_gzip_happy_path(self, headers):
         chunks: list[bytes] = []
         parse = create_stream_decode_feed(headers(("Content-Encoding", "gzip")), chunks.append)
+        assert parse is not None
         parse(gzip.compress(b"hello world"))
         assert b"".join(chunks) == b"hello world"
 
     def test_zstd_happy_path(self, headers):
         chunks: list[bytes] = []
         parse = create_stream_decode_feed(headers(("Content-Encoding", "zstd")), chunks.append)
+        assert parse is not None
         parse(zstandard.ZstdCompressor().compress(b"hello world"))
         assert b"".join(chunks) == b"hello world"
 
@@ -1474,6 +1476,7 @@ class TestStreamDecodeFeed:
             parse = create_stream_decode_feed(
                 headers(("Content-Encoding", encoding)), chunks.append
             )
+            assert parse is not None
             for idx in range(0, len(compressed), 3):
                 parse(compressed[idx : idx + 3])
             assert b"".join(chunks) == plaintext, encoding
@@ -1481,6 +1484,7 @@ class TestStreamDecodeFeed:
     def test_no_encoding_feeds_original_chunks(self, headers):
         chunks: list[bytes] = []
         parse = create_stream_decode_feed(headers(), chunks.append)
+        assert parse is not None
         parse(b"hello")
         parse(b" world")
         assert chunks == [b"hello", b" world"]
@@ -1488,6 +1492,7 @@ class TestStreamDecodeFeed:
     def test_identity_feeds_original_chunks(self, headers):
         chunks: list[bytes] = []
         parse = create_stream_decode_feed(headers(("Content-Encoding", "identity")), chunks.append)
+        assert parse is not None
         parse(b"hello")
         assert chunks == [b"hello"]
 
@@ -1495,6 +1500,7 @@ class TestStreamDecodeFeed:
         plaintext = b"A" * (STREAM_DECODE_CHUNK_LIMIT * 3 + 123)
         chunks: list[bytes] = []
         parse = create_stream_decode_feed(headers(("Content-Encoding", "gzip")), chunks.append)
+        assert parse is not None
 
         parse(gzip.compress(plaintext))
 
@@ -1506,6 +1512,7 @@ class TestStreamDecodeFeed:
         plaintext = b"A" * (STREAM_DECODE_CHUNK_LIMIT * 3 + 123)
         chunks: list[bytes] = []
         parse = create_stream_decode_feed(headers(("Content-Encoding", "zstd")), chunks.append)
+        assert parse is not None
 
         parse(zstandard.ZstdCompressor().compress(plaintext))
 
@@ -1532,6 +1539,7 @@ class TestStreamDecodeFeed:
         monkeypatch.setattr("body_utils.zstandard.ZstdDecompressor", CountingZstdDecompressor)
         chunks: list[bytes] = []
         parse = create_stream_decode_feed(headers(("Content-Encoding", "zstd")), chunks.append)
+        assert parse is not None
 
         parse(zstandard.ZstdCompressor().compress(b"hello world"))
 
@@ -1542,6 +1550,7 @@ class TestStreamDecodeFeed:
         chunks: list[bytes] = []
         with mitm_ctx() as log:
             parse = create_stream_decode_feed(headers(("Content-Encoding", "gzip")), chunks.append)
+            assert parse is not None
             parse(b"not gzip at all")
             parse(b"more garbage")
             parse(b"even more")
@@ -1555,8 +1564,7 @@ class TestStreamDecodeFeed:
         chunks: list[bytes] = []
         with mitm_ctx() as log:
             parse = create_stream_decode_feed(headers(("Content-Encoding", "br")), chunks.append)
-            parse(brotli.compress(b"A" * (STREAM_DECODE_CHUNK_LIMIT * 3)))
-            parse(brotli.compress(b"hello"))
+        assert parse is None
         assert log.debug.call_count == 1
         assert "Streaming decompression skipped" in log.debug.call_args[0][0]
         assert "br" in log.debug.call_args[0][0]
@@ -1566,6 +1574,7 @@ class TestStreamDecodeFeed:
         chunks: list[bytes] = []
         with mitm_ctx() as log:
             parse = create_stream_decode_feed(headers(("Content-Encoding", "zstd")), chunks.append)
+            assert parse is not None
             parse(b"not zstd at all")
             parse(b"more garbage")
         assert log.debug.call_count == 1
@@ -1576,6 +1585,7 @@ class TestStreamDecodeFeed:
         # No mitm_ctx patch — ctx.log is unavailable.  Guard must swallow.
         chunks: list[bytes] = []
         parse = create_stream_decode_feed(headers(("Content-Encoding", "gzip")), chunks.append)
+        assert parse is not None
         parse(b"garbage")
         parse(b"more garbage")
         assert chunks == []
@@ -1586,8 +1596,7 @@ class TestStreamDecodeFeed:
             parse = create_stream_decode_feed(
                 headers(("Content-Encoding", "compress")), chunks.append
             )
-            parse(b"compressed")
-            parse(b"more")
+        assert parse is None
         assert log.debug.call_count == 1
         assert "unsupported content encoding" in log.debug.call_args[0][0]
         assert chunks == []
@@ -1623,6 +1632,7 @@ class TestStreamDecodeFeed:
         chunks: list[bytes] = []
         with mitm_ctx():
             parse = create_stream_decode_feed(headers(("Content-Encoding", "gzip")), chunks.append)
+            assert parse is not None
             parse(b"not gzip")
             parse(b"more garbage")
             parse(b"and more")

--- a/crates/runner/mitm-addon/tests/test_body_capture.py
+++ b/crates/runner/mitm-addon/tests/test_body_capture.py
@@ -12,13 +12,14 @@ from mitmproxy import http
 
 from body_utils import (
     STREAM_BUFFER_LIMIT,
+    STREAM_DECODE_CHUNK_LIMIT,
     _encode_body,
     _is_sensitive_header,
     _is_text_content,
     _sanitize_headers_for_capture,
     _truncate_bytes_utf8_safe,
     add_capture_fields,
-    create_stream_decompressor,
+    create_stream_decode_feed,
     decompress_body,
 )
 from usage import (
@@ -1445,90 +1446,155 @@ class TestExtractOpenAIResponsesUsageFromJson:
         }
 
 
-class TestStreamDecompressor:
-    """Direct tests for ``create_stream_decompressor`` — exercises the
-    log-once + short-circuit guard that protects SSE/ndjson usage
-    extraction from garbage plaintext after a mid-stream failure.
-    """
+class TestStreamDecodeFeed:
+    """Direct tests for the bounded push-style streaming decoder."""
 
     def test_gzip_happy_path(self, headers):
-        decomp = create_stream_decompressor(headers(("Content-Encoding", "gzip")))
-        assert decomp is not None
-        assert decomp(gzip.compress(b"hello world")) == b"hello world"
-
-    def test_brotli_happy_path(self, headers):
-        decomp = create_stream_decompressor(headers(("Content-Encoding", "br")))
-        assert decomp is not None
-        assert decomp(brotli.compress(b"hello world")) == b"hello world"
+        chunks: list[bytes] = []
+        parse = create_stream_decode_feed(headers(("Content-Encoding", "gzip")), chunks.append)
+        parse(gzip.compress(b"hello world"))
+        assert b"".join(chunks) == b"hello world"
 
     def test_zstd_happy_path(self, headers):
-        decomp = create_stream_decompressor(headers(("Content-Encoding", "zstd")))
-        assert decomp is not None
-        assert decomp(zstandard.ZstdCompressor().compress(b"hello world")) == b"hello world"
+        chunks: list[bytes] = []
+        parse = create_stream_decode_feed(headers(("Content-Encoding", "zstd")), chunks.append)
+        parse(zstandard.ZstdCompressor().compress(b"hello world"))
+        assert b"".join(chunks) == b"hello world"
 
     def test_supported_encodings_across_small_chunks(self, headers):
         plaintext = b'{"model":"claude-sonnet-4-6","usage":{"input_tokens":42}}'
         compressed_by_encoding = {
             "gzip": gzip.compress(plaintext),
             "deflate": zlib.compress(plaintext),
-            "br": brotli.compress(plaintext),
             "zstd": zstandard.ZstdCompressor().compress(plaintext),
         }
 
         for encoding, compressed in compressed_by_encoding.items():
-            decomp = create_stream_decompressor(headers(("Content-Encoding", encoding)))
-            assert decomp is not None
-            out = bytearray()
+            chunks: list[bytes] = []
+            parse = create_stream_decode_feed(
+                headers(("Content-Encoding", encoding)), chunks.append
+            )
             for idx in range(0, len(compressed), 3):
-                out.extend(decomp(compressed[idx : idx + 3]))
-            assert bytes(out) == plaintext, encoding
+                parse(compressed[idx : idx + 3])
+            assert b"".join(chunks) == plaintext, encoding
 
-    def test_no_encoding_returns_none(self, headers):
-        assert create_stream_decompressor(headers()) is None
+    def test_no_encoding_feeds_original_chunks(self, headers):
+        chunks: list[bytes] = []
+        parse = create_stream_decode_feed(headers(), chunks.append)
+        parse(b"hello")
+        parse(b" world")
+        assert chunks == [b"hello", b" world"]
 
-    def test_identity_returns_none(self, headers):
-        assert create_stream_decompressor(headers(("Content-Encoding", "identity"))) is None
+    def test_identity_feeds_original_chunks(self, headers):
+        chunks: list[bytes] = []
+        parse = create_stream_decode_feed(headers(("Content-Encoding", "identity")), chunks.append)
+        parse(b"hello")
+        assert chunks == [b"hello"]
+
+    def test_gzip_high_ratio_output_is_chunked(self, headers):
+        plaintext = b"A" * (STREAM_DECODE_CHUNK_LIMIT * 3 + 123)
+        chunks: list[bytes] = []
+        parse = create_stream_decode_feed(headers(("Content-Encoding", "gzip")), chunks.append)
+
+        parse(gzip.compress(plaintext))
+
+        assert b"".join(chunks) == plaintext
+        assert len(chunks) > 1
+        assert max(len(chunk) for chunk in chunks) <= STREAM_DECODE_CHUNK_LIMIT
+
+    def test_zstd_high_ratio_output_is_chunked(self, headers):
+        plaintext = b"A" * (STREAM_DECODE_CHUNK_LIMIT * 3 + 123)
+        chunks: list[bytes] = []
+        parse = create_stream_decode_feed(headers(("Content-Encoding", "zstd")), chunks.append)
+
+        parse(zstandard.ZstdCompressor().compress(plaintext))
+
+        assert b"".join(chunks) == plaintext
+        assert len(chunks) > 1
+        assert max(len(chunk) for chunk in chunks) <= STREAM_DECODE_CHUNK_LIMIT
+
+    def test_zstd_streaming_uses_writer_instead_of_decompressobj(self, headers, monkeypatch):
+        real_decompressor = zstandard.ZstdDecompressor
+        stats = {"stream_writer": 0, "decompressobj": 0}
+
+        class CountingZstdDecompressor:
+            def __init__(self):
+                self._inner = real_decompressor()
+
+            def stream_writer(self, sink):
+                stats["stream_writer"] += 1
+                return self._inner.stream_writer(sink)
+
+            def decompressobj(self):
+                stats["decompressobj"] += 1
+                raise AssertionError("streaming usage decoder must not use decompressobj")
+
+        monkeypatch.setattr("body_utils.zstandard.ZstdDecompressor", CountingZstdDecompressor)
+        chunks: list[bytes] = []
+        parse = create_stream_decode_feed(headers(("Content-Encoding", "zstd")), chunks.append)
+
+        parse(zstandard.ZstdCompressor().compress(b"hello world"))
+
+        assert b"".join(chunks) == b"hello world"
+        assert stats == {"stream_writer": 1, "decompressobj": 0}
 
     def test_gzip_error_logs_once_and_short_circuits(self, headers, mitm_ctx):
+        chunks: list[bytes] = []
         with mitm_ctx() as log:
-            decomp = create_stream_decompressor(headers(("Content-Encoding", "gzip")))
-            assert decomp is not None
-            assert decomp(b"not gzip at all") == b""
-            assert decomp(b"more garbage") == b""
-            assert decomp(b"even more") == b""
+            parse = create_stream_decode_feed(headers(("Content-Encoding", "gzip")), chunks.append)
+            parse(b"not gzip at all")
+            parse(b"more garbage")
+            parse(b"even more")
         assert log.debug.call_count == 1
         msg = log.debug.call_args[0][0]
         assert "Streaming decompression failed" in msg
         assert "gzip" in msg
+        assert chunks == []
 
-    def test_brotli_error_logs_once_and_short_circuits(self, headers, mitm_ctx):
+    def test_brotli_unsafe_encoding_logs_once_and_does_not_feed(self, headers, mitm_ctx):
+        chunks: list[bytes] = []
         with mitm_ctx() as log:
-            decomp = create_stream_decompressor(headers(("Content-Encoding", "br")))
-            assert decomp is not None
-            assert decomp(b"not brotli at all") == b""
-            assert decomp(b"more garbage") == b""
+            parse = create_stream_decode_feed(headers(("Content-Encoding", "br")), chunks.append)
+            parse(brotli.compress(b"A" * (STREAM_DECODE_CHUNK_LIMIT * 3)))
+            parse(brotli.compress(b"hello"))
         assert log.debug.call_count == 1
+        assert "Streaming decompression skipped" in log.debug.call_args[0][0]
         assert "br" in log.debug.call_args[0][0]
+        assert chunks == []
 
     def test_zstd_error_logs_once_and_short_circuits(self, headers, mitm_ctx):
+        chunks: list[bytes] = []
         with mitm_ctx() as log:
-            decomp = create_stream_decompressor(headers(("Content-Encoding", "zstd")))
-            assert decomp is not None
-            assert decomp(b"not zstd at all") == b""
-            assert decomp(b"more garbage") == b""
+            parse = create_stream_decode_feed(headers(("Content-Encoding", "zstd")), chunks.append)
+            parse(b"not zstd at all")
+            parse(b"more garbage")
         assert log.debug.call_count == 1
         assert "zstd" in log.debug.call_args[0][0]
+        assert chunks == []
 
     def test_error_without_ctx_log_does_not_raise(self, headers):
         # No mitm_ctx patch — ctx.log is unavailable.  Guard must swallow.
-        decomp = create_stream_decompressor(headers(("Content-Encoding", "gzip")))
-        assert decomp is not None
-        assert decomp(b"garbage") == b""
-        assert decomp(b"more garbage") == b""
+        chunks: list[bytes] = []
+        parse = create_stream_decode_feed(headers(("Content-Encoding", "gzip")), chunks.append)
+        parse(b"garbage")
+        parse(b"more garbage")
+        assert chunks == []
+
+    def test_unsupported_encoding_logs_once_and_does_not_feed(self, headers, mitm_ctx):
+        chunks: list[bytes] = []
+        with mitm_ctx() as log:
+            parse = create_stream_decode_feed(
+                headers(("Content-Encoding", "compress")), chunks.append
+            )
+            parse(b"compressed")
+            parse(b"more")
+        assert log.debug.call_count == 1
+        assert "unsupported content encoding" in log.debug.call_args[0][0]
+        assert chunks == []
 
     def test_short_circuit_skips_decomp_fn_after_failure(self, headers, mitm_ctx, monkeypatch):
-        # Verify the broken flag actually prevents subsequent ``decomp_fn``
-        # calls — not just that they happen to return b"".  ``zlib.Decompress``
+        # Verify the broken flag actually prevents subsequent decoder calls.
+        # ``zlib.Decompress``
         # is a C type whose ``decompress`` attribute is read-only, so we wrap
         # the factory's return value in a proxy that counts delegations.
         real_factory = zlib.decompressobj
@@ -1542,6 +1608,10 @@ class TestStreamDecompressor:
                 self.count += 1
                 return self._real.decompress(chunk, *a, **kw)
 
+            @property
+            def unconsumed_tail(self):
+                return self._real.unconsumed_tail
+
         proxies: list[CountingProxy] = []
 
         def factory(*args, **kwargs):
@@ -1550,15 +1620,16 @@ class TestStreamDecompressor:
             return proxy
 
         monkeypatch.setattr("body_utils.zlib.decompressobj", factory)
+        chunks: list[bytes] = []
         with mitm_ctx():
-            decomp = create_stream_decompressor(headers(("Content-Encoding", "gzip")))
-            assert decomp is not None
-            assert decomp(b"not gzip") == b""
-            assert decomp(b"more garbage") == b""
-            assert decomp(b"and more") == b""
+            parse = create_stream_decode_feed(headers(("Content-Encoding", "gzip")), chunks.append)
+            parse(b"not gzip")
+            parse(b"more garbage")
+            parse(b"and more")
         # Only the first chunk reaches zlib; later ones are short-circuited.
         assert len(proxies) == 1
         assert proxies[0].count == 1
+        assert chunks == []
 
 
 class TestDecompressBody:

--- a/crates/runner/mitm-addon/tests/test_connector_usage.py
+++ b/crates/runner/mitm-addon/tests/test_connector_usage.py
@@ -66,6 +66,21 @@ class TestXStreamPathRouting:
         assert "x_ndjson_state" not in flow.metadata
         assert "connector_response_finish" in flow.metadata
 
+    def test_brotli_stream_path_skips_response_body_parser(self, real_flow, mitm_ctx):
+        flow = self._make_x_response_flow(real_flow, "/2/tweets/search/stream")
+        flow.response.headers = header_map(
+            {"content-type": "application/json", "content-encoding": "br"}
+        )
+
+        with mitm_ctx() as log:
+            mitm_addon.responseheaders(flow)
+
+        assert callable(response_stream(flow))
+        assert "x_ndjson_state" not in flow.metadata
+        assert "connector_response_finish" not in flow.metadata
+        assert log.debug.call_count == 1
+        assert "Streaming decompression skipped (br)" in log.debug.call_args[0][0]
+
 
 class TestReportConnectorUsage:
     """Tests for report_connector_usage helper (issue #9504)."""
@@ -592,6 +607,38 @@ class TestReportConnectorUsage:
         events = webhook.usage_events()
         by_category = {event["category"]: event["quantity"] for event in events}
         assert by_category == {"posts.read": 1, "user.read": 1}
+
+    def test_full_response_pipeline_brotli_x_json_uses_bounded_fallback(
+        self, tmp_path, real_flow, mitm_ctx
+    ):
+        """Brotli streaming decode is skipped, but X JSON fallback remains active."""
+        flow = real_flow(with_response=False, host="api.x.com", path="/2/tweets")
+        flow.metadata["original_url"] = "https://api.x.com/2/tweets"
+        flow.metadata["vm_proxy_log_path"] = str(tmp_path / "proxy.jsonl")
+        flow.metadata["vm_sandbox_token"] = "test-token"
+        flow.metadata["firewall_name"] = "x"
+        flow.metadata["firewall_billable"] = True
+        flow.metadata["firewall_permission"] = "tweet.read"
+        flow.metadata["firewall_rule_match"] = "GET /2/tweets"
+        flow.response = tutils.tresp(
+            status_code=200,
+            headers=header_map({"content-type": "application/json", "content-encoding": "br"}),
+        )
+
+        with mitm_ctx() as log:
+            mitm_addon.responseheaders(flow)
+        response_stream(flow)(
+            body_utils.brotli.compress(b'{"data":[{"id":"1"}],"includes":{"users":[{"id":"u1"}]}}')
+        )
+
+        payloads = self._call_and_get_billing(flow)
+
+        by_category = {event["category"]: event["quantity"] for event in payloads}
+        assert by_category == {"posts.read": 1, "user.read": 1}
+        assert "connector_response_finish" not in flow.metadata
+        assert "x_ndjson_state" not in flow.metadata
+        assert log.debug.call_count == 1
+        assert "Streaming decompression skipped (br)" in log.debug.call_args[0][0]
 
     def test_full_response_pipeline_x_data_object_bills_single_resource(
         self, tmp_path, real_flow, mitm_ctx

--- a/crates/runner/mitm-addon/tests/test_model_provider_response_usage.py
+++ b/crates/runner/mitm-addon/tests/test_model_provider_response_usage.py
@@ -867,6 +867,44 @@ class TestModelProviderResponseUsage:
         by_category = {event["category"]: event["quantity"] for event in events}
         assert by_category == _expected_event_quantities(provider_case)
 
+    @pytest.mark.parametrize(
+        "provider_case",
+        MODEL_PROVIDER_JSON_CASES,
+        ids=_model_provider_json_case_id,
+    )
+    def test_full_pipeline_brotli_model_json_uses_bounded_fallback(
+        self, tmp_path, real_flow, provider_case
+    ):
+        """Brotli streaming decode is skipped, but bounded JSON fallback remains active."""
+        flow = self._model_provider_flow(
+            real_flow,
+            tmp_path,
+            provider_case,
+            proxy_log_path=tmp_path / "proxy.jsonl",
+        )
+        payload = _standard_success_payload(provider_case)
+        compressed = body_utils.brotli.compress(payload)
+        flow.response = tutils.tresp(
+            status_code=200,
+            headers=header_map({"content-type": "application/json", "content-encoding": "br"}),
+        )
+
+        mitm_addon.responseheaders(flow)
+        response_stream(flow)(compressed)
+
+        webhook = self._run_response(flow)
+
+        extracted = flow.metadata["model_provider_usage"]
+        expected_usage = _expected_usage(provider_case)
+        assert extracted["model"] == expected_usage["model"]
+        assert extracted["tokens.input"] == expected_usage["tokens.input"]
+        assert extracted["tokens.output"] == expected_usage["tokens.output"]
+        if provider_case.uses_openai_responses:
+            assert extracted["tokens.cache_read"] == expected_usage["tokens.cache_read"]
+        events = webhook.usage_events()
+        by_category = {event["category"]: event["quantity"] for event in events}
+        assert by_category == _expected_event_quantities(provider_case)
+
     def test_full_pipeline_incomplete_model_json_does_not_report_partial_usage(
         self, tmp_path, real_flow
     ):

--- a/crates/runner/mitm-addon/tests/test_response_headers_handler.py
+++ b/crates/runner/mitm-addon/tests/test_response_headers_handler.py
@@ -3,7 +3,9 @@
 import gzip
 import json
 
+import brotli
 import pytest
+import zstandard
 from mitmproxy.test import tutils
 
 import body_utils
@@ -320,6 +322,57 @@ class TestResponseHeadersHandler:
         assert usage_result["message_id"] == "msg_1"
         assert usage_result["tokens.input"] == 10
         assert usage_result["tokens.output"] == 20
+
+    def test_model_provider_zstd_json_scans_past_decode_chunk_limit(self, real_flow, headers):
+        """Zstd usage parsing should chunk decoded output without total truncation."""
+        body = (
+            b'{"id":"msg_zstd","model":"claude-sonnet-4-6","content":[{"text":"'
+            + b"A" * (body_utils.STREAM_DECODE_CHUNK_LIMIT * 3)
+            + b'"}],"usage":{"input_tokens":10,"output_tokens":20}}'
+        )
+        flow = real_flow(with_response=False, host="api.anthropic.com")
+        flow.metadata["firewall_name"] = "model-provider:anthropic-api-key"
+        flow.metadata["firewall_billable"] = True
+        flow.response = tutils.tresp(
+            status_code=200,
+            headers=header_map({"content-type": "application/json", "content-encoding": "zstd"}),
+        )
+
+        mitm_addon.responseheaders(flow)
+
+        response_stream(flow)(zstandard.ZstdCompressor().compress(body))
+        usage_result, error = flow.metadata["model_json_usage_finish"]()
+        assert error is None
+        assert usage_result["message_id"] == "msg_zstd"
+        assert usage_result["tokens.input"] == 10
+        assert usage_result["tokens.output"] == 20
+
+    def test_model_provider_brotli_usage_stream_fails_closed(self, real_flow, headers, mitm_ctx):
+        """Brotli usage streams should not feed unsafe decoded output to parsers."""
+        body = json.dumps(
+            {
+                "id": "msg_br",
+                "model": "claude-sonnet-4-6",
+                "usage": {"input_tokens": 10, "output_tokens": 20},
+            }
+        ).encode()
+        flow = real_flow(with_response=False, host="api.anthropic.com")
+        flow.metadata["firewall_name"] = "model-provider:anthropic-api-key"
+        flow.metadata["firewall_billable"] = True
+        flow.response = tutils.tresp(
+            status_code=200,
+            headers=header_map({"content-type": "application/json", "content-encoding": "br"}),
+        )
+
+        mitm_addon.responseheaders(flow)
+
+        with mitm_ctx() as log:
+            response_stream(flow)(brotli.compress(body))
+        usage_result, error = flow.metadata["model_json_usage_finish"]()
+        assert usage_result is None
+        assert error == "incomplete json"
+        assert log.debug.call_count == 1
+        assert "Streaming decompression skipped (br)" in log.debug.call_args[0][0]
 
     def test_openai_model_provider_gzip_json_extractor(self, real_flow, headers):
         """OpenAI model-provider JSON uses the Responses usage extractor."""

--- a/crates/runner/mitm-addon/tests/test_response_headers_handler.py
+++ b/crates/runner/mitm-addon/tests/test_response_headers_handler.py
@@ -323,7 +323,7 @@ class TestResponseHeadersHandler:
         assert usage_result["tokens.input"] == 10
         assert usage_result["tokens.output"] == 20
 
-    def test_model_provider_zstd_json_scans_past_decode_chunk_limit(self, real_flow, headers):
+    def test_model_provider_zstd_json_scans_past_decode_chunk_limit(self, real_flow):
         """Zstd usage parsing should chunk decoded output without total truncation."""
         body = (
             b'{"id":"msg_zstd","model":"claude-sonnet-4-6","content":[{"text":"'
@@ -347,8 +347,8 @@ class TestResponseHeadersHandler:
         assert usage_result["tokens.input"] == 10
         assert usage_result["tokens.output"] == 20
 
-    def test_model_provider_brotli_usage_stream_fails_closed(self, real_flow, headers, mitm_ctx):
-        """Brotli usage streams should not feed unsafe decoded output to parsers."""
+    def test_model_provider_brotli_usage_stream_fails_closed(self, real_flow, mitm_ctx):
+        """Brotli usage streams should leave JSON extraction to the bounded fallback."""
         body = json.dumps(
             {
                 "id": "msg_br",
@@ -364,13 +364,11 @@ class TestResponseHeadersHandler:
             headers=header_map({"content-type": "application/json", "content-encoding": "br"}),
         )
 
-        mitm_addon.responseheaders(flow)
-
         with mitm_ctx() as log:
-            response_stream(flow)(brotli.compress(body))
-        usage_result, error = flow.metadata["model_json_usage_finish"]()
-        assert usage_result is None
-        assert error == "incomplete json"
+            mitm_addon.responseheaders(flow)
+
+        response_stream(flow)(brotli.compress(body))
+        assert "model_json_usage_finish" not in flow.metadata
         assert log.debug.call_count == 1
         assert "Streaming decompression skipped (br)" in log.debug.call_args[0][0]
 


### PR DESCRIPTION
## Summary
- replace streaming response decompression with a push-style decoder that bounds each decoded chunk before usage parsers see it
- keep gzip/deflate streaming with zlib max_length and switch zstd streaming to stream_writer with a chunked sink
- skip brotli/unsupported incremental usage decoding when it cannot be safely bounded, without disabling bounded JSON fallback
- avoid registering connector response parsers for unsafe stream encodings so connector metadata is not populated from an unparsed body
- add direct decoder, response hook, connector, and full pipeline regression coverage for high-ratio compressed streams and brotli fallback

Fixes #15790

## Tests
- python3 -m pytest tests/test_connector_usage.py tests/test_body_capture.py tests/test_response_headers_handler.py tests/test_model_provider_response_usage.py tests/test_response_streaming.py
- python3 -m ruff check src/body_utils.py src/response_streaming.py src/usage/providers/connectors/response_parser.py tests/test_body_capture.py tests/test_response_headers_handler.py tests/test_model_provider_response_usage.py tests/test_connector_usage.py
- basedpyright -p .
- git diff --check