### PR TITLE
chore(web): remove unused dependency declarations

### DIFF
--- a/turbo/apps/web/package.json
+++ b/turbo/apps/web/package.json
@@ -21,8 +21,6 @@
     "@tabler/icons-react": "^3.36.1",
     "@vm0/api-contracts": "workspace:*",
     "@vm0/ui": "workspace:*",
-    "cpu-features": "0.0.10",
-    "import-in-the-middle": "^3.0.0",
     "next": "^16.2.6",
     "next-intl": "^4.11.0",
     "react": "^19.2.6",
@@ -30,7 +28,6 @@
     "react-markdown": "^10.1.0",
     "rehype-highlight": "^7.0.2",
     "remark-gfm": "^4.0.1",
-    "require-in-the-middle": "^8.0.1",
     "zod": "^4.3.6"
   },
   "devDependencies": {
@@ -46,7 +43,6 @@
     "@vm0/connectors": "workspace:*",
     "@vm0/eslint-config": "workspace:*",
     "@vm0/typescript-config": "workspace:*",
-    "e2b": "^2.10.3",
     "eslint": "^9.34.0",
     "happy-dom": "^20.9.0",
     "msw": "^2.13.2",

--- a/turbo/knip.json
+++ b/turbo/knip.json
@@ -20,9 +20,7 @@
         "!src/lib/test-endpoints/**!",
         "!src/mocks/**!"
       ],
-      "ignoreDependencies": [
-        "@vm0/ui"
-      ],
+      "ignoreDependencies": ["@vm0/ui"],
       "next": {
         "entry": ["next.config.{js,ts,mjs}"]
       }

--- a/turbo/knip.json
+++ b/turbo/knip.json
@@ -21,11 +21,7 @@
         "!src/mocks/**!"
       ],
       "ignoreDependencies": [
-        "@vm0/ui",
-        "e2b",
-        "import-in-the-middle",
-        "require-in-the-middle",
-        "cpu-features"
+        "@vm0/ui"
       ],
       "next": {
         "entry": ["next.config.{js,ts,mjs}"]

--- a/turbo/pnpm-lock.yaml
+++ b/turbo/pnpm-lock.yaml
@@ -686,12 +686,6 @@ importers:
       '@vm0/ui':
         specifier: workspace:*
         version: link:../../packages/ui
-      cpu-features:
-        specifier: 0.0.10
-        version: 0.0.10
-      import-in-the-middle:
-        specifier: ^3.0.0
-        version: 3.0.1
       next:
         specifier: ^16.2.6
         version: 16.2.6(@opentelemetry/api@1.9.1)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
@@ -713,9 +707,6 @@ importers:
       remark-gfm:
         specifier: ^4.0.1
         version: 4.0.1
-      require-in-the-middle:
-        specifier: ^8.0.1
-        version: 8.0.1
       zod:
         specifier: 4.3.6
         version: 4.3.6
@@ -756,9 +747,6 @@ importers:
       '@vm0/typescript-config':
         specifier: workspace:*
         version: link:../../packages/typescript-config
-      e2b:
-        specifier: ^2.10.3
-        version: 2.18.0
       eslint:
         specifier: ^9.34.0
         version: 9.39.4(jiti@2.6.1)
@@ -5902,10 +5890,6 @@ packages:
   buffer@6.0.3:
     resolution: {integrity: sha512-FTiCpNxtwiZZHEZbcbTIcZjERVICn9yq/pDFkTl95/AxzD1naBctN7YO68riM/gLSDY7sdrMby8hofADYuuqOA==}
 
-  buildcheck@0.0.7:
-    resolution: {integrity: sha512-lHblz4ahamxpTmnsk+MNTRWsjYKv965MwOrSJyeD588rR3Jcu7swE+0wN5F+PbL5cjgu/9ObkhfzEPuofEMwLA==}
-    engines: {node: '>=10.0.0'}
-
   bundle-require@5.1.0:
     resolution: {integrity: sha512-3WrrOuZiyaaZPWiEt4G3+IffISVC9HYlWueJEBWED4ZH4aIAC2PnkdnuRrR94M+w6yGWn4AglWtJtBI8YqvgoA==}
     engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
@@ -6194,10 +6178,6 @@ packages:
     peerDependenciesMeta:
       typescript:
         optional: true
-
-  cpu-features@0.0.10:
-    resolution: {integrity: sha512-9IkYqtX3YHPCzoVg1Py+o9057a3i0fp7S530UWokCSaFVTc7CwXPRiOjRjBQQ18ZCNafx78YfnG+HALxtVmOGA==}
-    engines: {node: '>=10.0.0'}
 
   crc-32@1.2.2:
     resolution: {integrity: sha512-ROmzCKrTnOwybPcJApAA6WBWij23HVfGVNKqqrZpuyZOHqK2CwHSvpGuyt/UNNvaIjEd8X5IFGp4Mh+Ie1IHJQ==}
@@ -8157,9 +8137,6 @@ packages:
 
   mz@2.7.0:
     resolution: {integrity: sha512-z81GNO7nnYMEhrGh9LeymoE4+Yr0Wn5McHIZMK5cfQCl+NDX08sCZgUc9/6MHni9IWuFLm1Z3HTCXu2z9fN62Q==}
-
-  nan@2.26.2:
-    resolution: {integrity: sha512-0tTvBTYkt3tdGw22nrAy50x7gpbGCCFH3AFcyS5WiUu7Eu4vWlri1woE6qHBSfy11vksDqkiwjOnlR7WV8G1Hw==}
 
   nanoid@3.3.11:
     resolution: {integrity: sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w==}
@@ -15350,8 +15327,6 @@ snapshots:
       base64-js: 1.5.1
       ieee754: 1.2.1
 
-  buildcheck@0.0.7: {}
-
   bundle-require@5.1.0(esbuild@0.27.4):
     dependencies:
       esbuild: 0.27.4
@@ -15619,11 +15594,6 @@ snapshots:
       parse-json: 5.2.0
     optionalDependencies:
       typescript: 5.9.3
-
-  cpu-features@0.0.10:
-    dependencies:
-      buildcheck: 0.0.7
-      nan: 2.26.2
 
   crc-32@1.2.2: {}
 
@@ -17998,8 +17968,6 @@ snapshots:
       any-promise: 1.3.0
       object-assign: 4.1.1
       thenify-all: 1.6.0
-
-  nan@2.26.2: {}
 
   nanoid@3.3.11: {}
 


### PR DESCRIPTION
## Summary

- Remove unused direct `apps/web` dependencies: `e2b`, `cpu-features`, `import-in-the-middle`, and `require-in-the-middle`.
- Keep `@vm0/ui` as the only web Knip ignored dependency because it preserves the pruned workspace graph for the shared UI CSS import.
- Update the lockfile to drop the removed web dependency entries and no-longer-needed native `cpu-features` transitive packages.

## Validation

- `pnpm knip --workspace web`
- `pnpm knip --workspace web --production`
- `pnpm -F web lint`
- `pnpm -F web check-types`
- `pnpm -F web build`
- `pnpm -F web test`
- `pnpm exec turbo prune web --out-dir /tmp/vm0-web-prune-check && test -f /tmp/vm0-web-prune-check/packages/ui/src/styles/globals.css`
