### PR TITLE
docs: clarify browser ua passthrough semantics

### DIFF
--- a/crates/runner/mitm-addon/src/mitm_addon.py
+++ b/crates/runner/mitm-addon/src/mitm_addon.py
@@ -253,6 +253,8 @@ def _is_browser_user_agent(user_agent: str | None) -> bool:
 
 
 def _is_browser_request(flow: http.HTTPFlow) -> bool:
+    # This is only a browser-looking User-Agent heuristic. It is not trusted
+    # browser provenance: any sandbox client can set this header.
     return _is_browser_user_agent(flow.request.headers.get("User-Agent"))
 
 
@@ -260,7 +262,13 @@ def _record_browser_firewall_passthrough(
     flow: http.HTTPFlow,
     allow: matching.FirewallAllow,
 ) -> None:
-    """Record the firewall allow decision without applying provider auth."""
+    """Record a browser-looking UA allow without applying provider auth.
+
+    This path returns before ``handle_firewall_request()``, so mitmproxy does
+    not fetch or inject vm0 connector/model-provider tokens. Keep it
+    non-billable unless a future trusted browser path explicitly changes that
+    token boundary.
+    """
     api_entry = allow.api_entry
     flow.metadata[metadata_keys.FIREWALL_BASE] = api_entry["base"]
     flow.metadata[metadata_keys.FIREWALL_NAME] = allow.name
@@ -503,6 +511,9 @@ async def request(flow: http.HTTPFlow) -> None:
                 return
             if isinstance(result, matching.FirewallAllow):
                 if flow.metadata.get(metadata_keys.BROWSER_USER_AGENT):
+                    # User-Agent is client-controlled. This branch is an auth
+                    # mutation skip for browser-looking traffic, not proof that
+                    # the request came from a trusted browser integration.
                     _record_browser_firewall_passthrough(flow, result)
                     return
 

--- a/crates/runner/mitm-addon/tests/test_request_handler_firewall_dispatch.py
+++ b/crates/runner/mitm-addon/tests/test_request_handler_firewall_dispatch.py
@@ -436,7 +436,7 @@ async def test_firewall_unknown_policy_allow_writes_empty_permission_metadata(
 async def test_browser_firewall_match_skips_auth_injection(
     tmp_path, real_flow, mitm_ctx, fake_firewall_headers, headers
 ):
-    """Browser-originated firewall allows pass through without connector auth mutation."""
+    """Browser-looking UAs pass through without connector auth mutation."""
     reg_path = _write_registry(
         tmp_path,
         vm_info=_single_firewall_vm(
@@ -549,7 +549,7 @@ async def test_non_browser_firewall_match_still_injects_auth(
 async def test_browser_firewall_match_does_not_bypass_denied_unknown_policy(
     tmp_path, real_flow, mitm_ctx, fake_firewall_headers, headers
 ):
-    """Browser UA only skips auth mutation after the firewall has allowed the request."""
+    """Browser-looking UA only skips auth mutation after firewall allow."""
     reg_path = _write_registry(
         tmp_path,
         vm_info=_single_firewall_vm(


### PR DESCRIPTION
## Summary

- Clarify that the browser passthrough branch is based only on a browser-looking `User-Agent` heuristic, not trusted browser provenance.
- Document that the passthrough path returns before `handle_firewall_request()`, so mitmproxy does not fetch or inject vm0 connector/model-provider tokens.
- Update test docstrings to use "browser-looking UA" wording instead of implying browser origin.

## Tests

- `PATH=/tmp/vm0-mitm-addon-venv/bin:$PATH ruff check .`
- `PATH=/tmp/vm0-mitm-addon-venv/bin:$PATH ruff format --check .`
- `PATH=/tmp/vm0-mitm-addon-venv/bin:$PATH python -m pytest tests/test_request_handler_firewall_dispatch.py`

Closes #15838
