### PR TITLE
fix: reject cleartext platform api urls

### DIFF
--- a/crates/runner/mitm-addon/src/auth.py
+++ b/crates/runner/mitm-addon/src/auth.py
@@ -265,12 +265,8 @@ def get_api_url() -> str:
     return ctx.options.vm0_api_url
 
 
-def make_api_request(url: str, data: bytes, sandbox_token: str) -> urllib.request.Request:
-    """Build a Request with standard platform API headers.
-
-    Centralises User-Agent, Authorization, Content-Type, and the optional
-    Vercel bypass header so that callers cannot accidentally omit them.
-    """
+def platform_api_hostname(url: str) -> str:
+    """Return the validated platform API hostname."""
     try:
         parsed_url = urllib.parse.urlsplit(url)
     except ValueError as exc:
@@ -281,8 +277,20 @@ def make_api_request(url: str, data: bytes, sandbox_token: str) -> urllib.reques
         host = parsed_url.hostname
     except ValueError as exc:
         raise ValueError("Platform API URL must be an absolute http(s) URL") from exc
+    if host is None:
+        raise ValueError("Platform API URL must be an absolute http(s) URL")
     if parsed_url.scheme == "http" and not _is_loopback_http_host(host):
         raise ValueError(_HTTPS_OR_LOOPBACK_HTTP_MESSAGE)
+    return host
+
+
+def make_api_request(url: str, data: bytes, sandbox_token: str) -> urllib.request.Request:
+    """Build a Request with standard platform API headers.
+
+    Centralises User-Agent, Authorization, Content-Type, and the optional
+    Vercel bypass header so that callers cannot accidentally omit them.
+    """
+    platform_api_hostname(url)
 
     # S310 (suspicious-url-open-usage): callers build `url` from the
     # operator-configured platform API URL, and the scheme is validated above

--- a/crates/runner/mitm-addon/src/auth.py
+++ b/crates/runner/mitm-addon/src/auth.py
@@ -72,9 +72,7 @@ _STRUCTURED_FIREWALL_AUTH_ERROR_CODES = frozenset(
     }
 )
 _FIREWALL_AUTH_FAILURE_REASONS = frozenset({"upstream_provider", "reconnect_required"})
-_HTTPS_OR_LOOPBACK_HTTP_MESSAGE = (
-    "Platform API URL must use https unless the http host is loopback"
-)
+_HTTPS_OR_LOOPBACK_HTTP_MESSAGE = "Platform API URL must use https unless the http host is loopback"
 
 
 class _NoRedirect(urllib.request.HTTPRedirectHandler):
@@ -279,7 +277,11 @@ def make_api_request(url: str, data: bytes, sandbox_token: str) -> urllib.reques
         raise ValueError("Platform API URL must be an absolute http(s) URL") from exc
     if parsed_url.scheme not in {"http", "https"} or not parsed_url.netloc:
         raise ValueError("Platform API URL must be an absolute http(s) URL")
-    if parsed_url.scheme == "http" and not _is_loopback_http_host(parsed_url.hostname):
+    try:
+        host = parsed_url.hostname
+    except ValueError as exc:
+        raise ValueError("Platform API URL must be an absolute http(s) URL") from exc
+    if parsed_url.scheme == "http" and not _is_loopback_http_host(host):
         raise ValueError(_HTTPS_OR_LOOPBACK_HTTP_MESSAGE)
 
     # S310 (suspicious-url-open-usage): callers build `url` from the

--- a/crates/runner/mitm-addon/src/auth.py
+++ b/crates/runner/mitm-addon/src/auth.py
@@ -5,6 +5,7 @@ both standard header injection and auth.base URL rewriting.
 """
 
 import asyncio
+import ipaddress
 import json
 import math
 import os
@@ -71,6 +72,27 @@ _STRUCTURED_FIREWALL_AUTH_ERROR_CODES = frozenset(
     }
 )
 _FIREWALL_AUTH_FAILURE_REASONS = frozenset({"upstream_provider", "reconnect_required"})
+_HTTPS_OR_LOOPBACK_HTTP_MESSAGE = (
+    "Platform API URL must use https unless the http host is loopback"
+)
+
+
+class _NoRedirect(urllib.request.HTTPRedirectHandler):
+    """Disable automatic redirect following for platform API requests."""
+
+    def redirect_request(
+        self,
+        req: urllib.request.Request,
+        fp: object,
+        code: int,
+        msg: str,
+        headers: object,
+        newurl: str,
+    ) -> None:
+        return None
+
+
+_platform_api_opener = urllib.request.build_opener(_NoRedirect)
 
 
 @dataclass(frozen=True)
@@ -251,9 +273,14 @@ def make_api_request(url: str, data: bytes, sandbox_token: str) -> urllib.reques
     Centralises User-Agent, Authorization, Content-Type, and the optional
     Vercel bypass header so that callers cannot accidentally omit them.
     """
-    parsed_url = urllib.parse.urlsplit(url)
+    try:
+        parsed_url = urllib.parse.urlsplit(url)
+    except ValueError as exc:
+        raise ValueError("Platform API URL must be an absolute http(s) URL") from exc
     if parsed_url.scheme not in {"http", "https"} or not parsed_url.netloc:
         raise ValueError("Platform API URL must be an absolute http(s) URL")
+    if parsed_url.scheme == "http" and not _is_loopback_http_host(parsed_url.hostname):
+        raise ValueError(_HTTPS_OR_LOOPBACK_HTTP_MESSAGE)
 
     # S310 (suspicious-url-open-usage): callers build `url` from the
     # operator-configured platform API URL, and the scheme is validated above
@@ -270,6 +297,21 @@ def make_api_request(url: str, data: bytes, sandbox_token: str) -> urllib.reques
     if VERCEL_BYPASS:
         req.add_header("x-vercel-protection-bypass", VERCEL_BYPASS)
     return req
+
+
+def _is_loopback_http_host(host: str | None) -> bool:
+    if host is None:
+        return False
+    if host.lower() == "localhost":
+        return True
+    try:
+        parsed = ipaddress.ip_address(host)
+    except ValueError:
+        return False
+    if parsed.is_loopback:
+        return True
+    ipv4_mapped = getattr(parsed, "ipv4_mapped", None)
+    return bool(ipv4_mapped and ipv4_mapped.is_loopback)
 
 
 def _firewall_auth_api_error_from_envelope(
@@ -412,7 +454,7 @@ def _fetch_firewall_headers_sync(
     req = make_api_request(url, data, sandbox_token)
     try:
         # nosemgrep: dynamic-urllib-use-detected
-        with urllib.request.urlopen(req, timeout=10) as resp:  # noqa: S310
+        with _platform_api_opener.open(req, timeout=10) as resp:
             decoded: object = json.loads(resp.read())
             return _parse_firewall_auth_success(decoded)
     except urllib.error.HTTPError as e:

--- a/crates/runner/mitm-addon/src/mitm_addon.py
+++ b/crates/runner/mitm-addon/src/mitm_addon.py
@@ -44,6 +44,7 @@ from auth import (
     clear_cached_firewall_headers,
     handle_firewall_request,
     is_billable_firewall,
+    platform_api_hostname,
     request_force_refresh,
 )
 from logging_utils import add_firewall_metadata, log_network_entry, log_proxy_entry
@@ -122,6 +123,8 @@ def load(loader: Loader) -> None:
 
 
 def configure(updated: set[str]) -> None:
+    if "vm0_api_url" in updated:
+        platform_api_hostname(ctx.options.vm0_api_url)
     if "vm0_usage_flush_interval_seconds" in updated:
         usage.configure_usage_buffer(
             flush_interval_seconds=ctx.options.vm0_usage_flush_interval_seconds
@@ -442,8 +445,11 @@ async def request(flow: http.HTTPFlow) -> None:
         # auto-allow past the thing they're supposed to exercise.
         api_url = get_api_url()
         if api_url:
-            parsed_api = urllib.parse.urlparse(api_url)
-            api_hostname = parsed_api.hostname.lower() if parsed_api.hostname else ""
+            try:
+                api_hostname = platform_api_hostname(api_url).lower()
+            except ValueError as exc:
+                ctx.log.warn(f"Invalid vm0_api_url; platform API auto-allow disabled: {exc}")
+                api_hostname = ""
             if (
                 api_hostname
                 and (hostname == api_hostname or hostname.endswith(f".{api_hostname}"))

--- a/crates/runner/mitm-addon/src/mitm_addon.py
+++ b/crates/runner/mitm-addon/src/mitm_addon.py
@@ -94,7 +94,7 @@ def load(loader: Loader) -> None:
         name="vm0_api_url",
         typespec=str,
         default="https://www.vm0.ai",
-        help="VM0 API URL for proxy endpoint",
+        help="VM0 API URL for proxy endpoint (HTTPS, or HTTP loopback for local development)",
     )
     loader.add_option(
         name="vm0_proxy_registry_path",

--- a/crates/runner/mitm-addon/tests/test_addon_configuration.py
+++ b/crates/runner/mitm-addon/tests/test_addon_configuration.py
@@ -6,6 +6,7 @@ from dataclasses import dataclass
 from pathlib import Path
 from unittest.mock import patch
 
+import pytest
 from mitmproxy.addonmanager import Loader
 
 import mitm_addon
@@ -55,9 +56,11 @@ class _Options:
         *,
         usage_state_id: str = "runner-usage-state-id",
         flush_interval_seconds: float = usage.DEFAULT_FLUSH_INTERVAL_SECONDS,
+        api_url: str = "https://api.vm0.ai",
     ) -> None:
         self.vm0_usage_state_id = usage_state_id
         self.vm0_usage_flush_interval_seconds = flush_interval_seconds
+        self.vm0_api_url = api_url
 
 
 class _FakeTimer:
@@ -143,7 +146,7 @@ class TestAddonConfiguration:
         state = assert_pending(pending_path, flows=0, buffered=0, reports=0)
         uuid.UUID(state["usageStateId"])
 
-    def test_configure_ignores_unrelated_option_updates(self, tmp_path):
+    def test_configure_valid_vm0_api_url_does_not_write_pending_state(self, tmp_path):
         pending_path = tmp_path / "usage-pending"
 
         with (
@@ -153,6 +156,18 @@ class TestAddonConfiguration:
             mitm_addon.configure({"vm0_api_url"})
 
         assert not pending_path.exists()
+
+    def test_configure_rejects_invalid_vm0_api_url(self):
+        with (
+            patch.object(
+                mitm_addon.ctx,
+                "options",
+                _Options(api_url="http://api.vm0.ai"),
+                create=True,
+            ),
+            pytest.raises(ValueError, match="https unless"),
+        ):
+            mitm_addon.configure({"vm0_api_url"})
 
     def test_configure_updates_usage_flush_interval(self, tmp_path):
         timers: list[_FakeTimer] = []

--- a/crates/runner/mitm-addon/tests/test_firewall_auth.py
+++ b/crates/runner/mitm-addon/tests/test_firewall_auth.py
@@ -770,7 +770,7 @@ class TestHandleFirewallRequest:
         allow = _allow(api_entry)
 
         with (
-            patch("auth.urllib.request.urlopen", side_effect=network_error),
+            patch("auth._platform_api_opener.open", side_effect=network_error),
             mitm_ctx(),
         ):
             await auth.handle_firewall_request(flow, allow, vm_info)
@@ -820,7 +820,7 @@ class TestHandleFirewallRequest:
         mock_resp.read.return_value = b"not-json"
 
         with (
-            patch("auth.urllib.request.urlopen", return_value=mock_resp),
+            patch("auth._platform_api_opener.open", return_value=mock_resp),
             mitm_ctx(),
         ):
             await auth.handle_firewall_request(flow, allow, vm_info)
@@ -870,7 +870,7 @@ class TestHandleFirewallRequest:
         mock_resp = _json_response({"headers": []})
 
         with (
-            patch("auth.urllib.request.urlopen", return_value=mock_resp),
+            patch("auth._platform_api_opener.open", return_value=mock_resp),
             mitm_ctx(),
         ):
             await auth.handle_firewall_request(flow, allow, vm_info)
@@ -1226,6 +1226,53 @@ class TestMakeApiRequest:
     @pytest.mark.parametrize(
         "url",
         [
+            pytest.param(
+                "http://localhost/api/webhooks/agent/firewall/auth",
+                id="localhost",
+            ),
+            pytest.param(
+                "http://127.0.0.1:3000/api/webhooks/agent/firewall/auth",
+                id="ipv4-loopback",
+            ),
+            pytest.param(
+                "http://127.1.2.3:3000/api/webhooks/agent/firewall/auth",
+                id="ipv4-loopback-range",
+            ),
+            pytest.param(
+                "http://[::1]:3000/api/webhooks/agent/firewall/auth",
+                id="ipv6-loopback",
+            ),
+            pytest.param(
+                "http://[::ffff:127.0.0.1]:3000/api/webhooks/agent/firewall/auth",
+                id="ipv4-mapped-loopback",
+            ),
+        ],
+    )
+    def test_allows_loopback_http_urls(self, url: str):
+        req = auth.make_api_request(url, b"{}", "tok-xyz")
+
+        assert req.full_url == url
+
+    @pytest.mark.parametrize(
+        "url",
+        [
+            pytest.param("http://api.vm0.ai/api", id="public-host"),
+            pytest.param("http://10.0.0.1/api", id="private-10"),
+            pytest.param("http://172.16.0.1/api", id="private-172"),
+            pytest.param("http://192.168.1.10/api", id="private-192"),
+            pytest.param("http://169.254.1.1/api", id="link-local"),
+            pytest.param("http://0.0.0.0/api", id="wildcard"),
+            pytest.param("http://localhost.evil.com/api", id="localhost-suffix"),
+            pytest.param("http://[::ffff:10.0.0.1]/api", id="ipv4-mapped-private"),
+        ],
+    )
+    def test_rejects_non_loopback_http_urls(self, url: str):
+        with pytest.raises(ValueError, match="https unless"):
+            auth.make_api_request(url, b"{}", "tok-xyz")
+
+    @pytest.mark.parametrize(
+        "url",
+        [
             pytest.param("file:///etc/passwd", id="file"),
             pytest.param("ftp://example.com/api", id="ftp"),
             pytest.param(
@@ -1250,7 +1297,7 @@ class TestFetchFirewallHeaders:
 
         with (
             patch("auth.urllib.request.Request") as mock_req_cls,
-            patch("auth.urllib.request.urlopen", return_value=mock_resp),
+            patch("auth._platform_api_opener.open", return_value=mock_resp),
             patch.object(auth, "VERCEL_BYPASS", ""),
         ):
             result = auth._fetch_firewall_headers_sync(
@@ -1305,7 +1352,7 @@ class TestFetchFirewallHeaders:
 
         with (
             patch("auth.urllib.request.Request"),
-            patch("auth.urllib.request.urlopen", return_value=mock_resp),
+            patch("auth._platform_api_opener.open", return_value=mock_resp),
             patch.object(auth, "VERCEL_BYPASS", ""),
             pytest.raises(ValueError, match=_MALFORMED_SUCCESS_PREFIX),
         ):
@@ -1333,7 +1380,7 @@ class TestFetchFirewallHeaders:
 
         with (
             patch("auth.urllib.request.Request"),
-            patch("auth.urllib.request.urlopen", return_value=mock_resp),
+            patch("auth._platform_api_opener.open", return_value=mock_resp),
             patch.object(auth, "VERCEL_BYPASS", ""),
         ):
             result = auth._fetch_firewall_headers_sync(
@@ -1358,12 +1405,45 @@ class TestFetchFirewallHeaders:
 
     def test_invalid_api_url_raises_before_urlopen(self):
         with (
-            patch("auth.urllib.request.urlopen") as mock_urlopen,
+            patch("auth._platform_api_opener.open") as mock_urlopen,
             pytest.raises(ValueError, match="absolute http"),
         ):
             auth._fetch_firewall_headers_sync("iv:tag:data", {}, "tok-xyz", "file:///etc/passwd")
 
         mock_urlopen.assert_not_called()
+
+    def test_non_loopback_http_api_url_raises_before_open(self):
+        with (
+            patch("auth._platform_api_opener.open") as mock_open,
+            pytest.raises(ValueError, match="https unless"),
+        ):
+            auth._fetch_firewall_headers_sync(
+                "iv:tag:data",
+                {},
+                "tok-xyz",
+                "http://api.vm0.ai",
+            )
+
+        mock_open.assert_not_called()
+
+    def test_firewall_auth_does_not_follow_redirects(self, usage_webhook_server):
+        usage_webhook_server.queue_response(
+            302,
+            headers=(("Location", usage_webhook_server.url("/redirected")),),
+        )
+
+        with pytest.raises(urllib.error.HTTPError) as exc:
+            auth._fetch_firewall_headers_sync(
+                "iv:tag:data",
+                {},
+                "tok-xyz",
+                usage_webhook_server.api_url,
+            )
+
+        assert exc.value.code == 302
+        assert [request.path for request in usage_webhook_server.requests] == [
+            "/api/webhooks/agent/firewall/auth"
+        ]
 
     def test_includes_vercel_bypass_header(self, headers):
         mock_resp = MagicMock()
@@ -1374,7 +1454,7 @@ class TestFetchFirewallHeaders:
 
         with (
             patch("auth.urllib.request.Request", return_value=mock_req_instance),
-            patch("auth.urllib.request.urlopen", return_value=mock_resp),
+            patch("auth._platform_api_opener.open", return_value=mock_resp),
             patch.object(auth, "VERCEL_BYPASS", "secret-bypass-value"),
         ):
             auth._fetch_firewall_headers_sync("iv:tag:data", {}, "tok-xyz", "https://api.vm0.ai")
@@ -1393,7 +1473,7 @@ class TestFetchFirewallHeaders:
 
         with (
             patch("auth.urllib.request.Request", return_value=mock_req_instance),
-            patch("auth.urllib.request.urlopen", return_value=mock_resp),
+            patch("auth._platform_api_opener.open", return_value=mock_resp),
             patch.object(auth, "VERCEL_BYPASS", ""),
         ):
             auth._fetch_firewall_headers_sync("iv:tag:data", {}, "tok-xyz", "https://api.vm0.ai")
@@ -1409,7 +1489,7 @@ class TestFetchFirewallHeaders:
 
         with (
             patch("auth.urllib.request.Request") as mock_req_cls,
-            patch("auth.urllib.request.urlopen", return_value=mock_resp),
+            patch("auth._platform_api_opener.open", return_value=mock_resp),
             patch.object(auth, "VERCEL_BYPASS", ""),
         ):
             result = auth._fetch_firewall_headers_sync(
@@ -1437,7 +1517,7 @@ class TestFetchFirewallHeaders:
 
         with (
             patch("auth.urllib.request.Request") as mock_req_cls,
-            patch("auth.urllib.request.urlopen", return_value=mock_resp),
+            patch("auth._platform_api_opener.open", return_value=mock_resp),
             patch.object(auth, "VERCEL_BYPASS", ""),
         ):
             result = auth._fetch_firewall_headers_sync(
@@ -1467,7 +1547,7 @@ class TestFetchFirewallHeaders:
 
         with (
             patch("auth.urllib.request.Request") as mock_req_cls,
-            patch("auth.urllib.request.urlopen", return_value=mock_resp),
+            patch("auth._platform_api_opener.open", return_value=mock_resp),
             patch.object(auth, "VERCEL_BYPASS", ""),
         ):
             auth._fetch_firewall_headers_sync(
@@ -1502,7 +1582,7 @@ class TestFetchFirewallHeaders:
 
         with (
             patch("auth.urllib.request.Request"),
-            patch("auth.urllib.request.urlopen", side_effect=http_error),
+            patch("auth._platform_api_opener.open", side_effect=http_error),
             patch.object(auth, "VERCEL_BYPASS", ""),
         ):
             with pytest.raises(auth.ConnectorNotConfiguredError) as exc_info:
@@ -1529,7 +1609,7 @@ class TestFetchFirewallHeaders:
 
         with (
             patch("auth.urllib.request.Request"),
-            patch("auth.urllib.request.urlopen", side_effect=http_error),
+            patch("auth._platform_api_opener.open", side_effect=http_error),
             patch.object(auth, "VERCEL_BYPASS", ""),
         ):
             with pytest.raises(auth.InsufficientCreditsError) as exc_info:
@@ -1622,7 +1702,7 @@ class TestFetchFirewallHeaders:
 
         with (
             patch("auth.urllib.request.Request"),
-            patch("auth.urllib.request.urlopen", side_effect=http_error),
+            patch("auth._platform_api_opener.open", side_effect=http_error),
             patch.object(auth, "VERCEL_BYPASS", ""),
             pytest.raises(auth.FirewallAuthApiError) as exc_info,
         ):
@@ -1656,7 +1736,7 @@ class TestFetchFirewallHeaders:
 
         with (
             patch("auth.urllib.request.Request"),
-            patch("auth.urllib.request.urlopen", side_effect=http_error),
+            patch("auth._platform_api_opener.open", side_effect=http_error),
             patch.object(auth, "VERCEL_BYPASS", ""),
             pytest.raises(urllib.error.HTTPError) as exc_info,
         ):
@@ -1677,7 +1757,7 @@ class TestFetchFirewallHeaders:
 
         with (
             patch("auth.urllib.request.Request"),
-            patch("auth.urllib.request.urlopen", side_effect=http_error),
+            patch("auth._platform_api_opener.open", side_effect=http_error),
             patch.object(auth, "VERCEL_BYPASS", ""),
             pytest.raises(urllib.error.HTTPError) as exc_info,
         ):
@@ -1697,7 +1777,7 @@ class TestFetchFirewallHeaders:
 
         with (
             patch("auth.urllib.request.Request"),
-            patch("auth.urllib.request.urlopen", side_effect=http_error),
+            patch("auth._platform_api_opener.open", side_effect=http_error),
             patch.object(auth, "VERCEL_BYPASS", ""),
             pytest.raises(urllib.error.HTTPError) as exc_info,
         ):
@@ -1750,7 +1830,7 @@ class TestFetchFirewallHeaders:
 
         with (
             patch("auth.urllib.request.Request"),
-            patch("auth.urllib.request.urlopen", side_effect=http_error),
+            patch("auth._platform_api_opener.open", side_effect=http_error),
             patch.object(auth, "VERCEL_BYPASS", ""),
             pytest.raises(exception_type) as exc_info,
         ):
@@ -1766,7 +1846,7 @@ class TestFetchFirewallHeaders:
 
         with (
             patch("auth.urllib.request.Request"),
-            patch("auth.urllib.request.urlopen", return_value=mock_resp),
+            patch("auth._platform_api_opener.open", return_value=mock_resp),
             patch.object(auth, "VERCEL_BYPASS", ""),
         ):
             auth._fetch_firewall_headers_sync("iv:tag:data", {}, "tok-xyz", "https://api.vm0.ai")
@@ -1804,7 +1884,7 @@ class TestFetchFirewallHeaders:
 
         with (
             patch("auth.urllib.request.Request"),
-            patch("auth.urllib.request.urlopen", side_effect=http_error),
+            patch("auth._platform_api_opener.open", side_effect=http_error),
             patch.object(auth, "VERCEL_BYPASS", ""),
             pytest.raises(expected_exception),
         ):
@@ -1821,7 +1901,7 @@ class TestFetchFirewallHeaders:
         with (
             patch.object(auth, "get_api_url", return_value="https://ctx-url.vm0.ai"),
             patch("auth.urllib.request.Request") as mock_req_cls,
-            patch("auth.urllib.request.urlopen", return_value=mock_resp),
+            patch("auth._platform_api_opener.open", return_value=mock_resp),
             patch.object(auth, "VERCEL_BYPASS", ""),
         ):
             result = await auth.fetch_firewall_headers("enc", {}, "sandbox-tok")

--- a/crates/runner/mitm-addon/tests/test_firewall_auth.py
+++ b/crates/runner/mitm-addon/tests/test_firewall_auth.py
@@ -1263,6 +1263,7 @@ class TestMakeApiRequest:
             pytest.param("http://169.254.1.1/api", id="link-local"),
             pytest.param("http://0.0.0.0/api", id="wildcard"),
             pytest.param("http://localhost.evil.com/api", id="localhost-suffix"),
+            pytest.param("http://localhost@api.vm0.ai/api", id="localhost-userinfo"),
             pytest.param("http://[::ffff:10.0.0.1]/api", id="ipv4-mapped-private"),
         ],
     )
@@ -1280,6 +1281,7 @@ class TestMakeApiRequest:
                 id="scheme-relative",
             ),
             pytest.param("https:path-without-host", id="https-without-host"),
+            pytest.param("http://[::1]@api.vm0.ai/api", id="invalid-bracketed-host"),
         ],
     )
     def test_rejects_non_absolute_http_urls(self, url: str):

--- a/crates/runner/mitm-addon/tests/test_request_handler_passthrough.py
+++ b/crates/runner/mitm-addon/tests/test_request_handler_passthrough.py
@@ -65,6 +65,41 @@ async def test_vm0_api_test_paths_skip_auto_allow(tmp_path, real_flow, mitm_ctx,
     assert flow.metadata["firewall_base"] == "https://api.vm0.ai/api/test/oauth-provider"
 
 
+async def test_invalid_vm0_api_url_does_not_auto_allow(tmp_path, real_flow, mitm_ctx):
+    reg_path = _write_registry(
+        tmp_path,
+        client_ip="10.200.0.1",
+        vm_info=_single_firewall_vm(
+            tmp_path,
+            run_id="run-platform-api",
+            sandbox_marker="tok-platform",
+            firewall_name="platform-api",
+            api_entry={
+                "base": "https://api.vm0.ai",
+                "auth": {"headers": {"Authorization": "Bearer x"}},
+                "permissions": [{"name": "full-access", "rules": ["ANY /{path+}"]}],
+            },
+            network_policy=None,
+            include_encrypted_secrets=False,
+        ),
+    )
+    flow = real_flow(
+        with_response=False,
+        client_ip="10.200.0.1",
+        host="api.vm0.ai",
+        path="/api/runners/poll",
+    )
+
+    with mitm_ctx(
+        registry_path=str(reg_path),
+        api_url="http://[::1]@api.vm0.ai",
+    ) as log:
+        await mitm_addon.request(flow)
+
+    assert flow.metadata["firewall_base"] == "https://api.vm0.ai"
+    log.warn.assert_called_once()
+
+
 async def test_tracks_start_time(registry_file, real_flow, mitm_ctx):
     flow = real_flow(with_response=False, host="api.anthropic.com")
 

--- a/crates/runner/mitm-addon/tests/test_webhook.py
+++ b/crates/runner/mitm-addon/tests/test_webhook.py
@@ -72,6 +72,19 @@ class TestUsageWebhookDelivery:
 
         mock_open.assert_not_called()
 
+    def test_post_webhook_rejects_non_loopback_http_before_open(self):
+        with (
+            patch.object(usage.webhook._opener, "open") as mock_open,
+            pytest.raises(ValueError, match="https unless"),
+        ):
+            usage.webhook._post_webhook(
+                "http://api.vm0.ai/webhook",
+                "tok",
+                json.dumps({"runId": "run-1"}).encode(),
+            )
+
+        mock_open.assert_not_called()
+
     def test_succeeds_on_first_attempt(
         self, tmp_path, real_flow, fresh_usage_executor, usage_webhook_api
     ):

--- a/crates/runner/src/cmd/benchmark.rs
+++ b/crates/runner/src/cmd/benchmark.rs
@@ -43,6 +43,14 @@ fn parse_env_args(env: &[String]) -> RunnerResult<Vec<(String, String)>> {
         .collect()
 }
 
+fn benchmark_proxy_api_url(server: Option<&config::ServerConfig>) -> RunnerResult<Option<String>> {
+    let Some(server) = server else {
+        return Ok(None);
+    };
+    crate::platform_api_url::validate_platform_api_url(&server.url)?;
+    Ok(Some(server.url.clone()))
+}
+
 #[derive(Args)]
 pub struct BenchmarkArgs {
     /// The bash command to execute in the VM
@@ -76,6 +84,7 @@ pub async fn run_benchmark(
     // 1. Load config, force concurrency=1
     let mut runner_config = config::load(&args.config).await?;
     runner_config.sandbox.max_concurrent = 1;
+    let proxy_api_url = benchmark_proxy_api_url(runner_config.server.as_ref())?;
 
     let home = HomePaths::new()?;
 
@@ -110,7 +119,7 @@ pub async fn run_benchmark(
         addon_dir: runner_paths.mitm_addon_dir(),
         registry_path: runner_paths.proxy_registry(),
         registry_lock_path: runner_paths.proxy_registry_lock(),
-        api_url: runner_config.server.as_ref().map(|s| s.url.clone()),
+        api_url: proxy_api_url,
     })
     .await?;
     mitm.start().await?;
@@ -394,6 +403,48 @@ mod tests {
         let input = vec!["GOOD=ok".to_string(), "BAD".to_string()];
         let err = parse_env_args(&input).unwrap_err();
         assert!(err.to_string().contains("'BAD'"), "got: {err}");
+    }
+
+    #[test]
+    fn benchmark_proxy_api_url_allows_absent_server() {
+        assert_eq!(benchmark_proxy_api_url(None).unwrap(), None);
+    }
+
+    #[test]
+    fn benchmark_proxy_api_url_allows_https_server() {
+        let server = config::ServerConfig {
+            url: "https://api.vm0.ai".into(),
+            token: "runner-token".into(),
+        };
+
+        assert_eq!(
+            benchmark_proxy_api_url(Some(&server)).unwrap(),
+            Some("https://api.vm0.ai".into())
+        );
+    }
+
+    #[test]
+    fn benchmark_proxy_api_url_allows_loopback_http_server() {
+        let server = config::ServerConfig {
+            url: "http://127.0.0.1:3000".into(),
+            token: "runner-token".into(),
+        };
+
+        assert_eq!(
+            benchmark_proxy_api_url(Some(&server)).unwrap(),
+            Some("http://127.0.0.1:3000".into())
+        );
+    }
+
+    #[test]
+    fn benchmark_proxy_api_url_rejects_non_loopback_http_server() {
+        let server = config::ServerConfig {
+            url: "http://api.vm0.ai".into(),
+            token: "runner-token".into(),
+        };
+
+        let err = benchmark_proxy_api_url(Some(&server)).unwrap_err();
+        assert!(err.to_string().contains("platform API URL must use https"));
     }
 
     #[tokio::test]

--- a/crates/runner/src/cmd/config.rs
+++ b/crates/runner/src/cmd/config.rs
@@ -41,7 +41,7 @@ pub struct ConfigArgs {
     #[arg(long, default_value_t = DEFAULT_CONCURRENCY_FACTOR)]
     concurrency_factor: f64,
 
-    /// vm0 API URL
+    /// vm0 API URL (HTTPS, or HTTP loopback for local development)
     #[arg(long, env = "VM0_API_URL")]
     api_url: String,
     /// Runner authentication token

--- a/crates/runner/src/cmd/config.rs
+++ b/crates/runner/src/cmd/config.rs
@@ -54,6 +54,7 @@ pub async fn run_config(args: ConfigArgs) -> RunnerResult<()> {
     crate::group::validate_or_err(&args.group)?;
     crate::runner_dirname::validate_or_err(&args.runner_dirname)?;
     validate_concurrency_factor(args.concurrency_factor)?;
+    crate::platform_api_url::validate_platform_api_url(&args.api_url)?;
     if args.profile.len() != args.rootfs_hash.len()
         || args.profile.len() != args.snapshot_hash.len()
     {
@@ -279,5 +280,19 @@ mod tests {
             .unwrap_err();
         let msg = err.to_string();
         assert!(msg.contains("concurrency_factor"), "got: {msg}");
+    }
+
+    #[tokio::test]
+    async fn run_config_rejects_non_loopback_http_api_url() {
+        let mut args = args_with_dirname("runner-01");
+        args.api_url = "http://api.vm0.ai".into();
+
+        let err = run_config(args).await.unwrap_err();
+        let msg = err.to_string();
+
+        assert!(
+            msg.contains("platform API URL must use https"),
+            "got: {msg}"
+        );
     }
 }

--- a/crates/runner/src/cmd/doctor.rs
+++ b/crates/runner/src/cmd/doctor.rs
@@ -162,10 +162,10 @@ impl Warning {
                 server_url,
                 server_token,
             } => {
-                let client = match reqwest::Client::builder()
-                    .timeout(Duration::from_secs(5))
-                    .build()
-                {
+                if crate::platform_api_url::validate_platform_api_url(server_url).is_err() {
+                    return true;
+                }
+                let client = match platform_api_probe_client() {
                     Ok(c) => c,
                     Err(_) => return true,
                 };
@@ -810,17 +810,17 @@ fn is_test_tld(url: &str) -> bool {
 }
 
 /// Returns `None` if no server configured or URL uses `.test` TLD (RFC 2606),
-/// `Some(true)` if reachable, `Some(false)` if unreachable.
+/// `Some(true)` if reachable, `Some(false)` if unreachable or invalid.
 async fn check_api(config: &RunnerConfig) -> Option<bool> {
     let server = config.server.as_ref()?;
+    if crate::platform_api_url::validate_platform_api_url(&server.url).is_err() {
+        return Some(false);
+    }
     // Skip connectivity check for .test domains (reserved per RFC 2606, used in CI)
     if is_test_tld(&server.url) {
         return None;
     }
-    let client = reqwest::Client::builder()
-        .timeout(Duration::from_secs(5))
-        .build()
-        .ok()?;
+    let client = platform_api_probe_client().ok()?;
     Some(
         client
             .head(&server.url)
@@ -829,6 +829,13 @@ async fn check_api(config: &RunnerConfig) -> Option<bool> {
             .await
             .is_ok(),
     )
+}
+
+fn platform_api_probe_client() -> Result<reqwest::Client, reqwest::Error> {
+    reqwest::Client::builder()
+        .timeout(Duration::from_secs(5))
+        .redirect(reqwest::redirect::Policy::none())
+        .build()
 }
 
 // ---------------------------------------------------------------------------
@@ -1213,6 +1220,10 @@ fn format_uptime(started_at: &str) -> String {
 
 #[cfg(test)]
 mod tests {
+    use std::collections::BTreeMap;
+
+    use crate::config::{FirecrackerConfig, SandboxConfig, ServerConfig};
+
     use super::*;
 
     #[test]
@@ -1444,6 +1455,65 @@ mod tests {
             mitmdumps: vec![],
             dnsmasqs: vec![],
         }
+    }
+
+    fn runner_config_with_server_url(url: &str) -> RunnerConfig {
+        RunnerConfig {
+            name: "test-runner".into(),
+            group: "vm0/test".into(),
+            base_dir: PathBuf::from("/tmp/vm0-runner"),
+            ca_dir: PathBuf::from("/tmp/vm0-ca"),
+            firecracker: FirecrackerConfig {
+                binary: PathBuf::from("/tmp/firecracker"),
+                kernel: PathBuf::from("/tmp/vmlinux"),
+            },
+            sandbox: SandboxConfig::default(),
+            profiles: BTreeMap::new(),
+            server: Some(ServerConfig {
+                url: url.into(),
+                token: "runner-token".into(),
+            }),
+        }
+    }
+
+    #[tokio::test]
+    async fn check_api_treats_non_loopback_http_as_unreachable() {
+        let result = tokio::time::timeout(
+            std::time::Duration::from_secs(1),
+            check_api(&runner_config_with_server_url("http://api.vm0.ai")),
+        )
+        .await
+        .unwrap();
+
+        assert_eq!(result, Some(false));
+    }
+
+    #[tokio::test]
+    async fn check_api_treats_non_loopback_http_test_domain_as_unreachable() {
+        let result = tokio::time::timeout(
+            std::time::Duration::from_secs(1),
+            check_api(&runner_config_with_server_url("http://api.test")),
+        )
+        .await
+        .unwrap();
+
+        assert_eq!(result, Some(false));
+    }
+
+    #[tokio::test]
+    async fn api_unreachable_warning_persists_for_invalid_transport_without_probe() {
+        let warning = Warning::ApiUnreachable {
+            server_url: "http://api.vm0.ai".into(),
+            server_token: "runner-token".into(),
+        };
+        let result = tokio::time::timeout(
+            std::time::Duration::from_secs(1),
+            warning.persists(&empty_fresh()),
+        )
+        .await
+        .unwrap();
+
+        assert!(result);
     }
 
     #[tokio::test]

--- a/crates/runner/src/cmd/start/mod.rs
+++ b/crates/runner/src/cmd/start/mod.rs
@@ -195,6 +195,7 @@ pub async fn run_start(
             "server.token is required (set in config or via --token / VM0_RUNNER_TOKEN)".into(),
         ));
     }
+    crate::platform_api_url::validate_platform_api_url(&server.url)?;
 
     let runner_host_env = crate::host_env::read_runner_host_env()?;
     let config::SandboxConfig {

--- a/crates/runner/src/cmd/start/mod.rs
+++ b/crates/runner/src/cmd/start/mod.rs
@@ -145,7 +145,7 @@ pub struct StartArgs {
     /// Path to runner.yaml config file
     #[arg(long, short)]
     pub(crate) config: PathBuf,
-    /// vm0 API URL (overrides config)
+    /// vm0 API URL (HTTPS, or HTTP loopback for local development; overrides config)
     #[arg(long, env = "VM0_API_URL")]
     api_url: Option<String>,
     /// Runner authentication token (overrides config)

--- a/crates/runner/src/config.rs
+++ b/crates/runner/src/config.rs
@@ -152,8 +152,8 @@ impl Default for SandboxConfig {
 /// CLI flag or env var at `start` time and override what's in the YAML.
 #[derive(Debug, PartialEq, Serialize, Deserialize)]
 pub struct ServerConfig {
-    /// Base URL of the vm0 API (e.g. `https://api.example.com`). Overridable
-    /// via `--api-url` / `VM0_API_URL`.
+    /// Base URL of the vm0 API. Must use HTTPS, except HTTP loopback URLs for local development.
+    /// Overridable via `--api-url` / `VM0_API_URL`.
     pub url: String,
     /// Runner auth token. Overridable via `--token` / `VM0_RUNNER_TOKEN`.
     pub token: String,

--- a/crates/runner/src/http.rs
+++ b/crates/runner/src/http.rs
@@ -6,6 +6,7 @@ use reqwest::Client;
 use tracing::info;
 
 use crate::error::{RunnerError, RunnerResult};
+use crate::platform_api_url::validate_platform_api_url;
 
 /// Default timeout for API requests (covers large claim payloads).
 const DEFAULT_TIMEOUT: Duration = Duration::from_secs(10);
@@ -37,15 +38,17 @@ impl HttpClient {
     /// `config.vercel_bypass` is present, that value is attached as
     /// `x-vercel-protection-bypass` on authenticated requests.
     ///
-    /// Returns an error if the underlying HTTP client cannot be built.
+    /// Returns an error if the base API URL is invalid or the underlying HTTP client cannot be built.
     pub fn new(config: HttpClientConfig) -> RunnerResult<Self> {
         let HttpClientConfig {
             api_url,
             vercel_bypass,
         } = config;
+        validate_platform_api_url(&api_url)?;
 
         let client = Client::builder()
             .timeout(DEFAULT_TIMEOUT)
+            .redirect(reqwest::redirect::Policy::none())
             .build()
             .map_err(|e| RunnerError::Internal(format!("http client: {e}")))?;
 
@@ -118,6 +121,7 @@ fn reqwest_method(method: Method) -> reqwest::Method {
 mod tests {
     use api_contracts::generated::routes;
     use reqwest::header::AUTHORIZATION;
+    use tokio::io::{AsyncReadExt, AsyncWriteExt};
 
     use super::*;
 
@@ -211,5 +215,63 @@ mod tests {
             .unwrap();
 
         assert!(request.headers().get(VERCEL_BYPASS_HEADER).is_none());
+    }
+
+    #[test]
+    fn rejects_non_loopback_http_platform_api_url() {
+        let err = match HttpClient::new(HttpClientConfig {
+            api_url: "http://api.vm0.dev".to_string(),
+            vercel_bypass: None,
+        }) {
+            Ok(_) => panic!("expected non-loopback http platform API URL to be rejected"),
+            Err(err) => err,
+        };
+
+        assert!(err.to_string().contains("platform API URL must use https"));
+    }
+
+    #[test]
+    fn request_route_builds_request_from_loopback_http_base_url() {
+        let http = http_client("http://127.0.0.1:3000");
+
+        let request = http
+            .request_route(routes::webhooks::agent::telemetry::SEND, "sandbox-token")
+            .build()
+            .unwrap();
+
+        assert_eq!(
+            request.url().as_str(),
+            "http://127.0.0.1:3000/api/webhooks/agent/telemetry"
+        );
+    }
+
+    #[tokio::test]
+    async fn authenticated_requests_do_not_follow_redirects() {
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let addr = listener.local_addr().unwrap();
+        let server = tokio::spawn(async move {
+            let (mut socket, _) = listener.accept().await.unwrap();
+            let mut request = vec![0; 1024];
+            let read = socket.read(&mut request).await.unwrap();
+            let request = String::from_utf8_lossy(&request[..read]).to_string();
+            socket
+                .write_all(
+                    b"HTTP/1.1 302 Found\r\nLocation: http://127.0.0.1:1/redirected\r\nContent-Length: 0\r\n\r\n",
+                )
+                .await
+                .unwrap();
+            request
+        });
+
+        let http = http_client(&format!("http://{addr}"));
+        let response = http
+            .request_route(routes::webhooks::agent::telemetry::SEND, "sandbox-token")
+            .send()
+            .await
+            .unwrap();
+
+        assert_eq!(response.status(), reqwest::StatusCode::FOUND);
+        let request = server.await.unwrap();
+        assert!(request.starts_with("POST /api/webhooks/agent/telemetry "));
     }
 }

--- a/crates/runner/src/main.rs
+++ b/crates/runner/src/main.rs
@@ -20,6 +20,7 @@ mod network_log_drain;
 mod network_log_manager;
 mod network_logs;
 mod paths;
+mod platform_api_url;
 mod prefetch;
 mod process;
 mod profile;

--- a/crates/runner/src/platform_api_url.rs
+++ b/crates/runner/src/platform_api_url.rs
@@ -1,0 +1,148 @@
+use std::net::{Ipv4Addr, Ipv6Addr};
+
+use url::{Host, Url};
+
+use crate::error::{RunnerError, RunnerResult};
+
+const HTTPS_OR_LOOPBACK_HTTP_MESSAGE: &str =
+    "platform API URL must use https unless the http host is loopback";
+
+pub(crate) fn validate_platform_api_url(api_url: &str) -> RunnerResult<()> {
+    let parsed = Url::parse(api_url).map_err(|e| {
+        RunnerError::Config(format!(
+            "invalid platform API URL: {e}; {HTTPS_OR_LOOPBACK_HTTP_MESSAGE}"
+        ))
+    })?;
+    if !has_scheme_authority_separator(api_url, parsed.scheme()) {
+        return Err(RunnerError::Config(format!(
+            "invalid platform API URL: missing scheme authority separator; {HTTPS_OR_LOOPBACK_HTTP_MESSAGE}"
+        )));
+    }
+    let host = parsed.host().ok_or_else(|| {
+        RunnerError::Config(format!(
+            "invalid platform API URL: missing host; {HTTPS_OR_LOOPBACK_HTTP_MESSAGE}"
+        ))
+    })?;
+
+    match parsed.scheme() {
+        "https" => Ok(()),
+        "http" if is_loopback_host(host) => Ok(()),
+        "http" => Err(RunnerError::Config(HTTPS_OR_LOOPBACK_HTTP_MESSAGE.into())),
+        scheme => Err(RunnerError::Config(format!(
+            "invalid platform API URL scheme `{scheme}`; {HTTPS_OR_LOOPBACK_HTTP_MESSAGE}"
+        ))),
+    }
+}
+
+fn has_scheme_authority_separator(api_url: &str, parsed_scheme: &str) -> bool {
+    let Some((raw_scheme, rest)) = api_url.split_once(':') else {
+        return false;
+    };
+    raw_scheme.eq_ignore_ascii_case(parsed_scheme) && rest.starts_with("//")
+}
+
+fn is_loopback_host(host: Host<&str>) -> bool {
+    match host {
+        Host::Domain(domain) => domain.eq_ignore_ascii_case("localhost"),
+        Host::Ipv4(ip) => ip.is_loopback(),
+        Host::Ipv6(ip) => is_loopback_ipv6(ip),
+    }
+}
+
+fn is_loopback_ipv6(ip: Ipv6Addr) -> bool {
+    if ip.is_loopback() {
+        return true;
+    }
+    ipv4_mapped_is_loopback(ip)
+}
+
+fn ipv4_mapped_is_loopback(ip: Ipv6Addr) -> bool {
+    let segments = ip.segments();
+    if segments[..5] != [0, 0, 0, 0, 0] || segments[5] != 0xffff {
+        return false;
+    }
+    let octets = [
+        (segments[6] >> 8) as u8,
+        segments[6] as u8,
+        (segments[7] >> 8) as u8,
+        segments[7] as u8,
+    ];
+    Ipv4Addr::from(octets).is_loopback()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn accepts_https_platform_api_urls() {
+        for url in [
+            "https://api.vm0.ai",
+            "https://api.vm0.ai:443",
+            "https://api.vm0.ai/api",
+            "https://127.0.0.1",
+            "https://[2001:db8::1]:8443",
+        ] {
+            validate_platform_api_url(url).unwrap_or_else(|err| {
+                panic!("expected {url} to be accepted, got {err}");
+            });
+        }
+    }
+
+    #[test]
+    fn accepts_loopback_http_platform_api_urls() {
+        for url in [
+            "http://localhost",
+            "http://LOCALHOST:3000",
+            "http://127.0.0.1:3000",
+            "http://127.1.2.3:3000",
+            "http://[::1]:3000",
+            "http://[::ffff:127.0.0.1]:3000",
+        ] {
+            validate_platform_api_url(url).unwrap_or_else(|err| {
+                panic!("expected {url} to be accepted, got {err}");
+            });
+        }
+    }
+
+    #[test]
+    fn rejects_non_loopback_http_platform_api_urls() {
+        for url in [
+            "http://api.vm0.ai",
+            "http://10.0.0.1",
+            "http://172.16.0.1",
+            "http://192.168.1.10",
+            "http://169.254.1.1",
+            "http://0.0.0.0",
+            "http://[::ffff:10.0.0.1]",
+            "http://localhost.",
+        ] {
+            let err = validate_platform_api_url(url).unwrap_err();
+            assert!(
+                err.to_string().contains("platform API URL must use https"),
+                "{url} returned unexpected error: {err}"
+            );
+        }
+    }
+
+    #[test]
+    fn rejects_unsupported_or_malformed_platform_api_urls() {
+        for url in [
+            "ftp://api.vm0.ai",
+            "file:///etc/passwd",
+            "//api.vm0.ai",
+            "https:path-without-host",
+            "http://",
+            "http://api.vm0.ai:99999",
+        ] {
+            let err = match validate_platform_api_url(url) {
+                Ok(()) => panic!("expected {url} to be rejected"),
+                Err(err) => err,
+            };
+            assert!(
+                err.to_string().contains("platform API URL"),
+                "{url} returned unexpected error: {err}"
+            );
+        }
+    }
+}

--- a/crates/runner/src/platform_api_url.rs
+++ b/crates/runner/src/platform_api_url.rs
@@ -116,6 +116,7 @@ mod tests {
             "http://0.0.0.0",
             "http://[::ffff:10.0.0.1]",
             "http://localhost.",
+            "http://localhost@api.vm0.ai",
         ] {
             let err = validate_platform_api_url(url).unwrap_err();
             assert!(
@@ -132,6 +133,7 @@ mod tests {
             "file:///etc/passwd",
             "//api.vm0.ai",
             "https:path-without-host",
+            "http://[::1]@api.vm0.ai",
             "http://",
             "http://api.vm0.ai:99999",
         ] {


### PR DESCRIPTION
## Summary
- Add runner-side platform API URL validation: HTTPS is required except HTTP loopback hosts.
- Disable redirect following for authenticated platform API clients and doctor probes.
- Apply the same URL validation to mitm-addon platform API requests used by firewall auth, usage webhooks, and platform API auto-allow.
- Validate benchmark proxy platform API URLs before spawning mitmproxy.

## Tests
- `cargo fmt --manifest-path crates/Cargo.toml -p runner -- --check`
- `cargo test --manifest-path crates/Cargo.toml -p runner`
- `cargo test --manifest-path crates/Cargo.toml -p runner benchmark_proxy_api_url`
- `cargo test --manifest-path crates/Cargo.toml -p runner platform_api_url`
- `pytest tests/test_addon_configuration.py tests/test_request_handler_passthrough.py tests/test_firewall_auth.py tests/test_webhook.py`
- `ruff check src/auth.py src/mitm_addon.py tests/test_addon_configuration.py tests/test_request_handler_passthrough.py tests/test_firewall_auth.py tests/test_webhook.py`
- `ruff format --check src/auth.py src/mitm_addon.py tests/test_addon_configuration.py tests/test_request_handler_passthrough.py tests/test_firewall_auth.py tests/test_webhook.py`

Closes #15841
