### PR TITLE
fix(web): handle empty API backend env

### DIFF
--- a/turbo/apps/web/__tests__/security-headers.test.ts
+++ b/turbo/apps/web/__tests__/security-headers.test.ts
@@ -1918,6 +1918,26 @@ describe("API backend rewrites", () => {
     vi.unstubAllEnvs();
   });
 
+  it("should use the local API fallback when the backend URL is empty", async () => {
+    vi.stubEnv("VM0_API_BACKEND_URL", "");
+    vi.stubEnv("VERCEL_ENV", undefined);
+
+    const rewrites = await getBeforeFileRewrites();
+
+    expect(rewrites).toEqual(
+      expect.arrayContaining([
+        {
+          source: ZERO_FEATURE_SWITCHES_REWRITE_SOURCE,
+          destination: "http://localhost:3001/api/zero/feature-switches",
+        },
+        {
+          source: REALTIME_TOKEN_REWRITE_SOURCE,
+          destination: "http://localhost:3001/api/zero/realtime/token",
+        },
+      ]),
+    );
+  });
+
   it("should proxy migrated API backend routes to apps/api", async () => {
     vi.stubEnv("VM0_API_BACKEND_URL", "https://api.example.test");
 

--- a/turbo/apps/web/next.config.js
+++ b/turbo/apps/web/next.config.js
@@ -21,8 +21,9 @@ const MODEL_SLUG_REDIRECTS = [
 ];
 
 function resolveApiBackendUrl() {
+  const apiBackendUrl = process.env.VM0_API_BACKEND_URL?.trim();
   return (
-    process.env.VM0_API_BACKEND_URL ??
+    apiBackendUrl ||
     (process.env.VERCEL_ENV === "production"
       ? "https://vm0-api.vm6.ai"
       : process.env.VERCEL_ENV === undefined


### PR DESCRIPTION
## Summary
- Treat an empty `VM0_API_BACKEND_URL` as unset in the web Next config
- Preserve the local API backend fallback to `http://localhost:3001` for dev rewrites
- Add regression coverage for empty backend URL rewrites

## Testing
- `pnpm -F web exec vitest __tests__/security-headers.test.ts`
- `pnpm -F web exec eslint __tests__/security-headers.test.ts --max-warnings 0`
- `pnpm exec prettier --check apps/web/next.config.js apps/web/__tests__/security-headers.test.ts`
- pre-commit hook: `check-file-size`, `block-generated-firewalls`, `pnpm check-types`, `commitlint`
