### PR TITLE
refactor: make connector storage ownership explicit

### DIFF
--- a/turbo/apps/api/src/signals/routes/__tests__/connectors-type-callback.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/connectors-type-callback.test.ts
@@ -290,6 +290,10 @@ function testManualAuthMethod(args: {
   return {
     label: `Manual ${args.secretName}`,
     helpText: "Test-only manual grant.",
+    storage: {
+      secrets: [args.secretName],
+      variables: [args.variableName],
+    },
     grant: {
       kind: "manual",
       fields: {

--- a/turbo/apps/api/src/signals/services/agent-run-create.service.ts
+++ b/turbo/apps/api/src/signals/services/agent-run-create.service.ts
@@ -25,10 +25,8 @@ import {
 } from "@vm0/api-contracts/contracts/model-providers";
 import {
   getConnectorAuthMethod,
-  getConnectorAuthMethodAccessMetadata,
-  getConnectorAuthMethodEnvBindings,
-  getConnectorOwnedAccessSecretBindingEntries,
-  type ConnectorOwnedAccessSecretBindingEntry,
+  getConnectorAuthMethodStorageMetadata,
+  type ConnectorRuntimeBindingEntry,
 } from "@vm0/connectors/connector-utils";
 import {
   connectorTypeSchema,
@@ -1553,9 +1551,9 @@ interface StoredConnectorRuntimeRow {
 interface ConnectorEnvBindingSet {
   readonly connectorType: ConnectorType;
   readonly authMethod: string;
-  readonly envBindings: Record<string, string>;
-  readonly ownedSecretBindings: readonly ConnectorOwnedAccessSecretBindingEntry[];
-  readonly platformSecretNames: ReadonlySet<string>;
+  readonly accessKind: "static" | "refresh-token" | "none";
+  readonly accessTokenSecret: string | undefined;
+  readonly runtimeBindings: readonly ConnectorRuntimeBindingEntry[];
   readonly optionalSecretNames: ReadonlySet<string>;
   readonly optionalVariableNames: ReadonlySet<string>;
 }
@@ -1605,11 +1603,11 @@ function connectorEnvBindingSets(
 ): readonly ConnectorEnvBindingSet[] {
   return rows.map((row) => {
     const method = getConnectorAuthMethod(row.connectorType, row.authMethod);
-    const accessMetadata = getConnectorAuthMethodAccessMetadata(
+    const metadata = getConnectorAuthMethodStorageMetadata(
       row.connectorType,
       row.authMethod,
     );
-    if (!method) {
+    if (!method || !metadata) {
       throw new Error(
         `Invalid auth method "${row.authMethod}" for stored connector "${row.connectorType}"`,
       );
@@ -1631,14 +1629,9 @@ function connectorEnvBindingSets(
     return {
       connectorType: row.connectorType,
       authMethod: row.authMethod,
-      envBindings: getConnectorAuthMethodEnvBindings(
-        row.connectorType,
-        row.authMethod,
-      ),
-      ownedSecretBindings: accessMetadata
-        ? getConnectorOwnedAccessSecretBindingEntries(accessMetadata)
-        : [],
-      platformSecretNames: new Set(accessMetadata?.platformSecrets ?? []),
+      accessKind: method.access.kind,
+      accessTokenSecret: metadata.secretRoles.accessToken,
+      runtimeBindings: metadata.runtimeBindings,
       optionalSecretNames,
       optionalVariableNames,
     };
@@ -1651,13 +1644,20 @@ function collectStoredConnectorRequirements(
   const secretNames = new Set<string>();
   const variableNames = new Set<string>();
 
-  for (const { envBindings, ownedSecretBindings } of bindingSets) {
-    for (const { secretName } of ownedSecretBindings) {
-      secretNames.add(secretName);
-    }
-    for (const valueRef of Object.values(envBindings)) {
-      if (valueRef.startsWith(CONNECTOR_VAR_REF_PREFIX)) {
-        variableNames.add(valueRef.slice(CONNECTOR_VAR_REF_PREFIX.length));
+  for (const { runtimeBindings } of bindingSets) {
+    for (const { source } of runtimeBindings) {
+      switch (source.kind) {
+        case "connector-secret": {
+          secretNames.add(source.name);
+          break;
+        }
+        case "connector-variable": {
+          variableNames.add(source.name);
+          break;
+        }
+        case "platform-secret": {
+          break;
+        }
       }
     }
   }
@@ -1735,23 +1735,6 @@ async function loadStoredConnectorVariables(
   );
 }
 
-function handlePlatformSecretBinding(args: {
-  readonly secrets: Record<string, string>;
-  readonly envName: string;
-  readonly secretName: string;
-  readonly platformSecretNames: ReadonlySet<string>;
-}): boolean {
-  if (!args.platformSecretNames.has(args.secretName)) {
-    return false;
-  }
-
-  const secretValue = optionalEnv(args.secretName);
-  if (secretValue) {
-    args.secrets[args.envName] = secretValue;
-  }
-  return true;
-}
-
 function resolveStoredConnectorState(
   bindingSets: readonly ConnectorEnvBindingSet[],
   connectorSecrets: Record<string, string>,
@@ -1764,66 +1747,62 @@ function resolveStoredConnectorState(
 
   for (const {
     connectorType,
-    authMethod,
-    envBindings,
-    ownedSecretBindings,
-    platformSecretNames,
+    accessKind,
+    accessTokenSecret,
+    runtimeBindings,
     optionalSecretNames,
     optionalVariableNames,
   } of bindingSets) {
-    for (const [envName, valueRef] of Object.entries(envBindings)) {
-      if (valueRef.startsWith(CONNECTOR_SECRET_REF_PREFIX)) {
-        const secretName = valueRef.slice(CONNECTOR_SECRET_REF_PREFIX.length);
-        if (
-          handlePlatformSecretBinding({
-            secrets,
-            envName,
-            secretName,
-            platformSecretNames,
-          })
-        ) {
-          continue;
+    for (const { envName, valueRef, source } of runtimeBindings) {
+      switch (source.kind) {
+        case "connector-secret": {
+          const secretName = source.name;
+          const secretValue = connectorSecrets[secretName];
+          if (secretValue !== undefined) {
+            secrets[envName] = secretValue;
+            addConnectorEnvironmentTemplate(environment, envName, valueRef);
+          } else if (!optionalSecretNames.has(secretName)) {
+            addConnectorEnvironmentTemplate(environment, envName, valueRef);
+          }
+          break;
         }
-        const secretValue = connectorSecrets[secretName];
-        if (secretValue !== undefined) {
-          secrets[envName] = secretValue;
-          addConnectorEnvironmentTemplate(environment, envName, valueRef);
-        } else if (!optionalSecretNames.has(secretName)) {
-          addConnectorEnvironmentTemplate(environment, envName, valueRef);
+        case "connector-variable": {
+          const variableName = source.name;
+          const variableValue = connectorVariables[variableName];
+          if (variableValue !== undefined) {
+            vars[envName] = variableValue;
+            addConnectorEnvironmentTemplate(environment, envName, valueRef);
+          } else if (!optionalVariableNames.has(variableName)) {
+            addConnectorEnvironmentTemplate(environment, envName, valueRef);
+          }
+          break;
         }
-      } else if (valueRef.startsWith(CONNECTOR_VAR_REF_PREFIX)) {
-        const variableName = valueRef.slice(CONNECTOR_VAR_REF_PREFIX.length);
-        const variableValue = connectorVariables[variableName];
-        if (variableValue !== undefined) {
-          vars[envName] = variableValue;
-          addConnectorEnvironmentTemplate(environment, envName, valueRef);
-        } else if (!optionalVariableNames.has(variableName)) {
-          addConnectorEnvironmentTemplate(environment, envName, valueRef);
+        case "platform-secret": {
+          const secretValue = optionalEnv(source.name);
+          if (secretValue) {
+            secrets[envName] = secretValue;
+          }
+          break;
         }
-      } else {
-        addConnectorEnvironmentTemplate(environment, envName, valueRef);
       }
     }
 
-    const accessMetadata = getConnectorAuthMethodAccessMetadata(
-      connectorType,
-      authMethod,
-    );
     // Firewall auth templates can only reference env aliases from envBindings;
     // store the alias that points at the access secret, not the backing secret name.
-    if (accessMetadata?.kind === "refresh-token") {
-      const secretName = accessMetadata.accessToken;
-      for (const {
-        envName,
-        secretName: boundSecretName,
-      } of ownedSecretBindings) {
-        if (boundSecretName === secretName) {
+    if (accessKind === "refresh-token") {
+      for (const { envName, source } of runtimeBindings) {
+        if (
+          source.kind === "connector-secret" &&
+          source.name === accessTokenSecret
+        ) {
           secretConnectorMap[envName] = connectorType;
         }
       }
-    } else if (accessMetadata?.kind === "static") {
-      for (const { envName } of ownedSecretBindings) {
-        secretConnectorMap[envName] = connectorType;
+    } else if (accessKind === "static") {
+      for (const { envName, source } of runtimeBindings) {
+        if (source.kind === "connector-secret") {
+          secretConnectorMap[envName] = connectorType;
+        }
       }
     }
   }

--- a/turbo/apps/api/src/signals/services/agent-webhook-firewall-auth.service.ts
+++ b/turbo/apps/api/src/signals/services/agent-webhook-firewall-auth.service.ts
@@ -7,11 +7,12 @@ import {
 } from "@vm0/api-contracts/contracts/model-providers";
 import type { SecretConnectorMetadata } from "@vm0/api-contracts/contracts/runners";
 import {
-  resolveConnectorAuthClientForMethod,
   getConnectorAuthMethodAccessMetadata,
-  getConnectorOwnedAccessSecretBindingEntries,
+  getConnectorAuthMethodStorageMetadata,
+  resolveConnectorAuthClientForMethod,
   connectorAuthMethodSupportsRefreshTokenAccess,
   type ConnectorAuthMethodAccessMetadata,
+  type ConnectorAuthMethodStorageMetadata,
 } from "@vm0/connectors/connector-utils";
 import {
   connectorTypeSchema,
@@ -411,6 +412,7 @@ interface RefreshSourceState {
 interface ConnectorAccessState extends RefreshSourceState {
   readonly authMethod: string;
   readonly accessMetadata: ConnectorAuthMethodAccessMetadata;
+  readonly storageMetadata: ConnectorAuthMethodStorageMetadata;
 }
 
 interface BasicArgContext extends BasicAuthTemplateArg {
@@ -756,12 +758,17 @@ async function loadConnectorAccessStates(
       parsed.data,
       row.authMethod,
     );
-    if (!accessMetadata) {
+    const storageMetadata = getConnectorAuthMethodStorageMetadata(
+      parsed.data,
+      row.authMethod,
+    );
+    if (!accessMetadata || !storageMetadata) {
       continue;
     }
     result.set(row.type, {
       authMethod: row.authMethod,
       accessMetadata,
+      storageMetadata,
       ...refreshSourceStateFromRow(row),
     });
   }
@@ -1713,37 +1720,45 @@ function getOwnConnectorOwner(
 
 function isSelectedAccessSecretKey(
   key: string,
-  accessMetadata: ConnectorAuthMethodAccessMetadata,
+  connectorAccess: ConnectorAccessState,
 ): boolean {
-  return connectorAccessSecretName(key, accessMetadata) !== undefined;
+  return connectorAccessSecretName(key, connectorAccess) !== undefined;
 }
 
 function connectorAccessSecretName(
   key: string,
-  accessMetadata: ConnectorAuthMethodAccessMetadata,
+  connectorAccess: ConnectorAccessState,
 ): string | undefined {
-  switch (accessMetadata.kind) {
+  switch (connectorAccess.accessMetadata.kind) {
     case "refresh-token": {
-      const entry = getConnectorOwnedAccessSecretBindingEntries(
-        accessMetadata,
-      ).find((binding) => {
-        return binding.envName === key;
-      });
-      return entry?.secretName === accessMetadata.accessToken
-        ? accessMetadata.accessToken
+      const secretName = connectorRuntimeSecretName(
+        key,
+        connectorAccess.storageMetadata,
+      );
+      return secretName ===
+        connectorAccess.storageMetadata.secretRoles.accessToken
+        ? secretName
         : undefined;
     }
     case "static": {
-      return getConnectorOwnedAccessSecretBindingEntries(accessMetadata).find(
-        (binding) => {
-          return binding.envName === key;
-        },
-      )?.secretName;
+      return connectorRuntimeSecretName(key, connectorAccess.storageMetadata);
     }
     case "none": {
       return undefined;
     }
   }
+}
+
+function connectorRuntimeSecretName(
+  key: string,
+  storageMetadata: ConnectorAuthMethodStorageMetadata,
+): string | undefined {
+  const binding = storageMetadata.runtimeBindings.find((entry) => {
+    return entry.envName === key && entry.source.kind === "connector-secret";
+  });
+  return binding?.source.kind === "connector-secret"
+    ? binding.source.name
+    : undefined;
 }
 
 function modelProviderAccessSecretName(args: {
@@ -1840,12 +1855,11 @@ async function syncStaticConnectorAccessSecrets(args: {
     if (metadata.sourceType !== "connector") {
       return [];
     }
-    const accessMetadata =
-      args.connectorAccessByType.get(connectorType)?.accessMetadata;
-    if (accessMetadata?.kind !== "static") {
+    const connectorAccess = args.connectorAccessByType.get(connectorType);
+    if (connectorAccess?.accessMetadata.kind !== "static") {
       return [];
     }
-    const secretName = connectorAccessSecretName(key, accessMetadata);
+    const secretName = connectorAccessSecretName(key, connectorAccess);
     return secretName ? [{ key, secretName }] : [];
   });
   if (lookups.length === 0) {
@@ -1918,12 +1932,11 @@ function canResolveMissingAccessSecret(args: {
     );
   }
 
-  const accessMetadata =
-    args.connectorAccessByType.get(connectorType)?.accessMetadata;
-  if (accessMetadata?.kind !== "refresh-token") {
+  const connectorAccess = args.connectorAccessByType.get(connectorType);
+  if (connectorAccess?.accessMetadata.kind !== "refresh-token") {
     return false;
   }
-  return isSelectedAccessSecretKey(args.key, accessMetadata);
+  return isSelectedAccessSecretKey(args.key, connectorAccess);
 }
 
 function referencedConnectorTypes(args: {
@@ -1990,9 +2003,8 @@ function hasUnavailableAccessSource(args: {
       return !args.modelProviderSourceStateByConnector.has(connectorType);
     }
 
-    const accessMetadata =
-      args.connectorAccessByType.get(connectorType)?.accessMetadata;
-    return !accessMetadata || !isSelectedAccessSecretKey(key, accessMetadata);
+    const connectorAccess = args.connectorAccessByType.get(connectorType);
+    return !connectorAccess || !isSelectedAccessSecretKey(key, connectorAccess);
   });
 }
 

--- a/turbo/apps/api/src/signals/services/zero-connector-data.service.ts
+++ b/turbo/apps/api/src/signals/services/zero-connector-data.service.ts
@@ -8,15 +8,13 @@ import type { ConnectorSearchAuthMethod } from "@vm0/api-contracts/contracts/zer
 import {
   connectorAuthMethodSupportsTokenRevoke,
   getAvailableConnectorAuthMethods,
-  getConnectorAuthMethodAccessMetadata,
+  getConnectorAuthMethodStorageMetadata,
   getConnectorAuthMethodScopeDiff,
   getConnectorAuthMethod,
   getConnectorManualGrantFieldNamesForAuthMethod,
-  getConnectorOwnedAccessSecretBindingEntries,
   getConnectorOwnedSecretNames,
   getConnectorVariableNames,
   getRuntimeAvailableConnectorTypes,
-  type ConnectorAuthMethodAccessMetadata,
   type ManualGrantFieldNames,
 } from "@vm0/connectors/connector-utils";
 import { revokeConnectorAuthMethodAccessToken } from "@vm0/connectors/auth-providers";
@@ -409,18 +407,18 @@ function connectorProvidedEnvNamesForStoredConnectors(
 ): Set<string> {
   const provided = new Set<string>();
   for (const connector of connectorList) {
-    const accessMetadata = getConnectorAuthMethodAccessMetadata(
+    const metadata = getConnectorAuthMethodStorageMetadata(
       connector.type,
       connector.authMethod,
     );
-    if (!accessMetadata) {
+    if (!metadata) {
       continue;
     }
-    for (const {
-      envName,
-      secretName,
-    } of getConnectorOwnedAccessSecretBindingEntries(accessMetadata)) {
-      if (!connectorScopedSecretNames.secretNames.has(secretName)) {
+    for (const { envName, source } of metadata.runtimeBindings) {
+      if (source.kind !== "connector-secret") {
+        continue;
+      }
+      if (!connectorScopedSecretNames.secretNames.has(source.name)) {
         continue;
       }
       provided.add(envName);
@@ -1205,45 +1203,37 @@ function connectorTokenExpiresAt(args: {
     : new Date(nowDate().getTime() + expiresInSecs * 1000);
 }
 
-function staticConnectorOwnedAccessSecretName(
-  accessMetadata: Extract<
-    ConnectorAuthMethodAccessMetadata,
-    { readonly kind: "static" }
-  >,
-): string | undefined {
-  const secretNames = new Set<string>();
-  for (const { secretName } of getConnectorOwnedAccessSecretBindingEntries(
-    accessMetadata,
-  )) {
-    secretNames.add(secretName);
-  }
-  if (secretNames.size !== 1) {
-    return undefined;
-  }
-  return [...secretNames][0];
-}
-
 function connectorTokenSecretMetadataForAuthMethod(args: {
   readonly type: ConnectorType;
   readonly authMethod: string;
 }): ConnectorTokenSecretMetadata | undefined {
-  const accessMetadata = getConnectorAuthMethodAccessMetadata(
+  const method = getConnectorAuthMethod(args.type, args.authMethod);
+  const metadata = getConnectorAuthMethodStorageMetadata(
     args.type,
     args.authMethod,
   );
+  if (!method || !metadata) {
+    return undefined;
+  }
 
-  switch (accessMetadata?.kind) {
+  switch (method.access.kind) {
     case "refresh-token": {
+      const accessSecretName = metadata.secretRoles.accessToken;
+      const refreshSecretName = metadata.secretRoles.refreshToken;
+      if (!accessSecretName || !refreshSecretName) {
+        throw new Error(
+          `${args.type} connector auth method ${args.authMethod} is missing refresh token secret roles`,
+        );
+      }
       return {
-        accessSecretName: accessMetadata.accessToken,
-        refreshSecretName: accessMetadata.refreshToken,
+        accessSecretName,
+        refreshSecretName,
         isRefreshable: true,
       };
     }
 
     case "static": {
-      const accessSecretName =
-        staticConnectorOwnedAccessSecretName(accessMetadata);
+      const accessSecretName = metadata.secretRoles.accessToken;
       return accessSecretName
         ? {
             accessSecretName,

--- a/turbo/packages/connectors/src/__tests__/connectors.test.ts
+++ b/turbo/packages/connectors/src/__tests__/connectors.test.ts
@@ -43,6 +43,7 @@ import {
   getConnectorAuthMethodAuthCodeGrantConfig,
   getConnectorAuthMethodDeviceAuthGrantConfig,
   getConnectorAuthMethodAccessMetadata,
+  getConnectorAuthMethodStorageMetadata,
   getConnectorOwnedAccessSecretBindingEntries,
   resolveConnectorAuthClientForMethod,
   getConnectorAuthMethodEnvBindings,
@@ -198,6 +199,10 @@ function restoreEnv(values: Record<string, string | undefined>): void {
 const manualAuthMethodConfig = {
   label: "API Token",
   helpText: "Enter an API token.",
+  storage: {
+    secrets: ["API_TOKEN"],
+    variables: [],
+  },
   grant: {
     kind: "manual",
     fields: {
@@ -458,6 +463,10 @@ describe("connector auth method config", () => {
     const apiTokenMethod = {
       label: "API Token",
       helpText: "Enter an API token.",
+      storage: {
+        secrets: ["GITHUB_API_TOKEN"],
+        variables: ["GITHUB_API_HOST"],
+      },
       grant: {
         kind: "manual",
         fields: {
@@ -484,6 +493,10 @@ describe("connector auth method config", () => {
     const apiMethod = {
       label: "Secondary API Token",
       helpText: "Enter a secondary API token.",
+      storage: {
+        secrets: ["GITHUB_SECONDARY_TOKEN"],
+        variables: ["GITHUB_SECONDARY_HOST"],
+      },
       grant: {
         kind: "manual",
         fields: {
@@ -1862,6 +1875,132 @@ describe("getConnectorAuthMethodAccessMetadata", () => {
       { envName: "GH_TOKEN", secretName: "GITHUB_ACCESS_TOKEN" },
       { envName: "GITHUB_TOKEN", secretName: "GITHUB_ACCESS_TOKEN" },
     ]);
+  });
+});
+
+describe("getConnectorAuthMethodStorageMetadata", () => {
+  it("returns explicit static provider token storage roles", () => {
+    expect(
+      getConnectorAuthMethodStorageMetadata("github", "oauth"),
+    ).toStrictEqual({
+      storage: {
+        secrets: ["GITHUB_ACCESS_TOKEN"],
+        variables: [],
+      },
+      secretRoles: {
+        accessToken: "GITHUB_ACCESS_TOKEN",
+      },
+      runtimeBindings: [
+        {
+          envName: "GH_TOKEN",
+          valueRef: "$secrets.GITHUB_ACCESS_TOKEN",
+          source: {
+            kind: "connector-secret",
+            name: "GITHUB_ACCESS_TOKEN",
+          },
+        },
+        {
+          envName: "GITHUB_TOKEN",
+          valueRef: "$secrets.GITHUB_ACCESS_TOKEN",
+          source: {
+            kind: "connector-secret",
+            name: "GITHUB_ACCESS_TOKEN",
+          },
+        },
+      ],
+    });
+  });
+
+  it("keeps manual static API tokens role-free", () => {
+    expect(
+      getConnectorAuthMethodStorageMetadata("stripe", "api-token"),
+    ).toStrictEqual({
+      storage: {
+        secrets: ["STRIPE_TOKEN"],
+        variables: [],
+      },
+      secretRoles: {},
+      runtimeBindings: [
+        {
+          envName: "STRIPE_TOKEN",
+          valueRef: "$secrets.STRIPE_TOKEN",
+          source: {
+            kind: "connector-secret",
+            name: "STRIPE_TOKEN",
+          },
+        },
+      ],
+    });
+  });
+
+  it("represents provider extra secrets as storage-owned runtime sources", () => {
+    expect(
+      getConnectorAuthMethodStorageMetadata("slock", "oauth"),
+    ).toStrictEqual({
+      storage: {
+        secrets: [
+          "SLOCK_ACCESS_TOKEN",
+          "SLOCK_SERVER_ID",
+          "SLOCK_REFRESH_TOKEN",
+        ],
+        variables: [],
+      },
+      secretRoles: {
+        accessToken: "SLOCK_ACCESS_TOKEN",
+        refreshToken: "SLOCK_REFRESH_TOKEN",
+      },
+      runtimeBindings: [
+        {
+          envName: "SLOCK_TOKEN",
+          valueRef: "$secrets.SLOCK_ACCESS_TOKEN",
+          source: {
+            kind: "connector-secret",
+            name: "SLOCK_ACCESS_TOKEN",
+          },
+        },
+        {
+          envName: "SLOCK_SERVER_ID",
+          valueRef: "$secrets.SLOCK_SERVER_ID",
+          source: {
+            kind: "connector-secret",
+            name: "SLOCK_SERVER_ID",
+          },
+        },
+      ],
+    });
+  });
+
+  it("represents platform secrets as platform runtime sources", () => {
+    expect(
+      getConnectorAuthMethodStorageMetadata("google-ads", "oauth"),
+    ).toStrictEqual({
+      storage: {
+        secrets: ["GOOGLE_ADS_ACCESS_TOKEN", "GOOGLE_ADS_REFRESH_TOKEN"],
+        variables: [],
+      },
+      secretRoles: {
+        accessToken: "GOOGLE_ADS_ACCESS_TOKEN",
+        refreshToken: "GOOGLE_ADS_REFRESH_TOKEN",
+      },
+      runtimeBindings: [
+        {
+          envName: "GOOGLE_ADS_TOKEN",
+          valueRef: "$secrets.GOOGLE_ADS_ACCESS_TOKEN",
+          source: {
+            kind: "connector-secret",
+            name: "GOOGLE_ADS_ACCESS_TOKEN",
+          },
+        },
+        {
+          envName: "GOOGLE_ADS_DEVELOPER_TOKEN",
+          valueRef: "$secrets.GOOGLE_ADS_DEVELOPER_TOKEN",
+          source: {
+            kind: "platform-secret",
+            name: "GOOGLE_ADS_DEVELOPER_TOKEN",
+          },
+        },
+      ],
+    });
   });
 });
 

--- a/turbo/packages/connectors/src/connector-utils.ts
+++ b/turbo/packages/connectors/src/connector-utils.ts
@@ -41,6 +41,7 @@ const CONNECTOR_AUTH_METHOD_PRIORITY = {
   api: 2,
 } as const satisfies Record<ConnectorAuthMethodId, number>;
 const CONNECTOR_SECRET_REF_PREFIX = "$secrets.";
+const CONNECTOR_VARIABLE_REF_PREFIX = "$vars.";
 
 function connectorAuthMethodPriority(
   authMethod: ConnectorAuthMethodId,
@@ -253,6 +254,7 @@ function connectorAccessPlatformSecrets(
 export type ConnectorAuthMethodAccessMetadata =
   | {
       readonly kind: "static";
+      readonly accessToken?: string;
       readonly envBindings: ConnectorEnvBindings;
       readonly platformSecrets: readonly ConnectorPlatformSecretName[];
     }
@@ -272,6 +274,38 @@ export type ConnectorAuthMethodAccessMetadata =
 export interface ConnectorOwnedAccessSecretBindingEntry {
   readonly envName: string;
   readonly secretName: string;
+}
+
+export type ConnectorRuntimeBindingSource =
+  | {
+      readonly kind: "connector-secret";
+      readonly name: string;
+    }
+  | {
+      readonly kind: "connector-variable";
+      readonly name: string;
+    }
+  | {
+      readonly kind: "platform-secret";
+      readonly name: ConnectorPlatformSecretName;
+    };
+
+export interface ConnectorRuntimeBindingEntry {
+  readonly envName: string;
+  readonly valueRef: string;
+  readonly source: ConnectorRuntimeBindingSource;
+}
+
+export interface ConnectorAuthMethodStorageMetadata {
+  readonly storage: {
+    readonly secrets: readonly string[];
+    readonly variables: readonly string[];
+  };
+  readonly secretRoles: {
+    readonly accessToken?: string;
+    readonly refreshToken?: string;
+  };
+  readonly runtimeBindings: readonly ConnectorRuntimeBindingEntry[];
 }
 
 function connectorOwnedAccessSecretBindingEntries(args: {
@@ -304,6 +338,21 @@ export function getConnectorOwnedAccessSecretBindingEntries(
   });
 }
 
+function requireConnectorSecretRole(args: {
+  readonly type: ConnectorType;
+  readonly authMethod: string;
+  readonly role: "accessToken" | "refreshToken";
+}): string {
+  const role = getConnectorAuthMethod(args.type, args.authMethod)?.storage
+    .secretRoles?.[args.role];
+  if (!role) {
+    throw new Error(
+      `${args.type} connector auth method ${args.authMethod} is missing ${args.role} secret role`,
+    );
+  }
+  return role;
+}
+
 export function getConnectorAuthMethodAccessMetadata(
   type: ConnectorType,
   authMethod: string,
@@ -314,17 +363,28 @@ export function getConnectorAuthMethodAccessMetadata(
   }
 
   switch (method.access.kind) {
-    case "static":
+    case "static": {
+      const accessToken = method.storage.secretRoles?.accessToken;
       return {
         kind: "static",
+        ...(accessToken ? { accessToken } : {}),
         envBindings: method.access.envBindings,
         platformSecrets: method.access.platformSecrets ?? [],
       };
+    }
     case "refresh-token":
       return {
         kind: "refresh-token",
-        accessToken: method.access.accessToken,
-        refreshToken: method.access.refreshToken,
+        accessToken: requireConnectorSecretRole({
+          type,
+          authMethod,
+          role: "accessToken",
+        }),
+        refreshToken: requireConnectorSecretRole({
+          type,
+          authMethod,
+          role: "refreshToken",
+        }),
         envBindings: method.access.envBindings,
         platformSecrets: method.access.platformSecrets ?? [],
       };
@@ -335,6 +395,78 @@ export function getConnectorAuthMethodAccessMetadata(
         platformSecrets: [],
       };
   }
+}
+
+function connectorPlatformSecretSource(
+  secretName: string,
+  platformSecrets: readonly ConnectorPlatformSecretName[],
+): ConnectorPlatformSecretName | undefined {
+  return platformSecrets.find((platformSecret) => {
+    return platformSecret === secretName;
+  });
+}
+
+function connectorRuntimeBindingEntries(args: {
+  readonly envBindings: ConnectorEnvBindings;
+  readonly platformSecrets: readonly ConnectorPlatformSecretName[];
+}): ConnectorRuntimeBindingEntry[] {
+  const entries: ConnectorRuntimeBindingEntry[] = [];
+  for (const [envName, valueRef] of Object.entries(args.envBindings)) {
+    if (valueRef.startsWith(CONNECTOR_SECRET_REF_PREFIX)) {
+      const secretName = valueRef.slice(CONNECTOR_SECRET_REF_PREFIX.length);
+      const platformSecret = connectorPlatformSecretSource(
+        secretName,
+        args.platformSecrets,
+      );
+      entries.push({
+        envName,
+        valueRef,
+        source: platformSecret
+          ? { kind: "platform-secret", name: platformSecret }
+          : { kind: "connector-secret", name: secretName },
+      });
+      continue;
+    }
+
+    if (valueRef.startsWith(CONNECTOR_VARIABLE_REF_PREFIX)) {
+      entries.push({
+        envName,
+        valueRef,
+        source: {
+          kind: "connector-variable",
+          name: valueRef.slice(CONNECTOR_VARIABLE_REF_PREFIX.length),
+        },
+      });
+    }
+  }
+  return entries;
+}
+
+export function getConnectorAuthMethodStorageMetadata(
+  type: ConnectorType,
+  authMethod: string,
+): ConnectorAuthMethodStorageMetadata | undefined {
+  const method = getConnectorAuthMethod(type, authMethod);
+  if (!method) {
+    return undefined;
+  }
+  const platformSecrets = connectorAccessPlatformSecrets(method.access);
+  const accessToken = method.storage.secretRoles?.accessToken;
+  const refreshToken = method.storage.secretRoles?.refreshToken;
+  return {
+    storage: {
+      secrets: [...method.storage.secrets],
+      variables: [...method.storage.variables],
+    },
+    secretRoles: {
+      ...(accessToken ? { accessToken } : {}),
+      ...(refreshToken ? { refreshToken } : {}),
+    },
+    runtimeBindings: connectorRuntimeBindingEntries({
+      envBindings: connectorAccessEnvBindings(method.access),
+      platformSecrets,
+    }),
+  };
 }
 
 export function connectorAuthMethodHasGrantKind<
@@ -769,64 +901,13 @@ export function getConnectorVariableNames(
 function connectorMethodOwnedSecretNames(
   method: ConnectorAuthMethodConfig | undefined,
 ): string[] {
-  if (!method) {
-    return [];
-  }
-
-  const names = new Set<string>();
-  const fields = getManualGrantFields(method);
-  for (const [name, field] of Object.entries(fields ?? {})) {
-    if (field.storage !== "variable") {
-      names.add(name);
-    }
-  }
-
-  for (const { secretName } of connectorOwnedAccessSecretBindingEntries({
-    envBindings: connectorAccessEnvBindings(method.access),
-    platformSecrets: connectorAccessPlatformSecrets(method.access),
-  })) {
-    names.add(secretName);
-  }
-
-  if (method.access.kind === "refresh-token") {
-    names.add(method.access.accessToken);
-    names.add(method.access.refreshToken);
-  }
-
-  const platformSecretNames: ReadonlySet<string> = new Set(
-    connectorAccessPlatformSecrets(method.access),
-  );
-  for (const secretName of platformSecretNames) {
-    names.delete(secretName);
-  }
-
-  return [...names];
+  return method ? [...method.storage.secrets] : [];
 }
 
 function connectorMethodVariableNames(
   method: ConnectorAuthMethodConfig | undefined,
 ): string[] {
-  if (!method) {
-    return [];
-  }
-
-  const names = new Set<string>();
-  const fields = getManualGrantFields(method);
-  for (const [name, field] of Object.entries(fields ?? {})) {
-    if (field.storage === "variable") {
-      names.add(name);
-    }
-  }
-
-  for (const valueRef of Object.values(
-    connectorAccessEnvBindings(method.access),
-  )) {
-    if (valueRef.startsWith("$vars.")) {
-      names.add(valueRef.slice("$vars.".length));
-    }
-  }
-
-  return [...names];
+  return method ? [...method.storage.variables] : [];
 }
 
 /**

--- a/turbo/packages/connectors/src/connectors.ts
+++ b/turbo/packages/connectors/src/connectors.ts
@@ -361,6 +361,18 @@ export const CONNECTOR_PLATFORM_SECRET_NAMES = [
 export type ConnectorPlatformSecretName =
   (typeof CONNECTOR_PLATFORM_SECRET_NAMES)[number];
 
+export interface ConnectorStorageConfig {
+  readonly secrets: readonly string[];
+  readonly variables: readonly string[];
+  /** Role mapping for provider-written or refreshable connector secrets. */
+  readonly secretRoles?: ConnectorSecretRolesConfig;
+}
+
+export interface ConnectorSecretRolesConfig {
+  readonly accessToken?: string;
+  readonly refreshToken?: string;
+}
+
 interface ConnectorEnvBindingAccessConfigBase {
   readonly envBindings: ConnectorEnvBindings;
   /**
@@ -377,8 +389,6 @@ export interface ConnectorStaticAccessConfig extends ConnectorEnvBindingAccessCo
 export interface ConnectorRefreshTokenAccessConfig extends ConnectorEnvBindingAccessConfigBase {
   readonly kind: "refresh-token";
   readonly tokenUrl: string;
-  readonly accessToken: string;
-  readonly refreshToken: string;
 }
 
 export interface ConnectorNoAccessConfig {
@@ -407,6 +417,13 @@ interface ConnectorAuthMethodConfigBase {
   featureFlag?: FeatureSwitchKey;
   /** When false, feature-gated UI surfaces should not add an experimental label. */
   showExperimentalLabel?: boolean;
+  /**
+   * Connector-scoped storage names owned by this auth method.
+   *
+   * These lists are write/delete allowlists, not guarantees that rows currently
+   * exist in the DB.
+   */
+  storage: ConnectorStorageConfig;
 }
 
 /**
@@ -581,6 +598,180 @@ export type ConnectorConfig = ConnectorConfigBase & {
   readonly authMethods: ConnectorAuthMethods;
 };
 
+type ConnectorStorageSecretName<Storage> = Storage extends {
+  readonly secrets: readonly (infer Name)[];
+}
+  ? Extract<Name, string>
+  : never;
+
+type ConnectorStorageVariableName<Storage> = Storage extends {
+  readonly variables: readonly (infer Name)[];
+}
+  ? Extract<Name, string>
+  : never;
+
+type ConnectorAccessPlatformSecretName<Access> = Access extends {
+  readonly platformSecrets: readonly (infer Name)[];
+}
+  ? Extract<Name, ConnectorPlatformSecretName>
+  : never;
+
+type ConnectorRuntimeValueRef<Storage, Access> =
+  | `$secrets.${ConnectorStorageSecretName<Storage> | ConnectorAccessPlatformSecretName<Access>}`
+  | `$vars.${ConnectorStorageVariableName<Storage>}`;
+
+type ValidatedConnectorEnvBindings<EnvBindings, Storage, Access> = {
+  readonly [EnvName in keyof EnvBindings]: EnvBindings[EnvName] extends ConnectorRuntimeValueRef<
+    Storage,
+    Access
+  >
+    ? EnvBindings[EnvName]
+    : ConnectorRuntimeValueRef<Storage, Access>;
+};
+
+type ValidatedConnectorAccessConfig<Access, Storage> = Access extends {
+  readonly envBindings: infer EnvBindings;
+}
+  ? Access & {
+      readonly envBindings: ValidatedConnectorEnvBindings<
+        EnvBindings,
+        Storage,
+        Access
+      >;
+    }
+  : Access;
+
+type ValidatedConnectorManualGrantField<
+  Field,
+  FieldName extends string,
+  Storage,
+> =
+  FieldName extends ConnectorStorageSecretName<Storage>
+    ? Field extends { readonly storage: "variable" }
+      ? never
+      : Field
+    : FieldName extends ConnectorStorageVariableName<Storage>
+      ? Field extends { readonly storage: "variable" }
+        ? Field
+        : never
+      : never;
+
+type ValidatedConnectorGrantConfig<Grant, Storage> = Grant extends {
+  readonly kind: "manual";
+  readonly fields: infer Fields;
+}
+  ? Grant & {
+      readonly fields: {
+        readonly [FieldName in keyof Fields]: FieldName extends string
+          ? ValidatedConnectorManualGrantField<
+              Fields[FieldName],
+              FieldName,
+              Storage
+            >
+          : never;
+      };
+    }
+  : Grant;
+
+type ValidatedConnectorSecretName<Name, Storage> =
+  Name extends ConnectorStorageSecretName<Storage>
+    ? Name
+    : ConnectorStorageSecretName<Storage>;
+
+type ValidatedConnectorSecretRoles<Bindings, Storage> = Bindings & {
+  readonly accessToken?: Bindings extends {
+    readonly accessToken: infer Name;
+  }
+    ? ValidatedConnectorSecretName<Name, Storage>
+    : ConnectorStorageSecretName<Storage>;
+  readonly refreshToken?: Bindings extends {
+    readonly refreshToken: infer Name;
+  }
+    ? ValidatedConnectorSecretName<Name, Storage>
+    : ConnectorStorageSecretName<Storage>;
+};
+
+type ConnectorSecretRolesFromStorage<Storage> = Storage extends {
+  readonly secretRoles: infer Bindings;
+}
+  ? Bindings
+  : Record<string, never>;
+
+type ConnectorRefreshSecretRoles<Storage> = ValidatedConnectorSecretRoles<
+  ConnectorSecretRolesFromStorage<Storage>,
+  Storage
+> & {
+  readonly accessToken: ConnectorStorageSecretName<Storage>;
+  readonly refreshToken: ConnectorStorageSecretName<Storage>;
+};
+
+type ConnectorStaticProviderSecretRoles<Storage> =
+  ValidatedConnectorSecretRoles<
+    ConnectorSecretRolesFromStorage<Storage>,
+    Storage
+  > & {
+    readonly accessToken: ConnectorStorageSecretName<Storage>;
+  };
+
+type ValidatedConnectorStorageSecretRolesProperty<Method, Storage> =
+  Method extends {
+    readonly access: { readonly kind: "refresh-token" };
+  }
+    ? {
+        readonly secretRoles: ConnectorRefreshSecretRoles<Storage>;
+      }
+    : Method extends {
+          readonly grant: { readonly kind: "auth-code" | "device-auth" };
+          readonly access: { readonly kind: "static" };
+        }
+      ? {
+          readonly secretRoles: ConnectorStaticProviderSecretRoles<Storage>;
+        }
+      : Storage extends { readonly secretRoles: infer Bindings }
+        ? {
+            readonly secretRoles: ValidatedConnectorSecretRoles<
+              Bindings,
+              Storage
+            >;
+          }
+        : { readonly secretRoles?: ConnectorSecretRolesConfig };
+
+type ValidatedConnectorAuthMethod<Method> = Method extends {
+  readonly storage: infer Storage;
+  readonly grant: infer Grant;
+  readonly access: infer Access;
+}
+  ? Method & {
+      readonly storage: Storage &
+        ConnectorStorageConfig &
+        ValidatedConnectorStorageSecretRolesProperty<Method, Storage>;
+      readonly grant: ValidatedConnectorGrantConfig<Grant, Storage>;
+      readonly access: ValidatedConnectorAccessConfig<Access, Storage>;
+    }
+  : never;
+
+type ValidatedConnectorConfig<Config> = Config extends {
+  readonly authMethods: infer AuthMethods;
+}
+  ? Config & {
+      readonly authMethods: {
+        readonly [Method in keyof AuthMethods]: ValidatedConnectorAuthMethod<
+          AuthMethods[Method]
+        >;
+      };
+    }
+  : never;
+
+type ValidatedConnectorRegistry<Configs> = {
+  readonly [Type in keyof Configs]: ValidatedConnectorConfig<Configs[Type]>;
+};
+
+function defineConnectors<
+  const Configs extends Record<string, ConnectorConfig>,
+>(configs: Configs & ValidatedConnectorRegistry<Configs>): Configs {
+  return configs;
+}
+
 /**
  * Connector type configuration
  * Maps type to display info, auth methods, and runtime env bindings.
@@ -589,7 +780,7 @@ export type ConnectorConfig = ConnectorConfigBase & {
  * Spreading here keeps the ConnectorType union literal-keyed so the
  * schema, utility getters, and autocomplete all continue to work.
  */
-const CONNECTOR_TYPES_DEF = {
+const CONNECTOR_TYPES_DEF = defineConnectors({
   ...github,
   ...gmail,
   ...notion,
@@ -839,7 +1030,7 @@ const CONNECTOR_TYPES_DEF = {
   ...zep,
   ...zeptomail,
   ...zoom,
-} as const satisfies Record<string, ConnectorConfig>;
+} as const);
 
 export type ConnectorType = Extract<keyof typeof CONNECTOR_TYPES_DEF, string>;
 type ConnectorAuthMethodsOf<Type extends ConnectorType> =

--- a/turbo/packages/connectors/src/connectors/adzuna.ts
+++ b/turbo/packages/connectors/src/connectors/adzuna.ts
@@ -12,6 +12,10 @@ export const adzuna = {
         label: "App ID and App Key",
         helpText:
           "1. Register at the [Adzuna Developer Portal](https://developer.adzuna.com)\n2. Copy your **app_id** and **app_key**\n3. Pass them as the `app_id` and `app_key` query parameters on Adzuna API requests",
+        storage: {
+          secrets: ["ADZUNA_APP_KEY"],
+          variables: ["ADZUNA_APP_ID"],
+        },
         grant: {
           kind: "manual",
           fields: {

--- a/turbo/packages/connectors/src/connectors/agentmail.ts
+++ b/turbo/packages/connectors/src/connectors/agentmail.ts
@@ -11,6 +11,10 @@ export const agentmail = {
         label: "API Key",
         helpText:
           "1. Log in to [AgentMail Console](https://console.agentmail.to)\n2. Go to **API Keys**\n3. Create a new API key\n4. Copy the key",
+        storage: {
+          secrets: ["AGENTMAIL_TOKEN"],
+          variables: [],
+        },
         grant: {
           kind: "manual",
           fields: {

--- a/turbo/packages/connectors/src/connectors/agora.ts
+++ b/turbo/packages/connectors/src/connectors/agora.ts
@@ -12,6 +12,14 @@ export const agora = {
         label: "REST credentials",
         helpText:
           "1. In [Agora Console](https://console.agora.io), open **Developer Toolkit > RESTful API**\n2. Click **Add a secret** to create a Customer ID and Customer Secret, then download and store the secret securely\n3. Copy your project **App ID** from Agora Console\n4. Optionally copy your **App Certificate** if you need to generate RTC or RTM tokens",
+        storage: {
+          secrets: [
+            "AGORA_CUSTOMER_ID",
+            "AGORA_CUSTOMER_SECRET",
+            "AGORA_APP_CERTIFICATE",
+          ],
+          variables: ["AGORA_APP_ID"],
+        },
         grant: {
           kind: "manual",
           fields: {

--- a/turbo/packages/connectors/src/connectors/ahrefs.ts
+++ b/turbo/packages/connectors/src/connectors/ahrefs.ts
@@ -20,6 +20,14 @@ export const ahrefs = {
           clientIdEnv: "AHREFS_OAUTH_CLIENT_ID",
           clientSecretEnv: "AHREFS_OAUTH_CLIENT_SECRET",
         },
+        storage: {
+          secrets: ["AHREFS_ACCESS_TOKEN", "AHREFS_REFRESH_TOKEN"],
+          variables: [],
+          secretRoles: {
+            accessToken: "AHREFS_ACCESS_TOKEN",
+            refreshToken: "AHREFS_REFRESH_TOKEN",
+          },
+        },
         grant: {
           kind: "auth-code",
           tokenUrl: OAUTH_TOKEN_URL,
@@ -28,8 +36,6 @@ export const ahrefs = {
         access: {
           kind: "refresh-token",
           tokenUrl: OAUTH_TOKEN_URL,
-          accessToken: "AHREFS_ACCESS_TOKEN",
-          refreshToken: "AHREFS_REFRESH_TOKEN",
           envBindings: {
             AHREFS_TOKEN: "$secrets.AHREFS_ACCESS_TOKEN",
           },
@@ -40,6 +46,10 @@ export const ahrefs = {
         label: "API Token",
         helpText:
           "1. Log in to [Ahrefs](https://ahrefs.com) as a workspace owner or admin\n2. Go to **Account settings > API keys**\n3. Create a new API key\n4. Copy the API key and use it in the `Authorization: Bearer <YOUR_API_KEY>` header",
+        storage: {
+          secrets: ["AHREFS_TOKEN"],
+          variables: [],
+        },
         grant: {
           kind: "manual",
           fields: {

--- a/turbo/packages/connectors/src/connectors/airtable.ts
+++ b/turbo/packages/connectors/src/connectors/airtable.ts
@@ -18,6 +18,14 @@ export const airtable = {
           clientIdEnv: "AIRTABLE_OAUTH_CLIENT_ID",
           clientSecretEnv: "AIRTABLE_OAUTH_CLIENT_SECRET",
         },
+        storage: {
+          secrets: ["AIRTABLE_ACCESS_TOKEN", "AIRTABLE_REFRESH_TOKEN"],
+          variables: [],
+          secretRoles: {
+            accessToken: "AIRTABLE_ACCESS_TOKEN",
+            refreshToken: "AIRTABLE_REFRESH_TOKEN",
+          },
+        },
         grant: {
           kind: "auth-code",
           tokenUrl: OAUTH_TOKEN_URL,
@@ -34,8 +42,6 @@ export const airtable = {
         access: {
           kind: "refresh-token",
           tokenUrl: OAUTH_TOKEN_URL,
-          accessToken: "AIRTABLE_ACCESS_TOKEN",
-          refreshToken: "AIRTABLE_REFRESH_TOKEN",
           envBindings: {
             AIRTABLE_TOKEN: "$secrets.AIRTABLE_ACCESS_TOKEN",
           },

--- a/turbo/packages/connectors/src/connectors/alchemy.ts
+++ b/turbo/packages/connectors/src/connectors/alchemy.ts
@@ -11,6 +11,10 @@ export const alchemy = {
         label: "API Key or Access Key",
         helpText:
           "1. Log in to the [Alchemy Dashboard](https://dashboard.alchemy.com)\n2. Open **Team Overview** and go to the **Apps** tab\n3. Create or open an app and copy its **API Key**\n4. Use this key in the `Authorization: Bearer` header for supported Alchemy API requests",
+        storage: {
+          secrets: ["ALCHEMY_API_KEY"],
+          variables: [],
+        },
         grant: {
           kind: "manual",
           fields: {

--- a/turbo/packages/connectors/src/connectors/altium-365.ts
+++ b/turbo/packages/connectors/src/connectors/altium-365.ts
@@ -12,6 +12,10 @@ export const altium365 = {
         label: "API Key",
         helpText:
           "1. Sign in to your Altium 365 workspace (e.g. `https://<workspace>.365.altium.com`)\n2. Open **Settings → User Tokens** and click **Generate**\n3. Copy the generated token — it is shown only once and expires three months from creation\n4. Paste the token and your full workspace URL (including `https://`) below",
+        storage: {
+          secrets: ["ALTIUM365_TOKEN"],
+          variables: ["ALTIUM365_WORKSPACE_URL"],
+        },
         grant: {
           kind: "manual",
           fields: {

--- a/turbo/packages/connectors/src/connectors/amadeus.ts
+++ b/turbo/packages/connectors/src/connectors/amadeus.ts
@@ -11,6 +11,10 @@ export const amadeus = {
         label: "API Key and Secret",
         helpText:
           "1. Sign in to the [Amadeus for Developers portal](https://developers.amadeus.com/)\n2. Create or open an app in **My Self-Service Workspace**\n3. Copy the app's **API Key** and **API Secret**\n4. Use them with the client credentials grant to request an access token",
+        storage: {
+          secrets: ["AMADEUS_API_KEY", "AMADEUS_API_SECRET"],
+          variables: [],
+        },
         grant: {
           kind: "manual",
           fields: {

--- a/turbo/packages/connectors/src/connectors/amplitude.ts
+++ b/turbo/packages/connectors/src/connectors/amplitude.ts
@@ -12,6 +12,10 @@ export const amplitude = {
         label: "API Key",
         helpText:
           "1. In Amplitude, open **Organization Settings** (top right nav) → **Projects** and click the project you want to connect\n2. Copy the **API Key** from the project table (Manager role required)\n3. Click **Generate Secret Key**, name it, and copy it immediately (the secret is only shown once)\n4. Paste both values into the fields below",
+        storage: {
+          secrets: ["AMPLITUDE_API_KEY", "AMPLITUDE_SECRET_KEY"],
+          variables: [],
+        },
         grant: {
           kind: "manual",
           fields: {

--- a/turbo/packages/connectors/src/connectors/anthropic-managed-agents.ts
+++ b/turbo/packages/connectors/src/connectors/anthropic-managed-agents.ts
@@ -11,6 +11,10 @@ export const anthropicManagedAgents = {
         label: "API Key",
         helpText:
           "1. Sign up at [Anthropic Console](https://console.anthropic.com)\n2. Go to **API Keys** and create a new key\n3. Ensure your account has Managed Agents (beta) access\n4. Copy the API key (starts with `sk-ant-`)",
+        storage: {
+          secrets: ["ANTHROPIC_MANAGED_AGENTS_TOKEN"],
+          variables: [],
+        },
         grant: {
           kind: "manual",
           fields: {

--- a/turbo/packages/connectors/src/connectors/apify.ts
+++ b/turbo/packages/connectors/src/connectors/apify.ts
@@ -11,6 +11,10 @@ export const apify = {
         label: "API Token",
         helpText:
           "1. Log in to [Apify Console](https://console.apify.com)\n2. Go to **Settings > Integrations**\n3. Copy your **Personal API token**",
+        storage: {
+          secrets: ["APIFY_TOKEN"],
+          variables: [],
+        },
         grant: {
           kind: "manual",
           fields: {

--- a/turbo/packages/connectors/src/connectors/apollo.ts
+++ b/turbo/packages/connectors/src/connectors/apollo.ts
@@ -11,6 +11,10 @@ export const apollo = {
         label: "API Key",
         helpText:
           "1. Log in to [Apollo](https://app.apollo.io)\n2. Go to **Settings > Integrations**\n3. Click **Connect** beside Apollo API\n4. Select **API Keys > Create new key**\n5. Enter a name, select endpoint access (or toggle **Set as master key**)\n6. Copy the API key",
+        storage: {
+          secrets: ["APOLLO_TOKEN"],
+          variables: [],
+        },
         grant: {
           kind: "manual",
           fields: {

--- a/turbo/packages/connectors/src/connectors/asana.ts
+++ b/turbo/packages/connectors/src/connectors/asana.ts
@@ -18,6 +18,14 @@ export const asana = {
           clientIdEnv: "ASANA_OAUTH_CLIENT_ID",
           clientSecretEnv: "ASANA_OAUTH_CLIENT_SECRET",
         },
+        storage: {
+          secrets: ["ASANA_ACCESS_TOKEN", "ASANA_REFRESH_TOKEN"],
+          variables: [],
+          secretRoles: {
+            accessToken: "ASANA_ACCESS_TOKEN",
+            refreshToken: "ASANA_REFRESH_TOKEN",
+          },
+        },
         grant: {
           kind: "auth-code",
           tokenUrl: OAUTH_TOKEN_URL,
@@ -26,8 +34,6 @@ export const asana = {
         access: {
           kind: "refresh-token",
           tokenUrl: OAUTH_TOKEN_URL,
-          accessToken: "ASANA_ACCESS_TOKEN",
-          refreshToken: "ASANA_REFRESH_TOKEN",
           envBindings: {
             ASANA_TOKEN: "$secrets.ASANA_ACCESS_TOKEN",
           },

--- a/turbo/packages/connectors/src/connectors/atlascloud.ts
+++ b/turbo/packages/connectors/src/connectors/atlascloud.ts
@@ -13,6 +13,10 @@ export const atlascloud = {
         label: "API Key",
         helpText:
           "1. Sign in to [Atlas Cloud](https://console.atlascloud.ai)\n2. Go to **API Keys**\n3. Click **Create API Key**\n4. Copy the key and use it with `https://api.atlascloud.ai/v1` for OpenAI-compatible chat or `https://api.atlascloud.ai/api/v1` for image, video, and media APIs",
+        storage: {
+          secrets: ["ATLASCLOUD_API_KEY"],
+          variables: [],
+        },
         grant: {
           kind: "manual",
           fields: {

--- a/turbo/packages/connectors/src/connectors/atlassian.ts
+++ b/turbo/packages/connectors/src/connectors/atlassian.ts
@@ -11,6 +11,10 @@ export const atlassian = {
         label: "API Token",
         helpText:
           "1. Log in to [Atlassian](https://id.atlassian.com/manage-profile/security/api-tokens)\n2. Click **Create API token**\n3. Give it a label and click **Create**\n4. Copy the generated token",
+        storage: {
+          secrets: ["ATLASSIAN_TOKEN"],
+          variables: ["ATLASSIAN_EMAIL", "ATLASSIAN_DOMAIN"],
+        },
         grant: {
           kind: "manual",
           fields: {

--- a/turbo/packages/connectors/src/connectors/attio.ts
+++ b/turbo/packages/connectors/src/connectors/attio.ts
@@ -11,6 +11,10 @@ export const attio = {
         label: "API Key",
         helpText:
           "1. Open [Attio](https://app.attio.com) and sign in\n2. Open **Workspace settings** from the dropdown beside your workspace name\n3. Click the **Developers** tab\n4. Click **+ New access token**, give it a name, and select the scopes you need\n5. Click **Create**, then copy the token (shown once)",
+        storage: {
+          secrets: ["ATTIO_TOKEN"],
+          variables: [],
+        },
         grant: {
           kind: "manual",
           fields: {

--- a/turbo/packages/connectors/src/connectors/aviationstack.ts
+++ b/turbo/packages/connectors/src/connectors/aviationstack.ts
@@ -11,6 +11,10 @@ export const aviationstack = {
         label: "Access Key",
         helpText:
           "1. Sign in to the [AviationStack dashboard](https://aviationstack.com/dashboard)\n2. Copy the **API Access Key** shown on the main dashboard\n3. Pass it as the `access_key` query parameter on every request",
+        storage: {
+          secrets: ["AVIATIONSTACK_TOKEN"],
+          variables: [],
+        },
         grant: {
           kind: "manual",
           fields: {

--- a/turbo/packages/connectors/src/connectors/axiom.ts
+++ b/turbo/packages/connectors/src/connectors/axiom.ts
@@ -11,6 +11,10 @@ export const axiom = {
         label: "API Token",
         helpText:
           "1. Log in to [Axiom](https://app.axiom.co)\n2. Go to **Settings > API Tokens**\n3. Create a new API token with the required permissions\n4. Copy the token",
+        storage: {
+          secrets: ["AXIOM_TOKEN"],
+          variables: [],
+        },
         grant: {
           kind: "manual",
           fields: {

--- a/turbo/packages/connectors/src/connectors/base44.ts
+++ b/turbo/packages/connectors/src/connectors/base44.ts
@@ -17,6 +17,14 @@ export const base44 = {
           clientType: "public",
           clientId: "base44_cli",
         },
+        storage: {
+          secrets: ["BASE44_ACCESS_TOKEN", "BASE44_REFRESH_TOKEN"],
+          variables: [],
+          secretRoles: {
+            accessToken: "BASE44_ACCESS_TOKEN",
+            refreshToken: "BASE44_REFRESH_TOKEN",
+          },
+        },
         grant: {
           kind: "device-auth",
           deviceAuthUrl: "https://app.base44.com/oauth/device/code",
@@ -26,8 +34,6 @@ export const base44 = {
         access: {
           kind: "refresh-token",
           tokenUrl: OAUTH_TOKEN_URL,
-          accessToken: "BASE44_ACCESS_TOKEN",
-          refreshToken: "BASE44_REFRESH_TOKEN",
           envBindings: {
             BASE44_TOKEN: "$secrets.BASE44_ACCESS_TOKEN",
           },

--- a/turbo/packages/connectors/src/connectors/bentoml.ts
+++ b/turbo/packages/connectors/src/connectors/bentoml.ts
@@ -15,6 +15,10 @@ export const bentoml = {
         label: "BentoCloud API Token",
         helpText:
           "1. Log in to [BentoCloud](https://cloud.bentoml.com)\n2. Open your profile menu, then go to **API Tokens**\n3. Create a Personal or Organization API token with the access your workflow needs\n4. Copy the token and enter your organization endpoint, for example `https://your-org.cloud.bentoml.com`",
+        storage: {
+          secrets: ["BENTO_CLOUD_API_KEY"],
+          variables: ["BENTO_CLOUD_API_ENDPOINT"],
+        },
         grant: {
           kind: "manual",
           fields: {

--- a/turbo/packages/connectors/src/connectors/bfl.ts
+++ b/turbo/packages/connectors/src/connectors/bfl.ts
@@ -13,6 +13,10 @@ export const bfl = {
         label: "API Key",
         helpText:
           "1. Go to the [Black Forest Labs dashboard](https://dashboard.bfl.ai)\n2. Navigate to **API → Keys** in your project sidebar\n3. Click **Add Key** and give the key a descriptive name\n4. Copy the API key immediately — you will not be able to see the full key again",
+        storage: {
+          secrets: ["BFL_API_KEY"],
+          variables: [],
+        },
         grant: {
           kind: "manual",
           fields: {

--- a/turbo/packages/connectors/src/connectors/bitrefill.ts
+++ b/turbo/packages/connectors/src/connectors/bitrefill.ts
@@ -15,6 +15,10 @@ export const bitrefill = {
           "3. Generate an API key\n" +
           "4. Copy the Personal API token\n\n" +
           "This connector currently supports Bitrefill Personal API Bearer tokens. Business and Affiliate Basic auth credentials are not supported yet.",
+        storage: {
+          secrets: ["BITREFILL_TOKEN"],
+          variables: [],
+        },
         grant: {
           kind: "manual",
           fields: {

--- a/turbo/packages/connectors/src/connectors/bitrix.ts
+++ b/turbo/packages/connectors/src/connectors/bitrix.ts
@@ -11,6 +11,10 @@ export const bitrix = {
         label: "Webhook URL",
         helpText:
           "1. Log in to your [Bitrix24](https://www.bitrix24.com) account\n2. Go to **Applications > Developer resources**\n3. Select the **Ready-made scenarios** tab\n4. Choose **Other > Incoming webhook**\n5. Configure the webhook name and set access permissions\n6. Click **Execute** to test the webhook\n7. Copy the generated webhook URL, which contains your secret code in the format `https://<domain>/rest/1/<secret-code>/<method>.json`",
+        storage: {
+          secrets: ["BITRIX_WEBHOOK_URL"],
+          variables: [],
+        },
         grant: {
           kind: "manual",
           fields: {

--- a/turbo/packages/connectors/src/connectors/bland.ts
+++ b/turbo/packages/connectors/src/connectors/bland.ts
@@ -13,6 +13,10 @@ export const bland = {
         label: "API Key",
         helpText:
           "1. Go to the [Bland dashboard](https://app.bland.ai)\n2. Copy your API key from your account or API settings\n3. Paste the key here. You can also use the key with the Bland CLI as `BLAND_API_KEY`",
+        storage: {
+          secrets: ["BLAND_API_KEY"],
+          variables: [],
+        },
         grant: {
           kind: "manual",
           fields: {

--- a/turbo/packages/connectors/src/connectors/brave-search.ts
+++ b/turbo/packages/connectors/src/connectors/brave-search.ts
@@ -11,6 +11,10 @@ export const braveSearch = {
         label: "API Key",
         helpText:
           "1. Go to the [Brave Search API dashboard](https://api-dashboard.search.brave.com/register) and sign up for an account\n2. Provide a credit card for identity verification (free plans will not be charged)\n3. After registration, your API key will be available in the dashboard\n4. Copy the API key and use it in the `X-Subscription-Token` request header",
+        storage: {
+          secrets: ["BRAVE_API_KEY"],
+          variables: [],
+        },
         grant: {
           kind: "manual",
           fields: {

--- a/turbo/packages/connectors/src/connectors/brevo.ts
+++ b/turbo/packages/connectors/src/connectors/brevo.ts
@@ -11,6 +11,10 @@ export const brevo = {
         label: "API Key",
         helpText:
           "1. Log in to [Brevo](https://app.brevo.com)\n2. Go to **Settings** → **SMTP & API** → **API Keys**\n3. Copy your API key",
+        storage: {
+          secrets: ["BREVO_TOKEN"],
+          variables: [],
+        },
         grant: {
           kind: "manual",
           fields: {

--- a/turbo/packages/connectors/src/connectors/brex.ts
+++ b/turbo/packages/connectors/src/connectors/brex.ts
@@ -12,6 +12,10 @@ export const brex = {
         label: "API Token",
         helpText:
           "1. In Brex, create or obtain an API user token with the permissions required for your workflow\n2. Confirm the token is intended for the production API at `https://api.brex.com`\n3. Copy the token",
+        storage: {
+          secrets: ["BREX_TOKEN"],
+          variables: [],
+        },
         grant: {
           kind: "manual",
           fields: {

--- a/turbo/packages/connectors/src/connectors/bright-data.ts
+++ b/turbo/packages/connectors/src/connectors/bright-data.ts
@@ -11,6 +11,10 @@ export const brightData = {
         label: "API Token",
         helpText:
           "1. Log in to [Bright Data](https://brightdata.com/cp)\n2. Go to **Account settings**\n3. Click **Add API key** and configure permissions\n4. Copy the token (shown only once)",
+        storage: {
+          secrets: ["BRIGHTDATA_TOKEN"],
+          variables: [],
+        },
         grant: {
           kind: "manual",
           fields: {

--- a/turbo/packages/connectors/src/connectors/browser-use.ts
+++ b/turbo/packages/connectors/src/connectors/browser-use.ts
@@ -11,6 +11,10 @@ export const browserUse = {
         label: "API Key",
         helpText:
           "1. Sign in at [cloud.browser-use.com](https://cloud.browser-use.com)\n2. Go to **Settings → API Keys**\n3. Click **Create new key**\n4. Copy the generated API key",
+        storage: {
+          secrets: ["BROWSER_USE_TOKEN"],
+          variables: [],
+        },
         grant: {
           kind: "manual",
           fields: {

--- a/turbo/packages/connectors/src/connectors/browserbase.ts
+++ b/turbo/packages/connectors/src/connectors/browserbase.ts
@@ -11,6 +11,10 @@ export const browserbase = {
         label: "API Token",
         helpText:
           "1. Sign up for a [Browserbase](https://www.browserbase.com/sign-up) account\n2. Log in and navigate to the **Overview** dashboard\n3. Your **Project ID** and **API key** are displayed on the right side of the Overview page\n4. Copy the API key",
+        storage: {
+          secrets: ["BROWSERBASE_TOKEN"],
+          variables: ["BROWSERBASE_PROJECT_ID"],
+        },
         grant: {
           kind: "manual",
           fields: {

--- a/turbo/packages/connectors/src/connectors/browserless.ts
+++ b/turbo/packages/connectors/src/connectors/browserless.ts
@@ -12,6 +12,10 @@ export const browserless = {
         label: "API Token",
         helpText:
           "1. Sign up or log in at [Browserless](https://browserless.io/account/)\n2. Navigate to the account dashboard\n3. Copy your API token from the dashboard",
+        storage: {
+          secrets: ["BROWSERLESS_TOKEN"],
+          variables: [],
+        },
         grant: {
           kind: "manual",
           fields: {

--- a/turbo/packages/connectors/src/connectors/browserstack.ts
+++ b/turbo/packages/connectors/src/connectors/browserstack.ts
@@ -12,6 +12,10 @@ export const browserstack = {
         label: "API Key",
         helpText:
           "1. Sign in to [BrowserStack](https://www.browserstack.com) and open **Account Settings**\n2. Copy your **Username** and **Access Key** from the **Authentication & Security** section\n3. Paste both values below — these credentials work across Live, Automate, App Live, and App Automate",
+        storage: {
+          secrets: ["BROWSERSTACK_USERNAME", "BROWSERSTACK_ACCESS_KEY"],
+          variables: [],
+        },
         grant: {
           kind: "manual",
           fields: {

--- a/turbo/packages/connectors/src/connectors/bubblemaps.ts
+++ b/turbo/packages/connectors/src/connectors/bubblemaps.ts
@@ -11,6 +11,10 @@ export const bubblemaps = {
         label: "API Key",
         helpText:
           "1. Log in to the [Bubblemaps Pro platform](https://pro.bubblemaps.io)\n2. Get your Data API key\n3. Use this key in the `X-ApiKey` request header",
+        storage: {
+          secrets: ["BUBBLEMAPS_API_KEY"],
+          variables: [],
+        },
         grant: {
           kind: "manual",
           fields: {

--- a/turbo/packages/connectors/src/connectors/buffer.ts
+++ b/turbo/packages/connectors/src/connectors/buffer.ts
@@ -11,6 +11,10 @@ export const buffer = {
         label: "API Key",
         helpText:
           "1. Log in to [Buffer](https://publish.buffer.com) and go to **Settings > Developer Dashboard** (you must be an **Org Owner** — paid accounts can create up to 5 keys; free accounts get 1).\n2. Click **Create API Key**, give it a name, and set an expiration if desired.\n3. Copy the key immediately — it's only shown once.\n4. Paste it here.\n\n**Note:** Buffer's API is currently in beta.",
+        storage: {
+          secrets: ["BUFFER_TOKEN"],
+          variables: [],
+        },
         grant: {
           kind: "manual",
           fields: {

--- a/turbo/packages/connectors/src/connectors/builtwith.ts
+++ b/turbo/packages/connectors/src/connectors/builtwith.ts
@@ -11,6 +11,10 @@ export const builtwith = {
         label: "API Key",
         helpText:
           "1. Log in to [BuiltWith](https://api.builtwith.com)\n2. Open the **API access** page in your account\n3. Copy your **API key**\n4. Pass it as the `KEY` query parameter on every request",
+        storage: {
+          secrets: ["BUILTWITH_TOKEN"],
+          variables: [],
+        },
         grant: {
           kind: "manual",
           fields: {

--- a/turbo/packages/connectors/src/connectors/cal-com.ts
+++ b/turbo/packages/connectors/src/connectors/cal-com.ts
@@ -11,6 +11,10 @@ export const calCom = {
         label: "API Token",
         helpText:
           "1. Log in to [Cal.com](https://app.cal.com)\n2. Go to **Settings** → **Developer** → **API Keys**\n3. Click **Create API Key**\n4. Copy the generated key",
+        storage: {
+          secrets: ["CALCOM_TOKEN"],
+          variables: [],
+        },
         grant: {
           kind: "manual",
           fields: {

--- a/turbo/packages/connectors/src/connectors/calendly.ts
+++ b/turbo/packages/connectors/src/connectors/calendly.ts
@@ -11,6 +11,10 @@ export const calendly = {
         label: "Personal Access Token",
         helpText:
           "1. Log in to [Calendly](https://calendly.com)\n2. Go to **Integrations > API & Webhooks**\n3. Generate a Personal Access Token\n4. Copy the token",
+        storage: {
+          secrets: ["CALENDLY_TOKEN"],
+          variables: [],
+        },
         grant: {
           kind: "manual",
           fields: {

--- a/turbo/packages/connectors/src/connectors/canva.ts
+++ b/turbo/packages/connectors/src/connectors/canva.ts
@@ -20,6 +20,14 @@ export const canva = {
           clientIdEnv: "CANVA_OAUTH_CLIENT_ID",
           clientSecretEnv: "CANVA_OAUTH_CLIENT_SECRET",
         },
+        storage: {
+          secrets: ["CANVA_ACCESS_TOKEN", "CANVA_REFRESH_TOKEN"],
+          variables: [],
+          secretRoles: {
+            accessToken: "CANVA_ACCESS_TOKEN",
+            refreshToken: "CANVA_REFRESH_TOKEN",
+          },
+        },
         grant: {
           kind: "auth-code",
           tokenUrl: OAUTH_TOKEN_URL,
@@ -41,8 +49,6 @@ export const canva = {
         access: {
           kind: "refresh-token",
           tokenUrl: OAUTH_TOKEN_URL,
-          accessToken: "CANVA_ACCESS_TOKEN",
-          refreshToken: "CANVA_REFRESH_TOKEN",
           envBindings: {
             CANVA_TOKEN: "$secrets.CANVA_ACCESS_TOKEN",
           },

--- a/turbo/packages/connectors/src/connectors/chatwoot.ts
+++ b/turbo/packages/connectors/src/connectors/chatwoot.ts
@@ -11,6 +11,10 @@ export const chatwoot = {
         label: "API Access Token",
         helpText:
           "1. Log in to [Chatwoot](https://app.chatwoot.com) with an administrator account\n2. Click on your **avatar image** in the bottom left corner of the screen\n3. Select **Profile Settings** from the menu\n4. Scroll to the bottom of the Profile Settings page\n5. Copy the **Personal Access Token** displayed there",
+        storage: {
+          secrets: ["CHATWOOT_TOKEN"],
+          variables: [],
+        },
         grant: {
           kind: "manual",
           fields: {

--- a/turbo/packages/connectors/src/connectors/checkr.ts
+++ b/turbo/packages/connectors/src/connectors/checkr.ts
@@ -18,6 +18,10 @@ export const checkr = {
         label: "API Key",
         helpText:
           "1. Log in to the [Checkr Dashboard](https://dashboard.checkr.com)\n2. Go to **Account Settings > Developer Settings**\n3. Copy a live or test API key for the account you want to connect\n4. Use only keys and actions that comply with your background check authorization and compliance process",
+        storage: {
+          secrets: ["CHECKR_TOKEN"],
+          variables: [],
+        },
         grant: {
           kind: "manual",
           fields: {

--- a/turbo/packages/connectors/src/connectors/clado.ts
+++ b/turbo/packages/connectors/src/connectors/clado.ts
@@ -11,6 +11,10 @@ export const clado = {
         label: "API Key",
         helpText:
           "1. Sign in to [Clado](https://clado.ai)\n2. Open the **API keys** page in your account\n3. Click **Create Key**, name it, and copy the value\n4. Use it as a Bearer token on requests to `https://search.clado.ai`",
+        storage: {
+          secrets: ["CLADO_TOKEN"],
+          variables: [],
+        },
         grant: {
           kind: "manual",
           fields: {

--- a/turbo/packages/connectors/src/connectors/clearbit.ts
+++ b/turbo/packages/connectors/src/connectors/clearbit.ts
@@ -11,6 +11,10 @@ export const clearbit = {
         label: "API Key",
         helpText:
           "1. Log in to [Clearbit](https://dashboard.clearbit.com)\n2. Go to **Settings > Keys & Settings**\n3. Reveal and copy your **Secret API Key**\n\nClearbit API keys are available only for accounts created in 2023 or earlier; new 2024+ accounts may require HubSpot/Breeze Intelligence access instead.",
+        storage: {
+          secrets: ["CLEARBIT_TOKEN"],
+          variables: [],
+        },
         grant: {
           kind: "manual",
           fields: {

--- a/turbo/packages/connectors/src/connectors/clerk.ts
+++ b/turbo/packages/connectors/src/connectors/clerk.ts
@@ -11,6 +11,10 @@ export const clerk = {
         label: "Secret Key",
         helpText:
           "Go to Clerk Dashboard → API Keys → copy the **Secret key** (starts with `sk_test_` for development or `sk_live_` for production). The key grants full administrative access to the matching instance — vm0's firewall ships with write operations denied by default; enable `*:write` permissions per agent only when needed.",
+        storage: {
+          secrets: ["CLERK_TOKEN"],
+          variables: [],
+        },
         grant: {
           kind: "manual",
           fields: {

--- a/turbo/packages/connectors/src/connectors/clickup.ts
+++ b/turbo/packages/connectors/src/connectors/clickup.ts
@@ -11,6 +11,10 @@ export const clickup = {
         label: "API Token",
         helpText:
           "1. Log in to [ClickUp](https://app.clickup.com)\n2. Click your avatar in the upper-right corner and select **Settings**\n3. In the sidebar, click **Apps** (or visit [app.clickup.com/settings/apps](https://app.clickup.com/settings/apps))\n4. Under the **API Token** section, click **Generate** (or **Regenerate** if you already have one)\n5. Click **Copy** to copy the personal token (tokens start with `pk_` and never expire)",
+        storage: {
+          secrets: ["CLICKUP_TOKEN"],
+          variables: [],
+        },
         grant: {
           kind: "manual",
           fields: {

--- a/turbo/packages/connectors/src/connectors/close.ts
+++ b/turbo/packages/connectors/src/connectors/close.ts
@@ -20,6 +20,14 @@ export const close = {
           clientIdEnv: "CLOSE_OAUTH_CLIENT_ID",
           clientSecretEnv: "CLOSE_OAUTH_CLIENT_SECRET",
         },
+        storage: {
+          secrets: ["CLOSE_ACCESS_TOKEN", "CLOSE_REFRESH_TOKEN"],
+          variables: [],
+          secretRoles: {
+            accessToken: "CLOSE_ACCESS_TOKEN",
+            refreshToken: "CLOSE_REFRESH_TOKEN",
+          },
+        },
         grant: {
           kind: "auth-code",
           tokenUrl: OAUTH_TOKEN_URL,
@@ -28,8 +36,6 @@ export const close = {
         access: {
           kind: "refresh-token",
           tokenUrl: OAUTH_TOKEN_URL,
-          accessToken: "CLOSE_ACCESS_TOKEN",
-          refreshToken: "CLOSE_REFRESH_TOKEN",
           envBindings: {
             CLOSE_TOKEN: "$secrets.CLOSE_ACCESS_TOKEN",
           },

--- a/turbo/packages/connectors/src/connectors/cloudflare.ts
+++ b/turbo/packages/connectors/src/connectors/cloudflare.ts
@@ -11,6 +11,10 @@ export const cloudflare = {
         label: "API Token",
         helpText:
           "1. Log in to the [Cloudflare Dashboard](https://dash.cloudflare.com)\n2. Go to **My Profile** → **API Tokens**\n3. Click **Create Token** and configure the required permissions\n4. Copy the generated token",
+        storage: {
+          secrets: ["CLOUDFLARE_TOKEN"],
+          variables: [],
+        },
         grant: {
           kind: "manual",
           fields: {

--- a/turbo/packages/connectors/src/connectors/cloudinary.ts
+++ b/turbo/packages/connectors/src/connectors/cloudinary.ts
@@ -11,6 +11,10 @@ export const cloudinary = {
         label: "API Credentials",
         helpText:
           "1. Log in to the [Cloudinary Console](https://console.cloudinary.com/settings/api-keys)\n2. Go to **Settings** → **API Keys**\n3. Copy your **Cloud Name**, **API Key**, and **API Secret**",
+        storage: {
+          secrets: ["CLOUDINARY_TOKEN", "CLOUDINARY_API_SECRET"],
+          variables: ["CLOUDINARY_CLOUD_NAME"],
+        },
         grant: {
           kind: "manual",
           fields: {

--- a/turbo/packages/connectors/src/connectors/coda.ts
+++ b/turbo/packages/connectors/src/connectors/coda.ts
@@ -11,6 +11,10 @@ export const coda = {
         label: "API Token",
         helpText:
           "1. Open Coda and click your avatar (bottom left) then **Account Settings**\n2. Scroll to **API Settings**\n3. Click **Generate API Token**, give it a name, optionally restrict scope\n4. Copy the token and paste it here",
+        storage: {
+          secrets: ["CODA_TOKEN"],
+          variables: [],
+        },
         grant: {
           kind: "manual",
           fields: {

--- a/turbo/packages/connectors/src/connectors/coingecko.ts
+++ b/turbo/packages/connectors/src/connectors/coingecko.ts
@@ -11,6 +11,10 @@ export const coingecko = {
         label: "API Key",
         helpText:
           "1. Sign up or log in to [CoinGecko](https://www.coingecko.com/en/api)\n2. Open the **Developer Dashboard**\n3. Click **Add New Key** to create a Demo or Pro API key\n4. Copy the API key",
+        storage: {
+          secrets: ["COINGECKO_TOKEN"],
+          variables: [],
+        },
         grant: {
           kind: "manual",
           fields: {

--- a/turbo/packages/connectors/src/connectors/coresignal.ts
+++ b/turbo/packages/connectors/src/connectors/coresignal.ts
@@ -11,6 +11,10 @@ export const coresignal = {
         label: "API Key",
         helpText:
           "1. Log in to the [Coresignal self-service dashboard](https://dashboard.coresignal.com)\n2. Open **API Keys** from your account settings or homepage\n3. Copy an API key\n4. Use it in requests with the `apikey` header",
+        storage: {
+          secrets: ["CORESIGNAL_TOKEN"],
+          variables: [],
+        },
         grant: {
           kind: "manual",
           fields: {

--- a/turbo/packages/connectors/src/connectors/cronlytic.ts
+++ b/turbo/packages/connectors/src/connectors/cronlytic.ts
@@ -11,6 +11,10 @@ export const cronlytic = {
         label: "API Key",
         helpText:
           "1. Log in to the [Cronlytic dashboard](https://www.cronlytic.com/dashboard)\n2. Go to the **API Keys** section\n3. Click **Generate New API Key**\n4. Copy your **API Key** and **User ID** (both are required for authentication via `X-API-Key` and `X-User-ID` headers)",
+        storage: {
+          secrets: ["CRONLYTIC_API_KEY"],
+          variables: ["CRONLYTIC_USER_ID"],
+        },
         grant: {
           kind: "manual",
           fields: {

--- a/turbo/packages/connectors/src/connectors/crustdata.ts
+++ b/turbo/packages/connectors/src/connectors/crustdata.ts
@@ -11,6 +11,10 @@ export const crustdata = {
         label: "API Key",
         helpText:
           "1. Request or open your Crustdata API key from the [Crustdata dashboard](https://crustdata.com)\n2. Copy your API key\n3. Crustdata authenticates requests with `Authorization: Bearer <key>` and requires the `x-api-version` header",
+        storage: {
+          secrets: ["CRUSTDATA_TOKEN"],
+          variables: [],
+        },
         grant: {
           kind: "manual",
           fields: {

--- a/turbo/packages/connectors/src/connectors/customer-io.ts
+++ b/turbo/packages/connectors/src/connectors/customer-io.ts
@@ -11,6 +11,10 @@ export const customerIo = {
         label: "API Token",
         helpText:
           "1. Log in to your [Customer.io](https://fly.customer.io) account\n2. Go to **Account Settings > [API Credentials](https://fly.customer.io/settings/api_credentials)**\n3. Locate your **Site ID** and **API Key** on the Track API Keys page\n4. Copy both values (they are used together as basic authentication credentials in the format `site_id:api_key`, Base64-encoded)",
+        storage: {
+          secrets: ["CUSTOMERIO_APP_TOKEN"],
+          variables: [],
+        },
         grant: {
           kind: "manual",
           fields: {

--- a/turbo/packages/connectors/src/connectors/db9.ts
+++ b/turbo/packages/connectors/src/connectors/db9.ts
@@ -11,6 +11,10 @@ export const db9 = {
         label: "API Key",
         helpText:
           "1. Log in to [db9](https://db9.ai)\n2. Go to **Settings > API Keys**\n3. Create a new API key\n4. Copy the 128-character hex token",
+        storage: {
+          secrets: ["DB9_API_KEY"],
+          variables: [],
+        },
         grant: {
           kind: "manual",
           fields: {

--- a/turbo/packages/connectors/src/connectors/deel.ts
+++ b/turbo/packages/connectors/src/connectors/deel.ts
@@ -20,6 +20,14 @@ export const deel = {
           clientIdEnv: "DEEL_OAUTH_CLIENT_ID",
           clientSecretEnv: "DEEL_OAUTH_CLIENT_SECRET",
         },
+        storage: {
+          secrets: ["DEEL_ACCESS_TOKEN", "DEEL_REFRESH_TOKEN"],
+          variables: [],
+          secretRoles: {
+            accessToken: "DEEL_ACCESS_TOKEN",
+            refreshToken: "DEEL_REFRESH_TOKEN",
+          },
+        },
         grant: {
           kind: "auth-code",
           tokenUrl: OAUTH_TOKEN_URL,
@@ -37,8 +45,6 @@ export const deel = {
         access: {
           kind: "refresh-token",
           tokenUrl: OAUTH_TOKEN_URL,
-          accessToken: "DEEL_ACCESS_TOKEN",
-          refreshToken: "DEEL_REFRESH_TOKEN",
           envBindings: {
             DEEL_TOKEN: "$secrets.DEEL_ACCESS_TOKEN",
           },
@@ -49,6 +55,10 @@ export const deel = {
         label: "API Token",
         helpText:
           "1. Create a [Deel](https://app.deel.com) account and verify your email\n2. Navigate to the **Developer Center**\n3. Select the **API Sandbox** tab (or **Production** for live credentials)\n4. Click **Create Sandbox** and enter a unique email and password\n5. Click **Confirm** to finalize sandbox creation\n6. Locate your **API Key / Access Token** in the Developer Center\n7. Copy and store the token securely",
+        storage: {
+          secrets: ["DEEL_TOKEN"],
+          variables: [],
+        },
         grant: {
           kind: "manual",
           fields: {

--- a/turbo/packages/connectors/src/connectors/deepseek.ts
+++ b/turbo/packages/connectors/src/connectors/deepseek.ts
@@ -12,6 +12,10 @@ export const deepseek = {
         label: "API Key",
         helpText:
           "1. Go to the [DeepSeek Platform](https://platform.deepseek.com/api_keys)\n2. Sign up for an account or log in\n3. Navigate to the **API Keys** page\n4. Create a new API key and copy it",
+        storage: {
+          secrets: ["DEEPSEEK_TOKEN"],
+          variables: [],
+        },
         grant: {
           kind: "manual",
           fields: {

--- a/turbo/packages/connectors/src/connectors/defillama.ts
+++ b/turbo/packages/connectors/src/connectors/defillama.ts
@@ -11,6 +11,10 @@ export const defillama = {
         label: "Pro API Key",
         helpText:
           "1. Subscribe to [DefiLlama Pro API](https://defillama.com/subscription)\n2. Open the [Pro API docs](https://defillama.com/pro-api/docs)\n3. Copy your Pro API key\n\nThis connector is for the DefiLlama Pro API key. Most free DefiLlama API endpoints do not require authentication.",
+        storage: {
+          secrets: ["DEFILLAMA_TOKEN"],
+          variables: [],
+        },
         grant: {
           kind: "manual",
           fields: {

--- a/turbo/packages/connectors/src/connectors/devto.ts
+++ b/turbo/packages/connectors/src/connectors/devto.ts
@@ -11,6 +11,10 @@ export const devto = {
         label: "API Key",
         helpText:
           "1. Log in to [DEV.to](https://dev.to)\n2. Go to **Settings > Extensions** (or visit [dev.to/settings/extensions](https://dev.to/settings/extensions))\n3. Generate a new API key from the settings page\n4. Copy the API key and use it in the `api-key` request header",
+        storage: {
+          secrets: ["DEVTO_TOKEN"],
+          variables: [],
+        },
         grant: {
           kind: "manual",
           fields: {

--- a/turbo/packages/connectors/src/connectors/diffbot.ts
+++ b/turbo/packages/connectors/src/connectors/diffbot.ts
@@ -11,6 +11,10 @@ export const diffbot = {
         label: "API Token",
         helpText:
           "1. Log in to [Diffbot](https://app.diffbot.com/get-started/)\n2. Open your account dashboard\n3. Copy the **API token** shown on the dashboard\n4. Pass it as the `token` query parameter on every request",
+        storage: {
+          secrets: ["DIFFBOT_TOKEN"],
+          variables: [],
+        },
         grant: {
           kind: "manual",
           fields: {

--- a/turbo/packages/connectors/src/connectors/dify.ts
+++ b/turbo/packages/connectors/src/connectors/dify.ts
@@ -12,6 +12,10 @@ export const dify = {
         label: "API Key",
         helpText:
           "1. Log in to [Dify](https://cloud.dify.ai)\n2. Open your app and navigate to **API Access** in the left sidebar\n3. Click to generate new API credentials\n4. Copy the API key",
+        storage: {
+          secrets: ["DIFY_TOKEN"],
+          variables: [],
+        },
         grant: {
           kind: "manual",
           fields: {

--- a/turbo/packages/connectors/src/connectors/discord-webhook.ts
+++ b/turbo/packages/connectors/src/connectors/discord-webhook.ts
@@ -10,6 +10,10 @@ export const discordWebhook = {
         label: "Webhook URL",
         helpText:
           "1. Open your Discord server and navigate to **Server Settings**\n2. Select the **Integrations** tab\n3. Click the **Create Webhook** button\n4. Configure the webhook name and select the target text channel from the dropdown menu\n5. Click the **Copy Webhook URL** button to copy the webhook URL",
+        storage: {
+          secrets: ["DISCORD_WEBHOOK_URL"],
+          variables: [],
+        },
         grant: {
           kind: "manual",
           fields: {

--- a/turbo/packages/connectors/src/connectors/discord.ts
+++ b/turbo/packages/connectors/src/connectors/discord.ts
@@ -11,6 +11,10 @@ export const discord = {
         label: "Bot Token",
         helpText:
           "1. Go to the [Discord Developer Portal](https://discord.com/developers/applications)\n2. Select your application (or create a new one)\n3. Navigate to the **Bot** page in your app's settings\n4. In the **Token** section, click **Reset Token** to generate a new bot token\n5. Copy and securely store the token — you won't be able to view it again unless you regenerate it",
+        storage: {
+          secrets: ["DISCORD_BOT_TOKEN"],
+          variables: [],
+        },
         grant: {
           kind: "manual",
           fields: {

--- a/turbo/packages/connectors/src/connectors/docusign.ts
+++ b/turbo/packages/connectors/src/connectors/docusign.ts
@@ -20,6 +20,14 @@ export const docusign = {
           clientIdEnv: "DOCUSIGN_OAUTH_CLIENT_ID",
           clientSecretEnv: "DOCUSIGN_OAUTH_CLIENT_SECRET",
         },
+        storage: {
+          secrets: ["DOCUSIGN_ACCESS_TOKEN", "DOCUSIGN_REFRESH_TOKEN"],
+          variables: [],
+          secretRoles: {
+            accessToken: "DOCUSIGN_ACCESS_TOKEN",
+            refreshToken: "DOCUSIGN_REFRESH_TOKEN",
+          },
+        },
         grant: {
           kind: "auth-code",
           tokenUrl: OAUTH_TOKEN_URL,
@@ -28,8 +36,6 @@ export const docusign = {
         access: {
           kind: "refresh-token",
           tokenUrl: OAUTH_TOKEN_URL,
-          accessToken: "DOCUSIGN_ACCESS_TOKEN",
-          refreshToken: "DOCUSIGN_REFRESH_TOKEN",
           envBindings: {
             DOCUSIGN_TOKEN: "$secrets.DOCUSIGN_ACCESS_TOKEN",
           },

--- a/turbo/packages/connectors/src/connectors/doppler.ts
+++ b/turbo/packages/connectors/src/connectors/doppler.ts
@@ -11,6 +11,10 @@ export const doppler = {
         label: "Service Token",
         helpText:
           "1. Log in to [Doppler](https://dashboard.doppler.com)\n2. Go to your project, then select a config (environment)\n3. Click the **Access** tab\n4. Click **+ Generate Service Token**\n5. Set permissions to **Read** and copy the token",
+        storage: {
+          secrets: ["DOPPLER_TOKEN"],
+          variables: [],
+        },
         grant: {
           kind: "manual",
           fields: {

--- a/turbo/packages/connectors/src/connectors/doubao.ts
+++ b/turbo/packages/connectors/src/connectors/doubao.ts
@@ -13,6 +13,10 @@ export const doubao = {
         label: "Doubao API Key",
         helpText:
           "1. Sign in to the [Volcengine new speech console](https://console.volcengine.com/speech/new)\n2. Open **设置 → API Key 管理** ([direct link](https://console.volcengine.com/speech/new/setting/apikeys))\n3. Click **创建 API Key**, name it, and copy the UUID value\n4. The key authorises every endpoint under `openspeech.bytedance.com` — TTS, ASR file recognition, voice cloning",
+        storage: {
+          secrets: ["DOUBAO_API_KEY"],
+          variables: [],
+        },
         grant: {
           kind: "manual",
           fields: {

--- a/turbo/packages/connectors/src/connectors/drive9.ts
+++ b/turbo/packages/connectors/src/connectors/drive9.ts
@@ -11,6 +11,10 @@ export const drive9 = {
         label: "API Key",
         helpText:
           "1. Log in to [drive9](https://drive9.ai)\n2. Go to **Settings > API Keys**\n3. Create a new API key\n4. Copy the key (format: `drive9_sk_...`)",
+        storage: {
+          secrets: ["DRIVE9_TOKEN"],
+          variables: [],
+        },
         grant: {
           kind: "manual",
           fields: {

--- a/turbo/packages/connectors/src/connectors/dropbox-sign.ts
+++ b/turbo/packages/connectors/src/connectors/dropbox-sign.ts
@@ -12,6 +12,10 @@ export const dropboxSign = {
         label: "API Key",
         helpText:
           "1. Log in to [Dropbox Sign](https://sign.dropbox.com)\n2. Click **API** in the left sidebar and open the **API Dashboard**\n3. Click **Reveal key** for an existing key, or **Generate key** to create a new one\n4. Copy the 40-character hex key and paste it here\n\nTip: While developing, add `test_mode=1` to signature-request calls to avoid billing and real emails.",
+        storage: {
+          secrets: ["DROPBOX_SIGN_TOKEN"],
+          variables: [],
+        },
         grant: {
           kind: "manual",
           fields: {

--- a/turbo/packages/connectors/src/connectors/dropbox.ts
+++ b/turbo/packages/connectors/src/connectors/dropbox.ts
@@ -19,6 +19,14 @@ export const dropbox = {
           clientIdEnv: "DROPBOX_OAUTH_CLIENT_ID",
           clientSecretEnv: "DROPBOX_OAUTH_CLIENT_SECRET",
         },
+        storage: {
+          secrets: ["DROPBOX_ACCESS_TOKEN", "DROPBOX_REFRESH_TOKEN"],
+          variables: [],
+          secretRoles: {
+            accessToken: "DROPBOX_ACCESS_TOKEN",
+            refreshToken: "DROPBOX_REFRESH_TOKEN",
+          },
+        },
         grant: {
           kind: "auth-code",
           tokenUrl: OAUTH_TOKEN_URL,
@@ -31,8 +39,6 @@ export const dropbox = {
         access: {
           kind: "refresh-token",
           tokenUrl: OAUTH_TOKEN_URL,
-          accessToken: "DROPBOX_ACCESS_TOKEN",
-          refreshToken: "DROPBOX_REFRESH_TOKEN",
           envBindings: {
             DROPBOX_TOKEN: "$secrets.DROPBOX_ACCESS_TOKEN",
           },
@@ -43,6 +49,10 @@ export const dropbox = {
         label: "Access Token",
         helpText:
           "1. Go to the [Dropbox App Console](https://www.dropbox.com/developers/apps)\n2. Select your app (or create a new one)\n3. Click the button to generate an access token for your own account\n4. Copy the generated OAuth 2 access token",
+        storage: {
+          secrets: ["DROPBOX_TOKEN"],
+          variables: [],
+        },
         grant: {
           kind: "manual",
           fields: {

--- a/turbo/packages/connectors/src/connectors/duffel.ts
+++ b/turbo/packages/connectors/src/connectors/duffel.ts
@@ -11,6 +11,10 @@ export const duffel = {
         label: "Access Token",
         helpText:
           "1. Log in to the [Duffel dashboard](https://app.duffel.com)\n2. Click your organisation name, then **Developers > Access tokens**\n3. Click **New token**, give it a name, leave scope as **Read write**\n4. Click **Create token** and copy the value (format: `duffel_test_...` for test mode, `duffel_live_...` for live mode)",
+        storage: {
+          secrets: ["DUFFEL_TOKEN"],
+          variables: [],
+        },
         grant: {
           kind: "manual",
           fields: {

--- a/turbo/packages/connectors/src/connectors/e2b.ts
+++ b/turbo/packages/connectors/src/connectors/e2b.ts
@@ -11,6 +11,10 @@ export const e2b = {
         label: "API Key",
         helpText:
           "1. Sign up at [e2b.dev](https://e2b.dev)\n2. Go to Dashboard → **API Keys**\n3. Click **Create API Key**\n4. Copy the key (starts with `e2b_`). Paste it here.",
+        storage: {
+          secrets: ["E2B_TOKEN"],
+          variables: [],
+        },
         grant: {
           kind: "manual",
           fields: {

--- a/turbo/packages/connectors/src/connectors/elevenlabs.ts
+++ b/turbo/packages/connectors/src/connectors/elevenlabs.ts
@@ -12,6 +12,10 @@ export const elevenlabs = {
         label: "API Key",
         helpText:
           "1. Log in to [ElevenLabs](https://elevenlabs.io)\n2. Go to [Settings > API Keys](https://elevenlabs.io/app/settings/api-keys)\n3. Click to create a new API key\n4. Copy the key and store it securely",
+        storage: {
+          secrets: ["ELEVENLABS_TOKEN"],
+          variables: [],
+        },
         grant: {
           kind: "manual",
           fields: {

--- a/turbo/packages/connectors/src/connectors/etherscan.ts
+++ b/turbo/packages/connectors/src/connectors/etherscan.ts
@@ -11,6 +11,10 @@ export const etherscan = {
         label: "API Key",
         helpText:
           "1. Sign in to [Etherscan](https://etherscan.io)\n2. Open your [API Dashboard](https://etherscan.io/myapikey)\n3. Click **Add +** to create a new API key\n4. Use the key with Etherscan API V2 requests; one key works across supported chains via the `chainid` parameter",
+        storage: {
+          secrets: ["ETHERSCAN_API_KEY"],
+          variables: [],
+        },
         grant: {
           kind: "manual",
           fields: {

--- a/turbo/packages/connectors/src/connectors/etsy.ts
+++ b/turbo/packages/connectors/src/connectors/etsy.ts
@@ -14,6 +14,10 @@ export const etsy = {
           "2. Click **Create a New App** (or select an existing app)\n" +
           "3. Copy the **Keystring** and **Shared Secret**\n" +
           "4. Paste both values joined with a colon: `keystring:shared_secret`",
+        storage: {
+          secrets: ["ETSY_TOKEN"],
+          variables: [],
+        },
         grant: {
           kind: "manual",
           fields: {

--- a/turbo/packages/connectors/src/connectors/exa.ts
+++ b/turbo/packages/connectors/src/connectors/exa.ts
@@ -11,6 +11,10 @@ export const exa = {
         label: "API Key",
         helpText:
           "1. Sign up at [dashboard.exa.ai](https://dashboard.exa.ai)\n2. Click your account \u2192 **API Keys** \u2192 **Create API Key**\n3. Copy the key (starts with `exa_`). Free tier: 1,000 requests/month.",
+        storage: {
+          secrets: ["EXA_TOKEN"],
+          variables: [],
+        },
         grant: {
           kind: "manual",
           fields: {

--- a/turbo/packages/connectors/src/connectors/explorium.ts
+++ b/turbo/packages/connectors/src/connectors/explorium.ts
@@ -11,6 +11,10 @@ export const explorium = {
         label: "API Key",
         helpText:
           "1. Log in to the [Explorium Admin Portal](https://admin.explorium.ai)\n2. Navigate to **Access & Authentication > Getting Your API Key**\n3. Click the **Show Key** button to reveal the masked API key\n4. Click the **Copy Key** button to copy it",
+        storage: {
+          secrets: ["EXPLORIUM_TOKEN"],
+          variables: [],
+        },
         grant: {
           kind: "manual",
           fields: {

--- a/turbo/packages/connectors/src/connectors/faire.ts
+++ b/turbo/packages/connectors/src/connectors/faire.ts
@@ -19,6 +19,10 @@ export const faire = {
         label: "Access Token",
         helpText:
           "1. In the Faire portal, go to **Settings > Integrations**\n2. Generate an API key for a direct integration, or request one from Faire for a custom integration\n3. Copy the access token for the brand account you want to connect",
+        storage: {
+          secrets: ["FAIRE_TOKEN"],
+          variables: [],
+        },
         grant: {
           kind: "manual",
           fields: {

--- a/turbo/packages/connectors/src/connectors/fal.ts
+++ b/turbo/packages/connectors/src/connectors/fal.ts
@@ -12,6 +12,10 @@ export const fal = {
         label: "API Key",
         helpText:
           "1. Go to the [fal Dashboard Keys page](https://fal.ai/dashboard/keys)\n2. Click the **Create Key** button\n3. Provide a name for your key and select the appropriate scope (**API** for calling models, or **ADMIN** for full access)\n4. Copy the key immediately — you will not be able to see it again",
+        storage: {
+          secrets: ["FAL_TOKEN"],
+          variables: [],
+        },
         grant: {
           kind: "manual",
           fields: {

--- a/turbo/packages/connectors/src/connectors/figma.ts
+++ b/turbo/packages/connectors/src/connectors/figma.ts
@@ -19,6 +19,14 @@ export const figma = {
           clientIdEnv: "FIGMA_OAUTH_CLIENT_ID",
           clientSecretEnv: "FIGMA_OAUTH_CLIENT_SECRET",
         },
+        storage: {
+          secrets: ["FIGMA_ACCESS_TOKEN", "FIGMA_REFRESH_TOKEN"],
+          variables: [],
+          secretRoles: {
+            accessToken: "FIGMA_ACCESS_TOKEN",
+            refreshToken: "FIGMA_REFRESH_TOKEN",
+          },
+        },
         grant: {
           kind: "auth-code",
           tokenUrl: OAUTH_TOKEN_URL,
@@ -37,8 +45,6 @@ export const figma = {
         access: {
           kind: "refresh-token",
           tokenUrl: OAUTH_TOKEN_URL,
-          accessToken: "FIGMA_ACCESS_TOKEN",
-          refreshToken: "FIGMA_REFRESH_TOKEN",
           envBindings: {
             FIGMA_TOKEN: "$secrets.FIGMA_ACCESS_TOKEN",
           },
@@ -49,6 +55,10 @@ export const figma = {
         label: "Personal Access Token",
         helpText:
           "1. Log in to [Figma](https://www.figma.com) and open the file browser\n2. Click the account menu in the top-left corner and select **Settings**\n3. Select the **Security** tab\n4. Scroll to the **Personal access tokens** section and click **Generate new token**\n5. Enter a name for the token, assign the desired scopes, and press Return/Enter\n6. Copy the generated token immediately — it will not be shown again",
+        storage: {
+          secrets: ["FIGMA_TOKEN"],
+          variables: [],
+        },
         grant: {
           kind: "manual",
           fields: {

--- a/turbo/packages/connectors/src/connectors/firecrawl.ts
+++ b/turbo/packages/connectors/src/connectors/firecrawl.ts
@@ -11,6 +11,10 @@ export const firecrawl = {
         label: "API Token",
         helpText:
           "1. Log in to [Firecrawl](https://www.firecrawl.dev)\n2. Go to your **Dashboard**\n3. Copy your **API Key**",
+        storage: {
+          secrets: ["FIRECRAWL_TOKEN"],
+          variables: [],
+        },
         grant: {
           kind: "manual",
           fields: {

--- a/turbo/packages/connectors/src/connectors/fireflies.ts
+++ b/turbo/packages/connectors/src/connectors/fireflies.ts
@@ -11,6 +11,10 @@ export const fireflies = {
         label: "API Token",
         helpText:
           "1. Log in to [Fireflies](https://fireflies.ai)\n2. Navigate to the **Integrations** section\n3. Click on **Fireflies API**\n4. Copy your API key and store it securely",
+        storage: {
+          secrets: ["FIREFLIES_TOKEN"],
+          variables: [],
+        },
         grant: {
           kind: "manual",
           fields: {

--- a/turbo/packages/connectors/src/connectors/flightaware.ts
+++ b/turbo/packages/connectors/src/connectors/flightaware.ts
@@ -11,6 +11,10 @@ export const flightaware = {
         label: "AeroAPI Key",
         helpText:
           "1. Sign in to the [FlightAware AeroAPI portal](https://flightaware.com/aeroapi/portal/)\n2. Open your API key settings\n3. Copy your AeroAPI key\n4. Send it in the `x-apikey` header for AeroAPI requests",
+        storage: {
+          secrets: ["FLIGHTAWARE_TOKEN"],
+          variables: [],
+        },
         grant: {
           kind: "manual",
           fields: {

--- a/turbo/packages/connectors/src/connectors/freshdesk.ts
+++ b/turbo/packages/connectors/src/connectors/freshdesk.ts
@@ -12,6 +12,10 @@ export const freshdesk = {
         label: "API Key",
         helpText:
           "1. Log in to Freshdesk and click your profile picture (top right), then **Profile Settings**\n2. On the right pane, click **View API Key** and complete the captcha\n3. Copy the API key\n4. Enter your Freshdesk subdomain — the prefix of `https://<subdomain>.freshdesk.com`",
+        storage: {
+          secrets: ["FRESHDESK_TOKEN"],
+          variables: ["FRESHDESK_DOMAIN"],
+        },
         grant: {
           kind: "manual",
           fields: {

--- a/turbo/packages/connectors/src/connectors/gamma.ts
+++ b/turbo/packages/connectors/src/connectors/gamma.ts
@@ -12,6 +12,10 @@ export const gamma = {
         label: "API Key",
         helpText:
           "1. Log in to [Gamma](https://gamma.app)\n2. Go to [API Keys](https://gamma.app/settings/api-keys) (Settings > API Keys)\n3. Click **Create API key**\n4. Copy the key (it is only shown once)",
+        storage: {
+          secrets: ["GAMMA_TOKEN"],
+          variables: [],
+        },
         grant: {
           kind: "manual",
           fields: {

--- a/turbo/packages/connectors/src/connectors/garmin-connect.ts
+++ b/turbo/packages/connectors/src/connectors/garmin-connect.ts
@@ -21,6 +21,17 @@ export const garminConnect = {
           clientIdEnv: "GARMIN_CONNECT_OAUTH_CLIENT_ID",
           clientSecretEnv: "GARMIN_CONNECT_OAUTH_CLIENT_SECRET",
         },
+        storage: {
+          secrets: [
+            "GARMIN_CONNECT_ACCESS_TOKEN",
+            "GARMIN_CONNECT_REFRESH_TOKEN",
+          ],
+          variables: [],
+          secretRoles: {
+            accessToken: "GARMIN_CONNECT_ACCESS_TOKEN",
+            refreshToken: "GARMIN_CONNECT_REFRESH_TOKEN",
+          },
+        },
         grant: {
           kind: "auth-code",
           tokenUrl: OAUTH_TOKEN_URL,
@@ -29,8 +40,6 @@ export const garminConnect = {
         access: {
           kind: "refresh-token",
           tokenUrl: OAUTH_TOKEN_URL,
-          accessToken: "GARMIN_CONNECT_ACCESS_TOKEN",
-          refreshToken: "GARMIN_CONNECT_REFRESH_TOKEN",
           envBindings: {
             GARMIN_CONNECT_TOKEN: "$secrets.GARMIN_CONNECT_ACCESS_TOKEN",
           },

--- a/turbo/packages/connectors/src/connectors/gemini.ts
+++ b/turbo/packages/connectors/src/connectors/gemini.ts
@@ -13,6 +13,10 @@ export const gemini = {
         label: "API Key",
         helpText:
           "1. Go to [Google AI Studio](https://aistudio.google.com/apikey)\n2. Sign in with your Google account\n3. Click **Create API key**\n4. Copy the key (starts with `AIza`) and store it in a safe location",
+        storage: {
+          secrets: ["GEMINI_TOKEN"],
+          variables: [],
+        },
         grant: {
           kind: "manual",
           fields: {

--- a/turbo/packages/connectors/src/connectors/github.ts
+++ b/turbo/packages/connectors/src/connectors/github.ts
@@ -17,6 +17,13 @@ export const github = {
           clientIdEnv: "GH_OAUTH_CLIENT_ID",
           clientSecretEnv: "GH_OAUTH_CLIENT_SECRET",
         },
+        storage: {
+          secrets: ["GITHUB_ACCESS_TOKEN"],
+          variables: [],
+          secretRoles: {
+            accessToken: "GITHUB_ACCESS_TOKEN",
+          },
+        },
         grant: {
           kind: "auth-code",
           tokenUrl: "https://github.com/login/oauth/access_token",

--- a/turbo/packages/connectors/src/connectors/gitlab.ts
+++ b/turbo/packages/connectors/src/connectors/gitlab.ts
@@ -12,6 +12,10 @@ export const gitlab = {
         label: "Personal Access Token",
         helpText:
           "1. Log in to [GitLab](https://gitlab.com)\n2. Click your avatar in the upper-right corner and select **Edit profile**\n3. In the left sidebar, navigate to **Access > Personal access tokens**\n4. From the **Generate token** dropdown, select **Legacy token**\n5. Enter a name in the **Token name** field\n6. Optionally set an expiration date (defaults to 365 days)\n7. Select the required scopes for your token\n8. Click **Generate token**\n9. Copy and save the token — you cannot view it again after leaving the page",
+        storage: {
+          secrets: ["GITLAB_TOKEN"],
+          variables: ["GITLAB_HOST"],
+        },
         grant: {
           kind: "manual",
           fields: {

--- a/turbo/packages/connectors/src/connectors/gmail.ts
+++ b/turbo/packages/connectors/src/connectors/gmail.ts
@@ -18,6 +18,14 @@ export const gmail = {
           clientIdEnv: "GOOGLE_OAUTH_CLIENT_ID",
           clientSecretEnv: "GOOGLE_OAUTH_CLIENT_SECRET",
         },
+        storage: {
+          secrets: ["GMAIL_ACCESS_TOKEN", "GMAIL_REFRESH_TOKEN"],
+          variables: [],
+          secretRoles: {
+            accessToken: "GMAIL_ACCESS_TOKEN",
+            refreshToken: "GMAIL_REFRESH_TOKEN",
+          },
+        },
         grant: {
           kind: "auth-code",
           tokenUrl: OAUTH_TOKEN_URL,
@@ -26,8 +34,6 @@ export const gmail = {
         access: {
           kind: "refresh-token",
           tokenUrl: OAUTH_TOKEN_URL,
-          accessToken: "GMAIL_ACCESS_TOKEN",
-          refreshToken: "GMAIL_REFRESH_TOKEN",
           envBindings: {
             GMAIL_TOKEN: "$secrets.GMAIL_ACCESS_TOKEN",
           },

--- a/turbo/packages/connectors/src/connectors/gong.ts
+++ b/turbo/packages/connectors/src/connectors/gong.ts
@@ -12,6 +12,10 @@ export const gong = {
         label: "Access Key",
         helpText:
           "1. In Gong, go to **Company Settings → Ecosystem → API** (requires the Technical Administrator permission profile)\n2. Click **Create** to generate an Access Key and Access Key Secret\n3. Copy both values — the secret is shown only once\n4. Copy the **API Base URL** shown on the same screen (e.g. `api.gong.io`, or your region-specific host)",
+        storage: {
+          secrets: ["GONG_ACCESS_KEY", "GONG_ACCESS_KEY_SECRET"],
+          variables: ["GONG_API_BASE"],
+        },
         grant: {
           kind: "manual",
           fields: {

--- a/turbo/packages/connectors/src/connectors/google-ads.ts
+++ b/turbo/packages/connectors/src/connectors/google-ads.ts
@@ -20,6 +20,14 @@ export const googleAds = {
           clientIdEnv: "GOOGLE_OAUTH_CLIENT_ID",
           clientSecretEnv: "GOOGLE_OAUTH_CLIENT_SECRET",
         },
+        storage: {
+          secrets: ["GOOGLE_ADS_ACCESS_TOKEN", "GOOGLE_ADS_REFRESH_TOKEN"],
+          variables: [],
+          secretRoles: {
+            accessToken: "GOOGLE_ADS_ACCESS_TOKEN",
+            refreshToken: "GOOGLE_ADS_REFRESH_TOKEN",
+          },
+        },
         grant: {
           kind: "auth-code",
           tokenUrl: OAUTH_TOKEN_URL,
@@ -31,8 +39,6 @@ export const googleAds = {
         access: {
           kind: "refresh-token",
           tokenUrl: OAUTH_TOKEN_URL,
-          accessToken: "GOOGLE_ADS_ACCESS_TOKEN",
-          refreshToken: "GOOGLE_ADS_REFRESH_TOKEN",
           platformSecrets: ["GOOGLE_ADS_DEVELOPER_TOKEN"],
           envBindings: {
             GOOGLE_ADS_TOKEN: "$secrets.GOOGLE_ADS_ACCESS_TOKEN",

--- a/turbo/packages/connectors/src/connectors/google-calendar.ts
+++ b/turbo/packages/connectors/src/connectors/google-calendar.ts
@@ -19,6 +19,17 @@ export const googleCalendar = {
           clientIdEnv: "GOOGLE_OAUTH_CLIENT_ID",
           clientSecretEnv: "GOOGLE_OAUTH_CLIENT_SECRET",
         },
+        storage: {
+          secrets: [
+            "GOOGLE_CALENDAR_ACCESS_TOKEN",
+            "GOOGLE_CALENDAR_REFRESH_TOKEN",
+          ],
+          variables: [],
+          secretRoles: {
+            accessToken: "GOOGLE_CALENDAR_ACCESS_TOKEN",
+            refreshToken: "GOOGLE_CALENDAR_REFRESH_TOKEN",
+          },
+        },
         grant: {
           kind: "auth-code",
           tokenUrl: OAUTH_TOKEN_URL,
@@ -30,8 +41,6 @@ export const googleCalendar = {
         access: {
           kind: "refresh-token",
           tokenUrl: OAUTH_TOKEN_URL,
-          accessToken: "GOOGLE_CALENDAR_ACCESS_TOKEN",
-          refreshToken: "GOOGLE_CALENDAR_REFRESH_TOKEN",
           envBindings: {
             GOOGLE_CALENDAR_TOKEN: "$secrets.GOOGLE_CALENDAR_ACCESS_TOKEN",
           },

--- a/turbo/packages/connectors/src/connectors/google-docs.ts
+++ b/turbo/packages/connectors/src/connectors/google-docs.ts
@@ -17,6 +17,14 @@ export const googleDocs = {
           clientIdEnv: "GOOGLE_OAUTH_CLIENT_ID",
           clientSecretEnv: "GOOGLE_OAUTH_CLIENT_SECRET",
         },
+        storage: {
+          secrets: ["GOOGLE_DOCS_ACCESS_TOKEN", "GOOGLE_DOCS_REFRESH_TOKEN"],
+          variables: [],
+          secretRoles: {
+            accessToken: "GOOGLE_DOCS_ACCESS_TOKEN",
+            refreshToken: "GOOGLE_DOCS_REFRESH_TOKEN",
+          },
+        },
         grant: {
           kind: "auth-code",
           tokenUrl: OAUTH_TOKEN_URL,
@@ -28,8 +36,6 @@ export const googleDocs = {
         access: {
           kind: "refresh-token",
           tokenUrl: OAUTH_TOKEN_URL,
-          accessToken: "GOOGLE_DOCS_ACCESS_TOKEN",
-          refreshToken: "GOOGLE_DOCS_REFRESH_TOKEN",
           envBindings: {
             GOOGLE_DOCS_TOKEN: "$secrets.GOOGLE_DOCS_ACCESS_TOKEN",
           },

--- a/turbo/packages/connectors/src/connectors/google-drive.ts
+++ b/turbo/packages/connectors/src/connectors/google-drive.ts
@@ -17,6 +17,14 @@ export const googleDrive = {
           clientIdEnv: "GOOGLE_OAUTH_CLIENT_ID",
           clientSecretEnv: "GOOGLE_OAUTH_CLIENT_SECRET",
         },
+        storage: {
+          secrets: ["GOOGLE_DRIVE_ACCESS_TOKEN", "GOOGLE_DRIVE_REFRESH_TOKEN"],
+          variables: [],
+          secretRoles: {
+            accessToken: "GOOGLE_DRIVE_ACCESS_TOKEN",
+            refreshToken: "GOOGLE_DRIVE_REFRESH_TOKEN",
+          },
+        },
         grant: {
           kind: "auth-code",
           tokenUrl: OAUTH_TOKEN_URL,
@@ -28,8 +36,6 @@ export const googleDrive = {
         access: {
           kind: "refresh-token",
           tokenUrl: OAUTH_TOKEN_URL,
-          accessToken: "GOOGLE_DRIVE_ACCESS_TOKEN",
-          refreshToken: "GOOGLE_DRIVE_REFRESH_TOKEN",
           envBindings: {
             GOOGLE_DRIVE_TOKEN: "$secrets.GOOGLE_DRIVE_ACCESS_TOKEN",
           },

--- a/turbo/packages/connectors/src/connectors/google-maps.ts
+++ b/turbo/packages/connectors/src/connectors/google-maps.ts
@@ -11,6 +11,10 @@ export const googleMaps = {
         label: "API Key",
         helpText:
           "1. Open [Google Cloud Console](https://console.cloud.google.com/google/maps-apis/credentials)\n2. Select or create a project and enable the Maps APIs you need (Geocoding, Places, Directions, etc.)\n3. Go to **APIs & Services → Credentials** and click **Create credentials → API key**\n4. Copy the API key (format: `AIza…`) and restrict it to the APIs and referrers/IPs you trust",
+        storage: {
+          secrets: ["GOOGLE_MAPS_TOKEN"],
+          variables: [],
+        },
         grant: {
           kind: "manual",
           fields: {

--- a/turbo/packages/connectors/src/connectors/google-meet.ts
+++ b/turbo/packages/connectors/src/connectors/google-meet.ts
@@ -18,6 +18,14 @@ export const googleMeet = {
           clientIdEnv: "GOOGLE_OAUTH_CLIENT_ID",
           clientSecretEnv: "GOOGLE_OAUTH_CLIENT_SECRET",
         },
+        storage: {
+          secrets: ["GOOGLE_MEET_ACCESS_TOKEN", "GOOGLE_MEET_REFRESH_TOKEN"],
+          variables: [],
+          secretRoles: {
+            accessToken: "GOOGLE_MEET_ACCESS_TOKEN",
+            refreshToken: "GOOGLE_MEET_REFRESH_TOKEN",
+          },
+        },
         grant: {
           kind: "auth-code",
           tokenUrl: OAUTH_TOKEN_URL,
@@ -34,8 +42,6 @@ export const googleMeet = {
         access: {
           kind: "refresh-token",
           tokenUrl: OAUTH_TOKEN_URL,
-          accessToken: "GOOGLE_MEET_ACCESS_TOKEN",
-          refreshToken: "GOOGLE_MEET_REFRESH_TOKEN",
           envBindings: {
             GOOGLE_MEET_TOKEN: "$secrets.GOOGLE_MEET_ACCESS_TOKEN",
           },

--- a/turbo/packages/connectors/src/connectors/google-sheets.ts
+++ b/turbo/packages/connectors/src/connectors/google-sheets.ts
@@ -17,6 +17,17 @@ export const googleSheets = {
           clientIdEnv: "GOOGLE_OAUTH_CLIENT_ID",
           clientSecretEnv: "GOOGLE_OAUTH_CLIENT_SECRET",
         },
+        storage: {
+          secrets: [
+            "GOOGLE_SHEETS_ACCESS_TOKEN",
+            "GOOGLE_SHEETS_REFRESH_TOKEN",
+          ],
+          variables: [],
+          secretRoles: {
+            accessToken: "GOOGLE_SHEETS_ACCESS_TOKEN",
+            refreshToken: "GOOGLE_SHEETS_REFRESH_TOKEN",
+          },
+        },
         grant: {
           kind: "auth-code",
           tokenUrl: OAUTH_TOKEN_URL,
@@ -28,8 +39,6 @@ export const googleSheets = {
         access: {
           kind: "refresh-token",
           tokenUrl: OAUTH_TOKEN_URL,
-          accessToken: "GOOGLE_SHEETS_ACCESS_TOKEN",
-          refreshToken: "GOOGLE_SHEETS_REFRESH_TOKEN",
           envBindings: {
             GOOGLE_SHEETS_TOKEN: "$secrets.GOOGLE_SHEETS_ACCESS_TOKEN",
           },

--- a/turbo/packages/connectors/src/connectors/granola.ts
+++ b/turbo/packages/connectors/src/connectors/granola.ts
@@ -11,6 +11,10 @@ export const granola = {
         label: "API Key",
         helpText:
           "1. Open the [Granola](https://granola.ai) desktop app\n2. Go to **Settings > API**\n3. Click the **Create new key** button\n4. Choose a key type (if prompted) and click **Generate API Key**\n5. Copy and save the API key securely",
+        storage: {
+          secrets: ["GRANOLA_TOKEN"],
+          variables: [],
+        },
         grant: {
           kind: "manual",
           fields: {

--- a/turbo/packages/connectors/src/connectors/greenhouse.ts
+++ b/turbo/packages/connectors/src/connectors/greenhouse.ts
@@ -11,6 +11,10 @@ export const greenhouse = {
         label: "API Key",
         helpText:
           "1. In Greenhouse, click **Configure** (gear icon) → **Dev Center** (left sidebar)\n2. Click **API Credential Management** → **Create new API credentials**\n3. For **API type**, select **Harvest API** (v1/v2). For **Partner**, choose **Custom** (or **Unlisted vendor**). Description: **vm0**\n4. Select the endpoints you want this key to access (permission scoping)\n5. Click **View and store credentials** and copy the API key — it is only shown once\n6. Paste it here\n\n**Note:** Harvest v1/v2 will be deprecated on August 31, 2026; migrate to OAuth v3 before that date.",
+        storage: {
+          secrets: ["GREENHOUSE_TOKEN"],
+          variables: [],
+        },
         grant: {
           kind: "manual",
           fields: {

--- a/turbo/packages/connectors/src/connectors/groq.ts
+++ b/turbo/packages/connectors/src/connectors/groq.ts
@@ -13,6 +13,10 @@ export const groq = {
         label: "API Key",
         helpText:
           "1. Sign up at [console.groq.com](https://console.groq.com)\n2. Click **API Keys** in the left sidebar\n3. Click **Create API Key**, name it, and copy it immediately — it is shown only once\n4. Paste it here. Free tier available; the key is org-bound.",
+        storage: {
+          secrets: ["GROQ_TOKEN"],
+          variables: [],
+        },
         grant: {
           kind: "manual",
           fields: {

--- a/turbo/packages/connectors/src/connectors/gumroad.ts
+++ b/turbo/packages/connectors/src/connectors/gumroad.ts
@@ -19,6 +19,14 @@ export const gumroad = {
           clientIdEnv: "GUMROAD_OAUTH_CLIENT_ID",
           clientSecretEnv: "GUMROAD_OAUTH_CLIENT_SECRET",
         },
+        storage: {
+          secrets: ["GUMROAD_ACCESS_TOKEN", "GUMROAD_REFRESH_TOKEN"],
+          variables: [],
+          secretRoles: {
+            accessToken: "GUMROAD_ACCESS_TOKEN",
+            refreshToken: "GUMROAD_REFRESH_TOKEN",
+          },
+        },
         grant: {
           kind: "auth-code",
           tokenUrl: OAUTH_TOKEN_URL,
@@ -33,8 +41,6 @@ export const gumroad = {
         access: {
           kind: "refresh-token",
           tokenUrl: OAUTH_TOKEN_URL,
-          accessToken: "GUMROAD_ACCESS_TOKEN",
-          refreshToken: "GUMROAD_REFRESH_TOKEN",
           envBindings: {
             GUMROAD_TOKEN: "$secrets.GUMROAD_ACCESS_TOKEN",
           },
@@ -45,6 +51,10 @@ export const gumroad = {
         label: "Access Token",
         helpText:
           "1. Log in to [Gumroad](https://app.gumroad.com/settings/advanced)\n2. Scroll to the **Applications** section\n3. Click **Generate access token**\n4. Copy the token and paste it here",
+        storage: {
+          secrets: ["GUMROAD_TOKEN"],
+          variables: [],
+        },
         grant: {
           kind: "manual",
           fields: {

--- a/turbo/packages/connectors/src/connectors/helicone.ts
+++ b/turbo/packages/connectors/src/connectors/helicone.ts
@@ -10,6 +10,10 @@ export const helicone = {
       "api-token": {
         label: "API Key",
         helpText: "Go to helicone.ai → Settings → API Keys → create a new key.",
+        storage: {
+          secrets: ["HELICONE_TOKEN"],
+          variables: [],
+        },
         grant: {
           kind: "manual",
           fields: {

--- a/turbo/packages/connectors/src/connectors/heygen.ts
+++ b/turbo/packages/connectors/src/connectors/heygen.ts
@@ -12,6 +12,10 @@ export const heygen = {
         label: "API Key",
         helpText:
           "1. Log in to [HeyGen](https://app.heygen.com)\n2. Navigate to **Settings > API > API token**\n3. Click to generate your API key\n4. Copy and save the key immediately — you cannot retrieve it after leaving the page, and regenerating a new key will invalidate the previous one",
+        storage: {
+          secrets: ["HEYGEN_TOKEN"],
+          variables: [],
+        },
         grant: {
           kind: "manual",
           fields: {

--- a/turbo/packages/connectors/src/connectors/hitem3d.ts
+++ b/turbo/packages/connectors/src/connectors/hitem3d.ts
@@ -13,6 +13,10 @@ export const hitem3d = {
         label: "API Credentials",
         helpText:
           "1. Sign in to the [Hitem3D Developer Platform](https://platform.hitem3d.ai)\n2. Purchase or enable a resource package\n3. Open the API Key page and create an enabled API key\n4. Copy the client ID and client secret. Paste them here.",
+        storage: {
+          secrets: ["HITEM3D_CLIENT_ID", "HITEM3D_CLIENT_SECRET"],
+          variables: [],
+        },
         grant: {
           kind: "manual",
           fields: {

--- a/turbo/packages/connectors/src/connectors/honcho.ts
+++ b/turbo/packages/connectors/src/connectors/honcho.ts
@@ -11,6 +11,10 @@ export const honcho = {
         label: "API Key",
         helpText:
           "1. Log in to [Honcho](https://app.honcho.dev)\n2. Open **API KEYS**\n3. Create or copy an API key\n4. Honcho sends this key as `Authorization: Bearer <token>`",
+        storage: {
+          secrets: ["HONCHO_API_KEY"],
+          variables: [],
+        },
         grant: {
           kind: "manual",
           fields: {

--- a/turbo/packages/connectors/src/connectors/htmlcsstoimage.ts
+++ b/turbo/packages/connectors/src/connectors/htmlcsstoimage.ts
@@ -12,6 +12,10 @@ export const htmlcsstoimage = {
         label: "API Key",
         helpText:
           "1. Log in to [HTML/CSS to Image](https://htmlcsstoimage.com/dashboard)\n2. Go to your **Dashboard**\n3. Locate your **User ID** and **API Key** displayed on the dashboard\n4. Copy the **API Key** (used as the password in HTTP Basic authentication)",
+        storage: {
+          secrets: ["HCTI_API_KEY"],
+          variables: ["HCTI_USER_ID"],
+        },
         grant: {
           kind: "manual",
           fields: {

--- a/turbo/packages/connectors/src/connectors/hubspot.ts
+++ b/turbo/packages/connectors/src/connectors/hubspot.ts
@@ -18,6 +18,14 @@ export const hubspot = {
           clientIdEnv: "HUBSPOT_OAUTH_CLIENT_ID",
           clientSecretEnv: "HUBSPOT_OAUTH_CLIENT_SECRET",
         },
+        storage: {
+          secrets: ["HUBSPOT_ACCESS_TOKEN", "HUBSPOT_REFRESH_TOKEN"],
+          variables: [],
+          secretRoles: {
+            accessToken: "HUBSPOT_ACCESS_TOKEN",
+            refreshToken: "HUBSPOT_REFRESH_TOKEN",
+          },
+        },
         grant: {
           kind: "auth-code",
           tokenUrl: OAUTH_TOKEN_URL,
@@ -39,8 +47,6 @@ export const hubspot = {
         access: {
           kind: "refresh-token",
           tokenUrl: OAUTH_TOKEN_URL,
-          accessToken: "HUBSPOT_ACCESS_TOKEN",
-          refreshToken: "HUBSPOT_REFRESH_TOKEN",
           envBindings: {
             HUBSPOT_TOKEN: "$secrets.HUBSPOT_ACCESS_TOKEN",
           },

--- a/turbo/packages/connectors/src/connectors/hugging-face.ts
+++ b/turbo/packages/connectors/src/connectors/hugging-face.ts
@@ -12,6 +12,10 @@ export const huggingFace = {
         label: "API Token",
         helpText:
           "1. Log in to [Hugging Face](https://huggingface.co)\n2. Go to **Settings → Access Tokens**\n3. Create a new token with the required permissions\n4. Copy the token",
+        storage: {
+          secrets: ["HUGGING_FACE_TOKEN"],
+          variables: [],
+        },
         grant: {
           kind: "manual",
           fields: {

--- a/turbo/packages/connectors/src/connectors/hume.ts
+++ b/turbo/packages/connectors/src/connectors/hume.ts
@@ -12,6 +12,10 @@ export const hume = {
         label: "API Key",
         helpText:
           "1. Log in to the [Hume Portal](https://app.hume.ai)\n2. Navigate to the **API Keys** page\n3. Copy your API key",
+        storage: {
+          secrets: ["HUME_TOKEN"],
+          variables: [],
+        },
         grant: {
           kind: "manual",
           fields: {

--- a/turbo/packages/connectors/src/connectors/hunter.ts
+++ b/turbo/packages/connectors/src/connectors/hunter.ts
@@ -11,6 +11,10 @@ export const hunter = {
         label: "API Key",
         helpText:
           "1. Log in to [Hunter](https://hunter.io/api-keys)\n2. Open the **API keys** page under your account\n3. Copy your existing key or click **Generate a new key**\n4. Pass it as the `api_key` query parameter on every request",
+        storage: {
+          secrets: ["HUNTER_TOKEN"],
+          variables: [],
+        },
         grant: {
           kind: "manual",
           fields: {

--- a/turbo/packages/connectors/src/connectors/imgur.ts
+++ b/turbo/packages/connectors/src/connectors/imgur.ts
@@ -10,6 +10,10 @@ export const imgur = {
         label: "API Token",
         helpText:
           "1. Log in to [Imgur](https://imgur.com)\n2. Go to [Register an Application](https://api.imgur.com/oauth2/addclient)\n3. Fill in the application registration form\n4. After registration, you will receive a **Client ID** and **Client Secret**\n5. Copy and save both credentials",
+        storage: {
+          secrets: ["IMGUR_CLIENT_ID"],
+          variables: [],
+        },
         grant: {
           kind: "manual",
           fields: {

--- a/turbo/packages/connectors/src/connectors/infisical.ts
+++ b/turbo/packages/connectors/src/connectors/infisical.ts
@@ -11,6 +11,10 @@ export const infisical = {
         label: "Token Auth",
         helpText:
           "1. Log in to [Infisical](https://app.infisical.com)\n2. Go to **Access Control > Machine Identities**\n3. Create a new Machine Identity with **Token Auth**\n4. Copy the **Token**\n5. Assign the identity to your project with the desired role",
+        storage: {
+          secrets: ["INFISICAL_TOKEN"],
+          variables: [],
+        },
         grant: {
           kind: "manual",
           fields: {

--- a/turbo/packages/connectors/src/connectors/instagram.ts
+++ b/turbo/packages/connectors/src/connectors/instagram.ts
@@ -11,6 +11,10 @@ export const instagram = {
         label: "API Token",
         helpText:
           "1. Create a Meta app of type **Business** at [Meta for Developers](https://developers.facebook.com/apps)\n2. In your app dashboard, click **Instagram > API setup with Instagram business login** in the left side menu\n3. Click **Generate token** next to the Instagram account you want to access\n4. Log into Instagram when prompted\n5. Copy the access token",
+        storage: {
+          secrets: ["INSTAGRAM_TOKEN"],
+          variables: ["INSTAGRAM_BUSINESS_ACCOUNT_ID"],
+        },
         grant: {
           kind: "manual",
           fields: {

--- a/turbo/packages/connectors/src/connectors/instantly.ts
+++ b/turbo/packages/connectors/src/connectors/instantly.ts
@@ -11,6 +11,10 @@ export const instantly = {
         label: "API Key",
         helpText:
           "1. Log in to [Instantly](https://app.instantly.ai)\n2. Navigate to **Settings > Integrations** at https://app.instantly.ai/app/settings/integrations\n3. Click the **API Keys** section in the left sidebar\n4. Click the **Create API Key** button\n5. Enter a name for the API key\n6. Select the scopes (permissions) you want the API key to have\n7. Click **Create**\n8. Copy the key and store it in a secure place (it will only be displayed once)",
+        storage: {
+          secrets: ["INSTANTLY_API_KEY"],
+          variables: [],
+        },
         grant: {
           kind: "manual",
           fields: {

--- a/turbo/packages/connectors/src/connectors/intercom.ts
+++ b/turbo/packages/connectors/src/connectors/intercom.ts
@@ -11,6 +11,10 @@ export const intercom = {
         label: "Access Token",
         helpText:
           "1. Sign up at the [Intercom Developer Hub](https://app.intercom.com/admins/sign_up/developer) on your Intercom workspace\n2. Create a new app in the Developer Hub\n3. Navigate to **Configure > Authentication** within your app in the [Developer Hub](https://app.intercom.io/a/apps/_/developer-hub/app-packages)\n4. Copy your access token",
+        storage: {
+          secrets: ["INTERCOM_TOKEN"],
+          variables: [],
+        },
         grant: {
           kind: "manual",
           fields: {

--- a/turbo/packages/connectors/src/connectors/intervals-icu.ts
+++ b/turbo/packages/connectors/src/connectors/intervals-icu.ts
@@ -16,6 +16,13 @@ export const intervalsIcu = {
           clientIdEnv: "INTERVALS_ICU_OAUTH_CLIENT_ID",
           clientSecretEnv: "INTERVALS_ICU_OAUTH_CLIENT_SECRET",
         },
+        storage: {
+          secrets: ["INTERVALS_ICU_ACCESS_TOKEN"],
+          variables: [],
+          secretRoles: {
+            accessToken: "INTERVALS_ICU_ACCESS_TOKEN",
+          },
+        },
         grant: {
           kind: "auth-code",
           tokenUrl: "https://intervals.icu/api/oauth/token",

--- a/turbo/packages/connectors/src/connectors/ironclad.ts
+++ b/turbo/packages/connectors/src/connectors/ironclad.ts
@@ -12,6 +12,10 @@ export const ironclad = {
         label: "API Key",
         helpText:
           "1. In Ironclad, go to **Company Settings → API**\n2. Generate an API key and copy it\n3. Set the API host to match your instance's data region: `ironcladapp.com` (North America), `eu1.ironcladapp.com` (Europe), or `demo.ironcladapp.com` (demo)",
+        storage: {
+          secrets: ["IRONCLAD_API_KEY"],
+          variables: ["IRONCLAD_HOST"],
+        },
         grant: {
           kind: "manual",
           fields: {

--- a/turbo/packages/connectors/src/connectors/jam.ts
+++ b/turbo/packages/connectors/src/connectors/jam.ts
@@ -11,6 +11,10 @@ export const jam = {
         label: "Personal Access Token",
         helpText:
           '1. Log in to [Jam](https://jam.dev)\n2. Go to **Settings > Integrations > AI Agents**\n3. Scroll down to the **Personal Access Tokens** section\n4. Click **Create token**\n5. Enter a name for the token (e.g., "Cursor" or "Claude Code")\n6. Choose an expiration period (7 days, 30 days, 90 days, or 1 year)\n7. Select at least one scope (`mcp:read` for viewing or `mcp:write` for editing)\n8. Click **Create**\n9. Copy the token immediately (it will not be displayed again)',
+        storage: {
+          secrets: ["JAM_TOKEN"],
+          variables: [],
+        },
         grant: {
           kind: "manual",
           fields: {

--- a/turbo/packages/connectors/src/connectors/jira.ts
+++ b/turbo/packages/connectors/src/connectors/jira.ts
@@ -12,6 +12,10 @@ export const jira = {
         label: "API Token",
         helpText:
           "1. Go to [Atlassian API token management](https://id.atlassian.com/manage-profile/security/api-tokens)\n2. Log in to your Atlassian account\n3. Click **Create API token**\n4. Enter a name that describes what the token is for\n5. Choose an expiration date (between 1 and 365 days)\n6. Click **Create**\n7. Click **Copy to clipboard** and save the token in a secure place (you cannot recover it later)",
+        storage: {
+          secrets: ["JIRA_API_TOKEN"],
+          variables: ["JIRA_DOMAIN", "JIRA_EMAIL"],
+        },
         grant: {
           kind: "manual",
           fields: {

--- a/turbo/packages/connectors/src/connectors/jotform.ts
+++ b/turbo/packages/connectors/src/connectors/jotform.ts
@@ -11,6 +11,10 @@ export const jotform = {
         label: "API Key",
         helpText:
           "1. Log in to your [Jotform account](https://www.jotform.com/myaccount/api)\n2. Navigate to **Settings** → **API**\n3. Click **Create New Key**\n4. Copy your **API Key**",
+        storage: {
+          secrets: ["JOTFORM_TOKEN"],
+          variables: [],
+        },
         grant: {
           kind: "manual",
           fields: {

--- a/turbo/packages/connectors/src/connectors/klaviyo.ts
+++ b/turbo/packages/connectors/src/connectors/klaviyo.ts
@@ -11,6 +11,10 @@ export const klaviyo = {
         label: "API Key",
         helpText:
           "1. Log in to [Klaviyo](https://www.klaviyo.com/)\n2. Go to **Account > Settings > API keys**\n3. Click **Create Private API Key**\n4. Grant the scopes your workflow needs (e.g. `profiles:write`, `lists:write`, `events:write`, `subscriptions:write`)\n5. Copy the key (format: `pk_...`)",
+        storage: {
+          secrets: ["KLAVIYO_TOKEN"],
+          variables: [],
+        },
         grant: {
           kind: "manual",
           fields: {

--- a/turbo/packages/connectors/src/connectors/kommo.ts
+++ b/turbo/packages/connectors/src/connectors/kommo.ts
@@ -11,6 +11,10 @@ export const kommo = {
         label: "API Key",
         helpText:
           "1. Log in to [Kommo](https://www.kommo.com) and create a **private integration**\n2. Go to the **Keys and Scopes** tab in your private integration settings\n3. Click **Generate long-lived token**\n4. Set the token expiration date (from 1 day to 5 years)\n5. Copy and save the token immediately (it will only be displayed once)",
+        storage: {
+          secrets: ["KOMMO_API_KEY"],
+          variables: ["KOMMO_SUBDOMAIN"],
+        },
         grant: {
           kind: "manual",
           fields: {

--- a/turbo/packages/connectors/src/connectors/langfuse.ts
+++ b/turbo/packages/connectors/src/connectors/langfuse.ts
@@ -12,6 +12,10 @@ export const langfuse = {
         label: "API Keys",
         helpText:
           "1. Sign up at [cloud.langfuse.com](https://cloud.langfuse.com)\n2. Create an organization and a project\n3. In project **Settings → API Keys**, click **Create new API keys**\n4. Copy both the **Public Key** (`pk-lf-...`) and the **Secret Key** (`sk-lf-...`) — the secret is shown only once\n5. Paste both values into the fields below",
+        storage: {
+          secrets: ["LANGFUSE_PUBLIC_KEY", "LANGFUSE_SECRET_KEY"],
+          variables: [],
+        },
         grant: {
           kind: "manual",
           fields: {

--- a/turbo/packages/connectors/src/connectors/langsmith.ts
+++ b/turbo/packages/connectors/src/connectors/langsmith.ts
@@ -11,6 +11,10 @@ export const langsmith = {
         label: "API Key",
         helpText:
           "Go to [smith.langchain.com](https://smith.langchain.com) → Settings → API Keys → Create API Key.",
+        storage: {
+          secrets: ["LANGSMITH_TOKEN"],
+          variables: [],
+        },
         grant: {
           kind: "manual",
           fields: {

--- a/turbo/packages/connectors/src/connectors/lark.ts
+++ b/turbo/packages/connectors/src/connectors/lark.ts
@@ -13,6 +13,10 @@ export const lark = {
         label: "App Credentials",
         helpText:
           "1. Log in to the [Lark Developer Console](https://open.larksuite.com/app/)\n2. Select your app from the list (or create a new one)\n3. Go to the **Credentials & Basic Info** page\n4. Copy your **App ID** and **App Secret**\n5. Use these credentials to call the tenant_access_token API to obtain an access token",
+        storage: {
+          secrets: ["LARK_TOKEN"],
+          variables: ["LARK_APP_ID"],
+        },
         grant: {
           kind: "manual",
           fields: {

--- a/turbo/packages/connectors/src/connectors/line.ts
+++ b/turbo/packages/connectors/src/connectors/line.ts
@@ -11,6 +11,10 @@ export const line = {
         label: "Channel Access Token",
         helpText:
           "1. Log in to the [LINE Developers Console](https://developers.line.biz/console)\n2. Select your provider and channel\n3. Go to the **Messaging API** tab\n4. Issue or copy the **Channel access token (long-lived)**",
+        storage: {
+          secrets: ["LINE_TOKEN"],
+          variables: [],
+        },
         grant: {
           kind: "manual",
           fields: {

--- a/turbo/packages/connectors/src/connectors/linear.ts
+++ b/turbo/packages/connectors/src/connectors/linear.ts
@@ -18,6 +18,14 @@ export const linear = {
           clientIdEnv: "LINEAR_OAUTH_CLIENT_ID",
           clientSecretEnv: "LINEAR_OAUTH_CLIENT_SECRET",
         },
+        storage: {
+          secrets: ["LINEAR_ACCESS_TOKEN", "LINEAR_REFRESH_TOKEN"],
+          variables: [],
+          secretRoles: {
+            accessToken: "LINEAR_ACCESS_TOKEN",
+            refreshToken: "LINEAR_REFRESH_TOKEN",
+          },
+        },
         grant: {
           kind: "auth-code",
           tokenUrl: OAUTH_TOKEN_URL,
@@ -32,8 +40,6 @@ export const linear = {
         access: {
           kind: "refresh-token",
           tokenUrl: OAUTH_TOKEN_URL,
-          accessToken: "LINEAR_ACCESS_TOKEN",
-          refreshToken: "LINEAR_REFRESH_TOKEN",
           envBindings: {
             LINEAR_TOKEN: "$secrets.LINEAR_ACCESS_TOKEN",
           },

--- a/turbo/packages/connectors/src/connectors/loops.ts
+++ b/turbo/packages/connectors/src/connectors/loops.ts
@@ -11,6 +11,10 @@ export const loops = {
         label: "API Key",
         helpText:
           "1. Log in to [Loops](https://app.loops.so)\n2. Go to **Settings** → **API**\n3. Click **Generate key**\n4. Copy the generated API key",
+        storage: {
+          secrets: ["LOOPS_TOKEN"],
+          variables: [],
+        },
         grant: {
           kind: "manual",
           fields: {

--- a/turbo/packages/connectors/src/connectors/luma-ai.ts
+++ b/turbo/packages/connectors/src/connectors/luma-ai.ts
@@ -12,6 +12,10 @@ export const lumaAi = {
         label: "API Key",
         helpText:
           "1. Sign up at [lumalabs.ai](https://lumalabs.ai)\n2. Go to [lumalabs.ai/dream-machine/api](https://lumalabs.ai/dream-machine/api) or account settings → API Keys\n3. Create a new API key and copy it\n4. Paste the key here",
+        storage: {
+          secrets: ["LUMA_TOKEN"],
+          variables: [],
+        },
         grant: {
           kind: "manual",
           fields: {

--- a/turbo/packages/connectors/src/connectors/luma.ts
+++ b/turbo/packages/connectors/src/connectors/luma.ts
@@ -12,6 +12,10 @@ export const luma = {
         label: "API Key",
         helpText:
           "1. Log in at [lu.ma](https://lu.ma)\n2. Go to Calendars Home → select your calendar → Settings → Developer\n3. Generate or copy your API key\n4. Paste the key here",
+        storage: {
+          secrets: ["LUMA_API_KEY"],
+          variables: [],
+        },
         grant: {
           kind: "manual",
           fields: {

--- a/turbo/packages/connectors/src/connectors/mailchimp.ts
+++ b/turbo/packages/connectors/src/connectors/mailchimp.ts
@@ -18,6 +18,13 @@ export const mailchimp = {
           clientIdEnv: "MAILCHIMP_OAUTH_CLIENT_ID",
           clientSecretEnv: "MAILCHIMP_OAUTH_CLIENT_SECRET",
         },
+        storage: {
+          secrets: ["MAILCHIMP_ACCESS_TOKEN"],
+          variables: [],
+          secretRoles: {
+            accessToken: "MAILCHIMP_ACCESS_TOKEN",
+          },
+        },
         grant: {
           kind: "auth-code",
           tokenUrl: "https://login.mailchimp.com/oauth2/token",
@@ -35,6 +42,10 @@ export const mailchimp = {
         label: "API Key",
         helpText:
           "1. Log in to [Mailchimp](https://mailchimp.com)\n2. Click your **profile icon** and select **Profile**\n3. Click the **Extras** dropdown menu, then choose **API keys**\n4. In the **Your API Keys** section, click **Create A Key**\n5. Enter a descriptive name for the key\n6. Click **Generate Key**\n7. Click **Copy Key to Clipboard** and store it in a secure place (you will not be able to see or copy it again)\n8. Click **Done**",
+        storage: {
+          secrets: ["MAILCHIMP_TOKEN"],
+          variables: [],
+        },
         grant: {
           kind: "manual",
           fields: {

--- a/turbo/packages/connectors/src/connectors/mailsac.ts
+++ b/turbo/packages/connectors/src/connectors/mailsac.ts
@@ -11,6 +11,10 @@ export const mailsac = {
         label: "API Key",
         helpText:
           "1. Go to [Mailsac](https://mailsac.com) and sign up for an account\n2. Log in to your Mailsac dashboard\n3. Navigate to [API Keys](https://mailsac.com/api-keys)\n4. Copy your API key from the dashboard",
+        storage: {
+          secrets: ["MAILSAC_TOKEN"],
+          variables: [],
+        },
         grant: {
           kind: "manual",
           fields: {

--- a/turbo/packages/connectors/src/connectors/make.ts
+++ b/turbo/packages/connectors/src/connectors/make.ts
@@ -11,6 +11,10 @@ export const make = {
         label: "API Token",
         helpText:
           "1. Log in to [Make](https://www.make.com)\n2. Click your **avatar** at the bottom-left corner\n3. Select **Profile**, then open the **API** tab\n4. Click **Add token**\n5. Enter a **Label** (custom name to identify the token)\n6. Select the required **Scopes** (permissions)\n7. Click **Save**\n8. Copy the token and store it in a safe place (it will be hidden once you leave the page)",
+        storage: {
+          secrets: ["MAKE_TOKEN"],
+          variables: [],
+        },
         grant: {
           kind: "manual",
           fields: {

--- a/turbo/packages/connectors/src/connectors/manus.ts
+++ b/turbo/packages/connectors/src/connectors/manus.ts
@@ -11,6 +11,10 @@ export const manus = {
         label: "API Key",
         helpText:
           "1. Sign in to [Manus](https://manus.im)\n2. Navigate to **Settings → Integration → Build with Manus API**\n3. Click **Create New**, give it a name, and confirm\n4. Copy the generated API key",
+        storage: {
+          secrets: ["MANUS_TOKEN"],
+          variables: [],
+        },
         grant: {
           kind: "manual",
           fields: {

--- a/turbo/packages/connectors/src/connectors/mapbox.ts
+++ b/turbo/packages/connectors/src/connectors/mapbox.ts
@@ -11,6 +11,10 @@ export const mapbox = {
         label: "Access Token",
         helpText:
           "1. Log in to [Mapbox](https://account.mapbox.com)\n2. Open the **Access tokens** page\n3. Click **Create a token**, give it a name, and pick the scopes you need\n4. Copy the token (format: `pk.…`) — pass it as the `access_token` query parameter",
+        storage: {
+          secrets: ["MAPBOX_TOKEN"],
+          variables: [],
+        },
         grant: {
           kind: "manual",
           fields: {

--- a/turbo/packages/connectors/src/connectors/mathpix.ts
+++ b/turbo/packages/connectors/src/connectors/mathpix.ts
@@ -11,6 +11,10 @@ export const mathpix = {
         label: "App ID + App Key",
         helpText:
           "1. Sign in to the [Mathpix Console](https://console.mathpix.com)\n2. Open **API Keys** under your account\n3. Copy your **app_id** and create / copy an **app_key**\n4. Mathpix authenticates with both values sent as the `app_id` and `app_key` request headers",
+        storage: {
+          secrets: ["MATHPIX_APP_KEY"],
+          variables: ["MATHPIX_APP_ID"],
+        },
         grant: {
           kind: "manual",
           fields: {

--- a/turbo/packages/connectors/src/connectors/mem0.ts
+++ b/turbo/packages/connectors/src/connectors/mem0.ts
@@ -11,6 +11,10 @@ export const mem0 = {
         label: "API Key",
         helpText:
           "Go to [app.mem0.ai](https://app.mem0.ai) → **API Keys** → create or copy your key.",
+        storage: {
+          secrets: ["MEM0_TOKEN"],
+          variables: [],
+        },
         grant: {
           kind: "manual",
           fields: {

--- a/turbo/packages/connectors/src/connectors/mercury.ts
+++ b/turbo/packages/connectors/src/connectors/mercury.ts
@@ -20,6 +20,14 @@ export const mercury = {
           clientIdEnv: "MERCURY_OAUTH_CLIENT_ID",
           clientSecretEnv: "MERCURY_OAUTH_CLIENT_SECRET",
         },
+        storage: {
+          secrets: ["MERCURY_ACCESS_TOKEN", "MERCURY_REFRESH_TOKEN"],
+          variables: [],
+          secretRoles: {
+            accessToken: "MERCURY_ACCESS_TOKEN",
+            refreshToken: "MERCURY_REFRESH_TOKEN",
+          },
+        },
         grant: {
           kind: "auth-code",
           tokenUrl: OAUTH_TOKEN_URL,
@@ -28,8 +36,6 @@ export const mercury = {
         access: {
           kind: "refresh-token",
           tokenUrl: OAUTH_TOKEN_URL,
-          accessToken: "MERCURY_ACCESS_TOKEN",
-          refreshToken: "MERCURY_REFRESH_TOKEN",
           envBindings: {
             MERCURY_TOKEN: "$secrets.MERCURY_ACCESS_TOKEN",
           },
@@ -40,6 +46,10 @@ export const mercury = {
         label: "API Token",
         helpText:
           "1. Log in to your [Mercury Dashboard](https://mercury.com)\n2. Go to **Settings → Tokens**\n3. Generate a new API token\n4. Copy the token",
+        storage: {
+          secrets: ["MERCURY_TOKEN"],
+          variables: [],
+        },
         grant: {
           kind: "manual",
           fields: {

--- a/turbo/packages/connectors/src/connectors/meshy.ts
+++ b/turbo/packages/connectors/src/connectors/meshy.ts
@@ -12,6 +12,10 @@ export const meshy = {
         label: "API Key",
         helpText:
           "1. Sign in to [Meshy](https://www.meshy.ai)\n2. Open the [API settings page](https://www.meshy.ai/settings/api)\n3. Click **Create API Key**\n4. Copy the API key. You will not be able to see it again.",
+        storage: {
+          secrets: ["MESHY_API_KEY"],
+          variables: [],
+        },
         grant: {
           kind: "manual",
           fields: {

--- a/turbo/packages/connectors/src/connectors/meta-ads.ts
+++ b/turbo/packages/connectors/src/connectors/meta-ads.ts
@@ -18,6 +18,13 @@ export const metaAds = {
           clientIdEnv: "META_ADS_OAUTH_CLIENT_ID",
           clientSecretEnv: "META_ADS_OAUTH_CLIENT_SECRET",
         },
+        storage: {
+          secrets: ["META_ADS_ACCESS_TOKEN"],
+          variables: [],
+          secretRoles: {
+            accessToken: "META_ADS_ACCESS_TOKEN",
+          },
+        },
         grant: {
           kind: "auth-code",
           tokenUrl: "https://graph.facebook.com/v22.0/oauth/access_token",

--- a/turbo/packages/connectors/src/connectors/metabase.ts
+++ b/turbo/packages/connectors/src/connectors/metabase.ts
@@ -11,6 +11,10 @@ export const metabase = {
         label: "API Key",
         helpText:
           "1. Log in to your Metabase instance as an admin\n2. Go to **Admin** → **Settings** → **Authentication** → **API Keys**\n3. Click **Create API Key**\n4. Enter a name and select a group for the key\n5. Copy the generated API key",
+        storage: {
+          secrets: ["METABASE_TOKEN"],
+          variables: ["METABASE_BASE_URL"],
+        },
         grant: {
           kind: "manual",
           fields: {

--- a/turbo/packages/connectors/src/connectors/minimax.ts
+++ b/turbo/packages/connectors/src/connectors/minimax.ts
@@ -12,6 +12,10 @@ export const minimax = {
         label: "API Key",
         helpText:
           "1. Log in to [MiniMax Platform](https://platform.minimax.io)\n2. Go to **User Center > Basic Information > Interface Key**\n3. Create a new API key\n4. Copy the key",
+        storage: {
+          secrets: ["MINIMAX_TOKEN"],
+          variables: [],
+        },
         grant: {
           kind: "manual",
           fields: {

--- a/turbo/packages/connectors/src/connectors/minio.ts
+++ b/turbo/packages/connectors/src/connectors/minio.ts
@@ -11,6 +11,10 @@ export const minio = {
         label: "Access Credentials",
         helpText:
           "1. Log in to the MinIO Console\n2. Navigate to the **Access Keys** section under Security and Access\n3. Click **Create Access Key**\n4. The system automatically generates an access key and secret key\n5. Optionally override the auto-generated values or toggle **Restrict beyond user policy** to limit permissions\n6. Save the secret key in a secure location (you cannot retrieve or reset it after creation)\n7. Click **Create** to finalize",
+        storage: {
+          secrets: ["MINIO_TOKEN", "MINIO_SECRET_TOKEN"],
+          variables: ["MINIO_ENDPOINT"],
+        },
         grant: {
           kind: "manual",
           fields: {

--- a/turbo/packages/connectors/src/connectors/miro.ts
+++ b/turbo/packages/connectors/src/connectors/miro.ts
@@ -11,6 +11,10 @@ export const miro = {
         label: "Access Token",
         helpText:
           "1. Go to [Miro App Settings](https://miro.com/app/settings/user-profile/apps) and click **Create new app**\n2. Fill in the app name and description\n3. **Important:** when asked about token expiration, select **Non-expiring access token** — this choice is permanent for the app\n4. On the app's page, open **Permissions** and check the scopes you need (e.g. `boards:read`, `boards:write`)\n5. Click **Install app and get OAuth token**, select your team, and copy the token\n6. Paste the token here",
+        storage: {
+          secrets: ["MIRO_TOKEN"],
+          variables: [],
+        },
         grant: {
           kind: "manual",
           fields: {

--- a/turbo/packages/connectors/src/connectors/mixpanel.ts
+++ b/turbo/packages/connectors/src/connectors/mixpanel.ts
@@ -12,6 +12,13 @@ export const mixpanel = {
         label: "Service Account",
         helpText:
           "1. In Mixpanel, open **Organization Settings → Service Accounts** (or **Project Settings → Service Accounts**)\n2. Click **Add Service Account**, give it a name, and choose a role (minimum **Member**); optionally set an expiration\n3. Copy the **Username** and **Secret** immediately — the secret is only shown once\n4. Open **Project Settings → Overview → Access Keys** and copy your **Project ID**\n5. Paste all three values below",
+        storage: {
+          secrets: [
+            "MIXPANEL_SERVICE_ACCOUNT_USERNAME",
+            "MIXPANEL_SERVICE_ACCOUNT_SECRET",
+          ],
+          variables: ["MIXPANEL_PROJECT_ID"],
+        },
         grant: {
           kind: "manual",
           fields: {

--- a/turbo/packages/connectors/src/connectors/monday.ts
+++ b/turbo/packages/connectors/src/connectors/monday.ts
@@ -18,6 +18,14 @@ export const monday = {
           clientIdEnv: "MONDAY_OAUTH_CLIENT_ID",
           clientSecretEnv: "MONDAY_OAUTH_CLIENT_SECRET",
         },
+        storage: {
+          secrets: ["MONDAY_ACCESS_TOKEN", "MONDAY_REFRESH_TOKEN"],
+          variables: [],
+          secretRoles: {
+            accessToken: "MONDAY_ACCESS_TOKEN",
+            refreshToken: "MONDAY_REFRESH_TOKEN",
+          },
+        },
         grant: {
           kind: "auth-code",
           tokenUrl: OAUTH_TOKEN_URL,
@@ -41,8 +49,6 @@ export const monday = {
         access: {
           kind: "refresh-token",
           tokenUrl: OAUTH_TOKEN_URL,
-          accessToken: "MONDAY_ACCESS_TOKEN",
-          refreshToken: "MONDAY_REFRESH_TOKEN",
           envBindings: {
             MONDAY_TOKEN: "$secrets.MONDAY_ACCESS_TOKEN",
           },

--- a/turbo/packages/connectors/src/connectors/moss.ts
+++ b/turbo/packages/connectors/src/connectors/moss.ts
@@ -12,6 +12,10 @@ export const moss = {
         label: "Project Credentials",
         helpText:
           "1. Sign in to [Moss](https://www.moss.dev) and open the project portal\n2. Open **Project Settings → API Keys**\n3. Copy the **Project ID** and **Project Key** for your project (both are required and paired)",
+        storage: {
+          secrets: ["MOSS_PROJECT_ID", "MOSS_PROJECT_KEY"],
+          variables: [],
+        },
         grant: {
           kind: "manual",
           fields: {

--- a/turbo/packages/connectors/src/connectors/msg9.ts
+++ b/turbo/packages/connectors/src/connectors/msg9.ts
@@ -11,6 +11,10 @@ export const msg9 = {
         label: "API Key",
         helpText:
           "1. Log in to [msg9](https://www.msg9.io)\n2. Go to **Settings > API Keys**\n3. Create a new API key\n4. Copy the key (format: `msg9_sk_...`)",
+        storage: {
+          secrets: ["MSG9_TOKEN"],
+          variables: [],
+        },
         grant: {
           kind: "manual",
           fields: {

--- a/turbo/packages/connectors/src/connectors/n8n.ts
+++ b/turbo/packages/connectors/src/connectors/n8n.ts
@@ -11,6 +11,10 @@ export const n8n = {
         label: "API Key",
         helpText:
           "1. Open your n8n instance\n2. Go to **Settings** → **n8n API**\n3. Click **Create an API key**\n4. Copy the key and paste it below\n5. Set your instance URL (e.g. `https://your-instance.app.n8n.cloud`)",
+        storage: {
+          secrets: ["N8N_TOKEN"],
+          variables: ["N8N_BASE_URL"],
+        },
         grant: {
           kind: "manual",
           fields: {

--- a/turbo/packages/connectors/src/connectors/neon.ts
+++ b/turbo/packages/connectors/src/connectors/neon.ts
@@ -20,6 +20,14 @@ export const neon = {
           clientIdEnv: "NEON_OAUTH_CLIENT_ID",
           clientSecretEnv: "NEON_OAUTH_CLIENT_SECRET",
         },
+        storage: {
+          secrets: ["NEON_ACCESS_TOKEN", "NEON_REFRESH_TOKEN"],
+          variables: [],
+          secretRoles: {
+            accessToken: "NEON_ACCESS_TOKEN",
+            refreshToken: "NEON_REFRESH_TOKEN",
+          },
+        },
         grant: {
           kind: "auth-code",
           tokenUrl: OAUTH_TOKEN_URL,
@@ -35,8 +43,6 @@ export const neon = {
         access: {
           kind: "refresh-token",
           tokenUrl: OAUTH_TOKEN_URL,
-          accessToken: "NEON_ACCESS_TOKEN",
-          refreshToken: "NEON_REFRESH_TOKEN",
           envBindings: {
             NEON_TOKEN: "$secrets.NEON_ACCESS_TOKEN",
           },
@@ -47,6 +53,10 @@ export const neon = {
         label: "API Key",
         helpText:
           "1. Log in to [Neon Console](https://console.neon.tech)\n2. Navigate to **Account settings > API keys**\n3. Click the button to create a new API key\n4. Copy and store the secret token immediately (it is only displayed once)",
+        storage: {
+          secrets: ["NEON_TOKEN"],
+          variables: [],
+        },
         grant: {
           kind: "manual",
           fields: {

--- a/turbo/packages/connectors/src/connectors/notion.ts
+++ b/turbo/packages/connectors/src/connectors/notion.ts
@@ -18,6 +18,14 @@ export const notion = {
           clientIdEnv: "NOTION_OAUTH_CLIENT_ID",
           clientSecretEnv: "NOTION_OAUTH_CLIENT_SECRET",
         },
+        storage: {
+          secrets: ["NOTION_ACCESS_TOKEN", "NOTION_REFRESH_TOKEN"],
+          variables: [],
+          secretRoles: {
+            accessToken: "NOTION_ACCESS_TOKEN",
+            refreshToken: "NOTION_REFRESH_TOKEN",
+          },
+        },
         grant: {
           kind: "auth-code",
           tokenUrl: OAUTH_TOKEN_URL,
@@ -26,8 +34,6 @@ export const notion = {
         access: {
           kind: "refresh-token",
           tokenUrl: OAUTH_TOKEN_URL,
-          accessToken: "NOTION_ACCESS_TOKEN",
-          refreshToken: "NOTION_REFRESH_TOKEN",
           envBindings: {
             NOTION_TOKEN: "$secrets.NOTION_ACCESS_TOKEN",
           },

--- a/turbo/packages/connectors/src/connectors/novita.ts
+++ b/turbo/packages/connectors/src/connectors/novita.ts
@@ -12,6 +12,10 @@ export const novita = {
         label: "API Key",
         helpText:
           "1. Sign in at [novita.ai](https://novita.ai)\n2. Open **Settings → Key Management**\n3. Click **+ Add New Key**\n4. Copy the key (it begins with `sk_`). Paste it here.",
+        storage: {
+          secrets: ["NOVITA_TOKEN"],
+          variables: [],
+        },
         grant: {
           kind: "manual",
           fields: {

--- a/turbo/packages/connectors/src/connectors/nyne.ts
+++ b/turbo/packages/connectors/src/connectors/nyne.ts
@@ -11,6 +11,10 @@ export const nyne = {
         label: "API Credentials",
         helpText:
           "1. Sign in at [nyne.ai](https://nyne.ai)\n2. Open your dashboard → **API Keys**\n3. Copy your **API Key** and **API Secret**\n4. Nyne authenticates each request with both `X-API-Key` and `X-API-Secret` headers on `https://api.nyne.ai`",
+        storage: {
+          secrets: ["NYNE_API_KEY", "NYNE_API_SECRET"],
+          variables: [],
+        },
         grant: {
           kind: "manual",
           fields: {

--- a/turbo/packages/connectors/src/connectors/onyx.ts
+++ b/turbo/packages/connectors/src/connectors/onyx.ts
@@ -11,6 +11,10 @@ export const onyx = {
         label: "API Key / PAT",
         helpText:
           "1. Log in to [Onyx Cloud](https://cloud.onyx.app)\n2. Go to **Settings → Accounts & Access**\n3. Click **Create New Token**\n4. Give it a name and choose an expiration\n5. Copy the token immediately — it is shown only once",
+        storage: {
+          secrets: ["ONYX_TOKEN"],
+          variables: [],
+        },
         grant: {
           kind: "manual",
           fields: {

--- a/turbo/packages/connectors/src/connectors/openai.ts
+++ b/turbo/packages/connectors/src/connectors/openai.ts
@@ -13,6 +13,10 @@ export const openai = {
         label: "API Key",
         helpText:
           "1. Log in to [OpenAI Platform](https://platform.openai.com)\n2. Navigate to the [API Keys](https://platform.openai.com/api-keys) page in the dashboard\n3. Create a new API key\n4. Copy and store the key in a safe location",
+        storage: {
+          secrets: ["OPENAI_TOKEN"],
+          variables: [],
+        },
         grant: {
           kind: "manual",
           fields: {

--- a/turbo/packages/connectors/src/connectors/openrouter.ts
+++ b/turbo/packages/connectors/src/connectors/openrouter.ts
@@ -12,6 +12,10 @@ export const openrouter = {
         label: "API Key",
         helpText:
           "1. Sign in to [OpenRouter](https://openrouter.ai/keys)\n2. Click **Create Key**, name it, and set the credit limit you want\n3. Copy the key (format: `sk-or-v1-…`)\n4. Use it as a Bearer token on requests to `https://openrouter.ai/api/v1/...`",
+        storage: {
+          secrets: ["OPENROUTER_TOKEN"],
+          variables: [],
+        },
         grant: {
           kind: "manual",
           fields: {

--- a/turbo/packages/connectors/src/connectors/openweather.ts
+++ b/turbo/packages/connectors/src/connectors/openweather.ts
@@ -11,6 +11,10 @@ export const openweather = {
         label: "API Key",
         helpText:
           "1. Sign in to [OpenWeather](https://home.openweathermap.org)\n2. Go to **My API keys**\n3. Copy your default key or click **Generate** to create a new one\n4. Pass it as the `appid` query parameter on every request",
+        storage: {
+          secrets: ["OPENWEATHER_TOKEN"],
+          variables: [],
+        },
         grant: {
           kind: "manual",
           fields: {

--- a/turbo/packages/connectors/src/connectors/outlook-calendar.ts
+++ b/turbo/packages/connectors/src/connectors/outlook-calendar.ts
@@ -21,6 +21,17 @@ export const outlookCalendar = {
           clientIdEnv: "MICROSOFT_OAUTH_CLIENT_ID",
           clientSecretEnv: "MICROSOFT_OAUTH_CLIENT_SECRET",
         },
+        storage: {
+          secrets: [
+            "OUTLOOK_CALENDAR_ACCESS_TOKEN",
+            "OUTLOOK_CALENDAR_REFRESH_TOKEN",
+          ],
+          variables: [],
+          secretRoles: {
+            accessToken: "OUTLOOK_CALENDAR_ACCESS_TOKEN",
+            refreshToken: "OUTLOOK_CALENDAR_REFRESH_TOKEN",
+          },
+        },
         grant: {
           kind: "auth-code",
           tokenUrl: OAUTH_TOKEN_URL,
@@ -29,8 +40,6 @@ export const outlookCalendar = {
         access: {
           kind: "refresh-token",
           tokenUrl: OAUTH_TOKEN_URL,
-          accessToken: "OUTLOOK_CALENDAR_ACCESS_TOKEN",
-          refreshToken: "OUTLOOK_CALENDAR_REFRESH_TOKEN",
           envBindings: {
             OUTLOOK_CALENDAR_TOKEN: "$secrets.OUTLOOK_CALENDAR_ACCESS_TOKEN",
           },

--- a/turbo/packages/connectors/src/connectors/outlook-mail.ts
+++ b/turbo/packages/connectors/src/connectors/outlook-mail.ts
@@ -20,6 +20,14 @@ export const outlookMail = {
           clientIdEnv: "MICROSOFT_OAUTH_CLIENT_ID",
           clientSecretEnv: "MICROSOFT_OAUTH_CLIENT_SECRET",
         },
+        storage: {
+          secrets: ["OUTLOOK_MAIL_ACCESS_TOKEN", "OUTLOOK_MAIL_REFRESH_TOKEN"],
+          variables: [],
+          secretRoles: {
+            accessToken: "OUTLOOK_MAIL_ACCESS_TOKEN",
+            refreshToken: "OUTLOOK_MAIL_REFRESH_TOKEN",
+          },
+        },
         grant: {
           kind: "auth-code",
           tokenUrl: OAUTH_TOKEN_URL,
@@ -33,8 +41,6 @@ export const outlookMail = {
         access: {
           kind: "refresh-token",
           tokenUrl: OAUTH_TOKEN_URL,
-          accessToken: "OUTLOOK_MAIL_ACCESS_TOKEN",
-          refreshToken: "OUTLOOK_MAIL_REFRESH_TOKEN",
           envBindings: {
             OUTLOOK_MAIL_TOKEN: "$secrets.OUTLOOK_MAIL_ACCESS_TOKEN",
           },

--- a/turbo/packages/connectors/src/connectors/pandadoc.ts
+++ b/turbo/packages/connectors/src/connectors/pandadoc.ts
@@ -11,6 +11,10 @@ export const pandadoc = {
         label: "API Key",
         helpText:
           "1. In PandaDoc, go to **Settings > Integrations > API**\n2. Click **Generate Production Key** (requires an API-enabled plan) or **Generate Sandbox Key** for testing\n3. Copy the key and paste it here\n\nNote: Only Org Admins can generate keys. Sandbox keys work for free but signed documents have no legal validity.",
+        storage: {
+          secrets: ["PANDADOC_TOKEN"],
+          variables: [],
+        },
         grant: {
           kind: "manual",
           fields: {

--- a/turbo/packages/connectors/src/connectors/parallel.ts
+++ b/turbo/packages/connectors/src/connectors/parallel.ts
@@ -11,6 +11,10 @@ export const parallel = {
         label: "API Key",
         helpText:
           "1. Go to [Parallel Platform](https://platform.parallel.ai)\n2. Create or copy your API key\n3. Use it as `PARALLEL_API_KEY`",
+        storage: {
+          secrets: ["PARALLEL_API_KEY"],
+          variables: [],
+        },
         grant: {
           kind: "manual",
           fields: {

--- a/turbo/packages/connectors/src/connectors/pdf4me.ts
+++ b/turbo/packages/connectors/src/connectors/pdf4me.ts
@@ -12,6 +12,10 @@ export const pdf4me = {
         label: "API Key",
         helpText:
           "1. Register for an account at [PDF4me](https://portal.pdf4me.com) using email/password or via Google, Microsoft, Apple, or Facebook\n2. Go to the **Billing Info** section and select **Start Free Trial**\n3. After activation, you will be redirected to the **Dashboard**\n4. Find and copy your API Key from the Dashboard",
+        storage: {
+          secrets: ["PDF4ME_TOKEN"],
+          variables: [],
+        },
         grant: {
           kind: "manual",
           fields: {

--- a/turbo/packages/connectors/src/connectors/pdfco.ts
+++ b/turbo/packages/connectors/src/connectors/pdfco.ts
@@ -10,6 +10,10 @@ export const pdfco = {
     authMethods: {
       "api-token": {
         label: "API Key",
+        storage: {
+          secrets: ["PDFCO_TOKEN"],
+          variables: [],
+        },
         grant: {
           kind: "manual",
           fields: {

--- a/turbo/packages/connectors/src/connectors/pdforge.ts
+++ b/turbo/packages/connectors/src/connectors/pdforge.ts
@@ -12,6 +12,10 @@ export const pdforge = {
         label: "API Key",
         helpText:
           "1. Create an account on [pdforge](https://pdforge.com)\n2. Two API keys are automatically generated when you create your account\n3. Go to the **API Keys** menu in the sidebar to view your keys\n4. Copy your API key and use it in the `Authorization: Bearer pdfnoodle_api_[your_key]` header",
+        storage: {
+          secrets: ["PDFORGE_API_KEY"],
+          variables: [],
+        },
         grant: {
           kind: "manual",
           fields: {

--- a/turbo/packages/connectors/src/connectors/people-data-labs.ts
+++ b/turbo/packages/connectors/src/connectors/people-data-labs.ts
@@ -11,6 +11,10 @@ export const peopleDataLabs = {
         label: "API Key",
         helpText:
           "1. Log in to your [People Data Labs dashboard](https://dashboard.peopledatalabs.com)\n2. Open your API dashboard\n3. Copy your API key\n4. People Data Labs accepts it in the `X-Api-Key` header",
+        storage: {
+          secrets: ["PEOPLE_DATA_LABS_API_KEY"],
+          variables: [],
+        },
         grant: {
           kind: "manual",
           fields: {

--- a/turbo/packages/connectors/src/connectors/perplexity.ts
+++ b/turbo/packages/connectors/src/connectors/perplexity.ts
@@ -12,6 +12,10 @@ export const perplexity = {
         label: "API Key",
         helpText:
           '1. Log in to the [Perplexity Console](https://console.perplexity.ai)\n2. Navigate to the **API Groups** page and create an API group (e.g., "Production" or "Development")\n3. Go to the **API Keys** page\n4. Generate a new API key\n5. Store the key immediately and securely (you will only see the full token value once)',
+        storage: {
+          secrets: ["PERPLEXITY_TOKEN"],
+          variables: [],
+        },
         grant: {
           kind: "manual",
           fields: {

--- a/turbo/packages/connectors/src/connectors/pika.ts
+++ b/turbo/packages/connectors/src/connectors/pika.ts
@@ -11,6 +11,10 @@ export const pika = {
         label: "Developer Key",
         helpText:
           "1. Go to [pika.me/dev](https://www.pika.me/dev/)\n2. Sign in or create an account\n3. Create a new Developer Key\n4. Copy the key (format: `dk_...`)",
+        storage: {
+          secrets: ["PIKA_TOKEN"],
+          variables: [],
+        },
         grant: {
           kind: "manual",
           fields: {

--- a/turbo/packages/connectors/src/connectors/pinecone.ts
+++ b/turbo/packages/connectors/src/connectors/pinecone.ts
@@ -11,6 +11,10 @@ export const pinecone = {
         label: "API Key",
         helpText:
           "1. Log in to [Pinecone](https://app.pinecone.io)\n2. Go to **API Keys** in the left sidebar\n3. Copy your default API key or create a new one",
+        storage: {
+          secrets: ["PINECONE_TOKEN"],
+          variables: [],
+        },
         grant: {
           kind: "manual",
           fields: {

--- a/turbo/packages/connectors/src/connectors/pipedream.ts
+++ b/turbo/packages/connectors/src/connectors/pipedream.ts
@@ -11,6 +11,10 @@ export const pipedream = {
         label: "User API Key",
         helpText:
           "1. Log in to [Pipedream](https://pipedream.com)\n2. Open **My Account → API Key** in your user settings\n3. Copy your user API key\n4. Pipedream sends this key as `Authorization: Bearer <api key>`",
+        storage: {
+          secrets: ["PIPEDREAM_TOKEN"],
+          variables: [],
+        },
         grant: {
           kind: "manual",
           fields: {

--- a/turbo/packages/connectors/src/connectors/pipedrive.ts
+++ b/turbo/packages/connectors/src/connectors/pipedrive.ts
@@ -11,6 +11,10 @@ export const pipedrive = {
         label: "API Key",
         helpText:
           "1. In Pipedrive, click your avatar (top right) → **Personal Preferences** → **API**\n2. Copy your personal API token\n3. Paste it here",
+        storage: {
+          secrets: ["PIPEDRIVE_TOKEN"],
+          variables: [],
+        },
         grant: {
           kind: "manual",
           fields: {

--- a/turbo/packages/connectors/src/connectors/plain.ts
+++ b/turbo/packages/connectors/src/connectors/plain.ts
@@ -11,6 +11,10 @@ export const plain = {
         label: "API Key",
         helpText:
           "1. Log in to [Plain](https://app.plain.com)\n2. Go to **Settings → Machine Users**\n3. Click **New machine user** and generate an API key\n4. Copy the API key",
+        storage: {
+          secrets: ["PLAIN_TOKEN"],
+          variables: [],
+        },
         grant: {
           kind: "manual",
           fields: {

--- a/turbo/packages/connectors/src/connectors/plausible.ts
+++ b/turbo/packages/connectors/src/connectors/plausible.ts
@@ -11,6 +11,10 @@ export const plausible = {
         label: "API Key",
         helpText:
           "1. Log in to [Plausible Analytics](https://plausible.io)\n2. Go to **Account Settings** → **API Keys**\n3. Click **New API Key** and choose **Stats API**\n4. Copy the key (it is only shown once)",
+        storage: {
+          secrets: ["PLAUSIBLE_TOKEN"],
+          variables: [],
+        },
         grant: {
           kind: "manual",
           fields: {

--- a/turbo/packages/connectors/src/connectors/podchaser.ts
+++ b/turbo/packages/connectors/src/connectors/podchaser.ts
@@ -11,6 +11,10 @@ export const podchaser = {
         label: "API Token",
         helpText:
           "1. Log in to [Podchaser](https://www.podchaser.com)\n2. Go to [Profile > Settings > API](https://www.podchaser.com/profile/settings/api) to retrieve your **API Key** and **API Secret**\n3. Request an access token by sending a POST request to `https://api.podchaser.com/graphql` using the `requestAccessToken` mutation with `grant_type` set to `CLIENT_CREDENTIALS`, your API Key as `client_id`, and your API Secret as `client_secret`\n4. Store the returned access token (it lasts 1 year)",
+        storage: {
+          secrets: ["PODCHASER_TOKEN"],
+          variables: [],
+        },
         grant: {
           kind: "manual",
           fields: {

--- a/turbo/packages/connectors/src/connectors/porkbun.ts
+++ b/turbo/packages/connectors/src/connectors/porkbun.ts
@@ -11,6 +11,10 @@ export const porkbun = {
         label: "API Key",
         helpText:
           "1. Log in to [Porkbun](https://porkbun.com)\n2. Open **Account > API Access**\n3. Create an API key and save both the **API Key** and **Secret Key**\n4. Enable API access for each domain you want to manage",
+        storage: {
+          secrets: ["PORKBUN_API_KEY", "PORKBUN_SECRET_API_KEY"],
+          variables: [],
+        },
         grant: {
           kind: "manual",
           fields: {

--- a/turbo/packages/connectors/src/connectors/posthog.ts
+++ b/turbo/packages/connectors/src/connectors/posthog.ts
@@ -20,6 +20,14 @@ export const posthog = {
           clientIdEnv: "POSTHOG_OAUTH_CLIENT_ID",
           clientSecretEnv: "POSTHOG_OAUTH_CLIENT_SECRET",
         },
+        storage: {
+          secrets: ["POSTHOG_ACCESS_TOKEN", "POSTHOG_REFRESH_TOKEN"],
+          variables: [],
+          secretRoles: {
+            accessToken: "POSTHOG_ACCESS_TOKEN",
+            refreshToken: "POSTHOG_REFRESH_TOKEN",
+          },
+        },
         grant: {
           kind: "auth-code",
           tokenUrl: OAUTH_TOKEN_URL,
@@ -53,8 +61,6 @@ export const posthog = {
         access: {
           kind: "refresh-token",
           tokenUrl: OAUTH_TOKEN_URL,
-          accessToken: "POSTHOG_ACCESS_TOKEN",
-          refreshToken: "POSTHOG_REFRESH_TOKEN",
           envBindings: {
             POSTHOG_TOKEN: "$secrets.POSTHOG_ACCESS_TOKEN",
           },
@@ -65,6 +71,10 @@ export const posthog = {
         label: "Personal API Key",
         helpText:
           "1. Log in to [PostHog](https://app.posthog.com)\n2. Navigate to **Personal API keys** in your account settings\n3. Click **+ Create a personal API Key**\n4. Enter a descriptive label for the key\n5. Choose the scopes (permissions) required for your use case\n6. Copy the key immediately (it will not be shown again after refreshing the page)",
+        storage: {
+          secrets: ["POSTHOG_TOKEN"],
+          variables: [],
+        },
         grant: {
           kind: "manual",
           fields: {

--- a/turbo/packages/connectors/src/connectors/printful.ts
+++ b/turbo/packages/connectors/src/connectors/printful.ts
@@ -15,6 +15,10 @@ export const printful = {
           "2. Generate a **Private Token** with the scopes your workflow needs\n" +
           "3. Copy the token and use it as a Bearer token\n\n" +
           "For account-level Private Tokens, Printful requires an `X-PF-Store-Id` header on store-scoped requests.",
+        storage: {
+          secrets: ["PRINTFUL_TOKEN"],
+          variables: [],
+        },
         grant: {
           kind: "manual",
           fields: {

--- a/turbo/packages/connectors/src/connectors/prisma-postgres.ts
+++ b/turbo/packages/connectors/src/connectors/prisma-postgres.ts
@@ -11,6 +11,10 @@ export const prismaPostgres = {
         label: "API Key",
         helpText:
           "1. Log in to the [Prisma Console](https://console.prisma.io)\n2. Go to your workspace **Settings** page\n3. Select **Service Tokens**\n4. Click **New Service Token**\n5. Copy and save the generated service token securely",
+        storage: {
+          secrets: ["PRISMA_POSTGRES_TOKEN"],
+          variables: [],
+        },
         grant: {
           kind: "manual",
           fields: {

--- a/turbo/packages/connectors/src/connectors/productlane.ts
+++ b/turbo/packages/connectors/src/connectors/productlane.ts
@@ -9,6 +9,10 @@ export const productlane = {
     authMethods: {
       "api-token": {
         label: "API Key",
+        storage: {
+          secrets: ["PRODUCTLANE_TOKEN"],
+          variables: [],
+        },
         grant: {
           kind: "manual",
           fields: {

--- a/turbo/packages/connectors/src/connectors/pushinator.ts
+++ b/turbo/packages/connectors/src/connectors/pushinator.ts
@@ -9,6 +9,10 @@ export const pushinator = {
     authMethods: {
       "api-token": {
         label: "API Token",
+        storage: {
+          secrets: ["PUSHINATOR_TOKEN"],
+          variables: [],
+        },
         grant: {
           kind: "manual",
           fields: {

--- a/turbo/packages/connectors/src/connectors/qdrant.ts
+++ b/turbo/packages/connectors/src/connectors/qdrant.ts
@@ -11,6 +11,10 @@ export const qdrant = {
         label: "API Key",
         helpText:
           "1. Log in to [Qdrant Cloud](https://cloud.qdrant.io)\n2. Open your cluster's detail page and go to **API Keys**\n3. Click **Create** and configure your key\n4. Copy the key (shown only once)",
+        storage: {
+          secrets: ["QDRANT_TOKEN"],
+          variables: ["QDRANT_BASE_URL"],
+        },
         grant: {
           kind: "manual",
           fields: {

--- a/turbo/packages/connectors/src/connectors/qiita.ts
+++ b/turbo/packages/connectors/src/connectors/qiita.ts
@@ -11,6 +11,10 @@ export const qiita = {
         label: "Access Token",
         helpText:
           "1. Log in to [Qiita](https://qiita.com)\n2. Go to **Settings > Applications**\n3. Create a new access token with the desired scopes (e.g., `read_qiita`, `write_qiita`)\n4. Copy the generated token\n5. Use it in API requests with the header `Authorization: Bearer [your_token]`",
+        storage: {
+          secrets: ["QIITA_TOKEN"],
+          variables: [],
+        },
         grant: {
           kind: "manual",
           fields: {

--- a/turbo/packages/connectors/src/connectors/railway-project.ts
+++ b/turbo/packages/connectors/src/connectors/railway-project.ts
@@ -11,6 +11,10 @@ export const railwayProject = {
         label: "Project Token",
         helpText:
           "1. Log in to [Railway](https://railway.com) and open the target project\n2. Go to **Project Settings → Tokens**\n3. Click **Create Token**, pick the environment, and name it\n4. Copy the token (UUID v4 format)\n\nThis token is sent via the `Project-Access-Token` header and is bound to one environment in one project. For cross-project automation use the **Railway** connector instead.",
+        storage: {
+          secrets: ["RAILWAY_PROJECT_TOKEN"],
+          variables: [],
+        },
         grant: {
           kind: "manual",
           fields: {

--- a/turbo/packages/connectors/src/connectors/railway.ts
+++ b/turbo/packages/connectors/src/connectors/railway.ts
@@ -11,6 +11,10 @@ export const railway = {
         label: "Account or Workspace Token",
         helpText:
           "1. Log in to [Railway](https://railway.com)\n2. Open your account or workspace **Settings → Tokens**\n3. Click **Create New Token**, name it, and (for workspace tokens) pick the workspace\n4. Copy the token (UUID v4 format)\n\nUse this connector for cross-project automation. For a single project, use the **Railway Project** connector instead.",
+        storage: {
+          secrets: ["RAILWAY_TOKEN"],
+          variables: [],
+        },
         grant: {
           kind: "manual",
           fields: {

--- a/turbo/packages/connectors/src/connectors/reap.ts
+++ b/turbo/packages/connectors/src/connectors/reap.ts
@@ -19,6 +19,10 @@ export const reap = {
         label: "API Key",
         helpText:
           "1. Contact the Reap team to obtain an API key for your project\n2. Choose the matching API base URL for the key environment: `https://sandbox.api.reap.global/v1` or `https://prod.api.reap.global/v1`\n3. Copy the API key",
+        storage: {
+          secrets: ["REAP_API_KEY"],
+          variables: ["REAP_API_BASE_URL"],
+        },
         grant: {
           kind: "manual",
           fields: {

--- a/turbo/packages/connectors/src/connectors/recraft.ts
+++ b/turbo/packages/connectors/src/connectors/recraft.ts
@@ -12,6 +12,10 @@ export const recraft = {
         label: "API Token",
         helpText:
           "1. Sign in to [Recraft](https://app.recraft.ai)\n2. Open your profile\n3. Copy your API token\n4. Paste it here.",
+        storage: {
+          secrets: ["RECRAFT_API_TOKEN"],
+          variables: [],
+        },
         grant: {
           kind: "manual",
           fields: {

--- a/turbo/packages/connectors/src/connectors/reddit.ts
+++ b/turbo/packages/connectors/src/connectors/reddit.ts
@@ -20,6 +20,14 @@ export const reddit = {
           clientIdEnv: "REDDIT_OAUTH_CLIENT_ID",
           clientSecretEnv: "REDDIT_OAUTH_CLIENT_SECRET",
         },
+        storage: {
+          secrets: ["REDDIT_ACCESS_TOKEN", "REDDIT_REFRESH_TOKEN"],
+          variables: [],
+          secretRoles: {
+            accessToken: "REDDIT_ACCESS_TOKEN",
+            refreshToken: "REDDIT_REFRESH_TOKEN",
+          },
+        },
         grant: {
           kind: "auth-code",
           tokenUrl: OAUTH_TOKEN_URL,
@@ -28,8 +36,6 @@ export const reddit = {
         access: {
           kind: "refresh-token",
           tokenUrl: OAUTH_TOKEN_URL,
-          accessToken: "REDDIT_ACCESS_TOKEN",
-          refreshToken: "REDDIT_REFRESH_TOKEN",
           envBindings: {
             REDDIT_TOKEN: "$secrets.REDDIT_ACCESS_TOKEN",
           },

--- a/turbo/packages/connectors/src/connectors/reducto.ts
+++ b/turbo/packages/connectors/src/connectors/reducto.ts
@@ -11,6 +11,10 @@ export const reducto = {
         label: "API Key",
         helpText:
           "1. Sign in to the [Reducto Platform](https://platform.reducto.ai)\n2. Open **Settings → API Keys**\n3. Click **Create Key**, name it, and copy the value\n4. Use it as a Bearer token on requests to `https://platform.reducto.ai`",
+        storage: {
+          secrets: ["REDUCTO_TOKEN"],
+          variables: [],
+        },
         grant: {
           kind: "manual",
           fields: {

--- a/turbo/packages/connectors/src/connectors/rentcast.ts
+++ b/turbo/packages/connectors/src/connectors/rentcast.ts
@@ -11,6 +11,10 @@ export const rentcast = {
         label: "API Key",
         helpText:
           "1. Log in to the [RentCast API dashboard](https://app.rentcast.io/app/api)\n2. Click **Create API Key**\n3. Copy the generated API key",
+        storage: {
+          secrets: ["RENTCAST_API_KEY"],
+          variables: [],
+        },
         grant: {
           kind: "manual",
           fields: {

--- a/turbo/packages/connectors/src/connectors/replicate.ts
+++ b/turbo/packages/connectors/src/connectors/replicate.ts
@@ -12,6 +12,10 @@ export const replicate = {
         label: "API Token",
         helpText:
           "1. Sign up at [replicate.com](https://replicate.com)\n2. Click your avatar → **API Tokens**\n3. Click **Create token**, give it a name\n4. Copy the token (starts with `r8_`)\n5. Paste it here",
+        storage: {
+          secrets: ["REPLICATE_TOKEN"],
+          variables: [],
+        },
         grant: {
           kind: "manual",
           fields: {

--- a/turbo/packages/connectors/src/connectors/reportei.ts
+++ b/turbo/packages/connectors/src/connectors/reportei.ts
@@ -11,6 +11,10 @@ export const reportei = {
         label: "API Token",
         helpText:
           "1. Log in to [Reportei](https://app.reportei.com)\n2. Go to **Company Settings** (Configurações da Empresa)\n3. Navigate to the **API Reportei** section\n4. Click **Generate new token** or copy your existing token",
+        storage: {
+          secrets: ["REPORTEI_TOKEN"],
+          variables: [],
+        },
         grant: {
           kind: "manual",
           fields: {

--- a/turbo/packages/connectors/src/connectors/resend.ts
+++ b/turbo/packages/connectors/src/connectors/resend.ts
@@ -11,6 +11,10 @@ export const resend = {
         label: "API Key",
         helpText:
           "1. Log in to [Resend](https://resend.com)\n2. Navigate to the [API Keys](https://resend.com/api-keys) page\n3. Click **Create API Key**\n4. Enter a name for your key (up to 50 characters)\n5. Select the permission level: **Full access** or **Sending access**\n6. If choosing sending access, select which domain the key can access\n7. Copy the generated API key",
+        storage: {
+          secrets: ["RESEND_TOKEN"],
+          variables: [],
+        },
         grant: {
           kind: "manual",
           fields: {

--- a/turbo/packages/connectors/src/connectors/revenuecat.ts
+++ b/turbo/packages/connectors/src/connectors/revenuecat.ts
@@ -11,6 +11,10 @@ export const revenuecat = {
         label: "Secret API Key",
         helpText:
           "1. Log in to [RevenueCat](https://app.revenuecat.com)\n2. Navigate to the **API keys** section in your project dashboard\n3. Public API keys are automatically created when you add an app to your project\n4. To create a secret API key, click **+ New secret API key** in the API keys section\n5. Copy and store the key securely (never embed secret keys in client-side code)",
+        storage: {
+          secrets: ["REVENUECAT_TOKEN"],
+          variables: [],
+        },
         grant: {
           kind: "manual",
           fields: {

--- a/turbo/packages/connectors/src/connectors/runway.ts
+++ b/turbo/packages/connectors/src/connectors/runway.ts
@@ -12,6 +12,10 @@ export const runway = {
         label: "API Key",
         helpText:
           "1. Sign up for an account in the [Runway Developer Portal](https://dev.runwayml.com/)\n2. After signing up, create a new organization\n3. Click to the **API Keys** tab\n4. Create a new key, giving it a descriptive name\n5. Copy the key immediately and store it in a safe place — it will only be shown once",
+        storage: {
+          secrets: ["RUNWAY_TOKEN"],
+          variables: [],
+        },
         grant: {
           kind: "manual",
           fields: {

--- a/turbo/packages/connectors/src/connectors/salesforce.ts
+++ b/turbo/packages/connectors/src/connectors/salesforce.ts
@@ -9,6 +9,10 @@ export const salesforce = {
     authMethods: {
       "api-token": {
         label: "API Token",
+        storage: {
+          secrets: ["SALESFORCE_TOKEN"],
+          variables: ["SALESFORCE_INSTANCE"],
+        },
         grant: {
           kind: "manual",
           fields: {

--- a/turbo/packages/connectors/src/connectors/scrapeninja.ts
+++ b/turbo/packages/connectors/src/connectors/scrapeninja.ts
@@ -9,6 +9,10 @@ export const scrapeninja = {
     authMethods: {
       "api-token": {
         label: "API Token",
+        storage: {
+          secrets: ["SCRAPENINJA_TOKEN"],
+          variables: [],
+        },
         grant: {
           kind: "manual",
           fields: {

--- a/turbo/packages/connectors/src/connectors/segment.ts
+++ b/turbo/packages/connectors/src/connectors/segment.ts
@@ -12,6 +12,10 @@ export const segment = {
         label: "Public API Token",
         helpText:
           "1. Log in to [Segment](https://app.segment.com)\n2. Open the workspace you want to manage\n3. Create a Public API token with the permissions required for your workflow\n4. Copy the token",
+        storage: {
+          secrets: ["SEGMENT_TOKEN"],
+          variables: [],
+        },
         grant: {
           kind: "manual",
           fields: {

--- a/turbo/packages/connectors/src/connectors/sendgrid.ts
+++ b/turbo/packages/connectors/src/connectors/sendgrid.ts
@@ -12,6 +12,10 @@ export const sendgrid = {
         label: "API Key",
         helpText:
           "1. Log in to [SendGrid](https://app.sendgrid.com) and open **Settings > API Keys**\n2. Click **Create API Key**, name it (e.g. `vm0`), and pick **Full Access** or a scoped permission set covering Mail Send, Templates, and Suppressions\n3. Click **Create & View** and copy the API key — it is shown only once\n4. Paste the key below (starts with `SG.`)",
+        storage: {
+          secrets: ["SENDGRID_TOKEN"],
+          variables: [],
+        },
         grant: {
           kind: "manual",
           fields: {

--- a/turbo/packages/connectors/src/connectors/sentry.ts
+++ b/turbo/packages/connectors/src/connectors/sentry.ts
@@ -18,6 +18,14 @@ export const sentry = {
           clientIdEnv: "SENTRY_OAUTH_CLIENT_ID",
           clientSecretEnv: "SENTRY_OAUTH_CLIENT_SECRET",
         },
+        storage: {
+          secrets: ["SENTRY_ACCESS_TOKEN", "SENTRY_REFRESH_TOKEN"],
+          variables: [],
+          secretRoles: {
+            accessToken: "SENTRY_ACCESS_TOKEN",
+            refreshToken: "SENTRY_REFRESH_TOKEN",
+          },
+        },
         grant: {
           kind: "auth-code",
           tokenUrl: OAUTH_TOKEN_URL,
@@ -33,8 +41,6 @@ export const sentry = {
         access: {
           kind: "refresh-token",
           tokenUrl: OAUTH_TOKEN_URL,
-          accessToken: "SENTRY_ACCESS_TOKEN",
-          refreshToken: "SENTRY_REFRESH_TOKEN",
           envBindings: {
             SENTRY_TOKEN: "$secrets.SENTRY_ACCESS_TOKEN",
           },

--- a/turbo/packages/connectors/src/connectors/serpapi.ts
+++ b/turbo/packages/connectors/src/connectors/serpapi.ts
@@ -11,6 +11,10 @@ export const serpapi = {
         label: "API Key",
         helpText:
           "1. Go to [SerpApi](https://serpapi.com) and sign up for an account (free plan available with 250 searches/month)\n2. Log in and go to your [Dashboard](https://serpapi.com/dashboard)\n3. Your API key is displayed on the dashboard\n4. Copy the API key",
+        storage: {
+          secrets: ["SERPAPI_TOKEN"],
+          variables: [],
+        },
         grant: {
           kind: "manual",
           fields: {

--- a/turbo/packages/connectors/src/connectors/servicenow.ts
+++ b/turbo/packages/connectors/src/connectors/servicenow.ts
@@ -12,6 +12,10 @@ export const servicenow = {
         label: "API Key",
         helpText:
           "1. In ServiceNow, create (or pick) a dedicated service user with the roles the integration needs — `itil` for incident/change, `cmdb_read` for CMDB, etc.\n2. Set a password on that user under **User Administration → Users**\n3. Enter the username, password, and your ServiceNow instance subdomain — the prefix of `https://<subdomain>.service-now.com`",
+        storage: {
+          secrets: ["SERVICENOW_USERNAME", "SERVICENOW_PASSWORD"],
+          variables: ["SERVICENOW_INSTANCE"],
+        },
         grant: {
           kind: "manual",
           fields: {

--- a/turbo/packages/connectors/src/connectors/shopify.ts
+++ b/turbo/packages/connectors/src/connectors/shopify.ts
@@ -12,6 +12,10 @@ export const shopify = {
         label: "API Key",
         helpText:
           "1. In your Shopify admin, go to **Settings → Apps and sales channels → Develop apps**\n2. Click **Create an app**, name it (e.g. `vm0`), and open it\n3. Under **Configuration → Admin API integration**, grant the scopes you need (e.g. `read_products`, `read_orders`)\n4. Click **Install app** and then **Reveal token once** — copy the Admin API access token (starts with `shpat_`)\n5. For the **Store subdomain** below, enter only the subdomain of your `.myshopify.com` URL (for `acme.myshopify.com` enter `acme`)",
+        storage: {
+          secrets: ["SHOPIFY_TOKEN"],
+          variables: ["SHOPIFY_SHOP"],
+        },
         grant: {
           kind: "manual",
           fields: {

--- a/turbo/packages/connectors/src/connectors/shortio.ts
+++ b/turbo/packages/connectors/src/connectors/shortio.ts
@@ -11,6 +11,10 @@ export const shortio = {
         label: "API Key",
         helpText:
           "1. Log in to the [Short.io](https://short.io) Dashboard\n2. Navigate to **Integrations and API**\n3. Click on **Create API key**\n4. Leave the **Public key** option disabled to create a private (secret) key\n5. Restrict the scope of the key to a specific team or domain\n6. Click **Create**\n7. Copy the key and store it in a safe place — secret keys cannot be recovered",
+        storage: {
+          secrets: ["SHORTIO_TOKEN"],
+          variables: [],
+        },
         grant: {
           kind: "manual",
           fields: {

--- a/turbo/packages/connectors/src/connectors/similarweb.ts
+++ b/turbo/packages/connectors/src/connectors/similarweb.ts
@@ -11,6 +11,10 @@ export const similarweb = {
         label: "API Key",
         helpText:
           "1. Log in to the [Similarweb platform](https://pro.similarweb.com/) (admin access required)\n2. From the main menu on the left, select **Settings & Help**, then select **Account**\n3. Under **Data Tools**, select either **REST API** or **Batch API**\n4. Click **Generate a New API Key** on the right\n5. Type the name of the API key, then select whether this is for yourself or another user\n6. Click **Create** — your key will be displayed in the Generated Keys table\n7. In the Generated Keys table, ensure the **Activation** toggle is on for the relevant API key",
+        storage: {
+          secrets: ["SIMILARWEB_TOKEN"],
+          variables: [],
+        },
         grant: {
           kind: "manual",
           fields: {

--- a/turbo/packages/connectors/src/connectors/slack-webhook.ts
+++ b/turbo/packages/connectors/src/connectors/slack-webhook.ts
@@ -10,6 +10,10 @@ export const slackWebhook = {
         label: "Webhook URL",
         helpText:
           "1. Create a [Slack app](https://api.slack.com/apps) (or use an existing one), choosing a workspace to associate it with\n2. From the app settings page, select **Incoming Webhooks**\n3. Toggle **Activate Incoming Webhooks** to on\n4. Click **Add New Webhook to Workspace**\n5. Pick a channel for the app to post to, then click **Authorize**\n6. Copy the webhook URL from the **Webhook URLs for Your Workspace** section (it will look like `https://hooks.slack.com/services/T.../B.../XXXX...`)",
+        storage: {
+          secrets: ["SLACK_WEBHOOK_URL"],
+          variables: [],
+        },
         grant: {
           kind: "manual",
           fields: {

--- a/turbo/packages/connectors/src/connectors/slack.ts
+++ b/turbo/packages/connectors/src/connectors/slack.ts
@@ -16,6 +16,13 @@ export const slack = {
           clientIdEnv: "SLACK_OAUTH_CLIENT_ID",
           clientSecretEnv: "SLACK_OAUTH_CLIENT_SECRET",
         },
+        storage: {
+          secrets: ["SLACK_ACCESS_TOKEN"],
+          variables: [],
+          secretRoles: {
+            accessToken: "SLACK_ACCESS_TOKEN",
+          },
+        },
         grant: {
           kind: "auth-code",
           tokenUrl: "https://slack.com/api/oauth.v2.access",

--- a/turbo/packages/connectors/src/connectors/slock.ts
+++ b/turbo/packages/connectors/src/connectors/slock.ts
@@ -18,6 +18,18 @@ export const slock = {
           clientRegistration: "dynamic",
           clientType: "public",
         },
+        storage: {
+          secrets: [
+            "SLOCK_ACCESS_TOKEN",
+            "SLOCK_SERVER_ID",
+            "SLOCK_REFRESH_TOKEN",
+          ],
+          variables: [],
+          secretRoles: {
+            accessToken: "SLOCK_ACCESS_TOKEN",
+            refreshToken: "SLOCK_REFRESH_TOKEN",
+          },
+        },
         grant: {
           kind: "device-auth",
           deviceAuthUrl: `${SLOCK_API_BASE_URL}/api/auth/device/authorize`,
@@ -27,8 +39,6 @@ export const slock = {
         access: {
           kind: "refresh-token",
           tokenUrl: SLOCK_REFRESH_TOKEN_URL,
-          accessToken: "SLOCK_ACCESS_TOKEN",
-          refreshToken: "SLOCK_REFRESH_TOKEN",
           envBindings: {
             SLOCK_TOKEN: "$secrets.SLOCK_ACCESS_TOKEN",
             SLOCK_SERVER_ID: "$secrets.SLOCK_SERVER_ID",

--- a/turbo/packages/connectors/src/connectors/snowflake.ts
+++ b/turbo/packages/connectors/src/connectors/snowflake.ts
@@ -12,6 +12,10 @@ export const snowflake = {
         label: "Programmatic Access Token",
         helpText:
           "1. In Snowflake, generate a programmatic access token for the user or service user that should own the connection\n2. Copy the generated token secret when Snowflake displays it\n3. Enter your Snowflake account identifier, for example `myorganization-myaccount` from `https://myorganization-myaccount.snowflakecomputing.com`",
+        storage: {
+          secrets: ["SNOWFLAKE_PAT"],
+          variables: ["SNOWFLAKE_ACCOUNT"],
+        },
         grant: {
           kind: "manual",
           fields: {

--- a/turbo/packages/connectors/src/connectors/sociavault.ts
+++ b/turbo/packages/connectors/src/connectors/sociavault.ts
@@ -11,6 +11,10 @@ export const sociavault = {
         label: "API Key",
         helpText:
           "1. Sign up or log in to the [SociaVault Dashboard](https://sociavault.com)\n2. Copy your API key\n3. SociaVault authenticates requests with the `X-API-Key` header",
+        storage: {
+          secrets: ["SOCIAVAULT_TOKEN"],
+          variables: [],
+        },
         grant: {
           kind: "manual",
           fields: {

--- a/turbo/packages/connectors/src/connectors/sponge.ts
+++ b/turbo/packages/connectors/src/connectors/sponge.ts
@@ -12,6 +12,10 @@ export const sponge = {
         label: "Master API Key",
         helpText:
           "1. Sign in to the [Sponge Wallet dashboard](https://wallet.paysponge.com)\n2. Open **Settings → Master API Keys**\n3. Click **Create master key**, name it, and copy the value (prefix `sponge_master_...`)\n\nThe master key is the platform credential. Sponge agent runtime keys are minted on demand through it — store the master key once and never embed it in agent traffic.",
+        storage: {
+          secrets: ["SPONGE_MASTER_KEY"],
+          variables: [],
+        },
         grant: {
           kind: "manual",
           fields: {

--- a/turbo/packages/connectors/src/connectors/spotify.ts
+++ b/turbo/packages/connectors/src/connectors/spotify.ts
@@ -20,6 +20,14 @@ export const spotify = {
           clientIdEnv: "SPOTIFY_OAUTH_CLIENT_ID",
           clientSecretEnv: "SPOTIFY_OAUTH_CLIENT_SECRET",
         },
+        storage: {
+          secrets: ["SPOTIFY_ACCESS_TOKEN", "SPOTIFY_REFRESH_TOKEN"],
+          variables: [],
+          secretRoles: {
+            accessToken: "SPOTIFY_ACCESS_TOKEN",
+            refreshToken: "SPOTIFY_REFRESH_TOKEN",
+          },
+        },
         grant: {
           kind: "auth-code",
           tokenUrl: OAUTH_TOKEN_URL,
@@ -48,8 +56,6 @@ export const spotify = {
         access: {
           kind: "refresh-token",
           tokenUrl: OAUTH_TOKEN_URL,
-          accessToken: "SPOTIFY_ACCESS_TOKEN",
-          refreshToken: "SPOTIFY_REFRESH_TOKEN",
           envBindings: {
             SPOTIFY_TOKEN: "$secrets.SPOTIFY_ACCESS_TOKEN",
           },

--- a/turbo/packages/connectors/src/connectors/sproutgigs.ts
+++ b/turbo/packages/connectors/src/connectors/sproutgigs.ts
@@ -19,6 +19,10 @@ export const sproutgigs = {
         label: "API Secret",
         helpText:
           "1. Log in to [SproutGigs](https://sproutgigs.com)\n2. Open **Account Settings** and go to the **Settings** tab\n3. Create or reset your API secret\n4. Enter your SproutGigs user ID and API secret. SproutGigs signs requests with HTTP Basic Auth using `USER_ID:API_SECRET`.",
+        storage: {
+          secrets: ["SPROUTGIGS_API_SECRET"],
+          variables: ["SPROUTGIGS_USER_ID"],
+        },
         grant: {
           kind: "manual",
           fields: {

--- a/turbo/packages/connectors/src/connectors/square.ts
+++ b/turbo/packages/connectors/src/connectors/square.ts
@@ -11,6 +11,10 @@ export const square = {
         label: "Access Token",
         helpText:
           "1. Sign in to the [Square Developer Console](https://developer.squareup.com/apps)\n2. Open (or create) an application\n3. In the left pane, choose **Credentials**\n4. At the top of the page, select **Production**\n5. Copy the **Production Access token** (format: `EAAA...`)",
+        storage: {
+          secrets: ["SQUARE_TOKEN"],
+          variables: [],
+        },
         grant: {
           kind: "manual",
           fields: {

--- a/turbo/packages/connectors/src/connectors/stability-ai.ts
+++ b/turbo/packages/connectors/src/connectors/stability-ai.ts
@@ -12,6 +12,10 @@ export const stabilityAi = {
         label: "API Key",
         helpText:
           "1. Sign up at [platform.stability.ai](https://platform.stability.ai)\n2. Go to **Account → API Keys → Create API Key**\n3. Copy the key (starts with `sk-`). Paste here. Free credits on signup.",
+        storage: {
+          secrets: ["STABILITY_TOKEN"],
+          variables: [],
+        },
         grant: {
           kind: "manual",
           fields: {

--- a/turbo/packages/connectors/src/connectors/strapi.ts
+++ b/turbo/packages/connectors/src/connectors/strapi.ts
@@ -11,6 +11,10 @@ export const strapi = {
         label: "API Token",
         helpText:
           "1. Log in to your Strapi admin panel\n2. Go to **Settings → API Tokens**\n3. Click **Create new API Token**\n4. Enter a name, select a token duration, and choose a token type (Full Access or Custom)\n5. Click **Save** and copy the generated token",
+        storage: {
+          secrets: ["STRAPI_TOKEN"],
+          variables: ["STRAPI_BASE_URL"],
+        },
         grant: {
           kind: "manual",
           fields: {

--- a/turbo/packages/connectors/src/connectors/strava.ts
+++ b/turbo/packages/connectors/src/connectors/strava.ts
@@ -18,6 +18,14 @@ export const strava = {
           clientIdEnv: "STRAVA_OAUTH_CLIENT_ID",
           clientSecretEnv: "STRAVA_OAUTH_CLIENT_SECRET",
         },
+        storage: {
+          secrets: ["STRAVA_ACCESS_TOKEN", "STRAVA_REFRESH_TOKEN"],
+          variables: [],
+          secretRoles: {
+            accessToken: "STRAVA_ACCESS_TOKEN",
+            refreshToken: "STRAVA_REFRESH_TOKEN",
+          },
+        },
         grant: {
           kind: "auth-code",
           tokenUrl: OAUTH_TOKEN_URL,
@@ -31,8 +39,6 @@ export const strava = {
         access: {
           kind: "refresh-token",
           tokenUrl: OAUTH_TOKEN_URL,
-          accessToken: "STRAVA_ACCESS_TOKEN",
-          refreshToken: "STRAVA_REFRESH_TOKEN",
           envBindings: {
             STRAVA_TOKEN: "$secrets.STRAVA_ACCESS_TOKEN",
           },

--- a/turbo/packages/connectors/src/connectors/streak.ts
+++ b/turbo/packages/connectors/src/connectors/streak.ts
@@ -11,6 +11,10 @@ export const streak = {
         label: "API Key",
         helpText:
           "1. Install the Streak extension and navigate to [Gmail](https://mail.google.com)\n2. Click on the Streak icon in the right sidebar\n3. Select the **Integrations** button\n4. Under the **Streak API** section, click **Create New Key**\n5. Copy and store the API key securely",
+        storage: {
+          secrets: ["STREAK_TOKEN"],
+          variables: [],
+        },
         grant: {
           kind: "manual",
           fields: {

--- a/turbo/packages/connectors/src/connectors/stripe.ts
+++ b/turbo/packages/connectors/src/connectors/stripe.ts
@@ -21,6 +21,14 @@ export const stripe = {
           clientIdEnv: "STRIPE_OAUTH_CLIENT_ID",
           clientSecretEnv: "STRIPE_OAUTH_CLIENT_SECRET",
         },
+        storage: {
+          secrets: ["STRIPE_ACCESS_TOKEN", "STRIPE_REFRESH_TOKEN"],
+          variables: [],
+          secretRoles: {
+            accessToken: "STRIPE_ACCESS_TOKEN",
+            refreshToken: "STRIPE_REFRESH_TOKEN",
+          },
+        },
         grant: {
           kind: "auth-code",
           tokenUrl: OAUTH_TOKEN_URL,
@@ -29,8 +37,6 @@ export const stripe = {
         access: {
           kind: "refresh-token",
           tokenUrl: OAUTH_TOKEN_URL,
-          accessToken: "STRIPE_ACCESS_TOKEN",
-          refreshToken: "STRIPE_REFRESH_TOKEN",
           envBindings: {
             STRIPE_TOKEN: "$secrets.STRIPE_ACCESS_TOKEN",
           },
@@ -41,6 +47,10 @@ export const stripe = {
         label: "API Key",
         helpText:
           "1. Log in to your [Stripe Dashboard](https://dashboard.stripe.com/apikeys)\n2. Go to **Developers > API keys**\n3. Reveal the **Secret key** (starts with `sk_live_` or `sk_test_`) or create a **Restricted key** (`rk_live_...`) with the scopes you need\n4. Copy the key",
+        storage: {
+          secrets: ["STRIPE_TOKEN"],
+          variables: [],
+        },
         grant: {
           kind: "manual",
           fields: {

--- a/turbo/packages/connectors/src/connectors/supabase.ts
+++ b/turbo/packages/connectors/src/connectors/supabase.ts
@@ -20,6 +20,14 @@ export const supabase = {
           clientIdEnv: "SUPABASE_OAUTH_CLIENT_ID",
           clientSecretEnv: "SUPABASE_OAUTH_CLIENT_SECRET",
         },
+        storage: {
+          secrets: ["SUPABASE_ACCESS_TOKEN", "SUPABASE_REFRESH_TOKEN"],
+          variables: [],
+          secretRoles: {
+            accessToken: "SUPABASE_ACCESS_TOKEN",
+            refreshToken: "SUPABASE_REFRESH_TOKEN",
+          },
+        },
         grant: {
           kind: "auth-code",
           tokenUrl: OAUTH_TOKEN_URL,
@@ -41,8 +49,6 @@ export const supabase = {
         access: {
           kind: "refresh-token",
           tokenUrl: OAUTH_TOKEN_URL,
-          accessToken: "SUPABASE_ACCESS_TOKEN",
-          refreshToken: "SUPABASE_REFRESH_TOKEN",
           envBindings: {
             SUPABASE_TOKEN: "$secrets.SUPABASE_ACCESS_TOKEN",
           },
@@ -53,6 +59,10 @@ export const supabase = {
         label: "Service Role Key",
         helpText:
           "1. Log in to the [Supabase Dashboard](https://supabase.com/dashboard)\n2. Open your project's **Connect** dialog, or go to **Project Settings > API Keys**\n3. For legacy keys, copy the `anon` key (for client-side) or `service_role` key (for server-side) from the **Legacy API Keys** tab\n4. For new keys, open the **API Keys** tab, click **Create new API Keys** if needed, and copy the value from the **Publishable key** section",
+        storage: {
+          secrets: ["SUPABASE_TOKEN"],
+          variables: [],
+        },
         grant: {
           kind: "manual",
           fields: {

--- a/turbo/packages/connectors/src/connectors/supadata.ts
+++ b/turbo/packages/connectors/src/connectors/supadata.ts
@@ -11,6 +11,10 @@ export const supadata = {
         label: "API Key",
         helpText:
           "1. Go to the [Supadata Dashboard](https://dash.supadata.ai)\n2. Sign up for an account (no credit card required)\n3. Your API key will be generated automatically\n4. Use it in API requests with the header `x-api-key: [your_api_key]`",
+        storage: {
+          secrets: ["SUPADATA_TOKEN"],
+          variables: [],
+        },
         grant: {
           kind: "manual",
           fields: {

--- a/turbo/packages/connectors/src/connectors/supermemory.ts
+++ b/turbo/packages/connectors/src/connectors/supermemory.ts
@@ -11,6 +11,10 @@ export const supermemory = {
         label: "API Key",
         helpText:
           "Go to [console.supermemory.ai](https://console.supermemory.ai) → **API Keys** → create or copy your key.",
+        storage: {
+          secrets: ["SUPERMEMORY_API_KEY"],
+          variables: [],
+        },
         grant: {
           kind: "manual",
           fields: {

--- a/turbo/packages/connectors/src/connectors/tavily.ts
+++ b/turbo/packages/connectors/src/connectors/tavily.ts
@@ -11,6 +11,10 @@ export const tavily = {
         label: "API Key",
         helpText:
           "1. Go to [app.tavily.com](https://app.tavily.com/) and sign up for a free account\n2. After signing in, your API key will be available on the dashboard\n3. Copy the API key (it will start with `tvly-`)",
+        storage: {
+          secrets: ["TAVILY_TOKEN"],
+          variables: [],
+        },
         grant: {
           kind: "manual",
           fields: {

--- a/turbo/packages/connectors/src/connectors/test-oauth-device.ts
+++ b/turbo/packages/connectors/src/connectors/test-oauth-device.ts
@@ -17,6 +17,13 @@ export const testOauthDevice = {
           clientType: "public",
           clientId: "test-oauth-device-client",
         },
+        storage: {
+          secrets: ["TEST_OAUTH_DEVICE_ACCESS_TOKEN"],
+          variables: [],
+          secretRoles: {
+            accessToken: "TEST_OAUTH_DEVICE_ACCESS_TOKEN",
+          },
+        },
         grant: {
           kind: "device-auth",
           deviceAuthUrl: "/api/test/oauth-provider/device/code",
@@ -40,6 +47,13 @@ export const testOauthDevice = {
           clientRegistration: "static",
           clientType: "public",
           clientId: "test-oauth-device-api-client",
+        },
+        storage: {
+          secrets: ["TEST_OAUTH_DEVICE_API_ACCESS_TOKEN"],
+          variables: [],
+          secretRoles: {
+            accessToken: "TEST_OAUTH_DEVICE_API_ACCESS_TOKEN",
+          },
         },
         grant: {
           kind: "device-auth",

--- a/turbo/packages/connectors/src/connectors/test-oauth.ts
+++ b/turbo/packages/connectors/src/connectors/test-oauth.ts
@@ -35,12 +35,18 @@ export const testOauth = {
         label: "OAuth",
         helpText: "Test-only OAuth provider. Only reachable in dev/preview.",
         client: TEST_OAUTH_CLIENT,
+        storage: {
+          secrets: ["TEST_OAUTH_ACCESS_TOKEN", "TEST_OAUTH_REFRESH_TOKEN"],
+          variables: [],
+          secretRoles: {
+            accessToken: "TEST_OAUTH_ACCESS_TOKEN",
+            refreshToken: "TEST_OAUTH_REFRESH_TOKEN",
+          },
+        },
         grant: TEST_OAUTH_AUTH_CODE_GRANT,
         access: {
           kind: "refresh-token",
           tokenUrl: OAUTH_TOKEN_URL,
-          accessToken: "TEST_OAUTH_ACCESS_TOKEN",
-          refreshToken: "TEST_OAUTH_REFRESH_TOKEN",
           envBindings: {
             TEST_OAUTH_TOKEN: "$secrets.TEST_OAUTH_ACCESS_TOKEN",
           },
@@ -53,12 +59,21 @@ export const testOauth = {
         helpText:
           "Secondary test-only OAuth method used to exercise method-aware provider registration.",
         client: TEST_OAUTH_CLIENT,
+        storage: {
+          secrets: [
+            "TEST_OAUTH_API_ACCESS_TOKEN",
+            "TEST_OAUTH_API_REFRESH_TOKEN",
+          ],
+          variables: [],
+          secretRoles: {
+            accessToken: "TEST_OAUTH_API_ACCESS_TOKEN",
+            refreshToken: "TEST_OAUTH_API_REFRESH_TOKEN",
+          },
+        },
         grant: TEST_OAUTH_AUTH_CODE_GRANT,
         access: {
           kind: "refresh-token",
           tokenUrl: OAUTH_TOKEN_URL,
-          accessToken: "TEST_OAUTH_API_ACCESS_TOKEN",
-          refreshToken: "TEST_OAUTH_API_REFRESH_TOKEN",
           envBindings: {
             TEST_OAUTH_TOKEN: "$secrets.TEST_OAUTH_API_ACCESS_TOKEN",
           },

--- a/turbo/packages/connectors/src/connectors/testrail.ts
+++ b/turbo/packages/connectors/src/connectors/testrail.ts
@@ -12,6 +12,10 @@ export const testrail = {
         label: "API Key",
         helpText:
           "1. In TestRail, open **My Settings** (top-right user menu) → **API Keys**\n2. Click **Add Key**, name it (e.g. `vm0`), copy the generated key\n3. Enter the email you log in with, the generated API key, and your TestRail instance subdomain — the prefix of `https://<subdomain>.testrail.io`\n4. If your team self-hosts TestRail Server, set `TESTRAIL_INSTANCE` to the full host (e.g. `tests.example.com`) — the firewall accepts both forms",
+        storage: {
+          secrets: ["TESTRAIL_EMAIL", "TESTRAIL_TOKEN"],
+          variables: ["TESTRAIL_INSTANCE"],
+        },
         grant: {
           kind: "manual",
           fields: {

--- a/turbo/packages/connectors/src/connectors/ticketmaster.ts
+++ b/turbo/packages/connectors/src/connectors/ticketmaster.ts
@@ -11,6 +11,10 @@ export const ticketmaster = {
         label: "Discovery API Key",
         helpText:
           "1. Log in to the [Ticketmaster Developer Portal](https://developer.ticketmaster.com)\n2. Open your application in **My Apps**\n3. Copy the **Consumer Key** for the Discovery API\n4. Use it as the `apikey` query parameter for Discovery API requests",
+        storage: {
+          secrets: ["TICKETMASTER_API_KEY"],
+          variables: [],
+        },
         grant: {
           kind: "manual",
           fields: {

--- a/turbo/packages/connectors/src/connectors/tldv.ts
+++ b/turbo/packages/connectors/src/connectors/tldv.ts
@@ -11,6 +11,10 @@ export const tldv = {
         label: "API Key",
         helpText:
           "1. Ensure you have a **Business Plan** subscription on [tldv](https://tldv.io)\n2. API and webhook access is only available on the Business Plan\n3. Contact support at **support@tldv.io** to request API access and obtain your credentials",
+        storage: {
+          secrets: ["TLDV_TOKEN"],
+          variables: [],
+        },
         grant: {
           kind: "manual",
           fields: {

--- a/turbo/packages/connectors/src/connectors/todoist.ts
+++ b/turbo/packages/connectors/src/connectors/todoist.ts
@@ -16,6 +16,13 @@ export const todoist = {
           clientIdEnv: "TODOIST_OAUTH_CLIENT_ID",
           clientSecretEnv: "TODOIST_OAUTH_CLIENT_SECRET",
         },
+        storage: {
+          secrets: ["TODOIST_ACCESS_TOKEN"],
+          variables: [],
+          secretRoles: {
+            accessToken: "TODOIST_ACCESS_TOKEN",
+          },
+        },
         grant: {
           kind: "auth-code",
           tokenUrl: "https://todoist.com/oauth/access_token",

--- a/turbo/packages/connectors/src/connectors/together.ts
+++ b/turbo/packages/connectors/src/connectors/together.ts
@@ -12,6 +12,10 @@ export const together = {
         label: "API Key",
         helpText:
           "1. Sign up at [api.together.ai](https://api.together.ai)\n2. Go to **Settings → API Keys**\n3. Click **Create API Key**\n4. Copy the key. Paste it here. Free $1 credit on signup.",
+        storage: {
+          secrets: ["TOGETHER_TOKEN"],
+          variables: [],
+        },
         grant: {
           kind: "manual",
           fields: {

--- a/turbo/packages/connectors/src/connectors/tripo.ts
+++ b/turbo/packages/connectors/src/connectors/tripo.ts
@@ -12,6 +12,10 @@ export const tripo = {
         label: "API Key",
         helpText:
           "1. Sign in at [platform.tripo3d.ai](https://platform.tripo3d.ai)\n2. Open **API Keys**\n3. Click **Create API Key**\n4. Copy the key (it begins with `tsk_`). It is shown only once. Paste it here.",
+        storage: {
+          secrets: ["TRIPO_API_KEY"],
+          variables: [],
+        },
         grant: {
           kind: "manual",
           fields: {

--- a/turbo/packages/connectors/src/connectors/twenty.ts
+++ b/turbo/packages/connectors/src/connectors/twenty.ts
@@ -11,6 +11,10 @@ export const twenty = {
         label: "API Key",
         helpText:
           "1. Log in to your [Twenty](https://twenty.com) workspace\n2. Go to **Settings > APIs & Webhooks**\n3. Click **+ Create key**\n4. Enter a descriptive **Name** and set an **Expiration Date**\n5. Click **Save**\n6. Copy the key immediately — it is only shown once",
+        storage: {
+          secrets: ["TWENTY_TOKEN"],
+          variables: [],
+        },
         grant: {
           kind: "manual",
           fields: {

--- a/turbo/packages/connectors/src/connectors/twilio.ts
+++ b/turbo/packages/connectors/src/connectors/twilio.ts
@@ -12,6 +12,10 @@ export const twilio = {
         label: "API Key",
         helpText:
           "1. Open the [Twilio Console](https://console.twilio.com) — your **Account SID** is shown on the dashboard\n2. Click **View** next to **Auth Token** to reveal the live auth token\n3. Copy both values and paste them below — the SID always starts with `AC`",
+        storage: {
+          secrets: ["TWILIO_ACCOUNT_SID", "TWILIO_AUTH_TOKEN"],
+          variables: [],
+        },
         grant: {
           kind: "manual",
           fields: {

--- a/turbo/packages/connectors/src/connectors/typeform.ts
+++ b/turbo/packages/connectors/src/connectors/typeform.ts
@@ -11,6 +11,10 @@ export const typeform = {
         label: "Personal Access Token",
         helpText:
           "1. Log in to [Typeform](https://admin.typeform.com)\n2. Open the account menu (top-right) and pick **Personal tokens**\n3. Click **Generate a new token**, name it, and choose the scopes you need (e.g. `forms:read`, `responses:read`, `webhooks:write`)\n4. Copy the token (format: `tfp_...`)",
+        storage: {
+          secrets: ["TYPEFORM_TOKEN"],
+          variables: [],
+        },
         grant: {
           kind: "manual",
           fields: {

--- a/turbo/packages/connectors/src/connectors/v0.ts
+++ b/turbo/packages/connectors/src/connectors/v0.ts
@@ -12,6 +12,10 @@ export const v0 = {
         label: "API Token",
         helpText:
           "1. Log in to [v0](https://v0.dev)\n2. Go to **Settings** → **Keys** ([direct link](https://v0.dev/chat/settings/keys))\n3. Create a new API key\n4. Copy the generated token",
+        storage: {
+          secrets: ["V0_TOKEN"],
+          variables: [],
+        },
         grant: {
           kind: "manual",
           fields: {

--- a/turbo/packages/connectors/src/connectors/vercel.ts
+++ b/turbo/packages/connectors/src/connectors/vercel.ts
@@ -16,6 +16,13 @@ export const vercel = {
           clientIdEnv: "VERCEL_OAUTH_CLIENT_ID",
           clientSecretEnv: "VERCEL_OAUTH_CLIENT_SECRET",
         },
+        storage: {
+          secrets: ["VERCEL_ACCESS_TOKEN"],
+          variables: [],
+          secretRoles: {
+            accessToken: "VERCEL_ACCESS_TOKEN",
+          },
+        },
         grant: {
           kind: "auth-code",
           tokenUrl: "https://api.vercel.com/v2/oauth/access_token",

--- a/turbo/packages/connectors/src/connectors/wandb.ts
+++ b/turbo/packages/connectors/src/connectors/wandb.ts
@@ -10,6 +10,10 @@ export const wandb = {
       "api-token": {
         label: "API Key",
         helpText: "Go to wandb.ai → Settings → API Keys → copy your key.",
+        storage: {
+          secrets: ["WANDB_TOKEN"],
+          variables: [],
+        },
         grant: {
           kind: "manual",
           fields: {

--- a/turbo/packages/connectors/src/connectors/webflow.ts
+++ b/turbo/packages/connectors/src/connectors/webflow.ts
@@ -18,6 +18,13 @@ export const webflow = {
           clientIdEnv: "WEBFLOW_OAUTH_CLIENT_ID",
           clientSecretEnv: "WEBFLOW_OAUTH_CLIENT_SECRET",
         },
+        storage: {
+          secrets: ["WEBFLOW_ACCESS_TOKEN"],
+          variables: [],
+          secretRoles: {
+            accessToken: "WEBFLOW_ACCESS_TOKEN",
+          },
+        },
         grant: {
           kind: "auth-code",
           tokenUrl: "https://api.webflow.com/oauth/access_token",
@@ -52,6 +59,10 @@ export const webflow = {
         label: "Site Token",
         helpText:
           "1. Log in to [Webflow](https://webflow.com) (site administrator access required)\n2. In your workspace, find the site and click the gear icon to open **Site Settings**\n3. In the left sidebar, select **Apps & integrations**\n4. Scroll to the bottom of the page to the **API access** section\n5. Click **Generate API token**\n6. Enter a name for your token and choose the required scopes\n7. Click **Generate token**\n8. Copy the generated token and save it in a secure location",
+        storage: {
+          secrets: ["WEBFLOW_TOKEN"],
+          variables: [],
+        },
         grant: {
           kind: "manual",
           fields: {

--- a/turbo/packages/connectors/src/connectors/weread.ts
+++ b/turbo/packages/connectors/src/connectors/weread.ts
@@ -21,6 +21,10 @@ export const weread = {
         label: "WeRead API Key",
         helpText:
           "1. Open the [WeRead Skill page](https://weread.qq.com/r/weread-skills)\n2. Scan the QR code with WeChat to sign in to your WeChat Reading account\n3. Copy the generated API key (it begins with `wrk-`)\n4. The key authorises every endpoint under `i.weread.qq.com` and is scoped to your own account data",
+        storage: {
+          secrets: ["WEREAD_TOKEN"],
+          variables: [],
+        },
         grant: {
           kind: "manual",
           fields: {

--- a/turbo/packages/connectors/src/connectors/whale-alert.ts
+++ b/turbo/packages/connectors/src/connectors/whale-alert.ts
@@ -11,6 +11,10 @@ export const whaleAlert = {
         label: "API Key",
         helpText:
           "1. Create a Whale Alert developer account\n2. Subscribe to the Custom Alerts or Enterprise REST API plan\n3. Copy the API key provided for your subscription\n4. Use this key as the `api_key` query parameter",
+        storage: {
+          secrets: ["WHALE_ALERT_API_KEY"],
+          variables: [],
+        },
         grant: {
           kind: "manual",
           fields: {

--- a/turbo/packages/connectors/src/connectors/wix.ts
+++ b/turbo/packages/connectors/src/connectors/wix.ts
@@ -11,6 +11,10 @@ export const wix = {
         label: "API Key",
         helpText:
           "1. Log in to your [Wix](https://www.wix.com) account (account owner or co-owner access required)\n2. Go to the [API Keys Manager](https://manage.wix.com/account/api-keys)\n3. Create a new API key and assign the required permissions\n4. Copy the generated API key and store it securely",
+        storage: {
+          secrets: ["WIX_TOKEN"],
+          variables: [],
+        },
         grant: {
           kind: "manual",
           fields: {

--- a/turbo/packages/connectors/src/connectors/workos.ts
+++ b/turbo/packages/connectors/src/connectors/workos.ts
@@ -11,6 +11,10 @@ export const workos = {
         label: "API Key",
         helpText:
           "Go to WorkOS Dashboard → API Keys → copy your secret key (starts with `sk_live_` for production or `sk_test_` for sandbox).",
+        storage: {
+          secrets: ["WORKOS_TOKEN"],
+          variables: [],
+        },
         grant: {
           kind: "manual",
           fields: {

--- a/turbo/packages/connectors/src/connectors/wrike.ts
+++ b/turbo/packages/connectors/src/connectors/wrike.ts
@@ -11,6 +11,10 @@ export const wrike = {
         label: "Permanent Access Token",
         helpText:
           "1. Navigate to your [Wrike](https://www.wrike.com) workspace\n2. Click on your **profile icon** in the navigation bar\n3. Select **Apps & Integrations**\n4. Click on **API**\n5. Click **+ App**\n6. Enter a name for your integration\n7. Click **Get Token** at the bottom of the window\n8. Copy and securely store your token — it will not be shown again after closing the page\n9. Click **Save**",
+        storage: {
+          secrets: ["WRIKE_TOKEN"],
+          variables: [],
+        },
         grant: {
           kind: "manual",
           fields: {

--- a/turbo/packages/connectors/src/connectors/x.ts
+++ b/turbo/packages/connectors/src/connectors/x.ts
@@ -18,6 +18,14 @@ export const x = {
           clientIdEnv: "X_OAUTH_CLIENT_ID",
           clientSecretEnv: "X_OAUTH_CLIENT_SECRET",
         },
+        storage: {
+          secrets: ["X_ACCESS_TOKEN", "X_REFRESH_TOKEN"],
+          variables: [],
+          secretRoles: {
+            accessToken: "X_ACCESS_TOKEN",
+            refreshToken: "X_REFRESH_TOKEN",
+          },
+        },
         grant: {
           kind: "auth-code",
           tokenUrl: OAUTH_TOKEN_URL,
@@ -49,8 +57,6 @@ export const x = {
         access: {
           kind: "refresh-token",
           tokenUrl: OAUTH_TOKEN_URL,
-          accessToken: "X_ACCESS_TOKEN",
-          refreshToken: "X_REFRESH_TOKEN",
           envBindings: {
             X_TOKEN: "$secrets.X_ACCESS_TOKEN",
           },

--- a/turbo/packages/connectors/src/connectors/xero.ts
+++ b/turbo/packages/connectors/src/connectors/xero.ts
@@ -18,6 +18,14 @@ export const xero = {
           clientIdEnv: "XERO_OAUTH_CLIENT_ID",
           clientSecretEnv: "XERO_OAUTH_CLIENT_SECRET",
         },
+        storage: {
+          secrets: ["XERO_ACCESS_TOKEN", "XERO_REFRESH_TOKEN"],
+          variables: [],
+          secretRoles: {
+            accessToken: "XERO_ACCESS_TOKEN",
+            refreshToken: "XERO_REFRESH_TOKEN",
+          },
+        },
         grant: {
           kind: "auth-code",
           tokenUrl: OAUTH_TOKEN_URL,
@@ -49,8 +57,6 @@ export const xero = {
         access: {
           kind: "refresh-token",
           tokenUrl: OAUTH_TOKEN_URL,
-          accessToken: "XERO_ACCESS_TOKEN",
-          refreshToken: "XERO_REFRESH_TOKEN",
           envBindings: {
             XERO_TOKEN: "$secrets.XERO_ACCESS_TOKEN",
           },

--- a/turbo/packages/connectors/src/connectors/youtube.ts
+++ b/turbo/packages/connectors/src/connectors/youtube.ts
@@ -11,6 +11,10 @@ export const youtube = {
         label: "API Key",
         helpText:
           "1. Go to [Google Cloud Console](https://console.cloud.google.com/)\n2. Enable **YouTube Data API v3**\n3. Go to **Credentials** → **Create Credentials** → **API Key**\n4. Copy the API key",
+        storage: {
+          secrets: ["YOUTUBE_TOKEN"],
+          variables: [],
+        },
         grant: {
           kind: "manual",
           fields: {

--- a/turbo/packages/connectors/src/connectors/zapier.ts
+++ b/turbo/packages/connectors/src/connectors/zapier.ts
@@ -11,6 +11,10 @@ export const zapier = {
       "api-token": {
         featureFlag: FeatureSwitchKey.ZapierConnector,
         label: "API Key",
+        storage: {
+          secrets: ["ZAPIER_TOKEN"],
+          variables: [],
+        },
         grant: {
           kind: "manual",
           fields: {

--- a/turbo/packages/connectors/src/connectors/zapsign.ts
+++ b/turbo/packages/connectors/src/connectors/zapsign.ts
@@ -11,6 +11,10 @@ export const zapsign = {
         label: "API Token",
         helpText:
           "1. Log in to your [ZapSign](https://app.zapsign.com) account\n2. Go to **Settings**\n3. Navigate to **Integrations**\n4. Select **ZAPSIGN API**\n5. Copy your API token",
+        storage: {
+          secrets: ["ZAPSIGN_TOKEN"],
+          variables: [],
+        },
         grant: {
           kind: "manual",
           fields: {

--- a/turbo/packages/connectors/src/connectors/zendesk.ts
+++ b/turbo/packages/connectors/src/connectors/zendesk.ts
@@ -11,6 +11,10 @@ export const zendesk = {
         label: "API Token",
         helpText:
           "1. Log in to [Zendesk Admin Center](https://www.zendesk.com/admin/)\n2. Go to **Apps and integrations → APIs → Zendesk API**\n3. Enable **Token Access** under the Settings tab\n4. Click **Add API token** and copy the token",
+        storage: {
+          secrets: ["ZENDESK_API_TOKEN"],
+          variables: ["ZENDESK_EMAIL", "ZENDESK_SUBDOMAIN"],
+        },
         grant: {
           kind: "manual",
           fields: {

--- a/turbo/packages/connectors/src/connectors/zep.ts
+++ b/turbo/packages/connectors/src/connectors/zep.ts
@@ -11,6 +11,10 @@ export const zep = {
         label: "API Key",
         helpText:
           "1. Log in to [app.getzep.com](https://app.getzep.com)\n2. Go to **Settings**\n3. Navigate to **API Keys**\n4. Click **Create API Key** and copy the key",
+        storage: {
+          secrets: ["ZEP_TOKEN"],
+          variables: [],
+        },
         grant: {
           kind: "manual",
           fields: {

--- a/turbo/packages/connectors/src/connectors/zeptomail.ts
+++ b/turbo/packages/connectors/src/connectors/zeptomail.ts
@@ -11,6 +11,10 @@ export const zeptomail = {
         label: "Send Mail Token",
         helpText:
           "1. Log in to [ZeptoMail](https://zeptomail.zoho.com)\n2. Select the Mail Agent for which you want to generate the API key\n3. Go to the **SMTP/API** tab\n4. In the **API** section, copy the **Agent alias** (agentkey)\n5. Submit a POST request to `https://api.zeptomail.com/v1.1/agents/{agentkey}/apikeys` with an `Authorization: Zoho-oauthtoken [your-token]` header\n6. The response will contain your send mail token (username and password)",
+        storage: {
+          secrets: ["ZEPTOMAIL_TOKEN"],
+          variables: [],
+        },
         grant: {
           kind: "manual",
           fields: {

--- a/turbo/packages/connectors/src/connectors/zoom.ts
+++ b/turbo/packages/connectors/src/connectors/zoom.ts
@@ -20,6 +20,14 @@ export const zoom = {
           clientIdEnv: "ZOOM_OAUTH_CLIENT_ID",
           clientSecretEnv: "ZOOM_OAUTH_CLIENT_SECRET",
         },
+        storage: {
+          secrets: ["ZOOM_ACCESS_TOKEN", "ZOOM_REFRESH_TOKEN"],
+          variables: [],
+          secretRoles: {
+            accessToken: "ZOOM_ACCESS_TOKEN",
+            refreshToken: "ZOOM_REFRESH_TOKEN",
+          },
+        },
         grant: {
           kind: "auth-code",
           tokenUrl: OAUTH_TOKEN_URL,
@@ -43,8 +51,6 @@ export const zoom = {
         access: {
           kind: "refresh-token",
           tokenUrl: OAUTH_TOKEN_URL,
-          accessToken: "ZOOM_ACCESS_TOKEN",
-          refreshToken: "ZOOM_REFRESH_TOKEN",
           envBindings: {
             ZOOM_TOKEN: "$secrets.ZOOM_ACCESS_TOKEN",
           },


### PR DESCRIPTION
## Summary
- add explicit per-auth-method connector storage ownership with secret role mapping
- migrate connector configs to declare owned secrets/variables and access/refresh token roles under storage
- rewire token writes, cleanup, run creation, provided env reporting, and firewall auth to use selected auth method storage metadata

Closes #15834

## Tests
- pnpm -F @vm0/connectors check-types
- pnpm -F @vm0/connectors test
- pnpm -F @vm0/connectors lint
- pnpm -F api check-types
- pnpm -F api exec vitest run src/signals/services/__tests__/zero-connector-data.service.test.ts src/signals/routes/__tests__/zero-runs-create.test.ts src/signals/routes/__tests__/zero-connectors-oauth-device-auth.test.ts src/signals/routes/__tests__/connectors-type-callback.test.ts src/signals/routes/__tests__/webhooks-agent-firewall-auth.test.ts
- pnpm -F api exec vitest run src/signals/routes/__tests__/zero-connectors-list.test.ts src/signals/routes/__tests__/zero-connectors-by-type-get.test.ts src/signals/routes/__tests__/zero-connectors-by-type-delete.test.ts src/signals/routes/__tests__/zero-connectors-manual-grant-connect.test.ts src/signals/routes/__tests__/zero-connectors-oauth-start.test.ts
- pnpm -F api lint
- pre-commit: pnpm check-types