### PR TITLE
fix: classify Claude Code session/weekly limits as usage limits

### DIFF
--- a/crates/guest-agent/src/main.rs
+++ b/crates/guest-agent/src/main.rs
@@ -343,8 +343,13 @@ fn classify_cli_failure_reason(
     {
         return Some(FailureReason::InvalidApiKey);
     }
-    if matches!(framework, AgentFramework::Codex)
-        && (normalized.contains("usage limit") || normalized.contains("session limit"))
+    // Subscription/usage limits are an expected quota state for both Codex
+    // (ChatGPT plan "usage limit") and Claude Code (Max plan "session limit" /
+    // "weekly limit"), so classify them regardless of framework. This lets the
+    // runner log these expected outcomes at info instead of error.
+    if normalized.contains("usage limit")
+        || normalized.contains("session limit")
+        || normalized.contains("weekly limit")
     {
         return Some(FailureReason::UsageLimit);
     }
@@ -1078,23 +1083,33 @@ mod tests {
     }
 
     #[test]
-    fn cli_failure_reason_ignores_non_codex_usage_limit() {
+    fn cli_failure_reason_classifies_claude_usage_limit() {
         let reason = classify_cli_failure_reason(
             AgentFramework::ClaudeCode,
             "Claude usage limit reached. Visit https://claude.ai/settings/usage.",
         );
 
-        assert_eq!(reason, None);
+        assert_eq!(reason, Some(FailureReason::UsageLimit));
     }
 
     #[test]
-    fn cli_failure_reason_ignores_non_codex_session_limit() {
+    fn cli_failure_reason_classifies_claude_session_limit() {
         let reason = classify_cli_failure_reason(
             AgentFramework::ClaudeCode,
-            "You've hit your session limit. Visit https://chatgpt.com/codex/settings/usage.",
+            "You've hit your session limit · resets 12:50pm (Asia/Shanghai)",
         );
 
-        assert_eq!(reason, None);
+        assert_eq!(reason, Some(FailureReason::UsageLimit));
+    }
+
+    #[test]
+    fn cli_failure_reason_classifies_claude_weekly_limit() {
+        let reason = classify_cli_failure_reason(
+            AgentFramework::ClaudeCode,
+            "You've hit your weekly limit · resets 10am (Asia/Shanghai)",
+        );
+
+        assert_eq!(reason, Some(FailureReason::UsageLimit));
     }
 
     #[test]


### PR DESCRIPTION
## Summary

Claude Code subscription-limit failures (`You've hit your session limit · resets …`, `You've hit your weekly limit · resets …`) were logged by the runner at **error** level, inflating runner error counts. These are expected user/account quota states, not runner/system failures, and should be logged at **info**.

## Root cause

`crates/guest-agent/src/main.rs::classify_cli_failure_reason` gated the usage/session-limit match to `AgentFramework::Codex`. Claude Code limits run as `AgentFramework::ClaudeCode`, so they never matched → `failure_reason = None` → `is_info_level_job_failure` returns false → logged at `error`.

`#15371` ("classify codex session limits as usage limits") was meant to fix `#15360`, but it added the `session limit` match behind the same `Codex` gate, so it never matched the real traffic (which is Claude Code).

## Production evidence (Axiom `vm0-web-logs-prod`, 30d)

`You've hit your session/weekly limit` → **57 occurrences, 100% `failure_framework=claude_code`, 100% `level=error`** (the single largest `job execution failed` class in the window).

## Change

In `classify_cli_failure_reason`, classify `usage limit` / `session limit` / `weekly limit` as `FailureReason::UsageLimit` **regardless of framework**, and add `weekly limit` to the matched phrases. The runner's existing info-level policy (`is_info_level_job_failure`) then routes these to `info`.

- `invalid_api_key` classification stays Codex-gated (unchanged).
- No user-facing behavior change (handled in #15782).
- guest-agent tests updated: the two former "non-Codex ignored" cases now assert `UsageLimit`, plus a new Claude weekly-limit case.

## Testing

⚠️ The `guest-agent` crate is a Linux target and does not compile on the macOS dev host (`process-control-ipc` uses Linux-only `libc::SOCK_CLOEXEC`), so `cargo test` / `clippy` were not run locally. `rustfmt --check` passes. Compile + unit tests + clippy are left to CI (Linux).

Relevant tests:
- `cli_failure_reason_classifies_claude_usage_limit`
- `cli_failure_reason_classifies_claude_session_limit`
- `cli_failure_reason_classifies_claude_weekly_limit`
- `expected_cli_failure_reasons_log_job_execution_failed_at_info` (runner, unchanged — already covers `UsageLimit` → info)

## Acceptance criteria

- [x] Claude `session limit` / `weekly limit` → `FailureReason::UsageLimit` → runner logs at `info`.
- [x] Codex usage-limit / invalid-key / insufficient-credits classification unchanged.
- [x] Unexpected `cli_nonzero` failures (overloaded, 401, bug-class, infra) remain at `error`.

Closes #15852

🤖 Generated with [Claude Code](https://claude.com/claude-code)