### PR TITLE
refactor: remove unused mitm request metadata

### DIFF
--- a/crates/runner/mitm-addon/src/mitm_addon.py
+++ b/crates/runner/mitm-addon/src/mitm_addon.py
@@ -404,7 +404,6 @@ async def request(flow: http.HTTPFlow) -> None:
     try:
         # Store info for response handler
         flow.metadata[metadata_keys.VM_RUN_ID] = run_id
-        flow.metadata["vm_client_ip"] = client_ip
         flow.metadata[metadata_keys.VM_NETWORK_LOG_PATH] = vm_info.get("networkLogPath", "")
         flow.metadata[metadata_keys.VM_PROXY_LOG_PATH] = vm_info.get("proxyLogPath", "")
         flow.metadata[metadata_keys.CAPTURE_BODY] = vm_info.get("captureNetworkBodies", False)
@@ -423,7 +422,6 @@ async def request(flow: http.HTTPFlow) -> None:
         original_url = trusted_authority.url
         flow.metadata[metadata_keys.ORIGINAL_URL] = original_url
         flow.metadata[metadata_keys.TRUSTED_AUTHORITY_HOST] = trusted_authority.host
-        flow.metadata["trusted_authority_port"] = trusted_authority.port
         _set_network_log_target(
             flow,
             url=original_url,

--- a/crates/runner/mitm-addon/tests/test_connector_usage.py
+++ b/crates/runner/mitm-addon/tests/test_connector_usage.py
@@ -577,7 +577,6 @@ class TestReportConnectorUsage:
         """responseheaders + response bill X JSON without full-body buffering."""
         flow = real_flow(with_response=False, host="api.x.com", path="/2/tweets")
         flow.metadata["vm_run_id"] = "run-abc-123"
-        flow.metadata["vm_client_ip"] = "10.200.0.1"
         flow.metadata["vm_network_log_path"] = str(tmp_path / "network.jsonl")
         flow.metadata["vm_proxy_log_path"] = str(tmp_path / "proxy.jsonl")
         flow.metadata["vm_sandbox_token"] = "test-token"
@@ -646,7 +645,6 @@ class TestReportConnectorUsage:
         """Selective X JSON extraction must count a top-level data object as one resource."""
         flow = real_flow(with_response=False, host="api.x.com", path="/2/tweets/1")
         flow.metadata["vm_run_id"] = "run-abc-123"
-        flow.metadata["vm_client_ip"] = "10.200.0.1"
         flow.metadata["vm_network_log_path"] = str(tmp_path / "network.jsonl")
         flow.metadata["vm_proxy_log_path"] = str(tmp_path / "proxy.jsonl")
         flow.metadata["vm_sandbox_token"] = "test-token"
@@ -679,7 +677,6 @@ class TestReportConnectorUsage:
         """Parsed X soft errors must not fall back to URL hints and bill missing resources."""
         flow = real_flow(with_response=False, host="api.x.com", path="/2/tweets")
         flow.metadata["vm_run_id"] = "run-abc-123"
-        flow.metadata["vm_client_ip"] = "10.200.0.1"
         flow.metadata["vm_network_log_path"] = str(tmp_path / "network.jsonl")
         flow.metadata["vm_proxy_log_path"] = str(tmp_path / "proxy.jsonl")
         flow.metadata["vm_sandbox_token"] = "test-token"
@@ -720,7 +717,6 @@ class TestReportConnectorUsage:
         """Non-object JSON roots stay unparsed so request-side hints still bill."""
         flow = real_flow(with_response=False, host="api.x.com", path="/2/tweets?ids=1,2,3")
         flow.metadata["vm_run_id"] = "run-abc-123"
-        flow.metadata["vm_client_ip"] = "10.200.0.1"
         flow.metadata["vm_network_log_path"] = str(tmp_path / "network.jsonl")
         flow.metadata["vm_proxy_log_path"] = str(tmp_path / "proxy.jsonl")
         flow.metadata["vm_sandbox_token"] = "test-token"
@@ -1574,7 +1570,6 @@ class TestReportConnectorUsage:
         """End-to-end: responseheaders registers parser, chunks accumulate, response() logs."""
         flow = real_flow(with_response=False, host="api.x.com", path="/2/tweets/search/stream")
         flow.metadata["vm_run_id"] = "run-abc-123"
-        flow.metadata["vm_client_ip"] = "10.200.0.1"
         flow.metadata["vm_network_log_path"] = str(tmp_path / "network.jsonl")
         flow.metadata["vm_proxy_log_path"] = str(tmp_path / "proxy.jsonl")
         flow.metadata["vm_sandbox_token"] = "test-token"
@@ -1626,7 +1621,6 @@ class TestReportConnectorUsage:
         """Malformed include values are ignored while valid siblings still bill."""
         flow = real_flow(with_response=False, host="api.x.com", path="/2/tweets/search/stream")
         flow.metadata["vm_run_id"] = "run-abc-123"
-        flow.metadata["vm_client_ip"] = "10.200.0.1"
         flow.metadata["vm_network_log_path"] = str(tmp_path / "network.jsonl")
         flow.metadata["vm_proxy_log_path"] = str(tmp_path / "proxy.jsonl")
         flow.metadata["vm_sandbox_token"] = "test-token"

--- a/crates/runner/mitm-addon/tests/test_model_provider_response_usage.py
+++ b/crates/runner/mitm-addon/tests/test_model_provider_response_usage.py
@@ -155,13 +155,10 @@ class TestModelProviderResponseUsage:
         tmp_path: Path,
         *,
         billable: bool = True,
-        client_ip: str | None = "10.200.0.1",
         proxy_log_path: Path | None = None,
         run_id: str = "run-abc-123",
     ) -> None:
         flow.metadata["vm_run_id"] = run_id
-        if client_ip is not None:
-            flow.metadata["vm_client_ip"] = client_ip
         flow.metadata["vm_network_log_path"] = str(tmp_path / "network.jsonl")
         if proxy_log_path is not None:
             flow.metadata["vm_proxy_log_path"] = str(proxy_log_path)
@@ -176,7 +173,6 @@ class TestModelProviderResponseUsage:
         provider_case: ModelProviderJsonCase,
         *,
         billable: bool = True,
-        client_ip: str | None = "10.200.0.1",
         proxy_log_path: Path | None = None,
         run_id: str = "run-abc-123",
     ) -> None:
@@ -184,7 +180,6 @@ class TestModelProviderResponseUsage:
             flow,
             tmp_path,
             billable=billable,
-            client_ip=client_ip,
             proxy_log_path=proxy_log_path,
             run_id=run_id,
         )
@@ -200,7 +195,6 @@ class TestModelProviderResponseUsage:
         provider_case: ModelProviderJsonCase,
         *,
         billable: bool = True,
-        client_ip: str | None = "10.200.0.1",
         proxy_log_path: Path | None = None,
         run_id: str = "run-abc-123",
     ):
@@ -210,7 +204,6 @@ class TestModelProviderResponseUsage:
             tmp_path,
             provider_case,
             billable=billable,
-            client_ip=client_ip,
             proxy_log_path=proxy_log_path,
             run_id=run_id,
         )
@@ -762,7 +755,6 @@ class TestModelProviderResponseUsage:
             tmp_path,
             OPENAI_RESPONSES_CASE,
             billable=False,
-            client_ip=None,
         )
         body = _standard_success_payload(OPENAI_RESPONSES_CASE)
         flow.metadata["stream_buffer"] = bytearray(body)
@@ -784,7 +776,6 @@ class TestModelProviderResponseUsage:
             tmp_path,
             OPENAI_RESPONSES_CASE,
             billable=False,
-            client_ip=None,
             proxy_log_path=proxy_log_path,
         )
         body = b'{"id":"resp_1","model":"gpt-5.5","usage":{"input_tokens":50'
@@ -983,7 +974,6 @@ class TestModelProviderResponseUsage:
             real_flow,
             tmp_path,
             ANTHROPIC_JSON_CASE,
-            client_ip=None,
             proxy_log_path=tmp_path / "proxy.jsonl",
         )
         flow.response = tutils.tresp(
@@ -1003,7 +993,6 @@ class TestModelProviderResponseUsage:
         flow = real_flow(with_response=False, host="api.github.com")
         proxy_log_path = tmp_path / "proxy.jsonl"
         flow.metadata["vm_run_id"] = "run-abc-123"
-        flow.metadata["vm_client_ip"] = "10.200.0.1"
         flow.metadata["vm_network_log_path"] = str(tmp_path / "network.jsonl")
         flow.metadata["vm_proxy_log_path"] = str(proxy_log_path)
         flow.metadata["firewall_action"] = "ALLOW"
@@ -1035,7 +1024,6 @@ class TestModelProviderResponseUsageWebhookDelivery:
         flow = real_flow(with_response=False, host="api.anthropic.com")
         log_path = str(tmp_path / "network.jsonl")
         flow.metadata["vm_run_id"] = "run-int-001"
-        flow.metadata["vm_client_ip"] = "10.200.0.1"
         flow.metadata["vm_network_log_path"] = log_path
         flow.metadata["firewall_action"] = "ALLOW"
         flow.metadata["original_url"] = "https://api.anthropic.com/v1/messages"

--- a/crates/runner/mitm-addon/tests/test_response_handler.py
+++ b/crates/runner/mitm-addon/tests/test_response_handler.py
@@ -32,7 +32,6 @@ class TestResponseHandler:
 
         # Simulate request handler setting metadata
         flow.metadata["vm_run_id"] = "run-abc-123"
-        flow.metadata["vm_client_ip"] = "10.200.0.1"
 
         flow.metadata["vm_network_log_path"] = log_path
         flow.metadata["firewall_action"] = "ALLOW"
@@ -167,7 +166,6 @@ class TestResponseHandler:
         log_path = str(tmp_path / "network.jsonl")
 
         flow.metadata["vm_run_id"] = "run-abc-123"
-        flow.metadata["vm_client_ip"] = "10.200.0.1"
         flow.metadata["vm_network_log_path"] = log_path
         flow.metadata["firewall_action"] = "ALLOW"
         flow.metadata["original_url"] = "https://api.example.com/"
@@ -196,7 +194,6 @@ class TestResponseHandler:
         body = b"x" * (body_utils.STREAM_BUFFER_LIMIT + 4096)
 
         flow.metadata["vm_run_id"] = "run-abc-123"
-        flow.metadata["vm_client_ip"] = "10.200.0.1"
         flow.metadata["vm_network_log_path"] = log_path
         flow.metadata["firewall_action"] = "ALLOW"
         flow.metadata["original_url"] = "https://api.example.com/"
@@ -226,7 +223,6 @@ class TestResponseHandler:
         log_path = str(tmp_path / "network.jsonl")
 
         flow.metadata["vm_run_id"] = "run-abc-123"
-        flow.metadata["vm_client_ip"] = "10.200.0.1"
         flow.metadata["vm_network_log_path"] = log_path
         flow.metadata["firewall_action"] = "ALLOW"
         flow.metadata["original_url"] = "https://api.example.com/"
@@ -249,7 +245,6 @@ class TestResponseHandler:
         log_path = str(tmp_path / "network.jsonl")
 
         flow.metadata["vm_run_id"] = "run-abc-123"
-        flow.metadata["vm_client_ip"] = "10.200.0.1"
         flow.metadata["vm_network_log_path"] = log_path
         flow.metadata["firewall_action"] = "ALLOW"
         flow.metadata["original_url"] = "https://api.example.com/"
@@ -270,7 +265,6 @@ class TestResponseHandler:
         log_path = str(tmp_path / "network.jsonl")
 
         flow.metadata["vm_run_id"] = "run-abc-123"
-        flow.metadata["vm_client_ip"] = "10.200.0.1"
         flow.metadata["vm_network_log_path"] = log_path
         flow.metadata["firewall_action"] = "ALLOW"
         flow.metadata["original_url"] = "https://api.example.com/"
@@ -320,7 +314,6 @@ class TestResponseHandler:
         """401 response with firewall_base pops the cache entry and marks force-refresh (#9860)."""
         flow = real_flow(with_response=False, host="api.github.com")
         flow.metadata["vm_run_id"] = "run-conn-1"
-        flow.metadata["vm_client_ip"] = "10.200.0.5"
 
         flow.metadata["vm_network_log_path"] = ""
         flow.metadata["firewall_action"] = "ALLOW"
@@ -347,7 +340,6 @@ class TestResponseHandler:
         """401 should request a forced refresh even if no cache entry exists yet."""
         flow = real_flow(with_response=False, host="api.github.com")
         flow.metadata["vm_run_id"] = "run-conn-new"
-        flow.metadata["vm_client_ip"] = "10.200.0.5"
         flow.metadata["vm_network_log_path"] = ""
         flow.metadata["firewall_action"] = "ALLOW"
         flow.metadata["firewall_base"] = "https://api.github.com"
@@ -371,7 +363,6 @@ class TestResponseHandler:
         hit the provider's rate limits (#9860)."""
         flow = real_flow(with_response=False, host="api.github.com")
         flow.metadata["vm_run_id"] = "run-conn-cd"
-        flow.metadata["vm_client_ip"] = "10.200.0.5"
         flow.metadata["vm_network_log_path"] = ""
         flow.metadata["firewall_action"] = "ALLOW"
         flow.metadata["firewall_base"] = "https://api.github.com"
@@ -399,7 +390,6 @@ class TestResponseHandler:
         token-invalidation recovery (#9860)."""
         flow = real_flow(with_response=False, host="api.github.com")
         flow.metadata["vm_run_id"] = "run-conn-re"
-        flow.metadata["vm_client_ip"] = "10.200.0.5"
         flow.metadata["vm_network_log_path"] = ""
         flow.metadata["firewall_action"] = "ALLOW"
         flow.metadata["firewall_base"] = "https://api.github.com"
@@ -424,7 +414,6 @@ class TestResponseHandler:
         """Response with status >= 400 writes to per-job proxy log."""
         flow = real_flow(with_response=False, host="api.example.com")
         flow.metadata["vm_run_id"] = "run-abc-123"
-        flow.metadata["vm_client_ip"] = "10.200.0.1"
 
         proxy_log = tmp_path / "proxy-run-abc-123.jsonl"
         flow.metadata["vm_network_log_path"] = ""


### PR DESCRIPTION
## Summary

- remove unused `vm_client_ip` and `trusted_authority_port` writes from the mitm request hook
- clean stale `vm_client_ip` fixture setup from response, connector usage, and model provider response tests
- keep the real metadata contracts intact through `TRUSTED_AUTHORITY_HOST` and `NETWORK_LOG_TARGET`

Closes #15837.

## Tests

- `cd crates/runner/mitm-addon && python3 -m pytest tests/test_response_handler.py tests/test_connector_usage.py tests/test_model_provider_response_usage.py tests/test_request_handler_authority_validation.py -v`
- `cd crates/runner/mitm-addon && ruff check .`
- `cd crates/runner/mitm-addon && ruff format --check .`
- `cd crates/runner/mitm-addon && basedpyright -p .`
- `cd crates/runner/mitm-addon && python3 -m pytest tests/ -v`
