### PR TITLE
fix: require https for auth base rewrites

### DIFF
--- a/crates/runner/mitm-addon/src/auth_base_forwarder.py
+++ b/crates/runner/mitm-addon/src/auth_base_forwarder.py
@@ -1,4 +1,4 @@
-"""HTTP forwarding for auth.base URL rewrites.
+"""HTTPS forwarding for auth.base URL rewrites.
 
 The addon forwards auth.base requests itself because mitmproxy's eager
 connection has already connected to the placeholder IP. This module owns
@@ -24,7 +24,6 @@ HOP_BY_HOP: frozenset[str] = frozenset(
         "upgrade",
     )
 )
-DEFAULT_HTTP_PORT = 80
 DEFAULT_HTTPS_PORT = 443
 MAX_AUTH_BASE_RESPONSE_BODY_BYTES = 32 * 1024 * 1024
 MAX_CONCURRENT_AUTH_BASE_FORWARDS = 4
@@ -116,11 +115,7 @@ def _host_header(parsed: urllib.parse.SplitResult) -> str:
         port = parsed.port
     except ValueError as exc:
         raise ValueError("Invalid upstream URL: invalid port") from exc
-    if (
-        port is None
-        or (parsed.scheme == "https" and port == DEFAULT_HTTPS_PORT)
-        or (parsed.scheme == "http" and port == DEFAULT_HTTP_PORT)
-    ):
+    if port is None or port == DEFAULT_HTTPS_PORT:
         return host
     return f"{host}:{port}"
 
@@ -135,8 +130,6 @@ def _request_target(parsed: urllib.parse.SplitResult) -> str:
 def _connection_cls(scheme: str):
     if scheme == "https":
         return http_client.HTTPSConnection
-    if scheme == "http":
-        return http_client.HTTPConnection
     raise ValueError(f"Unsupported URL scheme: {scheme}")
 
 
@@ -170,13 +163,13 @@ def _forward_request_sync(
     headers: list[tuple[str, str]],
     body: bytes | None,
 ) -> tuple[int, bytes, http.Headers]:
-    """Forward an HTTP request to the real URL and return (status, body, headers).
+    """Forward an HTTPS request to the real URL and return (status, body, headers).
 
-    Security: only https/http schemes are allowed, and redirects are returned
+    Security: only https URLs are allowed, and redirects are returned
     to the sandbox client instead of being followed inside the addon.
     """
     parsed = urllib.parse.urlsplit(url)
-    conn_cls = _connection_cls(parsed.scheme)
+    conn_cls = _connection_cls(parsed.scheme.lower())
     _reject_userinfo(parsed)
     host = parsed.hostname
     if not host:

--- a/crates/runner/mitm-addon/src/matching.py
+++ b/crates/runner/mitm-addon/src/matching.py
@@ -59,6 +59,7 @@ _VALID_RULE_METHODS = frozenset(
     )
 )
 _VALID_BASE_SCHEMES = frozenset(("http", "https"))
+_VALID_AUTH_BASE_SCHEME = "https"
 _DEFAULT_SCHEME_PORTS = MappingProxyType({"http": 80, "https": 443})
 _AUTH_TEMPLATE_START = "${{"
 _AUTH_REFERENCE_PATTERN = re.compile(r"\$\{\{\s*(?:secrets|vars)\.[a-zA-Z_][a-zA-Z0-9_]*\s*\}\}")
@@ -775,7 +776,7 @@ def _static_auth_base_is_valid(auth_base: str) -> bool:
         parts = urlsplit(validation_url)
     except ValueError:
         return False
-    if parts.scheme.lower() not in _VALID_BASE_SCHEMES:
+    if parts.scheme.lower() != _VALID_AUTH_BASE_SCHEME:
         return False
     if parts.fragment:
         return False

--- a/crates/runner/mitm-addon/src/url_utils.py
+++ b/crates/runner/mitm-addon/src/url_utils.py
@@ -32,7 +32,7 @@ _HEX_DIGITS = frozenset("0123456789abcdefABCDEF")
 _PERCENT_DECODED_HOST_SYNTAX_CHARS = frozenset("{}.\u3002\uff0e\uff61,")
 _URL_PATH_SAFE_CHARS = "/%:@!$&'()*+,;="
 _URL_QUERY_SAFE_CHARS = "/?%:@!$&'()*+,;="
-_VALID_REWRITE_SCHEMES = frozenset(("http", "https"))
+_VALID_AUTH_BASE_SCHEME = "https"
 
 
 @dataclass(frozen=True)
@@ -445,8 +445,8 @@ def _validated_rewrite_base(resolved_base: str) -> tuple[urllib.parse.SplitResul
         )
 
     parsed = urllib.parse.urlsplit(resolved_base)
-    if parsed.scheme.lower() not in _VALID_REWRITE_SCHEMES:
-        raise ValueError("Invalid auth.base URL: scheme must be http or https")
+    if parsed.scheme.lower() != _VALID_AUTH_BASE_SCHEME:
+        raise ValueError("Invalid auth.base URL: scheme must be https")
     if not parsed.netloc:
         raise ValueError("Invalid auth.base URL: missing host")
     if parsed.username is not None or parsed.password is not None:

--- a/crates/runner/mitm-addon/tests/test_auth_base_forwarder.py
+++ b/crates/runner/mitm-addon/tests/test_auth_base_forwarder.py
@@ -4,7 +4,7 @@ import asyncio
 import contextlib
 import threading
 from collections.abc import Iterator
-from typing import Literal, NamedTuple
+from typing import NamedTuple
 from unittest.mock import MagicMock, call, patch
 
 import pytest
@@ -21,7 +21,6 @@ class ForwarderConnectionPatch(NamedTuple):
 @contextlib.contextmanager
 def _patched_forwarder_connection(
     *,
-    scheme: Literal["http", "https"] = "https",
     status: int = 200,
     body: bytes = b"ok",
     headers: list[tuple[str, str]] | None = None,
@@ -45,8 +44,7 @@ def _patched_forwarder_connection(
     else:
         conn.getresponse.side_effect = getresponse_side_effect
 
-    connection_name = "HTTPSConnection" if scheme == "https" else "HTTPConnection"
-    with patch.object(forwarder.http_client, connection_name, return_value=conn) as cls:
+    with patch.object(forwarder.http_client, "HTTPSConnection", return_value=conn) as cls:
         yield ForwarderConnectionPatch(conn=conn, resp=resp, connection_cls=cls)
 
 
@@ -58,6 +56,16 @@ class TestAuthBaseForwarderSecurity:
     def test_rejects_ftp_scheme(self):
         with pytest.raises(ValueError, match="Unsupported URL scheme"):
             forwarder._forward_request_sync("ftp://evil.com/file", "GET", [], None)
+
+    def test_rejects_http_scheme_without_opening_connection(self):
+        with (
+            patch.object(forwarder.http_client, "HTTPConnection") as http_conn,
+            patch.object(forwarder.http_client, "HTTPSConnection") as https_conn,
+            pytest.raises(ValueError, match="Unsupported URL scheme"),
+        ):
+            forwarder._forward_request_sync("http://example.com/path", "GET", [], None)
+        http_conn.assert_not_called()
+        https_conn.assert_not_called()
 
     def test_rejects_empty_scheme(self):
         with pytest.raises(ValueError, match="Unsupported URL scheme"):
@@ -76,8 +84,6 @@ class TestAuthBaseForwarderSecurity:
         [
             "https://user@example.com/path",
             "https://user:pass@example.com/path",
-            "http://user@example.com/path",
-            "http://user:pass@example.com/path",
         ],
     )
     def test_rejects_userinfo_authority(self, url):
@@ -228,7 +234,6 @@ class TestAuthBaseForwarderSecurity:
     @pytest.mark.parametrize(
         (
             "url",
-            "scheme",
             "expected_connection_host",
             "expected_connection_port",
             "expected_host_header",
@@ -236,23 +241,13 @@ class TestAuthBaseForwarderSecurity:
         [
             pytest.param(
                 "https://example.com:443/path",
-                "https",
                 "example.com",
                 443,
                 "example.com",
                 id="https-default-port",
             ),
             pytest.param(
-                "http://example.com:80/path",
-                "http",
-                "example.com",
-                80,
-                "example.com",
-                id="http-default-port",
-            ),
-            pytest.param(
                 "https://[2001:db8::1]:444/path",
-                "https",
                 "2001:db8::1",
                 444,
                 "[2001:db8::1]:444",
@@ -260,7 +255,6 @@ class TestAuthBaseForwarderSecurity:
             ),
             pytest.param(
                 "https://[2001:db8::1]/path",
-                "https",
                 "2001:db8::1",
                 None,
                 "[2001:db8::1]",
@@ -268,55 +262,28 @@ class TestAuthBaseForwarderSecurity:
             ),
             pytest.param(
                 "https://[2001:db8::1]:443/path",
-                "https",
                 "2001:db8::1",
                 443,
                 "[2001:db8::1]",
                 id="ipv6-https-default-port",
             ),
             pytest.param(
-                "http://[2001:db8::1]:80/path",
-                "http",
-                "2001:db8::1",
-                80,
-                "[2001:db8::1]",
-                id="ipv6-http-default-port",
-            ),
-            pytest.param(
-                "http://[2001:db8::1]:8080/path",
-                "http",
-                "2001:db8::1",
-                8080,
-                "[2001:db8::1]:8080",
-                id="ipv6-http-non-default-port",
-            ),
-            pytest.param(
                 "https://[2001:db8::1]:80/path",
-                "https",
                 "2001:db8::1",
                 80,
                 "[2001:db8::1]:80",
                 id="ipv6-https-http-default-port",
-            ),
-            pytest.param(
-                "http://[2001:db8::1]:443/path",
-                "http",
-                "2001:db8::1",
-                443,
-                "[2001:db8::1]:443",
-                id="ipv6-http-https-default-port",
             ),
         ],
     )
     def test_url_authority_sets_connection_target_and_host_header(
         self,
         url: str,
-        scheme: Literal["http", "https"],
         expected_connection_host: str,
         expected_connection_port: int | None,
         expected_host_header: str,
     ):
-        with _patched_forwarder_connection(scheme=scheme) as upstream:
+        with _patched_forwarder_connection() as upstream:
             forwarder._forward_request_sync(
                 url,
                 "GET",
@@ -641,9 +608,16 @@ class TestForwardRequestAsyncWrapper:
         assert forwarding_thread_ids
         assert all(thread_id != event_loop_thread_id for thread_id in forwarding_thread_ids)
 
-    async def test_propagates_validation_errors(self):
+    @pytest.mark.parametrize(
+        "url",
+        [
+            "file:///etc/passwd",
+            "http://example.com",
+        ],
+    )
+    async def test_propagates_validation_errors(self, url):
         with pytest.raises(ValueError, match="Unsupported URL scheme"):
-            await forwarder.forward_request("file:///etc/passwd", "GET", [], None)
+            await forwarder.forward_request(url, "GET", [], None)
 
     async def test_closes_connection_when_request_raises(self):
         event_loop_thread_id = threading.get_ident()

--- a/crates/runner/mitm-addon/tests/test_compiled_firewall_matching.py
+++ b/crates/runner/mitm-addon/tests/test_compiled_firewall_matching.py
@@ -3685,6 +3685,8 @@ class TestCompiledFirewallMatching:
             {"base": None},
             {"base": 123},
             {"base": "ftp://example.com/hook"},
+            {"base": "http://example.com/hook"},
+            {"base": "http://${{ vars.WEBHOOK_HOST }}/hook"},
             {"base": "https:/example.com/hook"},
             {"base": "https:///hook"},
             {"base": "https://example.com/hook#fragment"},

--- a/crates/runner/mitm-addon/tests/test_firewall_rewrite.py
+++ b/crates/runner/mitm-addon/tests/test_firewall_rewrite.py
@@ -723,6 +723,50 @@ class TestAuthBaseUrlRewriteEdgeCases:
             assert "super-secret-token" not in json.dumps(log_call.args)
             assert "super-secret-token" not in json.dumps(log_call.kwargs)
 
+    async def test_resolved_base_http_fails_closed_without_forwarding(
+        self, headers, real_flow, mitm_ctx, tmp_path
+    ):
+        """Secret-backed auth.base upstream URLs must not use cleartext HTTP."""
+        flow, allow, vm_info, token_meta = make_rewrite_inputs(
+            real_flow,
+            tmp_path,
+            path="/hook?client=visible",
+            request_headers=headers(
+                ("Host", "firewall-placeholder.vm3.ai"),
+                ("Authorization", "Bearer agent"),
+            ),
+            resolved_base="http://real.example.com/webhook/super-secret-token",
+            token_overrides={
+                "headers": {
+                    "Authorization": "Bearer real-token",
+                    "X-Custom": "injected-value",
+                },
+                "query": {"api_key": "resolved-key"},
+            },
+        )
+        mock_forward = AsyncMock()
+        mock_log = MagicMock()
+        with (
+            patch.object(auth, "get_firewall_headers", AsyncMock(return_value=token_meta)),
+            patch.object(auth, "forward_request", mock_forward),
+            patch.object(auth, "log_proxy_entry", mock_log),
+            mitm_ctx(),
+        ):
+            await auth.handle_firewall_request(flow, allow, vm_info)
+
+        assert mock_forward.call_count == 0
+        assert flow.response is not None
+        assert flow.response.status_code == 502
+        assert flow.metadata["firewall_error"] == "url_rewrite_forward_failed"
+        assert "super-secret-token" not in flow.response.text
+        assert flow.request.headers["Authorization"] == "Bearer agent"
+        assert "X-Custom" not in flow.request.headers
+        assert "api_key" not in flow.request.query
+        assert flow.request.query["client"] == "visible"
+        for log_call in mock_log.call_args_list:
+            assert "super-secret-token" not in json.dumps(log_call.args)
+            assert "super-secret-token" not in json.dumps(log_call.kwargs)
+
     async def test_resolved_base_fragment_fails_closed_without_forwarding(
         self, real_flow, mitm_ctx, tmp_path
     ):

--- a/crates/runner/mitm-addon/tests/test_url_utils.py
+++ b/crates/runner/mitm-addon/tests/test_url_utils.py
@@ -104,6 +104,7 @@ class TestBuildRewriteUrl:
             ("https://example.com/\x7fhook", "control characters or invalid Unicode"),
             ("https://example.com/\ud800hook", "control characters or invalid Unicode"),
             ("ftp://example.com/hook", "scheme"),
+            ("http://example.com/hook", "scheme must be https"),
             ("https:///hook", "missing host"),
             ("https://user:pass@example.com/hook", "userinfo"),
             ("https://exa mple.com/hook", "whitespace"),

--- a/turbo/packages/connectors/src/__tests__/firewall-expander.test.ts
+++ b/turbo/packages/connectors/src/__tests__/firewall-expander.test.ts
@@ -259,7 +259,15 @@ describe("resolveFirewallSelections", () => {
 
     expect(() => {
       return collectAndValidatePermissions(config("ftp://example.com/hook"));
-    }).toThrow("scheme must be http or https");
+    }).toThrow("scheme must be https");
+    expect(() => {
+      return collectAndValidatePermissions(config("http://example.com/hook"));
+    }).toThrow("scheme must be https");
+    expect(() => {
+      return collectAndValidatePermissions(
+        config("http://${{ vars.WEBHOOK_HOST }}/hook"),
+      );
+    }).toThrow("scheme must be https");
     expect(() => {
       return collectAndValidatePermissions(config("https:/example.com/hook"));
     }).toThrow('URL must include "://" after the scheme');

--- a/turbo/packages/connectors/src/__tests__/firewall-rule-matcher.test.ts
+++ b/turbo/packages/connectors/src/__tests__/firewall-rule-matcher.test.ts
@@ -1297,6 +1297,11 @@ describe("findMatchingPermissions", () => {
           permissions: [{ name: "bad-auth", rules: ["GET /items/{id}"] }],
         },
         {
+          base: "https://cleartext-auth.example.com",
+          auth: { base: "http://auth.example.com/token" },
+          permissions: [{ name: "cleartext-auth", rules: ["GET /items/{id}"] }],
+        },
+        {
           base: "https://valid.example.com",
           auth: { headers: {} },
           permissions: [{ name: "valid", rules: ["GET /items/{id}"] }],
@@ -1315,6 +1320,11 @@ describe("findMatchingPermissions", () => {
     expect(
       findMatchingPermissions("GET", "/items/1", malformedApiConfig, {
         apiBase: "https://auth.example.com",
+      }),
+    ).toEqual([]);
+    expect(
+      findMatchingPermissions("GET", "/items/1", malformedApiConfig, {
+        apiBase: "https://cleartext-auth.example.com",
       }),
     ).toEqual([]);
   });

--- a/turbo/packages/connectors/src/firewall-types.ts
+++ b/turbo/packages/connectors/src/firewall-types.ts
@@ -756,6 +756,7 @@ const HOST_DOT_EQUIVALENTS = new Set([".", "\u3002", "\uff0e", "\uff61"]);
 const HOST_DOT_EQUIVALENT_PATTERN = /[\u3002\uff0e\uff61]/g;
 const FORBIDDEN_NORMALIZED_LABEL_CHARS = new Set("#%,/:<>?@[\\]^|[]".split(""));
 const ALLOWED_BASE_URL_SCHEMES = new Set(["http", "https"]);
+const REQUIRED_AUTH_BASE_URL_SCHEME = "https";
 const WHITESPACE_PATTERN = /\s/u;
 const UNICODE_CONTROL_PATTERN = /\p{C}/u;
 const UNICODE_MARK_PATTERN = /\p{M}/u;
@@ -839,9 +840,17 @@ function validateUrlSchemeDelimiter(
   const colonIndex = value.indexOf(":");
   if (colonIndex !== -1) {
     const scheme = value.slice(0, colonIndex);
-    if (!ALLOWED_BASE_URL_SCHEMES.has(scheme.toLowerCase())) {
+    const schemeDetail =
+      label === "auth.base URL"
+        ? "scheme must be https"
+        : "scheme must be http or https";
+    const allowedScheme =
+      label === "auth.base URL"
+        ? scheme.toLowerCase() === REQUIRED_AUTH_BASE_URL_SCHEME
+        : ALLOWED_BASE_URL_SCHEMES.has(scheme.toLowerCase());
+    if (!allowedScheme) {
       throw new Error(
-        `Invalid ${label} "${displayValue}" in firewall "${serviceName}": scheme must be http or https`,
+        `Invalid ${label} "${displayValue}" in firewall "${serviceName}": ${schemeDetail}`,
       );
     }
     throw new Error(
@@ -1715,9 +1724,11 @@ export function validateAuthBaseUrl(
       `Invalid auth.base URL "${authBase}" in firewall "${serviceName}": not a valid URL`,
     );
   }
-  if (!ALLOWED_BASE_URL_SCHEMES.has(url.protocol.slice(0, -1).toLowerCase())) {
+  if (
+    url.protocol.slice(0, -1).toLowerCase() !== REQUIRED_AUTH_BASE_URL_SCHEME
+  ) {
     throw new Error(
-      `Invalid auth.base URL "${authBase}" in firewall "${serviceName}": scheme must be http or https`,
+      `Invalid auth.base URL "${authBase}" in firewall "${serviceName}": scheme must be https`,
     );
   }
   if (url.hash) {


### PR DESCRIPTION
## Summary

- require HTTPS for static and resolved `auth.base` rewrite upstreams
- keep ordinary firewall `base` HTTP support unchanged
- remove the auth.base forwarder's HTTPConnection path and add fail-closed coverage for resolved HTTP secrets

Closes #15836

## Tests

- `/tmp/mitm-addon-test-venv/bin/python -m ruff check src/auth_base_forwarder.py src/matching.py src/url_utils.py tests/test_auth_base_forwarder.py tests/test_compiled_firewall_matching.py tests/test_firewall_rewrite.py tests/test_url_utils.py`
- `/tmp/mitm-addon-test-venv/bin/python -m ruff format --check src/auth_base_forwarder.py src/matching.py src/url_utils.py tests/test_auth_base_forwarder.py tests/test_compiled_firewall_matching.py tests/test_firewall_rewrite.py tests/test_url_utils.py`
- `/tmp/mitm-addon-test-venv/bin/pytest tests/test_url_utils.py tests/test_firewall_rewrite.py tests/test_auth_base_forwarder.py tests/test_compiled_firewall_matching.py`
- `pnpm -F @vm0/connectors lint`
- `pnpm -F @vm0/connectors exec vitest src/__tests__/firewall-rule-matcher.test.ts`
- `pnpm -F @vm0/connectors exec tsx -e "...validateAuthBaseUrl/validateBaseUrl contract check..."`
- `pnpm exec prettier --check packages/connectors/src/firewall-types.ts packages/connectors/src/__tests__/firewall-expander.test.ts`

## Known Local Blocker

- `pnpm -F @vm0/connectors check-types` currently fails on `src/firewalls/index.ts(143,33): Cannot find module './hitem3d.generated'`. `origin/main` already references this missing generated file, so I kept that unrelated generated-firewall fix out of this PR.
- The combined targeted vitest command including `src/__tests__/firewall-expander.test.ts` hits the same missing generated import before the changed auth.base assertions can run. The isolated `firewall-rule-matcher` test and direct `validateAuthBaseUrl` contract check pass.
