### PR TITLE
fix(web): hide internal clerk error text constants

### DIFF
--- a/turbo/apps/web/app/components/auth/__tests__/banned-account-message.test.ts
+++ b/turbo/apps/web/app/components/auth/__tests__/banned-account-message.test.ts
@@ -4,11 +4,7 @@ import { renderToStaticMarkup } from "react-dom/server";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import RootLayout from "../../../layout";
 import { reloadEnv } from "../../../../src/env";
-import {
-  CLERK_BANNED_ACCOUNT_ERROR_TEXT,
-  CLERK_NOT_ALLOWED_ACCESS_ERROR_TEXT,
-  VM0_CLERK_LOCALIZATION,
-} from "../banned-account-message";
+import { VM0_CLERK_LOCALIZATION } from "../banned-account-message";
 
 const clerkProviderProps = vi.hoisted(() => {
   return {
@@ -113,14 +109,17 @@ describe("VM0_CLERK_LOCALIZATION", () => {
     expect(clerkProviderProps.current?.localization).toBe(
       VM0_CLERK_LOCALIZATION,
     );
-    expect(VM0_CLERK_LOCALIZATION.unstable__errors.user_banned).toBe(
-      CLERK_BANNED_ACCOUNT_ERROR_TEXT,
+    expect(VM0_CLERK_LOCALIZATION.unstable__errors.user_banned).toContain(
+      "support@vm0.ai",
+    );
+    expect(VM0_CLERK_LOCALIZATION.unstable__errors.user_banned).toContain(
+      "violated the vm0 Terms of Use",
     );
     expect(VM0_CLERK_LOCALIZATION.unstable__errors.not_allowed_access).toBe(
-      CLERK_NOT_ALLOWED_ACCESS_ERROR_TEXT,
+      "Access is not allowed.",
     );
-    expect(CLERK_BANNED_ACCOUNT_ERROR_TEXT).not.toBe(
-      CLERK_NOT_ALLOWED_ACCESS_ERROR_TEXT,
+    expect(VM0_CLERK_LOCALIZATION.unstable__errors.user_banned).not.toBe(
+      VM0_CLERK_LOCALIZATION.unstable__errors.not_allowed_access,
     );
   });
 });

--- a/turbo/apps/web/app/components/auth/banned-account-message.ts
+++ b/turbo/apps/web/app/components/auth/banned-account-message.ts
@@ -1,6 +1,6 @@
-export const CLERK_BANNED_ACCOUNT_ERROR_TEXT =
+const CLERK_BANNED_ACCOUNT_ERROR_TEXT =
   "Account access suspended because activity on this account violated the vm0 Terms of Use. If you have questions, contact support@vm0.ai.";
-export const CLERK_NOT_ALLOWED_ACCESS_ERROR_TEXT = "Access is not allowed.";
+const CLERK_NOT_ALLOWED_ACCESS_ERROR_TEXT = "Access is not allowed.";
 
 export const VM0_CLERK_LOCALIZATION = {
   unstable__errors: {


### PR DESCRIPTION
## Summary
- keep the Clerk banned-account error text constants internal to the localization module
- update the auth layout test to assert the exported `VM0_CLERK_LOCALIZATION` object instead of test-only constant exports

## Why
- `pnpm knip --workspace web --production` excludes tests as consumers, so exported constants that are only imported by tests are reported as unused production exports

## Validation
- `pnpm knip --workspace web --production`
- `pnpm knip --workspace web`
- `pnpm -F web lint`
- `pnpm -F web check-types`
- `pnpm -F web exec vitest run app/components/auth/__tests__/banned-account-message.test.ts`
- `pnpm format`
- pre-commit: prettier, knip, full `pnpm check-types`