### PR TITLE
fix: validate mock claude echo session ids

### DIFF
--- a/crates/guest-mock-claude/src/main.rs
+++ b/crates/guest-mock-claude/src/main.rs
@@ -34,6 +34,7 @@
 
 use serde_json::{Value, json};
 use std::io::Write;
+use std::path::{Component, Path, PathBuf};
 use std::process::{Command, ExitCode, Stdio};
 use std::time::{Duration, SystemTime, UNIX_EPOCH};
 
@@ -150,13 +151,10 @@ fn echo_session_id(events: &[(String, Value)]) -> Option<&str> {
     })
 }
 
-fn write_echo_session_history(events: &[(String, Value)]) {
-    let Some(session_id) = echo_session_id(events) else {
-        return;
-    };
-
-    if let Some(path) = create_session_history(session_id)
-        && let Ok(mut file) = std::fs::File::create(&path)
+fn write_echo_session_history(events: &[(String, Value)], session_id: Option<&str>) {
+    if let Some(session_id) = session_id
+        && let Some(path) = create_session_history(session_id)
+        && let Ok(mut file) = std::fs::File::create(path)
     {
         for (line, _) in events {
             let _ = writeln!(file, "{line}");
@@ -173,10 +171,18 @@ fn run_echo_jsonl_mode(payload: &str) -> ExitCode {
         }
     };
 
+    let session_id = echo_session_id(&events);
+    if let Some(session_id) = session_id
+        && !is_valid_session_history_id(session_id)
+    {
+        eprintln!("invalid @ECHO@ session_id: {session_id:?}");
+        return ExitCode::from(1);
+    }
+
     for (line, _) in &events {
         println!("{line}");
     }
-    write_echo_session_history(&events);
+    write_echo_session_history(&events, session_id);
     let _ = std::io::stdout().flush();
     ExitCode::SUCCESS
 }
@@ -264,20 +270,47 @@ fn generate_session_id() -> String {
     format!("mock-{micros}")
 }
 
+fn is_valid_session_history_id(session_id: &str) -> bool {
+    if session_id.is_empty()
+        || session_id == "."
+        || session_id == ".."
+        || session_id.contains('/')
+        || session_id.contains('\\')
+        || session_id.chars().any(char::is_control)
+    {
+        return false;
+    }
+
+    let mut components = Path::new(session_id).components();
+    matches!(components.next(), Some(Component::Normal(_))) && components.next().is_none()
+}
+
 /// Build the session history file path and create the directory.
 ///
 /// Claude Code stores session history at: `{home}/.claude/projects/-{path}/{session_id}.jsonl`
 fn build_session_history_path(session_id: &str, home: &str) -> Option<String> {
+    if !is_valid_session_history_id(session_id) {
+        return None;
+    }
+
     let project_name = CANONICAL_WORKING_DIR
         .trim_start_matches('/')
         .replace('/', "-");
-    let session_dir = format!("{home}/.claude/projects/-{project_name}");
+    let session_dir = PathBuf::from(home)
+        .join(".claude")
+        .join("projects")
+        .join(format!("-{project_name}"));
 
     if std::fs::create_dir_all(&session_dir).is_err() {
         return None;
     }
 
-    Some(format!("{session_dir}/{session_id}.jsonl"))
+    Some(
+        session_dir
+            .join(format!("{session_id}.jsonl"))
+            .to_string_lossy()
+            .into_owned(),
+    )
 }
 
 /// Create session history using `$HOME` from the environment.
@@ -769,6 +802,46 @@ mod tests {
 
         let expected_dir = dir.path().join(".claude/projects/-home-user-workspace");
         assert!(expected_dir.exists());
+    }
+
+    #[test]
+    fn session_history_id_accepts_safe_file_components() {
+        for session_id in [
+            "mock-123",
+            "preview-1",
+            "550e8400-e29b-41d4-a716-446655440000",
+            "session.with.dot",
+        ] {
+            assert!(
+                is_valid_session_history_id(session_id),
+                "expected {session_id} to be accepted"
+            );
+        }
+    }
+
+    #[test]
+    fn session_history_path_rejects_unsafe_session_ids() {
+        let dir = tempfile::tempdir().unwrap();
+        let home = dir.path().to_str().unwrap();
+
+        for session_id in [
+            "",
+            ".",
+            "..",
+            "../escape",
+            "..\\escape",
+            "/absolute",
+            "nested/path",
+            "nested\\path",
+            "line\nbreak",
+        ] {
+            assert!(
+                !is_valid_session_history_id(session_id),
+                "expected {session_id:?} to be rejected"
+            );
+            assert_eq!(build_session_history_path(session_id, home), None);
+        }
+        assert!(!dir.path().join(".claude").exists());
     }
 
     #[test]

--- a/crates/guest-mock-claude/tests/echo_jsonl.rs
+++ b/crates/guest-mock-claude/tests/echo_jsonl.rs
@@ -46,6 +46,38 @@ fn echo_jsonl_outputs_valid_payload_unchanged() -> Result<(), Box<dyn std::error
 }
 
 #[test]
+fn echo_jsonl_rejects_path_like_session_id_without_writing_history() -> std::io::Result<()> {
+    let home = tempfile::tempdir()?;
+    let payload = r#"{"type":"system","subtype":"init","cwd":"/home/user/workspace","session_id":"../escape","tools":["Bash"],"model":"mock-claude"}"#;
+    let prompt = format!("@ECHO@\n{payload}\n");
+
+    let output = mock_claude()
+        .env("HOME", home.path())
+        .args(["--output-format", "stream-json", "--", &prompt])
+        .output()?;
+
+    assert!(!output.status.success());
+    assert!(
+        output.stdout.is_empty(),
+        "expected empty stdout, got: {}",
+        String::from_utf8_lossy(&output.stdout)
+    );
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(stderr.contains("invalid @ECHO@ session_id"));
+    assert!(stderr.contains("../escape"));
+    assert!(!expected_history_path(home.path(), "../escape").exists());
+    assert!(
+        !home
+            .path()
+            .join(".claude")
+            .join("projects")
+            .join("escape.jsonl")
+            .exists()
+    );
+    Ok(())
+}
+
+#[test]
 fn echo_jsonl_rejects_invalid_json_line() -> Result<(), Box<dyn std::error::Error>> {
     let output = mock_claude()
         .args(["--output-format", "stream-json", "--", "@ECHO@\n{\"type\""])


### PR DESCRIPTION
## Summary

- reject path-like `@ECHO@` init session IDs before replay output is emitted
- validate session history IDs at the history path boundary
- build session history paths with `PathBuf` after validation
- add integration and helper regression tests for traversal-style IDs

Closes #15827

## Tests

- `cargo test --manifest-path crates/Cargo.toml -p guest-mock-claude`
- `cargo clippy --manifest-path crates/Cargo.toml -p guest-mock-claude --all-targets -- -D warnings`

Note: the local pre-commit hook's workspace `crates` task failed outside this crate while running concurrent cargo jobs; the focused changed-crate checks above passed.
