### PR TITLE
fix: add reusable zero host slug suffixes

### DIFF
--- a/turbo/apps/api/src/signals/routes/__tests__/zero-host.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/zero-host.test.ts
@@ -251,6 +251,28 @@ describe("POST /api/zero/host/deployments/prepare", () => {
     expect(second.body.siteId).toBe(first.body.siteId);
   });
 
+  it("rejects slug suffixes that would exceed the stored public slug length", async () => {
+    const fixture = await seedHostedSiteFixture();
+    mocks.clerk.session(fixture.userId, fixture.orgId);
+
+    const client = setupApp({ context })(zeroHostContract);
+    const response = await accept(
+      client.prepare({
+        headers: { authorization: "Bearer clerk-session" },
+        body: {
+          site: "a".repeat(63),
+          slugSuffix: "b".repeat(32),
+          spaFallback: true,
+          files: validFiles(),
+        },
+      }),
+      [400],
+    );
+
+    expect(response.body.error.code).toBe("BAD_REQUEST");
+    expect(response.body.error.message).toContain("96");
+  });
+
   it("rejects suspended orgs with insufficient credits", async () => {
     const fixture = await seedHostedSiteFixture("pro-suspend");
     mocks.clerk.session(fixture.userId, fixture.orgId);

--- a/turbo/apps/api/src/signals/routes/__tests__/zero-host.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/zero-host.test.ts
@@ -138,9 +138,11 @@ describe("POST /api/zero/host/deployments/prepare", () => {
       [200],
     );
 
-    expect(response.body.publicSlug).toMatch(/^demo-site-[a-f0-9]{8}$/);
+    expect(response.body.publicSlug).toMatch(
+      /^demo-site-[a-f0-9]{8}-[a-f0-9]{8}$/,
+    );
     expect(response.body.url).toMatch(
-      /^https:\/\/demo-site-[a-f0-9]{8}\.sites\.example\.com$/,
+      /^https:\/\/demo-site-[a-f0-9]{8}-[a-f0-9]{8}\.sites\.example\.com$/,
     );
     expect(response.body.uploads).toHaveLength(2);
     expect(
@@ -169,6 +171,84 @@ describe("POST /api/zero/host/deployments/prepare", () => {
       sizeBytes: 540,
       spaFallback: true,
     });
+  });
+
+  it("generates a unique public slug by default for the same site slug", async () => {
+    const fixture = await seedHostedSiteFixture();
+    mocks.clerk.session(fixture.userId, fixture.orgId);
+
+    const client = setupApp({ context })(zeroHostContract);
+    const first = await accept(
+      client.prepare({
+        headers: { authorization: "Bearer clerk-session" },
+        body: { site: "demo-site", spaFallback: true, files: validFiles() },
+      }),
+      [200],
+    );
+    const second = await accept(
+      client.prepare({
+        headers: { authorization: "Bearer clerk-session" },
+        body: { site: "demo-site", spaFallback: true, files: validFiles() },
+      }),
+      [200],
+    );
+
+    expect(first.body.publicSlug).toMatch(
+      /^demo-site-[a-f0-9]{8}-[a-f0-9]{8}$/,
+    );
+    expect(second.body.publicSlug).toMatch(
+      /^demo-site-[a-f0-9]{8}-[a-f0-9]{8}$/,
+    );
+    expect(second.body.publicSlug).not.toBe(first.body.publicSlug);
+    expect(second.body.url).not.toBe(first.body.url);
+    expect(second.body.siteId).toBe(first.body.siteId);
+
+    const [site] = await store
+      .set(writeDb$)
+      .select()
+      .from(hostedSites)
+      .where(eq(hostedSites.id, first.body.siteId));
+    expect(site).toMatchObject({
+      orgId: fixture.orgId,
+      slug: "demo-site",
+      publicSlug: second.body.publicSlug,
+    });
+  });
+
+  it("reuses the public slug when a slug suffix is provided", async () => {
+    const fixture = await seedHostedSiteFixture();
+    mocks.clerk.session(fixture.userId, fixture.orgId);
+
+    const client = setupApp({ context })(zeroHostContract);
+    const first = await accept(
+      client.prepare({
+        headers: { authorization: "Bearer clerk-session" },
+        body: {
+          site: "demo-site",
+          slugSuffix: "release-01",
+          spaFallback: true,
+          files: validFiles(),
+        },
+      }),
+      [200],
+    );
+    const second = await accept(
+      client.prepare({
+        headers: { authorization: "Bearer clerk-session" },
+        body: {
+          site: "demo-site",
+          slugSuffix: "release-01",
+          spaFallback: true,
+          files: validFiles(),
+        },
+      }),
+      [200],
+    );
+
+    expect(first.body.publicSlug).toMatch(/^demo-site-[a-f0-9]{8}-release-01$/);
+    expect(second.body.publicSlug).toBe(first.body.publicSlug);
+    expect(second.body.url).toBe(first.body.url);
+    expect(second.body.siteId).toBe(first.body.siteId);
   });
 
   it("rejects suspended orgs with insufficient credits", async () => {
@@ -241,7 +321,7 @@ describe("POST /api/zero/host/deployments/:deploymentId/complete", () => {
       status: "ready",
     });
     expect(completed.body.url).toMatch(
-      /^https:\/\/demo-site-[a-f0-9]{8}\.sites\.example\.com$/,
+      /^https:\/\/demo-site-[a-f0-9]{8}-[a-f0-9]{8}\.sites\.example\.com$/,
     );
     expect(puts).toStrictEqual([
       `${prefix}/manifest.json`,

--- a/turbo/apps/api/src/signals/services/zero-host.service.ts
+++ b/turbo/apps/api/src/signals/services/zero-host.service.ts
@@ -23,6 +23,7 @@ import { recordHostedSiteArtifact$ } from "./run-uploaded-files.service";
 const PUT_URL_TTL_SECONDS = 3600;
 const MAX_HOSTED_SITE_TOTAL_BYTES = 512 * 1024 * 1024;
 const MAX_HOSTED_SITE_FILE_BYTES = 100 * 1024 * 1024;
+const MAX_PUBLIC_SLUG_ATTEMPTS = 5;
 
 interface PrepareDeploymentArgs {
   readonly orgId: string;
@@ -91,6 +92,17 @@ type SiteDeploymentCreationResult =
       readonly deployment: HostedDeploymentRow;
     }
   | { readonly kind: "slug_conflict" };
+type CreatedSiteDeployment = Extract<
+  SiteDeploymentCreationResult,
+  { readonly kind: "ok" }
+>;
+
+interface CreateHostedSiteDeploymentContext {
+  readonly now: Date;
+  readonly publicSlug: string;
+  readonly url: string;
+  readonly allowExistingPublicSlug: boolean;
+}
 
 interface HostedR2Config {
   readonly bucket: string;
@@ -133,6 +145,22 @@ function activePointerKey(publicSlug: string): string {
 
 function deploymentPrefix(publicSlug: string, deploymentId: string): string {
   return `sites/${publicSlug}/deployments/${deploymentId}`;
+}
+
+function orgSlugHash(orgId: string): string {
+  return createHash("sha256").update(orgId).digest("hex").substring(0, 8);
+}
+
+function randomSlugSuffix(): string {
+  return crypto.randomUUID().replaceAll("-", "").substring(0, 8);
+}
+
+function publicSlugForSite(
+  site: string,
+  orgId: string,
+  slugSuffix: string,
+): string {
+  return `${site}-${orgSlugHash(orgId)}-${slugSuffix}`;
 }
 
 function fileKey(prefix: string, path: string): string {
@@ -248,9 +276,7 @@ function hostedSiteArtifactArgs(deployment: HostedDeploymentRow) {
 function createHostedSiteDeployment(
   writeDb: Db,
   args: PrepareDeploymentArgs,
-  now: Date,
-  publicSlug: string,
-  url: string,
+  context: CreateHostedSiteDeploymentContext,
 ): Promise<SiteDeploymentCreationResult> {
   return writeDb.transaction(async (tx) => {
     const [existingPublicSite] = await tx
@@ -258,7 +284,7 @@ function createHostedSiteDeployment(
       .from(hostedSites)
       .where(
         and(
-          eq(hostedSites.publicSlug, publicSlug),
+          eq(hostedSites.publicSlug, context.publicSlug),
           isNull(hostedSites.deletedAt),
         ),
       )
@@ -266,45 +292,41 @@ function createHostedSiteDeployment(
 
     if (
       existingPublicSite &&
-      (existingPublicSite.orgId !== args.orgId ||
+      (!context.allowExistingPublicSlug ||
+        existingPublicSite.orgId !== args.orgId ||
         existingPublicSite.slug !== args.body.site)
     ) {
       return { kind: "slug_conflict" };
     }
 
-    let site = existingPublicSite ?? null;
+    const [site] = await tx
+      .insert(hostedSites)
+      .values({
+        orgId: args.orgId,
+        userId: args.userId,
+        slug: args.body.site,
+        publicSlug: context.publicSlug,
+        createdFromRunId: args.runId,
+        updatedAt: context.now,
+      })
+      .onConflictDoUpdate({
+        target: [hostedSites.orgId, hostedSites.slug],
+        set: { publicSlug: context.publicSlug, updatedAt: context.now },
+      })
+      .returning();
     if (!site) {
-      const [insertedSite] = await tx
-        .insert(hostedSites)
-        .values({
-          orgId: args.orgId,
-          userId: args.userId,
-          slug: args.body.site,
-          publicSlug,
-          createdFromRunId: args.runId,
-          updatedAt: now,
-        })
-        .returning();
-      if (!insertedSite) {
-        throw new Error("Failed to create hosted site");
-      }
-      site = insertedSite;
-    } else {
-      await tx
-        .update(hostedSites)
-        .set({ updatedAt: now })
-        .where(eq(hostedSites.id, site.id));
+      throw new Error("Failed to create hosted site");
     }
 
     const deploymentId = crypto.randomUUID();
-    const prefix = deploymentPrefix(publicSlug, deploymentId);
+    const prefix = deploymentPrefix(context.publicSlug, deploymentId);
     const manifest = buildManifest({
       deploymentId,
       siteId: site.id,
-      publicSlug,
+      publicSlug: context.publicSlug,
       spaFallback: args.body.spaFallback,
       files: args.body.files,
-      createdAt: now,
+      createdAt: context.now,
     });
     const files = Object.values(manifest.files);
     const [deployment] = await tx
@@ -326,8 +348,8 @@ function createHostedSiteDeployment(
         sizeBytes: files.reduce((sum, file) => {
           return sum + file.size;
         }, 0),
-        url,
-        updatedAt: now,
+        url: context.url,
+        updatedAt: context.now,
       })
       .returning();
     if (!deployment) {
@@ -356,26 +378,57 @@ export const prepareHostedSiteDeployment$ = command(
 
     const writeDb = set(writeDb$);
     const now = nowDate();
-    const orgHash = createHash("sha256")
-      .update(args.orgId)
-      .digest("hex")
-      .substring(0, 8);
-    const publicSlug = `${args.body.site}-${orgHash}`;
-    const url = publicUrl(publicSlug);
+    let siteAndDeployment: CreatedSiteDeployment | null = null;
+    let publicSlug = "";
+    let url = "";
 
-    const siteAndDeployment = await createHostedSiteDeployment(
-      writeDb,
-      args,
-      now,
-      publicSlug,
-      url,
-    );
-    signal.throwIfAborted();
+    if (args.body.slugSuffix) {
+      publicSlug = publicSlugForSite(
+        args.body.site,
+        args.orgId,
+        args.body.slugSuffix,
+      );
+      url = publicUrl(publicSlug);
+      const result = await createHostedSiteDeployment(writeDb, args, {
+        now,
+        publicSlug,
+        url,
+        allowExistingPublicSlug: true,
+      });
+      signal.throwIfAborted();
+      if (result.kind === "slug_conflict") {
+        return {
+          status: "conflict",
+          message: `Hosted site slug is already in use: ${publicSlug}`,
+        };
+      }
+      siteAndDeployment = result;
+    } else {
+      for (let attempt = 0; attempt < MAX_PUBLIC_SLUG_ATTEMPTS; attempt += 1) {
+        publicSlug = publicSlugForSite(
+          args.body.site,
+          args.orgId,
+          randomSlugSuffix(),
+        );
+        url = publicUrl(publicSlug);
+        const result = await createHostedSiteDeployment(writeDb, args, {
+          now,
+          publicSlug,
+          url,
+          allowExistingPublicSlug: false,
+        });
+        signal.throwIfAborted();
+        if (result.kind === "ok") {
+          siteAndDeployment = result;
+          break;
+        }
+      }
+    }
 
-    if (siteAndDeployment.kind === "slug_conflict") {
+    if (!siteAndDeployment) {
       return {
         status: "conflict",
-        message: `Hosted site slug is already in use: ${publicSlug}`,
+        message: "Unable to allocate a unique hosted site slug",
       };
     }
 

--- a/turbo/apps/cli/src/commands/zero/generate/__tests__/website.test.ts
+++ b/turbo/apps/cli/src/commands/zero/generate/__tests__/website.test.ts
@@ -63,6 +63,23 @@ describe("zero generate website command", () => {
     );
   });
 
+  it("should use the generated base slug when no stable site slug is provided", async () => {
+    await generateCommand.parseAsync([
+      "node",
+      "cli",
+      "website",
+      "--prompt",
+      "observability launch site",
+      "--title",
+      "Clearpath",
+    ]);
+
+    const stdout = mockConsoleLog.mock.calls.flat().join("\n");
+    expect(stdout).toContain(
+      "zero host ./generated/mockups/clearpath --site clearpath --spa",
+    );
+  });
+
   it("should accept --template and --design-system from the registry", async () => {
     await generateCommand.parseAsync([
       "node",

--- a/turbo/apps/cli/src/commands/zero/generate/artifacts.ts
+++ b/turbo/apps/cli/src/commands/zero/generate/artifacts.ts
@@ -16,7 +16,7 @@ export const reportCommand = createArtifactGenerateCommand({
   description: "Generate an HTML report from a prompt",
   usageCommand: "zero generate report",
   examples: `  Generate report:      zero generate report --prompt "A Q2 usage report for the API team"
-  Stable hosted slug:    zero generate report --site-slug api-usage-q2 --prompt "A Q2 usage report"
+  Custom site slug:      zero generate report --site-slug api-usage-q2 --prompt "A Q2 usage report"
   Show choices:          zero generate report`,
   details: standardDetails("report"),
   artifactRules: [
@@ -34,7 +34,7 @@ export const docsDesignCommand = createArtifactGenerateCommand({
   description: "Generate a documentation design from a prompt",
   usageCommand: "zero generate docs-design",
   examples: `  Generate docs design: zero generate docs-design --prompt "Docs for adding artifact targets"
-  Stable hosted slug:    zero generate docs-design --site-slug artifact-target-docs --prompt "Artifact target docs"
+  Custom site slug:      zero generate docs-design --site-slug artifact-target-docs --prompt "Artifact target docs"
   Show choices:          zero generate docs-design`,
   details: standardDetails("docs-design"),
   artifactRules: [
@@ -52,7 +52,7 @@ export const posterCommand = createArtifactGenerateCommand({
   description: "Generate an HTML poster from a prompt",
   usageCommand: "zero generate poster",
   examples: `  Generate poster:      zero generate poster --prompt "A launch poster for artifact targets"
-  Stable hosted slug:    zero generate poster --site-slug artifact-poster --prompt "A launch poster"
+  Custom site slug:      zero generate poster --site-slug artifact-poster --prompt "A launch poster"
   Show choices:          zero generate poster`,
   details: standardDetails("poster"),
   artifactRules: [
@@ -70,7 +70,7 @@ export const dashboardDesignCommand = createArtifactGenerateCommand({
   description: "Generate a dashboard design from a prompt",
   usageCommand: "zero generate dashboard-design",
   examples: `  Generate dash design: zero generate dashboard-design --prompt "An ops dashboard for generation runs"
-  Stable hosted slug:    zero generate dashboard-design --site-slug generation-ops --prompt "A generation ops dashboard"
+  Custom site slug:      zero generate dashboard-design --site-slug generation-ops --prompt "A generation ops dashboard"
   Show choices:          zero generate dashboard-design`,
   details: standardDetails("dashboard-design"),
   artifactRules: [
@@ -88,7 +88,7 @@ export const mobileAppDesignCommand = createArtifactGenerateCommand({
   description: "Generate a mobile app design prototype from a prompt",
   usageCommand: "zero generate mobile-app-design",
   examples: `  Generate mobile UI:   zero generate mobile-app-design --prompt "A mobile review screen for generation artifacts"
-  Stable hosted slug:    zero generate mobile-app-design --site-slug generation-mobile-review --prompt "A mobile review screen"
+  Custom site slug:      zero generate mobile-app-design --site-slug generation-mobile-review --prompt "A mobile review screen"
   Show choices:          zero generate mobile-app-design`,
   details: standardDetails("mobile-app-design"),
   artifactRules: [

--- a/turbo/apps/cli/src/commands/zero/generate/presentation.ts
+++ b/turbo/apps/cli/src/commands/zero/generate/presentation.ts
@@ -7,6 +7,6 @@ export const presentationCommand = createPresentationGenerateCommand({
   examples: `  Generate deck:         zero generate presentation --prompt "A strategy deck for reducing support volume"
   Pipe prompt:           cat brief.txt | zero generate presentation
   Pick slide count:      zero generate presentation --slides 10 --prompt "A product launch narrative"
-  Stable hosted slug:    zero generate presentation --site-slug api-migration-plan --prompt "API migration plan"
+  Custom site slug:      zero generate presentation --site-slug api-migration-plan --prompt "API migration plan"
   Show choices:          zero generate presentation`,
 });

--- a/turbo/apps/cli/src/commands/zero/generate/website.ts
+++ b/turbo/apps/cli/src/commands/zero/generate/website.ts
@@ -78,7 +78,7 @@ Examples:
   Generate site:         zero generate website --prompt "A launch site for a developer observability tool"
   Pick template:         zero generate website --template saas-landing --prompt "Launch site for a billing API"
   Pick design system:    zero generate website --design-system stripe --prompt "Pricing page for a SaaS"
-  Stable hosted slug:    zero generate website --site-slug api-migration-demo --prompt "An internal migration microsite"
+  Custom site slug:      zero generate website --site-slug api-migration-demo --prompt "An internal migration microsite"
   Pipe prompt:           cat brief.txt | zero generate website
   Show choices:          zero generate website
 

--- a/turbo/apps/cli/src/commands/zero/host/index.ts
+++ b/turbo/apps/cli/src/commands/zero/host/index.ts
@@ -5,6 +5,7 @@ import { publishStaticSite } from "../../../lib/host/publish-static-site";
 
 interface HostOptions {
   readonly site: string;
+  readonly slugSuffix?: string;
   readonly spa?: boolean;
   readonly json?: boolean;
 }
@@ -20,6 +21,7 @@ export const zeroHostCommand = new Command()
   .description("Publish a built static site and print its public URL")
   .argument("<dir>", "Static build directory, for example ./dist")
   .requiredOption("--site <slug>", "Public site slug, e.g. my-product-demo")
+  .option("--slug-suffix <suffix>", "Reuse a generated site URL suffix")
   .option("--spa", "Serve unknown HTML navigation paths from index.html")
   .option("--json", "Output only the final result as JSON")
   .addHelpText(
@@ -27,10 +29,12 @@ export const zeroHostCommand = new Command()
     `
 Examples:
   Publish a Vite build:  zero host ./dist --site my-product-demo --spa
+  Redeploy a URL:       zero host ./dist --site my-product-demo --slug-suffix a1b2c3d4 --spa
   Machine readable:     zero host ./dist --site my-product-demo --spa --json
 
 Notes:
   - Authenticates via ZERO_TOKEN (requires host:write capability)
+  - Reusing both --site and --slug-suffix keeps the same URL
   - The directory must include index.html
   - Local HTML/CSS asset references must point at files inside the directory`,
   )
@@ -39,6 +43,7 @@ Notes:
       const result = await publishStaticSite({
         dir,
         site: options.site,
+        slugSuffix: options.slugSuffix,
         spaFallback: Boolean(options.spa),
         onProgress: options.json
           ? undefined

--- a/turbo/apps/cli/src/lib/host/publish-static-site.ts
+++ b/turbo/apps/cli/src/lib/host/publish-static-site.ts
@@ -21,6 +21,7 @@ interface PublishStaticSiteResult {
 interface PublishStaticSiteOptions {
   readonly dir: string;
   readonly site: string;
+  readonly slugSuffix?: string;
   readonly spaFallback?: boolean;
   readonly onProgress?: (progress: PublishStaticSiteProgress) => void;
 }
@@ -40,6 +41,7 @@ export async function publishStaticSite(
 
   const prepared = await prepareHostedSite({
     site: options.site,
+    ...(options.slugSuffix !== undefined && { slugSuffix: options.slugSuffix }),
     spaFallback: Boolean(options.spaFallback),
     files: scan.files.map((file) => {
       return {

--- a/turbo/packages/api-contracts/src/contracts/zero-host.ts
+++ b/turbo/packages/api-contracts/src/contracts/zero-host.ts
@@ -14,6 +14,16 @@ export const hostedSiteSlugSchema = z
     "Site slug must use lowercase letters, numbers, and hyphens, and must start and end with a letter or number",
   );
 
+export const hostedSiteSlugSuffixSchema = z
+  .string()
+  .trim()
+  .min(3)
+  .max(32)
+  .regex(
+    /^[a-z0-9](?:[a-z0-9-]*[a-z0-9])?$/,
+    "Site slug suffix must use lowercase letters, numbers, and hyphens, and must start and end with a letter or number",
+  );
+
 export const hostedSiteFileSchema = z.object({
   path: z.string().min(1).max(1024).regex(/^\//, "File path must start with /"),
   size: z.number().int().nonnegative(),
@@ -24,6 +34,7 @@ export const hostedSiteFileSchema = z.object({
 
 export const hostedSitePrepareRequestSchema = z.object({
   site: hostedSiteSlugSchema,
+  slugSuffix: hostedSiteSlugSuffixSchema.optional(),
   spaFallback: z.boolean().default(false),
   files: z.array(hostedSiteFileSchema).min(1).max(5000),
 });

--- a/turbo/packages/api-contracts/src/contracts/zero-host.ts
+++ b/turbo/packages/api-contracts/src/contracts/zero-host.ts
@@ -4,6 +4,11 @@ import { apiErrorSchema } from "./errors";
 
 const c = initContract();
 
+const ORG_SLUG_HASH_LENGTH = 8;
+const RANDOM_SLUG_SUFFIX_LENGTH = 8;
+const PUBLIC_SLUG_SEPARATOR_LENGTH = 2;
+const MAX_HOSTED_SITE_PUBLIC_SLUG_LENGTH = 96;
+
 export const hostedSiteSlugSchema = z
   .string()
   .trim()
@@ -32,12 +37,30 @@ export const hostedSiteFileSchema = z.object({
   immutable: z.boolean().optional(),
 });
 
-export const hostedSitePrepareRequestSchema = z.object({
-  site: hostedSiteSlugSchema,
-  slugSuffix: hostedSiteSlugSuffixSchema.optional(),
-  spaFallback: z.boolean().default(false),
-  files: z.array(hostedSiteFileSchema).min(1).max(5000),
-});
+export const hostedSitePrepareRequestSchema = z
+  .object({
+    site: hostedSiteSlugSchema,
+    slugSuffix: hostedSiteSlugSuffixSchema.optional(),
+    spaFallback: z.boolean().default(false),
+    files: z.array(hostedSiteFileSchema).min(1).max(5000),
+  })
+  .superRefine((value, ctx) => {
+    const suffixLength = value.slugSuffix?.length ?? RANDOM_SLUG_SUFFIX_LENGTH;
+    const publicSlugLength =
+      value.site.length +
+      ORG_SLUG_HASH_LENGTH +
+      suffixLength +
+      PUBLIC_SLUG_SEPARATOR_LENGTH;
+
+    if (publicSlugLength > MAX_HOSTED_SITE_PUBLIC_SLUG_LENGTH) {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        path: value.slugSuffix ? ["slugSuffix"] : ["site"],
+        message:
+          "Hosted site public slug must be 96 characters or fewer; shorten site or slug suffix",
+      });
+    }
+  });
 
 export const hostedSiteUploadSchema = z.object({
   path: z.string(),


### PR DESCRIPTION
## Summary

- Change zero-host public slugs to include both org identity and a deployment suffix: `site-{orgHash8}-{suffix}`.
- Default `zero host --site foo` prepares a fresh random 8-character suffix, so newly generated artifacts do not collide.
- Add `slugSuffix` / `zero host --slug-suffix <suffix>` for explicit redeploys to the same generated URL, e.g. `foo-{orgHash8}-release-01`.
- Keep org hash in the public slug and only allow reusing an existing public slug when it belongs to the same org and site slug.
- Keep `zero generate` publishing with the base site slug; the host API now appends the org hash and random suffix.

## Validation

- `pnpm exec vitest run apps/api/src/signals/routes/__tests__/zero-host.test.ts`
- `pnpm exec vitest run apps/cli/src/commands/zero/generate/__tests__/website.test.ts apps/cli/src/commands/zero/generate/__tests__/presentation.test.ts apps/cli/src/commands/zero/generate/__tests__/artifacts.test.ts`
- `pnpm exec vitest run apps/cli/src/commands/zero/generate/__tests__/website.test.ts`
- `NODE_OPTIONS=--max-old-space-size=8192 pnpm -F api check-types`
- `NODE_OPTIONS=--max-old-space-size=4096 pnpm -F @vm0/cli check-types`
- `NODE_OPTIONS=--max-old-space-size=4096 pnpm -F @vm0/api-contracts check-types`
- `NODE_OPTIONS=--max-old-space-size=8192 pnpm -F api lint`
- `NODE_OPTIONS=--max-old-space-size=4096 pnpm -F @vm0/cli lint`
- `NODE_OPTIONS=--max-old-space-size=4096 pnpm -F @vm0/api-contracts lint`