### PR TITLE
fix: handle concatenated zlib stream members

### DIFF
--- a/crates/runner/mitm-addon/src/body_utils.py
+++ b/crates/runner/mitm-addon/src/body_utils.py
@@ -157,15 +157,21 @@ def _create_zlib_stream_decode_feed(
     obj = zlib.decompressobj(wbits)
 
     def decode(chunk: bytes) -> None:
+        nonlocal obj
         data = chunk
         while data:
             decoded = obj.decompress(data, max_length=max_decoded_chunk)
             if decoded:
                 feed(decoded)
-            next_data = obj.unconsumed_tail
-            if not next_data:
-                return
-            data = next_data
+            if obj.unconsumed_tail:
+                data = obj.unconsumed_tail
+                continue
+            if obj.eof:
+                data = obj.unused_data
+                obj = zlib.decompressobj(wbits)
+                if data:
+                    continue
+            return
 
     return _make_streaming_decode_guard(decode, zlib.error, encoding)
 

--- a/crates/runner/mitm-addon/tests/test_body_capture.py
+++ b/crates/runner/mitm-addon/tests/test_body_capture.py
@@ -1481,6 +1481,39 @@ class TestStreamDecodeFeed:
                 parse(compressed[idx : idx + 3])
             assert b"".join(chunks) == plaintext, encoding
 
+    @pytest.mark.parametrize("encoding", ["gzip", "deflate"])
+    def test_concatenated_zlib_members_same_callback(self, headers, encoding):
+        plaintext = b'{"model":"claude-sonnet-4-6","usage":{"input_tokens":42}}'
+        if encoding == "gzip":
+            compressed = gzip.compress(b"") + gzip.compress(plaintext)
+        else:
+            compressed = zlib.compress(b"") + zlib.compress(plaintext)
+        chunks: list[bytes] = []
+        parse = create_stream_decode_feed(headers(("Content-Encoding", encoding)), chunks.append)
+        assert parse is not None
+
+        parse(compressed)
+
+        assert b"".join(chunks) == plaintext
+
+    @pytest.mark.parametrize("encoding", ["gzip", "deflate"])
+    def test_concatenated_zlib_members_across_callbacks(self, headers, encoding):
+        plaintext = b'{"model":"claude-sonnet-4-6","usage":{"input_tokens":42}}'
+        if encoding == "gzip":
+            empty_member = gzip.compress(b"")
+            payload_member = gzip.compress(plaintext)
+        else:
+            empty_member = zlib.compress(b"")
+            payload_member = zlib.compress(plaintext)
+        chunks: list[bytes] = []
+        parse = create_stream_decode_feed(headers(("Content-Encoding", encoding)), chunks.append)
+        assert parse is not None
+
+        parse(empty_member)
+        parse(payload_member)
+
+        assert b"".join(chunks) == plaintext
+
     def test_no_encoding_feeds_original_chunks(self, headers):
         chunks: list[bytes] = []
         parse = create_stream_decode_feed(headers(), chunks.append)
@@ -1620,6 +1653,14 @@ class TestStreamDecodeFeed:
             @property
             def unconsumed_tail(self):
                 return self._real.unconsumed_tail
+
+            @property
+            def eof(self):
+                return self._real.eof
+
+            @property
+            def unused_data(self):
+                return self._real.unused_data
 
         proxies: list[CountingProxy] = []
 

--- a/crates/runner/mitm-addon/tests/test_model_provider_response_usage.py
+++ b/crates/runner/mitm-addon/tests/test_model_provider_response_usage.py
@@ -858,6 +858,44 @@ class TestModelProviderResponseUsage:
         by_category = {event["category"]: event["quantity"] for event in events}
         assert by_category == _expected_event_quantities(provider_case)
 
+    @pytest.mark.parametrize("encoding_case", ["gzip", "deflate"])
+    def test_full_pipeline_concatenated_zlib_model_json_reports_usage(
+        self, tmp_path, real_flow, encoding_case
+    ):
+        """Streaming decompression should feed later zlib members into JSON usage parsing."""
+        provider_case = ANTHROPIC_JSON_CASE
+        flow = self._model_provider_flow(
+            real_flow,
+            tmp_path,
+            provider_case,
+            proxy_log_path=tmp_path / "proxy.jsonl",
+        )
+        payload = _standard_success_payload(provider_case)
+        if encoding_case == "gzip":
+            compressed = gzip.compress(b"") + gzip.compress(payload)
+        else:
+            compressed = zlib.compress(b"") + zlib.compress(payload)
+        flow.response = tutils.tresp(
+            status_code=200,
+            headers=header_map(
+                {"content-type": "application/json", "content-encoding": encoding_case}
+            ),
+        )
+
+        mitm_addon.responseheaders(flow)
+        response_stream(flow)(compressed)
+
+        webhook = self._run_response(flow)
+
+        extracted = flow.metadata["model_provider_usage"]
+        expected_usage = _expected_usage(provider_case)
+        assert extracted["model"] == expected_usage["model"]
+        assert extracted["tokens.input"] == expected_usage["tokens.input"]
+        assert extracted["tokens.output"] == expected_usage["tokens.output"]
+        events = webhook.usage_events()
+        by_category = {event["category"]: event["quantity"] for event in events}
+        assert by_category == _expected_event_quantities(provider_case)
+
     @pytest.mark.parametrize(
         "provider_case",
         MODEL_PROVIDER_JSON_CASES,

--- a/crates/runner/mitm-addon/tests/test_response_headers_handler.py
+++ b/crates/runner/mitm-addon/tests/test_response_headers_handler.py
@@ -2,6 +2,7 @@
 
 import gzip
 import json
+import zlib
 
 import brotli
 import pytest
@@ -428,6 +429,40 @@ class TestResponseHeadersHandler:
         response_stream(flow)(gzip.compress(body))
         response_streaming.finalize_connector_response_state(flow)
         json_state = flow.metadata["x_json_state"]
+        assert json_state["response_data_count"] == 2
+        assert json_state["response_includes"] == {"users": 1}
+        assert json_state["response_result_count"] == 2
+        assert json_state["response_total_tweet_count"] == 3
+
+    @pytest.mark.parametrize("encoding", ["gzip", "deflate"])
+    def test_x_non_stream_concatenated_zlib_json_extractor(self, real_flow, headers, encoding):
+        """X JSON parsing should consume payloads from later zlib members."""
+        body = json.dumps(
+            {
+                "data": [{"id": "1"}, {"id": "2"}],
+                "includes": {"users": [{"id": "u1"}]},
+                "meta": {"result_count": 2, "total_tweet_count": 3},
+            }
+        ).encode()
+        if encoding == "gzip":
+            compressed = gzip.compress(b"") + gzip.compress(body)
+        else:
+            compressed = zlib.compress(b"") + zlib.compress(body)
+        flow = real_flow(with_response=False, host="api.x.com", path="/2/tweets")
+        flow.metadata["firewall_name"] = "x"
+        flow.metadata["firewall_billable"] = True
+        flow.metadata["original_url"] = "https://api.x.com/2/tweets"
+        flow.response = tutils.tresp(
+            status_code=200,
+            headers=header_map({"content-type": "application/json", "content-encoding": encoding}),
+        )
+
+        mitm_addon.responseheaders(flow)
+        response_stream(flow)(compressed)
+        response_streaming.finalize_connector_response_state(flow)
+
+        json_state = flow.metadata["x_json_state"]
+        assert json_state["body_parsed"] is True
         assert json_state["response_data_count"] == 2
         assert json_state["response_includes"] == {"users": 1}
         assert json_state["response_result_count"] == 2


### PR DESCRIPTION
## Summary
- reset the gzip/deflate streaming decompressor after member EOF and continue through unused_data
- cover concatenated zlib members for same-callback and cross-callback decoder feeds
- add production path regressions for model provider usage extraction and X JSON response metadata

Closes #15805

## Tests
- pytest tests/test_body_capture.py::TestStreamDecodeFeed
- pytest tests/test_model_provider_response_usage.py
- pytest tests/test_response_headers_handler.py
- basedpyright -p .
- ruff check src/body_utils.py tests/test_body_capture.py tests/test_model_provider_response_usage.py tests/test_response_headers_handler.py
- ruff format --check src/body_utils.py tests/test_body_capture.py tests/test_model_provider_response_usage.py tests/test_response_headers_handler.py