### PR TITLE
test: use real HTTPFlow for firewall metadata logs

### DIFF
--- a/crates/runner/mitm-addon/tests/test_logging_utils.py
+++ b/crates/runner/mitm-addon/tests/test_logging_utils.py
@@ -81,6 +81,22 @@ class TestLogNetworkEntry:
 
 
 class TestAddFirewallMetadata:
+    def test_copies_valid_firewall_error_metadata(self, real_flow):
+        flow = real_flow(with_response=False)
+        flow.metadata.update({metadata_keys.FIREWALL_ERROR: "TOKEN_REFRESH_FAILED"})
+        log_entry = {}
+
+        logging_utils.add_firewall_metadata(flow, log_entry)
+
+        assert log_entry == {
+            "firewall_base": "",
+            "firewall_name": "",
+            "firewall_permission": "",
+            "firewall_rule_match": "",
+            "firewall_billable": False,
+            "firewall_error": "TOKEN_REFRESH_FAILED",
+        }
+
     def test_defaults_missing_required_firewall_metadata(self, real_flow):
         flow = real_flow(with_response=False)
         log_entry = {}

--- a/crates/runner/mitm-addon/tests/test_logging_utils.py
+++ b/crates/runner/mitm-addon/tests/test_logging_utils.py
@@ -1,0 +1,170 @@
+"""Tests for mitm addon logging utilities."""
+
+import json
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import flow_metadata_keys as metadata_keys
+import logging_utils
+from tests.timestamp_helpers import assert_utc_millisecond_timestamp
+
+
+class TestLogNetworkEntry:
+    def test_writes_jsonl(self, tmp_path):
+        log_path = str(tmp_path / "net.jsonl")
+        entry = {"action": "ALLOW", "host": "example.com"}
+
+        with patch.object(logging_utils.ctx, "log", MagicMock(), create=True):
+            logging_utils.log_network_entry(log_path, entry)
+
+        lines = Path(log_path).read_text().splitlines()
+        assert len(lines) == 1
+        parsed = json.loads(lines[0])
+        assert parsed["action"] == "ALLOW"
+        assert parsed["host"] == "example.com"
+        assert_utc_millisecond_timestamp(parsed["timestamp"])
+        assert "timestamp" not in entry
+
+    def test_timestamp_is_authoritative(self, tmp_path):
+        log_path = str(tmp_path / "net.jsonl")
+        entry = {"timestamp": "caller-timestamp", "action": "ALLOW"}
+
+        with patch.object(logging_utils.ctx, "log", MagicMock(), create=True):
+            logging_utils.log_network_entry(log_path, entry)
+
+        parsed = json.loads(Path(log_path).read_text().strip())
+        assert_utc_millisecond_timestamp(parsed["timestamp"])
+        assert parsed["timestamp"] != "caller-timestamp"
+        assert entry["timestamp"] == "caller-timestamp"
+
+    def test_appends_multiple(self, tmp_path):
+        log_path = str(tmp_path / "net.jsonl")
+
+        with patch.object(logging_utils.ctx, "log", MagicMock(), create=True):
+            logging_utils.log_network_entry(log_path, {"n": 1})
+            logging_utils.log_network_entry(log_path, {"n": 2})
+
+        lines = Path(log_path).read_text().splitlines()
+        assert len(lines) == 2
+
+    def test_no_path_is_noop(self):
+        log = MagicMock()
+
+        with patch.object(logging_utils.ctx, "log", log, create=True):
+            logging_utils.log_network_entry("", {"payload": b"binary"})
+
+        log.warn.assert_not_called()
+
+    def test_missing_parent_path_warns_and_does_not_raise(self, tmp_path):
+        log_path = tmp_path / "missing" / "net.jsonl"
+        log = MagicMock()
+
+        with patch.object(logging_utils.ctx, "log", log, create=True):
+            logging_utils.log_network_entry(str(log_path), {"action": "ALLOW"})
+
+        log.warn.assert_called_once()
+        warning = log.warn.call_args.args[0]
+        assert "Failed to write network log:" in warning
+        assert "FileNotFoundError" in warning
+
+    def test_non_serializable_entry_warns_without_creating_file(self, tmp_path):
+        log_path = tmp_path / "net.jsonl"
+        log = MagicMock()
+
+        with patch.object(logging_utils.ctx, "log", log, create=True):
+            logging_utils.log_network_entry(str(log_path), {"payload": b"binary"})
+
+        log.warn.assert_called_once()
+        warning = log.warn.call_args.args[0]
+        assert "Failed to encode network log: TypeError:" in warning
+        assert not log_path.exists()
+
+
+class TestAddFirewallMetadata:
+    def test_defaults_missing_required_firewall_metadata(self, real_flow):
+        flow = real_flow(with_response=False)
+        log_entry = {}
+
+        logging_utils.add_firewall_metadata(flow, log_entry)
+
+        assert log_entry == {
+            "firewall_base": "",
+            "firewall_name": "",
+            "firewall_permission": "",
+            "firewall_rule_match": "",
+            "firewall_billable": False,
+        }
+
+    def test_defaults_malformed_required_firewall_metadata(self, real_flow):
+        for billable in (None, "true", 1):
+            flow = real_flow(with_response=False)
+            flow.metadata.update(
+                {
+                    metadata_keys.FIREWALL_BASE: None,
+                    metadata_keys.FIREWALL_NAME: 42,
+                    metadata_keys.FIREWALL_PERMISSION: False,
+                    metadata_keys.FIREWALL_RULE_MATCH: ["GET /items"],
+                    metadata_keys.FIREWALL_BILLABLE: billable,
+                }
+            )
+            log_entry = {}
+
+            logging_utils.add_firewall_metadata(flow, log_entry)
+
+            assert log_entry == {
+                "firewall_base": "",
+                "firewall_name": "",
+                "firewall_permission": "",
+                "firewall_rule_match": "",
+                "firewall_billable": False,
+            }
+
+    def test_omits_optional_none_metadata(self, real_flow):
+        flow = real_flow(with_response=False)
+        flow.metadata.update(
+            {
+                metadata_keys.FIREWALL_PARAMS: None,
+                metadata_keys.FIREWALL_ERROR: None,
+                metadata_keys.AUTH_RESOLVED_SECRETS: None,
+                metadata_keys.AUTH_REFRESHED_CONNECTORS: None,
+                metadata_keys.AUTH_REFRESHED_SECRETS: None,
+                metadata_keys.AUTH_CACHE_HIT: None,
+                metadata_keys.AUTH_URL_REWRITE: None,
+            }
+        )
+        log_entry = {}
+
+        logging_utils.add_firewall_metadata(flow, log_entry)
+
+        assert log_entry == {
+            "firewall_base": "",
+            "firewall_name": "",
+            "firewall_permission": "",
+            "firewall_rule_match": "",
+            "firewall_billable": False,
+        }
+
+    def test_omits_malformed_optional_metadata(self, real_flow):
+        flow = real_flow(with_response=False)
+        flow.metadata.update(
+            {
+                metadata_keys.FIREWALL_PARAMS: {"owner": "vm0-ai", "branch": None},
+                metadata_keys.FIREWALL_ERROR: 123,
+                metadata_keys.AUTH_RESOLVED_SECRETS: ["GITHUB_TOKEN", None],
+                metadata_keys.AUTH_REFRESHED_CONNECTORS: "github",
+                metadata_keys.AUTH_REFRESHED_SECRETS: [1],
+                metadata_keys.AUTH_CACHE_HIT: "false",
+                metadata_keys.AUTH_URL_REWRITE: 1,
+            }
+        )
+        log_entry = {}
+
+        logging_utils.add_firewall_metadata(flow, log_entry)
+
+        assert log_entry == {
+            "firewall_base": "",
+            "firewall_name": "",
+            "firewall_permission": "",
+            "firewall_rule_match": "",
+            "firewall_billable": False,
+        }

--- a/crates/runner/mitm-addon/tests/test_registry.py
+++ b/crates/runner/mitm-addon/tests/test_registry.py
@@ -1,15 +1,12 @@
-"""Tests for registry loading, caching, and network logging."""
+"""Tests for registry loading and caching."""
 
 import json
 import os
-from pathlib import Path
 from types import SimpleNamespace
 from unittest.mock import MagicMock, patch
 
 import pytest
 
-import flow_metadata_keys as metadata_keys
-import logging_utils
 import matching
 import registry
 from tests.auth_state_helpers import (
@@ -22,7 +19,6 @@ from tests.auth_state_helpers import (
     set_cached_headers,
     set_last_force_refresh_at,
 )
-from tests.timestamp_helpers import assert_utc_millisecond_timestamp
 
 _FIXED_MTIME_NS = 1_700_000_000_000_000_000
 
@@ -829,194 +825,3 @@ class TestGetVmContext:
         )
         assert isinstance(result, matching.FirewallBlock)
         assert result.reason == "malformed_firewall_config"
-
-
-class TestLogNetworkEntry:
-    def test_writes_jsonl(self, tmp_path):
-        log_path = str(tmp_path / "net.jsonl")
-        entry = {"action": "ALLOW", "host": "example.com"}
-
-        with patch.object(logging_utils.ctx, "log", MagicMock(), create=True):
-            logging_utils.log_network_entry(log_path, entry)
-
-        lines = Path(log_path).read_text().splitlines()
-        assert len(lines) == 1
-        parsed = json.loads(lines[0])
-        assert parsed["action"] == "ALLOW"
-        assert parsed["host"] == "example.com"
-        assert_utc_millisecond_timestamp(parsed["timestamp"])
-        assert "timestamp" not in entry
-
-    def test_timestamp_is_authoritative(self, tmp_path):
-        log_path = str(tmp_path / "net.jsonl")
-        entry = {"timestamp": "caller-timestamp", "action": "ALLOW"}
-
-        with patch.object(logging_utils.ctx, "log", MagicMock(), create=True):
-            logging_utils.log_network_entry(log_path, entry)
-
-        parsed = json.loads(Path(log_path).read_text().strip())
-        assert_utc_millisecond_timestamp(parsed["timestamp"])
-        assert parsed["timestamp"] != "caller-timestamp"
-        assert entry["timestamp"] == "caller-timestamp"
-
-    def test_appends_multiple(self, tmp_path):
-        log_path = str(tmp_path / "net.jsonl")
-
-        with patch.object(logging_utils.ctx, "log", MagicMock(), create=True):
-            logging_utils.log_network_entry(log_path, {"n": 1})
-            logging_utils.log_network_entry(log_path, {"n": 2})
-
-        lines = Path(log_path).read_text().splitlines()
-        assert len(lines) == 2
-
-    def test_no_path_is_noop(self):
-        log = MagicMock()
-
-        with patch.object(logging_utils.ctx, "log", log, create=True):
-            logging_utils.log_network_entry("", {"payload": b"binary"})
-
-        log.warn.assert_not_called()
-
-    def test_missing_parent_path_warns_and_does_not_raise(self, tmp_path):
-        log_path = tmp_path / "missing" / "net.jsonl"
-        log = MagicMock()
-
-        with patch.object(logging_utils.ctx, "log", log, create=True):
-            logging_utils.log_network_entry(str(log_path), {"action": "ALLOW"})
-
-        log.warn.assert_called_once()
-        warning = log.warn.call_args.args[0]
-        assert "Failed to write network log:" in warning
-        assert "FileNotFoundError" in warning
-
-    def test_non_serializable_entry_warns_without_creating_file(self, tmp_path):
-        log_path = tmp_path / "net.jsonl"
-        log = MagicMock()
-
-        with patch.object(logging_utils.ctx, "log", log, create=True):
-            logging_utils.log_network_entry(str(log_path), {"payload": b"binary"})
-
-        log.warn.assert_called_once()
-        warning = log.warn.call_args.args[0]
-        assert "Failed to encode network log: TypeError:" in warning
-        assert not log_path.exists()
-
-
-class TestAddFirewallMetadata:
-    def test_copies_valid_firewall_metadata(self):
-        flow = MagicMock()
-        flow.metadata = {
-            metadata_keys.FIREWALL_BASE: "https://api.example.com",
-            metadata_keys.FIREWALL_NAME: "example",
-            metadata_keys.FIREWALL_PERMISSION: "read",
-            metadata_keys.FIREWALL_RULE_MATCH: "GET /items",
-            metadata_keys.FIREWALL_BILLABLE: True,
-            metadata_keys.FIREWALL_PARAMS: {"owner": "vm0-ai", "repo": "vm0"},
-            metadata_keys.FIREWALL_ERROR: "TOKEN_REFRESH_FAILED",
-            metadata_keys.AUTH_RESOLVED_SECRETS: ["GITHUB_TOKEN"],
-            metadata_keys.AUTH_REFRESHED_CONNECTORS: ["github"],
-            metadata_keys.AUTH_REFRESHED_SECRETS: ["GITHUB_TOKEN"],
-            metadata_keys.AUTH_CACHE_HIT: False,
-            metadata_keys.AUTH_URL_REWRITE: True,
-        }
-        log_entry = {}
-
-        logging_utils.add_firewall_metadata(flow, log_entry)
-
-        assert log_entry == {
-            "firewall_base": "https://api.example.com",
-            "firewall_name": "example",
-            "firewall_permission": "read",
-            "firewall_rule_match": "GET /items",
-            "firewall_billable": True,
-            "firewall_params": {"owner": "vm0-ai", "repo": "vm0"},
-            "firewall_error": "TOKEN_REFRESH_FAILED",
-            "auth_resolved_secrets": ["GITHUB_TOKEN"],
-            "auth_refreshed_connectors": ["github"],
-            "auth_refreshed_secrets": ["GITHUB_TOKEN"],
-            "auth_cache_hit": False,
-            "auth_url_rewrite": True,
-        }
-
-    def test_defaults_missing_required_firewall_metadata(self):
-        flow = MagicMock()
-        flow.metadata = {}
-        log_entry = {}
-
-        logging_utils.add_firewall_metadata(flow, log_entry)
-
-        assert log_entry == {
-            "firewall_base": "",
-            "firewall_name": "",
-            "firewall_permission": "",
-            "firewall_rule_match": "",
-            "firewall_billable": False,
-        }
-
-    def test_defaults_malformed_required_firewall_metadata(self):
-        for billable in (None, "true", 1):
-            flow = MagicMock()
-            flow.metadata = {
-                metadata_keys.FIREWALL_BASE: None,
-                metadata_keys.FIREWALL_NAME: 42,
-                metadata_keys.FIREWALL_PERMISSION: False,
-                metadata_keys.FIREWALL_RULE_MATCH: ["GET /items"],
-                metadata_keys.FIREWALL_BILLABLE: billable,
-            }
-            log_entry = {}
-
-            logging_utils.add_firewall_metadata(flow, log_entry)
-
-            assert log_entry == {
-                "firewall_base": "",
-                "firewall_name": "",
-                "firewall_permission": "",
-                "firewall_rule_match": "",
-                "firewall_billable": False,
-            }
-
-    def test_omits_optional_none_metadata(self):
-        flow = MagicMock()
-        flow.metadata = {
-            metadata_keys.FIREWALL_PARAMS: None,
-            metadata_keys.FIREWALL_ERROR: None,
-            metadata_keys.AUTH_RESOLVED_SECRETS: None,
-            metadata_keys.AUTH_REFRESHED_CONNECTORS: None,
-            metadata_keys.AUTH_REFRESHED_SECRETS: None,
-            metadata_keys.AUTH_CACHE_HIT: None,
-            metadata_keys.AUTH_URL_REWRITE: None,
-        }
-        log_entry = {}
-
-        logging_utils.add_firewall_metadata(flow, log_entry)
-
-        assert log_entry == {
-            "firewall_base": "",
-            "firewall_name": "",
-            "firewall_permission": "",
-            "firewall_rule_match": "",
-            "firewall_billable": False,
-        }
-
-    def test_omits_malformed_optional_metadata(self):
-        flow = MagicMock()
-        flow.metadata = {
-            metadata_keys.FIREWALL_PARAMS: {"owner": "vm0-ai", "branch": None},
-            metadata_keys.FIREWALL_ERROR: 123,
-            metadata_keys.AUTH_RESOLVED_SECRETS: ["GITHUB_TOKEN", None],
-            metadata_keys.AUTH_REFRESHED_CONNECTORS: "github",
-            metadata_keys.AUTH_REFRESHED_SECRETS: [1],
-            metadata_keys.AUTH_CACHE_HIT: "false",
-            metadata_keys.AUTH_URL_REWRITE: 1,
-        }
-        log_entry = {}
-
-        logging_utils.add_firewall_metadata(flow, log_entry)
-
-        assert log_entry == {
-            "firewall_base": "",
-            "firewall_name": "",
-            "firewall_permission": "",
-            "firewall_rule_match": "",
-            "firewall_billable": False,
-        }

--- a/crates/runner/mitm-addon/tests/test_response_handler.py
+++ b/crates/runner/mitm-addon/tests/test_response_handler.py
@@ -102,7 +102,7 @@ class TestResponseHandler:
                 metadata_keys.ORIGINAL_URL: "https://api.example.com/items",
                 metadata_keys.FIREWALL_ACTION: "ALLOW",
                 metadata_keys.FIREWALL_BASE: "https://api.example.com",
-                metadata_keys.FIREWALL_NAME: "example",
+                metadata_keys.FIREWALL_NAME: "model-provider:example",
                 metadata_keys.FIREWALL_PERMISSION: "read",
                 metadata_keys.FIREWALL_RULE_MATCH: "GET /items",
                 metadata_keys.FIREWALL_BILLABLE: True,
@@ -121,7 +121,7 @@ class TestResponseHandler:
 
         entry = json.loads(Path(log_path).read_text().strip())
         assert entry["firewall_base"] == "https://api.example.com"
-        assert entry["firewall_name"] == "example"
+        assert entry["firewall_name"] == "model-provider:example"
         assert entry["firewall_permission"] == "read"
         assert entry["firewall_rule_match"] == "GET /items"
         assert entry["firewall_billable"] is True

--- a/crates/runner/mitm-addon/tests/test_response_handler.py
+++ b/crates/runner/mitm-addon/tests/test_response_handler.py
@@ -92,6 +92,48 @@ class TestResponseHandler:
         assert entry["port"] == 9443
         assert entry["url"] == "https://target.example.com:9443/path"
 
+    def test_response_log_includes_firewall_auth_metadata(self, tmp_path, real_flow, mitm_ctx):
+        flow = real_flow(with_response=False, host="api.example.com", path="/items")
+        log_path = str(tmp_path / "network.jsonl")
+        flow.metadata.update(
+            {
+                metadata_keys.VM_RUN_ID: "run-abc-123",
+                metadata_keys.VM_NETWORK_LOG_PATH: log_path,
+                metadata_keys.ORIGINAL_URL: "https://api.example.com/items",
+                metadata_keys.FIREWALL_ACTION: "ALLOW",
+                metadata_keys.FIREWALL_BASE: "https://api.example.com",
+                metadata_keys.FIREWALL_NAME: "example",
+                metadata_keys.FIREWALL_PERMISSION: "read",
+                metadata_keys.FIREWALL_RULE_MATCH: "GET /items",
+                metadata_keys.FIREWALL_BILLABLE: True,
+                metadata_keys.FIREWALL_PARAMS: {"owner": "vm0-ai", "repo": "vm0"},
+                metadata_keys.FIREWALL_ERROR: "TOKEN_REFRESH_FAILED",
+                metadata_keys.AUTH_RESOLVED_SECRETS: ["GITHUB_TOKEN"],
+                metadata_keys.AUTH_REFRESHED_CONNECTORS: ["github"],
+                metadata_keys.AUTH_REFRESHED_SECRETS: ["GITHUB_TOKEN"],
+                metadata_keys.AUTH_CACHE_HIT: False,
+                metadata_keys.AUTH_URL_REWRITE: True,
+            }
+        )
+        flow.response = tutils.tresp(status_code=200, headers=header_map({"content-length": "0"}))
+
+        with mitm_ctx():
+            mitm_addon.response(flow)
+
+        entry = json.loads(Path(log_path).read_text().strip())
+        assert entry["firewall_base"] == "https://api.example.com"
+        assert entry["firewall_name"] == "example"
+        assert entry["firewall_permission"] == "read"
+        assert entry["firewall_rule_match"] == "GET /items"
+        assert entry["firewall_billable"] is True
+        assert entry["firewall_params"] == {"owner": "vm0-ai", "repo": "vm0"}
+        assert entry["firewall_error"] == "TOKEN_REFRESH_FAILED"
+        assert entry["auth_resolved_secrets"] == ["GITHUB_TOKEN"]
+        assert entry["auth_refreshed_connectors"] == ["github"]
+        assert entry["auth_refreshed_secrets"] == ["GITHUB_TOKEN"]
+        assert entry["auth_cache_hit"] is False
+        assert entry["auth_url_rewrite"] is True
+
     @pytest.mark.parametrize(
         ("raw_url", "expected_url"),
         [

--- a/crates/runner/mitm-addon/tests/test_response_handler.py
+++ b/crates/runner/mitm-addon/tests/test_response_handler.py
@@ -107,7 +107,6 @@ class TestResponseHandler:
                 metadata_keys.FIREWALL_RULE_MATCH: "GET /items",
                 metadata_keys.FIREWALL_BILLABLE: True,
                 metadata_keys.FIREWALL_PARAMS: {"owner": "vm0-ai", "repo": "vm0"},
-                metadata_keys.FIREWALL_ERROR: "TOKEN_REFRESH_FAILED",
                 metadata_keys.AUTH_RESOLVED_SECRETS: ["GITHUB_TOKEN"],
                 metadata_keys.AUTH_REFRESHED_CONNECTORS: ["github"],
                 metadata_keys.AUTH_REFRESHED_SECRETS: ["GITHUB_TOKEN"],
@@ -127,7 +126,6 @@ class TestResponseHandler:
         assert entry["firewall_rule_match"] == "GET /items"
         assert entry["firewall_billable"] is True
         assert entry["firewall_params"] == {"owner": "vm0-ai", "repo": "vm0"}
-        assert entry["firewall_error"] == "TOKEN_REFRESH_FAILED"
         assert entry["auth_resolved_secrets"] == ["GITHUB_TOKEN"]
         assert entry["auth_refreshed_connectors"] == ["github"]
         assert entry["auth_refreshed_secrets"] == ["GITHUB_TOKEN"]

--- a/docs/testing/mitm-addon-testing.md
+++ b/docs/testing/mitm-addon-testing.md
@@ -93,7 +93,7 @@ phases:
 
 ```python
 def test_firewall_response_logs_context(tmp_path, real_flow, mitm_ctx):
-    flow = real_flow(with_response=False, host="api.github.com", path="/repos")
+    flow = real_flow(with_response=True, host="api.github.com", path="/repos")
     flow.metadata.update(
         {
             "vm_run_id": "run-abc-123",

--- a/docs/testing/mitm-addon-testing.md
+++ b/docs/testing/mitm-addon-testing.md
@@ -84,25 +84,33 @@ def registry_file(tmp_path):
     return path
 ```
 
-### Mock HTTP Flows
+### Real HTTP Flows
 
-Build mock mitmproxy flow objects for testing:
+Use the shared `real_flow` fixture when a test needs an HTTP flow. It builds a
+real `mitmproxy.http.HTTPFlow` with real request, response, headers, and
+metadata semantics, while still letting the test seed metadata for later hook
+phases:
 
 ```python
-def _make_http_flow(client_ip="10.200.0.1", host="example.com", port=443, path="/"):
-    flow = MagicMock()
-    flow.client_conn.peername = (client_ip, 12345)
-    flow.request.pretty_host = host
-    flow.request.port = port
-    flow.request.path = path
-    flow.request.pretty_url = f"https://{host}{path}"
-    flow.request.method = "GET"
-    flow.request.content = b""
-    flow.request.headers = {}
-    flow.metadata = {}
-    flow.response = None
-    return flow
+def test_firewall_response_logs_context(tmp_path, real_flow, mitm_ctx):
+    flow = real_flow(with_response=False, host="api.github.com", path="/repos")
+    flow.metadata.update(
+        {
+            "vm_run_id": "run-abc-123",
+            "vm_network_log_path": str(tmp_path / "network.jsonl"),
+            "original_url": "https://api.github.com/repos",
+            "firewall_action": "ALLOW",
+        }
+    )
+
+    with mitm_ctx():
+        mitm_addon.response(flow)
 ```
+
+Do not hand-build `MagicMock` HTTP flows for addon hook tests. Mocks and stubs
+are still appropriate at real external boundaries such as `mitmproxy.ctx`,
+external HTTP clients, or protocol objects that mitmproxy does not expose
+through test constructors.
 
 ### Module State Reset
 
@@ -120,25 +128,30 @@ def _reset_module_state():
 
 ### Mocking with patch
 
-Use `unittest.mock.patch` for module-level functions:
+Patch at real external boundaries. For example, request hook tests can use the
+shared `fake_firewall_headers` fixture to stub the auth-service boundary while
+still running the real dispatcher and firewall handler:
 
 ```python
-from unittest.mock import MagicMock, patch
-
-def test_service_match_calls_handler(registry_file):
-    flow = _make_http_flow(host="api.github.com", path="/repos")
+async def test_firewall_request_injects_auth(
+    tmp_path, real_flow, mitm_ctx, fake_firewall_headers
+):
+    reg_path = _write_github_firewall_registry(tmp_path)
+    flow = real_flow(with_response=False, host="api.github.com", path="/repos")
 
     with (
-        patch.object(mitm_addon, "get_registry_path", return_value=str(registry_file)),
-        patch.object(mitm_addon, "handle_service_request") as mock_handler,
+        mitm_ctx(registry_path=str(reg_path)),
+        fake_firewall_headers(headers={"Authorization": "Bearer real-token"}),
     ):
-        mitm_addon.request(flow)
+        await mitm_addon.request(flow)
 
-    mock_handler.assert_called_once()
-    call_args = mock_handler.call_args
-    assert call_args[0][0] is flow
-    assert call_args[0][1]["base"] == "https://api.github.com"
+    assert flow.request.headers["Authorization"] == "Bearer real-token"
+    assert flow.metadata["firewall_action"] == "ALLOW"
 ```
+
+Avoid patching internal handlers only to prove they were called. Assert the flow
+state, response, log entry, or other observable behavior produced by the real
+hook path.
 
 ### Asserting Flow State
 
@@ -148,7 +161,7 @@ Check flow metadata and response after handler execution:
 # Service auth injected
 assert flow.request.headers["Authorization"] == "Bearer real-token"
 assert flow.metadata["firewall_action"] == "ALLOW"
-assert flow.metadata["service_base"] == "https://api.github.com"
+assert flow.metadata["firewall_base"] == "https://api.github.com"
 ```
 
 ### Shared Flow Metadata Keys


### PR DESCRIPTION
## Summary
- Move mitm-addon logging utility tests out of `test_registry.py` into `test_logging_utils.py`.
- Replace mock firewall metadata helper flows with real `HTTPFlow` instances from the shared `real_flow` fixture.
- Add response-hook JSONL coverage for valid firewall/auth metadata output.
- Update mitm-addon testing docs to recommend real HTTP flows and external-boundary mocks.

Closes #15804

## Tests
- `/tmp/vm0-mitm-addon-venv/bin/pytest tests/test_logging_utils.py`
- `/tmp/vm0-mitm-addon-venv/bin/pytest tests/test_response_handler.py -k firewall`
- `/tmp/vm0-mitm-addon-venv/bin/pytest tests/test_registry.py`
- `/tmp/vm0-mitm-addon-venv/bin/pytest tests/test_logging_utils.py tests/test_registry.py tests/test_response_handler.py tests/test_error_handler.py`
- `/tmp/vm0-mitm-addon-venv/bin/python -m ruff format --check tests/test_logging_utils.py tests/test_registry.py tests/test_response_handler.py`
- `/tmp/vm0-mitm-addon-venv/bin/python -m ruff check tests/test_logging_utils.py tests/test_registry.py tests/test_response_handler.py`
- `git diff --check`
