### PR TITLE
feat: add source grounding to presentation generation

### DIFF
--- a/turbo/apps/cli/src/commands/zero/generate/__tests__/presentation.test.ts
+++ b/turbo/apps/cli/src/commands/zero/generate/__tests__/presentation.test.ts
@@ -50,13 +50,6 @@ describe("zero generate presentation command", () => {
     const stdout = mockConsoleLog.mock.calls.flat().join("\n");
     expect(stdout).toContain("# Zero generate presentation");
     expect(stdout).toContain("federated generation source-selection packet");
-    expect(stdout).toContain("## Stage 0: Source-Grounded Deck Planning");
-    expect(stdout).toContain(
-      "Use this stage when the user supplies files, links, transcripts, notes, or asks for a source-based deck.",
-    );
-    expect(stdout).toContain(
-      "Do not fabricate unsupported facts, metrics, quotes, examples, or conclusions. Mark gaps or assumptions explicitly.",
-    );
     expect(stdout).toContain("## Stage 1: Resource Selection");
     expect(stdout).toContain("## Candidate Registry Slice");
     expect(stdout).toContain("API migration plan");
@@ -71,6 +64,9 @@ describe("zero generate presentation command", () => {
     );
     expect(stdout).toContain("Slide count: 10");
     expect(stdout).toContain("Use a fixed 1920x1080 slide canvas");
+    expect(stdout).toContain("establish the deck's arc");
+    expect(stdout).toContain("Vary slide forms across the deck");
+    expect(stdout).toContain("Each slide carries one idea");
   });
 
   it("should expose only base artifact flags plus slides in help", () => {

--- a/turbo/apps/cli/src/commands/zero/generate/__tests__/presentation.test.ts
+++ b/turbo/apps/cli/src/commands/zero/generate/__tests__/presentation.test.ts
@@ -50,6 +50,13 @@ describe("zero generate presentation command", () => {
     const stdout = mockConsoleLog.mock.calls.flat().join("\n");
     expect(stdout).toContain("# Zero generate presentation");
     expect(stdout).toContain("federated generation source-selection packet");
+    expect(stdout).toContain("## Stage 0: Source-Grounded Deck Planning");
+    expect(stdout).toContain(
+      "Use this stage when the user supplies files, links, transcripts, notes, or asks for a source-based deck.",
+    );
+    expect(stdout).toContain(
+      "Do not fabricate unsupported facts, metrics, quotes, examples, or conclusions. Mark gaps or assumptions explicitly.",
+    );
     expect(stdout).toContain("## Stage 1: Resource Selection");
     expect(stdout).toContain("## Candidate Registry Slice");
     expect(stdout).toContain("API migration plan");

--- a/turbo/apps/cli/src/commands/zero/shared/html-artifact-authoring.ts
+++ b/turbo/apps/cli/src/commands/zero/shared/html-artifact-authoring.ts
@@ -13,6 +13,7 @@ interface HtmlArtifactAuthoringOptions {
   readonly slugSource?: string;
   readonly siteSlug?: string;
   readonly details: readonly string[];
+  readonly contentPlanningRules?: readonly string[];
   readonly artifactRules: readonly string[];
 }
 
@@ -50,6 +51,7 @@ interface HtmlArtifactAuthoringPacket {
   };
   readonly authoring: {
     readonly details: readonly string[];
+    readonly contentPlanningRules?: readonly string[];
     readonly artifactRules: readonly string[];
   };
   readonly outputDir: string;
@@ -89,6 +91,23 @@ function outputDirForSite(site: string): string {
   return `./generated/mockups/${site}`;
 }
 
+function formatRuleList(rules: readonly string[]): string[] {
+  return rules.map((rule) => {
+    return `- ${rule}`;
+  });
+}
+
+function buildOptionalRuleSection(
+  title: string,
+  rules: readonly string[],
+): string[] {
+  if (rules.length === 0) {
+    return [];
+  }
+
+  return [`## ${title}`, ...formatRuleList(rules), ""];
+}
+
 export function createHtmlArtifactAuthoringPacket(
   options: HtmlArtifactAuthoringOptions,
 ): HtmlArtifactAuthoringPacket {
@@ -100,6 +119,11 @@ export function createHtmlArtifactAuthoringPacket(
   }`;
   const title = titleForKind(options.kind);
   const candidateSlice = selectResourceCandidates(options.kind);
+  const contentPlanningRules = options.contentPlanningRules ?? [];
+  const contentPlanningSection = buildOptionalRuleSection(
+    "Stage 0: Source-Grounded Deck Planning",
+    contentPlanningRules,
+  );
   const selectionSchema = {
     skills: "string[]",
     template: "string",
@@ -150,6 +174,7 @@ export function createHtmlArtifactAuthoringPacket(
     "## User Prompt",
     options.prompt,
     "",
+    ...contentPlanningSection,
     "## Stage 1: Resource Selection",
     "- Choose generation resources from the bundled federated registry slice below.",
     "- Select one template, one or more skills, zero or one design system, and optional media/style resources when relevant.",
@@ -240,6 +265,7 @@ export function createHtmlArtifactAuthoringPacket(
     },
     authoring: {
       details: options.details,
+      ...(contentPlanningRules.length > 0 ? { contentPlanningRules } : {}),
       artifactRules: options.artifactRules,
     },
     outputDir,

--- a/turbo/apps/cli/src/commands/zero/shared/presentation-generate.ts
+++ b/turbo/apps/cli/src/commands/zero/shared/presentation-generate.ts
@@ -178,20 +178,15 @@ ${formatRegistryListing(templates, "presentation templates")}`;
                 : "agent decides"
             }`,
           ],
-          contentPlanningRules: [
-            "Use this stage when the user supplies files, links, transcripts, notes, or asks for a source-based deck.",
-            "Read the sources before drafting slide content. The prompt defines objective, audience, and tone; the sources define facts.",
-            "Extract the source structure, key claims, evidence, metrics, dates, named entities, tables, charts, and reusable visuals.",
-            "Draft an internal slide plan before authoring: slide purpose, sourced claims, key bullets, visual treatment, source anchors, and gaps.",
-            "Do not fabricate unsupported facts, metrics, quotes, examples, or conclusions. Mark gaps or assumptions explicitly.",
-            "For prompt-only decks, avoid fake specificity and do not imply source grounding.",
-          ],
           artifactRules: [
             "Think like a presentation designer, not a web page designer.",
             "Use a fixed 1920x1080 slide canvas and scale it uniformly for smaller viewports.",
             "Use one section per slide and keep repeated elements in consistent positions.",
             "Make keyboard navigation work with ArrowLeft, ArrowRight, Home, and End.",
             "Keep slide text readable from across a room; avoid memo-like walls of text.",
+            "Before laying out slides, establish the deck's arc: the opening problem or question, how it develops, and what conclusion lands; every slide should serve a clear narrative role in that arc.",
+            "Vary slide forms across the deck — full-bleed statement, evidence with data, pull quote, section break, summary — and avoid defaulting every slide to title-plus-bullets.",
+            "Each slide carries one idea; prefer a single strong statement over a list, and never exceed three bullets on any slide.",
           ],
         });
 

--- a/turbo/apps/cli/src/commands/zero/shared/presentation-generate.ts
+++ b/turbo/apps/cli/src/commands/zero/shared/presentation-generate.ts
@@ -178,6 +178,14 @@ ${formatRegistryListing(templates, "presentation templates")}`;
                 : "agent decides"
             }`,
           ],
+          contentPlanningRules: [
+            "Use this stage when the user supplies files, links, transcripts, notes, or asks for a source-based deck.",
+            "Read the sources before drafting slide content. The prompt defines objective, audience, and tone; the sources define facts.",
+            "Extract the source structure, key claims, evidence, metrics, dates, named entities, tables, charts, and reusable visuals.",
+            "Draft an internal slide plan before authoring: slide purpose, sourced claims, key bullets, visual treatment, source anchors, and gaps.",
+            "Do not fabricate unsupported facts, metrics, quotes, examples, or conclusions. Mark gaps or assumptions explicitly.",
+            "For prompt-only decks, avoid fake specificity and do not imply source grounding.",
+          ],
           artifactRules: [
             "Think like a presentation designer, not a web page designer.",
             "Use a fixed 1920x1080 slide canvas and scale it uniformly for smaller viewports.",


### PR DESCRIPTION
## Summary
- add an optional source-grounded content planning stage to HTML artifact authoring packets
- enable that stage for presentation generation so source-backed decks read source material, extract claims, plan outlines, and avoid unsupported facts
- cover the presentation packet output in the existing CLI command test

## Verification
- pnpm exec prettier --write apps/cli/src/commands/zero/shared/html-artifact-authoring.ts apps/cli/src/commands/zero/shared/presentation-generate.ts apps/cli/src/commands/zero/generate/__tests__/presentation.test.ts
- pnpm -F @vm0/cli exec vitest run src/commands/zero/generate/__tests__/presentation.test.ts
- pnpm -F @vm0/cli lint
- pnpm -F @vm0/cli check-types