### PR TITLE
test(mitm-addon): detect stale x tld snapshot drift

### DIFF
--- a/crates/runner/mitm-addon/scripts/update_x_tlds.py
+++ b/crates/runner/mitm-addon/scripts/update_x_tlds.py
@@ -14,6 +14,7 @@ import urllib.request
 from http import HTTPStatus
 from pathlib import Path
 from types import ModuleType
+from typing import NamedTuple
 
 SOURCE_HOST = "data.iana.org"
 SOURCE_PATH = "/TLD/tlds-alpha-by-domain.txt"
@@ -28,6 +29,23 @@ TLD_RE = re.compile(r"^[a-z0-9-]+$")
 class _NoRedirect(urllib.request.HTTPRedirectHandler):
     def redirect_request(self, req, fp, code, msg, headers, newurl):
         return None
+
+
+class SnapshotComparison(NamedTuple):
+    checked_version: str
+    source_version: str
+    checked_count: int
+    source_count: int
+    added: tuple[str, ...]
+    removed: tuple[str, ...]
+
+    @property
+    def has_set_drift(self) -> bool:
+        return bool(self.added or self.removed)
+
+    @property
+    def has_version_drift(self) -> bool:
+        return self.checked_version != self.source_version
 
 
 def fetch_source() -> str:
@@ -149,6 +167,45 @@ def check_generated() -> int:
     return 1
 
 
+def compare_snapshot_to_source(source: str) -> SnapshotComparison:
+    checked_version, checked_tlds = read_existing_snapshot()
+    source_version, source_tlds = parse_source(source)
+    checked_set = set(checked_tlds)
+    source_set = set(source_tlds)
+    return SnapshotComparison(
+        checked_version=checked_version,
+        source_version=source_version,
+        checked_count=len(checked_tlds),
+        source_count=len(source_tlds),
+        added=tuple(sorted(source_set - checked_set)),
+        removed=tuple(sorted(checked_set - source_set)),
+    )
+
+
+def check_source(source_file: Path) -> int:
+    comparison = compare_snapshot_to_source(source_file.read_text(encoding="utf-8"))
+    sys.stdout.write(
+        f"checked-in IANA TLD version {comparison.checked_version} "
+        f"({comparison.checked_count} TLDs)\n"
+    )
+    sys.stdout.write(
+        f"source IANA TLD version {comparison.source_version} ({comparison.source_count} TLDs)\n"
+    )
+    if comparison.has_set_drift:
+        sys.stderr.write("IANA TLD set drift detected\n")
+        if comparison.added:
+            sys.stderr.write(f"added: {', '.join(comparison.added)}\n")
+        if comparison.removed:
+            sys.stderr.write(f"removed: {', '.join(comparison.removed)}\n")
+        return 1
+
+    if comparison.has_version_drift:
+        sys.stdout.write("IANA TLD version differs, but the TLD set is unchanged\n")
+    else:
+        sys.stdout.write("IANA TLD version and TLD set match supplied source\n")
+    return 0
+
+
 def write_generated_module(contents: str) -> None:
     tmp_path: Path | None = None
     try:
@@ -184,14 +241,25 @@ def main() -> int:
         help="verify the checked-in generated module is canonical without network access",
     )
     parser.add_argument(
+        "--check-source",
+        action="store_true",
+        help="compare the checked-in TLD set against --source-file without updating",
+    )
+    parser.add_argument(
         "--source-file",
         type=Path,
         help="read an IANA tlds-alpha-by-domain.txt file instead of fetching the live source",
     )
     args = parser.parse_args()
 
+    if args.check and args.check_source:
+        parser.error("--check cannot be combined with --check-source")
     if args.check:
         if args.source_file is not None:
             parser.error("--check cannot be combined with --source-file")
         return check_generated()
+    if args.check_source:
+        if args.source_file is None:
+            parser.error("--check-source requires --source-file")
+        return check_source(args.source_file)
     return update_generated(args.source_file)

--- a/crates/runner/mitm-addon/tests/test_update_x_tlds.py
+++ b/crates/runner/mitm-addon/tests/test_update_x_tlds.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import subprocess
 import sys
+from collections.abc import Iterable
 from pathlib import Path
 
 import pytest
@@ -12,6 +13,23 @@ from usage.providers.connectors.x_tlds import IANA_TLD_VERSION, IANA_TLDS
 _ADDON_ROOT = Path(__file__).resolve().parents[1]
 _UPDATE_SCRIPT = _ADDON_ROOT / "scripts" / "update-x-tlds.py"
 _CLI_TIMEOUT_SECONDS = 30
+
+
+def _source_text(version: str, tlds: Iterable[str]) -> str:
+    return f"# Version {version}, Last Updated test\n" + "\n".join(sorted(tlds)) + "\n"
+
+
+def _run_update_script(*args: str) -> subprocess.CompletedProcess[str]:
+    command = [sys.executable, str(_UPDATE_SCRIPT), *args]
+
+    # Trusted workspace tooling with constant argv; no user-controlled shell input.
+    return subprocess.run(  # noqa: S603
+        command,
+        text=True,
+        capture_output=True,
+        check=False,
+        timeout=_CLI_TIMEOUT_SECONDS,
+    )
 
 
 def test_parse_source_normalizes_sorts_and_deduplicates_tlds():
@@ -85,20 +103,98 @@ def test_snapshot_has_version_and_expected_stable_entries():
     assert {"ai", "com", "dev", "museum", "xn--q9jyb4c"} <= IANA_TLDS
 
 
-def test_check_generated_cli_accepts_checked_in_snapshot():
-    command = [sys.executable, str(_UPDATE_SCRIPT), "--check"]
+def test_compare_snapshot_to_source_accepts_version_only_drift():
+    source_version = "9999999999"
 
-    # Trusted workspace tooling with constant argv; no user-controlled shell input.
-    completed = subprocess.run(  # noqa: S603
-        command,
-        text=True,
-        capture_output=True,
-        check=False,
-        timeout=_CLI_TIMEOUT_SECONDS,
+    comparison = update_x_tlds.compare_snapshot_to_source(_source_text(source_version, IANA_TLDS))
+
+    assert comparison.checked_version == IANA_TLD_VERSION
+    assert comparison.source_version == source_version
+    assert comparison.checked_count == len(IANA_TLDS)
+    assert comparison.source_count == len(IANA_TLDS)
+    assert not comparison.has_set_drift
+    assert comparison.has_version_drift
+    assert comparison.added == ()
+    assert comparison.removed == ()
+
+
+def test_compare_snapshot_to_source_reports_added_tlds():
+    added_tld = "zzexampletest"
+    source_tlds = set(IANA_TLDS)
+    source_tlds.add(added_tld)
+
+    comparison = update_x_tlds.compare_snapshot_to_source(
+        _source_text(IANA_TLD_VERSION, source_tlds)
     )
+
+    assert added_tld not in IANA_TLDS
+    assert comparison.has_set_drift
+    assert comparison.added == (added_tld,)
+    assert comparison.removed == ()
+
+
+def test_compare_snapshot_to_source_reports_removed_tlds():
+    removed_tld = "com"
+    source_tlds = set(IANA_TLDS)
+    source_tlds.remove(removed_tld)
+
+    comparison = update_x_tlds.compare_snapshot_to_source(
+        _source_text(IANA_TLD_VERSION, source_tlds)
+    )
+
+    assert comparison.has_set_drift
+    assert comparison.added == ()
+    assert comparison.removed == (removed_tld,)
+
+
+def test_check_generated_cli_accepts_checked_in_snapshot():
+    completed = _run_update_script("--check")
 
     assert completed.returncode == 0, (
         f"{_UPDATE_SCRIPT} --check failed with exit code {completed.returncode}.\n\n"
         f"stdout:\n{completed.stdout}\n\n"
         f"stderr:\n{completed.stderr}"
     )
+
+
+def test_check_source_cli_accepts_version_only_drift(tmp_path):
+    source_version = "9999999999"
+    source = tmp_path / "tlds.txt"
+    source.write_text(_source_text(source_version, IANA_TLDS), encoding="utf-8")
+
+    completed = _run_update_script("--check-source", "--source-file", str(source))
+
+    assert completed.returncode == 0, (
+        f"{_UPDATE_SCRIPT} --check-source failed with exit code {completed.returncode}.\n\n"
+        f"stdout:\n{completed.stdout}\n\n"
+        f"stderr:\n{completed.stderr}"
+    )
+    assert f"checked-in IANA TLD version {IANA_TLD_VERSION}" in completed.stdout
+    assert f"source IANA TLD version {source_version}" in completed.stdout
+    assert "version differs, but the TLD set is unchanged" in completed.stdout
+
+
+def test_check_source_cli_reports_set_drift(tmp_path):
+    added_tld = "zzexampletest"
+    removed_tld = "com"
+    source_tlds = set(IANA_TLDS)
+    source_tlds.add(added_tld)
+    source_tlds.remove(removed_tld)
+    source = tmp_path / "tlds.txt"
+    source.write_text(_source_text(IANA_TLD_VERSION, source_tlds), encoding="utf-8")
+
+    completed = _run_update_script("--check-source", "--source-file", str(source))
+
+    assert completed.returncode == 1
+    assert f"checked-in IANA TLD version {IANA_TLD_VERSION}" in completed.stdout
+    assert f"source IANA TLD version {IANA_TLD_VERSION}" in completed.stdout
+    assert "IANA TLD set drift detected" in completed.stderr
+    assert f"added: {added_tld}" in completed.stderr
+    assert f"removed: {removed_tld}" in completed.stderr
+
+
+def test_check_source_cli_requires_source_file():
+    completed = _run_update_script("--check-source")
+
+    assert completed.returncode != 0
+    assert "--check-source requires --source-file" in completed.stderr


### PR DESCRIPTION
## Summary

- Add `--check-source --source-file <path>` to compare the checked-in X IANA TLD snapshot against a supplied IANA source document without updating files.
- Fail only when the TLD set has added or removed entries; version-only drift succeeds and is reported as informational output.
- Add offline pytest coverage for version-only drift, added TLDs, removed TLDs, and CLI argument handling.

## Notes

This intentionally does not add live IANA access to required PR CI and does not update `x_tlds.py` for version-only drift.

Closes #15803

## Verification

- `ruff check .`
- `ruff format --check .`
- `basedpyright -p .`
- `python3 -m pytest tests/test_update_x_tlds.py -v`
- `python3 -m pytest tests/test_x_billing.py -v`
- `python3 -m pytest tests/ -q`
