### PR TITLE
refactor(mitm-addon): sync stream usage delivery tests

### DIFF
--- a/crates/runner/mitm-addon/tests/test_model_provider_stream_usage.py
+++ b/crates/runner/mitm-addon/tests/test_model_provider_stream_usage.py
@@ -5,6 +5,7 @@ import uuid
 from collections.abc import Callable
 from pathlib import Path
 
+import pytest
 from mitmproxy import http, websocket
 from mitmproxy.flow import Error
 from mitmproxy.test import tutils
@@ -133,9 +134,36 @@ def _assert_single_model_sse_parse_warning(
 class TestModelProviderStreamUsage:
     """Tests for model-provider SSE and WebSocket usage reporting."""
 
-    def test_full_pipeline_model_sse_finalizes_trailing_event(
-        self, tmp_path, real_flow, mitm_ctx, fresh_usage_executor, usage_webhook_api
-    ):
+    @pytest.fixture(autouse=True)
+    def _sync_usage_delivery(self, sync_usage_executor, usage_webhook_api):
+        self._usage_webhook_api = usage_webhook_api
+
+    def _run_response(self, flow: http.HTTPFlow):
+        with self._usage_webhook_api() as webhook:
+            mitm_addon.response(flow)
+            usage.flush_usage_events(trigger="test")
+        return webhook
+
+    def _run_error(self, flow: http.HTTPFlow):
+        with self._usage_webhook_api() as webhook:
+            mitm_addon.error(flow)
+            usage.flush_usage_events(trigger="test")
+        return webhook
+
+    def _run_websocket_end(self, flow: http.HTTPFlow):
+        with self._usage_webhook_api() as webhook:
+            mitm_addon.websocket_end(flow)
+            usage.flush_usage_events(trigger="test")
+        return webhook
+
+    def _run_websocket_message_and_end(self, flow: http.HTTPFlow):
+        with self._usage_webhook_api() as webhook:
+            mitm_addon.websocket_message(flow)
+            mitm_addon.websocket_end(flow)
+            usage.flush_usage_events(trigger="test")
+        return webhook
+
+    def test_full_pipeline_model_sse_finalizes_trailing_event(self, tmp_path, real_flow):
         """response() must flush a trailing SSE usage event before reporting."""
         flow = _openai_responses_sse_flow(tmp_path, real_flow)
         response_stream(flow)(
@@ -145,10 +173,7 @@ class TestModelProviderStreamUsage:
             b'"input_tokens_details":{"cached_tokens":10}}}}'
         )
 
-        with usage_webhook_api() as webhook:
-            mitm_addon.response(flow)
-            usage.flush_usage_events(trigger="test")
-            usage.webhook.usage_executor.shutdown(wait=True)
+        webhook = self._run_response(flow)
 
         events = webhook.usage_events()
         by_category = {event["category"]: event["quantity"] for event in events}
@@ -158,9 +183,7 @@ class TestModelProviderStreamUsage:
             "tokens.cache_read": 10,
         }
 
-    def test_full_pipeline_model_sse_reports_response_incomplete_usage(
-        self, tmp_path, real_flow, mitm_ctx, fresh_usage_executor, usage_webhook_api
-    ):
+    def test_full_pipeline_model_sse_reports_response_incomplete_usage(self, tmp_path, real_flow):
         flow = _openai_responses_sse_flow(tmp_path, real_flow)
         response_stream(flow)(
             b"event: response.incomplete\n"
@@ -169,10 +192,7 @@ class TestModelProviderStreamUsage:
             b'"input_tokens_details":{"cached_tokens":2000}}}}\n\n'
         )
 
-        with usage_webhook_api() as webhook:
-            mitm_addon.response(flow)
-            usage.flush_usage_events(trigger="test")
-            usage.webhook.usage_executor.shutdown(wait=True)
+        webhook = self._run_response(flow)
 
         events = webhook.usage_events()
         by_category = {event["category"]: event["quantity"] for event in events}
@@ -183,9 +203,7 @@ class TestModelProviderStreamUsage:
         }
         assert {event["provider"] for event in events} == {"gpt-5.5"}
 
-    def test_full_pipeline_anthropic_sse_logs_truncated_message_start(
-        self, tmp_path, real_flow, mitm_ctx, fresh_usage_executor, usage_webhook_api
-    ):
+    def test_full_pipeline_anthropic_sse_logs_truncated_message_start(self, tmp_path, real_flow):
         flow = _model_provider_sse_flow(
             tmp_path,
             real_flow,
@@ -197,10 +215,7 @@ class TestModelProviderStreamUsage:
             b'event: message_start\ndata: {"type":"message_start","message":{"id":"msg_1","mod'
         )
 
-        with usage_webhook_api() as webhook:
-            mitm_addon.response(flow)
-            usage.flush_usage_events(trigger="test")
-            usage.webhook.usage_executor.shutdown(wait=True)
+        webhook = self._run_response(flow)
 
         assert webhook.request_count == 0
         _assert_single_model_sse_parse_warning(
@@ -210,7 +225,7 @@ class TestModelProviderStreamUsage:
         )
 
     def test_full_pipeline_anthropic_sse_error_logs_truncated_message_start(
-        self, tmp_path, real_flow, mitm_ctx, fresh_usage_executor, usage_webhook_api
+        self, tmp_path, real_flow
     ):
         flow = _model_provider_sse_flow(
             tmp_path,
@@ -224,10 +239,7 @@ class TestModelProviderStreamUsage:
         )
         flow.error = Error("connection reset by peer")
 
-        with usage_webhook_api() as webhook:
-            mitm_addon.error(flow)
-            usage.flush_usage_events(trigger="test")
-            usage.webhook.usage_executor.shutdown(wait=True)
+        webhook = self._run_error(flow)
 
         assert webhook.request_count == 0
         _assert_single_model_sse_parse_warning(
@@ -236,9 +248,7 @@ class TestModelProviderStreamUsage:
             event="message_start",
         )
 
-    def test_full_pipeline_anthropic_sse_logs_malformed_message_start(
-        self, tmp_path, real_flow, mitm_ctx, fresh_usage_executor, usage_webhook_api
-    ):
+    def test_full_pipeline_anthropic_sse_logs_malformed_message_start(self, tmp_path, real_flow):
         flow = _model_provider_sse_flow(
             tmp_path,
             real_flow,
@@ -248,10 +258,7 @@ class TestModelProviderStreamUsage:
         )
         response_stream(flow)(b"event: message_start\ndata: {invalid json}\n\n")
 
-        with usage_webhook_api() as webhook:
-            mitm_addon.response(flow)
-            usage.flush_usage_events(trigger="test")
-            usage.webhook.usage_executor.shutdown(wait=True)
+        webhook = self._run_response(flow)
 
         assert webhook.request_count == 0
         _assert_single_model_sse_parse_warning(
@@ -261,7 +268,7 @@ class TestModelProviderStreamUsage:
         )
 
     def test_full_pipeline_anthropic_sse_logs_truncated_message_delta_after_start(
-        self, tmp_path, real_flow, mitm_ctx, fresh_usage_executor, usage_webhook_api
+        self, tmp_path, real_flow
     ):
         flow = _model_provider_sse_flow(
             tmp_path,
@@ -278,10 +285,7 @@ class TestModelProviderStreamUsage:
             b'data: {"type":"message_delta","usage":{"output_tokens":'
         )
 
-        with usage_webhook_api() as webhook:
-            mitm_addon.response(flow)
-            usage.flush_usage_events(trigger="test")
-            usage.webhook.usage_executor.shutdown(wait=True)
+        webhook = self._run_response(flow)
 
         events = webhook.usage_events()
         by_category = {event["category"]: event["quantity"] for event in events}
@@ -293,19 +297,14 @@ class TestModelProviderStreamUsage:
             event="message_delta",
         )
 
-    def test_full_pipeline_openai_sse_logs_truncated_terminal_event(
-        self, tmp_path, real_flow, mitm_ctx, fresh_usage_executor, usage_webhook_api
-    ):
+    def test_full_pipeline_openai_sse_logs_truncated_terminal_event(self, tmp_path, real_flow):
         flow = _openai_responses_sse_flow(tmp_path, real_flow)
         response_stream(flow)(
             b"event: response.completed\n"
             b'data: {"type":"response.completed","response":{"id":"resp_1","model":"gpt'
         )
 
-        with usage_webhook_api() as webhook:
-            mitm_addon.response(flow)
-            usage.flush_usage_events(trigger="test")
-            usage.webhook.usage_executor.shutdown(wait=True)
+        webhook = self._run_response(flow)
 
         assert webhook.request_count == 0
         _assert_single_model_sse_parse_warning(
@@ -314,19 +313,14 @@ class TestModelProviderStreamUsage:
             event="response.completed",
         )
 
-    def test_full_pipeline_openai_sse_logs_truncated_late_event_name(
-        self, tmp_path, real_flow, mitm_ctx, fresh_usage_executor, usage_webhook_api
-    ):
+    def test_full_pipeline_openai_sse_logs_truncated_late_event_name(self, tmp_path, real_flow):
         flow = _openai_responses_sse_flow(tmp_path, real_flow)
         response_stream(flow)(
             b'data: {"type":"response.completed","response":{"id":"resp_1","model":"gpt\n'
             b"event: response.completed\n\n"
         )
 
-        with usage_webhook_api() as webhook:
-            mitm_addon.response(flow)
-            usage.flush_usage_events(trigger="test")
-            usage.webhook.usage_executor.shutdown(wait=True)
+        webhook = self._run_response(flow)
 
         assert webhook.request_count == 0
         _assert_single_model_sse_parse_warning(
@@ -336,7 +330,7 @@ class TestModelProviderStreamUsage:
         )
 
     def test_full_pipeline_eventless_incomplete_anthropic_usage_sse_warns(
-        self, tmp_path, real_flow, mitm_ctx, fresh_usage_executor, usage_webhook_api
+        self, tmp_path, real_flow
     ):
         flow = _model_provider_sse_flow(
             tmp_path,
@@ -349,10 +343,7 @@ class TestModelProviderStreamUsage:
             b'data: {"type":"message_start","message":{"id":"msg_1","model":"claude'
         )
 
-        with usage_webhook_api() as webhook:
-            mitm_addon.response(flow)
-            usage.flush_usage_events(trigger="test")
-            usage.webhook.usage_executor.shutdown(wait=True)
+        webhook = self._run_response(flow)
 
         assert webhook.request_count == 0
         _assert_single_model_sse_parse_warning(
@@ -362,7 +353,7 @@ class TestModelProviderStreamUsage:
         )
 
     def test_full_pipeline_anthropic_non_usage_incomplete_sse_does_not_warn(
-        self, tmp_path, real_flow, mitm_ctx, fresh_usage_executor, usage_webhook_api
+        self, tmp_path, real_flow
     ):
         flow = _model_provider_sse_flow(
             tmp_path,
@@ -376,32 +367,24 @@ class TestModelProviderStreamUsage:
             b'data: {"type":"content_block_delta","delta":{"text":"hello'
         )
 
-        with usage_webhook_api() as webhook:
-            mitm_addon.response(flow)
-            usage.flush_usage_events(trigger="test")
-            usage.webhook.usage_executor.shutdown(wait=True)
+        webhook = self._run_response(flow)
 
         assert webhook.request_count == 0
         assert _model_sse_parse_warnings(flow) == []
 
-    def test_full_pipeline_openai_eventless_incomplete_sse_does_not_warn(
-        self, tmp_path, real_flow, mitm_ctx, fresh_usage_executor, usage_webhook_api
-    ):
+    def test_full_pipeline_openai_eventless_incomplete_sse_does_not_warn(self, tmp_path, real_flow):
         flow = _openai_responses_sse_flow(tmp_path, real_flow)
         response_stream(flow)(
             b'data: {"type":"response.completed","response":{"id":"resp_1","model":"gpt'
         )
 
-        with usage_webhook_api() as webhook:
-            mitm_addon.response(flow)
-            usage.flush_usage_events(trigger="test")
-            usage.webhook.usage_executor.shutdown(wait=True)
+        webhook = self._run_response(flow)
 
         assert webhook.request_count == 0
         assert _model_sse_parse_warnings(flow) == []
 
     def test_full_pipeline_openai_non_terminal_incomplete_sse_does_not_warn(
-        self, tmp_path, real_flow, mitm_ctx, fresh_usage_executor, usage_webhook_api
+        self, tmp_path, real_flow
     ):
         flow = _openai_responses_sse_flow(tmp_path, real_flow)
         response_stream(flow)(
@@ -409,16 +392,13 @@ class TestModelProviderStreamUsage:
             b'data: {"type":"response.in_progress","response":{"id":"resp_1","model":"gpt'
         )
 
-        with usage_webhook_api() as webhook:
-            mitm_addon.response(flow)
-            usage.flush_usage_events(trigger="test")
-            usage.webhook.usage_executor.shutdown(wait=True)
+        webhook = self._run_response(flow)
 
         assert webhook.request_count == 0
         assert _model_sse_parse_warnings(flow) == []
 
     def test_full_pipeline_model_sse_zero_event_preserves_billed_usage_and_id(
-        self, tmp_path, real_flow, mitm_ctx, fresh_usage_executor, usage_webhook_api
+        self, tmp_path, real_flow
     ):
         flow = _openai_responses_sse_flow(tmp_path, real_flow)
         response_stream(flow)(
@@ -430,10 +410,7 @@ class TestModelProviderStreamUsage:
             b'"usage":{"input_tokens":0,"output_tokens":0}}}\n\n'
         )
 
-        with usage_webhook_api() as webhook:
-            mitm_addon.response(flow)
-            usage.flush_usage_events(trigger="test")
-            usage.webhook.usage_executor.shutdown(wait=True)
+        webhook = self._run_response(flow)
 
         events = webhook.usage_events()
         by_category = {event["category"]: event["quantity"] for event in events}
@@ -447,9 +424,7 @@ class TestModelProviderStreamUsage:
             uuid.UUID(key)
         assert {event["provider"] for event in events} == {"gpt-5.5"}
 
-    def test_full_pipeline_model_websocket_reports_usage(
-        self, tmp_path, real_flow, mitm_ctx, fresh_usage_executor, usage_webhook_api
-    ):
+    def test_full_pipeline_model_websocket_reports_usage(self, tmp_path, real_flow):
         """Codex Responses WebSocket frames should bill like SSE events."""
         flow = _openai_model_websocket_flow(tmp_path, real_flow)
         assert flow.metadata["model_websocket_usage_enabled"] is True
@@ -475,11 +450,7 @@ class TestModelProviderStreamUsage:
             ).encode(),
         )
 
-        with usage_webhook_api() as webhook:
-            mitm_addon.websocket_message(flow)
-            mitm_addon.websocket_end(flow)
-            usage.flush_usage_events(trigger="test")
-            usage.webhook.usage_executor.shutdown(wait=True)
+        webhook = self._run_websocket_message_and_end(flow)
 
         events = webhook.usage_events()
         by_category = {event["category"]: event["quantity"] for event in events}
@@ -490,9 +461,7 @@ class TestModelProviderStreamUsage:
             "tokens.cache_read": 10,
         }
 
-    def test_model_websocket_response_keeps_usage_flow_tracked_until_end(
-        self, tmp_path, real_flow, mitm_ctx, fresh_usage_executor, usage_webhook_api
-    ):
+    def test_model_websocket_response_keeps_usage_flow_tracked_until_end(self, tmp_path, real_flow):
         """The HTTP 101 response hook must not complete the WebSocket usage lifecycle."""
         pending_path = tmp_path / "usage-pending"
         usage.set_pending_path(str(pending_path), usage_state_id="test-usage-state-id")
@@ -509,7 +478,7 @@ class TestModelProviderStreamUsage:
             flush_request_id="before-response",
         )
 
-        with usage_webhook_api() as webhook:
+        with self._usage_webhook_api() as webhook:
             mitm_addon.response(flow)
             assert flow.metadata["_usage_flow_tracked"] is True
             usage.write_pending_snapshot(flush_request_id="after-response")
@@ -540,7 +509,6 @@ class TestModelProviderStreamUsage:
             )
             mitm_addon.websocket_end(flow)
             usage.flush_usage_events(trigger="test")
-            usage.webhook.usage_executor.shutdown(wait=True)
 
         events = webhook.usage_events()
         by_category = {event["category"]: event["quantity"] for event in events}
@@ -560,7 +528,7 @@ class TestModelProviderStreamUsage:
         )
 
     def test_full_pipeline_model_websocket_zero_frame_preserves_billed_usage_and_id(
-        self, tmp_path, real_flow, mitm_ctx, fresh_usage_executor, usage_webhook_api
+        self, tmp_path, real_flow
     ):
         flow = _openai_model_websocket_flow(tmp_path, real_flow)
 
@@ -598,10 +566,7 @@ class TestModelProviderStreamUsage:
             ).encode(),
         )
 
-        with usage_webhook_api() as webhook:
-            mitm_addon.websocket_end(flow)
-            usage.flush_usage_events(trigger="test")
-            usage.webhook.usage_executor.shutdown(wait=True)
+        webhook = self._run_websocket_end(flow)
 
         events = webhook.usage_events()
         by_category = {event["category"]: event["quantity"] for event in events}
@@ -614,6 +579,32 @@ class TestModelProviderStreamUsage:
         for key in idempotency_by_category.values():
             uuid.UUID(key)
         assert {event["provider"] for event in events} == {"gpt-5.5"}
+
+    def test_model_websocket_ignores_client_messages(self, tmp_path, real_flow):
+        flow = _openai_model_websocket_flow(tmp_path, real_flow)
+        _set_websocket_message(
+            flow,
+            from_client=True,
+            content=json.dumps(
+                {
+                    "type": "response.completed",
+                    "response": {
+                        "id": "resp_ws_1",
+                        "model": "gpt-5.5",
+                        "usage": {"input_tokens": 50, "output_tokens": 20},
+                    },
+                }
+            ).encode(),
+        )
+
+        webhook = self._run_websocket_message_and_end(flow)
+
+        assert webhook.request_count == 0
+        assert flow.metadata["model_provider_usage"] == {}
+
+
+class TestModelProviderWebSocketUsageMetadata:
+    """Tests for WebSocket usage metadata parsing without webhook reporting."""
 
     def test_model_websocket_zero_frame_preserves_prior_positive_usage(self, tmp_path, real_flow):
         flow = _openai_model_websocket_flow(tmp_path, real_flow)
@@ -828,31 +819,3 @@ class TestModelProviderStreamUsage:
 
         _feed_websocket_server_message(flow, b'{"type":"response.completed"')
         assert flow.metadata["model_provider_usage"] == "invalid"
-
-    def test_model_websocket_ignores_client_messages(
-        self, tmp_path, real_flow, mitm_ctx, fresh_usage_executor, usage_webhook_api
-    ):
-        flow = _openai_model_websocket_flow(tmp_path, real_flow)
-        _set_websocket_message(
-            flow,
-            from_client=True,
-            content=json.dumps(
-                {
-                    "type": "response.completed",
-                    "response": {
-                        "id": "resp_ws_1",
-                        "model": "gpt-5.5",
-                        "usage": {"input_tokens": 50, "output_tokens": 20},
-                    },
-                }
-            ).encode(),
-        )
-
-        with usage_webhook_api() as webhook:
-            mitm_addon.websocket_message(flow)
-            mitm_addon.websocket_end(flow)
-            usage.flush_usage_events(trigger="test")
-            usage.webhook.usage_executor.shutdown(wait=True)
-
-        assert webhook.request_count == 0
-        assert flow.metadata["model_provider_usage"] == {}


### PR DESCRIPTION
## Summary

- Move stream usage reporting tests onto the existing `sync_usage_executor` fixture boundary.
- Add narrow hook helpers for response, error, and WebSocket delivery flushes.
- Split WebSocket metadata-only tests into a separate class so they do not inherit webhook delivery fixtures.
- Remove manual `usage.webhook.usage_executor.shutdown(wait=True)` calls from `test_model_provider_stream_usage.py` while preserving dedicated real executor coverage elsewhere.

## Tests

- `/tmp/mitm-addon-test-venv/bin/python -m pytest tests/test_model_provider_stream_usage.py`
- `/tmp/mitm-addon-test-venv/bin/python -m pytest tests/test_model_provider_response_usage.py tests/test_webhook.py`
- `/tmp/mitm-addon-test-venv/bin/ruff check tests/test_model_provider_stream_usage.py`
- `/tmp/mitm-addon-test-venv/bin/ruff format --check tests/test_model_provider_stream_usage.py`
- `git diff --check`

Closes #15802
