### PR TITLE
feat: add platform api target policy

### DIFF
--- a/turbo/apps/platform/src/signals/__tests__/api-client.test.ts
+++ b/turbo/apps/platform/src/signals/__tests__/api-client.test.ts
@@ -4,6 +4,7 @@ import { server } from "../../mocks/server.ts";
 import { zeroClient$ } from "../api-client.ts";
 import { zeroOrgContract } from "@vm0/api-contracts/contracts/zero-org";
 import { zeroFeatureSwitchesContract } from "@vm0/api-contracts/contracts/zero-feature-switches";
+import { zeroUserPreferencesContract } from "@vm0/api-contracts/contracts/zero-user-preferences";
 import { testContext } from "./test-helpers.ts";
 import { detachedSetupPage } from "../../__tests__/page-helper.ts";
 import { mockedClerk } from "../../__tests__/mock-auth.ts";
@@ -324,6 +325,48 @@ describe("zeroClient$ apiBackend routing", () => {
 
     expect(result.status).toBe(200);
     expect(requestHosts).toStrictEqual(["www.vm0.ai"]);
+  });
+
+  it("routes policy allowlisted user preferences contract requests to api host when apiBackend is off", async () => {
+    vi.stubGlobal("location", new URL("https://platform.vm0.ai/"));
+    detachedSetupPage({
+      context,
+      path: "/",
+      withoutRender: true,
+    });
+
+    const requestHosts: string[] = [];
+    server.use(
+      mockApi(zeroUserPreferencesContract.get, ({ request, respond }) => {
+        requestHosts.push(new URL(request.url).host);
+        return respond(200, {
+          timezone: null,
+          pinnedAgentIds: [],
+          sendMode: "enter",
+          captureNetworkBodiesRemaining: 0,
+        });
+      }),
+      mockApi(zeroUserPreferencesContract.update, ({ request, respond }) => {
+        requestHosts.push(new URL(request.url).host);
+        return respond(200, {
+          timezone: "America/Los_Angeles",
+          pinnedAgentIds: [],
+          sendMode: "cmd-enter",
+          captureNetworkBodiesRemaining: 0,
+        });
+      }),
+    );
+
+    const createClient = context.store.get(zeroClient$);
+    const client = createClient(zeroUserPreferencesContract);
+    const getResult = await client.get();
+    const updateResult = await client.update({
+      body: { sendMode: "cmd-enter" },
+    });
+
+    expect(getResult.status).toBe(200);
+    expect(updateResult.status).toBe(200);
+    expect(requestHosts).toStrictEqual(["api.vm0.ai", "api.vm0.ai"]);
   });
 
   it("routes GET contract requests to api host when apiBackend is on", async () => {

--- a/turbo/apps/platform/src/signals/__tests__/fetch.test.ts
+++ b/turbo/apps/platform/src/signals/__tests__/fetch.test.ts
@@ -522,6 +522,80 @@ describe("apiBackend routing", () => {
     expect(postHosts).toStrictEqual(["www.vm0.ai"]);
   });
 
+  it("routes policy allowlisted user preferences string paths to api host when apiBackend is off", async () => {
+    vi.stubGlobal("location", new URL("https://platform.vm0.ai/"));
+    detachedSetupPage({
+      context,
+      path: "/",
+      withoutRender: true,
+    });
+
+    const hosts: string[] = [];
+    server.use(
+      http.get("*/api/zero/user-preferences", ({ request }) => {
+        hosts.push(new URL(request.url).host);
+        return new Response(null, { status: 200 });
+      }),
+    );
+
+    const fch = context.store.get(fetch$);
+    await fch("/api/zero/user-preferences");
+
+    expect(hosts).toStrictEqual(["api.vm0.ai"]);
+  });
+
+  it("routes policy allowlisted user preferences Request inputs to api host when apiBackend is off", async () => {
+    vi.stubGlobal("location", new URL("https://platform.vm0.ai/"));
+    detachedSetupPage({
+      context,
+      path: "/",
+      withoutRender: true,
+    });
+
+    const hosts: string[] = [];
+    server.use(
+      http.post("*/api/zero/user-preferences", ({ request }) => {
+        hosts.push(new URL(request.url).host);
+        return new Response(null, { status: 200 });
+      }),
+    );
+
+    const fch = context.store.get(fetch$);
+    await fch(
+      new Request("/api/zero/user-preferences", {
+        method: "POST",
+        body: JSON.stringify({ sendMode: "cmd-enter" }),
+        headers: { "Content-Type": "application/json" },
+      }),
+    );
+
+    expect(hosts).toStrictEqual(["api.vm0.ai"]);
+  });
+
+  it("uses RequestInit method overrides for policy allowlisted user preferences Request inputs", async () => {
+    vi.stubGlobal("location", new URL("https://platform.vm0.ai/"));
+    detachedSetupPage({
+      context,
+      path: "/",
+      withoutRender: true,
+    });
+
+    const hosts: string[] = [];
+    server.use(
+      http.post("*/api/zero/user-preferences", ({ request }) => {
+        hosts.push(new URL(request.url).host);
+        return new Response(null, { status: 200 });
+      }),
+    );
+
+    const fch = context.store.get(fetch$);
+    await fch(new Request("/api/zero/user-preferences"), {
+      method: "POST",
+    });
+
+    expect(hosts).toStrictEqual(["api.vm0.ai"]);
+  });
+
   it("routes GET and POST to api host when apiBackend is on", async () => {
     vi.stubGlobal("location", new URL("https://platform.vm0.ai/"));
     detachedSetupPage({

--- a/turbo/apps/platform/src/signals/api-base.ts
+++ b/turbo/apps/platform/src/signals/api-base.ts
@@ -8,7 +8,7 @@ function getConfiguredApiUrl(): string {
 
 const CONFIGURED_API_URL = getConfiguredApiUrl();
 
-type ApiHostTarget = "api" | "www";
+export type ApiHostTarget = "api" | "www";
 
 function trimTrailingSlash(base: string): string {
   return base.endsWith("/") ? base.slice(0, -1) : base;
@@ -48,12 +48,15 @@ function isLocalhostBrowser(): boolean {
   );
 }
 
-export function resolveApiBase(useApiBackend: boolean): string {
-  const target = useApiBackend ? "api" : "www";
+export function resolveApiBaseForTarget(target: ApiHostTarget): string {
   if (CONFIGURED_API_URL === "http://localhost:3000") {
     return browserOriginBase(target) ?? configuredApiBase(target);
   }
   return trimTrailingSlash(configuredApiBase(target));
+}
+
+export function resolveApiBase(useApiBackend: boolean): string {
+  return resolveApiBaseForTarget(useApiBackend ? "api" : "www");
 }
 
 export function resolveApiBaseForNavigation(useApiBackend: boolean): string {

--- a/turbo/apps/platform/src/signals/api-client.ts
+++ b/turbo/apps/platform/src/signals/api-client.ts
@@ -11,8 +11,9 @@ import type {
   InitClientReturn,
 } from "@ts-rest/core";
 import { clerk$ } from "./auth.ts";
-import { apiBase$ } from "./fetch.ts";
-import { resolveApiBase } from "./api-base.ts";
+import { apiBackendEnabled$ } from "./external/feature-switch.ts";
+import { resolveApiBase, resolveApiBaseForTarget } from "./api-base.ts";
+import { resolveApiTarget } from "./api-target-policy.ts";
 import { createAuthedTsRestClient } from "./api-client-base.ts";
 
 /**
@@ -59,14 +60,19 @@ export const zeroClient$ = computed((get) => {
       getClerk: () => {
         return get(clerk$);
       },
-      resolvePath: async (path) => {
+      resolvePath: async (path, { method }) => {
         if (options?.apiBase === "api") {
           return rebaseApiPath(path, resolveApiBase(true));
         }
         if (options?.apiBase === "www") {
           return rebaseApiPath(path, resolveApiBase(false));
         }
-        return rebaseApiPath(path, await get(apiBase$));
+        const url = new URL(path, resolveApiBase(false));
+        const target = resolveApiTarget(
+          { method, pathname: url.pathname },
+          await get(apiBackendEnabled$),
+        );
+        return rebaseApiPath(path, resolveApiBaseForTarget(target));
       },
     });
   };

--- a/turbo/apps/platform/src/signals/api-target-policy.ts
+++ b/turbo/apps/platform/src/signals/api-target-policy.ts
@@ -1,0 +1,46 @@
+import type { ApiHostTarget } from "./api-base.ts";
+
+type ApiRouteMethod = "DELETE" | "GET" | "PATCH" | "POST" | "PUT";
+
+interface ApiTargetRequest {
+  readonly method: string;
+  readonly pathname: string;
+}
+
+interface ApiTargetPolicyEntry {
+  readonly methods: readonly ApiRouteMethod[];
+  readonly pathname: string;
+  readonly target: ApiHostTarget;
+}
+
+const API_ROUTE_TARGET_POLICY: readonly ApiTargetPolicyEntry[] = [
+  {
+    methods: ["GET", "POST"],
+    pathname: "/api/zero/user-preferences",
+    target: "api",
+  },
+];
+
+function normalizeMethod(method: string): string {
+  return method.toUpperCase();
+}
+
+export function resolveApiTarget(
+  request: ApiTargetRequest,
+  useApiBackend: boolean,
+): ApiHostTarget {
+  if (useApiBackend) {
+    return "api";
+  }
+
+  const method = normalizeMethod(request.method);
+  const entry = API_ROUTE_TARGET_POLICY.find((candidate) => {
+    return (
+      candidate.pathname === request.pathname &&
+      candidate.methods.some((candidateMethod) => {
+        return candidateMethod === method;
+      })
+    );
+  });
+  return entry?.target ?? "www";
+}

--- a/turbo/apps/platform/src/signals/external/feature-switch.ts
+++ b/turbo/apps/platform/src/signals/external/feature-switch.ts
@@ -16,8 +16,8 @@ const { set$: setFeatureSwitchLocalStorage$, get$: featureSwitchCache$ } =
 // Pinned to the web backend: feature switches must load before
 // `apiBackendEnabled$` is known, so the transport that fetches them cannot
 // itself depend on it. Going through `zeroClient$` (which routes via
-// `apiBase$` → `apiBackendEnabled$` → `featureSwitch$`) creates a static
-// import cycle even though the runtime read is now sync from localStorage.
+// `apiBackendEnabled$` → `featureSwitch$`) creates a static import cycle even
+// though the runtime read is now sync from localStorage.
 const webFeatureSwitchClient$ = computed((get) => {
   return createAuthedTsRestClient(zeroFeatureSwitchesContract, {
     baseUrl: resolveApiBase(false),

--- a/turbo/apps/platform/src/signals/fetch.ts
+++ b/turbo/apps/platform/src/signals/fetch.ts
@@ -2,7 +2,12 @@ import { computed } from "ccstate";
 import { apiBackendEnabled$ } from "./external/feature-switch.ts";
 import { clerk$ } from "./auth.ts";
 import { fetchFreshToken, handleUnauthorizedRedirect } from "./auth-retry.ts";
-import { resolveApiBase, resolveApiBaseForNavigation } from "./api-base.ts";
+import {
+  resolveApiBase,
+  resolveApiBaseForNavigation,
+  resolveApiBaseForTarget,
+} from "./api-base.ts";
+import { resolveApiTarget } from "./api-target-policy.ts";
 
 /**
  * API base URL for opening external navigation (e.g. connector OAuth popup).
@@ -50,6 +55,7 @@ function mergeHeadersWithAutoIds(
 function rewriteRequestUrl(
   request: Request,
   apiBase: string,
+  method: string | undefined,
   token: string | null | undefined,
   initHeaders: HeadersInit | Record<string, string> | undefined,
 ): Request | null {
@@ -73,7 +79,7 @@ function rewriteRequestUrl(
   }
 
   const requestInit: RequestInit & { duplex: "half" } = {
-    method: request.method,
+    method: method ?? request.method,
     headers: combinedHeaders,
     mode: request.mode,
     credentials: request.credentials,
@@ -96,11 +102,25 @@ function rewriteRequestUrl(
   );
 }
 
+function apiBaseForRelativePath(
+  path: string,
+  method: string | undefined,
+  useApiBackend: boolean,
+): string {
+  const url = new URL(path, resolveApiBase(false));
+  return resolveApiBaseForTarget(
+    resolveApiTarget(
+      { method: method ?? "GET", pathname: url.pathname },
+      useApiBackend,
+    ),
+  );
+}
+
 export const fetch$ = computed((get) => {
   return async (url: string | URL | Request, options?: RequestInit) => {
     const clerk = await get(clerk$);
     const initialToken = (await clerk.session?.getToken()) ?? null;
-    const apiBase = await get(apiBase$);
+    const useApiBackend = await get(apiBackendEnabled$);
 
     const performFetch = async (token: string | null): Promise<Response> => {
       // Clone Request inputs so the body stream is available for retry.
@@ -138,20 +158,38 @@ export const fetch$ = computed((get) => {
       }
 
       if (typeof requestInput === "string" && !requestInput.includes("://")) {
-        const baseUrl = apiBase.endsWith("/") ? apiBase.slice(0, -1) : apiBase;
+        const requestMethod = finalInit.method;
         const path = requestInput.startsWith("/")
           ? requestInput
           : `/${requestInput}`;
+        const apiBase = apiBaseForRelativePath(
+          path,
+          requestMethod,
+          useApiBackend,
+        );
+        const baseUrl = apiBase.endsWith("/") ? apiBase.slice(0, -1) : apiBase;
         finalUrl = `${baseUrl}${path}`;
       } else if (requestInput instanceof URL && !requestInput.host) {
+        const apiBase = apiBaseForRelativePath(
+          requestInput.pathname,
+          finalInit.method,
+          useApiBackend,
+        );
         finalUrl = new URL(
           requestInput.pathname + requestInput.search + requestInput.hash,
           apiBase,
         );
       } else if (requestInput instanceof Request) {
+        const requestMethod = finalInit.method ?? requestInput.method;
+        const apiBase = apiBaseForRelativePath(
+          new URL(requestInput.url).pathname,
+          requestMethod,
+          useApiBackend,
+        );
         const rewritten = rewriteRequestUrl(
           requestInput,
           apiBase,
+          requestMethod,
           token,
           finalInit.headers,
         );

--- a/turbo/apps/platform/src/views/preferences-page/__tests__/preferences-page.test.tsx
+++ b/turbo/apps/platform/src/views/preferences-page/__tests__/preferences-page.test.tsx
@@ -38,7 +38,7 @@ function renderPreferencesPage() {
 }
 
 describe("zero preferences page - tab navigation", () => {
-  it("loads preferences through the web proxy host", async () => {
+  it("loads preferences through the api host", async () => {
     vi.stubGlobal("location", new URL("https://platform.vm0.ai/settings"));
     const requestHosts: string[] = [];
 
@@ -54,7 +54,7 @@ describe("zero preferences page - tab navigation", () => {
     await waitFor(() => {
       expect(screen.getByText("Theme")).toBeInTheDocument();
     });
-    expect(requestHosts).toStrictEqual(["www.vm0.ai"]);
+    expect(requestHosts).toStrictEqual(["api.vm0.ai"]);
   });
 
   it("should show appearance tab by default and switch to time zone tab", async () => {


### PR DESCRIPTION
## Summary
- Add a centralized Platform API target policy for list-based host routing.
- Route `fetch$` relative requests and `zeroClient$` contract requests through the policy.
- Allowlist `GET/POST /api/zero/user-preferences` to the API host while the global `apiBackend` switch is off.

Related to #15872.

## Validation
- `pnpm format`
- `pnpm turbo run lint`
- `pnpm check-types`
- `pnpm knip`
- `pnpm -F @vm0/app exec vitest run src/signals/__tests__/api-client.test.ts src/signals/__tests__/fetch.test.ts`
- `pnpm -F @vm0/app lint`
- `pnpm -F @vm0/app check-types`
- Local Vite server at `http://localhost:3003/` returned HTTP 200.

Full `pnpm vitest` was also run on the earlier version of this branch. It failed only on unrelated local-environment cases: `@vm0/desktop` native macOS CLI tests in this Linux container, and one API model-first test polluted by the local `OPENAI_API_KEY`; the API test passed when rerun with that env var unset.