### PR TITLE
fix: validate mock codex resume thread ids

### DIFF
--- a/crates/README.md
+++ b/crates/README.md
@@ -19,7 +19,7 @@ This workspace contains Rust crates for the vm0 sandbox runtime — VM orchestra
 | **guest-common** | Shared utilities for guest crates — logging macros, telemetry recording, environment accessors |
 | **guest-download** | Downloads and extracts storage archives — parallel downloads (4 concurrent), streaming extraction, retry logic |
 | **guest-mock-claude** | Mock Claude CLI for testing — executes bash commands and outputs Claude-compatible JSONL |
-| **guest-mock-codex** | Mock Codex CLI for testing — emits Codex JSONL protocol on stdout and persists zstd-compressed session files |
+| **guest-mock-codex** | Mock Codex CLI for testing — emits Codex JSONL protocol on stdout and persists JSONL session files |
 | **guest-reseed** | Entropy reseed after snapshot restore — mixes stdin entropy into /dev/urandom and forces CRNG reseed via RNDRESEEDCRNG |
 | **guest-write-file** | Direct file writer for vsock `write_file` — writes stdin to guest files without shell startup overhead |
 | **ably-subscriber** | Ably Pub/Sub subscribe-only realtime client — WebSocket/MessagePack protocol with token auth and automatic reconnection |

--- a/crates/guest-mock-codex/src/main.rs
+++ b/crates/guest-mock-codex/src/main.rs
@@ -14,7 +14,7 @@
 //!                          [-C <dir>] [-m <model>] [-c <config>]
 //!                          [--append-system-prompt <s>] [--last]
 //!                          [-- <prompt>]
-//!   guest-mock-codex exec resume <thread_id> [-- <prompt>]
+//!   guest-mock-codex exec resume <canonical-uuid-thread-id> [-- <prompt>]
 //! ```
 //!
 //! Fixture mode: when `MOCK_CODEX_FIXTURE=<name>` is set in the env, the
@@ -93,7 +93,7 @@ struct ExecArgs {
 
 #[derive(Subcommand, Debug)]
 enum ExecSub {
-    /// Mirrors `codex exec resume <thread_id>`.
+    /// Mirrors `codex exec resume <thread_id>`. The id must be a canonical UUID.
     Resume {
         thread_id: String,
 
@@ -104,10 +104,10 @@ enum ExecSub {
 
 /// Embedded JSONL fixtures selectable via `MOCK_CODEX_FIXTURE=<name>`.
 ///
-/// Each fixture's first event must be `thread.started{thread_id}`; the
-/// thread id is used to compute the on-disk session path so the
-/// guest-agent's checkpoint scan finds the same payload that was emitted
-/// to stdout. Adding a new fixture: drop a `*.jsonl` file under
+/// Each fixture's first event must be `thread.started{thread_id}` with a
+/// canonical UUID thread id; that id is used to compute the on-disk session
+/// path so the guest-agent's checkpoint scan finds the same payload that was
+/// emitted to stdout. Adding a new fixture: drop a `*.jsonl` file under
 /// `fixtures/`, append a `(name, include_str!(...))` row here, and refer
 /// to it from the bats test by `MOCK_CODEX_FIXTURE=<name>`.
 const FIXTURES: &[(&str, &str)] = &[
@@ -411,6 +411,11 @@ mod tests {
     #[test]
     fn build_session_path_rejects_non_canonical_uuid_thread_id() {
         assert_invalid_thread_id("0199A213-81C0-7800-8AA1-BBAB2A035A53");
+    }
+
+    #[test]
+    fn build_session_path_rejects_simple_uuid_thread_id() {
+        assert_invalid_thread_id("0199a21381c078008aa1bbab2a035a53");
     }
 
     fn assert_invalid_thread_id(thread_id: &str) {

--- a/crates/guest-mock-codex/src/main.rs
+++ b/crates/guest-mock-codex/src/main.rs
@@ -170,11 +170,11 @@ fn run_fixture(content: &str) -> io::Result<()> {
             "fixture missing thread.started/thread_id",
         )
     })?;
+    let path = build_session_path(&codex_home(), Utc::now().date_naive(), &thread_id)?;
 
     let mut stdout = io::stdout().lock();
     emit_events(&mut stdout, &events)?;
 
-    let path = build_session_path(&codex_home(), Utc::now().date_naive(), &thread_id);
     write_session_file(&path, &events)
 }
 
@@ -226,16 +226,32 @@ fn codex_home() -> PathBuf {
 /// Build the session file path, with `today` injected for testability.
 ///
 /// Layout: `<codex_home>/sessions/YYYY/MM/DD/<thread_id>.jsonl`
-fn build_session_path(codex_home: &Path, today: NaiveDate, thread_id: &str) -> PathBuf {
+fn build_session_path(codex_home: &Path, today: NaiveDate, thread_id: &str) -> io::Result<PathBuf> {
+    validate_thread_id(thread_id)?;
     let yyyy = today.format("%Y").to_string();
     let mm = today.format("%m").to_string();
     let dd = today.format("%d").to_string();
-    codex_home
+    Ok(codex_home
         .join("sessions")
         .join(yyyy)
         .join(mm)
         .join(dd)
-        .join(format!("{thread_id}.jsonl"))
+        .join(format!("{thread_id}.jsonl")))
+}
+
+fn validate_thread_id(thread_id: &str) -> io::Result<()> {
+    let parsed = Uuid::parse_str(thread_id).map_err(|_| invalid_thread_id_error(thread_id))?;
+    if parsed.to_string() != thread_id {
+        return Err(invalid_thread_id_error(thread_id));
+    }
+    Ok(())
+}
+
+fn invalid_thread_id_error(thread_id: &str) -> io::Error {
+    io::Error::new(
+        io::ErrorKind::InvalidInput,
+        format!("invalid thread id {thread_id:?}: expected canonical UUID"),
+    )
 }
 
 /// Build the three-event sequence the mock emits for a single turn.
@@ -309,11 +325,11 @@ fn append_session_file(path: &Path, new_events: &[Value]) -> io::Result<()> {
 /// to the session file under `$CODEX_HOME`.
 fn run(thread_id: &str, prompt: &str, is_resume: bool) -> io::Result<()> {
     let events = build_events(thread_id, prompt);
+    let path = build_session_path(&codex_home(), Utc::now().date_naive(), thread_id)?;
 
     let mut stdout = io::stdout().lock();
     emit_events(&mut stdout, &events)?;
 
-    let path = build_session_path(&codex_home(), Utc::now().date_naive(), thread_id);
     if is_resume {
         append_session_file(&path, &events)
     } else {
@@ -352,10 +368,11 @@ mod tests {
     fn build_session_path_zero_pads() {
         let home = Path::new("/tmp/.codex");
         let day = NaiveDate::from_ymd_opt(2026, 1, 5).unwrap();
-        let p = build_session_path(home, day, "abc");
+        let thread_id = "00000000-0000-0000-0000-000000000001";
+        let p = build_session_path(home, day, thread_id).unwrap();
         assert_eq!(
             p,
-            PathBuf::from("/tmp/.codex/sessions/2026/01/05/abc.jsonl")
+            PathBuf::from(format!("/tmp/.codex/sessions/2026/01/05/{thread_id}.jsonl"))
         );
     }
 
@@ -363,11 +380,44 @@ mod tests {
     fn build_session_path_typical() {
         let home = Path::new("/var/codex");
         let day = NaiveDate::from_ymd_opt(2026, 12, 31).unwrap();
-        let p = build_session_path(home, day, "xyz-uuid");
+        let thread_id = "0199a213-81c0-7800-8aa1-bbab2a035a53";
+        let p = build_session_path(home, day, thread_id).unwrap();
         assert_eq!(
             p,
-            PathBuf::from("/var/codex/sessions/2026/12/31/xyz-uuid.jsonl")
+            PathBuf::from(format!("/var/codex/sessions/2026/12/31/{thread_id}.jsonl"))
         );
+    }
+
+    #[test]
+    fn build_session_path_rejects_absolute_thread_id() {
+        assert_invalid_thread_id("/tmp/escape");
+    }
+
+    #[test]
+    fn build_session_path_rejects_traversal_thread_id() {
+        assert_invalid_thread_id("../escape");
+    }
+
+    #[test]
+    fn build_session_path_rejects_nested_thread_id() {
+        assert_invalid_thread_id("nested/id");
+    }
+
+    #[test]
+    fn build_session_path_rejects_non_uuid_thread_id() {
+        assert_invalid_thread_id("xyz-uuid");
+    }
+
+    #[test]
+    fn build_session_path_rejects_non_canonical_uuid_thread_id() {
+        assert_invalid_thread_id("0199A213-81C0-7800-8AA1-BBAB2A035A53");
+    }
+
+    fn assert_invalid_thread_id(thread_id: &str) {
+        let home = Path::new("/tmp/.codex");
+        let day = NaiveDate::from_ymd_opt(2026, 1, 5).unwrap();
+        let err = build_session_path(home, day, thread_id).unwrap_err();
+        assert_eq!(err.kind(), io::ErrorKind::InvalidInput);
     }
 
     #[test]

--- a/crates/guest-mock-codex/src/main.rs
+++ b/crates/guest-mock-codex/src/main.rs
@@ -389,43 +389,6 @@ mod tests {
     }
 
     #[test]
-    fn build_session_path_rejects_absolute_thread_id() {
-        assert_invalid_thread_id("/tmp/escape");
-    }
-
-    #[test]
-    fn build_session_path_rejects_traversal_thread_id() {
-        assert_invalid_thread_id("../escape");
-    }
-
-    #[test]
-    fn build_session_path_rejects_nested_thread_id() {
-        assert_invalid_thread_id("nested/id");
-    }
-
-    #[test]
-    fn build_session_path_rejects_non_uuid_thread_id() {
-        assert_invalid_thread_id("xyz-uuid");
-    }
-
-    #[test]
-    fn build_session_path_rejects_non_canonical_uuid_thread_id() {
-        assert_invalid_thread_id("0199A213-81C0-7800-8AA1-BBAB2A035A53");
-    }
-
-    #[test]
-    fn build_session_path_rejects_simple_uuid_thread_id() {
-        assert_invalid_thread_id("0199a21381c078008aa1bbab2a035a53");
-    }
-
-    fn assert_invalid_thread_id(thread_id: &str) {
-        let home = Path::new("/tmp/.codex");
-        let day = NaiveDate::from_ymd_opt(2026, 1, 5).unwrap();
-        let err = build_session_path(home, day, thread_id).unwrap_err();
-        assert_eq!(err.kind(), io::ErrorKind::InvalidInput);
-    }
-
-    #[test]
     fn build_events_shape() {
         let evs = build_events("tid-1", "hello");
         assert_eq!(evs[0]["type"], "thread.started");

--- a/crates/guest-mock-codex/src/main.rs
+++ b/crates/guest-mock-codex/src/main.rs
@@ -20,8 +20,8 @@
 //! Fixture mode: when `MOCK_CODEX_FIXTURE=<name>` is set in the env, the
 //! synthetic 3-event sequence is replaced with a baked JSONL fixture by
 //! that name (see `FIXTURES`). The thread id is taken from the fixture's
-//! `thread.started` event; the fixture's bytes are written verbatim to
-//! stdout and to the session file. Used by
+//! `thread.started` event; the fixture events are emitted to stdout and
+//! persisted to the session file. Used by
 //! `e2e/tests/03-runner/t-codex-event-mapping.bats` to exercise the
 //! codex-event-parser branches that the synthetic sequence cannot reach.
 

--- a/crates/guest-mock-codex/src/main.rs
+++ b/crates/guest-mock-codex/src/main.rs
@@ -324,8 +324,8 @@ fn append_session_file(path: &Path, new_events: &[Value]) -> io::Result<()> {
 /// Orchestrator: emit the three-event turn on stdout, then persist (or append)
 /// to the session file under `$CODEX_HOME`.
 fn run(thread_id: &str, prompt: &str, is_resume: bool) -> io::Result<()> {
-    let events = build_events(thread_id, prompt);
     let path = build_session_path(&codex_home(), Utc::now().date_naive(), thread_id)?;
+    let events = build_events(thread_id, prompt);
 
     let mut stdout = io::stdout().lock();
     emit_events(&mut stdout, &events)?;

--- a/crates/guest-mock-codex/tests/integration.rs
+++ b/crates/guest-mock-codex/tests/integration.rs
@@ -16,6 +16,7 @@ const BIN: &str = env!("CARGO_BIN_EXE_guest-mock-codex");
 struct RunOutput {
     events: Vec<Value>,
     status: i32,
+    stderr: String,
 }
 
 fn run(codex_home: &Path, args: &[&str]) -> std::io::Result<RunOutput> {
@@ -36,6 +37,8 @@ fn run_with_env(
 
     let stdout = String::from_utf8(output.stdout)
         .map_err(|e| std::io::Error::new(std::io::ErrorKind::InvalidData, e))?;
+    let stderr = String::from_utf8(output.stderr)
+        .map_err(|e| std::io::Error::new(std::io::ErrorKind::InvalidData, e))?;
     let mut events = Vec::new();
     for line in stdout.lines() {
         if line.is_empty() {
@@ -49,6 +52,7 @@ fn run_with_env(
     Ok(RunOutput {
         events,
         status: output.status.code().unwrap_or(-1),
+        stderr,
     })
 }
 
@@ -67,13 +71,35 @@ fn read_session_file(path: &Path) -> std::io::Result<Vec<Value>> {
 }
 
 fn find_session_file(codex_home: &Path) -> Option<PathBuf> {
-    let mut found = None;
+    session_files(codex_home).into_iter().next()
+}
+
+fn session_files(codex_home: &Path) -> Vec<PathBuf> {
+    let mut found = Vec::new();
     walk(&codex_home.join("sessions"), &mut |p| {
         if p.extension().and_then(|s| s.to_str()) == Some("jsonl") {
-            found = Some(p.to_path_buf());
+            found.push(p.to_path_buf());
         }
     });
+    found.sort();
     found
+}
+
+fn assert_invalid_resume_rejected(codex_home: &Path, out: &RunOutput) {
+    assert_ne!(out.status, 0, "invalid resume id should fail");
+    assert!(
+        out.events.is_empty(),
+        "invalid resume id should not emit JSONL events: {:?}",
+        out.events
+    );
+    assert!(
+        !out.stderr.is_empty(),
+        "invalid resume id should report an error on stderr"
+    );
+    assert!(
+        session_files(codex_home).is_empty(),
+        "invalid resume id should not write session files"
+    );
 }
 
 fn walk(dir: &Path, f: &mut dyn FnMut(&Path)) {
@@ -155,6 +181,42 @@ fn resume_with_unknown_id_starts_fresh_with_supplied_id() {
             .unwrap_or_default()
             .starts_with(supplied)
     );
+}
+
+#[test]
+fn resume_rejects_absolute_thread_id_without_writing_events_or_files() {
+    let codex_dir = TempDir::new().unwrap();
+    let outside_dir = TempDir::new().unwrap();
+    let outside_target = outside_dir.path().join("escape");
+    let supplied = outside_target.to_str().unwrap();
+
+    let out = run(codex_dir.path(), &["exec", "resume", supplied, "--", "hi"]).unwrap();
+    assert_invalid_resume_rejected(codex_dir.path(), &out);
+
+    assert!(
+        !outside_target.with_extension("jsonl").exists(),
+        "invalid absolute id should not create an outside session file"
+    );
+    assert!(
+        !outside_target.with_extension("jsonl.tmp").exists(),
+        "invalid absolute id should not leave an outside temp file"
+    );
+}
+
+#[test]
+fn resume_rejects_traversal_thread_id_without_writing_events_or_files() {
+    let dir = TempDir::new().unwrap();
+
+    let out = run(dir.path(), &["exec", "resume", "../escape", "--", "hi"]).unwrap();
+    assert_invalid_resume_rejected(dir.path(), &out);
+}
+
+#[test]
+fn resume_rejects_nested_thread_id_without_writing_events_or_files() {
+    let dir = TempDir::new().unwrap();
+
+    let out = run(dir.path(), &["exec", "resume", "nested/id", "--", "hi"]).unwrap();
+    assert_invalid_resume_rejected(dir.path(), &out);
 }
 
 #[test]

--- a/crates/guest-mock-codex/tests/integration.rs
+++ b/crates/guest-mock-codex/tests/integration.rs
@@ -107,6 +107,16 @@ fn assert_invalid_resume_rejected(codex_home: &Path, out: &RunOutput) {
         "invalid resume id should report an error on stderr"
     );
     assert!(
+        out.stderr.contains("invalid thread id"),
+        "invalid resume id should report the validation failure: {:?}",
+        out.stderr
+    );
+    assert!(
+        out.stderr.contains("expected canonical UUID"),
+        "invalid resume id should describe the expected format: {:?}",
+        out.stderr
+    );
+    assert!(
         session_artifacts(codex_home).is_empty(),
         "invalid resume id should not write session artifacts"
     );

--- a/crates/guest-mock-codex/tests/integration.rs
+++ b/crates/guest-mock-codex/tests/integration.rs
@@ -193,7 +193,7 @@ fn resume_with_unknown_id_starts_fresh_with_supplied_id() {
 }
 
 #[test]
-fn resume_rejects_absolute_thread_id_without_writing_events_or_files() {
+fn resume_rejects_absolute_thread_id_without_events_or_artifacts() {
     let codex_dir = TempDir::new().unwrap();
     let outside_dir = TempDir::new().unwrap();
     let outside_target = outside_dir.path().join("escape");
@@ -213,7 +213,7 @@ fn resume_rejects_absolute_thread_id_without_writing_events_or_files() {
 }
 
 #[test]
-fn resume_rejects_traversal_thread_id_without_writing_events_or_files() {
+fn resume_rejects_traversal_thread_id_without_events_or_artifacts() {
     let dir = TempDir::new().unwrap();
 
     let out = run(dir.path(), &["exec", "resume", "../escape", "--", "hi"]).unwrap();
@@ -221,7 +221,7 @@ fn resume_rejects_traversal_thread_id_without_writing_events_or_files() {
 }
 
 #[test]
-fn resume_rejects_nested_thread_id_without_writing_events_or_files() {
+fn resume_rejects_nested_thread_id_without_events_or_artifacts() {
     let dir = TempDir::new().unwrap();
 
     let out = run(dir.path(), &["exec", "resume", "nested/id", "--", "hi"]).unwrap();
@@ -229,7 +229,7 @@ fn resume_rejects_nested_thread_id_without_writing_events_or_files() {
 }
 
 #[test]
-fn resume_rejects_non_uuid_thread_id_without_writing_events_or_files() {
+fn resume_rejects_non_uuid_thread_id_without_events_or_artifacts() {
     let dir = TempDir::new().unwrap();
 
     let out = run(dir.path(), &["exec", "resume", "xyz-uuid", "--", "hi"]).unwrap();
@@ -237,7 +237,7 @@ fn resume_rejects_non_uuid_thread_id_without_writing_events_or_files() {
 }
 
 #[test]
-fn resume_rejects_uppercase_uuid_thread_id_without_writing_events_or_files() {
+fn resume_rejects_uppercase_uuid_thread_id_without_events_or_artifacts() {
     let dir = TempDir::new().unwrap();
 
     let out = run(
@@ -255,7 +255,7 @@ fn resume_rejects_uppercase_uuid_thread_id_without_writing_events_or_files() {
 }
 
 #[test]
-fn resume_rejects_simple_uuid_thread_id_without_writing_events_or_files() {
+fn resume_rejects_simple_uuid_thread_id_without_events_or_artifacts() {
     let dir = TempDir::new().unwrap();
 
     let out = run(

--- a/crates/guest-mock-codex/tests/integration.rs
+++ b/crates/guest-mock-codex/tests/integration.rs
@@ -229,6 +229,50 @@ fn resume_rejects_nested_thread_id_without_writing_events_or_files() {
 }
 
 #[test]
+fn resume_rejects_non_uuid_thread_id_without_writing_events_or_files() {
+    let dir = TempDir::new().unwrap();
+
+    let out = run(dir.path(), &["exec", "resume", "xyz-uuid", "--", "hi"]).unwrap();
+    assert_invalid_resume_rejected(dir.path(), &out);
+}
+
+#[test]
+fn resume_rejects_uppercase_uuid_thread_id_without_writing_events_or_files() {
+    let dir = TempDir::new().unwrap();
+
+    let out = run(
+        dir.path(),
+        &[
+            "exec",
+            "resume",
+            "0199A213-81C0-7800-8AA1-BBAB2A035A53",
+            "--",
+            "hi",
+        ],
+    )
+    .unwrap();
+    assert_invalid_resume_rejected(dir.path(), &out);
+}
+
+#[test]
+fn resume_rejects_simple_uuid_thread_id_without_writing_events_or_files() {
+    let dir = TempDir::new().unwrap();
+
+    let out = run(
+        dir.path(),
+        &[
+            "exec",
+            "resume",
+            "0199a21381c078008aa1bbab2a035a53",
+            "--",
+            "hi",
+        ],
+    )
+    .unwrap();
+    assert_invalid_resume_rejected(dir.path(), &out);
+}
+
+#[test]
 fn accepts_all_no_op_flags_without_failing() {
     let dir = TempDir::new().unwrap();
     let out = run(

--- a/crates/guest-mock-codex/tests/integration.rs
+++ b/crates/guest-mock-codex/tests/integration.rs
@@ -77,13 +77,18 @@ fn find_session_file(codex_home: &Path) -> Option<PathBuf> {
 fn session_files(codex_home: &Path) -> Vec<PathBuf> {
     session_artifacts(codex_home)
         .into_iter()
-        .filter(|p| p.extension().and_then(|s| s.to_str()) == Some("jsonl"))
+        .filter(|p| p.is_file() && p.extension().and_then(|s| s.to_str()) == Some("jsonl"))
         .collect()
 }
 
 fn session_artifacts(codex_home: &Path) -> Vec<PathBuf> {
+    let root = codex_home.join("sessions");
     let mut found = Vec::new();
-    walk(&codex_home.join("sessions"), &mut |p| {
+    if !root.exists() {
+        return found;
+    }
+    found.push(root.clone());
+    walk(&root, &mut |p| {
         found.push(p.to_path_buf());
     });
     found.sort();
@@ -113,10 +118,9 @@ fn walk(dir: &Path, f: &mut dyn FnMut(&Path)) {
     };
     for entry in entries.flatten() {
         let path = entry.path();
+        f(&path);
         if path.is_dir() {
             walk(&path, f);
-        } else {
-            f(&path);
         }
     }
 }

--- a/crates/guest-mock-codex/tests/integration.rs
+++ b/crates/guest-mock-codex/tests/integration.rs
@@ -75,11 +75,16 @@ fn find_session_file(codex_home: &Path) -> Option<PathBuf> {
 }
 
 fn session_files(codex_home: &Path) -> Vec<PathBuf> {
+    session_artifacts(codex_home)
+        .into_iter()
+        .filter(|p| p.extension().and_then(|s| s.to_str()) == Some("jsonl"))
+        .collect()
+}
+
+fn session_artifacts(codex_home: &Path) -> Vec<PathBuf> {
     let mut found = Vec::new();
     walk(&codex_home.join("sessions"), &mut |p| {
-        if p.extension().and_then(|s| s.to_str()) == Some("jsonl") {
-            found.push(p.to_path_buf());
-        }
+        found.push(p.to_path_buf());
     });
     found.sort();
     found
@@ -97,8 +102,8 @@ fn assert_invalid_resume_rejected(codex_home: &Path, out: &RunOutput) {
         "invalid resume id should report an error on stderr"
     );
     assert!(
-        session_files(codex_home).is_empty(),
-        "invalid resume id should not write session files"
+        session_artifacts(codex_home).is_empty(),
+        "invalid resume id should not write session artifacts"
     );
 }
 

--- a/e2e/helpers/codex-zero.bash
+++ b/e2e/helpers/codex-zero.bash
@@ -154,8 +154,8 @@ send_chat_run_message() {
     # debugNoMockCodex=true bypasses USE_MOCK_CODEX in the runner so the real
     # codex CLI executes against $OPENAI_API_KEY. Without it, CI's
     # USE_MOCK_CODEX=true env var causes guest-mock-codex to echo the prompt
-    # verbatim — see crates/runner/src/executor.rs:1307-1313 and
-    # crates/guest-mock-codex/src/main.rs:233-245. The chat/messages contract
+    # verbatim — see crates/runner/src/executor.rs (insert_codex_env) and
+    # crates/guest-mock-codex/src/main.rs (build_events). The chat/messages contract
     # exposes this flag via chatMessagesContract.body.debugNoMockCodex, mirroring
     # the same passthrough on /api/zero/runs.
     # Model-first selection can carry either the sentinel provider id for an org

--- a/e2e/tests/03-runner/t-codex-resume.bats
+++ b/e2e/tests/03-runner/t-codex-resume.bats
@@ -4,7 +4,7 @@
 # via the framework-aware checkpoint scan path.
 #
 # The first turn writes a session file at
-# `$CODEX_HOME/sessions/YYYY/MM/DD/<thread_id>.jsonl.zst`. Continue
+# `$CODEX_HOME/sessions/YYYY/MM/DD/<thread_id>.jsonl`. Continue
 # rehydrates from the agent session, calls codex with `exec resume`, and
 # the mock-codex appends another turn to the same file.
 

--- a/e2e/tests/03-runner/t-codex-smoke.bats
+++ b/e2e/tests/03-runner/t-codex-smoke.bats
@@ -5,8 +5,7 @@
 # Activated via USE_MOCK_CODEX=true in CI (see turbo.yml + crates.yml).
 # The mock-codex binary emits a synthetic 3-event sequence
 # (thread.started -> item.completed agent_message -> turn.completed)
-# and persists a zstd-compressed session file, mirroring the real
-# codex CLI's protocol.
+# and persists a JSONL session file, mirroring the real codex CLI's protocol.
 #
 # Verifies:
 #   - Codex framework markers render (▷ Codex Started / ◆ Codex Completed)


### PR DESCRIPTION
## Summary

- Validate guest-mock-codex thread IDs as canonical UUIDs before building session file paths.
- Build session paths before emitting JSONL events so invalid resume IDs fail without partial stdout output.
- Add binary integration regressions for absolute, traversal, and nested resume IDs.

Closes #15826

## Tests

- `cargo test --manifest-path crates/Cargo.toml -p guest-mock-codex resume_rejects -- --nocapture`
- `cargo test --manifest-path crates/Cargo.toml -p guest-mock-codex build_session_path -- --nocapture`
- `cargo test --manifest-path crates/Cargo.toml -p guest-mock-codex`
- `cargo fmt --manifest-path crates/Cargo.toml --all -- --check`
- `CARGO_BUILD_JOBS=1 cargo clippy --manifest-path crates/Cargo.toml -p guest-mock-codex --all-targets --all-features`
- `git diff --check`
- `cd crates && CARGO_BUILD_JOBS=1 cargo clippy --all-targets --all-features`
- `cd crates && cargo doc --workspace --all-features --no-deps`