### PR TITLE
fix(guest-agent): fail checkpoint on unreadable artifact root

### DIFF
--- a/crates/guest-agent/src/artifact/archive.rs
+++ b/crates/guest-agent/src/artifact/archive.rs
@@ -14,26 +14,20 @@ const LOG_TAG: &str = "sandbox:guest-agent";
 
 /// Walk directory and compute SHA-256 for each file, skipping `.git` and `.vm0`.
 #[cfg(target_os = "linux")]
-pub(super) fn collect_file_metadata(dir_path: &str) -> Vec<FileEntry> {
+pub(super) fn collect_file_metadata(dir_path: &str) -> Result<Vec<FileEntry>, ArchiveError> {
     let mut files = Vec::new();
-    let root = match Dir::open(Path::new(dir_path)) {
-        Ok(root) => root,
-        Err(e) => {
-            log_warn!(LOG_TAG, "Could not read artifact root {dir_path}: {e}");
-            return files;
-        }
-    };
-    walk_dir(&root, "", &mut files);
-    files
+    let root_path = Path::new(dir_path);
+    let root = open_artifact_root(root_path)?;
+    let entries = read_artifact_root(&root, root_path)?;
+    walk_entries(&root, "", entries, &mut files);
+    Ok(files)
 }
 
 #[cfg(not(target_os = "linux"))]
-pub(super) fn collect_file_metadata(dir_path: &str) -> Vec<FileEntry> {
-    log_warn!(
-        LOG_TAG,
-        "Artifact metadata collection requires Linux no-follow path opening: {dir_path}"
-    );
-    Vec::new()
+pub(super) fn collect_file_metadata(dir_path: &str) -> Result<Vec<FileEntry>, ArchiveError> {
+    Err(ArchiveError::UnsupportedRoot {
+        path: PathBuf::from(dir_path),
+    })
 }
 
 #[cfg(target_os = "linux")]
@@ -42,6 +36,11 @@ fn walk_dir(current: &Dir, relative: &str, out: &mut Vec<FileEntry>) {
         Ok(e) => e,
         Err(_) => return,
     };
+    walk_entries(current, relative, entries, out);
+}
+
+#[cfg(target_os = "linux")]
+fn walk_entries(current: &Dir, relative: &str, entries: fs::ReadDir, out: &mut Vec<FileEntry>) {
     for entry in entries.flatten() {
         let name = entry.file_name();
         let name_str = name.to_string_lossy();
@@ -106,6 +105,16 @@ fn compute_file_hash_from_reader(mut reader: impl Read) -> Result<(String, u64),
 
 #[derive(Debug, Error)]
 pub(super) enum ArchiveError {
+    #[error("failed to open artifact root {}: {source}", path.display())]
+    RootOpen { path: PathBuf, source: io::Error },
+    #[error("failed to read artifact root {}: {source}", path.display())]
+    RootRead { path: PathBuf, source: io::Error },
+    #[cfg(not(target_os = "linux"))]
+    #[error(
+        "artifact root access requires Linux no-follow path opening: {}",
+        path.display()
+    )]
+    UnsupportedRoot { path: PathBuf },
     #[error("failed to create archive output {}: {source}", path.display())]
     CreateOutput { path: PathBuf, source: io::Error },
     #[error("invalid archive path {path:?}: path must be relative and stay within the artifact")]
@@ -153,13 +162,17 @@ pub(super) fn create_archive(
     tar_path: &Path,
     files: &[FileEntry],
 ) -> Result<(), ArchiveError> {
+    let root = Path::new(dir_path);
+    if files.is_empty() {
+        ensure_readable_artifact_root(root)?;
+    }
+
     let output = File::create(tar_path).map_err(|source| ArchiveError::CreateOutput {
         path: tar_path.to_owned(),
         source,
     })?;
     let encoder = GzEncoder::new(output, Compression::default());
     let mut builder = tar::Builder::new(encoder);
-    let root = Path::new(dir_path);
 
     for file in files {
         append_archive_file(root, &mut builder, file)?;
@@ -179,6 +192,10 @@ pub(super) fn validate_archive_inputs(
     files: &[FileEntry],
 ) -> Result<(), ArchiveError> {
     let root = Path::new(dir_path);
+    if files.is_empty() {
+        ensure_readable_artifact_root(root)?;
+    }
+
     for file in files {
         validate_archive_file(root, file)?;
     }
@@ -301,6 +318,36 @@ fn archive_relative_path(path: &str) -> Result<&Path, ArchiveError> {
         });
     }
     Ok(rel_path)
+}
+
+#[cfg(target_os = "linux")]
+fn ensure_readable_artifact_root(root: &Path) -> Result<(), ArchiveError> {
+    let dir = open_artifact_root(root)?;
+    read_artifact_root(&dir, root)?;
+    Ok(())
+}
+
+#[cfg(not(target_os = "linux"))]
+fn ensure_readable_artifact_root(root: &Path) -> Result<(), ArchiveError> {
+    Err(ArchiveError::UnsupportedRoot {
+        path: root.to_owned(),
+    })
+}
+
+#[cfg(target_os = "linux")]
+fn open_artifact_root(root: &Path) -> Result<Dir, ArchiveError> {
+    Dir::open(root).map_err(|source| ArchiveError::RootOpen {
+        path: root.to_owned(),
+        source,
+    })
+}
+
+#[cfg(target_os = "linux")]
+fn read_artifact_root(root: &Dir, path: &Path) -> Result<fs::ReadDir, ArchiveError> {
+    root.read_dir().map_err(|source| ArchiveError::RootRead {
+        path: path.to_owned(),
+        source,
+    })
 }
 
 #[cfg(unix)]
@@ -467,7 +514,7 @@ mod tests {
         // Dangling symlink
         unix_fs::symlink("/nonexistent", root.join("dangling")).unwrap();
 
-        let files = collect_file_metadata(root.to_str().unwrap());
+        let files = collect_file_metadata(root.to_str().unwrap()).unwrap();
         let paths: Vec<&str> = files.iter().map(|f| f.path.as_str()).collect();
 
         // Regular files should be included
@@ -494,7 +541,7 @@ mod tests {
         std::fs::write(outside.join("secret.txt"), "secret").unwrap();
         unix_fs::symlink(&outside, root.join("link_dir")).unwrap();
 
-        let files = collect_file_metadata(root.to_str().unwrap());
+        let files = collect_file_metadata(root.to_str().unwrap()).unwrap();
         let paths: Vec<&str> = files.iter().map(|f| f.path.as_str()).collect();
 
         assert!(paths.contains(&"real.txt"));
@@ -510,7 +557,7 @@ mod tests {
         std::fs::write(root.join("real.txt"), "hello").unwrap();
         make_fifo(&root.join("pipe")).unwrap();
 
-        let files = collect_file_metadata(root.to_str().unwrap());
+        let files = collect_file_metadata(root.to_str().unwrap()).unwrap();
         let paths: Vec<&str> = files.iter().map(|f| f.path.as_str()).collect();
 
         assert!(paths.contains(&"real.txt"));
@@ -525,7 +572,7 @@ mod tests {
         std::fs::write(root.join("original.txt"), "content").unwrap();
         std::fs::hard_link(root.join("original.txt"), root.join("hardlink.txt")).unwrap();
 
-        let files = collect_file_metadata(root.to_str().unwrap());
+        let files = collect_file_metadata(root.to_str().unwrap()).unwrap();
         let paths: Vec<&str> = files.iter().map(|f| f.path.as_str()).collect();
 
         // Both original and hardlink should be recorded as independent files
@@ -554,7 +601,7 @@ mod tests {
         unix_fs::symlink("/nonexistent", root.join("dangling")).unwrap();
 
         // Collect metadata (skips symlinks)
-        let files = collect_file_metadata(root.to_str().unwrap());
+        let files = collect_file_metadata(root.to_str().unwrap()).unwrap();
 
         // Create archive using only manifest file list
         let tar_path = dir.path().join("archive.tar.gz");
@@ -587,7 +634,7 @@ mod tests {
         // File with newline in name
         std::fs::write(root.join("line1\nline2.txt"), "newline").unwrap();
 
-        let files = collect_file_metadata(root.to_str().unwrap());
+        let files = collect_file_metadata(root.to_str().unwrap()).unwrap();
 
         let tar_path = dir.path().join("archive.tar.gz");
         assert!(create_archive(root.to_str().unwrap(), &tar_path, &files).is_ok());
@@ -617,6 +664,66 @@ mod tests {
     }
 
     #[test]
+    fn archive_empty_files_requires_existing_root() {
+        let dir = tempfile::tempdir().unwrap();
+        let missing = dir.path().join("missing");
+        let tar_path = dir.path().join("empty.tar.gz");
+
+        let err = create_archive(missing.to_str().unwrap(), &tar_path, &[]).unwrap_err();
+
+        assert!(
+            err.to_string().contains("failed to open artifact root"),
+            "got: {err}"
+        );
+    }
+
+    #[test]
+    fn archive_empty_files_rejects_symlink_root() {
+        let dir = tempfile::tempdir().unwrap();
+        let real = dir.path().join("real");
+        let link = dir.path().join("link");
+        std::fs::create_dir(&real).unwrap();
+        unix_fs::symlink(&real, &link).unwrap();
+        let tar_path = dir.path().join("empty.tar.gz");
+
+        let err = create_archive(link.to_str().unwrap(), &tar_path, &[]).unwrap_err();
+
+        assert!(
+            err.to_string().contains("failed to open artifact root"),
+            "got: {err}"
+        );
+    }
+
+    #[test]
+    fn validate_archive_inputs_empty_files_requires_existing_root() {
+        let dir = tempfile::tempdir().unwrap();
+        let missing = dir.path().join("missing");
+
+        let err = validate_archive_inputs(missing.to_str().unwrap(), &[]).unwrap_err();
+
+        assert!(
+            err.to_string().contains("failed to open artifact root"),
+            "got: {err}"
+        );
+    }
+
+    #[test]
+    fn validate_archive_inputs_empty_files_rejects_symlink_root() {
+        let dir = tempfile::tempdir().unwrap();
+        let real = dir.path().join("real");
+        let link = dir.path().join("link");
+        std::fs::create_dir(&real).unwrap();
+        unix_fs::symlink(&real, &link).unwrap();
+
+        let err = validate_archive_inputs(link.to_str().unwrap(), &[]).unwrap_err();
+
+        assert!(
+            err.to_string().contains("failed to open artifact root"),
+            "got: {err}"
+        );
+    }
+
+    #[test]
     fn archive_hardlinks_as_independent_regular_files() {
         let dir = tempfile::tempdir().unwrap();
         let root = dir.path();
@@ -624,7 +731,7 @@ mod tests {
         std::fs::write(root.join("original.txt"), "content").unwrap();
         std::fs::hard_link(root.join("original.txt"), root.join("hardlink.txt")).unwrap();
 
-        let files = collect_file_metadata(root.to_str().unwrap());
+        let files = collect_file_metadata(root.to_str().unwrap()).unwrap();
 
         let tar_path = dir.path().join("archive.tar.gz");
         assert!(create_archive(root.to_str().unwrap(), &tar_path, &files).is_ok());
@@ -652,7 +759,7 @@ mod tests {
         std::fs::write(&script, "echo ok\n").unwrap();
         std::fs::set_permissions(&script, std::fs::Permissions::from_mode(0o755)).unwrap();
 
-        let files = collect_file_metadata(root.to_str().unwrap());
+        let files = collect_file_metadata(root.to_str().unwrap()).unwrap();
         let tar_path = dir.path().join("archive.tar.gz");
         assert!(create_archive(root.to_str().unwrap(), &tar_path, &files).is_ok());
 
@@ -672,7 +779,7 @@ mod tests {
         let root = dir.path();
 
         std::fs::write(root.join("target.txt"), "before").unwrap();
-        let files = collect_file_metadata(root.to_str().unwrap());
+        let files = collect_file_metadata(root.to_str().unwrap()).unwrap();
         std::fs::write(root.join("target.txt"), "after-size-change").unwrap();
 
         let tar_path = dir.path().join("archive.tar.gz");
@@ -688,7 +795,7 @@ mod tests {
         let root = dir.path();
 
         std::fs::write(root.join("target.txt"), "before").unwrap();
-        let files = collect_file_metadata(root.to_str().unwrap());
+        let files = collect_file_metadata(root.to_str().unwrap()).unwrap();
         std::fs::write(root.join("target.txt"), "after!").unwrap();
 
         let tar_path = dir.path().join("archive.tar.gz");
@@ -716,7 +823,7 @@ mod tests {
         let root = dir.path();
 
         std::fs::write(root.join("target.txt"), "before").unwrap();
-        let files = collect_file_metadata(root.to_str().unwrap());
+        let files = collect_file_metadata(root.to_str().unwrap()).unwrap();
         std::fs::write(root.join("target.txt"), "after!").unwrap();
 
         let err = validate_archive_inputs(root.to_str().unwrap(), &files).unwrap_err();
@@ -732,7 +839,7 @@ mod tests {
 
         std::fs::write(root.join("target.txt"), "before").unwrap();
         std::fs::write(root.join("outside.txt"), "outside").unwrap();
-        let files = collect_file_metadata(root.to_str().unwrap());
+        let files = collect_file_metadata(root.to_str().unwrap()).unwrap();
         let archive_files: Vec<FileEntry> = files
             .iter()
             .filter(|f| f.path == "target.txt")
@@ -754,7 +861,7 @@ mod tests {
         let root = dir.path();
 
         std::fs::write(root.join("target.txt"), "before").unwrap();
-        let files = collect_file_metadata(root.to_str().unwrap());
+        let files = collect_file_metadata(root.to_str().unwrap()).unwrap();
         let archive_files: Vec<FileEntry> = files
             .iter()
             .filter(|f| f.path == "target.txt")
@@ -823,7 +930,7 @@ mod tests {
 
         std::fs::write(root.join("target.txt"), "before").unwrap();
         std::fs::write(root.join("outside.txt"), "outside").unwrap();
-        let files = collect_file_metadata(root.to_str().unwrap());
+        let files = collect_file_metadata(root.to_str().unwrap()).unwrap();
         let archive_files: Vec<FileEntry> = files
             .iter()
             .filter(|f| f.path == "target.txt")
@@ -848,7 +955,7 @@ mod tests {
         let root = dir.path();
 
         std::fs::write(root.join("target.txt"), "before").unwrap();
-        let files = collect_file_metadata(root.to_str().unwrap());
+        let files = collect_file_metadata(root.to_str().unwrap()).unwrap();
         let archive_files: Vec<FileEntry> = files
             .iter()
             .filter(|f| f.path == "target.txt")
@@ -876,7 +983,7 @@ mod tests {
         std::fs::write(root.join("subdir/file.txt"), "before").unwrap();
         std::fs::create_dir(root.join("outside")).unwrap();
         std::fs::write(root.join("outside/file.txt"), "outside").unwrap();
-        let files = collect_file_metadata(root.to_str().unwrap());
+        let files = collect_file_metadata(root.to_str().unwrap()).unwrap();
         let archive_files: Vec<FileEntry> = files
             .iter()
             .filter(|f| f.path == "subdir/file.txt")
@@ -901,7 +1008,7 @@ mod tests {
         let root = dir.path();
 
         std::fs::write(root.join("gone.txt"), "data").unwrap();
-        let files = collect_file_metadata(root.to_str().unwrap());
+        let files = collect_file_metadata(root.to_str().unwrap()).unwrap();
         let paths: Vec<&str> = files.iter().map(|f| f.path.as_str()).collect();
         assert_eq!(paths, vec!["gone.txt"]);
 
@@ -936,7 +1043,7 @@ mod tests {
         std::fs::create_dir(root.join("src")).unwrap();
         std::fs::write(root.join("src/lib.rs"), "pub fn hello() {}").unwrap();
 
-        let files = collect_file_metadata(root.to_str().unwrap());
+        let files = collect_file_metadata(root.to_str().unwrap()).unwrap();
         let paths: Vec<&str> = files.iter().map(|f| f.path.as_str()).collect();
 
         assert!(paths.contains(&"main.rs"));
@@ -980,14 +1087,33 @@ mod tests {
     #[test]
     fn collect_file_metadata_empty_dir() {
         let dir = tempfile::tempdir().unwrap();
-        let files = collect_file_metadata(dir.path().to_str().unwrap());
+        let files = collect_file_metadata(dir.path().to_str().unwrap()).unwrap();
         assert!(files.is_empty());
     }
 
     #[test]
     fn collect_file_metadata_nonexistent_dir() {
         disable_system_log();
-        let files = collect_file_metadata("/nonexistent/path/that/does/not/exist");
-        assert!(files.is_empty());
+        let err = collect_file_metadata("/nonexistent/path/that/does/not/exist").unwrap_err();
+        assert!(
+            err.to_string().contains("failed to open artifact root"),
+            "got: {err}"
+        );
+    }
+
+    #[test]
+    fn collect_file_metadata_rejects_symlink_root() {
+        let dir = tempfile::tempdir().unwrap();
+        let real = dir.path().join("real");
+        let link = dir.path().join("link");
+        std::fs::create_dir(&real).unwrap();
+        unix_fs::symlink(&real, &link).unwrap();
+
+        let err = collect_file_metadata(link.to_str().unwrap()).unwrap_err();
+
+        assert!(
+            err.to_string().contains("failed to open artifact root"),
+            "got: {err}"
+        );
     }
 }

--- a/crates/guest-agent/src/artifact/mod.rs
+++ b/crates/guest-agent/src/artifact/mod.rs
@@ -28,7 +28,7 @@ use std::path::PathBuf;
 
 const LOG_TAG: &str = "sandbox:guest-agent";
 
-#[derive(Serialize, Clone)]
+#[derive(Debug, Serialize, Clone)]
 pub(crate) struct FileEntry {
     pub(crate) path: String,
     pub(crate) hash: String,
@@ -57,9 +57,34 @@ pub(crate) async fn walk_files(mount_path: &str) -> Result<Vec<FileEntry>, Agent
     log_info!(LOG_TAG, "Computing file hashes...");
     let hash_start = std::time::Instant::now();
     let mount = mount_path.to_string();
-    let files = tokio::task::spawn_blocking(move || collect_file_metadata(&mount))
-        .await
-        .map_err(|e| AgentError::Execution(format!("hash task panicked: {e}")))?;
+    let files_result =
+        match tokio::task::spawn_blocking(move || collect_file_metadata(&mount)).await {
+            Ok(result) => result,
+            Err(e) => {
+                let message = format!("hash task panicked: {e}");
+                record_sandbox_op(
+                    "artifact_hash_compute",
+                    hash_start.elapsed(),
+                    false,
+                    Some(&message),
+                );
+                return Err(AgentError::Execution(message));
+            }
+        };
+    let files = match files_result {
+        Ok(files) => files,
+        Err(e) => {
+            let message = format!("Failed to walk artifact files: {e}");
+            log_error!(LOG_TAG, "{message}");
+            record_sandbox_op(
+                "artifact_hash_compute",
+                hash_start.elapsed(),
+                false,
+                Some(&message),
+            );
+            return Err(AgentError::Checkpoint(message));
+        }
+    };
     record_sandbox_op("artifact_hash_compute", hash_start.elapsed(), true, None);
     log_info!(LOG_TAG, "Found {} files", files.len());
     Ok(files)
@@ -407,7 +432,7 @@ mod tests {
         let root = dir.path();
         std::fs::write(root.join("alpha.txt"), "alpha").unwrap();
         std::fs::write(root.join("target.txt"), "content").unwrap();
-        let mut files = archive::collect_file_metadata(root.to_str().unwrap());
+        let mut files = archive::collect_file_metadata(root.to_str().unwrap()).unwrap();
         files.sort_by(|left, right| left.path.cmp(&right.path));
         let expected_files = file_json_values(&files);
         let total_size: u64 = files.iter().map(|file| file.size).sum();
@@ -528,7 +553,7 @@ mod tests {
         let dir = tempfile::tempdir().unwrap();
         let root = dir.path();
         std::fs::write(root.join("alpha.txt"), "alpha").unwrap();
-        let mut files = archive::collect_file_metadata(root.to_str().unwrap());
+        let mut files = archive::collect_file_metadata(root.to_str().unwrap()).unwrap();
         files.sort_by(|left, right| left.path.cmp(&right.path));
         let expected_files = file_json_values(&files);
         let archive_url = format!("{}/test/artifact-archive-upload", server.base_url());
@@ -626,7 +651,7 @@ mod tests {
         let dir = tempfile::tempdir().unwrap();
         let root = dir.path();
         std::fs::write(root.join("alpha.txt"), "alpha").unwrap();
-        let mut files = archive::collect_file_metadata(root.to_str().unwrap());
+        let mut files = archive::collect_file_metadata(root.to_str().unwrap()).unwrap();
         files.sort_by(|left, right| left.path.cmp(&right.path));
         let expected_files = file_json_values(&files);
 

--- a/crates/guest-agent/src/checkpoint.rs
+++ b/crates/guest-agent/src/checkpoint.rs
@@ -71,6 +71,11 @@ fn build_artifact_snapshot_entry(name: &str, version: &str, mount_path: &str) ->
     })
 }
 
+struct ArtifactSnapshotPlan<'a> {
+    entry: &'a env::ArtifactEnv,
+    files: Vec<artifact::FileEntry>,
+}
+
 /// Prepare + upload the session history to S3 via a presigned URL. If the
 /// prepare endpoint reports `existing=true`, skip the upload (content-addressed
 /// dedup). Telemetry is recorded under `session_history_prepare` and
@@ -158,12 +163,14 @@ async fn upload_session_history(
     Ok(())
 }
 
-/// Snapshot all configured artifacts. Memory rides in env::artifacts()
-/// post-#10602, so there is no longer a separate memory arm. Payload shape is
+/// Snapshot artifact entries. Memory rides in `VM0_ARTIFACTS` post-#10602, so
+/// there is no longer a separate memory arm. Payload shape is
 /// `Array<{name, version, mountPath}>` per #10911 — the receiver tolerates the
 /// legacy `Record<name, version>` form too (#10919).
-async fn snapshot_artifacts(http: &HttpClient) -> Result<Option<serde_json::Value>, AgentError> {
-    let entries = env::artifacts();
+async fn snapshot_artifact_entries(
+    http: &HttpClient,
+    entries: &[env::ArtifactEnv],
+) -> Result<Option<serde_json::Value>, AgentError> {
     if entries.is_empty() {
         log_info!(
             LOG_TAG,
@@ -171,7 +178,8 @@ async fn snapshot_artifacts(http: &HttpClient) -> Result<Option<serde_json::Valu
         );
         return Ok(None);
     }
-    let mut results = Vec::with_capacity(entries.len());
+
+    let mut plans = Vec::with_capacity(entries.len());
     for entry in entries {
         log_info!(
             LOG_TAG,
@@ -180,7 +188,11 @@ async fn snapshot_artifacts(http: &HttpClient) -> Result<Option<serde_json::Valu
             entry.mount_path
         );
         let files = artifact::walk_files(&entry.mount_path).await?;
+        plans.push(ArtifactSnapshotPlan { entry, files });
+    }
 
+    let mut results = Vec::with_capacity(plans.len());
+    for ArtifactSnapshotPlan { entry, files } in plans {
         // Skip the VAS round-trips when the mount is byte-identical to what
         // was originally mounted. `version_id` in VAS *is* the content hash
         // (same SHA-256 the web producer emits), so an equality check on the
@@ -273,6 +285,14 @@ pub async fn create_recovery_checkpoint(http: &HttpClient) -> Result<(), AgentEr
 }
 
 async fn create_checkpoint_impl(http: &HttpClient, mode: CheckpointMode) -> Result<(), AgentError> {
+    create_checkpoint_impl_with_artifacts(http, mode, env::artifacts()).await
+}
+
+async fn create_checkpoint_impl_with_artifacts(
+    http: &HttpClient,
+    mode: CheckpointMode,
+    artifact_entries: &[env::ArtifactEnv],
+) -> Result<(), AgentError> {
     log_info!(LOG_TAG, "Creating {}...", mode.log_label());
 
     // Read session ID. Let `read_to_string` surface `NotFound` directly — an
@@ -382,7 +402,7 @@ async fn create_checkpoint_impl(http: &HttpClient, mode: CheckpointMode) -> Resu
             history_size,
             session_history.into_bytes()
         ),
-        snapshot_artifacts(http),
+        snapshot_artifact_entries(http, artifact_entries),
     )?;
 
     // Build and send checkpoint payload (session history hash only, content uploaded to S3)
@@ -462,6 +482,28 @@ fn validate_recoverable_session_history(session_history: &str) -> Result<(), Str
 #[cfg(test)]
 mod tests {
     use super::*;
+    use httpmock::prelude::*;
+    use std::time::Duration;
+
+    struct CheckpointFilesGuard;
+
+    impl CheckpointFilesGuard {
+        fn new() -> Self {
+            cleanup_checkpoint_files();
+            Self
+        }
+    }
+
+    impl Drop for CheckpointFilesGuard {
+        fn drop(&mut self) {
+            cleanup_checkpoint_files();
+        }
+    }
+
+    fn cleanup_checkpoint_files() {
+        let _ = std::fs::remove_file(paths::session_id_file());
+        let _ = std::fs::remove_file(paths::session_history_path_file());
+    }
 
     #[test]
     fn artifact_snapshot_entry_shape_matches_receiver_schema() {
@@ -487,6 +529,146 @@ mod tests {
         assert!(obj.contains_key("version"));
         assert!(obj.contains_key("mountPath"));
         assert!(!obj.contains_key("mount_path"));
+    }
+
+    #[tokio::test]
+    async fn artifact_snapshot_missing_mount_fails_before_storage_api_calls() {
+        let server = MockServer::start();
+        let prepare = server.mock(|when, then| {
+            when.method(POST)
+                .path("/api/webhooks/agent/storages/prepare");
+            then.status(200).json_body(json!({"unreachable": true}));
+        });
+        let commit = server.mock(|when, then| {
+            when.method(POST)
+                .path("/api/webhooks/agent/storages/commit");
+            then.status(200).json_body(json!({"unreachable": true}));
+        });
+        let http = HttpClient::with_api_config(server.base_url(), "test-token", "", Duration::ZERO)
+            .unwrap();
+        let dir = tempfile::tempdir().unwrap();
+        let missing_mount = dir.path().join("missing");
+        let entries = vec![env::ArtifactEnv {
+            name: "workspace".to_string(),
+            mount_path: missing_mount.to_string_lossy().into_owned(),
+            storage_id: "storage-id".to_string(),
+            version_id: "parent-version".to_string(),
+        }];
+
+        let err = snapshot_artifact_entries(&http, &entries)
+            .await
+            .unwrap_err();
+
+        assert!(
+            err.to_string().contains("Failed to walk artifact files"),
+            "got: {err}"
+        );
+        prepare.assert_calls(0);
+        commit.assert_calls(0);
+    }
+
+    #[tokio::test]
+    async fn artifact_snapshot_later_missing_mount_fails_before_any_storage_api_calls() {
+        let server = MockServer::start();
+        let prepare = server.mock(|when, then| {
+            when.method(POST)
+                .path("/api/webhooks/agent/storages/prepare");
+            then.status(200).json_body(json!({"unreachable": true}));
+        });
+        let commit = server.mock(|when, then| {
+            when.method(POST)
+                .path("/api/webhooks/agent/storages/commit");
+            then.status(200).json_body(json!({"unreachable": true}));
+        });
+        let http = HttpClient::with_api_config(server.base_url(), "test-token", "", Duration::ZERO)
+            .unwrap();
+        let dir = tempfile::tempdir().unwrap();
+        let valid_mount = dir.path().join("valid");
+        std::fs::create_dir(&valid_mount).unwrap();
+        std::fs::write(valid_mount.join("changed.txt"), "changed").unwrap();
+        let missing_mount = dir.path().join("missing");
+        let entries = vec![
+            env::ArtifactEnv {
+                name: "workspace".to_string(),
+                mount_path: valid_mount.to_string_lossy().into_owned(),
+                storage_id: "workspace-storage-id".to_string(),
+                version_id: "old-workspace-version".to_string(),
+            },
+            env::ArtifactEnv {
+                name: "memory".to_string(),
+                mount_path: missing_mount.to_string_lossy().into_owned(),
+                storage_id: "memory-storage-id".to_string(),
+                version_id: "old-memory-version".to_string(),
+            },
+        ];
+
+        let err = snapshot_artifact_entries(&http, &entries)
+            .await
+            .unwrap_err();
+
+        assert!(
+            err.to_string().contains("Failed to walk artifact files"),
+            "got: {err}"
+        );
+        prepare.assert_calls(0);
+        commit.assert_calls(0);
+    }
+
+    #[tokio::test]
+    async fn checkpoint_missing_mount_fails_before_final_checkpoint_api_call() {
+        let _files_guard = CheckpointFilesGuard::new();
+        let server = MockServer::start();
+        let dir = tempfile::tempdir().unwrap();
+        let history_path = dir.path().join("history.jsonl");
+        std::fs::write(&history_path, r#"{"type":"system"}"#).unwrap();
+        std::fs::write(paths::session_id_file(), "session-with-missing-artifact").unwrap();
+        std::fs::write(
+            paths::session_history_path_file(),
+            history_path.to_string_lossy().as_ref(),
+        )
+        .unwrap();
+
+        let _history_prepare = server.mock(|when, then| {
+            when.method(POST)
+                .path("/api/webhooks/agent/checkpoints/prepare-history");
+            then.status(200).json_body(json!({"existing": true}));
+        });
+        let prepare = server.mock(|when, then| {
+            when.method(POST)
+                .path("/api/webhooks/agent/storages/prepare");
+            then.status(200).json_body(json!({"unreachable": true}));
+        });
+        let commit = server.mock(|when, then| {
+            when.method(POST)
+                .path("/api/webhooks/agent/storages/commit");
+            then.status(200).json_body(json!({"unreachable": true}));
+        });
+        let checkpoint = server.mock(|when, then| {
+            when.method(POST).path("/api/webhooks/agent/checkpoints");
+            then.status(200)
+                .json_body(json!({"checkpointId": "unreachable"}));
+        });
+        let http = HttpClient::with_api_config(server.base_url(), "test-token", "", Duration::ZERO)
+            .unwrap();
+        let missing_mount = dir.path().join("missing");
+        let entries = vec![env::ArtifactEnv {
+            name: "workspace".to_string(),
+            mount_path: missing_mount.to_string_lossy().into_owned(),
+            storage_id: "storage-id".to_string(),
+            version_id: "parent-version".to_string(),
+        }];
+
+        let err = create_checkpoint_impl_with_artifacts(&http, CheckpointMode::Success, &entries)
+            .await
+            .unwrap_err();
+
+        assert!(
+            err.to_string().contains("Failed to walk artifact files"),
+            "got: {err}"
+        );
+        prepare.assert_calls(0);
+        commit.assert_calls(0);
+        checkpoint.assert_calls(0);
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- Treat configured artifact root open/read failures as checkpoint errors instead of empty file lists.
- Keep readable empty artifact roots valid, including empty archive creation.
- Verify root readability for empty archive validation and add regression coverage for missing/symlink roots.

Closes #15800

## Tests

- `cargo test --manifest-path crates/Cargo.toml -p guest-agent --lib artifact::archive`
- `cargo test --manifest-path crates/Cargo.toml -p guest-agent --lib artifact::tests`
- `cargo test --manifest-path crates/Cargo.toml -p guest-agent --lib checkpoint::tests`
- `cargo clippy --all-targets --all-features --jobs 1`
- `cargo doc --workspace --all-features --no-deps --jobs 1`
- `cargo test --manifest-path crates/Cargo.toml -p guest-agent --jobs 1`