### PR TITLE
docs(runner): correct storage cache hash guidance

### DIFF
--- a/crates/runner/src/paths.rs
+++ b/crates/runner/src/paths.rs
@@ -24,12 +24,12 @@ use sha2::{Digest, Sha256};
 use crate::error::RunnerResult;
 use crate::ids::RunId;
 
-/// Short hex digests (16 chars = 64 bits) of a `(name, version)` pair, used
-/// when building filesystem paths from untrusted manifest fields.
+/// Short hex digests for storage name and version components, used when
+/// building filesystem paths from untrusted manifest fields.
 ///
-/// The 64-bit prefix keeps directory names compact and is intended for this
-/// bounded runner-local cache, not as a mathematical uniqueness guarantee or
-/// unbounded global key.
+/// Each component uses a 16-character / 64-bit prefix. That keeps directory
+/// names compact for this bounded runner-local cache, but is not a
+/// mathematical uniqueness guarantee or unbounded global key.
 fn storage_key_hashes(name: &str, version: &str) -> (String, String) {
     (short_digest(name), short_digest(version))
 }

--- a/crates/runner/src/paths.rs
+++ b/crates/runner/src/paths.rs
@@ -24,19 +24,19 @@ use sha2::{Digest, Sha256};
 use crate::error::RunnerResult;
 use crate::ids::RunId;
 
-/// Short hex digests (16 chars = 8 bytes) of a `(name, version)` pair, used
+/// Short hex digests (16 chars = 64 bits) of a `(name, version)` pair, used
 /// when building filesystem paths from untrusted manifest fields.
 ///
-/// Prefix-length of 16 is ample collision resistance for a runner-local
-/// cache (~10^10 pairs before birthday collision) while keeping directory
-/// names compact.
+/// The 64-bit prefix keeps directory names compact and is intended for this
+/// bounded runner-local cache, not as a mathematical uniqueness guarantee or
+/// unbounded global key.
 fn storage_key_hashes(name: &str, version: &str) -> (String, String) {
     (short_digest(name), short_digest(version))
 }
 
 /// Hex-encode the first 8 bytes of `SHA-256(s)` — 16 characters, collision
-/// resistant enough for runner-local bookkeeping and always a valid path
-/// segment.
+/// resistant enough for bounded runner-local bookkeeping and always a valid
+/// path segment.
 ///
 /// Exposed `pub(crate)` so the host-side cache dir (built here) and the
 /// guest-side `file://` URL (built in `storage_cache`) share one source of
@@ -207,9 +207,9 @@ impl HomePaths {
     ///
     /// `name` and `version` come from untrusted manifest fields
     /// (`vas_storage_name` / `vas_version_id`) so they are hashed before use.
-    /// Hashing also makes the key pair injective — two distinct `(name,
-    /// version)` pairs cannot collide on a single directory regardless of
-    /// hyphen placement in either component.
+    /// Hashing also avoids separator ambiguity between the two path components
+    /// and provides compact collision-resistant cache keys under the truncated
+    /// hash model.
     pub fn storage_cache_dir(&self, name: &str, version: &str) -> PathBuf {
         let (name_hash, version_hash) = storage_key_hashes(name, version);
         self.storages_dir().join(name_hash).join(version_hash)
@@ -218,7 +218,8 @@ impl HomePaths {
     /// Per-version flock path guarding `storage_cache_dir(name, version)`.
     ///
     /// Same hashing rationale as `storage_cache_dir`: the lock filename must
-    /// be injective in `(name, version)` and safe to embed in a path segment.
+    /// use the same compact cache key components and be safe to embed in a
+    /// path segment.
     pub fn storage_lock(&self, name: &str, version: &str) -> PathBuf {
         let (name_hash, version_hash) = storage_key_hashes(name, version);
         self.storage_lock_for_cache_key(&name_hash, &version_hash)
@@ -739,16 +740,19 @@ mod tests {
     }
 
     #[test]
-    fn storage_lock_is_injective_and_inside_locks_dir() {
+    fn storage_lock_avoids_separator_ambiguity_and_stays_inside_locks_dir() {
         // Distinct (name, version) pairs that would collide under naive
         // `format!("storage-{name}-{version}.lock")` templating must produce
-        // distinct lock paths after hashing.
+        // distinct lock paths for these examples after hashing.
         let home = HomePaths::with_root(PathBuf::from("/test"));
         let locks = home.locks_dir();
 
         let a = home.storage_lock("foo", "bar-v1");
         let b = home.storage_lock("foo-bar", "v1");
-        assert_ne!(a, b, "hashed lock paths must not collide: {a:?} vs {b:?}");
+        assert_ne!(
+            a, b,
+            "naive-ambiguous examples should not share a lock path: {a:?} vs {b:?}"
+        );
         assert!(a.starts_with(&locks));
         assert!(b.starts_with(&locks));
         assert!(a.to_string_lossy().ends_with(".lock"));

--- a/crates/runner/src/storage_cache.rs
+++ b/crates/runner/src/storage_cache.rs
@@ -8,9 +8,9 @@
 //! entry's `archive_url` is rewritten to
 //! `file:///tmp/vm0-storage-cache/<hash(name)>-<hash(version)>.tar.gz`
 //! so `guest-download` reads from the local stage instead of re-fetching.
-//! Keying on both name and version keeps the guest file injective in the
-//! `(vasStorageName, vasVersionId)` pair — two entries that only differ in
-//! storage name cannot clobber each other on the guest tmpfs.
+//! Keying on both name and version gives same-version entries with different
+//! storage names separate collision-resistant staged filenames in normal
+//! operation, so they do not clobber each other on the guest tmpfs.
 //!
 //! Entries above [`CACHE_MAX_SIZE`], entries without a content key, and
 //! entries already marked `cached = true` (reuse-in-place from
@@ -55,11 +55,11 @@ const DOWNLOAD_TIMEOUT: Duration = Duration::from_secs(120);
 
 /// Guest-side filename for a cached archive.
 ///
-/// Must be injective in `(name, version)`: two manifest entries that differ
-/// only in `vas_storage_name` but share `vas_version_id` end up at distinct
-/// `file://` URLs so the second `sandbox.write_file` does not clobber the
-/// first. Uses the same `short_digest` helper that `HomePaths` uses for
-/// the host cache dir, so the two keys always map 1:1.
+/// Includes both hashed components so two manifest entries that differ only in
+/// `vas_storage_name` but share `vas_version_id` derive their staged filenames
+/// from both values under the same truncated-hash collision model as the host
+/// cache. Uses the same `short_digest` helper that `HomePaths` uses for the host
+/// cache dir, so host writes and guest reads use one shared keying scheme.
 fn guest_archive_path(name: &str, version: &str) -> String {
     let name_hash = short_digest(name);
     let version_hash = short_digest(version);


### PR DESCRIPTION
## Summary

- correct runner storage cache hash docs to describe the 16-hex-character / 64-bit SHA-256 prefix
- replace injective / impossible-collision wording with bounded runner-local collision-resistant guidance
- rename the path test that was using injective terminology while preserving behavior coverage

## Verification

- cargo fmt --all -- --check
- cargo test --manifest-path crates/Cargo.toml -p runner paths -j1
- cargo test --manifest-path crates/Cargo.toml -p runner storage_cache -j1
- CARGO_BUILD_JOBS=1 cargo clippy --all-targets --all-features

Closes #15799