### PR TITLE
fix: prevent tone pill label clipping

### DIFF
--- a/turbo/apps/platform/src/views/zero-page/zero-settings-tab.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-settings-tab.tsx
@@ -253,7 +253,7 @@ export function ZeroSettingsTab({
                 aria-label={`How ${resolvedAgentName} sounds`}
               >
                 <div
-                  className="flex w-full flex-wrap gap-2"
+                  className="grid w-full grid-cols-2 gap-2"
                   role="group"
                   aria-label="Tone"
                 >
@@ -266,7 +266,7 @@ export function ZeroSettingsTab({
                           return setTone(opt);
                         }}
                         className={cn(
-                          "min-w-[7.75rem] flex-1 rounded-lg border border-[0.7px] px-3 py-2.5 text-sm font-medium transition-all duration-200 focus:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 sm:flex-none",
+                          "w-full min-w-0 rounded-lg border border-[0.7px] px-3 py-2.5 text-sm font-medium transition-all duration-200 focus:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2",
                           tone === opt
                             ? "border-primary/40 bg-primary/10 text-primary dark:border-primary/50 dark:bg-primary/15"
                             : "zero-chip text-muted-foreground hover:text-foreground",

--- a/turbo/apps/platform/src/views/zero-page/zero-settings-tab.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-settings-tab.tsx
@@ -253,7 +253,7 @@ export function ZeroSettingsTab({
                 aria-label={`How ${resolvedAgentName} sounds`}
               >
                 <div
-                  className="grid w-full grid-cols-2 gap-2 sm:grid-cols-4"
+                  className="flex w-full flex-wrap gap-2"
                   role="group"
                   aria-label="Tone"
                 >
@@ -266,7 +266,7 @@ export function ZeroSettingsTab({
                           return setTone(opt);
                         }}
                         className={cn(
-                          "w-full min-w-0 rounded-lg border border-[0.7px] px-3 py-2.5 text-sm font-medium transition-all duration-200 focus:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2",
+                          "min-w-[7.75rem] flex-1 rounded-lg border border-[0.7px] px-3 py-2.5 text-sm font-medium transition-all duration-200 focus:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 sm:flex-none",
                           tone === opt
                             ? "border-primary/40 bg-primary/10 text-primary dark:border-primary/50 dark:bg-primary/15"
                             : "zero-chip text-muted-foreground hover:text-foreground",


### PR DESCRIPTION
## Summary
- Change the tone selector from a fixed four-column grid to a wrapping flex row
- Give each tone pill a content-safe minimum width so `Professional` is not clipped

## Verification
- `pnpm exec prettier --check apps/platform/src/views/zero-page/zero-settings-tab.tsx`
- `pnpm -F @vm0/app exec oxlint src/views/zero-page/zero-settings-tab.tsx`
- `pnpm -F @vm0/app exec tsc --noEmit --pretty false`
- Browser checked with app CSS injected from Vite: desktop 635px control width and mobile 328px control width both keep `Professional` fully visible with no horizontal overflow

## Notes
- `timeout 60s pnpm -F @vm0/app test -- src/views/zero-page/__tests__/zero-settings-tab.test.tsx --testNamePattern "changes tone selection"` was terminated by timeout with no test output beyond Vitest startup.