### PR TITLE
fix: block private auth.base rewrite destinations

### DIFF
--- a/crates/runner/mitm-addon/src/auth_base_forwarder.py
+++ b/crates/runner/mitm-addon/src/auth_base_forwarder.py
@@ -6,11 +6,9 @@ the low-level HTTP details for that forward path.
 """
 
 import asyncio
-import errno
 import http.client as http_client
 import ipaddress
 import socket
-import sys
 import urllib.parse
 from typing import NamedTuple
 
@@ -49,26 +47,15 @@ class _ValidatedAddress(NamedTuple):
     port: int
 
 
-class _ValidatedHTTPSConnection(http_client.HTTPSConnection):
-    def __init__(
-        self,
-        host: str,
-        port: int | None,
-        *,
-        timeout,
-        validated_addresses: tuple[_ValidatedAddress, ...],
-    ) -> None:
-        super().__init__(host, port=port, timeout=timeout)
-        self._validated_addresses = validated_addresses
-
-    def _connect_to_validated_address(self):
+def _connect_to_validated_addresses(validated_addresses: tuple[_ValidatedAddress, ...]):
+    def create_connection(_address, timeout, source_address):
         last_error: OSError | None = None
-        for address in self._validated_addresses:
+        for address in validated_addresses:
             try:
-                return self._create_connection(
+                return socket.create_connection(
                     (address.host, address.port),
-                    self.timeout,
-                    self.source_address,
+                    timeout,
+                    source_address,
                 )
             except OSError as exc:
                 last_error = exc
@@ -76,22 +63,19 @@ class _ValidatedHTTPSConnection(http_client.HTTPSConnection):
             raise last_error
         raise OSError("getaddrinfo returns an empty list")
 
-    def connect(self) -> None:
-        sys.audit("http.client.connect", self, self.host, self.port)
-        self.sock = self._connect_to_validated_address()
-        try:
-            self.sock.setsockopt(socket.IPPROTO_TCP, socket.TCP_NODELAY, 1)
-        except OSError as e:
-            if e.errno != errno.ENOPROTOOPT:
-                raise
+    return create_connection
 
-        if self._tunnel_host:
-            self._tunnel()
-            server_hostname = self._tunnel_host
-        else:
-            server_hostname = self.host
 
-        self.sock = self._context.wrap_socket(self.sock, server_hostname=server_hostname)
+def _make_validated_https_connection(
+    host: str,
+    port: int | None,
+    *,
+    timeout,
+    validated_addresses: tuple[_ValidatedAddress, ...],
+) -> http_client.HTTPSConnection:
+    conn = http_client.HTTPSConnection(host, port=port, timeout=timeout)
+    vars(conn)["_create_connection"] = _connect_to_validated_addresses(validated_addresses)
+    return conn
 
 
 def header_pairs(headers) -> list[tuple[str, str]]:
@@ -186,9 +170,9 @@ def _request_target(parsed: urllib.parse.SplitResult) -> str:
     return path
 
 
-def _connection_cls(scheme: str):
+def _connection_factory(scheme: str):
     if scheme == "https":
-        return _ValidatedHTTPSConnection
+        return _make_validated_https_connection
     raise ValueError(f"Unsupported URL scheme: {scheme}")
 
 
@@ -254,7 +238,7 @@ def _forward_request_sync(
     to the sandbox client instead of being followed inside the addon.
     """
     parsed = urllib.parse.urlsplit(url)
-    conn_cls = _connection_cls(parsed.scheme.lower())
+    conn_factory = _connection_factory(parsed.scheme.lower())
     _reject_userinfo(parsed)
     host = parsed.hostname
     if not host:
@@ -265,7 +249,7 @@ def _forward_request_sync(
         raise ValueError("Invalid upstream URL: invalid port") from exc
     effective_port = port if port is not None else DEFAULT_HTTPS_PORT
     validated_addresses = _resolve_validated_addresses(host, effective_port)
-    conn = conn_cls(host, port=port, timeout=30, validated_addresses=validated_addresses)
+    conn = conn_factory(host, port=port, timeout=30, validated_addresses=validated_addresses)
     resp = None
     try:
         conn.putrequest(

--- a/crates/runner/mitm-addon/src/auth_base_forwarder.py
+++ b/crates/runner/mitm-addon/src/auth_base_forwarder.py
@@ -72,6 +72,8 @@ def _connect_to_validated_addresses(validated_addresses: tuple[_ValidatedAddress
 def _create_https_context() -> ssl.SSLContext:
     context = ssl.create_default_context()
     context.set_alpn_protocols(["http/1.1"])
+    if context.post_handshake_auth is not None:
+        context.post_handshake_auth = True
     return context
 
 

--- a/crates/runner/mitm-addon/src/auth_base_forwarder.py
+++ b/crates/runner/mitm-addon/src/auth_base_forwarder.py
@@ -74,6 +74,7 @@ def _make_validated_https_connection(
     validated_addresses: tuple[_ValidatedAddress, ...],
 ) -> http_client.HTTPSConnection:
     conn = http_client.HTTPSConnection(host, port=port, timeout=timeout)
+    # Keep stdlib TLS/SNI handling while forcing TCP to use validated addresses.
     vars(conn)["_create_connection"] = _connect_to_validated_addresses(validated_addresses)
     return conn
 

--- a/crates/runner/mitm-addon/src/auth_base_forwarder.py
+++ b/crates/runner/mitm-addon/src/auth_base_forwarder.py
@@ -6,8 +6,13 @@ the low-level HTTP details for that forward path.
 """
 
 import asyncio
+import errno
 import http.client as http_client
+import ipaddress
+import socket
+import sys
 import urllib.parse
+from typing import NamedTuple
 
 from mitmproxy import http
 
@@ -33,6 +38,60 @@ _forward_request_semaphore_state: tuple[asyncio.AbstractEventLoop, asyncio.Semap
 
 class ForwardedResponseTooLargeError(Exception):
     """Raised when an auth.base upstream response exceeds the local body cap."""
+
+
+class UnsafeAuthBaseDestinationError(Exception):
+    """Raised when an auth.base upstream destination is not public internet."""
+
+
+class _ValidatedAddress(NamedTuple):
+    host: str
+    port: int
+
+
+class _ValidatedHTTPSConnection(http_client.HTTPSConnection):
+    def __init__(
+        self,
+        host: str,
+        port: int | None,
+        *,
+        timeout,
+        validated_addresses: tuple[_ValidatedAddress, ...],
+    ) -> None:
+        super().__init__(host, port=port, timeout=timeout)
+        self._validated_addresses = validated_addresses
+
+    def _connect_to_validated_address(self):
+        last_error: OSError | None = None
+        for address in self._validated_addresses:
+            try:
+                return self._create_connection(
+                    (address.host, address.port),
+                    self.timeout,
+                    self.source_address,
+                )
+            except OSError as exc:
+                last_error = exc
+        if last_error is not None:
+            raise last_error
+        raise OSError("getaddrinfo returns an empty list")
+
+    def connect(self) -> None:
+        sys.audit("http.client.connect", self, self.host, self.port)
+        self.sock = self._connect_to_validated_address()
+        try:
+            self.sock.setsockopt(socket.IPPROTO_TCP, socket.TCP_NODELAY, 1)
+        except OSError as e:
+            if e.errno != errno.ENOPROTOOPT:
+                raise
+
+        if self._tunnel_host:
+            self._tunnel()
+            server_hostname = self._tunnel_host
+        else:
+            server_hostname = self.host
+
+        self.sock = self._context.wrap_socket(self.sock, server_hostname=server_hostname)
 
 
 def header_pairs(headers) -> list[tuple[str, str]]:
@@ -129,7 +188,7 @@ def _request_target(parsed: urllib.parse.SplitResult) -> str:
 
 def _connection_cls(scheme: str):
     if scheme == "https":
-        return http_client.HTTPSConnection
+        return _ValidatedHTTPSConnection
     raise ValueError(f"Unsupported URL scheme: {scheme}")
 
 
@@ -157,6 +216,32 @@ def _read_response_body(resp) -> bytes:
     return body
 
 
+def _is_public_unicast_address(address: ipaddress.IPv4Address | ipaddress.IPv6Address) -> bool:
+    return address.is_global and not address.is_multicast and not address.is_reserved
+
+
+def _raise_unsafe_destination() -> None:
+    raise UnsafeAuthBaseDestinationError("Unsafe auth.base upstream destination")
+
+
+def _resolve_validated_addresses(host: str, port: int) -> tuple[_ValidatedAddress, ...]:
+    infos = socket.getaddrinfo(host, port, type=socket.SOCK_STREAM)
+    seen: set[str] = set()
+    addresses: list[_ValidatedAddress] = []
+    for _family, _socktype, _proto, _canonname, sockaddr in infos:
+        address = ipaddress.ip_address(sockaddr[0])
+        key = address.compressed
+        if key in seen:
+            continue
+        seen.add(key)
+        if not _is_public_unicast_address(address):
+            _raise_unsafe_destination()
+        addresses.append(_ValidatedAddress(address.compressed, port))
+    if not addresses:
+        raise ValueError("Invalid upstream URL: host did not resolve")
+    return tuple(addresses)
+
+
 def _forward_request_sync(
     url: str,
     method: str,
@@ -178,7 +263,9 @@ def _forward_request_sync(
         port = parsed.port
     except ValueError as exc:
         raise ValueError("Invalid upstream URL: invalid port") from exc
-    conn = conn_cls(host, port=port, timeout=30)
+    effective_port = port if port is not None else DEFAULT_HTTPS_PORT
+    validated_addresses = _resolve_validated_addresses(host, effective_port)
+    conn = conn_cls(host, port=port, timeout=30, validated_addresses=validated_addresses)
     resp = None
     try:
         conn.putrequest(

--- a/crates/runner/mitm-addon/src/auth_base_forwarder.py
+++ b/crates/runner/mitm-addon/src/auth_base_forwarder.py
@@ -6,9 +6,11 @@ the low-level HTTP details for that forward path.
 """
 
 import asyncio
+import errno
 import http.client as http_client
 import ipaddress
 import socket
+import ssl
 import urllib.parse
 from typing import NamedTuple
 
@@ -67,17 +69,59 @@ def _connect_to_validated_addresses(validated_addresses: tuple[_ValidatedAddress
     return create_connection
 
 
+def _create_https_context() -> ssl.SSLContext:
+    context = ssl.create_default_context()
+    context.set_alpn_protocols(["http/1.1"])
+    return context
+
+
+class _ValidatedTLSConnection(http_client.HTTPConnection):
+    default_port = DEFAULT_HTTPS_PORT
+
+    def __init__(
+        self,
+        host: str,
+        port: int | None,
+        *,
+        timeout,
+        validated_addresses: tuple[_ValidatedAddress, ...],
+    ) -> None:
+        super().__init__(host, port=port, timeout=timeout)
+        self._validated_addresses = validated_addresses
+        self._context = _create_https_context()
+
+    def connect(self) -> None:
+        raw_sock = _connect_to_validated_addresses(self._validated_addresses)(
+            (self.host, self.port),
+            self.timeout,
+            None,
+        )
+        try:
+            raw_sock.setsockopt(socket.IPPROTO_TCP, socket.TCP_NODELAY, 1)
+        except OSError as exc:
+            if exc.errno != errno.ENOPROTOOPT:
+                raw_sock.close()
+                raise
+        try:
+            self.sock = self._context.wrap_socket(raw_sock, server_hostname=self.host)
+        except Exception:
+            raw_sock.close()
+            raise
+
+
 def _make_validated_https_connection(
     host: str,
     port: int | None,
     *,
     timeout,
     validated_addresses: tuple[_ValidatedAddress, ...],
-) -> http_client.HTTPSConnection:
-    conn = http_client.HTTPSConnection(host, port=port, timeout=timeout)
-    # Keep stdlib TLS/SNI handling while forcing TCP to use validated addresses.
-    vars(conn)["_create_connection"] = _connect_to_validated_addresses(validated_addresses)
-    return conn
+) -> http_client.HTTPConnection:
+    return _ValidatedTLSConnection(
+        host,
+        port=port,
+        timeout=timeout,
+        validated_addresses=validated_addresses,
+    )
 
 
 def header_pairs(headers) -> list[tuple[str, str]]:

--- a/crates/runner/mitm-addon/src/auth_base_forwarder.py
+++ b/crates/runner/mitm-addon/src/auth_base_forwarder.py
@@ -30,6 +30,7 @@ HOP_BY_HOP: frozenset[str] = frozenset(
 DEFAULT_HTTPS_PORT = 443
 MAX_AUTH_BASE_RESPONSE_BODY_BYTES = 32 * 1024 * 1024
 MAX_CONCURRENT_AUTH_BASE_FORWARDS = 4
+NAT64_WELL_KNOWN_PREFIX = ipaddress.IPv6Network("64:ff9b::/96")
 
 _forward_request_semaphore_state: tuple[asyncio.AbstractEventLoop, asyncio.Semaphore] | None = None
 
@@ -202,6 +203,13 @@ def _read_response_body(resp) -> bytes:
 
 
 def _is_public_unicast_address(address: ipaddress.IPv4Address | ipaddress.IPv6Address) -> bool:
+    if isinstance(address, ipaddress.IPv6Address) and (
+        address.ipv4_mapped is not None
+        or address.sixtofour is not None
+        or address.teredo is not None
+        or address in NAT64_WELL_KNOWN_PREFIX
+    ):
+        return False
     return address.is_global and not address.is_multicast and not address.is_reserved
 
 

--- a/crates/runner/mitm-addon/tests/test_auth_base_forwarder.py
+++ b/crates/runner/mitm-addon/tests/test_auth_base_forwarder.py
@@ -80,6 +80,11 @@ class TestAuthBaseForwarderSecurity:
             pytest.param("https://[2001:db8::1]/", id="ipv6-documentation"),
             pytest.param("https://[::ffff:100.64.0.1]/", id="ipv6-mapped-cgnat"),
             pytest.param("https://[::ffff:8.8.8.8]/", id="ipv6-mapped-reserved"),
+            pytest.param("https://[2002:0808:0808::1]/", id="ipv6-6to4"),
+            pytest.param(
+                "https://[2001:0000:4136:e378:8000:63bf:3fff:fdd2]/",
+                id="ipv6-teredo",
+            ),
             pytest.param("https://[64:ff9b::169.254.169.254]/", id="ipv6-nat64-metadata"),
             pytest.param("https://[64:ff9b::8.8.8.8]/", id="ipv6-nat64-reserved"),
         ],

--- a/crates/runner/mitm-addon/tests/test_auth_base_forwarder.py
+++ b/crates/runner/mitm-addon/tests/test_auth_base_forwarder.py
@@ -2,6 +2,7 @@
 
 import asyncio
 import contextlib
+import errno
 import threading
 from collections.abc import Iterator
 from typing import NamedTuple
@@ -260,6 +261,47 @@ class TestAuthBaseForwarderSecurity:
         context.wrap_socket.assert_called_once_with(raw_sock, server_hostname="hooks.example.com")
         assert conn.sock is wrapped_sock
 
+    def test_validated_connection_ignores_missing_tcp_nodelay(self):
+        raw_sock = MagicMock()
+        raw_sock.setsockopt.side_effect = OSError(errno.ENOPROTOOPT, "not supported")
+        wrapped_sock = MagicMock()
+        context = MagicMock()
+        context.wrap_socket.return_value = wrapped_sock
+        conn = forwarder._make_validated_https_connection(
+            "hooks.example.com",
+            port=None,
+            timeout=30,
+            validated_addresses=(forwarder._ValidatedAddress("93.184.216.34", 443),),
+        )
+        vars(conn)["_context"] = context
+
+        with patch.object(forwarder.socket, "create_connection", return_value=raw_sock):
+            conn.connect()
+
+        raw_sock.close.assert_not_called()
+        context.wrap_socket.assert_called_once_with(raw_sock, server_hostname="hooks.example.com")
+        assert conn.sock is wrapped_sock
+
+    def test_validated_connection_closes_raw_socket_when_tls_wrap_fails(self):
+        raw_sock = MagicMock()
+        context = MagicMock()
+        context.wrap_socket.side_effect = OSError("tls failed")
+        conn = forwarder._make_validated_https_connection(
+            "hooks.example.com",
+            port=None,
+            timeout=30,
+            validated_addresses=(forwarder._ValidatedAddress("93.184.216.34", 443),),
+        )
+        vars(conn)["_context"] = context
+
+        with (
+            patch.object(forwarder.socket, "create_connection", return_value=raw_sock),
+            pytest.raises(OSError, match="tls failed"),
+        ):
+            conn.connect()
+
+        raw_sock.close.assert_called_once_with()
+
     def test_rejects_file_scheme(self):
         with pytest.raises(ValueError, match="Unsupported URL scheme"):
             forwarder._forward_request_sync("file:///etc/passwd", "GET", [], None)
@@ -271,7 +313,7 @@ class TestAuthBaseForwarderSecurity:
     def test_rejects_http_scheme_without_opening_connection(self):
         with (
             patch.object(forwarder.http_client, "HTTPConnection") as http_conn,
-            patch.object(forwarder.http_client, "HTTPSConnection") as https_conn,
+            patch.object(forwarder, "_make_validated_https_connection") as https_conn,
             pytest.raises(ValueError, match="Unsupported URL scheme"),
         ):
             forwarder._forward_request_sync("http://example.com/path", "GET", [], None)
@@ -300,7 +342,7 @@ class TestAuthBaseForwarderSecurity:
     def test_rejects_userinfo_authority(self, url):
         with (
             patch.object(forwarder.http_client, "HTTPConnection") as http_conn,
-            patch.object(forwarder.http_client, "HTTPSConnection") as https_conn,
+            patch.object(forwarder, "_make_validated_https_connection") as https_conn,
             pytest.raises(ValueError, match="Unsupported URL authority"),
         ):
             forwarder._forward_request_sync(url, "GET", [], None)

--- a/crates/runner/mitm-addon/tests/test_auth_base_forwarder.py
+++ b/crates/runner/mitm-addon/tests/test_auth_base_forwarder.py
@@ -16,6 +16,7 @@ class ForwarderConnectionPatch(NamedTuple):
     conn: MagicMock
     resp: MagicMock
     connection_cls: MagicMock
+    resolver: MagicMock
 
 
 @contextlib.contextmanager
@@ -44,11 +45,214 @@ def _patched_forwarder_connection(
     else:
         conn.getresponse.side_effect = getresponse_side_effect
 
-    with patch.object(forwarder.http_client, "HTTPSConnection", return_value=conn) as cls:
-        yield ForwarderConnectionPatch(conn=conn, resp=resp, connection_cls=cls)
+    def resolve_public_addresses(_host: str, port: int) -> tuple[forwarder._ValidatedAddress, ...]:
+        return (forwarder._ValidatedAddress("93.184.216.34", port),)
+
+    with (
+        patch.object(
+            forwarder, "_resolve_validated_addresses", side_effect=resolve_public_addresses
+        ) as resolver,
+        patch.object(forwarder, "_ValidatedHTTPSConnection", return_value=conn) as cls,
+    ):
+        yield ForwarderConnectionPatch(
+            conn=conn,
+            resp=resp,
+            connection_cls=cls,
+            resolver=resolver,
+        )
 
 
 class TestAuthBaseForwarderSecurity:
+    @pytest.mark.parametrize(
+        "url",
+        [
+            pytest.param("https://127.0.0.1/", id="ipv4-loopback"),
+            pytest.param("https://169.254.169.254/", id="ipv4-link-local-metadata"),
+            pytest.param("https://10.0.0.1/", id="ipv4-rfc1918-10"),
+            pytest.param("https://172.16.0.1/", id="ipv4-rfc1918-172"),
+            pytest.param("https://192.168.0.1/", id="ipv4-rfc1918-192"),
+            pytest.param("https://100.64.0.1/", id="ipv4-cgnat"),
+            pytest.param("https://224.0.0.1/", id="ipv4-multicast"),
+            pytest.param("https://240.0.0.1/", id="ipv4-reserved"),
+            pytest.param("https://[::1]/", id="ipv6-loopback"),
+            pytest.param("https://[fe80::1]/", id="ipv6-link-local"),
+            pytest.param("https://[fc00::1]/", id="ipv6-ula"),
+            pytest.param("https://[2001:db8::1]/", id="ipv6-documentation"),
+            pytest.param("https://[::ffff:100.64.0.1]/", id="ipv6-mapped-cgnat"),
+            pytest.param("https://[::ffff:8.8.8.8]/", id="ipv6-mapped-reserved"),
+            pytest.param("https://[64:ff9b::169.254.169.254]/", id="ipv6-nat64-metadata"),
+            pytest.param("https://[64:ff9b::8.8.8.8]/", id="ipv6-nat64-reserved"),
+        ],
+    )
+    def test_rejects_non_public_literal_destinations_without_opening_connection(self, url):
+        with (
+            patch.object(forwarder, "_ValidatedHTTPSConnection") as connection_cls,
+            pytest.raises(
+                forwarder.UnsafeAuthBaseDestinationError,
+                match=r"Unsafe auth\.base upstream destination",
+            ),
+        ):
+            forwarder._forward_request_sync(url, "GET", [], None)
+
+        connection_cls.assert_not_called()
+
+    def test_rejects_dns_private_destination_without_opening_connection(self):
+        with (
+            patch.object(
+                forwarder.socket,
+                "getaddrinfo",
+                return_value=[
+                    (
+                        forwarder.socket.AF_INET,
+                        forwarder.socket.SOCK_STREAM,
+                        6,
+                        "",
+                        ("10.0.0.1", 443),
+                    )
+                ],
+            ),
+            patch.object(forwarder, "_ValidatedHTTPSConnection") as connection_cls,
+            pytest.raises(forwarder.UnsafeAuthBaseDestinationError),
+        ):
+            forwarder._forward_request_sync("https://hooks.example.com/path", "GET", [], None)
+
+        connection_cls.assert_not_called()
+
+    def test_rejects_mixed_dns_answers_without_opening_connection(self):
+        with (
+            patch.object(
+                forwarder.socket,
+                "getaddrinfo",
+                return_value=[
+                    (
+                        forwarder.socket.AF_INET,
+                        forwarder.socket.SOCK_STREAM,
+                        6,
+                        "",
+                        ("93.184.216.34", 443),
+                    ),
+                    (
+                        forwarder.socket.AF_INET,
+                        forwarder.socket.SOCK_STREAM,
+                        6,
+                        "",
+                        ("127.0.0.1", 443),
+                    ),
+                ],
+            ),
+            patch.object(forwarder, "_ValidatedHTTPSConnection") as connection_cls,
+            pytest.raises(forwarder.UnsafeAuthBaseDestinationError),
+        ):
+            forwarder._forward_request_sync("https://hooks.example.com/path", "GET", [], None)
+
+        connection_cls.assert_not_called()
+
+    def test_allows_public_dns_destination_with_validated_addresses(self):
+        resp = MagicMock()
+        resp.status = 200
+        resp.read.return_value = b"ok"
+        resp.getheaders.return_value = []
+        conn = MagicMock()
+        conn.getresponse.return_value = resp
+
+        with (
+            patch.object(
+                forwarder.socket,
+                "getaddrinfo",
+                return_value=[
+                    (
+                        forwarder.socket.AF_INET,
+                        forwarder.socket.SOCK_STREAM,
+                        6,
+                        "",
+                        ("93.184.216.34", 443),
+                    ),
+                    (
+                        forwarder.socket.AF_INET6,
+                        forwarder.socket.SOCK_STREAM,
+                        6,
+                        "",
+                        ("2001:4860:4860::8888", 443, 0, 0),
+                    ),
+                ],
+            ),
+            patch.object(
+                forwarder, "_ValidatedHTTPSConnection", return_value=conn
+            ) as connection_cls,
+        ):
+            forwarder._forward_request_sync("https://hooks.example.com/path", "GET", [], None)
+
+        connection_cls.assert_called_once_with(
+            "hooks.example.com",
+            port=None,
+            timeout=30,
+            validated_addresses=(
+                forwarder._ValidatedAddress("93.184.216.34", 443),
+                forwarder._ValidatedAddress("2001:4860:4860::8888", 443),
+            ),
+        )
+        assert call("Host", "hooks.example.com") in conn.putheader.call_args_list
+
+    def test_validated_connection_uses_checked_ip_and_original_hostname_for_sni(self):
+        raw_sock = MagicMock()
+        wrapped_sock = MagicMock()
+        context = MagicMock()
+        context.wrap_socket.return_value = wrapped_sock
+        create_connection = MagicMock(return_value=raw_sock)
+        conn = forwarder._ValidatedHTTPSConnection(
+            "hooks.example.com",
+            port=None,
+            timeout=30,
+            validated_addresses=(forwarder._ValidatedAddress("93.184.216.34", 443),),
+        )
+        conn._context = context
+        conn._create_connection = create_connection
+
+        conn.connect()
+
+        create_connection.assert_called_once_with(("93.184.216.34", 443), 30, None)
+        raw_sock.setsockopt.assert_called_once_with(
+            forwarder.socket.IPPROTO_TCP,
+            forwarder.socket.TCP_NODELAY,
+            1,
+        )
+        context.wrap_socket.assert_called_once_with(raw_sock, server_hostname="hooks.example.com")
+        assert conn.sock is wrapped_sock
+
+    def test_validated_connection_retries_checked_addresses_without_new_dns(self):
+        raw_sock = MagicMock()
+        wrapped_sock = MagicMock()
+        context = MagicMock()
+        context.wrap_socket.return_value = wrapped_sock
+        create_connection = MagicMock(side_effect=[OSError("no route"), raw_sock])
+        conn = forwarder._ValidatedHTTPSConnection(
+            "hooks.example.com",
+            port=None,
+            timeout=30,
+            validated_addresses=(
+                forwarder._ValidatedAddress("2001:4860:4860::8888", 443),
+                forwarder._ValidatedAddress("93.184.216.34", 443),
+            ),
+        )
+        conn._context = context
+        conn._create_connection = create_connection
+
+        conn.connect()
+
+        create_connection.assert_has_calls(
+            [
+                call(("2001:4860:4860::8888", 443), 30, None),
+                call(("93.184.216.34", 443), 30, None),
+            ]
+        )
+        raw_sock.setsockopt.assert_called_once_with(
+            forwarder.socket.IPPROTO_TCP,
+            forwarder.socket.TCP_NODELAY,
+            1,
+        )
+        context.wrap_socket.assert_called_once_with(raw_sock, server_hostname="hooks.example.com")
+        assert conn.sock is wrapped_sock
+
     def test_rejects_file_scheme(self):
         with pytest.raises(ValueError, match="Unsupported URL scheme"):
             forwarder._forward_request_sync("file:///etc/passwd", "GET", [], None)
@@ -295,6 +499,16 @@ class TestAuthBaseForwarderSecurity:
             expected_connection_host,
             port=expected_connection_port,
             timeout=30,
+            validated_addresses=(
+                forwarder._ValidatedAddress(
+                    "93.184.216.34",
+                    expected_connection_port or forwarder.DEFAULT_HTTPS_PORT,
+                ),
+            ),
+        )
+        upstream.resolver.assert_called_once_with(
+            expected_connection_host,
+            expected_connection_port or forwarder.DEFAULT_HTTPS_PORT,
         )
         assert call("Host", expected_host_header) in upstream.conn.putheader.call_args_list
 
@@ -573,10 +787,11 @@ class TestForwardRequestAsyncWrapper:
                 record_forwarding_thread()
 
         class FakeConnection:
-            def __init__(self, host, *, port, timeout):
+            def __init__(self, host, *, port, timeout, validated_addresses):
                 self.host = host
                 self.port = port
                 self.timeout = timeout
+                self.validated_addresses = validated_addresses
 
             def putrequest(self, method, target, *, skip_host, skip_accept_encoding):
                 record_forwarding_thread()
@@ -594,7 +809,14 @@ class TestForwardRequestAsyncWrapper:
             def close(self):
                 record_forwarding_thread()
 
-        with patch.object(forwarder.http_client, "HTTPSConnection", FakeConnection):
+        with (
+            patch.object(forwarder, "_ValidatedHTTPSConnection", FakeConnection),
+            patch.object(
+                forwarder,
+                "_resolve_validated_addresses",
+                return_value=(forwarder._ValidatedAddress("93.184.216.34", 443),),
+            ),
+        ):
             status, body, headers = await forwarder.forward_request(
                 "https://example.com",
                 "GET",
@@ -630,7 +852,12 @@ class TestForwardRequestAsyncWrapper:
         conn.putrequest.side_effect = ConnectionError("connect failed")
         conn.close.side_effect = record_close_thread
         with (
-            patch.object(forwarder.http_client, "HTTPSConnection", return_value=conn),
+            patch.object(forwarder, "_ValidatedHTTPSConnection", return_value=conn),
+            patch.object(
+                forwarder,
+                "_resolve_validated_addresses",
+                return_value=(forwarder._ValidatedAddress("93.184.216.34", 443),),
+            ),
             pytest.raises(ConnectionError, match="connect failed"),
         ):
             await forwarder.forward_request("https://example.com", "GET", [], None)
@@ -655,7 +882,12 @@ class TestForwardRequestAsyncWrapper:
         conn.close.side_effect = record_close_thread
 
         with (
-            patch.object(forwarder.http_client, "HTTPSConnection", return_value=conn),
+            patch.object(forwarder, "_ValidatedHTTPSConnection", return_value=conn),
+            patch.object(
+                forwarder,
+                "_resolve_validated_addresses",
+                return_value=(forwarder._ValidatedAddress("93.184.216.34", 443),),
+            ),
             pytest.raises(OSError, match="socket closed"),
         ):
             await forwarder.forward_request("https://example.com", "GET", [], None)

--- a/crates/runner/mitm-addon/tests/test_auth_base_forwarder.py
+++ b/crates/runner/mitm-addon/tests/test_auth_base_forwarder.py
@@ -3,6 +3,7 @@
 import asyncio
 import contextlib
 import errno
+import ssl
 import threading
 from collections.abc import Iterator
 from typing import NamedTuple
@@ -260,6 +261,14 @@ class TestAuthBaseForwarderSecurity:
         )
         context.wrap_socket.assert_called_once_with(raw_sock, server_hostname="hooks.example.com")
         assert conn.sock is wrapped_sock
+
+    def test_validated_connection_context_keeps_https_security_defaults(self):
+        context = forwarder._create_https_context()
+
+        assert context.verify_mode is ssl.CERT_REQUIRED
+        assert context.check_hostname is True
+        if context.post_handshake_auth is not None:
+            assert context.post_handshake_auth is True
 
     def test_validated_connection_ignores_missing_tcp_nodelay(self):
         raw_sock = MagicMock()

--- a/crates/runner/mitm-addon/tests/test_auth_base_forwarder.py
+++ b/crates/runner/mitm-addon/tests/test_auth_base_forwarder.py
@@ -15,7 +15,7 @@ import auth_base_forwarder as forwarder
 class ForwarderConnectionPatch(NamedTuple):
     conn: MagicMock
     resp: MagicMock
-    connection_cls: MagicMock
+    connection_factory: MagicMock
     resolver: MagicMock
 
 
@@ -52,12 +52,12 @@ def _patched_forwarder_connection(
         patch.object(
             forwarder, "_resolve_validated_addresses", side_effect=resolve_public_addresses
         ) as resolver,
-        patch.object(forwarder, "_ValidatedHTTPSConnection", return_value=conn) as cls,
+        patch.object(forwarder, "_make_validated_https_connection", return_value=conn) as factory,
     ):
         yield ForwarderConnectionPatch(
             conn=conn,
             resp=resp,
-            connection_cls=cls,
+            connection_factory=factory,
             resolver=resolver,
         )
 
@@ -86,7 +86,7 @@ class TestAuthBaseForwarderSecurity:
     )
     def test_rejects_non_public_literal_destinations_without_opening_connection(self, url):
         with (
-            patch.object(forwarder, "_ValidatedHTTPSConnection") as connection_cls,
+            patch.object(forwarder, "_make_validated_https_connection") as connection_factory,
             pytest.raises(
                 forwarder.UnsafeAuthBaseDestinationError,
                 match=r"Unsafe auth\.base upstream destination",
@@ -94,7 +94,7 @@ class TestAuthBaseForwarderSecurity:
         ):
             forwarder._forward_request_sync(url, "GET", [], None)
 
-        connection_cls.assert_not_called()
+        connection_factory.assert_not_called()
 
     def test_rejects_dns_private_destination_without_opening_connection(self):
         with (
@@ -111,12 +111,12 @@ class TestAuthBaseForwarderSecurity:
                     )
                 ],
             ),
-            patch.object(forwarder, "_ValidatedHTTPSConnection") as connection_cls,
+            patch.object(forwarder, "_make_validated_https_connection") as connection_factory,
             pytest.raises(forwarder.UnsafeAuthBaseDestinationError),
         ):
             forwarder._forward_request_sync("https://hooks.example.com/path", "GET", [], None)
 
-        connection_cls.assert_not_called()
+        connection_factory.assert_not_called()
 
     def test_rejects_mixed_dns_answers_without_opening_connection(self):
         with (
@@ -140,12 +140,12 @@ class TestAuthBaseForwarderSecurity:
                     ),
                 ],
             ),
-            patch.object(forwarder, "_ValidatedHTTPSConnection") as connection_cls,
+            patch.object(forwarder, "_make_validated_https_connection") as connection_factory,
             pytest.raises(forwarder.UnsafeAuthBaseDestinationError),
         ):
             forwarder._forward_request_sync("https://hooks.example.com/path", "GET", [], None)
 
-        connection_cls.assert_not_called()
+        connection_factory.assert_not_called()
 
     def test_allows_public_dns_destination_with_validated_addresses(self):
         resp = MagicMock()
@@ -177,12 +177,12 @@ class TestAuthBaseForwarderSecurity:
                 ],
             ),
             patch.object(
-                forwarder, "_ValidatedHTTPSConnection", return_value=conn
-            ) as connection_cls,
+                forwarder, "_make_validated_https_connection", return_value=conn
+            ) as connection_factory,
         ):
             forwarder._forward_request_sync("https://hooks.example.com/path", "GET", [], None)
 
-        connection_cls.assert_called_once_with(
+        connection_factory.assert_called_once_with(
             "hooks.example.com",
             port=None,
             timeout=30,
@@ -198,19 +198,18 @@ class TestAuthBaseForwarderSecurity:
         wrapped_sock = MagicMock()
         context = MagicMock()
         context.wrap_socket.return_value = wrapped_sock
-        create_connection = MagicMock(return_value=raw_sock)
-        conn = forwarder._ValidatedHTTPSConnection(
+        conn = forwarder._make_validated_https_connection(
             "hooks.example.com",
             port=None,
             timeout=30,
             validated_addresses=(forwarder._ValidatedAddress("93.184.216.34", 443),),
         )
-        conn._context = context
-        conn._create_connection = create_connection
+        vars(conn)["_context"] = context
 
-        conn.connect()
+        with patch.object(forwarder.socket, "create_connection", return_value=raw_sock) as connect:
+            conn.connect()
 
-        create_connection.assert_called_once_with(("93.184.216.34", 443), 30, None)
+        connect.assert_called_once_with(("93.184.216.34", 443), 30, None)
         raw_sock.setsockopt.assert_called_once_with(
             forwarder.socket.IPPROTO_TCP,
             forwarder.socket.TCP_NODELAY,
@@ -224,8 +223,7 @@ class TestAuthBaseForwarderSecurity:
         wrapped_sock = MagicMock()
         context = MagicMock()
         context.wrap_socket.return_value = wrapped_sock
-        create_connection = MagicMock(side_effect=[OSError("no route"), raw_sock])
-        conn = forwarder._ValidatedHTTPSConnection(
+        conn = forwarder._make_validated_https_connection(
             "hooks.example.com",
             port=None,
             timeout=30,
@@ -234,12 +232,16 @@ class TestAuthBaseForwarderSecurity:
                 forwarder._ValidatedAddress("93.184.216.34", 443),
             ),
         )
-        conn._context = context
-        conn._create_connection = create_connection
+        vars(conn)["_context"] = context
 
-        conn.connect()
+        with patch.object(
+            forwarder.socket,
+            "create_connection",
+            side_effect=[OSError("no route"), raw_sock],
+        ) as connect:
+            conn.connect()
 
-        create_connection.assert_has_calls(
+        connect.assert_has_calls(
             [
                 call(("2001:4860:4860::8888", 443), 30, None),
                 call(("93.184.216.34", 443), 30, None),
@@ -495,7 +497,7 @@ class TestAuthBaseForwarderSecurity:
                 None,
             )
 
-        upstream.connection_cls.assert_called_once_with(
+        upstream.connection_factory.assert_called_once_with(
             expected_connection_host,
             port=expected_connection_port,
             timeout=30,
@@ -810,7 +812,7 @@ class TestForwardRequestAsyncWrapper:
                 record_forwarding_thread()
 
         with (
-            patch.object(forwarder, "_ValidatedHTTPSConnection", FakeConnection),
+            patch.object(forwarder, "_make_validated_https_connection", FakeConnection),
             patch.object(
                 forwarder,
                 "_resolve_validated_addresses",
@@ -852,7 +854,7 @@ class TestForwardRequestAsyncWrapper:
         conn.putrequest.side_effect = ConnectionError("connect failed")
         conn.close.side_effect = record_close_thread
         with (
-            patch.object(forwarder, "_ValidatedHTTPSConnection", return_value=conn),
+            patch.object(forwarder, "_make_validated_https_connection", return_value=conn),
             patch.object(
                 forwarder,
                 "_resolve_validated_addresses",
@@ -882,7 +884,7 @@ class TestForwardRequestAsyncWrapper:
         conn.close.side_effect = record_close_thread
 
         with (
-            patch.object(forwarder, "_ValidatedHTTPSConnection", return_value=conn),
+            patch.object(forwarder, "_make_validated_https_connection", return_value=conn),
             patch.object(
                 forwarder,
                 "_resolve_validated_addresses",

--- a/crates/runner/mitm-addon/tests/test_firewall_rewrite.py
+++ b/crates/runner/mitm-addon/tests/test_firewall_rewrite.py
@@ -8,6 +8,7 @@ from urllib.parse import parse_qs, urlparse
 from mitmproxy import http
 
 import auth
+import auth_base_forwarder as forwarder
 import matching
 
 
@@ -719,6 +720,56 @@ class TestAuthBaseUrlRewriteEdgeCases:
 
         assert flow.response is not None
         assert b"super-secret-token" not in flow.response.content
+        for log_call in mock_log.call_args_list:
+            assert "super-secret-token" not in json.dumps(log_call.args)
+            assert "super-secret-token" not in json.dumps(log_call.kwargs)
+
+    async def test_blocked_forward_destination_returns_502_without_mutating_request(
+        self, headers, real_flow, mitm_ctx, tmp_path
+    ):
+        """Forwarder destination guard failures use the local rewrite failure path."""
+        flow, allow, vm_info, token_meta = make_rewrite_inputs(
+            real_flow,
+            tmp_path,
+            path="/hook?client=visible",
+            request_headers=headers(
+                ("Host", "firewall-placeholder.vm3.ai"),
+                ("Authorization", "Bearer agent"),
+            ),
+            resolved_base="https://127.0.0.1/webhook/super-secret-token",
+            token_overrides={
+                "headers": {
+                    "Authorization": "Bearer real-token",
+                    "X-Custom": "injected-value",
+                },
+                "query": {"api_key": "resolved-key"},
+            },
+        )
+        mock_forward = AsyncMock(
+            side_effect=forwarder.UnsafeAuthBaseDestinationError(
+                "Unsafe auth.base upstream destination"
+            )
+        )
+        mock_log = MagicMock()
+
+        with (
+            patch.object(auth, "get_firewall_headers", AsyncMock(return_value=token_meta)),
+            patch.object(auth, "forward_request", mock_forward),
+            patch.object(auth, "log_proxy_entry", mock_log),
+            mitm_ctx(),
+        ):
+            await auth.handle_firewall_request(flow, allow, vm_info)
+
+        assert mock_forward.call_count == 1
+        assert flow.response is not None
+        assert flow.response.status_code == 502
+        assert flow.metadata["firewall_error"] == "url_rewrite_forward_failed"
+        assert "auth_url_rewrite" not in flow.metadata
+        assert flow.request.headers["Authorization"] == "Bearer agent"
+        assert "X-Custom" not in flow.request.headers
+        assert "api_key" not in flow.request.query
+        assert flow.request.query["client"] == "visible"
+        assert "super-secret-token" not in flow.response.text
         for log_call in mock_log.call_args_list:
             assert "super-secret-token" not in json.dumps(log_call.args)
             assert "super-secret-token" not in json.dumps(log_call.kwargs)


### PR DESCRIPTION
## Summary

- resolve and validate auth.base rewrite destinations before opening the upstream socket
- reject non-public, reserved, multicast, mixed-DNS, and private-network targets before constructing the connection
- connect only to the validated address set while preserving stdlib HTTPS hostname SNI and Host semantics
- add forwarder and rewrite-path regression coverage for blocked destinations and URL leakage

## Tests

- `/tmp/vm0-mitm-addon-venv/bin/python -m ruff format --check src/auth_base_forwarder.py tests/test_auth_base_forwarder.py tests/test_firewall_rewrite.py`
- `/tmp/vm0-mitm-addon-venv/bin/python -m ruff check src/auth_base_forwarder.py tests/test_auth_base_forwarder.py tests/test_firewall_rewrite.py`
- `VIRTUAL_ENV=/tmp/vm0-mitm-addon-venv PATH=/tmp/vm0-mitm-addon-venv/bin:$PATH basedpyright -p .`
- `/tmp/vm0-mitm-addon-venv/bin/pytest tests/test_auth_base_forwarder.py tests/test_firewall_rewrite.py`
- `git diff --check`
- `/tmp/vm0-mitm-addon-venv/bin/pytest` failed locally in `tests/test_x_billing.py` because `turbo/packages/connectors/src/firewalls/index.ts` imports missing local generated module `./hitem3d.generated`; 2074 tests passed before those unrelated local generated-firewall failures.

Closes #15798