### PR TITLE
fix: artifacts drawer does not open when ChatArtifactSidebar feature is enabled

### DIFF
--- a/turbo/apps/platform/src/views/zero-page/__tests__/zero-chat-thread-page-display.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/zero-chat-thread-page-display.test.tsx
@@ -2212,6 +2212,56 @@ describe("zero chat thread page display - artifacts drawer", () => {
     );
   });
 
+  it("opens the artifacts drawer when ChatArtifactSidebar feature is enabled", async () => {
+    mockChatLifecycle({
+      chatMessages: [
+        {
+          role: "user",
+          content: "Create a file",
+          runId: "run-sidebar-artifacts",
+          createdAt: "2026-03-10T00:00:00Z",
+        },
+      ],
+    });
+    server.use(
+      mockApi(chatThreadArtifactsContract.list, ({ respond }) => {
+        return respond(200, {
+          runs: [
+            {
+              runId: "run-sidebar-artifacts",
+              files: [
+                {
+                  id: "file-sidebar-1",
+                  filename: "report.pdf",
+                  contentType: "application/pdf",
+                  size: 1024,
+                  url: "https://example.com/report.pdf",
+                  createdAt: "2026-03-10T00:00:00Z",
+                },
+              ],
+            },
+          ],
+        });
+      }),
+    );
+
+    detachedSetupPage({
+      context,
+      path: "/chats/thread-test-1",
+      featureSwitches: { [FeatureSwitchKey.ChatArtifactSidebar]: true },
+    });
+
+    click(
+      await waitFor(() => {
+        return screen.getByLabelText("Open artifacts");
+      }),
+    );
+
+    await waitFor(() => {
+      expect(screen.getByRole("dialog", { name: "Artifacts" })).toBeInTheDocument();
+    });
+  });
+
   it("renders markdown artifacts through the text loader instead of an iframe", async () => {
     const user = userEvent.setup();
     let requestedUrl = "";

--- a/turbo/apps/platform/src/views/zero-page/__tests__/zero-chat-thread-page-display.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/zero-chat-thread-page-display.test.tsx
@@ -2224,6 +2224,12 @@ describe("zero chat thread page display - artifacts drawer", () => {
       ],
     });
     server.use(
+      http.get("https://example.com/report.pdf", () => {
+        return new HttpResponse(
+          new Blob(["pdf content"], { type: "application/pdf" }),
+          { headers: { "Content-Type": "application/pdf" } },
+        );
+      }),
       mockApi(chatThreadArtifactsContract.list, ({ respond }) => {
         return respond(200, {
           runs: [
@@ -2258,7 +2264,9 @@ describe("zero chat thread page display - artifacts drawer", () => {
     );
 
     await waitFor(() => {
-      expect(screen.getByRole("dialog", { name: "Artifacts" })).toBeInTheDocument();
+      expect(
+        screen.getByRole("dialog", { name: "Artifacts" }),
+      ).toBeInTheDocument();
     });
   });
 

--- a/turbo/apps/platform/src/views/zero-page/zero-chat-thread-page.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-chat-thread-page.tsx
@@ -1752,10 +1752,10 @@ export function ZeroChatThreadPage() {
           </div>
         )}
       </div>
-      {!sidebarEnabled && leftThread && (
+      {leftThread && (
         <ChatArtifactsDrawer thread={leftThread} />
       )}
-      {!sidebarEnabled && rightThread && (
+      {rightThread && (
         <ChatArtifactsDrawer key={rightThread.threadId} thread={rightThread} />
       )}
       {lightboxUrl && <AttachmentLightbox />}

--- a/turbo/apps/platform/src/views/zero-page/zero-chat-thread-page.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-chat-thread-page.tsx
@@ -1752,9 +1752,7 @@ export function ZeroChatThreadPage() {
           </div>
         )}
       </div>
-      {leftThread && (
-        <ChatArtifactsDrawer thread={leftThread} />
-      )}
+      {leftThread && <ChatArtifactsDrawer thread={leftThread} />}
       {rightThread && (
         <ChatArtifactsDrawer key={rightThread.threadId} thread={rightThread} />
       )}


### PR DESCRIPTION
## Bug

Clicking the **Open artifacts** button in the chat thread header had no visible effect when the `ChatArtifactSidebar` feature switch was ON.

## Root Cause

`ChatArtifactsDrawer` was gated by `!sidebarEnabled`:

```tsx
{!sidebarEnabled && leftThread && (
  <ChatArtifactsDrawer thread={leftThread} />
)}
```

When the sidebar feature flag is ON, the drawer component is never mounted. `ArtifactsButton` still calls `setArtifactsDrawerOpen$(true)` on click, but since the component isn't in the tree, nothing opens.

The two features serve different purposes:
- **Drawer** — lists *all* artifacts (uploaded files from runs) for the thread
- **Sidebar** — previews a *specific* artifact inline next to the chat

They should coexist, not be mutually exclusive.

## Fix

Remove the `!sidebarEnabled` guard from both `ChatArtifactsDrawer` render sites so the drawer is always mounted when a thread is active.

## Test

Added a regression test: `opens the artifacts drawer when ChatArtifactSidebar feature is enabled` — sets up the page with the feature flag ON, clicks the button, and asserts the drawer dialog appears.

🤖 Generated with [Claude Code](https://claude.com/claude-code)