### PR TITLE
chore: remove unused auto skill switch

### DIFF
--- a/turbo/packages/connectors/src/feature-switch-key.ts
+++ b/turbo/packages/connectors/src/feature-switch-key.ts
@@ -37,7 +37,6 @@ export enum FeatureSwitchKey {
   Lab = "lab",
   AuditLink = "auditLink",
   AudioOutput = "audioOutput",
-  AutoSkill = "autoSkill",
   OrgSkills = "orgSkills",
   TestOauthConnector = "testOauthConnector",
   ChatHeaderNewButton = "chatHeaderNewButton",

--- a/turbo/packages/core/src/feature-switch.ts
+++ b/turbo/packages/core/src/feature-switch.ts
@@ -208,11 +208,6 @@ const FEATURE_SWITCHES: Record<FeatureSwitchKey, FeatureSwitch> = {
       "Enable audio output in chat (TTS read-aloud + auto-read) — gates the volume/read buttons and the /api/zero/voice-io/tts route",
     enabled: false,
   },
-  [FeatureSwitchKey.AutoSkill]: {
-    maintainer: "lancy@vm0.ai",
-    description: "Enable automatic skill creation in agent prompts",
-    enabled: false,
-  },
   [FeatureSwitchKey.OrgSkills]: {
     maintainer: "lancy@vm0.ai",
     description:


### PR DESCRIPTION
## Summary
- remove the unused `AutoSkill` feature switch key
- remove its unreferenced feature switch registry entry

## Tests
- `pnpm -F @vm0/core exec vitest run src/__tests__/feature-switch.test.ts`
- `pnpm -F @vm0/core check-types`
- `pnpm -F @vm0/core lint`
- `pnpm -F @vm0/connectors check-types`
- `pnpm -F @vm0/connectors lint`