### PR TITLE
refactor: type connector auth provider args by method

### DIFF
--- a/turbo/apps/api/src/signals/routes/__tests__/connectors-type-callback.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/connectors-type-callback.test.ts
@@ -3,6 +3,7 @@ import { randomUUID } from "node:crypto";
 import {
   CONNECTOR_TYPES,
   type AuthCodeGrantConnectorType,
+  type ConnectorAuthCodeGrantAuthMethodId,
   type ConnectorAuthMethodId,
   type ConnectorAuthClientConfig,
   type ConnectorAuthMethodConfig,
@@ -16,6 +17,7 @@ import {
   testOauthApiProvider,
   testOauthProvider,
 } from "@vm0/connectors/auth-providers/oauth/providers/test-oauth-provider";
+import type { AuthCodeConnectorAuthProvider } from "@vm0/connectors/auth-providers/types";
 import { agentComposes } from "@vm0/db/schema/agent-compose";
 import { connectors } from "@vm0/db/schema/connector";
 import { connectorOauthStates } from "@vm0/db/schema/connector-oauth-state";
@@ -217,16 +219,34 @@ type CapturedOAuthExchange = {
   readonly oauthContext: string | undefined;
 };
 
-type DynamicTestOAuthExchangeOptions = {
-  readonly authMethod: "oauth" | "api";
-  readonly provider: typeof testOauthProvider;
+type DynamicTestOAuthExchangeOptions<
+  Method extends ConnectorAuthCodeGrantAuthMethodId<"test-oauth">,
+> = {
+  readonly authMethod: Method;
+  readonly provider: AuthCodeConnectorAuthProvider<"test-oauth", Method>;
 };
 
-function useDynamicTestOAuthExchange(
-  args: DynamicTestOAuthExchangeOptions = {
-    authMethod: "oauth",
-    provider: testOauthProvider,
-  },
+const defaultDynamicTestOAuthExchangeOptions = {
+  authMethod: "oauth",
+  provider: testOauthProvider,
+} satisfies DynamicTestOAuthExchangeOptions<"oauth">;
+
+function useDynamicTestOAuthExchange(): {
+  readonly exchanges: readonly CapturedOAuthExchange[];
+  readonly restore: () => void;
+};
+function useDynamicTestOAuthExchange<
+  Method extends ConnectorAuthCodeGrantAuthMethodId<"test-oauth">,
+>(
+  args: DynamicTestOAuthExchangeOptions<Method>,
+): {
+  readonly exchanges: readonly CapturedOAuthExchange[];
+  readonly restore: () => void;
+};
+function useDynamicTestOAuthExchange<
+  Method extends ConnectorAuthCodeGrantAuthMethodId<"test-oauth">,
+>(
+  args?: DynamicTestOAuthExchangeOptions<Method>,
 ): {
   readonly exchanges: readonly CapturedOAuthExchange[];
   readonly restore: () => void;
@@ -235,13 +255,20 @@ function useDynamicTestOAuthExchange(
 
   return {
     exchanges,
-    restore: configureDynamicTestOAuthExchange(exchanges, args),
+    restore: args
+      ? configureDynamicTestOAuthExchange(exchanges, args)
+      : configureDynamicTestOAuthExchange(
+          exchanges,
+          defaultDynamicTestOAuthExchangeOptions,
+        ),
   };
 }
 
-function configureDynamicTestOAuthExchange(
+function configureDynamicTestOAuthExchange<
+  Method extends ConnectorAuthCodeGrantAuthMethodId<"test-oauth">,
+>(
   exchanges: CapturedOAuthExchange[],
-  args: DynamicTestOAuthExchangeOptions,
+  args: DynamicTestOAuthExchangeOptions<Method>,
 ): () => void {
   const method = getConnectorAuthMethod("test-oauth", args.authMethod);
   if (method?.grant.kind !== "auth-code") {
@@ -256,8 +283,15 @@ function configureDynamicTestOAuthExchange(
   mutableMethod.client = dynamicPublicClient;
   provider.grant.exchangeCode = (args) => {
     exchanges.push({
-      clientId: args.clientId,
-      clientSecret: args.clientSecret,
+      clientId:
+        args.authClient.clientRegistration === "static"
+          ? args.authClient.clientId
+          : undefined,
+      clientSecret:
+        args.authClient.clientRegistration === "static" &&
+        args.authClient.clientType === "confidential"
+          ? args.authClient.clientSecret
+          : undefined,
       code: args.code,
       redirectUri: args.redirectUri,
       state: args.state,

--- a/turbo/apps/api/src/signals/routes/__tests__/webhooks-agent-firewall-auth.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/webhooks-agent-firewall-auth.test.ts
@@ -529,8 +529,15 @@ function configureDynamicTestOAuthRefresh(
   mutableMethod.client = dynamicPublicClient;
   access.refreshToken = (args) => {
     refreshes.push({
-      clientId: args.clientId,
-      clientSecret: args.clientSecret,
+      clientId:
+        args.authClient.clientRegistration === "static"
+          ? args.authClient.clientId
+          : undefined,
+      clientSecret:
+        args.authClient.clientRegistration === "static" &&
+        args.authClient.clientType === "confidential"
+          ? args.authClient.clientSecret
+          : undefined,
       refreshToken: args.refreshToken,
     });
     return Promise.resolve({

--- a/turbo/apps/api/src/signals/routes/__tests__/zero-connectors-oauth-device-auth.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/zero-connectors-oauth-device-auth.test.ts
@@ -1299,7 +1299,11 @@ describe("OAuth device authorization connector routes", () => {
     testOauthDeviceProvider.grant.pollDeviceAuth = () => {
       pollCount += 1;
       return originalPollDeviceAuth({
-        clientId: "test-oauth-device-client",
+        authClient: {
+          clientRegistration: "static",
+          clientType: "public",
+          clientId: "test-oauth-device-client",
+        },
         deviceAuthGrant: getConnectorAuthMethodDeviceAuthGrantConfig(
           "test-oauth-device",
           "oauth",

--- a/turbo/apps/api/src/signals/routes/__tests__/zero-connectors-oauth-start.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/zero-connectors-oauth-start.test.ts
@@ -350,7 +350,7 @@ describe("POST /api/zero/connectors/:type/oauth/start", () => {
     expect(states).toHaveLength(0);
   });
 
-  it("does not create server-side handoff state when OAuth is not configured", async () => {
+  it("does not create server-side handoff state when auth client is not configured", async () => {
     const userId = `user_${randomUUID()}`;
     const orgId = `org_${randomUUID()}`;
     orgIds.push(orgId);
@@ -364,7 +364,7 @@ describe("POST /api/zero/connectors/:type/oauth/start", () => {
     expect(response.status).toBe(500);
     await expect(response.json()).resolves.toStrictEqual({
       error: {
-        message: "github OAuth not configured",
+        message: "github auth client not configured",
         code: "INTERNAL_SERVER_ERROR",
       },
     });

--- a/turbo/apps/api/src/signals/routes/connector-auth-code-start.ts
+++ b/turbo/apps/api/src/signals/routes/connector-auth-code-start.ts
@@ -31,7 +31,7 @@ type PrepareResolvedConnectorAuthCodeStartResult<
     }
   | {
       readonly ok: false;
-      readonly reason: "oauth_not_configured";
+      readonly reason: "auth_client_not_configured";
     };
 
 type ResolveConnectorAuthCodeStartMethodResult =
@@ -80,7 +80,7 @@ export function prepareResolvedConnectorAuthCodeStart<
     args.readEnv,
   );
   if (!authClient) {
-    return { ok: false, reason: "oauth_not_configured" };
+    return { ok: false, reason: "auth_client_not_configured" };
   }
 
   return {

--- a/turbo/apps/api/src/signals/routes/connector-auth-code-start.ts
+++ b/turbo/apps/api/src/signals/routes/connector-auth-code-start.ts
@@ -2,9 +2,9 @@ import {
   connectorAuthMethodRefHasGrantKind,
   getConnectorAuthMethod,
   resolveConnectorAuthClientForMethod,
-  type ConnectorAuthClient,
   type ConnectorEnvReader,
   type ConnectorAuthMethodRefByGrantKind,
+  type ConnectorAuthClientForMethod,
 } from "@vm0/connectors/connector-utils";
 import type {
   AuthCodeGrantConnectorType,
@@ -19,12 +19,15 @@ import {
 
 import { generateConnectorOAuthState } from "./connector-oauth-route-state";
 
-type PrepareResolvedConnectorAuthCodeStartResult =
+type PrepareResolvedConnectorAuthCodeStartResult<
+  Type extends AuthCodeGrantConnectorType,
+  Method extends ConnectorAuthCodeGrantAuthMethodId<Type>,
+> =
   | {
       readonly ok: true;
       readonly state: string;
       readonly redirectUri: string;
-      readonly authClient: ConnectorAuthClient;
+      readonly authClient: ConnectorAuthClientForMethod<Type, Method>;
     }
   | {
       readonly ok: false;
@@ -62,12 +65,13 @@ export function resolveConnectorAuthCodeStartMethod(
 // the selected auth method for this auth-code flow.
 export function prepareResolvedConnectorAuthCodeStart<
   Type extends AuthCodeGrantConnectorType,
+  Method extends ConnectorAuthCodeGrantAuthMethodId<Type>,
 >(args: {
   readonly type: Type;
-  readonly authMethod: ConnectorAuthCodeGrantAuthMethodId<Type>;
+  readonly authMethod: Method;
   readonly origin: string;
   readonly readEnv: ConnectorEnvReader;
-}): PrepareResolvedConnectorAuthCodeStartResult {
+}): PrepareResolvedConnectorAuthCodeStartResult<Type, Method> {
   const state = generateConnectorOAuthState();
   const redirectUri = `${args.origin}/api/connectors/${args.type}/callback`;
   const authClient = resolveConnectorAuthClientForMethod(
@@ -89,10 +93,11 @@ export function prepareResolvedConnectorAuthCodeStart<
 
 export async function buildResolvedConnectorAuthCodeAuthUrl<
   Type extends AuthCodeGrantConnectorType,
+  Method extends ConnectorAuthCodeGrantAuthMethodId<Type>,
 >(args: {
   readonly type: Type;
-  readonly authMethod: ConnectorAuthCodeGrantAuthMethodId<Type>;
-  readonly authClient: ConnectorAuthClient;
+  readonly authMethod: Method;
+  readonly authClient: ConnectorAuthClientForMethod<Type, Method>;
   readonly redirectUri: string;
   readonly state: string;
 }): Promise<AuthUrlResult> {

--- a/turbo/apps/api/src/signals/routes/connectors-type-callback.ts
+++ b/turbo/apps/api/src/signals/routes/connectors-type-callback.ts
@@ -51,9 +51,11 @@ type CallbackIdentity = {
 
 type AuthCodeCallbackMethodRef<
   Type extends AuthCodeGrantConnectorType = AuthCodeGrantConnectorType,
+  Method extends ConnectorAuthCodeGrantAuthMethodId<Type> =
+    ConnectorAuthCodeGrantAuthMethodId<Type>,
 > = {
   readonly connectorType: Type;
-  readonly authMethod: ConnectorAuthCodeGrantAuthMethodId<Type>;
+  readonly authMethod: Method;
 };
 
 type CompleteOAuthCallbackInput = AuthCodeCallbackMethodRef & {
@@ -144,8 +146,11 @@ function missingStateRedirectResponse(origin: string, type: string): Response {
   return redirectWithError(origin, type, "Missing state parameter", true);
 }
 
-async function exchangeTokenForConnector(
-  args: AuthCodeCallbackMethodRef & {
+async function exchangeTokenForConnector<
+  Type extends AuthCodeGrantConnectorType,
+  Method extends ConnectorAuthCodeGrantAuthMethodId<Type>,
+>(
+  args: AuthCodeCallbackMethodRef<Type, Method> & {
     readonly code: string;
     readonly redirectUri: string;
     readonly state: string | undefined;
@@ -174,9 +179,10 @@ async function exchangeTokenForConnector(
   });
 }
 
-function getRequestedScopes(
-  args: AuthCodeCallbackMethodRef,
-): readonly string[] {
+function getRequestedScopes<
+  Type extends AuthCodeGrantConnectorType,
+  Method extends ConnectorAuthCodeGrantAuthMethodId<Type>,
+>(args: AuthCodeCallbackMethodRef<Type, Method>): readonly string[] {
   return getConnectorAuthMethodGrantScopes(args.connectorType, args.authMethod);
 }
 

--- a/turbo/apps/api/src/signals/routes/connectors-type-callback.ts
+++ b/turbo/apps/api/src/signals/routes/connectors-type-callback.ts
@@ -164,7 +164,7 @@ async function exchangeTokenForConnector<
     optionalEnv,
   );
   if (!authClient) {
-    throw new Error(`${args.connectorType} OAuth not configured`);
+    throw new Error(`${args.connectorType} auth client not configured`);
   }
 
   return await exchangeConnectorAuthCode({

--- a/turbo/apps/api/src/signals/routes/zero-connectors.ts
+++ b/turbo/apps/api/src/signals/routes/zero-connectors.ts
@@ -318,7 +318,7 @@ const startConnectorOauthInner$ = command(
       readEnv: optionalEnv,
     });
     if (!prepared.ok) {
-      return internalServerError(`${type} OAuth not configured`);
+      return internalServerError(`${type} auth client not configured`);
     }
     const authResult = await buildResolvedConnectorAuthCodeAuthUrl({
       type: authCodeStartType.type,

--- a/turbo/apps/api/src/signals/services/agent-webhook-firewall-auth.service.ts
+++ b/turbo/apps/api/src/signals/services/agent-webhook-firewall-auth.service.ts
@@ -9,18 +9,17 @@ import type { SecretConnectorMetadata } from "@vm0/api-contracts/contracts/runne
 import {
   getConnectorAuthMethodAccessMetadata,
   getConnectorAuthMethodStorageMetadata,
-  resolveConnectorAuthClientForMethod,
+  resolveConnectorAuthMethodClientRefByAccessKind,
   connectorAuthMethodRefHasAccessKind,
-  type ConnectorAuthClientForMethod,
+  type ConnectorAuthMethodClientRefByAccessKind,
   type ConnectorAuthMethodRef,
+  type ConnectorAuthMethodRefByAccessKind,
   type ConnectorAuthMethodAccessMetadata,
   type ConnectorAuthMethodStorageMetadata,
 } from "@vm0/connectors/connector-utils";
 import {
   connectorAuthMethodIdSchema,
   connectorTypeSchema,
-  type ConnectorAuthMethodIdsByAccessKind,
-  type RefreshTokenAccessConnectorType,
 } from "@vm0/connectors/connectors";
 import {
   parseBasicAuthTemplates,
@@ -315,18 +314,8 @@ type PreparedRefreshTokenContext =
       readonly context: RefreshTokenContext;
     };
 
-type ConnectorRefreshTokenAccessClientRef = {
-  readonly [Type in RefreshTokenAccessConnectorType]: {
-    readonly [Method in ConnectorAuthMethodIdsByAccessKind<
-      Type,
-      "refresh-token"
-    >]: {
-      readonly type: Type;
-      readonly authMethod: Method;
-      readonly authClient: ConnectorAuthClientForMethod<Type, Method>;
-    };
-  }[ConnectorAuthMethodIdsByAccessKind<Type, "refresh-token">];
-}[RefreshTokenAccessConnectorType];
+type ConnectorRefreshTokenAccessClientRef =
+  ConnectorAuthMethodClientRefByAccessKind<"refresh-token">;
 
 type ConnectorPreparedRefreshTokenContext =
   ConnectorRefreshTokenAccessClientRef & {
@@ -334,29 +323,15 @@ type ConnectorPreparedRefreshTokenContext =
     readonly context: RefreshTokenContext;
   };
 
-function resolveRefreshTokenAccessClientRef<
-  Type extends RefreshTokenAccessConnectorType,
-  Method extends ConnectorAuthMethodIdsByAccessKind<Type, "refresh-token">,
->(authMethodRef: {
-  readonly type: Type;
-  readonly authMethod: Method;
-}): ConnectorRefreshTokenAccessClientRef | undefined {
-  const authClient = resolveConnectorAuthClientForMethod(
-    authMethodRef.type,
-    authMethodRef.authMethod,
+function resolveRefreshTokenAccessClientRef(
+  authMethodRef: ConnectorAuthMethodRefByAccessKind<"refresh-token">,
+): ConnectorRefreshTokenAccessClientRef | undefined {
+  return resolveConnectorAuthMethodClientRefByAccessKind(
+    authMethodRef,
     (name) => {
       return optionalEnv(name);
     },
   );
-  if (!authClient) {
-    return undefined;
-  }
-
-  return {
-    type: authMethodRef.type,
-    authMethod: authMethodRef.authMethod,
-    authClient,
-  } as ConnectorRefreshTokenAccessClientRef;
 }
 
 type PrepareRefreshTokenContextResult =

--- a/turbo/apps/api/src/signals/services/agent-webhook-firewall-auth.service.ts
+++ b/turbo/apps/api/src/signals/services/agent-webhook-firewall-auth.service.ts
@@ -10,12 +10,16 @@ import {
   getConnectorAuthMethodAccessMetadata,
   getConnectorAuthMethodStorageMetadata,
   resolveConnectorAuthClientForMethod,
-  connectorAuthMethodSupportsRefreshTokenAccess,
+  connectorAuthMethodRefHasAccessKind,
+  type ConnectorAuthClientForMethod,
+  type ConnectorAuthMethodRef,
   type ConnectorAuthMethodAccessMetadata,
   type ConnectorAuthMethodStorageMetadata,
 } from "@vm0/connectors/connector-utils";
 import {
+  connectorAuthMethodIdSchema,
   connectorTypeSchema,
+  type ConnectorAuthMethodIdsByAccessKind,
   type RefreshTokenAccessConnectorType,
 } from "@vm0/connectors/connectors";
 import {
@@ -26,9 +30,7 @@ import {
 } from "@vm0/connectors/firewall-types";
 import type { FeatureSwitchContext } from "@vm0/core/feature-switch";
 import {
-  getConnectorAuthProviderClientArgs,
   refreshConnectorAuthProviderAccessToken,
-  type ConnectorAuthProviderClientArgs,
   type ProviderEnv,
 } from "@vm0/connectors/auth-providers";
 import { isOAuthProviderHttpError } from "@vm0/connectors/auth-providers/oauth/error";
@@ -305,19 +307,57 @@ interface RefreshStateRow {
 }
 
 type PreparedRefreshTokenContext =
-  | {
-      readonly sourceType: "connector";
-      readonly connectorType: RefreshTokenAccessConnectorType;
-      readonly authMethod: string;
-      readonly clientArgs: ConnectorAuthProviderClientArgs;
-      readonly context: RefreshTokenContext;
-    }
+  | ConnectorPreparedRefreshTokenContext
   | {
       readonly sourceType: "model-provider";
       readonly providerKey: ModelProviderOAuthProviderKey;
       readonly currentEnv: ProviderEnv;
       readonly context: RefreshTokenContext;
     };
+
+type ConnectorRefreshTokenAccessClientRef = {
+  readonly [Type in RefreshTokenAccessConnectorType]: {
+    readonly [Method in ConnectorAuthMethodIdsByAccessKind<
+      Type,
+      "refresh-token"
+    >]: {
+      readonly type: Type;
+      readonly authMethod: Method;
+      readonly authClient: ConnectorAuthClientForMethod<Type, Method>;
+    };
+  }[ConnectorAuthMethodIdsByAccessKind<Type, "refresh-token">];
+}[RefreshTokenAccessConnectorType];
+
+type ConnectorPreparedRefreshTokenContext =
+  ConnectorRefreshTokenAccessClientRef & {
+    readonly sourceType: "connector";
+    readonly context: RefreshTokenContext;
+  };
+
+function resolveRefreshTokenAccessClientRef<
+  Type extends RefreshTokenAccessConnectorType,
+  Method extends ConnectorAuthMethodIdsByAccessKind<Type, "refresh-token">,
+>(authMethodRef: {
+  readonly type: Type;
+  readonly authMethod: Method;
+}): ConnectorRefreshTokenAccessClientRef | undefined {
+  const authClient = resolveConnectorAuthClientForMethod(
+    authMethodRef.type,
+    authMethodRef.authMethod,
+    (name) => {
+      return optionalEnv(name);
+    },
+  );
+  if (!authClient) {
+    return undefined;
+  }
+
+  return {
+    type: authMethodRef.type,
+    authMethod: authMethodRef.authMethod,
+    authClient,
+  } as ConnectorRefreshTokenAccessClientRef;
+}
 
 type PrepareRefreshTokenContextResult =
   | {
@@ -1024,22 +1064,21 @@ function prepareRefreshTokenContext(
   if (!parsedConnectorType.success) {
     return { ok: false, reason: "not-refreshable" };
   }
-  if (
-    !connectorAuthMethodSupportsRefreshTokenAccess(
-      parsedConnectorType.data,
-      connectorAccess.authMethod,
-    )
-  ) {
+  const parsedAuthMethod = connectorAuthMethodIdSchema.safeParse(
+    connectorAccess.authMethod,
+  );
+  if (!parsedAuthMethod.success) {
     return { ok: false, reason: "not-refreshable" };
   }
-  const authClient = resolveConnectorAuthClientForMethod(
-    parsedConnectorType.data,
-    connectorAccess.authMethod,
-    (name) => {
-      return optionalEnv(name);
-    },
-  );
-  if (!authClient) {
+  const authMethodRef: ConnectorAuthMethodRef = {
+    type: parsedConnectorType.data,
+    authMethod: parsedAuthMethod.data,
+  };
+  if (!connectorAuthMethodRefHasAccessKind(authMethodRef, "refresh-token")) {
+    return { ok: false, reason: "not-refreshable" };
+  }
+  const authClientRef = resolveRefreshTokenAccessClientRef(authMethodRef);
+  if (!authClientRef) {
     L.debug(
       `${args.connectorType} connector client not configured, skipping token refresh`,
     );
@@ -1060,9 +1099,7 @@ function prepareRefreshTokenContext(
     ok: true,
     prepared: {
       sourceType: "connector",
-      connectorType: parsedConnectorType.data,
-      authMethod: connectorAccess.authMethod,
-      clientArgs: getConnectorAuthProviderClientArgs(authClient),
+      ...authClientRef,
       context,
     },
   };
@@ -1496,10 +1533,8 @@ function refreshPreparedAccessToken(args: {
   readonly signal: AbortSignal;
 }) {
   return args.prepared.sourceType === "connector"
-    ? refreshConnectorAuthProviderAccessToken({
-        type: args.prepared.connectorType,
-        authMethod: args.prepared.authMethod,
-        clientArgs: args.prepared.clientArgs,
+    ? refreshPreparedConnectorAccessToken({
+        prepared: args.prepared,
         refreshToken: args.refreshToken,
         signal: args.signal,
       })
@@ -1509,6 +1544,18 @@ function refreshPreparedAccessToken(args: {
         refreshToken: args.refreshToken,
         signal: args.signal,
       });
+}
+
+function refreshPreparedConnectorAccessToken(args: {
+  readonly prepared: ConnectorPreparedRefreshTokenContext;
+  readonly refreshToken: string;
+  readonly signal: AbortSignal;
+}) {
+  return refreshConnectorAuthProviderAccessToken({
+    ...args.prepared,
+    refreshToken: args.refreshToken,
+    signal: args.signal,
+  });
 }
 
 async function refreshAccessTokenForSource(
@@ -1530,7 +1577,7 @@ async function refreshAccessTokenForSource(
       await lockConnectorState(tx, {
         orgId: args.orgId,
         userId: args.userId,
-        type: prepared.connectorType,
+        type: prepared.type,
       });
     } else {
       await lockModelProviderState(tx, {

--- a/turbo/apps/api/src/signals/services/agent-webhook-firewall-auth.service.ts
+++ b/turbo/apps/api/src/signals/services/agent-webhook-firewall-auth.service.ts
@@ -1001,7 +1001,7 @@ function prepareRefreshTokenContext(
       })
     ) {
       L.debug(
-        `${args.connectorType} OAuth client ID not configured, skipping token refresh`,
+        `${args.connectorType} auth client not configured, skipping token refresh`,
       );
       return { ok: false, reason: "client-unconfigured" };
     }

--- a/turbo/apps/api/src/signals/services/connector-oauth-device-auth.service.ts
+++ b/turbo/apps/api/src/signals/services/connector-oauth-device-auth.service.ts
@@ -8,7 +8,6 @@ import type {
 import {
   connectorAuthMethodIdSchema,
   type ConnectorAuthMethodId,
-  type ConnectorDeviceAuthGrantAuthMethodId,
   type ConnectorType,
   type DeviceAuthGrantConnectorType,
 } from "@vm0/connectors/connectors";
@@ -16,8 +15,8 @@ import {
   connectorAuthMethodRefHasGrantKind,
   getConnectorAuthMethod,
   getConnectorAuthMethodIdsForGrantKind,
-  resolveConnectorAuthClientForMethod,
-  type ConnectorAuthClientForMethod,
+  resolveConnectorAuthMethodClientRefByGrantKind,
+  type ConnectorAuthMethodClientRefByGrantKind,
   type ConnectorAuthMethodRef,
   type ConnectorAuthMethodRefByGrantKind,
 } from "@vm0/connectors/connector-utils";
@@ -86,15 +85,8 @@ const encryptedProviderStateSchema = z.object({
 type EncryptedProviderState = z.infer<typeof encryptedProviderStateSchema>;
 
 type DeviceAuthMethodRef = ConnectorAuthMethodRefByGrantKind<"device-auth">;
-type DeviceAuthMethodClientRef = {
-  readonly [Type in DeviceAuthGrantConnectorType]: {
-    readonly [Method in ConnectorDeviceAuthGrantAuthMethodId<Type>]: {
-      readonly type: Type;
-      readonly authMethod: Method;
-      readonly authClient: ConnectorAuthClientForMethod<Type, Method>;
-    };
-  }[ConnectorDeviceAuthGrantAuthMethodId<Type>];
-}[DeviceAuthGrantConnectorType];
+type DeviceAuthMethodClientRef =
+  ConnectorAuthMethodClientRefByGrantKind<"device-auth">;
 
 type PollClaimedSessionArgs = DeviceAuthMethodClientRef & {
   readonly writeDb: Db;
@@ -252,26 +244,17 @@ function resolveStoredDeviceAuthMethod(
   return resolved;
 }
 
-function resolveRequiredAuthClient<
-  Type extends DeviceAuthGrantConnectorType,
-  Method extends ConnectorDeviceAuthGrantAuthMethodId<Type>,
->(method: {
-  readonly type: Type;
-  readonly authMethod: Method;
-}): DeviceAuthMethodClientRef | ReturnType<typeof internalServerError> {
-  const authClient = resolveConnectorAuthClientForMethod(
-    method.type,
-    method.authMethod,
+function resolveRequiredAuthClient(
+  method: DeviceAuthMethodRef,
+): DeviceAuthMethodClientRef | ReturnType<typeof internalServerError> {
+  const clientRef = resolveConnectorAuthMethodClientRefByGrantKind(
+    method,
     optionalEnv,
   );
-  if (!authClient) {
+  if (!clientRef) {
     return internalServerError(`${method.type} OAuth is not configured`);
   }
-  return {
-    type: method.type,
-    authMethod: method.authMethod,
-    authClient,
-  } as DeviceAuthMethodClientRef;
+  return clientRef;
 }
 
 async function lockDeviceAuthSessionOwner(

--- a/turbo/apps/api/src/signals/services/connector-oauth-device-auth.service.ts
+++ b/turbo/apps/api/src/signals/services/connector-oauth-device-auth.service.ts
@@ -252,7 +252,7 @@ function resolveRequiredAuthClient(
     optionalEnv,
   );
   if (!clientRef) {
-    return internalServerError(`${method.type} OAuth is not configured`);
+    return internalServerError(`${method.type} auth client not configured`);
   }
   return clientRef;
 }

--- a/turbo/apps/api/src/signals/services/connector-oauth-device-auth.service.ts
+++ b/turbo/apps/api/src/signals/services/connector-oauth-device-auth.service.ts
@@ -17,7 +17,7 @@ import {
   getConnectorAuthMethod,
   getConnectorAuthMethodIdsForGrantKind,
   resolveConnectorAuthClientForMethod,
-  type ConnectorAuthClient,
+  type ConnectorAuthClientForMethod,
   type ConnectorAuthMethodRef,
   type ConnectorAuthMethodRefByGrantKind,
 } from "@vm0/connectors/connector-utils";
@@ -86,12 +86,20 @@ const encryptedProviderStateSchema = z.object({
 type EncryptedProviderState = z.infer<typeof encryptedProviderStateSchema>;
 
 type DeviceAuthMethodRef = ConnectorAuthMethodRefByGrantKind<"device-auth">;
+type DeviceAuthMethodClientRef = {
+  readonly [Type in DeviceAuthGrantConnectorType]: {
+    readonly [Method in ConnectorDeviceAuthGrantAuthMethodId<Type>]: {
+      readonly type: Type;
+      readonly authMethod: Method;
+      readonly authClient: ConnectorAuthClientForMethod<Type, Method>;
+    };
+  }[ConnectorDeviceAuthGrantAuthMethodId<Type>];
+}[DeviceAuthGrantConnectorType];
 
-type PollClaimedSessionArgs = DeviceAuthMethodRef & {
+type PollClaimedSessionArgs = DeviceAuthMethodClientRef & {
   readonly writeDb: Db;
   readonly orgId: string;
   readonly userId: string;
-  readonly authClient: ConnectorAuthClient;
   readonly session: DeviceAuthSessionRow;
   readonly claimStartedAt: Date;
   readonly signal: AbortSignal;
@@ -244,19 +252,26 @@ function resolveStoredDeviceAuthMethod(
   return resolved;
 }
 
-function resolveRequiredAuthClient<Type extends DeviceAuthGrantConnectorType>(
-  type: Type,
-  authMethod: ConnectorDeviceAuthGrantAuthMethodId<Type>,
-): ConnectorAuthClient | ReturnType<typeof internalServerError> {
+function resolveRequiredAuthClient<
+  Type extends DeviceAuthGrantConnectorType,
+  Method extends ConnectorDeviceAuthGrantAuthMethodId<Type>,
+>(method: {
+  readonly type: Type;
+  readonly authMethod: Method;
+}): DeviceAuthMethodClientRef | ReturnType<typeof internalServerError> {
   const authClient = resolveConnectorAuthClientForMethod(
-    type,
-    authMethod,
+    method.type,
+    method.authMethod,
     optionalEnv,
   );
   if (!authClient) {
-    return internalServerError(`${type} OAuth is not configured`);
+    return internalServerError(`${method.type} OAuth is not configured`);
   }
-  return authClient;
+  return {
+    type: method.type,
+    authMethod: method.authMethod,
+    authClient,
+  } as DeviceAuthMethodClientRef;
 }
 
 async function lockDeviceAuthSessionOwner(
@@ -644,9 +659,7 @@ async function runClaimedSession(
     type: args.type,
   });
   const pollResult = await pollConnectorDeviceAuthorization({
-    type: args.type,
-    authMethod: args.authMethod,
-    authClient: args.authClient,
+    ...args,
     deviceCode: providerState.deviceCode,
   });
   args.signal.throwIfAborted();
@@ -747,19 +760,12 @@ export const startConnectorOauthDeviceAuthSession$ = command(
       return connectorOauthDeviceAuthDisabled;
     }
 
-    const authClient = resolveRequiredAuthClient(
-      resolvedMethod.type,
-      resolvedMethod.authMethod,
-    );
-    if ("status" in authClient) {
-      return authClient;
+    const authClientRef = resolveRequiredAuthClient(resolvedMethod);
+    if ("status" in authClientRef) {
+      return authClientRef;
     }
 
-    const startResult = await startConnectorDeviceAuthorization({
-      type: resolvedMethod.type,
-      authMethod: resolvedMethod.authMethod,
-      authClient,
-    });
+    const startResult = await startConnectorDeviceAuthorization(authClientRef);
     signal.throwIfAborted();
 
     const sessionToken = generateSessionToken();
@@ -883,12 +889,9 @@ export const pollConnectorOauthDeviceAuthSession$ = command(
       return connectorOauthDeviceAuthDisabled;
     }
 
-    const authClient = resolveRequiredAuthClient(
-      resolvedMethod.type,
-      resolvedMethod.authMethod,
-    );
-    if ("status" in authClient) {
-      return authClient;
+    const authClientRef = resolveRequiredAuthClient(resolvedMethod);
+    if ("status" in authClientRef) {
+      return authClientRef;
     }
 
     if (session.status === "complete") {
@@ -940,11 +943,10 @@ export const pollConnectorOauthDeviceAuthSession$ = command(
     }
 
     return await pollClaimedSession({
-      ...resolvedMethod,
+      ...authClientRef,
       writeDb,
       orgId: args.orgId,
       userId: args.userId,
-      authClient,
       session: claimedSession,
       claimStartedAt,
       signal,

--- a/turbo/apps/api/src/signals/services/zero-connector-data.service.ts
+++ b/turbo/apps/api/src/signals/services/zero-connector-data.service.ts
@@ -6,7 +6,7 @@ import type {
 } from "@vm0/api-contracts/contracts/connector-schemas";
 import type { ConnectorSearchAuthMethod } from "@vm0/api-contracts/contracts/zero-connectors";
 import {
-  connectorAuthMethodSupportsTokenRevoke,
+  connectorAuthMethodRefHasRevokeKind,
   getAvailableConnectorAuthMethods,
   getConnectorAuthMethodStorageMetadata,
   getConnectorAuthMethodScopeDiff,
@@ -15,18 +15,20 @@ import {
   getConnectorOwnedSecretNames,
   getConnectorVariableNames,
   getRuntimeAvailableConnectorTypes,
+  type ConnectorAuthMethodRef,
+  type ConnectorAuthMethodRefByRevokeKind,
   type ManualGrantFieldNames,
 } from "@vm0/connectors/connector-utils";
 import { revokeConnectorAuthMethodAccessToken } from "@vm0/connectors/auth-providers";
 import {
   CONNECTOR_TYPE_KEYS,
   CONNECTOR_TYPES,
+  connectorAuthMethodIdSchema,
   connectorTypeSchema,
   type ConnectorAuthMethodId,
   type ConnectorManualGrantFieldConfig,
   type ConnectorType,
   type ConnectorAuthProviderType,
-  type TokenRevokeConnectorType,
 } from "@vm0/connectors/connectors";
 import {
   getAllFeatureStates,
@@ -121,12 +123,12 @@ interface EncryptedConnectorTokenSecret {
   readonly description: string;
 }
 
-interface PendingConnectorTokenRevoke {
-  readonly type: TokenRevokeConnectorType;
-  readonly authMethod: string;
+type TokenRevokeMethodRef = ConnectorAuthMethodRefByRevokeKind<"token-revoke">;
+
+type PendingConnectorTokenRevoke = TokenRevokeMethodRef & {
   readonly encryptedAccessToken: string;
   readonly featureSwitchContext: FeatureSwitchContext;
-}
+};
 
 function parseOauthScopes(value: string | null): string[] | null {
   return value ? oauthScopesSchema.parse(JSON.parse(value)) : null;
@@ -498,15 +500,13 @@ async function loadPendingConnectorTokenRevoke(args: {
   readonly db: Db | ReadonlyDb;
   readonly orgId: string;
   readonly userId: string;
-  readonly type: TokenRevokeConnectorType;
-  readonly authMethod: string;
+  readonly method: TokenRevokeMethodRef;
   readonly featureSwitchContext: FeatureSwitchContext;
   readonly signal: AbortSignal;
 }): Promise<PendingConnectorTokenRevoke | null> {
-  const connectorType = args.type;
   const secretMetadata = connectorTokenSecretMetadataForAuthMethod({
-    type: connectorType,
-    authMethod: args.authMethod,
+    type: args.method.type,
+    authMethod: args.method.authMethod,
   });
   if (!secretMetadata) {
     return null;
@@ -532,11 +532,29 @@ async function loadPendingConnectorTokenRevoke(args: {
   }
 
   return {
-    type: connectorType,
-    authMethod: args.authMethod,
+    ...args.method,
     encryptedAccessToken: accessTokenSecret.encryptedValue,
     featureSwitchContext: args.featureSwitchContext,
   };
+}
+
+function resolveTokenRevokeMethodRef(args: {
+  readonly type: ConnectorType;
+  readonly authMethod: string;
+}): TokenRevokeMethodRef | null {
+  const parsedAuthMethod = connectorAuthMethodIdSchema.safeParse(
+    args.authMethod,
+  );
+  if (!parsedAuthMethod.success) {
+    return null;
+  }
+  const method: ConnectorAuthMethodRef = {
+    type: args.type,
+    authMethod: parsedAuthMethod.data,
+  };
+  return connectorAuthMethodRefHasRevokeKind(method, "token-revoke")
+    ? method
+    : null;
 }
 
 async function revokePendingConnectorToken(args: {
@@ -684,15 +702,16 @@ export const deleteZeroConnectorLocalState$ = command(
       }
 
       let pendingTokenRevoke: PendingConnectorTokenRevoke | null = null;
-      if (
-        connectorAuthMethodSupportsTokenRevoke(args.type, existing.authMethod)
-      ) {
+      const tokenRevokeMethod = resolveTokenRevokeMethodRef({
+        type: args.type,
+        authMethod: existing.authMethod,
+      });
+      if (tokenRevokeMethod) {
         pendingTokenRevoke = await loadPendingConnectorTokenRevoke({
           db: tx,
           orgId: args.orgId,
           userId: args.userId,
-          type: args.type,
-          authMethod: existing.authMethod,
+          method: tokenRevokeMethod,
           featureSwitchContext,
           signal,
         });
@@ -982,13 +1001,16 @@ async function cleanupExistingStoredConnectorForManualGrantConnect(
   }
 
   let pendingTokenRevoke: PendingConnectorTokenRevoke | null = null;
-  if (connectorAuthMethodSupportsTokenRevoke(args.type, existing.authMethod)) {
+  const tokenRevokeMethod = resolveTokenRevokeMethodRef({
+    type: args.type,
+    authMethod: existing.authMethod,
+  });
+  if (tokenRevokeMethod) {
     pendingTokenRevoke = await loadPendingConnectorTokenRevoke({
       db,
       orgId: args.orgId,
       userId: args.userId,
-      type: args.type,
-      authMethod: existing.authMethod,
+      method: tokenRevokeMethod,
       featureSwitchContext: args.featureSwitchContext,
       signal: args.signal,
     });

--- a/turbo/packages/connectors/src/__tests__/connectors.test.ts
+++ b/turbo/packages/connectors/src/__tests__/connectors.test.ts
@@ -29,7 +29,7 @@ import {
   type TokenRevokeConnectorType,
 } from "../connectors";
 import {
-  connectorAuthMethodSupportsRefreshTokenAccess,
+  connectorAuthMethodHasAccessKind,
   connectorAuthMethodSupportsTokenRevoke,
   connectorAuthMethodHasGrantKind,
   connectorAuthMethodRefHasGrantKind,
@@ -661,7 +661,7 @@ describe("connector selected auth method capability checks", () => {
           getConnectorAuthMethodAccessMetadata(type, authMethod)?.kind ===
           "refresh-token";
         expect(
-          connectorAuthMethodSupportsRefreshTokenAccess(type, authMethod),
+          connectorAuthMethodHasAccessKind(type, authMethod, "refresh-token"),
         ).toBe(hasRefreshTokenAccess);
       }
     }
@@ -699,7 +699,7 @@ describe("connector selected auth method capability checks", () => {
 
   it("does not mark non-refreshable auth methods as refresh-token access", () => {
     expect(
-      connectorAuthMethodSupportsRefreshTokenAccess("github", "oauth"),
+      connectorAuthMethodHasAccessKind("github", "oauth", "refresh-token"),
     ).toBe(false);
     expect(
       getConnectorAuthMethodAccessMetadata("github", "oauth")?.kind,
@@ -720,13 +720,17 @@ describe("connector selected auth method capability checks", () => {
       connectorAuthMethodHasGrantKind("test-oauth", "api", "device-auth"),
     ).toBe(false);
     expect(
-      connectorAuthMethodSupportsRefreshTokenAccess("test-oauth", "oauth"),
+      connectorAuthMethodHasAccessKind("test-oauth", "oauth", "refresh-token"),
     ).toBe(true);
     expect(
-      connectorAuthMethodSupportsRefreshTokenAccess("test-oauth", "api"),
+      connectorAuthMethodHasAccessKind("test-oauth", "api", "refresh-token"),
     ).toBe(true);
     expect(
-      connectorAuthMethodSupportsRefreshTokenAccess("test-oauth", "missing"),
+      connectorAuthMethodHasAccessKind(
+        "test-oauth",
+        "missing",
+        "refresh-token",
+      ),
     ).toBe(false);
     expect(
       getConnectorAuthMethodEnvBindings("test-oauth", "api"),

--- a/turbo/packages/connectors/src/__tests__/connectors.test.ts
+++ b/turbo/packages/connectors/src/__tests__/connectors.test.ts
@@ -30,9 +30,9 @@ import {
 } from "../connectors";
 import {
   connectorAuthMethodHasAccessKind,
-  connectorAuthMethodSupportsTokenRevoke,
   connectorAuthMethodHasGrantKind,
   connectorAuthMethodRefHasGrantKind,
+  connectorAuthMethodRefHasRevokeKind,
   getAvailableConnectorAuthMethods,
   getConnectorAuthMethodGrantScopes,
   getConnectorAuthMethodIdsForAccessKind,
@@ -673,9 +673,12 @@ describe("connector selected auth method capability checks", () => {
 
     for (const type of connectorTypeSchema.options) {
       for (const authMethod of getConfiguredConnectorAuthMethods(type)) {
-        const supportsTokenRevoke = connectorAuthMethodSupportsTokenRevoke(
-          type,
-          authMethod,
+        const supportsTokenRevoke = connectorAuthMethodRefHasRevokeKind(
+          {
+            type,
+            authMethod,
+          },
+          "token-revoke",
         );
         expect(supportsTokenRevoke).toBe(
           getConnectorAuthMethod(type, authMethod)?.revoke.kind ===
@@ -686,17 +689,25 @@ describe("connector selected auth method capability checks", () => {
   });
 
   it("detects token revoke support from selected auth method config", () => {
-    expect(connectorAuthMethodSupportsTokenRevoke("github", "oauth")).toBe(
-      true,
-    );
-    expect(connectorAuthMethodSupportsTokenRevoke("notion", "oauth")).toBe(
-      false,
-    );
-    expect(connectorAuthMethodSupportsTokenRevoke("stripe", "api-token")).toBe(
-      false,
-    );
+    expect(
+      connectorAuthMethodRefHasRevokeKind(
+        { type: "github", authMethod: "oauth" },
+        "token-revoke",
+      ),
+    ).toBe(true);
+    expect(
+      connectorAuthMethodRefHasRevokeKind(
+        { type: "notion", authMethod: "oauth" },
+        "token-revoke",
+      ),
+    ).toBe(false);
+    expect(
+      connectorAuthMethodRefHasRevokeKind(
+        { type: "stripe", authMethod: "api-token" },
+        "token-revoke",
+      ),
+    ).toBe(false);
   });
-
   it("does not mark non-refreshable auth methods as refresh-token access", () => {
     expect(
       connectorAuthMethodHasAccessKind("github", "oauth", "refresh-token"),

--- a/turbo/packages/connectors/src/__tests__/connectors.test.ts
+++ b/turbo/packages/connectors/src/__tests__/connectors.test.ts
@@ -16,6 +16,7 @@ import {
   connectorTypeSchema,
   type ConnectorAuthMethodConfig,
   type ConnectorAuthMethodId,
+  type ConnectorAuthMethodIds,
   type ConnectorAuthCodeGrantAuthMethodId,
   type ConnectorAuthCodeGrantConfig,
   type ConnectorConfig,
@@ -59,6 +60,8 @@ import {
   hasConnectorDeviceAuthGrant,
   isStaticConfidentialConnectorAuthClient,
   isStaticConnectorAuthClient,
+  type ConnectorAuthClient,
+  type ConnectorAuthClientForMethod,
   type ConnectorEnvReader,
 } from "../connector-utils";
 import { FeatureSwitchKey } from "../feature-switch-key";
@@ -104,6 +107,25 @@ function hasConnectorAuthorizationGrant(type: ConnectorType): boolean {
 
 const server = setupServer();
 const SLOCK_ACCESS_TOKEN_TTL_SECONDS = 900;
+
+type OAuthAuthMethodConnectorType = {
+  readonly [Type in ConnectorType]: "oauth" extends ConnectorAuthMethodIds<Type>
+    ? Type
+    : never;
+}[ConnectorType];
+
+function getOauthAuthClient<Type extends OAuthAuthMethodConnectorType>(
+  type: Type,
+  readEnv: ConnectorEnvReader,
+):
+  | ConnectorAuthClientForMethod<Type, ConnectorAuthMethodIds<Type> & "oauth">
+  | undefined;
+function getOauthAuthClient(
+  type: ConnectorType,
+  readEnv: ConnectorEnvReader,
+): ConnectorAuthClient | undefined {
+  return resolveConnectorAuthClientForMethod(type, "oauth", readEnv);
+}
 
 beforeAll(() => {
   server.listen({ onUnhandledRequest: "error" });
@@ -852,13 +874,9 @@ describe("connector selected auth method capability checks", () => {
       );
 
       for (const type of providerTypes) {
-        const oauthClient = resolveConnectorAuthClientForMethod(
-          type,
-          "oauth",
-          () => {
-            return "test-client-credential";
-          },
-        );
+        const oauthClient = getOauthAuthClient(type, () => {
+          return "test-client-credential";
+        });
         expect(oauthClient, `${type}: OAuth client`).toBeDefined();
         if (!oauthClient) {
           throw new Error(`${type} OAuth client not found`);
@@ -957,13 +975,9 @@ describe("connector selected auth method capability checks", () => {
       }),
     );
 
-    const oauthClient = resolveConnectorAuthClientForMethod(
-      "test-oauth-device",
-      "oauth",
-      () => {
-        return undefined;
-      },
-    );
+    const oauthClient = getOauthAuthClient("test-oauth-device", () => {
+      return undefined;
+    });
     expect(oauthClient).toBeDefined();
 
     if (!oauthClient) {
@@ -1181,13 +1195,9 @@ describe("connector selected auth method capability checks", () => {
       }),
     );
 
-    const oauthClient = resolveConnectorAuthClientForMethod(
-      "base44",
-      "oauth",
-      () => {
-        return undefined;
-      },
-    );
+    const oauthClient = getOauthAuthClient("base44", () => {
+      return undefined;
+    });
     expect(oauthClient).toBeDefined();
 
     if (!oauthClient) {
@@ -1476,13 +1486,9 @@ describe("connector selected auth method capability checks", () => {
       ),
     );
 
-    const oauthClient = resolveConnectorAuthClientForMethod(
-      "slock",
-      "oauth",
-      () => {
-        return undefined;
-      },
-    );
+    const oauthClient = getOauthAuthClient("slock", () => {
+      return undefined;
+    });
     expect(oauthClient).toBeDefined();
 
     if (!oauthClient) {
@@ -2326,17 +2332,13 @@ describe("getRuntimeAvailableConnectorTypes", () => {
   });
 
   it("derives static confidential OAuth client from connector config", () => {
-    const oauthClient = resolveConnectorAuthClientForMethod(
-      "github",
-      "oauth",
-      (name) => {
-        const env = new Map([
-          ["GH_OAUTH_CLIENT_ID", "github-client-id"],
-          ["GH_OAUTH_CLIENT_SECRET", "github-client-secret"],
-        ]);
-        return env.get(name);
-      },
-    );
+    const oauthClient = getOauthAuthClient("github", (name) => {
+      const env = new Map([
+        ["GH_OAUTH_CLIENT_ID", "github-client-id"],
+        ["GH_OAUTH_CLIENT_SECRET", "github-client-secret"],
+      ]);
+      return env.get(name);
+    });
 
     expect(oauthClient).toStrictEqual({
       clientRegistration: "static",
@@ -2347,23 +2349,15 @@ describe("getRuntimeAvailableConnectorTypes", () => {
   });
 
   it("does not configure static confidential OAuth when the secret is missing", () => {
-    const oauthClient = resolveConnectorAuthClientForMethod(
-      "github",
-      "oauth",
-      (name) => {
-        return name === "GH_OAUTH_CLIENT_ID" ? "github-client-id" : undefined;
-      },
-    );
+    const oauthClient = getOauthAuthClient("github", (name) => {
+      return name === "GH_OAUTH_CLIENT_ID" ? "github-client-id" : undefined;
+    });
 
     expect(oauthClient).toBeUndefined();
   });
 
   it("supports literal static OAuth clients without runtime OAuth client env", () => {
-    const oauthClient = resolveConnectorAuthClientForMethod(
-      "test-oauth",
-      "oauth",
-      emptyEnv,
-    );
+    const oauthClient = getOauthAuthClient("test-oauth", emptyEnv);
 
     expect(oauthClient).toStrictEqual({
       clientRegistration: "static",
@@ -2374,11 +2368,7 @@ describe("getRuntimeAvailableConnectorTypes", () => {
   });
 
   it("supports static public OAuth clients with only a client id", () => {
-    const oauthClient = resolveConnectorAuthClientForMethod(
-      "test-oauth-device",
-      "oauth",
-      emptyEnv,
-    );
+    const oauthClient = getOauthAuthClient("test-oauth-device", emptyEnv);
 
     expect(oauthClient).toStrictEqual({
       clientRegistration: "static",
@@ -2388,17 +2378,13 @@ describe("getRuntimeAvailableConnectorTypes", () => {
   });
 
   it("identifies static OAuth client variants", () => {
-    const staticAuthClient = resolveConnectorAuthClientForMethod(
-      "github",
-      "oauth",
-      (name) => {
-        const env = new Map([
-          ["GH_OAUTH_CLIENT_ID", "github-client-id"],
-          ["GH_OAUTH_CLIENT_SECRET", "github-client-secret"],
-        ]);
-        return env.get(name);
-      },
-    );
+    const staticAuthClient = getOauthAuthClient("github", (name) => {
+      const env = new Map([
+        ["GH_OAUTH_CLIENT_ID", "github-client-id"],
+        ["GH_OAUTH_CLIENT_SECRET", "github-client-secret"],
+      ]);
+      return env.get(name);
+    });
     if (!staticAuthClient) {
       throw new Error("Expected GitHub OAuth client");
     }
@@ -2411,11 +2397,7 @@ describe("getRuntimeAvailableConnectorTypes", () => {
       expect(clientSecret).toBe("github-client-secret");
     }
 
-    const publicAuthClient = resolveConnectorAuthClientForMethod(
-      "test-oauth-device",
-      "oauth",
-      emptyEnv,
-    );
+    const publicAuthClient = getOauthAuthClient("test-oauth-device", emptyEnv);
     if (!publicAuthClient) {
       throw new Error("Expected public OAuth client");
     }

--- a/turbo/packages/connectors/src/__tests__/connectors.test.ts
+++ b/turbo/packages/connectors/src/__tests__/connectors.test.ts
@@ -72,6 +72,14 @@ import {
   startConnectorDeviceAuthorization,
 } from "../auth-providers/connector-auth";
 import {
+  testOauthDeviceApiProvider,
+  testOauthDeviceProvider,
+} from "../auth-providers/oauth/providers/test-oauth-device-provider";
+import {
+  TEST_OAUTH_DEVICE_ACCESS_SECRET_NAME,
+  TEST_OAUTH_DEVICE_API_ACCESS_SECRET_NAME,
+} from "../auth-providers/oauth/providers/test-oauth-device";
+import {
   GOOGLE_OAUTH_CONNECTOR_TYPES,
   isGoogleOAuthConnector,
 } from "../auth-providers/oauth/google-connectors";
@@ -1076,6 +1084,15 @@ describe("connector selected auth method capability checks", () => {
         },
       },
     });
+  });
+
+  it("keeps test OAuth device provider access secrets method-specific", () => {
+    expect(testOauthDeviceProvider.access.getAccessSecretName()).toBe(
+      TEST_OAUTH_DEVICE_ACCESS_SECRET_NAME,
+    );
+    expect(testOauthDeviceApiProvider.access.getAccessSecretName()).toBe(
+      TEST_OAUTH_DEVICE_API_ACCESS_SECRET_NAME,
+    );
   });
 
   it("starts, polls, and refreshes the Base44 OAuth device provider", async () => {

--- a/turbo/packages/connectors/src/__tests__/connectors.test.ts
+++ b/turbo/packages/connectors/src/__tests__/connectors.test.ts
@@ -29,8 +29,8 @@ import {
   type TokenRevokeConnectorType,
 } from "../connectors";
 import {
-  connectorAuthMethodHasAccessKind,
   connectorAuthMethodHasGrantKind,
+  connectorAuthMethodRefHasAccessKind,
   connectorAuthMethodRefHasGrantKind,
   connectorAuthMethodRefHasRevokeKind,
   getAvailableConnectorAuthMethods,
@@ -661,7 +661,10 @@ describe("connector selected auth method capability checks", () => {
           getConnectorAuthMethodAccessMetadata(type, authMethod)?.kind ===
           "refresh-token";
         expect(
-          connectorAuthMethodHasAccessKind(type, authMethod, "refresh-token"),
+          connectorAuthMethodRefHasAccessKind(
+            { type, authMethod },
+            "refresh-token",
+          ),
         ).toBe(hasRefreshTokenAccess);
       }
     }
@@ -710,7 +713,10 @@ describe("connector selected auth method capability checks", () => {
   });
   it("does not mark non-refreshable auth methods as refresh-token access", () => {
     expect(
-      connectorAuthMethodHasAccessKind("github", "oauth", "refresh-token"),
+      connectorAuthMethodRefHasAccessKind(
+        { type: "github", authMethod: "oauth" },
+        "refresh-token",
+      ),
     ).toBe(false);
     expect(
       getConnectorAuthMethodAccessMetadata("github", "oauth")?.kind,
@@ -731,18 +737,20 @@ describe("connector selected auth method capability checks", () => {
       connectorAuthMethodHasGrantKind("test-oauth", "api", "device-auth"),
     ).toBe(false);
     expect(
-      connectorAuthMethodHasAccessKind("test-oauth", "oauth", "refresh-token"),
-    ).toBe(true);
-    expect(
-      connectorAuthMethodHasAccessKind("test-oauth", "api", "refresh-token"),
-    ).toBe(true);
-    expect(
-      connectorAuthMethodHasAccessKind(
-        "test-oauth",
-        "missing",
+      connectorAuthMethodRefHasAccessKind(
+        { type: "test-oauth", authMethod: "oauth" },
         "refresh-token",
       ),
-    ).toBe(false);
+    ).toBe(true);
+    expect(
+      connectorAuthMethodRefHasAccessKind(
+        { type: "test-oauth", authMethod: "api" },
+        "refresh-token",
+      ),
+    ).toBe(true);
+    expect(
+      getConnectorAuthMethodIdsForAccessKind("test-oauth", "refresh-token"),
+    ).toStrictEqual(["oauth", "api"]);
     expect(
       getConnectorAuthMethodEnvBindings("test-oauth", "api"),
     ).toStrictEqual({

--- a/turbo/packages/connectors/src/__tests__/connectors.test.ts
+++ b/turbo/packages/connectors/src/__tests__/connectors.test.ts
@@ -16,6 +16,7 @@ import {
   connectorTypeSchema,
   type ConnectorAuthMethodConfig,
   type ConnectorAuthMethodId,
+  type ConnectorAuthMethodIds,
   type ConnectorAuthCodeGrantAuthMethodId,
   type ConnectorAuthCodeGrantConfig,
   type ConnectorConfig,
@@ -59,12 +60,12 @@ import {
   hasConnectorDeviceAuthGrant,
   isStaticConfidentialConnectorAuthClient,
   isStaticConnectorAuthClient,
+  type ConnectorAuthClientForMethod,
   type ConnectorEnvReader,
 } from "../connector-utils";
 import { FeatureSwitchKey } from "../feature-switch-key";
 import {
   buildConnectorAuthCodeAuthorizationUrl,
-  getConnectorAuthProviderClientArgs,
   pollConnectorDeviceAuthorization,
   refreshConnectorAuthProviderAccessToken,
   revokeConnectorAuthMethodAccessToken,
@@ -98,8 +99,23 @@ function hasConnectorAuthorizationGrant(type: ConnectorType): boolean {
 const server = setupServer();
 const SLOCK_ACCESS_TOKEN_TTL_SECONDS = 900;
 
-function getOauthAuthClient(type: ConnectorType, readEnv: ConnectorEnvReader) {
-  return resolveConnectorAuthClientForMethod(type, "oauth", readEnv);
+type OAuthAuthMethodConnectorType = {
+  readonly [Type in ConnectorType]: "oauth" extends ConnectorAuthMethodIds<Type>
+    ? Type
+    : never;
+}[ConnectorType];
+
+function getOauthAuthClient<Type extends OAuthAuthMethodConnectorType>(
+  type: Type,
+  readEnv: ConnectorEnvReader,
+):
+  | ConnectorAuthClientForMethod<Type, ConnectorAuthMethodIds<Type> & "oauth">
+  | undefined {
+  const authMethod = "oauth" as ConnectorAuthMethodIds<Type> & "oauth";
+  return resolveConnectorAuthClientForMethod<
+    Type,
+    ConnectorAuthMethodIds<Type> & "oauth"
+  >(type, authMethod, readEnv);
 }
 
 beforeAll(() => {
@@ -737,20 +753,6 @@ describe("connector selected auth method capability checks", () => {
     expect(url.searchParams.get("scope")).toBe("read");
   });
 
-  it("rejects refresh when the selected auth method is not refreshable", async () => {
-    await expect(
-      refreshConnectorAuthProviderAccessToken({
-        type: "stripe",
-        authMethod: "api-token",
-        clientArgs: {},
-        refreshToken: "stripe-refresh-token",
-        signal: testRefreshSignal(),
-      }),
-    ).rejects.toThrow(
-      "stripe connector auth method api-token does not support token refresh",
-    );
-  });
-
   it("revokes OAuth tokens through the provider registry", async () => {
     const readEnv: ConnectorEnvReader = (name) => {
       if (name === "GH_OAUTH_CLIENT_ID") {
@@ -1278,7 +1280,7 @@ describe("connector selected auth method capability checks", () => {
       refreshConnectorAuthProviderAccessToken({
         type: "base44",
         authMethod: "oauth",
-        clientArgs: getConnectorAuthProviderClientArgs(oauthClient),
+        authClient: oauthClient,
         refreshToken: "base44-refresh-rotation",
         signal: testRefreshSignal(),
       }),
@@ -1291,7 +1293,7 @@ describe("connector selected auth method capability checks", () => {
       refreshConnectorAuthProviderAccessToken({
         type: "base44",
         authMethod: "oauth",
-        clientArgs: getConnectorAuthProviderClientArgs(oauthClient),
+        authClient: oauthClient,
         refreshToken: "base44-refresh-without-rotation",
         signal: testRefreshSignal(),
       }),
@@ -1624,7 +1626,7 @@ describe("connector selected auth method capability checks", () => {
     const refreshResult = await refreshConnectorAuthProviderAccessToken({
       type: "slock",
       authMethod: "oauth",
-      clientArgs: getConnectorAuthProviderClientArgs(oauthClient),
+      authClient: oauthClient,
       refreshToken: "slock-refresh-token",
       signal: testRefreshSignal(),
     });
@@ -1645,7 +1647,7 @@ describe("connector selected auth method capability checks", () => {
       refreshConnectorAuthProviderAccessToken({
         type: "slock",
         authMethod: "oauth",
-        clientArgs: getConnectorAuthProviderClientArgs(oauthClient),
+        authClient: oauthClient,
         refreshToken: "slock-refresh-malformed",
         signal: testRefreshSignal(),
       }),

--- a/turbo/packages/connectors/src/__tests__/connectors.test.ts
+++ b/turbo/packages/connectors/src/__tests__/connectors.test.ts
@@ -16,7 +16,6 @@ import {
   connectorTypeSchema,
   type ConnectorAuthMethodConfig,
   type ConnectorAuthMethodId,
-  type ConnectorAuthMethodIds,
   type ConnectorAuthCodeGrantAuthMethodId,
   type ConnectorAuthCodeGrantConfig,
   type ConnectorConfig,
@@ -60,7 +59,6 @@ import {
   hasConnectorDeviceAuthGrant,
   isStaticConfidentialConnectorAuthClient,
   isStaticConnectorAuthClient,
-  type ConnectorAuthClientForMethod,
   type ConnectorEnvReader,
 } from "../connector-utils";
 import { FeatureSwitchKey } from "../feature-switch-key";
@@ -106,25 +104,6 @@ function hasConnectorAuthorizationGrant(type: ConnectorType): boolean {
 
 const server = setupServer();
 const SLOCK_ACCESS_TOKEN_TTL_SECONDS = 900;
-
-type OAuthAuthMethodConnectorType = {
-  readonly [Type in ConnectorType]: "oauth" extends ConnectorAuthMethodIds<Type>
-    ? Type
-    : never;
-}[ConnectorType];
-
-function getOauthAuthClient<Type extends OAuthAuthMethodConnectorType>(
-  type: Type,
-  readEnv: ConnectorEnvReader,
-):
-  | ConnectorAuthClientForMethod<Type, ConnectorAuthMethodIds<Type> & "oauth">
-  | undefined {
-  const authMethod = "oauth" as ConnectorAuthMethodIds<Type> & "oauth";
-  return resolveConnectorAuthClientForMethod<
-    Type,
-    ConnectorAuthMethodIds<Type> & "oauth"
-  >(type, authMethod, readEnv);
-}
 
 beforeAll(() => {
   server.listen({ onUnhandledRequest: "error" });
@@ -873,9 +852,13 @@ describe("connector selected auth method capability checks", () => {
       );
 
       for (const type of providerTypes) {
-        const oauthClient = getOauthAuthClient(type, () => {
-          return "test-client-credential";
-        });
+        const oauthClient = resolveConnectorAuthClientForMethod(
+          type,
+          "oauth",
+          () => {
+            return "test-client-credential";
+          },
+        );
         expect(oauthClient, `${type}: OAuth client`).toBeDefined();
         if (!oauthClient) {
           throw new Error(`${type} OAuth client not found`);
@@ -974,9 +957,13 @@ describe("connector selected auth method capability checks", () => {
       }),
     );
 
-    const oauthClient = getOauthAuthClient("test-oauth-device", () => {
-      return undefined;
-    });
+    const oauthClient = resolveConnectorAuthClientForMethod(
+      "test-oauth-device",
+      "oauth",
+      () => {
+        return undefined;
+      },
+    );
     expect(oauthClient).toBeDefined();
 
     if (!oauthClient) {
@@ -1194,9 +1181,13 @@ describe("connector selected auth method capability checks", () => {
       }),
     );
 
-    const oauthClient = getOauthAuthClient("base44", () => {
-      return undefined;
-    });
+    const oauthClient = resolveConnectorAuthClientForMethod(
+      "base44",
+      "oauth",
+      () => {
+        return undefined;
+      },
+    );
     expect(oauthClient).toBeDefined();
 
     if (!oauthClient) {
@@ -1485,9 +1476,13 @@ describe("connector selected auth method capability checks", () => {
       ),
     );
 
-    const oauthClient = getOauthAuthClient("slock", () => {
-      return undefined;
-    });
+    const oauthClient = resolveConnectorAuthClientForMethod(
+      "slock",
+      "oauth",
+      () => {
+        return undefined;
+      },
+    );
     expect(oauthClient).toBeDefined();
 
     if (!oauthClient) {
@@ -2331,14 +2326,17 @@ describe("getRuntimeAvailableConnectorTypes", () => {
   });
 
   it("derives static confidential OAuth client from connector config", () => {
-    const oauthClient = getOauthAuthClient("github", (name) => {
-      return (
-        {
-          GH_OAUTH_CLIENT_ID: "github-client-id",
-          GH_OAUTH_CLIENT_SECRET: "github-client-secret",
-        } as Record<string, string>
-      )[name];
-    });
+    const oauthClient = resolveConnectorAuthClientForMethod(
+      "github",
+      "oauth",
+      (name) => {
+        const env = new Map([
+          ["GH_OAUTH_CLIENT_ID", "github-client-id"],
+          ["GH_OAUTH_CLIENT_SECRET", "github-client-secret"],
+        ]);
+        return env.get(name);
+      },
+    );
 
     expect(oauthClient).toStrictEqual({
       clientRegistration: "static",
@@ -2349,15 +2347,23 @@ describe("getRuntimeAvailableConnectorTypes", () => {
   });
 
   it("does not configure static confidential OAuth when the secret is missing", () => {
-    const oauthClient = getOauthAuthClient("github", (name) => {
-      return name === "GH_OAUTH_CLIENT_ID" ? "github-client-id" : undefined;
-    });
+    const oauthClient = resolveConnectorAuthClientForMethod(
+      "github",
+      "oauth",
+      (name) => {
+        return name === "GH_OAUTH_CLIENT_ID" ? "github-client-id" : undefined;
+      },
+    );
 
     expect(oauthClient).toBeUndefined();
   });
 
   it("supports literal static OAuth clients without runtime OAuth client env", () => {
-    const oauthClient = getOauthAuthClient("test-oauth", emptyEnv);
+    const oauthClient = resolveConnectorAuthClientForMethod(
+      "test-oauth",
+      "oauth",
+      emptyEnv,
+    );
 
     expect(oauthClient).toStrictEqual({
       clientRegistration: "static",
@@ -2368,7 +2374,11 @@ describe("getRuntimeAvailableConnectorTypes", () => {
   });
 
   it("supports static public OAuth clients with only a client id", () => {
-    const oauthClient = getOauthAuthClient("test-oauth-device", emptyEnv);
+    const oauthClient = resolveConnectorAuthClientForMethod(
+      "test-oauth-device",
+      "oauth",
+      emptyEnv,
+    );
 
     expect(oauthClient).toStrictEqual({
       clientRegistration: "static",
@@ -2378,14 +2388,17 @@ describe("getRuntimeAvailableConnectorTypes", () => {
   });
 
   it("identifies static OAuth client variants", () => {
-    const staticAuthClient = getOauthAuthClient("github", (name) => {
-      return (
-        {
-          GH_OAUTH_CLIENT_ID: "github-client-id",
-          GH_OAUTH_CLIENT_SECRET: "github-client-secret",
-        } as Record<string, string>
-      )[name];
-    });
+    const staticAuthClient = resolveConnectorAuthClientForMethod(
+      "github",
+      "oauth",
+      (name) => {
+        const env = new Map([
+          ["GH_OAUTH_CLIENT_ID", "github-client-id"],
+          ["GH_OAUTH_CLIENT_SECRET", "github-client-secret"],
+        ]);
+        return env.get(name);
+      },
+    );
     if (!staticAuthClient) {
       throw new Error("Expected GitHub OAuth client");
     }
@@ -2398,7 +2411,11 @@ describe("getRuntimeAvailableConnectorTypes", () => {
       expect(clientSecret).toBe("github-client-secret");
     }
 
-    const publicAuthClient = getOauthAuthClient("test-oauth-device", emptyEnv);
+    const publicAuthClient = resolveConnectorAuthClientForMethod(
+      "test-oauth-device",
+      "oauth",
+      emptyEnv,
+    );
     if (!publicAuthClient) {
       throw new Error("Expected public OAuth client");
     }

--- a/turbo/packages/connectors/src/__tests__/connectors.test.ts
+++ b/turbo/packages/connectors/src/__tests__/connectors.test.ts
@@ -29,6 +29,7 @@ import {
   type TokenRevokeConnectorType,
 } from "../connectors";
 import {
+  connectorAuthClientIdentity,
   connectorAuthMethodHasGrantKind,
   connectorAuthMethodRefHasAccessKind,
   connectorAuthMethodRefHasGrantKind,
@@ -2419,6 +2420,14 @@ describe("getRuntimeAvailableConnectorTypes", () => {
       const clientSecret: string = staticAuthClient.clientSecret;
       expect(clientSecret).toBe("github-client-secret");
     }
+    const staticAuthClientIdentity =
+      connectorAuthClientIdentity(staticAuthClient);
+    expect(staticAuthClientIdentity).toStrictEqual({
+      clientRegistration: "static",
+      clientType: "confidential",
+      clientId: "github-client-id",
+    });
+    expect("clientSecret" in staticAuthClientIdentity).toBe(false);
 
     const publicAuthClient = getOauthAuthClient("test-oauth-device", emptyEnv);
     if (!publicAuthClient) {

--- a/turbo/packages/connectors/src/auth-providers/connector-auth.ts
+++ b/turbo/packages/connectors/src/auth-providers/connector-auth.ts
@@ -21,6 +21,8 @@ import {
   isStaticConfidentialConnectorAuthClient,
   resolveConnectorAuthClientForMethod,
   type ConnectorAuthClientForMethod,
+  type ConnectorAuthMethodClientRefByAccessKind,
+  type ConnectorAuthMethodClientRefByGrantKind,
   type ConnectorEnvReader,
 } from "@vm0/connectors/connector-utils";
 import type {
@@ -430,38 +432,14 @@ const CONNECTOR_AUTH_METHOD_PROVIDERS = {
 const CONNECTOR_AUTH_METHOD_PROVIDER_REGISTRY: ConnectorAuthMethodProviderRegistry =
   CONNECTOR_AUTH_METHOD_PROVIDERS;
 
-type ConnectorAuthCodeMethodClientRef = {
-  readonly [Type in AuthCodeGrantConnectorType]: {
-    readonly [Method in ConnectorAuthCodeGrantAuthMethodId<Type>]: {
-      readonly type: Type;
-      readonly authMethod: Method;
-      readonly authClient: ConnectorAuthClientForMethod<Type, Method>;
-    };
-  }[ConnectorAuthCodeGrantAuthMethodId<Type>];
-}[AuthCodeGrantConnectorType];
+type ConnectorAuthCodeMethodClientRef =
+  ConnectorAuthMethodClientRefByGrantKind<"auth-code">;
 
-type ConnectorDeviceAuthMethodClientRef = {
-  readonly [Type in DeviceAuthGrantConnectorType]: {
-    readonly [Method in ConnectorDeviceAuthGrantAuthMethodId<Type>]: {
-      readonly type: Type;
-      readonly authMethod: Method;
-      readonly authClient: ConnectorAuthClientForMethod<Type, Method>;
-    };
-  }[ConnectorDeviceAuthGrantAuthMethodId<Type>];
-}[DeviceAuthGrantConnectorType];
+type ConnectorDeviceAuthMethodClientRef =
+  ConnectorAuthMethodClientRefByGrantKind<"device-auth">;
 
-type ConnectorRefreshTokenAccessMethodClientRef = {
-  readonly [Type in RefreshTokenAccessConnectorType]: {
-    readonly [Method in ConnectorAuthMethodIdsByAccessKind<
-      Type,
-      "refresh-token"
-    >]: {
-      readonly type: Type;
-      readonly authMethod: Method;
-      readonly authClient: ConnectorAuthClientForMethod<Type, Method>;
-    };
-  }[ConnectorAuthMethodIdsByAccessKind<Type, "refresh-token">];
-}[RefreshTokenAccessConnectorType];
+type ConnectorRefreshTokenAccessMethodClientRef =
+  ConnectorAuthMethodClientRefByAccessKind<"refresh-token">;
 
 type ConnectorAuthCodeAuthorizationUrlArgs =
   ConnectorAuthCodeMethodClientRef & {

--- a/turbo/packages/connectors/src/auth-providers/connector-auth.ts
+++ b/turbo/packages/connectors/src/auth-providers/connector-auth.ts
@@ -27,17 +27,12 @@ import type {
   AuthCodeConnectorAuthProvider,
   DeviceAuthConnectorAuthProvider,
   RefreshTokenAccessProvider,
+  TokenRevokeProvider,
 } from "./types";
 import {
   type AuthUrlResult,
-  type OAuthAuthorizeArgs,
-  type OAuthDeviceAuthPollArgs,
   type OAuthDeviceAuthPollResult,
-  type OAuthDeviceAuthStartArgs,
   type OAuthDeviceAuthStartResult,
-  type OAuthExchangeArgs,
-  type ConnectorAuthProviderRevokeArgs,
-  type OAuthRefreshArgs,
   type OAuthRefreshResult,
   type OAuthTokenResult,
 } from "./oauth/types";
@@ -99,13 +94,8 @@ import {
 
 export type {
   AuthUrlResult,
-  OAuthDeviceAuthPollArgs,
   OAuthDeviceAuthPollResult,
-  OAuthDeviceAuthStartArgs,
   OAuthDeviceAuthStartResult,
-  OAuthAuthorizeArgs,
-  OAuthExchangeArgs,
-  OAuthRefreshArgs,
   OAuthRefreshResult,
   OAuthTokenResult,
 };
@@ -133,17 +123,6 @@ type ConnectorDeviceAuthGrantProvider<
     ConnectorDeviceAuthGrantAuthMethodId<Type>,
 > = DeviceAuthConnectorAuthProvider<Type, Method>["grant"];
 
-interface ConnectorTokenRevokeProvider<
-  Type extends TokenRevokeConnectorType = TokenRevokeConnectorType,
-  Method extends ConnectorAuthMethodIdsByRevokeKind<Type, "token-revoke"> =
-    ConnectorAuthMethodIdsByRevokeKind<Type, "token-revoke">,
-> {
-  readonly kind: "token-revoke";
-  revokeToken(
-    args: ConnectorAuthProviderRevokeArgs<Type, Method>,
-  ): Promise<void>;
-}
-
 type ConnectorAuthCodeProviderEntry<
   Type extends AuthCodeGrantConnectorType,
   Method extends ConnectorAuthCodeGrantAuthMethodId<Type>,
@@ -169,7 +148,7 @@ type ConnectorTokenRevokeProviderEntry<
   Type extends TokenRevokeConnectorType,
   Method extends ConnectorAuthMethodIdsByRevokeKind<Type, "token-revoke">,
 > = {
-  readonly revoke: ConnectorTokenRevokeProvider<Type, Method>;
+  readonly revoke: TokenRevokeProvider<Type, Method>;
 };
 
 type ConnectorAuthCodeGrantProviderEntries<Type extends ConnectorType> = {
@@ -261,7 +240,7 @@ function authCodeTokenRevokeProviderEntry<
     ConnectorAuthMethodIdsByRevokeKind<Type, "token-revoke">,
 >(
   provider: AuthCodeConnectorAuthProvider<Type, Method> & {
-    readonly revoke: ConnectorTokenRevokeProvider<Type, Method>;
+    readonly revoke: TokenRevokeProvider<Type, Method>;
   },
 ): ConnectorAuthCodeProviderEntry<Type, Method> &
   ConnectorTokenRevokeProviderEntry<Type, Method> {
@@ -278,7 +257,7 @@ function authCodeRefreshTokenRevokeProviderEntry<
 >(
   provider: AuthCodeConnectorAuthProvider<Type, Method> & {
     readonly access: RefreshTokenAccessProvider<Type, Method>;
-    readonly revoke: ConnectorTokenRevokeProvider<Type, Method>;
+    readonly revoke: TokenRevokeProvider<Type, Method>;
   },
 ): ConnectorAuthCodeProviderEntry<Type, Method> &
   ConnectorRefreshTokenAccessProviderEntry<Type, Method> &
@@ -366,7 +345,7 @@ async function revokeTokenRevokeConnectorAccessToken<
 function connectorTokenRevokeProviderFor<
   T extends TokenRevokeConnectorType,
   Method extends ConnectorAuthMethodIdsByRevokeKind<T, "token-revoke">,
->(type: T, authMethod: Method): ConnectorTokenRevokeProvider<T, Method> {
+>(type: T, authMethod: Method): TokenRevokeProvider<T, Method> {
   const entry = CONNECTOR_AUTH_METHOD_PROVIDER_REGISTRY[type][
     authMethod
   ] as unknown as ConnectorTokenRevokeProviderEntry<T, Method>;

--- a/turbo/packages/connectors/src/auth-providers/connector-auth.ts
+++ b/turbo/packages/connectors/src/auth-providers/connector-auth.ts
@@ -298,10 +298,9 @@ function connectorRefreshTokenAccessProviderFor<
   T extends RefreshTokenAccessConnectorType,
   Method extends ConnectorAuthMethodIdsByAccessKind<T, "refresh-token">,
 >(type: T, authMethod: Method): RefreshTokenAccessProvider<T, Method> {
-  const entry = CONNECTOR_AUTH_METHOD_PROVIDER_REGISTRY[type][
-    authMethod
-  ] as ConnectorRefreshTokenAccessProviderEntry<T, Method>;
-  return entry.access;
+  const entries: ConnectorRefreshTokenAccessProviderEntries<T> =
+    CONNECTOR_AUTH_METHOD_PROVIDER_REGISTRY[type];
+  return entries[authMethod].access;
 }
 
 function connectorAuthCodeGrantProviderFor<
@@ -349,10 +348,9 @@ function connectorTokenRevokeProviderFor<
   T extends TokenRevokeConnectorType,
   Method extends ConnectorAuthMethodIdsByRevokeKind<T, "token-revoke">,
 >(type: T, authMethod: Method): TokenRevokeProvider<T, Method> {
-  const entry = CONNECTOR_AUTH_METHOD_PROVIDER_REGISTRY[type][
-    authMethod
-  ] as unknown as ConnectorTokenRevokeProviderEntry<T, Method>;
-  return entry.revoke;
+  const entries: ConnectorTokenRevokeProviderEntries<T> =
+    CONNECTOR_AUTH_METHOD_PROVIDER_REGISTRY[type];
+  return entries[authMethod].revoke;
 }
 
 const CONNECTOR_AUTH_METHOD_PROVIDERS = {

--- a/turbo/packages/connectors/src/auth-providers/connector-auth.ts
+++ b/turbo/packages/connectors/src/auth-providers/connector-auth.ts
@@ -1,8 +1,7 @@
 import {
   type ConnectorAuthCodeGrantAuthMethodId,
   type AuthCodeGrantConnectorType,
-  type ConnectorAuthCodeGrantConfig,
-  type ConnectorDeviceAuthGrantConfig,
+  connectorAuthMethodIdSchema,
   type ConnectorType,
   type ConnectorAuthProviderType,
   type ConnectorDeviceAuthGrantAuthMethodId,
@@ -14,15 +13,14 @@ import {
   type TokenRevokeConnectorType,
 } from "@vm0/connectors/connectors";
 import {
-  connectorAuthMethodSupportsTokenRevoke,
+  connectorAuthMethodRefHasRevokeKind,
   getConnectorAuthMethod,
   getConnectorAuthMethodAuthCodeGrantConfig,
   getConnectorAuthMethodDeviceAuthGrantConfig,
   getConnectorAuthMethodGrantScopes,
   isStaticConfidentialConnectorAuthClient,
-  isStaticConnectorAuthClient,
   resolveConnectorAuthClientForMethod,
-  type ConnectorAuthClient,
+  type ConnectorAuthClientForMethod,
   type ConnectorEnvReader,
 } from "@vm0/connectors/connector-utils";
 import type {
@@ -32,17 +30,13 @@ import type {
 } from "./types";
 import {
   type AuthUrlResult,
-  type ConnectorAuthCodeAuthorizeArgs,
-  type ConnectorDeviceAuthorizationPollArgs,
-  type ConnectorDeviceAuthorizationStartArgs,
-  type ConnectorAuthCodeExchangeArgs,
-  type ConnectorAuthProviderRefreshArgs,
   type OAuthAuthorizeArgs,
   type OAuthDeviceAuthPollArgs,
   type OAuthDeviceAuthPollResult,
   type OAuthDeviceAuthStartArgs,
   type OAuthDeviceAuthStartResult,
   type OAuthExchangeArgs,
+  type ConnectorAuthProviderRevokeArgs,
   type OAuthRefreshArgs,
   type OAuthRefreshResult,
   type OAuthTokenResult,
@@ -98,7 +92,10 @@ import {
   testOauthApiProvider,
   testOauthProvider,
 } from "./oauth/providers/test-oauth-provider";
-import { testOauthDeviceProvider } from "./oauth/providers/test-oauth-device-provider";
+import {
+  testOauthDeviceApiProvider,
+  testOauthDeviceProvider,
+} from "./oauth/providers/test-oauth-device-provider";
 
 export type {
   AuthUrlResult,
@@ -119,85 +116,111 @@ export type ConnectorAuthProviderAccessTokenRevokeResult =
   | { readonly status: "revoked" }
   | { readonly status: "unsupported" };
 
+type ConnectorProviderBackedType =
+  | ConnectorAuthProviderType
+  | RefreshTokenAccessConnectorType
+  | TokenRevokeConnectorType;
+
+type ConnectorAuthCodeGrantProvider<
+  Type extends AuthCodeGrantConnectorType,
+  Method extends ConnectorAuthCodeGrantAuthMethodId<Type> =
+    ConnectorAuthCodeGrantAuthMethodId<Type>,
+> = AuthCodeConnectorAuthProvider<Type, Method>["grant"];
+
+type ConnectorDeviceAuthGrantProvider<
+  Type extends DeviceAuthGrantConnectorType,
+  Method extends ConnectorDeviceAuthGrantAuthMethodId<Type> =
+    ConnectorDeviceAuthGrantAuthMethodId<Type>,
+> = DeviceAuthConnectorAuthProvider<Type, Method>["grant"];
+
+interface ConnectorTokenRevokeProvider<
+  Type extends TokenRevokeConnectorType = TokenRevokeConnectorType,
+  Method extends ConnectorAuthMethodIdsByRevokeKind<Type, "token-revoke"> =
+    ConnectorAuthMethodIdsByRevokeKind<Type, "token-revoke">,
+> {
+  readonly kind: "token-revoke";
+  revokeToken(
+    args: ConnectorAuthProviderRevokeArgs<Type, Method>,
+  ): Promise<void>;
+}
+
+type ConnectorAuthCodeProviderEntry<
+  Type extends AuthCodeGrantConnectorType,
+  Method extends ConnectorAuthCodeGrantAuthMethodId<Type>,
+> = {
+  readonly grant: ConnectorAuthCodeGrantProvider<Type, Method>;
+};
+
+type ConnectorDeviceAuthProviderEntry<
+  Type extends DeviceAuthGrantConnectorType,
+  Method extends ConnectorDeviceAuthGrantAuthMethodId<Type>,
+> = {
+  readonly grant: ConnectorDeviceAuthGrantProvider<Type, Method>;
+};
+
+type ConnectorRefreshTokenAccessProviderEntry<
+  Type extends RefreshTokenAccessConnectorType,
+  Method extends ConnectorAuthMethodIdsByAccessKind<Type, "refresh-token">,
+> = {
+  readonly access: RefreshTokenAccessProvider<Type, Method>;
+};
+
+type ConnectorTokenRevokeProviderEntry<
+  Type extends TokenRevokeConnectorType,
+  Method extends ConnectorAuthMethodIdsByRevokeKind<Type, "token-revoke">,
+> = {
+  readonly revoke: ConnectorTokenRevokeProvider<Type, Method>;
+};
+
 type ConnectorAuthCodeGrantProviderEntries<Type extends ConnectorType> = {
   readonly [Method in ConnectorAuthMethodIdsByGrantKind<
     Type,
     "auth-code"
-  >]: ConnectorAuthMethodProviderEntry<Type> & {
-    readonly grant: ConnectorAuthCodeGrantProvider<
-      Type & AuthCodeGrantConnectorType
-    >;
-  };
+  >]: ConnectorAuthCodeProviderEntry<
+    Type & AuthCodeGrantConnectorType,
+    Method &
+      ConnectorAuthCodeGrantAuthMethodId<Type & AuthCodeGrantConnectorType>
+  >;
 };
 
 type ConnectorDeviceAuthGrantProviderEntries<Type extends ConnectorType> = {
   readonly [Method in ConnectorAuthMethodIdsByGrantKind<
     Type,
     "device-auth"
-  >]: ConnectorAuthMethodProviderEntry<Type> & {
-    readonly grant: ConnectorDeviceAuthGrantProvider<
-      Type & DeviceAuthGrantConnectorType
-    >;
-  };
+  >]: ConnectorDeviceAuthProviderEntry<
+    Type & DeviceAuthGrantConnectorType,
+    Method &
+      ConnectorDeviceAuthGrantAuthMethodId<Type & DeviceAuthGrantConnectorType>
+  >;
 };
 
 type ConnectorRefreshTokenAccessProviderEntries<Type extends ConnectorType> = {
   readonly [Method in ConnectorAuthMethodIdsByAccessKind<
     Type,
     "refresh-token"
-  >]: ConnectorAuthMethodProviderEntry<Type> & {
-    readonly access: RefreshTokenAccessProvider<
-      Type & RefreshTokenAccessConnectorType
-    >;
-  };
+  >]: ConnectorRefreshTokenAccessProviderEntry<
+    Type & RefreshTokenAccessConnectorType,
+    Method &
+      ConnectorAuthMethodIdsByAccessKind<
+        Type & RefreshTokenAccessConnectorType,
+        "refresh-token"
+      >
+  >;
 };
 
 type ConnectorTokenRevokeProviderEntries<Type extends ConnectorType> = {
   readonly [Method in ConnectorAuthMethodIdsByRevokeKind<
     Type,
     "token-revoke"
-  >]: ConnectorAuthMethodProviderEntry<Type> & {
-    readonly revoke: ConnectorTokenRevokeProvider;
-  };
-};
-
-export interface ConnectorAuthProviderClientArgs {
-  readonly clientId?: string;
-  readonly clientSecret?: string;
-}
-
-type ConnectorProviderBackedType =
-  | ConnectorAuthProviderType
-  | RefreshTokenAccessConnectorType
-  | TokenRevokeConnectorType;
-
-type ConnectorAuthCodeGrantProvider<Type extends AuthCodeGrantConnectorType> =
-  AuthCodeConnectorAuthProvider<Type>["grant"];
-
-type ConnectorDeviceAuthGrantProvider<
-  Type extends DeviceAuthGrantConnectorType,
-> = DeviceAuthConnectorAuthProvider<Type>["grant"];
-
-type ConnectorAuthMethodGrantProvider<Type extends ConnectorType> =
-  | ConnectorAuthCodeGrantProvider<Type & AuthCodeGrantConnectorType>
-  | ConnectorDeviceAuthGrantProvider<Type & DeviceAuthGrantConnectorType>;
-
-interface ConnectorTokenRevokeProvider {
-  readonly kind: "token-revoke";
-  revokeToken(args: {
-    readonly clientId: string;
-    readonly clientSecret: string;
-    readonly accessToken: string;
-  }): Promise<void>;
-}
-
-interface ConnectorAuthMethodProviderEntry<Type extends ConnectorType> {
-  readonly grant?: ConnectorAuthMethodGrantProvider<Type>;
-  readonly access?: RefreshTokenAccessProvider<
-    Type & RefreshTokenAccessConnectorType
+  >]: ConnectorTokenRevokeProviderEntry<
+    Type & TokenRevokeConnectorType,
+    Method &
+      ConnectorAuthMethodIdsByRevokeKind<
+        Type & TokenRevokeConnectorType,
+        "token-revoke"
+      >
   >;
-  readonly revoke?: ConnectorTokenRevokeProvider;
-}
+};
 
 type ConnectorProviderBackedAuthMethodEntries<
   Type extends ConnectorProviderBackedType,
@@ -210,35 +233,38 @@ type ConnectorAuthMethodProviderRegistry = {
   readonly [Type in ConnectorProviderBackedType]: ConnectorProviderBackedAuthMethodEntries<Type>;
 };
 
-function authCodeProviderEntry<Type extends AuthCodeGrantConnectorType>(
-  provider: AuthCodeConnectorAuthProvider<Type>,
-): ConnectorAuthMethodProviderEntry<Type> & {
-  readonly grant: ConnectorAuthCodeGrantProvider<Type>;
-} {
+function authCodeProviderEntry<
+  Type extends AuthCodeGrantConnectorType,
+  Method extends ConnectorAuthCodeGrantAuthMethodId<Type>,
+>(
+  provider: AuthCodeConnectorAuthProvider<Type, Method>,
+): ConnectorAuthCodeProviderEntry<Type, Method> {
   return { grant: provider.grant };
 }
 
 function authCodeRefreshProviderEntry<
   Type extends AuthCodeGrantConnectorType & RefreshTokenAccessConnectorType,
+  Method extends ConnectorAuthCodeGrantAuthMethodId<Type> &
+    ConnectorAuthMethodIdsByAccessKind<Type, "refresh-token">,
 >(
-  provider: AuthCodeConnectorAuthProvider<Type> & {
-    readonly access: RefreshTokenAccessProvider<Type>;
+  provider: AuthCodeConnectorAuthProvider<Type, Method> & {
+    readonly access: RefreshTokenAccessProvider<Type, Method>;
   },
-): ConnectorAuthMethodProviderEntry<Type> & {
-  readonly grant: ConnectorAuthCodeGrantProvider<Type>;
-  readonly access: RefreshTokenAccessProvider<Type>;
-} {
+): ConnectorAuthCodeProviderEntry<Type, Method> &
+  ConnectorRefreshTokenAccessProviderEntry<Type, Method> {
   return { grant: provider.grant, access: provider.access };
 }
 
 function authCodeTokenRevokeProviderEntry<
   Type extends AuthCodeGrantConnectorType & TokenRevokeConnectorType,
+  Method extends ConnectorAuthCodeGrantAuthMethodId<Type> &
+    ConnectorAuthMethodIdsByRevokeKind<Type, "token-revoke">,
 >(
-  provider: AuthCodeConnectorAuthProvider<Type>,
-): ConnectorAuthMethodProviderEntry<Type> & {
-  readonly grant: ConnectorAuthCodeGrantProvider<Type>;
-  readonly revoke: ConnectorTokenRevokeProvider;
-} {
+  provider: AuthCodeConnectorAuthProvider<Type, Method> & {
+    readonly revoke: ConnectorTokenRevokeProvider<Type, Method>;
+  },
+): ConnectorAuthCodeProviderEntry<Type, Method> &
+  ConnectorTokenRevokeProviderEntry<Type, Method> {
   return { grant: provider.grant, revoke: provider.revoke };
 }
 
@@ -246,15 +272,17 @@ function authCodeRefreshTokenRevokeProviderEntry<
   Type extends AuthCodeGrantConnectorType &
     RefreshTokenAccessConnectorType &
     TokenRevokeConnectorType,
+  Method extends ConnectorAuthCodeGrantAuthMethodId<Type> &
+    ConnectorAuthMethodIdsByAccessKind<Type, "refresh-token"> &
+    ConnectorAuthMethodIdsByRevokeKind<Type, "token-revoke">,
 >(
-  provider: AuthCodeConnectorAuthProvider<Type> & {
-    readonly access: RefreshTokenAccessProvider<Type>;
+  provider: AuthCodeConnectorAuthProvider<Type, Method> & {
+    readonly access: RefreshTokenAccessProvider<Type, Method>;
+    readonly revoke: ConnectorTokenRevokeProvider<Type, Method>;
   },
-): ConnectorAuthMethodProviderEntry<Type> & {
-  readonly grant: ConnectorAuthCodeGrantProvider<Type>;
-  readonly access: RefreshTokenAccessProvider<Type>;
-  readonly revoke: ConnectorTokenRevokeProvider;
-} {
+): ConnectorAuthCodeProviderEntry<Type, Method> &
+  ConnectorRefreshTokenAccessProviderEntry<Type, Method> &
+  ConnectorTokenRevokeProviderEntry<Type, Method> {
   return {
     grant: provider.grant,
     access: provider.access,
@@ -262,143 +290,62 @@ function authCodeRefreshTokenRevokeProviderEntry<
   };
 }
 
-function deviceAuthProviderEntry<Type extends DeviceAuthGrantConnectorType>(
-  provider: DeviceAuthConnectorAuthProvider<Type>,
-): ConnectorAuthMethodProviderEntry<Type> & {
-  readonly grant: ConnectorDeviceAuthGrantProvider<Type>;
-} {
+function deviceAuthProviderEntry<
+  Type extends DeviceAuthGrantConnectorType,
+  Method extends ConnectorDeviceAuthGrantAuthMethodId<Type>,
+>(
+  provider: DeviceAuthConnectorAuthProvider<Type, Method>,
+): ConnectorDeviceAuthProviderEntry<Type, Method> {
   return { grant: provider.grant };
 }
 
 function deviceAuthRefreshProviderEntry<
   Type extends DeviceAuthGrantConnectorType & RefreshTokenAccessConnectorType,
+  Method extends ConnectorDeviceAuthGrantAuthMethodId<Type> &
+    ConnectorAuthMethodIdsByAccessKind<Type, "refresh-token">,
 >(
-  provider: DeviceAuthConnectorAuthProvider<Type> & {
-    readonly access: RefreshTokenAccessProvider<Type>;
+  provider: DeviceAuthConnectorAuthProvider<Type, Method> & {
+    readonly access: RefreshTokenAccessProvider<Type, Method>;
   },
-): ConnectorAuthMethodProviderEntry<Type> & {
-  readonly grant: ConnectorDeviceAuthGrantProvider<Type>;
-  readonly access: RefreshTokenAccessProvider<Type>;
-} {
+): ConnectorDeviceAuthProviderEntry<Type, Method> &
+  ConnectorRefreshTokenAccessProviderEntry<Type, Method> {
   return { grant: provider.grant, access: provider.access };
 }
 
 function connectorRefreshTokenAccessProviderFor<
   T extends RefreshTokenAccessConnectorType,
->(type: T, authMethod: string): RefreshTokenAccessProvider<T> | undefined {
-  const provider = connectorAuthMethodProviderEntryFor(type, authMethod);
-  if (provider?.access?.kind === "refresh-token") {
-    return provider.access;
-  }
-  return undefined;
+  Method extends ConnectorAuthMethodIdsByAccessKind<T, "refresh-token">,
+>(type: T, authMethod: Method): RefreshTokenAccessProvider<T, Method> {
+  const entry = CONNECTOR_AUTH_METHOD_PROVIDER_REGISTRY[type][
+    authMethod
+  ] as ConnectorRefreshTokenAccessProviderEntry<T, Method>;
+  return entry.access;
 }
 
 function connectorAuthCodeGrantProviderFor<
   T extends AuthCodeGrantConnectorType,
->(
-  type: T,
-  authMethod: ConnectorAuthCodeGrantAuthMethodId<T>,
-): ConnectorAuthCodeGrantProvider<T> {
+  Method extends ConnectorAuthCodeGrantAuthMethodId<T>,
+>(type: T, authMethod: Method): ConnectorAuthCodeGrantProvider<T, Method> {
   return CONNECTOR_AUTH_METHOD_PROVIDER_REGISTRY[type][authMethod].grant;
 }
 
 function connectorDeviceAuthGrantProviderFor<
   T extends DeviceAuthGrantConnectorType,
->(
-  type: T,
-  authMethod: ConnectorDeviceAuthGrantAuthMethodId<T>,
-): ConnectorDeviceAuthGrantProvider<T> {
+  Method extends ConnectorDeviceAuthGrantAuthMethodId<T>,
+>(type: T, authMethod: Method): ConnectorDeviceAuthGrantProvider<T, Method> {
   return CONNECTOR_AUTH_METHOD_PROVIDER_REGISTRY[type][authMethod].grant;
 }
 
-function connectorAuthProviderClientArgs(
-  authClient: ConnectorAuthClient,
-): ConnectorAuthProviderClientArgs {
-  if (!isStaticConnectorAuthClient(authClient)) {
-    return {};
-  }
-  if (isStaticConfidentialConnectorAuthClient(authClient)) {
-    return {
-      clientId: authClient.clientId,
-      clientSecret: authClient.clientSecret,
-    };
-  }
-  return { clientId: authClient.clientId };
-}
-
-function connectorAuthCodeAuthorizeProviderArgs<
-  T extends AuthCodeGrantConnectorType,
->(
-  args: OAuthAuthorizeArgs & {
-    readonly authCodeGrant: ConnectorAuthCodeGrantConfig;
-  },
-): ConnectorAuthCodeAuthorizeArgs<T> {
-  // The runtime resolver already chose the client from the selected method's
-  // config; TypeScript cannot connect that resolved value back to the
-  // method-config conditional credential fields.
-  return args as ConnectorAuthCodeAuthorizeArgs<T>;
-}
-
-function connectorAuthCodeExchangeProviderArgs<
-  T extends AuthCodeGrantConnectorType,
->(
-  args: OAuthExchangeArgs & {
-    readonly authCodeGrant: ConnectorAuthCodeGrantConfig;
-  },
-): ConnectorAuthCodeExchangeArgs<T> {
-  // See connectorAuthCodeAuthorizeProviderArgs.
-  return args as ConnectorAuthCodeExchangeArgs<T>;
-}
-
-function connectorDeviceAuthorizationStartProviderArgs<
-  T extends DeviceAuthGrantConnectorType,
->(
-  args: OAuthDeviceAuthStartArgs & {
-    readonly deviceAuthGrant: ConnectorDeviceAuthGrantConfig;
-  },
-): ConnectorDeviceAuthorizationStartArgs<T> {
-  // See connectorAuthCodeAuthorizeProviderArgs.
-  return args as ConnectorDeviceAuthorizationStartArgs<T>;
-}
-
-function connectorDeviceAuthorizationPollProviderArgs<
-  T extends DeviceAuthGrantConnectorType,
->(
-  args: OAuthDeviceAuthPollArgs & {
-    readonly deviceAuthGrant: ConnectorDeviceAuthGrantConfig;
-  },
-): ConnectorDeviceAuthorizationPollArgs<T> {
-  // See connectorAuthCodeAuthorizeProviderArgs.
-  return args as ConnectorDeviceAuthorizationPollArgs<T>;
-}
-
-function connectorRefreshTokenProviderArgs<
-  T extends RefreshTokenAccessConnectorType,
->(
-  args: OAuthRefreshArgs & {
-    readonly tokenUrl: string;
-  },
-): ConnectorAuthProviderRefreshArgs<T> {
-  // See connectorAuthCodeAuthorizeProviderArgs.
-  return args as ConnectorAuthProviderRefreshArgs<T>;
-}
-
-export function getConnectorAuthProviderClientArgs(
-  authClient: ConnectorAuthClient,
-): ConnectorAuthProviderClientArgs {
-  return connectorAuthProviderClientArgs(authClient);
-}
-
-async function revokeTokenRevokeConnectorAccessToken(args: {
-  readonly type: TokenRevokeConnectorType;
-  readonly authMethod: string;
+async function revokeTokenRevokeConnectorAccessToken<
+  T extends TokenRevokeConnectorType,
+  Method extends ConnectorAuthMethodIdsByRevokeKind<T, "token-revoke">,
+>(args: {
+  readonly type: T;
+  readonly authMethod: Method;
   readonly readEnv: ConnectorEnvReader;
   readonly loadAccessToken: () => string | Promise<string>;
 }): Promise<ConnectorAuthProviderAccessTokenRevokeResult> {
   const revoke = connectorTokenRevokeProviderFor(args.type, args.authMethod);
-  if (!revoke) {
-    return { status: "unsupported" };
-  }
 
   const authClient = resolveConnectorAuthClientForMethod(
     args.type,
@@ -410,22 +357,20 @@ async function revokeTokenRevokeConnectorAccessToken(args: {
   }
 
   await revoke.revokeToken({
-    clientId: authClient.clientId,
-    clientSecret: authClient.clientSecret,
+    authClient,
     accessToken: await args.loadAccessToken(),
   });
   return { status: "revoked" };
 }
 
-function connectorTokenRevokeProviderFor<T extends TokenRevokeConnectorType>(
-  type: T,
-  authMethod: string,
-): ConnectorTokenRevokeProvider | undefined {
-  const provider = connectorAuthMethodProviderEntryFor(type, authMethod);
-  if (provider?.revoke?.kind === "token-revoke") {
-    return provider.revoke;
-  }
-  return undefined;
+function connectorTokenRevokeProviderFor<
+  T extends TokenRevokeConnectorType,
+  Method extends ConnectorAuthMethodIdsByRevokeKind<T, "token-revoke">,
+>(type: T, authMethod: Method): ConnectorTokenRevokeProvider<T, Method> {
+  const entry = CONNECTOR_AUTH_METHOD_PROVIDER_REGISTRY[type][
+    authMethod
+  ] as unknown as ConnectorTokenRevokeProviderEntry<T, Method>;
+  return entry.revoke;
 }
 
 const CONNECTOR_AUTH_METHOD_PROVIDERS = {
@@ -492,7 +437,7 @@ const CONNECTOR_AUTH_METHOD_PROVIDERS = {
   },
   "test-oauth-device": {
     oauth: deviceAuthProviderEntry(testOauthDeviceProvider),
-    api: deviceAuthProviderEntry(testOauthDeviceProvider),
+    api: deviceAuthProviderEntry(testOauthDeviceApiProvider),
   },
   todoist: { oauth: authCodeProviderEntry(todoistProvider) },
   vercel: { oauth: authCodeProviderEntry(vercelProvider) },
@@ -506,25 +451,87 @@ const CONNECTOR_AUTH_METHOD_PROVIDERS = {
 const CONNECTOR_AUTH_METHOD_PROVIDER_REGISTRY: ConnectorAuthMethodProviderRegistry =
   CONNECTOR_AUTH_METHOD_PROVIDERS;
 
-function connectorAuthMethodProviderEntryFor<
-  Type extends ConnectorProviderBackedType,
->(
-  type: Type,
-  authMethod: string,
-): ConnectorAuthMethodProviderEntry<Type> | undefined {
-  const providers: Readonly<
-    Record<string, ConnectorAuthMethodProviderEntry<Type>>
-  > = CONNECTOR_AUTH_METHOD_PROVIDER_REGISTRY[type];
-  return providers[authMethod];
-}
+type ConnectorAuthCodeMethodClientRef = {
+  readonly [Type in AuthCodeGrantConnectorType]: {
+    readonly [Method in ConnectorAuthCodeGrantAuthMethodId<Type>]: {
+      readonly type: Type;
+      readonly authMethod: Method;
+      readonly authClient: ConnectorAuthClientForMethod<Type, Method>;
+    };
+  }[ConnectorAuthCodeGrantAuthMethodId<Type>];
+}[AuthCodeGrantConnectorType];
 
+type ConnectorDeviceAuthMethodClientRef = {
+  readonly [Type in DeviceAuthGrantConnectorType]: {
+    readonly [Method in ConnectorDeviceAuthGrantAuthMethodId<Type>]: {
+      readonly type: Type;
+      readonly authMethod: Method;
+      readonly authClient: ConnectorAuthClientForMethod<Type, Method>;
+    };
+  }[ConnectorDeviceAuthGrantAuthMethodId<Type>];
+}[DeviceAuthGrantConnectorType];
+
+type ConnectorRefreshTokenAccessMethodClientRef = {
+  readonly [Type in RefreshTokenAccessConnectorType]: {
+    readonly [Method in ConnectorAuthMethodIdsByAccessKind<
+      Type,
+      "refresh-token"
+    >]: {
+      readonly type: Type;
+      readonly authMethod: Method;
+      readonly authClient: ConnectorAuthClientForMethod<Type, Method>;
+    };
+  }[ConnectorAuthMethodIdsByAccessKind<Type, "refresh-token">];
+}[RefreshTokenAccessConnectorType];
+
+type ConnectorAuthCodeAuthorizationUrlArgs =
+  ConnectorAuthCodeMethodClientRef & {
+    readonly redirectUri: string;
+    readonly state: string;
+  };
+
+type ConnectorAuthCodeExchangeCallArgs = ConnectorAuthCodeMethodClientRef & {
+  readonly code: string;
+  readonly redirectUri: string;
+  readonly state: string | undefined;
+  readonly codeVerifier: string | undefined;
+  readonly oauthContext: string | undefined;
+};
+
+type ConnectorDeviceAuthorizationStartCallArgs =
+  ConnectorDeviceAuthMethodClientRef;
+
+type ConnectorDeviceAuthorizationPollCallArgs =
+  ConnectorDeviceAuthMethodClientRef & {
+    readonly deviceCode: string;
+  };
+
+type ConnectorRefreshTokenAccessCallArgs =
+  ConnectorRefreshTokenAccessMethodClientRef & {
+    readonly refreshToken: string;
+    readonly signal: AbortSignal;
+  };
+
+export function buildConnectorAuthCodeAuthorizationUrl<
+  T extends AuthCodeGrantConnectorType,
+  Method extends ConnectorAuthCodeGrantAuthMethodId<T>,
+>(args: {
+  readonly type: T;
+  readonly authMethod: Method;
+  readonly authClient: ConnectorAuthClientForMethod<T, Method>;
+  readonly redirectUri: string;
+  readonly state: string;
+}): Promise<string | AuthUrlResult>;
+export function buildConnectorAuthCodeAuthorizationUrl(
+  args: ConnectorAuthCodeAuthorizationUrlArgs,
+): Promise<string | AuthUrlResult>;
 export async function buildConnectorAuthCodeAuthorizationUrl<
   T extends AuthCodeGrantConnectorType,
   Method extends ConnectorAuthCodeGrantAuthMethodId<T>,
 >(args: {
   readonly type: T;
   readonly authMethod: Method;
-  readonly authClient: ConnectorAuthClient;
+  readonly authClient: ConnectorAuthClientForMethod<T, Method>;
   readonly redirectUri: string;
   readonly state: string;
 }): Promise<string | AuthUrlResult> {
@@ -536,23 +543,37 @@ export async function buildConnectorAuthCodeAuthorizationUrl<
     args.type,
     args.authMethod,
   );
-  return await provider.buildAuthUrl(
-    connectorAuthCodeAuthorizeProviderArgs<T>({
-      ...connectorAuthProviderClientArgs(args.authClient),
-      authCodeGrant,
-      redirectUri: args.redirectUri,
-      state: args.state,
-    }),
-  );
+  return await provider.buildAuthUrl({
+    authClient: args.authClient,
+    authCodeGrant,
+    redirectUri: args.redirectUri,
+    state: args.state,
+  });
 }
 
+export function exchangeConnectorAuthCode<
+  T extends AuthCodeGrantConnectorType,
+  Method extends ConnectorAuthCodeGrantAuthMethodId<T>,
+>(args: {
+  readonly type: T;
+  readonly authMethod: Method;
+  readonly authClient: ConnectorAuthClientForMethod<T, Method>;
+  readonly code: string;
+  readonly redirectUri: string;
+  readonly state: string | undefined;
+  readonly codeVerifier: string | undefined;
+  readonly oauthContext: string | undefined;
+}): Promise<OAuthTokenResult>;
+export function exchangeConnectorAuthCode(
+  args: ConnectorAuthCodeExchangeCallArgs,
+): Promise<OAuthTokenResult>;
 export async function exchangeConnectorAuthCode<
   T extends AuthCodeGrantConnectorType,
   Method extends ConnectorAuthCodeGrantAuthMethodId<T>,
 >(args: {
   readonly type: T;
   readonly authMethod: Method;
-  readonly authClient: ConnectorAuthClient;
+  readonly authClient: ConnectorAuthClientForMethod<T, Method>;
   readonly code: string;
   readonly redirectUri: string;
   readonly state: string | undefined;
@@ -567,26 +588,35 @@ export async function exchangeConnectorAuthCode<
     args.type,
     args.authMethod,
   );
-  return await provider.exchangeCode(
-    connectorAuthCodeExchangeProviderArgs<T>({
-      ...connectorAuthProviderClientArgs(args.authClient),
-      authCodeGrant,
-      code: args.code,
-      redirectUri: args.redirectUri,
-      state: args.state,
-      codeVerifier: args.codeVerifier,
-      oauthContext: args.oauthContext,
-    }),
-  );
+  return await provider.exchangeCode({
+    authClient: args.authClient,
+    authCodeGrant,
+    code: args.code,
+    redirectUri: args.redirectUri,
+    state: args.state,
+    codeVerifier: args.codeVerifier,
+    oauthContext: args.oauthContext,
+  });
 }
 
+export function startConnectorDeviceAuthorization<
+  T extends DeviceAuthGrantConnectorType,
+  Method extends ConnectorDeviceAuthGrantAuthMethodId<T>,
+>(args: {
+  readonly type: T;
+  readonly authMethod: Method;
+  readonly authClient: ConnectorAuthClientForMethod<T, Method>;
+}): Promise<OAuthDeviceAuthStartResult>;
+export function startConnectorDeviceAuthorization(
+  args: ConnectorDeviceAuthorizationStartCallArgs,
+): Promise<OAuthDeviceAuthStartResult>;
 export async function startConnectorDeviceAuthorization<
   T extends DeviceAuthGrantConnectorType,
   Method extends ConnectorDeviceAuthGrantAuthMethodId<T>,
 >(args: {
   readonly type: T;
   readonly authMethod: Method;
-  readonly authClient: ConnectorAuthClient;
+  readonly authClient: ConnectorAuthClientForMethod<T, Method>;
 }): Promise<OAuthDeviceAuthStartResult> {
   const provider = connectorDeviceAuthGrantProviderFor(
     args.type,
@@ -596,22 +626,32 @@ export async function startConnectorDeviceAuthorization<
     args.type,
     args.authMethod,
   );
-  return await provider.startDeviceAuth(
-    connectorDeviceAuthorizationStartProviderArgs<T>({
-      ...connectorAuthProviderClientArgs(args.authClient),
-      deviceAuthGrant,
-      scopes: getConnectorAuthMethodGrantScopes(args.type, args.authMethod),
-    }),
-  );
+  return await provider.startDeviceAuth({
+    authClient: args.authClient,
+    deviceAuthGrant,
+    scopes: getConnectorAuthMethodGrantScopes(args.type, args.authMethod),
+  });
 }
 
+export function pollConnectorDeviceAuthorization<
+  T extends DeviceAuthGrantConnectorType,
+  Method extends ConnectorDeviceAuthGrantAuthMethodId<T>,
+>(args: {
+  readonly type: T;
+  readonly authMethod: Method;
+  readonly authClient: ConnectorAuthClientForMethod<T, Method>;
+  readonly deviceCode: string;
+}): Promise<OAuthDeviceAuthPollResult>;
+export function pollConnectorDeviceAuthorization(
+  args: ConnectorDeviceAuthorizationPollCallArgs,
+): Promise<OAuthDeviceAuthPollResult>;
 export async function pollConnectorDeviceAuthorization<
   T extends DeviceAuthGrantConnectorType,
   Method extends ConnectorDeviceAuthGrantAuthMethodId<T>,
 >(args: {
   readonly type: T;
   readonly authMethod: Method;
-  readonly authClient: ConnectorAuthClient;
+  readonly authClient: ConnectorAuthClientForMethod<T, Method>;
   readonly deviceCode: string;
 }): Promise<OAuthDeviceAuthPollResult> {
   const provider = connectorDeviceAuthGrantProviderFor(
@@ -622,21 +662,33 @@ export async function pollConnectorDeviceAuthorization<
     args.type,
     args.authMethod,
   );
-  return await provider.pollDeviceAuth(
-    connectorDeviceAuthorizationPollProviderArgs<T>({
-      ...connectorAuthProviderClientArgs(args.authClient),
-      deviceAuthGrant,
-      deviceCode: args.deviceCode,
-    }),
-  );
+  return await provider.pollDeviceAuth({
+    authClient: args.authClient,
+    deviceAuthGrant,
+    deviceCode: args.deviceCode,
+  });
 }
 
-export async function refreshConnectorAuthProviderAccessToken<
+export function refreshConnectorAuthProviderAccessToken<
   T extends RefreshTokenAccessConnectorType,
+  Method extends ConnectorAuthMethodIdsByAccessKind<T, "refresh-token">,
 >(args: {
   readonly type: T;
-  readonly authMethod: string;
-  readonly clientArgs: ConnectorAuthProviderClientArgs;
+  readonly authMethod: Method;
+  readonly authClient: ConnectorAuthClientForMethod<T, Method>;
+  readonly refreshToken: string;
+  readonly signal: AbortSignal;
+}): Promise<OAuthRefreshResult>;
+export function refreshConnectorAuthProviderAccessToken(
+  args: ConnectorRefreshTokenAccessCallArgs,
+): Promise<OAuthRefreshResult>;
+export async function refreshConnectorAuthProviderAccessToken<
+  T extends RefreshTokenAccessConnectorType,
+  Method extends ConnectorAuthMethodIdsByAccessKind<T, "refresh-token">,
+>(args: {
+  readonly type: T;
+  readonly authMethod: Method;
+  readonly authClient: ConnectorAuthClientForMethod<T, Method>;
   readonly refreshToken: string;
   readonly signal: AbortSignal;
 }): Promise<OAuthRefreshResult> {
@@ -650,36 +702,38 @@ export async function refreshConnectorAuthProviderAccessToken<
     args.type,
     args.authMethod,
   );
-  if (!access) {
-    throw new Error(
-      `${args.type} connector auth method ${args.authMethod} has no refresh-token access provider`,
-    );
-  }
-  return await access.refreshToken(
-    connectorRefreshTokenProviderArgs<T>({
-      ...args.clientArgs,
-      tokenUrl: method.access.tokenUrl,
-      refreshToken: args.refreshToken,
-      signal: args.signal,
-    }),
-  );
+  return await access.refreshToken({
+    authClient: args.authClient,
+    tokenUrl: method.access.tokenUrl,
+    refreshToken: args.refreshToken,
+    signal: args.signal,
+  });
 }
 
-export async function revokeConnectorAuthMethodAccessToken<
-  T extends ConnectorType,
->(args: {
-  readonly type: T;
+export async function revokeConnectorAuthMethodAccessToken(args: {
+  readonly type: ConnectorType;
   readonly authMethod: string;
   readonly readEnv: ConnectorEnvReader;
   readonly loadAccessToken: () => string | Promise<string>;
 }): Promise<ConnectorAuthProviderAccessTokenRevokeResult> {
-  if (!connectorAuthMethodSupportsTokenRevoke(args.type, args.authMethod)) {
+  const parsedAuthMethod = connectorAuthMethodIdSchema.safeParse(
+    args.authMethod,
+  );
+  if (!parsedAuthMethod.success) {
+    return { status: "unsupported" };
+  }
+
+  const authMethodRef = {
+    type: args.type,
+    authMethod: parsedAuthMethod.data,
+  };
+  if (!connectorAuthMethodRefHasRevokeKind(authMethodRef, "token-revoke")) {
     return { status: "unsupported" };
   }
 
   return await revokeTokenRevokeConnectorAccessToken({
-    type: args.type,
-    authMethod: args.authMethod,
+    type: authMethodRef.type,
+    authMethod: authMethodRef.authMethod,
     readEnv: args.readEnv,
     loadAccessToken: args.loadAccessToken,
   });

--- a/turbo/packages/connectors/src/auth-providers/connector-auth.ts
+++ b/turbo/packages/connectors/src/auth-providers/connector-auth.ts
@@ -13,6 +13,7 @@ import {
   type TokenRevokeConnectorType,
 } from "@vm0/connectors/connectors";
 import {
+  connectorAuthClientIdentityForMethod,
   connectorAuthMethodRefHasRevokeKind,
   getConnectorAuthMethod,
   getConnectorAuthMethodAuthCodeGrantConfig,
@@ -501,7 +502,7 @@ export async function buildConnectorAuthCodeAuthorizationUrl<
     args.authMethod,
   );
   return await provider.buildAuthUrl({
-    authClient: args.authClient,
+    authClient: connectorAuthClientIdentityForMethod(args.authClient),
     authCodeGrant,
     redirectUri: args.redirectUri,
     state: args.state,
@@ -584,7 +585,7 @@ export async function startConnectorDeviceAuthorization<
     args.authMethod,
   );
   return await provider.startDeviceAuth({
-    authClient: args.authClient,
+    authClient: connectorAuthClientIdentityForMethod(args.authClient),
     deviceAuthGrant,
     scopes: getConnectorAuthMethodGrantScopes(args.type, args.authMethod),
   });

--- a/turbo/packages/connectors/src/auth-providers/model-provider-auth.ts
+++ b/turbo/packages/connectors/src/auth-providers/model-provider-auth.ts
@@ -80,7 +80,7 @@ export async function refreshModelProviderOAuthToken(args: {
     case "refresh-token": {
       const authClient = access.resolveAuthClient(args.currentEnv);
       if (!authClient) {
-        throw new Error(`${args.providerKey} OAuth client not configured`);
+        throw new Error(`${args.providerKey} auth client not configured`);
       }
 
       return await access.refreshToken({

--- a/turbo/packages/connectors/src/auth-providers/model-provider-auth.ts
+++ b/turbo/packages/connectors/src/auth-providers/model-provider-auth.ts
@@ -59,7 +59,7 @@ export function isModelProviderOAuthRefreshConfigured(args: {
       return false;
 
     case "refresh-token":
-      return Boolean(access.getClientId(args.currentEnv));
+      return Boolean(access.resolveAuthClient(args.currentEnv));
   }
 }
 
@@ -78,14 +78,13 @@ export async function refreshModelProviderOAuthToken(args: {
       );
 
     case "refresh-token": {
-      const clientId = access.getClientId(args.currentEnv);
-      if (!clientId) {
-        throw new Error(`${args.providerKey} OAuth client ID not configured`);
+      const authClient = access.resolveAuthClient(args.currentEnv);
+      if (!authClient) {
+        throw new Error(`${args.providerKey} OAuth client not configured`);
       }
 
       return await access.refreshToken({
-        clientId,
-        clientSecret: access.getClientSecret(args.currentEnv),
+        authClient,
         refreshToken: args.refreshToken,
         signal: args.signal,
       });

--- a/turbo/packages/connectors/src/auth-providers/oauth/providers/__tests__/codex-oauth.test.ts
+++ b/turbo/packages/connectors/src/auth-providers/oauth/providers/__tests__/codex-oauth.test.ts
@@ -44,8 +44,7 @@ describe("connector/providers/codex-oauth", () => {
       server.use(handler);
 
       const result = await refreshChatgptToken(
-        "x",
-        "x",
+        CODEX_PUBLIC_CLIENT_ID,
         "old-rt",
         testRefreshSignal(),
       );
@@ -61,8 +60,7 @@ describe("connector/providers/codex-oauth", () => {
       server.use(handler);
 
       const result = await refreshChatgptToken(
-        "x",
-        "x",
+        CODEX_PUBLIC_CLIENT_ID,
         "old-rt",
         testRefreshSignal(),
       );
@@ -85,7 +83,11 @@ describe("connector/providers/codex-oauth", () => {
       server.use(handler);
 
       await expect(
-        refreshChatgptToken("x", "x", "old-rt", testRefreshSignal()),
+        refreshChatgptToken(
+          CODEX_PUBLIC_CLIENT_ID,
+          "old-rt",
+          testRefreshSignal(),
+        ),
       ).rejects.toMatchObject({
         name: "ChatgptRefreshError",
         code: "refresh_token_expired",
@@ -102,7 +104,11 @@ describe("connector/providers/codex-oauth", () => {
       server.use(handler);
 
       await expect(
-        refreshChatgptToken("x", "x", "old-rt", testRefreshSignal()),
+        refreshChatgptToken(
+          CODEX_PUBLIC_CLIENT_ID,
+          "old-rt",
+          testRefreshSignal(),
+        ),
       ).rejects.toMatchObject({
         name: "ChatgptRefreshError",
         code: "refresh_token_reused",
@@ -124,8 +130,7 @@ describe("connector/providers/codex-oauth", () => {
       server.use(handler);
 
       const error = await refreshChatgptToken(
-        "x",
-        "x",
+        CODEX_PUBLIC_CLIENT_ID,
         "old-rt",
         testRefreshSignal(),
       ).catch((e: unknown) => {
@@ -147,8 +152,7 @@ describe("connector/providers/codex-oauth", () => {
       server.use(handler);
 
       const error = await refreshChatgptToken(
-        "x",
-        "x",
+        CODEX_PUBLIC_CLIENT_ID,
         "old-rt",
         testRefreshSignal(),
       ).catch((e: unknown) => {
@@ -165,8 +169,7 @@ describe("connector/providers/codex-oauth", () => {
       server.use(handler);
 
       const error = await refreshChatgptToken(
-        "x",
-        "x",
+        CODEX_PUBLIC_CLIENT_ID,
         "old-rt",
         testRefreshSignal(),
       ).catch((e: unknown) => {
@@ -183,7 +186,11 @@ describe("connector/providers/codex-oauth", () => {
       server.use(handler);
 
       await expect(
-        refreshChatgptToken("x", "x", "old-rt", testRefreshSignal()),
+        refreshChatgptToken(
+          CODEX_PUBLIC_CLIENT_ID,
+          "old-rt",
+          testRefreshSignal(),
+        ),
       ).rejects.toThrow(/No access token in ChatGPT refresh response/);
     });
   });
@@ -203,14 +210,12 @@ describe("connector/providers/codex-oauth", () => {
       expect(codexOauthProvider.grant.kind).toBe("none");
     });
 
-    it("getClientId returns the Codex public client_id (used by refresh)", () => {
-      expect(getCodexRefreshAccess().getClientId({})).toBe(
-        CODEX_PUBLIC_CLIENT_ID,
-      );
-    });
-
-    it("getClientSecret returns undefined (PKCE-only)", () => {
-      expect(getCodexRefreshAccess().getClientSecret({})).toBeUndefined();
+    it("resolves the Codex public client for refresh", () => {
+      expect(getCodexRefreshAccess().resolveAuthClient({})).toStrictEqual({
+        clientRegistration: "static",
+        clientType: "public",
+        clientId: CODEX_PUBLIC_CLIENT_ID,
+      });
     });
 
     it("returns documented secret names", () => {

--- a/turbo/packages/connectors/src/auth-providers/oauth/providers/__tests__/google-ads.test.ts
+++ b/turbo/packages/connectors/src/auth-providers/oauth/providers/__tests__/google-ads.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from "vitest";
 import { HttpResponse, http } from "msw";
 import {
+  connectorAuthClientIdentity,
   getConnectorAuthMethodAuthCodeGrantConfig,
   resolveConnectorAuthClientForMethod,
   type StaticConfidentialConnectorAuthClient,
@@ -29,7 +30,7 @@ describe("connector/providers/google-ads", () => {
           "google-ads",
           "oauth",
         ),
-        authClient: testAuthClient,
+        authClient: connectorAuthClientIdentity(testAuthClient),
         redirectUri: "https://example.com/callback",
         state: "test-state",
       });

--- a/turbo/packages/connectors/src/auth-providers/oauth/providers/__tests__/google-ads.test.ts
+++ b/turbo/packages/connectors/src/auth-providers/oauth/providers/__tests__/google-ads.test.ts
@@ -3,12 +3,19 @@ import { HttpResponse, http } from "msw";
 import {
   getConnectorAuthMethodAuthCodeGrantConfig,
   resolveConnectorAuthClientForMethod,
+  type StaticConfidentialConnectorAuthClient,
 } from "../../../../connector-utils";
 import { googleAdsProvider } from "../google-ads-provider";
 import { server } from "./test-server";
 
 const TOKEN_URL = "https://oauth2.googleapis.com/token";
 const USER_INFO_URL = "https://www.googleapis.com/oauth2/v2/userinfo";
+const testAuthClient = {
+  clientRegistration: "static",
+  clientType: "confidential",
+  clientId: "test-client",
+  clientSecret: "test-client-secret",
+} satisfies StaticConfidentialConnectorAuthClient;
 
 function testRefreshSignal(): AbortSignal {
   return new AbortController().signal;
@@ -22,7 +29,7 @@ describe("connector/providers/google-ads", () => {
           "google-ads",
           "oauth",
         ),
-        clientId: "test-client",
+        authClient: testAuthClient,
         redirectUri: "https://example.com/callback",
         state: "test-state",
       });
@@ -106,8 +113,11 @@ describe("connector/providers/google-ads", () => {
           "google-ads",
           "oauth",
         ),
-        clientId: "client-id",
-        clientSecret: "client-secret",
+        authClient: {
+          ...testAuthClient,
+          clientId: "client-id",
+          clientSecret: "client-secret",
+        },
         code: "auth-code",
         redirectUri: "https://example.com/callback",
       });
@@ -143,8 +153,11 @@ describe("connector/providers/google-ads", () => {
       }
 
       const result = await access.refreshToken({
-        clientId: "client-id",
-        clientSecret: "client-secret",
+        authClient: {
+          ...testAuthClient,
+          clientId: "client-id",
+          clientSecret: "client-secret",
+        },
         refreshToken: "refresh-token",
         signal: testRefreshSignal(),
         tokenUrl: getConnectorAuthMethodAuthCodeGrantConfig(

--- a/turbo/packages/connectors/src/auth-providers/oauth/providers/__tests__/meta-ads.test.ts
+++ b/turbo/packages/connectors/src/auth-providers/oauth/providers/__tests__/meta-ads.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from "vitest";
 import { HttpResponse, http } from "msw";
 import {
+  connectorAuthClientIdentity,
   getConnectorAuthMethodAuthCodeGrantConfig,
   resolveConnectorAuthClientForMethod,
   type StaticConfidentialConnectorAuthClient,
@@ -162,7 +163,7 @@ describe("connector/providers/meta-ads", () => {
           "meta-ads",
           "oauth",
         ),
-        authClient: testAuthClient,
+        authClient: connectorAuthClientIdentity(testAuthClient),
         redirectUri: "https://example.com/callback",
         state: "test-state",
       });

--- a/turbo/packages/connectors/src/auth-providers/oauth/providers/__tests__/meta-ads.test.ts
+++ b/turbo/packages/connectors/src/auth-providers/oauth/providers/__tests__/meta-ads.test.ts
@@ -3,6 +3,7 @@ import { HttpResponse, http } from "msw";
 import {
   getConnectorAuthMethodAuthCodeGrantConfig,
   resolveConnectorAuthClientForMethod,
+  type StaticConfidentialConnectorAuthClient,
 } from "../../../../connector-utils";
 import {
   buildMetaAdsAuthorizationUrl,
@@ -14,6 +15,12 @@ import { server } from "./test-server";
 
 const TOKEN_URL = "https://graph.facebook.com/v22.0/oauth/access_token";
 const USER_URL = "https://graph.facebook.com/v22.0/me";
+const testAuthClient = {
+  clientRegistration: "static",
+  clientType: "confidential",
+  clientId: "test-client",
+  clientSecret: "test-client-secret",
+} satisfies StaticConfidentialConnectorAuthClient;
 
 function authCodeGrant() {
   return getConnectorAuthMethodAuthCodeGrantConfig("meta-ads", "oauth");
@@ -155,7 +162,7 @@ describe("connector/providers/meta-ads", () => {
           "meta-ads",
           "oauth",
         ),
-        clientId: "test-client",
+        authClient: testAuthClient,
         redirectUri: "https://example.com/callback",
         state: "test-state",
       });

--- a/turbo/packages/connectors/src/auth-providers/oauth/providers/ahrefs-provider.ts
+++ b/turbo/packages/connectors/src/auth-providers/oauth/providers/ahrefs-provider.ts
@@ -9,7 +9,7 @@ export const ahrefsProvider: AuthCodeConnectorAuthProvider<"ahrefs"> = {
   grant: {
     kind: "auth-code",
     buildAuthUrl: (args) => {
-      const { clientId } = args;
+      const { clientId } = args.authClient;
       return buildAhrefsAuthorizationUrl(
         args.authCodeGrant,
         clientId,
@@ -18,7 +18,7 @@ export const ahrefsProvider: AuthCodeConnectorAuthProvider<"ahrefs"> = {
       );
     },
     exchangeCode: async (args) => {
-      const { clientId, clientSecret } = args;
+      const { clientId, clientSecret } = args.authClient;
       const code = args.code;
       const redirectUri = args.redirectUri;
       const result = await exchangeAhrefsCode(
@@ -48,7 +48,7 @@ export const ahrefsProvider: AuthCodeConnectorAuthProvider<"ahrefs"> = {
       return "AHREFS_REFRESH_TOKEN";
     },
     refreshToken: (args) => {
-      const { clientId, clientSecret } = args;
+      const { clientId, clientSecret } = args.authClient;
       return refreshAhrefsToken(
         args.tokenUrl,
         clientId,

--- a/turbo/packages/connectors/src/auth-providers/oauth/providers/airtable-provider.ts
+++ b/turbo/packages/connectors/src/auth-providers/oauth/providers/airtable-provider.ts
@@ -9,7 +9,7 @@ export const airtableProvider: AuthCodeConnectorAuthProvider<"airtable"> = {
   grant: {
     kind: "auth-code",
     buildAuthUrl: (args) => {
-      const { clientId } = args;
+      const { clientId } = args.authClient;
       return buildAirtableAuthorizationUrl(
         args.authCodeGrant,
         clientId,
@@ -18,7 +18,7 @@ export const airtableProvider: AuthCodeConnectorAuthProvider<"airtable"> = {
       );
     },
     exchangeCode: async (args) => {
-      const { clientId, clientSecret } = args;
+      const { clientId, clientSecret } = args.authClient;
       const code = args.code;
       const redirectUri = args.redirectUri;
       const codeVerifier = args.codeVerifier;
@@ -50,7 +50,7 @@ export const airtableProvider: AuthCodeConnectorAuthProvider<"airtable"> = {
       return "AIRTABLE_REFRESH_TOKEN";
     },
     refreshToken: (args) => {
-      const { clientId, clientSecret } = args;
+      const { clientId, clientSecret } = args.authClient;
       return refreshAirtableToken(
         args.tokenUrl,
         clientId,

--- a/turbo/packages/connectors/src/auth-providers/oauth/providers/asana-provider.ts
+++ b/turbo/packages/connectors/src/auth-providers/oauth/providers/asana-provider.ts
@@ -9,11 +9,11 @@ export const asanaProvider: AuthCodeConnectorAuthProvider<"asana"> = {
   grant: {
     kind: "auth-code",
     buildAuthUrl: (args) => {
-      const { clientId } = args;
+      const { clientId } = args.authClient;
       return buildAsanaAuthorizationUrl(clientId, args.redirectUri, args.state);
     },
     exchangeCode: async (args) => {
-      const { clientId, clientSecret } = args;
+      const { clientId, clientSecret } = args.authClient;
       const code = args.code;
       const redirectUri = args.redirectUri;
       const result = await exchangeAsanaCode(
@@ -43,7 +43,7 @@ export const asanaProvider: AuthCodeConnectorAuthProvider<"asana"> = {
       return "ASANA_REFRESH_TOKEN";
     },
     refreshToken: (args) => {
-      const { clientId, clientSecret } = args;
+      const { clientId, clientSecret } = args.authClient;
       return refreshAsanaToken(
         args.tokenUrl,
         clientId,

--- a/turbo/packages/connectors/src/auth-providers/oauth/providers/base44-provider.ts
+++ b/turbo/packages/connectors/src/auth-providers/oauth/providers/base44-provider.ts
@@ -11,7 +11,7 @@ export const base44Provider: DeviceAuthConnectorAuthProvider<"base44"> = {
   grant: {
     kind: "device-auth",
     startDeviceAuth: async (args) => {
-      const { clientId } = args;
+      const { clientId } = args.authClient;
       return await startBase44DeviceAuth({
         clientId,
         deviceAuthGrant: args.deviceAuthGrant,
@@ -19,7 +19,7 @@ export const base44Provider: DeviceAuthConnectorAuthProvider<"base44"> = {
       });
     },
     pollDeviceAuth: async (args) => {
-      const { clientId } = args;
+      const { clientId } = args.authClient;
       return await pollBase44DeviceAuth({
         clientId,
         deviceAuthGrant: args.deviceAuthGrant,
@@ -36,7 +36,7 @@ export const base44Provider: DeviceAuthConnectorAuthProvider<"base44"> = {
       return BASE44_REFRESH_SECRET_NAME;
     },
     refreshToken: async (args) => {
-      const { clientId } = args;
+      const { clientId } = args.authClient;
       return await refreshBase44Token({
         clientId,
         tokenUrl: args.tokenUrl,

--- a/turbo/packages/connectors/src/auth-providers/oauth/providers/canva-provider.ts
+++ b/turbo/packages/connectors/src/auth-providers/oauth/providers/canva-provider.ts
@@ -9,7 +9,7 @@ export const canvaProvider: AuthCodeConnectorAuthProvider<"canva"> = {
   grant: {
     kind: "auth-code",
     buildAuthUrl: (args) => {
-      const { clientId } = args;
+      const { clientId } = args.authClient;
       return buildCanvaAuthorizationUrl(
         args.authCodeGrant,
         clientId,
@@ -18,7 +18,7 @@ export const canvaProvider: AuthCodeConnectorAuthProvider<"canva"> = {
       );
     },
     exchangeCode: async (args) => {
-      const { clientId, clientSecret } = args;
+      const { clientId, clientSecret } = args.authClient;
       const code = args.code;
       const redirectUri = args.redirectUri;
       const state = args.state;
@@ -55,7 +55,7 @@ export const canvaProvider: AuthCodeConnectorAuthProvider<"canva"> = {
       return "CANVA_REFRESH_TOKEN";
     },
     refreshToken: (args) => {
-      const { clientId, clientSecret } = args;
+      const { clientId, clientSecret } = args.authClient;
       return refreshCanvaToken(
         args.tokenUrl,
         clientId,

--- a/turbo/packages/connectors/src/auth-providers/oauth/providers/close-provider.ts
+++ b/turbo/packages/connectors/src/auth-providers/oauth/providers/close-provider.ts
@@ -9,11 +9,11 @@ export const closeProvider: AuthCodeConnectorAuthProvider<"close"> = {
   grant: {
     kind: "auth-code",
     buildAuthUrl: (args) => {
-      const { clientId } = args;
+      const { clientId } = args.authClient;
       return buildCloseAuthorizationUrl(clientId, args.redirectUri, args.state);
     },
     exchangeCode: async (args) => {
-      const { clientId, clientSecret } = args;
+      const { clientId, clientSecret } = args.authClient;
       const code = args.code;
       const redirectUri = args.redirectUri;
       const result = await exchangeCloseCode(
@@ -43,7 +43,7 @@ export const closeProvider: AuthCodeConnectorAuthProvider<"close"> = {
       return "CLOSE_REFRESH_TOKEN";
     },
     refreshToken: (args) => {
-      const { clientId, clientSecret } = args;
+      const { clientId, clientSecret } = args.authClient;
       return refreshCloseToken(
         args.tokenUrl,
         clientId,

--- a/turbo/packages/connectors/src/auth-providers/oauth/providers/codex-oauth-provider.ts
+++ b/turbo/packages/connectors/src/auth-providers/oauth/providers/codex-oauth-provider.ts
@@ -20,16 +20,16 @@ export const codexOauthProvider: ModelProviderAuthProvider = {
     kind: "refresh-token",
     getAccessSecretName: getChatgptSecretName,
     getRefreshSecretName: getChatgptRefreshSecretName,
-    getClientId: () => {
-      return CHATGPT_OAUTH_CLIENT_ID;
-    },
-    getClientSecret: () => {
-      return undefined;
+    resolveAuthClient: () => {
+      return {
+        clientRegistration: "static",
+        clientType: "public",
+        clientId: CHATGPT_OAUTH_CLIENT_ID,
+      };
     },
     refreshToken: (args) => {
       return refreshChatgptToken(
-        args.clientId ?? CHATGPT_OAUTH_CLIENT_ID,
-        args.clientSecret ?? "",
+        args.authClient.clientId,
         args.refreshToken,
         args.signal,
       );

--- a/turbo/packages/connectors/src/auth-providers/oauth/providers/codex-oauth.ts
+++ b/turbo/packages/connectors/src/auth-providers/oauth/providers/codex-oauth.ts
@@ -71,8 +71,7 @@ const refreshErrorBodySchema = z.object({
  * so the firewall pipeline can distinguish stale-token from transient errors.
  */
 export async function refreshChatgptToken(
-  _clientId: string,
-  _clientSecret: string,
+  clientId: string,
   refreshToken: string,
   signal: AbortSignal,
 ): Promise<ChatgptRefreshResult> {
@@ -81,7 +80,7 @@ export async function refreshChatgptToken(
     method: "POST",
     headers: { "Content-Type": "application/json" },
     body: JSON.stringify({
-      client_id: CHATGPT_OAUTH_CLIENT_ID,
+      client_id: clientId,
       grant_type: "refresh_token",
       refresh_token: refreshToken,
     }),

--- a/turbo/packages/connectors/src/auth-providers/oauth/providers/deel-provider.ts
+++ b/turbo/packages/connectors/src/auth-providers/oauth/providers/deel-provider.ts
@@ -9,7 +9,7 @@ export const deelProvider: AuthCodeConnectorAuthProvider<"deel"> = {
   grant: {
     kind: "auth-code",
     buildAuthUrl: (args) => {
-      const { clientId } = args;
+      const { clientId } = args.authClient;
       return buildDeelAuthorizationUrl(
         args.authCodeGrant,
         clientId,
@@ -18,7 +18,7 @@ export const deelProvider: AuthCodeConnectorAuthProvider<"deel"> = {
       );
     },
     exchangeCode: async (args) => {
-      const { clientId, clientSecret } = args;
+      const { clientId, clientSecret } = args.authClient;
       const code = args.code;
       const redirectUri = args.redirectUri;
       const state = args.state;
@@ -55,7 +55,7 @@ export const deelProvider: AuthCodeConnectorAuthProvider<"deel"> = {
       return "DEEL_REFRESH_TOKEN";
     },
     refreshToken: (args) => {
-      const { clientId, clientSecret } = args;
+      const { clientId, clientSecret } = args.authClient;
       return refreshDeelToken(
         args.tokenUrl,
         clientId,

--- a/turbo/packages/connectors/src/auth-providers/oauth/providers/docusign-provider.ts
+++ b/turbo/packages/connectors/src/auth-providers/oauth/providers/docusign-provider.ts
@@ -9,7 +9,7 @@ export const docusignProvider: AuthCodeConnectorAuthProvider<"docusign"> = {
   grant: {
     kind: "auth-code",
     buildAuthUrl: (args) => {
-      const { clientId } = args;
+      const { clientId } = args.authClient;
       return buildDocuSignAuthorizationUrl(
         args.authCodeGrant,
         clientId,
@@ -18,7 +18,7 @@ export const docusignProvider: AuthCodeConnectorAuthProvider<"docusign"> = {
       );
     },
     exchangeCode: async (args) => {
-      const { clientId, clientSecret } = args;
+      const { clientId, clientSecret } = args.authClient;
       const code = args.code;
       const redirectUri = args.redirectUri;
       const state = args.state;
@@ -55,7 +55,7 @@ export const docusignProvider: AuthCodeConnectorAuthProvider<"docusign"> = {
       return "DOCUSIGN_REFRESH_TOKEN";
     },
     refreshToken: (args) => {
-      const { clientId, clientSecret } = args;
+      const { clientId, clientSecret } = args.authClient;
       return refreshDocuSignToken(
         args.tokenUrl,
         clientId,

--- a/turbo/packages/connectors/src/auth-providers/oauth/providers/dropbox-provider.ts
+++ b/turbo/packages/connectors/src/auth-providers/oauth/providers/dropbox-provider.ts
@@ -9,7 +9,7 @@ export const dropboxProvider: AuthCodeConnectorAuthProvider<"dropbox"> = {
   grant: {
     kind: "auth-code",
     buildAuthUrl: (args) => {
-      const { clientId } = args;
+      const { clientId } = args.authClient;
       return buildDropboxAuthorizationUrl(
         args.authCodeGrant,
         clientId,
@@ -18,7 +18,7 @@ export const dropboxProvider: AuthCodeConnectorAuthProvider<"dropbox"> = {
       );
     },
     exchangeCode: async (args) => {
-      const { clientId, clientSecret } = args;
+      const { clientId, clientSecret } = args.authClient;
       const code = args.code;
       const redirectUri = args.redirectUri;
       const result = await exchangeDropboxCode(
@@ -48,7 +48,7 @@ export const dropboxProvider: AuthCodeConnectorAuthProvider<"dropbox"> = {
       return "DROPBOX_REFRESH_TOKEN";
     },
     refreshToken: (args) => {
-      const { clientId, clientSecret } = args;
+      const { clientId, clientSecret } = args.authClient;
       return refreshDropboxToken(
         args.tokenUrl,
         clientId,

--- a/turbo/packages/connectors/src/auth-providers/oauth/providers/figma-provider.ts
+++ b/turbo/packages/connectors/src/auth-providers/oauth/providers/figma-provider.ts
@@ -9,7 +9,7 @@ export const figmaProvider: AuthCodeConnectorAuthProvider<"figma"> = {
   grant: {
     kind: "auth-code",
     buildAuthUrl: (args) => {
-      const { clientId } = args;
+      const { clientId } = args.authClient;
       return buildFigmaAuthorizationUrl(
         args.authCodeGrant,
         clientId,
@@ -18,7 +18,7 @@ export const figmaProvider: AuthCodeConnectorAuthProvider<"figma"> = {
       );
     },
     exchangeCode: async (args) => {
-      const { clientId, clientSecret } = args;
+      const { clientId, clientSecret } = args.authClient;
       const code = args.code;
       const redirectUri = args.redirectUri;
       const result = await exchangeFigmaCode(
@@ -48,7 +48,7 @@ export const figmaProvider: AuthCodeConnectorAuthProvider<"figma"> = {
       return "FIGMA_REFRESH_TOKEN";
     },
     refreshToken: (args) => {
-      const { clientId, clientSecret } = args;
+      const { clientId, clientSecret } = args.authClient;
       return refreshFigmaToken(
         args.tokenUrl,
         clientId,

--- a/turbo/packages/connectors/src/auth-providers/oauth/providers/garmin-connect-provider.ts
+++ b/turbo/packages/connectors/src/auth-providers/oauth/providers/garmin-connect-provider.ts
@@ -10,7 +10,7 @@ export const garminConnectProvider: AuthCodeConnectorAuthProvider<"garmin-connec
     grant: {
       kind: "auth-code",
       buildAuthUrl: (args) => {
-        const { clientId } = args;
+        const { clientId } = args.authClient;
         return buildGarminConnectAuthorizationUrl(
           clientId,
           args.redirectUri,
@@ -18,7 +18,7 @@ export const garminConnectProvider: AuthCodeConnectorAuthProvider<"garmin-connec
         );
       },
       exchangeCode: async (args) => {
-        const { clientId, clientSecret } = args;
+        const { clientId, clientSecret } = args.authClient;
         const code = args.code;
         const state = args.state;
         if (!state) {
@@ -53,7 +53,7 @@ export const garminConnectProvider: AuthCodeConnectorAuthProvider<"garmin-connec
         return "GARMIN_CONNECT_REFRESH_TOKEN";
       },
       refreshToken: (args) => {
-        const { clientId, clientSecret } = args;
+        const { clientId, clientSecret } = args.authClient;
         return refreshGarminConnectToken(
           args.tokenUrl,
           clientId,

--- a/turbo/packages/connectors/src/auth-providers/oauth/providers/github-provider.ts
+++ b/turbo/packages/connectors/src/auth-providers/oauth/providers/github-provider.ts
@@ -10,7 +10,7 @@ export const githubProvider: AuthCodeConnectorAuthProvider<"github"> = {
   grant: {
     kind: "auth-code",
     buildAuthUrl: (args) => {
-      const { clientId } = args;
+      const { clientId } = args.authClient;
       return buildGitHubAuthorizationUrl(
         args.authCodeGrant,
         clientId,
@@ -19,7 +19,7 @@ export const githubProvider: AuthCodeConnectorAuthProvider<"github"> = {
       );
     },
     exchangeCode: async (args) => {
-      const { clientId, clientSecret } = args;
+      const { clientId, clientSecret } = args.authClient;
       const code = args.code;
       const redirectUri = args.redirectUri;
       const { accessToken, scopes } = await exchangeGitHubCode(
@@ -40,7 +40,7 @@ export const githubProvider: AuthCodeConnectorAuthProvider<"github"> = {
   revoke: {
     kind: "token-revoke",
     revokeToken: (args) => {
-      const { clientId, clientSecret } = args;
+      const { clientId, clientSecret } = args.authClient;
       return revokeGitHubGrant(clientId, clientSecret, args.accessToken);
     },
   },

--- a/turbo/packages/connectors/src/auth-providers/oauth/providers/gmail-provider.ts
+++ b/turbo/packages/connectors/src/auth-providers/oauth/providers/gmail-provider.ts
@@ -9,7 +9,7 @@ export const gmailProvider: AuthCodeConnectorAuthProvider<"gmail"> = {
   grant: {
     kind: "auth-code",
     buildAuthUrl: (args) => {
-      const { clientId } = args;
+      const { clientId } = args.authClient;
       return buildGmailAuthorizationUrl(
         args.authCodeGrant,
         clientId,
@@ -18,7 +18,7 @@ export const gmailProvider: AuthCodeConnectorAuthProvider<"gmail"> = {
       );
     },
     exchangeCode: async (args) => {
-      const { clientId, clientSecret } = args;
+      const { clientId, clientSecret } = args.authClient;
       const code = args.code;
       const redirectUri = args.redirectUri;
       const result = await exchangeGmailCode(
@@ -48,7 +48,7 @@ export const gmailProvider: AuthCodeConnectorAuthProvider<"gmail"> = {
       return "GMAIL_REFRESH_TOKEN";
     },
     refreshToken: (args) => {
-      const { clientId, clientSecret } = args;
+      const { clientId, clientSecret } = args.authClient;
       const refreshToken = args.refreshToken;
       return refreshGoogleToken(
         args.tokenUrl,

--- a/turbo/packages/connectors/src/auth-providers/oauth/providers/google-ads-provider.ts
+++ b/turbo/packages/connectors/src/auth-providers/oauth/providers/google-ads-provider.ts
@@ -8,7 +8,7 @@ export const googleAdsProvider: AuthCodeConnectorAuthProvider<"google-ads"> = {
   grant: {
     kind: "auth-code",
     buildAuthUrl: (args) => {
-      const { clientId } = args;
+      const { clientId } = args.authClient;
       const redirectUri = args.redirectUri;
       const state = args.state;
       return buildGoogleAuthorizationUrl(
@@ -20,7 +20,7 @@ export const googleAdsProvider: AuthCodeConnectorAuthProvider<"google-ads"> = {
       );
     },
     exchangeCode: async (args) => {
-      const { clientId, clientSecret } = args;
+      const { clientId, clientSecret } = args.authClient;
       const code = args.code;
       const redirectUri = args.redirectUri;
       const result = await exchangeGoogleOAuthCode(
@@ -53,7 +53,7 @@ export const googleAdsProvider: AuthCodeConnectorAuthProvider<"google-ads"> = {
       return "GOOGLE_ADS_REFRESH_TOKEN";
     },
     refreshToken: (args) => {
-      const { clientId, clientSecret } = args;
+      const { clientId, clientSecret } = args.authClient;
       const refreshToken = args.refreshToken;
       return refreshGoogleToken(
         args.tokenUrl,

--- a/turbo/packages/connectors/src/auth-providers/oauth/providers/google-calendar-provider.ts
+++ b/turbo/packages/connectors/src/auth-providers/oauth/providers/google-calendar-provider.ts
@@ -9,7 +9,7 @@ export const googleCalendarProvider: AuthCodeConnectorAuthProvider<"google-calen
     grant: {
       kind: "auth-code",
       buildAuthUrl: (args) => {
-        const { clientId } = args;
+        const { clientId } = args.authClient;
         const redirectUri = args.redirectUri;
         const state = args.state;
         return buildGoogleAuthorizationUrl(
@@ -21,7 +21,7 @@ export const googleCalendarProvider: AuthCodeConnectorAuthProvider<"google-calen
         );
       },
       exchangeCode: async (args) => {
-        const { clientId, clientSecret } = args;
+        const { clientId, clientSecret } = args.authClient;
         const code = args.code;
         const redirectUri = args.redirectUri;
         const result = await exchangeGoogleOAuthCode(
@@ -54,7 +54,7 @@ export const googleCalendarProvider: AuthCodeConnectorAuthProvider<"google-calen
         return "GOOGLE_CALENDAR_REFRESH_TOKEN";
       },
       refreshToken: (args) => {
-        const { clientId, clientSecret } = args;
+        const { clientId, clientSecret } = args.authClient;
         const refreshToken = args.refreshToken;
         return refreshGoogleToken(
           args.tokenUrl,

--- a/turbo/packages/connectors/src/auth-providers/oauth/providers/google-docs-provider.ts
+++ b/turbo/packages/connectors/src/auth-providers/oauth/providers/google-docs-provider.ts
@@ -9,7 +9,7 @@ export const googleDocsProvider: AuthCodeConnectorAuthProvider<"google-docs"> =
     grant: {
       kind: "auth-code",
       buildAuthUrl: (args) => {
-        const { clientId } = args;
+        const { clientId } = args.authClient;
         const redirectUri = args.redirectUri;
         const state = args.state;
         return buildGoogleAuthorizationUrl(
@@ -21,7 +21,7 @@ export const googleDocsProvider: AuthCodeConnectorAuthProvider<"google-docs"> =
         );
       },
       exchangeCode: async (args) => {
-        const { clientId, clientSecret } = args;
+        const { clientId, clientSecret } = args.authClient;
         const code = args.code;
         const redirectUri = args.redirectUri;
         const result = await exchangeGoogleOAuthCode(
@@ -54,7 +54,7 @@ export const googleDocsProvider: AuthCodeConnectorAuthProvider<"google-docs"> =
         return "GOOGLE_DOCS_REFRESH_TOKEN";
       },
       refreshToken: (args) => {
-        const { clientId, clientSecret } = args;
+        const { clientId, clientSecret } = args.authClient;
         const refreshToken = args.refreshToken;
         return refreshGoogleToken(
           args.tokenUrl,

--- a/turbo/packages/connectors/src/auth-providers/oauth/providers/google-drive-provider.ts
+++ b/turbo/packages/connectors/src/auth-providers/oauth/providers/google-drive-provider.ts
@@ -9,7 +9,7 @@ export const googleDriveProvider: AuthCodeConnectorAuthProvider<"google-drive"> 
     grant: {
       kind: "auth-code",
       buildAuthUrl: (args) => {
-        const { clientId } = args;
+        const { clientId } = args.authClient;
         const redirectUri = args.redirectUri;
         const state = args.state;
         return buildGoogleAuthorizationUrl(
@@ -21,7 +21,7 @@ export const googleDriveProvider: AuthCodeConnectorAuthProvider<"google-drive"> 
         );
       },
       exchangeCode: async (args) => {
-        const { clientId, clientSecret } = args;
+        const { clientId, clientSecret } = args.authClient;
         const code = args.code;
         const redirectUri = args.redirectUri;
         const result = await exchangeGoogleOAuthCode(
@@ -54,7 +54,7 @@ export const googleDriveProvider: AuthCodeConnectorAuthProvider<"google-drive"> 
         return "GOOGLE_DRIVE_REFRESH_TOKEN";
       },
       refreshToken: (args) => {
-        const { clientId, clientSecret } = args;
+        const { clientId, clientSecret } = args.authClient;
         const refreshToken = args.refreshToken;
         return refreshGoogleToken(
           args.tokenUrl,

--- a/turbo/packages/connectors/src/auth-providers/oauth/providers/google-meet-provider.ts
+++ b/turbo/packages/connectors/src/auth-providers/oauth/providers/google-meet-provider.ts
@@ -9,7 +9,7 @@ export const googleMeetProvider: AuthCodeConnectorAuthProvider<"google-meet"> =
     grant: {
       kind: "auth-code",
       buildAuthUrl: (args) => {
-        const { clientId } = args;
+        const { clientId } = args.authClient;
         const redirectUri = args.redirectUri;
         const state = args.state;
         return buildGoogleAuthorizationUrl(
@@ -21,7 +21,7 @@ export const googleMeetProvider: AuthCodeConnectorAuthProvider<"google-meet"> =
         );
       },
       exchangeCode: async (args) => {
-        const { clientId, clientSecret } = args;
+        const { clientId, clientSecret } = args.authClient;
         const code = args.code;
         const redirectUri = args.redirectUri;
         const result = await exchangeGoogleOAuthCode(
@@ -54,7 +54,7 @@ export const googleMeetProvider: AuthCodeConnectorAuthProvider<"google-meet"> =
         return "GOOGLE_MEET_REFRESH_TOKEN";
       },
       refreshToken: (args) => {
-        const { clientId, clientSecret } = args;
+        const { clientId, clientSecret } = args.authClient;
         const refreshToken = args.refreshToken;
         return refreshGoogleToken(
           args.tokenUrl,

--- a/turbo/packages/connectors/src/auth-providers/oauth/providers/google-sheets-provider.ts
+++ b/turbo/packages/connectors/src/auth-providers/oauth/providers/google-sheets-provider.ts
@@ -9,7 +9,7 @@ export const googleSheetsProvider: AuthCodeConnectorAuthProvider<"google-sheets"
     grant: {
       kind: "auth-code",
       buildAuthUrl: (args) => {
-        const { clientId } = args;
+        const { clientId } = args.authClient;
         const redirectUri = args.redirectUri;
         const state = args.state;
         return buildGoogleAuthorizationUrl(
@@ -21,7 +21,7 @@ export const googleSheetsProvider: AuthCodeConnectorAuthProvider<"google-sheets"
         );
       },
       exchangeCode: async (args) => {
-        const { clientId, clientSecret } = args;
+        const { clientId, clientSecret } = args.authClient;
         const code = args.code;
         const redirectUri = args.redirectUri;
         const result = await exchangeGoogleOAuthCode(
@@ -54,7 +54,7 @@ export const googleSheetsProvider: AuthCodeConnectorAuthProvider<"google-sheets"
         return "GOOGLE_SHEETS_REFRESH_TOKEN";
       },
       refreshToken: (args) => {
-        const { clientId, clientSecret } = args;
+        const { clientId, clientSecret } = args.authClient;
         const refreshToken = args.refreshToken;
         return refreshGoogleToken(
           args.tokenUrl,

--- a/turbo/packages/connectors/src/auth-providers/oauth/providers/gumroad-provider.ts
+++ b/turbo/packages/connectors/src/auth-providers/oauth/providers/gumroad-provider.ts
@@ -9,7 +9,7 @@ export const gumroadProvider: AuthCodeConnectorAuthProvider<"gumroad"> = {
   grant: {
     kind: "auth-code",
     buildAuthUrl: (args) => {
-      const { clientId } = args;
+      const { clientId } = args.authClient;
       return buildGumroadAuthorizationUrl(
         args.authCodeGrant,
         clientId,
@@ -18,7 +18,7 @@ export const gumroadProvider: AuthCodeConnectorAuthProvider<"gumroad"> = {
       );
     },
     exchangeCode: async (args) => {
-      const { clientId, clientSecret } = args;
+      const { clientId, clientSecret } = args.authClient;
       const code = args.code;
       const redirectUri = args.redirectUri;
       const result = await exchangeGumroadCode(
@@ -48,7 +48,7 @@ export const gumroadProvider: AuthCodeConnectorAuthProvider<"gumroad"> = {
       return "GUMROAD_REFRESH_TOKEN";
     },
     refreshToken: (args) => {
-      const { clientId, clientSecret } = args;
+      const { clientId, clientSecret } = args.authClient;
       return refreshGumroadToken(
         args.tokenUrl,
         clientId,

--- a/turbo/packages/connectors/src/auth-providers/oauth/providers/hubspot-provider.ts
+++ b/turbo/packages/connectors/src/auth-providers/oauth/providers/hubspot-provider.ts
@@ -9,7 +9,7 @@ export const hubspotProvider: AuthCodeConnectorAuthProvider<"hubspot"> = {
   grant: {
     kind: "auth-code",
     buildAuthUrl: (args) => {
-      const { clientId } = args;
+      const { clientId } = args.authClient;
       return buildHubSpotAuthorizationUrl(
         args.authCodeGrant,
         clientId,
@@ -18,7 +18,7 @@ export const hubspotProvider: AuthCodeConnectorAuthProvider<"hubspot"> = {
       );
     },
     exchangeCode: async (args) => {
-      const { clientId, clientSecret } = args;
+      const { clientId, clientSecret } = args.authClient;
       const code = args.code;
       const redirectUri = args.redirectUri;
       const result = await exchangeHubSpotCode(
@@ -48,7 +48,7 @@ export const hubspotProvider: AuthCodeConnectorAuthProvider<"hubspot"> = {
       return "HUBSPOT_REFRESH_TOKEN";
     },
     refreshToken: (args) => {
-      const { clientId, clientSecret } = args;
+      const { clientId, clientSecret } = args.authClient;
       return refreshHubSpotToken(
         args.tokenUrl,
         clientId,

--- a/turbo/packages/connectors/src/auth-providers/oauth/providers/intervals-icu-provider.ts
+++ b/turbo/packages/connectors/src/auth-providers/oauth/providers/intervals-icu-provider.ts
@@ -9,7 +9,7 @@ export const intervalsIcuProvider: AuthCodeConnectorAuthProvider<"intervals-icu"
     grant: {
       kind: "auth-code",
       buildAuthUrl: (args) => {
-        const { clientId } = args;
+        const { clientId } = args.authClient;
         return buildIntervalsIcuAuthorizationUrl(
           args.authCodeGrant,
           clientId,
@@ -18,7 +18,7 @@ export const intervalsIcuProvider: AuthCodeConnectorAuthProvider<"intervals-icu"
         );
       },
       exchangeCode: async (args) => {
-        const { clientId, clientSecret } = args;
+        const { clientId, clientSecret } = args.authClient;
         const code = args.code;
         const result = await exchangeIntervalsIcuCode(
           args.authCodeGrant,

--- a/turbo/packages/connectors/src/auth-providers/oauth/providers/linear-provider.ts
+++ b/turbo/packages/connectors/src/auth-providers/oauth/providers/linear-provider.ts
@@ -10,7 +10,7 @@ export const linearProvider: AuthCodeConnectorAuthProvider<"linear"> = {
   grant: {
     kind: "auth-code",
     buildAuthUrl: (args) => {
-      const { clientId } = args;
+      const { clientId } = args.authClient;
       return buildLinearAuthorizationUrl(
         args.authCodeGrant,
         clientId,
@@ -19,7 +19,7 @@ export const linearProvider: AuthCodeConnectorAuthProvider<"linear"> = {
       );
     },
     exchangeCode: async (args) => {
-      const { clientId, clientSecret } = args;
+      const { clientId, clientSecret } = args.authClient;
       const code = args.code;
       const redirectUri = args.redirectUri;
       const result = await exchangeLinearCode(
@@ -49,7 +49,7 @@ export const linearProvider: AuthCodeConnectorAuthProvider<"linear"> = {
       return "LINEAR_REFRESH_TOKEN";
     },
     refreshToken: (args) => {
-      const { clientId, clientSecret } = args;
+      const { clientId, clientSecret } = args.authClient;
       return refreshLinearToken(
         args.tokenUrl,
         clientId,
@@ -62,7 +62,7 @@ export const linearProvider: AuthCodeConnectorAuthProvider<"linear"> = {
   revoke: {
     kind: "token-revoke",
     revokeToken: (args) => {
-      const { clientId, clientSecret } = args;
+      const { clientId, clientSecret } = args.authClient;
       return revokeLinearToken(clientId, clientSecret, args.accessToken);
     },
   },

--- a/turbo/packages/connectors/src/auth-providers/oauth/providers/mailchimp-provider.ts
+++ b/turbo/packages/connectors/src/auth-providers/oauth/providers/mailchimp-provider.ts
@@ -8,7 +8,7 @@ export const mailchimpProvider: AuthCodeConnectorAuthProvider<"mailchimp"> = {
   grant: {
     kind: "auth-code",
     buildAuthUrl: (args) => {
-      const { clientId } = args;
+      const { clientId } = args.authClient;
       return buildMailchimpAuthorizationUrl(
         clientId,
         args.redirectUri,
@@ -16,7 +16,7 @@ export const mailchimpProvider: AuthCodeConnectorAuthProvider<"mailchimp"> = {
       );
     },
     exchangeCode: async (args) => {
-      const { clientId, clientSecret } = args;
+      const { clientId, clientSecret } = args.authClient;
       const code = args.code;
       const redirectUri = args.redirectUri;
       const result = await exchangeMailchimpCode(

--- a/turbo/packages/connectors/src/auth-providers/oauth/providers/mercury-provider.ts
+++ b/turbo/packages/connectors/src/auth-providers/oauth/providers/mercury-provider.ts
@@ -9,7 +9,7 @@ export const mercuryProvider: AuthCodeConnectorAuthProvider<"mercury"> = {
   grant: {
     kind: "auth-code",
     buildAuthUrl: (args) => {
-      const { clientId } = args;
+      const { clientId } = args.authClient;
       return buildMercuryAuthorizationUrl(
         args.authCodeGrant,
         clientId,
@@ -18,7 +18,7 @@ export const mercuryProvider: AuthCodeConnectorAuthProvider<"mercury"> = {
       );
     },
     exchangeCode: async (args) => {
-      const { clientId, clientSecret } = args;
+      const { clientId, clientSecret } = args.authClient;
       const code = args.code;
       const redirectUri = args.redirectUri;
       const result = await exchangeMercuryCode(
@@ -48,7 +48,7 @@ export const mercuryProvider: AuthCodeConnectorAuthProvider<"mercury"> = {
       return "MERCURY_REFRESH_TOKEN";
     },
     refreshToken: (args) => {
-      const { clientId, clientSecret } = args;
+      const { clientId, clientSecret } = args.authClient;
       return refreshMercuryToken(
         args.tokenUrl,
         clientId,

--- a/turbo/packages/connectors/src/auth-providers/oauth/providers/meta-ads-provider.ts
+++ b/turbo/packages/connectors/src/auth-providers/oauth/providers/meta-ads-provider.ts
@@ -8,7 +8,7 @@ export const metaAdsProvider: AuthCodeConnectorAuthProvider<"meta-ads"> = {
   grant: {
     kind: "auth-code",
     buildAuthUrl: (args) => {
-      const { clientId } = args;
+      const { clientId } = args.authClient;
       return buildMetaAdsAuthorizationUrl(
         args.authCodeGrant,
         clientId,
@@ -17,7 +17,7 @@ export const metaAdsProvider: AuthCodeConnectorAuthProvider<"meta-ads"> = {
       );
     },
     exchangeCode: async (args) => {
-      const { clientId, clientSecret } = args;
+      const { clientId, clientSecret } = args.authClient;
       const code = args.code;
       const redirectUri = args.redirectUri;
       const result = await exchangeMetaAdsCode(

--- a/turbo/packages/connectors/src/auth-providers/oauth/providers/monday-provider.ts
+++ b/turbo/packages/connectors/src/auth-providers/oauth/providers/monday-provider.ts
@@ -9,7 +9,7 @@ export const mondayProvider: AuthCodeConnectorAuthProvider<"monday"> = {
   grant: {
     kind: "auth-code",
     buildAuthUrl: (args) => {
-      const { clientId } = args;
+      const { clientId } = args.authClient;
       return buildMondayAuthorizationUrl(
         args.authCodeGrant,
         clientId,
@@ -18,7 +18,7 @@ export const mondayProvider: AuthCodeConnectorAuthProvider<"monday"> = {
       );
     },
     exchangeCode: async (args) => {
-      const { clientId, clientSecret } = args;
+      const { clientId, clientSecret } = args.authClient;
       const code = args.code;
       const redirectUri = args.redirectUri;
       const result = await exchangeMondayCode(
@@ -48,7 +48,7 @@ export const mondayProvider: AuthCodeConnectorAuthProvider<"monday"> = {
       return "MONDAY_REFRESH_TOKEN";
     },
     refreshToken: (args) => {
-      const { clientId, clientSecret } = args;
+      const { clientId, clientSecret } = args.authClient;
       return refreshMondayToken(
         args.tokenUrl,
         clientId,

--- a/turbo/packages/connectors/src/auth-providers/oauth/providers/neon-provider.ts
+++ b/turbo/packages/connectors/src/auth-providers/oauth/providers/neon-provider.ts
@@ -9,7 +9,7 @@ export const neonProvider: AuthCodeConnectorAuthProvider<"neon"> = {
   grant: {
     kind: "auth-code",
     buildAuthUrl: (args) => {
-      const { clientId } = args;
+      const { clientId } = args.authClient;
       return buildNeonAuthorizationUrl(
         args.authCodeGrant,
         clientId,
@@ -18,7 +18,7 @@ export const neonProvider: AuthCodeConnectorAuthProvider<"neon"> = {
       );
     },
     exchangeCode: async (args) => {
-      const { clientId, clientSecret } = args;
+      const { clientId, clientSecret } = args.authClient;
       const code = args.code;
       const redirectUri = args.redirectUri;
       const result = await exchangeNeonCode(
@@ -48,7 +48,7 @@ export const neonProvider: AuthCodeConnectorAuthProvider<"neon"> = {
       return "NEON_REFRESH_TOKEN";
     },
     refreshToken: (args) => {
-      const { clientId, clientSecret } = args;
+      const { clientId, clientSecret } = args.authClient;
       return refreshNeonToken(
         args.tokenUrl,
         clientId,

--- a/turbo/packages/connectors/src/auth-providers/oauth/providers/notion-provider.ts
+++ b/turbo/packages/connectors/src/auth-providers/oauth/providers/notion-provider.ts
@@ -9,7 +9,7 @@ export const notionProvider: AuthCodeConnectorAuthProvider<"notion"> = {
   grant: {
     kind: "auth-code",
     buildAuthUrl: (args) => {
-      const { clientId } = args;
+      const { clientId } = args.authClient;
       return buildNotionAuthorizationUrl(
         clientId,
         args.redirectUri,
@@ -17,7 +17,7 @@ export const notionProvider: AuthCodeConnectorAuthProvider<"notion"> = {
       );
     },
     exchangeCode: async (args) => {
-      const { clientId, clientSecret } = args;
+      const { clientId, clientSecret } = args.authClient;
       const code = args.code;
       const redirectUri = args.redirectUri;
       const result = await exchangeNotionCode(
@@ -43,7 +43,7 @@ export const notionProvider: AuthCodeConnectorAuthProvider<"notion"> = {
       return "NOTION_REFRESH_TOKEN";
     },
     refreshToken: (args) => {
-      const { clientId, clientSecret } = args;
+      const { clientId, clientSecret } = args.authClient;
       return refreshNotionToken(
         args.tokenUrl,
         clientId,

--- a/turbo/packages/connectors/src/auth-providers/oauth/providers/outlook-calendar-provider.ts
+++ b/turbo/packages/connectors/src/auth-providers/oauth/providers/outlook-calendar-provider.ts
@@ -9,7 +9,7 @@ export const outlookCalendarProvider: AuthCodeConnectorAuthProvider<"outlook-cal
     grant: {
       kind: "auth-code",
       buildAuthUrl: (args) => {
-        const { clientId } = args;
+        const { clientId } = args.authClient;
         const redirectUri = args.redirectUri;
         const state = args.state;
         return buildMicrosoftAuthorizationUrl(
@@ -21,7 +21,7 @@ export const outlookCalendarProvider: AuthCodeConnectorAuthProvider<"outlook-cal
         );
       },
       exchangeCode: async (args) => {
-        const { clientId, clientSecret } = args;
+        const { clientId, clientSecret } = args.authClient;
         const code = args.code;
         const redirectUri = args.redirectUri;
         const result = await exchangeMicrosoftOAuthCode(
@@ -54,7 +54,7 @@ export const outlookCalendarProvider: AuthCodeConnectorAuthProvider<"outlook-cal
         return "OUTLOOK_CALENDAR_REFRESH_TOKEN";
       },
       refreshToken: (args) => {
-        const { clientId, clientSecret } = args;
+        const { clientId, clientSecret } = args.authClient;
         const refreshToken = args.refreshToken;
         return refreshMicrosoftToken(
           args.tokenUrl,

--- a/turbo/packages/connectors/src/auth-providers/oauth/providers/outlook-mail-provider.ts
+++ b/turbo/packages/connectors/src/auth-providers/oauth/providers/outlook-mail-provider.ts
@@ -9,7 +9,7 @@ export const outlookMailProvider: AuthCodeConnectorAuthProvider<"outlook-mail"> 
     grant: {
       kind: "auth-code",
       buildAuthUrl: (args) => {
-        const { clientId } = args;
+        const { clientId } = args.authClient;
         const redirectUri = args.redirectUri;
         const state = args.state;
         return buildMicrosoftAuthorizationUrl(
@@ -21,7 +21,7 @@ export const outlookMailProvider: AuthCodeConnectorAuthProvider<"outlook-mail"> 
         );
       },
       exchangeCode: async (args) => {
-        const { clientId, clientSecret } = args;
+        const { clientId, clientSecret } = args.authClient;
         const code = args.code;
         const redirectUri = args.redirectUri;
         const result = await exchangeMicrosoftOAuthCode(
@@ -54,7 +54,7 @@ export const outlookMailProvider: AuthCodeConnectorAuthProvider<"outlook-mail"> 
         return "OUTLOOK_MAIL_REFRESH_TOKEN";
       },
       refreshToken: (args) => {
-        const { clientId, clientSecret } = args;
+        const { clientId, clientSecret } = args.authClient;
         const refreshToken = args.refreshToken;
         return refreshMicrosoftToken(
           args.tokenUrl,

--- a/turbo/packages/connectors/src/auth-providers/oauth/providers/posthog-provider.ts
+++ b/turbo/packages/connectors/src/auth-providers/oauth/providers/posthog-provider.ts
@@ -9,7 +9,7 @@ export const posthogProvider: AuthCodeConnectorAuthProvider<"posthog"> = {
   grant: {
     kind: "auth-code",
     buildAuthUrl: (args) => {
-      const { clientId } = args;
+      const { clientId } = args.authClient;
       return buildPosthogAuthorizationUrl(
         args.authCodeGrant,
         clientId,
@@ -18,7 +18,7 @@ export const posthogProvider: AuthCodeConnectorAuthProvider<"posthog"> = {
       );
     },
     exchangeCode: async (args) => {
-      const { clientId, clientSecret } = args;
+      const { clientId, clientSecret } = args.authClient;
       const code = args.code;
       const redirectUri = args.redirectUri;
       const result = await exchangePosthogCode(
@@ -48,7 +48,7 @@ export const posthogProvider: AuthCodeConnectorAuthProvider<"posthog"> = {
       return "POSTHOG_REFRESH_TOKEN";
     },
     refreshToken: (args) => {
-      const { clientId, clientSecret } = args;
+      const { clientId, clientSecret } = args.authClient;
       return refreshPosthogToken(
         args.tokenUrl,
         clientId,

--- a/turbo/packages/connectors/src/auth-providers/oauth/providers/reddit-provider.ts
+++ b/turbo/packages/connectors/src/auth-providers/oauth/providers/reddit-provider.ts
@@ -9,7 +9,7 @@ export const redditProvider: AuthCodeConnectorAuthProvider<"reddit"> = {
   grant: {
     kind: "auth-code",
     buildAuthUrl: (args) => {
-      const { clientId } = args;
+      const { clientId } = args.authClient;
       return buildRedditAuthorizationUrl(
         args.authCodeGrant,
         clientId,
@@ -18,7 +18,7 @@ export const redditProvider: AuthCodeConnectorAuthProvider<"reddit"> = {
       );
     },
     exchangeCode: async (args) => {
-      const { clientId, clientSecret } = args;
+      const { clientId, clientSecret } = args.authClient;
       const code = args.code;
       const redirectUri = args.redirectUri;
       const result = await exchangeRedditCode(
@@ -48,7 +48,7 @@ export const redditProvider: AuthCodeConnectorAuthProvider<"reddit"> = {
       return "REDDIT_REFRESH_TOKEN";
     },
     refreshToken: (args) => {
-      const { clientId, clientSecret } = args;
+      const { clientId, clientSecret } = args.authClient;
       return refreshRedditToken(
         args.tokenUrl,
         clientId,

--- a/turbo/packages/connectors/src/auth-providers/oauth/providers/sentry-provider.ts
+++ b/turbo/packages/connectors/src/auth-providers/oauth/providers/sentry-provider.ts
@@ -9,7 +9,7 @@ export const sentryProvider: AuthCodeConnectorAuthProvider<"sentry"> = {
   grant: {
     kind: "auth-code",
     buildAuthUrl: (args) => {
-      const { clientId } = args;
+      const { clientId } = args.authClient;
       return buildSentryAuthorizationUrl(
         args.authCodeGrant,
         clientId,
@@ -18,7 +18,7 @@ export const sentryProvider: AuthCodeConnectorAuthProvider<"sentry"> = {
       );
     },
     exchangeCode: async (args) => {
-      const { clientId, clientSecret } = args;
+      const { clientId, clientSecret } = args.authClient;
       const code = args.code;
       const redirectUri = args.redirectUri;
       const result = await exchangeSentryCode(
@@ -48,7 +48,7 @@ export const sentryProvider: AuthCodeConnectorAuthProvider<"sentry"> = {
       return "SENTRY_REFRESH_TOKEN";
     },
     refreshToken: (args) => {
-      const { clientId, clientSecret } = args;
+      const { clientId, clientSecret } = args.authClient;
       return refreshSentryToken(
         args.tokenUrl,
         clientId,

--- a/turbo/packages/connectors/src/auth-providers/oauth/providers/slack-provider.ts
+++ b/turbo/packages/connectors/src/auth-providers/oauth/providers/slack-provider.ts
@@ -10,7 +10,7 @@ export const slackProvider: AuthCodeConnectorAuthProvider<"slack"> = {
   grant: {
     kind: "auth-code",
     buildAuthUrl: (args) => {
-      const { clientId } = args;
+      const { clientId } = args.authClient;
       return buildSlackAuthorizationUrl(
         args.authCodeGrant,
         clientId,
@@ -19,7 +19,7 @@ export const slackProvider: AuthCodeConnectorAuthProvider<"slack"> = {
       );
     },
     exchangeCode: async (args) => {
-      const { clientId, clientSecret } = args;
+      const { clientId, clientSecret } = args.authClient;
       const code = args.code;
       const redirectUri = args.redirectUri;
       const slackResult = await exchangeSlackCode(
@@ -51,7 +51,7 @@ export const slackProvider: AuthCodeConnectorAuthProvider<"slack"> = {
   revoke: {
     kind: "token-revoke",
     revokeToken: (args) => {
-      const { clientId, clientSecret } = args;
+      const { clientId, clientSecret } = args.authClient;
       return revokeSlackToken(clientId, clientSecret, args.accessToken);
     },
   },

--- a/turbo/packages/connectors/src/auth-providers/oauth/providers/spotify-provider.ts
+++ b/turbo/packages/connectors/src/auth-providers/oauth/providers/spotify-provider.ts
@@ -9,7 +9,7 @@ export const spotifyProvider: AuthCodeConnectorAuthProvider<"spotify"> = {
   grant: {
     kind: "auth-code",
     buildAuthUrl: (args) => {
-      const { clientId } = args;
+      const { clientId } = args.authClient;
       return buildSpotifyAuthorizationUrl(
         args.authCodeGrant,
         clientId,
@@ -18,7 +18,7 @@ export const spotifyProvider: AuthCodeConnectorAuthProvider<"spotify"> = {
       );
     },
     exchangeCode: async (args) => {
-      const { clientId, clientSecret } = args;
+      const { clientId, clientSecret } = args.authClient;
       const code = args.code;
       const redirectUri = args.redirectUri;
       const result = await exchangeSpotifyCode(
@@ -48,7 +48,7 @@ export const spotifyProvider: AuthCodeConnectorAuthProvider<"spotify"> = {
       return "SPOTIFY_REFRESH_TOKEN";
     },
     refreshToken: (args) => {
-      const { clientId, clientSecret } = args;
+      const { clientId, clientSecret } = args.authClient;
       return refreshSpotifyToken(
         args.tokenUrl,
         clientId,

--- a/turbo/packages/connectors/src/auth-providers/oauth/providers/strava-provider.ts
+++ b/turbo/packages/connectors/src/auth-providers/oauth/providers/strava-provider.ts
@@ -9,7 +9,7 @@ export const stravaProvider: AuthCodeConnectorAuthProvider<"strava"> = {
   grant: {
     kind: "auth-code",
     buildAuthUrl: (args) => {
-      const { clientId } = args;
+      const { clientId } = args.authClient;
       return buildStravaAuthorizationUrl(
         args.authCodeGrant,
         clientId,
@@ -18,7 +18,7 @@ export const stravaProvider: AuthCodeConnectorAuthProvider<"strava"> = {
       );
     },
     exchangeCode: async (args) => {
-      const { clientId, clientSecret } = args;
+      const { clientId, clientSecret } = args.authClient;
       const code = args.code;
       const result = await exchangeStravaCode(
         args.authCodeGrant,
@@ -46,7 +46,7 @@ export const stravaProvider: AuthCodeConnectorAuthProvider<"strava"> = {
       return "STRAVA_REFRESH_TOKEN";
     },
     refreshToken: (args) => {
-      const { clientId, clientSecret } = args;
+      const { clientId, clientSecret } = args.authClient;
       return refreshStravaToken(
         args.tokenUrl,
         clientId,

--- a/turbo/packages/connectors/src/auth-providers/oauth/providers/stripe-provider.ts
+++ b/turbo/packages/connectors/src/auth-providers/oauth/providers/stripe-provider.ts
@@ -9,7 +9,7 @@ export const stripeProvider: AuthCodeConnectorAuthProvider<"stripe"> = {
   grant: {
     kind: "auth-code",
     buildAuthUrl: (args) => {
-      const { clientId } = args;
+      const { clientId } = args.authClient;
       return buildStripeAuthorizationUrl(
         args.authCodeGrant,
         clientId,
@@ -18,7 +18,7 @@ export const stripeProvider: AuthCodeConnectorAuthProvider<"stripe"> = {
       );
     },
     exchangeCode: async (args) => {
-      const { clientId, clientSecret } = args;
+      const { clientId, clientSecret } = args.authClient;
       const code = args.code;
       const result = await exchangeStripeCode(
         args.authCodeGrant,
@@ -45,7 +45,7 @@ export const stripeProvider: AuthCodeConnectorAuthProvider<"stripe"> = {
       return "STRIPE_REFRESH_TOKEN";
     },
     refreshToken: (args) => {
-      const { clientId, clientSecret } = args;
+      const { clientId, clientSecret } = args.authClient;
       return refreshStripeToken(
         args.tokenUrl,
         clientId,

--- a/turbo/packages/connectors/src/auth-providers/oauth/providers/supabase-provider.ts
+++ b/turbo/packages/connectors/src/auth-providers/oauth/providers/supabase-provider.ts
@@ -9,7 +9,7 @@ export const supabaseProvider: AuthCodeConnectorAuthProvider<"supabase"> = {
   grant: {
     kind: "auth-code",
     buildAuthUrl: (args) => {
-      const { clientId } = args;
+      const { clientId } = args.authClient;
       return buildSupabaseAuthorizationUrl(
         args.authCodeGrant,
         clientId,
@@ -18,7 +18,7 @@ export const supabaseProvider: AuthCodeConnectorAuthProvider<"supabase"> = {
       );
     },
     exchangeCode: async (args) => {
-      const { clientId, clientSecret } = args;
+      const { clientId, clientSecret } = args.authClient;
       const code = args.code;
       const redirectUri = args.redirectUri;
       const state = args.state;
@@ -55,7 +55,7 @@ export const supabaseProvider: AuthCodeConnectorAuthProvider<"supabase"> = {
       return "SUPABASE_REFRESH_TOKEN";
     },
     refreshToken: (args) => {
-      const { clientId, clientSecret } = args;
+      const { clientId, clientSecret } = args.authClient;
       return refreshSupabaseToken(
         args.tokenUrl,
         clientId,

--- a/turbo/packages/connectors/src/auth-providers/oauth/providers/test-oauth-device-provider.ts
+++ b/turbo/packages/connectors/src/auth-providers/oauth/providers/test-oauth-device-provider.ts
@@ -1,36 +1,63 @@
-import type { DeviceAuthConnectorAuthProvider } from "../../types";
+import type {
+  DeviceAuthConnectorAuthProvider,
+  DeviceAuthGrantProvider,
+} from "../../types";
+import type { ConnectorDeviceAuthGrantAuthMethodId } from "../../../connectors";
 import {
   pollTestOAuthDeviceAuth,
+  TEST_OAUTH_DEVICE_API_ACCESS_SECRET_NAME,
   startTestOAuthDeviceAuth,
   TEST_OAUTH_DEVICE_ACCESS_SECRET_NAME,
 } from "./test-oauth-device";
 
-export const testOauthDeviceProvider: DeviceAuthConnectorAuthProvider<"test-oauth-device"> =
-  {
-    grant: {
-      kind: "device-auth",
-      startDeviceAuth: async (args) => {
-        const { clientId } = args;
-        return await startTestOAuthDeviceAuth({
-          clientId,
-          deviceAuthGrant: args.deviceAuthGrant,
-          scopes: args.scopes,
-        });
-      },
-      pollDeviceAuth: async (args) => {
-        const { clientId } = args;
-        return await pollTestOAuthDeviceAuth({
-          clientId,
-          deviceAuthGrant: args.deviceAuthGrant,
-          deviceCode: args.deviceCode,
-        });
-      },
+function createTestOauthDeviceGrant<
+  Method extends ConnectorDeviceAuthGrantAuthMethodId<"test-oauth-device">,
+>(): DeviceAuthGrantProvider<"test-oauth-device", Method> {
+  return {
+    kind: "device-auth",
+    startDeviceAuth: async (args) => {
+      const { clientId } = args.authClient;
+      return await startTestOAuthDeviceAuth({
+        clientId,
+        deviceAuthGrant: args.deviceAuthGrant,
+        scopes: args.scopes,
+      });
     },
-    access: {
-      kind: "none",
-      getAccessSecretName: () => {
-        return TEST_OAUTH_DEVICE_ACCESS_SECRET_NAME;
-      },
+    pollDeviceAuth: async (args) => {
+      const { clientId } = args.authClient;
+      return await pollTestOAuthDeviceAuth({
+        clientId,
+        deviceAuthGrant: args.deviceAuthGrant,
+        deviceCode: args.deviceCode,
+      });
     },
-    revoke: { kind: "none" },
   };
+}
+
+export const testOauthDeviceProvider: DeviceAuthConnectorAuthProvider<
+  "test-oauth-device",
+  "oauth"
+> = {
+  grant: createTestOauthDeviceGrant<"oauth">(),
+  access: {
+    kind: "none",
+    getAccessSecretName: () => {
+      return TEST_OAUTH_DEVICE_API_ACCESS_SECRET_NAME;
+    },
+  },
+  revoke: { kind: "none" },
+};
+
+export const testOauthDeviceApiProvider: DeviceAuthConnectorAuthProvider<
+  "test-oauth-device",
+  "api"
+> = {
+  grant: createTestOauthDeviceGrant<"api">(),
+  access: {
+    kind: "none",
+    getAccessSecretName: () => {
+      return TEST_OAUTH_DEVICE_ACCESS_SECRET_NAME;
+    },
+  },
+  revoke: { kind: "none" },
+};

--- a/turbo/packages/connectors/src/auth-providers/oauth/providers/test-oauth-device-provider.ts
+++ b/turbo/packages/connectors/src/auth-providers/oauth/providers/test-oauth-device-provider.ts
@@ -42,7 +42,7 @@ export const testOauthDeviceProvider: DeviceAuthConnectorAuthProvider<
   access: {
     kind: "none",
     getAccessSecretName: () => {
-      return TEST_OAUTH_DEVICE_API_ACCESS_SECRET_NAME;
+      return TEST_OAUTH_DEVICE_ACCESS_SECRET_NAME;
     },
   },
   revoke: { kind: "none" },
@@ -56,7 +56,7 @@ export const testOauthDeviceApiProvider: DeviceAuthConnectorAuthProvider<
   access: {
     kind: "none",
     getAccessSecretName: () => {
-      return TEST_OAUTH_DEVICE_ACCESS_SECRET_NAME;
+      return TEST_OAUTH_DEVICE_API_ACCESS_SECRET_NAME;
     },
   },
   revoke: { kind: "none" },

--- a/turbo/packages/connectors/src/auth-providers/oauth/providers/test-oauth-device.ts
+++ b/turbo/packages/connectors/src/auth-providers/oauth/providers/test-oauth-device.ts
@@ -17,6 +17,8 @@ export const TEST_OAUTH_DEVICE_VERIFICATION_URI =
   "https://oauth-device.test/device";
 export const TEST_OAUTH_DEVICE_ACCESS_SECRET_NAME =
   "TEST_OAUTH_DEVICE_ACCESS_TOKEN";
+export const TEST_OAUTH_DEVICE_API_ACCESS_SECRET_NAME =
+  "TEST_OAUTH_DEVICE_API_ACCESS_TOKEN";
 
 const DEVICE_CODE_GRANT_TYPE = "urn:ietf:params:oauth:grant-type:device_code";
 

--- a/turbo/packages/connectors/src/auth-providers/oauth/providers/test-oauth-provider.ts
+++ b/turbo/packages/connectors/src/auth-providers/oauth/providers/test-oauth-provider.ts
@@ -1,4 +1,12 @@
-import type { AuthCodeConnectorAuthProvider } from "../../types";
+import type {
+  AuthCodeConnectorAuthProvider,
+  AuthCodeGrantProvider,
+  RefreshTokenAccessProvider,
+} from "../../types";
+import type {
+  ConnectorAuthCodeGrantAuthMethodId,
+  ConnectorAuthMethodIdsByAccessKind,
+} from "../../../connectors";
 import {
   buildTestOAuthAuthorizationUrl,
   exchangeTestOAuthCode,
@@ -10,78 +18,99 @@ import {
   TEST_OAUTH_REFRESH_SECRET_NAME,
 } from "./test-oauth";
 
-function createTestOauthProvider(args: {
-  readonly accessSecretName: string;
-  readonly refreshSecretName: string;
-}): AuthCodeConnectorAuthProvider<"test-oauth"> {
+function createTestOauthGrant<
+  Method extends ConnectorAuthCodeGrantAuthMethodId<"test-oauth">,
+>(): AuthCodeGrantProvider<"test-oauth", Method> {
   return {
-    grant: {
-      kind: "auth-code",
-      buildAuthUrl: (authUrlArgs) => {
-        const { clientId } = authUrlArgs;
-        return buildTestOAuthAuthorizationUrl(
-          authUrlArgs.authCodeGrant,
-          clientId,
-          authUrlArgs.redirectUri,
-          authUrlArgs.state,
-        );
-      },
-      exchangeCode: async (exchangeArgs) => {
-        const { clientId, clientSecret } = exchangeArgs;
-        const code = exchangeArgs.code;
-        const redirectUri = exchangeArgs.redirectUri;
-        const token = await exchangeTestOAuthCode(
-          exchangeArgs.authCodeGrant,
-          clientId,
-          clientSecret,
-          code,
-          redirectUri,
-        );
-        const user = await fetchTestOAuthUserInfo(token.accessToken);
-        return {
-          accessToken: token.accessToken,
-          refreshToken: token.refreshToken,
-          expiresIn: token.expiresIn,
-          scopes: token.scopes,
-          userInfo: user,
-        };
-      },
+    kind: "auth-code",
+    buildAuthUrl: (authUrlArgs) => {
+      const { clientId } = authUrlArgs.authClient;
+      return buildTestOAuthAuthorizationUrl(
+        authUrlArgs.authCodeGrant,
+        clientId,
+        authUrlArgs.redirectUri,
+        authUrlArgs.state,
+      );
     },
-    access: {
-      kind: "refresh-token",
-      getAccessSecretName: () => {
-        return args.accessSecretName;
-      },
-      getRefreshSecretName: () => {
-        return args.refreshSecretName;
-      },
-      refreshToken: async (refreshArgs) => {
-        const { clientId, clientSecret } = refreshArgs;
-        const refreshToken = refreshArgs.refreshToken;
-        const result = await refreshTestOAuthToken(
-          refreshArgs.tokenUrl,
-          clientId,
-          clientSecret,
-          refreshToken,
-          refreshArgs.signal,
-        );
-        return {
-          accessToken: result.accessToken,
-          refreshToken: result.refreshToken,
-          expiresIn: result.expiresIn,
-        };
-      },
+    exchangeCode: async (exchangeArgs) => {
+      const { clientId, clientSecret } = exchangeArgs.authClient;
+      const code = exchangeArgs.code;
+      const redirectUri = exchangeArgs.redirectUri;
+      const token = await exchangeTestOAuthCode(
+        exchangeArgs.authCodeGrant,
+        clientId,
+        clientSecret,
+        code,
+        redirectUri,
+      );
+      const user = await fetchTestOAuthUserInfo(token.accessToken);
+      return {
+        accessToken: token.accessToken,
+        refreshToken: token.refreshToken,
+        expiresIn: token.expiresIn,
+        scopes: token.scopes,
+        userInfo: user,
+      };
     },
-    revoke: { kind: "none" },
   };
 }
 
-export const testOauthProvider = createTestOauthProvider({
-  accessSecretName: TEST_OAUTH_ACCESS_SECRET_NAME,
-  refreshSecretName: TEST_OAUTH_REFRESH_SECRET_NAME,
-});
+function createTestOauthAccess<
+  Method extends ConnectorAuthMethodIdsByAccessKind<
+    "test-oauth",
+    "refresh-token"
+  >,
+>(args: {
+  readonly accessSecretName: string;
+  readonly refreshSecretName: string;
+}): RefreshTokenAccessProvider<"test-oauth", Method> {
+  return {
+    kind: "refresh-token",
+    getAccessSecretName: () => {
+      return args.accessSecretName;
+    },
+    getRefreshSecretName: () => {
+      return args.refreshSecretName;
+    },
+    refreshToken: async (refreshArgs) => {
+      const { clientId, clientSecret } = refreshArgs.authClient;
+      const refreshToken = refreshArgs.refreshToken;
+      const result = await refreshTestOAuthToken(
+        refreshArgs.tokenUrl,
+        clientId,
+        clientSecret,
+        refreshToken,
+        refreshArgs.signal,
+      );
+      return {
+        accessToken: result.accessToken,
+        refreshToken: result.refreshToken,
+        expiresIn: result.expiresIn,
+      };
+    },
+  };
+}
 
-export const testOauthApiProvider = createTestOauthProvider({
-  accessSecretName: TEST_OAUTH_API_ACCESS_SECRET_NAME,
-  refreshSecretName: TEST_OAUTH_API_REFRESH_SECRET_NAME,
-});
+export const testOauthProvider: AuthCodeConnectorAuthProvider<
+  "test-oauth",
+  "oauth"
+> = {
+  grant: createTestOauthGrant<"oauth">(),
+  access: createTestOauthAccess<"oauth">({
+    accessSecretName: TEST_OAUTH_ACCESS_SECRET_NAME,
+    refreshSecretName: TEST_OAUTH_REFRESH_SECRET_NAME,
+  }),
+  revoke: { kind: "none" },
+};
+
+export const testOauthApiProvider: AuthCodeConnectorAuthProvider<
+  "test-oauth",
+  "api"
+> = {
+  grant: createTestOauthGrant<"api">(),
+  access: createTestOauthAccess<"api">({
+    accessSecretName: TEST_OAUTH_API_ACCESS_SECRET_NAME,
+    refreshSecretName: TEST_OAUTH_API_REFRESH_SECRET_NAME,
+  }),
+  revoke: { kind: "none" },
+};

--- a/turbo/packages/connectors/src/auth-providers/oauth/providers/todoist-provider.ts
+++ b/turbo/packages/connectors/src/auth-providers/oauth/providers/todoist-provider.ts
@@ -8,7 +8,7 @@ export const todoistProvider: AuthCodeConnectorAuthProvider<"todoist"> = {
   grant: {
     kind: "auth-code",
     buildAuthUrl: (args) => {
-      const { clientId } = args;
+      const { clientId } = args.authClient;
       return buildTodoistAuthorizationUrl(
         args.authCodeGrant,
         clientId,
@@ -17,7 +17,7 @@ export const todoistProvider: AuthCodeConnectorAuthProvider<"todoist"> = {
       );
     },
     exchangeCode: async (args) => {
-      const { clientId, clientSecret } = args;
+      const { clientId, clientSecret } = args.authClient;
       const code = args.code;
       const redirectUri = args.redirectUri;
       const result = await exchangeTodoistCode(

--- a/turbo/packages/connectors/src/auth-providers/oauth/providers/vercel-provider.ts
+++ b/turbo/packages/connectors/src/auth-providers/oauth/providers/vercel-provider.ts
@@ -8,7 +8,7 @@ export const vercelProvider: AuthCodeConnectorAuthProvider<"vercel"> = {
   grant: {
     kind: "auth-code",
     buildAuthUrl: (args) => {
-      const { clientId } = args;
+      const { clientId } = args.authClient;
       return buildVercelAuthorizationUrl(
         clientId,
         args.redirectUri,
@@ -16,7 +16,7 @@ export const vercelProvider: AuthCodeConnectorAuthProvider<"vercel"> = {
       );
     },
     exchangeCode: async (args) => {
-      const { clientId, clientSecret } = args;
+      const { clientId, clientSecret } = args.authClient;
       const code = args.code;
       const redirectUri = args.redirectUri;
       const result = await exchangeVercelCode(

--- a/turbo/packages/connectors/src/auth-providers/oauth/providers/webflow-provider.ts
+++ b/turbo/packages/connectors/src/auth-providers/oauth/providers/webflow-provider.ts
@@ -8,7 +8,7 @@ export const webflowProvider: AuthCodeConnectorAuthProvider<"webflow"> = {
   grant: {
     kind: "auth-code",
     buildAuthUrl: (args) => {
-      const { clientId } = args;
+      const { clientId } = args.authClient;
       return buildWebflowAuthorizationUrl(
         args.authCodeGrant,
         clientId,
@@ -17,7 +17,7 @@ export const webflowProvider: AuthCodeConnectorAuthProvider<"webflow"> = {
       );
     },
     exchangeCode: async (args) => {
-      const { clientId, clientSecret } = args;
+      const { clientId, clientSecret } = args.authClient;
       const code = args.code;
       const redirectUri = args.redirectUri;
       const result = await exchangeWebflowCode(

--- a/turbo/packages/connectors/src/auth-providers/oauth/providers/x-provider.ts
+++ b/turbo/packages/connectors/src/auth-providers/oauth/providers/x-provider.ts
@@ -9,7 +9,7 @@ export const xProvider: AuthCodeConnectorAuthProvider<"x"> = {
   grant: {
     kind: "auth-code",
     buildAuthUrl: (args) => {
-      const { clientId } = args;
+      const { clientId } = args.authClient;
       return buildXAuthorizationUrl(
         args.authCodeGrant,
         clientId,
@@ -18,7 +18,7 @@ export const xProvider: AuthCodeConnectorAuthProvider<"x"> = {
       );
     },
     exchangeCode: async (args) => {
-      const { clientId, clientSecret } = args;
+      const { clientId, clientSecret } = args.authClient;
       const code = args.code;
       const redirectUri = args.redirectUri;
       const state = args.state;
@@ -53,7 +53,7 @@ export const xProvider: AuthCodeConnectorAuthProvider<"x"> = {
       return "X_REFRESH_TOKEN";
     },
     refreshToken: (args) => {
-      const { clientId, clientSecret } = args;
+      const { clientId, clientSecret } = args.authClient;
       return refreshXToken(
         args.tokenUrl,
         clientId,

--- a/turbo/packages/connectors/src/auth-providers/oauth/providers/xero-provider.ts
+++ b/turbo/packages/connectors/src/auth-providers/oauth/providers/xero-provider.ts
@@ -9,7 +9,7 @@ export const xeroProvider: AuthCodeConnectorAuthProvider<"xero"> = {
   grant: {
     kind: "auth-code",
     buildAuthUrl: (args) => {
-      const { clientId } = args;
+      const { clientId } = args.authClient;
       return buildXeroAuthorizationUrl(
         args.authCodeGrant,
         clientId,
@@ -18,7 +18,7 @@ export const xeroProvider: AuthCodeConnectorAuthProvider<"xero"> = {
       );
     },
     exchangeCode: async (args) => {
-      const { clientId, clientSecret } = args;
+      const { clientId, clientSecret } = args.authClient;
       const code = args.code;
       const redirectUri = args.redirectUri;
       const result = await exchangeXeroCode(
@@ -48,7 +48,7 @@ export const xeroProvider: AuthCodeConnectorAuthProvider<"xero"> = {
       return "XERO_REFRESH_TOKEN";
     },
     refreshToken: (args) => {
-      const { clientId, clientSecret } = args;
+      const { clientId, clientSecret } = args.authClient;
       return refreshXeroToken(
         args.tokenUrl,
         clientId,

--- a/turbo/packages/connectors/src/auth-providers/oauth/providers/zoom-provider.ts
+++ b/turbo/packages/connectors/src/auth-providers/oauth/providers/zoom-provider.ts
@@ -9,7 +9,7 @@ export const zoomProvider: AuthCodeConnectorAuthProvider<"zoom"> = {
   grant: {
     kind: "auth-code",
     buildAuthUrl: (args) => {
-      const { clientId } = args;
+      const { clientId } = args.authClient;
       return buildZoomAuthorizationUrl(
         args.authCodeGrant,
         clientId,
@@ -18,7 +18,7 @@ export const zoomProvider: AuthCodeConnectorAuthProvider<"zoom"> = {
       );
     },
     exchangeCode: async (args) => {
-      const { clientId, clientSecret } = args;
+      const { clientId, clientSecret } = args.authClient;
       const code = args.code;
       const redirectUri = args.redirectUri;
       const result = await exchangeZoomCode(
@@ -48,7 +48,7 @@ export const zoomProvider: AuthCodeConnectorAuthProvider<"zoom"> = {
       return "ZOOM_REFRESH_TOKEN";
     },
     refreshToken: (args) => {
-      const { clientId, clientSecret } = args;
+      const { clientId, clientSecret } = args.authClient;
       return refreshZoomToken(
         args.tokenUrl,
         clientId,

--- a/turbo/packages/connectors/src/auth-providers/oauth/types.ts
+++ b/turbo/packages/connectors/src/auth-providers/oauth/types.ts
@@ -1,17 +1,18 @@
 import type {
   AuthCodeGrantConnectorType,
   ConnectorAuthCodeGrantConfig,
-  ConnectorAuthClientConfig,
+  ConnectorAuthMethodIds,
   ConnectorAuthCodeGrantAuthMethodId,
   ConnectorDeviceAuthGrantConfig,
   ConnectorDeviceAuthGrantAuthMethodId,
-  ConnectorAuthMethodClientConfig,
   ConnectorAuthMethodIdsByAccessKind,
   ConnectorAuthMethodIdsByRevokeKind,
   ConnectorAuthProviderType,
+  ConnectorType,
   DeviceAuthGrantConnectorType,
   RefreshTokenAccessConnectorType,
 } from "@vm0/connectors/connectors";
+import type { ConnectorAuthClientForMethod } from "@vm0/connectors/connector-utils";
 
 export interface OAuthTokenResult {
   accessToken: string;
@@ -137,42 +138,19 @@ export type OAuthDeviceAuthPollResult =
   | OAuthDeviceAuthExpiredResult
   | OAuthDeviceAuthErrorResult;
 
-type ConnectorAccessProviderClientFor<
-  T extends RefreshTokenAccessConnectorType,
-  Method extends ConnectorAuthMethodIdsByAccessKind<T, "refresh-token">,
-> = ConnectorAuthMethodClientConfig<T, Method> & ConnectorAuthClientConfig;
-
-type ConnectorRevokeProviderClientFor<
-  T extends ConnectorAuthProviderType,
-  Method extends ConnectorAuthMethodIdsByRevokeKind<T, "token-revoke">,
-> = ConnectorAuthMethodClientConfig<T, Method> & ConnectorAuthClientConfig;
-
-type NoClientCredentialArgs = Record<never, never>;
-
-type StaticClientIdArgs<Client extends ConnectorAuthClientConfig> =
-  Client extends { readonly clientRegistration: "static" }
-    ? { readonly clientId: string }
-    : NoClientCredentialArgs;
-
-type TokenCredentialArgs<Client extends ConnectorAuthClientConfig> =
-  Client extends {
-    readonly clientRegistration: "static";
-    readonly clientType: "confidential";
-  }
-    ? { readonly clientId: string; readonly clientSecret: string }
-    : Client extends {
-          readonly clientRegistration: "static";
-          readonly clientType: "public";
-        }
-      ? { readonly clientId: string }
-      : NoClientCredentialArgs;
+type ConnectorAuthMethodClientArgs<
+  T extends ConnectorType,
+  Method extends ConnectorAuthMethodIds<T>,
+> = {
+  readonly authClient: ConnectorAuthClientForMethod<T, Method>;
+};
 
 export type ConnectorAuthCodeAuthorizeArgs<
   T extends AuthCodeGrantConnectorType,
   Method extends ConnectorAuthCodeGrantAuthMethodId<T> =
     ConnectorAuthCodeGrantAuthMethodId<T>,
 > = OAuthAuthorizeFlowArgs &
-  StaticClientIdArgs<ConnectorAuthMethodClientConfig<T, Method>> & {
+  ConnectorAuthMethodClientArgs<T, Method> & {
     readonly authCodeGrant: ConnectorAuthCodeGrantConfig;
   };
 
@@ -181,7 +159,7 @@ export type ConnectorAuthCodeExchangeArgs<
   Method extends ConnectorAuthCodeGrantAuthMethodId<T> =
     ConnectorAuthCodeGrantAuthMethodId<T>,
 > = OAuthExchangeFlowArgs &
-  TokenCredentialArgs<ConnectorAuthMethodClientConfig<T, Method>> & {
+  ConnectorAuthMethodClientArgs<T, Method> & {
     readonly authCodeGrant: ConnectorAuthCodeGrantConfig;
   };
 
@@ -190,7 +168,7 @@ export type ConnectorAuthProviderRefreshArgs<
   Method extends ConnectorAuthMethodIdsByAccessKind<T, "refresh-token"> =
     ConnectorAuthMethodIdsByAccessKind<T, "refresh-token">,
 > = OAuthRefreshFlowArgs &
-  TokenCredentialArgs<ConnectorAccessProviderClientFor<T, Method>> & {
+  ConnectorAuthMethodClientArgs<T, Method> & {
     readonly tokenUrl: string;
   };
 
@@ -198,15 +176,14 @@ export type ConnectorAuthProviderRevokeArgs<
   T extends ConnectorAuthProviderType,
   Method extends ConnectorAuthMethodIdsByRevokeKind<T, "token-revoke"> =
     ConnectorAuthMethodIdsByRevokeKind<T, "token-revoke">,
-> = OAuthRevokeFlowArgs &
-  TokenCredentialArgs<ConnectorRevokeProviderClientFor<T, Method>>;
+> = OAuthRevokeFlowArgs & ConnectorAuthMethodClientArgs<T, Method>;
 
 export type ConnectorDeviceAuthorizationStartArgs<
   T extends DeviceAuthGrantConnectorType,
   Method extends ConnectorDeviceAuthGrantAuthMethodId<T> =
     ConnectorDeviceAuthGrantAuthMethodId<T>,
 > = OAuthDeviceAuthStartFlowArgs &
-  StaticClientIdArgs<ConnectorAuthMethodClientConfig<T, Method>> & {
+  ConnectorAuthMethodClientArgs<T, Method> & {
     readonly deviceAuthGrant: ConnectorDeviceAuthGrantConfig;
   };
 
@@ -215,6 +192,6 @@ export type ConnectorDeviceAuthorizationPollArgs<
   Method extends ConnectorDeviceAuthGrantAuthMethodId<T> =
     ConnectorDeviceAuthGrantAuthMethodId<T>,
 > = OAuthDeviceAuthPollFlowArgs &
-  TokenCredentialArgs<ConnectorAuthMethodClientConfig<T, Method>> & {
+  ConnectorAuthMethodClientArgs<T, Method> & {
     readonly deviceAuthGrant: ConnectorDeviceAuthGrantConfig;
   };

--- a/turbo/packages/connectors/src/auth-providers/oauth/types.ts
+++ b/turbo/packages/connectors/src/auth-providers/oauth/types.ts
@@ -7,10 +7,10 @@ import type {
   ConnectorDeviceAuthGrantAuthMethodId,
   ConnectorAuthMethodIdsByAccessKind,
   ConnectorAuthMethodIdsByRevokeKind,
-  ConnectorAuthProviderType,
   ConnectorType,
   DeviceAuthGrantConnectorType,
   RefreshTokenAccessConnectorType,
+  TokenRevokeConnectorType,
 } from "@vm0/connectors/connectors";
 import type { ConnectorAuthClientForMethod } from "@vm0/connectors/connector-utils";
 
@@ -62,26 +62,6 @@ interface OAuthDeviceAuthStartFlowArgs {
 interface OAuthDeviceAuthPollFlowArgs {
   readonly deviceCode: string;
 }
-
-type OptionalClientCredentialArgs = {
-  readonly clientId?: string;
-  readonly clientSecret?: string;
-};
-
-export type OAuthAuthorizeArgs = OAuthAuthorizeFlowArgs &
-  OptionalClientCredentialArgs;
-
-export type OAuthExchangeArgs = OAuthExchangeFlowArgs &
-  OptionalClientCredentialArgs;
-
-export type OAuthRefreshArgs = OAuthRefreshFlowArgs &
-  OptionalClientCredentialArgs;
-
-export type OAuthDeviceAuthStartArgs = OAuthDeviceAuthStartFlowArgs &
-  OptionalClientCredentialArgs;
-
-export type OAuthDeviceAuthPollArgs = OAuthDeviceAuthPollFlowArgs &
-  OptionalClientCredentialArgs;
 
 export interface OAuthRefreshResult {
   readonly accessToken: string;
@@ -173,7 +153,7 @@ export type ConnectorAuthProviderRefreshArgs<
   };
 
 export type ConnectorAuthProviderRevokeArgs<
-  T extends ConnectorAuthProviderType,
+  T extends TokenRevokeConnectorType,
   Method extends ConnectorAuthMethodIdsByRevokeKind<T, "token-revoke"> =
     ConnectorAuthMethodIdsByRevokeKind<T, "token-revoke">,
 > = OAuthRevokeFlowArgs & ConnectorAuthMethodClientArgs<T, Method>;

--- a/turbo/packages/connectors/src/auth-providers/oauth/types.ts
+++ b/turbo/packages/connectors/src/auth-providers/oauth/types.ts
@@ -12,7 +12,10 @@ import type {
   RefreshTokenAccessConnectorType,
   TokenRevokeConnectorType,
 } from "@vm0/connectors/connectors";
-import type { ConnectorAuthClientForMethod } from "@vm0/connectors/connector-utils";
+import type {
+  ConnectorAuthClientForMethod,
+  ConnectorAuthClientIdentityForMethod,
+} from "@vm0/connectors/connector-utils";
 
 export interface OAuthTokenResult {
   accessToken: string;
@@ -125,12 +128,19 @@ type ConnectorAuthMethodClientArgs<
   readonly authClient: ConnectorAuthClientForMethod<T, Method>;
 };
 
+type ConnectorAuthMethodClientIdentityArgs<
+  T extends ConnectorType,
+  Method extends ConnectorAuthMethodIds<T>,
+> = {
+  readonly authClient: ConnectorAuthClientIdentityForMethod<T, Method>;
+};
+
 export type ConnectorAuthCodeAuthorizeArgs<
   T extends AuthCodeGrantConnectorType,
   Method extends ConnectorAuthCodeGrantAuthMethodId<T> =
     ConnectorAuthCodeGrantAuthMethodId<T>,
 > = OAuthAuthorizeFlowArgs &
-  ConnectorAuthMethodClientArgs<T, Method> & {
+  ConnectorAuthMethodClientIdentityArgs<T, Method> & {
     readonly authCodeGrant: ConnectorAuthCodeGrantConfig;
   };
 
@@ -163,7 +173,7 @@ export type ConnectorDeviceAuthorizationStartArgs<
   Method extends ConnectorDeviceAuthGrantAuthMethodId<T> =
     ConnectorDeviceAuthGrantAuthMethodId<T>,
 > = OAuthDeviceAuthStartFlowArgs &
-  ConnectorAuthMethodClientArgs<T, Method> & {
+  ConnectorAuthMethodClientIdentityArgs<T, Method> & {
     readonly deviceAuthGrant: ConnectorDeviceAuthGrantConfig;
   };
 

--- a/turbo/packages/connectors/src/auth-providers/types.ts
+++ b/turbo/packages/connectors/src/auth-providers/types.ts
@@ -98,7 +98,7 @@ interface NoneRevokeProvider {
   readonly kind: "none";
 }
 
-interface TokenRevokeProvider<
+export interface TokenRevokeProvider<
   T extends TokenRevokeConnectorType,
   Method extends ConnectorAuthMethodIdsByRevokeKind<T, "token-revoke"> =
     ConnectorAuthMethodIdsByRevokeKind<T, "token-revoke">,

--- a/turbo/packages/connectors/src/auth-providers/types.ts
+++ b/turbo/packages/connectors/src/auth-providers/types.ts
@@ -1,7 +1,9 @@
 import type {
   AuthCodeGrantConnectorType,
   ConnectorAuthCodeGrantAuthMethodId,
+  ConnectorAuthMethodIds,
   ConnectorAuthMethodIdsByAccessKind,
+  ConnectorAuthMethodIdsByRevokeKind,
   ConnectorDeviceAuthGrantAuthMethodId,
   ConnectorAuthProviderType,
   ConnectorType,
@@ -74,23 +76,53 @@ export interface RefreshTokenAccessProvider<
   ): Promise<OAuthRefreshResult>;
 }
 
-export type ConnectorAuthProviderAccess<T extends ConnectorType> =
-  T extends RefreshTokenAccessConnectorType
-    ? RefreshTokenAccessProvider<T>
+export type ConnectorAuthProviderAccess<
+  T extends ConnectorType,
+  Method extends ConnectorAuthMethodIds<T> = ConnectorAuthMethodIds<T>,
+> =
+  Method extends ConnectorAuthMethodIdsByAccessKind<
+    T & RefreshTokenAccessConnectorType,
+    "refresh-token"
+  >
+    ? RefreshTokenAccessProvider<
+        T & RefreshTokenAccessConnectorType,
+        Method &
+          ConnectorAuthMethodIdsByAccessKind<
+            T & RefreshTokenAccessConnectorType,
+            "refresh-token"
+          >
+      >
     : NoneAccessProvider;
 
 interface NoneRevokeProvider {
   readonly kind: "none";
 }
 
-interface TokenRevokeProvider<T extends ConnectorAuthProviderType> {
+interface TokenRevokeProvider<
+  T extends TokenRevokeConnectorType,
+  Method extends ConnectorAuthMethodIdsByRevokeKind<T, "token-revoke"> =
+    ConnectorAuthMethodIdsByRevokeKind<T, "token-revoke">,
+> {
   readonly kind: "token-revoke";
-  revokeToken(args: ConnectorAuthProviderRevokeArgs<T>): Promise<void>;
+  revokeToken(args: ConnectorAuthProviderRevokeArgs<T, Method>): Promise<void>;
 }
 
-export type ConnectorAuthProviderRevoke<T extends ConnectorAuthProviderType> =
-  T extends TokenRevokeConnectorType
-    ? TokenRevokeProvider<T>
+export type ConnectorAuthProviderRevoke<
+  T extends ConnectorAuthProviderType,
+  Method extends ConnectorAuthMethodIds<T> = ConnectorAuthMethodIds<T>,
+> =
+  Method extends ConnectorAuthMethodIdsByRevokeKind<
+    T & TokenRevokeConnectorType,
+    "token-revoke"
+  >
+    ? TokenRevokeProvider<
+        T & TokenRevokeConnectorType,
+        Method &
+          ConnectorAuthMethodIdsByRevokeKind<
+            T & TokenRevokeConnectorType,
+            "token-revoke"
+          >
+      >
     : NoneRevokeProvider;
 
 export interface AuthProvider<TGrant, TAccess, TRevoke> {
@@ -105,8 +137,8 @@ export type AuthCodeConnectorAuthProvider<
     ConnectorAuthCodeGrantAuthMethodId<T>,
 > = AuthProvider<
   AuthCodeGrantProvider<T, Method>,
-  ConnectorAuthProviderAccess<T>,
-  ConnectorAuthProviderRevoke<T>
+  ConnectorAuthProviderAccess<T, Method>,
+  ConnectorAuthProviderRevoke<T, Method>
 >;
 
 export type DeviceAuthConnectorAuthProvider<
@@ -115,8 +147,8 @@ export type DeviceAuthConnectorAuthProvider<
     ConnectorDeviceAuthGrantAuthMethodId<T>,
 > = AuthProvider<
   DeviceAuthGrantProvider<T, Method>,
-  ConnectorAuthProviderAccess<T>,
-  ConnectorAuthProviderRevoke<T>
+  ConnectorAuthProviderAccess<T, Method>,
+  ConnectorAuthProviderRevoke<T, Method>
 >;
 
 export type ModelProviderGrantProvider = NoneGrantProvider;

--- a/turbo/packages/connectors/src/auth-providers/types.ts
+++ b/turbo/packages/connectors/src/auth-providers/types.ts
@@ -11,6 +11,7 @@ import type {
   RefreshTokenAccessConnectorType,
   TokenRevokeConnectorType,
 } from "../connectors";
+import type { StaticConnectorAuthClient } from "../connector-utils";
 import type {
   AuthUrlResult,
   ConnectorAuthCodeAuthorizeArgs,
@@ -153,9 +154,10 @@ export type DeviceAuthConnectorAuthProvider<
 
 export type ModelProviderGrantProvider = NoneGrantProvider;
 
-interface ModelProviderOAuthRefreshArgs {
-  readonly clientId?: string;
-  readonly clientSecret?: string;
+export type ModelProviderAuthClient = StaticConnectorAuthClient;
+
+interface ModelProviderAuthProviderRefreshArgs {
+  readonly authClient: ModelProviderAuthClient;
   readonly refreshToken: string;
   readonly signal: AbortSignal;
 }
@@ -164,10 +166,11 @@ interface ModelProviderRefreshTokenAccessProvider {
   readonly kind: "refresh-token";
   getAccessSecretName(): string;
   getRefreshSecretName(): string;
-  getClientId(currentEnv: ProviderEnv): string | undefined;
-  getClientSecret(currentEnv: ProviderEnv): string | undefined;
+  resolveAuthClient(
+    currentEnv: ProviderEnv,
+  ): ModelProviderAuthClient | undefined;
   refreshToken(
-    args: ModelProviderOAuthRefreshArgs,
+    args: ModelProviderAuthProviderRefreshArgs,
   ): Promise<OAuthRefreshResult>;
 }
 

--- a/turbo/packages/connectors/src/connector-utils.ts
+++ b/turbo/packages/connectors/src/connector-utils.ts
@@ -819,6 +819,18 @@ export function isStaticConfidentialConnectorAuthClient(
 }
 
 export function connectorAuthClientIdentity(
+  authClient: StaticConfidentialConnectorAuthClient,
+): StaticConfidentialConnectorAuthClientIdentity;
+export function connectorAuthClientIdentity(
+  authClient: StaticPublicConnectorAuthClient,
+): StaticPublicConnectorAuthClient;
+export function connectorAuthClientIdentity(
+  authClient: DynamicPublicConnectorAuthClient,
+): DynamicPublicConnectorAuthClient;
+export function connectorAuthClientIdentity(
+  authClient: ConnectorAuthClient,
+): ConnectorAuthClientIdentity;
+export function connectorAuthClientIdentity(
   authClient: ConnectorAuthClient,
 ): ConnectorAuthClientIdentity {
   switch (authClient.clientRegistration) {

--- a/turbo/packages/connectors/src/connector-utils.ts
+++ b/turbo/packages/connectors/src/connector-utils.ts
@@ -32,7 +32,6 @@ import {
   type DynamicPublicConnectorAuthClientConfig,
   type StaticConfidentialConnectorAuthClientConfig,
   type StaticPublicConnectorAuthClientConfig,
-  type TokenRevokeConnectorType,
 } from "./connectors";
 import type { FeatureSwitchKey } from "./feature-switch-key";
 
@@ -606,15 +605,6 @@ export function getConnectorAuthMethodGrantScopes(
   return [
     ...connectorGrantScopes(getConnectorAuthMethod(type, authMethod)?.grant),
   ];
-}
-
-export function connectorAuthMethodSupportsTokenRevoke(
-  type: ConnectorType,
-  authMethod: string,
-): type is TokenRevokeConnectorType {
-  return (
-    getConnectorAuthMethod(type, authMethod)?.revoke.kind === "token-revoke"
-  );
 }
 
 export function getConnectorGenerationTypes(

--- a/turbo/packages/connectors/src/connector-utils.ts
+++ b/turbo/packages/connectors/src/connector-utils.ts
@@ -761,8 +761,10 @@ export type ConnectorAuthMethodClientRef<
   readonly authClient: ConnectorAuthClientForMethod<Type, Method>;
 };
 
+export type ConnectorAuthClientGrantKind = "auth-code" | "device-auth";
+
 export type ConnectorAuthMethodClientRefByGrantKind<
-  Kind extends ConnectorGrantKind,
+  Kind extends ConnectorAuthClientGrantKind,
 > = {
   readonly [Type in ConnectorTypesByGrantKind<Kind>]: {
     readonly [Method in ConnectorAuthMethodIdsByGrantKind<
@@ -773,7 +775,7 @@ export type ConnectorAuthMethodClientRefByGrantKind<
 }[ConnectorTypesByGrantKind<Kind>];
 
 export type ConnectorAuthMethodClientRefByAccessKind<
-  Kind extends ConnectorAccessKind,
+  Kind extends "refresh-token",
 > = {
   readonly [Type in ConnectorTypesByAccessKind<Kind>]: {
     readonly [Method in ConnectorAuthMethodIdsByAccessKind<
@@ -927,7 +929,7 @@ export function resolveConnectorAuthMethodClientRefByGrantKind(
   readEnv: ConnectorEnvReader,
 ): ConnectorAuthMethodClientRefByGrantKind<"device-auth"> | undefined;
 export function resolveConnectorAuthMethodClientRefByGrantKind(
-  authMethodRef: ConnectorAuthMethodRefByGrantKind<"auth-code" | "device-auth">,
+  authMethodRef: ConnectorAuthMethodRefByGrantKind<ConnectorAuthClientGrantKind>,
   readEnv: ConnectorEnvReader,
 ): ResolvedConnectorAuthMethodClientRef | undefined {
   return resolveConnectorAuthMethodClientRef(authMethodRef, readEnv);

--- a/turbo/packages/connectors/src/connector-utils.ts
+++ b/turbo/packages/connectors/src/connector-utils.ts
@@ -109,7 +109,7 @@ export function getConnectorAuthMethodIdsForGrantKind<
   );
 }
 
-export function connectorAuthMethodHasAccessKind<
+function connectorAuthMethodHasAccessKind<
   Type extends ConnectorType,
   Kind extends ConnectorAccessKind,
 >(

--- a/turbo/packages/connectors/src/connector-utils.ts
+++ b/turbo/packages/connectors/src/connector-utils.ts
@@ -30,7 +30,6 @@ import {
   type AuthCodeGrantConnectorType,
   type DeviceAuthGrantConnectorType,
   type DynamicPublicConnectorAuthClientConfig,
-  type RefreshTokenAccessConnectorType,
   type StaticConfidentialConnectorAuthClientConfig,
   type StaticPublicConnectorAuthClientConfig,
   type TokenRevokeConnectorType,
@@ -111,7 +110,7 @@ export function getConnectorAuthMethodIdsForGrantKind<
   );
 }
 
-function connectorAuthMethodHasAccessKind<
+export function connectorAuthMethodHasAccessKind<
   Type extends ConnectorType,
   Kind extends ConnectorAccessKind,
 >(
@@ -618,15 +617,6 @@ export function connectorAuthMethodSupportsTokenRevoke(
   );
 }
 
-export function connectorAuthMethodSupportsRefreshTokenAccess(
-  type: ConnectorType,
-  authMethod: string,
-): type is RefreshTokenAccessConnectorType {
-  return (
-    getConnectorAuthMethod(type, authMethod)?.access.kind === "refresh-token"
-  );
-}
-
 export function getConnectorGenerationTypes(
   type: ConnectorType,
 ): readonly ConnectorGenerationType[] {
@@ -762,6 +752,37 @@ export type ConnectorAuthClientForMethod<
   Method extends ConnectorAuthMethodIds<Type>,
 > = ConnectorAuthClientForConfig<ConnectorAuthMethodClientConfig<Type, Method>>;
 
+export type ConnectorAuthMethodClientRef<
+  Type extends ConnectorType,
+  Method extends ConnectorAuthMethodIds<Type>,
+> = {
+  readonly type: Type;
+  readonly authMethod: Method;
+  readonly authClient: ConnectorAuthClientForMethod<Type, Method>;
+};
+
+export type ConnectorAuthMethodClientRefByGrantKind<
+  Kind extends ConnectorGrantKind,
+> = {
+  readonly [Type in ConnectorTypesByGrantKind<Kind>]: {
+    readonly [Method in ConnectorAuthMethodIdsByGrantKind<
+      Type,
+      Kind
+    >]: ConnectorAuthMethodClientRef<Type, Method>;
+  }[ConnectorAuthMethodIdsByGrantKind<Type, Kind>];
+}[ConnectorTypesByGrantKind<Kind>];
+
+export type ConnectorAuthMethodClientRefByAccessKind<
+  Kind extends ConnectorAccessKind,
+> = {
+  readonly [Type in ConnectorTypesByAccessKind<Kind>]: {
+    readonly [Method in ConnectorAuthMethodIdsByAccessKind<
+      Type,
+      Kind
+    >]: ConnectorAuthMethodClientRef<Type, Method>;
+  }[ConnectorAuthMethodIdsByAccessKind<Type, Kind>];
+}[ConnectorTypesByAccessKind<Kind>];
+
 export function isStaticConnectorAuthClient(
   authClient: ConnectorAuthClient,
 ): authClient is StaticConnectorAuthClient {
@@ -870,6 +891,57 @@ export function resolveConnectorAuthClientForMethod(
     return undefined;
   }
   return resolveConnectorAuthClient(clientConfig, readEnv);
+}
+
+type ResolvedConnectorAuthMethodClientRef = {
+  readonly type: ConnectorType;
+  readonly authMethod: ConnectorAuthMethodId;
+  readonly authClient: ConnectorAuthClient;
+};
+
+function resolveConnectorAuthMethodClientRef(
+  authMethodRef: ConnectorAuthMethodRef,
+  readEnv: ConnectorEnvReader,
+): ResolvedConnectorAuthMethodClientRef | undefined {
+  const authClient = resolveConnectorAuthClientForMethod(
+    authMethodRef.type,
+    authMethodRef.authMethod,
+    readEnv,
+  );
+  if (!authClient) {
+    return undefined;
+  }
+  return {
+    type: authMethodRef.type,
+    authMethod: authMethodRef.authMethod,
+    authClient,
+  };
+}
+
+export function resolveConnectorAuthMethodClientRefByGrantKind(
+  authMethodRef: ConnectorAuthMethodRefByGrantKind<"auth-code">,
+  readEnv: ConnectorEnvReader,
+): ConnectorAuthMethodClientRefByGrantKind<"auth-code"> | undefined;
+export function resolveConnectorAuthMethodClientRefByGrantKind(
+  authMethodRef: ConnectorAuthMethodRefByGrantKind<"device-auth">,
+  readEnv: ConnectorEnvReader,
+): ConnectorAuthMethodClientRefByGrantKind<"device-auth"> | undefined;
+export function resolveConnectorAuthMethodClientRefByGrantKind(
+  authMethodRef: ConnectorAuthMethodRefByGrantKind<"auth-code" | "device-auth">,
+  readEnv: ConnectorEnvReader,
+): ResolvedConnectorAuthMethodClientRef | undefined {
+  return resolveConnectorAuthMethodClientRef(authMethodRef, readEnv);
+}
+
+export function resolveConnectorAuthMethodClientRefByAccessKind(
+  authMethodRef: ConnectorAuthMethodRefByAccessKind<"refresh-token">,
+  readEnv: ConnectorEnvReader,
+): ConnectorAuthMethodClientRefByAccessKind<"refresh-token"> | undefined;
+export function resolveConnectorAuthMethodClientRefByAccessKind(
+  authMethodRef: ConnectorAuthMethodRefByAccessKind<"refresh-token">,
+  readEnv: ConnectorEnvReader,
+): ResolvedConnectorAuthMethodClientRef | undefined {
+  return resolveConnectorAuthMethodClientRef(authMethodRef, readEnv);
 }
 
 function hasRuntimeAvailableAuthMethod(

--- a/turbo/packages/connectors/src/connector-utils.ts
+++ b/turbo/packages/connectors/src/connector-utils.ts
@@ -708,6 +708,12 @@ export type StaticConfidentialConnectorAuthClient = {
   readonly clientSecret: string;
 };
 
+export type StaticConfidentialConnectorAuthClientIdentity = {
+  readonly clientRegistration: "static";
+  readonly clientType: "confidential";
+  readonly clientId: string;
+};
+
 export type StaticPublicConnectorAuthClient = {
   readonly clientRegistration: "static";
   readonly clientType: "public";
@@ -727,6 +733,11 @@ export type ConnectorAuthClient =
   | StaticConnectorAuthClient
   | DynamicPublicConnectorAuthClient;
 
+export type ConnectorAuthClientIdentity =
+  | StaticConfidentialConnectorAuthClientIdentity
+  | StaticPublicConnectorAuthClient
+  | DynamicPublicConnectorAuthClient;
+
 export type ConnectorAuthClientForConfig<
   Client extends ConnectorAuthClientConfig,
 > = Client extends StaticConfidentialConnectorAuthClientConfig
@@ -741,6 +752,23 @@ export type ConnectorAuthClientForMethod<
   Type extends ConnectorType,
   Method extends ConnectorAuthMethodIds<Type>,
 > = ConnectorAuthClientForConfig<ConnectorAuthMethodClientConfig<Type, Method>>;
+
+export type ConnectorAuthClientIdentityForConfig<
+  Client extends ConnectorAuthClientConfig,
+> = Client extends StaticConfidentialConnectorAuthClientConfig
+  ? StaticConfidentialConnectorAuthClientIdentity
+  : Client extends StaticPublicConnectorAuthClientConfig
+    ? StaticPublicConnectorAuthClient
+    : Client extends DynamicPublicConnectorAuthClientConfig
+      ? DynamicPublicConnectorAuthClient
+      : never;
+
+export type ConnectorAuthClientIdentityForMethod<
+  Type extends ConnectorType,
+  Method extends ConnectorAuthMethodIds<Type>,
+> = ConnectorAuthClientIdentityForConfig<
+  ConnectorAuthMethodClientConfig<Type, Method>
+>;
 
 export type ConnectorAuthMethodClientRef<
   Type extends ConnectorType,
@@ -788,6 +816,32 @@ export function isStaticConfidentialConnectorAuthClient(
     isStaticConnectorAuthClient(authClient) &&
     authClient.clientType === "confidential"
   );
+}
+
+export function connectorAuthClientIdentity(
+  authClient: ConnectorAuthClient,
+): ConnectorAuthClientIdentity {
+  switch (authClient.clientRegistration) {
+    case "dynamic":
+      return authClient;
+    case "static":
+      return {
+        clientRegistration: "static",
+        clientType: authClient.clientType,
+        clientId: authClient.clientId,
+      };
+  }
+}
+
+export function connectorAuthClientIdentityForMethod<
+  Type extends ConnectorType,
+  Method extends ConnectorAuthMethodIds<Type>,
+>(
+  authClient: ConnectorAuthClientForMethod<Type, Method>,
+): ConnectorAuthClientIdentityForMethod<Type, Method> {
+  return connectorAuthClientIdentity(
+    authClient,
+  ) as ConnectorAuthClientIdentityForMethod<Type, Method>;
 }
 
 export function getConnectorAuthClientConfigForMethod<

--- a/turbo/packages/connectors/src/connector-utils.ts
+++ b/turbo/packages/connectors/src/connector-utils.ts
@@ -10,7 +10,9 @@ import {
   type ConnectorAuthMethodIdsByAccessKind,
   type ConnectorAuthMethodIdsByGrantKind,
   type ConnectorAuthMethodIdsByRevokeKind,
+  type ConnectorTypesByAccessKind,
   type ConnectorTypesByGrantKind,
+  type ConnectorTypesByRevokeKind,
   type ConnectorAuthMethodClientConfig,
   type ConnectorAccessConfig,
   type ConnectorAccessKind,
@@ -494,6 +496,24 @@ export type ConnectorAuthMethodRefByGrantKind<Kind extends ConnectorGrantKind> =
     };
   }[ConnectorTypesByGrantKind<Kind>];
 
+export type ConnectorAuthMethodRefByAccessKind<
+  Kind extends ConnectorAccessKind,
+> = {
+  readonly [Type in ConnectorTypesByAccessKind<Kind>]: {
+    readonly type: Type;
+    readonly authMethod: ConnectorAuthMethodIdsByAccessKind<Type, Kind>;
+  };
+}[ConnectorTypesByAccessKind<Kind>];
+
+export type ConnectorAuthMethodRefByRevokeKind<
+  Kind extends ConnectorRevokeKind,
+> = {
+  readonly [Type in ConnectorTypesByRevokeKind<Kind>]: {
+    readonly type: Type;
+    readonly authMethod: ConnectorAuthMethodIdsByRevokeKind<Type, Kind>;
+  };
+}[ConnectorTypesByRevokeKind<Kind>];
+
 export function connectorAuthMethodRefHasGrantKind<
   Kind extends ConnectorGrantKind,
 >(
@@ -503,6 +523,30 @@ export function connectorAuthMethodRefHasGrantKind<
   return (
     getConnectorAuthMethod(authMethodRef.type, authMethodRef.authMethod)?.grant
       .kind === grantKind
+  );
+}
+
+export function connectorAuthMethodRefHasAccessKind<
+  Kind extends ConnectorAccessKind,
+>(
+  authMethodRef: ConnectorAuthMethodRef,
+  accessKind: Kind,
+): authMethodRef is ConnectorAuthMethodRefByAccessKind<Kind> {
+  return (
+    getConnectorAuthMethod(authMethodRef.type, authMethodRef.authMethod)?.access
+      .kind === accessKind
+  );
+}
+
+export function connectorAuthMethodRefHasRevokeKind<
+  Kind extends ConnectorRevokeKind,
+>(
+  authMethodRef: ConnectorAuthMethodRef,
+  revokeKind: Kind,
+): authMethodRef is ConnectorAuthMethodRefByRevokeKind<Kind> {
+  return (
+    getConnectorAuthMethod(authMethodRef.type, authMethodRef.authMethod)?.revoke
+      .kind === revokeKind
   );
 }
 

--- a/turbo/packages/connectors/src/connectors.ts
+++ b/turbo/packages/connectors/src/connectors.ts
@@ -1040,6 +1040,10 @@ export type ConnectorAuthMethodIds<Type extends ConnectorType> = Extract<
   keyof ConnectorAuthMethodsOf<Type>,
   ConnectorAuthMethodId
 >;
+export type ConnectorAuthMethodConfigFor<
+  Type extends ConnectorType,
+  Method extends ConnectorAuthMethodIds<Type>,
+> = ConnectorAuthMethodsOf<Type>[Method] & ConnectorAuthMethodConfig;
 export type ConnectorAuthMethodClientConfig<
   Type extends ConnectorType,
   Method extends ConnectorAuthMethodIds<Type>,


### PR DESCRIPTION
## Summary

- Replace broad connector auth provider client args with exact method-bound `authClient` provider args.
- Type connector auth provider registry entries by `(connectorType, authMethod)` and add method-aware call overloads for API runtime refs.
- Preserve selected auth method/client refs across auth-code callback, device auth, and firewall refresh paths.
- Update focused connector/API tests, including method-specific test OAuth providers.

Closes #14642

## Tests

- `pnpm -F @vm0/connectors check-types`
- `pnpm -F api check-types`
- `pnpm -F @vm0/connectors lint`
- `pnpm -F api lint`
- `pnpm -F @vm0/connectors test`
- `pnpm -F api exec vitest run src/signals/routes/__tests__/connectors-type-callback.test.ts src/signals/routes/__tests__/webhooks-agent-firewall-auth.test.ts src/signals/routes/__tests__/zero-connectors-oauth-device-auth.test.ts`
- `pnpm check-types`

Pre-commit also ran `prettier`, `knip`, and `check-types`.
