### PR TITLE
chore: update rootfs package versions

### DIFF
--- a/crates/runner/scripts/build-template.sh
+++ b/crates/runner/scripts/build-template.sh
@@ -116,7 +116,7 @@ CODEX_CLI_VERSION="0.136.0"
 GWS_CLI_VERSION="0.22.5"
 XURL_VERSION="1.0.3"
 AGENT_BROWSER_VERSION="0.27.1"
-PNPM_VERSION="11.5.0"
+PNPM_VERSION="11.5.1"
 
 # ---------------------------------------------------------------------------
 # Dependency checks


### PR DESCRIPTION
## Summary
- Updated `pnpm` in `crates/runner/scripts/build-template.sh` from `11.5.0` to `11.5.1`.
- Confirmed the other explicit rootfs tool pins are already current: Go `1.26.3`, Claude Code `2.1.160`, Codex CLI `0.136.0`, Google Workspace CLI `0.22.5`, xurl `1.0.3`, and agent-browser `0.27.1`.
- Kept NodeSource on Node 24, the current LTS line, and did not change Ubuntu Noble.

## Verification
- `bash -n crates/runner/scripts/build-template.sh`