### PR TITLE
feat: render markdown files in skills detail dialog

### DIFF
--- a/turbo/apps/platform/src/views/skills-page/__tests__/skills-page.test.tsx
+++ b/turbo/apps/platform/src/views/skills-page/__tests__/skills-page.test.tsx
@@ -116,6 +116,7 @@ function setupSkillsPage(): void {
       files: [
         { path: "SKILL.md", size: 37 },
         { path: "templates/prompt.md", size: 12 },
+        { path: "scripts/run.sh", size: 18 },
       ],
       fileContents: [
         {
@@ -123,6 +124,7 @@ function setupSkillsPage(): void {
           content: "# Research Notes\n\nStart with sources.",
         },
         { path: "templates/prompt.md", content: "Use the tool" },
+        { path: "scripts/run.sh", content: "#!/bin/sh\necho hi" },
       ],
     },
     {
@@ -189,7 +191,7 @@ describe("skills page", () => {
 
     await waitFor(() => {
       expect(screen.getByLabelText("Skill content")).toHaveTextContent(
-        "# Research Notes",
+        "Research Notes",
       );
     });
 
@@ -216,5 +218,34 @@ describe("skills page", () => {
         return button.textContent === "Save";
       }),
     ).toBeFalsy();
+  });
+
+  it("renders markdown files as formatted markdown and keeps non-markdown files raw", async () => {
+    setupSkillsPage();
+
+    click(await screen.findByText("Research Notes"));
+
+    // SKILL.md is markdown: rendered as a heading element, not raw "# ..." text.
+    await waitFor(() => {
+      expect(
+        within(screen.getByLabelText("Skill content")).getByRole("heading", {
+          name: "Research Notes",
+        }),
+      ).toBeInTheDocument();
+    });
+
+    const dialog = screen.getByRole("dialog");
+    const scriptButton = queryAllByRoleFast("button", dialog).find((button) => {
+      return button.textContent?.includes("scripts/run.sh");
+    });
+    expect(scriptButton).toBeDefined();
+    click(scriptButton!);
+
+    // Non-markdown file stays raw: rendered in a <pre> with "#" preserved.
+    await waitFor(() => {
+      const content = screen.getByLabelText("Skill content");
+      expect(content.tagName).toBe("PRE");
+      expect(content).toHaveTextContent("#!/bin/sh");
+    });
   });
 });

--- a/turbo/apps/platform/src/views/skills-page/skills-page.tsx
+++ b/turbo/apps/platform/src/views/skills-page/skills-page.tsx
@@ -34,6 +34,7 @@ import {
   skillUsages$,
 } from "../../signals/skills-page/skills-signals.ts";
 import { ROUTES } from "../../signals/route-paths.ts";
+import { Markdown } from "../components/markdown.tsx";
 import { Link } from "../router/link.tsx";
 import { AvatarFromUrl } from "../zero-page/zero-sidebar-shared.tsx";
 
@@ -51,6 +52,10 @@ function skillTitle(skill: {
 
 function agentTitle(agent: TeamComposeItem): string {
   return agent.displayName ?? agent.id;
+}
+
+function isMarkdownPath(path: string): boolean {
+  return /\.(md|markdown|mdx)$/i.test(path);
 }
 
 export function SkillsPage() {
@@ -370,12 +375,21 @@ function SkillEditor({
             </span>
           </div>
           {selectedFilePath && selectedContent !== null ? (
-            <pre
-              aria-label="Skill content"
-              className="min-h-[420px] flex-1 overflow-auto whitespace-pre-wrap bg-background px-4 py-3 font-mono text-sm leading-6 text-foreground"
-            >
-              {selectedContent}
-            </pre>
+            isMarkdownPath(selectedFilePath) ? (
+              <div
+                aria-label="Skill content"
+                className="min-h-[420px] flex-1 overflow-auto bg-background px-4 py-3"
+              >
+                <Markdown source={selectedContent} />
+              </div>
+            ) : (
+              <pre
+                aria-label="Skill content"
+                className="min-h-[420px] flex-1 overflow-auto whitespace-pre-wrap bg-background px-4 py-3 font-mono text-sm leading-6 text-foreground"
+              >
+                {selectedContent}
+              </pre>
+            )
           ) : (
             <div className="flex min-h-[420px] flex-1 items-center justify-center px-4 text-sm text-muted-foreground">
               {selectedFilePath


### PR DESCRIPTION
## What

On the Skills page (`/skills`), the detail dialog rendered every file's contents as raw monospace text in a `<pre>`. `SKILL.md` — authored as Markdown — was therefore shown unrendered (no headings, lists, code blocks, links, or tables).

This change renders Markdown files (`.md` / `.markdown` / `.mdx`) using the platform's existing `Markdown` component (the same renderer used in chat/activity views). Non-markdown files (scripts, plain text, etc.) keep the raw `<pre>` view.

## Changes

- `skills-page.tsx`: add an `isMarkdownPath()` helper; render the selected file with `<Markdown source={...} />` when it is a markdown file, otherwise keep the existing `<pre>`. The `aria-label="Skill content"` hook is preserved on both branches.
- `skills-page.test.tsx`: assert that `SKILL.md` renders as a heading element (not raw `#` text) and that a non-markdown file (`scripts/run.sh`) stays in a raw `<pre>`.

## Testing

- `pnpm -F @vm0/app run test src/views/skills-page/__tests__/skills-page.test.tsx` — 4 passed
- `check-types`, `lint`, `prettier --check`, `knip` — all clean

Closes #15897

🤖 Generated with [Claude Code](https://claude.com/claude-code)