### PR TITLE
feat: add read-only memory viewer page to platform

### DIFF
--- a/turbo/apps/api/src/signals/route.ts
+++ b/turbo/apps/api/src/signals/route.ts
@@ -90,6 +90,7 @@ import { zeroEmailCallbackRoutes } from "./routes/zero-email-callbacks";
 import { zeroEmailInboundRoutes } from "./routes/zero-email-inbound";
 import { zeroFeatureSwitchesRoutes } from "./routes/zero-feature-switches";
 import { zeroHostRoutes } from "./routes/zero-host";
+import { zeroMemoryRoutes } from "./routes/zero-memory";
 import { zeroBuiltInGenerationRoutes } from "./routes/zero-built-in-generation";
 import { zeroInsightsRoutes } from "./routes/zero-insights";
 import { zeroImageIoGenerateRoutes } from "./routes/zero-image-io-generate";
@@ -271,6 +272,7 @@ export const ROUTES: readonly RouteEntry[] = [
   ...zeroEmailInboundRoutes,
   ...zeroFeatureSwitchesRoutes,
   ...zeroHostRoutes,
+  ...zeroMemoryRoutes,
   ...zeroBuiltInGenerationRoutes,
   ...zeroInsightsRoutes,
   ...zeroImageIoGenerateRoutes,

--- a/turbo/apps/api/src/signals/routes/__tests__/helpers/zero-memory.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/helpers/zero-memory.ts
@@ -1,0 +1,238 @@
+import { randomUUID } from "node:crypto";
+import { gzipSync } from "node:zlib";
+
+import { MEMORY_ARTIFACT_NAME } from "@vm0/core/storage-names";
+import { command } from "ccstate";
+import { orgMetadata } from "@vm0/db/schema/org-metadata";
+import { storages, storageVersions } from "@vm0/db/schema/storage";
+import { eq } from "drizzle-orm";
+
+import type { TestContext } from "../../../../__tests__/test-helpers";
+import { writeDb$ } from "../../../external/db";
+
+export interface MemoryFixture {
+  readonly orgId: string;
+  readonly userId: string;
+}
+
+export const seedMemoryFixture$ = command(
+  async (
+    { set },
+    _input: void,
+    signal: AbortSignal,
+  ): Promise<MemoryFixture> => {
+    const db = set(writeDb$);
+    const fixture = {
+      orgId: `org_${randomUUID()}`,
+      userId: `user_${randomUUID()}`,
+    };
+    await db.insert(orgMetadata).values({
+      orgId: fixture.orgId,
+      tier: "free",
+      credits: 10_000,
+    });
+    signal.throwIfAborted();
+    return fixture;
+  },
+);
+
+export const deleteMemoryForFixture$ = command(
+  async (
+    { set },
+    fixture: MemoryFixture,
+    signal: AbortSignal,
+  ): Promise<void> => {
+    const db = set(writeDb$);
+    // Storage cascade deletes storage_versions via FK.
+    await db.delete(storages).where(eq(storages.orgId, fixture.orgId));
+    signal.throwIfAborted();
+    await db.delete(orgMetadata).where(eq(orgMetadata.orgId, fixture.orgId));
+    signal.throwIfAborted();
+  },
+);
+
+interface MemoryStorageSeed {
+  readonly orgId: string;
+  readonly userId: string;
+  readonly s3Key: string;
+  readonly headVersionId?: string | null;
+  readonly size?: number;
+  readonly fileCount?: number;
+  readonly updatedAt?: Date;
+  readonly type?: string;
+  readonly name?: string;
+}
+
+export const seedMemoryStorage$ = command(
+  async (
+    { set },
+    args: MemoryStorageSeed,
+    signal: AbortSignal,
+  ): Promise<void> => {
+    const db = set(writeDb$);
+    const storageId = randomUUID();
+    const name = args.name ?? MEMORY_ARTIFACT_NAME;
+
+    await db.insert(storages).values({
+      id: storageId,
+      userId: args.userId,
+      name,
+      type: args.type ?? "artifact",
+      orgId: args.orgId,
+      s3Prefix: `orgs/${args.orgId}/users/${args.userId}/${name}`,
+      size: args.size ?? 0,
+      fileCount: args.fileCount ?? 0,
+      updatedAt: args.updatedAt ?? new Date("2025-01-01T00:00:00.000Z"),
+    });
+    signal.throwIfAborted();
+
+    if (args.headVersionId === null) {
+      return;
+    }
+
+    const headVersionId = args.headVersionId ?? `head-${randomUUID()}`;
+    await db.insert(storageVersions).values({
+      id: headVersionId,
+      storageId,
+      s3Key: args.s3Key,
+      createdBy: args.userId,
+    });
+    signal.throwIfAborted();
+
+    await db
+      .update(storages)
+      .set({ headVersionId })
+      .where(eq(storages.id, storageId));
+    signal.throwIfAborted();
+  },
+);
+
+interface MemoryFile {
+  readonly path: string;
+  readonly content: string;
+}
+
+interface MemoryContentMockArgs {
+  readonly s3Key: string;
+  readonly files: readonly MemoryFile[];
+}
+
+const TAR_BLOCK_SIZE = 512;
+
+function octal(value: number, length: number): string {
+  return value.toString(8).padStart(length - 1, "0") + "\0";
+}
+
+function createTarEntry(filename: string, content: Buffer): Buffer {
+  // POSIX tar header (USTAR-compatible) is sufficient for extractFilesFromTarGz
+  // to parse the filename, size, and payload.
+  const header = Buffer.alloc(TAR_BLOCK_SIZE);
+  header.write(filename, 0, 100, "utf8");
+  header.write("0000644\0", 100); // mode
+  header.write("0000000\0", 108); // uid
+  header.write("0000000\0", 116); // gid
+  header.write(octal(content.length, 12), 124); // size
+  header.write(octal(0, 12), 136); // mtime
+  // Checksum placeholder: 8 spaces required so the checksum sum is correct.
+  header.write("        ", 148);
+  header.write("0", 156); // type flag (regular file)
+
+  let checksum = 0;
+  for (const byte of header) {
+    checksum += byte;
+  }
+  // Final checksum: 6 octal digits, NUL, space.
+  header.write(checksum.toString(8).padStart(6, "0") + "\0 ", 148);
+
+  const padding = content.length % TAR_BLOCK_SIZE;
+  const dataBlocks =
+    padding === 0
+      ? content
+      : Buffer.concat([content, Buffer.alloc(TAR_BLOCK_SIZE - padding)]);
+
+  return Buffer.concat([header, dataBlocks]);
+}
+
+function createTarGz(
+  files: readonly { readonly filename: string; readonly content: Buffer }[],
+): Buffer {
+  const eofBlocks = Buffer.alloc(TAR_BLOCK_SIZE * 2);
+  return gzipSync(
+    Buffer.concat([
+      ...files.map((file) => {
+        return createTarEntry(file.filename, file.content);
+      }),
+      eofBlocks,
+    ]),
+  );
+}
+
+function asyncIterableOf(buffer: Buffer): AsyncIterable<Uint8Array> {
+  return {
+    async *[Symbol.asyncIterator]() {
+      yield buffer;
+    },
+  };
+}
+
+function commandKey(command: unknown): string {
+  if (
+    typeof command !== "object" ||
+    command === null ||
+    !("input" in command)
+  ) {
+    return "";
+  }
+  const input = (command as { input: unknown }).input;
+  if (
+    typeof input !== "object" ||
+    input === null ||
+    !("Key" in input) ||
+    typeof (input as { Key: unknown }).Key !== "string"
+  ) {
+    return "";
+  }
+  return (input as { Key: string }).Key;
+}
+
+export function mockMemoryContent(
+  context: TestContext,
+  args: MemoryContentMockArgs,
+): void {
+  const files = args.files.map((file) => {
+    return { path: file.path, content: Buffer.from(file.content, "utf8") };
+  });
+  const archive = createTarGz(
+    files.map((file) => {
+      return { filename: file.path, content: file.content };
+    }),
+  );
+
+  const manifest = {
+    version: "test-version",
+    createdAt: new Date(0).toISOString(),
+    files: files.map((file) => {
+      return {
+        path: file.path,
+        hash: "test-hash-memory",
+        size: file.content.length,
+      };
+    }),
+    totalSize: files.reduce((sum, file) => {
+      return sum + file.content.length;
+    }, 0),
+    fileCount: files.length,
+  };
+  const manifestBuffer = Buffer.from(JSON.stringify(manifest), "utf8");
+
+  context.mocks.s3.send.mockImplementation((cmd: unknown): Promise<unknown> => {
+    const key = commandKey(cmd);
+    if (key === `${args.s3Key}/manifest.json`) {
+      return Promise.resolve({ Body: asyncIterableOf(manifestBuffer) });
+    }
+    if (key === `${args.s3Key}/archive.tar.gz`) {
+      return Promise.resolve({ Body: asyncIterableOf(archive) });
+    }
+    return Promise.resolve({});
+  });
+}

--- a/turbo/apps/api/src/signals/routes/__tests__/zero-memory.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/zero-memory.test.ts
@@ -1,0 +1,290 @@
+import { randomUUID } from "node:crypto";
+
+import { zeroMemoryContract } from "@vm0/api-contracts/contracts/zero-memory";
+import { MEMORY_ARTIFACT_NAME } from "@vm0/core/storage-names";
+import { cliTokens } from "@vm0/db/schema/cli-tokens";
+import { orgMembersCache } from "@vm0/db/schema/org-members-cache";
+import { createStore } from "ccstate";
+
+import { accept, setupApp, testContext } from "../../../__tests__/test-helpers";
+import { now } from "../../../lib/time";
+import { generateCliToken } from "../../auth/tokens";
+import { writeDb$ } from "../../external/db";
+import {
+  deleteMemoryForFixture$,
+  mockMemoryContent,
+  type MemoryFixture,
+  seedMemoryFixture$,
+  seedMemoryStorage$,
+} from "./helpers/zero-memory";
+import {
+  createFixtureTracker,
+  createZeroRouteMocks,
+} from "./helpers/zero-route-test";
+
+const context = testContext();
+const store = createStore();
+const mocks = createZeroRouteMocks(context);
+
+function authHeaders() {
+  return { authorization: "Bearer clerk-session" };
+}
+
+async function cliAuthHeaders(
+  fixture: MemoryFixture,
+): Promise<{ readonly authorization: string }> {
+  const tokenId = randomUUID();
+  const token = generateCliToken(fixture.userId, fixture.orgId, tokenId);
+  const writeDb = store.set(writeDb$);
+  await writeDb.insert(cliTokens).values({
+    id: tokenId,
+    token,
+    userId: fixture.userId,
+    name: "Test Token",
+    expiresAt: new Date(now() + 60 * 60 * 1000),
+  });
+  await writeDb
+    .insert(orgMembersCache)
+    .values({
+      orgId: fixture.orgId,
+      userId: fixture.userId,
+      role: "member",
+      cachedAt: new Date(now() + 60 * 1000),
+    })
+    .onConflictDoUpdate({
+      target: [orgMembersCache.orgId, orgMembersCache.userId],
+      set: {
+        role: "member",
+        cachedAt: new Date(now() + 60 * 1000),
+      },
+    });
+
+  return { authorization: `Bearer ${token}` };
+}
+
+function memoryClient() {
+  return setupApp({ context })(zeroMemoryContract);
+}
+
+describe("GET /api/zero/memory", () => {
+  const track = createFixtureTracker<MemoryFixture>((fixture) => {
+    return store.set(deleteMemoryForFixture$, fixture, context.signal);
+  });
+
+  it("returns 401 when the request is unauthenticated", async () => {
+    const response = await accept(memoryClient().get({ headers: {} }), [401]);
+    expect(response.body).toStrictEqual({
+      error: { message: "Not authenticated", code: "UNAUTHORIZED" },
+    });
+  });
+
+  it("returns 401 when the authenticated session has no organization", async () => {
+    mocks.clerk.session(`user_${randomUUID()}`, null);
+    const response = await accept(
+      memoryClient().get({ headers: authHeaders() }),
+      [401],
+    );
+    expect(response.body).toStrictEqual({
+      error: { message: "Not authenticated", code: "UNAUTHORIZED" },
+    });
+  });
+
+  it("returns exists:false when the user has no memory artifact", async () => {
+    const fixture = await track(
+      store.set(seedMemoryFixture$, undefined, context.signal),
+    );
+    mocks.clerk.session(fixture.userId, fixture.orgId);
+
+    const response = await accept(
+      memoryClient().get({ headers: authHeaders() }),
+      [200],
+    );
+
+    expect(response.body).toStrictEqual({
+      exists: false,
+      name: MEMORY_ARTIFACT_NAME,
+      size: 0,
+      fileCount: 0,
+      updatedAt: null,
+      files: [],
+      fileContents: [],
+    });
+  });
+
+  it("returns an empty file list when the artifact exists but is empty", async () => {
+    const fixture = await track(
+      store.set(seedMemoryFixture$, undefined, context.signal),
+    );
+    const updatedAt = new Date("2025-03-04T05:06:07.000Z");
+    await store.set(
+      seedMemoryStorage$,
+      {
+        orgId: fixture.orgId,
+        userId: fixture.userId,
+        s3Key: `orgs/${fixture.orgId}/users/${fixture.userId}/memory/v1`,
+        headVersionId: null,
+        size: 0,
+        fileCount: 0,
+        updatedAt,
+      },
+      context.signal,
+    );
+    mocks.clerk.session(fixture.userId, fixture.orgId);
+
+    const response = await accept(
+      memoryClient().get({ headers: authHeaders() }),
+      [200],
+    );
+
+    expect(response.body).toStrictEqual({
+      exists: true,
+      name: MEMORY_ARTIFACT_NAME,
+      size: 0,
+      fileCount: 0,
+      updatedAt: updatedAt.toISOString(),
+      files: [],
+      fileContents: [],
+    });
+  });
+
+  it("returns file listing and contents for a populated memory artifact", async () => {
+    const fixture = await track(
+      store.set(seedMemoryFixture$, undefined, context.signal),
+    );
+    const s3Key = `orgs/${fixture.orgId}/users/${fixture.userId}/memory/v1`;
+    const updatedAt = new Date("2025-04-05T06:07:08.000Z");
+    await store.set(
+      seedMemoryStorage$,
+      {
+        orgId: fixture.orgId,
+        userId: fixture.userId,
+        s3Key,
+        size: 31,
+        fileCount: 2,
+        updatedAt,
+      },
+      context.signal,
+    );
+    mockMemoryContent(context, {
+      s3Key,
+      files: [
+        { path: "MEMORY.md", content: "# My Memory" },
+        { path: "notes/todo.md", content: "Do the thing" },
+      ],
+    });
+    mocks.clerk.session(fixture.userId, fixture.orgId);
+
+    const response = await accept(
+      memoryClient().get({ headers: authHeaders() }),
+      [200],
+    );
+
+    expect(response.body).toStrictEqual({
+      exists: true,
+      name: MEMORY_ARTIFACT_NAME,
+      size: 31,
+      fileCount: 2,
+      updatedAt: updatedAt.toISOString(),
+      files: [
+        { path: "MEMORY.md", size: 11 },
+        { path: "notes/todo.md", size: 12 },
+      ],
+      fileContents: [
+        { path: "MEMORY.md", content: "# My Memory" },
+        { path: "notes/todo.md", content: "Do the thing" },
+      ],
+    });
+  });
+
+  it("normalizes ./-prefixed manifest paths", async () => {
+    const fixture = await track(
+      store.set(seedMemoryFixture$, undefined, context.signal),
+    );
+    const s3Key = `orgs/${fixture.orgId}/users/${fixture.userId}/memory/v1`;
+    await store.set(
+      seedMemoryStorage$,
+      {
+        orgId: fixture.orgId,
+        userId: fixture.userId,
+        s3Key,
+        size: 7,
+        fileCount: 1,
+      },
+      context.signal,
+    );
+    mockMemoryContent(context, {
+      s3Key,
+      files: [{ path: "./MEMORY.md", content: "# Memory" }],
+    });
+    mocks.clerk.session(fixture.userId, fixture.orgId);
+
+    const response = await accept(
+      memoryClient().get({ headers: authHeaders() }),
+      [200],
+    );
+
+    expect(response.body.files).toStrictEqual([{ path: "MEMORY.md", size: 8 }]);
+    expect(response.body.fileContents).toStrictEqual([
+      { path: "MEMORY.md", content: "# Memory" },
+    ]);
+  });
+
+  it("scopes memory to the requesting user", async () => {
+    const fixture = await track(
+      store.set(seedMemoryFixture$, undefined, context.signal),
+    );
+    const otherUserId = `user_${randomUUID()}`;
+    const otherS3Key = `orgs/${fixture.orgId}/users/${otherUserId}/memory/v1`;
+    await store.set(
+      seedMemoryStorage$,
+      {
+        orgId: fixture.orgId,
+        userId: otherUserId,
+        s3Key: otherS3Key,
+        size: 12,
+        fileCount: 1,
+      },
+      context.signal,
+    );
+    mocks.clerk.session(fixture.userId, fixture.orgId);
+
+    const response = await accept(
+      memoryClient().get({ headers: authHeaders() }),
+      [200],
+    );
+
+    expect(response.body.exists).toBeFalsy();
+  });
+
+  it("accepts CLI token auth when reading memory", async () => {
+    const fixture = await track(
+      store.set(seedMemoryFixture$, undefined, context.signal),
+    );
+    const s3Key = `orgs/${fixture.orgId}/users/${fixture.userId}/memory/v1`;
+    await store.set(
+      seedMemoryStorage$,
+      {
+        orgId: fixture.orgId,
+        userId: fixture.userId,
+        s3Key,
+        size: 14,
+        fileCount: 1,
+      },
+      context.signal,
+    );
+    mockMemoryContent(context, {
+      s3Key,
+      files: [{ path: "MEMORY.md", content: "# CLI Memory" }],
+    });
+
+    const response = await accept(
+      memoryClient().get({ headers: await cliAuthHeaders(fixture) }),
+      [200],
+    );
+
+    expect(response.body.exists).toBeTruthy();
+    expect(response.body.fileContents).toStrictEqual([
+      { path: "MEMORY.md", content: "# CLI Memory" },
+    ]);
+  });
+});

--- a/turbo/apps/api/src/signals/routes/zero-memory.ts
+++ b/turbo/apps/api/src/signals/routes/zero-memory.ts
@@ -1,0 +1,28 @@
+import { computed } from "ccstate";
+import { zeroMemoryContract } from "@vm0/api-contracts/contracts/zero-memory";
+
+import { organizationAuthContext$ } from "../auth/auth-context";
+import { authRoute } from "../auth/auth-route";
+import type { RouteEntry } from "../route";
+import { zeroMemoryDetail } from "../services/zero-memory-detail.service";
+
+const memoryAuthOptions = {
+  requireOrganization: true,
+  missingOrganizationStatus: 401,
+} as const;
+
+const getMemoryInner$ = computed(async (get): Promise<unknown> => {
+  const auth = get(organizationAuthContext$);
+  const detail = await get(zeroMemoryDetail(auth.orgId, auth.userId));
+  return {
+    status: 200 as const,
+    body: detail,
+  };
+});
+
+export const zeroMemoryRoutes: readonly RouteEntry[] = [
+  {
+    route: zeroMemoryContract.get,
+    handler: authRoute(memoryAuthOptions, getMemoryInner$),
+  },
+];

--- a/turbo/apps/api/src/signals/services/agent-run-create.service.ts
+++ b/turbo/apps/api/src/signals/services/agent-run-create.service.ts
@@ -65,6 +65,7 @@ import { resolveSkillRef, parseGitHubTreeUrl } from "@vm0/core/github-url";
 import {
   getCustomSkillStorageName,
   getSkillStorageName,
+  MEMORY_ARTIFACT_NAME,
 } from "@vm0/core/storage-names";
 import { SEED_SKILLS } from "@vm0/core/zero-seed-skills";
 import {
@@ -133,7 +134,7 @@ import { recordSandboxOperation } from "../external/sandbox-op-log";
 
 const PENDING_RUN_TTL_MS = 15 * 60 * 1000;
 const QUEUED_RUN_TTL_MS = 2 * 60 * 60 * 1000;
-const AUTO_MEMORY_ARTIFACT_NAME = "memory";
+const AUTO_MEMORY_ARTIFACT_NAME = MEMORY_ARTIFACT_NAME;
 const CODEX_AUTO_MEMORY_MOUNT_PATH = "/home/user/.codex/memories";
 
 const TIER_LIMITS = Object.freeze({

--- a/turbo/apps/api/src/signals/services/zero-memory-detail.service.ts
+++ b/turbo/apps/api/src/signals/services/zero-memory-detail.service.ts
@@ -1,0 +1,115 @@
+import { computed, type Computed } from "ccstate";
+import { MEMORY_ARTIFACT_NAME } from "@vm0/core/storage-names";
+import { storages, storageVersions } from "@vm0/db/schema/storage";
+import { and, eq } from "drizzle-orm";
+
+import { db$ } from "../external/db";
+import { downloadS3Buffer, downloadManifest } from "../external/s3";
+import { env } from "../../lib/env";
+import { extractFilesFromTarGz } from "../../lib/tar";
+
+interface MemoryDetailResult {
+  readonly exists: boolean;
+  readonly name: string;
+  readonly size: number;
+  readonly fileCount: number;
+  readonly updatedAt: string | null;
+  readonly files: readonly { readonly path: string; readonly size: number }[];
+  readonly fileContents: readonly {
+    readonly path: string;
+    readonly content: string;
+  }[];
+}
+
+function emptyMemory(exists: boolean): MemoryDetailResult {
+  return {
+    exists,
+    name: MEMORY_ARTIFACT_NAME,
+    size: 0,
+    fileCount: 0,
+    updatedAt: null,
+    files: [],
+    fileContents: [],
+  };
+}
+
+/**
+ * Read-only detail for the current user's "memory" artifact (latest version),
+ * including each text file's contents extracted from the S3 archive.
+ *
+ * Memory is a normal artifact (type='artifact') named "memory", scoped per
+ * (orgId, userId). Returns `exists: false` when the user has never produced
+ * memory; returns an empty file list when the artifact exists but is empty.
+ */
+export function zeroMemoryDetail(
+  orgId: string,
+  userId: string,
+): Computed<Promise<MemoryDetailResult>> {
+  return computed(async (get): Promise<MemoryDetailResult> => {
+    const [storage] = await get(db$)
+      .select({
+        headVersionId: storages.headVersionId,
+        size: storages.size,
+        fileCount: storages.fileCount,
+        updatedAt: storages.updatedAt,
+      })
+      .from(storages)
+      .where(
+        and(
+          eq(storages.orgId, orgId),
+          eq(storages.userId, userId),
+          eq(storages.name, MEMORY_ARTIFACT_NAME),
+          eq(storages.type, "artifact"),
+        ),
+      )
+      .limit(1);
+
+    if (!storage) {
+      return emptyMemory(false);
+    }
+
+    const base: MemoryDetailResult = {
+      exists: true,
+      name: MEMORY_ARTIFACT_NAME,
+      size: storage.size,
+      fileCount: storage.fileCount,
+      updatedAt: storage.updatedAt.toISOString(),
+      files: [],
+      fileContents: [],
+    };
+
+    if (!storage.headVersionId || storage.fileCount === 0) {
+      return base;
+    }
+
+    const [version] = await get(db$)
+      .select({ s3Key: storageVersions.s3Key })
+      .from(storageVersions)
+      .where(eq(storageVersions.id, storage.headVersionId))
+      .limit(1);
+
+    const bucket = env("R2_USER_STORAGES_BUCKET_NAME");
+    if (!version || !bucket) {
+      return base;
+    }
+
+    const manifest = await get(downloadManifest(bucket, version.s3Key));
+    const normalize = (p: string): string => {
+      return p.replace(/^\.\//, "");
+    };
+    const files = manifest.files.map((file) => {
+      return { path: normalize(file.path), size: file.size };
+    });
+
+    const archiveKey = `${version.s3Key}/archive.tar.gz`;
+    const archiveBuffer = await get(downloadS3Buffer(bucket, archiveKey));
+    const fileContents = extractFilesFromTarGz(
+      archiveBuffer,
+      files.map((file) => {
+        return file.path;
+      }),
+    );
+
+    return { ...base, files, fileContents };
+  });
+}

--- a/turbo/apps/platform/src/mocks/handlers/api-memory.ts
+++ b/turbo/apps/platform/src/mocks/handlers/api-memory.ts
@@ -1,0 +1,32 @@
+import {
+  zeroMemoryContract,
+  type MemoryDetailResponse,
+} from "@vm0/api-contracts/contracts/zero-memory";
+
+import { mockApi } from "../msw-contract.ts";
+
+const EMPTY_MEMORY: MemoryDetailResponse = {
+  exists: false,
+  name: "memory",
+  size: 0,
+  fileCount: 0,
+  updatedAt: null,
+  files: [],
+  fileContents: [],
+};
+
+let mockMemory: MemoryDetailResponse = { ...EMPTY_MEMORY };
+
+export function setMockMemory(memory: MemoryDetailResponse): void {
+  mockMemory = memory;
+}
+
+export function resetMockMemory(): void {
+  mockMemory = { ...EMPTY_MEMORY };
+}
+
+export const apiMemoryHandlers = [
+  mockApi(zeroMemoryContract.get, ({ respond }) => {
+    return respond(200, mockMemory);
+  }),
+];

--- a/turbo/apps/platform/src/mocks/handlers/index.ts
+++ b/turbo/apps/platform/src/mocks/handlers/index.ts
@@ -57,6 +57,7 @@ import {
   resetMockTeam,
 } from "./api-agents.ts";
 import { apiSkillsHandlers, resetMockSkills } from "./api-skills.ts";
+import { apiMemoryHandlers, resetMockMemory } from "./api-memory.ts";
 import { apiRunsHandlers } from "./api-runs.ts";
 import { apiFeatureSwitchesHandlers } from "./api-feature-switches.ts";
 import { apiRealtimeHandlers } from "./api-realtime.ts";
@@ -112,6 +113,7 @@ export const handlers = [
   ...apiIntegrationsGithubHandlers,
   ...apiAgentsHandlers,
   ...apiSkillsHandlers,
+  ...apiMemoryHandlers,
   ...apiRunsHandlers,
   ...apiUserPreferencesHandlers,
   ...apiUserModelPreferenceHandlers,
@@ -157,5 +159,6 @@ export function resetAllMockHandlers(): void {
   resetMockSchedules();
   resetMockTeam();
   resetMockSkills();
+  resetMockMemory();
   resetMockOnboardingStatus();
 }

--- a/turbo/apps/platform/src/signals/bootstrap.ts
+++ b/turbo/apps/platform/src/signals/bootstrap.ts
@@ -29,6 +29,7 @@ import { setupActivityInspectPage$ } from "./activity-page/activity-inspect-page
 import { setupAgentsPage$ } from "./agents-page/agents-page-setup.ts";
 import { setupAgentDetailPage$ } from "./agents-page/agent-detail-page-setup.ts";
 import { setupSkillsPage$ } from "./skills-page/skills-page-setup.ts";
+import { setupMemoryPage$ } from "./memory-page/memory-page-setup.ts";
 import { setupWorksPage$ } from "./works-page/works-page-setup.ts";
 import { setupPreferencesPage$ } from "./preferences-page/preferences-page-setup.ts";
 import { setupApiKeysPage$ } from "./api-keys-page/api-keys-page-setup.ts";
@@ -150,6 +151,10 @@ const ROUTE_CONFIG = [
   {
     path: ROUTES.skills,
     setup: setupAuthPageWrapper(setupSkillsPage$),
+  },
+  {
+    path: ROUTES.memory,
+    setup: setupAuthPageWrapper(setupMemoryPage$),
   },
   {
     path: ROUTES.settingsSlack,

--- a/turbo/apps/platform/src/signals/memory-page/memory-page-setup.ts
+++ b/turbo/apps/platform/src/signals/memory-page/memory-page-setup.ts
@@ -1,0 +1,30 @@
+import { command } from "ccstate";
+import { createElement } from "react";
+import { FeatureSwitchKey } from "@vm0/connectors/feature-switch-key";
+
+import { MemoryPage } from "../../views/memory-page/memory-page.tsx";
+import { hideAppSkeleton$ } from "../app-skeleton.ts";
+import { updateDocumentTitle$ } from "../document-title.ts";
+import { featureSwitch$ } from "../external/feature-switch.ts";
+import { updatePage$ } from "../react-router.ts";
+import { detachedNavigateTo$ } from "../route.ts";
+import { ROUTES } from "../route-paths.ts";
+import { onboardGuard$ } from "../zero-page/onboard-guard.ts";
+
+export const setupMemoryPage$ = command(
+  async ({ get, set }, signal: AbortSignal) => {
+    const features = await get(featureSwitch$);
+    signal.throwIfAborted();
+
+    if (!features[FeatureSwitchKey.MemoryViewer]) {
+      set(detachedNavigateTo$, ROUTES.home, { replace: true });
+      return;
+    }
+
+    set(updatePage$, createElement(MemoryPage), "sidebar");
+    set(updateDocumentTitle$, "Memory");
+    await set(hideAppSkeleton$, signal);
+
+    await set(onboardGuard$, signal);
+  },
+);

--- a/turbo/apps/platform/src/signals/memory-page/memory-signals.ts
+++ b/turbo/apps/platform/src/signals/memory-page/memory-signals.ts
@@ -1,0 +1,28 @@
+import { command, computed, state } from "ccstate";
+import {
+  zeroMemoryContract,
+  type MemoryDetailResponse,
+} from "@vm0/api-contracts/contracts/zero-memory";
+
+import { accept } from "../../lib/accept.ts";
+import { zeroClient$ } from "../api-client.ts";
+
+const internalSelectedMemoryFilePath$ = state<string | null>(null);
+
+export const selectedMemoryFilePath$ = computed((get) => {
+  return get(internalSelectedMemoryFilePath$);
+});
+
+export const setSelectedMemoryFilePath$ = command(
+  ({ set }, filePath: string | null) => {
+    set(internalSelectedMemoryFilePath$, filePath);
+  },
+);
+
+export const memoryDetail$ = computed(
+  async (get): Promise<MemoryDetailResponse> => {
+    const client = get(zeroClient$)(zeroMemoryContract);
+    const result = await accept(client.get(), [200], { toast: false });
+    return result.body;
+  },
+);

--- a/turbo/apps/platform/src/signals/route-paths.ts
+++ b/turbo/apps/platform/src/signals/route-paths.ts
@@ -2,6 +2,7 @@ export const ROUTES = {
   home: "/",
   agents: "/agents",
   skills: "/skills",
+  memory: "/memory",
   agentDetail: "/agents/:agentId",
   agentChat: "/agents/:agentId/chat",
   agentIdeas: "/agents/:agentId/ideas",

--- a/turbo/apps/platform/src/signals/zero-page/zero-nav.ts
+++ b/turbo/apps/platform/src/signals/zero-page/zero-nav.ts
@@ -83,6 +83,7 @@ export type SidebarNavId =
   | "chat"
   | "agents"
   | "skills"
+  | "memory"
   | "connectors"
   | "schedules"
   | "activities"
@@ -109,6 +110,7 @@ export const handleZeroNavSelect$ = command(
         chat: ROUTES.home,
         agents: ROUTES.agents,
         skills: ROUTES.skills,
+        memory: ROUTES.memory,
         connectors: ROUTES.connectors,
         schedules: ROUTES.schedules,
         activities: ROUTES.activities,

--- a/turbo/apps/platform/src/views/memory-page/__tests__/memory-page.test.tsx
+++ b/turbo/apps/platform/src/views/memory-page/__tests__/memory-page.test.tsx
@@ -1,0 +1,97 @@
+import { screen, waitFor } from "@testing-library/react";
+import { FeatureSwitchKey } from "@vm0/connectors/feature-switch-key";
+import { describe, expect, it } from "vitest";
+
+import {
+  click,
+  detachedSetupPage,
+  queryAllByRoleFast,
+} from "../../../__tests__/page-helper.ts";
+import { setMockMemory } from "../../../mocks/handlers/api-memory.ts";
+import { testContext } from "../../../signals/__tests__/test-helpers.ts";
+import { pathname$ } from "../../../signals/route.ts";
+
+const context = testContext();
+
+function setupMemoryPage(): void {
+  setMockMemory({
+    exists: true,
+    name: "memory",
+    size: 60,
+    fileCount: 2,
+    updatedAt: "2024-01-01T00:00:00Z",
+    files: [
+      { path: "MEMORY.md", size: 30 },
+      { path: "scratch.txt", size: 30 },
+    ],
+    fileContents: [
+      { path: "MEMORY.md", content: "# Memory Index\n\nThings I know." },
+      { path: "scratch.txt", content: "Plain scratch note." },
+    ],
+  });
+
+  detachedSetupPage({
+    context,
+    path: "/memory",
+    featureSwitches: { [FeatureSwitchKey.MemoryViewer]: true },
+  });
+}
+
+describe("memory page", () => {
+  it("redirects to home when MemoryViewer is disabled", async () => {
+    detachedSetupPage({
+      context,
+      path: "/memory",
+      featureSwitches: { [FeatureSwitchKey.MemoryViewer]: false },
+    });
+
+    await waitFor(() => {
+      expect(context.store.get(pathname$)).not.toBe("/memory");
+    });
+  });
+
+  it("shows an empty state when there is no memory", async () => {
+    detachedSetupPage({
+      context,
+      path: "/memory",
+      featureSwitches: { [FeatureSwitchKey.MemoryViewer]: true },
+    });
+
+    await waitFor(() => {
+      expect(screen.getByText("No memory yet")).toBeInTheDocument();
+    });
+  });
+
+  it("lists memory files and shows selected file content read-only", async () => {
+    setupMemoryPage();
+
+    // Defaults to MEMORY.md (rendered as markdown).
+    await waitFor(() => {
+      expect(screen.getByLabelText("Memory content")).toHaveTextContent(
+        "Things I know.",
+      );
+    });
+
+    expect(screen.getAllByText("MEMORY.md").length).toBeGreaterThan(0);
+    expect(screen.getAllByText("scratch.txt").length).toBeGreaterThan(0);
+
+    const scratchButton = queryAllByRoleFast("button").find((button) => {
+      return button.textContent?.includes("scratch.txt");
+    });
+    expect(scratchButton).toBeDefined();
+    click(scratchButton!);
+
+    await waitFor(() => {
+      expect(screen.getByLabelText("Memory content")).toHaveTextContent(
+        "Plain scratch note.",
+      );
+    });
+
+    // Read-only: no edit/save affordances.
+    expect(
+      queryAllByRoleFast("button").some((button) => {
+        return button.textContent === "Save";
+      }),
+    ).toBeFalsy();
+  });
+});

--- a/turbo/apps/platform/src/views/memory-page/memory-page.tsx
+++ b/turbo/apps/platform/src/views/memory-page/memory-page.tsx
@@ -1,0 +1,207 @@
+import { useGet, useLoadable, useSet } from "ccstate-react";
+import type { MemoryDetailResponse } from "@vm0/api-contracts/contracts/zero-memory";
+import { cn } from "@vm0/ui";
+
+import {
+  memoryDetail$,
+  selectedMemoryFilePath$,
+  setSelectedMemoryFilePath$,
+} from "../../signals/memory-page/memory-signals.ts";
+import { Markdown } from "../components/markdown.tsx";
+
+const PREFERRED_FILE = "MEMORY.md";
+
+function isMarkdown(path: string): boolean {
+  return path.toLowerCase().endsWith(".md");
+}
+
+function formatBytes(bytes: number): string {
+  if (bytes < 1024) {
+    return `${bytes} B`;
+  }
+  const kib = bytes / 1024;
+  if (kib < 1024) {
+    return `${kib.toFixed(1)} KiB`;
+  }
+  return `${(kib / 1024).toFixed(1)} MiB`;
+}
+
+export function MemoryPage() {
+  const detailLoadable = useLoadable(memoryDetail$);
+  const detail =
+    detailLoadable.state === "hasData" ? detailLoadable.data : null;
+  const loading = detailLoadable.state === "loading" && !detail;
+  const errored = detailLoadable.state === "hasError";
+  const hasFiles = detail !== null && detail.exists && detail.files.length > 0;
+
+  return (
+    <div className="flex min-h-0 flex-1 flex-col">
+      <header className="shrink-0 bg-transparent px-4 pb-0 pt-3 sm:px-6 md:pb-3 md:pt-10">
+        <div className="mx-auto w-full max-w-[900px]">
+          <div className="hidden min-w-0 md:block">
+            <h1 className="text-lg font-semibold tracking-tight text-foreground">
+              Memory
+            </h1>
+            <p className="mt-0.5 text-sm text-muted-foreground">
+              What Zero remembers across runs. Read-only.
+            </p>
+          </div>
+        </div>
+      </header>
+
+      <main className="flex-1 overflow-auto px-4 pb-8 pt-3 sm:px-6">
+        <div className="mx-auto max-w-[900px]">
+          {loading ? (
+            <MemorySkeleton />
+          ) : hasFiles && detail ? (
+            <MemoryViewer detail={detail} />
+          ) : (
+            <MemoryEmptyState errored={errored} />
+          )}
+        </div>
+      </main>
+    </div>
+  );
+}
+
+function MemoryViewer({ detail }: { readonly detail: MemoryDetailResponse }) {
+  const explicitSelected = useGet(selectedMemoryFilePath$);
+  const setSelected = useSet(setSelectedMemoryFilePath$);
+
+  const files = [...detail.files].sort((a, b) => {
+    return a.path.localeCompare(b.path);
+  });
+  const preferredPath =
+    files.find((file) => {
+      return file.path === PREFERRED_FILE;
+    })?.path ??
+    files[0]?.path ??
+    null;
+  const selectedPath =
+    explicitSelected !== null &&
+    files.some((file) => {
+      return file.path === explicitSelected;
+    })
+      ? explicitSelected
+      : preferredPath;
+  const selectedContent = selectedPath
+    ? (detail.fileContents.find((file) => {
+        return file.path === selectedPath;
+      })?.content ?? null)
+    : null;
+
+  return (
+    <section className="zero-card min-h-[520px] overflow-hidden">
+      <div className="grid min-h-[520px] gap-0 lg:grid-cols-[240px_minmax(0,1fr)]">
+        <aside className="min-h-0 border-b border-border/70 bg-muted/20 lg:border-b-0 lg:border-r">
+          <div className="flex h-9 items-center justify-between border-b border-border/70 px-3">
+            <span className="text-xs font-medium text-muted-foreground">
+              Files
+            </span>
+            <span className="text-xs text-muted-foreground">
+              {files.length}
+            </span>
+          </div>
+          <div className="max-h-[240px] overflow-auto p-2 lg:max-h-none">
+            <div className="flex flex-col gap-1">
+              {files.map((file) => {
+                const selected = file.path === selectedPath;
+                return (
+                  <button
+                    key={file.path}
+                    type="button"
+                    aria-pressed={selected}
+                    className={cn(
+                      "flex min-w-0 items-center justify-between gap-3 rounded-md px-2 py-1.5 text-left transition-colors",
+                      selected
+                        ? "bg-accent text-accent-foreground"
+                        : "text-foreground hover:bg-accent/70",
+                    )}
+                    onClick={() => {
+                      setSelected(file.path);
+                    }}
+                  >
+                    <span className="min-w-0 truncate text-xs">
+                      {file.path}
+                    </span>
+                    <span className="shrink-0 text-xs text-muted-foreground">
+                      {formatBytes(file.size)}
+                    </span>
+                  </button>
+                );
+              })}
+            </div>
+          </div>
+        </aside>
+
+        <div className="flex min-h-0 flex-col">
+          <div className="flex h-9 shrink-0 items-center border-b border-border/70 px-4 text-xs font-medium text-muted-foreground">
+            <span className="truncate">
+              {selectedPath ?? "No file selected"}
+            </span>
+          </div>
+          {selectedPath && selectedContent !== null ? (
+            isMarkdown(selectedPath) ? (
+              <div
+                aria-label="Memory content"
+                className="min-h-[420px] flex-1 overflow-auto bg-background px-4 py-3"
+              >
+                <Markdown source={selectedContent} />
+              </div>
+            ) : (
+              <pre
+                aria-label="Memory content"
+                className="min-h-[420px] flex-1 overflow-auto whitespace-pre-wrap bg-background px-4 py-3 font-mono text-sm leading-6 text-foreground"
+              >
+                {selectedContent}
+              </pre>
+            )
+          ) : (
+            <div className="flex min-h-[420px] flex-1 items-center justify-center px-4 text-sm text-muted-foreground">
+              No content available for this file.
+            </div>
+          )}
+        </div>
+      </div>
+    </section>
+  );
+}
+
+function MemoryEmptyState({ errored }: { readonly errored: boolean }) {
+  return (
+    <section className="zero-card flex min-h-[520px] flex-col items-center justify-center px-6 text-center">
+      <p className="text-sm font-medium text-foreground">
+        {errored ? "Couldn't load memory" : "No memory yet"}
+      </p>
+      <p className="mt-1 max-w-sm text-sm text-muted-foreground">
+        {errored
+          ? "Something went wrong loading your memory. Try again later."
+          : "Zero hasn't recorded any memory yet. It builds up as your agents run and will appear here."}
+      </p>
+    </section>
+  );
+}
+
+function MemorySkeleton() {
+  return (
+    <section className="zero-card min-h-[520px] overflow-hidden">
+      <div className="grid min-h-[520px] gap-0 lg:grid-cols-[240px_minmax(0,1fr)]">
+        <div
+          className="border-b border-border/70 bg-muted/20 p-2 lg:border-b-0 lg:border-r"
+          data-testid="memory-loading"
+        >
+          <div className="flex flex-col gap-1">
+            {[0, 1, 2, 3].map((index) => {
+              return (
+                <div key={index} className="h-7 w-full rounded bg-muted/50" />
+              );
+            })}
+          </div>
+        </div>
+        <div className="p-4">
+          <div className="h-[420px] rounded bg-muted/50" />
+        </div>
+      </div>
+    </section>
+  );
+}

--- a/turbo/apps/platform/src/views/zero-page/zero-sidebar.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-sidebar.tsx
@@ -12,6 +12,7 @@ import {
   IconLayoutGrid,
   IconCalendar,
   IconFileText,
+  IconBrain,
   IconUsers,
   IconEdit,
   IconChevronRight,
@@ -91,6 +92,14 @@ const MANAGE_NAV: readonly ManageNavItem[] = [
     label: "Skills",
     icon: IconFileText as NavIcon,
     featureGate: FeatureSwitchKey.OrgSkills,
+  },
+  {
+    id: "memory",
+    activeKeys: ["memory"],
+    pathname: "/memory",
+    label: "Memory",
+    icon: IconBrain as NavIcon,
+    featureGate: FeatureSwitchKey.MemoryViewer,
   },
   {
     id: "connectors",

--- a/turbo/apps/web/api-backend-rewrites.js
+++ b/turbo/apps/web/api-backend-rewrites.js
@@ -1082,6 +1082,7 @@ export const API_BACKEND_REWRITES = [
     "/api/zero/schedules/:name/enable",
     ZERO_SCHEDULES_ENABLE_PATH_RE,
   ],
+  ["/api/zero/memory", "/api/zero/memory"],
   ["/api/zero/skills", "/api/zero/skills"],
   [
     ZERO_SKILLS_BY_NAME_REWRITE_SOURCE,

--- a/turbo/packages/api-contracts/src/contracts/index.ts
+++ b/turbo/packages/api-contracts/src/contracts/index.ts
@@ -782,6 +782,10 @@ export {
   type UpdateFeatureSwitchesRequest,
 } from "./zero-feature-switches";
 export {
+  memoryDetailResponseSchema,
+  type MemoryDetailResponse,
+} from "./zero-memory";
+export {
   orgListItemSchema,
   orgListResponseSchema,
   type OrgListItem,
@@ -1007,6 +1011,7 @@ export {
   zeroFeatureSwitchesContract,
   type ZeroFeatureSwitchesContract,
 } from "./zero-feature-switches";
+export { zeroMemoryContract, type ZeroMemoryContract } from "./zero-memory";
 export {
   zeroSecretsContract,
   zeroSecretsByNameContract,

--- a/turbo/packages/api-contracts/src/contracts/zero-memory.ts
+++ b/turbo/packages/api-contracts/src/contracts/zero-memory.ts
@@ -1,0 +1,54 @@
+import { z } from "zod";
+import { initContract, authHeadersSchema } from "./base";
+import { apiErrorSchema } from "./errors";
+
+const c = initContract();
+
+const memoryFileSchema = z.object({
+  path: z.string(),
+  size: z.number(),
+});
+
+const memoryFileContentSchema = z.object({
+  path: z.string(),
+  content: z.string(),
+});
+
+/**
+ * Read-only view of the current user's "memory" artifact (latest version).
+ *
+ * `exists` is false when the user has never produced memory (no artifact yet);
+ * in that case the lists are empty and `updatedAt` is null.
+ */
+export const memoryDetailResponseSchema = z.object({
+  exists: z.boolean(),
+  name: z.string(),
+  size: z.number(),
+  fileCount: z.number(),
+  updatedAt: z.string().nullable(),
+  files: z.array(memoryFileSchema),
+  fileContents: z.array(memoryFileContentSchema),
+});
+
+export type MemoryDetailResponse = z.infer<typeof memoryDetailResponseSchema>;
+
+/**
+ * Zero memory contract for /api/zero/memory
+ *
+ * GET: Read the current user's memory artifact contents (latest version).
+ */
+export const zeroMemoryContract = c.router({
+  get: {
+    method: "GET",
+    path: "/api/zero/memory",
+    headers: authHeadersSchema,
+    responses: {
+      200: memoryDetailResponseSchema,
+      401: apiErrorSchema,
+      500: apiErrorSchema,
+    },
+    summary: "Get the current user's memory artifact contents",
+  },
+});
+
+export type ZeroMemoryContract = typeof zeroMemoryContract;

--- a/turbo/packages/connectors/src/feature-switch-key.ts
+++ b/turbo/packages/connectors/src/feature-switch-key.ts
@@ -55,4 +55,5 @@ export enum FeatureSwitchKey {
   SessionWorkspaceImageCache = "sessionWorkspaceImageCache",
   ChatArtifactSidebar = "chatArtifactSidebar",
   ChatScrollToBottomButton = "chatScrollToBottomButton",
+  MemoryViewer = "memoryViewer",
 }

--- a/turbo/packages/core/src/feature-switch.ts
+++ b/turbo/packages/core/src/feature-switch.ts
@@ -307,6 +307,13 @@ const FEATURE_SWITCHES: Record<FeatureSwitchKey, FeatureSwitch> = {
       "Show a floating scroll-to-bottom button in the bottom-right of the chat thread (above the composer) whenever the message list is scrolled away from the bottom. Clicking it jumps to the latest message.",
     enabled: true,
   },
+  [FeatureSwitchKey.MemoryViewer]: {
+    maintainer: "lancy@vm0.ai",
+    description:
+      "Show the read-only memory viewer page in the Zero sidebar and at /memory, listing the files in the user's memory artifact.",
+    enabled: false,
+    enabledOrgIdHashes: STAFF_ORG_ID_HASHES,
+  },
 };
 
 interface ResolvedHashes {

--- a/turbo/packages/core/src/storage-names.ts
+++ b/turbo/packages/core/src/storage-names.ts
@@ -49,3 +49,10 @@ export function getSkillStorageName(fullPath: string): string {
 export function getCustomSkillStorageName(skillName: string): string {
   return `custom-skill@${skillName}`;
 }
+
+/**
+ * Reserved name of the per-user "memory" artifact that Zero auto-injects into
+ * every agent run. Stored as an artifact (type='artifact') scoped per user,
+ * and mounted into the sandbox at a framework-specific path.
+ */
+export const MEMORY_ARTIFACT_NAME = "memory";


### PR DESCRIPTION
## What

Adds a **read-only** `/memory` page to the platform app so users can finally see what Zero has remembered. Implements #15898.

Memory is the per-user `"memory"` artifact that Zero auto-injects into every run; until now it was a complete black box on the web (no route, no nav, no API). This surfaces it.

## Scope (locked in discussion)

- **Read-only** — no edit / delete / version management
- **Dedicated `/memory` route**, first-class sidebar entry (Manage section)
- **Single latest (HEAD) version**, framework-agnostic (one copy)
- **Feature-switch gated** behind `MemoryViewer` (staff-only by default)
- File tree on the left, content on the right — `.md` renders as Markdown, other text as monospace

## Changes

**`packages/core`**
- New `FeatureSwitchKey.MemoryViewer` (`enabled: false`, staff-only via `STAFF_ORG_ID_HASHES`)
- New shared `MEMORY_ARTIFACT_NAME` constant; `agent-run-create` now references it instead of a local literal (single source of truth)

**`apps/api`**
- New `GET /api/zero/memory` endpoint, modeled on `zeroSkillDetail`: resolves the `(org, user)` memory artifact, reads `manifest.json` for the file tree, and extracts text contents from `archive.tar.gz` server-side (no client-side tar handling). Returns `exists: false` when the user has no memory yet.

**`apps/platform`**
- `/memory` route, gated sidebar nav item, page-setup signal, data signals, and the `MemoryPage` view
- Mock handler + integration test (redirect when gated off, empty state, file list + content + read-only)

## Testing

- `pnpm check-types` ✅ · `pnpm turbo run lint` ✅ · `pnpm format` ✅ · `pnpm knip` ✅
- `@vm0/app` full suite ✅ (274 files / 2458 tests, incl. new memory-page test)
- `@vm0/core` (177), `@vm0/connectors` (1552), `@vm0/api-contracts` (233) ✅

Closes #15898

🤖 Generated with [Claude Code](https://claude.com/claude-code)
