### PR TITLE
Route app.vm0.ai + vm0.ai PostHog ingest through j.vm0.ai

### DIFF
--- a/turbo/apps/platform/src/lib/posthog.ts
+++ b/turbo/apps/platform/src/lib/posthog.ts
@@ -9,7 +9,12 @@ export function initPostHog(): void {
   }
 
   posthog.init(POSTHOG_KEY, {
-    api_host: "/ingest",
+    // First-party reverse proxy (Cloudflare-fronted): forwards /static assets,
+    // /flags, ingest and replay (/s) to PostHog US so ad blockers do not drop
+    // events. Shared with so.vm0.ai for one ingest domain. The legacy /ingest
+    // vercel.json rewrite is now unused (kept as fallback for now).
+    api_host: "https://j.vm0.ai",
+    ui_host: "https://us.posthog.com",
     autocapture: false,
     capture_pageview: false,
     // Replay is off app-wide; it is enabled only for scoped flows (currently

--- a/turbo/apps/web/app/components/PostHogProvider.tsx
+++ b/turbo/apps/web/app/components/PostHogProvider.tsx
@@ -20,9 +20,11 @@ function ensureInitialized(): void {
     return;
   }
   posthog.init(POSTHOG_KEY, {
-    // Reverse-proxy through /ingest so ad blockers do not drop events.
-    // See next.config.js `rewrites` for the upstream destination.
-    api_host: "/ingest",
+    // First-party reverse proxy (Cloudflare-fronted): forwards /static assets,
+    // /flags and ingest to PostHog US so ad blockers do not drop events.
+    // Shared with so.vm0.ai for one ingest domain. The legacy /ingest
+    // next.config rewrite is now unused and can be removed in a follow-up.
+    api_host: "https://j.vm0.ai",
     ui_host: "https://us.posthog.com",
     autocapture: false,
     // Manual $pageview is required for the App Router because the SDK's


### PR DESCRIPTION
## What

Move the two PostHog inits in this repo onto the first-party reverse proxy `j.vm0.ai`, matching what so.vm0.ai already does (vm0-ai/vm0-marketing#31, merged).

- `apps/platform/src/lib/posthog.ts` (app.vm0.ai): `api_host` `/ingest` → `https://j.vm0.ai`, add `ui_host: https://us.posthog.com`
- `apps/web/app/components/PostHogProvider.tsx` (vm0.ai): `api_host` `/ingest` → `https://j.vm0.ai`

## Why

Consolidates all vm0 PostHog ingest (so.vm0.ai, vm0.ai, app.vm0.ai) onto a single Cloudflare-fronted proxy domain, so there is one place to manage blocker-resilient capture instead of a per-app rewrite. `ui_host` stays `us.posthog.com` for the toolbar/dashboard links. Same shared project (337442), so cross-subdomain attribution and funnels are unchanged.

## Proxy readiness (verified against j.vm0.ai)

Full passthrough to PostHog US confirmed — every path the apps use reaches upstream:

| Path | Result |
|---|---|
| `GET /flags/?v=2` | 200 |
| `GET /static/array.js`, `/static/recorder.js` | 200, `application/javascript` |
| `POST /e/`, `/i/v0/e/` (capture) | 400 on empty body = reached PostHog ingest |
| `POST /s/` (session replay) | 400 on empty body = reached PostHog ingest |

So capture, flags handshake, autocapture assets, and onboarding session replay all forward correctly.

## Scope / notes

- Leaves the legacy `/ingest` rewrites in place as harmless unused fallbacks: `apps/web/next.config.js` and `apps/platform/vercel.json`. Removing them is a small follow-up (the platform one is asserted by `vercel-headers.test.ts`, so it needs a test update too). Happy to fold that in if preferred.
- No env/secret changes; `j.vm0.ai` proxy is already live.

## Verify after deploy

On app.vm0.ai and vm0.ai, confirm PostHog network calls go to `https://j.vm0.ai/{e,i,s,flags,static}` and events land in project 337442; check onboarding replay still records on app.vm0.ai.

🤖 Generated with [Claude Code](https://claude.com/claude-code)