### PR TITLE
fix: remove stripe checkout flow metadata

### DIFF
--- a/turbo/apps/api/src/signals/routes/__tests__/zero-billing-checkout.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/zero-billing-checkout.test.ts
@@ -269,14 +269,12 @@ describe("POST /api/zero/billing/checkout", () => {
         orgId: fixture.orgId,
         tier: "pro",
         priceId: TEST_PRICE_PRO,
-        flow: "standard",
       },
       subscription_data: {
         metadata: {
           orgId: fixture.orgId,
           tier: "pro",
           priceId: TEST_PRICE_PRO,
-          flow: "standard",
         },
       },
     });
@@ -401,7 +399,6 @@ describe("POST /api/zero/billing/checkout", () => {
       orgId: fixture.orgId,
       tier: "pro",
       priceId: TEST_PRICE_PRO,
-      flow: "standard",
       ...expectedAttribution,
     };
     expect(context.mocks.stripe.customers.create).toHaveBeenCalledWith({
@@ -459,14 +456,12 @@ describe("POST /api/zero/billing/checkout", () => {
         orgId: fixture.orgId,
         tier: "pro",
         priceId: TEST_PRICE_PRO,
-        flow: "trial",
       },
       subscription_data: {
         metadata: {
           orgId: fixture.orgId,
           tier: "pro",
           priceId: TEST_PRICE_PRO,
-          flow: "trial",
         },
         trial_period_days: 7,
       },

--- a/turbo/apps/api/src/signals/services/zero-billing-checkout.service.ts
+++ b/turbo/apps/api/src/signals/services/zero-billing-checkout.service.ts
@@ -123,7 +123,6 @@ function checkoutSessionMetadata(args: {
   readonly orgId: string;
   readonly tier: SubscriptionCheckoutTier;
   readonly priceId: string;
-  readonly trialDays?: 7;
   readonly adAttribution:
     | Readonly<Record<string, string | undefined>>
     | undefined;
@@ -132,7 +131,6 @@ function checkoutSessionMetadata(args: {
     orgId: args.orgId,
     tier: args.tier,
     priceId: args.priceId,
-    flow: args.trialDays === undefined ? "standard" : "trial",
   };
   for (const [key, value] of Object.entries(args.adAttribution ?? {})) {
     if (value) {
@@ -210,7 +208,6 @@ export const createCheckoutSession$ = command(
       orgId: args.orgId,
       tier: args.tier,
       priceId: args.priceId,
-      trialDays: args.trialDays,
       adAttribution: args.adAttribution,
     });
     const customerId = await set(


### PR DESCRIPTION
## Summary
- Remove the `flow` field from Stripe Checkout Session and Subscription metadata.
- Update billing checkout tests so they no longer imply `flow=trial` is available during trial SetupIntent Radar evaluation.

## Verification
- `git diff --check`
- `NODE_OPTIONS=--max-old-space-size=8192 pnpm --filter api check-types`

Skipped full local vitest per vm0 PR preference; PR CI should cover it.