### PR TITLE
fix: create pro trial subscriptions from setup checkout

### DIFF
--- a/turbo/apps/api/src/__tests__/mocks.ts
+++ b/turbo/apps/api/src/__tests__/mocks.ts
@@ -116,7 +116,11 @@ export interface ApiTestMocks {
       readonly retrieve: AsyncMock;
       readonly create: AsyncMock;
     };
+    readonly setupIntents: {
+      readonly retrieve: AsyncMock;
+    };
     readonly subscriptions: {
+      readonly create: AsyncMock;
       readonly retrieve: AsyncMock;
       readonly update: AsyncMock;
       readonly cancel: AsyncMock;
@@ -261,7 +265,11 @@ const apiTestMocks: ApiTestMocks = vi.hoisted((): ApiTestMocks => {
       retrieve: vi.fn<(...args: unknown[]) => Promise<unknown>>(),
       create: vi.fn<(...args: unknown[]) => Promise<unknown>>(),
     },
+    setupIntents: {
+      retrieve: vi.fn<(...args: unknown[]) => Promise<unknown>>(),
+    },
     subscriptions: {
+      create: vi.fn<(...args: unknown[]) => Promise<unknown>>(),
       retrieve: vi.fn<(...args: unknown[]) => Promise<unknown>>(),
       update: vi.fn<(...args: unknown[]) => Promise<unknown>>(),
       cancel: vi.fn<(...args: unknown[]) => Promise<unknown>>(),
@@ -548,7 +556,11 @@ vi.mock("stripe", async (importOriginal) => {
           retrieve: apiTestMocks.stripe.customers.retrieve,
           create: apiTestMocks.stripe.customers.create,
         },
+        setupIntents: {
+          retrieve: apiTestMocks.stripe.setupIntents.retrieve,
+        },
         subscriptions: {
+          create: apiTestMocks.stripe.subscriptions.create,
           retrieve: apiTestMocks.stripe.subscriptions.retrieve,
           update: apiTestMocks.stripe.subscriptions.update,
           cancel: apiTestMocks.stripe.subscriptions.cancel,
@@ -776,6 +788,8 @@ export function resetApiTestMocks(): void {
   apiTestMocks.stripe.invoiceItems.create.mockReset();
   apiTestMocks.stripe.customers.retrieve.mockReset();
   apiTestMocks.stripe.customers.create.mockReset();
+  apiTestMocks.stripe.setupIntents.retrieve.mockReset();
+  apiTestMocks.stripe.subscriptions.create.mockReset();
   apiTestMocks.stripe.subscriptions.retrieve.mockReset();
   apiTestMocks.stripe.subscriptions.update.mockReset();
   apiTestMocks.stripe.subscriptions.cancel.mockReset();

--- a/turbo/apps/api/src/signals/routes/__tests__/webhooks-third-party.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/webhooks-third-party.test.ts
@@ -2221,6 +2221,88 @@ describe("POST /api/webhooks/stripe", () => {
       expect(billing.onboardingPaymentPending).toBeFalsy();
     });
 
+    it("creates Pro trial subscription from setup checkout metadata", async () => {
+      const fixture = await trackStripe(
+        store.set(seedStripeFixture$, undefined, context.signal),
+      );
+      await updateStripeOrg(fixture, { onboardingPaymentPending: true });
+      mockStripeWebhookEnv();
+      const sessionId = stripeId("cs");
+      const setupIntentId = stripeId("seti");
+      const paymentMethodId = stripeId("pm");
+      const subscriptionId = stripeId("sub");
+      const periodEnd = 1_800_000_000;
+      const metadata = {
+        orgId: fixture.orgId,
+        tier: "pro",
+        priceId: STRIPE_PRICE_PRO,
+        flow: "trial",
+        trialDays: "7",
+      };
+      context.mocks.stripe.subscriptions.create.mockResolvedValue({
+        id: subscriptionId,
+        status: "trialing",
+        cancel_at_period_end: false,
+        metadata: {
+          ...metadata,
+          checkoutSessionId: sessionId,
+          setupIntentId,
+        },
+        items: {
+          data: [
+            {
+              price: { id: STRIPE_PRICE_PRO },
+              current_period_end: periodEnd,
+            },
+          ],
+        },
+      });
+
+      const response = await postStripeWebhookEvent({
+        type: "checkout.session.completed",
+        dataObject: {
+          id: sessionId,
+          mode: "setup",
+          status: "complete",
+          subscription: null,
+          customer: fixture.stripeCustomerId,
+          metadata,
+          setup_intent: {
+            id: setupIntentId,
+            status: "succeeded",
+            payment_method: paymentMethodId,
+            metadata,
+          },
+        },
+      });
+
+      expect(response.status).toBe(200);
+      expect(context.mocks.stripe.subscriptions.create).toHaveBeenCalledWith(
+        {
+          customer: fixture.stripeCustomerId,
+          items: [{ price: STRIPE_PRICE_PRO }],
+          default_payment_method: paymentMethodId,
+          trial_period_days: 7,
+          metadata: {
+            ...metadata,
+            checkoutSessionId: sessionId,
+            setupIntentId,
+          },
+        },
+        {
+          idempotencyKey: `pro-trial-setup-checkout:${sessionId}`,
+        },
+      );
+      const billing = await selectStripeBilling(fixture);
+      expect(billing.tier).toBe("pro");
+      expect(billing.stripeSubscriptionId).toBe(subscriptionId);
+      expect(billing.subscriptionStatus).toBe("trialing");
+      expect(billing.currentPeriodEnd).toStrictEqual(
+        new Date(periodEnd * 1000),
+      );
+      expect(billing.onboardingPaymentPending).toBeFalsy();
+    });
+
     it("is idempotent when subscription is already stored", async () => {
       const fixture = await trackStripe(
         store.set(seedStripeFixture$, undefined, context.signal),

--- a/turbo/apps/api/src/signals/routes/__tests__/zero-billing-checkout.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/zero-billing-checkout.test.ts
@@ -449,10 +449,9 @@ describe("POST /api/zero/billing/checkout", () => {
       url: "https://checkout.stripe.com/session/trial",
     });
     expect(context.mocks.stripe.checkout.sessions.create).toHaveBeenCalledWith({
-      mode: "subscription",
+      mode: "setup",
       customer: customerId,
-      line_items: [{ price: TEST_PRICE_PRO, quantity: 1 }],
-      allow_promotion_codes: true,
+      payment_method_types: ["card"],
       success_url: `${APP_ORIGIN}/onboarding?billing=pro`,
       cancel_url: `${APP_ORIGIN}/onboarding?billing=canceled`,
       metadata: {
@@ -460,15 +459,16 @@ describe("POST /api/zero/billing/checkout", () => {
         tier: "pro",
         priceId: TEST_PRICE_PRO,
         flow: "trial",
+        trialDays: "7",
       },
-      subscription_data: {
+      setup_intent_data: {
         metadata: {
           orgId: fixture.orgId,
           tier: "pro",
           priceId: TEST_PRICE_PRO,
           flow: "trial",
+          trialDays: "7",
         },
-        trial_period_days: 7,
       },
     });
   });
@@ -675,6 +675,111 @@ describe("POST /api/zero/billing/checkout/complete", () => {
     );
 
     expect(response.body).toStrictEqual({ completed: true });
+
+    const writeDb = store.set(writeDb$);
+    const [row] = await writeDb
+      .select({
+        tier: orgMetadata.tier,
+        stripeSubscriptionId: orgMetadata.stripeSubscriptionId,
+        subscriptionStatus: orgMetadata.subscriptionStatus,
+        onboardingPaymentPending: orgMetadata.onboardingPaymentPending,
+        currentPeriodEnd: orgMetadata.currentPeriodEnd,
+      })
+      .from(orgMetadata)
+      .where(eq(orgMetadata.orgId, fixture.orgId))
+      .limit(1);
+
+    expect(row).toMatchObject({
+      tier: "pro",
+      stripeSubscriptionId: subscriptionId,
+      subscriptionStatus: "trialing",
+      onboardingPaymentPending: false,
+      currentPeriodEnd: new Date(1_800_000_000 * 1000),
+    });
+  });
+
+  it("creates a Pro trial subscription from completed setup checkout", async () => {
+    const customerId = `cus_${randomUUID().slice(0, 8)}`;
+    const setupIntentId = `seti_${randomUUID().slice(0, 8)}`;
+    const paymentMethodId = `pm_${randomUUID().slice(0, 8)}`;
+    const subscriptionId = `sub_${randomUUID().slice(0, 8)}`;
+    const fixture = await trackedSeed({
+      onboardingPaymentPending: true,
+      stripeCustomerId: customerId,
+    });
+    mocks.clerk.session(fixture.userId, fixture.orgId, "org:admin");
+    const metadata = {
+      orgId: fixture.orgId,
+      tier: "pro",
+      priceId: TEST_PRICE_PRO,
+      flow: "trial",
+      trialDays: "7",
+    };
+
+    context.mocks.stripe.checkout.sessions.retrieve.mockResolvedValue({
+      id: "cs_test_setup_completed",
+      mode: "setup",
+      status: "complete",
+      customer: customerId,
+      subscription: null,
+      metadata,
+      setup_intent: {
+        id: setupIntentId,
+        status: "succeeded",
+        payment_method: paymentMethodId,
+        metadata,
+      },
+    });
+    context.mocks.stripe.subscriptions.create.mockResolvedValue({
+      id: subscriptionId,
+      status: "trialing",
+      cancel_at_period_end: false,
+      metadata: {
+        ...metadata,
+        checkoutSessionId: "cs_test_setup_completed",
+        setupIntentId,
+      },
+      items: {
+        data: [
+          {
+            price: { id: TEST_PRICE_PRO },
+            current_period_end: 1_800_000_000,
+          },
+        ],
+      },
+    });
+
+    const client = setupApp({ context })(zeroBillingCheckoutContract);
+
+    const response = await accept(
+      client.complete({
+        body: { sessionId: "cs_test_setup_completed" },
+        headers: { authorization: "Bearer clerk-session" },
+      }),
+      [200],
+    );
+
+    expect(response.body).toStrictEqual({ completed: true });
+    expect(context.mocks.stripe.checkout.sessions.retrieve).toHaveBeenCalledWith(
+      "cs_test_setup_completed",
+      { expand: ["setup_intent"] },
+    );
+    expect(context.mocks.stripe.subscriptions.create).toHaveBeenCalledWith(
+      {
+        customer: customerId,
+        items: [{ price: TEST_PRICE_PRO }],
+        default_payment_method: paymentMethodId,
+        trial_period_days: 7,
+        metadata: {
+          ...metadata,
+          checkoutSessionId: "cs_test_setup_completed",
+          setupIntentId,
+        },
+      },
+      {
+        idempotencyKey: "pro-trial-setup-checkout:cs_test_setup_completed",
+      },
+    );
 
     const writeDb = store.set(writeDb$);
     const [row] = await writeDb

--- a/turbo/apps/api/src/signals/services/webhooks-stripe.service.ts
+++ b/turbo/apps/api/src/signals/services/webhooks-stripe.service.ts
@@ -13,6 +13,7 @@ import { getCampaign } from "./one-time-products";
 import {
   checkoutTierConflictMessage,
   checkoutWouldReplaceWithSameOrLowerTier,
+  completeSetupTrialCheckoutSession,
   type SubscriptionCheckoutTier,
   tierFromPriceId,
 } from "./zero-billing-checkout.service";
@@ -24,7 +25,10 @@ type WriteTx = Parameters<Parameters<Db["transaction"]>[0]>[0];
 
 interface CheckoutSessionInput {
   readonly id: string;
+  readonly mode?: string | null;
+  readonly status?: string | null;
   readonly subscription: string | { readonly id: string } | null;
+  readonly setup_intent?: string | Stripe.SetupIntent | null;
   readonly customer: string | { readonly id: string } | null;
   readonly metadata: Record<string, string> | null;
   readonly amount_subtotal?: number | null;
@@ -491,6 +495,40 @@ async function handleCheckoutCompleted(
   }
 
   if (await handlePaidCheckoutPurpose(db, session, "one_time_purchase")) {
+    return;
+  }
+
+  if (session.mode === "setup") {
+    const customerId =
+      typeof session.customer === "string"
+        ? session.customer
+        : session.customer?.id;
+    if (!customerId) {
+      L.warn("setup checkout.session.completed without customer ID", {
+        sessionId: session.id,
+      });
+      return;
+    }
+
+    const stripe = getStripeClient();
+    const result = await completeSetupTrialCheckoutSession({
+      db,
+      stripe,
+      session: session as Stripe.Checkout.Session,
+      customerId,
+    });
+    if (result.status === "tier_conflict") {
+      L.warn("setup checkout.session.completed rejected tier replacement", {
+        customerId,
+        sessionId: session.id,
+        currentTier: result.currentTier,
+        targetTier: result.targetTier,
+        reason: checkoutTierConflictMessage({
+          currentTier: result.currentTier,
+          targetTier: result.targetTier,
+        }),
+      });
+    }
     return;
   }
 

--- a/turbo/apps/api/src/signals/services/zero-billing-checkout.service.ts
+++ b/turbo/apps/api/src/signals/services/zero-billing-checkout.service.ts
@@ -5,7 +5,7 @@ import type { Stripe } from "stripe";
 
 import { env } from "../../lib/env";
 import { nowDate } from "../external/time";
-import { writeDb$ } from "../external/db";
+import { writeDb$, type Db } from "../external/db";
 import { getStripeClient } from "../external/stripe-client";
 import { getOrCreateStripeCustomer$ } from "./billing-customer.service";
 
@@ -134,6 +134,9 @@ function checkoutSessionMetadata(args: {
     priceId: args.priceId,
     flow: args.trialDays === undefined ? "standard" : "trial",
   };
+  if (args.trialDays !== undefined) {
+    metadata.trialDays = String(args.trialDays);
+  }
   for (const [key, value] of Object.entries(args.adAttribution ?? {})) {
     if (value) {
       metadata[key] = value;
@@ -151,11 +154,152 @@ function stripeObjectId(
   return value?.id ?? null;
 }
 
+async function checkoutSessionSetupIntent(
+  stripe: ReturnType<typeof getStripeClient>,
+  session: Stripe.Checkout.Session,
+): Promise<Stripe.SetupIntent | null> {
+  const setupIntent = session.setup_intent;
+  if (!setupIntent) {
+    return null;
+  }
+  if (typeof setupIntent === "string") {
+    return await stripe.setupIntents.retrieve(setupIntent);
+  }
+  return setupIntent;
+}
+
+function setupIntentPaymentMethodId(
+  setupIntent: Stripe.SetupIntent,
+): string | null {
+  return stripeObjectId(setupIntent.payment_method);
+}
+
+function setupTrialSubscriptionMetadata(args: {
+  readonly session: Stripe.Checkout.Session;
+  readonly setupIntent: Stripe.SetupIntent;
+}): Record<string, string> {
+  return {
+    ...args.session.metadata,
+    ...args.setupIntent.metadata,
+    checkoutSessionId: args.session.id,
+    setupIntentId: args.setupIntent.id,
+  };
+}
+
 function subscriptionPeriodEnd(subscription: Stripe.Subscription): Date | null {
   const periodEndUnix = subscription.items.data[0]?.current_period_end;
   return typeof periodEndUnix === "number"
     ? new Date(periodEndUnix * 1000)
     : null;
+}
+
+type SetupTrialCheckoutCompletionResult =
+  | { readonly status: "completed" }
+  | { readonly status: "pending" }
+  | {
+      readonly status: "tier_conflict";
+      readonly currentTier: string | null;
+      readonly targetTier: SubscriptionCheckoutTier;
+    };
+
+export async function completeSetupTrialCheckoutSession(args: {
+  readonly db: Db;
+  readonly stripe: ReturnType<typeof getStripeClient>;
+  readonly session: Stripe.Checkout.Session;
+  readonly customerId: string;
+}): Promise<SetupTrialCheckoutCompletionResult> {
+  const metadata = args.session.metadata ?? {};
+  if (
+    args.session.status !== "complete" ||
+    args.session.mode !== "setup" ||
+    metadata.flow !== "trial"
+  ) {
+    return { status: "pending" };
+  }
+
+  const priceId = metadata.priceId;
+  if (!priceId) {
+    return { status: "pending" };
+  }
+  const tier = tierFromPriceId(priceId);
+  if (tier !== "pro") {
+    return { status: "pending" };
+  }
+
+  const [org] = await args.db
+    .select({
+      stripeSubscriptionId: orgMetadata.stripeSubscriptionId,
+      tier: orgMetadata.tier,
+    })
+    .from(orgMetadata)
+    .where(eq(orgMetadata.stripeCustomerId, args.customerId))
+    .limit(1);
+  if (!org) {
+    return { status: "pending" };
+  }
+
+  if (org.stripeSubscriptionId) {
+    const existingSubscription = await args.stripe.subscriptions.retrieve(
+      org.stripeSubscriptionId,
+    );
+    if (existingSubscription.metadata.checkoutSessionId === args.session.id) {
+      return { status: "completed" };
+    }
+  }
+
+  if (
+    checkoutWouldReplaceWithSameOrLowerTier({
+      currentTier: org.tier,
+      targetTier: tier,
+    })
+  ) {
+    return {
+      status: "tier_conflict",
+      currentTier: org.tier,
+      targetTier: tier,
+    };
+  }
+
+  const setupIntent = await checkoutSessionSetupIntent(args.stripe, args.session);
+  if (setupIntent?.status !== "succeeded") {
+    return { status: "pending" };
+  }
+  const paymentMethodId = setupIntentPaymentMethodId(setupIntent);
+  if (!paymentMethodId) {
+    return { status: "pending" };
+  }
+
+  const subscription = await args.stripe.subscriptions.create(
+    {
+      customer: args.customerId,
+      items: [{ price: priceId }],
+      default_payment_method: paymentMethodId,
+      trial_period_days: 7,
+      metadata: setupTrialSubscriptionMetadata({
+        session: args.session,
+        setupIntent,
+      }),
+    },
+    {
+      idempotencyKey: `pro-trial-setup-checkout:${args.session.id}`,
+    },
+  );
+  const periodEnd = subscriptionPeriodEnd(subscription);
+
+  await args.db
+    .update(orgMetadata)
+    .set({
+      tier,
+      stripeSubscriptionId: subscription.id,
+      subscriptionStatus: subscription.status,
+      cancelAtPeriodEnd: subscription.cancel_at_period_end,
+      onboardingPaymentPending: false,
+      ...(periodEnd ? { currentPeriodEnd: periodEnd } : {}),
+      updatedAt: nowDate(),
+    })
+    .where(eq(orgMetadata.stripeCustomerId, args.customerId));
+
+  return { status: "completed" };
 }
 
 function customUnitAmountParams(
@@ -196,9 +340,8 @@ async function createPresetCustomCreditPrice(
 }
 
 /**
- * Create a Stripe Checkout session for subscription. Returns the
- * checkout session URL. Mirrors apps/web's createCheckoutSession
- * (allow_promotion_codes + subscription metadata orgId tag).
+ * Create a Stripe Checkout session for subscription checkout or Pro trial
+ * payment method setup. Returns the checkout session URL.
  */
 export const createCheckoutSession$ = command(
   async (
@@ -221,21 +364,32 @@ export const createCheckoutSession$ = command(
     signal.throwIfAborted();
 
     const stripe = getStripeClient();
-    const session = await stripe.checkout.sessions.create({
-      mode: "subscription",
-      customer: customerId,
-      line_items: [{ price: args.priceId, quantity: 1 }],
-      allow_promotion_codes: true,
-      success_url: args.successUrl,
-      cancel_url: args.cancelUrl,
-      metadata,
-      subscription_data: {
-        metadata,
-        ...(args.trialDays === undefined
-          ? {}
-          : { trial_period_days: args.trialDays }),
-      },
-    });
+    const session = await stripe.checkout.sessions.create(
+      args.trialDays === undefined
+        ? {
+            mode: "subscription",
+            customer: customerId,
+            line_items: [{ price: args.priceId, quantity: 1 }],
+            allow_promotion_codes: true,
+            success_url: args.successUrl,
+            cancel_url: args.cancelUrl,
+            metadata,
+            subscription_data: {
+              metadata,
+            },
+          }
+        : {
+            mode: "setup",
+            customer: customerId,
+            payment_method_types: ["card"],
+            success_url: args.successUrl,
+            cancel_url: args.cancelUrl,
+            metadata,
+            setup_intent_data: {
+              metadata,
+            },
+          },
+    );
     signal.throwIfAborted();
 
     if (!session.url) {
@@ -264,7 +418,9 @@ export const completeCheckoutSession$ = command(
     signal.throwIfAborted();
 
     const stripe = getStripeClient();
-    const session = await stripe.checkout.sessions.retrieve(args.sessionId);
+    const session = await stripe.checkout.sessions.retrieve(args.sessionId, {
+      expand: ["setup_intent"],
+    });
     signal.throwIfAborted();
 
     const customerId = stripeObjectId(session.customer);
@@ -272,7 +428,20 @@ export const completeCheckoutSession$ = command(
       return { status: "customer_mismatch" };
     }
 
-    if (session.status !== "complete" || session.mode !== "subscription") {
+    if (session.status !== "complete") {
+      return { status: "pending" };
+    }
+
+    if (session.mode === "setup") {
+      return await completeSetupTrialCheckoutSession({
+        db,
+        stripe,
+        session,
+        customerId,
+      });
+    }
+
+    if (session.mode !== "subscription") {
       return { status: "pending" };
     }
 


### PR DESCRIPTION
## Summary
- switch Pro onboarding trial checkout sessions from subscription mode to setup mode so SetupIntent receives metadata
- create the 7-day Pro subscription after setup checkout completion from both success-page completion and Stripe webhook paths
- propagate metadata to Checkout Session, SetupIntent, and created Subscription, including checkoutSessionId/setupIntentId for idempotent reconciliation

## Verification
- NODE_OPTIONS=--max-old-space-size=8192 pnpm -F api check-types
- NODE_OPTIONS=--max-old-space-size=8192 pnpm -F api lint
- pnpm -F api exec vitest run src/signals/routes/__tests__/zero-billing-checkout.test.ts src/signals/routes/__tests__/webhooks-third-party.test.ts *(fails locally because Postgres is not running: ECONNREFUSED on ::1/127.0.0.1:5432)*