### PR TITLE
refactor: tighten vsock drain fd ownership

### DIFF
--- a/crates/vsock-guest/src/drain.rs
+++ b/crates/vsock-guest/src/drain.rs
@@ -1,4 +1,5 @@
 use std::io;
+use std::os::fd::{AsRawFd, OwnedFd};
 use std::sync::atomic::{AtomicBool, Ordering};
 
 /// Buffer size for reading stdout chunks from a child process.
@@ -23,18 +24,17 @@ pub(crate) struct BoundedDrainResult {
 /// Cancel mechanism: each iteration polls for input with a 100 ms timeout
 /// before reading from the same fd, so the cancel flag is observed at most
 /// ~100 ms after it's set even if a leaked grandchild still holds the pipe
-/// write end open. When the loop returns, the caller's drop of the underlying
-/// `ChildStdout` / `ChildStderr` closes the read end of the pipe — at which
-/// point any still-writing producer gets EPIPE / SIGPIPE on its next write.
-/// That's the property a tempfile-based capture cannot offer: a regular file
-/// is always writable, so a leaked daemon would grow tmpfs memory indefinitely.
-pub(crate) fn drain_until_eof_or_cancelled<R>(
-    pipe: R,
+/// write end open. When the loop returns, dropping the owned read end closes
+/// it, at which point any still-writing producer gets EPIPE / SIGPIPE on its
+/// next write. That's the property a tempfile-based capture cannot offer: a
+/// regular file is always writable, so a leaked daemon would grow tmpfs memory
+/// indefinitely.
+pub(crate) fn drain_until_eof_or_cancelled(
+    pipe: impl Into<OwnedFd>,
     cancel: &AtomicBool,
     mut on_chunk: impl FnMut(&[u8]),
-) where
-    R: std::os::unix::io::AsRawFd,
-{
+) {
+    let pipe = pipe.into();
     let raw_fd = pipe.as_raw_fd();
     let mut chunk = [0u8; STDOUT_CHUNK_SIZE];
     loop {
@@ -68,7 +68,7 @@ pub(crate) fn drain_until_eof_or_cancelled<R>(
             continue;
         }
 
-        // SAFETY: raw_fd belongs to `pipe`, which remains alive until the
+        // SAFETY: raw_fd belongs to the owned `pipe`, which remains alive until the
         // function returns. `chunk` is valid writable memory of the given len.
         let n = unsafe { libc::read(raw_fd, chunk.as_mut_ptr().cast(), chunk.len()) };
         if n == 0 {
@@ -90,10 +90,7 @@ pub(crate) fn drain_until_eof_or_cancelled<R>(
 
 /// Buffered variant of [`drain_until_eof_or_cancelled`]: accumulates
 /// everything read into a `Vec<u8>` and returns it.
-pub(crate) fn drain_into_vec_cancellable<R>(pipe: R, cancel: &AtomicBool) -> Vec<u8>
-where
-    R: std::os::unix::io::AsRawFd,
-{
+pub(crate) fn drain_into_vec_cancellable(pipe: impl Into<OwnedFd>, cancel: &AtomicBool) -> Vec<u8> {
     let mut buf = Vec::new();
     drain_until_eof_or_cancelled(pipe, cancel, |chunk| buf.extend_from_slice(chunk));
     buf
@@ -113,7 +110,7 @@ pub(crate) fn drain_bounded_cancellable<R>(
     mut on_stream_chunk: impl FnMut(&[u8], bool) -> bool,
 ) -> BoundedDrainResult
 where
-    R: std::os::unix::io::AsRawFd,
+    R: Into<OwnedFd>,
 {
     let mut captured =
         capture_limit_bytes.map(|limit| Vec::with_capacity(limit.min(STDOUT_CHUNK_SIZE)));
@@ -184,16 +181,16 @@ mod tests {
 
     fn pipe_pair() -> (File, File) {
         let mut fds = [0; 2];
-        // SAFETY: fds points to two valid c_int slots for pipe() to fill.
-        let ret = unsafe { libc::pipe(fds.as_mut_ptr()) };
+        // SAFETY: fds points to two valid c_int slots for pipe2() to fill.
+        let ret = unsafe { libc::pipe2(fds.as_mut_ptr(), libc::O_CLOEXEC) };
         assert_eq!(ret, 0, "pipe failed: {}", io::Error::last_os_error());
 
-        // SAFETY: pipe() initialized both fds and ownership is transferred to File.
+        // SAFETY: pipe2() initialized both fds and ownership is transferred to File.
         unsafe { (File::from_raw_fd(fds[0]), File::from_raw_fd(fds[1])) }
     }
 
     #[test]
-    fn drain_cancel_exits_while_writer_fd_remains_open() {
+    fn drain_cancel_closes_reader_while_writer_fd_remains_open() {
         let (reader, mut writer) = pipe_pair();
         let cancel = Arc::new(AtomicBool::new(false));
         let (chunk_tx, chunk_rx) = mpsc::channel();
@@ -227,6 +224,10 @@ mod tests {
         };
 
         assert_eq!(output, b"hello".to_vec());
+        let err = writer
+            .write_all(b"after cancel")
+            .expect_err("owned reader should close when drain returns");
+        assert_eq!(err.kind(), io::ErrorKind::BrokenPipe);
         drop(writer);
         handle.join().unwrap();
     }

--- a/crates/vsock-guest/src/exec_operation.rs
+++ b/crates/vsock-guest/src/exec_operation.rs
@@ -875,7 +875,7 @@ fn spawn_exec_operation_drain<R, S>(
     spawner: S,
 ) -> io::Result<(JoinHandle<()>, mpsc::Receiver<BoundedDrainResult>)>
 where
-    R: std::os::unix::io::AsRawFd + Send + 'static,
+    R: Into<OwnedFd> + Send + 'static,
     S: ThreadSpawner,
 {
     let DrainWorker {


### PR DESCRIPTION
## Summary

- Narrow vsock drain helpers from broad `AsRawFd` inputs to owned-fd-convertible inputs.
- Convert drain inputs to `OwnedFd` inside the helper before polling/reading so cancellation closes the read end on return.
- Strengthen the cancellation regression test to assert a still-open writer observes `BrokenPipe`, and make test pipe fds close-on-exec to avoid parallel-test fd inheritance.

Closes #15909

## Verification

- `cargo test --manifest-path crates/Cargo.toml -p vsock-guest drain -- --nocapture`
- `cargo test --manifest-path crates/Cargo.toml -p vsock-guest`
- `cargo fmt --manifest-path crates/Cargo.toml --all -- --check`
- `git diff --check`
- `CARGO_BUILD_JOBS=1 cargo clippy --manifest-path crates/Cargo.toml -p vsock-guest --all-targets --all-features`
- `cargo doc --manifest-path crates/Cargo.toml --workspace --all-features --no-deps`
- `CARGO_BUILD_JOBS=1 cargo clippy --manifest-path crates/Cargo.toml --all-targets --all-features`