### PR TITLE
paid(lp): ai-ops-assistant office-ops campaign landing page (DRAFT)

### DIFF
--- a/turbo/apps/web/__tests__/proxy.public-routes.test.ts
+++ b/turbo/apps/web/__tests__/proxy.public-routes.test.ts
@@ -123,6 +123,22 @@ describe("proxy middleware: public routes", () => {
     expect(clerkState.protectedPaths).toEqual([]);
   });
 
+  it("keeps locale-prefixed ai-ops-assistant landing public", async () => {
+    const request = new NextRequest("https://www.vm0.ai/en/ai-ops-assistant");
+
+    await middleware(request, createMockEvent());
+
+    expect(clerkState.protectedPaths).toEqual([]);
+  });
+
+  it("keeps locale-less ai-ops-assistant landing public", async () => {
+    const request = new NextRequest("https://www.vm0.ai/ai-ops-assistant");
+
+    await middleware(request, createMockEvent());
+
+    expect(clerkState.protectedPaths).toEqual([]);
+  });
+
   it("keeps locale-prefixed report gallery public", async () => {
     const request = new NextRequest("https://www.vm0.ai/en/report");
 

--- a/turbo/apps/web/app/[locale]/ai-ops-assistant/data.ts
+++ b/turbo/apps/web/app/[locale]/ai-ops-assistant/data.ts
@@ -1,0 +1,26 @@
+import type { CampaignLandingConfig } from "../../components/CampaignLanding";
+
+// Office / operations paid segment. Follows the ai-cofounder template: a pure
+// config object consumed verbatim by the shared CampaignLanding component, so
+// the only thing that changes per segment is the copy and connector lineup.
+export const aiOpsAssistantConfig: CampaignLandingConfig = {
+  slug: "ai-ops-assistant",
+  utm_campaign: "oo_officeops_en",
+  segment: "office_ops",
+  h1: "Your AI assistant for the busywork you never get to.",
+  subhead:
+    "Zero connects to your tools and does the work. Data entry, follow-ups, scheduling, reporting. In Slack or on the web.",
+  useCases: [
+    { prompt: "Pull this week's numbers into a Google Sheet and summarize." },
+    { prompt: "Draft follow-up emails to everyone I met this week." },
+    { prompt: "Tidy my meeting notes into a shareable Notion doc." },
+    { prompt: "Schedule the team sync and send the agenda." },
+  ],
+  featuredConnectors: [
+    { name: "Google Sheets", icon: "/assets/connectors/google-sheet.svg" },
+    { name: "Gmail", icon: "/assets/connectors/gmail.svg" },
+    { name: "Notion", icon: "/assets/connectors/notion.svg", dark: true },
+    { name: "Slack", icon: "/assets/mockup/slack.svg" },
+  ],
+  ctaText: "Start your 7-day free trial",
+};

--- a/turbo/apps/web/app/[locale]/ai-ops-assistant/page.tsx
+++ b/turbo/apps/web/app/[locale]/ai-ops-assistant/page.tsx
@@ -1,0 +1,29 @@
+import type { Metadata } from "next";
+import { notFound } from "next/navigation";
+import { locales, type Locale } from "../../../i18n";
+import { CampaignLanding } from "../../components/CampaignLanding";
+import { aiOpsAssistantConfig } from "./data";
+
+interface PageProps {
+  params: Promise<{ locale: string }>;
+}
+
+// Paid-only landing page: noindex so it never competes with the homepage in
+// organic search. Traffic arrives from ads with utm/gclid params, which the
+// CTA forwards into the signup -> onboarding -> paywall -> trial flow.
+export const metadata: Metadata = {
+  title: "Your AI assistant | VM0",
+  description:
+    "Zero connects to your tools and does the work. Data entry, follow-ups, scheduling, reporting. In Slack or on the web.",
+  robots: { index: false, follow: false },
+  alternates: {},
+};
+
+export default async function AiOpsAssistantPage({ params }: PageProps) {
+  const { locale } = await params;
+  if (!locales.includes(locale as Locale)) {
+    notFound();
+  }
+
+  return <CampaignLanding config={aiOpsAssistantConfig} />;
+}

--- a/turbo/apps/web/proxy.ts
+++ b/turbo/apps/web/proxy.ts
@@ -45,6 +45,8 @@ const isPublicRoute = createRouteMatcher([
   "/:locale/presentation",
   "/ai-cofounder",
   "/:locale/ai-cofounder",
+  "/ai-ops-assistant",
+  "/:locale/ai-ops-assistant",
   "/report",
   "/:locale/report",
   "/sprite",


### PR DESCRIPTION
## What this is

A second on-brand paid campaign landing page, for the **office / operations** segment (vm0's core ICP). Slug `ai-ops-assistant`, noindex, paid-only.

Route: `turbo/apps/web/app/[locale]/ai-ops-assistant/` -> e.g. `www.vm0.ai/en/ai-ops-assistant`.

## Why it is small

This is the first page built **on top of the config-driven template from #15916**. It reuses the `CampaignLanding` component verbatim and adds only what a new segment needs:

- `app/[locale]/ai-ops-assistant/data.ts` (new) - office-ops config (h1, subhead, 4 one-tap use cases, featured connectors, CTA)
- `app/[locale]/ai-ops-assistant/page.tsx` (new) - noindex route + locale guard
- `proxy.ts` - add `/ai-ops-assistant` + `/:locale/ai-ops-assistant` to the Clerk public-route allowlist
- `__tests__/proxy.public-routes.test.ts` - public-route tests for the new path

No design-system or component changes. This validates the template's "future segments are sibling routes with their own config" claim: a new paid page is now 4 files and ~73 lines.

## Attribution + tracking (unchanged contract)

Inherited from `CampaignLanding` (#15916): clean `/sign-up` CTA, attribution via the shared `.vm0.ai` `vm0_attribution` cookie, ad params stripped from the address bar after capture, campaign-agnostic `LP Viewed` / `LP CTA Clicked` events on PostHog + Plausible.

Campaign identity for this page: `utm_campaign=oo_officeops_en`, `segment=office_ops`, `lp_slug=ai-ops-assistant`.

## Stacked on #15916

Base branch is `paid/ai-cofounder-lp`, so this PR's diff is only the new segment. Once #15916 merges to `main`, I will retarget this PR to `main`.

## Not done here

Phase 5 (full LP -> signup -> onboarding -> Stripe staging walk) and Phase 4 (Google Ads ad group) are NOT in this PR; this is the landing page only. DRAFT for preview review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
