### PR TITLE
chore: remove chat scroll feature flags

### DIFF
--- a/turbo/apps/platform/src/views/zero-page/__tests__/zero-chat-thread-page-interaction.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/zero-chat-thread-page-interaction.test.tsx
@@ -1,7 +1,6 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
-import { FeatureSwitchKey } from "@vm0/connectors/feature-switch-key";
 import { http, HttpResponse } from "msw";
 import {
   zeroBillingCheckoutContract,
@@ -602,59 +601,6 @@ describe("zero chat thread page - copy message button", () => {
 
     // The message should still be visible after copying (page remains stable)
     expect(screen.getAllByLabelText("Copy message").length).toBeGreaterThan(0);
-  });
-
-  it("keeps the scroll-to-message-start button hidden when the feature switch is off", async () => {
-    mockChatLifecycle({
-      chatMessages: [
-        {
-          role: "assistant",
-          content: "A long assistant message",
-          runId: "run-legacy-1",
-          createdAt: "2026-03-10T00:00:01Z",
-        },
-      ],
-    });
-
-    detachedSetupPage({ context, path: `/chats/${THREAD_ID}` });
-
-    await waitFor(() => {
-      expect(screen.getByText("A long assistant message")).toBeInTheDocument();
-    });
-    expect(
-      screen.queryByLabelText("Scroll to message start"),
-    ).not.toBeInTheDocument();
-  });
-
-  it("scrolls to the assistant message group start when the feature switch is on", async () => {
-    const scrollIntoView = vi
-      .spyOn(Element.prototype, "scrollIntoView")
-      .mockImplementation(() => {});
-
-    mockChatLifecycle({
-      chatMessages: [
-        {
-          role: "assistant",
-          content: "Another long assistant message",
-          runId: "run-legacy-2",
-          createdAt: "2026-03-10T00:00:01Z",
-        },
-      ],
-    });
-
-    detachedSetupPage({
-      context,
-      path: `/chats/${THREAD_ID}`,
-      featureSwitches: { [FeatureSwitchKey.ChatMessageStartButton]: true },
-    });
-
-    const button = await screen.findByLabelText("Scroll to message start");
-    click(button);
-
-    expect(scrollIntoView).toHaveBeenCalledWith({
-      block: "start",
-      behavior: "smooth",
-    });
   });
 });
 

--- a/turbo/apps/platform/src/views/zero-page/zero-chat-thread-page.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-chat-thread-page.tsx
@@ -26,7 +26,6 @@ import {
   IconCheck,
   IconDots,
   IconVolume2,
-  IconArrowBarToUp,
   IconArrowDown,
   IconBrandGoogleDrive,
   IconChevronRight,
@@ -2700,14 +2699,8 @@ function ChatThreadContent({ thread }: { thread: ChatThreadSignals }) {
   const skeletonVisible = useGet(thread.skeletonVisible$);
   const awayFromBottom = useGet(thread.awayFromBottom$);
   const scrollToBottom = useSet(thread.scrollToBottom$);
-  const features = useLastResolved(featureSwitch$);
-  const scrollToBottomButtonEnabled =
-    features?.[FeatureSwitchKey.ChatScrollToBottomButton] ?? false;
   const showScrollToBottomButton =
-    scrollToBottomButtonEnabled &&
-    awayFromBottom &&
-    !skeletonVisible &&
-    !sessionError;
+    awayFromBottom && !skeletonVisible && !sessionError;
   const loadingHistory = loadHistoryLoadable.state === "loading";
   const pageSignal = useGet(pageSignal$);
   const onLoadHistory = onDomEventFn(() => {
@@ -5033,17 +5026,7 @@ function PagedAssistantGroup({
           })}
         </div>
       </div>
-      <PagedGroupActions
-        group={group}
-        content={fullContent}
-        thread={thread}
-        onScrollToMessageStart={() => {
-          document.getElementById(groupElementId)?.scrollIntoView({
-            block: "start",
-            behavior: "smooth",
-          });
-        }}
-      />
+      <PagedGroupActions group={group} content={fullContent} thread={thread} />
     </div>
   );
 }
@@ -5172,36 +5155,14 @@ function PagedGroupPrimaryActions({
   );
 }
 
-function MessageStartButton({ onClick }: { onClick: () => void }) {
-  return (
-    <TooltipProvider delayDuration={300}>
-      <Tooltip>
-        <TooltipTrigger asChild>
-          <button
-            type="button"
-            onClick={onClick}
-            className="p-1 rounded-md text-muted-foreground/60 hover:text-foreground hover:bg-accent transition-colors duration-150"
-            aria-label="Scroll to message start"
-          >
-            <IconArrowBarToUp size={18} stroke={1.5} />
-          </button>
-        </TooltipTrigger>
-        <TooltipContent side="bottom">Scroll to start</TooltipContent>
-      </Tooltip>
-    </TooltipProvider>
-  );
-}
-
 function PagedGroupActions({
   group,
   content,
   thread,
-  onScrollToMessageStart,
 }: {
   group: GroupedChatMessageGroup;
   content: string;
   thread: ChatThreadSignals;
-  onScrollToMessageStart: () => void;
 }) {
   const pageSignal = useGet(pageSignal$);
   const copiedId = useGet(thread.copiedMessageId$);
@@ -5210,8 +5171,6 @@ function PagedGroupActions({
 
   const features = useLastResolved(featureSwitch$);
   const audioOutputEnabled = features?.[FeatureSwitchKey.AudioOutput] ?? false;
-  const messageStartButtonEnabled =
-    features?.[FeatureSwitchKey.ChatMessageStartButton] ?? false;
   const firstRunId = group.messages.find((m) => {
     return m.runId;
   })?.runId;
@@ -5262,9 +5221,6 @@ function PagedGroupActions({
           onCopy={handleCopy}
           onTts={handleTts}
         />
-        {messageStartButtonEnabled && (
-          <MessageStartButton onClick={onScrollToMessageStart} />
-        )}
       </div>
     </div>
   );

--- a/turbo/packages/connectors/src/feature-switch-key.ts
+++ b/turbo/packages/connectors/src/feature-switch-key.ts
@@ -40,8 +40,6 @@ export enum FeatureSwitchKey {
   OrgSkills = "orgSkills",
   TestOauthConnector = "testOauthConnector",
   ChatHeaderNewButton = "chatHeaderNewButton",
-
-  ChatMessageStartButton = "chatMessageStartButton",
   ChatThreadRename = "chatThreadRename",
   FreshdeskConnector = "freshdeskConnector",
   StabilityAiConnector = "stabilityAiConnector",
@@ -54,6 +52,5 @@ export enum FeatureSwitchKey {
   SessionWorkspaceImageCache = "sessionWorkspaceImageCache",
   ChatArtifactSidebar = "chatArtifactSidebar",
   ChatGithubPrTracking = "chatGithubPrTracking",
-  ChatScrollToBottomButton = "chatScrollToBottomButton",
   MemoryViewer = "memoryViewer",
 }

--- a/turbo/packages/core/src/__tests__/feature-switch.test.ts
+++ b/turbo/packages/core/src/__tests__/feature-switch.test.ts
@@ -107,11 +107,7 @@ describe("getAllFeatureStates", () => {
     });
     expect(staffOrgStates[FeatureSwitchKey.Lab]).toBe(true);
     expect(staffOrgStates[FeatureSwitchKey.OrgSkills]).toBe(true);
-    expect(staffOrgStates[FeatureSwitchKey.ChatScrollToBottomButton]).toBe(
-      true,
-    );
     expect(staffOrgStates[FeatureSwitchKey.ChatHeaderNewButton]).toBe(false);
-    expect(staffOrgStates[FeatureSwitchKey.ChatMessageStartButton]).toBe(false);
     expect(staffOrgStates[FeatureSwitchKey.ChatThreadRename]).toBe(false);
     expect(staffOrgStates[FeatureSwitchKey.UserPermissionGrants]).toBe(true);
     expect(staffOrgStates[FeatureSwitchKey.SessionWorkspaceImageCache]).toBe(
@@ -123,9 +119,6 @@ describe("getAllFeatureStates", () => {
     });
     expect(otherOrgStates[FeatureSwitchKey.Lab]).toBe(false);
     expect(otherOrgStates[FeatureSwitchKey.OrgSkills]).toBe(false);
-    expect(otherOrgStates[FeatureSwitchKey.ChatScrollToBottomButton]).toBe(
-      true,
-    );
     expect(otherOrgStates[FeatureSwitchKey.UserPermissionGrants]).toBe(false);
     expect(otherOrgStates[FeatureSwitchKey.SessionWorkspaceImageCache]).toBe(
       false,

--- a/turbo/packages/core/src/feature-switch.ts
+++ b/turbo/packages/core/src/feature-switch.ts
@@ -227,12 +227,6 @@ const FEATURE_SWITCHES: Record<FeatureSwitchKey, FeatureSwitch> = {
       "Replace the Invite people button in the agent chat page header with a New button that creates a new chat thread",
     enabled: false,
   },
-  [FeatureSwitchKey.ChatMessageStartButton]: {
-    maintainer: "linghan@vm0.ai",
-    description:
-      "Show an icon button in assistant message group actions that scrolls back to the start of that message group.",
-    enabled: false,
-  },
   [FeatureSwitchKey.ChatThreadRename]: {
     maintainer: "ethan@vm0.ai",
     description:
@@ -302,12 +296,6 @@ const FEATURE_SWITCHES: Record<FeatureSwitchKey, FeatureSwitch> = {
       "Show GitHub PR tracking in chat thread headers when the current agent is connected to and authorized for GitHub.",
     enabled: false,
     enabledOrgIdHashes: STAFF_ORG_ID_HASHES,
-  },
-  [FeatureSwitchKey.ChatScrollToBottomButton]: {
-    maintainer: "ethan@vm0.ai",
-    description:
-      "Show a floating scroll-to-bottom button in the bottom-right of the chat thread (above the composer) whenever the message list is scrolled away from the bottom. Clicking it jumps to the latest message.",
-    enabled: true,
   },
   [FeatureSwitchKey.MemoryViewer]: {
     maintainer: "lancy@vm0.ai",


### PR DESCRIPTION
Summary:
- Remove ChatScrollToBottomButton from the feature switch registry and keep the scroll-to-bottom button always available under its existing runtime conditions
- Remove the abandoned ChatMessageStartButton flag, button component, scroll callback, and dead tests
- Update feature switch registry tests after deleting both keys

Tests:
- pnpm format
- pnpm -F @vm0/core run lint
- pnpm -F @vm0/core run check-types
- pnpm -F @vm0/connectors run lint
- pnpm -F @vm0/connectors run check-types
- NODE_OPTIONS=--max-old-space-size=8192 pnpm -F @vm0/app run lint
- NODE_OPTIONS=--max-old-space-size=8192 pnpm -F @vm0/app run check-types
- pnpm -F @vm0/core exec vitest run src/__tests__/feature-switch.test.ts
- pnpm -F @vm0/app exec vitest run src/views/zero-page/__tests__/zero-chat-thread-page-interaction.test.tsx