### PR TITLE
chore: update rootfs package versions

### DIFF
--- a/crates/runner/scripts/build-template.sh
+++ b/crates/runner/scripts/build-template.sh
@@ -110,8 +110,8 @@ ROOTFS_DIR=""
 CACHE_TMP_TAR=""
 
 # Pinned versions (changes here invalidate the template cache via script hash)
-GO_VERSION="1.26.3"
-CLAUDE_CODE_VERSION="2.1.160"
+GO_VERSION="1.26.4"
+CLAUDE_CODE_VERSION="2.1.161"
 CODEX_CLI_VERSION="0.136.0"
 GWS_CLI_VERSION="0.22.5"
 XURL_VERSION="1.0.3"


### PR DESCRIPTION
## Updates

- Go: 1.26.3 -> 1.26.4
- Claude Code CLI: 2.1.160 -> 2.1.161

## Checks

- bash -n crates/runner/scripts/build-template.sh

## Notes

- Ubuntu/noble was left unchanged per request.
- NodeSource node_24.x was left unchanged because Node 24 remains the current LTS line.