### PR TITLE
chore(rust): update dependencies

### DIFF
--- a/crates/Cargo.lock
+++ b/crates/Cargo.lock
@@ -136,6 +136,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "arc-swap"
+version = "1.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6a3a1fd6f75306b68087b831f025c712524bcb19aad54e557b1129cfa0a2b207"
+dependencies = [
+ "rustversion",
+]
+
+[[package]]
 name = "assert-json-diff"
 version = "2.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -253,10 +262,11 @@ dependencies = [
 
 [[package]]
 name = "aws-sdk-s3"
-version = "1.134.0"
+version = "1.135.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "be06bdfdf00371318253d74776567512d1229d1f3cd5546d27d333c89e013b84"
+checksum = "f97e3e7e7d86fd26fcdc18bc382da5ca9e8b2ff8d54030d187fd0dac8a236d96"
 dependencies = [
+ "arc-swap",
  "aws-credential-types",
  "aws-runtime",
  "aws-sigv4",
@@ -288,9 +298,9 @@ dependencies = [
 
 [[package]]
 name = "aws-sigv4"
-version = "1.4.4"
+version = "1.4.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b7083fb918b38474ac65ffbf8a69fc8792d36879f4ac5f1667b43aec61efe9a5"
+checksum = "bae38512beae0ffee7010fc24e7a8a123c53efdfef42a61e80fda4882418dc71"
 dependencies = [
  "aws-credential-types",
  "aws-smithy-eventstream",
@@ -609,9 +619,9 @@ dependencies = [
 
 [[package]]
 name = "bitflags"
-version = "2.11.1"
+version = "2.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c4512299f36f043ab09a583e57bceb5a5aab7a73db1805848e8fef3c9e8c78b3"
+checksum = "84d7ced0ae9557296835c32bf1b1e02b44c746701f898460fb000d7eaa84f00a"
 
 [[package]]
 name = "bitvec"
@@ -1969,9 +1979,9 @@ dependencies = [
 
 [[package]]
 name = "log"
-version = "0.4.30"
+version = "0.4.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "616ec5685824bcc94416c6d4a7a446eea774a31efd7062c8480ba6fd06d7a6e5"
+checksum = "113b30b4cd05f7c06868fdb2854f66a7b9fece9a48425351cd532e810d74024f"
 
 [[package]]
 name = "lru"


### PR DESCRIPTION
## Summary
- Updated the Rust workspace lockfile under `crates/` with the latest Cargo-compatible dependency versions.
- `cargo update --verbose` changed 5 lockfile packages: added `arc-swap 1.9.1`, updated `aws-sdk-s3 1.134.0 -> 1.135.0`, `aws-sigv4 1.4.4 -> 1.4.5`, `bitflags 2.11.1 -> 2.12.1`, and `log 0.4.30 -> 0.4.31`.

## Dependencies not updated
- `generic-array 0.14.7` remains unchanged while `0.14.9` is available. `cargo update -p generic-array@0.14.7 --precise 0.14.9 --verbose` fails because transitive dependency `crypto-common 0.1.7` requires `generic-array = "=0.14.7"`.

## Manual version bumps
- None. No `Cargo.toml` version constraints required a safe minor/patch bump.

## Test status
- Passed: `CARGO_TARGET_DIR=/home/user/workspace/vm0-rust-deps-target env -u CLI_AGENT_TYPE -u TMPDIR cargo test --workspace -j 1`.
- Notes: the default workspace test attempt hit local runner constraints (`/tmp` filled when the target dir was under the clone, then parallel linking was killed with signal 9). The passing run keeps the build target on the workspace volume, unsets the agent-runtime `CLI_AGENT_TYPE=codex` so guest-agent tests use their default framework path, and serializes jobs to avoid linker memory pressure.