### PR TITLE
feat: memory viewer refinements — pin MEMORY.md, file panel on the right

### DIFF
--- a/turbo/apps/platform/src/views/memory-page/__tests__/memory-page.test.tsx
+++ b/turbo/apps/platform/src/views/memory-page/__tests__/memory-page.test.tsx
@@ -17,14 +17,18 @@ function setupMemoryPage(): void {
   setMockMemory({
     exists: true,
     name: "memory",
-    size: 60,
-    fileCount: 2,
+    size: 80,
+    fileCount: 3,
     updatedAt: "2024-01-01T00:00:00Z",
+    // "context.md" sorts before "MEMORY.md" alphabetically, so it proves the
+    // MEMORY.md pin (rather than plain alphabetical ordering).
     files: [
+      { path: "context.md", size: 20 },
       { path: "MEMORY.md", size: 30 },
       { path: "scratch.txt", size: 30 },
     ],
     fileContents: [
+      { path: "context.md", content: "Context note." },
       { path: "MEMORY.md", content: "# Memory Index\n\nThings I know." },
       { path: "scratch.txt", content: "Plain scratch note." },
     ],
@@ -93,5 +97,26 @@ describe("memory page", () => {
         return button.textContent === "Save";
       }),
     ).toBeFalsy();
+  });
+
+  it("pins MEMORY.md to the top of the file list", async () => {
+    setupMemoryPage();
+
+    await waitFor(() => {
+      expect(screen.getAllByText("MEMORY.md").length).toBeGreaterThan(0);
+    });
+
+    const filePaths = ["context.md", "MEMORY.md", "scratch.txt"];
+    const fileButtons = queryAllByRoleFast("button").filter((button) => {
+      const text = button.textContent ?? "";
+      return filePaths.some((path) => {
+        return text.includes(path);
+      });
+    });
+
+    // MEMORY.md is pinned first even though "context.md" sorts before it.
+    expect(fileButtons[0]?.textContent).toContain("MEMORY.md");
+    expect(fileButtons[1]?.textContent).toContain("context.md");
+    expect(fileButtons[2]?.textContent).toContain("scratch.txt");
   });
 });

--- a/turbo/apps/platform/src/views/memory-page/memory-page.tsx
+++ b/turbo/apps/platform/src/views/memory-page/memory-page.tsx
@@ -68,7 +68,15 @@ function MemoryViewer({ detail }: { readonly detail: MemoryDetailResponse }) {
   const explicitSelected = useGet(selectedMemoryFilePath$);
   const setSelected = useSet(setSelectedMemoryFilePath$);
 
+  // MEMORY.md is the index of all memory, so pin it to the top; the rest stay
+  // sorted alphabetically.
   const files = [...detail.files].sort((a, b) => {
+    if (a.path === PREFERRED_FILE) {
+      return -1;
+    }
+    if (b.path === PREFERRED_FILE) {
+      return 1;
+    }
     return a.path.localeCompare(b.path);
   });
   const preferredPath =

--- a/turbo/apps/platform/src/views/memory-page/memory-page.tsx
+++ b/turbo/apps/platform/src/views/memory-page/memory-page.tsx
@@ -49,8 +49,8 @@ export function MemoryPage() {
         </div>
       </header>
 
-      <main className="flex-1 overflow-auto px-4 pb-8 pt-3 sm:px-6">
-        <div className="mx-auto max-w-[900px]">
+      <main className="flex min-h-0 flex-1 flex-col overflow-hidden px-4 pb-8 pt-3 sm:px-6">
+        <div className="mx-auto flex min-h-0 w-full max-w-[900px] flex-1 flex-col">
           {loading ? (
             <MemorySkeleton />
           ) : hasFiles && detail ? (
@@ -99,10 +99,41 @@ function MemoryViewer({ detail }: { readonly detail: MemoryDetailResponse }) {
     : null;
 
   return (
-    <section className="zero-card min-h-[520px] overflow-hidden">
-      <div className="grid min-h-[520px] gap-0 lg:grid-cols-[240px_minmax(0,1fr)]">
-        <aside className="min-h-0 border-b border-border/70 bg-muted/20 lg:border-b-0 lg:border-r">
-          <div className="flex h-9 items-center justify-between border-b border-border/70 px-3">
+    <section className="zero-card flex min-h-[420px] flex-1 flex-col overflow-hidden">
+      <div className="flex min-h-0 flex-1 flex-col lg:flex-row">
+        {/* Content (left) — scrolls independently of the file panel. */}
+        <div className="order-1 flex min-h-0 flex-1 flex-col">
+          <div className="flex h-9 shrink-0 items-center border-b border-border/70 px-4 text-xs font-medium text-muted-foreground">
+            <span className="truncate">
+              {selectedPath ?? "No file selected"}
+            </span>
+          </div>
+          {selectedPath && selectedContent !== null ? (
+            isMarkdown(selectedPath) ? (
+              <div
+                aria-label="Memory content"
+                className="min-h-0 flex-1 overflow-auto bg-background px-4 py-3"
+              >
+                <Markdown source={selectedContent} />
+              </div>
+            ) : (
+              <pre
+                aria-label="Memory content"
+                className="min-h-0 flex-1 overflow-auto whitespace-pre-wrap bg-background px-4 py-3 font-mono text-sm leading-6 text-foreground"
+              >
+                {selectedContent}
+              </pre>
+            )
+          ) : (
+            <div className="flex min-h-0 flex-1 items-center justify-center px-4 text-sm text-muted-foreground">
+              No content available for this file.
+            </div>
+          )}
+        </div>
+
+        {/* File panel (right) — fixed; its own scroll, doesn't move with content. */}
+        <aside className="order-2 flex min-h-0 flex-col border-t border-border/70 bg-muted/20 lg:w-[240px] lg:shrink-0 lg:border-l lg:border-t-0">
+          <div className="flex h-9 shrink-0 items-center justify-between border-b border-border/70 px-3">
             <span className="text-xs font-medium text-muted-foreground">
               Files
             </span>
@@ -110,7 +141,7 @@ function MemoryViewer({ detail }: { readonly detail: MemoryDetailResponse }) {
               {files.length}
             </span>
           </div>
-          <div className="max-h-[240px] overflow-auto p-2 lg:max-h-none">
+          <div className="max-h-[240px] min-h-0 flex-1 overflow-auto p-2 lg:max-h-none">
             <div className="flex flex-col gap-1">
               {files.map((file) => {
                 const selected = file.path === selectedPath;
@@ -141,35 +172,6 @@ function MemoryViewer({ detail }: { readonly detail: MemoryDetailResponse }) {
             </div>
           </div>
         </aside>
-
-        <div className="flex min-h-0 flex-col">
-          <div className="flex h-9 shrink-0 items-center border-b border-border/70 px-4 text-xs font-medium text-muted-foreground">
-            <span className="truncate">
-              {selectedPath ?? "No file selected"}
-            </span>
-          </div>
-          {selectedPath && selectedContent !== null ? (
-            isMarkdown(selectedPath) ? (
-              <div
-                aria-label="Memory content"
-                className="min-h-[420px] flex-1 overflow-auto bg-background px-4 py-3"
-              >
-                <Markdown source={selectedContent} />
-              </div>
-            ) : (
-              <pre
-                aria-label="Memory content"
-                className="min-h-[420px] flex-1 overflow-auto whitespace-pre-wrap bg-background px-4 py-3 font-mono text-sm leading-6 text-foreground"
-              >
-                {selectedContent}
-              </pre>
-            )
-          ) : (
-            <div className="flex min-h-[420px] flex-1 items-center justify-center px-4 text-sm text-muted-foreground">
-              No content available for this file.
-            </div>
-          )}
-        </div>
       </div>
     </section>
   );
@@ -177,7 +179,7 @@ function MemoryViewer({ detail }: { readonly detail: MemoryDetailResponse }) {
 
 function MemoryEmptyState({ errored }: { readonly errored: boolean }) {
   return (
-    <section className="zero-card flex min-h-[520px] flex-col items-center justify-center px-6 text-center">
+    <section className="zero-card flex min-h-[420px] flex-1 flex-col items-center justify-center px-6 text-center">
       <p className="text-sm font-medium text-foreground">
         {errored ? "Couldn't load memory" : "No memory yet"}
       </p>
@@ -192,10 +194,13 @@ function MemoryEmptyState({ errored }: { readonly errored: boolean }) {
 
 function MemorySkeleton() {
   return (
-    <section className="zero-card min-h-[520px] overflow-hidden">
-      <div className="grid min-h-[520px] gap-0 lg:grid-cols-[240px_minmax(0,1fr)]">
+    <section className="zero-card flex min-h-[420px] flex-1 flex-col overflow-hidden">
+      <div className="flex min-h-0 flex-1 flex-col lg:flex-row">
+        <div className="order-1 flex min-h-0 flex-1 flex-col p-4">
+          <div className="min-h-[260px] flex-1 rounded bg-muted/50" />
+        </div>
         <div
-          className="border-b border-border/70 bg-muted/20 p-2 lg:border-b-0 lg:border-r"
+          className="order-2 border-t border-border/70 bg-muted/20 p-2 lg:w-[240px] lg:shrink-0 lg:border-l lg:border-t-0"
           data-testid="memory-loading"
         >
           <div className="flex flex-col gap-1">
@@ -205,9 +210,6 @@ function MemorySkeleton() {
               );
             })}
           </div>
-        </div>
-        <div className="p-4">
-          <div className="h-[420px] rounded bg-muted/50" />
         </div>
       </div>
     </section>


### PR DESCRIPTION
Two read-only memory-viewer (`/memory`) refinements, both following the Skills detail page as the reference. Follow-up to #15898.

## 1. Pin `MEMORY.md` to the top
The file list was sorted purely alphabetically, so a file like `context.md` could appear above `MEMORY.md`. `MEMORY.md` is the index of all memory, so it's now pinned first; the rest stay alphabetical. (It was already the default-selected file — this aligns list order with that.)

## 2. File panel on the right, with independent scroll
Mirrors the Skills detail layout:
- **Content on the left, file panel on the right** (was: files on the left).
- The content area scrolls within a **fixed-height region**, so the file panel **stays put** instead of scrolling along with the content. The file panel has its own scroll when the list is long.
- Page is height-bounded by `SidebarLayout` (`h-dvh`), so the viewer fills the available space; on mobile the panes stack (content above, files below with a capped height).

## Files
- `apps/platform/src/views/memory-page/memory-page.tsx` — sort comparator (pin) + layout restructure (content-left/files-right, fixed-height with internal scroll); empty/skeleton states updated to match
- Test updated: fixture includes `context.md` (sorts before `MEMORY.md`) and a case asserts `MEMORY.md` renders first

## Testing
- `@vm0/app` memory-page test: 4/4 ✅
- `pnpm check-types` ✅ · `pnpm turbo run lint` ✅ · `pnpm knip` ✅ (exit 0) · `pnpm format` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)