### PR TITLE
fix: add app permissions policy header

### DIFF
--- a/turbo/apps/platform/src/__tests__/vercel-headers.test.ts
+++ b/turbo/apps/platform/src/__tests__/vercel-headers.test.ts
@@ -20,6 +20,8 @@ const entries =
   (vercelConfig as { headers?: VercelHeaderEntry[] }).headers ?? [];
 const rewrites =
   (vercelConfig as { rewrites?: VercelRewriteEntry[] }).rewrites ?? [];
+const appPermissionsPolicy =
+  "camera=(), geolocation=(), payment=(), usb=(), serial=(), display-capture=(), microphone=(self), bluetooth=(self), clipboard-read=(self), clipboard-write=(self), fullscreen=(self)";
 
 function findHeaderEntry(source: string): VercelHeaderEntry | undefined {
   return entries.find((e) => {
@@ -56,6 +58,9 @@ describe("app vercel.json headers", () => {
     );
     expect(findHeader(catchAll!.headers, "Strict-Transport-Security")).toBe(
       "max-age=31536000; includeSubDomains",
+    );
+    expect(findHeader(catchAll!.headers, "Permissions-Policy")).toBe(
+      appPermissionsPolicy,
     );
   });
 

--- a/turbo/apps/platform/src/__tests__/vercel-headers.test.ts
+++ b/turbo/apps/platform/src/__tests__/vercel-headers.test.ts
@@ -21,7 +21,7 @@ const entries =
 const rewrites =
   (vercelConfig as { rewrites?: VercelRewriteEntry[] }).rewrites ?? [];
 const appPermissionsPolicy =
-  "camera=(), geolocation=(), payment=(), usb=(), serial=(), display-capture=(), microphone=(self), bluetooth=(self), clipboard-read=(self), clipboard-write=(self), fullscreen=(self)";
+  "camera=(), geolocation=(), payment=(), usb=(), serial=(), display-capture=(), clipboard-read=(), microphone=(self), bluetooth=(self), clipboard-write=(self), fullscreen=(self)";
 
 function findHeaderEntry(source: string): VercelHeaderEntry | undefined {
   return entries.find((e) => {

--- a/turbo/apps/platform/vercel.json
+++ b/turbo/apps/platform/vercel.json
@@ -42,7 +42,7 @@
         },
         {
           "key": "Permissions-Policy",
-          "value": "camera=(), geolocation=(), payment=(), usb=(), serial=(), display-capture=(), microphone=(self), bluetooth=(self), clipboard-read=(self), clipboard-write=(self), fullscreen=(self)"
+          "value": "camera=(), geolocation=(), payment=(), usb=(), serial=(), display-capture=(), clipboard-read=(), microphone=(self), bluetooth=(self), clipboard-write=(self), fullscreen=(self)"
         }
       ]
     }

--- a/turbo/apps/platform/vercel.json
+++ b/turbo/apps/platform/vercel.json
@@ -39,6 +39,10 @@
         {
           "key": "Strict-Transport-Security",
           "value": "max-age=31536000; includeSubDomains"
+        },
+        {
+          "key": "Permissions-Policy",
+          "value": "camera=(), geolocation=(), payment=(), usb=(), serial=(), display-capture=(), microphone=(self), bluetooth=(self), clipboard-read=(self), clipboard-write=(self), fullscreen=(self)"
         }
       ]
     }


### PR DESCRIPTION
## Summary
- add a catch-all Permissions-Policy header to the platform app Vercel config
- disable unused sensitive browser capabilities while allowing app-required microphone, bluetooth, clipboard, and fullscreen features for self
- cover the policy with the platform app Vercel header test

Fixes #15919

## Verification
- pnpm format
- pnpm -F @vm0/app exec vitest src/__tests__/vercel-headers.test.ts
- pnpm -F @vm0/app lint
- pnpm check-types

## Deployment verification
After deploy:
`curl -I https://staging-app.vm6.ai/ | rg -i '^permissions-policy:'`