### PR TITLE
fix: cap firewall auth response reads

### DIFF
--- a/crates/runner/mitm-addon/src/auth.py
+++ b/crates/runner/mitm-addon/src/auth.py
@@ -40,6 +40,10 @@ class InvalidBillableAuthExpiryError(Exception):
     """Raised when billable firewall auth succeeds with an invalid cache expiry."""
 
 
+class FirewallAuthResponseTooLargeError(Exception):
+    """Raised when /firewall/auth returns a response body above the local cap."""
+
+
 class FirewallAuthApiError(Exception):
     """Raised when /firewall/auth returns a structured error envelope."""
 
@@ -61,6 +65,7 @@ class FirewallAuthApiError(Exception):
 
 # Vercel bypass secret (still from environment as it's a secret)
 VERCEL_BYPASS = os.environ.get("VERCEL_AUTOMATION_BYPASS_SECRET", "")
+MAX_FIREWALL_AUTH_RESPONSE_BODY_BYTES = 256 * 1024
 _HTTP_STATUS_CLIENT_ERROR_MIN = 400
 _HTTP_STATUS_SERVER_ERROR_MIN = 500
 _STRUCTURED_FIREWALL_AUTH_ERROR_CODES = frozenset(
@@ -272,6 +277,13 @@ def make_api_request(url: str, data: bytes, sandbox_token: str) -> urllib.reques
     return req
 
 
+def _read_firewall_auth_response_body(resp) -> bytes:
+    body = resp.read(MAX_FIREWALL_AUTH_RESPONSE_BODY_BYTES + 1)
+    if len(body) > MAX_FIREWALL_AUTH_RESPONSE_BODY_BYTES:
+        raise FirewallAuthResponseTooLargeError("Firewall auth response body too large")
+    return body
+
+
 def _firewall_auth_api_error_from_envelope(
     status: int,
     error_info: dict,
@@ -413,14 +425,14 @@ def _fetch_firewall_headers_sync(
     try:
         # nosemgrep: dynamic-urllib-use-detected
         with urllib.request.urlopen(req, timeout=10) as resp:  # noqa: S310
-            decoded: object = json.loads(resp.read())
+            decoded: object = json.loads(_read_firewall_auth_response_body(resp))
             return _parse_firewall_auth_success(decoded)
     except urllib.error.HTTPError as e:
         # HTTPError wraps an open socket; `with e` closes on every exit
         # path to avoid FD exhaustion under sustained cache-miss load (#10475).
         with e:
             try:
-                error_body = json.loads(e.read())
+                error_body = json.loads(_read_firewall_auth_response_body(e))
             except (json.JSONDecodeError, OSError):
                 raise e from None
             if not isinstance(error_body, dict):

--- a/crates/runner/mitm-addon/src/auth.py
+++ b/crates/runner/mitm-addon/src/auth.py
@@ -13,6 +13,7 @@ import urllib.error
 import urllib.parse
 import urllib.request
 from dataclasses import dataclass, field
+from typing import Protocol
 
 from mitmproxy import ctx, http
 
@@ -61,6 +62,10 @@ class FirewallAuthApiError(Exception):
         self.code = code
         self.connectors = connectors
         self.failure_reason = failure_reason
+
+
+class _ResponseBodyReader(Protocol):
+    def read(self, n: int = -1) -> bytes: ...
 
 
 # Vercel bypass secret (still from environment as it's a secret)
@@ -277,7 +282,7 @@ def make_api_request(url: str, data: bytes, sandbox_token: str) -> urllib.reques
     return req
 
 
-def _read_firewall_auth_response_body(resp) -> bytes:
+def _read_firewall_auth_response_body(resp: _ResponseBodyReader) -> bytes:
     body = resp.read(MAX_FIREWALL_AUTH_RESPONSE_BODY_BYTES + 1)
     if len(body) > MAX_FIREWALL_AUTH_RESPONSE_BODY_BYTES:
         raise FirewallAuthResponseTooLargeError("Firewall auth response body too large")

--- a/crates/runner/mitm-addon/src/auth.py
+++ b/crates/runner/mitm-addon/src/auth.py
@@ -65,7 +65,8 @@ class FirewallAuthApiError(Exception):
 
 
 class _ResponseBodyReader(Protocol):
-    def read(self, n: int = -1) -> bytes: ...
+    def read(self, n: int = -1) -> bytes:
+        raise NotImplementedError
 
 
 # Vercel bypass secret (still from environment as it's a secret)

--- a/crates/runner/mitm-addon/tests/test_firewall_auth.py
+++ b/crates/runner/mitm-addon/tests/test_firewall_auth.py
@@ -67,6 +67,13 @@ def _json_response(body: object) -> MagicMock:
     return mock_resp
 
 
+def _raw_response(body: bytes) -> MagicMock:
+    mock_resp = MagicMock()
+    mock_resp.__enter__.return_value = mock_resp
+    mock_resp.read.return_value = body
+    return mock_resp
+
+
 def _allow(
     api_entry: dict,
     *,
@@ -840,6 +847,64 @@ class TestHandleFirewallRequest:
         assert "connectors" not in body
         mock_resp.__exit__.assert_called_once()
 
+    async def test_oversized_success_response_returns_502_without_auth_mutation(
+        self,
+        real_flow,
+        mitm_ctx,
+        tmp_path,
+    ):
+        flow = real_flow(
+            with_response=False,
+            host="api.github.com",
+            path="/repos?existing=1",
+        )
+        flow.metadata["vm_run_id"] = "test-run"
+        api_entry = {
+            "base": "https://api.github.com",
+            "auth": {
+                "headers": {"Authorization": "Bearer ${{ secrets.GITHUB_TOKEN }}"},
+                "query": {"api_key": "${{ secrets.GITHUB_TOKEN }}"},
+            },
+        }
+        vm_info = {
+            "runId": "run-1",
+            "sandboxToken": "tok-xyz",
+            "encryptedSecrets": "iv:tag:data",
+            "networkLogPath": str(tmp_path / "net.jsonl"),
+            "billableFirewalls": [],
+        }
+        allow = _allow(api_entry)
+        response_body = json.dumps({"headers": {"Authorization": "Bearer tok"}}).encode()
+        mock_resp = _raw_response(response_body)
+
+        with (
+            patch.object(
+                auth,
+                "MAX_FIREWALL_AUTH_RESPONSE_BODY_BYTES",
+                len(response_body) - 1,
+                create=True,
+            ),
+            patch("auth.urllib.request.urlopen", return_value=mock_resp),
+            mitm_ctx(),
+        ):
+            await auth.handle_firewall_request(flow, allow, vm_info)
+
+        assert flow.response is not None
+        assert flow.response.status_code == 502
+        assert flow.metadata["firewall_action"] == "ALLOW"
+        assert flow.metadata["firewall_error"] == "auth_failed"
+        assert "Authorization" not in flow.request.headers
+        assert "api_key" not in flow.request.query
+        assert flow.request.query["existing"] == "1"
+        assert cached_headers(("test-run", "https://api.github.com")) is None
+        body = json.loads(flow.response.content)
+        assert body["error"] == "auth_failed"
+        assert "Firewall auth response body too large" in body["message"]
+        assert body["permission"] == "github"
+        assert body["base"] == "https://api.github.com"
+        assert "connectors" not in body
+        mock_resp.__exit__.assert_called_once()
+
     async def test_malformed_json_success_response_returns_502_without_auth_mutation(
         self,
         real_flow,
@@ -1313,6 +1378,53 @@ class TestFetchFirewallHeaders:
 
         mock_resp.__exit__.assert_called_once()
 
+    def test_success_response_at_body_limit_is_accepted(self):
+        response_body = json.dumps({"headers": {}}).encode()
+        mock_resp = _raw_response(response_body)
+
+        with (
+            patch.object(
+                auth,
+                "MAX_FIREWALL_AUTH_RESPONSE_BODY_BYTES",
+                len(response_body),
+                create=True,
+            ),
+            patch("auth.urllib.request.Request"),
+            patch("auth.urllib.request.urlopen", return_value=mock_resp),
+            patch.object(auth, "VERCEL_BYPASS", ""),
+        ):
+            result = auth._fetch_firewall_headers_sync(
+                "iv:tag:data",
+                {},
+                "tok-xyz",
+                "https://api.vm0.ai",
+            )
+
+        assert result.payload.headers == {}
+        mock_resp.read.assert_called_once_with(len(response_body) + 1)
+        mock_resp.__exit__.assert_called_once()
+
+    def test_success_response_over_body_limit_raises_and_closes_response(self):
+        response_body = json.dumps({"headers": {}}).encode()
+        mock_resp = _raw_response(response_body)
+
+        with (
+            patch.object(
+                auth,
+                "MAX_FIREWALL_AUTH_RESPONSE_BODY_BYTES",
+                len(response_body) - 1,
+                create=True,
+            ),
+            patch("auth.urllib.request.Request"),
+            patch("auth.urllib.request.urlopen", return_value=mock_resp),
+            patch.object(auth, "VERCEL_BYPASS", ""),
+            pytest.raises(Exception, match="Firewall auth response body too large"),
+        ):
+            auth._fetch_firewall_headers_sync("iv:tag:data", {}, "tok-xyz", "https://api.vm0.ai")
+
+        mock_resp.read.assert_called_once_with(len(response_body))
+        mock_resp.__exit__.assert_called_once()
+
     def test_success_response_shape_is_parsed_to_internal_type(self):
         expires_at = time.time() + 30
         mock_resp = _json_response(
@@ -1633,6 +1745,73 @@ class TestFetchFirewallHeaders:
         assert str(exc_info.value) == message
         assert exc_info.value.connectors == connectors
         assert exc_info.value.failure_reason == expected_failure_reason
+
+    def test_structured_http_error_at_body_limit_is_preserved(self):
+        error_body = json.dumps(
+            {
+                "error": {
+                    "message": "Access token expired and refresh failed for: notion.",
+                    "code": "TOKEN_REFRESH_FAILED",
+                }
+            }
+        ).encode()
+        http_error = _http_error(
+            "https://api.vm0.ai/api/webhooks/agent/firewall/auth",
+            502,
+            "Bad Gateway",
+            error_body,
+        )
+        http_error.close = MagicMock()
+
+        with (
+            patch.object(
+                auth,
+                "MAX_FIREWALL_AUTH_RESPONSE_BODY_BYTES",
+                len(error_body),
+                create=True,
+            ),
+            patch("auth.urllib.request.Request"),
+            patch("auth.urllib.request.urlopen", side_effect=http_error),
+            patch.object(auth, "VERCEL_BYPASS", ""),
+            pytest.raises(auth.FirewallAuthApiError) as exc_info,
+        ):
+            auth._fetch_firewall_headers_sync("iv:tag:data", {}, "tok-xyz", "https://api.vm0.ai")
+
+        assert exc_info.value.code == "TOKEN_REFRESH_FAILED"
+        http_error.close.assert_called_once()
+
+    def test_http_error_over_body_limit_raises_and_closes_response(self):
+        error_body = json.dumps(
+            {
+                "error": {
+                    "message": "Access token expired and refresh failed for: notion.",
+                    "code": "TOKEN_REFRESH_FAILED",
+                }
+            }
+        ).encode()
+        http_error = _http_error(
+            "https://api.vm0.ai/api/webhooks/agent/firewall/auth",
+            502,
+            "Bad Gateway",
+            error_body,
+        )
+        http_error.close = MagicMock()
+
+        with (
+            patch.object(
+                auth,
+                "MAX_FIREWALL_AUTH_RESPONSE_BODY_BYTES",
+                len(error_body) - 1,
+                create=True,
+            ),
+            patch("auth.urllib.request.Request"),
+            patch("auth.urllib.request.urlopen", side_effect=http_error),
+            patch.object(auth, "VERCEL_BYPASS", ""),
+            pytest.raises(Exception, match="Firewall auth response body too large"),
+        ):
+            auth._fetch_firewall_headers_sync("iv:tag:data", {}, "tok-xyz", "https://api.vm0.ai")
+
+        http_error.close.assert_called_once()
 
     @pytest.mark.parametrize(
         "error_body",

--- a/crates/runner/mitm-addon/tests/test_firewall_auth.py
+++ b/crates/runner/mitm-addon/tests/test_firewall_auth.py
@@ -882,7 +882,6 @@ class TestHandleFirewallRequest:
                 auth,
                 "MAX_FIREWALL_AUTH_RESPONSE_BODY_BYTES",
                 len(response_body) - 1,
-                create=True,
             ),
             patch("auth.urllib.request.urlopen", return_value=mock_resp),
             mitm_ctx(),
@@ -1387,7 +1386,6 @@ class TestFetchFirewallHeaders:
                 auth,
                 "MAX_FIREWALL_AUTH_RESPONSE_BODY_BYTES",
                 len(response_body),
-                create=True,
             ),
             patch("auth.urllib.request.Request"),
             patch("auth.urllib.request.urlopen", return_value=mock_resp),
@@ -1413,12 +1411,14 @@ class TestFetchFirewallHeaders:
                 auth,
                 "MAX_FIREWALL_AUTH_RESPONSE_BODY_BYTES",
                 len(response_body) - 1,
-                create=True,
             ),
             patch("auth.urllib.request.Request"),
             patch("auth.urllib.request.urlopen", return_value=mock_resp),
             patch.object(auth, "VERCEL_BYPASS", ""),
-            pytest.raises(Exception, match="Firewall auth response body too large"),
+            pytest.raises(
+                auth.FirewallAuthResponseTooLargeError,
+                match="Firewall auth response body too large",
+            ),
         ):
             auth._fetch_firewall_headers_sync("iv:tag:data", {}, "tok-xyz", "https://api.vm0.ai")
 
@@ -1768,7 +1768,6 @@ class TestFetchFirewallHeaders:
                 auth,
                 "MAX_FIREWALL_AUTH_RESPONSE_BODY_BYTES",
                 len(error_body),
-                create=True,
             ),
             patch("auth.urllib.request.Request"),
             patch("auth.urllib.request.urlopen", side_effect=http_error),
@@ -1802,12 +1801,14 @@ class TestFetchFirewallHeaders:
                 auth,
                 "MAX_FIREWALL_AUTH_RESPONSE_BODY_BYTES",
                 len(error_body) - 1,
-                create=True,
             ),
             patch("auth.urllib.request.Request"),
             patch("auth.urllib.request.urlopen", side_effect=http_error),
             patch.object(auth, "VERCEL_BYPASS", ""),
-            pytest.raises(Exception, match="Firewall auth response body too large"),
+            pytest.raises(
+                auth.FirewallAuthResponseTooLargeError,
+                match="Firewall auth response body too large",
+            ),
         ):
             auth._fetch_firewall_headers_sync("iv:tag:data", {}, "tok-xyz", "https://api.vm0.ai")
 


### PR DESCRIPTION
## Summary
- add a 256 KiB cap for firewall auth webhook response reads in the mitm addon
- apply the cap to both success and HTTPError response parsing
- cover oversized success/HTTPError responses and hook-level no-auth-mutation behavior

Closes #15920

## Verification
- /tmp/mitm-addon-test-venv/bin/python -m pytest tests/test_firewall_auth.py -q
- /tmp/mitm-addon-test-venv/bin/python -m ruff check .
- /tmp/mitm-addon-test-venv/bin/python -m ruff format --check .
- /tmp/mitm-addon-test-venv/bin/basedpyright -p . --pythonpath /tmp/mitm-addon-test-venv/bin/python
- git diff --check