### PR TITLE
fix: render permission action status as text

### DIFF
--- a/turbo/apps/platform/src/views/zero-page/__tests__/zero-chat-thread-page-display.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/zero-chat-thread-page-display.test.tsx
@@ -646,7 +646,9 @@ describe("zero chat thread page display - permission action card", () => {
     expect(requestCreated).toBeFalsy();
     expect(requestsListed).toBeFalsy();
     expect(hasSubscription("permissionAccessRequestsChanged")).toBeFalsy();
-    expect(within(card).getByText("Permissions updated")).toBeInTheDocument();
+    const status = within(card).getByText("Permissions updated");
+    expect(status).toBeInTheDocument();
+    expect(status.closest("button")).toBeNull();
   });
 
   it("writes a current-user grant for admins when user permission grants are enabled", async () => {
@@ -735,7 +737,9 @@ describe("zero chat thread page display - permission action card", () => {
       });
     });
     expect(policyUpdated).toBeFalsy();
-    expect(within(card).getByText("Permission denied")).toBeInTheDocument();
+    const status = within(card).getByText("Permission denied");
+    expect(status).toBeInTheDocument();
+    expect(status.closest("button")).toBeNull();
   });
 
   it("uses default connector policies for already-applied chat permission actions", async () => {
@@ -795,7 +799,9 @@ describe("zero chat thread page display - permission action card", () => {
     const card = await waitFor(() => {
       return screen.getByTestId("permission-action-card");
     });
-    expect(within(card).getByText("Permissions updated")).toBeInTheDocument();
+    const status = within(card).getByText("Permissions updated");
+    expect(status).toBeInTheDocument();
+    expect(status.closest("button")).toBeNull();
     expect(grantCalled).toBeFalsy();
   });
 
@@ -850,12 +856,9 @@ describe("zero chat thread page display - permission action card", () => {
     const card = await waitFor(() => {
       return screen.getByTestId("permission-action-card");
     });
-    expect(within(card).getByText("Permissions updated")).toBeInTheDocument();
-    const button = queryAllByRoleFast("button", card).find((element) => {
-      return element.textContent === "Permissions updated";
-    });
-    expect(button).toBeDefined();
-    expect(button).toBeDisabled();
+    const status = within(card).getByText("Permissions updated");
+    expect(status).toBeInTheDocument();
+    expect(status.closest("button")).toBeNull();
   });
 
   it("does not write grants for unknown chat permission actions", async () => {

--- a/turbo/apps/platform/src/views/zero-page/__tests__/zero-chat-thread-page-display.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/zero-chat-thread-page-display.test.tsx
@@ -473,6 +473,67 @@ describe("zero chat thread page display - permission action card", () => {
     expect(createCalled).toBeFalsy();
   });
 
+  it("shows denied existing permission requests as text", async () => {
+    let createCalled = false;
+
+    setMockOrg({ role: "member" });
+    setMockPermissionRequests([
+      pendingPermissionRequest({
+        status: "rejected",
+        resolvedBy: "other-owner-id",
+        resolvedAt: "2026-03-10T00:01:00Z",
+      }),
+    ]);
+    mockChatLifecycle({
+      chatMessages: [
+        {
+          role: "assistant",
+          content:
+            "https://app.vm0.ai/agents/4f189ea8-ada2-416d-83a9-9c25ddb960c9/permissions?ref=vercel&permission=projects%3Awrite&action=allow",
+          runId: "run-rejected-permission-request",
+          status: "completed",
+          createdAt: "2026-03-10T00:00:00Z",
+        },
+      ],
+    });
+    server.use(
+      mockApi(zeroAgentsByIdContract.get, ({ respond }) => {
+        return respond(200, {
+          agentId: "4f189ea8-ada2-416d-83a9-9c25ddb960c9",
+          ownerId: "other-owner-id",
+          description: null,
+          displayName: null,
+          sound: null,
+          avatarUrl: null,
+          permissionPolicies: {
+            vercel: { policies: { "projects:write": "deny" } },
+          },
+          customSkills: [],
+          modelProviderId: null,
+          selectedModel: null,
+          preferPersonalProvider: false,
+        });
+      }),
+      mockApi(permissionAccessRequestsCreateContract.create, ({ respond }) => {
+        createCalled = true;
+        return respond(201, pendingPermissionRequest());
+      }),
+    );
+
+    detachedSetupPage({ context, path: "/chats/thread-test-1" });
+
+    const card = await waitFor(() => {
+      return screen.getByTestId("permission-action-card");
+    });
+    await waitFor(() => {
+      expect(within(card).getByText("Request denied")).toBeInTheDocument();
+    });
+    expect(
+      within(card).getByText("Request denied").closest("button"),
+    ).toBeNull();
+    expect(createCalled).toBeFalsy();
+  });
+
   it("refreshes a requested permission action when the Ably signal arrives", async () => {
     let requestBody: unknown;
     let agentPolicies: Record<

--- a/turbo/apps/platform/src/views/zero-page/zero-chat-thread-page.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-chat-thread-page.tsx
@@ -3544,7 +3544,6 @@ function permissionActionVerb(action: PermissionAction): string {
 
 function permissionActionButtonLabel(
   state: PermissionActionButtonState,
-  action: PermissionAction,
 ): string {
   if (state.loading) {
     return "Checking permissions";
@@ -3554,21 +3553,6 @@ function permissionActionButtonLabel(
   }
   if (!state.hasPermission) {
     return "Unknown permission";
-  }
-  if (state.saveDone || state.alreadyApplied) {
-    return action === "allow" ? "Permissions updated" : "Permission denied";
-  }
-  if (state.existingRequestStatus === "pending") {
-    return "Request sent";
-  }
-  if (state.existingRequestStatus === "approved") {
-    return "Permissions updated";
-  }
-  if (state.existingRequestStatus === "rejected") {
-    return "Request denied";
-  }
-  if (state.submitDone) {
-    return "Request sent";
   }
   if (state.saving) {
     return state.canManagePermissions || state.selfServiceGrant
@@ -3587,12 +3571,8 @@ function permissionActionButtonDisabled(
     state.loading ||
     state.loadError ||
     state.saving ||
-    state.alreadyApplied ||
-    state.saveDone ||
-    state.submitDone ||
     !state.hasAgent ||
-    !state.hasPermission ||
-    Boolean(state.existingRequestStatus)
+    !state.hasPermission
   );
 }
 
@@ -3643,7 +3623,7 @@ function PermissionActionButton({
       className="inline-flex h-9 w-full shrink-0 items-center justify-center gap-2 rounded-lg border border-border bg-background px-3 text-sm font-medium text-foreground transition-colors hover:bg-accent sm:w-auto"
     >
       {state.saving && <IconLoader2 size={15} className="animate-spin" />}
-      {permissionActionButtonLabel(state, action)}
+      {permissionActionButtonLabel(state)}
     </button>
   );
 }

--- a/turbo/apps/platform/src/views/zero-page/zero-chat-thread-page.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-chat-thread-page.tsx
@@ -3611,6 +3611,9 @@ function permissionActionStatusText(
   if (state.existingRequestStatus === "pending" || state.submitDone) {
     return { label: "Request sent", className: "text-green-600" };
   }
+  if (state.existingRequestStatus === "rejected") {
+    return { label: "Request denied", className: "text-destructive" };
+  }
   return null;
 }
 

--- a/turbo/apps/platform/src/views/zero-page/zero-chat-thread-page.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-chat-thread-page.tsx
@@ -3471,7 +3471,6 @@ interface PermissionActionButtonState {
   saveDone: boolean;
   submitDone: boolean;
   alreadyApplied: boolean;
-  explicitUserGrantApplied: boolean;
   canManagePermissions: boolean;
   selfServiceGrant: boolean;
   existingRequestStatus: "pending" | "approved" | "rejected" | null;
@@ -3601,9 +3600,6 @@ function permissionActionStatusText(
   state: PermissionActionButtonState,
   action: "allow" | "deny",
 ): { label: string; className: string } | null {
-  if (state.explicitUserGrantApplied) {
-    return null;
-  }
   if (state.saveDone || state.alreadyApplied) {
     return action === "allow"
       ? { label: "Permissions updated", className: "text-green-600" }
@@ -3771,26 +3767,6 @@ function permissionActionUserGrantPolicy(
   );
 }
 
-function explicitPermissionActionUserGrantApplied(
-  userPermissionGrantsEnabled: boolean,
-  loadable: LoadableLike<readonly PermissionActionUserGrant[]>,
-  block: PermissionActionBlock,
-): boolean {
-  if (!userPermissionGrantsEnabled) {
-    return false;
-  }
-  return (
-    loadableData(loadable)?.some((grant) => {
-      return (
-        grant.agentId === block.agentId &&
-        grant.connectorRef === block.connectorRef &&
-        grant.permission === block.permission &&
-        grant.action === block.action
-      );
-    }) ?? false
-  );
-}
-
 function storedPermissionActionPolicy(
   agent: PermissionActionAgent | null,
   block: PermissionActionBlock,
@@ -3807,7 +3783,6 @@ function createPermissionActionButtonState(params: {
   loadError: boolean;
   saving: boolean;
   alreadyApplied: boolean;
-  explicitUserGrantApplied: boolean;
   canManagePermissions: boolean;
   selfServiceGrant: boolean;
   existingRequestStatus: "pending" | "approved" | "rejected" | null;
@@ -3823,7 +3798,6 @@ function createPermissionActionButtonState(params: {
     saveDone: params.saveDone,
     submitDone: params.submitDone,
     alreadyApplied: params.alreadyApplied,
-    explicitUserGrantApplied: params.explicitUserGrantApplied,
     canManagePermissions: params.canManagePermissions,
     selfServiceGrant: params.selfServiceGrant,
     existingRequestStatus: params.existingRequestStatus,
@@ -3839,7 +3813,6 @@ function createPermissionActionCardButtonState(params: {
   saveDone: boolean;
   submitDone: boolean;
   alreadyApplied: boolean;
-  explicitUserGrantApplied: boolean;
   canManagePermissions: boolean;
   userPermissionGrantsEnabled: boolean;
   existingRequest: PermissionActionExistingRequest | null;
@@ -3853,7 +3826,6 @@ function createPermissionActionCardButtonState(params: {
     saveDone: params.saveDone,
     submitDone: params.submitDone,
     alreadyApplied: params.alreadyApplied,
-    explicitUserGrantApplied: params.explicitUserGrantApplied,
     canManagePermissions: params.canManagePermissions,
     selfServiceGrant: params.userPermissionGrantsEnabled,
     existingRequestStatus: params.existingRequest?.status ?? null,
@@ -3906,11 +3878,6 @@ function createPermissionActionCardViewState(params: {
     params.userGrantsLoadable,
     params.block,
   );
-  const explicitUserGrantApplied = explicitPermissionActionUserGrantApplied(
-    params.userPermissionGrantsEnabled,
-    params.userGrantsLoadable,
-    params.block,
-  );
   const alreadyApplied = isPermissionActionAlreadyApplied({
     hasAgent: Boolean(params.agent),
     userPermissionGrantsEnabled: params.userPermissionGrantsEnabled,
@@ -3936,7 +3903,6 @@ function createPermissionActionCardViewState(params: {
     saveDone,
     submitDone,
     alreadyApplied,
-    explicitUserGrantApplied,
     canManagePermissions: params.canManagePermissions,
     userPermissionGrantsEnabled: params.userPermissionGrantsEnabled,
     existingRequest,


### PR DESCRIPTION
## Summary
- render completed chat permission action statuses as non-interactive text
- remove the explicit user-grant branch that fell back to a disabled button
- render denied existing permission requests as non-interactive text too
- assert user-grant and denied request statuses are not nested inside buttons

## Verification
- pnpm -F @vm0/app exec vitest run src/views/zero-page/__tests__/zero-chat-thread-page-display.test.tsx
- pnpm -F @vm0/app lint
- pnpm -F @vm0/app check-types
- pre-commit: prettier, knip, turbo check-types
