### PR TITLE
refactor(connectors): move oauth endpoints into providers

### DIFF
--- a/turbo/apps/api/src/signals/routes/__tests__/zero-connectors-oauth-device-auth.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/zero-connectors-oauth-device-auth.test.ts
@@ -1,7 +1,6 @@
 import { createHash, randomUUID } from "node:crypto";
 
 import { zeroConnectorOauthDeviceAuthSessionContract } from "@vm0/api-contracts/contracts/zero-connectors";
-import { getConnectorAuthMethodDeviceAuthGrantConfig } from "@vm0/connectors/connector-utils";
 import { FeatureSwitchKey } from "@vm0/connectors/feature-switch-key";
 import { testOauthDeviceProvider } from "@vm0/connectors/auth-providers/oauth/providers/test-oauth-device-provider";
 import { connectors } from "@vm0/db/schema/connector";
@@ -1304,10 +1303,6 @@ describe("OAuth device authorization connector routes", () => {
           clientType: "public",
           clientId: "test-oauth-device-client",
         },
-        deviceAuthGrant: getConnectorAuthMethodDeviceAuthGrantConfig(
-          "test-oauth-device",
-          "oauth",
-        ),
         deviceCode: "test-device:test-oauth-device-client:read",
       });
     };

--- a/turbo/packages/connectors/src/__tests__/connectors.test.ts
+++ b/turbo/packages/connectors/src/__tests__/connectors.test.ts
@@ -465,8 +465,8 @@ describe("connector auth method config", () => {
       ).toStrictEqual(["oauth", "api"]);
       expect(hasConnectorAuthCodeGrant("github")).toBe(true);
       expect(
-        getConnectorAuthMethodAuthCodeGrantConfig("github", "api")?.tokenUrl,
-      ).toBe(authMethods.oauth.grant.tokenUrl);
+        getConnectorAuthMethodAuthCodeGrantConfig("github", "api"),
+      ).toStrictEqual(authMethods.oauth.grant);
     } finally {
       Reflect.deleteProperty(authMethods, "api");
     }
@@ -2513,9 +2513,9 @@ describe("connector OAuth lifecycle grant helpers", () => {
     expect(grant).toStrictEqual(method?.grant);
     expect(grant).toMatchObject({
       kind: "auth-code",
-      tokenUrl: "https://github.com/login/oauth/access_token",
       scopes: ["repo", "project", "workflow"],
     });
+    expect("tokenUrl" in grant).toBe(false);
     expect("client" in grant).toBe(false);
     expect(method).toMatchObject({
       client: {
@@ -2535,8 +2535,6 @@ describe("connector OAuth lifecycle grant helpers", () => {
       getConnectorAuthMethodDeviceAuthGrantConfig("test-oauth-device", "oauth"),
     ).toMatchObject({
       kind: "device-auth",
-      deviceAuthUrl: "/api/test/oauth-provider/device/code",
-      tokenUrl: "/api/test/oauth-provider/token",
       scopes: ["read"],
     });
     expect(getConnectorAuthMethod("test-oauth-device", "oauth")).toMatchObject({
@@ -2550,8 +2548,6 @@ describe("connector OAuth lifecycle grant helpers", () => {
       getConnectorAuthMethodDeviceAuthGrantConfig("test-oauth-device", "api"),
     ).toMatchObject({
       kind: "device-auth",
-      deviceAuthUrl: "/api/test/oauth-provider/device/code",
-      tokenUrl: "/api/test/oauth-provider/token",
       scopes: ["read"],
     });
     expect(getConnectorAuthMethod("test-oauth-device", "api")).toMatchObject({
@@ -2565,8 +2561,6 @@ describe("connector OAuth lifecycle grant helpers", () => {
       getConnectorAuthMethodDeviceAuthGrantConfig("base44", "oauth"),
     ).toMatchObject({
       kind: "device-auth",
-      deviceAuthUrl: "https://app.base44.com/oauth/device/code",
-      tokenUrl: "https://app.base44.com/oauth/token",
       scopes: ["apps:read", "apps:write", "offline"],
     });
     expect(getConnectorAuthMethod("base44", "oauth")).toMatchObject({
@@ -2580,8 +2574,6 @@ describe("connector OAuth lifecycle grant helpers", () => {
       getConnectorAuthMethodDeviceAuthGrantConfig("slock", "oauth"),
     ).toMatchObject({
       kind: "device-auth",
-      deviceAuthUrl: "https://api.slock.ai/api/auth/device/authorize",
-      tokenUrl: "https://api.slock.ai/api/auth/device/token",
       scopes: [],
     });
     expect(getConnectorAuthMethod("slock", "oauth")).toMatchObject({
@@ -2618,7 +2610,7 @@ describe("connector authorization-code grant config", () => {
     }
   });
 
-  it("keeps provider authorization URLs out of connector OAuth grants", () => {
+  it("keeps provider endpoint URLs out of connector OAuth grants", () => {
     for (const type of connectorTypeSchema.options) {
       for (const authMethod of getConnectorAuthMethodIdsForGrantKind(
         type,
@@ -2638,6 +2630,10 @@ describe("connector authorization-code grant config", () => {
         expect(
           "authorizationUrl" in grant,
           `${type}:${authMethod}: authorization URL should be provider-owned`,
+        ).toBe(false);
+        expect(
+          "tokenUrl" in grant,
+          `${type}:${authMethod}: token URL should be provider-owned`,
         ).toBe(false);
       }
       for (const authMethod of getConnectorAuthMethodIdsForGrantKind(
@@ -2659,6 +2655,14 @@ describe("connector authorization-code grant config", () => {
           "authorizationUrl" in grant,
           `${type}:${authMethod}: authorization URL should be provider-owned`,
         ).toBe(false);
+        expect(
+          "deviceAuthUrl" in grant,
+          `${type}:${authMethod}: device authorization URL should be provider-owned`,
+        ).toBe(false);
+        expect(
+          "tokenUrl" in grant,
+          `${type}:${authMethod}: token URL should be provider-owned`,
+        ).toBe(false);
       }
     }
   });
@@ -2671,8 +2675,6 @@ describe("connector OAuth device authorization config", () => {
       getConnectorAuthMethodDeviceAuthGrantConfig("test-oauth-device", "oauth"),
     ).toMatchObject({
       kind: "device-auth",
-      deviceAuthUrl: "/api/test/oauth-provider/device/code",
-      tokenUrl: "/api/test/oauth-provider/token",
       scopes: ["read"],
     });
     expect(getConnectorAuthMethod("test-oauth-device", "oauth")).toMatchObject({
@@ -2685,8 +2687,6 @@ describe("connector OAuth device authorization config", () => {
     expect(getConnectorAuthMethod("test-oauth-device", "api")).toMatchObject({
       grant: {
         kind: "device-auth",
-        deviceAuthUrl: "/api/test/oauth-provider/device/code",
-        tokenUrl: "/api/test/oauth-provider/token",
         scopes: ["read"],
       },
       client: {
@@ -2703,8 +2703,6 @@ describe("connector OAuth device authorization config", () => {
       getConnectorAuthMethodDeviceAuthGrantConfig("base44", "oauth"),
     ).toMatchObject({
       kind: "device-auth",
-      deviceAuthUrl: "https://app.base44.com/oauth/device/code",
-      tokenUrl: "https://app.base44.com/oauth/token",
       scopes: ["apps:read", "apps:write", "offline"],
     });
     expect(getConnectorAuthMethod("base44", "oauth")).toMatchObject({
@@ -2722,8 +2720,6 @@ describe("connector OAuth device authorization config", () => {
       getConnectorAuthMethodDeviceAuthGrantConfig("slock", "oauth"),
     ).toMatchObject({
       kind: "device-auth",
-      deviceAuthUrl: "https://api.slock.ai/api/auth/device/authorize",
-      tokenUrl: "https://api.slock.ai/api/auth/device/token",
       scopes: [],
     });
     expect(getConnectorAuthMethod("slock", "oauth")).toMatchObject({

--- a/turbo/packages/connectors/src/auth-providers/connector-auth.ts
+++ b/turbo/packages/connectors/src/auth-providers/connector-auth.ts
@@ -17,7 +17,6 @@ import {
   connectorAuthMethodRefHasRevokeKind,
   getConnectorAuthMethod,
   getConnectorAuthMethodAuthCodeGrantConfig,
-  getConnectorAuthMethodDeviceAuthGrantConfig,
   getConnectorAuthMethodGrantScopes,
   isStaticConfidentialConnectorAuthClient,
   resolveConnectorAuthClientForMethod,
@@ -578,13 +577,8 @@ export async function startConnectorDeviceAuthorization<
     args.type,
     args.authMethod,
   );
-  const deviceAuthGrant = getConnectorAuthMethodDeviceAuthGrantConfig(
-    args.type,
-    args.authMethod,
-  );
   return await provider.startDeviceAuth({
     authClient: connectorAuthClientIdentityForMethod(args.authClient),
-    deviceAuthGrant,
     scopes: getConnectorAuthMethodGrantScopes(args.type, args.authMethod),
   });
 }
@@ -614,13 +608,8 @@ export async function pollConnectorDeviceAuthorization<
     args.type,
     args.authMethod,
   );
-  const deviceAuthGrant = getConnectorAuthMethodDeviceAuthGrantConfig(
-    args.type,
-    args.authMethod,
-  );
   return await provider.pollDeviceAuth({
     authClient: args.authClient,
-    deviceAuthGrant,
     deviceCode: args.deviceCode,
   });
 }
@@ -660,7 +649,6 @@ export async function refreshConnectorAuthProviderAccessToken<
   );
   return await access.refreshToken({
     authClient: args.authClient,
-    tokenUrl: method.access.tokenUrl,
     refreshToken: args.refreshToken,
     signal: args.signal,
   });

--- a/turbo/packages/connectors/src/auth-providers/oauth/google.ts
+++ b/turbo/packages/connectors/src/auth-providers/oauth/google.ts
@@ -4,6 +4,8 @@ import type { ConnectorAuthCodeGrantConfig } from "@vm0/connectors/connectors";
 import type { GoogleOAuthConnectorType } from "./google-connectors";
 import { throwOAuthError } from "./error";
 
+const GOOGLE_OAUTH_TOKEN_URL = "https://oauth2.googleapis.com/token";
+
 const GOOGLE_OAUTH_AUTHORIZATION_URL =
   "https://accounts.google.com/o/oauth2/v2/auth";
 
@@ -65,7 +67,7 @@ export async function exchangeGoogleOAuthCode(
   code: string,
   redirectUri: string,
 ): Promise<GoogleTokenResult> {
-  const response = await fetch(authCodeGrant.tokenUrl, {
+  const response = await fetch(GOOGLE_OAUTH_TOKEN_URL, {
     method: "POST",
     headers: {
       "Content-Type": "application/x-www-form-urlencoded",
@@ -120,14 +122,13 @@ export async function exchangeGoogleOAuthCode(
  * Access token expires_in: 3600s (1 hour). Ref: https://developers.google.com/identity/protocols/oauth2/web-server
  */
 export async function refreshGoogleToken(
-  tokenUrl: string,
   connectorType: GoogleOAuthConnectorType,
   clientId: string,
   clientSecret: string,
   refreshToken: string,
   signal: AbortSignal,
 ): Promise<GoogleRefreshResult> {
-  const response = await fetch(tokenUrl, {
+  const response = await fetch(GOOGLE_OAUTH_TOKEN_URL, {
     signal,
     method: "POST",
     headers: {

--- a/turbo/packages/connectors/src/auth-providers/oauth/microsoft.ts
+++ b/turbo/packages/connectors/src/auth-providers/oauth/microsoft.ts
@@ -6,6 +6,9 @@ import { z } from "zod";
 
 import { throwOAuthError } from "./error";
 
+const MICROSOFT_TOKEN_URL =
+  "https://login.microsoftonline.com/common/oauth2/v2.0/token";
+
 const MICROSOFT_AUTHORIZATION_URL =
   "https://login.microsoftonline.com/common/oauth2/v2.0/authorize";
 
@@ -71,7 +74,7 @@ export async function exchangeMicrosoftOAuthCode(
   code: string,
   redirectUri: string,
 ): Promise<MicrosoftTokenResult> {
-  const response = await fetch(authCodeGrant.tokenUrl, {
+  const response = await fetch(MICROSOFT_TOKEN_URL, {
     method: "POST",
     headers: {
       "Content-Type": "application/x-www-form-urlencoded",
@@ -126,14 +129,13 @@ export async function exchangeMicrosoftOAuthCode(
  * Access token expires_in: 3600-5400s (~75 min). Ref: https://learn.microsoft.com/en-us/entra/identity-platform/v2-oauth2-auth-code-flow
  */
 export async function refreshMicrosoftToken(
-  tokenUrl: string,
   connectorType: MicrosoftOAuthConnectorType,
   clientId: string,
   clientSecret: string,
   refreshToken: string,
   signal: AbortSignal,
 ): Promise<MicrosoftRefreshResult> {
-  const response = await fetch(tokenUrl, {
+  const response = await fetch(MICROSOFT_TOKEN_URL, {
     signal,
     method: "POST",
     headers: {

--- a/turbo/packages/connectors/src/auth-providers/oauth/providers/__tests__/google-ads.test.ts
+++ b/turbo/packages/connectors/src/auth-providers/oauth/providers/__tests__/google-ads.test.ts
@@ -161,10 +161,6 @@ describe("connector/providers/google-ads", () => {
         },
         refreshToken: "refresh-token",
         signal: testRefreshSignal(),
-        tokenUrl: getConnectorAuthMethodAuthCodeGrantConfig(
-          "google-ads",
-          "oauth",
-        ).tokenUrl,
       });
 
       expect(result).toEqual({

--- a/turbo/packages/connectors/src/auth-providers/oauth/providers/__tests__/gumroad.test.ts
+++ b/turbo/packages/connectors/src/auth-providers/oauth/providers/__tests__/gumroad.test.ts
@@ -143,7 +143,6 @@ describe("connector/providers/gumroad", () => {
       server.use(handler);
 
       const result = await refreshGumroadToken(
-        authCodeGrant().tokenUrl,
         "client-id",
         "client-secret",
         "old-refresh-token",
@@ -165,7 +164,6 @@ describe("connector/providers/gumroad", () => {
 
       await expect(
         refreshGumroadToken(
-          authCodeGrant().tokenUrl,
           "client-id",
           "client-secret",
           "bad-refresh-token",
@@ -182,7 +180,6 @@ describe("connector/providers/gumroad", () => {
 
       await expect(
         refreshGumroadToken(
-          authCodeGrant().tokenUrl,
           "client-id",
           "client-secret",
           "refresh-token",
@@ -199,7 +196,6 @@ describe("connector/providers/gumroad", () => {
 
       await expect(
         refreshGumroadToken(
-          authCodeGrant().tokenUrl,
           "client-id",
           "client-secret",
           "refresh-token",

--- a/turbo/packages/connectors/src/auth-providers/oauth/providers/__tests__/spotify.test.ts
+++ b/turbo/packages/connectors/src/auth-providers/oauth/providers/__tests__/spotify.test.ts
@@ -156,7 +156,6 @@ describe("connector/providers/spotify", () => {
       server.use(handler);
 
       const result = await refreshSpotifyToken(
-        authCodeGrant().tokenUrl,
         "client-id",
         "client-secret",
         "old-refresh-token",
@@ -182,7 +181,6 @@ describe("connector/providers/spotify", () => {
 
       await expect(
         refreshSpotifyToken(
-          authCodeGrant().tokenUrl,
           "client-id",
           "client-secret",
           "bad-refresh-token",
@@ -202,7 +200,6 @@ describe("connector/providers/spotify", () => {
 
       await expect(
         refreshSpotifyToken(
-          authCodeGrant().tokenUrl,
           "client-id",
           "client-secret",
           "refresh-token",
@@ -222,7 +219,6 @@ describe("connector/providers/spotify", () => {
 
       await expect(
         refreshSpotifyToken(
-          authCodeGrant().tokenUrl,
           "client-id",
           "client-secret",
           "refresh-token",

--- a/turbo/packages/connectors/src/auth-providers/oauth/providers/__tests__/test-oauth.test.ts
+++ b/turbo/packages/connectors/src/auth-providers/oauth/providers/__tests__/test-oauth.test.ts
@@ -126,7 +126,6 @@ describe("test-oauth provider URLs", () => {
     );
 
     await refreshTestOAuthToken(
-      authCodeGrant().tokenUrl,
       "test-oauth-client",
       "test-oauth-secret",
       "refresh-1",

--- a/turbo/packages/connectors/src/auth-providers/oauth/providers/__tests__/zoom.test.ts
+++ b/turbo/packages/connectors/src/auth-providers/oauth/providers/__tests__/zoom.test.ts
@@ -146,7 +146,6 @@ describe("connector/providers/zoom", () => {
       server.use(handler);
 
       const result = await refreshZoomToken(
-        authCodeGrant().tokenUrl,
         "client-id",
         "client-secret",
         "old-refresh-token",
@@ -169,7 +168,6 @@ describe("connector/providers/zoom", () => {
 
       await expect(
         refreshZoomToken(
-          authCodeGrant().tokenUrl,
           "client-id",
           "client-secret",
           "bad-refresh-token",
@@ -186,7 +184,6 @@ describe("connector/providers/zoom", () => {
 
       await expect(
         refreshZoomToken(
-          authCodeGrant().tokenUrl,
           "client-id",
           "client-secret",
           "refresh-token",
@@ -203,7 +200,6 @@ describe("connector/providers/zoom", () => {
 
       await expect(
         refreshZoomToken(
-          authCodeGrant().tokenUrl,
           "client-id",
           "client-secret",
           "refresh-token",

--- a/turbo/packages/connectors/src/auth-providers/oauth/providers/ahrefs-provider.ts
+++ b/turbo/packages/connectors/src/auth-providers/oauth/providers/ahrefs-provider.ts
@@ -50,7 +50,6 @@ export const ahrefsProvider: AuthCodeConnectorAuthProvider<"ahrefs"> = {
     refreshToken: (args) => {
       const { clientId, clientSecret } = args.authClient;
       return refreshAhrefsToken(
-        args.tokenUrl,
         clientId,
         clientSecret,
         args.refreshToken,

--- a/turbo/packages/connectors/src/auth-providers/oauth/providers/ahrefs.ts
+++ b/turbo/packages/connectors/src/auth-providers/oauth/providers/ahrefs.ts
@@ -3,6 +3,8 @@ import { z } from "zod";
 import type { ConnectorAuthCodeGrantConfig } from "@vm0/connectors/connectors";
 import { throwOAuthError } from "../error";
 
+const AHREFS_TOKEN_URL = "https://app.ahrefs.com/api/token";
+
 const AHREFS_AUTHORIZATION_URL = "https://app.ahrefs.com/api/auth";
 
 const AHREFS_SUBSCRIPTION_URL =
@@ -58,7 +60,7 @@ export async function exchangeAhrefsCode(
   code: string,
   redirectUri: string,
 ): Promise<AhrefsTokenResult> {
-  const response = await fetch(authCodeGrant.tokenUrl, {
+  const response = await fetch(AHREFS_TOKEN_URL, {
     method: "POST",
     headers: {
       "Content-Type": "application/x-www-form-urlencoded",
@@ -112,13 +114,12 @@ export async function exchangeAhrefsCode(
  * Access token expires_in: returned but value undocumented. Ref: https://docs.ahrefs.com/docs/ahrefs-connect/developers/oauth-guide
  */
 export async function refreshAhrefsToken(
-  tokenUrl: string,
   clientId: string,
   clientSecret: string,
   refreshToken: string,
   signal: AbortSignal,
 ): Promise<AhrefsRefreshResult> {
-  const response = await fetch(tokenUrl, {
+  const response = await fetch(AHREFS_TOKEN_URL, {
     signal,
     method: "POST",
     headers: {

--- a/turbo/packages/connectors/src/auth-providers/oauth/providers/airtable-provider.ts
+++ b/turbo/packages/connectors/src/auth-providers/oauth/providers/airtable-provider.ts
@@ -52,7 +52,6 @@ export const airtableProvider: AuthCodeConnectorAuthProvider<"airtable"> = {
     refreshToken: (args) => {
       const { clientId, clientSecret } = args.authClient;
       return refreshAirtableToken(
-        args.tokenUrl,
         clientId,
         clientSecret,
         args.refreshToken,

--- a/turbo/packages/connectors/src/auth-providers/oauth/providers/airtable.ts
+++ b/turbo/packages/connectors/src/auth-providers/oauth/providers/airtable.ts
@@ -3,6 +3,8 @@ import { z } from "zod";
 import type { ConnectorAuthCodeGrantConfig } from "@vm0/connectors/connectors";
 import { throwOAuthError } from "../error";
 
+const AIRTABLE_TOKEN_URL = "https://airtable.com/oauth2/v1/token";
+
 const AIRTABLE_AUTHORIZATION_URL = "https://airtable.com/oauth2/v1/authorize";
 
 const AIRTABLE_WHOAMI_URL = "https://api.airtable.com/v0/meta/whoami";
@@ -99,7 +101,7 @@ export async function exchangeAirtableCode(
 
   const basicAuth = btoa(`${clientId}:${clientSecret}`);
 
-  const response = await fetch(authCodeGrant.tokenUrl, {
+  const response = await fetch(AIRTABLE_TOKEN_URL, {
     method: "POST",
     headers: {
       "Content-Type": "application/x-www-form-urlencoded",
@@ -153,7 +155,6 @@ export async function exchangeAirtableCode(
  * Access token expires_in: 3600s (1 hour). Ref: https://airtable.com/developers/web/api/oauth-reference
  */
 export async function refreshAirtableToken(
-  tokenUrl: string,
   clientId: string,
   clientSecret: string,
   refreshToken: string,
@@ -161,7 +162,7 @@ export async function refreshAirtableToken(
 ): Promise<AirtableRefreshResult> {
   const basicAuth = btoa(`${clientId}:${clientSecret}`);
 
-  const response = await fetch(tokenUrl, {
+  const response = await fetch(AIRTABLE_TOKEN_URL, {
     signal,
     method: "POST",
     headers: {

--- a/turbo/packages/connectors/src/auth-providers/oauth/providers/asana-provider.ts
+++ b/turbo/packages/connectors/src/auth-providers/oauth/providers/asana-provider.ts
@@ -45,7 +45,6 @@ export const asanaProvider: AuthCodeConnectorAuthProvider<"asana"> = {
     refreshToken: (args) => {
       const { clientId, clientSecret } = args.authClient;
       return refreshAsanaToken(
-        args.tokenUrl,
         clientId,
         clientSecret,
         args.refreshToken,

--- a/turbo/packages/connectors/src/auth-providers/oauth/providers/asana.ts
+++ b/turbo/packages/connectors/src/auth-providers/oauth/providers/asana.ts
@@ -3,6 +3,8 @@ import { z } from "zod";
 import type { ConnectorAuthCodeGrantConfig } from "@vm0/connectors/connectors";
 import { throwOAuthError } from "../error";
 
+const ASANA_TOKEN_URL = "https://app.asana.com/-/oauth_token";
+
 const ASANA_AUTHORIZATION_URL = "https://app.asana.com/-/oauth_authorize";
 
 const ASANA_USER_URL = "https://app.asana.com/api/1.0/users/me";
@@ -54,7 +56,7 @@ export async function exchangeAsanaCode(
   code: string,
   redirectUri: string,
 ): Promise<AsanaTokenResult> {
-  const response = await fetch(authCodeGrant.tokenUrl, {
+  const response = await fetch(ASANA_TOKEN_URL, {
     method: "POST",
     headers: {
       "Content-Type": "application/x-www-form-urlencoded",
@@ -156,13 +158,12 @@ async function fetchAsanaUserInfo(accessToken: string): Promise<{
  * Access token expires_in: 3600s (1 hour). Ref: https://developers.asana.com/docs/oauth
  */
 export async function refreshAsanaToken(
-  tokenUrl: string,
   clientId: string,
   clientSecret: string,
   refreshToken: string,
   signal: AbortSignal,
 ): Promise<AsanaRefreshResult> {
-  const response = await fetch(tokenUrl, {
+  const response = await fetch(ASANA_TOKEN_URL, {
     signal,
     method: "POST",
     headers: {

--- a/turbo/packages/connectors/src/auth-providers/oauth/providers/base44-provider.ts
+++ b/turbo/packages/connectors/src/auth-providers/oauth/providers/base44-provider.ts
@@ -14,7 +14,6 @@ export const base44Provider: DeviceAuthConnectorAuthProvider<"base44"> = {
       const { clientId } = args.authClient;
       return await startBase44DeviceAuth({
         clientId,
-        deviceAuthGrant: args.deviceAuthGrant,
         scopes: args.scopes,
       });
     },
@@ -22,7 +21,6 @@ export const base44Provider: DeviceAuthConnectorAuthProvider<"base44"> = {
       const { clientId } = args.authClient;
       return await pollBase44DeviceAuth({
         clientId,
-        deviceAuthGrant: args.deviceAuthGrant,
         deviceCode: args.deviceCode,
       });
     },
@@ -39,7 +37,6 @@ export const base44Provider: DeviceAuthConnectorAuthProvider<"base44"> = {
       const { clientId } = args.authClient;
       return await refreshBase44Token({
         clientId,
-        tokenUrl: args.tokenUrl,
         refreshToken: args.refreshToken,
         signal: args.signal,
       });

--- a/turbo/packages/connectors/src/auth-providers/oauth/providers/base44.ts
+++ b/turbo/packages/connectors/src/auth-providers/oauth/providers/base44.ts
@@ -1,6 +1,5 @@
 import { z } from "zod";
 
-import type { ConnectorDeviceAuthGrantConfig } from "@vm0/connectors/connectors";
 import type {
   OAuthDeviceAuthPollResult,
   OAuthDeviceAuthStartResult,
@@ -9,6 +8,8 @@ import type {
 } from "../types";
 import { throwOAuthError } from "../error";
 
+const BASE44_DEVICE_AUTH_URL = "https://app.base44.com/oauth/device/code";
+const BASE44_TOKEN_URL = "https://app.base44.com/oauth/token";
 const BASE44_USERINFO_URL = "https://app.base44.com/oauth/userinfo";
 const DEVICE_CODE_GRANT_TYPE = "urn:ietf:params:oauth:grant-type:device_code";
 export const BASE44_ACCESS_SECRET_NAME = "BASE44_ACCESS_TOKEN";
@@ -101,10 +102,9 @@ function requireAccessToken(
 
 export async function startBase44DeviceAuth(args: {
   readonly clientId: string;
-  readonly deviceAuthGrant: ConnectorDeviceAuthGrantConfig;
   readonly scopes: readonly string[];
 }): Promise<OAuthDeviceAuthStartResult> {
-  const response = await fetch(args.deviceAuthGrant.deviceAuthUrl, {
+  const response = await fetch(BASE44_DEVICE_AUTH_URL, {
     method: "POST",
     headers: {
       "Content-Type": "application/json",
@@ -132,10 +132,9 @@ export async function startBase44DeviceAuth(args: {
 
 export async function pollBase44DeviceAuth(args: {
   readonly clientId: string;
-  readonly deviceAuthGrant: ConnectorDeviceAuthGrantConfig;
   readonly deviceCode: string;
 }): Promise<OAuthDeviceAuthPollResult> {
-  const response = await fetch(args.deviceAuthGrant.tokenUrl, {
+  const response = await fetch(BASE44_TOKEN_URL, {
     method: "POST",
     headers: {
       "Content-Type": "application/x-www-form-urlencoded",
@@ -185,11 +184,10 @@ export async function pollBase44DeviceAuth(args: {
 
 export async function refreshBase44Token(args: {
   readonly clientId: string;
-  readonly tokenUrl: string;
   readonly refreshToken: string;
   readonly signal: AbortSignal;
 }): Promise<OAuthRefreshResult> {
-  const response = await fetch(args.tokenUrl, {
+  const response = await fetch(BASE44_TOKEN_URL, {
     signal: args.signal,
     method: "POST",
     headers: {

--- a/turbo/packages/connectors/src/auth-providers/oauth/providers/canva-provider.ts
+++ b/turbo/packages/connectors/src/auth-providers/oauth/providers/canva-provider.ts
@@ -57,7 +57,6 @@ export const canvaProvider: AuthCodeConnectorAuthProvider<"canva"> = {
     refreshToken: (args) => {
       const { clientId, clientSecret } = args.authClient;
       return refreshCanvaToken(
-        args.tokenUrl,
         clientId,
         clientSecret,
         args.refreshToken,

--- a/turbo/packages/connectors/src/auth-providers/oauth/providers/canva.ts
+++ b/turbo/packages/connectors/src/auth-providers/oauth/providers/canva.ts
@@ -3,6 +3,8 @@ import { z } from "zod";
 import type { ConnectorAuthCodeGrantConfig } from "@vm0/connectors/connectors";
 import { throwOAuthError } from "../error";
 
+const CANVA_TOKEN_URL = "https://api.canva.com/rest/v1/oauth/token";
+
 const CANVA_AUTHORIZATION_URL = "https://www.canva.com/api/oauth/authorize";
 
 const CANVA_ME_URL = "https://api.canva.com/rest/v1/users/me";
@@ -92,7 +94,6 @@ export async function buildCanvaAuthorizationUrl(
  * Access token expires_in: 14400s (4 hours). Ref: https://www.canva.dev/docs/connect/authentication/
  */
 export async function refreshCanvaToken(
-  tokenUrl: string,
   clientId: string,
   clientSecret: string,
   refreshToken: string,
@@ -102,7 +103,7 @@ export async function refreshCanvaToken(
     "base64",
   );
 
-  const response = await fetch(tokenUrl, {
+  const response = await fetch(CANVA_TOKEN_URL, {
     signal,
     method: "POST",
     headers: {
@@ -160,7 +161,7 @@ export async function exchangeCanvaCode(
     "base64",
   );
 
-  const response = await fetch(authCodeGrant.tokenUrl, {
+  const response = await fetch(CANVA_TOKEN_URL, {
     method: "POST",
     headers: {
       Authorization: `Basic ${credentials}`,

--- a/turbo/packages/connectors/src/auth-providers/oauth/providers/close-provider.ts
+++ b/turbo/packages/connectors/src/auth-providers/oauth/providers/close-provider.ts
@@ -45,7 +45,6 @@ export const closeProvider: AuthCodeConnectorAuthProvider<"close"> = {
     refreshToken: (args) => {
       const { clientId, clientSecret } = args.authClient;
       return refreshCloseToken(
-        args.tokenUrl,
         clientId,
         clientSecret,
         args.refreshToken,

--- a/turbo/packages/connectors/src/auth-providers/oauth/providers/close.ts
+++ b/turbo/packages/connectors/src/auth-providers/oauth/providers/close.ts
@@ -3,6 +3,8 @@ import { z } from "zod";
 import type { ConnectorAuthCodeGrantConfig } from "@vm0/connectors/connectors";
 import { throwOAuthError } from "../error";
 
+const CLOSE_TOKEN_URL = "https://api.close.com/oauth2/token/";
+
 const CLOSE_AUTHORIZATION_URL = "https://app.close.com/oauth2/authorize/";
 
 interface CloseUserInfo {
@@ -53,7 +55,7 @@ export async function exchangeCloseCode(
   code: string,
   redirectUri: string,
 ): Promise<CloseTokenResult> {
-  const response = await fetch(authCodeGrant.tokenUrl, {
+  const response = await fetch(CLOSE_TOKEN_URL, {
     method: "POST",
     headers: {
       "Content-Type": "application/x-www-form-urlencoded",
@@ -112,13 +114,12 @@ export async function exchangeCloseCode(
  * Access token expires_in: 3600s (1 hour). Ref: https://developer.close.com/topics/authentication-oauth2/
  */
 export async function refreshCloseToken(
-  tokenUrl: string,
   clientId: string,
   clientSecret: string,
   refreshToken: string,
   signal: AbortSignal,
 ): Promise<CloseRefreshResult> {
-  const response = await fetch(tokenUrl, {
+  const response = await fetch(CLOSE_TOKEN_URL, {
     signal,
     method: "POST",
     headers: {

--- a/turbo/packages/connectors/src/auth-providers/oauth/providers/deel-provider.ts
+++ b/turbo/packages/connectors/src/auth-providers/oauth/providers/deel-provider.ts
@@ -57,7 +57,6 @@ export const deelProvider: AuthCodeConnectorAuthProvider<"deel"> = {
     refreshToken: (args) => {
       const { clientId, clientSecret } = args.authClient;
       return refreshDeelToken(
-        args.tokenUrl,
         clientId,
         clientSecret,
         args.refreshToken,

--- a/turbo/packages/connectors/src/auth-providers/oauth/providers/deel.ts
+++ b/turbo/packages/connectors/src/auth-providers/oauth/providers/deel.ts
@@ -3,6 +3,8 @@ import { z } from "zod";
 import type { ConnectorAuthCodeGrantConfig } from "@vm0/connectors/connectors";
 import { throwOAuthError } from "../error";
 
+const DEEL_TOKEN_URL = "https://app.deel.com/oauth2/tokens";
+
 const DEEL_AUTHORIZATION_URL = "https://app.deel.com/oauth2/authorize";
 
 const DEEL_PEOPLE_ME_URL = "https://api.letsdeel.com/rest/v2/people/me";
@@ -92,7 +94,6 @@ export async function buildDeelAuthorizationUrl(
  * Access token expires_in: 2592000s (30 days). Ref: https://developer.deel.com/docs/oauth2
  */
 export async function refreshDeelToken(
-  tokenUrl: string,
   clientId: string,
   clientSecret: string,
   refreshToken: string,
@@ -102,7 +103,7 @@ export async function refreshDeelToken(
     "base64",
   );
 
-  const response = await fetch(tokenUrl, {
+  const response = await fetch(DEEL_TOKEN_URL, {
     signal,
     method: "POST",
     headers: {
@@ -160,7 +161,7 @@ export async function exchangeDeelCode(
     "base64",
   );
 
-  const response = await fetch(authCodeGrant.tokenUrl, {
+  const response = await fetch(DEEL_TOKEN_URL, {
     method: "POST",
     headers: {
       Authorization: `Basic ${credentials}`,

--- a/turbo/packages/connectors/src/auth-providers/oauth/providers/docusign-provider.ts
+++ b/turbo/packages/connectors/src/auth-providers/oauth/providers/docusign-provider.ts
@@ -57,7 +57,6 @@ export const docusignProvider: AuthCodeConnectorAuthProvider<"docusign"> = {
     refreshToken: (args) => {
       const { clientId, clientSecret } = args.authClient;
       return refreshDocuSignToken(
-        args.tokenUrl,
         clientId,
         clientSecret,
         args.refreshToken,

--- a/turbo/packages/connectors/src/auth-providers/oauth/providers/docusign.ts
+++ b/turbo/packages/connectors/src/auth-providers/oauth/providers/docusign.ts
@@ -3,6 +3,8 @@ import { z } from "zod";
 import type { ConnectorAuthCodeGrantConfig } from "@vm0/connectors/connectors";
 import { throwOAuthError } from "../error";
 
+const DOCUSIGN_TOKEN_URL = "https://account-d.docusign.com/oauth/token";
+
 const DOCUSIGN_AUTHORIZATION_URL = "https://account-d.docusign.com/oauth/auth";
 
 const DOCUSIGN_USERINFO_URL = "https://account-d.docusign.com/oauth/userinfo";
@@ -102,7 +104,7 @@ export async function exchangeDocuSignCode(
     "base64",
   );
 
-  const response = await fetch(authCodeGrant.tokenUrl, {
+  const response = await fetch(DOCUSIGN_TOKEN_URL, {
     method: "POST",
     headers: {
       "Content-Type": "application/x-www-form-urlencoded",
@@ -157,7 +159,6 @@ export async function exchangeDocuSignCode(
  * Access token expires_in: 28800s (8 hours) for auth code grant. Ref: https://developers.docusign.com/platform/auth/reference/obtain-access-token/
  */
 export async function refreshDocuSignToken(
-  tokenUrl: string,
   clientId: string,
   clientSecret: string,
   refreshToken: string,
@@ -167,7 +168,7 @@ export async function refreshDocuSignToken(
     "base64",
   );
 
-  const response = await fetch(tokenUrl, {
+  const response = await fetch(DOCUSIGN_TOKEN_URL, {
     signal,
     method: "POST",
     headers: {

--- a/turbo/packages/connectors/src/auth-providers/oauth/providers/dropbox-provider.ts
+++ b/turbo/packages/connectors/src/auth-providers/oauth/providers/dropbox-provider.ts
@@ -50,7 +50,6 @@ export const dropboxProvider: AuthCodeConnectorAuthProvider<"dropbox"> = {
     refreshToken: (args) => {
       const { clientId, clientSecret } = args.authClient;
       return refreshDropboxToken(
-        args.tokenUrl,
         clientId,
         clientSecret,
         args.refreshToken,

--- a/turbo/packages/connectors/src/auth-providers/oauth/providers/dropbox.ts
+++ b/turbo/packages/connectors/src/auth-providers/oauth/providers/dropbox.ts
@@ -3,6 +3,8 @@ import { z } from "zod";
 import type { ConnectorAuthCodeGrantConfig } from "@vm0/connectors/connectors";
 import { throwOAuthError } from "../error";
 
+const DROPBOX_TOKEN_URL = "https://api.dropboxapi.com/oauth2/token";
+
 const DROPBOX_AUTHORIZATION_URL = "https://www.dropbox.com/oauth2/authorize";
 
 const DROPBOX_CURRENT_ACCOUNT_URL =
@@ -61,7 +63,7 @@ export async function exchangeDropboxCode(
   code: string,
   redirectUri: string,
 ): Promise<DropboxTokenResult> {
-  const response = await fetch(authCodeGrant.tokenUrl, {
+  const response = await fetch(DROPBOX_TOKEN_URL, {
     method: "POST",
     headers: {
       "Content-Type": "application/x-www-form-urlencoded",
@@ -115,13 +117,12 @@ export async function exchangeDropboxCode(
  * Access token expires_in: 14400s (4 hours). Ref: https://developers.dropbox.com/oauth-guide
  */
 export async function refreshDropboxToken(
-  tokenUrl: string,
   clientId: string,
   clientSecret: string,
   refreshToken: string,
   signal: AbortSignal,
 ): Promise<DropboxRefreshResult> {
-  const response = await fetch(tokenUrl, {
+  const response = await fetch(DROPBOX_TOKEN_URL, {
     signal,
     method: "POST",
     headers: {

--- a/turbo/packages/connectors/src/auth-providers/oauth/providers/figma-provider.ts
+++ b/turbo/packages/connectors/src/auth-providers/oauth/providers/figma-provider.ts
@@ -50,7 +50,6 @@ export const figmaProvider: AuthCodeConnectorAuthProvider<"figma"> = {
     refreshToken: (args) => {
       const { clientId, clientSecret } = args.authClient;
       return refreshFigmaToken(
-        args.tokenUrl,
         clientId,
         clientSecret,
         args.refreshToken,

--- a/turbo/packages/connectors/src/auth-providers/oauth/providers/figma.ts
+++ b/turbo/packages/connectors/src/auth-providers/oauth/providers/figma.ts
@@ -3,6 +3,8 @@ import { z } from "zod";
 import type { ConnectorAuthCodeGrantConfig } from "@vm0/connectors/connectors";
 import { throwOAuthError } from "../error";
 
+const FIGMA_TOKEN_URL = "https://api.figma.com/v1/oauth/token";
+
 const FIGMA_AUTHORIZATION_URL = "https://www.figma.com/oauth";
 
 const FIGMA_ME_URL = "https://api.figma.com/v1/me";
@@ -62,7 +64,7 @@ export async function exchangeFigmaCode(
     "base64",
   );
 
-  const response = await fetch(authCodeGrant.tokenUrl, {
+  const response = await fetch(FIGMA_TOKEN_URL, {
     method: "POST",
     headers: {
       Authorization: `Basic ${credentials}`,
@@ -115,7 +117,6 @@ export async function exchangeFigmaCode(
  * Access token expires_in: ~7776000s (90 days). Ref: https://developers.figma.com/docs/rest-api/authentication/
  */
 export async function refreshFigmaToken(
-  tokenUrl: string,
   clientId: string,
   clientSecret: string,
   refreshToken: string,
@@ -125,7 +126,7 @@ export async function refreshFigmaToken(
     "base64",
   );
 
-  const response = await fetch(tokenUrl, {
+  const response = await fetch(FIGMA_TOKEN_URL, {
     signal,
     method: "POST",
     headers: {

--- a/turbo/packages/connectors/src/auth-providers/oauth/providers/garmin-connect-provider.ts
+++ b/turbo/packages/connectors/src/auth-providers/oauth/providers/garmin-connect-provider.ts
@@ -55,7 +55,6 @@ export const garminConnectProvider: AuthCodeConnectorAuthProvider<"garmin-connec
       refreshToken: (args) => {
         const { clientId, clientSecret } = args.authClient;
         return refreshGarminConnectToken(
-          args.tokenUrl,
           clientId,
           clientSecret,
           args.refreshToken,

--- a/turbo/packages/connectors/src/auth-providers/oauth/providers/garmin-connect.ts
+++ b/turbo/packages/connectors/src/auth-providers/oauth/providers/garmin-connect.ts
@@ -3,6 +3,9 @@ import { z } from "zod";
 import type { ConnectorAuthCodeGrantConfig } from "@vm0/connectors/connectors";
 import { throwOAuthError } from "../error";
 
+const GARMIN_CONNECT_TOKEN_URL =
+  "https://diauth.garmin.com/di-oauth2-service/oauth/token";
+
 const GARMIN_CONNECT_AUTHORIZATION_URL =
   "https://connect.garmin.com/oauth2Confirm";
 
@@ -98,7 +101,7 @@ export async function exchangeGarminConnectCode(
 ): Promise<GarminConnectTokenResult> {
   const codeVerifier = await deriveCodeVerifier(state);
 
-  const response = await fetch(authCodeGrant.tokenUrl, {
+  const response = await fetch(GARMIN_CONNECT_TOKEN_URL, {
     method: "POST",
     headers: {
       "Content-Type": "application/x-www-form-urlencoded",
@@ -153,13 +156,12 @@ export async function exchangeGarminConnectCode(
  * Access token expires_in: 86400s (1 day). Ref: https://developerportal.garmin.com
  */
 export async function refreshGarminConnectToken(
-  tokenUrl: string,
   clientId: string,
   clientSecret: string,
   refreshToken: string,
   signal: AbortSignal,
 ): Promise<GarminConnectRefreshResult> {
-  const response = await fetch(tokenUrl, {
+  const response = await fetch(GARMIN_CONNECT_TOKEN_URL, {
     signal,
     method: "POST",
     headers: {

--- a/turbo/packages/connectors/src/auth-providers/oauth/providers/github.ts
+++ b/turbo/packages/connectors/src/auth-providers/oauth/providers/github.ts
@@ -3,6 +3,8 @@ import { z } from "zod";
 import type { ConnectorAuthCodeGrantConfig } from "@vm0/connectors/connectors";
 import { throwOAuthError } from "../error";
 
+const GITHUB_TOKEN_URL = "https://github.com/login/oauth/access_token";
+
 const GITHUB_AUTHORIZATION_URL = "https://github.com/login/oauth/authorize";
 
 const GITHUB_API_BASE = "https://api.github.com";
@@ -51,7 +53,7 @@ export async function exchangeGitHubCode(
     body.set("redirect_uri", redirectUri);
   }
 
-  const response = await fetch(authCodeGrant.tokenUrl, {
+  const response = await fetch(GITHUB_TOKEN_URL, {
     method: "POST",
     headers: {
       Accept: "application/json",

--- a/turbo/packages/connectors/src/auth-providers/oauth/providers/gmail-provider.ts
+++ b/turbo/packages/connectors/src/auth-providers/oauth/providers/gmail-provider.ts
@@ -51,7 +51,6 @@ export const gmailProvider: AuthCodeConnectorAuthProvider<"gmail"> = {
       const { clientId, clientSecret } = args.authClient;
       const refreshToken = args.refreshToken;
       return refreshGoogleToken(
-        args.tokenUrl,
         "gmail",
         clientId,
         clientSecret,

--- a/turbo/packages/connectors/src/auth-providers/oauth/providers/gmail.ts
+++ b/turbo/packages/connectors/src/auth-providers/oauth/providers/gmail.ts
@@ -4,6 +4,8 @@ import type { ConnectorAuthCodeGrantConfig } from "@vm0/connectors/connectors";
 import { buildGoogleAuthorizationUrl } from "../google";
 import { throwOAuthError } from "../error";
 
+const GOOGLE_OAUTH_TOKEN_URL = "https://oauth2.googleapis.com/token";
+
 const GMAIL_PROFILE_URL =
   "https://www.googleapis.com/gmail/v1/users/me/profile";
 
@@ -51,7 +53,7 @@ export async function exchangeGmailCode(
   code: string,
   redirectUri: string,
 ): Promise<GmailTokenResult> {
-  const response = await fetch(authCodeGrant.tokenUrl, {
+  const response = await fetch(GOOGLE_OAUTH_TOKEN_URL, {
     method: "POST",
     headers: {
       "Content-Type": "application/x-www-form-urlencoded",

--- a/turbo/packages/connectors/src/auth-providers/oauth/providers/google-ads-provider.ts
+++ b/turbo/packages/connectors/src/auth-providers/oauth/providers/google-ads-provider.ts
@@ -56,7 +56,6 @@ export const googleAdsProvider: AuthCodeConnectorAuthProvider<"google-ads"> = {
       const { clientId, clientSecret } = args.authClient;
       const refreshToken = args.refreshToken;
       return refreshGoogleToken(
-        args.tokenUrl,
         "google-ads",
         clientId,
         clientSecret,

--- a/turbo/packages/connectors/src/auth-providers/oauth/providers/google-calendar-provider.ts
+++ b/turbo/packages/connectors/src/auth-providers/oauth/providers/google-calendar-provider.ts
@@ -57,7 +57,6 @@ export const googleCalendarProvider: AuthCodeConnectorAuthProvider<"google-calen
         const { clientId, clientSecret } = args.authClient;
         const refreshToken = args.refreshToken;
         return refreshGoogleToken(
-          args.tokenUrl,
           "google-calendar",
           clientId,
           clientSecret,

--- a/turbo/packages/connectors/src/auth-providers/oauth/providers/google-docs-provider.ts
+++ b/turbo/packages/connectors/src/auth-providers/oauth/providers/google-docs-provider.ts
@@ -57,7 +57,6 @@ export const googleDocsProvider: AuthCodeConnectorAuthProvider<"google-docs"> =
         const { clientId, clientSecret } = args.authClient;
         const refreshToken = args.refreshToken;
         return refreshGoogleToken(
-          args.tokenUrl,
           "google-docs",
           clientId,
           clientSecret,

--- a/turbo/packages/connectors/src/auth-providers/oauth/providers/google-drive-provider.ts
+++ b/turbo/packages/connectors/src/auth-providers/oauth/providers/google-drive-provider.ts
@@ -57,7 +57,6 @@ export const googleDriveProvider: AuthCodeConnectorAuthProvider<"google-drive"> 
         const { clientId, clientSecret } = args.authClient;
         const refreshToken = args.refreshToken;
         return refreshGoogleToken(
-          args.tokenUrl,
           "google-drive",
           clientId,
           clientSecret,

--- a/turbo/packages/connectors/src/auth-providers/oauth/providers/google-meet-provider.ts
+++ b/turbo/packages/connectors/src/auth-providers/oauth/providers/google-meet-provider.ts
@@ -57,7 +57,6 @@ export const googleMeetProvider: AuthCodeConnectorAuthProvider<"google-meet"> =
         const { clientId, clientSecret } = args.authClient;
         const refreshToken = args.refreshToken;
         return refreshGoogleToken(
-          args.tokenUrl,
           "google-meet",
           clientId,
           clientSecret,

--- a/turbo/packages/connectors/src/auth-providers/oauth/providers/google-sheets-provider.ts
+++ b/turbo/packages/connectors/src/auth-providers/oauth/providers/google-sheets-provider.ts
@@ -57,7 +57,6 @@ export const googleSheetsProvider: AuthCodeConnectorAuthProvider<"google-sheets"
         const { clientId, clientSecret } = args.authClient;
         const refreshToken = args.refreshToken;
         return refreshGoogleToken(
-          args.tokenUrl,
           "google-sheets",
           clientId,
           clientSecret,

--- a/turbo/packages/connectors/src/auth-providers/oauth/providers/gumroad-provider.ts
+++ b/turbo/packages/connectors/src/auth-providers/oauth/providers/gumroad-provider.ts
@@ -50,7 +50,6 @@ export const gumroadProvider: AuthCodeConnectorAuthProvider<"gumroad"> = {
     refreshToken: (args) => {
       const { clientId, clientSecret } = args.authClient;
       return refreshGumroadToken(
-        args.tokenUrl,
         clientId,
         clientSecret,
         args.refreshToken,

--- a/turbo/packages/connectors/src/auth-providers/oauth/providers/gumroad.ts
+++ b/turbo/packages/connectors/src/auth-providers/oauth/providers/gumroad.ts
@@ -3,6 +3,8 @@ import { z } from "zod";
 import type { ConnectorAuthCodeGrantConfig } from "@vm0/connectors/connectors";
 import { throwOAuthError } from "../error";
 
+const GUMROAD_TOKEN_URL = "https://gumroad.com/oauth/token";
+
 const GUMROAD_AUTHORIZATION_URL = "https://gumroad.com/oauth/authorize";
 
 const GUMROAD_USER_URL = "https://api.gumroad.com/v2/user";
@@ -51,7 +53,7 @@ export async function exchangeGumroadCode(
   code: string,
   redirectUri: string,
 ): Promise<GumroadTokenResult> {
-  const response = await fetch(authCodeGrant.tokenUrl, {
+  const response = await fetch(GUMROAD_TOKEN_URL, {
     method: "POST",
     headers: {
       "Content-Type": "application/x-www-form-urlencoded",
@@ -100,13 +102,12 @@ export async function exchangeGumroadCode(
 }
 
 export async function refreshGumroadToken(
-  tokenUrl: string,
   clientId: string,
   clientSecret: string,
   refreshToken: string,
   signal: AbortSignal,
 ): Promise<GumroadRefreshResult> {
-  const response = await fetch(tokenUrl, {
+  const response = await fetch(GUMROAD_TOKEN_URL, {
     signal,
     method: "POST",
     headers: {

--- a/turbo/packages/connectors/src/auth-providers/oauth/providers/hubspot-provider.ts
+++ b/turbo/packages/connectors/src/auth-providers/oauth/providers/hubspot-provider.ts
@@ -50,7 +50,6 @@ export const hubspotProvider: AuthCodeConnectorAuthProvider<"hubspot"> = {
     refreshToken: (args) => {
       const { clientId, clientSecret } = args.authClient;
       return refreshHubSpotToken(
-        args.tokenUrl,
         clientId,
         clientSecret,
         args.refreshToken,

--- a/turbo/packages/connectors/src/auth-providers/oauth/providers/hubspot.ts
+++ b/turbo/packages/connectors/src/auth-providers/oauth/providers/hubspot.ts
@@ -3,6 +3,8 @@ import { z } from "zod";
 import type { ConnectorAuthCodeGrantConfig } from "@vm0/connectors/connectors";
 import { throwOAuthError } from "../error";
 
+const HUBSPOT_TOKEN_URL = "https://api.hubapi.com/oauth/v1/token";
+
 const HUBSPOT_AUTHORIZATION_URL = "https://app.hubspot.com/oauth/authorize";
 
 const HUBSPOT_TOKEN_INFO_URL = "https://api.hubapi.com/oauth/v1/access-tokens";
@@ -56,7 +58,7 @@ export async function exchangeHubSpotCode(
   code: string,
   redirectUri: string,
 ): Promise<HubSpotTokenResult> {
-  const response = await fetch(authCodeGrant.tokenUrl, {
+  const response = await fetch(HUBSPOT_TOKEN_URL, {
     method: "POST",
     headers: {
       "Content-Type": "application/x-www-form-urlencoded",
@@ -108,13 +110,12 @@ export async function exchangeHubSpotCode(
  * Access token expires_in: 1800s (30 min). Ref: https://developers.hubspot.com/docs/api-reference/auth-oauth-v1/guide
  */
 export async function refreshHubSpotToken(
-  tokenUrl: string,
   clientId: string,
   clientSecret: string,
   refreshToken: string,
   signal: AbortSignal,
 ): Promise<HubSpotRefreshResult> {
-  const response = await fetch(tokenUrl, {
+  const response = await fetch(HUBSPOT_TOKEN_URL, {
     signal,
     method: "POST",
     headers: {

--- a/turbo/packages/connectors/src/auth-providers/oauth/providers/intervals-icu.ts
+++ b/turbo/packages/connectors/src/auth-providers/oauth/providers/intervals-icu.ts
@@ -3,6 +3,8 @@ import { z } from "zod";
 import type { ConnectorAuthCodeGrantConfig } from "@vm0/connectors/connectors";
 import { throwOAuthError } from "../error";
 
+const INTERVALS_ICU_TOKEN_URL = "https://intervals.icu/api/oauth/token";
+
 const INTERVALS_ICU_AUTHORIZATION_URL = "https://intervals.icu/oauth/authorize";
 
 interface IntervalsIcuTokenResult {
@@ -47,7 +49,7 @@ export async function exchangeIntervalsIcuCode(
   clientSecret: string,
   code: string,
 ): Promise<IntervalsIcuTokenResult> {
-  const response = await fetch(authCodeGrant.tokenUrl, {
+  const response = await fetch(INTERVALS_ICU_TOKEN_URL, {
     method: "POST",
     headers: {
       "Content-Type": "application/x-www-form-urlencoded",

--- a/turbo/packages/connectors/src/auth-providers/oauth/providers/linear-provider.ts
+++ b/turbo/packages/connectors/src/auth-providers/oauth/providers/linear-provider.ts
@@ -51,7 +51,6 @@ export const linearProvider: AuthCodeConnectorAuthProvider<"linear"> = {
     refreshToken: (args) => {
       const { clientId, clientSecret } = args.authClient;
       return refreshLinearToken(
-        args.tokenUrl,
         clientId,
         clientSecret,
         args.refreshToken,

--- a/turbo/packages/connectors/src/auth-providers/oauth/providers/linear.ts
+++ b/turbo/packages/connectors/src/auth-providers/oauth/providers/linear.ts
@@ -3,6 +3,8 @@ import { z } from "zod";
 import type { ConnectorAuthCodeGrantConfig } from "@vm0/connectors/connectors";
 import { throwOAuthError } from "../error";
 
+const LINEAR_TOKEN_URL = "https://api.linear.app/oauth/token";
+
 const LINEAR_AUTHORIZATION_URL = "https://linear.app/oauth/authorize";
 
 // User info URL is not part of the auth-code grant config since it uses GraphQL (POST), not a standard
@@ -62,7 +64,7 @@ export async function exchangeLinearCode(
   code: string,
   redirectUri: string,
 ): Promise<LinearTokenResult> {
-  const response = await fetch(authCodeGrant.tokenUrl, {
+  const response = await fetch(LINEAR_TOKEN_URL, {
     method: "POST",
     headers: {
       "Content-Type": "application/x-www-form-urlencoded",
@@ -116,13 +118,12 @@ export async function exchangeLinearCode(
  * Access token expires_in: 86399s (24 hours). Ref: https://developers.linear.app/docs/oauth/authentication
  */
 export async function refreshLinearToken(
-  tokenUrl: string,
   clientId: string,
   clientSecret: string,
   refreshToken: string,
   signal: AbortSignal,
 ): Promise<LinearRefreshResult> {
-  const response = await fetch(tokenUrl, {
+  const response = await fetch(LINEAR_TOKEN_URL, {
     signal,
     method: "POST",
     headers: {

--- a/turbo/packages/connectors/src/auth-providers/oauth/providers/mailchimp.ts
+++ b/turbo/packages/connectors/src/auth-providers/oauth/providers/mailchimp.ts
@@ -3,6 +3,8 @@ import { z } from "zod";
 import type { ConnectorAuthCodeGrantConfig } from "@vm0/connectors/connectors";
 import { throwOAuthError } from "../error";
 
+const MAILCHIMP_TOKEN_URL = "https://login.mailchimp.com/oauth2/token";
+
 const MAILCHIMP_AUTHORIZATION_URL =
   "https://login.mailchimp.com/oauth2/authorize";
 
@@ -49,7 +51,7 @@ export async function exchangeMailchimpCode(
   code: string,
   redirectUri: string,
 ): Promise<MailchimpTokenResult> {
-  const response = await fetch(authCodeGrant.tokenUrl, {
+  const response = await fetch(MAILCHIMP_TOKEN_URL, {
     method: "POST",
     headers: {
       "Content-Type": "application/x-www-form-urlencoded",

--- a/turbo/packages/connectors/src/auth-providers/oauth/providers/mercury-provider.ts
+++ b/turbo/packages/connectors/src/auth-providers/oauth/providers/mercury-provider.ts
@@ -50,7 +50,6 @@ export const mercuryProvider: AuthCodeConnectorAuthProvider<"mercury"> = {
     refreshToken: (args) => {
       const { clientId, clientSecret } = args.authClient;
       return refreshMercuryToken(
-        args.tokenUrl,
         clientId,
         clientSecret,
         args.refreshToken,

--- a/turbo/packages/connectors/src/auth-providers/oauth/providers/mercury.ts
+++ b/turbo/packages/connectors/src/auth-providers/oauth/providers/mercury.ts
@@ -3,6 +3,8 @@ import { z } from "zod";
 import type { ConnectorAuthCodeGrantConfig } from "@vm0/connectors/connectors";
 import { throwOAuthError } from "../error";
 
+const MERCURY_TOKEN_URL = "https://oauth2.mercury.com/oauth2/token";
+
 const MERCURY_AUTHORIZATION_URL = "https://oauth2.mercury.com/oauth2/auth";
 
 const MERCURY_ACCOUNTS_URL = "https://api.mercury.com/api/v1/accounts";
@@ -58,7 +60,7 @@ export async function exchangeMercuryCode(
   code: string,
   redirectUri: string,
 ): Promise<MercuryTokenResult> {
-  const response = await fetch(authCodeGrant.tokenUrl, {
+  const response = await fetch(MERCURY_TOKEN_URL, {
     method: "POST",
     headers: {
       "Content-Type": "application/x-www-form-urlencoded",
@@ -112,13 +114,12 @@ export async function exchangeMercuryCode(
  * Access token expires_in: 3600s (1 hour). Ref: https://docs.mercury.com/reference/obtain-the-tokens
  */
 export async function refreshMercuryToken(
-  tokenUrl: string,
   clientId: string,
   clientSecret: string,
   refreshToken: string,
   signal: AbortSignal,
 ): Promise<MercuryRefreshResult> {
-  const response = await fetch(tokenUrl, {
+  const response = await fetch(MERCURY_TOKEN_URL, {
     signal,
     method: "POST",
     headers: {

--- a/turbo/packages/connectors/src/auth-providers/oauth/providers/meta-ads.ts
+++ b/turbo/packages/connectors/src/auth-providers/oauth/providers/meta-ads.ts
@@ -3,6 +3,9 @@ import { z } from "zod";
 import type { ConnectorAuthCodeGrantConfig } from "@vm0/connectors/connectors";
 import { throwOAuthError } from "../error";
 
+const META_ADS_TOKEN_URL =
+  "https://graph.facebook.com/v22.0/oauth/access_token";
+
 const META_ADS_AUTHORIZATION_URL =
   "https://www.facebook.com/v22.0/dialog/oauth";
 
@@ -55,7 +58,7 @@ export async function exchangeMetaAdsCode(
   redirectUri: string,
 ): Promise<MetaAdsTokenResult> {
   // Step 1: Exchange code for short-lived token
-  const response = await fetch(authCodeGrant.tokenUrl, {
+  const response = await fetch(META_ADS_TOKEN_URL, {
     method: "POST",
     headers: {
       "Content-Type": "application/x-www-form-urlencoded",

--- a/turbo/packages/connectors/src/auth-providers/oauth/providers/monday-provider.ts
+++ b/turbo/packages/connectors/src/auth-providers/oauth/providers/monday-provider.ts
@@ -50,7 +50,6 @@ export const mondayProvider: AuthCodeConnectorAuthProvider<"monday"> = {
     refreshToken: (args) => {
       const { clientId, clientSecret } = args.authClient;
       return refreshMondayToken(
-        args.tokenUrl,
         clientId,
         clientSecret,
         args.refreshToken,

--- a/turbo/packages/connectors/src/auth-providers/oauth/providers/monday.ts
+++ b/turbo/packages/connectors/src/auth-providers/oauth/providers/monday.ts
@@ -3,6 +3,8 @@ import { z } from "zod";
 import type { ConnectorAuthCodeGrantConfig } from "@vm0/connectors/connectors";
 import { throwOAuthError } from "../error";
 
+const MONDAY_TOKEN_URL = "https://auth.monday.com/oauth2/token";
+
 const MONDAY_AUTHORIZATION_URL = "https://auth.monday.com/oauth2/authorize";
 
 interface MondayUserInfo {
@@ -58,7 +60,7 @@ export async function exchangeMondayCode(
   code: string,
   redirectUri: string,
 ): Promise<MondayTokenResult> {
-  const response = await fetch(authCodeGrant.tokenUrl, {
+  const response = await fetch(MONDAY_TOKEN_URL, {
     method: "POST",
     headers: {
       "Content-Type": "application/x-www-form-urlencoded",
@@ -111,13 +113,12 @@ export async function exchangeMondayCode(
  * Note: Monday.com tokens reportedly do not expire. expires_in may not be returned. Ref: https://developer.monday.com/apps/docs/oauth
  */
 export async function refreshMondayToken(
-  tokenUrl: string,
   clientId: string,
   clientSecret: string,
   refreshToken: string,
   signal: AbortSignal,
 ): Promise<MondayRefreshResult> {
-  const response = await fetch(tokenUrl, {
+  const response = await fetch(MONDAY_TOKEN_URL, {
     signal,
     method: "POST",
     headers: {

--- a/turbo/packages/connectors/src/auth-providers/oauth/providers/neon-provider.ts
+++ b/turbo/packages/connectors/src/auth-providers/oauth/providers/neon-provider.ts
@@ -50,7 +50,6 @@ export const neonProvider: AuthCodeConnectorAuthProvider<"neon"> = {
     refreshToken: (args) => {
       const { clientId, clientSecret } = args.authClient;
       return refreshNeonToken(
-        args.tokenUrl,
         clientId,
         clientSecret,
         args.refreshToken,

--- a/turbo/packages/connectors/src/auth-providers/oauth/providers/neon.ts
+++ b/turbo/packages/connectors/src/auth-providers/oauth/providers/neon.ts
@@ -3,6 +3,8 @@ import { z } from "zod";
 import type { ConnectorAuthCodeGrantConfig } from "@vm0/connectors/connectors";
 import { throwOAuthError } from "../error";
 
+const NEON_TOKEN_URL = "https://oauth2.neon.tech/oauth2/token";
+
 const NEON_AUTHORIZATION_URL = "https://oauth2.neon.tech/oauth2/auth";
 
 const NEON_USER_INFO_URL = "https://console.neon.tech/api/v2/users/me";
@@ -59,7 +61,7 @@ export async function exchangeNeonCode(
   code: string,
   redirectUri: string,
 ): Promise<NeonTokenResult> {
-  const response = await fetch(authCodeGrant.tokenUrl, {
+  const response = await fetch(NEON_TOKEN_URL, {
     method: "POST",
     headers: {
       "Content-Type": "application/x-www-form-urlencoded",
@@ -113,13 +115,12 @@ export async function exchangeNeonCode(
  * Access token expires_in: expected (OIDC-compliant) but not explicitly documented. Ref: https://neon.com/docs/guides/oauth-integration
  */
 export async function refreshNeonToken(
-  tokenUrl: string,
   clientId: string,
   clientSecret: string,
   refreshToken: string,
   signal: AbortSignal,
 ): Promise<NeonRefreshResult> {
-  const response = await fetch(tokenUrl, {
+  const response = await fetch(NEON_TOKEN_URL, {
     signal,
     method: "POST",
     headers: {

--- a/turbo/packages/connectors/src/auth-providers/oauth/providers/notion-provider.ts
+++ b/turbo/packages/connectors/src/auth-providers/oauth/providers/notion-provider.ts
@@ -45,7 +45,6 @@ export const notionProvider: AuthCodeConnectorAuthProvider<"notion"> = {
     refreshToken: (args) => {
       const { clientId, clientSecret } = args.authClient;
       return refreshNotionToken(
-        args.tokenUrl,
         clientId,
         clientSecret,
         args.refreshToken,

--- a/turbo/packages/connectors/src/auth-providers/oauth/providers/notion.ts
+++ b/turbo/packages/connectors/src/auth-providers/oauth/providers/notion.ts
@@ -3,6 +3,8 @@ import { z } from "zod";
 import type { ConnectorAuthCodeGrantConfig } from "@vm0/connectors/connectors";
 import { throwOAuthError } from "../error";
 
+const NOTION_TOKEN_URL = "https://api.notion.com/v1/oauth/token";
+
 const NOTION_AUTHORIZATION_URL = "https://api.notion.com/v1/oauth/authorize";
 
 interface NotionUserInfo {
@@ -63,7 +65,7 @@ export async function exchangeNotionCode(
   code: string,
   redirectUri: string,
 ): Promise<NotionTokenResult> {
-  const response = await fetch(authCodeGrant.tokenUrl, {
+  const response = await fetch(NOTION_TOKEN_URL, {
     method: "POST",
     headers: {
       Authorization: `Basic ${encodeBasicAuth(clientId, clientSecret)}`,
@@ -128,13 +130,12 @@ export async function exchangeNotionCode(
  * Note: Notion does not return expires_in. Token lifetime ~1 hour (undocumented). Ref: https://developers.notion.com/reference/refresh-a-token
  */
 export async function refreshNotionToken(
-  tokenUrl: string,
   clientId: string,
   clientSecret: string,
   refreshToken: string,
   signal: AbortSignal,
 ): Promise<NotionRefreshResult> {
-  const response = await fetch(tokenUrl, {
+  const response = await fetch(NOTION_TOKEN_URL, {
     signal,
     method: "POST",
     headers: {

--- a/turbo/packages/connectors/src/auth-providers/oauth/providers/outlook-calendar-provider.ts
+++ b/turbo/packages/connectors/src/auth-providers/oauth/providers/outlook-calendar-provider.ts
@@ -57,7 +57,6 @@ export const outlookCalendarProvider: AuthCodeConnectorAuthProvider<"outlook-cal
         const { clientId, clientSecret } = args.authClient;
         const refreshToken = args.refreshToken;
         return refreshMicrosoftToken(
-          args.tokenUrl,
           "outlook-calendar",
           clientId,
           clientSecret,

--- a/turbo/packages/connectors/src/auth-providers/oauth/providers/outlook-mail-provider.ts
+++ b/turbo/packages/connectors/src/auth-providers/oauth/providers/outlook-mail-provider.ts
@@ -57,7 +57,6 @@ export const outlookMailProvider: AuthCodeConnectorAuthProvider<"outlook-mail"> 
         const { clientId, clientSecret } = args.authClient;
         const refreshToken = args.refreshToken;
         return refreshMicrosoftToken(
-          args.tokenUrl,
           "outlook-mail",
           clientId,
           clientSecret,

--- a/turbo/packages/connectors/src/auth-providers/oauth/providers/posthog-provider.ts
+++ b/turbo/packages/connectors/src/auth-providers/oauth/providers/posthog-provider.ts
@@ -50,7 +50,6 @@ export const posthogProvider: AuthCodeConnectorAuthProvider<"posthog"> = {
     refreshToken: (args) => {
       const { clientId, clientSecret } = args.authClient;
       return refreshPosthogToken(
-        args.tokenUrl,
         clientId,
         clientSecret,
         args.refreshToken,

--- a/turbo/packages/connectors/src/auth-providers/oauth/providers/posthog.ts
+++ b/turbo/packages/connectors/src/auth-providers/oauth/providers/posthog.ts
@@ -3,6 +3,8 @@ import { z } from "zod";
 import type { ConnectorAuthCodeGrantConfig } from "@vm0/connectors/connectors";
 import { throwOAuthError } from "../error";
 
+const POSTHOG_TOKEN_URL = "https://us.posthog.com/oauth/token";
+
 const POSTHOG_AUTHORIZATION_URL = "https://us.posthog.com/oauth/authorize";
 
 const POSTHOG_USER_INFO_URL = "https://us.posthog.com/api/users/@me/";
@@ -57,7 +59,7 @@ export async function exchangePosthogCode(
   code: string,
   redirectUri: string,
 ): Promise<PosthogTokenResult> {
-  const response = await fetch(authCodeGrant.tokenUrl, {
+  const response = await fetch(POSTHOG_TOKEN_URL, {
     method: "POST",
     headers: {
       "Content-Type": "application/x-www-form-urlencoded",
@@ -110,13 +112,12 @@ export async function exchangePosthogCode(
  * Access token expires_in: 36000s (10 hours). Ref: https://posthog.com/handbook/engineering/oauth-development-guide
  */
 export async function refreshPosthogToken(
-  tokenUrl: string,
   clientId: string,
   clientSecret: string,
   refreshToken: string,
   signal: AbortSignal,
 ): Promise<PosthogRefreshResult> {
-  const response = await fetch(tokenUrl, {
+  const response = await fetch(POSTHOG_TOKEN_URL, {
     signal,
     method: "POST",
     headers: {

--- a/turbo/packages/connectors/src/auth-providers/oauth/providers/reddit-provider.ts
+++ b/turbo/packages/connectors/src/auth-providers/oauth/providers/reddit-provider.ts
@@ -50,7 +50,6 @@ export const redditProvider: AuthCodeConnectorAuthProvider<"reddit"> = {
     refreshToken: (args) => {
       const { clientId, clientSecret } = args.authClient;
       return refreshRedditToken(
-        args.tokenUrl,
         clientId,
         clientSecret,
         args.refreshToken,

--- a/turbo/packages/connectors/src/auth-providers/oauth/providers/reddit.ts
+++ b/turbo/packages/connectors/src/auth-providers/oauth/providers/reddit.ts
@@ -3,6 +3,8 @@ import { z } from "zod";
 import type { ConnectorAuthCodeGrantConfig } from "@vm0/connectors/connectors";
 import { throwOAuthError } from "../error";
 
+const REDDIT_TOKEN_URL = "https://www.reddit.com/api/v1/access_token";
+
 const REDDIT_AUTHORIZATION_URL = "https://www.reddit.com/api/v1/authorize";
 
 const REDDIT_USER_INFO_URL = "https://oauth.reddit.com/api/v1/me";
@@ -63,7 +65,7 @@ export async function exchangeRedditCode(
   code: string,
   redirectUri: string,
 ): Promise<RedditTokenResult> {
-  const response = await fetch(authCodeGrant.tokenUrl, {
+  const response = await fetch(REDDIT_TOKEN_URL, {
     method: "POST",
     headers: {
       Authorization: `Basic ${encodeBasicAuth(clientId, clientSecret)}`,
@@ -157,13 +159,12 @@ interface RedditRefreshResult {
  * Access token expires_in: 3600s (1 hour). Ref: https://github.com/reddit-archive/reddit/wiki/oauth2
  */
 export async function refreshRedditToken(
-  tokenUrl: string,
   clientId: string,
   clientSecret: string,
   refreshToken: string,
   signal: AbortSignal,
 ): Promise<RedditRefreshResult> {
-  const response = await fetch(tokenUrl, {
+  const response = await fetch(REDDIT_TOKEN_URL, {
     signal,
     method: "POST",
     headers: {

--- a/turbo/packages/connectors/src/auth-providers/oauth/providers/sentry-provider.ts
+++ b/turbo/packages/connectors/src/auth-providers/oauth/providers/sentry-provider.ts
@@ -50,7 +50,6 @@ export const sentryProvider: AuthCodeConnectorAuthProvider<"sentry"> = {
     refreshToken: (args) => {
       const { clientId, clientSecret } = args.authClient;
       return refreshSentryToken(
-        args.tokenUrl,
         clientId,
         clientSecret,
         args.refreshToken,

--- a/turbo/packages/connectors/src/auth-providers/oauth/providers/sentry.ts
+++ b/turbo/packages/connectors/src/auth-providers/oauth/providers/sentry.ts
@@ -3,6 +3,8 @@ import { z } from "zod";
 import type { ConnectorAuthCodeGrantConfig } from "@vm0/connectors/connectors";
 import { throwOAuthError } from "../error";
 
+const SENTRY_TOKEN_URL = "https://sentry.io/oauth/token/";
+
 const SENTRY_AUTHORIZATION_URL = "https://sentry.io/oauth/authorize/";
 
 interface SentryUserInfo {
@@ -56,7 +58,7 @@ export async function exchangeSentryCode(
   code: string,
   redirectUri: string,
 ): Promise<SentryTokenResult> {
-  const response = await fetch(authCodeGrant.tokenUrl, {
+  const response = await fetch(SENTRY_TOKEN_URL, {
     method: "POST",
     headers: {
       "Content-Type": "application/x-www-form-urlencoded",
@@ -123,13 +125,12 @@ export async function exchangeSentryCode(
  * Access token expires_in: ~2592000s (30 days). Ref: https://docs.sentry.io/api/auth/
  */
 export async function refreshSentryToken(
-  tokenUrl: string,
   clientId: string,
   clientSecret: string,
   refreshToken: string,
   signal: AbortSignal,
 ): Promise<SentryRefreshResult> {
-  const response = await fetch(tokenUrl, {
+  const response = await fetch(SENTRY_TOKEN_URL, {
     signal,
     method: "POST",
     headers: {

--- a/turbo/packages/connectors/src/auth-providers/oauth/providers/slack.ts
+++ b/turbo/packages/connectors/src/auth-providers/oauth/providers/slack.ts
@@ -3,6 +3,8 @@ import { z } from "zod";
 import type { ConnectorAuthCodeGrantConfig } from "@vm0/connectors/connectors";
 import { throwOAuthError } from "../error";
 
+const SLACK_TOKEN_URL = "https://slack.com/api/oauth.v2.access";
+
 const SLACK_AUTHORIZATION_URL = "https://slack.com/oauth/v2/authorize";
 
 interface SlackTokenResult {
@@ -48,7 +50,7 @@ export async function exchangeSlackCode(
   code: string,
   redirectUri: string,
 ): Promise<SlackTokenResult> {
-  const response = await fetch(authCodeGrant.tokenUrl, {
+  const response = await fetch(SLACK_TOKEN_URL, {
     method: "POST",
     headers: {
       "Content-Type": "application/x-www-form-urlencoded",

--- a/turbo/packages/connectors/src/auth-providers/oauth/providers/slock-provider.ts
+++ b/turbo/packages/connectors/src/auth-providers/oauth/providers/slock-provider.ts
@@ -10,14 +10,11 @@ import {
 export const slockProvider: DeviceAuthConnectorAuthProvider<"slock"> = {
   grant: {
     kind: "device-auth",
-    startDeviceAuth: async (args) => {
-      return await startSlockDeviceAuth({
-        deviceAuthGrant: args.deviceAuthGrant,
-      });
+    startDeviceAuth: async () => {
+      return await startSlockDeviceAuth();
     },
     pollDeviceAuth: async (args) => {
       return await pollSlockDeviceAuth({
-        deviceAuthGrant: args.deviceAuthGrant,
         deviceCode: args.deviceCode,
       });
     },
@@ -32,7 +29,6 @@ export const slockProvider: DeviceAuthConnectorAuthProvider<"slock"> = {
     },
     refreshToken: async (args) => {
       return await refreshSlockToken({
-        tokenUrl: args.tokenUrl,
         refreshToken: args.refreshToken,
         signal: args.signal,
       });

--- a/turbo/packages/connectors/src/auth-providers/oauth/providers/slock.ts
+++ b/turbo/packages/connectors/src/auth-providers/oauth/providers/slock.ts
@@ -1,6 +1,5 @@
 import { z } from "zod";
 
-import type { ConnectorDeviceAuthGrantConfig } from "@vm0/connectors/connectors";
 import { throwOAuthError } from "../error";
 import type {
   OAuthDeviceAuthPollResult,
@@ -10,6 +9,9 @@ import type {
 } from "../types";
 
 const SLOCK_API_BASE_URL = "https://api.slock.ai";
+const SLOCK_DEVICE_AUTH_URL = `${SLOCK_API_BASE_URL}/api/auth/device/authorize`;
+const SLOCK_DEVICE_TOKEN_URL = `${SLOCK_API_BASE_URL}/api/auth/device/token`;
+const SLOCK_REFRESH_TOKEN_URL = `${SLOCK_API_BASE_URL}/api/auth/refresh`;
 const DEFAULT_DEVICE_AUTH_EXPIRES_IN_SECONDS = 600;
 const POST_TOKEN_LOOKUP_FAILED_DESCRIPTION =
   "Unable to load Slock account metadata after authorization.";
@@ -296,10 +298,8 @@ async function fetchSlockServerId(
   return { ok: true, serverId: server.id };
 }
 
-export async function startSlockDeviceAuth(args: {
-  readonly deviceAuthGrant: ConnectorDeviceAuthGrantConfig;
-}): Promise<OAuthDeviceAuthStartResult> {
-  const response = await fetch(args.deviceAuthGrant.deviceAuthUrl, {
+export async function startSlockDeviceAuth(): Promise<OAuthDeviceAuthStartResult> {
+  const response = await fetch(SLOCK_DEVICE_AUTH_URL, {
     method: "POST",
     headers: {
       "Content-Type": "application/json",
@@ -325,10 +325,9 @@ export async function startSlockDeviceAuth(args: {
 }
 
 export async function pollSlockDeviceAuth(args: {
-  readonly deviceAuthGrant: ConnectorDeviceAuthGrantConfig;
   readonly deviceCode: string;
 }): Promise<OAuthDeviceAuthPollResult> {
-  const response = await fetch(args.deviceAuthGrant.tokenUrl, {
+  const response = await fetch(SLOCK_DEVICE_TOKEN_URL, {
     method: "POST",
     headers: {
       "Content-Type": "application/json",
@@ -406,11 +405,10 @@ export async function pollSlockDeviceAuth(args: {
 }
 
 export async function refreshSlockToken(args: {
-  readonly tokenUrl: string;
   readonly refreshToken: string;
   readonly signal: AbortSignal;
 }): Promise<OAuthRefreshResult> {
-  const response = await fetch(args.tokenUrl, {
+  const response = await fetch(SLOCK_REFRESH_TOKEN_URL, {
     signal: args.signal,
     method: "POST",
     headers: {

--- a/turbo/packages/connectors/src/auth-providers/oauth/providers/spotify-provider.ts
+++ b/turbo/packages/connectors/src/auth-providers/oauth/providers/spotify-provider.ts
@@ -50,7 +50,6 @@ export const spotifyProvider: AuthCodeConnectorAuthProvider<"spotify"> = {
     refreshToken: (args) => {
       const { clientId, clientSecret } = args.authClient;
       return refreshSpotifyToken(
-        args.tokenUrl,
         clientId,
         clientSecret,
         args.refreshToken,

--- a/turbo/packages/connectors/src/auth-providers/oauth/providers/spotify.ts
+++ b/turbo/packages/connectors/src/auth-providers/oauth/providers/spotify.ts
@@ -3,6 +3,8 @@ import { z } from "zod";
 import type { ConnectorAuthCodeGrantConfig } from "@vm0/connectors/connectors";
 import { throwOAuthError } from "../error";
 
+const SPOTIFY_TOKEN_URL = "https://accounts.spotify.com/api/token";
+
 const SPOTIFY_AUTHORIZATION_URL = "https://accounts.spotify.com/authorize";
 
 const SPOTIFY_ME_URL = "https://api.spotify.com/v1/me";
@@ -62,7 +64,7 @@ export async function exchangeSpotifyCode(
     "base64",
   );
 
-  const response = await fetch(authCodeGrant.tokenUrl, {
+  const response = await fetch(SPOTIFY_TOKEN_URL, {
     method: "POST",
     headers: {
       "Content-Type": "application/x-www-form-urlencoded",
@@ -114,7 +116,6 @@ export async function exchangeSpotifyCode(
  * Uses Basic auth header (base64 of clientId:clientSecret).
  */
 export async function refreshSpotifyToken(
-  tokenUrl: string,
   clientId: string,
   clientSecret: string,
   refreshToken: string,
@@ -124,7 +125,7 @@ export async function refreshSpotifyToken(
     "base64",
   );
 
-  const response = await fetch(tokenUrl, {
+  const response = await fetch(SPOTIFY_TOKEN_URL, {
     signal,
     method: "POST",
     headers: {

--- a/turbo/packages/connectors/src/auth-providers/oauth/providers/strava-provider.ts
+++ b/turbo/packages/connectors/src/auth-providers/oauth/providers/strava-provider.ts
@@ -48,7 +48,6 @@ export const stravaProvider: AuthCodeConnectorAuthProvider<"strava"> = {
     refreshToken: (args) => {
       const { clientId, clientSecret } = args.authClient;
       return refreshStravaToken(
-        args.tokenUrl,
         clientId,
         clientSecret,
         args.refreshToken,

--- a/turbo/packages/connectors/src/auth-providers/oauth/providers/strava.ts
+++ b/turbo/packages/connectors/src/auth-providers/oauth/providers/strava.ts
@@ -3,6 +3,8 @@ import { z } from "zod";
 import type { ConnectorAuthCodeGrantConfig } from "@vm0/connectors/connectors";
 import { throwOAuthError } from "../error";
 
+const STRAVA_TOKEN_URL = "https://www.strava.com/oauth/token";
+
 const STRAVA_AUTHORIZATION_URL = "https://www.strava.com/oauth/authorize";
 
 const STRAVA_ATHLETE_URL = "https://www.strava.com/api/v3/athlete";
@@ -59,7 +61,7 @@ export async function exchangeStravaCode(
   clientSecret: string,
   code: string,
 ): Promise<StravaTokenResult> {
-  const response = await fetch(authCodeGrant.tokenUrl, {
+  const response = await fetch(STRAVA_TOKEN_URL, {
     method: "POST",
     headers: {
       "Content-Type": "application/x-www-form-urlencoded",
@@ -130,13 +132,12 @@ export async function exchangeStravaCode(
  * Access token expires_in: 21600s (6 hours). Ref: https://developers.strava.com/docs/authentication/
  */
 export async function refreshStravaToken(
-  tokenUrl: string,
   clientId: string,
   clientSecret: string,
   refreshToken: string,
   signal: AbortSignal,
 ): Promise<StravaRefreshResult> {
-  const response = await fetch(tokenUrl, {
+  const response = await fetch(STRAVA_TOKEN_URL, {
     signal,
     method: "POST",
     headers: {

--- a/turbo/packages/connectors/src/auth-providers/oauth/providers/stripe-provider.ts
+++ b/turbo/packages/connectors/src/auth-providers/oauth/providers/stripe-provider.ts
@@ -47,7 +47,6 @@ export const stripeProvider: AuthCodeConnectorAuthProvider<"stripe"> = {
     refreshToken: (args) => {
       const { clientId, clientSecret } = args.authClient;
       return refreshStripeToken(
-        args.tokenUrl,
         clientId,
         clientSecret,
         args.refreshToken,

--- a/turbo/packages/connectors/src/auth-providers/oauth/providers/stripe.ts
+++ b/turbo/packages/connectors/src/auth-providers/oauth/providers/stripe.ts
@@ -3,6 +3,8 @@ import { z } from "zod";
 import type { ConnectorAuthCodeGrantConfig } from "@vm0/connectors/connectors";
 import { throwOAuthError } from "../error";
 
+const STRIPE_TOKEN_URL = "https://connect.stripe.com/oauth/token";
+
 const STRIPE_AUTHORIZATION_URL = "https://connect.stripe.com/oauth/authorize";
 
 const STRIPE_ACCOUNT_URL = "https://api.stripe.com/v1/account";
@@ -57,7 +59,7 @@ export async function exchangeStripeCode(
   clientSecret: string,
   code: string,
 ): Promise<StripeTokenResult> {
-  const response = await fetch(authCodeGrant.tokenUrl, {
+  const response = await fetch(STRIPE_TOKEN_URL, {
     method: "POST",
     headers: {
       "Content-Type": "application/x-www-form-urlencoded",
@@ -113,13 +115,12 @@ export async function exchangeStripeCode(
  * Access token expires_in: 3600s (1 hour). Ref: https://docs.stripe.com/stripe-apps/api-authentication/oauth
  */
 export async function refreshStripeToken(
-  tokenUrl: string,
   _clientId: string,
   clientSecret: string,
   refreshToken: string,
   signal: AbortSignal,
 ): Promise<StripeRefreshResult> {
-  const response = await fetch(tokenUrl, {
+  const response = await fetch(STRIPE_TOKEN_URL, {
     signal,
     method: "POST",
     headers: {

--- a/turbo/packages/connectors/src/auth-providers/oauth/providers/supabase-provider.ts
+++ b/turbo/packages/connectors/src/auth-providers/oauth/providers/supabase-provider.ts
@@ -57,7 +57,6 @@ export const supabaseProvider: AuthCodeConnectorAuthProvider<"supabase"> = {
     refreshToken: (args) => {
       const { clientId, clientSecret } = args.authClient;
       return refreshSupabaseToken(
-        args.tokenUrl,
         clientId,
         clientSecret,
         args.refreshToken,

--- a/turbo/packages/connectors/src/auth-providers/oauth/providers/supabase.ts
+++ b/turbo/packages/connectors/src/auth-providers/oauth/providers/supabase.ts
@@ -3,6 +3,8 @@ import { z } from "zod";
 import type { ConnectorAuthCodeGrantConfig } from "@vm0/connectors/connectors";
 import { throwOAuthError } from "../error";
 
+const SUPABASE_TOKEN_URL = "https://api.supabase.com/v1/oauth/token";
+
 const SUPABASE_AUTHORIZATION_URL =
   "https://api.supabase.com/v1/oauth/authorize";
 
@@ -92,7 +94,6 @@ export async function buildSupabaseAuthorizationUrl(
  * Access token expires_in: 3600s (1 hour, configurable). Ref: https://supabase.com/docs/guides/auth/oauth-server/oauth-flows
  */
 export async function refreshSupabaseToken(
-  tokenUrl: string,
   clientId: string,
   clientSecret: string,
   refreshToken: string,
@@ -102,7 +103,7 @@ export async function refreshSupabaseToken(
     "base64",
   );
 
-  const response = await fetch(tokenUrl, {
+  const response = await fetch(SUPABASE_TOKEN_URL, {
     signal,
     method: "POST",
     headers: {
@@ -161,7 +162,7 @@ export async function exchangeSupabaseCode(
     "base64",
   );
 
-  const response = await fetch(authCodeGrant.tokenUrl, {
+  const response = await fetch(SUPABASE_TOKEN_URL, {
     method: "POST",
     headers: {
       Authorization: `Basic ${credentials}`,

--- a/turbo/packages/connectors/src/auth-providers/oauth/providers/test-oauth-device-provider.ts
+++ b/turbo/packages/connectors/src/auth-providers/oauth/providers/test-oauth-device-provider.ts
@@ -19,7 +19,6 @@ function createTestOauthDeviceGrant<
       const { clientId } = args.authClient;
       return await startTestOAuthDeviceAuth({
         clientId,
-        deviceAuthGrant: args.deviceAuthGrant,
         scopes: args.scopes,
       });
     },
@@ -27,7 +26,6 @@ function createTestOauthDeviceGrant<
       const { clientId } = args.authClient;
       return await pollTestOAuthDeviceAuth({
         clientId,
-        deviceAuthGrant: args.deviceAuthGrant,
         deviceCode: args.deviceCode,
       });
     },

--- a/turbo/packages/connectors/src/auth-providers/oauth/providers/test-oauth-device.ts
+++ b/turbo/packages/connectors/src/auth-providers/oauth/providers/test-oauth-device.ts
@@ -1,6 +1,5 @@
 import { z } from "zod";
 
-import type { ConnectorDeviceAuthGrantConfig } from "@vm0/connectors/connectors";
 import type {
   OAuthDeviceAuthPollResult,
   OAuthDeviceAuthStartResult,
@@ -20,6 +19,8 @@ export const TEST_OAUTH_DEVICE_ACCESS_SECRET_NAME =
 export const TEST_OAUTH_DEVICE_API_ACCESS_SECRET_NAME =
   "TEST_OAUTH_DEVICE_API_ACCESS_TOKEN";
 
+const TEST_OAUTH_DEVICE_AUTH_URL = "/api/test/oauth-provider/device/code";
+const TEST_OAUTH_DEVICE_TOKEN_URL = "/api/test/oauth-provider/token";
 const DEVICE_CODE_GRANT_TYPE = "urn:ietf:params:oauth:grant-type:device_code";
 
 const deviceAuthResponseSchema = z.object({
@@ -44,27 +45,22 @@ const tokenErrorResponseSchema = z.object({
   error_description: z.string().optional(),
 });
 
-function getDeviceAuthUrl(
-  deviceAuthGrant: ConnectorDeviceAuthGrantConfig,
-): string {
+function getDeviceAuthUrl(): string {
   return resolveTestOAuthProviderUrl(
     "deviceAuthUrl",
-    deviceAuthGrant.deviceAuthUrl,
+    TEST_OAUTH_DEVICE_AUTH_URL,
   );
 }
 
-function getDeviceTokenUrl(
-  deviceAuthGrant: ConnectorDeviceAuthGrantConfig,
-): string {
-  return resolveTestOAuthProviderUrl("tokenUrl", deviceAuthGrant.tokenUrl);
+function getDeviceTokenUrl(): string {
+  return resolveTestOAuthProviderUrl("tokenUrl", TEST_OAUTH_DEVICE_TOKEN_URL);
 }
 
 export async function startTestOAuthDeviceAuth(args: {
   readonly clientId: string;
-  readonly deviceAuthGrant: ConnectorDeviceAuthGrantConfig;
   readonly scopes: readonly string[];
 }): Promise<OAuthDeviceAuthStartResult> {
-  const response = await fetch(getDeviceAuthUrl(args.deviceAuthGrant), {
+  const response = await fetch(getDeviceAuthUrl(), {
     method: "POST",
     headers: {
       "Content-Type": "application/x-www-form-urlencoded",
@@ -127,10 +123,9 @@ function devicePollErrorResult(args: {
 
 export async function pollTestOAuthDeviceAuth(args: {
   readonly clientId: string;
-  readonly deviceAuthGrant: ConnectorDeviceAuthGrantConfig;
   readonly deviceCode: string;
 }): Promise<OAuthDeviceAuthPollResult> {
-  const response = await fetch(getDeviceTokenUrl(args.deviceAuthGrant), {
+  const response = await fetch(getDeviceTokenUrl(), {
     method: "POST",
     headers: {
       "Content-Type": "application/x-www-form-urlencoded",

--- a/turbo/packages/connectors/src/auth-providers/oauth/providers/test-oauth-provider.ts
+++ b/turbo/packages/connectors/src/auth-providers/oauth/providers/test-oauth-provider.ts
@@ -37,7 +37,6 @@ function createTestOauthGrant<
       const code = exchangeArgs.code;
       const redirectUri = exchangeArgs.redirectUri;
       const token = await exchangeTestOAuthCode(
-        exchangeArgs.authCodeGrant,
         clientId,
         clientSecret,
         code,
@@ -76,7 +75,6 @@ function createTestOauthAccess<
       const { clientId, clientSecret } = refreshArgs.authClient;
       const refreshToken = refreshArgs.refreshToken;
       const result = await refreshTestOAuthToken(
-        refreshArgs.tokenUrl,
         clientId,
         clientSecret,
         refreshToken,

--- a/turbo/packages/connectors/src/auth-providers/oauth/providers/test-oauth.ts
+++ b/turbo/packages/connectors/src/auth-providers/oauth/providers/test-oauth.ts
@@ -23,6 +23,7 @@ export {
 } from "./test-oauth-constants";
 
 const TEST_OAUTH_AUTHORIZATION_URL = "/api/test/oauth-provider/authorize";
+const TEST_OAUTH_TOKEN_URL = "/api/test/oauth-provider/token";
 
 interface TokenResponse {
   accessToken: string;
@@ -139,8 +140,8 @@ function getAuthorizationUrl(): string {
   );
 }
 
-function getTestOAuthTokenUrl(tokenUrl: string): string {
-  return resolveTestOAuthProviderUrl("tokenUrl", tokenUrl);
+function getTestOAuthTokenUrl(): string {
+  return resolveTestOAuthProviderUrl("tokenUrl", TEST_OAUTH_TOKEN_URL);
 }
 
 export function buildTestOAuthAuthorizationUrl(
@@ -168,12 +169,11 @@ const tokenResponseSchema = z.object({
 });
 
 async function postToken(
-  tokenUrl: string,
   body: URLSearchParams,
   operation: "exchange" | "refresh",
   signal: AbortSignal | undefined,
 ): Promise<TokenResponse> {
-  const response = await fetch(getTestOAuthTokenUrl(tokenUrl), {
+  const response = await fetch(getTestOAuthTokenUrl(), {
     signal,
     method: "POST",
     headers: {
@@ -198,14 +198,12 @@ async function postToken(
 }
 
 export async function exchangeTestOAuthCode(
-  authCodeGrant: ConnectorAuthCodeGrantConfig,
   clientId: string,
   clientSecret: string,
   code: string,
   redirectUri: string,
 ): Promise<TokenResponse> {
   return postToken(
-    authCodeGrant.tokenUrl,
     new URLSearchParams({
       grant_type: "authorization_code",
       client_id: clientId,
@@ -219,14 +217,12 @@ export async function exchangeTestOAuthCode(
 }
 
 export async function refreshTestOAuthToken(
-  tokenUrl: string,
   clientId: string,
   clientSecret: string,
   refreshToken: string,
   signal: AbortSignal,
 ): Promise<TokenResponse> {
   return postToken(
-    tokenUrl,
     new URLSearchParams({
       grant_type: "refresh_token",
       client_id: clientId,

--- a/turbo/packages/connectors/src/auth-providers/oauth/providers/todoist.ts
+++ b/turbo/packages/connectors/src/auth-providers/oauth/providers/todoist.ts
@@ -3,6 +3,8 @@ import { z } from "zod";
 import type { ConnectorAuthCodeGrantConfig } from "@vm0/connectors/connectors";
 import { throwOAuthError } from "../error";
 
+const TODOIST_TOKEN_URL = "https://todoist.com/oauth/access_token";
+
 const TODOIST_AUTHORIZATION_URL = "https://todoist.com/oauth/authorize";
 
 const TODOIST_USER_URL = "https://api.todoist.com/api/v1/user";
@@ -49,7 +51,7 @@ export async function exchangeTodoistCode(
   code: string,
   redirectUri: string,
 ): Promise<TodoistTokenResult> {
-  const response = await fetch(authCodeGrant.tokenUrl, {
+  const response = await fetch(TODOIST_TOKEN_URL, {
     method: "POST",
     headers: {
       "Content-Type": "application/x-www-form-urlencoded",

--- a/turbo/packages/connectors/src/auth-providers/oauth/providers/vercel.ts
+++ b/turbo/packages/connectors/src/auth-providers/oauth/providers/vercel.ts
@@ -3,6 +3,8 @@ import { z } from "zod";
 import type { ConnectorAuthCodeGrantConfig } from "@vm0/connectors/connectors";
 import { throwOAuthError } from "../error";
 
+const VERCEL_TOKEN_URL = "https://api.vercel.com/v2/oauth/access_token";
+
 interface VercelUserInfo {
   id: string;
   username: string | null;
@@ -44,7 +46,7 @@ export async function exchangeVercelCode(
   code: string,
   redirectUri: string,
 ): Promise<VercelTokenResult> {
-  const response = await fetch(authCodeGrant.tokenUrl, {
+  const response = await fetch(VERCEL_TOKEN_URL, {
     method: "POST",
     headers: {
       "Content-Type": "application/x-www-form-urlencoded",

--- a/turbo/packages/connectors/src/auth-providers/oauth/providers/webflow.ts
+++ b/turbo/packages/connectors/src/auth-providers/oauth/providers/webflow.ts
@@ -3,6 +3,8 @@ import { z } from "zod";
 import type { ConnectorAuthCodeGrantConfig } from "@vm0/connectors/connectors";
 import { throwOAuthError } from "../error";
 
+const WEBFLOW_TOKEN_URL = "https://api.webflow.com/oauth/access_token";
+
 const WEBFLOW_AUTHORIZATION_URL = "https://webflow.com/oauth/authorize";
 
 interface WebflowTokenResult {
@@ -46,7 +48,7 @@ export async function exchangeWebflowCode(
   code: string,
   redirectUri: string,
 ): Promise<WebflowTokenResult> {
-  const response = await fetch(authCodeGrant.tokenUrl, {
+  const response = await fetch(WEBFLOW_TOKEN_URL, {
     method: "POST",
     headers: {
       "Content-Type": "application/json",

--- a/turbo/packages/connectors/src/auth-providers/oauth/providers/x-provider.ts
+++ b/turbo/packages/connectors/src/auth-providers/oauth/providers/x-provider.ts
@@ -55,7 +55,6 @@ export const xProvider: AuthCodeConnectorAuthProvider<"x"> = {
     refreshToken: (args) => {
       const { clientId, clientSecret } = args.authClient;
       return refreshXToken(
-        args.tokenUrl,
         clientId,
         clientSecret,
         args.refreshToken,

--- a/turbo/packages/connectors/src/auth-providers/oauth/providers/x.ts
+++ b/turbo/packages/connectors/src/auth-providers/oauth/providers/x.ts
@@ -3,6 +3,8 @@ import { z } from "zod";
 import type { ConnectorAuthCodeGrantConfig } from "@vm0/connectors/connectors";
 import { throwOAuthError } from "../error";
 
+const X_TOKEN_URL = "https://api.x.com/2/oauth2/token";
+
 const X_AUTHORIZATION_URL = "https://x.com/i/oauth2/authorize";
 
 const X_USERS_ME_URL =
@@ -92,7 +94,6 @@ export async function buildXAuthorizationUrl(
  * Access token expires_in: 7200s (2 hours). Ref: https://developer.x.com/en/docs/authentication/oauth-2-0/authorization-code
  */
 export async function refreshXToken(
-  tokenUrl: string,
   clientId: string,
   clientSecret: string,
   refreshToken: string,
@@ -102,7 +103,7 @@ export async function refreshXToken(
     "base64",
   );
 
-  const response = await fetch(tokenUrl, {
+  const response = await fetch(X_TOKEN_URL, {
     signal,
     method: "POST",
     headers: {
@@ -160,7 +161,7 @@ export async function exchangeXCode(
     "base64",
   );
 
-  const response = await fetch(authCodeGrant.tokenUrl, {
+  const response = await fetch(X_TOKEN_URL, {
     method: "POST",
     headers: {
       Authorization: `Basic ${credentials}`,

--- a/turbo/packages/connectors/src/auth-providers/oauth/providers/xero-provider.ts
+++ b/turbo/packages/connectors/src/auth-providers/oauth/providers/xero-provider.ts
@@ -50,7 +50,6 @@ export const xeroProvider: AuthCodeConnectorAuthProvider<"xero"> = {
     refreshToken: (args) => {
       const { clientId, clientSecret } = args.authClient;
       return refreshXeroToken(
-        args.tokenUrl,
         clientId,
         clientSecret,
         args.refreshToken,

--- a/turbo/packages/connectors/src/auth-providers/oauth/providers/xero.ts
+++ b/turbo/packages/connectors/src/auth-providers/oauth/providers/xero.ts
@@ -3,6 +3,8 @@ import { z } from "zod";
 import type { ConnectorAuthCodeGrantConfig } from "@vm0/connectors/connectors";
 import { throwOAuthError } from "../error";
 
+const XERO_TOKEN_URL = "https://identity.xero.com/connect/token";
+
 const XERO_AUTHORIZATION_URL =
   "https://login.xero.com/identity/connect/authorize";
 
@@ -59,7 +61,7 @@ export async function exchangeXeroCode(
   code: string,
   redirectUri: string,
 ): Promise<XeroTokenResult> {
-  const response = await fetch(authCodeGrant.tokenUrl, {
+  const response = await fetch(XERO_TOKEN_URL, {
     method: "POST",
     headers: {
       "Content-Type": "application/x-www-form-urlencoded",
@@ -114,13 +116,12 @@ export async function exchangeXeroCode(
  * Access token expires_in: 1800s (30 min). Ref: https://developer.xero.com/documentation/guides/oauth2/auth-flow/
  */
 export async function refreshXeroToken(
-  tokenUrl: string,
   clientId: string,
   clientSecret: string,
   refreshToken: string,
   signal: AbortSignal,
 ): Promise<XeroRefreshResult> {
-  const response = await fetch(tokenUrl, {
+  const response = await fetch(XERO_TOKEN_URL, {
     signal,
     method: "POST",
     headers: {

--- a/turbo/packages/connectors/src/auth-providers/oauth/providers/zoom-provider.ts
+++ b/turbo/packages/connectors/src/auth-providers/oauth/providers/zoom-provider.ts
@@ -50,7 +50,6 @@ export const zoomProvider: AuthCodeConnectorAuthProvider<"zoom"> = {
     refreshToken: (args) => {
       const { clientId, clientSecret } = args.authClient;
       return refreshZoomToken(
-        args.tokenUrl,
         clientId,
         clientSecret,
         args.refreshToken,

--- a/turbo/packages/connectors/src/auth-providers/oauth/providers/zoom.ts
+++ b/turbo/packages/connectors/src/auth-providers/oauth/providers/zoom.ts
@@ -3,6 +3,8 @@ import { z } from "zod";
 import type { ConnectorAuthCodeGrantConfig } from "@vm0/connectors/connectors";
 import { throwOAuthError } from "../error";
 
+const ZOOM_TOKEN_URL = "https://zoom.us/oauth/token";
+
 const ZOOM_AUTHORIZATION_URL = "https://zoom.us/oauth/authorize";
 
 const ZOOM_ME_URL = "https://api.zoom.us/v2/users/me";
@@ -64,7 +66,7 @@ export async function exchangeZoomCode(
     "base64",
   );
 
-  const response = await fetch(authCodeGrant.tokenUrl, {
+  const response = await fetch(ZOOM_TOKEN_URL, {
     method: "POST",
     headers: {
       "Content-Type": "application/x-www-form-urlencoded",
@@ -117,7 +119,6 @@ export async function exchangeZoomCode(
  * Ref: https://developers.zoom.us/docs/integrations/oauth/
  */
 export async function refreshZoomToken(
-  tokenUrl: string,
   clientId: string,
   clientSecret: string,
   refreshToken: string,
@@ -127,7 +128,7 @@ export async function refreshZoomToken(
     "base64",
   );
 
-  const response = await fetch(tokenUrl, {
+  const response = await fetch(ZOOM_TOKEN_URL, {
     signal,
     method: "POST",
     headers: {

--- a/turbo/packages/connectors/src/auth-providers/oauth/types.ts
+++ b/turbo/packages/connectors/src/auth-providers/oauth/types.ts
@@ -3,7 +3,6 @@ import type {
   ConnectorAuthCodeGrantConfig,
   ConnectorAuthMethodIds,
   ConnectorAuthCodeGrantAuthMethodId,
-  ConnectorDeviceAuthGrantConfig,
   ConnectorDeviceAuthGrantAuthMethodId,
   ConnectorAuthMethodIdsByAccessKind,
   ConnectorAuthMethodIdsByRevokeKind,
@@ -158,9 +157,7 @@ export type ConnectorAuthProviderRefreshArgs<
   Method extends ConnectorAuthMethodIdsByAccessKind<T, "refresh-token"> =
     ConnectorAuthMethodIdsByAccessKind<T, "refresh-token">,
 > = OAuthRefreshFlowArgs &
-  ConnectorAuthMethodClientArgs<T, Method> & {
-    readonly tokenUrl: string;
-  };
+  ConnectorAuthMethodClientArgs<T, Method>;
 
 export type ConnectorAuthProviderRevokeArgs<
   T extends TokenRevokeConnectorType,
@@ -173,15 +170,11 @@ export type ConnectorDeviceAuthorizationStartArgs<
   Method extends ConnectorDeviceAuthGrantAuthMethodId<T> =
     ConnectorDeviceAuthGrantAuthMethodId<T>,
 > = OAuthDeviceAuthStartFlowArgs &
-  ConnectorAuthMethodClientIdentityArgs<T, Method> & {
-    readonly deviceAuthGrant: ConnectorDeviceAuthGrantConfig;
-  };
+  ConnectorAuthMethodClientIdentityArgs<T, Method>;
 
 export type ConnectorDeviceAuthorizationPollArgs<
   T extends DeviceAuthGrantConnectorType,
   Method extends ConnectorDeviceAuthGrantAuthMethodId<T> =
     ConnectorDeviceAuthGrantAuthMethodId<T>,
 > = OAuthDeviceAuthPollFlowArgs &
-  ConnectorAuthMethodClientArgs<T, Method> & {
-    readonly deviceAuthGrant: ConnectorDeviceAuthGrantConfig;
-  };
+  ConnectorAuthMethodClientArgs<T, Method>;

--- a/turbo/packages/connectors/src/auth-providers/oauth/types.ts
+++ b/turbo/packages/connectors/src/auth-providers/oauth/types.ts
@@ -156,8 +156,7 @@ export type ConnectorAuthProviderRefreshArgs<
   T extends RefreshTokenAccessConnectorType,
   Method extends ConnectorAuthMethodIdsByAccessKind<T, "refresh-token"> =
     ConnectorAuthMethodIdsByAccessKind<T, "refresh-token">,
-> = OAuthRefreshFlowArgs &
-  ConnectorAuthMethodClientArgs<T, Method>;
+> = OAuthRefreshFlowArgs & ConnectorAuthMethodClientArgs<T, Method>;
 
 export type ConnectorAuthProviderRevokeArgs<
   T extends TokenRevokeConnectorType,
@@ -176,5 +175,4 @@ export type ConnectorDeviceAuthorizationPollArgs<
   T extends DeviceAuthGrantConnectorType,
   Method extends ConnectorDeviceAuthGrantAuthMethodId<T> =
     ConnectorDeviceAuthGrantAuthMethodId<T>,
-> = OAuthDeviceAuthPollFlowArgs &
-  ConnectorAuthMethodClientArgs<T, Method>;
+> = OAuthDeviceAuthPollFlowArgs & ConnectorAuthMethodClientArgs<T, Method>;

--- a/turbo/packages/connectors/src/connectors.ts
+++ b/turbo/packages/connectors/src/connectors.ts
@@ -330,14 +330,11 @@ export interface ConnectorManualGrantConfig {
 
 export interface ConnectorAuthCodeGrantConfig {
   readonly kind: "auth-code";
-  readonly tokenUrl: string;
   readonly scopes: string[];
 }
 
 export interface ConnectorDeviceAuthGrantConfig {
   readonly kind: "device-auth";
-  readonly deviceAuthUrl: string;
-  readonly tokenUrl: string;
   readonly scopes: string[];
 }
 
@@ -388,7 +385,6 @@ export interface ConnectorStaticAccessConfig extends ConnectorEnvBindingAccessCo
 
 export interface ConnectorRefreshTokenAccessConfig extends ConnectorEnvBindingAccessConfigBase {
   readonly kind: "refresh-token";
-  readonly tokenUrl: string;
 }
 
 export interface ConnectorNoAccessConfig {

--- a/turbo/packages/connectors/src/connectors/ahrefs.ts
+++ b/turbo/packages/connectors/src/connectors/ahrefs.ts
@@ -1,8 +1,6 @@
 import type { ConnectorConfig } from "../connectors";
 import { FeatureSwitchKey } from "../feature-switch-key";
 
-const OAUTH_TOKEN_URL = "https://app.ahrefs.com/api/token";
-
 export const ahrefs = {
   ahrefs: {
     label: "Ahrefs",
@@ -30,12 +28,10 @@ export const ahrefs = {
         },
         grant: {
           kind: "auth-code",
-          tokenUrl: OAUTH_TOKEN_URL,
           scopes: ["api"],
         },
         access: {
           kind: "refresh-token",
-          tokenUrl: OAUTH_TOKEN_URL,
           envBindings: {
             AHREFS_TOKEN: "$secrets.AHREFS_ACCESS_TOKEN",
           },

--- a/turbo/packages/connectors/src/connectors/airtable.ts
+++ b/turbo/packages/connectors/src/connectors/airtable.ts
@@ -1,7 +1,5 @@
 import type { ConnectorConfig } from "../connectors";
 
-const OAUTH_TOKEN_URL = "https://airtable.com/oauth2/v1/token";
-
 export const airtable = {
   airtable: {
     label: "Airtable",
@@ -28,7 +26,6 @@ export const airtable = {
         },
         grant: {
           kind: "auth-code",
-          tokenUrl: OAUTH_TOKEN_URL,
           scopes: [
             "data.records:read",
             "data.records:write",
@@ -41,7 +38,6 @@ export const airtable = {
         },
         access: {
           kind: "refresh-token",
-          tokenUrl: OAUTH_TOKEN_URL,
           envBindings: {
             AIRTABLE_TOKEN: "$secrets.AIRTABLE_ACCESS_TOKEN",
           },

--- a/turbo/packages/connectors/src/connectors/asana.ts
+++ b/turbo/packages/connectors/src/connectors/asana.ts
@@ -1,7 +1,5 @@
 import type { ConnectorConfig } from "../connectors";
 
-const OAUTH_TOKEN_URL = "https://app.asana.com/-/oauth_token";
-
 export const asana = {
   asana: {
     label: "Asana",
@@ -28,12 +26,10 @@ export const asana = {
         },
         grant: {
           kind: "auth-code",
-          tokenUrl: OAUTH_TOKEN_URL,
           scopes: [],
         },
         access: {
           kind: "refresh-token",
-          tokenUrl: OAUTH_TOKEN_URL,
           envBindings: {
             ASANA_TOKEN: "$secrets.ASANA_ACCESS_TOKEN",
           },

--- a/turbo/packages/connectors/src/connectors/base44.ts
+++ b/turbo/packages/connectors/src/connectors/base44.ts
@@ -1,7 +1,5 @@
 import type { ConnectorConfig } from "../connectors";
 
-const OAUTH_TOKEN_URL = "https://app.base44.com/oauth/token";
-
 export const base44 = {
   base44: {
     label: "Base44",
@@ -27,13 +25,10 @@ export const base44 = {
         },
         grant: {
           kind: "device-auth",
-          deviceAuthUrl: "https://app.base44.com/oauth/device/code",
-          tokenUrl: OAUTH_TOKEN_URL,
           scopes: ["apps:read", "apps:write", "offline"],
         },
         access: {
           kind: "refresh-token",
-          tokenUrl: OAUTH_TOKEN_URL,
           envBindings: {
             BASE44_TOKEN: "$secrets.BASE44_ACCESS_TOKEN",
           },

--- a/turbo/packages/connectors/src/connectors/canva.ts
+++ b/turbo/packages/connectors/src/connectors/canva.ts
@@ -1,8 +1,6 @@
 import type { ConnectorConfig } from "../connectors";
 import { FeatureSwitchKey } from "../feature-switch-key";
 
-const OAUTH_TOKEN_URL = "https://api.canva.com/rest/v1/oauth/token";
-
 export const canva = {
   canva: {
     label: "Canva",
@@ -30,7 +28,6 @@ export const canva = {
         },
         grant: {
           kind: "auth-code",
-          tokenUrl: OAUTH_TOKEN_URL,
           scopes: [
             "asset:read",
             "asset:write",
@@ -48,7 +45,6 @@ export const canva = {
         },
         access: {
           kind: "refresh-token",
-          tokenUrl: OAUTH_TOKEN_URL,
           envBindings: {
             CANVA_TOKEN: "$secrets.CANVA_ACCESS_TOKEN",
           },

--- a/turbo/packages/connectors/src/connectors/close.ts
+++ b/turbo/packages/connectors/src/connectors/close.ts
@@ -1,8 +1,6 @@
 import type { ConnectorConfig } from "../connectors";
 import { FeatureSwitchKey } from "../feature-switch-key";
 
-const OAUTH_TOKEN_URL = "https://api.close.com/oauth2/token/";
-
 export const close = {
   close: {
     label: "Close",
@@ -30,12 +28,10 @@ export const close = {
         },
         grant: {
           kind: "auth-code",
-          tokenUrl: OAUTH_TOKEN_URL,
           scopes: ["all.full_access", "offline_access"],
         },
         access: {
           kind: "refresh-token",
-          tokenUrl: OAUTH_TOKEN_URL,
           envBindings: {
             CLOSE_TOKEN: "$secrets.CLOSE_ACCESS_TOKEN",
           },

--- a/turbo/packages/connectors/src/connectors/deel.ts
+++ b/turbo/packages/connectors/src/connectors/deel.ts
@@ -1,8 +1,6 @@
 import type { ConnectorConfig } from "../connectors";
 import { FeatureSwitchKey } from "../feature-switch-key";
 
-const OAUTH_TOKEN_URL = "https://app.deel.com/oauth2/tokens";
-
 export const deel = {
   deel: {
     label: "Deel",
@@ -30,7 +28,6 @@ export const deel = {
         },
         grant: {
           kind: "auth-code",
-          tokenUrl: OAUTH_TOKEN_URL,
           scopes: [
             "contracts:read",
             "people:read",
@@ -44,7 +41,6 @@ export const deel = {
         },
         access: {
           kind: "refresh-token",
-          tokenUrl: OAUTH_TOKEN_URL,
           envBindings: {
             DEEL_TOKEN: "$secrets.DEEL_ACCESS_TOKEN",
           },

--- a/turbo/packages/connectors/src/connectors/docusign.ts
+++ b/turbo/packages/connectors/src/connectors/docusign.ts
@@ -1,8 +1,6 @@
 import type { ConnectorConfig } from "../connectors";
 import { FeatureSwitchKey } from "../feature-switch-key";
 
-const OAUTH_TOKEN_URL = "https://account-d.docusign.com/oauth/token";
-
 export const docusign = {
   docusign: {
     label: "DocuSign",
@@ -30,12 +28,10 @@ export const docusign = {
         },
         grant: {
           kind: "auth-code",
-          tokenUrl: OAUTH_TOKEN_URL,
           scopes: ["signature", "extended", "openid"],
         },
         access: {
           kind: "refresh-token",
-          tokenUrl: OAUTH_TOKEN_URL,
           envBindings: {
             DOCUSIGN_TOKEN: "$secrets.DOCUSIGN_ACCESS_TOKEN",
           },

--- a/turbo/packages/connectors/src/connectors/dropbox.ts
+++ b/turbo/packages/connectors/src/connectors/dropbox.ts
@@ -1,8 +1,6 @@
 import type { ConnectorConfig } from "../connectors";
 import { FeatureSwitchKey } from "../feature-switch-key";
 
-const OAUTH_TOKEN_URL = "https://api.dropboxapi.com/oauth2/token";
-
 export const dropbox = {
   dropbox: {
     label: "Dropbox",
@@ -29,7 +27,6 @@ export const dropbox = {
         },
         grant: {
           kind: "auth-code",
-          tokenUrl: OAUTH_TOKEN_URL,
           scopes: [
             "account_info.read",
             "files.metadata.read",
@@ -38,7 +35,6 @@ export const dropbox = {
         },
         access: {
           kind: "refresh-token",
-          tokenUrl: OAUTH_TOKEN_URL,
           envBindings: {
             DROPBOX_TOKEN: "$secrets.DROPBOX_ACCESS_TOKEN",
           },

--- a/turbo/packages/connectors/src/connectors/figma.ts
+++ b/turbo/packages/connectors/src/connectors/figma.ts
@@ -1,8 +1,6 @@
 import type { ConnectorConfig } from "../connectors";
 import { FeatureSwitchKey } from "../feature-switch-key";
 
-const OAUTH_TOKEN_URL = "https://api.figma.com/v1/oauth/token";
-
 export const figma = {
   figma: {
     label: "Figma",
@@ -29,7 +27,6 @@ export const figma = {
         },
         grant: {
           kind: "auth-code",
-          tokenUrl: OAUTH_TOKEN_URL,
           scopes: [
             "current_user:read",
             "file_content:read",
@@ -44,7 +41,6 @@ export const figma = {
         },
         access: {
           kind: "refresh-token",
-          tokenUrl: OAUTH_TOKEN_URL,
           envBindings: {
             FIGMA_TOKEN: "$secrets.FIGMA_ACCESS_TOKEN",
           },

--- a/turbo/packages/connectors/src/connectors/garmin-connect.ts
+++ b/turbo/packages/connectors/src/connectors/garmin-connect.ts
@@ -1,9 +1,6 @@
 import type { ConnectorConfig } from "../connectors";
 import { FeatureSwitchKey } from "../feature-switch-key";
 
-const OAUTH_TOKEN_URL =
-  "https://diauth.garmin.com/di-oauth2-service/oauth/token";
-
 export const garminConnect = {
   "garmin-connect": {
     label: "Garmin Connect",
@@ -34,12 +31,10 @@ export const garminConnect = {
         },
         grant: {
           kind: "auth-code",
-          tokenUrl: OAUTH_TOKEN_URL,
           scopes: [],
         },
         access: {
           kind: "refresh-token",
-          tokenUrl: OAUTH_TOKEN_URL,
           envBindings: {
             GARMIN_CONNECT_TOKEN: "$secrets.GARMIN_CONNECT_ACCESS_TOKEN",
           },

--- a/turbo/packages/connectors/src/connectors/github.ts
+++ b/turbo/packages/connectors/src/connectors/github.ts
@@ -26,7 +26,6 @@ export const github = {
         },
         grant: {
           kind: "auth-code",
-          tokenUrl: "https://github.com/login/oauth/access_token",
           scopes: ["repo", "project", "workflow"],
         },
         access: {

--- a/turbo/packages/connectors/src/connectors/gmail.ts
+++ b/turbo/packages/connectors/src/connectors/gmail.ts
@@ -1,7 +1,5 @@
 import type { ConnectorConfig } from "../connectors";
 
-const OAUTH_TOKEN_URL = "https://oauth2.googleapis.com/token";
-
 export const gmail = {
   gmail: {
     label: "Gmail",
@@ -28,12 +26,10 @@ export const gmail = {
         },
         grant: {
           kind: "auth-code",
-          tokenUrl: OAUTH_TOKEN_URL,
           scopes: ["https://www.googleapis.com/auth/gmail.modify"],
         },
         access: {
           kind: "refresh-token",
-          tokenUrl: OAUTH_TOKEN_URL,
           envBindings: {
             GMAIL_TOKEN: "$secrets.GMAIL_ACCESS_TOKEN",
           },

--- a/turbo/packages/connectors/src/connectors/google-ads.ts
+++ b/turbo/packages/connectors/src/connectors/google-ads.ts
@@ -1,7 +1,5 @@
 import type { ConnectorConfig } from "../connectors";
 
-const OAUTH_TOKEN_URL = "https://oauth2.googleapis.com/token";
-
 export const googleAds = {
   "google-ads": {
     label: "Google Ads",
@@ -30,7 +28,6 @@ export const googleAds = {
         },
         grant: {
           kind: "auth-code",
-          tokenUrl: OAUTH_TOKEN_URL,
           scopes: [
             "https://www.googleapis.com/auth/adwords",
             "https://www.googleapis.com/auth/userinfo.email",
@@ -38,7 +35,6 @@ export const googleAds = {
         },
         access: {
           kind: "refresh-token",
-          tokenUrl: OAUTH_TOKEN_URL,
           platformSecrets: ["GOOGLE_ADS_DEVELOPER_TOKEN"],
           envBindings: {
             GOOGLE_ADS_TOKEN: "$secrets.GOOGLE_ADS_ACCESS_TOKEN",

--- a/turbo/packages/connectors/src/connectors/google-calendar.ts
+++ b/turbo/packages/connectors/src/connectors/google-calendar.ts
@@ -1,7 +1,5 @@
 import type { ConnectorConfig } from "../connectors";
 
-const OAUTH_TOKEN_URL = "https://oauth2.googleapis.com/token";
-
 export const googleCalendar = {
   "google-calendar": {
     label: "Google Calendar",
@@ -32,7 +30,6 @@ export const googleCalendar = {
         },
         grant: {
           kind: "auth-code",
-          tokenUrl: OAUTH_TOKEN_URL,
           scopes: [
             "https://www.googleapis.com/auth/calendar",
             "https://www.googleapis.com/auth/userinfo.email",
@@ -40,7 +37,6 @@ export const googleCalendar = {
         },
         access: {
           kind: "refresh-token",
-          tokenUrl: OAUTH_TOKEN_URL,
           envBindings: {
             GOOGLE_CALENDAR_TOKEN: "$secrets.GOOGLE_CALENDAR_ACCESS_TOKEN",
           },

--- a/turbo/packages/connectors/src/connectors/google-docs.ts
+++ b/turbo/packages/connectors/src/connectors/google-docs.ts
@@ -1,7 +1,5 @@
 import type { ConnectorConfig } from "../connectors";
 
-const OAUTH_TOKEN_URL = "https://oauth2.googleapis.com/token";
-
 export const googleDocs = {
   "google-docs": {
     label: "Google Docs",
@@ -27,7 +25,6 @@ export const googleDocs = {
         },
         grant: {
           kind: "auth-code",
-          tokenUrl: OAUTH_TOKEN_URL,
           scopes: [
             "https://www.googleapis.com/auth/documents",
             "https://www.googleapis.com/auth/userinfo.email",
@@ -35,7 +32,6 @@ export const googleDocs = {
         },
         access: {
           kind: "refresh-token",
-          tokenUrl: OAUTH_TOKEN_URL,
           envBindings: {
             GOOGLE_DOCS_TOKEN: "$secrets.GOOGLE_DOCS_ACCESS_TOKEN",
           },

--- a/turbo/packages/connectors/src/connectors/google-drive.ts
+++ b/turbo/packages/connectors/src/connectors/google-drive.ts
@@ -1,7 +1,5 @@
 import type { ConnectorConfig } from "../connectors";
 
-const OAUTH_TOKEN_URL = "https://oauth2.googleapis.com/token";
-
 export const googleDrive = {
   "google-drive": {
     label: "Google Drive",
@@ -27,7 +25,6 @@ export const googleDrive = {
         },
         grant: {
           kind: "auth-code",
-          tokenUrl: OAUTH_TOKEN_URL,
           scopes: [
             "https://www.googleapis.com/auth/drive",
             "https://www.googleapis.com/auth/userinfo.email",
@@ -35,7 +32,6 @@ export const googleDrive = {
         },
         access: {
           kind: "refresh-token",
-          tokenUrl: OAUTH_TOKEN_URL,
           envBindings: {
             GOOGLE_DRIVE_TOKEN: "$secrets.GOOGLE_DRIVE_ACCESS_TOKEN",
           },

--- a/turbo/packages/connectors/src/connectors/google-meet.ts
+++ b/turbo/packages/connectors/src/connectors/google-meet.ts
@@ -1,7 +1,5 @@
 import type { ConnectorConfig } from "../connectors";
 
-const OAUTH_TOKEN_URL = "https://oauth2.googleapis.com/token";
-
 export const googleMeet = {
   "google-meet": {
     label: "Google Meet",
@@ -28,7 +26,6 @@ export const googleMeet = {
         },
         grant: {
           kind: "auth-code",
-          tokenUrl: OAUTH_TOKEN_URL,
           scopes: [
             "https://www.googleapis.com/auth/meetings.space.created",
             // Use meetings.space.readonly (not meetings.conferencerecords.readonly) — confirmed
@@ -41,7 +38,6 @@ export const googleMeet = {
         },
         access: {
           kind: "refresh-token",
-          tokenUrl: OAUTH_TOKEN_URL,
           envBindings: {
             GOOGLE_MEET_TOKEN: "$secrets.GOOGLE_MEET_ACCESS_TOKEN",
           },

--- a/turbo/packages/connectors/src/connectors/google-sheets.ts
+++ b/turbo/packages/connectors/src/connectors/google-sheets.ts
@@ -1,7 +1,5 @@
 import type { ConnectorConfig } from "../connectors";
 
-const OAUTH_TOKEN_URL = "https://oauth2.googleapis.com/token";
-
 export const googleSheets = {
   "google-sheets": {
     label: "Google Sheets",
@@ -30,7 +28,6 @@ export const googleSheets = {
         },
         grant: {
           kind: "auth-code",
-          tokenUrl: OAUTH_TOKEN_URL,
           scopes: [
             "https://www.googleapis.com/auth/spreadsheets",
             "https://www.googleapis.com/auth/userinfo.email",
@@ -38,7 +35,6 @@ export const googleSheets = {
         },
         access: {
           kind: "refresh-token",
-          tokenUrl: OAUTH_TOKEN_URL,
           envBindings: {
             GOOGLE_SHEETS_TOKEN: "$secrets.GOOGLE_SHEETS_ACCESS_TOKEN",
           },

--- a/turbo/packages/connectors/src/connectors/gumroad.ts
+++ b/turbo/packages/connectors/src/connectors/gumroad.ts
@@ -1,7 +1,5 @@
 import type { ConnectorConfig } from "../connectors";
 
-const OAUTH_TOKEN_URL = "https://gumroad.com/oauth/token";
-
 export const gumroad = {
   gumroad: {
     label: "Gumroad",
@@ -29,7 +27,6 @@ export const gumroad = {
         },
         grant: {
           kind: "auth-code",
-          tokenUrl: OAUTH_TOKEN_URL,
           scopes: [
             "view_profile",
             "edit_products",
@@ -40,7 +37,6 @@ export const gumroad = {
         },
         access: {
           kind: "refresh-token",
-          tokenUrl: OAUTH_TOKEN_URL,
           envBindings: {
             GUMROAD_TOKEN: "$secrets.GUMROAD_ACCESS_TOKEN",
           },

--- a/turbo/packages/connectors/src/connectors/hubspot.ts
+++ b/turbo/packages/connectors/src/connectors/hubspot.ts
@@ -1,7 +1,5 @@
 import type { ConnectorConfig } from "../connectors";
 
-const OAUTH_TOKEN_URL = "https://api.hubapi.com/oauth/v1/token";
-
 export const hubspot = {
   hubspot: {
     label: "HubSpot",
@@ -28,7 +26,6 @@ export const hubspot = {
         },
         grant: {
           kind: "auth-code",
-          tokenUrl: OAUTH_TOKEN_URL,
           scopes: [
             "crm.objects.contacts.read",
             "crm.objects.contacts.write",
@@ -46,7 +43,6 @@ export const hubspot = {
         },
         access: {
           kind: "refresh-token",
-          tokenUrl: OAUTH_TOKEN_URL,
           envBindings: {
             HUBSPOT_TOKEN: "$secrets.HUBSPOT_ACCESS_TOKEN",
           },

--- a/turbo/packages/connectors/src/connectors/intervals-icu.ts
+++ b/turbo/packages/connectors/src/connectors/intervals-icu.ts
@@ -25,7 +25,6 @@ export const intervalsIcu = {
         },
         grant: {
           kind: "auth-code",
-          tokenUrl: "https://intervals.icu/api/oauth/token",
           scopes: ["ACTIVITY", "WELLNESS", "CALENDAR", "SETTINGS", "LIBRARY"],
         },
         access: {

--- a/turbo/packages/connectors/src/connectors/linear.ts
+++ b/turbo/packages/connectors/src/connectors/linear.ts
@@ -1,7 +1,5 @@
 import type { ConnectorConfig } from "../connectors";
 
-const OAUTH_TOKEN_URL = "https://api.linear.app/oauth/token";
-
 export const linear = {
   linear: {
     label: "Linear",
@@ -28,7 +26,6 @@ export const linear = {
         },
         grant: {
           kind: "auth-code",
-          tokenUrl: OAUTH_TOKEN_URL,
           scopes: [
             "read",
             "write",
@@ -39,7 +36,6 @@ export const linear = {
         },
         access: {
           kind: "refresh-token",
-          tokenUrl: OAUTH_TOKEN_URL,
           envBindings: {
             LINEAR_TOKEN: "$secrets.LINEAR_ACCESS_TOKEN",
           },

--- a/turbo/packages/connectors/src/connectors/mailchimp.ts
+++ b/turbo/packages/connectors/src/connectors/mailchimp.ts
@@ -27,7 +27,6 @@ export const mailchimp = {
         },
         grant: {
           kind: "auth-code",
-          tokenUrl: "https://login.mailchimp.com/oauth2/token",
           scopes: [],
         },
         access: {

--- a/turbo/packages/connectors/src/connectors/mercury.ts
+++ b/turbo/packages/connectors/src/connectors/mercury.ts
@@ -1,8 +1,6 @@
 import type { ConnectorConfig } from "../connectors";
 import { FeatureSwitchKey } from "../feature-switch-key";
 
-const OAUTH_TOKEN_URL = "https://oauth2.mercury.com/oauth2/token";
-
 export const mercury = {
   mercury: {
     label: "Mercury",
@@ -30,12 +28,10 @@ export const mercury = {
         },
         grant: {
           kind: "auth-code",
-          tokenUrl: OAUTH_TOKEN_URL,
           scopes: ["offline_access"],
         },
         access: {
           kind: "refresh-token",
-          tokenUrl: OAUTH_TOKEN_URL,
           envBindings: {
             MERCURY_TOKEN: "$secrets.MERCURY_ACCESS_TOKEN",
           },

--- a/turbo/packages/connectors/src/connectors/meta-ads.ts
+++ b/turbo/packages/connectors/src/connectors/meta-ads.ts
@@ -27,7 +27,6 @@ export const metaAds = {
         },
         grant: {
           kind: "auth-code",
-          tokenUrl: "https://graph.facebook.com/v22.0/oauth/access_token",
           scopes: ["ads_management", "ads_read", "business_management"],
         },
         access: {

--- a/turbo/packages/connectors/src/connectors/monday.ts
+++ b/turbo/packages/connectors/src/connectors/monday.ts
@@ -1,7 +1,5 @@
 import type { ConnectorConfig } from "../connectors";
 
-const OAUTH_TOKEN_URL = "https://auth.monday.com/oauth2/token";
-
 export const monday = {
   monday: {
     label: "Monday.com",
@@ -28,7 +26,6 @@ export const monday = {
         },
         grant: {
           kind: "auth-code",
-          tokenUrl: OAUTH_TOKEN_URL,
           scopes: [
             "me:read",
             "boards:read",
@@ -48,7 +45,6 @@ export const monday = {
         },
         access: {
           kind: "refresh-token",
-          tokenUrl: OAUTH_TOKEN_URL,
           envBindings: {
             MONDAY_TOKEN: "$secrets.MONDAY_ACCESS_TOKEN",
           },

--- a/turbo/packages/connectors/src/connectors/neon.ts
+++ b/turbo/packages/connectors/src/connectors/neon.ts
@@ -1,8 +1,6 @@
 import type { ConnectorConfig } from "../connectors";
 import { FeatureSwitchKey } from "../feature-switch-key";
 
-const OAUTH_TOKEN_URL = "https://oauth2.neon.tech/oauth2/token";
-
 export const neon = {
   neon: {
     label: "Neon",
@@ -30,7 +28,6 @@ export const neon = {
         },
         grant: {
           kind: "auth-code",
-          tokenUrl: OAUTH_TOKEN_URL,
           scopes: [
             "openid",
             "offline_access",
@@ -42,7 +39,6 @@ export const neon = {
         },
         access: {
           kind: "refresh-token",
-          tokenUrl: OAUTH_TOKEN_URL,
           envBindings: {
             NEON_TOKEN: "$secrets.NEON_ACCESS_TOKEN",
           },

--- a/turbo/packages/connectors/src/connectors/notion.ts
+++ b/turbo/packages/connectors/src/connectors/notion.ts
@@ -1,7 +1,5 @@
 import type { ConnectorConfig } from "../connectors";
 
-const OAUTH_TOKEN_URL = "https://api.notion.com/v1/oauth/token";
-
 export const notion = {
   notion: {
     label: "Notion",
@@ -28,12 +26,10 @@ export const notion = {
         },
         grant: {
           kind: "auth-code",
-          tokenUrl: OAUTH_TOKEN_URL,
           scopes: [],
         },
         access: {
           kind: "refresh-token",
-          tokenUrl: OAUTH_TOKEN_URL,
           envBindings: {
             NOTION_TOKEN: "$secrets.NOTION_ACCESS_TOKEN",
           },

--- a/turbo/packages/connectors/src/connectors/outlook-calendar.ts
+++ b/turbo/packages/connectors/src/connectors/outlook-calendar.ts
@@ -1,9 +1,6 @@
 import type { ConnectorConfig } from "../connectors";
 import { FeatureSwitchKey } from "../feature-switch-key";
 
-const OAUTH_TOKEN_URL =
-  "https://login.microsoftonline.com/common/oauth2/v2.0/token";
-
 export const outlookCalendar = {
   "outlook-calendar": {
     label: "Outlook Calendar",
@@ -34,12 +31,10 @@ export const outlookCalendar = {
         },
         grant: {
           kind: "auth-code",
-          tokenUrl: OAUTH_TOKEN_URL,
           scopes: ["Calendars.ReadWrite", "User.Read", "offline_access"],
         },
         access: {
           kind: "refresh-token",
-          tokenUrl: OAUTH_TOKEN_URL,
           envBindings: {
             OUTLOOK_CALENDAR_TOKEN: "$secrets.OUTLOOK_CALENDAR_ACCESS_TOKEN",
           },

--- a/turbo/packages/connectors/src/connectors/outlook-mail.ts
+++ b/turbo/packages/connectors/src/connectors/outlook-mail.ts
@@ -1,9 +1,6 @@
 import type { ConnectorConfig } from "../connectors";
 import { FeatureSwitchKey } from "../feature-switch-key";
 
-const OAUTH_TOKEN_URL =
-  "https://login.microsoftonline.com/common/oauth2/v2.0/token";
-
 export const outlookMail = {
   "outlook-mail": {
     label: "Outlook Mail",
@@ -30,7 +27,6 @@ export const outlookMail = {
         },
         grant: {
           kind: "auth-code",
-          tokenUrl: OAUTH_TOKEN_URL,
           scopes: [
             "Mail.ReadWrite",
             "Mail.Send",
@@ -40,7 +36,6 @@ export const outlookMail = {
         },
         access: {
           kind: "refresh-token",
-          tokenUrl: OAUTH_TOKEN_URL,
           envBindings: {
             OUTLOOK_MAIL_TOKEN: "$secrets.OUTLOOK_MAIL_ACCESS_TOKEN",
           },

--- a/turbo/packages/connectors/src/connectors/posthog.ts
+++ b/turbo/packages/connectors/src/connectors/posthog.ts
@@ -1,8 +1,6 @@
 import type { ConnectorConfig } from "../connectors";
 import { FeatureSwitchKey } from "../feature-switch-key";
 
-const OAUTH_TOKEN_URL = "https://us.posthog.com/oauth/token";
-
 export const posthog = {
   posthog: {
     label: "PostHog",
@@ -30,7 +28,6 @@ export const posthog = {
         },
         grant: {
           kind: "auth-code",
-          tokenUrl: OAUTH_TOKEN_URL,
           scopes: [
             "openid",
             "profile",
@@ -60,7 +57,6 @@ export const posthog = {
         },
         access: {
           kind: "refresh-token",
-          tokenUrl: OAUTH_TOKEN_URL,
           envBindings: {
             POSTHOG_TOKEN: "$secrets.POSTHOG_ACCESS_TOKEN",
           },

--- a/turbo/packages/connectors/src/connectors/reddit.ts
+++ b/turbo/packages/connectors/src/connectors/reddit.ts
@@ -1,8 +1,6 @@
 import type { ConnectorConfig } from "../connectors";
 import { FeatureSwitchKey } from "../feature-switch-key";
 
-const OAUTH_TOKEN_URL = "https://www.reddit.com/api/v1/access_token";
-
 export const reddit = {
   reddit: {
     label: "Reddit",
@@ -30,12 +28,10 @@ export const reddit = {
         },
         grant: {
           kind: "auth-code",
-          tokenUrl: OAUTH_TOKEN_URL,
           scopes: ["identity", "read"],
         },
         access: {
           kind: "refresh-token",
-          tokenUrl: OAUTH_TOKEN_URL,
           envBindings: {
             REDDIT_TOKEN: "$secrets.REDDIT_ACCESS_TOKEN",
           },

--- a/turbo/packages/connectors/src/connectors/sentry.ts
+++ b/turbo/packages/connectors/src/connectors/sentry.ts
@@ -1,7 +1,5 @@
 import type { ConnectorConfig } from "../connectors";
 
-const OAUTH_TOKEN_URL = "https://sentry.io/oauth/token/";
-
 export const sentry = {
   sentry: {
     label: "Sentry",
@@ -28,7 +26,6 @@ export const sentry = {
         },
         grant: {
           kind: "auth-code",
-          tokenUrl: OAUTH_TOKEN_URL,
           scopes: [
             "org:read",
             "project:read",
@@ -40,7 +37,6 @@ export const sentry = {
         },
         access: {
           kind: "refresh-token",
-          tokenUrl: OAUTH_TOKEN_URL,
           envBindings: {
             SENTRY_TOKEN: "$secrets.SENTRY_ACCESS_TOKEN",
           },

--- a/turbo/packages/connectors/src/connectors/slack.ts
+++ b/turbo/packages/connectors/src/connectors/slack.ts
@@ -25,7 +25,6 @@ export const slack = {
         },
         grant: {
           kind: "auth-code",
-          tokenUrl: "https://slack.com/api/oauth.v2.access",
           scopes: [
             // Channels
             "channels:read",

--- a/turbo/packages/connectors/src/connectors/slock.ts
+++ b/turbo/packages/connectors/src/connectors/slock.ts
@@ -1,9 +1,5 @@
 import type { ConnectorConfig } from "../connectors";
 
-const SLOCK_API_BASE_URL = "https://api.slock.ai";
-const SLOCK_DEVICE_TOKEN_URL = `${SLOCK_API_BASE_URL}/api/auth/device/token`;
-const SLOCK_REFRESH_TOKEN_URL = `${SLOCK_API_BASE_URL}/api/auth/refresh`;
-
 export const slock = {
   slock: {
     label: "Slock",
@@ -32,13 +28,10 @@ export const slock = {
         },
         grant: {
           kind: "device-auth",
-          deviceAuthUrl: `${SLOCK_API_BASE_URL}/api/auth/device/authorize`,
-          tokenUrl: SLOCK_DEVICE_TOKEN_URL,
           scopes: [],
         },
         access: {
           kind: "refresh-token",
-          tokenUrl: SLOCK_REFRESH_TOKEN_URL,
           envBindings: {
             SLOCK_TOKEN: "$secrets.SLOCK_ACCESS_TOKEN",
             SLOCK_SERVER_ID: "$secrets.SLOCK_SERVER_ID",

--- a/turbo/packages/connectors/src/connectors/spotify.ts
+++ b/turbo/packages/connectors/src/connectors/spotify.ts
@@ -1,8 +1,6 @@
 import type { ConnectorConfig } from "../connectors";
 import { FeatureSwitchKey } from "../feature-switch-key";
 
-const OAUTH_TOKEN_URL = "https://accounts.spotify.com/api/token";
-
 export const spotify = {
   spotify: {
     label: "Spotify",
@@ -30,7 +28,6 @@ export const spotify = {
         },
         grant: {
           kind: "auth-code",
-          tokenUrl: OAUTH_TOKEN_URL,
           scopes: [
             "ugc-image-upload",
             "user-read-playback-state",
@@ -55,7 +52,6 @@ export const spotify = {
         },
         access: {
           kind: "refresh-token",
-          tokenUrl: OAUTH_TOKEN_URL,
           envBindings: {
             SPOTIFY_TOKEN: "$secrets.SPOTIFY_ACCESS_TOKEN",
           },

--- a/turbo/packages/connectors/src/connectors/strava.ts
+++ b/turbo/packages/connectors/src/connectors/strava.ts
@@ -1,7 +1,5 @@
 import type { ConnectorConfig } from "../connectors";
 
-const OAUTH_TOKEN_URL = "https://www.strava.com/oauth/token";
-
 export const strava = {
   strava: {
     label: "Strava",
@@ -28,7 +26,6 @@ export const strava = {
         },
         grant: {
           kind: "auth-code",
-          tokenUrl: OAUTH_TOKEN_URL,
           scopes: [
             "read",
             "profile:read_all",
@@ -38,7 +35,6 @@ export const strava = {
         },
         access: {
           kind: "refresh-token",
-          tokenUrl: OAUTH_TOKEN_URL,
           envBindings: {
             STRAVA_TOKEN: "$secrets.STRAVA_ACCESS_TOKEN",
           },

--- a/turbo/packages/connectors/src/connectors/stripe.ts
+++ b/turbo/packages/connectors/src/connectors/stripe.ts
@@ -1,8 +1,6 @@
 import type { ConnectorConfig } from "../connectors";
 import { FeatureSwitchKey } from "../feature-switch-key";
 
-const OAUTH_TOKEN_URL = "https://connect.stripe.com/oauth/token";
-
 export const stripe = {
   stripe: {
     label: "Stripe",
@@ -31,12 +29,10 @@ export const stripe = {
         },
         grant: {
           kind: "auth-code",
-          tokenUrl: OAUTH_TOKEN_URL,
           scopes: ["read_write"],
         },
         access: {
           kind: "refresh-token",
-          tokenUrl: OAUTH_TOKEN_URL,
           envBindings: {
             STRIPE_TOKEN: "$secrets.STRIPE_ACCESS_TOKEN",
           },

--- a/turbo/packages/connectors/src/connectors/supabase.ts
+++ b/turbo/packages/connectors/src/connectors/supabase.ts
@@ -1,8 +1,6 @@
 import type { ConnectorConfig } from "../connectors";
 import { FeatureSwitchKey } from "../feature-switch-key";
 
-const OAUTH_TOKEN_URL = "https://api.supabase.com/v1/oauth/token";
-
 export const supabase = {
   supabase: {
     label: "Supabase",
@@ -30,7 +28,6 @@ export const supabase = {
         },
         grant: {
           kind: "auth-code",
-          tokenUrl: OAUTH_TOKEN_URL,
           scopes: [
             "organizations:read",
             "projects:read",
@@ -48,7 +45,6 @@ export const supabase = {
         },
         access: {
           kind: "refresh-token",
-          tokenUrl: OAUTH_TOKEN_URL,
           envBindings: {
             SUPABASE_TOKEN: "$secrets.SUPABASE_ACCESS_TOKEN",
           },

--- a/turbo/packages/connectors/src/connectors/test-oauth-device.ts
+++ b/turbo/packages/connectors/src/connectors/test-oauth-device.ts
@@ -26,8 +26,6 @@ export const testOauthDevice = {
         },
         grant: {
           kind: "device-auth",
-          deviceAuthUrl: "/api/test/oauth-provider/device/code",
-          tokenUrl: "/api/test/oauth-provider/token",
           scopes: ["read"],
         },
         access: {
@@ -57,8 +55,6 @@ export const testOauthDevice = {
         },
         grant: {
           kind: "device-auth",
-          deviceAuthUrl: "/api/test/oauth-provider/device/code",
-          tokenUrl: "/api/test/oauth-provider/token",
           scopes: ["read"],
         },
         access: {

--- a/turbo/packages/connectors/src/connectors/test-oauth.ts
+++ b/turbo/packages/connectors/src/connectors/test-oauth.ts
@@ -6,8 +6,6 @@ import type {
 } from "../connectors";
 import { FeatureSwitchKey } from "../feature-switch-key";
 
-const OAUTH_TOKEN_URL = "/api/test/oauth-provider/token";
-
 const TEST_OAUTH_CLIENT = {
   clientRegistration: "static",
   clientType: "confidential",
@@ -17,7 +15,6 @@ const TEST_OAUTH_CLIENT = {
 
 const TEST_OAUTH_AUTH_CODE_GRANT = {
   kind: "auth-code",
-  tokenUrl: OAUTH_TOKEN_URL,
   scopes: ["read"],
 } satisfies ConnectorAuthCodeGrantConfig;
 
@@ -46,7 +43,6 @@ export const testOauth = {
         grant: TEST_OAUTH_AUTH_CODE_GRANT,
         access: {
           kind: "refresh-token",
-          tokenUrl: OAUTH_TOKEN_URL,
           envBindings: {
             TEST_OAUTH_TOKEN: "$secrets.TEST_OAUTH_ACCESS_TOKEN",
           },
@@ -73,7 +69,6 @@ export const testOauth = {
         grant: TEST_OAUTH_AUTH_CODE_GRANT,
         access: {
           kind: "refresh-token",
-          tokenUrl: OAUTH_TOKEN_URL,
           envBindings: {
             TEST_OAUTH_TOKEN: "$secrets.TEST_OAUTH_API_ACCESS_TOKEN",
           },

--- a/turbo/packages/connectors/src/connectors/todoist.ts
+++ b/turbo/packages/connectors/src/connectors/todoist.ts
@@ -25,7 +25,6 @@ export const todoist = {
         },
         grant: {
           kind: "auth-code",
-          tokenUrl: "https://todoist.com/oauth/access_token",
           scopes: ["data:read_write", "data:delete", "project:delete"],
         },
         access: {

--- a/turbo/packages/connectors/src/connectors/vercel.ts
+++ b/turbo/packages/connectors/src/connectors/vercel.ts
@@ -25,7 +25,6 @@ export const vercel = {
         },
         grant: {
           kind: "auth-code",
-          tokenUrl: "https://api.vercel.com/v2/oauth/access_token",
           scopes: [],
         },
         access: {

--- a/turbo/packages/connectors/src/connectors/webflow.ts
+++ b/turbo/packages/connectors/src/connectors/webflow.ts
@@ -27,7 +27,6 @@ export const webflow = {
         },
         grant: {
           kind: "auth-code",
-          tokenUrl: "https://api.webflow.com/oauth/access_token",
           scopes: [
             "authorized_user:read",
             "sites:read",

--- a/turbo/packages/connectors/src/connectors/x.ts
+++ b/turbo/packages/connectors/src/connectors/x.ts
@@ -1,7 +1,5 @@
 import type { ConnectorConfig } from "../connectors";
 
-const OAUTH_TOKEN_URL = "https://api.x.com/2/oauth2/token";
-
 export const x = {
   x: {
     label: "X",
@@ -28,7 +26,6 @@ export const x = {
         },
         grant: {
           kind: "auth-code",
-          tokenUrl: OAUTH_TOKEN_URL,
           scopes: [
             "tweet.read", // All the Tweets you can view, including Tweets from protected accounts.
             "tweet.write", // Tweet and Retweet for you.
@@ -56,7 +53,6 @@ export const x = {
         },
         access: {
           kind: "refresh-token",
-          tokenUrl: OAUTH_TOKEN_URL,
           envBindings: {
             X_TOKEN: "$secrets.X_ACCESS_TOKEN",
           },

--- a/turbo/packages/connectors/src/connectors/xero.ts
+++ b/turbo/packages/connectors/src/connectors/xero.ts
@@ -1,7 +1,5 @@
 import type { ConnectorConfig } from "../connectors";
 
-const OAUTH_TOKEN_URL = "https://identity.xero.com/connect/token";
-
 export const xero = {
   xero: {
     label: "Xero",
@@ -28,7 +26,6 @@ export const xero = {
         },
         grant: {
           kind: "auth-code",
-          tokenUrl: OAUTH_TOKEN_URL,
           scopes: [
             "openid",
             "profile",
@@ -56,7 +53,6 @@ export const xero = {
         },
         access: {
           kind: "refresh-token",
-          tokenUrl: OAUTH_TOKEN_URL,
           envBindings: {
             XERO_TOKEN: "$secrets.XERO_ACCESS_TOKEN",
           },

--- a/turbo/packages/connectors/src/connectors/zoom.ts
+++ b/turbo/packages/connectors/src/connectors/zoom.ts
@@ -1,8 +1,6 @@
 import type { ConnectorConfig } from "../connectors";
 import { FeatureSwitchKey } from "../feature-switch-key";
 
-const OAUTH_TOKEN_URL = "https://zoom.us/oauth/token";
-
 export const zoom = {
   zoom: {
     label: "Zoom",
@@ -30,7 +28,6 @@ export const zoom = {
         },
         grant: {
           kind: "auth-code",
-          tokenUrl: OAUTH_TOKEN_URL,
           scopes: [
             "user:read:user",
             "meeting:read:list_meetings",
@@ -50,7 +47,6 @@ export const zoom = {
         },
         access: {
           kind: "refresh-token",
-          tokenUrl: OAUTH_TOKEN_URL,
           envBindings: {
             ZOOM_TOKEN: "$secrets.ZOOM_ACCESS_TOKEN",
           },


### PR DESCRIPTION
## Summary
- remove auth-code, device-auth, and refresh-token endpoint URLs from connector config types and registry entries
- move OAuth token/device endpoints into connector auth providers and shared provider helpers
- update connector/provider/API tests to use the provider-owned endpoint boundary

## Tests
- pnpm format
- pnpm -F @vm0/connectors lint
- pnpm -F api lint
- pnpm check-types
- pnpm -F @vm0/connectors exec vitest src/__tests__/connectors.test.ts
- pnpm -F @vm0/connectors exec vitest src/auth-providers/oauth/providers/__tests__
- pnpm -F api exec vitest src/signals/routes/__tests__/zero-connectors-oauth-device-auth.test.ts

Closes #15940