### PR TITLE
fix: intercept relative memory links to switch files instead of 404

### DIFF
--- a/turbo/apps/platform/src/views/memory-page/__tests__/memory-page.test.tsx
+++ b/turbo/apps/platform/src/views/memory-page/__tests__/memory-page.test.tsx
@@ -119,4 +119,54 @@ describe("memory page", () => {
     expect(fileButtons[1]?.textContent).toContain("context.md");
     expect(fileButtons[2]?.textContent).toContain("scratch.txt");
   });
+
+  it("switches files when a relative link to another memory file is clicked", async () => {
+    setMockMemory({
+      exists: true,
+      name: "memory",
+      size: 90,
+      fileCount: 2,
+      updatedAt: "2024-01-01T00:00:00Z",
+      files: [
+        { path: "MEMORY.md", size: 60 },
+        { path: "other-note.md", size: 30 },
+      ],
+      fileContents: [
+        {
+          path: "MEMORY.md",
+          content: "# Memory Index\n\n- [Other note](other-note.md) — details",
+        },
+        {
+          path: "other-note.md",
+          content: "# Other Note\n\nDeep content here.",
+        },
+      ],
+    });
+
+    detachedSetupPage({
+      context,
+      path: "/memory",
+      featureSwitches: { [FeatureSwitchKey.MemoryViewer]: true },
+    });
+
+    // Defaults to MEMORY.md, which renders the relative link to other-note.md.
+    await waitFor(() => {
+      expect(screen.getByLabelText("Memory content")).toHaveTextContent(
+        "Other note",
+      );
+    });
+
+    const internalLink = queryAllByRoleFast("link").find((link) => {
+      return link.textContent?.includes("Other note");
+    });
+    expect(internalLink).toBeDefined();
+    click(internalLink!);
+
+    // Clicking switches the viewer instead of navigating away to a 404.
+    await waitFor(() => {
+      expect(screen.getByLabelText("Memory content")).toHaveTextContent(
+        "Deep content here.",
+      );
+    });
+  });
 });

--- a/turbo/apps/platform/src/views/memory-page/__tests__/memory-page.test.tsx
+++ b/turbo/apps/platform/src/views/memory-page/__tests__/memory-page.test.tsx
@@ -169,4 +169,55 @@ describe("memory page", () => {
       );
     });
   });
+
+  it("leaves external links untouched so the browser handles them", async () => {
+    setMockMemory({
+      exists: true,
+      name: "memory",
+      size: 90,
+      fileCount: 2,
+      updatedAt: "2024-01-01T00:00:00Z",
+      files: [
+        { path: "MEMORY.md", size: 60 },
+        { path: "other-note.md", size: 30 },
+      ],
+      fileContents: [
+        {
+          path: "MEMORY.md",
+          content:
+            "# Memory Index\n\n- [Docs](https://example.com/docs) — external",
+        },
+        {
+          path: "other-note.md",
+          content: "# Other Note\n\nDeep content here.",
+        },
+      ],
+    });
+
+    detachedSetupPage({
+      context,
+      path: "/memory",
+      featureSwitches: { [FeatureSwitchKey.MemoryViewer]: true },
+    });
+
+    // Defaults to MEMORY.md, which renders an absolute external link.
+    await waitFor(() => {
+      expect(screen.getByLabelText("Memory content")).toHaveTextContent("Docs");
+    });
+
+    const externalLink = queryAllByRoleFast("link").find((link) => {
+      return link.textContent?.includes("Docs");
+    });
+    expect(externalLink).toBeDefined();
+    // The link keeps its absolute href so the browser (not the viewer) owns it.
+    expect(externalLink!.getAttribute("href")).toBe("https://example.com/docs");
+    click(externalLink!);
+
+    // External links are not memory files, so the handler must not intercept
+    // them: the viewer stays on MEMORY.md rather than switching to a sibling.
+    expect(screen.getByLabelText("Memory content")).toHaveTextContent("Docs");
+    expect(screen.getByLabelText("Memory content")).not.toHaveTextContent(
+      "Deep content here.",
+    );
+  });
 });

--- a/turbo/apps/platform/src/views/memory-page/memory-page.tsx
+++ b/turbo/apps/platform/src/views/memory-page/memory-page.tsx
@@ -44,6 +44,54 @@ function formatBytes(bytes: number): string {
   return `${(kib / 1024).toFixed(1)} MiB`;
 }
 
+interface MemoryViewerState {
+  readonly files: MemoryDetailResponse["files"];
+  readonly selectedPath: string | null;
+  readonly selectedContent: string | null;
+  readonly knownPaths: ReadonlySet<string>;
+}
+
+function deriveMemoryViewerState(
+  detail: MemoryDetailResponse,
+  explicitSelected: string | null,
+): MemoryViewerState {
+  // MEMORY.md is the index of all memory, so pin it to the top; the rest stay
+  // sorted alphabetically.
+  const files = [...detail.files].sort((a, b) => {
+    if (a.path === PREFERRED_FILE) {
+      return -1;
+    }
+    if (b.path === PREFERRED_FILE) {
+      return 1;
+    }
+    return a.path.localeCompare(b.path);
+  });
+  const preferredPath =
+    files.find((file) => {
+      return file.path === PREFERRED_FILE;
+    })?.path ??
+    files[0]?.path ??
+    null;
+  const selectedPath =
+    explicitSelected !== null &&
+    files.some((file) => {
+      return file.path === explicitSelected;
+    })
+      ? explicitSelected
+      : preferredPath;
+  const selectedContent = selectedPath
+    ? (detail.fileContents.find((file) => {
+        return file.path === selectedPath;
+      })?.content ?? null)
+    : null;
+  const knownPaths = new Set(
+    files.map((file) => {
+      return file.path;
+    }),
+  );
+  return { files, selectedPath, selectedContent, knownPaths };
+}
+
 export function MemoryPage() {
   const detailLoadable = useLoadable(memoryDetail$);
   const detail =
@@ -86,41 +134,8 @@ function MemoryViewer({ detail }: { readonly detail: MemoryDetailResponse }) {
   const explicitSelected = useGet(selectedMemoryFilePath$);
   const setSelected = useSet(setSelectedMemoryFilePath$);
 
-  // MEMORY.md is the index of all memory, so pin it to the top; the rest stay
-  // sorted alphabetically.
-  const files = [...detail.files].sort((a, b) => {
-    if (a.path === PREFERRED_FILE) {
-      return -1;
-    }
-    if (b.path === PREFERRED_FILE) {
-      return 1;
-    }
-    return a.path.localeCompare(b.path);
-  });
-  const preferredPath =
-    files.find((file) => {
-      return file.path === PREFERRED_FILE;
-    })?.path ??
-    files[0]?.path ??
-    null;
-  const selectedPath =
-    explicitSelected !== null &&
-    files.some((file) => {
-      return file.path === explicitSelected;
-    })
-      ? explicitSelected
-      : preferredPath;
-  const selectedContent = selectedPath
-    ? (detail.fileContents.find((file) => {
-        return file.path === selectedPath;
-      })?.content ?? null)
-    : null;
-
-  const knownPaths = new Set(
-    files.map((file) => {
-      return file.path;
-    }),
-  );
+  const { files, selectedPath, selectedContent, knownPaths } =
+    deriveMemoryViewerState(detail, explicitSelected);
 
   // Links between memory files render as relative anchors (e.g.
   // `[foo](foo.md)`). Left alone they navigate the browser to a non-existent

--- a/turbo/apps/platform/src/views/memory-page/memory-page.tsx
+++ b/turbo/apps/platform/src/views/memory-page/memory-page.tsx
@@ -1,4 +1,5 @@
 import { useGet, useLoadable, useSet } from "ccstate-react";
+import type { MouseEvent } from "react";
 import type { MemoryDetailResponse } from "@vm0/api-contracts/contracts/zero-memory";
 import { cn } from "@vm0/ui";
 
@@ -13,6 +14,23 @@ const PREFERRED_FILE = "MEMORY.md";
 
 function isMarkdown(path: string): boolean {
   return path.toLowerCase().endsWith(".md");
+}
+
+/**
+ * Resolve a markdown link href to a memory file path, or null when the link
+ * points outside the memory tree (absolute URL, in-page anchor, or root path).
+ * Memory files reference each other with plain relative paths in MEMORY.md, so
+ * we only intercept those and let the browser handle everything else.
+ */
+function resolveMemoryLinkPath(href: string): string | null {
+  if (
+    /^[a-z][a-z0-9+.-]*:/i.test(href) ||
+    href.startsWith("#") ||
+    href.startsWith("/")
+  ) {
+    return null;
+  }
+  return href.replace(/[?#].*$/, "").replace(/^\.\//, "");
 }
 
 function formatBytes(bytes: number): string {
@@ -98,6 +116,36 @@ function MemoryViewer({ detail }: { readonly detail: MemoryDetailResponse }) {
       })?.content ?? null)
     : null;
 
+  const knownPaths = new Set(
+    files.map((file) => {
+      return file.path;
+    }),
+  );
+
+  // Links between memory files render as relative anchors (e.g.
+  // `[foo](foo.md)`). Left alone they navigate the browser to a non-existent
+  // route and 404, so intercept clicks that resolve to a known file and switch
+  // the viewer instead. External links fall through to the browser.
+  const handleContentClick = (event: MouseEvent<HTMLDivElement>) => {
+    if (!(event.target instanceof Element)) {
+      return;
+    }
+    const anchor = event.target.closest("a");
+    if (anchor === null) {
+      return;
+    }
+    const href = anchor.getAttribute("href");
+    if (href === null) {
+      return;
+    }
+    const targetPath = resolveMemoryLinkPath(href);
+    if (targetPath === null || !knownPaths.has(targetPath)) {
+      return;
+    }
+    event.preventDefault();
+    setSelected(targetPath);
+  };
+
   return (
     <section className="zero-card flex min-h-[420px] flex-1 flex-col overflow-hidden">
       <div className="flex min-h-0 flex-1 flex-col lg:flex-row">
@@ -113,6 +161,7 @@ function MemoryViewer({ detail }: { readonly detail: MemoryDetailResponse }) {
               <div
                 aria-label="Memory content"
                 className="min-h-0 flex-1 overflow-auto bg-background px-4 py-3"
+                onClick={handleContentClick}
               >
                 <Markdown source={selectedContent} />
               </div>


### PR DESCRIPTION
## Problem

On the Memory page (`/memory`), `MEMORY.md` indexes other memory files with relative markdown links like `[apps/api ccstate rule](apps-api-ccstate-getset-params.md)`. The shared `Markdown` component renders these as plain `<a href="…">` with `target="_blank"`, so clicking one resolved the relative href against the current path:

```
base  https://app.vm0.ai/memory   (no trailing slash)
href  feedback_zero_search_recall.md
  →   https://app.vm0.ai/feedback_zero_search_recall.md   → 404 (no such SPA route)
```

The viewer already has every file's content in hand (`detail.fileContents` from a single `GET /api/zero/memory`) and switches files via the `selectedMemoryFilePath$` signal — so these links should switch the viewer, exactly like the sidebar, not navigate away.

## Fix (Approach A — localized to the Memory page)

Intercept clicks in the markdown content container. When the clicked anchor's **raw** href (`getAttribute("href")`, not the browser-resolved absolute) resolves to a known memory file, `preventDefault()` and switch via the existing signal. External links (absolute URLs, `mailto:`, in-page `#anchors`, root `/` paths) fall through to the browser untouched.

The shared `Markdown` component is intentionally **not** modified: its `<a>`/`<img>` renderers are deliberately module-scoped for stable identity (to avoid tearing down `<video>`/`<img>` subtrees on re-render), and "navigate within the memory tree" is behavior specific to this one page. Event delegation keeps the change contained to `memory-page.tsx`.

## Changes

- `memory-page.tsx`: add `resolveMemoryLinkPath()` helper + a click handler on the `Memory content` container; wire `onClick`.
- `memory-page.test.tsx`: add a case asserting that clicking a relative link to another memory file switches the viewer (rather than navigating to a 404).

## Verification

- `pnpm -F @vm0/app run test src/views/memory-page` — 4 passed
- `pnpm -F @vm0/app run check-types` — clean
- `pnpm -F @vm0/app run lint` (oxlint ×2 + eslint) — 0 warnings, 0 errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)