### PR TITLE
fix(mitm-addon): bound usage webhook delivery queue

### DIFF
--- a/crates/runner/mitm-addon/src/usage/buffer.py
+++ b/crates/runner/mitm-addon/src/usage/buffer.py
@@ -100,6 +100,7 @@ class _FlushSummary:
     source_event_count: int = 0
     aggregate_event_count: int = 0
     webhook_batch_count: int = 0
+    dropped_webhook_batch_count: int = 0
     run_ids: set[str] = field(default_factory=set)
     destinations: set[tuple[str, str]] = field(default_factory=set)
 
@@ -208,7 +209,7 @@ class UsageEventBuffer:
         started_at = time.monotonic()
         try:
             _log_flush_summaries("started", trigger, flush_sequence, summaries)
-            _enqueue_batches(batches)
+            _apply_dropped_batch_counts(summaries, _enqueue_batches(batches))
             _log_flush_summaries(
                 "completed",
                 trigger,
@@ -416,15 +417,29 @@ class UsageEventBuffer:
         return threading.Timer(delay, callback)
 
 
-def _enqueue_batches(batches: Iterable[_FlushBatch]) -> None:
+def _enqueue_batches(batches: Iterable[_FlushBatch]) -> dict[str, int]:
+    dropped_counts: dict[str, int] = {}
     for batch in batches:
-        _enqueue_webhook(
+        admitted = _enqueue_webhook(
             batch.url,
             batch.sandbox_token,
             batch.payload,
             batch.proxy_log_path,
             "usage_event",
         )
+        if admitted is False:
+            dropped_counts[batch.proxy_log_path] = dropped_counts.get(batch.proxy_log_path, 0) + 1
+    return dropped_counts
+
+
+def _apply_dropped_batch_counts(
+    summaries: Iterable[_FlushSummary],
+    dropped_counts: dict[str, int],
+) -> None:
+    if not dropped_counts:
+        return
+    for summary in summaries:
+        summary.dropped_webhook_batch_count = dropped_counts.get(summary.proxy_log_path, 0)
 
 
 def _build_flush_summaries(
@@ -476,6 +491,7 @@ def _log_flush_summaries(
             "source_event_count": summary.source_event_count,
             "aggregate_event_count": summary.aggregate_event_count,
             "webhook_batch_count": summary.webhook_batch_count,
+            "dropped_webhook_batch_count": summary.dropped_webhook_batch_count,
             "run_count": len(summary.run_ids),
             "destination_count": len(summary.destinations),
         }
@@ -483,10 +499,15 @@ def _log_flush_summaries(
             extra["duration_ms"] = duration_ms
         if error_type is not None:
             extra["error_type"] = error_type
+        level = "error" if phase == "failed" else "info"
+        message = f"Usage event buffer flush {phase}"
+        if phase == "completed" and summary.dropped_webhook_batch_count:
+            level = "warn"
+            message = "Usage event buffer flush completed with dropped webhook batches"
         log_proxy_entry(
             summary.proxy_log_path,
-            "error" if phase == "failed" else "info",
-            f"Usage event buffer flush {phase}",
+            level,
+            message,
             **extra,
         )
 

--- a/crates/runner/mitm-addon/src/usage/webhook.py
+++ b/crates/runner/mitm-addon/src/usage/webhook.py
@@ -8,6 +8,7 @@ reports are not silently lost.
 """
 
 import json
+import threading
 import time
 import urllib.error
 import urllib.request
@@ -58,6 +59,7 @@ def _log_webhook_entry(
     payload_bytes: int | None = None,
     attempt: int | None = None,
     error: str | None = None,
+    extra_fields: dict[str, object] | None = None,
 ) -> None:
     extra: dict = {"type": log_type, "url": url}
     extra.update(_payload_log_summary(payload))
@@ -67,6 +69,8 @@ def _log_webhook_entry(
         extra["attempt"] = attempt
     if error is not None:
         extra["error"] = error
+    if extra_fields is not None:
+        extra.update(extra_fields)
     log_proxy_entry(proxy_log_path, level, message, **extra)
 
 
@@ -192,7 +196,61 @@ def _do_post_webhook_attempts(
             raise
 
 
-usage_executor = ThreadPoolExecutor(max_workers=4, thread_name_prefix="usage")
+USAGE_WEBHOOK_WORKERS = 4
+MAX_PENDING_WEBHOOK_PAYLOADS = USAGE_WEBHOOK_WORKERS * 4
+
+usage_executor = ThreadPoolExecutor(
+    max_workers=USAGE_WEBHOOK_WORKERS,
+    thread_name_prefix="usage",
+)
+
+_delivery_capacity_lock = threading.Lock()
+_pending_delivery_payloads = 0
+
+
+def _try_acquire_delivery_capacity() -> int | None:
+    global _pending_delivery_payloads
+    with _delivery_capacity_lock:
+        if _pending_delivery_payloads >= MAX_PENDING_WEBHOOK_PAYLOADS:
+            return None
+        _pending_delivery_payloads += 1
+        return _pending_delivery_payloads
+
+
+def _release_delivery_capacity() -> None:
+    global _pending_delivery_payloads
+    with _delivery_capacity_lock:
+        if _pending_delivery_payloads <= 0:
+            raise RuntimeError("usage webhook delivery capacity released without acquire")
+        _pending_delivery_payloads -= 1
+
+
+def _pending_delivery_payload_count() -> int:
+    with _delivery_capacity_lock:
+        return _pending_delivery_payloads
+
+
+def _pending_delivery_payload_count_for_tests() -> int:
+    return _pending_delivery_payload_count()
+
+
+def reset_delivery_capacity_for_tests() -> None:
+    global _pending_delivery_payloads
+    with _delivery_capacity_lock:
+        _pending_delivery_payloads = 0
+
+
+def _post_admitted_webhook_with_retry(
+    url: str,
+    sandbox_token: str,
+    payload: dict,
+    proxy_log_path: str,
+    log_type: str,
+) -> None:
+    try:
+        _post_webhook_with_retry(url, sandbox_token, payload, proxy_log_path, log_type)
+    finally:
+        _release_delivery_capacity()
 
 
 def _enqueue_webhook(
@@ -201,7 +259,7 @@ def _enqueue_webhook(
     payload: dict,
     proxy_log_path: str,
     log_type: str,
-) -> None:
+) -> bool:
     """Submit webhook POST to the thread pool.
 
     The caller transfers ownership of ``payload`` to webhook delivery and
@@ -209,30 +267,68 @@ def _enqueue_webhook(
 
     If the executor has already been shut down (drain/shutdown race),
     falls back to synchronous delivery so the report is not silently lost.
+
+    Returns whether the payload was admitted to delivery.  ``False`` means
+    delivery was saturated and the payload was explicitly dropped.
     """
-    _log_webhook_entry(
-        proxy_log_path,
-        "info",
-        f"Webhook POST to {url} enqueued",
-        url,
-        log_type,
-        payload,
-    )
+    admitted_count = _try_acquire_delivery_capacity()
+    if admitted_count is None:
+        _log_webhook_entry(
+            proxy_log_path,
+            "warn",
+            f"Webhook POST to {url} dropped because usage delivery is saturated",
+            url,
+            log_type,
+            payload,
+            extra_fields={
+                "webhook_delivery_capacity": MAX_PENDING_WEBHOOK_PAYLOADS,
+                "webhook_delivery_pending": _pending_delivery_payload_count(),
+            },
+        )
+        return False
+
+    try:
+        _log_webhook_entry(
+            proxy_log_path,
+            "info",
+            f"Webhook POST to {url} enqueued",
+            url,
+            log_type,
+            payload,
+            extra_fields={
+                "webhook_delivery_capacity": MAX_PENDING_WEBHOOK_PAYLOADS,
+                "webhook_delivery_pending": admitted_count,
+            },
+        )
+    except Exception:
+        _release_delivery_capacity()
+        raise
+
     increment_pending_reports()
     try:
         usage_executor.submit(
-            _post_webhook_with_retry, url, sandbox_token, payload, proxy_log_path, log_type
+            _post_admitted_webhook_with_retry,
+            url,
+            sandbox_token,
+            payload,
+            proxy_log_path,
+            log_type,
         )
     except RuntimeError:
         # Executor shut down (done() already called during drain).
-        log_proxy_entry(
-            proxy_log_path,
-            "warn",
-            "Webhook executor shut down, falling back to synchronous delivery",
-            type=log_type,
-            url=url,
-        )
-        _post_webhook_with_retry(url, sandbox_token, payload, proxy_log_path, log_type)
+        try:
+            log_proxy_entry(
+                proxy_log_path,
+                "warn",
+                "Webhook executor shut down, falling back to synchronous delivery",
+                type=log_type,
+                url=url,
+            )
+            _post_webhook_with_retry(url, sandbox_token, payload, proxy_log_path, log_type)
+        finally:
+            _release_delivery_capacity()
     except Exception:
         decrement_pending_reports()
+        _release_delivery_capacity()
         raise
+    return True

--- a/crates/runner/mitm-addon/tests/conftest.py
+++ b/crates/runner/mitm-addon/tests/conftest.py
@@ -48,9 +48,11 @@ def _reset_module_state() -> Iterator[None]:
     clear_auth_state()
     _usage_connectors._unregistered_handler_warned.clear()
     usage.counters.reset_for_tests()
+    usage.webhook.reset_delivery_capacity_for_tests()
     usage.reset_usage_buffer_for_tests()
     yield
     usage.reset_usage_buffer_for_tests()
+    usage.webhook.reset_delivery_capacity_for_tests()
     usage.counters.reset_for_tests()
 
 

--- a/crates/runner/mitm-addon/tests/test_counters.py
+++ b/crates/runner/mitm-addon/tests/test_counters.py
@@ -183,6 +183,7 @@ class TestUsagePendingCounter:
             )
 
         assert usage.counters._pending_reports == 0
+        assert usage.webhook._pending_delivery_payload_count_for_tests() == 0
         usage.write_pending_snapshot(flush_request_id="request-1")
         assert_pending(pending_path, flows=0, buffered=0, reports=0, flush_request_id="request-1")
 
@@ -331,6 +332,7 @@ class TestUsagePendingCounter:
             usage.webhook.usage_executor.shutdown(wait=True)
 
         assert usage.counters._pending_reports == 0
+        assert usage.webhook._pending_delivery_payload_count_for_tests() == 0
         usage.write_pending_snapshot(flush_request_id="request-1")
         assert_pending(pending_path, flows=0, buffered=0, reports=0, flush_request_id="request-1")
 
@@ -354,6 +356,7 @@ class TestUsagePendingCounter:
             usage.webhook.usage_executor.shutdown(wait=True)
 
         assert usage.counters._pending_reports == 0
+        assert usage.webhook._pending_delivery_payload_count_for_tests() == 0
         usage.write_pending_snapshot(flush_request_id="request-1")
         assert_pending(pending_path, flows=0, buffered=0, reports=0, flush_request_id="request-1")
 
@@ -414,5 +417,6 @@ class TestUsagePendingCounter:
             usage.flush_usage_events(trigger="test")
 
         assert usage.counters._pending_reports == 0
+        assert usage.webhook._pending_delivery_payload_count_for_tests() == 0
         usage.write_pending_snapshot(flush_request_id="request-1")
         assert_pending(pending_path, flows=0, buffered=0, reports=0, flush_request_id="request-1")

--- a/crates/runner/mitm-addon/tests/test_usage_buffer.py
+++ b/crates/runner/mitm-addon/tests/test_usage_buffer.py
@@ -305,6 +305,32 @@ def test_flush_logs_aggregate_summary_without_token(tmp_path):
     assert entries[1]["duration_ms"] >= 0
 
 
+def test_flush_logs_dropped_webhook_batches(tmp_path):
+    proxy_log_path = tmp_path / "proxy.jsonl"
+    usage.buffer_usage_events(
+        "https://api.test/api/webhooks/agent/usage-event",
+        "secret-token",
+        "run-1",
+        [_event(source_key="source-1")],
+        str(proxy_log_path),
+    )
+
+    with patch.object(usage_buffer, "_enqueue_webhook", return_value=False) as enqueue:
+        assert usage.flush_usage_events(trigger="test") == 1
+
+    enqueue.assert_called_once()
+    entries = _flush_log_entries(proxy_log_path)
+    assert [entry["phase"] for entry in entries] == ["started", "completed"]
+    assert entries[0]["dropped_webhook_batch_count"] == 0
+    assert entries[1]["level"] == "warn"
+    assert entries[1]["message"] == (
+        "Usage event buffer flush completed with dropped webhook batches"
+    )
+    assert entries[1]["dropped_webhook_batch_count"] == 1
+    assert entries[1]["webhook_batch_count"] == 1
+    assert "secret-token" not in json.dumps(entries)
+
+
 def test_flush_logs_failure_without_token(tmp_path):
     proxy_log_path = tmp_path / "proxy.jsonl"
     usage.buffer_usage_events(

--- a/crates/runner/mitm-addon/tests/test_webhook.py
+++ b/crates/runner/mitm-addon/tests/test_webhook.py
@@ -3,6 +3,7 @@
 import json
 import urllib.error
 import uuid
+from concurrent.futures import Future
 from pathlib import Path
 from unittest.mock import patch
 
@@ -10,6 +11,16 @@ import pytest
 
 import auth
 import usage
+
+
+class _QueuedUsageExecutor:
+    def __init__(self) -> None:
+        self.submissions: list[tuple[object, tuple[object, ...], dict[str, object]]] = []
+
+    def submit(self, fn, *args, **kwargs) -> Future:
+        future: Future = Future()
+        self.submissions.append((fn, args, kwargs))
+        return future
 
 
 def _assert_body_free_webhook_entry(
@@ -270,6 +281,7 @@ class TestUsageWebhookDelivery:
         )
 
         assert usage.counters._pending_reports == 1
+        assert usage.webhook._pending_delivery_payload_count_for_tests() == 0
         assert "non-retryable" in proxy_log.read_text()
         with pytest.raises(ValueError, match="absolute http"):
             sync_usage_executor.shutdown(wait=True)
@@ -373,3 +385,85 @@ class TestUsageWebhookDelivery:
         assert body["runId"] == "run-1"
         assert body["events"][0]["quantity"] == 42
         assert body["events"][0]["category"] == "tokens.input"
+
+    def test_drops_when_delivery_capacity_is_saturated(self, tmp_path):
+        proxy_log = tmp_path / "proxy.jsonl"
+        executor = _QueuedUsageExecutor()
+
+        with patch.object(usage.webhook, "usage_executor", executor):
+            for index in range(usage.webhook.MAX_PENDING_WEBHOOK_PAYLOADS):
+                assert usage.webhook._enqueue_webhook(
+                    "https://api.vm0.ai/api/webhooks/agent/usage-event",
+                    "tok",
+                    {"runId": f"run-{index}", "events": []},
+                    str(proxy_log),
+                    "usage_event",
+                )
+
+            dropped = usage.webhook._enqueue_webhook(
+                "https://api.vm0.ai/api/webhooks/agent/usage-event",
+                "tok",
+                {
+                    "runId": "run-drop",
+                    "events": [{"idempotencyKey": "secret-key", "quantity": 1}],
+                    "payload": "secret-payload",
+                },
+                str(proxy_log),
+                "usage_event",
+            )
+
+        assert dropped is False
+        assert len(executor.submissions) == usage.webhook.MAX_PENDING_WEBHOOK_PAYLOADS
+        assert usage.counters._pending_reports == usage.webhook.MAX_PENDING_WEBHOOK_PAYLOADS
+
+        entries = [json.loads(line) for line in proxy_log.read_text().splitlines()]
+        dropped_entry = entries[-1]
+        assert dropped_entry["level"] == "warn"
+        assert "saturated" in dropped_entry["message"]
+        assert dropped_entry["webhook_delivery_capacity"] == (
+            usage.webhook.MAX_PENDING_WEBHOOK_PAYLOADS
+        )
+        assert dropped_entry["webhook_delivery_pending"] == (
+            usage.webhook.MAX_PENDING_WEBHOOK_PAYLOADS
+        )
+        _assert_body_free_webhook_entry(dropped_entry, run_id="run-drop", event_count=1)
+        assert "payload_bytes" not in dropped_entry
+        assert "secret-payload" not in json.dumps(dropped_entry)
+
+    def test_delivery_capacity_released_after_success(
+        self, tmp_path, sync_usage_executor, usage_webhook_server
+    ):
+        proxy_log = tmp_path / "proxy.jsonl"
+        usage_webhook_server.queue_response(204)
+
+        assert usage.webhook._enqueue_webhook(
+            usage_webhook_server.url("/usage"),
+            "tok",
+            {"runId": "run-1", "events": []},
+            str(proxy_log),
+            "usage_event",
+        )
+
+        assert usage_webhook_server.request_count == 1
+        assert usage.webhook._pending_delivery_payload_count_for_tests() == 0
+        assert usage.counters._pending_reports == 0
+
+    def test_delivery_capacity_released_after_retry_exhaustion(
+        self, tmp_path, sync_usage_executor, usage_webhook_server
+    ):
+        proxy_log = tmp_path / "proxy.jsonl"
+        usage_webhook_server.queue_response(500)
+        usage_webhook_server.queue_response(500)
+
+        with patch.object(usage.webhook.time, "sleep"):
+            assert usage.webhook._enqueue_webhook(
+                usage_webhook_server.url("/usage"),
+                "tok",
+                {"runId": "run-1", "events": []},
+                str(proxy_log),
+                "usage_event",
+            )
+
+        assert usage_webhook_server.request_count == 2
+        assert usage.webhook._pending_delivery_payload_count_for_tests() == 0
+        assert usage.counters._pending_reports == 0


### PR DESCRIPTION
## Summary
- add bounded admission for usage webhook delivery so the ThreadPoolExecutor queue cannot grow without limit
- log saturated drops with body-free metadata and surface dropped batch counts in usage buffer flush summaries
- reset delivery capacity in tests and cover saturation, capacity release, and flush drop logging

## Tests
- cd crates/runner/mitm-addon && pytest tests/test_webhook.py tests/test_counters.py tests/test_usage_buffer.py tests/test_connection_hooks.py
- cd crates/runner/mitm-addon && ruff check . && basedpyright && pytest

Closes #15926