### PR TITLE
fix: preserve missing auto memory artifact checkpoints

### DIFF
--- a/crates/api-contracts/src/generated/types.rs
+++ b/crates/api-contracts/src/generated/types.rs
@@ -6,6 +6,8 @@ pub mod runners {
     pub mod storage {
         #[derive(Debug, Clone, Copy, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
         pub enum ArtifactEntryMissingRootPolicy {
+            #[serde(rename = "fail")]
+            Fail,
             #[serde(rename = "preserveParentVersion")]
             PreserveParentVersion,
         }

--- a/crates/api-contracts/src/generated/types.rs
+++ b/crates/api-contracts/src/generated/types.rs
@@ -4,6 +4,12 @@
 
 pub mod runners {
     pub mod storage {
+        #[derive(Debug, Clone, Copy, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
+        pub enum ArtifactEntryMissingRootPolicy {
+            #[serde(rename = "preserveParentVersion")]
+            PreserveParentVersion,
+        }
+
         #[derive(Debug, Clone, PartialEq, serde::Serialize, serde::Deserialize)]
         #[serde(rename_all = "camelCase")]
         pub struct ArtifactEntry {
@@ -14,6 +20,8 @@ pub mod runners {
             pub archive_url: String,
             #[serde(default, skip_serializing_if = "Option::is_none")]
             pub manifest_url: Option<String>,
+            #[serde(default, skip_serializing_if = "Option::is_none")]
+            pub missing_root_policy: Option<ArtifactEntryMissingRootPolicy>,
         }
 
         #[derive(Debug, Clone, PartialEq, serde::Serialize, serde::Deserialize)]

--- a/crates/api-contracts/tests/types.rs
+++ b/crates/api-contracts/tests/types.rs
@@ -236,6 +236,7 @@ fn generated_storage_manifest_serializes_without_absent_manifest_url() {
             vas_version_id: "version-2".to_string(),
             archive_url: "https://storage.example/artifact.tar.gz".to_string(),
             manifest_url: None,
+            missing_root_policy: None,
         }],
     };
 

--- a/crates/guest-agent/src/artifact/archive.rs
+++ b/crates/guest-agent/src/artifact/archive.rs
@@ -151,6 +151,15 @@ pub(super) enum ArchiveError {
     FinishGzip { source: io::Error },
 }
 
+impl ArchiveError {
+    pub(super) fn is_root_not_found(&self) -> bool {
+        matches!(
+            self,
+            Self::RootOpen { source, .. } if source.kind() == io::ErrorKind::NotFound
+        )
+    }
+}
+
 /// Create a tar.gz archive containing only the listed manifest files.
 ///
 /// This ensures the archive matches the manifest exactly — no symlinks or other

--- a/crates/guest-agent/src/artifact/mod.rs
+++ b/crates/guest-agent/src/artifact/mod.rs
@@ -1,7 +1,7 @@
 //! VAS artifact upload — SHA-256 hashing, tar.gz creation, S3 presigned upload.
 //!
-//! Flow (caller first walks the mount via [`walk_files`], then invokes
-//! [`create_snapshot`] with the pre-walked file list):
+//! Flow (caller first walks the mount via [`walk_files_for_checkpoint`], then
+//! invokes [`create_snapshot`] with the pre-walked file list):
 //! 1. POST `/storages/prepare` with file list → get presigned URLs
 //! 2. If deduplicated, POST `/storages/commit` to update HEAD
 //! 3. Create tar.gz archive
@@ -123,8 +123,9 @@ pub(crate) async fn walk_files_for_checkpoint(
 }
 
 /// Create a VAS snapshot using direct S3 upload. Caller provides the
-/// pre-walked file list (see [`walk_files`]) — this lets the checkpoint step
-/// share one walk between its skip-check fingerprint and the snapshot upload.
+/// pre-walked file list (see [`walk_files_for_checkpoint`]) — this lets the
+/// checkpoint step share one walk between its skip-check fingerprint and the
+/// snapshot upload.
 pub(crate) async fn create_snapshot(
     http: &HttpClient,
     request: CreateSnapshotRequest<'_>,

--- a/crates/guest-agent/src/artifact/mod.rs
+++ b/crates/guest-agent/src/artifact/mod.rs
@@ -55,6 +55,7 @@ pub(crate) enum WalkFilesError {
     Checkpoint {
         message: String,
         root_not_found: bool,
+        elapsed: std::time::Duration,
     },
 }
 
@@ -72,7 +73,10 @@ impl WalkFilesError {
     pub(crate) fn into_agent_error(self) -> AgentError {
         match self {
             Self::Execution(message) => AgentError::Execution(message),
-            Self::Checkpoint { message, .. } => {
+            Self::Checkpoint {
+                message, elapsed, ..
+            } => {
+                record_sandbox_op("artifact_hash_compute", elapsed, false, Some(&message));
                 log_error!(LOG_TAG, "{message}");
                 AgentError::Checkpoint(message)
             }
@@ -105,15 +109,10 @@ pub(crate) async fn walk_files_for_checkpoint(
         Err(e) => {
             let root_not_found = e.is_root_not_found();
             let message = format!("Failed to walk artifact files: {e}");
-            record_sandbox_op(
-                "artifact_hash_compute",
-                hash_start.elapsed(),
-                false,
-                Some(&message),
-            );
             return Err(WalkFilesError::Checkpoint {
                 message,
                 root_not_found,
+                elapsed: hash_start.elapsed(),
             });
         }
     };

--- a/crates/guest-agent/src/artifact/mod.rs
+++ b/crates/guest-agent/src/artifact/mod.rs
@@ -49,11 +49,40 @@ pub(crate) struct CreateSnapshotRequest<'a> {
     pub(crate) parent_version_id: &'a str,
 }
 
-/// Walk `mount_path` in a blocking task and collect `FileEntry` records,
-/// recording the hash-compute op and emitting a "Found N files" log. Exposed
-/// so the checkpoint step can pre-walk once, decide whether to skip, and reuse
-/// the result for `create_snapshot` without a second walk.
-pub(crate) async fn walk_files(mount_path: &str) -> Result<Vec<FileEntry>, AgentError> {
+#[derive(Debug)]
+pub(crate) enum WalkFilesError {
+    Execution(String),
+    Checkpoint {
+        message: String,
+        root_not_found: bool,
+    },
+}
+
+impl WalkFilesError {
+    pub(crate) fn is_root_not_found(&self) -> bool {
+        matches!(
+            self,
+            Self::Checkpoint {
+                root_not_found: true,
+                ..
+            }
+        )
+    }
+
+    pub(crate) fn into_agent_error(self) -> AgentError {
+        match self {
+            Self::Execution(message) => AgentError::Execution(message),
+            Self::Checkpoint { message, .. } => {
+                log_error!(LOG_TAG, "{message}");
+                AgentError::Checkpoint(message)
+            }
+        }
+    }
+}
+
+pub(crate) async fn walk_files_for_checkpoint(
+    mount_path: &str,
+) -> Result<Vec<FileEntry>, WalkFilesError> {
     log_info!(LOG_TAG, "Computing file hashes...");
     let hash_start = std::time::Instant::now();
     let mount = mount_path.to_string();
@@ -68,21 +97,24 @@ pub(crate) async fn walk_files(mount_path: &str) -> Result<Vec<FileEntry>, Agent
                     false,
                     Some(&message),
                 );
-                return Err(AgentError::Execution(message));
+                return Err(WalkFilesError::Execution(message));
             }
         };
     let files = match files_result {
         Ok(files) => files,
         Err(e) => {
+            let root_not_found = e.is_root_not_found();
             let message = format!("Failed to walk artifact files: {e}");
-            log_error!(LOG_TAG, "{message}");
             record_sandbox_op(
                 "artifact_hash_compute",
                 hash_start.elapsed(),
                 false,
                 Some(&message),
             );
-            return Err(AgentError::Checkpoint(message));
+            return Err(WalkFilesError::Checkpoint {
+                message,
+                root_not_found,
+            });
         }
     };
     record_sandbox_op("artifact_hash_compute", hash_start.elapsed(), true, None);

--- a/crates/guest-agent/src/checkpoint.rs
+++ b/crates/guest-agent/src/checkpoint.rs
@@ -193,8 +193,8 @@ async fn upload_session_history(
 
 /// Snapshot artifact entries. Memory rides in `VM0_ARTIFACTS` post-#10602, so
 /// there is no longer a separate memory arm. Payload shape is
-/// `Array<{name, version, mountPath}>` per #10911 — the receiver tolerates the
-/// legacy `Record<name, version>` form too (#10919).
+/// `Array<{name, version, mountPath, generatedBy?}>`, matching the webhook
+/// receiver's canonical artifact snapshot schema.
 async fn snapshot_artifact_entries(
     http: &HttpClient,
     entries: &[env::ArtifactEnv],

--- a/crates/guest-agent/src/checkpoint.rs
+++ b/crates/guest-agent/src/checkpoint.rs
@@ -18,6 +18,7 @@ use std::io::ErrorKind;
 use api_contracts::generated::types::runners::storage::ArtifactEntryMissingRootPolicy;
 
 const LOG_TAG: &str = "sandbox:guest-agent";
+const API_AUTO_MEMORY_GENERATED_BY: &str = "apiAutoMemory";
 
 #[derive(Clone, Copy)]
 enum CheckpointMode {
@@ -65,12 +66,32 @@ fn fail(
 
 /// Shape one entry of the `artifactSnapshots` payload. Keys are the
 /// camelCase names the web Zod receiver (`artifactSnapshotsSchema`) expects.
-fn build_artifact_snapshot_entry(name: &str, version: &str, mount_path: &str) -> serde_json::Value {
-    json!({
+fn build_artifact_snapshot_entry(
+    name: &str,
+    version: &str,
+    mount_path: &str,
+    generated_by: Option<&str>,
+) -> serde_json::Value {
+    let mut entry = json!({
         "name": name,
         "version": version,
         "mountPath": mount_path,
-    })
+    });
+    if let Some(generated_by) = generated_by
+        && let Some(object) = entry.as_object_mut()
+    {
+        object.insert("generatedBy".to_string(), json!(generated_by));
+    }
+    entry
+}
+
+fn artifact_snapshot_generated_by(entry: &env::ArtifactEnv) -> Option<&'static str> {
+    match entry.missing_root_policy {
+        Some(ArtifactEntryMissingRootPolicy::PreserveParentVersion) => {
+            Some(API_AUTO_MEMORY_GENERATED_BY)
+        }
+        _ => None,
+    }
 }
 
 struct ArtifactSnapshotPlan<'a> {
@@ -218,6 +239,7 @@ async fn snapshot_artifact_entries(
                         &entry.name,
                         &entry.version_id,
                         &entry.mount_path,
+                        artifact_snapshot_generated_by(entry),
                     ),
                 ));
                 continue;
@@ -266,6 +288,7 @@ async fn snapshot_artifact_entries(
                 &entry.name,
                 &entry.version_id,
                 &entry.mount_path,
+                artifact_snapshot_generated_by(entry),
             ));
             continue;
         }
@@ -299,6 +322,7 @@ async fn snapshot_artifact_entries(
             &entry.name,
             &snapshot.version_id,
             &entry.mount_path,
+            artifact_snapshot_generated_by(entry),
         ));
     }
     Ok(Some(serde_json::Value::Array(results)))
@@ -553,7 +577,7 @@ mod tests {
 
     #[test]
     fn artifact_snapshot_entry_shape_matches_receiver_schema() {
-        let entry = build_artifact_snapshot_entry("workspace", "v-abc-123", "/workspace");
+        let entry = build_artifact_snapshot_entry("workspace", "v-abc-123", "/workspace", None);
         assert_eq!(
             entry,
             json!({
@@ -566,7 +590,7 @@ mod tests {
 
     #[test]
     fn artifact_snapshot_entry_uses_camel_case_keys() {
-        let entry = build_artifact_snapshot_entry("n", "v", "/m");
+        let entry = build_artifact_snapshot_entry("n", "v", "/m", None);
         let obj = entry.as_object().expect("entry must be a JSON object");
         // Contract-boundary invariant: the web Zod receiver requires camelCase
         // `mountPath`; a snake_case slip would silently cause a 400 on the
@@ -733,6 +757,7 @@ mod tests {
                 "name": "memory",
                 "version": "old-memory-version",
                 "mountPath": missing_mount.to_string_lossy(),
+                "generatedBy": "apiAutoMemory",
             }]))
         );
         prepare.assert_calls(0);

--- a/crates/guest-agent/src/checkpoint.rs
+++ b/crates/guest-agent/src/checkpoint.rs
@@ -615,6 +615,43 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn artifact_snapshot_explicit_fail_policy_missing_mount_fails() {
+        let server = MockServer::start();
+        let prepare = server.mock(|when, then| {
+            when.method(POST)
+                .path("/api/webhooks/agent/storages/prepare");
+            then.status(200).json_body(json!({"unreachable": true}));
+        });
+        let commit = server.mock(|when, then| {
+            when.method(POST)
+                .path("/api/webhooks/agent/storages/commit");
+            then.status(200).json_body(json!({"unreachable": true}));
+        });
+        let http = HttpClient::with_api_config(server.base_url(), "test-token", "", Duration::ZERO)
+            .unwrap();
+        let dir = tempfile::tempdir().unwrap();
+        let missing_mount = dir.path().join("missing");
+        let entries = vec![env::ArtifactEnv {
+            name: "workspace".to_string(),
+            mount_path: missing_mount.to_string_lossy().into_owned(),
+            storage_id: "storage-id".to_string(),
+            version_id: "parent-version".to_string(),
+            missing_root_policy: Some(ArtifactEntryMissingRootPolicy::Fail),
+        }];
+
+        let err = snapshot_artifact_entries(&http, &entries)
+            .await
+            .unwrap_err();
+
+        assert!(
+            err.to_string().contains("Failed to walk artifact files"),
+            "got: {err}"
+        );
+        prepare.assert_calls(0);
+        commit.assert_calls(0);
+    }
+
+    #[tokio::test]
     async fn artifact_snapshot_later_missing_mount_fails_before_any_storage_api_calls() {
         let server = MockServer::start();
         let prepare = server.mock(|when, then| {

--- a/crates/guest-agent/src/checkpoint.rs
+++ b/crates/guest-agent/src/checkpoint.rs
@@ -15,6 +15,8 @@ use serde_json::json;
 use sha2::{Digest, Sha256};
 use std::io::ErrorKind;
 
+use api_contracts::generated::types::runners::storage::ArtifactEntryMissingRootPolicy;
+
 const LOG_TAG: &str = "sandbox:guest-agent";
 
 #[derive(Clone, Copy)]
@@ -74,6 +76,11 @@ fn build_artifact_snapshot_entry(name: &str, version: &str, mount_path: &str) ->
 struct ArtifactSnapshotPlan<'a> {
     entry: &'a env::ArtifactEnv,
     files: Vec<artifact::FileEntry>,
+}
+
+enum ArtifactSnapshotWork<'a> {
+    Preserve(serde_json::Value),
+    Snapshot(ArtifactSnapshotPlan<'a>),
 }
 
 /// Prepare + upload the session history to S3 via a presigned URL. If the
@@ -179,7 +186,7 @@ async fn snapshot_artifact_entries(
         return Ok(None);
     }
 
-    let mut plans = Vec::with_capacity(entries.len());
+    let mut work = Vec::with_capacity(entries.len());
     for entry in entries {
         log_info!(
             LOG_TAG,
@@ -187,12 +194,51 @@ async fn snapshot_artifact_entries(
             entry.name,
             entry.mount_path
         );
-        let files = artifact::walk_files(&entry.mount_path).await?;
-        plans.push(ArtifactSnapshotPlan { entry, files });
+        let files = match artifact::walk_files_for_checkpoint(&entry.mount_path).await {
+            Ok(files) => files,
+            Err(error)
+                if entry.missing_root_policy
+                    == Some(ArtifactEntryMissingRootPolicy::PreserveParentVersion)
+                    && error.is_root_not_found() =>
+            {
+                let preserve_start = std::time::Instant::now();
+                let message = format!(
+                    "Preserving artifact '{}' parent version {} because mount root is missing at {}",
+                    entry.name, entry.version_id, entry.mount_path
+                );
+                log_warn!(LOG_TAG, "{message}");
+                record_sandbox_op(
+                    "artifact_snapshot_preserved_missing_root",
+                    preserve_start.elapsed(),
+                    true,
+                    Some(&message),
+                );
+                work.push(ArtifactSnapshotWork::Preserve(
+                    build_artifact_snapshot_entry(
+                        &entry.name,
+                        &entry.version_id,
+                        &entry.mount_path,
+                    ),
+                ));
+                continue;
+            }
+            Err(error) => return Err(error.into_agent_error()),
+        };
+        work.push(ArtifactSnapshotWork::Snapshot(ArtifactSnapshotPlan {
+            entry,
+            files,
+        }));
     }
 
-    let mut results = Vec::with_capacity(plans.len());
-    for ArtifactSnapshotPlan { entry, files } in plans {
+    let mut results = Vec::with_capacity(work.len());
+    for item in work {
+        let (entry, files) = match item {
+            ArtifactSnapshotWork::Preserve(entry) => {
+                results.push(entry);
+                continue;
+            }
+            ArtifactSnapshotWork::Snapshot(ArtifactSnapshotPlan { entry, files }) => (entry, files),
+        };
         // Skip the VAS round-trips when the mount is byte-identical to what
         // was originally mounted. `version_id` in VAS *is* the content hash
         // (same SHA-256 the web producer emits), so an equality check on the
@@ -553,6 +599,7 @@ mod tests {
             mount_path: missing_mount.to_string_lossy().into_owned(),
             storage_id: "storage-id".to_string(),
             version_id: "parent-version".to_string(),
+            missing_root_policy: None,
         }];
 
         let err = snapshot_artifact_entries(&http, &entries)
@@ -593,14 +640,93 @@ mod tests {
                 mount_path: valid_mount.to_string_lossy().into_owned(),
                 storage_id: "workspace-storage-id".to_string(),
                 version_id: "old-workspace-version".to_string(),
+                missing_root_policy: None,
             },
             env::ArtifactEnv {
                 name: "memory".to_string(),
                 mount_path: missing_mount.to_string_lossy().into_owned(),
                 storage_id: "memory-storage-id".to_string(),
                 version_id: "old-memory-version".to_string(),
+                missing_root_policy: None,
             },
         ];
+
+        let err = snapshot_artifact_entries(&http, &entries)
+            .await
+            .unwrap_err();
+
+        assert!(
+            err.to_string().contains("Failed to walk artifact files"),
+            "got: {err}"
+        );
+        prepare.assert_calls(0);
+        commit.assert_calls(0);
+    }
+
+    #[tokio::test]
+    async fn artifact_snapshot_preserves_parent_version_for_policy_missing_root() {
+        let server = MockServer::start();
+        let prepare = server.mock(|when, then| {
+            when.method(POST)
+                .path("/api/webhooks/agent/storages/prepare");
+            then.status(200).json_body(json!({"unreachable": true}));
+        });
+        let commit = server.mock(|when, then| {
+            when.method(POST)
+                .path("/api/webhooks/agent/storages/commit");
+            then.status(200).json_body(json!({"unreachable": true}));
+        });
+        let http = HttpClient::with_api_config(server.base_url(), "test-token", "", Duration::ZERO)
+            .unwrap();
+        let dir = tempfile::tempdir().unwrap();
+        let missing_mount = dir.path().join("memory");
+        let entries = vec![env::ArtifactEnv {
+            name: "memory".to_string(),
+            mount_path: missing_mount.to_string_lossy().into_owned(),
+            storage_id: "memory-storage-id".to_string(),
+            version_id: "old-memory-version".to_string(),
+            missing_root_policy: Some(ArtifactEntryMissingRootPolicy::PreserveParentVersion),
+        }];
+
+        let snapshots = snapshot_artifact_entries(&http, &entries).await.unwrap();
+
+        assert_eq!(
+            snapshots,
+            Some(json!([{
+                "name": "memory",
+                "version": "old-memory-version",
+                "mountPath": missing_mount.to_string_lossy(),
+            }]))
+        );
+        prepare.assert_calls(0);
+        commit.assert_calls(0);
+    }
+
+    #[tokio::test]
+    async fn artifact_snapshot_policy_still_fails_on_non_not_found_root_error() {
+        let server = MockServer::start();
+        let prepare = server.mock(|when, then| {
+            when.method(POST)
+                .path("/api/webhooks/agent/storages/prepare");
+            then.status(200).json_body(json!({"unreachable": true}));
+        });
+        let commit = server.mock(|when, then| {
+            when.method(POST)
+                .path("/api/webhooks/agent/storages/commit");
+            then.status(200).json_body(json!({"unreachable": true}));
+        });
+        let http = HttpClient::with_api_config(server.base_url(), "test-token", "", Duration::ZERO)
+            .unwrap();
+        let dir = tempfile::tempdir().unwrap();
+        let file_mount = dir.path().join("memory");
+        std::fs::write(&file_mount, "not a directory").unwrap();
+        let entries = vec![env::ArtifactEnv {
+            name: "memory".to_string(),
+            mount_path: file_mount.to_string_lossy().into_owned(),
+            storage_id: "memory-storage-id".to_string(),
+            version_id: "old-memory-version".to_string(),
+            missing_root_policy: Some(ArtifactEntryMissingRootPolicy::PreserveParentVersion),
+        }];
 
         let err = snapshot_artifact_entries(&http, &entries)
             .await
@@ -656,6 +782,7 @@ mod tests {
             mount_path: missing_mount.to_string_lossy().into_owned(),
             storage_id: "storage-id".to_string(),
             version_id: "parent-version".to_string(),
+            missing_root_policy: None,
         }];
 
         let err = create_checkpoint_impl_with_artifacts(&http, CheckpointMode::Success, &entries)

--- a/crates/guest-agent/src/env.rs
+++ b/crates/guest-agent/src/env.rs
@@ -2,6 +2,8 @@
 
 use std::sync::LazyLock;
 
+use api_contracts::generated::types::runners::storage::ArtifactEntryMissingRootPolicy;
+
 use crate::constants;
 use guest_common::log_warn;
 
@@ -178,8 +180,9 @@ static POST_RESULT_SIGKILL_GRACE: LazyLock<u64> = LazyLock::new(|| {
 // Artifacts (multi-mount)
 //
 // The runner emits a single `VM0_ARTIFACTS` env var containing a JSON array
-// of `{name, mountPath, storageId, versionId}` entries — one per artifact
-// mounted at boot. If the env var is unset or empty, there are no artifacts.
+// of `{name, mountPath, storageId, versionId, missingRootPolicy?}` entries —
+// one per artifact mounted at boot. If the env var is unset or empty, there
+// are no artifacts.
 // ---------------------------------------------------------------------------
 
 /// One artifact mount described by the runner-provided `VM0_ARTIFACTS` JSON array.
@@ -200,6 +203,10 @@ pub struct ArtifactEnv {
     /// VAS version id mounted at startup. This is the expected content hash used
     /// to skip unchanged snapshots and the parent version for new snapshots.
     pub version_id: String,
+    /// Optional internal checkpoint policy. Absence means strict failure on a
+    /// missing or unreadable artifact root.
+    #[serde(default)]
+    pub missing_root_policy: Option<ArtifactEntryMissingRootPolicy>,
 }
 
 /// Parse `VM0_ARTIFACTS`, which the runner writes as a JSON array.

--- a/crates/guest-download/src/manifest.rs
+++ b/crates/guest-download/src/manifest.rs
@@ -40,6 +40,8 @@ pub(crate) struct ManifestEntry {
     pub(crate) vas_storage_name: Option<String>,
     #[serde(default)]
     pub(crate) vas_version_id: Option<String>,
+    #[serde(default)]
+    pub(crate) missing_root_policy: Option<String>,
 }
 
 #[cfg(test)]
@@ -104,7 +106,8 @@ mod tests {
                 "archiveUrl": "https://s3/artifact.tar.gz",
                 "vasStorageName": "artifact",
                 "vasStorageId": "artifact-id",
-                "vasVersionId": "v2"
+                "vasVersionId": "v2",
+                "missingRootPolicy": "preserveParentVersion"
             }]
         }"#;
         let manifest: Manifest = serde_json::from_str(json).unwrap();
@@ -120,5 +123,9 @@ mod tests {
             Some("artifact")
         );
         assert_eq!(manifest.artifacts[0].vas_version_id.as_deref(), Some("v2"));
+        assert_eq!(
+            manifest.artifacts[0].missing_root_policy.as_deref(),
+            Some("preserveParentVersion")
+        );
     }
 }

--- a/crates/guest-download/src/plan.rs
+++ b/crates/guest-download/src/plan.rs
@@ -109,14 +109,22 @@ fn format_entry_label(
 ) -> String {
     let storage_name = entry.vas_storage_name.as_deref().unwrap_or("unknown");
     let version_id = entry.vas_version_id.as_deref().unwrap_or("unknown");
+    let missing_root_policy = entry.missing_root_policy.as_deref().unwrap_or("fail");
     let url_scheme = archive_url
         .split_once("://")
         .map(|(scheme, _)| scheme)
         .unwrap_or("unknown");
 
     format!(
-        "{} {} mountPath={} vasStorageName={} vasVersionId={} urlScheme={} cached={}",
-        label_prefix, index, entry.mount_path, storage_name, version_id, url_scheme, entry.cached
+        "{} {} mountPath={} vasStorageName={} vasVersionId={} urlScheme={} cached={} missingRootPolicy={}",
+        label_prefix,
+        index,
+        entry.mount_path,
+        storage_name,
+        version_id,
+        url_scheme,
+        entry.cached,
+        missing_root_policy
     )
 }
 
@@ -164,7 +172,8 @@ mod tests {
                     "mountPath": "/workspace/a",
                     "archiveUrl": "https://s3/a.tar.gz",
                     "vasStorageName": "workspace-a",
-                    "vasVersionId": "artifact-v1"
+                    "vasVersionId": "artifact-v1",
+                    "missingRootPolicy": "preserveParentVersion"
                 },
                 {
                     "mountPath": "/workspace/b",
@@ -184,7 +193,7 @@ mod tests {
         assert_eq!(
             plan.download_tasks[0],
             DownloadTask::new(
-                "storage 1 mountPath=/data vasStorageName=data vasVersionId=storage-v1 urlScheme=https cached=false".into(),
+                "storage 1 mountPath=/data vasStorageName=data vasVersionId=storage-v1 urlScheme=https cached=false missingRootPolicy=fail".into(),
                 "storage_download",
                 "https://s3/storage.tar.gz".into(),
                 "/data".into(),
@@ -194,7 +203,7 @@ mod tests {
         assert_eq!(
             plan.download_tasks[1],
             DownloadTask::new(
-                "artifact 1 mountPath=/workspace/a vasStorageName=workspace-a vasVersionId=artifact-v1 urlScheme=https cached=false".into(),
+                "artifact 1 mountPath=/workspace/a vasStorageName=workspace-a vasVersionId=artifact-v1 urlScheme=https cached=false missingRootPolicy=preserveParentVersion".into(),
                 "artifact_download",
                 "https://s3/a.tar.gz".into(),
                 "/workspace/a".into(),
@@ -204,7 +213,7 @@ mod tests {
         assert_eq!(
             plan.download_tasks[2],
             DownloadTask::new(
-                "artifact 2 mountPath=/workspace/b vasStorageName=workspace-b vasVersionId=artifact-v2 urlScheme=file cached=false".into(),
+                "artifact 2 mountPath=/workspace/b vasStorageName=workspace-b vasVersionId=artifact-v2 urlScheme=file cached=false missingRootPolicy=fail".into(),
                 "artifact_download",
                 "file:///tmp/vm0-storage-cache/b.tar.gz".into(),
                 "/workspace/b".into(),

--- a/crates/guest-download/src/plan.rs
+++ b/crates/guest-download/src/plan.rs
@@ -109,14 +109,21 @@ fn format_entry_label(
 ) -> String {
     let storage_name = entry.vas_storage_name.as_deref().unwrap_or("unknown");
     let version_id = entry.vas_version_id.as_deref().unwrap_or("unknown");
-    let missing_root_policy = entry.missing_root_policy.as_deref().unwrap_or("fail");
     let url_scheme = archive_url
         .split_once("://")
         .map(|(scheme, _)| scheme)
         .unwrap_or("unknown");
+    let missing_root_policy = if label_prefix == "artifact" {
+        format!(
+            " missingRootPolicy={}",
+            entry.missing_root_policy.as_deref().unwrap_or("fail")
+        )
+    } else {
+        String::new()
+    };
 
     format!(
-        "{} {} mountPath={} vasStorageName={} vasVersionId={} urlScheme={} cached={} missingRootPolicy={}",
+        "{} {} mountPath={} vasStorageName={} vasVersionId={} urlScheme={} cached={}{}",
         label_prefix,
         index,
         entry.mount_path,
@@ -193,7 +200,7 @@ mod tests {
         assert_eq!(
             plan.download_tasks[0],
             DownloadTask::new(
-                "storage 1 mountPath=/data vasStorageName=data vasVersionId=storage-v1 urlScheme=https cached=false missingRootPolicy=fail".into(),
+                "storage 1 mountPath=/data vasStorageName=data vasVersionId=storage-v1 urlScheme=https cached=false".into(),
                 "storage_download",
                 "https://s3/storage.tar.gz".into(),
                 "/data".into(),

--- a/crates/guest-download/src/plan.rs
+++ b/crates/guest-download/src/plan.rs
@@ -54,6 +54,7 @@ impl RunPlan {
             "storage",
             "storage_download",
             false,
+            false,
         );
 
         // Artifacts: 404 is non-fatal (may not exist on first run)
@@ -62,6 +63,7 @@ impl RunPlan {
             &manifest.artifacts,
             "artifact",
             "artifact_download",
+            true,
             true,
         );
 
@@ -85,13 +87,20 @@ fn append_download_tasks(
     label_prefix: &str,
     op_name: &'static str,
     allow_404: bool,
+    include_missing_root_policy: bool,
 ) {
     for (idx, entry) in entries.iter().enumerate() {
         if is_valid_url(&entry.archive_url)
             && let Some(url) = entry.archive_url.clone()
         {
             tasks.push(DownloadTask::new(
-                format_entry_label(entry, label_prefix, idx + 1, &url),
+                format_entry_label(
+                    entry,
+                    label_prefix,
+                    idx + 1,
+                    &url,
+                    include_missing_root_policy,
+                ),
                 op_name,
                 url,
                 entry.mount_path.clone(),
@@ -106,6 +115,7 @@ fn format_entry_label(
     label_prefix: &str,
     index: usize,
     archive_url: &str,
+    include_missing_root_policy: bool,
 ) -> String {
     let storage_name = entry.vas_storage_name.as_deref().unwrap_or("unknown");
     let version_id = entry.vas_version_id.as_deref().unwrap_or("unknown");
@@ -113,7 +123,7 @@ fn format_entry_label(
         .split_once("://")
         .map(|(scheme, _)| scheme)
         .unwrap_or("unknown");
-    let missing_root_policy = if label_prefix == "artifact" {
+    let missing_root_policy = if include_missing_root_policy {
         format!(
             " missingRootPolicy={}",
             entry.missing_root_policy.as_deref().unwrap_or("fail")

--- a/crates/runner/src/executor.rs
+++ b/crates/runner/src/executor.rs
@@ -2501,13 +2501,12 @@ fn build_env_json_with_host_env(
     // Artifacts config (multi-mount).
     //
     // Emit a single `VM0_ARTIFACTS` env var containing a JSON array of
-    // `{name, mountPath, storageId, versionId}` objects. Guest-agent
-    // parses this on startup and iterates the list when taking snapshots
-    // at run end. The shape here must stay lockstep with guest-agent's
-    // `ArtifactEnv` — the two ship as one unit via `include_bytes!`, and
-    // `ArtifactEnv` deserializes strict (no `serde(default)`), so a
-    // field drop here will panic the VM at startup instead of silently
-    // producing empty strings.
+    // `{name, mountPath, storageId, versionId, missingRootPolicy?}` objects.
+    // Guest-agent parses this on startup and iterates the list when taking
+    // snapshots at run end. The required fields here must stay lockstep with
+    // guest-agent's `ArtifactEnv` — the two ship as one unit via
+    // `include_bytes!`, and required field drops will panic the VM at startup
+    // instead of silently producing empty strings.
     //
     // Empty-list case: do not set the env var at all (matches the prior
     // "unset = no artifact" convention).
@@ -4523,7 +4522,7 @@ mod tests {
         sandbox.push_exec_result(Ok(ExecResult::new(
             1,
             b"stdout clue".to_vec(),
-            b"[2026-05-20T18:03:00Z] [ERROR] [sandbox:guest-download] storage 1 mountPath=/workspace vasStorageName=repo vasVersionId=v1 urlScheme=file cached=false missingRootPolicy=fail download failed: Failed to read archive entries: invalid gzip header".to_vec(),
+            b"[2026-05-20T18:03:00Z] [ERROR] [sandbox:guest-download] storage 1 mountPath=/workspace vasStorageName=repo vasVersionId=v1 urlScheme=file cached=false download failed: Failed to read archive entries: invalid gzip header".to_vec(),
         )));
         let ctx = minimal_context();
         let manifest = GuestDownloadManifest {

--- a/crates/runner/src/executor.rs
+++ b/crates/runner/src/executor.rs
@@ -36,6 +36,7 @@ use tracing::{info, warn};
 
 use api_contracts::generated::constants::model_provider_env::placeholders as model_provider_placeholders;
 use api_contracts::generated::constants::runners::paths::CANONICAL_WORKING_DIR;
+use api_contracts::generated::types::runners::storage::ArtifactEntryMissingRootPolicy;
 
 use crate::ids::RunId;
 
@@ -2141,8 +2142,11 @@ fn filter_unchanged_storages(
                            prev_ver: Option<&(String, String)>,
                            skipped: &mut usize,
                            cleanup: &mut Vec<String>| {
+        let preserve_missing_root =
+            a.missing_root_policy == Some(ArtifactEntryMissingRootPolicy::PreserveParentVersion);
         let same = prev_ver.is_some_and(|fingerprint| {
-            !StorageFingerprints::fingerprint_is_tainted(fingerprint)
+            !preserve_missing_root
+                && !StorageFingerprints::fingerprint_is_tainted(fingerprint)
                 && fingerprint.0.as_str() == a.vas_storage_name.as_str()
                 && fingerprint.1.as_str() == a.vas_version_id.as_str()
         });
@@ -2514,12 +2518,18 @@ fn build_env_json_with_host_env(
             .artifacts
             .iter()
             .map(|a| {
-                serde_json::json!({
+                let mut entry = serde_json::json!({
                     "name": a.vas_storage_name,
                     "mountPath": a.mount_path,
                     "storageId": a.vas_storage_id,
                     "versionId": a.vas_version_id,
-                })
+                });
+                if let Some(policy) = a.missing_root_policy
+                    && let Some(object) = entry.as_object_mut()
+                {
+                    object.insert("missingRootPolicy".to_string(), serde_json::json!(policy));
+                }
+                entry
             })
             .collect();
         // Serialization cannot fail — payload is a Vec of String-only JSON
@@ -2744,7 +2754,7 @@ mod tests {
     };
     use crate::workspace_image_cache::WorkspaceCacheTerminalStatus;
     use api_contracts::generated::types::runners::storage::{
-        ArtifactEntry, StorageEntry, StorageManifest,
+        ArtifactEntry, ArtifactEntryMissingRootPolicy, StorageEntry, StorageManifest,
     };
     use async_trait::async_trait;
     use sandbox_mock::MockSandboxFactory;
@@ -2841,6 +2851,7 @@ mod tests {
             vas_storage_id: storage_id.into(),
             vas_version_id: version.into(),
             manifest_url: None,
+            missing_root_policy: None,
         }
     }
 
@@ -3399,11 +3410,37 @@ mod tests {
         assert_eq!(parsed[0]["mountPath"], "/artifacts");
         assert_eq!(parsed[0]["storageId"], "sid-1");
         assert_eq!(parsed[0]["versionId"], "v1");
+        assert!(parsed[0].get("missingRootPolicy").is_none());
         // Legacy singleton env vars must no longer be emitted.
         assert!(!env.contains_key("VM0_ARTIFACT_DRIVER"));
         assert!(!env.contains_key("VM0_ARTIFACT_MOUNT_PATH"));
         assert!(!env.contains_key("VM0_ARTIFACT_VOLUME_NAME"));
         assert!(!env.contains_key("VM0_ARTIFACT_VERSION_ID"));
+    }
+
+    #[test]
+    fn build_env_json_with_artifact_missing_root_policy() {
+        let mut ctx = minimal_context();
+        let mut artifact = api_artifact(
+            "memory",
+            "/home/user/.claude/projects/-home-user-workspace/memory",
+            "sid-memory",
+            "v1",
+            "https://example.com/memory.tar.gz",
+        );
+        artifact.missing_root_policy = Some(ArtifactEntryMissingRootPolicy::PreserveParentVersion);
+        ctx.storage_manifest = Some(StorageManifest {
+            storages: vec![],
+            artifacts: vec![artifact],
+        });
+
+        let env = build_env_for_test(&ctx, "http://localhost");
+        let raw = env.get("VM0_ARTIFACTS").expect("VM0_ARTIFACTS must be set");
+        let parsed: Vec<serde_json::Value> = serde_json::from_str(raw).unwrap();
+
+        assert_eq!(parsed.len(), 1);
+        assert_eq!(parsed[0]["name"], "memory");
+        assert_eq!(parsed[0]["missingRootPolicy"], "preserveParentVersion");
     }
 
     #[test]
@@ -4486,7 +4523,7 @@ mod tests {
         sandbox.push_exec_result(Ok(ExecResult::new(
             1,
             b"stdout clue".to_vec(),
-            b"[2026-05-20T18:03:00Z] [ERROR] [sandbox:guest-download] storage 1 mountPath=/workspace vasStorageName=repo vasVersionId=v1 urlScheme=file cached=false download failed: Failed to read archive entries: invalid gzip header".to_vec(),
+            b"[2026-05-20T18:03:00Z] [ERROR] [sandbox:guest-download] storage 1 mountPath=/workspace vasStorageName=repo vasVersionId=v1 urlScheme=file cached=false missingRootPolicy=fail download failed: Failed to read archive entries: invalid gzip header".to_vec(),
         )));
         let ctx = minimal_context();
         let manifest = GuestDownloadManifest {
@@ -7018,6 +7055,15 @@ mod tests {
     // -----------------------------------------------------------------------
 
     fn guest_art(name: &str, ver: &str, url: Option<&str>) -> GuestDownloadArtifactEntry {
+        guest_art_with_policy(name, ver, url, None)
+    }
+
+    fn guest_art_with_policy(
+        name: &str,
+        ver: &str,
+        url: Option<&str>,
+        missing_root_policy: Option<ArtifactEntryMissingRootPolicy>,
+    ) -> GuestDownloadArtifactEntry {
         GuestDownloadArtifactEntry {
             mount_path: "/workspace".into(),
             archive_url: url.map(str::to_string),
@@ -7025,6 +7071,7 @@ mod tests {
             vas_storage_name: name.into(),
             vas_storage_id: String::new(),
             vas_version_id: ver.into(),
+            missing_root_policy,
         }
     }
 
@@ -7162,6 +7209,7 @@ mod tests {
             vas_storage_name: "art-a".into(),
             vas_storage_id: String::new(),
             vas_version_id: "v2".into(),
+            missing_root_policy: None,
         };
         let art_b = GuestDownloadArtifactEntry {
             mount_path: "/data".into(),
@@ -7170,6 +7218,7 @@ mod tests {
             vas_storage_name: "art-b".into(),
             vas_storage_id: String::new(),
             vas_version_id: "v1".into(),
+            missing_root_policy: None,
         };
         let manifest = GuestDownloadManifest {
             storages: vec![],
@@ -7331,6 +7380,33 @@ mod tests {
     }
 
     #[test]
+    fn filter_preserve_missing_root_artifact_keeps_url_even_when_version_matches() {
+        let manifest = GuestDownloadManifest {
+            storages: vec![],
+            artifacts: vec![guest_art_with_policy(
+                "memory",
+                "v1",
+                Some("https://s3/memory"),
+                Some(ArtifactEntryMissingRootPolicy::PreserveParentVersion),
+            )],
+            cleanup_paths: vec![],
+        };
+        let prev = crate::idle_pool::StorageFingerprints {
+            storages: HashMap::new(),
+            artifacts: art_fp("/workspace", "memory", "v1"),
+        };
+
+        let result = filter_unchanged_storages(&manifest, &prev);
+
+        assert_eq!(
+            result.artifacts[0].archive_url.as_deref(),
+            Some("https://s3/memory")
+        );
+        assert!(!result.artifacts[0].cached);
+        assert!(result.cleanup_paths.contains(&"/workspace".to_string()));
+    }
+
+    #[test]
     fn filter_changed_storage_with_null_url_adds_cleanup_path() {
         let manifest = GuestDownloadManifest {
             storages: vec![guest_storage("/data", "vol-1", "v2", None)],
@@ -7388,6 +7464,7 @@ mod tests {
                 vas_storage_name: "artifact".into(),
                 vas_storage_id: String::new(),
                 vas_version_id: "v1".into(),
+                missing_root_policy: None,
             }],
             cleanup_paths: vec![],
         };

--- a/crates/runner/src/storage_cache.rs
+++ b/crates/runner/src/storage_cache.rs
@@ -1141,6 +1141,7 @@ mod tests {
                 vas_storage_name: name.to_string(),
                 vas_storage_id: String::new(),
                 vas_version_id: version.to_string(),
+                missing_root_policy: None,
             }],
             cleanup_paths: Vec::new(),
         };
@@ -1498,6 +1499,7 @@ mod tests {
                 vas_storage_name: String::new(),
                 vas_storage_id: String::new(),
                 vas_version_id: String::new(),
+                missing_root_policy: None,
             }],
             cleanup_paths: Vec::new(),
         };

--- a/crates/runner/src/types.rs
+++ b/crates/runner/src/types.rs
@@ -4,7 +4,9 @@ use sandbox::SandboxId;
 use serde::{Deserialize, Serialize};
 use uuid::Uuid;
 
-use api_contracts::generated::types::runners::storage::StorageManifest;
+use api_contracts::generated::types::runners::storage::{
+    ArtifactEntryMissingRootPolicy, StorageManifest,
+};
 
 use crate::ids::RunId;
 
@@ -222,6 +224,8 @@ pub struct GuestDownloadArtifactEntry {
     pub vas_storage_name: String,
     pub vas_storage_id: String,
     pub vas_version_id: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub missing_root_policy: Option<ArtifactEntryMissingRootPolicy>,
 }
 
 impl From<&StorageManifest> for GuestDownloadManifest {
@@ -249,6 +253,7 @@ impl From<&StorageManifest> for GuestDownloadManifest {
                     vas_storage_name: artifact.vas_storage_name.clone(),
                     vas_storage_id: artifact.vas_storage_id.clone(),
                     vas_version_id: artifact.vas_version_id.clone(),
+                    missing_root_policy: artifact.missing_root_policy,
                 })
                 .collect(),
             cleanup_paths: Vec::new(),
@@ -366,7 +371,9 @@ impl SandboxReuseResult {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use api_contracts::generated::types::runners::storage::{ArtifactEntry, StorageEntry};
+    use api_contracts::generated::types::runners::storage::{
+        ArtifactEntry, ArtifactEntryMissingRootPolicy, StorageEntry,
+    };
     use serde_json::json;
 
     #[test]
@@ -764,6 +771,7 @@ mod tests {
                 vas_storage_id: "sid-1".into(),
                 vas_version_id: "v2".into(),
                 manifest_url: Some("https://example.com/manifest.json".into()),
+                missing_root_policy: Some(ArtifactEntryMissingRootPolicy::PreserveParentVersion),
             }],
         };
 
@@ -786,6 +794,10 @@ mod tests {
             guest_manifest.artifacts[0].archive_url.as_deref(),
             Some("https://example.com/artifact.tar.gz")
         );
+        assert_eq!(
+            guest_manifest.artifacts[0].missing_root_policy,
+            Some(ArtifactEntryMissingRootPolicy::PreserveParentVersion)
+        );
     }
 
     #[test]
@@ -806,6 +818,7 @@ mod tests {
                 vas_storage_id: "sid-1".into(),
                 vas_version_id: "v2".into(),
                 manifest_url: Some("https://example.com/manifest.json".into()),
+                missing_root_policy: None,
             }],
         };
 
@@ -816,6 +829,7 @@ mod tests {
         assert!(value["storages"][0].get("name").is_none());
         assert_eq!(value["artifacts"][0]["cached"], false);
         assert!(value["artifacts"][0].get("manifestUrl").is_none());
+        assert!(value["artifacts"][0].get("missingRootPolicy").is_none());
     }
 
     #[test]

--- a/turbo/apps/api/src/signals/routes/__tests__/agent-runs-create.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/agent-runs-create.test.ts
@@ -1576,6 +1576,71 @@ describe("POST /api/agent/runs", () => {
     ).toBeUndefined();
   });
 
+  it("keeps user-authored canonical memory mount overrides strict", async () => {
+    const fx = await fixture();
+    const compose = await createCompose({ fixture: fx });
+
+    const response = await accept(
+      runsClient().create({
+        headers: { authorization: "Bearer clerk-session" },
+        body: {
+          agentComposeId: compose.composeId,
+          prompt: "Use canonical memory mount with a custom artifact",
+          artifacts: [
+            {
+              name: "custom-memory",
+              mountPath: CANONICAL_CLAUDE_MEMORY_MOUNT_PATH,
+            },
+          ],
+        },
+      }),
+      [201],
+    );
+
+    const db = store.set(writeDb$);
+    const [session] = await db
+      .select({ artifacts: agentSessions.artifacts })
+      .from(agentSessions)
+      .where(eq(agentSessions.id, response.body.sessionId));
+    expect(session?.artifacts).toStrictEqual([
+      {
+        name: "custom-memory",
+        mountPath: CANONICAL_CLAUDE_MEMORY_MOUNT_PATH,
+      },
+    ]);
+
+    const [job] = await db
+      .select({ executionContext: runnerJobQueue.executionContext })
+      .from(runnerJobQueue)
+      .where(eq(runnerJobQueue.runId, response.body.runId));
+    expect(job).toBeDefined();
+    const executionContext = job!.executionContext as {
+      readonly storageManifest: {
+        readonly artifacts: readonly {
+          readonly mountPath: string;
+          readonly vasStorageName: string;
+          readonly missingRootPolicy?: ArtifactEntry["missingRootPolicy"];
+        }[];
+      };
+    };
+
+    expect(
+      executionContext.storageManifest.artifacts.map((artifact) => {
+        return {
+          mountPath: artifact.mountPath,
+          name: artifact.vasStorageName,
+          missingRootPolicy: artifact.missingRootPolicy,
+        };
+      }),
+    ).toStrictEqual([
+      {
+        mountPath: CANONICAL_CLAUDE_MEMORY_MOUNT_PATH,
+        name: "custom-memory",
+        missingRootPolicy: undefined,
+      },
+    ]);
+  });
+
   it("keeps continued user-authored canonical memory artifacts strict", async () => {
     const fx = await fixture();
     const compose = await createCompose({ fixture: fx });
@@ -2112,6 +2177,76 @@ describe("POST /api/agent/runs", () => {
       {
         mountPath: "/mnt/user-memory",
         name: "memory",
+        missingRootPolicy: undefined,
+      },
+    ]);
+  });
+
+  it("keeps continued body canonical memory mount overrides strict", async () => {
+    const fx = await fixture();
+    const compose = await createCompose({ fixture: fx });
+    const first = await accept(
+      runsClient().create({
+        headers: { authorization: "Bearer clerk-session" },
+        body: { agentComposeId: compose.composeId, prompt: "first" },
+      }),
+      [201],
+    );
+    const db = store.set(writeDb$);
+    await store.set(
+      seedConversationForSession$,
+      { runId: first.body.runId, sessionId: first.body.sessionId },
+      context.signal,
+    );
+    await db
+      .update(agentRuns)
+      .set({ status: "completed", completedAt: nowDate() })
+      .where(eq(agentRuns.id, first.body.runId));
+
+    const continued = await accept(
+      runsClient().create({
+        headers: { authorization: "Bearer clerk-session" },
+        body: {
+          sessionId: first.body.sessionId,
+          prompt: "continue",
+          artifacts: [
+            {
+              name: "custom-memory",
+              mountPath: CANONICAL_CLAUDE_MEMORY_MOUNT_PATH,
+            },
+          ],
+        },
+      }),
+      [201],
+    );
+
+    const [job] = await db
+      .select({ executionContext: runnerJobQueue.executionContext })
+      .from(runnerJobQueue)
+      .where(eq(runnerJobQueue.runId, continued.body.runId));
+    expect(job).toBeDefined();
+    const executionContext = job!.executionContext as {
+      readonly storageManifest: {
+        readonly artifacts: readonly {
+          readonly mountPath: string;
+          readonly vasStorageName: string;
+          readonly missingRootPolicy?: ArtifactEntry["missingRootPolicy"];
+        }[];
+      };
+    };
+
+    expect(
+      executionContext.storageManifest.artifacts.map((artifact) => {
+        return {
+          mountPath: artifact.mountPath,
+          name: artifact.vasStorageName,
+          missingRootPolicy: artifact.missingRootPolicy,
+        };
+      }),
+    ).toStrictEqual([
+      {
+        mountPath: CANONICAL_CLAUDE_MEMORY_MOUNT_PATH,
+        name: "custom-memory",
         missingRootPolicy: undefined,
       },
     ]);

--- a/turbo/apps/api/src/signals/routes/__tests__/agent-runs-create.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/agent-runs-create.test.ts
@@ -4,6 +4,7 @@ import { runsMainContract } from "@vm0/api-contracts/contracts/runs";
 import {
   CANONICAL_CLAUDE_MEMORY_MOUNT_PATH,
   CANONICAL_WORKING_DIR,
+  type ArtifactEntry,
 } from "@vm0/api-contracts/contracts/runners";
 import { MOUNT_PATH_TEMPLATE } from "@vm0/api-contracts/contracts/composes";
 import {
@@ -1423,7 +1424,7 @@ describe("POST /api/agent/runs", () => {
           readonly vasStorageName: string;
           readonly archiveUrl: string;
           readonly manifestUrl?: string;
-          readonly missingRootPolicy?: "preserveParentVersion";
+          readonly missingRootPolicy?: ArtifactEntry["missingRootPolicy"];
         }[];
       };
     };
@@ -1501,7 +1502,7 @@ describe("POST /api/agent/runs", () => {
         readonly artifacts: readonly {
           readonly mountPath: string;
           readonly vasStorageName: string;
-          readonly missingRootPolicy?: "preserveParentVersion";
+          readonly missingRootPolicy?: ArtifactEntry["missingRootPolicy"];
         }[];
       };
     };
@@ -1555,7 +1556,7 @@ describe("POST /api/agent/runs", () => {
         readonly artifacts: readonly {
           readonly mountPath: string;
           readonly vasStorageName: string;
-          readonly missingRootPolicy?: "preserveParentVersion";
+          readonly missingRootPolicy?: ArtifactEntry["missingRootPolicy"];
         }[];
       };
     };
@@ -1957,7 +1958,7 @@ describe("POST /api/agent/runs", () => {
         readonly artifacts: readonly {
           readonly vasStorageName: string;
           readonly mountPath: string;
-          readonly missingRootPolicy?: "preserveParentVersion";
+          readonly missingRootPolicy?: ArtifactEntry["missingRootPolicy"];
         }[];
       };
     };

--- a/turbo/apps/api/src/signals/routes/__tests__/agent-runs-create.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/agent-runs-create.test.ts
@@ -1410,7 +1410,7 @@ describe("POST /api/agent/runs", () => {
           "missingRootPolicy",
         );
       }),
-    ).toBe(false);
+    ).toBeFalsy();
     expect(
       session?.artifacts.find((artifact) => {
         return artifact.name === "memory";
@@ -2050,6 +2050,71 @@ describe("POST /api/agent/runs", () => {
       sessionId: `session-${first.body.runId}`,
     });
     expect(conversationId).toBeDefined();
+  });
+
+  it("keeps continued body memory overrides strict", async () => {
+    const fx = await fixture();
+    const compose = await createCompose({ fixture: fx });
+    const first = await accept(
+      runsClient().create({
+        headers: { authorization: "Bearer clerk-session" },
+        body: { agentComposeId: compose.composeId, prompt: "first" },
+      }),
+      [201],
+    );
+    const db = store.set(writeDb$);
+    await store.set(
+      seedConversationForSession$,
+      { runId: first.body.runId, sessionId: first.body.sessionId },
+      context.signal,
+    );
+    await db
+      .update(agentRuns)
+      .set({ status: "completed", completedAt: nowDate() })
+      .where(eq(agentRuns.id, first.body.runId));
+
+    const continued = await accept(
+      runsClient().create({
+        headers: { authorization: "Bearer clerk-session" },
+        body: {
+          sessionId: first.body.sessionId,
+          prompt: "continue",
+          artifacts: [{ name: "memory", mountPath: "/mnt/user-memory" }],
+        },
+      }),
+      [201],
+    );
+
+    const [job] = await db
+      .select({ executionContext: runnerJobQueue.executionContext })
+      .from(runnerJobQueue)
+      .where(eq(runnerJobQueue.runId, continued.body.runId));
+    expect(job).toBeDefined();
+    const executionContext = job!.executionContext as {
+      readonly storageManifest: {
+        readonly artifacts: readonly {
+          readonly mountPath: string;
+          readonly vasStorageName: string;
+          readonly missingRootPolicy?: ArtifactEntry["missingRootPolicy"];
+        }[];
+      };
+    };
+
+    expect(
+      executionContext.storageManifest.artifacts.map((artifact) => {
+        return {
+          mountPath: artifact.mountPath,
+          name: artifact.vasStorageName,
+          missingRootPolicy: artifact.missingRootPolicy,
+        };
+      }),
+    ).toStrictEqual([
+      {
+        mountPath: "/mnt/user-memory",
+        name: "memory",
+        missingRootPolicy: undefined,
+      },
+    ]);
   });
 
   it("continues a session whose history is stored only in R2 (hash-only conversation)", async () => {

--- a/turbo/apps/api/src/signals/routes/__tests__/agent-runs-create.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/agent-runs-create.test.ts
@@ -1411,6 +1411,11 @@ describe("POST /api/agent/runs", () => {
         );
       }),
     ).toBe(false);
+    expect(
+      session?.artifacts.find((artifact) => {
+        return artifact.name === "memory";
+      })?.generatedBy,
+    ).toBe("apiAutoMemory");
 
     const [job] = await db
       .select({ executionContext: runnerJobQueue.executionContext })
@@ -1568,6 +1573,70 @@ describe("POST /api/agent/runs", () => {
     });
     expect(
       executionContext.storageManifest.artifacts[0]?.missingRootPolicy,
+    ).toBeUndefined();
+  });
+
+  it("keeps continued user-authored canonical memory artifacts strict", async () => {
+    const fx = await fixture();
+    const compose = await createCompose({ fixture: fx });
+
+    const first = await accept(
+      runsClient().create({
+        headers: { authorization: "Bearer clerk-session" },
+        body: {
+          agentComposeId: compose.composeId,
+          prompt: "Use canonical user memory artifact",
+          artifacts: [
+            {
+              name: "memory",
+              mountPath: CANONICAL_CLAUDE_MEMORY_MOUNT_PATH,
+            },
+          ],
+        },
+      }),
+      [201],
+    );
+    const db = store.set(writeDb$);
+    await store.set(
+      seedConversationForSession$,
+      { runId: first.body.runId, sessionId: first.body.sessionId },
+      context.signal,
+    );
+    await db
+      .update(agentRuns)
+      .set({ status: "completed", completedAt: nowDate() })
+      .where(eq(agentRuns.id, first.body.runId));
+
+    const continued = await accept(
+      runsClient().create({
+        headers: { authorization: "Bearer clerk-session" },
+        body: { sessionId: first.body.sessionId, prompt: "continue" },
+      }),
+      [201],
+    );
+
+    const [job] = await db
+      .select({ executionContext: runnerJobQueue.executionContext })
+      .from(runnerJobQueue)
+      .where(eq(runnerJobQueue.runId, continued.body.runId));
+    expect(job).toBeDefined();
+    const executionContext = job!.executionContext as {
+      readonly storageManifest: {
+        readonly artifacts: readonly {
+          readonly mountPath: string;
+          readonly vasStorageName: string;
+          readonly missingRootPolicy?: ArtifactEntry["missingRootPolicy"];
+        }[];
+      };
+    };
+
+    expect(
+      executionContext.storageManifest.artifacts.find((artifact) => {
+        return (
+          artifact.vasStorageName === "memory" &&
+          artifact.mountPath === CANONICAL_CLAUDE_MEMORY_MOUNT_PATH
+        );
+      })?.missingRootPolicy,
     ).toBeUndefined();
   });
 
@@ -2112,5 +2181,156 @@ describe("POST /api/agent/runs", () => {
       .from(agentRuns)
       .where(eq(agentRuns.id, response.body.runId));
     expect(run?.resumedFromCheckpointId).toBe(checkpoint.id);
+  });
+
+  it("preserves auto memory policy when resuming checkpoint artifacts", async () => {
+    const fx = await fixture();
+    const compose = await createCompose({ fixture: fx });
+    const first = await accept(
+      runsClient().create({
+        headers: { authorization: "Bearer clerk-session" },
+        body: { agentComposeId: compose.composeId, prompt: "first" },
+      }),
+      [201],
+    );
+    const conversationId = await store.set(
+      seedConversationForSession$,
+      { runId: first.body.runId, sessionId: first.body.sessionId },
+      context.signal,
+    );
+    const db = store.set(writeDb$);
+    await db
+      .update(agentRuns)
+      .set({ status: "completed", completedAt: nowDate() })
+      .where(eq(agentRuns.id, first.body.runId));
+    const [checkpoint] = await db
+      .insert(checkpoints)
+      .values({
+        runId: first.body.runId,
+        conversationId,
+        agentComposeSnapshot: { agentComposeVersionId: compose.versionId },
+        artifactSnapshots: [
+          {
+            name: "memory",
+            mountPath: CANONICAL_CLAUDE_MEMORY_MOUNT_PATH,
+          },
+        ],
+      })
+      .returning({ id: checkpoints.id });
+    if (!checkpoint) {
+      throw new Error("checkpoint insert returned no row");
+    }
+
+    const response = await accept(
+      runsClient().create({
+        headers: { authorization: "Bearer clerk-session" },
+        body: { checkpointId: checkpoint.id, prompt: "resume" },
+      }),
+      [201],
+    );
+
+    const [job] = await db
+      .select({ executionContext: runnerJobQueue.executionContext })
+      .from(runnerJobQueue)
+      .where(eq(runnerJobQueue.runId, response.body.runId));
+    expect(job).toBeDefined();
+    const executionContext = job!.executionContext as {
+      readonly storageManifest: {
+        readonly artifacts: readonly {
+          readonly mountPath: string;
+          readonly vasStorageName: string;
+          readonly missingRootPolicy?: ArtifactEntry["missingRootPolicy"];
+        }[];
+      };
+    };
+
+    expect(
+      executionContext.storageManifest.artifacts.find((artifact) => {
+        return (
+          artifact.vasStorageName === "memory" &&
+          artifact.mountPath === CANONICAL_CLAUDE_MEMORY_MOUNT_PATH
+        );
+      })?.missingRootPolicy,
+    ).toBe("preserveParentVersion");
+  });
+
+  it("keeps user-authored canonical memory checkpoint artifacts strict", async () => {
+    const fx = await fixture();
+    const compose = await createCompose({ fixture: fx });
+    const first = await accept(
+      runsClient().create({
+        headers: { authorization: "Bearer clerk-session" },
+        body: {
+          agentComposeId: compose.composeId,
+          prompt: "first",
+          artifacts: [
+            {
+              name: "memory",
+              mountPath: CANONICAL_CLAUDE_MEMORY_MOUNT_PATH,
+            },
+          ],
+        },
+      }),
+      [201],
+    );
+    const conversationId = await store.set(
+      seedConversationForSession$,
+      { runId: first.body.runId, sessionId: first.body.sessionId },
+      context.signal,
+    );
+    const db = store.set(writeDb$);
+    await db
+      .update(agentRuns)
+      .set({ status: "completed", completedAt: nowDate() })
+      .where(eq(agentRuns.id, first.body.runId));
+    const [checkpoint] = await db
+      .insert(checkpoints)
+      .values({
+        runId: first.body.runId,
+        conversationId,
+        agentComposeSnapshot: { agentComposeVersionId: compose.versionId },
+        artifactSnapshots: [
+          {
+            name: "memory",
+            mountPath: CANONICAL_CLAUDE_MEMORY_MOUNT_PATH,
+          },
+        ],
+      })
+      .returning({ id: checkpoints.id });
+    if (!checkpoint) {
+      throw new Error("checkpoint insert returned no row");
+    }
+
+    const response = await accept(
+      runsClient().create({
+        headers: { authorization: "Bearer clerk-session" },
+        body: { checkpointId: checkpoint.id, prompt: "resume" },
+      }),
+      [201],
+    );
+
+    const [job] = await db
+      .select({ executionContext: runnerJobQueue.executionContext })
+      .from(runnerJobQueue)
+      .where(eq(runnerJobQueue.runId, response.body.runId));
+    expect(job).toBeDefined();
+    const executionContext = job!.executionContext as {
+      readonly storageManifest: {
+        readonly artifacts: readonly {
+          readonly mountPath: string;
+          readonly vasStorageName: string;
+          readonly missingRootPolicy?: ArtifactEntry["missingRootPolicy"];
+        }[];
+      };
+    };
+
+    expect(
+      executionContext.storageManifest.artifacts.find((artifact) => {
+        return (
+          artifact.vasStorageName === "memory" &&
+          artifact.mountPath === CANONICAL_CLAUDE_MEMORY_MOUNT_PATH
+        );
+      })?.missingRootPolicy,
+    ).toBeUndefined();
   });
 });

--- a/turbo/apps/api/src/signals/routes/__tests__/agent-runs-create.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/agent-runs-create.test.ts
@@ -1402,6 +1402,14 @@ describe("POST /api/agent/runs", () => {
         })
         .sort(),
     ).toStrictEqual(["artifact", "memory"]);
+    expect(
+      session?.artifacts.some((artifact) => {
+        return Object.prototype.hasOwnProperty.call(
+          artifact,
+          "missingRootPolicy",
+        );
+      }),
+    ).toBe(false);
 
     const [job] = await db
       .select({ executionContext: runnerJobQueue.executionContext })
@@ -1415,6 +1423,7 @@ describe("POST /api/agent/runs", () => {
           readonly vasStorageName: string;
           readonly archiveUrl: string;
           readonly manifestUrl?: string;
+          readonly missingRootPolicy?: "preserveParentVersion";
         }[];
       };
     };
@@ -1443,6 +1452,122 @@ describe("POST /api/agent/runs", () => {
         return artifact.archiveUrl && artifact.manifestUrl;
       }),
     ).toBeTruthy();
+    const memoryArtifact = executionContext.storageManifest.artifacts.find(
+      (artifact) => {
+        return artifact.vasStorageName === "memory";
+      },
+    );
+    const requestedArtifact = executionContext.storageManifest.artifacts.find(
+      (artifact) => {
+        return artifact.vasStorageName === "artifact";
+      },
+    );
+    expect(memoryArtifact?.missingRootPolicy).toBe("preserveParentVersion");
+    expect(requestedArtifact?.missingRootPolicy).toBeUndefined();
+  });
+
+  it("keeps user-authored memory artifacts strict", async () => {
+    const fx = await fixture();
+    const compose = await createCompose({ fixture: fx });
+
+    const response = await accept(
+      runsClient().create({
+        headers: { authorization: "Bearer clerk-session" },
+        body: {
+          agentComposeId: compose.composeId,
+          prompt: "Use user memory artifact",
+          artifacts: [{ name: "memory", mountPath: "/mnt/user-memory" }],
+        },
+      }),
+      [201],
+    );
+
+    const db = store.set(writeDb$);
+    const [session] = await db
+      .select({ artifacts: agentSessions.artifacts })
+      .from(agentSessions)
+      .where(eq(agentSessions.id, response.body.sessionId));
+    expect(session?.artifacts).toStrictEqual([
+      { name: "memory", mountPath: "/mnt/user-memory" },
+    ]);
+
+    const [job] = await db
+      .select({ executionContext: runnerJobQueue.executionContext })
+      .from(runnerJobQueue)
+      .where(eq(runnerJobQueue.runId, response.body.runId));
+    expect(job).toBeDefined();
+    const executionContext = job!.executionContext as {
+      readonly storageManifest: {
+        readonly artifacts: readonly {
+          readonly mountPath: string;
+          readonly vasStorageName: string;
+          readonly missingRootPolicy?: "preserveParentVersion";
+        }[];
+      };
+    };
+
+    expect(
+      executionContext.storageManifest.artifacts.map((artifact) => {
+        return {
+          mountPath: artifact.mountPath,
+          name: artifact.vasStorageName,
+          missingRootPolicy: artifact.missingRootPolicy,
+        };
+      }),
+    ).toStrictEqual([
+      {
+        mountPath: "/mnt/user-memory",
+        name: "memory",
+        missingRootPolicy: undefined,
+      },
+    ]);
+  });
+
+  it("keeps user-authored canonical memory artifacts strict", async () => {
+    const fx = await fixture();
+    const compose = await createCompose({ fixture: fx });
+
+    const response = await accept(
+      runsClient().create({
+        headers: { authorization: "Bearer clerk-session" },
+        body: {
+          agentComposeId: compose.composeId,
+          prompt: "Use canonical user memory artifact",
+          artifacts: [
+            {
+              name: "memory",
+              mountPath: CANONICAL_CLAUDE_MEMORY_MOUNT_PATH,
+            },
+          ],
+        },
+      }),
+      [201],
+    );
+
+    const db = store.set(writeDb$);
+    const [job] = await db
+      .select({ executionContext: runnerJobQueue.executionContext })
+      .from(runnerJobQueue)
+      .where(eq(runnerJobQueue.runId, response.body.runId));
+    expect(job).toBeDefined();
+    const executionContext = job!.executionContext as {
+      readonly storageManifest: {
+        readonly artifacts: readonly {
+          readonly mountPath: string;
+          readonly vasStorageName: string;
+          readonly missingRootPolicy?: "preserveParentVersion";
+        }[];
+      };
+    };
+
+    expect(executionContext.storageManifest.artifacts).toHaveLength(1);
+    expect(executionContext.storageManifest.artifacts[0]).toMatchObject({
+      mountPath: CANONICAL_CLAUDE_MEMORY_MOUNT_PATH,
+      vasStorageName: "memory",
+    });
+    expect(
+      executionContext.storageManifest.artifacts[0]?.missingRootPolicy,
+    ).toBeUndefined();
   });
 
   it("includes compose artifacts and volumes in the runner storage manifest", async () => {
@@ -1828,11 +1953,26 @@ describe("POST /api/agent/runs", () => {
     const executionContext = job!.executionContext as {
       readonly resumeSession: { readonly sessionId: string };
       readonly environment: Record<string, string>;
+      readonly storageManifest: {
+        readonly artifacts: readonly {
+          readonly vasStorageName: string;
+          readonly mountPath: string;
+          readonly missingRootPolicy?: "preserveParentVersion";
+        }[];
+      };
     };
     expect(executionContext.resumeSession.sessionId).toBe(
       `session-${first.body.runId}`,
     );
     expect(executionContext.environment.TEST_VAR).toBe("from-first-run");
+    expect(
+      executionContext.storageManifest.artifacts.find((artifact) => {
+        return (
+          artifact.vasStorageName === "memory" &&
+          artifact.mountPath === CANONICAL_CLAUDE_MEMORY_MOUNT_PATH
+        );
+      })?.missingRootPolicy,
+    ).toBe("preserveParentVersion");
     expect(runContextSnapshot(continued.body.runId)).toMatchObject({
       runId: continued.body.runId,
       userId: fx.userId,

--- a/turbo/apps/api/src/signals/routes/__tests__/agent-runs-create.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/agent-runs-create.test.ts
@@ -32,7 +32,7 @@ import { variables } from "@vm0/db/schema/variable";
 import { zeroAgents } from "@vm0/db/schema/zero-agent";
 import { FeatureSwitchKey } from "@vm0/core/feature-switch-key";
 import { createStore, command } from "ccstate";
-import { eq } from "drizzle-orm";
+import { and, eq } from "drizzle-orm";
 import { describe, expect, it } from "vitest";
 
 import { accept, setupApp, testContext } from "../../../__tests__/test-helpers";
@@ -2278,6 +2278,7 @@ describe("POST /api/agent/runs", () => {
           {
             name: "memory",
             mountPath: CANONICAL_CLAUDE_MEMORY_MOUNT_PATH,
+            generatedBy: "apiAutoMemory",
           },
         ],
       })
@@ -2358,6 +2359,112 @@ describe("POST /api/agent/runs", () => {
           {
             name: "memory",
             mountPath: CANONICAL_CLAUDE_MEMORY_MOUNT_PATH,
+          },
+        ],
+      })
+      .returning({ id: checkpoints.id });
+    if (!checkpoint) {
+      throw new Error("checkpoint insert returned no row");
+    }
+
+    const response = await accept(
+      runsClient().create({
+        headers: { authorization: "Bearer clerk-session" },
+        body: { checkpointId: checkpoint.id, prompt: "resume" },
+      }),
+      [201],
+    );
+
+    const [job] = await db
+      .select({ executionContext: runnerJobQueue.executionContext })
+      .from(runnerJobQueue)
+      .where(eq(runnerJobQueue.runId, response.body.runId));
+    expect(job).toBeDefined();
+    const executionContext = job!.executionContext as {
+      readonly storageManifest: {
+        readonly artifacts: readonly {
+          readonly mountPath: string;
+          readonly vasStorageName: string;
+          readonly missingRootPolicy?: ArtifactEntry["missingRootPolicy"];
+        }[];
+      };
+    };
+
+    expect(
+      executionContext.storageManifest.artifacts.find((artifact) => {
+        return (
+          artifact.vasStorageName === "memory" &&
+          artifact.mountPath === CANONICAL_CLAUDE_MEMORY_MOUNT_PATH
+        );
+      })?.missingRootPolicy,
+    ).toBeUndefined();
+  });
+
+  it("keeps continued canonical body memory checkpoint artifacts strict", async () => {
+    const fx = await fixture();
+    const compose = await createCompose({ fixture: fx });
+    const first = await accept(
+      runsClient().create({
+        headers: { authorization: "Bearer clerk-session" },
+        body: { agentComposeId: compose.composeId, prompt: "first" },
+      }),
+      [201],
+    );
+    const firstConversationId = await store.set(
+      seedConversationForSession$,
+      { runId: first.body.runId, sessionId: first.body.sessionId },
+      context.signal,
+    );
+    const db = store.set(writeDb$);
+    await db
+      .update(agentRuns)
+      .set({ status: "completed", completedAt: nowDate() })
+      .where(eq(agentRuns.id, first.body.runId));
+    const continued = await accept(
+      runsClient().create({
+        headers: { authorization: "Bearer clerk-session" },
+        body: {
+          sessionId: first.body.sessionId,
+          prompt: "continue",
+          artifacts: [
+            {
+              name: "memory",
+              mountPath: CANONICAL_CLAUDE_MEMORY_MOUNT_PATH,
+            },
+          ],
+        },
+      }),
+      [201],
+    );
+    await db
+      .update(agentRuns)
+      .set({ status: "completed", completedAt: nowDate() })
+      .where(eq(agentRuns.id, continued.body.runId));
+    const [memoryStorage] = await db
+      .select({ headVersionId: storages.headVersionId })
+      .from(storages)
+      .where(
+        and(
+          eq(storages.orgId, fx.orgId),
+          eq(storages.userId, fx.userId),
+          eq(storages.type, "artifact"),
+          eq(storages.name, "memory"),
+        ),
+      );
+    if (!memoryStorage?.headVersionId) {
+      throw new Error("memory storage has no head version");
+    }
+    const [checkpoint] = await db
+      .insert(checkpoints)
+      .values({
+        runId: continued.body.runId,
+        conversationId: firstConversationId,
+        agentComposeSnapshot: { agentComposeVersionId: compose.versionId },
+        artifactSnapshots: [
+          {
+            name: "memory",
+            mountPath: CANONICAL_CLAUDE_MEMORY_MOUNT_PATH,
+            version: memoryStorage.headVersionId,
           },
         ],
       })

--- a/turbo/apps/api/src/signals/routes/__tests__/webhooks-agent-checkpoints.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/webhooks-agent-checkpoints.test.ts
@@ -545,7 +545,7 @@ describe("POST /api/webhooks/agent/checkpoints", () => {
     expect(checkpoint?.artifactSnapshots).toBeNull();
   });
 
-  it("persists canonical array-shape artifact snapshots verbatim", async () => {
+  it("persists artifact snapshots and strips unsupported provenance", async () => {
     const fixture = await track(seedFixture());
     const artifactSnapshots = [
       {
@@ -558,6 +558,30 @@ describe("POST /api/webhooks/agent/checkpoints", () => {
         version: "version-bbb",
         mountPath: "/home/user/.claude/projects/-home-user-workspace/memory",
         generatedBy: "apiAutoMemory" as const,
+      },
+      {
+        name: "artifact-c",
+        version: "version-ccc",
+        mountPath: "/workspace/c",
+        generatedBy: "apiAutoMemory" as const,
+      },
+    ];
+    const persistedArtifactSnapshots = [
+      {
+        name: "artifact-a",
+        version: "version-aaa",
+        mountPath: "/workspace/a",
+      },
+      {
+        name: "memory",
+        version: "version-bbb",
+        mountPath: "/home/user/.claude/projects/-home-user-workspace/memory",
+        generatedBy: "apiAutoMemory" as const,
+      },
+      {
+        name: "artifact-c",
+        version: "version-ccc",
+        mountPath: "/workspace/c",
       },
     ];
     const body = {
@@ -581,7 +605,9 @@ describe("POST /api/webhooks/agent/checkpoints", () => {
       .from(checkpoints)
       .where(eq(checkpoints.id, response.body.checkpointId))
       .limit(1);
-    expect(checkpoint?.artifactSnapshots).toStrictEqual(artifactSnapshots);
+    expect(checkpoint?.artifactSnapshots).toStrictEqual(
+      persistedArtifactSnapshots,
+    );
   });
 
   it("creates independent sessions for separate runs", async () => {

--- a/turbo/apps/api/src/signals/routes/__tests__/webhooks-agent-checkpoints.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/webhooks-agent-checkpoints.test.ts
@@ -554,9 +554,10 @@ describe("POST /api/webhooks/agent/checkpoints", () => {
         mountPath: "/workspace/a",
       },
       {
-        name: "artifact-b",
+        name: "memory",
         version: "version-bbb",
-        mountPath: "/workspace/b",
+        mountPath: "/home/user/.claude/projects/-home-user-workspace/memory",
+        generatedBy: "apiAutoMemory" as const,
       },
     ];
     const body = {

--- a/turbo/apps/api/src/signals/routes/__tests__/webhooks-agent-checkpoints.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/webhooks-agent-checkpoints.test.ts
@@ -4,6 +4,10 @@ import {
   webhookCheckpointsContract,
   webhookCheckpointsPrepareHistoryContract,
 } from "@vm0/api-contracts/contracts/webhooks";
+import {
+  CANONICAL_CODEX_MEMORY_MOUNT_PATH,
+  CANONICAL_CLAUDE_MEMORY_MOUNT_PATH,
+} from "@vm0/api-contracts/contracts/runners";
 import { agentRuns } from "@vm0/db/schema/agent-run";
 import { agentSessions } from "@vm0/db/schema/agent-session";
 import { blobs } from "@vm0/db/schema/blob";
@@ -556,7 +560,13 @@ describe("POST /api/webhooks/agent/checkpoints", () => {
       {
         name: "memory",
         version: "version-bbb",
-        mountPath: "/home/user/.claude/projects/-home-user-workspace/memory",
+        mountPath: CANONICAL_CLAUDE_MEMORY_MOUNT_PATH,
+        generatedBy: "apiAutoMemory" as const,
+      },
+      {
+        name: "memory",
+        version: "version-codex",
+        mountPath: CANONICAL_CODEX_MEMORY_MOUNT_PATH,
         generatedBy: "apiAutoMemory" as const,
       },
       {
@@ -575,7 +585,13 @@ describe("POST /api/webhooks/agent/checkpoints", () => {
       {
         name: "memory",
         version: "version-bbb",
-        mountPath: "/home/user/.claude/projects/-home-user-workspace/memory",
+        mountPath: CANONICAL_CLAUDE_MEMORY_MOUNT_PATH,
+        generatedBy: "apiAutoMemory" as const,
+      },
+      {
+        name: "memory",
+        version: "version-codex",
+        mountPath: CANONICAL_CODEX_MEMORY_MOUNT_PATH,
         generatedBy: "apiAutoMemory" as const,
       },
       {

--- a/turbo/apps/api/src/signals/routes/__tests__/webhooks-agent-checkpoints.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/webhooks-agent-checkpoints.test.ts
@@ -572,7 +572,7 @@ describe("POST /api/webhooks/agent/checkpoints", () => {
     expect(checkpoint?.artifactSnapshots).toBeNull();
   });
 
-  it("persists artifact snapshots and strips unsupported provenance", async () => {
+  it("persists artifact snapshots without overwriting session artifact declarations", async () => {
     const fixture = await track(seedFixture());
     const artifactSnapshots = [
       {
@@ -634,21 +634,22 @@ describe("POST /api/webhooks/agent/checkpoints", () => {
       .where(eq(agentRuns.id, fixture.runId))
       .limit(1);
     expect(run).toBeDefined();
+    const originalSessionArtifacts = [
+      {
+        name: "memory",
+        mountPath: CANONICAL_CLAUDE_MEMORY_MOUNT_PATH,
+        generatedBy: "apiAutoMemory" as const,
+      },
+      {
+        name: "memory",
+        mountPath: CANONICAL_CODEX_MEMORY_MOUNT_PATH,
+        generatedBy: "apiAutoMemory" as const,
+      },
+    ];
     await db
       .update(agentSessions)
       .set({
-        artifacts: [
-          {
-            name: "memory",
-            mountPath: CANONICAL_CLAUDE_MEMORY_MOUNT_PATH,
-            generatedBy: "apiAutoMemory" as const,
-          },
-          {
-            name: "memory",
-            mountPath: CANONICAL_CODEX_MEMORY_MOUNT_PATH,
-            generatedBy: "apiAutoMemory" as const,
-          },
-        ],
+        artifacts: originalSessionArtifacts,
       })
       .where(eq(agentSessions.id, run!.sessionId));
 
@@ -675,7 +676,7 @@ describe("POST /api/webhooks/agent/checkpoints", () => {
       .from(agentSessions)
       .where(eq(agentSessions.id, run!.sessionId))
       .limit(1);
-    expect(session?.artifacts).toStrictEqual(persistedArtifactSnapshots);
+    expect(session?.artifacts).toStrictEqual(originalSessionArtifacts);
   });
 
   it("strips canonical memory provenance unless the session expects api auto memory", async () => {

--- a/turbo/apps/api/src/signals/routes/__tests__/webhooks-agent-checkpoints.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/webhooks-agent-checkpoints.test.ts
@@ -500,6 +500,24 @@ describe("POST /api/webhooks/agent/checkpoints", () => {
 
   it("accepts checkpoints without artifact snapshots", async () => {
     const fixture = await track(seedFixture());
+    const originalArtifacts = [
+      {
+        name: "existing-artifact",
+        version: "existing-version",
+        mountPath: "/existing",
+      },
+    ];
+    const db = store.set(writeDb$);
+    const [run] = await db
+      .select({ sessionId: agentRuns.sessionId })
+      .from(agentRuns)
+      .where(eq(agentRuns.id, fixture.runId))
+      .limit(1);
+    expect(run).toBeDefined();
+    await db
+      .update(agentSessions)
+      .set({ artifacts: originalArtifacts })
+      .where(eq(agentSessions.id, run!.sessionId));
 
     const response = await accept(
       checkpointClient().create({
@@ -514,13 +532,18 @@ describe("POST /api/webhooks/agent/checkpoints", () => {
     expect(response.body.conversationId).toBeTruthy();
     expect(response.body.artifacts).toBeUndefined();
 
-    const db = store.set(writeDb$);
     const [checkpoint] = await db
       .select({ artifactSnapshots: checkpoints.artifactSnapshots })
       .from(checkpoints)
       .where(eq(checkpoints.id, response.body.checkpointId))
       .limit(1);
     expect(checkpoint?.artifactSnapshots).toBeNull();
+    const [session] = await db
+      .select({ artifacts: agentSessions.artifacts })
+      .from(agentSessions)
+      .where(eq(agentSessions.id, run!.sessionId))
+      .limit(1);
+    expect(session?.artifacts).toStrictEqual(originalArtifacts);
   });
 
   it("normalizes empty artifact snapshots to a missing response field", async () => {
@@ -624,6 +647,18 @@ describe("POST /api/webhooks/agent/checkpoints", () => {
     expect(checkpoint?.artifactSnapshots).toStrictEqual(
       persistedArtifactSnapshots,
     );
+    const [run] = await db
+      .select({ sessionId: agentRuns.sessionId })
+      .from(agentRuns)
+      .where(eq(agentRuns.id, fixture.runId))
+      .limit(1);
+    expect(run).toBeDefined();
+    const [session] = await db
+      .select({ artifacts: agentSessions.artifacts })
+      .from(agentSessions)
+      .where(eq(agentSessions.id, run!.sessionId))
+      .limit(1);
+    expect(session?.artifacts).toStrictEqual(persistedArtifactSnapshots);
   });
 
   it("creates independent sessions for separate runs", async () => {

--- a/turbo/apps/api/src/signals/routes/__tests__/webhooks-agent-checkpoints.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/webhooks-agent-checkpoints.test.ts
@@ -627,6 +627,71 @@ describe("POST /api/webhooks/agent/checkpoints", () => {
       ...minimalCheckpointBody(fixture),
       artifactSnapshots,
     };
+    const db = store.set(writeDb$);
+    const [run] = await db
+      .select({ sessionId: agentRuns.sessionId })
+      .from(agentRuns)
+      .where(eq(agentRuns.id, fixture.runId))
+      .limit(1);
+    expect(run).toBeDefined();
+    await db
+      .update(agentSessions)
+      .set({
+        artifacts: [
+          {
+            name: "memory",
+            mountPath: CANONICAL_CLAUDE_MEMORY_MOUNT_PATH,
+            generatedBy: "apiAutoMemory" as const,
+          },
+          {
+            name: "memory",
+            mountPath: CANONICAL_CODEX_MEMORY_MOUNT_PATH,
+            generatedBy: "apiAutoMemory" as const,
+          },
+        ],
+      })
+      .where(eq(agentSessions.id, run!.sessionId));
+
+    const response = await accept(
+      checkpointClient().create({
+        body,
+        headers: authHeaders(fixture),
+      }),
+      [200],
+    );
+
+    expect(response.body.artifacts).toStrictEqual(artifactSnapshots);
+
+    const [checkpoint] = await db
+      .select({ artifactSnapshots: checkpoints.artifactSnapshots })
+      .from(checkpoints)
+      .where(eq(checkpoints.id, response.body.checkpointId))
+      .limit(1);
+    expect(checkpoint?.artifactSnapshots).toStrictEqual(
+      persistedArtifactSnapshots,
+    );
+    const [session] = await db
+      .select({ artifacts: agentSessions.artifacts })
+      .from(agentSessions)
+      .where(eq(agentSessions.id, run!.sessionId))
+      .limit(1);
+    expect(session?.artifacts).toStrictEqual(persistedArtifactSnapshots);
+  });
+
+  it("strips canonical memory provenance unless the session expects api auto memory", async () => {
+    const fixture = await track(seedFixture());
+    const artifactSnapshots = [
+      {
+        name: "memory",
+        version: "version-bbb",
+        mountPath: CANONICAL_CLAUDE_MEMORY_MOUNT_PATH,
+        generatedBy: "apiAutoMemory" as const,
+      },
+    ];
+    const body = {
+      ...minimalCheckpointBody(fixture),
+      artifactSnapshots,
+    };
 
     const response = await accept(
       checkpointClient().create({
@@ -644,21 +709,13 @@ describe("POST /api/webhooks/agent/checkpoints", () => {
       .from(checkpoints)
       .where(eq(checkpoints.id, response.body.checkpointId))
       .limit(1);
-    expect(checkpoint?.artifactSnapshots).toStrictEqual(
-      persistedArtifactSnapshots,
-    );
-    const [run] = await db
-      .select({ sessionId: agentRuns.sessionId })
-      .from(agentRuns)
-      .where(eq(agentRuns.id, fixture.runId))
-      .limit(1);
-    expect(run).toBeDefined();
-    const [session] = await db
-      .select({ artifacts: agentSessions.artifacts })
-      .from(agentSessions)
-      .where(eq(agentSessions.id, run!.sessionId))
-      .limit(1);
-    expect(session?.artifacts).toStrictEqual(persistedArtifactSnapshots);
+    expect(checkpoint?.artifactSnapshots).toStrictEqual([
+      {
+        name: "memory",
+        version: "version-bbb",
+        mountPath: CANONICAL_CLAUDE_MEMORY_MOUNT_PATH,
+      },
+    ]);
   });
 
   it("creates independent sessions for separate runs", async () => {

--- a/turbo/apps/api/src/signals/services/agent-run-create.service.ts
+++ b/turbo/apps/api/src/signals/services/agent-run-create.service.ts
@@ -183,11 +183,13 @@ interface ContextArtifact {
   readonly name: string;
   readonly version?: string;
   readonly mountPath: string;
+  readonly generatedBy?: "apiAutoMemory";
 }
 
 interface AutoMemoryContextArtifact {
   readonly name: typeof AUTO_MEMORY_ARTIFACT_NAME;
   readonly mountPath: string;
+  readonly generatedBy: "apiAutoMemory";
 }
 
 interface StorageContextArtifact extends ContextArtifact {
@@ -615,6 +617,7 @@ function autoMemoryArtifact(
   return {
     name: AUTO_MEMORY_ARTIFACT_NAME,
     mountPath: autoMemoryMountPath(framework),
+    generatedBy: "apiAutoMemory",
   };
 }
 
@@ -624,8 +627,34 @@ function isAutoMemoryArtifact(
 ): boolean {
   return (
     artifact.name === AUTO_MEMORY_ARTIFACT_NAME &&
-    artifact.mountPath === autoMemoryMountPath(framework)
+    artifact.mountPath === autoMemoryMountPath(framework) &&
+    artifact.generatedBy === "apiAutoMemory"
   );
+}
+
+function mergeArtifactGenerationMetadata(args: {
+  readonly artifacts: readonly ContextArtifact[];
+  readonly sourceArtifacts: readonly ContextArtifact[];
+}): readonly ContextArtifact[] {
+  const generatedByByIdentity = new Map<
+    string,
+    ContextArtifact["generatedBy"]
+  >();
+  for (const artifact of args.sourceArtifacts) {
+    if (artifact.generatedBy) {
+      generatedByByIdentity.set(
+        `${artifact.name}\u0000${artifact.mountPath}`,
+        artifact.generatedBy,
+      );
+    }
+  }
+
+  return args.artifacts.map((artifact) => {
+    const generatedBy = generatedByByIdentity.get(
+      `${artifact.name}\u0000${artifact.mountPath}`,
+    );
+    return generatedBy ? { ...artifact, generatedBy } : artifact;
+  });
 }
 
 function storageArtifactsForRun(
@@ -2480,6 +2509,7 @@ function resolveByCheckpointId(
         .select({
           snapshot: checkpoints.agentComposeSnapshot,
           artifacts: checkpoints.artifactSnapshots,
+          sessionArtifacts: agentSessions.artifacts,
           volumeVersionsSnapshot: checkpoints.volumeVersionsSnapshot,
           conversationId: checkpoints.conversationId,
           runUserId: agentRuns.userId,
@@ -2487,6 +2517,7 @@ function resolveByCheckpointId(
         })
         .from(checkpoints)
         .leftJoin(agentRuns, eq(checkpoints.runId, agentRuns.id))
+        .leftJoin(agentSessions, eq(agentRuns.sessionId, agentSessions.id))
         .where(eq(checkpoints.id, checkpointId))
         .limit(1);
 
@@ -2514,7 +2545,10 @@ function resolveByCheckpointId(
 
       return {
         ...resolved,
-        artifacts: row.artifacts ?? [],
+        artifacts: mergeArtifactGenerationMetadata({
+          artifacts: row.artifacts ?? [],
+          sourceArtifacts: row.sessionArtifacts ?? [],
+        }),
         vars: snapshot.vars ?? {},
         volumeVersions: parseVolumeVersionsSnapshot(row.volumeVersionsSnapshot),
         additionalVolumes: parseAdditionalVolumesSnapshot(

--- a/turbo/apps/api/src/signals/services/agent-run-create.service.ts
+++ b/turbo/apps/api/src/signals/services/agent-run-create.service.ts
@@ -184,6 +184,21 @@ interface ContextArtifact {
   readonly mountPath: string;
 }
 
+interface AutoMemoryContextArtifact {
+  readonly name: typeof AUTO_MEMORY_ARTIFACT_NAME;
+  readonly mountPath: string;
+}
+
+interface StorageContextArtifact extends ContextArtifact {
+  readonly missingRootPolicy?: "preserveParentVersion";
+}
+
+interface RunArtifacts {
+  readonly artifacts: readonly ContextArtifact[];
+  // Index into `artifacts` for API-managed memory checkpoint policy.
+  readonly autoMemoryPolicyArtifactIndex: number | undefined;
+}
+
 interface ComposeArtifact {
   readonly name: string;
   readonly version?: string;
@@ -587,28 +602,44 @@ function frameworkApiKeyEnv(framework: SupportedFramework): string {
   return framework === "codex" ? "OPENAI_API_KEY" : "ANTHROPIC_API_KEY";
 }
 
-function autoMemoryArtifact(framework: SupportedFramework): ContextArtifact {
+function autoMemoryMountPath(framework: SupportedFramework): string {
+  return framework === "codex"
+    ? CODEX_AUTO_MEMORY_MOUNT_PATH
+    : CANONICAL_CLAUDE_MEMORY_MOUNT_PATH;
+}
+
+function autoMemoryArtifact(
+  framework: SupportedFramework,
+): AutoMemoryContextArtifact {
   return {
     name: AUTO_MEMORY_ARTIFACT_NAME,
-    mountPath:
-      framework === "codex"
-        ? CODEX_AUTO_MEMORY_MOUNT_PATH
-        : CANONICAL_CLAUDE_MEMORY_MOUNT_PATH,
+    mountPath: autoMemoryMountPath(framework),
   };
 }
 
-function withAutoMemoryArtifact(
-  artifacts: readonly ContextArtifact[],
+function isAutoMemoryArtifact(
+  artifact: ContextArtifact,
   framework: SupportedFramework,
-): readonly ContextArtifact[] {
-  if (
-    artifacts.some((artifact) => {
-      return artifact.name === AUTO_MEMORY_ARTIFACT_NAME;
-    })
-  ) {
-    return artifacts;
-  }
-  return [...artifacts, autoMemoryArtifact(framework)];
+): boolean {
+  return (
+    artifact.name === AUTO_MEMORY_ARTIFACT_NAME &&
+    artifact.mountPath === autoMemoryMountPath(framework)
+  );
+}
+
+function storageArtifactsForRun(
+  artifacts: readonly ContextArtifact[],
+  autoMemoryPolicyArtifactIndex: number | undefined,
+): readonly StorageContextArtifact[] {
+  return artifacts.map((artifact, index) => {
+    if (index === autoMemoryPolicyArtifactIndex) {
+      return {
+        ...artifact,
+        missingRootPolicy: "preserveParentVersion",
+      };
+    }
+    return artifact;
+  });
 }
 
 function resolveComposeArtifactMountPath(artifact: ComposeArtifact): string {
@@ -631,18 +662,47 @@ function artifactsForRun(args: {
   readonly resolved: ResolvedCompose;
   readonly framework: SupportedFramework;
   readonly bodyArtifacts: readonly ContextArtifact[] | undefined;
-}): readonly ContextArtifact[] {
-  const baseArtifacts =
-    args.resolved.sessionId || args.resolved.resumedFromCheckpointId
-      ? args.resolved.artifacts
-      : [
-          ...composeArtifacts(args.resolved.content),
-          ...args.resolved.artifacts,
-        ];
-  return withAutoMemoryArtifact(
-    [...baseArtifacts, ...(args.bodyArtifacts ?? [])],
-    args.framework,
+}): RunArtifacts {
+  const isContinuation =
+    Boolean(args.resolved.sessionId) ||
+    Boolean(args.resolved.resumedFromCheckpointId);
+  const composeContextArtifacts = isContinuation
+    ? []
+    : composeArtifacts(args.resolved.content);
+  const persistedArtifactStart = composeContextArtifacts.length;
+  const persistedArtifactEnd =
+    persistedArtifactStart + args.resolved.artifacts.length;
+  const baseArtifacts = isContinuation
+    ? args.resolved.artifacts
+    : [...composeContextArtifacts, ...args.resolved.artifacts];
+  const bodyArtifacts = args.bodyArtifacts ?? [];
+  const artifacts = [...baseArtifacts, ...bodyArtifacts];
+  const hasMemoryArtifact = artifacts.some((artifact) => {
+    return artifact.name === AUTO_MEMORY_ARTIFACT_NAME;
+  });
+  if (!hasMemoryArtifact) {
+    return {
+      artifacts: [...artifacts, autoMemoryArtifact(args.framework)],
+      autoMemoryPolicyArtifactIndex: artifacts.length,
+    };
+  }
+
+  const autoMemoryPolicyArtifactIndex = artifacts.findIndex(
+    (artifact, index) => {
+      return (
+        index >= persistedArtifactStart &&
+        index < persistedArtifactEnd &&
+        isAutoMemoryArtifact(artifact, args.framework)
+      );
+    },
   );
+  return {
+    artifacts,
+    autoMemoryPolicyArtifactIndex:
+      autoMemoryPolicyArtifactIndex >= 0
+        ? autoMemoryPolicyArtifactIndex
+        : undefined,
+  };
 }
 
 function runnerGroup(content: AgentComposeContent): string | null {
@@ -3119,6 +3179,7 @@ function buildRunnerJobPayload(
     readonly resolved: ResolvedCompose;
     readonly body: CreateRunBody;
     readonly artifacts: readonly ContextArtifact[];
+    readonly autoMemoryPolicyArtifactIndex: number | undefined;
     readonly framework: SupportedFramework;
     readonly modelProvider: ResolvedModelProviderEnvironment | null;
     readonly connectorContext: ConnectorRuntimeContext;
@@ -3166,7 +3227,10 @@ function buildRunnerJobPayload(
           agentOrgId: args.resolved.orgId,
           runtimeOrgId: args.orgId,
           userId: args.userId,
-          artifacts: args.artifacts,
+          artifacts: storageArtifactsForRun(
+            args.artifacts,
+            args.autoMemoryPolicyArtifactIndex,
+          ),
           volumeVersionOverrides: body.volumeVersions,
           additionalVolumes: args.additionalVolumes,
           framework: args.framework,
@@ -3227,6 +3291,7 @@ function dispatchRun(
     readonly resolved: ResolvedCompose;
     readonly body: CreateRunBody;
     readonly artifacts: readonly ContextArtifact[];
+    readonly autoMemoryPolicyArtifactIndex: number | undefined;
     readonly framework: SupportedFramework;
     readonly modelProvider: ResolvedModelProviderEnvironment | null;
     readonly connectorContext: ConnectorRuntimeContext;
@@ -3299,6 +3364,7 @@ function enqueueRunForConcurrency(
     readonly resolved: ResolvedCompose;
     readonly body: CreateRunBody;
     readonly artifacts: readonly ContextArtifact[];
+    readonly autoMemoryPolicyArtifactIndex: number | undefined;
     readonly framework: SupportedFramework;
     readonly modelProvider: ResolvedModelProviderEnvironment | null;
     readonly connectorContext: ConnectorRuntimeContext;
@@ -3407,6 +3473,7 @@ interface PreparedRunContext {
   readonly connectorContext: ConnectorRuntimeContext;
   readonly customConnectorContext: CustomConnectorRuntimeContext;
   readonly artifacts: readonly ContextArtifact[];
+  readonly autoMemoryPolicyArtifactIndex: number | undefined;
   readonly additionalVolumes: readonly AdditionalVolume[] | undefined;
   readonly userTimezone: string | undefined;
   readonly featureSwitchContext: FeatureSwitchContext;
@@ -3710,7 +3777,7 @@ function prepareRunContext(
       const userTimezone = await loadUserTimezone(db, args);
       signal.throwIfAborted();
 
-      const artifacts = artifactsForRun({
+      const runArtifacts = artifactsForRun({
         resolved,
         framework,
         bodyArtifacts: body.artifacts,
@@ -3727,7 +3794,9 @@ function prepareRunContext(
         modelProvider,
         connectorContext,
         customConnectorContext,
-        artifacts,
+        artifacts: runArtifacts.artifacts,
+        autoMemoryPolicyArtifactIndex:
+          runArtifacts.autoMemoryPolicyArtifactIndex,
         additionalVolumes,
         userTimezone,
         featureSwitchContext,
@@ -3800,6 +3869,8 @@ function completeQueuedRun(input: {
             resolved: input.context.resolved,
             body: input.context.body,
             artifacts: input.context.artifacts,
+            autoMemoryPolicyArtifactIndex:
+              input.context.autoMemoryPolicyArtifactIndex,
             framework: input.context.framework,
             modelProvider: input.context.modelProvider,
             connectorContext: input.context.connectorContext,
@@ -3845,6 +3916,8 @@ function completePendingRun(input: {
             resolved: input.context.resolved,
             body: input.context.body,
             artifacts: input.context.artifacts,
+            autoMemoryPolicyArtifactIndex:
+              input.context.autoMemoryPolicyArtifactIndex,
             framework: input.context.framework,
             modelProvider: input.context.modelProvider,
             connectorContext: input.context.connectorContext,

--- a/turbo/apps/api/src/signals/services/agent-run-create.service.ts
+++ b/turbo/apps/api/src/signals/services/agent-run-create.service.ts
@@ -632,31 +632,6 @@ function isAutoMemoryArtifact(
   );
 }
 
-function mergeArtifactGenerationMetadata(args: {
-  readonly artifacts: readonly ContextArtifact[];
-  readonly sourceArtifacts: readonly ContextArtifact[];
-}): readonly ContextArtifact[] {
-  const generatedByByIdentity = new Map<
-    string,
-    ContextArtifact["generatedBy"]
-  >();
-  for (const artifact of args.sourceArtifacts) {
-    if (artifact.generatedBy) {
-      generatedByByIdentity.set(
-        `${artifact.name}\u0000${artifact.mountPath}`,
-        artifact.generatedBy,
-      );
-    }
-  }
-
-  return args.artifacts.map((artifact) => {
-    const generatedBy = generatedByByIdentity.get(
-      `${artifact.name}\u0000${artifact.mountPath}`,
-    );
-    return generatedBy ? { ...artifact, generatedBy } : artifact;
-  });
-}
-
 function storageArtifactsForRun(
   artifacts: readonly ContextArtifact[],
   autoMemoryPolicyArtifactIndex: number | undefined,
@@ -2512,7 +2487,6 @@ function resolveByCheckpointId(
         .select({
           snapshot: checkpoints.agentComposeSnapshot,
           artifacts: checkpoints.artifactSnapshots,
-          sessionArtifacts: agentSessions.artifacts,
           volumeVersionsSnapshot: checkpoints.volumeVersionsSnapshot,
           conversationId: checkpoints.conversationId,
           runUserId: agentRuns.userId,
@@ -2520,7 +2494,6 @@ function resolveByCheckpointId(
         })
         .from(checkpoints)
         .leftJoin(agentRuns, eq(checkpoints.runId, agentRuns.id))
-        .leftJoin(agentSessions, eq(agentRuns.sessionId, agentSessions.id))
         .where(eq(checkpoints.id, checkpointId))
         .limit(1);
 
@@ -2548,10 +2521,7 @@ function resolveByCheckpointId(
 
       return {
         ...resolved,
-        artifacts: mergeArtifactGenerationMetadata({
-          artifacts: row.artifacts ?? [],
-          sourceArtifacts: row.sessionArtifacts ?? [],
-        }),
+        artifacts: row.artifacts ?? [],
         vars: snapshot.vars ?? {},
         volumeVersions: parseVolumeVersionsSnapshot(row.volumeVersionsSnapshot),
         additionalVolumes: parseAdditionalVolumesSnapshot(

--- a/turbo/apps/api/src/signals/services/agent-run-create.service.ts
+++ b/turbo/apps/api/src/signals/services/agent-run-create.service.ts
@@ -632,6 +632,28 @@ function isAutoMemoryArtifact(
   );
 }
 
+function claimsAutoMemorySlot(
+  artifact: ContextArtifact,
+  framework: SupportedFramework,
+): boolean {
+  return (
+    artifact.name === AUTO_MEMORY_ARTIFACT_NAME ||
+    artifact.mountPath === autoMemoryMountPath(framework)
+  );
+}
+
+function withoutSupersededAutoMemoryArtifacts(
+  artifacts: readonly ContextArtifact[],
+  framework: SupportedFramework,
+  slotOwnerIndex: number,
+): readonly ContextArtifact[] {
+  return artifacts.filter((artifact, index) => {
+    return (
+      index >= slotOwnerIndex || !isAutoMemoryArtifact(artifact, framework)
+    );
+  });
+}
+
 function storageArtifactsForRun(
   artifacts: readonly ContextArtifact[],
   autoMemoryPolicyArtifactIndex: number | undefined,
@@ -682,31 +704,39 @@ function artifactsForRun(args: {
     : [...composeContextArtifacts, ...args.resolved.artifacts];
   const bodyArtifacts = args.bodyArtifacts ?? [];
   const artifacts = [...baseArtifacts, ...bodyArtifacts];
-  const hasMemoryArtifact = artifacts.some((artifact) => {
-    return artifact.name === AUTO_MEMORY_ARTIFACT_NAME;
-  });
-  if (!hasMemoryArtifact) {
+
+  let autoMemorySlotArtifactIndex: number | undefined;
+  for (let index = artifacts.length - 1; index >= 0; index -= 1) {
+    const artifact = artifacts[index];
+    if (artifact && claimsAutoMemorySlot(artifact, args.framework)) {
+      autoMemorySlotArtifactIndex = index;
+      break;
+    }
+  }
+  if (autoMemorySlotArtifactIndex === undefined) {
     return {
       artifacts: [...artifacts, autoMemoryArtifact(args.framework)],
       autoMemoryPolicyArtifactIndex: artifacts.length,
     };
   }
 
-  let autoMemoryPolicyArtifactIndex: number | undefined;
-  for (let index = artifacts.length - 1; index >= 0; index -= 1) {
-    const artifact = artifacts[index];
-    if (!artifact || artifact.name !== AUTO_MEMORY_ARTIFACT_NAME) {
-      continue;
-    }
-    if (
-      index >= persistedArtifactStart &&
-      index < persistedArtifactEnd &&
-      isAutoMemoryArtifact(artifact, args.framework)
-    ) {
-      autoMemoryPolicyArtifactIndex = index;
-    }
-    break;
+  const slotOwner = artifacts[autoMemorySlotArtifactIndex]!;
+  if (!isAutoMemoryArtifact(slotOwner, args.framework)) {
+    return {
+      artifacts: withoutSupersededAutoMemoryArtifacts(
+        artifacts,
+        args.framework,
+        autoMemorySlotArtifactIndex,
+      ),
+      autoMemoryPolicyArtifactIndex: undefined,
+    };
   }
+
+  const autoMemoryPolicyArtifactIndex =
+    autoMemorySlotArtifactIndex >= persistedArtifactStart &&
+    autoMemorySlotArtifactIndex < persistedArtifactEnd
+      ? autoMemorySlotArtifactIndex
+      : undefined;
   return {
     artifacts,
     autoMemoryPolicyArtifactIndex,

--- a/turbo/apps/api/src/signals/services/agent-run-create.service.ts
+++ b/turbo/apps/api/src/signals/services/agent-run-create.service.ts
@@ -1,5 +1,6 @@
 import { command, computed, type Computed } from "ccstate";
 import {
+  CANONICAL_CODEX_MEMORY_MOUNT_PATH,
   CANONICAL_CLAUDE_MEMORY_MOUNT_PATH,
   DEFAULT_PROFILE,
   type ArtifactEntry,
@@ -136,7 +137,6 @@ import { recordSandboxOperation } from "../external/sandbox-op-log";
 const PENDING_RUN_TTL_MS = 15 * 60 * 1000;
 const QUEUED_RUN_TTL_MS = 2 * 60 * 60 * 1000;
 const AUTO_MEMORY_ARTIFACT_NAME = MEMORY_ARTIFACT_NAME;
-const CODEX_AUTO_MEMORY_MOUNT_PATH = "/home/user/.codex/memories";
 
 const TIER_LIMITS = Object.freeze({
   free: 1,
@@ -607,7 +607,7 @@ function frameworkApiKeyEnv(framework: SupportedFramework): string {
 
 function autoMemoryMountPath(framework: SupportedFramework): string {
   return framework === "codex"
-    ? CODEX_AUTO_MEMORY_MOUNT_PATH
+    ? CANONICAL_CODEX_MEMORY_MOUNT_PATH
     : CANONICAL_CLAUDE_MEMORY_MOUNT_PATH;
 }
 

--- a/turbo/apps/api/src/signals/services/agent-run-create.service.ts
+++ b/turbo/apps/api/src/signals/services/agent-run-create.service.ts
@@ -717,21 +717,24 @@ function artifactsForRun(args: {
     };
   }
 
-  const autoMemoryPolicyArtifactIndex = artifacts.findIndex(
-    (artifact, index) => {
-      return (
-        index >= persistedArtifactStart &&
-        index < persistedArtifactEnd &&
-        isAutoMemoryArtifact(artifact, args.framework)
-      );
-    },
-  );
+  let autoMemoryPolicyArtifactIndex: number | undefined;
+  for (let index = artifacts.length - 1; index >= 0; index -= 1) {
+    const artifact = artifacts[index];
+    if (!artifact || artifact.name !== AUTO_MEMORY_ARTIFACT_NAME) {
+      continue;
+    }
+    if (
+      index >= persistedArtifactStart &&
+      index < persistedArtifactEnd &&
+      isAutoMemoryArtifact(artifact, args.framework)
+    ) {
+      autoMemoryPolicyArtifactIndex = index;
+    }
+    break;
+  }
   return {
     artifacts,
-    autoMemoryPolicyArtifactIndex:
-      autoMemoryPolicyArtifactIndex >= 0
-        ? autoMemoryPolicyArtifactIndex
-        : undefined,
+    autoMemoryPolicyArtifactIndex,
   };
 }
 

--- a/turbo/apps/api/src/signals/services/agent-run-create.service.ts
+++ b/turbo/apps/api/src/signals/services/agent-run-create.service.ts
@@ -2,6 +2,7 @@ import { command, computed, type Computed } from "ccstate";
 import {
   CANONICAL_CLAUDE_MEMORY_MOUNT_PATH,
   DEFAULT_PROFILE,
+  type ArtifactEntry,
   type SecretConnectorMetadata,
   type StorageManifest,
   type StoredExecutionContext,
@@ -190,7 +191,7 @@ interface AutoMemoryContextArtifact {
 }
 
 interface StorageContextArtifact extends ContextArtifact {
-  readonly missingRootPolicy?: "preserveParentVersion";
+  readonly missingRootPolicy?: ArtifactEntry["missingRootPolicy"];
 }
 
 interface RunArtifacts {

--- a/turbo/apps/api/src/signals/services/agent-run-storage.service.ts
+++ b/turbo/apps/api/src/signals/services/agent-run-storage.service.ts
@@ -31,6 +31,7 @@ interface ContextArtifact {
   readonly name: string;
   readonly version?: string;
   readonly mountPath: string;
+  readonly missingRootPolicy?: ManifestArtifact["missingRootPolicy"];
 }
 
 interface AdditionalVolume {
@@ -718,6 +719,9 @@ function buildArtifactEntry(args: {
       vasVersionId: resolved.versionId,
       archiveUrl,
       manifestUrl,
+      ...(args.artifact.missingRootPolicy
+        ? { missingRootPolicy: args.artifact.missingRootPolicy }
+        : {}),
     };
   });
 }

--- a/turbo/apps/api/src/signals/services/agent-webhook-checkpoints.service.ts
+++ b/turbo/apps/api/src/signals/services/agent-webhook-checkpoints.service.ts
@@ -82,6 +82,7 @@ function artifactSnapshotsForDb(
       name: snapshot.name,
       version: snapshot.version,
       mountPath: snapshot.mountPath,
+      ...(snapshot.generatedBy ? { generatedBy: snapshot.generatedBy } : {}),
     };
   });
 }

--- a/turbo/apps/api/src/signals/services/agent-webhook-checkpoints.service.ts
+++ b/turbo/apps/api/src/signals/services/agent-webhook-checkpoints.service.ts
@@ -3,6 +3,8 @@ import {
   webhookCheckpointsContract,
   webhookCheckpointsPrepareHistoryContract,
 } from "@vm0/api-contracts/contracts/webhooks";
+import { CANONICAL_CLAUDE_MEMORY_MOUNT_PATH } from "@vm0/api-contracts/contracts/runners";
+import { MEMORY_ARTIFACT_NAME } from "@vm0/core/storage-names";
 import { agentRuns } from "@vm0/db/schema/agent-run";
 import { agentSessions } from "@vm0/db/schema/agent-session";
 import { blobs } from "@vm0/db/schema/blob";
@@ -50,6 +52,7 @@ interface EnrichedVolumeVersionsSnapshot {
 }
 
 const L = logger("webhooks:agent:checkpoints");
+const CODEX_AUTO_MEMORY_MOUNT_PATH = "/home/user/.codex/memories";
 
 function recordOfStringsOrUndefined(
   value: unknown,
@@ -78,11 +81,16 @@ function artifactSnapshotsForDb(
   }
 
   return snapshots.map((snapshot) => {
+    const preserveGeneratedBy =
+      snapshot.generatedBy === "apiAutoMemory" &&
+      snapshot.name === MEMORY_ARTIFACT_NAME &&
+      (snapshot.mountPath === CANONICAL_CLAUDE_MEMORY_MOUNT_PATH ||
+        snapshot.mountPath === CODEX_AUTO_MEMORY_MOUNT_PATH);
     return {
       name: snapshot.name,
       version: snapshot.version,
       mountPath: snapshot.mountPath,
-      ...(snapshot.generatedBy ? { generatedBy: snapshot.generatedBy } : {}),
+      ...(preserveGeneratedBy ? { generatedBy: snapshot.generatedBy } : {}),
     };
   });
 }

--- a/turbo/apps/api/src/signals/services/agent-webhook-checkpoints.service.ts
+++ b/turbo/apps/api/src/signals/services/agent-webhook-checkpoints.service.ts
@@ -22,7 +22,7 @@ import { notFound } from "../../lib/error";
 import { logger } from "../../lib/log";
 import { nowDate } from "../../lib/time";
 import type { SandboxAuth } from "../../types/auth";
-import { writeDb$ } from "../external/db";
+import { writeDb$, type Db } from "../external/db";
 import { generatePresignedPutUrl, s3ObjectExists } from "../external/s3";
 
 type CheckpointCreateBody = z.infer<
@@ -54,6 +54,15 @@ interface EnrichedVolumeVersionsSnapshot {
   readonly additionalVolumes?: readonly AdditionalVolumeSnapshot[];
 }
 
+interface CheckpointRunContext {
+  readonly agentComposeVersionId: string | null;
+  readonly additionalVolumes: typeof agentRuns.$inferSelect.additionalVolumes;
+  readonly secretNames: readonly string[] | null;
+  readonly sessionId: string;
+  readonly sessionArtifacts: readonly ContextArtifact[];
+  readonly vars: unknown;
+}
+
 const L = logger("webhooks:agent:checkpoints");
 
 function recordOfStringsOrUndefined(
@@ -75,19 +84,41 @@ function recordOfStringsOrUndefined(
   return result;
 }
 
-function artifactSnapshotsForDb(
-  snapshots: CheckpointCreateBody["artifactSnapshots"],
-): ContextArtifact[] | null {
-  if (!snapshots || snapshots.length === 0) {
+function isCanonicalMemoryMountPath(mountPath: string): boolean {
+  return (
+    mountPath === CANONICAL_CLAUDE_MEMORY_MOUNT_PATH ||
+    mountPath === CANONICAL_CODEX_MEMORY_MOUNT_PATH
+  );
+}
+
+function isApiAutoMemoryArtifact(artifact: ContextArtifact): boolean {
+  return (
+    artifact.generatedBy === "apiAutoMemory" &&
+    artifact.name === MEMORY_ARTIFACT_NAME &&
+    isCanonicalMemoryMountPath(artifact.mountPath)
+  );
+}
+
+function artifactSnapshotsForDb(args: {
+  readonly snapshots: CheckpointCreateBody["artifactSnapshots"];
+  readonly expectedArtifacts: readonly ContextArtifact[];
+}): ContextArtifact[] | null {
+  if (!args.snapshots || args.snapshots.length === 0) {
     return null;
   }
 
-  return snapshots.map((snapshot) => {
+  return args.snapshots.map((snapshot) => {
     const preserveGeneratedBy =
       snapshot.generatedBy === "apiAutoMemory" &&
       snapshot.name === MEMORY_ARTIFACT_NAME &&
-      (snapshot.mountPath === CANONICAL_CLAUDE_MEMORY_MOUNT_PATH ||
-        snapshot.mountPath === CANONICAL_CODEX_MEMORY_MOUNT_PATH);
+      isCanonicalMemoryMountPath(snapshot.mountPath) &&
+      args.expectedArtifacts.some((artifact) => {
+        return (
+          isApiAutoMemoryArtifact(artifact) &&
+          artifact.name === snapshot.name &&
+          artifact.mountPath === snapshot.mountPath
+        );
+      });
     return {
       name: snapshot.name,
       version: snapshot.version,
@@ -135,6 +166,32 @@ function enrichVolumeSnapshot(args: {
     versions: request.versions,
     ...(additionalVolumes ? { additionalVolumes } : {}),
   };
+}
+
+async function loadCheckpointRunContext(
+  db: Db,
+  input: CheckpointAuthInput<CheckpointCreateBody>,
+): Promise<CheckpointRunContext | undefined> {
+  const [run] = await db
+    .select({
+      agentComposeVersionId: agentRuns.agentComposeVersionId,
+      additionalVolumes: agentRuns.additionalVolumes,
+      secretNames: agentRuns.secretNames,
+      sessionId: agentRuns.sessionId,
+      sessionArtifacts: agentSessions.artifacts,
+      vars: agentRuns.vars,
+    })
+    .from(agentRuns)
+    .innerJoin(agentSessions, eq(agentSessions.id, agentRuns.sessionId))
+    .where(
+      and(
+        eq(agentRuns.id, input.body.runId),
+        eq(agentRuns.userId, input.auth.userId),
+      ),
+    )
+    .limit(1);
+
+  return run;
 }
 
 export const prepareCheckpointHistoryUpload$ = command(
@@ -217,22 +274,7 @@ export const createAgentCheckpoint$ = command(
     signal: AbortSignal,
   ) => {
     const db = set(writeDb$);
-    const [run] = await db
-      .select({
-        agentComposeVersionId: agentRuns.agentComposeVersionId,
-        additionalVolumes: agentRuns.additionalVolumes,
-        secretNames: agentRuns.secretNames,
-        sessionId: agentRuns.sessionId,
-        vars: agentRuns.vars,
-      })
-      .from(agentRuns)
-      .where(
-        and(
-          eq(agentRuns.id, input.body.runId),
-          eq(agentRuns.userId, input.auth.userId),
-        ),
-      )
-      .limit(1);
+    const run = await loadCheckpointRunContext(db, input);
     signal.throwIfAborted();
 
     if (!run) {
@@ -287,9 +329,10 @@ export const createAgentCheckpoint$ = command(
       ...(vars ? { vars } : {}),
       ...(run.secretNames ? { secretNames: run.secretNames } : {}),
     };
-    const artifactSnapshots = artifactSnapshotsForDb(
-      input.body.artifactSnapshots,
-    );
+    const artifactSnapshots = artifactSnapshotsForDb({
+      snapshots: input.body.artifactSnapshots,
+      expectedArtifacts: run.sessionArtifacts,
+    });
     const volumeVersionsSnapshot = enrichVolumeSnapshot({
       request: input.body.volumeVersionsSnapshot,
       additionalVolumes: run.additionalVolumes,

--- a/turbo/apps/api/src/signals/services/agent-webhook-checkpoints.service.ts
+++ b/turbo/apps/api/src/signals/services/agent-webhook-checkpoints.service.ts
@@ -365,7 +365,6 @@ export const createAgentCheckpoint$ = command(
       .update(agentSessions)
       .set({
         conversationId: conversation.id,
-        ...(artifactSnapshots ? { artifacts: artifactSnapshots } : {}),
         updatedAt: nowDate(),
       })
       .where(eq(agentSessions.id, run.sessionId))

--- a/turbo/apps/api/src/signals/services/agent-webhook-checkpoints.service.ts
+++ b/turbo/apps/api/src/signals/services/agent-webhook-checkpoints.service.ts
@@ -322,6 +322,7 @@ export const createAgentCheckpoint$ = command(
       .update(agentSessions)
       .set({
         conversationId: conversation.id,
+        ...(artifactSnapshots ? { artifacts: artifactSnapshots } : {}),
         updatedAt: nowDate(),
       })
       .where(eq(agentSessions.id, run.sessionId))

--- a/turbo/apps/api/src/signals/services/agent-webhook-checkpoints.service.ts
+++ b/turbo/apps/api/src/signals/services/agent-webhook-checkpoints.service.ts
@@ -3,7 +3,10 @@ import {
   webhookCheckpointsContract,
   webhookCheckpointsPrepareHistoryContract,
 } from "@vm0/api-contracts/contracts/webhooks";
-import { CANONICAL_CLAUDE_MEMORY_MOUNT_PATH } from "@vm0/api-contracts/contracts/runners";
+import {
+  CANONICAL_CODEX_MEMORY_MOUNT_PATH,
+  CANONICAL_CLAUDE_MEMORY_MOUNT_PATH,
+} from "@vm0/api-contracts/contracts/runners";
 import { MEMORY_ARTIFACT_NAME } from "@vm0/core/storage-names";
 import { agentRuns } from "@vm0/db/schema/agent-run";
 import { agentSessions } from "@vm0/db/schema/agent-session";
@@ -52,7 +55,6 @@ interface EnrichedVolumeVersionsSnapshot {
 }
 
 const L = logger("webhooks:agent:checkpoints");
-const CODEX_AUTO_MEMORY_MOUNT_PATH = "/home/user/.codex/memories";
 
 function recordOfStringsOrUndefined(
   value: unknown,
@@ -85,7 +87,7 @@ function artifactSnapshotsForDb(
       snapshot.generatedBy === "apiAutoMemory" &&
       snapshot.name === MEMORY_ARTIFACT_NAME &&
       (snapshot.mountPath === CANONICAL_CLAUDE_MEMORY_MOUNT_PATH ||
-        snapshot.mountPath === CODEX_AUTO_MEMORY_MOUNT_PATH);
+        snapshot.mountPath === CANONICAL_CODEX_MEMORY_MOUNT_PATH);
     return {
       name: snapshot.name,
       version: snapshot.version,

--- a/turbo/packages/api-contracts/src/contracts/__tests__/runners.test.ts
+++ b/turbo/packages/api-contracts/src/contracts/__tests__/runners.test.ts
@@ -92,6 +92,24 @@ describe("runner storage manifest contract", () => {
     );
   });
 
+  it("accepts explicit fail missing-root policy on artifact entries", () => {
+    const manifest = storageManifestSchema.parse({
+      storages: [],
+      artifacts: [
+        {
+          mountPath: "/home/user/.claude/projects/-home-user-workspace/memory",
+          vasStorageName: "memory",
+          vasStorageId: "storage-id-1",
+          vasVersionId: "version-2",
+          archiveUrl: "https://storage.example/artifact.tar.gz",
+          missingRootPolicy: "fail",
+        },
+      ],
+    });
+
+    expect(manifest.artifacts[0]?.missingRootPolicy).toBe("fail");
+  });
+
   it("rejects unknown artifact missing-root policies", () => {
     const result = storageManifestSchema.safeParse({
       storages: [],

--- a/turbo/packages/api-contracts/src/contracts/__tests__/runners.test.ts
+++ b/turbo/packages/api-contracts/src/contracts/__tests__/runners.test.ts
@@ -71,6 +71,45 @@ describe("runner storage manifest contract", () => {
     expect(result.success).toBe(false);
   });
 
+  it("accepts preserve-parent missing-root policy on artifact entries", () => {
+    const manifest = storageManifestSchema.parse({
+      storages: [],
+      artifacts: [
+        {
+          mountPath: "/home/user/.claude/projects/-home-user-workspace/memory",
+          vasStorageName: "memory",
+          vasStorageId: "storage-id-1",
+          vasVersionId: "version-2",
+          archiveUrl: "https://storage.example/artifact.tar.gz",
+          manifestUrl: "https://storage.example/manifest.json",
+          missingRootPolicy: "preserveParentVersion",
+        },
+      ],
+    });
+
+    expect(manifest.artifacts[0]?.missingRootPolicy).toBe(
+      "preserveParentVersion",
+    );
+  });
+
+  it("rejects unknown artifact missing-root policies", () => {
+    const result = storageManifestSchema.safeParse({
+      storages: [],
+      artifacts: [
+        {
+          mountPath: "/home/user/.claude/projects/-home-user-workspace/memory",
+          vasStorageName: "memory",
+          vasStorageId: "storage-id-1",
+          vasVersionId: "version-2",
+          archiveUrl: "https://storage.example/artifact.tar.gz",
+          missingRootPolicy: "ignore",
+        },
+      ],
+    });
+
+    expect(result.success).toBe(false);
+  });
+
   it("strips runner-derived guest-download fields", () => {
     const manifest = storageManifestSchema.parse({
       storages: [

--- a/turbo/packages/api-contracts/src/contracts/index.ts
+++ b/turbo/packages/api-contracts/src/contracts/index.ts
@@ -647,6 +647,7 @@ export {
   secretConnectorMetadataSchema,
   secretConnectorMetadataMapSchema,
   storageEntrySchema,
+  CANONICAL_CODEX_MEMORY_MOUNT_PATH,
   CANONICAL_CLAUDE_MEMORY_MOUNT_PATH,
   CANONICAL_WORKING_DIR,
   DEFAULT_PROFILE,

--- a/turbo/packages/api-contracts/src/contracts/runners.ts
+++ b/turbo/packages/api-contracts/src/contracts/runners.ts
@@ -111,6 +111,8 @@ export const storageEntrySchema = z.object({
 /**
  * Artifact entry in manifest
  */
+// Optional internal checkpoint behavior for a missing artifact root. Absence
+// is equivalent to "fail".
 export const artifactMissingRootPolicySchema = z.enum([
   "fail",
   "preserveParentVersion",

--- a/turbo/packages/api-contracts/src/contracts/runners.ts
+++ b/turbo/packages/api-contracts/src/contracts/runners.ts
@@ -17,6 +17,7 @@ const CANONICAL_CLAUDE_PROJECT_NAME = CANONICAL_WORKING_DIR.replace(
   "",
 ).replace(/\//g, "-");
 export const CANONICAL_CLAUDE_MEMORY_MOUNT_PATH = `/home/user/.claude/projects/-${CANONICAL_CLAUDE_PROJECT_NAME}/memory`;
+export const CANONICAL_CODEX_MEMORY_MOUNT_PATH = "/home/user/.codex/memories";
 
 export function elapsedSinceApiStartMs(
   apiStartTimeMs: number | undefined,

--- a/turbo/packages/api-contracts/src/contracts/runners.ts
+++ b/turbo/packages/api-contracts/src/contracts/runners.ts
@@ -112,6 +112,7 @@ export const storageEntrySchema = z.object({
  * Artifact entry in manifest
  */
 export const artifactMissingRootPolicySchema = z.enum([
+  "fail",
   "preserveParentVersion",
 ]);
 

--- a/turbo/packages/api-contracts/src/contracts/runners.ts
+++ b/turbo/packages/api-contracts/src/contracts/runners.ts
@@ -111,6 +111,10 @@ export const storageEntrySchema = z.object({
 /**
  * Artifact entry in manifest
  */
+export const artifactMissingRootPolicySchema = z.enum([
+  "preserveParentVersion",
+]);
+
 export const artifactEntrySchema = z.object({
   mountPath: z.string(),
   vasStorageName: z.string(),
@@ -118,6 +122,7 @@ export const artifactEntrySchema = z.object({
   vasVersionId: z.string(),
   archiveUrl: z.string(),
   manifestUrl: z.string().optional(),
+  missingRootPolicy: artifactMissingRootPolicySchema.optional(),
 });
 
 /**

--- a/turbo/packages/api-contracts/src/contracts/webhooks.ts
+++ b/turbo/packages/api-contracts/src/contracts/webhooks.ts
@@ -158,6 +158,9 @@ const artifactSnapshotsSchema = z.array(
     name: z.string(),
     version: z.string(),
     mountPath: z.string(),
+    // Internal provenance used by run creation to decide checkpoint-time
+    // behavior on a later resume. It is not exposed by public checkpoint APIs.
+    generatedBy: z.literal("apiAutoMemory").optional(),
   }),
 );
 

--- a/turbo/packages/api-contracts/src/rust-bindings/__tests__/types.test.ts
+++ b/turbo/packages/api-contracts/src/rust-bindings/__tests__/types.test.ts
@@ -128,6 +128,8 @@ describe("Rust type bindings", () => {
     expect(firstRender).toContain("pub storages: Vec<StorageEntry>,");
     expect(firstRender).toContain("pub artifacts: Vec<ArtifactEntry>,");
     expect(firstRender).toContain("pub enum ArtifactEntryMissingRootPolicy {");
+    expect(firstRender).toContain("Fail,");
+    expect(firstRender).toContain("PreserveParentVersion,");
     expect(firstRender).toContain(
       "pub missing_root_policy: Option<ArtifactEntryMissingRootPolicy>,",
     );

--- a/turbo/packages/api-contracts/src/rust-bindings/__tests__/types.test.ts
+++ b/turbo/packages/api-contracts/src/rust-bindings/__tests__/types.test.ts
@@ -127,6 +127,10 @@ describe("Rust type bindings", () => {
     expect(firstRender).toContain("pub struct StorageManifest {");
     expect(firstRender).toContain("pub storages: Vec<StorageEntry>,");
     expect(firstRender).toContain("pub artifacts: Vec<ArtifactEntry>,");
+    expect(firstRender).toContain("pub enum ArtifactEntryMissingRootPolicy {");
+    expect(firstRender).toContain(
+      "pub missing_root_policy: Option<ArtifactEntryMissingRootPolicy>,",
+    );
   });
 
   it("keeps storage manifest field overrides aligned with entry schemas", () => {

--- a/turbo/packages/db/src/types.ts
+++ b/turbo/packages/db/src/types.ts
@@ -2,4 +2,5 @@ export interface ContextArtifact {
   name: string;
   version?: string;
   mountPath: string;
+  generatedBy?: "apiAutoMemory";
 }


### PR DESCRIPTION
## Summary

- add an internal `preserveParentVersion` missing-root policy to runner artifact entries
- apply the policy only to API-managed auto memory artifacts, while keeping user-authored artifacts strict
- preserve the parent memory artifact version during checkpoint when the auto memory root is missing instead of failing the run
- keep normal artifact snapshots, session artifact output, and guest-download behavior strict by default

Closes #15950

## Testing

- `pnpm -F api exec vitest run src/signals/routes/__tests__/agent-runs-create.test.ts`
- `pnpm -F @vm0/api-contracts test -- src/contracts/__tests__/runners.test.ts src/rust-bindings/__tests__/types.test.ts`
- `pnpm -F @vm0/api-contracts check-types`
- `pnpm -F api check-types`
- `pnpm -F web check-types`
- `pnpm check-types`
- `cargo fmt --manifest-path crates/Cargo.toml --all`
- `cargo test --manifest-path crates/Cargo.toml -p guest-agent --lib checkpoint::tests -j1`
- `cargo test --manifest-path crates/Cargo.toml -p runner --bin runner missing_root -j1`
- `cargo test --manifest-path crates/Cargo.toml -p runner --bin runner storage_manifest -j1`
- `cargo test --manifest-path crates/Cargo.toml -p runner --bin runner guest_download_manifest_serialization_omits_api_only_fields -j1`
- `cargo test --manifest-path crates/Cargo.toml -p api-contracts -j1`
- `cargo test --manifest-path crates/Cargo.toml -p guest-download`
- `cargo clippy --manifest-path crates/Cargo.toml -p runner --bin runner --tests -j1 -- -D warnings`
- pre-commit hook: prettier, knip, cargo doc/fmt/clippy, full typecheck, commitlint
