### PR TITLE
fix: render website thumbnails at desktop viewport

### DIFF
--- a/turbo/apps/platform/src/views/zero-page/__tests__/zero-attachment-preview.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/zero-attachment-preview.test.tsx
@@ -545,6 +545,29 @@ describe("document thumbnail preview", () => {
     expect(iframe).toHaveAttribute("tabindex", "-1");
   });
 
+  it("renders HTML site previews from a desktop-sized viewport", () => {
+    render(
+      <StoreProvider value={context.store}>
+        <AttachmentPreview
+          attachment={{
+            filename: "page.html",
+            url: "https://example.com/page.html",
+          }}
+        />
+      </StoreProvider>,
+    );
+
+    const preview = screen.getByTestId("attachment-preview-html");
+    const viewport = within(preview).getByTestId(
+      "attachment-preview-html-viewport",
+    );
+
+    expect(viewport).toHaveClass("h-[400%]", "w-[400%]", "scale-[0.25]");
+    expect(
+      within(viewport).getByTitle("Site preview for page.html"),
+    ).toHaveAttribute("scrolling", "no");
+  });
+
   it("uses the hosted site slug as the fallback site preview card title", () => {
     const url = "https://tabby-cat-guide-35a4112d.sites.vm7.io";
     render(

--- a/turbo/apps/platform/src/views/zero-page/zero-attachment-preview.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-attachment-preview.tsx
@@ -239,20 +239,27 @@ function HtmlSitePreviewCard({
           {title}
         </span>
       </div>
-      <div className="relative aspect-[16/10] bg-muted/30">
-        <iframe
-          src={IN_VITEST ? undefined : publicUrl}
-          srcDoc={
-            IN_VITEST ? "<!doctype html><html><body></body></html>" : undefined
-          }
-          data-preview-src={publicUrl}
-          title={`Site preview for ${title}`}
-          sandbox="allow-scripts"
-          tabIndex={-1}
-          loading="lazy"
-          scrolling="no"
-          className="pointer-events-none h-full w-full origin-top-left bg-background transition-transform duration-200 group-hover/site-preview:scale-[1.01]"
-        />
+      <div className="relative aspect-[16/10] overflow-hidden bg-muted/30">
+        <div
+          data-testid="attachment-preview-html-viewport"
+          className="pointer-events-none absolute left-0 top-0 h-[400%] w-[400%] origin-top-left scale-[0.25]"
+        >
+          <iframe
+            src={IN_VITEST ? undefined : publicUrl}
+            srcDoc={
+              IN_VITEST
+                ? "<!doctype html><html><body></body></html>"
+                : undefined
+            }
+            data-preview-src={publicUrl}
+            title={`Site preview for ${title}`}
+            sandbox="allow-scripts"
+            tabIndex={-1}
+            loading="lazy"
+            scrolling="no"
+            className="pointer-events-none h-full w-full bg-background"
+          />
+        </div>
       </div>
     </a>
   );


### PR DESCRIPTION
## Summary
- Render HTML site preview thumbnails through a 4x backing iframe viewport, so the existing 320px thumbnail uses a 1280px-wide page viewport before downscaling.
- Keep the preview non-interactive and clipped to the current thumbnail card.
- Add regression coverage for the desktop-sized site preview viewport wrapper.

Fixes #15949

## Tests
- pnpm format
- pnpm turbo run lint
- pnpm check-types
- pnpm knip
- pnpm -F @vm0/app exec vitest run src/views/zero-page/__tests__/zero-attachment-preview.test.tsx
- pnpm -F @vm0/db exec vitest run src/__tests__/migrations/0420_backfill_user_permission_grants.test.ts

## Local notes
- `pnpm vitest` was attempted. After syncing migrations, the persistent isolated failure is `@vm0/desktop src/computer-use-native.test.ts`, where macOS-only native computer-use CLI checks report `accessibility_unavailable` in this Linux container.