### PR TITLE
fix: cache workspace images only on destroy

### DIFF
--- a/crates/runner/src/cmd/gc.rs
+++ b/crates/runner/src/cmd/gc.rs
@@ -768,14 +768,8 @@ async fn gc_orphaned_locks(home: &HomePaths, dry_run: bool) -> RunnerResult<u64>
 
         let lock_path = entry.path();
         match probe_lock(&lock_path) {
-            LockProbe::Free(_lock) => {
-                if dry_run {
-                    info!("[dry-run] would remove unused lock {name}");
-                    removed += 1;
-                } else if let Err(e) = tokio::fs::remove_file(&lock_path).await {
-                    warn!("cannot remove {}: {e}", lock_path.display());
-                } else {
-                    info!("removed unused lock {name}");
+            LockProbe::Free(lock) => {
+                if remove_unused_lock_after_probe(&lock_path, &lock, name, dry_run).await {
                     removed += 1;
                 }
             }
@@ -784,6 +778,38 @@ async fn gc_orphaned_locks(home: &HomePaths, dry_run: bool) -> RunnerResult<u64>
     }
 
     Ok(removed)
+}
+
+async fn remove_unused_lock_after_probe(
+    lock_path: &Path,
+    lock: &Flock<std::fs::File>,
+    name: &str,
+    dry_run: bool,
+) -> bool {
+    match lock_probe_inode_is_current(lock, lock_path) {
+        Ok(true) => {}
+        Ok(false) => return false,
+        Err(e) => {
+            warn!("{e}");
+            return false;
+        }
+    }
+
+    if dry_run {
+        info!("[dry-run] would remove unused lock {name}");
+        return true;
+    }
+
+    match tokio::fs::remove_file(lock_path).await {
+        Ok(()) => {
+            info!("removed unused lock {name}");
+            true
+        }
+        Err(e) => {
+            warn!("cannot remove {}: {e}", lock_path.display());
+            false
+        }
+    }
 }
 
 /// Delete stale log files (older than [`JOB_LOG_MAX_AGE`]).
@@ -1849,6 +1875,42 @@ mod tests {
         assert!(
             !lock_file_inode_is_current(&file, &path).unwrap(),
             "inode check must reject an opened lock fd whose path was recreated"
+        );
+    }
+
+    #[tokio::test]
+    async fn remove_unused_lock_after_probe_keeps_replaced_lock_path() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir
+            .path()
+            .join("locks")
+            .join("workspace-image-cache-test.lock");
+
+        let held_lock = match probe_lock(&path) {
+            LockProbe::Free(lock) => lock,
+            LockProbe::Held => panic!("new test lock must not be held"),
+            LockProbe::Error(e) => panic!("new test lock must be probeable: {e}"),
+        };
+
+        std::fs::remove_file(&path).unwrap();
+        drop(lock::open_lock_file(&path).unwrap());
+        assert!(
+            path.exists(),
+            "test setup must recreate the lock path with a new inode"
+        );
+
+        let removed = remove_unused_lock_after_probe(
+            &path,
+            &held_lock,
+            "workspace-image-cache-test.lock",
+            false,
+        )
+        .await;
+
+        assert!(!removed, "stale lock fd must not remove a recreated path");
+        assert!(
+            path.exists(),
+            "cleanup must not remove a lock path recreated after this lock was acquired"
         );
     }
 

--- a/crates/runner/src/cmd/start/idle_lifecycle.rs
+++ b/crates/runner/src/cmd/start/idle_lifecycle.rs
@@ -185,7 +185,10 @@ mod tests {
     use std::time::Duration;
 
     use async_trait::async_trait;
-    use sandbox::{Sandbox, SandboxFactory, SandboxId};
+    use sandbox::{
+        CopyFileOptions, CopyFileResult, ExecRequest, ExecResult, GuestProcessHandle, ProcessExit,
+        Sandbox, SandboxFactory, SandboxId, StartProcessRequest,
+    };
     use sandbox_mock::{MockSandbox, MockSandboxFactory};
 
     use crate::idle_pool::{
@@ -253,6 +256,79 @@ mod tests {
         }
 
         async fn shutdown(&mut self) {}
+    }
+
+    struct PanicExecSandbox {
+        id: String,
+    }
+
+    impl PanicExecSandbox {
+        fn new(id: impl Into<String>) -> Self {
+            Self { id: id.into() }
+        }
+    }
+
+    #[async_trait]
+    impl Sandbox for PanicExecSandbox {
+        fn id(&self) -> &str {
+            &self.id
+        }
+
+        fn source_ip(&self) -> &str {
+            "10.0.0.1"
+        }
+
+        async fn start(&mut self) -> sandbox::Result<()> {
+            Ok(())
+        }
+
+        async fn stop(&mut self) -> sandbox::Result<()> {
+            Ok(())
+        }
+
+        async fn kill(&mut self) -> sandbox::Result<()> {
+            Ok(())
+        }
+
+        async fn exec(&self, _request: &ExecRequest<'_>) -> sandbox::Result<ExecResult> {
+            panic!("simulated exec panic");
+        }
+
+        async fn read_file(
+            &self,
+            _path: &str,
+            _max_bytes: u64,
+        ) -> sandbox::Result<Option<Vec<u8>>> {
+            Ok(None)
+        }
+
+        async fn copy_file(
+            &self,
+            _path: &str,
+            _host_path: &std::path::Path,
+            _options: CopyFileOptions,
+        ) -> sandbox::Result<CopyFileResult> {
+            panic!("unused copy_file");
+        }
+
+        async fn write_file(&self, _path: &str, _content: &[u8]) -> sandbox::Result<()> {
+            Ok(())
+        }
+
+        async fn start_process(
+            &self,
+            _request: &StartProcessRequest<'_>,
+        ) -> sandbox::Result<GuestProcessHandle> {
+            panic!("unused start_process");
+        }
+
+        async fn wait_process(
+            &self,
+            _handle: GuestProcessHandle,
+            _timeout: Duration,
+        ) -> sandbox::Result<ProcessExit> {
+            panic!("unused wait_process");
+        }
     }
 
     #[tokio::test]
@@ -451,5 +527,80 @@ mod tests {
         let held = cache.held_session_states().await;
         assert_eq!(held.len(), 1);
         assert_eq!(held[0].session_id, session_id);
+    }
+
+    #[tokio::test]
+    async fn idle_destroy_exec_panic_skips_workspace_cache_and_still_destroys() {
+        let dir = tempfile::tempdir().unwrap();
+        let paths = RunnerPaths::new(dir.path().join("runner"));
+        tokio::fs::create_dir_all(paths.base_dir()).await.unwrap();
+        let cache = SessionWorkspaceCache::new(paths.clone());
+        let run_id = RunId::new_v4();
+        let sandbox_id = SandboxId::new_v4();
+        let session_id = "sess-idle-destroy-exec-panic";
+        let image = b"workspace image";
+        let workspace_image = cache
+            .prepare(WorkspaceImagePrepareRequest {
+                run_id,
+                sandbox_id,
+                profile_name: "vm0/default",
+                session_id: Some(session_id),
+                working_dir: CANONICAL_WORKING_DIR,
+                image_size_bytes: image.len() as u64,
+                workspace_drive_required: true,
+            })
+            .await;
+        tokio::fs::create_dir_all(paths.workspace_dir(&sandbox_id))
+            .await
+            .unwrap();
+        tokio::fs::write(paths.active_workspace_image(&sandbox_id), image)
+            .await
+            .unwrap();
+        let workspace_promotion = workspace_image
+            .into_promotion_context(WorkspaceImagePromotionRequest {
+                run_id,
+                sandbox_id,
+                session_id_override: Some(session_id),
+                terminal_status: WorkspaceCacheTerminalStatus::Success,
+                completed_at: "2026-06-03T00:00:00.000Z".into(),
+                storage_fingerprints: StorageFingerprints::default(),
+                promotable: true,
+            })
+            .expect("workspace image should be promotable");
+
+        let budget = Arc::new(ResourceBudget::new(2, 4096, 1.0, 0));
+        let lease = ResourceBudget::try_reserve_lease(&budget, 2, 4096).unwrap();
+        let destroy_count = Arc::new(AtomicUsize::new(0));
+        let request = IdleParkRequest::new(IdleParkRequestParts {
+            sandbox: Box::new(PanicExecSandbox::new("idle-destroy-exec-panic")),
+            factory: Arc::new(Box::new(RecordingDestroyFactory {
+                destroy_count: Arc::clone(&destroy_count),
+            }) as Box<dyn SandboxFactory>),
+            session_id: session_id.into(),
+            sandbox_id,
+            profile_name: "vm0/default".into(),
+            device_rate_limits: None,
+            budget_lease: lease,
+            source_ip: "10.0.0.1".into(),
+            storage_fingerprints: StorageFingerprints::default(),
+            workspace_promotion: Some(workspace_promotion),
+        });
+        let candidate = match request.park_for_idle().await {
+            Ok(candidate) => candidate.with_last_completed_at("2026-06-03T00:00:00.000Z".into()),
+            Err(_) => panic!("park should succeed"),
+        };
+        let mut pool = IdlePool::new(IdlePoolConfig {
+            default_timeout: Duration::from_secs(300),
+            max_idle: 0,
+        });
+        assert!(matches!(pool.park(candidate), ParkResult::Parked));
+
+        let promoted =
+            destroy_idle_jobs_and_wait(pool.drain(), "test_idle_destroy_exec_panic").await;
+
+        assert!(!promoted);
+        assert_eq!(destroy_count.load(Ordering::SeqCst), 1);
+        assert_eq!(budget.allocated(), (0, 0, 0));
+        assert!(cache.held_session_states().await.is_empty());
     }
 }

--- a/crates/runner/src/cmd/start/idle_lifecycle.rs
+++ b/crates/runner/src/cmd/start/idle_lifecycle.rs
@@ -7,7 +7,8 @@ use tokio::task::JoinSet;
 use tracing::{info, warn};
 
 use crate::idle_pool::{
-    DestroyOutcome, IdleDestroyJob, IdleDestroyPayload, IdlePool, IdlePoolSnapshot,
+    DestroyOutcome, IdleDestroyJob, IdleDestroyPayload, IdleDestroyResult, IdlePool,
+    IdlePoolSnapshot,
 };
 use crate::ids::RunId;
 use crate::status::StatusTracker;
@@ -149,20 +150,23 @@ pub(super) async fn destroy_idle_jobs_and_wait(jobs: Vec<IdleDestroyJob>, contex
 }
 
 /// Destroy an idle sandbox entry. Its budget lease is released by Drop.
-async fn destroy_idle_job(job: IdleDestroyJob, _context: &'static str) {
-    job.run().await;
+async fn destroy_idle_job(job: IdleDestroyJob, context: &'static str) {
+    job.run_with_context(context).await;
 }
 
 pub(super) async fn destroy_idle_payload_and_wait(
     payload: IdleDestroyPayload,
     context: &'static str,
-) -> DestroyOutcome {
-    let handle = tokio::spawn(payload.stop_and_destroy());
+) -> IdleDestroyResult {
+    let handle = tokio::spawn(payload.promote_then_stop_and_destroy(context));
     match handle.await {
         Ok(outcome) => outcome,
         Err(e) => {
             warn!(context, error = %e, "idle payload destroy task panicked");
-            DestroyOutcome::Uncertain
+            IdleDestroyResult {
+                outcome: DestroyOutcome::Uncertain,
+                workspace_cache_promoted: false,
+            }
         }
     }
 }

--- a/crates/runner/src/cmd/start/idle_lifecycle.rs
+++ b/crates/runner/src/cmd/start/idle_lifecycle.rs
@@ -530,6 +530,117 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn idle_destroy_unpark_error_skips_workspace_cache_and_still_destroys() {
+        assert_idle_destroy_unpark_failure_skips_workspace_cache_and_still_destroys(
+            "sess-idle-destroy-unpark-error",
+            |overrides| {
+                overrides.push_unpark_result(Err(sandbox::SandboxError::IdleTransition {
+                    transition: sandbox::SandboxIdleTransition::Unpark,
+                    message: "simulated unpark failure".into(),
+                }));
+            },
+        )
+        .await;
+    }
+
+    #[tokio::test]
+    async fn idle_destroy_unpark_panic_skips_workspace_cache_and_still_destroys() {
+        assert_idle_destroy_unpark_failure_skips_workspace_cache_and_still_destroys(
+            "sess-idle-destroy-unpark-panic",
+            |overrides| overrides.push_unpark_panic("simulated unpark panic"),
+        )
+        .await;
+    }
+
+    async fn assert_idle_destroy_unpark_failure_skips_workspace_cache_and_still_destroys(
+        session_id: &str,
+        configure_overrides: impl FnOnce(&sandbox_mock::MockSandboxOverrides),
+    ) {
+        let dir = tempfile::tempdir().unwrap();
+        let paths = RunnerPaths::new(dir.path().join("runner"));
+        tokio::fs::create_dir_all(paths.base_dir()).await.unwrap();
+        let cache = SessionWorkspaceCache::new(paths.clone());
+        let run_id = RunId::new_v4();
+        let sandbox_id = SandboxId::new_v4();
+        let image = b"workspace image";
+        let workspace_image = cache
+            .prepare(WorkspaceImagePrepareRequest {
+                run_id,
+                sandbox_id,
+                profile_name: "vm0/default",
+                session_id: Some(session_id),
+                working_dir: CANONICAL_WORKING_DIR,
+                image_size_bytes: image.len() as u64,
+                workspace_drive_required: true,
+            })
+            .await;
+        tokio::fs::create_dir_all(paths.workspace_dir(&sandbox_id))
+            .await
+            .unwrap();
+        tokio::fs::write(paths.active_workspace_image(&sandbox_id), image)
+            .await
+            .unwrap();
+        let workspace_promotion = workspace_image
+            .into_promotion_context(WorkspaceImagePromotionRequest {
+                run_id,
+                sandbox_id,
+                session_id_override: Some(session_id),
+                terminal_status: WorkspaceCacheTerminalStatus::Success,
+                completed_at: "2026-06-03T00:00:00.000Z".into(),
+                storage_fingerprints: StorageFingerprints::default(),
+                promotable: true,
+            })
+            .expect("workspace image should be promotable");
+
+        let overrides = Arc::new(sandbox_mock::MockSandboxOverrides::new());
+        configure_overrides(&overrides);
+        let sandbox_factory = MockSandboxFactory::with_overrides(Arc::clone(&overrides));
+        let sandbox = sandbox_factory
+            .create(sandbox::SandboxConfig {
+                id: sandbox_id,
+                resources: sandbox::ResourceLimits {
+                    cpu_count: 2,
+                    memory_mb: 4096,
+                },
+                device_rate_limits: None,
+                workspace_drive: None,
+            })
+            .await
+            .expect("create sandbox");
+        let budget = Arc::new(ResourceBudget::new(2, 4096, 1.0, 0));
+        let lease = ResourceBudget::try_reserve_lease(&budget, 2, 4096).unwrap();
+        let request = IdleParkRequest::new(IdleParkRequestParts {
+            sandbox,
+            factory: Arc::new(Box::new(sandbox_factory) as Box<dyn SandboxFactory>),
+            session_id: session_id.into(),
+            sandbox_id,
+            profile_name: "vm0/default".into(),
+            device_rate_limits: None,
+            budget_lease: lease,
+            source_ip: "10.0.0.1".into(),
+            storage_fingerprints: StorageFingerprints::default(),
+            workspace_promotion: Some(workspace_promotion),
+        });
+        let candidate = match request.park_for_idle().await {
+            Ok(candidate) => candidate.with_last_completed_at("2026-06-03T00:00:00.000Z".into()),
+            Err(_) => panic!("park should succeed"),
+        };
+        let mut pool = IdlePool::new(IdlePoolConfig {
+            default_timeout: Duration::from_secs(300),
+            max_idle: 0,
+        });
+        assert!(matches!(pool.park(candidate), ParkResult::Parked));
+
+        let promoted =
+            destroy_idle_jobs_and_wait(pool.drain(), "test_idle_destroy_unpark_error").await;
+
+        assert!(!promoted);
+        assert_eq!(overrides.destroy_call_count(), 1);
+        assert_eq!(budget.allocated(), (0, 0, 0));
+        assert!(cache.held_session_states().await.is_empty());
+    }
+
+    #[tokio::test]
     async fn idle_destroy_exec_panic_skips_workspace_cache_and_still_destroys() {
         let dir = tempfile::tempdir().unwrap();
         let paths = RunnerPaths::new(dir.path().join("runner"));

--- a/crates/runner/src/cmd/start/idle_lifecycle.rs
+++ b/crates/runner/src/cmd/start/idle_lifecycle.rs
@@ -126,7 +126,7 @@ pub(super) async fn add_run_with_idle_status_snapshot(
 }
 
 pub(super) fn spawn_idle_destroy_job(
-    destroy_tasks: &mut JoinSet<()>,
+    destroy_tasks: &mut JoinSet<bool>,
     job: IdleDestroyJob,
     context: &'static str,
 ) {
@@ -134,7 +134,10 @@ pub(super) fn spawn_idle_destroy_job(
 }
 
 /// Destroy idle entries in parallel and wait until their leases are dropped.
-pub(super) async fn destroy_idle_jobs_and_wait(jobs: Vec<IdleDestroyJob>, context: &'static str) {
+pub(super) async fn destroy_idle_jobs_and_wait(
+    jobs: Vec<IdleDestroyJob>,
+    context: &'static str,
+) -> bool {
     // Destroy in parallel -- each `stop_and_destroy` is ~1-3s (FC shutdown +
     // cgroup/NBD/netns teardown). Serial destroy blows past shutdown and
     // budget-pressure recovery budgets on multi-VM cleanup.
@@ -142,16 +145,19 @@ pub(super) async fn destroy_idle_jobs_and_wait(jobs: Vec<IdleDestroyJob>, contex
     for job in jobs {
         set.spawn(destroy_idle_job(job, context));
     }
+    let mut workspace_cache_promoted = false;
     while let Some(result) = set.join_next().await {
-        if let Err(e) = result {
-            warn!(context, error = %e, "idle entry destroy task panicked");
+        match result {
+            Ok(promoted) => workspace_cache_promoted |= promoted,
+            Err(e) => warn!(context, error = %e, "idle entry destroy task panicked"),
         }
     }
+    workspace_cache_promoted
 }
 
 /// Destroy an idle sandbox entry. Its budget lease is released by Drop.
-async fn destroy_idle_job(job: IdleDestroyJob, context: &'static str) {
-    job.run_with_context(context).await;
+async fn destroy_idle_job(job: IdleDestroyJob, context: &'static str) -> bool {
+    job.run_with_context(context).await
 }
 
 pub(super) async fn destroy_idle_payload_and_wait(
@@ -183,10 +189,17 @@ mod tests {
     use sandbox_mock::{MockSandbox, MockSandboxFactory};
 
     use crate::idle_pool::{
-        IdlePool, IdlePoolConfig, ParkResult, ParkedIdleCandidate,
-        SyntheticParkedIdleCandidateParts,
+        IdleParkRequest, IdleParkRequestParts, IdlePool, IdlePoolConfig, ParkResult,
+        ParkedIdleCandidate, StorageFingerprints, SyntheticParkedIdleCandidateParts,
     };
+    use crate::ids::RunId;
+    use crate::paths::RunnerPaths;
     use crate::resource_budget::ResourceBudget;
+    use crate::workspace_image_cache::{
+        SessionWorkspaceCache, WorkspaceCacheTerminalStatus, WorkspaceImagePrepareRequest,
+        WorkspaceImagePromotionRequest,
+    };
+    use api_contracts::generated::constants::runners::paths::CANONICAL_WORKING_DIR;
 
     struct PanickingDestroyFactory;
 
@@ -366,5 +379,77 @@ mod tests {
 
         assert_eq!(overrides.destroy_call_count(), 1);
         assert_eq!(budget.allocated(), (0, 0, 0));
+    }
+
+    #[tokio::test]
+    async fn idle_destroy_reports_workspace_cache_promotion() {
+        let dir = tempfile::tempdir().unwrap();
+        let paths = RunnerPaths::new(dir.path().join("runner"));
+        tokio::fs::create_dir_all(paths.base_dir()).await.unwrap();
+        let cache = SessionWorkspaceCache::new(paths.clone());
+        let run_id = RunId::new_v4();
+        let sandbox_id = SandboxId::new_v4();
+        let session_id = "sess-idle-destroy-cache";
+        let image = b"workspace image";
+        let workspace_image = cache
+            .prepare(WorkspaceImagePrepareRequest {
+                run_id,
+                sandbox_id,
+                profile_name: "vm0/default",
+                session_id: Some(session_id),
+                working_dir: CANONICAL_WORKING_DIR,
+                image_size_bytes: image.len() as u64,
+                workspace_drive_required: true,
+            })
+            .await;
+        tokio::fs::create_dir_all(paths.workspace_dir(&sandbox_id))
+            .await
+            .unwrap();
+        tokio::fs::write(paths.active_workspace_image(&sandbox_id), image)
+            .await
+            .unwrap();
+        let workspace_promotion = workspace_image
+            .into_promotion_context(WorkspaceImagePromotionRequest {
+                run_id,
+                sandbox_id,
+                session_id_override: Some(session_id),
+                terminal_status: WorkspaceCacheTerminalStatus::Success,
+                completed_at: "2026-06-03T00:00:00.000Z".into(),
+                storage_fingerprints: StorageFingerprints::default(),
+                promotable: true,
+            })
+            .expect("workspace image should be promotable");
+
+        let budget = Arc::new(ResourceBudget::new(2, 4096, 1.0, 0));
+        let lease = ResourceBudget::try_reserve_lease(&budget, 2, 4096).unwrap();
+        let request = IdleParkRequest::new(IdleParkRequestParts {
+            sandbox: Box::new(MockSandbox::new("idle-destroy-cache")),
+            factory: Arc::new(Box::new(MockSandboxFactory::new()) as Box<dyn SandboxFactory>),
+            session_id: session_id.into(),
+            sandbox_id,
+            profile_name: "vm0/default".into(),
+            device_rate_limits: None,
+            budget_lease: lease,
+            source_ip: "10.0.0.1".into(),
+            storage_fingerprints: StorageFingerprints::default(),
+            workspace_promotion: Some(workspace_promotion),
+        });
+        let candidate = match request.park_for_idle().await {
+            Ok(candidate) => candidate.with_last_completed_at("2026-06-03T00:00:00.000Z".into()),
+            Err(_) => panic!("park should succeed"),
+        };
+        let mut pool = IdlePool::new(IdlePoolConfig {
+            default_timeout: Duration::from_secs(300),
+            max_idle: 0,
+        });
+        assert!(matches!(pool.park(candidate), ParkResult::Parked));
+
+        let promoted = destroy_idle_jobs_and_wait(pool.drain(), "test_idle_destroy_cache").await;
+
+        assert!(promoted);
+        assert_eq!(budget.allocated(), (0, 0, 0));
+        let held = cache.held_session_states().await;
+        assert_eq!(held.len(), 1);
+        assert_eq!(held[0].session_id, session_id);
     }
 }

--- a/crates/runner/src/cmd/start/job_discovery.rs
+++ b/crates/runner/src/cmd/start/job_discovery.rs
@@ -294,7 +294,7 @@ async fn try_reuse_from_pool(
                     // task before handing the sandbox to the executor.
                     drop(job_lease);
                     (
-                        Some(sandbox),
+                        Some(*sandbox),
                         budget_lease,
                         SandboxReuseResult::Reused,
                         snapshot,

--- a/crates/runner/src/cmd/start/job_discovery.rs
+++ b/crates/runner/src/cmd/start/job_discovery.rs
@@ -307,7 +307,7 @@ async fn try_reuse_from_pool(
                         error = %error,
                         "unpark failed, destroying idle VM and falling through to fresh create"
                     );
-                    spawn_idle_destroy_job(ctx.destroy_tasks, destroy_job, "reuse_unpark_failed");
+                    spawn_idle_destroy_job(ctx.destroy_tasks, *destroy_job, "reuse_unpark_failed");
                     (None, job_lease, SandboxReuseResult::UnparkFailed, snapshot)
                 }
             }

--- a/crates/runner/src/cmd/start/job_discovery.rs
+++ b/crates/runner/src/cmd/start/job_discovery.rs
@@ -40,7 +40,7 @@ pub(super) struct DiscoveredJobContext<'a> {
     pub(super) mode_rx: &'a tokio::sync::watch::Receiver<RunnerMode>,
     pub(super) cancel_tokens: &'a Arc<tokio::sync::Mutex<HashMap<RunId, CancellationToken>>>,
     pub(super) spawn_ctx: &'a SpawnContext,
-    pub(super) destroy_tasks: &'a mut JoinSet<()>,
+    pub(super) destroy_tasks: &'a mut JoinSet<bool>,
     pub(super) jobs: &'a mut JoinSet<Option<RunId>>,
 }
 

--- a/crates/runner/src/cmd/start/mod.rs
+++ b/crates/runner/src/cmd/start/mod.rs
@@ -954,7 +954,7 @@ async fn run(config: RunConfig) -> RunnerResult<()> {
     // Tracked destroy tasks — JoinSet ensures we can await all in-flight
     // destroys at shutdown, preventing factory Arc leaks that cause
     // "factory still referenced" warnings from Arc::try_unwrap.
-    let mut destroy_tasks: JoinSet<()> = JoinSet::new();
+    let mut destroy_tasks: JoinSet<bool> = JoinSet::new();
 
     shared.status.write_initial().await;
     info!(
@@ -1129,7 +1129,9 @@ async fn run(config: RunConfig) -> RunnerResult<()> {
                         count = expired.len(),
                         "reclaiming expired idle VMs for resource pressure"
                     );
-                    destroy_idle_jobs_and_wait(expired, "budget_pressure_expired").await;
+                    if destroy_idle_jobs_and_wait(expired, "budget_pressure_expired").await {
+                        park_notify.notify_one();
+                    }
                     continue;
                 }
 
@@ -1149,7 +1151,9 @@ async fn run(config: RunConfig) -> RunnerResult<()> {
                     );
                     // Wait for the destroy task so the idle VM's lease is
                     // dropped before the loop re-checks can_afford().
-                    destroy_idle_jobs_and_wait(vec![evicted], "budget_pressure_oldest").await;
+                    if destroy_idle_jobs_and_wait(vec![evicted], "budget_pressure_oldest").await {
+                        park_notify.notify_one();
+                    }
                     continue;
                 }
             }
@@ -1236,8 +1240,10 @@ async fn run(config: RunConfig) -> RunnerResult<()> {
             }
             // Reap completed destroy tasks
             Some(result) = destroy_tasks.join_next(), if !destroy_tasks.is_empty() => {
-                if let Err(e) = result {
-                    warn!(error = %e, "destroy task panicked");
+                match result {
+                    Ok(true) => park_notify.notify_one(),
+                    Ok(false) => {}
+                    Err(e) => warn!(error = %e, "destroy task panicked"),
                 }
             }
             // Mitmproxy crash detection
@@ -1353,8 +1359,9 @@ async fn run(config: RunConfig) -> RunnerResult<()> {
                     mitm.request_usage_flush();
                 }
                 Some(result) = destroy_tasks.join_next() => {
-                    if let Err(e) = result {
-                        warn!(error = %e, "destroy task panicked");
+                    match result {
+                        Ok(_) => {}
+                        Err(e) => warn!(error = %e, "destroy task panicked"),
                     }
                 }
                 _ = mitm_crash_rx.recv() => {
@@ -1386,8 +1393,11 @@ async fn run(config: RunConfig) -> RunnerResult<()> {
     // shutdown_factories calls Arc::try_unwrap.
     let phase = teardown.phase_start("destroy_tasks_drain");
     while let Some(result) = destroy_tasks.join_next().await {
-        if let Err(e) = result {
-            warn!(error = %e, "destroy task panicked during shutdown");
+        match result {
+            Ok(_) => {}
+            Err(e) => {
+                warn!(error = %e, "destroy task panicked during shutdown");
+            }
         }
     }
     teardown.phase_complete("destroy_tasks_drain", phase);

--- a/crates/runner/src/cmd/start/sandbox_finalization.rs
+++ b/crates/runner/src/cmd/start/sandbox_finalization.rs
@@ -1104,15 +1104,17 @@ mod tests {
             .wait_entered(1, Duration::from_secs(5))
             .await
             .expect("replaced idle destroy should reach destroy gate");
-        tokio::time::timeout(Duration::from_secs(1), park_notify.notified())
-            .await
-            .expect("newly parked replacement should notify before replaced destroy finishes");
+        assert!(
+            park_notify.notified().now_or_never().is_some(),
+            "newly parked replacement should notify before replaced destroy finishes"
+        );
 
         destroy_gate.release_one();
         let _completion_ready = finalize_task.await.expect("finalizer task should join");
-        tokio::time::timeout(Duration::from_secs(1), park_notify.notified())
-            .await
-            .expect("replaced idle workspace cache promotion should notify after destroy");
+        assert!(
+            park_notify.notified().now_or_never().is_some(),
+            "replaced idle workspace cache promotion should notify after destroy"
+        );
         assert!(
             cache
                 .held_session_states()

--- a/crates/runner/src/cmd/start/sandbox_finalization.rs
+++ b/crates/runner/src/cmd/start/sandbox_finalization.rs
@@ -171,6 +171,7 @@ pub(super) async fn finalize_sandbox_for_completion(
                     sandbox,
                     factory: failure_factory,
                     budget_lease,
+                    workspace_promotion,
                 } = failure.active;
                 warn!(
                     run_id = %run_id,
@@ -178,6 +179,12 @@ pub(super) async fn finalize_sandbox_for_completion(
                     error = %failure.error,
                     "sandbox park failed, destroying instead of parking"
                 );
+                let workspace_cache_promoted = promote_workspace_image_from_active_sandbox(
+                    sandbox.as_ref(),
+                    workspace_promotion.as_ref(),
+                    "park_failed",
+                )
+                .await;
                 let destroy_outcome = stop_and_destroy_sandbox(
                     sandbox,
                     &**failure_factory,
@@ -208,7 +215,7 @@ pub(super) async fn finalize_sandbox_for_completion(
                             budget_lease,
                         )),
                     ),
-                    false,
+                    workspace_cache_promoted,
                     false,
                 );
             }

--- a/crates/runner/src/cmd/start/sandbox_finalization.rs
+++ b/crates/runner/src/cmd/start/sandbox_finalization.rs
@@ -325,7 +325,9 @@ pub(super) async fn finalize_sandbox_for_completion(
                     // pool; destroying a parked sandbox is safe — Drop
                     // aborts any leftover handles and the FC process is
                     // killed regardless of balloon state.
-                    destroy_idle_jobs_and_wait(vec![evicted], "park_replaced").await;
+                    if destroy_idle_jobs_and_wait(vec![evicted], "park_replaced").await {
+                        park_notify.notify_one();
+                    }
                     BudgetOwnership::idle_owned()
                 }
                 ParkResult::Rejected(rejected) => {
@@ -522,14 +524,14 @@ mod tests {
 
     use api_contracts::generated::constants::runners::paths::CANONICAL_WORKING_DIR;
     use sandbox::{ExecResult, SandboxFactory, SandboxId};
-    use sandbox_mock::{MockSandbox, MockSandboxFactory};
+    use sandbox_mock::{MockLifecycleGate, MockSandbox, MockSandboxFactory};
     use tokio_util::sync::CancellationToken;
 
     use super::super::idle_lifecycle::SharedIdlePool;
     use super::super::job_lifecycle::{ActiveBudgetLease, CompletionPayload, RunCleanupState};
     use crate::idle_pool::{
-        IdlePool, IdlePoolConfig, ParkedIdleCandidate, ParkingGate,
-        SyntheticParkedIdleCandidateParts,
+        IdleParkRequest, IdleParkRequestParts, IdlePool, IdlePoolConfig, ParkResult,
+        ParkedIdleCandidate, ParkingGate, SyntheticParkedIdleCandidateParts,
     };
     use crate::ids::RunId;
     use crate::network_log_drain::NetworkLogDrainCoordinator;
@@ -998,6 +1000,127 @@ mod tests {
         let cache_states = cache.held_session_states().await;
         assert_eq!(cache_states.len(), 1);
         assert_eq!(cache_states[0].session_id, "sess-new");
+    }
+
+    #[tokio::test]
+    async fn finalizer_notifies_after_replaced_idle_workspace_cache_promotion() {
+        let fixture = FinalizeTestFixture::new().await;
+        let session_id = "sess-replaced-cache";
+        let dir = tempfile::tempdir().unwrap();
+        let paths = RunnerPaths::new(dir.path().join("runner"));
+        tokio::fs::create_dir_all(paths.base_dir()).await.unwrap();
+        let cache = SessionWorkspaceCache::new(paths.clone());
+
+        let old_run_id = RunId::new_v4();
+        let old_sandbox_id = SandboxId::new_v4();
+        let old_workspace_image = prepare_test_workspace_image_lease(
+            &paths,
+            &cache,
+            old_run_id,
+            old_sandbox_id,
+            session_id,
+        )
+        .await;
+        let old_promotion = test_promotion_context(
+            old_workspace_image,
+            old_run_id,
+            old_sandbox_id,
+            session_id,
+            WorkspaceCacheTerminalStatus::Success,
+            crate::idle_pool::StorageFingerprints::default(),
+        );
+        let destroy_gate = MockLifecycleGate::new();
+        let existing_overrides = Arc::new(sandbox_mock::MockSandboxOverrides::new());
+        existing_overrides.set_destroy_lifecycle_gate(destroy_gate.clone());
+        let existing_factory: Arc<Box<dyn SandboxFactory>> = Arc::new(Box::new(
+            MockSandboxFactory::with_overrides(Arc::clone(&existing_overrides)),
+        ));
+        let existing_sandbox = existing_factory
+            .create(sandbox::SandboxConfig {
+                id: old_sandbox_id,
+                resources: sandbox::ResourceLimits {
+                    cpu_count: 2,
+                    memory_mb: 4096,
+                },
+                device_rate_limits: None,
+                workspace_drive: None,
+            })
+            .await
+            .expect("create existing sandbox");
+        let (_existing_budget, existing_lease) = test_budget_lease();
+        let existing_candidate = IdleParkRequest::new(IdleParkRequestParts {
+            source_ip: existing_sandbox.source_ip().to_owned(),
+            sandbox: existing_sandbox,
+            factory: existing_factory,
+            session_id: session_id.into(),
+            sandbox_id: old_sandbox_id,
+            profile_name: "vm0/default".into(),
+            device_rate_limits: None,
+            budget_lease: existing_lease,
+            storage_fingerprints: crate::idle_pool::StorageFingerprints::default(),
+            workspace_promotion: Some(old_promotion),
+        })
+        .park_for_idle()
+        .await
+        .unwrap_or_else(|failure| {
+            let error = failure.into_active_parts().error;
+            panic!("existing sandbox should park: {error}");
+        })
+        .with_last_completed_at(local_completed_at());
+        assert!(matches!(
+            fixture.idle_pool.lock().await.park(existing_candidate),
+            ParkResult::Parked
+        ));
+
+        let park_notify = Arc::new(tokio::sync::Notify::new());
+        let (_budget, lease) = test_budget_lease();
+        let network_log_session = fixture.network_log_session().await;
+        let new_run_id = RunId::new_v4();
+        let new_sandbox_id = SandboxId::new_v4();
+        let mut context = fixture.finalize_context(
+            new_run_id,
+            new_sandbox_id,
+            session_id,
+            network_log_session,
+            CancellationToken::new(),
+        );
+        context.park_notify = Arc::clone(&park_notify);
+
+        let finalize_task = tokio::spawn(finalize_sandbox_for_completion(
+            Some(Box::new(MockSandbox::new("replacement-sandbox"))),
+            ActiveBudgetLease::new(lease),
+            CompletionPayload::new(
+                new_run_id,
+                0,
+                None,
+                new_sandbox_id,
+                SandboxReuseResult::PoolMiss,
+                CompletionAuth::local(),
+            ),
+            context,
+        ));
+
+        destroy_gate
+            .wait_entered(1, Duration::from_secs(5))
+            .await
+            .expect("replaced idle destroy should reach destroy gate");
+        tokio::time::timeout(Duration::from_secs(1), park_notify.notified())
+            .await
+            .expect("newly parked replacement should notify before replaced destroy finishes");
+
+        destroy_gate.release_one();
+        let _completion_ready = finalize_task.await.expect("finalizer task should join");
+        tokio::time::timeout(Duration::from_secs(1), park_notify.notified())
+            .await
+            .expect("replaced idle workspace cache promotion should notify after destroy");
+        assert!(
+            cache
+                .held_session_states()
+                .await
+                .iter()
+                .any(|state| state.session_id == session_id),
+            "replaced idle workspace cache should be visible after destroy completion"
+        );
     }
 
     #[tokio::test]

--- a/crates/runner/src/cmd/start/sandbox_finalization.rs
+++ b/crates/runner/src/cmd/start/sandbox_finalization.rs
@@ -32,8 +32,10 @@ use crate::network_log_manager::NetworkLogSession;
 #[cfg(test)]
 use crate::provider::CompletionAuth;
 use crate::status::StatusTracker;
-use crate::workspace_image_cache::{WorkspaceCacheTerminalStatus, WorkspaceImageLease};
-use crate::workspace_mount::flush_and_unmount_workspace_drive;
+use crate::workspace_image_cache::{
+    WorkspaceCacheTerminalStatus, WorkspaceImageLease, WorkspaceImagePromotionRequest,
+};
+use crate::workspace_promotion::promote_workspace_image_from_active_sandbox;
 
 fn local_completed_at() -> String {
     chrono::Utc::now().to_rfc3339_opts(SecondsFormat::Millis, true)
@@ -118,6 +120,8 @@ pub(super) async fn finalize_sandbox_for_completion(
     } = ctx;
 
     let cancelled = cancel.is_cancelled();
+    let terminal_status = workspace_terminal_status(exit_code, cancelled);
+    let completed_at = local_completed_at();
     let parkable_session = if exit_code == 0 && !cancelled && parking_gate.is_open() {
         // Prefer context session_id (from resume_session), fall back to
         // guest-reported session ID (first run — CLI generated it).
@@ -128,27 +132,22 @@ pub(super) async fn finalize_sandbox_for_completion(
     } else {
         None
     };
+    let promotion_session_id = session_id.as_deref().or(guest_session_id.as_deref());
+    let workspace_promotion = workspace_image.and_then(|workspace_image| {
+        workspace_image.into_promotion_context(WorkspaceImagePromotionRequest {
+            run_id,
+            sandbox_id,
+            session_id_override: promotion_session_id,
+            terminal_status,
+            completed_at: completed_at.clone(),
+            storage_fingerprints: storage_fingerprints.clone(),
+            promotable: workspace_promotable,
+        })
+    });
 
     let mut session_affinity_changed = false;
     let mut session_affinity_refresh_sent = false;
     let budget = if let Some(session_id) = parkable_session {
-        let workspace_cache_promoted = promote_workspace_image_from_active_sandbox(
-            sandbox.as_ref(),
-            run_id,
-            workspace_image.as_ref(),
-            workspace_promotable,
-            workspace_terminal_status(exit_code, cancelled),
-            &storage_fingerprints,
-            &WorkspacePromotionLogContext {
-                sandbox_id,
-                profile_name: &profile_name,
-                session_id: Some(&session_id),
-                reason: "park",
-            },
-        )
-        .await;
-        session_affinity_changed |= workspace_cache_promoted;
-
         // Inflate the guest balloon BEFORE acquiring the pool lock —
         // the HTTP call to Firecracker can take milliseconds, and we
         // must not block other take/park operations on it.
@@ -162,6 +161,7 @@ pub(super) async fn finalize_sandbox_for_completion(
             budget_lease: active_lease.into_idle_park_lease(),
             source_ip,
             storage_fingerprints,
+            workspace_promotion,
         });
         let candidate = match park_request.park_for_idle().await {
             Ok(candidate) => candidate,
@@ -208,38 +208,21 @@ pub(super) async fn finalize_sandbox_for_completion(
                             budget_lease,
                         )),
                     ),
-                    workspace_cache_promoted,
+                    false,
                     false,
                 );
             }
         };
         if cancel.is_cancelled() {
-            let IdleParkActiveParts {
-                sandbox,
-                factory: candidate_factory,
-                budget_lease,
-            } = candidate.into_active_parts();
+            let (payload, budget_lease) = candidate.into_active_destroy_parts();
             close_network_log_session(run_id, network_log_session.take(), &network_log_drain).await;
             info!(
                 run_id = %run_id,
                 session_id,
                 "job cancelled while parking, destroying VM"
             );
-            let destroy_outcome = stop_and_destroy_sandbox(
-                sandbox,
-                &**candidate_factory,
-                ActiveCleanupContext {
-                    run_id,
-                    sandbox_id,
-                    profile_name: &profile_name,
-                    session_id: Some(&session_id),
-                    reason: "cancelled",
-                    network_log_session: None,
-                    network_log_drain: network_log_drain.clone(),
-                },
-            )
-            .await;
-            if destroy_outcome == DestroyOutcome::Completed {
+            let destroy_result = destroy_idle_payload_and_wait(payload, "cancelled").await;
+            if destroy_result.outcome == DestroyOutcome::Completed {
                 cleanup_state.mark_destroy_completed();
             }
             #[cfg(test)]
@@ -248,6 +231,7 @@ pub(super) async fn finalize_sandbox_for_completion(
                 OuterJobPanicPoint::DestroyCompleted,
                 run_id,
             );
+            session_affinity_changed |= destroy_result.workspace_cache_promoted;
             BudgetOwnership::active(ActiveBudgetLease::from_idle_park_lease(budget_lease))
         } else {
             close_network_log_session(run_id, network_log_session.take(), &network_log_drain).await;
@@ -261,26 +245,9 @@ pub(super) async fn finalize_sandbox_for_completion(
                     "job cancelled before idle pool ownership transfer, destroying VM"
                 );
                 drop(pool);
-                let IdleParkActiveParts {
-                    sandbox,
-                    factory: candidate_factory,
-                    budget_lease,
-                } = candidate.into_active_parts();
-                let destroy_outcome = stop_and_destroy_sandbox(
-                    sandbox,
-                    &**candidate_factory,
-                    ActiveCleanupContext {
-                        run_id,
-                        sandbox_id,
-                        profile_name: &profile_name,
-                        session_id: Some(&session_id),
-                        reason: "cancelled",
-                        network_log_session: None,
-                        network_log_drain: network_log_drain.clone(),
-                    },
-                )
-                .await;
-                if destroy_outcome == DestroyOutcome::Completed {
+                let (payload, budget_lease) = candidate.into_active_destroy_parts();
+                let destroy_result = destroy_idle_payload_and_wait(payload, "cancelled").await;
+                if destroy_result.outcome == DestroyOutcome::Completed {
                     cleanup_state.mark_destroy_completed();
                 }
                 #[cfg(test)]
@@ -296,11 +263,11 @@ pub(super) async fn finalize_sandbox_for_completion(
                             budget_lease,
                         )),
                     ),
-                    workspace_cache_promoted,
+                    destroy_result.workspace_cache_promoted,
                     false,
                 );
             }
-            let candidate = candidate.with_last_completed_at(local_completed_at());
+            let candidate = candidate.with_last_completed_at(completed_at.clone());
             match pool.park(candidate) {
                 ParkResult::Parked => {
                     info!(run_id = %run_id, session_id, "VM parked for reuse");
@@ -362,9 +329,9 @@ pub(super) async fn finalize_sandbox_for_completion(
                     // park()ed above; destroying a parked sandbox is
                     // safe — see Replaced arm for rationale.
                     let (payload, lease) = rejected.into_active_destroy_parts();
-                    let destroy_outcome =
+                    let destroy_result =
                         destroy_idle_payload_and_wait(payload, "park_rejected").await;
-                    if destroy_outcome == DestroyOutcome::Completed {
+                    if destroy_result.outcome == DestroyOutcome::Completed {
                         cleanup_state.mark_destroy_completed();
                     }
                     #[cfg(test)]
@@ -373,6 +340,7 @@ pub(super) async fn finalize_sandbox_for_completion(
                         OuterJobPanicPoint::DestroyCompleted,
                         run_id,
                     );
+                    session_affinity_changed |= destroy_result.workspace_cache_promoted;
                     BudgetOwnership::active(ActiveBudgetLease::from_idle_park_lease(lease))
                 }
             }
@@ -381,23 +349,14 @@ pub(super) async fn finalize_sandbox_for_completion(
         // No parkable session — stop + destroy.
         let workspace_cache_promoted = promote_workspace_image_from_active_sandbox(
             sandbox.as_ref(),
-            run_id,
-            workspace_image.as_ref(),
-            workspace_promotable,
-            workspace_terminal_status(exit_code, cancelled),
-            &storage_fingerprints,
-            &WorkspacePromotionLogContext {
-                sandbox_id,
-                profile_name: &profile_name,
-                session_id: session_id.as_deref().or(guest_session_id.as_deref()),
-                reason: active_cleanup_reason(
-                    exit_code,
-                    cancelled,
-                    parking_gate.is_open(),
-                    session_id.as_deref(),
-                    guest_session_id.as_deref(),
-                ),
-            },
+            workspace_promotion.as_ref(),
+            active_cleanup_reason(
+                exit_code,
+                cancelled,
+                parking_gate.is_open(),
+                session_id.as_deref(),
+                guest_session_id.as_deref(),
+            ),
         )
         .await;
         session_affinity_changed |= workspace_cache_promoted;
@@ -477,83 +436,6 @@ fn workspace_terminal_status(exit_code: i32, cancelled: bool) -> WorkspaceCacheT
         WorkspaceCacheTerminalStatus::Success
     } else {
         WorkspaceCacheTerminalStatus::NonzeroExit
-    }
-}
-
-struct WorkspacePromotionLogContext<'a> {
-    sandbox_id: SandboxId,
-    profile_name: &'a str,
-    session_id: Option<&'a str>,
-    reason: &'static str,
-}
-
-async fn promote_workspace_image_from_active_sandbox(
-    sandbox: &dyn Sandbox,
-    run_id: RunId,
-    workspace_image: Option<&WorkspaceImageLease>,
-    workspace_promotable: bool,
-    terminal_status: WorkspaceCacheTerminalStatus,
-    storage_fingerprints: &StorageFingerprints,
-    log: &WorkspacePromotionLogContext<'_>,
-) -> bool {
-    if !workspace_promotable {
-        return false;
-    }
-    let Some(workspace_image) = workspace_image else {
-        return false;
-    };
-    if !workspace_image.workspace_drive_available() {
-        return false;
-    }
-
-    match flush_and_unmount_workspace_drive(sandbox, run_id).await {
-        Ok(()) => {}
-        Err(e) => {
-            warn!(
-                run_id = %run_id,
-                sandbox_id = %log.sandbox_id,
-                profile_name = log.profile_name,
-                session_id = log.session_id.unwrap_or("<none>"),
-                reason = log.reason,
-                error = %e,
-                "workspace image cache promotion skipped because guest unmount failed"
-            );
-            return false;
-        }
-    }
-
-    let tainted_storage_fingerprints;
-    let promotion_storage_fingerprints = match terminal_status {
-        WorkspaceCacheTerminalStatus::Success => storage_fingerprints,
-        WorkspaceCacheTerminalStatus::NonzeroExit | WorkspaceCacheTerminalStatus::Cancelled => {
-            tainted_storage_fingerprints = storage_fingerprints.tainted_paths();
-            &tainted_storage_fingerprints
-        }
-    };
-
-    match workspace_image
-        .promote(
-            run_id,
-            log.session_id,
-            terminal_status,
-            local_completed_at(),
-            promotion_storage_fingerprints,
-        )
-        .await
-    {
-        Ok(promoted) => promoted,
-        Err(e) => {
-            warn!(
-                run_id = %run_id,
-                sandbox_id = %log.sandbox_id,
-                profile_name = log.profile_name,
-                session_id = log.session_id.unwrap_or("<none>"),
-                reason = log.reason,
-                error = %e,
-                "workspace image cache promotion failed"
-            );
-            false
-        }
     }
 }
 
@@ -638,7 +520,10 @@ mod tests {
 
     use super::super::idle_lifecycle::SharedIdlePool;
     use super::super::job_lifecycle::{ActiveBudgetLease, CompletionPayload, RunCleanupState};
-    use crate::idle_pool::{IdlePool, IdlePoolConfig, ParkingGate};
+    use crate::idle_pool::{
+        IdlePool, IdlePoolConfig, ParkedIdleCandidate, ParkingGate,
+        SyntheticParkedIdleCandidateParts,
+    };
     use crate::ids::RunId;
     use crate::network_log_drain::NetworkLogDrainCoordinator;
     use crate::network_log_manager::NetworkLogManager;
@@ -646,7 +531,9 @@ mod tests {
     use crate::resource_budget::{BudgetLease, ResourceBudget};
     use crate::status::StatusTracker;
     use crate::types::SandboxReuseResult;
-    use crate::workspace_image_cache::{SessionWorkspaceCache, WorkspaceImagePrepareRequest};
+    use crate::workspace_image_cache::{
+        SessionWorkspaceCache, WorkspaceImagePrepareRequest, WorkspaceImagePromotionContext,
+    };
 
     fn test_budget_lease() -> (Arc<ResourceBudget>, BudgetLease) {
         let budget = Arc::new(ResourceBudget::new(8, 32768, 1.0, 0));
@@ -664,6 +551,10 @@ mod tests {
 
     impl FinalizeTestFixture {
         async fn new() -> Self {
+            Self::new_with_max_idle(10).await
+        }
+
+        async fn new_with_max_idle(max_idle: usize) -> Self {
             let dir = tempfile::tempdir().unwrap();
             let status = Arc::new(StatusTracker::new(
                 dir.path().join("status.json"),
@@ -677,7 +568,7 @@ mod tests {
                 Arc::new(tokio::sync::Mutex::new(IdlePool::new_with_parking_gate(
                     IdlePoolConfig {
                         default_timeout: Duration::from_secs(300),
-                        max_idle: 10,
+                        max_idle,
                     },
                     parking_gate.clone(),
                 )));
@@ -760,6 +651,27 @@ mod tests {
         lease
     }
 
+    fn test_promotion_context(
+        lease: WorkspaceImageLease,
+        run_id: RunId,
+        sandbox_id: SandboxId,
+        session_id: &str,
+        terminal_status: WorkspaceCacheTerminalStatus,
+        storage_fingerprints: crate::idle_pool::StorageFingerprints,
+    ) -> WorkspaceImagePromotionContext {
+        lease
+            .into_promotion_context(WorkspaceImagePromotionRequest {
+                run_id,
+                sandbox_id,
+                session_id_override: Some(session_id),
+                terminal_status,
+                completed_at: local_completed_at(),
+                storage_fingerprints,
+                promotable: true,
+            })
+            .expect("test workspace image should be promotable")
+    }
+
     #[tokio::test]
     async fn finalizer_closes_network_log_session_before_parking() {
         let (_budget, lease) = test_budget_lease();
@@ -814,25 +726,19 @@ mod tests {
             prepare_test_workspace_image_lease(&paths, &cache, run_id, sandbox_id, "sess-promote")
                 .await;
         let sandbox = MockSandbox::new("workspace-promotion");
-
-        let promoted = promote_workspace_image_from_active_sandbox(
-            &sandbox,
+        let promotion = test_promotion_context(
+            lease,
             run_id,
-            Some(&lease),
-            true,
+            sandbox_id,
+            "sess-promote",
             WorkspaceCacheTerminalStatus::Success,
-            &crate::idle_pool::StorageFingerprints::default(),
-            &WorkspacePromotionLogContext {
-                sandbox_id,
-                profile_name: "vm0/default",
-                session_id: Some("sess-promote"),
-                reason: "test",
-            },
-        )
-        .await;
+            crate::idle_pool::StorageFingerprints::default(),
+        );
+
+        let promoted =
+            promote_workspace_image_from_active_sandbox(&sandbox, Some(&promotion), "test").await;
 
         assert!(promoted);
-        drop(lease);
         let states = cache.held_session_states().await;
         assert_eq!(states.len(), 1);
         assert_eq!(states[0].session_id, "sess-promote");
@@ -864,25 +770,19 @@ mod tests {
                 ("artifact".to_owned(), "v1".to_owned()),
             )]),
         };
-
-        let promoted = promote_workspace_image_from_active_sandbox(
-            &sandbox,
+        let promotion = test_promotion_context(
+            lease,
             run_id,
-            Some(&lease),
-            true,
+            sandbox_id,
+            "sess-nonzero",
             WorkspaceCacheTerminalStatus::NonzeroExit,
-            &storage_fingerprints,
-            &WorkspacePromotionLogContext {
-                sandbox_id,
-                profile_name: "vm0/default",
-                session_id: Some("sess-nonzero"),
-                reason: "test",
-            },
-        )
-        .await;
+            storage_fingerprints,
+        );
+
+        let promoted =
+            promote_workspace_image_from_active_sandbox(&sandbox, Some(&promotion), "test").await;
 
         assert!(promoted);
-        drop(lease);
         let checkout = cache
             .prepare(WorkspaceImagePrepareRequest {
                 run_id: RunId::new_v4(),
@@ -926,25 +826,19 @@ mod tests {
                 .await;
         let sandbox = MockSandbox::new("workspace-promotion-fail");
         sandbox.push_exec_result(Ok(ExecResult::new(64, Vec::new(), b"not mounted".to_vec())));
-
-        let promoted = promote_workspace_image_from_active_sandbox(
-            &sandbox,
+        let promotion = test_promotion_context(
+            lease,
             run_id,
-            Some(&lease),
-            true,
+            sandbox_id,
+            "sess-failed",
             WorkspaceCacheTerminalStatus::Success,
-            &crate::idle_pool::StorageFingerprints::default(),
-            &WorkspacePromotionLogContext {
-                sandbox_id,
-                profile_name: "vm0/default",
-                session_id: Some("sess-failed"),
-                reason: "test",
-            },
-        )
-        .await;
+            crate::idle_pool::StorageFingerprints::default(),
+        );
+
+        let promoted =
+            promote_workspace_image_from_active_sandbox(&sandbox, Some(&promotion), "test").await;
 
         assert!(!promoted);
-        drop(lease);
         assert!(
             cache.held_session_states().await.is_empty(),
             "unmount failure must not advertise an unflushed workspace image"
@@ -953,7 +847,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn finalizer_promotes_workspace_cache_with_guest_session_id_without_context_session() {
+    async fn finalizer_parks_workspace_cache_promotion_without_publishing_cache() {
         let (_budget, lease) = test_budget_lease();
         let fixture = FinalizeTestFixture::new().await;
         let network_log_session = fixture.network_log_session().await;
@@ -1012,8 +906,89 @@ mod tests {
         assert_eq!(idle_states.len(), 1);
         assert_eq!(idle_states[0].session_id, "sess-guest");
         let cache_states = cache.held_session_states().await;
+        assert!(
+            cache_states.is_empty(),
+            "parked sandboxes keep the live workspace mounted and must not publish a separate cache image"
+        );
+    }
+
+    #[tokio::test]
+    async fn finalizer_promotes_workspace_cache_when_parked_candidate_is_rejected() {
+        let fixture = FinalizeTestFixture::new_with_max_idle(1).await;
+        let (_existing_budget, existing_lease) = test_budget_lease();
+        let existing = ParkedIdleCandidate::synthetic_for_test(SyntheticParkedIdleCandidateParts {
+            sandbox: Box::new(MockSandbox::new("existing-idle")),
+            factory: Arc::new(Box::new(MockSandboxFactory::new()) as Box<dyn SandboxFactory>),
+            session_id: "sess-existing".into(),
+            sandbox_id: SandboxId::new_v4(),
+            profile_name: "vm0/default".into(),
+            device_rate_limits: None,
+            budget_lease: existing_lease,
+            source_ip: "10.0.0.1".into(),
+            storage_fingerprints: crate::idle_pool::StorageFingerprints::default(),
+        })
+        .with_last_completed_at(local_completed_at());
+        assert!(matches!(
+            fixture.idle_pool.lock().await.park(existing),
+            ParkResult::Parked
+        ));
+
+        let (_budget, lease) = test_budget_lease();
+        let network_log_session = fixture.network_log_session().await;
+        let dir = tempfile::tempdir().unwrap();
+        let paths = RunnerPaths::new(dir.path().join("runner"));
+        tokio::fs::create_dir_all(paths.base_dir()).await.unwrap();
+        let cache = SessionWorkspaceCache::new(paths.clone());
+        let run_id = RunId::new_v4();
+        let sandbox_id = SandboxId::new_v4();
+        let workspace_image = cache
+            .prepare(WorkspaceImagePrepareRequest {
+                run_id,
+                sandbox_id,
+                profile_name: "vm0/default",
+                session_id: Some("sess-new"),
+                working_dir: CANONICAL_WORKING_DIR,
+                image_size_bytes: b"image".len() as u64,
+                workspace_drive_required: true,
+            })
+            .await;
+        tokio::fs::create_dir_all(paths.workspace_dir(&sandbox_id))
+            .await
+            .unwrap();
+        tokio::fs::write(paths.active_workspace_image(&sandbox_id), b"image")
+            .await
+            .unwrap();
+        let mut context = fixture.finalize_context(
+            run_id,
+            sandbox_id,
+            "sess-new",
+            network_log_session,
+            CancellationToken::new(),
+        );
+        context.workspace_image = Some(workspace_image);
+        context.workspace_promotable = true;
+
+        let _completion_ready = finalize_sandbox_for_completion(
+            Some(Box::new(MockSandbox::new("rejected-workspace-promotion"))),
+            ActiveBudgetLease::new(lease),
+            CompletionPayload::new(
+                run_id,
+                0,
+                None,
+                sandbox_id,
+                SandboxReuseResult::PoolMiss,
+                CompletionAuth::local(),
+            ),
+            context,
+        )
+        .await;
+
+        let idle_states = fixture.idle_pool.lock().await.held_session_states();
+        assert_eq!(idle_states.len(), 1);
+        assert_eq!(idle_states[0].session_id, "sess-existing");
+        let cache_states = cache.held_session_states().await;
         assert_eq!(cache_states.len(), 1);
-        assert_eq!(cache_states[0].session_id, "sess-guest");
+        assert_eq!(cache_states[0].session_id, "sess-new");
     }
 
     #[tokio::test]

--- a/crates/runner/src/cmd/start/sandbox_finalization.rs
+++ b/crates/runner/src/cmd/start/sandbox_finalization.rs
@@ -746,6 +746,7 @@ mod tests {
             promote_workspace_image_from_active_sandbox(&sandbox, Some(&promotion), "test").await;
 
         assert!(promoted);
+        drop(promotion);
         let states = cache.held_session_states().await;
         assert_eq!(states.len(), 1);
         assert_eq!(states[0].session_id, "sess-promote");
@@ -790,6 +791,7 @@ mod tests {
             promote_workspace_image_from_active_sandbox(&sandbox, Some(&promotion), "test").await;
 
         assert!(promoted);
+        drop(promotion);
         let checkout = cache
             .prepare(WorkspaceImagePrepareRequest {
                 run_id: RunId::new_v4(),

--- a/crates/runner/src/cmd/start/sandbox_finalization.rs
+++ b/crates/runner/src/cmd/start/sandbox_finalization.rs
@@ -764,64 +764,71 @@ mod tests {
         let paths = RunnerPaths::new(dir.path().join("runner"));
         tokio::fs::create_dir_all(paths.base_dir()).await.unwrap();
         let cache = SessionWorkspaceCache::new(paths.clone());
-        let run_id = RunId::new_v4();
-        let sandbox_id = SandboxId::new_v4();
-        let lease =
-            prepare_test_workspace_image_lease(&paths, &cache, run_id, sandbox_id, "sess-nonzero")
+
+        for (session_id, terminal_status) in [
+            ("sess-nonzero", WorkspaceCacheTerminalStatus::NonzeroExit),
+            ("sess-cancelled", WorkspaceCacheTerminalStatus::Cancelled),
+        ] {
+            let run_id = RunId::new_v4();
+            let sandbox_id = SandboxId::new_v4();
+            let lease =
+                prepare_test_workspace_image_lease(&paths, &cache, run_id, sandbox_id, session_id)
+                    .await;
+            let sandbox = MockSandbox::new(format!("workspace-promotion-{session_id}"));
+            let storage_fingerprints = crate::idle_pool::StorageFingerprints {
+                storages: std::collections::HashMap::from([(
+                    CANONICAL_WORKING_DIR.to_owned(),
+                    ("repo".to_owned(), "v1".to_owned()),
+                )]),
+                artifacts: std::collections::HashMap::from([(
+                    format!("{CANONICAL_WORKING_DIR}/artifact"),
+                    ("artifact".to_owned(), "v1".to_owned()),
+                )]),
+            };
+            let promotion = test_promotion_context(
+                lease,
+                run_id,
+                sandbox_id,
+                session_id,
+                terminal_status,
+                storage_fingerprints,
+            );
+
+            let promoted =
+                promote_workspace_image_from_active_sandbox(&sandbox, Some(&promotion), "test")
+                    .await;
+
+            assert!(promoted);
+            drop(promotion);
+            let checkout = cache
+                .prepare(WorkspaceImagePrepareRequest {
+                    run_id: RunId::new_v4(),
+                    sandbox_id: SandboxId::new_v4(),
+                    profile_name: "vm0/default",
+                    session_id: Some(session_id),
+                    working_dir: CANONICAL_WORKING_DIR,
+                    image_size_bytes: b"image".len() as u64,
+                    workspace_drive_required: true,
+                })
                 .await;
-        let sandbox = MockSandbox::new("workspace-promotion-nonzero");
-        let storage_fingerprints = crate::idle_pool::StorageFingerprints {
-            storages: std::collections::HashMap::from([(
-                CANONICAL_WORKING_DIR.to_owned(),
-                ("repo".to_owned(), "v1".to_owned()),
-            )]),
-            artifacts: std::collections::HashMap::from([(
-                format!("{CANONICAL_WORKING_DIR}/artifact"),
-                ("artifact".to_owned(), "v1".to_owned()),
-            )]),
-        };
-        let promotion = test_promotion_context(
-            lease,
-            run_id,
-            sandbox_id,
-            "sess-nonzero",
-            WorkspaceCacheTerminalStatus::NonzeroExit,
-            storage_fingerprints,
-        );
 
-        let promoted =
-            promote_workspace_image_from_active_sandbox(&sandbox, Some(&promotion), "test").await;
-
-        assert!(promoted);
-        drop(promotion);
-        let checkout = cache
-            .prepare(WorkspaceImagePrepareRequest {
-                run_id: RunId::new_v4(),
-                sandbox_id: SandboxId::new_v4(),
-                profile_name: "vm0/default",
-                session_id: Some("sess-nonzero"),
-                working_dir: CANONICAL_WORKING_DIR,
-                image_size_bytes: b"image".len() as u64,
-                workspace_drive_required: true,
-            })
-            .await;
-
-        assert!(checkout.is_cache_hit());
-        let previous_storage = checkout
-            .previous_storage()
-            .expect("cache hit should expose previous storage fingerprints");
-        assert!(StorageFingerprints::fingerprint_is_tainted(
-            previous_storage
-                .storages
-                .get(CANONICAL_WORKING_DIR)
-                .expect("storage path should be retained for cleanup")
-        ));
-        assert!(StorageFingerprints::fingerprint_is_tainted(
-            previous_storage
-                .artifacts
-                .get(&format!("{CANONICAL_WORKING_DIR}/artifact"))
-                .expect("artifact path should be retained for cleanup")
-        ));
+            assert!(checkout.is_cache_hit());
+            let previous_storage = checkout
+                .previous_storage()
+                .expect("cache hit should expose previous storage fingerprints");
+            assert!(StorageFingerprints::fingerprint_is_tainted(
+                previous_storage
+                    .storages
+                    .get(CANONICAL_WORKING_DIR)
+                    .expect("storage path should be retained for cleanup")
+            ));
+            assert!(StorageFingerprints::fingerprint_is_tainted(
+                previous_storage
+                    .artifacts
+                    .get(&format!("{CANONICAL_WORKING_DIR}/artifact"))
+                    .expect("artifact path should be retained for cleanup")
+            ));
+        }
     }
 
     #[tokio::test]

--- a/crates/runner/src/cmd/start/tests/failure_recovery/parking_cleanup.rs
+++ b/crates/runner/src/cmd/start/tests/failure_recovery/parking_cleanup.rs
@@ -160,6 +160,148 @@ async fn assert_workspace_cache_after_failed_park(
     shutdown(&env, run_handle).await;
 }
 
+#[tokio::test]
+async fn cancellation_during_sandbox_park_promotes_workspace_cache_before_destroy() {
+    assert_workspace_cache_after_late_cancellation(
+        "sess-cancel-during-park-cache",
+        LateCancellationPoint::DuringPark,
+    )
+    .await;
+}
+
+#[tokio::test]
+async fn cancellation_before_idle_pool_transfer_promotes_workspace_cache_before_destroy() {
+    assert_workspace_cache_after_late_cancellation(
+        "sess-cancel-before-pool-cache",
+        LateCancellationPoint::BeforeIdlePoolTransfer,
+    )
+    .await;
+}
+
+enum LateCancellationPoint {
+    DuringPark,
+    BeforeIdlePoolTransfer,
+}
+
+async fn assert_workspace_cache_after_late_cancellation(
+    session_id: &str,
+    cancellation_point: LateCancellationPoint,
+) {
+    let wait_gate = MockLifecycleGate::new();
+    let park_gate = MockLifecycleGate::new();
+    let destroy_gate = MockLifecycleGate::new();
+    let overrides = Arc::new(sandbox_mock::MockSandboxOverrides::new());
+    overrides.set_wait_process_lifecycle_gate(wait_gate.clone());
+    overrides.set_park_lifecycle_gate(park_gate.clone());
+    overrides.set_destroy_lifecycle_gate(destroy_gate.clone());
+    let counter = Arc::clone(&overrides);
+
+    let mut profiles = test_profiles();
+    profiles.get_mut("vm0/default").unwrap().workspace_disk_mb = 16;
+    let (mut config, env) =
+        mock_run_config_with_overrides(profiles, 8, 32768, 4, Arc::clone(&overrides));
+    let runner_paths = RunnerPaths::new(config.paths.base_dir.clone());
+    let workspace_cache = SessionWorkspaceCache::shared(
+        runner_paths.clone(),
+        &config.paths.home,
+        &config.runner.group,
+    );
+    Arc::get_mut(&mut config.exec_config)
+        .unwrap()
+        .workspace_cache = Some(workspace_cache.clone());
+    let budget = Arc::clone(&config.capacity.budget);
+    let idle_pool = Arc::clone(&config.shared.idle_pool);
+    let cancel_tokens = Arc::clone(&config.provider.cancel_tokens);
+    let run_handle = tokio::spawn(run(config));
+
+    let run_id = RunId::new_v4();
+    let mut context = context_with_session(run_id, session_id);
+    context.feature_flags = Some(std::collections::HashMap::from([(
+        SESSION_WORKSPACE_IMAGE_CACHE_FEATURE_FLAG.to_string(),
+        true,
+    )]));
+    push_job(&env, run_id, "vm0/default", Some(context));
+    let token = wait_cancel_token(&cancel_tokens, run_id, Duration::from_secs(5)).await;
+
+    wait_gate
+        .wait_entered(1, Duration::from_secs(5))
+        .await
+        .expect("wait_process should enter before the active workspace image is written");
+    let sandbox_id = counter
+        .create_configs()
+        .into_iter()
+        .next()
+        .expect("sandbox create config should be recorded before wait_process entry")
+        .id;
+    let active_image = runner_paths.active_workspace_image(&sandbox_id);
+    tokio::fs::create_dir_all(active_image.parent().unwrap())
+        .await
+        .unwrap();
+    let file = tokio::fs::File::create(&active_image).await.unwrap();
+    file.set_len(16 * 1024 * 1024).await.unwrap();
+    drop(file);
+
+    counter.clear_wait_process_lifecycle_gate();
+    wait_gate.release_one();
+    park_gate
+        .wait_entered(1, Duration::from_secs(5))
+        .await
+        .expect("sandbox park should enter gate");
+
+    match cancellation_point {
+        LateCancellationPoint::DuringPark => {
+            token.cancel();
+            park_gate.release_one();
+        }
+        LateCancellationPoint::BeforeIdlePoolTransfer => {
+            let pool_guard = idle_pool.lock().await;
+            park_gate.release_one();
+            env.start_observer
+                .wait_before_idle_pool_ownership_transfer(run_id, Duration::from_secs(5))
+                .await;
+            token.cancel();
+            drop(pool_guard);
+        }
+    }
+
+    destroy_gate
+        .wait_entered(1, Duration::from_secs(5))
+        .await
+        .expect("cancelled parked sandbox should enter destroy gate");
+    assert_eq!(counter.destroy_call_count(), 1);
+    assert_eq!(
+        budget.allocated().2,
+        1,
+        "cancelled VM must retain budget while destroy is in-flight"
+    );
+    assert_no_completion_for_run(
+        &env,
+        run_id,
+        "provider.complete must wait until cancelled VM destroy finishes",
+    );
+
+    destroy_gate.release_one();
+    let completion = env
+        .handle
+        .wait_completion(run_id, Duration::from_secs(5))
+        .await
+        .expect("job should complete after destroy finishes");
+    assert_eq!(completion.exit_code, 0);
+    assert!(
+        completion.error.is_none(),
+        "late cleanup cancellation should not rewrite job result"
+    );
+
+    wait_budget_count(&budget, 0, Duration::from_secs(2)).await;
+    wait_cancel_token_removed(&cancel_tokens, run_id, Duration::from_secs(2)).await;
+    assert_eq!(idle_pool.lock().await.len(), 0);
+    let held = workspace_cache.held_session_states().await;
+    assert_eq!(held.len(), 1);
+    assert_eq!(held[0].session_id, session_id);
+
+    shutdown(&env, run_handle).await;
+}
+
 #[tokio::test(start_paused = true)]
 async fn park_panic_destroys_sandbox_reports_completion_and_releases_budget() {
     let overrides = Arc::new(sandbox_mock::MockSandboxOverrides::new());

--- a/crates/runner/src/cmd/start/tests/failure_recovery/parking_cleanup.rs
+++ b/crates/runner/src/cmd/start/tests/failure_recovery/parking_cleanup.rs
@@ -6,6 +6,9 @@ use super::super::support::{
 use super::support::assert_no_completion_for_run;
 
 use crate::idle_pool::ParkingState;
+use crate::paths::RunnerPaths;
+use crate::types::SESSION_WORKSPACE_IMAGE_CACHE_FEATURE_FLAG;
+use crate::workspace_image_cache::SessionWorkspaceCache;
 use sandbox_mock::MockLifecycleGate;
 
 /// When `Sandbox::park()` returns an error, the runner falls back to
@@ -50,6 +53,81 @@ async fn park_failure_destroys_sandbox_and_skips_pool() {
         1,
         "park() should have been attempted exactly once"
     );
+
+    shutdown(&env, run_handle).await;
+}
+
+#[tokio::test]
+async fn park_failure_promotes_workspace_cache_before_destroy() {
+    let wait_gate = MockLifecycleGate::new();
+    let overrides = Arc::new(sandbox_mock::MockSandboxOverrides::new());
+    overrides.set_wait_process_lifecycle_gate(wait_gate.clone());
+    overrides.push_park_result(Err(sandbox::SandboxError::IdleTransition {
+        transition: sandbox::SandboxIdleTransition::Park,
+        message: "simulated balloon failure".into(),
+    }));
+    let counter = Arc::clone(&overrides);
+
+    let mut profiles = test_profiles();
+    profiles.get_mut("vm0/default").unwrap().workspace_disk_mb = 16;
+    let (mut config, env) =
+        mock_run_config_with_overrides(profiles, 8, 32768, 4, Arc::clone(&overrides));
+    let runner_paths = RunnerPaths::new(config.paths.base_dir.clone());
+    let workspace_cache = SessionWorkspaceCache::shared(
+        runner_paths.clone(),
+        &config.paths.home,
+        &config.runner.group,
+    );
+    Arc::get_mut(&mut config.exec_config)
+        .unwrap()
+        .workspace_cache = Some(workspace_cache.clone());
+    let budget = Arc::clone(&config.capacity.budget);
+    let idle_pool = Arc::clone(&config.shared.idle_pool);
+    let run_handle = tokio::spawn(run(config));
+
+    let run_id = RunId::new_v4();
+    let session_id = "sess-park-fail-cache";
+    let mut context = context_with_session(run_id, session_id);
+    context.feature_flags = Some(std::collections::HashMap::from([(
+        SESSION_WORKSPACE_IMAGE_CACHE_FEATURE_FLAG.to_string(),
+        true,
+    )]));
+    push_job(&env, run_id, "vm0/default", Some(context));
+
+    wait_gate
+        .wait_entered(1, Duration::from_secs(5))
+        .await
+        .expect("wait_process should enter before the active workspace image is written");
+    let sandbox_id = counter
+        .create_configs()
+        .into_iter()
+        .next()
+        .expect("sandbox create config should be recorded before wait_process entry")
+        .id;
+    let active_image = runner_paths.active_workspace_image(&sandbox_id);
+    tokio::fs::create_dir_all(active_image.parent().unwrap())
+        .await
+        .unwrap();
+    let file = tokio::fs::File::create(&active_image).await.unwrap();
+    file.set_len(16 * 1024 * 1024).await.unwrap();
+    drop(file);
+
+    counter.clear_wait_process_lifecycle_gate();
+    wait_gate.release_one();
+    let completion = env
+        .handle
+        .wait_completion(run_id, Duration::from_secs(5))
+        .await
+        .expect("job should complete normally after park failure destroy");
+    assert_eq!(completion.exit_code, 0);
+
+    wait_budget_count(&budget, 0, Duration::from_secs(2)).await;
+    assert_eq!(idle_pool.lock().await.len(), 0);
+    assert_eq!(counter.park_call_count(), 1);
+    assert_eq!(counter.destroy_call_count(), 1);
+    let held = workspace_cache.held_session_states().await;
+    assert_eq!(held.len(), 1);
+    assert_eq!(held[0].session_id, session_id);
 
     shutdown(&env, run_handle).await;
 }

--- a/crates/runner/src/cmd/start/tests/failure_recovery/parking_cleanup.rs
+++ b/crates/runner/src/cmd/start/tests/failure_recovery/parking_cleanup.rs
@@ -59,13 +59,38 @@ async fn park_failure_destroys_sandbox_and_skips_pool() {
 
 #[tokio::test]
 async fn park_failure_promotes_workspace_cache_before_destroy() {
+    assert_workspace_cache_after_failed_park(
+        "sess-park-fail-cache",
+        |overrides| {
+            overrides.push_park_result(Err(sandbox::SandboxError::IdleTransition {
+                transition: sandbox::SandboxIdleTransition::Park,
+                message: "simulated balloon failure".into(),
+            }));
+        },
+        true,
+    )
+    .await;
+}
+
+#[tokio::test]
+async fn park_panic_skips_workspace_cache_before_destroy() {
+    assert_workspace_cache_after_failed_park(
+        "sess-park-panic-cache",
+        |overrides| overrides.push_park_panic("simulated park panic"),
+        false,
+    )
+    .await;
+}
+
+async fn assert_workspace_cache_after_failed_park(
+    session_id: &str,
+    configure_park: impl FnOnce(&sandbox_mock::MockSandboxOverrides),
+    expect_cache: bool,
+) {
     let wait_gate = MockLifecycleGate::new();
     let overrides = Arc::new(sandbox_mock::MockSandboxOverrides::new());
     overrides.set_wait_process_lifecycle_gate(wait_gate.clone());
-    overrides.push_park_result(Err(sandbox::SandboxError::IdleTransition {
-        transition: sandbox::SandboxIdleTransition::Park,
-        message: "simulated balloon failure".into(),
-    }));
+    configure_park(&overrides);
     let counter = Arc::clone(&overrides);
 
     let mut profiles = test_profiles();
@@ -86,7 +111,6 @@ async fn park_failure_promotes_workspace_cache_before_destroy() {
     let run_handle = tokio::spawn(run(config));
 
     let run_id = RunId::new_v4();
-    let session_id = "sess-park-fail-cache";
     let mut context = context_with_session(run_id, session_id);
     context.feature_flags = Some(std::collections::HashMap::from([(
         SESSION_WORKSPACE_IMAGE_CACHE_FEATURE_FLAG.to_string(),
@@ -126,8 +150,12 @@ async fn park_failure_promotes_workspace_cache_before_destroy() {
     assert_eq!(counter.park_call_count(), 1);
     assert_eq!(counter.destroy_call_count(), 1);
     let held = workspace_cache.held_session_states().await;
-    assert_eq!(held.len(), 1);
-    assert_eq!(held[0].session_id, session_id);
+    if expect_cache {
+        assert_eq!(held.len(), 1);
+        assert_eq!(held[0].session_id, session_id);
+    } else {
+        assert!(held.is_empty());
+    }
 
     shutdown(&env, run_handle).await;
 }

--- a/crates/runner/src/executor.rs
+++ b/crates/runner/src/executor.rs
@@ -584,7 +584,30 @@ pub async fn execute_job_reuse(
                     None => cache.lease_active(active_request).await,
                 })
             }
-            _ => None,
+            _ => {
+                if let Some(promotion) = workspace_promotion
+                    && let Err(error) = promotion
+                        .invalidate_current("reused sandbox ran without workspace image cache")
+                        .await
+                {
+                    let failure = ExecutionFailure::from_error(format!(
+                        "failed to invalidate workspace image cache before disabled-cache reuse: {error}"
+                    ));
+                    return (
+                        ExecuteOutcome {
+                            failure: Some(failure),
+                            sandbox: Some(sandbox),
+                            source_ip,
+                            network_log_session: None,
+                            workspace_image: None,
+                            workspace_promotable: false,
+                            guest_session_id: None,
+                        },
+                        telemetry,
+                    );
+                }
+                None
+            }
         };
         let mut outcome = execute_reused_sandbox(
             sandbox,
@@ -6594,6 +6617,118 @@ mod tests {
         assert_eq!(reuse_outcome.exit_code(), 0);
         assert!(reuse_outcome.error().is_none());
         assert!(reuse_outcome.sandbox.is_some());
+    }
+
+    #[tokio::test]
+    async fn execute_job_reuse_without_workspace_cache_invalidates_held_cache_entry() {
+        use crate::idle_pool::{
+            IdleParkRequest, IdleParkRequestParts, IdlePool, IdlePoolConfig, IdleUnparkResult,
+            ParkResult, StorageFingerprints,
+        };
+
+        let dir = tempfile::tempdir().unwrap();
+        let runner_paths = RunnerPaths::new(dir.path().join("runner"));
+        let cache = SessionWorkspaceCache::new(runner_paths.clone());
+        let mut config = test_executor_config(dir.path()).await;
+        config.workspace_cache = Some(cache.clone());
+        let params = JobParams {
+            workspace_disk_mb: 16,
+            ..default_params()
+        };
+        let session_id = "sess-cache-disabled-reuse";
+        seed_workspace_image_cache(&cache, &runner_paths, session_id, params.workspace_disk_mb)
+            .await;
+
+        let run_id = RunId::new_v4();
+        let sandbox_id = SandboxId::new_v4();
+        let lease = cache
+            .prepare(WorkspaceImagePrepareRequest {
+                run_id,
+                sandbox_id,
+                profile_name: &params.profile_name,
+                session_id: Some(session_id),
+                working_dir: CANONICAL_WORKING_DIR,
+                image_size_bytes: u64::from(params.workspace_disk_mb) * 1024 * 1024,
+                workspace_drive_required: true,
+            })
+            .await;
+        assert!(lease.is_cache_hit());
+        let promotion = lease
+            .into_promotion_context(
+                crate::workspace_image_cache::WorkspaceImagePromotionRequest {
+                    run_id,
+                    sandbox_id,
+                    session_id_override: Some(session_id),
+                    terminal_status: WorkspaceCacheTerminalStatus::Success,
+                    completed_at: "2026-06-01T00:00:01.000Z".into(),
+                    storage_fingerprints: StorageFingerprints::default(),
+                    promotable: true,
+                },
+            )
+            .unwrap();
+
+        let sandbox = Box::new(MockSandbox::new("cache-disabled-reuse")) as Box<dyn Sandbox>;
+        let source_ip = sandbox.source_ip().to_owned();
+        let candidate = IdleParkRequest::new(IdleParkRequestParts {
+            sandbox,
+            factory: Arc::new(Box::new(MockSandboxFactory::new()) as Box<dyn SandboxFactory>),
+            session_id: session_id.to_owned(),
+            sandbox_id,
+            profile_name: params.profile_name.clone(),
+            device_rate_limits: None,
+            budget_lease: test_budget_lease(),
+            source_ip,
+            storage_fingerprints: StorageFingerprints::default(),
+            workspace_promotion: Some(promotion),
+        })
+        .park_for_idle()
+        .await
+        .unwrap_or_else(|failure| {
+            let error = failure.into_active_parts().error;
+            panic!("test sandbox should park: {error}");
+        })
+        .with_last_completed_at("2026-06-01T00:00:01.000Z".into());
+
+        let mut pool = IdlePool::new(IdlePoolConfig {
+            default_timeout: std::time::Duration::from_secs(300),
+            max_idle: 0,
+        });
+        assert!(matches!(pool.park(candidate), ParkResult::Parked));
+        let entry = pool.take(session_id).expect("idle entry should exist");
+        let idle_sandbox = match entry.try_unpark().await {
+            IdleUnparkResult::Reused { sandbox, .. } => *sandbox,
+            IdleUnparkResult::Failed { error, .. } => {
+                panic!("test idle entry should unpark: {error}");
+            }
+        };
+
+        let mut ctx = minimal_context();
+        ctx.resume_session = Some(ResumeSession {
+            session_id: session_id.into(),
+            session_history: r#"{"type":"init"}"#.into(),
+        });
+        ctx.feature_flags = Some(HashMap::from([(
+            SESSION_WORKSPACE_IMAGE_CACHE_FEATURE_FLAG.into(),
+            false,
+        )]));
+
+        let cancel = tokio_util::sync::CancellationToken::new();
+        let (reuse_outcome, _telemetry) =
+            execute_job_reuse(idle_sandbox, ctx, &config, &params, cancel).await;
+        assert_eq!(reuse_outcome.exit_code(), 0);
+
+        let checkout = cache
+            .prepare(WorkspaceImagePrepareRequest {
+                run_id: RunId::new_v4(),
+                sandbox_id: SandboxId::new_v4(),
+                profile_name: &params.profile_name,
+                session_id: Some(session_id),
+                working_dir: CANONICAL_WORKING_DIR,
+                image_size_bytes: u64::from(params.workspace_disk_mb) * 1024 * 1024,
+                workspace_drive_required: true,
+            })
+            .await;
+        assert_eq!(checkout.result(), WorkspaceCacheCheckoutResult::Miss);
     }
 
     #[tokio::test]

--- a/crates/runner/src/executor.rs
+++ b/crates/runner/src/executor.rs
@@ -6621,11 +6621,6 @@ mod tests {
 
     #[tokio::test]
     async fn execute_job_reuse_without_workspace_cache_invalidates_held_cache_entry() {
-        use crate::idle_pool::{
-            IdleParkRequest, IdleParkRequestParts, IdlePool, IdlePoolConfig, IdleUnparkResult,
-            ParkResult, StorageFingerprints,
-        };
-
         let dir = tempfile::tempdir().unwrap();
         let runner_paths = RunnerPaths::new(dir.path().join("runner"));
         let cache = SessionWorkspaceCache::new(runner_paths.clone());
@@ -6636,8 +6631,113 @@ mod tests {
             ..default_params()
         };
         let session_id = "sess-cache-disabled-reuse";
-        seed_workspace_image_cache(&cache, &runner_paths, session_id, params.workspace_disk_mb)
+        let (idle_sandbox, _current_image, _overrides) =
+            reusable_idle_sandbox_with_workspace_promotion(
+                &cache,
+                &runner_paths,
+                &params,
+                session_id,
+            )
             .await;
+
+        let mut ctx = minimal_context();
+        ctx.resume_session = Some(ResumeSession {
+            session_id: session_id.into(),
+            session_history: r#"{"type":"init"}"#.into(),
+        });
+        ctx.feature_flags = Some(HashMap::from([(
+            SESSION_WORKSPACE_IMAGE_CACHE_FEATURE_FLAG.into(),
+            false,
+        )]));
+
+        let cancel = tokio_util::sync::CancellationToken::new();
+        let (reuse_outcome, _telemetry) =
+            execute_job_reuse(idle_sandbox, ctx, &config, &params, cancel).await;
+        assert_eq!(reuse_outcome.exit_code(), 0);
+
+        let checkout = cache
+            .prepare(WorkspaceImagePrepareRequest {
+                run_id: RunId::new_v4(),
+                sandbox_id: SandboxId::new_v4(),
+                profile_name: &params.profile_name,
+                session_id: Some(session_id),
+                working_dir: CANONICAL_WORKING_DIR,
+                image_size_bytes: u64::from(params.workspace_disk_mb) * 1024 * 1024,
+                workspace_drive_required: true,
+            })
+            .await;
+        assert_eq!(checkout.result(), WorkspaceCacheCheckoutResult::Miss);
+    }
+
+    #[tokio::test]
+    async fn uncached_reuse_stops_when_cache_invalidation_fails() {
+        let dir = tempfile::tempdir().unwrap();
+        let runner_paths = RunnerPaths::new(dir.path().join("runner"));
+        let cache = SessionWorkspaceCache::new(runner_paths.clone());
+        let mut config = test_executor_config(dir.path()).await;
+        config.workspace_cache = Some(cache.clone());
+        let params = JobParams {
+            workspace_disk_mb: 16,
+            ..default_params()
+        };
+        let session_id = "sess-cache-disabled-reuse-invalidate-error";
+        let (idle_sandbox, current_image, overrides) =
+            reusable_idle_sandbox_with_workspace_promotion(
+                &cache,
+                &runner_paths,
+                &params,
+                session_id,
+            )
+            .await;
+        tokio::fs::remove_file(&current_image).await.unwrap();
+        tokio::fs::create_dir(&current_image).await.unwrap();
+
+        let mut ctx = minimal_context();
+        ctx.resume_session = Some(ResumeSession {
+            session_id: session_id.into(),
+            session_history: r#"{"type":"init"}"#.into(),
+        });
+        ctx.feature_flags = Some(HashMap::from([(
+            SESSION_WORKSPACE_IMAGE_CACHE_FEATURE_FLAG.into(),
+            false,
+        )]));
+
+        let cancel = tokio_util::sync::CancellationToken::new();
+        let (reuse_outcome, _telemetry) =
+            execute_job_reuse(idle_sandbox, ctx, &config, &params, cancel).await;
+
+        assert_eq!(reuse_outcome.exit_code(), 1);
+        assert!(reuse_outcome.sandbox.is_some());
+        assert!(
+            reuse_outcome
+                .error()
+                .unwrap()
+                .contains("failed to invalidate workspace image cache before disabled-cache reuse")
+        );
+        assert!(
+            overrides.exec_calls().is_empty(),
+            "reused sandbox must not run after stale cache invalidation fails"
+        );
+    }
+
+    async fn reusable_idle_sandbox_with_workspace_promotion(
+        cache: &SessionWorkspaceCache,
+        runner_paths: &RunnerPaths,
+        params: &JobParams,
+        session_id: &str,
+    ) -> (
+        crate::idle_pool::ReusableIdleSandbox,
+        PathBuf,
+        Arc<sandbox_mock::MockSandboxOverrides>,
+    ) {
+        use crate::idle_pool::{
+            IdleParkRequest, IdleParkRequestParts, IdlePool, IdlePoolConfig, IdleUnparkResult,
+            ParkResult, StorageFingerprints,
+        };
+
+        let current_image =
+            seed_workspace_image_cache(cache, runner_paths, session_id, params.workspace_disk_mb)
+                .await;
 
         let run_id = RunId::new_v4();
         let sandbox_id = SandboxId::new_v4();
@@ -6667,15 +6767,30 @@ mod tests {
             )
             .unwrap();
 
-        let sandbox = Box::new(MockSandbox::new("cache-disabled-reuse")) as Box<dyn Sandbox>;
+        let overrides = Arc::new(sandbox_mock::MockSandboxOverrides::new());
+        let factory: Arc<Box<dyn SandboxFactory>> = Arc::new(Box::new(
+            MockSandboxFactory::with_overrides(Arc::clone(&overrides)),
+        ));
+        let sandbox = factory
+            .create(sandbox::SandboxConfig {
+                id: sandbox_id,
+                resources: sandbox::ResourceLimits {
+                    cpu_count: params.vcpu,
+                    memory_mb: params.memory_mb,
+                },
+                device_rate_limits: params.device_rate_limits.clone(),
+                workspace_drive: None,
+            })
+            .await
+            .expect("create sandbox");
         let source_ip = sandbox.source_ip().to_owned();
         let candidate = IdleParkRequest::new(IdleParkRequestParts {
             sandbox,
-            factory: Arc::new(Box::new(MockSandboxFactory::new()) as Box<dyn SandboxFactory>),
+            factory,
             session_id: session_id.to_owned(),
             sandbox_id,
             profile_name: params.profile_name.clone(),
-            device_rate_limits: None,
+            device_rate_limits: params.device_rate_limits.clone(),
             budget_lease: test_budget_lease(),
             source_ip,
             storage_fingerprints: StorageFingerprints::default(),
@@ -6702,33 +6817,7 @@ mod tests {
             }
         };
 
-        let mut ctx = minimal_context();
-        ctx.resume_session = Some(ResumeSession {
-            session_id: session_id.into(),
-            session_history: r#"{"type":"init"}"#.into(),
-        });
-        ctx.feature_flags = Some(HashMap::from([(
-            SESSION_WORKSPACE_IMAGE_CACHE_FEATURE_FLAG.into(),
-            false,
-        )]));
-
-        let cancel = tokio_util::sync::CancellationToken::new();
-        let (reuse_outcome, _telemetry) =
-            execute_job_reuse(idle_sandbox, ctx, &config, &params, cancel).await;
-        assert_eq!(reuse_outcome.exit_code(), 0);
-
-        let checkout = cache
-            .prepare(WorkspaceImagePrepareRequest {
-                run_id: RunId::new_v4(),
-                sandbox_id: SandboxId::new_v4(),
-                profile_name: &params.profile_name,
-                session_id: Some(session_id),
-                working_dir: CANONICAL_WORKING_DIR,
-                image_size_bytes: u64::from(params.workspace_disk_mb) * 1024 * 1024,
-                workspace_drive_required: true,
-            })
-            .await;
-        assert_eq!(checkout.result(), WorkspaceCacheCheckoutResult::Miss);
+        (idle_sandbox, current_image, overrides)
     }
 
     #[tokio::test]

--- a/crates/runner/src/executor.rs
+++ b/crates/runner/src/executor.rs
@@ -549,6 +549,7 @@ pub async fn execute_job_reuse(
     let idle_parts = idle_sandbox.into_parts();
     let source_ip = idle_parts.source_ip;
     let prev_storage = idle_parts.storage_fingerprints;
+    let workspace_promotion = idle_parts.workspace_promotion;
     let sandbox = idle_parts.sandbox;
 
     // execute_reused_sandbox never returns Err — it always returns the sandbox
@@ -568,19 +569,21 @@ pub async fn execute_job_reuse(
             context.session_workspace_image_cache_enabled(),
             config.workspace_cache.as_ref(),
         ) {
-            (true, Some(cache)) => Some(
-                cache
-                    .lease_active(WorkspaceImageActiveLeaseRequest {
-                        run_id,
-                        sandbox_id,
-                        profile_name: &params.profile_name,
-                        session_id: context.session_id(),
-                        working_dir: CANONICAL_WORKING_DIR,
-                        image_size_bytes: u64::from(params.workspace_disk_mb) * 1024 * 1024,
-                        workspace_drive_available: true,
-                    })
-                    .await,
-            ),
+            (true, Some(cache)) => {
+                let active_request = WorkspaceImageActiveLeaseRequest {
+                    run_id,
+                    sandbox_id,
+                    profile_name: &params.profile_name,
+                    session_id: context.session_id(),
+                    working_dir: CANONICAL_WORKING_DIR,
+                    image_size_bytes: u64::from(params.workspace_disk_mb) * 1024 * 1024,
+                    workspace_drive_available: true,
+                };
+                Some(match workspace_promotion {
+                    Some(promotion) => promotion.into_active_lease(active_request),
+                    None => cache.lease_active(active_request).await,
+                })
+            }
             _ => None,
         };
         let mut outcome = execute_reused_sandbox(
@@ -5051,7 +5054,7 @@ mod tests {
             IdleUnparkResult::Reused {
                 sandbox,
                 budget_lease,
-            } => (sandbox, budget_lease),
+            } => (*sandbox, budget_lease),
             IdleUnparkResult::Failed { error, .. } => {
                 panic!("test idle entry should unpark: {error}");
             }
@@ -6793,7 +6796,7 @@ mod tests {
             crate::idle_pool::IdleUnparkResult::Reused {
                 sandbox,
                 budget_lease,
-            } => (sandbox, budget_lease),
+            } => (*sandbox, budget_lease),
             crate::idle_pool::IdleUnparkResult::Failed { error, .. } => {
                 panic!("test idle entry should unpark: {error}");
             }

--- a/crates/runner/src/executor.rs
+++ b/crates/runner/src/executor.rs
@@ -552,6 +552,51 @@ pub async fn execute_job_reuse(
     let workspace_promotion = idle_parts.workspace_promotion;
     let sandbox = idle_parts.sandbox;
 
+    let workspace_image = match (
+        context.session_workspace_image_cache_enabled(),
+        config.workspace_cache.as_ref(),
+    ) {
+        (true, Some(cache)) => {
+            let active_request = WorkspaceImageActiveLeaseRequest {
+                run_id,
+                sandbox_id,
+                profile_name: &params.profile_name,
+                session_id: context.session_id(),
+                working_dir: CANONICAL_WORKING_DIR,
+                image_size_bytes: u64::from(params.workspace_disk_mb) * 1024 * 1024,
+                workspace_drive_available: true,
+            };
+            Some(match workspace_promotion {
+                Some(promotion) => promotion.into_active_lease(active_request),
+                None => cache.lease_active(active_request).await,
+            })
+        }
+        _ => {
+            if let Some(promotion) = workspace_promotion
+                && let Err(error) = promotion
+                    .invalidate_current("reused sandbox ran without workspace image cache")
+                    .await
+            {
+                let failure = ExecutionFailure::from_error(format!(
+                    "failed to invalidate workspace image cache before disabled-cache reuse: {error}"
+                ));
+                return (
+                    ExecuteOutcome {
+                        failure: Some(failure),
+                        sandbox: Some(sandbox),
+                        source_ip,
+                        network_log_session: None,
+                        workspace_image: None,
+                        workspace_promotable: false,
+                        guest_session_id: None,
+                    },
+                    telemetry,
+                );
+            }
+            None
+        }
+    };
+
     // execute_reused_sandbox never returns Err — it always returns the sandbox
     // in the outcome so the caller can stop + destroy it on failure.
     let outcome = if let Err(error) = validate_execution_context_before_sandbox(&context) {
@@ -560,55 +605,15 @@ pub async fn execute_job_reuse(
             sandbox: Some(sandbox),
             source_ip,
             network_log_session: None,
-            workspace_image: None,
-            workspace_promotable: false,
+            workspace_promotable: workspace_image_promotable(
+                workspace_image.as_ref(),
+                &context,
+                None,
+            ),
+            workspace_image,
             guest_session_id: None,
         }
     } else {
-        let workspace_image = match (
-            context.session_workspace_image_cache_enabled(),
-            config.workspace_cache.as_ref(),
-        ) {
-            (true, Some(cache)) => {
-                let active_request = WorkspaceImageActiveLeaseRequest {
-                    run_id,
-                    sandbox_id,
-                    profile_name: &params.profile_name,
-                    session_id: context.session_id(),
-                    working_dir: CANONICAL_WORKING_DIR,
-                    image_size_bytes: u64::from(params.workspace_disk_mb) * 1024 * 1024,
-                    workspace_drive_available: true,
-                };
-                Some(match workspace_promotion {
-                    Some(promotion) => promotion.into_active_lease(active_request),
-                    None => cache.lease_active(active_request).await,
-                })
-            }
-            _ => {
-                if let Some(promotion) = workspace_promotion
-                    && let Err(error) = promotion
-                        .invalidate_current("reused sandbox ran without workspace image cache")
-                        .await
-                {
-                    let failure = ExecutionFailure::from_error(format!(
-                        "failed to invalidate workspace image cache before disabled-cache reuse: {error}"
-                    ));
-                    return (
-                        ExecuteOutcome {
-                            failure: Some(failure),
-                            sandbox: Some(sandbox),
-                            source_ip,
-                            network_log_session: None,
-                            workspace_image: None,
-                            workspace_promotable: false,
-                            guest_session_id: None,
-                        },
-                        telemetry,
-                    );
-                }
-                None
-            }
-        };
         let mut outcome = execute_reused_sandbox(
             sandbox,
             &source_ip,
@@ -6789,6 +6794,72 @@ mod tests {
         assert!(
             current_image.exists(),
             "lock-busy invalidation must not remove a cache image it could not lock"
+        );
+    }
+
+    #[tokio::test]
+    async fn cached_reuse_validation_failure_keeps_workspace_cache_hidden() {
+        let dir = tempfile::tempdir().unwrap();
+        let runner_paths = RunnerPaths::new(dir.path().join("runner"));
+        let cache = SessionWorkspaceCache::new(runner_paths.clone());
+        let mut config = test_executor_config(dir.path()).await;
+        config.workspace_cache = Some(cache.clone());
+        let params = JobParams {
+            workspace_disk_mb: 16,
+            ..default_params()
+        };
+        let session_id = "sess-cache-reuse-validation-failure";
+        let (idle_sandbox, _current_image, overrides) =
+            reusable_idle_sandbox_with_workspace_promotion(
+                &cache,
+                &runner_paths,
+                &params,
+                session_id,
+            )
+            .await;
+
+        let mut ctx = minimal_context();
+        ctx.resume_session = Some(ResumeSession {
+            session_id: session_id.into(),
+            session_history: r#"{"type":"init"}"#.into(),
+        });
+        ctx.feature_flags = Some(HashMap::from([(
+            SESSION_WORKSPACE_IMAGE_CACHE_FEATURE_FLAG.into(),
+            true,
+        )]));
+        ctx.environment = Some(HashMap::from([(
+            "OPENAI_API_KEY".into(),
+            "sk-proj-real-openai-secret".into(),
+        )]));
+
+        let cancel = tokio_util::sync::CancellationToken::new();
+        let (reuse_outcome, _telemetry) =
+            execute_job_reuse(idle_sandbox, ctx, &config, &params, cancel).await;
+
+        assert_eq!(reuse_outcome.exit_code(), 1);
+        assert!(reuse_outcome.sandbox.is_some());
+        assert!(reuse_outcome.workspace_promotable);
+        assert!(reuse_outcome.workspace_image.is_some());
+        assert!(
+            overrides.start_process_calls().is_empty(),
+            "reused sandbox must not start a process after env validation failure"
+        );
+
+        let checkout = cache
+            .prepare(WorkspaceImagePrepareRequest {
+                run_id: RunId::new_v4(),
+                sandbox_id: SandboxId::new_v4(),
+                profile_name: &params.profile_name,
+                session_id: Some(session_id),
+                working_dir: CANONICAL_WORKING_DIR,
+                image_size_bytes: u64::from(params.workspace_disk_mb) * 1024 * 1024,
+                workspace_drive_required: true,
+            })
+            .await;
+        assert_eq!(
+            checkout.result(),
+            WorkspaceCacheCheckoutResult::LockBusy,
+            "pre-run validation failure must not release the hidden cache baseline before finalization can promote or invalidate the live workspace"
         );
     }
 

--- a/crates/runner/src/executor.rs
+++ b/crates/runner/src/executor.rs
@@ -6720,6 +6720,78 @@ mod tests {
         );
     }
 
+    #[tokio::test]
+    async fn uncached_reuse_stops_when_required_cache_invalidation_lock_is_busy() {
+        let dir = tempfile::tempdir().unwrap();
+        let runner_paths = RunnerPaths::new(dir.path().join("runner"));
+        let cache = SessionWorkspaceCache::new(runner_paths.clone());
+        let mut config = test_executor_config(dir.path()).await;
+        config.workspace_cache = Some(cache.clone());
+        let params = JobParams {
+            workspace_disk_mb: 16,
+            ..default_params()
+        };
+        let session_id = "sess-cache-disabled-reuse-lock-busy";
+        let current_image =
+            seed_workspace_image_cache(&cache, &runner_paths, session_id, params.workspace_disk_mb)
+                .await;
+        let (idle_sandbox, overrides) = reusable_idle_sandbox_with_unlocked_workspace_promotion(
+            &cache,
+            &runner_paths,
+            &params,
+            session_id,
+        )
+        .await;
+        let cache_key = crate::paths::scoped_session_workspace_cache_key(
+            "",
+            &params.profile_name,
+            session_id,
+            CANONICAL_WORKING_DIR,
+            u64::from(params.workspace_disk_mb) * 1024 * 1024,
+        );
+        let _held_lock = crate::lock::acquire(crate::paths::workspace_image_cache_lock_path(
+            &runner_paths.base_dir().join("locks"),
+            &cache_key,
+        ))
+        .await
+        .unwrap();
+
+        let mut ctx = minimal_context();
+        ctx.resume_session = Some(ResumeSession {
+            session_id: session_id.into(),
+            session_history: r#"{"type":"init"}"#.into(),
+        });
+        ctx.feature_flags = Some(HashMap::from([(
+            SESSION_WORKSPACE_IMAGE_CACHE_FEATURE_FLAG.into(),
+            false,
+        )]));
+
+        let cancel = tokio_util::sync::CancellationToken::new();
+        let (reuse_outcome, _telemetry) =
+            execute_job_reuse(idle_sandbox, ctx, &config, &params, cancel).await;
+
+        assert_eq!(reuse_outcome.exit_code(), 1);
+        assert!(reuse_outcome.sandbox.is_some());
+        let error = reuse_outcome.error().unwrap();
+        assert!(
+            error
+                .contains("failed to invalidate workspace image cache before disabled-cache reuse"),
+            "got: {error}"
+        );
+        assert!(
+            error.contains("lock unavailable"),
+            "lock contention should be surfaced, got: {error}"
+        );
+        assert!(
+            overrides.exec_calls().is_empty(),
+            "reused sandbox must not run when required stale cache invalidation cannot get the entry lock"
+        );
+        assert!(
+            current_image.exists(),
+            "lock-busy invalidation must not remove a cache image it could not lock"
+        );
+    }
+
     async fn reusable_idle_sandbox_with_workspace_promotion(
         cache: &SessionWorkspaceCache,
         runner_paths: &RunnerPaths,
@@ -6818,6 +6890,108 @@ mod tests {
         };
 
         (idle_sandbox, current_image, overrides)
+    }
+
+    async fn reusable_idle_sandbox_with_unlocked_workspace_promotion(
+        cache: &SessionWorkspaceCache,
+        runner_paths: &RunnerPaths,
+        params: &JobParams,
+        session_id: &str,
+    ) -> (
+        crate::idle_pool::ReusableIdleSandbox,
+        Arc<sandbox_mock::MockSandboxOverrides>,
+    ) {
+        use crate::idle_pool::{
+            IdleParkRequest, IdleParkRequestParts, IdlePool, IdlePoolConfig, IdleUnparkResult,
+            ParkResult, StorageFingerprints,
+        };
+
+        let run_id = RunId::new_v4();
+        let sandbox_id = SandboxId::new_v4();
+        let lease = cache
+            .prepare(WorkspaceImagePrepareRequest {
+                run_id,
+                sandbox_id,
+                profile_name: &params.profile_name,
+                session_id: None,
+                working_dir: CANONICAL_WORKING_DIR,
+                image_size_bytes: u64::from(params.workspace_disk_mb) * 1024 * 1024,
+                workspace_drive_required: true,
+            })
+            .await;
+        assert_eq!(lease.result(), WorkspaceCacheCheckoutResult::NoSession);
+        let active_image = runner_paths.active_workspace_image(&sandbox_id);
+        tokio::fs::create_dir_all(active_image.parent().unwrap())
+            .await
+            .unwrap();
+        tokio::fs::write(&active_image, b"active image")
+            .await
+            .unwrap();
+        let promotion = lease
+            .into_promotion_context(
+                crate::workspace_image_cache::WorkspaceImagePromotionRequest {
+                    run_id,
+                    sandbox_id,
+                    session_id_override: Some(session_id),
+                    terminal_status: WorkspaceCacheTerminalStatus::Success,
+                    completed_at: "2026-06-01T00:00:01.000Z".into(),
+                    storage_fingerprints: StorageFingerprints::default(),
+                    promotable: true,
+                },
+            )
+            .unwrap();
+
+        let overrides = Arc::new(sandbox_mock::MockSandboxOverrides::new());
+        let factory: Arc<Box<dyn SandboxFactory>> = Arc::new(Box::new(
+            MockSandboxFactory::with_overrides(Arc::clone(&overrides)),
+        ));
+        let sandbox = factory
+            .create(sandbox::SandboxConfig {
+                id: sandbox_id,
+                resources: sandbox::ResourceLimits {
+                    cpu_count: params.vcpu,
+                    memory_mb: params.memory_mb,
+                },
+                device_rate_limits: params.device_rate_limits.clone(),
+                workspace_drive: None,
+            })
+            .await
+            .expect("create sandbox");
+        let source_ip = sandbox.source_ip().to_owned();
+        let candidate = IdleParkRequest::new(IdleParkRequestParts {
+            sandbox,
+            factory,
+            session_id: session_id.to_owned(),
+            sandbox_id,
+            profile_name: params.profile_name.clone(),
+            device_rate_limits: params.device_rate_limits.clone(),
+            budget_lease: test_budget_lease(),
+            source_ip,
+            storage_fingerprints: StorageFingerprints::default(),
+            workspace_promotion: Some(promotion),
+        })
+        .park_for_idle()
+        .await
+        .unwrap_or_else(|failure| {
+            let error = failure.into_active_parts().error;
+            panic!("test sandbox should park: {error}");
+        })
+        .with_last_completed_at("2026-06-01T00:00:01.000Z".into());
+
+        let mut pool = IdlePool::new(IdlePoolConfig {
+            default_timeout: std::time::Duration::from_secs(300),
+            max_idle: 0,
+        });
+        assert!(matches!(pool.park(candidate), ParkResult::Parked));
+        let entry = pool.take(session_id).expect("idle entry should exist");
+        let idle_sandbox = match entry.try_unpark().await {
+            IdleUnparkResult::Reused { sandbox, .. } => *sandbox,
+            IdleUnparkResult::Failed { error, .. } => {
+                panic!("test idle entry should unpark: {error}");
+            }
+        };
+
+        (idle_sandbox, overrides)
     }
 
     #[tokio::test]

--- a/crates/runner/src/idle_pool.rs
+++ b/crates/runner/src/idle_pool.rs
@@ -14,6 +14,8 @@ use serde::{Deserialize, Serialize};
 use crate::resource_budget::BudgetLease;
 use crate::status::IdleVm;
 use crate::types::HeldSessionState;
+use crate::workspace_image_cache::WorkspaceImagePromotionContext;
+use crate::workspace_promotion::promote_workspace_image_from_parked_sandbox;
 
 /// Default idle timeout for kept-alive VMs (30 minutes).
 ///
@@ -197,6 +199,7 @@ pub(crate) struct IdleParkRequestParts {
     pub(crate) budget_lease: BudgetLease,
     pub(crate) source_ip: String,
     pub(crate) storage_fingerprints: StorageFingerprints,
+    pub(crate) workspace_promotion: Option<WorkspaceImagePromotionContext>,
 }
 
 /// Active-owned sandbox after `Sandbox::park()` succeeds, before idle-pool
@@ -220,6 +223,7 @@ pub struct ParkedIdleCandidate {
     /// Version fingerprints of storages downloaded in the previous turn.
     /// Used to skip re-downloading unchanged entries on reuse.
     storage_fingerprints: StorageFingerprints,
+    workspace_promotion: Option<WorkspaceImagePromotionContext>,
     /// Local terminal timestamp for this parked session.
     ///
     /// `None` is reserved for synthetic test entries and means the VM is not
@@ -277,6 +281,7 @@ impl IdleParkRequest {
             budget_lease,
             source_ip,
             storage_fingerprints,
+            workspace_promotion,
         } = self.parts;
 
         match AssertUnwindSafe(sandbox.park()).catch_unwind().await {
@@ -290,6 +295,7 @@ impl IdleParkRequest {
                 budget_lease,
                 source_ip,
                 storage_fingerprints,
+                workspace_promotion,
                 last_completed_at: None,
             }),
             Ok(Err(e)) => Err(IdleParkFailure {
@@ -342,6 +348,7 @@ impl ParkedIdleCandidate {
             budget_lease: parts.budget_lease,
             source_ip: parts.source_ip,
             storage_fingerprints: parts.storage_fingerprints,
+            workspace_promotion: None,
             last_completed_at: None,
         }
     }
@@ -371,6 +378,7 @@ impl ParkedIdleCandidate {
             budget_lease,
             source_ip,
             storage_fingerprints,
+            workspace_promotion,
             last_completed_at,
         } = self;
 
@@ -386,22 +394,27 @@ impl ParkedIdleCandidate {
             parked_at,
             idle_timeout,
             storage_fingerprints,
+            workspace_promotion,
             last_completed_at,
         }
     }
 
-    pub(crate) fn into_active_parts(self) -> IdleParkActiveParts {
+    pub(crate) fn into_active_destroy_parts(self) -> (IdleDestroyPayload, BudgetLease) {
         let Self {
             sandbox,
             factory,
             budget_lease,
+            workspace_promotion,
             ..
         } = self;
-        IdleParkActiveParts {
-            sandbox,
-            factory,
+        (
+            IdleDestroyPayload {
+                sandbox,
+                factory,
+                workspace_promotion,
+            },
             budget_lease,
-        }
+        )
     }
 
     fn into_rejected(self) -> RejectedParkedIdleCandidate {
@@ -409,11 +422,16 @@ impl ParkedIdleCandidate {
             sandbox,
             factory,
             budget_lease,
+            workspace_promotion,
             ..
         } = self;
 
         RejectedParkedIdleCandidate {
-            payload: IdleDestroyPayload { sandbox, factory },
+            payload: IdleDestroyPayload {
+                sandbox,
+                factory,
+                workspace_promotion,
+            },
             budget_lease,
         }
     }
@@ -437,6 +455,7 @@ pub struct IdleEntry {
     /// Version fingerprints of storages downloaded in the previous turn.
     /// Used to skip re-downloading unchanged entries on reuse.
     storage_fingerprints: StorageFingerprints,
+    workspace_promotion: Option<WorkspaceImagePromotionContext>,
     last_completed_at: Option<String>,
 }
 
@@ -504,12 +523,34 @@ impl ReusableIdleSandbox {
 pub(crate) struct IdleDestroyPayload {
     sandbox: Box<dyn Sandbox>,
     factory: Arc<Box<dyn SandboxFactory>>,
+    workspace_promotion: Option<WorkspaceImagePromotionContext>,
+}
+
+pub(crate) struct IdleDestroyResult {
+    pub(crate) outcome: DestroyOutcome,
+    pub(crate) workspace_cache_promoted: bool,
 }
 
 impl IdleDestroyPayload {
     /// Stop the sandbox and destroy it via its factory.
+    #[cfg(test)]
     pub(crate) async fn stop_and_destroy(self) -> DestroyOutcome {
+        self.promote_then_stop_and_destroy("idle_destroy")
+            .await
+            .outcome
+    }
+
+    pub(crate) async fn promote_then_stop_and_destroy(
+        self,
+        context: &'static str,
+    ) -> IdleDestroyResult {
         let mut sandbox = self.sandbox;
+        let workspace_cache_promoted = promote_workspace_image_from_parked_sandbox(
+            sandbox.as_mut(),
+            self.workspace_promotion.as_ref(),
+            context,
+        )
+        .await;
         let mut uncertain = false;
         match AssertUnwindSafe(sandbox.stop()).catch_unwind().await {
             Ok(Ok(())) => {}
@@ -528,9 +569,15 @@ impl IdleDestroyPayload {
             uncertain = true;
         }
         if uncertain {
-            DestroyOutcome::Uncertain
+            IdleDestroyResult {
+                outcome: DestroyOutcome::Uncertain,
+                workspace_cache_promoted,
+            }
         } else {
-            DestroyOutcome::Completed
+            IdleDestroyResult {
+                outcome: DestroyOutcome::Completed,
+                workspace_cache_promoted,
+            }
         }
     }
 }
@@ -546,14 +593,19 @@ pub struct IdleDestroyJob {
 }
 
 impl IdleDestroyJob {
+    #[cfg(test)]
     pub async fn run(self) {
+        self.run_with_context("idle_destroy").await;
+    }
+
+    pub async fn run_with_context(self, context: &'static str) {
         let Self {
             payload,
             budget_lease,
             session_id: _,
             profile_name: _,
         } = self;
-        let _ = payload.stop_and_destroy().await;
+        let _ = payload.promote_then_stop_and_destroy(context).await;
         drop(budget_lease);
     }
 
@@ -600,7 +652,7 @@ pub enum IdleUnparkResult {
         budget_lease: BudgetLease,
     },
     Failed {
-        destroy_job: IdleDestroyJob,
+        destroy_job: Box<IdleDestroyJob>,
         error: String,
     },
 }
@@ -637,11 +689,11 @@ impl IdleEntry {
                 }
             }
             Ok(Err(e)) => IdleUnparkResult::Failed {
-                destroy_job: self.into_destroy_job(),
+                destroy_job: Box::new(self.into_destroy_job_without_workspace_promotion()),
                 error: e.to_string(),
             },
             Err(_) => IdleUnparkResult::Failed {
-                destroy_job: self.into_destroy_job(),
+                destroy_job: Box::new(self.into_destroy_job_without_workspace_promotion()),
                 error: "sandbox unpark panicked".into(),
             },
         }
@@ -669,17 +721,35 @@ impl IdleEntry {
     }
 
     pub fn into_destroy_job(self) -> IdleDestroyJob {
+        self.into_destroy_job_with_workspace_promotion(true)
+    }
+
+    fn into_destroy_job_without_workspace_promotion(self) -> IdleDestroyJob {
+        self.into_destroy_job_with_workspace_promotion(false)
+    }
+
+    fn into_destroy_job_with_workspace_promotion(
+        self,
+        keep_workspace_promotion: bool,
+    ) -> IdleDestroyJob {
         let Self {
             sandbox,
             factory,
             session_id,
             profile_name,
             budget_lease,
+            workspace_promotion,
             ..
         } = self;
 
         IdleDestroyJob {
-            payload: IdleDestroyPayload { sandbox, factory },
+            payload: IdleDestroyPayload {
+                sandbox,
+                factory,
+                workspace_promotion: keep_workspace_promotion
+                    .then_some(workspace_promotion)
+                    .flatten(),
+            },
             budget_lease,
             session_id,
             profile_name,
@@ -992,7 +1062,11 @@ mod tests {
             .await
             .expect("create sandbox");
 
-        IdleDestroyPayload { sandbox, factory }
+        IdleDestroyPayload {
+            sandbox,
+            factory,
+            workspace_promotion: None,
+        }
     }
 
     async fn make_idle_park_request(
@@ -1025,6 +1099,7 @@ mod tests {
             budget_lease,
             source_ip: "10.0.0.1".into(),
             storage_fingerprints: StorageFingerprints::default(),
+            workspace_promotion: None,
         })
     }
 
@@ -1117,6 +1192,7 @@ mod tests {
             budget_lease,
             source_ip: source_ip.into(),
             storage_fingerprints,
+            workspace_promotion: None,
         });
 
         let candidate = match request.park_for_idle().await {

--- a/crates/runner/src/idle_pool.rs
+++ b/crates/runner/src/idle_pool.rs
@@ -498,12 +498,14 @@ pub struct ReusableIdleSandbox {
     sandbox_id: SandboxId,
     source_ip: String,
     storage_fingerprints: StorageFingerprints,
+    workspace_promotion: Option<WorkspaceImagePromotionContext>,
 }
 
 pub struct ReusableIdleSandboxParts {
     pub sandbox: Box<dyn Sandbox>,
     pub source_ip: String,
     pub storage_fingerprints: StorageFingerprints,
+    pub workspace_promotion: Option<WorkspaceImagePromotionContext>,
 }
 
 impl ReusableIdleSandbox {
@@ -517,12 +519,14 @@ impl ReusableIdleSandbox {
             sandbox_id: _,
             source_ip,
             storage_fingerprints,
+            workspace_promotion,
         } = self;
 
         ReusableIdleSandboxParts {
             sandbox,
             source_ip,
             storage_fingerprints,
+            workspace_promotion,
         }
     }
 }
@@ -657,7 +661,7 @@ impl RejectedParkedIdleCandidate {
 
 pub enum IdleUnparkResult {
     Reused {
-        sandbox: ReusableIdleSandbox,
+        sandbox: Box<ReusableIdleSandbox>,
         budget_lease: BudgetLease,
     },
     Failed {
@@ -693,7 +697,7 @@ impl IdleEntry {
             Ok(Ok(())) => {
                 let (sandbox, budget_lease) = self.into_reuse_parts();
                 IdleUnparkResult::Reused {
-                    sandbox,
+                    sandbox: Box::new(sandbox),
                     budget_lease,
                 }
             }
@@ -714,6 +718,7 @@ impl IdleEntry {
             sandbox_id,
             source_ip,
             storage_fingerprints,
+            workspace_promotion,
             budget_lease,
             ..
         } = self;
@@ -724,6 +729,7 @@ impl IdleEntry {
                 sandbox_id,
                 source_ip,
                 storage_fingerprints,
+                workspace_promotion,
             },
             budget_lease,
         )
@@ -1226,6 +1232,7 @@ mod tests {
         else {
             panic!("unpark should succeed");
         };
+        let sandbox = *sandbox;
         assert_eq!(sandbox.sandbox_id(), sandbox_id);
         let reused_parts = sandbox.into_parts();
         assert_eq!(reused_parts.source_ip, source_ip);

--- a/crates/runner/src/idle_pool.rs
+++ b/crates/runner/src/idle_pool.rs
@@ -311,7 +311,9 @@ impl IdleParkRequest {
                 sandbox,
                 factory,
                 budget_lease,
-                workspace_promotion,
+                // A panic leaves the park transition state uncertain; destroy
+                // the sandbox, but do not publish a workspace cache image.
+                workspace_promotion: None,
                 error: "sandbox park panicked".into(),
             }),
         }

--- a/crates/runner/src/idle_pool.rs
+++ b/crates/runner/src/idle_pool.rs
@@ -595,18 +595,19 @@ pub struct IdleDestroyJob {
 impl IdleDestroyJob {
     #[cfg(test)]
     pub async fn run(self) {
-        self.run_with_context("idle_destroy").await;
+        let _ = self.run_with_context("idle_destroy").await;
     }
 
-    pub async fn run_with_context(self, context: &'static str) {
+    pub async fn run_with_context(self, context: &'static str) -> bool {
         let Self {
             payload,
             budget_lease,
             session_id: _,
             profile_name: _,
         } = self;
-        let _ = payload.promote_then_stop_and_destroy(context).await;
+        let result = payload.promote_then_stop_and_destroy(context).await;
         drop(budget_lease);
+        result.workspace_cache_promoted
     }
 
     pub fn session_id(&self) -> &str {

--- a/crates/runner/src/idle_pool.rs
+++ b/crates/runner/src/idle_pool.rs
@@ -249,6 +249,7 @@ pub(crate) struct IdleParkFailure {
     sandbox: Box<dyn Sandbox>,
     factory: Arc<Box<dyn SandboxFactory>>,
     budget_lease: BudgetLease,
+    workspace_promotion: Option<WorkspaceImagePromotionContext>,
     error: String,
 }
 
@@ -257,6 +258,7 @@ pub(crate) struct IdleParkActiveParts {
     pub(crate) sandbox: Box<dyn Sandbox>,
     pub(crate) factory: Arc<Box<dyn SandboxFactory>>,
     pub(crate) budget_lease: BudgetLease,
+    pub(crate) workspace_promotion: Option<WorkspaceImagePromotionContext>,
 }
 
 #[must_use = "idle park failure parts must be logged and cleaned up"]
@@ -302,12 +304,14 @@ impl IdleParkRequest {
                 sandbox,
                 factory,
                 budget_lease,
+                workspace_promotion,
                 error: e.to_string(),
             }),
             Err(_) => Err(IdleParkFailure {
                 sandbox,
                 factory,
                 budget_lease,
+                workspace_promotion,
                 error: "sandbox park panicked".into(),
             }),
         }
@@ -320,6 +324,7 @@ impl IdleParkFailure {
             sandbox,
             factory,
             budget_lease,
+            workspace_promotion,
             error,
         } = self;
         IdleParkFailureParts {
@@ -327,6 +332,7 @@ impl IdleParkFailure {
                 sandbox,
                 factory,
                 budget_lease,
+                workspace_promotion,
             },
             error,
         }

--- a/crates/runner/src/main.rs
+++ b/crates/runner/src/main.rs
@@ -38,6 +38,7 @@ mod telemetry;
 mod types;
 mod workspace_image_cache;
 mod workspace_mount;
+mod workspace_promotion;
 
 use std::path::Path;
 use std::process::ExitCode;

--- a/crates/runner/src/workspace_image_cache.rs
+++ b/crates/runner/src/workspace_image_cache.rs
@@ -1405,6 +1405,18 @@ impl SessionWorkspaceCache {
                 tmp.display()
             )));
         }
+        let logical_image_size_bytes = tmp_metadata.len();
+        if logical_image_size_bytes != input.image_size_bytes {
+            let _ = remove_workspace_cache_path_if_exists(&tmp).await;
+            info!(
+                run_id = %input.run_id,
+                cache_key = input.cache_key,
+                actual_image_size_bytes = logical_image_size_bytes,
+                expected_image_size_bytes = input.image_size_bytes,
+                "workspace image cache promotion skipped because copied image size does not match cache key"
+            );
+            return Ok(false);
+        }
         let tmp_allocated = allocated_bytes(&tmp_metadata);
         if tmp_allocated > budget.max_entry_bytes {
             let _ = remove_workspace_cache_path_if_exists(&tmp).await;
@@ -1444,7 +1456,6 @@ impl SessionWorkspaceCache {
                 current.display()
             )));
         }
-        let logical_image_size_bytes = current_metadata.len();
         let allocated = allocated_bytes(&current_metadata);
         let metadata = WorkspaceCacheMetadata {
             format_version: CACHE_FORMAT_VERSION,
@@ -4506,6 +4517,53 @@ mod tests {
 
         assert!(fs::metadata(&current).await.unwrap().is_file());
         assert_eq!(fs::read(current).await.unwrap(), b"image");
+    }
+
+    #[tokio::test]
+    async fn promote_skips_copied_image_with_unexpected_logical_size() {
+        let dir = tempfile::tempdir().unwrap();
+        let paths = RunnerPaths::new(dir.path().join("runner"));
+        tokio::fs::create_dir_all(paths.base_dir()).await.unwrap();
+        let cache = SessionWorkspaceCache::new(paths.clone());
+        let run_id = RunId::new_v4();
+        let sandbox_id = sandbox::SandboxId::new_v4();
+        let lease = cache
+            .prepare(WorkspaceImagePrepareRequest {
+                run_id,
+                sandbox_id,
+                profile_name: TEST_PROFILE_NAME,
+                session_id: Some("sess-size-mismatch"),
+                working_dir: "/workspace",
+                image_size_bytes: 16 * 1024 * 1024,
+                workspace_drive_required: false,
+            })
+            .await;
+        tokio::fs::create_dir_all(paths.workspace_dir(&sandbox_id))
+            .await
+            .unwrap();
+        tokio::fs::write(paths.active_workspace_image(&sandbox_id), b"truncated")
+            .await
+            .unwrap();
+        let cache_key = session_workspace_cache_key("sess-size-mismatch", "/workspace");
+
+        assert!(
+            !lease
+                .promote(
+                    run_id,
+                    None,
+                    WorkspaceCacheTerminalStatus::Success,
+                    "2026-05-01T00:00:00.000Z".into(),
+                    &StorageFingerprints::default(),
+                )
+                .await
+                .unwrap()
+        );
+        assert!(
+            !paths
+                .session_workspace_cache_current_image(&cache_key)
+                .exists()
+        );
+        assert!(cache.held_session_states().await.is_empty());
     }
 
     #[tokio::test]

--- a/crates/runner/src/workspace_image_cache.rs
+++ b/crates/runner/src/workspace_image_cache.rs
@@ -123,10 +123,10 @@ pub(crate) struct WorkspaceImageLease {
     entry_lock: Option<Flock<std::fs::File>>,
 }
 
-#[derive(Clone)]
 pub(crate) struct WorkspaceImagePromotionContext {
     cache: SessionWorkspaceCache,
     cache_key: String,
+    entry_lock: Option<Flock<std::fs::File>>,
     run_id: RunId,
     sandbox_id: sandbox::SandboxId,
     profile_name: String,
@@ -1611,7 +1611,7 @@ impl WorkspaceImageLease {
     }
 
     pub(crate) fn into_promotion_context(
-        self,
+        mut self,
         request: WorkspaceImagePromotionRequest<'_>,
     ) -> Option<WorkspaceImagePromotionContext> {
         if !request.promotable {
@@ -1652,6 +1652,7 @@ impl WorkspaceImageLease {
         Some(WorkspaceImagePromotionContext {
             cache: self.cache.clone(),
             cache_key,
+            entry_lock: self.entry_lock.take(),
             run_id: request.run_id,
             sandbox_id: request.sandbox_id,
             profile_name: self.profile_name.clone(),
@@ -1693,8 +1694,11 @@ impl WorkspaceImagePromotionContext {
             }
         };
 
-        let _entry_lock_guard =
-            crate::lock::acquire(self.cache.entry_lock_path(&self.cache_key)).await?;
+        let _late_entry_lock_guard = if self.entry_lock.is_some() {
+            None
+        } else {
+            Some(crate::lock::acquire(self.cache.entry_lock_path(&self.cache_key)).await?)
+        };
 
         self.cache
             .promote_locked(WorkspaceImagePromotionInput {
@@ -1710,6 +1714,46 @@ impl WorkspaceImagePromotionContext {
                 storage_fingerprints: promotion_storage_fingerprints,
             })
             .await
+    }
+
+    pub(crate) fn into_active_lease(
+        self,
+        request: WorkspaceImageActiveLeaseRequest<'_>,
+    ) -> WorkspaceImageLease {
+        let Self {
+            cache,
+            cache_key,
+            entry_lock,
+            run_id: _,
+            sandbox_id,
+            profile_name,
+            session_id,
+            working_dir,
+            active_image,
+            image_size_bytes,
+            terminal_status: _,
+            completed_at: _,
+            storage_fingerprints: _,
+        } = self;
+        debug_assert_eq!(request.sandbox_id, sandbox_id);
+        debug_assert_eq!(request.profile_name, profile_name.as_str());
+        debug_assert_eq!(request.session_id, Some(session_id.as_str()));
+        debug_assert_eq!(request.working_dir, working_dir.as_str());
+        debug_assert_eq!(request.image_size_bytes, image_size_bytes);
+        WorkspaceImageLease {
+            cache,
+            cache_key: Some(cache_key),
+            profile_name,
+            session_id: Some(session_id),
+            working_dir,
+            active_image,
+            source_image: None,
+            image_size_bytes,
+            workspace_drive_enabled: request.workspace_drive_available,
+            result: WorkspaceCacheCheckoutResult::Miss,
+            previous_storage: None,
+            entry_lock,
+        }
     }
 }
 
@@ -3454,6 +3498,99 @@ mod tests {
         assert!(cache.held_session_states().await.is_empty());
         drop(lease);
         assert_eq!(cache.held_session_states().await.len(), 1);
+    }
+
+    #[tokio::test]
+    async fn promotion_context_keeps_entry_locked_until_reused_active_lease_drops() {
+        let dir = tempfile::tempdir().unwrap();
+        let paths = RunnerPaths::new(dir.path().join("runner"));
+        tokio::fs::create_dir_all(paths.base_dir()).await.unwrap();
+        let cache = SessionWorkspaceCache::new(paths.clone());
+        let run_id = RunId::new_v4();
+        let sandbox_id = sandbox::SandboxId::new_v4();
+        let session_id = "sess-locked-context";
+        let image_size_bytes = 16 * 1024 * 1024;
+
+        let lease = cache
+            .prepare(WorkspaceImagePrepareRequest {
+                run_id,
+                sandbox_id,
+                profile_name: TEST_PROFILE_NAME,
+                session_id: Some(session_id),
+                working_dir: "/workspace",
+                image_size_bytes,
+                workspace_drive_required: false,
+            })
+            .await;
+        assert_eq!(lease.result(), WorkspaceCacheCheckoutResult::Miss);
+
+        let promotion = lease
+            .into_promotion_context(WorkspaceImagePromotionRequest {
+                run_id,
+                sandbox_id,
+                session_id_override: Some(session_id),
+                terminal_status: WorkspaceCacheTerminalStatus::Success,
+                completed_at: local_timestamp(),
+                storage_fingerprints: StorageFingerprints::default(),
+                promotable: true,
+            })
+            .unwrap();
+
+        let blocked_by_context = cache
+            .prepare(WorkspaceImagePrepareRequest {
+                run_id: RunId::new_v4(),
+                sandbox_id: sandbox::SandboxId::new_v4(),
+                profile_name: TEST_PROFILE_NAME,
+                session_id: Some(session_id),
+                working_dir: "/workspace",
+                image_size_bytes,
+                workspace_drive_required: false,
+            })
+            .await;
+        assert_eq!(
+            blocked_by_context.result(),
+            WorkspaceCacheCheckoutResult::LockBusy
+        );
+
+        let active_lease = promotion.into_active_lease(WorkspaceImageActiveLeaseRequest {
+            run_id: RunId::new_v4(),
+            sandbox_id,
+            profile_name: TEST_PROFILE_NAME,
+            session_id: Some(session_id),
+            working_dir: "/workspace",
+            image_size_bytes,
+            workspace_drive_available: true,
+        });
+
+        let blocked_by_active_lease = cache
+            .prepare(WorkspaceImagePrepareRequest {
+                run_id: RunId::new_v4(),
+                sandbox_id: sandbox::SandboxId::new_v4(),
+                profile_name: TEST_PROFILE_NAME,
+                session_id: Some(session_id),
+                working_dir: "/workspace",
+                image_size_bytes,
+                workspace_drive_required: false,
+            })
+            .await;
+        assert_eq!(
+            blocked_by_active_lease.result(),
+            WorkspaceCacheCheckoutResult::LockBusy
+        );
+
+        drop(active_lease);
+        let after_drop = cache
+            .prepare(WorkspaceImagePrepareRequest {
+                run_id: RunId::new_v4(),
+                sandbox_id: sandbox::SandboxId::new_v4(),
+                profile_name: TEST_PROFILE_NAME,
+                session_id: Some(session_id),
+                working_dir: "/workspace",
+                image_size_bytes,
+                workspace_drive_required: false,
+            })
+            .await;
+        assert_eq!(after_drop.result(), WorkspaceCacheCheckoutResult::Miss);
     }
 
     #[tokio::test]

--- a/crates/runner/src/workspace_image_cache.rs
+++ b/crates/runner/src/workspace_image_cache.rs
@@ -1082,9 +1082,6 @@ impl SessionWorkspaceCache {
                 }
             };
             while let Some(file) = files.next_entry().await? {
-                if !entry_file_type_is_file(&file).await? {
-                    continue;
-                }
                 let file_name = file.file_name();
                 let Some(file_name) = file_name.to_str() else {
                     continue;
@@ -1093,32 +1090,33 @@ impl SessionWorkspaceCache {
                     continue;
                 }
                 let path = file.path();
-                let allocated = fs::metadata(&path)
-                    .await
-                    .map(|metadata| allocated_bytes(&metadata))
-                    .unwrap_or(0);
+                let allocated = workspace_cache_path_allocated_bytes(&path).await;
                 if dry_run {
                     info!(
                         cache_key,
                         path = %path.display(),
                         allocated_bytes = allocated,
-                        "[dry-run] would delete temporary workspace image cache file"
+                        "[dry-run] would delete temporary workspace image cache path"
                     );
-                } else if let Err(e) = fs::remove_file(&path).await {
-                    warn!(
-                        cache_key,
-                        path = %path.display(),
-                        error = %e,
-                        "failed to delete temporary workspace image cache file"
-                    );
-                    continue;
                 } else {
-                    info!(
-                        cache_key,
-                        path = %path.display(),
-                        allocated_bytes = allocated,
-                        "deleted temporary workspace image cache file"
-                    );
+                    match remove_workspace_cache_path_if_exists(&path).await {
+                        Ok(true) => info!(
+                            cache_key,
+                            path = %path.display(),
+                            allocated_bytes = allocated,
+                            "deleted temporary workspace image cache path"
+                        ),
+                        Ok(false) => continue,
+                        Err(e) => {
+                            warn!(
+                                cache_key,
+                                path = %path.display(),
+                                error = %e,
+                                "failed to delete temporary workspace image cache path"
+                            );
+                            continue;
+                        }
+                    }
                 }
                 freed = freed.saturating_add(allocated);
             }
@@ -1253,11 +1251,11 @@ impl SessionWorkspaceCache {
         let bytes = serde_json::to_vec_pretty(&metadata)
             .map_err(|e| RunnerError::Internal(format!("serialize workspace metadata: {e}")))?;
         if let Err(e) = fs::write(&tmp, bytes).await {
-            let _ = fs::remove_file(&tmp).await;
+            let _ = remove_workspace_cache_path_if_exists(&tmp).await;
             return Err(e.into());
         }
         if let Err(e) = fs::rename(&tmp, &metadata_path).await {
-            let _ = fs::remove_file(&tmp).await;
+            let _ = remove_workspace_cache_path_if_exists(&tmp).await;
             return Err(e.into());
         }
         Ok(())
@@ -1385,17 +1383,28 @@ impl SessionWorkspaceCache {
         let cache_dir = self.session_workspace_cache_entry_dir(input.cache_key);
         fs::create_dir_all(&cache_dir).await?;
         let tmp = self.session_workspace_cache_tmp_image(input.cache_key, input.run_id);
-        if fs::try_exists(&tmp).await.unwrap_or(false) {
-            let _ = fs::remove_file(&tmp).await;
-        }
+        let _ = remove_workspace_cache_path_if_exists(&tmp).await;
         if let Err(e) = sparse_copy(input.active_image, &tmp).await {
-            let _ = fs::remove_file(&tmp).await;
+            let _ = remove_workspace_cache_path_if_exists(&tmp).await;
             return Err(e);
         }
-        let tmp_metadata = fs::metadata(&tmp).await?;
+        let tmp_metadata = match fs::metadata(&tmp).await {
+            Ok(metadata) => metadata,
+            Err(e) => {
+                let _ = remove_workspace_cache_path_if_exists(&tmp).await;
+                return Err(e.into());
+            }
+        };
+        if !tmp_metadata.is_file() {
+            let _ = remove_workspace_cache_path_if_exists(&tmp).await;
+            return Err(RunnerError::Internal(format!(
+                "workspace image cache temporary image is not a file: {}",
+                tmp.display()
+            )));
+        }
         let tmp_allocated = allocated_bytes(&tmp_metadata);
         if tmp_allocated > budget.max_entry_bytes {
-            let _ = fs::remove_file(&tmp).await;
+            let _ = remove_workspace_cache_path_if_exists(&tmp).await;
             info!(
                 run_id = %input.run_id,
                 cache_key = input.cache_key,
@@ -1406,11 +1415,32 @@ impl SessionWorkspaceCache {
             return Ok(false);
         }
         let current = self.session_workspace_cache_current_image(input.cache_key);
+        match fs::symlink_metadata(&current).await {
+            Ok(metadata) if metadata.is_dir() => {
+                remove_workspace_cache_path_if_exists(&current).await?;
+            }
+            Ok(_) => {}
+            Err(e) if e.kind() == std::io::ErrorKind::NotFound => {}
+            Err(e) => return Err(e.into()),
+        }
         if let Err(e) = fs::rename(&tmp, &current).await {
-            let _ = fs::remove_file(&tmp).await;
+            let _ = remove_workspace_cache_path_if_exists(&tmp).await;
             return Err(e.into());
         }
-        let current_metadata = fs::metadata(&current).await?;
+        let current_metadata = match fs::metadata(&current).await {
+            Ok(metadata) => metadata,
+            Err(e) => {
+                let _ = remove_workspace_cache_path_if_exists(&current).await;
+                return Err(e.into());
+            }
+        };
+        if !current_metadata.is_file() {
+            let _ = remove_workspace_cache_path_if_exists(&current).await;
+            return Err(RunnerError::Internal(format!(
+                "workspace image cache current image is not a file: {}",
+                current.display()
+            )));
+        }
         let logical_image_size_bytes = current_metadata.len();
         let allocated = allocated_bytes(&current_metadata);
         let metadata = WorkspaceCacheMetadata {
@@ -1438,7 +1468,7 @@ impl SessionWorkspaceCache {
             .write_metadata(input.cache_key, input.run_id, metadata)
             .await
         {
-            let _ = fs::remove_file(&current).await;
+            let _ = remove_workspace_cache_path_if_exists(&current).await;
             return Err(e);
         }
         info!(
@@ -1976,6 +2006,11 @@ fn validate_current_image_identity(
     metadata: &WorkspaceCacheMetadata,
     current: &std::fs::Metadata,
 ) -> RunnerResult<()> {
+    if !current.is_file() {
+        return Err(RunnerError::Internal(
+            "workspace metadata current image is not a file".into(),
+        ));
+    }
     let current_image = WorkspaceImageFileIdentity::from_metadata(current);
     if metadata.current_image != current_image {
         return Err(RunnerError::Internal(
@@ -1998,6 +2033,31 @@ fn is_workspace_tmp_file_name(name: &str) -> bool {
 
 fn allocated_bytes(metadata: &std::fs::Metadata) -> u64 {
     metadata.blocks().saturating_mul(512)
+}
+
+async fn workspace_cache_path_allocated_bytes(path: &Path) -> u64 {
+    let Ok(metadata) = fs::symlink_metadata(path).await else {
+        return 0;
+    };
+    if metadata.is_dir() {
+        flat_directory_allocated_bytes(path).await
+    } else {
+        allocated_bytes(&metadata)
+    }
+}
+
+async fn remove_workspace_cache_path_if_exists(path: &Path) -> std::io::Result<bool> {
+    let metadata = match fs::symlink_metadata(path).await {
+        Ok(metadata) => metadata,
+        Err(e) if e.kind() == std::io::ErrorKind::NotFound => return Ok(false),
+        Err(e) => return Err(e),
+    };
+    if metadata.is_dir() {
+        fs::remove_dir_all(path).await?;
+    } else {
+        fs::remove_file(path).await?;
+    }
+    Ok(true)
 }
 
 fn has_copy_headroom(stats: FsStats, budget: CacheBudget, allocated_bytes: u64) -> bool {
@@ -2102,10 +2162,6 @@ async fn statvfs_bytes(path: &Path) -> RunnerResult<FsStats> {
 
 async fn entry_file_type_is_dir(entry: &fs::DirEntry) -> RunnerResult<bool> {
     entry_file_type_matches(entry, std::fs::FileType::is_dir).await
-}
-
-async fn entry_file_type_is_file(entry: &fs::DirEntry) -> RunnerResult<bool> {
-    entry_file_type_matches(entry, std::fs::FileType::is_file).await
 }
 
 async fn entry_file_type_matches(
@@ -3826,6 +3882,59 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn gc_removes_current_directory_even_when_metadata_matches() {
+        let dir = tempfile::tempdir().unwrap();
+        let paths = RunnerPaths::new(dir.path().join("runner"));
+        tokio::fs::create_dir_all(paths.base_dir()).await.unwrap();
+        let cache = SessionWorkspaceCache::new(paths.clone());
+        let run_id = RunId::new_v4();
+        let session_id = "sess-1";
+        let working_dir = "/workspace";
+        let probe = dir.path().join("current-probe");
+        tokio::fs::create_dir_all(&probe).await.unwrap();
+        let image_size_bytes = fs::metadata(&probe).await.unwrap().len();
+        tokio::fs::remove_dir_all(&probe).await.unwrap();
+        let key =
+            cache.scoped_cache_key(TEST_PROFILE_NAME, session_id, working_dir, image_size_bytes);
+        let current = paths.session_workspace_cache_current_image(&key);
+        tokio::fs::create_dir_all(&current).await.unwrap();
+        let current_metadata = fs::metadata(&current).await.unwrap();
+        cache
+            .write_metadata(
+                &key,
+                run_id,
+                WorkspaceCacheMetadata {
+                    format_version: CACHE_FORMAT_VERSION,
+                    key_version: CACHE_KEY_VERSION,
+                    cache_scope: cache.inner.cache_scope.clone(),
+                    profile_name: TEST_PROFILE_NAME.into(),
+                    session_id: session_id.into(),
+                    working_dir: working_dir.into(),
+                    last_completed_at: "2026-05-01T00:00:00.000Z".into(),
+                    last_used_at: "2026-05-01T00:00:00.000Z".into(),
+                    last_terminal_status: WorkspaceCacheTerminalStatus::Success,
+                    workspace_trust: WorkspaceTrust::Clean,
+                    logical_image_size_bytes: image_size_bytes,
+                    allocated_bytes: allocated_bytes(&current_metadata),
+                    current_image: WorkspaceImageFileIdentity::from_metadata(&current_metadata),
+                    drive_layout: WORKSPACE_DRIVE_LAYOUT.into(),
+                    storage_fingerprints: StorageFingerprints::default(),
+                    state: WorkspaceCacheState::Current,
+                },
+            )
+            .await
+            .unwrap();
+
+        let freed = cache.gc(false).await.unwrap();
+
+        assert!(freed > 0);
+        assert!(
+            !paths.session_workspace_cache_entry_dir(&key).exists(),
+            "current directories must not remain as reusable workspace cache entries"
+        );
+    }
+
+    #[tokio::test]
     async fn gc_keeps_unusable_current_entry_when_entry_lock_is_held() {
         let dir = tempfile::tempdir().unwrap();
         let paths = RunnerPaths::new(dir.path().join("runner"));
@@ -3912,6 +4021,48 @@ mod tests {
         assert!(freed > 0);
         assert!(!tmp.exists());
         assert!(!metadata_tmp.exists());
+    }
+
+    #[tokio::test]
+    async fn gc_removes_orphan_temporary_workspace_cache_directories() {
+        let dir = tempfile::tempdir().unwrap();
+        let paths = RunnerPaths::new(dir.path().join("runner"));
+        tokio::fs::create_dir_all(paths.base_dir()).await.unwrap();
+        let cache = SessionWorkspaceCache::new(paths.clone());
+        let run_id = RunId::new_v4();
+        let cache_key = write_current_cache_entry(
+            &cache,
+            &paths,
+            run_id,
+            "sess-1",
+            "/workspace",
+            "2026-05-01T00:00:00.000Z",
+            "2026-05-01T00:00:00.000Z",
+        )
+        .await;
+        let tmp = paths.session_workspace_cache_tmp_image(&cache_key, run_id);
+        let metadata_tmp = paths
+            .session_workspace_cache_metadata(&cache_key)
+            .with_file_name(format!("metadata.json.tmp.{run_id}"));
+        tokio::fs::create_dir_all(&tmp).await.unwrap();
+        tokio::fs::write(tmp.join("partial-image"), b"partial image")
+            .await
+            .unwrap();
+        tokio::fs::create_dir_all(&metadata_tmp).await.unwrap();
+        tokio::fs::write(metadata_tmp.join("partial-metadata"), b"partial metadata")
+            .await
+            .unwrap();
+
+        let freed = cache.gc(false).await.unwrap();
+
+        assert!(freed > 0);
+        assert!(!tmp.exists());
+        assert!(!metadata_tmp.exists());
+        assert!(
+            paths
+                .session_workspace_cache_current_image(&cache_key)
+                .exists()
+        );
     }
 
     #[tokio::test]
@@ -4019,6 +4170,104 @@ mod tests {
                 .with_file_name(format!("metadata.json.tmp.{run_id}"))
                 .exists()
         );
+    }
+
+    #[tokio::test]
+    async fn promote_removes_stale_temporary_directory_before_copy() {
+        let dir = tempfile::tempdir().unwrap();
+        let paths = RunnerPaths::new(dir.path().join("runner"));
+        tokio::fs::create_dir_all(paths.base_dir()).await.unwrap();
+        let cache = SessionWorkspaceCache::new(paths.clone());
+        let run_id = RunId::new_v4();
+        let sandbox_id = sandbox::SandboxId::new_v4();
+        let lease = cache
+            .prepare(WorkspaceImagePrepareRequest {
+                run_id,
+                sandbox_id,
+                profile_name: TEST_PROFILE_NAME,
+                session_id: None,
+                working_dir: "/workspace",
+                image_size_bytes: 5,
+                workspace_drive_required: false,
+            })
+            .await;
+        tokio::fs::create_dir_all(paths.workspace_dir(&sandbox_id))
+            .await
+            .unwrap();
+        tokio::fs::write(paths.active_workspace_image(&sandbox_id), b"image")
+            .await
+            .unwrap();
+        let cache_key = session_workspace_cache_key("sess-1", "/workspace");
+        let tmp = paths.session_workspace_cache_tmp_image(&cache_key, run_id);
+        tokio::fs::create_dir_all(&tmp).await.unwrap();
+        tokio::fs::write(tmp.join("stale"), b"stale").await.unwrap();
+
+        assert!(
+            lease
+                .promote(
+                    run_id,
+                    Some("sess-1"),
+                    WorkspaceCacheTerminalStatus::Success,
+                    "2026-05-01T00:00:00.000Z".into(),
+                    &StorageFingerprints::default(),
+                )
+                .await
+                .unwrap()
+        );
+
+        let current = paths.session_workspace_cache_current_image(&cache_key);
+        assert!(!tmp.exists());
+        assert!(fs::metadata(&current).await.unwrap().is_file());
+        assert_eq!(fs::read(current).await.unwrap(), b"image");
+    }
+
+    #[tokio::test]
+    async fn promote_replaces_stale_current_directory_before_rename() {
+        let dir = tempfile::tempdir().unwrap();
+        let paths = RunnerPaths::new(dir.path().join("runner"));
+        tokio::fs::create_dir_all(paths.base_dir()).await.unwrap();
+        let cache = SessionWorkspaceCache::new(paths.clone());
+        let run_id = RunId::new_v4();
+        let sandbox_id = sandbox::SandboxId::new_v4();
+        let lease = cache
+            .prepare(WorkspaceImagePrepareRequest {
+                run_id,
+                sandbox_id,
+                profile_name: TEST_PROFILE_NAME,
+                session_id: None,
+                working_dir: "/workspace",
+                image_size_bytes: 5,
+                workspace_drive_required: false,
+            })
+            .await;
+        tokio::fs::create_dir_all(paths.workspace_dir(&sandbox_id))
+            .await
+            .unwrap();
+        tokio::fs::write(paths.active_workspace_image(&sandbox_id), b"image")
+            .await
+            .unwrap();
+        let cache_key = session_workspace_cache_key("sess-1", "/workspace");
+        let current = paths.session_workspace_cache_current_image(&cache_key);
+        tokio::fs::create_dir_all(&current).await.unwrap();
+        tokio::fs::write(current.join("stale"), b"stale")
+            .await
+            .unwrap();
+
+        assert!(
+            lease
+                .promote(
+                    run_id,
+                    Some("sess-1"),
+                    WorkspaceCacheTerminalStatus::Success,
+                    "2026-05-01T00:00:00.000Z".into(),
+                    &StorageFingerprints::default(),
+                )
+                .await
+                .unwrap()
+        );
+
+        assert!(fs::metadata(&current).await.unwrap().is_file());
+        assert_eq!(fs::read(current).await.unwrap(), b"image");
     }
 
     #[tokio::test]

--- a/crates/runner/src/workspace_image_cache.rs
+++ b/crates/runner/src/workspace_image_cache.rs
@@ -2426,6 +2426,64 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn promotion_does_not_overwrite_same_completed_at_cache_entry() {
+        let dir = tempfile::tempdir().unwrap();
+        let paths = RunnerPaths::new(dir.path().join("runner"));
+        tokio::fs::create_dir_all(paths.base_dir()).await.unwrap();
+        let cache = SessionWorkspaceCache::new(paths.clone());
+        let session_id = "sess-same-completed-at";
+        let completed_at = "2026-06-02T00:00:00.000Z";
+        let image_size = b"old image".len() as u64;
+        let key =
+            promote_current_cache_entry(&cache, &paths, session_id, b"old image", completed_at)
+                .await;
+        let competing_run_id = RunId::new_v4();
+        let competing_sandbox_id = sandbox::SandboxId::new_v4();
+        let competing_lease = cache
+            .prepare(WorkspaceImagePrepareRequest {
+                run_id: competing_run_id,
+                sandbox_id: competing_sandbox_id,
+                profile_name: TEST_PROFILE_NAME,
+                session_id: Some(session_id),
+                working_dir: "/workspace",
+                image_size_bytes: image_size,
+                workspace_drive_required: false,
+            })
+            .await;
+        assert!(competing_lease.is_cache_hit());
+        let competing_active_image = paths.active_workspace_image(&competing_sandbox_id);
+        tokio::fs::create_dir_all(competing_active_image.parent().unwrap())
+            .await
+            .unwrap();
+        tokio::fs::write(&competing_active_image, b"new image")
+            .await
+            .unwrap();
+
+        let promoted = competing_lease
+            .promote(
+                competing_run_id,
+                None,
+                WorkspaceCacheTerminalStatus::Success,
+                completed_at.into(),
+                &StorageFingerprints::default(),
+            )
+            .await
+            .unwrap();
+
+        assert!(!promoted);
+        drop(competing_lease);
+        let metadata = cache
+            .read_metadata_file(&paths.session_workspace_cache_metadata(&key))
+            .await
+            .unwrap();
+        assert_eq!(metadata.last_completed_at, completed_at);
+        let current = tokio::fs::read(paths.session_workspace_cache_current_image(&key))
+            .await
+            .unwrap();
+        assert_eq!(current, b"old image");
+    }
+
+    #[tokio::test]
     async fn promotion_overwrites_older_cache_entry() {
         let dir = tempfile::tempdir().unwrap();
         let paths = RunnerPaths::new(dir.path().join("runner"));

--- a/crates/runner/src/workspace_image_cache.rs
+++ b/crates/runner/src/workspace_image_cache.rs
@@ -1773,14 +1773,16 @@ impl WorkspaceImagePromotionContext {
             None => match crate::lock::try_acquire(cache.entry_lock_path(&cache_key)).await {
                 Ok(lock) => Some(lock),
                 Err(e) => {
-                    info!(
+                    warn!(
                         run_id = %run_id,
                         cache_key,
                         reason,
                         error = %e,
-                        "workspace image cache baseline invalidation skipped: late entry lock unavailable"
+                        "workspace image cache baseline invalidation failed: late entry lock unavailable"
                     );
-                    return Ok(false);
+                    return Err(RunnerError::Internal(format!(
+                        "workspace image cache baseline invalidation lock unavailable: {e}"
+                    )));
                 }
             },
         };

--- a/crates/runner/src/workspace_image_cache.rs
+++ b/crates/runner/src/workspace_image_cache.rs
@@ -12,7 +12,9 @@ use nix::fcntl::Flock;
 use serde::{Deserialize, Serialize};
 use tokio::fs;
 use tokio::io::AsyncReadExt;
-use tracing::{debug, info, warn};
+#[cfg(test)]
+use tracing::debug;
+use tracing::{info, warn};
 
 use crate::error::{RunnerError, RunnerResult};
 use crate::idle_pool::StorageFingerprints;
@@ -119,6 +121,45 @@ pub(crate) struct WorkspaceImageLease {
     result: WorkspaceCacheCheckoutResult,
     previous_storage: Option<StorageFingerprints>,
     entry_lock: Option<Flock<std::fs::File>>,
+}
+
+#[derive(Clone)]
+pub(crate) struct WorkspaceImagePromotionContext {
+    cache: SessionWorkspaceCache,
+    cache_key: String,
+    run_id: RunId,
+    sandbox_id: sandbox::SandboxId,
+    profile_name: String,
+    session_id: String,
+    working_dir: String,
+    active_image: PathBuf,
+    image_size_bytes: u64,
+    terminal_status: WorkspaceCacheTerminalStatus,
+    completed_at: String,
+    storage_fingerprints: StorageFingerprints,
+}
+
+pub(crate) struct WorkspaceImagePromotionRequest<'a> {
+    pub(crate) run_id: RunId,
+    pub(crate) sandbox_id: sandbox::SandboxId,
+    pub(crate) session_id_override: Option<&'a str>,
+    pub(crate) terminal_status: WorkspaceCacheTerminalStatus,
+    pub(crate) completed_at: String,
+    pub(crate) storage_fingerprints: StorageFingerprints,
+    pub(crate) promotable: bool,
+}
+
+struct WorkspaceImagePromotionInput<'a> {
+    run_id: RunId,
+    cache_key: &'a str,
+    profile_name: &'a str,
+    session_id: &'a str,
+    working_dir: &'a str,
+    active_image: &'a Path,
+    image_size_bytes: u64,
+    terminal_status: WorkspaceCacheTerminalStatus,
+    completed_at: &'a str,
+    storage_fingerprints: &'a StorageFingerprints,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -1243,6 +1284,179 @@ impl SessionWorkspaceCache {
             Err(e) => Err(e.into()),
         }
     }
+
+    async fn promote_locked(&self, input: WorkspaceImagePromotionInput<'_>) -> RunnerResult<bool> {
+        let metadata_path = self.session_workspace_cache_metadata(input.cache_key);
+        match self
+            .read_valid_metadata(
+                &metadata_path,
+                input.profile_name,
+                input.session_id,
+                input.working_dir,
+                input.image_size_bytes,
+            )
+            .await
+        {
+            Ok(Some(metadata)) if metadata.last_completed_at.as_str() >= input.completed_at => {
+                info!(
+                    run_id = %input.run_id,
+                    cache_key = input.cache_key,
+                    existing_last_completed_at = %metadata.last_completed_at,
+                    promotion_completed_at = %input.completed_at,
+                    "workspace image cache promotion skipped because existing cache is newer"
+                );
+                return Ok(false);
+            }
+            Ok(_) => {}
+            Err(e) => warn!(
+                run_id = %input.run_id,
+                cache_key = input.cache_key,
+                error = %e,
+                "workspace image cache existing metadata invalid during promotion; overwriting"
+            ),
+        }
+
+        let mut stats = self.fs_stats().await?;
+        let mut budget = CacheBudget::from_fs_stats(stats);
+        if stats.available_bytes < budget.min_free_bytes {
+            match self.gc(false).await {
+                Ok(freed) if freed > 0 => {
+                    stats = self.fs_stats().await?;
+                    budget = CacheBudget::from_fs_stats(stats);
+                }
+                Ok(_) => {}
+                Err(e) => warn!(
+                    run_id = %input.run_id,
+                    cache_key = input.cache_key,
+                    error = %e,
+                    "workspace image cache GC failed before promotion"
+                ),
+            }
+        }
+        if stats.available_bytes < budget.min_free_bytes {
+            info!(
+                run_id = %input.run_id,
+                cache_key = input.cache_key,
+                available_bytes = stats.available_bytes,
+                min_free_bytes = budget.min_free_bytes,
+                "workspace image cache promotion skipped due to free-space pressure"
+            );
+            return Ok(false);
+        }
+        let image_metadata = fs::metadata(input.active_image).await?;
+        let active_allocated = allocated_bytes(&image_metadata);
+        if active_allocated > budget.max_entry_bytes {
+            info!(
+                run_id = %input.run_id,
+                cache_key = input.cache_key,
+                allocated_bytes = active_allocated,
+                max_entry_bytes = budget.max_entry_bytes,
+                "workspace image cache promotion skipped because image is too large"
+            );
+            return Ok(false);
+        }
+        if !has_copy_headroom(stats, budget, active_allocated) {
+            match self.gc(false).await {
+                Ok(freed) if freed > 0 => {
+                    stats = self.fs_stats().await?;
+                    budget = CacheBudget::from_fs_stats(stats);
+                }
+                Ok(_) => {}
+                Err(e) => warn!(
+                    run_id = %input.run_id,
+                    cache_key = input.cache_key,
+                    error = %e,
+                    "workspace image cache GC failed before promotion copy"
+                ),
+            }
+        }
+        if !has_copy_headroom(stats, budget, active_allocated) {
+            info!(
+                run_id = %input.run_id,
+                cache_key = input.cache_key,
+                allocated_bytes = active_allocated,
+                available_bytes = stats.available_bytes,
+                min_free_bytes = budget.min_free_bytes,
+                "workspace image cache promotion skipped due to copy free-space pressure"
+            );
+            return Ok(false);
+        }
+
+        let cache_dir = self.session_workspace_cache_entry_dir(input.cache_key);
+        fs::create_dir_all(&cache_dir).await?;
+        let tmp = self.session_workspace_cache_tmp_image(input.cache_key, input.run_id);
+        if fs::try_exists(&tmp).await.unwrap_or(false) {
+            let _ = fs::remove_file(&tmp).await;
+        }
+        if let Err(e) = sparse_copy(input.active_image, &tmp).await {
+            let _ = fs::remove_file(&tmp).await;
+            return Err(e);
+        }
+        let tmp_metadata = fs::metadata(&tmp).await?;
+        let tmp_allocated = allocated_bytes(&tmp_metadata);
+        if tmp_allocated > budget.max_entry_bytes {
+            let _ = fs::remove_file(&tmp).await;
+            info!(
+                run_id = %input.run_id,
+                cache_key = input.cache_key,
+                allocated_bytes = tmp_allocated,
+                max_entry_bytes = budget.max_entry_bytes,
+                "workspace image cache promotion skipped because copied image is too large"
+            );
+            return Ok(false);
+        }
+        let current = self.session_workspace_cache_current_image(input.cache_key);
+        if let Err(e) = fs::rename(&tmp, &current).await {
+            let _ = fs::remove_file(&tmp).await;
+            return Err(e.into());
+        }
+        let current_metadata = fs::metadata(&current).await?;
+        let logical_image_size_bytes = current_metadata.len();
+        let allocated = allocated_bytes(&current_metadata);
+        let metadata = WorkspaceCacheMetadata {
+            format_version: CACHE_FORMAT_VERSION,
+            key_version: CACHE_KEY_VERSION,
+            cache_scope: self.inner.cache_scope.clone(),
+            profile_name: input.profile_name.to_owned(),
+            session_id: input.session_id.to_owned(),
+            working_dir: input.working_dir.to_owned(),
+            last_completed_at: input.completed_at.to_owned(),
+            last_used_at: local_timestamp(),
+            last_terminal_status: input.terminal_status,
+            workspace_trust: WorkspaceTrust::Clean,
+            logical_image_size_bytes,
+            allocated_bytes: allocated,
+            current_image: WorkspaceImageFileIdentity::from_metadata(&current_metadata),
+            drive_layout: WORKSPACE_DRIVE_LAYOUT.to_owned(),
+            storage_fingerprints: filter_storage_fingerprints_for_working_dir(
+                input.storage_fingerprints,
+                input.working_dir,
+            ),
+            state: WorkspaceCacheState::Current,
+        };
+        if let Err(e) = self
+            .write_metadata(input.cache_key, input.run_id, metadata)
+            .await
+        {
+            let _ = fs::remove_file(&current).await;
+            return Err(e);
+        }
+        info!(
+            run_id = %input.run_id,
+            cache_key = input.cache_key,
+            allocated_bytes = allocated,
+            "workspace image cache promoted"
+        );
+        if let Err(e) = self.gc(false).await {
+            warn!(
+                run_id = %input.run_id,
+                cache_key = input.cache_key,
+                error = %e,
+                "workspace image cache GC failed after promotion"
+            );
+        }
+        Ok(true)
+    }
 }
 
 impl WorkspaceImageLease {
@@ -1269,10 +1483,6 @@ impl WorkspaceImageLease {
                 size_mb: workspace_image_size_mb(self.image_size_bytes),
                 seed_image: self.source_image.clone(),
             })
-    }
-
-    pub(crate) fn workspace_drive_available(&self) -> bool {
-        self.workspace_drive_enabled
     }
 
     pub(crate) fn can_attempt_promotion(&self, session_id_override: Option<&str>) -> bool {
@@ -1304,6 +1514,7 @@ impl WorkspaceImageLease {
             .await
     }
 
+    #[cfg(test)]
     pub(crate) async fn promote(
         &self,
         run_id: RunId,
@@ -1383,145 +1594,122 @@ impl WorkspaceImageLease {
             return Ok(false);
         };
 
-        let mut stats = self.cache.fs_stats().await?;
-        let mut budget = CacheBudget::from_fs_stats(stats);
-        if stats.available_bytes < budget.min_free_bytes {
-            match self.cache.gc(false).await {
-                Ok(freed) if freed > 0 => {
-                    stats = self.cache.fs_stats().await?;
-                    budget = CacheBudget::from_fs_stats(stats);
-                }
-                Ok(_) => {}
-                Err(e) => warn!(
-                    run_id = %run_id,
-                    cache_key,
-                    error = %e,
-                    "workspace image cache GC failed before promotion"
-                ),
-            }
-        }
-        if stats.available_bytes < budget.min_free_bytes {
-            info!(
-                run_id = %run_id,
+        self.cache
+            .promote_locked(WorkspaceImagePromotionInput {
+                run_id,
                 cache_key,
-                available_bytes = stats.available_bytes,
-                min_free_bytes = budget.min_free_bytes,
-                "workspace image cache promotion skipped due to free-space pressure"
-            );
-            return Ok(false);
+                profile_name: &self.profile_name,
+                session_id,
+                working_dir: &self.working_dir,
+                active_image: &self.active_image,
+                image_size_bytes: self.image_size_bytes,
+                terminal_status,
+                completed_at: &completed_at,
+                storage_fingerprints,
+            })
+            .await
+    }
+
+    pub(crate) fn into_promotion_context(
+        self,
+        request: WorkspaceImagePromotionRequest<'_>,
+    ) -> Option<WorkspaceImagePromotionContext> {
+        if !request.promotable {
+            return None;
         }
-        let image_metadata = fs::metadata(&self.active_image).await?;
-        let active_allocated = allocated_bytes(&image_metadata);
-        if active_allocated > budget.max_entry_bytes {
-            info!(
-                run_id = %run_id,
-                cache_key,
-                allocated_bytes = active_allocated,
-                max_entry_bytes = budget.max_entry_bytes,
-                "workspace image cache promotion skipped because image is too large"
-            );
-            return Ok(false);
-        }
-        if !has_copy_headroom(stats, budget, active_allocated) {
-            match self.cache.gc(false).await {
-                Ok(freed) if freed > 0 => {
-                    stats = self.cache.fs_stats().await?;
-                    budget = CacheBudget::from_fs_stats(stats);
-                }
-                Ok(_) => {}
-                Err(e) => warn!(
-                    run_id = %run_id,
-                    cache_key,
-                    error = %e,
-                    "workspace image cache GC failed before promotion copy"
-                ),
-            }
-        }
-        if !has_copy_headroom(stats, budget, active_allocated) {
-            info!(
-                run_id = %run_id,
-                cache_key,
-                allocated_bytes = active_allocated,
-                available_bytes = stats.available_bytes,
-                min_free_bytes = budget.min_free_bytes,
-                "workspace image cache promotion skipped due to copy free-space pressure"
-            );
-            return Ok(false);
+        if !self.workspace_drive_enabled || !is_safe_guest_working_dir(&self.working_dir) {
+            return None;
         }
 
-        let cache_dir = self.cache.session_workspace_cache_entry_dir(cache_key);
-        fs::create_dir_all(&cache_dir).await?;
-        let tmp = self
-            .cache
-            .session_workspace_cache_tmp_image(cache_key, run_id);
-        if fs::try_exists(&tmp).await.unwrap_or(false) {
-            let _ = fs::remove_file(&tmp).await;
-        }
-        if let Err(e) = sparse_copy(&self.active_image, &tmp).await {
-            let _ = fs::remove_file(&tmp).await;
-            return Err(e);
-        }
-        let tmp_metadata = fs::metadata(&tmp).await?;
-        let tmp_allocated = allocated_bytes(&tmp_metadata);
-        if tmp_allocated > budget.max_entry_bytes {
-            let _ = fs::remove_file(&tmp).await;
-            info!(
-                run_id = %run_id,
-                cache_key,
-                allocated_bytes = tmp_allocated,
-                max_entry_bytes = budget.max_entry_bytes,
-                "workspace image cache promotion skipped because copied image is too large"
-            );
-            return Ok(false);
-        }
-        let current = self.cache.session_workspace_cache_current_image(cache_key);
-        if let Err(e) = fs::rename(&tmp, &current).await {
-            let _ = fs::remove_file(&tmp).await;
-            return Err(e.into());
-        }
-        let current_metadata = fs::metadata(&current).await?;
-        let logical_image_size_bytes = current_metadata.len();
-        let allocated = allocated_bytes(&current_metadata);
-        let metadata = WorkspaceCacheMetadata {
-            format_version: CACHE_FORMAT_VERSION,
-            key_version: CACHE_KEY_VERSION,
-            cache_scope: self.cache.inner.cache_scope.clone(),
-            profile_name: self.profile_name.clone(),
-            session_id: session_id.to_owned(),
-            working_dir: self.working_dir.clone(),
-            last_completed_at: completed_at,
-            last_used_at: local_timestamp(),
-            last_terminal_status: terminal_status,
-            workspace_trust: WorkspaceTrust::Clean,
-            logical_image_size_bytes,
-            allocated_bytes: allocated,
-            current_image: WorkspaceImageFileIdentity::from_metadata(&current_metadata),
-            drive_layout: WORKSPACE_DRIVE_LAYOUT.to_owned(),
-            storage_fingerprints: filter_storage_fingerprints_for_working_dir(
-                storage_fingerprints,
-                &self.working_dir,
-            ),
-            state: WorkspaceCacheState::Current,
+        let session_id = match self.result {
+            WorkspaceCacheCheckoutResult::Hit | WorkspaceCacheCheckoutResult::Miss => {
+                self.session_id.clone()?
+            }
+            WorkspaceCacheCheckoutResult::NoSession => request.session_id_override?.to_owned(),
+            WorkspaceCacheCheckoutResult::InvalidWorkingDir
+            | WorkspaceCacheCheckoutResult::LockBusy
+            | WorkspaceCacheCheckoutResult::InvalidMetadata
+            | WorkspaceCacheCheckoutResult::DiskPressure => return None,
         };
-        if let Err(e) = self.cache.write_metadata(cache_key, run_id, metadata).await {
-            let _ = fs::remove_file(&current).await;
-            return Err(e);
-        }
-        info!(
-            run_id = %run_id,
+
+        let cache_key = match self.result {
+            WorkspaceCacheCheckoutResult::Hit | WorkspaceCacheCheckoutResult::Miss => {
+                self.entry_lock.as_ref()?;
+                self.cache_key.clone()?
+            }
+            WorkspaceCacheCheckoutResult::NoSession => self.cache.scoped_cache_key(
+                &self.profile_name,
+                &session_id,
+                &self.working_dir,
+                self.image_size_bytes,
+            ),
+            WorkspaceCacheCheckoutResult::InvalidWorkingDir
+            | WorkspaceCacheCheckoutResult::LockBusy
+            | WorkspaceCacheCheckoutResult::InvalidMetadata
+            | WorkspaceCacheCheckoutResult::DiskPressure => return None,
+        };
+
+        Some(WorkspaceImagePromotionContext {
+            cache: self.cache.clone(),
             cache_key,
-            allocated_bytes = allocated,
-            "workspace image cache promoted"
-        );
-        if let Err(e) = self.cache.gc(false).await {
-            warn!(
-                run_id = %run_id,
-                cache_key,
-                error = %e,
-                "workspace image cache GC failed after promotion"
-            );
-        }
-        Ok(true)
+            run_id: request.run_id,
+            sandbox_id: request.sandbox_id,
+            profile_name: self.profile_name.clone(),
+            session_id,
+            working_dir: self.working_dir.clone(),
+            active_image: self.active_image.clone(),
+            image_size_bytes: self.image_size_bytes,
+            terminal_status: request.terminal_status,
+            completed_at: request.completed_at,
+            storage_fingerprints: request.storage_fingerprints,
+        })
+    }
+}
+
+impl WorkspaceImagePromotionContext {
+    pub(crate) fn run_id(&self) -> RunId {
+        self.run_id
+    }
+
+    pub(crate) fn sandbox_id(&self) -> sandbox::SandboxId {
+        self.sandbox_id
+    }
+
+    pub(crate) fn profile_name(&self) -> &str {
+        &self.profile_name
+    }
+
+    pub(crate) fn session_id(&self) -> &str {
+        &self.session_id
+    }
+
+    pub(crate) async fn promote(&self) -> RunnerResult<bool> {
+        let tainted_storage_fingerprints;
+        let promotion_storage_fingerprints = match self.terminal_status {
+            WorkspaceCacheTerminalStatus::Success => &self.storage_fingerprints,
+            WorkspaceCacheTerminalStatus::NonzeroExit | WorkspaceCacheTerminalStatus::Cancelled => {
+                tainted_storage_fingerprints = self.storage_fingerprints.tainted_paths();
+                &tainted_storage_fingerprints
+            }
+        };
+
+        let _entry_lock_guard =
+            crate::lock::acquire(self.cache.entry_lock_path(&self.cache_key)).await?;
+
+        self.cache
+            .promote_locked(WorkspaceImagePromotionInput {
+                run_id: self.run_id,
+                cache_key: &self.cache_key,
+                profile_name: &self.profile_name,
+                session_id: &self.session_id,
+                working_dir: &self.working_dir,
+                active_image: &self.active_image,
+                image_size_bytes: self.image_size_bytes,
+                terminal_status: self.terminal_status,
+                completed_at: &self.completed_at,
+                storage_fingerprints: promotion_storage_fingerprints,
+            })
+            .await
     }
 }
 
@@ -2000,6 +2188,130 @@ mod tests {
             "/workspace",
             image.len() as u64,
         )
+    }
+
+    #[tokio::test]
+    async fn promotion_does_not_overwrite_newer_cache_entry() {
+        let dir = tempfile::tempdir().unwrap();
+        let paths = RunnerPaths::new(dir.path().join("runner"));
+        tokio::fs::create_dir_all(paths.base_dir()).await.unwrap();
+        let cache = SessionWorkspaceCache::new(paths.clone());
+        let session_id = "sess-race";
+        let image_size = b"new image".len() as u64;
+        let key = promote_current_cache_entry(
+            &cache,
+            &paths,
+            session_id,
+            b"new image",
+            "2026-06-02T00:00:00.000Z",
+        )
+        .await;
+        let stale_run_id = RunId::new_v4();
+        let stale_sandbox_id = sandbox::SandboxId::new_v4();
+        let stale_lease = cache
+            .prepare(WorkspaceImagePrepareRequest {
+                run_id: stale_run_id,
+                sandbox_id: stale_sandbox_id,
+                profile_name: TEST_PROFILE_NAME,
+                session_id: Some(session_id),
+                working_dir: "/workspace",
+                image_size_bytes: image_size,
+                workspace_drive_required: false,
+            })
+            .await;
+        assert!(stale_lease.is_cache_hit());
+        let stale_active_image = paths.active_workspace_image(&stale_sandbox_id);
+        tokio::fs::create_dir_all(stale_active_image.parent().unwrap())
+            .await
+            .unwrap();
+        tokio::fs::write(&stale_active_image, b"old image")
+            .await
+            .unwrap();
+
+        let promoted = stale_lease
+            .promote(
+                stale_run_id,
+                None,
+                WorkspaceCacheTerminalStatus::Success,
+                "2026-06-01T00:00:00.000Z".into(),
+                &StorageFingerprints::default(),
+            )
+            .await
+            .unwrap();
+
+        assert!(!promoted);
+        drop(stale_lease);
+        let metadata = cache
+            .read_metadata_file(&paths.session_workspace_cache_metadata(&key))
+            .await
+            .unwrap();
+        assert_eq!(metadata.last_completed_at, "2026-06-02T00:00:00.000Z");
+        let current = tokio::fs::read(paths.session_workspace_cache_current_image(&key))
+            .await
+            .unwrap();
+        assert_eq!(current, b"new image");
+    }
+
+    #[tokio::test]
+    async fn promotion_overwrites_older_cache_entry() {
+        let dir = tempfile::tempdir().unwrap();
+        let paths = RunnerPaths::new(dir.path().join("runner"));
+        tokio::fs::create_dir_all(paths.base_dir()).await.unwrap();
+        let cache = SessionWorkspaceCache::new(paths.clone());
+        let session_id = "sess-newer";
+        let image_size = b"old image".len() as u64;
+        let key = promote_current_cache_entry(
+            &cache,
+            &paths,
+            session_id,
+            b"old image",
+            "2026-06-01T00:00:00.000Z",
+        )
+        .await;
+        let newer_run_id = RunId::new_v4();
+        let newer_sandbox_id = sandbox::SandboxId::new_v4();
+        let newer_lease = cache
+            .prepare(WorkspaceImagePrepareRequest {
+                run_id: newer_run_id,
+                sandbox_id: newer_sandbox_id,
+                profile_name: TEST_PROFILE_NAME,
+                session_id: Some(session_id),
+                working_dir: "/workspace",
+                image_size_bytes: image_size,
+                workspace_drive_required: false,
+            })
+            .await;
+        assert!(newer_lease.is_cache_hit());
+        let newer_active_image = paths.active_workspace_image(&newer_sandbox_id);
+        tokio::fs::create_dir_all(newer_active_image.parent().unwrap())
+            .await
+            .unwrap();
+        tokio::fs::write(&newer_active_image, b"new image")
+            .await
+            .unwrap();
+
+        let promoted = newer_lease
+            .promote(
+                newer_run_id,
+                None,
+                WorkspaceCacheTerminalStatus::Success,
+                "2026-06-02T00:00:00.000Z".into(),
+                &StorageFingerprints::default(),
+            )
+            .await
+            .unwrap();
+
+        assert!(promoted);
+        drop(newer_lease);
+        let metadata = cache
+            .read_metadata_file(&paths.session_workspace_cache_metadata(&key))
+            .await
+            .unwrap();
+        assert_eq!(metadata.last_completed_at, "2026-06-02T00:00:00.000Z");
+        let current = tokio::fs::read(paths.session_workspace_cache_current_image(&key))
+            .await
+            .unwrap();
+        assert_eq!(current, b"new image");
     }
 
     #[test]

--- a/crates/runner/src/workspace_image_cache.rs
+++ b/crates/runner/src/workspace_image_cache.rs
@@ -885,7 +885,7 @@ impl SessionWorkspaceCache {
                 continue;
             };
             let current = self.session_workspace_cache_current_image(&cache_key);
-            let current_metadata = match fs::metadata(&current).await {
+            let current_metadata = match fs::symlink_metadata(&current).await {
                 Ok(metadata) => metadata,
                 Err(e) if e.kind() == std::io::ErrorKind::NotFound => {
                     drop(lock);
@@ -1154,7 +1154,10 @@ impl SessionWorkspaceCache {
     async fn gc_candidate(&self, cache_key: String) -> Option<GcCandidate> {
         let metadata_path = self.session_workspace_cache_metadata(&cache_key);
         let current_path = self.session_workspace_cache_current_image(&cache_key);
-        let file_metadata = fs::metadata(&current_path).await.ok()?;
+        let file_metadata = fs::symlink_metadata(&current_path).await.ok()?;
+        if !file_metadata.is_file() {
+            return None;
+        }
         let last_used_at = match self.read_metadata_file(&metadata_path).await {
             Ok(metadata) => {
                 if !self.can_collect_metadata_scope(&metadata) {
@@ -1199,7 +1202,7 @@ impl SessionWorkspaceCache {
             working_dir,
             image_size_bytes,
         ));
-        let current_metadata = match fs::metadata(&current_path).await {
+        let current_metadata = match fs::symlink_metadata(&current_path).await {
             Ok(metadata) => metadata,
             Err(e) if e.kind() == std::io::ErrorKind::NotFound => return Ok(None),
             Err(e) => return Err(e.into()),
@@ -1222,7 +1225,7 @@ impl SessionWorkspaceCache {
         metadata: &WorkspaceCacheMetadata,
     ) -> bool {
         let current_path = self.session_workspace_cache_current_image(cache_key);
-        let Ok(current_metadata) = fs::metadata(current_path).await else {
+        let Ok(current_metadata) = fs::symlink_metadata(current_path).await else {
             return false;
         };
         validate_current_image_identity(metadata, &current_metadata).is_ok()
@@ -1427,7 +1430,7 @@ impl SessionWorkspaceCache {
             let _ = remove_workspace_cache_path_if_exists(&tmp).await;
             return Err(e.into());
         }
-        let current_metadata = match fs::metadata(&current).await {
+        let current_metadata = match fs::symlink_metadata(&current).await {
             Ok(metadata) => metadata,
             Err(e) => {
                 let _ = remove_workspace_cache_path_if_exists(&current).await;
@@ -2040,7 +2043,7 @@ async fn workspace_cache_path_allocated_bytes(path: &Path) -> u64 {
         return 0;
     };
     if metadata.is_dir() {
-        flat_directory_allocated_bytes(path).await
+        directory_tree_allocated_bytes(path).await
     } else {
         allocated_bytes(&metadata)
     }
@@ -2215,6 +2218,33 @@ async fn flat_directory_allocated_bytes(path: &Path) -> u64 {
             .map(|metadata| allocated_bytes(&metadata))
             .unwrap_or(0);
         total = total.saturating_add(allocated);
+    }
+    total
+}
+
+async fn directory_tree_allocated_bytes(path: &Path) -> u64 {
+    let mut total: u64 = 0;
+    let mut pending = vec![path.to_path_buf()];
+    while let Some(dir) = pending.pop() {
+        let Ok(metadata) = fs::symlink_metadata(&dir).await else {
+            continue;
+        };
+        total = total.saturating_add(allocated_bytes(&metadata));
+        let mut entries = match fs::read_dir(&dir).await {
+            Ok(entries) => entries,
+            Err(_) => continue,
+        };
+        while let Ok(Some(entry)) = entries.next_entry().await {
+            let path = entry.path();
+            let Ok(metadata) = fs::symlink_metadata(&path).await else {
+                continue;
+            };
+            if metadata.is_dir() {
+                pending.push(path);
+            } else {
+                total = total.saturating_add(allocated_bytes(&metadata));
+            }
+        }
     }
     total
 }
@@ -3326,6 +3356,81 @@ mod tests {
         );
     }
 
+    #[tokio::test]
+    async fn metadata_validation_rejects_symlink_current_image() {
+        let dir = tempfile::tempdir().unwrap();
+        let paths = RunnerPaths::new(dir.path().to_path_buf());
+        let cache = SessionWorkspaceCache::new(paths.clone());
+        let run_id = RunId::new_v4();
+        let key = cache.scoped_cache_key(
+            TEST_PROFILE_NAME,
+            "sess-1",
+            "/workspace",
+            b"image".len() as u64,
+        );
+        fs::create_dir_all(paths.session_workspace_cache_entry_dir(&key))
+            .await
+            .unwrap();
+        let target = dir.path().join("target.ext4");
+        fs::write(&target, b"image").await.unwrap();
+        let current = paths.session_workspace_cache_current_image(&key);
+        std::os::unix::fs::symlink(&target, &current).unwrap();
+        let current_target_metadata = fs::metadata(&current).await.unwrap();
+        cache
+            .write_metadata(
+                &key,
+                run_id,
+                WorkspaceCacheMetadata {
+                    format_version: CACHE_FORMAT_VERSION,
+                    key_version: CACHE_KEY_VERSION,
+                    cache_scope: String::new(),
+                    profile_name: TEST_PROFILE_NAME.into(),
+                    session_id: "sess-1".into(),
+                    working_dir: "/workspace".into(),
+                    last_completed_at: local_timestamp(),
+                    last_used_at: local_timestamp(),
+                    last_terminal_status: WorkspaceCacheTerminalStatus::Success,
+                    workspace_trust: WorkspaceTrust::Clean,
+                    logical_image_size_bytes: current_target_metadata.len(),
+                    allocated_bytes: allocated_bytes(&current_target_metadata),
+                    current_image: WorkspaceImageFileIdentity::from_metadata(
+                        &current_target_metadata,
+                    ),
+                    drive_layout: WORKSPACE_DRIVE_LAYOUT.into(),
+                    storage_fingerprints: StorageFingerprints::default(),
+                    state: WorkspaceCacheState::Current,
+                },
+            )
+            .await
+            .unwrap();
+
+        let err = cache
+            .read_valid_metadata(
+                &paths.session_workspace_cache_metadata(&key),
+                TEST_PROFILE_NAME,
+                "sess-1",
+                "/workspace",
+                current_target_metadata.len(),
+            )
+            .await
+            .unwrap_err();
+
+        assert!(err.to_string().contains("current image is not a file"));
+        assert!(
+            cache.held_session_states().await.is_empty(),
+            "symlink current image entries must not be advertised for affinity",
+        );
+
+        let freed = cache.gc(false).await.unwrap();
+
+        assert!(freed > 0);
+        assert!(!paths.session_workspace_cache_entry_dir(&key).exists());
+        assert!(
+            target.exists(),
+            "GC must remove the symlink, not its target"
+        );
+    }
+
     #[test]
     fn copy_headroom_requires_min_free_after_copy() {
         let budget = CacheBudget {
@@ -4058,6 +4163,44 @@ mod tests {
         assert!(freed > 0);
         assert!(!tmp.exists());
         assert!(!metadata_tmp.exists());
+        assert!(
+            paths
+                .session_workspace_cache_current_image(&cache_key)
+                .exists()
+        );
+    }
+
+    #[tokio::test]
+    async fn gc_counts_nested_temporary_workspace_cache_directories() {
+        let dir = tempfile::tempdir().unwrap();
+        let paths = RunnerPaths::new(dir.path().join("runner"));
+        tokio::fs::create_dir_all(paths.base_dir()).await.unwrap();
+        let cache = SessionWorkspaceCache::new(paths.clone());
+        let run_id = RunId::new_v4();
+        let cache_key = write_current_cache_entry(
+            &cache,
+            &paths,
+            run_id,
+            "sess-1",
+            "/workspace",
+            "2026-05-01T00:00:00.000Z",
+            "2026-05-01T00:00:00.000Z",
+        )
+        .await;
+        let tmp = paths.session_workspace_cache_tmp_image(&cache_key, run_id);
+        let nested = tmp.join("nested");
+        tokio::fs::create_dir_all(&nested).await.unwrap();
+        tokio::fs::write(nested.join("partial-image"), vec![1_u8; 4096])
+            .await
+            .unwrap();
+
+        let freed = cache.gc(false).await.unwrap();
+
+        assert!(
+            freed > 0,
+            "GC must report bytes freed from nested temporary directories"
+        );
+        assert!(!tmp.exists());
         assert!(
             paths
                 .session_workspace_cache_current_image(&cache_key)

--- a/crates/runner/src/workspace_image_cache.rs
+++ b/crates/runner/src/workspace_image_cache.rs
@@ -1716,6 +1716,25 @@ impl WorkspaceImagePromotionContext {
             .await
     }
 
+    pub(crate) async fn invalidate_current(self, reason: &str) -> RunnerResult<bool> {
+        let Self {
+            cache,
+            cache_key,
+            entry_lock,
+            run_id,
+            ..
+        } = self;
+        let _late_entry_lock_guard = if entry_lock.is_some() {
+            None
+        } else {
+            Some(crate::lock::acquire(cache.entry_lock_path(&cache_key)).await?)
+        };
+        let current = cache.session_workspace_cache_current_image(&cache_key);
+        cache
+            .invalidate_current_image(run_id, &cache_key, &current, reason)
+            .await
+    }
+
     pub(crate) fn into_active_lease(
         self,
         request: WorkspaceImageActiveLeaseRequest<'_>,

--- a/crates/runner/src/workspace_image_cache.rs
+++ b/crates/runner/src/workspace_image_cache.rs
@@ -1492,7 +1492,7 @@ impl WorkspaceImageLease {
 
         match self.result {
             WorkspaceCacheCheckoutResult::Hit | WorkspaceCacheCheckoutResult::Miss => {
-                self.cache_key.is_some() && self.entry_lock.is_some() && self.session_id.is_some()
+                self.cache_key.is_some() && self.session_id.is_some()
             }
             WorkspaceCacheCheckoutResult::NoSession => {
                 self.session_id.is_none() && session_id_override.is_some()
@@ -1634,7 +1634,6 @@ impl WorkspaceImageLease {
 
         let cache_key = match self.result {
             WorkspaceCacheCheckoutResult::Hit | WorkspaceCacheCheckoutResult::Miss => {
-                self.entry_lock.as_ref()?;
                 self.cache_key.clone()?
             }
             WorkspaceCacheCheckoutResult::NoSession => self.cache.scoped_cache_key(
@@ -1694,10 +1693,22 @@ impl WorkspaceImagePromotionContext {
             }
         };
 
-        let _late_entry_lock_guard = if self.entry_lock.is_some() {
-            None
-        } else {
-            Some(crate::lock::acquire(self.cache.entry_lock_path(&self.cache_key)).await?)
+        let _late_entry_lock_guard = match self.entry_lock.as_ref() {
+            Some(_) => None,
+            None => {
+                match crate::lock::try_acquire(self.cache.entry_lock_path(&self.cache_key)).await {
+                    Ok(lock) => Some(lock),
+                    Err(e) => {
+                        info!(
+                            run_id = %self.run_id,
+                            cache_key = self.cache_key,
+                            error = %e,
+                            "workspace image cache promotion skipped: late entry lock unavailable"
+                        );
+                        return Ok(false);
+                    }
+                }
+            }
         };
 
         self.cache
@@ -1724,10 +1735,21 @@ impl WorkspaceImagePromotionContext {
             run_id,
             ..
         } = self;
-        let _late_entry_lock_guard = if entry_lock.is_some() {
-            None
-        } else {
-            Some(crate::lock::acquire(cache.entry_lock_path(&cache_key)).await?)
+        let _late_entry_lock_guard = match entry_lock.as_ref() {
+            Some(_) => None,
+            None => match crate::lock::try_acquire(cache.entry_lock_path(&cache_key)).await {
+                Ok(lock) => Some(lock),
+                Err(e) => {
+                    info!(
+                        run_id = %run_id,
+                        cache_key,
+                        reason,
+                        error = %e,
+                        "workspace image cache baseline invalidation skipped: late entry lock unavailable"
+                    );
+                    return Ok(false);
+                }
+            },
         };
         let current = cache.session_workspace_cache_current_image(&cache_key);
         cache
@@ -4054,5 +4076,119 @@ mod tests {
         assert_eq!(metadata.session_id, "sess-1");
         assert_eq!(metadata.working_dir, "/workspace");
         assert_eq!(metadata.logical_image_size_bytes, 5);
+    }
+
+    #[tokio::test]
+    async fn late_session_promotion_skips_when_entry_lock_is_busy() {
+        let dir = tempfile::tempdir().unwrap();
+        let paths = RunnerPaths::new(dir.path().join("runner"));
+        tokio::fs::create_dir_all(paths.base_dir()).await.unwrap();
+        let cache = SessionWorkspaceCache::new(paths.clone());
+        let run_id = RunId::new_v4();
+        let sandbox_id = sandbox::SandboxId::new_v4();
+        let session_id = "sess-late-lock-busy";
+        let lease = cache
+            .prepare(WorkspaceImagePrepareRequest {
+                run_id,
+                sandbox_id,
+                profile_name: TEST_PROFILE_NAME,
+                session_id: None,
+                working_dir: "/workspace",
+                image_size_bytes: 5,
+                workspace_drive_required: false,
+            })
+            .await;
+        tokio::fs::create_dir_all(paths.workspace_dir(&sandbox_id))
+            .await
+            .unwrap();
+        tokio::fs::write(paths.active_workspace_image(&sandbox_id), b"image")
+            .await
+            .unwrap();
+        let promotion = lease
+            .into_promotion_context(WorkspaceImagePromotionRequest {
+                run_id,
+                sandbox_id,
+                session_id_override: Some(session_id),
+                terminal_status: WorkspaceCacheTerminalStatus::Success,
+                completed_at: "2026-05-01T00:00:00.000Z".into(),
+                storage_fingerprints: StorageFingerprints::default(),
+                promotable: true,
+            })
+            .unwrap();
+        let cache_key = session_workspace_cache_key(session_id, "/workspace");
+        let _held_lock = crate::lock::acquire(cache.entry_lock_path(&cache_key))
+            .await
+            .unwrap();
+
+        let promoted = tokio::time::timeout(std::time::Duration::from_secs(1), promotion.promote())
+            .await
+            .expect("late-session promotion must not block behind another runner's lock")
+            .unwrap();
+
+        assert!(!promoted);
+        assert!(
+            !paths
+                .session_workspace_cache_current_image(&cache_key)
+                .exists()
+        );
+    }
+
+    #[tokio::test]
+    async fn no_lock_promotion_context_survives_reuse_active_lease() {
+        let dir = tempfile::tempdir().unwrap();
+        let paths = RunnerPaths::new(dir.path().join("runner"));
+        tokio::fs::create_dir_all(paths.base_dir()).await.unwrap();
+        let cache = SessionWorkspaceCache::new(paths);
+        let run_id = RunId::new_v4();
+        let sandbox_id = sandbox::SandboxId::new_v4();
+        let session_id = "sess-reused-late-context";
+        let lease = cache
+            .prepare(WorkspaceImagePrepareRequest {
+                run_id,
+                sandbox_id,
+                profile_name: TEST_PROFILE_NAME,
+                session_id: None,
+                working_dir: "/workspace",
+                image_size_bytes: 5,
+                workspace_drive_required: false,
+            })
+            .await;
+        let promotion = lease
+            .into_promotion_context(WorkspaceImagePromotionRequest {
+                run_id,
+                sandbox_id,
+                session_id_override: Some(session_id),
+                terminal_status: WorkspaceCacheTerminalStatus::Success,
+                completed_at: "2026-05-01T00:00:00.000Z".into(),
+                storage_fingerprints: StorageFingerprints::default(),
+                promotable: true,
+            })
+            .unwrap();
+
+        let active_lease = promotion.into_active_lease(WorkspaceImageActiveLeaseRequest {
+            run_id: RunId::new_v4(),
+            sandbox_id,
+            profile_name: TEST_PROFILE_NAME,
+            session_id: Some(session_id),
+            working_dir: "/workspace",
+            image_size_bytes: 5,
+            workspace_drive_available: true,
+        });
+
+        assert!(active_lease.can_attempt_promotion(Some(session_id)));
+        assert!(
+            active_lease
+                .into_promotion_context(WorkspaceImagePromotionRequest {
+                    run_id: RunId::new_v4(),
+                    sandbox_id,
+                    session_id_override: Some(session_id),
+                    terminal_status: WorkspaceCacheTerminalStatus::Success,
+                    completed_at: "2026-05-01T00:00:01.000Z".into(),
+                    storage_fingerprints: StorageFingerprints::default(),
+                    promotable: true,
+                })
+                .is_some(),
+            "reusing an idle sandbox created before the CLI reported a session id must not lose the future cache promotion"
+        );
     }
 }

--- a/crates/runner/src/workspace_image_cache.rs
+++ b/crates/runner/src/workspace_image_cache.rs
@@ -921,7 +921,7 @@ impl SessionWorkspaceCache {
             };
 
             let entry_dir = entry.path();
-            let allocated = flat_directory_allocated_bytes(&entry_dir).await;
+            let allocated = directory_tree_allocated_bytes(&entry_dir).await;
             if dry_run {
                 info!(
                     cache_key,
@@ -1019,7 +1019,7 @@ impl SessionWorkspaceCache {
                 }
             }
             let entry_dir = entry.path();
-            let allocated = flat_directory_allocated_bytes(&entry_dir).await;
+            let allocated = directory_tree_allocated_bytes(&entry_dir).await;
             if dry_run {
                 info!(
                     cache_key,
@@ -2200,28 +2200,6 @@ fn statvfs_bytes_sync(path: &Path) -> RunnerResult<FsStats> {
         total_bytes: stats.f_blocks.saturating_mul(block_size),
         available_bytes: stats.f_bavail.saturating_mul(block_size),
     })
-}
-
-async fn flat_directory_allocated_bytes(path: &Path) -> u64 {
-    let mut entries = match fs::read_dir(path).await {
-        Ok(entries) => entries,
-        Err(_) => return 0,
-    };
-    let mut total: u64 = 0;
-    while let Ok(Some(entry)) = entries.next_entry().await {
-        let Ok(file_type) = entry.file_type().await else {
-            continue;
-        };
-        if !file_type.is_file() {
-            continue;
-        }
-        let allocated = fs::metadata(entry.path())
-            .await
-            .map(|metadata| allocated_bytes(&metadata))
-            .unwrap_or(0);
-        total = total.saturating_add(allocated);
-    }
-    total
 }
 
 async fn directory_tree_allocated_bytes(path: &Path) -> u64 {
@@ -4097,6 +4075,63 @@ mod tests {
             !paths.session_workspace_cache_entry_dir(&key).exists(),
             "current directories must not remain as reusable workspace cache entries"
         );
+    }
+
+    #[tokio::test]
+    async fn gc_counts_nested_current_directory_bytes() {
+        let dir = tempfile::tempdir().unwrap();
+        let paths = RunnerPaths::new(dir.path().join("runner"));
+        tokio::fs::create_dir_all(paths.base_dir()).await.unwrap();
+        let cache = SessionWorkspaceCache::new(paths.clone());
+        let run_id = RunId::new_v4();
+        let session_id = "sess-1";
+        let working_dir = "/workspace";
+        let image_size_bytes = 1024 * 1024;
+        let key =
+            cache.scoped_cache_key(TEST_PROFILE_NAME, session_id, working_dir, image_size_bytes);
+        let current = paths.session_workspace_cache_current_image(&key);
+        let nested = current.join("nested");
+        tokio::fs::create_dir_all(&nested).await.unwrap();
+        tokio::fs::write(
+            nested.join("payload"),
+            vec![1_u8; image_size_bytes as usize],
+        )
+        .await
+        .unwrap();
+        let current_metadata = fs::metadata(&current).await.unwrap();
+        cache
+            .write_metadata(
+                &key,
+                run_id,
+                WorkspaceCacheMetadata {
+                    format_version: CACHE_FORMAT_VERSION,
+                    key_version: CACHE_KEY_VERSION,
+                    cache_scope: cache.inner.cache_scope.clone(),
+                    profile_name: TEST_PROFILE_NAME.into(),
+                    session_id: session_id.into(),
+                    working_dir: working_dir.into(),
+                    last_completed_at: "2026-05-01T00:00:00.000Z".into(),
+                    last_used_at: "2026-05-01T00:00:00.000Z".into(),
+                    last_terminal_status: WorkspaceCacheTerminalStatus::Success,
+                    workspace_trust: WorkspaceTrust::Clean,
+                    logical_image_size_bytes: current_metadata.len(),
+                    allocated_bytes: allocated_bytes(&current_metadata),
+                    current_image: WorkspaceImageFileIdentity::from_metadata(&current_metadata),
+                    drive_layout: WORKSPACE_DRIVE_LAYOUT.into(),
+                    storage_fingerprints: StorageFingerprints::default(),
+                    state: WorkspaceCacheState::Current,
+                },
+            )
+            .await
+            .unwrap();
+
+        let freed = cache.gc(false).await.unwrap();
+
+        assert!(
+            freed >= image_size_bytes,
+            "GC must report nested current directory bytes so callers refresh disk stats after cleanup"
+        );
+        assert!(!paths.session_workspace_cache_entry_dir(&key).exists());
     }
 
     #[tokio::test]

--- a/crates/runner/src/workspace_promotion.rs
+++ b/crates/runner/src/workspace_promotion.rs
@@ -16,6 +16,32 @@ pub(crate) async fn promote_workspace_image_from_active_sandbox(
         return false;
     };
 
+    match AssertUnwindSafe(promote_workspace_image_from_active_sandbox_inner(
+        sandbox, promotion, reason,
+    ))
+    .catch_unwind()
+    .await
+    {
+        Ok(promoted) => promoted,
+        Err(_) => {
+            warn!(
+                run_id = %promotion.run_id(),
+                sandbox_id = %promotion.sandbox_id(),
+                profile_name = promotion.profile_name(),
+                session_id = promotion.session_id(),
+                reason,
+                "workspace image cache promotion panicked"
+            );
+            false
+        }
+    }
+}
+
+async fn promote_workspace_image_from_active_sandbox_inner(
+    sandbox: &dyn Sandbox,
+    promotion: &WorkspaceImagePromotionContext,
+    reason: &'static str,
+) -> bool {
     match flush_and_unmount_workspace_drive(sandbox, promotion.run_id()).await {
         Ok(()) => {}
         Err(e) => {

--- a/crates/runner/src/workspace_promotion.rs
+++ b/crates/runner/src/workspace_promotion.rs
@@ -1,0 +1,89 @@
+use std::panic::AssertUnwindSafe;
+
+use futures_util::FutureExt;
+use sandbox::Sandbox;
+use tracing::warn;
+
+use crate::workspace_image_cache::WorkspaceImagePromotionContext;
+use crate::workspace_mount::flush_and_unmount_workspace_drive;
+
+pub(crate) async fn promote_workspace_image_from_active_sandbox(
+    sandbox: &dyn Sandbox,
+    promotion: Option<&WorkspaceImagePromotionContext>,
+    reason: &'static str,
+) -> bool {
+    let Some(promotion) = promotion else {
+        return false;
+    };
+
+    match flush_and_unmount_workspace_drive(sandbox, promotion.run_id()).await {
+        Ok(()) => {}
+        Err(e) => {
+            warn!(
+                run_id = %promotion.run_id(),
+                sandbox_id = %promotion.sandbox_id(),
+                profile_name = promotion.profile_name(),
+                session_id = promotion.session_id(),
+                reason,
+                error = %e,
+                "workspace image cache promotion skipped because guest unmount failed"
+            );
+            return false;
+        }
+    }
+
+    match promotion.promote().await {
+        Ok(promoted) => promoted,
+        Err(e) => {
+            warn!(
+                run_id = %promotion.run_id(),
+                sandbox_id = %promotion.sandbox_id(),
+                profile_name = promotion.profile_name(),
+                session_id = promotion.session_id(),
+                reason,
+                error = %e,
+                "workspace image cache promotion failed"
+            );
+            false
+        }
+    }
+}
+
+pub(crate) async fn promote_workspace_image_from_parked_sandbox(
+    sandbox: &mut dyn Sandbox,
+    promotion: Option<&WorkspaceImagePromotionContext>,
+    reason: &'static str,
+) -> bool {
+    let Some(promotion) = promotion else {
+        return false;
+    };
+
+    match AssertUnwindSafe(sandbox.unpark()).catch_unwind().await {
+        Ok(Ok(())) => {}
+        Ok(Err(e)) => {
+            warn!(
+                run_id = %promotion.run_id(),
+                sandbox_id = %promotion.sandbox_id(),
+                profile_name = promotion.profile_name(),
+                session_id = promotion.session_id(),
+                reason,
+                error = %e,
+                "workspace image cache promotion skipped because idle sandbox unpark failed"
+            );
+            return false;
+        }
+        Err(_) => {
+            warn!(
+                run_id = %promotion.run_id(),
+                sandbox_id = %promotion.sandbox_id(),
+                profile_name = promotion.profile_name(),
+                session_id = promotion.session_id(),
+                reason,
+                "workspace image cache promotion skipped because idle sandbox unpark panicked"
+            );
+            return false;
+        }
+    }
+
+    promote_workspace_image_from_active_sandbox(sandbox, Some(promotion), reason).await
+}


### PR DESCRIPTION
## Summary
- keep workspace images mounted when a sandbox parks successfully for reuse
- promote workspace image cache only when a parked or active sandbox is about to be destroyed
- prevent older session cache promotions from overwriting newer cache entries

Closes #15957

## Tests
- cargo test --manifest-path crates/Cargo.toml -p runner
- pre-commit: cargo fmt, cargo doc, cargo clippy