### PR TITLE
fix: increase activity detail initial event load

### DIFF
--- a/turbo/apps/platform/src/signals/zero-page/polling.ts
+++ b/turbo/apps/platform/src/signals/zero-page/polling.ts
@@ -10,7 +10,8 @@ import { zeroQueuePositionContract } from "@vm0/api-contracts/contracts/zero-que
 import { accept } from "../../lib/accept.ts";
 import { zeroClient$, type ZeroClientFactory } from "../api-client.ts";
 
-const AGENT_EVENTS_PAGE_LIMIT = 30;
+const INITIAL_AGENT_EVENTS_PAGE_LIMIT = 100;
+const POLLED_AGENT_EVENTS_PAGE_LIMIT = 30;
 
 function isTerminalStatus(status: string | null): boolean {
   return (
@@ -29,22 +30,25 @@ interface PagedRunEvents {
 async function fetchEvents(
   client: ZeroClientFactory,
   runId: string,
-  since?: number,
-  signal?: AbortSignal,
-) {
+  options: {
+    limit: number;
+    since?: number;
+    signal?: AbortSignal;
+  },
+): Promise<PagedRunEvents> {
   const query: { limit: number; order: "asc"; since?: number } = {
-    limit: AGENT_EVENTS_PAGE_LIMIT,
+    limit: options.limit,
     order: "asc",
   };
-  if (since !== undefined) {
-    query.since = since;
+  if (options.since !== undefined) {
+    query.since = options.since;
   }
   const result = await accept(
     client(zeroRunAgentEventsContract).getAgentEvents({
       params: { id: runId },
       query,
       fetchOptions: {
-        signal,
+        signal: options.signal,
       },
     }),
     [200],
@@ -54,11 +58,13 @@ async function fetchEvents(
 
 function createEventPageComputed(
   runId: string,
+  limit: number,
   since?: number,
 ): Computed<Promise<PagedRunEvents>> {
   return computed(async (get) => {
     const client = get(zeroClient$);
-    return await fetchEvents(client, runId, since);
+    const options = since === undefined ? { limit } : { limit, since };
+    return await fetchEvents(client, runId, options);
   });
 }
 
@@ -147,7 +153,9 @@ async function findLastEventSequence(
 
 function createRunPagedEvents(runId: string) {
   const initialPagedEventsList$ = computed(async (get) => {
-    const pages = [createEventPageComputed(runId)];
+    const pages = [
+      createEventPageComputed(runId, INITIAL_AGENT_EVENTS_PAGE_LIMIT),
+    ];
 
     while (true) {
       const lastPage = await get(pages[pages.length - 1]);
@@ -156,7 +164,9 @@ function createRunPagedEvents(runId: string) {
       }
 
       const since = await findLastEventSequence(pages, get);
-      pages.push(createEventPageComputed(runId, since));
+      pages.push(
+        createEventPageComputed(runId, INITIAL_AGENT_EVENTS_PAGE_LIMIT, since),
+      );
     }
   });
 
@@ -210,7 +220,11 @@ export function createRunLoop(runId: string) {
     const since = await findLastEventSequence(allPages, get);
     signal.throwIfAborted();
 
-    const nextPage$ = createEventPageComputed(runId, since);
+    const nextPage$ = createEventPageComputed(
+      runId,
+      POLLED_AGENT_EVENTS_PAGE_LIMIT,
+      since,
+    );
     set(internalLoopedPagedEvents$, (prev) => {
       return [...prev, nextPage$];
     });

--- a/turbo/apps/platform/src/views/activity-page/__tests__/activity-paged-events.test.tsx
+++ b/turbo/apps/platform/src/views/activity-page/__tests__/activity-paged-events.test.tsx
@@ -217,6 +217,81 @@ describe("activity paged events", () => {
     });
   });
 
+  it("should load initial event history with larger pages before polling", async () => {
+    const requestedLimits: { since: number | undefined; limit: number }[] = [];
+
+    const firstEvent = {
+      sequenceNumber: 0,
+      eventType: "assistant",
+      eventData: {
+        message: { content: [{ type: "text", text: "Initial history one" }] },
+      },
+      createdAt: "2026-03-10T14:56:02Z",
+    };
+
+    const secondEvent = {
+      sequenceNumber: 1,
+      eventType: "assistant",
+      eventData: {
+        message: { content: [{ type: "text", text: "Initial history two" }] },
+      },
+      createdAt: "2026-03-10T14:56:03Z",
+    };
+
+    setMockComposesList([]);
+    server.use(
+      mockApi(logsByIdContract.getById, ({ respond }) => {
+        return respond(200, makeLogDetail({ status: "completed" }));
+      }),
+      mockApi(
+        zeroRunAgentEventsContract.getAgentEvents,
+        ({ query, respond }) => {
+          requestedLimits.push({ since: query.since, limit: query.limit });
+
+          if (query.since === undefined) {
+            return respond(200, {
+              events: [firstEvent],
+              hasMore: true,
+              framework: "claude-code",
+            } satisfies AgentEventsResponse);
+          }
+
+          if (query.since === 0) {
+            return respond(200, {
+              events: [secondEvent],
+              hasMore: false,
+              framework: "claude-code",
+            } satisfies AgentEventsResponse);
+          }
+
+          return respond(200, {
+            events: [],
+            hasMore: false,
+            framework: "claude-code",
+          } satisfies AgentEventsResponse);
+        },
+      ),
+    );
+
+    detachedSetupPage({
+      context,
+      path: "/activities/a0000000-0000-4000-a000-000000000099",
+    });
+
+    await waitFor(() => {
+      expect(screen.getByText("Initial history one")).toBeInTheDocument();
+      expect(screen.getByText("Initial history two")).toBeInTheDocument();
+    });
+
+    await waitFor(() => {
+      expect(requestedLimits).toStrictEqual([
+        { since: undefined, limit: 100 },
+        { since: 0, limit: 100 },
+        { since: 1, limit: 30 },
+      ]);
+    });
+  });
+
   it("should stop polling when navigating away from the run page", async () => {
     let eventFetchCount = 0;
 


### PR DESCRIPTION
## Summary
- use the API maximum page size for initial activity detail event history pages
- keep follow-up polling pages at 30 events after initial history is exhausted
- add an activity detail integration test covering the initial-history limit and polling fallback

## Tests
- pnpm exec prettier --write apps/platform/src/signals/zero-page/polling.ts apps/platform/src/views/activity-page/__tests__/activity-paged-events.test.tsx
- pnpm -F @vm0/app lint
- pnpm -F @vm0/app check-types
- pnpm -F @vm0/app exec vitest run src/views/activity-page/__tests__/activity-paged-events.test.tsx src/views/activity-page/__tests__/activity-detail-polling.test.tsx
- pre-commit: prettier, knip, pnpm check-types