### PR TITLE
feat: add artifact inbox sidebar preview

### DIFF
--- a/turbo/apps/platform/package.json
+++ b/turbo/apps/platform/package.json
@@ -44,6 +44,7 @@
     "posthog-js": "^1.372.1",
     "react": "^19.2.6",
     "react-dom": "^19.2.6",
+    "react-zoom-pan-pinch": "^4.0.3",
     "rehype-katex": "^7.0.1",
     "remark-math": "^6.0.0",
     "signal-timers": "^1.0.4",

--- a/turbo/apps/platform/src/signals/view-component-state.ts
+++ b/turbo/apps/platform/src/signals/view-component-state.ts
@@ -12,16 +12,15 @@ export type TextPreviewLoadState = {
 
 type ImageLightboxImageState = {
   imageStatus: ImageLoadStatus;
-  zoom: number;
 };
 
 export const IMAGE_LIGHTBOX_MIN_ZOOM = 0.5;
 export const IMAGE_LIGHTBOX_MAX_ZOOM = 3;
-const IMAGE_LIGHTBOX_ZOOM_STEP = 0.25;
 
 const internalImageLoadStatusByKey$ = state<Record<string, ImageLoadStatus>>(
   {},
 );
+const internalZoomableImageCanvasZoomByKey$ = state<Record<string, number>>({});
 const internalTextPreviewLoadStateByKey$ = state<
   Record<string, TextPreviewLoadState>
 >({});
@@ -29,11 +28,14 @@ const internalTextPreviewCollapsedByKey$ = state<Record<string, boolean>>({});
 const internalTypewriterDisplayedByKey$ = state<Record<string, string>>({});
 const internalImageLightboxState$ = state<ImageLightboxImageState>({
   imageStatus: "loading",
-  zoom: 1,
 });
 
 export const imageLoadStatusByKey$ = computed((get) => {
   return get(internalImageLoadStatusByKey$);
+});
+
+export const zoomableImageCanvasZoomByKey$ = computed((get) => {
+  return get(internalZoomableImageCanvasZoomByKey$);
 });
 
 export const textPreviewLoadStateByKey$ = computed((get) => {
@@ -59,6 +61,31 @@ export const setImageLoadStatus$ = command(
     });
   },
 );
+
+function clampImageZoom(zoom: number) {
+  return Math.min(
+    IMAGE_LIGHTBOX_MAX_ZOOM,
+    Math.max(IMAGE_LIGHTBOX_MIN_ZOOM, zoom),
+  );
+}
+
+function roundImageZoom(zoom: number) {
+  return Math.round(clampImageZoom(zoom) * 100) / 100;
+}
+
+export const setZoomableImageCanvasZoom$ = command(
+  ({ set }, key: string, zoom: number) => {
+    set(internalZoomableImageCanvasZoomByKey$, (current) => {
+      return { ...current, [key]: roundImageZoom(zoom) };
+    });
+  },
+);
+
+export const resetZoomableImageCanvasZoom$ = command(({ set }, key: string) => {
+  set(internalZoomableImageCanvasZoomByKey$, (current) => {
+    return { ...current, [key]: 1 };
+  });
+});
 
 const resetImageLoadStatus$ = command(({ set }, key: string) => {
   set(internalImageLoadStatusByKey$, (current) => {
@@ -172,15 +199,8 @@ const startTypewriterOnRef$ = command(
 
 export const typewriterRef$ = onRef(startTypewriterOnRef$);
 
-function clampImageLightboxZoom(zoom: number): number {
-  return Math.min(
-    IMAGE_LIGHTBOX_MAX_ZOOM,
-    Math.max(IMAGE_LIGHTBOX_MIN_ZOOM, zoom),
-  );
-}
-
 const resetImageLightboxState$ = command(({ set }) => {
-  set(internalImageLightboxState$, { imageStatus: "loading", zoom: 1 });
+  set(internalImageLightboxState$, { imageStatus: "loading" });
 });
 
 export const setImageLightboxStatus$ = command(
@@ -191,30 +211,6 @@ export const setImageLightboxStatus$ = command(
   },
 );
 
-export const zoomImageLightboxIn$ = command(({ set }) => {
-  set(internalImageLightboxState$, (current) => {
-    return {
-      ...current,
-      zoom: clampImageLightboxZoom(current.zoom + IMAGE_LIGHTBOX_ZOOM_STEP),
-    };
-  });
-});
-
-export const zoomImageLightboxOut$ = command(({ set }) => {
-  set(internalImageLightboxState$, (current) => {
-    return {
-      ...current,
-      zoom: clampImageLightboxZoom(current.zoom - IMAGE_LIGHTBOX_ZOOM_STEP),
-    };
-  });
-});
-
-export const resetImageLightboxZoom$ = command(({ set }) => {
-  set(internalImageLightboxState$, (current) => {
-    return { ...current, zoom: 1 };
-  });
-});
-
 const resetImageLightboxOnRef$ = command(
   ({ set }, _el: HTMLElement, _signal: AbortSignal) => {
     set(resetImageLightboxState$);
@@ -222,44 +218,6 @@ const resetImageLightboxOnRef$ = command(
 );
 
 export const imageLightboxImageRef$ = onRef(resetImageLightboxOnRef$);
-
-const imageLightboxKeyboardShortcutsOnRef$ = command(
-  ({ set }, _el: HTMLElement, signal: AbortSignal) => {
-    document.addEventListener(
-      "keydown",
-      (event: KeyboardEvent) => {
-        if (!event.metaKey && !event.ctrlKey) {
-          return;
-        }
-
-        if (event.key === "+" || event.key === "=") {
-          event.preventDefault();
-          event.stopPropagation();
-          set(zoomImageLightboxIn$);
-          return;
-        }
-
-        if (event.key === "-" || event.key === "_") {
-          event.preventDefault();
-          event.stopPropagation();
-          set(zoomImageLightboxOut$);
-          return;
-        }
-
-        if (event.key === "0") {
-          event.preventDefault();
-          event.stopPropagation();
-          set(resetImageLightboxZoom$);
-        }
-      },
-      { signal },
-    );
-  },
-);
-
-export const imageLightboxKeyboardShortcutsRef$ = onRef(
-  imageLightboxKeyboardShortcutsOnRef$,
-);
 
 const openTelegramOnRef$ = command(
   (_ctx, el: HTMLElement, _signal: AbortSignal) => {

--- a/turbo/apps/platform/src/signals/zero-page/zero-artifact-actions.ts
+++ b/turbo/apps/platform/src/signals/zero-page/zero-artifact-actions.ts
@@ -1,0 +1,47 @@
+import { command, computed, state } from "ccstate";
+
+const ARTIFACT_DOWNLOAD_MENU_CLOSE_DELAY_MS = 80;
+
+const internalArtifactDownloadMenuOpenKey$ = state<string | null>(null);
+const internalArtifactDownloadMenuCloseToken$ = state(0);
+
+export const artifactDownloadMenuOpenKey$ = computed((get) => {
+  return get(internalArtifactDownloadMenuOpenKey$);
+});
+
+const closeArtifactDownloadMenuForToken$ = command(
+  ({ get, set }, value: { key: string; token: number }) => {
+    if (get(internalArtifactDownloadMenuCloseToken$) !== value.token) {
+      return;
+    }
+    if (get(internalArtifactDownloadMenuOpenKey$) === value.key) {
+      set(internalArtifactDownloadMenuOpenKey$, null);
+    }
+  },
+);
+
+export const openArtifactDownloadMenu$ = command(
+  ({ set }, key: string | null) => {
+    set(internalArtifactDownloadMenuCloseToken$, (value) => {
+      return value + 1;
+    });
+    set(internalArtifactDownloadMenuOpenKey$, key);
+  },
+);
+
+export const closeArtifactDownloadMenu$ = command(({ set }) => {
+  set(internalArtifactDownloadMenuCloseToken$, (value) => {
+    return value + 1;
+  });
+  set(internalArtifactDownloadMenuOpenKey$, null);
+});
+
+export const scheduleArtifactDownloadMenuClose$ = command(
+  ({ get, set }, key: string) => {
+    const token = get(internalArtifactDownloadMenuCloseToken$) + 1;
+    set(internalArtifactDownloadMenuCloseToken$, token);
+    window.setTimeout(() => {
+      set(closeArtifactDownloadMenuForToken$, { key, token });
+    }, ARTIFACT_DOWNLOAD_MENU_CLOSE_DELAY_MS);
+  },
+);

--- a/turbo/apps/platform/src/signals/zero-page/zero-artifact-sidebar.ts
+++ b/turbo/apps/platform/src/signals/zero-page/zero-artifact-sidebar.ts
@@ -1,4 +1,4 @@
-import { command, computed } from "ccstate";
+import { command, computed, state } from "ccstate";
 import { FeatureSwitchKey } from "@vm0/connectors/feature-switch-key";
 import { featureSwitch$ } from "../external/feature-switch.ts";
 import {
@@ -22,17 +22,23 @@ import {
 // FeatureSwitchKey.ChatArtifactSidebar; the OFF path keeps the old modal
 // lightbox in place.
 //
-// Every piece of sidebar state lives in `?artifact=` (plus the optional
-// `?artifact-fullscreen=1` flag). There is no in-memory state — opening
-// is a search-param write, closing is a search-param delete, and the
-// fullscreen toggle is just another search-param flip. Components read
-// the state through `currentArtifactRef$` / `artifactFullscreen$`, which
-// are pure computeds over `searchParams$`.
+// Sidebar state lives in search params: `?artifacts=<threadId>` opens the
+// artifact inbox, `?artifact=<url>` opens a detail preview, and
+// `?artifact-fullscreen=1` expands whichever artifact surface is active.
+// There is no in-memory state — opening is a search-param write, closing is a
+// search-param delete, and components read pure computeds over `searchParams$`.
 // ---------------------------------------------------------------------------
 
 const ARTIFACT_QUERY_PARAM = "artifact";
+const ARTIFACT_INBOX_QUERY_PARAM = "artifacts";
 const ARTIFACT_FULLSCREEN_PARAM = "artifact-fullscreen";
 const IMAGE_ID_PREFIX = "image:";
+
+export type ArtifactInboxSection = "all" | "media" | "docs" | "sites";
+
+const internalArtifactInboxSection$ = state<ArtifactInboxSection>("all");
+const internalArtifactInboxQuery$ = state("");
+const internalArtifactInboxSearchOpen$ = state(false);
 
 export type ArtifactPreviewKind =
   | "markdown"
@@ -74,6 +80,22 @@ export const chatArtifactSidebarEnabled$ = computed((get) => {
   return features[FeatureSwitchKey.ChatArtifactSidebar] ?? false;
 });
 
+export const currentArtifactInboxThreadId$ = computed((get) => {
+  return get(searchParams$).get(ARTIFACT_INBOX_QUERY_PARAM);
+});
+
+export const artifactInboxSection$ = computed((get) => {
+  return get(internalArtifactInboxSection$);
+});
+
+export const artifactInboxQuery$ = computed((get) => {
+  return get(internalArtifactInboxQuery$);
+});
+
+export const artifactInboxSearchOpen$ = computed((get) => {
+  return get(internalArtifactInboxSearchOpen$);
+});
+
 // The URL alone is the source of truth: kind + filename are derived from
 // the URL itself via previewAttachmentFromUrl, so deep-linking or refreshing
 // the page re-renders the right body without any in-memory metadata cache.
@@ -103,15 +125,63 @@ const openArtifact$ = command(({ get, set }, url: string) => {
   set(updateSearchParams$, params);
 });
 
+export const openArtifactInbox$ = command(({ get, set }, threadId: string) => {
+  const params = new URLSearchParams(get(searchParams$));
+  params.set(ARTIFACT_INBOX_QUERY_PARAM, threadId);
+  params.delete(ARTIFACT_QUERY_PARAM);
+  params.delete(ARTIFACT_FULLSCREEN_PARAM);
+  set(internalArtifactInboxSection$, "all");
+  set(internalArtifactInboxQuery$, "");
+  set(internalArtifactInboxSearchOpen$, false);
+  set(updateSearchParams$, params);
+});
+
+export const setArtifactInboxSection$ = command(
+  ({ set }, value: ArtifactInboxSection) => {
+    set(internalArtifactInboxSection$, value);
+  },
+);
+
+export const setArtifactInboxQuery$ = command(({ set }, value: string) => {
+  set(internalArtifactInboxQuery$, value);
+});
+
+export const toggleArtifactInboxSearch$ = command(({ get, set }) => {
+  const nextOpen = !get(internalArtifactInboxSearchOpen$);
+  set(internalArtifactInboxSearchOpen$, nextOpen);
+  if (!nextOpen) {
+    set(internalArtifactInboxQuery$, "");
+  }
+});
+
+export const openArtifactFromInbox$ = command(
+  ({ get, set }, args: { threadId: string; url: string }) => {
+    const params = new URLSearchParams(get(searchParams$));
+    params.set(ARTIFACT_INBOX_QUERY_PARAM, args.threadId);
+    params.set(ARTIFACT_QUERY_PARAM, args.url);
+    params.delete(ARTIFACT_FULLSCREEN_PARAM);
+    set(updateSearchParams$, params);
+  },
+);
+
+export const backToArtifactInbox$ = command(({ get, set }) => {
+  const params = new URLSearchParams(get(searchParams$));
+  params.delete(ARTIFACT_QUERY_PARAM);
+  params.delete(ARTIFACT_FULLSCREEN_PARAM);
+  set(replaceSearchParams$, params);
+});
+
 export const closeArtifact$ = command(({ get, set }) => {
   const params = new URLSearchParams(get(searchParams$));
   if (
     !params.has(ARTIFACT_QUERY_PARAM) &&
+    !params.has(ARTIFACT_INBOX_QUERY_PARAM) &&
     !params.has(ARTIFACT_FULLSCREEN_PARAM)
   ) {
     return;
   }
   params.delete(ARTIFACT_QUERY_PARAM);
+  params.delete(ARTIFACT_INBOX_QUERY_PARAM);
   params.delete(ARTIFACT_FULLSCREEN_PARAM);
   set(replaceSearchParams$, params);
 });

--- a/turbo/apps/platform/src/signals/zero-page/zero-artifact-sidebar.ts
+++ b/turbo/apps/platform/src/signals/zero-page/zero-artifact-sidebar.ts
@@ -11,6 +11,7 @@ import {
   previewAttachmentFromUrl,
 } from "../chat-page/parse-body-blocks.ts";
 import {
+  type AttachmentArtifactMetadata,
   openDocumentLightbox$ as openDocumentLightboxModal$,
   openImageLightbox$ as openImageLightboxModal$,
   openVideoLightbox$ as openVideoLightboxModal$,
@@ -116,14 +117,15 @@ export const currentArtifactRef$ = computed<ArtifactRef | null>((get) => {
   return { source: "url", url: raw, kind, filename: attachment.filename };
 });
 
-const openArtifact$ = command(({ get, set }, url: string) => {
-  const params = new URLSearchParams(get(searchParams$));
-  params.set(ARTIFACT_QUERY_PARAM, url);
-  // Don't carry a previous artifact's fullscreen flag onto a fresh open;
-  // a new artifact starts at the default 50/50 size.
-  params.delete(ARTIFACT_FULLSCREEN_PARAM);
-  set(updateSearchParams$, params);
-});
+export const openArtifactSidebarPreview$ = command(
+  ({ get, set }, url: string) => {
+    const params = new URLSearchParams(get(searchParams$));
+    params.set(ARTIFACT_QUERY_PARAM, url);
+    params.delete(ARTIFACT_INBOX_QUERY_PARAM);
+    params.delete(ARTIFACT_FULLSCREEN_PARAM);
+    set(updateSearchParams$, params);
+  },
+);
 
 export const openArtifactInbox$ = command(({ get, set }, threadId: string) => {
   const params = new URLSearchParams(get(searchParams$));
@@ -205,44 +207,49 @@ export const toggleArtifactFullscreen$ = command(({ get, set }) => {
 });
 
 // ---------------------------------------------------------------------------
-// Switch-aware open commands — the existing lightbox-open commands route
-// here when the sidebar feature switch is on, so every chip click site
-// participates without per-callsite branching.
+// Attachment preview clicks still open the modal lightbox. Moving into the
+// artifact sidebar is an explicit lightbox action so chat previews do not jump
+// directly into split view.
 // ---------------------------------------------------------------------------
 
 export const openImageLightboxOrArtifact$ = command(
-  ({ get, set }, url: string) => {
-    if (get(chatArtifactSidebarEnabled$)) {
-      set(openArtifact$, url);
-      return;
-    }
-    set(openImageLightboxModal$, url);
+  (
+    { set },
+    value:
+      | string
+      | {
+          url: string;
+          filename?: string;
+          artifact?: AttachmentArtifactMetadata;
+        },
+  ) => {
+    set(openImageLightboxModal$, value);
   },
 );
 
 export const openVideoLightboxOrArtifact$ = command(
-  ({ get, set }, value: { url: string; filename: string }) => {
-    if (get(chatArtifactSidebarEnabled$)) {
-      set(openArtifact$, value.url);
-      return;
-    }
+  (
+    { set },
+    value: {
+      url: string;
+      filename: string;
+      artifact?: AttachmentArtifactMetadata;
+    },
+  ) => {
     set(openVideoLightboxModal$, value);
   },
 );
 
 export const openDocumentLightboxOrArtifact$ = command(
   (
-    { get, set },
+    { set },
     value: {
       kind: "markdown" | "text" | "json" | "csv" | "html" | "pdf";
       url: string;
       filename: string;
+      artifact?: AttachmentArtifactMetadata;
     },
   ) => {
-    if (get(chatArtifactSidebarEnabled$)) {
-      set(openArtifact$, value.url);
-      return;
-    }
     set(openDocumentLightboxModal$, value);
   },
 );

--- a/turbo/apps/platform/src/signals/zero-page/zero-artifact-sidebar.ts
+++ b/turbo/apps/platform/src/signals/zero-page/zero-artifact-sidebar.ts
@@ -12,6 +12,7 @@ import {
 } from "../chat-page/parse-body-blocks.ts";
 import {
   type AttachmentArtifactMetadata,
+  openAudioLightbox$ as openAudioLightboxModal$,
   openDocumentLightbox$ as openDocumentLightboxModal$,
   openImageLightbox$ as openImageLightboxModal$,
   openVideoLightbox$ as openVideoLightboxModal$,
@@ -237,6 +238,19 @@ export const openVideoLightboxOrArtifact$ = command(
     },
   ) => {
     set(openVideoLightboxModal$, value);
+  },
+);
+
+export const openAudioLightboxOrArtifact$ = command(
+  (
+    { set },
+    value: {
+      url: string;
+      filename: string;
+      artifact?: AttachmentArtifactMetadata;
+    },
+  ) => {
+    set(openAudioLightboxModal$, value);
   },
 );
 

--- a/turbo/apps/platform/src/signals/zero-page/zero-attachment-chips.ts
+++ b/turbo/apps/platform/src/signals/zero-page/zero-attachment-chips.ts
@@ -34,7 +34,7 @@ export type AttachmentLightboxState =
       artifact?: AttachmentArtifactMetadata;
     }
   | {
-      kind: "video";
+      kind: "audio" | "video";
       url: string;
       filename: string;
       artifact?: AttachmentArtifactMetadata;
@@ -142,6 +142,24 @@ export const openVideoLightbox$ = command(
     set(internalLightboxDialogVisible$, true);
     set(internalLightboxDialogFullscreen$, false);
     set(internalLightboxState$, { kind: "video", ...value });
+  },
+);
+
+export const openAudioLightbox$ = command(
+  (
+    { set },
+    value: {
+      url: string;
+      filename: string;
+      artifact?: AttachmentArtifactMetadata;
+    },
+  ) => {
+    set(internalLightboxDialogCloseToken$, (value) => {
+      return value + 1;
+    });
+    set(internalLightboxDialogVisible$, true);
+    set(internalLightboxDialogFullscreen$, false);
+    set(internalLightboxState$, { kind: "audio", ...value });
   },
 );
 

--- a/turbo/apps/platform/src/signals/zero-page/zero-attachment-chips.ts
+++ b/turbo/apps/platform/src/signals/zero-page/zero-attachment-chips.ts
@@ -5,32 +5,108 @@ import { onRef } from "../utils.ts";
 // Lightbox state — tracks which attachment is open in the global preview UI
 // ---------------------------------------------------------------------------
 
-type AttachmentLightboxState =
+const LIGHTBOX_DIALOG_EXIT_DURATION_MS = 180;
+
+export type AttachmentArtifactMetadata = {
+  readonly agentId?: string | null;
+  readonly contentType: string;
+  readonly createdAt: string;
+  readonly fileId: string;
+  readonly filename: string;
+  readonly googleDriveSynced: boolean;
+  readonly onSyncSuccess?: () => void;
+  readonly runId: string;
+  readonly size: number;
+  readonly threadId: string;
+};
+
+export type AttachmentLightboxState =
   | {
       kind: "image";
       url: string;
       filename?: string;
+      artifact?: AttachmentArtifactMetadata;
     }
   | {
       kind: "markdown" | "text" | "json" | "csv" | "html" | "pdf";
       url: string;
       filename: string;
+      artifact?: AttachmentArtifactMetadata;
     }
   | {
       kind: "video";
       url: string;
       filename: string;
+      artifact?: AttachmentArtifactMetadata;
     };
 
 const internalLightboxState$ = state<AttachmentLightboxState | null>(null);
+const internalLightboxDialogVisible$ = state(false);
+const internalLightboxDialogFullscreen$ = state(false);
+const internalLightboxDialogCloseToken$ = state(0);
 
 export const lightboxUrl$ = computed((get) => {
   return get(internalLightboxState$);
 });
 
-export const openImageLightbox$ = command(({ set }, url: string) => {
-  set(internalLightboxState$, { kind: "image", url });
+export const lightboxDialogVisible$ = computed((get) => {
+  return get(internalLightboxDialogVisible$);
 });
+
+export const lightboxDialogFullscreen$ = computed((get) => {
+  return get(internalLightboxDialogFullscreen$);
+});
+
+export const toggleLightboxDialogFullscreen$ = command(({ get, set }) => {
+  set(
+    internalLightboxDialogFullscreen$,
+    !get(internalLightboxDialogFullscreen$),
+  );
+});
+
+const closeLightboxForDialogExitToken$ = command(
+  ({ get, set }, token: number) => {
+    if (get(internalLightboxDialogCloseToken$) !== token) {
+      return;
+    }
+    set(internalLightboxDialogVisible$, false);
+    set(internalLightboxDialogFullscreen$, false);
+    set(internalLightboxState$, null);
+  },
+);
+
+export const closeLightboxWithDialogExit$ = command(({ get, set }) => {
+  const token = get(internalLightboxDialogCloseToken$) + 1;
+  set(internalLightboxDialogCloseToken$, token);
+  set(internalLightboxDialogVisible$, false);
+  window.setTimeout(() => {
+    set(closeLightboxForDialogExitToken$, token);
+  }, LIGHTBOX_DIALOG_EXIT_DURATION_MS);
+});
+
+export const openImageLightbox$ = command(
+  (
+    { set },
+    value:
+      | string
+      | {
+          url: string;
+          filename?: string;
+          artifact?: AttachmentArtifactMetadata;
+        },
+  ) => {
+    set(internalLightboxDialogCloseToken$, (value) => {
+      return value + 1;
+    });
+    set(internalLightboxDialogVisible$, true);
+    set(internalLightboxDialogFullscreen$, false);
+    if (typeof value === "string") {
+      set(internalLightboxState$, { kind: "image", url: value });
+      return;
+    }
+    set(internalLightboxState$, { kind: "image", ...value });
+  },
+);
 
 export const openDocumentLightbox$ = command(
   (
@@ -39,8 +115,14 @@ export const openDocumentLightbox$ = command(
       kind: "markdown" | "text" | "json" | "csv" | "html" | "pdf";
       url: string;
       filename: string;
+      artifact?: AttachmentArtifactMetadata;
     },
   ) => {
+    set(internalLightboxDialogCloseToken$, (value) => {
+      return value + 1;
+    });
+    set(internalLightboxDialogVisible$, true);
+    set(internalLightboxDialogFullscreen$, false);
     set(internalLightboxState$, value);
   },
 );
@@ -51,13 +133,24 @@ export const openVideoLightbox$ = command(
     value: {
       url: string;
       filename: string;
+      artifact?: AttachmentArtifactMetadata;
     },
   ) => {
+    set(internalLightboxDialogCloseToken$, (value) => {
+      return value + 1;
+    });
+    set(internalLightboxDialogVisible$, true);
+    set(internalLightboxDialogFullscreen$, false);
     set(internalLightboxState$, { kind: "video", ...value });
   },
 );
 
 export const closeLightbox$ = command(({ set }) => {
+  set(internalLightboxDialogCloseToken$, (value) => {
+    return value + 1;
+  });
+  set(internalLightboxDialogVisible$, false);
+  set(internalLightboxDialogFullscreen$, false);
   set(internalLightboxState$, null);
 });
 
@@ -71,6 +164,11 @@ const closeLightboxOnEscape$ = command(
       "keydown",
       (e: KeyboardEvent) => {
         if (e.key === "Escape") {
+          set(internalLightboxDialogCloseToken$, (value) => {
+            return value + 1;
+          });
+          set(internalLightboxDialogVisible$, false);
+          set(internalLightboxDialogFullscreen$, false);
           set(internalLightboxState$, null);
         }
       },

--- a/turbo/apps/platform/src/views/zero-page/__tests__/zero-artifact-sidebar.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/zero-artifact-sidebar.test.tsx
@@ -178,6 +178,9 @@ describe("chatArtifactSidebar: sidebar slot rendering", () => {
     detachedSetupPage({
       context,
       path: "/chats/thread-1?artifact=https%3A%2F%2Fexample.com%2Fnotes.txt",
+      featureSwitches: {
+        [FeatureSwitchKey.ChatArtifactSidebar]: false,
+      },
       withoutRender: true,
     });
     context.store.set(setPageSignal$, context.signal);

--- a/turbo/apps/platform/src/views/zero-page/__tests__/zero-artifact-sidebar.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/zero-artifact-sidebar.test.tsx
@@ -305,6 +305,21 @@ describe("chatArtifactSidebar: image preview zoom controls", () => {
     expect(level.textContent).toBe("100%");
   });
 
+  it("resets image zoom before toggling fullscreen", () => {
+    renderImageSidebar();
+
+    fireEvent.click(screen.getByTestId("artifact-sidebar-image-zoom-in"));
+    expect(
+      screen.getByTestId("artifact-sidebar-image-zoom-level").textContent,
+    ).toBe("115%");
+
+    fireEvent.click(screen.getByTestId("artifact-sidebar-fullscreen-toggle"));
+    expect(context.store.get(artifactFullscreen$)).toBeTruthy();
+    expect(
+      screen.getByTestId("artifact-sidebar-image-zoom-level").textContent,
+    ).toBe("100%");
+  });
+
   it("disables zoom out at min zoom and zoom in at max zoom", () => {
     renderImageSidebar();
     const zoomIn = screen.getByTestId("artifact-sidebar-image-zoom-in");

--- a/turbo/apps/platform/src/views/zero-page/__tests__/zero-artifact-sidebar.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/zero-artifact-sidebar.test.tsx
@@ -268,6 +268,13 @@ describe("chatArtifactSidebar: image preview zoom controls", () => {
 
   it("renders the zoom toolbar on the image body at 100%", () => {
     renderImageSidebar();
+    expect(screen.getByTestId("artifact-sidebar-stage")).toHaveClass(
+      "overflow-hidden",
+    );
+    expect(screen.getByTestId("artifact-sidebar-body-image")).toHaveClass(
+      "max-h-full",
+      "max-w-full",
+    );
     expect(
       screen.getByTestId("artifact-sidebar-image-zoom-controls"),
     ).toBeInTheDocument();

--- a/turbo/apps/platform/src/views/zero-page/__tests__/zero-artifact-sidebar.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/zero-artifact-sidebar.test.tsx
@@ -2,9 +2,9 @@
  * Integration tests for the ChatArtifactSidebar feature switch behavior.
  *
  * Covers the ON path that issue #15027 introduces: inline .txt/.md
- * attachments collapse to anchor chips, clicking them writes the
- * ?artifact= URL parameter, and the page-level slot then renders the
- * sidebar component. The OFF path is covered by the existing
+ * attachments collapse to anchor chips, plain clicks still open the modal
+ * lightbox, and explicit sidebar opens write the ?artifact= URL parameter.
+ * The OFF path is covered by the existing
  * zero-attachment-preview.test.tsx file.
  */
 
@@ -16,6 +16,10 @@ import { testContext } from "../../../signals/__tests__/test-helpers.ts";
 import { detachedSetupPage } from "../../../__tests__/page-helper.ts";
 import { search } from "../../../signals/location.ts";
 import { setPageSignal$ } from "../../../signals/page-signal.ts";
+import {
+  closeLightbox$,
+  lightboxUrl$,
+} from "../../../signals/zero-page/zero-attachment-chips.ts";
 import { AttachmentPreview } from "../zero-attachment-preview.tsx";
 import {
   ArtifactSidebarSlot,
@@ -42,6 +46,7 @@ function setup(path = "/chats/thread-1") {
   // ArtifactSidebar reads pageSignal$ for fetch cancellation; tests render
   // it outside of normal page setup, so we have to seed it explicitly.
   context.store.set(setPageSignal$, context.signal);
+  context.store.set(closeLightbox$);
 }
 
 function renderWithStore(node: React.ReactNode) {
@@ -83,7 +88,7 @@ describe("chatArtifactSidebar: inline anchor chip behavior", () => {
     expect(chip).toHaveAttribute("href", "https://example.com/readme.md");
   });
 
-  it("opens the artifact pane and writes ?artifact= on plain click", () => {
+  it("opens the attachment lightbox on plain click", () => {
     setup();
     renderWithStore(
       <AttachmentPreview
@@ -97,16 +102,13 @@ describe("chatArtifactSidebar: inline anchor chip behavior", () => {
     const chip = screen.getByTestId("attachment-preview-text");
     fireEvent.click(chip);
 
-    const ref = context.store.get(currentArtifactRef$);
-    expect(ref).toStrictEqual({
-      source: "url",
-      url: "https://example.com/notes.txt",
+    expect(context.store.get(lightboxUrl$)).toStrictEqual({
       kind: "text",
       filename: "notes.txt",
+      url: "https://example.com/notes.txt",
     });
-    expect(search()).toContain(
-      "artifact=https%3A%2F%2Fexample.com%2Fnotes.txt",
-    );
+    expect(context.store.get(currentArtifactRef$)).toBeNull();
+    expect(search()).not.toContain("artifact=");
   });
 
   it("does not intercept cmd+click (modifier-click navigates natively)", () => {
@@ -133,6 +135,7 @@ describe("chatArtifactSidebar: inline anchor chip behavior", () => {
     // (handled by the browser) is left intact.
     expect(search()).not.toContain("artifact=");
     expect(context.store.get(currentArtifactRef$)).toBeNull();
+    expect(context.store.get(lightboxUrl$)).toBeNull();
   });
 });
 
@@ -201,6 +204,28 @@ describe("chatArtifactSidebar: sidebar slot rendering", () => {
 });
 
 describe("chatArtifactSidebar: fullscreen toggle", () => {
+  it("renders video artifacts inside a padded stage card", () => {
+    setup("/chats/thread-1?artifact=https%3A%2F%2Fexample.com%2Fclip.mp4");
+    renderWithStore(
+      <ArtifactSidebar
+        artifactRef={{
+          source: "url",
+          url: "https://example.com/clip.mp4",
+          kind: "video",
+          filename: "clip.mp4",
+        }}
+      />,
+    );
+
+    const stage = screen.getByTestId("artifact-sidebar-stage");
+    const videoStage = screen.getByTestId("artifact-sidebar-video-stage");
+    const video = screen.getByTestId("artifact-sidebar-body-video");
+
+    expect(stage).toHaveClass("bg-muted/30", "p-5");
+    expect(videoStage).toHaveClass("rounded-xl", "border", "bg-black");
+    expect(video).toHaveClass("aspect-video", "object-contain");
+  });
+
   it("toggles fullscreen state when the fullscreen button is clicked", () => {
     setup("/chats/thread-1?artifact=https%3A%2F%2Fexample.com%2Fnotes.txt");
     renderWithStore(

--- a/turbo/apps/platform/src/views/zero-page/__tests__/zero-artifact-sidebar.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/zero-artifact-sidebar.test.tsx
@@ -24,6 +24,7 @@ import {
 import {
   artifactFullscreen$,
   clearArtifactPreview$,
+  currentArtifactInboxThreadId$,
   currentArtifactRef$,
 } from "../../../signals/zero-page/zero-artifact-sidebar.ts";
 
@@ -181,16 +182,19 @@ describe("chatArtifactSidebar: sidebar slot rendering", () => {
 
   it("clears the artifact pane state", () => {
     setup(
-      "/chats/thread-1?artifact=https%3A%2F%2Fexample.com%2Fnotes.txt&artifact-fullscreen=1",
+      "/chats/thread-1?artifacts=thread-1&artifact=https%3A%2F%2Fexample.com%2Fnotes.txt&artifact-fullscreen=1",
     );
 
+    expect(context.store.get(currentArtifactInboxThreadId$)).toBe("thread-1");
     expect(context.store.get(currentArtifactRef$)).not.toBeNull();
     expect(context.store.get(artifactFullscreen$)).toBeTruthy();
 
     context.store.set(clearArtifactPreview$);
 
+    expect(context.store.get(currentArtifactInboxThreadId$)).toBeNull();
     expect(context.store.get(currentArtifactRef$)).toBeNull();
     expect(context.store.get(artifactFullscreen$)).toBeFalsy();
+    expect(search()).not.toContain("artifacts=");
     expect(search()).not.toContain("artifact=");
     expect(search()).not.toContain("artifact-fullscreen=");
   });
@@ -247,11 +251,10 @@ describe("chatArtifactSidebar: image preview zoom controls", () => {
     ).toBe("100%");
   });
 
-  it("zooms in, zooms out, and resets back to 100%", () => {
+  it("zooms in and zooms out", () => {
     renderImageSidebar();
     const zoomIn = screen.getByTestId("artifact-sidebar-image-zoom-in");
     const zoomOut = screen.getByTestId("artifact-sidebar-image-zoom-out");
-    const reset = screen.getByTestId("artifact-sidebar-image-zoom-reset");
     const level = screen.getByTestId("artifact-sidebar-image-zoom-level");
 
     fireEvent.click(zoomIn);
@@ -259,11 +262,8 @@ describe("chatArtifactSidebar: image preview zoom controls", () => {
     fireEvent.click(zoomIn);
     expect(level.textContent).toBe("150%");
 
-    fireEvent.click(reset);
-    expect(level.textContent).toBe("100%");
-
     fireEvent.click(zoomOut);
-    expect(level.textContent).toBe("75%");
+    expect(level.textContent).toBe("125%");
   });
 
   it("disables zoom out at min zoom and zoom in at max zoom", () => {

--- a/turbo/apps/platform/src/views/zero-page/__tests__/zero-artifact-sidebar.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/zero-artifact-sidebar.test.tsx
@@ -2,14 +2,14 @@
  * Integration tests for the ChatArtifactSidebar feature switch behavior.
  *
  * Covers the ON path that issue #15027 introduces: inline .txt/.md
- * attachments collapse to anchor chips, plain clicks still open the modal
+ * attachments render as thumbnail anchors, plain clicks still open the modal
  * lightbox, and explicit sidebar opens write the ?artifact= URL parameter.
  * The OFF path is covered by the existing
  * zero-attachment-preview.test.tsx file.
  */
 
 import { describe, expect, it } from "vitest";
-import { fireEvent, render, screen } from "@testing-library/react";
+import { fireEvent, render, screen, within } from "@testing-library/react";
 import { StoreProvider } from "ccstate-react";
 import { FeatureSwitchKey } from "@vm0/connectors/feature-switch-key";
 import { testContext } from "../../../signals/__tests__/test-helpers.ts";
@@ -53,8 +53,8 @@ function renderWithStore(node: React.ReactNode) {
   return render(<StoreProvider value={context.store}>{node}</StoreProvider>);
 }
 
-describe("chatArtifactSidebar: inline anchor chip behavior", () => {
-  it("renders a .txt attachment as an anchor chip when the switch is on", () => {
+describe("chatArtifactSidebar: inline thumbnail anchor behavior", () => {
+  it("renders a .txt attachment as a thumbnail anchor when the switch is on", () => {
     setup();
     renderWithStore(
       <AttachmentPreview
@@ -68,11 +68,20 @@ describe("chatArtifactSidebar: inline anchor chip behavior", () => {
     const chip = screen.getByTestId("attachment-preview-text");
     expect(chip.tagName).toBe("A");
     expect(chip).toHaveAttribute("href", "https://example.com/notes.txt");
+    expect(chip).toHaveClass("group/doc-preview", "w-fit");
+    expect(chip.firstElementChild).toHaveClass(
+      "aspect-[4/3]",
+      "w-[144px]",
+      "sm:w-[168px]",
+    );
+    expect(
+      within(chip).getByTestId("attachment-preview-text-icon"),
+    ).toBeInTheDocument();
     // The inline <pre> body should NOT be present on the ON path.
     expect(screen.queryByText(/notes\.txt/)).toBeInTheDocument();
   });
 
-  it("renders a .md attachment as an anchor chip when the switch is on", () => {
+  it("renders a .md attachment as a thumbnail anchor when the switch is on", () => {
     setup();
     renderWithStore(
       <AttachmentPreview
@@ -86,6 +95,11 @@ describe("chatArtifactSidebar: inline anchor chip behavior", () => {
     const chip = screen.getByTestId("attachment-preview-markdown");
     expect(chip.tagName).toBe("A");
     expect(chip).toHaveAttribute("href", "https://example.com/readme.md");
+    expect(chip.firstElementChild).toHaveClass(
+      "aspect-[4/3]",
+      "w-[144px]",
+      "sm:w-[168px]",
+    );
   });
 
   it("opens the attachment lightbox on plain click", () => {

--- a/turbo/apps/platform/src/views/zero-page/__tests__/zero-artifact-sidebar.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/zero-artifact-sidebar.test.tsx
@@ -283,12 +283,12 @@ describe("chatArtifactSidebar: image preview zoom controls", () => {
     const level = screen.getByTestId("artifact-sidebar-image-zoom-level");
 
     fireEvent.click(zoomIn);
-    expect(level.textContent).toBe("125%");
+    expect(level.textContent).toBe("115%");
     fireEvent.click(zoomIn);
-    expect(level.textContent).toBe("150%");
+    expect(level.textContent).toBe("130%");
 
     fireEvent.click(zoomOut);
-    expect(level.textContent).toBe("125%");
+    expect(level.textContent).toBe("115%");
   });
 
   it("disables zoom out at min zoom and zoom in at max zoom", () => {
@@ -296,13 +296,13 @@ describe("chatArtifactSidebar: image preview zoom controls", () => {
     const zoomIn = screen.getByTestId("artifact-sidebar-image-zoom-in");
     const zoomOut = screen.getByTestId("artifact-sidebar-image-zoom-out");
 
-    // Step is 0.25; min is 0.5 (so 2 outs from 1 reaches min), max is 3 (8 ins).
-    for (let i = 0; i < 2; i += 1) {
+    // Step is 0.15; min is 0.5 and max is 3.
+    for (let i = 0; i < 4; i += 1) {
       fireEvent.click(zoomOut);
     }
     expect(zoomOut).toBeDisabled();
 
-    for (let i = 0; i < 10; i += 1) {
+    for (let i = 0; i < 17; i += 1) {
       fireEvent.click(zoomIn);
     }
     expect(zoomIn).toBeDisabled();

--- a/turbo/apps/platform/src/views/zero-page/__tests__/zero-artifact-sidebar.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/zero-artifact-sidebar.test.tsx
@@ -268,9 +268,10 @@ describe("chatArtifactSidebar: image preview zoom controls", () => {
 
   it("renders the zoom toolbar on the image body at 100%", () => {
     renderImageSidebar();
-    expect(screen.getByTestId("artifact-sidebar-stage")).toHaveClass(
-      "overflow-hidden",
-    );
+    const stage = screen.getByTestId("artifact-sidebar-stage");
+    expect(stage).toHaveClass("overflow-hidden");
+    expect(stage).not.toHaveClass("p-5");
+    expect(stage.firstElementChild).toHaveClass("max-w-none");
     expect(screen.getByTestId("artifact-sidebar-body-image")).toHaveClass(
       "max-h-full",
       "max-w-full",

--- a/turbo/apps/platform/src/views/zero-page/__tests__/zero-artifact-sidebar.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/zero-artifact-sidebar.test.tsx
@@ -279,6 +279,9 @@ describe("chatArtifactSidebar: image preview zoom controls", () => {
       screen.getByTestId("artifact-sidebar-image-zoom-controls"),
     ).toBeInTheDocument();
     expect(
+      screen.getByTestId("artifact-sidebar-image-reset-zoom"),
+    ).toBeInTheDocument();
+    expect(
       screen.getByTestId("artifact-sidebar-image-zoom-level").textContent,
     ).toBe("100%");
   });
@@ -296,6 +299,9 @@ describe("chatArtifactSidebar: image preview zoom controls", () => {
 
     fireEvent.click(zoomOut);
     expect(level.textContent).toBe("115%");
+
+    fireEvent.click(screen.getByTestId("artifact-sidebar-image-reset-zoom"));
+    expect(level.textContent).toBe("100%");
   });
 
   it("disables zoom out at min zoom and zoom in at max zoom", () => {

--- a/turbo/apps/platform/src/views/zero-page/__tests__/zero-attachment-chips.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/zero-attachment-chips.test.tsx
@@ -5,6 +5,7 @@ import { http, HttpResponse } from "msw";
 import { toast } from "@vm0/ui/components/ui/sonner";
 import { chatMessagesContract } from "@vm0/api-contracts/contracts/chat-threads";
 import { zeroUploadsContract } from "@vm0/api-contracts/contracts/zero-uploads";
+import { FeatureSwitchKey } from "@vm0/connectors/feature-switch-key";
 import { server } from "../../../mocks/server.ts";
 import { testContext } from "../../../signals/__tests__/test-helpers.ts";
 import { detachedSetupPage, click } from "../../../__tests__/page-helper.ts";
@@ -29,6 +30,12 @@ const context = testContext();
 const mockApi = createMockApi(context);
 const attachmentLogger = getLoggers()["zero-attachment-chips"];
 const attachmentLoggerLevel = attachmentLogger?.level;
+
+function chatArtifactSidebarOff() {
+  return {
+    [FeatureSwitchKey.ChatArtifactSidebar]: false,
+  };
+}
 
 beforeEach(() => {
   if (attachmentLogger) {
@@ -254,7 +261,11 @@ describe("chat-i-059: image preview button opens lightbox", () => {
     );
     mockChatAPI();
 
-    detachedSetupPage({ context, path: "/" });
+    detachedSetupPage({
+      context,
+      path: "/",
+      featureSwitches: chatArtifactSidebarOff(),
+    });
 
     await waitFor(() => {
       expect(screen.getByPlaceholderText(PLACEHOLDER)).toBeInTheDocument();
@@ -295,7 +306,11 @@ describe("chat-i-059: image preview button opens lightbox", () => {
     );
     mockChatAPI();
 
-    detachedSetupPage({ context, path: "/" });
+    detachedSetupPage({
+      context,
+      path: "/",
+      featureSwitches: chatArtifactSidebarOff(),
+    });
 
     await waitFor(() => {
       expect(screen.getByPlaceholderText(PLACEHOLDER)).toBeInTheDocument();
@@ -549,7 +564,11 @@ describe("chat-i-066: lightbox download fetches blobs", () => {
     );
     mockChatAPI();
 
-    detachedSetupPage({ context, path: "/" });
+    detachedSetupPage({
+      context,
+      path: "/",
+      featureSwitches: chatArtifactSidebarOff(),
+    });
 
     await waitFor(() => {
       expect(screen.getByPlaceholderText(PLACEHOLDER)).toBeInTheDocument();

--- a/turbo/apps/platform/src/views/zero-page/__tests__/zero-attachment-chips.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/zero-attachment-chips.test.tsx
@@ -331,7 +331,7 @@ describe("chat-i-059: image preview button opens lightbox", () => {
     expect(screen.getByText("100%")).toBeInTheDocument();
     await user.click(screen.getByLabelText("Zoom in"));
     await waitFor(() => {
-      expect(screen.getByText("125%")).toBeInTheDocument();
+      expect(screen.getByText("115%")).toBeInTheDocument();
     });
 
     await user.click(screen.getByLabelText("Zoom out"));
@@ -341,7 +341,7 @@ describe("chat-i-059: image preview button opens lightbox", () => {
 
     await user.click(screen.getByLabelText("Zoom in"));
     await waitFor(() => {
-      expect(screen.getByText("125%")).toBeInTheDocument();
+      expect(screen.getByText("115%")).toBeInTheDocument();
     });
     await user.click(screen.getByLabelText("Reset zoom"));
     await waitFor(() => {
@@ -350,7 +350,7 @@ describe("chat-i-059: image preview button opens lightbox", () => {
 
     fireEvent.keyDown(document, { key: "=", metaKey: true });
     await waitFor(() => {
-      expect(screen.getByText("125%")).toBeInTheDocument();
+      expect(screen.getByText("115%")).toBeInTheDocument();
     });
 
     fireEvent.keyDown(document, { key: "-", metaKey: true });

--- a/turbo/apps/platform/src/views/zero-page/__tests__/zero-attachment-preview.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/zero-attachment-preview.test.tsx
@@ -6,7 +6,7 @@
  * via render rather than direct calls.
  */
 
-import { describe, expect, it } from "vitest";
+import { beforeEach, describe, expect, it } from "vitest";
 import {
   fireEvent,
   render,
@@ -16,16 +16,41 @@ import {
 } from "@testing-library/react";
 import { StoreProvider } from "ccstate-react";
 import { computed } from "ccstate";
+import { FeatureSwitchKey } from "@vm0/connectors/feature-switch-key";
 import { server } from "../../../mocks/server.ts";
 import { http, HttpResponse } from "msw";
 import { testContext } from "../../../signals/__tests__/test-helpers.ts";
 import { queryAllByRoleFast } from "../../../__tests__/page-helper.ts";
+import {
+  clearMockedAuth,
+  mockOrganization,
+  mockUser,
+} from "../../../__tests__/mock-auth.ts";
 import { createDeferredPromise } from "../../../signals/utils.ts";
 import { fetchPreviewText } from "../../../signals/chat-page/parse-body-blocks.ts";
-import { lightboxUrl$ } from "../../../signals/zero-page/zero-attachment-chips.ts";
+import { reloadFeatureSwitch$ } from "../../../signals/external/feature-switch.ts";
+import { setMockFeatureSwitches } from "../../../mocks/handlers/api-feature-switches.helpers.ts";
+import {
+  closeLightbox$,
+  lightboxUrl$,
+} from "../../../signals/zero-page/zero-attachment-chips.ts";
 import { AttachmentPreview } from "../zero-attachment-preview.tsx";
 
 const context = testContext();
+
+beforeEach(async () => {
+  mockUser({ id: "test-user-123", fullName: "Test User" }, { token: "test" });
+  mockOrganization({
+    activeOrg: { id: "org_default", name: "Default Org" },
+    memberships: [{ id: "org_default" }],
+  });
+  context.signal.addEventListener("abort", () => {
+    clearMockedAuth();
+  });
+  setMockFeatureSwitches({ [FeatureSwitchKey.ChatArtifactSidebar]: false });
+  await context.store.set(reloadFeatureSwitch$, context.signal);
+  context.store.set(closeLightbox$);
+});
 
 // =============================================================================
 // AttachmentPreview component — render matrix
@@ -122,11 +147,22 @@ describe("attachment preview component", () => {
       url: "https://example.com/clip.mp3",
     });
     const preview = screen.getByTestId("attachment-preview-audio");
+
     expect(preview).toBeInTheDocument();
-    expect(screen.getByLabelText("Audio preview for clip.mp3")).toHaveAttribute(
-      "src",
-      "https://example.com/clip.mp3",
-    );
+    expect(preview).toHaveAttribute("type", "button");
+    expect(preview.firstElementChild).toHaveClass("aspect-[4/3]");
+    expect(
+      within(preview).getByTestId("attachment-preview-audio-icon"),
+    ).toBeInTheDocument();
+
+    fireEvent.click(preview);
+
+    expect(context.store.get(lightboxUrl$)).toStrictEqual({
+      kind: "audio",
+      filename: "clip.mp3",
+      url: "https://example.com/clip.mp3",
+    });
+    context.store.set(closeLightbox$);
   });
 
   it("should render null for image files (.svg)", () => {
@@ -623,6 +659,8 @@ describe("document thumbnail preview", () => {
         />
       </StoreProvider>,
     );
+
+    context.store.set(closeLightbox$);
 
     fireEvent.click(screen.getByTestId("attachment-preview-html"), {
       metaKey: true,

--- a/turbo/apps/platform/src/views/zero-page/__tests__/zero-attachment-preview.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/zero-attachment-preview.test.tsx
@@ -146,6 +146,8 @@ describe("attachment preview component", () => {
     const video = preview.querySelector("video");
 
     expect(preview).toBeInTheDocument();
+    expect(preview).toHaveClass("w-[min(100%,400px)]");
+    expect(preview.firstElementChild).toHaveClass("aspect-[16/10]");
     expect(
       screen.getByLabelText("Open video preview for video.mp4"),
     ).toHaveAttribute("type", "button");

--- a/turbo/apps/platform/src/views/zero-page/__tests__/zero-chat-thread-page-display.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/zero-chat-thread-page-display.test.tsx
@@ -257,6 +257,7 @@ describe("zero chat thread page display - attachment image preview", () => {
       "href",
       "https://example.com/photo.png",
     );
+    expect(previewLink).toHaveClass("w-[min(100%,400px)]", "aspect-[16/10]");
     const previewImage = within(previewLink).getByAltText("photo.png");
     expect(previewImage).toBeInTheDocument();
     expect(
@@ -1135,6 +1136,7 @@ describe("zero chat thread page display - attachment video preview", () => {
     });
     const posterVideo = previewButton.querySelector("video");
 
+    expect(previewButton).toHaveClass("w-[min(100%,400px)]", "aspect-[16/10]");
     expect(
       within(previewButton).getByTestId("chat-video-preview-poster"),
     ).toBeInTheDocument();
@@ -1691,7 +1693,21 @@ describe("zero chat thread page display - artifacts drawer", () => {
     expect(search()).not.toContain("artifacts=");
     expect(search()).not.toContain("artifact=");
 
-    await user.click(within(lightbox).getByLabelText("Open in split view"));
+    await user.click(within(lightbox).getByLabelText("Zoom in"));
+    expect(within(lightbox).getByText("115%")).toBeInTheDocument();
+
+    await user.click(within(lightbox).getByLabelText("Enter fullscreen"));
+    const fullscreenLightbox = await screen.findByTestId("attachment-lightbox");
+    await waitFor(() => {
+      expect(within(fullscreenLightbox).getByText("100%")).toBeInTheDocument();
+    });
+    expect(
+      within(fullscreenLightbox).getByLabelText("Exit fullscreen"),
+    ).toBeInTheDocument();
+
+    await user.click(
+      within(fullscreenLightbox).getByLabelText("Open in split view"),
+    );
 
     await expect(
       screen.findByTestId("artifact-sidebar"),

--- a/turbo/apps/platform/src/views/zero-page/__tests__/zero-chat-thread-page-display.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/zero-chat-thread-page-display.test.tsx
@@ -1157,8 +1157,44 @@ describe("zero chat thread page display - attachment video preview", () => {
     expect(video).toHaveAttribute("src", videoUrl);
     expect(video).toHaveAttribute("controls");
     expect((video as HTMLVideoElement).autoplay).toBeTruthy();
-    expect(within(lightbox).getByLabelText("Copy link")).toBeInTheDocument();
+    expect(within(lightbox).getByLabelText("Share")).toBeInTheDocument();
     expect(within(lightbox).getByLabelText("Download")).toBeInTheDocument();
+  });
+
+  it("uses the padded artifact dialog stage for video previews when enabled", async () => {
+    const videoUrl = "https://example.com/clip.mp4";
+    mockChatLifecycle({
+      chatMessages: [
+        {
+          role: "user",
+          content: `[Attached file: clip.mp4](${videoUrl})\nDownload with: curl ${videoUrl}\n`,
+          createdAt: "2026-03-10T00:00:00Z",
+        },
+      ],
+    });
+
+    detachedSetupPage({
+      context,
+      path: "/chats/thread-test-1",
+      featureSwitches: {
+        [FeatureSwitchKey.ChatArtifactSidebar]: true,
+      },
+    });
+
+    await userEvent.click(await screen.findByLabelText("Preview clip.mp4"));
+
+    const lightbox = await screen.findByTestId("attachment-lightbox");
+    const stage = within(lightbox).getByTestId("artifact-dialog-stage");
+    const videoStage = within(lightbox).getByTestId(
+      "artifact-dialog-video-stage",
+    );
+    const video = within(videoStage).getByLabelText(
+      "Video preview for clip.mp4",
+    );
+
+    expect(stage).toHaveClass("bg-muted/30", "p-5");
+    expect(videoStage).toHaveClass("rounded-xl", "border", "bg-black");
+    expect(video).toHaveClass("aspect-video", "object-contain");
   });
 });
 
@@ -1532,6 +1568,10 @@ describe("zero chat thread page display - artifacts drawer", () => {
     const sidebar = await screen.findByTestId("artifact-sidebar");
     expect(sidebar).toBeInTheDocument();
     expect(screen.getByLabelText("Back to all artifacts")).toBeInTheDocument();
+    expect(within(sidebar).getByText("chart.png")).toBeInTheDocument();
+    expect(
+      within(sidebar).getByText(/Image · PNG · 4\.0 KB · Generated/u),
+    ).toBeInTheDocument();
     expect(
       screen.getByTestId("artifact-sidebar-image-zoom-controls"),
     ).toBeInTheDocument();
@@ -1559,6 +1599,145 @@ describe("zero chat thread page display - artifacts drawer", () => {
       expect(screen.queryByTestId("artifact-inbox")).not.toBeInTheDocument();
     });
     expect(search()).not.toContain("artifacts=");
+  });
+
+  it("opens chat previews in a modal before split view", async () => {
+    const user = userEvent.setup();
+    const imageUrl =
+      "https://www.vm0.ai/f/user_123/3a474c61-ffe4-4e56-b9e7-0185b3dba9f7/chart.png";
+    server.use(
+      http.get(imageUrl, () => {
+        return new HttpResponse("png", {
+          headers: { "Content-Type": "image/png" },
+        });
+      }),
+      mockApi(chatThreadArtifactsContract.list, ({ respond }) => {
+        return respond(200, {
+          runs: [
+            {
+              runId: "run-chat-preview-artifact",
+              files: [
+                {
+                  id: "file-image",
+                  filename: "chart.png",
+                  contentType: "image/png",
+                  size: 4096,
+                  url: imageUrl,
+                  createdAt: "2026-03-10T00:00:00Z",
+                },
+              ],
+            },
+          ],
+        });
+      }),
+    );
+    mockChatLifecycle({
+      chatMessages: [
+        {
+          role: "assistant",
+          content: `Generated chart:\n\n${imageUrl}`,
+          runId: "run-chat-preview-artifact",
+          createdAt: "2026-03-10T00:00:00Z",
+        },
+      ],
+    });
+
+    detachedSetupPage({
+      context,
+      path: "/chats/thread-test-1",
+      featureSwitches: {
+        [FeatureSwitchKey.ChatArtifactSidebar]: true,
+      },
+    });
+
+    await user.click(await screen.findByLabelText("Preview chart.png"));
+
+    const lightbox = await screen.findByTestId("attachment-lightbox");
+    expect(lightbox).toBeInTheDocument();
+    expect(screen.getByRole("dialog", { name: "chart.png preview" })).toBe(
+      lightbox,
+    );
+    expect(within(lightbox).getByText("chart.png")).toBeInTheDocument();
+    expect(
+      within(lightbox).getByText(/Image · PNG · 4\.0 KB · Generated/u),
+    ).toBeInTheDocument();
+    expect(
+      within(lightbox).queryByTestId("attachment-lightbox-file-icon"),
+    ).not.toBeInTheDocument();
+    expect(screen.queryByTestId("artifact-inbox")).not.toBeInTheDocument();
+    expect(screen.queryByTestId("artifact-sidebar")).not.toBeInTheDocument();
+    expect(search()).not.toContain("artifacts=");
+    expect(search()).not.toContain("artifact=");
+
+    await user.click(within(lightbox).getByLabelText("Open in split view"));
+
+    await expect(
+      screen.findByTestId("artifact-sidebar"),
+    ).resolves.toBeInTheDocument();
+    await waitFor(() => {
+      expect(
+        screen.queryByTestId("attachment-lightbox"),
+      ).not.toBeInTheDocument();
+    });
+    expect(screen.queryByTestId("artifact-inbox")).not.toBeInTheDocument();
+    expect(screen.queryByLabelText("Back to all artifacts")).toBeNull();
+    expect(search()).not.toContain("artifacts=");
+    expect(search()).toContain(
+      "artifact=https%3A%2F%2Fwww.vm0.ai%2Ff%2Fuser_123%2F3a474c61-ffe4-4e56-b9e7-0185b3dba9f7%2Fchart.png",
+    );
+  });
+
+  it("only shows artifact inbox filters for existing artifact types", async () => {
+    const user = userEvent.setup();
+    mockChatLifecycle({
+      chatMessages: [
+        {
+          role: "user",
+          content: "Create an image",
+          runId: "run-artifact-inbox-media",
+          createdAt: "2026-03-10T00:00:00Z",
+        },
+      ],
+    });
+    server.use(
+      mockApi(chatThreadArtifactsContract.list, ({ respond }) => {
+        return respond(200, {
+          runs: [
+            {
+              runId: "run-artifact-inbox-media",
+              files: [
+                {
+                  id: "file-image",
+                  filename: "chart.png",
+                  contentType: "image/png",
+                  size: 4096,
+                  url: "https://example.com/chart.png",
+                  createdAt: "2026-03-10T00:00:00Z",
+                },
+              ],
+            },
+          ],
+        });
+      }),
+    );
+
+    detachedSetupPage({
+      context,
+      path: "/chats/thread-test-1",
+      featureSwitches: {
+        [FeatureSwitchKey.ChatArtifactSidebar]: true,
+      },
+    });
+
+    await user.click(await screen.findByLabelText("Open artifacts"));
+
+    await expect(
+      screen.findByTestId("artifact-inbox"),
+    ).resolves.toBeInTheDocument();
+    expect(getRoleByText("tab", "All")).toBeInTheDocument();
+    expect(getRoleByText("tab", "Media")).toBeInTheDocument();
+    expect(queryRoleByText("tab", "Docs")).toBeUndefined();
+    expect(queryRoleByText("tab", "Sites")).toBeUndefined();
   });
 
   it("opens artifacts from the mobile top bar icon", async () => {
@@ -1975,14 +2154,27 @@ describe("zero chat thread page display - artifacts drawer", () => {
     click(button);
 
     await waitFor(() => {
-      expect(
-        screen.getByLabelText("Copy link for chart.png"),
-      ).toBeInTheDocument();
+      expect(screen.getByLabelText("Share chart.png")).toBeInTheDocument();
     });
-    await user.click(screen.getByLabelText("Copy link for chart.png"));
+    await user.click(screen.getByLabelText("Share chart.png"));
     expect(writeTextSpy).toHaveBeenCalledWith(publicFileUrl);
 
-    await user.click(screen.getByLabelText("Sync chart.png to Google Drive"));
+    const downloadButton = screen.getByLabelText("Download chart.png");
+    await user.hover(downloadButton);
+    await waitFor(() => {
+      expect(
+        getRoleByText("menuitem", "Upload to Google Drive"),
+      ).toBeInTheDocument();
+    });
+    fireEvent.pointerLeave(downloadButton);
+    await waitFor(() => {
+      expect(
+        queryRoleByText("menuitem", "Upload to Google Drive"),
+      ).toBeUndefined();
+    });
+
+    await user.click(downloadButton);
+    await user.click(await screen.findByText("Upload to Google Drive"));
 
     await waitFor(() => {
       expect(syncBodies).toStrictEqual([
@@ -1992,11 +2184,13 @@ describe("zero chat thread page display - artifacts drawer", () => {
         },
       ]);
     });
+    await user.click(downloadButton);
     await waitFor(() => {
       expect(
-        screen.getByLabelText("chart.png is synced to Google Drive"),
+        getRoleByText("menuitem", "Synced to Google Drive"),
       ).toHaveAttribute("aria-disabled", "true");
     });
+    await user.keyboard("{Escape}");
 
     await user.click(screen.getByLabelText("More artifact actions"));
     await user.click(screen.getByText("Sync all to Google Drive"));
@@ -2239,13 +2433,19 @@ describe("zero chat thread page display - artifacts drawer", () => {
     });
     click(button);
 
-    const syncButton = await waitFor(() => {
-      return screen.getByLabelText(
-        "Sync disconnected-chart.png to Google Drive",
-      );
+    const downloadButton = await waitFor(() => {
+      return screen.getByLabelText("Download disconnected-chart.png");
     });
 
-    await user.click(syncButton);
+    await user.click(downloadButton);
+    const connectGoogleDriveItem = await screen.findByText(
+      "Connect Google Drive",
+    );
+    await user.hover(connectGoogleDriveItem);
+    await expect(
+      screen.findAllByText("Connect Google Drive to upload artifacts"),
+    ).resolves.not.toHaveLength(0);
+    await user.click(connectGoogleDriveItem);
     await waitFor(() => {
       expect(openSpy).toHaveBeenCalledWith(
         "about:blank",

--- a/turbo/apps/platform/src/views/zero-page/__tests__/zero-chat-thread-page-display.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/zero-chat-thread-page-display.test.tsx
@@ -1670,6 +1670,9 @@ describe("zero chat thread page display - artifacts drawer", () => {
       "min-h-0",
     );
     expect(
+      within(lightbox).getByTestId("artifact-dialog-card"),
+    ).not.toHaveClass("border");
+    expect(
       within(lightbox).getByTestId("artifact-dialog-image-stage"),
     ).toHaveClass("h-full", "overflow-hidden");
     expect(screen.getByRole("dialog", { name: "chart.png preview" })).toBe(

--- a/turbo/apps/platform/src/views/zero-page/__tests__/zero-chat-thread-page-display.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/zero-chat-thread-page-display.test.tsx
@@ -1662,9 +1662,10 @@ describe("zero chat thread page display - artifacts drawer", () => {
     expect(
       within(lightbox).getByTestId("attachment-lightbox-panel"),
     ).toHaveClass("zero-dialog-enter-content");
-    expect(within(lightbox).getByTestId("artifact-dialog-stage")).toHaveClass(
-      "overflow-hidden",
-    );
+    const stage = within(lightbox).getByTestId("artifact-dialog-stage");
+    expect(stage).toHaveClass("overflow-hidden");
+    expect(stage).not.toHaveClass("p-5");
+    expect(stage.firstElementChild).toHaveClass("max-w-none");
     expect(within(lightbox).getByTestId("artifact-dialog-card")).toHaveClass(
       "h-full",
       "min-h-0",

--- a/turbo/apps/platform/src/views/zero-page/__tests__/zero-chat-thread-page-display.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/zero-chat-thread-page-display.test.tsx
@@ -1654,6 +1654,10 @@ describe("zero chat thread page display - artifacts drawer", () => {
 
     const lightbox = await screen.findByTestId("attachment-lightbox");
     expect(lightbox).toBeInTheDocument();
+    expect(lightbox).toHaveClass("animate-in", "fade-in");
+    expect(
+      within(lightbox).getByTestId("attachment-lightbox-panel"),
+    ).toHaveClass("animate-in", "slide-in-from-bottom-2");
     expect(screen.getByRole("dialog", { name: "chart.png preview" })).toBe(
       lightbox,
     );

--- a/turbo/apps/platform/src/views/zero-page/__tests__/zero-chat-thread-page-display.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/zero-chat-thread-page-display.test.tsx
@@ -1154,10 +1154,10 @@ describe("zero chat thread page display - attachment video preview", () => {
     });
     const video = within(lightbox).getByLabelText("Video preview for clip.mp4");
 
-    expect(lightbox).toHaveClass("animate-in", "fade-in", "duration-[180ms]");
+    expect(lightbox).toHaveClass("zero-dialog-enter-overlay");
     expect(
       within(lightbox).getByTestId("attachment-lightbox-panel"),
-    ).toHaveClass("animate-in", "slide-in-from-bottom-2", "duration-[180ms]");
+    ).toHaveClass("zero-dialog-enter-content");
     expect(video).toHaveAttribute("src", videoUrl);
     expect(video).toHaveAttribute("controls");
     expect((video as HTMLVideoElement).autoplay).toBeTruthy();
@@ -1658,10 +1658,20 @@ describe("zero chat thread page display - artifacts drawer", () => {
 
     const lightbox = await screen.findByTestId("attachment-lightbox");
     expect(lightbox).toBeInTheDocument();
-    expect(lightbox).toHaveClass("animate-in", "fade-in");
+    expect(lightbox).toHaveClass("zero-dialog-enter-overlay");
     expect(
       within(lightbox).getByTestId("attachment-lightbox-panel"),
-    ).toHaveClass("animate-in", "slide-in-from-bottom-2");
+    ).toHaveClass("zero-dialog-enter-content");
+    expect(within(lightbox).getByTestId("artifact-dialog-stage")).toHaveClass(
+      "overflow-hidden",
+    );
+    expect(within(lightbox).getByTestId("artifact-dialog-card")).toHaveClass(
+      "h-full",
+      "min-h-0",
+    );
+    expect(
+      within(lightbox).getByTestId("artifact-dialog-image-stage"),
+    ).toHaveClass("h-full", "overflow-hidden");
     expect(screen.getByRole("dialog", { name: "chart.png preview" })).toBe(
       lightbox,
     );

--- a/turbo/apps/platform/src/views/zero-page/__tests__/zero-chat-thread-page-display.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/zero-chat-thread-page-display.test.tsx
@@ -36,6 +36,12 @@ import { mockChatLifecycle, PLACEHOLDER } from "./chat-test-helpers.ts";
 
 const context = testContext();
 
+function chatArtifactSidebarOff() {
+  return {
+    [FeatureSwitchKey.ChatArtifactSidebar]: false,
+  };
+}
+
 function queryRoleByText(
   role: Parameters<typeof queryAllByRoleFast>[0],
   text: string,
@@ -155,6 +161,7 @@ describe("zero chat thread page display - permission action card", () => {
     detachedSetupPage({
       context,
       path: "/chats/thread-test-1",
+      featureSwitches: chatArtifactSidebarOff(),
     });
 
     const card = await waitFor(() => {
@@ -190,6 +197,7 @@ describe("zero chat thread page display - permission action card", () => {
     detachedSetupPage({
       context,
       path: "/chats/thread-test-1",
+      featureSwitches: chatArtifactSidebarOff(),
     });
 
     const card = await waitFor(() => {
@@ -218,6 +226,7 @@ describe("zero chat thread page display - permission action card", () => {
     detachedSetupPage({
       context,
       path: "/chats/thread-test-1",
+      featureSwitches: chatArtifactSidebarOff(),
     });
 
     const card = await waitFor(() => {
@@ -248,7 +257,11 @@ describe("zero chat thread page display - attachment image preview", () => {
       ],
     });
 
-    detachedSetupPage({ context, path: "/chats/thread-test-1" });
+    detachedSetupPage({
+      context,
+      path: "/chats/thread-test-1",
+      featureSwitches: chatArtifactSidebarOff(),
+    });
 
     const previewLink = await waitFor(() => {
       return screen.getByLabelText("Preview photo.png");
@@ -274,7 +287,8 @@ describe("zero chat thread page display - attachment image preview", () => {
 });
 
 describe("zero chat thread page display - attachment audio chip", () => {
-  it("renders audio attachment as a compact download chip", async () => {
+  it("renders audio attachment as a compact preview chip", async () => {
+    const user = userEvent.setup();
     mockChatLifecycle({
       chatMessages: [
         {
@@ -294,16 +308,27 @@ describe("zero chat thread page display - attachment audio chip", () => {
       ],
     });
 
-    detachedSetupPage({ context, path: "/chats/thread-test-1" });
-
-    const download = await waitFor(() => {
-      return screen.getByLabelText("Download clip.mp3");
+    detachedSetupPage({
+      context,
+      path: "/chats/thread-test-1",
+      featureSwitches: chatArtifactSidebarOff(),
     });
-    expect(download).toHaveAttribute("type", "button");
-    expect(download).not.toHaveAttribute("href");
+
+    const preview = await waitFor(() => {
+      return screen.getByLabelText("Open audio preview for clip.mp3");
+    });
+    expect(preview).toHaveAttribute("type", "button");
+    expect(preview).not.toHaveAttribute("href");
     expect(
-      within(download).getByTestId("attachment-chip-file-icon"),
+      within(preview).getByTestId("attachment-chip-file-icon"),
     ).toBeInTheDocument();
+
+    await user.click(preview);
+
+    const lightbox = await screen.findByTestId("attachment-lightbox");
+    expect(
+      within(lightbox).getByLabelText("Audio preview for clip.mp3"),
+    ).toHaveAttribute("src", "https://example.com/clip.mp3");
   });
 });
 
@@ -331,7 +356,11 @@ describe("zero chat thread page display - attachment document preview", () => {
       ],
     });
 
-    detachedSetupPage({ context, path: "/chats/thread-test-1" });
+    detachedSetupPage({
+      context,
+      path: "/chats/thread-test-1",
+      featureSwitches: chatArtifactSidebarOff(),
+    });
 
     await waitFor(() => {
       expect(
@@ -379,7 +408,11 @@ describe("zero chat thread page display - body link document preview", () => {
       ],
     });
 
-    detachedSetupPage({ context, path: "/chats/thread-test-1" });
+    detachedSetupPage({
+      context,
+      path: "/chats/thread-test-1",
+      featureSwitches: chatArtifactSidebarOff(),
+    });
 
     await waitFor(() => {
       expect(
@@ -413,7 +446,11 @@ describe("zero chat thread page display - body link document preview", () => {
       ],
     });
 
-    detachedSetupPage({ context, path: "/chats/thread-test-1" });
+    detachedSetupPage({
+      context,
+      path: "/chats/thread-test-1",
+      featureSwitches: chatArtifactSidebarOff(),
+    });
 
     await waitFor(() => {
       expect(screen.getByText("notes")).toBeInTheDocument();
@@ -467,7 +504,11 @@ describe("zero chat thread page display - body link document preview", () => {
         ],
       });
 
-      detachedSetupPage({ context, path: "/chats/thread-test-1" });
+      detachedSetupPage({
+        context,
+        path: "/chats/thread-test-1",
+        featureSwitches: chatArtifactSidebarOff(),
+      });
 
       const preview = await screen.findByTestId("attachment-preview-file");
       expect(
@@ -733,7 +774,11 @@ describe("zero chat thread page display - body link document preview", () => {
       ],
     });
 
-    detachedSetupPage({ context, path: "/chats/thread-test-1" });
+    detachedSetupPage({
+      context,
+      path: "/chats/thread-test-1",
+      featureSwitches: chatArtifactSidebarOff(),
+    });
 
     await waitFor(() => {
       expect(screen.getByTestId("attachment-preview-json")).toBeInTheDocument();
@@ -770,7 +815,11 @@ describe("zero chat thread page display - body link document preview", () => {
       ],
     });
 
-    detachedSetupPage({ context, path: "/chats/thread-test-1" });
+    detachedSetupPage({
+      context,
+      path: "/chats/thread-test-1",
+      featureSwitches: chatArtifactSidebarOff(),
+    });
 
     await waitFor(() => {
       expect(screen.getByTestId("attachment-preview-pdf")).toBeInTheDocument();
@@ -855,7 +904,11 @@ describe("zero chat thread page display - body link document preview", () => {
       ],
     });
 
-    detachedSetupPage({ context, path: "/chats/thread-test-1" });
+    detachedSetupPage({
+      context,
+      path: "/chats/thread-test-1",
+      featureSwitches: chatArtifactSidebarOff(),
+    });
 
     await waitFor(() => {
       expect(screen.getByTestId("attachment-preview-text")).toBeInTheDocument();
@@ -914,7 +967,11 @@ describe("zero chat thread page display - body link document preview", () => {
         ],
       });
 
-      detachedSetupPage({ context, path: "/chats/thread-test-1" });
+      detachedSetupPage({
+        context,
+        path: "/chats/thread-test-1",
+        featureSwitches: chatArtifactSidebarOff(),
+      });
 
       await waitFor(() => {
         const textPreview = screen.getByTestId("attachment-preview-text");
@@ -941,7 +998,11 @@ describe("zero chat thread page display - body link document preview", () => {
       ],
     });
 
-    detachedSetupPage({ context, path: "/chats/thread-test-1" });
+    detachedSetupPage({
+      context,
+      path: "/chats/thread-test-1",
+      featureSwitches: chatArtifactSidebarOff(),
+    });
 
     await waitFor(() => {
       const preview = screen.getByTestId("attachment-preview-file");
@@ -1129,7 +1190,11 @@ describe("zero chat thread page display - attachment video preview", () => {
       ],
     });
 
-    detachedSetupPage({ context, path: "/chats/thread-test-1" });
+    detachedSetupPage({
+      context,
+      path: "/chats/thread-test-1",
+      featureSwitches: chatArtifactSidebarOff(),
+    });
 
     const previewButton = await waitFor(() => {
       return screen.getByLabelText("Preview clip.mp4");
@@ -1406,6 +1471,7 @@ describe("zero chat thread page display - artifacts drawer", () => {
     detachedSetupPage({
       context,
       path: "/chats/thread-test-1",
+      featureSwitches: chatArtifactSidebarOff(),
     });
 
     const button = await waitFor(() => {
@@ -1509,6 +1575,14 @@ describe("zero chat thread page display - artifacts drawer", () => {
                   createdAt: "2026-03-10T00:00:00Z",
                 },
                 {
+                  id: "file-video",
+                  filename: "demo.mp4",
+                  contentType: "video/mp4",
+                  size: 16_384,
+                  url: "https://example.com/demo.mp4",
+                  createdAt: "2026-03-10T00:00:00Z",
+                },
+                {
                   id: "file-site",
                   filename: "landing.html",
                   contentType: "text/html",
@@ -1551,6 +1625,15 @@ describe("zero chat thread page display - artifacts drawer", () => {
     expect(
       getRoleByAriaLabel("button", "Open artifact landing.html"),
     ).toBeInTheDocument();
+    const videoRow = getRoleByAriaLabel("button", "Open artifact demo.mp4");
+    expect(
+      within(videoRow).getByTestId("artifact-video-preview-badge"),
+    ).toHaveAttribute("src", "https://example.com/demo.mp4#t=0.001");
+    const siteRow = getRoleByAriaLabel("button", "Open artifact landing.html");
+    expect(
+      within(siteRow).getByTestId("artifact-html-preview-badge"),
+    ).toBeInTheDocument();
+    expect(within(inbox).queryByText("Live")).not.toBeInTheDocument();
 
     await user.click(getRoleByText("tab", "Sites"));
     expect(
@@ -1814,6 +1897,7 @@ describe("zero chat thread page display - artifacts drawer", () => {
     detachedSetupPage({
       context,
       path: "/chats/thread-test-1",
+      featureSwitches: chatArtifactSidebarOff(),
     });
 
     click(
@@ -1875,6 +1959,7 @@ describe("zero chat thread page display - artifacts drawer", () => {
     detachedSetupPage({
       context,
       path: "/chats/thread-test-1",
+      featureSwitches: chatArtifactSidebarOff(),
     });
 
     click(
@@ -1938,6 +2023,7 @@ describe("zero chat thread page display - artifacts drawer", () => {
     detachedSetupPage({
       context,
       path: "/chats/thread-test-1",
+      featureSwitches: chatArtifactSidebarOff(),
     });
 
     click(
@@ -1998,6 +2084,7 @@ describe("zero chat thread page display - artifacts drawer", () => {
     detachedSetupPage({
       context,
       path: "/chats/thread-test-1",
+      featureSwitches: chatArtifactSidebarOff(),
     });
 
     click(
@@ -2184,6 +2271,7 @@ describe("zero chat thread page display - artifacts drawer", () => {
     detachedSetupPage({
       context,
       path: "/chats/thread-test-1",
+      featureSwitches: chatArtifactSidebarOff(),
     });
 
     const button = await waitFor(() => {
@@ -2353,6 +2441,7 @@ describe("zero chat thread page display - artifacts drawer", () => {
     detachedSetupPage({
       context,
       path: "/chats/thread-test-1",
+      featureSwitches: chatArtifactSidebarOff(),
     });
 
     const button = await waitFor(() => {
@@ -2464,6 +2553,7 @@ describe("zero chat thread page display - artifacts drawer", () => {
     detachedSetupPage({
       context,
       path: "/chats/thread-test-1",
+      featureSwitches: chatArtifactSidebarOff(),
     });
 
     const button = await waitFor(() => {

--- a/turbo/apps/platform/src/views/zero-page/__tests__/zero-chat-thread-page-display.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/zero-chat-thread-page-display.test.tsx
@@ -12,6 +12,7 @@ import {
 import { mockApi } from "../../../mocks/msw-contract.ts";
 import { hasSubscription, triggerAblyEvent } from "../../../mocks/ably.ts";
 import { updateChatArtifacts } from "../../../mocks/mock-helpers.ts";
+import { search } from "../../../signals/location.ts";
 import {
   chatMessagesContract,
   chatThreadArtifactsContract,
@@ -60,6 +61,15 @@ function queryRoleByAriaLabel(
   return queryAllByRoleFast(role).find((element) => {
     return element.getAttribute("aria-label") === label;
   });
+}
+
+function getRoleByAriaLabel(
+  role: Parameters<typeof queryAllByRoleFast>[0],
+  label: string,
+): HTMLElement {
+  const element = queryRoleByAriaLabel(role, label);
+  expect(element).toBeDefined();
+  return element!;
 }
 
 function mockConnectorOauthStart() {
@@ -1417,6 +1427,138 @@ describe("zero chat thread page display - artifacts drawer", () => {
       expect(within(table).getByText("alpha")).toBeInTheDocument();
       expect(within(table).getByText("1")).toBeInTheDocument();
     });
+  });
+
+  it("opens the artifact inbox sidebar when the sidebar feature is enabled", async () => {
+    const user = userEvent.setup();
+    let artifactsRequests = 0;
+    mockChatLifecycle({
+      chatMessages: [
+        {
+          role: "user",
+          content: "Create files",
+          runId: "run-artifact-inbox",
+          createdAt: "2026-03-10T00:00:00Z",
+        },
+      ],
+    });
+    server.use(
+      mockApi(chatThreadArtifactsContract.list, ({ respond }) => {
+        artifactsRequests += 1;
+        return respond(200, {
+          runs: [
+            {
+              runId: "run-artifact-inbox",
+              files: [
+                {
+                  id: "file-image",
+                  filename: "chart.png",
+                  contentType: "image/png",
+                  size: 4096,
+                  url: "https://example.com/chart.png",
+                  createdAt: "2026-03-10T00:00:00Z",
+                },
+                {
+                  id: "file-data",
+                  filename: "data.csv",
+                  contentType: "text/csv",
+                  size: 2048,
+                  url: "https://example.com/data.csv",
+                  createdAt: "2026-03-10T00:00:00Z",
+                },
+                {
+                  id: "file-site",
+                  filename: "landing.html",
+                  contentType: "text/html",
+                  size: 8192,
+                  url: "https://preview.sites.vm7.io",
+                  createdAt: "2026-03-10T00:00:00Z",
+                },
+              ],
+            },
+          ],
+        });
+      }),
+    );
+
+    detachedSetupPage({
+      context,
+      path: "/chats/thread-test-1",
+      featureSwitches: {
+        [FeatureSwitchKey.ChatArtifactSidebar]: true,
+      },
+    });
+
+    const button = await waitFor(() => {
+      return screen.getByLabelText("Open artifacts");
+    });
+    expect(artifactsRequests).toBe(0);
+    await user.click(button);
+
+    const inbox = await screen.findByTestId("artifact-inbox");
+    expect(inbox).toBeInTheDocument();
+    expect(screen.queryByRole("dialog", { name: "Artifacts" })).toBeNull();
+    expect(artifactsRequests).toBeGreaterThan(0);
+    expect(search()).toContain("artifacts=thread-test-1");
+    expect(
+      getRoleByAriaLabel("button", "Open artifact chart.png"),
+    ).toBeInTheDocument();
+    expect(
+      getRoleByAriaLabel("button", "Open artifact data.csv"),
+    ).toBeInTheDocument();
+    expect(
+      getRoleByAriaLabel("button", "Open artifact landing.html"),
+    ).toBeInTheDocument();
+
+    await user.click(getRoleByText("tab", "Sites"));
+    expect(
+      getRoleByAriaLabel("button", "Open artifact landing.html"),
+    ).toBeInTheDocument();
+    expect(
+      queryRoleByAriaLabel("button", "Open artifact chart.png"),
+    ).toBeUndefined();
+
+    await user.click(getRoleByText("tab", "Docs"));
+    expect(
+      getRoleByAriaLabel("button", "Open artifact data.csv"),
+    ).toBeInTheDocument();
+    expect(
+      queryRoleByAriaLabel("button", "Open artifact landing.html"),
+    ).toBeUndefined();
+
+    await user.click(getRoleByText("tab", "Media"));
+    await user.click(getRoleByAriaLabel("button", "Open artifact chart.png"));
+
+    const sidebar = await screen.findByTestId("artifact-sidebar");
+    expect(sidebar).toBeInTheDocument();
+    expect(screen.getByLabelText("Back to all artifacts")).toBeInTheDocument();
+    expect(
+      screen.getByTestId("artifact-sidebar-image-zoom-controls"),
+    ).toBeInTheDocument();
+    expect(search()).toContain(
+      "artifact=https%3A%2F%2Fexample.com%2Fchart.png",
+    );
+
+    await user.click(screen.getByTestId("artifact-sidebar-fullscreen-toggle"));
+    expect(screen.getByTestId("artifact-sidebar")).toHaveClass("fixed");
+    expect(search()).toContain("artifact-fullscreen=1");
+
+    await user.click(screen.getByLabelText("Back to all artifacts"));
+    await expect(
+      screen.findByTestId("artifact-inbox"),
+    ).resolves.toBeInTheDocument();
+    expect(search()).toContain("artifacts=thread-test-1");
+    expect(search()).not.toContain("artifact=");
+    expect(search()).not.toContain("artifact-fullscreen=");
+
+    await user.click(screen.getByTestId("artifact-inbox-fullscreen-toggle"));
+    expect(screen.getByTestId("artifact-inbox")).toHaveClass("fixed");
+
+    await user.click(screen.getByLabelText("Close artifacts"));
+    await waitFor(() => {
+      expect(screen.queryByTestId("artifact-inbox")).not.toBeInTheDocument();
+    });
+    expect(search()).not.toContain("artifacts=");
   });
 
   it("opens artifacts from the mobile top bar icon", async () => {

--- a/turbo/apps/platform/src/views/zero-page/__tests__/zero-chat-thread-page-display.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/zero-chat-thread-page-display.test.tsx
@@ -1154,6 +1154,10 @@ describe("zero chat thread page display - attachment video preview", () => {
     });
     const video = within(lightbox).getByLabelText("Video preview for clip.mp4");
 
+    expect(lightbox).toHaveClass("animate-in", "fade-in", "duration-[180ms]");
+    expect(
+      within(lightbox).getByTestId("attachment-lightbox-panel"),
+    ).toHaveClass("animate-in", "slide-in-from-bottom-2", "duration-[180ms]");
     expect(video).toHaveAttribute("src", videoUrl);
     expect(video).toHaveAttribute("controls");
     expect((video as HTMLVideoElement).autoplay).toBeTruthy();

--- a/turbo/apps/platform/src/views/zero-page/__tests__/zero-chat-thread-page-interaction.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/zero-chat-thread-page-interaction.test.tsx
@@ -12,6 +12,7 @@ import {
   chatMessagesContract,
   chatThreadMessagesContract,
 } from "@vm0/api-contracts/contracts/chat-threads";
+import { FeatureSwitchKey } from "@vm0/connectors/feature-switch-key";
 import { server } from "../../../mocks/server.ts";
 import { mockApi } from "../../../mocks/msw-contract.ts";
 import { setMockBillingStatus } from "../../../mocks/handlers/api-billing.ts";
@@ -33,6 +34,12 @@ import {
 const context = testContext();
 
 const THREAD_ID = "thread-test-1";
+
+function chatArtifactSidebarOff() {
+  return {
+    [FeatureSwitchKey.ChatArtifactSidebar]: false,
+  };
+}
 
 function queryButtonByText(text: string): HTMLElement | undefined {
   return queryAllByRoleFast("button").find((button) => {
@@ -435,7 +442,11 @@ describe("zero chat thread page - image attachment opens lightbox", () => {
       ],
     });
 
-    detachedSetupPage({ context, path: `/chats/${THREAD_ID}` });
+    detachedSetupPage({
+      context,
+      path: `/chats/${THREAD_ID}`,
+      featureSwitches: chatArtifactSidebarOff(),
+    });
 
     await waitFor(() => {
       expect(screen.getByAltText("photo.png")).toBeInTheDocument();
@@ -483,7 +494,11 @@ describe("zero chat thread page - image attachment opens lightbox", () => {
       ],
     });
 
-    detachedSetupPage({ context, path: `/chats/${THREAD_ID}` });
+    detachedSetupPage({
+      context,
+      path: `/chats/${THREAD_ID}`,
+      featureSwitches: chatArtifactSidebarOff(),
+    });
 
     const imageLink = await waitFor(() => {
       return screen.getByLabelText("Preview photo.png");
@@ -527,7 +542,11 @@ describe("zero chat thread page - document preview opens global lightbox", () =>
       ],
     });
 
-    detachedSetupPage({ context, path: `/chats/${THREAD_ID}` });
+    detachedSetupPage({
+      context,
+      path: `/chats/${THREAD_ID}`,
+      featureSwitches: chatArtifactSidebarOff(),
+    });
 
     const previewButton = await waitFor(() => {
       return screen.getByLabelText("Open html preview for report");

--- a/turbo/apps/platform/src/views/zero-page/__tests__/zero-chat-thread-page-interaction.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/zero-chat-thread-page-interaction.test.tsx
@@ -560,7 +560,7 @@ describe("zero chat thread page - document preview opens global lightbox", () =>
       );
     });
 
-    await userEvent.click(screen.getByLabelText("Copy link"));
+    await userEvent.click(screen.getByLabelText("Share"));
     expect(writeTextSpy).toHaveBeenCalledWith(publicHtmlUrl);
   });
 });

--- a/turbo/apps/platform/src/views/zero-page/schedule-dialog.tsx
+++ b/turbo/apps/platform/src/views/zero-page/schedule-dialog.tsx
@@ -149,11 +149,11 @@ function ConfirmCloseOverlay({
       aria-describedby="confirm-close-desc"
     >
       <div
-        className="fixed inset-0 bg-black/50 animate-in fade-in duration-[180ms] ease dark:bg-black/70"
+        className="zero-dialog-enter-overlay fixed inset-0 bg-black/50 dark:bg-black/70"
         onClick={onContinue}
         role="presentation"
       />
-      <div className="relative z-10 mx-4 max-w-sm rounded-lg border border-border bg-card p-6 shadow-xl animate-in slide-in-from-bottom-2 duration-[180ms] ease">
+      <div className="zero-dialog-enter-content relative z-10 mx-4 max-w-sm rounded-lg border border-border bg-card p-6 shadow-xl">
         <p
           id="confirm-close-title"
           className="text-sm font-medium text-foreground mb-1"

--- a/turbo/apps/platform/src/views/zero-page/schedule-dialog.tsx
+++ b/turbo/apps/platform/src/views/zero-page/schedule-dialog.tsx
@@ -149,11 +149,11 @@ function ConfirmCloseOverlay({
       aria-describedby="confirm-close-desc"
     >
       <div
-        className="fixed inset-0 bg-black/50 dark:bg-black/70"
+        className="fixed inset-0 bg-black/50 animate-in fade-in duration-[180ms] ease dark:bg-black/70"
         onClick={onContinue}
         role="presentation"
       />
-      <div className="relative z-10 mx-4 max-w-sm rounded-lg border border-border bg-card p-6 shadow-xl">
+      <div className="relative z-10 mx-4 max-w-sm rounded-lg border border-border bg-card p-6 shadow-xl animate-in slide-in-from-bottom-2 duration-[180ms] ease">
         <p
           id="confirm-close-title"
           className="text-sm font-medium text-foreground mb-1"

--- a/turbo/apps/platform/src/views/zero-page/sidebar-layout.tsx
+++ b/turbo/apps/platform/src/views/zero-page/sidebar-layout.tsx
@@ -73,6 +73,11 @@ import {
   InstallBanner,
   IosInstallModal,
 } from "../pwa-install/install-banner.tsx";
+import {
+  chatArtifactSidebarEnabled$,
+  currentArtifactInboxThreadId$,
+  openArtifactInbox$,
+} from "../../signals/zero-page/zero-artifact-sidebar.ts";
 
 function AgentAvatarInTopBar() {
   const agent = useLastResolved(currentChatAgent$);
@@ -191,13 +196,21 @@ function NewOrUnreadChatButtonLeaf() {
 }
 
 function MobileArtifactsButtonInner({ thread }: { thread: ChatThreadSignals }) {
-  const open = useGet(thread.artifactsDrawerOpen$);
+  const drawerOpen = useGet(thread.artifactsDrawerOpen$);
+  const sidebarEnabled = useGet(chatArtifactSidebarEnabled$);
+  const inboxThreadId = useGet(currentArtifactInboxThreadId$);
   const setOpen = useSet(thread.setArtifactsDrawerOpen$);
+  const openInbox = useSet(openArtifactInbox$);
+  const open = sidebarEnabled ? inboxThreadId === thread.threadId : drawerOpen;
 
   return (
     <button
       type="button"
       onClick={() => {
+        if (sidebarEnabled) {
+          openInbox(thread.threadId);
+          return;
+        }
         setOpen(true);
       }}
       className={cn(

--- a/turbo/apps/platform/src/views/zero-page/zero-artifact-actions.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-artifact-actions.tsx
@@ -1,0 +1,450 @@
+import type { ComponentPropsWithoutRef, ReactNode } from "react";
+import {
+  IconBrandGoogleDrive,
+  IconDownload,
+  IconShare,
+} from "@tabler/icons-react";
+import {
+  cn,
+  Popover,
+  PopoverAnchor,
+  PopoverContent,
+  Tooltip,
+  TooltipContent,
+  TooltipProvider,
+  TooltipTrigger,
+} from "@vm0/ui";
+import { toast } from "@vm0/ui/components/ui/sonner";
+import type { ConnectorAuthMethodIdsByGrantKind } from "@vm0/connectors/connectors";
+import { zeroConnectorOauthStartContract } from "@vm0/api-contracts/contracts/zero-connectors";
+import { useGet, useLastResolved, useSet } from "ccstate-react";
+import { accept } from "../../lib/accept.ts";
+import {
+  zeroClient$,
+  type ZeroClientFactory,
+} from "../../signals/api-client.ts";
+import { connectors$ } from "../../signals/external/connectors.ts";
+import { pageSignal$ } from "../../signals/page-signal.ts";
+import {
+  artifactDownloadMenuOpenKey$,
+  closeArtifactDownloadMenu$,
+  openArtifactDownloadMenu$,
+  scheduleArtifactDownloadMenuClose$,
+} from "../../signals/zero-page/zero-artifact-actions.ts";
+import {
+  type ArtifactGoogleDriveSyncFile,
+  syncArtifactFileToGoogleDrive,
+  waitForGoogleDriveAndSyncArtifacts$,
+} from "../../signals/chat-page/artifact-google-drive-sync.ts";
+import { detach, Reason } from "../../signals/utils.ts";
+import {
+  copyAttachmentLinkToClipboard,
+  downloadAttachmentUrl,
+  publicAttachmentUrl,
+} from "./zero-attachment-url.ts";
+
+const CONNECT_GOOGLE_DRIVE_ARTIFACT_UPLOAD_TOOLTIP =
+  "Connect Google Drive to upload artifacts";
+const GOOGLE_DRIVE_ARTIFACT_SYNC_AUTH_METHOD =
+  "oauth" satisfies ConnectorAuthMethodIdsByGrantKind<
+    "google-drive",
+    "auth-code"
+  >;
+const ARTIFACT_FLOATING_LAYER_CLASS =
+  "!z-[10000] transition-[opacity,transform] duration-[180ms] ease data-[state=open]:!animate-none data-[state=closed]:!animate-none data-[state=open]:translate-y-0 data-[state=open]:opacity-100 data-[state=closed]:translate-y-2 data-[state=closed]:opacity-0";
+
+type WaitForGoogleDriveAndSyncArtifactsFn = (
+  params: {
+    readonly agentId: string;
+    readonly threadId: string;
+    readonly files: readonly ArtifactGoogleDriveSyncFile[];
+  },
+  signal: AbortSignal,
+) => Promise<unknown>;
+
+export type ArtifactDownloadSyncTarget = {
+  readonly agentId: string | null | undefined;
+  readonly fileId: string;
+  readonly filename: string;
+  readonly onSyncSuccess: () => void;
+  readonly runId: string;
+  readonly synced: boolean;
+  readonly threadId: string;
+};
+
+async function shareArtifactUrl(url: string): Promise<void> {
+  await copyAttachmentLinkToClipboard(url);
+}
+
+function startGoogleDriveConnectAndSync(params: {
+  agentId: string | null | undefined;
+  createClient: ZeroClientFactory;
+  file: ArtifactGoogleDriveSyncFile;
+  pageSignal: AbortSignal;
+  threadId: string;
+  waitForGoogleDriveAndSyncArtifacts: WaitForGoogleDriveAndSyncArtifactsFn;
+  onSyncComplete: () => void;
+}): void {
+  if (!params.agentId) {
+    toast.error("Agent is still loading");
+    return;
+  }
+  const authWindow = window.open(
+    "about:blank",
+    "_blank",
+    "width=600,height=700",
+  );
+  if (!authWindow) {
+    toast.error("Failed to open Google Drive connection page");
+    return;
+  }
+  const agentId = params.agentId;
+  detach(
+    (async () => {
+      const client = params.createClient(zeroConnectorOauthStartContract, {
+        apiBase: "www",
+      });
+      const result = await accept(
+        client.start({
+          params: { type: "google-drive" },
+          body: { authMethod: GOOGLE_DRIVE_ARTIFACT_SYNC_AUTH_METHOD },
+          fetchOptions: { signal: params.pageSignal },
+        }),
+        [200],
+      );
+      params.pageSignal.throwIfAborted();
+      authWindow.location.href = result.body.authorizationUrl;
+    })(),
+    Reason.DomCallback,
+    "artifact google drive oauth start",
+  );
+  detach(
+    (async () => {
+      await params.waitForGoogleDriveAndSyncArtifacts(
+        {
+          agentId,
+          threadId: params.threadId,
+          files: [params.file],
+        },
+        params.pageSignal,
+      );
+      params.onSyncComplete();
+    })(),
+    Reason.DomCallback,
+    "artifact google drive connect sync",
+  );
+}
+
+function syncArtifactToGoogleDriveAndRefresh(params: {
+  sync: Promise<boolean>;
+  onSyncSuccess: () => void;
+}): void {
+  detach(
+    (async () => {
+      const success = await params.sync;
+      if (success) {
+        params.onSyncSuccess();
+      }
+    })(),
+    Reason.DomCallback,
+    "artifact google drive sync",
+  );
+}
+
+function iconButtonClassName(className?: string): string {
+  return cn(
+    "inline-flex h-8 w-8 shrink-0 items-center justify-center rounded-md text-muted-foreground transition-colors hover:bg-muted/60 hover:text-foreground",
+    className,
+  );
+}
+
+export function ArtifactActionSeparator() {
+  return <span className="mx-0.5 h-5 w-px shrink-0 bg-border/70" />;
+}
+
+export function ArtifactShareButton({
+  ariaLabel = "Share",
+  className,
+  iconSize = 16,
+  url,
+}: {
+  ariaLabel?: string;
+  className?: string;
+  iconSize?: number;
+  url: string;
+}) {
+  return (
+    <TooltipProvider delayDuration={200}>
+      <Tooltip>
+        <TooltipTrigger asChild>
+          <button
+            type="button"
+            onClick={() => {
+              detach(
+                shareArtifactUrl(url),
+                Reason.DomCallback,
+                "artifact share",
+              );
+            }}
+            aria-label={ariaLabel}
+            title={publicAttachmentUrl(url)}
+            className={iconButtonClassName(className)}
+          >
+            <IconShare size={iconSize} stroke={1.5} />
+          </button>
+        </TooltipTrigger>
+        <TooltipContent
+          side="top"
+          className={cn("!z-[10000]", ARTIFACT_FLOATING_LAYER_CLASS)}
+        >
+          <p className="text-xs">Share</p>
+        </TooltipContent>
+      </Tooltip>
+    </TooltipProvider>
+  );
+}
+
+type ArtifactDownloadMenuItemProps = Omit<
+  ComponentPropsWithoutRef<"button">,
+  "type"
+> & {
+  children: ReactNode;
+};
+
+function ArtifactDownloadMenuItem({
+  children,
+  className,
+  disabled = false,
+  ...props
+}: ArtifactDownloadMenuItemProps) {
+  return (
+    <button
+      {...props}
+      type="button"
+      role="menuitem"
+      aria-disabled={disabled ? "true" : undefined}
+      disabled={disabled}
+      className={cn(
+        "relative flex w-full select-none items-center gap-2 rounded-md px-2 py-1.5 text-left text-sm outline-none transition-colors hover:bg-accent focus:bg-accent disabled:pointer-events-none disabled:opacity-50 [&_svg]:pointer-events-none [&_svg]:size-4 [&_svg]:shrink-0",
+        disabled ? "cursor-default" : "cursor-pointer",
+        className,
+      )}
+    >
+      {children}
+    </button>
+  );
+}
+
+function GoogleDriveMenuItem({
+  closeMenu,
+  onHover,
+  syncTarget,
+}: {
+  closeMenu: () => void;
+  onHover: () => void;
+  syncTarget?: ArtifactDownloadSyncTarget;
+}) {
+  const connectorList = useLastResolved(connectors$);
+  const googleDriveConnected =
+    connectorList?.connectors.some((connector) => {
+      return connector.type === "google-drive" && !connector.needsReconnect;
+    }) ?? false;
+  const createClient = useGet(zeroClient$);
+  const pageSignal = useGet(pageSignal$);
+  const waitForGoogleDriveAndSyncArtifacts = useSet(
+    waitForGoogleDriveAndSyncArtifacts$,
+  );
+
+  if (!syncTarget) {
+    return (
+      <ArtifactDownloadMenuItem disabled>
+        <IconBrandGoogleDrive size={14} stroke={1.5} />
+        Upload to Google Drive
+      </ArtifactDownloadMenuItem>
+    );
+  }
+
+  if (syncTarget.synced) {
+    return (
+      <ArtifactDownloadMenuItem disabled>
+        <IconBrandGoogleDrive size={14} stroke={1.5} />
+        Synced to Google Drive
+      </ArtifactDownloadMenuItem>
+    );
+  }
+
+  const syncOrConnect = () => {
+    closeMenu();
+    const file = {
+      runId: syncTarget.runId,
+      fileId: syncTarget.fileId,
+      filename: syncTarget.filename,
+    };
+    if (googleDriveConnected) {
+      syncArtifactToGoogleDriveAndRefresh({
+        sync: syncArtifactFileToGoogleDrive({
+          createClient,
+          threadId: syncTarget.threadId,
+          runId: syncTarget.runId,
+          fileId: syncTarget.fileId,
+          filename: syncTarget.filename,
+          signal: pageSignal,
+        }),
+        onSyncSuccess: syncTarget.onSyncSuccess,
+      });
+      return;
+    }
+    startGoogleDriveConnectAndSync({
+      agentId: syncTarget.agentId,
+      createClient,
+      file,
+      pageSignal,
+      threadId: syncTarget.threadId,
+      waitForGoogleDriveAndSyncArtifacts,
+      onSyncComplete: syncTarget.onSyncSuccess,
+    });
+  };
+
+  if (googleDriveConnected) {
+    return (
+      <ArtifactDownloadMenuItem onClick={syncOrConnect}>
+        <IconBrandGoogleDrive size={14} stroke={1.5} />
+        Upload to Google Drive
+      </ArtifactDownloadMenuItem>
+    );
+  }
+
+  return (
+    <div
+      className="group/google-drive-connect relative"
+      onPointerEnter={onHover}
+    >
+      <ArtifactDownloadMenuItem
+        className="text-muted-foreground"
+        onFocus={onHover}
+        onPointerEnter={onHover}
+        onClick={syncOrConnect}
+      >
+        <IconBrandGoogleDrive size={14} stroke={1.5} />
+        Connect Google Drive
+      </ArtifactDownloadMenuItem>
+      <div
+        role="tooltip"
+        className={cn(
+          "pointer-events-none absolute right-full top-1/2 z-[10001] mr-2 -translate-y-1/2 translate-x-1 whitespace-nowrap rounded-md border border-border/70 bg-popover px-2 py-1 text-xs text-popover-foreground opacity-0 shadow-md transition-[opacity,transform] duration-[180ms] ease",
+          "group-hover/google-drive-connect:translate-x-0 group-hover/google-drive-connect:opacity-100 group-focus-within/google-drive-connect:translate-x-0 group-focus-within/google-drive-connect:opacity-100",
+        )}
+      >
+        {CONNECT_GOOGLE_DRIVE_ARTIFACT_UPLOAD_TOOLTIP}
+      </div>
+    </div>
+  );
+}
+
+export function ArtifactDownloadMenu({
+  align = "end",
+  ariaLabel = "Download options",
+  className,
+  filename,
+  iconSize = 16,
+  syncTarget,
+  url,
+}: {
+  align?: "center" | "end" | "start";
+  ariaLabel?: string;
+  className?: string;
+  filename: string;
+  iconSize?: number;
+  syncTarget?: ArtifactDownloadSyncTarget;
+  url: string;
+}) {
+  const menuKey = `${url}:${filename}`;
+  const openKey = useGet(artifactDownloadMenuOpenKey$);
+  const openMenu = useSet(openArtifactDownloadMenu$);
+  const closeMenu = useSet(closeArtifactDownloadMenu$);
+  const scheduleCloseMenu = useSet(scheduleArtifactDownloadMenuClose$);
+  const pageSignal = useGet(pageSignal$);
+  const open = openKey === menuKey;
+
+  const show = () => {
+    openMenu(menuKey);
+  };
+
+  const hide = () => {
+    scheduleCloseMenu(menuKey);
+  };
+
+  const closeNow = () => {
+    closeMenu();
+  };
+
+  return (
+    <Popover
+      modal={false}
+      open={open}
+      onOpenChange={(nextOpen) => {
+        if (nextOpen) {
+          openMenu(menuKey);
+          return;
+        }
+        closeMenu();
+      }}
+    >
+      <PopoverAnchor asChild>
+        <button
+          type="button"
+          aria-label={ariaLabel}
+          aria-haspopup="menu"
+          aria-expanded={open}
+          className={iconButtonClassName(className)}
+          onPointerEnter={show}
+          onPointerLeave={hide}
+          onFocus={show}
+          onBlur={hide}
+          onClick={show}
+        >
+          <IconDownload size={iconSize} stroke={1.5} />
+        </button>
+      </PopoverAnchor>
+      <PopoverContent
+        role="menu"
+        align={align}
+        sideOffset={6}
+        style={{ pointerEvents: "auto" }}
+        onOpenAutoFocus={(event) => {
+          event.preventDefault();
+        }}
+        onCloseAutoFocus={(event) => {
+          event.preventDefault();
+        }}
+        onPointerEnter={show}
+        onPointerLeave={hide}
+        onFocus={show}
+        onBlur={hide}
+        className={cn(
+          "pointer-events-auto w-56 p-1",
+          ARTIFACT_FLOATING_LAYER_CLASS,
+        )}
+      >
+        <ArtifactDownloadMenuItem
+          onClick={() => {
+            closeNow();
+            detach(
+              downloadAttachmentUrl(url, pageSignal, filename),
+              Reason.DomCallback,
+              "artifact download",
+            );
+          }}
+        >
+          <IconDownload size={14} stroke={1.5} />
+          Download
+        </ArtifactDownloadMenuItem>
+        <GoogleDriveMenuItem
+          closeMenu={closeNow}
+          onHover={show}
+          syncTarget={syncTarget}
+        />
+      </PopoverContent>
+    </Popover>
+  );
+}

--- a/turbo/apps/platform/src/views/zero-page/zero-artifact-display.ts
+++ b/turbo/apps/platform/src/views/zero-page/zero-artifact-display.ts
@@ -1,0 +1,167 @@
+import type { AttachmentArtifactMetadata } from "../../signals/zero-page/zero-attachment-chips.ts";
+
+type ArtifactDisplayKind =
+  | "markdown"
+  | "text"
+  | "json"
+  | "csv"
+  | "html"
+  | "pdf"
+  | "image"
+  | "video"
+  | "audio"
+  | "file";
+
+type ArtifactTitleMetadata = Pick<
+  AttachmentArtifactMetadata,
+  "contentType" | "createdAt" | "filename" | "size"
+>;
+
+function fileExtension(filename: string): string | null {
+  const extension = filename.split(".").pop();
+  if (!extension || extension === filename) {
+    return null;
+  }
+  return extension.toUpperCase();
+}
+
+function contentTypeFormat(contentType: string): string | null {
+  const subtype = contentType.split("/")[1]?.split(";")[0]?.trim();
+  if (!subtype) {
+    return null;
+  }
+  if (subtype === "jpeg") {
+    return "JPG";
+  }
+  if (subtype === "plain") {
+    return "TXT";
+  }
+  if (subtype === "mpeg") {
+    return "MP3";
+  }
+  return subtype.toUpperCase();
+}
+
+function isPresentationExtension(extension: string): boolean {
+  switch (extension) {
+    case "KEY":
+    case "ODP":
+    case "PPT":
+    case "PPTX": {
+      return true;
+    }
+    default: {
+      return false;
+    }
+  }
+}
+
+function isCodeExtension(extension: string): boolean {
+  switch (extension) {
+    case "CSS":
+    case "GO":
+    case "HTML":
+    case "JS":
+    case "JSX":
+    case "PY":
+    case "RB":
+    case "RS":
+    case "TS":
+    case "TSX": {
+      return true;
+    }
+    default: {
+      return false;
+    }
+  }
+}
+
+function artifactFormat(meta: ArtifactTitleMetadata): string | null {
+  return fileExtension(meta.filename) ?? contentTypeFormat(meta.contentType);
+}
+
+function formatArtifactBytes(bytes: number): string {
+  if (bytes < 1024) {
+    return `${bytes} B`;
+  }
+  const units = ["KB", "MB", "GB"] as const;
+  let value = bytes / 1024;
+  for (let i = 0; i < units.length; i++) {
+    const unit = units[i]!;
+    if (value < 1024 || i === units.length - 1) {
+      return `${value.toFixed(value >= 10 ? 0 : 1)} ${unit}`;
+    }
+    value = value / 1024;
+  }
+  return `${bytes} B`;
+}
+
+function formatArtifactGeneratedTime(value: string): string {
+  return new Date(value).toLocaleString("en-US", {
+    month: "short",
+    day: "numeric",
+    hour: "numeric",
+    minute: "2-digit",
+  });
+}
+
+function artifactKindTitle(
+  kind: ArtifactDisplayKind,
+  filename: string,
+): string {
+  const extension = fileExtension(filename);
+  if (extension && isPresentationExtension(extension)) {
+    return "Presentation";
+  }
+  if (extension && isCodeExtension(extension)) {
+    return kind === "html" ? "Hosted site" : "Code";
+  }
+
+  switch (kind) {
+    case "markdown":
+    case "pdf":
+    case "text": {
+      return "Document";
+    }
+    case "json":
+    case "csv": {
+      return "Data";
+    }
+    case "html": {
+      return "Hosted site";
+    }
+    case "image": {
+      return "Image";
+    }
+    case "video": {
+      return "Video";
+    }
+    case "audio": {
+      return "Audio";
+    }
+    case "file": {
+      return "File";
+    }
+  }
+}
+
+export function artifactFallbackSubtitle(
+  kind: ArtifactDisplayKind,
+  filename: string,
+): string {
+  return artifactKindTitle(kind, filename);
+}
+
+export function artifactTitleSubtitle(
+  kind: ArtifactDisplayKind,
+  meta: ArtifactTitleMetadata,
+): string {
+  const parts = [artifactKindTitle(kind, meta.filename)];
+  const format = artifactFormat(meta);
+  if (format && parts[0] !== "Hosted site") {
+    parts.push(format);
+  }
+  parts.push(formatArtifactBytes(meta.size));
+  parts.push(`Generated ${formatArtifactGeneratedTime(meta.createdAt)}`);
+  return parts.join(" · ");
+}

--- a/turbo/apps/platform/src/views/zero-page/zero-artifact-sidebar.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-artifact-sidebar.tsx
@@ -1,17 +1,24 @@
 import type { ReactNode } from "react";
+import { createPortal } from "react-dom";
 import {
+  IconArrowLeft,
   IconArrowsDiagonal,
   IconArrowsDiagonalMinimize2,
   IconCopy,
   IconDownload,
+  IconDots,
   IconExternalLink,
   IconLoader2,
   IconX,
-  IconZoomIn,
-  IconZoomOut,
-  IconZoomReset,
 } from "@tabler/icons-react";
 import { useGet, useSet } from "ccstate-react";
+import {
+  cn,
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuTrigger,
+} from "@vm0/ui";
 import {
   artifactFullscreen$,
   type ArtifactRef,
@@ -36,7 +43,6 @@ import {
   IMAGE_LIGHTBOX_MIN_ZOOM,
   imageLightboxImageRef$,
   imageLightboxState$,
-  resetImageLightboxZoom$,
   zoomImageLightboxIn$,
   zoomImageLightboxOut$,
 } from "../../signals/view-component-state.ts";
@@ -59,44 +65,59 @@ export function ArtifactSidebarSlot() {
   return <ArtifactSidebar artifactRef={ref} />;
 }
 
-export function ArtifactSidebar({ artifactRef }: { artifactRef: ArtifactRef }) {
+export function ArtifactSidebar({
+  artifactRef,
+  onBack,
+  onClose,
+}: {
+  artifactRef: ArtifactRef;
+  onBack?: () => void;
+  onClose?: () => void;
+}) {
   const fullscreen = useGet(artifactFullscreen$);
   const close = useSet(closeArtifact$);
   const toggleFullscreen = useSet(toggleArtifactFullscreen$);
   const pageSignal = useGet(pageSignal$);
+  const closePreview = onClose ?? close;
 
   const display = resolveArtifactDisplay(artifactRef);
 
   if (!display) {
-    return (
+    const sidebar = (
       <div
-        className={
+        className={cn(
           fullscreen
-            ? "fixed inset-0 z-40 flex flex-col bg-background"
-            : "flex h-full w-full min-h-0 flex-col border-l border-border/60 bg-background"
-        }
+            ? "fixed inset-0 z-[100] flex flex-col bg-background"
+            : "flex h-full w-full min-h-0 flex-col border-l border-border/60 bg-background",
+          "animate-in fade-in slide-in-from-right-2 duration-200",
+        )}
         data-testid="artifact-sidebar"
       >
         <ArtifactSidebarHeader
           title="Artifact unavailable"
           fullscreen={fullscreen}
+          onBack={onBack}
           onToggleFullscreen={toggleFullscreen}
-          onClose={close}
+          onClose={closePreview}
         />
         <div className="flex flex-1 items-center justify-center p-6 text-sm text-muted-foreground">
           Unsupported artifact reference.
         </div>
       </div>
     );
+    return fullscreen && typeof document !== "undefined"
+      ? createPortal(sidebar, document.body)
+      : sidebar;
   }
 
-  return (
+  const sidebar = (
     <div
-      className={
+      className={cn(
         fullscreen
-          ? "fixed inset-0 z-40 flex flex-col bg-background"
-          : "flex h-full w-full min-h-0 flex-col border-l border-border/60 bg-background"
-      }
+          ? "fixed inset-0 z-[100] flex flex-col bg-background"
+          : "flex h-full w-full min-h-0 flex-col border-l border-border/60 bg-background",
+        "animate-in fade-in slide-in-from-right-2 duration-200",
+      )}
       data-testid="artifact-sidebar"
     >
       <ArtifactSidebarHeader
@@ -104,8 +125,9 @@ export function ArtifactSidebar({ artifactRef }: { artifactRef: ArtifactRef }) {
         kind={display.kind}
         url={display.url}
         fullscreen={fullscreen}
+        onBack={onBack}
         onToggleFullscreen={toggleFullscreen}
-        onClose={close}
+        onClose={closePreview}
       />
       <div className="min-h-0 flex-1 overflow-hidden bg-background">
         <ArtifactBody
@@ -117,6 +139,9 @@ export function ArtifactSidebar({ artifactRef }: { artifactRef: ArtifactRef }) {
       </div>
     </div>
   );
+  return fullscreen && typeof document !== "undefined"
+    ? createPortal(sidebar, document.body)
+    : sidebar;
 }
 
 interface ArtifactDisplay {
@@ -153,6 +178,7 @@ function ArtifactSidebarHeader({
   kind,
   url,
   fullscreen,
+  onBack,
   onToggleFullscreen,
   onClose,
 }: {
@@ -160,93 +186,254 @@ function ArtifactSidebarHeader({
   kind?: ArtifactKindForBody;
   url?: string;
   fullscreen: boolean;
+  onBack?: () => void;
   onToggleFullscreen: () => void;
   onClose: () => void;
 }) {
-  const publicUrl = url ? publicAttachmentUrl(url) : undefined;
+  const compactActions = onBack !== undefined;
+
   return (
-    <div className="flex shrink-0 items-center gap-2 border-b border-border/60 px-4 py-3">
-      {url ? (
+    <div className="flex min-h-14 shrink-0 items-center gap-3 border-b border-border/60 px-4 py-2">
+      {onBack && (
         <button
           type="button"
-          onClick={() => {
-            detach(
-              copyAttachmentLinkToClipboard(url),
-              Reason.DomCallback,
-              "artifact copy link",
-            );
-          }}
-          aria-label="Copy artifact URL"
-          title={publicUrl}
-          className="group/copy-url flex min-w-0 flex-1 items-center gap-2 rounded-md px-2 py-1 text-left text-muted-foreground hover:bg-muted/60 hover:text-foreground"
+          onClick={onBack}
+          aria-label="Back to all artifacts"
+          className="inline-flex h-8 w-8 shrink-0 items-center justify-center rounded-md text-muted-foreground transition-colors hover:bg-muted/60 hover:text-foreground"
         >
-          <IconCopy size={14} className="shrink-0" />
-          <span className="min-w-0 flex-1 truncate font-mono text-xs">
-            {publicUrl}
-          </span>
+          <IconArrowLeft size={16} />
         </button>
-      ) : (
-        <div className="min-w-0 flex-1 truncate text-sm font-medium text-foreground">
+      )}
+      <div className="min-w-0 flex-1">
+        <div className="truncate text-sm font-medium text-foreground">
           {title}
         </div>
-      )}
-      <div className="flex shrink-0 items-center gap-1">
-        {url && (
-          <>
-            {kind === "html" ? (
-              <a
-                href={publicAttachmentUrl(url)}
-                target="_blank"
-                rel="noopener noreferrer"
-                aria-label="Open in new tab"
-                data-testid="artifact-sidebar-open-external"
-                className="inline-flex h-8 w-8 items-center justify-center rounded-md text-muted-foreground hover:bg-muted/60 hover:text-foreground"
-              >
-                <IconExternalLink size={16} />
-              </a>
-            ) : (
-              <button
-                type="button"
-                onClick={() => {
-                  detach(
-                    downloadAttachmentUrl(url, undefined, title),
-                    Reason.DomCallback,
-                    "artifact download",
-                  );
-                }}
-                aria-label="Download"
-                className="inline-flex h-8 w-8 items-center justify-center rounded-md text-muted-foreground hover:bg-muted/60 hover:text-foreground"
-              >
-                <IconDownload size={16} />
-              </button>
-            )}
-          </>
+        {kind && (
+          <div className="mt-0.5 truncate text-xs text-muted-foreground">
+            {artifactKindLabel(kind)}
+          </div>
         )}
-        <button
-          type="button"
-          onClick={onToggleFullscreen}
-          aria-label={fullscreen ? "Exit fullscreen" : "Enter fullscreen"}
-          data-testid="artifact-sidebar-fullscreen-toggle"
-          className="hidden xl:inline-flex h-8 w-8 items-center justify-center rounded-md text-muted-foreground hover:bg-muted/60 hover:text-foreground"
-        >
-          {fullscreen ? (
-            <IconArrowsDiagonalMinimize2 size={16} />
-          ) : (
-            <IconArrowsDiagonal size={16} />
-          )}
-        </button>
-        <button
-          type="button"
-          onClick={onClose}
-          aria-label="Close artifact"
-          data-testid="artifact-sidebar-close"
-          className="inline-flex h-8 w-8 items-center justify-center rounded-md text-muted-foreground hover:bg-muted/60 hover:text-foreground"
-        >
-          <IconX size={16} />
-        </button>
       </div>
+      <ArtifactSidebarActions
+        compactActions={compactActions}
+        fullscreen={fullscreen}
+        kind={kind}
+        onClose={onClose}
+        onToggleFullscreen={onToggleFullscreen}
+        title={title}
+        url={url}
+      />
     </div>
   );
+}
+
+function ArtifactSidebarActions({
+  compactActions,
+  fullscreen,
+  kind,
+  onClose,
+  onToggleFullscreen,
+  title,
+  url,
+}: {
+  compactActions: boolean;
+  fullscreen: boolean;
+  kind?: ArtifactKindForBody;
+  onClose: () => void;
+  onToggleFullscreen: () => void;
+  title: string;
+  url?: string;
+}) {
+  return (
+    <div className="flex shrink-0 items-center gap-1">
+      {url && (
+        <>
+          <ArtifactPrimaryAction kind={kind} title={title} url={url} />
+          {!compactActions && <ArtifactCopyAction url={url} />}
+        </>
+      )}
+      <ArtifactFullscreenAction
+        fullscreen={fullscreen}
+        onToggleFullscreen={onToggleFullscreen}
+      />
+      {compactActions && url ? (
+        <ArtifactMoreActions onClose={onClose} url={url} />
+      ) : (
+        <ArtifactCloseAction onClose={onClose} />
+      )}
+    </div>
+  );
+}
+
+function ArtifactPrimaryAction({
+  kind,
+  title,
+  url,
+}: {
+  kind?: ArtifactKindForBody;
+  title: string;
+  url: string;
+}) {
+  if (kind === "html") {
+    return (
+      <a
+        href={publicAttachmentUrl(url)}
+        target="_blank"
+        rel="noopener noreferrer"
+        aria-label="Open in new tab"
+        data-testid="artifact-sidebar-open-external"
+        className="inline-flex h-8 w-8 items-center justify-center rounded-md text-muted-foreground hover:bg-muted/60 hover:text-foreground"
+      >
+        <IconExternalLink size={16} />
+      </a>
+    );
+  }
+
+  return (
+    <button
+      type="button"
+      onClick={() => {
+        detach(
+          downloadAttachmentUrl(url, undefined, title),
+          Reason.DomCallback,
+          "artifact download",
+        );
+      }}
+      aria-label="Download"
+      className="inline-flex h-8 w-8 items-center justify-center rounded-md text-muted-foreground hover:bg-muted/60 hover:text-foreground"
+    >
+      <IconDownload size={16} />
+    </button>
+  );
+}
+
+function ArtifactCopyAction({ url }: { url: string }) {
+  return (
+    <button
+      type="button"
+      onClick={() => {
+        copyArtifactUrl(url);
+      }}
+      aria-label="Copy artifact URL"
+      title={publicAttachmentUrl(url)}
+      className="inline-flex h-8 w-8 items-center justify-center rounded-md text-muted-foreground hover:bg-muted/60 hover:text-foreground"
+    >
+      <IconCopy size={16} />
+    </button>
+  );
+}
+
+function ArtifactFullscreenAction({
+  fullscreen,
+  onToggleFullscreen,
+}: {
+  fullscreen: boolean;
+  onToggleFullscreen: () => void;
+}) {
+  return (
+    <button
+      type="button"
+      onClick={onToggleFullscreen}
+      aria-label={fullscreen ? "Exit fullscreen" : "Enter fullscreen"}
+      data-testid="artifact-sidebar-fullscreen-toggle"
+      className="hidden xl:inline-flex h-8 w-8 items-center justify-center rounded-md text-muted-foreground hover:bg-muted/60 hover:text-foreground"
+    >
+      {fullscreen ? (
+        <IconArrowsDiagonalMinimize2 size={16} />
+      ) : (
+        <IconArrowsDiagonal size={16} />
+      )}
+    </button>
+  );
+}
+
+function ArtifactMoreActions({
+  onClose,
+  url,
+}: {
+  onClose: () => void;
+  url: string;
+}) {
+  return (
+    <DropdownMenu>
+      <DropdownMenuTrigger asChild>
+        <button
+          type="button"
+          aria-label="More artifact actions"
+          className="inline-flex h-8 w-8 items-center justify-center rounded-md text-muted-foreground hover:bg-muted/60 hover:text-foreground"
+        >
+          <IconDots size={16} />
+        </button>
+      </DropdownMenuTrigger>
+      <DropdownMenuContent align="end">
+        <DropdownMenuItem
+          onClick={() => {
+            copyArtifactUrl(url);
+          }}
+        >
+          Copy link
+        </DropdownMenuItem>
+        <DropdownMenuItem onClick={onClose}>Close preview</DropdownMenuItem>
+      </DropdownMenuContent>
+    </DropdownMenu>
+  );
+}
+
+function ArtifactCloseAction({ onClose }: { onClose: () => void }) {
+  return (
+    <button
+      type="button"
+      onClick={onClose}
+      aria-label="Close artifact"
+      data-testid="artifact-sidebar-close"
+      className="inline-flex h-8 w-8 items-center justify-center rounded-md text-muted-foreground hover:bg-muted/60 hover:text-foreground"
+    >
+      <IconX size={16} />
+    </button>
+  );
+}
+
+function copyArtifactUrl(url: string) {
+  detach(
+    copyAttachmentLinkToClipboard(url),
+    Reason.DomCallback,
+    "artifact copy link",
+  );
+}
+
+function artifactKindLabel(kind: ArtifactKindForBody): string {
+  switch (kind) {
+    case "markdown": {
+      return "Markdown document";
+    }
+    case "text": {
+      return "Text document";
+    }
+    case "json": {
+      return "JSON document";
+    }
+    case "csv": {
+      return "Data table";
+    }
+    case "html": {
+      return "Hosted site";
+    }
+    case "pdf": {
+      return "PDF document";
+    }
+    case "image": {
+      return "Image";
+    }
+    case "video": {
+      return "Video";
+    }
+    case "audio": {
+      return "Audio";
+    }
+    case "file": {
+      return "File";
+    }
+  }
 }
 
 function ArtifactBody({
@@ -404,10 +591,6 @@ function ArtifactCsvBody({
   );
 }
 
-function isImageLightboxZoomAtReset(zoom: number): boolean {
-  return Math.abs(zoom - 1) < 0.001;
-}
-
 function ArtifactImageBody({
   url,
   filename,
@@ -424,7 +607,6 @@ function ArtifactImageBody({
   const setImageRef = useSet(imageLightboxImageRef$);
   const zoomIn = useSet(zoomImageLightboxIn$);
   const zoomOut = useSet(zoomImageLightboxOut$);
-  const resetZoom = useSet(resetImageLightboxZoom$);
 
   return (
     <div className="relative flex h-full items-center justify-center overflow-auto bg-muted/20 p-4">
@@ -441,7 +623,6 @@ function ArtifactImageBody({
         zoom={zoom}
         zoomIn={zoomIn}
         zoomOut={zoomOut}
-        resetZoom={resetZoom}
       />
     </div>
   );
@@ -451,31 +632,29 @@ function ArtifactImageZoomControls({
   zoom,
   zoomIn,
   zoomOut,
-  resetZoom,
 }: {
   zoom: number;
   zoomIn: () => void;
   zoomOut: () => void;
-  resetZoom: () => void;
 }) {
   return (
     <div
-      className="absolute bottom-4 left-1/2 z-10 flex -translate-x-1/2 items-center gap-1 rounded-full bg-foreground/80 p-1 text-background shadow-lg backdrop-blur-sm"
+      className="absolute right-4 top-4 z-10 flex items-center gap-2 rounded-lg border border-border/70 bg-background/95 px-2.5 py-1.5 text-muted-foreground shadow-sm backdrop-blur-sm"
       data-testid="artifact-sidebar-image-zoom-controls"
     >
       <button
         type="button"
         onClick={zoomOut}
         disabled={zoom <= IMAGE_LIGHTBOX_MIN_ZOOM}
-        className="rounded-full p-1.5 transition-colors hover:bg-background/20 disabled:pointer-events-none disabled:opacity-40"
+        className="flex h-5 w-5 items-center justify-center rounded-md text-sm leading-none transition-colors hover:bg-muted/70 hover:text-foreground disabled:pointer-events-none disabled:opacity-40"
         aria-label="Zoom out"
         title="Zoom out"
         data-testid="artifact-sidebar-image-zoom-out"
       >
-        <IconZoomOut size={18} stroke={2} />
+        -
       </button>
       <span
-        className="min-w-10 text-center text-xs font-medium tabular-nums"
+        className="min-w-10 text-center text-xs font-medium tabular-nums text-foreground"
         data-testid="artifact-sidebar-image-zoom-level"
       >
         {Math.round(zoom * 100)}%
@@ -484,23 +663,12 @@ function ArtifactImageZoomControls({
         type="button"
         onClick={zoomIn}
         disabled={zoom >= IMAGE_LIGHTBOX_MAX_ZOOM}
-        className="rounded-full p-1.5 transition-colors hover:bg-background/20 disabled:pointer-events-none disabled:opacity-40"
+        className="flex h-5 w-5 items-center justify-center rounded-md text-sm leading-none transition-colors hover:bg-muted/70 hover:text-foreground disabled:pointer-events-none disabled:opacity-40"
         aria-label="Zoom in"
         title="Zoom in"
         data-testid="artifact-sidebar-image-zoom-in"
       >
-        <IconZoomIn size={18} stroke={2} />
-      </button>
-      <button
-        type="button"
-        onClick={resetZoom}
-        disabled={isImageLightboxZoomAtReset(zoom)}
-        className="rounded-full p-1.5 transition-colors hover:bg-background/20 disabled:pointer-events-none disabled:opacity-40"
-        aria-label="Reset zoom"
-        title="Reset zoom"
-        data-testid="artifact-sidebar-image-zoom-reset"
-      >
-        <IconZoomReset size={18} stroke={2} />
+        +
       </button>
     </div>
   );

--- a/turbo/apps/platform/src/views/zero-page/zero-artifact-sidebar.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-artifact-sidebar.tsx
@@ -4,14 +4,17 @@ import {
   IconArrowLeft,
   IconArrowsDiagonal,
   IconArrowsDiagonalMinimize2,
-  IconCopy,
-  IconDownload,
   IconDots,
   IconExternalLink,
   IconLoader2,
   IconX,
 } from "@tabler/icons-react";
-import { useGet, useSet } from "ccstate-react";
+import {
+  useGet,
+  useLastLoadable,
+  useLastResolved,
+  useSet,
+} from "ccstate-react";
 import {
   cn,
   DropdownMenu,
@@ -28,16 +31,14 @@ import {
   toggleArtifactFullscreen$,
 } from "../../signals/zero-page/zero-artifact-sidebar.ts";
 import {
-  copyAttachmentLinkToClipboard,
   CsvPreviewTable,
-  downloadAttachmentUrl,
   parseCsvRows,
   publicAttachmentUrl,
   TextPreviewLoader,
 } from "./zero-attachment-chips.tsx";
 import { Markdown } from "../components/markdown.tsx";
 import { pageSignal$ } from "../../signals/page-signal.ts";
-import { detach, jsonParseOr, Reason } from "../../signals/utils.ts";
+import { jsonParseOr } from "../../signals/utils.ts";
 import {
   IMAGE_LIGHTBOX_MAX_ZOOM,
   IMAGE_LIGHTBOX_MIN_ZOOM,
@@ -46,6 +47,18 @@ import {
   zoomImageLightboxIn$,
   zoomImageLightboxOut$,
 } from "../../signals/view-component-state.ts";
+import type { ChatThreadSignals } from "../../signals/chat-page/create-chat-thread.ts";
+import type { ChatThreadArtifactFile } from "@vm0/api-contracts/contracts/chat-threads";
+import {
+  ArtifactActionSeparator,
+  ArtifactDownloadMenu,
+  ArtifactShareButton,
+  type ArtifactDownloadSyncTarget,
+} from "./zero-artifact-actions.tsx";
+import {
+  artifactFallbackSubtitle,
+  artifactTitleSubtitle,
+} from "./zero-artifact-display.ts";
 
 // ---------------------------------------------------------------------------
 // ArtifactSidebar — page-level pane for previewing the artifact pointed to
@@ -69,10 +82,85 @@ export function ArtifactSidebar({
   artifactRef,
   onBack,
   onClose,
-}: {
+  thread,
+}: ArtifactSidebarProps) {
+  if (thread) {
+    return (
+      <ArtifactSidebarWithThreadData
+        artifactRef={artifactRef}
+        onBack={onBack}
+        onClose={onClose}
+        thread={thread}
+      />
+    );
+  }
+
+  return (
+    <ArtifactSidebarContent
+      artifactRef={artifactRef}
+      onBack={onBack}
+      onClose={onClose}
+    />
+  );
+}
+
+type ArtifactSidebarProps = {
   artifactRef: ArtifactRef;
   onBack?: () => void;
   onClose?: () => void;
+  thread?: ChatThreadSignals;
+};
+
+type ArtifactSidebarItem = {
+  runId: string;
+  file: ChatThreadArtifactFile;
+};
+
+function ArtifactSidebarWithThreadData({
+  artifactRef,
+  onBack,
+  onClose,
+  thread,
+}: ArtifactSidebarProps & { thread: ChatThreadSignals }) {
+  const loadable = useLastLoadable(thread.artifacts$);
+  const agentId = useLastResolved(thread.agentId$);
+  const reloadArtifacts = useSet(thread.setArtifactsDrawerOpen$);
+  const item =
+    artifactRef.source === "url" && loadable.state === "hasData"
+      ? findArtifactItemForUrl(loadable.data, artifactRef.url)
+      : undefined;
+
+  return (
+    <ArtifactSidebarContent
+      agentId={agentId}
+      artifactRef={artifactRef}
+      item={item}
+      onBack={onBack}
+      onClose={onClose}
+      onSyncSuccess={() => {
+        reloadArtifacts(true);
+      }}
+      threadId={thread.threadId}
+    />
+  );
+}
+
+function ArtifactSidebarContent({
+  agentId,
+  artifactRef,
+  item,
+  onBack,
+  onClose,
+  onSyncSuccess,
+  threadId,
+}: {
+  agentId?: string | null;
+  artifactRef: ArtifactRef;
+  item?: ArtifactSidebarItem;
+  onBack?: () => void;
+  onClose?: () => void;
+  onSyncSuccess?: () => void;
+  threadId?: string;
 }) {
   const fullscreen = useGet(artifactFullscreen$);
   const close = useSet(closeArtifact$);
@@ -80,7 +168,20 @@ export function ArtifactSidebar({
   const pageSignal = useGet(pageSignal$);
   const closePreview = onClose ?? close;
 
-  const display = resolveArtifactDisplay(artifactRef);
+  const display = resolveArtifactDisplay(artifactRef, item);
+  const syncTarget =
+    item && threadId
+      ? artifactSidebarSyncTarget({
+          agentId,
+          item,
+          onSyncSuccess:
+            onSyncSuccess ??
+            (() => {
+              return undefined;
+            }),
+          threadId,
+        })
+      : undefined;
 
   if (!display) {
     const sidebar = (
@@ -89,12 +190,13 @@ export function ArtifactSidebar({
           fullscreen
             ? "fixed inset-0 z-[100] flex flex-col bg-background"
             : "flex h-full w-full min-h-0 flex-col border-l border-border/60 bg-background",
-          "animate-in fade-in slide-in-from-right-2 duration-200",
+          "animate-in fade-in duration-[180ms] ease",
         )}
         data-testid="artifact-sidebar"
       >
         <ArtifactSidebarHeader
           title="Artifact unavailable"
+          subtitle="Unavailable"
           fullscreen={fullscreen}
           onBack={onBack}
           onToggleFullscreen={toggleFullscreen}
@@ -116,13 +218,15 @@ export function ArtifactSidebar({
         fullscreen
           ? "fixed inset-0 z-[100] flex flex-col bg-background"
           : "flex h-full w-full min-h-0 flex-col border-l border-border/60 bg-background",
-        "animate-in fade-in slide-in-from-right-2 duration-200",
+        "animate-in fade-in duration-[180ms] ease",
       )}
       data-testid="artifact-sidebar"
     >
       <ArtifactSidebarHeader
         title={display.filename}
         kind={display.kind}
+        subtitle={display.subtitle}
+        syncTarget={syncTarget}
         url={display.url}
         fullscreen={fullscreen}
         onBack={onBack}
@@ -148,6 +252,7 @@ interface ArtifactDisplay {
   url: string;
   kind: ArtifactKindForBody;
   filename: string;
+  subtitle: string;
 }
 
 type ArtifactKindForBody =
@@ -162,20 +267,66 @@ type ArtifactKindForBody =
   | "audio"
   | "file";
 
-function resolveArtifactDisplay(ref: ArtifactRef): ArtifactDisplay | null {
+function findArtifactItemForUrl(
+  runs: { runId: string; files: ChatThreadArtifactFile[] }[],
+  url: string,
+): ArtifactSidebarItem | undefined {
+  for (const run of runs) {
+    const file = run.files.find((candidate) => {
+      return candidate.url === url;
+    });
+    if (file) {
+      return { runId: run.runId, file };
+    }
+  }
+  return undefined;
+}
+
+function artifactSidebarSyncTarget(params: {
+  agentId: string | null | undefined;
+  item: ArtifactSidebarItem;
+  onSyncSuccess: () => void;
+  threadId: string;
+}): ArtifactDownloadSyncTarget {
+  return {
+    agentId: params.agentId,
+    fileId: params.item.file.id,
+    filename: params.item.file.filename,
+    onSyncSuccess: params.onSyncSuccess,
+    runId: params.item.runId,
+    synced: params.item.file.googleDriveSync?.status === "synced",
+    threadId: params.threadId,
+  };
+}
+
+function resolveArtifactDisplay(
+  ref: ArtifactRef,
+  item?: ArtifactSidebarItem,
+): ArtifactDisplay | null {
   if (ref.source !== "url") {
     return null;
+  }
+  if (item) {
+    return {
+      url: ref.url,
+      kind: ref.kind,
+      filename: item.file.filename,
+      subtitle: artifactTitleSubtitle(ref.kind, item.file),
+    };
   }
   return {
     url: ref.url,
     kind: ref.kind,
     filename: ref.filename,
+    subtitle: artifactFallbackSubtitle(ref.kind, ref.filename),
   };
 }
 
 function ArtifactSidebarHeader({
   title,
   kind,
+  subtitle,
+  syncTarget,
   url,
   fullscreen,
   onBack,
@@ -184,6 +335,8 @@ function ArtifactSidebarHeader({
 }: {
   title: string;
   kind?: ArtifactKindForBody;
+  subtitle: string;
+  syncTarget?: ArtifactDownloadSyncTarget;
   url?: string;
   fullscreen: boolean;
   onBack?: () => void;
@@ -208,9 +361,9 @@ function ArtifactSidebarHeader({
         <div className="truncate text-sm font-medium text-foreground">
           {title}
         </div>
-        {kind && (
+        {subtitle && (
           <div className="mt-0.5 truncate text-xs text-muted-foreground">
-            {artifactKindLabel(kind)}
+            {subtitle}
           </div>
         )}
       </div>
@@ -220,6 +373,7 @@ function ArtifactSidebarHeader({
         kind={kind}
         onClose={onClose}
         onToggleFullscreen={onToggleFullscreen}
+        syncTarget={syncTarget}
         title={title}
         url={url}
       />
@@ -233,6 +387,7 @@ function ArtifactSidebarActions({
   kind,
   onClose,
   onToggleFullscreen,
+  syncTarget,
   title,
   url,
 }: {
@@ -241,6 +396,7 @@ function ArtifactSidebarActions({
   kind?: ArtifactKindForBody;
   onClose: () => void;
   onToggleFullscreen: () => void;
+  syncTarget?: ArtifactDownloadSyncTarget;
   title: string;
   url?: string;
 }) {
@@ -248,16 +404,23 @@ function ArtifactSidebarActions({
     <div className="flex shrink-0 items-center gap-1">
       {url && (
         <>
-          <ArtifactPrimaryAction kind={kind} title={title} url={url} />
-          {!compactActions && <ArtifactCopyAction url={url} />}
+          {kind === "html" && <ArtifactOpenExternalAction url={url} />}
+          <ArtifactShareButton ariaLabel="Share artifact" url={url} />
+          <ArtifactDownloadMenu
+            ariaLabel="Download artifact"
+            filename={title}
+            syncTarget={syncTarget}
+            url={url}
+          />
+          <ArtifactActionSeparator />
         </>
       )}
       <ArtifactFullscreenAction
         fullscreen={fullscreen}
         onToggleFullscreen={onToggleFullscreen}
       />
-      {compactActions && url ? (
-        <ArtifactMoreActions onClose={onClose} url={url} />
+      {compactActions ? (
+        <ArtifactMoreActions onClose={onClose} />
       ) : (
         <ArtifactCloseAction onClose={onClose} />
       )}
@@ -265,61 +428,18 @@ function ArtifactSidebarActions({
   );
 }
 
-function ArtifactPrimaryAction({
-  kind,
-  title,
-  url,
-}: {
-  kind?: ArtifactKindForBody;
-  title: string;
-  url: string;
-}) {
-  if (kind === "html") {
-    return (
-      <a
-        href={publicAttachmentUrl(url)}
-        target="_blank"
-        rel="noopener noreferrer"
-        aria-label="Open in new tab"
-        data-testid="artifact-sidebar-open-external"
-        className="inline-flex h-8 w-8 items-center justify-center rounded-md text-muted-foreground hover:bg-muted/60 hover:text-foreground"
-      >
-        <IconExternalLink size={16} />
-      </a>
-    );
-  }
-
+function ArtifactOpenExternalAction({ url }: { url: string }) {
   return (
-    <button
-      type="button"
-      onClick={() => {
-        detach(
-          downloadAttachmentUrl(url, undefined, title),
-          Reason.DomCallback,
-          "artifact download",
-        );
-      }}
-      aria-label="Download"
+    <a
+      href={publicAttachmentUrl(url)}
+      target="_blank"
+      rel="noopener noreferrer"
+      aria-label="Open in new tab"
+      data-testid="artifact-sidebar-open-external"
       className="inline-flex h-8 w-8 items-center justify-center rounded-md text-muted-foreground hover:bg-muted/60 hover:text-foreground"
     >
-      <IconDownload size={16} />
-    </button>
-  );
-}
-
-function ArtifactCopyAction({ url }: { url: string }) {
-  return (
-    <button
-      type="button"
-      onClick={() => {
-        copyArtifactUrl(url);
-      }}
-      aria-label="Copy artifact URL"
-      title={publicAttachmentUrl(url)}
-      className="inline-flex h-8 w-8 items-center justify-center rounded-md text-muted-foreground hover:bg-muted/60 hover:text-foreground"
-    >
-      <IconCopy size={16} />
-    </button>
+      <IconExternalLink size={16} />
+    </a>
   );
 }
 
@@ -347,13 +467,7 @@ function ArtifactFullscreenAction({
   );
 }
 
-function ArtifactMoreActions({
-  onClose,
-  url,
-}: {
-  onClose: () => void;
-  url: string;
-}) {
+function ArtifactMoreActions({ onClose }: { onClose: () => void }) {
   return (
     <DropdownMenu>
       <DropdownMenuTrigger asChild>
@@ -366,13 +480,6 @@ function ArtifactMoreActions({
         </button>
       </DropdownMenuTrigger>
       <DropdownMenuContent align="end">
-        <DropdownMenuItem
-          onClick={() => {
-            copyArtifactUrl(url);
-          }}
-        >
-          Copy link
-        </DropdownMenuItem>
         <DropdownMenuItem onClick={onClose}>Close preview</DropdownMenuItem>
       </DropdownMenuContent>
     </DropdownMenu>
@@ -391,49 +498,6 @@ function ArtifactCloseAction({ onClose }: { onClose: () => void }) {
       <IconX size={16} />
     </button>
   );
-}
-
-function copyArtifactUrl(url: string) {
-  detach(
-    copyAttachmentLinkToClipboard(url),
-    Reason.DomCallback,
-    "artifact copy link",
-  );
-}
-
-function artifactKindLabel(kind: ArtifactKindForBody): string {
-  switch (kind) {
-    case "markdown": {
-      return "Markdown document";
-    }
-    case "text": {
-      return "Text document";
-    }
-    case "json": {
-      return "JSON document";
-    }
-    case "csv": {
-      return "Data table";
-    }
-    case "html": {
-      return "Hosted site";
-    }
-    case "pdf": {
-      return "PDF document";
-    }
-    case "image": {
-      return "Image";
-    }
-    case "video": {
-      return "Video";
-    }
-    case "audio": {
-      return "Audio";
-    }
-    case "file": {
-      return "File";
-    }
-  }
 }
 
 function ArtifactBody({
@@ -487,6 +551,41 @@ function ArtifactBodyError({ message }: { message: string }): ReactNode {
   );
 }
 
+function ArtifactStageShell({
+  centered = false,
+  children,
+  gap = false,
+}: {
+  centered?: boolean;
+  children: ReactNode;
+  gap?: boolean;
+}) {
+  return (
+    <div
+      className="h-full overflow-auto bg-muted/30 p-5"
+      data-testid="artifact-sidebar-stage"
+    >
+      <div
+        className={cn(
+          "mx-auto flex min-h-full w-full max-w-[900px] flex-col",
+          centered && "items-center justify-center",
+          gap && "gap-3",
+        )}
+      >
+        {children}
+      </div>
+    </div>
+  );
+}
+
+function ArtifactStageCard({ children }: { children: ReactNode }) {
+  return (
+    <div className="flex min-h-[420px] w-full flex-1 flex-col overflow-hidden rounded-xl border border-border/70 bg-background shadow-sm">
+      {children}
+    </div>
+  );
+}
+
 function ArtifactMarkdownBody({
   url,
   signal,
@@ -498,15 +597,31 @@ function ArtifactMarkdownBody({
     <TextPreviewLoader url={url} signal={signal}>
       {({ status, text }) => {
         if (status === "loading") {
-          return <ArtifactSpinner />;
+          return (
+            <ArtifactStageShell>
+              <ArtifactStageCard>
+                <ArtifactSpinner />
+              </ArtifactStageCard>
+            </ArtifactStageShell>
+          );
         }
         if (status === "error") {
-          return <ArtifactBodyError message="Markdown preview unavailable." />;
+          return (
+            <ArtifactStageShell>
+              <ArtifactStageCard>
+                <ArtifactBodyError message="Markdown preview unavailable." />
+              </ArtifactStageCard>
+            </ArtifactStageShell>
+          );
         }
         return (
-          <div className="h-full overflow-auto p-6">
-            <Markdown source={text} />
-          </div>
+          <ArtifactStageShell>
+            <ArtifactStageCard>
+              <div className="h-full overflow-auto p-6">
+                <Markdown source={text} />
+              </div>
+            </ArtifactStageCard>
+          </ArtifactStageShell>
         );
       }}
     </TextPreviewLoader>
@@ -526,27 +641,41 @@ function ArtifactPlainTextBody({
     <TextPreviewLoader url={url} signal={signal}>
       {({ status, text }) => {
         if (status === "loading") {
-          return <ArtifactSpinner />;
+          return (
+            <ArtifactStageShell>
+              <ArtifactStageCard>
+                <ArtifactSpinner />
+              </ArtifactStageCard>
+            </ArtifactStageShell>
+          );
         }
         if (status === "error") {
           return (
-            <ArtifactBodyError
-              message={
-                kind === "json"
-                  ? "JSON preview unavailable."
-                  : "Text preview unavailable."
-              }
-            />
+            <ArtifactStageShell>
+              <ArtifactStageCard>
+                <ArtifactBodyError
+                  message={
+                    kind === "json"
+                      ? "JSON preview unavailable."
+                      : "Text preview unavailable."
+                  }
+                />
+              </ArtifactStageCard>
+            </ArtifactStageShell>
           );
         }
         const formatted = formatBodyText(kind, text);
         return (
-          <pre
-            className="h-full overflow-auto whitespace-pre-wrap break-words p-6 text-sm text-foreground"
-            data-testid={`artifact-sidebar-body-${kind}`}
-          >
-            {formatted}
-          </pre>
+          <ArtifactStageShell>
+            <ArtifactStageCard>
+              <pre
+                className="m-0 h-full overflow-auto whitespace-pre-wrap break-words p-6 text-sm text-foreground"
+                data-testid={`artifact-sidebar-body-${kind}`}
+              >
+                {formatted}
+              </pre>
+            </ArtifactStageCard>
+          </ArtifactStageShell>
         );
       }}
     </TextPreviewLoader>
@@ -572,19 +701,41 @@ function ArtifactCsvBody({
     <TextPreviewLoader url={url} signal={signal}>
       {({ status, text }) => {
         if (status === "loading") {
-          return <ArtifactSpinner />;
+          return (
+            <ArtifactStageShell>
+              <ArtifactStageCard>
+                <ArtifactSpinner />
+              </ArtifactStageCard>
+            </ArtifactStageShell>
+          );
         }
         if (status === "error") {
-          return <ArtifactBodyError message="CSV preview unavailable." />;
+          return (
+            <ArtifactStageShell>
+              <ArtifactStageCard>
+                <ArtifactBodyError message="CSV preview unavailable." />
+              </ArtifactStageCard>
+            </ArtifactStageShell>
+          );
         }
         const rows = parseCsvRows(text);
         if (rows.length === 0) {
-          return <ArtifactBodyError message="Empty CSV." />;
+          return (
+            <ArtifactStageShell>
+              <ArtifactStageCard>
+                <ArtifactBodyError message="Empty CSV." />
+              </ArtifactStageCard>
+            </ArtifactStageShell>
+          );
         }
         return (
-          <div className="h-full overflow-auto p-6">
-            <CsvPreviewTable rows={rows} />
-          </div>
+          <ArtifactStageShell>
+            <ArtifactStageCard>
+              <div className="h-full overflow-auto p-5">
+                <CsvPreviewTable rows={rows} />
+              </div>
+            </ArtifactStageCard>
+          </ArtifactStageShell>
         );
       }}
     </TextPreviewLoader>
@@ -609,22 +760,26 @@ function ArtifactImageBody({
   const zoomOut = useSet(zoomImageLightboxOut$);
 
   return (
-    <div className="relative flex h-full items-center justify-center overflow-auto bg-muted/20 p-4">
-      <img
-        key={url}
-        ref={setImageRef}
-        src={url}
-        alt={filename}
-        style={{ transform: `scale(${String(zoom)})` }}
-        className="max-h-full max-w-full object-contain transition-transform duration-150"
-        data-testid="artifact-sidebar-body-image"
-      />
-      <ArtifactImageZoomControls
-        zoom={zoom}
-        zoomIn={zoomIn}
-        zoomOut={zoomOut}
-      />
-    </div>
+    <ArtifactStageShell>
+      <ArtifactStageCard>
+        <div className="relative flex min-h-full flex-1 items-center justify-center overflow-auto bg-muted/30 p-6">
+          <img
+            key={url}
+            ref={setImageRef}
+            src={publicAttachmentUrl(url)}
+            alt={filename}
+            style={{ transform: `scale(${String(zoom)})` }}
+            className="max-h-full max-w-full object-contain transition-transform duration-150"
+            data-testid="artifact-sidebar-body-image"
+          />
+          <ArtifactImageZoomControls
+            zoom={zoom}
+            zoomIn={zoomIn}
+            zoomOut={zoomOut}
+          />
+        </div>
+      </ArtifactStageCard>
+    </ArtifactStageShell>
   );
 }
 
@@ -682,16 +837,21 @@ function ArtifactVideoBody({
   filename: string;
 }) {
   return (
-    <div className="flex h-full items-center justify-center bg-black/95 p-4">
-      <video
-        src={publicAttachmentUrl(url)}
-        controls
-        playsInline
-        className="max-h-full max-w-full"
-        aria-label={`Video preview for ${filename}`}
-        data-testid="artifact-sidebar-body-video"
-      />
-    </div>
+    <ArtifactStageShell centered>
+      <div
+        className="w-full overflow-hidden rounded-xl border border-border/70 bg-black shadow-sm"
+        data-testid="artifact-sidebar-video-stage"
+      >
+        <video
+          src={publicAttachmentUrl(url)}
+          controls
+          playsInline
+          className="block aspect-video w-full bg-black object-contain"
+          aria-label={`Video preview for ${filename}`}
+          data-testid="artifact-sidebar-body-video"
+        />
+      </div>
+    </ArtifactStageShell>
   );
 }
 
@@ -703,17 +863,19 @@ function ArtifactAudioBody({
   filename: string;
 }) {
   return (
-    <div className="flex h-full flex-col items-center justify-center gap-4 p-6">
-      <p className="text-sm text-muted-foreground">{filename}</p>
-      <audio
-        src={url}
-        controls
-        preload="metadata"
-        className="w-full max-w-md"
-        aria-label={`Audio preview for ${filename}`}
-        data-testid="artifact-sidebar-body-audio"
-      />
-    </div>
+    <ArtifactStageShell centered>
+      <div className="flex w-full max-w-[520px] flex-col items-center gap-4 rounded-xl border border-border/70 bg-background p-6 shadow-sm">
+        <p className="text-sm text-muted-foreground">{filename}</p>
+        <audio
+          src={publicAttachmentUrl(url)}
+          controls
+          preload="metadata"
+          className="w-full"
+          aria-label={`Audio preview for ${filename}`}
+          data-testid="artifact-sidebar-body-audio"
+        />
+      </div>
+    </ArtifactStageShell>
   );
 }
 
@@ -730,22 +892,39 @@ function ArtifactIframeBody({
   // (thumbnails / bookmarks) so the embedded preview shows just the page
   // and toolbar by default. Firefox/PDF.js silently ignores it.
   const src = kind === "pdf" ? `${url}#navpanes=0` : url;
+  if (kind === "html") {
+    return (
+      <iframe
+        src={src}
+        title={`${filename} preview`}
+        sandbox="allow-scripts"
+        className="h-full w-full border-0 bg-background"
+        data-testid={`artifact-sidebar-body-${kind}`}
+      />
+    );
+  }
+
   return (
-    <iframe
-      src={src}
-      title={`${filename} preview`}
-      sandbox={kind === "html" ? "allow-scripts" : undefined}
-      className="h-full w-full bg-background"
-      data-testid={`artifact-sidebar-body-${kind}`}
-    />
+    <ArtifactStageShell>
+      <div className="flex min-h-[420px] w-full flex-1 overflow-hidden rounded-xl border border-border/70 bg-background shadow-sm">
+        <iframe
+          src={src}
+          title={`${filename} preview`}
+          className="h-full w-full bg-background"
+          data-testid={`artifact-sidebar-body-${kind}`}
+        />
+      </div>
+    </ArtifactStageShell>
   );
 }
 
 function ArtifactGenericBody({ filename }: { filename: string }) {
   return (
-    <div className="flex h-full flex-col items-center justify-center gap-3 p-6 text-center text-muted-foreground">
-      <p className="text-sm">No inline preview available for this file.</p>
-      <p className="text-xs">{filename}</p>
-    </div>
+    <ArtifactStageShell centered>
+      <div className="flex w-full max-w-md flex-col items-center justify-center gap-3 rounded-xl border border-border/70 bg-background p-6 text-center text-muted-foreground shadow-sm">
+        <p className="text-sm">No inline preview available for this file.</p>
+        <p className="text-xs">{filename}</p>
+      </div>
+    </ArtifactStageShell>
   );
 }

--- a/turbo/apps/platform/src/views/zero-page/zero-artifact-sidebar.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-artifact-sidebar.tsx
@@ -551,19 +551,25 @@ function ArtifactStageShell({
   centered = false,
   children,
   gap = false,
+  scrollable = true,
 }: {
   centered?: boolean;
   children: ReactNode;
   gap?: boolean;
+  scrollable?: boolean;
 }) {
   return (
     <div
-      className="h-full overflow-auto bg-muted/30 p-5"
+      className={cn(
+        "h-full min-h-0 bg-muted/30 p-5",
+        scrollable ? "overflow-auto" : "overflow-hidden",
+      )}
       data-testid="artifact-sidebar-stage"
     >
       <div
         className={cn(
-          "mx-auto flex min-h-full w-full max-w-[900px] flex-col",
+          "mx-auto flex w-full max-w-[900px] flex-col",
+          scrollable ? "min-h-full" : "h-full min-h-0",
           centered && "items-center justify-center",
           gap && "gap-3",
         )}
@@ -574,9 +580,20 @@ function ArtifactStageShell({
   );
 }
 
-function ArtifactStageCard({ children }: { children: ReactNode }) {
+function ArtifactStageCard({
+  children,
+  fillHeight = false,
+}: {
+  children: ReactNode;
+  fillHeight?: boolean;
+}) {
   return (
-    <div className="flex min-h-[420px] w-full flex-1 flex-col overflow-hidden rounded-xl border border-border/70 bg-background shadow-sm">
+    <div
+      className={cn(
+        "flex w-full flex-1 flex-col overflow-hidden rounded-xl border border-border/70 bg-background shadow-sm",
+        fillHeight ? "h-full min-h-0" : "min-h-[420px]",
+      )}
+    >
       {children}
     </div>
   );
@@ -746,8 +763,8 @@ function ArtifactImageBody({
   filename: string;
 }) {
   return (
-    <ArtifactStageShell>
-      <ArtifactStageCard>
+    <ArtifactStageShell scrollable={false}>
+      <ArtifactStageCard fillHeight>
         <ZoomableArtifactImageCanvas
           src={publicAttachmentUrl(url)}
           alt={filename}

--- a/turbo/apps/platform/src/views/zero-page/zero-artifact-sidebar.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-artifact-sidebar.tsx
@@ -551,25 +551,29 @@ function ArtifactBodyError({ message }: { message: string }): ReactNode {
 function ArtifactStageShell({
   centered = false,
   children,
+  flush = false,
   gap = false,
   scrollable = true,
 }: {
   centered?: boolean;
   children: ReactNode;
+  flush?: boolean;
   gap?: boolean;
   scrollable?: boolean;
 }) {
   return (
     <div
       className={cn(
-        "h-full min-h-0 bg-muted/30 p-5",
+        "h-full min-h-0 bg-muted/30",
+        flush ? "p-0" : "p-5",
         scrollable ? "overflow-auto" : "overflow-hidden",
       )}
       data-testid="artifact-sidebar-stage"
     >
       <div
         className={cn(
-          "mx-auto flex w-full max-w-[900px] flex-col",
+          "mx-auto flex w-full flex-col",
+          flush ? "max-w-none" : "max-w-[900px]",
           scrollable ? "min-h-full" : "h-full min-h-0",
           centered && "items-center justify-center",
           gap && "gap-3",
@@ -591,10 +595,10 @@ function ArtifactStageCard({
   return (
     <div
       className={cn(
-        "flex w-full flex-1 flex-col overflow-hidden rounded-xl",
+        "flex w-full flex-1 flex-col overflow-hidden",
         fillHeight
           ? "h-full min-h-0 bg-transparent"
-          : "min-h-[420px] border border-border/70 bg-background shadow-sm",
+          : "min-h-[420px] rounded-xl border border-border/70 bg-background shadow-sm",
       )}
     >
       {children}
@@ -766,14 +770,14 @@ function ArtifactImageBody({
   filename: string;
 }) {
   return (
-    <ArtifactStageShell scrollable={false}>
+    <ArtifactStageShell flush scrollable={false}>
       <ArtifactStageCard fillHeight>
         <ZoomableArtifactImageCanvas
           src={publicAttachmentUrl(url)}
           alt={filename}
           zoomKey={`artifact-sidebar:${url}`}
           imageTestId="artifact-sidebar-body-image"
-          className="p-6"
+          contentClassName="p-6"
         >
           {(controls) => {
             return <ArtifactImageZoomControls controls={controls} />;

--- a/turbo/apps/platform/src/views/zero-page/zero-artifact-sidebar.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-artifact-sidebar.tsx
@@ -7,6 +7,7 @@ import {
   IconDots,
   IconExternalLink,
   IconLoader2,
+  IconZoomReset,
   IconX,
 } from "@tabler/icons-react";
 import {
@@ -590,8 +591,10 @@ function ArtifactStageCard({
   return (
     <div
       className={cn(
-        "flex w-full flex-1 flex-col overflow-hidden rounded-xl border border-border/70 bg-background shadow-sm",
-        fillHeight ? "h-full min-h-0" : "min-h-[420px]",
+        "flex w-full flex-1 flex-col overflow-hidden rounded-xl",
+        fillHeight
+          ? "h-full min-h-0 bg-transparent"
+          : "min-h-[420px] border border-border/70 bg-background shadow-sm",
       )}
     >
       {children}
@@ -818,6 +821,16 @@ function ArtifactImageZoomControls({
         data-testid="artifact-sidebar-image-zoom-in"
       >
         +
+      </button>
+      <button
+        type="button"
+        onClick={controls.resetZoom}
+        className="flex h-5 w-5 items-center justify-center rounded-md transition-colors hover:bg-muted/70 hover:text-foreground"
+        aria-label="Reset zoom"
+        title="Reset zoom"
+        data-testid="artifact-sidebar-image-reset-zoom"
+      >
+        <IconZoomReset size={15} stroke={1.8} />
       </button>
     </div>
   );

--- a/turbo/apps/platform/src/views/zero-page/zero-artifact-sidebar.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-artifact-sidebar.tsx
@@ -40,9 +40,11 @@ import {
 import { Markdown } from "../components/markdown.tsx";
 import { pageSignal$ } from "../../signals/page-signal.ts";
 import { jsonParseOr } from "../../signals/utils.ts";
+import { resetZoomableImageCanvasZoom$ } from "../../signals/view-component-state.ts";
 import {
   ZoomableArtifactImageCanvas,
   type ZoomableImageControls,
+  zoomableArtifactImageKey,
 } from "./zero-zoomable-image-canvas.tsx";
 import type { ChatThreadSignals } from "../../signals/chat-page/create-chat-thread.ts";
 import type { ChatThreadArtifactFile } from "@vm0/api-contracts/contracts/chat-threads";
@@ -162,6 +164,7 @@ function ArtifactSidebarContent({
   const fullscreen = useGet(artifactFullscreen$);
   const close = useSet(closeArtifact$);
   const toggleFullscreen = useSet(toggleArtifactFullscreen$);
+  const resetZoomableImageCanvasZoom = useSet(resetZoomableImageCanvasZoom$);
   const pageSignal = useGet(pageSignal$);
   const closePreview = onClose ?? close;
 
@@ -209,6 +212,26 @@ function ArtifactSidebarContent({
       : sidebar;
   }
 
+  const toggleFullscreenWithImageReset = () => {
+    if (display.kind === "image") {
+      resetZoomableImageCanvasZoom(
+        zoomableArtifactImageKey(
+          "artifact-sidebar",
+          display.url,
+          fullscreen ? "fullscreen" : "sidebar",
+        ),
+      );
+      resetZoomableImageCanvasZoom(
+        zoomableArtifactImageKey(
+          "artifact-sidebar",
+          display.url,
+          fullscreen ? "sidebar" : "fullscreen",
+        ),
+      );
+    }
+    toggleFullscreen();
+  };
+
   const sidebar = (
     <div
       className={cn(
@@ -227,7 +250,7 @@ function ArtifactSidebarContent({
         url={display.url}
         fullscreen={fullscreen}
         onBack={onBack}
-        onToggleFullscreen={toggleFullscreen}
+        onToggleFullscreen={toggleFullscreenWithImageReset}
         onClose={closePreview}
       />
       <div className="min-h-0 flex-1 overflow-hidden bg-background">
@@ -769,13 +792,19 @@ function ArtifactImageBody({
   url: string;
   filename: string;
 }) {
+  const fullscreen = useGet(artifactFullscreen$);
+
   return (
     <ArtifactStageShell flush scrollable={false}>
       <ArtifactStageCard fillHeight>
         <ZoomableArtifactImageCanvas
           src={publicAttachmentUrl(url)}
           alt={filename}
-          zoomKey={`artifact-sidebar:${url}`}
+          zoomKey={zoomableArtifactImageKey(
+            "artifact-sidebar",
+            url,
+            fullscreen ? "fullscreen" : "sidebar",
+          )}
           imageTestId="artifact-sidebar-body-image"
           contentClassName="p-6"
         >

--- a/turbo/apps/platform/src/views/zero-page/zero-artifact-sidebar.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-artifact-sidebar.tsx
@@ -40,13 +40,9 @@ import { Markdown } from "../components/markdown.tsx";
 import { pageSignal$ } from "../../signals/page-signal.ts";
 import { jsonParseOr } from "../../signals/utils.ts";
 import {
-  IMAGE_LIGHTBOX_MAX_ZOOM,
-  IMAGE_LIGHTBOX_MIN_ZOOM,
-  imageLightboxImageRef$,
-  imageLightboxState$,
-  zoomImageLightboxIn$,
-  zoomImageLightboxOut$,
-} from "../../signals/view-component-state.ts";
+  ZoomableArtifactImageCanvas,
+  type ZoomableImageControls,
+} from "./zero-zoomable-image-canvas.tsx";
 import type { ChatThreadSignals } from "../../signals/chat-page/create-chat-thread.ts";
 import type { ChatThreadArtifactFile } from "@vm0/api-contracts/contracts/chat-threads";
 import {
@@ -749,58 +745,39 @@ function ArtifactImageBody({
   url: string;
   filename: string;
 }) {
-  // The sidebar image preview and the legacy full-screen lightbox are mutually
-  // exclusive (chatArtifactSidebar feature switch routes image clicks to one
-  // or the other), so the lightbox zoom state is reused here. The `key={url}`
-  // on the img remounts it on artifact change, which triggers the onRef
-  // reset that wipes any stale zoom level.
-  const { zoom } = useGet(imageLightboxState$);
-  const setImageRef = useSet(imageLightboxImageRef$);
-  const zoomIn = useSet(zoomImageLightboxIn$);
-  const zoomOut = useSet(zoomImageLightboxOut$);
-
   return (
     <ArtifactStageShell>
       <ArtifactStageCard>
-        <div className="relative flex min-h-full flex-1 items-center justify-center overflow-auto bg-muted/30 p-6">
-          <img
-            key={url}
-            ref={setImageRef}
-            src={publicAttachmentUrl(url)}
-            alt={filename}
-            style={{ transform: `scale(${String(zoom)})` }}
-            className="max-h-full max-w-full object-contain transition-transform duration-150"
-            data-testid="artifact-sidebar-body-image"
-          />
-          <ArtifactImageZoomControls
-            zoom={zoom}
-            zoomIn={zoomIn}
-            zoomOut={zoomOut}
-          />
-        </div>
+        <ZoomableArtifactImageCanvas
+          src={publicAttachmentUrl(url)}
+          alt={filename}
+          zoomKey={`artifact-sidebar:${url}`}
+          imageTestId="artifact-sidebar-body-image"
+          className="p-6"
+        >
+          {(controls) => {
+            return <ArtifactImageZoomControls controls={controls} />;
+          }}
+        </ZoomableArtifactImageCanvas>
       </ArtifactStageCard>
     </ArtifactStageShell>
   );
 }
 
 function ArtifactImageZoomControls({
-  zoom,
-  zoomIn,
-  zoomOut,
+  controls,
 }: {
-  zoom: number;
-  zoomIn: () => void;
-  zoomOut: () => void;
+  controls: ZoomableImageControls;
 }) {
   return (
     <div
-      className="absolute right-4 top-4 z-10 flex items-center gap-2 rounded-lg border border-border/70 bg-background/95 px-2.5 py-1.5 text-muted-foreground shadow-sm backdrop-blur-sm"
+      className="absolute right-4 top-4 z-10 flex items-center gap-2 rounded-lg bg-background/95 px-2.5 py-1.5 text-muted-foreground shadow-sm backdrop-blur-sm"
       data-testid="artifact-sidebar-image-zoom-controls"
     >
       <button
         type="button"
-        onClick={zoomOut}
-        disabled={zoom <= IMAGE_LIGHTBOX_MIN_ZOOM}
+        onClick={controls.zoomOut}
+        disabled={!controls.canZoomOut}
         className="flex h-5 w-5 items-center justify-center rounded-md text-sm leading-none transition-colors hover:bg-muted/70 hover:text-foreground disabled:pointer-events-none disabled:opacity-40"
         aria-label="Zoom out"
         title="Zoom out"
@@ -812,12 +789,12 @@ function ArtifactImageZoomControls({
         className="min-w-10 text-center text-xs font-medium tabular-nums text-foreground"
         data-testid="artifact-sidebar-image-zoom-level"
       >
-        {Math.round(zoom * 100)}%
+        {Math.round(controls.zoom * 100)}%
       </span>
       <button
         type="button"
-        onClick={zoomIn}
-        disabled={zoom >= IMAGE_LIGHTBOX_MAX_ZOOM}
+        onClick={controls.zoomIn}
+        disabled={!controls.canZoomIn}
         className="flex h-5 w-5 items-center justify-center rounded-md text-sm leading-none transition-colors hover:bg-muted/70 hover:text-foreground disabled:pointer-events-none disabled:opacity-40"
         aria-label="Zoom in"
         title="Zoom in"

--- a/turbo/apps/platform/src/views/zero-page/zero-attachment-chips.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-attachment-chips.tsx
@@ -740,8 +740,10 @@ function ArtifactDialogCard({
 }) {
   return (
     <div
-      className={`flex w-full flex-1 flex-col overflow-hidden rounded-xl border border-border/70 bg-background shadow-sm ${
-        fillHeight ? "h-full min-h-0" : "min-h-[420px]"
+      className={`flex w-full flex-1 flex-col overflow-hidden rounded-xl ${
+        fillHeight
+          ? "h-full min-h-0 bg-transparent"
+          : "min-h-[420px] border border-border/70 bg-background shadow-sm"
       }`}
       data-testid="artifact-dialog-card"
     >
@@ -786,11 +788,11 @@ function ArtifactDialogImageZoomControls({
       <button
         type="button"
         onClick={controls.resetZoom}
-        className="rounded-md px-1.5 text-xs font-medium transition-colors hover:bg-muted/70 hover:text-foreground"
+        className="flex h-5 w-5 items-center justify-center rounded-md transition-colors hover:bg-muted/70 hover:text-foreground"
         aria-label="Reset zoom"
         title="Reset zoom"
       >
-        Reset
+        <IconZoomReset size={15} stroke={1.8} />
       </button>
     </div>
   );

--- a/turbo/apps/platform/src/views/zero-page/zero-attachment-chips.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-attachment-chips.tsx
@@ -1054,7 +1054,7 @@ function ArtifactPreviewDialogContent({
     <div
       ref={dialogRef}
       tabIndex={-1}
-      className={`fixed inset-0 z-[9999] isolate flex items-center justify-center bg-gray-900/45 outline-none transition-opacity duration-[180ms] ease ${
+      className={`fixed inset-0 z-[9999] isolate flex items-center justify-center bg-gray-900/45 outline-none transition-opacity duration-[180ms] ease animate-in fade-in ${
         visible
           ? "pointer-events-auto opacity-100"
           : "pointer-events-none opacity-0"
@@ -1067,13 +1067,14 @@ function ArtifactPreviewDialogContent({
     >
       <LightboxBodyScrollLock />
       <div
-        className={`flex min-h-0 flex-col overflow-hidden bg-background text-foreground shadow-[0_24px_70px_rgba(0,0,0,0.30)] transition-transform duration-[180ms] ease ${
+        className={`flex min-h-0 flex-col overflow-hidden bg-background text-foreground shadow-[0_24px_70px_rgba(0,0,0,0.30)] transition-transform duration-[180ms] ease animate-in slide-in-from-bottom-2 ${
           visible ? "translate-y-0" : "translate-y-2"
         } ${
           fullscreen
             ? "h-dvh w-dvw rounded-none"
             : "h-[min(700px,86vh)] w-[min(980px,92vw)] rounded-2xl"
         }`}
+        data-testid="attachment-lightbox-panel"
       >
         <div className="flex h-14 shrink-0 items-center gap-2 border-b border-border/70 pl-4 pr-3">
           <div className="min-w-0 flex-1">

--- a/turbo/apps/platform/src/views/zero-page/zero-attachment-chips.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-attachment-chips.tsx
@@ -39,6 +39,7 @@ import {
   imageLightboxState$,
   imageLoadStatusByKey$,
   imageLoadStatusRef$,
+  resetZoomableImageCanvasZoom$,
   setImageLightboxStatus$,
   setImageLoadStatus$,
   textPreviewLoaderRef$,
@@ -83,6 +84,7 @@ import {
 import {
   ZoomableArtifactImageCanvas,
   type ZoomableImageControls,
+  zoomableArtifactImageKey,
 } from "./zero-zoomable-image-canvas.tsx";
 
 export {
@@ -437,7 +439,7 @@ function ImageLightboxContent({
     <ZoomableArtifactImageCanvas
       src={url}
       alt=""
-      zoomKey={`attachment-lightbox:${url}`}
+      zoomKey={zoomableArtifactImageKey("attachment-lightbox", url)}
       keyboardShortcuts
       imageRef={imageLightboxImageRef}
       imageTestId="attachment-lightbox-image"
@@ -901,6 +903,7 @@ function ArtifactDialogBody({
   preview: AttachmentLightboxState;
 }) {
   const filename = artifactDialogFilename(preview);
+  const fullscreen = useGet(lightboxDialogFullscreen$);
 
   if (preview.kind === "image") {
     return (
@@ -909,7 +912,7 @@ function ArtifactDialogBody({
           <ZoomableArtifactImageCanvas
             src={publicAttachmentUrl(preview.url)}
             alt={filename}
-            zoomKey={`artifact-dialog:${preview.url}`}
+            zoomKey={artifactDialogImageZoomKey(preview.url, fullscreen)}
             imageTestId="attachment-lightbox-image"
             contentClassName="p-6"
             imageClassName="rounded-lg shadow-sm"
@@ -1085,6 +1088,32 @@ function ArtifactPreviewDialogThreadResolver({
   );
 }
 
+function artifactDialogImageZoomKey(url: string, fullscreen: boolean) {
+  return zoomableArtifactImageKey(
+    "artifact-dialog",
+    url,
+    fullscreen ? "fullscreen" : "windowed",
+  );
+}
+
+function resetArtifactDialogImageZoom({
+  fullscreen,
+  preview,
+  resetZoom,
+  targetFullscreen,
+}: {
+  fullscreen: boolean;
+  preview: AttachmentLightboxState;
+  resetZoom: (key: string) => void;
+  targetFullscreen: boolean;
+}) {
+  if (preview.kind !== "image") {
+    return;
+  }
+  resetZoom(artifactDialogImageZoomKey(preview.url, fullscreen));
+  resetZoom(artifactDialogImageZoomKey(preview.url, targetFullscreen));
+}
+
 function ArtifactPreviewDialogContent({
   artifact,
   preview,
@@ -1098,6 +1127,7 @@ function ArtifactPreviewDialogContent({
   const toggleLightboxDialogFullscreen = useSet(
     toggleLightboxDialogFullscreen$,
   );
+  const resetZoomableImageCanvasZoom = useSet(resetZoomableImageCanvasZoom$);
   const pageSignal = useGet(pageSignal$);
   const filename = artifact?.filename ?? artifactDialogFilename(preview);
   const subtitle = artifactDialogKindLabel(preview, artifact);
@@ -1109,7 +1139,22 @@ function ArtifactPreviewDialogContent({
     closeLightboxWithDialogExit();
   };
 
+  const resetDialogImageZoom = (targetFullscreen: boolean) => {
+    resetArtifactDialogImageZoom({
+      fullscreen,
+      preview,
+      resetZoom: resetZoomableImageCanvasZoom,
+      targetFullscreen,
+    });
+  };
+
   const openInSplitView = () => {
+    resetDialogImageZoom(fullscreen);
+    if (preview.kind === "image") {
+      resetZoomableImageCanvasZoom(
+        zoomableArtifactImageKey("artifact-sidebar", preview.url, "sidebar"),
+      );
+    }
     openArtifactSidebarPreview(preview.url);
     closeLightboxWithDialogExit();
   };
@@ -1171,6 +1216,7 @@ function ArtifactPreviewDialogContent({
             <ArtifactDialogFullscreenButton
               fullscreen={fullscreen}
               onClick={() => {
+                resetDialogImageZoom(!fullscreen);
                 toggleLightboxDialogFullscreen();
               }}
             />

--- a/turbo/apps/platform/src/views/zero-page/zero-attachment-chips.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-attachment-chips.tsx
@@ -121,10 +121,9 @@ function contentTypeForDocumentAttachmentPreviewKind(
 }
 
 const ATTACHMENT_LIGHTBOX_OVERLAY_CLASS =
-  "pointer-events-auto fixed inset-0 z-[9999] isolate flex items-center justify-center bg-black/80 backdrop-blur-sm animate-in fade-in duration-[180ms] ease outline-none";
+  "zero-dialog-enter-overlay pointer-events-auto fixed inset-0 z-[9999] isolate flex items-center justify-center bg-black/80 backdrop-blur-sm outline-none";
 
-const ATTACHMENT_LIGHTBOX_PANEL_CLASS =
-  "animate-in slide-in-from-bottom-2 duration-[180ms] ease";
+const ATTACHMENT_LIGHTBOX_PANEL_CLASS = "zero-dialog-enter-content";
 
 // ---------------------------------------------------------------------------
 // AttachmentLightbox — full-screen attachment viewer
@@ -705,18 +704,24 @@ function ArtifactDialogStage({
   children,
   centered = false,
   gap = false,
+  scrollable = true,
 }: {
   children: ReactNode;
   centered?: boolean;
   gap?: boolean;
+  scrollable?: boolean;
 }) {
   return (
     <div
-      className="h-full overflow-auto bg-muted/30 p-5"
+      className={`h-full min-h-0 bg-muted/30 p-5 ${
+        scrollable ? "overflow-auto" : "overflow-hidden"
+      }`}
       data-testid="artifact-dialog-stage"
     >
       <div
-        className={`mx-auto flex min-h-full w-full max-w-[900px] flex-col ${
+        className={`mx-auto flex w-full max-w-[900px] flex-col ${
+          scrollable ? "min-h-full" : "h-full min-h-0"
+        } ${
           centered ? "items-center justify-center" : ""
         } ${gap ? "gap-3" : ""}`}
       >
@@ -726,10 +731,18 @@ function ArtifactDialogStage({
   );
 }
 
-function ArtifactDialogCard({ children }: { children: ReactNode }) {
+function ArtifactDialogCard({
+  children,
+  fillHeight = false,
+}: {
+  children: ReactNode;
+  fillHeight?: boolean;
+}) {
   return (
     <div
-      className="flex min-h-[420px] w-full flex-1 flex-col overflow-hidden rounded-xl border border-border/70 bg-background shadow-sm"
+      className={`flex w-full flex-1 flex-col overflow-hidden rounded-xl border border-border/70 bg-background shadow-sm ${
+        fillHeight ? "h-full min-h-0" : "min-h-[420px]"
+      }`}
       data-testid="artifact-dialog-card"
     >
       {children}
@@ -887,8 +900,8 @@ function ArtifactDialogBody({
 
   if (preview.kind === "image") {
     return (
-      <ArtifactDialogStage>
-        <ArtifactDialogCard>
+      <ArtifactDialogStage scrollable={false}>
+        <ArtifactDialogCard fillHeight>
           <ZoomableArtifactImageCanvas
             src={publicAttachmentUrl(preview.url)}
             alt={filename}
@@ -1107,7 +1120,7 @@ function ArtifactPreviewDialogContent({
     <div
       ref={dialogRef}
       tabIndex={-1}
-      className={`fixed inset-0 z-[9999] isolate flex items-center justify-center bg-gray-900/45 outline-none transition-opacity duration-[180ms] ease animate-in fade-in ${
+      className={`zero-dialog-enter-overlay fixed inset-0 z-[9999] isolate flex items-center justify-center bg-gray-900/45 outline-none transition-opacity duration-[180ms] ease ${
         visible
           ? "pointer-events-auto opacity-100"
           : "pointer-events-none opacity-0"
@@ -1120,7 +1133,7 @@ function ArtifactPreviewDialogContent({
     >
       <LightboxBodyScrollLock />
       <div
-        className={`flex min-h-0 flex-col overflow-hidden bg-background text-foreground shadow-[0_24px_70px_rgba(0,0,0,0.30)] transition-transform duration-[180ms] ease animate-in slide-in-from-bottom-2 ${
+        className={`zero-dialog-enter-content flex min-h-0 flex-col overflow-hidden bg-background text-foreground shadow-[0_24px_70px_rgba(0,0,0,0.30)] transition-transform duration-[180ms] ease ${
           visible ? "translate-y-0" : "translate-y-2"
         } ${
           fullscreen

--- a/turbo/apps/platform/src/views/zero-page/zero-attachment-chips.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-attachment-chips.tsx
@@ -1,22 +1,37 @@
 import type { MouseEvent, ReactNode } from "react";
-import { useGet, useSet, useLoadable } from "ccstate-react";
+import {
+  useGet,
+  useLastLoadable,
+  useLastResolved,
+  useLoadable,
+  useSet,
+} from "ccstate-react";
 import { createPortal } from "react-dom";
 import {
+  IconArrowsDiagonal,
+  IconArrowsDiagonalMinimize2,
+  IconColumns2,
   IconDownload,
-  IconLink,
   IconPhoto,
   IconLoader2,
+  IconShare,
   IconZoomIn,
   IconZoomOut,
   IconZoomReset,
   IconX,
 } from "@tabler/icons-react";
-import { toast } from "@vm0/ui/components/ui/sonner";
+import type {
+  ChatThreadArtifactFile,
+  ChatThreadArtifactRun,
+} from "@vm0/api-contracts/contracts/chat-threads";
 import type { ZeroChatAttachment } from "../../signals/chat-page/chat-message.ts";
-import { logger } from "../../signals/log.ts";
+import type { ChatThreadSignals } from "../../signals/chat-page/create-chat-thread.ts";
+import {
+  currentLeftThread$,
+  currentRightThread$,
+} from "../../signals/chat-page/chat-thread-panes.ts";
 import { detach, jsonParseOr, Reason } from "../../signals/utils.ts";
 import { pageSignal$ } from "../../signals/page-signal.ts";
-import { writeToClipboard } from "../../signals/zero-page/clipboard.ts";
 import {
   IMAGE_LIGHTBOX_MAX_ZOOM,
   IMAGE_LIGHTBOX_MIN_ZOOM,
@@ -38,13 +53,43 @@ import { Markdown } from "../components/markdown.tsx";
 import {
   lightboxUrl$,
   closeLightbox$,
+  closeLightboxWithDialogExit$,
+  lightboxDialogFullscreen$,
+  lightboxDialogVisible$,
   openDocumentLightbox$,
   openImageLightbox$,
   lightboxDialogRef$,
+  toggleLightboxDialogFullscreen$,
+  type AttachmentArtifactMetadata,
+  type AttachmentLightboxState,
 } from "../../signals/zero-page/zero-attachment-chips.ts";
+import {
+  chatArtifactSidebarEnabled$,
+  openArtifactSidebarPreview$,
+} from "../../signals/zero-page/zero-artifact-sidebar.ts";
 import { FilePreviewIcon } from "./zero-file-preview-icon.tsx";
+import {
+  attachmentFilenameFromUrl,
+  copyAttachmentLinkToClipboard,
+  downloadAttachmentUrl,
+  publicAttachmentUrl,
+} from "./zero-attachment-url.ts";
+import {
+  ArtifactActionSeparator,
+  ArtifactDownloadMenu,
+  ArtifactShareButton,
+  type ArtifactDownloadSyncTarget,
+} from "./zero-artifact-actions.tsx";
+import {
+  artifactFallbackSubtitle,
+  artifactTitleSubtitle,
+} from "./zero-artifact-display.ts";
 
-const log = logger("zero-attachment-chips");
+export {
+  downloadAttachmentUrl,
+  getAttachmentRawUrl,
+  publicAttachmentUrl,
+} from "./zero-attachment-url.ts";
 
 type DocumentAttachmentPreviewKind =
   | "markdown"
@@ -78,168 +123,6 @@ function contentTypeForDocumentAttachmentPreviewKind(
 // ---------------------------------------------------------------------------
 // AttachmentLightbox — full-screen attachment viewer
 // ---------------------------------------------------------------------------
-
-function filenameFromUrl(url: string): string {
-  const path = url.split("?")[0].split("#")[0];
-  const last = path.split("/").pop();
-  return last && last.length > 0 ? last : "image";
-}
-
-const LEGACY_FILE_PATH_PATTERN = /^\/f\/([^/]+)\/([^/]+)\/([^/]+)$/;
-const ARTIFACT_FILE_PATH_PATTERN = /^\/artifacts\/([^/]+)\/([^/]+)\/([^/]+)$/;
-const CLERK_USER_ID_PREFIX = "user_";
-
-function publicArtifactsBaseUrl(): string | null {
-  const baseUrl = import.meta.env.PUBLIC_ARTIFACTS_BASE_URL;
-  if (!baseUrl || !URL.canParse(baseUrl)) {
-    return null;
-  }
-  return baseUrl.replace(/\/+$/, "");
-}
-
-function hasExplicitUrlOrigin(url: string): boolean {
-  return /^[a-z][a-z\d+\-.]*:\/\//i.test(url);
-}
-
-function browserOrigin(): string | null {
-  if (typeof window === "undefined") {
-    return null;
-  }
-  return window.location.origin;
-}
-
-type PlatformHostTarget = "api" | "www";
-
-function rewritePlatformHostname(
-  hostname: string,
-  target: PlatformHostTarget,
-): string {
-  return hostname.replace(/(^|-)(platform|app|www|api)\./, `$1${target}.`);
-}
-
-function addOrigin(origins: Set<string>, baseUrl: string | null) {
-  if (!baseUrl || !URL.canParse(baseUrl)) {
-    return;
-  }
-  origins.add(new URL(baseUrl).origin);
-}
-
-function addPlatformOriginVariants(
-  origins: Set<string>,
-  baseUrl: string | null,
-) {
-  if (!baseUrl || !URL.canParse(baseUrl)) {
-    return;
-  }
-
-  const parsed = new URL(baseUrl);
-  origins.add(parsed.origin);
-
-  for (const target of ["api", "www"] as const) {
-    const variant = new URL(parsed);
-    variant.hostname = rewritePlatformHostname(variant.hostname, target);
-    origins.add(variant.origin);
-  }
-}
-
-function platformFileOrigins(): Set<string> {
-  const origins = new Set<string>();
-  const configuredApiUrl = import.meta.env.VITE_API_URL as string | undefined;
-
-  addPlatformOriginVariants(origins, browserOrigin());
-  addPlatformOriginVariants(origins, configuredApiUrl ?? null);
-  addOrigin(origins, publicArtifactsBaseUrl());
-
-  return origins;
-}
-
-function isPlatformFileUrlHost(parsed: URL, sourceUrl: string): boolean {
-  return (
-    !hasExplicitUrlOrigin(sourceUrl) || platformFileOrigins().has(parsed.origin)
-  );
-}
-
-function storageUserIdSegmentFromFileUrlSegment(userIdSegment: string): string {
-  if (
-    userIdSegment === "user" ||
-    userIdSegment.startsWith(CLERK_USER_ID_PREFIX) ||
-    userIdSegment.startsWith("user-")
-  ) {
-    return userIdSegment;
-  }
-  return `${CLERK_USER_ID_PREFIX}${userIdSegment}`;
-}
-
-function artifactCdnUrl(args: {
-  userIdSegment: string;
-  idSegment: string;
-  filenameSegment: string;
-  hash: string;
-}): string | null {
-  const baseUrl = publicArtifactsBaseUrl();
-  if (!baseUrl) {
-    return null;
-  }
-  return `${baseUrl}/artifacts/${args.userIdSegment}/${args.idSegment}/${args.filenameSegment}${args.hash}`;
-}
-
-function parseFileUrl(url: string): URL | null {
-  const baseUrl = browserOrigin() ?? undefined;
-  if (!URL.canParse(url, baseUrl)) {
-    return null;
-  }
-  return new URL(url, baseUrl);
-}
-
-function normalizedLegacyFileUrl(url: string): string | null {
-  const parsed = parseFileUrl(url);
-  if (!parsed) {
-    return null;
-  }
-  if (!isPlatformFileUrlHost(parsed, url)) {
-    return null;
-  }
-  const match = parsed.pathname.match(LEGACY_FILE_PATH_PATTERN);
-  if (!match) {
-    return null;
-  }
-  const [, userIdSegment, idSegment, filenameSegment] = match;
-  return artifactCdnUrl({
-    userIdSegment: storageUserIdSegmentFromFileUrlSegment(userIdSegment),
-    idSegment,
-    filenameSegment,
-    hash: parsed.hash,
-  });
-}
-
-function normalizedArtifactFileUrl(url: string): string | null {
-  const parsed = parseFileUrl(url);
-  if (!parsed) {
-    return null;
-  }
-  if (!isPlatformFileUrlHost(parsed, url)) {
-    return null;
-  }
-  const match = parsed.pathname.match(ARTIFACT_FILE_PATH_PATTERN);
-  if (!match) {
-    return null;
-  }
-  const [, userIdSegment, idSegment, filenameSegment] = match;
-  return artifactCdnUrl({
-    userIdSegment,
-    idSegment,
-    filenameSegment,
-    hash: parsed.hash,
-  });
-}
-
-export function publicAttachmentUrl(url: string): string {
-  return normalizedLegacyFileUrl(url) ?? normalizedArtifactFileUrl(url) ?? url;
-}
-
-export function getAttachmentRawUrl(url: string): string {
-  return url;
-}
 
 export function TextPreviewLoader({
   url,
@@ -343,68 +226,6 @@ export function CsvPreviewTable({ rows }: { rows: string[][] }) {
   );
 }
 
-function triggerBlobDownload(blob: Blob, filename: string): void {
-  const blobUrl = URL.createObjectURL(blob);
-  const a = document.createElement("a");
-  a.href = blobUrl;
-  a.download = filename;
-  document.body.appendChild(a);
-  a.click();
-  a.remove();
-  URL.revokeObjectURL(blobUrl);
-}
-
-// Fetch the asset as a blob so downloads are delivered from a same-origin
-// object URL. Cross-origin `<a download>` is intentionally avoided because
-// browsers ignore it for CDN image URLs and open the asset instead.
-async function fetchBlobForDownload(
-  url: string,
-  signal: AbortSignal,
-): Promise<Blob | null> {
-  const fetchUrl = publicAttachmentUrl(url);
-  // The catch branch reports network/CORS failures without falling back to
-  // cross-origin anchor navigation, which would open images instead.
-  // eslint-disable-next-line no-restricted-syntax -- fetch/CORS failures should surface as download failures
-  try {
-    const res = await fetch(fetchUrl, {
-      cache: "reload",
-      mode: "cors",
-      signal,
-    });
-    if (!res.ok) {
-      throw new Error(`fetch failed: ${String(res.status)}`);
-    }
-    return await res.blob();
-  } catch (error) {
-    signal.throwIfAborted();
-    log.warn("downloadUrl: fetch failed", error);
-    toast.error("Download failed");
-    return null;
-  }
-}
-
-export async function downloadAttachmentUrl(
-  url: string,
-  signal: AbortSignal = AbortSignal.any([]),
-  filename = filenameFromUrl(url),
-): Promise<void> {
-  const blob = await fetchBlobForDownload(url, signal);
-  if (blob !== null) {
-    triggerBlobDownload(blob, filename);
-  }
-}
-
-export async function copyAttachmentLinkToClipboard(
-  url: string,
-): Promise<void> {
-  const copied = await writeToClipboard(publicAttachmentUrl(url));
-  if (copied) {
-    toast.success("Link copied");
-    return;
-  }
-  toast.error("Failed to copy link");
-}
-
 function LightboxBodyScrollLock() {
   let restore: (() => void) | null = null;
 
@@ -443,6 +264,57 @@ function LightboxBodyScrollLock() {
 
 function isImageLightboxZoomAtReset(zoom: number): boolean {
   return Math.abs(zoom - 1) < 0.001;
+}
+
+function DialogIconButton({
+  ariaLabel,
+  children,
+  onClick,
+}: {
+  ariaLabel: string;
+  children: ReactNode;
+  onClick: () => void;
+}) {
+  return (
+    <button
+      type="button"
+      onClick={onClick}
+      className="inline-flex h-8 w-8 shrink-0 items-center justify-center rounded-md text-muted-foreground transition-colors hover:bg-muted hover:text-foreground"
+      aria-label={ariaLabel}
+      title={ariaLabel}
+    >
+      {children}
+    </button>
+  );
+}
+
+function ArtifactDialogSplitViewButton({ onClick }: { onClick: () => void }) {
+  return (
+    <DialogIconButton ariaLabel="Open in split view" onClick={onClick}>
+      <IconColumns2 size={18} stroke={1.8} />
+    </DialogIconButton>
+  );
+}
+
+function ArtifactDialogFullscreenButton({
+  fullscreen,
+  onClick,
+}: {
+  fullscreen: boolean;
+  onClick: () => void;
+}) {
+  return (
+    <DialogIconButton
+      ariaLabel={fullscreen ? "Exit fullscreen" : "Enter fullscreen"}
+      onClick={onClick}
+    >
+      {fullscreen ? (
+        <IconArrowsDiagonalMinimize2 size={18} stroke={1.8} />
+      ) : (
+        <IconArrowsDiagonal size={18} stroke={1.8} />
+      )}
+    </DialogIconButton>
+  );
 }
 
 function ImageLightboxControls({
@@ -503,9 +375,9 @@ function ImageLightboxControls({
         type="button"
         onClick={copyLink}
         className="p-2 rounded-full bg-black/50 text-white hover:bg-black/70 transition-colors cursor-pointer"
-        aria-label="Copy link"
+        aria-label="Share"
       >
-        <IconLink size={20} stroke={2} />
+        <IconShare size={20} stroke={2} />
       </button>
       <button
         type="button"
@@ -683,9 +555,9 @@ function VideoLightbox({ filename, url }: { filename: string; url: string }) {
             );
           }}
           className="p-2 rounded-full bg-black/50 text-white hover:bg-black/70 transition-colors cursor-pointer"
-          aria-label="Copy link"
+          aria-label="Share"
         >
-          <IconLink size={20} stroke={2} />
+          <IconShare size={20} stroke={2} />
         </button>
         <button
           type="button"
@@ -728,14 +600,541 @@ function VideoLightbox({ filename, url }: { filename: string; url: string }) {
   );
 }
 
+function artifactDialogFilename(preview: AttachmentLightboxState): string {
+  return "filename" in preview && preview.filename
+    ? preview.filename
+    : attachmentFilenameFromUrl(preview.url);
+}
+
+type ArtifactDialogItem = {
+  runId: string;
+  file: ChatThreadArtifactFile;
+};
+
+function artifactDialogKindLabel(
+  preview: AttachmentLightboxState,
+  artifact: AttachmentArtifactMetadata | undefined,
+): string {
+  if (artifact) {
+    return artifactTitleSubtitle(preview.kind, artifact);
+  }
+  return artifactFallbackSubtitle(
+    preview.kind,
+    artifactDialogFilename(preview),
+  );
+}
+
+function artifactDialogSyncTarget(
+  artifact: AttachmentArtifactMetadata | undefined,
+): ArtifactDownloadSyncTarget | undefined {
+  if (!artifact) {
+    return undefined;
+  }
+  return {
+    agentId: artifact.agentId,
+    fileId: artifact.fileId,
+    filename: artifact.filename,
+    onSyncSuccess:
+      artifact.onSyncSuccess ??
+      (() => {
+        return undefined;
+      }),
+    runId: artifact.runId,
+    synced: artifact.googleDriveSynced,
+    threadId: artifact.threadId,
+  };
+}
+
+function findArtifactDialogItemForUrl(
+  runs: ChatThreadArtifactRun[],
+  url: string,
+): ArtifactDialogItem | undefined {
+  for (const run of runs) {
+    const file = run.files.find((candidate) => {
+      return candidate.url === url;
+    });
+    if (file) {
+      return { runId: run.runId, file };
+    }
+  }
+  return undefined;
+}
+
+function artifactDialogMetadataFromItem(params: {
+  agentId: string | null | undefined;
+  item: ArtifactDialogItem;
+  onSyncSuccess: () => void;
+  threadId: string;
+}): AttachmentArtifactMetadata {
+  return {
+    agentId: params.agentId,
+    contentType: params.item.file.contentType,
+    createdAt: params.item.file.createdAt,
+    fileId: params.item.file.id,
+    filename: params.item.file.filename,
+    googleDriveSynced: params.item.file.googleDriveSync?.status === "synced",
+    onSyncSuccess: params.onSyncSuccess,
+    runId: params.item.runId,
+    size: params.item.file.size,
+    threadId: params.threadId,
+  };
+}
+
+function ArtifactDialogLoadingBody() {
+  return (
+    <div className="flex h-full items-center justify-center p-6 text-muted-foreground">
+      <IconLoader2 size={20} stroke={1.8} className="animate-spin" />
+    </div>
+  );
+}
+
+function ArtifactDialogUnavailableBody({ label }: { label: string }) {
+  return (
+    <div className="flex h-full items-center justify-center p-6 text-sm text-muted-foreground">
+      {label} preview unavailable.
+    </div>
+  );
+}
+
+function ArtifactDialogStage({
+  children,
+  centered = false,
+  gap = false,
+}: {
+  children: ReactNode;
+  centered?: boolean;
+  gap?: boolean;
+}) {
+  return (
+    <div
+      className="h-full overflow-auto bg-muted/30 p-5"
+      data-testid="artifact-dialog-stage"
+    >
+      <div
+        className={`mx-auto flex min-h-full w-full max-w-[900px] flex-col ${
+          centered ? "items-center justify-center" : ""
+        } ${gap ? "gap-3" : ""}`}
+      >
+        {children}
+      </div>
+    </div>
+  );
+}
+
+function ArtifactDialogCard({ children }: { children: ReactNode }) {
+  return (
+    <div
+      className="flex min-h-[420px] w-full flex-1 flex-col overflow-hidden rounded-xl border border-border/70 bg-background shadow-sm"
+      data-testid="artifact-dialog-card"
+    >
+      {children}
+    </div>
+  );
+}
+
+function ArtifactDialogTextBody({
+  kind,
+  signal,
+  url,
+}: {
+  kind: "markdown" | "text" | "json" | "csv";
+  signal: AbortSignal;
+  url: string;
+}) {
+  return (
+    <TextPreviewLoader url={url} signal={signal}>
+      {({ status, text }) => {
+        if (status === "loading") {
+          return (
+            <ArtifactDialogStage>
+              <ArtifactDialogCard>
+                <ArtifactDialogLoadingBody />
+              </ArtifactDialogCard>
+            </ArtifactDialogStage>
+          );
+        }
+
+        if (status === "error") {
+          return (
+            <ArtifactDialogStage>
+              <ArtifactDialogCard>
+                <ArtifactDialogUnavailableBody
+                  label={
+                    kind === "json"
+                      ? "JSON"
+                      : kind === "csv"
+                        ? "CSV"
+                        : kind === "markdown"
+                          ? "Markdown"
+                          : "Text"
+                  }
+                />
+              </ArtifactDialogCard>
+            </ArtifactDialogStage>
+          );
+        }
+
+        if (kind === "markdown") {
+          return (
+            <ArtifactDialogStage>
+              <ArtifactDialogCard>
+                <div className="h-full overflow-auto p-6">
+                  <Markdown source={text} />
+                </div>
+              </ArtifactDialogCard>
+            </ArtifactDialogStage>
+          );
+        }
+
+        if (kind === "csv") {
+          const rows = parseCsvRows(text);
+          return (
+            <ArtifactDialogStage>
+              <ArtifactDialogCard>
+                <div className="h-full overflow-auto p-5">
+                  {rows.length > 0 ? (
+                    <CsvPreviewTable rows={rows} />
+                  ) : (
+                    <div className="text-sm text-muted-foreground">
+                      CSV preview unavailable.
+                    </div>
+                  )}
+                </div>
+              </ArtifactDialogCard>
+            </ArtifactDialogStage>
+          );
+        }
+
+        const formatted = formatPlainPreviewText(kind, text);
+        const display =
+          formatted.length > 16_000
+            ? `${formatted.slice(0, 16_000)}\n\n…`
+            : formatted;
+
+        return (
+          <ArtifactDialogStage>
+            <ArtifactDialogCard>
+              <pre className="m-0 h-full overflow-auto whitespace-pre-wrap break-words p-6 text-sm text-foreground">
+                {display}
+              </pre>
+            </ArtifactDialogCard>
+          </ArtifactDialogStage>
+        );
+      }}
+    </TextPreviewLoader>
+  );
+}
+
+function ArtifactDialogBody({
+  pageSignal,
+  preview,
+}: {
+  pageSignal: AbortSignal;
+  preview: AttachmentLightboxState;
+}) {
+  const filename = artifactDialogFilename(preview);
+
+  if (preview.kind === "image") {
+    return (
+      <ArtifactDialogStage>
+        <ArtifactDialogCard>
+          <div
+            className="flex min-h-full flex-1 items-center justify-center overflow-auto bg-muted/30 p-6"
+            data-testid="artifact-dialog-image-stage"
+          >
+            <img
+              src={publicAttachmentUrl(preview.url)}
+              alt={filename}
+              data-testid="attachment-lightbox-image"
+              className="max-h-full max-w-full rounded-lg object-contain shadow-sm"
+            />
+          </div>
+        </ArtifactDialogCard>
+      </ArtifactDialogStage>
+    );
+  }
+
+  if (preview.kind === "video") {
+    return (
+      <ArtifactDialogStage centered>
+        <div
+          className="w-full overflow-hidden rounded-xl border border-border/70 bg-black shadow-sm"
+          data-testid="artifact-dialog-video-stage"
+        >
+          <video
+            src={publicAttachmentUrl(preview.url)}
+            controls
+            autoPlay
+            playsInline
+            preload="metadata"
+            className="block aspect-video w-full bg-black object-contain"
+            aria-label={`Video preview for ${filename}`}
+          />
+        </div>
+      </ArtifactDialogStage>
+    );
+  }
+
+  if (
+    preview.kind === "markdown" ||
+    preview.kind === "text" ||
+    preview.kind === "json" ||
+    preview.kind === "csv"
+  ) {
+    return (
+      <ArtifactDialogTextBody
+        kind={preview.kind}
+        signal={pageSignal}
+        url={preview.url}
+      />
+    );
+  }
+
+  if (preview.kind === "html") {
+    return (
+      <div
+        className="h-full w-full bg-background"
+        data-testid="artifact-dialog-site-frame"
+      >
+        <iframe
+          src={preview.url}
+          title={`${filename} preview`}
+          sandbox="allow-scripts"
+          scrolling="yes"
+          className="block h-full w-full border-0 bg-background"
+        />
+      </div>
+    );
+  }
+
+  return (
+    <ArtifactDialogStage>
+      <div
+        className="flex min-h-[420px] w-full flex-1 overflow-hidden rounded-xl border border-border/70 bg-background shadow-sm"
+        data-testid="artifact-dialog-document-frame"
+      >
+        <iframe
+          src={
+            preview.kind === "pdf" ? `${preview.url}#navpanes=0` : preview.url
+          }
+          title={`${filename} preview`}
+          scrolling="yes"
+          className="block h-full w-full bg-background"
+        />
+      </div>
+    </ArtifactDialogStage>
+  );
+}
+
+function ArtifactPreviewDialog({
+  preview,
+}: {
+  preview: AttachmentLightboxState;
+}) {
+  const leftThread = useLastResolved(currentLeftThread$);
+  const rightThread = useLastResolved(currentRightThread$);
+
+  if (leftThread) {
+    return (
+      <ArtifactPreviewDialogThreadResolver
+        preview={preview}
+        thread={leftThread}
+        fallbackThread={
+          rightThread && rightThread.threadId !== leftThread.threadId
+            ? rightThread
+            : undefined
+        }
+      />
+    );
+  }
+
+  if (rightThread) {
+    return (
+      <ArtifactPreviewDialogThreadResolver
+        preview={preview}
+        thread={rightThread}
+      />
+    );
+  }
+
+  return (
+    <ArtifactPreviewDialogContent
+      artifact={preview.artifact}
+      preview={preview}
+    />
+  );
+}
+
+function ArtifactPreviewDialogThreadResolver({
+  fallbackThread,
+  preview,
+  thread,
+}: {
+  fallbackThread?: ChatThreadSignals;
+  preview: AttachmentLightboxState;
+  thread: ChatThreadSignals;
+}) {
+  const loadable = useLastLoadable(thread.artifacts$);
+  const agentId = useLastResolved(thread.agentId$);
+  const reloadArtifacts = useSet(thread.setArtifactsDrawerOpen$);
+  const item =
+    loadable.state === "hasData"
+      ? findArtifactDialogItemForUrl(loadable.data, preview.url)
+      : undefined;
+
+  if (item) {
+    return (
+      <ArtifactPreviewDialogContent
+        artifact={artifactDialogMetadataFromItem({
+          agentId,
+          item,
+          onSyncSuccess: () => {
+            reloadArtifacts(true);
+          },
+          threadId: thread.threadId,
+        })}
+        preview={preview}
+      />
+    );
+  }
+
+  if (fallbackThread && loadable.state === "hasData") {
+    return (
+      <ArtifactPreviewDialogThreadResolver
+        preview={preview}
+        thread={fallbackThread}
+      />
+    );
+  }
+
+  return (
+    <ArtifactPreviewDialogContent
+      artifact={preview.artifact}
+      preview={preview}
+    />
+  );
+}
+
+function ArtifactPreviewDialogContent({
+  artifact,
+  preview,
+}: {
+  artifact: AttachmentArtifactMetadata | undefined;
+  preview: AttachmentLightboxState;
+}) {
+  const dialogRef = useSet(lightboxDialogRef$);
+  const closeLightboxWithDialogExit = useSet(closeLightboxWithDialogExit$);
+  const openArtifactSidebarPreview = useSet(openArtifactSidebarPreview$);
+  const toggleLightboxDialogFullscreen = useSet(
+    toggleLightboxDialogFullscreen$,
+  );
+  const pageSignal = useGet(pageSignal$);
+  const filename = artifact?.filename ?? artifactDialogFilename(preview);
+  const subtitle = artifactDialogKindLabel(preview, artifact);
+  const syncTarget = artifactDialogSyncTarget(artifact);
+  const visible = useGet(lightboxDialogVisible$);
+  const fullscreen = useGet(lightboxDialogFullscreen$);
+
+  const closeWithAnimation = () => {
+    closeLightboxWithDialogExit();
+  };
+
+  const openInSplitView = () => {
+    openArtifactSidebarPreview(preview.url);
+    closeLightboxWithDialogExit();
+  };
+
+  const handleBackdropClick = (e: MouseEvent<HTMLDivElement>) => {
+    if (e.target === e.currentTarget) {
+      closeWithAnimation();
+    }
+  };
+
+  return createPortal(
+    <div
+      ref={dialogRef}
+      tabIndex={-1}
+      className={`fixed inset-0 z-[9999] isolate flex items-center justify-center bg-gray-900/45 outline-none transition-opacity duration-[180ms] ease ${
+        visible
+          ? "pointer-events-auto opacity-100"
+          : "pointer-events-none opacity-0"
+      } ${fullscreen ? "p-0" : "p-6"}`}
+      onClick={handleBackdropClick}
+      role="dialog"
+      aria-modal="true"
+      aria-label={`${filename} preview`}
+      data-testid="attachment-lightbox"
+    >
+      <LightboxBodyScrollLock />
+      <div
+        className={`flex min-h-0 flex-col overflow-hidden bg-background text-foreground shadow-[0_24px_70px_rgba(0,0,0,0.30)] transition-transform duration-[180ms] ease ${
+          visible ? "translate-y-0" : "translate-y-2"
+        } ${
+          fullscreen
+            ? "h-dvh w-dvw rounded-none"
+            : "h-[min(700px,86vh)] w-[min(980px,92vw)] rounded-2xl"
+        }`}
+      >
+        <div className="flex h-14 shrink-0 items-center gap-2 border-b border-border/70 pl-4 pr-3">
+          <div className="min-w-0 flex-1">
+            <div className="truncate text-sm font-medium">{filename}</div>
+            <div className="truncate text-xs text-muted-foreground">
+              {subtitle}
+            </div>
+          </div>
+          <div className="flex shrink-0 items-center gap-1">
+            <ArtifactShareButton
+              ariaLabel="Share"
+              iconSize={18}
+              url={preview.url}
+            />
+            <ArtifactDownloadMenu
+              ariaLabel="Download options"
+              filename={filename}
+              iconSize={18}
+              syncTarget={syncTarget}
+              url={preview.url}
+            />
+            <ArtifactActionSeparator />
+            <ArtifactDialogSplitViewButton onClick={openInSplitView} />
+            <ArtifactDialogFullscreenButton
+              fullscreen={fullscreen}
+              onClick={() => {
+                toggleLightboxDialogFullscreen();
+              }}
+            />
+            <DialogIconButton
+              ariaLabel="Close"
+              onClick={() => {
+                closeWithAnimation();
+              }}
+            >
+              <IconX size={18} stroke={1.8} />
+            </DialogIconButton>
+          </div>
+        </div>
+        <div className="min-h-0 flex-1 bg-background">
+          <ArtifactDialogBody pageSignal={pageSignal} preview={preview} />
+        </div>
+      </div>
+    </div>,
+    document.body,
+  );
+}
+
 export function AttachmentLightbox() {
   const preview = useGet(lightboxUrl$);
+  const sidebarEnabled = useGet(chatArtifactSidebarEnabled$);
   const dialogRef = useSet(lightboxDialogRef$);
   const closeLightbox = useSet(closeLightbox$);
   const pageSignal = useGet(pageSignal$);
 
   if (!preview) {
     return null;
+  }
+
+  if (sidebarEnabled) {
+    return <ArtifactPreviewDialog preview={preview} />;
   }
 
   if (preview.kind === "image") {
@@ -775,9 +1174,9 @@ export function AttachmentLightbox() {
             );
           }}
           className="p-2 rounded-full bg-black/50 text-white hover:bg-black/70 transition-colors cursor-pointer"
-          aria-label="Copy link"
+          aria-label="Share"
         >
-          <IconLink size={20} stroke={2} />
+          <IconShare size={20} stroke={2} />
         </button>
         <button
           type="button"

--- a/turbo/apps/platform/src/views/zero-page/zero-attachment-chips.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-attachment-chips.tsx
@@ -36,18 +36,14 @@ import {
   IMAGE_LIGHTBOX_MAX_ZOOM,
   IMAGE_LIGHTBOX_MIN_ZOOM,
   imageLightboxImageRef$,
-  imageLightboxKeyboardShortcutsRef$,
   imageLightboxState$,
   imageLoadStatusByKey$,
   imageLoadStatusRef$,
-  resetImageLightboxZoom$,
   setImageLightboxStatus$,
   setImageLoadStatus$,
   textPreviewLoaderRef$,
   textPreviewLoadStateByKey$,
   type TextPreviewLoadState,
-  zoomImageLightboxIn$,
-  zoomImageLightboxOut$,
 } from "../../signals/view-component-state.ts";
 import { Markdown } from "../components/markdown.tsx";
 import {
@@ -84,6 +80,10 @@ import {
   artifactFallbackSubtitle,
   artifactTitleSubtitle,
 } from "./zero-artifact-display.ts";
+import {
+  ZoomableArtifactImageCanvas,
+  type ZoomableImageControls,
+} from "./zero-zoomable-image-canvas.tsx";
 
 export {
   downloadAttachmentUrl,
@@ -119,6 +119,12 @@ function contentTypeForDocumentAttachmentPreviewKind(
   }
   return "application/pdf";
 }
+
+const ATTACHMENT_LIGHTBOX_OVERLAY_CLASS =
+  "pointer-events-auto fixed inset-0 z-[9999] isolate flex items-center justify-center bg-black/80 backdrop-blur-sm animate-in fade-in duration-[180ms] ease outline-none";
+
+const ATTACHMENT_LIGHTBOX_PANEL_CLASS =
+  "animate-in slide-in-from-bottom-2 duration-[180ms] ease";
 
 // ---------------------------------------------------------------------------
 // AttachmentLightbox — full-screen attachment viewer
@@ -399,12 +405,6 @@ function ImageLightboxControls({
   );
 }
 
-function ImageLightboxKeyboardShortcuts() {
-  const keyboardShortcutsRef = useSet(imageLightboxKeyboardShortcutsRef$);
-
-  return <span ref={keyboardShortcutsRef} hidden />;
-}
-
 function ImageLightboxContent({
   closeLightbox,
   pageSignal,
@@ -415,11 +415,7 @@ function ImageLightboxContent({
   url: string;
 }) {
   const imageLightboxImageRef = useSet(imageLightboxImageRef$);
-  const imageState = useGet(imageLightboxState$);
-  const resetZoom = useSet(resetImageLightboxZoom$);
   const setImageLightboxStatus = useSet(setImageLightboxStatus$);
-  const zoomIn = useSet(zoomImageLightboxIn$);
-  const zoomOut = useSet(zoomImageLightboxOut$);
 
   const download = () => {
     detach(
@@ -436,54 +432,60 @@ function ImageLightboxContent({
     );
   };
 
-  const { imageStatus, zoom } = imageState;
+  const { imageStatus } = useGet(imageLightboxState$);
 
   return (
-    <>
-      <ImageLightboxKeyboardShortcuts />
-      <ImageLightboxControls
-        closeLightbox={closeLightbox}
-        copyLink={copyLink}
-        download={download}
-        resetZoom={resetZoom}
-        zoom={zoom}
-        zoomIn={zoomIn}
-        zoomOut={zoomOut}
-      />
-      <div
-        className="relative flex items-center justify-center transition-transform duration-150 animate-in zoom-in-95"
-        style={{ transform: `scale(${String(zoom)})` }}
-      >
-        {imageStatus !== "loaded" && (
-          <div
-            data-testid="attachment-lightbox-image-loading"
-            className="flex h-[min(85vh,480px)] w-[min(90vw,720px)] items-center justify-center rounded-lg bg-black/30 text-white shadow-2xl"
-          >
-            {imageStatus === "loading" ? (
-              <IconLoader2 size={24} stroke={1.8} className="animate-spin" />
-            ) : (
-              <IconPhoto size={24} stroke={1.5} />
+    <ZoomableArtifactImageCanvas
+      src={url}
+      alt=""
+      zoomKey={`attachment-lightbox:${url}`}
+      keyboardShortcuts
+      imageRef={imageLightboxImageRef}
+      imageTestId="attachment-lightbox-image"
+      canvasTestId="attachment-lightbox-panel"
+      onLoad={() => {
+        setImageLightboxStatus("loaded");
+      }}
+      onError={() => {
+        setImageLightboxStatus("error");
+      }}
+      className={`relative z-10 h-[min(85vh,720px)] w-[min(90vw,1100px)] bg-transparent ${ATTACHMENT_LIGHTBOX_PANEL_CLASS}`}
+      imageClassName={`rounded-lg shadow-2xl ${
+        imageStatus === "loaded" ? "" : "opacity-0"
+      }`}
+    >
+      {({ resetZoom, zoom, zoomIn, zoomOut }) => {
+        return (
+          <>
+            <ImageLightboxControls
+              closeLightbox={closeLightbox}
+              copyLink={copyLink}
+              download={download}
+              resetZoom={resetZoom}
+              zoom={zoom}
+              zoomIn={zoomIn}
+              zoomOut={zoomOut}
+            />
+            {imageStatus !== "loaded" && (
+              <div
+                data-testid="attachment-lightbox-image-loading"
+                className="absolute left-1/2 top-1/2 z-10 flex h-[min(85vh,480px)] w-[min(90vw,720px)] -translate-x-1/2 -translate-y-1/2 items-center justify-center rounded-lg bg-black/30 text-white shadow-2xl"
+              >
+                {imageStatus === "loading" ? (
+                  <IconLoader2
+                    size={24}
+                    stroke={1.8}
+                    className="animate-spin"
+                  />
+                ) : (
+                  <IconPhoto size={24} stroke={1.5} />
+                )}
+              </div>
             )}
-          </div>
-        )}
-        <img
-          key={url}
-          ref={imageLightboxImageRef}
-          src={url}
-          alt=""
-          data-testid="attachment-lightbox-image"
-          onLoad={() => {
-            setImageLightboxStatus("loaded");
-          }}
-          onError={() => {
-            setImageLightboxStatus("error");
-          }}
-          className={`max-h-[85vh] max-w-[90vw] rounded-lg object-contain shadow-2xl ${
-            imageStatus === "loaded" ? "" : "absolute inset-0 opacity-0"
-          }`}
-        />
-      </div>
-    </>
+          </>
+        );
+      }}
+    </ZoomableArtifactImageCanvas>
   );
 }
 
@@ -502,7 +504,7 @@ function ImageLightbox({ url }: { url: string }) {
     <div
       ref={dialogRef}
       tabIndex={-1}
-      className="pointer-events-auto fixed inset-0 z-[9999] isolate flex items-center justify-center bg-black/80 backdrop-blur-sm animate-in fade-in duration-200 outline-none"
+      className={ATTACHMENT_LIGHTBOX_OVERLAY_CLASS}
       style={{ pointerEvents: "auto" }}
       onClick={handleBackdropClick}
       role="dialog"
@@ -536,7 +538,7 @@ function VideoLightbox({ filename, url }: { filename: string; url: string }) {
     <div
       ref={dialogRef}
       tabIndex={-1}
-      className="pointer-events-auto fixed inset-0 z-[9999] isolate flex items-center justify-center bg-black/80 backdrop-blur-sm animate-in fade-in duration-200 outline-none"
+      className={ATTACHMENT_LIGHTBOX_OVERLAY_CLASS}
       style={{ pointerEvents: "auto" }}
       onClick={handleBackdropClick}
       role="dialog"
@@ -584,7 +586,10 @@ function VideoLightbox({ filename, url }: { filename: string; url: string }) {
           <IconX size={20} stroke={2} />
         </button>
       </div>
-      <div className="relative z-10 flex w-[min(92vw,1100px)] min-w-0 overflow-hidden bg-black shadow-2xl animate-in zoom-in-95 duration-200">
+      <div
+        className={`relative z-10 flex w-[min(92vw,1100px)] min-w-0 overflow-hidden bg-black shadow-2xl ${ATTACHMENT_LIGHTBOX_PANEL_CLASS}`}
+        data-testid="attachment-lightbox-panel"
+      >
         <video
           src={videoUrl}
           controls
@@ -732,6 +737,52 @@ function ArtifactDialogCard({ children }: { children: ReactNode }) {
   );
 }
 
+function ArtifactDialogImageZoomControls({
+  controls,
+}: {
+  controls: ZoomableImageControls;
+}) {
+  return (
+    <div
+      className="absolute right-4 top-4 z-10 flex items-center gap-2 rounded-lg bg-background/95 px-2.5 py-1.5 text-muted-foreground shadow-sm backdrop-blur-sm"
+      data-testid="artifact-dialog-image-zoom-controls"
+    >
+      <button
+        type="button"
+        onClick={controls.zoomOut}
+        disabled={!controls.canZoomOut}
+        className="flex h-5 w-5 items-center justify-center rounded-md text-sm leading-none transition-colors hover:bg-muted/70 hover:text-foreground disabled:pointer-events-none disabled:opacity-40"
+        aria-label="Zoom out"
+        title="Zoom out"
+      >
+        -
+      </button>
+      <span className="min-w-10 text-center text-xs font-medium tabular-nums text-foreground">
+        {Math.round(controls.zoom * 100)}%
+      </span>
+      <button
+        type="button"
+        onClick={controls.zoomIn}
+        disabled={!controls.canZoomIn}
+        className="flex h-5 w-5 items-center justify-center rounded-md text-sm leading-none transition-colors hover:bg-muted/70 hover:text-foreground disabled:pointer-events-none disabled:opacity-40"
+        aria-label="Zoom in"
+        title="Zoom in"
+      >
+        +
+      </button>
+      <button
+        type="button"
+        onClick={controls.resetZoom}
+        className="rounded-md px-1.5 text-xs font-medium transition-colors hover:bg-muted/70 hover:text-foreground"
+        aria-label="Reset zoom"
+        title="Reset zoom"
+      >
+        Reset
+      </button>
+    </div>
+  );
+}
+
 function ArtifactDialogTextBody({
   kind,
   signal,
@@ -838,17 +889,19 @@ function ArtifactDialogBody({
     return (
       <ArtifactDialogStage>
         <ArtifactDialogCard>
-          <div
-            className="flex min-h-full flex-1 items-center justify-center overflow-auto bg-muted/30 p-6"
-            data-testid="artifact-dialog-image-stage"
+          <ZoomableArtifactImageCanvas
+            src={publicAttachmentUrl(preview.url)}
+            alt={filename}
+            zoomKey={`artifact-dialog:${preview.url}`}
+            imageTestId="attachment-lightbox-image"
+            className="p-6"
+            imageClassName="rounded-lg shadow-sm"
+            canvasTestId="artifact-dialog-image-stage"
           >
-            <img
-              src={publicAttachmentUrl(preview.url)}
-              alt={filename}
-              data-testid="attachment-lightbox-image"
-              className="max-h-full max-w-full rounded-lg object-contain shadow-sm"
-            />
-          </div>
+            {(controls) => {
+              return <ArtifactDialogImageZoomControls controls={controls} />;
+            }}
+          </ZoomableArtifactImageCanvas>
         </ArtifactDialogCard>
       </ArtifactDialogStage>
     );
@@ -1156,7 +1209,7 @@ export function AttachmentLightbox() {
     <div
       ref={dialogRef}
       tabIndex={-1}
-      className="pointer-events-auto fixed inset-0 z-[9999] isolate flex items-center justify-center bg-black/80 backdrop-blur-sm animate-in fade-in duration-200 outline-none"
+      className={ATTACHMENT_LIGHTBOX_OVERLAY_CLASS}
       style={{ pointerEvents: "auto" }}
       onClick={handleBackdropClick}
       role="dialog"
@@ -1204,7 +1257,10 @@ export function AttachmentLightbox() {
           <IconX size={20} stroke={2} />
         </button>
       </div>
-      <div className="relative z-10 w-[min(92vw,1100px)] min-w-0 rounded-2xl bg-background shadow-2xl overflow-hidden animate-in zoom-in-95 duration-200">
+      <div
+        className={`relative z-10 w-[min(92vw,1100px)] min-w-0 overflow-hidden rounded-2xl bg-background shadow-2xl ${ATTACHMENT_LIGHTBOX_PANEL_CLASS}`}
+        data-testid="attachment-lightbox-panel"
+      >
         <div className="flex items-center gap-3 border-b border-foreground/10 px-4 py-3">
           <div className="flex h-10 w-10 items-center justify-center rounded-xl bg-muted">
             <FilePreviewIcon

--- a/turbo/apps/platform/src/views/zero-page/zero-attachment-chips.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-attachment-chips.tsx
@@ -12,6 +12,7 @@ import {
   IconArrowsDiagonalMinimize2,
   IconColumns2,
   IconDownload,
+  IconFileMusic,
   IconPhoto,
   IconLoader2,
   IconShare,
@@ -53,6 +54,7 @@ import {
   closeLightboxWithDialogExit$,
   lightboxDialogFullscreen$,
   lightboxDialogVisible$,
+  openAudioLightbox$,
   openDocumentLightbox$,
   openImageLightbox$,
   lightboxDialogRef$,
@@ -606,6 +608,95 @@ function VideoLightbox({ filename, url }: { filename: string; url: string }) {
   );
 }
 
+function AudioLightbox({ filename, url }: { filename: string; url: string }) {
+  const dialogRef = useSet(lightboxDialogRef$);
+  const closeLightbox = useSet(closeLightbox$);
+  const pageSignal = useGet(pageSignal$);
+  const audioUrl = publicAttachmentUrl(url);
+
+  const handleBackdropClick = (e: MouseEvent<HTMLDivElement>) => {
+    if (e.target === e.currentTarget) {
+      closeLightbox();
+    }
+  };
+
+  return createPortal(
+    <div
+      ref={dialogRef}
+      tabIndex={-1}
+      className={ATTACHMENT_LIGHTBOX_OVERLAY_CLASS}
+      style={{ pointerEvents: "auto" }}
+      onClick={handleBackdropClick}
+      role="dialog"
+      aria-modal="true"
+      data-testid="attachment-lightbox"
+    >
+      <LightboxBodyScrollLock />
+      <div className="absolute top-4 right-4 z-20 flex items-center gap-2">
+        <button
+          type="button"
+          onClick={() => {
+            detach(
+              copyAttachmentLinkToClipboard(url),
+              Reason.DomCallback,
+              "attachment copy link",
+            );
+          }}
+          className="p-2 rounded-full bg-black/50 text-white hover:bg-black/70 transition-colors cursor-pointer"
+          aria-label="Share"
+        >
+          <IconShare size={20} stroke={2} />
+        </button>
+        <button
+          type="button"
+          onClick={() => {
+            detach(
+              downloadAttachmentUrl(url, pageSignal, filename),
+              Reason.DomCallback,
+              "attachment download",
+            );
+          }}
+          className="p-2 rounded-full bg-black/50 text-white hover:bg-black/70 transition-colors cursor-pointer"
+          aria-label="Download"
+        >
+          <IconDownload size={20} stroke={2} />
+        </button>
+        <button
+          type="button"
+          onClick={() => {
+            closeLightbox();
+          }}
+          className="p-2 rounded-full bg-black/50 text-white hover:bg-black/70 transition-colors"
+          aria-label="Close"
+        >
+          <IconX size={20} stroke={2} />
+        </button>
+      </div>
+      <div
+        className={`relative z-10 flex w-[min(92vw,560px)] min-w-0 flex-col items-center gap-4 overflow-hidden rounded-2xl bg-background p-6 shadow-2xl ${ATTACHMENT_LIGHTBOX_PANEL_CLASS}`}
+        data-testid="attachment-lightbox-panel"
+      >
+        <span className="flex h-14 w-14 items-center justify-center rounded-2xl border border-border/70 bg-muted/50 text-muted-foreground">
+          <IconFileMusic size={28} stroke={1.6} />
+        </span>
+        <div className="max-w-full truncate text-sm font-medium text-foreground">
+          {filename}
+        </div>
+        <audio
+          src={audioUrl}
+          controls
+          autoPlay
+          preload="metadata"
+          className="w-full"
+          aria-label={`Audio preview for ${filename}`}
+          data-testid="attachment-lightbox-audio"
+        />
+      </div>
+    </div>,
+    document.body,
+  );
+}
+
 function artifactDialogFilename(preview: AttachmentLightboxState): string {
   return "filename" in preview && preview.filename
     ? preview.filename
@@ -948,6 +1039,30 @@ function ArtifactDialogBody({
     );
   }
 
+  if (preview.kind === "audio") {
+    return (
+      <ArtifactDialogStage centered>
+        <div className="flex w-full max-w-[520px] flex-col items-center gap-4 rounded-xl border border-border/70 bg-background p-6 shadow-sm">
+          <span className="flex h-14 w-14 items-center justify-center rounded-2xl border border-border/70 bg-muted/50 text-muted-foreground">
+            <IconFileMusic size={28} stroke={1.6} />
+          </span>
+          <p className="max-w-full truncate text-sm text-muted-foreground">
+            {filename}
+          </p>
+          <audio
+            src={publicAttachmentUrl(preview.url)}
+            controls
+            autoPlay
+            preload="metadata"
+            className="w-full"
+            aria-label={`Audio preview for ${filename}`}
+            data-testid="artifact-dialog-audio"
+          />
+        </div>
+      </ArtifactDialogStage>
+    );
+  }
+
   if (
     preview.kind === "markdown" ||
     preview.kind === "text" ||
@@ -1260,6 +1375,10 @@ export function AttachmentLightbox() {
 
   if (preview.kind === "video") {
     return <VideoLightbox filename={preview.filename} url={preview.url} />;
+  }
+
+  if (preview.kind === "audio") {
+    return <AudioLightbox filename={preview.filename} url={preview.url} />;
   }
 
   const handleBackdropClick = (e: MouseEvent<HTMLDivElement>) => {
@@ -1587,6 +1706,36 @@ export function PreviewableFileAttachmentChip({
       <FileChipBody
         filename={filename}
         contentType={contentTypeForDocumentAttachmentPreviewKind(kind)}
+        testId="attachment-chip-file-icon"
+      />
+    </button>
+  );
+}
+
+export function PreviewableAudioAttachmentChip({
+  contentType,
+  filename,
+  url,
+}: {
+  contentType?: string;
+  filename: string;
+  url: string;
+}) {
+  const openAudioLightbox = useSet(openAudioLightbox$);
+
+  return (
+    <button
+      type="button"
+      onClick={() => {
+        openAudioLightbox({ url, filename });
+      }}
+      title={filename}
+      aria-label={`Open audio preview for ${filename}`}
+      className={`${FILE_CHIP_CLASSES} hover:bg-foreground/10`}
+    >
+      <FileChipBody
+        filename={filename}
+        contentType={contentType}
         testId="attachment-chip-file-icon"
       />
     </button>

--- a/turbo/apps/platform/src/views/zero-page/zero-attachment-chips.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-attachment-chips.tsx
@@ -703,25 +703,27 @@ function ArtifactDialogUnavailableBody({ label }: { label: string }) {
 function ArtifactDialogStage({
   children,
   centered = false,
+  flush = false,
   gap = false,
   scrollable = true,
 }: {
   children: ReactNode;
   centered?: boolean;
+  flush?: boolean;
   gap?: boolean;
   scrollable?: boolean;
 }) {
   return (
     <div
-      className={`h-full min-h-0 bg-muted/30 p-5 ${
+      className={`h-full min-h-0 bg-muted/30 ${flush ? "p-0" : "p-5"} ${
         scrollable ? "overflow-auto" : "overflow-hidden"
       }`}
       data-testid="artifact-dialog-stage"
     >
       <div
-        className={`mx-auto flex w-full max-w-[900px] flex-col ${
-          scrollable ? "min-h-full" : "h-full min-h-0"
-        } ${
+        className={`mx-auto flex w-full flex-col ${
+          flush ? "max-w-none" : "max-w-[900px]"
+        } ${scrollable ? "min-h-full" : "h-full min-h-0"} ${
           centered ? "items-center justify-center" : ""
         } ${gap ? "gap-3" : ""}`}
       >
@@ -740,10 +742,10 @@ function ArtifactDialogCard({
 }) {
   return (
     <div
-      className={`flex w-full flex-1 flex-col overflow-hidden rounded-xl ${
+      className={`flex w-full flex-1 flex-col overflow-hidden ${
         fillHeight
           ? "h-full min-h-0 bg-transparent"
-          : "min-h-[420px] border border-border/70 bg-background shadow-sm"
+          : "min-h-[420px] rounded-xl border border-border/70 bg-background shadow-sm"
       }`}
       data-testid="artifact-dialog-card"
     >
@@ -902,14 +904,14 @@ function ArtifactDialogBody({
 
   if (preview.kind === "image") {
     return (
-      <ArtifactDialogStage scrollable={false}>
+      <ArtifactDialogStage flush scrollable={false}>
         <ArtifactDialogCard fillHeight>
           <ZoomableArtifactImageCanvas
             src={publicAttachmentUrl(preview.url)}
             alt={filename}
             zoomKey={`artifact-dialog:${preview.url}`}
             imageTestId="attachment-lightbox-image"
-            className="p-6"
+            contentClassName="p-6"
             imageClassName="rounded-lg shadow-sm"
             canvasTestId="artifact-dialog-image-stage"
           >

--- a/turbo/apps/platform/src/views/zero-page/zero-attachment-preview.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-attachment-preview.tsx
@@ -105,6 +105,11 @@ type TextPreviewProps = {
   text$?: Computed<Promise<string>>;
 };
 
+const MEDIA_PREVIEW_CARD_CLASS =
+  "inline-flex w-[min(100%,400px)] overflow-hidden rounded-lg border border-foreground/10 bg-background text-left align-top text-foreground no-underline shadow-sm transition-all duration-200";
+const MEDIA_PREVIEW_CARD_HOVER_CLASS =
+  "hover:scale-[1.015] hover:border-foreground/20 hover:shadow-lg hover:shadow-black/10 dark:hover:shadow-black/30";
+
 function TextPreview(props: TextPreviewProps) {
   const sidebarEnabled = useGet(chatArtifactSidebarEnabled$);
   if (sidebarEnabled) {
@@ -230,7 +235,7 @@ function HtmlSitePreviewCard({
       }}
       aria-label={`Open html preview for ${filename}`}
       title={title}
-      className="group/site-preview inline-flex w-[min(100%,400px)] flex-col overflow-hidden rounded-lg border border-foreground/10 bg-background text-left align-top text-foreground no-underline shadow-sm transition-all duration-200 hover:scale-[1.015] hover:border-foreground/20 hover:shadow-lg hover:shadow-black/10 dark:hover:shadow-black/30"
+      className={`group/site-preview flex-col ${MEDIA_PREVIEW_CARD_CLASS} ${MEDIA_PREVIEW_CARD_HOVER_CLASS}`}
     >
       <div className="flex min-h-10 items-center border-b border-border/60 bg-background/95 px-3 py-2">
         <span className="min-w-0 flex-1 truncate text-sm font-medium">
@@ -539,9 +544,13 @@ function VideoThumbnailPreview({
       title={filename}
       aria-label={`Open video preview for ${filename}`}
       data-testid="attachment-preview-video"
-      className={`${lightboxOpen ? "" : "group/video-preview"} inline-flex w-fit self-start align-top text-left disabled:pointer-events-none`}
+      className={`${
+        lightboxOpen
+          ? ""
+          : `group/video-preview ${MEDIA_PREVIEW_CARD_HOVER_CLASS}`
+      } ${MEDIA_PREVIEW_CARD_CLASS} self-start disabled:pointer-events-none`}
     >
-      <div className="relative flex aspect-[4/3] w-[144px] items-center justify-center overflow-hidden rounded-xl border border-foreground/10 bg-black sm:w-[168px]">
+      <div className="relative flex aspect-[16/10] w-full items-center justify-center overflow-hidden bg-black">
         <div className="absolute inset-0 flex items-center justify-center bg-gradient-to-br from-slate-900 via-slate-800 to-stone-900 text-white">
           <span className="flex h-14 w-14 items-center justify-center rounded-2xl border border-white/15 bg-white/10">
             <FilePreviewIcon

--- a/turbo/apps/platform/src/views/zero-page/zero-attachment-preview.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-attachment-preview.tsx
@@ -150,8 +150,6 @@ function AttachmentAnchorChip({
   kind: AttachmentAnchorChipKind;
 }) {
   const publicUrl = publicAttachmentUrl(url);
-  // Switch-aware open. html chips can render even when the sidebar feature is
-  // off, in which case this routes back to the legacy modal lightbox.
   const openDocument = useSet(openDocumentLightboxOrArtifact$);
 
   return (

--- a/turbo/apps/platform/src/views/zero-page/zero-attachment-preview.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-attachment-preview.tsx
@@ -4,14 +4,10 @@ import {
   IconChevronUp,
   IconDownload,
   IconEye,
-  IconExternalLink,
   IconFileMusic,
-  IconFileTypePdf,
   IconLoader2,
   IconPlayerPlay,
-  IconTable,
   IconVideo,
-  IconWorld,
 } from "@tabler/icons-react";
 import { useGet, useLastResolved, useSet } from "ccstate-react";
 import type { Computed } from "ccstate";
@@ -132,17 +128,56 @@ type AttachmentAnchorChipKind =
   | "pdf"
   | "html";
 
-function attachmentAnchorChipIcon(kind: AttachmentAnchorChipKind): ReactNode {
-  if (kind === "html") {
-    return <IconWorld size={13} stroke={1.8} />;
+function documentPreviewAccentClass(kind: AttachmentAnchorChipKind) {
+  if (kind === "markdown") {
+    return "from-emerald-500/15 via-lime-500/10 to-background";
   }
   if (kind === "csv") {
-    return <IconTable size={13} stroke={1.8} />;
+    return "from-teal-500/15 via-emerald-500/10 to-background";
   }
   if (kind === "pdf") {
-    return <IconFileTypePdf size={13} stroke={1.8} />;
+    return "from-rose-500/15 via-orange-500/10 to-background";
   }
-  return <IconExternalLink size={13} stroke={1.8} />;
+  return "from-slate-500/15 via-cyan-500/10 to-background";
+}
+
+function AttachmentDocumentThumbnailArtwork({
+  actionIcon,
+  actionLabel,
+  filename,
+  kind,
+}: {
+  actionIcon: ReactNode;
+  actionLabel: string;
+  filename: string;
+  kind: AttachmentAnchorChipKind;
+}) {
+  return (
+    <div
+      className={`relative flex aspect-[4/3] w-[144px] items-center justify-center overflow-hidden rounded-xl bg-gradient-to-br sm:w-[168px] ${documentPreviewAccentClass(
+        kind,
+      )}`}
+    >
+      <div className="absolute inset-0 bg-[radial-gradient(circle_at_top,rgba(255,255,255,0.45),transparent_55%)] dark:bg-[radial-gradient(circle_at_top,rgba(255,255,255,0.08),transparent_55%)]" />
+      <div className="absolute inset-x-0 top-0 h-10 bg-gradient-to-b from-black/10 to-transparent" />
+      <div className="relative flex h-16 w-16 items-center justify-center rounded-2xl border border-foreground/10 bg-background/90 shadow-sm transition-transform duration-200 group-hover/doc-preview:scale-105">
+        <FilePreviewIcon
+          filename={filename}
+          contentType={contentTypeForDocumentPreviewKind(kind)}
+          testId={`attachment-preview-${kind}-icon`}
+        />
+      </div>
+      <div className="absolute right-2 top-2 inline-flex items-center gap-1 rounded-full bg-background/85 px-1.5 py-0.5 text-[9px] font-medium uppercase tracking-wide text-muted-foreground opacity-0 transition-opacity duration-200 group-hover/doc-preview:opacity-100">
+        {actionIcon}
+        {actionLabel}
+      </div>
+      <div className="absolute inset-x-0 bottom-0 flex items-end justify-between gap-2 bg-gradient-to-t from-black/55 via-black/15 to-transparent px-2.5 py-2.5 text-white opacity-0 transition-opacity duration-200 group-hover/doc-preview:opacity-100">
+        <div className="min-w-0">
+          <div className="truncate text-xs font-medium">{filename}</div>
+        </div>
+      </div>
+    </div>
+  );
 }
 
 function AttachmentAnchorChip({
@@ -171,15 +206,14 @@ function AttachmentAnchorChip({
       }}
       aria-label={`Open ${kind} preview for ${filename}`}
       title={filename}
-      className="group/anchor-chip inline-flex min-h-8 max-w-[min(100%,520px)] w-fit items-center gap-2 self-start rounded-full border border-foreground/10 bg-background px-2 py-1 pr-3 text-left align-top text-sm text-foreground no-underline transition-colors hover:border-foreground/20 hover:bg-muted/40"
+      className="group/doc-preview inline-flex w-fit self-start align-top text-left no-underline"
     >
-      <span
-        data-testid={`attachment-preview-${kind}-icon`}
-        className="flex h-6 w-6 shrink-0 items-center justify-center rounded-md border border-foreground/10 bg-muted/40 text-muted-foreground transition-colors group-hover/anchor-chip:border-foreground/15 group-hover/anchor-chip:bg-muted/60 group-hover/anchor-chip:text-foreground"
-      >
-        {attachmentAnchorChipIcon(kind)}
-      </span>
-      <span className="min-w-0 truncate font-medium">{filename}</span>
+      <AttachmentDocumentThumbnailArtwork
+        actionIcon={<IconEye size={10} />}
+        actionLabel="Preview"
+        filename={filename}
+        kind={kind}
+      />
     </a>
   );
 }
@@ -372,13 +406,6 @@ function DocumentThumbnailPreview({
     return <AttachmentAnchorChip filename={filename} url={url} kind={kind} />;
   }
 
-  const accentClass =
-    kind === "markdown"
-      ? "from-emerald-500/15 via-lime-500/10 to-background"
-      : kind === "csv"
-        ? "from-teal-500/15 via-emerald-500/10 to-background"
-        : "from-rose-500/15 via-orange-500/10 to-background";
-
   return (
     <button
       type="button"
@@ -392,28 +419,12 @@ function DocumentThumbnailPreview({
       aria-label={`Open ${kind} preview for ${filename}`}
       title={filename}
     >
-      <div
-        className={`relative flex aspect-[4/3] w-[144px] items-center justify-center overflow-hidden rounded-xl bg-gradient-to-br sm:w-[168px] ${accentClass}`}
-      >
-        <div className="absolute inset-0 bg-[radial-gradient(circle_at_top,rgba(255,255,255,0.45),transparent_55%)] dark:bg-[radial-gradient(circle_at_top,rgba(255,255,255,0.08),transparent_55%)]" />
-        <div className="absolute inset-x-0 top-0 h-10 bg-gradient-to-b from-black/10 to-transparent" />
-        <div className="relative flex h-16 w-16 items-center justify-center rounded-2xl border border-foreground/10 bg-background/90 shadow-sm transition-transform duration-200 group-hover/doc-preview:scale-105">
-          <FilePreviewIcon
-            filename={filename}
-            contentType={contentTypeForDocumentPreviewKind(kind)}
-            testId={`attachment-preview-${kind}-icon`}
-          />
-        </div>
-        <div className="absolute right-2 top-2 inline-flex items-center gap-1 rounded-full bg-background/85 px-1.5 py-0.5 text-[9px] font-medium uppercase tracking-wide text-muted-foreground opacity-0 transition-opacity duration-200 group-hover/doc-preview:opacity-100">
-          <IconEye size={10} />
-          Preview
-        </div>
-        <div className="absolute inset-x-0 bottom-0 flex items-end justify-between gap-2 bg-gradient-to-t from-black/55 via-black/15 to-transparent px-2.5 py-2.5 text-white opacity-0 transition-opacity duration-200 group-hover/doc-preview:opacity-100">
-          <div className="min-w-0">
-            <div className="truncate text-xs font-medium">{filename}</div>
-          </div>
-        </div>
-      </div>
+      <AttachmentDocumentThumbnailArtwork
+        actionIcon={<IconEye size={10} />}
+        actionLabel="Preview"
+        filename={filename}
+        kind={kind}
+      />
     </button>
   );
 }

--- a/turbo/apps/platform/src/views/zero-page/zero-attachment-preview.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-attachment-preview.tsx
@@ -19,6 +19,7 @@ import {
 } from "../../signals/view-component-state.ts";
 import { lightboxUrl$ } from "../../signals/zero-page/zero-attachment-chips.ts";
 import {
+  openAudioLightboxOrArtifact$,
   chatArtifactSidebarEnabled$,
   openDocumentLightboxOrArtifact$,
   openVideoLightboxOrArtifact$,
@@ -485,49 +486,58 @@ function FileThumbnailPreview({
   );
 }
 
-function AudioPreview({ filename, url }: { filename: string; url: string }) {
+function AudioPreview({
+  contentType,
+  filename,
+  url,
+}: {
+  contentType?: string;
+  filename: string;
+  url: string;
+}) {
+  const openAudioLightbox = useSet(openAudioLightboxOrArtifact$);
+  const lightboxOpen = useGet(lightboxUrl$) !== null;
+  const accentClass = getFilePreviewAccentClass(
+    filename,
+    contentType ?? "audio/mpeg",
+  );
+
   return (
-    <div
-      className="w-full max-w-md rounded-xl border border-foreground/10 bg-background/60 p-3"
+    <button
+      type="button"
+      onClick={(event) => {
+        event.currentTarget.blur();
+        openAudioLightbox({ url, filename });
+      }}
+      disabled={lightboxOpen}
+      title={filename}
+      aria-label={`Open audio preview for ${filename}`}
       data-testid="attachment-preview-audio"
+      className={`${lightboxOpen ? "" : "group/doc-preview"} inline-flex w-fit self-start align-top text-left disabled:pointer-events-none`}
     >
-      <div className="mb-3 flex items-center gap-3">
-        <div className="flex h-10 w-10 shrink-0 items-center justify-center rounded-xl bg-muted/60 text-muted-foreground">
-          <IconFileMusic size={22} stroke={1.6} />
+      <div
+        className={`relative flex aspect-[4/3] w-[144px] items-center justify-center overflow-hidden rounded-xl bg-gradient-to-br sm:w-[168px] ${accentClass}`}
+      >
+        <div className="absolute inset-0 bg-[radial-gradient(circle_at_top,rgba(255,255,255,0.45),transparent_55%)] dark:bg-[radial-gradient(circle_at_top,rgba(255,255,255,0.08),transparent_55%)]" />
+        <div className="absolute inset-x-0 top-0 h-10 bg-gradient-to-b from-black/10 to-transparent" />
+        <div className="relative flex h-16 w-16 items-center justify-center rounded-2xl border border-foreground/10 bg-background/90 shadow-sm transition-transform duration-200 group-hover/doc-preview:scale-105">
+          <FilePreviewIcon
+            filename={filename}
+            contentType={contentType ?? "audio/mpeg"}
+            testId="attachment-preview-audio-icon"
+          />
         </div>
-        <div className="min-w-0 flex-1">
-          <div className="truncate text-sm font-medium text-foreground">
-            {filename}
+        <div className="absolute right-2 top-2 inline-flex items-center gap-1 rounded-full bg-background/85 px-1.5 py-0.5 text-[9px] font-medium uppercase tracking-wide text-muted-foreground opacity-0 transition-opacity duration-200 group-hover/doc-preview:opacity-100">
+          <IconFileMusic size={10} />
+          Preview
+        </div>
+        <div className="absolute inset-x-0 bottom-0 flex items-end justify-between gap-2 bg-gradient-to-t from-black/55 via-black/15 to-transparent px-2.5 py-2.5 text-white opacity-0 transition-opacity duration-200 group-hover/doc-preview:opacity-100">
+          <div className="min-w-0">
+            <div className="truncate text-xs font-medium">{filename}</div>
           </div>
         </div>
-        <button
-          type="button"
-          onClick={() => {
-            detach(
-              downloadAttachmentUrl(
-                normalizePlatformFileUrl(url),
-                undefined,
-                filename,
-              ),
-              Reason.DomCallback,
-              "attachment download",
-            );
-          }}
-          title={filename}
-          aria-label={`Download ${filename}`}
-          className="inline-flex h-7 w-7 shrink-0 items-center justify-center rounded-full bg-background/90 text-muted-foreground hover:text-foreground"
-        >
-          <IconDownload size={12} />
-        </button>
       </div>
-      <audio
-        src={url}
-        controls
-        preload="metadata"
-        className="block w-full"
-        aria-label={`Audio preview for ${filename}`}
-      />
-    </div>
+    </button>
   );
 }
 
@@ -667,7 +677,11 @@ export function AttachmentPreview({
     }
     case "audio": {
       return (
-        <AudioPreview filename={attachment.filename} url={attachment.url} />
+        <AudioPreview
+          contentType={attachment.contentType}
+          filename={attachment.filename}
+          url={attachment.url}
+        />
       );
     }
     case "video": {

--- a/turbo/apps/platform/src/views/zero-page/zero-attachment-url.ts
+++ b/turbo/apps/platform/src/views/zero-page/zero-attachment-url.ts
@@ -1,0 +1,229 @@
+import { toast } from "@vm0/ui/components/ui/sonner";
+import { logger } from "../../signals/log.ts";
+import { writeToClipboard } from "../../signals/zero-page/clipboard.ts";
+
+const log = logger("zero-attachment-url");
+
+const LEGACY_FILE_PATH_PATTERN = /^\/f\/([^/]+)\/([^/]+)\/([^/]+)$/;
+const ARTIFACT_FILE_PATH_PATTERN = /^\/artifacts\/([^/]+)\/([^/]+)\/([^/]+)$/;
+const CLERK_USER_ID_PREFIX = "user_";
+
+export function attachmentFilenameFromUrl(url: string): string {
+  const path = url.split("?")[0].split("#")[0];
+  const last = path.split("/").pop();
+  return last && last.length > 0 ? last : "image";
+}
+
+function publicArtifactsBaseUrl(): string | null {
+  const baseUrl = import.meta.env.PUBLIC_ARTIFACTS_BASE_URL;
+  if (!baseUrl || !URL.canParse(baseUrl)) {
+    return null;
+  }
+  return baseUrl.replace(/\/+$/, "");
+}
+
+function hasExplicitUrlOrigin(url: string): boolean {
+  return /^[a-z][a-z\d+\-.]*:\/\//i.test(url);
+}
+
+function browserOrigin(): string | null {
+  if (typeof window === "undefined") {
+    return null;
+  }
+  return window.location.origin;
+}
+
+type PlatformHostTarget = "api" | "www";
+
+function rewritePlatformHostname(
+  hostname: string,
+  target: PlatformHostTarget,
+): string {
+  return hostname.replace(/(^|-)(platform|app|www|api)\./, `$1${target}.`);
+}
+
+function addOrigin(origins: Set<string>, baseUrl: string | null) {
+  if (!baseUrl || !URL.canParse(baseUrl)) {
+    return;
+  }
+  origins.add(new URL(baseUrl).origin);
+}
+
+function addPlatformOriginVariants(
+  origins: Set<string>,
+  baseUrl: string | null,
+) {
+  if (!baseUrl || !URL.canParse(baseUrl)) {
+    return;
+  }
+
+  const parsed = new URL(baseUrl);
+  origins.add(parsed.origin);
+
+  for (const target of ["api", "www"] as const) {
+    const variant = new URL(parsed);
+    variant.hostname = rewritePlatformHostname(variant.hostname, target);
+    origins.add(variant.origin);
+  }
+}
+
+function platformFileOrigins(): Set<string> {
+  const origins = new Set<string>();
+  const configuredApiUrl = import.meta.env.VITE_API_URL as string | undefined;
+
+  addPlatformOriginVariants(origins, browserOrigin());
+  addPlatformOriginVariants(origins, configuredApiUrl ?? null);
+  addOrigin(origins, publicArtifactsBaseUrl());
+
+  return origins;
+}
+
+function isPlatformFileUrlHost(parsed: URL, sourceUrl: string): boolean {
+  return (
+    !hasExplicitUrlOrigin(sourceUrl) || platformFileOrigins().has(parsed.origin)
+  );
+}
+
+function storageUserIdSegmentFromFileUrlSegment(userIdSegment: string): string {
+  if (
+    userIdSegment === "user" ||
+    userIdSegment.startsWith(CLERK_USER_ID_PREFIX) ||
+    userIdSegment.startsWith("user-")
+  ) {
+    return userIdSegment;
+  }
+  return `${CLERK_USER_ID_PREFIX}${userIdSegment}`;
+}
+
+function artifactCdnUrl(args: {
+  userIdSegment: string;
+  idSegment: string;
+  filenameSegment: string;
+  hash: string;
+}): string | null {
+  const baseUrl = publicArtifactsBaseUrl();
+  if (!baseUrl) {
+    return null;
+  }
+  return `${baseUrl}/artifacts/${args.userIdSegment}/${args.idSegment}/${args.filenameSegment}${args.hash}`;
+}
+
+function parseFileUrl(url: string): URL | null {
+  const baseUrl = browserOrigin() ?? undefined;
+  if (!URL.canParse(url, baseUrl)) {
+    return null;
+  }
+  return new URL(url, baseUrl);
+}
+
+function normalizedLegacyFileUrl(url: string): string | null {
+  const parsed = parseFileUrl(url);
+  if (!parsed) {
+    return null;
+  }
+  if (!isPlatformFileUrlHost(parsed, url)) {
+    return null;
+  }
+  const match = parsed.pathname.match(LEGACY_FILE_PATH_PATTERN);
+  if (!match) {
+    return null;
+  }
+  const [, userIdSegment, idSegment, filenameSegment] = match;
+  return artifactCdnUrl({
+    userIdSegment: storageUserIdSegmentFromFileUrlSegment(userIdSegment),
+    idSegment,
+    filenameSegment,
+    hash: parsed.hash,
+  });
+}
+
+function normalizedArtifactFileUrl(url: string): string | null {
+  const parsed = parseFileUrl(url);
+  if (!parsed) {
+    return null;
+  }
+  if (!isPlatformFileUrlHost(parsed, url)) {
+    return null;
+  }
+  const match = parsed.pathname.match(ARTIFACT_FILE_PATH_PATTERN);
+  if (!match) {
+    return null;
+  }
+  const [, userIdSegment, idSegment, filenameSegment] = match;
+  return artifactCdnUrl({
+    userIdSegment,
+    idSegment,
+    filenameSegment,
+    hash: parsed.hash,
+  });
+}
+
+export function publicAttachmentUrl(url: string): string {
+  return normalizedLegacyFileUrl(url) ?? normalizedArtifactFileUrl(url) ?? url;
+}
+
+export function getAttachmentRawUrl(url: string): string {
+  return url;
+}
+
+function triggerBlobDownload(blob: Blob, filename: string): void {
+  const blobUrl = URL.createObjectURL(blob);
+  const a = document.createElement("a");
+  a.href = blobUrl;
+  a.download = filename;
+  document.body.appendChild(a);
+  a.click();
+  a.remove();
+  URL.revokeObjectURL(blobUrl);
+}
+
+// Fetch the asset as a blob so downloads are delivered from a same-origin
+// object URL. Cross-origin `<a download>` is intentionally avoided because
+// browsers ignore it for CDN image URLs and open the asset instead.
+async function fetchBlobForDownload(
+  url: string,
+  signal: AbortSignal,
+): Promise<Blob | null> {
+  const fetchUrl = publicAttachmentUrl(url);
+  // The catch branch reports network/CORS failures without falling back to
+  // cross-origin anchor navigation, which would open images instead.
+  // eslint-disable-next-line no-restricted-syntax -- fetch/CORS failures should surface as download failures
+  try {
+    const res = await fetch(fetchUrl, {
+      cache: "reload",
+      mode: "cors",
+      signal,
+    });
+    if (!res.ok) {
+      throw new Error(`fetch failed: ${String(res.status)}`);
+    }
+    return await res.blob();
+  } catch (error) {
+    signal.throwIfAborted();
+    log.warn("downloadUrl: fetch failed", error);
+    toast.error("Download failed");
+    return null;
+  }
+}
+
+export async function downloadAttachmentUrl(
+  url: string,
+  signal: AbortSignal = AbortSignal.any([]),
+  filename = attachmentFilenameFromUrl(url),
+): Promise<void> {
+  const blob = await fetchBlobForDownload(url, signal);
+  if (blob !== null) {
+    triggerBlobDownload(blob, filename);
+  }
+}
+
+export async function copyAttachmentLinkToClipboard(
+  url: string,
+): Promise<void> {
+  const copied = await writeToClipboard(publicAttachmentUrl(url));
+  if (copied) {
+    toast.success("Link copied");
+    return;
+  }
+  toast.error("Failed to copy link");
+}

--- a/turbo/apps/platform/src/views/zero-page/zero-chat-thread-page.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-chat-thread-page.tsx
@@ -107,7 +107,6 @@ import {
 import {
   AttachmentLightbox,
   CsvPreviewTable,
-  downloadAttachmentUrl,
   FileAttachmentChip,
   getAttachmentRawUrl,
   parseCsvRows,
@@ -132,9 +131,17 @@ import {
 import type { PermissionActionBlock } from "../../signals/chat-page/permission-action-block.ts";
 import { AttachmentPreview } from "./zero-attachment-preview.tsx";
 import { FilePreviewIcon } from "./zero-file-preview-icon.tsx";
+import {
+  ArtifactDownloadMenu,
+  ArtifactShareButton,
+  type ArtifactDownloadSyncTarget,
+} from "./zero-artifact-actions.tsx";
 import { ConnectorIcon } from "./components/settings/connector-icons.tsx";
 import { ConnectModal } from "./components/settings/add-connection-dialog.tsx";
-import { lightboxUrl$ as attachmentLightboxUrl$ } from "../../signals/zero-page/zero-attachment-chips.ts";
+import {
+  lightboxUrl$ as attachmentLightboxUrl$,
+  type AttachmentArtifactMetadata,
+} from "../../signals/zero-page/zero-attachment-chips.ts";
 import {
   artifactFullscreen$,
   artifactInboxQuery$,
@@ -157,10 +164,7 @@ import {
   toggleArtifactFullscreen$,
   toggleArtifactInboxSearch$,
 } from "../../signals/zero-page/zero-artifact-sidebar.ts";
-import {
-  writeToClipboard,
-  type ChatClipboardAttachment,
-} from "../../signals/zero-page/clipboard.ts";
+import type { ChatClipboardAttachment } from "../../signals/zero-page/clipboard.ts";
 import { connectors$ } from "../../signals/external/connectors.ts";
 import { toast } from "@vm0/ui/components/ui/sonner";
 import {
@@ -244,7 +248,6 @@ import { sidebarChatThreads$ } from "../../signals/chat-page/optimistic-chat-thr
 import {
   type ArtifactGoogleDriveSyncFile,
   syncArtifactFilesToGoogleDrive,
-  syncArtifactFileToGoogleDrive,
   waitForGoogleDriveAndSyncArtifacts$,
 } from "../../signals/chat-page/artifact-google-drive-sync.ts";
 import { zeroConnectorOauthStartContract } from "@vm0/api-contracts/contracts/zero-connectors";
@@ -1160,6 +1163,8 @@ const ARTIFACT_INBOX_SECTIONS = [
   label: string;
 }[];
 
+type ArtifactInboxSectionEntry = (typeof ARTIFACT_INBOX_SECTIONS)[number];
+
 function artifactItemKey(item: ChatArtifactItem): string {
   return `${item.runId}:${item.file.id}:${item.file.url}`;
 }
@@ -1268,6 +1273,30 @@ function artifactMatchesInboxSection(
     previewKind === "video" ||
     previewKind === "audio"
   );
+}
+
+function artifactInboxSectionsForItems(
+  items: readonly ChatArtifactItem[],
+): readonly ArtifactInboxSectionEntry[] {
+  return ARTIFACT_INBOX_SECTIONS.filter((entry) => {
+    return (
+      entry.key === "all" ||
+      items.some((item) => {
+        return artifactMatchesInboxSection(item, entry.key);
+      })
+    );
+  });
+}
+
+function resolveVisibleArtifactInboxSection(
+  section: ArtifactInboxSection,
+  sections: readonly ArtifactInboxSectionEntry[],
+): ArtifactInboxSection {
+  return sections.some((entry) => {
+    return entry.key === section;
+  })
+    ? section
+    : "all";
 }
 
 function artifactMatchesSearch(item: ChatArtifactItem, query: string): boolean {
@@ -1490,17 +1519,6 @@ function ArtifactPreviewOpenOverlay({
   );
 }
 
-async function copyArtifactLinkToClipboard(
-  file: ChatThreadArtifactFile,
-): Promise<void> {
-  const copied = await writeToClipboard(publicAttachmentUrl(file.url));
-  if (copied) {
-    toast.success("Link copied");
-    return;
-  }
-  toast.error("Failed to copy link");
-}
-
 async function downloadArtifactItemsAsZip(params: {
   readonly items: readonly ChatArtifactItem[];
   readonly signal: AbortSignal;
@@ -1576,6 +1594,43 @@ function artifactItemsToGoogleDriveFiles(
 
 function isArtifactSyncedToGoogleDrive(item: ChatArtifactItem): boolean {
   return item.file.googleDriveSync?.status === "synced";
+}
+
+function artifactDownloadSyncTargetFromItem(params: {
+  agentId: string | null | undefined;
+  item: ChatArtifactItem;
+  onSyncSuccess: () => void;
+  threadId: string;
+}): ArtifactDownloadSyncTarget {
+  return {
+    agentId: params.agentId,
+    fileId: params.item.file.id,
+    filename: params.item.file.filename,
+    onSyncSuccess: params.onSyncSuccess,
+    runId: params.item.runId,
+    synced: isArtifactSyncedToGoogleDrive(params.item),
+    threadId: params.threadId,
+  };
+}
+
+function artifactLightboxMetadataFromItem(params: {
+  agentId: string | null | undefined;
+  item: ChatArtifactItem;
+  onSyncSuccess: () => void;
+  threadId: string;
+}): AttachmentArtifactMetadata {
+  return {
+    agentId: params.agentId,
+    contentType: params.item.file.contentType,
+    createdAt: params.item.file.createdAt,
+    fileId: params.item.file.id,
+    filename: params.item.file.filename,
+    googleDriveSynced: isArtifactSyncedToGoogleDrive(params.item),
+    onSyncSuccess: params.onSyncSuccess,
+    runId: params.item.runId,
+    size: params.item.file.size,
+    threadId: params.threadId,
+  };
 }
 
 type WaitForGoogleDriveAndSyncArtifactsFn = (
@@ -1716,139 +1771,37 @@ function ArtifactGoogleDriveConnectMenuItem({
   );
 }
 
-function ArtifactPreviewIconButton({
-  ariaLabel,
-  children,
-  disabled = false,
-  onClick,
-  tooltip,
-}: {
-  ariaLabel: string;
-  children: ReactNode;
-  disabled?: boolean;
-  onClick: () => void;
-  tooltip: string;
-}) {
-  return (
-    <TooltipProvider delayDuration={200}>
-      <Tooltip>
-        <TooltipTrigger asChild>
-          <button
-            type="button"
-            aria-disabled={disabled}
-            aria-label={ariaLabel}
-            onClick={() => {
-              if (!disabled) {
-                onClick();
-              }
-            }}
-            className={cn(
-              "flex h-8 w-8 items-center justify-center rounded-md text-muted-foreground transition-colors hover:bg-accent hover:text-foreground",
-              disabled &&
-                "cursor-not-allowed opacity-45 hover:bg-transparent hover:text-muted-foreground",
-            )}
-          >
-            {children}
-          </button>
-        </TooltipTrigger>
-        <TooltipContent side="top">
-          <p className="text-xs">{tooltip}</p>
-        </TooltipContent>
-      </Tooltip>
-    </TooltipProvider>
-  );
-}
-
 function ArtifactPreviewActions({
   item,
-  googleDriveConnected,
   agentId,
   threadId,
   onSyncSuccess,
 }: {
   item: ChatArtifactItem;
-  googleDriveConnected: boolean;
   agentId: string | null | undefined;
   threadId: string;
   onSyncSuccess: () => void;
 }) {
-  const createClient = useGet(zeroClient$);
-  const waitForGoogleDriveAndSyncArtifacts = useSet(
-    waitForGoogleDriveAndSyncArtifacts$,
-  );
-  const pageSignal = useGet(pageSignal$);
   const { file } = item;
-  const synced = isArtifactSyncedToGoogleDrive(item);
-  const syncTooltip = synced
-    ? "Synced to Google Drive"
-    : googleDriveConnected
-      ? "Sync to Google Drive"
-      : CONNECT_GOOGLE_DRIVE_ARTIFACT_UPLOAD_TOOLTIP;
-  const syncAriaLabel = synced
-    ? `${file.filename} is synced to Google Drive`
-    : `Sync ${file.filename} to Google Drive`;
+  const syncTarget = artifactDownloadSyncTargetFromItem({
+    agentId,
+    item,
+    onSyncSuccess,
+    threadId,
+  });
 
   return (
     <div className="flex shrink-0 items-center gap-1">
-      <ArtifactPreviewIconButton
-        ariaLabel={`Copy link for ${file.filename}`}
-        tooltip="Copy link"
-        onClick={() => {
-          detach(
-            copyArtifactLinkToClipboard(file),
-            Reason.DomCallback,
-            "artifact copy link",
-          );
-        }}
-      >
-        <IconLink size={16} stroke={1.5} />
-      </ArtifactPreviewIconButton>
-      <ArtifactPreviewIconButton
+      <ArtifactShareButton
+        ariaLabel={`Share ${file.filename}`}
+        url={file.url}
+      />
+      <ArtifactDownloadMenu
         ariaLabel={`Download ${file.filename}`}
-        tooltip="Download"
-        onClick={() => {
-          detach(
-            downloadAttachmentUrl(file.url, pageSignal, file.filename),
-            Reason.DomCallback,
-            "artifact download",
-          );
-        }}
-      >
-        <IconDownload size={16} stroke={1.5} />
-      </ArtifactPreviewIconButton>
-      <ArtifactPreviewIconButton
-        ariaLabel={syncAriaLabel}
-        disabled={synced}
-        tooltip={syncTooltip}
-        onClick={() => {
-          if (googleDriveConnected) {
-            syncArtifactFilesAndRefresh({
-              sync: syncArtifactFileToGoogleDrive({
-                createClient,
-                threadId,
-                runId: item.runId,
-                fileId: item.file.id,
-                filename: item.file.filename,
-                signal: pageSignal,
-              }),
-              onSyncSuccess,
-              reason: "artifact google drive sync",
-            });
-            return;
-          }
-          startGoogleDriveConnectAndSync({
-            agentId,
-            createClient,
-            files: artifactItemsToGoogleDriveFiles([item]),
-            pageSignal,
-            threadId,
-            waitForGoogleDriveAndSyncArtifacts,
-            onSyncComplete: onSyncSuccess,
-          });
-        }}
-      >
-        <IconBrandGoogleDrive size={16} stroke={1.5} />
-      </ArtifactPreviewIconButton>
+        filename={file.filename}
+        syncTarget={syncTarget}
+        url={file.url}
+      />
     </div>
   );
 }
@@ -2097,11 +2050,28 @@ function ChatVideoPreviewButton({
   );
 }
 
-function ArtifactPreviewFrame({ file }: { file: ChatThreadArtifactFile }) {
+function ArtifactPreviewFrame({
+  agentId,
+  item,
+  onSyncSuccess,
+  threadId,
+}: {
+  agentId: string | null | undefined;
+  item: ChatArtifactItem;
+  onSyncSuccess: () => void;
+  threadId: string;
+}) {
   const openImageLightbox = useSet(openAttachmentImageLightbox$);
   const openDocumentLightbox = useSet(openAttachmentDocumentLightbox$);
   const openVideoLightbox = useSet(openAttachmentVideoLightbox$);
+  const { file } = item;
   const previewKind = getArtifactPreviewKind(file);
+  const artifact = artifactLightboxMetadataFromItem({
+    agentId,
+    item,
+    onSyncSuccess,
+    threadId,
+  });
 
   if (previewKind === "image") {
     return (
@@ -2111,7 +2081,11 @@ function ArtifactPreviewFrame({ file }: { file: ChatThreadArtifactFile }) {
         imageClassName="h-full w-full object-contain"
         linkClassName="flex h-full w-full items-center justify-center bg-muted"
         onPreview={() => {
-          openImageLightbox(file.url);
+          openImageLightbox({
+            url: file.url,
+            filename: file.filename,
+            artifact,
+          });
         }}
         placeholderClassName="h-full w-full"
         url={file.url}
@@ -2129,6 +2103,7 @@ function ArtifactPreviewFrame({ file }: { file: ChatThreadArtifactFile }) {
           openVideoLightbox({
             url: file.url,
             filename: file.filename,
+            artifact,
           });
         }}
         posterClassName="h-full w-full"
@@ -2167,6 +2142,7 @@ function ArtifactPreviewFrame({ file }: { file: ChatThreadArtifactFile }) {
         kind: documentPreviewKind,
         url: file.url,
         filename: file.filename,
+        artifact,
       });
     };
 
@@ -2211,13 +2187,11 @@ function ArtifactPreviewFrame({ file }: { file: ChatThreadArtifactFile }) {
 
 function ArtifactPreviewPanel({
   item,
-  googleDriveConnected,
   agentId,
   onSyncSuccess,
   threadId,
 }: {
   item: ChatArtifactItem;
-  googleDriveConnected: boolean;
   agentId: string | null | undefined;
   onSyncSuccess: () => void;
   threadId: string;
@@ -2227,7 +2201,12 @@ function ArtifactPreviewPanel({
   return (
     <div className="min-w-0 overflow-hidden rounded-lg border border-border/70 bg-background shadow-sm">
       <div className="h-[260px] border-b border-border/60 bg-muted/30">
-        <ArtifactPreviewFrame file={file} />
+        <ArtifactPreviewFrame
+          agentId={agentId}
+          item={item}
+          onSyncSuccess={onSyncSuccess}
+          threadId={threadId}
+        />
       </div>
       <div className="flex items-start gap-3 px-3 py-3">
         <span className="mt-0.5 flex h-9 w-9 shrink-0 items-center justify-center overflow-hidden rounded-md bg-muted text-muted-foreground">
@@ -2238,13 +2217,16 @@ function ArtifactPreviewPanel({
             {file.filename}
           </p>
           <div className="mt-1 flex flex-wrap items-center gap-x-2 gap-y-1 text-xs text-muted-foreground">
+            <span>{artifactFileKindLabel(file)}</span>
+            <span aria-hidden>·</span>
             <span>{formatBytes(file.size)}</span>
+            <span aria-hidden>·</span>
+            <span>{formatArtifactTime(file.createdAt)}</span>
           </div>
         </div>
         <div className="flex shrink-0 items-center gap-1">
           <ArtifactPreviewActions
             item={item}
-            googleDriveConnected={googleDriveConnected}
             agentId={agentId}
             threadId={threadId}
             onSyncSuccess={onSyncSuccess}
@@ -2437,18 +2419,23 @@ function ChatArtifactInboxHeader({
 
 function ArtifactInboxTabs({
   section,
+  sections,
   setSection,
 }: {
   section: ArtifactInboxSection;
+  sections: readonly ArtifactInboxSectionEntry[];
   setSection: (value: ArtifactInboxSection) => void;
 }) {
   return (
     <div
-      className="grid grid-cols-4 rounded-lg bg-muted/70 p-1"
+      className="grid rounded-lg bg-muted/70 p-1"
+      style={{
+        gridTemplateColumns: `repeat(${sections.length}, minmax(0, 1fr))`,
+      }}
       role="tablist"
       aria-label="Artifact sections"
     >
-      {ARTIFACT_INBOX_SECTIONS.map((entry) => {
+      {sections.map((entry) => {
         const selected = section === entry.key;
         return (
           <button
@@ -2600,16 +2587,22 @@ function ChatArtifactInboxBody({ thread }: { thread: ChatThreadSignals }) {
   }
 
   const normalizedQuery = query.trim().toLowerCase();
+  const sections = artifactInboxSectionsForItems(items);
+  const activeSection = resolveVisibleArtifactInboxSection(section, sections);
   const visibleItems = items.filter((item) => {
     return (
-      artifactMatchesInboxSection(item, section) &&
+      artifactMatchesInboxSection(item, activeSection) &&
       artifactMatchesSearch(item, normalizedQuery)
     );
   });
 
   return (
     <div className="flex min-h-full flex-col gap-4">
-      <ArtifactInboxTabs section={section} setSection={setSection} />
+      <ArtifactInboxTabs
+        section={activeSection}
+        sections={sections}
+        setSection={setSection}
+      />
       {(searchOpen || query.length > 0) && (
         <ArtifactInboxSearch query={query} setQuery={setQuery} />
       )}
@@ -2658,7 +2651,7 @@ function ChatArtifactInboxList({ thread }: { thread: ChatThreadSignals }) {
         fullscreen
           ? "fixed inset-0 z-[100] flex flex-col bg-background"
           : "flex h-full w-full min-h-0 flex-col border-l border-border/60 bg-background",
-        "animate-in fade-in slide-in-from-right-2 duration-200",
+        "animate-in fade-in duration-[180ms] ease",
       )}
       data-testid="artifact-inbox"
     >
@@ -2706,6 +2699,7 @@ function ChatArtifactInboxSlot({
     return (
       <ArtifactSidebar
         artifactRef={artifactRef}
+        thread={thread ?? undefined}
         onBack={inboxThreadId ? backToInbox : undefined}
         onClose={close}
       />
@@ -2790,7 +2784,6 @@ function ChatArtifactsDrawerContent({ thread }: { thread: ChatThreadSignals }) {
       {selectedItem && (
         <ArtifactPreviewPanel
           item={selectedItem}
-          googleDriveConnected={googleDriveConnected}
           agentId={agentId}
           onSyncSuccess={refreshArtifactSyncStatus}
           threadId={thread.threadId}
@@ -2956,21 +2949,29 @@ export function ZeroChatThreadPage() {
         <div
           className={
             artifactPanelOpen
-              ? "hidden xl:flex flex-1 basis-0 min-w-0 min-h-0"
-              : "flex flex-1 min-w-0 min-h-0"
+              ? "hidden xl:flex flex-1 basis-0 min-w-0 min-h-0 transition-[flex-basis,width] duration-[240ms] ease"
+              : "flex flex-1 min-w-0 min-h-0 transition-[flex-basis,width] duration-[240ms] ease"
           }
         >
           {threadArea}
         </div>
-        {artifactPanelOpen && (
-          <div className="flex flex-1 basis-0 min-w-0 min-h-0">
+        <div
+          className={cn(
+            "flex min-h-0 min-w-0 overflow-hidden transition-[flex-basis,width] duration-[240ms] ease",
+            artifactPanelOpen
+              ? "flex-1 basis-0 xl:w-[min(760px,48vw)] xl:flex-none xl:basis-[min(760px,48vw)]"
+              : "pointer-events-none w-0 flex-none basis-0",
+          )}
+          aria-hidden={!artifactPanelOpen}
+        >
+          {artifactPanelOpen && (
             <ChatArtifactInboxSlot
               artifactRef={artifactRef}
               leftThread={leftThread}
               rightThread={rightThread}
             />
-          </div>
-        )}
+          )}
+        </div>
       </div>
       {!sidebarEnabled && leftThread && (
         <ChatArtifactsDrawer thread={leftThread} />

--- a/turbo/apps/platform/src/views/zero-page/zero-chat-thread-page.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-chat-thread-page.tsx
@@ -4,6 +4,7 @@ import type {
   MouseEvent as ReactMouseEvent,
   ReactNode,
 } from "react";
+import { createPortal } from "react-dom";
 import {
   useGet,
   useSet,
@@ -16,6 +17,8 @@ import { pageSignal$ } from "../../signals/page-signal.ts";
 import { rootSignal$ } from "../../signals/root-signal.ts";
 import {
   IconAlertCircle,
+  IconArrowsDiagonal,
+  IconArrowsDiagonalMinimize2,
   IconHandStop,
   IconPhoto,
   IconChartLine,
@@ -38,6 +41,7 @@ import {
   IconMessageCircle,
   IconPackage,
   IconPresentation,
+  IconSearch,
   IconTag,
   IconX,
   IconClock,
@@ -111,7 +115,7 @@ import {
   publicAttachmentUrl,
   TextPreviewLoader,
 } from "./zero-attachment-chips.tsx";
-import { ArtifactSidebarSlot } from "./zero-artifact-sidebar.tsx";
+import { ArtifactSidebar } from "./zero-artifact-sidebar.tsx";
 import {
   classifyChatAttachment,
   contentTypeForBodyPreviewKind,
@@ -132,11 +136,26 @@ import { ConnectorIcon } from "./components/settings/connector-icons.tsx";
 import { ConnectModal } from "./components/settings/add-connection-dialog.tsx";
 import { lightboxUrl$ as attachmentLightboxUrl$ } from "../../signals/zero-page/zero-attachment-chips.ts";
 import {
+  artifactFullscreen$,
+  artifactInboxQuery$,
+  artifactInboxSearchOpen$,
+  artifactInboxSection$,
+  backToArtifactInbox$,
+  type ArtifactInboxSection,
+  type ArtifactRef,
   chatArtifactSidebarEnabled$,
+  closeArtifact$,
+  currentArtifactInboxThreadId$,
   currentArtifactRef$,
+  openArtifactFromInbox$,
+  openArtifactInbox$,
+  setArtifactInboxQuery$,
+  setArtifactInboxSection$,
   openDocumentLightboxOrArtifact$ as openAttachmentDocumentLightbox$,
   openImageLightboxOrArtifact$ as openAttachmentImageLightbox$,
   openVideoLightboxOrArtifact$ as openAttachmentVideoLightbox$,
+  toggleArtifactFullscreen$,
+  toggleArtifactInboxSearch$,
 } from "../../signals/zero-page/zero-artifact-sidebar.ts";
 import {
   writeToClipboard,
@@ -278,8 +297,12 @@ function ArtifactsButton({ thread }: { thread: ChatThreadSignals }) {
 }
 
 function ArtifactsButtonInner({ thread }: { thread: ChatThreadSignals }) {
-  const open = useGet(thread.artifactsDrawerOpen$);
+  const drawerOpen = useGet(thread.artifactsDrawerOpen$);
+  const sidebarEnabled = useGet(chatArtifactSidebarEnabled$);
+  const inboxThreadId = useGet(currentArtifactInboxThreadId$);
   const setOpen = useSet(thread.setArtifactsDrawerOpen$);
+  const openInbox = useSet(openArtifactInbox$);
+  const open = sidebarEnabled ? inboxThreadId === thread.threadId : drawerOpen;
 
   return (
     <TooltipProvider delayDuration={300}>
@@ -288,6 +311,10 @@ function ArtifactsButtonInner({ thread }: { thread: ChatThreadSignals }) {
           <button
             type="button"
             onClick={() => {
+              if (sidebarEnabled) {
+                openInbox(thread.threadId);
+                return;
+              }
               setOpen(true);
             }}
             className={cn(
@@ -1123,6 +1150,16 @@ type ChatArtifactItem = {
 
 type ArtifactPreviewKind = "image" | "video" | "audio" | "document" | "file";
 
+const ARTIFACT_INBOX_SECTIONS = [
+  { key: "all", label: "All" },
+  { key: "media", label: "Media" },
+  { key: "docs", label: "Docs" },
+  { key: "sites", label: "Sites" },
+] as const satisfies readonly {
+  key: ArtifactInboxSection;
+  label: string;
+}[];
+
 function artifactItemKey(item: ChatArtifactItem): string {
   return `${item.runId}:${item.file.id}:${item.file.url}`;
 }
@@ -1166,6 +1203,80 @@ function flattenArtifactRuns(
       return { runId: run.runId, file };
     });
   });
+}
+
+function artifactFileKindLabel(file: ChatThreadArtifactFile): string {
+  const documentKind = getArtifactDocumentPreviewKind(file);
+  if (documentKind === "html") {
+    return "Hosted site";
+  }
+  if (documentKind === "pdf") {
+    return "PDF";
+  }
+  if (documentKind === "markdown") {
+    return "Markdown";
+  }
+  if (documentKind === "json") {
+    return "JSON";
+  }
+  if (documentKind === "csv") {
+    return "Data";
+  }
+  if (documentKind === "text") {
+    return "Text";
+  }
+
+  const previewKind = getArtifactPreviewKind(file);
+  switch (previewKind) {
+    case "image": {
+      return "Image";
+    }
+    case "video": {
+      return "Video";
+    }
+    case "audio": {
+      return "Audio";
+    }
+    case "document": {
+      return "Document";
+    }
+    case "file": {
+      return "File";
+    }
+  }
+}
+
+function artifactMatchesInboxSection(
+  item: ChatArtifactItem,
+  section: ArtifactInboxSection,
+): boolean {
+  if (section === "all") {
+    return true;
+  }
+
+  const documentKind = getArtifactDocumentPreviewKind(item.file);
+  if (section === "sites") {
+    return documentKind === "html";
+  }
+  if (section === "docs") {
+    return documentKind !== null && documentKind !== "html";
+  }
+
+  const previewKind = getArtifactPreviewKind(item.file);
+  return (
+    previewKind === "image" ||
+    previewKind === "video" ||
+    previewKind === "audio"
+  );
+}
+
+function artifactMatchesSearch(item: ChatArtifactItem, query: string): boolean {
+  if (query.length === 0) {
+    return true;
+  }
+  const haystack =
+    `${item.file.filename} ${item.file.contentType}`.toLowerCase();
+  return haystack.includes(query);
 }
 
 function ArtifactFileIcon({
@@ -2260,6 +2371,354 @@ function ArtifactFileRow({
   );
 }
 
+function ChatArtifactInboxHeader({
+  count,
+  fullscreen,
+  searchOpen,
+  onClose,
+  onToggleSearch,
+  onToggleFullscreen,
+}: {
+  count: number | null;
+  fullscreen: boolean;
+  searchOpen: boolean;
+  onClose: () => void;
+  onToggleSearch: () => void;
+  onToggleFullscreen: () => void;
+}) {
+  return (
+    <div className="flex min-h-14 shrink-0 items-center gap-3 border-b border-border/60 px-4 py-2">
+      <div className="flex min-w-0 flex-1 items-center gap-2">
+        <h2 className="truncate text-sm font-medium text-foreground">
+          Artifacts
+        </h2>
+        {count !== null && (
+          <span className="shrink-0 rounded-full bg-muted px-2 py-0.5 text-xs font-medium text-muted-foreground">
+            {count}
+          </span>
+        )}
+      </div>
+      <button
+        type="button"
+        onClick={onToggleSearch}
+        aria-label="Search artifacts"
+        aria-pressed={searchOpen}
+        className={cn(
+          "inline-flex h-8 w-8 items-center justify-center rounded-md text-muted-foreground transition-colors hover:bg-muted/60 hover:text-foreground",
+          searchOpen && "bg-muted/60 text-foreground",
+        )}
+      >
+        <IconSearch size={16} />
+      </button>
+      <button
+        type="button"
+        onClick={onToggleFullscreen}
+        aria-label={fullscreen ? "Exit fullscreen" : "Enter fullscreen"}
+        data-testid="artifact-inbox-fullscreen-toggle"
+        className="hidden h-8 w-8 items-center justify-center rounded-md text-muted-foreground transition-colors hover:bg-muted/60 hover:text-foreground xl:inline-flex"
+      >
+        {fullscreen ? (
+          <IconArrowsDiagonalMinimize2 size={16} />
+        ) : (
+          <IconArrowsDiagonal size={16} />
+        )}
+      </button>
+      <button
+        type="button"
+        onClick={onClose}
+        aria-label="Close artifacts"
+        className="inline-flex h-8 w-8 items-center justify-center rounded-md text-muted-foreground transition-colors hover:bg-muted/60 hover:text-foreground"
+      >
+        <IconX size={16} />
+      </button>
+    </div>
+  );
+}
+
+function ArtifactInboxTabs({
+  section,
+  setSection,
+}: {
+  section: ArtifactInboxSection;
+  setSection: (value: ArtifactInboxSection) => void;
+}) {
+  return (
+    <div
+      className="grid grid-cols-4 rounded-lg bg-muted/70 p-1"
+      role="tablist"
+      aria-label="Artifact sections"
+    >
+      {ARTIFACT_INBOX_SECTIONS.map((entry) => {
+        const selected = section === entry.key;
+        return (
+          <button
+            key={entry.key}
+            type="button"
+            role="tab"
+            aria-selected={selected}
+            onClick={() => {
+              setSection(entry.key);
+            }}
+            className={cn(
+              "h-8 rounded-md px-2 text-xs font-medium transition-colors",
+              selected
+                ? "bg-background text-foreground shadow-sm"
+                : "text-muted-foreground hover:text-foreground",
+            )}
+          >
+            {entry.label}
+          </button>
+        );
+      })}
+    </div>
+  );
+}
+
+function ArtifactInboxSearch({
+  query,
+  setQuery,
+}: {
+  query: string;
+  setQuery: (value: string) => void;
+}) {
+  return (
+    <label className="relative block">
+      <span className="sr-only">Search artifacts</span>
+      <IconSearch
+        size={15}
+        className="pointer-events-none absolute left-3 top-1/2 -translate-y-1/2 text-muted-foreground"
+      />
+      <input
+        value={query}
+        onChange={(event) => {
+          setQuery(event.currentTarget.value);
+        }}
+        className="h-9 w-full rounded-lg border border-border/70 bg-background pl-9 pr-3 text-sm text-foreground outline-none transition-colors placeholder:text-muted-foreground focus:border-ring"
+        placeholder="Search"
+        autoComplete="off"
+        autoFocus
+      />
+    </label>
+  );
+}
+
+function ArtifactInboxRow({
+  item,
+  onOpen,
+}: {
+  item: ChatArtifactItem;
+  onOpen: () => void;
+}) {
+  const { file } = item;
+  const live = getArtifactDocumentPreviewKind(file) === "html";
+
+  return (
+    <button
+      type="button"
+      onClick={onOpen}
+      aria-label={`Open artifact ${file.filename}`}
+      className="group flex w-full min-w-0 items-center gap-3 rounded-lg border border-border/60 bg-background/80 p-3 text-left shadow-sm transition-colors hover:border-foreground/20 hover:bg-muted/25 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2"
+    >
+      <span className="flex h-12 w-12 shrink-0 items-center justify-center overflow-hidden rounded-lg bg-muted text-muted-foreground">
+        <ArtifactPreviewBadge file={file} />
+      </span>
+      <span className="min-w-0 flex-1">
+        <span
+          className="block truncate text-sm font-medium text-foreground"
+          title={file.filename}
+        >
+          {file.filename}
+        </span>
+        <span className="mt-1 flex min-w-0 flex-wrap items-center gap-x-2 gap-y-1 text-xs text-muted-foreground">
+          <span>{artifactFileKindLabel(file)}</span>
+          <span aria-hidden>·</span>
+          <span>{formatBytes(file.size)}</span>
+          <span aria-hidden>·</span>
+          <span>{formatArtifactTime(file.createdAt)}</span>
+        </span>
+      </span>
+      {live && (
+        <span className="shrink-0 rounded-full bg-emerald-500/10 px-2 py-0.5 text-xs font-medium text-emerald-700 dark:text-emerald-400">
+          Live
+        </span>
+      )}
+      <IconChevronRight
+        size={16}
+        className="shrink-0 text-muted-foreground transition-transform group-hover:translate-x-0.5 group-hover:text-foreground"
+      />
+    </button>
+  );
+}
+
+function ChatArtifactInboxBody({ thread }: { thread: ChatThreadSignals }) {
+  const loadable = useLastLoadable(thread.artifacts$);
+  const section = useGet(artifactInboxSection$);
+  const query = useGet(artifactInboxQuery$);
+  const searchOpen = useGet(artifactInboxSearchOpen$);
+  const setSection = useSet(setArtifactInboxSection$);
+  const setQuery = useSet(setArtifactInboxQuery$);
+  const openArtifact = useSet(openArtifactFromInbox$);
+
+  if (loadable.state === "loading") {
+    return (
+      <div className="flex flex-col gap-3">
+        {Array.from({ length: 5 }, (_, i) => {
+          return <Skeleton key={i} className="h-[74px] rounded-lg" />;
+        })}
+      </div>
+    );
+  }
+
+  if (loadable.state === "hasError") {
+    return (
+      <div className="rounded-lg border border-destructive/30 bg-destructive/5 p-4 text-sm text-destructive">
+        Failed to load artifacts
+      </div>
+    );
+  }
+
+  if (loadable.state !== "hasData") {
+    return null;
+  }
+
+  const items = flattenArtifactRuns(loadable.data);
+  if (items.length === 0) {
+    return (
+      <div className="flex h-full min-h-[360px] flex-col items-center justify-center gap-3 rounded-lg border border-dashed border-border/70 p-8 text-center">
+        <img
+          src={emptyArtifactImg}
+          alt=""
+          role="presentation"
+          loading="lazy"
+          className="h-24 w-24 object-contain opacity-80"
+        />
+        <p className="text-sm text-muted-foreground">
+          No uploaded files in this chat yet.
+        </p>
+      </div>
+    );
+  }
+
+  const normalizedQuery = query.trim().toLowerCase();
+  const visibleItems = items.filter((item) => {
+    return (
+      artifactMatchesInboxSection(item, section) &&
+      artifactMatchesSearch(item, normalizedQuery)
+    );
+  });
+
+  return (
+    <div className="flex min-h-full flex-col gap-4">
+      <ArtifactInboxTabs section={section} setSection={setSection} />
+      {(searchOpen || query.length > 0) && (
+        <ArtifactInboxSearch query={query} setQuery={setQuery} />
+      )}
+      {visibleItems.length === 0 ? (
+        <div className="flex flex-1 items-center justify-center rounded-lg border border-dashed border-border/70 p-8 text-center text-sm text-muted-foreground">
+          No artifacts match this view.
+        </div>
+      ) : (
+        <div className="flex flex-col gap-2">
+          {visibleItems.map((item) => {
+            return (
+              <ArtifactInboxRow
+                key={artifactItemKey(item)}
+                item={item}
+                onOpen={() => {
+                  openArtifact({
+                    threadId: thread.threadId,
+                    url: item.file.url,
+                  });
+                }}
+              />
+            );
+          })}
+        </div>
+      )}
+    </div>
+  );
+}
+
+function ChatArtifactInboxList({ thread }: { thread: ChatThreadSignals }) {
+  const loadable = useLastLoadable(thread.artifacts$);
+  const setArtifactsRealtimeRef = useSet(thread.setArtifactsRealtimeRef$);
+  const fullscreen = useGet(artifactFullscreen$);
+  const searchOpen = useGet(artifactInboxSearchOpen$);
+  const toggleFullscreen = useSet(toggleArtifactFullscreen$);
+  const toggleSearch = useSet(toggleArtifactInboxSearch$);
+  const close = useSet(closeArtifact$);
+  const count =
+    loadable.state === "hasData"
+      ? flattenArtifactRuns(loadable.data).length
+      : null;
+
+  const inbox = (
+    <div
+      className={cn(
+        fullscreen
+          ? "fixed inset-0 z-[100] flex flex-col bg-background"
+          : "flex h-full w-full min-h-0 flex-col border-l border-border/60 bg-background",
+        "animate-in fade-in slide-in-from-right-2 duration-200",
+      )}
+      data-testid="artifact-inbox"
+    >
+      <ChatArtifactInboxHeader
+        count={count}
+        fullscreen={fullscreen}
+        searchOpen={searchOpen}
+        onToggleSearch={toggleSearch}
+        onToggleFullscreen={toggleFullscreen}
+        onClose={close}
+      />
+      <div
+        ref={setArtifactsRealtimeRef}
+        className="min-h-0 flex-1 overflow-y-auto px-4 py-4"
+      >
+        <ChatArtifactInboxBody thread={thread} />
+      </div>
+    </div>
+  );
+  return fullscreen && typeof document !== "undefined"
+    ? createPortal(inbox, document.body)
+    : inbox;
+}
+
+function ChatArtifactInboxSlot({
+  artifactRef,
+  leftThread,
+  rightThread,
+}: {
+  artifactRef: ArtifactRef | null;
+  leftThread: ChatThreadSignals | null;
+  rightThread: ChatThreadSignals | null;
+}) {
+  const inboxThreadId = useGet(currentArtifactInboxThreadId$);
+  const backToInbox = useSet(backToArtifactInbox$);
+  const close = useSet(closeArtifact$);
+  const thread =
+    [leftThread, rightThread].find((candidate) => {
+      return candidate?.threadId === inboxThreadId;
+    }) ??
+    leftThread ??
+    rightThread;
+
+  if (artifactRef) {
+    return (
+      <ArtifactSidebar
+        artifactRef={artifactRef}
+        onBack={inboxThreadId ? backToInbox : undefined}
+        onClose={close}
+      />
+    );
+  }
+
+  if (!thread || !inboxThreadId) {
+    return null;
+  }
+
+  return <ChatArtifactInboxList thread={thread} />;
+}
+
 function ChatArtifactsDrawerContent({ thread }: { thread: ChatThreadSignals }) {
   const loadable = useLastLoadable(thread.artifacts$);
   const connectorList = useLastResolved(connectors$);
@@ -2449,7 +2908,9 @@ export function ZeroChatThreadPage() {
   const setKeyboardScrollRoot = useSet(setChatKeyboardScrollRoot$);
   const sidebarEnabled = useGet(chatArtifactSidebarEnabled$);
   const artifactRef = useGet(currentArtifactRef$);
-  const artifactSidebarOpen = sidebarEnabled && artifactRef !== null;
+  const artifactInboxThreadId = useGet(currentArtifactInboxThreadId$);
+  const artifactPanelOpen =
+    sidebarEnabled && (artifactRef !== null || artifactInboxThreadId !== null);
   // Lifted from ChatThread so the keyboard handler's sidebarChatThreads$
   // snapshot survives keyed ChatThread remounts during thread navigation.
   // Otherwise a second mod+shift+arrow press lands on a freshly mounted
@@ -2494,16 +2955,20 @@ export function ZeroChatThreadPage() {
       <div className="flex flex-1 min-h-0 bg-transparent">
         <div
           className={
-            artifactSidebarOpen
+            artifactPanelOpen
               ? "hidden xl:flex flex-1 basis-0 min-w-0 min-h-0"
               : "flex flex-1 min-w-0 min-h-0"
           }
         >
           {threadArea}
         </div>
-        {artifactSidebarOpen && (
+        {artifactPanelOpen && (
           <div className="flex flex-1 basis-0 min-w-0 min-h-0">
-            <ArtifactSidebarSlot />
+            <ChatArtifactInboxSlot
+              artifactRef={artifactRef}
+              leftThread={leftThread}
+              rightThread={rightThread}
+            />
           </div>
         )}
       </div>

--- a/turbo/apps/platform/src/views/zero-page/zero-chat-thread-page.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-chat-thread-page.tsx
@@ -1900,6 +1900,9 @@ type ChatImagePreviewLinkProps = {
   url: string;
 };
 
+const CHAT_INLINE_MEDIA_PREVIEW_CLASS =
+  "inline-flex aspect-[16/10] w-[min(100%,400px)] items-center justify-center rounded-lg border border-foreground/10 shadow-sm transition-all duration-200 hover:scale-[1.015] hover:border-foreground/20 hover:shadow-lg hover:shadow-black/10 dark:hover:shadow-black/30";
+
 function ChatImagePreviewLink({
   alt,
   ariaLabel,
@@ -4213,12 +4216,12 @@ function BodyContentBlocks({
               key={block.id}
               alt={block.preview.filename}
               ariaLabel={`Preview ${block.preview.filename}`}
-              imageClassName="max-h-48 max-w-full object-contain"
-              linkClassName="w-fit max-w-full rounded-lg border border-foreground/10"
+              imageClassName="h-full w-full object-contain"
+              linkClassName={`${CHAT_INLINE_MEDIA_PREVIEW_CLASS} bg-muted/30`}
               onPreview={() => {
                 openLightbox(block.preview.url);
               }}
-              placeholderClassName="h-48 w-64 max-w-full"
+              placeholderClassName="h-full w-full"
               url={block.preview.url}
             />
           );
@@ -4229,7 +4232,7 @@ function BodyContentBlocks({
             <ChatVideoPreviewButton
               key={block.id}
               ariaLabel={`Preview ${block.preview.filename}`}
-              buttonClassName="w-fit max-w-full rounded-lg border border-foreground/10"
+              buttonClassName={CHAT_INLINE_MEDIA_PREVIEW_CLASS}
               filename={block.preview.filename}
               onPreview={() => {
                 openVideoLightbox({
@@ -4237,7 +4240,7 @@ function BodyContentBlocks({
                   filename: block.preview.filename,
                 });
               }}
-              posterClassName="h-48 w-64 max-w-full"
+              posterClassName="h-full w-full"
               url={block.preview.url}
               videoClassName="h-full w-full object-contain"
             />
@@ -5323,12 +5326,12 @@ function UserMessageAttachments({
               key={a.url}
               alt={a.filename}
               ariaLabel={`Preview ${a.filename}`}
-              imageClassName="h-9 max-w-[72px] object-cover"
-              linkClassName="rounded-lg border border-foreground/10 transition-colors hover:border-foreground/25"
+              imageClassName="h-full w-full object-contain"
+              linkClassName={`${CHAT_INLINE_MEDIA_PREVIEW_CLASS} bg-muted/30`}
               onPreview={() => {
                 onImageClick(a.url);
               }}
-              placeholderClassName="h-9 w-[72px]"
+              placeholderClassName="h-full w-full"
               url={a.url}
             />
           );
@@ -5338,7 +5341,7 @@ function UserMessageAttachments({
             <ChatVideoPreviewButton
               key={a.url}
               ariaLabel={`Preview ${a.filename}`}
-              buttonClassName="rounded-lg border border-foreground/10 transition-colors hover:border-foreground/25"
+              buttonClassName={CHAT_INLINE_MEDIA_PREVIEW_CLASS}
               filename={a.filename}
               onPreview={() => {
                 openVideoLightbox({
@@ -5346,9 +5349,9 @@ function UserMessageAttachments({
                   filename: a.filename,
                 });
               }}
-              posterClassName="h-9 w-[72px]"
+              posterClassName="h-full w-full"
               url={a.url}
-              videoClassName="h-full w-full object-cover"
+              videoClassName="h-full w-full object-contain"
             />
           );
         }

--- a/turbo/apps/platform/src/views/zero-page/zero-chat-thread-page.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-chat-thread-page.tsx
@@ -74,6 +74,7 @@ import type {
 import { PRESENTATION_TEMPLATE_ITEMS } from "@vm0/core";
 import type { UserPermissionGrantResponse } from "@vm0/api-contracts/contracts/zero-user-permission-grants";
 import { isSupportedRunModel } from "@vm0/api-contracts/contracts/model-providers";
+import { IN_VITEST } from "../../env.ts";
 import emptyChatImg from "./assets/empty-chat.webp";
 import emptyArtifactImg from "./assets/empty-artifact.webp";
 import { FeatureSwitchKey } from "@vm0/connectors/feature-switch-key";
@@ -110,6 +111,7 @@ import {
   FileAttachmentChip,
   getAttachmentRawUrl,
   parseCsvRows,
+  PreviewableAudioAttachmentChip,
   PreviewableFileAttachmentChip,
   publicAttachmentUrl,
   TextPreviewLoader,
@@ -156,6 +158,7 @@ import {
   currentArtifactRef$,
   openArtifactFromInbox$,
   openArtifactInbox$,
+  openAudioLightboxOrArtifact$ as openAttachmentAudioLightbox$,
   setArtifactInboxQuery$,
   setArtifactInboxSection$,
   openDocumentLightboxOrArtifact$ as openAttachmentDocumentLightbox$,
@@ -1326,14 +1329,54 @@ function ArtifactFileIcon({
 }
 
 function ArtifactPreviewBadge({ file }: { file: ChatThreadArtifactFile }) {
-  if (getArtifactPreviewKind(file) === "image") {
+  const previewKind = getArtifactPreviewKind(file);
+  const publicUrl = publicAttachmentUrl(file.url);
+
+  if (previewKind === "image") {
     return (
       <img
-        src={file.url}
+        src={publicUrl}
         alt=""
         aria-hidden="true"
         className="h-full w-full object-cover"
       />
+    );
+  }
+
+  if (previewKind === "video") {
+    return (
+      <video
+        src={videoPosterFrameUrl(publicUrl)}
+        preload="metadata"
+        muted
+        playsInline
+        aria-hidden="true"
+        className="h-full w-full object-cover"
+        data-testid="artifact-video-preview-badge"
+      />
+    );
+  }
+
+  if (getArtifactDocumentPreviewKind(file) === "html") {
+    return (
+      <span
+        className="relative block h-full w-full overflow-hidden bg-background"
+        aria-hidden="true"
+        data-testid="artifact-html-preview-badge"
+      >
+        <iframe
+          src={IN_VITEST ? undefined : publicUrl}
+          srcDoc={
+            IN_VITEST ? "<!doctype html><html><body></body></html>" : undefined
+          }
+          title={`${file.filename} artifact thumbnail`}
+          sandbox="allow-scripts"
+          tabIndex={-1}
+          loading="lazy"
+          scrolling="no"
+          className="pointer-events-none absolute left-0 top-0 h-[400%] w-[400%] origin-top-left scale-[0.25] border-0 bg-background"
+        />
+      </span>
     );
   }
 
@@ -2053,6 +2096,38 @@ function ChatVideoPreviewButton({
   );
 }
 
+function ArtifactAudioPreviewButton({
+  file,
+  onOpen,
+}: {
+  file: ChatThreadArtifactFile;
+  onOpen: () => void;
+}) {
+  return (
+    <button
+      type="button"
+      onClick={(event) => {
+        event.currentTarget.blur();
+        onOpen();
+      }}
+      className="group/audio-preview flex h-full w-full flex-col items-center justify-center gap-4 bg-gradient-to-br from-slate-900 via-stone-900 to-cyan-950 px-8 text-white"
+      aria-label={`Preview ${file.filename}`}
+      title={file.filename}
+      data-testid="artifact-audio-preview-button"
+    >
+      <span className="flex h-16 w-16 items-center justify-center rounded-2xl border border-white/15 bg-white/10 shadow-sm transition-transform group-hover/audio-preview:scale-105">
+        <ArtifactFileIcon file={file} size="md" />
+      </span>
+      <span className="flex h-11 w-11 items-center justify-center rounded-full bg-black/55 text-white shadow-lg transition-transform group-hover/audio-preview:scale-105">
+        <IconPlayerPlay size={20} stroke={1.8} />
+      </span>
+      <span className="max-w-[260px] truncate text-sm font-medium">
+        {file.filename}
+      </span>
+    </button>
+  );
+}
+
 function ArtifactPreviewFrame({
   agentId,
   item,
@@ -2067,6 +2142,7 @@ function ArtifactPreviewFrame({
   const openImageLightbox = useSet(openAttachmentImageLightbox$);
   const openDocumentLightbox = useSet(openAttachmentDocumentLightbox$);
   const openVideoLightbox = useSet(openAttachmentVideoLightbox$);
+  const openAudioLightbox = useSet(openAttachmentAudioLightbox$);
   const { file } = item;
   const previewKind = getArtifactPreviewKind(file);
   const artifact = artifactLightboxMetadataFromItem({
@@ -2118,15 +2194,16 @@ function ArtifactPreviewFrame({
 
   if (previewKind === "audio") {
     return (
-      <div className="flex h-full w-full items-center justify-center bg-muted/40 px-8">
-        <audio
-          src={file.url}
-          controls
-          preload="metadata"
-          className="w-full max-w-[480px]"
-          aria-label={`Audio preview for ${file.filename}`}
-        />
-      </div>
+      <ArtifactAudioPreviewButton
+        file={file}
+        onOpen={() => {
+          openAudioLightbox({
+            url: file.url,
+            filename: file.filename,
+            artifact,
+          });
+        }}
+      />
     );
   }
 
@@ -2500,7 +2577,6 @@ function ArtifactInboxRow({
   onOpen: () => void;
 }) {
   const { file } = item;
-  const live = getArtifactDocumentPreviewKind(file) === "html";
 
   return (
     <button
@@ -2527,11 +2603,6 @@ function ArtifactInboxRow({
           <span>{formatArtifactTime(file.createdAt)}</span>
         </span>
       </span>
-      {live && (
-        <span className="shrink-0 rounded-full bg-emerald-500/10 px-2 py-0.5 text-xs font-medium text-emerald-700 dark:text-emerald-400">
-          Live
-        </span>
-      )}
       <IconChevronRight
         size={16}
         className="shrink-0 text-muted-foreground transition-transform group-hover:translate-x-0.5 group-hover:text-foreground"
@@ -5369,6 +5440,16 @@ function UserMessageAttachments({
               filename={a.filename}
               url={a.url}
               kind={a.kind}
+            />
+          );
+        }
+        if (a.kind === "audio") {
+          return (
+            <PreviewableAudioAttachmentChip
+              key={a.url}
+              filename={a.filename}
+              url={a.url}
+              contentType={a.contentType}
             />
           );
         }

--- a/turbo/apps/platform/src/views/zero-page/zero-zoomable-image-canvas.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-zoomable-image-canvas.tsx
@@ -22,10 +22,6 @@ const IMAGE_ZOOM_ANIMATION_TYPE = "linear";
 type SetZoomHandler = (key: string, zoom: number) => void;
 type ResetZoomHandler = (key: string) => void;
 
-type TransformState = {
-  scale: number;
-};
-
 export type ZoomableImageControls = {
   canZoomIn: boolean;
   canZoomOut: boolean;
@@ -191,15 +187,12 @@ export function ZoomableArtifactImageCanvas({
   const resetDisplayZoom = useSet(resetZoomableImageCanvasZoom$);
   const displayZoom = zoomByKey[zoomKey] ?? 1;
 
-  const handleTransform = (
-    ref: ReactZoomPanPinchRef,
-    state: TransformState,
-  ) => {
+  const syncDisplayZoom = (ref: ReactZoomPanPinchRef) => {
     if (!hasMeasurableCanvas(ref)) {
       return;
     }
 
-    setDisplayZoom(zoomKey, state.scale);
+    setDisplayZoom(zoomKey, ref.state.scale);
   };
 
   return (
@@ -212,7 +205,7 @@ export function ZoomableArtifactImageCanvas({
       centerZoomedOut
       smooth
       wheel={{ step: 0.008, wheelDisabled: true }}
-      pinch={{ allowPanning: false, step: 2.5 }}
+      pinch={{ allowPanning: false, step: 5 }}
       doubleClick={{
         mode: "toggle",
         step: IMAGE_ZOOM_STEP,
@@ -224,7 +217,15 @@ export function ZoomableArtifactImageCanvas({
         animationType: IMAGE_ZOOM_ANIMATION_TYPE,
         size: 0.2,
       }}
-      onTransform={handleTransform}
+      onPinchStop={(ref) => {
+        syncDisplayZoom(ref);
+      }}
+      onWheelStop={(ref) => {
+        syncDisplayZoom(ref);
+      }}
+      onZoomStop={(ref) => {
+        syncDisplayZoom(ref);
+      }}
       onInit={() => {
         resetDisplayZoom(zoomKey);
       }}

--- a/turbo/apps/platform/src/views/zero-page/zero-zoomable-image-canvas.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-zoomable-image-canvas.tsx
@@ -36,6 +36,7 @@ type ZoomableArtifactImageCanvasProps = {
   canvasTestId?: string;
   children?: (controls: ZoomableImageControls) => ReactNode;
   className?: string;
+  contentClassName?: string;
   imageClassName?: string;
   imageRef?: Ref<HTMLImageElement>;
   imageTestId: string;
@@ -173,6 +174,7 @@ export function ZoomableArtifactImageCanvas({
   canvasTestId = "zoomable-image-canvas",
   children,
   className,
+  contentClassName,
   imageClassName,
   imageRef,
   imageTestId,
@@ -255,9 +257,11 @@ export function ZoomableArtifactImageCanvas({
             />
             {children?.(controls)}
             <TransformComponent
+              contentClass={contentClassName}
               wrapperStyle={{ height: "100%", width: "100%" }}
               contentStyle={{
                 alignItems: "center",
+                boxSizing: "border-box",
                 display: "flex",
                 height: "100%",
                 justifyContent: "center",

--- a/turbo/apps/platform/src/views/zero-page/zero-zoomable-image-canvas.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-zoomable-image-canvas.tsx
@@ -211,8 +211,8 @@ export function ZoomableArtifactImageCanvas({
       limitToBounds
       centerZoomedOut
       smooth
-      wheel={{ step: 0.008 }}
-      pinch={{ allowPanning: true, step: 2.5 }}
+      wheel={{ step: 0.008, wheelDisabled: true }}
+      pinch={{ allowPanning: false, step: 2.5 }}
       doubleClick={{
         mode: "toggle",
         step: IMAGE_ZOOM_STEP,

--- a/turbo/apps/platform/src/views/zero-page/zero-zoomable-image-canvas.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-zoomable-image-canvas.tsx
@@ -19,6 +19,19 @@ const IMAGE_ZOOM_STEP = 0.15;
 const IMAGE_ZOOM_ANIMATION_MS = 180;
 const IMAGE_ZOOM_ANIMATION_TYPE = "linear";
 
+type ZoomableArtifactImageSurface =
+  | "attachment-lightbox"
+  | "artifact-dialog"
+  | "artifact-sidebar";
+
+export function zoomableArtifactImageKey(
+  surface: ZoomableArtifactImageSurface,
+  url: string,
+  mode = "default",
+) {
+  return `${surface}:${mode}:${url}`;
+}
+
 type SetZoomHandler = (key: string, zoom: number) => void;
 type ResetZoomHandler = (key: string) => void;
 

--- a/turbo/apps/platform/src/views/zero-page/zero-zoomable-image-canvas.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-zoomable-image-canvas.tsx
@@ -205,6 +205,8 @@ export function ZoomableArtifactImageCanvas({
       centerZoomedOut
       smooth
       wheel={{ step: 0.008, wheelDisabled: true }}
+      trackPadPanning={{ disabled: false }}
+      panning={{ allowLeftClickPan: true }}
       pinch={{ allowPanning: false, step: 5 }}
       doubleClick={{
         mode: "toggle",

--- a/turbo/apps/platform/src/views/zero-page/zero-zoomable-image-canvas.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-zoomable-image-canvas.tsx
@@ -1,0 +1,283 @@
+import type { ReactNode, Ref, RefCallback } from "react";
+import { useGet, useSet } from "ccstate-react";
+import {
+  TransformComponent,
+  TransformWrapper,
+  type ReactZoomPanPinchContentRef,
+  type ReactZoomPanPinchRef,
+} from "react-zoom-pan-pinch";
+import { cn } from "@vm0/ui";
+import {
+  IMAGE_LIGHTBOX_MAX_ZOOM,
+  IMAGE_LIGHTBOX_MIN_ZOOM,
+  resetZoomableImageCanvasZoom$,
+  setZoomableImageCanvasZoom$,
+  zoomableImageCanvasZoomByKey$,
+} from "../../signals/view-component-state.ts";
+
+const IMAGE_ZOOM_STEP = 0.15;
+const IMAGE_ZOOM_ANIMATION_MS = 180;
+const IMAGE_ZOOM_ANIMATION_TYPE = "linear";
+
+type SetZoomHandler = (key: string, zoom: number) => void;
+type ResetZoomHandler = (key: string) => void;
+
+type TransformState = {
+  scale: number;
+};
+
+export type ZoomableImageControls = {
+  canZoomIn: boolean;
+  canZoomOut: boolean;
+  resetZoom: () => void;
+  zoom: number;
+  zoomIn: () => void;
+  zoomOut: () => void;
+};
+
+type ZoomableArtifactImageCanvasProps = {
+  alt: string;
+  canvasTestId?: string;
+  children?: (controls: ZoomableImageControls) => ReactNode;
+  className?: string;
+  imageClassName?: string;
+  imageRef?: Ref<HTMLImageElement>;
+  imageTestId: string;
+  keyboardShortcuts?: boolean;
+  onError?: () => void;
+  onLoad?: () => void;
+  src: string;
+  zoomKey?: string;
+};
+
+function keyboardShortcutRef({
+  resetZoom,
+  zoomIn,
+  zoomOut,
+}: Pick<
+  ZoomableImageControls,
+  "resetZoom" | "zoomIn" | "zoomOut"
+>): RefCallback<HTMLSpanElement> {
+  let detachKeydown: (() => void) | null = null;
+
+  return (element) => {
+    detachKeydown?.();
+    detachKeydown = null;
+
+    if (!element) {
+      return;
+    }
+
+    const handleKeyDown = (event: KeyboardEvent) => {
+      if (!event.metaKey && !event.ctrlKey) {
+        return;
+      }
+
+      if (event.key === "+" || event.key === "=") {
+        event.preventDefault();
+        event.stopPropagation();
+        zoomIn();
+        return;
+      }
+
+      if (event.key === "-" || event.key === "_") {
+        event.preventDefault();
+        event.stopPropagation();
+        zoomOut();
+        return;
+      }
+
+      if (event.key === "0") {
+        event.preventDefault();
+        event.stopPropagation();
+        resetZoom();
+      }
+    };
+
+    document.addEventListener("keydown", handleKeyDown);
+    detachKeydown = () => {
+      document.removeEventListener("keydown", handleKeyDown);
+    };
+  };
+}
+
+function ZoomableImageKeyboardShortcuts({
+  controls,
+  enabled,
+}: {
+  controls: ZoomableImageControls;
+  enabled: boolean;
+}) {
+  if (!enabled) {
+    return null;
+  }
+
+  return <span ref={keyboardShortcutRef(controls)} hidden />;
+}
+
+function controlsFromTransform({
+  displayZoom,
+  resetDisplayZoom,
+  resetTransform,
+  setDisplayZoom,
+  zoomIn,
+  zoomKey,
+  zoomOut,
+}: Pick<
+  ReactZoomPanPinchContentRef,
+  "resetTransform" | "zoomIn" | "zoomOut"
+> & {
+  displayZoom: number;
+  resetDisplayZoom: ResetZoomHandler;
+  setDisplayZoom: SetZoomHandler;
+  zoomKey: string;
+}): ZoomableImageControls {
+  const zoom = displayZoom;
+
+  return {
+    canZoomIn: zoom < IMAGE_LIGHTBOX_MAX_ZOOM - 0.001,
+    canZoomOut: zoom > IMAGE_LIGHTBOX_MIN_ZOOM + 0.001,
+    resetZoom: () => {
+      resetDisplayZoom(zoomKey);
+      resetTransform(IMAGE_ZOOM_ANIMATION_MS, IMAGE_ZOOM_ANIMATION_TYPE);
+    },
+    zoom,
+    zoomIn: () => {
+      setDisplayZoom(zoomKey, zoom + IMAGE_ZOOM_STEP);
+      zoomIn(
+        IMAGE_ZOOM_STEP,
+        IMAGE_ZOOM_ANIMATION_MS,
+        IMAGE_ZOOM_ANIMATION_TYPE,
+      );
+    },
+    zoomOut: () => {
+      setDisplayZoom(zoomKey, zoom - IMAGE_ZOOM_STEP);
+      zoomOut(
+        IMAGE_ZOOM_STEP,
+        IMAGE_ZOOM_ANIMATION_MS,
+        IMAGE_ZOOM_ANIMATION_TYPE,
+      );
+    },
+  };
+}
+
+function hasMeasurableCanvas(ref: ReactZoomPanPinchRef) {
+  const { contentComponent, wrapperComponent } = ref.instance;
+
+  return Boolean(
+    wrapperComponent?.offsetWidth ||
+    wrapperComponent?.offsetHeight ||
+    contentComponent?.offsetWidth ||
+    contentComponent?.offsetHeight,
+  );
+}
+
+export function ZoomableArtifactImageCanvas({
+  alt,
+  canvasTestId = "zoomable-image-canvas",
+  children,
+  className,
+  imageClassName,
+  imageRef,
+  imageTestId,
+  keyboardShortcuts = false,
+  onError,
+  onLoad,
+  src,
+  zoomKey = src,
+}: ZoomableArtifactImageCanvasProps) {
+  const zoomByKey = useGet(zoomableImageCanvasZoomByKey$);
+  const setDisplayZoom = useSet(setZoomableImageCanvasZoom$);
+  const resetDisplayZoom = useSet(resetZoomableImageCanvasZoom$);
+  const displayZoom = zoomByKey[zoomKey] ?? 1;
+
+  const handleTransform = (
+    ref: ReactZoomPanPinchRef,
+    state: TransformState,
+  ) => {
+    if (!hasMeasurableCanvas(ref)) {
+      return;
+    }
+
+    setDisplayZoom(zoomKey, state.scale);
+  };
+
+  return (
+    <TransformWrapper
+      key={zoomKey}
+      initialScale={1}
+      minScale={IMAGE_LIGHTBOX_MIN_ZOOM}
+      maxScale={IMAGE_LIGHTBOX_MAX_ZOOM}
+      limitToBounds
+      centerZoomedOut
+      smooth
+      wheel={{ step: 0.008 }}
+      pinch={{ allowPanning: true, step: 2.5 }}
+      doubleClick={{
+        mode: "toggle",
+        step: IMAGE_ZOOM_STEP,
+        animationTime: IMAGE_ZOOM_ANIMATION_MS,
+        animationType: IMAGE_ZOOM_ANIMATION_TYPE,
+      }}
+      zoomAnimation={{
+        animationTime: IMAGE_ZOOM_ANIMATION_MS,
+        animationType: IMAGE_ZOOM_ANIMATION_TYPE,
+        size: 0.2,
+      }}
+      onTransform={handleTransform}
+      onInit={() => {
+        resetDisplayZoom(zoomKey);
+      }}
+    >
+      {(transform) => {
+        const controls = controlsFromTransform({
+          ...transform,
+          displayZoom,
+          resetDisplayZoom,
+          setDisplayZoom,
+          zoomKey,
+        });
+
+        return (
+          <div
+            className={cn(
+              "relative flex h-full min-h-0 w-full flex-1 items-center justify-center overflow-hidden bg-muted/30 touch-none",
+              className,
+            )}
+            data-testid={canvasTestId}
+          >
+            <ZoomableImageKeyboardShortcuts
+              controls={controls}
+              enabled={keyboardShortcuts}
+            />
+            {children?.(controls)}
+            <TransformComponent
+              wrapperStyle={{ height: "100%", width: "100%" }}
+              contentStyle={{
+                alignItems: "center",
+                display: "flex",
+                height: "100%",
+                justifyContent: "center",
+                width: "100%",
+              }}
+            >
+              <img
+                ref={imageRef}
+                src={src}
+                alt={alt}
+                draggable={false}
+                data-testid={imageTestId}
+                onLoad={onLoad}
+                onError={onError}
+                className={cn(
+                  "block max-h-full max-w-full select-none object-contain",
+                  imageClassName,
+                )}
+              />
+            </TransformComponent>
+          </div>
+        );
+      }}
+    </TransformWrapper>
+  );
+}

--- a/turbo/packages/core/src/__tests__/feature-switch.test.ts
+++ b/turbo/packages/core/src/__tests__/feature-switch.test.ts
@@ -9,6 +9,9 @@ import {
 describe("isFeatureEnabled", () => {
   it("should return true for globally enabled switch", () => {
     expect(isFeatureEnabled(FeatureSwitchKey.Dummy, {})).toBe(true);
+    expect(isFeatureEnabled(FeatureSwitchKey.ChatArtifactSidebar, {})).toBe(
+      true,
+    );
   });
 
   it("should return true for globally enabled switch even with context", () => {
@@ -74,6 +77,7 @@ describe("getAllFeatureStates", () => {
     const states = getAllFeatureStates();
     // Globally enabled switches should be true
     expect(states[FeatureSwitchKey.Dummy]).toBe(true);
+    expect(states[FeatureSwitchKey.ChatArtifactSidebar]).toBe(true);
   });
 
   it("should enable switches when orgId matches enabledOrgIdHashes", () => {

--- a/turbo/packages/core/src/feature-switch.ts
+++ b/turbo/packages/core/src/feature-switch.ts
@@ -278,9 +278,8 @@ const FEATURE_SWITCHES: Record<FeatureSwitchKey, FeatureSwitch> = {
   [FeatureSwitchKey.ChatArtifactSidebar]: {
     maintainer: "ethan@vm0.ai",
     description:
-      "Replace the inline attachment text editor and modal lightbox with a single page-level artifact sidebar (50/50 with the chat thread area, URL-routed via ?artifact=, fullscreen-capable). When on, inline text/markdown attachments render as anchor chips, all preview chips route to the sidebar, and the artifacts drawer is hidden.",
-    enabled: false,
-    enabledOrgIdHashes: STAFF_ORG_ID_HASHES,
+      "Replace the inline attachment text editor and modal lightbox with a single page-level artifact sidebar (50/50 with the chat thread area, URL-routed via ?artifact=, fullscreen-capable). When on, inline text/markdown attachments render as thumbnail anchors, all preview chips route to the sidebar, and the artifacts drawer is hidden.",
+    enabled: true,
   },
   [FeatureSwitchKey.ChatGithubPrTracking]: {
     maintainer: "linghan@vm0.ai",

--- a/turbo/packages/ui/src/components/ui/__tests__/dialog.test.tsx
+++ b/turbo/packages/ui/src/components/ui/__tests__/dialog.test.tsx
@@ -1,0 +1,22 @@
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+import { Dialog, DialogContent, DialogTitle } from "../dialog";
+
+describe("Dialog", () => {
+  it("applies the default dialog animation classes", () => {
+    render(
+      <Dialog open>
+        <DialogContent>
+          <DialogTitle>Default dialog</DialogTitle>
+        </DialogContent>
+      </Dialog>,
+    );
+
+    const overlay = document.querySelector(".zero-dialog-overlay");
+    expect(overlay).toBeInTheDocument();
+    expect(overlay).toHaveClass("zero-dialog-overlay");
+    expect(screen.getByRole("dialog", { name: "Default dialog" })).toHaveClass(
+      "zero-dialog-content",
+    );
+  });
+});

--- a/turbo/packages/ui/src/components/ui/dialog.tsx
+++ b/turbo/packages/ui/src/components/ui/dialog.tsx
@@ -20,7 +20,7 @@ const DialogOverlay = React.forwardRef<
     <DialogPrimitive.Overlay
       ref={ref}
       className={cn(
-        "fixed inset-0 z-50 bg-black/80 dark:bg-background/50 data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0",
+        "zero-dialog-overlay fixed inset-0 z-50 bg-black/80 dark:bg-background/50",
         className,
       )}
       {...props}
@@ -39,7 +39,7 @@ const DialogContent = React.forwardRef<
       <DialogPrimitive.Content
         ref={ref}
         className={cn(
-          "fixed left-[50%] top-[50%] z-50 grid w-full max-w-lg max-h-[90vh] overflow-y-auto dialog-scrollable translate-x-[-50%] translate-y-[-50%] gap-4 border-[0.7px] border-[hsl(var(--gray-400))] bg-card p-6 shadow-lg duration-200 data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[state=closed]:slide-out-to-left-1/2 data-[state=closed]:slide-out-to-top-[48%] data-[state=open]:slide-in-from-left-1/2 data-[state=open]:slide-in-from-top-[48%] rounded-xl",
+          "zero-dialog-content fixed left-[50%] top-[50%] z-50 grid w-full max-w-lg max-h-[90vh] overflow-y-auto dialog-scrollable translate-x-[-50%] translate-y-[-50%] gap-4 border-[0.7px] border-[hsl(var(--gray-400))] bg-card p-6 shadow-lg rounded-xl",
           className,
         )}
         {...props}

--- a/turbo/packages/ui/src/styles/globals.css
+++ b/turbo/packages/ui/src/styles/globals.css
@@ -396,6 +396,31 @@
     background-color: rgba(128, 128, 128, 0.5);
   }
 
+  .zero-dialog-overlay[data-state="open"] {
+    animation: zero-dialog-overlay-in 180ms ease;
+  }
+
+  .zero-dialog-overlay[data-state="closed"] {
+    animation: zero-dialog-overlay-out 180ms ease;
+  }
+
+  .zero-dialog-content[data-state="open"] {
+    animation: zero-dialog-content-in 180ms ease;
+  }
+
+  .zero-dialog-content[data-state="closed"] {
+    animation: zero-dialog-content-out 180ms ease;
+  }
+
+  @media (prefers-reduced-motion: reduce) {
+    .zero-dialog-overlay[data-state="open"],
+    .zero-dialog-overlay[data-state="closed"],
+    .zero-dialog-content[data-state="open"],
+    .zero-dialog-content[data-state="closed"] {
+      animation: none;
+    }
+  }
+
   /* Running indicator — breathing dot for "in progress" state. */
   .running-indicator {
     position: relative;
@@ -421,6 +446,42 @@
     border: 1px solid currentColor;
     transform-origin: center;
     animation: running-indicator-ripple 2400ms ease-out infinite;
+  }
+}
+
+@keyframes zero-dialog-overlay-in {
+  from {
+    opacity: 0;
+  }
+  to {
+    opacity: 1;
+  }
+}
+
+@keyframes zero-dialog-overlay-out {
+  from {
+    opacity: 1;
+  }
+  to {
+    opacity: 0;
+  }
+}
+
+@keyframes zero-dialog-content-in {
+  from {
+    transform: translate(-50%, calc(-50% + 8px));
+  }
+  to {
+    transform: translate(-50%, -50%);
+  }
+}
+
+@keyframes zero-dialog-content-out {
+  from {
+    transform: translate(-50%, -50%);
+  }
+  to {
+    transform: translate(-50%, calc(-50% + 8px));
   }
 }
 

--- a/turbo/packages/ui/src/styles/globals.css
+++ b/turbo/packages/ui/src/styles/globals.css
@@ -412,11 +412,21 @@
     animation: zero-dialog-content-out 180ms ease;
   }
 
+  .zero-dialog-enter-overlay {
+    animation: zero-dialog-overlay-in 180ms ease;
+  }
+
+  .zero-dialog-enter-content {
+    animation: zero-dialog-content-in 180ms ease;
+  }
+
   @media (prefers-reduced-motion: reduce) {
     .zero-dialog-overlay[data-state="open"],
     .zero-dialog-overlay[data-state="closed"],
     .zero-dialog-content[data-state="open"],
-    .zero-dialog-content[data-state="closed"] {
+    .zero-dialog-content[data-state="closed"],
+    .zero-dialog-enter-overlay,
+    .zero-dialog-enter-content {
       animation: none;
     }
   }
@@ -469,19 +479,19 @@
 
 @keyframes zero-dialog-content-in {
   from {
-    transform: translate(-50%, calc(-50% + 8px));
+    transform: translateY(8px);
   }
   to {
-    transform: translate(-50%, -50%);
+    transform: translateY(0);
   }
 }
 
 @keyframes zero-dialog-content-out {
   from {
-    transform: translate(-50%, -50%);
+    transform: translateY(0);
   }
   to {
-    transform: translate(-50%, calc(-50% + 8px));
+    transform: translateY(8px);
   }
 }
 

--- a/turbo/pnpm-lock.yaml
+++ b/turbo/pnpm-lock.yaml
@@ -105,7 +105,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: ^4.1.7
-        version: 4.1.7(@opentelemetry/api@1.9.1)(@types/node@24.3.0)(@vitest/browser-playwright@4.1.7)(@vitest/coverage-v8@4.1.7)(@vitest/ui@4.1.7)(esbuild@0.27.4)(happy-dom@20.9.0)(jiti@2.6.1)(msw@2.13.2(@types/node@24.3.0)(typescript@5.9.3))(terser@5.47.1)(tsx@4.21.0)(yaml@2.8.3)
+        version: 4.1.7(@opentelemetry/api@1.9.1)(@types/node@24.3.0)(@vitest/browser-playwright@4.1.7)(@vitest/coverage-v8@4.1.7)(@vitest/ui@4.1.7)(happy-dom@20.9.0)(msw@2.13.2(@types/node@24.3.0)(typescript@5.9.3))(vite@8.0.10(@types/node@24.3.0)(esbuild@0.27.4)(jiti@2.6.1)(terser@5.47.1)(tsx@4.21.0)(yaml@2.8.3))
 
   apps/api:
     dependencies:
@@ -298,7 +298,7 @@ importers:
         version: 8.0.10(@types/node@24.3.0)(esbuild@0.27.4)(jiti@2.6.1)(terser@5.47.1)(tsx@4.21.0)(yaml@2.8.3)
       vitest:
         specifier: ^4.1.7
-        version: 4.1.7(@opentelemetry/api@1.9.1)(@types/node@24.3.0)(@vitest/browser-playwright@4.1.7)(@vitest/coverage-v8@4.1.7)(@vitest/ui@4.1.7)(esbuild@0.27.4)(happy-dom@20.9.0)(jiti@2.6.1)(msw@2.13.2(@types/node@24.3.0)(typescript@5.9.3))(terser@5.47.1)(tsx@4.21.0)(yaml@2.8.3)
+        version: 4.1.7(@opentelemetry/api@1.9.1)(@types/node@24.3.0)(@vitest/browser-playwright@4.1.7)(@vitest/coverage-v8@4.1.7)(@vitest/ui@4.1.7)(happy-dom@20.9.0)(msw@2.13.2(@types/node@24.3.0)(typescript@5.9.3))(vite@8.0.10(@types/node@24.3.0)(esbuild@0.27.4)(jiti@2.6.1)(terser@5.47.1)(tsx@4.21.0)(yaml@2.8.3))
 
   apps/cli:
     dependencies:
@@ -389,7 +389,7 @@ importers:
         version: 6.24.1
       vitest:
         specifier: ^4.1.7
-        version: 4.1.7(@opentelemetry/api@1.9.1)(@types/node@24.3.0)(@vitest/browser-playwright@4.1.7)(@vitest/coverage-v8@4.1.7)(@vitest/ui@4.1.7)(esbuild@0.27.4)(happy-dom@20.9.0)(jiti@2.6.1)(msw@2.13.2(@types/node@24.3.0)(typescript@5.9.3))(terser@5.47.1)(tsx@4.21.0)(yaml@2.8.3)
+        version: 4.1.7(@opentelemetry/api@1.9.1)(@types/node@24.3.0)(@vitest/browser-playwright@4.1.7)(@vitest/coverage-v8@4.1.7)(@vitest/ui@4.1.7)(happy-dom@20.9.0)(msw@2.13.2(@types/node@24.3.0)(typescript@5.9.3))(vite@8.0.10(@types/node@24.3.0)(esbuild@0.27.4)(jiti@2.6.1)(terser@5.47.1)(tsx@4.21.0)(yaml@2.8.3))
       yaml:
         specifier: '>=2.8.3'
         version: 2.8.3
@@ -453,7 +453,7 @@ importers:
         version: 8.0.10(@types/node@24.3.0)(esbuild@0.27.4)(jiti@2.6.1)(terser@5.47.1)(tsx@4.21.0)(yaml@2.8.3)
       vitest:
         specifier: ^4.1.7
-        version: 4.1.7(@opentelemetry/api@1.9.1)(@types/node@24.3.0)(@vitest/browser-playwright@4.1.7)(@vitest/coverage-v8@4.1.7)(@vitest/ui@4.1.7)(esbuild@0.27.4)(happy-dom@20.9.0)(jiti@2.6.1)(msw@2.13.2(@types/node@24.3.0)(typescript@5.9.3))(terser@5.47.1)(tsx@4.21.0)(yaml@2.8.3)
+        version: 4.1.7(@opentelemetry/api@1.9.1)(@types/node@24.3.0)(@vitest/browser-playwright@4.1.7)(@vitest/coverage-v8@4.1.7)(@vitest/ui@4.1.7)(happy-dom@20.9.0)(msw@2.13.2(@types/node@24.3.0)(typescript@5.9.3))(vite@8.0.10(@types/node@24.3.0)(esbuild@0.27.4)(jiti@2.6.1)(terser@5.47.1)(tsx@4.21.0)(yaml@2.8.3))
 
   apps/host-worker:
     devDependencies:
@@ -568,6 +568,9 @@ importers:
       react-dom:
         specifier: ^19.2.6
         version: 19.2.6(react@19.2.6)
+      react-zoom-pan-pinch:
+        specifier: ^4.0.3
+        version: 4.0.3(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
       rehype-katex:
         specifier: ^7.0.1
         version: 7.0.1
@@ -658,7 +661,7 @@ importers:
         version: 8.0.10(@types/node@24.3.0)(esbuild@0.27.4)(jiti@2.6.1)(terser@5.47.1)(tsx@4.21.0)(yaml@2.8.3)
       vitest:
         specifier: ^4.1.7
-        version: 4.1.7(@opentelemetry/api@1.9.1)(@types/node@24.3.0)(@vitest/browser-playwright@4.1.7)(@vitest/coverage-v8@4.1.7)(@vitest/ui@4.1.7)(esbuild@0.27.4)(happy-dom@20.9.0)(jiti@2.6.1)(msw@2.13.2(@types/node@24.3.0)(typescript@5.9.3))(terser@5.47.1)(tsx@4.21.0)(yaml@2.8.3)
+        version: 4.1.7(@opentelemetry/api@1.9.1)(@types/node@24.3.0)(@vitest/browser-playwright@4.1.7)(@vitest/coverage-v8@4.1.7)(@vitest/ui@4.1.7)(happy-dom@20.9.0)(msw@2.13.2(@types/node@24.3.0)(typescript@5.9.3))(vite@8.0.10(@types/node@24.3.0)(esbuild@0.27.4)(jiti@2.6.1)(terser@5.47.1)(tsx@4.21.0)(yaml@2.8.3))
 
   apps/web:
     dependencies:
@@ -776,7 +779,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: ^4.1.7
-        version: 4.1.7(@opentelemetry/api@1.9.1)(@types/node@24.3.0)(@vitest/browser-playwright@4.1.7)(@vitest/coverage-v8@4.1.7)(@vitest/ui@4.1.7)(esbuild@0.27.4)(happy-dom@20.9.0)(jiti@2.6.1)(msw@2.13.2(@types/node@24.3.0)(typescript@5.9.3))(terser@5.47.1)(tsx@4.21.0)(yaml@2.8.3)
+        version: 4.1.7(@opentelemetry/api@1.9.1)(@types/node@24.3.0)(@vitest/browser-playwright@4.1.7)(@vitest/coverage-v8@4.1.7)(@vitest/ui@4.1.7)(happy-dom@20.9.0)(msw@2.13.2(@types/node@24.3.0)(typescript@5.9.3))(vite@8.0.10(@types/node@24.3.0)(esbuild@0.27.4)(jiti@2.6.1)(terser@5.47.1)(tsx@4.21.0)(yaml@2.8.3))
 
   packages/api-contracts:
     dependencies:
@@ -816,7 +819,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: ^4.1.7
-        version: 4.1.7(@opentelemetry/api@1.9.1)(@types/node@24.3.0)(@vitest/browser-playwright@4.1.7)(@vitest/coverage-v8@4.1.7)(@vitest/ui@4.1.7)(esbuild@0.27.4)(happy-dom@20.9.0)(jiti@2.6.1)(msw@2.13.2(@types/node@24.3.0)(typescript@5.9.3))(terser@5.47.1)(tsx@4.21.0)(yaml@2.8.3)
+        version: 4.1.7(@opentelemetry/api@1.9.1)(@types/node@24.3.0)(@vitest/browser-playwright@4.1.7)(@vitest/coverage-v8@4.1.7)(@vitest/ui@4.1.7)(happy-dom@20.9.0)(msw@2.13.2(@types/node@24.3.0)(typescript@5.9.3))(vite@8.0.10(@types/node@24.3.0)(esbuild@0.27.4)(jiti@2.6.1)(terser@5.47.1)(tsx@4.21.0)(yaml@2.8.3))
 
   packages/api-services:
     devDependencies:
@@ -840,7 +843,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: ^4.1.7
-        version: 4.1.7(@opentelemetry/api@1.9.1)(@types/node@24.3.0)(@vitest/browser-playwright@4.1.7)(@vitest/coverage-v8@4.1.7)(@vitest/ui@4.1.7)(esbuild@0.27.4)(happy-dom@20.9.0)(jiti@2.6.1)(msw@2.13.2(@types/node@24.3.0)(typescript@5.9.3))(terser@5.47.1)(tsx@4.21.0)(yaml@2.8.3)
+        version: 4.1.7(@opentelemetry/api@1.9.1)(@types/node@24.3.0)(@vitest/browser-playwright@4.1.7)(@vitest/coverage-v8@4.1.7)(@vitest/ui@4.1.7)(happy-dom@20.9.0)(msw@2.13.2(@types/node@24.3.0)(typescript@5.9.3))(vite@8.0.10(@types/node@24.3.0)(esbuild@0.27.4)(jiti@2.6.1)(terser@5.47.1)(tsx@4.21.0)(yaml@2.8.3))
 
   packages/connectors:
     dependencies:
@@ -877,7 +880,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: ^4.1.7
-        version: 4.1.7(@opentelemetry/api@1.9.1)(@types/node@24.3.0)(@vitest/browser-playwright@4.1.7)(@vitest/coverage-v8@4.1.7)(@vitest/ui@4.1.7)(esbuild@0.27.4)(happy-dom@20.9.0)(jiti@2.6.1)(msw@2.13.2(@types/node@24.3.0)(typescript@5.9.3))(terser@5.47.1)(tsx@4.21.0)(yaml@2.8.3)
+        version: 4.1.7(@opentelemetry/api@1.9.1)(@types/node@24.3.0)(@vitest/browser-playwright@4.1.7)(@vitest/coverage-v8@4.1.7)(@vitest/ui@4.1.7)(happy-dom@20.9.0)(msw@2.13.2(@types/node@24.3.0)(typescript@5.9.3))(vite@8.0.10(@types/node@24.3.0)(esbuild@0.27.4)(jiti@2.6.1)(terser@5.47.1)(tsx@4.21.0)(yaml@2.8.3))
 
   packages/core:
     dependencies:
@@ -911,7 +914,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: ^4.1.7
-        version: 4.1.7(@opentelemetry/api@1.9.1)(@types/node@24.3.0)(@vitest/browser-playwright@4.1.7)(@vitest/coverage-v8@4.1.7)(@vitest/ui@4.1.7)(esbuild@0.27.4)(happy-dom@20.9.0)(jiti@2.6.1)(msw@2.13.2(@types/node@24.3.0)(typescript@5.9.3))(terser@5.47.1)(tsx@4.21.0)(yaml@2.8.3)
+        version: 4.1.7(@opentelemetry/api@1.9.1)(@types/node@24.3.0)(@vitest/browser-playwright@4.1.7)(@vitest/coverage-v8@4.1.7)(@vitest/ui@4.1.7)(happy-dom@20.9.0)(msw@2.13.2(@types/node@24.3.0)(typescript@5.9.3))(vite@8.0.10(@types/node@24.3.0)(esbuild@0.27.4)(jiti@2.6.1)(terser@5.47.1)(tsx@4.21.0)(yaml@2.8.3))
 
   packages/db:
     dependencies:
@@ -963,7 +966,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: ^4.1.7
-        version: 4.1.7(@opentelemetry/api@1.9.1)(@types/node@24.3.0)(@vitest/browser-playwright@4.1.7)(@vitest/coverage-v8@4.1.7)(@vitest/ui@4.1.7)(esbuild@0.27.4)(happy-dom@20.9.0)(jiti@2.6.1)(msw@2.13.2(@types/node@24.3.0)(typescript@5.9.3))(terser@5.47.1)(tsx@4.21.0)(yaml@2.8.3)
+        version: 4.1.7(@opentelemetry/api@1.9.1)(@types/node@24.3.0)(@vitest/browser-playwright@4.1.7)(@vitest/coverage-v8@4.1.7)(@vitest/ui@4.1.7)(happy-dom@20.9.0)(msw@2.13.2(@types/node@24.3.0)(typescript@5.9.3))(vite@8.0.10(@types/node@24.3.0)(esbuild@0.27.4)(jiti@2.6.1)(terser@5.47.1)(tsx@4.21.0)(yaml@2.8.3))
 
   packages/eslint-config:
     devDependencies:
@@ -1017,7 +1020,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: ^4.1.7
-        version: 4.1.7(@opentelemetry/api@1.9.1)(@types/node@24.3.0)(@vitest/browser-playwright@4.1.7)(@vitest/coverage-v8@4.1.7)(@vitest/ui@4.1.7)(esbuild@0.27.4)(happy-dom@20.9.0)(jiti@2.6.1)(msw@2.13.2(@types/node@24.3.0)(typescript@5.9.3))(terser@5.47.1)(tsx@4.21.0)(yaml@2.8.3)
+        version: 4.1.7(@opentelemetry/api@1.9.1)(@types/node@24.3.0)(@vitest/browser-playwright@4.1.7)(@vitest/coverage-v8@4.1.7)(@vitest/ui@4.1.7)(happy-dom@20.9.0)(msw@2.13.2(@types/node@24.3.0)(typescript@5.9.3))(vite@8.0.10(@types/node@24.3.0)(esbuild@0.27.4)(jiti@2.6.1)(terser@5.47.1)(tsx@4.21.0)(yaml@2.8.3))
       yaml:
         specifier: '>=2.8.3'
         version: 2.8.3
@@ -1127,7 +1130,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: ^4.1.7
-        version: 4.1.7(@opentelemetry/api@1.9.1)(@types/node@24.3.0)(@vitest/browser-playwright@4.1.7)(@vitest/coverage-v8@4.1.7)(@vitest/ui@4.1.7)(esbuild@0.27.4)(happy-dom@20.9.0)(jiti@2.6.1)(msw@2.13.2(@types/node@24.3.0)(typescript@5.9.3))(terser@5.47.1)(tsx@4.21.0)(yaml@2.8.3)
+        version: 4.1.7(@opentelemetry/api@1.9.1)(@types/node@24.3.0)(@vitest/browser-playwright@4.1.7)(@vitest/coverage-v8@4.1.7)(@vitest/ui@4.1.7)(happy-dom@20.9.0)(msw@2.13.2(@types/node@24.3.0)(typescript@5.9.3))(vite@8.0.10(@types/node@24.3.0)(esbuild@0.27.4)(jiti@2.6.1)(terser@5.47.1)(tsx@4.21.0)(yaml@2.8.3))
 
 packages:
 
@@ -1679,7 +1682,7 @@ packages:
     engines: {node: '>=22.12.0'}
 
   '@electron/node-gyp@https://codeload.github.com/electron/node-gyp/tar.gz/06b29aafb7708acef8b3669835c8a7857ebc92d2':
-    resolution: {gitHosted: true, integrity: sha512-MXgzlTDEEndJB3TBbvd5uFQO/8gaINo1Hfen8vef5rq/VHVPeB63uuv/uO5+8GFsAJ/rauu6XB79S6K4+aXc+w==, tarball: https://codeload.github.com/electron/node-gyp/tar.gz/06b29aafb7708acef8b3669835c8a7857ebc92d2}
+    resolution: {gitHosted: true, tarball: https://codeload.github.com/electron/node-gyp/tar.gz/06b29aafb7708acef8b3669835c8a7857ebc92d2}
     version: 10.2.0-electron.1
     engines: {node: '>=12.13.0'}
     hasBin: true
@@ -8851,6 +8854,13 @@ packages:
       '@types/react':
         optional: true
 
+  react-zoom-pan-pinch@4.0.3:
+    resolution: {integrity: sha512-N2Hi6L78fFmhRra+ORpFSW7WST5x6kxpOPplIvtB0b7b+U2anpo1z1wLgaWRPS2kUSqcraRG+JgBCIlDJnqqAg==}
+    engines: {node: '>=8', npm: '>=5'}
+    peerDependencies:
+      react: '*'
+      react-dom: '*'
+
   react@19.2.6:
     resolution: {integrity: sha512-sfWGGfavi0xr8Pg0sVsyHMAOziVYKgPLNrS7ig+ivMNb3wbCBw3KxtflsGBAwD3gYQlE/AEZsTLgToRrSCjb0Q==}
     engines: {node: '>=0.10.0'}
@@ -9894,6 +9904,7 @@ packages:
       '@vitest/ui': 4.1.7
       happy-dom: '*'
       jsdom: '*'
+      vite: ^6.0.0 || ^7.0.0 || ^8.0.0
     peerDependenciesMeta:
       '@edge-runtime/vm':
         optional: true
@@ -14743,7 +14754,7 @@ snapshots:
       '@vitest/mocker': 4.1.7(msw@2.13.2(@types/node@24.3.0)(typescript@5.9.3))(vite@8.0.10(@types/node@24.3.0)(esbuild@0.27.4)(jiti@2.6.1)(terser@5.47.1)(tsx@4.21.0)(yaml@2.8.3))
       playwright: 1.59.1
       tinyrainbow: 3.1.0
-      vitest: 4.1.7(@opentelemetry/api@1.9.1)(@types/node@24.3.0)(@vitest/browser-playwright@4.1.7)(@vitest/coverage-v8@4.1.7)(@vitest/ui@4.1.7)(esbuild@0.27.4)(happy-dom@20.9.0)(jiti@2.6.1)(msw@2.13.2(@types/node@24.3.0)(typescript@5.9.3))(terser@5.47.1)(tsx@4.21.0)(yaml@2.8.3)
+      vitest: 4.1.7(@opentelemetry/api@1.9.1)(@types/node@24.3.0)(@vitest/browser-playwright@4.1.7)(@vitest/coverage-v8@4.1.7)(@vitest/ui@4.1.7)(happy-dom@20.9.0)(msw@2.13.2(@types/node@24.3.0)(typescript@5.9.3))(vite@8.0.10(@types/node@24.3.0)(esbuild@0.27.4)(jiti@2.6.1)(terser@5.47.1)(tsx@4.21.0)(yaml@2.8.3))
     transitivePeerDependencies:
       - bufferutil
       - msw
@@ -14759,7 +14770,7 @@ snapshots:
       pngjs: 7.0.0
       sirv: 3.0.2
       tinyrainbow: 3.1.0
-      vitest: 4.1.7(@opentelemetry/api@1.9.1)(@types/node@24.3.0)(@vitest/browser-playwright@4.1.7)(@vitest/coverage-v8@4.1.7)(@vitest/ui@4.1.7)(esbuild@0.27.4)(happy-dom@20.9.0)(jiti@2.6.1)(msw@2.13.2(@types/node@24.3.0)(typescript@5.9.3))(terser@5.47.1)(tsx@4.21.0)(yaml@2.8.3)
+      vitest: 4.1.7(@opentelemetry/api@1.9.1)(@types/node@24.3.0)(@vitest/browser-playwright@4.1.7)(@vitest/coverage-v8@4.1.7)(@vitest/ui@4.1.7)(happy-dom@20.9.0)(msw@2.13.2(@types/node@24.3.0)(typescript@5.9.3))(vite@8.0.10(@types/node@24.3.0)(esbuild@0.27.4)(jiti@2.6.1)(terser@5.47.1)(tsx@4.21.0)(yaml@2.8.3))
       ws: 8.20.1
     transitivePeerDependencies:
       - bufferutil
@@ -14779,7 +14790,7 @@ snapshots:
       obug: 2.1.1
       std-env: 4.1.0
       tinyrainbow: 3.1.0
-      vitest: 4.1.7(@opentelemetry/api@1.9.1)(@types/node@24.3.0)(@vitest/browser-playwright@4.1.7)(@vitest/coverage-v8@4.1.7)(@vitest/ui@4.1.7)(esbuild@0.27.4)(happy-dom@20.9.0)(jiti@2.6.1)(msw@2.13.2(@types/node@24.3.0)(typescript@5.9.3))(terser@5.47.1)(tsx@4.21.0)(yaml@2.8.3)
+      vitest: 4.1.7(@opentelemetry/api@1.9.1)(@types/node@24.3.0)(@vitest/browser-playwright@4.1.7)(@vitest/coverage-v8@4.1.7)(@vitest/ui@4.1.7)(happy-dom@20.9.0)(msw@2.13.2(@types/node@24.3.0)(typescript@5.9.3))(vite@8.0.10(@types/node@24.3.0)(esbuild@0.27.4)(jiti@2.6.1)(terser@5.47.1)(tsx@4.21.0)(yaml@2.8.3))
     optionalDependencies:
       '@vitest/browser': 4.1.7(msw@2.13.2(@types/node@24.3.0)(typescript@5.9.3))(vite@8.0.10(@types/node@24.3.0)(esbuild@0.27.4)(jiti@2.6.1)(terser@5.47.1)(tsx@4.21.0)(yaml@2.8.3))(vitest@4.1.7)
 
@@ -14828,7 +14839,7 @@ snapshots:
       sirv: 3.0.2
       tinyglobby: 0.2.16
       tinyrainbow: 3.1.0
-      vitest: 4.1.7(@opentelemetry/api@1.9.1)(@types/node@24.3.0)(@vitest/browser-playwright@4.1.7)(@vitest/coverage-v8@4.1.7)(@vitest/ui@4.1.7)(esbuild@0.27.4)(happy-dom@20.9.0)(jiti@2.6.1)(msw@2.13.2(@types/node@24.3.0)(typescript@5.9.3))(terser@5.47.1)(tsx@4.21.0)(yaml@2.8.3)
+      vitest: 4.1.7(@opentelemetry/api@1.9.1)(@types/node@24.3.0)(@vitest/browser-playwright@4.1.7)(@vitest/coverage-v8@4.1.7)(@vitest/ui@4.1.7)(happy-dom@20.9.0)(msw@2.13.2(@types/node@24.3.0)(typescript@5.9.3))(vite@8.0.10(@types/node@24.3.0)(esbuild@0.27.4)(jiti@2.6.1)(terser@5.47.1)(tsx@4.21.0)(yaml@2.8.3))
 
   '@vitest/utils@4.1.7':
     dependencies:
@@ -18761,6 +18772,11 @@ snapshots:
     optionalDependencies:
       '@types/react': 19.2.14
 
+  react-zoom-pan-pinch@4.0.3(react-dom@19.2.6(react@19.2.6))(react@19.2.6):
+    dependencies:
+      react: 19.2.6
+      react-dom: 19.2.6(react@19.2.6)
+
   react@19.2.6: {}
 
   read-binary-file-arch@1.0.6:
@@ -19978,7 +19994,7 @@ snapshots:
       tsx: 4.21.0
       yaml: 2.8.3
 
-  vitest@4.1.7(@opentelemetry/api@1.9.1)(@types/node@24.3.0)(@vitest/browser-playwright@4.1.7)(@vitest/coverage-v8@4.1.7)(@vitest/ui@4.1.7)(esbuild@0.27.4)(happy-dom@20.9.0)(jiti@2.6.1)(msw@2.13.2(@types/node@24.3.0)(typescript@5.9.3))(terser@5.47.1)(tsx@4.21.0)(yaml@2.8.3):
+  vitest@4.1.7(@opentelemetry/api@1.9.1)(@types/node@24.3.0)(@vitest/browser-playwright@4.1.7)(@vitest/coverage-v8@4.1.7)(@vitest/ui@4.1.7)(happy-dom@20.9.0)(msw@2.13.2(@types/node@24.3.0)(typescript@5.9.3))(vite@8.0.10(@types/node@24.3.0)(esbuild@0.27.4)(jiti@2.6.1)(terser@5.47.1)(tsx@4.21.0)(yaml@2.8.3)):
     dependencies:
       '@vitest/expect': 4.1.7
       '@vitest/mocker': 4.1.7(msw@2.13.2(@types/node@24.3.0)(typescript@5.9.3))(vite@8.0.10(@types/node@24.3.0)(esbuild@0.27.4)(jiti@2.6.1)(terser@5.47.1)(tsx@4.21.0)(yaml@2.8.3))
@@ -20008,18 +20024,7 @@ snapshots:
       '@vitest/ui': 4.1.7(vitest@4.1.7)
       happy-dom: 20.9.0
     transitivePeerDependencies:
-      - '@vitejs/devtools'
-      - esbuild
-      - jiti
-      - less
       - msw
-      - sass
-      - sass-embedded
-      - stylus
-      - sugarss
-      - terser
-      - tsx
-      - yaml
 
   vscode-languageserver-textdocument@1.0.12: {}
 


### PR DESCRIPTION
## Summary
- add URL-routed artifact inbox state for the ChatArtifactSidebar feature path
- open the desktop and mobile artifact buttons into an inbox with sections, search, right-docked preview, fullscreen, and back navigation
- restyle the artifact detail header and image zoom controls to match the new preview flow

## Tests
- pnpm -F @vm0/app exec vitest run src/views/zero-page/__tests__/zero-artifact-sidebar.test.tsx src/views/zero-page/__tests__/zero-chat-thread-page-display.test.tsx
- pnpm -F @vm0/app lint
- pnpm -F @vm0/app check-types

Pre-commit also ran prettier, knip, and turbo check-types.