### PR TITLE
fix: preserve usage buffer flushes on enqueue failure

### DIFF
--- a/crates/runner/mitm-addon/src/usage/buffer.py
+++ b/crates/runner/mitm-addon/src/usage/buffer.py
@@ -105,6 +105,14 @@ class _FlushSummary:
     destinations: set[tuple[str, str]] = field(default_factory=set)
 
 
+@dataclass
+class _PendingFlush:
+    source_event_count: int
+    flush_sequence: int
+    batches: list[_FlushBatch]
+    summaries: list[_FlushSummary]
+
+
 class UsageEventBuffer:
     """Thread-safe process-local usage-event buffer."""
 
@@ -131,6 +139,7 @@ class UsageEventBuffer:
         self._destination_source_event_counts: dict[_DestinationKey, int] = {}
         self._source_event_count = 0
         self._enqueuing_source_event_count = 0
+        self._pending_flushes: list[_PendingFlush] = []
 
     def configure(self, *, flush_interval_seconds: float) -> None:
         """Update runtime buffer settings."""
@@ -146,8 +155,7 @@ class UsageEventBuffer:
         proxy_log_path: str,
     ) -> int:
         """Add source usage events and flush if the buffer exceeds a bound."""
-        batches: list[_FlushBatch] = []
-        enqueuing_count = 0
+        flush_now = False
         timer_to_start: _TimerHandle | None = None
         with self._lock:
             accepted_count = self._add_events_locked(
@@ -156,88 +164,131 @@ class UsageEventBuffer:
             if accepted_count == 0:
                 return 0
             if self._should_flush_locked():
-                enqueuing_count, flush_sequence, batches, summaries = (
-                    self._snapshot_batches_locked()
-                )
-                self._enqueuing_source_event_count += enqueuing_count
+                flush_now = True
             else:
                 timer_to_start = self._schedule_timer_locked()
-                flush_sequence = 0
-                summaries = []
             self._sync_buffered_counter_locked()
 
         if timer_to_start is not None:
             timer_to_start.start()
-        self._enqueue_and_clear_enqueuing(
-            batches, enqueuing_count, "threshold", flush_sequence, summaries
-        )
+        if flush_now:
+            self._flush_usage_events(trigger="threshold")
         return accepted_count
 
     def flush_usage_events(self, *, trigger: UsageFlushTrigger) -> int:
         """Flush all buffered usage events now."""
-        with self._lock:
-            enqueuing_count, flush_sequence, batches, summaries = self._snapshot_batches_locked()
-            self._enqueuing_source_event_count += enqueuing_count
-            self._sync_buffered_counter_locked()
-        self._enqueue_and_clear_enqueuing(
-            batches, enqueuing_count, trigger, flush_sequence, summaries
-        )
-        return len(batches)
+        return self._flush_usage_events(trigger=trigger)
 
     def close(self) -> None:
         """Cancel any pending timer for test cleanup or process shutdown."""
         with self._lock:
-            timer = self._timer
-            self._timer = None
+            timer = self._pop_timer_locked()
             self._buckets = {}
             self._seen_source_keys.clear()
             self._destination_source_event_counts = {}
             self._source_event_count = 0
             self._enqueuing_source_event_count = 0
+            self._pending_flushes = []
             self._sync_buffered_counter_locked()
         if timer is not None:
             timer.cancel()
 
-    def _enqueue_and_clear_enqueuing(
+    def _flush_usage_events(self, *, trigger: UsageFlushTrigger) -> int:
+        flushed_batch_count = 0
+        snapshot_live = True
+        if trigger == "timer":
+            with self._lock:
+                timer = self._pop_timer_locked()
+            if timer is not None:
+                timer.cancel()
+
+        while True:
+            timer_to_start: _TimerHandle | None = None
+            with self._lock:
+                pending_flush, live_snapshot_attempted = self._next_pending_flush_locked(
+                    snapshot_live=snapshot_live
+                )
+                if live_snapshot_attempted:
+                    snapshot_live = False
+                if self._enqueuing_source_event_count and pending_flush is None:
+                    timer_to_start = self._schedule_timer_if_buffered_locked()
+                if pending_flush is None:
+                    self._sync_buffered_counter_locked()
+                else:
+                    self._enqueuing_source_event_count += pending_flush.source_event_count
+                    self._sync_buffered_counter_locked()
+
+            if timer_to_start is not None:
+                timer_to_start.start()
+            if pending_flush is None:
+                return flushed_batch_count
+
+            try:
+                self._enqueue_pending_flush(pending_flush, trigger)
+            except Exception:
+                timer_to_start = None
+                with self._lock:
+                    self._pending_flushes.insert(0, pending_flush)
+                    self._enqueuing_source_event_count = max(
+                        0,
+                        self._enqueuing_source_event_count - pending_flush.source_event_count,
+                    )
+                    if trigger != "shutdown":
+                        timer_to_start = self._schedule_timer_if_buffered_locked()
+                    self._sync_buffered_counter_locked()
+                if timer_to_start is not None:
+                    timer_to_start.start()
+                raise
+
+            flushed_batch_count += len(pending_flush.batches)
+            with self._lock:
+                self._enqueuing_source_event_count = max(
+                    0,
+                    self._enqueuing_source_event_count - pending_flush.source_event_count,
+                )
+                self._sync_buffered_counter_locked()
+
+    def _enqueue_pending_flush(
         self,
-        batches: list[_FlushBatch],
-        enqueuing_count: int,
+        pending_flush: _PendingFlush,
         trigger: UsageFlushTrigger,
-        flush_sequence: int,
-        summaries: list[_FlushSummary],
     ) -> None:
         started_at = time.monotonic()
         try:
-            _log_flush_summaries("started", trigger, flush_sequence, summaries)
-            _apply_dropped_batch_counts(summaries, _enqueue_batches(batches))
+            _log_flush_summaries(
+                "started", trigger, pending_flush.flush_sequence, pending_flush.summaries
+            )
+            _apply_dropped_batch_counts(
+                pending_flush.summaries,
+                _enqueue_batches(pending_flush.batches),
+            )
             _log_flush_summaries(
                 "completed",
                 trigger,
-                flush_sequence,
-                summaries,
+                pending_flush.flush_sequence,
+                pending_flush.summaries,
                 duration_ms=_elapsed_ms(started_at),
             )
         except Exception as exc:
             _log_flush_summaries(
                 "failed",
                 trigger,
-                flush_sequence,
-                summaries,
+                pending_flush.flush_sequence,
+                pending_flush.summaries,
                 duration_ms=_elapsed_ms(started_at),
                 error_type=type(exc).__name__,
             )
             raise
-        finally:
-            if enqueuing_count:
-                with self._lock:
-                    self._enqueuing_source_event_count = max(
-                        0,
-                        self._enqueuing_source_event_count - enqueuing_count,
-                    )
-                    self._sync_buffered_counter_locked()
 
     def _sync_buffered_counter_locked(self) -> None:
-        set_buffered_usage_events(self._source_event_count + self._enqueuing_source_event_count)
+        set_buffered_usage_events(
+            self._source_event_count
+            + self._pending_source_event_count_locked()
+            + self._enqueuing_source_event_count
+        )
+
+    def _pending_source_event_count_locked(self) -> int:
+        return sum(pending_flush.source_event_count for pending_flush in self._pending_flushes)
 
     def _add_events_locked(
         self,
@@ -304,6 +355,16 @@ class UsageEventBuffer:
         self._timer = timer
         return timer
 
+    def _schedule_timer_if_buffered_locked(self) -> _TimerHandle | None:
+        if not self._pending_flushes and not self._source_event_count:
+            return None
+        return self._schedule_timer_locked()
+
+    def _pop_timer_locked(self) -> _TimerHandle | None:
+        timer = self._timer
+        self._timer = None
+        return timer
+
     def _flush_from_timer(self) -> None:
         self.flush_usage_events(trigger="timer")
 
@@ -311,9 +372,22 @@ class UsageEventBuffer:
         jitter = self._flush_interval_seconds * self._jitter_ratio
         return max(0.001, self._flush_interval_seconds + _jitter_rng.uniform(-jitter, jitter))
 
-    def _snapshot_batches_locked(self) -> tuple[int, int, list[_FlushBatch], list[_FlushSummary]]:
-        timer = self._timer
-        self._timer = None
+    def _next_pending_flush_locked(
+        self, *, snapshot_live: bool
+    ) -> tuple[_PendingFlush | None, bool]:
+        if self._enqueuing_source_event_count:
+            return None, False
+        if self._pending_flushes:
+            timer = self._pop_timer_locked()
+            if timer is not None:
+                timer.cancel()
+            return self._pending_flushes.pop(0), False
+        if not snapshot_live:
+            return None, False
+        return self._snapshot_pending_flush_locked(), True
+
+    def _snapshot_pending_flush_locked(self) -> _PendingFlush | None:
+        timer = self._pop_timer_locked()
         if timer is not None:
             timer.cancel()
         source_event_count = self._source_event_count
@@ -321,7 +395,7 @@ class UsageEventBuffer:
         self._destination_source_event_counts = {}
         if not self._buckets:
             self._source_event_count = 0
-            return 0, 0, [], []
+            return None
 
         self._flush_sequence += 1
         flush_sequence = self._flush_sequence
@@ -329,11 +403,11 @@ class UsageEventBuffer:
         self._buckets = {}
         self._source_event_count = 0
         batches = self._build_flush_batches_locked(buckets, flush_sequence)
-        return (
-            source_event_count,
-            flush_sequence,
-            batches,
-            _build_flush_summaries(destination_source_event_counts, batches),
+        return _PendingFlush(
+            source_event_count=source_event_count,
+            flush_sequence=flush_sequence,
+            batches=batches,
+            summaries=_build_flush_summaries(destination_source_event_counts, batches),
         )
 
     def _build_flush_batches_locked(

--- a/crates/runner/mitm-addon/tests/test_connection_hooks.py
+++ b/crates/runner/mitm-addon/tests/test_connection_hooks.py
@@ -12,6 +12,7 @@ from mitmproxy.flow import Error
 import flow_metadata_keys as metadata_keys
 import mitm_addon
 import usage
+import usage.buffer as usage_buffer
 from tests.pending_helpers import assert_pending
 from tests.timestamp_helpers import assert_utc_millisecond_timestamp
 
@@ -250,6 +251,52 @@ class TestRunnerUsageFlushSignal:
         message = log.warn.call_args.args[0]
         assert "RuntimeError" in message
         assert "secret-token" not in message
+
+    def test_runner_flush_failure_snapshot_includes_retryable_buffered_usage(self, tmp_path):
+        pending_path = tmp_path / "usage-pending"
+        request_path = tmp_path / "usage-flush-request"
+        usage.set_pending_path(str(pending_path), usage_state_id="runner-state")
+        request_path.write_text(
+            json.dumps(
+                {
+                    "usageStateId": "runner-state",
+                    "flushRequestId": "request-1",
+                    "requestedAtMs": 1_770_000_000_000,
+                }
+            )
+        )
+        usage.buffer_usage_events(
+            "https://api.test/api/webhooks/agent/usage-event",
+            "token-a",
+            "run-1",
+            [
+                {
+                    "idempotencyKey": "source-1",
+                    "kind": "model",
+                    "provider": "claude-sonnet-4-6",
+                    "category": "tokens.input",
+                    "quantity": 1,
+                }
+            ],
+            str(tmp_path / "proxy.jsonl"),
+        )
+
+        try:
+            with (
+                patch.object(usage_buffer, "_enqueue_webhook", side_effect=OSError("no threads")),
+                patch.object(mitm_addon.ctx, "log", MagicMock(), create=True),
+            ):
+                mitm_addon._flush_usage_for_runner_request()
+
+            assert_pending(
+                pending_path,
+                flows=0,
+                buffered=1,
+                reports=0,
+                flush_request_id="request-1",
+            )
+        finally:
+            usage.set_pending_path("")
 
     def test_signal_during_active_flush_runs_follow_up_flush(self):
         reset_runner_usage_flush_state()

--- a/crates/runner/mitm-addon/tests/test_usage_buffer.py
+++ b/crates/runner/mitm-addon/tests/test_usage_buffer.py
@@ -400,6 +400,49 @@ def test_flush_failure_preserves_retryable_payload_with_same_idempotency_key(tmp
     assert usage.counters._buffered_usage_events == 0
 
 
+def test_partial_flush_failure_retries_accepted_batches_with_same_idempotency_keys(tmp_path):
+    proxy_log_path = str(tmp_path / "proxy.jsonl")
+    with patch.object(usage_buffer, "USAGE_EVENT_BATCH_SIZE", 1):
+        usage.buffer_usage_events(
+            "https://api.test/api/webhooks/agent/usage-event",
+            "token-a",
+            "run-1",
+            [
+                _event(source_key="source-1", category="category-1"),
+                _event(source_key="source-2", category="category-2"),
+            ],
+            proxy_log_path,
+        )
+
+        failed_payloads = []
+
+        def fail_second_batch(url, sandbox_token, payload, path, log_type):
+            failed_payloads.append(payload)
+            if len(failed_payloads) == 2:
+                raise OSError("second batch rejected")
+
+        with (
+            patch.object(
+                usage_buffer, "_enqueue_webhook", side_effect=fail_second_batch
+            ) as enqueue,
+            pytest.raises(OSError, match="second batch rejected"),
+        ):
+            usage.flush_usage_events(trigger="test")
+
+        assert enqueue.call_count == 2
+        assert [len(payload["events"]) for payload in failed_payloads] == [1, 1]
+        assert usage.counters._buffered_usage_events == 2
+
+        with patch.object(usage_buffer, "_enqueue_webhook") as enqueue:
+            assert usage.flush_usage_events(trigger="test") == 2
+
+        retry_payloads = _payloads_from_enqueue_calls(enqueue.call_args_list)
+        assert [
+            event["idempotencyKey"] for payload in retry_payloads for event in payload["events"]
+        ] == [event["idempotencyKey"] for payload in failed_payloads for event in payload["events"]]
+        assert usage.counters._buffered_usage_events == 0
+
+
 def test_pending_flush_retries_before_live_usage_snapshot(tmp_path):
     proxy_log_path = str(tmp_path / "proxy.jsonl")
     usage.buffer_usage_events(

--- a/crates/runner/mitm-addon/tests/test_usage_buffer.py
+++ b/crates/runner/mitm-addon/tests/test_usage_buffer.py
@@ -360,6 +360,90 @@ def test_flush_logs_failure_without_token(tmp_path):
     assert isinstance(entries[1]["duration_ms"], int)
     assert entries[1]["duration_ms"] >= 0
     assert "secret-token" not in json.dumps(entries)
+    assert usage.counters._buffered_usage_events == 1
+
+
+def test_flush_failure_preserves_retryable_payload_with_same_idempotency_key(tmp_path):
+    proxy_log_path = str(tmp_path / "proxy.jsonl")
+    usage.buffer_usage_events(
+        "https://api.test/api/webhooks/agent/usage-event",
+        "token-a",
+        "run-1",
+        [_event(source_key="source-1", quantity=10)],
+        proxy_log_path,
+    )
+
+    failed_payloads = []
+
+    def fail_enqueue(url, sandbox_token, payload, path, log_type):
+        failed_payloads.append(payload)
+        raise OSError("no threads")
+
+    with (
+        patch.object(usage_buffer, "_enqueue_webhook", side_effect=fail_enqueue) as enqueue,
+        pytest.raises(OSError, match="no threads"),
+    ):
+        usage.flush_usage_events(trigger="test")
+
+    enqueue.assert_called_once()
+    assert usage.counters._buffered_usage_events == 1
+    failed_key = failed_payloads[0]["events"][0]["idempotencyKey"]
+
+    with patch.object(usage_buffer, "_enqueue_webhook") as enqueue:
+        assert usage.flush_usage_events(trigger="test") == 1
+
+    enqueue.assert_called_once()
+    retry_payload = enqueue.call_args.args[2]
+    assert retry_payload["runId"] == "run-1"
+    assert retry_payload["events"][0]["quantity"] == 10
+    assert retry_payload["events"][0]["idempotencyKey"] == failed_key
+    assert usage.counters._buffered_usage_events == 0
+
+
+def test_pending_flush_retries_before_live_usage_snapshot(tmp_path):
+    proxy_log_path = str(tmp_path / "proxy.jsonl")
+    usage.buffer_usage_events(
+        "https://api.test/api/webhooks/agent/usage-event",
+        "token-a",
+        "run-a",
+        [_event(source_key="source-a")],
+        proxy_log_path,
+    )
+
+    with (
+        patch.object(usage_buffer, "_enqueue_webhook", side_effect=OSError("no threads")),
+        pytest.raises(OSError, match="no threads"),
+    ):
+        usage.flush_usage_events(trigger="test")
+
+    usage.buffer_usage_events(
+        "https://api.test/api/webhooks/agent/usage-event",
+        "token-a",
+        "run-b",
+        [_event(source_key="source-b")],
+        proxy_log_path,
+    )
+    assert usage.counters._buffered_usage_events == 2
+
+    attempted_runs = []
+
+    def fail_retry(url, sandbox_token, payload, path, log_type):
+        attempted_runs.append(payload["runId"])
+        raise OSError("still full")
+
+    with (
+        patch.object(usage_buffer, "_enqueue_webhook", side_effect=fail_retry),
+        pytest.raises(OSError, match="still full"),
+    ):
+        usage.flush_usage_events(trigger="test")
+
+    assert attempted_runs == ["run-a"]
+    assert usage.counters._buffered_usage_events == 2
+
+    with patch.object(usage_buffer, "_enqueue_webhook") as enqueue:
+        assert usage.flush_usage_events(trigger="test") == 2
+
+    assert [call.args[2]["runId"] for call in enqueue.call_args_list] == ["run-a", "run-b"]
     assert usage.counters._buffered_usage_events == 0
 
 
@@ -470,6 +554,40 @@ def test_timer_flush_uses_scheduled_callback_without_real_sleep(tmp_path):
     enqueue.assert_called_once()
     assert timers[0].cancelled is True
     assert enqueue.call_args.args[2]["events"][0]["quantity"] == 10
+
+
+def test_timer_flush_failure_reschedules_retry_without_real_sleep(tmp_path):
+    timers = []
+
+    def timer_factory(delay: float, callback):
+        timer = _FakeTimer(delay, callback)
+        timers.append(timer)
+        return timer
+
+    usage.reset_usage_buffer_for_tests(timer_enabled=True, timer_factory=timer_factory)
+
+    usage.buffer_usage_events(
+        "https://api.test/api/webhooks/agent/usage-event",
+        "token-a",
+        "run-1",
+        [_event(source_key="source-1", quantity=10)],
+        str(tmp_path / "proxy.jsonl"),
+    )
+
+    assert len(timers) == 1
+    assert timers[0].started is True
+
+    with (
+        patch.object(usage_buffer, "_enqueue_webhook", side_effect=OSError("no threads")),
+        pytest.raises(OSError, match="no threads"),
+    ):
+        timers[0].callback()
+
+    assert timers[0].cancelled is True
+    assert len(timers) == 2
+    assert timers[1].started is True
+    assert timers[1].cancelled is False
+    assert usage.counters._buffered_usage_events == 1
 
 
 def test_threshold_flush_cancels_scheduled_timer_and_allows_reschedule(tmp_path):

--- a/crates/runner/mitm-addon/tests/test_usage_buffer.py
+++ b/crates/runner/mitm-addon/tests/test_usage_buffer.py
@@ -444,6 +444,47 @@ def test_partial_flush_failure_retries_accepted_batches_with_same_idempotency_ke
     assert usage.counters._buffered_usage_events == 0
 
 
+def test_threshold_flush_failure_preserves_retryable_payload_with_same_idempotency_key(
+    tmp_path,
+):
+    proxy_log_path = str(tmp_path / "proxy.jsonl")
+    events = [
+        _event(source_key=f"source-{index}", quantity=1)
+        for index in range(usage_buffer.MAX_BUFFERED_SOURCE_EVENTS)
+    ]
+    failed_payloads = []
+
+    def fail_enqueue(url, sandbox_token, payload, path, log_type):
+        failed_payloads.append(payload)
+        raise OSError("threshold enqueue failed")
+
+    with (
+        patch.object(usage_buffer, "_enqueue_webhook", side_effect=fail_enqueue) as enqueue,
+        pytest.raises(OSError, match="threshold enqueue failed"),
+    ):
+        usage.buffer_usage_events(
+            "https://api.test/api/webhooks/agent/usage-event",
+            "token-a",
+            "run-threshold",
+            events,
+            proxy_log_path,
+        )
+
+    enqueue.assert_called_once()
+    assert usage.counters._buffered_usage_events == usage_buffer.MAX_BUFFERED_SOURCE_EVENTS
+    failed_key = failed_payloads[0]["events"][0]["idempotencyKey"]
+
+    with patch.object(usage_buffer, "_enqueue_webhook") as enqueue:
+        assert usage.flush_usage_events(trigger="test") == 1
+
+    enqueue.assert_called_once()
+    retry_payload = enqueue.call_args.args[2]
+    assert retry_payload["runId"] == "run-threshold"
+    assert retry_payload["events"][0]["quantity"] == usage_buffer.MAX_BUFFERED_SOURCE_EVENTS
+    assert retry_payload["events"][0]["idempotencyKey"] == failed_key
+    assert usage.counters._buffered_usage_events == 0
+
+
 def test_pending_flush_retries_before_live_usage_snapshot(tmp_path):
     proxy_log_path = str(tmp_path / "proxy.jsonl")
     usage.buffer_usage_events(

--- a/crates/runner/mitm-addon/tests/test_usage_buffer.py
+++ b/crates/runner/mitm-addon/tests/test_usage_buffer.py
@@ -402,45 +402,46 @@ def test_flush_failure_preserves_retryable_payload_with_same_idempotency_key(tmp
 
 def test_partial_flush_failure_retries_accepted_batches_with_same_idempotency_keys(tmp_path):
     proxy_log_path = str(tmp_path / "proxy.jsonl")
-    with patch.object(usage_buffer, "USAGE_EVENT_BATCH_SIZE", 1):
-        usage.buffer_usage_events(
-            "https://api.test/api/webhooks/agent/usage-event",
-            "token-a",
-            "run-1",
-            [
-                _event(source_key="source-1", category="category-1"),
-                _event(source_key="source-2", category="category-2"),
-            ],
-            proxy_log_path,
-        )
+    usage.buffer_usage_events(
+        "https://api.test/api/webhooks/agent/usage-event",
+        "token-a",
+        "run-1",
+        [_event(source_key="source-1")],
+        proxy_log_path,
+    )
+    usage.buffer_usage_events(
+        "https://api.test/api/webhooks/agent/usage-event",
+        "token-a",
+        "run-2",
+        [_event(source_key="source-2")],
+        proxy_log_path,
+    )
 
-        failed_payloads = []
+    failed_payloads = []
 
-        def fail_second_batch(url, sandbox_token, payload, path, log_type):
-            failed_payloads.append(payload)
-            if len(failed_payloads) == 2:
-                raise OSError("second batch rejected")
+    def fail_second_batch(url, sandbox_token, payload, path, log_type):
+        failed_payloads.append(payload)
+        if len(failed_payloads) == 2:
+            raise OSError("second batch rejected")
 
-        with (
-            patch.object(
-                usage_buffer, "_enqueue_webhook", side_effect=fail_second_batch
-            ) as enqueue,
-            pytest.raises(OSError, match="second batch rejected"),
-        ):
-            usage.flush_usage_events(trigger="test")
+    with (
+        patch.object(usage_buffer, "_enqueue_webhook", side_effect=fail_second_batch) as enqueue,
+        pytest.raises(OSError, match="second batch rejected"),
+    ):
+        usage.flush_usage_events(trigger="test")
 
-        assert enqueue.call_count == 2
-        assert [len(payload["events"]) for payload in failed_payloads] == [1, 1]
-        assert usage.counters._buffered_usage_events == 2
+    assert enqueue.call_count == 2
+    assert [payload["runId"] for payload in failed_payloads] == ["run-1", "run-2"]
+    assert usage.counters._buffered_usage_events == 2
 
-        with patch.object(usage_buffer, "_enqueue_webhook") as enqueue:
-            assert usage.flush_usage_events(trigger="test") == 2
+    with patch.object(usage_buffer, "_enqueue_webhook") as enqueue:
+        assert usage.flush_usage_events(trigger="test") == 2
 
-        retry_payloads = _payloads_from_enqueue_calls(enqueue.call_args_list)
-        assert [
-            event["idempotencyKey"] for payload in retry_payloads for event in payload["events"]
-        ] == [event["idempotencyKey"] for payload in failed_payloads for event in payload["events"]]
-        assert usage.counters._buffered_usage_events == 0
+    retry_payloads = _payloads_from_enqueue_calls(enqueue.call_args_list)
+    assert [
+        event["idempotencyKey"] for payload in retry_payloads for event in payload["events"]
+    ] == [event["idempotencyKey"] for payload in failed_payloads for event in payload["events"]]
+    assert usage.counters._buffered_usage_events == 0
 
 
 def test_pending_flush_retries_before_live_usage_snapshot(tmp_path):

--- a/crates/runner/mitm-addon/tests/test_usage_buffer.py
+++ b/crates/runner/mitm-addon/tests/test_usage_buffer.py
@@ -532,6 +532,42 @@ def test_pending_flush_retries_before_live_usage_snapshot(tmp_path):
     assert usage.counters._buffered_usage_events == 0
 
 
+def test_overlapping_flush_defers_live_snapshot_while_enqueueing(tmp_path):
+    proxy_log_path = str(tmp_path / "proxy.jsonl")
+    usage.buffer_usage_events(
+        "https://api.test/api/webhooks/agent/usage-event",
+        "token-a",
+        "run-1",
+        [_event(source_key="source-1")],
+        proxy_log_path,
+    )
+
+    def enqueue_webhook(url, sandbox_token, payload, path, log_type):
+        usage.buffer_usage_events(
+            url,
+            sandbox_token,
+            "run-2",
+            [_event(source_key="source-2")],
+            path,
+        )
+        assert usage.flush_usage_events(trigger="runner") == 0
+        assert payload["runId"] == "run-1"
+        assert usage.counters._buffered_usage_events == 2
+
+    with patch.object(usage_buffer, "_enqueue_webhook", side_effect=enqueue_webhook) as enqueue:
+        assert usage.flush_usage_events(trigger="test") == 1
+
+    enqueue.assert_called_once()
+    assert usage.counters._buffered_usage_events == 1
+
+    with patch.object(usage_buffer, "_enqueue_webhook") as enqueue:
+        assert usage.flush_usage_events(trigger="test") == 1
+
+    enqueue.assert_called_once()
+    assert enqueue.call_args.args[2]["runId"] == "run-2"
+    assert usage.counters._buffered_usage_events == 0
+
+
 def test_flush_preserves_events_buffered_during_enqueue(tmp_path):
     proxy_log_path = str(tmp_path / "proxy.jsonl")
     usage.buffer_usage_events(


### PR DESCRIPTION
## Summary

- keep snapshotted usage flush payloads as retry-pending state until webhook enqueue accepts ownership
- retry pending flushes before snapshotting live usage, preserving aggregate idempotency keys across enqueue failures
- keep buffered usage counters accurate for live, pending, and enqueuing usage; reschedule timer retries after timer-triggered enqueue failures

Fixes #15931

## Tests

- `cd crates/runner/mitm-addon && git diff --check`
- `cd crates/runner/mitm-addon && ruff check src/usage/buffer.py tests/test_usage_buffer.py`
- `cd crates/runner/mitm-addon && ruff format --check src/usage/buffer.py tests/test_usage_buffer.py`
- `cd crates/runner/mitm-addon && basedpyright src/usage/buffer.py tests/test_usage_buffer.py`
- `cd crates/runner/mitm-addon && pytest tests/test_usage_buffer.py`
- `cd crates/runner/mitm-addon && pytest tests/test_counters.py tests/test_connection_hooks.py`

Also ran earlier during implementation:

- `cd crates/runner/mitm-addon && pytest tests/`