### PR TITLE
feat: route platform team and onboarding-status reads to api backend

### DIFF
--- a/turbo/apps/platform/src/signals/__tests__/api-client.test.ts
+++ b/turbo/apps/platform/src/signals/__tests__/api-client.test.ts
@@ -5,6 +5,8 @@ import { zeroClient$ } from "../api-client.ts";
 import { zeroOrgContract } from "@vm0/api-contracts/contracts/zero-org";
 import { zeroFeatureSwitchesContract } from "@vm0/api-contracts/contracts/zero-feature-switches";
 import { zeroUserPreferencesContract } from "@vm0/api-contracts/contracts/zero-user-preferences";
+import { zeroTeamContract } from "@vm0/api-contracts/contracts/zero-team";
+import { onboardingStatusContract } from "@vm0/api-contracts/contracts/onboarding";
 import { testContext } from "./test-helpers.ts";
 import { detachedSetupPage } from "../../__tests__/page-helper.ts";
 import { mockedClerk } from "../../__tests__/mock-auth.ts";
@@ -367,6 +369,64 @@ describe("zeroClient$ apiBackend routing", () => {
     expect(getResult.status).toBe(200);
     expect(updateResult.status).toBe(200);
     expect(requestHosts).toStrictEqual(["api.vm0.ai", "api.vm0.ai"]);
+  });
+
+  it("routes policy allowlisted team contract requests to api host when apiBackend is off", async () => {
+    vi.stubGlobal("location", new URL("https://platform.vm0.ai/"));
+    detachedSetupPage({
+      context,
+      path: "/",
+      withoutRender: true,
+    });
+
+    const requestHosts: string[] = [];
+    server.use(
+      mockApi(zeroTeamContract.list, ({ request, respond }) => {
+        requestHosts.push(new URL(request.url).host);
+        return respond(200, []);
+      }),
+    );
+
+    const createClient = context.store.get(zeroClient$);
+    const client = createClient(zeroTeamContract);
+    const result = await client.list();
+
+    expect(result.status).toBe(200);
+    expect(requestHosts).toStrictEqual(["api.vm0.ai"]);
+  });
+
+  it("routes policy allowlisted onboarding status contract requests to api host when apiBackend is off", async () => {
+    vi.stubGlobal("location", new URL("https://platform.vm0.ai/"));
+    detachedSetupPage({
+      context,
+      path: "/",
+      withoutRender: true,
+    });
+
+    const requestHosts: string[] = [];
+    server.use(
+      mockApi(onboardingStatusContract.getStatus, ({ request, respond }) => {
+        requestHosts.push(new URL(request.url).host);
+        return respond(200, {
+          needsOnboarding: false,
+          isAdmin: true,
+          hasOrg: true,
+          hasDefaultAgent: true,
+          defaultAgentId: "agent_1",
+          defaultAgentMetadata: null,
+        });
+      }),
+    );
+
+    const createClient = context.store.get(zeroClient$);
+    const client = createClient(onboardingStatusContract);
+    const result = await client.getStatus();
+
+    expect(result.status).toBe(200);
+    // The onboard guard may also fetch status during page bootstrap; assert
+    // every onboarding-status request routes to the api host, not the count.
+    expect(requestHosts.length).toBeGreaterThan(0);
+    expect([...new Set(requestHosts)]).toStrictEqual(["api.vm0.ai"]);
   });
 
   it("routes GET contract requests to api host when apiBackend is on", async () => {

--- a/turbo/apps/platform/src/signals/api-target-policy.ts
+++ b/turbo/apps/platform/src/signals/api-target-policy.ts
@@ -15,6 +15,16 @@ interface ApiTargetPolicyEntry {
 
 const API_ROUTE_TARGET_POLICY: readonly ApiTargetPolicyEntry[] = [
   {
+    methods: ["GET"],
+    pathname: "/api/zero/onboarding/status",
+    target: "api",
+  },
+  {
+    methods: ["GET"],
+    pathname: "/api/zero/team",
+    target: "api",
+  },
+  {
     methods: ["GET", "POST"],
     pathname: "/api/zero/user-preferences",
     target: "api",


### PR DESCRIPTION
## Summary
- First progressive batch of the Platform API backend cutover (#15872), building on the centralized target policy from #15880.
- Allowlist two read-only, first-party Platform routes to the `api` host while the global `apiBackend` switch is off:
  - `GET /api/zero/team` — `agents$` (`zeroTeamContract.list`)
  - `GET /api/zero/onboarding/status` — `zeroOnboardingStatus$` (`onboardingStatusContract.getStatus`)
- Both are static-path GET reads called through `zeroClient$` with no `apiBase` override; the method-aware policy leaves any same-path mutations on `www`.
- `GET /api/zero/org` is intentionally kept on `www` this batch as the default-routing test fixture (candidate for batch 2).

## Why these are safe
- First-party only (Platform UI calls), read-only, static path (works with the current exact-path matcher).
- No bootstrap dependency: resolving `apiBackendEnabled$` loads feature switches via the www-pinned client, so routing these through the policy introduces no cycle.
- Rollback is read-only and code-level: remove the entries and redeploy, or flip `FeatureSwitchKey.ApiBackend`. No data-mutation risk.

## Out of scope (stays on www)
Bootstrap `feature-switches`, OAuth start/callback triad (caller-supplied redirect origin pinned to `VM0_WEB_URL`), and the external inbound surface (webhooks, OSS/storage callbacks, cron, CLI).

## Validation
- `pnpm -F @vm0/app exec vitest run src/signals/__tests__/api-client.test.ts src/signals/__tests__/fetch.test.ts` — 40 passed (2 new routing assertions: team + onboarding-status route to `api` when `apiBackend` is off).
- `pnpm format`, `pnpm -F @vm0/app lint`, `pnpm -F @vm0/app check-types` — clean.
- `pnpm knip` — no new findings from this diff (only pre-existing `knip.json` config hints on main).

## Post-merge verification
Confirm in `vm0-traces-prod` that `GET /api/zero/team` and `GET /api/zero/onboarding/status` land on `service.name=vm0-api` with no 5xx and no fallback-to-web, matching the already-verified `user-preferences` cutover.

Closes #15989
Part of #15872

🤖 Generated with [Claude Code](https://claude.com/claude-code)
