### PR TITLE
fix: show skill file count in sidebar

### DIFF
--- a/turbo/apps/platform/src/views/skills-page/__tests__/skills-page.test.tsx
+++ b/turbo/apps/platform/src/views/skills-page/__tests__/skills-page.test.tsx
@@ -199,6 +199,13 @@ describe("skills page", () => {
     expect(within(dialog).getByText("Used by")).toBeInTheDocument();
     expect(within(dialog).getByText("Research Agent")).toBeInTheDocument();
     expect(within(dialog).getByAltText("Research Agent")).toBeInTheDocument();
+    const filesSummary = within(dialog).getByText("Files").closest("div");
+    expect(filesSummary).not.toBeNull();
+    if (filesSummary === null) {
+      throw new Error("Files summary row not found");
+    }
+    expect(within(filesSummary).getByText("3")).toBeInTheDocument();
+    expect(within(filesSummary).queryByText("67 B")).not.toBeInTheDocument();
     const promptFileButton = queryAllByRoleFast("button", dialog).find(
       (button) => {
         return button.textContent?.includes("templates/prompt.md");

--- a/turbo/apps/platform/src/views/skills-page/skills-page.tsx
+++ b/turbo/apps/platform/src/views/skills-page/skills-page.tsx
@@ -525,17 +525,11 @@ function SkillFiles({
   readonly selectedPath: string | null;
   readonly onSelectFile: (path: string) => void;
 }) {
-  const totalSize = files.reduce((sum, file) => {
-    return sum + file.size;
-  }, 0);
-
   return (
     <div className="min-h-0">
       <div className="flex h-9 items-center justify-between border-b border-border/70 px-3">
         <span className="text-xs font-medium text-muted-foreground">Files</span>
-        <span className="text-xs text-muted-foreground">
-          {formatBytes(totalSize)}
-        </span>
+        <span className="text-xs text-muted-foreground">{files.length}</span>
       </div>
       <div className="max-h-[240px] overflow-auto p-2 lg:max-h-none">
         {files.length > 0 ? (


### PR DESCRIPTION
## Summary
- Show the number of files in the skill detail sidebar Files header instead of the aggregate byte size
- Keep per-file sizes visible on individual file rows
- Add a regression assertion for the Files header count

## Tests
- pnpm exec prettier --check apps/platform/src/views/skills-page/skills-page.tsx apps/platform/src/views/skills-page/__tests__/skills-page.test.tsx
- pnpm -F @vm0/app exec eslint src/views/skills-page/skills-page.tsx src/views/skills-page/__tests__/skills-page.test.tsx --max-warnings 0
- pnpm -F @vm0/app exec vitest run src/views/skills-page/__tests__/skills-page.test.tsx *(fails locally in this sandbox: test harness renders an empty body; broader run shows localStorage.getItem is not initialized in this local Vitest environment)*