### PR TITLE
feat: route platform org, schedules and voice-io quota reads to api backend

### DIFF
--- a/turbo/apps/platform/src/signals/__tests__/api-client.test.ts
+++ b/turbo/apps/platform/src/signals/__tests__/api-client.test.ts
@@ -7,6 +7,9 @@ import { zeroFeatureSwitchesContract } from "@vm0/api-contracts/contracts/zero-f
 import { zeroUserPreferencesContract } from "@vm0/api-contracts/contracts/zero-user-preferences";
 import { zeroTeamContract } from "@vm0/api-contracts/contracts/zero-team";
 import { onboardingStatusContract } from "@vm0/api-contracts/contracts/onboarding";
+import { zeroVoiceIoQuotaContract } from "@vm0/api-contracts/contracts/zero-voice-io-quota";
+import { zeroSchedulesMainContract } from "@vm0/api-contracts/contracts/zero-schedules";
+import { zeroConnectorsMainContract } from "@vm0/api-contracts/contracts/zero-connectors";
 import { testContext } from "./test-helpers.ts";
 import { detachedSetupPage } from "../../__tests__/page-helper.ts";
 import { mockedClerk } from "../../__tests__/mock-auth.ts";
@@ -300,7 +303,7 @@ describe("zeroClient$ apiBackend routing", () => {
     expect(requestHosts).toStrictEqual(["api.vm0.ai"]);
   });
 
-  it("keeps GET contract requests on www when apiBackend is off", async () => {
+  it("keeps non-allowlisted GET contract requests on www when apiBackend is off", async () => {
     vi.stubGlobal("location", new URL("https://platform.vm0.ai/"));
     detachedSetupPage({
       context,
@@ -310,20 +313,19 @@ describe("zeroClient$ apiBackend routing", () => {
 
     const requestHosts: string[] = [];
     server.use(
-      mockApi(zeroOrgContract.get, ({ request, respond }) => {
+      mockApi(zeroConnectorsMainContract.list, ({ request, respond }) => {
         requestHosts.push(new URL(request.url).host);
         return respond(200, {
-          id: "org_1",
-          name: "Org",
-          slug: "org-1",
-          role: "admin",
+          connectors: [],
+          configuredTypes: [],
+          connectorProvidedEnvNames: [],
         });
       }),
     );
 
     const createClient = context.store.get(zeroClient$);
-    const client = createClient(zeroOrgContract);
-    const result = await client.get();
+    const client = createClient(zeroConnectorsMainContract);
+    const result = await client.list();
 
     expect(result.status).toBe(200);
     expect(requestHosts).toStrictEqual(["www.vm0.ai"]);
@@ -427,6 +429,83 @@ describe("zeroClient$ apiBackend routing", () => {
     // every onboarding-status request routes to the api host, not the count.
     expect(requestHosts.length).toBeGreaterThan(0);
     expect([...new Set(requestHosts)]).toStrictEqual(["api.vm0.ai"]);
+  });
+
+  it("routes policy allowlisted org contract requests to api host when apiBackend is off", async () => {
+    vi.stubGlobal("location", new URL("https://platform.vm0.ai/"));
+    detachedSetupPage({
+      context,
+      path: "/",
+      withoutRender: true,
+    });
+
+    const requestHosts: string[] = [];
+    server.use(
+      mockApi(zeroOrgContract.get, ({ request, respond }) => {
+        requestHosts.push(new URL(request.url).host);
+        return respond(200, {
+          id: "org_1",
+          name: "Org",
+          slug: "org-1",
+          role: "admin",
+        });
+      }),
+    );
+
+    const createClient = context.store.get(zeroClient$);
+    const client = createClient(zeroOrgContract);
+    const result = await client.get();
+
+    expect(result.status).toBe(200);
+    expect(requestHosts).toStrictEqual(["api.vm0.ai"]);
+  });
+
+  it("routes policy allowlisted voice-io quota contract requests to api host when apiBackend is off", async () => {
+    vi.stubGlobal("location", new URL("https://platform.vm0.ai/"));
+    detachedSetupPage({
+      context,
+      path: "/",
+      withoutRender: true,
+    });
+
+    const requestHosts: string[] = [];
+    server.use(
+      mockApi(zeroVoiceIoQuotaContract.get, ({ request, respond }) => {
+        requestHosts.push(new URL(request.url).host);
+        return respond(200, { allowed: true, count: 0, limit: null });
+      }),
+    );
+
+    const createClient = context.store.get(zeroClient$);
+    const client = createClient(zeroVoiceIoQuotaContract);
+    const result = await client.get();
+
+    expect(result.status).toBe(200);
+    expect(requestHosts).toStrictEqual(["api.vm0.ai"]);
+  });
+
+  it("routes policy allowlisted schedules list contract requests to api host when apiBackend is off", async () => {
+    vi.stubGlobal("location", new URL("https://platform.vm0.ai/"));
+    detachedSetupPage({
+      context,
+      path: "/",
+      withoutRender: true,
+    });
+
+    const requestHosts: string[] = [];
+    server.use(
+      mockApi(zeroSchedulesMainContract.list, ({ request, respond }) => {
+        requestHosts.push(new URL(request.url).host);
+        return respond(200, { schedules: [] });
+      }),
+    );
+
+    const createClient = context.store.get(zeroClient$);
+    const client = createClient(zeroSchedulesMainContract);
+    const result = await client.list();
+
+    expect(result.status).toBe(200);
+    expect(requestHosts).toStrictEqual(["api.vm0.ai"]);
   });
 
   it("routes GET contract requests to api host when apiBackend is on", async () => {

--- a/turbo/apps/platform/src/signals/__tests__/api-client.test.ts
+++ b/turbo/apps/platform/src/signals/__tests__/api-client.test.ts
@@ -460,6 +460,35 @@ describe("zeroClient$ apiBackend routing", () => {
     expect(requestHosts).toStrictEqual(["api.vm0.ai"]);
   });
 
+  it("keeps same-path org mutation on www when apiBackend is off", async () => {
+    vi.stubGlobal("location", new URL("https://platform.vm0.ai/"));
+    detachedSetupPage({
+      context,
+      path: "/",
+      withoutRender: true,
+    });
+
+    const requestHosts: string[] = [];
+    server.use(
+      mockApi(zeroOrgContract.update, ({ request, respond }) => {
+        requestHosts.push(new URL(request.url).host);
+        return respond(200, {
+          id: "org_1",
+          name: "Org",
+          slug: "org-1",
+          role: "admin",
+        });
+      }),
+    );
+
+    const createClient = context.store.get(zeroClient$);
+    const client = createClient(zeroOrgContract);
+    const result = await client.update({ body: { name: "Renamed" } });
+
+    expect(result.status).toBe(200);
+    expect(requestHosts).toStrictEqual(["www.vm0.ai"]);
+  });
+
   it("routes policy allowlisted voice-io quota contract requests to api host when apiBackend is off", async () => {
     vi.stubGlobal("location", new URL("https://platform.vm0.ai/"));
     detachedSetupPage({

--- a/turbo/apps/platform/src/signals/api-target-policy.ts
+++ b/turbo/apps/platform/src/signals/api-target-policy.ts
@@ -21,12 +21,27 @@ const API_ROUTE_TARGET_POLICY: readonly ApiTargetPolicyEntry[] = [
   },
   {
     methods: ["GET"],
+    pathname: "/api/zero/org",
+    target: "api",
+  },
+  {
+    methods: ["GET"],
+    pathname: "/api/zero/schedules",
+    target: "api",
+  },
+  {
+    methods: ["GET"],
     pathname: "/api/zero/team",
     target: "api",
   },
   {
     methods: ["GET", "POST"],
     pathname: "/api/zero/user-preferences",
+    target: "api",
+  },
+  {
+    methods: ["GET"],
+    pathname: "/api/zero/voice-io/quota",
     target: "api",
   },
 ];


### PR DESCRIPTION
## Summary
- Second progressive batch of the Platform API backend cutover (#15872), continuing from batch 1 (#15990).
- Allowlist three read-only, first-party Platform routes to the `api` host while the global `apiBackend` switch is off:
  - `GET /api/zero/org` — `org$` (`zeroOrgContract.get`)
  - `GET /api/zero/schedules` — `zeroSchedulesMainContract.list`
  - `GET /api/zero/voice-io/quota` — `audioInputQuota$` (`zeroVoiceIoQuotaContract.get`)
- All are static-path GET reads called through `zeroClient$` with no `apiBase` override; the method-aware policy keeps same-path mutations (`PUT /api/zero/org`, `POST /api/zero/schedules`) on `www`.

## Test fixture change
`GET /api/zero/org` was the existing default-`www` routing test fixture. Since it now routes to `api`, the default-`www` test is re-pointed to `GET /api/zero/connectors` (a still-`www` policy-routed read).

## Why these are safe
- First-party only, read-only, static path (works with the current exact-path matcher).
- No bootstrap dependency: `apiBackendEnabled$` resolves via the www-pinned feature-switch client, so routing these through the policy introduces no cycle.
- Rollback is read-only and code-level: remove the entries and redeploy, or flip `FeatureSwitchKey.ApiBackend`.

## Out of scope (stays on www)
Bootstrap `feature-switches`, OAuth start/callback triad (caller-supplied redirect origin pinned to `VM0_WEB_URL`), external inbound surface (webhooks, OSS/storage callbacks, cron, CLI).

## Validation
- `pnpm -F @vm0/app exec vitest run src/signals/__tests__/api-client.test.ts src/signals/__tests__/fetch.test.ts` — passed (3 new routing assertions; default-`www` test re-pointed to connectors).
- `pnpm format`, `pnpm -F @vm0/app lint`, `pnpm -F @vm0/app check-types` — clean.
- `pnpm knip --workspace apps/platform` — clean.

## Post-merge verification
Confirm in `vm0-traces-prod` that `GET /api/zero/org`, `GET /api/zero/schedules`, and `GET /api/zero/voice-io/quota` land on `service.name=vm0-api` with no 5xx and no fallback-to-web.

Closes #15996
Part of #15872

🤖 Generated with [Claude Code](https://claude.com/claude-code)
