### PR TITLE
feat(api): add memory activity read endpoint

### DIFF
--- a/turbo/apps/api/src/signals/route.ts
+++ b/turbo/apps/api/src/signals/route.ts
@@ -91,6 +91,7 @@ import { zeroEmailInboundRoutes } from "./routes/zero-email-inbound";
 import { zeroFeatureSwitchesRoutes } from "./routes/zero-feature-switches";
 import { zeroHostRoutes } from "./routes/zero-host";
 import { zeroMemoryRoutes } from "./routes/zero-memory";
+import { zeroMemoryActivityRoutes } from "./routes/zero-memory-activity";
 import { zeroBuiltInGenerationRoutes } from "./routes/zero-built-in-generation";
 import { zeroInsightsRoutes } from "./routes/zero-insights";
 import { zeroImageIoGenerateRoutes } from "./routes/zero-image-io-generate";
@@ -271,6 +272,7 @@ export const ROUTES: readonly RouteEntry[] = [
   ...zeroFeatureSwitchesRoutes,
   ...zeroHostRoutes,
   ...zeroMemoryRoutes,
+  ...zeroMemoryActivityRoutes,
   ...zeroBuiltInGenerationRoutes,
   ...zeroInsightsRoutes,
   ...zeroImageIoGenerateRoutes,

--- a/turbo/apps/api/src/signals/routes/__tests__/helpers/zero-memory.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/helpers/zero-memory.ts
@@ -98,8 +98,12 @@ export const seedMemoryActivitySummary$ = command(
 
     const items = seed.items ?? [];
     if (items.length > 0) {
+      // Stagger `created_at` per item so the seeded order is preserved by the
+      // service's `ORDER BY created_at, id`. A plain multi-row insert would give
+      // every item the same transaction-start `now()`, leaving order undefined.
+      const base = Date.UTC(2025, 0, 1);
       await db.insert(memoryChangeItems).values(
-        items.map((item) => {
+        items.map((item, index) => {
           return {
             summaryId,
             kind: item.kind,
@@ -108,6 +112,7 @@ export const seedMemoryActivitySummary$ = command(
             filePath: item.filePath,
             beforeSnippet: item.beforeSnippet ?? null,
             afterSnippet: item.afterSnippet ?? null,
+            createdAt: new Date(base + index * 1000),
           };
         }),
       );

--- a/turbo/apps/api/src/signals/routes/__tests__/helpers/zero-memory.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/helpers/zero-memory.ts
@@ -3,6 +3,8 @@ import { gzipSync } from "node:zlib";
 
 import { MEMORY_ARTIFACT_NAME } from "@vm0/core/storage-names";
 import { command } from "ccstate";
+import { memoryChangeItems } from "@vm0/db/schema/memory-change-item";
+import { memoryChangeSummaries } from "@vm0/db/schema/memory-change-summary";
 import { orgMetadata } from "@vm0/db/schema/org-metadata";
 import { storages, storageVersions } from "@vm0/db/schema/storage";
 import { eq } from "drizzle-orm";
@@ -46,8 +48,73 @@ export const deleteMemoryForFixture$ = command(
     // Storage cascade deletes storage_versions via FK.
     await db.delete(storages).where(eq(storages.orgId, fixture.orgId));
     signal.throwIfAborted();
+    // Change items cascade delete with their parent summary via FK.
+    await db
+      .delete(memoryChangeSummaries)
+      .where(eq(memoryChangeSummaries.orgId, fixture.orgId));
+    signal.throwIfAborted();
     await db.delete(orgMetadata).where(eq(orgMetadata.orgId, fixture.orgId));
     signal.throwIfAborted();
+  },
+);
+
+interface MemoryActivityItemSeed {
+  readonly kind: string;
+  readonly title?: string | null;
+  readonly description?: string | null;
+  readonly filePath: string;
+  readonly beforeSnippet?: string | null;
+  readonly afterSnippet?: string | null;
+}
+
+interface MemoryActivitySummarySeed {
+  readonly orgId: string;
+  readonly userId: string;
+  readonly date: string;
+  readonly fromVersionId?: string | null;
+  readonly toVersionId: string;
+  readonly summary?: string | null;
+  readonly items?: readonly MemoryActivityItemSeed[];
+}
+
+export const seedMemoryActivitySummary$ = command(
+  async (
+    { set },
+    seed: MemoryActivitySummarySeed,
+    signal: AbortSignal,
+  ): Promise<string> => {
+    const db = set(writeDb$);
+    const summaryId = randomUUID();
+    await db.insert(memoryChangeSummaries).values({
+      id: summaryId,
+      orgId: seed.orgId,
+      userId: seed.userId,
+      date: seed.date,
+      fromVersionId: seed.fromVersionId ?? null,
+      toVersionId: seed.toVersionId,
+      summary: seed.summary ?? null,
+    });
+    signal.throwIfAborted();
+
+    const items = seed.items ?? [];
+    if (items.length > 0) {
+      await db.insert(memoryChangeItems).values(
+        items.map((item) => {
+          return {
+            summaryId,
+            kind: item.kind,
+            title: item.title ?? null,
+            description: item.description ?? null,
+            filePath: item.filePath,
+            beforeSnippet: item.beforeSnippet ?? null,
+            afterSnippet: item.afterSnippet ?? null,
+          };
+        }),
+      );
+      signal.throwIfAborted();
+    }
+
+    return summaryId;
   },
 );
 

--- a/turbo/apps/api/src/signals/routes/__tests__/zero-memory-activity.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/zero-memory-activity.test.ts
@@ -206,6 +206,41 @@ describe("GET /api/zero/memory/activity", () => {
     ]);
   });
 
+  it("returns a summary's items in a deterministic order", async () => {
+    const fixture = await track(
+      store.set(seedMemoryFixture$, undefined, context.signal),
+    );
+    await store.set(
+      seedMemoryActivitySummary$,
+      {
+        orgId: fixture.orgId,
+        userId: fixture.userId,
+        date: "2025-07-01",
+        toVersionId: "v-order",
+        summary: "Many changes in one day",
+        items: [
+          { kind: "learned", filePath: "a.md" },
+          { kind: "updated", filePath: "b.md" },
+          { kind: "forgotten", filePath: "c.md" },
+          { kind: "learned", filePath: "d.md" },
+        ],
+      },
+      context.signal,
+    );
+    mocks.clerk.session(fixture.userId, fixture.orgId);
+
+    const response = await accept(
+      activityClient().get({ headers: authHeaders() }),
+      [200],
+    );
+
+    expect(
+      response.body.entries[0]?.items.map((item) => {
+        return item.filePath;
+      }),
+    ).toStrictEqual(["a.md", "b.md", "c.md", "d.md"]);
+  });
+
   it("scopes summaries to the authenticated user and org", async () => {
     const fixture = await track(
       store.set(seedMemoryFixture$, undefined, context.signal),

--- a/turbo/apps/api/src/signals/routes/__tests__/zero-memory-activity.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/zero-memory-activity.test.ts
@@ -1,0 +1,277 @@
+import { randomUUID } from "node:crypto";
+
+import { zeroMemoryActivityContract } from "@vm0/api-contracts/contracts/zero-memory-activity";
+import { createStore } from "ccstate";
+
+import { accept, setupApp, testContext } from "../../../__tests__/test-helpers";
+import {
+  deleteMemoryForFixture$,
+  type MemoryFixture,
+  seedMemoryActivitySummary$,
+  seedMemoryFixture$,
+} from "./helpers/zero-memory";
+import {
+  createFixtureTracker,
+  createZeroRouteMocks,
+} from "./helpers/zero-route-test";
+
+const context = testContext();
+const store = createStore();
+const mocks = createZeroRouteMocks(context);
+
+function authHeaders() {
+  return { authorization: "Bearer clerk-session" };
+}
+
+function activityClient() {
+  return setupApp({ context })(zeroMemoryActivityContract);
+}
+
+describe("GET /api/zero/memory/activity", () => {
+  const track = createFixtureTracker<MemoryFixture>((fixture) => {
+    return store.set(deleteMemoryForFixture$, fixture, context.signal);
+  });
+
+  it("returns 401 when the request is unauthenticated", async () => {
+    const response = await accept(activityClient().get({ headers: {} }), [401]);
+    expect(response.body).toStrictEqual({
+      error: { message: "Not authenticated", code: "UNAUTHORIZED" },
+    });
+  });
+
+  it("returns 401 when the authenticated session has no organization", async () => {
+    mocks.clerk.session(`user_${randomUUID()}`, null);
+    const response = await accept(
+      activityClient().get({ headers: authHeaders() }),
+      [401],
+    );
+    expect(response.body).toStrictEqual({
+      error: { message: "Not authenticated", code: "UNAUTHORIZED" },
+    });
+  });
+
+  it("returns an empty timeline when the user has no summaries", async () => {
+    const fixture = await track(
+      store.set(seedMemoryFixture$, undefined, context.signal),
+    );
+    mocks.clerk.session(fixture.userId, fixture.orgId);
+
+    const response = await accept(
+      activityClient().get({ headers: authHeaders() }),
+      [200],
+    );
+
+    expect(response.body).toStrictEqual({ entries: [] });
+  });
+
+  it("returns entries most-recent-day first with their items", async () => {
+    const fixture = await track(
+      store.set(seedMemoryFixture$, undefined, context.signal),
+    );
+    await store.set(
+      seedMemoryActivitySummary$,
+      {
+        orgId: fixture.orgId,
+        userId: fixture.userId,
+        date: "2025-05-01",
+        fromVersionId: null,
+        toVersionId: "v1",
+        summary: "Zero learned about your project setup",
+        items: [
+          {
+            kind: "learned",
+            title: "Project uses pnpm",
+            description: "Package manager preference",
+            filePath: "preferences/pnpm.md",
+            beforeSnippet: null,
+            afterSnippet: "Use pnpm for all package operations",
+          },
+        ],
+      },
+      context.signal,
+    );
+    await store.set(
+      seedMemoryActivitySummary$,
+      {
+        orgId: fixture.orgId,
+        userId: fixture.userId,
+        date: "2025-05-03",
+        fromVersionId: "v1",
+        toVersionId: "v2",
+        summary: null,
+        items: [
+          {
+            kind: "updated",
+            title: "Project uses pnpm",
+            description: null,
+            filePath: "preferences/pnpm.md",
+            beforeSnippet: "Use pnpm for all package operations",
+            afterSnippet: "Use pnpm 9 for all package operations",
+          },
+          {
+            kind: "forgotten",
+            title: null,
+            description: null,
+            filePath: "notes/stale.md",
+            beforeSnippet: "Old note",
+            afterSnippet: null,
+          },
+        ],
+      },
+      context.signal,
+    );
+    mocks.clerk.session(fixture.userId, fixture.orgId);
+
+    const response = await accept(
+      activityClient().get({ headers: authHeaders() }),
+      [200],
+    );
+
+    expect(response.body).toStrictEqual({
+      entries: [
+        {
+          date: "2025-05-03",
+          summary: null,
+          fromVersionId: "v1",
+          toVersionId: "v2",
+          items: [
+            {
+              kind: "updated",
+              title: "Project uses pnpm",
+              description: null,
+              filePath: "preferences/pnpm.md",
+              beforeSnippet: "Use pnpm for all package operations",
+              afterSnippet: "Use pnpm 9 for all package operations",
+            },
+            {
+              kind: "forgotten",
+              title: null,
+              description: null,
+              filePath: "notes/stale.md",
+              beforeSnippet: "Old note",
+              afterSnippet: null,
+            },
+          ],
+        },
+        {
+          date: "2025-05-01",
+          summary: "Zero learned about your project setup",
+          fromVersionId: null,
+          toVersionId: "v1",
+          items: [
+            {
+              kind: "learned",
+              title: "Project uses pnpm",
+              description: "Package manager preference",
+              filePath: "preferences/pnpm.md",
+              beforeSnippet: null,
+              afterSnippet: "Use pnpm for all package operations",
+            },
+          ],
+        },
+      ],
+    });
+  });
+
+  it("returns an entry with no items", async () => {
+    const fixture = await track(
+      store.set(seedMemoryFixture$, undefined, context.signal),
+    );
+    await store.set(
+      seedMemoryActivitySummary$,
+      {
+        orgId: fixture.orgId,
+        userId: fixture.userId,
+        date: "2025-06-01",
+        toVersionId: "v9",
+        summary: "A quiet narrative day",
+      },
+      context.signal,
+    );
+    mocks.clerk.session(fixture.userId, fixture.orgId);
+
+    const response = await accept(
+      activityClient().get({ headers: authHeaders() }),
+      [200],
+    );
+
+    expect(response.body.entries).toStrictEqual([
+      {
+        date: "2025-06-01",
+        summary: "A quiet narrative day",
+        fromVersionId: null,
+        toVersionId: "v9",
+        items: [],
+      },
+    ]);
+  });
+
+  it("scopes summaries to the authenticated user and org", async () => {
+    const fixture = await track(
+      store.set(seedMemoryFixture$, undefined, context.signal),
+    );
+    // Same org, different user.
+    const otherUserId = `user_${randomUUID()}`;
+    await store.set(
+      seedMemoryActivitySummary$,
+      {
+        orgId: fixture.orgId,
+        userId: otherUserId,
+        date: "2025-05-10",
+        toVersionId: "other-user-v1",
+        summary: "Other user's memory",
+        items: [
+          {
+            kind: "learned",
+            title: "Secret",
+            filePath: "secret.md",
+            afterSnippet: "Should not leak",
+          },
+        ],
+      },
+      context.signal,
+    );
+    // Different org, same user id (must not leak across orgs).
+    const otherFixture = await track(
+      store.set(seedMemoryFixture$, undefined, context.signal),
+    );
+    await store.set(
+      seedMemoryActivitySummary$,
+      {
+        orgId: otherFixture.orgId,
+        userId: fixture.userId,
+        date: "2025-05-11",
+        toVersionId: "other-org-v1",
+        summary: "Other org's memory",
+      },
+      context.signal,
+    );
+    // The authenticated user's own summary in their own org.
+    await store.set(
+      seedMemoryActivitySummary$,
+      {
+        orgId: fixture.orgId,
+        userId: fixture.userId,
+        date: "2025-05-12",
+        toVersionId: "mine-v1",
+        summary: "My memory",
+      },
+      context.signal,
+    );
+    mocks.clerk.session(fixture.userId, fixture.orgId);
+
+    const response = await accept(
+      activityClient().get({ headers: authHeaders() }),
+      [200],
+    );
+
+    expect(response.body.entries).toHaveLength(1);
+    expect(response.body.entries[0]).toStrictEqual({
+      date: "2025-05-12",
+      summary: "My memory",
+      fromVersionId: null,
+      toVersionId: "mine-v1",
+      items: [],
+    });
+  });
+});

--- a/turbo/apps/api/src/signals/routes/zero-memory-activity.ts
+++ b/turbo/apps/api/src/signals/routes/zero-memory-activity.ts
@@ -1,0 +1,28 @@
+import { computed } from "ccstate";
+import { zeroMemoryActivityContract } from "@vm0/api-contracts/contracts/zero-memory-activity";
+
+import { organizationAuthContext$ } from "../auth/auth-context";
+import { authRoute } from "../auth/auth-route";
+import type { RouteEntry } from "../route";
+import { zeroMemoryActivity } from "../services/zero-memory-activity.service";
+
+const memoryAuthOptions = {
+  requireOrganization: true,
+  missingOrganizationStatus: 401,
+} as const;
+
+const getMemoryActivityInner$ = computed(async (get): Promise<unknown> => {
+  const auth = get(organizationAuthContext$);
+  const activity = await get(zeroMemoryActivity(auth.orgId, auth.userId));
+  return {
+    status: 200 as const,
+    body: activity,
+  };
+});
+
+export const zeroMemoryActivityRoutes: readonly RouteEntry[] = [
+  {
+    route: zeroMemoryActivityContract.get,
+    handler: authRoute(memoryAuthOptions, getMemoryActivityInner$),
+  },
+];

--- a/turbo/apps/api/src/signals/services/zero-memory-activity.service.ts
+++ b/turbo/apps/api/src/signals/services/zero-memory-activity.service.ts
@@ -32,7 +32,9 @@ function toKind(kind: string): MemoryActivityKind {
   if (kind === "learned" || kind === "updated" || kind === "forgotten") {
     return kind;
   }
-  return "updated";
+  // The cron owns this vocabulary; an unknown value is a producer-side data bug
+  // that should surface rather than be silently coerced.
+  throw new Error(`Unexpected memory change item kind: ${kind}`);
 }
 
 /**
@@ -75,6 +77,7 @@ export function zeroMemoryActivity(
 
     const items = await get(db$)
       .select({
+        id: memoryChangeItems.id,
         summaryId: memoryChangeItems.summaryId,
         kind: memoryChangeItems.kind,
         title: memoryChangeItems.title,
@@ -85,7 +88,10 @@ export function zeroMemoryActivity(
       })
       .from(memoryChangeItems)
       .where(inArray(memoryChangeItems.summaryId, summaryIds))
-      .orderBy(asc(memoryChangeItems.createdAt));
+      // `created_at` defaults to the transaction-start `now()`, so all items of
+      // a single batch insert share one timestamp; `id` is a stable secondary
+      // key that gives a fully deterministic order instead of an undefined one.
+      .orderBy(asc(memoryChangeItems.createdAt), asc(memoryChangeItems.id));
 
     const itemsBySummaryId = new Map<string, MemoryActivityItem[]>();
     for (const item of items) {

--- a/turbo/apps/api/src/signals/services/zero-memory-activity.service.ts
+++ b/turbo/apps/api/src/signals/services/zero-memory-activity.service.ts
@@ -1,0 +1,116 @@
+import { computed, type Computed } from "ccstate";
+import { memoryChangeItems } from "@vm0/db/schema/memory-change-item";
+import { memoryChangeSummaries } from "@vm0/db/schema/memory-change-summary";
+import { and, asc, desc, eq, inArray } from "drizzle-orm";
+
+import { db$ } from "../external/db";
+
+type MemoryActivityKind = "learned" | "updated" | "forgotten";
+
+interface MemoryActivityItem {
+  readonly kind: MemoryActivityKind;
+  readonly title: string | null;
+  readonly description: string | null;
+  readonly filePath: string;
+  readonly beforeSnippet: string | null;
+  readonly afterSnippet: string | null;
+}
+
+interface MemoryActivityEntry {
+  readonly date: string;
+  readonly summary: string | null;
+  readonly fromVersionId: string | null;
+  readonly toVersionId: string;
+  readonly items: readonly MemoryActivityItem[];
+}
+
+interface MemoryActivityResult {
+  readonly entries: readonly MemoryActivityEntry[];
+}
+
+function toKind(kind: string): MemoryActivityKind {
+  if (kind === "learned" || kind === "updated" || kind === "forgotten") {
+    return kind;
+  }
+  return "updated";
+}
+
+/**
+ * Read-only daily Memory Activity timeline for the current user, assembled
+ * purely from the precomputed `memory_change_summaries` /
+ * `memory_change_items` tables (never touches S3).
+ *
+ * Summaries are scoped per (orgId, userId) and returned most-recent-day first;
+ * each summary's deterministic change items are nested under it.
+ */
+export function zeroMemoryActivity(
+  orgId: string,
+  userId: string,
+): Computed<Promise<MemoryActivityResult>> {
+  return computed(async (get): Promise<MemoryActivityResult> => {
+    const summaries = await get(db$)
+      .select({
+        id: memoryChangeSummaries.id,
+        date: memoryChangeSummaries.date,
+        summary: memoryChangeSummaries.summary,
+        fromVersionId: memoryChangeSummaries.fromVersionId,
+        toVersionId: memoryChangeSummaries.toVersionId,
+      })
+      .from(memoryChangeSummaries)
+      .where(
+        and(
+          eq(memoryChangeSummaries.orgId, orgId),
+          eq(memoryChangeSummaries.userId, userId),
+        ),
+      )
+      .orderBy(desc(memoryChangeSummaries.date));
+
+    if (summaries.length === 0) {
+      return { entries: [] };
+    }
+
+    const summaryIds = summaries.map((summary) => {
+      return summary.id;
+    });
+
+    const items = await get(db$)
+      .select({
+        summaryId: memoryChangeItems.summaryId,
+        kind: memoryChangeItems.kind,
+        title: memoryChangeItems.title,
+        description: memoryChangeItems.description,
+        filePath: memoryChangeItems.filePath,
+        beforeSnippet: memoryChangeItems.beforeSnippet,
+        afterSnippet: memoryChangeItems.afterSnippet,
+      })
+      .from(memoryChangeItems)
+      .where(inArray(memoryChangeItems.summaryId, summaryIds))
+      .orderBy(asc(memoryChangeItems.createdAt));
+
+    const itemsBySummaryId = new Map<string, MemoryActivityItem[]>();
+    for (const item of items) {
+      const bucket = itemsBySummaryId.get(item.summaryId) ?? [];
+      bucket.push({
+        kind: toKind(item.kind),
+        title: item.title,
+        description: item.description,
+        filePath: item.filePath,
+        beforeSnippet: item.beforeSnippet,
+        afterSnippet: item.afterSnippet,
+      });
+      itemsBySummaryId.set(item.summaryId, bucket);
+    }
+
+    const entries = summaries.map((summary): MemoryActivityEntry => {
+      return {
+        date: summary.date,
+        summary: summary.summary,
+        fromVersionId: summary.fromVersionId,
+        toVersionId: summary.toVersionId,
+        items: itemsBySummaryId.get(summary.id) ?? [],
+      };
+    });
+
+    return { entries };
+  });
+}

--- a/turbo/apps/web/api-backend-rewrites.js
+++ b/turbo/apps/web/api-backend-rewrites.js
@@ -1087,6 +1087,7 @@ export const API_BACKEND_REWRITES = [
     ZERO_SCHEDULES_ENABLE_PATH_RE,
   ],
   ["/api/zero/memory", "/api/zero/memory"],
+  ["/api/zero/memory/activity", "/api/zero/memory/activity"],
   ["/api/zero/skills", "/api/zero/skills"],
   [
     ZERO_SKILLS_BY_NAME_REWRITE_SOURCE,

--- a/turbo/packages/api-contracts/src/contracts/zero-memory-activity.ts
+++ b/turbo/packages/api-contracts/src/contracts/zero-memory-activity.ts
@@ -1,0 +1,60 @@
+import { z } from "zod";
+import { initContract, authHeadersSchema } from "./base";
+import { apiErrorSchema } from "./errors";
+
+const c = initContract();
+
+const memoryActivityItemSchema = z.object({
+  kind: z.enum(["learned", "updated", "forgotten"]),
+  title: z.string().nullable(),
+  description: z.string().nullable(),
+  filePath: z.string(),
+  beforeSnippet: z.string().nullable(),
+  afterSnippet: z.string().nullable(),
+});
+
+const memoryActivityEntrySchema = z.object({
+  /** Local day this summary covers, formatted YYYY-MM-DD. */
+  date: z.string(),
+  /** LLM narrative for the day; null when generation failed. */
+  summary: z.string().nullable(),
+  /** Version current at the start of the day; null for the first-ever summary. */
+  fromVersionId: z.string().nullable(),
+  /** Last version of the day. */
+  toVersionId: z.string(),
+  items: z.array(memoryActivityItemSchema),
+});
+
+/**
+ * Precomputed daily Memory Activity timeline for the current user, ordered
+ * most-recent-day first. Each entry is a per-local-day net summary of memory
+ * changes with inline before/after evidence — served as a pure DB read.
+ */
+export const memoryActivityResponseSchema = z.object({
+  entries: z.array(memoryActivityEntrySchema),
+});
+
+export type MemoryActivityResponse = z.infer<
+  typeof memoryActivityResponseSchema
+>;
+
+/**
+ * Zero memory activity contract for /api/zero/memory/activity
+ *
+ * GET: Read the current user's precomputed daily memory-change summaries.
+ */
+export const zeroMemoryActivityContract = c.router({
+  get: {
+    method: "GET",
+    path: "/api/zero/memory/activity",
+    headers: authHeadersSchema,
+    responses: {
+      200: memoryActivityResponseSchema,
+      401: apiErrorSchema,
+      500: apiErrorSchema,
+    },
+    summary: "Get the current user's daily memory-change summaries",
+  },
+});
+
+export type ZeroMemoryActivityContract = typeof zeroMemoryActivityContract;


### PR DESCRIPTION
## Summary

Adds `GET /api/zero/memory/activity` — a **pure DB read** that serves the precomputed daily Memory Activity timeline to the frontend. This is PR-C of the Memory Activity feature: it reads the `memory_change_summaries` / `memory_change_items` tables (DB foundation already merged to main) and never touches S3. The cron/generation pipeline and the UI are separate PRs.

## Changes

- **Contract** `packages/api-contracts/src/contracts/zero-memory-activity.ts` — `GET /api/zero/memory/activity`, `authHeadersSchema`, responses `{ 200, 401, 500 }`. 200 body is `{ entries: Array<{ date, summary, fromVersionId, toVersionId, items: Array<{ kind, title, description, filePath, beforeSnippet, afterSnippet }> }> }`, ordered most-recent-day first.
- **Service** `apps/api/src/signals/services/zero-memory-activity.service.ts` — `zeroMemoryActivity(orgId, userId)` (ccstate `computed`): selects summaries for the org+user ordered by `date DESC`, batch-loads their items, and assembles the nested `entries` shape. Pure DB read.
- **Route** `apps/api/src/signals/routes/zero-memory-activity.ts` — mirrors `zero-memory.ts`: `authRoute` with `requireOrganization` (401 on missing org), reads `organizationAuthContext$`. Registered in `route.ts`.
- **Web compatibility** — added the `/api/zero/memory/activity` rewrite to `apps/web/api-backend-rewrites.js` (mirrors the existing `/api/zero/memory` entry) so the `web-api-compatibility` test passes.
- **Tests** `apps/api/src/signals/routes/__tests__/zero-memory-activity.test.ts` — seeds summaries + items via the real DB; asserts 200 shape and most-recent-first ordering, empty timeline, an entry with no items, 401 unauthenticated / no-org, and strict scoping to the authenticated user+org (no leakage across users or orgs). Added a `seedMemoryActivitySummary$` helper and extended `deleteMemoryForFixture$` cleanup in the shared `helpers/zero-memory.ts`.

## Verification

- `pnpm check-types`, `pnpm turbo run lint`, `pnpm format`, `pnpm knip` all clean.
- New activity test (6 cases) + `web-api-compatibility` test pass.

Part of #15977 (Memory Activity, PR-C: read API)

🤖 Generated with [Claude Code](https://claude.com/claude-code)