### PR TITLE
fix: count final X NDJSON stream line

### DIFF
--- a/crates/runner/mitm-addon/src/mitm_addon.py
+++ b/crates/runner/mitm-addon/src/mitm_addon.py
@@ -824,6 +824,7 @@ def error(flow: http.HTTPFlow) -> None:
     # non-streaming JSON errors: partial bodies could otherwise be treated
     # as unparseable successes and billed from request-side hints.
     if flow.metadata.get(metadata_keys.X_NDJSON_STATE) is not None:
+        response_streaming.finalize_connector_response_state(flow)
         usage.report_connector_usage(flow, run_id)
 
     safe_url = network_log_sanitization.sanitize_url_for_network_log(original_url)

--- a/crates/runner/mitm-addon/src/response_streaming.py
+++ b/crates/runner/mitm-addon/src/response_streaming.py
@@ -280,10 +280,11 @@ def feed_model_websocket_usage(flow: http.HTTPFlow, content: bytes | str) -> Non
 def finalize_connector_response_state(flow: http.HTTPFlow) -> None:
     """Finalize connector response parser state before connector usage reporting.
 
-    Called from ``response()`` before ``usage.report_connector_usage()``. Pops
-    ``_CONNECTOR_RESPONSE_FINISH``, so repeated calls after the first are
-    no-ops. Connector-specific parser state is owned by the registered finish
-    callback, for example X JSON or NDJSON usage metadata.
+    Called from ``response()`` before ``usage.report_connector_usage()`` and
+    from selected connector error paths that explicitly keep partial streamed
+    usage. Pops ``_CONNECTOR_RESPONSE_FINISH``, so repeated calls after the
+    first are no-ops. Connector-specific parser state is owned by the
+    registered finish callback, for example X JSON or NDJSON usage metadata.
     """
     finish = flow.metadata.pop(_CONNECTOR_RESPONSE_FINISH, None)
     if finish is not None:

--- a/crates/runner/mitm-addon/src/usage/providers/connectors/x.py
+++ b/crates/runner/mitm-addon/src/usage/providers/connectors/x.py
@@ -139,9 +139,8 @@ def _parse_x_json_response_fields_from_body(body: bytes) -> dict | None:
 class _NdjsonState(TypedDict):
     """Accumulated parser state for an X NDJSON stream.
 
-    Populated by :func:`_create_ndjson_extractor`'s ``parse_chunk`` and
-    read by :func:`_parse_response_metadata` when emitting the billing
-    log entry.
+    Populated by :class:`_NdjsonExtractor` and read by
+    :func:`_parse_response_metadata` when emitting the billing log entry.
     """
 
     data_count: int
@@ -154,8 +153,8 @@ class _NdjsonState(TypedDict):
     """Lines that failed JSON decoding or exceeded the single-line safety cap."""
 
 
-def _create_ndjson_extractor() -> tuple[Callable[[bytes], None], _NdjsonState]:
-    """Create an incremental NDJSON parser for X v2 streaming responses.
+class _NdjsonExtractor:
+    """Incremental NDJSON parser for X v2 streaming responses.
 
     X v2 streaming endpoints deliver one JSON object per line separated by
     ``\\n`` (or ``\\r\\n``), with blank lines as keep-alives.  Each tweet
@@ -163,9 +162,8 @@ def _create_ndjson_extractor() -> tuple[Callable[[bytes], None], _NdjsonState]:
 
         {"data": {...tweet...}, "includes": {...}, "matching_rules": [...]}
 
-    Returns ``(parse_chunk, state)`` where *parse_chunk* processes raw
-    response bytes incrementally (so we never buffer the full body) and
-    *state* is a dict that accumulates:
+    ``feed`` processes raw response bytes incrementally so we never buffer the
+    full body. ``state`` is a dict that accumulates:
 
     - ``data_count``: int — number of lines whose top-level ``data`` is a
       dict (one tweet per line).  Lines whose ``data`` is an array or
@@ -179,76 +177,89 @@ def _create_ndjson_extractor() -> tuple[Callable[[bytes], None], _NdjsonState]:
     The parser keeps a ``line_buf`` holding the in-flight partial line
     across chunk boundaries.  If a single line ever exceeds
     :data:`_MAX_NDJSON_LINE_BYTES` the whole line is discarded until its
-    terminating newline (malformed / hostile upstream).  A truncated
-    trailing line at connection close (no final ``\\n``) stays in the buffer
-    uncounted — worst-case under-count is 1.
+    terminating newline (malformed / hostile upstream). ``finish`` finalizes a
+    complete trailing line that arrived without a final ``\\n`` and treats
+    malformed or incomplete trailing data as a failed, unbilled line.
     """
-    state: _NdjsonState = {
-        "data_count": 0,
-        "includes": {},
-        "lines_parsed": 0,
-        "lines_failed": 0,
-    }
-    # Mutate in-place (``line_buf[:] = ...``, ``extend(...)``) throughout
-    # ``parse_chunk`` — captured by the closure.  Rebinding via
-    # ``line_buf = ...`` would create a new local and lose cross-call state.
-    line_buf = bytearray()
-    discarding_overlong_line = False
 
-    def parse_chunk(chunk: bytes) -> None:
-        nonlocal discarding_overlong_line
+    def __init__(self) -> None:
+        self.state: _NdjsonState = {
+            "data_count": 0,
+            "includes": {},
+            "lines_parsed": 0,
+            "lines_failed": 0,
+        }
+        self._line_buf = bytearray()
+        self._discarding_overlong_line = False
+        self._finished = False
 
+    def feed(self, chunk: bytes) -> None:
+        """Process one decoded response-body chunk."""
         start = 0
         while start < len(chunk):
             newline = chunk.find(b"\n", start)
             end = len(chunk) if newline == -1 else newline
             fragment_len = end - start
 
-            if discarding_overlong_line:
+            if self._discarding_overlong_line:
                 if newline == -1:
                     return
-                discarding_overlong_line = False
+                self._discarding_overlong_line = False
                 start = newline + 1
                 continue
 
-            if len(line_buf) + fragment_len > _MAX_NDJSON_LINE_BYTES:
-                line_buf[:] = b""
-                state["lines_failed"] += 1
+            if len(self._line_buf) + fragment_len > _MAX_NDJSON_LINE_BYTES:
+                self._line_buf.clear()
+                self.state["lines_failed"] += 1
                 if newline == -1:
-                    discarding_overlong_line = True
+                    self._discarding_overlong_line = True
                     return
                 start = newline + 1
                 continue
 
-            line_buf.extend(chunk[start:end])
+            self._line_buf.extend(chunk[start:end])
             if newline == -1:
                 return
 
-            line = bytes(line_buf).rstrip(b"\r")
-            line_buf[:] = b""
-            if not line:
-                start = newline + 1
-                continue  # keep-alive blank line
-            try:
-                obj = json.loads(line)
-            except (json.JSONDecodeError, UnicodeDecodeError):
-                state["lines_failed"] += 1
-                start = newline + 1
-                continue
-            state["lines_parsed"] += 1
-            if not isinstance(obj, dict):
-                start = newline + 1
-                continue
-            if isinstance(obj.get("data"), dict):
-                state["data_count"] += 1
-            inc = obj.get("includes")
-            if isinstance(inc, dict):
-                for k, v in inc.items():
-                    if isinstance(v, list):
-                        state["includes"][k] = state["includes"].get(k, 0) + len(v)
+            line = bytes(self._line_buf)
+            self._line_buf.clear()
+            self._parse_line(line)
             start = newline + 1
 
-    return parse_chunk, state
+    def finish(self) -> None:
+        """Finalize a complete trailing line that was not newline-terminated."""
+        if self._finished:
+            return
+        self._finished = True
+        if self._discarding_overlong_line:
+            self._line_buf.clear()
+            self._discarding_overlong_line = False
+            return
+        if not self._line_buf:
+            return
+        line = bytes(self._line_buf)
+        self._line_buf.clear()
+        self._parse_line(line)
+
+    def _parse_line(self, raw_line: bytes) -> None:
+        line = raw_line.rstrip(b"\r")
+        if not line:
+            return  # keep-alive blank line
+        try:
+            obj = json.loads(line)
+        except (json.JSONDecodeError, UnicodeDecodeError):
+            self.state["lines_failed"] += 1
+            return
+        self.state["lines_parsed"] += 1
+        if not isinstance(obj, dict):
+            return
+        if isinstance(obj.get("data"), dict):
+            self.state["data_count"] += 1
+        inc = obj.get("includes")
+        if isinstance(inc, dict):
+            for k, v in inc.items():
+                if isinstance(v, list):
+                    self.state["includes"][k] = self.state["includes"].get(k, 0) + len(v)
 
 
 class _XJsonResponseExtractor:
@@ -287,12 +298,12 @@ def create_response_parser(flow: http.HTTPFlow) -> ConnectorResponseParser | Non
         # before ``responseheaders`` fires.
         stream_path = urllib.parse.urlparse(flow.metadata.get(metadata_keys.ORIGINAL_URL, "")).path
         if _is_stream_path(stream_path):
-            parser_fn, ndjson_state = _create_ndjson_extractor()
+            extractor = _NdjsonExtractor()
             # Deliberately NOT "model_provider_usage" — that key routes through
             # report_model_provider_usage and triggers the model-provider webhook.
             # x_ndjson_state is only consumed by report_connector_usage.
-            flow.metadata[metadata_keys.X_NDJSON_STATE] = ndjson_state
-            return ConnectorResponseParser(feed=parser_fn)
+            flow.metadata[metadata_keys.X_NDJSON_STATE] = extractor.state
+            return ConnectorResponseParser(feed=extractor.feed, finish=extractor.finish)
 
     if not (_HTTP_STATUS_OK_MIN <= status_code < _HTTP_STATUS_REDIRECT_MIN):
         return None

--- a/crates/runner/mitm-addon/tests/test_connector_usage.py
+++ b/crates/runner/mitm-addon/tests/test_connector_usage.py
@@ -45,7 +45,7 @@ class TestXStreamPathRouting:
         mitm_addon.responseheaders(flow)
 
         assert "x_ndjson_state" in flow.metadata
-        assert "connector_response_finish" not in flow.metadata
+        assert "connector_response_finish" in flow.metadata
 
     @pytest.mark.parametrize(
         "path",
@@ -1588,7 +1588,7 @@ class TestReportConnectorUsage:
         mitm_addon.responseheaders(flow)
         callback = response_stream(flow)
         assert "x_ndjson_state" in flow.metadata
-        assert "connector_response_finish" not in flow.metadata
+        assert "connector_response_finish" in flow.metadata
 
         # 2. Stream chunks (including keep-alives and a mid-line split)
         chunks = [
@@ -1615,6 +1615,40 @@ class TestReportConnectorUsage:
         # 3 users from includes
         assert by_cat["user.read"] == 3
 
+    def test_full_streaming_pipeline_counts_final_line_without_newline(
+        self, tmp_path, real_flow, mitm_ctx, headers, fresh_usage_executor
+    ):
+        """End-to-end: response() finalizes a complete NDJSON row without trailing newline."""
+        flow = real_flow(with_response=False, host="api.x.com", path="/2/tweets/search/stream")
+        flow.metadata["vm_run_id"] = "run-abc-123"
+        flow.metadata["vm_network_log_path"] = str(tmp_path / "network.jsonl")
+        flow.metadata["vm_proxy_log_path"] = str(tmp_path / "proxy.jsonl")
+        flow.metadata["vm_sandbox_token"] = "test-token"
+        flow.metadata["firewall_action"] = "ALLOW"
+        flow.metadata["original_url"] = "https://api.x.com/2/tweets/search/stream"
+        flow.metadata["firewall_name"] = "x"
+        flow.metadata["firewall_billable"] = True
+        flow.metadata["firewall_permission"] = "tweet.read"
+        flow.metadata["firewall_rule_match"] = "GET /2/tweets/search/stream"
+        flow.response = tutils.tresp(status_code=200)
+        flow.response.headers = header_map({"content-type": "application/json"})
+        flow.response.stream = False
+
+        mitm_addon.responseheaders(flow)
+        callback = response_stream(flow)
+        callback(b'{"data":{"id":"1"}}\n')
+        callback(b'{"data":{"id":"2"},"includes":{"users":[{"id":"u2"}]}}')
+
+        with self._usage_webhook_api() as webhook:
+            mitm_addon.response(flow)
+            usage.flush_usage_events(trigger="test")
+            usage.webhook.usage_executor.shutdown(wait=True)
+
+        payloads = webhook.usage_events()
+        by_cat = {payload["category"]: payload["quantity"] for payload in payloads}
+        assert by_cat == {"posts.read": 2, "user.read": 1}
+        assert "connector_response_finish" not in flow.metadata
+
     def test_full_streaming_pipeline_ignores_malformed_include_values(
         self, tmp_path, real_flow, mitm_ctx, headers, fresh_usage_executor
     ):
@@ -1637,7 +1671,7 @@ class TestReportConnectorUsage:
         mitm_addon.responseheaders(flow)
         callback = response_stream(flow)
         assert "x_ndjson_state" in flow.metadata
-        assert "connector_response_finish" not in flow.metadata
+        assert "connector_response_finish" in flow.metadata
 
         callback(
             b'{"data":{"id":"1"},"includes":'

--- a/crates/runner/mitm-addon/tests/test_error_handler.py
+++ b/crates/runner/mitm-addon/tests/test_error_handler.py
@@ -333,6 +333,43 @@ class TestErrorHandler:
         assert by_cat["posts.read"] == 2  # not 3 — partial trailing dropped
         assert by_cat["user.read"] == 1
 
+    def test_full_pipeline_stream_error_counts_complete_final_line_without_newline(
+        self, tmp_path, real_flow, mitm_ctx, headers, fresh_usage_executor, usage_webhook_api
+    ):
+        """Connection error finalizes a complete NDJSON row without trailing newline."""
+        flow = real_flow(with_response=False, host="api.x.com", path="/2/tweets/search/stream")
+        log_path = str(tmp_path / "network.jsonl")
+        proxy_log = tmp_path / "proxy.jsonl"
+        flow.metadata["vm_run_id"] = "run-abc-123"
+        flow.metadata["vm_network_log_path"] = log_path
+        flow.metadata["vm_proxy_log_path"] = str(proxy_log)
+        flow.metadata["original_url"] = "https://api.x.com/2/tweets/search/stream"
+        flow.metadata["firewall_action"] = "ALLOW"
+        flow.metadata["firewall_name"] = "x"
+        flow.metadata["firewall_billable"] = True
+        flow.metadata["firewall_permission"] = "tweet.read"
+        flow.metadata["firewall_rule_match"] = "GET /2/tweets/search/stream"
+        flow.response = tutils.tresp(
+            status_code=200, headers=header_map({"content-type": "application/json"})
+        )
+
+        mitm_addon.responseheaders(flow)
+        callback = response_stream(flow)
+        callback(b'{"data":{"id":"1"}}\n')
+        callback(b'{"data":{"id":"2"},"includes":{"users":[{"id":"u2"}]}}')
+        flow.error = Error("connection reset by peer")
+        flow.metadata["vm_sandbox_token"] = "test-token"
+
+        with usage_webhook_api() as webhook:
+            mitm_addon.error(flow)
+            usage.flush_usage_events(trigger="test")
+            usage.webhook.usage_executor.shutdown(wait=True)
+
+        payloads = webhook.usage_events()
+        by_cat = {payload["category"]: payload["quantity"] for payload in payloads}
+        assert by_cat == {"posts.read": 2, "user.read": 1}
+        assert "connector_response_finish" not in flow.metadata
+
     def test_full_path_error_to_webhook(
         self, tmp_path, real_flow, mitm_ctx, fresh_usage_executor, usage_webhook_api
     ):

--- a/crates/runner/mitm-addon/tests/test_response_headers_handler.py
+++ b/crates/runner/mitm-addon/tests/test_response_headers_handler.py
@@ -169,6 +169,7 @@ class TestResponseHeadersHandler:
         mitm_addon.responseheaders(flow)
 
         assert "x_ndjson_state" in flow.metadata
+        assert "connector_response_finish" in flow.metadata
         callback = response_stream(flow)
         callback(b'{"data":{"id":"1"},"includes":{"users":[{"id":"u1"}]}}\n')
         callback(b'{"data":{"id":"2"},"includes":{"users":[{"id":"u2"}]}}\n')
@@ -195,6 +196,7 @@ class TestResponseHeadersHandler:
         assert len(flow.metadata["stream_buffer"]) <= body_utils.STREAM_BUFFER_LIMIT
         assert flow.metadata["stream_buffer_state"]["truncated"] is True
         assert flow.metadata["x_ndjson_state"]["data_count"] == 1
+        assert "connector_response_finish" in flow.metadata
 
     def test_x_non_stream_endpoint_uses_bounded_buffer_and_json_extractor(self, real_flow, headers):
         """Non-stream X requests parse billing JSON without unbounded buffering."""
@@ -297,6 +299,7 @@ class TestResponseHeadersHandler:
         state = flow.metadata["x_ndjson_state"]
         assert state["data_count"] == 3
         assert state["includes"] == {"users": 3}
+        assert "connector_response_finish" in flow.metadata
 
     def test_model_provider_gzip_json_extractor(self, real_flow, headers):
         """Gzip-encoded non-streaming model JSON feeds the selective extractor."""

--- a/crates/runner/mitm-addon/tests/test_response_streaming.py
+++ b/crates/runner/mitm-addon/tests/test_response_streaming.py
@@ -16,7 +16,7 @@ _OVERSIZED_NDJSON_LINE_BYTES = body_utils.LARGE_RESPONSE_DECOMPRESS_LIMIT + 1024
 class TestNdjsonExtractor:
     """Tests for X NDJSON extraction through responseheaders (issue #9534)."""
 
-    def _stream_parser(self, real_flow):
+    def _stream_flow(self, real_flow):
         flow = real_flow(with_response=False, host="api.x.com", path="/2/tweets/search/stream")
         flow.metadata["firewall_name"] = "x"
         flow.metadata["firewall_billable"] = True
@@ -28,6 +28,10 @@ class TestNdjsonExtractor:
 
         mitm_addon.responseheaders(flow)
 
+        return flow
+
+    def _stream_parser(self, real_flow):
+        flow = self._stream_flow(real_flow)
         return response_stream(flow), flow.metadata["x_ndjson_state"]
 
     def test_single_line(self, real_flow):
@@ -100,6 +104,71 @@ class TestNdjsonExtractor:
         parse(b'{"data":{"id":"1"}}\n{"data":{"id":"2"}')  # no trailing \n
         assert state["data_count"] == 1
         assert state["lines_parsed"] == 1
+
+    def test_complete_trailing_line_without_newline_counted_on_finish(self, real_flow):
+        flow = self._stream_flow(real_flow)
+        parse = response_stream(flow)
+        state = flow.metadata["x_ndjson_state"]
+
+        parse(b'{"data":{"id":"1"},"includes":{"users":[{"id":"u1"}]}}')
+        response_streaming.finalize_connector_response_state(flow)
+
+        assert state["data_count"] == 1
+        assert state["includes"] == {"users": 1}
+        assert state["lines_parsed"] == 1
+        assert state["lines_failed"] == 0
+
+    def test_incomplete_trailing_line_without_newline_fails_on_finish(self, real_flow):
+        flow = self._stream_flow(real_flow)
+        parse = response_stream(flow)
+        state = flow.metadata["x_ndjson_state"]
+
+        parse(b'{"data":{"id":"1"}}\n{"data":{"id":"2"}')
+        response_streaming.finalize_connector_response_state(flow)
+
+        assert state["data_count"] == 1
+        assert state["lines_parsed"] == 1
+        assert state["lines_failed"] == 1
+
+    @pytest.mark.parametrize("tail", [b"", b"\r", b"\r\r"])
+    def test_blank_trailing_line_ignored_on_finish(self, real_flow, tail):
+        flow = self._stream_flow(real_flow)
+        parse = response_stream(flow)
+        state = flow.metadata["x_ndjson_state"]
+
+        parse(b'{"data":{"id":"1"}}\n' + tail)
+        response_streaming.finalize_connector_response_state(flow)
+
+        assert state["data_count"] == 1
+        assert state["lines_parsed"] == 1
+        assert state["lines_failed"] == 0
+
+    def test_trailing_line_finish_is_idempotent(self, real_flow):
+        flow = self._stream_flow(real_flow)
+        parse = response_stream(flow)
+        state = flow.metadata["x_ndjson_state"]
+
+        parse(b'{"data":{"id":"1"}}')
+        response_streaming.finalize_connector_response_state(flow)
+        finalized = dict(state)
+        finalized["includes"] = dict(state["includes"])
+        response_streaming.finalize_connector_response_state(flow)
+
+        assert state == finalized
+
+    def test_oversized_line_tail_not_counted_on_finish(self, real_flow):
+        flow = self._stream_flow(real_flow)
+        parse = response_stream(flow)
+        state = flow.metadata["x_ndjson_state"]
+        big = b"x" * _OVERSIZED_NDJSON_LINE_BYTES
+
+        parse(big)
+        parse(b'{"data":{"id":"tail"}}')
+        response_streaming.finalize_connector_response_state(flow)
+
+        assert state["data_count"] == 0
+        assert state["lines_parsed"] == 0
+        assert state["lines_failed"] == 1
 
     def test_empty_chunks_safe(self, real_flow):
         parse, state = self._stream_parser(real_flow)
@@ -523,6 +592,18 @@ class TestReleaseResponseStreamState:
                 },
                 "connector_response_finish",
                 id="x-json",
+            ),
+            pytest.param(
+                "api.x.com",
+                "/2/tweets/search/stream",
+                "application/json",
+                {
+                    "firewall_name": "x",
+                    "firewall_billable": True,
+                    "original_url": "https://api.x.com/2/tweets/search/stream",
+                },
+                "connector_response_finish",
+                id="x-ndjson",
             ),
         ],
     )


### PR DESCRIPTION
## Summary

- Refactor the X NDJSON stream parser into an explicit extractor with idempotent finalization.
- Count a complete final NDJSON row when a stream ends without a trailing newline.
- Finalize X NDJSON state on the conservative X-only error path without broadening generic connector error finalization.
- Add regression coverage for normal response, connection error, incomplete tails, blank tails, idempotency, and overlong-line tails.

Fixes #15933.

## Tests

- `python3 -m pytest tests/test_response_streaming.py tests/test_connector_usage.py tests/test_error_handler.py tests/test_response_headers_handler.py -q`
- `ruff check . && ruff format --check . && basedpyright -p .`
- `python3 -m pytest tests/ -q`
