### PR TITLE
fix(mitm-addon): sanitize proxy log url fields

### DIFF
--- a/crates/runner/mitm-addon/src/logging_utils.py
+++ b/crates/runner/mitm-addon/src/logging_utils.py
@@ -12,6 +12,7 @@ from datetime import datetime, timezone
 from mitmproxy import ctx, http
 
 import flow_metadata_keys as metadata_keys
+import network_log_sanitization
 
 _PROXY_LOG_RESERVED_FIELDS = {"timestamp", "level", "message"}
 
@@ -48,6 +49,12 @@ def log_network_entry(log_path: str, entry: dict) -> None:
     _write_jsonl_entry(log_path, log_entry, "network")
 
 
+def _proxy_log_extra_value(key: str, value: object) -> object:
+    if key == "url" and isinstance(value, str):
+        return network_log_sanitization.sanitize_url_for_network_log(value)
+    return value
+
+
 def log_proxy_entry(
     proxy_log_path: str,
     log_level: str,
@@ -63,7 +70,7 @@ def log_proxy_entry(
     }
     for key, value in extra.items():
         if key not in _PROXY_LOG_RESERVED_FIELDS:
-            entry[key] = value
+            entry[key] = _proxy_log_extra_value(key, value)
     _write_jsonl_entry(proxy_log_path, entry, "proxy")
 
 

--- a/crates/runner/mitm-addon/src/usage/providers/connectors/x.py
+++ b/crates/runner/mitm-addon/src/usage/providers/connectors/x.py
@@ -588,6 +588,9 @@ def report_usage(flow: http.HTTPFlow, run_id: str) -> None:
     req_meta = _parse_request_metadata(flow)
     resp_meta = _parse_response_metadata(flow)
     proxy_log_path = flow.metadata.get(metadata_keys.VM_PROXY_LOG_PATH, "")
+    audit_url = flow.metadata.get(metadata_keys.ORIGINAL_URL)
+    if not isinstance(audit_url, str) or not audit_url:
+        audit_url = flow.request.url
 
     # Structured context common to every billing-side proxy log entry
     # for this flow — threaded into the helper so the log firing at the
@@ -598,7 +601,7 @@ def report_usage(flow: http.HTTPFlow, run_id: str) -> None:
         "firewall_name": firewall_name,
         "permission": permission,
         "method": flow.request.method,
-        "url": flow.request.url,
+        "url": audit_url,
     }
 
     def _log_warn(message: str, extra: dict) -> None:

--- a/crates/runner/mitm-addon/tests/test_connector_usage.py
+++ b/crates/runner/mitm-addon/tests/test_connector_usage.py
@@ -352,6 +352,7 @@ class TestReportConnectorUsage:
         """Unknown includes.<key> types emit a synthetic ``includes.<key>``
         category (the billing processor applies a server-side fallback
         price) and emit a warn log at the decision point."""
+        sensitive_query = "vm0-sensitive-unknown-includes"
         body = json.dumps(
             {
                 "data": [{"id": "1"}],
@@ -361,7 +362,12 @@ class TestReportConnectorUsage:
                 },
             }
         ).encode()
-        flow = self._make_x_flow(real_flow, tmp_path, query="expansions=author_id", body=body)
+        flow = self._make_x_flow(
+            real_flow,
+            tmp_path,
+            path=f"/2/tweets?expansions=author_id&query={sensitive_query}",
+            body=body,
+        )
         payloads = self._call_and_get_billing(flow)
         by_cat = {p["category"]: p["quantity"] for p in payloads}
         # 1 primary (posts.read) + 1 users include (mapped to user.read)
@@ -377,6 +383,9 @@ class TestReportConnectorUsage:
         assert "future_widget" in content
         assert "unrecognised" in content.lower()
         assert '"level":"warn"' in content or '"level": "warn"' in content
+        assert sensitive_query not in content
+        entry = json.loads(content.splitlines()[0])
+        assert entry["url"] == "https://api.x.com/2/tweets"
 
     def test_logs_search_meta_result_count(self, tmp_path, real_flow):
         """Search response with meta.result_count -> quantity=20."""
@@ -1266,20 +1275,27 @@ class TestReportConnectorUsage:
     def test_unparseable_no_hints_writes_error_to_proxy_log(self, tmp_path, real_flow):
         """Operators must be able to audit the lost-visibility case —
         the proxy log receives a structured error entry."""
+        sensitive_query = "vm0-sensitive-unparseable"
         flow = self._make_x_flow(
             real_flow,
             tmp_path,
-            path="/2/tweets/search/recent",
+            path=f"/2/tweets/search/recent?query={sensitive_query}",
             body=b"not json",
             rule="GET /2/tweets/search/recent",
+        )
+        flow.metadata["original_url"] = (
+            f"https://api.x.com:8443/2/tweets/search/recent?query={sensitive_query}"
         )
         proxy_log = tmp_path / "proxy.jsonl"
         assert self._call_and_get_billing(flow) == []
         assert proxy_log.exists()
-        entry = json.loads(proxy_log.read_text().splitlines()[0])
+        content = proxy_log.read_text()
+        assert sensitive_query not in content
+        entry = json.loads(content.splitlines()[0])
         assert entry["level"] == "error"
         assert "unparseable" in entry["message"].lower()
         assert entry["permission"] == "tweet.read"
+        assert entry["url"] == "https://api.x.com:8443/2/tweets/search/recent"
         assert "parse_error" not in entry
 
     def test_unparseable_x_json_state_logs_parse_error(self, tmp_path, real_flow):

--- a/crates/runner/mitm-addon/tests/test_connector_usage.py
+++ b/crates/runner/mitm-addon/tests/test_connector_usage.py
@@ -384,7 +384,14 @@ class TestReportConnectorUsage:
         assert "unrecognised" in content.lower()
         assert '"level":"warn"' in content or '"level": "warn"' in content
         assert sensitive_query not in content
-        entry = json.loads(content.splitlines()[0])
+        entries = [json.loads(line) for line in content.splitlines()]
+        matching_entries = [
+            entry
+            for entry in entries
+            if entry.get("level") == "warn" and "unrecognised" in entry.get("message", "").lower()
+        ]
+        assert len(matching_entries) == 1
+        entry = matching_entries[0]
         assert entry["url"] == "https://api.x.com/2/tweets"
 
     def test_logs_search_meta_result_count(self, tmp_path, real_flow):
@@ -1291,7 +1298,14 @@ class TestReportConnectorUsage:
         assert proxy_log.exists()
         content = proxy_log.read_text()
         assert sensitive_query not in content
-        entry = json.loads(content.splitlines()[0])
+        entries = [json.loads(line) for line in content.splitlines()]
+        matching_entries = [
+            entry
+            for entry in entries
+            if entry.get("level") == "error" and "unparseable" in entry.get("message", "").lower()
+        ]
+        assert len(matching_entries) == 1
+        entry = matching_entries[0]
         assert entry["level"] == "error"
         assert "unparseable" in entry["message"].lower()
         assert entry["permission"] == "tweet.read"

--- a/crates/runner/mitm-addon/tests/test_utils.py
+++ b/crates/runner/mitm-addon/tests/test_utils.py
@@ -114,6 +114,23 @@ class TestLogProxyEntry:
         assert entry["extra_field"] == "value"
         assert_utc_millisecond_timestamp(entry["timestamp"])
 
+    def test_sanitizes_structured_url_field(self, tmp_path):
+        proxy_path = tmp_path / "proxy-test.jsonl"
+        raw_url = "https://user:pass@example.com/v1/search?token=secret#fragment"
+
+        logging_utils.log_proxy_entry(
+            str(proxy_path),
+            "warn",
+            "url diagnostic",
+            url=raw_url,
+            raw_url_copy=raw_url,
+        )
+
+        entry = json.loads(proxy_path.read_text().strip())
+        assert entry["message"] == "url diagnostic"
+        assert entry["url"] == "https://example.com/v1/search"
+        assert entry["raw_url_copy"] == raw_url
+
     def test_appends_multiple_entries(self, tmp_path):
         proxy_path = str(tmp_path / "proxy-test.jsonl")
         logging_utils.log_proxy_entry(proxy_path, "info", "first")


### PR DESCRIPTION
## Summary

- sanitize structured proxy-log `url` fields at the `log_proxy_entry` boundary
- make X connector usage diagnostics prefer `original_url` metadata for audit context
- add regressions for logger URL sanitization and X connector warning/error proxy logs

Closes #15934

## Testing

- `/tmp/mitm-addon-venv/bin/python -m pytest tests/test_utils.py::TestLogProxyEntry::test_sanitizes_structured_url_field tests/test_connector_usage.py::TestReportConnectorUsage::test_handles_unknown_includes_key tests/test_connector_usage.py::TestReportConnectorUsage::test_unparseable_no_hints_writes_error_to_proxy_log -q`
- `/tmp/mitm-addon-venv/bin/python -m pytest tests/test_utils.py::TestLogProxyEntry tests/test_connector_usage.py::TestReportConnectorUsage -q`
- `/tmp/mitm-addon-venv/bin/python -m pytest tests/test_utils.py tests/test_connector_usage.py -q`
- `/tmp/mitm-addon-venv/bin/ruff check .`
- `/tmp/mitm-addon-venv/bin/ruff format --check .`
- `/tmp/mitm-addon-venv/bin/basedpyright -p . --pythonpath /tmp/mitm-addon-venv/bin/python`
