### PR TITLE
feat: route platform model-provider config reads to api backend

### DIFF
--- a/turbo/apps/platform/src/signals/__tests__/api-client.test.ts
+++ b/turbo/apps/platform/src/signals/__tests__/api-client.test.ts
@@ -10,6 +10,8 @@ import { onboardingStatusContract } from "@vm0/api-contracts/contracts/onboardin
 import { zeroVoiceIoQuotaContract } from "@vm0/api-contracts/contracts/zero-voice-io-quota";
 import { zeroSchedulesMainContract } from "@vm0/api-contracts/contracts/zero-schedules";
 import { zeroConnectorsMainContract } from "@vm0/api-contracts/contracts/zero-connectors";
+import { zeroPersonalModelProvidersMainContract } from "@vm0/api-contracts/contracts/zero-personal-model-providers";
+import { zeroModelProvidersMainContract } from "@vm0/api-contracts/contracts/zero-model-providers";
 import { testContext } from "./test-helpers.ts";
 import { detachedSetupPage } from "../../__tests__/page-helper.ts";
 import { mockedClerk } from "../../__tests__/mock-auth.ts";
@@ -531,6 +533,57 @@ describe("zeroClient$ apiBackend routing", () => {
 
     const createClient = context.store.get(zeroClient$);
     const client = createClient(zeroSchedulesMainContract);
+    const result = await client.list();
+
+    expect(result.status).toBe(200);
+    expect(requestHosts).toStrictEqual(["api.vm0.ai"]);
+  });
+
+  it("routes policy allowlisted personal model providers contract requests to api host when apiBackend is off", async () => {
+    vi.stubGlobal("location", new URL("https://platform.vm0.ai/"));
+    detachedSetupPage({
+      context,
+      path: "/",
+      withoutRender: true,
+    });
+
+    const requestHosts: string[] = [];
+    server.use(
+      mockApi(
+        zeroPersonalModelProvidersMainContract.list,
+        ({ request, respond }) => {
+          requestHosts.push(new URL(request.url).host);
+          return respond(200, { modelProviders: [] });
+        },
+      ),
+    );
+
+    const createClient = context.store.get(zeroClient$);
+    const client = createClient(zeroPersonalModelProvidersMainContract);
+    const result = await client.list();
+
+    expect(result.status).toBe(200);
+    expect(requestHosts).toStrictEqual(["api.vm0.ai"]);
+  });
+
+  it("routes policy allowlisted org model providers contract requests to api host when apiBackend is off", async () => {
+    vi.stubGlobal("location", new URL("https://platform.vm0.ai/"));
+    detachedSetupPage({
+      context,
+      path: "/",
+      withoutRender: true,
+    });
+
+    const requestHosts: string[] = [];
+    server.use(
+      mockApi(zeroModelProvidersMainContract.list, ({ request, respond }) => {
+        requestHosts.push(new URL(request.url).host);
+        return respond(200, { modelProviders: [] });
+      }),
+    );
+
+    const createClient = context.store.get(zeroClient$);
+    const client = createClient(zeroModelProvidersMainContract);
     const result = await client.list();
 
     expect(result.status).toBe(200);

--- a/turbo/apps/platform/src/signals/api-target-policy.ts
+++ b/turbo/apps/platform/src/signals/api-target-policy.ts
@@ -16,6 +16,16 @@ interface ApiTargetPolicyEntry {
 const API_ROUTE_TARGET_POLICY: readonly ApiTargetPolicyEntry[] = [
   {
     methods: ["GET"],
+    pathname: "/api/zero/me/model-providers",
+    target: "api",
+  },
+  {
+    methods: ["GET"],
+    pathname: "/api/zero/model-providers",
+    target: "api",
+  },
+  {
+    methods: ["GET"],
     pathname: "/api/zero/onboarding/status",
     target: "api",
   },


### PR DESCRIPTION
## Summary
- Third progressive batch of the Platform API backend cutover (#15872), continuing from batch 2 (#15997).
- Allowlist two read-only, first-party model-provider config reads to the `api` host while the global `apiBackend` switch is off:
  - `GET /api/zero/me/model-providers` — `personalModelProviders$` (`zeroPersonalModelProvidersMainContract.list`)
  - `GET /api/zero/model-providers` — `orgModelProviders$` (`zeroModelProvidersMainContract.list`)
- Both are static-path GET reads called through `zeroClient$` with no `apiBase` override; the method-aware policy keeps same-path mutations (`POST`/`DELETE`) on `www`.
- Completes the model-config domain on `api`, alongside the already-`api` `model-policies` and `user-model-preference` call sites (explicit `apiBase: "api"` overrides).

## Why these are safe
- First-party only, read-only, static path (works with the current exact-path matcher).
- No bootstrap dependency: `apiBackendEnabled$` resolves via the www-pinned feature-switch client, so routing these through the policy introduces no cycle.
- Rollback is read-only and code-level: remove the entries and redeploy, or flip `FeatureSwitchKey.ApiBackend`.

## Out of scope (stays on www)
Bootstrap `feature-switches`, OAuth start/callback triad (caller-supplied redirect origin pinned to `VM0_WEB_URL`), external inbound surface (webhooks, OSS/storage callbacks, cron, CLI). `connectors` is retained on `www` as the default-`www` routing test fixture.

## Validation
- `pnpm -F @vm0/app exec vitest run src/signals/__tests__/api-client.test.ts src/signals/__tests__/fetch.test.ts` — 46 passed (2 new routing assertions).
- `pnpm format`, `pnpm -F @vm0/app lint`, `pnpm -F @vm0/app check-types`, `pnpm knip --workspace apps/platform` — clean.

## Post-merge verification
Confirm in `vm0-traces-prod` that `GET /api/zero/me/model-providers` and `GET /api/zero/model-providers` land on `service.name=vm0-api` with no 5xx and no fallback-to-web.

Closes #16003
Part of #15872

🤖 Generated with [Claude Code](https://claude.com/claude-code)
