### PR TITLE
feat(api): add memory activity daily summary cron

### DIFF
--- a/turbo/apps/api/src/__tests__/vercel-crons.test.ts
+++ b/turbo/apps/api/src/__tests__/vercel-crons.test.ts
@@ -10,6 +10,7 @@ import {
   cronExecuteSchedulesContract,
   cronProcessUsageEventsContract,
   cronReconcileBillingEntitlementsContract,
+  cronSummarizeMemoryContract,
   cronSyncSkillsContract,
   cronTelegramCleanupContract,
 } from "@vm0/api-contracts/contracts/cron";
@@ -49,6 +50,10 @@ const expectedVercelCrons = [
   {
     path: cronAggregateInsightsContract.aggregate.path,
     schedule: "0 * * * *",
+  },
+  {
+    path: cronSummarizeMemoryContract.summarize.path,
+    schedule: "30 * * * *",
   },
   {
     path: cronTelegramCleanupContract.cleanup.path,

--- a/turbo/apps/api/src/signals/external/openrouter.ts
+++ b/turbo/apps/api/src/signals/external/openrouter.ts
@@ -1,0 +1,70 @@
+import { optionalEnv } from "../../lib/env";
+import { settle } from "../utils";
+
+const OPENROUTER_CHAT_COMPLETIONS_URL =
+  "https://openrouter.ai/api/v1/chat/completions";
+
+interface OpenRouterMessage {
+  readonly role: "system" | "user" | "assistant";
+  readonly content: string;
+}
+
+interface OpenRouterResponse {
+  readonly choices: readonly {
+    readonly message: {
+      readonly content: string;
+    };
+  }[];
+}
+
+/**
+ * Whether OpenRouter-backed text generation is available. Callers gate optional
+ * LLM enrichment on this so the surrounding feature degrades when the key is
+ * unset (e.g. local dev) instead of throwing.
+ */
+export function isLlmConfigured(): boolean {
+  return Boolean(optionalEnv("OPENROUTER_API_KEY"));
+}
+
+/**
+ * Call OpenRouter chat completions and return the trimmed first-choice text.
+ * Returns `null` when no API key is configured. HTTP/parse failures throw so
+ * the caller can decide how to degrade (typically by wrapping in `settle`).
+ */
+export async function generateText(
+  model: string,
+  messages: readonly OpenRouterMessage[],
+  maxTokens: number,
+): Promise<string | null> {
+  const apiKey = optionalEnv("OPENROUTER_API_KEY");
+  if (!apiKey) {
+    return null;
+  }
+
+  const response = await fetch(OPENROUTER_CHAT_COMPLETIONS_URL, {
+    method: "POST",
+    headers: {
+      Authorization: `Bearer ${apiKey}`,
+      "Content-Type": "application/json",
+    },
+    body: JSON.stringify({
+      model,
+      messages,
+      max_tokens: maxTokens,
+      temperature: 0.3,
+    }),
+  });
+
+  if (!response.ok) {
+    const settled = await settle(response.text());
+    const text = settled.ok ? settled.value : "unknown error";
+    throw new Error(`OpenRouter request failed: ${response.status} ${text}`);
+  }
+
+  const data = (await response.json()) as OpenRouterResponse;
+  const content = data.choices[0]?.message.content.trim();
+  if (!content) {
+    throw new Error("OpenRouter returned empty content");
+  }
+  return content;
+}

--- a/turbo/apps/api/src/signals/route.ts
+++ b/turbo/apps/api/src/signals/route.ts
@@ -26,6 +26,7 @@ import { cronExecuteSchedulesRoutes } from "./routes/cron-execute-schedules";
 import { cronProcessUsageEventsRoutes } from "./routes/cron-process-usage-events";
 import { cronReconcileBillingEntitlementsRoutes } from "./routes/cron-reconcile-billing-entitlements";
 import { cronComputerUseScreenshotCleanupRoutes } from "./routes/cron-computer-use-screenshot-cleanup";
+import { cronSummarizeMemoryRoutes } from "./routes/cron-summarize-memory";
 import { cronSyncSkillsRoutes } from "./routes/cron-sync-skills";
 import { cronTelegramCleanupRoutes } from "./routes/cron-telegram-cleanup";
 import { deviceTokenRoutes } from "./routes/device-token";
@@ -237,6 +238,7 @@ export const ROUTES: readonly RouteEntry[] = [
   ...cronProcessUsageEventsRoutes,
   ...cronReconcileBillingEntitlementsRoutes,
   ...cronComputerUseScreenshotCleanupRoutes,
+  ...cronSummarizeMemoryRoutes,
   ...cronSyncSkillsRoutes,
   ...cronTelegramCleanupRoutes,
   ...deviceTokenRoutes,

--- a/turbo/apps/api/src/signals/routes/__tests__/cron-summarize-memory.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/cron-summarize-memory.test.ts
@@ -1,0 +1,351 @@
+import { randomUUID } from "node:crypto";
+
+import { cronSummarizeMemoryContract } from "@vm0/api-contracts/contracts/cron";
+import { memoryChangeItems } from "@vm0/db/schema/memory-change-item";
+import { memoryChangeSummaries } from "@vm0/db/schema/memory-change-summary";
+import { createStore } from "ccstate";
+import { and, asc, eq } from "drizzle-orm";
+import { HttpResponse, http } from "msw";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+
+import { createApp } from "../../../app-factory";
+import { accept, setupApp, testContext } from "../../../__tests__/test-helpers";
+import { mockEnv, mockOptionalEnv } from "../../../lib/env";
+import { clearMockNow, mockNow } from "../../../lib/time";
+import { server } from "../../../mocks/server";
+import { writeDb$ } from "../../external/db";
+import {
+  deleteMemoryForFixture$,
+  findMemoryStorageId$,
+  type MemoryFixture,
+  mockMemoryVersions,
+  seedMemoryFixture$,
+  seedMemoryStorage$,
+  seedMemoryVersion$,
+} from "./helpers/zero-memory";
+import { createFixtureTracker } from "./helpers/zero-route-test";
+
+const context = testContext();
+const store = createStore();
+const OPENROUTER_URL = "https://openrouter.ai/api/v1/chat/completions";
+// Fixed clock: the closed local (UTC) day under test is 2999-01-02.
+const FIXED_NOW_ISO = "2999-01-03T12:00:00.000Z";
+const CLOSED_DATE = "2999-01-02";
+
+const track = createFixtureTracker<MemoryFixture>((fixture) => {
+  return store.set(deleteMemoryForFixture$, fixture, context.signal);
+});
+
+function apiClient() {
+  return setupApp({ context })(cronSummarizeMemoryContract);
+}
+
+function cronHeaders(secret = "test-cron-secret") {
+  return { authorization: `Bearer ${secret}` };
+}
+
+async function rawCronRequest(
+  headers: Record<string, string> = {},
+): Promise<Response> {
+  const app = createApp({ signal: context.signal });
+  return await app.request("/api/cron/summarize-memory", {
+    method: "GET",
+    headers,
+  });
+}
+
+interface MemoryFile {
+  readonly path: string;
+  readonly content: string;
+}
+
+interface SeededMemory {
+  readonly fixture: MemoryFixture;
+  readonly v2Id: string;
+}
+
+/**
+ * Seed a memory artifact with two versions both inside the closed day, mock
+ * their S3 content, and register the fixture for cleanup. The first version
+ * establishes the baseline; the second version is the day's net result.
+ */
+async function seedTwoVersions(
+  files1: readonly MemoryFile[],
+  files2: readonly MemoryFile[],
+): Promise<SeededMemory> {
+  const fixture = await track(
+    store.set(seedMemoryFixture$, undefined, context.signal),
+  );
+  const base = `orgs/${fixture.orgId}/users/${fixture.userId}/memory`;
+  const v1Key = `${base}/v1`;
+  const v2Key = `${base}/v2`;
+  const v1Id = `v1-${randomUUID()}`;
+  const v2Id = `v2-${randomUUID()}`;
+
+  await store.set(
+    seedMemoryStorage$,
+    {
+      orgId: fixture.orgId,
+      userId: fixture.userId,
+      s3Key: v1Key,
+      headVersionId: v1Id,
+      fileCount: files1.length,
+      updatedAt: new Date("2999-01-02T03:00:00.000Z"),
+    },
+    context.signal,
+  );
+
+  const storageId = await store.set(
+    findMemoryStorageId$,
+    fixture.orgId,
+    context.signal,
+  );
+  await store.set(
+    seedMemoryVersion$,
+    {
+      storageId,
+      versionId: v2Id,
+      s3Key: v2Key,
+      userId: fixture.userId,
+      createdAt: new Date("2999-01-02T09:00:00.000Z"),
+    },
+    context.signal,
+  );
+
+  mockMemoryVersions(context, [
+    { s3Key: v1Key, files: files1 },
+    { s3Key: v2Key, files: files2 },
+  ]);
+
+  return { fixture, v2Id };
+}
+
+async function findSummary(
+  fixture: MemoryFixture,
+): Promise<{ id: string; toVersionId: string; summary: string | null } | null> {
+  const db = store.set(writeDb$);
+  const [row] = await db
+    .select({
+      id: memoryChangeSummaries.id,
+      toVersionId: memoryChangeSummaries.toVersionId,
+      summary: memoryChangeSummaries.summary,
+    })
+    .from(memoryChangeSummaries)
+    .where(
+      and(
+        eq(memoryChangeSummaries.orgId, fixture.orgId),
+        eq(memoryChangeSummaries.userId, fixture.userId),
+        eq(memoryChangeSummaries.date, CLOSED_DATE),
+      ),
+    )
+    .limit(1);
+  return row ?? null;
+}
+
+async function findItems(
+  summaryId: string,
+): Promise<{ kind: string; filePath: string }[]> {
+  const db = store.set(writeDb$);
+  return await db
+    .select({
+      kind: memoryChangeItems.kind,
+      filePath: memoryChangeItems.filePath,
+    })
+    .from(memoryChangeItems)
+    .where(eq(memoryChangeItems.summaryId, summaryId))
+    .orderBy(asc(memoryChangeItems.filePath));
+}
+
+function mockLlm(content = "Today Zero learned one new thing about you."): {
+  calls: number;
+} {
+  const state = { calls: 0 };
+  mockOptionalEnv("OPENROUTER_API_KEY", "test-openrouter-key");
+  server.use(
+    http.post(OPENROUTER_URL, () => {
+      state.calls++;
+      return HttpResponse.json({ choices: [{ message: { content } }] });
+    }),
+  );
+  return state;
+}
+
+describe("GET /api/cron/summarize-memory", () => {
+  beforeEach(() => {
+    mockEnv("CRON_SECRET", "test-cron-secret");
+    mockNow(new Date(FIXED_NOW_ISO));
+  });
+
+  afterEach(() => {
+    clearMockNow();
+  });
+
+  it("rejects requests with an invalid cron secret", async () => {
+    const response = await accept(
+      apiClient().summarize({ headers: cronHeaders("wrong-secret") }),
+      [401],
+    );
+    expect(response.body).toStrictEqual({
+      error: { message: "Invalid cron secret", code: "UNAUTHORIZED" },
+    });
+  });
+
+  it("rejects requests with a missing authorization header", async () => {
+    const response = await rawCronRequest();
+    const body = await response.json();
+    expect(response.status).toBe(401);
+    expect(body).toStrictEqual({
+      error: { message: "Invalid cron secret", code: "UNAUTHORIZED" },
+    });
+  });
+
+  it("returns skipped when there are no memory artifacts", async () => {
+    const response = await accept(
+      apiClient().summarize({ headers: cronHeaders() }),
+      [200],
+    );
+    expect(response.body).toStrictEqual({ skipped: true });
+  });
+
+  it("summarizes a closed day with learned and updated items and an LLM narrative", async () => {
+    const llm = mockLlm(
+      "Zero learned your coffee order and updated your pets.",
+    );
+    const seeded = await seedTwoVersions(
+      [{ path: "facts/pets.md", content: "Has a dog" }],
+      [
+        { path: "facts/pets.md", content: "Has a dog and a cat" },
+        { path: "facts/coffee.md", content: "Drinks oat milk lattes" },
+      ],
+    );
+
+    const response = await accept(
+      apiClient().summarize({ headers: cronHeaders() }),
+      [200],
+    );
+
+    expect(response.body).toStrictEqual({ summarized: 1 });
+    expect(llm.calls).toBe(1);
+
+    const summary = await findSummary(seeded.fixture);
+    expect(summary).not.toBeNull();
+    expect(summary?.toVersionId).toBe(seeded.v2Id);
+    expect(summary?.summary).toBe(
+      "Zero learned your coffee order and updated your pets.",
+    );
+
+    const items = await findItems(summary?.id ?? "");
+    expect(items).toStrictEqual([
+      { kind: "learned", filePath: "facts/coffee.md" },
+      { kind: "updated", filePath: "facts/pets.md" },
+    ]);
+  });
+
+  it("folds MEMORY.md churn into the real file change", async () => {
+    mockLlm();
+    const seeded = await seedTwoVersions(
+      [{ path: "MEMORY.md", content: "# index v1" }],
+      [
+        { path: "MEMORY.md", content: "# index v2" },
+        { path: "facts/coffee.md", content: "Drinks oat milk lattes" },
+      ],
+    );
+
+    await accept(apiClient().summarize({ headers: cronHeaders() }), [200]);
+
+    const summary = await findSummary(seeded.fixture);
+    const items = await findItems(summary?.id ?? "");
+    expect(items).toStrictEqual([
+      { kind: "learned", filePath: "facts/coffee.md" },
+    ]);
+  });
+
+  it("writes no row and makes no LLM call when memory did not change in the day", async () => {
+    const llm = mockLlm();
+    const seeded = await seedTwoVersions(
+      [{ path: "facts/pets.md", content: "Has a dog" }],
+      [{ path: "facts/pets.md", content: "Has a dog" }],
+    );
+
+    const response = await accept(
+      apiClient().summarize({ headers: cronHeaders() }),
+      [200],
+    );
+
+    expect(response.body).toStrictEqual({ skipped: true });
+    expect(llm.calls).toBe(0);
+    await expect(findSummary(seeded.fixture)).resolves.toBeNull();
+  });
+
+  it("persists deterministic items with a null summary when the LLM fails", async () => {
+    mockOptionalEnv("OPENROUTER_API_KEY", "test-openrouter-key");
+    server.use(
+      http.post(OPENROUTER_URL, () => {
+        return new HttpResponse(null, { status: 500 });
+      }),
+    );
+    const seeded = await seedTwoVersions(
+      [{ path: "facts/pets.md", content: "Has a dog" }],
+      [{ path: "facts/coffee.md", content: "Drinks oat milk lattes" }],
+    );
+
+    const response = await accept(
+      apiClient().summarize({ headers: cronHeaders() }),
+      [200],
+    );
+
+    expect(response.body).toStrictEqual({ summarized: 1 });
+    const summary = await findSummary(seeded.fixture);
+    expect(summary?.summary).toBeNull();
+    await expect(findItems(summary?.id ?? "")).resolves.toHaveLength(2);
+  });
+
+  it("persists deterministic items with a null summary when no LLM key is configured", async () => {
+    mockOptionalEnv("OPENROUTER_API_KEY", undefined);
+    const seeded = await seedTwoVersions(
+      [{ path: "facts/pets.md", content: "Has a dog" }],
+      [
+        { path: "facts/pets.md", content: "Has a dog" },
+        { path: "facts/coffee.md", content: "Drinks oat milk lattes" },
+      ],
+    );
+
+    const response = await accept(
+      apiClient().summarize({ headers: cronHeaders() }),
+      [200],
+    );
+
+    expect(response.body).toStrictEqual({ summarized: 1 });
+    const summary = await findSummary(seeded.fixture);
+    expect(summary?.summary).toBeNull();
+    await expect(findItems(summary?.id ?? "")).resolves.toHaveLength(1);
+  });
+
+  it("is idempotent on rerun", async () => {
+    mockLlm();
+    const seeded = await seedTwoVersions(
+      [{ path: "facts/pets.md", content: "Has a dog" }],
+      [
+        { path: "facts/pets.md", content: "Has a dog" },
+        { path: "facts/coffee.md", content: "Drinks oat milk lattes" },
+      ],
+    );
+
+    await accept(apiClient().summarize({ headers: cronHeaders() }), [200]);
+    const second = await accept(
+      apiClient().summarize({ headers: cronHeaders() }),
+      [200],
+    );
+
+    // The day was already summarized, so the next run advances past it.
+    expect(second.body).toStrictEqual({ skipped: true });
+
+    const db = store.set(writeDb$);
+    const rows = await db
+      .select({ id: memoryChangeSummaries.id })
+      .from(memoryChangeSummaries)
+      .where(eq(memoryChangeSummaries.orgId, seeded.fixture.orgId));
+    expect(rows).toHaveLength(1);
+    await expect(findItems(rows[0]?.id ?? "")).resolves.toHaveLength(1);
+  });
+});

--- a/turbo/apps/api/src/signals/routes/__tests__/cron-summarize-memory.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/cron-summarize-memory.test.ts
@@ -28,7 +28,9 @@ import { createFixtureTracker } from "./helpers/zero-route-test";
 const context = testContext();
 const store = createStore();
 const OPENROUTER_URL = "https://openrouter.ai/api/v1/chat/completions";
-// Fixed clock: the closed local (UTC) day under test is 2999-01-02.
+// Fixed clock: the closed local (UTC) days before "today" (2999-01-03) are
+// 2999-01-01 and 2999-01-02. Single-day tests target 2999-01-02; the multi-day
+// backfill test spans both.
 const FIXED_NOW_ISO = "2999-01-03T12:00:00.000Z";
 const CLOSED_DATE = "2999-01-02";
 
@@ -118,6 +120,75 @@ async function seedTwoVersions(
   ]);
 
   return { fixture, v2Id };
+}
+
+interface DayVersion {
+  readonly createdAt: Date;
+  readonly files: readonly MemoryFile[];
+}
+
+/**
+ * Seed a memory artifact with an arbitrary number of versions spread across
+ * several days, mock their S3 content, and register the fixture for cleanup.
+ * The first version establishes the baseline; each later version is that
+ * version's net memory state at its createdAt.
+ */
+async function seedVersions(versions: readonly DayVersion[]): Promise<{
+  fixture: MemoryFixture;
+}> {
+  const fixture = await track(
+    store.set(seedMemoryFixture$, undefined, context.signal),
+  );
+  const base = `orgs/${fixture.orgId}/users/${fixture.userId}/memory`;
+  const [first, ...rest] = versions;
+  if (!first) {
+    throw new Error("seedVersions requires at least one version");
+  }
+
+  const firstKey = `${base}/v1`;
+  await store.set(
+    seedMemoryStorage$,
+    {
+      orgId: fixture.orgId,
+      userId: fixture.userId,
+      s3Key: firstKey,
+      headVersionId: `v1-${randomUUID()}`,
+      fileCount: first.files.length,
+      updatedAt: first.createdAt,
+    },
+    context.signal,
+  );
+
+  const storageId = await store.set(
+    findMemoryStorageId$,
+    fixture.orgId,
+    context.signal,
+  );
+
+  const content: { s3Key: string; files: readonly MemoryFile[] }[] = [
+    { s3Key: firstKey, files: first.files },
+  ];
+  let index = 2;
+  for (const version of rest) {
+    const key = `${base}/v${index}`;
+    await store.set(
+      seedMemoryVersion$,
+      {
+        storageId,
+        versionId: `v${index}-${randomUUID()}`,
+        s3Key: key,
+        userId: fixture.userId,
+        createdAt: version.createdAt,
+      },
+      context.signal,
+    );
+    content.push({ s3Key: key, files: version.files });
+    index++;
+  }
+
+  mockMemoryVersions(context, content);
+
+  return { fixture };
 }
 
 async function findSummary(
@@ -347,5 +418,60 @@ describe("GET /api/cron/summarize-memory", () => {
       .where(eq(memoryChangeSummaries.orgId, seeded.fixture.orgId));
     expect(rows).toHaveLength(1);
     await expect(findItems(rows[0]?.id ?? "")).resolves.toHaveLength(1);
+  });
+
+  it("backfills every closed day when the cron missed earlier runs", async () => {
+    const llm = mockLlm();
+    // Three versions across two closed days: 2999-01-01 (v1 -> v2) and
+    // 2999-01-02 (v2 -> v3). A single run must summarize both days.
+    const { fixture } = await seedVersions([
+      {
+        createdAt: new Date("2999-01-01T03:00:00.000Z"),
+        files: [{ path: "facts/pets.md", content: "Has a dog" }],
+      },
+      {
+        createdAt: new Date("2999-01-01T09:00:00.000Z"),
+        files: [{ path: "facts/pets.md", content: "Has a dog and a cat" }],
+      },
+      {
+        createdAt: new Date("2999-01-02T09:00:00.000Z"),
+        files: [
+          { path: "facts/pets.md", content: "Has a dog and a cat" },
+          { path: "facts/coffee.md", content: "Drinks oat milk lattes" },
+        ],
+      },
+    ]);
+
+    const response = await accept(
+      apiClient().summarize({ headers: cronHeaders() }),
+      [200],
+    );
+
+    expect(response.body).toStrictEqual({ summarized: 2 });
+    expect(llm.calls).toBe(2);
+
+    const db = store.set(writeDb$);
+    const summaries = await db
+      .select({
+        date: memoryChangeSummaries.date,
+        id: memoryChangeSummaries.id,
+      })
+      .from(memoryChangeSummaries)
+      .where(eq(memoryChangeSummaries.orgId, fixture.orgId))
+      .orderBy(asc(memoryChangeSummaries.date));
+
+    expect(
+      summaries.map((row) => {
+        return row.date;
+      }),
+    ).toStrictEqual(["2999-01-01", "2999-01-02"]);
+    // Day one: pets.md updated (the cat). Day two re-diffs from the day-one
+    // baseline, so only coffee.md is new.
+    await expect(findItems(summaries[0]?.id ?? "")).resolves.toStrictEqual([
+      { kind: "updated", filePath: "facts/pets.md" },
+    ]);
+    await expect(findItems(summaries[1]?.id ?? "")).resolves.toStrictEqual([
+      { kind: "learned", filePath: "facts/coffee.md" },
+    ]);
   });
 });

--- a/turbo/apps/api/src/signals/routes/__tests__/helpers/zero-memory.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/helpers/zero-memory.ts
@@ -1,4 +1,4 @@
-import { randomUUID } from "node:crypto";
+import { createHash, randomUUID } from "node:crypto";
 import { gzipSync } from "node:zlib";
 
 import { MEMORY_ARTIFACT_NAME } from "@vm0/core/storage-names";
@@ -232,6 +232,103 @@ export function mockMemoryContent(
     }
     if (key === `${args.s3Key}/archive.tar.gz`) {
       return Promise.resolve({ Body: asyncIterableOf(archive) });
+    }
+    return Promise.resolve({});
+  });
+}
+
+interface MemoryVersionSeed {
+  readonly storageId: string;
+  readonly versionId: string;
+  readonly s3Key: string;
+  readonly userId: string;
+  readonly createdAt: Date;
+}
+
+export const seedMemoryVersion$ = command(
+  async (
+    { set },
+    args: MemoryVersionSeed,
+    signal: AbortSignal,
+  ): Promise<void> => {
+    const db = set(writeDb$);
+    await db.insert(storageVersions).values({
+      id: args.versionId,
+      storageId: args.storageId,
+      s3Key: args.s3Key,
+      createdBy: args.userId,
+      createdAt: args.createdAt,
+    });
+    signal.throwIfAborted();
+  },
+);
+
+export const findMemoryStorageId$ = command(
+  async ({ set }, orgId: string, signal: AbortSignal): Promise<string> => {
+    const db = set(writeDb$);
+    const [row] = await db
+      .select({ id: storages.id })
+      .from(storages)
+      .where(eq(storages.orgId, orgId))
+      .limit(1);
+    signal.throwIfAborted();
+    if (!row) {
+      throw new Error("Memory storage not found for org");
+    }
+    return row.id;
+  },
+);
+
+interface MemoryVersionContent {
+  readonly s3Key: string;
+  readonly files: readonly MemoryFile[];
+}
+
+/**
+ * Mock S3 for several memory versions at once, each keyed by its own s3Key.
+ * Per-file manifest hashes are content-derived so the diff service classifies
+ * `updated` only when a file's content actually changes between versions.
+ */
+export function mockMemoryVersions(
+  context: TestContext,
+  versions: readonly MemoryVersionContent[],
+): void {
+  const byKey = new Map<string, Buffer>();
+  for (const version of versions) {
+    const files = version.files.map((file) => {
+      return { path: file.path, content: Buffer.from(file.content, "utf8") };
+    });
+    const archive = createTarGz(
+      files.map((file) => {
+        return { filename: file.path, content: file.content };
+      }),
+    );
+    const manifest = {
+      version: "test-version",
+      createdAt: new Date(0).toISOString(),
+      files: files.map((file) => {
+        return {
+          path: file.path,
+          hash: createHash("sha256").update(file.content).digest("hex"),
+          size: file.content.length,
+        };
+      }),
+      totalSize: files.reduce((sum, file) => {
+        return sum + file.content.length;
+      }, 0),
+      fileCount: files.length,
+    };
+    byKey.set(
+      `${version.s3Key}/manifest.json`,
+      Buffer.from(JSON.stringify(manifest), "utf8"),
+    );
+    byKey.set(`${version.s3Key}/archive.tar.gz`, archive);
+  }
+
+  context.mocks.s3.send.mockImplementation((cmd: unknown): Promise<unknown> => {
+    const body = byKey.get(commandKey(cmd));
+    if (body) {
+      return Promise.resolve({ Body: asyncIterableOf(body) });
     }
     return Promise.resolve({});
   });

--- a/turbo/apps/api/src/signals/routes/cron-summarize-memory.ts
+++ b/turbo/apps/api/src/signals/routes/cron-summarize-memory.ts
@@ -1,0 +1,25 @@
+import { cronSummarizeMemoryContract } from "@vm0/api-contracts/contracts/cron";
+import { command } from "ccstate";
+
+import type { RouteEntry } from "../route";
+import { summarizeMemory$ } from "../services/cron-summarize-memory.service";
+import { cronUnauthorized, hasValidCronSecret$ } from "./cron-auth";
+
+const summarizeMemoryRoute$ = command(
+  async ({ get, set }, signal: AbortSignal) => {
+    if (!get(hasValidCronSecret$)) {
+      return cronUnauthorized();
+    }
+
+    const body = await set(summarizeMemory$, signal);
+    signal.throwIfAborted();
+    return { status: 200 as const, body };
+  },
+);
+
+export const cronSummarizeMemoryRoutes: readonly RouteEntry[] = [
+  {
+    route: cronSummarizeMemoryContract.summarize,
+    handler: summarizeMemoryRoute$,
+  },
+];

--- a/turbo/apps/api/src/signals/services/__tests__/memory-activity-diff.service.test.ts
+++ b/turbo/apps/api/src/signals/services/__tests__/memory-activity-diff.service.test.ts
@@ -1,0 +1,132 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  computeChangeSet,
+  type MemoryFileMap,
+} from "../memory-activity-diff.service";
+
+function fileMap(
+  entries: readonly (readonly [string, string, string])[],
+): MemoryFileMap {
+  return new Map(
+    entries.map(([path, hash, content]) => {
+      return [path, { hash, content }];
+    }),
+  );
+}
+
+describe("computeChangeSet", () => {
+  it("classifies an added file as learned", () => {
+    const changeSet = computeChangeSet(
+      fileMap([]),
+      fileMap([["facts/coffee.md", "h1", "User drinks oat milk lattes"]]),
+    );
+
+    expect(changeSet.changed).toBeTruthy();
+    expect(changeSet.items).toHaveLength(1);
+    expect(changeSet.items[0]).toMatchObject({
+      kind: "learned",
+      filePath: "facts/coffee.md",
+      beforeSnippet: null,
+      afterSnippet: "User drinks oat milk lattes",
+    });
+  });
+
+  it("classifies a removed file as forgotten", () => {
+    const changeSet = computeChangeSet(
+      fileMap([["facts/coffee.md", "h1", "User drinks oat milk lattes"]]),
+      fileMap([]),
+    );
+
+    expect(changeSet.items).toHaveLength(1);
+    expect(changeSet.items[0]).toMatchObject({
+      kind: "forgotten",
+      filePath: "facts/coffee.md",
+      beforeSnippet: "User drinks oat milk lattes",
+      afterSnippet: null,
+    });
+  });
+
+  it("classifies a hash change as updated and ignores unchanged files", () => {
+    const changeSet = computeChangeSet(
+      fileMap([
+        ["facts/coffee.md", "h1", "old"],
+        ["facts/pets.md", "same", "Has a cat"],
+      ]),
+      fileMap([
+        ["facts/coffee.md", "h2", "new"],
+        ["facts/pets.md", "same", "Has a cat"],
+      ]),
+    );
+
+    expect(changeSet.items).toHaveLength(1);
+    expect(changeSet.items[0]).toMatchObject({
+      kind: "updated",
+      filePath: "facts/coffee.md",
+      beforeSnippet: "old",
+      afterSnippet: "new",
+    });
+  });
+
+  it("derives title and description from markdown frontmatter", () => {
+    const content =
+      "---\nname: Coffee preference\ndescription: User prefers oat milk lattes\n---\nbody";
+    const changeSet = computeChangeSet(
+      fileMap([]),
+      fileMap([["facts/coffee.md", "h1", content]]),
+    );
+
+    expect(changeSet.items[0]).toMatchObject({
+      title: "Coffee preference",
+      description: "User prefers oat milk lattes",
+    });
+  });
+
+  it("falls back to the file path as title when there is no frontmatter", () => {
+    const changeSet = computeChangeSet(
+      fileMap([]),
+      fileMap([["notes/raw.txt", "h1", "freeform note"]]),
+    );
+
+    expect(changeSet.items[0]).toMatchObject({
+      title: "notes/raw.txt",
+      description: null,
+    });
+  });
+
+  it("folds MEMORY.md churn into real file changes (does not emit it)", () => {
+    const changeSet = computeChangeSet(
+      fileMap([["MEMORY.md", "idx1", "# index v1"]]),
+      fileMap([
+        ["MEMORY.md", "idx2", "# index v2"],
+        ["facts/coffee.md", "h1", "User drinks oat milk lattes"],
+      ]),
+    );
+
+    expect(changeSet.items).toHaveLength(1);
+    expect(changeSet.items[0]?.filePath).toBe("facts/coffee.md");
+  });
+
+  it("emits MEMORY.md as its own item when no real file change explains it", () => {
+    const changeSet = computeChangeSet(
+      fileMap([["MEMORY.md", "idx1", "# index v1"]]),
+      fileMap([["MEMORY.md", "idx2", "# index v2 reorganized"]]),
+    );
+
+    expect(changeSet.items).toHaveLength(1);
+    expect(changeSet.items[0]).toMatchObject({
+      kind: "updated",
+      filePath: "MEMORY.md",
+    });
+  });
+
+  it("reports no change when both versions are identical", () => {
+    const changeSet = computeChangeSet(
+      fileMap([["facts/coffee.md", "h1", "x"]]),
+      fileMap([["facts/coffee.md", "h1", "x"]]),
+    );
+
+    expect(changeSet.changed).toBeFalsy();
+    expect(changeSet.items).toHaveLength(0);
+  });
+});

--- a/turbo/apps/api/src/signals/services/cron-aggregate-insights.service.ts
+++ b/turbo/apps/api/src/signals/services/cron-aggregate-insights.service.ts
@@ -5,7 +5,6 @@ import {
 import { agentComposeVersions } from "@vm0/db/schema/agent-compose";
 import { agentRuns } from "@vm0/db/schema/agent-run";
 import { insightsDaily } from "@vm0/db/schema/insights-daily";
-import { orgMembersMetadata } from "@vm0/db/schema/org-members-metadata";
 import { orgMetadata } from "@vm0/db/schema/org-metadata";
 import { usageEvent } from "@vm0/db/schema/usage-event";
 import { userCache } from "@vm0/db/schema/user-cache";
@@ -18,6 +17,7 @@ import { getDatasetName, queryAxiom } from "../external/axiom";
 import { clerk$ } from "../external/clerk";
 import { writeDb$, type Db } from "../external/db";
 import { nowDate } from "../external/time";
+import { getLocalToday, resolveUserTimezones } from "./local-day";
 import { settle } from "../utils";
 
 const L = logger("CronAggregateInsights");
@@ -208,81 +208,6 @@ interface NetworkQueryResult {
 
 function normalizeDbDate(value: Date | string): Date {
   return value instanceof Date ? value : new Date(value);
-}
-
-async function resolveUserTimezones(
-  db: Db,
-  orgUserPairs: OrgUserPair[],
-  signal: AbortSignal,
-): Promise<Map<string, string>> {
-  if (orgUserPairs.length === 0) {
-    return new Map();
-  }
-
-  const userIds = [
-    ...new Set(
-      orgUserPairs.map((pair) => {
-        return pair.userId;
-      }),
-    ),
-  ];
-
-  const rows = await db
-    .select({
-      orgId: orgMembersMetadata.orgId,
-      userId: orgMembersMetadata.userId,
-      timezone: orgMembersMetadata.timezone,
-    })
-    .from(orgMembersMetadata)
-    .where(
-      and(
-        inArray(orgMembersMetadata.userId, userIds),
-        isNotNull(orgMembersMetadata.timezone),
-      ),
-    );
-  signal.throwIfAborted();
-
-  const tzMap = new Map<string, string>();
-  for (const row of rows) {
-    if (row.timezone) {
-      tzMap.set(`${row.orgId}:${row.userId}`, row.timezone);
-    }
-  }
-  return tzMap;
-}
-
-function getLocalDayStartUtc(timezone: string, now: Date): Date {
-  const parts = new Intl.DateTimeFormat("en-CA", {
-    timeZone: timezone,
-    year: "numeric",
-    month: "2-digit",
-    day: "2-digit",
-  }).format(now);
-  const localMidnight = new Date(`${parts}T00:00:00`);
-  const utcStr = localMidnight.toLocaleString("en-US", { timeZone: "UTC" });
-  const tzStr = localMidnight.toLocaleString("en-US", { timeZone: timezone });
-  const utcDate = new Date(utcStr);
-  const tzDate = new Date(tzStr);
-  const offsetMs = utcDate.getTime() - tzDate.getTime();
-  return new Date(localMidnight.getTime() + offsetMs);
-}
-
-function getLocalToday(
-  timezone: string,
-  now: Date,
-): {
-  readonly targetDate: string;
-  readonly dayStart: Date;
-  readonly dayEnd: Date;
-} {
-  const dayStart = getLocalDayStartUtc(timezone, now);
-  const targetDate = new Intl.DateTimeFormat("en-CA", {
-    timeZone: timezone,
-    year: "numeric",
-    month: "2-digit",
-    day: "2-digit",
-  }).format(now);
-  return { targetDate, dayStart, dayEnd: now };
 }
 
 function getPermissionLabel(

--- a/turbo/apps/api/src/signals/services/cron-summarize-memory.service.ts
+++ b/turbo/apps/api/src/signals/services/cron-summarize-memory.service.ts
@@ -1,0 +1,378 @@
+import { MEMORY_ARTIFACT_NAME } from "@vm0/core/storage-names";
+import { memoryChangeItems } from "@vm0/db/schema/memory-change-item";
+import { memoryChangeSummaries } from "@vm0/db/schema/memory-change-summary";
+import { storages, storageVersions } from "@vm0/db/schema/storage";
+import { command, computed, type Computed } from "ccstate";
+import { and, asc, desc, eq } from "drizzle-orm";
+
+import { logger } from "../../lib/log";
+import { writeDb$, type Db } from "../external/db";
+import { nowDate } from "../external/time";
+import {
+  localDateLabel,
+  localMidnightUtc,
+  resolveUserTimezones,
+} from "./local-day";
+import {
+  computeMemoryChangeSet,
+  type MemoryChangeSet,
+} from "./memory-activity-diff.service";
+import { generateMemoryDaySummary } from "./memory-activity-summarize.service";
+import { settle } from "../utils";
+
+const L = logger("CronSummarizeMemory");
+
+// Most closed local days a single run will summarize. Bounds missed-cron
+// recovery (and guards against pathologically old windows) so one run stays
+// cheap; older un-summarized days are simply not backfilled.
+const MAX_RECOVERY_DAYS = 14;
+
+type SummarizeMemoryResult =
+  | { readonly skipped: true }
+  | { readonly summarized: number };
+
+interface MemoryStorageRow {
+  readonly orgId: string;
+  readonly userId: string;
+  readonly storageId: string;
+}
+
+interface MemoryVersionRow {
+  readonly id: string;
+  readonly s3Key: string;
+  readonly createdAt: Date;
+}
+
+interface LastSummaryRow {
+  readonly date: string;
+  readonly toVersionId: string;
+}
+
+interface ClosedDayWindow {
+  readonly targetDate: string;
+  readonly dayEnd: Date;
+}
+
+/** The next calendar date (YYYY-MM-DD) after `dateLabel`. */
+function nextDateLabel(dateLabel: string): string {
+  const next = new Date(`${dateLabel}T00:00:00Z`);
+  next.setUTCDate(next.getUTCDate() + 1);
+  return next.toISOString().slice(0, 10);
+}
+
+/**
+ * The closed (already-elapsed) local days in `[windowStart, now)`, one window
+ * per day. The current local day is excluded because it is still open. Each
+ * window's `dayEnd` is the UTC instant of the next local midnight, so a version
+ * is "in" the day when its createdAt is strictly before dayEnd.
+ *
+ * Iteration is by calendar date (stable across hosts), capped at the recovery
+ * window so a stale/never-summarized baseline can't expand into a huge list.
+ */
+function closedLocalDays(
+  timezone: string,
+  windowStart: Date,
+  now: Date,
+): ClosedDayWindow[] {
+  const currentDate = localDateLabel(timezone, now);
+  const earliest = new Date(
+    localMidnightUtc(timezone, currentDate).getTime() -
+      MAX_RECOVERY_DAYS * 24 * 3_600_000,
+  );
+  const effectiveStart = windowStart > earliest ? windowStart : earliest;
+
+  const windows: ClosedDayWindow[] = [];
+  let date = localDateLabel(timezone, effectiveStart);
+  while (date < currentDate) {
+    const nextDate = nextDateLabel(date);
+    windows.push({
+      targetDate: date,
+      dayEnd: localMidnightUtc(timezone, nextDate),
+    });
+    date = nextDate;
+  }
+
+  return windows;
+}
+
+async function loadMemoryStorages(
+  db: Db,
+  signal: AbortSignal,
+): Promise<MemoryStorageRow[]> {
+  const rows = await db
+    .select({
+      orgId: storages.orgId,
+      userId: storages.userId,
+      storageId: storages.id,
+    })
+    .from(storages)
+    .where(
+      and(
+        eq(storages.name, MEMORY_ARTIFACT_NAME),
+        eq(storages.type, "artifact"),
+      ),
+    );
+  signal.throwIfAborted();
+  return rows;
+}
+
+async function loadVersions(
+  db: Db,
+  storageId: string,
+  signal: AbortSignal,
+): Promise<MemoryVersionRow[]> {
+  const rows = await db
+    .select({
+      id: storageVersions.id,
+      s3Key: storageVersions.s3Key,
+      createdAt: storageVersions.createdAt,
+    })
+    .from(storageVersions)
+    .where(eq(storageVersions.storageId, storageId))
+    .orderBy(asc(storageVersions.createdAt));
+  signal.throwIfAborted();
+  return rows;
+}
+
+async function loadLastSummary(
+  db: Db,
+  orgId: string,
+  userId: string,
+  signal: AbortSignal,
+): Promise<LastSummaryRow | null> {
+  const [row] = await db
+    .select({
+      date: memoryChangeSummaries.date,
+      toVersionId: memoryChangeSummaries.toVersionId,
+    })
+    .from(memoryChangeSummaries)
+    .where(
+      and(
+        eq(memoryChangeSummaries.orgId, orgId),
+        eq(memoryChangeSummaries.userId, userId),
+      ),
+    )
+    .orderBy(desc(memoryChangeSummaries.date))
+    .limit(1);
+  signal.throwIfAborted();
+  return row ?? null;
+}
+
+/** The latest version whose createdAt is strictly before `instant`. */
+function lastVersionBefore(
+  versions: readonly MemoryVersionRow[],
+  instant: Date,
+): MemoryVersionRow | null {
+  let result: MemoryVersionRow | null = null;
+  for (const version of versions) {
+    if (version.createdAt < instant) {
+      result = version;
+    } else {
+      break;
+    }
+  }
+  return result;
+}
+
+async function persistSummary(
+  db: Db,
+  args: {
+    readonly orgId: string;
+    readonly userId: string;
+    readonly date: string;
+    readonly fromVersionId: string;
+    readonly toVersionId: string;
+    readonly summary: string | null;
+    readonly changeSet: MemoryChangeSet;
+    readonly createdAt: Date;
+  },
+  signal: AbortSignal,
+): Promise<void> {
+  await db.transaction(async (tx) => {
+    const [inserted] = await tx
+      .insert(memoryChangeSummaries)
+      .values({
+        orgId: args.orgId,
+        userId: args.userId,
+        date: args.date,
+        fromVersionId: args.fromVersionId,
+        toVersionId: args.toVersionId,
+        summary: args.summary,
+        createdAt: args.createdAt,
+      })
+      .onConflictDoUpdate({
+        target: [
+          memoryChangeSummaries.orgId,
+          memoryChangeSummaries.userId,
+          memoryChangeSummaries.date,
+        ],
+        set: {
+          fromVersionId: args.fromVersionId,
+          toVersionId: args.toVersionId,
+          summary: args.summary,
+          createdAt: args.createdAt,
+        },
+      })
+      .returning({ id: memoryChangeSummaries.id });
+
+    if (!inserted) {
+      throw new Error("Failed to upsert memory change summary");
+    }
+    const summaryId = inserted.id;
+    await tx
+      .delete(memoryChangeItems)
+      .where(eq(memoryChangeItems.summaryId, summaryId));
+    await tx.insert(memoryChangeItems).values(
+      args.changeSet.items.map((item) => {
+        return {
+          summaryId,
+          kind: item.kind,
+          title: item.title,
+          description: item.description,
+          filePath: item.filePath,
+          beforeSnippet: item.beforeSnippet,
+          afterSnippet: item.afterSnippet,
+        };
+      }),
+    );
+  });
+  signal.throwIfAborted();
+}
+
+function summarizeUserMemory(
+  db: Db,
+  storage: MemoryStorageRow,
+  timezone: string,
+  now: Date,
+  signal: AbortSignal,
+): Computed<Promise<number>> {
+  return computed(async (get): Promise<number> => {
+    const versions = await loadVersions(db, storage.storageId, signal);
+    const firstVersion = versions[0];
+    if (!firstVersion) {
+      return 0;
+    }
+
+    const lastSummary = await loadLastSummary(
+      db,
+      storage.orgId,
+      storage.userId,
+      signal,
+    );
+
+    const latestVersion = versions[versions.length - 1] ?? firstVersion;
+    if (lastSummary && latestVersion.id === lastSummary.toVersionId) {
+      // Memory has not advanced since the last summary: nothing new can fall
+      // into a newly-closed day. Skip without any S3 work.
+      return 0;
+    }
+
+    // Baseline = version current at the start of the window. On the first ever
+    // run it's the user's first version (older memory is not re-emitted as
+    // "learned today"); otherwise it's the previous summary's toVersion. The
+    // window starts at the first version's day, or the day after the last
+    // summarized day.
+    let baseline = firstVersion;
+    let windowStart = firstVersion.createdAt;
+    if (lastSummary) {
+      const prior = versions.find((version) => {
+        return version.id === lastSummary.toVersionId;
+      });
+      if (prior) {
+        baseline = prior;
+      }
+      // Resume from the local day after the one already summarized.
+      windowStart = localMidnightUtc(timezone, nextDateLabel(lastSummary.date));
+    }
+
+    const days = closedLocalDays(timezone, windowStart, now);
+    let summarized = 0;
+
+    for (const day of days) {
+      const toVersion = lastVersionBefore(versions, day.dayEnd);
+      if (!toVersion || toVersion.id === baseline.id) {
+        // No version through this day's close, or unchanged since the
+        // baseline: skip entirely (no LLM call, no row).
+        continue;
+      }
+
+      const changeSet = await get(
+        computeMemoryChangeSet(baseline.s3Key, toVersion.s3Key),
+      );
+      signal.throwIfAborted();
+
+      const fromVersionId = baseline.id;
+      // Carry the baseline forward so a quiet later day re-diffs from here.
+      baseline = toVersion;
+
+      if (!changeSet.changed) {
+        continue;
+      }
+
+      const summaryResult = await settle(generateMemoryDaySummary(changeSet));
+      if (!summaryResult.ok) {
+        L.warn("Memory day summary generation failed", {
+          orgId: storage.orgId,
+          userId: storage.userId,
+          date: day.targetDate,
+          err: summaryResult.error,
+        });
+      }
+
+      await persistSummary(
+        db,
+        {
+          orgId: storage.orgId,
+          userId: storage.userId,
+          date: day.targetDate,
+          fromVersionId,
+          toVersionId: toVersion.id,
+          summary: summaryResult.ok ? summaryResult.value : null,
+          changeSet,
+          createdAt: now,
+        },
+        signal,
+      );
+      summarized++;
+    }
+
+    return summarized;
+  });
+}
+
+export const summarizeMemory$ = command(
+  async ({ get, set }, signal: AbortSignal): Promise<SummarizeMemoryResult> => {
+    const db = set(writeDb$);
+    const now = nowDate();
+
+    const memoryStorages = await loadMemoryStorages(db, signal);
+    if (memoryStorages.length === 0) {
+      L.debug("No memory artifacts to summarize");
+      return { skipped: true };
+    }
+
+    const timezoneMap = await resolveUserTimezones(
+      db,
+      memoryStorages.map((row) => {
+        return { orgId: row.orgId, userId: row.userId };
+      }),
+      signal,
+    );
+
+    let summarized = 0;
+    for (const storage of memoryStorages) {
+      const timezone =
+        timezoneMap.get(`${storage.orgId}:${storage.userId}`) ?? "UTC";
+      summarized += await get(
+        summarizeUserMemory(db, storage, timezone, now, signal),
+      );
+      signal.throwIfAborted();
+    }
+
+    L.debug("Summarized memory changes", { summarized });
+    if (summarized === 0) {
+      return { skipped: true };
+    }
+    return { summarized };
+  },
+);

--- a/turbo/apps/api/src/signals/services/local-day.ts
+++ b/turbo/apps/api/src/signals/services/local-day.ts
@@ -1,0 +1,147 @@
+import { orgMembersMetadata } from "@vm0/db/schema/org-members-metadata";
+import { and, inArray, isNotNull } from "drizzle-orm";
+
+import type { Db } from "../external/db";
+
+interface OrgUserPair {
+  readonly orgId: string;
+  readonly userId: string;
+}
+
+/**
+ * Load each member's preferred timezone, keyed by `${orgId}:${userId}`.
+ * Members without an explicit timezone are omitted; callers fall back to UTC.
+ */
+export async function resolveUserTimezones(
+  db: Db,
+  orgUserPairs: readonly OrgUserPair[],
+  signal: AbortSignal,
+): Promise<Map<string, string>> {
+  if (orgUserPairs.length === 0) {
+    return new Map();
+  }
+
+  const userIds = [
+    ...new Set(
+      orgUserPairs.map((pair) => {
+        return pair.userId;
+      }),
+    ),
+  ];
+
+  const rows = await db
+    .select({
+      orgId: orgMembersMetadata.orgId,
+      userId: orgMembersMetadata.userId,
+      timezone: orgMembersMetadata.timezone,
+    })
+    .from(orgMembersMetadata)
+    .where(
+      and(
+        inArray(orgMembersMetadata.userId, userIds),
+        isNotNull(orgMembersMetadata.timezone),
+      ),
+    );
+  signal.throwIfAborted();
+
+  const tzMap = new Map<string, string>();
+  for (const row of rows) {
+    if (row.timezone) {
+      tzMap.set(`${row.orgId}:${row.userId}`, row.timezone);
+    }
+  }
+  return tzMap;
+}
+
+/**
+ * UTC instant of the most recent local-midnight in `timezone` at or before
+ * `now` (the start of the user's current local day).
+ */
+function getLocalDayStartUtc(timezone: string, now: Date): Date {
+  const parts = new Intl.DateTimeFormat("en-CA", {
+    timeZone: timezone,
+    year: "numeric",
+    month: "2-digit",
+    day: "2-digit",
+  }).format(now);
+  const localMidnight = new Date(`${parts}T00:00:00`);
+  const utcStr = localMidnight.toLocaleString("en-US", { timeZone: "UTC" });
+  const tzStr = localMidnight.toLocaleString("en-US", { timeZone: timezone });
+  const utcDate = new Date(utcStr);
+  const tzDate = new Date(tzStr);
+  const offsetMs = utcDate.getTime() - tzDate.getTime();
+  return new Date(localMidnight.getTime() + offsetMs);
+}
+
+/**
+ * The calendar date (YYYY-MM-DD) of `instant` in `timezone`.
+ */
+export function localDateLabel(timezone: string, instant: Date): string {
+  return new Intl.DateTimeFormat("en-CA", {
+    timeZone: timezone,
+    year: "numeric",
+    month: "2-digit",
+    day: "2-digit",
+  }).format(instant);
+}
+
+/**
+ * The UTC instant of local midnight for `dateLabel` (YYYY-MM-DD) in `timezone`.
+ *
+ * Unlike `getLocalDayStartUtc`, this never re-parses a formatted string as a
+ * machine-local date, so it is stable regardless of the host's `TZ` and safe to
+ * call repeatedly while walking a range of calendar days.
+ */
+export function localMidnightUtc(timezone: string, dateLabel: string): Date {
+  // Anchor: treat the label as a UTC wall-clock, then measure how far that
+  // instant's wall-clock in `timezone` differs from UTC and correct for it.
+  const anchor = new Date(`${dateLabel}T00:00:00Z`);
+  const parts = new Intl.DateTimeFormat("en-US", {
+    timeZone: timezone,
+    hourCycle: "h23",
+    year: "numeric",
+    month: "2-digit",
+    day: "2-digit",
+    hour: "2-digit",
+    minute: "2-digit",
+    second: "2-digit",
+  }).formatToParts(anchor);
+  const get = (type: string): number => {
+    const value = parts.find((part) => {
+      return part.type === type;
+    })?.value;
+    return Number(value);
+  };
+  const asUtcOfLocalParts = Date.UTC(
+    get("year"),
+    get("month") - 1,
+    get("day"),
+    get("hour"),
+    get("minute"),
+    get("second"),
+  );
+  const offsetMs = asUtcOfLocalParts - anchor.getTime();
+  return new Date(anchor.getTime() - offsetMs);
+}
+
+/**
+ * Calendar date label (YYYY-MM-DD) and UTC window for the user's local "today
+ * so far": from local midnight to `now`.
+ */
+export function getLocalToday(
+  timezone: string,
+  now: Date,
+): {
+  readonly targetDate: string;
+  readonly dayStart: Date;
+  readonly dayEnd: Date;
+} {
+  const dayStart = getLocalDayStartUtc(timezone, now);
+  const targetDate = new Intl.DateTimeFormat("en-CA", {
+    timeZone: timezone,
+    year: "numeric",
+    month: "2-digit",
+    day: "2-digit",
+  }).format(now);
+  return { targetDate, dayStart, dayEnd: now };
+}

--- a/turbo/apps/api/src/signals/services/memory-activity-diff.service.ts
+++ b/turbo/apps/api/src/signals/services/memory-activity-diff.service.ts
@@ -1,0 +1,214 @@
+import { parseSkillFrontmatter } from "@vm0/core/skill-frontmatter";
+import { computed, type Computed } from "ccstate";
+
+import { env } from "../../lib/env";
+import { extractFilesFromTarGz } from "../../lib/tar";
+import { downloadManifest, downloadS3Buffer } from "../external/s3";
+
+type MemoryChangeKind = "learned" | "updated" | "forgotten";
+
+export interface MemoryChangeItem {
+  readonly kind: MemoryChangeKind;
+  readonly title: string | null;
+  readonly description: string | null;
+  readonly filePath: string;
+  readonly beforeSnippet: string | null;
+  readonly afterSnippet: string | null;
+}
+
+export interface MemoryChangeSet {
+  readonly items: readonly MemoryChangeItem[];
+  readonly changed: boolean;
+}
+
+/** A file as seen in one version: its content hash and (text) content. */
+interface MemoryFileState {
+  readonly hash: string;
+  readonly content: string;
+}
+
+export type MemoryFileMap = ReadonlyMap<string, MemoryFileState>;
+
+const MEMORY_INDEX_PATH = "MEMORY.md";
+
+function truncateSnippet(
+  text: string,
+  maxLines = 3,
+  maxCharsPerLine = 80,
+): string {
+  return text
+    .split("\n")
+    .slice(0, maxLines)
+    .map((line) => {
+      return line.length > maxCharsPerLine
+        ? `${line.slice(0, maxCharsPerLine)}...`
+        : line;
+    })
+    .join("\n");
+}
+
+/**
+ * Derive a human title/description for a changed file. Markdown files with
+ * frontmatter (the one-fact-per-file convention) expose a `description`; for
+ * everything else the title falls back to the file path.
+ */
+function deriveTitle(
+  filePath: string,
+  content: string | undefined,
+): { readonly title: string | null; readonly description: string | null } {
+  if (content && filePath.endsWith(".md")) {
+    const frontmatter = parseSkillFrontmatter(content);
+    if (frontmatter.description) {
+      return {
+        title: frontmatter.name ?? filePath,
+        description: frontmatter.description,
+      };
+    }
+  }
+  return { title: filePath, description: null };
+}
+
+function snippetOf(content: string | undefined): string | null {
+  return content === undefined ? null : truncateSnippet(content);
+}
+
+function classifyFile(
+  filePath: string,
+  before: MemoryFileState | undefined,
+  after: MemoryFileState | undefined,
+): MemoryChangeItem | null {
+  if (after && !before) {
+    const { title, description } = deriveTitle(filePath, after.content);
+    return {
+      kind: "learned",
+      title,
+      description,
+      filePath,
+      beforeSnippet: null,
+      afterSnippet: snippetOf(after.content),
+    };
+  }
+  if (before && !after) {
+    const { title, description } = deriveTitle(filePath, before.content);
+    return {
+      kind: "forgotten",
+      title,
+      description,
+      filePath,
+      beforeSnippet: snippetOf(before.content),
+      afterSnippet: null,
+    };
+  }
+  if (before && after && before.hash !== after.hash) {
+    const { title, description } = deriveTitle(filePath, after.content);
+    return {
+      kind: "updated",
+      title,
+      description,
+      filePath,
+      beforeSnippet: snippetOf(before.content),
+      afterSnippet: snippetOf(after.content),
+    };
+  }
+  return null;
+}
+
+/**
+ * Pure deterministic change set between two memory file maps, keyed by path.
+ * Classification is by manifest hash (added -> learned, removed -> forgotten,
+ * hash differs -> updated); unchanged files are skipped without byte-diffing.
+ *
+ * `MEMORY.md` is a derived index: its churn is folded into the real fact
+ * changes. It is only emitted as its own item when it changed AND no other
+ * file change explains it (pure index reorg / prose-only edit).
+ */
+export function computeChangeSet(
+  fromFiles: MemoryFileMap,
+  toFiles: MemoryFileMap,
+): MemoryChangeSet {
+  const paths = new Set<string>([...fromFiles.keys(), ...toFiles.keys()]);
+
+  const items: MemoryChangeItem[] = [];
+  let memoryIndexItem: MemoryChangeItem | null = null;
+
+  for (const filePath of paths) {
+    const item = classifyFile(
+      filePath,
+      fromFiles.get(filePath),
+      toFiles.get(filePath),
+    );
+    if (!item) {
+      continue;
+    }
+    if (filePath === MEMORY_INDEX_PATH) {
+      memoryIndexItem = item;
+      continue;
+    }
+    items.push(item);
+  }
+
+  if (memoryIndexItem && items.length === 0) {
+    items.push(memoryIndexItem);
+  }
+
+  return { items, changed: items.length > 0 };
+}
+
+function normalizePath(path: string): string {
+  return path.replace(/^\.\//, "");
+}
+
+function loadVersionFiles(
+  bucket: string,
+  s3Key: string,
+): Computed<Promise<MemoryFileMap>> {
+  return computed(async (get): Promise<MemoryFileMap> => {
+    const manifest = await get(downloadManifest(bucket, s3Key));
+    const entries = manifest.files.map((file) => {
+      return { path: normalizePath(file.path), hash: file.hash };
+    });
+
+    const archiveBuffer = await get(
+      downloadS3Buffer(bucket, `${s3Key}/archive.tar.gz`),
+    );
+    const extracted = extractFilesFromTarGz(
+      archiveBuffer,
+      entries.map((entry) => {
+        return entry.path;
+      }),
+    );
+    const contentByPath = new Map(
+      extracted.map((file) => {
+        return [file.path, file.content];
+      }),
+    );
+
+    const fileMap = new Map<string, MemoryFileState>();
+    for (const entry of entries) {
+      fileMap.set(entry.path, {
+        hash: entry.hash,
+        content: contentByPath.get(entry.path) ?? "",
+      });
+    }
+    return fileMap;
+  });
+}
+
+/**
+ * Load both memory versions from S3 and compute their net change set. Reads the
+ * per-file hash from each version's manifest and the file bodies from its
+ * archive, then delegates to the pure `computeChangeSet`.
+ */
+export function computeMemoryChangeSet(
+  fromS3Key: string,
+  toS3Key: string,
+): Computed<Promise<MemoryChangeSet>> {
+  return computed(async (get): Promise<MemoryChangeSet> => {
+    const bucket = env("R2_USER_STORAGES_BUCKET_NAME");
+    const [fromFiles, toFiles] = await Promise.all([
+      get(loadVersionFiles(bucket, fromS3Key)),
+      get(loadVersionFiles(bucket, toS3Key)),
+    ]);
+    return computeChangeSet(fromFiles, toFiles);
+  });
+}

--- a/turbo/apps/api/src/signals/services/memory-activity-summarize.service.ts
+++ b/turbo/apps/api/src/signals/services/memory-activity-summarize.service.ts
@@ -1,0 +1,60 @@
+import { generateText, isLlmConfigured } from "../external/openrouter";
+import type {
+  MemoryChangeItem,
+  MemoryChangeSet,
+} from "./memory-activity-diff.service";
+
+const MEMORY_SUMMARY_MODEL = "google/gemini-3.1-flash-lite-preview";
+const MEMORY_SUMMARY_MAX_TOKENS = 200;
+
+function kindVerb(kind: MemoryChangeItem["kind"]): string {
+  switch (kind) {
+    case "learned": {
+      return "Learned";
+    }
+    case "updated": {
+      return "Updated";
+    }
+    case "forgotten": {
+      return "Forgot";
+    }
+  }
+}
+
+function describeItem(item: MemoryChangeItem): string {
+  const label = item.description ?? item.title ?? item.filePath;
+  return `- ${kindVerb(item.kind)}: ${label} (${item.filePath})`;
+}
+
+/**
+ * Narrative layer on top of the deterministic change set: a concise plain-text
+ * summary of what the agent's memory learned/updated/forgot in a day.
+ *
+ * Returns `null` when no LLM is configured so the caller still persists the
+ * deterministic items with a null summary. API errors are left to propagate;
+ * the cron wraps this in `settle` to degrade on failure.
+ */
+export function generateMemoryDaySummary(
+  changeSet: MemoryChangeSet,
+): Promise<string | null> {
+  if (!isLlmConfigured()) {
+    return Promise.resolve(null);
+  }
+
+  const itemLines = changeSet.items.map(describeItem).join("\n");
+  return generateText(
+    MEMORY_SUMMARY_MODEL,
+    [
+      {
+        role: "system",
+        content:
+          "You summarize how an AI agent's long-term memory about a user changed during a single day. Write one or two short, friendly plain-text sentences describing what was learned, updated, or forgotten. No markdown, no bullet points, no quotes.",
+      },
+      {
+        role: "user",
+        content: `Memory changes today:\n${itemLines}`,
+      },
+    ],
+    MEMORY_SUMMARY_MAX_TOKENS,
+  );
+}

--- a/turbo/apps/api/vercel.json
+++ b/turbo/apps/api/vercel.json
@@ -21,6 +21,10 @@
       "schedule": "0 * * * *"
     },
     {
+      "path": "/api/cron/summarize-memory",
+      "schedule": "30 * * * *"
+    },
+    {
       "path": "/api/cron/telegram-cleanup",
       "schedule": "0 1 * * *"
     },

--- a/turbo/apps/web/api-backend-rewrites.js
+++ b/turbo/apps/web/api-backend-rewrites.js
@@ -455,6 +455,7 @@ export const API_BACKEND_REWRITES = [
     "/api/cron/reconcile-billing-entitlements",
     "/api/cron/reconcile-billing-entitlements",
   ],
+  ["/api/cron/summarize-memory", "/api/cron/summarize-memory"],
   ["/api/cron/sync-skills", "/api/cron/sync-skills"],
   ["/api/cron/telegram-cleanup", "/api/cron/telegram-cleanup"],
   [

--- a/turbo/packages/api-contracts/src/contracts/cron.ts
+++ b/turbo/packages/api-contracts/src/contracts/cron.ts
@@ -110,6 +110,19 @@ const cronAggregateInsightsResponseSchema = z.union([
   cronAggregateInsightsAggregatedResponseSchema,
 ]);
 
+const cronSummarizeMemorySkippedResponseSchema = z.object({
+  skipped: z.literal(true),
+});
+
+const cronSummarizeMemorySummarizedResponseSchema = z.object({
+  summarized: z.number(),
+});
+
+const cronSummarizeMemoryResponseSchema = z.union([
+  cronSummarizeMemorySkippedResponseSchema,
+  cronSummarizeMemorySummarizedResponseSchema,
+]);
+
 export const cronAggregateUsageContract = c.router({
   aggregate: {
     method: "GET",
@@ -227,6 +240,19 @@ export const cronAggregateInsightsContract = c.router({
   },
 });
 
+export const cronSummarizeMemoryContract = c.router({
+  summarize: {
+    method: "GET",
+    path: "/api/cron/summarize-memory",
+    headers: authHeadersSchema,
+    responses: {
+      200: cronSummarizeMemoryResponseSchema,
+      401: apiErrorSchema,
+    },
+    summary: "Summarize daily memory changes per user",
+  },
+});
+
 export type CronAggregateUsageContract = typeof cronAggregateUsageContract;
 export type CronProcessUsageEventsContract =
   typeof cronProcessUsageEventsContract;
@@ -234,6 +260,7 @@ export type CronReconcileBillingEntitlementsContract =
   typeof cronReconcileBillingEntitlementsContract;
 export type CronAggregateInsightsContract =
   typeof cronAggregateInsightsContract;
+export type CronSummarizeMemoryContract = typeof cronSummarizeMemoryContract;
 export type CronTelegramCleanupContract = typeof cronTelegramCleanupContract;
 export type CronComputerUseScreenshotCleanupContract =
   typeof cronComputerUseScreenshotCleanupContract;
@@ -254,4 +281,5 @@ export {
   cronSyncSkillsResponseSchema,
   cronExecuteSchedulesResponseSchema,
   cronAggregateInsightsResponseSchema,
+  cronSummarizeMemoryResponseSchema,
 };


### PR DESCRIPTION
## Summary

Backend **generation pipeline** for the Memory Activity feature (Part of #15977, PR-B). PR-A (DB tables `memory_change_summaries` / `memory_change_items`) is already on main; this PR adds the services that compute a daily memory change set, narrate it with an LLM, and write summaries via an hourly cron.

The design follows the issue's decided spec:
- **Hourly cron**, each user summarized at most once per **closed local day**; window = since that user's last summary. No change in the elapsed day → no LLM call, no row.
- Day boundary uses per-user timezone (`org_members_metadata.timezone`, UTC fallback), aligned with the insights cron.
- A day's versions collapse into ONE net before/after diff (prev summary's `toVersionId` → last version of the day).
- Two decoupled layers: a deterministic change set (source of truth, always persisted) and an LLM narrative on top that **degrades** — on LLM failure the change items are still saved with `summary = null`.
- Evidence = inline truncated before/after snippets (no S3 on read path, no diff library). Item kinds: `learned` / `updated` / `forgotten`.
- `MEMORY.md` index churn is folded into real fact changes.

## Changes

- **Shared day-boundary helpers** — extracted `resolveUserTimezones` / `getLocalToday` (previously private in `cron-aggregate-insights.service.ts`) into `services/local-day.ts`, reused by both crons. Added a host-`TZ`-stable `localMidnightUtc` for walking closed-day windows (the existing helper round-trips through machine-local time and isn't safe to iterate).
- **`external/openrouter.ts`** — shared `generateText` / `isLlmConfigured` over `fetch`, gated on `OPENROUTER_API_KEY`.
- **`memory-activity-diff.service.ts`** — pure `computeChangeSet(fromFiles, toFiles)` classifying by manifest hash, frontmatter-derived titles, snippet truncation, MEMORY.md folding; plus an S3-loading wrapper (`downloadManifest` + archive + `extractFilesFromTarGz`).
- **`memory-activity-summarize.service.ts`** — `generateMemoryDaySummary` behind `MEMORY_SUMMARY_MODEL = "google/gemini-3.1-flash-lite-preview"`, returns `null` when no LLM is configured; errors propagate so the cron can `settle`.
- **`cron-summarize-memory.service.ts`** — ccstate command mirroring `aggregateInsights$`; per (user, closed day) resolves from/to versions, skips when unchanged, upserts the summary row + items in a transaction. Capped recovery window for missed crons.
- **Contract / route / `vercel.json`** — `cronSummarizeMemoryContract` (`GET /api/cron/summarize-memory`), guarded route registered in `route.ts`, cron schedule `30 * * * *`.
- **Tests** — integration test (real DB, stubbed S3, MSW OpenRouter): row/item kinds, MEMORY.md folding, no-change-day → no row + no LLM call, LLM failure / unset key → items persisted with `summary = null`, 401. Plus a pure `computeChangeSet` unit test.

## Verification

Run from `turbo`: `pnpm turbo run lint`, `pnpm -F api check-types` + `@vm0/api-contracts`, `pnpm knip`, `pnpm format` all clean. `pnpm -F api exec vitest` for the new tests (9 cron + 8 diff) and the insights cron regression (14) — **31 passed**, confirming the helper extraction preserves insights behavior.

🤖 Generated with [Claude Code](https://claude.com/claude-code)