### PR TITLE
feat(platform): add memory activity updates timeline

### DIFF
--- a/turbo/apps/platform/src/mocks/handlers/api-memory-activity.ts
+++ b/turbo/apps/platform/src/mocks/handlers/api-memory-activity.ts
@@ -1,0 +1,24 @@
+import {
+  zeroMemoryActivityContract,
+  type MemoryActivityResponse,
+} from "@vm0/api-contracts/contracts/zero-memory-activity";
+
+import { mockApi } from "../msw-contract.ts";
+
+const EMPTY_ACTIVITY: MemoryActivityResponse = { entries: [] };
+
+let mockMemoryActivity: MemoryActivityResponse = { ...EMPTY_ACTIVITY };
+
+export function setMockMemoryActivity(activity: MemoryActivityResponse): void {
+  mockMemoryActivity = activity;
+}
+
+export function resetMockMemoryActivity(): void {
+  mockMemoryActivity = { ...EMPTY_ACTIVITY };
+}
+
+export const apiMemoryActivityHandlers = [
+  mockApi(zeroMemoryActivityContract.get, ({ respond }) => {
+    return respond(200, mockMemoryActivity);
+  }),
+];

--- a/turbo/apps/platform/src/mocks/handlers/index.ts
+++ b/turbo/apps/platform/src/mocks/handlers/index.ts
@@ -58,6 +58,10 @@ import {
 } from "./api-agents.ts";
 import { apiSkillsHandlers, resetMockSkills } from "./api-skills.ts";
 import { apiMemoryHandlers, resetMockMemory } from "./api-memory.ts";
+import {
+  apiMemoryActivityHandlers,
+  resetMockMemoryActivity,
+} from "./api-memory-activity.ts";
 import { apiRunsHandlers } from "./api-runs.ts";
 import { apiFeatureSwitchesHandlers } from "./api-feature-switches.ts";
 import { apiRealtimeHandlers } from "./api-realtime.ts";
@@ -109,6 +113,7 @@ export const handlers = [
   ...apiAgentsHandlers,
   ...apiSkillsHandlers,
   ...apiMemoryHandlers,
+  ...apiMemoryActivityHandlers,
   ...apiRunsHandlers,
   ...apiUserPreferencesHandlers,
   ...apiUserModelPreferenceHandlers,
@@ -152,5 +157,6 @@ export function resetAllMockHandlers(): void {
   resetMockTeam();
   resetMockSkills();
   resetMockMemory();
+  resetMockMemoryActivity();
   resetMockOnboardingStatus();
 }

--- a/turbo/apps/platform/src/signals/memory-page/memory-signals.ts
+++ b/turbo/apps/platform/src/signals/memory-page/memory-signals.ts
@@ -3,9 +3,15 @@ import {
   zeroMemoryContract,
   type MemoryDetailResponse,
 } from "@vm0/api-contracts/contracts/zero-memory";
+import {
+  zeroMemoryActivityContract,
+  type MemoryActivityResponse,
+} from "@vm0/api-contracts/contracts/zero-memory-activity";
 
 import { accept } from "../../lib/accept.ts";
 import { zeroClient$ } from "../api-client.ts";
+
+export type MemoryTab = "updates" | "raw";
 
 const internalSelectedMemoryFilePath$ = state<string | null>(null);
 
@@ -19,9 +25,42 @@ export const setSelectedMemoryFilePath$ = command(
   },
 );
 
+const internalMemoryTab$ = state<MemoryTab>("updates");
+
+export const memoryTab$ = computed((get) => {
+  return get(internalMemoryTab$);
+});
+
+export const setMemoryTab$ = command(({ set }, tab: MemoryTab) => {
+  set(internalMemoryTab$, tab);
+});
+
+// Per-item expand state for the Updates timeline, keyed by a stable item key.
+// Mirrors the keyed-record ephemeral UI state pattern used elsewhere in the
+// platform (e.g. view-component-state) since `useState` is restricted here.
+const internalExpandedMemoryItems$ = state<Record<string, boolean>>({});
+
+export const expandedMemoryItems$ = computed((get) => {
+  return get(internalExpandedMemoryItems$);
+});
+
+export const toggleMemoryItemExpanded$ = command(({ set }, key: string) => {
+  set(internalExpandedMemoryItems$, (current) => {
+    return { ...current, [key]: !current[key] };
+  });
+});
+
 export const memoryDetail$ = computed(
   async (get): Promise<MemoryDetailResponse> => {
     const client = get(zeroClient$)(zeroMemoryContract);
+    const result = await accept(client.get(), [200], { toast: false });
+    return result.body;
+  },
+);
+
+export const memoryActivity$ = computed(
+  async (get): Promise<MemoryActivityResponse> => {
+    const client = get(zeroClient$)(zeroMemoryActivityContract);
     const result = await accept(client.get(), [200], { toast: false });
     return result.body;
   },

--- a/turbo/apps/platform/src/views/memory-page/__tests__/memory-page.test.tsx
+++ b/turbo/apps/platform/src/views/memory-page/__tests__/memory-page.test.tsx
@@ -8,10 +8,22 @@ import {
   queryAllByRoleFast,
 } from "../../../__tests__/page-helper.ts";
 import { setMockMemory } from "../../../mocks/handlers/api-memory.ts";
+import { setMockMemoryActivity } from "../../../mocks/handlers/api-memory-activity.ts";
 import { testContext } from "../../../signals/__tests__/test-helpers.ts";
 import { pathname$ } from "../../../signals/route.ts";
 
 const context = testContext();
+
+async function clickTab(name: string): Promise<void> {
+  const tab = await waitFor(() => {
+    const found = queryAllByRoleFast("tab").find((element) => {
+      return element.textContent?.includes(name);
+    });
+    expect(found).toBeDefined();
+    return found!;
+  });
+  click(tab);
+}
 
 function setupMemoryPage(): void {
   setMockMemory({
@@ -62,12 +74,146 @@ describe("memory page", () => {
     });
 
     await waitFor(() => {
+      expect(screen.getByText("No updates yet")).toBeInTheDocument();
+    });
+
+    await clickTab("Raw files");
+
+    await waitFor(() => {
       expect(screen.getByText("No memory yet")).toBeInTheDocument();
     });
   });
 
+  it("defaults to the Updates tab and renders the daily activity timeline", async () => {
+    setMockMemoryActivity({
+      entries: [
+        {
+          date: "2024-03-02",
+          summary: "Zero learned how you prefer to deploy.",
+          fromVersionId: "v1",
+          toVersionId: "v2",
+          items: [
+            {
+              kind: "learned",
+              title: "Deploy preference",
+              description: "Use blue-green deploys",
+              filePath: "deploy.md",
+              beforeSnippet: null,
+              afterSnippet: "Use blue-green deploys",
+            },
+            {
+              kind: "updated",
+              title: "Project setup",
+              description: null,
+              filePath: "setup.md",
+              beforeSnippet: "old setup",
+              afterSnippet: "new setup",
+            },
+          ],
+        },
+      ],
+    });
+
+    detachedSetupPage({
+      context,
+      path: "/memory",
+      featureSwitches: { [FeatureSwitchKey.MemoryViewer]: true },
+    });
+
+    await waitFor(() => {
+      expect(
+        screen.getByText("Zero learned how you prefer to deploy."),
+      ).toBeInTheDocument();
+    });
+
+    expect(screen.getByText("Deploy preference")).toBeInTheDocument();
+    expect(screen.getByText("Learned")).toBeInTheDocument();
+    expect(screen.getByText("Updated")).toBeInTheDocument();
+
+    // Evidence is hidden until the item is expanded.
+    expect(screen.queryByText("new setup")).not.toBeInTheDocument();
+
+    const updatedItem = queryAllByRoleFast("button").find((button) => {
+      return button.textContent?.includes("Project setup");
+    });
+    expect(updatedItem).toBeDefined();
+    click(updatedItem!);
+
+    await waitFor(() => {
+      expect(screen.getByText("new setup")).toBeInTheDocument();
+    });
+    expect(screen.getByText("old setup")).toBeInTheDocument();
+  });
+
+  it("falls back to a deterministic summary line when the LLM summary is null", async () => {
+    setMockMemoryActivity({
+      entries: [
+        {
+          date: "2024-03-02",
+          summary: null,
+          fromVersionId: "v1",
+          toVersionId: "v2",
+          items: [
+            {
+              kind: "learned",
+              title: "Fact A",
+              description: null,
+              filePath: "a.md",
+              beforeSnippet: null,
+              afterSnippet: "a",
+            },
+            {
+              kind: "learned",
+              title: "Fact B",
+              description: null,
+              filePath: "b.md",
+              beforeSnippet: null,
+              afterSnippet: "b",
+            },
+            {
+              kind: "updated",
+              title: "Fact C",
+              description: null,
+              filePath: "c.md",
+              beforeSnippet: "old",
+              afterSnippet: "new",
+            },
+          ],
+        },
+      ],
+    });
+
+    detachedSetupPage({
+      context,
+      path: "/memory",
+      featureSwitches: { [FeatureSwitchKey.MemoryViewer]: true },
+    });
+
+    await waitFor(() => {
+      expect(
+        screen.getByText("3 changes — 2 learned, 1 updated"),
+      ).toBeInTheDocument();
+    });
+  });
+
+  it("shows a friendly empty state on the Updates tab when there is no activity", async () => {
+    detachedSetupPage({
+      context,
+      path: "/memory",
+      featureSwitches: { [FeatureSwitchKey.MemoryViewer]: true },
+    });
+
+    await waitFor(() => {
+      expect(screen.getByText("No updates yet")).toBeInTheDocument();
+    });
+    expect(
+      screen.getByText(/Memory-change tracking starts/i),
+    ).toBeInTheDocument();
+  });
+
   it("lists memory files and shows selected file content read-only", async () => {
     setupMemoryPage();
+    await clickTab("Raw files");
 
     // Defaults to MEMORY.md (rendered as markdown).
     await waitFor(() => {
@@ -101,6 +247,7 @@ describe("memory page", () => {
 
   it("pins MEMORY.md to the top of the file list", async () => {
     setupMemoryPage();
+    await clickTab("Raw files");
 
     await waitFor(() => {
       expect(screen.getAllByText("MEMORY.md").length).toBeGreaterThan(0);
@@ -148,6 +295,8 @@ describe("memory page", () => {
       path: "/memory",
       featureSwitches: { [FeatureSwitchKey.MemoryViewer]: true },
     });
+
+    await clickTab("Raw files");
 
     // Defaults to MEMORY.md, which renders the relative link to other-note.md.
     await waitFor(() => {
@@ -210,6 +359,8 @@ describe("memory page", () => {
       featureSwitches: { [FeatureSwitchKey.MemoryViewer]: true },
     });
 
+    await clickTab("Raw files");
+
     await waitFor(() => {
       expect(screen.getByLabelText("Memory content")).toHaveTextContent(
         "Wrong:",
@@ -259,6 +410,8 @@ describe("memory page", () => {
       path: "/memory",
       featureSwitches: { [FeatureSwitchKey.MemoryViewer]: true },
     });
+
+    await clickTab("Raw files");
 
     // Defaults to MEMORY.md, which renders an absolute external link.
     await waitFor(() => {

--- a/turbo/apps/platform/src/views/memory-page/memory-page.tsx
+++ b/turbo/apps/platform/src/views/memory-page/memory-page.tsx
@@ -2,12 +2,20 @@ import { useGet, useLoadable, useSet } from "ccstate-react";
 import type { MouseEvent } from "react";
 import { isMap, isScalar, isSeq, parseDocument } from "yaml";
 import type { MemoryDetailResponse } from "@vm0/api-contracts/contracts/zero-memory";
+import type { MemoryActivityResponse } from "@vm0/api-contracts/contracts/zero-memory-activity";
 import { cn } from "@vm0/ui";
+import { Tabs, TabsList, TabsTrigger } from "@vm0/ui/components/ui/tabs";
 
 import {
+  expandedMemoryItems$,
+  memoryActivity$,
   memoryDetail$,
+  memoryTab$,
   selectedMemoryFilePath$,
+  setMemoryTab$,
   setSelectedMemoryFilePath$,
+  toggleMemoryItemExpanded$,
+  type MemoryTab,
 } from "../../signals/memory-page/memory-signals.ts";
 import { Markdown } from "../components/markdown.tsx";
 
@@ -161,13 +169,13 @@ function deriveMemoryViewerState(
   return { files, selectedPath, selectedContent, knownPaths };
 }
 
+function isMemoryTab(value: string): value is MemoryTab {
+  return value === "updates" || value === "raw";
+}
+
 export function MemoryPage() {
-  const detailLoadable = useLoadable(memoryDetail$);
-  const detail =
-    detailLoadable.state === "hasData" ? detailLoadable.data : null;
-  const loading = detailLoadable.state === "loading" && !detail;
-  const errored = detailLoadable.state === "hasError";
-  const hasFiles = detail !== null && detail.exists && detail.files.length > 0;
+  const activeTab = useGet(memoryTab$);
+  const setTab = useSet(setMemoryTab$);
 
   return (
     <div className="flex min-h-0 flex-1 flex-col">
@@ -181,22 +189,57 @@ export function MemoryPage() {
               What Zero remembers across runs. Read-only.
             </p>
           </div>
+          <Tabs
+            value={activeTab}
+            onValueChange={(value) => {
+              if (isMemoryTab(value)) {
+                setTab(value);
+              }
+            }}
+            className="mt-3"
+          >
+            <TabsList className="zero-tabs h-9 gap-1 px-1 py-1">
+              <TabsTrigger
+                value="updates"
+                className="gap-1.5 px-3 text-sm data-[state=active]:bg-background"
+              >
+                Updates
+              </TabsTrigger>
+              <TabsTrigger
+                value="raw"
+                className="gap-1.5 px-3 text-sm data-[state=active]:bg-background"
+              >
+                Raw files
+              </TabsTrigger>
+            </TabsList>
+          </Tabs>
         </div>
       </header>
 
       <main className="flex min-h-0 flex-1 flex-col overflow-hidden px-4 pb-8 pt-3 sm:px-6">
         <div className="mx-auto flex min-h-0 w-full max-w-[900px] flex-1 flex-col">
-          {loading ? (
-            <MemorySkeleton />
-          ) : hasFiles && detail ? (
-            <MemoryViewer detail={detail} />
-          ) : (
-            <MemoryEmptyState errored={errored} />
-          )}
+          {activeTab === "updates" ? <MemoryUpdates /> : <MemoryRawFiles />}
         </div>
       </main>
     </div>
   );
+}
+
+function MemoryRawFiles() {
+  const detailLoadable = useLoadable(memoryDetail$);
+  const detail =
+    detailLoadable.state === "hasData" ? detailLoadable.data : null;
+  const loading = detailLoadable.state === "loading" && !detail;
+  const errored = detailLoadable.state === "hasError";
+  const hasFiles = detail !== null && detail.exists && detail.files.length > 0;
+
+  if (loading) {
+    return <MemorySkeleton />;
+  }
+  if (hasFiles && detail) {
+    return <MemoryViewer detail={detail} />;
+  }
+  return <MemoryEmptyState errored={errored} />;
 }
 
 function MemoryViewer({ detail }: { readonly detail: MemoryDetailResponse }) {
@@ -376,6 +419,262 @@ function MemoryFrontmatter({
         </dl>
       ) : null}
     </header>
+  );
+}
+
+type MemoryActivityEntry = MemoryActivityResponse["entries"][number];
+type MemoryActivityItem = MemoryActivityEntry["items"][number];
+type MemoryItemKind = MemoryActivityItem["kind"];
+
+const KIND_ORDER: readonly MemoryItemKind[] = [
+  "learned",
+  "updated",
+  "forgotten",
+];
+
+const KIND_LABEL = {
+  learned: "Learned",
+  updated: "Updated",
+  forgotten: "Forgotten",
+} as const satisfies Record<MemoryItemKind, string>;
+
+const KIND_BADGE_CLASS = {
+  learned:
+    "border-emerald-500/30 bg-emerald-500/10 text-emerald-700 dark:text-emerald-300",
+  updated:
+    "border-amber-500/30 bg-amber-500/10 text-amber-700 dark:text-amber-300",
+  forgotten:
+    "border-rose-500/30 bg-rose-500/10 text-rose-700 dark:text-rose-300",
+} as const satisfies Record<MemoryItemKind, string>;
+
+function isMarkdownPath(path: string): boolean {
+  return path.toLowerCase().endsWith(".md");
+}
+
+/**
+ * Deterministic fallback line shown when the LLM narrative is null. Mirrors the
+ * "N changes — A learned, B updated, C forgotten" shape so a failed generation
+ * still reads as a real summary rather than a broken card.
+ */
+function buildFallbackSummary(items: readonly MemoryActivityItem[]): string {
+  const counts = new Map<MemoryItemKind, number>();
+  for (const item of items) {
+    counts.set(item.kind, (counts.get(item.kind) ?? 0) + 1);
+  }
+  const parts = KIND_ORDER.filter((kind) => {
+    return (counts.get(kind) ?? 0) > 0;
+  }).map((kind) => {
+    return `${counts.get(kind)} ${kind}`;
+  });
+  const total = items.length;
+  const noun = total === 1 ? "change" : "changes";
+  if (parts.length === 0) {
+    return `${total} ${noun}`;
+  }
+  return `${total} ${noun} — ${parts.join(", ")}`;
+}
+
+function formatActivityDate(date: string): string {
+  // `date` is a local YYYY-MM-DD label produced server-side. Parse it as a
+  // local date (not UTC) so the displayed day matches the stored label exactly.
+  const match = /^(\d{4})-(\d{2})-(\d{2})$/.exec(date);
+  if (match === null) {
+    return date;
+  }
+  const [, year, month, day] = match;
+  const parsed = new Date(Number(year), Number(month) - 1, Number(day));
+  if (Number.isNaN(parsed.getTime())) {
+    return date;
+  }
+  return parsed.toLocaleDateString(undefined, {
+    weekday: "long",
+    year: "numeric",
+    month: "long",
+    day: "numeric",
+  });
+}
+
+function MemoryUpdates() {
+  const activityLoadable = useLoadable(memoryActivity$);
+
+  if (activityLoadable.state === "loading") {
+    return <MemorySkeleton />;
+  }
+  if (activityLoadable.state === "hasError") {
+    return <MemoryEmptyState errored />;
+  }
+
+  const entries = activityLoadable.data.entries;
+  if (entries.length === 0) {
+    return <MemoryUpdatesEmptyState />;
+  }
+
+  return (
+    <div className="flex min-h-0 flex-1 flex-col gap-4 overflow-auto pb-2">
+      {entries.map((entry) => {
+        return <MemoryUpdateCard key={entry.toVersionId} entry={entry} />;
+      })}
+    </div>
+  );
+}
+
+function MemoryUpdateCard({ entry }: { readonly entry: MemoryActivityEntry }) {
+  const summary = entry.summary ?? buildFallbackSummary(entry.items);
+  const grouped = KIND_ORDER.map((kind) => {
+    return {
+      kind,
+      items: entry.items.filter((item) => {
+        return item.kind === kind;
+      }),
+    };
+  }).filter((group) => {
+    return group.items.length > 0;
+  });
+
+  return (
+    <section className="zero-card flex flex-col overflow-hidden">
+      <header className="border-b border-border/70 px-4 py-3">
+        <h2 className="text-sm font-semibold tracking-tight text-foreground">
+          {formatActivityDate(entry.date)}
+        </h2>
+        <p className="mt-1 whitespace-pre-wrap text-sm leading-5 text-muted-foreground">
+          {summary}
+        </p>
+      </header>
+      <div className="flex flex-col gap-4 px-4 py-3">
+        {grouped.map((group) => {
+          return (
+            <div key={group.kind} className="flex flex-col gap-2">
+              <div className="flex items-center gap-2">
+                <span
+                  className={cn(
+                    "inline-flex items-center rounded-full border px-2 py-0.5 text-xs font-medium",
+                    KIND_BADGE_CLASS[group.kind],
+                  )}
+                >
+                  {KIND_LABEL[group.kind]}
+                </span>
+                <span className="text-xs text-muted-foreground">
+                  {group.items.length}
+                </span>
+              </div>
+              <div className="flex flex-col gap-2">
+                {group.items.map((item) => {
+                  const itemKey = `${entry.toVersionId}:${item.kind}:${item.filePath}`;
+                  return (
+                    <MemoryUpdateItem
+                      key={itemKey}
+                      itemKey={itemKey}
+                      item={item}
+                    />
+                  );
+                })}
+              </div>
+            </div>
+          );
+        })}
+      </div>
+    </section>
+  );
+}
+
+function MemoryUpdateItem({
+  itemKey,
+  item,
+}: {
+  readonly itemKey: string;
+  readonly item: MemoryActivityItem;
+}) {
+  const expandedByKey = useGet(expandedMemoryItems$);
+  const toggleExpanded = useSet(toggleMemoryItemExpanded$);
+  const expanded = expandedByKey[itemKey] ?? false;
+  const title = item.title ?? item.filePath;
+  const hasEvidence = item.beforeSnippet !== null || item.afterSnippet !== null;
+
+  return (
+    <div className="rounded-md border border-border/70 bg-background">
+      <button
+        type="button"
+        aria-expanded={expanded}
+        disabled={!hasEvidence}
+        onClick={() => {
+          toggleExpanded(itemKey);
+        }}
+        className={cn(
+          "flex w-full min-w-0 flex-col items-start gap-0.5 px-3 py-2 text-left",
+          hasEvidence
+            ? "transition-colors hover:bg-accent/40"
+            : "cursor-default",
+        )}
+      >
+        <span className="min-w-0 truncate text-sm font-medium text-foreground">
+          {title}
+        </span>
+        {item.description !== null ? (
+          <span className="min-w-0 truncate text-xs text-muted-foreground">
+            {item.description}
+          </span>
+        ) : null}
+        <span className="truncate font-mono text-[11px] text-muted-foreground/80">
+          {item.filePath}
+        </span>
+      </button>
+      {expanded && hasEvidence ? (
+        <div className="border-t border-border/70 px-3 py-2">
+          <MemorySnippet
+            label="Before"
+            filePath={item.filePath}
+            snippet={item.beforeSnippet}
+          />
+          <MemorySnippet
+            label="After"
+            filePath={item.filePath}
+            snippet={item.afterSnippet}
+          />
+        </div>
+      ) : null}
+    </div>
+  );
+}
+
+function MemorySnippet({
+  label,
+  filePath,
+  snippet,
+}: {
+  readonly label: string;
+  readonly filePath: string;
+  readonly snippet: string | null;
+}) {
+  return (
+    <div className="mt-2 first:mt-0">
+      <div className="mb-1 text-[11px] font-medium uppercase tracking-wide text-muted-foreground">
+        {label}
+      </div>
+      {snippet === null ? (
+        <p className="text-xs italic text-muted-foreground">None</p>
+      ) : isMarkdownPath(filePath) ? (
+        <div className="overflow-auto rounded bg-muted/30 px-3 py-2 text-sm">
+          <Markdown source={snippet} />
+        </div>
+      ) : (
+        <pre className="overflow-auto whitespace-pre-wrap rounded bg-muted/30 px-3 py-2 font-mono text-xs leading-5 text-foreground">
+          {snippet}
+        </pre>
+      )}
+    </div>
+  );
+}
+
+function MemoryUpdatesEmptyState() {
+  return (
+    <section className="zero-card flex min-h-[420px] flex-1 flex-col items-center justify-center px-6 text-center">
+      <p className="text-sm font-medium text-foreground">No updates yet</p>
+      <p className="mt-1 max-w-sm text-sm text-muted-foreground">
+        Memory-change tracking starts from when this feature launched. As your
+        agents run and Zero learns, daily updates will appear here.
+      </p>
+    </section>
   );
 }
 


### PR DESCRIPTION
## Summary

Turns the Memory page into a tabbed experience: a new **Updates** tab (default) alongside the existing **Raw files** viewer (unchanged).

The Updates tab renders the precomputed daily Memory Activity timeline from the already-merged `GET /api/zero/memory/activity` read API:

- Reverse-chronological per-day cards showing the date, the LLM `summary`, and the day's change `items`.
- Items grouped by kind (**Learned** / **Updated** / **Forgotten**) with distinct badges; each item shows its title (falling back to the file path), optional description, the file path, and expandable before/after evidence. Markdown snippets reuse the existing `Markdown` component; non-markdown snippets render as preformatted text.
- When `summary` is `null` (LLM generation failed), a deterministic fallback line is shown (e.g. `3 changes — 2 learned, 1 updated`) so the card never looks broken.
- Empty state explains that memory-change tracking starts from when the feature launched, so a sparse timeline doesn't read as an error.

The page stays gated by the existing `FeatureSwitchKey.MemoryViewer` — no new switch, no change to setup/sidebar.

## Changes

- `signals/memory-page/memory-signals.ts`: `memoryActivity$` computed (mirrors `memoryDetail$`), `memoryTab$` state + `setMemoryTab$` command (default `"updates"`), and keyed per-item expand state (ccstate, since `useState` is restricted in this app).
- `views/memory-page/memory-page.tsx`: tab header using the platform's existing `Tabs`/`TabsList`/`TabsTrigger`; `MemoryRawFiles` wraps the unchanged `MemoryViewer`; new `MemoryUpdates` timeline.
- `mocks/handlers/api-memory-activity.ts` + registration: MSW handler for the activity endpoint.
- `views/memory-page/__tests__/memory-page.test.tsx`: tab switching, timeline rendering + evidence expansion, null-summary fallback, and Updates empty state; existing Raw-files tests now switch to the Raw files tab first.

No backend/API/cron/contract files were touched.

## Test plan

- `pnpm -F @vm0/app run test src/views/memory-page` — 10 passed
- `pnpm check-types`, `pnpm turbo run lint`, `pnpm format`, `pnpm knip` — all green

Part of #15977 (Memory Activity, PR-D: UI)

🤖 Generated with [Claude Code](https://claude.com/claude-code)