### PR TITLE
fix: make storage content hash serialization unambiguous

### DIFF
--- a/crates/guest-agent/src/checkpoint.rs
+++ b/crates/guest-agent/src/checkpoint.rs
@@ -270,7 +270,13 @@ async fn snapshot_artifact_entries(
         let local_hash = content_hash::compute_content_hash(
             &entry.storage_id,
             files.iter().map(|f| (f.path.as_str(), f.hash.as_str())),
-        );
+        )
+        .map_err(|error| {
+            AgentError::Checkpoint(format!(
+                "Failed to compute VAS artifact content hash for '{}': {error}",
+                entry.name
+            ))
+        })?;
         if local_hash == entry.version_id {
             log_info!(
                 LOG_TAG,

--- a/crates/guest-agent/src/content_hash.rs
+++ b/crates/guest-agent/src/content_hash.rs
@@ -1,5 +1,5 @@
-//! Content-addressable storage hash — Rust port of the TS implementation
-//! at `turbo/apps/web/src/lib/infra/storage/content-hash.ts`.
+//! Content-addressable storage hash — Rust port of the TS implementation at
+//! `turbo/apps/api/src/signals/services/storage-content-hash.service.ts`.
 //!
 //! `version_id` in VAS *is* this hash — the TS function is the sole producer
 //! across every prepare/commit route. Guest-side we recompute it locally so
@@ -7,41 +7,87 @@
 //! artifact is unchanged since mount (see issue #10967).
 //!
 //! The two implementations must stay byte-identical. The inline `#[cfg(test)]`
-//! suite below and its TS counterpart at
-//! `turbo/apps/web/src/lib/infra/storage/__tests__/content-hash-parity.test.ts`
+//! suite below and its TS counterpart in `turbo/apps/api/src/signals/services`
 //! hardcode the same fixture vectors — a drift on either side fails CI.
 
 use sha2::{Digest, Sha256};
+use thiserror::Error;
+
+const STORAGE_CONTENT_HASH_PREFIX: &[u8] = b"vm0-storage-content-hash-v2\0";
+
+#[derive(Debug, Error, PartialEq)]
+pub(crate) enum ContentHashError {
+    #[error("content hash field length exceeds u32")]
+    FieldLengthTooLarge,
+    #[error("file hash must be SHA-256 hex: {0}")]
+    InvalidFileHash(#[from] hex::FromHexError),
+}
+
+struct CanonicalEntry<'a> {
+    path: &'a str,
+    hash: [u8; 32],
+}
+
+fn update_u32(hasher: &mut Sha256, value: usize) -> Result<(), ContentHashError> {
+    let value = u32::try_from(value).map_err(|_| ContentHashError::FieldLengthTooLarge)?;
+    hasher.update(value.to_be_bytes());
+    Ok(())
+}
+
+fn update_length_prefixed_bytes(hasher: &mut Sha256, bytes: &[u8]) -> Result<(), ContentHashError> {
+    update_u32(hasher, bytes.len())?;
+    hasher.update(bytes);
+    Ok(())
+}
+
+fn sha256_digest_from_hex(hash: &str) -> Result<[u8; 32], ContentHashError> {
+    let mut bytes = [0u8; 32];
+    hex::decode_to_slice(hash, &mut bytes)?;
+    Ok(bytes)
+}
 
 /// Compute the content hash for a storage version.
 ///
-/// Format matches the TS reference:
-/// - empty files: `sha256("storage:<id>\n")`
-/// - non-empty: `sha256("storage:<id>\n<path>:<hash>\n<path>:<hash>…")`
-///   with entries sorted lexicographically.
-///
-/// The Rust byte-wise sort agrees with JS's default `Array.sort()` for any
-/// BMP code points (UTF-8 byte order and UTF-16 code-unit order coincide
-/// there). Non-BMP characters in a file path are the only theoretical
-/// divergence and are not present in current VAS-backed workloads.
-pub(crate) fn compute_content_hash<'a, I>(storage_id: &str, files: I) -> String
+/// Format matches the TS reference. The hash input is a v2 canonical byte
+/// stream, not delimiter-joined text:
+/// - domain/version prefix
+/// - u32be storage id byte length + UTF-8 storage id bytes
+/// - u32be entry count
+/// - for each entry sorted by `(path UTF-8 bytes, file digest bytes)`:
+///   - u32be path byte length + UTF-8 path bytes
+///   - 32-byte SHA-256 file digest parsed from hex
+pub(crate) fn compute_content_hash<'a, I>(
+    storage_id: &str,
+    files: I,
+) -> Result<String, ContentHashError>
 where
     I: IntoIterator<Item = (&'a str, &'a str)>,
 {
-    let mut entries: Vec<String> = files
+    let mut entries: Vec<CanonicalEntry<'a>> = files
         .into_iter()
-        .map(|(path, hash)| format!("{path}:{hash}"))
-        .collect();
+        .map(|(path, hash)| {
+            Ok(CanonicalEntry {
+                path,
+                hash: sha256_digest_from_hex(hash)?,
+            })
+        })
+        .collect::<Result<_, ContentHashError>>()?;
+    entries.sort_by(|a, b| {
+        a.path
+            .as_bytes()
+            .cmp(b.path.as_bytes())
+            .then_with(|| a.hash.cmp(&b.hash))
+    });
 
     let mut hasher = Sha256::new();
-    if entries.is_empty() {
-        hasher.update(format!("storage:{storage_id}\n").as_bytes());
-    } else {
-        entries.sort();
-        let combined = format!("storage:{storage_id}\n{}", entries.join("\n"));
-        hasher.update(combined.as_bytes());
+    hasher.update(STORAGE_CONTENT_HASH_PREFIX);
+    update_length_prefixed_bytes(&mut hasher, storage_id.as_bytes())?;
+    update_u32(&mut hasher, entries.len())?;
+    for entry in entries {
+        update_length_prefixed_bytes(&mut hasher, entry.path.as_bytes())?;
+        hasher.update(entry.hash);
     }
-    hex::encode(hasher.finalize())
+    Ok(hex::encode(hasher.finalize()))
 }
 
 #[cfg(test)]
@@ -49,28 +95,31 @@ mod tests {
     use super::*;
 
     // Fixtures below are shared with the TS parity test at
-    // `turbo/apps/web/src/lib/infra/storage/__tests__/content-hash-parity.test.ts`.
+    // `turbo/apps/api/src/signals/services/__tests__/storage-content-hash.service.test.ts`.
     // Any change here must be mirrored there (and vice versa); CI runs both
-    // sides, so a drift between TS `computeContentHashFromHashes` and this
-    // Rust port fails fast.
+    // sides, so a drift between TS `computeContentHashFromHashes` and this Rust
+    // port fails fast.
     const STORAGE_A: &str = "01234567-89ab-cdef-0123-456789abcdef";
     const STORAGE_B: &str = "ffffffff-ffff-ffff-ffff-ffffffffffff";
+    const HASH_A: &str = "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa";
+    const HASH_B: &str = "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb";
+    const HASH_C: &str = "cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc";
 
     #[test]
-    fn empty_files_hashes_storage_prefix_only() {
+    fn empty_files_hashes_v2_canonical_bytes() {
         let got = compute_content_hash(STORAGE_A, std::iter::empty());
         assert_eq!(
-            got,
-            "4c679c352da0ad578c21cc413e4afa83c32d467424725129795dda25d1c5ea4e"
+            got.as_deref(),
+            Ok("afde087ee3ce79ab8360daf49e5f68fe1bbb49153775fff6eff5e7ccd7ecdb57")
         );
     }
 
     #[test]
     fn single_file() {
-        let got = compute_content_hash(STORAGE_A, [("a.txt", "deadbeef")]);
+        let got = compute_content_hash(STORAGE_A, [("a.txt", HASH_A)]);
         assert_eq!(
-            got,
-            "3d7165d60d7fd53858323feb1cc04b0116aee77858b4aea45beba855f7816fc0"
+            got.as_deref(),
+            Ok("b7c8d9f8fe72381faeeeff30bab820e075ff048240f16ccc3ecec23e6ab32918")
         );
     }
 
@@ -78,11 +127,38 @@ mod tests {
     fn multiple_files_sorted_regardless_of_input_order() {
         let got = compute_content_hash(
             STORAGE_A,
-            [("b.txt", "222"), ("a.txt", "111"), ("c.txt", "333")],
+            [("b.txt", HASH_B), ("a.txt", HASH_A), ("c.txt", HASH_C)],
         );
         assert_eq!(
-            got,
-            "384d77579354ce230d8a7465343e1530e2561eab48a94d63e0bf80f90307e24c"
+            got.as_deref(),
+            Ok("4a91b8c9ac9c083131b960cc1d97d25aab243b841e29cbbd187597e6b82d5231")
+        );
+
+        let reversed = compute_content_hash(
+            STORAGE_A,
+            [("c.txt", HASH_C), ("a.txt", HASH_A), ("b.txt", HASH_B)],
+        );
+        assert_eq!(got, reversed);
+    }
+
+    #[test]
+    fn delimiter_bearing_paths_have_golden_vectors() {
+        let colon = compute_content_hash(STORAGE_A, [("dir:name/file.txt", HASH_A)]);
+        assert_eq!(
+            colon.as_deref(),
+            Ok("24eb7994557105120ffa3f444cb7384d275a9a0e6ffe53d8828366af54375b93")
+        );
+
+        let newline = compute_content_hash(STORAGE_A, [("line1\nline2.txt", HASH_A)]);
+        assert_eq!(
+            newline.as_deref(),
+            Ok("26d1a10c31ec4a704d4a76dcb858fb7633495c012624c07b99d31cdbee376740")
+        );
+
+        let non_bmp = compute_content_hash(STORAGE_A, [("emoji-😀.txt", HASH_A)]);
+        assert_eq!(
+            non_bmp.as_deref(),
+            Ok("231bec6d6d3c0d8ae2e9d740cf476156aa0fb7d555ccccf3acd033bc784842dd")
         );
     }
 
@@ -90,24 +166,36 @@ mod tests {
     fn different_storage_id_yields_different_hash() {
         let got = compute_content_hash(STORAGE_B, std::iter::empty());
         assert_eq!(
-            got,
-            "d87bf91de459004a9512e649c3484a8ced316fe5547149ec3f6b6ae669ac79ff"
+            got.as_deref(),
+            Ok("2fc5c81fee486da6a906b4c3e2d0036c3580784963a75521d817b4c54b055da7")
         );
     }
 
     #[test]
-    fn nested_paths_sort_lexicographically() {
-        let got = compute_content_hash(
-            STORAGE_A,
-            [
-                ("src/main.rs", "bbb"),
-                ("README.md", "ccc"),
-                ("src/lib.rs", "aaa"),
-            ],
+    fn file_hash_casing_is_canonicalized() {
+        let lowercase = compute_content_hash(STORAGE_A, [("a.txt", HASH_A)]);
+        let uppercase_hash = HASH_A.to_uppercase();
+        let uppercase = compute_content_hash(STORAGE_A, [("a.txt", uppercase_hash.as_str())]);
+        assert_eq!(lowercase, uppercase);
+    }
+
+    #[test]
+    fn old_text_format_collision_inputs_are_separated() {
+        let hash_1 = "1111111111111111111111111111111111111111111111111111111111111111";
+        let hash_2 = "2222222222222222222222222222222222222222222222222222222222222222";
+
+        let first = compute_content_hash(STORAGE_A, [("a", hash_1), ("b", hash_2)]);
+        let colliding_path = format!("a:{hash_1}\nb");
+        let second = compute_content_hash(STORAGE_A, [(colliding_path.as_str(), hash_2)]);
+
+        assert_eq!(
+            first.as_deref(),
+            Ok("49ebfcd2f3a4d5050ab39c789f5bed874014ebae3efa9cc08af3c79db5ab8def")
         );
         assert_eq!(
-            got,
-            "e7158d0cbdae3793daa8352a6197eab9f772d8cb8784c941d921e81f5d4b09d6"
+            second.as_deref(),
+            Ok("365babcde9af438dbba697ccfec0260f7a704785e481a4842cfaaf0468eb68b5")
         );
+        assert_ne!(first, second);
     }
 }

--- a/crates/guest-agent/src/content_hash.rs
+++ b/crates/guest-agent/src/content_hash.rs
@@ -180,6 +180,12 @@ mod tests {
     }
 
     #[test]
+    fn invalid_file_hash_returns_error() {
+        let got = compute_content_hash(STORAGE_A, [("a.txt", "g")]);
+        assert!(matches!(got, Err(ContentHashError::InvalidFileHash(_))));
+    }
+
+    #[test]
     fn old_text_format_collision_inputs_are_separated() {
         let hash_1 = "1111111111111111111111111111111111111111111111111111111111111111";
         let hash_2 = "2222222222222222222222222222222222222222222222222222222222222222";

--- a/turbo/apps/api/src/signals/routes/__tests__/storages-write.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/storages-write.test.ts
@@ -364,6 +364,43 @@ describe("POST /api/storages/prepare", () => {
     expect(response.body.error.code).toBe("BAD_REQUEST");
   });
 
+  it("returns 400 when a file hash is not hex", async () => {
+    await useClerkSession();
+
+    const response = await accept(
+      prepareClient().prepare({
+        body: prepareBody({
+          files: [validFile({ hash: "g".repeat(64) })],
+        }),
+        headers: authHeaders(),
+      }),
+      [400],
+    );
+
+    expect(response.body.error.code).toBe("BAD_REQUEST");
+    expect(response.body.error.message).toContain("Hash must be SHA-256 hex");
+  });
+
+  it("returns 400 when prepare files contain duplicate paths", async () => {
+    await useClerkSession();
+
+    const response = await accept(
+      prepareClient().prepare({
+        body: prepareBody({
+          files: [
+            validFile({ path: "duplicate.txt", hash: TEST_HASH }),
+            validFile({ path: "duplicate.txt", hash: SECOND_TEST_HASH }),
+          ],
+        }),
+        headers: authHeaders(),
+      }),
+      [400],
+    );
+
+    expect(response.body.error.code).toBe("BAD_REQUEST");
+    expect(response.body.error.message).toContain("Duplicate file path");
+  });
+
   it("computes the same version ID regardless of file order", async () => {
     await useClerkSession();
     const name = storageName("order-independent");
@@ -381,6 +418,25 @@ describe("POST /api/storages/prepare", () => {
     );
 
     expect(first.versionId).toBe(second.versionId);
+  });
+
+  it("canonicalizes uppercase file hashes", async () => {
+    await useClerkSession();
+    const name = storageName("hash-case");
+    const lower = await prepareOk(
+      prepareBody({
+        storageName: name,
+        files: [validFile({ path: "data.txt", hash: TEST_HASH })],
+      }),
+    );
+    const upper = await prepareOk(
+      prepareBody({
+        storageName: name,
+        files: [validFile({ path: "data.txt", hash: TEST_HASH.toUpperCase() })],
+      }),
+    );
+
+    expect(upper.versionId).toBe(lower.versionId);
   });
 
   it("computes different version IDs when file content or path changes", async () => {
@@ -555,6 +611,26 @@ describe("POST /api/storages/commit", () => {
     );
 
     expect(response.body.error.message).toContain("Version ID mismatch");
+  });
+
+  it("returns 400 when commit files contain duplicate paths", async () => {
+    await useClerkSession();
+
+    const response = await accept(
+      commitClient().commit({
+        body: commitBody({
+          files: [
+            validFile({ path: "duplicate.txt", hash: TEST_HASH }),
+            validFile({ path: "duplicate.txt", hash: SECOND_TEST_HASH }),
+          ],
+        }),
+        headers: authHeaders(),
+      }),
+      [400],
+    );
+
+    expect(response.body.error.code).toBe("BAD_REQUEST");
+    expect(response.body.error.message).toContain("Duplicate file path");
   });
 
   it("returns 400 when uploaded S3 objects are missing", async () => {

--- a/turbo/apps/api/src/signals/routes/__tests__/webhooks-agent-storage.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/webhooks-agent-storage.test.ts
@@ -323,6 +323,26 @@ describe("POST /api/webhooks/agent/storages/prepare", () => {
     expect(response.body.error.code).toBe("BAD_REQUEST");
   });
 
+  it("returns 400 when prepare files contain duplicate paths", async () => {
+    const fixture = await track(seedFixture());
+
+    const response = await accept(
+      prepareClient().prepare({
+        body: prepareBody(fixture, {
+          files: [
+            validFile({ path: "duplicate.txt", hash: TEST_HASH }),
+            validFile({ path: "duplicate.txt", hash: SECOND_TEST_HASH }),
+          ],
+        }),
+        headers: authHeaders(fixture),
+      }),
+      [400],
+    );
+
+    expect(response.body.error.code).toBe("BAD_REQUEST");
+    expect(response.body.error.message).toContain("Duplicate file path");
+  });
+
   it("returns existing=true for deduplicated versions with uploaded S3 files", async () => {
     const fixture = await track(seedFixture());
     const name = storageName("webhook-prepare-existing");
@@ -426,6 +446,26 @@ describe("POST /api/webhooks/agent/storages/commit", () => {
     );
 
     expect(response.body.error.message).toContain("Version ID mismatch");
+  });
+
+  it("returns 400 when commit files contain duplicate paths", async () => {
+    const fixture = await track(seedFixture());
+
+    const response = await accept(
+      commitClient().commit({
+        body: commitBody(fixture, {
+          files: [
+            validFile({ path: "duplicate.txt", hash: TEST_HASH }),
+            validFile({ path: "duplicate.txt", hash: SECOND_TEST_HASH }),
+          ],
+        }),
+        headers: authHeaders(fixture),
+      }),
+      [400],
+    );
+
+    expect(response.body.error.code).toBe("BAD_REQUEST");
+    expect(response.body.error.message).toContain("Duplicate file path");
   });
 
   it("commits uploaded storage and records artifact lineage", async () => {

--- a/turbo/apps/api/src/signals/routes/__tests__/zero-skills.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/zero-skills.test.ts
@@ -98,6 +98,13 @@ function skillFiles(content: string) {
   return [{ path: "SKILL.md", content }];
 }
 
+function duplicateSkillFiles() {
+  return [
+    { path: "SKILL.md", content: "# First" },
+    { path: "SKILL.md", content: "# Second" },
+  ];
+}
+
 function s3CommandInput(command: unknown): Record<string, unknown> {
   if (
     typeof command === "object" &&
@@ -439,6 +446,27 @@ describe("POST /api/zero/skills", () => {
     );
 
     expect(response.body.error.code).toBe("BAD_REQUEST");
+  });
+
+  it("returns 400 when create files contain duplicate paths", async () => {
+    const fixture = await track(
+      store.set(seedSkillsFixture$, undefined, context.signal),
+    );
+    mocks.clerk.session(fixture.userId, fixture.orgId, "org:admin");
+
+    const response = await accept(
+      listClient().create({
+        headers: authHeaders(),
+        body: {
+          name: "duplicate-path-skill",
+          files: duplicateSkillFiles(),
+        },
+      }),
+      [400],
+    );
+
+    expect(response.body.error.code).toBe("BAD_REQUEST");
+    expect(response.body.error.message).toContain("Duplicate file path");
   });
 
   it("stores the skill row and uploads a custom skill volume", async () => {
@@ -1054,6 +1082,25 @@ describe("PUT /api/zero/skills/:name", () => {
     );
 
     expect(response.body.error.code).toBe("BAD_REQUEST");
+  });
+
+  it("returns 400 when update files contain duplicate paths", async () => {
+    const fixture = await track(
+      store.set(seedSkillsFixture$, undefined, context.signal),
+    );
+    mocks.clerk.session(fixture.userId, fixture.orgId, "org:admin");
+
+    const response = await accept(
+      detailClient().update({
+        headers: authHeaders(),
+        params: { name: "any" },
+        body: { files: duplicateSkillFiles() },
+      }),
+      [400],
+    );
+
+    expect(response.body.error.code).toBe("BAD_REQUEST");
+    expect(response.body.error.message).toContain("Duplicate file path");
   });
 
   it("updates skill content and stores a new volume version", async () => {

--- a/turbo/apps/api/src/signals/routes/__tests__/zero-skills.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/zero-skills.test.ts
@@ -469,6 +469,32 @@ describe("POST /api/zero/skills", () => {
     expect(response.body.error.message).toContain("Duplicate file path");
   });
 
+  it("returns 400 when create files contain non-canonical paths", async () => {
+    const fixture = await track(
+      store.set(seedSkillsFixture$, undefined, context.signal),
+    );
+    mocks.clerk.session(fixture.userId, fixture.orgId, "org:admin");
+
+    const response = await accept(
+      listClient().create({
+        headers: authHeaders(),
+        body: {
+          name: "non-canonical-path-skill",
+          files: [
+            { path: "SKILL.md", content: "# Skill" },
+            { path: "templates/./prompt.md", content: "Use the tool" },
+          ],
+        },
+      }),
+      [400],
+    );
+
+    expect(response.body.error.code).toBe("BAD_REQUEST");
+    expect(response.body.error.message).toContain(
+      "Path must not contain empty or . segments",
+    );
+  });
+
   it("stores the skill row and uploads a custom skill volume", async () => {
     const fixture = await track(
       store.set(seedSkillsFixture$, undefined, context.signal),

--- a/turbo/apps/api/src/signals/services/__tests__/storage-content-hash.service.test.ts
+++ b/turbo/apps/api/src/signals/services/__tests__/storage-content-hash.service.test.ts
@@ -1,0 +1,139 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  computeContentHashFromHashes,
+  computeSystemSkillContentHash,
+  type FileEntryWithHash,
+} from "../storage-content-hash.service";
+
+const STORAGE_A = "01234567-89ab-cdef-0123-456789abcdef";
+const STORAGE_B = "ffffffff-ffff-ffff-ffff-ffffffffffff";
+const HASH_A = "a".repeat(64);
+const HASH_B = "b".repeat(64);
+const HASH_C = "c".repeat(64);
+
+function file(path: string, hash: string, size = 1): FileEntryWithHash {
+  return { path, hash, size };
+}
+
+describe("computeContentHashFromHashes", () => {
+  it.each([
+    {
+      name: "empty storage",
+      storageId: STORAGE_A,
+      files: [],
+      expected:
+        "afde087ee3ce79ab8360daf49e5f68fe1bbb49153775fff6eff5e7ccd7ecdb57",
+    },
+    {
+      name: "single file",
+      storageId: STORAGE_A,
+      files: [file("a.txt", HASH_A)],
+      expected:
+        "b7c8d9f8fe72381faeeeff30bab820e075ff048240f16ccc3ecec23e6ab32918",
+    },
+    {
+      name: "multiple files",
+      storageId: STORAGE_A,
+      files: [
+        file("b.txt", HASH_B),
+        file("a.txt", HASH_A),
+        file("c.txt", HASH_C),
+      ],
+      expected:
+        "4a91b8c9ac9c083131b960cc1d97d25aab243b841e29cbbd187597e6b82d5231",
+    },
+    {
+      name: "colon path",
+      storageId: STORAGE_A,
+      files: [file("dir:name/file.txt", HASH_A)],
+      expected:
+        "24eb7994557105120ffa3f444cb7384d275a9a0e6ffe53d8828366af54375b93",
+    },
+    {
+      name: "newline path",
+      storageId: STORAGE_A,
+      files: [file("line1\nline2.txt", HASH_A)],
+      expected:
+        "26d1a10c31ec4a704d4a76dcb858fb7633495c012624c07b99d31cdbee376740",
+    },
+    {
+      name: "non-BMP path",
+      storageId: STORAGE_A,
+      files: [file("emoji-😀.txt", HASH_A)],
+      expected:
+        "231bec6d6d3c0d8ae2e9d740cf476156aa0fb7d555ccccf3acd033bc784842dd",
+    },
+    {
+      name: "different storage id",
+      storageId: STORAGE_B,
+      files: [],
+      expected:
+        "2fc5c81fee486da6a906b4c3e2d0036c3580784963a75521d817b4c54b055da7",
+    },
+  ])("matches the v2 golden vector for $name", (testCase) => {
+    expect(
+      computeContentHashFromHashes(testCase.storageId, testCase.files),
+    ).toBe(testCase.expected);
+  });
+
+  it("computes the same hash regardless of file order", () => {
+    const files = [
+      file("b.txt", HASH_B),
+      file("a.txt", HASH_A),
+      file("c.txt", HASH_C),
+    ];
+
+    expect(computeContentHashFromHashes(STORAGE_A, files)).toBe(
+      computeContentHashFromHashes(STORAGE_A, [...files].reverse()),
+    );
+  });
+
+  it("canonicalizes file hash casing", () => {
+    expect(
+      computeContentHashFromHashes(STORAGE_A, [file("a.txt", HASH_A)]),
+    ).toBe(
+      computeContentHashFromHashes(STORAGE_A, [
+        file("a.txt", HASH_A.toUpperCase()),
+      ]),
+    );
+  });
+
+  it("separates file lists that collided under the old text format", () => {
+    const first = computeContentHashFromHashes(STORAGE_A, [
+      file("a", "1".repeat(64)),
+      file("b", "2".repeat(64)),
+    ]);
+    const second = computeContentHashFromHashes(STORAGE_A, [
+      file(`a:${"1".repeat(64)}\nb`, "2".repeat(64)),
+    ]);
+
+    expect(first).toBe(
+      "49ebfcd2f3a4d5050ab39c789f5bed874014ebae3efa9cc08af3c79db5ab8def",
+    );
+    expect(second).toBe(
+      "365babcde9af438dbba697ccfec0260f7a704785e481a4842cfaaf0468eb68b5",
+    );
+    expect(first).not.toBe(second);
+  });
+
+  it("rejects invalid file hashes", () => {
+    expect(() => {
+      computeContentHashFromHashes(STORAGE_A, [file("a.txt", "g".repeat(64))]);
+    }).toThrow("File hash must be SHA-256 hex");
+  });
+});
+
+describe("computeSystemSkillContentHash", () => {
+  it("uses a canonical file-list hash with a separate domain", () => {
+    expect(
+      computeSystemSkillContentHash(
+        "https://github.com/vm0-ai/vm0-skills/tree/main/base44",
+        [
+          file("SKILL.md", HASH_A, 100),
+          file("refs/examples:demo.md", HASH_B, 50),
+        ],
+      ),
+    ).toBe("e764015f47875727a22b46c03cc1e0d37bba7bbd3fab32e9a0d9eda688ef689b");
+  });
+});

--- a/turbo/apps/api/src/signals/services/cron-sync-skills.service.ts
+++ b/turbo/apps/api/src/signals/services/cron-sync-skills.service.ts
@@ -33,7 +33,10 @@ import { nowDate } from "../../lib/time";
 import { writeDb$, type Db } from "../external/db";
 import { deleteS3Objects, listS3Objects, putS3Object } from "../external/s3";
 import { settle } from "../utils";
-import type { FileEntryWithHash } from "./storage-content-hash.service";
+import {
+  computeSystemSkillContentHash,
+  type FileEntryWithHash,
+} from "./storage-content-hash.service";
 
 interface SyncSkillsResult {
   readonly commitSha: string;
@@ -184,26 +187,6 @@ async function downloadAndExtractSkills(
   );
 }
 
-function computeSystemSkillHash(
-  skillUrl: string,
-  files: readonly FileEntryWithHash[],
-): string {
-  if (files.length === 0) {
-    return createHash("sha256")
-      .update(`system-skill:${skillUrl}\n`)
-      .digest("hex");
-  }
-
-  const entries = files
-    .map((file) => {
-      return `${file.path}:${file.hash}`;
-    })
-    .sort();
-  return createHash("sha256")
-    .update(`system-skill:${skillUrl}\n${entries.join("\n")}`)
-    .digest("hex");
-}
-
 function skillUrl(skillName: string): string {
   return `https://github.com/${DEFAULT_SKILLS_OWNER}/${DEFAULT_SKILLS_REPO}/tree/${DEFAULT_SKILLS_BRANCH}/${skillName}`;
 }
@@ -237,7 +220,7 @@ function buildSkillSyncContext(extracted: ExtractedSkill): SkillSyncContext {
     fullPath,
     storageName: getSkillStorageName(fullPath),
     frontmatter,
-    versionHash: computeSystemSkillHash(url, fileEntries),
+    versionHash: computeSystemSkillContentHash(url, fileEntries),
     totalSize,
   };
 }

--- a/turbo/apps/api/src/signals/services/storage-content-hash.service.ts
+++ b/turbo/apps/api/src/signals/services/storage-content-hash.service.ts
@@ -1,4 +1,8 @@
-import { createHash } from "node:crypto";
+import { createHash, type Hash } from "node:crypto";
+
+const STORAGE_CONTENT_HASH_PREFIX = "vm0-storage-content-hash-v2\0";
+const SYSTEM_SKILL_CONTENT_HASH_PREFIX = "vm0-system-skill-content-hash-v2\0";
+const SHA256_HEX_PATTERN = /^[a-fA-F0-9]{64}$/;
 
 export interface FileEntryWithHash {
   readonly path: string;
@@ -10,21 +14,86 @@ export function hashFileContent(content: Buffer): string {
   return createHash("sha256").update(content).digest("hex");
 }
 
+function u32be(value: number): Buffer {
+  if (!Number.isSafeInteger(value) || value < 0 || value > 4_294_967_295) {
+    throw new Error(`Value ${value} cannot be encoded as u32`);
+  }
+  const buffer = Buffer.alloc(4);
+  buffer.writeUInt32BE(value, 0);
+  return buffer;
+}
+
+function sha256DigestFromHex(hash: string): Buffer {
+  if (!SHA256_HEX_PATTERN.test(hash)) {
+    throw new Error("File hash must be SHA-256 hex");
+  }
+  return Buffer.from(hash, "hex");
+}
+
+function updateLengthPrefixedBytes(hasher: Hash, bytes: Buffer): void {
+  hasher.update(u32be(bytes.length));
+  hasher.update(bytes);
+}
+
+function compareCanonicalEntries(
+  a: CanonicalFileEntry,
+  b: CanonicalFileEntry,
+): number {
+  const pathOrder = Buffer.compare(a.pathBytes, b.pathBytes);
+  if (pathOrder !== 0) {
+    return pathOrder;
+  }
+  return Buffer.compare(a.hashBytes, b.hashBytes);
+}
+
+interface CanonicalFileEntry {
+  readonly pathBytes: Buffer;
+  readonly hashBytes: Buffer;
+}
+
+function computeCanonicalFileListHash(
+  domainPrefix: string,
+  subjectId: string,
+  files: readonly FileEntryWithHash[],
+): string {
+  const entries = files
+    .map((file) => {
+      return {
+        pathBytes: Buffer.from(file.path, "utf8"),
+        hashBytes: sha256DigestFromHex(file.hash),
+      };
+    })
+    .sort(compareCanonicalEntries);
+
+  const hasher = createHash("sha256");
+  hasher.update(domainPrefix, "utf8");
+  updateLengthPrefixedBytes(hasher, Buffer.from(subjectId, "utf8"));
+  hasher.update(u32be(entries.length));
+  for (const entry of entries) {
+    updateLengthPrefixedBytes(hasher, entry.pathBytes);
+    hasher.update(entry.hashBytes);
+  }
+  return hasher.digest("hex");
+}
+
 export function computeContentHashFromHashes(
   storageId: string,
   files: readonly FileEntryWithHash[],
 ): string {
-  if (files.length === 0) {
-    return createHash("sha256").update(`storage:${storageId}\n`).digest("hex");
-  }
+  return computeCanonicalFileListHash(
+    STORAGE_CONTENT_HASH_PREFIX,
+    storageId,
+    files,
+  );
+}
 
-  const entries = files
-    .map((file) => {
-      return `${file.path}:${file.hash}`;
-    })
-    .sort();
-
-  return createHash("sha256")
-    .update(`storage:${storageId}\n${entries.join("\n")}`)
-    .digest("hex");
+export function computeSystemSkillContentHash(
+  skillUrl: string,
+  files: readonly FileEntryWithHash[],
+): string {
+  return computeCanonicalFileListHash(
+    SYSTEM_SKILL_CONTENT_HASH_PREFIX,
+    skillUrl,
+    files,
+  );
 }

--- a/turbo/packages/api-contracts/src/contracts/storages.ts
+++ b/turbo/packages/api-contracts/src/contracts/storages.ts
@@ -129,7 +129,7 @@ export const fileEntryWithHashSchema = z.object({
     .max(MAX_FILE_SIZE_BYTES, "File size exceeds 100MB limit"),
 });
 
-const fileEntriesWithHashSchema = z
+export const fileEntriesWithHashSchema = z
   .array(fileEntryWithHashSchema)
   .superRefine((files, ctx) => {
     const paths = new Set<string>();

--- a/turbo/packages/api-contracts/src/contracts/storages.ts
+++ b/turbo/packages/api-contracts/src/contracts/storages.ts
@@ -112,18 +112,39 @@ export type StoragesContract = typeof storagesContract;
  */
 export const MAX_FILE_SIZE_BYTES = 104_857_600;
 
+const sha256HexSchema = z
+  .string()
+  .regex(/^[a-fA-F0-9]{64}$/, "Hash must be SHA-256 hex");
+
 /**
  * File entry with hash for content-addressable storage
  */
 export const fileEntryWithHashSchema = z.object({
   path: z.string().min(1, "File path is required"),
-  hash: z.string().length(64, "Hash must be SHA-256 (64 hex chars)"),
+  hash: sha256HexSchema,
   size: z
     .number()
     .int()
     .min(0, "Size must be non-negative")
     .max(MAX_FILE_SIZE_BYTES, "File size exceeds 100MB limit"),
 });
+
+const fileEntriesWithHashSchema = z
+  .array(fileEntryWithHashSchema)
+  .superRefine((files, ctx) => {
+    const paths = new Set<string>();
+    for (const [index, file] of files.entries()) {
+      if (paths.has(file.path)) {
+        ctx.addIssue({
+          code: "custom",
+          path: [index, "path"],
+          message: `Duplicate file path "${file.path}"`,
+        });
+        continue;
+      }
+      paths.add(file.path);
+    }
+  });
 
 /**
  * Incremental changes schema for partial uploads
@@ -162,7 +183,7 @@ export const storagesPrepareContract = c.router({
     body: z.object({
       storageName: z.string().min(1, "Storage name is required"),
       storageType: storageTypeSchema,
-      files: z.array(fileEntryWithHashSchema),
+      files: fileEntriesWithHashSchema,
       force: z.boolean().optional(),
       runId: z.string().optional(), // For sandbox auth
       baseVersion: z.string().optional(), // For incremental uploads
@@ -207,7 +228,7 @@ export const storagesCommitContract = c.router({
       storageName: z.string().min(1, "Storage name is required"),
       storageType: storageTypeSchema,
       versionId: z.string().min(1, "Version ID is required"),
-      files: z.array(fileEntryWithHashSchema),
+      files: fileEntriesWithHashSchema,
       runId: z.string().optional(),
       message: z.string().optional(),
     }),

--- a/turbo/packages/api-contracts/src/contracts/webhooks.ts
+++ b/turbo/packages/api-contracts/src/contracts/webhooks.ts
@@ -5,7 +5,7 @@ import { secretConnectorMetadataMapSchema } from "./runners";
 import { eventSequenceNumberSchema, networkLogEntrySchema } from "./runs";
 import {
   storageTypeSchema,
-  fileEntryWithHashSchema,
+  fileEntriesWithHashSchema,
   storageChangesSchema,
   presignedUploadSchema,
 } from "./storages";
@@ -576,7 +576,7 @@ export const webhookStoragesPrepareContract = c.router({
       runId: z.string().min(1, "runId is required"), // Required for webhook auth
       storageName: z.string().min(1, "Storage name is required"),
       storageType: storageTypeSchema,
-      files: z.array(fileEntryWithHashSchema),
+      files: fileEntriesWithHashSchema,
       parentVersionId: z.string().optional(),
       force: z.boolean().optional(),
       baseVersion: z.string().optional(),
@@ -620,7 +620,7 @@ export const webhookStoragesCommitContract = c.router({
       storageType: storageTypeSchema,
       versionId: z.string().min(1, "Version ID is required"),
       parentVersionId: z.string().optional(),
-      files: z.array(fileEntryWithHashSchema),
+      files: fileEntriesWithHashSchema,
       message: z.string().optional(),
     }),
     responses: {

--- a/turbo/packages/api-contracts/src/contracts/zero-agents.ts
+++ b/turbo/packages/api-contracts/src/contracts/zero-agents.ts
@@ -265,6 +265,20 @@ export const zeroAgentSkillFilesRequestSchema = z.object({
       SKILL_FILES_MAX_COUNT,
       `Maximum ${SKILL_FILES_MAX_COUNT} files allowed`,
     )
+    .superRefine((files, ctx) => {
+      const paths = new Set<string>();
+      for (const [index, file] of files.entries()) {
+        if (paths.has(file.path)) {
+          ctx.addIssue({
+            code: "custom",
+            path: [index, "path"],
+            message: `Duplicate file path "${file.path}"`,
+          });
+          continue;
+        }
+        paths.add(file.path);
+      }
+    })
     .refine(
       (files) => {
         return files.some((f) => {

--- a/turbo/packages/api-contracts/src/contracts/zero-agents.ts
+++ b/turbo/packages/api-contracts/src/contracts/zero-agents.ts
@@ -240,6 +240,24 @@ export const skillFileEntrySchema = z.object({
       {
         message: "Path must not contain ..",
       },
+    )
+    .refine(
+      (p) => {
+        return !p.includes("\0");
+      },
+      {
+        message: "Path must not contain NUL",
+      },
+    )
+    .refine(
+      (p) => {
+        return p.split("/").every((segment) => {
+          return segment.length > 0 && segment !== ".";
+        });
+      },
+      {
+        message: "Path must not contain empty or . segments",
+      },
     ),
   content: z.string(),
 });


### PR DESCRIPTION
## Summary
- replace storage content hash input serialization with a v2 length-prefixed byte protocol
- share the same canonical hash behavior between the API and guest-agent implementations
- validate SHA-256 file hashes and reject duplicate storage file paths at the API contract boundary
- apply duplicate file path validation consistently to user storage, sandbox webhook storage, and custom skill file uploads
- reject non-canonical custom skill paths before server-side volume materialization
- move system skill file-list hashing to the same unambiguous protocol with a separate domain prefix

Closes #15960

## Tests
- pnpm -F api exec vitest run src/signals/services/__tests__/storage-content-hash.service.test.ts
- pnpm -F api exec vitest run src/signals/routes/__tests__/storages-write.test.ts
- pnpm -F api exec vitest run src/signals/routes/__tests__/webhooks-agent-storage.test.ts
- pnpm -F api exec vitest run src/signals/routes/__tests__/zero-skills.test.ts
- pnpm -F api exec vitest run src/signals/routes/__tests__/cron-sync-skills.test.ts
- pnpm -F @vm0/api-contracts exec vitest run
- pnpm -F api check-types
- pnpm -F @vm0/api-contracts check-types
- pnpm -F api lint
- pnpm -F @vm0/api-contracts lint
- CARGO_BUILD_JOBS=1 cargo test --manifest-path crates/Cargo.toml -p guest-agent --lib content_hash
- cargo test --manifest-path crates/Cargo.toml -p guest-agent content_hash (linking failed once with local OOM while building unrelated test target; lib-scoped test above passed)
- cargo clippy --manifest-path crates/Cargo.toml -p guest-agent --lib -- -D warnings
- cargo clippy --manifest-path crates/Cargo.toml -p guest-agent --all-targets -- -D warnings
- cargo fmt --manifest-path crates/Cargo.toml --package guest-agent
- pnpm format
- git diff --check
- pre-commit hook: block-generated-firewalls, check-file-size, cargo clippy/doc/fmt, prettier, knip, check-types