### PR TITLE
fix: sync artifact bucket files to google drive

### DIFF
--- a/turbo/apps/api/src/signals/routes/__tests__/zero-chat-threads-artifacts-sync.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/zero-chat-threads-artifacts-sync.test.ts
@@ -92,6 +92,13 @@ function isS3GetCommandLike(command: unknown): command is S3GetCommandLike {
   );
 }
 
+function s3CommandName(command: unknown): string {
+  if (typeof command !== "object" || command === null) {
+    return "";
+  }
+  return command.constructor.name;
+}
+
 function stubS3Buffer(
   buffer: Buffer,
   observe?: (command: S3GetCommandLike) => void,
@@ -467,6 +474,202 @@ describe("POST /api/zero/chat-threads/:threadId/artifacts", () => {
     expect(s3GetInput).toMatchObject({
       Bucket: "test-user-artifacts",
       Key: s3Key,
+    });
+  });
+
+  it("syncs artifact-bucket files resolved from persisted CDN URLs", async () => {
+    const fixture = await track(
+      store.set(seedUsageInsightFixture$, undefined, context.signal),
+    );
+    const { composeId } = await store.set(
+      seedCompose$,
+      { orgId: fixture.orgId, userId: fixture.userId },
+      context.signal,
+    );
+    const threadId = await store.set(
+      seedChatThread$,
+      { userId: fixture.userId, composeId },
+      context.signal,
+    );
+    const { runId } = await store.set(
+      seedRun$,
+      {
+        orgId: fixture.orgId,
+        userId: fixture.userId,
+        composeId,
+        status: "completed",
+        chatThreadId: threadId,
+      },
+      context.signal,
+    );
+    const s3Key = `artifacts/${encodeURIComponent(
+      fixture.userId,
+    )}/file-1/data.csv`;
+    const fileUrl = `https://cdn.vm7.io/${s3Key}`;
+    await seedRunUploadedFile({
+      runId,
+      userId: fixture.userId,
+      orgId: fixture.orgId,
+      externalId: "file-1",
+      filename: "data.csv",
+      contentType: "text/csv",
+      sizeBytes: 2048,
+      url: fileUrl,
+      metadata: { sourceUrl: fileUrl },
+    });
+    await seedGoogleDriveConnector({
+      orgId: fixture.orgId,
+      userId: fixture.userId,
+      accessToken: "drive-access-token",
+    });
+    seededDriveOrgs.push(fixture.orgId);
+
+    let s3GetInput: S3GetCommandLike["input"] | null = null;
+    stubS3Buffer(Buffer.from("name,value\nalpha,1\n"), (command) => {
+      if (s3CommandName(command) === "GetObjectCommand") {
+        s3GetInput = command.input;
+      }
+    });
+
+    server.use(
+      http.get("https://www.googleapis.com/drive/v3/files", () => {
+        return HttpResponse.json({
+          files: [{ id: "drive-folder-id", name: "folder" }],
+        });
+      }),
+      http.post("https://www.googleapis.com/upload/drive/v3/files", () => {
+        return HttpResponse.json({
+          id: "drive-file-id",
+          name: "data.csv",
+          webViewLink: "https://drive.google.com/file/d/drive-file-id/view",
+        });
+      }),
+    );
+
+    mocks.clerk.session(fixture.userId, fixture.orgId);
+
+    const client = setupApp({ context })(chatThreadArtifactsContract);
+    const response = await accept(
+      client.syncGoogleDrive({
+        params: { threadId },
+        body: { runId, fileId: "file-1" },
+        headers: { authorization: "Bearer clerk-session" },
+      }),
+      [200],
+    );
+
+    expect(response.body).toStrictEqual({
+      id: "drive-file-id",
+      name: "data.csv",
+      webViewLink: "https://drive.google.com/file/d/drive-file-id/view",
+    });
+    expect(s3GetInput).toMatchObject({
+      Bucket: "test-user-artifacts",
+      Key: s3Key,
+    });
+  });
+
+  it("falls back to legacy storage-bucket files when migrated artifacts are absent", async () => {
+    const fixture = await track(
+      store.set(seedUsageInsightFixture$, undefined, context.signal),
+    );
+    const { composeId } = await store.set(
+      seedCompose$,
+      { orgId: fixture.orgId, userId: fixture.userId },
+      context.signal,
+    );
+    const threadId = await store.set(
+      seedChatThread$,
+      { userId: fixture.userId, composeId },
+      context.signal,
+    );
+    const { runId } = await store.set(
+      seedRun$,
+      {
+        orgId: fixture.orgId,
+        userId: fixture.userId,
+        composeId,
+        status: "completed",
+        chatThreadId: threadId,
+      },
+      context.signal,
+    );
+    await seedRunUploadedFile({
+      runId,
+      userId: fixture.userId,
+      orgId: fixture.orgId,
+      externalId: "file-1",
+      filename: "data.csv",
+      contentType: "text/csv",
+      sizeBytes: 2048,
+      url: `http://localhost:3000/f/${fixture.userId}/file-1/data.csv`,
+      metadata: {},
+    });
+    await seedGoogleDriveConnector({
+      orgId: fixture.orgId,
+      userId: fixture.userId,
+      accessToken: "drive-access-token",
+    });
+    seededDriveOrgs.push(fixture.orgId);
+
+    let s3GetInput: S3GetCommandLike["input"] | null = null;
+    context.mocks.s3.send.mockImplementation((command: unknown) => {
+      if (!isS3GetCommandLike(command)) {
+        return Promise.resolve({});
+      }
+      if (s3CommandName(command) === "HeadObjectCommand") {
+        return Promise.reject(
+          Object.assign(new Error("NotFound"), {
+            name: "NotFound",
+            $metadata: { httpStatusCode: 404 },
+          }),
+        );
+      }
+      if (s3CommandName(command) === "GetObjectCommand") {
+        s3GetInput = command.input;
+        const stream = Readable.from([
+          new Uint8Array(Buffer.from("name,value\nalpha,1\n")),
+        ]);
+        return Promise.resolve({ Body: stream });
+      }
+      return Promise.resolve({});
+    });
+
+    server.use(
+      http.get("https://www.googleapis.com/drive/v3/files", () => {
+        return HttpResponse.json({
+          files: [{ id: "drive-folder-id", name: "folder" }],
+        });
+      }),
+      http.post("https://www.googleapis.com/upload/drive/v3/files", () => {
+        return HttpResponse.json({
+          id: "drive-file-id",
+          name: "data.csv",
+          webViewLink: "https://drive.google.com/file/d/drive-file-id/view",
+        });
+      }),
+    );
+
+    mocks.clerk.session(fixture.userId, fixture.orgId);
+
+    const client = setupApp({ context })(chatThreadArtifactsContract);
+    const response = await accept(
+      client.syncGoogleDrive({
+        params: { threadId },
+        body: { runId, fileId: "file-1" },
+        headers: { authorization: "Bearer clerk-session" },
+      }),
+      [200],
+    );
+
+    expect(response.body).toStrictEqual({
+      id: "drive-file-id",
+      name: "data.csv",
+      webViewLink: "https://drive.google.com/file/d/drive-file-id/view",
+    });
+    expect(s3GetInput).toMatchObject({
+      Bucket: "test-user-storages",
+      Key: `uploads/${fixture.userId}/file-1/data.csv`,
     });
   });
 });

--- a/turbo/apps/api/src/signals/routes/__tests__/zero-chat-threads-artifacts-sync.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/zero-chat-threads-artifacts-sync.test.ts
@@ -92,11 +92,15 @@ function isS3GetCommandLike(command: unknown): command is S3GetCommandLike {
   );
 }
 
-function stubS3Buffer(buffer: Buffer): void {
+function stubS3Buffer(
+  buffer: Buffer,
+  observe?: (command: S3GetCommandLike) => void,
+): void {
   context.mocks.s3.send.mockImplementation((command: unknown) => {
     if (!isS3GetCommandLike(command)) {
       return Promise.resolve({});
     }
+    observe?.(command);
     const stream = Readable.from([new Uint8Array(buffer)]);
     return Promise.resolve({ Body: stream });
   });
@@ -375,5 +379,94 @@ describe("POST /api/zero/chat-threads/:threadId/artifacts", () => {
     expect(uploadBody).toContain(`"vm0RunId":"${runId}"`);
     expect(uploadBody).toContain('"vm0FileId":"file-1"');
     expect(uploadBody).toContain("Content-Type: text/csv\r\n\r\nname,value");
+  });
+
+  it("syncs current artifact-bucket files to Google Drive", async () => {
+    const fixture = await track(
+      store.set(seedUsageInsightFixture$, undefined, context.signal),
+    );
+    const { composeId } = await store.set(
+      seedCompose$,
+      { orgId: fixture.orgId, userId: fixture.userId },
+      context.signal,
+    );
+    const threadId = await store.set(
+      seedChatThread$,
+      { userId: fixture.userId, composeId },
+      context.signal,
+    );
+    const { runId } = await store.set(
+      seedRun$,
+      {
+        orgId: fixture.orgId,
+        userId: fixture.userId,
+        composeId,
+        status: "completed",
+        chatThreadId: threadId,
+      },
+      context.signal,
+    );
+    const s3Key = `artifacts/${encodeURIComponent(
+      fixture.userId,
+    )}/file-1/data.csv`;
+    await seedRunUploadedFile({
+      runId,
+      userId: fixture.userId,
+      orgId: fixture.orgId,
+      externalId: "file-1",
+      filename: "data.csv",
+      contentType: "text/csv",
+      sizeBytes: 2048,
+      url: `https://cdn.vm7.io/${s3Key}`,
+      metadata: { s3Key },
+    });
+    await seedGoogleDriveConnector({
+      orgId: fixture.orgId,
+      userId: fixture.userId,
+      accessToken: "drive-access-token",
+    });
+    seededDriveOrgs.push(fixture.orgId);
+
+    let s3GetInput: S3GetCommandLike["input"] | null = null;
+    stubS3Buffer(Buffer.from("name,value\nalpha,1\n"), (command) => {
+      s3GetInput = command.input;
+    });
+
+    server.use(
+      http.get("https://www.googleapis.com/drive/v3/files", () => {
+        return HttpResponse.json({
+          files: [{ id: "drive-folder-id", name: "folder" }],
+        });
+      }),
+      http.post("https://www.googleapis.com/upload/drive/v3/files", () => {
+        return HttpResponse.json({
+          id: "drive-file-id",
+          name: "data.csv",
+          webViewLink: "https://drive.google.com/file/d/drive-file-id/view",
+        });
+      }),
+    );
+
+    mocks.clerk.session(fixture.userId, fixture.orgId);
+
+    const client = setupApp({ context })(chatThreadArtifactsContract);
+    const response = await accept(
+      client.syncGoogleDrive({
+        params: { threadId },
+        body: { runId, fileId: "file-1" },
+        headers: { authorization: "Bearer clerk-session" },
+      }),
+      [200],
+    );
+
+    expect(response.body).toStrictEqual({
+      id: "drive-file-id",
+      name: "data.csv",
+      webViewLink: "https://drive.google.com/file/d/drive-file-id/view",
+    });
+    expect(s3GetInput).toMatchObject({
+      Bucket: "test-user-artifacts",
+      Key: s3Key,
+    });
   });
 });

--- a/turbo/apps/api/src/signals/routes/__tests__/zero-integrations-agentphone-routes.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/zero-integrations-agentphone-routes.test.ts
@@ -1283,13 +1283,14 @@ describe("AgentPhone migrated API routes", () => {
     const orgId = uniqueId("org");
     const phoneHandle = uniquePhone();
     const uploadId = randomUUID();
+    const s3Key = `artifacts/${userId}/${uploadId}/photo.png`;
     await seedOrgMembership({ orgId, userId });
     const run = await seedRun({ userId, orgId });
     await seedAgentPhoneLink({ phoneHandle, userId, orgId });
     mocks.s3.listObjects([
       {
         bucket: "test-user-artifacts",
-        key: `artifacts/${userId}/${uploadId}/photo.png`,
+        key: s3Key,
         size: 456,
       },
     ]);
@@ -1336,6 +1337,33 @@ describe("AgentPhone migrated API routes", () => {
     ).resolves.toMatchObject({
       direction: "outbound",
       mediaUrl: response.body.url,
+    });
+    const [uploadedFile] = await writeDb
+      .select({
+        runId: runUploadedFiles.runId,
+        source: runUploadedFiles.source,
+        externalId: runUploadedFiles.externalId,
+        url: runUploadedFiles.url,
+        metadata: runUploadedFiles.metadata,
+      })
+      .from(runUploadedFiles)
+      .where(
+        and(
+          eq(runUploadedFiles.runId, run.runId),
+          eq(runUploadedFiles.externalId, response.body.messageId),
+        ),
+      )
+      .limit(1);
+    expect(uploadedFile).toMatchObject({
+      runId: run.runId,
+      source: "agentphone",
+      externalId: response.body.messageId,
+      url: response.body.url,
+      metadata: {
+        uploadId,
+        s3Key,
+        sourceUrl: response.body.url,
+      },
     });
   });
 

--- a/turbo/apps/api/src/signals/routes/__tests__/zero-integrations-github-files.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/zero-integrations-github-files.test.ts
@@ -444,6 +444,7 @@ describe("GitHub zero file integration routes", () => {
         repo: "vm0-ai/vm0",
         issueNumber: 42,
         uploadId,
+        s3Key,
         sourceUrl: fileUrl,
         caption: "Daily report",
         githubComment: { id: "98765" },

--- a/turbo/apps/api/src/signals/routes/__tests__/zero-integrations-telegram-upload-complete.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/zero-integrations-telegram-upload-complete.test.ts
@@ -220,6 +220,7 @@ describe("POST /api/zero/integrations/telegram/upload-file/complete", () => {
         botId: fixture.telegramBotId,
         chatId: "-1001234567890",
         uploadId,
+        s3Key,
         sourceUrl: fileUrl,
         caption: "Daily report",
         messageThreadId: 42,

--- a/turbo/apps/api/src/signals/routes/zero-integrations-github-upload-complete.ts
+++ b/turbo/apps/api/src/signals/routes/zero-integrations-github-upload-complete.ts
@@ -45,6 +45,7 @@ function buildCommentBody(args: {
 
 function buildMetadata(args: {
   readonly body: GithubUploadCompleteBody;
+  readonly s3Key: string;
   readonly sourceUrl: string;
   readonly commentId: string;
 }): Record<string, unknown> {
@@ -52,6 +53,7 @@ function buildMetadata(args: {
     repo: args.body.repo,
     issueNumber: args.body.issueNumber,
     uploadId: args.body.uploadId,
+    s3Key: args.s3Key,
     sourceUrl: args.sourceUrl,
     ...(args.body.caption ? { caption: args.body.caption } : {}),
     githubComment: { id: args.commentId },
@@ -141,7 +143,12 @@ const complete$ = command(async ({ get, set }, signal: AbortSignal) => {
       contentType: mimetype,
       sizeBytes: object.size,
       url: fileUrl,
-      metadata: buildMetadata({ body, sourceUrl: fileUrl, commentId }),
+      metadata: buildMetadata({
+        body,
+        s3Key: object.key,
+        sourceUrl: fileUrl,
+        commentId,
+      }),
     },
     signal,
   );

--- a/turbo/apps/api/src/signals/routes/zero-integrations-phone-upload-complete.ts
+++ b/turbo/apps/api/src/signals/routes/zero-integrations-phone-upload-complete.ts
@@ -60,12 +60,14 @@ function agentPhoneRouteError(error: unknown) {
 function buildMetadata(params: {
   readonly body: PhoneUploadCompleteBody;
   readonly uploadId: string;
+  readonly s3Key: string;
   readonly sourceUrl: string;
   readonly agentphoneMessageId: string;
 }): Record<string, unknown> {
   return {
     toNumber: normalizeAgentPhoneHandle(params.body.toNumber, "sms"),
     uploadId: params.uploadId,
+    s3Key: params.s3Key,
     sourceUrl: params.sourceUrl,
     ...(params.body.caption ? { caption: params.body.caption } : {}),
     agentphoneMessage: { id: params.agentphoneMessageId },
@@ -163,6 +165,7 @@ const complete$ = command(async ({ get, set }, signal: AbortSignal) => {
       metadata: buildMetadata({
         body,
         uploadId: body.uploadId,
+        s3Key: uploadedFile.key,
         sourceUrl: uploadedFile.fileUrl,
         agentphoneMessageId: sent.id,
       }),

--- a/turbo/apps/api/src/signals/routes/zero-integrations-telegram-upload-complete.ts
+++ b/turbo/apps/api/src/signals/routes/zero-integrations-telegram-upload-complete.ts
@@ -55,15 +55,17 @@ const organizationContextRequired = Object.freeze({
 
 function buildMetadata(args: {
   readonly body: TelegramUploadCompleteBody;
+  readonly s3Key: string;
   readonly sourceUrl: string;
   readonly telegramMessageId: number;
   readonly telegramFileId: string | undefined;
 }): Record<string, unknown> {
-  const { body, sourceUrl, telegramMessageId, telegramFileId } = args;
+  const { body, s3Key, sourceUrl, telegramMessageId, telegramFileId } = args;
   return {
     botId: body.botId,
     chatId: body.chatId,
     uploadId: body.uploadId,
+    s3Key,
     sourceUrl,
     ...(body.caption ? { caption: body.caption } : {}),
     ...(body.messageThreadId ? { messageThreadId: body.messageThreadId } : {}),
@@ -166,6 +168,7 @@ const completeInner$ = command(async ({ get, set }, signal: AbortSignal) => {
       url: fileUrl,
       metadata: buildMetadata({
         body,
+        s3Key: s3Object.key,
         sourceUrl: fileUrl,
         telegramMessageId: result.messageId,
         telegramFileId: fileId,

--- a/turbo/apps/api/src/signals/services/google-drive-artifact-sync.service.ts
+++ b/turbo/apps/api/src/signals/services/google-drive-artifact-sync.service.ts
@@ -17,9 +17,13 @@ import { z } from "zod";
 
 import { env, optionalEnv } from "../../lib/env";
 import { badRequestMessage, notFound } from "../../lib/error";
+import {
+  buildArtifactKey,
+  storageUserIdFromFileUrlSegment,
+} from "../../lib/file-url";
 import { db$, type ReadonlyDb } from "../external/db";
-import { downloadS3Buffer } from "../external/s3";
-import { settle } from "../utils";
+import { downloadS3Buffer, s3ObjectExists } from "../external/s3";
+import { safeSync, settle } from "../utils";
 import { decryptStoredSecretValue } from "./crypto.utils";
 import { userFeatureSwitchOverrides } from "./feature-switches.service";
 
@@ -444,14 +448,10 @@ async function loadArtifactFile(
   return row ?? null;
 }
 
-function resolveArtifactS3Object(
-  metadata: Record<string, unknown>,
+function resolveArtifactS3ObjectFromKey(
+  value: string,
   userId: string,
 ): ArtifactS3Object | null {
-  const value = metadata.s3Key;
-  if (typeof value !== "string") {
-    return null;
-  }
   if (value.startsWith(`artifacts/${encodeURIComponent(userId)}/`)) {
     return {
       bucketName: env("R2_USER_ARTIFACTS_BUCKET_NAME"),
@@ -465,6 +465,118 @@ function resolveArtifactS3Object(
     bucketName: env("R2_USER_STORAGES_BUCKET_NAME"),
     key: value,
   };
+}
+
+function resolveArtifactS3ObjectFromUrl(
+  value: string,
+  userId: string,
+): ArtifactS3Object | null {
+  if (!URL.canParse(value)) {
+    return null;
+  }
+  const key = new URL(value).pathname.replace(/^\/+/, "");
+  return resolveArtifactS3ObjectFromKey(key, userId);
+}
+
+interface LegacyFileUrlParts {
+  readonly storageUserId: string;
+  readonly id: string;
+  readonly filename: string;
+}
+
+function decodeUrlSegment(segment: string): string | null {
+  const result = safeSync(() => {
+    return decodeURIComponent(segment);
+  });
+  if ("error" in result) {
+    return null;
+  }
+  return result.ok;
+}
+
+function legacyFileUrlParts(value: string): LegacyFileUrlParts | null {
+  if (!URL.canParse(value)) {
+    return null;
+  }
+  const segments = new URL(value).pathname.split("/").filter(Boolean);
+  if (segments.length !== 4 || segments[0] !== "f") {
+    return null;
+  }
+
+  const [, rawUserIdSegment, rawId, rawFilename] = segments;
+  if (!rawUserIdSegment || !rawId || !rawFilename) {
+    return null;
+  }
+
+  const userIdSegment = decodeUrlSegment(rawUserIdSegment);
+  const id = decodeUrlSegment(rawId);
+  const filename = decodeUrlSegment(rawFilename);
+  if (!userIdSegment || !id || !filename) {
+    return null;
+  }
+
+  return {
+    storageUserId: storageUserIdFromFileUrlSegment(userIdSegment),
+    id,
+    filename,
+  };
+}
+
+function artifactSourceUrls(artifact: ArtifactFileRow): readonly string[] {
+  const metadataSourceUrl = artifact.metadata.sourceUrl;
+  return [
+    ...(artifact.url ? [artifact.url] : []),
+    ...(typeof metadataSourceUrl === "string" &&
+    metadataSourceUrl !== artifact.url
+      ? [metadataSourceUrl]
+      : []),
+  ];
+}
+
+function resolveArtifactS3Object(
+  artifact: ArtifactFileRow,
+  userId: string,
+): Computed<Promise<ArtifactS3Object | null>> {
+  return computed(async (get): Promise<ArtifactS3Object | null> => {
+    const value = artifact.metadata.s3Key;
+    if (typeof value === "string") {
+      const s3Object = resolveArtifactS3ObjectFromKey(value, userId);
+      if (s3Object) {
+        return s3Object;
+      }
+    }
+
+    for (const sourceUrl of artifactSourceUrls(artifact)) {
+      const s3Object = resolveArtifactS3ObjectFromUrl(sourceUrl, userId);
+      if (s3Object) {
+        return s3Object;
+      }
+    }
+
+    for (const sourceUrl of artifactSourceUrls(artifact)) {
+      const legacy = legacyFileUrlParts(sourceUrl);
+      if (!legacy || legacy.storageUserId !== userId) {
+        continue;
+      }
+
+      const artifactBucket = env("R2_USER_ARTIFACTS_BUCKET_NAME");
+      const artifactKey = buildArtifactKey(
+        legacy.storageUserId,
+        legacy.id,
+        legacy.filename,
+      );
+      if (await get(s3ObjectExists(artifactBucket, artifactKey))) {
+        return { bucketName: artifactBucket, key: artifactKey };
+      }
+
+      return {
+        bucketName: env("R2_USER_STORAGES_BUCKET_NAME"),
+        key: `uploads/${legacy.storageUserId}/${legacy.id}/${legacy.filename}`,
+      };
+    }
+
+    return null;
+  });
 }
 
 type DriveTokenResult<T> =
@@ -693,7 +805,7 @@ type BadRequestResponse = ReturnType<typeof badRequestMessage>;
  *  - 400 "Connect Google Drive before syncing artifacts" — connector
  *    absent or `needsReconnect`.
  *  - 400 "This artifact file cannot be synced to Google Drive" — file
- *    metadata.s3Key is missing or doesn't match a caller-owned artifact prefix.
+ *    location is missing or doesn't match a caller-owned artifact prefix.
  *  - 400 "Google Drive upload failed with HTTP <status>" — upload error
  *    after refresh-token retry exhausted.
  *  - 200 with `{ id, name, webViewLink }`.
@@ -741,7 +853,8 @@ export const syncArtifactToGoogleDrive$ = command(
       return notFound("Artifact file not found");
     }
 
-    const s3Object = resolveArtifactS3Object(artifact.metadata, args.userId);
+    const s3Object = await get(resolveArtifactS3Object(artifact, args.userId));
+    signal.throwIfAborted();
     if (!s3Object) {
       return badRequestMessage(
         "This artifact file cannot be synced to Google Drive",

--- a/turbo/apps/api/src/signals/services/google-drive-artifact-sync.service.ts
+++ b/turbo/apps/api/src/signals/services/google-drive-artifact-sync.service.ts
@@ -384,6 +384,11 @@ interface ArtifactFileRow {
   readonly metadata: Record<string, unknown>;
 }
 
+interface ArtifactS3Object {
+  readonly bucketName: string;
+  readonly key: string;
+}
+
 async function loadArtifactFile(
   db: ReadonlyDb,
   args: {
@@ -439,18 +444,27 @@ async function loadArtifactFile(
   return row ?? null;
 }
 
-function resolveArtifactS3Key(
+function resolveArtifactS3Object(
   metadata: Record<string, unknown>,
   userId: string,
-): string | null {
+): ArtifactS3Object | null {
   const value = metadata.s3Key;
   if (typeof value !== "string") {
     return null;
   }
+  if (value.startsWith(`artifacts/${encodeURIComponent(userId)}/`)) {
+    return {
+      bucketName: env("R2_USER_ARTIFACTS_BUCKET_NAME"),
+      key: value,
+    };
+  }
   if (!value.startsWith(`uploads/${userId}/`)) {
     return null;
   }
-  return value;
+  return {
+    bucketName: env("R2_USER_STORAGES_BUCKET_NAME"),
+    key: value,
+  };
 }
 
 type DriveTokenResult<T> =
@@ -679,7 +693,7 @@ type BadRequestResponse = ReturnType<typeof badRequestMessage>;
  *  - 400 "Connect Google Drive before syncing artifacts" — connector
  *    absent or `needsReconnect`.
  *  - 400 "This artifact file cannot be synced to Google Drive" — file
- *    metadata.s3Key is missing or doesn't match the caller's user prefix.
+ *    metadata.s3Key is missing or doesn't match a caller-owned artifact prefix.
  *  - 400 "Google Drive upload failed with HTTP <status>" — upload error
  *    after refresh-token retry exhausted.
  *  - 200 with `{ id, name, webViewLink }`.
@@ -727,8 +741,8 @@ export const syncArtifactToGoogleDrive$ = command(
       return notFound("Artifact file not found");
     }
 
-    const s3Key = resolveArtifactS3Key(artifact.metadata, args.userId);
-    if (!s3Key) {
+    const s3Object = resolveArtifactS3Object(artifact.metadata, args.userId);
+    if (!s3Object) {
       return badRequestMessage(
         "This artifact file cannot be synced to Google Drive",
       );
@@ -736,9 +750,7 @@ export const syncArtifactToGoogleDrive$ = command(
 
     const filename = artifact.filename ?? artifact.externalId;
     const contentType = artifact.contentType ?? inferMimetype(filename);
-    const file = await get(
-      downloadS3Buffer(env("R2_USER_STORAGES_BUCKET_NAME"), s3Key),
-    );
+    const file = await get(downloadS3Buffer(s3Object.bucketName, s3Object.key));
     signal.throwIfAborted();
 
     let result = await uploadArtifactWithToken({


### PR DESCRIPTION
## Summary
- support current artifact-bucket S3 keys when syncing artifacts to Google Drive
- keep legacy uploads-bucket artifact keys supported
- add route coverage verifying artifact-bucket files are read from R2_USER_ARTIFACTS_BUCKET_NAME before Drive upload

## Testing
- pnpm format
- pnpm -F api lint
- pnpm -F api check-types
- pnpm knip --workspace api
- DATABASE_URL=<temp migrated db> pnpm -F api exec vitest src/signals/routes/__tests__/zero-chat-threads-artifacts-sync.test.ts
- pre-commit: pnpm knip --cache; pnpm check-types