### PR TITLE
fix: hide skill frontmatter in viewer

### DIFF
--- a/turbo/apps/platform/src/views/skills-page/__tests__/skills-page.test.tsx
+++ b/turbo/apps/platform/src/views/skills-page/__tests__/skills-page.test.tsx
@@ -17,6 +17,16 @@ const context = testContext();
 
 const RESEARCH_AGENT_ID = "c0000000-0000-4000-a000-000000000001";
 const WRITER_AGENT_ID = "c0000000-0000-4000-a000-000000000002";
+const RESEARCH_SKILL_CONTENT = [
+  "---",
+  "name: Research Notes",
+  "description: Capture source-backed findings",
+  "---",
+  "",
+  "# Research Notes",
+  "",
+  "Start with sources.",
+].join("\n");
 
 const AGENTS = [
   {
@@ -112,7 +122,7 @@ function setupSkillsPage(): void {
       name: "research-notes",
       displayName: "Research Notes",
       description: "Capture source-backed findings",
-      content: "# Research Notes\n\nStart with sources.",
+      content: RESEARCH_SKILL_CONTENT,
       files: [
         { path: "SKILL.md", size: 37 },
         { path: "templates/prompt.md", size: 12 },
@@ -121,7 +131,7 @@ function setupSkillsPage(): void {
       fileContents: [
         {
           path: "SKILL.md",
-          content: "# Research Notes\n\nStart with sources.",
+          content: RESEARCH_SKILL_CONTENT,
         },
         { path: "templates/prompt.md", content: "Use the tool" },
         { path: "scripts/run.sh", content: "#!/bin/sh\necho hi" },
@@ -254,5 +264,23 @@ describe("skills page", () => {
       expect(content.tagName).toBe("PRE");
       expect(content).toHaveTextContent("#!/bin/sh");
     });
+  });
+
+  it("strips leading YAML frontmatter from markdown skill files", async () => {
+    setupSkillsPage();
+
+    click(await screen.findByText("Research Notes"));
+
+    await waitFor(() => {
+      expect(screen.getByLabelText("Skill content")).toHaveTextContent(
+        "Start with sources.",
+      );
+    });
+
+    const content = screen.getByLabelText("Skill content");
+    expect(content).not.toHaveTextContent("---");
+    expect(content).not.toHaveTextContent("name:");
+    expect(content).not.toHaveTextContent("description:");
+    expect(content).not.toHaveTextContent("Capture source-backed findings");
   });
 });

--- a/turbo/apps/platform/src/views/skills-page/skills-page.tsx
+++ b/turbo/apps/platform/src/views/skills-page/skills-page.tsx
@@ -42,6 +42,8 @@ const ALL_AGENTS_FILTER = "all";
 const LIST_AVATAR_LIMIT = 5;
 const SKILL_LIST_GRID =
   "grid grid-cols-[minmax(10rem,1.1fr)_minmax(16rem,1.8fr)_8rem_2.5rem] gap-x-6 items-center";
+const LEADING_YAML_FRONTMATTER_PATTERN =
+  /^---[ \t]*\r?\n[\s\S]*?\r?\n---[ \t]*(?:\r?\n|$)/;
 
 function skillTitle(skill: {
   readonly name: string;
@@ -56,6 +58,10 @@ function agentTitle(agent: TeamComposeItem): string {
 
 function isMarkdownPath(path: string): boolean {
   return /\.(md|markdown|mdx)$/i.test(path);
+}
+
+function stripMarkdownFrontmatter(content: string): string {
+  return content.replace(LEADING_YAML_FRONTMATTER_PATTERN, "");
 }
 
 export function SkillsPage() {
@@ -380,7 +386,7 @@ function SkillEditor({
                 aria-label="Skill content"
                 className="min-h-[420px] flex-1 overflow-auto bg-background px-4 py-3"
               >
-                <Markdown source={selectedContent} />
+                <Markdown source={stripMarkdownFrontmatter(selectedContent)} />
               </div>
             ) : (
               <pre


### PR DESCRIPTION
## Summary

- Strip leading YAML frontmatter before rendering Markdown files in the skills detail viewer.
- Keep non-Markdown skill files rendered as raw text.
- Add a regression test for `SKILL.md` content that includes `name` and `description` frontmatter.

Closes #16013

## Tests

- `PATH=/Users/lancy/.nvm/versions/node/v24.11.0/bin:$PATH ./node_modules/.bin/vitest run src/views/skills-page/__tests__/skills-page.test.tsx` from `turbo/apps/platform`
- `PATH=/Users/lancy/.nvm/versions/node/v24.11.0/bin:$PATH pnpm -F @vm0/app check-types` from `turbo`
- `PATH=/Users/lancy/.nvm/versions/node/v24.11.0/bin:$PATH pnpm -F @vm0/app lint` from `turbo`
- `PATH=/Users/lancy/.nvm/versions/node/v24.11.0/bin:$PATH pnpm exec prettier --check apps/platform/src/views/skills-page/skills-page.tsx apps/platform/src/views/skills-page/__tests__/skills-page.test.tsx` from `turbo`

Note: local shell `node` resolved to v25.6.1, which exposes a broken Node webstorage `localStorage` object in this environment. The focused test passes with the nvm Node v24.11.0 toolchain used by local `pnpm`.