### PR TITLE
fix(api): make memory activity item ordering deterministic

### DIFF
--- a/turbo/apps/api/src/signals/routes/__tests__/helpers/zero-memory.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/helpers/zero-memory.ts
@@ -98,12 +98,12 @@ export const seedMemoryActivitySummary$ = command(
 
     const items = seed.items ?? [];
     if (items.length > 0) {
-      // Stagger `created_at` per item so the seeded order is preserved by the
-      // service's `ORDER BY created_at, id`. A plain multi-row insert would give
-      // every item the same transaction-start `now()`, leaving order undefined.
-      const base = Date.UTC(2025, 0, 1);
+      // Mirror the cron: every item of a summary is batch-inserted in one
+      // transaction and so shares the same transaction-start `now()`
+      // `created_at`. This leaves `created_at` order undefined and lets the
+      // service's `kind` / `file_path` ordering be exercised honestly.
       await db.insert(memoryChangeItems).values(
-        items.map((item, index) => {
+        items.map((item) => {
           return {
             summaryId,
             kind: item.kind,
@@ -112,7 +112,6 @@ export const seedMemoryActivitySummary$ = command(
             filePath: item.filePath,
             beforeSnippet: item.beforeSnippet ?? null,
             afterSnippet: item.afterSnippet ?? null,
-            createdAt: new Date(base + index * 1000),
           };
         }),
       );

--- a/turbo/apps/api/src/signals/routes/__tests__/zero-memory-activity.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/zero-memory-activity.test.ts
@@ -134,15 +134,9 @@ describe("GET /api/zero/memory/activity", () => {
           summary: null,
           fromVersionId: "v1",
           toVersionId: "v2",
+          // Items are ordered by `kind` then `file_path`, so `forgotten`
+          // precedes `updated` regardless of the seeded insertion order.
           items: [
-            {
-              kind: "updated",
-              title: "Project uses pnpm",
-              description: null,
-              filePath: "preferences/pnpm.md",
-              beforeSnippet: "Use pnpm for all package operations",
-              afterSnippet: "Use pnpm 9 for all package operations",
-            },
             {
               kind: "forgotten",
               title: null,
@@ -150,6 +144,14 @@ describe("GET /api/zero/memory/activity", () => {
               filePath: "notes/stale.md",
               beforeSnippet: "Old note",
               afterSnippet: null,
+            },
+            {
+              kind: "updated",
+              title: "Project uses pnpm",
+              description: null,
+              filePath: "preferences/pnpm.md",
+              beforeSnippet: "Use pnpm for all package operations",
+              afterSnippet: "Use pnpm 9 for all package operations",
             },
           ],
         },
@@ -206,10 +208,15 @@ describe("GET /api/zero/memory/activity", () => {
     ]);
   });
 
-  it("returns a summary's items in a deterministic order", async () => {
+  it("orders a summary's items deterministically by kind then file_path", async () => {
     const fixture = await track(
       store.set(seedMemoryFixture$, undefined, context.signal),
     );
+    // Seeded out of the expected order and with a `file_path`-only order
+    // (b, a, d, c) that differs from the kind-then-path order, so a pass
+    // can only come from sorting on `kind` first and `file_path` second.
+    // All items share one batch-insert `created_at`, mirroring the cron, so
+    // the previous `created_at` ordering would leave this order undefined.
     await store.set(
       seedMemoryActivitySummary$,
       {
@@ -219,10 +226,10 @@ describe("GET /api/zero/memory/activity", () => {
         toVersionId: "v-order",
         summary: "Many changes in one day",
         items: [
-          { kind: "learned", filePath: "a.md" },
           { kind: "updated", filePath: "b.md" },
-          { kind: "forgotten", filePath: "c.md" },
           { kind: "learned", filePath: "d.md" },
+          { kind: "learned", filePath: "a.md" },
+          { kind: "forgotten", filePath: "c.md" },
         ],
       },
       context.signal,
@@ -236,9 +243,14 @@ describe("GET /api/zero/memory/activity", () => {
 
     expect(
       response.body.entries[0]?.items.map((item) => {
-        return item.filePath;
+        return { kind: item.kind, filePath: item.filePath };
       }),
-    ).toStrictEqual(["a.md", "b.md", "c.md", "d.md"]);
+    ).toStrictEqual([
+      { kind: "forgotten", filePath: "c.md" },
+      { kind: "learned", filePath: "a.md" },
+      { kind: "learned", filePath: "d.md" },
+      { kind: "updated", filePath: "b.md" },
+    ]);
   });
 
   it("scopes summaries to the authenticated user and org", async () => {

--- a/turbo/apps/api/src/signals/services/zero-memory-activity.service.ts
+++ b/turbo/apps/api/src/signals/services/zero-memory-activity.service.ts
@@ -88,10 +88,12 @@ export function zeroMemoryActivity(
       })
       .from(memoryChangeItems)
       .where(inArray(memoryChangeItems.summaryId, summaryIds))
-      // `created_at` defaults to the transaction-start `now()`, so all items of
-      // a single batch insert share one timestamp; `id` is a stable secondary
-      // key that gives a fully deterministic order instead of an undefined one.
-      .orderBy(asc(memoryChangeItems.createdAt), asc(memoryChangeItems.id));
+      // The cron batch-inserts every item of a summary in one transaction, so
+      // they all share the transaction-start `now()` `created_at`; ordering by
+      // it would leave intra-day order undefined across page loads. Order by
+      // `kind` then `file_path` instead: both are stable, non-null columns, so
+      // the result is fully deterministic and matches the kind-grouped UI.
+      .orderBy(asc(memoryChangeItems.kind), asc(memoryChangeItems.filePath));
 
     const itemsBySummaryId = new Map<string, MemoryActivityItem[]>();
     for (const item of items) {


### PR DESCRIPTION
Fixes a P1 from #15998 — deterministic intra-day item ordering. Part of #15977.

The read API ordered each day's summary items by `created_at`, but the cron batch-inserts all items of a summary in one transaction, so they share the same `now()` timestamp — making intra-day item order non-deterministic across page loads.

Items are now ordered by `kind` then `file_path` (both stable, non-null columns), which is fully deterministic and matches the kind-grouped UI. Day/entry ordering (summaries by `date` DESC) was already deterministic and is left as-is.

The seed helper no longer staggers `created_at`; it mirrors the cron's single-timestamp batch insert so the integration tests exercise the new ordering honestly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)