### PR TITLE
fix(nbd-cow): bound netlink reply attrs by message length

### DIFF
--- a/crates/nbd-cow/src/netlink.rs
+++ b/crates/nbd-cow/src/netlink.rs
@@ -292,16 +292,15 @@ fn resolve_nbd_family(sock: &socket::GenlSocket) -> Result<u16> {
 
     let mut buf = vec![0u8; 4096];
     let n = socket::recv_for_seq(sock, &mut buf, seq)?;
-    match wire::parse_nl_msg(&buf, n)? {
-        wire::NlMsg::Reply => {}
-        wire::NlMsg::Ack => {
+    let reply_attrs = match wire::parse_genl_response(&buf, n)? {
+        wire::GenlResponse::Reply { attrs } => attrs,
+        wire::GenlResponse::Ack => {
             return Err(NbdCowError::Netlink(
                 "unexpected ACK while resolving NBD family".into(),
             ));
         }
-    }
+    };
 
-    let reply_attrs = wire::genl_attrs(&buf, n)?;
     wire::find_nla_u16(reply_attrs, CTRL_ATTR_FAMILY_ID, "truncated family id")?
         .ok_or_else(|| NbdCowError::Netlink("NBD family ID not found in response".into()))
 }
@@ -346,10 +345,10 @@ fn classify_connect_completion(
 }
 
 fn parse_genl_completion(buf: &[u8], n: usize) -> Result<()> {
-    match wire::parse_nl_msg(buf, n)? {
+    match wire::parse_genl_response(buf, n)? {
         // NBD connect returns a genetlink reply on success; other commands may
         // complete with a netlink ACK. Non-zero NLMSG_ERROR is handled above.
-        wire::NlMsg::Ack | wire::NlMsg::Reply => Ok(()),
+        wire::GenlResponse::Ack | wire::GenlResponse::Reply { .. } => Ok(()),
     }
 }
 
@@ -368,6 +367,13 @@ fn build_sockets_nla(client_fds: &[OwnedFd]) -> Vec<u8> {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    fn raw_nla_header(nla_len: u16, nla_type: u16) -> Vec<u8> {
+        let mut attr = Vec::new();
+        attr.extend_from_slice(&nla_len.to_ne_bytes());
+        attr.extend_from_slice(&nla_type.to_ne_bytes());
+        attr
+    }
 
     #[test]
     fn random_offset_zero_max() {
@@ -401,6 +407,62 @@ mod tests {
         let result = resolve_nbd_family(&sock);
 
         assert_eq!(result.unwrap(), 123);
+    }
+
+    #[test]
+    fn resolve_nbd_family_ignores_family_id_after_declared_length() {
+        let (sock, peer) = socket::test_genl_socket_pair();
+        let mut reply = wire::build_genl_msg(GENL_ID_CTRL, CTRL_CMD_GETFAMILY, 1, &[], 1, false);
+        reply.extend_from_slice(&wire::build_nla(CTRL_ATTR_FAMILY_ID, &123u16.to_ne_bytes()));
+        socket::send_test_nl(&peer, &reply);
+
+        let result = resolve_nbd_family(&sock);
+
+        assert!(
+            matches!(result, Err(NbdCowError::Netlink(message)) if message == "NBD family ID not found in response")
+        );
+    }
+
+    #[test]
+    fn resolve_nbd_family_rejects_short_non_target_attr_before_family_id() {
+        let (sock, peer) = socket::test_genl_socket_pair();
+        let mut attrs = raw_nla_header(3, 999);
+        attrs.extend_from_slice(&wire::build_nla(CTRL_ATTR_FAMILY_ID, &123u16.to_ne_bytes()));
+        let reply = wire::build_genl_msg(GENL_ID_CTRL, CTRL_CMD_GETFAMILY, 1, &attrs, 1, false);
+        socket::send_test_nl(&peer, &reply);
+
+        let result = resolve_nbd_family(&sock);
+
+        assert!(
+            matches!(result, Err(NbdCowError::Netlink(message)) if message == "invalid nla length")
+        );
+    }
+
+    #[test]
+    fn resolve_nbd_family_rejects_overlong_non_target_attr_before_family_id() {
+        let (sock, peer) = socket::test_genl_socket_pair();
+        let mut attrs = raw_nla_header(128, 999);
+        attrs.extend_from_slice(&wire::build_nla(CTRL_ATTR_FAMILY_ID, &123u16.to_ne_bytes()));
+        let reply = wire::build_genl_msg(GENL_ID_CTRL, CTRL_CMD_GETFAMILY, 1, &attrs, 1, false);
+        socket::send_test_nl(&peer, &reply);
+
+        let result = resolve_nbd_family(&sock);
+
+        assert!(matches!(result, Err(NbdCowError::Netlink(message)) if message == "truncated nla"));
+    }
+
+    #[test]
+    fn resolve_nbd_family_rejects_truncated_family_id_payload() {
+        let (sock, peer) = socket::test_genl_socket_pair();
+        let attrs = wire::build_nla(CTRL_ATTR_FAMILY_ID, &[0x7b]);
+        let reply = wire::build_genl_msg(GENL_ID_CTRL, CTRL_CMD_GETFAMILY, 1, &attrs, 1, false);
+        socket::send_test_nl(&peer, &reply);
+
+        let result = resolve_nbd_family(&sock);
+
+        assert!(
+            matches!(result, Err(NbdCowError::Netlink(message)) if message == "truncated family id")
+        );
     }
 
     #[test]

--- a/crates/nbd-cow/src/netlink.rs
+++ b/crates/nbd-cow/src/netlink.rs
@@ -410,6 +410,19 @@ mod tests {
     }
 
     #[test]
+    fn resolve_nbd_family_skips_padded_non_target_attr_before_family_id() {
+        let (sock, peer) = socket::test_genl_socket_pair();
+        let mut attrs = wire::build_nla(999, &[0x01]);
+        attrs.extend_from_slice(&wire::build_nla(CTRL_ATTR_FAMILY_ID, &123u16.to_ne_bytes()));
+        let reply = wire::build_genl_msg(GENL_ID_CTRL, CTRL_CMD_GETFAMILY, 1, &attrs, 1, false);
+        socket::send_test_nl(&peer, &reply);
+
+        let result = resolve_nbd_family(&sock);
+
+        assert_eq!(result.unwrap(), 123);
+    }
+
+    #[test]
     fn resolve_nbd_family_ignores_family_id_after_declared_length() {
         let (sock, peer) = socket::test_genl_socket_pair();
         let mut reply = wire::build_genl_msg(GENL_ID_CTRL, CTRL_CMD_GETFAMILY, 1, &[], 1, false);

--- a/crates/nbd-cow/src/netlink/socket.rs
+++ b/crates/nbd-cow/src/netlink/socket.rs
@@ -184,8 +184,8 @@ mod tests {
         let mut buf = vec![0u8; 4096];
         let n = recv_for_seq(&sock, &mut buf, expected_seq).unwrap();
         assert!(matches!(
-            wire::parse_nl_msg(&buf, n),
-            Ok(wire::NlMsg::Reply)
+            wire::parse_genl_response(&buf, n),
+            Ok(wire::GenlResponse::Reply { .. })
         ));
         assert_eq!(wire::parse_nl_header(&buf, n).unwrap().seq, expected_seq);
     }

--- a/crates/nbd-cow/src/netlink/wire.rs
+++ b/crates/nbd-cow/src/netlink/wire.rs
@@ -31,13 +31,13 @@ pub(super) struct NlHeader {
     pub(super) seq: u32,
 }
 
-/// Result of parsing a single netlink message.
+/// Result of parsing a single generic-netlink response.
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
-pub(super) enum NlMsg {
+pub(super) enum GenlResponse<'a> {
     /// NLMSG_ERROR with error=0 (ACK).
     Ack,
-    /// Non-error message (genetlink reply or broadcast).
-    Reply,
+    /// Non-error generic-netlink reply.
+    Reply { attrs: &'a [u8] },
 }
 
 pub(super) fn build_genl_msg(
@@ -103,9 +103,9 @@ pub(super) fn parse_nl_header(buf: &[u8], n: usize) -> Result<NlHeader> {
     })
 }
 
-/// Parse a single netlink message from the buffer. Returns `NlMsg` on
-/// success, or an error for NLMSG_ERROR with non-zero errno.
-pub(super) fn parse_nl_msg(buf: &[u8], n: usize) -> Result<NlMsg> {
+/// Parse a single generic-netlink response from the buffer. Returns
+/// `GenlResponse` on success, or an error for NLMSG_ERROR with non-zero errno.
+pub(super) fn parse_genl_response(buf: &[u8], n: usize) -> Result<GenlResponse<'_>> {
     let received = received_slice(buf, n)?;
     let header = parse_nl_header(buf, n)?;
     if header.len < NLMSG_HEADER_LEN {
@@ -124,7 +124,7 @@ pub(super) fn parse_nl_msg(buf: &[u8], n: usize) -> Result<NlMsg> {
             "error code conversion",
         )?;
         if error == 0 {
-            return Ok(NlMsg::Ack);
+            return Ok(GenlResponse::Ack);
         }
         let errno = -error;
         return Err(NbdCowError::NetlinkErrno {
@@ -133,17 +133,14 @@ pub(super) fn parse_nl_msg(buf: &[u8], n: usize) -> Result<NlMsg> {
         });
     }
 
-    Ok(NlMsg::Reply)
-}
-
-pub(super) fn genl_attrs(buf: &[u8], n: usize) -> Result<&[u8]> {
-    let received = received_slice(buf, n)?;
-    if received.len() < GENL_ATTR_OFFSET {
+    if msg.len() < GENL_ATTR_OFFSET {
         return Err(NbdCowError::Netlink("response too short".into()));
     }
-    received
+    let attrs = msg
         .get(GENL_ATTR_OFFSET..)
-        .ok_or_else(|| NbdCowError::Netlink("response too short".into()))
+        .ok_or_else(|| NbdCowError::Netlink("response too short".into()))?;
+
+    Ok(GenlResponse::Reply { attrs })
 }
 
 pub(super) fn find_nla_u16(
@@ -152,7 +149,12 @@ pub(super) fn find_nla_u16(
     truncated_value_message: &'static str,
 ) -> Result<Option<u16>> {
     let mut offset = 0usize;
-    while offset + NLA_HEADER_LEN <= attrs.len() {
+    while offset < attrs.len() {
+        let remaining = attrs.len() - offset;
+        if remaining < NLA_HEADER_LEN {
+            return Err(NbdCowError::Netlink("truncated nla".into()));
+        }
+
         let nla_len = read_u16_at(attrs, offset, "truncated nla", "nla len conversion")? as usize;
         let nla_type = read_u16_at(
             attrs,
@@ -161,7 +163,17 @@ pub(super) fn find_nla_u16(
             "nla type conversion",
         )?;
 
-        if nla_type == target_type && nla_len >= NLA_HEADER_LEN + U16_LEN {
+        if nla_len < NLA_HEADER_LEN {
+            return Err(NbdCowError::Netlink("invalid nla length".into()));
+        }
+        if nla_len > remaining {
+            return Err(NbdCowError::Netlink("truncated nla".into()));
+        }
+
+        if nla_type == target_type {
+            if nla_len < NLA_HEADER_LEN + U16_LEN {
+                return Err(NbdCowError::Netlink(truncated_value_message.into()));
+            }
             return read_u16_at(
                 attrs,
                 offset + NLA_HEADER_LEN,
@@ -172,9 +184,6 @@ pub(super) fn find_nla_u16(
         }
 
         let aligned = align_nla_len(nla_len);
-        if aligned == 0 {
-            break;
-        }
         offset = offset
             .checked_add(aligned)
             .ok_or_else(|| NbdCowError::Netlink("nla offset overflow".into()))?;
@@ -406,26 +415,62 @@ mod tests {
     }
 
     #[test]
-    fn parse_nl_msg_ack() {
+    fn parse_genl_response_ack() {
         let msg = build_nlmsg_error_for_test(42, 0);
 
-        assert!(matches!(parse_nl_msg(&msg, msg.len()), Ok(NlMsg::Ack)));
+        assert!(matches!(
+            parse_genl_response(&msg, msg.len()),
+            Ok(GenlResponse::Ack)
+        ));
         assert_eq!(parse_nl_header(&msg, msg.len()).unwrap().seq, 42);
     }
 
     #[test]
-    fn parse_nl_msg_reply() {
+    fn parse_genl_response_reply() {
         let msg = build_genl_msg(0x0019, 1, 1, &[], 43, false);
 
-        assert!(matches!(parse_nl_msg(&msg, msg.len()), Ok(NlMsg::Reply)));
+        assert!(matches!(
+            parse_genl_response(&msg, msg.len()),
+            Ok(GenlResponse::Reply { attrs }) if attrs.is_empty()
+        ));
         assert_eq!(parse_nl_header(&msg, msg.len()).unwrap().seq, 43);
     }
 
     #[test]
-    fn parse_nl_msg_error_errno() {
+    fn parse_genl_response_reply_requires_genl_header() {
+        let mut buf = vec![0u8; NLMSG_HEADER_LEN];
+        write_at(
+            &mut buf,
+            NLMSG_LEN_OFFSET,
+            &(NLMSG_HEADER_LEN as u32).to_ne_bytes(),
+        );
+        write_at(&mut buf, NLMSG_TYPE_OFFSET, &0x19u16.to_ne_bytes());
+
+        let result = parse_genl_response(&buf, buf.len());
+
+        assert!(
+            matches!(result, Err(NbdCowError::Netlink(message)) if message == "response too short")
+        );
+    }
+
+    #[test]
+    fn parse_genl_response_reply_attrs_are_bounded_by_declared_length() {
+        let mut msg = build_genl_msg(0x0019, 1, 1, &[], 43, false);
+        msg.extend_from_slice(&build_nla(1, &123u16.to_ne_bytes()));
+
+        let result = parse_genl_response(&msg, msg.len());
+
+        assert!(matches!(
+            result,
+            Ok(GenlResponse::Reply { attrs }) if attrs.is_empty()
+        ));
+    }
+
+    #[test]
+    fn parse_genl_response_error_errno() {
         let msg = build_nlmsg_error_for_test(2, -libc::EBUSY);
 
-        let result = parse_nl_msg(&msg, msg.len());
+        let result = parse_genl_response(&msg, msg.len());
         assert!(matches!(
             result,
             Err(NbdCowError::NetlinkErrno { errno, .. }) if errno == libc::EBUSY
@@ -433,40 +478,40 @@ mod tests {
     }
 
     #[test]
-    fn parse_nl_msg_too_short() {
+    fn parse_genl_response_too_short() {
         let buf = [0u8; NLMSG_HEADER_LEN - 1];
-        let result = parse_nl_msg(&buf, buf.len());
+        let result = parse_genl_response(&buf, buf.len());
 
         assert!(result.is_err());
     }
 
     #[test]
-    fn parse_nl_msg_error_response_truncated() {
+    fn parse_genl_response_error_response_truncated() {
         let mut buf = vec![0u8; 4096];
         write_at(&mut buf, NLMSG_LEN_OFFSET, &20u32.to_ne_bytes());
         write_at(&mut buf, NLMSG_TYPE_OFFSET, &NLMSG_ERROR.to_ne_bytes());
 
-        let result = parse_nl_msg(&buf, 18);
+        let result = parse_genl_response(&buf, 18);
 
         assert!(result.is_err());
     }
 
     #[test]
-    fn parse_nl_msg_declared_length_too_short() {
+    fn parse_genl_response_declared_length_too_short() {
         let mut buf = vec![0u8; NLMSG_HEADER_LEN + U32_LEN + U32_LEN];
         write_at(&mut buf, NLMSG_LEN_OFFSET, &15u32.to_ne_bytes());
 
-        let result = parse_nl_msg(&buf, buf.len());
+        let result = parse_genl_response(&buf, buf.len());
 
         assert!(result.is_err());
     }
 
     #[test]
-    fn parse_nl_msg_error_body_bounded_by_declared_length() {
+    fn parse_genl_response_error_body_bounded_by_declared_length() {
         let mut buf = build_nlmsg_error_for_test(2, 0);
         write_at(&mut buf, NLMSG_LEN_OFFSET, &18u32.to_ne_bytes());
 
-        let result = parse_nl_msg(&buf, buf.len());
+        let result = parse_genl_response(&buf, buf.len());
 
         assert!(result.is_err());
     }

--- a/crates/nbd-cow/src/netlink/wire.rs
+++ b/crates/nbd-cow/src/netlink/wire.rs
@@ -133,9 +133,6 @@ pub(super) fn parse_genl_response(buf: &[u8], n: usize) -> Result<GenlResponse<'
         });
     }
 
-    if msg.len() < GENL_ATTR_OFFSET {
-        return Err(NbdCowError::Netlink("response too short".into()));
-    }
     let attrs = msg
         .get(GENL_ATTR_OFFSET..)
         .ok_or_else(|| NbdCowError::Netlink("response too short".into()))?;


### PR DESCRIPTION
## Summary

- Replace the split netlink response parsing flow with a bounded generic-netlink response parser that returns ACK or reply attrs.
- Derive reply attrs from the declared `nlmsg_len` message slice instead of the raw received datagram length.
- Tighten NLA length validation so malformed target and non-target attrs fail consistently.
- Add regressions for trailing attrs outside `nlmsg_len`, malformed non-target attrs, truncated family-id payloads, and generic reply header bounds.

Closes #15961

## Tests

- `cargo test --manifest-path crates/Cargo.toml -p nbd-cow netlink`
- `cargo test --manifest-path crates/Cargo.toml -p nbd-cow`
- `cargo fmt --manifest-path crates/nbd-cow/Cargo.toml --check`
- `cargo clippy --manifest-path crates/Cargo.toml -p nbd-cow --all-targets --all-features -- -D warnings`
- `git diff --check`
