### PR TITLE
fix(vsock-host): guard connection timeout overflow

### DIFF
--- a/crates/vsock-host/src/lib.rs
+++ b/crates/vsock-host/src/lib.rs
@@ -806,12 +806,22 @@ fn validate_empty_lifecycle_response(
         .map_err(protocol_invalid_data)
 }
 
+fn deadline_after(timeout: Duration, overflow_message: &'static str) -> io::Result<Instant> {
+    Instant::now()
+        .checked_add(timeout)
+        .ok_or_else(|| io::Error::new(io::ErrorKind::InvalidInput, overflow_message))
+}
+
 impl VsockHost {
     /// Wait for a guest to connect on the vsock UDS path.
     ///
     /// Creates a UDS listener at `{vsock_path}_{port}`, accepts the first
     /// connection, and performs the ready/ping/pong handshake.
+    ///
+    /// Returns [`io::ErrorKind::InvalidInput`] if `timeout` cannot be
+    /// represented as a Tokio deadline.
     pub async fn wait_for_connection(vsock_path: &str, timeout: Duration) -> io::Result<Self> {
+        let deadline = deadline_after(timeout, "guest connection timeout overflowed")?;
         let listener_path = format!("{vsock_path}_{}", vsock_proto::VSOCK_PORT);
 
         // Clean up stale socket
@@ -821,7 +831,6 @@ impl VsockHost {
         let mut listener_socket = ListenerSocketGuard {
             path: Some(listener_path.clone()),
         };
-        let deadline = Instant::now() + timeout;
 
         let accept_result = time::timeout_at(deadline, listener.accept()).await;
 
@@ -1129,7 +1138,7 @@ impl VsockHost {
     /// state under the same lock that `close` holds, so no transition is
     /// missed.
     async fn wait_until_closed(&self, timeout: Duration) -> io::Result<()> {
-        let deadline = Instant::now() + timeout;
+        let deadline = deadline_after(timeout, "wait_until_closed timeout overflowed")?;
         loop {
             let notified = self.shared.close_notify.notified();
             tokio::pin!(notified);

--- a/crates/vsock-host/src/tests/connection.rs
+++ b/crates/vsock-host/src/tests/connection.rs
@@ -19,6 +19,33 @@ use crate::{
 };
 
 #[tokio::test]
+async fn wait_for_connection_oversized_timeout_returns_invalid_input() {
+    let unique = std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .unwrap()
+        .as_nanos();
+    let base = std::env::temp_dir().join(format!(
+        "vsock-host-timeout-overflow-{}-{unique}",
+        std::process::id()
+    ));
+    let listener =
+        std::path::PathBuf::from(format!("{}_{}", base.display(), vsock_proto::VSOCK_PORT));
+    let base = base.display().to_string();
+
+    let result = VsockHost::wait_for_connection(&base, Duration::MAX).await;
+    let error_kind = match result {
+        Ok(_) => panic!("oversized timeout should return InvalidInput"),
+        Err(error) => error.kind(),
+    };
+
+    assert_eq!(error_kind, io::ErrorKind::InvalidInput);
+    assert!(
+        !listener.exists(),
+        "invalid timeout should not create listener socket"
+    );
+}
+
+#[tokio::test]
 async fn wait_for_connection_removes_listener_socket_on_abort() {
     let unique = std::time::SystemTime::now()
         .duration_since(std::time::UNIX_EPOCH)


### PR DESCRIPTION
## Summary

- add a checked deadline helper for `vsock-host` timeout deadlines
- return `InvalidInput` when `wait_for_connection` receives an unrepresentable timeout
- cover the public `wait_for_connection(Duration::MAX)` edge and listener socket side effect

Fixes #15963

## Tests

- `cargo test --manifest-path crates/Cargo.toml -p vsock-host wait_for_connection_oversized_timeout_returns_invalid_input`
- `cargo test --manifest-path crates/Cargo.toml -p vsock-host wait_for_connection`
- `cargo test --manifest-path crates/Cargo.toml -p vsock-host`
- `cargo clippy --manifest-path crates/Cargo.toml -p vsock-host --all-targets --all-features -- -D warnings`
- pre-commit hook: `cargo-fmt`, `cargo-clippy`, `cargo-doc`
