### PR TITLE
fix(mitm-addon): require original url for connector usage

### DIFF
--- a/crates/runner/mitm-addon/src/usage/providers/connectors/__init__.py
+++ b/crates/runner/mitm-addon/src/usage/providers/connectors/__init__.py
@@ -24,17 +24,18 @@ from logging_utils import log_proxy_entry
 from . import x
 from .response_parser import ConnectorResponseParser
 
+_ConnectorUsageHandler = Callable[[http.HTTPFlow, str, str], None]
+_ResponseParserFactory = Callable[[http.HTTPFlow, str], ConnectorResponseParser | None]
+
 # Map firewall_name → per-connector report_usage handler.  A handler is only
 # invoked when ``flow.metadata[metadata_keys.FIREWALL_BILLABLE]`` is True, so the
 # BILLABLE_CONNECTORS whitelist in ``@vm0/core`` and this table must stay
 # in sync.  (The web layer controls who shows up as ``billable``; this
 # table controls who we know how to parse.  Desync manifests as a
 # dropped billing record plus a missing handler in test coverage.)
-_HANDLERS: dict[str, Callable[[http.HTTPFlow, str], None]] = {
+_HANDLERS: dict[str, _ConnectorUsageHandler] = {
     "x": x.report_usage,
 }
-
-_ResponseParserFactory = Callable[[http.HTTPFlow], ConnectorResponseParser | None]
 
 # Response parser factories are consulted at response-header time for registered
 # connector firewall flows that may need streamed response-body state before
@@ -50,6 +51,13 @@ _RESPONSE_PARSER_FACTORIES: dict[str, _ResponseParserFactory] = {
 # grown but the runner is on an older addon image — without this, billing
 # records silently drop with no local signal.
 _unregistered_handler_warned: set[str] = set()
+
+
+def _require_original_url(flow: http.HTTPFlow) -> str:
+    original_url = flow.metadata.get(metadata_keys.ORIGINAL_URL)
+    if not isinstance(original_url, str) or not original_url:
+        raise ValueError("registered billable connector flow is missing original_url")
+    return original_url
 
 
 def report_connector_usage(flow: http.HTTPFlow, run_id: str) -> None:
@@ -88,7 +96,8 @@ def report_connector_usage(flow: http.HTTPFlow, run_id: str) -> None:
                 firewall_name=firewall_name,
             )
         return
-    handler(flow, run_id)
+    original_url = _require_original_url(flow)
+    handler(flow, run_id, original_url)
 
 
 def create_connector_response_parser(flow: http.HTTPFlow) -> ConnectorResponseParser | None:
@@ -104,4 +113,5 @@ def create_connector_response_parser(flow: http.HTTPFlow) -> ConnectorResponsePa
     factory = _RESPONSE_PARSER_FACTORIES.get(firewall_name)
     if factory is None:
         return None
-    return factory(flow)
+    original_url = _require_original_url(flow)
+    return factory(flow, original_url)

--- a/crates/runner/mitm-addon/src/usage/providers/connectors/x.py
+++ b/crates/runner/mitm-addon/src/usage/providers/connectors/x.py
@@ -301,16 +301,18 @@ class _XJsonResponseExtractor:
         return result, None
 
 
-def create_response_parser(flow: http.HTTPFlow) -> ConnectorResponseParser | None:
+def create_response_parser(
+    flow: http.HTTPFlow, original_url: str
+) -> ConnectorResponseParser | None:
     """Create the X response-body parser needed for this flow, if any."""
     if not flow.response:
         return None
 
     status_code = flow.response.status_code
     if _HTTP_STATUS_OK_MIN <= status_code < _HTTP_STATUS_REDIRECT_MIN:
-        # Use the request target path so the hot path never needs to split or
-        # decode the original URL query just to detect streaming endpoints.
-        stream_path = _strip_request_target_query(flow.request.path)
+        # Use the dispatcher-required original URL so parser registration and
+        # final request metadata cannot diverge.
+        stream_path = urllib.parse.urlparse(original_url).path
         if _is_stream_path(stream_path):
             extractor = _NdjsonExtractor()
             # Deliberately NOT "model_provider_usage" — that key routes through
@@ -340,6 +342,20 @@ def _count_non_empty_comma_segments(values: Iterable[str]) -> int | None:
 
 def _empty_request_query_fallback_hints() -> dict:
     return {"request_ids_count": None, "max_results": None}
+
+
+def _parse_request_metadata(original_url: str) -> dict:
+    """Extract billing-relevant query params from an X API request.
+
+    Returns a dict with:
+      - ``is_count_endpoint``: bool — True when the request path is an X Post
+        Counts endpoint whose ``data`` array contains time buckets instead of
+        returned posts.
+
+    Parses the dispatcher-required original URL rather than ``pretty_url`` to
+    stay consistent with the rest of the addon.
+    """
+    return {"is_count_endpoint": _is_count_path(urllib.parse.urlparse(original_url).path)}
 
 
 def _decode_request_query_hint_key(raw_key: str) -> str | None:
@@ -373,8 +389,7 @@ def _exceeds_query_hint_byte_limit(value: str, max_bytes: int) -> bool:
     return _slice_exceeds_query_hint_byte_limit(value, 0, len(value), max_bytes)
 
 
-def _get_bounded_original_request_query(flow: http.HTTPFlow) -> str | None:
-    original_url = flow.metadata.get(metadata_keys.ORIGINAL_URL, "")
+def _get_bounded_original_request_query(original_url: str) -> str | None:
     query_start = original_url.find("?")
     if query_start == -1:
         return ""
@@ -392,7 +407,7 @@ def _get_bounded_original_request_query(flow: http.HTTPFlow) -> str | None:
     return original_url[value_start:fragment_start]
 
 
-def _parse_request_query_fallback_hints(flow: http.HTTPFlow) -> dict:
+def _parse_request_query_fallback_hints(original_url: str) -> dict:
     """Extract request-side count hints only for unparseable GET responses.
 
     This intentionally does not call ``parse_qs``.  Successful X responses
@@ -402,7 +417,7 @@ def _parse_request_query_fallback_hints(flow: http.HTTPFlow) -> dict:
     blank-value and ``+`` behavior for those keys, and caps work on hostile
     query strings instead of materializing every parameter.
     """
-    query = _get_bounded_original_request_query(flow)
+    query = _get_bounded_original_request_query(original_url)
     if query is None:
         return _empty_request_query_fallback_hints()
 
@@ -622,7 +637,7 @@ def _compute_billable_counts(
     return counts
 
 
-def report_usage(flow: http.HTTPFlow, run_id: str) -> None:
+def report_usage(flow: http.HTTPFlow, run_id: str, original_url: str) -> None:
     """Compute billable resource counts and buffer them for upload.
 
     Derives per-permission billable resource counts from the request and
@@ -631,9 +646,10 @@ def report_usage(flow: http.HTTPFlow, run_id: str) -> None:
 
     **Caller contract**: the dispatcher in
     :mod:`usage.providers.connectors` guarantees ``run_id`` is non-empty,
-    ``flow.metadata[metadata_keys.FIREWALL_BILLABLE]`` is True, and
-    ``flow.metadata[metadata_keys.FIREWALL_NAME] == "x"`` before calling this.  Those
-    gates are not re-checked here.
+    ``flow.metadata[metadata_keys.FIREWALL_BILLABLE]`` is True,
+    ``flow.metadata[metadata_keys.FIREWALL_NAME] == "x"``, and
+    ``original_url`` is a non-empty string before calling this. Those gates are
+    not re-checked here.
 
     Additional X-specific skip conditions:
 
@@ -673,10 +689,10 @@ def report_usage(flow: http.HTTPFlow, run_id: str) -> None:
             request_body,
         )
 
-    req_meta = {"is_count_endpoint": _is_count_path(request_path)}
+    req_meta = _parse_request_metadata(original_url)
     resp_meta = _parse_response_metadata(flow)
     req_meta.update(
-        _parse_request_query_fallback_hints(flow)
+        _parse_request_query_fallback_hints(original_url)
         if (
             flow.request.method == "GET"
             and not req_meta["is_count_endpoint"]
@@ -685,9 +701,6 @@ def report_usage(flow: http.HTTPFlow, run_id: str) -> None:
         else _empty_request_query_fallback_hints()
     )
     proxy_log_path = flow.metadata.get(metadata_keys.VM_PROXY_LOG_PATH, "")
-    audit_url = flow.metadata.get(metadata_keys.ORIGINAL_URL)
-    if not isinstance(audit_url, str) or not audit_url:
-        audit_url = flow.request.url
 
     # Structured context common to every billing-side proxy log entry
     # for this flow — threaded into the helper so the log firing at the
@@ -698,7 +711,7 @@ def report_usage(flow: http.HTTPFlow, run_id: str) -> None:
         "firewall_name": firewall_name,
         "permission": permission,
         "method": flow.request.method,
-        "url": audit_url,
+        "url": original_url,
     }
 
     def _log_warn(message: str, extra: dict) -> None:

--- a/crates/runner/mitm-addon/tests/test_connector_usage.py
+++ b/crates/runner/mitm-addon/tests/test_connector_usage.py
@@ -47,17 +47,26 @@ class TestXStreamPathRouting:
         assert "x_ndjson_state" in flow.metadata
         assert "connector_response_finish" in flow.metadata
 
-    def test_absolute_form_stream_endpoint_registers_ndjson_parser(self, real_flow):
-        """Absolute-form request targets keep the old urlsplit path behavior."""
+    def test_absolute_form_request_target_registers_ndjson_parser_from_original_url(
+        self, real_flow
+    ):
         flow = self._make_x_response_flow(
             real_flow,
-            "https://api.x.com/2/tweets/search/stream?tweet.fields=id",
+            "/2/tweets/search/stream?tweet.fields=id",
         )
+        flow.request.path = "https://api.x.com/2/tweets/search/stream?tweet.fields=id"
 
         mitm_addon.responseheaders(flow)
 
         assert "x_ndjson_state" in flow.metadata
         assert "connector_response_finish" in flow.metadata
+
+    def test_stream_parser_requires_original_url(self, real_flow):
+        flow = self._make_x_response_flow(real_flow, "/2/tweets/search/stream")
+        flow.metadata.pop("original_url")
+
+        with pytest.raises(ValueError, match="original_url"):
+            mitm_addon.responseheaders(flow)
 
     @pytest.mark.parametrize(
         "path",
@@ -92,6 +101,16 @@ class TestXStreamPathRouting:
         assert "connector_response_finish" not in flow.metadata
         assert log.debug.call_count == 1
         assert "Streaming decompression skipped (br)" in log.debug.call_args[0][0]
+
+    def test_unregistered_parser_factory_does_not_require_original_url(self, real_flow):
+        flow = self._make_x_response_flow(real_flow, "/2/tweets/search/stream")
+        flow.metadata["firewall_name"] = "github"
+        flow.metadata.pop("original_url")
+
+        mitm_addon.responseheaders(flow)
+
+        assert "x_ndjson_state" not in flow.metadata
+        assert "connector_response_finish" not in flow.metadata
 
 
 class TestReportConnectorUsage:
@@ -1616,6 +1635,13 @@ class TestReportConnectorUsage:
         flow.metadata["firewall_name"] = "github"
         assert self._call_and_get_billing(flow) == []
 
+    def test_unregistered_handler_does_not_require_original_url(self, tmp_path, real_flow):
+        flow = self._make_x_flow(real_flow, tmp_path)
+        flow.metadata["firewall_name"] = "github"
+        flow.metadata.pop("original_url")
+
+        assert self._call_and_get_billing(flow) == []
+
     # ---- unregistered-handler one-shot warn (issue #10483) ----
 
     def test_warns_once_per_unregistered_firewall_name(self, tmp_path, real_flow):
@@ -1674,6 +1700,16 @@ class TestReportConnectorUsage:
         flow = self._make_x_flow(real_flow, tmp_path)
         flow.response = None
         assert self._call_and_get_billing(flow) == []
+
+    def test_registered_x_usage_requires_original_url(self, tmp_path, real_flow, mitm_ctx):
+        flow = self._make_x_flow(real_flow, tmp_path)
+        flow.metadata.pop("original_url")
+
+        with (
+            mitm_ctx(api_url="https://api.vm0.ai"),
+            pytest.raises(ValueError, match="original_url"),
+        ):
+            usage.report_connector_usage(flow, "run-abc-123")
 
     # ---- webhook skip ----
 


### PR DESCRIPTION
## Summary

- require `original_url` at the registered billable connector dispatcher boundary
- pass `original_url` explicitly into the X connector parser and usage paths
- add regression coverage for missing `original_url` plus unknown connector skip behavior

Fixes #15965

## Tests

- `pytest tests/test_connector_usage.py`
- `ruff check .`
- `ruff format --check .`
- `basedpyright -p .`