### PR TITLE
feat: migrate all remaining first-party platform routes to api backend

### DIFF
--- a/turbo/apps/platform/src/signals/__tests__/api-client.test.ts
+++ b/turbo/apps/platform/src/signals/__tests__/api-client.test.ts
@@ -12,6 +12,10 @@ import { zeroSchedulesMainContract } from "@vm0/api-contracts/contracts/zero-sch
 import { zeroConnectorsMainContract } from "@vm0/api-contracts/contracts/zero-connectors";
 import { zeroPersonalModelProvidersMainContract } from "@vm0/api-contracts/contracts/zero-personal-model-providers";
 import { zeroModelProvidersMainContract } from "@vm0/api-contracts/contracts/zero-model-providers";
+import {
+  chatThreadsContract,
+  chatThreadByIdContract,
+} from "@vm0/api-contracts/contracts/chat-threads";
 import { testContext } from "./test-helpers.ts";
 import { detachedSetupPage } from "../../__tests__/page-helper.ts";
 import { mockedClerk } from "../../__tests__/mock-auth.ts";
@@ -462,7 +466,7 @@ describe("zeroClient$ apiBackend routing", () => {
     expect(requestHosts).toStrictEqual(["api.vm0.ai"]);
   });
 
-  it("keeps same-path org mutation on www when apiBackend is off", async () => {
+  it("routes allowlisted org mutation to api host when apiBackend is off", async () => {
     vi.stubGlobal("location", new URL("https://platform.vm0.ai/"));
     detachedSetupPage({
       context,
@@ -488,7 +492,7 @@ describe("zeroClient$ apiBackend routing", () => {
     const result = await client.update({ body: { name: "Renamed" } });
 
     expect(result.status).toBe(200);
-    expect(requestHosts).toStrictEqual(["www.vm0.ai"]);
+    expect(requestHosts).toStrictEqual(["api.vm0.ai"]);
   });
 
   it("routes policy allowlisted voice-io quota contract requests to api host when apiBackend is off", async () => {
@@ -587,6 +591,61 @@ describe("zeroClient$ apiBackend routing", () => {
     const result = await client.list();
 
     expect(result.status).toBe(200);
+    expect(requestHosts).toStrictEqual(["api.vm0.ai"]);
+  });
+
+  it("routes allowlisted mutation contract requests to api host when apiBackend is off", async () => {
+    vi.stubGlobal("location", new URL("https://platform.vm0.ai/"));
+    detachedSetupPage({
+      context,
+      path: "/",
+      withoutRender: true,
+    });
+
+    const requestHosts: string[] = [];
+    server.use(
+      mockApi(chatThreadsContract.create, ({ request, respond }) => {
+        requestHosts.push(new URL(request.url).host);
+        return respond(201, {
+          id: "thread_1",
+          title: null,
+          createdAt: "2026-01-01T00:00:00.000Z",
+        });
+      }),
+    );
+
+    const createClient = context.store.get(zeroClient$);
+    const client = createClient(chatThreadsContract);
+    const result = await client.create({ body: { agentId: "agent_1" } });
+
+    expect(result.status).toBe(201);
+    expect(requestHosts).toStrictEqual(["api.vm0.ai"]);
+  });
+
+  it("routes allowlisted dynamic-path requests to api host when apiBackend is off", async () => {
+    vi.stubGlobal("location", new URL("https://platform.vm0.ai/"));
+    detachedSetupPage({
+      context,
+      path: "/",
+      withoutRender: true,
+    });
+
+    const requestHosts: string[] = [];
+    server.use(
+      mockApi(chatThreadByIdContract.delete, ({ request, respond }) => {
+        requestHosts.push(new URL(request.url).host);
+        return respond(204);
+      }),
+    );
+
+    const createClient = context.store.get(zeroClient$);
+    const client = createClient(chatThreadByIdContract);
+    const result = await client.delete({
+      params: { id: "00000000-0000-0000-0000-000000000001" },
+    });
+
+    expect(result.status).toBe(204);
+    // The :id template segment must match a concrete id, not just an exact path.
     expect(requestHosts).toStrictEqual(["api.vm0.ai"]);
   });
 

--- a/turbo/apps/platform/src/signals/__tests__/fetch.test.ts
+++ b/turbo/apps/platform/src/signals/__tests__/fetch.test.ts
@@ -522,6 +522,58 @@ describe("apiBackend routing", () => {
     expect(postHosts).toStrictEqual(["www.vm0.ai"]);
   });
 
+  it("is method-aware: routes an allowlisted GET to api but a non-allowlisted method on the same path to www", async () => {
+    vi.stubGlobal("location", new URL("https://platform.vm0.ai/"));
+    detachedSetupPage({
+      context,
+      path: "/",
+      withoutRender: true,
+    });
+
+    const getHosts: string[] = [];
+    const postHosts: string[] = [];
+    server.use(
+      http.get("*/api/zero/voice-io/quota", ({ request }) => {
+        getHosts.push(new URL(request.url).host);
+        return new Response(null, { status: 200 });
+      }),
+      http.post("*/api/zero/voice-io/quota", ({ request }) => {
+        postHosts.push(new URL(request.url).host);
+        return new Response(null, { status: 200 });
+      }),
+    );
+
+    const fch = context.store.get(fetch$);
+    await fch("/api/zero/voice-io/quota");
+    await fch("/api/zero/voice-io/quota", { method: "POST" });
+
+    // Only GET is allowlisted for this path; POST falls through to www.
+    expect(getHosts).toStrictEqual(["api.vm0.ai"]);
+    expect(postHosts).toStrictEqual(["www.vm0.ai"]);
+  });
+
+  it("routes allowlisted dynamic :id paths to api host when apiBackend is off", async () => {
+    vi.stubGlobal("location", new URL("https://platform.vm0.ai/"));
+    detachedSetupPage({
+      context,
+      path: "/",
+      withoutRender: true,
+    });
+
+    const hosts: string[] = [];
+    server.use(
+      http.get("*/api/zero/runs/:id", ({ request }) => {
+        hosts.push(new URL(request.url).host);
+        return new Response(null, { status: 200 });
+      }),
+    );
+
+    const fch = context.store.get(fetch$);
+    await fch("/api/zero/runs/00000000-0000-0000-0000-000000000001");
+
+    expect(hosts).toStrictEqual(["api.vm0.ai"]);
+  });
+
   it("routes policy allowlisted user preferences string paths to api host when apiBackend is off", async () => {
     vi.stubGlobal("location", new URL("https://platform.vm0.ai/"));
     detachedSetupPage({

--- a/turbo/apps/platform/src/signals/__tests__/fetch.test.ts
+++ b/turbo/apps/platform/src/signals/__tests__/fetch.test.ts
@@ -574,6 +574,32 @@ describe("apiBackend routing", () => {
     expect(hosts).toStrictEqual(["api.vm0.ai"]);
   });
 
+  it("does not let a :param template over-match a shorter parent path", async () => {
+    vi.stubGlobal("location", new URL("https://platform.vm0.ai/"));
+    detachedSetupPage({
+      context,
+      path: "/",
+      withoutRender: true,
+    });
+
+    // `/api/zero/runs/:id` is allowlisted for GET, but the bare parent
+    // `/api/zero/runs` is only allowlisted for POST. A GET to the parent must
+    // not be absorbed by the `:id` template (segment counts differ), so it
+    // falls through to www.
+    const hosts: string[] = [];
+    server.use(
+      http.get("*/api/zero/runs", ({ request }) => {
+        hosts.push(new URL(request.url).host);
+        return new Response(null, { status: 200 });
+      }),
+    );
+
+    const fch = context.store.get(fetch$);
+    await fch("/api/zero/runs");
+
+    expect(hosts).toStrictEqual(["www.vm0.ai"]);
+  });
+
   it("routes policy allowlisted user preferences string paths to api host when apiBackend is off", async () => {
     vi.stubGlobal("location", new URL("https://platform.vm0.ai/"));
     detachedSetupPage({

--- a/turbo/apps/platform/src/signals/api-target-policy.ts
+++ b/turbo/apps/platform/src/signals/api-target-policy.ts
@@ -7,57 +7,121 @@ interface ApiTargetRequest {
   readonly pathname: string;
 }
 
-interface ApiTargetPolicyEntry {
+interface ApiRouteAllowlistEntry {
   readonly methods: readonly ApiRouteMethod[];
+  // Exact pathname, or a template with `:param` segments (each `:param`
+  // matches exactly one non-empty path segment, e.g. "/api/zero/runs/:id").
   readonly pathname: string;
-  readonly target: ApiHostTarget;
 }
 
-const API_ROUTE_TARGET_POLICY: readonly ApiTargetPolicyEntry[] = [
+// First-party apps/platform routes that resolve to the dedicated `api` host
+// while the global `apiBackend` switch is off. Everything not listed here
+// defaults to `www`. Routes are method-aware: a path's mutations are migrated
+// only when their method is listed. OAuth, connector/integration, billing,
+// bootstrap feature-switches, and web-origin flows are intentionally absent
+// and stay on `www`.
+const API_ROUTE_ALLOWLIST: readonly ApiRouteAllowlistEntry[] = [
+  { methods: ["GET", "POST"], pathname: "/api/zero/agents" },
   {
-    methods: ["GET"],
-    pathname: "/api/zero/me/model-providers",
-    target: "api",
+    methods: ["GET", "PUT", "PATCH", "DELETE"],
+    pathname: "/api/zero/agents/:id",
   },
+  { methods: ["GET", "PUT"], pathname: "/api/zero/agents/:id/instructions" },
+  { methods: ["GET", "POST"], pathname: "/api/zero/api-keys" },
+  { methods: ["DELETE"], pathname: "/api/zero/api-keys/:id" },
+  { methods: ["GET", "POST"], pathname: "/api/zero/chat-threads" },
   {
-    methods: ["GET"],
-    pathname: "/api/zero/model-providers",
-    target: "api",
+    methods: ["GET", "PATCH", "DELETE"],
+    pathname: "/api/zero/chat-threads/:id",
   },
-  {
-    methods: ["GET"],
-    pathname: "/api/zero/onboarding/status",
-    target: "api",
-  },
-  {
-    methods: ["GET"],
-    pathname: "/api/zero/org",
-    target: "api",
-  },
-  {
-    methods: ["GET"],
-    pathname: "/api/zero/schedules",
-    target: "api",
-  },
-  {
-    methods: ["GET"],
-    pathname: "/api/zero/team",
-    target: "api",
-  },
+  { methods: ["POST"], pathname: "/api/zero/chat-threads/:id/mark-read" },
+  { methods: ["POST"], pathname: "/api/zero/chat-threads/:id/pin" },
+  { methods: ["POST"], pathname: "/api/zero/chat-threads/:id/rename" },
+  { methods: ["POST"], pathname: "/api/zero/chat-threads/:id/unpin" },
   {
     methods: ["GET", "POST"],
-    pathname: "/api/zero/user-preferences",
-    target: "api",
+    pathname: "/api/zero/chat-threads/:threadId/artifacts",
   },
+  { methods: ["GET"], pathname: "/api/zero/chat-threads/:threadId/messages" },
+  { methods: ["POST"], pathname: "/api/zero/chat/messages" },
+  { methods: ["GET"], pathname: "/api/zero/chat/search" },
+  { methods: ["GET"], pathname: "/api/zero/composes" },
+  { methods: ["GET", "DELETE"], pathname: "/api/zero/composes/:id" },
+  { methods: ["PATCH"], pathname: "/api/zero/composes/:id/metadata" },
+  { methods: ["GET"], pathname: "/api/zero/composes/list" },
+  { methods: ["PUT"], pathname: "/api/zero/default-agent" },
+  { methods: ["GET"], pathname: "/api/zero/insights" },
+  { methods: ["GET"], pathname: "/api/zero/insights/range" },
+  { methods: ["GET"], pathname: "/api/zero/logs" },
+  { methods: ["GET"], pathname: "/api/zero/logs/:id" },
+  { methods: ["GET"], pathname: "/api/zero/logs/search" },
+  { methods: ["GET", "POST"], pathname: "/api/zero/me/model-providers" },
+  { methods: ["DELETE"], pathname: "/api/zero/me/model-providers/:type" },
+  { methods: ["GET"], pathname: "/api/zero/memory" },
+  { methods: ["GET", "POST"], pathname: "/api/zero/model-providers" },
+  { methods: ["DELETE"], pathname: "/api/zero/model-providers/:type" },
+  { methods: ["GET"], pathname: "/api/zero/onboarding/status" },
+  { methods: ["GET", "PUT"], pathname: "/api/zero/org" },
+  { methods: ["POST"], pathname: "/api/zero/org/delete" },
+  { methods: ["POST", "DELETE"], pathname: "/api/zero/org/invite" },
+  { methods: ["POST"], pathname: "/api/zero/org/leave" },
+  { methods: ["GET", "PATCH", "DELETE"], pathname: "/api/zero/org/members" },
   {
-    methods: ["GET"],
-    pathname: "/api/zero/voice-io/quota",
-    target: "api",
+    methods: ["POST", "DELETE"],
+    pathname: "/api/zero/org/membership-requests",
   },
+  { methods: ["GET"], pathname: "/api/zero/queue-position" },
+  { methods: ["POST"], pathname: "/api/zero/realtime/token" },
+  { methods: ["POST"], pathname: "/api/zero/report-error" },
+  { methods: ["POST"], pathname: "/api/zero/runs" },
+  { methods: ["GET"], pathname: "/api/zero/runs/:id" },
+  { methods: ["POST"], pathname: "/api/zero/runs/:id/cancel" },
+  { methods: ["GET"], pathname: "/api/zero/runs/:id/context" },
+  { methods: ["GET"], pathname: "/api/zero/runs/:id/network" },
+  { methods: ["GET"], pathname: "/api/zero/runs/:id/runner" },
+  { methods: ["GET"], pathname: "/api/zero/runs/:id/telemetry/agent" },
+  { methods: ["GET"], pathname: "/api/zero/runs/queue" },
+  { methods: ["GET", "POST"], pathname: "/api/zero/schedules" },
+  { methods: ["DELETE"], pathname: "/api/zero/schedules/:name" },
+  { methods: ["POST"], pathname: "/api/zero/schedules/:name/disable" },
+  { methods: ["POST"], pathname: "/api/zero/schedules/:name/enable" },
+  { methods: ["POST"], pathname: "/api/zero/schedules/run" },
+  { methods: ["GET", "POST"], pathname: "/api/zero/secrets" },
+  { methods: ["DELETE"], pathname: "/api/zero/secrets/:name" },
+  { methods: ["GET", "POST"], pathname: "/api/zero/skills" },
+  { methods: ["GET", "PUT", "DELETE"], pathname: "/api/zero/skills/:name" },
+  { methods: ["GET"], pathname: "/api/zero/team" },
+  { methods: ["POST"], pathname: "/api/zero/uploads/complete" },
+  { methods: ["POST"], pathname: "/api/zero/uploads/prepare" },
+  { methods: ["GET"], pathname: "/api/zero/usage/insight" },
+  { methods: ["GET"], pathname: "/api/zero/usage/members" },
+  { methods: ["GET", "PUT"], pathname: "/api/zero/user-permission-grants" },
+  { methods: ["GET", "POST"], pathname: "/api/zero/user-preferences" },
+  { methods: ["GET", "POST"], pathname: "/api/zero/variables" },
+  { methods: ["DELETE"], pathname: "/api/zero/variables/:name" },
+  { methods: ["GET"], pathname: "/api/zero/voice-io/quota" },
 ];
 
 function normalizeMethod(method: string): string {
   return method.toUpperCase();
+}
+
+// Matches an allowlist pathname template against a concrete request pathname.
+// A `:param` template segment matches exactly one non-empty segment; all other
+// segments must match literally and the segment counts must be equal.
+function pathnameMatches(template: string, pathname: string): boolean {
+  const templateSegments = template.split("/");
+  const pathnameSegments = pathname.split("/");
+  if (templateSegments.length !== pathnameSegments.length) {
+    return false;
+  }
+  return templateSegments.every((segment, index) => {
+    const actual = pathnameSegments[index];
+    if (segment.startsWith(":")) {
+      return actual.length > 0;
+    }
+    return segment === actual;
+  });
 }
 
 export function resolveApiTarget(
@@ -69,13 +133,13 @@ export function resolveApiTarget(
   }
 
   const method = normalizeMethod(request.method);
-  const entry = API_ROUTE_TARGET_POLICY.find((candidate) => {
+  const allowed = API_ROUTE_ALLOWLIST.some((entry) => {
     return (
-      candidate.pathname === request.pathname &&
-      candidate.methods.some((candidateMethod) => {
-        return candidateMethod === method;
+      pathnameMatches(entry.pathname, request.pathname) &&
+      entry.methods.some((entryMethod) => {
+        return entryMethod === method;
       })
     );
   });
-  return entry?.target ?? "www";
+  return allowed ? "api" : "www";
 }


### PR DESCRIPTION
## Summary
Final bulk batch of the Platform API backend cutover (#15872): migrate **all remaining first-party, vm0-owned `/api/zero/*` routes** (reads and writes) from `www` to the dedicated `api` host. Two parts:

1. **Matcher upgrade** (`api-target-policy.ts`): exact-path → route-template matching (`:param` matches exactly one non-empty segment), unlocking dynamic routes like `/api/zero/runs/:id`. Routing stays method-aware.
2. **Allowlist expansion**: 84 new method+path routes (33 reads, 51 writes; 37 dynamic), grouped into 67 path entries.

The route set was produced by a workflow inventory + adversarial classification, then **verified against the contract definitions** (hallucinated/duplicate paths dropped; connector/integration leaks removed).

## Why this is safe
- `apps/web/app/api` is empty; `next.config.js` rewrites `/api/zero/*` to the **same `apps/api` backend**. The cutover only removes the `www` proxy hop — **the handler is identical**. Reads (batches 0–3) and the `user-preferences` POST already run healthy on `api` in prod.
- `apps/api` CORS (`lib/cors.ts`) allows `GET/POST/PUT/PATCH/DELETE` + credentials for the platform origin, so writes work cross-origin.

## Intentionally kept on www (NOT migrated)
OAuth start/callback; connector / custom-connector / user-connector routes; integration routes (github/slack/telegram/agentphone, `/api/zero/integrations/*`); billing/Stripe; bootstrap `feature-switches`; model-provider device-auth sessions; `attribution/signup`; `onboarding/setup`; bb0 device confirm; and the entire external inbound surface (webhooks/cron/cli) the platform never calls. `/api/agent/*` (CLI surface) also stays on www. A sanity grep confirms none of these keywords appear in the allowlist (only in the explanatory comment).

## Matcher collision check
Every excluded path was checked against the allowlisted dynamic templates: none structurally collide (e.g. `/api/zero/connectors/:type` shares no segment shape with any allowlisted template; `/api/zero/agents/:id/user-connectors` differs from `/api/zero/agents/:id/instructions` at the static leaf). Since every allowlist entry targets `api`, any match yields `api` and non-matches fall through to `www`.

## Validation
- New tests — `api-client.test.ts`: dynamic-path delete (`chat-threads/:id`), static write (`chat-threads` create), org mutation now → api. `fetch.test.ts`: method-awareness (GET→api, non-allowlisted method→www) and dynamic `:id`→api. Full `api-client` + `fetch` suites pass (50).
- `pnpm format`, `pnpm -F @vm0/app lint`, `pnpm -F @vm0/app check-types`, `pnpm knip --workspace apps/platform` — clean.

## Rollback
Code-level: revert the entries, or flip `FeatureSwitchKey.ApiBackend`.

## Post-merge verification
Confirm in `vm0-traces-prod` that representative migrated routes (incl. dynamic + writes) land on `service.name=vm0-api` with no 5xx and no fallback-to-web.

Closes #16025
Part of #15872

🤖 Generated with [Claude Code](https://claude.com/claude-code)
