### PR TITLE
fix: disable permission apply without changes

### DIFF
--- a/turbo/apps/platform/src/views/fw/__tests__/permissions-dialog.test.tsx
+++ b/turbo/apps/platform/src/views/fw/__tests__/permissions-dialog.test.tsx
@@ -161,6 +161,15 @@ function getPolicyButton(row: HTMLElement, label: string): HTMLElement {
   return button;
 }
 
+function getUnknownEndpointsRow(): HTMLElement {
+  const label = screen.getByText("Other endpoints");
+  const row = label.closest(".flex.items-center.justify-between");
+  if (!(row instanceof HTMLElement)) {
+    throw new Error("Unknown endpoints row not found");
+  }
+  return row;
+}
+
 describe("permissions dialog - flat list connector (Notion)", () => {
   it("renders permission names and descriptions in flat list (FW-D-031)", async () => {
     mockAPIs({ connectorType: "notion" });
@@ -327,6 +336,26 @@ describe("permissions dialog - grouped connector (Slack)", () => {
         screen.queryByRole("heading", { name: /Slack permissions/i }),
       ).not.toBeInTheDocument();
     });
+  });
+
+  it("enables Apply only when permission policies changed", async () => {
+    mockAPIs({ connectorType: "slack" });
+    detachedSetupPage({ context, path: "/agents/my-agent" });
+    await openPermissionsDrawer("Slack");
+
+    const applyButton = screen.getByText("Apply");
+    expect(applyButton).toBeDisabled();
+
+    click(screen.getByText(/Read \(\d+\)/i));
+    const channelsReadRow = getPermissionRow("channels:read");
+    click(getPolicyButton(channelsReadRow, "Deny"));
+    expect(applyButton).toBeEnabled();
+
+    click(getPolicyButton(channelsReadRow, "Allow"));
+    expect(applyButton).toBeDisabled();
+
+    click(getPolicyButton(getUnknownEndpointsRow(), "Deny"));
+    expect(applyButton).toBeEnabled();
   });
 
   it("allows org admins to manage permissions for agents owned by another user (FW-V-001)", async () => {

--- a/turbo/apps/platform/src/views/zero-page/components/settings/permissions-dialog.tsx
+++ b/turbo/apps/platform/src/views/zero-page/components/settings/permissions-dialog.tsx
@@ -213,6 +213,54 @@ function buildInitialPolicies(
   return result;
 }
 
+function permissionPoliciesEqual(
+  a: Record<string, PermissionPolicy>,
+  b: Record<string, PermissionPolicy>,
+): boolean {
+  const aKeys = Object.keys(a);
+  if (aKeys.length !== Object.keys(b).length) {
+    return false;
+  }
+  for (const key of aKeys) {
+    if (a[key] !== b[key]) {
+      return false;
+    }
+  }
+  return true;
+}
+
+function hasPermissionPolicyChanges({
+  currentPolicies,
+  initialPolicies,
+  currentUnknownPolicy,
+  initialUnknownPolicy,
+}: {
+  currentPolicies: Record<string, PermissionPolicy> | undefined;
+  initialPolicies: Record<string, PermissionPolicy>;
+  currentUnknownPolicy: FirewallPolicyValue;
+  initialUnknownPolicy: FirewallPolicyValue;
+}): boolean {
+  if (currentPolicies === undefined) {
+    return false;
+  }
+  if (currentUnknownPolicy !== initialUnknownPolicy) {
+    return true;
+  }
+  return !permissionPoliciesEqual(currentPolicies, initialPolicies);
+}
+
+function canApplyPermissionPolicies({
+  config,
+  saving,
+  hasChanges,
+}: {
+  config: FirewallConfig | null;
+  saving: boolean;
+  hasChanges: boolean;
+}): boolean {
+  return config !== null && !saving && hasChanges;
+}
+
 function UnknownEndpointsToggle({
   policy,
   disabled,
@@ -278,8 +326,20 @@ export function PermissionsDrawer({
   const pageSignal = useGet(pageSignal$);
 
   const permissions = config ? sortPermissions(extractPermissions(config)) : [];
-  const policies = allPolicies[ref] ?? {};
+  const policiesForRef = allPolicies[ref];
+  const policies = policiesForRef ?? {};
   const groups = buildSortedGroups(config, ref);
+  const hasPermissionChanges = hasPermissionPolicyChanges({
+    currentPolicies: policiesForRef,
+    initialPolicies: initialPolicyState[ref] ?? {},
+    currentUnknownPolicy: unknownPolicy,
+    initialUnknownPolicy,
+  });
+  const canApply = canApplyPermissionPolicies({
+    config,
+    saving,
+    hasChanges: hasPermissionChanges,
+  });
 
   const handlePolicyChange = (name: string, policy: PermissionPolicy) => {
     setPolicyFn(ref, name, policy);
@@ -510,7 +570,7 @@ export function PermissionsDrawer({
             {readOnly ? "Close" : "Cancel"}
           </Button>
           {!readOnly && (
-            <Button onClick={handleApply} disabled={!config || saving}>
+            <Button onClick={handleApply} disabled={!canApply}>
               {saving ? "Saving..." : "Apply"}
             </Button>
           )}


### PR DESCRIPTION
## Summary
- disable the connector permission Apply button until policies actually change
- include the unknown-endpoints policy in the dirty-state check
- cover initial disabled, changed enabled, reverted disabled, and unknown-endpoints changed states

## Tests
- pnpm -F @vm0/app exec vitest run src/views/fw/__tests__/permissions-dialog.test.tsx
- pnpm -F @vm0/app lint
- pnpm prettier --check apps/platform/src/views/zero-page/components/settings/permissions-dialog.tsx apps/platform/src/views/fw/__tests__/permissions-dialog.test.tsx
- git diff --check