### PR TITLE
refactor: generalize model-provider refresh boundary

### DIFF
--- a/turbo/apps/api/src/signals/routes/__tests__/webhooks-agent-firewall-auth.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/webhooks-agent-firewall-auth.test.ts
@@ -3619,7 +3619,7 @@ describe("POST /api/webhooks/agent/firewall/auth", () => {
     expect(forcedResponse.body.refreshedConnectors).toStrictEqual(["notion"]);
   });
 
-  it("refreshes expired codex model-provider OAuth tokens", async () => {
+  it("refreshes expired codex model-provider access tokens", async () => {
     const fixture = await track(seedFixture());
     await seedExpiredCodexModelProvider(fixture);
     server.use(
@@ -3680,7 +3680,7 @@ describe("POST /api/webhooks/agent/firewall/auth", () => {
     });
   });
 
-  it("refreshes user-owned codex model-provider OAuth tokens", async () => {
+  it("refreshes user-owned codex model-provider access tokens", async () => {
     const fixture = await track(seedFixture());
     await seedCodexModelProvider(fixture, {
       sourceUserId: fixture.userId,
@@ -3814,7 +3814,7 @@ describe("POST /api/webhooks/agent/firewall/auth", () => {
     expect(refreshCallCount).toBe(0);
   });
 
-  it("returns missing configuration when a model-provider OAuth row is absent", async () => {
+  it("returns missing configuration when a model-provider row is absent", async () => {
     const fixture = await track(seedFixture());
     let refreshCallCount = 0;
     server.use(
@@ -3863,7 +3863,7 @@ describe("POST /api/webhooks/agent/firewall/auth", () => {
     expect(refreshCallCount).toBe(0);
   });
 
-  it("serializes concurrent model-provider OAuth refreshes for rotated refresh tokens", async () => {
+  it("serializes concurrent model-provider access refreshes for rotated refresh tokens", async () => {
     const fixture = await track(seedFixture());
     await seedExpiredCodexModelProvider(fixture);
 
@@ -4137,7 +4137,7 @@ describe("POST /api/webhooks/agent/firewall/auth", () => {
     expect(refreshCallCount).toBe(0);
   });
 
-  it("preserves model-provider reauth that races with runtime OAuth refresh", async () => {
+  it("preserves model-provider reauth that races with runtime access refresh", async () => {
     const fixture = await track(seedFixture());
     await seedExpiredCodexModelProvider(fixture);
 
@@ -4241,7 +4241,7 @@ describe("POST /api/webhooks/agent/firewall/auth", () => {
     });
   });
 
-  it("derives model-provider source from registered OAuth provider keys", async () => {
+  it("derives model-provider source from registered refresh provider keys", async () => {
     const fixture = await track(seedFixture());
     await seedExpiredCodexModelProvider(fixture);
     server.use(

--- a/turbo/apps/api/src/signals/services/agent-run-create.service.ts
+++ b/turbo/apps/api/src/signals/services/agent-run-create.service.ts
@@ -40,7 +40,7 @@ import {
   getConnectorFirewall,
   isFirewallConnectorType,
 } from "@vm0/connectors/firewalls";
-import { getModelProviderOAuthSecretMetadata } from "@vm0/connectors/auth-providers/model-provider-auth";
+import { getModelProviderRefreshMetadata } from "@vm0/connectors/auth-providers/model-provider-auth";
 import {
   expandHostWildcardsInBaseUrl,
   extractSecretNamesFromApis,
@@ -1175,7 +1175,7 @@ function modelProviderRefreshMaps(
       >;
     }
   | undefined {
-  const metadata = getModelProviderOAuthSecretMetadata(providerType);
+  const metadata = getModelProviderRefreshMetadata(providerType);
   if (!metadata?.isRefreshable) {
     return undefined;
   }

--- a/turbo/apps/api/src/signals/services/agent-webhook-firewall-auth.service.ts
+++ b/turbo/apps/api/src/signals/services/agent-webhook-firewall-auth.service.ts
@@ -39,7 +39,7 @@ import { isOAuthProviderHttpError } from "@vm0/connectors/auth-providers/oauth/e
 import {
   getModelProviderRefreshMetadata,
   isModelProviderRefreshConfigured,
-  refreshModelProviderAccess,
+  refreshPreparedModelProviderAccess,
   isModelProviderRefreshProviderKey,
   type ModelProviderRefreshProviderKey,
 } from "@vm0/connectors/auth-providers/model-provider-auth";
@@ -1749,7 +1749,7 @@ function refreshPreparedModelProviderAccessToken(args: {
   readonly inputs: Readonly<Record<string, string>>;
   readonly signal: AbortSignal;
 }) {
-  return refreshModelProviderAccess({
+  return refreshPreparedModelProviderAccess({
     providerKey: args.prepared.providerKey,
     currentEnv: args.prepared.currentEnv,
     inputs: args.inputs,

--- a/turbo/apps/api/src/signals/services/agent-webhook-firewall-auth.service.ts
+++ b/turbo/apps/api/src/signals/services/agent-webhook-firewall-auth.service.ts
@@ -37,11 +37,11 @@ import {
 } from "@vm0/connectors/auth-providers";
 import { isOAuthProviderHttpError } from "@vm0/connectors/auth-providers/oauth/error";
 import {
-  getModelProviderOAuthSecretMetadata,
-  isModelProviderOAuthRefreshConfigured,
-  refreshModelProviderOAuthToken,
-  isModelProviderOAuthProviderKey,
-  type ModelProviderOAuthProviderKey,
+  getModelProviderRefreshMetadata,
+  isModelProviderRefreshConfigured,
+  refreshModelProviderAccess,
+  isModelProviderRefreshProviderKey,
+  type ModelProviderRefreshProviderKey,
 } from "@vm0/connectors/auth-providers/model-provider-auth";
 import { isChatgptRefreshError } from "@vm0/connectors/auth-providers/oauth/providers/codex-oauth";
 import { agentRuns } from "@vm0/db/schema/agent-run";
@@ -340,7 +340,7 @@ type ConnectorPreparedRefreshTokenContext =
 
 type ModelProviderPreparedRefreshTokenContext = {
   readonly sourceType: "model-provider";
-  readonly providerKey: ModelProviderOAuthProviderKey;
+  readonly providerKey: ModelProviderRefreshProviderKey;
   readonly currentEnv: ProviderEnv;
   readonly context: RefreshTokenContext;
 };
@@ -465,18 +465,20 @@ const REFRESH_BUFFER_SECS = 60;
 const DEFAULT_ACCESS_TOKEN_EXPIRES_IN_SECS = 15 * 60;
 const TEMPLATE_RE = /\$\{\{\s*(secrets|vars)\.([a-zA-Z_][a-zA-Z0-9_]*)\s*\}\}/g;
 
-function getOAuthProviderKeySourceType(
+function getRefreshProviderKeySourceType(
   providerKey: string,
 ): AccessSecretSource {
-  return isModelProviderOAuthProviderKey(providerKey)
+  return isModelProviderRefreshProviderKey(providerKey)
     ? "model-provider"
     : "connector";
 }
 
-function modelProviderTypeForOAuthProviderKey(
+function modelProviderTypeForRefreshProviderKey(
   providerKey: string,
 ): string | undefined {
-  return isModelProviderOAuthProviderKey(providerKey) ? providerKey : undefined;
+  return isModelProviderRefreshProviderKey(providerKey)
+    ? providerKey
+    : undefined;
 }
 
 function resolveSecretUserId(
@@ -494,7 +496,7 @@ function resolveRefreshMetadata(
   metadata: SecretConnectorMetadata | undefined,
 ): SecretConnectorMetadata {
   const sourceType =
-    metadata?.sourceType ?? getOAuthProviderKeySourceType(connectorType);
+    metadata?.sourceType ?? getRefreshProviderKeySourceType(connectorType);
   return {
     sourceType,
     sourceUserId:
@@ -502,7 +504,7 @@ function resolveRefreshMetadata(
     metadataKey:
       sourceType === "model-provider"
         ? (metadata?.metadataKey ??
-          modelProviderTypeForOAuthProviderKey(connectorType))
+          modelProviderTypeForRefreshProviderKey(connectorType))
         : undefined,
   };
 }
@@ -512,7 +514,8 @@ function modelProviderTypeForMetadata(
   metadata: SecretConnectorMetadata,
 ): ModelProviderType | undefined {
   const providerType =
-    metadata.metadataKey ?? modelProviderTypeForOAuthProviderKey(connectorType);
+    metadata.metadataKey ??
+    modelProviderTypeForRefreshProviderKey(connectorType);
   const parsedProviderType = providerType
     ? modelProviderTypeSchema.safeParse(providerType)
     : undefined;
@@ -703,7 +706,7 @@ async function upsertSecretValue(
       type: args.type,
       description:
         args.type === "model-provider"
-          ? `Model provider OAuth secret: ${args.name}`
+          ? `Model provider secret: ${args.name}`
           : `Connector secret: ${args.name}`,
     })
     .onConflictDoUpdate({
@@ -725,9 +728,7 @@ function modelProviderRuntimeSecretName(args: {
   readonly connectorType: string;
   readonly metadata: SecretConnectorMetadata;
 }): string | undefined {
-  const secretMetadata = getModelProviderOAuthSecretMetadata(
-    args.connectorType,
-  );
+  const secretMetadata = getModelProviderRefreshMetadata(args.connectorType);
   if (!secretMetadata?.isRefreshable) {
     return undefined;
   }
@@ -754,9 +755,7 @@ function refreshableRuntimeSecretNameForSource(args: {
 }): string | undefined {
   if (args.metadata.sourceType === "model-provider") {
     const secretName = modelProviderRuntimeSecretName(args);
-    const secretMetadata = getModelProviderOAuthSecretMetadata(
-      args.connectorType,
-    );
+    const secretMetadata = getModelProviderRefreshMetadata(args.connectorType);
     return secretName && secretMetadata?.refreshableSecrets.includes(secretName)
       ? secretName
       : undefined;
@@ -913,7 +912,7 @@ function modelProviderSourceLookup(args: {
     providerKey: args.providerKey,
     providerType:
       metadata.metadataKey ??
-      modelProviderTypeForOAuthProviderKey(args.providerKey) ??
+      modelProviderTypeForRefreshProviderKey(args.providerKey) ??
       args.providerKey,
     userId: resolveSecretUserId(
       "model-provider",
@@ -1046,7 +1045,7 @@ async function getSourceStateByProviderKey(args: {
       ).sourceType === "connector"
     );
   });
-  const modelProviderOAuthProviderKeys = args.connectorTypes.filter(
+  const modelProviderRefreshProviderKeys = args.connectorTypes.filter(
     (connectorType) => {
       return (
         resolveRefreshMetadata(
@@ -1069,7 +1068,7 @@ async function getSourceStateByProviderKey(args: {
     db: args.db,
     orgId: args.orgId,
     userId: args.userId,
-    providerKeys: modelProviderOAuthProviderKeys,
+    providerKeys: modelProviderRefreshProviderKeys,
     metadataByConnector: args.metadataByConnector,
   });
   for (const [providerKey, state] of modelProviderStates) {
@@ -1131,12 +1130,10 @@ function prepareRefreshTokenContext(
   }
 
   if (args.sourceType === "model-provider") {
-    if (!isModelProviderOAuthProviderKey(args.connectorType)) {
+    if (!isModelProviderRefreshProviderKey(args.connectorType)) {
       return { ok: false, reason: "not-refreshable" };
     }
-    const secretMetadata = getModelProviderOAuthSecretMetadata(
-      args.connectorType,
-    );
+    const secretMetadata = getModelProviderRefreshMetadata(args.connectorType);
     if (!secretMetadata.isRefreshable) {
       return { ok: false, reason: "not-refreshable" };
     }
@@ -1148,7 +1145,7 @@ function prepareRefreshTokenContext(
 
     const env = currentProviderEnv();
     if (
-      !isModelProviderOAuthRefreshConfigured({
+      !isModelProviderRefreshConfigured({
         providerKey: args.connectorType,
         currentEnv: env,
       })
@@ -1752,36 +1749,12 @@ function refreshPreparedModelProviderAccessToken(args: {
   readonly inputs: Readonly<Record<string, string>>;
   readonly signal: AbortSignal;
 }) {
-  switch (args.prepared.providerKey) {
-    case "codex-oauth-token": {
-      return refreshModelProviderOAuthToken({
-        providerKey: args.prepared.providerKey,
-        currentEnv: args.prepared.currentEnv,
-        inputs: {
-          refreshToken: requiredPreparedRefreshInput({
-            connectorType: args.prepared.providerKey,
-            inputs: args.inputs,
-            inputName: "refreshToken",
-          }),
-        },
-        signal: args.signal,
-      });
-    }
-  }
-}
-
-function requiredPreparedRefreshInput(args: {
-  readonly connectorType: string;
-  readonly inputs: Readonly<Record<string, string>>;
-  readonly inputName: string;
-}): string {
-  const value = args.inputs[args.inputName];
-  if (value === undefined) {
-    throw new Error(
-      `${args.connectorType} refresh input ${args.inputName} missing after refresh state validation`,
-    );
-  }
-  return value;
+  return refreshModelProviderAccess({
+    providerKey: args.prepared.providerKey,
+    currentEnv: args.prepared.currentEnv,
+    inputs: args.inputs,
+    signal: args.signal,
+  });
 }
 
 function refreshPreparedConnectorAccessToken(args: {
@@ -2212,9 +2185,7 @@ function modelProviderAccessSecretName(args: {
   readonly connectorType: string;
   readonly metadata: SecretConnectorMetadata;
 }): string | undefined {
-  const secretMetadata = getModelProviderOAuthSecretMetadata(
-    args.connectorType,
-  );
+  const secretMetadata = getModelProviderRefreshMetadata(args.connectorType);
   if (!secretMetadata?.isRefreshable) {
     return undefined;
   }

--- a/turbo/apps/api/src/signals/services/zero-model-provider.service.ts
+++ b/turbo/apps/api/src/signals/services/zero-model-provider.service.ts
@@ -130,7 +130,7 @@ type NotFoundResponse = ReturnType<typeof notFound>;
  *   - Multi-auth providers: deletes the per-auth-method secrets by name,
  *     then deletes the model_provider row explicitly.
  *
- * Uses the same auth-state advisory lock as runtime OAuth refresh so a refresh
+ * Uses the same auth-state advisory lock as runtime access refresh so a refresh
  * cannot recreate secrets after a delete.
  */
 export const deleteUserModelProvider$ = command(

--- a/turbo/packages/connectors/src/__tests__/model-provider-auth.test.ts
+++ b/turbo/packages/connectors/src/__tests__/model-provider-auth.test.ts
@@ -1,8 +1,9 @@
-import { describe, expect, it } from "vitest";
+import { describe, expect, expectTypeOf, it } from "vitest";
 import {
   MODEL_PROVIDER_REFRESH_PROVIDER_KEYS,
   getModelProviderRefreshMetadata,
   isModelProviderRefreshProviderKey,
+  refreshModelProviderAccess,
 } from "../auth-providers/model-provider-auth";
 
 describe("model-provider refresh provider registry", () => {
@@ -25,5 +26,20 @@ describe("model-provider refresh provider registry", () => {
     expect(isModelProviderRefreshProviderKey("notion")).toBe(false);
     expect(isModelProviderRefreshProviderKey("totally-unknown")).toBe(false);
     expect(getModelProviderRefreshMetadata("totally-unknown")).toBe(undefined);
+  });
+
+  it("keeps registered provider refresh outputs typed by metadata", () => {
+    const typedRefreshModelProviderAccess =
+      refreshModelProviderAccess<"codex-oauth-token">;
+    type CodexRefreshResult = Awaited<
+      ReturnType<typeof typedRefreshModelProviderAccess>
+    >;
+
+    expectTypeOf<
+      CodexRefreshResult["outputs"]["accessToken"]
+    >().toEqualTypeOf<string>();
+    expectTypeOf<CodexRefreshResult["outputs"]["refreshToken"]>().toEqualTypeOf<
+      string | undefined
+    >();
   });
 });

--- a/turbo/packages/connectors/src/__tests__/model-provider-auth.test.ts
+++ b/turbo/packages/connectors/src/__tests__/model-provider-auth.test.ts
@@ -1,31 +1,29 @@
 import { describe, expect, it } from "vitest";
 import {
-  MODEL_PROVIDER_OAUTH_PROVIDER_KEYS,
-  getModelProviderOAuthSecretMetadata,
-  isModelProviderOAuthProviderKey,
+  MODEL_PROVIDER_REFRESH_PROVIDER_KEYS,
+  getModelProviderRefreshMetadata,
+  isModelProviderRefreshProviderKey,
 } from "../auth-providers/model-provider-auth";
 
-describe("model-provider OAuth provider registry", () => {
-  it("recognizes every registered model-provider OAuth provider key", () => {
-    for (const providerKey of MODEL_PROVIDER_OAUTH_PROVIDER_KEYS) {
-      expect(isModelProviderOAuthProviderKey(providerKey)).toBe(true);
+describe("model-provider refresh provider registry", () => {
+  it("recognizes every registered model-provider refresh provider key", () => {
+    for (const providerKey of MODEL_PROVIDER_REFRESH_PROVIDER_KEYS) {
+      expect(isModelProviderRefreshProviderKey(providerKey)).toBe(true);
     }
   });
 
-  it("returns refreshable metadata for every registered model-provider OAuth provider key", () => {
-    for (const providerKey of MODEL_PROVIDER_OAUTH_PROVIDER_KEYS) {
-      expect(getModelProviderOAuthSecretMetadata(providerKey)).toMatchObject({
+  it("returns refreshable metadata for every registered model-provider refresh provider key", () => {
+    for (const providerKey of MODEL_PROVIDER_REFRESH_PROVIDER_KEYS) {
+      expect(getModelProviderRefreshMetadata(providerKey)).toMatchObject({
         isRefreshable: true,
       });
     }
   });
 
   it("does not recognize connector or unknown provider keys", () => {
-    expect(isModelProviderOAuthProviderKey("github")).toBe(false);
-    expect(isModelProviderOAuthProviderKey("notion")).toBe(false);
-    expect(isModelProviderOAuthProviderKey("totally-unknown")).toBe(false);
-    expect(getModelProviderOAuthSecretMetadata("totally-unknown")).toBe(
-      undefined,
-    );
+    expect(isModelProviderRefreshProviderKey("github")).toBe(false);
+    expect(isModelProviderRefreshProviderKey("notion")).toBe(false);
+    expect(isModelProviderRefreshProviderKey("totally-unknown")).toBe(false);
+    expect(getModelProviderRefreshMetadata("totally-unknown")).toBe(undefined);
   });
 });

--- a/turbo/packages/connectors/src/auth-providers/model-provider-auth.ts
+++ b/turbo/packages/connectors/src/auth-providers/model-provider-auth.ts
@@ -119,7 +119,7 @@ export function isModelProviderRefreshConfigured(args: {
   return Boolean(access.resolveAuthClient(args.currentEnv));
 }
 
-export function refreshModelProviderAccess<
+export async function refreshModelProviderAccess<
   ProviderKey extends ModelProviderRefreshProviderKey,
 >(args: {
   readonly providerKey: ProviderKey;
@@ -130,18 +130,21 @@ export function refreshModelProviderAccess<
   ModelProviderAuthProviderRefreshResult<
     ModelProviderRefreshOutputValues<ProviderKey>
   >
->;
-export function refreshModelProviderAccess(args: {
-  readonly providerKey: ModelProviderRefreshProviderKey;
-  readonly currentEnv: ProviderEnv;
-  readonly inputs: Readonly<Record<string, string>>;
-  readonly signal: AbortSignal;
-}): Promise<
-  ModelProviderAuthProviderRefreshResult<
-    Readonly<Record<string, string | undefined>>
-  >
->;
-export async function refreshModelProviderAccess(args: {
+> {
+  const access = MODEL_PROVIDER_REFRESH_PROVIDERS[args.providerKey].access;
+  const authClient = access.resolveAuthClient(args.currentEnv);
+  if (!authClient) {
+    throw new Error(`${args.providerKey} auth client not configured`);
+  }
+
+  return await access.refresh({
+    authClient,
+    inputs: args.inputs,
+    signal: args.signal,
+  });
+}
+
+export async function refreshPreparedModelProviderAccess(args: {
   readonly providerKey: ModelProviderRefreshProviderKey;
   readonly currentEnv: ProviderEnv;
   readonly inputs: Readonly<Record<string, string>>;
@@ -153,37 +156,20 @@ export async function refreshModelProviderAccess(args: {
 > {
   switch (args.providerKey) {
     case "codex-oauth-token": {
-      return await refreshCodexModelProviderAccess(args);
+      return await refreshModelProviderAccess({
+        providerKey: args.providerKey,
+        currentEnv: args.currentEnv,
+        inputs: {
+          refreshToken: requiredModelProviderRefreshInput({
+            providerKey: args.providerKey,
+            inputs: args.inputs,
+            inputName: "refreshToken",
+          }),
+        },
+        signal: args.signal,
+      });
     }
   }
-}
-
-async function refreshCodexModelProviderAccess(args: {
-  readonly providerKey: "codex-oauth-token";
-  readonly currentEnv: ProviderEnv;
-  readonly inputs: Readonly<Record<string, string>>;
-  readonly signal: AbortSignal;
-}): Promise<
-  ModelProviderAuthProviderRefreshResult<
-    ModelProviderRefreshOutputValues<"codex-oauth-token">
-  >
-> {
-  const access = MODEL_PROVIDER_REFRESH_PROVIDERS[args.providerKey].access;
-  const authClient = access.resolveAuthClient(args.currentEnv);
-  if (!authClient) {
-    throw new Error(`${args.providerKey} auth client not configured`);
-  }
-  return await access.refresh({
-    authClient,
-    inputs: {
-      refreshToken: requiredModelProviderRefreshInput({
-        providerKey: args.providerKey,
-        inputs: args.inputs,
-        inputName: "refreshToken",
-      }),
-    },
-    signal: args.signal,
-  });
 }
 
 function requiredModelProviderRefreshInput(args: {

--- a/turbo/packages/connectors/src/auth-providers/model-provider-auth.ts
+++ b/turbo/packages/connectors/src/auth-providers/model-provider-auth.ts
@@ -9,21 +9,21 @@ import {
   getChatgptSecretName,
 } from "./oauth/providers/codex-oauth";
 
-export const MODEL_PROVIDER_OAUTH_PROVIDER_KEYS = [
+export const MODEL_PROVIDER_REFRESH_PROVIDER_KEYS = [
   "codex-oauth-token",
 ] as const;
 
-export type ModelProviderOAuthProviderKey =
-  (typeof MODEL_PROVIDER_OAUTH_PROVIDER_KEYS)[number];
+export type ModelProviderRefreshProviderKey =
+  (typeof MODEL_PROVIDER_REFRESH_PROVIDER_KEYS)[number];
 
-export interface ModelProviderOAuthSecretMetadata {
+export interface ModelProviderRefreshMetadata {
   readonly isRefreshable: true;
   readonly inputs: Readonly<Record<string, string>>;
   readonly outputs: Readonly<Record<string, string>>;
   readonly refreshableSecrets: readonly string[];
 }
 
-const MODEL_PROVIDER_OAUTH_SECRET_METADATA = {
+const MODEL_PROVIDER_REFRESH_METADATA = {
   "codex-oauth-token": {
     isRefreshable: true,
     inputs: {
@@ -36,111 +36,144 @@ const MODEL_PROVIDER_OAUTH_SECRET_METADATA = {
     refreshableSecrets: [getChatgptSecretName()],
   },
 } as const satisfies Record<
-  ModelProviderOAuthProviderKey,
-  ModelProviderOAuthSecretMetadata
+  ModelProviderRefreshProviderKey,
+  ModelProviderRefreshMetadata
 >;
 
-type ModelProviderOAuthSecretMetadataMap =
-  typeof MODEL_PROVIDER_OAUTH_SECRET_METADATA;
+type ModelProviderRefreshMetadataMap = typeof MODEL_PROVIDER_REFRESH_METADATA;
 
-type ModelProviderOAuthRefreshInputValues<
-  ProviderKey extends ModelProviderOAuthProviderKey,
+type ModelProviderRefreshInputValues<
+  ProviderKey extends ModelProviderRefreshProviderKey,
 > = {
-  readonly [InputName in keyof ModelProviderOAuthSecretMetadataMap[ProviderKey]["inputs"]]: string;
+  readonly [InputName in keyof ModelProviderRefreshMetadataMap[ProviderKey]["inputs"]]: string;
 };
 
-type ModelProviderOAuthRefreshableSecretName<
-  ProviderKey extends ModelProviderOAuthProviderKey,
-> = ModelProviderOAuthSecretMetadataMap[ProviderKey] extends {
+type ModelProviderRefreshableSecretName<
+  ProviderKey extends ModelProviderRefreshProviderKey,
+> = ModelProviderRefreshMetadataMap[ProviderKey] extends {
   readonly refreshableSecrets: readonly (infer SecretName)[];
 }
   ? Extract<SecretName, string>
   : never;
 
-type ModelProviderOAuthRequiredRefreshOutputName<
-  ProviderKey extends ModelProviderOAuthProviderKey,
+type ModelProviderRequiredRefreshOutputName<
+  ProviderKey extends ModelProviderRefreshProviderKey,
 > = {
-  readonly [OutputName in keyof ModelProviderOAuthSecretMetadataMap[ProviderKey]["outputs"]]: ModelProviderOAuthSecretMetadataMap[ProviderKey]["outputs"][OutputName] extends ModelProviderOAuthRefreshableSecretName<ProviderKey>
+  readonly [OutputName in keyof ModelProviderRefreshMetadataMap[ProviderKey]["outputs"]]: ModelProviderRefreshMetadataMap[ProviderKey]["outputs"][OutputName] extends ModelProviderRefreshableSecretName<ProviderKey>
     ? OutputName
     : never;
-}[keyof ModelProviderOAuthSecretMetadataMap[ProviderKey]["outputs"]];
+}[keyof ModelProviderRefreshMetadataMap[ProviderKey]["outputs"]];
 
-type ModelProviderOAuthRefreshOutputValues<
-  ProviderKey extends ModelProviderOAuthProviderKey,
+type ModelProviderRefreshOutputValues<
+  ProviderKey extends ModelProviderRefreshProviderKey,
 > = Readonly<
   Record<
-    Extract<ModelProviderOAuthRequiredRefreshOutputName<ProviderKey>, string>,
+    Extract<ModelProviderRequiredRefreshOutputName<ProviderKey>, string>,
     string
   >
 > & {
   readonly [OutputName in Exclude<
-    keyof ModelProviderOAuthSecretMetadataMap[ProviderKey]["outputs"],
-    ModelProviderOAuthRequiredRefreshOutputName<ProviderKey>
+    keyof ModelProviderRefreshMetadataMap[ProviderKey]["outputs"],
+    ModelProviderRequiredRefreshOutputName<ProviderKey>
   >]?: string;
 };
 
-type ModelProviderOAuthProviderMap = {
-  readonly [Key in ModelProviderOAuthProviderKey]: ModelProviderRefreshTokenAuthProvider<
-    ModelProviderOAuthRefreshInputValues<Key>,
-    ModelProviderOAuthRefreshOutputValues<Key>
+type ModelProviderRefreshProviderMap = {
+  readonly [Key in ModelProviderRefreshProviderKey]: ModelProviderRefreshTokenAuthProvider<
+    ModelProviderRefreshInputValues<Key>,
+    ModelProviderRefreshOutputValues<Key>
   >;
 };
 
-const MODEL_PROVIDER_OAUTH_PROVIDERS: ModelProviderOAuthProviderMap = {
+const MODEL_PROVIDER_REFRESH_PROVIDERS: ModelProviderRefreshProviderMap = {
   "codex-oauth-token": codexOauthProvider,
 };
 
-export function isModelProviderOAuthProviderKey(
+export function isModelProviderRefreshProviderKey(
   providerKey: string,
-): providerKey is ModelProviderOAuthProviderKey {
-  return Object.hasOwn(MODEL_PROVIDER_OAUTH_PROVIDERS, providerKey);
+): providerKey is ModelProviderRefreshProviderKey {
+  return Object.hasOwn(MODEL_PROVIDER_REFRESH_PROVIDERS, providerKey);
 }
 
-export function getModelProviderOAuthSecretMetadata(
-  providerKey: ModelProviderOAuthProviderKey,
-): ModelProviderOAuthSecretMetadata;
-export function getModelProviderOAuthSecretMetadata(
+export function getModelProviderRefreshMetadata(
+  providerKey: ModelProviderRefreshProviderKey,
+): ModelProviderRefreshMetadata;
+export function getModelProviderRefreshMetadata(
   providerKey: string,
-): ModelProviderOAuthSecretMetadata | undefined;
-export function getModelProviderOAuthSecretMetadata(
+): ModelProviderRefreshMetadata | undefined;
+export function getModelProviderRefreshMetadata(
   providerKey: string,
-): ModelProviderOAuthSecretMetadata | undefined {
-  if (!isModelProviderOAuthProviderKey(providerKey)) {
+): ModelProviderRefreshMetadata | undefined {
+  if (!isModelProviderRefreshProviderKey(providerKey)) {
     return undefined;
   }
 
-  return MODEL_PROVIDER_OAUTH_SECRET_METADATA[providerKey];
+  return MODEL_PROVIDER_REFRESH_METADATA[providerKey];
 }
 
-export function isModelProviderOAuthRefreshConfigured(args: {
-  readonly providerKey: ModelProviderOAuthProviderKey;
+export function isModelProviderRefreshConfigured(args: {
+  readonly providerKey: ModelProviderRefreshProviderKey;
   readonly currentEnv: ProviderEnv;
 }): boolean {
-  const access = MODEL_PROVIDER_OAUTH_PROVIDERS[args.providerKey].access;
+  const access = MODEL_PROVIDER_REFRESH_PROVIDERS[args.providerKey].access;
   return Boolean(access.resolveAuthClient(args.currentEnv));
 }
 
-export async function refreshModelProviderOAuthToken<
-  ProviderKey extends ModelProviderOAuthProviderKey,
->(args: {
-  readonly providerKey: ProviderKey;
+export async function refreshModelProviderAccess(args: {
+  readonly providerKey: ModelProviderRefreshProviderKey;
   readonly currentEnv: ProviderEnv;
-  readonly inputs: ModelProviderOAuthRefreshInputValues<ProviderKey>;
+  readonly inputs: Readonly<Record<string, string>>;
   readonly signal: AbortSignal;
 }): Promise<
   ModelProviderAuthProviderRefreshResult<
-    ModelProviderOAuthRefreshOutputValues<ProviderKey>
+    Readonly<Record<string, string | undefined>>
   >
 > {
-  const access = MODEL_PROVIDER_OAUTH_PROVIDERS[args.providerKey].access;
+  switch (args.providerKey) {
+    case "codex-oauth-token": {
+      return await refreshCodexModelProviderAccess(args);
+    }
+  }
+}
+
+async function refreshCodexModelProviderAccess(args: {
+  readonly providerKey: "codex-oauth-token";
+  readonly currentEnv: ProviderEnv;
+  readonly inputs: Readonly<Record<string, string>>;
+  readonly signal: AbortSignal;
+}): Promise<
+  ModelProviderAuthProviderRefreshResult<
+    ModelProviderRefreshOutputValues<"codex-oauth-token">
+  >
+> {
+  const access = MODEL_PROVIDER_REFRESH_PROVIDERS[args.providerKey].access;
   const authClient = access.resolveAuthClient(args.currentEnv);
   if (!authClient) {
     throw new Error(`${args.providerKey} auth client not configured`);
   }
-
   return await access.refresh({
     authClient,
-    inputs: args.inputs,
+    inputs: {
+      refreshToken: requiredModelProviderRefreshInput({
+        providerKey: args.providerKey,
+        inputs: args.inputs,
+        inputName: "refreshToken",
+      }),
+    },
     signal: args.signal,
   });
+}
+
+function requiredModelProviderRefreshInput(args: {
+  readonly providerKey: ModelProviderRefreshProviderKey;
+  readonly inputs: Readonly<Record<string, string>>;
+  readonly inputName: string;
+}): string {
+  const value = args.inputs[args.inputName];
+  if (value === undefined) {
+    throw new Error(
+      `${args.providerKey} refresh input ${args.inputName} missing after refresh state validation`,
+    );
+  }
+  return value;
 }

--- a/turbo/packages/connectors/src/auth-providers/model-provider-auth.ts
+++ b/turbo/packages/connectors/src/auth-providers/model-provider-auth.ts
@@ -119,6 +119,28 @@ export function isModelProviderRefreshConfigured(args: {
   return Boolean(access.resolveAuthClient(args.currentEnv));
 }
 
+export function refreshModelProviderAccess<
+  ProviderKey extends ModelProviderRefreshProviderKey,
+>(args: {
+  readonly providerKey: ProviderKey;
+  readonly currentEnv: ProviderEnv;
+  readonly inputs: ModelProviderRefreshInputValues<ProviderKey>;
+  readonly signal: AbortSignal;
+}): Promise<
+  ModelProviderAuthProviderRefreshResult<
+    ModelProviderRefreshOutputValues<ProviderKey>
+  >
+>;
+export function refreshModelProviderAccess(args: {
+  readonly providerKey: ModelProviderRefreshProviderKey;
+  readonly currentEnv: ProviderEnv;
+  readonly inputs: Readonly<Record<string, string>>;
+  readonly signal: AbortSignal;
+}): Promise<
+  ModelProviderAuthProviderRefreshResult<
+    Readonly<Record<string, string | undefined>>
+  >
+>;
 export async function refreshModelProviderAccess(args: {
   readonly providerKey: ModelProviderRefreshProviderKey;
   readonly currentEnv: ProviderEnv;

--- a/turbo/packages/connectors/src/auth-providers/oauth/providers/__tests__/codex-oauth.test.ts
+++ b/turbo/packages/connectors/src/auth-providers/oauth/providers/__tests__/codex-oauth.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from "vitest";
 import { HttpResponse, http } from "msw";
-import { getModelProviderOAuthSecretMetadata } from "../../../model-provider-auth";
+import { getModelProviderRefreshMetadata } from "../../../model-provider-auth";
 import {
   getChatgptSecretName,
   getChatgptRefreshSecretName,
@@ -194,7 +194,7 @@ describe("connector/providers/codex-oauth", () => {
   describe("codexOauthProvider", () => {
     it("is registered with model-provider refresh metadata", () => {
       expect(
-        getModelProviderOAuthSecretMetadata("codex-oauth-token"),
+        getModelProviderRefreshMetadata("codex-oauth-token"),
       ).toStrictEqual({
         isRefreshable: true,
         inputs: {


### PR DESCRIPTION
## Summary

- Rename the upper-layer model-provider refresh registry/helpers from OAuth-specific names to generic refresh/access names.
- Move Codex-specific refresh input preparation into the model-provider refresh boundary so API service code calls a generic `refreshModelProviderAccess` helper.
- Update firewall auth, run-context construction, and focused tests to use the generic model-provider refresh boundary while keeping `codex-oauth-token` and OAuth provider internals unchanged.

Closes #16030

## Verification

- `pnpm -F @vm0/connectors exec vitest src/__tests__/model-provider-auth.test.ts src/auth-providers/oauth/providers/__tests__/codex-oauth.test.ts`
- `pnpm -F api exec vitest src/signals/routes/__tests__/webhooks-agent-firewall-auth.test.ts`
- `pnpm -F @vm0/connectors check-types`
- `pnpm -F api check-types`
- `pnpm -F @vm0/connectors lint`
- `pnpm -F api lint`
- `pnpm exec prettier --write --ignore-unknown apps/api/src/signals/services/agent-run-create.service.ts apps/api/src/signals/services/agent-webhook-firewall-auth.service.ts packages/connectors/src/__tests__/model-provider-auth.test.ts packages/connectors/src/auth-providers/model-provider-auth.ts packages/connectors/src/auth-providers/oauth/providers/__tests__/codex-oauth.test.ts`

Full `pnpm check-types` currently fails in unrelated web presentation files on this base:

- `apps/web/app/[locale]/presentation/PresentationClient.tsx(110,36): Parameter 'item' implicitly has an 'any' type`
- `apps/web/app/[locale]/presentation/data.ts(4,8): Cannot find module '@vm0/core' or its corresponding type declarations`
- `apps/web/app/[locale]/presentation/page.tsx(60,46): Parameter 'item' implicitly has an 'any' type`
- `apps/web/app/[locale]/presentation/page.tsx(60,52): Parameter 'i' implicitly has an 'any' type`