### PR TITLE
fix(api): ignore stale onboarding pending for paid orgs

### DIFF
--- a/turbo/apps/api/src/signals/routes/__tests__/helpers/zero-onboarding-status.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/helpers/zero-onboarding-status.ts
@@ -18,6 +18,7 @@ interface DefaultAgentValues {
 interface OnboardingSeedValues {
   readonly defaultAgent?: DefaultAgentValues;
   readonly onboardingPaymentPending?: boolean;
+  readonly tier?: string;
 }
 
 export interface OnboardingStatusFixture {
@@ -61,6 +62,7 @@ export const seedOnboardingStatusOrg$ = command(
       orgId,
       defaultAgentId: composeId,
       onboardingPaymentPending: values.onboardingPaymentPending ?? false,
+      ...(values.tier === undefined ? {} : { tier: values.tier }),
     });
     signal.throwIfAborted();
 

--- a/turbo/apps/api/src/signals/routes/__tests__/zero-onboarding-status.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/zero-onboarding-status.test.ts
@@ -145,6 +145,42 @@ describe("GET /api/zero/onboarding/status", () => {
     });
   });
 
+  it.each(["pro", "team"] as const)(
+    "ignores stale pending onboarding payment for %s orgs",
+    async (tier) => {
+      const fixture = await track(
+        store.set(
+          seedOnboardingStatusOrg$,
+          {
+            defaultAgent: {},
+            onboardingPaymentPending: true,
+            tier,
+          },
+          context.signal,
+        ),
+      );
+      mocks.clerk.session(fixture.userId, fixture.orgId, "org:admin");
+
+      const client = setupApp({ context })(onboardingStatusContract);
+
+      const response = await accept(
+        client.getStatus({
+          headers: { authorization: "Bearer clerk-session" },
+        }),
+        [200],
+      );
+
+      expect(response.body).toStrictEqual({
+        needsOnboarding: false,
+        isAdmin: true,
+        hasOrg: true,
+        hasDefaultAgent: true,
+        defaultAgentId: fixture.composeId,
+        defaultAgentMetadata: null,
+      });
+    },
+  );
+
   it("returns default agent metadata when the compose has metadata", async () => {
     const fixture = await track(
       store.set(

--- a/turbo/apps/api/src/signals/services/onboarding.service.ts
+++ b/turbo/apps/api/src/signals/services/onboarding.service.ts
@@ -435,6 +435,19 @@ function onboardingPaymentPending(orgId: string): Computed<Promise<boolean>> {
   });
 }
 
+function orgTier(orgId: string): Computed<Promise<string>> {
+  return computed(async (get): Promise<string> => {
+    const db = get(db$);
+    const [row] = await db
+      .select({ tier: orgMetadata.tier })
+      .from(orgMetadata)
+      .where(eq(orgMetadata.orgId, orgId))
+      .limit(1);
+
+    return row?.tier ?? "pro-suspend";
+  });
+}
+
 function defaultAgentInfo(
   orgId: string,
   composeId: string,
@@ -494,15 +507,18 @@ export function onboardingStatus(
     const isAdmin = "orgRole" in auth && auth.orgRole === "admin";
     const agentId = await get(defaultAgentId(auth.orgId));
     const paymentPending = await get(onboardingPaymentPending(auth.orgId));
+    const tier = await get(orgTier(auth.orgId));
     const defaultAgent = agentId
       ? await get(defaultAgentInfo(auth.orgId, agentId))
       : null;
 
-    // Existing free workspaces never have onboardingPaymentPending set, so
-    // they do not re-enter onboarding. New onboarding remains active until the
-    // Pro trial checkout succeeds.
+    // New pro-suspend onboarding stays active until checkout clears the
+    // pending marker. Paid orgs do not re-enter onboarding just because a
+    // stale marker exists.
     return {
-      needsOnboarding: isAdmin && (!defaultAgent || paymentPending),
+      needsOnboarding:
+        isAdmin &&
+        (!defaultAgent || (tier === "pro-suspend" && paymentPending)),
       isAdmin,
       hasOrg: true,
       hasDefaultAgent: defaultAgent !== null,


### PR DESCRIPTION
## Summary
- keep onboarding pending active only for `pro-suspend` orgs
- prevent paid Pro/Team orgs from re-entering onboarding when `onboardingPaymentPending` is stale
- add onboarding status coverage for Pro/Team orgs with a default agent and stale pending marker

## Tests
- `pnpm -F api exec vitest run src/signals/routes/__tests__/zero-onboarding-status.test.ts`
- `pnpm -F api check-types`
- `pnpm -F api lint`
- `pnpm exec prettier --check apps/api/src/signals/services/onboarding.service.ts apps/api/src/signals/routes/__tests__/helpers/zero-onboarding-status.ts apps/api/src/signals/routes/__tests__/zero-onboarding-status.test.ts && git diff --check`