### PR TITLE
fix(billing): bind dashboard stripe subscriptions to orgs

### DIFF
--- a/.github/workflows/turbo.yml
+++ b/.github/workflows/turbo.yml
@@ -1001,6 +1001,39 @@ jobs:
           REPO_SECRETS_JSON: ${{ toJSON(secrets) }}
           DOPPLER_SECRETS_JSON: ${{ toJSON(steps.doppler-oauth.outputs) }}
 
+      - name: Use Stripe CLI webhook secret for API preview
+        if: |
+          needs.prepare.outputs.web-changed == 'true' ||
+          needs.prepare.outputs.api-changed == 'true' ||
+          needs.prepare.outputs.cli-changed == 'true' ||
+          needs.prepare.outputs.platform-changed == 'true' ||
+          needs.prepare.outputs.crates-changed == 'true' ||
+          needs.prepare.outputs.ci-changed == 'true' ||
+          needs.prepare.outputs.e2e-changed == 'true' ||
+          needs.prepare.outputs.api-backend-needed == 'true'
+        run: |
+          set -euo pipefail
+          export PATH="$HOME/.local/bin:$PATH"
+          bash e2e/scripts/ensure-stripe-cli.sh
+
+          stripe_webhook_secret="$(stripe listen --api-key "$STRIPE_SECRET_KEY" --print-secret 2>/dev/null)"
+          echo "::add-mask::$stripe_webhook_secret"
+          if [[ "$stripe_webhook_secret" != whsec_* ]]; then
+            echo "Stripe CLI did not return a webhook signing secret" >&2
+            exit 1
+          fi
+
+          if grep -q '^STRIPE_WEBHOOK_SECRET=' "$API_ENV_FILE"; then
+            sed -i "s|^STRIPE_WEBHOOK_SECRET=.*|STRIPE_WEBHOOK_SECRET=${stripe_webhook_secret}|" "$API_ENV_FILE"
+          else
+            printf 'STRIPE_WEBHOOK_SECRET=%s\n' "$stripe_webhook_secret" >> "$API_ENV_FILE"
+          fi
+
+          echo "Configured API preview to trust Stripe CLI webhooks"
+        env:
+          API_ENV_FILE: ${{ steps.api-deploy-env.outputs.file }}
+          STRIPE_SECRET_KEY: ${{ secrets.STRIPE_SECRET_KEY }}
+
       - name: Deploy API to Vercel
         id: api-deploy
         if: |
@@ -1303,6 +1336,42 @@ jobs:
         run: cd e2e && npm ci
       - name: Install Playwright browsers
         run: cd e2e && npx playwright install --with-deps chromium
+      - name: Start Stripe webhook forwarding
+        run: |
+          set -euo pipefail
+          export PATH="$HOME/.local/bin:$PATH"
+          bash e2e/scripts/ensure-stripe-cli.sh
+
+          stripe_webhook_secret="$(stripe listen --api-key "$STRIPE_SECRET_KEY" --print-secret 2>/dev/null)"
+          echo "::add-mask::$stripe_webhook_secret"
+
+          forward_url="${API_PREVIEW_URL%/}/api/webhooks/stripe"
+          stripe listen \
+            --api-key "$STRIPE_SECRET_KEY" \
+            --events checkout.session.completed,invoice.paid,customer.subscription.updated,customer.subscription.deleted \
+            --forward-to "$forward_url" \
+            > /tmp/stripe-listen.log 2>&1 &
+          stripe_pid="$!"
+          echo "$stripe_pid" > /tmp/stripe-listen.pid
+
+          for _ in {1..10}; do
+            if grep -qi 'ready' /tmp/stripe-listen.log; then
+              echo "Stripe webhook forwarding started for $forward_url"
+              exit 0
+            fi
+            if ! kill -0 "$stripe_pid" 2>/dev/null; then
+              sed -E 's/whsec_[[:alnum:]_]+/[masked-stripe-webhook-secret]/g' /tmp/stripe-listen.log >&2
+              exit 1
+            fi
+            sleep 1
+          done
+
+          echo "Stripe CLI did not become ready" >&2
+          sed -E 's/whsec_[[:alnum:]_]+/[masked-stripe-webhook-secret]/g' /tmp/stripe-listen.log >&2
+          exit 1
+        env:
+          API_PREVIEW_URL: ${{ needs.deploy-web.outputs.api-preview-url }}
+          STRIPE_SECRET_KEY: ${{ secrets.STRIPE_SECRET_KEY }}
       - name: Run Playwright E2E tests
         run: cd e2e && npx playwright test --config playwright/playwright.config.ts
         env:
@@ -1310,6 +1379,18 @@ jobs:
           CLERK_PUBLISHABLE_KEY: ${{ vars.CLERK_PUBLISHABLE_KEY }}
           CLERK_SECRET_KEY: ${{ secrets.CLERK_SECRET_KEY }}
           JOB_REF: ${{ needs.prepare.outputs.job-ref }}
+      - name: Print Stripe webhook forwarding log
+        if: always()
+        run: |
+          if [[ -f /tmp/stripe-listen.log ]]; then
+            tail -200 /tmp/stripe-listen.log | sed -E 's/whsec_[[:alnum:]_]+/[masked-stripe-webhook-secret]/g'
+          fi
+      - name: Stop Stripe webhook forwarding
+        if: always()
+        run: |
+          if [[ -f /tmp/stripe-listen.pid ]]; then
+            kill "$(cat /tmp/stripe-listen.pid)" 2>/dev/null || true
+          fi
       - name: Upload Playwright report
         if: always()
         uses: actions/upload-artifact@v7

--- a/.github/workflows/turbo.yml
+++ b/.github/workflows/turbo.yml
@@ -1370,7 +1370,7 @@ jobs:
           sed -E 's/whsec_[[:alnum:]_]+/[masked-stripe-webhook-secret]/g' /tmp/stripe-listen.log >&2
           exit 1
         env:
-          API_PREVIEW_URL: ${{ needs.deploy-web.outputs.api-preview-url }}
+          API_PREVIEW_URL: ${{ needs.prepare.outputs.api-preview-url }}
           STRIPE_SECRET_KEY: ${{ secrets.STRIPE_SECRET_KEY }}
       - name: Run Playwright E2E tests
         run: cd e2e && npx playwright test --config playwright/playwright.config.ts

--- a/e2e/scripts/ensure-stripe-cli.sh
+++ b/e2e/scripts/ensure-stripe-cli.sh
@@ -1,0 +1,52 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+if command -v stripe >/dev/null 2>&1; then
+  stripe --version
+  exit 0
+fi
+
+version="${STRIPE_CLI_VERSION:-1.41.2}"
+
+case "$(uname -s)" in
+  Linux)
+    os="linux"
+    ;;
+  *)
+    echo "Unsupported Stripe CLI platform: $(uname -s)" >&2
+    exit 1
+    ;;
+esac
+
+case "$(uname -m)" in
+  x86_64 | amd64)
+    arch="x86_64"
+    ;;
+  aarch64 | arm64)
+    arch="arm64"
+    ;;
+  *)
+    echo "Unsupported Stripe CLI architecture: $(uname -m)" >&2
+    exit 1
+    ;;
+esac
+
+tmp_dir="$(mktemp -d)"
+trap 'rm -rf "$tmp_dir"' EXIT
+
+curl -fsSL \
+  "https://github.com/stripe/stripe-cli/releases/download/v${version}/stripe_${version}_${os}_${arch}.tar.gz" \
+  -o "$tmp_dir/stripe.tar.gz"
+tar -xzf "$tmp_dir/stripe.tar.gz" -C "$tmp_dir"
+
+install_dir="${STRIPE_CLI_INSTALL_DIR:-$HOME/.local/bin}"
+mkdir -p "$install_dir"
+cp "$tmp_dir/stripe" "$install_dir/stripe"
+chmod 0755 "$install_dir/stripe"
+
+if [[ -n "${GITHUB_PATH:-}" ]]; then
+  echo "$install_dir" >> "$GITHUB_PATH"
+fi
+
+export PATH="$install_dir:$PATH"
+stripe --version

--- a/turbo/apps/api/src/signals/route.ts
+++ b/turbo/apps/api/src/signals/route.ts
@@ -74,6 +74,7 @@ import { zeroBillingDowngradeRoutes } from "./routes/zero-billing-downgrade";
 import { zeroBillingInvoicesRoutes } from "./routes/zero-billing-invoices";
 import { zeroBillingPortalRoutes } from "./routes/zero-billing-portal";
 import { zeroBillingRedeemRoutes } from "./routes/zero-billing-redeem";
+import { zeroBillingRestoreRoutes } from "./routes/zero-billing-restore";
 import { zeroBillingStatusRoutes } from "./routes/zero-billing-status";
 import { zeroBankingRoutes } from "./routes/zero-banking";
 import { zeroChatThreadRoutes } from "./routes/zero-chat-threads";
@@ -256,6 +257,7 @@ export const ROUTES: readonly RouteEntry[] = [
   ...zeroBillingInvoicesRoutes,
   ...zeroBillingPortalRoutes,
   ...zeroBillingRedeemRoutes,
+  ...zeroBillingRestoreRoutes,
   ...zeroBillingStatusRoutes,
   ...zeroBankingRoutes,
   ...zeroChatThreadRoutes,

--- a/turbo/apps/api/src/signals/routes/__tests__/cron-reconcile-billing-entitlements.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/cron-reconcile-billing-entitlements.test.ts
@@ -265,7 +265,7 @@ describe("GET /api/cron/reconcile-billing-entitlements", () => {
 
   it("downgrades canceled Stripe subscriptions as missed deleted hooks", async () => {
     const fixture = await track(
-      seedBillingOrg({ status: "past_due", currentPeriodEnd: null }),
+      seedBillingOrg({ status: "past_due", currentPeriodEnd: hoursAgo(48) }),
     );
     context.mocks.stripe.subscriptions.retrieve.mockResolvedValue(
       stripeSubscription(fixture.subscriptionId, {
@@ -284,6 +284,7 @@ describe("GET /api/cron/reconcile-billing-entitlements", () => {
       tier: "pro-suspend",
       subscriptionStatus: "canceled",
       stripeSubscriptionId: null,
+      currentPeriodEnd: null,
     });
   });
 

--- a/turbo/apps/api/src/signals/routes/__tests__/helpers/zero-billing-invoices.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/helpers/zero-billing-invoices.ts
@@ -18,6 +18,7 @@ interface InvoicesSeedValues {
   readonly subscriptionStatus?: string | null;
   readonly tier?: string;
   readonly currentPeriodEnd?: Date | null;
+  readonly cancelAtPeriodEnd?: boolean;
 }
 
 export const seedInvoicesOrg$ = command(
@@ -40,6 +41,9 @@ export const seedInvoicesOrg$ = command(
       ...(values.tier !== undefined ? { tier: values.tier } : {}),
       ...(values.currentPeriodEnd !== undefined
         ? { currentPeriodEnd: values.currentPeriodEnd }
+        : {}),
+      ...(values.cancelAtPeriodEnd !== undefined
+        ? { cancelAtPeriodEnd: values.cancelAtPeriodEnd }
         : {}),
     });
     signal.throwIfAborted();

--- a/turbo/apps/api/src/signals/routes/__tests__/webhooks-third-party.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/webhooks-third-party.test.ts
@@ -222,6 +222,7 @@ interface GitHubIssueCommentPayloadOverrides {
 interface StripeBillingRow {
   readonly credits: number;
   readonly tier: string;
+  readonly stripeCustomerId: string | null;
   readonly stripeSubscriptionId: string | null;
   readonly subscriptionStatus: string | null;
   readonly currentPeriodEnd: Date | null;
@@ -682,6 +683,7 @@ async function selectStripeBilling(
     .select({
       credits: orgMetadata.credits,
       tier: orgMetadata.tier,
+      stripeCustomerId: orgMetadata.stripeCustomerId,
       stripeSubscriptionId: orgMetadata.stripeSubscriptionId,
       subscriptionStatus: orgMetadata.subscriptionStatus,
       currentPeriodEnd: orgMetadata.currentPeriodEnd,
@@ -2425,6 +2427,151 @@ describe("POST /api/webhooks/stripe", () => {
     });
   });
 
+  describe("customer.subscription.created", () => {
+    it("binds a dashboard-created Pro subscription to the org by Stripe customer", async () => {
+      const fixture = await trackStripe(
+        store.set(seedStripeFixture$, undefined, context.signal),
+      );
+      mockStripeWebhookEnv();
+      const subId = stripeId("sub");
+      const periodEnd = 1_800_000_000;
+
+      const response = await postStripeWebhookEvent({
+        type: "customer.subscription.created",
+        dataObject: {
+          id: subId,
+          customer: fixture.stripeCustomerId,
+          status: "active",
+          cancel_at_period_end: false,
+          items: {
+            data: [
+              {
+                price: { id: STRIPE_PRICE_PRO },
+                current_period_end: periodEnd,
+              },
+            ],
+          },
+        },
+      });
+
+      expect(response.status).toBe(200);
+      const billing = await selectStripeBilling(fixture);
+      expect(billing.tier).toBe("pro");
+      expect(billing.stripeSubscriptionId).toBe(subId);
+      expect(billing.subscriptionStatus).toBe("active");
+      expect(billing.currentPeriodEnd).toStrictEqual(
+        new Date(periodEnd * 1000),
+      );
+      expect(billing.cancelAtPeriodEnd).toBeFalsy();
+    });
+
+    it("does not bind a subscription for an unknown Stripe customer", async () => {
+      const fixture = await trackStripe(
+        store.set(seedStripeFixture$, undefined, context.signal),
+      );
+      mockStripeWebhookEnv();
+      const customerId = stripeId("cus");
+      context.mocks.stripe.customers.retrieve.mockResolvedValue({
+        id: customerId,
+        metadata: {},
+      });
+
+      const response = await postStripeWebhookEvent({
+        type: "customer.subscription.created",
+        dataObject: {
+          id: stripeId("sub"),
+          customer: customerId,
+          status: "active",
+          cancel_at_period_end: false,
+          items: {
+            data: [{ price: { id: STRIPE_PRICE_PRO } }],
+          },
+        },
+      });
+
+      expect(response.status).toBe(200);
+      const billing = await selectStripeBilling(fixture);
+      expect(billing.tier).toBe("pro-suspend");
+      expect(billing.stripeSubscriptionId).toBeNull();
+      expect(billing.subscriptionStatus).toBeNull();
+    });
+
+    it("binds a dashboard-created customer to the org from Stripe metadata", async () => {
+      const fixture = await trackStripe(
+        store.set(seedStripeFixture$, undefined, context.signal),
+      );
+      mockStripeWebhookEnv();
+      const customerId = stripeId("cus");
+      const subId = stripeId("sub");
+      const periodEnd = 1_800_000_000;
+      await updateStripeOrg(fixture, { stripeCustomerId: null });
+      context.mocks.stripe.customers.retrieve.mockResolvedValue({
+        id: customerId,
+        metadata: { orgId: fixture.orgId },
+      });
+
+      const response = await postStripeWebhookEvent({
+        type: "customer.subscription.created",
+        dataObject: {
+          id: subId,
+          customer: customerId,
+          status: "active",
+          cancel_at_period_end: false,
+          items: {
+            data: [
+              {
+                price: { id: STRIPE_PRICE_PRO },
+                current_period_end: periodEnd,
+              },
+            ],
+          },
+        },
+      });
+
+      expect(response.status).toBe(200);
+      const billing = await selectStripeBilling(fixture);
+      expect(billing.stripeCustomerId).toBe(customerId);
+      expect(billing.tier).toBe("pro");
+      expect(billing.stripeSubscriptionId).toBe(subId);
+      expect(billing.subscriptionStatus).toBe("active");
+      expect(billing.currentPeriodEnd).toStrictEqual(
+        new Date(periodEnd * 1000),
+      );
+    });
+
+    it("does not rebind metadata to an org with a different Stripe customer", async () => {
+      const fixture = await trackStripe(
+        store.set(seedStripeFixture$, undefined, context.signal),
+      );
+      mockStripeWebhookEnv();
+      const customerId = stripeId("cus");
+      context.mocks.stripe.customers.retrieve.mockResolvedValue({
+        id: customerId,
+        metadata: { orgId: fixture.orgId },
+      });
+
+      const response = await postStripeWebhookEvent({
+        type: "customer.subscription.created",
+        dataObject: {
+          id: stripeId("sub"),
+          customer: customerId,
+          status: "active",
+          cancel_at_period_end: false,
+          items: {
+            data: [{ price: { id: STRIPE_PRICE_PRO } }],
+          },
+        },
+      });
+
+      expect(response.status).toBe(200);
+      const billing = await selectStripeBilling(fixture);
+      expect(billing.stripeCustomerId).toBe(fixture.stripeCustomerId);
+      expect(billing.tier).toBe("pro-suspend");
+      expect(billing.stripeSubscriptionId).toBeNull();
+      expect(billing.subscriptionStatus).toBeNull();
+    });
+  });
+
   describe("invoice.paid", () => {
     it("grants 20k credits for pro tier", async () => {
       const fixture = await trackStripe(
@@ -2827,6 +2974,56 @@ describe("POST /api/webhooks/stripe", () => {
       ).toStrictEqual(new Date(periodEnd * 1000));
     });
 
+    it("syncs trial credit expiry when the Stripe trial period is extended", async () => {
+      const fixture = await trackStripe(
+        store.set(seedStripeFixture$, undefined, context.signal),
+      );
+      mockStripeWebhookEnv();
+      const subId = stripeId("sub");
+      const extendedPeriodEnd = 1_900_000_000;
+      const extendedTrialEnd = 1_900_086_400;
+      await updateStripeOrg(fixture, {
+        stripeSubscriptionId: subId,
+        subscriptionStatus: "trialing",
+        tier: "pro",
+      });
+      await insertStripeCreditExpiresRecord(fixture, {
+        stripeInvoiceId: stripeId("inv_trial"),
+        amount: 20_000,
+        remaining: 15_000,
+        expiresAt: new Date("2026-01-01T00:00:00.000Z"),
+      });
+
+      const response = await postStripeWebhookEvent({
+        type: "customer.subscription.updated",
+        dataObject: {
+          id: subId,
+          status: "trialing",
+          trial_end: extendedTrialEnd,
+          cancel_at_period_end: false,
+          items: {
+            data: [
+              {
+                price: { id: STRIPE_PRICE_PRO },
+                current_period_end: extendedPeriodEnd,
+              },
+            ],
+          },
+        },
+      });
+
+      expect(response.status).toBe(200);
+      const billing = await selectStripeBilling(fixture);
+      const records = await selectStripeCreditExpiresRecords(fixture);
+      expect(billing.currentPeriodEnd).toStrictEqual(
+        new Date(extendedPeriodEnd * 1000),
+      );
+      expect(records).toHaveLength(1);
+      expect(records[0]?.expiresAt).toStrictEqual(
+        new Date(extendedTrialEnd * 1000),
+      );
+    });
+
     it("does not extend paid-through from a failed payment update", async () => {
       const fixture = await trackStripe(
         store.set(seedStripeFixture$, undefined, context.signal),
@@ -2906,28 +3103,30 @@ describe("POST /api/webhooks/stripe", () => {
       expect(records[0]?.expiresAt).toStrictEqual(expectedExpiresAt);
     });
 
-    it("creates trialing Pro expires record with seven-day expiresAt", async () => {
+    it("creates trialing Pro expires record at the Stripe trial period end", async () => {
       const fixture = await trackStripe(
         store.set(seedStripeFixture$, undefined, context.signal),
       );
       mockStripeWebhookEnv();
       const subId = stripeId("sub");
       const invId = stripeId("inv");
+      const periodEnd = 1_800_000_000;
+      const trialEnd = 1_800_086_400;
       await updateStripeOrg(fixture, { stripeSubscriptionId: subId });
       context.mocks.stripe.subscriptions.retrieve.mockResolvedValue({
         id: subId,
         status: "trialing",
+        trial_end: trialEnd,
         items: { data: [{ price: { id: STRIPE_PRICE_PRO } }] },
       });
 
-      const lowerBound = nowDate().getTime() + 7 * 86_400 * 1000;
       const response = await postStripeWebhookEvent({
         type: "invoice.paid",
         dataObject: {
           id: invId,
           customer: fixture.stripeCustomerId,
           metadata: null,
-          lines: invoiceLinesWithSubscriptionPeriod(1_800_000_000),
+          lines: invoiceLinesWithSubscriptionPeriod(periodEnd),
           parent: { subscription_details: { subscription: subId } },
         },
       });
@@ -2940,11 +3139,7 @@ describe("POST /api/webhooks/stripe", () => {
         remaining: 20_000,
         stripeInvoiceId: invId,
       });
-      const upperBound = nowDate().getTime() + 7 * 86_400 * 1000;
-      expect(records[0]?.expiresAt.getTime()).toBeGreaterThanOrEqual(
-        lowerBound,
-      );
-      expect(records[0]?.expiresAt.getTime()).toBeLessThanOrEqual(upperBound);
+      expect(records[0]?.expiresAt).toStrictEqual(new Date(trialEnd * 1000));
     });
 
     it("expires old credits before granting new ones", async () => {

--- a/turbo/apps/api/src/signals/routes/__tests__/webhooks-third-party.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/webhooks-third-party.test.ts
@@ -649,12 +649,18 @@ function invoiceLinesWithSubscriptionPeriod(periodEnd: number): {
 async function postStripeWebhookEvent(args: {
   readonly type: string;
   readonly dataObject: Record<string, unknown>;
+  readonly previousAttributes?: Record<string, unknown>;
   readonly body?: string;
 }): Promise<AppResponse> {
   context.mocks.stripe.webhooks.constructEvent.mockReturnValue({
     id: stripeId("evt"),
     type: args.type,
-    data: { object: args.dataObject },
+    data: {
+      object: args.dataObject,
+      ...(args.previousAttributes === undefined
+        ? {}
+        : { previous_attributes: args.previousAttributes }),
+    },
   });
 
   return await postRaw({
@@ -3108,7 +3114,7 @@ describe("POST /api/webhooks/stripe", () => {
       ).toStrictEqual(paidThrough);
     });
 
-    it("does not sync trial period or credit expiry from subscription updates", async () => {
+    it("does not extend trial period or credit expiry from subscription updates", async () => {
       const fixture = await trackStripe(
         store.set(seedStripeFixture$, undefined, context.signal),
       );
@@ -3147,6 +3153,7 @@ describe("POST /api/webhooks/stripe", () => {
             ],
           },
         },
+        previousAttributes: { trial_end: 1_800_000_000 },
       });
 
       expect(response.status).toBe(200);
@@ -3155,6 +3162,68 @@ describe("POST /api/webhooks/stripe", () => {
       expect(billing.currentPeriodEnd).toStrictEqual(existingPeriodEnd);
       expect(records).toHaveLength(1);
       expect(records[0]?.expiresAt).toStrictEqual(existingExpiresAt);
+    });
+
+    it("clamps trial period and credit expiry when subscription update shortens trial", async () => {
+      const fixture = await trackStripe(
+        store.set(seedStripeFixture$, undefined, context.signal),
+      );
+      mockStripeWebhookEnv();
+      const subId = stripeId("sub");
+      const shortenedTrialEnd = 1_800_000_000;
+      const previousTrialEnd = 1_900_000_000;
+      const existingPeriodEnd = new Date(previousTrialEnd * 1000);
+      const existingExpiresAt = new Date(previousTrialEnd * 1000);
+      await updateStripeOrg(fixture, {
+        credits: 20_000,
+        stripeSubscriptionId: subId,
+        subscriptionStatus: "trialing",
+        tier: "pro",
+        currentPeriodEnd: existingPeriodEnd,
+      });
+      await insertStripeCreditExpiresRecord(fixture, {
+        stripeInvoiceId: stripeId("inv_trial"),
+        amount: 20_000,
+        remaining: 15_000,
+        expiresAt: existingExpiresAt,
+      });
+
+      const response = await postStripeWebhookEvent({
+        type: "customer.subscription.updated",
+        dataObject: {
+          id: subId,
+          status: "trialing",
+          trial_end: shortenedTrialEnd,
+          cancel_at_period_end: false,
+          items: {
+            data: [
+              {
+                price: { id: STRIPE_PRICE_PRO },
+                current_period_end: shortenedTrialEnd,
+              },
+            ],
+          },
+        },
+        previousAttributes: { trial_end: previousTrialEnd },
+      });
+
+      expect(response.status).toBe(200);
+      const billing = await selectStripeBilling(fixture);
+      const records = await selectStripeCreditExpiresRecords(fixture);
+      expect(billing.credits).toBe(20_000);
+      expect(billing.tier).toBe("pro");
+      expect(billing.subscriptionStatus).toBe("trialing");
+      expect(billing.currentPeriodEnd).toStrictEqual(
+        new Date(shortenedTrialEnd * 1000),
+      );
+      expect(records).toHaveLength(1);
+      expect(records[0]).toMatchObject({
+        amount: 20_000,
+        remaining: 15_000,
+      });
+      expect(records[0]?.expiresAt).toStrictEqual(
+        new Date(shortenedTrialEnd * 1000),
+      );
     });
 
     it("does not extend paid-through from a failed payment update", async () => {

--- a/turbo/apps/api/src/signals/routes/__tests__/webhooks-third-party.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/webhooks-third-party.test.ts
@@ -2180,7 +2180,7 @@ describe("POST /api/webhooks/stripe", () => {
   });
 
   describe("checkout.session.completed", () => {
-    it("activates subscription and sets tier", async () => {
+    it("records subscription checkout without granting invoice-backed entitlement", async () => {
       const fixture = await trackStripe(
         store.set(seedStripeFixture$, undefined, context.signal),
       );
@@ -2213,14 +2213,12 @@ describe("POST /api/webhooks/stripe", () => {
 
       expect(response.status).toBe(200);
       const billing = await selectStripeBilling(fixture);
-      expect(billing.tier).toBe("pro");
+      expect(billing.tier).toBe("pro-suspend");
       expect(billing.stripeSubscriptionId).toBe(subId);
       expect(billing.subscriptionStatus).toBe("active");
-      expect(billing.currentPeriodEnd).toStrictEqual(
-        new Date(periodEnd * 1000),
-      );
+      expect(billing.currentPeriodEnd).toBeNull();
       expect(billing.cancelAtPeriodEnd).toBeFalsy();
-      expect(billing.onboardingPaymentPending).toBeFalsy();
+      expect(billing.onboardingPaymentPending).toBeTruthy();
     });
 
     it("is idempotent when subscription is already stored", async () => {
@@ -2435,6 +2433,7 @@ describe("POST /api/webhooks/stripe", () => {
       mockStripeWebhookEnv();
       const subId = stripeId("sub");
       const periodEnd = 1_800_000_000;
+      await updateStripeOrg(fixture, { onboardingPaymentPending: true });
 
       const response = await postStripeWebhookEvent({
         type: "customer.subscription.created",
@@ -2456,13 +2455,47 @@ describe("POST /api/webhooks/stripe", () => {
 
       expect(response.status).toBe(200);
       const billing = await selectStripeBilling(fixture);
-      expect(billing.tier).toBe("pro");
+      expect(billing.tier).toBe("pro-suspend");
       expect(billing.stripeSubscriptionId).toBe(subId);
       expect(billing.subscriptionStatus).toBe("active");
-      expect(billing.currentPeriodEnd).toStrictEqual(
-        new Date(periodEnd * 1000),
-      );
+      expect(billing.currentPeriodEnd).toBeNull();
       expect(billing.cancelAtPeriodEnd).toBeFalsy();
+      expect(billing.onboardingPaymentPending).toBeTruthy();
+    });
+
+    it("records an incomplete subscription without granting paid tier", async () => {
+      const fixture = await trackStripe(
+        store.set(seedStripeFixture$, undefined, context.signal),
+      );
+      mockStripeWebhookEnv();
+      const subId = stripeId("sub");
+      await updateStripeOrg(fixture, { onboardingPaymentPending: true });
+
+      const response = await postStripeWebhookEvent({
+        type: "customer.subscription.created",
+        dataObject: {
+          id: subId,
+          customer: fixture.stripeCustomerId,
+          status: "incomplete",
+          cancel_at_period_end: false,
+          items: {
+            data: [
+              {
+                price: { id: STRIPE_PRICE_PRO },
+                current_period_end: 1_800_000_000,
+              },
+            ],
+          },
+        },
+      });
+
+      expect(response.status).toBe(200);
+      const billing = await selectStripeBilling(fixture);
+      expect(billing.tier).toBe("pro-suspend");
+      expect(billing.stripeSubscriptionId).toBe(subId);
+      expect(billing.subscriptionStatus).toBe("incomplete");
+      expect(billing.currentPeriodEnd).toBeNull();
+      expect(billing.onboardingPaymentPending).toBeTruthy();
     });
 
     it("does not bind a subscription for an unknown Stripe customer", async () => {
@@ -2531,12 +2564,10 @@ describe("POST /api/webhooks/stripe", () => {
       expect(response.status).toBe(200);
       const billing = await selectStripeBilling(fixture);
       expect(billing.stripeCustomerId).toBe(customerId);
-      expect(billing.tier).toBe("pro");
+      expect(billing.tier).toBe("pro-suspend");
       expect(billing.stripeSubscriptionId).toBe(subId);
       expect(billing.subscriptionStatus).toBe("active");
-      expect(billing.currentPeriodEnd).toStrictEqual(
-        new Date(periodEnd * 1000),
-      );
+      expect(billing.currentPeriodEnd).toBeNull();
     });
 
     it("does not rebind metadata to an org with a different Stripe customer", async () => {
@@ -2581,10 +2612,14 @@ describe("POST /api/webhooks/stripe", () => {
       const subId = stripeId("sub");
       const invId = stripeId("inv");
       const periodEnd = 1_800_000_000;
-      await updateStripeOrg(fixture, { stripeSubscriptionId: subId });
+      await updateStripeOrg(fixture, {
+        stripeSubscriptionId: subId,
+        onboardingPaymentPending: true,
+      });
       context.mocks.stripe.subscriptions.retrieve.mockResolvedValue({
         id: subId,
         status: "active",
+        cancel_at_period_end: false,
         items: { data: [{ price: { id: STRIPE_PRICE_PRO } }] },
       });
       const creditsBefore = (await selectStripeBilling(fixture)).credits;
@@ -2603,10 +2638,70 @@ describe("POST /api/webhooks/stripe", () => {
       expect(response.status).toBe(200);
       const billing = await selectStripeBilling(fixture);
       expect(billing.credits - creditsBefore).toBe(20_000);
+      expect(billing.tier).toBe("pro");
+      expect(billing.subscriptionStatus).toBe("active");
+      expect(billing.cancelAtPeriodEnd).toBeFalsy();
+      expect(billing.onboardingPaymentPending).toBeFalsy();
       expect(billing.lastProcessedInvoiceId).toBe(invId);
       expect(billing.currentPeriodEnd).toStrictEqual(
         new Date(periodEnd * 1000),
       );
+    });
+
+    it("binds the Stripe customer and grants credits when invoice.paid arrives first", async () => {
+      const fixture = await trackStripe(
+        store.set(seedStripeFixture$, undefined, context.signal),
+      );
+      mockStripeWebhookEnv();
+      const subId = stripeId("sub");
+      const invId = stripeId("inv");
+      const periodEnd = 1_800_000_000;
+      await updateStripeOrg(fixture, {
+        stripeCustomerId: null,
+        onboardingPaymentPending: true,
+      });
+      context.mocks.stripe.customers.retrieve.mockResolvedValue({
+        id: fixture.stripeCustomerId,
+        metadata: { orgId: fixture.orgId },
+      });
+      context.mocks.stripe.subscriptions.retrieve.mockResolvedValue({
+        id: subId,
+        status: "active",
+        cancel_at_period_end: false,
+        items: { data: [{ price: { id: STRIPE_PRICE_PRO } }] },
+      });
+
+      const response = await postStripeWebhookEvent({
+        type: "invoice.paid",
+        dataObject: {
+          id: invId,
+          customer: fixture.stripeCustomerId,
+          metadata: null,
+          lines: invoiceLinesWithSubscriptionPeriod(periodEnd),
+          parent: { subscription_details: { subscription: subId } },
+        },
+      });
+
+      expect(response.status).toBe(200);
+      const billing = await selectStripeBilling(fixture);
+      expect(billing.stripeCustomerId).toBe(fixture.stripeCustomerId);
+      expect(billing.stripeSubscriptionId).toBe(subId);
+      expect(billing.subscriptionStatus).toBe("active");
+      expect(billing.tier).toBe("pro");
+      expect(billing.onboardingPaymentPending).toBeFalsy();
+      expect(billing.credits).toBe(20_000);
+      expect(billing.lastProcessedInvoiceId).toBe(invId);
+      expect(billing.currentPeriodEnd).toStrictEqual(
+        new Date(periodEnd * 1000),
+      );
+      const records = await selectStripeCreditExpiresRecords(fixture);
+      expect(records).toHaveLength(1);
+      expect(records[0]).toMatchObject({
+        source: "subscription_renewal",
+        stripeInvoiceId: invId,
+        amount: 20_000,
+        remaining: 20_000,
+      });
     });
 
     it("grants 120k credits for team tier", async () => {
@@ -2827,7 +2922,7 @@ describe("POST /api/webhooks/stripe", () => {
       expect(billing.tier).toBe("pro");
     });
 
-    it("downgrades tier from team to pro when price changes", async () => {
+    it("does not downgrade tier from a subscription price change before invoice payment", async () => {
       const fixture = await trackStripe(
         store.set(seedStripeFixture$, undefined, context.signal),
       );
@@ -2851,11 +2946,11 @@ describe("POST /api/webhooks/stripe", () => {
 
       expect(response.status).toBe(200);
       const billing = await selectStripeBilling(fixture);
-      expect(billing.tier).toBe("pro");
+      expect(billing.tier).toBe("team");
       expect(billing.subscriptionStatus).toBe("active");
     });
 
-    it("resolves legacy price ID to correct tier", async () => {
+    it("does not update tier from legacy price ID before invoice payment", async () => {
       const fixture = await trackStripe(
         store.set(seedStripeFixture$, undefined, context.signal),
       );
@@ -2878,7 +2973,7 @@ describe("POST /api/webhooks/stripe", () => {
       });
 
       expect(response.status).toBe(200);
-      expect((await selectStripeBilling(fixture)).tier).toBe("team");
+      expect((await selectStripeBilling(fixture)).tier).toBe("pro");
     });
 
     it("syncs cancelAtPeriodEnd true from subscription.updated", async () => {
@@ -2907,6 +3002,43 @@ describe("POST /api/webhooks/stripe", () => {
       expect(
         (await selectStripeBilling(fixture)).cancelAtPeriodEnd,
       ).toBeTruthy();
+    });
+
+    it("syncs scheduled cancellation when Stripe only sends cancel_at", async () => {
+      const fixture = await trackStripe(
+        store.set(seedStripeFixture$, undefined, context.signal),
+      );
+      mockStripeWebhookEnv();
+      const subId = stripeId("sub");
+      const cancelAt = 1_800_000_000;
+      await updateStripeOrg(fixture, {
+        stripeSubscriptionId: subId,
+        subscriptionStatus: "active",
+        tier: "pro",
+      });
+
+      const response = await postStripeWebhookEvent({
+        type: "customer.subscription.updated",
+        dataObject: {
+          id: subId,
+          status: "active",
+          cancel_at: cancelAt,
+          cancel_at_period_end: false,
+          items: {
+            data: [
+              {
+                price: { id: STRIPE_PRICE_PRO },
+                current_period_end: cancelAt,
+              },
+            ],
+          },
+        },
+      });
+
+      expect(response.status).toBe(200);
+      const billing = await selectStripeBilling(fixture);
+      expect(billing.cancelAtPeriodEnd).toBeTruthy();
+      expect(billing.currentPeriodEnd).toStrictEqual(new Date(cancelAt * 1000));
     });
 
     it("clears cancelAtPeriodEnd when subscription is uncancelled", async () => {
@@ -2938,17 +3070,19 @@ describe("POST /api/webhooks/stripe", () => {
       ).toBeFalsy();
     });
 
-    it("refreshes current period end for active subscriptions", async () => {
+    it("does not refresh current period end for active subscriptions before invoice payment", async () => {
       const fixture = await trackStripe(
         store.set(seedStripeFixture$, undefined, context.signal),
       );
       mockStripeWebhookEnv();
       const subId = stripeId("sub");
       const periodEnd = 1_800_000_000;
+      const paidThrough = new Date("2026-04-26T07:24:12Z");
       await updateStripeOrg(fixture, {
         stripeSubscriptionId: subId,
         subscriptionStatus: "active",
         tier: "pro",
+        currentPeriodEnd: paidThrough,
       });
 
       const response = await postStripeWebhookEvent({
@@ -2971,7 +3105,7 @@ describe("POST /api/webhooks/stripe", () => {
       expect(response.status).toBe(200);
       expect(
         (await selectStripeBilling(fixture)).currentPeriodEnd,
-      ).toStrictEqual(new Date(periodEnd * 1000));
+      ).toStrictEqual(paidThrough);
     });
 
     it("syncs trial credit expiry when the Stripe trial period is extended", async () => {
@@ -3413,6 +3547,7 @@ describe("POST /api/webhooks/stripe", () => {
         stripeSubscriptionId: subId,
         subscriptionStatus: "active",
         cancelAtPeriodEnd: true,
+        currentPeriodEnd: new Date("2026-07-04T03:55:51Z"),
         tier: "team",
       });
 
@@ -3427,6 +3562,7 @@ describe("POST /api/webhooks/stripe", () => {
       expect(billing.subscriptionStatus).toBe("canceled");
       expect(billing.stripeSubscriptionId).toBeNull();
       expect(billing.cancelAtPeriodEnd).toBeFalsy();
+      expect(billing.currentPeriodEnd).toBeNull();
     });
   });
 });

--- a/turbo/apps/api/src/signals/routes/__tests__/webhooks-third-party.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/webhooks-third-party.test.ts
@@ -3108,24 +3108,27 @@ describe("POST /api/webhooks/stripe", () => {
       ).toStrictEqual(paidThrough);
     });
 
-    it("syncs trial credit expiry when the Stripe trial period is extended", async () => {
+    it("does not sync trial period or credit expiry from subscription updates", async () => {
       const fixture = await trackStripe(
         store.set(seedStripeFixture$, undefined, context.signal),
       );
       mockStripeWebhookEnv();
       const subId = stripeId("sub");
+      const existingPeriodEnd = new Date("2026-01-01T00:00:00.000Z");
+      const existingExpiresAt = new Date("2026-01-02T00:00:00.000Z");
       const extendedPeriodEnd = 1_900_000_000;
       const extendedTrialEnd = 1_900_086_400;
       await updateStripeOrg(fixture, {
         stripeSubscriptionId: subId,
         subscriptionStatus: "trialing",
         tier: "pro",
+        currentPeriodEnd: existingPeriodEnd,
       });
       await insertStripeCreditExpiresRecord(fixture, {
         stripeInvoiceId: stripeId("inv_trial"),
         amount: 20_000,
         remaining: 15_000,
-        expiresAt: new Date("2026-01-01T00:00:00.000Z"),
+        expiresAt: existingExpiresAt,
       });
 
       const response = await postStripeWebhookEvent({
@@ -3149,13 +3152,9 @@ describe("POST /api/webhooks/stripe", () => {
       expect(response.status).toBe(200);
       const billing = await selectStripeBilling(fixture);
       const records = await selectStripeCreditExpiresRecords(fixture);
-      expect(billing.currentPeriodEnd).toStrictEqual(
-        new Date(extendedPeriodEnd * 1000),
-      );
+      expect(billing.currentPeriodEnd).toStrictEqual(existingPeriodEnd);
       expect(records).toHaveLength(1);
-      expect(records[0]?.expiresAt).toStrictEqual(
-        new Date(extendedTrialEnd * 1000),
-      );
+      expect(records[0]?.expiresAt).toStrictEqual(existingExpiresAt);
     });
 
     it("does not extend paid-through from a failed payment update", async () => {
@@ -3274,6 +3273,81 @@ describe("POST /api/webhooks/stripe", () => {
         stripeInvoiceId: invId,
       });
       expect(records[0]?.expiresAt).toStrictEqual(new Date(trialEnd * 1000));
+    });
+
+    it("refreshes trial expiry from later trial invoices without granting duplicate credits", async () => {
+      const fixture = await trackStripe(
+        store.set(seedStripeFixture$, undefined, context.signal),
+      );
+      mockStripeWebhookEnv();
+      const subId = stripeId("sub");
+      const firstInvId = stripeId("inv");
+      const secondInvId = stripeId("inv");
+      const firstPeriodEnd = 1_800_000_000;
+      const firstTrialEnd = 1_800_086_400;
+      const extendedPeriodEnd = 1_900_000_000;
+      const extendedTrialEnd = 1_900_086_400;
+      await updateStripeOrg(fixture, {
+        stripeSubscriptionId: subId,
+        onboardingPaymentPending: true,
+      });
+      context.mocks.stripe.subscriptions.retrieve
+        .mockResolvedValueOnce({
+          id: subId,
+          status: "trialing",
+          trial_end: firstTrialEnd,
+          cancel_at_period_end: false,
+          items: { data: [{ price: { id: STRIPE_PRICE_PRO } }] },
+        })
+        .mockResolvedValueOnce({
+          id: subId,
+          status: "trialing",
+          trial_end: extendedTrialEnd,
+          cancel_at_period_end: false,
+          items: { data: [{ price: { id: STRIPE_PRICE_PRO } }] },
+        });
+
+      const firstResponse = await postStripeWebhookEvent({
+        type: "invoice.paid",
+        dataObject: {
+          id: firstInvId,
+          customer: fixture.stripeCustomerId,
+          metadata: null,
+          lines: invoiceLinesWithSubscriptionPeriod(firstPeriodEnd),
+          parent: { subscription_details: { subscription: subId } },
+        },
+      });
+      const secondResponse = await postStripeWebhookEvent({
+        type: "invoice.paid",
+        dataObject: {
+          id: secondInvId,
+          customer: fixture.stripeCustomerId,
+          metadata: null,
+          lines: invoiceLinesWithSubscriptionPeriod(extendedPeriodEnd),
+          parent: { subscription_details: { subscription: subId } },
+        },
+      });
+
+      expect(firstResponse.status).toBe(200);
+      expect(secondResponse.status).toBe(200);
+      const billing = await selectStripeBilling(fixture);
+      const records = await selectStripeCreditExpiresRecords(fixture);
+      expect(billing.credits).toBe(20_000);
+      expect(billing.tier).toBe("pro");
+      expect(billing.subscriptionStatus).toBe("trialing");
+      expect(billing.lastProcessedInvoiceId).toBe(secondInvId);
+      expect(billing.currentPeriodEnd).toStrictEqual(
+        new Date(extendedPeriodEnd * 1000),
+      );
+      expect(records).toHaveLength(1);
+      expect(records[0]).toMatchObject({
+        amount: 20_000,
+        remaining: 20_000,
+        stripeInvoiceId: firstInvId,
+      });
+      expect(records[0]?.expiresAt).toStrictEqual(
+        new Date(extendedTrialEnd * 1000),
+      );
     });
 
     it("expires old credits before granting new ones", async () => {

--- a/turbo/apps/api/src/signals/routes/__tests__/zero-billing-checkout.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/zero-billing-checkout.test.ts
@@ -659,7 +659,7 @@ describe("POST /api/zero/billing/checkout/complete", () => {
     return fixture;
   }
 
-  it("reconciles a completed subscription checkout for the current org", async () => {
+  it("records a completed subscription checkout while waiting for invoice payment", async () => {
     const customerId = `cus_${randomUUID().slice(0, 8)}`;
     const subscriptionId = `sub_${randomUUID().slice(0, 8)}`;
     const fixture = await trackedSeed({
@@ -699,7 +699,7 @@ describe("POST /api/zero/billing/checkout/complete", () => {
       [200],
     );
 
-    expect(response.body).toStrictEqual({ completed: true });
+    expect(response.body).toStrictEqual({ completed: false });
 
     const writeDb = store.set(writeDb$);
     const [row] = await writeDb
@@ -714,12 +714,76 @@ describe("POST /api/zero/billing/checkout/complete", () => {
       .where(eq(orgMetadata.orgId, fixture.orgId))
       .limit(1);
 
-    expect(row).toMatchObject({
-      tier: "pro",
+    expect(row).toStrictEqual({
+      tier: "pro-suspend",
       stripeSubscriptionId: subscriptionId,
       subscriptionStatus: "trialing",
-      onboardingPaymentPending: false,
-      currentPeriodEnd: new Date(1_800_000_000 * 1000),
+      onboardingPaymentPending: true,
+      currentPeriodEnd: null,
+    });
+  });
+
+  it("keeps checkout pending when the subscription is incomplete", async () => {
+    const customerId = `cus_${randomUUID().slice(0, 8)}`;
+    const subscriptionId = `sub_${randomUUID().slice(0, 8)}`;
+    const fixture = await trackedSeed({
+      onboardingPaymentPending: true,
+      stripeCustomerId: customerId,
+    });
+    mocks.clerk.session(fixture.userId, fixture.orgId, "org:admin");
+
+    context.mocks.stripe.checkout.sessions.retrieve.mockResolvedValue({
+      id: "cs_test_completed",
+      mode: "subscription",
+      status: "complete",
+      customer: customerId,
+      subscription: subscriptionId,
+    });
+    context.mocks.stripe.subscriptions.retrieve.mockResolvedValue({
+      id: subscriptionId,
+      status: "incomplete",
+      cancel_at_period_end: false,
+      items: {
+        data: [
+          {
+            price: { id: TEST_PRICE_PRO },
+            current_period_end: 1_800_000_000,
+          },
+        ],
+      },
+    });
+
+    const client = setupApp({ context })(zeroBillingCheckoutContract);
+
+    const response = await accept(
+      client.complete({
+        body: { sessionId: "cs_test_completed" },
+        headers: { authorization: "Bearer clerk-session" },
+      }),
+      [200],
+    );
+
+    expect(response.body).toStrictEqual({ completed: false });
+
+    const writeDb = store.set(writeDb$);
+    const [row] = await writeDb
+      .select({
+        tier: orgMetadata.tier,
+        stripeSubscriptionId: orgMetadata.stripeSubscriptionId,
+        subscriptionStatus: orgMetadata.subscriptionStatus,
+        onboardingPaymentPending: orgMetadata.onboardingPaymentPending,
+        currentPeriodEnd: orgMetadata.currentPeriodEnd,
+      })
+      .from(orgMetadata)
+      .where(eq(orgMetadata.orgId, fixture.orgId))
+      .limit(1);
+
+    expect(row).toStrictEqual({
+      tier: "pro-suspend",
+      stripeSubscriptionId: subscriptionId,
+      subscriptionStatus: "incomplete",
+      onboardingPaymentPending: true,
+      currentPeriodEnd: null,
     });
   });
 

--- a/turbo/apps/api/src/signals/routes/__tests__/zero-billing-checkout.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/zero-billing-checkout.test.ts
@@ -6,6 +6,7 @@ import {
 } from "@vm0/api-contracts/contracts/zero-billing";
 import type { ZeroCapability } from "@vm0/api-contracts/contracts/composes";
 import { createStore } from "ccstate";
+import { creditExpiresRecord } from "@vm0/db/schema/credit-expires-record";
 import { orgMetadata } from "@vm0/db/schema/org-metadata";
 import { orgMembersCache } from "@vm0/db/schema/org-members-cache";
 import { eq } from "drizzle-orm";
@@ -85,6 +86,9 @@ async function seedOrgRow(values?: {
 async function deleteOrgRow(orgId: string): Promise<void> {
   const writeDb = store.set(writeDb$);
   await writeDb.delete(orgMembersCache).where(eq(orgMembersCache.orgId, orgId));
+  await writeDb
+    .delete(creditExpiresRecord)
+    .where(eq(creditExpiresRecord.orgId, orgId));
   await writeDb.delete(orgMetadata).where(eq(orgMetadata.orgId, orgId));
 }
 
@@ -658,6 +662,115 @@ describe("POST /api/zero/billing/checkout/complete", () => {
     createdOrgIds.push(fixture.orgId);
     return fixture;
   }
+
+  it("completes onboarding when the checkout subscription latest invoice is paid", async () => {
+    const customerId = `cus_${randomUUID().slice(0, 8)}`;
+    const subscriptionId = `sub_${randomUUID().slice(0, 8)}`;
+    const invoiceId = `in_${randomUUID().slice(0, 8)}`;
+    const currentPeriodEnd = 1_800_000_000;
+    const trialEnd = 1_800_086_400;
+    const fixture = await trackedSeed({
+      onboardingPaymentPending: true,
+      stripeCustomerId: customerId,
+    });
+    mocks.clerk.session(fixture.userId, fixture.orgId, "org:admin");
+
+    context.mocks.stripe.checkout.sessions.retrieve.mockResolvedValue({
+      id: "cs_test_completed",
+      mode: "subscription",
+      status: "complete",
+      customer: customerId,
+      subscription: subscriptionId,
+    });
+    context.mocks.stripe.subscriptions.retrieve.mockResolvedValue({
+      id: subscriptionId,
+      status: "trialing",
+      trial_end: trialEnd,
+      cancel_at: null,
+      cancel_at_period_end: false,
+      latest_invoice: {
+        id: invoiceId,
+        status: "paid",
+        parent: {
+          subscription_details: { subscription: subscriptionId },
+        },
+        lines: {
+          data: [
+            {
+              period: { end: currentPeriodEnd },
+              parent: { type: "subscription_item_details" },
+            },
+          ],
+        },
+      },
+      items: {
+        data: [
+          {
+            price: { id: TEST_PRICE_PRO },
+            current_period_end: currentPeriodEnd,
+          },
+        ],
+      },
+    });
+
+    const client = setupApp({ context })(zeroBillingCheckoutContract);
+
+    const response = await accept(
+      client.complete({
+        body: { sessionId: "cs_test_completed" },
+        headers: { authorization: "Bearer clerk-session" },
+      }),
+      [200],
+    );
+
+    expect(response.body).toStrictEqual({ completed: true });
+
+    const writeDb = store.set(writeDb$);
+    const [row] = await writeDb
+      .select({
+        credits: orgMetadata.credits,
+        tier: orgMetadata.tier,
+        stripeSubscriptionId: orgMetadata.stripeSubscriptionId,
+        subscriptionStatus: orgMetadata.subscriptionStatus,
+        onboardingPaymentPending: orgMetadata.onboardingPaymentPending,
+        currentPeriodEnd: orgMetadata.currentPeriodEnd,
+        lastProcessedInvoiceId: orgMetadata.lastProcessedInvoiceId,
+      })
+      .from(orgMetadata)
+      .where(eq(orgMetadata.orgId, fixture.orgId))
+      .limit(1);
+
+    expect(row).toStrictEqual({
+      credits: 20_000,
+      tier: "pro",
+      stripeSubscriptionId: subscriptionId,
+      subscriptionStatus: "trialing",
+      onboardingPaymentPending: false,
+      currentPeriodEnd: new Date(currentPeriodEnd * 1000),
+      lastProcessedInvoiceId: invoiceId,
+    });
+
+    const records = await writeDb
+      .select({
+        source: creditExpiresRecord.source,
+        stripeInvoiceId: creditExpiresRecord.stripeInvoiceId,
+        amount: creditExpiresRecord.amount,
+        remaining: creditExpiresRecord.remaining,
+        expiresAt: creditExpiresRecord.expiresAt,
+      })
+      .from(creditExpiresRecord)
+      .where(eq(creditExpiresRecord.orgId, fixture.orgId));
+
+    expect(records).toStrictEqual([
+      {
+        source: "subscription_renewal",
+        stripeInvoiceId: invoiceId,
+        amount: 20_000,
+        remaining: 20_000,
+        expiresAt: new Date(trialEnd * 1000),
+      },
+    ]);
+  });
 
   it("records a completed subscription checkout while waiting for invoice payment", async () => {
     const customerId = `cus_${randomUUID().slice(0, 8)}`;

--- a/turbo/apps/api/src/signals/routes/__tests__/zero-billing-checkout.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/zero-billing-checkout.test.ts
@@ -6,7 +6,6 @@ import {
 } from "@vm0/api-contracts/contracts/zero-billing";
 import type { ZeroCapability } from "@vm0/api-contracts/contracts/composes";
 import { createStore } from "ccstate";
-import { creditExpiresRecord } from "@vm0/db/schema/credit-expires-record";
 import { orgMetadata } from "@vm0/db/schema/org-metadata";
 import { orgMembersCache } from "@vm0/db/schema/org-members-cache";
 import { eq } from "drizzle-orm";
@@ -85,9 +84,6 @@ async function seedOrgRow(values?: {
 
 async function deleteOrgRow(orgId: string): Promise<void> {
   const writeDb = store.set(writeDb$);
-  await writeDb
-    .delete(creditExpiresRecord)
-    .where(eq(creditExpiresRecord.orgId, orgId));
   await writeDb.delete(orgMembersCache).where(eq(orgMembersCache.orgId, orgId));
   await writeDb.delete(orgMetadata).where(eq(orgMetadata.orgId, orgId));
 }
@@ -663,11 +659,9 @@ describe("POST /api/zero/billing/checkout/complete", () => {
     return fixture;
   }
 
-  it("completes onboarding for a trial subscription checkout", async () => {
+  it("records a completed subscription checkout while waiting for invoice payment", async () => {
     const customerId = `cus_${randomUUID().slice(0, 8)}`;
     const subscriptionId = `sub_${randomUUID().slice(0, 8)}`;
-    const currentPeriodEnd = 1_800_000_000;
-    const trialEnd = 1_800_086_400;
     const fixture = await trackedSeed({
       onboardingPaymentPending: true,
       stripeCustomerId: customerId,
@@ -684,13 +678,12 @@ describe("POST /api/zero/billing/checkout/complete", () => {
     context.mocks.stripe.subscriptions.retrieve.mockResolvedValue({
       id: subscriptionId,
       status: "trialing",
-      trial_end: trialEnd,
       cancel_at_period_end: false,
       items: {
         data: [
           {
             price: { id: TEST_PRICE_PRO },
-            current_period_end: currentPeriodEnd,
+            current_period_end: 1_800_000_000,
           },
         ],
       },
@@ -706,12 +699,11 @@ describe("POST /api/zero/billing/checkout/complete", () => {
       [200],
     );
 
-    expect(response.body).toStrictEqual({ completed: true });
+    expect(response.body).toStrictEqual({ completed: false });
 
     const writeDb = store.set(writeDb$);
     const [row] = await writeDb
       .select({
-        credits: orgMetadata.credits,
         tier: orgMetadata.tier,
         stripeSubscriptionId: orgMetadata.stripeSubscriptionId,
         subscriptionStatus: orgMetadata.subscriptionStatus,
@@ -723,122 +715,12 @@ describe("POST /api/zero/billing/checkout/complete", () => {
       .limit(1);
 
     expect(row).toStrictEqual({
-      credits: 20_000,
-      tier: "pro",
+      tier: "pro-suspend",
       stripeSubscriptionId: subscriptionId,
       subscriptionStatus: "trialing",
-      onboardingPaymentPending: false,
-      currentPeriodEnd: new Date(currentPeriodEnd * 1000),
+      onboardingPaymentPending: true,
+      currentPeriodEnd: null,
     });
-
-    const records = await writeDb
-      .select({
-        source: creditExpiresRecord.source,
-        stripeInvoiceId: creditExpiresRecord.stripeInvoiceId,
-        amount: creditExpiresRecord.amount,
-        remaining: creditExpiresRecord.remaining,
-        expiresAt: creditExpiresRecord.expiresAt,
-      })
-      .from(creditExpiresRecord)
-      .where(eq(creditExpiresRecord.orgId, fixture.orgId));
-
-    expect(records).toStrictEqual([
-      {
-        source: "subscription_renewal",
-        stripeInvoiceId: "cs_test_completed",
-        amount: 20_000,
-        remaining: 20_000,
-        expiresAt: new Date(trialEnd * 1000),
-      },
-    ]);
-  });
-
-  it("does not duplicate trial credits when the invoice already granted them", async () => {
-    const customerId = `cus_${randomUUID().slice(0, 8)}`;
-    const subscriptionId = `sub_${randomUUID().slice(0, 8)}`;
-    const trialEnd = 1_800_086_400;
-    const refreshedTrialEnd = 1_800_172_800;
-    const fixture = await trackedSeed({
-      onboardingPaymentPending: false,
-      stripeCustomerId: customerId,
-      stripeSubscriptionId: subscriptionId,
-      subscriptionStatus: "trialing",
-      tier: "pro",
-    });
-    mocks.clerk.session(fixture.userId, fixture.orgId, "org:admin");
-
-    const writeDb = store.set(writeDb$);
-    await writeDb
-      .update(orgMetadata)
-      .set({ credits: 20_000 })
-      .where(eq(orgMetadata.orgId, fixture.orgId));
-    await writeDb.insert(creditExpiresRecord).values({
-      orgId: fixture.orgId,
-      source: "subscription_renewal",
-      stripeInvoiceId: "inv_test_trial",
-      amount: 20_000,
-      remaining: 20_000,
-      expiresAt: new Date(trialEnd * 1000),
-    });
-
-    context.mocks.stripe.checkout.sessions.retrieve.mockResolvedValue({
-      id: "cs_test_completed",
-      mode: "subscription",
-      status: "complete",
-      customer: customerId,
-      subscription: subscriptionId,
-    });
-    context.mocks.stripe.subscriptions.retrieve.mockResolvedValue({
-      id: subscriptionId,
-      status: "trialing",
-      trial_end: refreshedTrialEnd,
-      cancel_at_period_end: false,
-      items: {
-        data: [
-          {
-            price: { id: TEST_PRICE_PRO },
-            current_period_end: refreshedTrialEnd,
-          },
-        ],
-      },
-    });
-
-    const client = setupApp({ context })(zeroBillingCheckoutContract);
-
-    const response = await accept(
-      client.complete({
-        body: { sessionId: "cs_test_completed" },
-        headers: { authorization: "Bearer clerk-session" },
-      }),
-      [200],
-    );
-
-    expect(response.body).toStrictEqual({ completed: true });
-
-    const [row] = await writeDb
-      .select({ credits: orgMetadata.credits })
-      .from(orgMetadata)
-      .where(eq(orgMetadata.orgId, fixture.orgId))
-      .limit(1);
-    const records = await writeDb
-      .select({
-        stripeInvoiceId: creditExpiresRecord.stripeInvoiceId,
-        amount: creditExpiresRecord.amount,
-        remaining: creditExpiresRecord.remaining,
-        expiresAt: creditExpiresRecord.expiresAt,
-      })
-      .from(creditExpiresRecord)
-      .where(eq(creditExpiresRecord.orgId, fixture.orgId));
-
-    expect(row?.credits).toBe(20_000);
-    expect(records).toStrictEqual([
-      {
-        stripeInvoiceId: "inv_test_trial",
-        amount: 20_000,
-        remaining: 20_000,
-        expiresAt: new Date(refreshedTrialEnd * 1000),
-      },
-    ]);
   });
 
   it("keeps checkout pending when the subscription is incomplete", async () => {

--- a/turbo/apps/api/src/signals/routes/__tests__/zero-billing-checkout.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/zero-billing-checkout.test.ts
@@ -6,6 +6,7 @@ import {
 } from "@vm0/api-contracts/contracts/zero-billing";
 import type { ZeroCapability } from "@vm0/api-contracts/contracts/composes";
 import { createStore } from "ccstate";
+import { creditExpiresRecord } from "@vm0/db/schema/credit-expires-record";
 import { orgMetadata } from "@vm0/db/schema/org-metadata";
 import { orgMembersCache } from "@vm0/db/schema/org-members-cache";
 import { eq } from "drizzle-orm";
@@ -84,6 +85,9 @@ async function seedOrgRow(values?: {
 
 async function deleteOrgRow(orgId: string): Promise<void> {
   const writeDb = store.set(writeDb$);
+  await writeDb
+    .delete(creditExpiresRecord)
+    .where(eq(creditExpiresRecord.orgId, orgId));
   await writeDb.delete(orgMembersCache).where(eq(orgMembersCache.orgId, orgId));
   await writeDb.delete(orgMetadata).where(eq(orgMetadata.orgId, orgId));
 }
@@ -659,9 +663,11 @@ describe("POST /api/zero/billing/checkout/complete", () => {
     return fixture;
   }
 
-  it("records a completed subscription checkout while waiting for invoice payment", async () => {
+  it("completes onboarding for a trial subscription checkout", async () => {
     const customerId = `cus_${randomUUID().slice(0, 8)}`;
     const subscriptionId = `sub_${randomUUID().slice(0, 8)}`;
+    const currentPeriodEnd = 1_800_000_000;
+    const trialEnd = 1_800_086_400;
     const fixture = await trackedSeed({
       onboardingPaymentPending: true,
       stripeCustomerId: customerId,
@@ -678,12 +684,13 @@ describe("POST /api/zero/billing/checkout/complete", () => {
     context.mocks.stripe.subscriptions.retrieve.mockResolvedValue({
       id: subscriptionId,
       status: "trialing",
+      trial_end: trialEnd,
       cancel_at_period_end: false,
       items: {
         data: [
           {
             price: { id: TEST_PRICE_PRO },
-            current_period_end: 1_800_000_000,
+            current_period_end: currentPeriodEnd,
           },
         ],
       },
@@ -699,11 +706,12 @@ describe("POST /api/zero/billing/checkout/complete", () => {
       [200],
     );
 
-    expect(response.body).toStrictEqual({ completed: false });
+    expect(response.body).toStrictEqual({ completed: true });
 
     const writeDb = store.set(writeDb$);
     const [row] = await writeDb
       .select({
+        credits: orgMetadata.credits,
         tier: orgMetadata.tier,
         stripeSubscriptionId: orgMetadata.stripeSubscriptionId,
         subscriptionStatus: orgMetadata.subscriptionStatus,
@@ -715,12 +723,122 @@ describe("POST /api/zero/billing/checkout/complete", () => {
       .limit(1);
 
     expect(row).toStrictEqual({
-      tier: "pro-suspend",
+      credits: 20_000,
+      tier: "pro",
       stripeSubscriptionId: subscriptionId,
       subscriptionStatus: "trialing",
-      onboardingPaymentPending: true,
-      currentPeriodEnd: null,
+      onboardingPaymentPending: false,
+      currentPeriodEnd: new Date(currentPeriodEnd * 1000),
     });
+
+    const records = await writeDb
+      .select({
+        source: creditExpiresRecord.source,
+        stripeInvoiceId: creditExpiresRecord.stripeInvoiceId,
+        amount: creditExpiresRecord.amount,
+        remaining: creditExpiresRecord.remaining,
+        expiresAt: creditExpiresRecord.expiresAt,
+      })
+      .from(creditExpiresRecord)
+      .where(eq(creditExpiresRecord.orgId, fixture.orgId));
+
+    expect(records).toStrictEqual([
+      {
+        source: "subscription_renewal",
+        stripeInvoiceId: "cs_test_completed",
+        amount: 20_000,
+        remaining: 20_000,
+        expiresAt: new Date(trialEnd * 1000),
+      },
+    ]);
+  });
+
+  it("does not duplicate trial credits when the invoice already granted them", async () => {
+    const customerId = `cus_${randomUUID().slice(0, 8)}`;
+    const subscriptionId = `sub_${randomUUID().slice(0, 8)}`;
+    const trialEnd = 1_800_086_400;
+    const refreshedTrialEnd = 1_800_172_800;
+    const fixture = await trackedSeed({
+      onboardingPaymentPending: false,
+      stripeCustomerId: customerId,
+      stripeSubscriptionId: subscriptionId,
+      subscriptionStatus: "trialing",
+      tier: "pro",
+    });
+    mocks.clerk.session(fixture.userId, fixture.orgId, "org:admin");
+
+    const writeDb = store.set(writeDb$);
+    await writeDb
+      .update(orgMetadata)
+      .set({ credits: 20_000 })
+      .where(eq(orgMetadata.orgId, fixture.orgId));
+    await writeDb.insert(creditExpiresRecord).values({
+      orgId: fixture.orgId,
+      source: "subscription_renewal",
+      stripeInvoiceId: "inv_test_trial",
+      amount: 20_000,
+      remaining: 20_000,
+      expiresAt: new Date(trialEnd * 1000),
+    });
+
+    context.mocks.stripe.checkout.sessions.retrieve.mockResolvedValue({
+      id: "cs_test_completed",
+      mode: "subscription",
+      status: "complete",
+      customer: customerId,
+      subscription: subscriptionId,
+    });
+    context.mocks.stripe.subscriptions.retrieve.mockResolvedValue({
+      id: subscriptionId,
+      status: "trialing",
+      trial_end: refreshedTrialEnd,
+      cancel_at_period_end: false,
+      items: {
+        data: [
+          {
+            price: { id: TEST_PRICE_PRO },
+            current_period_end: refreshedTrialEnd,
+          },
+        ],
+      },
+    });
+
+    const client = setupApp({ context })(zeroBillingCheckoutContract);
+
+    const response = await accept(
+      client.complete({
+        body: { sessionId: "cs_test_completed" },
+        headers: { authorization: "Bearer clerk-session" },
+      }),
+      [200],
+    );
+
+    expect(response.body).toStrictEqual({ completed: true });
+
+    const [row] = await writeDb
+      .select({ credits: orgMetadata.credits })
+      .from(orgMetadata)
+      .where(eq(orgMetadata.orgId, fixture.orgId))
+      .limit(1);
+    const records = await writeDb
+      .select({
+        stripeInvoiceId: creditExpiresRecord.stripeInvoiceId,
+        amount: creditExpiresRecord.amount,
+        remaining: creditExpiresRecord.remaining,
+        expiresAt: creditExpiresRecord.expiresAt,
+      })
+      .from(creditExpiresRecord)
+      .where(eq(creditExpiresRecord.orgId, fixture.orgId));
+
+    expect(row?.credits).toBe(20_000);
+    expect(records).toStrictEqual([
+      {
+        stripeInvoiceId: "inv_test_trial",
+        amount: 20_000,
+        remaining: 20_000,
+        expiresAt: new Date(refreshedTrialEnd * 1000),
+      },
+    ]);
   });
 
   it("keeps checkout pending when the subscription is incomplete", async () => {

--- a/turbo/apps/api/src/signals/routes/__tests__/zero-billing-checkout.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/zero-billing-checkout.test.ts
@@ -6,7 +6,6 @@ import {
 } from "@vm0/api-contracts/contracts/zero-billing";
 import type { ZeroCapability } from "@vm0/api-contracts/contracts/composes";
 import { createStore } from "ccstate";
-import { creditExpiresRecord } from "@vm0/db/schema/credit-expires-record";
 import { orgMetadata } from "@vm0/db/schema/org-metadata";
 import { orgMembersCache } from "@vm0/db/schema/org-members-cache";
 import { eq } from "drizzle-orm";
@@ -86,9 +85,6 @@ async function seedOrgRow(values?: {
 async function deleteOrgRow(orgId: string): Promise<void> {
   const writeDb = store.set(writeDb$);
   await writeDb.delete(orgMembersCache).where(eq(orgMembersCache.orgId, orgId));
-  await writeDb
-    .delete(creditExpiresRecord)
-    .where(eq(creditExpiresRecord.orgId, orgId));
   await writeDb.delete(orgMetadata).where(eq(orgMetadata.orgId, orgId));
 }
 
@@ -662,115 +658,6 @@ describe("POST /api/zero/billing/checkout/complete", () => {
     createdOrgIds.push(fixture.orgId);
     return fixture;
   }
-
-  it("completes onboarding when the checkout subscription latest invoice is paid", async () => {
-    const customerId = `cus_${randomUUID().slice(0, 8)}`;
-    const subscriptionId = `sub_${randomUUID().slice(0, 8)}`;
-    const invoiceId = `in_${randomUUID().slice(0, 8)}`;
-    const currentPeriodEnd = 1_800_000_000;
-    const trialEnd = 1_800_086_400;
-    const fixture = await trackedSeed({
-      onboardingPaymentPending: true,
-      stripeCustomerId: customerId,
-    });
-    mocks.clerk.session(fixture.userId, fixture.orgId, "org:admin");
-
-    context.mocks.stripe.checkout.sessions.retrieve.mockResolvedValue({
-      id: "cs_test_completed",
-      mode: "subscription",
-      status: "complete",
-      customer: customerId,
-      subscription: subscriptionId,
-    });
-    context.mocks.stripe.subscriptions.retrieve.mockResolvedValue({
-      id: subscriptionId,
-      status: "trialing",
-      trial_end: trialEnd,
-      cancel_at: null,
-      cancel_at_period_end: false,
-      latest_invoice: {
-        id: invoiceId,
-        status: "paid",
-        parent: {
-          subscription_details: { subscription: subscriptionId },
-        },
-        lines: {
-          data: [
-            {
-              period: { end: currentPeriodEnd },
-              parent: { type: "subscription_item_details" },
-            },
-          ],
-        },
-      },
-      items: {
-        data: [
-          {
-            price: { id: TEST_PRICE_PRO },
-            current_period_end: currentPeriodEnd,
-          },
-        ],
-      },
-    });
-
-    const client = setupApp({ context })(zeroBillingCheckoutContract);
-
-    const response = await accept(
-      client.complete({
-        body: { sessionId: "cs_test_completed" },
-        headers: { authorization: "Bearer clerk-session" },
-      }),
-      [200],
-    );
-
-    expect(response.body).toStrictEqual({ completed: true });
-
-    const writeDb = store.set(writeDb$);
-    const [row] = await writeDb
-      .select({
-        credits: orgMetadata.credits,
-        tier: orgMetadata.tier,
-        stripeSubscriptionId: orgMetadata.stripeSubscriptionId,
-        subscriptionStatus: orgMetadata.subscriptionStatus,
-        onboardingPaymentPending: orgMetadata.onboardingPaymentPending,
-        currentPeriodEnd: orgMetadata.currentPeriodEnd,
-        lastProcessedInvoiceId: orgMetadata.lastProcessedInvoiceId,
-      })
-      .from(orgMetadata)
-      .where(eq(orgMetadata.orgId, fixture.orgId))
-      .limit(1);
-
-    expect(row).toStrictEqual({
-      credits: 20_000,
-      tier: "pro",
-      stripeSubscriptionId: subscriptionId,
-      subscriptionStatus: "trialing",
-      onboardingPaymentPending: false,
-      currentPeriodEnd: new Date(currentPeriodEnd * 1000),
-      lastProcessedInvoiceId: invoiceId,
-    });
-
-    const records = await writeDb
-      .select({
-        source: creditExpiresRecord.source,
-        stripeInvoiceId: creditExpiresRecord.stripeInvoiceId,
-        amount: creditExpiresRecord.amount,
-        remaining: creditExpiresRecord.remaining,
-        expiresAt: creditExpiresRecord.expiresAt,
-      })
-      .from(creditExpiresRecord)
-      .where(eq(creditExpiresRecord.orgId, fixture.orgId));
-
-    expect(records).toStrictEqual([
-      {
-        source: "subscription_renewal",
-        stripeInvoiceId: invoiceId,
-        amount: 20_000,
-        remaining: 20_000,
-        expiresAt: new Date(trialEnd * 1000),
-      },
-    ]);
-  });
 
   it("records a completed subscription checkout while waiting for invoice payment", async () => {
     const customerId = `cus_${randomUUID().slice(0, 8)}`;

--- a/turbo/apps/api/src/signals/routes/__tests__/zero-billing-restore.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/zero-billing-restore.test.ts
@@ -1,0 +1,187 @@
+import { randomUUID } from "node:crypto";
+
+import { zeroBillingRestoreContract } from "@vm0/api-contracts/contracts/zero-billing";
+import { createStore } from "ccstate";
+import { orgMetadata } from "@vm0/db/schema/org-metadata";
+import { eq } from "drizzle-orm";
+
+import { accept, setupApp, testContext } from "../../../__tests__/test-helpers";
+import { mockOptionalEnv } from "../../../lib/env";
+import { writeDb$ } from "../../external/db";
+import {
+  deleteInvoicesOrg$,
+  seedInvoicesOrg$,
+  type InvoicesOrgFixture,
+} from "./helpers/zero-billing-invoices";
+import {
+  createFixtureTracker,
+  createZeroRouteMocks,
+} from "./helpers/zero-route-test";
+
+const context = testContext();
+const store = createStore();
+const mocks = createZeroRouteMocks(context);
+
+describe("POST /api/zero/billing/restore", () => {
+  const track = createFixtureTracker<InvoicesOrgFixture>((fixture) => {
+    return store.set(deleteInvoicesOrg$, fixture, context.signal);
+  });
+
+  beforeEach(() => {
+    mockOptionalEnv("STRIPE_SECRET_KEY", "sk_test_fake");
+  });
+
+  it("returns 503 when STRIPE_SECRET_KEY is not configured", async () => {
+    mockOptionalEnv("STRIPE_SECRET_KEY", undefined);
+
+    const client = setupApp({ context })(zeroBillingRestoreContract);
+    const response = await accept(
+      client.create({
+        body: {},
+        headers: {},
+      }),
+      [503],
+    );
+
+    expect(response.body).toStrictEqual({
+      error: {
+        message: "Billing not configured",
+        code: "PROVIDER_UNAVAILABLE",
+      },
+    });
+  });
+
+  it("returns 401 when not authenticated", async () => {
+    const client = setupApp({ context })(zeroBillingRestoreContract);
+    const response = await accept(
+      client.create({
+        body: {},
+        headers: {},
+      }),
+      [401],
+    );
+
+    expect(response.status).toBe(401);
+  });
+
+  it("returns 403 for non-admin org member", async () => {
+    const fixture = await track(
+      store.set(seedInvoicesOrg$, {}, context.signal),
+    );
+    mocks.clerk.session(fixture.userId, fixture.orgId, "org:member");
+
+    const client = setupApp({ context })(zeroBillingRestoreContract);
+    const response = await accept(
+      client.create({
+        body: {},
+        headers: { authorization: "Bearer clerk-session" },
+      }),
+      [403],
+    );
+
+    expect(response.body).toStrictEqual({
+      error: {
+        message: "Only org admins can manage billing",
+        code: "FORBIDDEN",
+      },
+    });
+  });
+
+  it("returns 409 when org has no subscription", async () => {
+    const fixture = await track(
+      store.set(seedInvoicesOrg$, {}, context.signal),
+    );
+    mocks.clerk.session(fixture.userId, fixture.orgId, "org:admin");
+
+    const client = setupApp({ context })(zeroBillingRestoreContract);
+    const response = await accept(
+      client.create({
+        body: {},
+        headers: { authorization: "Bearer clerk-session" },
+      }),
+      [409],
+    );
+
+    expect(response.body).toStrictEqual({
+      error: {
+        message: "Org has no active subscription",
+        code: "CONFLICT",
+      },
+    });
+  });
+
+  it("returns 409 when subscription is not scheduled for cancellation", async () => {
+    const subId = `sub-not-scheduled-${randomUUID().slice(0, 8)}`;
+    const fixture = await track(
+      store.set(
+        seedInvoicesOrg$,
+        {
+          stripeSubscriptionId: subId,
+          subscriptionStatus: "active",
+          tier: "pro",
+          cancelAtPeriodEnd: false,
+        },
+        context.signal,
+      ),
+    );
+    mocks.clerk.session(fixture.userId, fixture.orgId, "org:admin");
+
+    const client = setupApp({ context })(zeroBillingRestoreContract);
+    const response = await accept(
+      client.create({
+        body: {},
+        headers: { authorization: "Bearer clerk-session" },
+      }),
+      [409],
+    );
+
+    expect(response.body).toStrictEqual({
+      error: {
+        message: "Subscription is not scheduled for cancellation",
+        code: "CONFLICT",
+      },
+    });
+    expect(context.mocks.stripe.subscriptions.update).not.toHaveBeenCalled();
+  });
+
+  it("restores a subscription scheduled for cancellation", async () => {
+    const subId = `sub-restore-${randomUUID().slice(0, 8)}`;
+    const fixture = await track(
+      store.set(
+        seedInvoicesOrg$,
+        {
+          stripeSubscriptionId: subId,
+          subscriptionStatus: "active",
+          tier: "pro",
+          cancelAtPeriodEnd: true,
+        },
+        context.signal,
+      ),
+    );
+    mocks.clerk.session(fixture.userId, fixture.orgId, "org:admin");
+    context.mocks.stripe.subscriptions.update.mockResolvedValue({ id: subId });
+
+    const client = setupApp({ context })(zeroBillingRestoreContract);
+    const response = await accept(
+      client.create({
+        body: {},
+        headers: { authorization: "Bearer clerk-session" },
+      }),
+      [200],
+    );
+
+    expect(response.body).toStrictEqual({ success: true });
+    expect(context.mocks.stripe.subscriptions.update).toHaveBeenCalledWith(
+      subId,
+      { cancel_at_period_end: false },
+    );
+
+    const writeDb = store.set(writeDb$);
+    const [row] = await writeDb
+      .select({ cancelAtPeriodEnd: orgMetadata.cancelAtPeriodEnd })
+      .from(orgMetadata)
+      .where(eq(orgMetadata.orgId, fixture.orgId))
+      .limit(1);
+    expect(row?.cancelAtPeriodEnd).toBeFalsy();
+  });
+});

--- a/turbo/apps/api/src/signals/routes/zero-billing-restore.ts
+++ b/turbo/apps/api/src/signals/routes/zero-billing-restore.ts
@@ -1,0 +1,70 @@
+import { command } from "ccstate";
+import { zeroBillingRestoreContract } from "@vm0/api-contracts/contracts/zero-billing";
+
+import { optionalEnv } from "../../lib/env";
+import { conflict, providerUnavailable } from "../../lib/error";
+import { organizationAuthContext$ } from "../auth/auth-context";
+import { authRoute } from "../auth/auth-route";
+import { bodyResultOf } from "../context/request";
+import { restoreSubscription$ } from "../services/zero-billing-restore.service";
+import type { RouteEntry } from "../route";
+
+const adminRequired = Object.freeze({
+  status: 403 as const,
+  body: Object.freeze({
+    error: Object.freeze({
+      message: "Only org admins can manage billing",
+      code: "FORBIDDEN",
+    }),
+  }),
+});
+
+const restoreAuthed$ = command(async ({ get, set }, signal: AbortSignal) => {
+  const auth = get(organizationAuthContext$);
+  if (auth.orgRole !== "admin") {
+    return adminRequired;
+  }
+  signal.throwIfAborted();
+
+  const bodyResult = await get(bodyResultOf(zeroBillingRestoreContract.create));
+  signal.throwIfAborted();
+  if (!bodyResult.ok) {
+    return bodyResult.response;
+  }
+
+  const result = await set(restoreSubscription$, { orgId: auth.orgId }, signal);
+  signal.throwIfAborted();
+
+  if (!result.ok) {
+    if (result.reason === "no_subscription") {
+      return conflict("Org has no active subscription");
+    }
+    return conflict("Subscription is not scheduled for cancellation");
+  }
+
+  return {
+    status: 200 as const,
+    body: { success: true },
+  };
+});
+
+const restore$ = command(async ({ set }, signal: AbortSignal) => {
+  if (!optionalEnv("STRIPE_SECRET_KEY")) {
+    return providerUnavailable("Billing not configured");
+  }
+
+  return await set(
+    authRoute(
+      { requireOrganization: true, missingOrganizationStatus: 401 },
+      restoreAuthed$,
+    ),
+    signal,
+  );
+});
+
+export const zeroBillingRestoreRoutes: readonly RouteEntry[] = [
+  {
+    route: zeroBillingRestoreContract.create,
+    handler: restore$,
+  },
+];

--- a/turbo/apps/api/src/signals/services/cron-billing-entitlements.service.ts
+++ b/turbo/apps/api/src/signals/services/cron-billing-entitlements.service.ts
@@ -19,6 +19,7 @@ const PAYMENT_FAILURE_DOWNGRADE_GRACE_MS = 24 * 60 * 60 * 1000;
 interface SubscriptionInput {
   readonly id: string;
   readonly status: string;
+  readonly cancel_at?: number | null;
   readonly cancel_at_period_end: boolean;
   readonly items: {
     readonly data: readonly {
@@ -52,6 +53,27 @@ function subscriptionPeriodEnd(subscription: SubscriptionInput): Date | null {
   return typeof periodEndUnix === "number"
     ? new Date(periodEndUnix * 1000)
     : null;
+}
+
+function subscriptionCancelAt(subscription: SubscriptionInput): Date | null {
+  return typeof subscription.cancel_at === "number"
+    ? new Date(subscription.cancel_at * 1000)
+    : null;
+}
+
+function subscriptionWillCancel(subscription: SubscriptionInput): boolean {
+  return (
+    subscription.cancel_at_period_end ||
+    subscriptionCancelAt(subscription) !== null
+  );
+}
+
+function subscriptionScheduledEnd(
+  subscription: SubscriptionInput,
+): Date | null {
+  return (
+    subscriptionCancelAt(subscription) ?? subscriptionPeriodEnd(subscription)
+  );
 }
 
 function subscriptionCanRefreshPaidThrough(
@@ -95,13 +117,14 @@ async function reconcileBillingCandidate(
   signal.throwIfAborted();
 
   const stripePeriodEnd = subscriptionPeriodEnd(subscription);
+  const scheduledEnd = subscriptionScheduledEnd(subscription);
   const canRefreshPaidThrough = subscriptionCanRefreshPaidThrough(subscription);
   const isPaymentFailed = subscriptionIsPaymentFailed(subscription);
   const syncedFields = {
     subscriptionStatus: subscription.status,
-    cancelAtPeriodEnd: subscription.cancel_at_period_end,
+    cancelAtPeriodEnd: subscriptionWillCancel(subscription),
     updatedAt: now,
-    ...(stripePeriodEnd ? { currentPeriodEnd: stripePeriodEnd } : {}),
+    ...(scheduledEnd ? { currentPeriodEnd: scheduledEnd } : {}),
   };
 
   const currentCandidate = and(
@@ -121,6 +144,7 @@ async function reconcileBillingCandidate(
         subscriptionStatus: "canceled",
         stripeSubscriptionId: null,
         cancelAtPeriodEnd: false,
+        currentPeriodEnd: null,
         updatedAt: now,
       })
       .where(currentCandidate)

--- a/turbo/apps/api/src/signals/services/webhooks-stripe.service.ts
+++ b/turbo/apps/api/src/signals/services/webhooks-stripe.service.ts
@@ -81,6 +81,16 @@ interface InvoicePaidOrg {
   readonly tier: string;
 }
 
+type LockedInvoicePaidOrg = InvoicePaidOrg;
+
+interface SubscriptionInvoiceDetails {
+  readonly subscription: SubscriptionInput;
+  readonly tier: SubscriptionCheckoutTier;
+  readonly credits: number;
+  readonly periodEndDate: Date;
+  readonly expiresAt: Date;
+}
+
 function subscriptionPeriodEnd(subscription: SubscriptionInput): Date | null {
   const periodEndUnix = subscription.items.data[0]?.current_period_end;
   return typeof periodEndUnix === "number"
@@ -225,6 +235,68 @@ async function createExpiresRecord(
     .returning({ id: creditExpiresRecord.id });
 
   return rows.length > 0;
+}
+
+async function lockInvoicePaidOrg(
+  tx: WriteTx,
+  orgId: string,
+): Promise<LockedInvoicePaidOrg | null> {
+  const [org] = await tx
+    .select({
+      orgId: orgMetadata.orgId,
+      lastProcessedInvoiceId: orgMetadata.lastProcessedInvoiceId,
+      stripeSubscriptionId: orgMetadata.stripeSubscriptionId,
+      tier: orgMetadata.tier,
+    })
+    .from(orgMetadata)
+    .where(eq(orgMetadata.orgId, orgId))
+    .for("update")
+    .limit(1);
+
+  return org ?? null;
+}
+
+async function existingTrialPlanCredits(
+  tx: WriteTx,
+  args: {
+    readonly orgId: string;
+    readonly credits: number;
+  },
+): Promise<boolean> {
+  const rows = await tx
+    .select({ id: creditExpiresRecord.id })
+    .from(creditExpiresRecord)
+    .where(
+      and(
+        eq(creditExpiresRecord.orgId, args.orgId),
+        eq(creditExpiresRecord.source, "subscription_renewal"),
+        eq(creditExpiresRecord.amount, args.credits),
+      ),
+    )
+    .for("update");
+
+  return rows.length > 0;
+}
+
+async function refreshTrialPlanCredits(
+  tx: WriteTx,
+  args: {
+    readonly orgId: string;
+    readonly credits: number;
+    readonly expiresAt: Date;
+  },
+): Promise<void> {
+  await tx
+    .update(creditExpiresRecord)
+    .set({ expiresAt: args.expiresAt })
+    .where(
+      and(
+        eq(creditExpiresRecord.orgId, args.orgId),
+        eq(creditExpiresRecord.source, "subscription_renewal"),
+        eq(creditExpiresRecord.amount, args.credits),
+        gt(creditExpiresRecord.remaining, 0),
+      ),
+    );
 }
 
 async function expireCredits(tx: WriteTx, orgId: string): Promise<number> {
@@ -688,6 +760,192 @@ function invoiceWouldReplaceWithSameOrLowerTier(args: {
   );
 }
 
+function subscriptionIdFromInvoice(invoice: InvoiceInput): string | null {
+  const subscription = invoice.parent?.subscription_details?.subscription;
+  return typeof subscription === "string"
+    ? subscription
+    : (subscription?.id ?? null);
+}
+
+function customerIdFromInvoice(invoice: InvoiceInput): string | null {
+  return typeof invoice.customer === "string"
+    ? invoice.customer
+    : (invoice.customer?.id ?? null);
+}
+
+function subscriptionPeriodEndFromInvoice(
+  invoice: InvoiceInput,
+  orgId: string,
+): Date {
+  const subscriptionLine = invoice.lines.data.find((line) => {
+    return line.parent?.type === "subscription_item_details";
+  });
+  const periodEndUnix = subscriptionLine?.period.end;
+  if (!periodEndUnix) {
+    throw new Error(
+      `invoice.paid has no subscription line item with period.end (invoiceId=${invoice.id}, orgId=${orgId})`,
+    );
+  }
+  return new Date(periodEndUnix * 1000);
+}
+
+async function subscriptionInvoiceDetails(
+  invoice: InvoiceInput,
+  args: {
+    readonly subscriptionId: string;
+    readonly orgId: string;
+  },
+): Promise<SubscriptionInvoiceDetails | null> {
+  const stripe = getStripeClient();
+  const subscription = await stripe.subscriptions.retrieve(args.subscriptionId);
+  const priceId = subscription.items.data[0]?.price?.id;
+  if (!priceId) {
+    L.warn("subscription has no price ID for credit grant", {
+      subscriptionId: args.subscriptionId,
+    });
+    return null;
+  }
+
+  const tier = tierFromPriceId(priceId);
+  const credits = monthlyCreditsForTier(tier);
+  if (credits <= 0) {
+    L.warn("no credits to grant for tier", {
+      tier,
+      invoiceId: invoice.id,
+      orgId: args.orgId,
+    });
+    return null;
+  }
+
+  const periodEndDate = subscriptionPeriodEndFromInvoice(invoice, args.orgId);
+  return {
+    subscription,
+    tier,
+    credits,
+    periodEndDate,
+    expiresAt: subscriptionCreditExpiresAt(subscription, periodEndDate),
+  };
+}
+
+async function updateSubscriptionInvoiceMetadata(
+  tx: WriteTx,
+  args: {
+    readonly orgId: string;
+    readonly invoiceId: string;
+    readonly subscriptionId: string;
+    readonly details: SubscriptionInvoiceDetails;
+  },
+): Promise<void> {
+  await tx
+    .update(orgMetadata)
+    .set({
+      tier: args.details.tier,
+      stripeSubscriptionId: args.subscriptionId,
+      subscriptionStatus: args.details.subscription.status,
+      cancelAtPeriodEnd: subscriptionWillCancel(args.details.subscription),
+      onboardingPaymentPending: false,
+      lastProcessedInvoiceId: args.invoiceId,
+      currentPeriodEnd: args.details.periodEndDate,
+      updatedAt: nowDate(),
+    })
+    .where(eq(orgMetadata.orgId, args.orgId));
+}
+
+async function processSubscriptionInvoicePaid(
+  tx: WriteTx,
+  args: {
+    readonly invoice: InvoiceInput;
+    readonly customerId: string;
+    readonly subscriptionId: string;
+    readonly orgId: string;
+    readonly details: SubscriptionInvoiceDetails;
+  },
+): Promise<void> {
+  const lockedOrg = await lockInvoicePaidOrg(tx, args.orgId);
+  if (!lockedOrg) {
+    return;
+  }
+
+  if (lockedOrg.lastProcessedInvoiceId === args.invoice.id) {
+    L.debug("invoice.paid already processed by concurrent delivery", {
+      invoiceId: args.invoice.id,
+      orgId: args.orgId,
+    });
+    return;
+  }
+
+  if (
+    invoiceWouldReplaceWithSameOrLowerTier({
+      currentSubscriptionId: lockedOrg.stripeSubscriptionId,
+      subscriptionId: args.subscriptionId,
+      currentTier: lockedOrg.tier,
+      targetTier: args.details.tier,
+    })
+  ) {
+    L.warn("invoice.paid rejected tier replacement", {
+      customerId: args.customerId,
+      invoiceId: args.invoice.id,
+      subscriptionId: args.subscriptionId,
+      currentSubscriptionId: lockedOrg.stripeSubscriptionId,
+      currentTier: lockedOrg.tier,
+      targetTier: args.details.tier,
+      reason: checkoutTierConflictMessage({
+        currentTier: lockedOrg.tier,
+        targetTier: args.details.tier,
+      }),
+    });
+    return;
+  }
+
+  const trialingExistingSubscription =
+    args.details.subscription.status === "trialing" &&
+    lockedOrg.stripeSubscriptionId === args.subscriptionId &&
+    lockedOrg.tier === args.details.tier &&
+    (await existingTrialPlanCredits(tx, {
+      orgId: args.orgId,
+      credits: args.details.credits,
+    }));
+
+  if (trialingExistingSubscription) {
+    await refreshTrialPlanCredits(tx, {
+      orgId: args.orgId,
+      credits: args.details.credits,
+      expiresAt: args.details.expiresAt,
+    });
+    await updateSubscriptionInvoiceMetadata(tx, {
+      orgId: args.orgId,
+      invoiceId: args.invoice.id,
+      subscriptionId: args.subscriptionId,
+      details: args.details,
+    });
+    return;
+  }
+
+  await expireCredits(tx, args.orgId);
+
+  const inserted = await createExpiresRecord(tx, args.orgId, {
+    source: "subscription_renewal",
+    stripeInvoiceId: args.invoice.id,
+    amount: args.details.credits,
+    expiresAt: args.details.expiresAt,
+  });
+  if (!inserted) {
+    L.debug("invoice.paid already processed by concurrent delivery", {
+      invoiceId: args.invoice.id,
+      orgId: args.orgId,
+    });
+    return;
+  }
+
+  await grantOrgCredits(tx, args.orgId, args.details.credits);
+  await updateSubscriptionInvoiceMetadata(tx, {
+    orgId: args.orgId,
+    invoiceId: args.invoice.id,
+    subscriptionId: args.subscriptionId,
+    details: args.details,
+  });
+}
+
 async function handleCheckoutCompleted(
   db: Db,
   session: CheckoutSessionInput,
@@ -740,9 +998,7 @@ async function handleInvoicePaid(db: Db, invoice: InvoiceInput): Promise<void> {
     return;
   }
 
-  const subscription = invoice.parent?.subscription_details?.subscription;
-  const subscriptionId =
-    typeof subscription === "string" ? subscription : subscription?.id;
+  const subscriptionId = subscriptionIdFromInvoice(invoice);
   if (!subscriptionId) {
     L.warn("invoice.paid without subscription; skipping", {
       invoiceId: invoice.id,
@@ -750,10 +1006,7 @@ async function handleInvoicePaid(db: Db, invoice: InvoiceInput): Promise<void> {
     return;
   }
 
-  const customerId =
-    typeof invoice.customer === "string"
-      ? invoice.customer
-      : invoice.customer?.id;
+  const customerId = customerIdFromInvoice(invoice);
   if (!customerId) {
     L.warn("invoice.paid without customer ID", { invoiceId: invoice.id });
     return;
@@ -779,97 +1032,22 @@ async function handleInvoicePaid(db: Db, invoice: InvoiceInput): Promise<void> {
     return;
   }
 
-  const stripe = getStripeClient();
-  const subscriptionRecord =
-    await stripe.subscriptions.retrieve(subscriptionId);
-  const priceId = subscriptionRecord.items.data[0]?.price?.id;
-  if (!priceId) {
-    L.warn("subscription has no price ID for credit grant", {
-      subscriptionId,
-    });
-    return;
-  }
-
-  const tier = tierFromPriceId(priceId);
-  if (
-    invoiceWouldReplaceWithSameOrLowerTier({
-      currentSubscriptionId: org.stripeSubscriptionId,
-      subscriptionId,
-      currentTier: org.tier,
-      targetTier: tier,
-    })
-  ) {
-    L.warn("invoice.paid rejected tier replacement", {
-      customerId,
-      invoiceId: invoice.id,
-      subscriptionId,
-      currentSubscriptionId: org.stripeSubscriptionId,
-      currentTier: org.tier,
-      targetTier: tier,
-      reason: checkoutTierConflictMessage({
-        currentTier: org.tier,
-        targetTier: tier,
-      }),
-    });
-    return;
-  }
-
-  const credits = monthlyCreditsForTier(tier);
-  if (credits <= 0) {
-    L.warn("no credits to grant for tier", {
-      tier,
-      invoiceId: invoice.id,
-      orgId: org.orgId,
-    });
-    return;
-  }
-
-  const subscriptionLine = invoice.lines.data.find((line) => {
-    return line.parent?.type === "subscription_item_details";
+  const details = await subscriptionInvoiceDetails(invoice, {
+    subscriptionId,
+    orgId: org.orgId,
   });
-  const periodEndUnix = subscriptionLine?.period.end;
-  if (!periodEndUnix) {
-    throw new Error(
-      `invoice.paid has no subscription line item with period.end (invoiceId=${invoice.id}, orgId=${org.orgId})`,
-    );
+  if (!details) {
+    return;
   }
-  const periodEndDate = new Date(periodEndUnix * 1000);
-  const expiresAt = subscriptionCreditExpiresAt(
-    subscriptionRecord,
-    periodEndDate,
-  );
 
   await db.transaction(async (tx) => {
-    await expireCredits(tx, org.orgId);
-
-    const inserted = await createExpiresRecord(tx, org.orgId, {
-      source: "subscription_renewal",
-      stripeInvoiceId: invoice.id,
-      amount: credits,
-      expiresAt,
+    await processSubscriptionInvoicePaid(tx, {
+      invoice,
+      customerId,
+      subscriptionId,
+      orgId: org.orgId,
+      details,
     });
-    if (!inserted) {
-      L.debug("invoice.paid already processed by concurrent delivery", {
-        invoiceId: invoice.id,
-        orgId: org.orgId,
-      });
-      return;
-    }
-
-    await grantOrgCredits(tx, org.orgId, credits);
-    await tx
-      .update(orgMetadata)
-      .set({
-        tier,
-        stripeSubscriptionId: subscriptionId,
-        subscriptionStatus: subscriptionRecord.status,
-        cancelAtPeriodEnd: subscriptionWillCancel(subscriptionRecord),
-        onboardingPaymentPending: false,
-        lastProcessedInvoiceId: invoice.id,
-        currentPeriodEnd: periodEndDate,
-        updatedAt: nowDate(),
-      })
-      .where(eq(orgMetadata.orgId, org.orgId));
   });
 }
 
@@ -877,42 +1055,19 @@ async function handleSubscriptionUpdated(
   db: Db,
   subscription: SubscriptionInput,
 ): Promise<void> {
-  const periodEnd =
-    subscription.status === "trialing"
-      ? subscriptionPeriodEnd(subscription)
-      : subscriptionWillCancel(subscription)
-        ? subscriptionScheduledEnd(subscription)
-        : null;
+  const periodEnd = subscriptionWillCancel(subscription)
+    ? subscriptionScheduledEnd(subscription)
+    : null;
 
-  await db.transaction(async (tx) => {
-    const rows = await tx
-      .update(orgMetadata)
-      .set({
-        subscriptionStatus: subscription.status,
-        cancelAtPeriodEnd: subscriptionWillCancel(subscription),
-        updatedAt: nowDate(),
-        ...(periodEnd ? { currentPeriodEnd: periodEnd } : {}),
-      })
-      .where(eq(orgMetadata.stripeSubscriptionId, subscription.id))
-      .returning({ orgId: orgMetadata.orgId });
-
-    if (subscription.status !== "trialing") {
-      return;
-    }
-    const trialEnd = requiredSubscriptionTrialEnd(subscription);
-    for (const row of rows) {
-      await tx
-        .update(creditExpiresRecord)
-        .set({ expiresAt: trialEnd })
-        .where(
-          and(
-            eq(creditExpiresRecord.orgId, row.orgId),
-            eq(creditExpiresRecord.source, "subscription_renewal"),
-            gt(creditExpiresRecord.remaining, 0),
-          ),
-        );
-    }
-  });
+  await db
+    .update(orgMetadata)
+    .set({
+      subscriptionStatus: subscription.status,
+      cancelAtPeriodEnd: subscriptionWillCancel(subscription),
+      updatedAt: nowDate(),
+      ...(periodEnd ? { currentPeriodEnd: periodEnd } : {}),
+    })
+    .where(eq(orgMetadata.stripeSubscriptionId, subscription.id));
 }
 
 async function handleSubscriptionDeleted(

--- a/turbo/apps/api/src/signals/services/webhooks-stripe.service.ts
+++ b/turbo/apps/api/src/signals/services/webhooks-stripe.service.ts
@@ -3,7 +3,7 @@ import type { OrgTier } from "@vm0/api-contracts/contracts/orgs";
 import { creditExpiresRecord } from "@vm0/db/schema/credit-expires-record";
 import { orgMetadata } from "@vm0/db/schema/org-metadata";
 import { command } from "ccstate";
-import { and, eq, gt, lte, sql } from "drizzle-orm";
+import { and, eq, gt, isNull, lte, sql } from "drizzle-orm";
 
 import { logger } from "../../lib/log";
 import { now, nowDate } from "../../lib/time";
@@ -18,7 +18,6 @@ import {
 } from "./zero-billing-checkout.service";
 
 const L = logger("WebhookStripe");
-const TRIALING_CREDIT_EXPIRY_DAYS = 7;
 
 type WriteTx = Parameters<Parameters<Db["transaction"]>[0]>[0];
 
@@ -53,7 +52,9 @@ interface InvoiceInput {
 
 interface SubscriptionInput {
   readonly id: string;
+  readonly customer?: string | { readonly id: string } | null;
   readonly status: string;
+  readonly trial_end?: number | null;
   readonly cancel_at_period_end: boolean;
   readonly items: {
     readonly data: readonly {
@@ -79,10 +80,34 @@ function subscriptionPeriodEnd(subscription: SubscriptionInput): Date | null {
     : null;
 }
 
+function customerIdFromSubscription(
+  subscription: SubscriptionInput,
+): string | null {
+  return typeof subscription.customer === "string"
+    ? subscription.customer
+    : (subscription.customer?.id ?? null);
+}
+
 function subscriptionCanRefreshPaidThrough(
   subscription: SubscriptionInput,
 ): boolean {
   return subscription.status === "active" || subscription.status === "trialing";
+}
+
+function subscriptionTrialEnd(subscription: SubscriptionInput): Date | null {
+  return typeof subscription.trial_end === "number"
+    ? new Date(subscription.trial_end * 1000)
+    : null;
+}
+
+function requiredSubscriptionTrialEnd(subscription: SubscriptionInput): Date {
+  const trialEnd = subscriptionTrialEnd(subscription);
+  if (!trialEnd) {
+    throw new Error(
+      `trialing subscription has no trial_end (subscriptionId=${subscription.id})`,
+    );
+  }
+  return trialEnd;
 }
 
 function monthlyCreditsForTier(tier: OrgTier): number {
@@ -103,13 +128,11 @@ function monthlyCreditsForTier(tier: OrgTier): number {
 }
 
 function subscriptionCreditExpiresAt(
-  subscriptionStatus: string,
+  subscription: SubscriptionInput,
   periodEndDate: Date,
 ): Date {
-  if (subscriptionStatus === "trialing") {
-    const expiresAt = nowDate();
-    expiresAt.setDate(expiresAt.getDate() + TRIALING_CREDIT_EXPIRY_DAYS);
-    return expiresAt;
+  if (subscription.status === "trialing") {
+    return requiredSubscriptionTrialEnd(subscription);
   }
 
   const expiresAt = new Date(periodEndDate);
@@ -466,6 +489,141 @@ async function shouldSkipCheckoutSubscriptionUpdate(
   return false;
 }
 
+async function orgHasStripeCustomer(
+  db: Db,
+  customerId: string,
+): Promise<boolean> {
+  const [existing] = await db
+    .select({ orgId: orgMetadata.orgId })
+    .from(orgMetadata)
+    .where(eq(orgMetadata.stripeCustomerId, customerId))
+    .limit(1);
+
+  return Boolean(existing);
+}
+
+async function bindCustomerFromStripeMetadata(
+  db: Db,
+  args: {
+    readonly customerId: string;
+    readonly subscriptionId: string;
+  },
+): Promise<boolean> {
+  if (await orgHasStripeCustomer(db, args.customerId)) {
+    return true;
+  }
+
+  const stripe = getStripeClient();
+  const customer = await stripe.customers.retrieve(args.customerId);
+  if ("deleted" in customer && customer.deleted) {
+    L.warn("subscription customer was deleted before org binding", {
+      customerId: args.customerId,
+      subscriptionId: args.subscriptionId,
+    });
+    return false;
+  }
+
+  const orgId = customer.metadata.orgId;
+  if (!orgId) {
+    L.warn("subscription customer has no org metadata", {
+      customerId: args.customerId,
+      subscriptionId: args.subscriptionId,
+    });
+    return false;
+  }
+
+  const rows = await db
+    .update(orgMetadata)
+    .set({ stripeCustomerId: args.customerId, updatedAt: nowDate() })
+    .where(
+      and(eq(orgMetadata.orgId, orgId), isNull(orgMetadata.stripeCustomerId)),
+    )
+    .returning({ orgId: orgMetadata.orgId });
+
+  if (rows.length > 0) {
+    return true;
+  }
+
+  const [org] = await db
+    .select({ stripeCustomerId: orgMetadata.stripeCustomerId })
+    .from(orgMetadata)
+    .where(eq(orgMetadata.orgId, orgId))
+    .limit(1);
+
+  L.warn("subscription customer metadata could not bind org", {
+    customerId: args.customerId,
+    subscriptionId: args.subscriptionId,
+    orgId,
+    existingStripeCustomerId: org?.stripeCustomerId ?? null,
+  });
+  return false;
+}
+
+async function bindSubscriptionToCustomerOrg(
+  db: Db,
+  args: {
+    readonly customerId: string;
+    readonly subscription: SubscriptionInput;
+    readonly source:
+      | "checkout.session.completed"
+      | "customer.subscription.created";
+  },
+): Promise<void> {
+  if (
+    args.source === "customer.subscription.created" &&
+    !(await bindCustomerFromStripeMetadata(db, {
+      customerId: args.customerId,
+      subscriptionId: args.subscription.id,
+    }))
+  ) {
+    return;
+  }
+
+  const priceId = args.subscription.items.data[0]?.price?.id;
+  if (!priceId) {
+    L.warn("subscription has no price ID", {
+      subscriptionId: args.subscription.id,
+      source: args.source,
+    });
+    return;
+  }
+
+  const tier = tierFromPriceId(priceId);
+  if (
+    await shouldSkipCheckoutSubscriptionUpdate(db, {
+      customerId: args.customerId,
+      subscriptionId: args.subscription.id,
+      tier,
+    })
+  ) {
+    return;
+  }
+
+  const periodEnd = subscriptionPeriodEnd(args.subscription);
+
+  const rows = await db
+    .update(orgMetadata)
+    .set({
+      tier,
+      stripeSubscriptionId: args.subscription.id,
+      subscriptionStatus: args.subscription.status,
+      cancelAtPeriodEnd: args.subscription.cancel_at_period_end,
+      onboardingPaymentPending: false,
+      ...(periodEnd ? { currentPeriodEnd: periodEnd } : {}),
+      updatedAt: nowDate(),
+    })
+    .where(eq(orgMetadata.stripeCustomerId, args.customerId))
+    .returning({ orgId: orgMetadata.orgId });
+
+  if (rows.length === 0) {
+    L.warn("subscription customer has no matching org", {
+      customerId: args.customerId,
+      subscriptionId: args.subscription.id,
+      source: args.source,
+    });
+  }
+}
+
 function invoiceWouldReplaceWithSameOrLowerTier(args: {
   readonly currentSubscriptionId: string | null;
   readonly subscriptionId: string;
@@ -502,38 +660,30 @@ async function handleCheckoutCompleted(
 
   const stripe = getStripeClient();
   const subscription = await stripe.subscriptions.retrieve(subscriptionId);
-  const priceId = subscription.items.data[0]?.price?.id;
-  if (!priceId) {
-    L.warn("subscription has no price ID", { subscriptionId });
+  await bindSubscriptionToCustomerOrg(db, {
+    customerId,
+    subscription,
+    source: "checkout.session.completed",
+  });
+}
+
+async function handleSubscriptionCreated(
+  db: Db,
+  subscription: SubscriptionInput,
+): Promise<void> {
+  const customerId = customerIdFromSubscription(subscription);
+  if (!customerId) {
+    L.warn("customer.subscription.created without customer ID", {
+      subscriptionId: subscription.id,
+    });
     return;
   }
 
-  const tier = tierFromPriceId(priceId);
-  if (
-    await shouldSkipCheckoutSubscriptionUpdate(db, {
-      customerId,
-      subscriptionId,
-      tier,
-    })
-  ) {
-    return;
-  }
-
-  const itemPeriodEnd = subscription.items.data[0]?.current_period_end;
-  const periodEnd = itemPeriodEnd ? new Date(itemPeriodEnd * 1000) : undefined;
-
-  await db
-    .update(orgMetadata)
-    .set({
-      tier,
-      stripeSubscriptionId: subscriptionId,
-      subscriptionStatus: subscription.status,
-      cancelAtPeriodEnd: false,
-      onboardingPaymentPending: false,
-      ...(periodEnd ? { currentPeriodEnd: periodEnd } : {}),
-      updatedAt: nowDate(),
-    })
-    .where(eq(orgMetadata.stripeCustomerId, customerId));
+  await bindSubscriptionToCustomerOrg(db, {
+    customerId,
+    subscription,
+    source: "customer.subscription.created",
+  });
 }
 
 async function handleInvoicePaid(db: Db, invoice: InvoiceInput): Promise<void> {
@@ -644,7 +794,7 @@ async function handleInvoicePaid(db: Db, invoice: InvoiceInput): Promise<void> {
   }
   const periodEndDate = new Date(periodEndUnix * 1000);
   const expiresAt = subscriptionCreditExpiresAt(
-    subscriptionRecord.status,
+    subscriptionRecord,
     periodEndDate,
   );
 
@@ -690,16 +840,36 @@ async function handleSubscriptionUpdated(
     ? subscriptionPeriodEnd(subscription)
     : null;
 
-  await db
-    .update(orgMetadata)
-    .set({
-      subscriptionStatus: subscription.status,
-      cancelAtPeriodEnd: subscription.cancel_at_period_end,
-      updatedAt: nowDate(),
-      ...(tier ? { tier } : {}),
-      ...(periodEnd ? { currentPeriodEnd: periodEnd } : {}),
-    })
-    .where(eq(orgMetadata.stripeSubscriptionId, subscription.id));
+  await db.transaction(async (tx) => {
+    const rows = await tx
+      .update(orgMetadata)
+      .set({
+        subscriptionStatus: subscription.status,
+        cancelAtPeriodEnd: subscription.cancel_at_period_end,
+        updatedAt: nowDate(),
+        ...(tier ? { tier } : {}),
+        ...(periodEnd ? { currentPeriodEnd: periodEnd } : {}),
+      })
+      .where(eq(orgMetadata.stripeSubscriptionId, subscription.id))
+      .returning({ orgId: orgMetadata.orgId });
+
+    if (subscription.status !== "trialing") {
+      return;
+    }
+    const trialEnd = requiredSubscriptionTrialEnd(subscription);
+    for (const row of rows) {
+      await tx
+        .update(creditExpiresRecord)
+        .set({ expiresAt: trialEnd })
+        .where(
+          and(
+            eq(creditExpiresRecord.orgId, row.orgId),
+            eq(creditExpiresRecord.source, "subscription_renewal"),
+            gt(creditExpiresRecord.remaining, 0),
+          ),
+        );
+    }
+  });
 }
 
 async function handleSubscriptionDeleted(
@@ -736,6 +906,11 @@ export const handleStripeWebhookEvent$ = command(
       }
       case "invoice.paid": {
         await handleInvoicePaid(db, event.data.object);
+        signal.throwIfAborted();
+        break;
+      }
+      case "customer.subscription.created": {
+        await handleSubscriptionCreated(db, event.data.object);
         signal.throwIfAborted();
         break;
       }

--- a/turbo/apps/api/src/signals/services/webhooks-stripe.service.ts
+++ b/turbo/apps/api/src/signals/services/webhooks-stripe.service.ts
@@ -55,6 +55,7 @@ interface SubscriptionInput {
   readonly customer?: string | { readonly id: string } | null;
   readonly status: string;
   readonly trial_end?: number | null;
+  readonly cancel_at?: number | null;
   readonly cancel_at_period_end: boolean;
   readonly items: {
     readonly data: readonly {
@@ -73,11 +74,39 @@ interface CheckoutSubscriptionContext {
   readonly subscriptionId: string;
 }
 
+interface InvoicePaidOrg {
+  readonly orgId: string;
+  readonly lastProcessedInvoiceId: string | null;
+  readonly stripeSubscriptionId: string | null;
+  readonly tier: string;
+}
+
 function subscriptionPeriodEnd(subscription: SubscriptionInput): Date | null {
   const periodEndUnix = subscription.items.data[0]?.current_period_end;
   return typeof periodEndUnix === "number"
     ? new Date(periodEndUnix * 1000)
     : null;
+}
+
+function subscriptionCancelAt(subscription: SubscriptionInput): Date | null {
+  return typeof subscription.cancel_at === "number"
+    ? new Date(subscription.cancel_at * 1000)
+    : null;
+}
+
+function subscriptionWillCancel(subscription: SubscriptionInput): boolean {
+  return (
+    subscription.cancel_at_period_end ||
+    subscriptionCancelAt(subscription) !== null
+  );
+}
+
+function subscriptionScheduledEnd(
+  subscription: SubscriptionInput,
+): Date | null {
+  return (
+    subscriptionCancelAt(subscription) ?? subscriptionPeriodEnd(subscription)
+  );
 }
 
 function customerIdFromSubscription(
@@ -86,12 +115,6 @@ function customerIdFromSubscription(
   return typeof subscription.customer === "string"
     ? subscription.customer
     : (subscription.customer?.id ?? null);
-}
-
-function subscriptionCanRefreshPaidThrough(
-  subscription: SubscriptionInput,
-): boolean {
-  return subscription.status === "active" || subscription.status === "trialing";
 }
 
 function subscriptionTrialEnd(subscription: SubscriptionInput): Date | null {
@@ -444,7 +467,7 @@ function checkoutSubscriptionContext(
   return { customerId, subscriptionId };
 }
 
-async function shouldSkipCheckoutSubscriptionUpdate(
+async function shouldSkipSubscriptionBinding(
   db: Db,
   args: {
     readonly customerId: string;
@@ -462,7 +485,7 @@ async function shouldSkipCheckoutSubscriptionUpdate(
     .limit(1);
 
   if (existing?.stripeSubscriptionId === args.subscriptionId) {
-    L.debug("checkout.session.completed already processed", {
+    L.debug("subscription binding already processed", {
       subscriptionId: args.subscriptionId,
     });
     return true;
@@ -473,7 +496,7 @@ async function shouldSkipCheckoutSubscriptionUpdate(
       targetTier: args.tier,
     })
   ) {
-    L.warn("checkout.session.completed rejected tier replacement", {
+    L.warn("subscription binding rejected tier replacement", {
       customerId: args.customerId,
       subscriptionId: args.subscriptionId,
       currentTier: existing?.tier ?? null,
@@ -502,7 +525,7 @@ async function orgHasStripeCustomer(
   return Boolean(existing);
 }
 
-async function bindCustomerFromStripeMetadata(
+async function bindStripeCustomerFromMetadata(
   db: Db,
   args: {
     readonly customerId: string;
@@ -516,7 +539,7 @@ async function bindCustomerFromStripeMetadata(
   const stripe = getStripeClient();
   const customer = await stripe.customers.retrieve(args.customerId);
   if ("deleted" in customer && customer.deleted) {
-    L.warn("subscription customer was deleted before org binding", {
+    L.warn("stripe customer was deleted before org binding", {
       customerId: args.customerId,
       subscriptionId: args.subscriptionId,
     });
@@ -525,7 +548,7 @@ async function bindCustomerFromStripeMetadata(
 
   const orgId = customer.metadata.orgId;
   if (!orgId) {
-    L.warn("subscription customer has no org metadata", {
+    L.warn("stripe customer has no org metadata", {
       customerId: args.customerId,
       subscriptionId: args.subscriptionId,
     });
@@ -550,13 +573,47 @@ async function bindCustomerFromStripeMetadata(
     .where(eq(orgMetadata.orgId, orgId))
     .limit(1);
 
-  L.warn("subscription customer metadata could not bind org", {
+  L.warn("stripe customer metadata could not bind org", {
     customerId: args.customerId,
     subscriptionId: args.subscriptionId,
     orgId,
     existingStripeCustomerId: org?.stripeCustomerId ?? null,
   });
   return false;
+}
+
+async function invoicePaidOrgForCustomer(
+  db: Db,
+  customerId: string,
+): Promise<InvoicePaidOrg | null> {
+  const [org] = await db
+    .select({
+      orgId: orgMetadata.orgId,
+      lastProcessedInvoiceId: orgMetadata.lastProcessedInvoiceId,
+      stripeSubscriptionId: orgMetadata.stripeSubscriptionId,
+      tier: orgMetadata.tier,
+    })
+    .from(orgMetadata)
+    .where(eq(orgMetadata.stripeCustomerId, customerId))
+    .limit(1);
+
+  return org ?? null;
+}
+
+async function invoicePaidOrgForCustomerOrMetadata(
+  db: Db,
+  args: {
+    readonly customerId: string;
+    readonly subscriptionId: string;
+  },
+): Promise<InvoicePaidOrg | null> {
+  const org = await invoicePaidOrgForCustomer(db, args.customerId);
+  if (org) {
+    return org;
+  }
+
+  const bound = await bindStripeCustomerFromMetadata(db, args);
+  return bound ? await invoicePaidOrgForCustomer(db, args.customerId) : null;
 }
 
 async function bindSubscriptionToCustomerOrg(
@@ -571,7 +628,7 @@ async function bindSubscriptionToCustomerOrg(
 ): Promise<void> {
   if (
     args.source === "customer.subscription.created" &&
-    !(await bindCustomerFromStripeMetadata(db, {
+    !(await bindStripeCustomerFromMetadata(db, {
       customerId: args.customerId,
       subscriptionId: args.subscription.id,
     }))
@@ -585,31 +642,22 @@ async function bindSubscriptionToCustomerOrg(
       subscriptionId: args.subscription.id,
       source: args.source,
     });
-    return;
-  }
-
-  const tier = tierFromPriceId(priceId);
-  if (
-    await shouldSkipCheckoutSubscriptionUpdate(db, {
+  } else if (
+    await shouldSkipSubscriptionBinding(db, {
       customerId: args.customerId,
       subscriptionId: args.subscription.id,
-      tier,
+      tier: tierFromPriceId(priceId),
     })
   ) {
     return;
   }
 
-  const periodEnd = subscriptionPeriodEnd(args.subscription);
-
   const rows = await db
     .update(orgMetadata)
     .set({
-      tier,
       stripeSubscriptionId: args.subscription.id,
       subscriptionStatus: args.subscription.status,
-      cancelAtPeriodEnd: args.subscription.cancel_at_period_end,
-      onboardingPaymentPending: false,
-      ...(periodEnd ? { currentPeriodEnd: periodEnd } : {}),
+      cancelAtPeriodEnd: subscriptionWillCancel(args.subscription),
       updatedAt: nowDate(),
     })
     .where(eq(orgMetadata.stripeCustomerId, args.customerId))
@@ -711,17 +759,10 @@ async function handleInvoicePaid(db: Db, invoice: InvoiceInput): Promise<void> {
     return;
   }
 
-  const [org] = await db
-    .select({
-      orgId: orgMetadata.orgId,
-      lastProcessedInvoiceId: orgMetadata.lastProcessedInvoiceId,
-      stripeSubscriptionId: orgMetadata.stripeSubscriptionId,
-      tier: orgMetadata.tier,
-    })
-    .from(orgMetadata)
-    .where(eq(orgMetadata.stripeCustomerId, customerId))
-    .limit(1);
-
+  const org = await invoicePaidOrgForCustomerOrMetadata(db, {
+    customerId,
+    subscriptionId,
+  });
   if (!org) {
     L.warn("invoice.paid for unknown customer", {
       customerId,
@@ -819,6 +860,11 @@ async function handleInvoicePaid(db: Db, invoice: InvoiceInput): Promise<void> {
     await tx
       .update(orgMetadata)
       .set({
+        tier,
+        stripeSubscriptionId: subscriptionId,
+        subscriptionStatus: subscriptionRecord.status,
+        cancelAtPeriodEnd: subscriptionWillCancel(subscriptionRecord),
+        onboardingPaymentPending: false,
         lastProcessedInvoiceId: invoice.id,
         currentPeriodEnd: periodEndDate,
         updatedAt: nowDate(),
@@ -831,23 +877,20 @@ async function handleSubscriptionUpdated(
   db: Db,
   subscription: SubscriptionInput,
 ): Promise<void> {
-  const priceId = subscription.items.data[0]?.price?.id;
-  const canSyncPaidEntitlement =
-    subscriptionCanRefreshPaidThrough(subscription);
-  const tier: OrgTier | undefined =
-    canSyncPaidEntitlement && priceId ? tierFromPriceId(priceId) : undefined;
-  const periodEnd = canSyncPaidEntitlement
-    ? subscriptionPeriodEnd(subscription)
-    : null;
+  const periodEnd =
+    subscription.status === "trialing"
+      ? subscriptionPeriodEnd(subscription)
+      : subscriptionWillCancel(subscription)
+        ? subscriptionScheduledEnd(subscription)
+        : null;
 
   await db.transaction(async (tx) => {
     const rows = await tx
       .update(orgMetadata)
       .set({
         subscriptionStatus: subscription.status,
-        cancelAtPeriodEnd: subscription.cancel_at_period_end,
+        cancelAtPeriodEnd: subscriptionWillCancel(subscription),
         updatedAt: nowDate(),
-        ...(tier ? { tier } : {}),
         ...(periodEnd ? { currentPeriodEnd: periodEnd } : {}),
       })
       .where(eq(orgMetadata.stripeSubscriptionId, subscription.id))
@@ -883,6 +926,7 @@ async function handleSubscriptionDeleted(
       subscriptionStatus: "canceled",
       stripeSubscriptionId: null,
       cancelAtPeriodEnd: false,
+      currentPeriodEnd: null,
       updatedAt: nowDate(),
     })
     .where(eq(orgMetadata.stripeSubscriptionId, subscription.id));

--- a/turbo/apps/api/src/signals/services/webhooks-stripe.service.ts
+++ b/turbo/apps/api/src/signals/services/webhooks-stripe.service.ts
@@ -69,6 +69,10 @@ interface SubscriptionDeletedInput {
   readonly id: string;
 }
 
+interface SubscriptionPreviousAttributes {
+  readonly trial_end?: number | null;
+}
+
 interface CheckoutSubscriptionContext {
   readonly customerId: string;
   readonly subscriptionId: string;
@@ -1054,20 +1058,53 @@ async function handleInvoicePaid(db: Db, invoice: InvoiceInput): Promise<void> {
 async function handleSubscriptionUpdated(
   db: Db,
   subscription: SubscriptionInput,
+  previousAttributes: SubscriptionPreviousAttributes | undefined,
 ): Promise<void> {
   const periodEnd = subscriptionWillCancel(subscription)
     ? subscriptionScheduledEnd(subscription)
     : null;
+  const trialEnd = subscriptionTrialEnd(subscription);
+  const previousTrialEnd =
+    typeof previousAttributes?.trial_end === "number"
+      ? new Date(previousAttributes.trial_end * 1000)
+      : null;
+  const trialShortened =
+    subscription.status === "trialing" &&
+    trialEnd !== null &&
+    previousTrialEnd !== null &&
+    trialEnd < previousTrialEnd;
 
-  await db
-    .update(orgMetadata)
-    .set({
-      subscriptionStatus: subscription.status,
-      cancelAtPeriodEnd: subscriptionWillCancel(subscription),
-      updatedAt: nowDate(),
-      ...(periodEnd ? { currentPeriodEnd: periodEnd } : {}),
-    })
-    .where(eq(orgMetadata.stripeSubscriptionId, subscription.id));
+  await db.transaction(async (tx) => {
+    const rows = await tx
+      .update(orgMetadata)
+      .set({
+        subscriptionStatus: subscription.status,
+        cancelAtPeriodEnd: subscriptionWillCancel(subscription),
+        updatedAt: nowDate(),
+        ...(periodEnd ? { currentPeriodEnd: periodEnd } : {}),
+        ...(trialShortened ? { currentPeriodEnd: trialEnd } : {}),
+      })
+      .where(eq(orgMetadata.stripeSubscriptionId, subscription.id))
+      .returning({ orgId: orgMetadata.orgId });
+
+    if (!trialShortened) {
+      return;
+    }
+
+    for (const row of rows) {
+      await tx
+        .update(creditExpiresRecord)
+        .set({ expiresAt: trialEnd })
+        .where(
+          and(
+            eq(creditExpiresRecord.orgId, row.orgId),
+            eq(creditExpiresRecord.source, "subscription_renewal"),
+            gt(creditExpiresRecord.expiresAt, trialEnd),
+            gt(creditExpiresRecord.remaining, 0),
+          ),
+        );
+    }
+  });
 }
 
 async function handleSubscriptionDeleted(
@@ -1114,7 +1151,11 @@ export const handleStripeWebhookEvent$ = command(
         break;
       }
       case "customer.subscription.updated": {
-        await handleSubscriptionUpdated(db, event.data.object);
+        await handleSubscriptionUpdated(
+          db,
+          event.data.object,
+          event.data.previous_attributes,
+        );
         signal.throwIfAborted();
         break;
       }

--- a/turbo/apps/api/src/signals/services/zero-billing-checkout.service.ts
+++ b/turbo/apps/api/src/signals/services/zero-billing-checkout.service.ts
@@ -149,11 +149,8 @@ function stripeObjectId(
   return value?.id ?? null;
 }
 
-function subscriptionPeriodEnd(subscription: Stripe.Subscription): Date | null {
-  const periodEndUnix = subscription.items.data[0]?.current_period_end;
-  return typeof periodEndUnix === "number"
-    ? new Date(periodEndUnix * 1000)
-    : null;
+function subscriptionWillCancel(subscription: Stripe.Subscription): boolean {
+  return subscription.cancel_at_period_end || subscription.cancel_at !== null;
 }
 
 function customUnitAmountParams(
@@ -300,17 +297,15 @@ export const completeCheckoutSession$ = command(
         targetTier: tier,
       };
     }
-    const periodEnd = subscriptionPeriodEnd(subscription);
+    const alreadyPaidSubscription =
+      org.stripeSubscriptionId === subscription.id && org.tier === tier;
 
     await db
       .update(orgMetadata)
       .set({
-        tier,
         stripeSubscriptionId: subscription.id,
         subscriptionStatus: subscription.status,
-        cancelAtPeriodEnd: subscription.cancel_at_period_end,
-        onboardingPaymentPending: false,
-        ...(periodEnd ? { currentPeriodEnd: periodEnd } : {}),
+        cancelAtPeriodEnd: subscriptionWillCancel(subscription),
         updatedAt: nowDate(),
       })
       .where(
@@ -321,7 +316,7 @@ export const completeCheckoutSession$ = command(
       );
     signal.throwIfAborted();
 
-    return { status: "completed" };
+    return { status: alreadyPaidSubscription ? "completed" : "pending" };
   },
 );
 

--- a/turbo/apps/api/src/signals/services/zero-billing-checkout.service.ts
+++ b/turbo/apps/api/src/signals/services/zero-billing-checkout.service.ts
@@ -1,17 +1,13 @@
 import { command } from "ccstate";
-import type { OrgTier } from "@vm0/api-contracts/contracts/orgs";
-import { creditExpiresRecord } from "@vm0/db/schema/credit-expires-record";
 import { orgMetadata } from "@vm0/db/schema/org-metadata";
-import { and, eq, gt, sql } from "drizzle-orm";
+import { and, eq } from "drizzle-orm";
 import type { Stripe } from "stripe";
 
 import { env } from "../../lib/env";
 import { nowDate } from "../external/time";
-import { writeDb$, type Db } from "../external/db";
+import { writeDb$ } from "../external/db";
 import { getStripeClient } from "../external/stripe-client";
 import { getOrCreateStripeCustomer$ } from "./billing-customer.service";
-
-type WriteTx = Parameters<Parameters<Db["transaction"]>[0]>[0];
 
 interface CreateCheckoutSessionArgs {
   readonly orgId: string;
@@ -153,119 +149,8 @@ function stripeObjectId(
   return value?.id ?? null;
 }
 
-function subscriptionPeriodEnd(subscription: Stripe.Subscription): Date | null {
-  const periodEndUnix = subscription.items.data[0]?.current_period_end;
-  return typeof periodEndUnix === "number"
-    ? new Date(periodEndUnix * 1000)
-    : null;
-}
-
-function subscriptionTrialEnd(subscription: Stripe.Subscription): Date | null {
-  return typeof subscription.trial_end === "number"
-    ? new Date(subscription.trial_end * 1000)
-    : null;
-}
-
-function requiredSubscriptionTrialEnd(subscription: Stripe.Subscription): Date {
-  const trialEnd = subscriptionTrialEnd(subscription);
-  if (!trialEnd) {
-    throw new Error(
-      `trialing subscription has no trial_end (subscriptionId=${subscription.id})`,
-    );
-  }
-  return trialEnd;
-}
-
 function subscriptionWillCancel(subscription: Stripe.Subscription): boolean {
-  return (
-    subscription.cancel_at_period_end ||
-    typeof subscription.cancel_at === "number"
-  );
-}
-
-function monthlyCreditsForTier(tier: OrgTier): number {
-  switch (tier) {
-    case "free": {
-      return 0;
-    }
-    case "pro-suspend": {
-      return 0;
-    }
-    case "pro": {
-      return 20_000;
-    }
-    case "team": {
-      return 120_000;
-    }
-  }
-}
-
-async function grantOrgCredits(
-  tx: WriteTx,
-  orgId: string,
-  amount: number,
-): Promise<void> {
-  await tx.execute(
-    sql`INSERT INTO org_metadata (org_id, credits, created_at, updated_at)
-        VALUES (${orgId}, ${amount}, now(), now())
-        ON CONFLICT (org_id)
-        DO UPDATE SET credits = org_metadata.credits + ${amount}, updated_at = now()`,
-  );
-}
-
-async function createTrialCredits(
-  tx: WriteTx,
-  args: {
-    readonly orgId: string;
-    readonly sessionId: string;
-    readonly tier: SubscriptionCheckoutTier;
-    readonly expiresAt: Date;
-  },
-): Promise<void> {
-  const amount = monthlyCreditsForTier(args.tier);
-  const existingRows = await tx
-    .select({ id: creditExpiresRecord.id })
-    .from(creditExpiresRecord)
-    .where(
-      and(
-        eq(creditExpiresRecord.orgId, args.orgId),
-        eq(creditExpiresRecord.source, "subscription_renewal"),
-        eq(creditExpiresRecord.amount, amount),
-      ),
-    )
-    .for("update");
-
-  if (existingRows.length > 0) {
-    await tx
-      .update(creditExpiresRecord)
-      .set({ expiresAt: args.expiresAt })
-      .where(
-        and(
-          eq(creditExpiresRecord.orgId, args.orgId),
-          eq(creditExpiresRecord.source, "subscription_renewal"),
-          eq(creditExpiresRecord.amount, amount),
-          gt(creditExpiresRecord.remaining, 0),
-        ),
-      );
-    return;
-  }
-
-  const rows = await tx
-    .insert(creditExpiresRecord)
-    .values({
-      orgId: args.orgId,
-      source: "subscription_renewal",
-      stripeInvoiceId: args.sessionId,
-      amount,
-      remaining: amount,
-      expiresAt: args.expiresAt,
-    })
-    .onConflictDoNothing()
-    .returning({ id: creditExpiresRecord.id });
-
-  if (rows.length > 0) {
-    await grantOrgCredits(tx, args.orgId, amount);
-  }
+  return subscription.cancel_at_period_end || subscription.cancel_at !== null;
 }
 
 function customUnitAmountParams(
@@ -414,47 +299,24 @@ export const completeCheckoutSession$ = command(
     }
     const alreadyPaidSubscription =
       org.stripeSubscriptionId === subscription.id && org.tier === tier;
-    const trialingSubscription = subscription.status === "trialing";
-    const periodEnd = subscriptionPeriodEnd(subscription);
 
-    await db.transaction(async (tx) => {
-      await tx
-        .update(orgMetadata)
-        .set({
-          ...(trialingSubscription ? { tier } : {}),
-          stripeSubscriptionId: subscription.id,
-          subscriptionStatus: subscription.status,
-          cancelAtPeriodEnd: subscriptionWillCancel(subscription),
-          ...(trialingSubscription ? { onboardingPaymentPending: false } : {}),
-          ...(trialingSubscription && periodEnd
-            ? { currentPeriodEnd: periodEnd }
-            : {}),
-          updatedAt: nowDate(),
-        })
-        .where(
-          and(
-            eq(orgMetadata.orgId, args.orgId),
-            eq(orgMetadata.stripeCustomerId, customerId),
-          ),
-        );
-
-      if (trialingSubscription) {
-        await createTrialCredits(tx, {
-          orgId: args.orgId,
-          sessionId: args.sessionId,
-          tier,
-          expiresAt: requiredSubscriptionTrialEnd(subscription),
-        });
-      }
-    });
+    await db
+      .update(orgMetadata)
+      .set({
+        stripeSubscriptionId: subscription.id,
+        subscriptionStatus: subscription.status,
+        cancelAtPeriodEnd: subscriptionWillCancel(subscription),
+        updatedAt: nowDate(),
+      })
+      .where(
+        and(
+          eq(orgMetadata.orgId, args.orgId),
+          eq(orgMetadata.stripeCustomerId, customerId),
+        ),
+      );
     signal.throwIfAborted();
 
-    return {
-      status:
-        alreadyPaidSubscription || trialingSubscription
-          ? "completed"
-          : "pending",
-    };
+    return { status: alreadyPaidSubscription ? "completed" : "pending" };
   },
 );
 

--- a/turbo/apps/api/src/signals/services/zero-billing-checkout.service.ts
+++ b/turbo/apps/api/src/signals/services/zero-billing-checkout.service.ts
@@ -1,13 +1,17 @@
 import { command } from "ccstate";
+import type { OrgTier } from "@vm0/api-contracts/contracts/orgs";
+import { creditExpiresRecord } from "@vm0/db/schema/credit-expires-record";
 import { orgMetadata } from "@vm0/db/schema/org-metadata";
-import { and, eq } from "drizzle-orm";
+import { and, eq, gt, sql } from "drizzle-orm";
 import type { Stripe } from "stripe";
 
 import { env } from "../../lib/env";
 import { nowDate } from "../external/time";
-import { writeDb$ } from "../external/db";
+import { writeDb$, type Db } from "../external/db";
 import { getStripeClient } from "../external/stripe-client";
 import { getOrCreateStripeCustomer$ } from "./billing-customer.service";
+
+type WriteTx = Parameters<Parameters<Db["transaction"]>[0]>[0];
 
 interface CreateCheckoutSessionArgs {
   readonly orgId: string;
@@ -149,8 +153,119 @@ function stripeObjectId(
   return value?.id ?? null;
 }
 
+function subscriptionPeriodEnd(subscription: Stripe.Subscription): Date | null {
+  const periodEndUnix = subscription.items.data[0]?.current_period_end;
+  return typeof periodEndUnix === "number"
+    ? new Date(periodEndUnix * 1000)
+    : null;
+}
+
+function subscriptionTrialEnd(subscription: Stripe.Subscription): Date | null {
+  return typeof subscription.trial_end === "number"
+    ? new Date(subscription.trial_end * 1000)
+    : null;
+}
+
+function requiredSubscriptionTrialEnd(subscription: Stripe.Subscription): Date {
+  const trialEnd = subscriptionTrialEnd(subscription);
+  if (!trialEnd) {
+    throw new Error(
+      `trialing subscription has no trial_end (subscriptionId=${subscription.id})`,
+    );
+  }
+  return trialEnd;
+}
+
 function subscriptionWillCancel(subscription: Stripe.Subscription): boolean {
-  return subscription.cancel_at_period_end || subscription.cancel_at !== null;
+  return (
+    subscription.cancel_at_period_end ||
+    typeof subscription.cancel_at === "number"
+  );
+}
+
+function monthlyCreditsForTier(tier: OrgTier): number {
+  switch (tier) {
+    case "free": {
+      return 0;
+    }
+    case "pro-suspend": {
+      return 0;
+    }
+    case "pro": {
+      return 20_000;
+    }
+    case "team": {
+      return 120_000;
+    }
+  }
+}
+
+async function grantOrgCredits(
+  tx: WriteTx,
+  orgId: string,
+  amount: number,
+): Promise<void> {
+  await tx.execute(
+    sql`INSERT INTO org_metadata (org_id, credits, created_at, updated_at)
+        VALUES (${orgId}, ${amount}, now(), now())
+        ON CONFLICT (org_id)
+        DO UPDATE SET credits = org_metadata.credits + ${amount}, updated_at = now()`,
+  );
+}
+
+async function createTrialCredits(
+  tx: WriteTx,
+  args: {
+    readonly orgId: string;
+    readonly sessionId: string;
+    readonly tier: SubscriptionCheckoutTier;
+    readonly expiresAt: Date;
+  },
+): Promise<void> {
+  const amount = monthlyCreditsForTier(args.tier);
+  const existingRows = await tx
+    .select({ id: creditExpiresRecord.id })
+    .from(creditExpiresRecord)
+    .where(
+      and(
+        eq(creditExpiresRecord.orgId, args.orgId),
+        eq(creditExpiresRecord.source, "subscription_renewal"),
+        eq(creditExpiresRecord.amount, amount),
+      ),
+    )
+    .for("update");
+
+  if (existingRows.length > 0) {
+    await tx
+      .update(creditExpiresRecord)
+      .set({ expiresAt: args.expiresAt })
+      .where(
+        and(
+          eq(creditExpiresRecord.orgId, args.orgId),
+          eq(creditExpiresRecord.source, "subscription_renewal"),
+          eq(creditExpiresRecord.amount, amount),
+          gt(creditExpiresRecord.remaining, 0),
+        ),
+      );
+    return;
+  }
+
+  const rows = await tx
+    .insert(creditExpiresRecord)
+    .values({
+      orgId: args.orgId,
+      source: "subscription_renewal",
+      stripeInvoiceId: args.sessionId,
+      amount,
+      remaining: amount,
+      expiresAt: args.expiresAt,
+    })
+    .onConflictDoNothing()
+    .returning({ id: creditExpiresRecord.id });
+
+  if (rows.length > 0) {
+    await grantOrgCredits(tx, args.orgId, amount);
+  }
 }
 
 function customUnitAmountParams(
@@ -299,24 +414,47 @@ export const completeCheckoutSession$ = command(
     }
     const alreadyPaidSubscription =
       org.stripeSubscriptionId === subscription.id && org.tier === tier;
+    const trialingSubscription = subscription.status === "trialing";
+    const periodEnd = subscriptionPeriodEnd(subscription);
 
-    await db
-      .update(orgMetadata)
-      .set({
-        stripeSubscriptionId: subscription.id,
-        subscriptionStatus: subscription.status,
-        cancelAtPeriodEnd: subscriptionWillCancel(subscription),
-        updatedAt: nowDate(),
-      })
-      .where(
-        and(
-          eq(orgMetadata.orgId, args.orgId),
-          eq(orgMetadata.stripeCustomerId, customerId),
-        ),
-      );
+    await db.transaction(async (tx) => {
+      await tx
+        .update(orgMetadata)
+        .set({
+          ...(trialingSubscription ? { tier } : {}),
+          stripeSubscriptionId: subscription.id,
+          subscriptionStatus: subscription.status,
+          cancelAtPeriodEnd: subscriptionWillCancel(subscription),
+          ...(trialingSubscription ? { onboardingPaymentPending: false } : {}),
+          ...(trialingSubscription && periodEnd
+            ? { currentPeriodEnd: periodEnd }
+            : {}),
+          updatedAt: nowDate(),
+        })
+        .where(
+          and(
+            eq(orgMetadata.orgId, args.orgId),
+            eq(orgMetadata.stripeCustomerId, customerId),
+          ),
+        );
+
+      if (trialingSubscription) {
+        await createTrialCredits(tx, {
+          orgId: args.orgId,
+          sessionId: args.sessionId,
+          tier,
+          expiresAt: requiredSubscriptionTrialEnd(subscription),
+        });
+      }
+    });
     signal.throwIfAborted();
 
-    return { status: alreadyPaidSubscription ? "completed" : "pending" };
+    return {
+      status:
+        alreadyPaidSubscription || trialingSubscription
+          ? "completed"
+          : "pending",
+    };
   },
 );
 

--- a/turbo/apps/api/src/signals/services/zero-billing-checkout.service.ts
+++ b/turbo/apps/api/src/signals/services/zero-billing-checkout.service.ts
@@ -1,23 +1,13 @@
 import { command } from "ccstate";
-import { creditExpiresRecord } from "@vm0/db/schema/credit-expires-record";
 import { orgMetadata } from "@vm0/db/schema/org-metadata";
-import { and, eq, gt, lte, sql } from "drizzle-orm";
+import { and, eq } from "drizzle-orm";
 import type { Stripe } from "stripe";
 
 import { env } from "../../lib/env";
 import { nowDate } from "../external/time";
-import { writeDb$, type Db } from "../external/db";
+import { writeDb$ } from "../external/db";
 import { getStripeClient } from "../external/stripe-client";
 import { getOrCreateStripeCustomer$ } from "./billing-customer.service";
-
-type WriteTx = Parameters<Parameters<Db["transaction"]>[0]>[0];
-
-interface LockedCheckoutOrg {
-  readonly orgId: string;
-  readonly lastProcessedInvoiceId: string | null;
-  readonly stripeSubscriptionId: string | null;
-  readonly tier: string;
-}
 
 interface CreateCheckoutSessionArgs {
   readonly orgId: string;
@@ -38,15 +28,6 @@ type CheckoutCompletionResult =
   | { readonly status: "completed" }
   | { readonly status: "pending" }
   | { readonly status: "customer_mismatch" }
-  | {
-      readonly status: "tier_conflict";
-      readonly currentTier: string | null;
-      readonly targetTier: SubscriptionCheckoutTier;
-    };
-
-type PaidCheckoutInvoiceResult =
-  | { readonly status: "completed" }
-  | { readonly status: "pending" }
   | {
       readonly status: "tier_conflict";
       readonly currentTier: string | null;
@@ -172,244 +153,6 @@ function subscriptionWillCancel(subscription: Stripe.Subscription): boolean {
   return subscription.cancel_at_period_end || subscription.cancel_at !== null;
 }
 
-function subscriptionTrialEnd(subscription: Stripe.Subscription): Date | null {
-  return typeof subscription.trial_end === "number"
-    ? new Date(subscription.trial_end * 1000)
-    : null;
-}
-
-function requiredSubscriptionTrialEnd(subscription: Stripe.Subscription): Date {
-  const trialEnd = subscriptionTrialEnd(subscription);
-  if (!trialEnd) {
-    throw new Error(
-      `trialing subscription has no trial_end (subscriptionId=${subscription.id})`,
-    );
-  }
-  return trialEnd;
-}
-
-function monthlyCreditsForTier(tier: SubscriptionCheckoutTier): number {
-  switch (tier) {
-    case "pro": {
-      return 20_000;
-    }
-    case "team": {
-      return 120_000;
-    }
-  }
-}
-
-function subscriptionCreditExpiresAt(
-  subscription: Stripe.Subscription,
-  periodEndDate: Date,
-): Date {
-  if (subscription.status === "trialing") {
-    return requiredSubscriptionTrialEnd(subscription);
-  }
-
-  const expiresAt = new Date(periodEndDate);
-  expiresAt.setMonth(expiresAt.getMonth() + 1);
-  return expiresAt;
-}
-
-function subscriptionIdFromInvoice(invoice: Stripe.Invoice): string | null {
-  const subscription = invoice.parent?.subscription_details?.subscription;
-  if (typeof subscription === "string") {
-    return subscription;
-  }
-  return subscription?.id ?? null;
-}
-
-function subscriptionPeriodEndFromInvoice(
-  invoice: Stripe.Invoice,
-): Date | null {
-  const subscriptionLine = invoice.lines.data.find((line) => {
-    return line.parent?.type === "subscription_item_details";
-  });
-  const periodEndUnix = subscriptionLine?.period.end;
-  return typeof periodEndUnix === "number"
-    ? new Date(periodEndUnix * 1000)
-    : null;
-}
-
-async function latestPaidInvoice(
-  stripe: ReturnType<typeof getStripeClient>,
-  subscription: Stripe.Subscription,
-): Promise<Stripe.Invoice | null> {
-  const latestInvoice = subscription.latest_invoice;
-  if (!latestInvoice) {
-    return null;
-  }
-
-  const invoice =
-    typeof latestInvoice === "string"
-      ? await stripe.invoices.retrieve(latestInvoice)
-      : latestInvoice;
-
-  return invoice.status === "paid" ? invoice : null;
-}
-
-async function lockCheckoutOrg(
-  tx: WriteTx,
-  orgId: string,
-): Promise<LockedCheckoutOrg | null> {
-  const [org] = await tx
-    .select({
-      orgId: orgMetadata.orgId,
-      lastProcessedInvoiceId: orgMetadata.lastProcessedInvoiceId,
-      stripeSubscriptionId: orgMetadata.stripeSubscriptionId,
-      tier: orgMetadata.tier,
-    })
-    .from(orgMetadata)
-    .where(eq(orgMetadata.orgId, orgId))
-    .for("update")
-    .limit(1);
-
-  return org ?? null;
-}
-
-function invoiceWouldReplaceWithSameOrLowerTier(args: {
-  readonly currentSubscriptionId: string | null;
-  readonly subscriptionId: string;
-  readonly currentTier: string;
-  readonly targetTier: SubscriptionCheckoutTier;
-}): boolean {
-  return (
-    args.currentSubscriptionId !== null &&
-    args.currentSubscriptionId !== args.subscriptionId &&
-    checkoutWouldReplaceWithSameOrLowerTier({
-      currentTier: args.currentTier,
-      targetTier: args.targetTier,
-    })
-  );
-}
-
-async function expireCredits(tx: WriteTx, orgId: string): Promise<void> {
-  const expired = await tx
-    .select({
-      id: creditExpiresRecord.id,
-      remaining: creditExpiresRecord.remaining,
-    })
-    .from(creditExpiresRecord)
-    .where(
-      and(
-        eq(creditExpiresRecord.orgId, orgId),
-        lte(creditExpiresRecord.expiresAt, nowDate()),
-        gt(creditExpiresRecord.remaining, 0),
-      ),
-    )
-    .for("update");
-
-  const totalExpired = expired.reduce((sum, record) => {
-    return sum + record.remaining;
-  }, 0);
-  if (totalExpired === 0) {
-    return;
-  }
-
-  for (const record of expired) {
-    await tx
-      .update(creditExpiresRecord)
-      .set({ remaining: 0 })
-      .where(eq(creditExpiresRecord.id, record.id));
-  }
-
-  await tx
-    .update(orgMetadata)
-    .set({
-      credits: sql`GREATEST(${orgMetadata.credits} - ${totalExpired}, 0)`,
-      updatedAt: nowDate(),
-    })
-    .where(eq(orgMetadata.orgId, orgId));
-}
-
-async function grantOrgCredits(
-  tx: WriteTx,
-  orgId: string,
-  amount: number,
-): Promise<void> {
-  await tx.execute(
-    sql`INSERT INTO org_metadata (org_id, credits, created_at, updated_at)
-        VALUES (${orgId}, ${amount}, now(), now())
-        ON CONFLICT (org_id)
-        DO UPDATE SET credits = org_metadata.credits + ${amount}, updated_at = now()`,
-  );
-}
-
-async function applyPaidCheckoutInvoice(
-  tx: WriteTx,
-  args: {
-    readonly orgId: string;
-    readonly invoice: Stripe.Invoice;
-    readonly subscription: Stripe.Subscription;
-    readonly tier: SubscriptionCheckoutTier;
-    readonly periodEndDate: Date;
-  },
-): Promise<PaidCheckoutInvoiceResult> {
-  const lockedOrg = await lockCheckoutOrg(tx, args.orgId);
-  if (!lockedOrg) {
-    return { status: "pending" };
-  }
-
-  if (lockedOrg.lastProcessedInvoiceId === args.invoice.id) {
-    return { status: "completed" };
-  }
-
-  if (
-    invoiceWouldReplaceWithSameOrLowerTier({
-      currentSubscriptionId: lockedOrg.stripeSubscriptionId,
-      subscriptionId: args.subscription.id,
-      currentTier: lockedOrg.tier,
-      targetTier: args.tier,
-    })
-  ) {
-    return {
-      status: "tier_conflict",
-      currentTier: lockedOrg.tier,
-      targetTier: args.tier,
-    };
-  }
-
-  await expireCredits(tx, args.orgId);
-
-  const credits = monthlyCreditsForTier(args.tier);
-  const inserted = await tx
-    .insert(creditExpiresRecord)
-    .values({
-      orgId: args.orgId,
-      source: "subscription_renewal",
-      stripeInvoiceId: args.invoice.id,
-      amount: credits,
-      remaining: credits,
-      expiresAt: subscriptionCreditExpiresAt(
-        args.subscription,
-        args.periodEndDate,
-      ),
-    })
-    .onConflictDoNothing()
-    .returning({ id: creditExpiresRecord.id });
-
-  if (inserted.length > 0) {
-    await grantOrgCredits(tx, args.orgId, credits);
-  }
-
-  await tx
-    .update(orgMetadata)
-    .set({
-      tier: args.tier,
-      stripeSubscriptionId: args.subscription.id,
-      subscriptionStatus: args.subscription.status,
-      cancelAtPeriodEnd: subscriptionWillCancel(args.subscription),
-      onboardingPaymentPending: false,
-      lastProcessedInvoiceId: args.invoice.id,
-      currentPeriodEnd: args.periodEndDate,
-      updatedAt: nowDate(),
-    })
-    .where(eq(orgMetadata.orgId, args.orgId));
-
-  return { status: "completed" };
-}
-
 function customUnitAmountParams(
   template: Stripe.Price.CustomUnitAmount | null,
   preset: number,
@@ -532,9 +275,7 @@ export const completeCheckoutSession$ = command(
       return { status: "pending" };
     }
 
-    const subscription = await stripe.subscriptions.retrieve(subscriptionId, {
-      expand: ["latest_invoice"],
-    });
+    const subscription = await stripe.subscriptions.retrieve(subscriptionId);
     signal.throwIfAborted();
 
     const priceId = subscription.items.data[0]?.price?.id;
@@ -558,32 +299,6 @@ export const completeCheckoutSession$ = command(
     }
     const alreadyPaidSubscription =
       org.stripeSubscriptionId === subscription.id && org.tier === tier;
-
-    const paidInvoice = await latestPaidInvoice(stripe, subscription);
-    signal.throwIfAborted();
-    if (
-      paidInvoice &&
-      subscriptionIdFromInvoice(paidInvoice) === subscription.id
-    ) {
-      const periodEndDate = subscriptionPeriodEndFromInvoice(paidInvoice);
-      if (!periodEndDate) {
-        throw new Error(
-          `checkout invoice has no subscription line item with period.end (invoiceId=${paidInvoice.id}, orgId=${args.orgId})`,
-        );
-      }
-
-      const result = await db.transaction(async (tx) => {
-        return await applyPaidCheckoutInvoice(tx, {
-          orgId: args.orgId,
-          invoice: paidInvoice,
-          subscription,
-          tier,
-          periodEndDate,
-        });
-      });
-      signal.throwIfAborted();
-      return result;
-    }
 
     await db
       .update(orgMetadata)

--- a/turbo/apps/api/src/signals/services/zero-billing-checkout.service.ts
+++ b/turbo/apps/api/src/signals/services/zero-billing-checkout.service.ts
@@ -1,13 +1,23 @@
 import { command } from "ccstate";
+import { creditExpiresRecord } from "@vm0/db/schema/credit-expires-record";
 import { orgMetadata } from "@vm0/db/schema/org-metadata";
-import { and, eq } from "drizzle-orm";
+import { and, eq, gt, lte, sql } from "drizzle-orm";
 import type { Stripe } from "stripe";
 
 import { env } from "../../lib/env";
 import { nowDate } from "../external/time";
-import { writeDb$ } from "../external/db";
+import { writeDb$, type Db } from "../external/db";
 import { getStripeClient } from "../external/stripe-client";
 import { getOrCreateStripeCustomer$ } from "./billing-customer.service";
+
+type WriteTx = Parameters<Parameters<Db["transaction"]>[0]>[0];
+
+interface LockedCheckoutOrg {
+  readonly orgId: string;
+  readonly lastProcessedInvoiceId: string | null;
+  readonly stripeSubscriptionId: string | null;
+  readonly tier: string;
+}
 
 interface CreateCheckoutSessionArgs {
   readonly orgId: string;
@@ -28,6 +38,15 @@ type CheckoutCompletionResult =
   | { readonly status: "completed" }
   | { readonly status: "pending" }
   | { readonly status: "customer_mismatch" }
+  | {
+      readonly status: "tier_conflict";
+      readonly currentTier: string | null;
+      readonly targetTier: SubscriptionCheckoutTier;
+    };
+
+type PaidCheckoutInvoiceResult =
+  | { readonly status: "completed" }
+  | { readonly status: "pending" }
   | {
       readonly status: "tier_conflict";
       readonly currentTier: string | null;
@@ -153,6 +172,244 @@ function subscriptionWillCancel(subscription: Stripe.Subscription): boolean {
   return subscription.cancel_at_period_end || subscription.cancel_at !== null;
 }
 
+function subscriptionTrialEnd(subscription: Stripe.Subscription): Date | null {
+  return typeof subscription.trial_end === "number"
+    ? new Date(subscription.trial_end * 1000)
+    : null;
+}
+
+function requiredSubscriptionTrialEnd(subscription: Stripe.Subscription): Date {
+  const trialEnd = subscriptionTrialEnd(subscription);
+  if (!trialEnd) {
+    throw new Error(
+      `trialing subscription has no trial_end (subscriptionId=${subscription.id})`,
+    );
+  }
+  return trialEnd;
+}
+
+function monthlyCreditsForTier(tier: SubscriptionCheckoutTier): number {
+  switch (tier) {
+    case "pro": {
+      return 20_000;
+    }
+    case "team": {
+      return 120_000;
+    }
+  }
+}
+
+function subscriptionCreditExpiresAt(
+  subscription: Stripe.Subscription,
+  periodEndDate: Date,
+): Date {
+  if (subscription.status === "trialing") {
+    return requiredSubscriptionTrialEnd(subscription);
+  }
+
+  const expiresAt = new Date(periodEndDate);
+  expiresAt.setMonth(expiresAt.getMonth() + 1);
+  return expiresAt;
+}
+
+function subscriptionIdFromInvoice(invoice: Stripe.Invoice): string | null {
+  const subscription = invoice.parent?.subscription_details?.subscription;
+  if (typeof subscription === "string") {
+    return subscription;
+  }
+  return subscription?.id ?? null;
+}
+
+function subscriptionPeriodEndFromInvoice(
+  invoice: Stripe.Invoice,
+): Date | null {
+  const subscriptionLine = invoice.lines.data.find((line) => {
+    return line.parent?.type === "subscription_item_details";
+  });
+  const periodEndUnix = subscriptionLine?.period.end;
+  return typeof periodEndUnix === "number"
+    ? new Date(periodEndUnix * 1000)
+    : null;
+}
+
+async function latestPaidInvoice(
+  stripe: ReturnType<typeof getStripeClient>,
+  subscription: Stripe.Subscription,
+): Promise<Stripe.Invoice | null> {
+  const latestInvoice = subscription.latest_invoice;
+  if (!latestInvoice) {
+    return null;
+  }
+
+  const invoice =
+    typeof latestInvoice === "string"
+      ? await stripe.invoices.retrieve(latestInvoice)
+      : latestInvoice;
+
+  return invoice.status === "paid" ? invoice : null;
+}
+
+async function lockCheckoutOrg(
+  tx: WriteTx,
+  orgId: string,
+): Promise<LockedCheckoutOrg | null> {
+  const [org] = await tx
+    .select({
+      orgId: orgMetadata.orgId,
+      lastProcessedInvoiceId: orgMetadata.lastProcessedInvoiceId,
+      stripeSubscriptionId: orgMetadata.stripeSubscriptionId,
+      tier: orgMetadata.tier,
+    })
+    .from(orgMetadata)
+    .where(eq(orgMetadata.orgId, orgId))
+    .for("update")
+    .limit(1);
+
+  return org ?? null;
+}
+
+function invoiceWouldReplaceWithSameOrLowerTier(args: {
+  readonly currentSubscriptionId: string | null;
+  readonly subscriptionId: string;
+  readonly currentTier: string;
+  readonly targetTier: SubscriptionCheckoutTier;
+}): boolean {
+  return (
+    args.currentSubscriptionId !== null &&
+    args.currentSubscriptionId !== args.subscriptionId &&
+    checkoutWouldReplaceWithSameOrLowerTier({
+      currentTier: args.currentTier,
+      targetTier: args.targetTier,
+    })
+  );
+}
+
+async function expireCredits(tx: WriteTx, orgId: string): Promise<void> {
+  const expired = await tx
+    .select({
+      id: creditExpiresRecord.id,
+      remaining: creditExpiresRecord.remaining,
+    })
+    .from(creditExpiresRecord)
+    .where(
+      and(
+        eq(creditExpiresRecord.orgId, orgId),
+        lte(creditExpiresRecord.expiresAt, nowDate()),
+        gt(creditExpiresRecord.remaining, 0),
+      ),
+    )
+    .for("update");
+
+  const totalExpired = expired.reduce((sum, record) => {
+    return sum + record.remaining;
+  }, 0);
+  if (totalExpired === 0) {
+    return;
+  }
+
+  for (const record of expired) {
+    await tx
+      .update(creditExpiresRecord)
+      .set({ remaining: 0 })
+      .where(eq(creditExpiresRecord.id, record.id));
+  }
+
+  await tx
+    .update(orgMetadata)
+    .set({
+      credits: sql`GREATEST(${orgMetadata.credits} - ${totalExpired}, 0)`,
+      updatedAt: nowDate(),
+    })
+    .where(eq(orgMetadata.orgId, orgId));
+}
+
+async function grantOrgCredits(
+  tx: WriteTx,
+  orgId: string,
+  amount: number,
+): Promise<void> {
+  await tx.execute(
+    sql`INSERT INTO org_metadata (org_id, credits, created_at, updated_at)
+        VALUES (${orgId}, ${amount}, now(), now())
+        ON CONFLICT (org_id)
+        DO UPDATE SET credits = org_metadata.credits + ${amount}, updated_at = now()`,
+  );
+}
+
+async function applyPaidCheckoutInvoice(
+  tx: WriteTx,
+  args: {
+    readonly orgId: string;
+    readonly invoice: Stripe.Invoice;
+    readonly subscription: Stripe.Subscription;
+    readonly tier: SubscriptionCheckoutTier;
+    readonly periodEndDate: Date;
+  },
+): Promise<PaidCheckoutInvoiceResult> {
+  const lockedOrg = await lockCheckoutOrg(tx, args.orgId);
+  if (!lockedOrg) {
+    return { status: "pending" };
+  }
+
+  if (lockedOrg.lastProcessedInvoiceId === args.invoice.id) {
+    return { status: "completed" };
+  }
+
+  if (
+    invoiceWouldReplaceWithSameOrLowerTier({
+      currentSubscriptionId: lockedOrg.stripeSubscriptionId,
+      subscriptionId: args.subscription.id,
+      currentTier: lockedOrg.tier,
+      targetTier: args.tier,
+    })
+  ) {
+    return {
+      status: "tier_conflict",
+      currentTier: lockedOrg.tier,
+      targetTier: args.tier,
+    };
+  }
+
+  await expireCredits(tx, args.orgId);
+
+  const credits = monthlyCreditsForTier(args.tier);
+  const inserted = await tx
+    .insert(creditExpiresRecord)
+    .values({
+      orgId: args.orgId,
+      source: "subscription_renewal",
+      stripeInvoiceId: args.invoice.id,
+      amount: credits,
+      remaining: credits,
+      expiresAt: subscriptionCreditExpiresAt(
+        args.subscription,
+        args.periodEndDate,
+      ),
+    })
+    .onConflictDoNothing()
+    .returning({ id: creditExpiresRecord.id });
+
+  if (inserted.length > 0) {
+    await grantOrgCredits(tx, args.orgId, credits);
+  }
+
+  await tx
+    .update(orgMetadata)
+    .set({
+      tier: args.tier,
+      stripeSubscriptionId: args.subscription.id,
+      subscriptionStatus: args.subscription.status,
+      cancelAtPeriodEnd: subscriptionWillCancel(args.subscription),
+      onboardingPaymentPending: false,
+      lastProcessedInvoiceId: args.invoice.id,
+      currentPeriodEnd: args.periodEndDate,
+      updatedAt: nowDate(),
+    })
+    .where(eq(orgMetadata.orgId, args.orgId));
+
+  return { status: "completed" };
+}
+
 function customUnitAmountParams(
   template: Stripe.Price.CustomUnitAmount | null,
   preset: number,
@@ -275,7 +532,9 @@ export const completeCheckoutSession$ = command(
       return { status: "pending" };
     }
 
-    const subscription = await stripe.subscriptions.retrieve(subscriptionId);
+    const subscription = await stripe.subscriptions.retrieve(subscriptionId, {
+      expand: ["latest_invoice"],
+    });
     signal.throwIfAborted();
 
     const priceId = subscription.items.data[0]?.price?.id;
@@ -299,6 +558,32 @@ export const completeCheckoutSession$ = command(
     }
     const alreadyPaidSubscription =
       org.stripeSubscriptionId === subscription.id && org.tier === tier;
+
+    const paidInvoice = await latestPaidInvoice(stripe, subscription);
+    signal.throwIfAborted();
+    if (
+      paidInvoice &&
+      subscriptionIdFromInvoice(paidInvoice) === subscription.id
+    ) {
+      const periodEndDate = subscriptionPeriodEndFromInvoice(paidInvoice);
+      if (!periodEndDate) {
+        throw new Error(
+          `checkout invoice has no subscription line item with period.end (invoiceId=${paidInvoice.id}, orgId=${args.orgId})`,
+        );
+      }
+
+      const result = await db.transaction(async (tx) => {
+        return await applyPaidCheckoutInvoice(tx, {
+          orgId: args.orgId,
+          invoice: paidInvoice,
+          subscription,
+          tier,
+          periodEndDate,
+        });
+      });
+      signal.throwIfAborted();
+      return result;
+    }
 
     await db
       .update(orgMetadata)

--- a/turbo/apps/api/src/signals/services/zero-billing-restore.service.ts
+++ b/turbo/apps/api/src/signals/services/zero-billing-restore.service.ts
@@ -1,0 +1,66 @@
+import { command } from "ccstate";
+import { orgMetadata } from "@vm0/db/schema/org-metadata";
+import { eq } from "drizzle-orm";
+
+import { logger } from "../../lib/log";
+import { writeDb$ } from "../external/db";
+import { nowDate } from "../external/time";
+import { getStripeClient } from "../external/stripe-client";
+
+const L = logger("BillingRestore");
+
+type RestoreResult =
+  | { readonly ok: true }
+  | { readonly ok: false; readonly reason: "no_subscription" }
+  | { readonly ok: false; readonly reason: "not_scheduled" };
+
+interface RestoreArgs {
+  readonly orgId: string;
+}
+
+export const restoreSubscription$ = command(
+  async (
+    { set },
+    args: RestoreArgs,
+    signal: AbortSignal,
+  ): Promise<RestoreResult> => {
+    const writeDb = set(writeDb$);
+
+    const [org] = await writeDb
+      .select({
+        stripeSubscriptionId: orgMetadata.stripeSubscriptionId,
+        cancelAtPeriodEnd: orgMetadata.cancelAtPeriodEnd,
+      })
+      .from(orgMetadata)
+      .where(eq(orgMetadata.orgId, args.orgId))
+      .limit(1);
+    signal.throwIfAborted();
+
+    if (!org?.stripeSubscriptionId) {
+      return { ok: false, reason: "no_subscription" };
+    }
+
+    if (!org.cancelAtPeriodEnd) {
+      return { ok: false, reason: "not_scheduled" };
+    }
+
+    const stripe = getStripeClient();
+    await stripe.subscriptions.update(org.stripeSubscriptionId, {
+      cancel_at_period_end: false,
+    });
+    signal.throwIfAborted();
+
+    await writeDb
+      .update(orgMetadata)
+      .set({ cancelAtPeriodEnd: false, updatedAt: nowDate() })
+      .where(eq(orgMetadata.orgId, args.orgId));
+    signal.throwIfAborted();
+
+    L.debug("subscription cancellation restored", {
+      orgId: args.orgId,
+      stripeSubscriptionId: org.stripeSubscriptionId,
+    });
+
+    return { ok: true };
+  },
+);

--- a/turbo/apps/platform/src/mocks/handlers/api-billing.ts
+++ b/turbo/apps/platform/src/mocks/handlers/api-billing.ts
@@ -3,6 +3,7 @@ import {
   zeroBillingCheckoutContract,
   zeroBillingPortalContract,
   zeroBillingDowngradeContract,
+  zeroBillingRestoreContract,
   zeroBillingAutoRechargeContract,
   zeroBillingInvoicesContract,
   zeroBillingRedeemContract,
@@ -85,6 +86,11 @@ export const apiBillingHandlers = [
       success: true,
       effectiveDate: null,
     });
+  }),
+
+  mockApi(zeroBillingRestoreContract.create, ({ respond }) => {
+    mockBillingStatus.cancelAtPeriodEnd = false;
+    return respond(200, { success: true });
   }),
 
   mockApi(zeroBillingAutoRechargeContract.get, ({ respond }) => {

--- a/turbo/apps/platform/src/signals/bootstrap.ts
+++ b/turbo/apps/platform/src/signals/bootstrap.ts
@@ -1,4 +1,4 @@
-import { command } from "ccstate";
+import { command, type Command } from "ccstate";
 import { createElement } from "react";
 import { toast } from "@vm0/ui/components/ui/sonner";
 import { setupClerk$, watchOrgSwitch$ } from "./auth.ts";
@@ -9,6 +9,7 @@ import {
   detachedNavigateTo$,
   setupAuthPageWrapper,
   pathParams$,
+  pathname$,
 } from "./route.ts";
 import { registerServiceWorker$ } from "../lib/push-notifications.ts";
 import { onDomEventFn } from "./utils.ts";
@@ -66,6 +67,7 @@ import {
   markCompletedBillingCheckout$,
   reloadBillingStatus$,
 } from "./zero-page/billing.ts";
+import { checkUnifiedSettingsParam$ } from "./zero-page/settings/settings-dialog.ts";
 
 const setupNotFoundPage$ = command(async ({ set }, signal: AbortSignal) => {
   set(updatePage$, createElement(NotFoundPage));
@@ -98,19 +100,39 @@ function redirectWithId(target: RoutePath, targetParam: string) {
   });
 }
 
+function setupSettingsParamAfterStableRoute(
+  setupPage: Command<Promise<void> | void, [AbortSignal]>,
+) {
+  return command(async ({ get, set }, signal: AbortSignal) => {
+    const initialPathname = get(pathname$);
+    await set(setupPage, signal);
+    signal.throwIfAborted();
+    if (get(pathname$) !== initialPathname) {
+      return;
+    }
+    await set(checkUnifiedSettingsParam$, signal);
+  });
+}
+
+function setupAuthSidebarPageWrapper(
+  setupPage: Command<Promise<void> | void, [AbortSignal]>,
+) {
+  return setupAuthPageWrapper(setupSettingsParamAfterStableRoute(setupPage));
+}
+
 const ROUTE_CONFIG = [
   // --- New routes ---
   {
     path: ROUTES.insights,
-    setup: setupAuthPageWrapper(setupNetworkInsightsPage$),
+    setup: setupAuthSidebarPageWrapper(setupNetworkInsightsPage$),
   },
   {
     path: ROUTES.chat,
-    setup: setupAuthPageWrapper(setupChatPage$),
+    setup: setupAuthSidebarPageWrapper(setupChatPage$),
   },
   {
     path: ROUTES.ideas,
-    setup: setupAuthPageWrapper(setupIdeationPage$),
+    setup: setupAuthSidebarPageWrapper(setupIdeationPage$),
   },
   {
     path: ROUTES.directedAuthorize,
@@ -122,11 +144,11 @@ const ROUTE_CONFIG = [
   },
   {
     path: ROUTES.connectors,
-    setup: setupAuthPageWrapper(setupConnectorsPage$),
+    setup: setupAuthSidebarPageWrapper(setupConnectorsPage$),
   },
   {
     path: ROUTES.agentIdeas,
-    setup: setupAuthPageWrapper(setupIdeationPage$),
+    setup: setupAuthSidebarPageWrapper(setupIdeationPage$),
   },
   {
     path: ROUTES.agentChat,
@@ -142,31 +164,31 @@ const ROUTE_CONFIG = [
   },
   {
     path: ROUTES.agentDetail,
-    setup: setupAuthPageWrapper(setupAgentDetailPage$),
+    setup: setupAuthSidebarPageWrapper(setupAgentDetailPage$),
   },
   {
     path: ROUTES.agents,
-    setup: setupAuthPageWrapper(setupAgentsPage$),
+    setup: setupAuthSidebarPageWrapper(setupAgentsPage$),
   },
   {
     path: ROUTES.skills,
-    setup: setupAuthPageWrapper(setupSkillsPage$),
+    setup: setupAuthSidebarPageWrapper(setupSkillsPage$),
   },
   {
     path: ROUTES.memory,
-    setup: setupAuthPageWrapper(setupMemoryPage$),
+    setup: setupAuthSidebarPageWrapper(setupMemoryPage$),
   },
   {
     path: ROUTES.settingsSlack,
-    setup: setupAuthPageWrapper(setupSlackConnectPage$),
+    setup: setupAuthSidebarPageWrapper(setupSlackConnectPage$),
   },
   {
     path: ROUTES.settingsGithub,
-    setup: setupAuthPageWrapper(setupGithubSettingsPage$),
+    setup: setupAuthSidebarPageWrapper(setupGithubSettingsPage$),
   },
   {
     path: ROUTES.settingsTelegram,
-    setup: setupAuthPageWrapper(setupTelegramSettingsPage$),
+    setup: setupAuthSidebarPageWrapper(setupTelegramSettingsPage$),
   },
   {
     path: ROUTES.githubConnect,
@@ -182,47 +204,47 @@ const ROUTE_CONFIG = [
   },
   {
     path: ROUTES.activityInspect,
-    setup: setupAuthPageWrapper(setupActivityInspectPage$),
+    setup: setupAuthSidebarPageWrapper(setupActivityInspectPage$),
   },
   {
     path: ROUTES.activityDetail,
-    setup: setupAuthPageWrapper(setupActivityDetailPage$),
+    setup: setupAuthSidebarPageWrapper(setupActivityDetailPage$),
   },
   {
     path: ROUTES.activities,
-    setup: setupAuthPageWrapper(setupActivityPage$),
+    setup: setupAuthSidebarPageWrapper(setupActivityPage$),
   },
   {
     path: ROUTES.works,
-    setup: setupAuthPageWrapper(setupWorksPage$),
+    setup: setupAuthSidebarPageWrapper(setupWorksPage$),
   },
   {
     path: ROUTES.settings,
-    setup: setupAuthPageWrapper(setupPreferencesPage$),
+    setup: setupAuthSidebarPageWrapper(setupPreferencesPage$),
   },
   {
     path: ROUTES.settingsApiKeys,
-    setup: setupAuthPageWrapper(setupApiKeysPage$),
+    setup: setupAuthSidebarPageWrapper(setupApiKeysPage$),
   },
   {
     path: ROUTES.deviceBb0,
-    setup: setupAuthPageWrapper(setupBb0DevicePage$),
+    setup: setupAuthSidebarPageWrapper(setupBb0DevicePage$),
   },
   {
     path: ROUTES.scheduleDetail,
-    setup: setupAuthPageWrapper(setupScheduleDetailPage$),
+    setup: setupAuthSidebarPageWrapper(setupScheduleDetailPage$),
   },
   {
     path: ROUTES.schedules,
-    setup: setupAuthPageWrapper(setupSchedulePage$),
+    setup: setupAuthSidebarPageWrapper(setupSchedulePage$),
   },
   {
     path: ROUTES.lab,
-    setup: setupAuthPageWrapper(setupLabPage$),
+    setup: setupAuthSidebarPageWrapper(setupLabPage$),
   },
   {
     path: ROUTES.usage,
-    setup: setupAuthPageWrapper(setupUsagePage$),
+    setup: setupAuthSidebarPageWrapper(setupUsagePage$),
   },
   {
     path: ROUTES.onboarding,
@@ -343,7 +365,7 @@ const handleBillingRedirect$ = command(({ set }) => {
 
     const label = billing === "pro" ? "Pro" : "Team";
     showSuccessToastAfterMount(
-      `Upgraded to ${label}! Your credits have been added.`,
+      `${label} checkout completed. Credits will be added after the invoice is paid.`,
     );
     set(markCompletedBillingCheckout$, billing, transactionId);
     set(reloadBillingStatus$);

--- a/turbo/apps/platform/src/signals/onboarding-page/__tests__/onboarding-page-setup.test.ts
+++ b/turbo/apps/platform/src/signals/onboarding-page/__tests__/onboarding-page-setup.test.ts
@@ -111,6 +111,45 @@ describe("setupOnboardingPage$ — redirect when onboarding is not needed", () =
       "/agents/c0000000-0000-4000-a000-000000000001/chat",
     );
   });
+
+  it("retries checkout reconciliation while onboarding payment is pending", async () => {
+    let checkoutCompleteCalls = 0;
+    let statusCalls = 0;
+    server.use(
+      mockApi(zeroBillingCheckoutContract.complete, ({ respond }) => {
+        checkoutCompleteCalls += 1;
+        return respond(200, { completed: checkoutCompleteCalls > 1 });
+      }),
+      mockApi(onboardingStatusContract.getStatus, ({ respond }) => {
+        statusCalls += 1;
+        const completed = statusCalls > 1;
+        return respond(200, {
+          needsOnboarding: !completed,
+          isAdmin: true,
+          hasOrg: true,
+          hasDefaultAgent: true,
+          defaultAgentId: completed
+            ? "c0000000-0000-4000-a000-000000000001"
+            : null,
+          defaultAgentMetadata: completed ? { displayName: "Zero" } : null,
+        });
+      }),
+    );
+    context.store.set(markCompletedBillingCheckout$, "pro", "cs_test_retry");
+
+    detachedSetupPage({
+      context,
+      path: "/onboarding",
+      withoutRender: true,
+    });
+
+    await context.store.set(setupOnboardingPage$, context.signal);
+
+    expect(checkoutCompleteCalls).toBeGreaterThan(1);
+    expect(pathname()).toBe(
+      "/agents/c0000000-0000-4000-a000-000000000001/chat",
+    );
+  });
 });
 
 describe("setupOnboardingPage$ — ?connector= consumption", () => {

--- a/turbo/apps/platform/src/signals/onboarding-page/__tests__/onboarding-page-setup.test.ts
+++ b/turbo/apps/platform/src/signals/onboarding-page/__tests__/onboarding-page-setup.test.ts
@@ -111,45 +111,6 @@ describe("setupOnboardingPage$ — redirect when onboarding is not needed", () =
       "/agents/c0000000-0000-4000-a000-000000000001/chat",
     );
   });
-
-  it("retries checkout reconciliation while onboarding payment is pending", async () => {
-    let checkoutCompleteCalls = 0;
-    let statusCalls = 0;
-    server.use(
-      mockApi(zeroBillingCheckoutContract.complete, ({ respond }) => {
-        checkoutCompleteCalls += 1;
-        return respond(200, { completed: checkoutCompleteCalls > 1 });
-      }),
-      mockApi(onboardingStatusContract.getStatus, ({ respond }) => {
-        statusCalls += 1;
-        const completed = statusCalls > 1;
-        return respond(200, {
-          needsOnboarding: !completed,
-          isAdmin: true,
-          hasOrg: true,
-          hasDefaultAgent: true,
-          defaultAgentId: completed
-            ? "c0000000-0000-4000-a000-000000000001"
-            : null,
-          defaultAgentMetadata: completed ? { displayName: "Zero" } : null,
-        });
-      }),
-    );
-    context.store.set(markCompletedBillingCheckout$, "pro", "cs_test_retry");
-
-    detachedSetupPage({
-      context,
-      path: "/onboarding",
-      withoutRender: true,
-    });
-
-    await context.store.set(setupOnboardingPage$, context.signal);
-
-    expect(checkoutCompleteCalls).toBeGreaterThan(1);
-    expect(pathname()).toBe(
-      "/agents/c0000000-0000-4000-a000-000000000001/chat",
-    );
-  });
 });
 
 describe("setupOnboardingPage$ — ?connector= consumption", () => {

--- a/turbo/apps/platform/src/signals/zero-page/agent-chat-page-setup.ts
+++ b/turbo/apps/platform/src/signals/zero-page/agent-chat-page-setup.ts
@@ -24,6 +24,7 @@ import {
 } from "./zero-chat-page.ts";
 import { reloadUserModelPreference$ } from "../external/user-model-preference.ts";
 import { openQueueDrawer$ } from "../queue-page/queue-drawer-state.ts";
+import { checkUnifiedSettingsParam$ } from "./settings/settings-dialog.ts";
 
 export const setupAgentChatPage$ = command(
   async ({ get, set }, signal: AbortSignal) => {
@@ -75,6 +76,8 @@ export const setupAgentChatPage$ = command(
 
     set(rememberLastUsedAgentId$, agentId);
     set(updateDocumentTitle$, agent.displayName ?? "Chat");
+
+    await set(checkUnifiedSettingsParam$, signal);
 
     const params = get(searchParams$);
     const prompt = params.get("prompt");

--- a/turbo/apps/platform/src/signals/zero-page/billing.ts
+++ b/turbo/apps/platform/src/signals/zero-page/billing.ts
@@ -7,6 +7,7 @@ import {
   zeroBillingAutoRechargeContract,
   zeroBillingInvoicesContract,
   zeroBillingDowngradeContract,
+  zeroBillingRestoreContract,
 } from "@vm0/api-contracts/contracts/zero-billing";
 import { toast } from "@vm0/ui/components/ui/sonner";
 import { zeroClient$ } from "../api-client.ts";
@@ -276,6 +277,34 @@ export const confirmDowngrade$ = command(
     set(billingReload$, (x) => {
       return x + 1;
     });
+    if (targetTier === "pro-suspend") {
+      toast.success(
+        "Cancellation scheduled. Your current plan stays active until the billing period ends.",
+      );
+    } else {
+      toast.success(
+        "Downgrade started. Your plan and credits will update after Stripe confirms payment.",
+      );
+    }
+  },
+);
+
+export const restorePlan$ = command(
+  async ({ get, set }, signal: AbortSignal) => {
+    const createClient = get(zeroClient$);
+    const client = createClient(zeroBillingRestoreContract);
+    await accept(
+      client.create({
+        body: {},
+        fetchOptions: { signal },
+      }),
+      [200],
+    );
+    signal.throwIfAborted();
+    set(billingReload$, (x) => {
+      return x + 1;
+    });
+    toast.success("Plan restored. Your subscription will renew normally.");
   },
 );
 

--- a/turbo/apps/platform/src/signals/zero-page/settings/__tests__/settings-dialog.test.ts
+++ b/turbo/apps/platform/src/signals/zero-page/settings/__tests__/settings-dialog.test.ts
@@ -13,12 +13,17 @@ import {
 import {
   billingScrollTarget$,
   billingSubPage$,
+  orgManageTab$,
 } from "../org-manage-tabs-state.ts";
 import { searchParams$ } from "../../../route.ts";
 import {
   resetMockOrg,
   setMockOrg,
 } from "../../../../mocks/handlers/api-org.ts";
+import {
+  orgManageDialogOpen$,
+  setOrgManageDialogOpen$,
+} from "../org-manage-dialog.ts";
 
 const context = testContext();
 
@@ -45,9 +50,10 @@ describe("checkUnifiedSettingsParam$", () => {
 
     await store.set(checkUnifiedSettingsParam$, signal);
 
-    expect(store.get(settingsDialogOpen$)).toBeTruthy();
-    expect(store.get(settingsActiveSection$)).toBe("billing");
-    expect(store.get(searchParams$).has("settings")).toBeFalsy();
+    expect(store.get(orgManageDialogOpen$)).toBeTruthy();
+    expect(store.get(orgManageTab$)).toBe("billing");
+    expect(store.get(settingsDialogOpen$)).toBeFalsy();
+    expect(store.get(searchParams$).get("settings")).toBe("billing");
   });
 
   it("opens billing on Compare plans when ?settings=billing&billingView=plans", async () => {
@@ -61,11 +67,12 @@ describe("checkUnifiedSettingsParam$", () => {
 
     await store.set(checkUnifiedSettingsParam$, signal);
 
-    expect(store.get(settingsDialogOpen$)).toBeTruthy();
-    expect(store.get(settingsActiveSection$)).toBe("billing");
+    expect(store.get(orgManageDialogOpen$)).toBeTruthy();
+    expect(store.get(orgManageTab$)).toBe("billing");
+    expect(store.get(settingsDialogOpen$)).toBeFalsy();
     expect(store.get(billingSubPage$)).toBeTruthy();
-    expect(store.get(searchParams$).has("settings")).toBeFalsy();
-    expect(store.get(searchParams$).has("billingView")).toBeFalsy();
+    expect(store.get(searchParams$).get("settings")).toBe("billing");
+    expect(store.get(searchParams$).get("billingView")).toBe("plans");
   });
 
   it("opens billing on Buy credits when ?settings=billing&billingView=credits", async () => {
@@ -79,12 +86,27 @@ describe("checkUnifiedSettingsParam$", () => {
 
     await store.set(checkUnifiedSettingsParam$, signal);
 
-    expect(store.get(settingsDialogOpen$)).toBeTruthy();
-    expect(store.get(settingsActiveSection$)).toBe("billing");
+    expect(store.get(orgManageDialogOpen$)).toBeTruthy();
+    expect(store.get(orgManageTab$)).toBe("billing");
+    expect(store.get(settingsDialogOpen$)).toBeFalsy();
     expect(store.get(billingSubPage$)).toBeFalsy();
     expect(store.get(billingScrollTarget$)).toBe("buy-credits");
-    expect(store.get(searchParams$).has("settings")).toBeFalsy();
-    expect(store.get(searchParams$).has("billingView")).toBeFalsy();
+    expect(store.get(searchParams$).get("settings")).toBe("billing");
+    expect(store.get(searchParams$).get("billingView")).toBe("credits");
+  });
+
+  it("opens workspace providers for admin when ?settings=providers", async () => {
+    const { store, signal } = context;
+    setupAuth(signal);
+    createPushStateMock(signal);
+    mockLocation({ pathname: "/", search: "?settings=providers" }, signal);
+
+    await store.set(checkUnifiedSettingsParam$, signal);
+
+    expect(store.get(orgManageDialogOpen$)).toBeTruthy();
+    expect(store.get(orgManageTab$)).toBe("providers");
+    expect(store.get(settingsDialogOpen$)).toBeFalsy();
+    expect(store.get(searchParams$).get("settings")).toBe("providers");
   });
 
   it("keeps non-admins on the home page when opening Compare plans link", async () => {
@@ -135,6 +157,7 @@ describe("checkUnifiedSettingsParam$", () => {
 
     expect(store.get(settingsDialogOpen$)).toBeTruthy();
     expect(store.get(settingsActiveSection$)).toBe("preference");
+    expect(store.get(searchParams$).get("settings")).toBe("preference");
   });
 
   it("does not open dialog for unknown settings value", async () => {
@@ -159,7 +182,7 @@ describe("checkUnifiedSettingsParam$", () => {
     expect(store.get(settingsDialogOpen$)).toBeFalsy();
   });
 
-  it("preserves other search params when stripping settings", async () => {
+  it("preserves settings and other search params while the dialog is open", async () => {
     const { store, signal } = context;
     setupAuth(signal);
     createPushStateMock(signal);
@@ -171,7 +194,7 @@ describe("checkUnifiedSettingsParam$", () => {
     await store.set(checkUnifiedSettingsParam$, signal);
 
     const params = store.get(searchParams$);
-    expect(params.has("settings")).toBeFalsy();
+    expect(params.get("settings")).toBe("preference");
     expect(params.get("other")).toBe("keep");
   });
 });
@@ -200,11 +223,14 @@ describe("setSettingsActiveSection$", () => {
 });
 
 describe("setSettingsDialogOpen$", () => {
-  it("removes ?settings from URL when closing the dialog", async () => {
+  it("removes settings params from URL when closing the dialog", async () => {
     const { store, signal } = context;
     setupAuth(signal);
     createPushStateMock(signal);
-    mockLocation({ pathname: "/", search: "?settings=preference" }, signal);
+    mockLocation(
+      { pathname: "/", search: "?settings=preference&billingView=plans" },
+      signal,
+    );
 
     await store.set(setSettingsDialogOpen$, true, signal);
     expect(store.get(settingsDialogOpen$)).toBeTruthy();
@@ -213,5 +239,27 @@ describe("setSettingsDialogOpen$", () => {
 
     expect(store.get(settingsDialogOpen$)).toBeFalsy();
     expect(store.get(searchParams$).has("settings")).toBeFalsy();
+    expect(store.get(searchParams$).has("billingView")).toBeFalsy();
+  });
+});
+
+describe("setOrgManageDialogOpen$", () => {
+  it("removes settings params from URL when closing the dialog", async () => {
+    const { store, signal } = context;
+    setupAuth(signal);
+    createPushStateMock(signal);
+    mockLocation(
+      { pathname: "/", search: "?settings=billing&billingView=plans" },
+      signal,
+    );
+
+    await store.set(setOrgManageDialogOpen$, true, signal);
+    expect(store.get(orgManageDialogOpen$)).toBeTruthy();
+
+    await store.set(setOrgManageDialogOpen$, false, signal);
+
+    expect(store.get(orgManageDialogOpen$)).toBeFalsy();
+    expect(store.get(searchParams$).has("settings")).toBeFalsy();
+    expect(store.get(searchParams$).has("billingView")).toBeFalsy();
   });
 });

--- a/turbo/apps/platform/src/signals/zero-page/settings/org-manage-dialog.ts
+++ b/turbo/apps/platform/src/signals/zero-page/settings/org-manage-dialog.ts
@@ -1,6 +1,7 @@
 import { command, computed, state } from "ccstate";
 import { reloadBillingStatus$ } from "../billing.ts";
 import { initProfileName$ } from "./org-manage-tabs-state.ts";
+import { searchParams$, updateSearchParams$ } from "../../route.ts";
 
 const internalOrgManageDialogOpen$ = state(false);
 
@@ -9,11 +10,18 @@ export const orgManageDialogOpen$ = computed((get) => {
 });
 
 export const setOrgManageDialogOpen$ = command(
-  async ({ set }, open: boolean, signal: AbortSignal) => {
+  async ({ get, set }, open: boolean, signal: AbortSignal) => {
     set(internalOrgManageDialogOpen$, open);
     if (open) {
       await set(initProfileName$, signal);
       set(reloadBillingStatus$);
+    } else {
+      const params = new URLSearchParams(get(searchParams$));
+      if (params.has("settings") || params.has("billingView")) {
+        params.delete("settings");
+        params.delete("billingView");
+        set(updateSearchParams$, params);
+      }
     }
   },
 );

--- a/turbo/apps/platform/src/signals/zero-page/settings/settings-dialog.ts
+++ b/turbo/apps/platform/src/signals/zero-page/settings/settings-dialog.ts
@@ -4,9 +4,12 @@ import { reloadBillingStatus$ } from "../billing.ts";
 import { isOrgAdmin$ } from "../../org.ts";
 import {
   initProfileName$,
+  setActiveOrgManageTab$,
   setBillingScrollTarget$,
   setBillingSubPage$,
+  type OrgManageTab,
 } from "./org-manage-tabs-state.ts";
+import { setOrgManageDialogOpen$ } from "./org-manage-dialog.ts";
 
 export const SETTINGS_SECTIONS = [
   "preference",
@@ -21,6 +24,8 @@ export const SETTINGS_SECTIONS = [
 ] as const;
 
 export type SettingsSection = (typeof SETTINGS_SECTIONS)[number];
+type OrgManageOnlySettingsSection = "providers";
+type UnifiedSettingsSection = SettingsSection | OrgManageOnlySettingsSection;
 
 const ADMIN_ONLY_SETTINGS_SECTIONS_LIST = [
   "general",
@@ -85,8 +90,9 @@ export const setSettingsDialogOpen$ = command(
       }
     } else {
       const params = new URLSearchParams(get(searchParams$));
-      if (params.has("settings")) {
+      if (params.has("settings") || params.has("billingView")) {
         params.delete("settings");
+        params.delete("billingView");
         set(updateSearchParams$, params);
       }
     }
@@ -108,11 +114,46 @@ function isSettingsSection(value: string): value is SettingsSection {
   return (SETTINGS_SECTIONS as readonly string[]).includes(value);
 }
 
+function isUnifiedSettingsSection(
+  value: string,
+): value is UnifiedSettingsSection {
+  return isSettingsSection(value) || value === "providers";
+}
+
+function orgManageTabForSettingsSection(
+  section: UnifiedSettingsSection,
+): OrgManageTab | null {
+  switch (section) {
+    case "general": {
+      return "general";
+    }
+    case "people": {
+      return "members";
+    }
+    case "providers": {
+      return "providers";
+    }
+    case "billing": {
+      return "billing";
+    }
+    case "usage": {
+      return "usage";
+    }
+    case "invoices": {
+      return "invoices";
+    }
+    default: {
+      return null;
+    }
+  }
+}
+
 /**
- * Check URL for `?settings=<section>` and auto-open the dialog on that section.
- * Falls back to the closest non-admin section if the user lacks workspace
- * admin and the URL points at an admin-only section. Strips the param from
- * the URL after consuming it so reloads don't re-pin the dialog.
+ * Check URL for `?settings=<section>` and auto-open the matching settings
+ * surface. Admin-only workspace sections open the workspace management dialog
+ * for admins, and fall back to the closest non-admin section otherwise.
+ * Valid settings params stay in the URL while the dialog is open; closing the
+ * dialog clears them.
  */
 export const checkUnifiedSettingsParam$ = command(
   async ({ get, set }, signal: AbortSignal) => {
@@ -122,36 +163,49 @@ export const checkUnifiedSettingsParam$ = command(
     if (!value) {
       return;
     }
-    if (isSettingsSection(value)) {
-      const section = value;
-      const opensBillingPlans =
-        section === "billing" && billingView === "plans";
-      const opensBuyCredits =
-        section === "billing" && billingView === "credits";
-      const isAdmin = await get(isOrgAdmin$);
-      signal.throwIfAborted();
-      if (!isAdmin && (opensBillingPlans || opensBuyCredits)) {
-        set(setBillingSubPage$, false);
-        set(setBillingScrollTarget$, null);
-      } else {
-        const resolved =
-          !isAdmin && isAdminOnlySettingsSection(section)
-            ? "preference"
-            : section;
-        set(internalActiveSection$, resolved);
-        set(setBillingSubPage$, opensBillingPlans && resolved === "billing");
-        set(
-          setBillingScrollTarget$,
-          opensBuyCredits && resolved === "billing" ? "buy-credits" : null,
-        );
-        await set(setSettingsDialogOpen$, true, signal);
-      }
+    if (!isUnifiedSettingsSection(value)) {
+      const next = new URLSearchParams(get(searchParams$));
+      next.delete("settings");
+      next.delete("billingView");
+      set(updateSearchParams$, next);
+      return;
     }
 
-    // Strip the param so a reload doesn't re-pin the dialog on this section
-    const next = new URLSearchParams(get(searchParams$));
-    next.delete("settings");
-    next.delete("billingView");
-    set(updateSearchParams$, next);
+    const section = value;
+    const opensBillingPlans = section === "billing" && billingView === "plans";
+    const opensBuyCredits = section === "billing" && billingView === "credits";
+    const isAdmin = await get(isOrgAdmin$);
+    signal.throwIfAborted();
+
+    const orgManageTab = orgManageTabForSettingsSection(section);
+    if (orgManageTab && isAdmin) {
+      set(setActiveOrgManageTab$, orgManageTab);
+      set(setBillingSubPage$, opensBillingPlans);
+      set(setBillingScrollTarget$, opensBuyCredits ? "buy-credits" : null);
+      await set(setOrgManageDialogOpen$, true, signal);
+      return;
+    }
+    if (!isAdmin && (opensBillingPlans || opensBuyCredits)) {
+      set(setBillingSubPage$, false);
+      set(setBillingScrollTarget$, null);
+      const next = new URLSearchParams(get(searchParams$));
+      next.delete("settings");
+      next.delete("billingView");
+      set(updateSearchParams$, next);
+      return;
+    }
+
+    const resolved: SettingsSection =
+      !isSettingsSection(section) ||
+      (!isAdmin && isAdminOnlySettingsSection(section))
+        ? "preference"
+        : section;
+    set(internalActiveSection$, resolved);
+    set(setBillingSubPage$, opensBillingPlans && resolved === "billing");
+    set(
+      setBillingScrollTarget$,
+      opensBuyCredits && resolved === "billing" ? "buy-credits" : null,
+    );
+    await set(setSettingsDialogOpen$, true, signal);
   },
 );

--- a/turbo/apps/platform/src/signals/zero-page/zero-onboarding-actions.ts
+++ b/turbo/apps/platform/src/signals/zero-page/zero-onboarding-actions.ts
@@ -390,12 +390,21 @@ const onboardingContinueWeb$ = command(
 const MAX_CHECKOUT_STATUS_POLLS = 90;
 
 const waitForCompletedOnboardingCheckout$ = command(
-  async ({ get, set }, signal: AbortSignal): Promise<string | null> => {
+  async (
+    { get, set },
+    sessionId: string | null,
+    signal: AbortSignal,
+  ): Promise<string | null> => {
     let attempts = 0;
     let resolvedAgentId: string | null = null;
 
     await setLoop(
       async () => {
+        if (sessionId) {
+          await set(completeCheckoutSession$, sessionId, signal);
+          signal.throwIfAborted();
+        }
+
         set(reloadOnboardingStatus$);
         const status = await get(zeroOnboardingStatus$);
         signal.throwIfAborted();
@@ -423,12 +432,12 @@ export const continueOnboardingAfterCheckout$ = command(
     signal: AbortSignal,
   ): Promise<boolean> => {
     set(showAppSkeleton$);
-    if (sessionId) {
-      await set(completeCheckoutSession$, sessionId, signal);
-      signal.throwIfAborted();
-    }
 
-    const agentId = await set(waitForCompletedOnboardingCheckout$, signal);
+    const agentId = await set(
+      waitForCompletedOnboardingCheckout$,
+      sessionId,
+      signal,
+    );
     signal.throwIfAborted();
     if (!agentId) {
       await set(hideAppSkeleton$, signal);

--- a/turbo/apps/platform/src/signals/zero-page/zero-onboarding-actions.ts
+++ b/turbo/apps/platform/src/signals/zero-page/zero-onboarding-actions.ts
@@ -390,21 +390,12 @@ const onboardingContinueWeb$ = command(
 const MAX_CHECKOUT_STATUS_POLLS = 90;
 
 const waitForCompletedOnboardingCheckout$ = command(
-  async (
-    { get, set },
-    sessionId: string | null,
-    signal: AbortSignal,
-  ): Promise<string | null> => {
+  async ({ get, set }, signal: AbortSignal): Promise<string | null> => {
     let attempts = 0;
     let resolvedAgentId: string | null = null;
 
     await setLoop(
       async () => {
-        if (sessionId) {
-          await set(completeCheckoutSession$, sessionId, signal);
-          signal.throwIfAborted();
-        }
-
         set(reloadOnboardingStatus$);
         const status = await get(zeroOnboardingStatus$);
         signal.throwIfAborted();
@@ -432,12 +423,12 @@ export const continueOnboardingAfterCheckout$ = command(
     signal: AbortSignal,
   ): Promise<boolean> => {
     set(showAppSkeleton$);
+    if (sessionId) {
+      await set(completeCheckoutSession$, sessionId, signal);
+      signal.throwIfAborted();
+    }
 
-    const agentId = await set(
-      waitForCompletedOnboardingCheckout$,
-      sessionId,
-      signal,
-    );
+    const agentId = await set(waitForCompletedOnboardingCheckout$, signal);
     signal.throwIfAborted();
     if (!agentId) {
       await set(hideAppSkeleton$, signal);

--- a/turbo/apps/platform/src/views/zero-page/__tests__/org-billing-tab.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/org-billing-tab.test.tsx
@@ -1,4 +1,4 @@
-import { describe, it, expect, afterEach, vi } from "vitest";
+import { describe, it, expect, afterEach, vi, beforeEach } from "vitest";
 import { screen, waitFor, within } from "@testing-library/react";
 import { toast } from "@vm0/ui/components/ui/sonner";
 import { server } from "../../../mocks/server.ts";
@@ -9,7 +9,9 @@ import {
   click,
   queryAllByRoleFast,
 } from "../../../__tests__/page-helper.ts";
+import { pathname, search } from "../../../signals/location.ts";
 import { setMockBillingStatus } from "../../../mocks/handlers/api-billing.ts";
+import { setMockTeam } from "../../../mocks/handlers/api-agents.ts";
 import { reloadBillingStatus$ } from "../../../signals/zero-page/billing.ts";
 import { createDeferredPromise } from "../../../signals/utils.ts";
 import {
@@ -19,11 +21,26 @@ import {
   zeroBillingCreditCheckoutContract,
   zeroBillingPortalContract,
   zeroBillingDowngradeContract,
+  zeroBillingRestoreContract,
 } from "@vm0/api-contracts/contracts/zero-billing";
 import { createMockApi } from "../../../mocks/msw-contract.ts";
 
+vi.mock("@vm0/ui/components/ui/sonner", async (importOriginal) => {
+  const actual =
+    (await importOriginal()) as typeof import("@vm0/ui/components/ui/sonner");
+  return {
+    ...actual,
+    toast: { error: vi.fn(), success: vi.fn(), info: vi.fn() },
+  };
+});
+
 const context = testContext();
 const mockApi = createMockApi(context);
+
+beforeEach(() => {
+  vi.mocked(toast.error).mockClear();
+  vi.mocked(toast.success).mockClear();
+});
 
 async function openBillingTab() {
   detachedSetupPage({ context, path: "/?settings=billing" });
@@ -33,6 +50,74 @@ async function openBillingTab() {
 }
 
 describe("org billing tab - plan display", () => {
+  it("opens workspace billing from an agent chat settings URL for admins", async () => {
+    const agentId = "d80ad561-0801-4082-a3fe-e34470cee304";
+    setMockTeam([
+      {
+        id: agentId,
+        displayName: "Billing Test Agent",
+        description: null,
+        sound: null,
+        avatarUrl: null,
+        customSkills: [],
+        headVersionId: "version_1",
+        updatedAt: "2026-01-01T00:00:00Z",
+      },
+    ]);
+    setMockBillingStatus({ tier: "free", credits: 10_000 });
+
+    detachedSetupPage({
+      context,
+      path: `/agents/${agentId}/chat?settings=billing`,
+    });
+
+    const dialog = await waitFor(() => {
+      return screen.getByRole("dialog", { name: "Workspace settings" });
+    });
+
+    expect(within(dialog).getByText("Billing & pricing")).toBeInTheDocument();
+    expect(within(dialog).getByText("Free plan")).toBeInTheDocument();
+    expect(search()).toBe("?settings=billing");
+  });
+
+  it("opens workspace billing from a primary app route settings URL", async () => {
+    setMockBillingStatus({ tier: "free", credits: 10_000 });
+
+    detachedSetupPage({
+      context,
+      path: "/agents?settings=billing",
+    });
+
+    const dialog = await waitFor(() => {
+      return screen.getByRole("dialog", { name: "Workspace settings" });
+    });
+
+    expect(pathname()).toBe("/agents");
+    expect(within(dialog).getByText("Billing & pricing")).toBeInTheDocument();
+    expect(within(dialog).getByText("Free plan")).toBeInTheDocument();
+    expect(search()).toBe("?settings=billing");
+  });
+
+  it("keeps billing settings through a chat route switch", async () => {
+    setMockBillingStatus({ tier: "free", credits: 10_000 });
+
+    detachedSetupPage({
+      context,
+      path: "/agents/not-in-team/chat?settings=billing",
+    });
+
+    const dialog = await waitFor(() => {
+      return screen.getByRole("dialog", { name: "Workspace settings" });
+    });
+
+    expect(pathname()).toBe(
+      "/agents/c0000000-0000-4000-a000-000000000001/chat",
+    );
+    expect(within(dialog).getByText("Billing & pricing")).toBeInTheDocument();
+    expect(within(dialog).getByText("Free plan")).toBeInTheDocument();
+    expect(search()).toBe("?settings=billing");
+  });
+
   it("should show Free plan for free tier", async () => {
     setMockBillingStatus({ tier: "free", credits: 10_000 });
 
@@ -125,6 +210,8 @@ describe("org billing tab - pricing sub-page navigation", () => {
     expect(screen.queryByText("Free")).not.toBeInTheDocument();
     expect(screen.getByText("Pro")).toBeInTheDocument();
     expect(screen.getByText("Team")).toBeInTheDocument();
+    const planGrid = screen.getByText("Pro").closest(".grid");
+    expect(planGrid?.className).not.toContain("-mx-");
   });
 
   it("should navigate to pricing page when clicking Compare all plans", async () => {
@@ -287,9 +374,7 @@ describe("org billing tab - buy credits section", () => {
   });
 
   it("shows range toast without starting checkout for invalid custom amounts", async () => {
-    const errorSpy = vi.spyOn(toast, "error").mockImplementation(() => {
-      return "" as ReturnType<typeof toast.error>;
-    });
+    const errorSpy = vi.mocked(toast.error);
     let capturedBody: unknown = null;
     server.use(
       mockApi(zeroBillingCreditCheckoutContract.create, ({ body, respond }) => {
@@ -326,7 +411,6 @@ describe("org billing tab - buy credits section", () => {
       expect(errorSpy).toHaveBeenCalledWith("Enter between $1 and $10,000");
     });
     expect(capturedBody).toBeNull();
-    errorSpy.mockRestore();
   });
 });
 
@@ -795,6 +879,69 @@ describe("org billing tab - cancellation pending", () => {
     ).toHaveLength(0);
   });
 
+  it("should show Restore plan button when cancellation is pending", async () => {
+    setMockBillingStatus({
+      tier: "pro",
+      credits: 20_000,
+      subscriptionStatus: "active",
+      currentPeriodEnd: futureDate,
+      cancelAtPeriodEnd: true,
+      hasSubscription: true,
+    });
+
+    await openBillingTab();
+
+    await waitFor(() => {
+      expect(screen.getByText("Pro plan")).toBeInTheDocument();
+    });
+
+    expect(
+      queryAllByRoleFast("button").find((el) => {
+        return el.textContent?.trim() === "Restore plan";
+      }),
+    ).toBeDefined();
+  });
+
+  it("should call restore API and reload billing status", async () => {
+    let restoreCalled = false;
+    server.use(
+      mockApi(zeroBillingRestoreContract.create, ({ respond }) => {
+        restoreCalled = true;
+        setMockBillingStatus({ cancelAtPeriodEnd: false });
+        return respond(200, { success: true });
+      }),
+    );
+    setMockBillingStatus({
+      tier: "pro",
+      credits: 20_000,
+      subscriptionStatus: "active",
+      currentPeriodEnd: futureDate,
+      cancelAtPeriodEnd: true,
+      hasSubscription: true,
+    });
+
+    await openBillingTab();
+
+    await waitFor(() => {
+      expect(screen.getByText("Pro plan")).toBeInTheDocument();
+    });
+
+    const restoreButton = queryAllByRoleFast("button").find((el) => {
+      return el.textContent?.trim() === "Restore plan";
+    });
+    expect(restoreButton).toBeDefined();
+    click(restoreButton!);
+
+    await waitFor(() => {
+      expect(restoreCalled).toBeTruthy();
+      expect(screen.getByText(/Renews/)).toBeInTheDocument();
+      expect(vi.mocked(toast.success)).toHaveBeenCalledWith(
+        "Plan restored. Your subscription will renew normally.",
+      );
+    });
+    expect(screen.queryByText(/has been cancelled/)).not.toBeInTheDocument();
+  });
+
   it("should show Manage button when cancellation is pending", async () => {
     setMockBillingStatus({
       tier: "pro",
@@ -916,6 +1063,56 @@ describe("org billing tab - plan card details", () => {
       screen.queryByText("Voice input (10/month)"),
     ).not.toBeInTheDocument();
   });
+
+  it("should show expiry and restore action on the cancelling current plan card", async () => {
+    const periodEnd = "2026-07-04T00:00:00.000Z";
+    let restoreCalled = false;
+    server.use(
+      mockApi(zeroBillingRestoreContract.create, ({ respond }) => {
+        restoreCalled = true;
+        setMockBillingStatus({ cancelAtPeriodEnd: false });
+        return respond(200, { success: true });
+      }),
+    );
+    setMockBillingStatus({
+      tier: "pro",
+      credits: 20_000,
+      subscriptionStatus: "active",
+      currentPeriodEnd: periodEnd,
+      cancelAtPeriodEnd: true,
+      hasSubscription: true,
+    });
+
+    await openBillingTab();
+
+    await waitFor(() => {
+      expect(screen.getByText("Pro plan")).toBeInTheDocument();
+    });
+
+    click(screen.getByText("Compare all plans"));
+
+    await waitFor(() => {
+      expect(screen.getByText("Compare plans")).toBeInTheDocument();
+    });
+
+    const proCard = screen.getByText("Pro").closest("div");
+    expect(proCard).not.toBeNull();
+    expect(
+      within(proCard!).getByText(
+        `Ends on ${new Date(periodEnd).toLocaleDateString("en-US")}`,
+      ),
+    ).toBeInTheDocument();
+
+    const restoreButton = queryAllByRoleFast("button", proCard!).find((el) => {
+      return el.textContent?.trim() === "Restore plan";
+    });
+    expect(restoreButton).toBeDefined();
+    click(restoreButton!);
+
+    await waitFor(() => {
+      expect(restoreCalled).toBeTruthy();
+    });
+  });
 });
 
 describe("org billing tab - renewal date display", () => {
@@ -935,6 +1132,28 @@ describe("org billing tab - renewal date display", () => {
     await waitFor(() => {
       expect(screen.getByText(/Renews/)).toBeInTheDocument();
     });
+  });
+
+  it("should not show stale renewal date when there is no active plan", async () => {
+    const staleDate = new Date(Date.now() + 30 * 86_400 * 1000).toISOString();
+    setMockBillingStatus({
+      tier: "pro-suspend",
+      credits: 0,
+      subscriptionStatus: "canceled",
+      currentPeriodEnd: staleDate,
+      cancelAtPeriodEnd: false,
+      hasSubscription: false,
+    });
+
+    await openBillingTab();
+
+    await waitFor(() => {
+      expect(screen.getByText("No active plan")).toBeInTheDocument();
+    });
+
+    expect(screen.getByText("No active subscription")).toBeInTheDocument();
+    expect(screen.queryByText(/Renews/)).not.toBeInTheDocument();
+    expect(screen.queryByText(/Ends on/)).not.toBeInTheDocument();
   });
 });
 
@@ -1215,6 +1434,9 @@ describe("org billing tab - downgrade flow", () => {
 
     await waitFor(() => {
       expect(capturedBody).toStrictEqual({ targetTier: "pro-suspend" });
+      expect(vi.mocked(toast.success)).toHaveBeenCalledWith(
+        "Cancellation scheduled. Your current plan stays active until the billing period ends.",
+      );
     });
   });
 

--- a/turbo/apps/platform/src/views/zero-page/__tests__/org-provider-dialog.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/org-provider-dialog.test.tsx
@@ -8,7 +8,7 @@
  */
 
 import { describe, expect, it } from "vitest";
-import { screen, waitFor } from "@testing-library/react";
+import { screen, waitFor, within } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { server } from "../../../mocks/server.ts";
 import { testContext } from "../../../signals/__tests__/test-helpers.ts";
@@ -84,6 +84,18 @@ function mockProviderResponse(
 }
 
 describe("org-provider-dialog - display", () => {
+  it("opens providers from a primary app route settings URL", async () => {
+    detachedSetupPage({ context, path: "/agents?settings=providers" });
+
+    const dialog = await waitFor(() => {
+      return screen.getByRole("dialog", { name: "Workspace settings" });
+    });
+
+    expect(
+      within(dialog).getByText("Models Configuration"),
+    ).toBeInTheDocument();
+  });
+
   // ORG-D-089: dialog title and description based on mode/type
   it("shows add title for anthropic-api-key in add mode", async () => {
     await openAddDialog("anthropic-api-key", /Add workspace Anthropic/i);

--- a/turbo/apps/platform/src/views/zero-page/components/org-manage/org-billing-tab.tsx
+++ b/turbo/apps/platform/src/views/zero-page/components/org-manage/org-billing-tab.tsx
@@ -20,6 +20,7 @@ import {
   closeDowngradeDialog$,
   confirmDowngrade$,
   downgradeDialogOpen$,
+  restorePlan$,
   type BillingTier,
 } from "../../../../signals/zero-page/billing.ts";
 import {
@@ -137,6 +138,10 @@ function isPaidTier(tier: BillingTier): boolean {
   return tier === "pro" || tier === "team";
 }
 
+function formatBillingDate(value: string): string {
+  return new Date(value).toLocaleDateString("en-US");
+}
+
 function planButtonLabel(
   plan: (typeof PLANS)[number],
   currentTier: BillingTier,
@@ -159,16 +164,26 @@ function planButtonLabel(
 function PlanCard({
   plan,
   currentTier,
+  isCancelling,
+  periodEnd,
   loading,
   onAction,
+  onRestore,
 }: {
   plan: (typeof PLANS)[number];
   currentTier: BillingTier;
+  isCancelling: boolean;
+  periodEnd: string | null | undefined;
   loading: boolean;
   onAction: (planTier: BillingTier, e: React.MouseEvent) => void;
+  onRestore: () => void;
 }) {
   const isCurrent = plan.tier === currentTier;
-  const label = planButtonLabel(plan, currentTier);
+  const restoreCurrentPlan =
+    isCurrent && isCancelling && isPaidTier(currentTier);
+  const label = restoreCurrentPlan
+    ? "Restore plan"
+    : planButtonLabel(plan, currentTier);
   const unavailable = label === "Unavailable";
 
   return (
@@ -206,6 +221,12 @@ function PlanCard({
         {plan.description}
       </p>
 
+      {restoreCurrentPlan && periodEnd && (
+        <p className="mb-5 rounded-lg border border-amber-200/70 bg-amber-50/70 px-3 py-2 text-[12px] leading-relaxed text-amber-700 dark:border-amber-400/20 dark:bg-amber-400/10 dark:text-amber-300">
+          Ends on {formatBillingDate(periodEnd)}
+        </p>
+      )}
+
       <ul className="mb-6 flex flex-col gap-2.5">
         {plan.features.map((feature) => {
           return (
@@ -235,20 +256,27 @@ function PlanCard({
       <div className="mt-auto">
         <Button
           variant={
-            isCurrent
-              ? "outline"
-              : "primary" in plan && plan.primary
-                ? "default"
-                : "outline"
+            restoreCurrentPlan
+              ? "default"
+              : isCurrent
+                ? "outline"
+                : "primary" in plan && plan.primary
+                  ? "default"
+                  : "outline"
           }
           size="default"
           className="w-full h-11 text-sm font-medium"
-          disabled={loading || isCurrent || unavailable}
+          disabled={
+            loading || (!restoreCurrentPlan && (isCurrent || unavailable))
+          }
           onClick={(e) => {
+            if (restoreCurrentPlan) {
+              return onRestore();
+            }
             return onAction(plan.tier, e);
           }}
         >
-          {isCurrent ? "Current plan" : label}
+          {label}
         </Button>
       </div>
     </div>
@@ -257,14 +285,22 @@ function PlanCard({
 
 function PricingPage({
   currentTier,
+  isCancelling,
+  periodEnd,
+  restoreLoading,
   onBack,
+  onRestore,
 }: {
   currentTier: BillingTier;
+  isCancelling: boolean;
+  periodEnd: string | null | undefined;
+  restoreLoading: boolean;
   onBack: () => void;
+  onRestore: () => void;
 }) {
   const pageSignal = useGet(pageSignal$);
   const [checkoutLoadable, checkout] = useLoadableSet(startCheckout$);
-  const loading = checkoutLoadable.state === "loading";
+  const loading = checkoutLoadable.state === "loading" || restoreLoading;
   const openDowngrade = useSet(openDowngradeDialog$);
 
   const handlePlanAction = (planTier: BillingTier, e: React.MouseEvent) => {
@@ -323,15 +359,18 @@ function PricingPage({
         </div>
       </div>
 
-      <div className="grid grid-cols-1 sm:grid-cols-2 gap-4 -mx-4 sm:-mx-10">
+      <div className="grid grid-cols-1 sm:grid-cols-2 gap-4">
         {COMPARE_PLANS.map((plan) => {
           return (
             <PlanCard
               key={plan.tier}
               plan={plan}
               currentTier={currentTier}
+              isCancelling={isCancelling}
+              periodEnd={periodEnd}
               loading={loading}
               onAction={handlePlanAction}
+              onRestore={onRestore}
             />
           );
         })}
@@ -470,22 +509,37 @@ function PlanActionButtons({
   isCancelling,
   currentTier,
   loading,
+  restoreLoading,
   onUpgrade,
   onDowngrade,
+  onRestore,
 }: {
   isPaid: boolean;
   isCancelling: boolean;
   currentTier: BillingTier;
   loading: boolean;
+  restoreLoading: boolean;
   onUpgrade: () => void;
   onDowngrade: () => void;
+  onRestore: () => void;
 }) {
   const showUpgrade =
     (isPaid && currentTier !== "team" && !isCancelling) || !isPaid;
   const showDowngrade = isPaid && !isCancelling;
+  const showRestore = isPaid && isCancelling;
 
   return (
     <div className="flex items-center gap-2 shrink-0">
+      {showRestore && (
+        <Button
+          size="sm"
+          className="rounded-lg h-8 text-xs"
+          disabled={loading}
+          onClick={onRestore}
+        >
+          {restoreLoading ? "Restoring..." : "Restore plan"}
+        </Button>
+      )}
       {showUpgrade && (
         <Button
           size="sm"
@@ -518,6 +572,20 @@ function shouldShowBuyCreditsSection(
   return hasBillingStatus && currentTier !== "pro-suspend";
 }
 
+function billingPeriodLabel(args: {
+  isPaid: boolean;
+  isCancelling: boolean;
+  periodEnd: string | null | undefined;
+}): string | null {
+  const { isPaid, isCancelling, periodEnd } = args;
+  if (!isPaid || !periodEnd) {
+    return null;
+  }
+
+  const date = formatBillingDate(periodEnd);
+  return isCancelling ? `Ends on ${date}` : `Renews ${date}`;
+}
+
 export function OrgBillingTab() {
   const pricingOpen = useGet(billingSubPage$);
   const billingScrollTarget = useGet(billingScrollTarget$);
@@ -530,8 +598,10 @@ export function OrgBillingTab() {
   const reloadBilling = useSet(reloadBillingStatus$);
   const openDowngrade = useSet(openDowngradeDialog$);
   const [portalLoadable, portal] = useLoadableSet(startDowngrade$);
+  const [restoreLoadable, restore] = useLoadableSet(restorePlan$);
   const statusLoadable = useLastLoadable(billingStatusAsync$);
-  const loading = portalLoadable.state === "loading";
+  const restoreLoading = restoreLoadable.state === "loading";
+  const loading = portalLoadable.state === "loading" || restoreLoading;
 
   const status =
     statusLoadable.state === "hasData" ? statusLoadable.data : null;
@@ -542,15 +612,17 @@ export function OrgBillingTab() {
   const isPaid = isPaidTier(currentTier);
   const isCancelling = status?.cancelAtPeriodEnd === true;
   const periodEnd = status?.currentPeriodEnd;
-  const periodLabel =
-    periodEnd !== undefined && periodEnd !== null && periodEnd !== ""
-      ? isCancelling
-        ? `Ends on ${new Date(periodEnd).toLocaleDateString("en-US")}`
-        : `Renews ${new Date(periodEnd).toLocaleDateString("en-US")}`
-      : null;
+  const periodLabel = billingPeriodLabel({
+    isPaid,
+    isCancelling,
+    periodEnd,
+  });
 
   const handleDowngrade = () => {
     openDowngrade();
+  };
+  const handleRestore = () => {
+    detach(restore(pageSignal), Reason.DomCallback);
   };
   const currentPlanLabel =
     currentTier === "pro-suspend"
@@ -566,9 +638,13 @@ export function OrgBillingTab() {
       <>
         <PricingPage
           currentTier={currentTier}
+          isCancelling={isCancelling}
+          periodEnd={periodEnd}
+          restoreLoading={restoreLoading}
           onBack={() => {
             return setPricingOpen(false);
           }}
+          onRestore={handleRestore}
         />
         <DowngradeConfirmDialog currentTier={currentTier} />
       </>
@@ -619,10 +695,12 @@ export function OrgBillingTab() {
                   isCancelling={isCancelling}
                   currentTier={currentTier}
                   loading={loading}
+                  restoreLoading={restoreLoading}
                   onUpgrade={() => {
                     return setPricingOpen(true);
                   }}
                   onDowngrade={handleDowngrade}
+                  onRestore={handleRestore}
                 />
               </div>
               {isCancelling && periodEnd && (
@@ -631,8 +709,7 @@ export function OrgBillingTab() {
                   <div className="px-5 py-3">
                     <p className="text-[13px] text-amber-600 dark:text-amber-400">
                       Your {formatTierLabel(currentTier)} plan has been
-                      cancelled and will end on{" "}
-                      {new Date(periodEnd).toLocaleDateString("en-US")}.
+                      cancelled and will end on {formatBillingDate(periodEnd)}.
                     </p>
                   </div>
                 </>

--- a/turbo/apps/web/__tests__/api-backend-rewrite-proxy.test.ts
+++ b/turbo/apps/web/__tests__/api-backend-rewrite-proxy.test.ts
@@ -1928,6 +1928,19 @@ describe("API backend rewrite proxy behavior", () => {
     );
   });
 
+  it("matches the zero billing restore rewrite path exactly", () => {
+    expect(matchesApiBackendRewritePath("/api/zero/billing/restore")).toBe(
+      true,
+    );
+    expect(
+      matchesApiBackendRewritePath("/api/zero/billing/restore/extra"),
+    ).toBe(false);
+    expect(matchesApiBackendRewritePath("/api/zero/billing")).toBe(false);
+    expect(matchesApiBackendRewritePath("/api/zero/billing/restores")).toBe(
+      false,
+    );
+  });
+
   it("matches the zero billing redeem rewrite path by a single campaign segment", () => {
     expect(
       matchesApiBackendRewritePath("/api/zero/billing/redeem/ZERO100"),

--- a/turbo/apps/web/__tests__/security-headers.test.ts
+++ b/turbo/apps/web/__tests__/security-headers.test.ts
@@ -1016,6 +1016,13 @@ const ZERO_BILLING_REDEEM_NEXT_NEGATIVE_PATHS = [
   "/api/zero/billing/redeem/ZERO100/extra",
   "/api/zero/billing/redeems/ZERO100",
 ] as const;
+const ZERO_BILLING_RESTORE_REWRITE_SOURCE = "/api/zero/billing/restore";
+const ZERO_BILLING_RESTORE_PATH = "/api/zero/billing/restore";
+const ZERO_BILLING_RESTORE_NEXT_NEGATIVE_PATHS = [
+  "/api/zero/billing",
+  "/api/zero/billing/restore/extra",
+  "/api/zero/billing/restores",
+] as const;
 const ZERO_BILLING_STATUS_REWRITE_SOURCE = "/api/zero/billing/status";
 const ZERO_BILLING_STATUS_PATH = "/api/zero/billing/status";
 const ZERO_BILLING_STATUS_NEXT_NEGATIVE_PATHS = [
@@ -2470,6 +2477,10 @@ describe("API backend rewrites", () => {
           source: ZERO_BILLING_REDEEM_REWRITE_SOURCE,
           destination:
             "https://api.example.test/api/zero/billing/redeem/:campaign",
+        },
+        {
+          source: ZERO_BILLING_RESTORE_REWRITE_SOURCE,
+          destination: "https://api.example.test/api/zero/billing/restore",
         },
         {
           source: ZERO_BILLING_STATUS_REWRITE_SOURCE,
@@ -6748,6 +6759,29 @@ describe("API backend rewrites", () => {
     }
   });
 
+  it("should match only the exact zero billing restore rewrite", async () => {
+    vi.stubEnv("VM0_API_BACKEND_URL", "https://api.example.test");
+
+    const rewrites = await getBeforeFileRewrites();
+    const rewrite = rewrites.find((entry) => {
+      return entry.source === ZERO_BILLING_RESTORE_REWRITE_SOURCE;
+    });
+    expect(rewrite).toStrictEqual({
+      source: ZERO_BILLING_RESTORE_REWRITE_SOURCE,
+      destination: "https://api.example.test/api/zero/billing/restore",
+    });
+
+    const matcher = getPathMatch(ZERO_BILLING_RESTORE_REWRITE_SOURCE, {
+      removeUnnamedParams: true,
+      strict: true,
+    });
+
+    expect(matcher(ZERO_BILLING_RESTORE_PATH)).toStrictEqual({});
+    for (const pathname of ZERO_BILLING_RESTORE_NEXT_NEGATIVE_PATHS) {
+      expect(matcher(pathname)).toBe(false);
+    }
+  });
+
   it("should match only the exact zero default-agent rewrite", async () => {
     vi.stubEnv("VM0_API_BACKEND_URL", "https://api.example.test");
 
@@ -8755,6 +8789,13 @@ describe("API backend rewrites", () => {
   it("should bypass web middleware only for the exact zero billing portal path", () => {
     expect(matchesApiBackendRewritePath(ZERO_BILLING_PORTAL_PATH)).toBe(true);
     for (const pathname of ZERO_BILLING_PORTAL_NEXT_NEGATIVE_PATHS) {
+      expect(matchesApiBackendRewritePath(pathname)).toBe(false);
+    }
+  });
+
+  it("should bypass web middleware only for the exact zero billing restore path", () => {
+    expect(matchesApiBackendRewritePath(ZERO_BILLING_RESTORE_PATH)).toBe(true);
+    for (const pathname of ZERO_BILLING_RESTORE_NEXT_NEGATIVE_PATHS) {
       expect(matchesApiBackendRewritePath(pathname)).toBe(false);
     }
   });

--- a/turbo/apps/web/api-backend-rewrites.js
+++ b/turbo/apps/web/api-backend-rewrites.js
@@ -350,6 +350,7 @@ const ZERO_BILLING_INVOICES_REWRITE_SOURCE = "/api/zero/billing/invoices";
 const ZERO_BILLING_PORTAL_REWRITE_SOURCE = "/api/zero/billing/portal";
 const ZERO_BILLING_REDEEM_REWRITE_SOURCE = "/api/zero/billing/redeem/:campaign";
 const ZERO_BILLING_REDEEM_PATH_RE = /^\/api\/zero\/billing\/redeem\/[^/]+$/;
+const ZERO_BILLING_RESTORE_REWRITE_SOURCE = "/api/zero/billing/restore";
 const ZERO_BILLING_STATUS_REWRITE_SOURCE = "/api/zero/billing/status";
 const ZERO_DEFAULT_AGENT_REWRITE_SOURCE = "/api/zero/default-agent";
 const ZERO_FEATURE_SWITCHES_REWRITE_SOURCE = "/api/zero/feature-switches";
@@ -694,6 +695,7 @@ export const API_BACKEND_REWRITES = [
     "/api/zero/billing/redeem/:campaign",
     ZERO_BILLING_REDEEM_PATH_RE,
   ],
+  [ZERO_BILLING_RESTORE_REWRITE_SOURCE, "/api/zero/billing/restore"],
   [ZERO_BILLING_STATUS_REWRITE_SOURCE, "/api/zero/billing/status"],
   [ZERO_DEFAULT_AGENT_REWRITE_SOURCE, "/api/zero/default-agent"],
   [ZERO_FEATURE_SWITCHES_REWRITE_SOURCE, "/api/zero/feature-switches"],

--- a/turbo/packages/api-contracts/src/contracts/index.ts
+++ b/turbo/packages/api-contracts/src/contracts/index.ts
@@ -1120,6 +1120,7 @@ export {
   zeroBillingAutoRechargeContract,
   zeroBillingInvoicesContract,
   zeroBillingDowngradeContract,
+  zeroBillingRestoreContract,
   zeroBillingRedeemContract,
   type ZeroBillingStatusContract,
   type ZeroBillingCheckoutContract,
@@ -1127,6 +1128,7 @@ export {
   type ZeroBillingAutoRechargeContract,
   type ZeroBillingInvoicesContract,
   type ZeroBillingDowngradeContract,
+  type ZeroBillingRestoreContract,
   type ZeroBillingRedeemContract,
   // Inferred types
   type BillingStatusResponse,

--- a/turbo/packages/api-contracts/src/contracts/zero-billing.ts
+++ b/turbo/packages/api-contracts/src/contracts/zero-billing.ts
@@ -350,6 +350,10 @@ const downgradeResponseSchema = z.object({
   effectiveDate: z.string().nullable(),
 });
 
+const restoreResponseSchema = z.object({
+  success: z.boolean(),
+});
+
 /**
  * Zero contract for POST /api/zero/billing/downgrade
  */
@@ -373,6 +377,29 @@ export const zeroBillingDowngradeContract = c.router({
 });
 
 export type ZeroBillingDowngradeContract = typeof zeroBillingDowngradeContract;
+
+/**
+ * Zero contract for POST /api/zero/billing/restore
+ */
+export const zeroBillingRestoreContract = c.router({
+  create: {
+    method: "POST",
+    path: "/api/zero/billing/restore",
+    headers: authHeadersSchema,
+    body: z.object({}),
+    responses: {
+      200: restoreResponseSchema,
+      401: apiErrorSchema,
+      403: apiErrorSchema,
+      409: apiErrorSchema,
+      500: apiErrorSchema,
+      503: apiErrorSchema,
+    },
+    summary: "Restore a subscription scheduled for cancellation",
+  },
+});
+
+export type ZeroBillingRestoreContract = typeof zeroBillingRestoreContract;
 
 /**
  * Zero contract for POST /api/zero/billing/redeem/:campaign
@@ -414,5 +441,6 @@ export type BillingInvoicesResponse = z.infer<
   typeof billingInvoicesResponseSchema
 >;
 export type DowngradeResponse = z.infer<typeof downgradeResponseSchema>;
+export type RestoreResponse = z.infer<typeof restoreResponseSchema>;
 export type RedeemRequest = z.infer<typeof redeemRequestSchema>;
 export type RedeemResponse = z.infer<typeof redeemResponseSchema>;


### PR DESCRIPTION
## Summary
- handle `customer.subscription.created` so dashboard-created Stripe subscriptions can bind and upgrade the matching org
- when no local `stripe_customer_id` match exists, retrieve the Stripe customer and bind via `metadata.orgId` only if the org has no existing Stripe customer
- sync trial credit expiry to Stripe `trial_end` and keep subscription updates aligned with trial extensions

## Verification
- `pnpm format`
- `pnpm lint`
- `NODE_OPTIONS=--max-old-space-size=6144 pnpm check-types`
- `pnpm knip`
- `pnpm -F api exec vitest run src/signals/routes/__tests__/webhooks-third-party.test.ts -t "POST /api/webhooks/stripe"` *(blocked locally: test DB schema is behind; inserts fail because `org_metadata.default_agent_id` is missing, and `pnpm -F @vm0/db db:migrate` is blocked by existing NULL `email_thread_sessions.agent_id` rows)*