### PR TITLE
refactor: separate connector refresh types

### DIFF
--- a/turbo/packages/connectors/src/auth-providers/connector-auth.ts
+++ b/turbo/packages/connectors/src/auth-providers/connector-auth.ts
@@ -29,18 +29,17 @@ import {
 } from "@vm0/connectors/connector-utils";
 import type {
   AuthCodeConnectorAuthProvider,
+  ConnectorAuthProviderRefreshResultBase,
+  ConnectorAuthProviderRefreshResult,
   DeviceAuthConnectorAuthProvider,
   RefreshTokenAccessProvider,
   TokenRevokeProvider,
 } from "./types";
 import {
   type AuthUrlResult,
-  type ConnectorAuthProviderRefreshResultBase,
-  type ConnectorAuthProviderRefreshResult,
   type OAuthDeviceAuthPollResult,
   type OAuthDeviceAuthPollResultBase,
   type OAuthDeviceAuthStartResult,
-  type OAuthRefreshResult,
   type OAuthTokenResult,
   type OAuthTokenResultBase,
 } from "./oauth/types";
@@ -107,7 +106,6 @@ export type {
   OAuthDeviceAuthPollResult,
   OAuthDeviceAuthPollResultBase,
   OAuthDeviceAuthStartResult,
-  OAuthRefreshResult,
   OAuthTokenResult,
   OAuthTokenResultBase,
 };

--- a/turbo/packages/connectors/src/auth-providers/oauth/types.ts
+++ b/turbo/packages/connectors/src/auth-providers/oauth/types.ts
@@ -4,15 +4,11 @@ import type {
   ConnectorAuthMethodIds,
   ConnectorAuthCodeGrantAuthMethodId,
   ConnectorDeviceAuthGrantAuthMethodId,
-  ConnectorAuthMethodIdsByAccessKind,
   ConnectorAuthMethodIdsByRevokeKind,
   ConnectorGrantOutputValues,
-  ConnectorRefreshInputValues,
-  ConnectorRefreshOutputValues,
   ConnectorRevokeInputValues,
   ConnectorType,
   DeviceAuthGrantConnectorType,
-  RefreshTokenAccessConnectorType,
   TokenRevokeConnectorType,
 } from "@vm0/connectors/connectors";
 import type {
@@ -203,28 +199,6 @@ export type ConnectorAuthCodeExchangeArgs<
   ConnectorAuthMethodClientArgs<T, Method> & {
     readonly authCodeGrant: ConnectorAuthCodeGrantConfig;
   };
-
-export type ConnectorAuthProviderRefreshArgs<
-  T extends RefreshTokenAccessConnectorType,
-  Method extends ConnectorAuthMethodIdsByAccessKind<T, "refresh-token"> =
-    ConnectorAuthMethodIdsByAccessKind<T, "refresh-token">,
-> = ConnectorAuthMethodClientArgs<T, Method> & {
-  readonly inputs: ConnectorRefreshInputValues<T, Method>;
-  readonly signal: AbortSignal;
-};
-
-export interface ConnectorAuthProviderRefreshResultBase {
-  readonly outputs: Readonly<Record<string, string | undefined>>;
-  readonly expiresIn?: number;
-}
-
-export interface ConnectorAuthProviderRefreshResult<
-  T extends RefreshTokenAccessConnectorType,
-  Method extends ConnectorAuthMethodIdsByAccessKind<T, "refresh-token"> =
-    ConnectorAuthMethodIdsByAccessKind<T, "refresh-token">,
-> extends ConnectorAuthProviderRefreshResultBase {
-  readonly outputs: ConnectorRefreshOutputValues<T, Method>;
-}
 
 export type ConnectorAuthProviderRevokeArgs<
   T extends TokenRevokeConnectorType,

--- a/turbo/packages/connectors/src/auth-providers/types.ts
+++ b/turbo/packages/connectors/src/auth-providers/types.ts
@@ -6,20 +6,23 @@ import type {
   ConnectorAuthMethodIdsByRevokeKind,
   ConnectorDeviceAuthGrantAuthMethodId,
   ConnectorAuthProviderType,
+  ConnectorRefreshInputValues,
+  ConnectorRefreshOutputValues,
   ConnectorType,
   DeviceAuthGrantConnectorType,
   RefreshTokenAccessConnectorType,
   TokenRevokeConnectorType,
 } from "../connectors";
-import type { StaticConnectorAuthClient } from "../connector-utils";
+import type {
+  ConnectorAuthClientForMethod,
+  StaticConnectorAuthClient,
+} from "../connector-utils";
 import type {
   AuthUrlResult,
   ConnectorAuthCodeAuthorizeArgs,
   ConnectorDeviceAuthorizationPollArgs,
   ConnectorDeviceAuthorizationStartArgs,
   ConnectorAuthCodeExchangeArgs,
-  ConnectorAuthProviderRefreshArgs,
-  ConnectorAuthProviderRefreshResult,
   ConnectorAuthProviderRevokeArgs,
   OAuthDeviceAuthPollResult,
   OAuthDeviceAuthStartResult,
@@ -61,6 +64,29 @@ export interface DeviceAuthGrantProvider<
 
 export interface NoneAccessProvider {
   readonly kind: "none";
+}
+
+export type ConnectorAuthProviderRefreshArgs<
+  T extends RefreshTokenAccessConnectorType,
+  Method extends ConnectorAuthMethodIdsByAccessKind<T, "refresh-token"> =
+    ConnectorAuthMethodIdsByAccessKind<T, "refresh-token">,
+> = {
+  readonly authClient: ConnectorAuthClientForMethod<T, Method>;
+  readonly inputs: ConnectorRefreshInputValues<T, Method>;
+  readonly signal: AbortSignal;
+};
+
+export interface ConnectorAuthProviderRefreshResultBase {
+  readonly outputs: Readonly<Record<string, string | undefined>>;
+  readonly expiresIn?: number;
+}
+
+export interface ConnectorAuthProviderRefreshResult<
+  T extends RefreshTokenAccessConnectorType,
+  Method extends ConnectorAuthMethodIdsByAccessKind<T, "refresh-token"> =
+    ConnectorAuthMethodIdsByAccessKind<T, "refresh-token">,
+> extends ConnectorAuthProviderRefreshResultBase {
+  readonly outputs: ConnectorRefreshOutputValues<T, Method>;
 }
 
 export interface RefreshTokenAccessProvider<


### PR DESCRIPTION
## Summary

- Move generic connector refresh access provider types from the OAuth protocol type module into the generic auth-provider type layer.
- Keep `OAuthRefreshResult` scoped to OAuth protocol modules and stop exporting it from the generic `@vm0/connectors/auth-providers` facade.
- Preserve connector refresh runtime behavior, provider config, storage metadata, and persisted secret names.

Closes #16031

## Verification

- `pnpm -F @vm0/connectors check-types`
- `pnpm -F @vm0/connectors lint`
- `pnpm -F @vm0/connectors exec vitest src/__tests__/connectors.test.ts`
- `pnpm -F @vm0/connectors exec vitest src/auth-providers/oauth/providers/__tests__`

Full pre-commit `pnpm check-types` currently fails in unrelated web presentation files on this base:

- `apps/web/app/[locale]/presentation/PresentationClient.tsx(110,36): Parameter 'item' implicitly has an 'any' type`
- `apps/web/app/[locale]/presentation/data.ts(4,8): Cannot find module '@vm0/core' or its corresponding type declarations`
- `apps/web/app/[locale]/presentation/page.tsx(60,46): Parameter 'item' implicitly has an 'any' type`
- `apps/web/app/[locale]/presentation/page.tsx(60,52): Parameter 'i' implicitly has an 'any' type`
