### PR TITLE
refactor: separate connector grant result types

### DIFF
--- a/turbo/apps/api/src/signals/routes/__tests__/connectors-type-callback.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/connectors-type-callback.test.ts
@@ -19,7 +19,7 @@ import {
   testOauthProvider,
 } from "@vm0/connectors/auth-providers/oauth/providers/test-oauth-provider";
 import type { AuthCodeConnectorAuthProvider } from "@vm0/connectors/auth-providers/types";
-import type { OAuthTokenResultBase } from "@vm0/connectors/auth-providers";
+import type { ConnectorAuthProviderGrantResultBase } from "@vm0/connectors/auth-providers";
 import { agentComposes } from "@vm0/db/schema/agent-compose";
 import { connectors } from "@vm0/db/schema/connector";
 import { connectorOauthStates } from "@vm0/db/schema/connector-oauth-state";
@@ -2283,7 +2283,7 @@ describe("GET /api/connectors/:type/callback", () => {
       outputs: {
         initialRefreshToken: "dynamic-refresh-token",
       },
-    } satisfies OAuthTokenResultBase;
+    } satisfies ConnectorAuthProviderGrantResultBase;
     testOauthApiProvider.grant.exchangeCode = () => {
       return Promise.resolve(
         malformedResult as DynamicTestOAuthApiExchangeResult,

--- a/turbo/apps/api/src/signals/routes/__tests__/connectors-type-callback.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/connectors-type-callback.test.ts
@@ -19,7 +19,7 @@ import {
   testOauthProvider,
 } from "@vm0/connectors/auth-providers/oauth/providers/test-oauth-provider";
 import type { AuthCodeConnectorAuthProvider } from "@vm0/connectors/auth-providers/types";
-import type { ConnectorAuthProviderGrantResultBase } from "@vm0/connectors/auth-providers";
+import type { exchangeConnectorAuthCode } from "@vm0/connectors/auth-providers";
 import { agentComposes } from "@vm0/db/schema/agent-compose";
 import { connectors } from "@vm0/db/schema/connector";
 import { connectorOauthStates } from "@vm0/db/schema/connector-oauth-state";
@@ -44,6 +44,10 @@ import { decryptSecretForTests } from "./helpers/encrypt-secret";
 const context = testContext();
 const store = createStore();
 const mocks = createZeroRouteMocks(context);
+
+type ConnectorAuthCodeExchangeResult = Awaited<
+  ReturnType<typeof exchangeConnectorAuthCode>
+>;
 
 const BASE_URL = "https://app.vm0.test";
 const API_ORIGIN = "https://api.vm0.ai";
@@ -2283,7 +2287,7 @@ describe("GET /api/connectors/:type/callback", () => {
       outputs: {
         initialRefreshToken: "dynamic-refresh-token",
       },
-    } satisfies ConnectorAuthProviderGrantResultBase;
+    } satisfies ConnectorAuthCodeExchangeResult;
     testOauthApiProvider.grant.exchangeCode = () => {
       return Promise.resolve(
         malformedResult as DynamicTestOAuthApiExchangeResult,

--- a/turbo/apps/api/src/signals/routes/connector-auth-code-start.ts
+++ b/turbo/apps/api/src/signals/routes/connector-auth-code-start.ts
@@ -12,10 +12,8 @@ import type {
   ConnectorAuthMethodId,
   ConnectorType,
 } from "@vm0/connectors/connectors";
-import {
-  buildConnectorAuthCodeAuthorizationUrl,
-  type AuthUrlResult,
-} from "@vm0/connectors/auth-providers";
+import { buildConnectorAuthCodeAuthorizationUrl } from "@vm0/connectors/auth-providers";
+import type { AuthUrlResult } from "@vm0/connectors/auth-providers/oauth/types";
 
 import { generateConnectorOAuthState } from "./connector-oauth-route-state";
 

--- a/turbo/apps/api/src/signals/routes/connectors-type-callback.ts
+++ b/turbo/apps/api/src/signals/routes/connectors-type-callback.ts
@@ -13,10 +13,7 @@ import {
   type AuthCodeGrantConnectorType,
   type ConnectorAuthCodeGrantAuthMethodId,
 } from "@vm0/connectors/connectors";
-import {
-  exchangeConnectorAuthCode,
-  type ConnectorAuthProviderGrantResultBase,
-} from "@vm0/connectors/auth-providers";
+import { exchangeConnectorAuthCode } from "@vm0/connectors/auth-providers";
 
 import { request$ } from "../context/hono";
 import { pathParamsOf, queryOf } from "../context/request";
@@ -48,6 +45,10 @@ type CallbackIdentity = {
   readonly userId: string;
   readonly orgId: string;
 };
+
+type ConnectorAuthCodeExchangeResult = Awaited<
+  ReturnType<typeof exchangeConnectorAuthCode>
+>;
 
 type AuthCodeCallbackMethodRef<
   Type extends AuthCodeGrantConnectorType = AuthCodeGrantConnectorType,
@@ -157,7 +158,7 @@ async function exchangeTokenForConnector<
     readonly codeVerifier: string | undefined;
     readonly oauthContext: string | undefined;
   },
-): Promise<ConnectorAuthProviderGrantResultBase> {
+): Promise<ConnectorAuthCodeExchangeResult> {
   const authClient = resolveConnectorAuthClientForMethod(
     args.connectorType,
     args.authMethod,
@@ -331,7 +332,7 @@ async function linkGithubIntegrationAfterConnectorConnect(args: {
   readonly db: Db;
   readonly connectorType: AuthCodeGrantConnectorType;
   readonly identity: CallbackIdentity;
-  readonly token: ConnectorAuthProviderGrantResultBase;
+  readonly token: ConnectorAuthCodeExchangeResult;
   readonly signal: AbortSignal;
 }): Promise<void> {
   if (args.connectorType !== "github") {

--- a/turbo/apps/api/src/signals/routes/connectors-type-callback.ts
+++ b/turbo/apps/api/src/signals/routes/connectors-type-callback.ts
@@ -15,7 +15,7 @@ import {
 } from "@vm0/connectors/connectors";
 import {
   exchangeConnectorAuthCode,
-  type OAuthTokenResultBase,
+  type ConnectorAuthProviderGrantResultBase,
 } from "@vm0/connectors/auth-providers";
 
 import { request$ } from "../context/hono";
@@ -157,7 +157,7 @@ async function exchangeTokenForConnector<
     readonly codeVerifier: string | undefined;
     readonly oauthContext: string | undefined;
   },
-): Promise<OAuthTokenResultBase> {
+): Promise<ConnectorAuthProviderGrantResultBase> {
   const authClient = resolveConnectorAuthClientForMethod(
     args.connectorType,
     args.authMethod,
@@ -331,7 +331,7 @@ async function linkGithubIntegrationAfterConnectorConnect(args: {
   readonly db: Db;
   readonly connectorType: AuthCodeGrantConnectorType;
   readonly identity: CallbackIdentity;
-  readonly token: OAuthTokenResultBase;
+  readonly token: ConnectorAuthProviderGrantResultBase;
   readonly signal: AbortSignal;
 }): Promise<void> {
   if (args.connectorType !== "github") {

--- a/turbo/apps/api/src/signals/services/github-oauth.service.ts
+++ b/turbo/apps/api/src/signals/services/github-oauth.service.ts
@@ -7,10 +7,8 @@ import {
 } from "node:crypto";
 
 import { and, eq } from "drizzle-orm";
-import {
-  buildConnectorAuthCodeAuthorizationUrl,
-  type AuthUrlResult,
-} from "@vm0/connectors/auth-providers";
+import { buildConnectorAuthCodeAuthorizationUrl } from "@vm0/connectors/auth-providers";
+import type { AuthUrlResult } from "@vm0/connectors/auth-providers/oauth/types";
 import {
   connectorAuthMethodHasGrantKind,
   resolveConnectorAuthClientForMethod,

--- a/turbo/packages/connectors/src/auth-providers/connector-auth.ts
+++ b/turbo/packages/connectors/src/auth-providers/connector-auth.ts
@@ -29,6 +29,9 @@ import {
 } from "@vm0/connectors/connector-utils";
 import type {
   AuthCodeConnectorAuthProvider,
+  ConnectorAuthProviderGrantResultBase,
+  ConnectorAuthProviderGrantResult,
+  ConnectorAuthProviderGrantUserInfo,
   ConnectorAuthProviderRefreshResultBase,
   ConnectorAuthProviderRefreshResult,
   DeviceAuthConnectorAuthProvider,
@@ -40,8 +43,6 @@ import {
   type OAuthDeviceAuthPollResult,
   type OAuthDeviceAuthPollResultBase,
   type OAuthDeviceAuthStartResult,
-  type OAuthTokenResult,
-  type OAuthTokenResultBase,
 } from "./oauth/types";
 import { providerEnvFromObject, type ProviderEnv } from "./provider-env";
 import { ahrefsProvider } from "./oauth/providers/ahrefs-provider";
@@ -101,13 +102,14 @@ import {
 
 export type {
   AuthUrlResult,
+  ConnectorAuthProviderGrantResultBase,
+  ConnectorAuthProviderGrantResult,
+  ConnectorAuthProviderGrantUserInfo,
   ConnectorAuthProviderRefreshResultBase,
   ConnectorAuthProviderRefreshResult,
   OAuthDeviceAuthPollResult,
   OAuthDeviceAuthPollResultBase,
   OAuthDeviceAuthStartResult,
-  OAuthTokenResult,
-  OAuthTokenResultBase,
 };
 export type { ProviderEnv };
 export { providerEnvFromObject };
@@ -528,10 +530,10 @@ export function exchangeConnectorAuthCode<
   readonly state: string | undefined;
   readonly codeVerifier: string | undefined;
   readonly oauthContext: string | undefined;
-}): Promise<OAuthTokenResult<T, Method>>;
+}): Promise<ConnectorAuthProviderGrantResult<T, Method>>;
 export function exchangeConnectorAuthCode(
   args: ConnectorAuthCodeExchangeCallArgs,
-): Promise<OAuthTokenResultBase>;
+): Promise<ConnectorAuthProviderGrantResultBase>;
 export async function exchangeConnectorAuthCode<
   T extends AuthCodeGrantConnectorType,
   Method extends ConnectorAuthCodeGrantAuthMethodId<T>,
@@ -544,7 +546,7 @@ export async function exchangeConnectorAuthCode<
   readonly state: string | undefined;
   readonly codeVerifier: string | undefined;
   readonly oauthContext: string | undefined;
-}): Promise<OAuthTokenResult<T, Method>> {
+}): Promise<ConnectorAuthProviderGrantResult<T, Method>> {
   const provider = connectorAuthCodeGrantProviderFor(
     args.type,
     args.authMethod,

--- a/turbo/packages/connectors/src/auth-providers/connector-auth.ts
+++ b/turbo/packages/connectors/src/auth-providers/connector-auth.ts
@@ -102,12 +102,8 @@ import {
 } from "./oauth/providers/test-oauth-device-provider";
 
 export type {
-  AuthUrlResult,
   ConnectorAuthProviderRefreshResultBase,
   ConnectorAuthProviderRefreshResult,
-  OAuthDeviceAuthPollResult,
-  OAuthDeviceAuthPollResultBase,
-  OAuthDeviceAuthStartResult,
 };
 export type { ProviderEnv };
 export { providerEnvFromObject };

--- a/turbo/packages/connectors/src/auth-providers/connector-auth.ts
+++ b/turbo/packages/connectors/src/auth-providers/connector-auth.ts
@@ -29,15 +29,16 @@ import {
 } from "@vm0/connectors/connector-utils";
 import type {
   AuthCodeConnectorAuthProvider,
-  ConnectorAuthProviderGrantResultBase,
-  ConnectorAuthProviderGrantResult,
-  ConnectorAuthProviderGrantUserInfo,
   ConnectorAuthProviderRefreshResultBase,
   ConnectorAuthProviderRefreshResult,
   DeviceAuthConnectorAuthProvider,
   RefreshTokenAccessProvider,
   TokenRevokeProvider,
 } from "./types";
+import type {
+  ConnectorAuthProviderGrantResult,
+  ConnectorAuthProviderGrantResultForMethod,
+} from "./grant-result";
 import {
   type AuthUrlResult,
   type OAuthDeviceAuthPollResult,
@@ -102,9 +103,6 @@ import {
 
 export type {
   AuthUrlResult,
-  ConnectorAuthProviderGrantResultBase,
-  ConnectorAuthProviderGrantResult,
-  ConnectorAuthProviderGrantUserInfo,
   ConnectorAuthProviderRefreshResultBase,
   ConnectorAuthProviderRefreshResult,
   OAuthDeviceAuthPollResult,
@@ -530,10 +528,10 @@ export function exchangeConnectorAuthCode<
   readonly state: string | undefined;
   readonly codeVerifier: string | undefined;
   readonly oauthContext: string | undefined;
-}): Promise<ConnectorAuthProviderGrantResult<T, Method>>;
+}): Promise<ConnectorAuthProviderGrantResultForMethod<T, Method>>;
 export function exchangeConnectorAuthCode(
   args: ConnectorAuthCodeExchangeCallArgs,
-): Promise<ConnectorAuthProviderGrantResultBase>;
+): Promise<ConnectorAuthProviderGrantResult>;
 export async function exchangeConnectorAuthCode<
   T extends AuthCodeGrantConnectorType,
   Method extends ConnectorAuthCodeGrantAuthMethodId<T>,
@@ -546,7 +544,7 @@ export async function exchangeConnectorAuthCode<
   readonly state: string | undefined;
   readonly codeVerifier: string | undefined;
   readonly oauthContext: string | undefined;
-}): Promise<ConnectorAuthProviderGrantResult<T, Method>> {
+}): Promise<ConnectorAuthProviderGrantResultForMethod<T, Method>> {
   const provider = connectorAuthCodeGrantProviderFor(
     args.type,
     args.authMethod,

--- a/turbo/packages/connectors/src/auth-providers/grant-result.ts
+++ b/turbo/packages/connectors/src/auth-providers/grant-result.ts
@@ -28,11 +28,6 @@ export interface ConnectorAuthProviderGrantResult<
   readonly extraConnectorSecrets?: Readonly<Record<string, string>>;
 }
 
-export type ConnectorAuthProviderGrantResultFields = Pick<
-  ConnectorAuthProviderGrantResult,
-  "expiresIn" | "scopes" | "userInfo" | "extraConnectorSecrets"
->;
-
 type ConnectorAuthProviderGrantMethodId<
   T extends AuthCodeGrantConnectorType | DeviceAuthGrantConnectorType,
 > = ConnectorAuthMethodIdsByGrantKind<T, "auth-code" | "device-auth">;

--- a/turbo/packages/connectors/src/auth-providers/grant-result.ts
+++ b/turbo/packages/connectors/src/auth-providers/grant-result.ts
@@ -35,7 +35,6 @@ type ConnectorAuthProviderGrantMethodId<
 export type ConnectorAuthProviderGrantResultForMethod<
   T extends AuthCodeGrantConnectorType | DeviceAuthGrantConnectorType,
   Method extends ConnectorAuthMethodIds<T>,
-> =
-  Method extends ConnectorAuthProviderGrantMethodId<T>
-    ? ConnectorAuthProviderGrantResult<ConnectorGrantOutputValues<T, Method>>
-    : never;
+> = [Method] extends [ConnectorAuthProviderGrantMethodId<T>]
+  ? ConnectorAuthProviderGrantResult<ConnectorGrantOutputValues<T, Method>>
+  : never;

--- a/turbo/packages/connectors/src/auth-providers/grant-result.ts
+++ b/turbo/packages/connectors/src/auth-providers/grant-result.ts
@@ -1,6 +1,7 @@
 import type {
   AuthCodeGrantConnectorType,
   ConnectorAuthMethodIds,
+  ConnectorAuthMethodIdsByGrantKind,
   ConnectorGrantOutputValues,
   DeviceAuthGrantConnectorType,
 } from "../connectors";
@@ -26,7 +27,14 @@ export interface ConnectorAuthProviderGrantResult<
   readonly extraConnectorSecrets?: Readonly<Record<string, string>>;
 }
 
+type ConnectorAuthProviderGrantMethodId<
+  T extends AuthCodeGrantConnectorType | DeviceAuthGrantConnectorType,
+> = ConnectorAuthMethodIdsByGrantKind<T, "auth-code" | "device-auth">;
+
 export type ConnectorAuthProviderGrantResultForMethod<
   T extends AuthCodeGrantConnectorType | DeviceAuthGrantConnectorType,
   Method extends ConnectorAuthMethodIds<T>,
-> = ConnectorAuthProviderGrantResult<ConnectorGrantOutputValues<T, Method>>;
+> =
+  Method extends ConnectorAuthProviderGrantMethodId<T>
+    ? ConnectorAuthProviderGrantResult<ConnectorGrantOutputValues<T, Method>>
+    : never;

--- a/turbo/packages/connectors/src/auth-providers/grant-result.ts
+++ b/turbo/packages/connectors/src/auth-providers/grant-result.ts
@@ -11,17 +11,22 @@ export interface ConnectorAuthProviderGrantUserInfo {
   readonly email: string | null;
 }
 
-export interface ConnectorAuthProviderGrantResultBase {
-  readonly outputs: Readonly<Record<string, string | null | undefined>>;
+export type ConnectorAuthProviderGrantOutputValues = Readonly<
+  Record<string, string | null | undefined>
+>;
+
+export interface ConnectorAuthProviderGrantResult<
+  Outputs extends ConnectorAuthProviderGrantOutputValues =
+    ConnectorAuthProviderGrantOutputValues,
+> {
+  readonly outputs: Outputs;
   readonly expiresIn?: number;
   readonly scopes: readonly string[];
   readonly userInfo: ConnectorAuthProviderGrantUserInfo;
   readonly extraConnectorSecrets?: Readonly<Record<string, string>>;
 }
 
-export interface ConnectorAuthProviderGrantResult<
+export type ConnectorAuthProviderGrantResultForMethod<
   T extends AuthCodeGrantConnectorType | DeviceAuthGrantConnectorType,
   Method extends ConnectorAuthMethodIds<T>,
-> extends ConnectorAuthProviderGrantResultBase {
-  readonly outputs: ConnectorGrantOutputValues<T, Method>;
-}
+> = ConnectorAuthProviderGrantResult<ConnectorGrantOutputValues<T, Method>>;

--- a/turbo/packages/connectors/src/auth-providers/grant-result.ts
+++ b/turbo/packages/connectors/src/auth-providers/grant-result.ts
@@ -1,0 +1,27 @@
+import type {
+  AuthCodeGrantConnectorType,
+  ConnectorAuthMethodIds,
+  ConnectorGrantOutputValues,
+  DeviceAuthGrantConnectorType,
+} from "../connectors";
+
+export interface ConnectorAuthProviderGrantUserInfo {
+  readonly id: string;
+  readonly username: string | null;
+  readonly email: string | null;
+}
+
+export interface ConnectorAuthProviderGrantResultBase {
+  readonly outputs: Readonly<Record<string, string | null | undefined>>;
+  readonly expiresIn?: number;
+  readonly scopes: readonly string[];
+  readonly userInfo: ConnectorAuthProviderGrantUserInfo;
+  readonly extraConnectorSecrets?: Readonly<Record<string, string>>;
+}
+
+export interface ConnectorAuthProviderGrantResult<
+  T extends AuthCodeGrantConnectorType | DeviceAuthGrantConnectorType,
+  Method extends ConnectorAuthMethodIds<T>,
+> extends ConnectorAuthProviderGrantResultBase {
+  readonly outputs: ConnectorGrantOutputValues<T, Method>;
+}

--- a/turbo/packages/connectors/src/auth-providers/grant-result.ts
+++ b/turbo/packages/connectors/src/auth-providers/grant-result.ts
@@ -28,6 +28,11 @@ export interface ConnectorAuthProviderGrantResult<
   readonly extraConnectorSecrets?: Readonly<Record<string, string>>;
 }
 
+export type ConnectorAuthProviderGrantResultFields = Pick<
+  ConnectorAuthProviderGrantResult,
+  "expiresIn" | "scopes" | "userInfo" | "extraConnectorSecrets"
+>;
+
 type ConnectorAuthProviderGrantMethodId<
   T extends AuthCodeGrantConnectorType | DeviceAuthGrantConnectorType,
 > = ConnectorAuthMethodIdsByGrantKind<T, "auth-code" | "device-auth">;

--- a/turbo/packages/connectors/src/auth-providers/grant-result.ts
+++ b/turbo/packages/connectors/src/auth-providers/grant-result.ts
@@ -21,6 +21,7 @@ export interface ConnectorAuthProviderGrantResult<
     ConnectorAuthProviderGrantOutputValues,
 > {
   readonly outputs: Outputs;
+  /** Seconds until the granted credentials expire. */
   readonly expiresIn?: number;
   readonly scopes: readonly string[];
   readonly userInfo: ConnectorAuthProviderGrantUserInfo;

--- a/turbo/packages/connectors/src/auth-providers/oauth/providers/base44.ts
+++ b/turbo/packages/connectors/src/auth-providers/oauth/providers/base44.ts
@@ -5,8 +5,8 @@ import type {
   OAuthDeviceAuthIncompleteResult,
   OAuthDeviceAuthStartResult,
   OAuthRefreshResult,
-  OAuthTokenUserInfo,
 } from "../types";
+import type { ConnectorAuthProviderGrantUserInfo } from "../../grant-result";
 import { throwOAuthError } from "../error";
 
 const BASE44_DEVICE_AUTH_URL = "https://app.base44.com/oauth/device/code";
@@ -217,7 +217,7 @@ export async function refreshBase44Token(args: {
 
 async function fetchBase44UserInfo(
   accessToken: string,
-): Promise<OAuthTokenUserInfo> {
+): Promise<ConnectorAuthProviderGrantUserInfo> {
   const response = await fetch(BASE44_USERINFO_URL, {
     headers: {
       Authorization: `Bearer ${accessToken}`,

--- a/turbo/packages/connectors/src/auth-providers/oauth/providers/slock.ts
+++ b/turbo/packages/connectors/src/auth-providers/oauth/providers/slock.ts
@@ -6,8 +6,8 @@ import type {
   OAuthDeviceAuthIncompleteResult,
   OAuthDeviceAuthStartResult,
   OAuthRefreshResult,
-  OAuthTokenUserInfo,
 } from "../types";
+import type { ConnectorAuthProviderGrantUserInfo } from "../../grant-result";
 
 const SLOCK_API_BASE_URL = "https://api.slock.ai";
 const SLOCK_DEVICE_AUTH_URL = `${SLOCK_API_BASE_URL}/api/auth/device/authorize`;
@@ -249,7 +249,7 @@ function selectSlockServer(
 async function fetchSlockUserInfo(
   accessToken: string,
   fallbackUserId: string | undefined,
-): Promise<OAuthTokenUserInfo> {
+): Promise<ConnectorAuthProviderGrantUserInfo> {
   const response = await fetch(`${SLOCK_API_BASE_URL}/api/auth/me`, {
     headers: {
       Authorization: `Bearer ${accessToken}`,
@@ -381,7 +381,7 @@ export async function pollSlockDeviceAuth(args: {
   if (!("ok" in serverIdResult)) {
     return serverIdResult;
   }
-  let userInfo: OAuthTokenUserInfo;
+  let userInfo: ConnectorAuthProviderGrantUserInfo;
   try {
     userInfo = await fetchSlockUserInfo(accessToken, data.data.userId);
   } catch {

--- a/turbo/packages/connectors/src/auth-providers/oauth/providers/test-oauth-device.ts
+++ b/turbo/packages/connectors/src/auth-providers/oauth/providers/test-oauth-device.ts
@@ -4,7 +4,7 @@ import type {
   OAuthDeviceAuthIncompleteResult,
   OAuthDeviceAuthStartResult,
 } from "../types";
-import type { ConnectorAuthProviderGrantResultFields } from "../../grant-result";
+import type { ConnectorAuthProviderGrantResult } from "../../grant-result";
 import { throwOAuthError } from "../error";
 import {
   resolveTestOAuthProviderUrl,
@@ -46,11 +46,9 @@ const tokenErrorResponseSchema = z.object({
   error_description: z.string().optional(),
 });
 
-type TestOAuthDeviceTokenResult = ConnectorAuthProviderGrantResultFields & {
-  readonly outputs: {
-    readonly accessToken: string;
-  };
-};
+type TestOAuthDeviceTokenResult = ConnectorAuthProviderGrantResult<{
+  readonly accessToken: string;
+}>;
 
 type TestOAuthDevicePollResult =
   | OAuthDeviceAuthIncompleteResult

--- a/turbo/packages/connectors/src/auth-providers/oauth/providers/test-oauth-device.ts
+++ b/turbo/packages/connectors/src/auth-providers/oauth/providers/test-oauth-device.ts
@@ -3,8 +3,8 @@ import { z } from "zod";
 import type {
   OAuthDeviceAuthIncompleteResult,
   OAuthDeviceAuthStartResult,
-  OAuthTokenResultFields,
 } from "../types";
+import type { ConnectorAuthProviderGrantResultFields } from "../../grant-result";
 import { throwOAuthError } from "../error";
 import {
   resolveTestOAuthProviderUrl,
@@ -46,7 +46,7 @@ const tokenErrorResponseSchema = z.object({
   error_description: z.string().optional(),
 });
 
-type TestOAuthDeviceTokenResult = OAuthTokenResultFields & {
+type TestOAuthDeviceTokenResult = ConnectorAuthProviderGrantResultFields & {
   readonly outputs: {
     readonly accessToken: string;
   };

--- a/turbo/packages/connectors/src/auth-providers/oauth/providers/test-oauth-provider.ts
+++ b/turbo/packages/connectors/src/auth-providers/oauth/providers/test-oauth-provider.ts
@@ -10,21 +10,20 @@ import {
   refreshTestOAuthToken,
 } from "./test-oauth";
 import { oauthRefreshResultToProviderResult } from "../types";
-import type { ConnectorAuthProviderGrantResultFields } from "../../grant-result";
+import type {
+  ConnectorAuthProviderGrantResult,
+  ConnectorAuthProviderGrantUserInfo,
+} from "../../grant-result";
 
-type TestOAuthGrantResult = ConnectorAuthProviderGrantResultFields & {
-  readonly outputs: {
-    readonly accessToken: string;
-    readonly refreshToken: string | null;
-  };
-};
+type TestOAuthGrantResult = ConnectorAuthProviderGrantResult<{
+  readonly accessToken: string;
+  readonly refreshToken: string | null;
+}>;
 
-type TestOAuthApiGrantResult = ConnectorAuthProviderGrantResultFields & {
-  readonly outputs: {
-    readonly initialAccessToken: string;
-    readonly initialRefreshToken: string | null;
-  };
-};
+type TestOAuthApiGrantResult = ConnectorAuthProviderGrantResult<{
+  readonly initialAccessToken: string;
+  readonly initialRefreshToken: string | null;
+}>;
 
 interface TestOAuthApiRefreshResult {
   readonly outputs: {
@@ -39,7 +38,7 @@ interface TestOAuthTokenExchange {
   readonly refreshToken: string | null;
   readonly expiresIn: number | undefined;
   readonly scopes: string[];
-  readonly userInfo: ConnectorAuthProviderGrantResultFields["userInfo"];
+  readonly userInfo: ConnectorAuthProviderGrantUserInfo;
 }
 
 async function exchangeTestOauthToken(args: {

--- a/turbo/packages/connectors/src/auth-providers/oauth/providers/test-oauth-provider.ts
+++ b/turbo/packages/connectors/src/auth-providers/oauth/providers/test-oauth-provider.ts
@@ -9,19 +9,17 @@ import {
   fetchTestOAuthUserInfo,
   refreshTestOAuthToken,
 } from "./test-oauth";
-import {
-  oauthRefreshResultToProviderResult,
-  type OAuthTokenResultFields,
-} from "../types";
+import { oauthRefreshResultToProviderResult } from "../types";
+import type { ConnectorAuthProviderGrantResultFields } from "../../grant-result";
 
-type TestOAuthGrantResult = OAuthTokenResultFields & {
+type TestOAuthGrantResult = ConnectorAuthProviderGrantResultFields & {
   readonly outputs: {
     readonly accessToken: string;
     readonly refreshToken: string | null;
   };
 };
 
-type TestOAuthApiGrantResult = OAuthTokenResultFields & {
+type TestOAuthApiGrantResult = ConnectorAuthProviderGrantResultFields & {
   readonly outputs: {
     readonly initialAccessToken: string;
     readonly initialRefreshToken: string | null;
@@ -41,7 +39,7 @@ interface TestOAuthTokenExchange {
   readonly refreshToken: string | null;
   readonly expiresIn: number | undefined;
   readonly scopes: string[];
-  readonly userInfo: OAuthTokenResultFields["userInfo"];
+  readonly userInfo: ConnectorAuthProviderGrantResultFields["userInfo"];
 }
 
 async function exchangeTestOauthToken(args: {

--- a/turbo/packages/connectors/src/auth-providers/oauth/types.ts
+++ b/turbo/packages/connectors/src/auth-providers/oauth/types.ts
@@ -16,14 +16,13 @@ import type {
 } from "@vm0/connectors/connector-utils";
 import type {
   ConnectorAuthProviderGrantResult,
-  ConnectorAuthProviderGrantResultBase,
+  ConnectorAuthProviderGrantResultForMethod,
 } from "../grant-result";
 
-export type OAuthTokenUserInfo =
-  ConnectorAuthProviderGrantResultBase["userInfo"];
+export type OAuthTokenUserInfo = ConnectorAuthProviderGrantResult["userInfo"];
 
 export type OAuthTokenResultFields = Pick<
-  ConnectorAuthProviderGrantResultBase,
+  ConnectorAuthProviderGrantResult,
   "expiresIn" | "scopes" | "userInfo" | "extraConnectorSecrets"
 >;
 
@@ -102,7 +101,7 @@ export interface OAuthDeviceAuthSlowDownResult {
 
 export interface OAuthDeviceAuthCompleteResultBase {
   readonly status: "complete";
-  readonly token: ConnectorAuthProviderGrantResultBase;
+  readonly token: ConnectorAuthProviderGrantResult;
 }
 
 export interface OAuthDeviceAuthCompleteResult<
@@ -110,7 +109,7 @@ export interface OAuthDeviceAuthCompleteResult<
   Method extends ConnectorDeviceAuthGrantAuthMethodId<T>,
 > {
   readonly status: "complete";
-  readonly token: ConnectorAuthProviderGrantResult<T, Method>;
+  readonly token: ConnectorAuthProviderGrantResultForMethod<T, Method>;
 }
 
 export interface OAuthDeviceAuthDeniedResult {

--- a/turbo/packages/connectors/src/auth-providers/oauth/types.ts
+++ b/turbo/packages/connectors/src/auth-providers/oauth/types.ts
@@ -19,13 +19,6 @@ import type {
   ConnectorAuthProviderGrantResultForMethod,
 } from "../grant-result";
 
-export type OAuthTokenUserInfo = ConnectorAuthProviderGrantResult["userInfo"];
-
-export type OAuthTokenResultFields = Pick<
-  ConnectorAuthProviderGrantResult,
-  "expiresIn" | "scopes" | "userInfo" | "extraConnectorSecrets"
->;
-
 /**
  * Result from buildAuthUrl when PKCE is required.
  * Providers that need PKCE return { url, codeVerifier } instead of a plain string.

--- a/turbo/packages/connectors/src/auth-providers/oauth/types.ts
+++ b/turbo/packages/connectors/src/auth-providers/oauth/types.ts
@@ -19,18 +19,13 @@ import type {
   ConnectorAuthProviderGrantResultBase,
 } from "../grant-result";
 
-export interface OAuthTokenUserInfo {
-  readonly id: string;
-  readonly username: string | null;
-  readonly email: string | null;
-}
+export type OAuthTokenUserInfo =
+  ConnectorAuthProviderGrantResultBase["userInfo"];
 
-export interface OAuthTokenResultFields {
-  expiresIn?: number; // seconds until access token expires
-  scopes: string[];
-  userInfo: OAuthTokenUserInfo;
-  extraConnectorSecrets?: Readonly<Record<string, string>>;
-}
+export type OAuthTokenResultFields = Pick<
+  ConnectorAuthProviderGrantResultBase,
+  "expiresIn" | "scopes" | "userInfo" | "extraConnectorSecrets"
+>;
 
 /**
  * Result from buildAuthUrl when PKCE is required.

--- a/turbo/packages/connectors/src/auth-providers/oauth/types.ts
+++ b/turbo/packages/connectors/src/auth-providers/oauth/types.ts
@@ -5,7 +5,6 @@ import type {
   ConnectorAuthCodeGrantAuthMethodId,
   ConnectorDeviceAuthGrantAuthMethodId,
   ConnectorAuthMethodIdsByRevokeKind,
-  ConnectorGrantOutputValues,
   ConnectorRevokeInputValues,
   ConnectorType,
   DeviceAuthGrantConnectorType,
@@ -15,6 +14,10 @@ import type {
   ConnectorAuthClientForMethod,
   ConnectorAuthClientIdentityForMethod,
 } from "@vm0/connectors/connector-utils";
+import type {
+  ConnectorAuthProviderGrantResult,
+  ConnectorAuthProviderGrantResultBase,
+} from "../grant-result";
 
 export interface OAuthTokenUserInfo {
   readonly id: string;
@@ -28,17 +31,6 @@ export interface OAuthTokenResultFields {
   userInfo: OAuthTokenUserInfo;
   extraConnectorSecrets?: Readonly<Record<string, string>>;
 }
-
-export type OAuthTokenResultBase = OAuthTokenResultFields & {
-  readonly outputs: Readonly<Record<string, string | null | undefined>>;
-};
-
-export type OAuthTokenResult<
-  T extends AuthCodeGrantConnectorType | DeviceAuthGrantConnectorType,
-  Method extends ConnectorAuthMethodIds<T>,
-> = OAuthTokenResultFields & {
-  readonly outputs: ConnectorGrantOutputValues<T, Method>;
-};
 
 /**
  * Result from buildAuthUrl when PKCE is required.
@@ -115,7 +107,7 @@ export interface OAuthDeviceAuthSlowDownResult {
 
 export interface OAuthDeviceAuthCompleteResultBase {
   readonly status: "complete";
-  readonly token: OAuthTokenResultBase;
+  readonly token: ConnectorAuthProviderGrantResultBase;
 }
 
 export interface OAuthDeviceAuthCompleteResult<
@@ -123,7 +115,7 @@ export interface OAuthDeviceAuthCompleteResult<
   Method extends ConnectorDeviceAuthGrantAuthMethodId<T>,
 > {
   readonly status: "complete";
-  readonly token: OAuthTokenResult<T, Method>;
+  readonly token: ConnectorAuthProviderGrantResult<T, Method>;
 }
 
 export interface OAuthDeviceAuthDeniedResult {

--- a/turbo/packages/connectors/src/auth-providers/types.ts
+++ b/turbo/packages/connectors/src/auth-providers/types.ts
@@ -27,14 +27,8 @@ import type {
   OAuthDeviceAuthPollResult,
   OAuthDeviceAuthStartResult,
 } from "./oauth/types";
-import type { ConnectorAuthProviderGrantResult } from "./grant-result";
+import type { ConnectorAuthProviderGrantResultForMethod } from "./grant-result";
 import type { ProviderEnv } from "./provider-env";
-
-export type {
-  ConnectorAuthProviderGrantResult,
-  ConnectorAuthProviderGrantResultBase,
-  ConnectorAuthProviderGrantUserInfo,
-} from "./grant-result";
 
 interface NoneGrantProvider {
   readonly kind: "none";
@@ -51,7 +45,7 @@ export interface AuthCodeGrantProvider<
   ): string | AuthUrlResult | Promise<string | AuthUrlResult>;
   exchangeCode(
     args: ConnectorAuthCodeExchangeArgs<T, Method>,
-  ): Promise<ConnectorAuthProviderGrantResult<T, Method>>;
+  ): Promise<ConnectorAuthProviderGrantResultForMethod<T, Method>>;
 }
 
 export interface DeviceAuthGrantProvider<

--- a/turbo/packages/connectors/src/auth-providers/types.ts
+++ b/turbo/packages/connectors/src/auth-providers/types.ts
@@ -26,9 +26,15 @@ import type {
   ConnectorAuthProviderRevokeArgs,
   OAuthDeviceAuthPollResult,
   OAuthDeviceAuthStartResult,
-  OAuthTokenResult,
 } from "./oauth/types";
+import type { ConnectorAuthProviderGrantResult } from "./grant-result";
 import type { ProviderEnv } from "./provider-env";
+
+export type {
+  ConnectorAuthProviderGrantResult,
+  ConnectorAuthProviderGrantResultBase,
+  ConnectorAuthProviderGrantUserInfo,
+} from "./grant-result";
 
 interface NoneGrantProvider {
   readonly kind: "none";
@@ -45,7 +51,7 @@ export interface AuthCodeGrantProvider<
   ): string | AuthUrlResult | Promise<string | AuthUrlResult>;
   exchangeCode(
     args: ConnectorAuthCodeExchangeArgs<T, Method>,
-  ): Promise<OAuthTokenResult<T, Method>>;
+  ): Promise<ConnectorAuthProviderGrantResult<T, Method>>;
 }
 
 export interface DeviceAuthGrantProvider<


### PR DESCRIPTION
## Summary

- add a protocol-neutral connector grant result leaf type module
- make auth-code exchange and device-auth complete payloads use generic connector grant result types instead of OAuth token result types
- keep OAuth provider internals protocol-specific while deriving OAuth field helpers from the generic grant result shape
- keep API call sites behavior-equivalent without re-exporting the new grant result types from the generic facade

## Behavior

This is a type-boundary refactor only. It does not change connector metadata, persisted output mappings, `oauthScopes`, token expiry handling, `extraConnectorSecrets`, OAuth routes, or provider runtime behavior.

Closes #16036

## Tests

- `pnpm -F @vm0/connectors check-types`
- `pnpm -F api check-types`
- `pnpm -F @vm0/connectors lint`
- `pnpm -F api lint`
- `pnpm -F @vm0/connectors exec vitest src/__tests__/connectors.test.ts`
- `pnpm -F api exec vitest src/signals/routes/__tests__/connectors-type-callback.test.ts src/signals/routes/__tests__/zero-connectors-oauth-device-auth.test.ts`
- pre-commit: `pnpm check-types`, `pnpm knip`, staged prettier
