### PR TITLE
fix: guard malformed firewall metadata in usage paths

### DIFF
--- a/crates/runner/mitm-addon/src/flow_metadata.py
+++ b/crates/runner/mitm-addon/src/flow_metadata.py
@@ -1,0 +1,10 @@
+"""Firewall metadata access helpers."""
+
+from collections.abc import Mapping
+
+import flow_metadata_keys as metadata_keys
+
+
+def get_firewall_name_metadata(meta: Mapping[str, object]) -> str:
+    value = meta.get(metadata_keys.FIREWALL_NAME)
+    return value if isinstance(value, str) else ""

--- a/crates/runner/mitm-addon/src/mitm_addon.py
+++ b/crates/runner/mitm-addon/src/mitm_addon.py
@@ -34,6 +34,7 @@ from mitmproxy.addonmanager import Loader
 #   2. Tests can patch names on the owning module object and affect all
 #      callers — no mock-placement pitfalls from copied function bindings.
 import body_utils
+import flow_metadata
 import flow_metadata_keys as metadata_keys
 import matching
 import network_log_sanitization
@@ -709,7 +710,7 @@ def response(flow: http.HTTPFlow) -> None:
         and not flow.metadata.get(metadata_keys.MODEL_PROVIDER_USAGE)
         and stream_buf
     ):
-        firewall_name = flow.metadata.get(metadata_keys.FIREWALL_NAME, "")
+        firewall_name = flow_metadata.get_firewall_name_metadata(flow.metadata)
         if firewall_name.startswith("model-provider:") and flow.metadata.get(
             metadata_keys.FIREWALL_BILLABLE, False
         ):

--- a/crates/runner/mitm-addon/src/response_streaming.py
+++ b/crates/runner/mitm-addon/src/response_streaming.py
@@ -21,6 +21,7 @@ from collections.abc import Callable
 from mitmproxy import http
 
 import body_utils
+import flow_metadata
 import flow_metadata_keys as metadata_keys
 import usage
 from logging_utils import log_proxy_entry
@@ -93,7 +94,7 @@ def _configure_response_usage_parser(flow: http.HTTPFlow) -> _ResponseChunkParse
     if not flow.response:
         return None
 
-    firewall_name = flow.metadata.get(metadata_keys.FIREWALL_NAME, "")
+    firewall_name = flow_metadata.get_firewall_name_metadata(flow.metadata)
     is_model_provider = firewall_name.startswith("model-provider:")
     # Platform-billable firewall flag, sourced from vm_info["billableFirewalls"]
     # via auth.handle_firewall_request.  Gates report_connector_usage (in response())

--- a/crates/runner/mitm-addon/src/usage/providers/connectors/__init__.py
+++ b/crates/runner/mitm-addon/src/usage/providers/connectors/__init__.py
@@ -18,6 +18,7 @@ from collections.abc import Callable
 
 from mitmproxy import http
 
+import flow_metadata
 import flow_metadata_keys as metadata_keys
 from logging_utils import log_proxy_entry
 
@@ -71,7 +72,7 @@ def report_connector_usage(flow: http.HTTPFlow, run_id: str) -> None:
         return
     if not flow.metadata.get(metadata_keys.FIREWALL_BILLABLE, False):
         return
-    firewall_name = flow.metadata.get(metadata_keys.FIREWALL_NAME, "")
+    firewall_name = flow_metadata.get_firewall_name_metadata(flow.metadata)
     if firewall_name.startswith("model-provider:"):
         return
     handler = _HANDLERS.get(firewall_name)
@@ -100,7 +101,7 @@ def create_connector_response_parser(flow: http.HTTPFlow) -> ConnectorResponsePa
     """
     if not flow.metadata.get(metadata_keys.FIREWALL_BILLABLE, False):
         return None
-    firewall_name = flow.metadata.get(metadata_keys.FIREWALL_NAME, "")
+    firewall_name = flow_metadata.get_firewall_name_metadata(flow.metadata)
     factory = _RESPONSE_PARSER_FACTORIES.get(firewall_name)
     if factory is None:
         return None

--- a/crates/runner/mitm-addon/src/usage/providers/model_provider.py
+++ b/crates/runner/mitm-addon/src/usage/providers/model_provider.py
@@ -17,6 +17,7 @@ from typing import TypeGuard
 
 from mitmproxy import http
 
+import flow_metadata
 import flow_metadata_keys as metadata_keys
 from auth import get_api_url
 from logging_utils import log_proxy_entry
@@ -47,7 +48,7 @@ def report_model_provider_usage(flow: http.HTTPFlow, run_id: str) -> bool:
     writes a proxy warning because that indicates an environment/reporting setup
     problem.
     """
-    firewall_name = flow.metadata.get(metadata_keys.FIREWALL_NAME, "")
+    firewall_name = flow_metadata.get_firewall_name_metadata(flow.metadata)
     if not (firewall_name.startswith("model-provider:") and run_id):
         return False
     if not flow.metadata.get(metadata_keys.FIREWALL_BILLABLE, False):

--- a/crates/runner/mitm-addon/tests/test_connector_usage.py
+++ b/crates/runner/mitm-addon/tests/test_connector_usage.py
@@ -1512,6 +1512,22 @@ class TestReportConnectorUsage:
         if proxy_log.exists():
             assert "no registered handler" not in proxy_log.read_text()
 
+    @pytest.mark.parametrize("firewall_name", [None, 42])
+    def test_skips_malformed_firewall_name_without_warning(
+        self, tmp_path, real_flow, firewall_name
+    ):
+        body = json.dumps({"data": {"id": "1", "text": "hi"}}).encode()
+        flow = self._make_x_flow(
+            real_flow, tmp_path, path="/2/tweets/1", body=body, rule="GET /2/tweets/{id}"
+        )
+        flow.metadata["firewall_name"] = firewall_name
+
+        assert self._call_and_get_billing(flow) == []
+
+        proxy_log = tmp_path / "proxy.jsonl"
+        if proxy_log.exists():
+            assert "no registered handler" not in proxy_log.read_text()
+
     def test_skips_for_non_x_billable_firewall(self, tmp_path, real_flow):
         """Billable non-x connectors (hypothetical future additions to
         BILLABLE_CONNECTORS) must NOT reach the X parser.  The dispatcher

--- a/crates/runner/mitm-addon/tests/test_model_provider_response_usage.py
+++ b/crates/runner/mitm-addon/tests/test_model_provider_response_usage.py
@@ -1048,6 +1048,23 @@ class TestModelProviderResponseUsage:
         assert "model_provider_usage" not in flow.metadata
         assert not proxy_log_path.exists()
 
+    @pytest.mark.parametrize("firewall_name", [None, 42])
+    def test_json_fallback_skips_malformed_firewall_name(self, tmp_path, real_flow, firewall_name):
+        flow = real_flow(with_response=False, host="api.anthropic.com")
+        self._set_common_model_metadata(flow, tmp_path)
+        flow.metadata["original_url"] = ANTHROPIC_JSON_CASE.original_url
+        flow.metadata["firewall_name"] = firewall_name
+        body = _standard_success_payload(ANTHROPIC_JSON_CASE)
+        set_stream_buffer(flow, body)
+        flow.response = tutils.tresp(
+            status_code=200, headers=header_map({"content-type": "application/json"})
+        )
+
+        webhook = self._run_response(flow)
+
+        assert webhook.request_count == 0
+        assert "model_provider_usage" not in flow.metadata
+
 
 class TestModelProviderResponseUsageWebhookDelivery:
     """Tests for real background executor webhook delivery."""

--- a/crates/runner/mitm-addon/tests/test_model_provider_usage.py
+++ b/crates/runner/mitm-addon/tests/test_model_provider_usage.py
@@ -3,6 +3,8 @@
 import json
 import uuid
 
+import pytest
+
 import usage
 
 
@@ -157,6 +159,24 @@ class TestReportModelProviderUsage:
             usage.flush_usage_events(trigger="test")
             usage.webhook.usage_executor.shutdown(wait=True)
 
+        assert webhook.request_count == 0
+
+    @pytest.mark.parametrize("firewall_name", [None, 42])
+    def test_skips_malformed_firewall_name(
+        self, real_flow, fresh_usage_executor, usage_webhook_api, firewall_name
+    ):
+        flow = real_flow(with_response=False, host="api.anthropic.com")
+        flow.metadata["firewall_name"] = firewall_name
+        flow.metadata["firewall_billable"] = True
+        flow.metadata["vm_sandbox_token"] = "tok-xyz"
+        flow.metadata["model_provider_usage"] = {"tokens.input": 50}
+
+        with usage_webhook_api() as webhook:
+            accepted = usage.report_model_provider_usage(flow, "run-abc-123")
+            usage.flush_usage_events(trigger="test")
+            usage.webhook.usage_executor.shutdown(wait=True)
+
+        assert accepted is False
         assert webhook.request_count == 0
 
     def test_skips_when_no_model_provider_usage(

--- a/crates/runner/mitm-addon/tests/test_response_streaming.py
+++ b/crates/runner/mitm-addon/tests/test_response_streaming.py
@@ -530,6 +530,25 @@ class TestResponseHeadersSseParser:
 
         assert "model_provider_usage" not in flow.metadata
 
+    @pytest.mark.parametrize("firewall_name", [None, 42])
+    def test_malformed_firewall_name_skips_usage_parsers(self, real_flow, firewall_name):
+        flow = real_flow(with_response=False, host="api.x.com", path="/2/tweets/search/stream")
+        flow.response = tutils.tresp(
+            status_code=200,
+            headers=header_map({"content-type": "application/json"}),
+        )
+        flow.metadata["firewall_name"] = firewall_name
+        flow.metadata["firewall_billable"] = True
+        flow.metadata["original_url"] = "https://api.x.com/2/tweets/search/stream"
+
+        mitm_addon.responseheaders(flow)
+
+        assert "model_provider_usage" not in flow.metadata
+        assert "model_json_usage_finish" not in flow.metadata
+        assert "model_sse_usage_finish" not in flow.metadata
+        assert "connector_response_finish" not in flow.metadata
+        assert "x_ndjson_state" not in flow.metadata
+
 
 class TestReleaseResponseStreamState:
     """Tests for direct response streaming cleanup."""


### PR DESCRIPTION
## Summary

- Add a firewall_name metadata helper that treats non-string values as absent
- Use it in response streaming, connector usage dispatch, model-provider reporting, and JSON fallback
- Add regression coverage for malformed firewall_name values across usage entry points

Fixes #15967

## Tests

- `python3 -m ruff check src/flow_metadata.py src/response_streaming.py src/mitm_addon.py src/usage/providers/connectors/__init__.py src/usage/providers/model_provider.py tests/test_response_streaming.py tests/test_connector_usage.py tests/test_model_provider_usage.py tests/test_model_provider_response_usage.py`
- `python3 -m ruff format --check src/flow_metadata.py src/response_streaming.py src/mitm_addon.py src/usage/providers/connectors/__init__.py src/usage/providers/model_provider.py tests/test_response_streaming.py tests/test_connector_usage.py tests/test_model_provider_usage.py tests/test_model_provider_response_usage.py`
- `python3 -m basedpyright src/flow_metadata.py src/response_streaming.py src/mitm_addon.py src/usage/providers/connectors/__init__.py src/usage/providers/model_provider.py tests/test_response_streaming.py tests/test_connector_usage.py tests/test_model_provider_usage.py tests/test_model_provider_response_usage.py`
- `python3 -m pytest tests/test_response_streaming.py tests/test_connector_usage.py tests/test_model_provider_usage.py tests/test_model_provider_response_usage.py`
- `git diff --check`