### PR TITLE
Harden credit checkout promotion codes and auto-recharge pay idempotency

### DIFF
--- a/turbo/apps/api/src/signals/routes/__tests__/zero-billing-auto-recharge.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/zero-billing-auto-recharge.test.ts
@@ -277,6 +277,66 @@ describe("PUT /api/zero/billing/auto-recharge", () => {
     expect(row?.pendingAt).toBeInstanceOf(Date);
   });
 
+  it("keeps auto-recharge pending when Stripe reports the invoice is already paid", async () => {
+    const customerId = `cus_${randomUUID().slice(0, 8)}`;
+    const fixture = await track(
+      store.set(seedAutoRechargeOrg$, { tier: "pro" }, context.signal),
+    );
+    const writeDb = store.set(writeDb$);
+    await writeDb
+      .update(orgMetadata)
+      .set({
+        credits: 500,
+        stripeCustomerId: customerId,
+        stripeSubscriptionId: null,
+      })
+      .where(eq(orgMetadata.orgId, fixture.orgId));
+    context.mocks.stripe.customers.retrieve.mockResolvedValue({
+      id: customerId,
+      deleted: false,
+      invoice_settings: { default_payment_method: "pm_test" },
+    });
+    context.mocks.stripe.invoices.create.mockResolvedValue({
+      id: "in_auto_recharge_already_paid",
+    });
+    context.mocks.stripe.invoiceItems.create.mockResolvedValue({
+      id: "ii_auto_recharge_already_paid",
+    });
+    context.mocks.stripe.invoices.finalizeInvoice.mockResolvedValue({
+      id: "in_auto_recharge_already_paid",
+    });
+    context.mocks.stripe.invoices.pay.mockRejectedValue(
+      new Error("Invoice is already paid"),
+    );
+    mocks.clerk.session(fixture.userId, fixture.orgId, "org:admin");
+
+    const client = setupApp({ context })(zeroBillingAutoRechargeContract);
+
+    const response = await accept(
+      client.update({
+        body: { enabled: true, threshold: 1000, amount: 5000 },
+        headers: { authorization: "Bearer clerk-session" },
+      }),
+      [200],
+    );
+
+    expect(response.body).toStrictEqual({
+      enabled: true,
+      threshold: 1000,
+      amount: 5000,
+    });
+    expect(context.mocks.stripe.invoices.pay).toHaveBeenCalledWith(
+      "in_auto_recharge_already_paid",
+    );
+
+    const [row] = await writeDb
+      .select({ pendingAt: orgMetadata.autoRechargePendingAt })
+      .from(orgMetadata)
+      .where(eq(orgMetadata.orgId, fixture.orgId))
+      .limit(1);
+    expect(row?.pendingAt).toBeInstanceOf(Date);
+  });
+
   it("disables auto-recharge and clears pending state", async () => {
     const fixture = await track(
       store.set(

--- a/turbo/apps/api/src/signals/routes/__tests__/zero-billing-checkout.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/zero-billing-checkout.test.ts
@@ -1047,7 +1047,7 @@ describe("POST /api/zero/billing/credit-checkout", () => {
       }),
     );
     expect(context.mocks.stripe.checkout.sessions.create).toHaveBeenCalledWith(
-      expect.not.objectContaining({
+      expect.objectContaining({
         allow_promotion_codes: true,
       }),
     );

--- a/turbo/apps/api/src/signals/services/zero-billing-checkout.service.ts
+++ b/turbo/apps/api/src/signals/services/zero-billing-checkout.service.ts
@@ -364,6 +364,7 @@ export const createCreditCheckoutSession$ = command(
       mode: "payment",
       customer: customerId,
       line_items: [{ price: presetPriceId, quantity: 1 }],
+      allow_promotion_codes: true,
       success_url: args.successUrl,
       cancel_url: args.cancelUrl,
       payment_intent_data: {

--- a/turbo/apps/api/src/signals/services/zero-credit-recharge.service.ts
+++ b/turbo/apps/api/src/signals/services/zero-credit-recharge.service.ts
@@ -68,6 +68,19 @@ async function resolvePaymentMethod(
   return null;
 }
 
+function isInvoiceAlreadyPaidError(error: unknown): boolean {
+  const maybeStripeError = error as
+    | { readonly code?: string; readonly message?: string }
+    | undefined;
+  const message =
+    error instanceof Error ? error.message : (maybeStripeError?.message ?? "");
+
+  return (
+    maybeStripeError?.code === "invoice_already_paid" ||
+    /invoice is already paid/i.test(message)
+  );
+}
+
 /**
  * Trigger a Stripe auto-recharge invoice if the org's balance has
  * crossed the recharge threshold. Mirrors web's `triggerAutoRecharge`.
@@ -172,7 +185,19 @@ export const triggerAutoRecharge$ = command(
 
         await stripe.invoices.finalizeInvoice(invoice.id);
         signal.throwIfAborted();
-        await stripe.invoices.pay(invoice.id);
+        const payOutcome = await settle(stripe.invoices.pay(invoice.id), signal);
+        signal.throwIfAborted();
+        if (!payOutcome.ok) {
+          if (!isInvoiceAlreadyPaidError(payOutcome.error)) {
+            throw payOutcome.error;
+          }
+          L.debug("Auto-recharge invoice was already paid", {
+            orgId,
+            creditsAmount,
+            amountCents,
+            invoiceId: invoice.id,
+          });
+        }
         signal.throwIfAborted();
 
         L.debug("Auto-recharge invoice created and paid", {


### PR DESCRIPTION
## Summary
- enable Stripe promotion codes on one-time credit checkout sessions
- treat Stripe `invoice_already_paid` from auto-recharge invoice payment as an idempotent success path instead of clearing the pending flag
- add focused regressions for credit-checkout promotion codes and already-paid auto-recharge invoices

## Context
This addresses the billing edge cases reported in #15359 around credit checkout discounts and auto-recharge false failures. Current `main` already triggers auto-recharge immediately after enabling it when balance is below threshold; this PR keeps that path from being marked failed if Stripe reports the finalized invoice was already paid.

## Validation
- `git diff --check`
- `pnpm -F api check-types`
- `pnpm -F api lint`
- `pnpm -F api exec vitest run src/signals/routes/__tests__/zero-billing-checkout.test.ts src/signals/routes/__tests__/zero-billing-auto-recharge.test.ts` blocked locally because Postgres is not running (`ECONNREFUSED 127.0.0.1:5432` / `::1:5432`)
