### PR TITLE
ci(deploy-web): pre-migrate Neon test parent branch on main to speed up preview migrate

### DIFF
--- a/.github/workflows/turbo.yml
+++ b/.github/workflows/turbo.yml
@@ -838,7 +838,7 @@ jobs:
           # near no-op -- this is what keeps preview migrate (and deploy-web) fast.
           # Safe by construction: this job has no `environment: production`, so
           # NEON_PROJECT_ID resolves to the Neon TEST project, never production.
-          if [ "${{ github.event_name }}" = "push" ] && [ "${{ github.ref }}" = "refs/heads/main" ]; then
+          if [ "$GITHUB_EVENT_NAME" = "push" ] && [ "$GITHUB_REF" = "refs/heads/main" ]; then
             echo "main push: pre-migrating test project default (parent) branch"
             PARENT_DATABASE_URL=$(neonctl connection-string --project-id "$NEON_PROJECT_ID" --database-name neondb --role-name neondb_owner --pooled)
             if [ -z "$PARENT_DATABASE_URL" ]; then

--- a/.github/workflows/turbo.yml
+++ b/.github/workflows/turbo.yml
@@ -831,6 +831,22 @@ jobs:
 
           npm install -g neonctl@2.15.0
 
+          # On pushes to main, migrate the test project's default (parent) branch
+          # BEFORE creating/resetting the preview branch off it. Neon branches are
+          # copy-on-write, so a preview branched from an already-migrated parent
+          # inherits the up-to-date schema and its own db:migrate below becomes a
+          # near no-op -- this is what keeps preview migrate (and deploy-web) fast.
+          # Safe by construction: this job has no `environment: production`, so
+          # NEON_PROJECT_ID resolves to the Neon TEST project, never production.
+          if [ "${{ github.event_name }}" = "push" ] && [ "${{ github.ref }}" = "refs/heads/main" ]; then
+            echo "main push: pre-migrating test project default (parent) branch"
+            PARENT_DATABASE_URL=$(neonctl connection-string --project-id "$NEON_PROJECT_ID" --database-name neondb --role-name neondb_owner --pooled)
+            if [ -z "$PARENT_DATABASE_URL" ]; then
+              PARENT_DATABASE_URL=$(neonctl connection-string --project-id "$NEON_PROJECT_ID" --database-name neondb --role-name neondb_owner)
+            fi
+            (cd turbo && DATABASE_URL="$PARENT_DATABASE_URL" pnpm -F @vm0/db db:migrate)
+          fi
+
           BRANCH_NAME="preview/${{ needs.prepare.outputs.job-ref }}"
 
           if neonctl branches list --project-id "$NEON_PROJECT_ID" --output json | jq -e --arg name "$BRANCH_NAME" '.[] | select(.name == $name)' > /dev/null; then


### PR DESCRIPTION
## Why

`deploy-web` is slow mainly because `db:migrate` is slow. Neon preview branches are copy-on-write off the **test project's default (parent) branch**, but that parent is **not** migrated on merges to `main` (production migration only happens at release time via `migrate-production`). So every preview branch:

1. replays the **whole migration backlog** accumulated since the parent was last migrated, and
2. pays for any **heavy migration** (large-table rewrite, index build, backfill) again on the COW child, because the parent doesn't already have it to share.

## What this changes

On pushes to `main`, migrate the **parent (default) branch** of the Neon **test** project *before* creating/resetting the `preview/<job-ref>` branch off it. The preview then inherits an up-to-date schema, so:

- its own `db:migrate` (kept as-is) becomes a near no-op,
- every subsequent PR preview that `reset --parent`s off the parent inherits the migrated schema too → fast preview migrate,
- the heavy migration work is paid **once on the parent** instead of on every branch.

`drizzle` migrate is idempotent (`__drizzle_migrations`), so re-running on an already-current parent is cheap.

## Safety

`deploy-web` has **no** `environment: production`, so `vars.NEON_PROJECT_ID` resolves to the Neon **TEST** project, never production. Real production migrations are untouched and still run only at release time in `migrate-production` (`environment: production`). The new step is gated to `github.event_name == 'push' && github.ref == 'refs/heads/main'`, so PR runs only branch (they don't touch the parent).

## Notes for reviewers

- The pre-migrate uses `neonctl connection-string` with no branch arg, which resolves to the project's default branch — the same branch `neonctl branches create` (no `--parent`) uses as the parent. Worth a sanity check against the test project's actual default branch name.
- Edge case: a merge to `main` that changes *only* migration files and triggers nothing else that runs `deploy-web` would let the parent lag by one deploy. In practice migrations ship with code, and release-time production migration still guarantees correctness.

cc @e7h4n — flagging for infra review (Lancy / Qiqi) since this touches the core deploy path. Not enabling auto-merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
