### PR TITLE
fix: contain memory markdown overflow

### DIFF
--- a/turbo/apps/platform/src/views/components/markdown.tsx
+++ b/turbo/apps/platform/src/views/components/markdown.tsx
@@ -375,7 +375,7 @@ export function Markdown({
     : PLAIN_MARKDOWN_COMPONENTS;
   return (
     <MarkdownPreview
-      className={`!bg-transparent !text-foreground text-sm ${className ?? ""}`}
+      className={`min-w-0 max-w-full !bg-transparent !text-foreground text-sm ${className ?? ""}`}
       style={{
         backgroundColor: "transparent",
         fontSize: "0.875rem",

--- a/turbo/apps/platform/src/views/css/index.css
+++ b/turbo/apps/platform/src/views/css/index.css
@@ -670,6 +670,11 @@
 }
 
 /* --- Spacing ------------------------------------------------------------ */
+.wmde-markdown {
+  min-width: 0;
+  max-width: 100%;
+}
+
 .wmde-markdown p {
   margin-top: 6px;
   margin-bottom: 6px;
@@ -871,6 +876,8 @@
 .wmde-markdown pre {
   overflow-x: auto;
   max-width: 100%;
+  width: 100%;
+  box-sizing: border-box;
   border: 0.7px solid hsl(var(--gray-400));
   border-radius: 8px;
 }

--- a/turbo/apps/platform/src/views/memory-page/__tests__/memory-page-layout.btest.ts
+++ b/turbo/apps/platform/src/views/memory-page/__tests__/memory-page-layout.btest.ts
@@ -1,0 +1,60 @@
+import { describe, expect, it } from "vitest";
+
+import "../../css/index.css";
+
+function getRequiredElement(selector: string): HTMLElement {
+  const element = document.querySelector(selector);
+  if (!(element instanceof HTMLElement)) {
+    throw new Error(`Missing element for selector: ${selector}`);
+  }
+  return element;
+}
+
+describe("memory page layout", () => {
+  it("keeps the file list visible beside a wide markdown code block", () => {
+    const wrapper = document.createElement("div");
+    wrapper.style.display = "flex";
+    wrapper.style.width = "760px";
+    wrapper.innerHTML = `
+      <section class="zero-card" style="display: flex; min-height: 420px; min-width: 0; flex: 1 1 0%; flex-direction: column; overflow: hidden;">
+        <div style="display: flex; min-height: 0; min-width: 0; flex: 1 1 0%; flex-direction: row;">
+          <div style="order: 1; display: flex; min-height: 0; min-width: 0; flex: 1 1 0%; flex-direction: column;">
+            <div class="border-b border-border/70 px-4 text-xs font-medium text-muted-foreground" style="display: flex; height: 36px; flex-shrink: 0; align-items: center;">
+              <span class="truncate">MEMORY.md</span>
+            </div>
+            <div aria-label="Memory content" class="bg-background px-4 py-3" style="min-height: 0; min-width: 0; flex: 1 1 0%; overflow: auto;">
+              <div class="wmde-markdown min-w-0 max-w-full !bg-transparent !text-foreground text-sm">
+                <pre><code>npx -p @vm0/cli zero agent edit $ZERO_AGENT_ID --instructions-file /tmp/${"very-long-segment-".repeat(16)}current-instructions.md</code></pre>
+              </div>
+            </div>
+          </div>
+          <aside class="border-l border-border/70 bg-muted/20" style="order: 2; display: flex; min-height: 0; width: 240px; flex-shrink: 0; flex-direction: column;">
+            <div class="border-b border-border/70 px-3" style="display: flex; height: 36px; flex-shrink: 0; align-items: center; justify-content: space-between;">
+              <span class="text-xs font-medium text-muted-foreground">Files</span>
+              <span class="text-xs text-muted-foreground">2</span>
+            </div>
+            <div class="p-2" style="min-height: 0; flex: 1 1 0%; overflow: auto;">
+              <button type="button" class="rounded-md px-2 py-1.5 text-left transition-colors bg-accent text-accent-foreground" style="display: flex; min-width: 0; align-items: center; justify-content: space-between; gap: 12px;">
+                <span class="min-w-0 truncate text-xs">MEMORY.md</span>
+                <span class="shrink-0 text-xs text-muted-foreground">900 B</span>
+              </button>
+            </div>
+          </aside>
+        </div>
+      </section>
+    `;
+    document.body.appendChild(wrapper);
+
+    try {
+      const cardRect = getRequiredElement(".zero-card").getBoundingClientRect();
+      const filePanelRect = getRequiredElement("aside").getBoundingClientRect();
+      const codeBlock = getRequiredElement(".wmde-markdown pre");
+
+      expect(filePanelRect.right).toBeLessThanOrEqual(cardRect.right);
+      expect(filePanelRect.width).toBeGreaterThanOrEqual(230);
+      expect(codeBlock.scrollWidth).toBeGreaterThan(codeBlock.clientWidth);
+    } finally {
+      wrapper.remove();
+    }
+  });
+});

--- a/turbo/apps/platform/src/views/memory-page/__tests__/memory-page.test.tsx
+++ b/turbo/apps/platform/src/views/memory-page/__tests__/memory-page.test.tsx
@@ -267,6 +267,53 @@ describe("memory page", () => {
     expect(fileButtons[2]?.textContent).toContain("scratch.txt");
   });
 
+  it("constrains markdown content so wide code blocks do not displace the file list", async () => {
+    setMockMemory({
+      exists: true,
+      name: "memory",
+      size: 900,
+      fileCount: 1,
+      updatedAt: "2024-01-01T00:00:00Z",
+      files: [{ path: "MEMORY.md", size: 900 }],
+      fileContents: [
+        {
+          path: "MEMORY.md",
+          content: [
+            "# Memory Index",
+            "",
+            "```sh",
+            `npx -p @vm0/cli zero agent edit $ZERO_AGENT_ID --instructions-file /tmp/${"very-long-segment-".repeat(8)}current-instructions.md`,
+            "```",
+          ].join("\n"),
+        },
+      ],
+    });
+
+    detachedSetupPage({
+      context,
+      path: "/memory",
+      featureSwitches: { [FeatureSwitchKey.MemoryViewer]: true },
+    });
+
+    await clickTab("Raw files");
+
+    await waitFor(() => {
+      expect(screen.getByLabelText("Memory content")).toHaveTextContent(
+        "zero agent edit",
+      );
+    });
+
+    const content = screen.getByLabelText("Memory content");
+    const markdownRoot = document.querySelector(".wmde-markdown");
+    if (!(markdownRoot instanceof HTMLElement)) {
+      throw new Error("Missing markdown root");
+    }
+
+    expect(content.className).toContain("min-w-0");
+    expect(content.parentElement?.className).toContain("min-w-0");
+    expect(markdownRoot.className).toContain("min-w-0");
+  });
+
   it("switches files when a relative link to another memory file is clicked", async () => {
     setMockMemory({
       exists: true,

--- a/turbo/apps/platform/src/views/memory-page/memory-page.tsx
+++ b/turbo/apps/platform/src/views/memory-page/memory-page.tsx
@@ -280,10 +280,10 @@ function MemoryViewer({ detail }: { readonly detail: MemoryDetailResponse }) {
   };
 
   return (
-    <section className="zero-card flex min-h-[420px] flex-1 flex-col overflow-hidden">
-      <div className="flex min-h-0 flex-1 flex-col lg:flex-row">
+    <section className="zero-card flex min-h-[420px] min-w-0 flex-1 flex-col overflow-hidden">
+      <div className="flex min-h-0 min-w-0 flex-1 flex-col lg:flex-row">
         {/* Content (left) — scrolls independently of the file panel. */}
-        <div className="order-1 flex min-h-0 flex-1 flex-col">
+        <div className="order-1 flex min-h-0 min-w-0 flex-1 flex-col">
           <div className="flex h-9 shrink-0 items-center border-b border-border/70 px-4 text-xs font-medium text-muted-foreground">
             <span className="truncate">
               {selectedPath ?? "No file selected"}
@@ -293,7 +293,7 @@ function MemoryViewer({ detail }: { readonly detail: MemoryDetailResponse }) {
             selectedMarkdown !== null ? (
               <div
                 aria-label="Memory content"
-                className="min-h-0 flex-1 overflow-auto bg-background px-4 py-3"
+                className="min-h-0 min-w-0 flex-1 overflow-auto bg-background px-4 py-3"
                 onClick={handleContentClick}
               >
                 <MemoryFrontmatter fields={selectedMarkdown.frontmatter} />


### PR DESCRIPTION
## Summary

- Constrain the Memory raw-file viewer flex layout so wide markdown content can shrink beside the fixed Files panel.
- Add markdown renderer and global markdown CSS width constraints so code blocks scroll inside their content area instead of expanding the page layout.
- Add regression coverage for wide Memory markdown code blocks, including a Chromium layout check.

## Root Cause

Long markdown code blocks contributed an intrinsic width to the left content column. The Memory viewer's flex children did not consistently opt into `min-width: 0`, so the content column could push the right-side Files panel out of the visible card.

## Validation

- `env NODE_OPTIONS=--no-experimental-webstorage pnpm -F @vm0/app exec vitest run src/views/memory-page/__tests__/memory-page.test.tsx`
- `env NODE_OPTIONS=--no-experimental-webstorage pnpm -F @vm0/app exec vitest run --config vitest.browser.config.ts src/views/memory-page/__tests__/memory-page-layout.btest.ts`
- `pnpm -F @vm0/app check-types`
- `pnpm -F @vm0/app lint`
- `pnpm exec prettier --check apps/platform/src/views/components/markdown.tsx apps/platform/src/views/css/index.css apps/platform/src/views/memory-page/memory-page.tsx apps/platform/src/views/memory-page/__tests__/memory-page.test.tsx apps/platform/src/views/memory-page/__tests__/memory-page-layout.btest.ts`

Note: this local Node 25 environment requires `NODE_OPTIONS=--no-experimental-webstorage` for the happy-dom/browser Vitest runs because Node's experimental Web Storage global lacks the DOM storage methods used by the app tests.