### PR TITLE
fix: sanitize artifact filename consistently across upload and message storage

### DIFF
--- a/turbo/apps/api/src/lib/file-url.ts
+++ b/turbo/apps/api/src/lib/file-url.ts
@@ -3,6 +3,16 @@ import { env } from "./env";
 const ARTIFACTS_PREFIX = "artifacts";
 const CLERK_USER_ID_PREFIX = "user_";
 
+/**
+ * Sanitize a user-supplied filename for use in an artifact object key.
+ * Replaces characters that are unsafe or problematic in URLs / object storage
+ * (spaces, non-ASCII, etc.) with underscores so the key is stable and
+ * predictable across upload, message storage, and retrieval.
+ */
+export function sanitizeArtifactFilename(filename: string): string {
+  return filename.replace(/[^a-zA-Z0-9._-]/g, "_");
+}
+
 function publicArtifactsBaseUrl(): string {
   return env("PUBLIC_ARTIFACTS_BASE_URL").replace(/\/+$/, "");
 }

--- a/turbo/apps/api/src/signals/routes/__tests__/zero-chat-messages.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/zero-chat-messages.test.ts
@@ -1112,6 +1112,7 @@ describe("POST /api/zero/chat/messages", () => {
   it("persists attachments on the user message and injects them into the run prompt", async () => {
     const fixture = await track(seedFixture());
     const fileId = randomUUID();
+    const filename = "diagram final 100%.png";
 
     const response = await send({
       agentId: fixture.agentId,
@@ -1119,8 +1120,8 @@ describe("POST /api/zero/chat/messages", () => {
       attachFiles: [
         {
           id: fileId,
-          filename: "notes.txt",
-          contentType: "text/plain",
+          filename,
+          contentType: "image/png",
           size: 42,
         },
       ],
@@ -1136,7 +1137,7 @@ describe("POST /api/zero/chat/messages", () => {
       .from(agentRuns)
       .where(eq(agentRuns.id, response.body.runId!))
       .limit(1);
-    expect(run?.prompt).toContain("[Web file] notes.txt (text/plain)");
+    expect(run?.prompt).toContain(`[Web file] ${filename} (image/png)`);
     expect(run?.prompt).toContain(`[ID] ${fileId}`);
     expect(run?.appendSystemPrompt).toContain("zero web download-file -h");
     expect(run?.appendSystemPrompt).toContain("zero web upload-file -h");
@@ -1147,10 +1148,10 @@ describe("POST /api/zero/chat/messages", () => {
     expect(message?.attachFileMetadata).toStrictEqual([
       {
         id: fileId,
-        filename: "notes.txt",
-        contentType: "text/plain",
+        filename,
+        contentType: "image/png",
         size: 42,
-        objectKey: `artifacts/${fixture.userId}/${fileId}/notes.txt`,
+        objectKey: `artifacts/${fixture.userId}/${fileId}/diagram_final_100_.png`,
       },
     ]);
   });

--- a/turbo/apps/api/src/signals/routes/zero-chat-messages.ts
+++ b/turbo/apps/api/src/signals/routes/zero-chat-messages.ts
@@ -45,7 +45,10 @@ import {
   providerDeleted,
 } from "../../lib/error";
 import { env } from "../../lib/env";
-import { buildArtifactKey } from "../../lib/file-url";
+import {
+  buildArtifactKey,
+  sanitizeArtifactFilename,
+} from "../../lib/file-url";
 import type { AuthContext } from "../../types/auth";
 import { createZeroRun$ } from "../services/zero-runs-create.service";
 import {
@@ -485,12 +488,13 @@ function attachFileMetadata(
   attachFiles: readonly AttachFile[] | undefined,
 ): ChatMessageAttachFileMetadata[] | null {
   const metadata = attachFiles?.map((file) => {
+    const sanitized = sanitizeArtifactFilename(file.filename);
     return {
       id: file.id,
       filename: file.filename,
       contentType: file.contentType,
       size: file.size,
-      objectKey: buildArtifactKey(userId, file.id, file.filename),
+      objectKey: buildArtifactKey(userId, file.id, sanitized),
     };
   });
   return metadata && metadata.length > 0 ? metadata : null;

--- a/turbo/apps/api/src/signals/routes/zero-chat-messages.ts
+++ b/turbo/apps/api/src/signals/routes/zero-chat-messages.ts
@@ -45,10 +45,7 @@ import {
   providerDeleted,
 } from "../../lib/error";
 import { env } from "../../lib/env";
-import {
-  buildArtifactKey,
-  sanitizeArtifactFilename,
-} from "../../lib/file-url";
+import { buildArtifactKey, sanitizeArtifactFilename } from "../../lib/file-url";
 import type { AuthContext } from "../../types/auth";
 import { createZeroRun$ } from "../services/zero-runs-create.service";
 import {

--- a/turbo/apps/api/src/signals/routes/zero-integrations-github-upload-init.ts
+++ b/turbo/apps/api/src/signals/routes/zero-integrations-github-upload-init.ts
@@ -2,7 +2,11 @@ import { command } from "ccstate";
 import { integrationsGithubUploadInitContract } from "@vm0/api-contracts/contracts/integrations";
 
 import { env } from "../../lib/env";
-import { buildArtifactKey, buildFileUrl } from "../../lib/file-url";
+import {
+  buildArtifactKey,
+  buildFileUrl,
+  sanitizeArtifactFilename,
+} from "../../lib/file-url";
 import { organizationAuthContext$ } from "../auth/auth-context";
 import { authRoute } from "../auth/auth-route";
 import { bodyResultOf } from "../context/request";
@@ -10,10 +14,6 @@ import { generatePresignedPutUrl } from "../external/s3";
 import type { RouteEntry } from "../route";
 
 const PUT_URL_TTL_SECONDS = 3600;
-
-function sanitizeFilename(filename: string): string {
-  return filename.replace(/[^a-zA-Z0-9._-]/gu, "_");
-}
 
 const init$ = command(async ({ get }, signal: AbortSignal) => {
   const auth = get(organizationAuthContext$);
@@ -27,7 +27,7 @@ const init$ = command(async ({ get }, signal: AbortSignal) => {
 
   const body = bodyResult.data;
   const uploadId = crypto.randomUUID();
-  const filename = sanitizeFilename(body.filename);
+  const filename = sanitizeArtifactFilename(body.filename);
   const s3Key = buildArtifactKey(auth.userId, uploadId, filename);
   const bucket = env("R2_USER_ARTIFACTS_BUCKET_NAME");
   const uploadUrl = await get(

--- a/turbo/apps/api/src/signals/routes/zero-integrations-phone-upload-init.ts
+++ b/turbo/apps/api/src/signals/routes/zero-integrations-phone-upload-init.ts
@@ -2,7 +2,11 @@ import { command } from "ccstate";
 import { integrationsPhoneUploadInitContract } from "@vm0/api-contracts/contracts/integrations";
 
 import { env } from "../../lib/env";
-import { buildArtifactKey, buildFileUrl } from "../../lib/file-url";
+import {
+  buildArtifactKey,
+  buildFileUrl,
+  sanitizeArtifactFilename,
+} from "../../lib/file-url";
 import { authContext$ } from "../auth/auth-context";
 import { authRoute } from "../auth/auth-route";
 import { bodyResultOf } from "../context/request";
@@ -10,10 +14,6 @@ import { generatePresignedPutUrl } from "../external/s3";
 import type { RouteEntry } from "../route";
 
 const PUT_URL_TTL_SECONDS = 3600;
-
-function sanitizeFilename(filename: string): string {
-  return filename.replace(/[^a-zA-Z0-9._-]/gu, "_");
-}
 
 const init$ = command(async ({ get }, signal: AbortSignal) => {
   const auth = get(authContext$);
@@ -27,7 +27,7 @@ const init$ = command(async ({ get }, signal: AbortSignal) => {
 
   const body = bodyResult.data;
   const uploadId = crypto.randomUUID();
-  const filename = sanitizeFilename(body.filename);
+  const filename = sanitizeArtifactFilename(body.filename);
   const s3Key = buildArtifactKey(auth.userId, uploadId, filename);
   const bucket = env("R2_USER_ARTIFACTS_BUCKET_NAME");
   const uploadUrl = await get(

--- a/turbo/apps/api/src/signals/routes/zero-integrations-telegram-upload-init.ts
+++ b/turbo/apps/api/src/signals/routes/zero-integrations-telegram-upload-init.ts
@@ -2,7 +2,11 @@ import { command } from "ccstate";
 import { integrationsTelegramUploadInitContract } from "@vm0/api-contracts/contracts/integrations";
 
 import { env } from "../../lib/env";
-import { buildArtifactKey, buildFileUrl } from "../../lib/file-url";
+import {
+  buildArtifactKey,
+  buildFileUrl,
+  sanitizeArtifactFilename,
+} from "../../lib/file-url";
 import { authContext$ } from "../auth/auth-context";
 import { authRoute } from "../auth/auth-route";
 import { bodyResultOf } from "../context/request";
@@ -24,7 +28,7 @@ const initInner$ = command(async ({ get }, signal: AbortSignal) => {
 
   const { filename, contentType, length } = bodyResult.data;
   const uploadId = crypto.randomUUID();
-  const sanitized = filename.replace(/[^a-zA-Z0-9._-]/g, "_");
+  const sanitized = sanitizeArtifactFilename(filename);
   const s3Key = buildArtifactKey(auth.userId, uploadId, sanitized);
   const bucket = env("R2_USER_ARTIFACTS_BUCKET_NAME");
   const uploadUrl = await get(

--- a/turbo/apps/api/src/signals/routes/zero-uploads-prepare.ts
+++ b/turbo/apps/api/src/signals/routes/zero-uploads-prepare.ts
@@ -3,7 +3,11 @@ import { zeroUploadsContract } from "@vm0/api-contracts/contracts/zero-uploads";
 
 import { env } from "../../lib/env";
 import { badRequestMessage } from "../../lib/error";
-import { buildArtifactKey, buildFileUrl } from "../../lib/file-url";
+import {
+  buildArtifactKey,
+  buildFileUrl,
+  sanitizeArtifactFilename,
+} from "../../lib/file-url";
 import {
   isAllowedUploadType,
   MAX_UPLOAD_SIZE_BYTES,
@@ -47,7 +51,7 @@ const prepareUploadInner$ = command(
     }
 
     const id = crypto.randomUUID();
-    const sanitizedName = filename.replace(/[^a-zA-Z0-9._-]/g, "_");
+    const sanitizedName = sanitizeArtifactFilename(filename);
     const s3Key = buildArtifactKey(auth.userId, id, sanitizedName);
     const bucket = env("R2_USER_ARTIFACTS_BUCKET_NAME");
 


### PR DESCRIPTION
## Problem

Images uploaded in chat break after page refresh. The upload path in `zero-uploads-prepare` sanitizes user filenames (e.g. `Screenshot 2026.png` → `Screenshot_2026.png`) before storing in R2, but `attachFileMetadata` in `zero-chat-messages` recorded the **raw** filename as the `objectKey`. `buildArtifactKey` does `encodeURIComponent` internally, so spaces become `%20` in the stored key — but the actual R2 object has underscores.

- **Upload**: `Screenshot 2026.png` → sanitize → `Screenshot_2026.png` → R2 ✓  
- **Message DB**: `Screenshot 2026.png` → `encodeURIComponent` → `Screenshot%202026.png` → DB ✗  
- **Render**: reads `%20` key → `buildFileUrlFromKey` → 404 ✗

## Fix

Extract `sanitizeArtifactFilename` into `file-url.ts` as the single source of truth and use it consistently in all places that compute artifact object keys:

| File | Change |
|------|--------|
| `lib/file-url.ts` | Added `sanitizeArtifactFilename` export |
| `zero-uploads-prepare.ts` | Switched inline regex → shared function |
| `zero-chat-messages.ts` | **Bug fix**: sanitize filename in `attachFileMetadata` before `buildArtifactKey` |
| `zero-integrations-github-upload-init.ts` | Removed local duplicate → shared function |
| `zero-integrations-phone-upload-init.ts` | Removed local duplicate → shared function |
| `zero-integrations-telegram-upload-init.ts` | Switched inline regex → shared function |

The sanitization regex is identical: `/[^a-zA-Z0-9._-]/g` → `_` (the previous local copies used the `u` Unicode flag; the shared version drops it since the character class is pure ASCII and `u` is unnecessary).