### PR TITLE
fix(api): handle invalid memory frontmatter in summary cron

### DIFF
--- a/turbo/apps/api/src/signals/routes/__tests__/cron-summarize-memory.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/cron-summarize-memory.test.ts
@@ -122,6 +122,60 @@ async function seedTwoVersions(
   return { fixture, v2Id };
 }
 
+/**
+ * Seed two versions for a user inside the closed day without mocking their S3
+ * content. The caller supplies a single combined S3 mock (so several users can
+ * coexist on the shared mock), and may deliberately omit a user's content to
+ * make their per-user summarize throw — exercising the cron's per-user error
+ * isolation.
+ */
+async function seedTwoVersionsNoMock(): Promise<{
+  fixture: MemoryFixture;
+  v1Key: string;
+  v2Key: string;
+  v2Id: string;
+}> {
+  const fixture = await track(
+    store.set(seedMemoryFixture$, undefined, context.signal),
+  );
+  const base = `orgs/${fixture.orgId}/users/${fixture.userId}/memory`;
+  const v1Key = `${base}/v1`;
+  const v2Key = `${base}/v2`;
+  const v2Id = `v2-${randomUUID()}`;
+
+  await store.set(
+    seedMemoryStorage$,
+    {
+      orgId: fixture.orgId,
+      userId: fixture.userId,
+      s3Key: v1Key,
+      headVersionId: `v1-${randomUUID()}`,
+      fileCount: 1,
+      updatedAt: new Date("2999-01-02T03:00:00.000Z"),
+    },
+    context.signal,
+  );
+
+  const storageId = await store.set(
+    findMemoryStorageId$,
+    fixture.orgId,
+    context.signal,
+  );
+  await store.set(
+    seedMemoryVersion$,
+    {
+      storageId,
+      versionId: v2Id,
+      s3Key: v2Key,
+      userId: fixture.userId,
+      createdAt: new Date("2999-01-02T09:00:00.000Z"),
+    },
+    context.signal,
+  );
+
+  return { fixture, v1Key, v2Key, v2Id };
+}
+
 interface DayVersion {
   readonly createdAt: Date;
   readonly files: readonly MemoryFile[];
@@ -312,6 +366,39 @@ describe("GET /api/cron/summarize-memory", () => {
     ]);
   });
 
+  it("summarizes a file whose frontmatter is not valid YAML", async () => {
+    // Regression for the prod 500: a memory file whose `description` opens with
+    // a backtick is invalid YAML and made parseSkillFrontmatter throw a
+    // YAMLParseError, which propagated up and 500'd every cron run. The run
+    // must now complete and persist the item with a path-based title.
+    const llm = mockLlm();
+    const seeded = await seedTwoVersions(
+      [{ path: "facts/pets.md", content: "Has a dog" }],
+      [
+        { path: "facts/pets.md", content: "Has a dog" },
+        {
+          path: "facts/zero-search.md",
+          content:
+            "---\nname: zero search\ndescription: `zero search` command shipped in CLI v9.125.x\n---\nbody",
+        },
+      ],
+    );
+
+    const response = await accept(
+      apiClient().summarize({ headers: cronHeaders() }),
+      [200],
+    );
+
+    expect(response.body).toStrictEqual({ summarized: 1 });
+    expect(llm.calls).toBe(1);
+
+    const summary = await findSummary(seeded.fixture);
+    const items = await findItems(summary?.id ?? "");
+    expect(items).toStrictEqual([
+      { kind: "learned", filePath: "facts/zero-search.md" },
+    ]);
+  });
+
   it("folds MEMORY.md churn into the real file change", async () => {
     mockLlm();
     const seeded = await seedTwoVersions(
@@ -418,6 +505,49 @@ describe("GET /api/cron/summarize-memory", () => {
       .where(eq(memoryChangeSummaries.orgId, seeded.fixture.orgId));
     expect(rows).toHaveLength(1);
     await expect(findItems(rows[0]?.id ?? "")).resolves.toHaveLength(1);
+  });
+
+  it("isolates a failing user so others are still summarized", async () => {
+    // Defense-in-depth: one user's data error (here, missing S3 content) must
+    // not abort the whole run. The healthy user must still be summarized.
+    const llm = mockLlm();
+    const healthy = await seedTwoVersionsNoMock();
+    const broken = await seedTwoVersionsNoMock();
+
+    // Combined mock: only the healthy user's versions resolve. The broken
+    // user's keys are absent, so its manifest download throws and its per-user
+    // summarize fails — without the isolation that would 500 the whole run.
+    mockMemoryVersions(context, [
+      {
+        s3Key: healthy.v1Key,
+        files: [{ path: "facts/pets.md", content: "Has a dog" }],
+      },
+      {
+        s3Key: healthy.v2Key,
+        files: [
+          { path: "facts/pets.md", content: "Has a dog" },
+          { path: "facts/coffee.md", content: "Drinks oat milk lattes" },
+        ],
+      },
+    ]);
+
+    const response = await accept(
+      apiClient().summarize({ headers: cronHeaders() }),
+      [200],
+    );
+
+    expect(response.body).toStrictEqual({ summarized: 1 });
+    expect(llm.calls).toBe(1);
+
+    const healthySummary = await findSummary(healthy.fixture);
+    expect(healthySummary).not.toBeNull();
+    expect(healthySummary?.toVersionId).toBe(healthy.v2Id);
+    const items = await findItems(healthySummary?.id ?? "");
+    expect(items).toStrictEqual([
+      { kind: "learned", filePath: "facts/coffee.md" },
+    ]);
+
+    await expect(findSummary(broken.fixture)).resolves.toBeNull();
   });
 
   it("backfills every closed day when the cron missed earlier runs", async () => {

--- a/turbo/apps/api/src/signals/services/__tests__/memory-activity-diff.service.test.ts
+++ b/turbo/apps/api/src/signals/services/__tests__/memory-activity-diff.service.test.ts
@@ -94,6 +94,31 @@ describe("computeChangeSet", () => {
     });
   });
 
+  it("falls back to the file path when frontmatter is not valid YAML", () => {
+    // Regression for the prod crash: a memory file whose `description` value
+    // opens with a backtick is a reserved YAML scalar char and makes
+    // parseSkillFrontmatter throw a YAMLParseError. The diff must degrade to a
+    // path-based title instead of letting the whole summary run 500.
+    const content =
+      "---\nname: zero search\ndescription: `zero search` command shipped in CLI v9.125.x\n---\nbody";
+    expect(() => {
+      return computeChangeSet(
+        fileMap([]),
+        fileMap([["facts/zero-search.md", "h1", content]]),
+      );
+    }).not.toThrow();
+
+    const changeSet = computeChangeSet(
+      fileMap([]),
+      fileMap([["facts/zero-search.md", "h1", content]]),
+    );
+    expect(changeSet.items[0]).toMatchObject({
+      kind: "learned",
+      title: "facts/zero-search.md",
+      description: null,
+    });
+  });
+
   it("folds MEMORY.md churn into real file changes (does not emit it)", () => {
     const changeSet = computeChangeSet(
       fileMap([["MEMORY.md", "idx1", "# index v1"]]),

--- a/turbo/apps/api/src/signals/services/cron-summarize-memory.service.ts
+++ b/turbo/apps/api/src/signals/services/cron-summarize-memory.service.ts
@@ -363,9 +363,23 @@ export const summarizeMemory$ = command(
     for (const storage of memoryStorages) {
       const timezone =
         timezoneMap.get(`${storage.orgId}:${storage.userId}`) ?? "UTC";
-      summarized += await get(
-        summarizeUserMemory(db, storage, timezone, now, signal),
+      // Isolate each user: one user's malformed data (e.g. invalid memory
+      // frontmatter) must not abort the whole run for everyone. AbortError
+      // still propagates through `settle`, so a genuine cancellation stops the
+      // loop instead of being swallowed.
+      const result = await settle(
+        get(summarizeUserMemory(db, storage, timezone, now, signal)),
+        signal,
       );
+      if (result.ok) {
+        summarized += result.value;
+      } else {
+        L.warn("Failed to summarize user memory", {
+          orgId: storage.orgId,
+          userId: storage.userId,
+          err: result.error,
+        });
+      }
       signal.throwIfAborted();
     }
 

--- a/turbo/apps/api/src/signals/services/memory-activity-diff.service.ts
+++ b/turbo/apps/api/src/signals/services/memory-activity-diff.service.ts
@@ -4,6 +4,7 @@ import { computed, type Computed } from "ccstate";
 import { env } from "../../lib/env";
 import { extractFilesFromTarGz } from "../../lib/tar";
 import { downloadManifest, downloadS3Buffer } from "../external/s3";
+import { safeSync } from "../utils";
 
 type MemoryChangeKind = "learned" | "updated" | "forgotten";
 
@@ -57,11 +58,17 @@ function deriveTitle(
   content: string | undefined,
 ): { readonly title: string | null; readonly description: string | null } {
   if (content && filePath.endsWith(".md")) {
-    const frontmatter = parseSkillFrontmatter(content);
-    if (frontmatter.description) {
+    // Memory files are free-form, agent-written markdown, so a body that opens
+    // with `---` but is not valid YAML (e.g. a `description` value starting
+    // with a backtick, a reserved YAML scalar char) is expected. Guard the
+    // parse and degrade to a path-based title rather than crashing the run.
+    const parsed = safeSync(() => {
+      return parseSkillFrontmatter(content);
+    });
+    if ("ok" in parsed && parsed.ok.description) {
       return {
-        title: frontmatter.name ?? filePath,
-        description: frontmatter.description,
+        title: parsed.ok.name ?? filePath,
+        description: parsed.ok.description,
       };
     }
   }


### PR DESCRIPTION
## Problem

The Memory Activity daily-summary cron (`GET /api/cron/summarize-memory`, feature #15977) has returned **HTTP 500 on every single run** since deploy (16/16, never succeeded), so no summaries are ever written and the Memory page is empty.

**Root cause (confirmed via prod traces):** a real memory file has frontmatter like:

```
---
name: zero search
description: `zero search` command shipped in CLI v9.125.x with --source chat|...
---
```

The `description` value opens with a backtick, which is invalid YAML — a plain scalar cannot start with a reserved character, so `parseSkillFrontmatter` throws a `YAMLParseError` (`BAD_SCALAR_START` / "Plain value cannot start with reserved character"). `deriveTitle` in the diff service called it unguarded, the throw propagated through `computeMemoryChangeSet` → the cron's per-user loop → `summarizeMemory$`, and the route 500'd. Because the per-user loop was not error-isolated, **one user's malformed frontmatter aborted the whole run for every user.**

## Fix (two layers)

1. **Root cause** — `memory-activity-diff.service.ts`: guard the `parseSkillFrontmatter` call in `deriveTitle` via the centralized `safeSync` helper. Memory files are free-form, agent-written markdown, so invalid/no frontmatter is expected and must degrade gracefully to a path-based title (`{ title: filePath, description: null }`).
2. **Defense-in-depth** — `cron-summarize-memory.service.ts`: isolate each user in the `summarizeMemory$` per-user loop via `settle(...)`. On failure, `L.warn` with `orgId`/`userId`/`err` and continue; on success, accumulate. Genuine cancellation is preserved — `AbortError` rethrows through `settle` and `signal.throwIfAborted()` still runs each iteration, so a real abort stops the loop instead of being swallowed.

The shared `parseSkillFrontmatter` is intentionally left unchanged (also used by skill loading; out of scope).

## Tests

- **Diff service** (`memory-activity-diff.service.test.ts`): a changed file whose `description` opens with a backtick does NOT throw and falls back to the file-path title. Verified this test fails without the fix with the exact prod error (`YAMLParseError: Plain value cannot start with reserved character` `` ` ``).
- **Cron** (`cron-summarize-memory.test.ts`): (a) a file with invalid-YAML frontmatter now completes the run and persists the item; (b) a user whose S3 content errors no longer aborts the run — a healthy user is still summarized while the broken user gets no summary. Verified the isolation test fails without the cron fix (whole run 500s).

Fixes the prod crash from #15977; all 16 cron runs since deploy returned 500.

🤖 Generated with [Claude Code](https://claude.com/claude-code)