### PR TITLE
chore: remove chat scroll to bottom flag

### DIFF
--- a/turbo/apps/platform/src/views/zero-page/zero-chat-thread-page.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-chat-thread-page.tsx
@@ -2740,7 +2740,7 @@ function ChatThreadContent({ thread }: { thread: ChatThreadSignals }) {
               sessionError={sessionError}
               skeletonVisible={skeletonVisible}
             />
-            <ChatScrollToBottomButton
+            <ScrollToBottomButton
               thread={thread}
               skeletonVisible={skeletonVisible}
               sessionError={sessionError}
@@ -2756,7 +2756,7 @@ function ChatThreadContent({ thread }: { thread: ChatThreadSignals }) {
   );
 }
 
-function ChatScrollToBottomButton({
+function ScrollToBottomButton({
   thread,
   skeletonVisible,
   sessionError,
@@ -2765,13 +2765,10 @@ function ChatScrollToBottomButton({
   skeletonVisible: boolean;
   sessionError: string | null;
 }) {
-  const features = useLastResolved(featureSwitch$);
-  const enabled =
-    features?.[FeatureSwitchKey.ChatScrollToBottomButton] ?? false;
   const awayFromBottom = useGet(thread.awayFromBottom$);
   const scrollToBottom = useSet(thread.scrollToBottom$);
 
-  if (!enabled || !awayFromBottom || skeletonVisible || sessionError) {
+  if (!awayFromBottom || skeletonVisible || sessionError) {
     return null;
   }
 

--- a/turbo/packages/connectors/src/feature-switch-key.ts
+++ b/turbo/packages/connectors/src/feature-switch-key.ts
@@ -52,6 +52,5 @@ export enum FeatureSwitchKey {
   ChatArtifactSidebar = "chatArtifactSidebar",
   ChatGithubPrTracking = "chatGithubPrTracking",
   MemoryViewer = "memoryViewer",
-  ChatScrollToBottomButton = "chatScrollToBottomButton",
   ChatRecommendedFollowups = "chatRecommendedFollowups",
 }

--- a/turbo/packages/core/src/__tests__/feature-switch.test.ts
+++ b/turbo/packages/core/src/__tests__/feature-switch.test.ts
@@ -106,9 +106,6 @@ describe("getAllFeatureStates", () => {
     expect(staffOrgStates[FeatureSwitchKey.SessionWorkspaceImageCache]).toBe(
       true,
     );
-    expect(staffOrgStates[FeatureSwitchKey.ChatScrollToBottomButton]).toBe(
-      true,
-    );
     expect(staffOrgStates[FeatureSwitchKey.ChatRecommendedFollowups]).toBe(
       true,
     );
@@ -120,9 +117,6 @@ describe("getAllFeatureStates", () => {
     expect(otherOrgStates[FeatureSwitchKey.SkillsViewer]).toBe(false);
     expect(otherOrgStates[FeatureSwitchKey.SessionWorkspaceImageCache]).toBe(
       false,
-    );
-    expect(otherOrgStates[FeatureSwitchKey.ChatScrollToBottomButton]).toBe(
-      true,
     );
     expect(otherOrgStates[FeatureSwitchKey.ChatRecommendedFollowups]).toBe(
       false,

--- a/turbo/packages/core/src/feature-switch.ts
+++ b/turbo/packages/core/src/feature-switch.ts
@@ -296,12 +296,6 @@ const FEATURE_SWITCHES: Record<FeatureSwitchKey, FeatureSwitch> = {
     enabled: false,
     enabledOrgIdHashes: STAFF_ORG_ID_HASHES,
   },
-  [FeatureSwitchKey.ChatScrollToBottomButton]: {
-    maintainer: "ethan@vm0.ai",
-    description:
-      "Show a floating scroll-to-bottom button in the bottom-right of the chat thread whenever the message list is scrolled away from the bottom. Clicking it jumps to the latest message.",
-    enabled: true,
-  },
   [FeatureSwitchKey.ChatRecommendedFollowups]: {
     maintainer: "linghan@vm0.ai",
     description:


### PR DESCRIPTION
Summary:
- Remove the reintroduced ChatScrollToBottomButton feature switch key and registry entry
- Keep the scroll-to-bottom button always available under its existing runtime visibility conditions
- Rename the live button component to avoid the old feature-switch name lingering in code

Tests:
- pnpm format
- pnpm -F @vm0/core run lint
- pnpm -F @vm0/core run check-types
- pnpm -F @vm0/connectors run lint
- pnpm -F @vm0/connectors run check-types
- NODE_OPTIONS=--max-old-space-size=8192 pnpm -F @vm0/app run lint
- NODE_OPTIONS=--max-old-space-size=8192 pnpm -F @vm0/app run check-types
- pnpm -F @vm0/core exec vitest run src/__tests__/feature-switch.test.ts
- pnpm -F @vm0/app exec vitest run src/views/zero-page/__tests__/chat-scroll-behavior.test.tsx
- pnpm -F @vm0/app exec vitest run src/views/zero-page/__tests__/zero-chat-thread-page-interaction.test.tsx