### PR TITLE
feat: add posthog tracking for follow-ups and connectors

### DIFF
--- a/turbo/apps/platform/src/lib/posthog.ts
+++ b/turbo/apps/platform/src/lib/posthog.ts
@@ -167,3 +167,51 @@ export const captureFirstSkeletonHide$ = command(({ get, set }) => {
     duration_ms: Math.round(performance.now() - startMark),
   });
 });
+
+interface RecommendedFollowupTelemetryItem {
+  readonly kind: string;
+  readonly generationType?: string;
+}
+
+function recommendedFollowupGenerationTypes(
+  followups: readonly RecommendedFollowupTelemetryItem[],
+): string[] {
+  return followups.flatMap((followup) => {
+    return followup.generationType ? [followup.generationType] : [];
+  });
+}
+
+export function captureRecommendedFollowupsShown(args: {
+  readonly messageId: string;
+  readonly followups: readonly RecommendedFollowupTelemetryItem[];
+}): void {
+  if (!POSTHOG_KEY) {
+    return;
+  }
+  posthog.capture("chat_recommended_followups_shown", {
+    assistant_message_id: args.messageId,
+    followup_count: args.followups.length,
+    followup_kinds: args.followups.map((followup) => {
+      return followup.kind;
+    }),
+    generation_types: recommendedFollowupGenerationTypes(args.followups),
+  });
+}
+
+export function captureRecommendedFollowupSelected(args: {
+  readonly messageId: string;
+  readonly followupIndex: number;
+  readonly followupCount: number;
+  readonly followup: RecommendedFollowupTelemetryItem;
+}): void {
+  if (!POSTHOG_KEY) {
+    return;
+  }
+  posthog.capture("chat_recommended_followup_selected", {
+    assistant_message_id: args.messageId,
+    followup_index: args.followupIndex,
+    followup_count: args.followupCount,
+    followup_kind: args.followup.kind,
+    generation_type: args.followup.generationType,
+  });
+}

--- a/turbo/apps/platform/src/views/zero-page/zero-chat-thread-page.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-chat-thread-page.tsx
@@ -93,6 +93,10 @@ import {
 } from "../../signals/api-client.ts";
 import { accept } from "../../lib/accept.ts";
 import {
+  captureRecommendedFollowupSelected,
+  captureRecommendedFollowupsShown,
+} from "../../lib/posthog.ts";
+import {
   AttachmentLightbox,
   CsvPreviewTable,
   downloadAttachmentUrl,
@@ -2840,6 +2844,38 @@ function RecommendedFollowupIcon({
   return <IconPackage size={14} stroke={1.8} />;
 }
 
+function recommendedFollowupShownKey(
+  source: RecommendedFollowupSource,
+): string {
+  return [
+    source.messageId,
+    source.followups.length,
+    ...source.followups.map((followup) => {
+      return `${followup.kind}:${followup.generationType ?? ""}`;
+    }),
+  ].join("|");
+}
+
+function reportRecommendedFollowupsShown(
+  element: HTMLDivElement | null,
+  source: RecommendedFollowupSource,
+): void {
+  if (!element) {
+    return;
+  }
+
+  const shownKey = recommendedFollowupShownKey(source);
+  if (element.dataset.recommendedFollowupsShownKey === shownKey) {
+    return;
+  }
+  element.dataset.recommendedFollowupsShownKey = shownKey;
+
+  captureRecommendedFollowupsShown({
+    messageId: source.messageId,
+    followups: source.followups,
+  });
+}
+
 function RecommendedFollowupList({
   thread,
   source,
@@ -2850,8 +2886,20 @@ function RecommendedFollowupList({
   const [, sendMessage] = useLoadableSet(thread.sendMessage$);
   const modelSelection = useLastResolved(thread.modelSelection$) ?? null;
   const rootSignal = useGet(rootSignal$);
+  const handleRecommendedFollowupsRef = (element: HTMLDivElement | null) => {
+    reportRecommendedFollowupsShown(element, source);
+  };
 
-  const handleSelect = (followup: RecommendedFollowup) => {
+  const handleSelect = (
+    followup: RecommendedFollowup,
+    followupIndex: number,
+  ) => {
+    captureRecommendedFollowupSelected({
+      messageId: source.messageId,
+      followupIndex,
+      followupCount: source.followups.length,
+      followup,
+    });
     detach(
       sendMessage(
         followup.prompt,
@@ -2867,15 +2915,18 @@ function RecommendedFollowupList({
   };
 
   return (
-    <div className="-mx-2 divide-y divide-border/60">
-      {source.followups.map((followup) => {
+    <div
+      ref={handleRecommendedFollowupsRef}
+      className="-mx-2 divide-y divide-border/60"
+    >
+      {source.followups.map((followup, followupIndex) => {
         return (
           <button
             key={followup.prompt}
             type="button"
             className="group flex min-h-10 w-full items-center gap-2 px-2 py-2 text-left transition-colors first:rounded-t-lg last:rounded-b-lg hover:bg-muted/40"
             onClick={() => {
-              handleSelect(followup);
+              handleSelect(followup, followupIndex);
             }}
           >
             <span className="shrink-0 text-muted-foreground/70 transition-colors group-hover:text-foreground">

--- a/turbo/apps/web/app/components/PostHogProvider.tsx
+++ b/turbo/apps/web/app/components/PostHogProvider.tsx
@@ -48,6 +48,17 @@ function ensureInitialized(): void {
   initialized = true;
 }
 
+export function capturePostHogEvent(
+  eventName: string,
+  properties?: Record<string, unknown>,
+): void {
+  ensureInitialized();
+  if (!POSTHOG_KEY) {
+    return;
+  }
+  posthog.capture(eventName, properties);
+}
+
 export function PostHogProvider() {
   const pathname = usePathname();
 

--- a/turbo/apps/web/app/connector/[status]/page.tsx
+++ b/turbo/apps/web/app/connector/[status]/page.tsx
@@ -1,10 +1,11 @@
 "use client";
 
+import { capturePostHogEvent } from "../../components/PostHogProvider";
 import { useTheme } from "../../components/ThemeProvider";
 import Image from "next/image";
 import { IconCheck, IconX } from "@tabler/icons-react";
 import { useSearchParams } from "next/navigation";
-import { use } from "react";
+import { use, useEffect, useRef } from "react";
 
 interface PageProps {
   params: Promise<{ status: string }>;
@@ -24,6 +25,18 @@ export default function ConnectorStatusPage({
   const isSuccess = status === "success";
   const connectorLabel =
     connectorType === "github" ? "GitHub" : connectorType.toUpperCase();
+  const capturedSuccessRef = useRef(false);
+
+  useEffect(() => {
+    if (!isSuccess || capturedSuccessRef.current) {
+      return;
+    }
+    capturedSuccessRef.current = true;
+    capturePostHogEvent("connector_connection_success", {
+      connector_type: connectorType,
+      has_username: Boolean(username),
+    });
+  }, [connectorType, isSuccess, username]);
 
   return (
     <div className="flex min-h-screen items-center justify-center bg-background p-6">


### PR DESCRIPTION
## Summary

- track recommended follow-up impressions and selections in the platform chat UI
- track successful connector connections on the connector success page
- avoid sending follow-up prompt text or connected usernames to PostHog

## Verification

- pnpm -F web lint
- pnpm -F web check-types
- pnpm -F @vm0/app lint
- pnpm -F @vm0/app check-types
- pnpm -F @vm0/app exec vitest run src/views/zero-page/__tests__/zero-session-chat-page.test.tsx
