### PR TITLE
fix: preserve canonical auto memory missing roots

### DIFF
--- a/crates/guest-agent/src/checkpoint.rs
+++ b/crates/guest-agent/src/checkpoint.rs
@@ -18,7 +18,6 @@ use std::io::ErrorKind;
 use api_contracts::generated::types::runners::storage::ArtifactEntryMissingRootPolicy;
 
 const LOG_TAG: &str = "sandbox:guest-agent";
-const API_AUTO_MEMORY_GENERATED_BY: &str = "apiAutoMemory";
 
 #[derive(Clone, Copy)]
 enum CheckpointMode {
@@ -66,32 +65,12 @@ fn fail(
 
 /// Shape one entry of the `artifactSnapshots` payload. Keys are the
 /// camelCase names the web Zod receiver (`artifactSnapshotsSchema`) expects.
-fn build_artifact_snapshot_entry(
-    name: &str,
-    version: &str,
-    mount_path: &str,
-    generated_by: Option<&str>,
-) -> serde_json::Value {
-    let mut entry = json!({
+fn build_artifact_snapshot_entry(name: &str, version: &str, mount_path: &str) -> serde_json::Value {
+    json!({
         "name": name,
         "version": version,
         "mountPath": mount_path,
-    });
-    if let Some(generated_by) = generated_by
-        && let Some(object) = entry.as_object_mut()
-    {
-        object.insert("generatedBy".to_string(), json!(generated_by));
-    }
-    entry
-}
-
-fn artifact_snapshot_generated_by(entry: &env::ArtifactEnv) -> Option<&'static str> {
-    match entry.missing_root_policy {
-        Some(ArtifactEntryMissingRootPolicy::PreserveParentVersion) => {
-            Some(API_AUTO_MEMORY_GENERATED_BY)
-        }
-        _ => None,
-    }
+    })
 }
 
 struct ArtifactSnapshotPlan<'a> {
@@ -193,7 +172,7 @@ async fn upload_session_history(
 
 /// Snapshot artifact entries. Memory rides in `VM0_ARTIFACTS` post-#10602, so
 /// there is no longer a separate memory arm. Payload shape is
-/// `Array<{name, version, mountPath, generatedBy?}>`, matching the webhook
+/// `Array<{name, version, mountPath}>`, matching the webhook
 /// receiver's canonical artifact snapshot schema.
 async fn snapshot_artifact_entries(
     http: &HttpClient,
@@ -239,7 +218,6 @@ async fn snapshot_artifact_entries(
                         &entry.name,
                         &entry.version_id,
                         &entry.mount_path,
-                        artifact_snapshot_generated_by(entry),
                     ),
                 ));
                 continue;
@@ -288,7 +266,6 @@ async fn snapshot_artifact_entries(
                 &entry.name,
                 &entry.version_id,
                 &entry.mount_path,
-                artifact_snapshot_generated_by(entry),
             ));
             continue;
         }
@@ -322,7 +299,6 @@ async fn snapshot_artifact_entries(
             &entry.name,
             &snapshot.version_id,
             &entry.mount_path,
-            artifact_snapshot_generated_by(entry),
         ));
     }
     Ok(Some(serde_json::Value::Array(results)))
@@ -577,7 +553,7 @@ mod tests {
 
     #[test]
     fn artifact_snapshot_entry_shape_matches_receiver_schema() {
-        let entry = build_artifact_snapshot_entry("workspace", "v-abc-123", "/workspace", None);
+        let entry = build_artifact_snapshot_entry("workspace", "v-abc-123", "/workspace");
         assert_eq!(
             entry,
             json!({
@@ -590,7 +566,7 @@ mod tests {
 
     #[test]
     fn artifact_snapshot_entry_uses_camel_case_keys() {
-        let entry = build_artifact_snapshot_entry("n", "v", "/m", None);
+        let entry = build_artifact_snapshot_entry("n", "v", "/m");
         let obj = entry.as_object().expect("entry must be a JSON object");
         // Contract-boundary invariant: the web Zod receiver requires camelCase
         // `mountPath`; a snake_case slip would silently cause a 400 on the
@@ -757,7 +733,6 @@ mod tests {
                 "name": "memory",
                 "version": "old-memory-version",
                 "mountPath": missing_mount.to_string_lossy(),
-                "generatedBy": "apiAutoMemory",
             }]))
         );
         prepare.assert_calls(0);

--- a/turbo/apps/api/src/signals/routes/__tests__/agent-runs-create.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/agent-runs-create.test.ts
@@ -1507,8 +1507,11 @@ describe("POST /api/agent/runs", () => {
     expect(
       session?.artifacts.find((artifact) => {
         return artifact.name === "memory";
-      })?.generatedBy,
-    ).toBe("apiAutoMemory");
+      }),
+    ).toStrictEqual({
+      name: "memory",
+      mountPath: CANONICAL_CLAUDE_MEMORY_MOUNT_PATH,
+    });
 
     const [job] = await db
       .select({ executionContext: runnerJobQueue.executionContext })
@@ -1520,8 +1523,8 @@ describe("POST /api/agent/runs", () => {
         readonly artifacts: readonly {
           readonly mountPath: string;
           readonly vasStorageName: string;
-          readonly archiveUrl: string;
-          readonly manifestUrl?: string;
+          readonly vasStorageId: string;
+          readonly vasVersionId: string;
           readonly missingRootPolicy?: ArtifactEntry["missingRootPolicy"];
         }[];
       };
@@ -1548,7 +1551,7 @@ describe("POST /api/agent/runs", () => {
     ]);
     expect(
       executionContext.storageManifest.artifacts.every((artifact) => {
-        return artifact.archiveUrl && artifact.manifestUrl;
+        return artifact.vasStorageId && artifact.vasVersionId;
       }),
     ).toBeTruthy();
     const memoryArtifact = executionContext.storageManifest.artifacts.find(
@@ -1622,7 +1625,7 @@ describe("POST /api/agent/runs", () => {
     ]);
   });
 
-  it("keeps user-authored canonical memory artifacts strict", async () => {
+  it("applies auto memory policy to canonical memory artifacts", async () => {
     const fx = await fixture();
     const compose = await createCompose({ fixture: fx });
 
@@ -1666,7 +1669,7 @@ describe("POST /api/agent/runs", () => {
     });
     expect(
       executionContext.storageManifest.artifacts[0]?.missingRootPolicy,
-    ).toBeUndefined();
+    ).toBe("preserveParentVersion");
   });
 
   it("keeps user-authored canonical memory mount overrides strict", async () => {
@@ -1734,7 +1737,7 @@ describe("POST /api/agent/runs", () => {
     ]);
   });
 
-  it("keeps continued user-authored canonical memory artifacts strict", async () => {
+  it("keeps auto memory policy for continued canonical memory artifacts", async () => {
     const fx = await fixture();
     const compose = await createCompose({ fixture: fx });
 
@@ -1795,7 +1798,7 @@ describe("POST /api/agent/runs", () => {
           artifact.mountPath === CANONICAL_CLAUDE_MEMORY_MOUNT_PATH
         );
       })?.missingRootPolicy,
-    ).toBeUndefined();
+    ).toBe("preserveParentVersion");
   });
 
   it("includes compose artifacts and volumes in the runner storage manifest", async () => {
@@ -2476,7 +2479,7 @@ describe("POST /api/agent/runs", () => {
     expect(run?.resumedFromCheckpointId).toBe(checkpoint.id);
   });
 
-  it("preserves auto memory policy when resuming checkpoint artifacts", async () => {
+  it("applies auto memory policy when resuming legacy checkpoint artifacts", async () => {
     const fx = await fixture();
     const compose = await createCompose({ fixture: fx });
     const first = await accept(
@@ -2506,7 +2509,6 @@ describe("POST /api/agent/runs", () => {
           {
             name: "memory",
             mountPath: CANONICAL_CLAUDE_MEMORY_MOUNT_PATH,
-            generatedBy: "apiAutoMemory",
           },
         ],
       })
@@ -2548,7 +2550,7 @@ describe("POST /api/agent/runs", () => {
     ).toBe("preserveParentVersion");
   });
 
-  it("keeps user-authored canonical memory checkpoint artifacts strict", async () => {
+  it("applies auto memory policy to canonical memory checkpoint artifacts", async () => {
     const fx = await fixture();
     const compose = await createCompose({ fixture: fx });
     const first = await accept(
@@ -2625,10 +2627,10 @@ describe("POST /api/agent/runs", () => {
           artifact.mountPath === CANONICAL_CLAUDE_MEMORY_MOUNT_PATH
         );
       })?.missingRootPolicy,
-    ).toBeUndefined();
+    ).toBe("preserveParentVersion");
   });
 
-  it("keeps continued canonical body memory checkpoint artifacts strict", async () => {
+  it("applies auto memory policy to continued canonical memory checkpoint artifacts", async () => {
     const fx = await fixture();
     const compose = await createCompose({ fixture: fx });
     const first = await accept(
@@ -2731,6 +2733,6 @@ describe("POST /api/agent/runs", () => {
           artifact.mountPath === CANONICAL_CLAUDE_MEMORY_MOUNT_PATH
         );
       })?.missingRootPolicy,
-    ).toBeUndefined();
+    ).toBe("preserveParentVersion");
   });
 });

--- a/turbo/apps/api/src/signals/routes/__tests__/webhooks-agent-checkpoints.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/webhooks-agent-checkpoints.test.ts
@@ -584,13 +584,11 @@ describe("POST /api/webhooks/agent/checkpoints", () => {
         name: "memory",
         version: "version-bbb",
         mountPath: CANONICAL_CLAUDE_MEMORY_MOUNT_PATH,
-        generatedBy: "apiAutoMemory" as const,
       },
       {
         name: "memory",
         version: "version-codex",
         mountPath: CANONICAL_CODEX_MEMORY_MOUNT_PATH,
-        generatedBy: "apiAutoMemory" as const,
       },
       {
         name: "artifact-c",
@@ -609,13 +607,11 @@ describe("POST /api/webhooks/agent/checkpoints", () => {
         name: "memory",
         version: "version-bbb",
         mountPath: CANONICAL_CLAUDE_MEMORY_MOUNT_PATH,
-        generatedBy: "apiAutoMemory" as const,
       },
       {
         name: "memory",
         version: "version-codex",
         mountPath: CANONICAL_CODEX_MEMORY_MOUNT_PATH,
-        generatedBy: "apiAutoMemory" as const,
       },
       {
         name: "artifact-c",
@@ -679,7 +675,7 @@ describe("POST /api/webhooks/agent/checkpoints", () => {
     expect(session?.artifacts).toStrictEqual(originalSessionArtifacts);
   });
 
-  it("strips canonical memory provenance unless the session expects api auto memory", async () => {
+  it("strips canonical memory provenance from stored checkpoint snapshots", async () => {
     const fixture = await track(seedFixture());
     const artifactSnapshots = [
       {

--- a/turbo/apps/api/src/signals/services/agent-run-create.service.ts
+++ b/turbo/apps/api/src/signals/services/agent-run-create.service.ts
@@ -187,12 +187,6 @@ interface ContextArtifact {
   readonly generatedBy?: "apiAutoMemory";
 }
 
-interface AutoMemoryContextArtifact {
-  readonly name: typeof AUTO_MEMORY_ARTIFACT_NAME;
-  readonly mountPath: string;
-  readonly generatedBy: "apiAutoMemory";
-}
-
 interface StorageContextArtifact extends ContextArtifact {
   readonly missingRootPolicy?: ArtifactEntry["missingRootPolicy"];
 }
@@ -612,24 +606,20 @@ function autoMemoryMountPath(framework: SupportedFramework): string {
     : CANONICAL_CLAUDE_MEMORY_MOUNT_PATH;
 }
 
-function autoMemoryArtifact(
-  framework: SupportedFramework,
-): AutoMemoryContextArtifact {
+function autoMemoryArtifact(framework: SupportedFramework): ContextArtifact {
   return {
     name: AUTO_MEMORY_ARTIFACT_NAME,
     mountPath: autoMemoryMountPath(framework),
-    generatedBy: "apiAutoMemory",
   };
 }
 
-function isAutoMemoryArtifact(
+function isCanonicalAutoMemoryArtifact(
   artifact: ContextArtifact,
   framework: SupportedFramework,
 ): boolean {
   return (
     artifact.name === AUTO_MEMORY_ARTIFACT_NAME &&
-    artifact.mountPath === autoMemoryMountPath(framework) &&
-    artifact.generatedBy === "apiAutoMemory"
+    artifact.mountPath === autoMemoryMountPath(framework)
   );
 }
 
@@ -650,7 +640,8 @@ function withoutSupersededAutoMemoryArtifacts(
 ): readonly ContextArtifact[] {
   return artifacts.filter((artifact, index) => {
     return (
-      index >= slotOwnerIndex || !isAutoMemoryArtifact(artifact, framework)
+      index >= slotOwnerIndex ||
+      !isCanonicalAutoMemoryArtifact(artifact, framework)
     );
   });
 }
@@ -697,9 +688,6 @@ function artifactsForRun(args: {
   const composeContextArtifacts = isContinuation
     ? []
     : composeArtifacts(args.resolved.content);
-  const persistedArtifactStart = composeContextArtifacts.length;
-  const persistedArtifactEnd =
-    persistedArtifactStart + args.resolved.artifacts.length;
   const baseArtifacts = isContinuation
     ? args.resolved.artifacts
     : [...composeContextArtifacts, ...args.resolved.artifacts];
@@ -722,7 +710,7 @@ function artifactsForRun(args: {
   }
 
   const slotOwner = artifacts[autoMemorySlotArtifactIndex]!;
-  if (!isAutoMemoryArtifact(slotOwner, args.framework)) {
+  if (!isCanonicalAutoMemoryArtifact(slotOwner, args.framework)) {
     return {
       artifacts: withoutSupersededAutoMemoryArtifacts(
         artifacts,
@@ -733,14 +721,9 @@ function artifactsForRun(args: {
     };
   }
 
-  const autoMemoryPolicyArtifactIndex =
-    autoMemorySlotArtifactIndex >= persistedArtifactStart &&
-    autoMemorySlotArtifactIndex < persistedArtifactEnd
-      ? autoMemorySlotArtifactIndex
-      : undefined;
   return {
     artifacts,
-    autoMemoryPolicyArtifactIndex,
+    autoMemoryPolicyArtifactIndex: autoMemorySlotArtifactIndex,
   };
 }
 

--- a/turbo/apps/api/src/signals/services/agent-webhook-checkpoints.service.ts
+++ b/turbo/apps/api/src/signals/services/agent-webhook-checkpoints.service.ts
@@ -3,11 +3,6 @@ import {
   webhookCheckpointsContract,
   webhookCheckpointsPrepareHistoryContract,
 } from "@vm0/api-contracts/contracts/webhooks";
-import {
-  CANONICAL_CODEX_MEMORY_MOUNT_PATH,
-  CANONICAL_CLAUDE_MEMORY_MOUNT_PATH,
-} from "@vm0/api-contracts/contracts/runners";
-import { MEMORY_ARTIFACT_NAME } from "@vm0/core/storage-names";
 import { agentRuns } from "@vm0/db/schema/agent-run";
 import { agentSessions } from "@vm0/db/schema/agent-session";
 import { blobs } from "@vm0/db/schema/blob";
@@ -59,7 +54,6 @@ interface CheckpointRunContext {
   readonly additionalVolumes: typeof agentRuns.$inferSelect.additionalVolumes;
   readonly secretNames: readonly string[] | null;
   readonly sessionId: string;
-  readonly sessionArtifacts: readonly ContextArtifact[];
   readonly vars: unknown;
 }
 
@@ -84,46 +78,18 @@ function recordOfStringsOrUndefined(
   return result;
 }
 
-function isCanonicalMemoryMountPath(mountPath: string): boolean {
-  return (
-    mountPath === CANONICAL_CLAUDE_MEMORY_MOUNT_PATH ||
-    mountPath === CANONICAL_CODEX_MEMORY_MOUNT_PATH
-  );
-}
-
-function isApiAutoMemoryArtifact(artifact: ContextArtifact): boolean {
-  return (
-    artifact.generatedBy === "apiAutoMemory" &&
-    artifact.name === MEMORY_ARTIFACT_NAME &&
-    isCanonicalMemoryMountPath(artifact.mountPath)
-  );
-}
-
 function artifactSnapshotsForDb(args: {
   readonly snapshots: CheckpointCreateBody["artifactSnapshots"];
-  readonly expectedArtifacts: readonly ContextArtifact[];
 }): ContextArtifact[] | null {
   if (!args.snapshots || args.snapshots.length === 0) {
     return null;
   }
 
   return args.snapshots.map((snapshot) => {
-    const preserveGeneratedBy =
-      snapshot.generatedBy === "apiAutoMemory" &&
-      snapshot.name === MEMORY_ARTIFACT_NAME &&
-      isCanonicalMemoryMountPath(snapshot.mountPath) &&
-      args.expectedArtifacts.some((artifact) => {
-        return (
-          isApiAutoMemoryArtifact(artifact) &&
-          artifact.name === snapshot.name &&
-          artifact.mountPath === snapshot.mountPath
-        );
-      });
     return {
       name: snapshot.name,
       version: snapshot.version,
       mountPath: snapshot.mountPath,
-      ...(preserveGeneratedBy ? { generatedBy: snapshot.generatedBy } : {}),
     };
   });
 }
@@ -178,7 +144,6 @@ async function loadCheckpointRunContext(
       additionalVolumes: agentRuns.additionalVolumes,
       secretNames: agentRuns.secretNames,
       sessionId: agentRuns.sessionId,
-      sessionArtifacts: agentSessions.artifacts,
       vars: agentRuns.vars,
     })
     .from(agentRuns)
@@ -331,7 +296,6 @@ export const createAgentCheckpoint$ = command(
     };
     const artifactSnapshots = artifactSnapshotsForDb({
       snapshots: input.body.artifactSnapshots,
-      expectedArtifacts: run.sessionArtifacts,
     });
     const volumeVersionsSnapshot = enrichVolumeSnapshot({
       request: input.body.volumeVersionsSnapshot,

--- a/turbo/packages/api-contracts/src/contracts/webhooks.ts
+++ b/turbo/packages/api-contracts/src/contracts/webhooks.ts
@@ -158,8 +158,8 @@ const artifactSnapshotsSchema = z.array(
     name: z.string(),
     version: z.string(),
     mountPath: z.string(),
-    // Internal provenance used by run creation to decide checkpoint-time
-    // behavior on a later resume. It is not exposed by public checkpoint APIs.
+    // Legacy internal provenance accepted for older guest agents. Run creation
+    // decides checkpoint-time behavior from the canonical artifact slot.
     generatedBy: z.literal("apiAutoMemory").optional(),
   }),
 );


### PR DESCRIPTION
## Summary
- preserve missing-root checkpoint policy for canonical auto-memory artifacts without requiring apiAutoMemory provenance
- stop round-tripping apiAutoMemory from guest-agent checkpoint snapshots
- strip legacy checkpoint provenance before storing DB snapshots while still accepting older payloads

Fixes #16046

## Tests
- pnpm -F api lint
- pnpm -F api check-types
- pnpm -F api exec vitest src/signals/routes/__tests__/agent-runs-create.test.ts src/signals/routes/__tests__/webhooks-agent-checkpoints.test.ts --run
- cargo test -p guest-agent artifact_snapshot_ -- --nocapture
- cargo fmt --check -p guest-agent
- pnpm -F web check-types