### PR TITLE
fix(runner): fail closed when proxy registry is unavailable

### DIFF
--- a/crates/runner/mitm-addon/src/auth.py
+++ b/crates/runner/mitm-addon/src/auth.py
@@ -251,6 +251,11 @@ def evict_stale_cache_keys(active_run_ids: set[str]) -> None:
         _auth_state.pop(k, None)
 
 
+def evict_all_cache_keys() -> None:
+    """Remove all auth cache entries when active registry ownership is unknown."""
+    _auth_state.clear()
+
+
 def get_api_url() -> str:
     """Get API URL from mitmproxy options."""
     return ctx.options.vm0_api_url

--- a/crates/runner/mitm-addon/src/mitm_addon.py
+++ b/crates/runner/mitm-addon/src/mitm_addon.py
@@ -351,6 +351,25 @@ def _block_authority_validation_error(flow: http.HTTPFlow, error: AuthorityValid
     )
 
 
+def _block_registry_unavailable(
+    flow: http.HTTPFlow,
+    unavailable: registry.RegistryUnavailable,
+) -> None:
+    flow.metadata[metadata_keys.FIREWALL_ACTION] = "BLOCK"
+    flow.metadata[metadata_keys.FIREWALL_ERROR] = "registry_unavailable"
+    flow.response = http.Response.make(
+        503,
+        json.dumps(
+            {
+                "error": "registry_unavailable",
+                "message": "Proxy registry is unavailable",
+                "reason": unavailable.reason,
+            }
+        ).encode(),
+        {"Content-Type": "application/json"},
+    )
+
+
 # ============================================================================
 # TLS ClientHello Handler
 # ============================================================================
@@ -366,8 +385,11 @@ def tls_clienthello(data: tls.ClientHelloData) -> None:
     if not client_ip:
         return
 
-    vm_info = registry.get_vm_info(client_ip, get_registry_path())
-    if not vm_info:
+    registry_state = registry.load_registry_state(get_registry_path())
+    if isinstance(registry_state, registry.RegistryUnavailable):
+        return
+
+    if client_ip not in registry_state.vms:
         # Not a registered VM - pass through without MITM interception
         # This is critical for CIDR-based rules where all VM traffic is redirected
         data.ignore_connection = True
@@ -396,13 +418,19 @@ async def request(flow: http.HTTPFlow) -> None:
         ctx.log.warn("No client IP available, passing through")
         return
 
-    # Look up VM info from registry
-    vm_context = registry.get_vm_context(client_ip, get_registry_path())
+    registry_state = registry.load_registry_state(get_registry_path())
+    if isinstance(registry_state, registry.RegistryUnavailable):
+        _block_registry_unavailable(flow, registry_state)
+        return
 
-    if not vm_context:
+    # Look up VM info from registry. This pass-through path is valid only after
+    # the registry file loaded successfully; unavailable registry is blocked above.
+    vm_info = registry_state.vms.get(client_ip)
+    if vm_info is None:
         # Not a registered VM, pass through without proxying
         return
-    vm_info, compiled_firewalls, compiled_network_policies = vm_context
+    compiled_firewalls = registry_state.compiled_firewalls.get(client_ip)
+    compiled_network_policies = registry_state.compiled_network_policies[client_ip]
 
     run_id = vm_info.get("runId", "")
 
@@ -876,7 +904,12 @@ def tcp_start(flow: tcp.TCPFlow) -> None:
     if not client_ip:
         return
 
-    vm_info = registry.get_vm_info(client_ip, get_registry_path())
+    registry_state = registry.load_registry_state(get_registry_path())
+    if isinstance(registry_state, registry.RegistryUnavailable):
+        flow.kill()
+        return
+
+    vm_info = registry_state.vms.get(client_ip)
     if not vm_info:
         return
 

--- a/crates/runner/mitm-addon/src/registry.py
+++ b/crates/runner/mitm-addon/src/registry.py
@@ -7,7 +7,7 @@ from pathlib import Path
 from mitmproxy import ctx
 
 import matching
-from auth import evict_stale_cache_keys
+from auth import evict_all_cache_keys, evict_stale_cache_keys
 
 VmContext = tuple[
     dict,
@@ -29,6 +29,17 @@ class _RegistrySnapshot:
     loaded_key: _RegistryCacheKey | None
 
 
+@dataclass(frozen=True)
+class RegistryUnavailable:
+    """Current registry file cannot be trusted as an enforcement source."""
+
+    reason: str
+    message: str
+
+
+RegistryState = _RegistrySnapshot | RegistryUnavailable
+
+
 def _empty_snapshot() -> _RegistrySnapshot:
     return _RegistrySnapshot({}, {}, {}, None)
 
@@ -39,6 +50,7 @@ class _RegistryCacheState:
     # Successful registry state is stored in one snapshot so raw VM entries and
     # compiled matcher sidecars are published together.
     snapshot: _RegistrySnapshot = field(default_factory=_empty_snapshot)
+    unavailable: RegistryUnavailable | None = None
     # Known-bad decoded registry input. Unlike the snapshot loaded key, this
     # means the current snapshot belongs to an older file state and this key
     # should short-circuit until the file changes again.
@@ -52,6 +64,7 @@ class _RegistryCacheState:
     def reset(self, registry_path: str | None = None) -> None:
         self.registry_path = registry_path
         self.snapshot = _empty_snapshot()
+        self.unavailable = None
         self.failed_key = None
         self.stat_error_logged = False
         self.read_error_key = None
@@ -71,6 +84,8 @@ def _path_key(path: Path) -> str:
 
 def _state_for_path(path_key: str) -> _RegistryCacheState:
     if _registry_state.registry_path != path_key:
+        if _registry_state.snapshot.loaded_key is not None:
+            evict_all_cache_keys()
         _registry_state.reset(path_key)
     return _registry_state
 
@@ -109,16 +124,29 @@ def _read_registry_vms(path: Path) -> dict:
     return raw_vms
 
 
-def _load_registry_snapshot(registry_path: str) -> _RegistrySnapshot:
-    """Load the proxy registry snapshot, reusing cached data when possible.
+def _mark_unavailable(
+    state: _RegistryCacheState,
+    *,
+    reason: str,
+    message: str,
+) -> RegistryUnavailable:
+    if state.unavailable is None and state.snapshot.loaded_key is not None:
+        evict_all_cache_keys()
+    state.unavailable = RegistryUnavailable(reason, message)
+    return state.unavailable
+
+
+def load_registry_state(registry_path: str) -> RegistryState:
+    """Load the proxy registry state, reusing cached data when possible.
 
     Cache state is scoped to one active registry path. A successful load
     publishes raw and compiled registry state together in a snapshot keyed by
-    file identity metadata. Malformed registry input is recorded separately as
-    a failed key so repeated reads of the same bad bytes do not reparse or
-    re-warn. File read errors preserve the last snapshot but keep retrying that
-    key, and internal compile/eviction errors are allowed to propagate instead
-    of being treated as stale-cache parse failures.
+    file identity metadata. Registry file stat/read/parse failures publish a
+    separate unavailable state instead of returning a stale snapshot for
+    enforcement. Malformed registry input is recorded separately as a failed key
+    so repeated reads of the same bad bytes do not reparse or re-warn. File read
+    errors keep retrying that key, and internal compile/eviction errors are
+    allowed to propagate.
     """
     path = Path(registry_path)
     path_key = _path_key(path)
@@ -127,28 +155,40 @@ def _load_registry_snapshot(registry_path: str) -> _RegistrySnapshot:
     try:
         st = path.stat()
     except OSError as e:
+        message = str(e)
         if not state.stat_error_logged:
             state.stat_error_logged = True
-            ctx.log.warn(f"Failed to stat proxy registry: {e}")
-        return state.snapshot
+            ctx.log.warn(f"Failed to stat proxy registry: {message}")
+        return _mark_unavailable(state, reason="stat_failed", message=message)
 
     key = (path_key, st.st_dev, st.st_ino, st.st_mtime_ns, st.st_size)
-    if key in (state.snapshot.loaded_key, state.failed_key):
+    if key == state.snapshot.loaded_key:
+        state.unavailable = None
+        state.stat_error_logged = False
+        state.read_error_key = None
         return state.snapshot
+    if key == state.failed_key:
+        return state.unavailable or _mark_unavailable(
+            state,
+            reason="parse_failed",
+            message="proxy registry is unavailable",
+        )
 
     try:
         raw_registry = _read_registry_vms(path)
     except OSError as e:
+        message = str(e)
         state.failed_key = None
         if key != state.read_error_key:
             state.read_error_key = key
-            ctx.log.warn(f"Failed to read proxy registry: {e}")
-        return state.snapshot
+            ctx.log.warn(f"Failed to read proxy registry: {message}")
+        return _mark_unavailable(state, reason="read_failed", message=message)
     except (json.JSONDecodeError, UnicodeDecodeError, _RegistryFormatError) as e:
+        message = str(e)
         state.failed_key = key
         state.read_error_key = None
-        ctx.log.warn(f"Failed to parse proxy registry: {e}")
-        return state.snapshot
+        ctx.log.warn(f"Failed to parse proxy registry: {message}")
+        return _mark_unavailable(state, reason="parse_failed", message=message)
 
     new_registry, malformed_vm_count = _normalize_registry_vms(raw_registry)
     if malformed_vm_count:
@@ -169,6 +209,7 @@ def _load_registry_snapshot(registry_path: str) -> _RegistrySnapshot:
         new_compiled_policy_registry,
         key,
     )
+    state.unavailable = None
     state.failed_key = None
     state.stat_error_logged = False
     state.read_error_key = None
@@ -177,7 +218,10 @@ def _load_registry_snapshot(registry_path: str) -> _RegistrySnapshot:
 
 def load_registry(registry_path: str) -> dict:
     """Load the proxy registry, reusing cached data when possible."""
-    return _load_registry_snapshot(registry_path).vms
+    state = load_registry_state(registry_path)
+    if isinstance(state, RegistryUnavailable):
+        return {}
+    return state.vms
 
 
 def get_vm_info(client_ip: str, registry_path: str) -> dict | None:
@@ -190,7 +234,9 @@ def get_vm_context(
     registry_path: str,
 ) -> VmContext | None:
     """Look up raw VM info with compiled firewall and policy matcher sidecars."""
-    snapshot = _load_registry_snapshot(registry_path)
+    snapshot = load_registry_state(registry_path)
+    if isinstance(snapshot, RegistryUnavailable):
+        return None
     vm_info = snapshot.vms.get(client_ip)
     if vm_info is None:
         return None

--- a/crates/runner/mitm-addon/tests/test_connection_hooks.py
+++ b/crates/runner/mitm-addon/tests/test_connection_hooks.py
@@ -11,6 +11,7 @@ from mitmproxy.flow import Error
 
 import flow_metadata_keys as metadata_keys
 import mitm_addon
+import registry
 import usage
 import usage.buffer as usage_buffer
 from tests.pending_helpers import assert_pending
@@ -391,6 +392,18 @@ class TestTlsClienthello:
         # All registered VMs use MITM — should NOT set ignore_connection
         assert data.ignore_connection is False
 
+    def test_registry_unavailable_does_not_ignore_connection(
+        self, registry_file, make_tls_data, mitm_ctx
+    ):
+        registry.load_registry(str(registry_file))
+        registry_file.unlink()
+        data = make_tls_data(client_ip="10.200.0.1", sni="anything.com")
+
+        with mitm_ctx(registry_path=str(registry_file), api_url="https://api.vm0.ai"):
+            mitm_addon.tls_clienthello(data)
+
+        assert data.ignore_connection is False
+
 
 class TestTcpStart:
     def test_sets_metadata_for_registered_vm(self, registry_file, mitm_ctx, real_tcp_flow):
@@ -424,6 +437,19 @@ class TestTcpStart:
         ):
             mitm_addon.tcp_start(flow)
 
+        assert "vm_run_id" not in flow.metadata
+
+    def test_registry_unavailable_kills_flow(self, registry_file, mitm_ctx, real_tcp_flow):
+        registry.load_registry(str(registry_file))
+        registry_file.unlink()
+        flow = real_tcp_flow(client_ip="10.200.0.1")
+
+        with mitm_ctx(registry_path=str(registry_file)):
+            mitm_addon.tcp_start(flow)
+
+        assert flow.error is not None
+        assert flow.error.msg == Error.KILLED_MESSAGE
+        assert not flow.live
         assert "vm_run_id" not in flow.metadata
 
 

--- a/crates/runner/mitm-addon/tests/test_registry.py
+++ b/crates/runner/mitm-addon/tests/test_registry.py
@@ -88,8 +88,10 @@ class TestLoadRegistry:
         missing = str(tmp_path / "nonexistent.json")
         with patch.object(registry.ctx, "log", MagicMock(), create=True):
             result = registry.load_registry(missing)
+            state = registry.load_registry_state(missing)
 
         assert result == {}
+        assert isinstance(state, registry.RegistryUnavailable)
 
     def test_cache_returns_same_on_unchanged(self, registry_file):
         result1 = registry.load_registry(str(registry_file))
@@ -124,6 +126,21 @@ class TestLoadRegistry:
         assert first["10.200.0.1"]["runId"] == "run-one"
         assert second["10.200.0.1"]["runId"] == "run-two"
         assert second is not first
+
+    def test_registry_path_switch_evicts_header_cache(self, tmp_path):
+        path_a = tmp_path / "registry-a.json"
+        path_b = tmp_path / "registry-b.json"
+        _write_simple_registry(path_a, run_id="run-one")
+        _write_simple_registry(path_b, run_id="run-two")
+        registry.load_registry(str(path_a))
+        set_cached_headers(
+            ("run-one", "api-0"),
+            headers={"Authorization": "Bearer old"},
+        )
+
+        registry.load_registry(str(path_b))
+
+        assert not has_auth_state(("run-one", "api-0"))
 
     def test_missing_different_path_does_not_return_previous_cache(self, tmp_path):
         path_a = tmp_path / "registry-a.json"
@@ -198,19 +215,20 @@ class TestLoadRegistry:
         assert log.warn.call_count == 1
         assert "Failed to stat" in log.warn.call_args_list[0].args[0]
 
-    def test_missing_file_after_success_returns_cached_registry(self, registry_file):
-        """A transiently missing registry file should not drop the last valid cache."""
-        cached = registry.load_registry(str(registry_file))
+    def test_missing_file_after_success_marks_registry_unavailable(self, registry_file):
+        registry.load_registry(str(registry_file))
         registry_file.unlink()
 
         log = MagicMock()
         with patch.object(registry.ctx, "log", log, create=True):
             result1 = registry.load_registry(str(registry_file))
             result2 = registry.load_registry(str(registry_file))
+            state = registry.load_registry_state(str(registry_file))
 
-        assert result1 is cached
-        assert result2 is cached
-        assert result1["10.200.0.1"]["runId"] == "run-abc-123"
+        assert result1 == {}
+        assert result2 == {}
+        assert isinstance(state, registry.RegistryUnavailable)
+        assert state.reason == "stat_failed"
         assert log.warn.call_count == 1
         assert "Failed to stat" in log.warn.call_args_list[0].args[0]
 
@@ -230,9 +248,8 @@ class TestLoadRegistry:
         assert log.warn.call_count == 1
         assert "Failed to parse" in log.warn.call_args_list[0].args[0]
 
-    def test_parse_failure_after_success_returns_cached_registry(self, registry_file):
-        """A transient parse failure should preserve the last valid registry cache."""
-        cached = registry.load_registry(str(registry_file))
+    def test_parse_failure_after_success_marks_registry_unavailable(self, registry_file):
+        registry.load_registry(str(registry_file))
         registry_file.write_text("{ not valid json after success")
 
         log = MagicMock()
@@ -242,17 +259,18 @@ class TestLoadRegistry:
         ):
             result1 = registry.load_registry(str(registry_file))
             result2 = registry.load_registry(str(registry_file))
+            state = registry.load_registry_state(str(registry_file))
 
-        assert result1 is cached
-        assert result2 is cached
-        assert result1["10.200.0.1"]["runId"] == "run-abc-123"
+        assert result1 == {}
+        assert result2 == {}
+        assert isinstance(state, registry.RegistryUnavailable)
+        assert state.reason == "parse_failed"
         assert spy.call_count == 1
         assert log.warn.call_count == 1
         assert "Failed to parse" in log.warn.call_args_list[0].args[0]
 
-    def test_non_object_vms_after_success_returns_cached_registry(self, registry_file):
-        """A registry whose vms field is not an object should preserve last valid cache."""
-        cached = registry.load_registry(str(registry_file))
+    def test_non_object_vms_after_success_marks_registry_unavailable(self, registry_file):
+        registry.load_registry(str(registry_file))
         registry_file.write_text(json.dumps({"vms": ["broken"], "updatedAt": 0}))
 
         log = MagicMock()
@@ -262,16 +280,18 @@ class TestLoadRegistry:
         ):
             result1 = registry.load_registry(str(registry_file))
             result2 = registry.load_registry(str(registry_file))
+            state = registry.load_registry_state(str(registry_file))
 
-        assert result1 is cached
-        assert result2 is cached
-        assert result1["10.200.0.1"]["runId"] == "run-abc-123"
+        assert result1 == {}
+        assert result2 == {}
+        assert isinstance(state, registry.RegistryUnavailable)
+        assert state.reason == "parse_failed"
         assert spy.call_count == 1
         assert log.warn.call_count == 1
         assert "Failed to parse" in log.warn.call_args_list[0].args[0]
 
-    def test_non_object_registry_after_success_returns_cached_registry(self, registry_file):
-        cached = registry.load_registry(str(registry_file))
+    def test_non_object_registry_after_success_marks_registry_unavailable(self, registry_file):
+        registry.load_registry(str(registry_file))
         registry_file.write_text(json.dumps(["broken"]))
 
         log = MagicMock()
@@ -281,9 +301,12 @@ class TestLoadRegistry:
         ):
             result1 = registry.load_registry(str(registry_file))
             result2 = registry.load_registry(str(registry_file))
+            state = registry.load_registry_state(str(registry_file))
 
-        assert result1 is cached
-        assert result2 is cached
+        assert result1 == {}
+        assert result2 == {}
+        assert isinstance(state, registry.RegistryUnavailable)
+        assert state.reason == "parse_failed"
         assert spy.call_count == 1
         assert log.warn.call_count == 1
         assert "Failed to parse" in log.warn.call_args_list[0].args[0]
@@ -334,7 +357,7 @@ class TestLoadRegistry:
             registry.load_registry(str(registry_file))
 
     def test_read_failure_after_stat_does_not_poison_file_key(self, registry_file):
-        cached = registry.load_registry(str(registry_file))
+        registry.load_registry(str(registry_file))
         new_registry = {"vms": {"10.200.0.99": {"runId": "new-run"}}, "updatedAt": 0}
         registry_file.write_text(json.dumps(new_registry))
 
@@ -350,8 +373,7 @@ class TestLoadRegistry:
             failed = registry.load_registry(str(registry_file))
             recovered = registry.load_registry(str(registry_file))
 
-        assert failed is cached
-        assert recovered is not cached
+        assert failed == {}
         assert recovered == {"10.200.0.99": {"runId": "new-run"}}
         assert spy.call_count == 2
         assert log.warn.call_count == 1
@@ -443,8 +465,8 @@ class TestLoadRegistry:
         assert force_refresh_pending(("run-other", "api-0"))
         assert last_force_refresh_at(("run-other", "api-0")) == 200.0
 
-    def test_parse_failure_does_not_evict_header_cache(self, registry_file):
-        """Auth cache eviction only runs after a successfully parsed registry reload."""
+    def test_parse_failure_evicts_header_cache_once(self, registry_file):
+        """Unavailable registry clears auth state once when ownership is unknown."""
         registry.load_registry(str(registry_file))
 
         set_cached_headers(
@@ -454,14 +476,21 @@ class TestLoadRegistry:
         mark_force_refresh(("run-abc-123", "api-0"))
         set_last_force_refresh_at(("run-abc-123", "api-0"), 100.0)
 
-        registry_file.write_text("{ broken while preserving cache")
+        registry_file.write_text("{ broken while evicting cache")
 
-        with patch.object(registry.ctx, "log", MagicMock(), create=True):
+        with (
+            patch.object(registry.ctx, "log", MagicMock(), create=True),
+            patch.object(
+                registry,
+                "evict_all_cache_keys",
+                wraps=registry.evict_all_cache_keys,
+            ) as evict_spy,
+        ):
+            registry.load_registry(str(registry_file))
             registry.load_registry(str(registry_file))
 
-        assert cached_headers(("run-abc-123", "api-0"))
-        assert force_refresh_pending(("run-abc-123", "api-0"))
-        assert last_force_refresh_at(("run-abc-123", "api-0")) == 100.0
+        assert evict_spy.call_count == 1
+        assert not has_auth_state(("run-abc-123", "api-0"))
 
     def test_evicts_marker_only_auth_state_on_run_removal(self, registry_file):
         """Registry eviction removes auth state even when it has no cached headers."""
@@ -728,59 +757,39 @@ class TestGetVmContext:
             matching.FirewallAllow,
         )
 
-    def test_parse_failure_preserves_compiled_context(self, tmp_path):
+    def test_parse_failure_returns_no_compiled_context(self, tmp_path):
         path = tmp_path / "registry.json"
         _write_firewall_registry(path)
         context = registry.get_vm_context("10.200.0.1", str(path))
         assert context is not None
-        vm_info, compiled_firewalls, compiled_network_policies = context
+        _, compiled_firewalls, _ = context
         assert compiled_firewalls is not None
 
         path.write_text("{ broken")
         with patch.object(registry.ctx, "log", MagicMock(), create=True):
-            preserved_context = registry.get_vm_context("10.200.0.1", str(path))
+            unavailable_context = registry.get_vm_context("10.200.0.1", str(path))
+            state = registry.load_registry_state(str(path))
 
-        assert preserved_context is not None
-        preserved_vm_info, preserved_compiled, preserved_compiled_policies = preserved_context
-        assert preserved_vm_info is vm_info
-        assert preserved_compiled is compiled_firewalls
-        assert preserved_compiled_policies is compiled_network_policies
-        assert isinstance(
-            matching.match_compiled_firewall_request(
-                "https://api.example.com/items",
-                "GET",
-                preserved_compiled,
-                preserved_compiled_policies,
-            ),
-            matching.FirewallAllow,
-        )
+        assert unavailable_context is None
+        assert isinstance(state, registry.RegistryUnavailable)
+        assert state.reason == "parse_failed"
 
-    def test_missing_file_preserves_compiled_context(self, tmp_path):
+    def test_missing_file_returns_no_compiled_context(self, tmp_path):
         path = tmp_path / "registry.json"
         _write_firewall_registry(path)
         context = registry.get_vm_context("10.200.0.1", str(path))
         assert context is not None
-        vm_info, compiled_firewalls, compiled_network_policies = context
+        _, compiled_firewalls, _ = context
         assert compiled_firewalls is not None
 
         path.unlink()
         with patch.object(registry.ctx, "log", MagicMock(), create=True):
-            preserved_context = registry.get_vm_context("10.200.0.1", str(path))
+            unavailable_context = registry.get_vm_context("10.200.0.1", str(path))
+            state = registry.load_registry_state(str(path))
 
-        assert preserved_context is not None
-        preserved_vm_info, preserved_compiled, preserved_compiled_policies = preserved_context
-        assert preserved_vm_info is vm_info
-        assert preserved_compiled is compiled_firewalls
-        assert preserved_compiled_policies is compiled_network_policies
-        assert isinstance(
-            matching.match_compiled_firewall_request(
-                "https://api.example.com/items",
-                "GET",
-                preserved_compiled,
-                preserved_compiled_policies,
-            ),
-            matching.FirewallAllow,
-        )
+        assert unavailable_context is None
+        assert isinstance(state, registry.RegistryUnavailable)
+        assert state.reason == "stat_failed"
 
     def test_malformed_network_policy_shape_compiles_without_load_failure(self, tmp_path):
         path = tmp_path / "registry.json"

--- a/crates/runner/mitm-addon/tests/test_request_handler_passthrough.py
+++ b/crates/runner/mitm-addon/tests/test_request_handler_passthrough.py
@@ -1,7 +1,10 @@
 """Pass-through and auto-allow tests for the request hook."""
 
+import json
+
 import flow_metadata_keys as metadata_keys
 import mitm_addon
+import registry
 from tests.request_handler_helpers import _single_firewall_vm, _write_registry
 
 
@@ -25,6 +28,26 @@ async def test_vm0_api_auto_allowed(registry_file, real_flow, mitm_ctx):
         await mitm_addon.request(flow)
 
     assert flow.metadata["firewall_action"] == "ALLOW"
+
+
+async def test_registry_unavailable_blocks_vm0_api_auto_allow(registry_file, real_flow, mitm_ctx):
+    registry.load_registry(str(registry_file))
+    registry_file.write_text("{ broken registry")
+    flow = real_flow(with_response=False, host="api.vm0.ai")
+
+    with mitm_ctx(registry_path=str(registry_file), api_url="https://api.vm0.ai"):
+        await mitm_addon.request(flow)
+
+    assert flow.response is not None
+    assert flow.response.status_code == 503
+    assert json.loads(flow.response.content) == {
+        "error": "registry_unavailable",
+        "message": "Proxy registry is unavailable",
+        "reason": "parse_failed",
+    }
+    assert flow.metadata["firewall_action"] == "BLOCK"
+    assert flow.metadata["firewall_error"] == "registry_unavailable"
+    assert "vm_run_id" not in flow.metadata
 
 
 async def test_vm0_api_test_paths_skip_auto_allow(tmp_path, real_flow, mitm_ctx, headers):
@@ -63,6 +86,40 @@ async def test_vm0_api_test_paths_skip_auto_allow(tmp_path, real_flow, mitm_ctx,
     # entered (firewall_base is written at auth.py:327 up-front).  Step 1's
     # auto-allow would have returned without writing firewall_base.
     assert flow.metadata["firewall_base"] == "https://api.vm0.ai/api/test/oauth-provider"
+
+
+async def test_registry_unavailable_blocks_before_auth_injection(tmp_path, real_flow, mitm_ctx):
+    reg_path = _write_registry(
+        tmp_path,
+        client_ip="10.200.0.5",
+        vm_info=_single_firewall_vm(
+            tmp_path,
+            api_entry={
+                "base": "https://api.github.com",
+                "auth": {"headers": {"Authorization": "Bearer secret"}},
+                "permissions": [{"name": "full-access", "rules": ["ANY /{path+}"]}],
+            },
+            network_policy={
+                "allow": ["full-access"],
+                "deny": [],
+                "ask": [],
+                "unknownPolicy": "allow",
+            },
+        ),
+    )
+    registry.load_registry(str(reg_path))
+    reg_path.unlink()
+    flow = real_flow(with_response=False, client_ip="10.200.0.5", host="api.github.com")
+
+    with mitm_ctx(registry_path=str(reg_path), api_url="https://api.vm0.ai"):
+        await mitm_addon.request(flow)
+
+    assert flow.response is not None
+    assert flow.response.status_code == 503
+    assert flow.request.headers.get("Authorization") is None
+    assert flow.metadata["firewall_action"] == "BLOCK"
+    assert flow.metadata["firewall_error"] == "registry_unavailable"
+    assert "firewall_base" not in flow.metadata
 
 
 async def test_tracks_start_time(registry_file, real_flow, mitm_ctx):

--- a/crates/runner/src/executor.rs
+++ b/crates/runner/src/executor.rs
@@ -862,10 +862,12 @@ async fn execute_new_sandbox(
     {
         Ok(prepared) => prepared,
         Err(e)
-            if workspace_image
-                .as_ref()
-                .is_some_and(WorkspaceImageLease::is_cache_hit) =>
+            if e.retry_without_workspace_image
+                && workspace_image
+                    .as_ref()
+                    .is_some_and(WorkspaceImageLease::is_cache_hit) =>
         {
+            let error = e.error;
             invalidate_workspace_cache_hit(
                 workspace_image.as_ref(),
                 context.run_id,
@@ -875,16 +877,17 @@ async fn execute_new_sandbox(
             warn!(
                 run_id = %context.run_id,
                 sandbox_id = %sandbox_id,
-                error = %e,
+                error = %error,
                 "workspace image cache hit failed during sandbox preparation; retrying with fresh workspace image"
             );
             workspace_image = None;
             create_started_sandbox(
                 factory, context, sandbox_id, config, params, telemetry, None,
             )
-            .await?
+            .await
+            .map_err(|e| e.error)?
         }
-        Err(e) => return Err(e),
+        Err(e) => return Err(e.error),
     };
 
     let mut outcome = execute_prepared_sandbox_run(
@@ -915,6 +918,27 @@ struct PreparedSandboxRun {
     sandbox: Box<dyn Sandbox>,
     source_ip: String,
     network_log_session: NetworkLogSession,
+}
+
+struct SandboxPrepareError {
+    error: RunnerError,
+    retry_without_workspace_image: bool,
+}
+
+impl SandboxPrepareError {
+    fn retry(error: RunnerError) -> Self {
+        Self {
+            error,
+            retry_without_workspace_image: true,
+        }
+    }
+
+    fn fatal(error: RunnerError) -> Self {
+        Self {
+            error,
+            retry_without_workspace_image: false,
+        }
+    }
 }
 
 async fn prepare_workspace_image(
@@ -964,7 +988,7 @@ async fn create_started_sandbox(
     params: &JobParams,
     telemetry: &mut JobTelemetry,
     workspace_image: Option<&WorkspaceImageLease>,
-) -> RunnerResult<PreparedSandboxRun> {
+) -> Result<PreparedSandboxRun, SandboxPrepareError> {
     let sandbox_config = SandboxConfig {
         id: sandbox_id,
         resources: sandbox::ResourceLimits {
@@ -989,21 +1013,34 @@ async fn create_started_sandbox(
         Ok(s) => s,
         Err(e) => {
             telemetry.record("vm_create", t.elapsed(), false, Some(&e.to_string()));
-            return Err(e.into());
+            return Err(SandboxPrepareError::retry(e.into()));
         }
     };
 
     let source_ip = sandbox.source_ip().to_string();
-    let network_log_session = register_proxy(config, context, &source_ip).await;
+    let network_log_session = match register_proxy(config, context, &source_ip).await {
+        Ok(session) => session,
+        Err(e) => {
+            telemetry.record("vm_create", t.elapsed(), false, Some(&e.to_string()));
+            destroy_sandbox_panic_safe(factory, sandbox).await;
+            return Err(SandboxPrepareError::fatal(e));
+        }
+    };
 
     if let Err(e) = sandbox.start().await {
         telemetry.record("vm_create", t.elapsed(), false, Some(&e.to_string()));
-        unregister_proxy_registry(config, context, &source_ip).await;
+        if let Err(unregister_error) = unregister_proxy_registry(config, &source_ip).await {
+            warn!(
+                run_id = %context.run_id,
+                error = %unregister_error,
+                "failed to unregister VM from proxy after sandbox start failure"
+            );
+        }
         network_log_session
             .close_for_upload(context.run_id, &config.network_log_drain)
             .await;
         destroy_sandbox_panic_safe(factory, sandbox).await;
-        return Err(e.into());
+        return Err(SandboxPrepareError::retry(e.into()));
     }
     telemetry.record("vm_create", t.elapsed(), true, None);
 
@@ -1015,12 +1052,18 @@ async fn create_started_sandbox(
             false,
             Some(&e.to_string()),
         );
-        unregister_proxy_registry(config, context, &source_ip).await;
+        if let Err(unregister_error) = unregister_proxy_registry(config, &source_ip).await {
+            warn!(
+                run_id = %context.run_id,
+                error = %unregister_error,
+                "failed to unregister VM from proxy after workspace mount failure"
+            );
+        }
         network_log_session
             .close_for_upload(context.run_id, &config.network_log_drain)
             .await;
         destroy_sandbox_panic_safe(factory, sandbox).await;
-        return Err(e);
+        return Err(SandboxPrepareError::retry(e));
     }
     telemetry.record("workspace_drive_mount", mount_started.elapsed(), true, None);
 
@@ -1081,7 +1124,20 @@ async fn execute_reused_sandbox(
     );
 
     let source_ip = source_ip.to_string();
-    let network_log_session = register_proxy(config, context, &source_ip).await;
+    let network_log_session = match register_proxy(config, context, &source_ip).await {
+        Ok(session) => session,
+        Err(e) => {
+            return ExecuteOutcome {
+                failure: Some(ExecutionFailure::from_error(e.to_string())),
+                sandbox: Some(sandbox),
+                source_ip,
+                network_log_session: None,
+                workspace_image: None,
+                workspace_promotable: false,
+                guest_session_id: None,
+            };
+        }
+    };
 
     let mount_started = Instant::now();
     if let Err(e) = ensure_workspace_drive_mounted(sandbox.as_ref(), context.run_id).await {
@@ -1091,7 +1147,13 @@ async fn execute_reused_sandbox(
             false,
             Some(&e.to_string()),
         );
-        unregister_proxy_registry(config, context, &source_ip).await;
+        if let Err(unregister_error) = unregister_proxy_registry(config, &source_ip).await {
+            warn!(
+                run_id = %context.run_id,
+                error = %unregister_error,
+                "failed to unregister VM from proxy after reused sandbox mount failure"
+            );
+        }
         return ExecuteOutcome {
             failure: Some(ExecutionFailure::from_error(e.to_string())),
             sandbox: Some(sandbox),
@@ -1152,7 +1214,7 @@ async fn execute_prepared_sandbox_run(
         |result| result.stdout_stream_diagnostics,
     );
 
-    post_job_cleanup(
+    let cleanup_result = post_job_cleanup(
         sandbox.as_ref(),
         config,
         context,
@@ -1162,10 +1224,22 @@ async fn execute_prepared_sandbox_run(
     )
     .await;
 
-    let agent_result = match result {
+    let mut agent_result = match result {
         Ok(result) => result,
         Err(e) => AgentExecutionResult::failure_from_error(e.to_string()),
     };
+    if let Err(e) = cleanup_result {
+        warn!(
+            run_id = %context.run_id,
+            error = %e,
+            "post-job proxy cleanup failed"
+        );
+        if agent_result.failure.is_none() {
+            agent_result.failure = Some(ExecutionFailure::from_error(format!(
+                "post-job proxy cleanup failed: {e}"
+            )));
+        }
+    }
 
     // Read CLI-generated session ID for first-run parking.
     let guest_session_id = if agent_result.exit_code() == 0 && context.session_id().is_none() {
@@ -1194,7 +1268,7 @@ async fn register_proxy(
     config: &ExecutorConfig,
     context: &ExecutionContext,
     source_ip: &str,
-) -> NetworkLogSession {
+) -> RunnerResult<NetworkLogSession> {
     let network_log_path = config.log_paths.network_log(context.run_id);
     let proxy_log_path = config.log_paths.proxy_log(context.run_id);
     let run_id_str = context.run_id.to_string();
@@ -1215,24 +1289,24 @@ async fn register_proxy(
         billable_firewalls: &context.billable_firewalls,
         model_usage_provider: context.model_usage_provider.as_deref(),
     };
-    if let Err(e) = config.registry.register_vm(source_ip, &registration).await {
-        warn!(run_id = %context.run_id, error = %e, "failed to register VM in proxy");
-    }
     config
+        .registry
+        .register_vm(source_ip, &registration)
+        .await
+        .map_err(|e| RunnerError::Internal(format!("register VM in proxy registry: {e}")))?;
+    Ok(config
         .network_log_manager
         .register_source_ip(source_ip, network_log_path)
-        .await
+        .await)
 }
 
 /// Unregister a VM from the proxy registry.
-async fn unregister_proxy_registry(
-    config: &ExecutorConfig,
-    context: &ExecutionContext,
-    source_ip: &str,
-) {
-    if let Err(e) = config.registry.unregister_vm(source_ip).await {
-        warn!(run_id = %context.run_id, error = %e, "failed to unregister VM from proxy");
-    }
+async fn unregister_proxy_registry(config: &ExecutorConfig, source_ip: &str) -> RunnerResult<()> {
+    config
+        .registry
+        .unregister_vm(source_ip)
+        .await
+        .map_err(|e| RunnerError::Internal(format!("unregister VM from proxy registry: {e}")))
 }
 
 /// Post-job cleanup: copy logs, unregister proxy registry.
@@ -1248,7 +1322,7 @@ async fn post_job_cleanup(
     source_ip: &str,
     cancelled: bool,
     stdout_stream_diagnostics: AgentStdoutStreamDiagnostics,
-) {
+) -> RunnerResult<()> {
     copy_guest_logs(sandbox, context, &config.log_paths, cancelled).await;
     append_stdout_stream_diagnostics_to_stream_log(
         context.run_id,
@@ -1256,7 +1330,7 @@ async fn post_job_cleanup(
         stdout_stream_diagnostics,
     )
     .await;
-    unregister_proxy_registry(config, context, source_ip).await;
+    unregister_proxy_registry(config, source_ip).await
 }
 
 /// How this run is entering its sandbox. Each field feeds a distinct step:
@@ -4867,7 +4941,8 @@ mod tests {
                 stream_overflowed: true,
             },
         )
-        .await;
+        .await
+        .unwrap();
 
         let system_log = tokio::fs::read(&system_log_path).await.unwrap();
         assert_eq!(system_log, b"guest system log");
@@ -5232,6 +5307,7 @@ mod tests {
     struct QueuedCopyFileSandbox {
         inner: Box<dyn Sandbox>,
         copy_file_results: Mutex<VecDeque<Vec<u8>>>,
+        remove_path_before_copy: Option<std::path::PathBuf>,
     }
 
     impl QueuedCopyFileSandbox {
@@ -5239,7 +5315,13 @@ mod tests {
             Self {
                 inner,
                 copy_file_results: Mutex::new(VecDeque::from(copy_file_results)),
+                remove_path_before_copy: None,
             }
+        }
+
+        fn with_remove_path_before_copy(mut self, path: std::path::PathBuf) -> Self {
+            self.remove_path_before_copy = Some(path);
+            self
         }
     }
 
@@ -5291,6 +5373,9 @@ mod tests {
             host_path: &std::path::Path,
             options: CopyFileOptions,
         ) -> sandbox::Result<sandbox::CopyFileResult> {
+            if let Some(path) = &self.remove_path_before_copy {
+                let _ = std::fs::remove_file(path);
+            }
             let bytes = self
                 .copy_file_results
                 .lock()
@@ -5743,6 +5828,83 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn execute_job_proxy_register_failure_destroys_fresh_sandbox_before_agent_start() {
+        let dir = tempfile::tempdir().unwrap();
+        let config = test_executor_config(dir.path()).await;
+        tokio::fs::remove_file(dir.path().join("proxy-registry.json"))
+            .await
+            .unwrap();
+        let overrides = Arc::new(sandbox_mock::MockSandboxOverrides::new());
+        let factory = MockSandboxFactory::with_overrides(Arc::clone(&overrides));
+
+        let (outcome, _telemetry) = execute_job(
+            &factory,
+            minimal_context(),
+            NewSandboxDispatch {
+                id: SandboxId::new_v4(),
+                reuse_result: SandboxReuseResult::PoolMiss,
+            },
+            &config,
+            &default_params(),
+            tokio_util::sync::CancellationToken::new(),
+        )
+        .await;
+
+        assert_eq!(outcome.exit_code(), 1);
+        let error = outcome.error().unwrap();
+        assert!(
+            error.contains("register VM in proxy registry"),
+            "got: {error}"
+        );
+        assert!(outcome.sandbox.is_none());
+        assert!(outcome.network_log_session.is_none());
+        assert_eq!(overrides.destroy_call_count(), 1);
+        assert!(
+            overrides.start_process_calls().is_empty(),
+            "agent must not start when proxy registry registration fails"
+        );
+    }
+
+    #[tokio::test]
+    async fn execute_reused_sandbox_proxy_register_failure_returns_sandbox_before_agent_start() {
+        let dir = tempfile::tempdir().unwrap();
+        let config = test_executor_config(dir.path()).await;
+        tokio::fs::remove_file(dir.path().join("proxy-registry.json"))
+            .await
+            .unwrap();
+        let overrides = Arc::new(sandbox_mock::MockSandboxOverrides::new());
+        let sandbox = create_overridden_sandbox(Arc::clone(&overrides)).await;
+        let source_ip = sandbox.source_ip().to_string();
+        let ctx = minimal_context();
+        let mut telemetry = test_telemetry(&config, &ctx);
+        let prev_storage = crate::idle_pool::StorageFingerprints::default();
+
+        let outcome = execute_reused_sandbox(
+            sandbox,
+            &source_ip,
+            &ctx,
+            &config,
+            &prev_storage,
+            &mut telemetry,
+            tokio_util::sync::CancellationToken::new(),
+        )
+        .await;
+
+        assert_eq!(outcome.exit_code(), 1);
+        let error = outcome.error().unwrap();
+        assert!(
+            error.contains("register VM in proxy registry"),
+            "got: {error}"
+        );
+        assert!(outcome.sandbox.is_some());
+        assert!(outcome.network_log_session.is_none());
+        assert!(
+            overrides.start_process_calls().is_empty(),
+            "reused sandbox must not start an agent when proxy registration fails"
+        );
+    }
+
+    #[tokio::test]
     async fn execute_job_workspace_mount_failure_destroys_sandbox() {
         let dir = tempfile::tempdir().unwrap();
         let config = test_executor_config(dir.path()).await;
@@ -5886,7 +6048,7 @@ mod tests {
         let sandbox = create_overridden_sandbox(Arc::clone(&overrides)).await;
         let ctx = minimal_context();
         let source_ip = sandbox.source_ip().to_string();
-        let network_log_session = register_proxy(&config, &ctx, &source_ip).await;
+        let network_log_session = register_proxy(&config, &ctx, &source_ip).await.unwrap();
         let sandbox: Box<dyn Sandbox> = Box::new(QueuedCopyFileSandbox::new(
             sandbox,
             vec![b"guest system log\n".to_vec()],
@@ -5921,6 +6083,54 @@ mod tests {
         assert_eq!(system_log, b"guest system log\n");
         let system_stream_log = tokio::fs::read(&system_stream_log_path).await.unwrap();
         assert_eq!(system_stream_log, b"bootstrap diagnostic\n");
+    }
+
+    #[tokio::test]
+    async fn execute_inner_proxy_unregister_failure_marks_successful_run_failed() {
+        let dir = tempfile::tempdir().unwrap();
+        let config = test_executor_config(dir.path()).await;
+        let overrides = Arc::new(sandbox_mock::MockSandboxOverrides::new());
+        let sandbox = create_overridden_sandbox(Arc::clone(&overrides)).await;
+        let ctx = minimal_context();
+        let source_ip = sandbox.source_ip().to_string();
+        let network_log_session = register_proxy(&config, &ctx, &source_ip).await.unwrap();
+        let sandbox: Box<dyn Sandbox> = Box::new(
+            QueuedCopyFileSandbox::new(sandbox, vec![b"guest system log\n".to_vec()])
+                .with_remove_path_before_copy(dir.path().join("proxy-registry.json")),
+        );
+        let mut telemetry = test_telemetry(&config, &ctx);
+
+        let outcome = execute_prepared_sandbox_run(
+            PreparedSandboxRun {
+                sandbox,
+                source_ip,
+                network_log_session,
+            },
+            &ctx,
+            &config,
+            RunStart {
+                restore_guest_state: false,
+                reuse_result: SandboxReuseResult::PoolMiss,
+                prev_storage: None,
+            },
+            &mut telemetry,
+            tokio_util::sync::CancellationToken::new(),
+        )
+        .await;
+
+        assert_eq!(outcome.exit_code(), 1);
+        let error = outcome.error().unwrap();
+        assert!(
+            error.contains("post-job proxy cleanup failed"),
+            "got: {error}"
+        );
+        assert!(
+            error.contains("unregister VM from proxy registry"),
+            "got: {error}"
+        );
+        assert!(outcome.sandbox.is_some());
+        assert!(outcome.network_log_session.is_some());
+        assert!(outcome.guest_session_id.is_none());
     }
 
     #[tokio::test]
@@ -6107,6 +6317,74 @@ mod tests {
         assert!(
             !expected_seed.exists(),
             "failed cache hit should invalidate the unusable baseline"
+        );
+    }
+
+    #[tokio::test]
+    async fn execute_inner_does_not_retry_workspace_cache_hit_after_proxy_register_failure() {
+        let dir = tempfile::tempdir().unwrap();
+        let runner_paths = RunnerPaths::new(dir.path().join("runner"));
+        let cache = SessionWorkspaceCache::new(runner_paths.clone());
+        let mut config = test_executor_config(dir.path()).await;
+        config.workspace_cache = Some(cache.clone());
+        tokio::fs::remove_file(dir.path().join("proxy-registry.json"))
+            .await
+            .unwrap();
+        let overrides = Arc::new(sandbox_mock::MockSandboxOverrides::new());
+        let factory = MockSandboxFactory::with_overrides(Arc::clone(&overrides));
+        let mut ctx = minimal_context();
+        ctx.resume_session = Some(ResumeSession {
+            session_id: "sess-register-fail".into(),
+            session_history: r#"{"type":"init"}"#.into(),
+        });
+        ctx.feature_flags = Some(HashMap::from([(
+            SESSION_WORKSPACE_IMAGE_CACHE_FEATURE_FLAG.into(),
+            true,
+        )]));
+        let params = JobParams {
+            workspace_disk_mb: 16,
+            ..default_params()
+        };
+        let expected_seed =
+            seed_workspace_image_cache(&cache, &runner_paths, "sess-register-fail", 16).await;
+        let mut telemetry = test_telemetry(&config, &ctx);
+
+        let result = execute_new_sandbox(
+            &factory,
+            &ctx,
+            NewSandboxDispatch {
+                id: SandboxId::new_v4(),
+                reuse_result: SandboxReuseResult::PoolMiss,
+            },
+            &config,
+            &params,
+            &mut telemetry,
+            tokio_util::sync::CancellationToken::new(),
+        )
+        .await;
+
+        assert!(
+            result.is_err(),
+            "proxy registration failure must return an error"
+        );
+        let err = result.err().unwrap();
+        assert!(
+            err.to_string().contains("register VM in proxy registry"),
+            "got: {err}"
+        );
+        assert_eq!(
+            overrides.create_configs().len(),
+            1,
+            "proxy registration failure must not retry with a fresh workspace image"
+        );
+        assert_eq!(overrides.destroy_call_count(), 1);
+        assert!(
+            overrides.start_process_calls().is_empty(),
+            "agent must not start when proxy registry registration fails"
+        );
+        assert!(
+            expected_seed.exists(),
+            "proxy registration failure must not invalidate the unrelated workspace cache hit"
         );
     }
 


### PR DESCRIPTION
## Summary
- make mitm-addon distinguish loaded registry state from registry_unavailable and fail closed for HTTP/TLS/TCP paths
- clear firewall auth cache when registry ownership becomes unknown or the registry path changes
- make runner proxy registry registration fail run preparation, and make cleanup unregister failures fail otherwise successful runs

## Tests
- `cd crates/runner/mitm-addon && uv run --extra test pytest tests/test_registry.py tests/test_request_handler_passthrough.py tests/test_connection_hooks.py`
- `cd crates/runner/mitm-addon && uv run --extra dev ruff check .`
- `cd crates/runner/mitm-addon && uv run --extra dev basedpyright`
- `cargo test --manifest-path crates/runner/Cargo.toml proxy_register_failure -- --nocapture`
- `cargo test --manifest-path crates/runner/Cargo.toml proxy_unregister_failure -- --nocapture`
- `cargo test --manifest-path crates/runner/Cargo.toml does_not_retry_workspace_cache_hit_after_proxy_register_failure -- --nocapture`
- `cargo test --manifest-path crates/runner/Cargo.toml retries_fresh_after_workspace_cache_hit_create_failure -- --nocapture`
- `cargo test --manifest-path crates/runner/Cargo.toml post_job_cleanup_appends_stream_markers_after_guest_log_copy -- --nocapture`
- `cargo test --manifest-path crates/runner/Cargo.toml execute_inner_happy_path -- --nocapture`
- `cargo test --manifest-path crates/runner/Cargo.toml execute_job_workspace_mount_failure_destroys_sandbox -- --nocapture`
- `cargo clippy --manifest-path crates/runner/Cargo.toml --tests -- -D warnings`
- `git diff --check`
- pre-commit hook via lefthook

Closes #15968
