### PR TITLE
Support input-only connector refresh access

### DIFF
--- a/turbo/apps/api/src/signals/routes/__tests__/webhooks-agent-firewall-auth.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/webhooks-agent-firewall-auth.test.ts
@@ -10,6 +10,7 @@ import { webhookFirewallAuthContract } from "@vm0/api-contracts/contracts/webhoo
 import type { ConnectorAuthClientConfig } from "@vm0/connectors/connectors";
 import { getConnectorAuthMethod } from "@vm0/connectors/connector-utils";
 import {
+  testOauthApiTokenProvider,
   testOauthApiProvider,
   testOauthProvider,
 } from "@vm0/connectors/auth-providers/oauth/providers/test-oauth-provider";
@@ -497,6 +498,69 @@ async function seedExpiredTestOAuthApiConnector(
   });
 }
 
+async function seedTestOAuthApiTokenConnector(
+  fixture: FirewallFixture,
+  args: {
+    readonly accessToken?: string;
+    readonly tokenExpiresAt?: Date | null;
+    readonly inputSecret?: string | undefined;
+    readonly inputVariable?: string | undefined;
+  } = {},
+): Promise<void> {
+  const db = store.set(writeDb$);
+  await db.insert(connectors).values({
+    orgId: fixture.orgId,
+    userId: fixture.userId,
+    type: "test-oauth",
+    authMethod: "api-token",
+    externalId: "test-oauth-api-token-user",
+    externalUsername: "test-oauth-api-token-user",
+    externalEmail: "test-oauth-api-token@example.com",
+    oauthScopes: JSON.stringify([]),
+    tokenExpiresAt:
+      args.tokenExpiresAt === undefined
+        ? new Date(now() - 60_000)
+        : args.tokenExpiresAt,
+  });
+
+  const inputSecret =
+    "inputSecret" in args
+      ? args.inputSecret
+      : "test-oauth-api-token-input-secret";
+  if (inputSecret !== undefined) {
+    await seedSecret({
+      orgId: fixture.orgId,
+      userId: fixture.userId,
+      name: "TEST_OAUTH_TOKEN",
+      value: inputSecret,
+      type: "connector",
+    });
+  }
+
+  const inputVariable =
+    "inputVariable" in args
+      ? args.inputVariable
+      : "test-oauth-api-token-input-variable";
+  if (inputVariable !== undefined) {
+    await seedVariable({
+      orgId: fixture.orgId,
+      userId: fixture.userId,
+      name: "TEST_OAUTH_API_TOKEN_INPUT_VAR",
+      value: inputVariable,
+    });
+  }
+
+  if (args.accessToken !== undefined) {
+    await seedSecret({
+      orgId: fixture.orgId,
+      userId: fixture.userId,
+      name: "TEST_OAUTH_API_TOKEN_ACCESS_TOKEN",
+      value: args.accessToken,
+      type: "connector",
+    });
+  }
+}
+
 async function seedStripeApiTokenConnector(
   fixture: FirewallFixture,
   args: { readonly token?: string } = {},
@@ -565,6 +629,11 @@ type CapturedOAuthRefresh = {
   readonly tenantId?: string;
 };
 
+type CapturedInputOnlyRefresh = {
+  readonly inputSecret: string;
+  readonly inputVariable: string;
+};
+
 type TestOAuthApiRefreshOutputs = {
   readonly refreshedAccessToken: string;
   readonly refreshedRefreshToken?: string;
@@ -607,6 +676,21 @@ function useMalformedTestOAuthApiRefresh(args: {
   return {
     refreshes,
     restore: configureMalformedTestOAuthApiRefresh(refreshes, args.outputs),
+  };
+}
+
+function useTestOAuthApiTokenRefresh(
+  args: {
+    readonly accessToken?: string;
+  } = {},
+): {
+  readonly refreshes: readonly CapturedInputOnlyRefresh[];
+  readonly restore: () => void;
+} {
+  const refreshes: CapturedInputOnlyRefresh[] = [];
+  return {
+    refreshes,
+    restore: configureTestOAuthApiTokenRefresh(refreshes, args.accessToken),
   };
 }
 
@@ -682,6 +766,33 @@ function configureDynamicTestOAuthApiRefresh(
 
   return () => {
     Object.assign(method, { client: originalClient });
+    access.refresh = originalRefresh;
+  };
+}
+
+function configureTestOAuthApiTokenRefresh(
+  refreshes: CapturedInputOnlyRefresh[],
+  accessToken?: string,
+): () => void {
+  const access = testOauthApiTokenProvider.access;
+  const originalRefresh = access.refresh;
+
+  access.refresh = (args) => {
+    refreshes.push({
+      inputSecret: args.inputs.inputSecret,
+      inputVariable: args.inputs.inputVariable,
+    });
+    return Promise.resolve({
+      outputs: {
+        accessToken:
+          accessToken ??
+          `fresh-test-oauth-api-token:${args.inputs.inputSecret}:${args.inputs.inputVariable}`,
+      },
+      expiresIn: 3600,
+    });
+  };
+
+  return () => {
     access.refresh = originalRefresh;
   };
 }
@@ -2245,6 +2356,210 @@ describe("POST /api/webhooks/agent/firewall/auth", () => {
         type: "connector",
       }),
     ).resolves.toBe("test-oauth-api-refresh-token");
+  });
+
+  it("resolves a missing input-only connector access secret through refresh metadata", async () => {
+    const inputOnlyRefresh = useTestOAuthApiTokenRefresh();
+    restoreDynamicTestOAuthRefresh = inputOnlyRefresh.restore;
+    const fixture = await track(seedFixture());
+    await seedTestOAuthApiTokenConnector(fixture);
+
+    const response = await accept(
+      firewallClient().resolve({
+        body: {
+          encryptedSecrets: encryptedSecrets({}),
+          authHeaders: {
+            Authorization: `Bearer ${secretTemplate("TEST_OAUTH_API_TOKEN")}`,
+          },
+          secretConnectorMap: {
+            TEST_OAUTH_API_TOKEN: "test-oauth",
+          },
+        },
+        headers: authHeaders(fixture),
+      }),
+      [200],
+    );
+
+    expect(inputOnlyRefresh.refreshes).toStrictEqual([
+      {
+        inputSecret: "test-oauth-api-token-input-secret",
+        inputVariable: "test-oauth-api-token-input-variable",
+      },
+    ]);
+    expect(response.body.headers.Authorization).toBe(
+      "Bearer fresh-test-oauth-api-token:test-oauth-api-token-input-secret:test-oauth-api-token-input-variable",
+    );
+    expect(response.body.refreshedConnectors).toStrictEqual(["test-oauth"]);
+    expect(response.body.refreshedSecrets).toStrictEqual([
+      "TEST_OAUTH_API_TOKEN",
+    ]);
+    await expect(
+      readSecret({
+        orgId: fixture.orgId,
+        userId: fixture.userId,
+        name: "TEST_OAUTH_API_TOKEN_ACCESS_TOKEN",
+        type: "connector",
+      }),
+    ).resolves.toBe(
+      "fresh-test-oauth-api-token:test-oauth-api-token-input-secret:test-oauth-api-token-input-variable",
+    );
+  });
+
+  it("reuses current input-only connector access without refreshing", async () => {
+    const inputOnlyRefresh = useTestOAuthApiTokenRefresh();
+    restoreDynamicTestOAuthRefresh = inputOnlyRefresh.restore;
+    const fixture = await track(seedFixture());
+    await seedTestOAuthApiTokenConnector(fixture, {
+      accessToken: "current-test-oauth-api-token",
+      tokenExpiresAt: new Date(now() + 60 * 60 * 1000),
+    });
+
+    const response = await accept(
+      firewallClient().resolve({
+        body: {
+          encryptedSecrets: encryptedSecrets({}),
+          authHeaders: {
+            Authorization: `Bearer ${secretTemplate("TEST_OAUTH_API_TOKEN")}`,
+          },
+          secretConnectorMap: {
+            TEST_OAUTH_API_TOKEN: "test-oauth",
+          },
+        },
+        headers: authHeaders(fixture),
+      }),
+      [200],
+    );
+
+    expect(inputOnlyRefresh.refreshes).toStrictEqual([]);
+    expect(response.body.headers.Authorization).toBe(
+      "Bearer current-test-oauth-api-token",
+    );
+    expect(response.body.refreshedConnectors).toStrictEqual([]);
+    expect(response.body.refreshedSecrets).toStrictEqual([]);
+  });
+
+  it("refreshes expired input-only connector access", async () => {
+    const inputOnlyRefresh = useTestOAuthApiTokenRefresh({
+      accessToken: "fresh-expired-test-oauth-api-token",
+    });
+    restoreDynamicTestOAuthRefresh = inputOnlyRefresh.restore;
+    const fixture = await track(seedFixture());
+    await seedTestOAuthApiTokenConnector(fixture, {
+      accessToken: "stale-test-oauth-api-token",
+      tokenExpiresAt: new Date(now() - 60_000),
+    });
+
+    const response = await accept(
+      firewallClient().resolve({
+        body: {
+          encryptedSecrets: encryptedSecrets({
+            TEST_OAUTH_API_TOKEN: "stale-test-oauth-api-token",
+          }),
+          authHeaders: {
+            Authorization: `Bearer ${secretTemplate("TEST_OAUTH_API_TOKEN")}`,
+          },
+          secretConnectorMap: {
+            TEST_OAUTH_API_TOKEN: "test-oauth",
+          },
+        },
+        headers: authHeaders(fixture),
+      }),
+      [200],
+    );
+
+    expect(inputOnlyRefresh.refreshes).toStrictEqual([
+      {
+        inputSecret: "test-oauth-api-token-input-secret",
+        inputVariable: "test-oauth-api-token-input-variable",
+      },
+    ]);
+    expect(response.body.headers.Authorization).toBe(
+      "Bearer fresh-expired-test-oauth-api-token",
+    );
+    expect(response.body.refreshedConnectors).toStrictEqual(["test-oauth"]);
+    expect(response.body.refreshedSecrets).toStrictEqual([
+      "TEST_OAUTH_API_TOKEN",
+    ]);
+  });
+
+  it("force refreshes current input-only connector access", async () => {
+    const inputOnlyRefresh = useTestOAuthApiTokenRefresh({
+      accessToken: "fresh-forced-test-oauth-api-token",
+    });
+    restoreDynamicTestOAuthRefresh = inputOnlyRefresh.restore;
+    const fixture = await track(seedFixture());
+    await seedTestOAuthApiTokenConnector(fixture, {
+      accessToken: "current-test-oauth-api-token",
+      tokenExpiresAt: new Date(now() + 60 * 60 * 1000),
+    });
+
+    const response = await accept(
+      firewallClient().resolve({
+        body: {
+          encryptedSecrets: encryptedSecrets({
+            TEST_OAUTH_API_TOKEN: "current-test-oauth-api-token",
+          }),
+          authHeaders: {
+            Authorization: `Bearer ${secretTemplate("TEST_OAUTH_API_TOKEN")}`,
+          },
+          secretConnectorMap: {
+            TEST_OAUTH_API_TOKEN: "test-oauth",
+          },
+          forceRefresh: true,
+        },
+        headers: authHeaders(fixture),
+      }),
+      [200],
+    );
+
+    expect(inputOnlyRefresh.refreshes).toStrictEqual([
+      {
+        inputSecret: "test-oauth-api-token-input-secret",
+        inputVariable: "test-oauth-api-token-input-variable",
+      },
+    ]);
+    expect(response.body.headers.Authorization).toBe(
+      "Bearer fresh-forced-test-oauth-api-token",
+    );
+    expect(response.body.refreshedConnectors).toStrictEqual(["test-oauth"]);
+    expect(response.body.refreshedSecrets).toStrictEqual([
+      "TEST_OAUTH_API_TOKEN",
+    ]);
+  });
+
+  it("returns refresh failure when input-only connector refresh variables are missing", async () => {
+    const inputOnlyRefresh = useTestOAuthApiTokenRefresh();
+    restoreDynamicTestOAuthRefresh = inputOnlyRefresh.restore;
+    const fixture = await track(seedFixture());
+    await seedTestOAuthApiTokenConnector(fixture, {
+      inputVariable: undefined,
+    });
+
+    const response = await accept(
+      firewallClient().resolve({
+        body: {
+          encryptedSecrets: encryptedSecrets({}),
+          authHeaders: {
+            Authorization: `Bearer ${secretTemplate("TEST_OAUTH_API_TOKEN")}`,
+          },
+          secretConnectorMap: {
+            TEST_OAUTH_API_TOKEN: "test-oauth",
+          },
+        },
+        headers: authHeaders(fixture),
+      }),
+      [502],
+    );
+
+    expect(response.body.error).toMatchObject({
+      code: "TOKEN_REFRESH_FAILED",
+      connectors: ["test-oauth"],
+      failureReason: "reconnect_required",
+    });
+    expect(inputOnlyRefresh.refreshes).toStrictEqual([]);
+    await expect(connectorState(fixture, "test-oauth")).resolves.toMatchObject({
+      needsReconnect: true,
+    });
   });
 
   it("returns refresh failure when provider output omits the runtime token", async () => {

--- a/turbo/apps/api/src/signals/routes/__tests__/webhooks-agent-firewall-auth.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/webhooks-agent-firewall-auth.test.ts
@@ -679,18 +679,14 @@ function useMalformedTestOAuthApiRefresh(args: {
   };
 }
 
-function useTestOAuthApiTokenRefresh(
-  args: {
-    readonly accessToken?: string;
-  } = {},
-): {
+function useTestOAuthApiTokenRefresh(): {
   readonly refreshes: readonly CapturedInputOnlyRefresh[];
   readonly restore: () => void;
 } {
   const refreshes: CapturedInputOnlyRefresh[] = [];
   return {
     refreshes,
-    restore: configureTestOAuthApiTokenRefresh(refreshes, args.accessToken),
+    restore: configureTestOAuthApiTokenRefresh(refreshes),
   };
 }
 
@@ -772,7 +768,6 @@ function configureDynamicTestOAuthApiRefresh(
 
 function configureTestOAuthApiTokenRefresh(
   refreshes: CapturedInputOnlyRefresh[],
-  accessToken?: string,
 ): () => void {
   const access = testOauthApiTokenProvider.access;
   const originalRefresh = access.refresh;
@@ -784,9 +779,7 @@ function configureTestOAuthApiTokenRefresh(
     });
     return Promise.resolve({
       outputs: {
-        accessToken:
-          accessToken ??
-          `fresh-test-oauth-api-token:${args.inputs.inputSecret}:${args.inputs.inputVariable}`,
+        accessToken: `fresh-test-oauth-api-token:${args.inputs.inputSecret}:${args.inputs.inputVariable}`,
       },
       expiresIn: 3600,
     });
@@ -2436,95 +2429,6 @@ describe("POST /api/webhooks/agent/firewall/auth", () => {
     );
     expect(response.body.refreshedConnectors).toStrictEqual([]);
     expect(response.body.refreshedSecrets).toStrictEqual([]);
-  });
-
-  it("refreshes expired input-only connector access", async () => {
-    const inputOnlyRefresh = useTestOAuthApiTokenRefresh({
-      accessToken: "fresh-expired-test-oauth-api-token",
-    });
-    restoreDynamicTestOAuthRefresh = inputOnlyRefresh.restore;
-    const fixture = await track(seedFixture());
-    await seedTestOAuthApiTokenConnector(fixture, {
-      accessToken: "stale-test-oauth-api-token",
-      tokenExpiresAt: new Date(now() - 60_000),
-    });
-
-    const response = await accept(
-      firewallClient().resolve({
-        body: {
-          encryptedSecrets: encryptedSecrets({
-            TEST_OAUTH_API_TOKEN: "stale-test-oauth-api-token",
-          }),
-          authHeaders: {
-            Authorization: `Bearer ${secretTemplate("TEST_OAUTH_API_TOKEN")}`,
-          },
-          secretConnectorMap: {
-            TEST_OAUTH_API_TOKEN: "test-oauth",
-          },
-        },
-        headers: authHeaders(fixture),
-      }),
-      [200],
-    );
-
-    expect(inputOnlyRefresh.refreshes).toStrictEqual([
-      {
-        inputSecret: "test-oauth-api-token-input-secret",
-        inputVariable: "test-oauth-api-token-input-variable",
-      },
-    ]);
-    expect(response.body.headers.Authorization).toBe(
-      "Bearer fresh-expired-test-oauth-api-token",
-    );
-    expect(response.body.refreshedConnectors).toStrictEqual(["test-oauth"]);
-    expect(response.body.refreshedSecrets).toStrictEqual([
-      "TEST_OAUTH_API_TOKEN",
-    ]);
-  });
-
-  it("force refreshes current input-only connector access", async () => {
-    const inputOnlyRefresh = useTestOAuthApiTokenRefresh({
-      accessToken: "fresh-forced-test-oauth-api-token",
-    });
-    restoreDynamicTestOAuthRefresh = inputOnlyRefresh.restore;
-    const fixture = await track(seedFixture());
-    await seedTestOAuthApiTokenConnector(fixture, {
-      accessToken: "current-test-oauth-api-token",
-      tokenExpiresAt: new Date(now() + 60 * 60 * 1000),
-    });
-
-    const response = await accept(
-      firewallClient().resolve({
-        body: {
-          encryptedSecrets: encryptedSecrets({
-            TEST_OAUTH_API_TOKEN: "current-test-oauth-api-token",
-          }),
-          authHeaders: {
-            Authorization: `Bearer ${secretTemplate("TEST_OAUTH_API_TOKEN")}`,
-          },
-          secretConnectorMap: {
-            TEST_OAUTH_API_TOKEN: "test-oauth",
-          },
-          forceRefresh: true,
-        },
-        headers: authHeaders(fixture),
-      }),
-      [200],
-    );
-
-    expect(inputOnlyRefresh.refreshes).toStrictEqual([
-      {
-        inputSecret: "test-oauth-api-token-input-secret",
-        inputVariable: "test-oauth-api-token-input-variable",
-      },
-    ]);
-    expect(response.body.headers.Authorization).toBe(
-      "Bearer fresh-forced-test-oauth-api-token",
-    );
-    expect(response.body.refreshedConnectors).toStrictEqual(["test-oauth"]);
-    expect(response.body.refreshedSecrets).toStrictEqual([
-      "TEST_OAUTH_API_TOKEN",
-    ]);
   });
 
   it("returns refresh failure when input-only connector refresh variables are missing", async () => {

--- a/turbo/apps/api/src/signals/services/agent-webhook-firewall-auth.service.ts
+++ b/turbo/apps/api/src/signals/services/agent-webhook-firewall-auth.service.ts
@@ -8,6 +8,7 @@ import {
 import type { SecretConnectorMetadata } from "@vm0/api-contracts/contracts/runners";
 import {
   connectorRefreshMetadataHasRefreshableSecret,
+  getConnectorAuthClientConfigForMethod,
   getConnectorAuthMethodAccessMetadata,
   getConnectorAuthMethodStorageMetadata,
   getConnectorRuntimeBindingSecretName,
@@ -19,10 +20,14 @@ import {
   type ConnectorAuthMethodAccessMetadata,
   type ConnectorRefreshInputMetadata,
   type ConnectorAuthMethodStorageMetadata,
+  type ConnectorAuthClientForMethod,
 } from "@vm0/connectors/connector-utils";
 import {
+  type ConnectorAuthMethodClientConfig,
+  type ConnectorAuthMethodIdsByAccessKind,
   connectorAuthMethodIdSchema,
   connectorTypeSchema,
+  type RefreshTokenAccessConnectorType,
 } from "@vm0/connectors/connectors";
 import {
   parseBasicAuthTemplates,
@@ -332,11 +337,57 @@ type PreparedRefreshTokenContext =
 type ConnectorRefreshTokenAccessClientRef =
   ConnectorAuthMethodClientRefByAccessKind<"refresh-token">;
 
-type ConnectorPreparedRefreshTokenContext =
-  ConnectorRefreshTokenAccessClientRef & {
-    readonly sourceType: "connector";
-    readonly context: RefreshTokenContext;
-  };
+type ConnectorRefreshTokenAccessMethodRef =
+  ConnectorAuthMethodRefByAccessKind<"refresh-token">;
+
+type ConnectorRefreshTokenAccessClientMethodRef = {
+  readonly [Type in RefreshTokenAccessConnectorType]: {
+    readonly [Method in ConnectorAuthMethodIdsByAccessKind<
+      Type,
+      "refresh-token"
+    >]: [ConnectorAuthMethodClientConfig<Type, Method>] extends [never]
+      ? never
+      : {
+          readonly type: Type;
+          readonly authMethod: Method;
+        };
+  }[ConnectorAuthMethodIdsByAccessKind<Type, "refresh-token">];
+}[RefreshTokenAccessConnectorType];
+
+type ConnectorRefreshTokenAccessNoClientMethodRef = {
+  readonly [Type in RefreshTokenAccessConnectorType]: {
+    readonly [Method in ConnectorAuthMethodIdsByAccessKind<
+      Type,
+      "refresh-token"
+    >]: [ConnectorAuthMethodClientConfig<Type, Method>] extends [never]
+      ? {
+          readonly type: Type;
+          readonly authMethod: Method;
+        }
+      : never;
+  }[ConnectorAuthMethodIdsByAccessKind<Type, "refresh-token">];
+}[RefreshTokenAccessConnectorType];
+
+type ConnectorPreparedRefreshTokenContextFor<
+  Type extends RefreshTokenAccessConnectorType,
+  Method extends ConnectorAuthMethodIdsByAccessKind<Type, "refresh-token">,
+> = {
+  readonly sourceType: "connector";
+  readonly type: Type;
+  readonly authMethod: Method;
+  readonly context: RefreshTokenContext;
+} & ([ConnectorAuthMethodClientConfig<Type, Method>] extends [never]
+  ? Record<never, never>
+  : { readonly authClient: ConnectorAuthClientForMethod<Type, Method> });
+
+type ConnectorPreparedRefreshTokenContext = {
+  readonly [Type in RefreshTokenAccessConnectorType]: {
+    readonly [Method in ConnectorAuthMethodIdsByAccessKind<
+      Type,
+      "refresh-token"
+    >]: ConnectorPreparedRefreshTokenContextFor<Type, Method>;
+  }[ConnectorAuthMethodIdsByAccessKind<Type, "refresh-token">];
+}[RefreshTokenAccessConnectorType];
 
 type ModelProviderPreparedRefreshTokenContext = {
   readonly sourceType: "model-provider";
@@ -346,7 +397,7 @@ type ModelProviderPreparedRefreshTokenContext = {
 };
 
 function resolveRefreshTokenAccessClientRef(
-  authMethodRef: ConnectorAuthMethodRefByAccessKind<"refresh-token">,
+  authMethodRef: ConnectorRefreshTokenAccessClientMethodRef,
 ): ConnectorRefreshTokenAccessClientRef | undefined {
   return resolveConnectorAuthMethodClientRefByAccessKind(
     authMethodRef,
@@ -354,6 +405,45 @@ function resolveRefreshTokenAccessClientRef(
       return optionalEnv(name);
     },
   );
+}
+
+function connectorRefreshTokenAccessMethodHasClient(
+  authMethodRef: ConnectorRefreshTokenAccessMethodRef,
+): authMethodRef is ConnectorRefreshTokenAccessClientMethodRef {
+  return (
+    getConnectorAuthClientConfigForMethod(
+      authMethodRef.type,
+      authMethodRef.authMethod,
+    ) !== undefined
+  );
+}
+
+function connectorRefreshTokenAccessMethodHasNoClient(
+  authMethodRef: ConnectorRefreshTokenAccessMethodRef,
+): authMethodRef is ConnectorRefreshTokenAccessNoClientMethodRef {
+  return !connectorRefreshTokenAccessMethodHasClient(authMethodRef);
+}
+
+function connectorPreparedRefreshTokenContextWithClient(args: {
+  readonly authClientRef: ConnectorRefreshTokenAccessClientRef;
+  readonly context: RefreshTokenContext;
+}): ConnectorPreparedRefreshTokenContext {
+  return {
+    sourceType: "connector",
+    ...args.authClientRef,
+    context: args.context,
+  };
+}
+
+function connectorPreparedRefreshTokenContextWithoutClient(args: {
+  readonly authMethodRef: ConnectorRefreshTokenAccessNoClientMethodRef;
+  readonly context: RefreshTokenContext;
+}): ConnectorPreparedRefreshTokenContext {
+  return {
+    sourceType: "connector",
+    ...args.authMethodRef,
+    context: args.context,
+  };
 }
 
 type PrepareRefreshTokenContextResult =
@@ -1207,13 +1297,6 @@ function prepareRefreshTokenContext(
   if (!connectorAuthMethodRefHasAccessKind(authMethodRef, "refresh-token")) {
     return { ok: false, reason: "not-refreshable" };
   }
-  const authClientRef = resolveRefreshTokenAccessClientRef(authMethodRef);
-  if (!authClientRef) {
-    L.debug(
-      `${args.connectorType} connector client not configured, skipping token refresh`,
-    );
-    return { ok: false, reason: "client-unconfigured" };
-  }
 
   const context: RefreshTokenContext = {
     inputSources: connectorRefreshInputSources(accessMetadata),
@@ -1226,14 +1309,35 @@ function prepareRefreshTokenContext(
     ),
   };
 
-  return {
-    ok: true,
-    prepared: {
-      sourceType: "connector",
-      ...authClientRef,
-      context,
-    },
-  };
+  if (connectorRefreshTokenAccessMethodHasClient(authMethodRef)) {
+    const authClientRef = resolveRefreshTokenAccessClientRef(authMethodRef);
+    if (!authClientRef) {
+      L.debug(
+        `${args.connectorType} connector client not configured, skipping token refresh`,
+      );
+      return { ok: false, reason: "client-unconfigured" };
+    }
+
+    return {
+      ok: true,
+      prepared: connectorPreparedRefreshTokenContextWithClient({
+        authClientRef,
+        context,
+      }),
+    };
+  }
+
+  if (connectorRefreshTokenAccessMethodHasNoClient(authMethodRef)) {
+    return {
+      ok: true,
+      prepared: connectorPreparedRefreshTokenContextWithoutClient({
+        authMethodRef,
+        context,
+      }),
+    };
+  }
+
+  return { ok: false, reason: "not-refreshable" };
 }
 
 function tokenExpiresAtNeedsRefresh(tokenExpiresAt: Date | null): boolean {

--- a/turbo/apps/api/src/signals/services/agent-webhook-firewall-auth.service.ts
+++ b/turbo/apps/api/src/signals/services/agent-webhook-firewall-auth.service.ts
@@ -377,7 +377,7 @@ type ConnectorPreparedRefreshTokenContextFor<
   readonly authMethod: Method;
   readonly context: RefreshTokenContext;
 } & ([ConnectorAuthMethodClientConfig<Type, Method>] extends [never]
-  ? Record<never, never>
+  ? unknown
   : { readonly authClient: ConnectorAuthClientForMethod<Type, Method> });
 
 type ConnectorPreparedRefreshTokenContext = {

--- a/turbo/packages/connectors/src/__tests__/connectors.test.ts
+++ b/turbo/packages/connectors/src/__tests__/connectors.test.ts
@@ -83,7 +83,6 @@ import {
   TEST_OAUTH_DEVICE_ACCESS_SECRET_NAME,
   TEST_OAUTH_DEVICE_API_ACCESS_SECRET_NAME,
 } from "../auth-providers/oauth/providers/test-oauth-device";
-import { testOauthApiTokenProvider } from "../auth-providers/oauth/providers/test-oauth-provider";
 import {
   GOOGLE_OAUTH_CONNECTOR_TYPES,
   isGoogleOAuthConnector,
@@ -1198,40 +1197,6 @@ describe("connector selected auth method capability checks", () => {
       },
       expiresIn: 3600,
     });
-  });
-
-  it("rejects undeclared input-only refresh provider outputs", async () => {
-    const access = testOauthApiTokenProvider.access;
-    const originalRefresh = access.refresh;
-    const malformedRefresh = (
-      args: Parameters<typeof originalRefresh>[0],
-    ): Promise<unknown> => {
-      args.signal.throwIfAborted();
-      return Promise.resolve({
-        outputs: {
-          undeclaredToken: "fresh-undeclared-token",
-        },
-        expiresIn: 3600,
-      });
-    };
-    access.refresh = malformedRefresh as typeof originalRefresh;
-    try {
-      await expect(
-        refreshConnectorAuthProviderAccessToken({
-          type: "test-oauth",
-          authMethod: "api-token",
-          inputs: {
-            inputSecret: "secret-input",
-            inputVariable: "variable-input",
-          },
-          signal: testRefreshSignal(),
-        }),
-      ).rejects.toThrow(
-        "test-oauth connector auth method api-token returned undeclared refresh output undeclaredToken",
-      );
-    } finally {
-      access.refresh = originalRefresh;
-    }
   });
 
   it("starts, polls, and refreshes the Base44 OAuth device provider", async () => {

--- a/turbo/packages/connectors/src/__tests__/connectors.test.ts
+++ b/turbo/packages/connectors/src/__tests__/connectors.test.ts
@@ -704,6 +704,11 @@ describe("connector selected auth method capability checks", () => {
       "test-oauth",
       "api-token"
     >;
+    type DefaultRefreshArgs = ConnectorAuthProviderRefreshArgs<"test-oauth">;
+    type DefaultInputOnlyRefreshArgs = Exclude<
+      DefaultRefreshArgs,
+      { readonly authClient: unknown }
+    >;
 
     expectTypeOf<ClientBackedRefreshArgs["authClient"]>().toEqualTypeOf<
       ConnectorAuthClientForMethod<"test-oauth", "oauth">
@@ -712,6 +717,13 @@ describe("connector selected auth method capability checks", () => {
       keyof InputOnlyRefreshArgs
     >();
     expectTypeOf<InputOnlyRefreshArgs["inputs"]>().toEqualTypeOf<{
+      readonly inputSecret: string;
+      readonly inputVariable: string;
+    }>();
+    expectTypeOf<"authClient">().not.toMatchTypeOf<
+      keyof DefaultInputOnlyRefreshArgs
+    >();
+    expectTypeOf<DefaultInputOnlyRefreshArgs["inputs"]>().toEqualTypeOf<{
       readonly inputSecret: string;
       readonly inputVariable: string;
     }>();

--- a/turbo/packages/connectors/src/__tests__/connectors.test.ts
+++ b/turbo/packages/connectors/src/__tests__/connectors.test.ts
@@ -78,10 +78,12 @@ import {
   revokeConnectorAuthMethodAccessToken,
   startConnectorDeviceAuthorization,
 } from "../auth-providers/connector-auth";
+import type { ConnectorAuthProviderRefreshArgs } from "../auth-providers/types";
 import {
   TEST_OAUTH_DEVICE_ACCESS_SECRET_NAME,
   TEST_OAUTH_DEVICE_API_ACCESS_SECRET_NAME,
 } from "../auth-providers/oauth/providers/test-oauth-device";
+import { testOauthApiTokenProvider } from "../auth-providers/oauth/providers/test-oauth-provider";
 import {
   GOOGLE_OAUTH_CONNECTOR_TYPES,
   isGoogleOAuthConnector,
@@ -324,7 +326,7 @@ describe("connector auth method lifecycle helpers", () => {
     ).toStrictEqual(["oauth", "api"]);
     expect(
       getConnectorAuthMethodIdsForAccessKind("test-oauth", "refresh-token"),
-    ).toStrictEqual(["oauth", "api"]);
+    ).toStrictEqual(["oauth", "api-token", "api"]);
 
     expect(
       connectorAuthMethodHasGrantKind("github", "oauth", "auth-code"),
@@ -694,6 +696,28 @@ describe("connector selected auth method capability checks", () => {
     }
   });
 
+  it("types refresh provider auth clients from the selected auth method", () => {
+    type ClientBackedRefreshArgs = ConnectorAuthProviderRefreshArgs<
+      "test-oauth",
+      "oauth"
+    >;
+    type InputOnlyRefreshArgs = ConnectorAuthProviderRefreshArgs<
+      "test-oauth",
+      "api-token"
+    >;
+
+    expectTypeOf<ClientBackedRefreshArgs["authClient"]>().toEqualTypeOf<
+      ConnectorAuthClientForMethod<"test-oauth", "oauth">
+    >();
+    expectTypeOf<"authClient">().not.toMatchTypeOf<
+      keyof InputOnlyRefreshArgs
+    >();
+    expectTypeOf<InputOnlyRefreshArgs["inputs"]>().toEqualTypeOf<{
+      readonly inputSecret: string;
+      readonly inputVariable: string;
+    }>();
+  });
+
   it("matches exactly the auth methods that declare token revoke", () => {
     expectTypeOf<"github">().toMatchTypeOf<TokenRevokeConnectorType>();
     expectTypeOf<"notion">().not.toMatchTypeOf<TokenRevokeConnectorType>();
@@ -773,12 +797,23 @@ describe("connector selected auth method capability checks", () => {
       ),
     ).toBe(true);
     expect(
+      connectorAuthMethodRefHasAccessKind(
+        { type: "test-oauth", authMethod: "api-token" },
+        "refresh-token",
+      ),
+    ).toBe(true);
+    expect(
       getConnectorAuthMethodIdsForAccessKind("test-oauth", "refresh-token"),
-    ).toStrictEqual(["oauth", "api"]);
+    ).toStrictEqual(["oauth", "api-token", "api"]);
     expect(
       getConnectorAuthMethodEnvBindings("test-oauth", "api"),
     ).toStrictEqual({
       TEST_OAUTH_TOKEN: "$secrets.TEST_OAUTH_API_ACCESS_TOKEN",
+    });
+    expect(
+      getConnectorAuthMethodEnvBindings("test-oauth", "api-token"),
+    ).toStrictEqual({
+      TEST_OAUTH_API_TOKEN: "$secrets.TEST_OAUTH_API_TOKEN_ACCESS_TOKEN",
     });
 
     const authClient = resolveConnectorAuthClientForMethod(
@@ -1144,6 +1179,59 @@ describe("connector selected auth method capability checks", () => {
       getConnectorAuthMethodGrantMetadata("test-oauth-device", "api")?.outputs
         .accessToken?.secretName,
     ).toBe(TEST_OAUTH_DEVICE_API_ACCESS_SECRET_NAME);
+  });
+
+  it("refreshes an input-only connector access provider without an auth client", async () => {
+    await expect(
+      refreshConnectorAuthProviderAccessToken({
+        type: "test-oauth",
+        authMethod: "api-token",
+        inputs: {
+          inputSecret: "secret-input",
+          inputVariable: "variable-input",
+        },
+        signal: testRefreshSignal(),
+      }),
+    ).resolves.toStrictEqual({
+      outputs: {
+        accessToken: "fresh-test-oauth-api-token:secret-input:variable-input",
+      },
+      expiresIn: 3600,
+    });
+  });
+
+  it("rejects undeclared input-only refresh provider outputs", async () => {
+    const access = testOauthApiTokenProvider.access;
+    const originalRefresh = access.refresh;
+    const malformedRefresh = (
+      args: Parameters<typeof originalRefresh>[0],
+    ): Promise<unknown> => {
+      args.signal.throwIfAborted();
+      return Promise.resolve({
+        outputs: {
+          undeclaredToken: "fresh-undeclared-token",
+        },
+        expiresIn: 3600,
+      });
+    };
+    access.refresh = malformedRefresh as typeof originalRefresh;
+    try {
+      await expect(
+        refreshConnectorAuthProviderAccessToken({
+          type: "test-oauth",
+          authMethod: "api-token",
+          inputs: {
+            inputSecret: "secret-input",
+            inputVariable: "variable-input",
+          },
+          signal: testRefreshSignal(),
+        }),
+      ).rejects.toThrow(
+        "test-oauth connector auth method api-token returned undeclared refresh output undeclaredToken",
+      );
+    } finally {
+      access.refresh = originalRefresh;
+    }
   });
 
   it("starts, polls, and refreshes the Base44 OAuth device provider", async () => {
@@ -1942,6 +2030,41 @@ describe("getConnectorAuthMethodAccessMetadata", () => {
     });
   });
 
+  it("supports input-only refresh metadata", () => {
+    expect(
+      getConnectorAuthMethodAccessMetadata("test-oauth", "api-token"),
+    ).toStrictEqual({
+      kind: "refresh-token",
+      inputs: {
+        inputSecret: {
+          valueRef: "$secrets.TEST_OAUTH_TOKEN",
+          source: {
+            kind: "connector-secret",
+            name: "TEST_OAUTH_TOKEN",
+          },
+        },
+        inputVariable: {
+          valueRef: "$vars.TEST_OAUTH_API_TOKEN_INPUT_VAR",
+          source: {
+            kind: "connector-variable",
+            name: "TEST_OAUTH_API_TOKEN_INPUT_VAR",
+          },
+        },
+      },
+      outputs: {
+        accessToken: {
+          valueRef: "$secrets.TEST_OAUTH_API_TOKEN_ACCESS_TOKEN",
+          secretName: "TEST_OAUTH_API_TOKEN_ACCESS_TOKEN",
+        },
+      },
+      refreshableSecrets: ["TEST_OAUTH_API_TOKEN_ACCESS_TOKEN"],
+      envBindings: {
+        TEST_OAUTH_API_TOKEN: "$secrets.TEST_OAUTH_API_TOKEN_ACCESS_TOKEN",
+      },
+      platformSecrets: [],
+    });
+  });
+
   it("returns undefined for an unknown auth method", () => {
     expect(
       getConnectorAuthMethodAccessMetadata("stripe", "missing"),
@@ -2392,9 +2515,16 @@ describe("getConnectorEnvBindingEntries", () => {
       // api-token (if exists): exactly one secret XXX_TOKEN
       const apiTokenFields = getApiTokenManualGrantFields(type);
       if (apiTokenFields) {
+        const apiTokenSecretFields = Object.entries(apiTokenFields)
+          .filter(([, field]) => {
+            return field.storage !== "variable";
+          })
+          .map(([name]) => {
+            return name;
+          });
         expect(
-          Object.keys(apiTokenFields),
-          `${type}: api-token must have exactly ["${prefix}_TOKEN"]`,
+          apiTokenSecretFields,
+          `${type}: api-token must have exactly one secret field ["${prefix}_TOKEN"]`,
         ).toEqual([`${prefix}_TOKEN`]);
       }
     }

--- a/turbo/packages/connectors/src/auth-providers/connector-auth.ts
+++ b/turbo/packages/connectors/src/auth-providers/connector-auth.ts
@@ -9,6 +9,7 @@ import {
   type DeviceAuthGrantConnectorType,
   type ConnectorAuthMethodIdsByAccessKind,
   type ConnectorAuthMethodIdsByRevokeKind,
+  type ConnectorAuthMethodClientConfig,
   type ConnectorRefreshInputValues,
   type ConnectorRevokeInputValues,
   type RefreshTokenAccessConnectorType,
@@ -23,7 +24,6 @@ import {
   isStaticConfidentialConnectorAuthClient,
   resolveConnectorAuthClientForMethod,
   type ConnectorAuthClientForMethod,
-  type ConnectorAuthMethodClientRefByAccessKind,
   type ConnectorAuthMethodClientRefByGrantKind,
   type ConnectorEnvReader,
 } from "@vm0/connectors/connector-utils";
@@ -93,6 +93,7 @@ import { xProvider } from "./oauth/providers/x-provider";
 import { xeroProvider } from "./oauth/providers/xero-provider";
 import { zoomProvider } from "./oauth/providers/zoom-provider";
 import {
+  testOauthApiTokenProvider,
   testOauthApiProvider,
   testOauthProvider,
 } from "./oauth/providers/test-oauth-provider";
@@ -297,6 +298,15 @@ function deviceAuthRefreshProviderEntry<
   return { grant: provider.grant, access: provider.access };
 }
 
+function refreshProviderEntry<
+  Type extends RefreshTokenAccessConnectorType,
+  Method extends ConnectorAuthMethodIdsByAccessKind<Type, "refresh-token">,
+>(provider: {
+  readonly access: RefreshTokenAccessProvider<Type, Method>;
+}): ConnectorRefreshTokenAccessProviderEntry<Type, Method> {
+  return { access: provider.access };
+}
+
 function connectorRefreshTokenAccessProviderFor<
   T extends RefreshTokenAccessConnectorType,
   Method extends ConnectorAuthMethodIdsByAccessKind<T, "refresh-token">,
@@ -418,6 +428,7 @@ const CONNECTOR_AUTH_METHOD_PROVIDERS = {
   supabase: { oauth: authCodeRefreshProviderEntry(supabaseProvider) },
   "test-oauth": {
     oauth: authCodeRefreshProviderEntry(testOauthProvider),
+    "api-token": refreshProviderEntry(testOauthApiTokenProvider),
     api: authCodeRefreshProviderEntry(testOauthApiProvider),
   },
   "test-oauth-device": {
@@ -442,9 +453,6 @@ type ConnectorAuthCodeMethodClientRef =
 type ConnectorDeviceAuthMethodClientRef =
   ConnectorAuthMethodClientRefByGrantKind<"device-auth">;
 
-type ConnectorRefreshTokenAccessMethodClientRef =
-  ConnectorAuthMethodClientRefByAccessKind<"refresh-token">;
-
 type ConnectorAuthCodeAuthorizationUrlArgs =
   ConnectorAuthCodeMethodClientRef & {
     readonly redirectUri: string;
@@ -467,11 +475,39 @@ type ConnectorDeviceAuthorizationPollCallArgs =
     readonly deviceCode: string;
   };
 
-type ConnectorRefreshTokenAccessCallArgs =
-  ConnectorRefreshTokenAccessMethodClientRef & {
-    readonly inputs: Readonly<Record<string, string>>;
-    readonly signal: AbortSignal;
-  };
+type ConnectorRefreshTokenAccessCallArgs<
+  T extends RefreshTokenAccessConnectorType,
+  Method extends ConnectorAuthMethodIdsByAccessKind<T, "refresh-token">,
+  Inputs extends Readonly<Record<string, string>> = ConnectorRefreshInputValues<
+    T,
+    Method
+  >,
+> = {
+  readonly type: T;
+  readonly authMethod: Method;
+  readonly inputs: Inputs;
+  readonly signal: AbortSignal;
+} & ConnectorRefreshTokenAccessClientArgs<T, Method>;
+
+type ConnectorRefreshTokenAccessClientArgs<
+  T extends RefreshTokenAccessConnectorType,
+  Method extends ConnectorAuthMethodIdsByAccessKind<T, "refresh-token">,
+> = [ConnectorAuthMethodClientConfig<T, Method>] extends [never]
+  ? Record<never, never>
+  : { readonly authClient: ConnectorAuthClientForMethod<T, Method> };
+
+type ConnectorRefreshTokenAccessDynamicCallArgs = {
+  readonly [Type in RefreshTokenAccessConnectorType]: {
+    readonly [Method in ConnectorAuthMethodIdsByAccessKind<
+      Type,
+      "refresh-token"
+    >]: ConnectorRefreshTokenAccessCallArgs<
+      Type,
+      Method,
+      Readonly<Record<string, string>>
+    >;
+  }[ConnectorAuthMethodIdsByAccessKind<Type, "refresh-token">];
+}[RefreshTokenAccessConnectorType];
 
 export function buildConnectorAuthCodeAuthorizationUrl<
   T extends AuthCodeGrantConnectorType,
@@ -623,26 +659,15 @@ export async function pollConnectorDeviceAuthorization<
 export function refreshConnectorAuthProviderAccessToken<
   T extends RefreshTokenAccessConnectorType,
   Method extends ConnectorAuthMethodIdsByAccessKind<T, "refresh-token">,
->(args: {
-  readonly type: T;
-  readonly authMethod: Method;
-  readonly authClient: ConnectorAuthClientForMethod<T, Method>;
-  readonly inputs: ConnectorRefreshInputValues<T, Method>;
-  readonly signal: AbortSignal;
-}): Promise<ConnectorAuthProviderRefreshResult<T, Method>>;
+>(
+  args: ConnectorRefreshTokenAccessCallArgs<T, Method>,
+): Promise<ConnectorAuthProviderRefreshResult<T, Method>>;
 export function refreshConnectorAuthProviderAccessToken(
-  args: ConnectorRefreshTokenAccessCallArgs,
+  args: ConnectorRefreshTokenAccessDynamicCallArgs,
 ): Promise<ConnectorAuthProviderRefreshResultBase>;
-export async function refreshConnectorAuthProviderAccessToken<
-  T extends RefreshTokenAccessConnectorType,
-  Method extends ConnectorAuthMethodIdsByAccessKind<T, "refresh-token">,
->(args: {
-  readonly type: T;
-  readonly authMethod: Method;
-  readonly authClient: ConnectorAuthClientForMethod<T, Method>;
-  readonly inputs: ConnectorRefreshInputValues<T, Method>;
-  readonly signal: AbortSignal;
-}): Promise<ConnectorAuthProviderRefreshResult<T, Method>> {
+export async function refreshConnectorAuthProviderAccessToken(
+  args: ConnectorRefreshTokenAccessDynamicCallArgs,
+): Promise<ConnectorAuthProviderRefreshResultBase> {
   const accessMetadata = getConnectorAuthMethodAccessMetadata(
     args.type,
     args.authMethod,
@@ -651,11 +676,7 @@ export async function refreshConnectorAuthProviderAccessToken<
     args.type,
     args.authMethod,
   );
-  const result = await access.refresh({
-    authClient: args.authClient,
-    inputs: args.inputs,
-    signal: args.signal,
-  });
+  const result = await access.refresh(args);
   const declaredOutputs = new Set(Object.keys(accessMetadata.outputs));
   for (const outputName of Object.keys(result.outputs)) {
     if (!declaredOutputs.has(outputName)) {

--- a/turbo/packages/connectors/src/auth-providers/connector-auth.ts
+++ b/turbo/packages/connectors/src/auth-providers/connector-auth.ts
@@ -9,7 +9,6 @@ import {
   type DeviceAuthGrantConnectorType,
   type ConnectorAuthMethodIdsByAccessKind,
   type ConnectorAuthMethodIdsByRevokeKind,
-  type ConnectorAuthMethodClientConfig,
   type ConnectorRefreshInputValues,
   type ConnectorRevokeInputValues,
   type RefreshTokenAccessConnectorType,
@@ -29,6 +28,7 @@ import {
 } from "@vm0/connectors/connector-utils";
 import type {
   AuthCodeConnectorAuthProvider,
+  ConnectorAuthProviderRefreshArgs,
   ConnectorAuthProviderRefreshResultBase,
   ConnectorAuthProviderRefreshResult,
   DeviceAuthConnectorAuthProvider,
@@ -492,9 +492,7 @@ type ConnectorRefreshTokenAccessCallArgs<
 type ConnectorRefreshTokenAccessClientArgs<
   T extends RefreshTokenAccessConnectorType,
   Method extends ConnectorAuthMethodIdsByAccessKind<T, "refresh-token">,
-> = [ConnectorAuthMethodClientConfig<T, Method>] extends [never]
-  ? Record<never, never>
-  : { readonly authClient: ConnectorAuthClientForMethod<T, Method> };
+> = Omit<ConnectorAuthProviderRefreshArgs<T, Method>, "inputs" | "signal">;
 
 type ConnectorRefreshTokenAccessDynamicCallArgs = {
   readonly [Type in RefreshTokenAccessConnectorType]: {

--- a/turbo/packages/connectors/src/auth-providers/connector-auth.ts
+++ b/turbo/packages/connectors/src/auth-providers/connector-auth.ts
@@ -482,17 +482,23 @@ type ConnectorRefreshTokenAccessCallArgs<
     T,
     Method
   >,
-> = {
-  readonly type: T;
-  readonly authMethod: Method;
-  readonly inputs: Inputs;
-  readonly signal: AbortSignal;
-} & ConnectorRefreshTokenAccessClientArgs<T, Method>;
+> =
+  Method extends ConnectorAuthMethodIdsByAccessKind<T, "refresh-token">
+    ? {
+        readonly type: T;
+        readonly authMethod: Method;
+        readonly inputs: Inputs;
+        readonly signal: AbortSignal;
+      } & ConnectorRefreshTokenAccessClientArgs<T, Method>
+    : never;
 
 type ConnectorRefreshTokenAccessClientArgs<
   T extends RefreshTokenAccessConnectorType,
   Method extends ConnectorAuthMethodIdsByAccessKind<T, "refresh-token">,
-> = Omit<ConnectorAuthProviderRefreshArgs<T, Method>, "inputs" | "signal">;
+> =
+  Method extends ConnectorAuthMethodIdsByAccessKind<T, "refresh-token">
+    ? Omit<ConnectorAuthProviderRefreshArgs<T, Method>, "inputs" | "signal">
+    : never;
 
 type ConnectorRefreshTokenAccessDynamicCallArgs = {
   readonly [Type in RefreshTokenAccessConnectorType]: {

--- a/turbo/packages/connectors/src/auth-providers/oauth/providers/test-oauth-provider.ts
+++ b/turbo/packages/connectors/src/auth-providers/oauth/providers/test-oauth-provider.ts
@@ -33,6 +33,13 @@ interface TestOAuthApiRefreshResult {
   readonly expiresIn?: number;
 }
 
+interface TestOAuthApiTokenRefreshResult {
+  readonly outputs: {
+    readonly accessToken: string;
+  };
+  readonly expiresIn?: number;
+}
+
 interface TestOAuthTokenExchange {
   readonly accessToken: string;
   readonly refreshToken: string | null;
@@ -198,6 +205,25 @@ function createTestOauthApiAccess(): RefreshTokenAccessProvider<
   };
 }
 
+function createTestOauthApiTokenAccess(): RefreshTokenAccessProvider<
+  "test-oauth",
+  "api-token"
+> {
+  return {
+    kind: "refresh-token",
+    refresh: async (refreshArgs) => {
+      refreshArgs.signal.throwIfAborted();
+      const providerResult: TestOAuthApiTokenRefreshResult = {
+        outputs: {
+          accessToken: `fresh-test-oauth-api-token:${refreshArgs.inputs.inputSecret}:${refreshArgs.inputs.inputVariable}`,
+        },
+        expiresIn: 3600,
+      };
+      return providerResult;
+    },
+  };
+}
+
 export const testOauthProvider: AuthCodeConnectorAuthProvider<
   "test-oauth",
   "oauth"
@@ -214,4 +240,10 @@ export const testOauthApiProvider: AuthCodeConnectorAuthProvider<
   grant: createTestOauthApiGrant(),
   access: createTestOauthApiAccess(),
   revoke: { kind: "none" },
+};
+
+export const testOauthApiTokenProvider = {
+  access: createTestOauthApiTokenAccess(),
+} as const satisfies {
+  readonly access: RefreshTokenAccessProvider<"test-oauth", "api-token">;
 };

--- a/turbo/packages/connectors/src/auth-providers/types.ts
+++ b/turbo/packages/connectors/src/auth-providers/types.ts
@@ -1,6 +1,7 @@
 import type {
   AuthCodeGrantConnectorType,
   ConnectorAuthCodeGrantAuthMethodId,
+  ConnectorAuthMethodClientConfig,
   ConnectorAuthMethodIds,
   ConnectorAuthMethodIdsByAccessKind,
   ConnectorAuthMethodIdsByRevokeKind,
@@ -71,10 +72,18 @@ export type ConnectorAuthProviderRefreshArgs<
   Method extends ConnectorAuthMethodIdsByAccessKind<T, "refresh-token"> =
     ConnectorAuthMethodIdsByAccessKind<T, "refresh-token">,
 > = {
-  readonly authClient: ConnectorAuthClientForMethod<T, Method>;
   readonly inputs: ConnectorRefreshInputValues<T, Method>;
   readonly signal: AbortSignal;
-};
+} & ConnectorRefreshAuthClientArgs<T, Method>;
+
+type ConnectorRefreshAuthClientArgs<
+  T extends RefreshTokenAccessConnectorType,
+  Method extends ConnectorAuthMethodIdsByAccessKind<T, "refresh-token">,
+> = [ConnectorAuthMethodClientConfig<T, Method>] extends [never]
+  ? Record<never, never>
+  : {
+      readonly authClient: ConnectorAuthClientForMethod<T, Method>;
+    };
 
 export interface ConnectorAuthProviderRefreshResultBase {
   readonly outputs: Readonly<Record<string, string | undefined>>;

--- a/turbo/packages/connectors/src/auth-providers/types.ts
+++ b/turbo/packages/connectors/src/auth-providers/types.ts
@@ -80,7 +80,7 @@ type ConnectorRefreshAuthClientArgs<
   T extends RefreshTokenAccessConnectorType,
   Method extends ConnectorAuthMethodIdsByAccessKind<T, "refresh-token">,
 > = [ConnectorAuthMethodClientConfig<T, Method>] extends [never]
-  ? Record<never, never>
+  ? unknown
   : {
       readonly authClient: ConnectorAuthClientForMethod<T, Method>;
     };

--- a/turbo/packages/connectors/src/auth-providers/types.ts
+++ b/turbo/packages/connectors/src/auth-providers/types.ts
@@ -71,10 +71,13 @@ export type ConnectorAuthProviderRefreshArgs<
   T extends RefreshTokenAccessConnectorType,
   Method extends ConnectorAuthMethodIdsByAccessKind<T, "refresh-token"> =
     ConnectorAuthMethodIdsByAccessKind<T, "refresh-token">,
-> = {
-  readonly inputs: ConnectorRefreshInputValues<T, Method>;
-  readonly signal: AbortSignal;
-} & ConnectorRefreshAuthClientArgs<T, Method>;
+> =
+  Method extends ConnectorAuthMethodIdsByAccessKind<T, "refresh-token">
+    ? {
+        readonly inputs: ConnectorRefreshInputValues<T, Method>;
+        readonly signal: AbortSignal;
+      } & ConnectorRefreshAuthClientArgs<T, Method>
+    : never;
 
 type ConnectorRefreshAuthClientArgs<
   T extends RefreshTokenAccessConnectorType,

--- a/turbo/packages/connectors/src/connectors/test-oauth.ts
+++ b/turbo/packages/connectors/src/connectors/test-oauth.ts
@@ -2,6 +2,7 @@ import type {
   ConnectorAuthClientConfig,
   ConnectorAuthCodeGrantConfig,
   ConnectorConfig,
+  ConnectorManualGrantConfig,
   ConnectorRevokeConfig,
 } from "../connectors";
 import { FeatureSwitchKey } from "../feature-switch-key";
@@ -30,6 +31,23 @@ const TEST_OAUTH_API_AUTH_CODE_GRANT = {
     initialRefreshToken: "$secrets.TEST_OAUTH_API_REFRESH_TOKEN",
   },
 } as const satisfies ConnectorAuthCodeGrantConfig;
+
+const TEST_OAUTH_API_TOKEN_MANUAL_GRANT = {
+  kind: "manual",
+  fields: {
+    TEST_OAUTH_TOKEN: {
+      label: "API Token",
+      required: true,
+      placeholder: "test-oauth-token",
+    },
+    TEST_OAUTH_API_TOKEN_INPUT_VAR: {
+      label: "Input Variable",
+      required: true,
+      placeholder: "test-input-variable",
+      storage: "variable",
+    },
+  },
+} as const satisfies ConnectorManualGrantConfig;
 
 const TEST_OAUTH_REVOKE = { kind: "none" } satisfies ConnectorRevokeConfig;
 
@@ -95,6 +113,32 @@ export const testOauth = {
           refreshableSecrets: ["TEST_OAUTH_API_ACCESS_TOKEN"],
           envBindings: {
             TEST_OAUTH_TOKEN: "$secrets.TEST_OAUTH_API_ACCESS_TOKEN",
+          },
+        },
+        revoke: TEST_OAUTH_REVOKE,
+      },
+      "api-token": {
+        featureFlag: FeatureSwitchKey.TestOauthConnector,
+        label: "API Token",
+        helpText:
+          "Test-only manual method used to exercise refreshable access without a platform auth client.",
+        storage: {
+          secrets: ["TEST_OAUTH_TOKEN", "TEST_OAUTH_API_TOKEN_ACCESS_TOKEN"],
+          variables: ["TEST_OAUTH_API_TOKEN_INPUT_VAR"],
+        },
+        grant: TEST_OAUTH_API_TOKEN_MANUAL_GRANT,
+        access: {
+          kind: "refresh-token",
+          inputs: {
+            inputSecret: "$secrets.TEST_OAUTH_TOKEN",
+            inputVariable: "$vars.TEST_OAUTH_API_TOKEN_INPUT_VAR",
+          },
+          outputs: {
+            accessToken: "$secrets.TEST_OAUTH_API_TOKEN_ACCESS_TOKEN",
+          },
+          refreshableSecrets: ["TEST_OAUTH_API_TOKEN_ACCESS_TOKEN"],
+          envBindings: {
+            TEST_OAUTH_API_TOKEN: "$secrets.TEST_OAUTH_API_TOKEN_ACCESS_TOKEN",
           },
         },
         revoke: TEST_OAUTH_REVOKE,


### PR DESCRIPTION
## Summary
- derive refresh access auth-client requirements from the selected connector auth method
- allow refresh-token connector access methods without a platform auth client
- add test-oauth api-token fixture coverage for input-only refresh metadata and firewall auth refresh behavior

## Tests
- pnpm -F @vm0/connectors check-types
- pnpm -F @vm0/connectors lint
- pnpm -F @vm0/connectors exec vitest src/__tests__/connectors.test.ts
- pnpm -F api check-types
- pnpm -F api lint
- pnpm -F api exec vitest src/signals/routes/__tests__/webhooks-agent-firewall-auth.test.ts
- pnpm -F api exec vitest src/signals/routes/__tests__/connectors-type-callback.test.ts src/signals/routes/__tests__/zero-connectors-oauth-start.test.ts src/signals/routes/__tests__/zero-connectors-search.test.ts
- pnpm check-types
- pnpm exec prettier --check apps/api/src/signals/routes/__tests__/webhooks-agent-firewall-auth.test.ts apps/api/src/signals/services/agent-webhook-firewall-auth.service.ts packages/connectors/src/__tests__/connectors.test.ts packages/connectors/src/auth-providers/connector-auth.ts packages/connectors/src/auth-providers/oauth/providers/test-oauth-provider.ts packages/connectors/src/auth-providers/types.ts packages/connectors/src/connectors/test-oauth.ts
- git diff --check

Closes #16047