### PR TITLE
copy: soften memory files labels

### DIFF
--- a/turbo/apps/platform/src/views/memory-page/__tests__/memory-page.test.tsx
+++ b/turbo/apps/platform/src/views/memory-page/__tests__/memory-page.test.tsx
@@ -77,7 +77,7 @@ describe("memory page", () => {
       expect(screen.getByText("No updates yet")).toBeInTheDocument();
     });
 
-    await clickTab("Raw files");
+    await clickTab("Memory files");
 
     await waitFor(() => {
       expect(screen.getByText("No memory yet")).toBeInTheDocument();
@@ -213,7 +213,7 @@ describe("memory page", () => {
 
   it("lists memory files and shows selected file content read-only", async () => {
     setupMemoryPage();
-    await clickTab("Raw files");
+    await clickTab("Memory files");
 
     // Defaults to MEMORY.md (rendered as markdown).
     await waitFor(() => {
@@ -247,7 +247,7 @@ describe("memory page", () => {
 
   it("pins MEMORY.md to the top of the file list", async () => {
     setupMemoryPage();
-    await clickTab("Raw files");
+    await clickTab("Memory files");
 
     await waitFor(() => {
       expect(screen.getAllByText("MEMORY.md").length).toBeGreaterThan(0);
@@ -295,7 +295,7 @@ describe("memory page", () => {
       featureSwitches: { [FeatureSwitchKey.MemoryViewer]: true },
     });
 
-    await clickTab("Raw files");
+    await clickTab("Memory files");
 
     await waitFor(() => {
       expect(screen.getByLabelText("Memory content")).toHaveTextContent(
@@ -343,7 +343,7 @@ describe("memory page", () => {
       featureSwitches: { [FeatureSwitchKey.MemoryViewer]: true },
     });
 
-    await clickTab("Raw files");
+    await clickTab("Memory files");
 
     // Defaults to MEMORY.md, which renders the relative link to other-note.md.
     await waitFor(() => {
@@ -406,7 +406,7 @@ describe("memory page", () => {
       featureSwitches: { [FeatureSwitchKey.MemoryViewer]: true },
     });
 
-    await clickTab("Raw files");
+    await clickTab("Memory files");
 
     await waitFor(() => {
       expect(screen.getByLabelText("Memory content")).toHaveTextContent(
@@ -458,7 +458,7 @@ describe("memory page", () => {
       featureSwitches: { [FeatureSwitchKey.MemoryViewer]: true },
     });
 
-    await clickTab("Raw files");
+    await clickTab("Memory files");
 
     // Defaults to MEMORY.md, which renders an absolute external link.
     await waitFor(() => {

--- a/turbo/apps/platform/src/views/memory-page/memory-page.tsx
+++ b/turbo/apps/platform/src/views/memory-page/memory-page.tsx
@@ -186,7 +186,7 @@ export function MemoryPage() {
               Memory
             </h1>
             <p className="mt-0.5 text-sm text-muted-foreground">
-              What Zero remembers across runs. Read-only.
+              What Zero remembers from previous work.
             </p>
           </div>
           <Tabs
@@ -209,7 +209,7 @@ export function MemoryPage() {
                 value="raw"
                 className="gap-1.5 px-3 text-sm data-[state=active]:bg-background"
               >
-                Raw files
+                Memory files
               </TabsTrigger>
             </TabsList>
           </Tabs>


### PR DESCRIPTION
Summary: Rename the Memory page Raw files tab to Memory files and update the subtitle to 'What Zero remembers from previous work.' Tests: env NODE_OPTIONS=--no-experimental-webstorage pnpm -F @vm0/app exec vitest run --config vitest.config.ts src/views/memory-page/__tests__/memory-page.test.tsx