### PR TITLE
refactor: clarify local queue job lookup

### DIFF
--- a/crates/runner/src/local_queue/state.rs
+++ b/crates/runner/src/local_queue/state.rs
@@ -10,6 +10,12 @@ pub(crate) struct LocalQueue {
     group_dir: PathBuf,
 }
 
+enum JobFileLookup {
+    Found(PathBuf),
+    NotFound,
+    ScanFailed,
+}
+
 impl LocalQueue {
     pub(crate) fn new(group_dir: PathBuf) -> Self {
         Self { group_dir }
@@ -19,14 +25,18 @@ impl LocalQueue {
         &self.group_dir
     }
 
-    pub(crate) fn cancel_has_pending_target(&self, run_id: RunId) -> bool {
+    pub(crate) fn has_pending_cancel_target(&self, run_id: RunId) -> bool {
         if self.result_file_has_content(run_id) {
             return false;
         }
         if super::claim_path(&self.group_dir, run_id).exists() {
             return true;
         }
-        self.job_file_exists(run_id).unwrap_or(true)
+        match self.lookup_job_file(run_id) {
+            JobFileLookup::Found(_) => true,
+            JobFileLookup::NotFound => false,
+            JobFileLookup::ScanFailed => true,
+        }
     }
 
     pub(crate) fn result_file_has_content(&self, run_id: RunId) -> bool {
@@ -36,18 +46,29 @@ impl LocalQueue {
             .unwrap_or(false)
     }
 
-    fn job_file_exists(&self, run_id: RunId) -> Option<bool> {
-        self.find_job_file(run_id).map(|path| path.is_some())
+    pub(crate) fn remove_job_file_if_present(&self, run_id: RunId) -> bool {
+        match self.lookup_job_file(run_id) {
+            JobFileLookup::Found(path) => match std::fs::remove_file(&path) {
+                Ok(()) => true,
+                Err(e) if e.kind() == std::io::ErrorKind::NotFound => true,
+                Err(e) => {
+                    warn!(run_id = %run_id, path = %path.display(), error = %e, "local: failed to remove job file after result failure");
+                    false
+                }
+            },
+            JobFileLookup::NotFound => true,
+            JobFileLookup::ScanFailed => false,
+        }
     }
 
-    pub(crate) fn find_job_file(&self, run_id: RunId) -> Option<Option<PathBuf>> {
+    fn lookup_job_file(&self, run_id: RunId) -> JobFileLookup {
         let jobs_dir = super::jobs_dir(&self.group_dir);
         let orgs = match std::fs::read_dir(&jobs_dir) {
             Ok(entries) => entries,
-            Err(e) if e.kind() == std::io::ErrorKind::NotFound => return Some(None),
+            Err(e) if e.kind() == std::io::ErrorKind::NotFound => return JobFileLookup::NotFound,
             Err(e) => {
                 warn!(path = %jobs_dir.display(), error = %e, "local: cannot scan jobs dir for job file");
-                return None;
+                return JobFileLookup::ScanFailed;
             }
         };
 
@@ -61,7 +82,7 @@ impl LocalQueue {
                 Err(e) if e.kind() == std::io::ErrorKind::NotFound => continue,
                 Err(e) => {
                     warn!(path = %org_path.display(), error = %e, "local: cannot scan profile org dir for job file");
-                    return None;
+                    return JobFileLookup::ScanFailed;
                 }
             };
             for profile in profiles.filter_map(Result::ok) {
@@ -70,16 +91,16 @@ impl LocalQueue {
                 }
                 let path = profile.path().join(format!("{run_id}.job"));
                 match std::fs::metadata(&path) {
-                    Ok(_) => return Some(Some(path)),
+                    Ok(_) => return JobFileLookup::Found(path),
                     Err(e) if e.kind() == std::io::ErrorKind::NotFound => {}
                     Err(e) => {
                         warn!(run_id = %run_id, path = %path.display(), error = %e, "local: cannot stat job file");
-                        return None;
+                        return JobFileLookup::ScanFailed;
                     }
                 }
             }
         }
 
-        Some(None)
+        JobFileLookup::NotFound
     }
 }

--- a/crates/runner/src/provider/local.rs
+++ b/crates/runner/src/provider/local.rs
@@ -98,27 +98,6 @@ impl LocalProvider {
 }
 
 impl LocalProvider {
-    fn find_job_file(&self, run_id: RunId) -> Option<Option<PathBuf>> {
-        self.queue.find_job_file(run_id)
-    }
-
-    fn remove_job_file_if_present(&self, run_id: RunId) -> bool {
-        let Some(path) = self.find_job_file(run_id) else {
-            return false;
-        };
-        let Some(path) = path else {
-            return true;
-        };
-        match std::fs::remove_file(&path) {
-            Ok(()) => true,
-            Err(e) if e.kind() == std::io::ErrorKind::NotFound => true,
-            Err(e) => {
-                warn!(run_id = %run_id, path = %path.display(), error = %e, "local: failed to remove job file after result failure");
-                false
-            }
-        }
-    }
-
     /// Find the first unclaimed job in the supported profile partitions.
     fn find_unclaimed_job(&self) -> Option<JobCandidate> {
         if self.supported_profiles.is_empty() {
@@ -425,7 +404,7 @@ impl JobProvider for LocalProvider {
     ) {
         self.cancel_scanner.remove_owned_claim(run_id).await;
         if !self.write_result(run_id, exit_code, error) {
-            if self.remove_job_file_if_present(run_id) {
+            if self.queue.remove_job_file_if_present(run_id) {
                 let _ =
                     std::fs::remove_file(local_queue::cancel_path(self.queue.group_dir(), run_id));
                 let _ =

--- a/crates/runner/src/provider/local.rs
+++ b/crates/runner/src/provider/local.rs
@@ -1023,6 +1023,38 @@ mod tests {
         );
     }
 
+    #[tokio::test]
+    async fn complete_result_failure_keeps_state_when_job_scan_fails() {
+        let dir = tempfile::tempdir().unwrap();
+        let cancel = CancellationToken::new();
+        let provider = default_provider(dir.path(), cancel, empty_cancel_tokens());
+
+        let run_id = RunId::new_v4();
+        let claim_path = local_queue::claim_path(dir.path(), run_id);
+        let cancel_path = local_queue::cancel_path(dir.path(), run_id);
+        let result_dir = local_queue::results_dir(dir.path());
+        std::fs::create_dir_all(claim_path.parent().unwrap()).unwrap();
+        std::fs::create_dir_all(cancel_path.parent().unwrap()).unwrap();
+
+        std::fs::write(&claim_path, b"").unwrap();
+        std::fs::write(&cancel_path, b"").unwrap();
+        std::fs::write(&result_dir, b"not a directory").unwrap();
+        std::fs::write(local_queue::jobs_dir(dir.path()), b"not a directory").unwrap();
+
+        provider
+            .complete(run_id, 0, None, None, None, CompletionAuth::local())
+            .await;
+
+        assert!(
+            claim_path.exists(),
+            "claim should stay when job-file cleanup cannot verify retry state"
+        );
+        assert!(
+            cancel_path.exists(),
+            "cancel file should stay when job-file cleanup cannot verify retry state"
+        );
+    }
+
     /// Regression: if the job file is missing when claim() reads it, the
     /// .claim file must be removed so the job doesn't get stranded forever.
     #[tokio::test]

--- a/crates/runner/src/provider/local_cancel.rs
+++ b/crates/runner/src/provider/local_cancel.rs
@@ -61,14 +61,14 @@ impl LocalCancelScanner {
                     info!(run_id = %run_id, "local: cancel file detected, cancelling job");
                 }
                 let should_delete =
-                    owned_claims.contains(&run_id) || !self.queue.cancel_has_pending_target(run_id);
+                    owned_claims.contains(&run_id) || !self.queue.has_pending_cancel_target(run_id);
                 if should_delete {
                     let _ = std::fs::remove_file(local_queue::cancel_path(
                         self.queue.group_dir(),
                         run_id,
                     ));
                 }
-            } else if !self.queue.cancel_has_pending_target(run_id) {
+            } else if !self.queue.has_pending_cancel_target(run_id) {
                 let _ =
                     std::fs::remove_file(local_queue::cancel_path(self.queue.group_dir(), run_id));
             }
@@ -478,6 +478,23 @@ mod tests {
         assert!(
             !cancel_path.exists(),
             "cancel file should be deleted when no pending target exists"
+        );
+    }
+
+    #[tokio::test]
+    async fn cancel_file_is_kept_when_job_scan_fails() {
+        let dir = tempfile::tempdir().unwrap();
+        let run_id = RunId::new_v4();
+        let cancel_path = write_cancel(dir.path(), run_id);
+        std::fs::write(local_queue::jobs_dir(dir.path()), b"not a directory").unwrap();
+
+        scanner(dir.path(), empty_cancel_tokens())
+            .scan_cancel_files()
+            .await;
+
+        assert!(
+            cancel_path.exists(),
+            "cancel file should stay when the pending target state is unknown"
         );
     }
 


### PR DESCRIPTION
## Summary

- replace the local queue job-file nested `Option<Option<PathBuf>>` lookup with a private `JobFileLookup` enum
- keep raw lookup state inside `LocalQueue` and expose intent methods for cancel target checks and job-file cleanup
- add regression coverage for scan failures keeping cancel markers when pending target state is unknown

Closes #16059

## Tests

- `cargo test --manifest-path crates/Cargo.toml -p runner local_cancel`
- `cargo test --manifest-path crates/Cargo.toml -p runner provider::local`
- `cargo fmt --all --check` from `crates/`
- `git diff --check`
- `cargo clippy --manifest-path crates/Cargo.toml -p runner --all-targets -- -D warnings`
- pre-commit hook: cargo-fmt, cargo-clippy, cargo-doc
