### PR TITLE
refactor: share mock Claude JSONL transcript

### DIFF
--- a/crates/guest-mock-claude/src/main.rs
+++ b/crates/guest-mock-claude/src/main.rs
@@ -151,17 +151,6 @@ fn echo_session_id(events: &[(String, Value)]) -> Option<&str> {
     })
 }
 
-fn write_echo_session_history(events: &[(String, Value)], session_id: Option<&str>) {
-    if let Some(session_id) = session_id
-        && let Some(path) = create_session_history(session_id)
-        && let Ok(mut file) = std::fs::File::create(path)
-    {
-        for (line, _) in events {
-            let _ = writeln!(file, "{line}");
-        }
-    }
-}
-
 fn run_echo_jsonl_mode(payload: &str) -> ExitCode {
     let events = match parse_echo_jsonl(payload) {
         Ok(events) => events,
@@ -179,10 +168,13 @@ fn run_echo_jsonl_mode(payload: &str) -> ExitCode {
         return ExitCode::from(1);
     }
 
+    let mut transcript = JsonlTranscript::default();
     for (line, _) in &events {
-        println!("{line}");
+        transcript.emit_raw_line(line.clone());
     }
-    write_echo_session_history(&events, session_id);
+    if let Some(session_id) = session_id {
+        transcript.write_session_history(session_id);
+    }
     let _ = std::io::stdout().flush();
     ExitCode::SUCCESS
 }
@@ -319,81 +311,129 @@ fn create_session_history(session_id: &str) -> Option<String> {
     build_session_history_path(session_id, &home)
 }
 
+#[derive(Default)]
+struct JsonlTranscript {
+    lines: Vec<String>,
+}
+
+impl JsonlTranscript {
+    fn emit_value(&mut self, event: Value) {
+        self.emit_raw_line(event.to_string());
+    }
+
+    fn emit_raw_line(&mut self, line: String) {
+        println!("{line}");
+        self.lines.push(line);
+    }
+
+    fn write_session_history(&self, session_id: &str) {
+        if let Some(path) = create_session_history(session_id) {
+            self.write_session_history_file(&path);
+        }
+    }
+
+    fn write_session_history_file(&self, path: &str) {
+        if let Ok(mut file) = std::fs::File::create(path) {
+            for line in &self.lines {
+                let _ = writeln!(file, "{line}");
+            }
+        }
+    }
+}
+
+fn init_event(session_id: &str, tools: &[&str]) -> Value {
+    json!({
+        "type": "system",
+        "subtype": "init",
+        "cwd": CANONICAL_WORKING_DIR,
+        "session_id": session_id,
+        "tools": tools,
+        "model": "mock-claude"
+    })
+}
+
+fn result_event(session_id: &str, is_error: bool, result: &str) -> Value {
+    json!({
+        "type": "result",
+        "subtype": if is_error { "error" } else { "success" },
+        "session_id": session_id,
+        "is_error": is_error,
+        "duration_ms": 100,
+        "num_turns": 1,
+        "result": result,
+        "total_cost_usd": 0,
+        "usage": {"input_tokens": 0, "output_tokens": 0}
+    })
+}
+
+fn assistant_text_event(session_id: &str, text: &str) -> Value {
+    json!({
+        "type": "assistant",
+        "session_id": session_id,
+        "message": {
+            "role": "assistant",
+            "content": [{"type": "text", "text": text}]
+        }
+    })
+}
+
+fn tool_use_event(session_id: &str, id: &str, name: &str, input: Value) -> Value {
+    json!({
+        "type": "assistant",
+        "session_id": session_id,
+        "message": {
+            "role": "assistant",
+            "content": [{
+                "type": "tool_use",
+                "id": id,
+                "name": name,
+                "input": input
+            }]
+        }
+    })
+}
+
+fn tool_result_event(session_id: &str, tool_use_id: &str, content: &str, is_error: bool) -> Value {
+    json!({
+        "type": "user",
+        "session_id": session_id,
+        "message": {
+            "role": "user",
+            "content": [{
+                "type": "tool_result",
+                "tool_use_id": tool_use_id,
+                "content": content,
+                "is_error": is_error
+            }]
+        }
+    })
+}
+
 /// Emit the init + result JSONL pair shared by post-result mock test
 /// prefixes, flush stdout so guest-agent sees them, and write the
 /// session history checkpoint file. Caller decides which post-result
 /// behavior follows (hang / exit / ignore SIGTERM / orphan stdout).
 fn emit_post_result_pair() {
     let session_id = generate_session_id();
-    let cwd = CANONICAL_WORKING_DIR;
-
-    let init_event = json!({
-        "type": "system",
-        "subtype": "init",
-        "cwd": cwd,
-        "session_id": session_id,
-        "tools": ["Bash"],
-        "model": "mock-claude"
-    });
-    println!("{init_event}");
-
-    let result_event = json!({
-        "type": "result",
-        "subtype": "success",
-        "session_id": session_id,
-        "is_error": false,
-        "duration_ms": 100,
-        "num_turns": 1,
-        "result": "Done.",
-        "total_cost_usd": 0,
-        "usage": {"input_tokens": 0, "output_tokens": 0}
-    });
-    println!("{result_event}");
-
-    if let Some(path) = create_session_history(&session_id)
-        && let Ok(mut file) = std::fs::File::create(&path)
-    {
-        let _ = writeln!(file, "{init_event}");
-        let _ = writeln!(file, "{result_event}");
-    }
+    let mut transcript = JsonlTranscript::default();
+    transcript.emit_value(init_event(&session_id, &["Bash"]));
+    transcript.emit_value(result_event(&session_id, false, "Done."));
+    transcript.write_session_history(&session_id);
 
     let _ = std::io::stdout().flush();
 }
 
 fn emit_stuck_tool_events() {
     let session_id = generate_session_id();
-    let cwd = CANONICAL_WORKING_DIR;
+    let mut transcript = JsonlTranscript::default();
 
-    // Init event
-    println!(
-        "{}",
-        json!({
-            "type": "system",
-            "subtype": "init",
-            "cwd": cwd,
-            "session_id": session_id,
-            "tools": ["WebFetch"],
-            "model": "mock-claude"
-        })
-    );
-
-    // Tool use event — WebFetch that never completes
-    println!(
-        "{}",
-        json!({
-            "type": "assistant",
-            "session_id": session_id,
-            "message": {
-                "role": "assistant",
-                "content": [{
-                    "type": "tool_use",
-                    "id": "toolu_stuck_001",
-                    "name": "WebFetch",
-                    "input": {"url": "https://example.com/hang"}
-                }]
-            }
-        })
-    );
+    transcript.emit_value(init_event(&session_id, &["WebFetch"]));
+    transcript.emit_value(tool_use_event(
+        &session_id,
+        "toolu_stuck_001",
+        "WebFetch",
+        json!({"url": "https://example.com/hang"}),
+    ));
 
     // Flush stdout so guest-agent receives the events before we hang.
     // When piped, stdout is fully buffered and println! may not flush.
@@ -470,51 +510,22 @@ fn run_text_mode(prompt: &str) -> ExitCode {
 
 /// Execute prompt in stream-json mode: output JSONL events, capture output.
 fn run_stream_json_mode(prompt: &str, session_id: &str) -> ExitCode {
-    let cwd = CANONICAL_WORKING_DIR;
-
     let session_history_file = create_session_history(session_id);
-    let mut events: Vec<Value> = Vec::with_capacity(5);
+    let mut transcript = JsonlTranscript::default();
 
     // 1. System init event
-    let init_event = json!({
-        "type": "system",
-        "subtype": "init",
-        "cwd": cwd,
-        "session_id": session_id,
-        "tools": ["Bash"],
-        "model": "mock-claude"
-    });
-    println!("{}", init_event);
-    events.push(init_event);
+    transcript.emit_value(init_event(session_id, &["Bash"]));
 
     // 2. Assistant text event
-    let text_event = json!({
-        "type": "assistant",
-        "session_id": session_id,
-        "message": {
-            "role": "assistant",
-            "content": [{"type": "text", "text": "Executing command..."}]
-        }
-    });
-    println!("{}", text_event);
-    events.push(text_event);
+    transcript.emit_value(assistant_text_event(session_id, "Executing command..."));
 
     // 3. Assistant tool_use event
-    let tool_use_event = json!({
-        "type": "assistant",
-        "session_id": session_id,
-        "message": {
-            "role": "assistant",
-            "content": [{
-                "type": "tool_use",
-                "id": "toolu_mock_001",
-                "name": "Bash",
-                "input": {"command": prompt}
-            }]
-        }
-    });
-    println!("{}", tool_use_event);
-    events.push(tool_use_event);
+    transcript.emit_value(tool_use_event(
+        session_id,
+        "toolu_mock_001",
+        "Bash",
+        json!({"command": prompt}),
+    ));
 
     // 4. Execute bash and capture output
     let (output, exit_code) = match Command::new("bash")
@@ -538,44 +549,19 @@ fn run_stream_json_mode(prompt: &str, session_id: &str) -> ExitCode {
     let is_error = exit_code != 0;
 
     // 5. User tool_result event
-    let tool_result_event = json!({
-        "type": "user",
-        "session_id": session_id,
-        "message": {
-            "role": "user",
-            "content": [{
-                "type": "tool_result",
-                "tool_use_id": "toolu_mock_001",
-                "content": output,
-                "is_error": is_error
-            }]
-        }
-    });
-    println!("{}", tool_result_event);
-    events.push(tool_result_event);
+    transcript.emit_value(tool_result_event(
+        session_id,
+        "toolu_mock_001",
+        &output,
+        is_error,
+    ));
 
     // 6. Result event
-    let result_event = json!({
-        "type": "result",
-        "subtype": if is_error { "error" } else { "success" },
-        "session_id": session_id,
-        "is_error": is_error,
-        "duration_ms": 100,
-        "num_turns": 1,
-        "result": output,
-        "total_cost_usd": 0,
-        "usage": {"input_tokens": 0, "output_tokens": 0}
-    });
-    println!("{}", result_event);
-    events.push(result_event);
+    transcript.emit_value(result_event(session_id, is_error, &output));
 
     // Write session history
-    if let Some(path) = session_history_file
-        && let Ok(mut file) = std::fs::File::create(&path)
-    {
-        for event in &events {
-            let _ = writeln!(file, "{event}");
-        }
+    if let Some(path) = session_history_file {
+        transcript.write_session_history_file(&path);
     }
 
     ExitCode::from(exit_code as u8)

--- a/crates/guest-mock-claude/src/main.rs
+++ b/crates/guest-mock-claude/src/main.rs
@@ -160,8 +160,8 @@ fn run_echo_jsonl_mode(payload: &str) -> ExitCode {
         }
     };
 
-    let session_id = echo_session_id(&events);
-    if let Some(session_id) = session_id
+    let session_id = echo_session_id(&events).map(str::to_owned);
+    if let Some(session_id) = session_id.as_deref()
         && !is_valid_session_history_id(session_id)
     {
         eprintln!("invalid @ECHO@ session_id: {session_id:?}");
@@ -169,10 +169,10 @@ fn run_echo_jsonl_mode(payload: &str) -> ExitCode {
     }
 
     let mut transcript = JsonlTranscript::default();
-    for (line, _) in &events {
-        transcript.emit_raw_line(line.clone());
+    for (line, _) in events {
+        transcript.emit_raw_line(line);
     }
-    if let Some(session_id) = session_id {
+    if let Some(session_id) = session_id.as_deref() {
         transcript.write_session_history(session_id);
     }
     let _ = std::io::stdout().flush();

--- a/crates/guest-mock-claude/tests/echo_jsonl.rs
+++ b/crates/guest-mock-claude/tests/echo_jsonl.rs
@@ -1,6 +1,8 @@
 use std::fs;
 use std::process::Command;
 
+use serde_json::Value;
+
 fn mock_claude() -> Command {
     Command::new(env!("CARGO_BIN_EXE_guest-mock-claude"))
 }
@@ -11,6 +13,45 @@ fn expected_history_path(home: &std::path::Path, session_id: &str) -> std::path:
         .join("projects")
         .join(format!("-{project_name}"))
         .join(format!("{session_id}.jsonl"))
+}
+
+fn parse_jsonl(output: &[u8]) -> Result<Vec<Value>, Box<dyn std::error::Error>> {
+    let stdout = String::from_utf8(output.to_vec())?;
+    stdout
+        .lines()
+        .map(|line| Ok(serde_json::from_str::<Value>(line)?))
+        .collect()
+}
+
+fn init_session_id(events: &[Value]) -> Result<String, Box<dyn std::error::Error>> {
+    let session_id = events
+        .iter()
+        .find(|event| {
+            event.get("type").and_then(Value::as_str) == Some("system")
+                && event.get("subtype").and_then(Value::as_str) == Some("init")
+        })
+        .and_then(|event| event.get("session_id"))
+        .and_then(Value::as_str)
+        .ok_or("missing init session_id")?;
+    Ok(session_id.to_string())
+}
+
+fn event_kind(event: &Value) -> String {
+    let event_type = event.get("type").and_then(Value::as_str).unwrap_or("");
+    match event_type {
+        "system" | "result" => {
+            let subtype = event.get("subtype").and_then(Value::as_str).unwrap_or("");
+            format!("{event_type}/{subtype}")
+        }
+        "assistant" | "user" => {
+            let content_type = event
+                .pointer("/message/content/0/type")
+                .and_then(Value::as_str)
+                .unwrap_or("");
+            format!("{event_type}/{content_type}")
+        }
+        _ => event_type.to_string(),
+    }
 }
 
 #[test]
@@ -42,6 +83,70 @@ fn echo_jsonl_outputs_valid_payload_unchanged() -> Result<(), Box<dyn std::error
 
     let history = fs::read_to_string(expected_history_path(home.path(), "preview-1"))?;
     assert_eq!(history, format!("{payload}\n"));
+    Ok(())
+}
+
+#[test]
+fn stream_json_shell_writes_matching_session_history() -> Result<(), Box<dyn std::error::Error>> {
+    let home = tempfile::tempdir()?;
+
+    let output = mock_claude()
+        .env("HOME", home.path())
+        .args(["--output-format", "stream-json", "--", "printf hello"])
+        .output()?;
+
+    assert!(
+        output.status.success(),
+        "expected success, stderr: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    assert!(output.stderr.is_empty());
+
+    let events = parse_jsonl(&output.stdout)?;
+    let session_id = init_session_id(&events)?;
+    let stdout = String::from_utf8(output.stdout)?;
+    let history = fs::read_to_string(expected_history_path(home.path(), &session_id))?;
+
+    assert_eq!(history, stdout);
+    assert_eq!(
+        events.iter().map(event_kind).collect::<Vec<_>>(),
+        [
+            "system/init",
+            "assistant/text",
+            "assistant/tool_use",
+            "user/tool_result",
+            "result/success",
+        ]
+    );
+    Ok(())
+}
+
+#[test]
+fn exit_after_result_writes_init_and_result_history() -> Result<(), Box<dyn std::error::Error>> {
+    let home = tempfile::tempdir()?;
+
+    let output = mock_claude()
+        .env("HOME", home.path())
+        .args(["--output-format", "stream-json", "--", "@exit-after-result"])
+        .output()?;
+
+    assert!(
+        output.status.success(),
+        "expected success, stderr: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    assert!(output.stderr.is_empty());
+
+    let events = parse_jsonl(&output.stdout)?;
+    let session_id = init_session_id(&events)?;
+    let stdout = String::from_utf8(output.stdout)?;
+    let history = fs::read_to_string(expected_history_path(home.path(), &session_id))?;
+
+    assert_eq!(history, stdout);
+    assert_eq!(
+        events.iter().map(event_kind).collect::<Vec<_>>(),
+        ["system/init", "result/success"]
+    );
     Ok(())
 }
 

--- a/crates/guest-mock-claude/tests/echo_jsonl.rs
+++ b/crates/guest-mock-claude/tests/echo_jsonl.rs
@@ -118,6 +118,26 @@ fn stream_json_shell_writes_matching_session_history() -> Result<(), Box<dyn std
             "result/success",
         ]
     );
+    assert_eq!(
+        events[2]
+            .pointer("/message/content/0/input/command")
+            .and_then(Value::as_str),
+        Some("printf hello")
+    );
+    assert_eq!(
+        events[3]
+            .pointer("/message/content/0/content")
+            .and_then(Value::as_str),
+        Some("hello")
+    );
+    assert_eq!(
+        events[4].get("result").and_then(Value::as_str),
+        Some("hello")
+    );
+    assert_eq!(
+        events[4].get("is_error").and_then(Value::as_bool),
+        Some(false)
+    );
     Ok(())
 }
 
@@ -146,6 +166,26 @@ fn exit_after_result_writes_init_and_result_history() -> Result<(), Box<dyn std:
     assert_eq!(
         events.iter().map(event_kind).collect::<Vec<_>>(),
         ["system/init", "result/success"]
+    );
+    assert_eq!(
+        events[0].get("model").and_then(Value::as_str),
+        Some("mock-claude")
+    );
+    assert_eq!(
+        events[0]
+            .get("tools")
+            .and_then(Value::as_array)
+            .and_then(|tools| tools.first())
+            .and_then(Value::as_str),
+        Some("Bash")
+    );
+    assert_eq!(
+        events[1].get("result").and_then(Value::as_str),
+        Some("Done.")
+    );
+    assert_eq!(
+        events[1].get("is_error").and_then(Value::as_bool),
+        Some(false)
     );
     Ok(())
 }

--- a/crates/guest-mock-claude/tests/echo_jsonl.rs
+++ b/crates/guest-mock-claude/tests/echo_jsonl.rs
@@ -87,6 +87,31 @@ fn echo_jsonl_outputs_valid_payload_unchanged() -> Result<(), Box<dyn std::error
 }
 
 #[test]
+fn echo_jsonl_without_init_skips_history() -> Result<(), Box<dyn std::error::Error>> {
+    let home = tempfile::tempdir()?;
+    let payload = r#"{"type":"assistant","session_id":"preview-no-init","message":{"role":"assistant","content":[{"type":"text","text":"hello"}]}}"#;
+    let prompt = format!("@ECHO@\n{payload}\n");
+
+    let output = mock_claude()
+        .env("HOME", home.path())
+        .args(["--output-format", "stream-json", "--", &prompt])
+        .output()?;
+
+    assert!(
+        output.status.success(),
+        "expected success, stderr: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    assert_eq!(
+        String::from_utf8_lossy(&output.stdout),
+        format!("{payload}\n")
+    );
+    assert!(output.stderr.is_empty());
+    assert!(!home.path().join(".claude").exists());
+    Ok(())
+}
+
+#[test]
 fn stream_json_shell_writes_matching_session_history() -> Result<(), Box<dyn std::error::Error>> {
     let home = tempfile::tempdir()?;
 

--- a/crates/guest-mock-claude/tests/echo_jsonl.rs
+++ b/crates/guest-mock-claude/tests/echo_jsonl.rs
@@ -142,6 +142,62 @@ fn stream_json_shell_writes_matching_session_history() -> Result<(), Box<dyn std
 }
 
 #[test]
+fn stream_json_shell_failure_writes_error_history() -> Result<(), Box<dyn std::error::Error>> {
+    let home = tempfile::tempdir()?;
+
+    let output = mock_claude()
+        .env("HOME", home.path())
+        .args([
+            "--output-format",
+            "stream-json",
+            "--",
+            "printf out; printf err >&2; exit 7",
+        ])
+        .output()?;
+
+    assert_eq!(output.status.code(), Some(7));
+    assert!(output.stderr.is_empty());
+
+    let events = parse_jsonl(&output.stdout)?;
+    let session_id = init_session_id(&events)?;
+    let stdout = String::from_utf8(output.stdout)?;
+    let history = fs::read_to_string(expected_history_path(home.path(), &session_id))?;
+
+    assert_eq!(history, stdout);
+    assert_eq!(
+        events.iter().map(event_kind).collect::<Vec<_>>(),
+        [
+            "system/init",
+            "assistant/text",
+            "assistant/tool_use",
+            "user/tool_result",
+            "result/error",
+        ]
+    );
+    assert_eq!(
+        events[3]
+            .pointer("/message/content/0/content")
+            .and_then(Value::as_str),
+        Some("outerr")
+    );
+    assert_eq!(
+        events[3]
+            .pointer("/message/content/0/is_error")
+            .and_then(Value::as_bool),
+        Some(true)
+    );
+    assert_eq!(
+        events[4].get("result").and_then(Value::as_str),
+        Some("outerr")
+    );
+    assert_eq!(
+        events[4].get("is_error").and_then(Value::as_bool),
+        Some(true)
+    );
+    Ok(())
+}
+
+#[test]
 fn exit_after_result_writes_init_and_result_history() -> Result<(), Box<dyn std::error::Error>> {
     let home = tempfile::tempdir()?;
 


### PR DESCRIPTION
## Summary
- add black-box guest-mock-claude tests for stream-json stdout/history equivalence
- introduce a small JsonlTranscript helper so stdout and history reuse the same serialized JSONL lines
- move repeated mock Claude init/result/tool event shapes into focused local helpers

## Tests
- cargo test --manifest-path crates/Cargo.toml -p guest-mock-claude
- cargo fmt --all -- --check
- pre-commit: crates cargo-fmt, cargo-doc, cargo-clippy

Closes #16061