### PR TITLE
chore(rust): update dependencies

### DIFF
--- a/crates/Cargo.lock
+++ b/crates/Cargo.lock
@@ -2968,9 +2968,9 @@ dependencies = [
 
 [[package]]
 name = "serde_regex"
-version = "1.1.0"
+version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a8136f1a4ea815d7eac4101cfd0b16dc0cb5e1fe1b8609dfd728058656b7badf"
+checksum = "bafc8d0c5330cecff10f16b459b479fd9acaa5b4acd7167301414e21b0057012"
 dependencies = [
  "regex",
  "serde",
@@ -4310,9 +4310,9 @@ checksum = "cfe53a6657fd280eaa890a3bc59152892ffa3e30101319d168b781ed6529b049"
 
 [[package]]
 name = "yoke"
-version = "0.8.2"
+version = "0.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "abe8c5fda708d9ca3df187cae8bfb9ceda00dd96231bed36e445a1a48e66f9ca"
+checksum = "709fe23a0424b6a435d82152b1bd3fdfb0833487d5fa90d05d42762a9891fef5"
 dependencies = [
  "stable_deref_trait",
  "yoke-derive",


### PR DESCRIPTION
## Summary
- Updated the Rust workspace lockfile under `crates/`.
- Updated `serde_regex` from `1.1.0` to `1.2.0`.
- Updated `yoke` from `0.8.2` to `0.8.3`.

## Dependencies Not Updated
- `generic-array` remains at `0.14.7`. `cargo update --verbose` reported `0.14.9` as available, but `cargo update -p generic-array --precise 0.14.9` failed because `crypto-common 0.1.7` requires `generic-array = "=0.14.7"` transitively through `digest 0.10.7` and `aws-smithy-checksums`.

## Manual Version Bumps
- None. No safe minor/patch `Cargo.toml` constraint bumps were needed; the remaining blocker is a transitive exact pin outside this repo.

## Tests
- Passed: `env -u TMPDIR CLI_AGENT_TYPE=claude-code CARGO_TARGET_DIR=/home/user/workspace/vm0-rust-deps-target CARGO_BUILD_JOBS=1 cargo test --workspace`
- Context: the initial default run hit sandbox resource/env issues (`/tmp` disk space, parallel linker memory pressure, and the agent runtime's `CLI_AGENT_TYPE=codex` leaking into tests that expect the default `claude-code` framework). The final command above keeps the build target on the larger workspace volume, reduces linker pressure, and sets the repo-expected framework explicitly.
