### PR TITLE
fix: surface codex reconnect run errors

### DIFF
--- a/turbo/packages/api-contracts/src/contracts/__tests__/errors.test.ts
+++ b/turbo/packages/api-contracts/src/contracts/__tests__/errors.test.ts
@@ -131,6 +131,20 @@ describe("formatRunErrorForExternalSurface", () => {
     expect(isGenericRunErrorForDisplay(rawRunError)).toBe(true);
   });
 
+  it("does not show reconnect guidance when upstream provider marker is present", () => {
+    const rawRunError =
+      'unexpected status 502 Bad Gateway: {"error":"TOKEN_REFRESH_FAILED","message":"Access token refresh failed for: codex-oauth-token after reconnect_required state.","permission":"model-provider:codex-oauth-token","connectors":["codex-oauth-token"],"failureReason":"upstream_provider"}, url: https://chatgpt.com/backend-api/codex/responses';
+
+    expect(
+      formatRunErrorForExternalSurface({
+        code: "UNKNOWN",
+        message: rawRunError,
+      }),
+    ).toBe(CHAT_RUN_TRANSIENT_ERROR_MESSAGE);
+    expect(isActionableRunError(rawRunError)).toBe(false);
+    expect(isGenericRunErrorForDisplay(rawRunError)).toBe(true);
+  });
+
   it("keeps non-Codex token refresh failures generic", () => {
     const rawRunError =
       'unexpected status 502 Bad Gateway: {"error":"TOKEN_REFRESH_FAILED","message":"Access token expired and refresh failed for: zendesk.","permission":"connector:zendesk","connectors":["zendesk"],"failureReason":"reconnect_required"}, url: https://example.zendesk.com/api/v2/tickets';

--- a/turbo/packages/api-contracts/src/contracts/__tests__/errors.test.ts
+++ b/turbo/packages/api-contracts/src/contracts/__tests__/errors.test.ts
@@ -1,8 +1,11 @@
 import { describe, expect, it } from "vitest";
 
 import {
+  CHAT_RUN_TRANSIENT_ERROR_MESSAGE,
   formatRunErrorForExternalSurface,
   INSUFFICIENT_CREDITS_ASK_ADMIN_MESSAGE,
+  isActionableRunError,
+  isGenericRunErrorForDisplay,
 } from "../errors";
 
 describe("formatRunErrorForExternalSurface", () => {
@@ -94,5 +97,51 @@ describe("formatRunErrorForExternalSurface", () => {
         message: "Something failed",
       }),
     ).toBe("Oops, something went wrong. Please try again later.");
+  });
+
+  it("shows reconnect guidance for Codex OAuth reconnect-required refresh failures", () => {
+    const rawRunError =
+      'unexpected status 502 Bad Gateway: {"error":"TOKEN_REFRESH_FAILED","message":"Access token expired and refresh failed for: codex-oauth-token. The connector may need to be reconnected.","permission":"model-provider:codex-oauth-token","base":"https://chatgpt.com/backend-api/codex","connectors":["codex-oauth-token"],"failureReason":"reconnect_required"}, url: https://chatgpt.com/backend-api/codex/responses';
+    const expectedMessage =
+      "ChatGPT session needs reconnection. Reconnect ChatGPT (Codex) in Model Providers, then retry.";
+
+    expect(
+      formatRunErrorForExternalSurface({
+        code: "UNKNOWN",
+        message: rawRunError,
+      }),
+    ).toBe(expectedMessage);
+    expect(isActionableRunError(rawRunError)).toBe(true);
+    expect(isGenericRunErrorForDisplay(rawRunError)).toBe(false);
+    expect(isActionableRunError(expectedMessage)).toBe(true);
+    expect(isGenericRunErrorForDisplay(expectedMessage)).toBe(false);
+  });
+
+  it("keeps upstream Codex token refresh failures generic", () => {
+    const rawRunError =
+      'unexpected status 502 Bad Gateway: {"error":"TOKEN_REFRESH_FAILED","message":"Access token refresh failed for: codex-oauth-token.","permission":"model-provider:codex-oauth-token","connectors":["codex-oauth-token"],"failureReason":"upstream_provider"}, url: https://chatgpt.com/backend-api/codex/responses';
+
+    expect(
+      formatRunErrorForExternalSurface({
+        code: "UNKNOWN",
+        message: rawRunError,
+      }),
+    ).toBe(CHAT_RUN_TRANSIENT_ERROR_MESSAGE);
+    expect(isActionableRunError(rawRunError)).toBe(false);
+    expect(isGenericRunErrorForDisplay(rawRunError)).toBe(true);
+  });
+
+  it("keeps non-Codex token refresh failures generic", () => {
+    const rawRunError =
+      'unexpected status 502 Bad Gateway: {"error":"TOKEN_REFRESH_FAILED","message":"Access token expired and refresh failed for: zendesk.","permission":"connector:zendesk","connectors":["zendesk"],"failureReason":"reconnect_required"}, url: https://example.zendesk.com/api/v2/tickets';
+
+    expect(
+      formatRunErrorForExternalSurface({
+        code: "UNKNOWN",
+        message: rawRunError,
+      }),
+    ).toBe(CHAT_RUN_TRANSIENT_ERROR_MESSAGE);
+    expect(isActionableRunError(rawRunError)).toBe(false);
+    expect(isGenericRunErrorForDisplay(rawRunError)).toBe(true);
   });
 });

--- a/turbo/packages/api-contracts/src/contracts/__tests__/errors.test.ts
+++ b/turbo/packages/api-contracts/src/contracts/__tests__/errors.test.ts
@@ -158,4 +158,18 @@ describe("formatRunErrorForExternalSurface", () => {
     expect(isActionableRunError(rawRunError)).toBe(false);
     expect(isGenericRunErrorForDisplay(rawRunError)).toBe(true);
   });
+
+  it("keeps mixed connector token refresh failures generic", () => {
+    const rawRunError =
+      'unexpected status 502 Bad Gateway: {"error":"TOKEN_REFRESH_FAILED","message":"Access token expired and refresh failed for: notion, codex-oauth-token. The connector may need to be reconnected.","connectors":["notion","codex-oauth-token"],"failureReason":"reconnect_required"}, url: https://chatgpt.com/backend-api/codex/responses';
+
+    expect(
+      formatRunErrorForExternalSurface({
+        code: "UNKNOWN",
+        message: rawRunError,
+      }),
+    ).toBe(CHAT_RUN_TRANSIENT_ERROR_MESSAGE);
+    expect(isActionableRunError(rawRunError)).toBe(false);
+    expect(isGenericRunErrorForDisplay(rawRunError)).toBe(true);
+  });
 });

--- a/turbo/packages/api-contracts/src/contracts/__tests__/errors.test.ts
+++ b/turbo/packages/api-contracts/src/contracts/__tests__/errors.test.ts
@@ -149,6 +149,36 @@ describe("formatRunErrorForExternalSurface", () => {
     expect(isGenericRunErrorForDisplay(rawRunError)).toBe(false);
   });
 
+  it("shows reconnect guidance for firewall auth API error envelopes", () => {
+    const rawRunError =
+      'unexpected status 502 Bad Gateway: {"error":{"message":"Access token expired and refresh failed for: codex-oauth-token.","code":"TOKEN_REFRESH_FAILED","connectors":["codex-oauth-token"],"failureReason":"reconnect_required"}}';
+
+    expect(
+      formatRunErrorForExternalSurface({
+        code: "UNKNOWN",
+        message: rawRunError,
+      }),
+    ).toBe(
+      "ChatGPT session needs reconnection. Reconnect ChatGPT (Codex) in Model Providers, then retry.",
+    );
+    expect(isActionableRunError(rawRunError)).toBe(true);
+    expect(isGenericRunErrorForDisplay(rawRunError)).toBe(false);
+  });
+
+  it("does not match nested debug objects inside unrelated error bodies", () => {
+    const rawRunError =
+      'unexpected status 502 Bad Gateway: {"error":"SOMETHING_ELSE","debug":{"error":"TOKEN_REFRESH_FAILED","connectors":["codex-oauth-token"],"failureReason":"reconnect_required"}}';
+
+    expect(
+      formatRunErrorForExternalSurface({
+        code: "UNKNOWN",
+        message: rawRunError,
+      }),
+    ).toBe(CHAT_RUN_TRANSIENT_ERROR_MESSAGE);
+    expect(isActionableRunError(rawRunError)).toBe(false);
+    expect(isGenericRunErrorForDisplay(rawRunError)).toBe(true);
+  });
+
   it("keeps upstream Codex token refresh failures generic", () => {
     const rawRunError =
       'unexpected status 502 Bad Gateway: {"error":"TOKEN_REFRESH_FAILED","message":"Access token refresh failed for: codex-oauth-token.","permission":"model-provider:codex-oauth-token","connectors":["codex-oauth-token"],"failureReason":"upstream_provider"}, url: https://chatgpt.com/backend-api/codex/responses';

--- a/turbo/packages/api-contracts/src/contracts/__tests__/errors.test.ts
+++ b/turbo/packages/api-contracts/src/contracts/__tests__/errors.test.ts
@@ -179,6 +179,20 @@ describe("formatRunErrorForExternalSurface", () => {
     expect(isGenericRunErrorForDisplay(rawRunError)).toBe(true);
   });
 
+  it("does not match nested debug objects inside unrelated metadata bodies", () => {
+    const rawRunError =
+      'unexpected status 502 Bad Gateway: {"traceId":"abc","debug":{"error":"TOKEN_REFRESH_FAILED","connectors":["codex-oauth-token"],"failureReason":"reconnect_required"}}';
+
+    expect(
+      formatRunErrorForExternalSurface({
+        code: "UNKNOWN",
+        message: rawRunError,
+      }),
+    ).toBe(CHAT_RUN_TRANSIENT_ERROR_MESSAGE);
+    expect(isActionableRunError(rawRunError)).toBe(false);
+    expect(isGenericRunErrorForDisplay(rawRunError)).toBe(true);
+  });
+
   it("keeps upstream Codex token refresh failures generic", () => {
     const rawRunError =
       'unexpected status 502 Bad Gateway: {"error":"TOKEN_REFRESH_FAILED","message":"Access token refresh failed for: codex-oauth-token.","permission":"model-provider:codex-oauth-token","connectors":["codex-oauth-token"],"failureReason":"upstream_provider"}, url: https://chatgpt.com/backend-api/codex/responses';

--- a/turbo/packages/api-contracts/src/contracts/__tests__/errors.test.ts
+++ b/turbo/packages/api-contracts/src/contracts/__tests__/errors.test.ts
@@ -209,6 +209,20 @@ describe("formatRunErrorForExternalSurface", () => {
     expect(isGenericRunErrorForDisplay(rawRunError)).toBe(true);
   });
 
+  it("does not match nested debug objects inside incomplete JSON-looking bodies", () => {
+    const rawRunError =
+      'unexpected status 502 Bad Gateway: {"traceId":"abc","debug":{"error":"TOKEN_REFRESH_FAILED","connectors":["codex-oauth-token"],"failureReason":"reconnect_required"}';
+
+    expect(
+      formatRunErrorForExternalSurface({
+        code: "UNKNOWN",
+        message: rawRunError,
+      }),
+    ).toBe(CHAT_RUN_TRANSIENT_ERROR_MESSAGE);
+    expect(isActionableRunError(rawRunError)).toBe(false);
+    expect(isGenericRunErrorForDisplay(rawRunError)).toBe(true);
+  });
+
   it("keeps upstream Codex token refresh failures generic", () => {
     const rawRunError =
       'unexpected status 502 Bad Gateway: {"error":"TOKEN_REFRESH_FAILED","message":"Access token refresh failed for: codex-oauth-token.","permission":"model-provider:codex-oauth-token","connectors":["codex-oauth-token"],"failureReason":"upstream_provider"}, url: https://chatgpt.com/backend-api/codex/responses';

--- a/turbo/packages/api-contracts/src/contracts/__tests__/errors.test.ts
+++ b/turbo/packages/api-contracts/src/contracts/__tests__/errors.test.ts
@@ -159,6 +159,20 @@ describe("formatRunErrorForExternalSurface", () => {
     expect(isGenericRunErrorForDisplay(rawRunError)).toBe(true);
   });
 
+  it("requires token refresh failed to be the error code field", () => {
+    const rawRunError =
+      'unexpected status 502 Bad Gateway: {"error":"SOMETHING_ELSE","message":"TOKEN_REFRESH_FAILED for codex-oauth-token.","permission":"model-provider:codex-oauth-token","connectors":["codex-oauth-token"],"failureReason":"reconnect_required"}, url: https://chatgpt.com/backend-api/codex/responses';
+
+    expect(
+      formatRunErrorForExternalSurface({
+        code: "UNKNOWN",
+        message: rawRunError,
+      }),
+    ).toBe(CHAT_RUN_TRANSIENT_ERROR_MESSAGE);
+    expect(isActionableRunError(rawRunError)).toBe(false);
+    expect(isGenericRunErrorForDisplay(rawRunError)).toBe(true);
+  });
+
   it("keeps non-Codex token refresh failures generic", () => {
     const rawRunError =
       'unexpected status 502 Bad Gateway: {"error":"TOKEN_REFRESH_FAILED","message":"Access token expired and refresh failed for: zendesk.","permission":"connector:zendesk","connectors":["zendesk"],"failureReason":"reconnect_required"}, url: https://example.zendesk.com/api/v2/tickets';

--- a/turbo/packages/api-contracts/src/contracts/__tests__/errors.test.ts
+++ b/turbo/packages/api-contracts/src/contracts/__tests__/errors.test.ts
@@ -149,6 +149,22 @@ describe("formatRunErrorForExternalSurface", () => {
     expect(isGenericRunErrorForDisplay(rawRunError)).toBe(false);
   });
 
+  it("skips non-JSON brace templates before the reconnect-required error body", () => {
+    const rawRunError =
+      'request template {response_id: {"error":"TOKEN_REFRESH_FAILED","message":"Access token expired and refresh failed for: codex-oauth-token.","permission":"model-provider:codex-oauth-token","connectors":["codex-oauth-token"],"failureReason":"reconnect_required"}, url: https://chatgpt.com/backend-api/codex/responses';
+
+    expect(
+      formatRunErrorForExternalSurface({
+        code: "UNKNOWN",
+        message: rawRunError,
+      }),
+    ).toBe(
+      "ChatGPT session needs reconnection. Reconnect ChatGPT (Codex) in Model Providers, then retry.",
+    );
+    expect(isActionableRunError(rawRunError)).toBe(true);
+    expect(isGenericRunErrorForDisplay(rawRunError)).toBe(false);
+  });
+
   it("shows reconnect guidance for firewall auth API error envelopes", () => {
     const rawRunError =
       'unexpected status 502 Bad Gateway: {"error":{"message":"Access token expired and refresh failed for: codex-oauth-token.","code":"TOKEN_REFRESH_FAILED","connectors":["codex-oauth-token"],"failureReason":"reconnect_required"}}';

--- a/turbo/packages/api-contracts/src/contracts/__tests__/errors.test.ts
+++ b/turbo/packages/api-contracts/src/contracts/__tests__/errors.test.ts
@@ -117,6 +117,22 @@ describe("formatRunErrorForExternalSurface", () => {
     expect(isGenericRunErrorForDisplay(expectedMessage)).toBe(false);
   });
 
+  it("ignores braces after the embedded reconnect-required error body", () => {
+    const rawRunError =
+      'unexpected status 502 Bad Gateway: {"error":"TOKEN_REFRESH_FAILED","message":"Refresh failed for {codex} token.","permission":"model-provider:codex-oauth-token","connectors":["codex-oauth-token"],"failureReason":"reconnect_required"}, url: https://chatgpt.com/backend-api/codex/{response_id}';
+
+    expect(
+      formatRunErrorForExternalSurface({
+        code: "UNKNOWN",
+        message: rawRunError,
+      }),
+    ).toBe(
+      "ChatGPT session needs reconnection. Reconnect ChatGPT (Codex) in Model Providers, then retry.",
+    );
+    expect(isActionableRunError(rawRunError)).toBe(true);
+    expect(isGenericRunErrorForDisplay(rawRunError)).toBe(false);
+  });
+
   it("keeps upstream Codex token refresh failures generic", () => {
     const rawRunError =
       'unexpected status 502 Bad Gateway: {"error":"TOKEN_REFRESH_FAILED","message":"Access token refresh failed for: codex-oauth-token.","permission":"model-provider:codex-oauth-token","connectors":["codex-oauth-token"],"failureReason":"upstream_provider"}, url: https://chatgpt.com/backend-api/codex/responses';

--- a/turbo/packages/api-contracts/src/contracts/__tests__/errors.test.ts
+++ b/turbo/packages/api-contracts/src/contracts/__tests__/errors.test.ts
@@ -145,6 +145,20 @@ describe("formatRunErrorForExternalSurface", () => {
     expect(isGenericRunErrorForDisplay(rawRunError)).toBe(true);
   });
 
+  it("requires reconnect-required to be the failure reason field", () => {
+    const rawRunError =
+      'unexpected status 502 Bad Gateway: {"error":"TOKEN_REFRESH_FAILED","message":"Access token refresh failed for: codex-oauth-token after reconnect_required state.","permission":"model-provider:codex-oauth-token","connectors":["codex-oauth-token"]}, url: https://chatgpt.com/backend-api/codex/responses';
+
+    expect(
+      formatRunErrorForExternalSurface({
+        code: "UNKNOWN",
+        message: rawRunError,
+      }),
+    ).toBe(CHAT_RUN_TRANSIENT_ERROR_MESSAGE);
+    expect(isActionableRunError(rawRunError)).toBe(false);
+    expect(isGenericRunErrorForDisplay(rawRunError)).toBe(true);
+  });
+
   it("keeps non-Codex token refresh failures generic", () => {
     const rawRunError =
       'unexpected status 502 Bad Gateway: {"error":"TOKEN_REFRESH_FAILED","message":"Access token expired and refresh failed for: zendesk.","permission":"connector:zendesk","connectors":["zendesk"],"failureReason":"reconnect_required"}, url: https://example.zendesk.com/api/v2/tickets';

--- a/turbo/packages/api-contracts/src/contracts/__tests__/errors.test.ts
+++ b/turbo/packages/api-contracts/src/contracts/__tests__/errors.test.ts
@@ -133,6 +133,22 @@ describe("formatRunErrorForExternalSurface", () => {
     expect(isGenericRunErrorForDisplay(rawRunError)).toBe(false);
   });
 
+  it("skips unrelated objects before the reconnect-required error body", () => {
+    const rawRunError =
+      'request metadata {"traceId":"abc","status":502}: {"error":"TOKEN_REFRESH_FAILED","message":"Access token expired and refresh failed for: codex-oauth-token.","permission":"model-provider:codex-oauth-token","connectors":["codex-oauth-token"],"failureReason":"reconnect_required"}, url: https://chatgpt.com/backend-api/codex/responses';
+
+    expect(
+      formatRunErrorForExternalSurface({
+        code: "UNKNOWN",
+        message: rawRunError,
+      }),
+    ).toBe(
+      "ChatGPT session needs reconnection. Reconnect ChatGPT (Codex) in Model Providers, then retry.",
+    );
+    expect(isActionableRunError(rawRunError)).toBe(true);
+    expect(isGenericRunErrorForDisplay(rawRunError)).toBe(false);
+  });
+
   it("keeps upstream Codex token refresh failures generic", () => {
     const rawRunError =
       'unexpected status 502 Bad Gateway: {"error":"TOKEN_REFRESH_FAILED","message":"Access token refresh failed for: codex-oauth-token.","permission":"model-provider:codex-oauth-token","connectors":["codex-oauth-token"],"failureReason":"upstream_provider"}, url: https://chatgpt.com/backend-api/codex/responses';

--- a/turbo/packages/api-contracts/src/contracts/errors.ts
+++ b/turbo/packages/api-contracts/src/contracts/errors.ts
@@ -248,6 +248,14 @@ function isCodexOAuthReconnectRequiredRunErrorObject(value: unknown): boolean {
 }
 
 function isCodexOAuthReconnectRequiredRunError(errorMessage: string): boolean {
+  if (
+    !errorMessage.includes("TOKEN_REFRESH_FAILED") ||
+    !errorMessage.includes("codex-oauth-token") ||
+    !errorMessage.includes("reconnect_required")
+  ) {
+    return false;
+  }
+
   let searchStart = 0;
   let parsed = parseNextJsonObject(errorMessage, searchStart);
   while (parsed !== undefined) {
@@ -260,13 +268,17 @@ function isCodexOAuthReconnectRequiredRunError(errorMessage: string): boolean {
   return false;
 }
 
-export function isActionableRunError(errorMessage: string): boolean {
+function hasActionableRunErrorSnippet(errorMessage: string): boolean {
   const normalized = errorMessage.toLowerCase();
+  return ACTIONABLE_RUN_ERROR_SNIPPETS.some((snippet) => {
+    return normalized.includes(snippet.toLowerCase());
+  });
+}
+
+export function isActionableRunError(errorMessage: string): boolean {
   return (
     isCodexOAuthReconnectRequiredRunError(errorMessage) ||
-    ACTIONABLE_RUN_ERROR_SNIPPETS.some((snippet) => {
-      return normalized.includes(snippet.toLowerCase());
-    })
+    hasActionableRunErrorSnippet(errorMessage)
   );
 }
 
@@ -314,7 +326,7 @@ export function formatRunErrorForExternalSurface(params: {
     return CODEX_OAUTH_RECONNECT_REQUIRED_MESSAGE;
   }
 
-  return isGenericRunErrorForDisplay(errorMessage)
-    ? CHAT_RUN_TRANSIENT_ERROR_MESSAGE
-    : errorMessage;
+  return hasActionableRunErrorSnippet(errorMessage)
+    ? errorMessage
+    : CHAT_RUN_TRANSIENT_ERROR_MESSAGE;
 }

--- a/turbo/packages/api-contracts/src/contracts/errors.ts
+++ b/turbo/packages/api-contracts/src/contracts/errors.ts
@@ -128,6 +128,14 @@ const codexOAuthReconnectRequiredRunErrorBodySchema = z.object({
   failureReason: z.literal("reconnect_required"),
 });
 
+const codexOAuthReconnectRequiredRunErrorEnvelopeSchema = z.object({
+  error: z.object({
+    code: z.literal("TOKEN_REFRESH_FAILED"),
+    connectors: z.tuple([z.literal("codex-oauth-token")]),
+    failureReason: z.literal("reconnect_required"),
+  }),
+});
+
 export const INSUFFICIENT_CREDITS_ASK_ADMIN_MESSAGE =
   "Ask a workspace admin to add credits or upgrade the workspace plan.";
 
@@ -153,7 +161,10 @@ export const ACTIONABLE_RUN_ERROR_SNIPPETS = [
   CODEX_OAUTH_RECONNECT_REQUIRED_MESSAGE,
 ] as const;
 
-function parseJsonObjectAt(errorMessage: string, bodyStart: number): unknown {
+function parseJsonObjectAt(
+  errorMessage: string,
+  bodyStart: number,
+): { readonly value?: unknown; readonly endIndex: number } | undefined {
   let depth = 0;
   let inString = false;
   let escaped = false;
@@ -188,26 +199,36 @@ function parseJsonObjectAt(errorMessage: string, bodyStart: number): unknown {
     }
 
     try {
-      return JSON.parse(errorMessage.slice(bodyStart, index + 1)) as unknown;
+      return {
+        value: JSON.parse(errorMessage.slice(bodyStart, index + 1)) as unknown,
+        endIndex: index + 1,
+      };
     } catch {
-      return undefined;
+      return { endIndex: index + 1 };
     }
   }
 
   return undefined;
 }
 
+function isCodexOAuthReconnectRequiredRunErrorObject(value: unknown): boolean {
+  return (
+    codexOAuthReconnectRequiredRunErrorBodySchema.safeParse(value).success ||
+    codexOAuthReconnectRequiredRunErrorEnvelopeSchema.safeParse(value).success
+  );
+}
+
 function isCodexOAuthReconnectRequiredRunError(errorMessage: string): boolean {
   let bodyStart = errorMessage.indexOf("{");
   while (bodyStart !== -1) {
-    if (
-      codexOAuthReconnectRequiredRunErrorBodySchema.safeParse(
-        parseJsonObjectAt(errorMessage, bodyStart),
-      ).success
-    ) {
+    const parsed = parseJsonObjectAt(errorMessage, bodyStart);
+    if (isCodexOAuthReconnectRequiredRunErrorObject(parsed?.value)) {
       return true;
     }
-    bodyStart = errorMessage.indexOf("{", bodyStart + 1);
+    bodyStart = errorMessage.indexOf(
+      "{",
+      parsed === undefined ? bodyStart + 1 : parsed.endIndex,
+    );
   }
   return false;
 }

--- a/turbo/packages/api-contracts/src/contracts/errors.ts
+++ b/turbo/packages/api-contracts/src/contracts/errors.ts
@@ -151,10 +151,12 @@ function isCodexOAuthReconnectRequiredRunError(errorMessage: string): boolean {
   const normalized = errorMessage.toLowerCase();
   const hasOnlyCodexOAuthConnector =
     /"connectors"\s*:\s*\[\s*"codex-oauth-token"\s*\]/.test(normalized);
+  const hasReconnectRequiredFailureReason =
+    /"failurereason"\s*:\s*"reconnect_required"/.test(normalized);
   return (
     normalized.includes("token_refresh_failed") &&
     hasOnlyCodexOAuthConnector &&
-    normalized.includes("reconnect_required") &&
+    hasReconnectRequiredFailureReason &&
     !normalized.includes("upstream_provider")
   );
 }

--- a/turbo/packages/api-contracts/src/contracts/errors.ts
+++ b/turbo/packages/api-contracts/src/contracts/errors.ts
@@ -152,7 +152,8 @@ function isCodexOAuthReconnectRequiredRunError(errorMessage: string): boolean {
   return (
     normalized.includes("token_refresh_failed") &&
     normalized.includes("codex-oauth-token") &&
-    normalized.includes("reconnect_required")
+    normalized.includes("reconnect_required") &&
+    !normalized.includes("upstream_provider")
   );
 }
 

--- a/turbo/packages/api-contracts/src/contracts/errors.ts
+++ b/turbo/packages/api-contracts/src/contracts/errors.ts
@@ -159,8 +159,7 @@ function isCodexOAuthReconnectRequiredRunError(errorMessage: string): boolean {
   return (
     hasTokenRefreshFailedCode &&
     hasOnlyCodexOAuthConnector &&
-    hasReconnectRequiredFailureReason &&
-    !normalized.includes("upstream_provider")
+    hasReconnectRequiredFailureReason
   );
 }
 

--- a/turbo/packages/api-contracts/src/contracts/errors.ts
+++ b/turbo/packages/api-contracts/src/contracts/errors.ts
@@ -149,12 +149,15 @@ export const ACTIONABLE_RUN_ERROR_SNIPPETS = [
 
 function isCodexOAuthReconnectRequiredRunError(errorMessage: string): boolean {
   const normalized = errorMessage.toLowerCase();
+  const hasTokenRefreshFailedCode = /"error"\s*:\s*"token_refresh_failed"/.test(
+    normalized,
+  );
   const hasOnlyCodexOAuthConnector =
     /"connectors"\s*:\s*\[\s*"codex-oauth-token"\s*\]/.test(normalized);
   const hasReconnectRequiredFailureReason =
     /"failurereason"\s*:\s*"reconnect_required"/.test(normalized);
   return (
-    normalized.includes("token_refresh_failed") &&
+    hasTokenRefreshFailedCode &&
     hasOnlyCodexOAuthConnector &&
     hasReconnectRequiredFailureReason &&
     !normalized.includes("upstream_provider")

--- a/turbo/packages/api-contracts/src/contracts/errors.ts
+++ b/turbo/packages/api-contracts/src/contracts/errors.ts
@@ -155,16 +155,51 @@ export const ACTIONABLE_RUN_ERROR_SNIPPETS = [
 
 function parseEmbeddedRunErrorBody(errorMessage: string): unknown {
   const bodyStart = errorMessage.indexOf("{");
-  const bodyEnd = errorMessage.lastIndexOf("}");
-  if (bodyStart === -1 || bodyEnd <= bodyStart) {
+  if (bodyStart === -1) {
     return undefined;
   }
 
-  try {
-    return JSON.parse(errorMessage.slice(bodyStart, bodyEnd + 1)) as unknown;
-  } catch {
-    return undefined;
+  let depth = 0;
+  let inString = false;
+  let escaped = false;
+  for (let index = bodyStart; index < errorMessage.length; index += 1) {
+    const char = errorMessage[index];
+    if (escaped) {
+      escaped = false;
+      continue;
+    }
+    if (char === "\\") {
+      escaped = inString;
+      continue;
+    }
+    if (char === '"') {
+      inString = !inString;
+      continue;
+    }
+    if (inString) {
+      continue;
+    }
+    if (char === "{") {
+      depth += 1;
+      continue;
+    }
+    if (char !== "}") {
+      continue;
+    }
+
+    depth -= 1;
+    if (depth !== 0) {
+      continue;
+    }
+
+    try {
+      return JSON.parse(errorMessage.slice(bodyStart, index + 1)) as unknown;
+    } catch {
+      return undefined;
+    }
   }
+
+  return undefined;
 }
 
 function isCodexOAuthReconnectRequiredRunError(errorMessage: string): boolean {

--- a/turbo/packages/api-contracts/src/contracts/errors.ts
+++ b/turbo/packages/api-contracts/src/contracts/errors.ts
@@ -122,6 +122,12 @@ export const CHAT_RUN_TRANSIENT_ERROR_MESSAGE =
 const CODEX_OAUTH_RECONNECT_REQUIRED_MESSAGE =
   "ChatGPT session needs reconnection. Reconnect ChatGPT (Codex) in Model Providers, then retry.";
 
+const codexOAuthReconnectRequiredRunErrorBodySchema = z.object({
+  error: z.literal("TOKEN_REFRESH_FAILED"),
+  connectors: z.tuple([z.literal("codex-oauth-token")]),
+  failureReason: z.literal("reconnect_required"),
+});
+
 export const INSUFFICIENT_CREDITS_ASK_ADMIN_MESSAGE =
   "Ask a workspace admin to add credits or upgrade the workspace plan.";
 
@@ -147,20 +153,24 @@ export const ACTIONABLE_RUN_ERROR_SNIPPETS = [
   CODEX_OAUTH_RECONNECT_REQUIRED_MESSAGE,
 ] as const;
 
+function parseEmbeddedRunErrorBody(errorMessage: string): unknown {
+  const bodyStart = errorMessage.indexOf("{");
+  const bodyEnd = errorMessage.lastIndexOf("}");
+  if (bodyStart === -1 || bodyEnd <= bodyStart) {
+    return undefined;
+  }
+
+  try {
+    return JSON.parse(errorMessage.slice(bodyStart, bodyEnd + 1)) as unknown;
+  } catch {
+    return undefined;
+  }
+}
+
 function isCodexOAuthReconnectRequiredRunError(errorMessage: string): boolean {
-  const normalized = errorMessage.toLowerCase();
-  const hasTokenRefreshFailedCode = /"error"\s*:\s*"token_refresh_failed"/.test(
-    normalized,
-  );
-  const hasOnlyCodexOAuthConnector =
-    /"connectors"\s*:\s*\[\s*"codex-oauth-token"\s*\]/.test(normalized);
-  const hasReconnectRequiredFailureReason =
-    /"failurereason"\s*:\s*"reconnect_required"/.test(normalized);
-  return (
-    hasTokenRefreshFailedCode &&
-    hasOnlyCodexOAuthConnector &&
-    hasReconnectRequiredFailureReason
-  );
+  return codexOAuthReconnectRequiredRunErrorBodySchema.safeParse(
+    parseEmbeddedRunErrorBody(errorMessage),
+  ).success;
 }
 
 export function isActionableRunError(errorMessage: string): boolean {

--- a/turbo/packages/api-contracts/src/contracts/errors.ts
+++ b/turbo/packages/api-contracts/src/contracts/errors.ts
@@ -149,9 +149,11 @@ export const ACTIONABLE_RUN_ERROR_SNIPPETS = [
 
 function isCodexOAuthReconnectRequiredRunError(errorMessage: string): boolean {
   const normalized = errorMessage.toLowerCase();
+  const hasOnlyCodexOAuthConnector =
+    /"connectors"\s*:\s*\[\s*"codex-oauth-token"\s*\]/.test(normalized);
   return (
     normalized.includes("token_refresh_failed") &&
-    normalized.includes("codex-oauth-token") &&
+    hasOnlyCodexOAuthConnector &&
     normalized.includes("reconnect_required") &&
     !normalized.includes("upstream_provider")
   );

--- a/turbo/packages/api-contracts/src/contracts/errors.ts
+++ b/turbo/packages/api-contracts/src/contracts/errors.ts
@@ -119,6 +119,9 @@ export const RUN_ERROR_GUIDANCE: Record<
 export const CHAT_RUN_TRANSIENT_ERROR_MESSAGE =
   "Oops, something went wrong. Please try again later.";
 
+export const CODEX_OAUTH_RECONNECT_REQUIRED_MESSAGE =
+  "ChatGPT session needs reconnection. Reconnect ChatGPT (Codex) in Model Providers, then retry.";
+
 export const INSUFFICIENT_CREDITS_ASK_ADMIN_MESSAGE =
   "Ask a workspace admin to add credits or upgrade the workspace plan.";
 
@@ -141,13 +144,26 @@ export const ACTIONABLE_RUN_ERROR_SNIPPETS = [
   //   "You've hit your weekly limit · resets …"
   "session limit",
   "weekly limit",
+  CODEX_OAUTH_RECONNECT_REQUIRED_MESSAGE,
 ] as const;
+
+function isCodexOAuthReconnectRequiredRunError(errorMessage: string): boolean {
+  const normalized = errorMessage.toLowerCase();
+  return (
+    normalized.includes("token_refresh_failed") &&
+    normalized.includes("codex-oauth-token") &&
+    normalized.includes("reconnect_required")
+  );
+}
 
 export function isActionableRunError(errorMessage: string): boolean {
   const normalized = errorMessage.toLowerCase();
-  return ACTIONABLE_RUN_ERROR_SNIPPETS.some((snippet) => {
-    return normalized.includes(snippet.toLowerCase());
-  });
+  return (
+    isCodexOAuthReconnectRequiredRunError(errorMessage) ||
+    ACTIONABLE_RUN_ERROR_SNIPPETS.some((snippet) => {
+      return normalized.includes(snippet.toLowerCase());
+    })
+  );
 }
 
 export function isGenericRunErrorForDisplay(errorMessage: string): boolean {
@@ -188,6 +204,10 @@ export function formatRunErrorForExternalSurface(params: {
       params.insufficientCredits.addCreditsUrl ??
       params.insufficientCredits.comparePlansUrl;
     return `${errorMessage}\n\nAdd credits: ${addCreditsUrl}`;
+  }
+
+  if (isCodexOAuthReconnectRequiredRunError(errorMessage)) {
+    return CODEX_OAUTH_RECONNECT_REQUIRED_MESSAGE;
   }
 
   return isGenericRunErrorForDisplay(errorMessage)

--- a/turbo/packages/api-contracts/src/contracts/errors.ts
+++ b/turbo/packages/api-contracts/src/contracts/errors.ts
@@ -161,10 +161,15 @@ export const ACTIONABLE_RUN_ERROR_SNIPPETS = [
   CODEX_OAUTH_RECONNECT_REQUIRED_MESSAGE,
 ] as const;
 
-function parseJsonObjectAt(
+function parseNextJsonObject(
   errorMessage: string,
-  bodyStart: number,
+  searchStart: number,
 ): { readonly value?: unknown; readonly endIndex: number } | undefined {
+  const bodyStart = errorMessage.indexOf("{", searchStart);
+  if (bodyStart === -1) {
+    return undefined;
+  }
+
   let depth = 0;
   let inString = false;
   let escaped = false;
@@ -219,16 +224,14 @@ function isCodexOAuthReconnectRequiredRunErrorObject(value: unknown): boolean {
 }
 
 function isCodexOAuthReconnectRequiredRunError(errorMessage: string): boolean {
-  let bodyStart = errorMessage.indexOf("{");
-  while (bodyStart !== -1) {
-    const parsed = parseJsonObjectAt(errorMessage, bodyStart);
+  let searchStart = 0;
+  let parsed = parseNextJsonObject(errorMessage, searchStart);
+  while (parsed !== undefined) {
     if (isCodexOAuthReconnectRequiredRunErrorObject(parsed?.value)) {
       return true;
     }
-    bodyStart = errorMessage.indexOf(
-      "{",
-      parsed === undefined ? bodyStart + 1 : parsed.endIndex,
-    );
+    searchStart = parsed.endIndex;
+    parsed = parseNextJsonObject(errorMessage, searchStart);
   }
   return false;
 }

--- a/turbo/packages/api-contracts/src/contracts/errors.ts
+++ b/turbo/packages/api-contracts/src/contracts/errors.ts
@@ -119,7 +119,7 @@ export const RUN_ERROR_GUIDANCE: Record<
 export const CHAT_RUN_TRANSIENT_ERROR_MESSAGE =
   "Oops, something went wrong. Please try again later.";
 
-export const CODEX_OAUTH_RECONNECT_REQUIRED_MESSAGE =
+const CODEX_OAUTH_RECONNECT_REQUIRED_MESSAGE =
   "ChatGPT session needs reconnection. Reconnect ChatGPT (Codex) in Model Providers, then retry.";
 
 export const INSUFFICIENT_CREDITS_ASK_ADMIN_MESSAGE =

--- a/turbo/packages/api-contracts/src/contracts/errors.ts
+++ b/turbo/packages/api-contracts/src/contracts/errors.ts
@@ -153,12 +153,7 @@ export const ACTIONABLE_RUN_ERROR_SNIPPETS = [
   CODEX_OAUTH_RECONNECT_REQUIRED_MESSAGE,
 ] as const;
 
-function parseEmbeddedRunErrorBody(errorMessage: string): unknown {
-  const bodyStart = errorMessage.indexOf("{");
-  if (bodyStart === -1) {
-    return undefined;
-  }
-
+function parseJsonObjectAt(errorMessage: string, bodyStart: number): unknown {
   let depth = 0;
   let inString = false;
   let escaped = false;
@@ -203,9 +198,18 @@ function parseEmbeddedRunErrorBody(errorMessage: string): unknown {
 }
 
 function isCodexOAuthReconnectRequiredRunError(errorMessage: string): boolean {
-  return codexOAuthReconnectRequiredRunErrorBodySchema.safeParse(
-    parseEmbeddedRunErrorBody(errorMessage),
-  ).success;
+  let bodyStart = errorMessage.indexOf("{");
+  while (bodyStart !== -1) {
+    if (
+      codexOAuthReconnectRequiredRunErrorBodySchema.safeParse(
+        parseJsonObjectAt(errorMessage, bodyStart),
+      ).success
+    ) {
+      return true;
+    }
+    bodyStart = errorMessage.indexOf("{", bodyStart + 1);
+  }
+  return false;
 }
 
 export function isActionableRunError(errorMessage: string): boolean {

--- a/turbo/packages/api-contracts/src/contracts/errors.ts
+++ b/turbo/packages/api-contracts/src/contracts/errors.ts
@@ -237,7 +237,7 @@ function parseNextJsonObject(
     }
   }
 
-  return { endIndex: bodyStart + 1 };
+  return { endIndex: errorMessage.length };
 }
 
 function isCodexOAuthReconnectRequiredRunErrorObject(value: unknown): boolean {

--- a/turbo/packages/api-contracts/src/contracts/errors.ts
+++ b/turbo/packages/api-contracts/src/contracts/errors.ts
@@ -161,11 +161,35 @@ export const ACTIONABLE_RUN_ERROR_SNIPPETS = [
   CODEX_OAUTH_RECONNECT_REQUIRED_MESSAGE,
 ] as const;
 
+function isJsonWhitespace(char: string | undefined): boolean {
+  return char === " " || char === "\n" || char === "\r" || char === "\t";
+}
+
+function findNextJsonObjectStart(
+  errorMessage: string,
+  searchStart: number,
+): number {
+  let bodyStart = errorMessage.indexOf("{", searchStart);
+  while (bodyStart !== -1) {
+    let nextNonWhitespace = bodyStart + 1;
+    while (isJsonWhitespace(errorMessage[nextNonWhitespace])) {
+      nextNonWhitespace += 1;
+    }
+
+    const firstToken = errorMessage[nextNonWhitespace];
+    if (firstToken === '"' || firstToken === "}") {
+      return bodyStart;
+    }
+    bodyStart = errorMessage.indexOf("{", bodyStart + 1);
+  }
+  return -1;
+}
+
 function parseNextJsonObject(
   errorMessage: string,
   searchStart: number,
 ): { readonly value?: unknown; readonly endIndex: number } | undefined {
-  const bodyStart = errorMessage.indexOf("{", searchStart);
+  const bodyStart = findNextJsonObjectStart(errorMessage, searchStart);
   if (bodyStart === -1) {
     return undefined;
   }
@@ -213,7 +237,7 @@ function parseNextJsonObject(
     }
   }
 
-  return undefined;
+  return { endIndex: bodyStart + 1 };
 }
 
 function isCodexOAuthReconnectRequiredRunErrorObject(value: unknown): boolean {

--- a/turbo/packages/api-contracts/src/contracts/index.ts
+++ b/turbo/packages/api-contracts/src/contracts/index.ts
@@ -27,6 +27,7 @@ export {
   apiErrorSchema,
   ApiError,
   CHAT_RUN_TRANSIENT_ERROR_MESSAGE,
+  CODEX_OAUTH_RECONNECT_REQUIRED_MESSAGE,
   createErrorResponse,
   formatRunErrorForExternalSurface,
   isActionableRunError,

--- a/turbo/packages/api-contracts/src/contracts/index.ts
+++ b/turbo/packages/api-contracts/src/contracts/index.ts
@@ -27,7 +27,6 @@ export {
   apiErrorSchema,
   ApiError,
   CHAT_RUN_TRANSIENT_ERROR_MESSAGE,
-  CODEX_OAUTH_RECONNECT_REQUIRED_MESSAGE,
   createErrorResponse,
   formatRunErrorForExternalSurface,
   isActionableRunError,


### PR DESCRIPTION
## Summary

- add narrow detection for Codex OAuth `TOKEN_REFRESH_FAILED` run errors that require reconnect
- format those failures with actionable ChatGPT/Codex reconnect guidance
- keep upstream-provider and non-Codex token refresh failures on the generic transient path

Closes #16056

## Tests

- `pnpm -F @vm0/api-contracts exec vitest src/contracts/__tests__/errors.test.ts`
- `pnpm -F @vm0/api-contracts lint`
- `pnpm -F @vm0/api-contracts check-types`
- pre-commit: prettier, knip, full `pnpm check-types`
