### PR TITLE
perf: avoid exec output payload copy

### DIFF
--- a/crates/vsock-host/src/exec_operation.rs
+++ b/crates/vsock-host/src/exec_operation.rs
@@ -15,10 +15,10 @@ use crate::{
     operation_tracker::{NormalOperationToken, NormalOperationTransitionHandle},
 };
 use vsock_proto::{
-    ExecCapturedOutput, ExecControlNonce, ExecControlPolicy, ExecControlStatus,
+    BorrowedRawMessage, ExecCapturedOutput, ExecControlNonce, ExecControlPolicy, ExecControlStatus,
     ExecLifecyclePolicy, ExecOutputPolicy, ExecOutputStream, ExecTermination, ExecTimeoutPolicy,
     MSG_ERROR, MSG_EXEC_CANCEL, MSG_EXEC_CONTROL, MSG_EXEC_CONTROL_RESULT, MSG_EXEC_OUTPUT,
-    MSG_EXEC_RESULT, MSG_EXEC_START, MSG_EXEC_STARTED, RawMessage,
+    MSG_EXEC_RESULT, MSG_EXEC_START, MSG_EXEC_STARTED,
 };
 
 pub(crate) const DEFAULT_EXEC_CAPTURE_LIMIT_BYTES: u32 = 1024 * 1024;
@@ -1743,7 +1743,10 @@ fn owned_result(
 
 /// Returns true when exec handling consumed the frame; false lets the normal
 /// pending-response dispatcher handle it.
-pub(crate) fn dispatch_incoming_frame(shared: &Arc<Shared>, msg: &RawMessage) -> io::Result<bool> {
+pub(crate) fn dispatch_incoming_frame(
+    shared: &Arc<Shared>,
+    msg: BorrowedRawMessage<'_>,
+) -> io::Result<bool> {
     match msg.msg_type {
         MSG_ERROR => dispatch_error(shared, msg),
         MSG_EXEC_OUTPUT => dispatch_output(shared, msg).map(|_| true),
@@ -1754,14 +1757,14 @@ pub(crate) fn dispatch_incoming_frame(shared: &Arc<Shared>, msg: &RawMessage) ->
     }
 }
 
-fn dispatch_output(shared: &Arc<Shared>, msg: &RawMessage) -> io::Result<()> {
+fn dispatch_output(shared: &Arc<Shared>, msg: BorrowedRawMessage<'_>) -> io::Result<()> {
     let mut first_output_slow = None;
     {
         let mut guard = shared.state.lock().unwrap_or_else(|e| e.into_inner());
         if let ConnectionState::Connected { operations, .. } = &mut *guard
             && let Some(operation) = operations.get_mut(msg.seq)
         {
-            let decoded = vsock_proto::decode_exec_output(&msg.payload)
+            let decoded = vsock_proto::decode_exec_output(msg.payload)
                 .map_err(exec_operation_protocol_error)?;
             if !operation.allows_output() {
                 return Err(exec_operation_protocol_error(
@@ -1796,7 +1799,7 @@ fn dispatch_output(shared: &Arc<Shared>, msg: &RawMessage) -> io::Result<()> {
     Ok(())
 }
 
-fn dispatch_started(shared: &Arc<Shared>, msg: &RawMessage) -> io::Result<()> {
+fn dispatch_started(shared: &Arc<Shared>, msg: BorrowedRawMessage<'_>) -> io::Result<()> {
     let start = {
         let mut guard = shared.state.lock().unwrap_or_else(|e| e.into_inner());
         match &mut *guard {
@@ -1804,7 +1807,7 @@ fn dispatch_started(shared: &Arc<Shared>, msg: &RawMessage) -> io::Result<()> {
                 let Some(operation) = operations.get_mut(msg.seq) else {
                     return Ok(());
                 };
-                let decoded = vsock_proto::decode_exec_started(&msg.payload)
+                let decoded = vsock_proto::decode_exec_started(msg.payload)
                     .map_err(exec_operation_protocol_error)?;
                 let lifecycle =
                     std::mem::replace(&mut operation.lifecycle, ExecOperationLifecycle::OneShot);
@@ -1844,7 +1847,7 @@ fn dispatch_started(shared: &Arc<Shared>, msg: &RawMessage) -> io::Result<()> {
     Ok(())
 }
 
-fn dispatch_result(shared: &Arc<Shared>, msg: &RawMessage) -> io::Result<()> {
+fn dispatch_result(shared: &Arc<Shared>, msg: BorrowedRawMessage<'_>) -> io::Result<()> {
     let Some((
         diagnostic,
         result_tx,
@@ -1857,7 +1860,7 @@ fn dispatch_result(shared: &Arc<Shared>, msg: &RawMessage) -> io::Result<()> {
         let mut guard = shared.state.lock().unwrap_or_else(|e| e.into_inner());
         match &mut *guard {
             ConnectionState::Connected { operations, .. } if operations.contains(msg.seq) => {
-                let decoded = vsock_proto::decode_exec_result(&msg.payload)
+                let decoded = vsock_proto::decode_exec_result(msg.payload)
                     .map_err(exec_operation_protocol_error)?;
                 let Some(operation) = operations.get_mut(msg.seq) else {
                     return Ok(());
@@ -1924,7 +1927,7 @@ fn dispatch_result(shared: &Arc<Shared>, msg: &RawMessage) -> io::Result<()> {
     Ok(())
 }
 
-fn dispatch_control_result(shared: &Arc<Shared>, msg: &RawMessage) -> io::Result<()> {
+fn dispatch_control_result(shared: &Arc<Shared>, msg: BorrowedRawMessage<'_>) -> io::Result<()> {
     let Some(pending) = ({
         let mut guard = shared.state.lock().unwrap_or_else(|e| e.into_inner());
         match &mut *guard {
@@ -1936,7 +1939,7 @@ fn dispatch_control_result(shared: &Arc<Shared>, msg: &RawMessage) -> io::Result
     }) else {
         return Ok(());
     };
-    let decoded = vsock_proto::decode_exec_control_result(&msg.payload)
+    let decoded = vsock_proto::decode_exec_control_result(msg.payload)
         .map_err(exec_operation_protocol_error)?;
 
     if decoded.control_nonce != pending.control_nonce {
@@ -1974,12 +1977,12 @@ fn dispatch_control_result(shared: &Arc<Shared>, msg: &RawMessage) -> io::Result
     Ok(())
 }
 
-fn dispatch_error(shared: &Arc<Shared>, msg: &RawMessage) -> io::Result<bool> {
+fn dispatch_error(shared: &Arc<Shared>, msg: BorrowedRawMessage<'_>) -> io::Result<bool> {
     let Some((diagnostic, result_tx, start_tx, err)) = ({
         let mut guard = shared.state.lock().unwrap_or_else(|e| e.into_inner());
         match &mut *guard {
             ConnectionState::Connected { operations, .. } if operations.contains(msg.seq) => {
-                let err = vsock_proto::decode_error(&msg.payload)
+                let err = vsock_proto::decode_error(msg.payload)
                     .map(|message| io::Error::other(message.to_string()))
                     .map_err(exec_operation_protocol_error)?;
                 let Some(operation) = operations.take(msg.seq) else {
@@ -2018,7 +2021,7 @@ fn dispatch_error(shared: &Arc<Shared>, msg: &RawMessage) -> io::Result<bool> {
     Ok(true)
 }
 
-fn dispatch_control_error(shared: &Arc<Shared>, msg: &RawMessage) -> io::Result<bool> {
+fn dispatch_control_error(shared: &Arc<Shared>, msg: BorrowedRawMessage<'_>) -> io::Result<bool> {
     let Some(pending) = ({
         let mut guard = shared.state.lock().unwrap_or_else(|e| e.into_inner());
         match &mut *guard {
@@ -2030,7 +2033,7 @@ fn dispatch_control_error(shared: &Arc<Shared>, msg: &RawMessage) -> io::Result<
     }) else {
         return Ok(false);
     };
-    let message = vsock_proto::decode_error(&msg.payload)
+    let message = vsock_proto::decode_error(msg.payload)
         .map(|message| message.to_owned())
         .map_err(exec_operation_protocol_error)?;
     pending
@@ -2964,6 +2967,7 @@ mod tests {
     use tracing::{Event, Level, Subscriber};
     use tracing_subscriber::layer::{Context, Layer};
     use tracing_subscriber::prelude::*;
+    use vsock_proto::RawMessage;
 
     #[derive(Clone, Debug)]
     struct CapturedEvent {
@@ -3415,7 +3419,7 @@ mod tests {
         let subscriber = tracing_subscriber::registry().with(captured.clone());
         tracing::subscriber::with_default(subscriber, || {
             tracing::callsite::rebuild_interest_cache();
-            dispatch_result(&shared, &msg).unwrap();
+            dispatch_result(&shared, msg.as_borrowed()).unwrap();
         });
 
         let events = captured.events();
@@ -3577,7 +3581,7 @@ mod tests {
         let subscriber = tracing_subscriber::registry().with(captured.clone());
         tracing::subscriber::with_default(subscriber, || {
             tracing::callsite::rebuild_interest_cache();
-            dispatch_result(&shared, &msg).unwrap();
+            dispatch_result(&shared, msg.as_borrowed()).unwrap();
         });
 
         let events = captured.events();
@@ -3636,7 +3640,7 @@ mod tests {
         let subscriber = tracing_subscriber::registry().with(captured.clone());
         tracing::subscriber::with_default(subscriber, || {
             tracing::callsite::rebuild_interest_cache();
-            dispatch_result(&shared, &msg).unwrap();
+            dispatch_result(&shared, msg.as_borrowed()).unwrap();
         });
 
         let events = captured.events();

--- a/crates/vsock-host/src/lib.rs
+++ b/crates/vsock-host/src/lib.rs
@@ -43,9 +43,9 @@ use operation_tracker::{
     NormalOperationTransitionError, NormalOperationTransitionHandle,
 };
 use vsock_proto::{
-    Decoder, MSG_ERROR, MSG_OPERATIONS_QUIESCED, MSG_OPERATIONS_RESUMED, MSG_PING, MSG_PONG,
-    MSG_QUIESCE_OPERATIONS, MSG_READY, MSG_RESUME_OPERATIONS, MSG_SHUTDOWN, MSG_SHUTDOWN_ACK,
-    RawMessage,
+    BorrowedRawMessage, DecodeWithError, Decoder, MSG_ERROR, MSG_OPERATIONS_QUIESCED,
+    MSG_OPERATIONS_RESUMED, MSG_PING, MSG_PONG, MSG_QUIESCE_OPERATIONS, MSG_READY,
+    MSG_RESUME_OPERATIONS, MSG_SHUTDOWN, MSG_SHUTDOWN_ACK, RawMessage,
 };
 
 pub use exec_operation::{
@@ -449,51 +449,14 @@ async fn reader_loop(
             Ok(n) => n,
         };
         // n <= READ_BUF_SIZE guaranteed by read()
-        let messages = match decoder.decode(buf.get(..n).unwrap_or_default()) {
-            Ok(msgs) => msgs,
-            Err(_) => break,
-        };
-        for msg in messages {
-            match exec_operation::dispatch_incoming_frame(&shared, &msg) {
-                Ok(true) => {
-                    continue;
-                }
-                Ok(false) => {}
-                Err(_) => {
-                    shared.poison_connection();
-                    return;
-                }
-            }
-
-            let mut normal_operation_transition_failed = false;
-            let pending_response = {
-                let mut guard = shared.state.lock().unwrap_or_else(|e| e.into_inner());
-                match &mut *guard {
-                    ConnectionState::Connected { pending, .. } => {
-                        if let Some(mut pending_response) = pending.remove(&msg.seq) {
-                            if pending_response
-                                .normal_terminal_msg_types
-                                .contains(&msg.msg_type)
-                                && let Some(normal_operation) =
-                                    pending_response.normal_operation.take()
-                                && complete_pending_normal_operation(normal_operation).is_err()
-                            {
-                                normal_operation_transition_failed = true;
-                            }
-                            Some(pending_response)
-                        } else {
-                            None
-                        }
-                    }
-                    ConnectionState::Closed => None,
-                }
-            };
-            if normal_operation_transition_failed {
+        match decoder.decode_with(buf.get(..n).unwrap_or_default(), |msg| {
+            dispatch_reader_frame(&shared, msg)
+        }) {
+            Ok(()) => {}
+            Err(DecodeWithError::Protocol(_)) => break,
+            Err(DecodeWithError::Visitor(_)) => {
                 shared.poison_connection();
                 return;
-            }
-            if let Some(pending_response) = pending_response {
-                let _ = pending_response.response_tx.send(msg);
             }
         }
     }
@@ -503,6 +466,42 @@ async fn reader_loop(
     shared.close();
 }
 
+fn dispatch_reader_frame(shared: &Arc<Shared>, msg: BorrowedRawMessage<'_>) -> io::Result<()> {
+    match exec_operation::dispatch_incoming_frame(shared, msg) {
+        Ok(true) => {
+            return Ok(());
+        }
+        Ok(false) => {}
+        Err(error) => {
+            return Err(error);
+        }
+    }
+
+    let pending_response = {
+        let mut guard = shared.state.lock().unwrap_or_else(|e| e.into_inner());
+        match &mut *guard {
+            ConnectionState::Connected { pending, .. } => {
+                if let Some(mut pending_response) = pending.remove(&msg.seq) {
+                    if pending_response
+                        .normal_terminal_msg_types
+                        .contains(&msg.msg_type)
+                        && let Some(normal_operation) = pending_response.normal_operation.take()
+                    {
+                        complete_pending_normal_operation(normal_operation)?;
+                    }
+                    Some(pending_response)
+                } else {
+                    None
+                }
+            }
+            ConnectionState::Closed => None,
+        }
+    };
+    if let Some(pending_response) = pending_response {
+        let _ = pending_response.response_tx.send(msg.to_owned_message());
+    }
+    Ok(())
+}
 /// Send a request and wait for a response with matching sequence number.
 async fn request_on_shared(
     shared: &Arc<Shared>,

--- a/crates/vsock-host/src/tests/exec_operation/stream.rs
+++ b/crates/vsock-host/src/tests/exec_operation/stream.rs
@@ -2,7 +2,11 @@ use std::io;
 use std::sync::Arc;
 use std::time::Duration;
 
-use vsock_proto::{ExecOutputPolicy, ExecOutputStream, ExecTermination, MSG_EXEC_START};
+use tokio::io::AsyncWriteExt;
+use vsock_proto::{
+    ExecCapturedOutput, ExecOutputPolicy, ExecOutputStream, ExecTermination, MSG_EXEC_OUTPUT,
+    MSG_EXEC_RESULT, MSG_EXEC_START,
+};
 
 use super::super::support::{
     assert_connection_accepts_exec_operation, operation_count, read_guest_message,
@@ -388,6 +392,59 @@ async fn exec_operation_stream_dispatches_stdout_stderr_and_closes_on_result() {
     )
     .await;
     let result = handle.wait(Duration::from_secs(5)).await.unwrap();
+    assert!(!result.stream_overflowed);
+    assert!(rx.recv().await.is_none());
+}
+
+#[tokio::test]
+async fn exec_operation_stream_handles_output_and_result_from_one_write() {
+    let (host, mut guest) = setup_host_and_guest().await;
+    let mut handle = host
+        .exec_operation_stream(ExecStreamRequest {
+            timeout_ms: 5000,
+            command: "stream",
+            env: &[],
+            sudo: false,
+            label: "stream-coalesced",
+            stdout: ExecOutputPolicy::Stream {
+                limit_bytes: 1024,
+                chunk_limit_bytes: 16,
+            },
+            stderr: ExecOutputPolicy::Discard,
+            expected_exit_codes: &[],
+            stdin_bytes: None,
+            stream_queue_capacity: None,
+        })
+        .await
+        .unwrap();
+    let mut rx = handle.take_stream_receiver().unwrap();
+
+    let msg = read_guest_message(&mut guest).await;
+    assert_eq!(msg.msg_type, MSG_EXEC_START);
+    let output_payload =
+        vsock_proto::encode_exec_output(ExecOutputStream::Stdout, 0, b"coalesced", false).unwrap();
+    let result_payload = vsock_proto::encode_exec_result(
+        ExecTermination::Exited { exit_code: 0 },
+        12,
+        ExecCapturedOutput::Discarded,
+        ExecCapturedOutput::Discarded,
+        "",
+    )
+    .unwrap();
+    let mut frames = vsock_proto::encode(MSG_EXEC_OUTPUT, msg.seq, &output_payload).unwrap();
+    frames.extend_from_slice(
+        &vsock_proto::encode(MSG_EXEC_RESULT, msg.seq, &result_payload).unwrap(),
+    );
+    guest.write_all(&frames).await.unwrap();
+
+    let event = rx.recv().await.unwrap();
+    assert_eq!(event.stream, ExecOutputStream::Stdout);
+    assert_eq!(event.output_seq, 0);
+    assert_eq!(event.chunk, b"coalesced");
+    assert!(!event.truncated);
+
+    let result = handle.wait(Duration::from_secs(5)).await.unwrap();
+    assert_eq!(result.termination, ExecTermination::Exited { exit_code: 0 });
     assert!(!result.stream_overflowed);
     assert!(rx.recv().await.is_none());
 }

--- a/crates/vsock-host/src/tests/exec_operation/stream.rs
+++ b/crates/vsock-host/src/tests/exec_operation/stream.rs
@@ -5,7 +5,7 @@ use std::time::Duration;
 use tokio::io::AsyncWriteExt;
 use vsock_proto::{
     ExecCapturedOutput, ExecOutputPolicy, ExecOutputStream, ExecTermination, MSG_EXEC_OUTPUT,
-    MSG_EXEC_RESULT, MSG_EXEC_START,
+    MSG_EXEC_RESULT, MSG_EXEC_START, MSG_OPERATIONS_QUIESCED, MSG_QUIESCE_OPERATIONS,
 };
 
 use super::super::support::{
@@ -443,6 +443,66 @@ async fn exec_operation_stream_handles_output_and_result_from_one_write() {
     assert_eq!(event.chunk, b"coalesced");
     assert!(!event.truncated);
 
+    let result = handle.wait(Duration::from_secs(5)).await.unwrap();
+    assert_eq!(result.termination, ExecTermination::Exited { exit_code: 0 });
+    assert!(!result.stream_overflowed);
+    assert!(rx.recv().await.is_none());
+}
+
+#[tokio::test]
+async fn exec_operation_stream_handles_output_and_pending_response_from_one_write() {
+    let (host, mut guest) = setup_host_and_guest().await;
+    let host = Arc::new(host);
+    let mut handle = host
+        .exec_operation_stream(ExecStreamRequest {
+            timeout_ms: 5000,
+            command: "stream",
+            env: &[],
+            sudo: false,
+            label: "stream-with-pending-response",
+            stdout: ExecOutputPolicy::Stream {
+                limit_bytes: 1024,
+                chunk_limit_bytes: 16,
+            },
+            stderr: ExecOutputPolicy::Discard,
+            expected_exit_codes: &[],
+            stdin_bytes: None,
+            stream_queue_capacity: None,
+        })
+        .await
+        .unwrap();
+    let mut rx = handle.take_stream_receiver().unwrap();
+
+    let start_msg = read_guest_message(&mut guest).await;
+    assert_eq!(start_msg.msg_type, MSG_EXEC_START);
+    let quiesce_task = {
+        let host = Arc::clone(&host);
+        tokio::spawn(async move { host.quiesce_operations(Duration::from_secs(5)).await })
+    };
+    let quiesce_msg = read_guest_message(&mut guest).await;
+    assert_eq!(quiesce_msg.msg_type, MSG_QUIESCE_OPERATIONS);
+
+    let output_payload =
+        vsock_proto::encode_exec_output(ExecOutputStream::Stdout, 0, b"pending", false).unwrap();
+    let mut frames = vsock_proto::encode(MSG_EXEC_OUTPUT, start_msg.seq, &output_payload).unwrap();
+    frames.extend_from_slice(
+        &vsock_proto::encode(MSG_OPERATIONS_QUIESCED, quiesce_msg.seq, &[]).unwrap(),
+    );
+    guest.write_all(&frames).await.unwrap();
+
+    let event = rx.recv().await.unwrap();
+    assert_eq!(event.stream, ExecOutputStream::Stdout);
+    assert_eq!(event.output_seq, 0);
+    assert_eq!(event.chunk, b"pending");
+    assert!(!event.truncated);
+    quiesce_task.await.unwrap().unwrap();
+
+    send_discarded_exec_result(
+        &mut guest,
+        start_msg.seq,
+        ExecTermination::Exited { exit_code: 0 },
+    )
+    .await;
     let result = handle.wait(Duration::from_secs(5)).await.unwrap();
     assert_eq!(result.termination, ExecTermination::Exited { exit_code: 0 });
     assert!(!result.stream_overflowed);

--- a/crates/vsock-proto/src/frame.rs
+++ b/crates/vsock-proto/src/frame.rs
@@ -437,4 +437,45 @@ mod tests {
         assert_eq!(visited[0].msg_type, MSG_PONG);
         assert_eq!(visited[0].payload, b"second");
     }
+
+    #[test]
+    fn decode_with_preserves_later_frames_after_mid_batch_visitor_error() {
+        #[derive(Debug, Clone, PartialEq, Eq)]
+        enum VisitorError {
+            Stop,
+        }
+
+        let mut data = encode(MSG_PING, 1, b"first").unwrap();
+        data.extend_from_slice(&encode(MSG_PONG, 2, b"second").unwrap());
+        data.extend_from_slice(&encode(MSG_READY, 3, b"third").unwrap());
+        let mut dec = Decoder::new();
+        let mut visited = Vec::new();
+
+        let err = dec
+            .decode_with(&data, |msg| {
+                visited.push((msg.msg_type, msg.seq, msg.payload.to_vec()));
+                if msg.seq == 2 {
+                    Err(VisitorError::Stop)
+                } else {
+                    Ok(())
+                }
+            })
+            .unwrap_err();
+        assert!(matches!(err, DecodeWithError::Visitor(VisitorError::Stop)));
+        assert_eq!(
+            visited,
+            vec![
+                (MSG_PING, 1, b"first".to_vec()),
+                (MSG_PONG, 2, b"second".to_vec()),
+            ]
+        );
+
+        visited.clear();
+        dec.decode_with(&[], |msg| {
+            visited.push((msg.msg_type, msg.seq, msg.payload.to_vec()));
+            Ok::<(), Infallible>(())
+        })
+        .unwrap();
+        assert_eq!(visited, vec![(MSG_READY, 3, b"third".to_vec())]);
+    }
 }

--- a/crates/vsock-proto/src/frame.rs
+++ b/crates/vsock-proto/src/frame.rs
@@ -308,6 +308,35 @@ mod tests {
     }
 
     #[test]
+    fn decode_with_preserves_partial_frame_after_complete_frame() {
+        let first = encode(MSG_PING, 1, b"first").unwrap();
+        let second = encode(MSG_PONG, 2, b"second").unwrap();
+        let mut data = first;
+        data.extend_from_slice(&second[..7]);
+        let mut dec = Decoder::new();
+        let mut visited = Vec::new();
+
+        dec.decode_with(&data, |msg| {
+            visited.push(msg.to_owned_message());
+            Ok::<(), Infallible>(())
+        })
+        .unwrap();
+        assert_eq!(visited.len(), 1);
+        assert_eq!(visited[0].msg_type, MSG_PING);
+        assert_eq!(visited[0].payload, b"first");
+
+        dec.decode_with(&second[7..], |msg| {
+            visited.push(msg.to_owned_message());
+            Ok::<(), Infallible>(())
+        })
+        .unwrap();
+        assert_eq!(visited.len(), 2);
+        assert_eq!(visited[1].msg_type, MSG_PONG);
+        assert_eq!(visited[1].seq, 2);
+        assert_eq!(visited[1].payload, b"second");
+    }
+
+    #[test]
     fn decode_with_handles_multiple_messages() {
         let mut data = encode(MSG_PING, 1, b"a").unwrap();
         data.extend_from_slice(&encode(MSG_PONG, 2, b"b").unwrap());

--- a/crates/vsock-proto/src/frame.rs
+++ b/crates/vsock-proto/src/frame.rs
@@ -102,21 +102,11 @@ impl Decoder {
         data: &[u8],
         mut visitor: impl FnMut(BorrowedRawMessage<'_>) -> Result<(), E>,
     ) -> Result<(), DecodeWithError<E>> {
-        #[derive(Clone, Copy)]
-        struct CompleteFrame {
-            msg_type: u8,
-            seq: u32,
-            payload_start: usize,
-            payload_end: usize,
-            next_offset: usize,
-        }
-
         self.buf.extend_from_slice(data);
-        let mut offset = 0;
-        let mut frames = Vec::new();
+        let mut verified_offset = 0;
 
-        while offset + HEADER_SIZE <= self.buf.len() {
-            let length = match read_u32_at(&self.buf, offset) {
+        while verified_offset + HEADER_SIZE <= self.buf.len() {
+            let length = match read_u32_at(&self.buf, verified_offset) {
                 Some(v) => v as usize,
                 None => break,
             };
@@ -135,10 +125,21 @@ impl Decoder {
             }
 
             let total = HEADER_SIZE + length;
-            if offset + total > self.buf.len() {
+            if verified_offset + total > self.buf.len() {
                 break;
             }
 
+            verified_offset += total;
+        }
+
+        let mut offset = 0;
+        while offset < verified_offset {
+            let length = match read_u32_at(&self.buf, offset) {
+                Some(v) => v as usize,
+                None => break,
+            };
+            let total = HEADER_SIZE + length;
+            let next_offset = offset + total;
             let msg_type = match read_u8_at(&self.buf, offset + HEADER_SIZE) {
                 Some(v) => v,
                 None => break,
@@ -147,38 +148,23 @@ impl Decoder {
                 Some(v) => v,
                 None => break,
             };
-            let next_offset = offset + total;
             let payload_start = offset + HEADER_SIZE + MIN_BODY_SIZE;
-            let payload_end = next_offset;
-            frames.push(CompleteFrame {
+            let payload = self.buf.get(payload_start..next_offset).unwrap_or_default();
+            let result = visitor(BorrowedRawMessage {
                 msg_type,
                 seq,
-                payload_start,
-                payload_end,
-                next_offset,
-            });
-            offset = next_offset;
-        }
-
-        for frame in frames {
-            let payload = self
-                .buf
-                .get(frame.payload_start..frame.payload_end)
-                .unwrap_or_default();
-            let result = visitor(BorrowedRawMessage {
-                msg_type: frame.msg_type,
-                seq: frame.seq,
                 payload,
             });
             if let Err(error) = result {
-                self.buf.drain(..frame.next_offset);
+                self.buf.drain(..next_offset);
                 return Err(DecodeWithError::Visitor(error));
             }
+            offset = next_offset;
         }
 
         // Compact: remove consumed bytes once at the end
-        if offset > 0 {
-            self.buf.drain(..offset);
+        if verified_offset > 0 {
+            self.buf.drain(..verified_offset);
         }
 
         Ok(())

--- a/crates/vsock-proto/src/frame.rs
+++ b/crates/vsock-proto/src/frame.rs
@@ -1,6 +1,7 @@
 use crate::error::ProtocolError;
 use crate::read::{read_u8_at, read_u32_at};
 use crate::wire::{HEADER_SIZE, MAX_MESSAGE_SIZE, MIN_BODY_SIZE};
+use std::convert::Infallible;
 
 /// A raw decoded message.
 #[derive(Debug, Clone)]
@@ -8,6 +9,40 @@ pub struct RawMessage {
     pub msg_type: u8,
     pub seq: u32,
     pub payload: Vec<u8>,
+}
+
+impl RawMessage {
+    pub fn as_borrowed(&self) -> BorrowedRawMessage<'_> {
+        BorrowedRawMessage {
+            msg_type: self.msg_type,
+            seq: self.seq,
+            payload: &self.payload,
+        }
+    }
+}
+
+/// A raw decoded message that borrows its payload from a decoder buffer.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct BorrowedRawMessage<'a> {
+    pub msg_type: u8,
+    pub seq: u32,
+    pub payload: &'a [u8],
+}
+
+impl BorrowedRawMessage<'_> {
+    pub fn to_owned_message(self) -> RawMessage {
+        RawMessage {
+            msg_type: self.msg_type,
+            seq: self.seq,
+            payload: self.payload.to_vec(),
+        }
+    }
+}
+
+#[derive(Debug, Clone)]
+pub enum DecodeWithError<E> {
+    Protocol(ProtocolError),
+    Visitor(E),
 }
 
 /// Encode a raw message: `[4-byte length][1-byte type][4-byte seq][payload]`.
@@ -38,9 +73,37 @@ impl Decoder {
 
     /// Feed data and extract complete messages.
     pub fn decode(&mut self, data: &[u8]) -> Result<Vec<RawMessage>, ProtocolError> {
-        self.buf.extend_from_slice(data);
         let mut messages = Vec::new();
+        let result = self.decode_with(data, |msg| {
+            messages.push(msg.to_owned_message());
+            Ok::<(), Infallible>(())
+        });
+
+        match result {
+            Ok(()) => Ok(messages),
+            Err(DecodeWithError::Protocol(error)) => Err(error),
+            Err(DecodeWithError::Visitor(error)) => match error {},
+        }
+    }
+
+    /// Feed data and visit complete messages while they still borrow the decoder buffer.
+    pub fn decode_with<E>(
+        &mut self,
+        data: &[u8],
+        mut visitor: impl FnMut(BorrowedRawMessage<'_>) -> Result<(), E>,
+    ) -> Result<(), DecodeWithError<E>> {
+        #[derive(Clone, Copy)]
+        struct CompleteFrame {
+            msg_type: u8,
+            seq: u32,
+            payload_start: usize,
+            payload_end: usize,
+            next_offset: usize,
+        }
+
+        self.buf.extend_from_slice(data);
         let mut offset = 0;
+        let mut frames = Vec::new();
 
         while offset + HEADER_SIZE <= self.buf.len() {
             let length = match read_u32_at(&self.buf, offset) {
@@ -50,11 +113,15 @@ impl Decoder {
 
             if length > MAX_MESSAGE_SIZE {
                 self.buf.clear();
-                return Err(ProtocolError::MessageTooLarge(length));
+                return Err(DecodeWithError::Protocol(ProtocolError::MessageTooLarge(
+                    length,
+                )));
             }
             if length < MIN_BODY_SIZE {
                 self.buf.clear();
-                return Err(ProtocolError::MessageTooSmall(length));
+                return Err(DecodeWithError::Protocol(ProtocolError::MessageTooSmall(
+                    length,
+                )));
             }
 
             let total = HEADER_SIZE + length;
@@ -70,18 +137,33 @@ impl Decoder {
                 Some(v) => v,
                 None => break,
             };
-            let payload = self
-                .buf
-                .get(offset + HEADER_SIZE + MIN_BODY_SIZE..offset + total)
-                .unwrap_or_default()
-                .to_vec();
-
-            messages.push(RawMessage {
+            let next_offset = offset + total;
+            let payload_start = offset + HEADER_SIZE + MIN_BODY_SIZE;
+            let payload_end = next_offset;
+            frames.push(CompleteFrame {
                 msg_type,
                 seq,
+                payload_start,
+                payload_end,
+                next_offset,
+            });
+            offset = next_offset;
+        }
+
+        for frame in frames {
+            let payload = self
+                .buf
+                .get(frame.payload_start..frame.payload_end)
+                .unwrap_or_default();
+            let result = visitor(BorrowedRawMessage {
+                msg_type: frame.msg_type,
+                seq: frame.seq,
                 payload,
             });
-            offset += total;
+            if let Err(error) = result {
+                self.buf.drain(..frame.next_offset);
+                return Err(DecodeWithError::Visitor(error));
+            }
         }
 
         // Compact: remove consumed bytes once at the end
@@ -89,7 +171,7 @@ impl Decoder {
             self.buf.drain(..offset);
         }
 
-        Ok(messages)
+        Ok(())
     }
 }
 
@@ -188,5 +270,146 @@ mod tests {
                 assert_eq!(msgs[0].msg_type, MSG_PING);
             }
         }
+    }
+
+    #[test]
+    fn decode_with_visits_borrowed_message() {
+        let data = encode(MSG_PING, 42, b"hello world").unwrap();
+        let mut dec = Decoder::new();
+        let mut visited = Vec::new();
+
+        dec.decode_with(&data, |msg| {
+            visited.push((msg.msg_type, msg.seq, msg.payload.to_vec()));
+            Ok::<(), Infallible>(())
+        })
+        .unwrap();
+
+        assert_eq!(visited, vec![(MSG_PING, 42, b"hello world".to_vec())]);
+    }
+
+    #[test]
+    fn decode_with_handles_partial_reads() {
+        let data = encode(MSG_PONG, 7, b"later").unwrap();
+        let mut dec = Decoder::new();
+        let mut visited = Vec::new();
+
+        dec.decode_with(&data[..4], |msg| {
+            visited.push(msg.to_owned_message());
+            Ok::<(), Infallible>(())
+        })
+        .unwrap();
+        assert!(visited.is_empty());
+
+        dec.decode_with(&data[4..], |msg| {
+            visited.push(msg.to_owned_message());
+            Ok::<(), Infallible>(())
+        })
+        .unwrap();
+        assert_eq!(visited.len(), 1);
+        assert_eq!(visited[0].msg_type, MSG_PONG);
+        assert_eq!(visited[0].seq, 7);
+        assert_eq!(visited[0].payload, b"later");
+    }
+
+    #[test]
+    fn decode_with_handles_multiple_messages() {
+        let mut data = encode(MSG_PING, 1, b"a").unwrap();
+        data.extend_from_slice(&encode(MSG_PONG, 2, b"b").unwrap());
+        data.extend_from_slice(&encode(MSG_READY, 3, b"c").unwrap());
+        let mut dec = Decoder::new();
+        let mut visited = Vec::new();
+
+        dec.decode_with(&data, |msg| {
+            visited.push((msg.msg_type, msg.seq, msg.payload.to_vec()));
+            Ok::<(), Infallible>(())
+        })
+        .unwrap();
+
+        assert_eq!(
+            visited,
+            vec![
+                (MSG_PING, 1, b"a".to_vec()),
+                (MSG_PONG, 2, b"b".to_vec()),
+                (MSG_READY, 3, b"c".to_vec()),
+            ]
+        );
+    }
+
+    #[test]
+    fn decode_with_preserves_protocol_errors() {
+        let mut dec = Decoder::new();
+        let err = dec
+            .decode_with::<()>(&(17 * 1024 * 1024_u32).to_be_bytes(), |_| {
+                panic!("visitor should not run for oversized frame")
+            })
+            .unwrap_err();
+        assert!(matches!(
+            err,
+            DecodeWithError::Protocol(ProtocolError::MessageTooLarge(_))
+        ));
+
+        let err = dec
+            .decode_with::<()>(&2_u32.to_be_bytes(), |_| {
+                panic!("visitor should not run for too-small frame")
+            })
+            .unwrap_err();
+        assert!(matches!(
+            err,
+            DecodeWithError::Protocol(ProtocolError::MessageTooSmall(2))
+        ));
+    }
+
+    #[test]
+    fn decode_with_rejects_protocol_error_before_visiting_prior_frames() {
+        let mut data = encode(MSG_PING, 1, b"valid").unwrap();
+        data.extend_from_slice(&(17 * 1024 * 1024_u32).to_be_bytes());
+        let mut dec = Decoder::new();
+        let mut visited = false;
+
+        let err = dec
+            .decode_with(&data, |_msg| {
+                visited = true;
+                Ok::<(), Infallible>(())
+            })
+            .unwrap_err();
+
+        assert!(matches!(
+            err,
+            DecodeWithError::Protocol(ProtocolError::MessageTooLarge(_))
+        ));
+        assert!(!visited);
+
+        dec.decode_with(&[], |_msg| {
+            visited = true;
+            Ok::<(), Infallible>(())
+        })
+        .unwrap();
+        assert!(!visited);
+    }
+
+    #[test]
+    fn decode_with_propagates_visitor_error() {
+        #[derive(Debug, Clone, PartialEq, Eq)]
+        enum VisitorError {
+            Stop,
+        }
+
+        let mut data = encode(MSG_PING, 1, b"first").unwrap();
+        data.extend_from_slice(&encode(MSG_PONG, 2, b"second").unwrap());
+        let mut dec = Decoder::new();
+        let err = dec
+            .decode_with(&data, |_msg| Err(VisitorError::Stop))
+            .unwrap_err();
+        assert!(matches!(err, DecodeWithError::Visitor(VisitorError::Stop)));
+
+        let mut visited = Vec::new();
+        dec.decode_with(&[], |msg| {
+            visited.push(msg.to_owned_message());
+            Ok::<(), Infallible>(())
+        })
+        .unwrap();
+        assert_eq!(visited.len(), 1);
+        assert_eq!(visited[0].msg_type, MSG_PONG);
+        assert_eq!(visited[0].payload, b"second");
     }
 }

--- a/crates/vsock-proto/src/frame.rs
+++ b/crates/vsock-proto/src/frame.rs
@@ -93,8 +93,8 @@ impl Decoder {
 
     /// Feed data and visit complete messages while they still borrow the decoder buffer.
     ///
-    /// Protocol errors are detected before any complete frame in the same input
-    /// batch is visited, preserving the all-or-error behavior of [`Self::decode`].
+    /// Protocol errors are detected before any complete frame in the current
+    /// buffered data is visited, preserving the all-or-error behavior of [`Self::decode`].
     /// If the visitor returns an error, frames through the rejected frame are
     /// consumed and later complete frames remain buffered.
     pub fn decode_with<E>(

--- a/crates/vsock-proto/src/frame.rs
+++ b/crates/vsock-proto/src/frame.rs
@@ -22,7 +22,7 @@ impl RawMessage {
     }
 }
 
-/// A raw decoded message that borrows its payload from a decoder buffer.
+/// A raw decoded message that borrows its payload.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct BorrowedRawMessage<'a> {
     pub msg_type: u8,

--- a/crates/vsock-proto/src/frame.rs
+++ b/crates/vsock-proto/src/frame.rs
@@ -12,6 +12,7 @@ pub struct RawMessage {
 }
 
 impl RawMessage {
+    /// Borrow this owned message without copying its payload.
     pub fn as_borrowed(&self) -> BorrowedRawMessage<'_> {
         BorrowedRawMessage {
             msg_type: self.msg_type,
@@ -30,6 +31,7 @@ pub struct BorrowedRawMessage<'a> {
 }
 
 impl BorrowedRawMessage<'_> {
+    /// Convert this borrowed message into an owned message by copying its payload.
     pub fn to_owned_message(self) -> RawMessage {
         RawMessage {
             msg_type: self.msg_type,
@@ -39,9 +41,12 @@ impl BorrowedRawMessage<'_> {
     }
 }
 
+/// Error returned by [`Decoder::decode_with`].
 #[derive(Debug, Clone)]
 pub enum DecodeWithError<E> {
+    /// The byte stream contains an invalid frame.
     Protocol(ProtocolError),
+    /// The visitor rejected a complete decoded frame.
     Visitor(E),
 }
 
@@ -87,6 +92,11 @@ impl Decoder {
     }
 
     /// Feed data and visit complete messages while they still borrow the decoder buffer.
+    ///
+    /// Protocol errors are detected before any complete frame in the same input
+    /// batch is visited, preserving the all-or-error behavior of [`Self::decode`].
+    /// If the visitor returns an error, frames through the rejected frame are
+    /// consumed and later complete frames remain buffered.
     pub fn decode_with<E>(
         &mut self,
         data: &[u8],

--- a/crates/vsock-proto/src/frame.rs
+++ b/crates/vsock-proto/src/frame.rs
@@ -385,6 +385,41 @@ mod tests {
     }
 
     #[test]
+    fn decode_with_reports_invalid_length_after_partial_header() {
+        let bad_header = 2_u32.to_be_bytes();
+        let mut dec = Decoder::new();
+        let mut visited = false;
+
+        dec.decode_with(&bad_header[..3], |_msg| {
+            visited = true;
+            Ok::<(), Infallible>(())
+        })
+        .unwrap();
+        assert!(!visited);
+
+        let err = dec
+            .decode_with(&bad_header[3..], |_msg| {
+                visited = true;
+                Ok::<(), Infallible>(())
+            })
+            .unwrap_err();
+        assert!(matches!(
+            err,
+            DecodeWithError::Protocol(ProtocolError::MessageTooSmall(2))
+        ));
+        assert!(!visited);
+
+        let valid = encode(MSG_PING, 9, b"recovered").unwrap();
+        let mut recovered = Vec::new();
+        dec.decode_with(&valid, |msg| {
+            recovered.push((msg.msg_type, msg.seq, msg.payload.to_vec()));
+            Ok::<(), Infallible>(())
+        })
+        .unwrap();
+        assert_eq!(recovered, vec![(MSG_PING, 9, b"recovered".to_vec())]);
+    }
+
+    #[test]
     fn decode_with_rejects_protocol_error_before_visiting_prior_frames() {
         let mut data = encode(MSG_PING, 1, b"valid").unwrap();
         data.extend_from_slice(&(17 * 1024 * 1024_u32).to_be_bytes());

--- a/crates/vsock-proto/src/lib.rs
+++ b/crates/vsock-proto/src/lib.rs
@@ -69,7 +69,7 @@ mod read;
 mod wire;
 
 pub use error::ProtocolError;
-pub use frame::{Decoder, RawMessage, encode};
+pub use frame::{BorrowedRawMessage, DecodeWithError, Decoder, RawMessage, encode};
 pub use payloads::empty::decode_empty_payload;
 pub use payloads::error::{decode_error, encode_error};
 pub use payloads::exec_control::{


### PR DESCRIPTION
## Summary
- add a borrowed vsock frame decode path that preserves existing decode error semantics
- route host reader frames through borrowed dispatch so exec stream frames do not copy payloads
- cover coalesced exec output/result frames arriving in one read

Fixes #16058

## Tests
- cargo fmt -p vsock-proto -p vsock-host
- cargo test -p vsock-proto
- cargo test -p vsock-host
- cargo test -p vsock-guest
- cargo clippy -p vsock-proto -p vsock-host --all-targets -- -D warnings
- git diff --check
- pre-commit: crates cargo-fmt, cargo-clippy, cargo-doc