### PR TITLE
fix(mitm-addon): avoid quadratic sse line scans

### DIFF
--- a/crates/runner/mitm-addon/src/usage/sse.py
+++ b/crates/runner/mitm-addon/src/usage/sse.py
@@ -14,6 +14,8 @@ from typing import Protocol
 
 _CR = ord("\r")
 _LF = ord("\n")
+_CR_BYTE = b"\r"
+_LF_BYTE = b"\n"
 _SPACE = ord(" ")
 _DATA_FIELD_PREFIX = b"data:"
 
@@ -102,6 +104,7 @@ class SseUsageScanner:
         self._state = "line"
         self._discard_event = False
         self._skip_next_lf = False
+        self._line_ending_hint = _LF
         self._capturing_event = False
         self._captured_data_lines = 0
 
@@ -174,7 +177,7 @@ class SseUsageScanner:
         return i
 
     def _consume_data(self, chunk: bytes, i: int) -> int:
-        line_end = _find_next_line_ending(chunk, i)
+        line_end = _find_next_line_ending(chunk, i, self._line_ending_hint)
         if line_end == -1:
             self._handler.on_data(chunk[i:])
             return len(chunk)
@@ -185,7 +188,7 @@ class SseUsageScanner:
         return line_end + 1
 
     def _consume_discard_line(self, chunk: bytes, i: int) -> int:
-        line_end = _find_next_line_ending(chunk, i)
+        line_end = _find_next_line_ending(chunk, i, self._line_ending_hint)
         if line_end == -1:
             return len(chunk)
 
@@ -197,11 +200,13 @@ class SseUsageScanner:
         self._line_buf.clear()
         self._process_control_line(line)
         self._state = "line"
+        self._line_ending_hint = line_ending
         if line_ending == _CR:
             self._skip_next_lf = True
 
     def _finish_data_or_discard_line(self, line_ending: int) -> None:
         self._state = "line"
+        self._line_ending_hint = line_ending
         if line_ending == _CR:
             self._skip_next_lf = True
 
@@ -285,11 +290,15 @@ def _is_line_ending(byte: int) -> bool:
     return byte in (_LF, _CR)
 
 
-def _find_next_line_ending(chunk: bytes, start: int) -> int:
-    next_lf = chunk.find(b"\n", start)
-    next_cr = chunk.find(b"\r", start)
-    if next_lf == -1:
-        return next_cr
-    if next_cr == -1:
-        return next_lf
-    return min(next_lf, next_cr)
+def _find_next_line_ending(chunk: bytes, start: int, preferred: int) -> int:
+    preferred_byte = _LF_BYTE if preferred == _LF else _CR_BYTE
+    other_byte = _CR_BYTE if preferred == _LF else _LF_BYTE
+
+    next_preferred = chunk.find(preferred_byte, start)
+    if next_preferred == -1:
+        return chunk.find(other_byte, start)
+
+    next_other = chunk.find(other_byte, start, next_preferred)
+    if next_other == -1:
+        return next_preferred
+    return next_other

--- a/crates/runner/mitm-addon/tests/test_sse.py
+++ b/crates/runner/mitm-addon/tests/test_sse.py
@@ -37,6 +37,52 @@ class _CaptureHandler:
         self.current = None
 
 
+class _FindTrackingBytes(bytes):
+    find_calls: list[tuple[bytes, int, int | None]]
+
+    def __new__(cls, value: bytes) -> "_FindTrackingBytes":
+        instance = super().__new__(cls, value)
+        instance.find_calls = []
+        return instance
+
+    def find(self, sub: bytes, start: int = 0, end: int | None = None) -> int:
+        self.find_calls.append((sub, start, end))
+        if end is None:
+            return super().find(sub, start)
+        return super().find(sub, start, end)
+
+
+@pytest.mark.parametrize(
+    ("preferred_newline", "other_newline"),
+    [
+        (b"\n", b"\r"),
+        (b"\r", b"\n"),
+    ],
+)
+def test_data_line_search_bounds_other_line_ending_before_preferred_match(
+    preferred_newline: bytes,
+    other_newline: bytes,
+) -> None:
+    handler = _CaptureHandler({"target"})
+    scanner = SseUsageScanner(handler)
+    data_prefix = b"event: target" + preferred_newline + b"data: "
+    chunk = _FindTrackingBytes(
+        data_prefix + b"payload" + preferred_newline + b"data: " + b"x" * 10_000 + other_newline
+    )
+    data_start = len(data_prefix)
+    data_end = data_start + len(b"payload")
+
+    scanner.feed(chunk)
+
+    assert handler.started == ["target"]
+    assert handler.events == []
+    assert handler.discarded == []
+    assert chunk.find_calls[:2] == [
+        (preferred_newline, data_start, None),
+        (other_newline, data_start, data_end),
+    ]
+
+
 def test_streams_target_multi_data_with_newline_injection() -> None:
     handler = _CaptureHandler({"target"})
     scanner = SseUsageScanner(handler)
@@ -172,6 +218,69 @@ def test_supports_sse_line_endings(newline: bytes) -> None:
     scanner.feed(b"event: target" + newline + b"data: payload" + newline + newline)
 
     assert handler.events == [("target", b"payload")]
+
+
+@pytest.mark.parametrize(
+    ("hint_newline", "data_newline", "later_newline"),
+    [
+        (b"\n", b"\r", b"\n"),
+        (b"\r", b"\n", b"\r"),
+    ],
+)
+def test_data_line_uses_earliest_line_ending_when_hint_prefers_later_match(
+    hint_newline: bytes,
+    data_newline: bytes,
+    later_newline: bytes,
+) -> None:
+    handler = _CaptureHandler({"target"})
+    scanner = SseUsageScanner(handler)
+
+    scanner.feed(
+        b"event: target"
+        + hint_newline
+        + b"data: payload"
+        + data_newline
+        + b"ignored"
+        + later_newline
+        + later_newline
+    )
+
+    assert handler.events == [("target", b"payload")]
+    assert handler.discarded == []
+
+
+@pytest.mark.parametrize("newline", [b"\n", b"\r"])
+def test_streams_many_data_lines_in_one_chunk(newline: bytes) -> None:
+    handler = _CaptureHandler({"target"})
+    scanner = SseUsageScanner(handler)
+    payloads = [f"line-{i}".encode() for i in range(1000)]
+
+    scanner.feed(
+        b"event: target"
+        + newline
+        + b"".join(b"data: " + payload + newline for payload in payloads)
+        + newline
+    )
+
+    assert handler.events == [("target", b"\n".join(payloads))]
+    assert handler.discarded == []
+
+
+def test_discards_many_cr_only_data_lines_and_recovers_in_same_chunk() -> None:
+    handler = _CaptureHandler({"target"})
+    scanner = SseUsageScanner(handler)
+
+    scanner.feed(
+        b"event: ignored\r"
+        + (b"data: ignored\r" * 1000)
+        + b"\r"
+        + b"event: target\r"
+        + b"data: ok\r"
+        + b"\r"
+    )
+
+    assert handler.events == [("target", b"ok")]
+    assert handler.discarded == []
 
 
 def test_skips_large_ignored_event_and_recovers_in_same_chunk() -> None:


### PR DESCRIPTION
## Summary

- Add a last-seen line-ending hint to the SSE usage scanner so data/discard line scans prefer the stream's observed line-ending style.
- Bound the secondary CR/LF search to the range before the preferred match, avoiding repeated full-tail scans on line-heavy chunks.
- Add regression coverage for helper semantics, bounded secondary searches, many LF/CR data lines, and CR-only discard recovery.

Closes #16063

## Tests

- `cd crates/runner/mitm-addon && uv run --extra test pytest tests/test_sse.py`
- `cd crates/runner/mitm-addon && uv run --extra test pytest tests/test_anthropic_messages.py tests/test_openai_responses_sse.py tests/test_model_provider_stream_usage.py`
- `cd crates/runner/mitm-addon && uv run --extra dev ruff check .`
- `cd crates/runner/mitm-addon && uv run --extra dev basedpyright`
