### PR TITLE
fix: materialize cached artifact mount roots

### DIFF
--- a/crates/guest-agent/src/artifact/archive.rs
+++ b/crates/guest-agent/src/artifact/archive.rs
@@ -151,15 +151,6 @@ pub(super) enum ArchiveError {
     FinishGzip { source: io::Error },
 }
 
-impl ArchiveError {
-    pub(super) fn is_root_not_found(&self) -> bool {
-        matches!(
-            self,
-            Self::RootOpen { source, .. } if source.kind() == io::ErrorKind::NotFound
-        )
-    }
-}
-
 /// Create a tar.gz archive containing only the listed manifest files.
 ///
 /// This ensures the archive matches the manifest exactly — no symlinks or other

--- a/crates/guest-agent/src/artifact/mod.rs
+++ b/crates/guest-agent/src/artifact/mod.rs
@@ -54,28 +54,15 @@ pub(crate) enum WalkFilesError {
     Execution(String),
     Checkpoint {
         message: String,
-        root_not_found: bool,
         elapsed: std::time::Duration,
     },
 }
 
 impl WalkFilesError {
-    pub(crate) fn is_root_not_found(&self) -> bool {
-        matches!(
-            self,
-            Self::Checkpoint {
-                root_not_found: true,
-                ..
-            }
-        )
-    }
-
     pub(crate) fn into_agent_error(self) -> AgentError {
         match self {
             Self::Execution(message) => AgentError::Execution(message),
-            Self::Checkpoint {
-                message, elapsed, ..
-            } => {
+            Self::Checkpoint { message, elapsed } => {
                 record_sandbox_op("artifact_hash_compute", elapsed, false, Some(&message));
                 log_error!(LOG_TAG, "{message}");
                 AgentError::Checkpoint(message)
@@ -107,11 +94,9 @@ pub(crate) async fn walk_files_for_checkpoint(
     let files = match files_result {
         Ok(files) => files,
         Err(e) => {
-            let root_not_found = e.is_root_not_found();
             let message = format!("Failed to walk artifact files: {e}");
             return Err(WalkFilesError::Checkpoint {
                 message,
-                root_not_found,
                 elapsed: hash_start.elapsed(),
             });
         }

--- a/crates/guest-agent/src/checkpoint.rs
+++ b/crates/guest-agent/src/checkpoint.rs
@@ -15,8 +15,6 @@ use serde_json::json;
 use sha2::{Digest, Sha256};
 use std::io::ErrorKind;
 
-use api_contracts::generated::types::runners::storage::ArtifactEntryMissingRootPolicy;
-
 const LOG_TAG: &str = "sandbox:guest-agent";
 
 #[derive(Clone, Copy)]
@@ -76,11 +74,6 @@ fn build_artifact_snapshot_entry(name: &str, version: &str, mount_path: &str) ->
 struct ArtifactSnapshotPlan<'a> {
     entry: &'a env::ArtifactEnv,
     files: Vec<artifact::FileEntry>,
-}
-
-enum ArtifactSnapshotWork<'a> {
-    Preserve(serde_json::Value),
-    Snapshot(ArtifactSnapshotPlan<'a>),
 }
 
 /// Prepare + upload the session history to S3 via a presigned URL. If the
@@ -186,7 +179,7 @@ async fn snapshot_artifact_entries(
         return Ok(None);
     }
 
-    let mut work = Vec::with_capacity(entries.len());
+    let mut plans = Vec::with_capacity(entries.len());
     for entry in entries {
         log_info!(
             LOG_TAG,
@@ -194,51 +187,14 @@ async fn snapshot_artifact_entries(
             entry.name,
             entry.mount_path
         );
-        let files = match artifact::walk_files_for_checkpoint(&entry.mount_path).await {
-            Ok(files) => files,
-            Err(error)
-                if entry.missing_root_policy
-                    == Some(ArtifactEntryMissingRootPolicy::PreserveParentVersion)
-                    && error.is_root_not_found() =>
-            {
-                let preserve_start = std::time::Instant::now();
-                let message = format!(
-                    "Preserving artifact '{}' parent version {} because mount root is missing at {}",
-                    entry.name, entry.version_id, entry.mount_path
-                );
-                log_warn!(LOG_TAG, "{message}");
-                record_sandbox_op(
-                    "artifact_snapshot_preserved_missing_root",
-                    preserve_start.elapsed(),
-                    true,
-                    Some(&message),
-                );
-                work.push(ArtifactSnapshotWork::Preserve(
-                    build_artifact_snapshot_entry(
-                        &entry.name,
-                        &entry.version_id,
-                        &entry.mount_path,
-                    ),
-                ));
-                continue;
-            }
-            Err(error) => return Err(error.into_agent_error()),
-        };
-        work.push(ArtifactSnapshotWork::Snapshot(ArtifactSnapshotPlan {
-            entry,
-            files,
-        }));
+        let files = artifact::walk_files_for_checkpoint(&entry.mount_path)
+            .await
+            .map_err(|error| error.into_agent_error())?;
+        plans.push(ArtifactSnapshotPlan { entry, files });
     }
 
-    let mut results = Vec::with_capacity(work.len());
-    for item in work {
-        let (entry, files) = match item {
-            ArtifactSnapshotWork::Preserve(entry) => {
-                results.push(entry);
-                continue;
-            }
-            ArtifactSnapshotWork::Snapshot(ArtifactSnapshotPlan { entry, files }) => (entry, files),
-        };
+    let mut results = Vec::with_capacity(plans.len());
+    for ArtifactSnapshotPlan { entry, files } in plans {
         // Skip the VAS round-trips when the mount is byte-identical to what
         // was originally mounted. `version_id` in VAS *is* the content hash
         // (same SHA-256 the web producer emits), so an equality check on the
@@ -528,6 +484,7 @@ fn validate_recoverable_session_history(session_history: &str) -> Result<(), Str
 #[cfg(test)]
 mod tests {
     use super::*;
+    use api_contracts::generated::types::runners::storage::ArtifactEntryMissingRootPolicy;
     use httpmock::prelude::*;
     use std::time::Duration;
 
@@ -701,7 +658,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn artifact_snapshot_preserves_parent_version_for_policy_missing_root() {
+    async fn artifact_snapshot_preserve_policy_missing_mount_still_fails() {
         let server = MockServer::start();
         let prepare = server.mock(|when, then| {
             when.method(POST)
@@ -725,15 +682,13 @@ mod tests {
             missing_root_policy: Some(ArtifactEntryMissingRootPolicy::PreserveParentVersion),
         }];
 
-        let snapshots = snapshot_artifact_entries(&http, &entries).await.unwrap();
+        let err = snapshot_artifact_entries(&http, &entries)
+            .await
+            .unwrap_err();
 
-        assert_eq!(
-            snapshots,
-            Some(json!([{
-                "name": "memory",
-                "version": "old-memory-version",
-                "mountPath": missing_mount.to_string_lossy(),
-            }]))
+        assert!(
+            err.to_string().contains("Failed to walk artifact files"),
+            "got: {err}"
         );
         prepare.assert_calls(0);
         commit.assert_calls(0);

--- a/crates/guest-download/src/plan.rs
+++ b/crates/guest-download/src/plan.rs
@@ -1,6 +1,7 @@
 use crate::download::DownloadTask;
 use crate::instructions::InstructionNormalization;
 use crate::manifest::{Manifest, ManifestEntry};
+use std::path::Path;
 
 pub(crate) struct RunPlan {
     pub(crate) cleanup_paths: Vec<String>,
@@ -55,6 +56,7 @@ impl RunPlan {
             "storage_download",
             false,
             false,
+            false,
         );
 
         // Artifacts: 404 is non-fatal (may not exist on first run)
@@ -63,6 +65,7 @@ impl RunPlan {
             &manifest.artifacts,
             "artifact",
             "artifact_download",
+            true,
             true,
             true,
         );
@@ -88,9 +91,10 @@ fn append_download_tasks(
     op_name: &'static str,
     allow_404: bool,
     include_missing_root_policy: bool,
+    skip_cached_existing_root: bool,
 ) {
     for (idx, entry) in entries.iter().enumerate() {
-        if is_valid_url(&entry.archive_url)
+        if should_download_entry(entry, skip_cached_existing_root)
             && let Some(url) = entry.archive_url.clone()
         {
             tasks.push(DownloadTask::new(
@@ -108,6 +112,16 @@ fn append_download_tasks(
             ));
         }
     }
+}
+
+fn should_download_entry(entry: &ManifestEntry, skip_cached_existing_root: bool) -> bool {
+    if !is_valid_url(&entry.archive_url) {
+        return false;
+    }
+    if !skip_cached_existing_root || !entry.cached {
+        return true;
+    }
+    !Path::new(&entry.mount_path).is_dir()
 }
 
 fn format_entry_label(
@@ -148,6 +162,7 @@ fn format_entry_label(
 #[cfg(test)]
 mod tests {
     use super::*;
+    use std::fs;
 
     #[test]
     fn is_valid_url_none() {
@@ -270,6 +285,71 @@ mod tests {
         assert_eq!(
             plan.instruction_files[0],
             InstructionNormalization::new("/home/user/.codex".into(), "AGENTS.md".into())
+        );
+    }
+
+    #[test]
+    fn run_plan_skips_cached_artifact_when_mount_root_exists() {
+        let dir = tempfile::tempdir().unwrap();
+        let mount = dir.path().join("workspace");
+        fs::create_dir_all(&mount).unwrap();
+        let mount_path = mount.to_string_lossy().into_owned();
+        let manifest = Manifest {
+            storages: vec![],
+            artifacts: vec![ManifestEntry {
+                mount_path: mount_path.clone(),
+                archive_url: Some("https://s3/artifact.tar.gz".into()),
+                instructions_target_filename: None,
+                cached: true,
+                vas_storage_name: Some("artifact".into()),
+                vas_version_id: Some("artifact-v1".into()),
+                missing_root_policy: None,
+            }],
+            cleanup_paths: vec![],
+        };
+
+        let plan = RunPlan::from_manifest(&manifest);
+
+        assert_eq!(plan.preserved_paths, [mount_path]);
+        assert!(plan.download_tasks.is_empty());
+    }
+
+    #[test]
+    fn run_plan_downloads_cached_artifact_when_mount_root_is_missing() {
+        let dir = tempfile::tempdir().unwrap();
+        let mount_path = dir
+            .path()
+            .join("missing-workspace")
+            .to_string_lossy()
+            .into_owned();
+        let manifest = Manifest {
+            storages: vec![],
+            artifacts: vec![ManifestEntry {
+                mount_path: mount_path.clone(),
+                archive_url: Some("https://s3/artifact.tar.gz".into()),
+                instructions_target_filename: None,
+                cached: true,
+                vas_storage_name: Some("artifact".into()),
+                vas_version_id: Some("artifact-v1".into()),
+                missing_root_policy: None,
+            }],
+            cleanup_paths: vec![],
+        };
+
+        let plan = RunPlan::from_manifest(&manifest);
+
+        assert_eq!(plan.preserved_paths, std::slice::from_ref(&mount_path));
+        assert_eq!(
+            plan.download_tasks,
+            [DownloadTask::new(
+                format!(
+                    "artifact 1 mountPath={mount_path} vasStorageName=artifact vasVersionId=artifact-v1 urlScheme=https cached=true missingRootPolicy=fail"
+                ),
+                "artifact_download",
+                "https://s3/artifact.tar.gz".into(),
+                mount_path,
+                true,
+            )],
         );
     }
 }

--- a/crates/runner/src/executor.rs
+++ b/crates/runner/src/executor.rs
@@ -34,11 +34,9 @@ use tokio::io::{AsyncReadExt, AsyncSeekExt, AsyncWriteExt};
 use tokio_util::sync::CancellationToken;
 use tracing::{info, warn};
 
+use crate::ids::RunId;
 use api_contracts::generated::constants::model_provider_env::placeholders as model_provider_placeholders;
 use api_contracts::generated::constants::runners::paths::CANONICAL_WORKING_DIR;
-use api_contracts::generated::types::runners::storage::ArtifactEntryMissingRootPolicy;
-
-use crate::ids::RunId;
 
 /// Maximum wall-clock time for a single job (2 hours).
 const JOB_TIMEOUT: Duration = Duration::from_secs(7200);
@@ -2194,9 +2192,12 @@ async fn sync_guest_timezone(sandbox: &dyn Sandbox, context: &ExecutionContext) 
     }
 }
 
-/// Filter a storage manifest by nulling `archive_url` for entries whose
-/// version matches the previous turn's fingerprints. `guest-download`
-/// skips entries without a valid URL, so unchanged storages stay on disk.
+/// Filter a storage manifest for VM reuse.
+///
+/// Unchanged storages have `archive_url` nulled so `guest-download` skips them.
+/// Unchanged artifacts keep their archive URL so `guest-download` can repair a
+/// cached artifact whose mount root is missing, while still skipping it when
+/// the root is present.
 fn filter_unchanged_storages(
     manifest: &GuestDownloadManifest,
     prev: &StorageFingerprints,
@@ -2247,11 +2248,8 @@ fn filter_unchanged_storages(
                            prev_ver: Option<&(String, String)>,
                            skipped: &mut usize,
                            cleanup: &mut Vec<String>| {
-        let preserve_missing_root =
-            a.missing_root_policy == Some(ArtifactEntryMissingRootPolicy::PreserveParentVersion);
         let same = prev_ver.is_some_and(|fingerprint| {
-            !preserve_missing_root
-                && !StorageFingerprints::fingerprint_is_tainted(fingerprint)
+            !StorageFingerprints::fingerprint_is_tainted(fingerprint)
                 && fingerprint.0.as_str() == a.vas_storage_name.as_str()
                 && fingerprint.1.as_str() == a.vas_version_id.as_str()
         });
@@ -2261,7 +2259,7 @@ fn filter_unchanged_storages(
             cleanup.push(a.mount_path.clone());
         }
         GuestDownloadArtifactEntry {
-            archive_url: if same { None } else { a.archive_url.clone() },
+            archive_url: a.archive_url.clone(),
             cached: same,
             ..a.clone()
         }
@@ -7847,7 +7845,7 @@ mod tests {
     }
 
     #[test]
-    fn filter_same_artifact_version_nulls_url() {
+    fn filter_same_artifact_version_keeps_url_for_mount_repair() {
         let manifest = GuestDownloadManifest {
             storages: vec![],
             artifacts: vec![guest_art("my-art", "v1", Some("https://s3/v1"))],
@@ -7858,7 +7856,12 @@ mod tests {
             artifacts: art_fp("/workspace", "my-art", "v1"),
         };
         let result = filter_unchanged_storages(&manifest, &prev);
-        assert!(result.artifacts[0].archive_url.is_none());
+        assert_eq!(
+            result.artifacts[0].archive_url.as_deref(),
+            Some("https://s3/v1")
+        );
+        assert!(result.artifacts[0].cached);
+        assert!(!result.cleanup_paths.contains(&"/workspace".to_string()));
     }
 
     #[test]
@@ -7925,7 +7928,7 @@ mod tests {
     }
 
     #[test]
-    fn filter_all_unchanged_nulls_all_urls() {
+    fn filter_all_unchanged_nulls_storage_urls_and_keeps_artifact_urls() {
         let manifest = GuestDownloadManifest {
             storages: vec![guest_storage(
                 "/data",
@@ -7945,7 +7948,10 @@ mod tests {
         let result = filter_unchanged_storages(&manifest, &prev);
         assert!(result.storages[0].archive_url.is_none());
         assert!(result.storages[0].cached);
-        assert!(result.artifacts[0].archive_url.is_none());
+        assert_eq!(
+            result.artifacts[0].archive_url.as_deref(),
+            Some("https://s3/v1")
+        );
         assert!(result.artifacts[0].cached);
     }
 
@@ -7988,8 +7994,11 @@ mod tests {
         assert!(result.artifacts[0].archive_url.is_some());
         assert!(!result.artifacts[0].cached);
         assert!(result.cleanup_paths.contains(&"/workspace".to_string()));
-        // art-b unchanged → URL nulled, cached
-        assert!(result.artifacts[1].archive_url.is_none());
+        // art-b unchanged -> URL retained for missing-root repair, still cached.
+        assert_eq!(
+            result.artifacts[1].archive_url.as_deref(),
+            Some("https://s3/b-v1")
+        );
         assert!(result.artifacts[1].cached);
     }
 
@@ -8129,7 +8138,7 @@ mod tests {
     }
 
     #[test]
-    fn filter_preserve_missing_root_artifact_keeps_url_even_when_version_matches() {
+    fn filter_unchanged_artifact_policy_does_not_force_redownload() {
         let manifest = GuestDownloadManifest {
             storages: vec![],
             artifacts: vec![guest_art_with_policy(
@@ -8151,8 +8160,8 @@ mod tests {
             result.artifacts[0].archive_url.as_deref(),
             Some("https://s3/memory")
         );
-        assert!(!result.artifacts[0].cached);
-        assert!(result.cleanup_paths.contains(&"/workspace".to_string()));
+        assert!(result.artifacts[0].cached);
+        assert!(!result.cleanup_paths.contains(&"/workspace".to_string()));
     }
 
     #[test]

--- a/turbo/apps/api/src/signals/routes/__tests__/agent-runs-create.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/agent-runs-create.test.ts
@@ -1564,7 +1564,7 @@ describe("POST /api/agent/runs", () => {
         return artifact.vasStorageName === "artifact";
       },
     );
-    expect(memoryArtifact?.missingRootPolicy).toBe("preserveParentVersion");
+    expect(memoryArtifact?.missingRootPolicy).toBeUndefined();
     expect(requestedArtifact?.missingRootPolicy).toBeUndefined();
   });
 
@@ -1625,7 +1625,7 @@ describe("POST /api/agent/runs", () => {
     ]);
   });
 
-  it("applies auto memory policy to canonical memory artifacts", async () => {
+  it("does not add missing root policy to canonical memory artifacts", async () => {
     const fx = await fixture();
     const compose = await createCompose({ fixture: fx });
 
@@ -1669,7 +1669,7 @@ describe("POST /api/agent/runs", () => {
     });
     expect(
       executionContext.storageManifest.artifacts[0]?.missingRootPolicy,
-    ).toBe("preserveParentVersion");
+    ).toBeUndefined();
   });
 
   it("keeps user-authored canonical memory mount overrides strict", async () => {
@@ -1737,7 +1737,7 @@ describe("POST /api/agent/runs", () => {
     ]);
   });
 
-  it("keeps auto memory policy for continued canonical memory artifacts", async () => {
+  it("does not add missing root policy for continued canonical memory artifacts", async () => {
     const fx = await fixture();
     const compose = await createCompose({ fixture: fx });
 
@@ -1798,7 +1798,7 @@ describe("POST /api/agent/runs", () => {
           artifact.mountPath === CANONICAL_CLAUDE_MEMORY_MOUNT_PATH
         );
       })?.missingRootPolicy,
-    ).toBe("preserveParentVersion");
+    ).toBeUndefined();
   });
 
   it("includes compose artifacts and volumes in the runner storage manifest", async () => {
@@ -2203,7 +2203,7 @@ describe("POST /api/agent/runs", () => {
           artifact.mountPath === CANONICAL_CLAUDE_MEMORY_MOUNT_PATH
         );
       })?.missingRootPolicy,
-    ).toBe("preserveParentVersion");
+    ).toBeUndefined();
     expect(runContextSnapshot(continued.body.runId)).toMatchObject({
       runId: continued.body.runId,
       userId: fx.userId,
@@ -2479,7 +2479,7 @@ describe("POST /api/agent/runs", () => {
     expect(run?.resumedFromCheckpointId).toBe(checkpoint.id);
   });
 
-  it("applies auto memory policy when resuming legacy checkpoint artifacts", async () => {
+  it("does not add missing root policy when resuming legacy checkpoint artifacts", async () => {
     const fx = await fixture();
     const compose = await createCompose({ fixture: fx });
     const first = await accept(
@@ -2547,10 +2547,10 @@ describe("POST /api/agent/runs", () => {
           artifact.mountPath === CANONICAL_CLAUDE_MEMORY_MOUNT_PATH
         );
       })?.missingRootPolicy,
-    ).toBe("preserveParentVersion");
+    ).toBeUndefined();
   });
 
-  it("applies auto memory policy to canonical memory checkpoint artifacts", async () => {
+  it("does not add missing root policy to canonical memory checkpoint artifacts", async () => {
     const fx = await fixture();
     const compose = await createCompose({ fixture: fx });
     const first = await accept(
@@ -2627,10 +2627,10 @@ describe("POST /api/agent/runs", () => {
           artifact.mountPath === CANONICAL_CLAUDE_MEMORY_MOUNT_PATH
         );
       })?.missingRootPolicy,
-    ).toBe("preserveParentVersion");
+    ).toBeUndefined();
   });
 
-  it("applies auto memory policy to continued canonical memory checkpoint artifacts", async () => {
+  it("does not add missing root policy to continued canonical memory checkpoint artifacts", async () => {
     const fx = await fixture();
     const compose = await createCompose({ fixture: fx });
     const first = await accept(
@@ -2733,6 +2733,6 @@ describe("POST /api/agent/runs", () => {
           artifact.mountPath === CANONICAL_CLAUDE_MEMORY_MOUNT_PATH
         );
       })?.missingRootPolicy,
-    ).toBe("preserveParentVersion");
+    ).toBeUndefined();
   });
 });

--- a/turbo/apps/api/src/signals/services/agent-run-create.service.ts
+++ b/turbo/apps/api/src/signals/services/agent-run-create.service.ts
@@ -3,7 +3,6 @@ import {
   CANONICAL_CODEX_MEMORY_MOUNT_PATH,
   CANONICAL_CLAUDE_MEMORY_MOUNT_PATH,
   DEFAULT_PROFILE,
-  type ArtifactEntry,
   type SecretConnectorMetadata,
   type StorageManifest,
   type StoredExecutionContext,
@@ -189,14 +188,8 @@ interface ContextArtifact {
   readonly generatedBy?: "apiAutoMemory";
 }
 
-interface StorageContextArtifact extends ContextArtifact {
-  readonly missingRootPolicy?: ArtifactEntry["missingRootPolicy"];
-}
-
 interface RunArtifacts {
   readonly artifacts: readonly ContextArtifact[];
-  // Index into `artifacts` for API-managed memory checkpoint policy.
-  readonly autoMemoryPolicyArtifactIndex: number | undefined;
 }
 
 interface ComposeArtifact {
@@ -648,21 +641,6 @@ function withoutSupersededAutoMemoryArtifacts(
   });
 }
 
-function storageArtifactsForRun(
-  artifacts: readonly ContextArtifact[],
-  autoMemoryPolicyArtifactIndex: number | undefined,
-): readonly StorageContextArtifact[] {
-  return artifacts.map((artifact, index) => {
-    if (index === autoMemoryPolicyArtifactIndex) {
-      return {
-        ...artifact,
-        missingRootPolicy: "preserveParentVersion",
-      };
-    }
-    return artifact;
-  });
-}
-
 function resolveComposeArtifactMountPath(artifact: ComposeArtifact): string {
   return expandMountPath(artifact.mount_path);
 }
@@ -707,7 +685,6 @@ function artifactsForRun(args: {
   if (autoMemorySlotArtifactIndex === undefined) {
     return {
       artifacts: [...artifacts, autoMemoryArtifact(args.framework)],
-      autoMemoryPolicyArtifactIndex: artifacts.length,
     };
   }
 
@@ -719,13 +696,11 @@ function artifactsForRun(args: {
         args.framework,
         autoMemorySlotArtifactIndex,
       ),
-      autoMemoryPolicyArtifactIndex: undefined,
     };
   }
 
   return {
     artifacts,
-    autoMemoryPolicyArtifactIndex: autoMemorySlotArtifactIndex,
   };
 }
 
@@ -3238,7 +3213,6 @@ function buildRunnerJobPayload(
     readonly resolved: ResolvedCompose;
     readonly body: CreateRunBody;
     readonly artifacts: readonly ContextArtifact[];
-    readonly autoMemoryPolicyArtifactIndex: number | undefined;
     readonly framework: SupportedFramework;
     readonly modelProvider: ResolvedModelProviderEnvironment | null;
     readonly connectorContext: ConnectorRuntimeContext;
@@ -3286,10 +3260,7 @@ function buildRunnerJobPayload(
           agentOrgId: args.resolved.orgId,
           runtimeOrgId: args.orgId,
           userId: args.userId,
-          artifacts: storageArtifactsForRun(
-            args.artifacts,
-            args.autoMemoryPolicyArtifactIndex,
-          ),
+          artifacts: args.artifacts,
           volumeVersionOverrides: body.volumeVersions,
           additionalVolumes: args.additionalVolumes,
           framework: args.framework,
@@ -3350,7 +3321,6 @@ function dispatchRun(
     readonly resolved: ResolvedCompose;
     readonly body: CreateRunBody;
     readonly artifacts: readonly ContextArtifact[];
-    readonly autoMemoryPolicyArtifactIndex: number | undefined;
     readonly framework: SupportedFramework;
     readonly modelProvider: ResolvedModelProviderEnvironment | null;
     readonly connectorContext: ConnectorRuntimeContext;
@@ -3423,7 +3393,6 @@ function enqueueRunForConcurrency(
     readonly resolved: ResolvedCompose;
     readonly body: CreateRunBody;
     readonly artifacts: readonly ContextArtifact[];
-    readonly autoMemoryPolicyArtifactIndex: number | undefined;
     readonly framework: SupportedFramework;
     readonly modelProvider: ResolvedModelProviderEnvironment | null;
     readonly connectorContext: ConnectorRuntimeContext;
@@ -3532,7 +3501,6 @@ interface PreparedRunContext {
   readonly connectorContext: ConnectorRuntimeContext;
   readonly customConnectorContext: CustomConnectorRuntimeContext;
   readonly artifacts: readonly ContextArtifact[];
-  readonly autoMemoryPolicyArtifactIndex: number | undefined;
   readonly additionalVolumes: readonly AdditionalVolume[] | undefined;
   readonly userTimezone: string | undefined;
   readonly featureSwitchContext: FeatureSwitchContext;
@@ -3854,8 +3822,6 @@ function prepareRunContext(
         connectorContext,
         customConnectorContext,
         artifacts: runArtifacts.artifacts,
-        autoMemoryPolicyArtifactIndex:
-          runArtifacts.autoMemoryPolicyArtifactIndex,
         additionalVolumes,
         userTimezone,
         featureSwitchContext,
@@ -3928,8 +3894,6 @@ function completeQueuedRun(input: {
             resolved: input.context.resolved,
             body: input.context.body,
             artifacts: input.context.artifacts,
-            autoMemoryPolicyArtifactIndex:
-              input.context.autoMemoryPolicyArtifactIndex,
             framework: input.context.framework,
             modelProvider: input.context.modelProvider,
             connectorContext: input.context.connectorContext,
@@ -3975,8 +3939,6 @@ function completePendingRun(input: {
             resolved: input.context.resolved,
             body: input.context.body,
             artifacts: input.context.artifacts,
-            autoMemoryPolicyArtifactIndex:
-              input.context.autoMemoryPolicyArtifactIndex,
             framework: input.context.framework,
             modelProvider: input.context.modelProvider,
             connectorContext: input.context.connectorContext,


### PR DESCRIPTION
## Summary

- stop adding `preserveParentVersion` to API-managed auto-memory artifacts
- keep cached artifact archive metadata in the runner manifest so guest-download can repair missing mount roots
- make guest-download skip cached artifacts only when the mount root already exists
- make guest-agent checkpoint strict again: a missing artifact root fails instead of preserving the parent version

The `missingRootPolicy` wire field remains parseable/serializable for compatibility with older manifests, but new run creation no longer emits it for auto-memory and checkpoint no longer honors it as a missing-root escape hatch.

Closes #16080

## Tests

- `cargo test -p guest-download run_plan_`
- `cargo test -p runner filter_`
- `cargo test -p guest-agent artifact_snapshot_`
- `pnpm -F @vm0/db db:migrate`
- `pnpm -F api exec vitest src/signals/routes/__tests__/agent-runs-create.test.ts --run`
- `cargo fmt --check --package guest-agent --package guest-download --package runner`
- `pnpm -F api check-types`
- pre-commit hook: cargo fmt/doc/clippy, prettier, knip, full `pnpm check-types`