### PR TITLE
docs(mitm-addon): document anthropic json usage extractor

### DIFF
--- a/crates/runner/mitm-addon/src/usage/anthropic_messages.py
+++ b/crates/runner/mitm-addon/src/usage/anthropic_messages.py
@@ -153,9 +153,10 @@ class AnthropicMessagesJsonUsageExtractor:
     """Incrementally extract usage from non-SSE Anthropic Messages JSON chunks.
 
     Callers feed raw response chunks with ``feed()`` and call ``finish()`` once.
-    ``finish()`` returns ``(usage, None)`` when selected usage or metadata was
-    parsed, ``(None, error)`` on JSON parse failure, and ``(None, None)`` when
-    the JSON is valid but contains no reportable usage.
+    ``finish()`` returns ``(usage, None)`` when selected usage quantities or
+    model metadata were parsed, ``(None, error)`` when parsing fails or an
+    extractor bound is exceeded, and ``(None, None)`` when the complete JSON
+    contains no reportable usage or model metadata.
     """
 
     def __init__(self) -> None:

--- a/crates/runner/mitm-addon/src/usage/anthropic_messages.py
+++ b/crates/runner/mitm-addon/src/usage/anthropic_messages.py
@@ -150,7 +150,13 @@ class _AnthropicMessagesSseUsageHandler:
 
 
 class AnthropicMessagesJsonUsageExtractor:
-    """Incrementally extract model usage from non-streaming JSON responses."""
+    """Incrementally extract usage from non-SSE Anthropic Messages JSON chunks.
+
+    Callers feed raw response chunks with ``feed()`` and call ``finish()`` once.
+    ``finish()`` returns ``(usage, None)`` when selected usage or metadata was
+    parsed, ``(None, error)`` on JSON parse failure, and ``(None, None)`` when
+    the JSON is valid but contains no reportable usage.
+    """
 
     def __init__(self) -> None:
         self._extractor = JsonSelectiveExtractor(scalar_fields=_MODEL_JSON_SCALAR_FIELDS)
@@ -176,6 +182,8 @@ class AnthropicMessagesJsonUsageExtractor:
 
 
 def create_anthropic_messages_json_usage_extractor() -> AnthropicMessagesJsonUsageExtractor:
+    """Create an incremental parser for non-SSE Anthropic Messages JSON chunks."""
+
     return AnthropicMessagesJsonUsageExtractor()
 
 

--- a/crates/runner/mitm-addon/src/usage/anthropic_messages.py
+++ b/crates/runner/mitm-addon/src/usage/anthropic_messages.py
@@ -152,9 +152,9 @@ class _AnthropicMessagesSseUsageHandler:
 class AnthropicMessagesJsonUsageExtractor:
     """Incrementally extract usage from non-SSE Anthropic Messages JSON chunks.
 
-    Callers feed raw response chunks with ``feed()`` and call ``finish()`` once.
-    ``finish()`` returns ``(usage, None)`` when selected usage quantities or
-    model metadata were parsed, ``(None, error)`` when parsing fails or an
+    Callers feed decoded response chunks with ``feed()`` and call ``finish()``
+    once. ``finish()`` returns ``(usage, None)`` when selected usage quantities
+    or model metadata were parsed, ``(None, error)`` when parsing fails or an
     extractor bound is exceeded, and ``(None, None)`` when the complete JSON
     contains no reportable usage or model metadata.
     """


### PR DESCRIPTION
## Summary
- document the Anthropic non-SSE JSON usage extractor feed/finish contract
- add a short docstring to the exported Anthropic JSON extractor factory
- keep the change documentation-only with no parser behavior changes

## Tests
- `python3 -m py_compile crates/runner/mitm-addon/src/usage/anthropic_messages.py`
- `PATH="$HOME/.local/bin:$PATH" ruff check crates/runner/mitm-addon/src/usage/anthropic_messages.py`
- `PATH="$HOME/.local/bin:$PATH" ruff format --check crates/runner/mitm-addon/src/usage/anthropic_messages.py`
- pre-commit hooks: `check-file-size`, `block-generated-firewalls`, `ruff-fmt`, `ruff-check`, `commitlint`

Not run:
- `python3 -m pytest crates/runner/mitm-addon/tests/test_body_capture.py::TestExtractAnthropicUsageFromJson` (base Python environment has no `pytest` module; change is docstring-only)

Closes #16065
