### PR TITLE
perf: make firewall deny dedupe linear

### DIFF
--- a/crates/runner/mitm-addon/src/matching.py
+++ b/crates/runner/mitm-addon/src/matching.py
@@ -1508,7 +1508,7 @@ class _FirewallDecisionState:
     best_base_specificity: int | None
     best_rule_specificity: _PathSpecificity | None
     denied_match: _BlockMatch | None
-    denied_permission_names: list[str]
+    denied_permission_names: dict[str, None]
     malformed_config_match: _BlockMatch | None
     malformed_policy_match: _BlockMatch | None
 
@@ -1518,7 +1518,7 @@ class _FirewallDecisionState:
         self.best_base_specificity = None
         self.best_rule_specificity = None
         self.denied_match = None
-        self.denied_permission_names = []
+        self.denied_permission_names = {}
         self.malformed_config_match = None
         self.malformed_policy_match = None
 
@@ -1539,7 +1539,7 @@ class _FirewallDecisionState:
             self.allowed_match = None
             self.base_match = None
             self.denied_match = None
-            self.denied_permission_names = []
+            self.denied_permission_names = {}
             self.malformed_config_match = None
             self.malformed_policy_match = None
         elif api_entry.base.specificity < self.best_base_specificity:
@@ -1568,7 +1568,7 @@ class _FirewallDecisionState:
             self.best_rule_specificity = candidate.specificity
             self.allowed_match = None
             self.denied_match = None
-            self.denied_permission_names = []
+            self.denied_permission_names = {}
         elif candidate.specificity < self.best_rule_specificity:
             return False
 
@@ -1579,8 +1579,7 @@ class _FirewallDecisionState:
             self.allowed_match = match
 
     def record_denied_rule(self, match: _BlockMatch, permission: str) -> None:
-        if permission not in self.denied_permission_names:
-            self.denied_permission_names.append(permission)
+        self.denied_permission_names[permission] = None
         if self.denied_match is None:
             self.denied_match = match
 

--- a/crates/runner/mitm-addon/src/matching.py
+++ b/crates/runner/mitm-addon/src/matching.py
@@ -1508,6 +1508,7 @@ class _FirewallDecisionState:
     best_base_specificity: int | None
     best_rule_specificity: _PathSpecificity | None
     denied_match: _BlockMatch | None
+    # Dict keys act as an ordered set of first-seen denied permission names.
     denied_permission_names: dict[str, None]
     malformed_config_match: _BlockMatch | None
     malformed_policy_match: _BlockMatch | None

--- a/crates/runner/mitm-addon/tests/test_compiled_firewall_precedence.py
+++ b/crates/runner/mitm-addon/tests/test_compiled_firewall_precedence.py
@@ -886,6 +886,48 @@ def test_same_base_specific_deny_blocks_earlier_broad_allow():
     assert result.reason == "permission_denied"
 
 
+def test_same_base_specific_deny_discards_earlier_broad_deny_permissions():
+    fws = wrap_firewalls(
+        [
+            {
+                "base": "https://api.example.com",
+                "auth": {"headers": {"Authorization": "Bearer broad"}},
+                "permissions": [
+                    {"name": "broad", "rules": ["ANY /{path+}"]},
+                ],
+            },
+            {
+                "base": "https://api.example.com",
+                "auth": {"headers": {"Authorization": "Bearer admin"}},
+                "permissions": [
+                    {"name": "admin", "rules": ["GET /admin/delete"]},
+                ],
+            },
+        ],
+        name="example",
+    )
+    policies = {
+        "example": {
+            "allow": [],
+            "deny": ["broad", "admin"],
+            "unknownPolicy": "deny",
+        }
+    }
+
+    result = matching.match_compiled_firewall_request(
+        "https://api.example.com/admin/delete",
+        "GET",
+        compile_firewalls_or_fail(fws),
+        policies,
+    )
+
+    assert isinstance(result, matching.FirewallBlock)
+    assert result.base == "https://api.example.com"
+    assert result.path == "/admin/delete"
+    assert result.permissions == ("admin",)
+    assert result.reason == "permission_denied"
+
+
 # Malformed policy precedence
 
 

--- a/crates/runner/mitm-addon/tests/test_compiled_firewall_precedence.py
+++ b/crates/runner/mitm-addon/tests/test_compiled_firewall_precedence.py
@@ -1229,3 +1229,54 @@ def test_denied_permission_names_keep_encounter_order_and_deduplicate():
     assert isinstance(compiled, matching.FirewallBlock)
     assert compiled.permissions == ("repo-read", "repo-admin")
     assert compiled.reason == "permission_denied"
+
+
+def test_denied_permission_names_deduplicate_many_same_specificity_candidates():
+    matching_rule = "GET /repos/{owner}/{repo}"
+    repeated_rule = "ANY /repos/{owner}/{repo}"
+    generated_permissions = [
+        {"name": f"generated-{index}", "rules": [matching_rule, repeated_rule]}
+        for index in range(12)
+    ]
+    fws = wrap_firewalls(
+        [
+            api_entry(
+                "https://api.github.com",
+                [
+                    {"name": "repo-read", "rules": [matching_rule, repeated_rule]},
+                    *generated_permissions,
+                ],
+            ),
+            api_entry(
+                "https://api.github.com",
+                [
+                    {"name": "repo-write", "rules": [matching_rule]},
+                    {"name": "generated-3", "rules": [repeated_rule]},
+                    {"name": "repo-read", "rules": [repeated_rule]},
+                ],
+            ),
+        ],
+        name="github",
+    )
+    expected_permissions = (
+        "repo-read",
+        *(f"generated-{index}" for index in range(12)),
+        "repo-write",
+    )
+    policies = {
+        "github": {
+            "allow": [],
+            "deny": list(expected_permissions),
+            "unknownPolicy": "deny",
+        }
+    }
+    url = "https://api.github.com/repos/org/repo"
+    compiled = matching.match_compiled_firewall_request(
+        url,
+        "GET",
+        compile_firewalls_or_fail(fws),
+        policies,
+    )
+    assert isinstance(compiled, matching.FirewallBlock)
+    assert compiled.permissions == expected_permissions
+    assert compiled.reason == "permission_denied"


### PR DESCRIPTION
## Summary
- store denied firewall permission names as an ordered dict for O(1) de-duplication
- preserve the existing `FirewallBlock.permissions` tuple order contract
- add compiled matcher regression coverage for many same-specificity denied candidates

## Tests
- `pytest tests/test_compiled_firewall_precedence.py`
- `pytest tests/test_compiled_firewall_precedence.py tests/test_firewall_matching.py`
- `ruff format --check . && ruff check . && basedpyright`
- `pytest`

Closes #16064
