### PR TITLE
fix: tolerate invalid response content length

### DIFF
--- a/crates/runner/mitm-addon/src/mitm_addon.py
+++ b/crates/runner/mitm-addon/src/mitm_addon.py
@@ -642,14 +642,28 @@ def _content_length_response_size(content_length: str | None) -> int:
     if content_length is None:
         return 0
 
-    try:
-        response_size = int(content_length)
-    except ValueError:
-        return 0
+    response_size: int | None = None
+    for value in content_length.split(","):
+        parsed_size = _single_content_length_response_size(value)
+        if parsed_size is None:
+            return 0
+        if response_size is None:
+            response_size = parsed_size
+        elif response_size != parsed_size:
+            return 0
 
-    if response_size < 0:
-        return 0
-    return response_size
+    return response_size if response_size is not None else 0
+
+
+def _single_content_length_response_size(content_length: str) -> int | None:
+    content_length = content_length.strip(" \t")
+    if not content_length.isascii() or not content_length.isdigit():
+        return None
+
+    try:
+        return int(content_length)
+    except ValueError:
+        return None
 
 
 def _release_usage_hook_state(flow: http.HTTPFlow, *, release_tracking: bool) -> None:

--- a/crates/runner/mitm-addon/src/mitm_addon.py
+++ b/crates/runner/mitm-addon/src/mitm_addon.py
@@ -67,6 +67,7 @@ _BROWSER_USER_AGENT_MARKERS = (
 )
 _MODEL_PROVIDER_USAGE_REPORTED = "_model_provider_usage_reported"
 _USAGE_FLOW_TRACKED = "_usage_flow_tracked"
+_MAX_SAFE_NETWORK_LOG_SIZE = 9_007_199_254_740_991
 
 # Runner-triggered usage drain protocol:
 # - Rust writes `usage-flush-request` with the active usageStateId and a fresh
@@ -661,9 +662,13 @@ def _single_content_length_response_size(content_length: str) -> int | None:
         return None
 
     try:
-        return int(content_length)
+        response_size = int(content_length)
     except ValueError:
         return None
+
+    if response_size > _MAX_SAFE_NETWORK_LOG_SIZE:
+        return None
+    return response_size
 
 
 def _release_usage_hook_state(flow: http.HTTPFlow, *, release_tracking: bool) -> None:

--- a/crates/runner/mitm-addon/src/mitm_addon.py
+++ b/crates/runner/mitm-addon/src/mitm_addon.py
@@ -635,7 +635,21 @@ def _response_size(flow: http.HTTPFlow) -> int:
     if streamed_size is not None:
         return streamed_size
 
-    return int(flow.response.headers.get("content-length", 0))
+    return _content_length_response_size(flow.response.headers.get("content-length"))
+
+
+def _content_length_response_size(content_length: str | None) -> int:
+    if content_length is None:
+        return 0
+
+    try:
+        response_size = int(content_length)
+    except ValueError:
+        return 0
+
+    if response_size < 0:
+        return 0
+    return response_size
 
 
 def _release_usage_hook_state(flow: http.HTTPFlow, *, release_tracking: bool) -> None:
@@ -704,7 +718,6 @@ def response(flow: http.HTTPFlow) -> None:
     firewall_action = flow.metadata.get(metadata_keys.FIREWALL_ACTION, "ALLOW")
 
     request_size = len(flow.request.raw_content or b"")
-    response_size = _response_size(flow)
     stream_buf = flow.metadata.get(metadata_keys.STREAM_BUFFER)
     status_code = flow.response.status_code if flow.response else 0
 
@@ -714,6 +727,7 @@ def response(flow: http.HTTPFlow) -> None:
     network_log_path = flow.metadata.get(metadata_keys.VM_NETWORK_LOG_PATH, "")
     proxy_log_path = flow.metadata.get(metadata_keys.VM_PROXY_LOG_PATH, "")
     if network_log_path:
+        response_size = _response_size(flow)
         log_entry = _http_network_log_entry(
             flow,
             action=firewall_action,

--- a/crates/runner/mitm-addon/src/mitm_addon.py
+++ b/crates/runner/mitm-addon/src/mitm_addon.py
@@ -666,11 +666,7 @@ def _single_content_length_response_size(content_length: str) -> int | None:
     if not content_length.isascii() or not content_length.isdigit():
         return None
 
-    try:
-        response_size = int(content_length)
-    except ValueError:
-        return None
-
+    response_size = int(content_length)
     if response_size > _MAX_SAFE_NETWORK_LOG_SIZE:
         return None
     return response_size

--- a/crates/runner/mitm-addon/src/mitm_addon.py
+++ b/crates/runner/mitm-addon/src/mitm_addon.py
@@ -67,7 +67,9 @@ _BROWSER_USER_AGENT_MARKERS = (
 )
 _MODEL_PROVIDER_USAGE_REPORTED = "_model_provider_usage_reported"
 _USAGE_FLOW_TRACKED = "_usage_flow_tracked"
+# Network log size fields are consumed as JavaScript numbers downstream.
 _MAX_SAFE_NETWORK_LOG_SIZE = 9_007_199_254_740_991
+# Bound untrusted log-only header parsing before splitting comma lists.
 _MAX_CONTENT_LENGTH_HEADER_CHARS = 256
 
 # Runner-triggered usage drain protocol:

--- a/crates/runner/mitm-addon/src/mitm_addon.py
+++ b/crates/runner/mitm-addon/src/mitm_addon.py
@@ -68,6 +68,7 @@ _BROWSER_USER_AGENT_MARKERS = (
 _MODEL_PROVIDER_USAGE_REPORTED = "_model_provider_usage_reported"
 _USAGE_FLOW_TRACKED = "_usage_flow_tracked"
 _MAX_SAFE_NETWORK_LOG_SIZE = 9_007_199_254_740_991
+_MAX_CONTENT_LENGTH_HEADER_CHARS = 256
 
 # Runner-triggered usage drain protocol:
 # - Rust writes `usage-flush-request` with the active usageStateId and a fresh
@@ -641,6 +642,8 @@ def _response_size(flow: http.HTTPFlow) -> int:
 
 def _content_length_response_size(content_length: str | None) -> int:
     if content_length is None:
+        return 0
+    if len(content_length) > _MAX_CONTENT_LENGTH_HEADER_CHARS:
         return 0
 
     response_size: int | None = None

--- a/crates/runner/mitm-addon/tests/test_response_handler.py
+++ b/crates/runner/mitm-addon/tests/test_response_handler.py
@@ -255,8 +255,9 @@ class TestResponseHandler:
         entry = json.loads(lines[0])
         assert entry["response_size"] == len(body)
 
+    @pytest.mark.parametrize("content_length", ["50000", " 50000\t"])
     def test_response_size_uses_content_length_without_stream_state(
-        self, tmp_path, real_flow, mitm_ctx
+        self, tmp_path, real_flow, mitm_ctx, content_length
     ):
         """response_size should fall back to Content-Length without stream metadata."""
         flow = real_flow(with_response=False, host="api.example.com")
@@ -267,7 +268,7 @@ class TestResponseHandler:
         flow.metadata["firewall_action"] = "ALLOW"
         flow.metadata["original_url"] = "https://api.example.com/"
         flow.response = tutils.tresp(
-            status_code=200, headers=header_map({"content-length": "50000"})
+            status_code=200, headers=header_map({"content-length": content_length})
         )
 
         with mitm_ctx():
@@ -322,10 +323,15 @@ class TestResponseHandler:
     @pytest.mark.parametrize(
         "content_length",
         [
+            "",
+            " ",
+            "\t",
             "not-an-int",
             "-1",
             "+1",
             "1, 2",
+            "1,",
+            ",1",
             "\u0661\u0662",
             "9007199254740992",
             "1" * 257,

--- a/crates/runner/mitm-addon/tests/test_response_handler.py
+++ b/crates/runner/mitm-addon/tests/test_response_handler.py
@@ -277,6 +277,26 @@ class TestResponseHandler:
         entry = json.loads(lines[0])
         assert entry["response_size"] == 50000
 
+    def test_response_size_accepts_max_safe_content_length(self, tmp_path, real_flow, mitm_ctx):
+        """response_size should accept the largest exactly representable JavaScript integer."""
+        flow = real_flow(with_response=False, host="api.example.com")
+        log_path = str(tmp_path / "network.jsonl")
+
+        flow.metadata["vm_run_id"] = "run-abc-123"
+        flow.metadata["vm_network_log_path"] = log_path
+        flow.metadata["firewall_action"] = "ALLOW"
+        flow.metadata["original_url"] = "https://api.example.com/"
+        flow.response = tutils.tresp(
+            status_code=200, headers=header_map({"content-length": "9007199254740991"})
+        )
+
+        with mitm_ctx():
+            mitm_addon.response(flow)
+
+        lines = Path(log_path).read_text().splitlines()
+        entry = json.loads(lines[0])
+        assert entry["response_size"] == 9007199254740991
+
     def test_response_size_is_zero_without_stream_state_or_content_length(
         self, tmp_path, real_flow, mitm_ctx
     ):

--- a/crates/runner/mitm-addon/tests/test_response_handler.py
+++ b/crates/runner/mitm-addon/tests/test_response_handler.py
@@ -301,7 +301,15 @@ class TestResponseHandler:
 
     @pytest.mark.parametrize(
         "content_length",
-        ["not-an-int", "-1", "+1", "1, 2", "\u0661\u0662", "9007199254740992"],
+        [
+            "not-an-int",
+            "-1",
+            "+1",
+            "1, 2",
+            "\u0661\u0662",
+            "9007199254740992",
+            "1" * 257,
+        ],
     )
     def test_response_size_is_zero_for_invalid_content_length(
         self, tmp_path, real_flow, mitm_ctx, content_length

--- a/crates/runner/mitm-addon/tests/test_response_handler.py
+++ b/crates/runner/mitm-addon/tests/test_response_handler.py
@@ -434,7 +434,7 @@ class TestResponseHandler:
         assert force_refresh_pending(cache_key)
 
     def test_invalid_content_length_without_network_log_does_not_block_401_cache_invalidation(
-        self, real_flow, mitm_ctx, headers
+        self, real_flow, mitm_ctx
     ):
         """Malformed log-only response size metadata must not block 401 auth recovery."""
         flow = real_flow(with_response=False, host="api.github.com")

--- a/crates/runner/mitm-addon/tests/test_response_handler.py
+++ b/crates/runner/mitm-addon/tests/test_response_handler.py
@@ -299,7 +299,7 @@ class TestResponseHandler:
         entry = json.loads(lines[0])
         assert entry["response_size"] == 0
 
-    @pytest.mark.parametrize("content_length", ["not-an-int", "-1"])
+    @pytest.mark.parametrize("content_length", ["not-an-int", "-1", "+1", "1, 2", "١٢"])
     def test_response_size_is_zero_for_invalid_content_length(
         self, tmp_path, real_flow, mitm_ctx, content_length
     ):
@@ -321,6 +321,29 @@ class TestResponseHandler:
         lines = Path(log_path).read_text().splitlines()
         entry = json.loads(lines[0])
         assert entry["response_size"] == 0
+
+    def test_response_size_accepts_matching_repeated_content_length(
+        self, tmp_path, real_flow, mitm_ctx
+    ):
+        """Repeated matching Content-Length values should keep the advertised size."""
+        flow = real_flow(with_response=False, host="api.example.com")
+        log_path = str(tmp_path / "network.jsonl")
+
+        flow.metadata["vm_run_id"] = "run-abc-123"
+        flow.metadata["vm_network_log_path"] = log_path
+        flow.metadata["firewall_action"] = "ALLOW"
+        flow.metadata["original_url"] = "https://api.example.com/"
+        flow.response = tutils.tresp(
+            status_code=200,
+            headers=http.Headers([(b"content-length", b"50000"), (b"content-length", b"50000")]),
+        )
+
+        with mitm_ctx():
+            mitm_addon.response(flow)
+
+        lines = Path(log_path).read_text().splitlines()
+        entry = json.loads(lines[0])
+        assert entry["response_size"] == 50000
 
     def test_response_size_keeps_zero_streamed_bytes(self, tmp_path, real_flow, mitm_ctx):
         """response_size should not treat a streamed byte count of 0 as missing."""

--- a/crates/runner/mitm-addon/tests/test_response_handler.py
+++ b/crates/runner/mitm-addon/tests/test_response_handler.py
@@ -299,7 +299,10 @@ class TestResponseHandler:
         entry = json.loads(lines[0])
         assert entry["response_size"] == 0
 
-    @pytest.mark.parametrize("content_length", ["not-an-int", "-1", "+1", "1, 2", "١٢"])
+    @pytest.mark.parametrize(
+        "content_length",
+        ["not-an-int", "-1", "+1", "1, 2", "١٢", "9007199254740992"],
+    )
     def test_response_size_is_zero_for_invalid_content_length(
         self, tmp_path, real_flow, mitm_ctx, content_length
     ):

--- a/crates/runner/mitm-addon/tests/test_response_handler.py
+++ b/crates/runner/mitm-addon/tests/test_response_handler.py
@@ -301,7 +301,7 @@ class TestResponseHandler:
 
     @pytest.mark.parametrize(
         "content_length",
-        ["not-an-int", "-1", "+1", "1, 2", "١٢", "9007199254740992"],
+        ["not-an-int", "-1", "+1", "1, 2", "\u0661\u0662", "9007199254740992"],
     )
     def test_response_size_is_zero_for_invalid_content_length(
         self, tmp_path, real_flow, mitm_ctx, content_length

--- a/crates/runner/mitm-addon/tests/test_response_handler.py
+++ b/crates/runner/mitm-addon/tests/test_response_handler.py
@@ -299,6 +299,29 @@ class TestResponseHandler:
         entry = json.loads(lines[0])
         assert entry["response_size"] == 0
 
+    @pytest.mark.parametrize("content_length", ["not-an-int", "-1"])
+    def test_response_size_is_zero_for_invalid_content_length(
+        self, tmp_path, real_flow, mitm_ctx, content_length
+    ):
+        """response_size should tolerate invalid Content-Length without stream metadata."""
+        flow = real_flow(with_response=False, host="api.example.com")
+        log_path = str(tmp_path / "network.jsonl")
+
+        flow.metadata["vm_run_id"] = "run-abc-123"
+        flow.metadata["vm_network_log_path"] = log_path
+        flow.metadata["firewall_action"] = "ALLOW"
+        flow.metadata["original_url"] = "https://api.example.com/"
+        flow.response = tutils.tresp(
+            status_code=200, headers=header_map({"content-length": content_length})
+        )
+
+        with mitm_ctx():
+            mitm_addon.response(flow)
+
+        lines = Path(log_path).read_text().splitlines()
+        entry = json.loads(lines[0])
+        assert entry["response_size"] == 0
+
     def test_response_size_keeps_zero_streamed_bytes(self, tmp_path, real_flow, mitm_ctx):
         """response_size should not treat a streamed byte count of 0 as missing."""
         flow = real_flow(with_response=False, host="api.example.com")
@@ -374,6 +397,33 @@ class TestResponseHandler:
         assert cached_headers(cache_key) is None
         # Force-refresh marker must be set so the next /firewall/auth fetch
         # refreshes the token regardless of DB tokenExpiresAt (#9860).
+        assert force_refresh_pending(cache_key)
+
+    def test_invalid_content_length_without_network_log_does_not_block_401_cache_invalidation(
+        self, real_flow, mitm_ctx, headers
+    ):
+        """Malformed log-only response size metadata must not block 401 auth recovery."""
+        flow = real_flow(with_response=False, host="api.github.com")
+        flow.metadata["vm_run_id"] = "run-conn-invalid-length"
+
+        flow.metadata["vm_network_log_path"] = ""
+        flow.metadata["firewall_action"] = "ALLOW"
+        flow.metadata["firewall_base"] = "https://api.github.com"
+        flow.metadata["firewall_api_id"] = "run-conn-invalid-length:0"
+        flow.metadata["original_url"] = "https://api.github.com/repos"
+
+        flow.response = tutils.tresp(
+            status_code=401,
+            headers=header_map({"content-length": "not-an-int"}),
+        )
+
+        cache_key = ("run-conn-invalid-length", "run-conn-invalid-length:0")
+        set_cached_headers(cache_key, headers={"Authorization": "Bearer old-token"})
+
+        with mitm_ctx():
+            mitm_addon.response(flow)
+
+        assert cached_headers(cache_key) is None
         assert force_refresh_pending(cache_key)
 
     def test_401_without_existing_state_marks_force_refresh(self, real_flow, mitm_ctx, headers):

--- a/crates/runner/mitm-addon/tests/test_response_handler.py
+++ b/crates/runner/mitm-addon/tests/test_response_handler.py
@@ -460,6 +460,37 @@ class TestResponseHandler:
         assert cached_headers(cache_key) is None
         assert force_refresh_pending(cache_key)
 
+    def test_invalid_content_length_with_network_log_does_not_block_401_cache_invalidation(
+        self, tmp_path, real_flow, mitm_ctx
+    ):
+        """Malformed network-log response size metadata must not block 401 auth recovery."""
+        flow = real_flow(with_response=False, host="api.github.com")
+        log_path = str(tmp_path / "network.jsonl")
+        flow.metadata["vm_run_id"] = "run-conn-invalid-length-log"
+
+        flow.metadata["vm_network_log_path"] = log_path
+        flow.metadata["firewall_action"] = "ALLOW"
+        flow.metadata["firewall_base"] = "https://api.github.com"
+        flow.metadata["firewall_api_id"] = "run-conn-invalid-length-log:0"
+        flow.metadata["original_url"] = "https://api.github.com/repos"
+
+        flow.response = tutils.tresp(
+            status_code=401,
+            headers=header_map({"content-length": "not-an-int"}),
+        )
+
+        cache_key = ("run-conn-invalid-length-log", "run-conn-invalid-length-log:0")
+        set_cached_headers(cache_key, headers={"Authorization": "Bearer old-token"})
+
+        with mitm_ctx():
+            mitm_addon.response(flow)
+
+        lines = Path(log_path).read_text().splitlines()
+        entry = json.loads(lines[0])
+        assert entry["response_size"] == 0
+        assert cached_headers(cache_key) is None
+        assert force_refresh_pending(cache_key)
+
     def test_401_without_existing_state_marks_force_refresh(self, real_flow, mitm_ctx, headers):
         """401 should request a forced refresh even if no cache entry exists yet."""
         flow = real_flow(with_response=False, host="api.github.com")


### PR DESCRIPTION
## Summary
- parse fallback Content-Length values without raising in mitm-addon response logging
- compute response_size only while writing network logs
- add response hook regression coverage for malformed/negative lengths and 401 auth-cache recovery without network logs

## Tests
- cd crates/runner/mitm-addon && pytest tests/test_response_handler.py
- cd crates/runner/mitm-addon && ruff check src/mitm_addon.py tests/test_response_handler.py
- cd crates/runner/mitm-addon && basedpyright src/mitm_addon.py tests/test_response_handler.py

Closes #16066