### PR TITLE
fix: show updates skeleton on memory page load

### DIFF
--- a/turbo/apps/platform/src/views/memory-page/__tests__/memory-page.test.tsx
+++ b/turbo/apps/platform/src/views/memory-page/__tests__/memory-page.test.tsx
@@ -1,4 +1,5 @@
 import { screen, waitFor } from "@testing-library/react";
+import { zeroMemoryActivityContract } from "@vm0/api-contracts/contracts/zero-memory-activity";
 import { FeatureSwitchKey } from "@vm0/connectors/feature-switch-key";
 import { describe, expect, it } from "vitest";
 
@@ -7,12 +8,15 @@ import {
   detachedSetupPage,
   queryAllByRoleFast,
 } from "../../../__tests__/page-helper.ts";
+import { createMockApi } from "../../../mocks/msw-contract.ts";
 import { setMockMemory } from "../../../mocks/handlers/api-memory.ts";
 import { setMockMemoryActivity } from "../../../mocks/handlers/api-memory-activity.ts";
+import { server } from "../../../mocks/server.ts";
 import { testContext } from "../../../signals/__tests__/test-helpers.ts";
 import { pathname$ } from "../../../signals/route.ts";
 
 const context = testContext();
+const mockApi = createMockApi(context);
 
 async function clickTab(name: string): Promise<void> {
   const tab = await waitFor(() => {
@@ -143,6 +147,25 @@ describe("memory page", () => {
       expect(screen.getByText("new setup")).toBeInTheDocument();
     });
     expect(screen.getByText("old setup")).toBeInTheDocument();
+  });
+
+  it("shows an Updates-shaped skeleton while the default tab is loading", async () => {
+    server.use(
+      mockApi(zeroMemoryActivityContract.get, ({ never }) => {
+        return never();
+      }),
+    );
+
+    detachedSetupPage({
+      context,
+      path: "/memory",
+      featureSwitches: { [FeatureSwitchKey.MemoryViewer]: true },
+    });
+
+    await waitFor(() => {
+      expect(screen.getByTestId("memory-updates-loading")).toBeInTheDocument();
+    });
+    expect(screen.queryByTestId("memory-loading")).not.toBeInTheDocument();
   });
 
   it("falls back to a deterministic summary line when the LLM summary is null", async () => {

--- a/turbo/apps/platform/src/views/memory-page/memory-page.tsx
+++ b/turbo/apps/platform/src/views/memory-page/memory-page.tsx
@@ -234,7 +234,7 @@ function MemoryRawFiles() {
   const hasFiles = detail !== null && detail.exists && detail.files.length > 0;
 
   if (loading) {
-    return <MemorySkeleton />;
+    return <MemoryRawFilesSkeleton />;
   }
   if (hasFiles && detail) {
     return <MemoryViewer detail={detail} />;
@@ -498,7 +498,7 @@ function MemoryUpdates() {
   const activityLoadable = useLoadable(memoryActivity$);
 
   if (activityLoadable.state === "loading") {
-    return <MemorySkeleton />;
+    return <MemoryUpdatesSkeleton />;
   }
   if (activityLoadable.state === "hasError") {
     return <MemoryEmptyState errored />;
@@ -693,7 +693,56 @@ function MemoryEmptyState({ errored }: { readonly errored: boolean }) {
   );
 }
 
-function MemorySkeleton() {
+function MemoryUpdatesSkeleton() {
+  return (
+    <div
+      className="flex min-h-0 flex-1 flex-col gap-4 overflow-auto pb-2"
+      data-testid="memory-updates-loading"
+    >
+      {[0, 1].map((cardIndex) => {
+        return (
+          <section
+            key={cardIndex}
+            className="zero-card flex flex-col overflow-hidden"
+          >
+            <header className="border-b border-border/70 px-4 py-3">
+              <div className="h-4 w-40 rounded bg-muted/50" />
+              <div className="mt-2 h-3 w-full max-w-[560px] rounded bg-muted/50" />
+            </header>
+            <div className="flex flex-col gap-4 px-4 py-3">
+              {[0, 1].map((groupIndex) => {
+                return (
+                  <div key={groupIndex} className="flex flex-col gap-2">
+                    <div className="flex items-center gap-2">
+                      <div className="h-5 w-20 rounded-full bg-muted/50" />
+                      <div className="h-3 w-4 rounded bg-muted/50" />
+                    </div>
+                    <div className="flex flex-col gap-2">
+                      {[0, 1].map((itemIndex) => {
+                        return (
+                          <div
+                            key={itemIndex}
+                            className="rounded-md border border-border/70 bg-background px-3 py-2"
+                          >
+                            <div className="h-4 w-52 max-w-full rounded bg-muted/50" />
+                            <div className="mt-1.5 h-3 w-72 max-w-full rounded bg-muted/50" />
+                            <div className="mt-1.5 h-3 w-36 max-w-full rounded bg-muted/50" />
+                          </div>
+                        );
+                      })}
+                    </div>
+                  </div>
+                );
+              })}
+            </div>
+          </section>
+        );
+      })}
+    </div>
+  );
+}
+
+function MemoryRawFilesSkeleton() {
   return (
     <section className="zero-card flex min-h-[420px] flex-1 flex-col overflow-hidden">
       <div className="flex min-h-0 flex-1 flex-col lg:flex-row">


### PR DESCRIPTION
## Summary

- Split the memory page loading UI into Updates and Raw files skeletons.
- Keep the existing raw-files skeleton for the Raw files tab.
- Add a regression test that holds the default Updates tab in loading state and verifies it does not render the files skeleton.

## Root cause

The page default tab changed to Updates, but both `MemoryUpdates` and `MemoryRawFiles` still reused the same raw-files-shaped `MemorySkeleton`.

## Validation

Run with Node v24.11.0 because Node v25 exposes an experimental empty `localStorage` object that breaks the happy-dom test environment in this checkout.

- `PATH=/Users/lancy/.nvm/versions/node/v24.11.0/bin:$PATH pnpm prettier --write apps/platform/src/views/memory-page/memory-page.tsx apps/platform/src/views/memory-page/__tests__/memory-page.test.tsx`
- `PATH=/Users/lancy/.nvm/versions/node/v24.11.0/bin:$PATH pnpm -F @vm0/app exec vitest run --config vitest.config.ts src/signals/external/__tests__/local-storage.test.ts`
- `PATH=/Users/lancy/.nvm/versions/node/v24.11.0/bin:$PATH pnpm -F @vm0/app exec vitest run --config vitest.config.ts src/views/memory-page/__tests__/memory-page.test.tsx`
- `PATH=/Users/lancy/.nvm/versions/node/v24.11.0/bin:$PATH pnpm -F @vm0/app check-types`
- `PATH=/Users/lancy/.nvm/versions/node/v24.11.0/bin:$PATH pnpm -F @vm0/app lint`