### PR TITLE
fix(web): pass PostHog key to production build

### DIFF
--- a/.github/actions/web-api-env/action.yml
+++ b/.github/actions/web-api-env/action.yml
@@ -254,6 +254,10 @@ runs:
           add_env E2E_TELEGRAM_MOCK_ENABLED "1"
         fi
         add_env PLAUSIBLE_SCRIPT_URL "$plausible_script_url"
+        if [[ "$INPUT_APP" == "web" && "$INPUT_ENVIRONMENT" == "production" ]]; then
+          add_var POSTHOG_KEY POSTHOG_KEY
+          add_var POSTHOG_HOST POSTHOG_HOST
+        fi
         add_secret SENTRY_DSN_WEB SENTRY_DSN_WEB
         if [[ "$INPUT_APP" == "api" ]]; then
           sentry_dsn="$(first_non_empty "$(repo_secret SENTRY_DSN_API)" "$(repo_secret SENTRY_DSN_WEB)" "$(repo_secret SENTRY_DSN)")"

--- a/.github/scripts/tests/web-api-env-action-test.sh
+++ b/.github/scripts/tests/web-api-env-action-test.sh
@@ -90,7 +90,7 @@ oauth_client_config_keys() {
   while IFS= read -r prefix; do
     printf '%s_OAUTH_CLIENT_ID\n' "$prefix"
     printf '%s_OAUTH_CLIENT_SECRET\n' "$prefix"
-  done < <(oauth_client_config_prefixes)
+  done <<< "$(oauth_client_config_prefixes)"
 }
 
 build_doppler_secrets_json() {
@@ -102,13 +102,15 @@ build_doppler_secrets_json() {
       continue
     fi
     json="$(jq -c --arg key "$key" --arg value "doppler-${key}" '. + {($key): $value}' <<< "$json")"
-  done < <(oauth_client_config_keys)
+  done <<< "$(oauth_client_config_keys)"
   printf '%s' "$json"
 }
 
 run_action() {
   local doppler_secrets_json="$1"
   local test_dir="$2"
+  local input_app="${3:-api}"
+  local input_environment="${4:-preview}"
   local action_script="${test_dir}/web-api-env-action.sh"
   local github_output="${test_dir}/github-output"
 
@@ -118,15 +120,15 @@ run_action() {
     RUNNER_TEMP="$test_dir" \
     GITHUB_OUTPUT="$github_output" \
     GITHUB_SHA="test-sha" \
-    INPUT_APP="api" \
-    INPUT_ENVIRONMENT="preview" \
+    INPUT_APP="$input_app" \
+    INPUT_ENVIRONMENT="$input_environment" \
     INPUT_DATABASE_URL="postgres://preview-db" \
     INPUT_JOB_REF="pr-123" \
     INPUT_WEB_URL="https://pr-123-www.vm0.test" \
     INPUT_APP_URL="https://pr-123-app.vm0.test" \
     INPUT_API_URL="https://pr-123-api.vm0.test" \
     INPUT_API_BACKEND_URL="https://pr-123-api-backend.vm0.test" \
-    REPO_VARS_JSON='{"GH_OAUTH_CLIENT_ID":"github-gh-client-id","SLACK_OAUTH_CLIENT_ID":"github-slack-client-id","VM0_API_URL":"https://api.github.test","GOOGLE_ADS_DEVELOPER_TOKEN":"github-google-ads-var","FINICITY_PARTNER_ID":"github-finicity-partner-id"}' \
+    REPO_VARS_JSON='{"GH_OAUTH_CLIENT_ID":"github-gh-client-id","SLACK_OAUTH_CLIENT_ID":"github-slack-client-id","VM0_API_URL":"https://api.github.test","GOOGLE_ADS_DEVELOPER_TOKEN":"github-google-ads-var","FINICITY_PARTNER_ID":"github-finicity-partner-id","POSTHOG_KEY":"github-posthog-key","POSTHOG_HOST":"https://posthog.github.test"}' \
     REPO_SECRETS_JSON='{"GH_OAUTH_CLIENT_SECRET":"github-gh-client-secret","SLACK_OAUTH_CLIENT_SECRET":"github-slack-client-secret","GOOGLE_ADS_DEVELOPER_TOKEN":"github-google-ads-secret","FINICITY_APP_KEY":"github-finicity-app-key","FINICITY_APP_SECRET":"github-finicity-app-secret"}' \
     DOPPLER_SECRETS_JSON="$doppler_secrets_json" \
     bash "$action_script"
@@ -157,6 +159,15 @@ assert_env_absent_value "$success_env_file" "github-gh-client-id"
 assert_env_absent_value "$success_env_file" "github-gh-client-secret"
 assert_env_absent_value "$success_env_file" "github-slack-client-id"
 assert_env_absent_value "$success_env_file" "github-slack-client-secret"
+assert_env_absent_value "$success_env_file" "github-posthog-key"
+
+production_web_dir="$(mktemp -d)"
+TEMP_DIRS+=("$production_web_dir")
+production_web_output="$(run_action "$(build_doppler_secrets_json)" "$production_web_dir" web production)"
+production_web_env_file="$(awk -F= '$1 == "file" { sub(/^[^=]*=/, ""); print }' "${production_web_dir}/github-output")"
+assert_contains "$production_web_output" "Rendered"
+assert_env_value "$production_web_env_file" POSTHOG_KEY "github-posthog-key"
+assert_env_value "$production_web_env_file" POSTHOG_HOST "https://posthog.github.test"
 
 missing_dir="$(mktemp -d)"
 TEMP_DIRS+=("$missing_dir")


### PR DESCRIPTION
## Summary

- pass the repository `POSTHOG_KEY` into the production `web-api-env` file for marketing-site builds
- optionally pass `POSTHOG_HOST` when it exists
- cover the production web env path in the focused action test

## Context

This corrects #16087 for our actual deployment path: the marketing site does not rely on Vercel dashboard environment variables. The production build receives env through GitHub Actions, and `web-api-env` was not rendering `POSTHOG_KEY` for `web` production builds.

## Verification

- `bash .github/scripts/tests/web-api-env-action-test.sh`

Fixes #16087