### PR TITLE
fix: constrain recommended follow-up display length

### DIFF
--- a/turbo/apps/api/src/signals/routes/__tests__/internal-callbacks-chat.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/internal-callbacks-chat.test.ts
@@ -670,6 +670,7 @@ describe("POST /api/internal/callbacks/chat", () => {
       if (
         systemContent.includes("Generate up to three concise follow-up prompts")
       ) {
+        expect(systemContent).toContain("Keep each prompt under 30 characters");
         return JSON.stringify([
           {
             prompt: "Turn this into a checklist",

--- a/turbo/apps/api/src/signals/services/zero-chat-title.service.ts
+++ b/turbo/apps/api/src/signals/services/zero-chat-title.service.ts
@@ -438,7 +438,7 @@ async function generateRecommendedFollowups(
         role: "system",
         content: [
           "Generate up to three concise follow-up prompts the user may ask next in this chat.",
-          "Make them specific to the latest assistant reply, actionable, and useful. Match the user's language.",
+          "Keep each prompt under 30 characters. Make them specific to the latest assistant reply, actionable, and useful. Match the user's language.",
           'Classify each item as kind "talk" for normal discussion, planning, analysis, or refinement, or kind "generate" when the prompt asks VM0 to create one of the supported built-in generation outputs.',
           BUILT_IN_GENERATION_FOLLOWUP_CONTEXT,
           "For generate items, include generationType as one of: image, video, presentation, website.",

--- a/turbo/apps/platform/src/views/zero-page/__tests__/zero-session-chat-page.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/zero-session-chat-page.test.tsx
@@ -175,6 +175,13 @@ describe("recommended follow-ups", () => {
     if (!followupButton) {
       throw new Error("Expected recommended follow-up button");
     }
+    expect(followupButton).toHaveAttribute(
+      "title",
+      "Turn this into a week-by-week checklist",
+    );
+    expect(
+      screen.getByText("Turn this into a week-by-week checklist"),
+    ).toHaveClass("truncate");
     await userEvent.click(followupButton);
 
     await waitFor(() => {

--- a/turbo/apps/platform/src/views/zero-page/zero-chat-thread-page.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-chat-thread-page.tsx
@@ -2923,6 +2923,7 @@ function RecommendedFollowupList({
           <button
             key={followup.prompt}
             type="button"
+            title={followup.prompt}
             className="group flex min-h-10 w-full items-center gap-2 rounded-lg px-2 py-2 text-left transition-colors hover:bg-muted/40"
             onClick={() => {
               handleSelect(followup, followupIndex);
@@ -2931,7 +2932,7 @@ function RecommendedFollowupList({
             <span className="shrink-0 text-muted-foreground/70 transition-colors group-hover:text-foreground">
               <RecommendedFollowupIcon followup={followup} />
             </span>
-            <span className="min-w-0 flex-1 break-words text-xs font-medium leading-5 text-muted-foreground group-hover:text-foreground">
+            <span className="min-w-0 flex-1 truncate text-xs font-medium leading-5 text-muted-foreground group-hover:text-foreground">
               {followup.prompt}
             </span>
             <IconArrowUpRight


### PR DESCRIPTION
## Summary
- ask the follow-up generator to keep each suggestion under 30 characters
- render recommended follow-up labels as a single truncated line while preserving the full prompt in the title
- cover the generation prompt and UI truncation behavior in existing integration tests

## Tests
- pnpm format
- pnpm turbo run lint
- pnpm check-types
- pnpm -F api exec vitest run src/signals/routes/__tests__/internal-callbacks-chat.test.ts
- pnpm -F @vm0/app exec vitest run src/views/zero-page/__tests__/zero-session-chat-page.test.tsx
- pnpm knip
- pnpm vitest (local unrelated failures: desktop native vm0-computer CLI tests require macOS in this Linux container; several API GitHub/storage fixture tests hit pre-existing fixed-ID database duplicates such as storage_versions id 2222222222222222 and github_installations installation_id 987654321)