### PR TITLE
fix: add side padding to Compare plans cards on wide screens

### DIFF
--- a/turbo/apps/platform/src/views/zero-page/components/org-manage/org-billing-tab.tsx
+++ b/turbo/apps/platform/src/views/zero-page/components/org-manage/org-billing-tab.tsx
@@ -323,7 +323,7 @@ function PricingPage({
         </div>
       </div>
 
-      <div className="grid grid-cols-1 sm:grid-cols-2 gap-4 -mx-4 sm:-mx-10">
+      <div className="grid grid-cols-1 sm:grid-cols-2 gap-4">
         {COMPARE_PLANS.map((plan) => {
           return (
             <PlanCard


### PR DESCRIPTION
## Problem

On the **Compare plans** sub-page (Billing → Compare all plans), the settings
sidebar is hidden, so the plan grid used full-bleed negative margins
(`-mx-4 sm:-mx-10`) that cancelled the modal's `px-4 sm:px-10` padding and
pushed the two cards **flush against the modal border** — no left/right gutter.

## Fix

Drop the negative margins. The cards keep filling the full modal width on wide
screens, but now sit inside the content padding with comfortable left/right
gutters that line up with the page header. One-line layout change — no copy,
logic, or test changes.

## Before / After

Desktop (1280px) and mobile (375px):

![desktop before/after](https://compare-plans-responsive-715f6d07-4cb62a33.sites.vm0.io/cmp_desktop.png)
![mobile before/after](https://compare-plans-responsive-715f6d07-4cb62a33.sites.vm0.io/cmp_mobile.png)

Verified across 375 / 700 / 1024 / 1280px via a faithful static reproduction of
the modal (real Tailwind classes + design tokens).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
