### PR TITLE
fix(mitm-addon): bound X includes usage categories

### DIFF
--- a/crates/runner/mitm-addon/src/usage/providers/connectors/x.py
+++ b/crates/runner/mitm-addon/src/usage/providers/connectors/x.py
@@ -5,10 +5,11 @@ through the X firewall and buffers them for aggregate platform upload.
 """
 
 import json
+import re
 import urllib.parse
 import uuid
 from collections.abc import Callable, Iterable
-from typing import TypedDict
+from typing import Literal, NamedTuple, TypedDict
 
 from mitmproxy import http
 
@@ -96,6 +97,11 @@ _REQUEST_QUERY_HINT_VALUE_MAX_BYTES = 16 * 1024
 _REQUEST_ID_LIKE_QUERY_KEYS = frozenset({"ids", "usernames"})
 _REQUEST_MAX_RESULTS_QUERY_KEY = "max_results"
 _ASCII_CODEPOINT_LIMIT = 128
+_MAX_UNKNOWN_INCLUDE_CATEGORIES = 64
+_MAX_USAGE_CATEGORY_CHARS = 100
+_SYNTHETIC_INCLUDE_CATEGORY_PREFIX = "includes."
+_INCLUDES_OVERFLOW_CATEGORY = "includes.__overflow__"
+_SAFE_SYNTHETIC_INCLUDE_KEY_RE = re.compile(r"^[A-Za-z0-9_.-]+$")
 
 _X_JSON_RESULT_COUNT_FIELDS = {
     ("meta", "result_count"): ScalarField("int", max_bytes=64),
@@ -103,8 +109,33 @@ _X_JSON_RESULT_COUNT_FIELDS = {
 }
 
 
+class _IncludeBillingCategory(NamedTuple):
+    category: str
+    kind: Literal["known", "synthetic", "overflow"]
+
+
 def _as_non_bool_int(value: object) -> int | None:
     return value if isinstance(value, int) and not isinstance(value, bool) else None
+
+
+def _synthetic_include_category(key: str) -> str | None:
+    max_key_chars = _MAX_USAGE_CATEGORY_CHARS - len(_SYNTHETIC_INCLUDE_CATEGORY_PREFIX)
+    if not key or len(key) > max_key_chars:
+        return None
+    if _SAFE_SYNTHETIC_INCLUDE_KEY_RE.fullmatch(key) is None:
+        return None
+    return f"{_SYNTHETIC_INCLUDE_CATEGORY_PREFIX}{key}"
+
+
+def _include_billing_category(key: str) -> _IncludeBillingCategory:
+    bucket = classify_includes_bucket(key)
+    if bucket is not None:
+        return _IncludeBillingCategory(bucket, "known")
+
+    category = _synthetic_include_category(key)
+    if category is None:
+        return _IncludeBillingCategory(_INCLUDES_OVERFLOW_CATEGORY, "overflow")
+    return _IncludeBillingCategory(category, "synthetic")
 
 
 def _create_x_json_selective_extractor() -> JsonSelectiveExtractor:
@@ -164,6 +195,8 @@ class _NdjsonState(TypedDict):
     """Number of lines whose top-level ``data`` is a dict (one tweet per line)."""
     includes: dict[str, int]
     """Running sum of ``len(includes.<key>)`` across all lines, per key."""
+    unknown_includes_overflow_count: int
+    """Unknown include quantities routed to the bounded overflow category."""
     lines_parsed: int
     """JSON-parseable non-blank lines."""
     lines_failed: int
@@ -186,7 +219,11 @@ class _NdjsonExtractor:
       dict (one tweet per line).  Lines whose ``data`` is an array or
       absent contribute 0 to this counter but still bump ``lines_parsed``.
     - ``includes``: dict[str, int] — running sum across all lines of
-      ``len(includes.<key>)`` for each expansion resource key.
+      ``len(includes.<key>)`` for known expansion keys and the first bounded
+      set of safe unknown keys.
+    - ``unknown_includes_overflow_count``: int — running sum of unknown
+      include quantities that are unsafe for category emission or exceed the
+      per-stream unknown-category budget.
     - ``lines_parsed``: int — JSON-parseable non-blank lines.
     - ``lines_failed``: int — lines that failed JSON decoding or exceeded
       the single-line safety cap.
@@ -203,9 +240,11 @@ class _NdjsonExtractor:
         self.state: _NdjsonState = {
             "data_count": 0,
             "includes": {},
+            "unknown_includes_overflow_count": 0,
             "lines_parsed": 0,
             "lines_failed": 0,
         }
+        self._unknown_include_keys: set[str] = set()
         self._line_buf = bytearray()
         self._discarding_overlong_line = False
         self._finished = False
@@ -276,7 +315,26 @@ class _NdjsonExtractor:
         if isinstance(inc, dict):
             for k, v in inc.items():
                 if isinstance(v, list):
-                    self.state["includes"][k] = self.state["includes"].get(k, 0) + len(v)
+                    self._record_include_count(k, len(v))
+
+    def _record_include_count(self, key: str, count: int) -> None:
+        if count <= 0:
+            return
+
+        billing_category = _include_billing_category(key)
+        if billing_category.kind == "known":
+            self.state["includes"][key] = self.state["includes"].get(key, 0) + count
+            return
+
+        if billing_category.kind == "synthetic" and (
+            key in self._unknown_include_keys
+            or len(self._unknown_include_keys) < _MAX_UNKNOWN_INCLUDE_CATEGORIES
+        ):
+            self._unknown_include_keys.add(key)
+            self.state["includes"][key] = self.state["includes"].get(key, 0) + count
+            return
+
+        self.state["unknown_includes_overflow_count"] += count
 
 
 class _XJsonResponseExtractor:
@@ -510,6 +568,9 @@ def _parse_response_metadata(flow: http.HTTPFlow) -> dict:
         result["response_data_count"] = ndjson_state["data_count"]
         if ndjson_state["includes"]:
             result["response_includes"] = dict(ndjson_state["includes"])
+        unknown_includes_overflow_count = ndjson_state.get("unknown_includes_overflow_count", 0)
+        if unknown_includes_overflow_count:
+            result["response_unknown_includes_overflow_count"] = unknown_includes_overflow_count
         result["ndjson_lines_parsed"] = ndjson_state["lines_parsed"]
         result["ndjson_lines_failed"] = ndjson_state["lines_failed"]
         return result
@@ -569,10 +630,10 @@ def _compute_billable_counts(
       ``max(ids_count, max_results, 1)``.  When the URL also carries
       no hints we emit no ``usage_event`` row; :func:`report_usage`
       detects that state and writes an error log so ops can audit.
-    - **Includes**: each ``includes.<key>`` is mapped to a billing
-      bucket via :func:`classify_includes_bucket`.  Unknown keys emit
-      a synthetic ``includes.<key>`` category for server-side fallback
-      pricing.  Counts at the same bucket are summed.
+    - **Includes**: each ``includes.<key>`` is normalized to a billing
+      bucket via :func:`classify_includes_bucket`, a bounded safe synthetic
+      ``includes.<key>`` category, or the fixed overflow category used for
+      server-side fallback pricing.  Counts at the same bucket are summed.
     """
     if method != "GET":
         return {endpoint_bucket: 1}
@@ -617,22 +678,53 @@ def _compute_billable_counts(
     if req_meta.get("is_count_endpoint"):
         return counts
 
+    overflow_includes_count = 0
+    synthetic_include_categories: set[str] = set()
     includes = resp_meta.get("response_includes") or {}
     for key, n in includes.items():
         if n <= 0:
             continue
-        bucket = classify_includes_bucket(key)
-        if bucket is None:
+        include_category = _include_billing_category(key)
+        if include_category.kind == "synthetic":
+            if (
+                include_category.category in synthetic_include_categories
+                or len(synthetic_include_categories) < _MAX_UNKNOWN_INCLUDE_CATEGORIES
+            ):
+                synthetic_include_categories.add(include_category.category)
+            else:
+                overflow_includes_count += n
+                continue
             # Emit a synthetic per-key category so the billing processor
             # can apply its server-side fallback price and ops can track
             # each unknown type independently in ``usage_event``.
-            bucket = f"includes.{key}"
             log_warn(
                 "X includes key unrecognised — "
                 "emitting synthetic category for server-side fallback",
-                {"includes_key": key, "includes_count": n, "category": bucket},
+                {
+                    "includes_key": key,
+                    "includes_count": n,
+                    "category": include_category.category,
+                },
             )
-        counts[bucket] = counts.get(bucket, 0) + n
+
+        if include_category.kind == "overflow":
+            overflow_includes_count += n
+            continue
+
+        counts[include_category.category] = counts.get(include_category.category, 0) + n
+
+    overflow_includes_count += resp_meta.get("response_unknown_includes_overflow_count") or 0
+    if overflow_includes_count > 0:
+        counts[_INCLUDES_OVERFLOW_CATEGORY] = (
+            counts.get(_INCLUDES_OVERFLOW_CATEGORY, 0) + overflow_includes_count
+        )
+        log_warn(
+            "X includes overflow — emitting bounded category for server-side fallback",
+            {
+                "includes_count": overflow_includes_count,
+                "category": _INCLUDES_OVERFLOW_CATEGORY,
+            },
+        )
 
     return counts
 

--- a/crates/runner/mitm-addon/src/usage/providers/connectors/x.py
+++ b/crates/runner/mitm-addon/src/usage/providers/connectors/x.py
@@ -124,6 +124,8 @@ def _synthetic_include_category(key: str) -> str | None:
         return None
     if _SAFE_SYNTHETIC_INCLUDE_KEY_RE.fullmatch(key) is None:
         return None
+    if f"{_SYNTHETIC_INCLUDE_CATEGORY_PREFIX}{key}" == _INCLUDES_OVERFLOW_CATEGORY:
+        return None
     return f"{_SYNTHETIC_INCLUDE_CATEGORY_PREFIX}{key}"
 
 

--- a/crates/runner/mitm-addon/src/usage/providers/connectors/x_billing.py
+++ b/crates/runner/mitm-addon/src/usage/providers/connectors/x_billing.py
@@ -33,8 +33,8 @@ Design:
   will cause under- or over-charging until an override is corrected.
 
 - ``_INCLUDES_TO_BUCKET`` maps X v2 ``includes.<key>`` resource types
-  to buckets.  Unknown keys return ``None`` and the caller emits a
-  synthetic ``includes.<key>`` category; the billing processor applies
+  to buckets.  Unknown keys return ``None`` and the caller routes them
+  to a bounded synthetic or overflow category; the billing processor applies
   a server-side fallback price for these.
 
 - Scopes that are not billable (e.g. the ``"app-only"`` group for

--- a/crates/runner/mitm-addon/tests/test_connector_usage.py
+++ b/crates/runner/mitm-addon/tests/test_connector_usage.py
@@ -312,6 +312,7 @@ class TestReportConnectorUsage:
                 "includes": {
                     overlong_key: [{"id": "long"}],
                     "bad/key": [{"id": "unsafe"}, {"id": "unsafe-2"}],
+                    "__overflow__": [{"id": "reserved"}],
                 },
             }
         ).encode()
@@ -320,7 +321,7 @@ class TestReportConnectorUsage:
         payloads = self._call_and_get_billing(flow)
         by_cat = {p["category"]: p["quantity"] for p in payloads}
 
-        assert by_cat == {"posts.read": 1, "includes.__overflow__": 3}
+        assert by_cat == {"posts.read": 1, "includes.__overflow__": 4}
         assert all(len(category) <= 100 for category in by_cat)
 
     def test_empty_search_emits_no_billing(self, tmp_path, real_flow):

--- a/crates/runner/mitm-addon/tests/test_connector_usage.py
+++ b/crates/runner/mitm-addon/tests/test_connector_usage.py
@@ -271,8 +271,8 @@ class TestReportConnectorUsage:
         assert by_cat["posts.read"]["quantity"] == 1
         assert by_cat["user.read"]["quantity"] == 1
 
-    def test_splits_usage_event_batches_at_server_limit(self, tmp_path, real_flow):
-        """Large synthetic category sets are chunked to match the webhook contract."""
+    def test_bounds_unknown_include_categories_before_buffering(self, tmp_path, real_flow):
+        """Unknown includes cannot create unbounded synthetic usage categories."""
         body = json.dumps(
             {
                 "data": [],
@@ -286,17 +286,42 @@ class TestReportConnectorUsage:
             usage.flush_usage_events(trigger="test")
 
         bodies = webhook.json_bodies()
-        assert [len(body["events"]) for body in bodies] == [100, 1]
+        assert [len(body["events"]) for body in bodies] == [65]
         assert {body["runId"] for body in bodies} == {"run-abc-123"}
         assert all(
             event["kind"] == "connector" and event["provider"] == "x"
             for body in bodies
             for event in body["events"]
         )
-        categories = {event["category"] for body in bodies for event in body["events"]}
-        assert len(categories) == 101
-        assert "includes.future_0" in categories
-        assert "includes.future_100" in categories
+        by_cat = {
+            event["category"]: event["quantity"] for body in bodies for event in body["events"]
+        }
+        assert len(by_cat) == 65
+        assert "includes.future_0" in by_cat
+        assert "includes.future_63" in by_cat
+        assert "includes.future_64" not in by_cat
+        assert by_cat["includes.__overflow__"] == 37
+        assert all(len(category) <= 100 for category in by_cat)
+
+    def test_overlong_unknown_include_key_uses_overflow_category(self, tmp_path, real_flow):
+        """Unsafe synthetic categories are folded into the fallback-priced overflow bucket."""
+        overlong_key = "x" * 92
+        body = json.dumps(
+            {
+                "data": [{"id": "1"}],
+                "includes": {
+                    overlong_key: [{"id": "long"}],
+                    "bad/key": [{"id": "unsafe"}, {"id": "unsafe-2"}],
+                },
+            }
+        ).encode()
+        flow = self._make_x_flow(real_flow, tmp_path, query="expansions=future", body=body)
+
+        payloads = self._call_and_get_billing(flow)
+        by_cat = {p["category"]: p["quantity"] for p in payloads}
+
+        assert by_cat == {"posts.read": 1, "includes.__overflow__": 3}
+        assert all(len(category) <= 100 for category in by_cat)
 
     def test_empty_search_emits_no_billing(self, tmp_path, real_flow):
         """Search returning zero results emits no usage_event row."""
@@ -1869,6 +1894,56 @@ class TestReportConnectorUsage:
         payloads = webhook.usage_events()
         by_cat = {payload["category"]: payload["quantity"] for payload in payloads}
         assert by_cat == {"posts.read": 1, "media.read": 1}
+
+    def test_full_streaming_pipeline_bounds_unknown_include_categories(
+        self, tmp_path, real_flow, mitm_ctx, headers, fresh_usage_executor
+    ):
+        """Long-lived streams fold unknown include overflow into one fallback-priced bucket."""
+        flow = real_flow(with_response=False, host="api.x.com", path="/2/tweets/search/stream")
+        flow.metadata["vm_run_id"] = "run-abc-123"
+        flow.metadata["vm_network_log_path"] = str(tmp_path / "network.jsonl")
+        flow.metadata["vm_proxy_log_path"] = str(tmp_path / "proxy.jsonl")
+        flow.metadata["vm_sandbox_token"] = "test-token"
+        flow.metadata["firewall_action"] = "ALLOW"
+        flow.metadata["original_url"] = "https://api.x.com/2/tweets/search/stream"
+        flow.metadata["firewall_name"] = "x"
+        flow.metadata["firewall_billable"] = True
+        flow.metadata["firewall_permission"] = "tweet.read"
+        flow.metadata["firewall_rule_match"] = "GET /2/tweets/search/stream"
+        flow.response = tutils.tresp(status_code=200)
+        flow.response.headers = header_map({"content-type": "application/json"})
+        flow.response.stream = False
+
+        mitm_addon.responseheaders(flow)
+        callback = response_stream(flow)
+        for index in range(70):
+            callback(
+                b'{"data":{"id":"'
+                + str(index).encode()
+                + b'"},"includes":{"future_'
+                + str(index).encode()
+                + b'":[{"id":"u"}]}}\n'
+            )
+        callback(b'{"data":{"id":"known"},"includes":{"users":[{"id":"user"}]}}\n')
+        state = flow.metadata["x_ndjson_state"]
+        assert state["unknown_includes_overflow_count"] == 6
+        assert state["includes"]["users"] == 1
+
+        with self._usage_webhook_api() as webhook:
+            mitm_addon.response(flow)
+            usage.flush_usage_events(trigger="test")
+            usage.webhook.usage_executor.shutdown(wait=True)
+
+        payloads = webhook.usage_events()
+        by_cat = {payload["category"]: payload["quantity"] for payload in payloads}
+        assert by_cat["posts.read"] == 71
+        assert by_cat["user.read"] == 1
+        assert by_cat["includes.future_0"] == 1
+        assert by_cat["includes.future_63"] == 1
+        assert "includes.future_64" not in by_cat
+        assert by_cat["includes.__overflow__"] == 6
+        assert len(by_cat) == 67
+        assert all(len(category) <= 100 for category in by_cat)
 
     def test_response_logs_incremental_x_json_parse_error(
         self, tmp_path, real_flow, mitm_ctx, sync_usage_executor

--- a/crates/runner/mitm-addon/tests/test_response_streaming.py
+++ b/crates/runner/mitm-addon/tests/test_response_streaming.py
@@ -247,11 +247,12 @@ class TestNdjsonExtractor:
         parse(
             b'{"data":{"id":"1"},"includes":{"'
             + overlong_key
-            + b'":[{"id":"long"}],"bad/key":[{"id":"one"},{"id":"two"}]}}\n'
+            + b'":[{"id":"long"}],"bad/key":[{"id":"one"},{"id":"two"}],'
+            b'"__overflow__":[{"id":"reserved"}]}}\n'
         )
 
         assert state["includes"] == {}
-        assert state["unknown_includes_overflow_count"] == 3
+        assert state["unknown_includes_overflow_count"] == 4
         assert state["data_count"] == 1
         assert state["lines_failed"] == 0
 

--- a/crates/runner/mitm-addon/tests/test_response_streaming.py
+++ b/crates/runner/mitm-addon/tests/test_response_streaming.py
@@ -220,6 +220,41 @@ class TestNdjsonExtractor:
         )
         assert state["includes"] == {"users": 1, "tweets": 2, "media": 1}
 
+    def test_unknown_include_keys_are_bounded_and_known_keys_continue(self, real_flow):
+        parse, state = self._stream_parser(real_flow)
+
+        for index in range(70):
+            parse(
+                b'{"data":{"id":"'
+                + str(index).encode()
+                + b'"},"includes":{"future_'
+                + str(index).encode()
+                + b'":[{"id":"u"}]}}\n'
+            )
+        parse(b'{"data":{"id":"known"},"includes":{"users":[{"id":"user"}]}}\n')
+
+        unknown_keys = [key for key in state["includes"] if key.startswith("future_")]
+        assert len(unknown_keys) == 64
+        assert state["unknown_includes_overflow_count"] == 6
+        assert state["includes"]["users"] == 1
+        assert state["data_count"] == 71
+        assert state["lines_failed"] == 0
+
+    def test_unsafe_unknown_include_keys_overflow(self, real_flow):
+        parse, state = self._stream_parser(real_flow)
+        overlong_key = b"x" * 92
+
+        parse(
+            b'{"data":{"id":"1"},"includes":{"'
+            + overlong_key
+            + b'":[{"id":"long"}],"bad/key":[{"id":"one"},{"id":"two"}]}}\n'
+        )
+
+        assert state["includes"] == {}
+        assert state["unknown_includes_overflow_count"] == 3
+        assert state["data_count"] == 1
+        assert state["lines_failed"] == 0
+
     def test_data_array_not_counted(self, real_flow):
         """Line where top-level ``data`` is an array (not a dict) contributes 0 to data_count."""
         parse, state = self._stream_parser(real_flow)


### PR DESCRIPTION
## Summary

- bound X NDJSON unknown include accumulation while keeping known include keys accurate
- normalize unknown include usage categories against the 100-character webhook contract
- route unsafe, overlong, and over-cap unknown includes to `includes.__overflow__` for fallback pricing

Fixes #16068

## Tests

- `python3 -m pytest tests/test_response_streaming.py tests/test_connector_usage.py tests/test_error_handler.py`
- `python3 -m pytest tests/`
- `ruff check .`
- `ruff format --check .`
- `basedpyright -p .`
