### PR TITLE
fix(mitm-addon): guard content length response size fallback

### DIFF
--- a/crates/runner/mitm-addon/src/mitm_addon.py
+++ b/crates/runner/mitm-addon/src/mitm_addon.py
@@ -69,8 +69,7 @@ _MODEL_PROVIDER_USAGE_REPORTED = "_model_provider_usage_reported"
 _USAGE_FLOW_TRACKED = "_usage_flow_tracked"
 # Network log size fields are consumed as JavaScript numbers downstream.
 _MAX_SAFE_NETWORK_LOG_SIZE = 9_007_199_254_740_991
-# Bound untrusted log-only header parsing before splitting comma lists.
-_MAX_CONTENT_LENGTH_HEADER_CHARS = 256
+_MAX_SAFE_NETWORK_LOG_SIZE_DIGITS = len(str(_MAX_SAFE_NETWORK_LOG_SIZE))
 
 # Runner-triggered usage drain protocol:
 # - Rust writes `usage-flush-request` with the active usageStateId and a fresh
@@ -645,28 +644,48 @@ def _response_size(flow: http.HTTPFlow) -> int:
 def _content_length_response_size(content_length: str | None) -> int:
     if content_length is None:
         return 0
-    if len(content_length) > _MAX_CONTENT_LENGTH_HEADER_CHARS:
-        return 0
 
     response_size: int | None = None
-    for value in content_length.split(","):
-        parsed_size = _single_content_length_response_size(value)
+    start = 0
+    while True:
+        comma = content_length.find(",", start)
+        end = len(content_length) if comma == -1 else comma
+        parsed_size = _single_content_length_response_size(content_length, start, end)
         if parsed_size is None:
             return 0
         if response_size is None:
             response_size = parsed_size
         elif response_size != parsed_size:
             return 0
+        if comma == -1:
+            break
+        start = comma + 1
 
     return response_size if response_size is not None else 0
 
 
-def _single_content_length_response_size(content_length: str) -> int | None:
-    content_length = content_length.strip(" \t")
-    if not content_length.isascii() or not content_length.isdigit():
+def _single_content_length_response_size(content_length: str, start: int, end: int) -> int | None:
+    while start < end and content_length[start] in (" ", "\t"):
+        start += 1
+    while end > start and content_length[end - 1] in (" ", "\t"):
+        end -= 1
+    if start == end:
         return None
 
-    response_size = int(content_length)
+    while start < end and content_length[start] == "0":
+        start += 1
+    if start == end:
+        return 0
+
+    significant_start = start
+    if end - significant_start > _MAX_SAFE_NETWORK_LOG_SIZE_DIGITS:
+        return None
+    for index in range(significant_start, end):
+        char = content_length[index]
+        if char < "0" or char > "9":
+            return None
+
+    response_size = int(content_length[significant_start:end])
     if response_size > _MAX_SAFE_NETWORK_LOG_SIZE:
         return None
     return response_size

--- a/crates/runner/mitm-addon/tests/test_response_handler.py
+++ b/crates/runner/mitm-addon/tests/test_response_handler.py
@@ -255,9 +255,18 @@ class TestResponseHandler:
         entry = json.loads(lines[0])
         assert entry["response_size"] == len(body)
 
-    @pytest.mark.parametrize("content_length", ["50000", " 50000\t"])
+    @pytest.mark.parametrize(
+        ("content_length", "expected_size"),
+        [
+            pytest.param("50000", 50000, id="plain"),
+            pytest.param(" 50000\t", 50000, id="optional-whitespace"),
+            pytest.param("10, 10", 10, id="joined-consistent"),
+            pytest.param("00042, 42", 42, id="joined-leading-zero-consistent"),
+            pytest.param("0" * 32 + "42", 42, id="leading-zero-safe-integer"),
+        ],
+    )
     def test_response_size_uses_content_length_without_stream_state(
-        self, tmp_path, real_flow, mitm_ctx, content_length
+        self, tmp_path, real_flow, mitm_ctx, content_length, expected_size
     ):
         """response_size should fall back to Content-Length without stream metadata."""
         flow = real_flow(with_response=False, host="api.example.com")
@@ -276,7 +285,7 @@ class TestResponseHandler:
 
         lines = Path(log_path).read_text().splitlines()
         entry = json.loads(lines[0])
-        assert entry["response_size"] == 50000
+        assert entry["response_size"] == expected_size
 
     def test_response_size_accepts_max_safe_content_length(self, tmp_path, real_flow, mitm_ctx):
         """response_size should accept the largest exactly representable JavaScript integer."""
@@ -323,18 +332,24 @@ class TestResponseHandler:
     @pytest.mark.parametrize(
         "content_length",
         [
-            "",
-            " ",
-            "\t",
-            "not-an-int",
-            "-1",
-            "+1",
-            "1, 2",
-            "1,",
-            ",1",
-            "\u0661\u0662",
-            "9007199254740992",
-            "1" * 257,
+            pytest.param("", id="empty"),
+            pytest.param(" ", id="space"),
+            pytest.param("\t", id="tab"),
+            pytest.param("not-an-int", id="malformed"),
+            pytest.param("-1", id="negative"),
+            pytest.param("+1", id="signed"),
+            pytest.param("1.5", id="fractional"),
+            pytest.param("1e3", id="exponential"),
+            pytest.param("1, 2", id="joined-conflicting"),
+            pytest.param("1,", id="joined-trailing-empty"),
+            pytest.param(",1", id="joined-leading-empty"),
+            pytest.param("10,,10", id="joined-empty-part"),
+            pytest.param("10, abc", id="joined-invalid"),
+            pytest.param("\u0661\u0662", id="unicode-digits"),
+            pytest.param("9007199254740992", id="above-max-safe-integer"),
+            pytest.param("0" * 32 + str(1 << 53), id="leading-zero-above-max-safe-integer"),
+            pytest.param("1" * 257, id="too-many-safe-digits"),
+            pytest.param("9" * 4301, id="too-many-digits"),
         ],
     )
     def test_response_size_is_zero_for_invalid_content_length(
@@ -381,6 +396,29 @@ class TestResponseHandler:
         lines = Path(log_path).read_text().splitlines()
         entry = json.loads(lines[0])
         assert entry["response_size"] == 50000
+
+    def test_response_size_rejects_conflicting_repeated_content_length(
+        self, tmp_path, real_flow, mitm_ctx
+    ):
+        """Repeated conflicting Content-Length values should not be logged as a size."""
+        flow = real_flow(with_response=False, host="api.example.com")
+        log_path = str(tmp_path / "network.jsonl")
+
+        flow.metadata["vm_run_id"] = "run-abc-123"
+        flow.metadata["vm_network_log_path"] = log_path
+        flow.metadata["firewall_action"] = "ALLOW"
+        flow.metadata["original_url"] = "https://api.example.com/"
+        flow.response = tutils.tresp(
+            status_code=200,
+            headers=http.Headers([(b"content-length", b"50000"), (b"content-length", b"50001")]),
+        )
+
+        with mitm_ctx():
+            mitm_addon.response(flow)
+
+        lines = Path(log_path).read_text().splitlines()
+        entry = json.loads(lines[0])
+        assert entry["response_size"] == 0
 
     def test_response_size_keeps_zero_streamed_bytes(self, tmp_path, real_flow, mitm_ctx):
         """response_size should not treat a streamed byte count of 0 as missing."""


### PR DESCRIPTION
## Summary

- add a safe `Content-Length` parser for response-size fallback telemetry
- preserve streamed byte accounting precedence when stream metadata exists
- reject malformed, negative, non-decimal, conflicting duplicate, empty comma segment, and unsafe oversized fallback values
- avoid oversized fallback parsing, comma-list allocation, comma-segment slices, and large leading-zero slices while preserving valid leading-zero lengths
- add response-hook regression coverage for malformed, negative, signed, fractional, exponential, leading-zero, comma-joined, raw duplicate, and oversized fallback values

## Non-goals

- no response body length fallback
- no streaming, body capture, usage extraction, or downstream network-log contract changes

## Tests

- `python3 -m pytest tests/test_response_handler.py -q` (52 passed)
- `python3 -m pytest tests -q` (2196 passed)
- `python3 -m py_compile src/mitm_addon.py tests/test_response_handler.py`
- `PATH="$HOME/.local/bin:$PATH" ruff check src/mitm_addon.py tests/test_response_handler.py`
- `PATH="$HOME/.local/bin:$PATH" ruff format --check src/mitm_addon.py tests/test_response_handler.py`

Closes #16071