### PR TITLE
test: cover firewall auth fetch through public api

### DIFF
--- a/crates/runner/mitm-addon/tests/auth_endpoint_helpers.py
+++ b/crates/runner/mitm-addon/tests/auth_endpoint_helpers.py
@@ -1,0 +1,165 @@
+"""Shared fake auth endpoint for mitm-addon tests."""
+
+import contextlib
+import json
+import threading
+from collections import deque
+from collections.abc import Iterator, Sequence
+from dataclasses import dataclass
+from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
+
+
+@dataclass(frozen=True)
+class AuthEndpointRequest:
+    method: str
+    path: str
+    headers: dict[str, str]
+    body: bytes
+
+    def json_body(self) -> dict[str, object]:
+        body = json.loads(self.body)
+        assert isinstance(body, dict)
+        return body
+
+
+@dataclass(frozen=True)
+class AuthEndpointResponse:
+    status: int
+    body: bytes
+    headers: tuple[tuple[str, str], ...] = ()
+    release_event: threading.Event | None = None
+
+
+class FakeAuthEndpoint:
+    def __init__(self) -> None:
+        self._condition = threading.Condition()
+        self._requests: list[AuthEndpointRequest] = []
+        self._responses: deque[AuthEndpointResponse] = deque()
+        self._release_events: list[threading.Event] = []
+        self._server: ThreadingHTTPServer | None = None
+        self._thread: threading.Thread | None = None
+
+    @property
+    def api_url(self) -> str:
+        assert self._server is not None
+        host, port = self._server.server_address[:2]
+        return f"http://{host}:{port}"
+
+    @property
+    def requests(self) -> tuple[AuthEndpointRequest, ...]:
+        with self._condition:
+            return tuple(self._requests)
+
+    @property
+    def request_count(self) -> int:
+        with self._condition:
+            return len(self._requests)
+
+    def queue_json_response(
+        self,
+        body: dict[str, object],
+        *,
+        status: int = 200,
+        release_event: threading.Event | None = None,
+    ) -> None:
+        self.queue_response(
+            status,
+            body=json.dumps(body).encode(),
+            headers=(("Content-Type", "application/json"),),
+            release_event=release_event,
+        )
+
+    def queue_response(
+        self,
+        status: int,
+        *,
+        body: bytes = b"",
+        headers: Sequence[tuple[str, str]] = (),
+        release_event: threading.Event | None = None,
+    ) -> None:
+        with self._condition:
+            if release_event is not None:
+                self._release_events.append(release_event)
+            self._responses.append(
+                AuthEndpointResponse(
+                    status=status,
+                    body=body,
+                    headers=tuple(headers),
+                    release_event=release_event,
+                )
+            )
+
+    def wait_for_request_count(self, count: int, *, timeout: float = 2.0) -> bool:
+        with self._condition:
+            return self._condition.wait_for(lambda: len(self._requests) >= count, timeout)
+
+    @contextlib.contextmanager
+    def run(self) -> Iterator["FakeAuthEndpoint"]:
+        endpoint = self
+
+        class _Handler(BaseHTTPRequestHandler):
+            def do_POST(self) -> None:
+                endpoint._handle_request(self)
+
+            def log_message(self, message_format: str, *args: object) -> None:
+                return None
+
+        self._server = ThreadingHTTPServer(("127.0.0.1", 0), _Handler)
+        self._server.daemon_threads = True
+        server = self._server
+
+        def serve_forever() -> None:
+            server.serve_forever(poll_interval=0.01)
+
+        self._thread = threading.Thread(
+            target=serve_forever,
+            name="auth-endpoint-test-server",
+            daemon=True,
+        )
+        self._thread.start()
+        try:
+            yield self
+        finally:
+            for release_event in self._release_events:
+                release_event.set()
+            self._server.shutdown()
+            self._thread.join(timeout=2.0)
+            self._server.server_close()
+            self._server = None
+            self._thread = None
+
+    def _record_request(self, request: AuthEndpointRequest) -> None:
+        with self._condition:
+            self._requests.append(request)
+            self._condition.notify_all()
+
+    def _next_response(self) -> AuthEndpointResponse:
+        with self._condition:
+            if self._responses:
+                return self._responses.popleft()
+        return AuthEndpointResponse(status=500, body=b"unexpected auth request")
+
+    def _handle_request(self, handler: BaseHTTPRequestHandler) -> None:
+        content_length = int(handler.headers.get("content-length", "0"))
+        body = handler.rfile.read(content_length)
+        self._record_request(
+            AuthEndpointRequest(
+                method=handler.command,
+                path=handler.path,
+                headers={key.lower(): value for key, value in handler.headers.items()},
+                body=body,
+            )
+        )
+
+        response = self._next_response()
+        if response.release_event is not None:
+            response.release_event.wait()
+
+        handler.send_response(response.status)
+        for name, value in response.headers:
+            handler.send_header(name, value)
+        if response.body:
+            handler.send_header("Content-Length", str(len(response.body)))
+        handler.end_headers()
+        if response.body:
+            handler.wfile.write(response.body)

--- a/crates/runner/mitm-addon/tests/test_auth_cache.py
+++ b/crates/runner/mitm-addon/tests/test_auth_cache.py
@@ -1,20 +1,16 @@
 """Tests for firewall auth cache behavior."""
 
 import asyncio
-import contextlib
 import json
 import threading
 import time
 import urllib.error
-from collections import deque
-from collections.abc import Iterator, Sequence
-from dataclasses import dataclass
-from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
 
 import pytest
 
 import auth
 import registry as registry_cache
+from tests.auth_endpoint_helpers import FakeAuthEndpoint
 from tests.auth_state_helpers import (
     cached_headers,
     has_auth_state,
@@ -23,163 +19,12 @@ from tests.auth_state_helpers import (
 )
 
 
-@dataclass(frozen=True)
-class _AuthRequest:
-    method: str
-    path: str
-    headers: dict[str, str]
-    body: bytes
-
-
-@dataclass(frozen=True)
-class _AuthResponse:
-    status: int
-    body: bytes
-    headers: tuple[tuple[str, str], ...] = ()
-    release_event: threading.Event | None = None
-
-
-class _FakeAuthEndpoint:
-    def __init__(self) -> None:
-        self._condition = threading.Condition()
-        self._requests: list[_AuthRequest] = []
-        self._responses: deque[_AuthResponse] = deque()
-        self._release_events: list[threading.Event] = []
-        self._server: ThreadingHTTPServer | None = None
-        self._thread: threading.Thread | None = None
-
-    @property
-    def api_url(self) -> str:
-        assert self._server is not None
-        host, port = self._server.server_address[:2]
-        return f"http://{host}:{port}"
-
-    @property
-    def requests(self) -> tuple[_AuthRequest, ...]:
-        with self._condition:
-            return tuple(self._requests)
-
-    @property
-    def request_count(self) -> int:
-        with self._condition:
-            return len(self._requests)
-
-    def queue_json_response(
-        self,
-        body: dict[str, object],
-        *,
-        status: int = 200,
-        release_event: threading.Event | None = None,
-    ) -> None:
-        self.queue_response(
-            status,
-            body=json.dumps(body).encode(),
-            headers=(("Content-Type", "application/json"),),
-            release_event=release_event,
-        )
-
-    def queue_response(
-        self,
-        status: int,
-        *,
-        body: bytes = b"",
-        headers: Sequence[tuple[str, str]] = (),
-        release_event: threading.Event | None = None,
-    ) -> None:
-        with self._condition:
-            if release_event is not None:
-                self._release_events.append(release_event)
-            self._responses.append(
-                _AuthResponse(
-                    status=status,
-                    body=body,
-                    headers=tuple(headers),
-                    release_event=release_event,
-                )
-            )
-
-    def wait_for_request_count(self, count: int, *, timeout: float = 2.0) -> bool:
-        with self._condition:
-            return self._condition.wait_for(lambda: len(self._requests) >= count, timeout)
-
-    @contextlib.contextmanager
-    def run(self) -> Iterator["_FakeAuthEndpoint"]:
-        endpoint = self
-
-        class _Handler(BaseHTTPRequestHandler):
-            def do_POST(self) -> None:
-                endpoint._handle_request(self)
-
-            def log_message(self, message_format: str, *args: object) -> None:
-                return None
-
-        self._server = ThreadingHTTPServer(("127.0.0.1", 0), _Handler)
-        self._server.daemon_threads = True
-        server = self._server
-
-        def serve_forever() -> None:
-            server.serve_forever(poll_interval=0.01)
-
-        self._thread = threading.Thread(
-            target=serve_forever,
-            name="auth-endpoint-test-server",
-            daemon=True,
-        )
-        self._thread.start()
-        try:
-            yield self
-        finally:
-            for release_event in self._release_events:
-                release_event.set()
-            self._server.shutdown()
-            self._thread.join(timeout=2.0)
-            self._server.server_close()
-            self._server = None
-            self._thread = None
-
-    def _record_request(self, request: _AuthRequest) -> None:
-        with self._condition:
-            self._requests.append(request)
-            self._condition.notify_all()
-
-    def _next_response(self) -> _AuthResponse:
-        with self._condition:
-            if self._responses:
-                return self._responses.popleft()
-        return _AuthResponse(status=500, body=b"unexpected auth request")
-
-    def _handle_request(self, handler: BaseHTTPRequestHandler) -> None:
-        content_length = int(handler.headers.get("content-length", "0"))
-        body = handler.rfile.read(content_length)
-        self._record_request(
-            _AuthRequest(
-                method=handler.command,
-                path=handler.path,
-                headers={key.lower(): value for key, value in handler.headers.items()},
-                body=body,
-            )
-        )
-
-        response = self._next_response()
-        if response.release_event is not None:
-            response.release_event.wait()
-
-        handler.send_response(response.status)
-        for name, value in response.headers:
-            handler.send_header(name, value)
-        if response.body:
-            handler.send_header("Content-Length", str(len(response.body)))
-        handler.end_headers()
-        if response.body:
-            handler.wfile.write(response.body)
-
-
 class TestFirewallHeaderCache:
     """Tests for get_firewall_headers caching and concurrency protection."""
 
     async def test_concurrent_fetches_coalesce(self, mitm_ctx):
         """Multiple concurrent get_firewall_headers calls should make only one HTTP request."""
-        endpoint = _FakeAuthEndpoint()
+        endpoint = FakeAuthEndpoint()
         release_response = threading.Event()
         endpoint.queue_json_response(
             {
@@ -225,7 +70,7 @@ class TestFirewallHeaderCache:
 
     async def test_different_keys_fetch_independently(self, mitm_ctx):
         """Different (run_id, api_id) pairs should fetch independently."""
-        endpoint = _FakeAuthEndpoint()
+        endpoint = FakeAuthEndpoint()
         endpoint.queue_json_response(
             {
                 "headers": {"Authorization": "Bearer token-1"},
@@ -256,7 +101,7 @@ class TestFirewallHeaderCache:
 
     async def test_fetch_failure_does_not_cache(self, mitm_ctx):
         """Failed fetch should not populate cache; next caller retries independently."""
-        endpoint = _FakeAuthEndpoint()
+        endpoint = FakeAuthEndpoint()
         endpoint.queue_response(500, body=b"not-json")
 
         with (

--- a/crates/runner/mitm-addon/tests/test_firewall_auth.py
+++ b/crates/runner/mitm-addon/tests/test_firewall_auth.py
@@ -12,6 +12,7 @@ import pytest
 
 import auth
 import matching
+from tests.auth_endpoint_helpers import FakeAuthEndpoint
 from tests.auth_state_helpers import (
     cached_headers,
     force_refresh_pending,
@@ -1257,41 +1258,410 @@ class TestMakeApiRequest:
 
 
 class TestFetchFirewallHeaders:
-    def test_builds_correct_request(self, headers):
-        mock_resp = MagicMock()
-        mock_resp.__enter__.return_value = mock_resp
-        mock_resp.read.return_value = json.dumps(
-            {"headers": {"Authorization": "Bearer tok"}}
-        ).encode()
+    async def test_sends_request_and_maps_basic_success(self, mitm_ctx):
+        endpoint = FakeAuthEndpoint()
+        endpoint.queue_json_response({"headers": {"Authorization": "Bearer tok"}})
 
         with (
-            patch("auth.urllib.request.Request") as mock_req_cls,
-            patch("auth.urllib.request.urlopen", return_value=mock_resp),
+            endpoint.run(),
+            mitm_ctx(api_url=endpoint.api_url),
             patch.object(auth, "VERCEL_BYPASS", ""),
         ):
-            result = auth._fetch_firewall_headers_sync(
+            result = await auth.fetch_firewall_headers(
                 "iv:tag:data",
                 {"Authorization": "Bearer ${{ secrets.TOKEN }}"},
                 "tok-xyz",
-                "https://api.vm0.ai",
             )
 
         assert result.payload.headers == {"Authorization": "Bearer tok"}
         assert result.payload.base is None
         assert result.payload.query is None
 
-        # urllib.request.Request construction is the external boundary (#9991).
-        mock_req_cls.assert_called_once()
-        call_args = mock_req_cls.call_args
-        assert call_args[0][0] == "https://api.vm0.ai/api/webhooks/agent/firewall/auth"
-        body = json.loads(call_args[1]["data"])
-        assert body["encryptedSecrets"] == "iv:tag:data"
-        assert body["authHeaders"] == {"Authorization": "Bearer ${{ secrets.TOKEN }}"}
-        assert "runId" not in body
-        assert "base" not in body
-        assert call_args[1]["headers"]["Authorization"] == "Bearer tok-xyz"
-        assert call_args[1]["headers"]["Content-Type"] == "application/json"
+        assert endpoint.request_count == 1
+        request = endpoint.requests[0]
+        assert request.method == "POST"
+        assert request.path == "/api/webhooks/agent/firewall/auth"
+        assert request.headers["authorization"] == "Bearer tok-xyz"
+        assert request.headers["content-type"] == "application/json"
+        assert request.headers["user-agent"] == "vm0-mitm-addon/1.0"
+        assert "x-vercel-protection-bypass" not in request.headers
+        assert request.json_body() == {
+            "encryptedSecrets": "iv:tag:data",
+            "authHeaders": {"Authorization": "Bearer ${{ secrets.TOKEN }}"},
+        }
 
+    async def test_success_response_shape_is_mapped(self, mitm_ctx):
+        expires_at = time.time() + 30
+        endpoint = FakeAuthEndpoint()
+        endpoint.queue_json_response(
+            {
+                "headers": {
+                    "Authorization": "Bearer tok",
+                    "X-Custom": "custom",
+                },
+                "base": "https://example.com/webhook/secret",
+                "query": {"api_key": "resolved-key"},
+                "expiresAt": expires_at,
+                "resolvedSecrets": ["API_TOKEN"],
+                "refreshedConnectors": ["notion"],
+                "refreshedSecrets": ["NOTION_TOKEN"],
+                "futureField": {"ignored": True},
+            }
+        )
+
+        with (
+            endpoint.run(),
+            mitm_ctx(api_url=endpoint.api_url),
+            patch.object(auth, "VERCEL_BYPASS", ""),
+        ):
+            result = await auth.fetch_firewall_headers("iv:tag:data", {}, "tok-xyz")
+
+        assert result.payload.headers == {
+            "Authorization": "Bearer tok",
+            "X-Custom": "custom",
+        }
+        assert result.payload.base == "https://example.com/webhook/secret"
+        assert result.payload.query == {"api_key": "resolved-key"}
+        assert result.expires_at == expires_at
+        assert result.payload.resolved_secrets == ["API_TOKEN"]
+        assert result.refreshed_connectors == ["notion"]
+        assert result.refreshed_secrets == ["NOTION_TOKEN"]
+        assert not hasattr(result, "futureField")
+
+    async def test_sends_optional_request_body_fields(self, mitm_ctx):
+        endpoint = FakeAuthEndpoint()
+        endpoint.queue_json_response({"headers": {}, "expiresAt": time.time() + 30})
+
+        with (
+            endpoint.run(),
+            mitm_ctx(api_url=endpoint.api_url),
+            patch.object(auth, "VERCEL_BYPASS", ""),
+        ):
+            await auth.fetch_firewall_headers(
+                "iv:tag:data",
+                {},
+                "tok-xyz",
+                secret_connector_map={"TOKEN": "notion"},
+                secret_connector_metadata_map={"TOKEN": {"kind": "oauth"}},
+                vars_map={"TEAM": "vm0"},
+                auth_base="${{ secrets.WEBHOOK_URL }}",
+                auth_query={"api_key": "${{ secrets.API_KEY }}"},
+                firewall_billable=True,
+                force_refresh=True,
+            )
+
+        body = endpoint.requests[0].json_body()
+        assert body["encryptedSecrets"] == "iv:tag:data"
+        assert body["authHeaders"] == {}
+        assert body["secretConnectorMap"] == {"TOKEN": "notion"}
+        assert body["secretConnectorMetadataMap"] == {"TOKEN": {"kind": "oauth"}}
+        assert body["vars"] == {"TEAM": "vm0"}
+        assert body["authBase"] == "${{ secrets.WEBHOOK_URL }}"
+        assert body["authQuery"] == {"api_key": "${{ secrets.API_KEY }}"}
+        assert body["firewallBillable"] is True
+        assert body["forceRefresh"] is True
+        assert "firewallName" not in body
+        assert "modelUsageProvider" not in body
+
+    async def test_includes_vercel_bypass_header(self, mitm_ctx):
+        endpoint = FakeAuthEndpoint()
+        endpoint.queue_json_response({"headers": {}})
+        with (
+            endpoint.run(),
+            mitm_ctx(api_url=endpoint.api_url),
+            patch.object(auth, "VERCEL_BYPASS", "secret-bypass-value"),
+        ):
+            await auth.fetch_firewall_headers("iv:tag:data", {}, "tok-xyz")
+
+        assert endpoint.requests[0].headers["x-vercel-protection-bypass"] == "secret-bypass-value"
+
+    async def test_invalid_api_url_raises_before_urlopen(self):
+        with (
+            patch.object(auth, "get_api_url", return_value="file:///etc/passwd"),
+            patch("auth.urllib.request.urlopen") as mock_urlopen,
+            pytest.raises(ValueError, match="absolute http"),
+        ):
+            await auth.fetch_firewall_headers("iv:tag:data", {}, "tok-xyz")
+
+        mock_urlopen.assert_not_called()
+
+    async def test_424_connector_not_configured_raises_custom_error(self, mitm_ctx):
+        """Auth endpoint 424 CONNECTOR_NOT_CONFIGURED raises ConnectorNotConfiguredError."""
+        endpoint = FakeAuthEndpoint()
+        endpoint.queue_json_response(
+            {
+                "error": {
+                    "message": "Connector not configured",
+                    "code": "CONNECTOR_NOT_CONFIGURED",
+                }
+            },
+            status=424,
+        )
+
+        with (
+            endpoint.run(),
+            mitm_ctx(api_url=endpoint.api_url),
+            patch.object(auth, "VERCEL_BYPASS", ""),
+        ):
+            with pytest.raises(auth.ConnectorNotConfiguredError) as exc_info:
+                await auth.fetch_firewall_headers("iv:tag:data", {}, "tok-xyz")
+            assert "Connector not configured" in str(exc_info.value)
+
+    async def test_402_insufficient_credits_raises_custom_error(self, mitm_ctx):
+        endpoint = FakeAuthEndpoint()
+        endpoint.queue_json_response(
+            {
+                "error": {
+                    "message": "Insufficient credits",
+                    "code": "INSUFFICIENT_CREDITS",
+                }
+            },
+            status=402,
+        )
+
+        with (
+            endpoint.run(),
+            mitm_ctx(api_url=endpoint.api_url),
+            patch.object(auth, "VERCEL_BYPASS", ""),
+        ):
+            with pytest.raises(auth.InsufficientCreditsError) as exc_info:
+                await auth.fetch_firewall_headers("iv:tag:data", {}, "tok-xyz")
+            assert "Insufficient credits" in str(exc_info.value)
+
+    @pytest.mark.parametrize(
+        (
+            "status",
+            "code",
+            "message",
+            "connectors",
+            "failure_reason",
+            "expected_failure_reason",
+        ),
+        [
+            (
+                424,
+                "TOKEN_ACCESS_RESOLUTION_FAILED",
+                "Token access resolution failed for: notion.",
+                ["notion"],
+                None,
+                None,
+            ),
+            (
+                403,
+                "FORBIDDEN",
+                "Invalid model-provider secret owner",
+                None,
+                None,
+                None,
+            ),
+            (
+                502,
+                "TOKEN_REFRESH_FAILED",
+                "Access token expired and refresh failed for: codex-oauth-token.",
+                ["codex-oauth-token"],
+                "upstream_provider",
+                "upstream_provider",
+            ),
+            (
+                502,
+                "TOKEN_REFRESH_FAILED",
+                "Access token expired and refresh failed for: notion.",
+                ["notion"],
+                "provider_rate_limited",
+                None,
+            ),
+        ],
+        ids=[
+            "token-access-resolution",
+            "forbidden",
+            "token-refresh",
+            "unknown-failure-reason",
+        ],
+    )
+    async def test_current_structured_error_raises_custom_error(
+        self,
+        mitm_ctx,
+        status: int,
+        code: str,
+        message: str,
+        connectors: list[str] | None,
+        failure_reason: str | None,
+        expected_failure_reason: str | None,
+    ):
+        """Current auth endpoint errors should preserve their code and connectors."""
+        error_info: dict[str, object] = {
+            "message": message,
+            "code": code,
+        }
+        if connectors is not None:
+            error_info["connectors"] = connectors
+        if failure_reason is not None:
+            error_info["failureReason"] = failure_reason
+        endpoint = FakeAuthEndpoint()
+        endpoint.queue_json_response({"error": error_info}, status=status)
+
+        with (
+            endpoint.run(),
+            mitm_ctx(api_url=endpoint.api_url),
+            patch.object(auth, "VERCEL_BYPASS", ""),
+            pytest.raises(auth.FirewallAuthApiError) as exc_info,
+        ):
+            await auth.fetch_firewall_headers("iv:tag:data", {}, "tok-xyz")
+
+        assert exc_info.value.status == status
+        assert exc_info.value.code == code
+        assert str(exc_info.value) == message
+        assert exc_info.value.connectors == connectors
+        assert exc_info.value.failure_reason == expected_failure_reason
+
+    async def test_structured_http_error_at_body_limit_is_preserved(self, mitm_ctx):
+        error_body = json.dumps(
+            {
+                "error": {
+                    "message": "Access token expired and refresh failed for: notion.",
+                    "code": "TOKEN_REFRESH_FAILED",
+                }
+            }
+        ).encode()
+        endpoint = FakeAuthEndpoint()
+        endpoint.queue_response(502, body=error_body)
+
+        with (
+            endpoint.run(),
+            mitm_ctx(api_url=endpoint.api_url),
+            patch.object(
+                auth,
+                "MAX_FIREWALL_AUTH_RESPONSE_BODY_BYTES",
+                len(error_body),
+            ),
+            patch.object(auth, "VERCEL_BYPASS", ""),
+            pytest.raises(auth.FirewallAuthApiError) as exc_info,
+        ):
+            await auth.fetch_firewall_headers("iv:tag:data", {}, "tok-xyz")
+
+        assert exc_info.value.code == "TOKEN_REFRESH_FAILED"
+
+    async def test_http_error_over_body_limit_raises(self, mitm_ctx):
+        error_body = json.dumps(
+            {
+                "error": {
+                    "message": "Access token expired and refresh failed for: notion.",
+                    "code": "TOKEN_REFRESH_FAILED",
+                }
+            }
+        ).encode()
+        endpoint = FakeAuthEndpoint()
+        endpoint.queue_response(502, body=error_body)
+
+        with (
+            endpoint.run(),
+            mitm_ctx(api_url=endpoint.api_url),
+            patch.object(
+                auth,
+                "MAX_FIREWALL_AUTH_RESPONSE_BODY_BYTES",
+                len(error_body) - 1,
+            ),
+            patch.object(auth, "VERCEL_BYPASS", ""),
+            pytest.raises(
+                auth.FirewallAuthResponseTooLargeError,
+                match="Firewall auth response body too large",
+            ),
+        ):
+            await auth.fetch_firewall_headers("iv:tag:data", {}, "tok-xyz")
+
+    @pytest.mark.parametrize(
+        "error_body",
+        [
+            b"not-json",
+            b'"plain string"',
+            b"[1, 2, 3]",
+            b"{}",
+            json.dumps({"error": "not-a-dict"}).encode(),
+            json.dumps({"error": None}).encode(),
+            json.dumps({"error": {}}).encode(),
+            json.dumps({"error": {"message": "Bad Request", "code": "BAD_REQUEST"}}).encode(),
+        ],
+    )
+    async def test_malformed_http_error_envelope_reraises_http_error(
+        self,
+        mitm_ctx,
+        error_body: bytes,
+    ):
+        endpoint = FakeAuthEndpoint()
+        endpoint.queue_response(400, body=error_body)
+
+        with (
+            endpoint.run(),
+            mitm_ctx(api_url=endpoint.api_url),
+            patch.object(auth, "VERCEL_BYPASS", ""),
+            pytest.raises(urllib.error.HTTPError) as exc_info,
+        ):
+            await auth.fetch_firewall_headers("iv:tag:data", {}, "tok-xyz")
+
+        assert exc_info.value.code == 400
+
+    @pytest.mark.parametrize(
+        ("code", "status", "exception_type", "default_message"),
+        [
+            (
+                "CONNECTOR_NOT_CONFIGURED",
+                424,
+                auth.ConnectorNotConfiguredError,
+                "Connector not configured",
+            ),
+            (
+                "INSUFFICIENT_CREDITS",
+                402,
+                auth.InsufficientCreditsError,
+                "Insufficient credits",
+            ),
+        ],
+    )
+    async def test_known_error_with_non_string_message_uses_default(
+        self,
+        mitm_ctx,
+        code: str,
+        status: int,
+        exception_type: type[Exception],
+        default_message: str,
+    ):
+        endpoint = FakeAuthEndpoint()
+        endpoint.queue_json_response(
+            {
+                "error": {
+                    "message": None,
+                    "code": code,
+                }
+            },
+            status=status,
+        )
+
+        with (
+            endpoint.run(),
+            mitm_ctx(api_url=endpoint.api_url),
+            patch.object(auth, "VERCEL_BYPASS", ""),
+            pytest.raises(exception_type) as exc_info,
+        ):
+            await auth.fetch_firewall_headers("iv:tag:data", {}, "tok-xyz")
+
+        assert str(exc_info.value) == default_message
+
+    async def test_async_wrapper_uses_api_url_from_ctx(self, mitm_ctx):
+        endpoint = FakeAuthEndpoint()
+        endpoint.queue_json_response({"headers": {"Auth": "tok"}})
+
+        with (
+            endpoint.run(),
+            mitm_ctx(api_url=endpoint.api_url),
+            patch.object(auth, "VERCEL_BYPASS", ""),
+        ):
+            result = await auth.fetch_firewall_headers("enc", {}, "sandbox-tok")
+
+        assert result.payload.headers == {"Auth": "tok"}
+        assert endpoint.requests[0].path == "/api/webhooks/agent/firewall/auth"
+
+
+class TestFirewallAuthSuccessParser:
     @pytest.mark.parametrize(
         "body",
         [
@@ -1317,421 +1687,74 @@ class TestFetchFirewallHeaders:
         ],
     )
     def test_malformed_success_response_shape_raises_value_error(self, body: object):
-        mock_resp = _json_response(body)
+        with pytest.raises(ValueError, match=_MALFORMED_SUCCESS_PREFIX):
+            auth._parse_firewall_auth_success(body)
 
-        with (
-            patch("auth.urllib.request.Request"),
-            patch("auth.urllib.request.urlopen", return_value=mock_resp),
-            patch.object(auth, "VERCEL_BYPASS", ""),
-            pytest.raises(ValueError, match=_MALFORMED_SUCCESS_PREFIX),
-        ):
-            auth._fetch_firewall_headers_sync("iv:tag:data", {}, "tok-xyz", "https://api.vm0.ai")
 
-        mock_resp.__exit__.assert_called_once()
-
-    def test_success_response_at_body_limit_is_accepted(self):
+class TestFirewallAuthResponseBodyReader:
+    def test_response_at_body_limit_is_accepted(self):
         response_body = json.dumps({"headers": {}}).encode()
         mock_resp = _raw_response(response_body)
 
-        with (
-            patch.object(
-                auth,
-                "MAX_FIREWALL_AUTH_RESPONSE_BODY_BYTES",
-                len(response_body),
-            ),
-            patch("auth.urllib.request.Request"),
-            patch("auth.urllib.request.urlopen", return_value=mock_resp),
-            patch.object(auth, "VERCEL_BYPASS", ""),
-        ):
-            result = auth._fetch_firewall_headers_sync(
-                "iv:tag:data",
-                {},
-                "tok-xyz",
-                "https://api.vm0.ai",
-            )
+        with patch.object(auth, "MAX_FIREWALL_AUTH_RESPONSE_BODY_BYTES", len(response_body)):
+            assert auth._read_firewall_auth_response_body(mock_resp) == response_body
 
-        assert result.payload.headers == {}
         mock_resp.read.assert_called_once_with(len(response_body) + 1)
-        mock_resp.__exit__.assert_called_once()
 
-    def test_success_response_over_body_limit_raises_and_closes_response(self):
+    def test_response_over_body_limit_raises(self):
         response_body = json.dumps({"headers": {}}).encode()
         mock_resp = _raw_response(response_body)
 
         with (
-            patch.object(
-                auth,
-                "MAX_FIREWALL_AUTH_RESPONSE_BODY_BYTES",
-                len(response_body) - 1,
-            ),
-            patch("auth.urllib.request.Request"),
-            patch("auth.urllib.request.urlopen", return_value=mock_resp),
-            patch.object(auth, "VERCEL_BYPASS", ""),
+            patch.object(auth, "MAX_FIREWALL_AUTH_RESPONSE_BODY_BYTES", len(response_body) - 1),
             pytest.raises(
                 auth.FirewallAuthResponseTooLargeError,
                 match="Firewall auth response body too large",
             ),
         ):
-            auth._fetch_firewall_headers_sync("iv:tag:data", {}, "tok-xyz", "https://api.vm0.ai")
+            auth._read_firewall_auth_response_body(mock_resp)
 
         mock_resp.read.assert_called_once_with(len(response_body))
-        mock_resp.__exit__.assert_called_once()
 
-    def test_success_response_shape_is_parsed_to_internal_type(self):
-        expires_at = time.time() + 30
-        mock_resp = _json_response(
-            {
-                "headers": {
-                    "Authorization": "Bearer tok",
-                    "X-Custom": "custom",
-                },
-                "base": "https://example.com/webhook/secret",
-                "query": {"api_key": "resolved-key"},
-                "expiresAt": expires_at,
-                "resolvedSecrets": ["API_TOKEN"],
-                "refreshedConnectors": ["notion"],
-                "refreshedSecrets": ["NOTION_TOKEN"],
-                "futureField": {"ignored": True},
-            }
-        )
 
-        with (
-            patch("auth.urllib.request.Request"),
-            patch("auth.urllib.request.urlopen", return_value=mock_resp),
-            patch.object(auth, "VERCEL_BYPASS", ""),
-        ):
-            result = auth._fetch_firewall_headers_sync(
-                "iv:tag:data",
-                {},
-                "tok-xyz",
-                "https://api.vm0.ai",
-            )
-
-        assert isinstance(result, auth._FirewallAuthSuccess)
-        assert result.payload.headers == {
-            "Authorization": "Bearer tok",
-            "X-Custom": "custom",
-        }
-        assert result.payload.base == "https://example.com/webhook/secret"
-        assert result.payload.query == {"api_key": "resolved-key"}
-        assert result.expires_at == expires_at
-        assert result.payload.resolved_secrets == ["API_TOKEN"]
-        assert result.refreshed_connectors == ["notion"]
-        assert result.refreshed_secrets == ["NOTION_TOKEN"]
-        assert not hasattr(result, "futureField")
-
-    def test_invalid_api_url_raises_before_urlopen(self):
-        with (
-            patch("auth.urllib.request.urlopen") as mock_urlopen,
-            pytest.raises(ValueError, match="absolute http"),
-        ):
-            auth._fetch_firewall_headers_sync("iv:tag:data", {}, "tok-xyz", "file:///etc/passwd")
-
-        mock_urlopen.assert_not_called()
-
-    def test_includes_vercel_bypass_header(self, headers):
+class TestFetchFirewallHeadersResourceBoundary:
+    def test_closes_response_on_success(self):
+        """Success path must close the urlopen response — FD leak guard (#10475)."""
         mock_resp = MagicMock()
         mock_resp.__enter__.return_value = mock_resp
         mock_resp.read.return_value = json.dumps({"headers": {}}).encode()
 
-        mock_req_instance = MagicMock()
-
         with (
-            patch("auth.urllib.request.Request", return_value=mock_req_instance),
-            patch("auth.urllib.request.urlopen", return_value=mock_resp),
-            patch.object(auth, "VERCEL_BYPASS", "secret-bypass-value"),
-        ):
-            auth._fetch_firewall_headers_sync("iv:tag:data", {}, "tok-xyz", "https://api.vm0.ai")
-
-        # urllib Request.add_header is the external boundary (#9991).
-        mock_req_instance.add_header.assert_called_once_with(
-            "x-vercel-protection-bypass", "secret-bypass-value"
-        )
-
-    def test_no_vercel_bypass_when_empty(self, headers):
-        mock_resp = MagicMock()
-        mock_resp.__enter__.return_value = mock_resp
-        mock_resp.read.return_value = json.dumps({"headers": {}}).encode()
-
-        mock_req_instance = MagicMock()
-
-        with (
-            patch("auth.urllib.request.Request", return_value=mock_req_instance),
+            patch("auth.urllib.request.Request"),
             patch("auth.urllib.request.urlopen", return_value=mock_resp),
             patch.object(auth, "VERCEL_BYPASS", ""),
         ):
             auth._fetch_firewall_headers_sync("iv:tag:data", {}, "tok-xyz", "https://api.vm0.ai")
 
-        mock_req_instance.add_header.assert_not_called()
+        mock_resp.__exit__.assert_called_once()  # urllib external boundary (#9991)
 
-    def test_includes_auth_base_in_request_body(self, headers):
-        mock_resp = MagicMock()
-        mock_resp.__enter__.return_value = mock_resp
-        mock_resp.read.return_value = json.dumps(
-            {"headers": {}, "base": "https://discord.com/api/webhooks/123/abc"}
-        ).encode()
-
-        with (
-            patch("auth.urllib.request.Request") as mock_req_cls,
-            patch("auth.urllib.request.urlopen", return_value=mock_resp),
-            patch.object(auth, "VERCEL_BYPASS", ""),
-        ):
-            result = auth._fetch_firewall_headers_sync(
-                "iv:tag:data",
-                {},
-                "tok-xyz",
-                "https://api.vm0.ai",
-                auth_base="${{ secrets.DISCORD_WEBHOOK_URL }}",
-            )
-
-        assert result.payload.base == "https://discord.com/api/webhooks/123/abc"
-        body = json.loads(mock_req_cls.call_args[1]["data"])
-        assert body["authBase"] == "${{ secrets.DISCORD_WEBHOOK_URL }}"
-
-    def test_includes_auth_base_and_query_in_request_body(self, headers):
-        mock_resp = MagicMock()
-        mock_resp.__enter__.return_value = mock_resp
-        mock_resp.read.return_value = json.dumps(
-            {
-                "headers": {},
-                "base": "https://example.com/webhook/secret",
-                "query": {"api_key": "resolved-key"},
-            }
-        ).encode()
-
-        with (
-            patch("auth.urllib.request.Request") as mock_req_cls,
-            patch("auth.urllib.request.urlopen", return_value=mock_resp),
-            patch.object(auth, "VERCEL_BYPASS", ""),
-        ):
-            result = auth._fetch_firewall_headers_sync(
-                "iv:tag:data",
-                {},
-                "tok-xyz",
-                "https://api.vm0.ai",
-                auth_base="${{ secrets.WEBHOOK_URL }}",
-                auth_query={"api_key": "${{ secrets.API_KEY }}"},
-            )
-
-        assert result.payload.base == "https://example.com/webhook/secret"
-        assert result.payload.query == {"api_key": "resolved-key"}
-        body = json.loads(mock_req_cls.call_args[1]["data"])
-        assert body["authBase"] == "${{ secrets.WEBHOOK_URL }}"
-        assert body["authQuery"] == {"api_key": "${{ secrets.API_KEY }}"}
-
-    def test_includes_billable_firewall_flag_in_request_body(self, headers):
-        mock_resp = MagicMock()
-        mock_resp.__enter__.return_value = mock_resp
-        mock_resp.read.return_value = json.dumps(
-            {
-                "headers": {},
-                "expiresAt": time.time() + 30,
-            }
-        ).encode()
-
-        with (
-            patch("auth.urllib.request.Request") as mock_req_cls,
-            patch("auth.urllib.request.urlopen", return_value=mock_resp),
-            patch.object(auth, "VERCEL_BYPASS", ""),
-        ):
-            auth._fetch_firewall_headers_sync(
-                "iv:tag:data",
-                {},
-                "tok-xyz",
-                "https://api.vm0.ai",
-                firewall_billable=True,
-            )
-
-        body = json.loads(mock_req_cls.call_args[1]["data"])
-        assert body["firewallBillable"] is True
-        assert "firewallName" not in body
-        assert "modelUsageProvider" not in body
-
-    def test_424_connector_not_configured_raises_custom_error(self):
-        """Auth endpoint 424 CONNECTOR_NOT_CONFIGURED raises ConnectorNotConfiguredError."""
-        error_body = json.dumps(
-            {
-                "error": {
-                    "message": "Connector not configured",
-                    "code": "CONNECTOR_NOT_CONFIGURED",
-                }
-            }
-        ).encode()
-        http_error = _http_error(
+    def test_closes_http_error_response_when_body_is_unreadable(self):
+        http_error = urllib.error.HTTPError(
             "https://api.vm0.ai/api/webhooks/agent/firewall/auth",
-            424,
-            "Failed Dependency",
-            error_body,
-        )
-
-        with (
-            patch("auth.urllib.request.Request"),
-            patch("auth.urllib.request.urlopen", side_effect=http_error),
-            patch.object(auth, "VERCEL_BYPASS", ""),
-        ):
-            with pytest.raises(auth.ConnectorNotConfiguredError) as exc_info:
-                auth._fetch_firewall_headers_sync(
-                    "iv:tag:data", {}, "tok-xyz", "https://api.vm0.ai"
-                )
-            assert "Connector not configured" in str(exc_info.value)
-
-    def test_402_insufficient_credits_raises_custom_error(self):
-        error_body = json.dumps(
-            {
-                "error": {
-                    "message": "Insufficient credits",
-                    "code": "INSUFFICIENT_CREDITS",
-                }
-            }
-        ).encode()
-        http_error = _http_error(
-            "https://api.vm0.ai/api/webhooks/agent/firewall/auth",
-            402,
-            "Payment Required",
-            error_body,
-        )
-
-        with (
-            patch("auth.urllib.request.Request"),
-            patch("auth.urllib.request.urlopen", side_effect=http_error),
-            patch.object(auth, "VERCEL_BYPASS", ""),
-        ):
-            with pytest.raises(auth.InsufficientCreditsError) as exc_info:
-                auth._fetch_firewall_headers_sync(
-                    "iv:tag:data", {}, "tok-xyz", "https://api.vm0.ai"
-                )
-            assert "Insufficient credits" in str(exc_info.value)
-
-    @pytest.mark.parametrize(
-        (
-            "status",
-            "reason",
-            "code",
-            "message",
-            "connectors",
-            "failure_reason",
-            "expected_failure_reason",
-        ),
-        [
-            (
-                424,
-                "Failed Dependency",
-                "TOKEN_ACCESS_RESOLUTION_FAILED",
-                "Token access resolution failed for: notion.",
-                ["notion"],
-                None,
-                None,
-            ),
-            (
-                403,
-                "Forbidden",
-                "FORBIDDEN",
-                "Invalid model-provider secret owner",
-                None,
-                None,
-                None,
-            ),
-            (
-                502,
-                "Bad Gateway",
-                "TOKEN_REFRESH_FAILED",
-                "Access token expired and refresh failed for: codex-oauth-token.",
-                ["codex-oauth-token"],
-                "upstream_provider",
-                "upstream_provider",
-            ),
-            (
-                502,
-                "Bad Gateway",
-                "TOKEN_REFRESH_FAILED",
-                "Access token expired and refresh failed for: notion.",
-                ["notion"],
-                "provider_rate_limited",
-                None,
-            ),
-        ],
-        ids=[
-            "token-access-resolution",
-            "forbidden",
-            "token-refresh",
-            "unknown-failure-reason",
-        ],
-    )
-    def test_current_structured_error_raises_custom_error(
-        self,
-        status: int,
-        reason: str,
-        code: str,
-        message: str,
-        connectors: list[str] | None,
-        failure_reason: str | None,
-        expected_failure_reason: str | None,
-    ):
-        """Current auth endpoint errors should preserve their code and connectors."""
-        error_info: dict[str, object] = {
-            "message": message,
-            "code": code,
-        }
-        if connectors is not None:
-            error_info["connectors"] = connectors
-        if failure_reason is not None:
-            error_info["failureReason"] = failure_reason
-        error_body = json.dumps({"error": error_info}).encode()
-        http_error = _http_error(
-            "https://api.vm0.ai/api/webhooks/agent/firewall/auth",
-            status,
-            reason,
-            error_body,
-        )
-
-        with (
-            patch("auth.urllib.request.Request"),
-            patch("auth.urllib.request.urlopen", side_effect=http_error),
-            patch.object(auth, "VERCEL_BYPASS", ""),
-            pytest.raises(auth.FirewallAuthApiError) as exc_info,
-        ):
-            auth._fetch_firewall_headers_sync("iv:tag:data", {}, "tok-xyz", "https://api.vm0.ai")
-
-        assert exc_info.value.status == status
-        assert exc_info.value.code == code
-        assert str(exc_info.value) == message
-        assert exc_info.value.connectors == connectors
-        assert exc_info.value.failure_reason == expected_failure_reason
-
-    def test_structured_http_error_at_body_limit_is_preserved(self):
-        error_body = json.dumps(
-            {
-                "error": {
-                    "message": "Access token expired and refresh failed for: notion.",
-                    "code": "TOKEN_REFRESH_FAILED",
-                }
-            }
-        ).encode()
-        http_error = _http_error(
-            "https://api.vm0.ai/api/webhooks/agent/firewall/auth",
-            502,
-            "Bad Gateway",
-            error_body,
+            400,
+            "Bad Request",
+            Message(),
+            _UnreadableHttpErrorBody(),
         )
         http_error.close = MagicMock()
 
         with (
-            patch.object(
-                auth,
-                "MAX_FIREWALL_AUTH_RESPONSE_BODY_BYTES",
-                len(error_body),
-            ),
             patch("auth.urllib.request.Request"),
             patch("auth.urllib.request.urlopen", side_effect=http_error),
             patch.object(auth, "VERCEL_BYPASS", ""),
-            pytest.raises(auth.FirewallAuthApiError) as exc_info,
+            pytest.raises(urllib.error.HTTPError) as exc_info,
         ):
             auth._fetch_firewall_headers_sync("iv:tag:data", {}, "tok-xyz", "https://api.vm0.ai")
 
-        assert exc_info.value.code == "TOKEN_REFRESH_FAILED"
+        assert exc_info.value is http_error
         http_error.close.assert_called_once()
 
-    def test_http_error_over_body_limit_raises_and_closes_response(self):
+    def test_closes_http_error_response_when_body_is_too_large(self):
         error_body = json.dumps(
             {
                 "error": {
@@ -1765,145 +1788,6 @@ class TestFetchFirewallHeaders:
             auth._fetch_firewall_headers_sync("iv:tag:data", {}, "tok-xyz", "https://api.vm0.ai")
 
         http_error.close.assert_called_once()
-
-    @pytest.mark.parametrize(
-        "error_body",
-        [
-            b"not-json",
-            b'"plain string"',
-            b"[1, 2, 3]",
-            b"{}",
-            json.dumps({"error": "not-a-dict"}).encode(),
-            json.dumps({"error": None}).encode(),
-            json.dumps({"error": {}}).encode(),
-        ],
-    )
-    def test_malformed_http_error_envelope_reraises_http_error(self, error_body: bytes):
-        http_error = _http_error(
-            "https://api.vm0.ai/api/webhooks/agent/firewall/auth",
-            400,
-            "Bad Request",
-            error_body,
-        )
-
-        with (
-            patch("auth.urllib.request.Request"),
-            patch("auth.urllib.request.urlopen", side_effect=http_error),
-            patch.object(auth, "VERCEL_BYPASS", ""),
-            pytest.raises(urllib.error.HTTPError) as exc_info,
-        ):
-            auth._fetch_firewall_headers_sync("iv:tag:data", {}, "tok-xyz", "https://api.vm0.ai")
-
-        assert exc_info.value is http_error
-
-    def test_unrecognized_error_envelope_reraises_http_error(self):
-        error_body = json.dumps(
-            {"error": {"message": "Bad Request", "code": "BAD_REQUEST"}}
-        ).encode()
-        http_error = _http_error(
-            "https://api.vm0.ai/api/webhooks/agent/firewall/auth",
-            400,
-            "Bad Request",
-            error_body,
-        )
-
-        with (
-            patch("auth.urllib.request.Request"),
-            patch("auth.urllib.request.urlopen", side_effect=http_error),
-            patch.object(auth, "VERCEL_BYPASS", ""),
-            pytest.raises(urllib.error.HTTPError) as exc_info,
-        ):
-            auth._fetch_firewall_headers_sync("iv:tag:data", {}, "tok-xyz", "https://api.vm0.ai")
-
-        assert exc_info.value is http_error
-
-    def test_http_error_body_read_failure_reraises_http_error(self):
-        http_error = urllib.error.HTTPError(
-            "https://api.vm0.ai/api/webhooks/agent/firewall/auth",
-            400,
-            "Bad Request",
-            Message(),
-            _UnreadableHttpErrorBody(),
-        )
-        http_error.close = MagicMock()
-
-        with (
-            patch("auth.urllib.request.Request"),
-            patch("auth.urllib.request.urlopen", side_effect=http_error),
-            patch.object(auth, "VERCEL_BYPASS", ""),
-            pytest.raises(urllib.error.HTTPError) as exc_info,
-        ):
-            auth._fetch_firewall_headers_sync("iv:tag:data", {}, "tok-xyz", "https://api.vm0.ai")
-
-        assert exc_info.value is http_error
-        http_error.close.assert_called_once()
-
-    @pytest.mark.parametrize(
-        ("code", "status", "reason", "exception_type", "default_message"),
-        [
-            (
-                "CONNECTOR_NOT_CONFIGURED",
-                424,
-                "Failed Dependency",
-                auth.ConnectorNotConfiguredError,
-                "Connector not configured",
-            ),
-            (
-                "INSUFFICIENT_CREDITS",
-                402,
-                "Payment Required",
-                auth.InsufficientCreditsError,
-                "Insufficient credits",
-            ),
-        ],
-    )
-    def test_known_error_with_non_string_message_uses_default(
-        self,
-        code: str,
-        status: int,
-        reason: str,
-        exception_type: type[Exception],
-        default_message: str,
-    ):
-        error_body = json.dumps(
-            {
-                "error": {
-                    "message": None,
-                    "code": code,
-                }
-            }
-        ).encode()
-        http_error = _http_error(
-            "https://api.vm0.ai/api/webhooks/agent/firewall/auth",
-            status,
-            reason,
-            error_body,
-        )
-
-        with (
-            patch("auth.urllib.request.Request"),
-            patch("auth.urllib.request.urlopen", side_effect=http_error),
-            patch.object(auth, "VERCEL_BYPASS", ""),
-            pytest.raises(exception_type) as exc_info,
-        ):
-            auth._fetch_firewall_headers_sync("iv:tag:data", {}, "tok-xyz", "https://api.vm0.ai")
-
-        assert str(exc_info.value) == default_message
-
-    def test_closes_response_on_success(self):
-        """Success path must close the urlopen response — FD leak guard (#10475)."""
-        mock_resp = MagicMock()
-        mock_resp.__enter__.return_value = mock_resp
-        mock_resp.read.return_value = json.dumps({"headers": {}}).encode()
-
-        with (
-            patch("auth.urllib.request.Request"),
-            patch("auth.urllib.request.urlopen", return_value=mock_resp),
-            patch.object(auth, "VERCEL_BYPASS", ""),
-        ):
-            auth._fetch_firewall_headers_sync("iv:tag:data", {}, "tok-xyz", "https://api.vm0.ai")
-
-        mock_resp.__exit__.assert_called_once()  # urllib external boundary (#9991)
 
     @pytest.mark.parametrize(
         ("error_body", "expected_exception"),
@@ -1943,22 +1827,3 @@ class TestFetchFirewallHeaders:
             auth._fetch_firewall_headers_sync("iv:tag:data", {}, "tok-xyz", "https://api.vm0.ai")
 
         http_error.close.assert_called_once()  # urllib external boundary (#9991)
-
-    async def test_async_wrapper_passes_api_url_from_ctx(self, headers):
-        """fetch_firewall_headers reads api_url on the event loop and passes it to the sync fn."""
-        mock_resp = MagicMock()
-        mock_resp.__enter__.return_value = mock_resp
-        mock_resp.read.return_value = json.dumps({"headers": {"Auth": "tok"}}).encode()
-
-        with (
-            patch.object(auth, "get_api_url", return_value="https://ctx-url.vm0.ai"),
-            patch("auth.urllib.request.Request") as mock_req_cls,
-            patch("auth.urllib.request.urlopen", return_value=mock_resp),
-            patch.object(auth, "VERCEL_BYPASS", ""),
-        ):
-            result = await auth.fetch_firewall_headers("enc", {}, "sandbox-tok")
-
-        assert result.payload.headers == {"Auth": "tok"}
-        # Verify the URL was built from the ctx-provided api_url
-        call_args = mock_req_cls.call_args
-        assert call_args[0][0] == "https://ctx-url.vm0.ai/api/webhooks/agent/firewall/auth"


### PR DESCRIPTION
## Summary

- Extract the fake firewall auth endpoint into a shared mitm-addon test helper.
- Move broad firewall auth fetch behavior coverage to the public `fetch_firewall_headers()` entry point using the fake local endpoint.
- Keep parser/body-reader/resource-close coverage scoped to narrow boundary tests, with direct `_fetch_firewall_headers_sync()` use limited to FD-leak/resource-close regressions.

Closes #16069

## Tests

- `pytest tests/test_auth_cache.py`
- `pytest tests/test_firewall_auth.py`
- `pytest tests/test_firewall_auth.py tests/test_auth_cache.py`
- `ruff check tests/auth_endpoint_helpers.py tests/test_auth_cache.py tests/test_firewall_auth.py`
- `ruff format --check tests/auth_endpoint_helpers.py tests/test_auth_cache.py tests/test_firewall_auth.py`
- `basedpyright tests/auth_endpoint_helpers.py tests/test_auth_cache.py tests/test_firewall_auth.py`
- `pytest tests/`
