### PR TITLE
fix: reject invalid registry vm entries before auth

### DIFF
--- a/crates/runner/mitm-addon/src/mitm_addon.py
+++ b/crates/runner/mitm-addon/src/mitm_addon.py
@@ -427,8 +427,9 @@ async def request(flow: http.HTTPFlow) -> None:
     Intercept request: inject firewall auth headers for configured firewall rules.
 
     Order:
-    1. VM0 API auto-allow (agent must always reach the platform)
-    2. Firewall match (inject auth headers for allowed requests)
+    1. Registry gate (block unavailable or invalid registered VM state)
+    2. VM0 API auto-allow (agent must always reach the platform)
+    3. Firewall match (inject auth headers for allowed requests)
     """
     # Get client IP (source VM)
     client_ip = flow.client_conn.peername[0] if flow.client_conn.peername else None

--- a/crates/runner/mitm-addon/src/mitm_addon.py
+++ b/crates/runner/mitm-addon/src/mitm_addon.py
@@ -370,6 +370,25 @@ def _block_registry_unavailable(
     )
 
 
+def _block_invalid_registry_vm(
+    flow: http.HTTPFlow,
+    invalid_vm: registry.InvalidVmEntry,
+) -> None:
+    flow.metadata[metadata_keys.FIREWALL_ACTION] = "BLOCK"
+    flow.metadata[metadata_keys.FIREWALL_ERROR] = "invalid_registry_vm"
+    flow.response = http.Response.make(
+        503,
+        json.dumps(
+            {
+                "error": "invalid_registry_vm",
+                "message": invalid_vm.message,
+                "reason": invalid_vm.reason,
+            }
+        ).encode(),
+        {"Content-Type": "application/json"},
+    )
+
+
 # ============================================================================
 # TLS ClientHello Handler
 # ============================================================================
@@ -389,7 +408,7 @@ def tls_clienthello(data: tls.ClientHelloData) -> None:
     if isinstance(registry_state, registry.RegistryUnavailable):
         return
 
-    if client_ip not in registry_state.vms:
+    if client_ip not in registry_state.vms and client_ip not in registry_state.invalid_vms:
         # Not a registered VM - pass through without MITM interception
         # This is critical for CIDR-based rules where all VM traffic is redirected
         data.ignore_connection = True
@@ -427,6 +446,10 @@ async def request(flow: http.HTTPFlow) -> None:
     # the registry file loaded successfully; unavailable registry is blocked above.
     vm_info = registry_state.vms.get(client_ip)
     if vm_info is None:
+        invalid_vm = registry_state.invalid_vms.get(client_ip)
+        if invalid_vm is not None:
+            _block_invalid_registry_vm(flow, invalid_vm)
+            return
         # Not a registered VM, pass through without proxying
         return
     compiled_firewalls = registry_state.compiled_firewalls.get(client_ip)
@@ -911,6 +934,8 @@ def tcp_start(flow: tcp.TCPFlow) -> None:
 
     vm_info = registry_state.vms.get(client_ip)
     if not vm_info:
+        if client_ip in registry_state.invalid_vms:
+            flow.kill()
         return
 
     flow.metadata[metadata_keys.VM_RUN_ID] = vm_info.get("runId", "")

--- a/crates/runner/mitm-addon/src/mitm_addon.py
+++ b/crates/runner/mitm-addon/src/mitm_addon.py
@@ -491,11 +491,11 @@ async def request(flow: http.HTTPFlow) -> None:
 
         hostname = trusted_authority.host.lower()
 
-        # --- Step 1: Auto-allow VM0 API requests ---
+        # --- Step 2: Auto-allow VM0 API requests ---
         # The agent MUST be able to communicate with the platform (heartbeat,
         # logs, CLI auth, etc.). Exception: `/api/test/*` routes exist only to
         # exercise the firewall pipeline itself (e.g. the test-oauth provider),
-        # so they must go through Step 2 and get their auth injected by the
+        # so they must go through Step 3 and get their auth injected by the
         # matching firewall — otherwise the E2E tests that back them would
         # auto-allow past the thing they're supposed to exercise.
         api_url = get_api_url()
@@ -510,7 +510,7 @@ async def request(flow: http.HTTPFlow) -> None:
                 flow.metadata[metadata_keys.FIREWALL_ACTION] = "ALLOW"
                 return
 
-        # --- Step 2: Firewall match with permission check ---
+        # --- Step 3: Firewall match with permission check ---
         # Match base URL, then check permission rules before injecting auth headers.
         if compiled_firewalls:
             result = matching.match_compiled_firewall_request(

--- a/crates/runner/mitm-addon/src/mitm_addon.py
+++ b/crates/runner/mitm-addon/src/mitm_addon.py
@@ -933,7 +933,7 @@ def tcp_start(flow: tcp.TCPFlow) -> None:
         return
 
     vm_info = registry_state.vms.get(client_ip)
-    if not vm_info:
+    if vm_info is None:
         if client_ip in registry_state.invalid_vms:
             flow.kill()
         return

--- a/crates/runner/mitm-addon/src/registry.py
+++ b/crates/runner/mitm-addon/src/registry.py
@@ -184,10 +184,10 @@ def load_registry_state(registry_path: str) -> RegistryState:
     publishes raw and compiled registry state together in a snapshot keyed by
     file identity metadata. Registry file stat/read/parse failures publish a
     separate unavailable state instead of returning a stale snapshot for
-    enforcement. Malformed registry input is recorded separately as a failed key
-    so repeated reads of the same bad bytes do not reparse or re-warn. File read
-    errors keep retrying that key, and internal compile/eviction errors are
-    allowed to propagate.
+    enforcement. Malformed registry document input is recorded separately as a
+    failed key so repeated reads of the same bad bytes do not reparse or
+    re-warn. File read errors keep retrying that key, and internal
+    compile/eviction errors are allowed to propagate.
     """
     path = Path(registry_path)
     path_key = _path_key(path)

--- a/crates/runner/mitm-addon/src/registry.py
+++ b/crates/runner/mitm-addon/src/registry.py
@@ -146,7 +146,7 @@ def _classify_registry_vms(raw_registry: dict) -> tuple[dict, dict[str, InvalidV
                 "proxy registry VM entry runId must be a string",
             )
             continue
-        if not run_id:
+        if not run_id.strip():
             invalid_vms[client_ip] = _invalid_vm_entry(
                 "empty_run_id",
                 "proxy registry VM entry runId must be non-empty",

--- a/crates/runner/mitm-addon/src/registry.py
+++ b/crates/runner/mitm-addon/src/registry.py
@@ -117,23 +117,19 @@ def _compile_registry(
     return compiled_firewall_registry, compiled_policy_registry
 
 
-def _invalid_vm_entry(reason: str, message: str) -> InvalidVmEntry:
-    return InvalidVmEntry(reason=reason, message=message)
-
-
 def _classify_registry_vms(raw_registry: dict) -> tuple[dict, dict[str, InvalidVmEntry]]:
     new_registry: dict = {}
     invalid_vms: dict[str, InvalidVmEntry] = {}
     for client_ip, vm in raw_registry.items():
         if not isinstance(vm, dict):
-            invalid_vms[client_ip] = _invalid_vm_entry(
+            invalid_vms[client_ip] = InvalidVmEntry(
                 "invalid_vm_entry",
                 "proxy registry VM entry must be an object",
             )
             continue
 
         if "runId" not in vm:
-            invalid_vms[client_ip] = _invalid_vm_entry(
+            invalid_vms[client_ip] = InvalidVmEntry(
                 "missing_run_id",
                 "proxy registry VM entry is missing runId",
             )
@@ -141,13 +137,13 @@ def _classify_registry_vms(raw_registry: dict) -> tuple[dict, dict[str, InvalidV
 
         run_id = vm["runId"]
         if not isinstance(run_id, str):
-            invalid_vms[client_ip] = _invalid_vm_entry(
+            invalid_vms[client_ip] = InvalidVmEntry(
                 "invalid_run_id",
                 "proxy registry VM entry runId must be a string",
             )
             continue
         if not run_id.strip():
-            invalid_vms[client_ip] = _invalid_vm_entry(
+            invalid_vms[client_ip] = InvalidVmEntry(
                 "empty_run_id",
                 "proxy registry VM entry runId must be non-empty",
             )

--- a/crates/runner/mitm-addon/src/registry.py
+++ b/crates/runner/mitm-addon/src/registry.py
@@ -22,8 +22,17 @@ class _RegistryFormatError(ValueError):
 
 
 @dataclass(frozen=True)
+class InvalidVmEntry:
+    """Registry entry present for an IP but invalid for runtime VM context use."""
+
+    reason: str
+    message: str
+
+
+@dataclass(frozen=True)
 class _RegistrySnapshot:
     vms: dict
+    invalid_vms: dict[str, InvalidVmEntry]
     compiled_firewalls: dict[str, matching.CompiledFirewallSet]
     compiled_network_policies: dict[str, matching.CompiledNetworkPolicies]
     loaded_key: _RegistryCacheKey | None
@@ -41,7 +50,7 @@ RegistryState = _RegistrySnapshot | RegistryUnavailable
 
 
 def _empty_snapshot() -> _RegistrySnapshot:
-    return _RegistrySnapshot({}, {}, {}, None)
+    return _RegistrySnapshot({}, {}, {}, {}, None)
 
 
 @dataclass
@@ -108,9 +117,45 @@ def _compile_registry(
     return compiled_firewall_registry, compiled_policy_registry
 
 
-def _normalize_registry_vms(raw_registry: dict) -> tuple[dict, int]:
-    new_registry = {client_ip: vm for client_ip, vm in raw_registry.items() if isinstance(vm, dict)}
-    return new_registry, len(raw_registry) - len(new_registry)
+def _invalid_vm_entry(reason: str, message: str) -> InvalidVmEntry:
+    return InvalidVmEntry(reason=reason, message=message)
+
+
+def _classify_registry_vms(raw_registry: dict) -> tuple[dict, dict[str, InvalidVmEntry]]:
+    new_registry: dict = {}
+    invalid_vms: dict[str, InvalidVmEntry] = {}
+    for client_ip, vm in raw_registry.items():
+        if not isinstance(vm, dict):
+            invalid_vms[client_ip] = _invalid_vm_entry(
+                "invalid_vm_entry",
+                "proxy registry VM entry must be an object",
+            )
+            continue
+
+        if "runId" not in vm:
+            invalid_vms[client_ip] = _invalid_vm_entry(
+                "missing_run_id",
+                "proxy registry VM entry is missing runId",
+            )
+            continue
+
+        run_id = vm["runId"]
+        if not isinstance(run_id, str):
+            invalid_vms[client_ip] = _invalid_vm_entry(
+                "invalid_run_id",
+                "proxy registry VM entry runId must be a string",
+            )
+            continue
+        if not run_id:
+            invalid_vms[client_ip] = _invalid_vm_entry(
+                "empty_run_id",
+                "proxy registry VM entry runId must be non-empty",
+            )
+            continue
+
+        new_registry[client_ip] = vm
+
+    return new_registry, invalid_vms
 
 
 def _read_registry_vms(path: Path) -> dict:
@@ -190,9 +235,9 @@ def load_registry_state(registry_path: str) -> RegistryState:
         ctx.log.warn(f"Failed to parse proxy registry: {message}")
         return _mark_unavailable(state, reason="parse_failed", message=message)
 
-    new_registry, malformed_vm_count = _normalize_registry_vms(raw_registry)
-    if malformed_vm_count:
-        ctx.log.warn(f"Skipped {malformed_vm_count} malformed proxy registry VM entries")
+    new_registry, invalid_vms = _classify_registry_vms(raw_registry)
+    if invalid_vms:
+        ctx.log.warn(f"Rejected {len(invalid_vms)} invalid proxy registry VM entries")
     new_compiled_registry, new_compiled_policy_registry = _compile_registry(new_registry)
 
     # Evict cache entries for runs no longer in the registry.
@@ -205,6 +250,7 @@ def load_registry_state(registry_path: str) -> RegistryState:
 
     state.snapshot = _RegistrySnapshot(
         new_registry,
+        invalid_vms,
         new_compiled_registry,
         new_compiled_policy_registry,
         key,

--- a/crates/runner/mitm-addon/src/registry.py
+++ b/crates/runner/mitm-addon/src/registry.py
@@ -148,6 +148,12 @@ def _classify_registry_vms(raw_registry: dict) -> tuple[dict, dict[str, InvalidV
                 "proxy registry VM entry runId must be non-empty",
             )
             continue
+        if run_id != run_id.strip():
+            invalid_vms[client_ip] = InvalidVmEntry(
+                "invalid_run_id",
+                "proxy registry VM entry runId must not include leading or trailing whitespace",
+            )
+            continue
 
         new_registry[client_ip] = vm
 

--- a/crates/runner/mitm-addon/src/registry.py
+++ b/crates/runner/mitm-addon/src/registry.py
@@ -108,11 +108,11 @@ def _compile_registry(
     compiled_firewall_registry: dict[str, matching.CompiledFirewallSet] = {}
     compiled_policy_registry: dict[str, matching.CompiledNetworkPolicies] = {}
     for client_ip, vm in new_registry.items():
-        firewalls = vm.get("firewalls") if isinstance(vm, dict) else None
+        firewalls = vm.get("firewalls")
         compiled_firewalls = matching.compile_firewalls(firewalls)
         if compiled_firewalls is not None:
             compiled_firewall_registry[client_ip] = compiled_firewalls
-        network_policies = vm.get("networkPolicies") if isinstance(vm, dict) else None
+        network_policies = vm.get("networkPolicies")
         compiled_policy_registry[client_ip] = matching.compile_network_policies(network_policies)
     return compiled_firewall_registry, compiled_policy_registry
 
@@ -237,11 +237,7 @@ def load_registry_state(registry_path: str) -> RegistryState:
     new_compiled_registry, new_compiled_policy_registry = _compile_registry(new_registry)
 
     # Evict cache entries for runs no longer in the registry.
-    active_run_ids = {
-        run_id
-        for vm in new_registry.values()
-        if isinstance(run_id := vm.get("runId"), str) and run_id
-    }
+    active_run_ids = {vm["runId"] for vm in new_registry.values()}
     evict_stale_cache_keys(active_run_ids)
 
     state.snapshot = _RegistrySnapshot(

--- a/crates/runner/mitm-addon/tests/test_connection_hooks.py
+++ b/crates/runner/mitm-addon/tests/test_connection_hooks.py
@@ -392,6 +392,16 @@ class TestTlsClienthello:
         # All registered VMs use MITM — should NOT set ignore_connection
         assert data.ignore_connection is False
 
+    def test_invalid_registered_vm_allows_mitm(self, tmp_path, make_tls_data, mitm_ctx):
+        registry_file = tmp_path / "registry.json"
+        registry_file.write_text(json.dumps({"vms": {"10.200.0.9": "broken"}, "updatedAt": 0}))
+        data = make_tls_data(client_ip="10.200.0.9", sni="anything.com")
+
+        with mitm_ctx(registry_path=str(registry_file), api_url="https://api.vm0.ai"):
+            mitm_addon.tls_clienthello(data)
+
+        assert data.ignore_connection is False
+
     def test_registry_unavailable_does_not_ignore_connection(
         self, registry_file, make_tls_data, mitm_ctx
     ):
@@ -443,6 +453,19 @@ class TestTcpStart:
         registry.load_registry(str(registry_file))
         registry_file.unlink()
         flow = real_tcp_flow(client_ip="10.200.0.1")
+
+        with mitm_ctx(registry_path=str(registry_file)):
+            mitm_addon.tcp_start(flow)
+
+        assert flow.error is not None
+        assert flow.error.msg == Error.KILLED_MESSAGE
+        assert not flow.live
+        assert "vm_run_id" not in flow.metadata
+
+    def test_invalid_registered_vm_kills_flow(self, tmp_path, mitm_ctx, real_tcp_flow):
+        registry_file = tmp_path / "registry.json"
+        registry_file.write_text(json.dumps({"vms": {"10.200.0.9": {"runId": ""}}, "updatedAt": 0}))
+        flow = real_tcp_flow(client_ip="10.200.0.9")
 
         with mitm_ctx(registry_path=str(registry_file)):
             mitm_addon.tcp_start(flow)

--- a/crates/runner/mitm-addon/tests/test_registry.py
+++ b/crates/runner/mitm-addon/tests/test_registry.py
@@ -249,8 +249,7 @@ class TestLoadRegistry:
         assert "Failed to stat" in log.warn.call_args_list[0].args[0]
 
     def test_missing_file_after_success_marks_registry_unavailable(self, registry_file):
-        with patch.object(registry.ctx, "log", MagicMock(), create=True):
-            registry.load_registry(str(registry_file))
+        registry.load_registry(str(registry_file))
         registry_file.unlink()
 
         log = MagicMock()
@@ -283,8 +282,7 @@ class TestLoadRegistry:
         assert "Failed to parse" in log.warn.call_args_list[0].args[0]
 
     def test_parse_failure_after_success_marks_registry_unavailable(self, registry_file):
-        with patch.object(registry.ctx, "log", MagicMock(), create=True):
-            registry.load_registry(str(registry_file))
+        registry.load_registry(str(registry_file))
         registry_file.write_text("{ not valid json after success")
 
         log = MagicMock()

--- a/crates/runner/mitm-addon/tests/test_registry.py
+++ b/crates/runner/mitm-addon/tests/test_registry.py
@@ -574,6 +574,70 @@ class TestLoadRegistry:
         assert force_refresh_pending(("run-active", "api-0"))
         assert last_force_refresh_at(("run-active", "api-0")) == 200.0
 
+    def test_valid_entry_becoming_invalid_evicts_context_and_cache(self, tmp_path):
+        registry_file = tmp_path / "registry.json"
+        _write_firewall_registry(registry_file)
+
+        context = registry.get_vm_context("10.200.0.1", str(registry_file))
+        assert context is not None
+        _, compiled_firewalls, _ = context
+        assert compiled_firewalls is not None
+        set_cached_headers(
+            ("run-abc-123", "api-0"),
+            headers={"Authorization": "Bearer tok"},
+        )
+
+        registry_file.write_text(
+            json.dumps(
+                {
+                    "vms": {
+                        "10.200.0.1": {"runId": ""},
+                    },
+                    "updatedAt": 0,
+                }
+            )
+        )
+
+        with patch.object(registry.ctx, "log", MagicMock(), create=True):
+            state = registry.load_registry_state(str(registry_file))
+
+        assert not isinstance(state, registry.RegistryUnavailable)
+        assert state.vms == {}
+        assert set(state.invalid_vms) == {"10.200.0.1"}
+        assert state.compiled_firewalls == {}
+        assert state.compiled_network_policies == {}
+        assert registry.get_vm_context("10.200.0.1", str(registry_file)) is None
+        assert not has_auth_state(("run-abc-123", "api-0"))
+
+    def test_invalid_entry_can_recover_to_valid_context(self, tmp_path):
+        path = tmp_path / "registry.json"
+        path.write_text(json.dumps({"vms": {"10.200.0.1": {"runId": ""}}, "updatedAt": 0}))
+
+        with patch.object(registry.ctx, "log", MagicMock(), create=True):
+            invalid_state = registry.load_registry_state(str(path))
+
+        assert not isinstance(invalid_state, registry.RegistryUnavailable)
+        assert invalid_state.vms == {}
+        assert set(invalid_state.invalid_vms) == {"10.200.0.1"}
+
+        path.write_text(
+            json.dumps(
+                {
+                    "vms": {
+                        "10.200.0.1": {"runId": "run-recovered"},
+                    },
+                    "updatedAt": 1,
+                }
+            )
+        )
+
+        recovered_state = registry.load_registry_state(str(path))
+
+        assert not isinstance(recovered_state, registry.RegistryUnavailable)
+        assert recovered_state.vms["10.200.0.1"]["runId"] == "run-recovered"
+        assert recovered_state.invalid_vms == {}
+        assert registry.get_vm_info("10.200.0.1", str(path)) == {"runId": "run-recovered"}
+
     def test_malformed_vm_entries_do_not_block_header_cache_eviction(self, registry_file):
         """Malformed VM entries are not active cache owners."""
         registry.load_registry(str(registry_file))

--- a/crates/runner/mitm-addon/tests/test_registry.py
+++ b/crates/runner/mitm-addon/tests/test_registry.py
@@ -542,7 +542,7 @@ class TestLoadRegistry:
         assert not has_auth_state(("run-abc-123", "api-0"))
 
     def test_registry_entries_without_run_id_do_not_keep_header_cache(self, registry_file):
-        """Registry entries with missing/empty runId are not active cache owners."""
+        """Registry entries with missing or blank runId are not active cache owners."""
         registry.load_registry(str(registry_file))
 
         set_cached_headers(("", "api-0"), headers={})
@@ -638,8 +638,8 @@ class TestLoadRegistry:
         assert recovered_state.invalid_vms == {}
         assert registry.get_vm_info("10.200.0.1", str(path)) == {"runId": "run-recovered"}
 
-    def test_malformed_vm_entries_do_not_block_header_cache_eviction(self, registry_file):
-        """Malformed VM entries are not active cache owners."""
+    def test_invalid_vm_entries_do_not_block_header_cache_eviction(self, registry_file):
+        """Invalid VM entries are not active cache owners."""
         registry.load_registry(str(registry_file))
 
         set_cached_headers(("run-old", "api-0"), headers={})

--- a/crates/runner/mitm-addon/tests/test_registry.py
+++ b/crates/runner/mitm-addon/tests/test_registry.py
@@ -95,6 +95,7 @@ class TestLoadRegistry:
                         "10.200.0.3": {},
                         "10.200.0.4": {"runId": ""},
                         "10.200.0.5": {"runId": 123},
+                        "10.200.0.6": {"runId": "  \t"},
                     },
                     "updatedAt": 0,
                 }
@@ -111,11 +112,13 @@ class TestLoadRegistry:
             "10.200.0.3",
             "10.200.0.4",
             "10.200.0.5",
+            "10.200.0.6",
         }
         assert state.invalid_vms["10.200.0.2"].reason == "invalid_vm_entry"
         assert state.invalid_vms["10.200.0.3"].reason == "missing_run_id"
         assert state.invalid_vms["10.200.0.4"].reason == "empty_run_id"
         assert state.invalid_vms["10.200.0.5"].reason == "invalid_run_id"
+        assert state.invalid_vms["10.200.0.6"].reason == "empty_run_id"
 
     def test_missing_file_returns_empty(self, tmp_path):
         missing = str(tmp_path / "nonexistent.json")
@@ -556,6 +559,7 @@ class TestLoadRegistry:
                         "10.200.0.1": {"runId": ""},
                         "10.200.0.2": {},
                         "10.200.0.3": {"runId": "run-active"},
+                        "10.200.0.4": {"runId": "  \t"},
                     },
                     "updatedAt": 0,
                 }

--- a/crates/runner/mitm-addon/tests/test_registry.py
+++ b/crates/runner/mitm-addon/tests/test_registry.py
@@ -96,6 +96,7 @@ class TestLoadRegistry:
                         "10.200.0.4": {"runId": ""},
                         "10.200.0.5": {"runId": 123},
                         "10.200.0.6": {"runId": "  \t"},
+                        "10.200.0.7": {"runId": " run-active "},
                     },
                     "updatedAt": 0,
                 }
@@ -113,12 +114,14 @@ class TestLoadRegistry:
             "10.200.0.4",
             "10.200.0.5",
             "10.200.0.6",
+            "10.200.0.7",
         }
         assert state.invalid_vms["10.200.0.2"].reason == "invalid_vm_entry"
         assert state.invalid_vms["10.200.0.3"].reason == "missing_run_id"
         assert state.invalid_vms["10.200.0.4"].reason == "empty_run_id"
         assert state.invalid_vms["10.200.0.5"].reason == "invalid_run_id"
         assert state.invalid_vms["10.200.0.6"].reason == "empty_run_id"
+        assert state.invalid_vms["10.200.0.7"].reason == "invalid_run_id"
 
     def test_missing_file_returns_empty(self, tmp_path):
         missing = str(tmp_path / "nonexistent.json")
@@ -560,6 +563,7 @@ class TestLoadRegistry:
                         "10.200.0.2": {},
                         "10.200.0.3": {"runId": "run-active"},
                         "10.200.0.4": {"runId": "  \t"},
+                        "10.200.0.5": {"runId": " run-active "},
                     },
                     "updatedAt": 0,
                 }

--- a/crates/runner/mitm-addon/tests/test_registry.py
+++ b/crates/runner/mitm-addon/tests/test_registry.py
@@ -84,6 +84,39 @@ class TestLoadRegistry:
         assert "10.200.0.1" in result
         assert result["10.200.0.1"]["runId"] == "run-abc-123"
 
+    def test_classifies_invalid_registered_vm_entries(self, tmp_path):
+        path = tmp_path / "registry.json"
+        path.write_text(
+            json.dumps(
+                {
+                    "vms": {
+                        "10.200.0.1": {"runId": "run-active"},
+                        "10.200.0.2": "broken",
+                        "10.200.0.3": {},
+                        "10.200.0.4": {"runId": ""},
+                        "10.200.0.5": {"runId": 123},
+                    },
+                    "updatedAt": 0,
+                }
+            )
+        )
+
+        with patch.object(registry.ctx, "log", MagicMock(), create=True):
+            state = registry.load_registry_state(str(path))
+
+        assert not isinstance(state, registry.RegistryUnavailable)
+        assert set(state.vms) == {"10.200.0.1"}
+        assert set(state.invalid_vms) == {
+            "10.200.0.2",
+            "10.200.0.3",
+            "10.200.0.4",
+            "10.200.0.5",
+        }
+        assert state.invalid_vms["10.200.0.2"].reason == "invalid_vm_entry"
+        assert state.invalid_vms["10.200.0.3"].reason == "missing_run_id"
+        assert state.invalid_vms["10.200.0.4"].reason == "empty_run_id"
+        assert state.invalid_vms["10.200.0.5"].reason == "invalid_run_id"
+
     def test_missing_file_returns_empty(self, tmp_path):
         missing = str(tmp_path / "nonexistent.json")
         with patch.object(registry.ctx, "log", MagicMock(), create=True):
@@ -174,7 +207,7 @@ class TestLoadRegistry:
         assert second["10.200.0.1"]["runId"] == "run-two"
         assert second is not first
 
-    def test_non_dict_vm_entries_are_filtered_without_blocking_valid_vms(self, tmp_path):
+    def test_invalid_vm_entries_do_not_block_valid_vms(self, tmp_path):
         path = tmp_path / "registry.json"
         path.write_text(
             json.dumps(
@@ -200,7 +233,7 @@ class TestLoadRegistry:
         assert cached is result
         assert log.warn.call_count == 1
         warning = log.warn.call_args_list[0].args[0]
-        assert "Skipped 4 malformed proxy registry VM entries" in warning
+        assert "Rejected 4 invalid proxy registry VM entries" in warning
         assert "10.200.0.2" not in warning
         assert "good-run" not in warning
 
@@ -216,7 +249,8 @@ class TestLoadRegistry:
         assert "Failed to stat" in log.warn.call_args_list[0].args[0]
 
     def test_missing_file_after_success_marks_registry_unavailable(self, registry_file):
-        registry.load_registry(str(registry_file))
+        with patch.object(registry.ctx, "log", MagicMock(), create=True):
+            registry.load_registry(str(registry_file))
         registry_file.unlink()
 
         log = MagicMock()
@@ -249,7 +283,8 @@ class TestLoadRegistry:
         assert "Failed to parse" in log.warn.call_args_list[0].args[0]
 
     def test_parse_failure_after_success_marks_registry_unavailable(self, registry_file):
-        registry.load_registry(str(registry_file))
+        with patch.object(registry.ctx, "log", MagicMock(), create=True):
+            registry.load_registry(str(registry_file))
         registry_file.write_text("{ not valid json after success")
 
         log = MagicMock()
@@ -529,7 +564,8 @@ class TestLoadRegistry:
             )
         )
 
-        registry.load_registry(str(registry_file))
+        with patch.object(registry.ctx, "log", MagicMock(), create=True):
+            registry.load_registry(str(registry_file))
 
         assert not has_auth_state(("", "api-0"))
         assert cached_headers(("run-active", "api-0"))
@@ -584,7 +620,7 @@ class TestGetVmInfo:
 
         assert info is None
 
-    def test_malformed_entry_is_unknown_ip(self, tmp_path):
+    def test_invalid_entry_has_no_usable_vm_info(self, tmp_path):
         path = tmp_path / "registry.json"
         path.write_text(
             json.dumps(
@@ -603,6 +639,10 @@ class TestGetVmInfo:
             assert vm_info is not None
             assert vm_info["runId"] == "good-run"
             assert registry.get_vm_info("10.200.0.2", str(path)) is None
+            state = registry.load_registry_state(str(path))
+
+        assert not isinstance(state, registry.RegistryUnavailable)
+        assert set(state.invalid_vms) == {"10.200.0.2"}
 
 
 class TestGetVmContext:
@@ -631,7 +671,7 @@ class TestGetVmContext:
         assert isinstance(result, matching.FirewallAllow)
         assert result.api_entry is vm_info["firewalls"][0]["apis"][0]
 
-    def test_malformed_entry_has_no_context(self, tmp_path):
+    def test_invalid_entry_has_no_context(self, tmp_path):
         path = tmp_path / "registry.json"
         path.write_text(
             json.dumps(
@@ -648,6 +688,10 @@ class TestGetVmContext:
         with patch.object(registry.ctx, "log", MagicMock(), create=True):
             assert registry.get_vm_context("10.200.0.1", str(path)) is not None
             assert registry.get_vm_context("10.200.0.2", str(path)) is None
+            state = registry.load_registry_state(str(path))
+
+        assert not isinstance(state, registry.RegistryUnavailable)
+        assert set(state.invalid_vms) == {"10.200.0.2"}
 
     def test_compiled_context_updates_after_successful_registry_change(self, tmp_path):
         path = tmp_path / "registry.json"

--- a/crates/runner/mitm-addon/tests/test_request_handler_passthrough.py
+++ b/crates/runner/mitm-addon/tests/test_request_handler_passthrough.py
@@ -185,6 +185,36 @@ async def test_invalid_registered_vm_blocks_before_auth_injection(
     assert flow.metadata["firewall_error"] == "invalid_registry_vm"
 
 
+async def test_invalid_registered_vm_non_object_blocks_before_auth_injection(
+    tmp_path,
+    real_flow,
+    mitm_ctx,
+    fake_firewall_headers,
+):
+    reg_path = tmp_path / "registry.json"
+    reg_path.write_text(json.dumps({"vms": {"10.200.0.5": "broken"}, "updatedAt": 0}))
+    flow = real_flow(with_response=False, client_ip="10.200.0.5", host="api.github.com")
+
+    with (
+        mitm_ctx(registry_path=str(reg_path), api_url="https://api.vm0.ai"),
+        fake_firewall_headers() as auth_fetch,
+    ):
+        await mitm_addon.request(flow)
+
+    assert flow.response is not None
+    assert flow.response.status_code == 503
+    assert json.loads(flow.response.content) == {
+        "error": "invalid_registry_vm",
+        "message": "proxy registry VM entry must be an object",
+        "reason": "invalid_vm_entry",
+    }
+    auth_fetch.assert_not_called()
+    assert "vm_run_id" not in flow.metadata
+    assert "firewall_base" not in flow.metadata
+    assert flow.metadata["firewall_action"] == "BLOCK"
+    assert flow.metadata["firewall_error"] == "invalid_registry_vm"
+
+
 async def test_tracks_start_time(registry_file, real_flow, mitm_ctx):
     flow = real_flow(with_response=False, host="api.anthropic.com")
 

--- a/crates/runner/mitm-addon/tests/test_request_handler_passthrough.py
+++ b/crates/runner/mitm-addon/tests/test_request_handler_passthrough.py
@@ -129,6 +129,7 @@ async def test_registry_unavailable_blocks_before_auth_injection(tmp_path, real_
     ("run_id_value", "expected_reason", "expected_message"),
     [
         ("", "empty_run_id", "proxy registry VM entry runId must be non-empty"),
+        ("  \t", "empty_run_id", "proxy registry VM entry runId must be non-empty"),
         (None, "missing_run_id", "proxy registry VM entry is missing runId"),
         (123, "invalid_run_id", "proxy registry VM entry runId must be a string"),
     ],

--- a/crates/runner/mitm-addon/tests/test_request_handler_passthrough.py
+++ b/crates/runner/mitm-addon/tests/test_request_handler_passthrough.py
@@ -130,6 +130,7 @@ async def test_registry_unavailable_blocks_before_auth_injection(tmp_path, real_
     [
         ("", "empty_run_id", "proxy registry VM entry runId must be non-empty"),
         (None, "missing_run_id", "proxy registry VM entry is missing runId"),
+        (123, "invalid_run_id", "proxy registry VM entry runId must be a string"),
     ],
 )
 async def test_invalid_registered_vm_blocks_before_auth_injection(

--- a/crates/runner/mitm-addon/tests/test_request_handler_passthrough.py
+++ b/crates/runner/mitm-addon/tests/test_request_handler_passthrough.py
@@ -2,9 +2,12 @@
 
 import json
 
+import pytest
+
 import flow_metadata_keys as metadata_keys
 import mitm_addon
 import registry
+from tests.auth_state_helpers import has_auth_state
 from tests.request_handler_helpers import _single_firewall_vm, _write_registry
 
 
@@ -120,6 +123,64 @@ async def test_registry_unavailable_blocks_before_auth_injection(tmp_path, real_
     assert flow.metadata["firewall_action"] == "BLOCK"
     assert flow.metadata["firewall_error"] == "registry_unavailable"
     assert "firewall_base" not in flow.metadata
+
+
+@pytest.mark.parametrize(
+    ("run_id_value", "expected_reason", "expected_message"),
+    [
+        ("", "empty_run_id", "proxy registry VM entry runId must be non-empty"),
+        (None, "missing_run_id", "proxy registry VM entry is missing runId"),
+    ],
+)
+async def test_invalid_registered_vm_blocks_before_auth_injection(
+    tmp_path,
+    real_flow,
+    mitm_ctx,
+    fake_firewall_headers,
+    run_id_value,
+    expected_reason,
+    expected_message,
+):
+    vm_info = _single_firewall_vm(
+        tmp_path,
+        api_entry={
+            "base": "https://api.github.com",
+            "auth": {"headers": {"Authorization": "Bearer secret"}},
+            "permissions": [{"name": "full-access", "rules": ["ANY /{path+}"]}],
+        },
+        network_policy={
+            "allow": ["full-access"],
+            "deny": [],
+            "ask": [],
+            "unknownPolicy": "allow",
+        },
+    )
+    if run_id_value is None:
+        del vm_info["runId"]
+    else:
+        vm_info["runId"] = run_id_value
+    reg_path = _write_registry(tmp_path, client_ip="10.200.0.5", vm_info=vm_info)
+    flow = real_flow(with_response=False, client_ip="10.200.0.5", host="api.github.com")
+
+    with (
+        mitm_ctx(registry_path=str(reg_path), api_url="https://api.vm0.ai"),
+        fake_firewall_headers() as auth_fetch,
+    ):
+        await mitm_addon.request(flow)
+
+    assert flow.response is not None
+    assert flow.response.status_code == 503
+    assert json.loads(flow.response.content) == {
+        "error": "invalid_registry_vm",
+        "message": expected_message,
+        "reason": expected_reason,
+    }
+    auth_fetch.assert_not_called()
+    assert not has_auth_state(("", "https://api.github.com"))
+    assert "vm_run_id" not in flow.metadata
+    assert "firewall_base" not in flow.metadata
+    assert flow.metadata["firewall_action"] == "BLOCK"
+    assert flow.metadata["firewall_error"] == "invalid_registry_vm"
 
 
 async def test_tracks_start_time(registry_file, real_flow, mitm_ctx):

--- a/crates/runner/mitm-addon/tests/test_request_handler_passthrough.py
+++ b/crates/runner/mitm-addon/tests/test_request_handler_passthrough.py
@@ -130,6 +130,11 @@ async def test_registry_unavailable_blocks_before_auth_injection(tmp_path, real_
     [
         ("", "empty_run_id", "proxy registry VM entry runId must be non-empty"),
         ("  \t", "empty_run_id", "proxy registry VM entry runId must be non-empty"),
+        (
+            " run-abc ",
+            "invalid_run_id",
+            "proxy registry VM entry runId must not include leading or trailing whitespace",
+        ),
         (None, "missing_run_id", "proxy registry VM entry is missing runId"),
         (123, "invalid_run_id", "proxy registry VM entry runId must be a string"),
     ],

--- a/crates/runner/mitm-addon/tests/test_request_handler_passthrough.py
+++ b/crates/runner/mitm-addon/tests/test_request_handler_passthrough.py
@@ -56,10 +56,10 @@ async def test_registry_unavailable_blocks_vm0_api_auto_allow(registry_file, rea
 async def test_vm0_api_test_paths_skip_auto_allow(tmp_path, real_flow, mitm_ctx, headers):
     """`/api/test/*` routes exist to exercise the firewall pipeline itself.
 
-    If they fell into Step 1's auto-allow fast path, the test-oauth E2E
+    If they fell into Step 2's auto-allow fast path, the test-oauth E2E
     test would never get proxy-injected Authorization headers and the
     pipeline it's supposed to exercise would be silently bypassed. The
-    carve-out drops these paths into Step 2 so the registered firewall
+    carve-out drops these paths into Step 3 so the registered firewall
     runs `handle_firewall_request`.
     """
     reg_path = _write_registry(
@@ -85,8 +85,8 @@ async def test_vm0_api_test_paths_skip_auto_allow(tmp_path, real_flow, mitm_ctx,
     with mitm_ctx(registry_path=str(reg_path), api_url="https://api.vm0.ai"):
         await mitm_addon.request(flow)
 
-    # Carve-out took effect: Step 2 ran and the real handle_firewall_request
-    # entered (firewall_base is written at auth.py:327 up-front).  Step 1's
+    # Carve-out took effect: Step 3 ran and the real handle_firewall_request
+    # entered (firewall_base is written at auth.py:327 up-front).  Step 2's
     # auto-allow would have returned without writing firewall_base.
     assert flow.metadata["firewall_base"] == "https://api.vm0.ai/api/test/oauth-provider"
 

--- a/crates/runner/mitm-addon/tests/test_response_handler.py
+++ b/crates/runner/mitm-addon/tests/test_response_handler.py
@@ -473,9 +473,8 @@ class TestResponseHandler:
         assert "#frag" not in entry["message"]
 
     def test_pops_start_time_even_when_run_id_absent(self, real_flow, mitm_ctx):
-        # If the request handler tracked this flow's start time but the
-        # metadata ended up without vm_run_id (registry missing runId),
-        # response() must still pop the timing state.
+        # If a partially initialized flow reaches response() without
+        # vm_run_id, response() must still pop the timing state.
         flow = real_flow(with_response=False)
         flow.metadata[metadata_keys.HTTP_REQUEST_START_MONOTONIC] = time.monotonic()
 


### PR DESCRIPTION
## Summary
- classify proxy registry VM entries into valid runtime entries and invalid registered entries
- keep invalid registered IPs intercepted while failing closed before HTTP auth injection or TCP metadata setup
- add regression coverage for missing/empty runId entries, TLS interception, TCP fail-closed behavior, and registry helper semantics

Closes #16070

## Tests
- `pytest tests/test_registry.py tests/test_connection_hooks.py tests/test_request_handler_passthrough.py tests/test_request_handler_firewall_dispatch.py tests/test_firewall_auth.py tests/test_auth_cache.py`
- `ruff format --check . && ruff check . && basedpyright`
