### PR TITLE
fix(platform): stop model picker measuring item bleeding through

### DIFF
--- a/turbo/apps/platform/src/views/zero-page/components/model-provider-picker.tsx
+++ b/turbo/apps/platform/src/views/zero-page/components/model-provider-picker.tsx
@@ -74,8 +74,11 @@ const INHERIT_SENTINEL = "__inherit_default__";
 
 // Radix Select uses the selected item's offsetHeight as the scroll-button
 // step. Keep hidden selected items measurable so native hover scrolling works.
+// These items are also `disabled`, and SelectItem's base `data-[disabled]:opacity-50`
+// outranks a plain `opacity-0` on specificity, so restate the hidden opacity under
+// the disabled variant to stop the measuring item from bleeding through.
 const MEASURABLE_HIDDEN_SELECT_ITEM_CLASS =
-  "absolute left-0 top-0 h-8 w-px overflow-hidden opacity-0 pointer-events-none";
+  "absolute left-0 top-0 h-8 w-px overflow-hidden opacity-0 data-[disabled]:opacity-0 pointer-events-none";
 
 function formatMultiplier(multiplier: number): string {
   return `×${multiplier}`;


### PR DESCRIPTION
## Problem

When the model picker is opened with **no configured models**, a faint ghost `Default` label renders overlapping the `No configured models` empty state.

## Root cause

`MEASURABLE_HIDDEN_SELECT_ITEM_CLASS` (in `model-provider-picker.tsx`) hides the measuring `SelectItem`s with `opacity-0`. These items are also `disabled`, and the base `SelectItem` class carries `data-[disabled]:opacity-50` (`packages/ui/src/components/ui/select.tsx`).

Radix sets `data-disabled` on disabled items, and Tailwind compiles the variant to a `class + attribute` selector — specificity `(0,2,0)` — which outranks plain `.opacity-0` `(0,1,0)`. So the "hidden" measuring item actually rendered at **50% opacity**, and with no policies it stacks at the same top-left position as the empty state, leaking the placeholder text through.

This affects both measuring items: the `INHERIT_SENTINEL` row and the `explicitSelectedModel` row.

## Fix

Restate the hidden opacity under the `data-[disabled]` variant so it wins on equal specificity:

```diff
-  "absolute left-0 top-0 h-8 w-px overflow-hidden opacity-0 pointer-events-none";
+  "absolute left-0 top-0 h-8 w-px overflow-hidden opacity-0 data-[disabled]:opacity-0 pointer-events-none";
```

Purely a CSS-class change; no logic touched.

## Testing

⚠️ Could not run the suite locally — the sandbox root fs (7.8G) lacked space for `pnpm install` (ENOSPC). Relying on CI. The change is an additive Tailwind class restating the intended hidden state.

🤖 Generated with [Claude Code](https://claude.com/claude-code)