### PR TITLE
test: wait for workspace cache sessions in runner tests

### DIFF
--- a/crates/runner/src/cmd/start/tests/failure_recovery/parking_cleanup.rs
+++ b/crates/runner/src/cmd/start/tests/failure_recovery/parking_cleanup.rs
@@ -2,6 +2,7 @@ use super::super::super::*;
 use super::super::support::{
     context_with_session, mock_run_config_with_overrides, push_job, seed_idle_pool, shutdown,
     test_profiles, wait_budget_count, wait_cancel_token, wait_cancel_token_removed,
+    wait_workspace_cache_sessions,
 };
 use super::support::assert_no_completion_for_run;
 
@@ -149,11 +150,11 @@ async fn assert_workspace_cache_after_failed_park(
     assert_eq!(idle_pool.lock().await.len(), 0);
     assert_eq!(counter.park_call_count(), 1);
     assert_eq!(counter.destroy_call_count(), 1);
-    let held = workspace_cache.held_session_states().await;
     if expect_cache {
-        assert_eq!(held.len(), 1);
-        assert_eq!(held[0].session_id, session_id);
+        wait_workspace_cache_sessions(&workspace_cache, &[session_id], Duration::from_secs(2))
+            .await;
     } else {
+        let held = workspace_cache.held_session_states().await;
         assert!(held.is_empty());
     }
 
@@ -295,9 +296,7 @@ async fn assert_workspace_cache_after_late_cancellation(
     wait_budget_count(&budget, 0, Duration::from_secs(2)).await;
     wait_cancel_token_removed(&cancel_tokens, run_id, Duration::from_secs(2)).await;
     assert_eq!(idle_pool.lock().await.len(), 0);
-    let held = workspace_cache.held_session_states().await;
-    assert_eq!(held.len(), 1);
-    assert_eq!(held[0].session_id, session_id);
+    wait_workspace_cache_sessions(&workspace_cache, &[session_id], Duration::from_secs(2)).await;
 
     shutdown(&env, run_handle).await;
 }

--- a/crates/runner/src/cmd/start/tests/support/mod.rs
+++ b/crates/runner/src/cmd/start/tests/support/mod.rs
@@ -25,5 +25,5 @@ pub(super) use self::wait::{
     wait_cancel_token_removed, wait_discover_entered,
     wait_idle_cleanup_processed_with_expired_entries, wait_idle_pool_len,
     wait_idle_pool_session_states, wait_idle_pool_sessions, wait_parking_state,
-    wait_sandbox_lifecycle_counts, wait_usage_flush_requested,
+    wait_sandbox_lifecycle_counts, wait_usage_flush_requested, wait_workspace_cache_sessions,
 };

--- a/crates/runner/src/cmd/start/tests/support/wait.rs
+++ b/crates/runner/src/cmd/start/tests/support/wait.rs
@@ -3,6 +3,7 @@ use super::env::MockRunEnv;
 use std::future::Future;
 
 use crate::idle_pool::ParkingState;
+use crate::workspace_image_cache::SessionWorkspaceCache;
 
 const WAIT_POLL_INTERVAL: Duration = Duration::from_millis(10);
 
@@ -132,6 +133,38 @@ pub(in super::super) async fn wait_idle_pool_session_states(
         } else {
             WaitProbe::Pending(format!(
                 "idle pool session states did not reach {expected:?} within {timeout:?} (actual: {actual:?})",
+            ))
+        }
+    })
+    .await;
+}
+
+pub(in super::super) async fn wait_workspace_cache_sessions(
+    cache: &SessionWorkspaceCache,
+    expected: &[&str],
+    timeout: Duration,
+) {
+    let mut expected: Vec<String> = expected
+        .iter()
+        .map(|session| (*session).to_string())
+        .collect();
+    expected.sort_unstable();
+    wait_for_probe(timeout, || async {
+        let states = cache.held_session_states().await;
+        for state in &states {
+            if chrono::DateTime::parse_from_rfc3339(&state.last_completed_at).is_err() {
+                return WaitProbe::Pending(format!(
+                    "workspace cache session state had invalid timestamp: {state:?}",
+                ));
+            }
+        }
+        let mut actual: Vec<String> = states.into_iter().map(|state| state.session_id).collect();
+        actual.sort_unstable();
+        if actual == expected {
+            WaitProbe::Ready(())
+        } else {
+            WaitProbe::Pending(format!(
+                "workspace cache sessions did not reach {expected:?} within {timeout:?} (actual: {actual:?})",
             ))
         }
     })


### PR DESCRIPTION
## Summary
- add a runner test helper that waits for workspace cache held session state to become observable
- use it in parking cleanup cache promotion assertions instead of a one-shot cache scan
- keep production runner logic unchanged

## Testing
- cargo fmt --manifest-path crates/Cargo.toml --all -- --check
- for i in {1..100}; do cargo test --manifest-path crates/Cargo.toml -p runner cmd::start::tests::failure_recovery::parking_cleanup::park_failure_promotes_workspace_cache_before_destroy -- --exact; done
- cargo test --manifest-path crates/Cargo.toml -p runner cmd::start::tests::failure_recovery::parking_cleanup
- cargo test --manifest-path crates/Cargo.toml -p runner