### PR TITLE
refactor: normalize connector type naming

### DIFF
--- a/turbo/apps/api/src/signals/services/agent-webhook-firewall-auth.service.ts
+++ b/turbo/apps/api/src/signals/services/agent-webhook-firewall-auth.service.ts
@@ -396,7 +396,7 @@ type ModelProviderPreparedRefreshTokenContext = {
   readonly context: RefreshTokenContext;
 };
 
-function resolveRefreshTokenAccessResolvedClient(
+function resolveRefreshTokenAccessClient(
   authMethodRef: ConnectorRefreshTokenAccessClientMethodRef,
 ): ConnectorRefreshTokenAccessResolvedClient | undefined {
   return resolveConnectorResolvedAuthMethodClientByAccessKind(
@@ -1310,8 +1310,7 @@ function prepareRefreshTokenContext(
   };
 
   if (connectorRefreshTokenAccessMethodHasClient(authMethodRef)) {
-    const resolvedClient =
-      resolveRefreshTokenAccessResolvedClient(authMethodRef);
+    const resolvedClient = resolveRefreshTokenAccessClient(authMethodRef);
     if (!resolvedClient) {
       L.debug(
         `${args.connectorType} connector client not configured, skipping token refresh`,

--- a/turbo/apps/api/src/signals/services/agent-webhook-firewall-auth.service.ts
+++ b/turbo/apps/api/src/signals/services/agent-webhook-firewall-auth.service.ts
@@ -12,18 +12,18 @@ import {
   getConnectorAuthMethodAccessMetadata,
   getConnectorAuthMethodStorageMetadata,
   getConnectorRuntimeBindingSecretName,
-  resolveConnectorAuthMethodClientRefByAccessKind,
+  resolveConnectorResolvedAuthMethodClientByAccessKind,
   connectorAuthMethodRefHasAccessKind,
-  type ConnectorAuthMethodClientRefByAccessKind,
+  type ConnectorResolvedAuthMethodClientByAccessKind,
   type ConnectorAuthMethodRef,
   type ConnectorAuthMethodRefByAccessKind,
   type ConnectorAuthMethodAccessMetadata,
-  type ConnectorRefreshInputMetadata,
+  type ConnectorRefreshTokenInputMetadata,
   type ConnectorAuthMethodStorageMetadata,
   type ConnectorAuthClientForMethod,
 } from "@vm0/connectors/connector-utils";
 import {
-  type ConnectorAuthMethodClientConfig,
+  type ConnectorAuthClientConfigForMethod,
   type ConnectorAuthMethodIdsByAccessKind,
   connectorAuthMethodIdSchema,
   connectorTypeSchema,
@@ -334,8 +334,8 @@ type PreparedRefreshTokenContext =
   | ConnectorPreparedRefreshTokenContext
   | ModelProviderPreparedRefreshTokenContext;
 
-type ConnectorRefreshTokenAccessClientRef =
-  ConnectorAuthMethodClientRefByAccessKind<"refresh-token">;
+type ConnectorRefreshTokenAccessResolvedClient =
+  ConnectorResolvedAuthMethodClientByAccessKind<"refresh-token">;
 
 type ConnectorRefreshTokenAccessMethodRef =
   ConnectorAuthMethodRefByAccessKind<"refresh-token">;
@@ -345,7 +345,7 @@ type ConnectorRefreshTokenAccessClientMethodRef = {
     readonly [Method in ConnectorAuthMethodIdsByAccessKind<
       Type,
       "refresh-token"
-    >]: [ConnectorAuthMethodClientConfig<Type, Method>] extends [never]
+    >]: [ConnectorAuthClientConfigForMethod<Type, Method>] extends [never]
       ? never
       : {
           readonly type: Type;
@@ -359,7 +359,7 @@ type ConnectorRefreshTokenAccessNoClientMethodRef = {
     readonly [Method in ConnectorAuthMethodIdsByAccessKind<
       Type,
       "refresh-token"
-    >]: [ConnectorAuthMethodClientConfig<Type, Method>] extends [never]
+    >]: [ConnectorAuthClientConfigForMethod<Type, Method>] extends [never]
       ? {
           readonly type: Type;
           readonly authMethod: Method;
@@ -376,7 +376,7 @@ type ConnectorPreparedRefreshTokenContextFor<
   readonly type: Type;
   readonly authMethod: Method;
   readonly context: RefreshTokenContext;
-} & ([ConnectorAuthMethodClientConfig<Type, Method>] extends [never]
+} & ([ConnectorAuthClientConfigForMethod<Type, Method>] extends [never]
   ? unknown
   : { readonly authClient: ConnectorAuthClientForMethod<Type, Method> });
 
@@ -396,10 +396,10 @@ type ModelProviderPreparedRefreshTokenContext = {
   readonly context: RefreshTokenContext;
 };
 
-function resolveRefreshTokenAccessClientRef(
+function resolveRefreshTokenAccessResolvedClient(
   authMethodRef: ConnectorRefreshTokenAccessClientMethodRef,
-): ConnectorRefreshTokenAccessClientRef | undefined {
-  return resolveConnectorAuthMethodClientRefByAccessKind(
+): ConnectorRefreshTokenAccessResolvedClient | undefined {
+  return resolveConnectorResolvedAuthMethodClientByAccessKind(
     authMethodRef,
     (name) => {
       return optionalEnv(name);
@@ -425,12 +425,12 @@ function connectorRefreshTokenAccessMethodHasNoClient(
 }
 
 function connectorPreparedRefreshTokenContextWithClient(args: {
-  readonly authClientRef: ConnectorRefreshTokenAccessClientRef;
+  readonly resolvedClient: ConnectorRefreshTokenAccessResolvedClient;
   readonly context: RefreshTokenContext;
 }): ConnectorPreparedRefreshTokenContext {
   return {
     sourceType: "connector",
-    ...args.authClientRef,
+    ...args.resolvedClient,
     context: args.context,
   };
 }
@@ -1013,7 +1013,7 @@ function modelProviderSourceLookup(args: {
 }
 
 function refreshInputSourceFromConnectorMetadata(
-  metadata: ConnectorRefreshInputMetadata,
+  metadata: ConnectorRefreshTokenInputMetadata,
 ): RefreshInputSource {
   switch (metadata.source.kind) {
     case "connector-secret": {
@@ -1310,8 +1310,9 @@ function prepareRefreshTokenContext(
   };
 
   if (connectorRefreshTokenAccessMethodHasClient(authMethodRef)) {
-    const authClientRef = resolveRefreshTokenAccessClientRef(authMethodRef);
-    if (!authClientRef) {
+    const resolvedClient =
+      resolveRefreshTokenAccessResolvedClient(authMethodRef);
+    if (!resolvedClient) {
       L.debug(
         `${args.connectorType} connector client not configured, skipping token refresh`,
       );
@@ -1321,7 +1322,7 @@ function prepareRefreshTokenContext(
     return {
       ok: true,
       prepared: connectorPreparedRefreshTokenContextWithClient({
-        authClientRef,
+        resolvedClient,
         context,
       }),
     };

--- a/turbo/apps/api/src/signals/services/connector-oauth-device-auth.service.ts
+++ b/turbo/apps/api/src/signals/services/connector-oauth-device-auth.service.ts
@@ -15,8 +15,8 @@ import {
   connectorAuthMethodRefHasGrantKind,
   getConnectorAuthMethod,
   getConnectorAuthMethodIdsForGrantKind,
-  resolveConnectorAuthMethodClientRefByGrantKind,
-  type ConnectorAuthMethodClientRefByGrantKind,
+  resolveConnectorResolvedAuthMethodClientByGrantKind,
+  type ConnectorResolvedAuthMethodClientByGrantKind,
   type ConnectorAuthMethodRef,
   type ConnectorAuthMethodRefByGrantKind,
 } from "@vm0/connectors/connector-utils";
@@ -85,10 +85,10 @@ const encryptedProviderStateSchema = z.object({
 type EncryptedProviderState = z.infer<typeof encryptedProviderStateSchema>;
 
 type DeviceAuthMethodRef = ConnectorAuthMethodRefByGrantKind<"device-auth">;
-type DeviceAuthMethodClientRef =
-  ConnectorAuthMethodClientRefByGrantKind<"device-auth">;
+type DeviceAuthResolvedMethodClient =
+  ConnectorResolvedAuthMethodClientByGrantKind<"device-auth">;
 
-type PollClaimedSessionArgs = DeviceAuthMethodClientRef & {
+type PollClaimedSessionArgs = DeviceAuthResolvedMethodClient & {
   readonly writeDb: Db;
   readonly orgId: string;
   readonly userId: string;
@@ -246,15 +246,15 @@ function resolveStoredDeviceAuthMethod(
 
 function resolveRequiredAuthClient(
   method: DeviceAuthMethodRef,
-): DeviceAuthMethodClientRef | ReturnType<typeof internalServerError> {
-  const clientRef = resolveConnectorAuthMethodClientRefByGrantKind(
+): DeviceAuthResolvedMethodClient | ReturnType<typeof internalServerError> {
+  const resolvedClient = resolveConnectorResolvedAuthMethodClientByGrantKind(
     method,
     optionalEnv,
   );
-  if (!clientRef) {
+  if (!resolvedClient) {
     return internalServerError(`${method.type} auth client not configured`);
   }
-  return clientRef;
+  return resolvedClient;
 }
 
 async function lockDeviceAuthSessionOwner(
@@ -743,12 +743,12 @@ export const startConnectorOauthDeviceAuthSession$ = command(
       return connectorOauthDeviceAuthDisabled;
     }
 
-    const authClientRef = resolveRequiredAuthClient(resolvedMethod);
-    if ("status" in authClientRef) {
-      return authClientRef;
+    const resolvedClient = resolveRequiredAuthClient(resolvedMethod);
+    if ("status" in resolvedClient) {
+      return resolvedClient;
     }
 
-    const startResult = await startConnectorDeviceAuthorization(authClientRef);
+    const startResult = await startConnectorDeviceAuthorization(resolvedClient);
     signal.throwIfAborted();
 
     const sessionToken = generateSessionToken();
@@ -872,9 +872,9 @@ export const pollConnectorOauthDeviceAuthSession$ = command(
       return connectorOauthDeviceAuthDisabled;
     }
 
-    const authClientRef = resolveRequiredAuthClient(resolvedMethod);
-    if ("status" in authClientRef) {
-      return authClientRef;
+    const resolvedClient = resolveRequiredAuthClient(resolvedMethod);
+    if ("status" in resolvedClient) {
+      return resolvedClient;
     }
 
     if (session.status === "complete") {
@@ -926,7 +926,7 @@ export const pollConnectorOauthDeviceAuthSession$ = command(
     }
 
     return await pollClaimedSession({
-      ...authClientRef,
+      ...resolvedClient,
       writeDb,
       orgId: args.orgId,
       userId: args.userId,

--- a/turbo/apps/api/src/signals/services/zero-connector-data.service.ts
+++ b/turbo/apps/api/src/signals/services/zero-connector-data.service.ts
@@ -19,7 +19,7 @@ import {
   getRuntimeAvailableConnectorTypes,
   type ConnectorAuthMethodRef,
   type ConnectorAuthMethodRefByRevokeKind,
-  type ManualGrantFieldNames,
+  type ConnectorManualGrantFieldNames,
 } from "@vm0/connectors/connector-utils";
 import { revokeConnectorAuthMethodAccessToken } from "@vm0/connectors/auth-providers";
 import {
@@ -626,7 +626,7 @@ async function deleteManualGrantConnectorLocalState(args: {
   readonly db: Db;
   readonly orgId: string;
   readonly userId: string;
-  readonly fields: ManualGrantFieldNames | null;
+  readonly fields: ConnectorManualGrantFieldNames | null;
   readonly signal: AbortSignal;
 }): Promise<boolean> {
   if (!args.fields) {

--- a/turbo/packages/connectors/src/auth-providers/connector-auth.ts
+++ b/turbo/packages/connectors/src/auth-providers/connector-auth.ts
@@ -23,7 +23,7 @@ import {
   isStaticConfidentialConnectorAuthClient,
   resolveConnectorAuthClientForMethod,
   type ConnectorAuthClientForMethod,
-  type ConnectorAuthMethodClientRefByGrantKind,
+  type ConnectorResolvedAuthMethodClientByGrantKind,
   type ConnectorEnvReader,
 } from "@vm0/connectors/connector-utils";
 import type {
@@ -447,31 +447,32 @@ const CONNECTOR_AUTH_METHOD_PROVIDERS = {
 const CONNECTOR_AUTH_METHOD_PROVIDER_REGISTRY: ConnectorAuthMethodProviderRegistry =
   CONNECTOR_AUTH_METHOD_PROVIDERS;
 
-type ConnectorAuthCodeMethodClientRef =
-  ConnectorAuthMethodClientRefByGrantKind<"auth-code">;
+type ConnectorAuthCodeResolvedMethodClient =
+  ConnectorResolvedAuthMethodClientByGrantKind<"auth-code">;
 
-type ConnectorDeviceAuthMethodClientRef =
-  ConnectorAuthMethodClientRefByGrantKind<"device-auth">;
+type ConnectorDeviceAuthResolvedMethodClient =
+  ConnectorResolvedAuthMethodClientByGrantKind<"device-auth">;
 
 type ConnectorAuthCodeAuthorizationUrlArgs =
-  ConnectorAuthCodeMethodClientRef & {
+  ConnectorAuthCodeResolvedMethodClient & {
     readonly redirectUri: string;
     readonly state: string;
   };
 
-type ConnectorAuthCodeExchangeCallArgs = ConnectorAuthCodeMethodClientRef & {
-  readonly code: string;
-  readonly redirectUri: string;
-  readonly state: string | undefined;
-  readonly codeVerifier: string | undefined;
-  readonly oauthContext: string | undefined;
-};
+type ConnectorAuthCodeExchangeCallArgs =
+  ConnectorAuthCodeResolvedMethodClient & {
+    readonly code: string;
+    readonly redirectUri: string;
+    readonly state: string | undefined;
+    readonly codeVerifier: string | undefined;
+    readonly oauthContext: string | undefined;
+  };
 
 type ConnectorDeviceAuthorizationStartCallArgs =
-  ConnectorDeviceAuthMethodClientRef;
+  ConnectorDeviceAuthResolvedMethodClient;
 
 type ConnectorDeviceAuthorizationPollCallArgs =
-  ConnectorDeviceAuthMethodClientRef & {
+  ConnectorDeviceAuthResolvedMethodClient & {
     readonly deviceCode: string;
   };
 

--- a/turbo/packages/connectors/src/auth-providers/types.ts
+++ b/turbo/packages/connectors/src/auth-providers/types.ts
@@ -1,7 +1,7 @@
 import type {
   AuthCodeGrantConnectorType,
   ConnectorAuthCodeGrantAuthMethodId,
-  ConnectorAuthMethodClientConfig,
+  ConnectorAuthClientConfigForMethod,
   ConnectorAuthMethodIds,
   ConnectorAuthMethodIdsByAccessKind,
   ConnectorAuthMethodIdsByRevokeKind,
@@ -82,7 +82,7 @@ export type ConnectorAuthProviderRefreshArgs<
 type ConnectorRefreshAuthClientArgs<
   T extends RefreshTokenAccessConnectorType,
   Method extends ConnectorAuthMethodIdsByAccessKind<T, "refresh-token">,
-> = [ConnectorAuthMethodClientConfig<T, Method>] extends [never]
+> = [ConnectorAuthClientConfigForMethod<T, Method>] extends [never]
   ? unknown
   : {
       readonly authClient: ConnectorAuthClientForMethod<T, Method>;

--- a/turbo/packages/connectors/src/connector-utils.ts
+++ b/turbo/packages/connectors/src/connector-utils.ts
@@ -13,7 +13,7 @@ import {
   type ConnectorTypesByAccessKind,
   type ConnectorTypesByGrantKind,
   type ConnectorTypesByRevokeKind,
-  type ConnectorAuthMethodClientConfig,
+  type ConnectorAuthClientConfigForMethod,
   type ConnectorAuthMethodConfigFor,
   type RefreshTokenAccessConnectorType,
   type ConnectorAccessConfig,
@@ -189,14 +189,14 @@ function getManualGrantFields(
   return method.grant.fields;
 }
 
-export interface ManualGrantFieldNames {
+export interface ConnectorManualGrantFieldNames {
   readonly secrets: readonly string[];
   readonly variables: readonly string[];
 }
 
 function manualGrantFieldNames(
   fields: Record<string, ConnectorManualGrantFieldConfig>,
-): ManualGrantFieldNames {
+): ConnectorManualGrantFieldNames {
   const secretNames: string[] = [];
   const variableNames: string[] = [];
   for (const [name, cfg] of Object.entries(fields)) {
@@ -212,14 +212,14 @@ function manualGrantFieldNames(
 export function getConnectorManualGrantFieldNamesForAuthMethod(
   type: ConnectorType,
   authMethod: string,
-): ManualGrantFieldNames | null {
+): ConnectorManualGrantFieldNames | null {
   const fields = getManualGrantFields(getConnectorAuthMethod(type, authMethod));
   return fields ? manualGrantFieldNames(fields) : null;
 }
 
 export function getConnectorManualGrantFieldNames(
   type: ConnectorType,
-): ManualGrantFieldNames | null {
+): ConnectorManualGrantFieldNames | null {
   const secretNames = new Set<string>();
   const variableNames = new Set<string>();
   for (const authMethod of getConfiguredConnectorAuthMethods(type)) {
@@ -276,9 +276,11 @@ export type ConnectorAuthMethodAccessMetadata =
     }
   | {
       readonly kind: "refresh-token";
-      readonly inputs: Readonly<Record<string, ConnectorRefreshInputMetadata>>;
+      readonly inputs: Readonly<
+        Record<string, ConnectorRefreshTokenInputMetadata>
+      >;
       readonly outputs: Readonly<
-        Record<string, ConnectorRefreshOutputMetadata>
+        Record<string, ConnectorRefreshTokenOutputMetadata>
       >;
       readonly refreshableSecrets: readonly string[];
       readonly envBindings: ConnectorEnvBindings;
@@ -295,7 +297,7 @@ export type ConnectorRefreshTokenAccessMetadata = Extract<
   { readonly kind: "refresh-token" }
 >;
 
-export interface ConnectorRefreshInputMetadata {
+export interface ConnectorRefreshTokenInputMetadata {
   readonly valueRef: string;
   readonly source: Extract<
     ConnectorRuntimeBindingSource,
@@ -303,14 +305,16 @@ export interface ConnectorRefreshInputMetadata {
   >;
 }
 
-export interface ConnectorRefreshOutputMetadata {
+export interface ConnectorRefreshTokenOutputMetadata {
   readonly valueRef: string;
   readonly secretName: string;
 }
 
-export interface ConnectorRefreshMetadata {
-  readonly inputs: Readonly<Record<string, ConnectorRefreshInputMetadata>>;
-  readonly outputs: Readonly<Record<string, ConnectorRefreshOutputMetadata>>;
+export interface ConnectorRefreshTokenMetadata {
+  readonly inputs: Readonly<Record<string, ConnectorRefreshTokenInputMetadata>>;
+  readonly outputs: Readonly<
+    Record<string, ConnectorRefreshTokenOutputMetadata>
+  >;
   readonly refreshableSecrets: readonly string[];
 }
 
@@ -392,7 +396,7 @@ function connectorVariableNameFromValueRef(
 
 function connectorRefreshInputMetadata(
   valueRef: ConnectorRefreshTokenInputValueRef,
-): ConnectorRefreshInputMetadata {
+): ConnectorRefreshTokenInputMetadata {
   if (isConnectorSecretValueRef(valueRef)) {
     return {
       valueRef,
@@ -412,7 +416,7 @@ function connectorRefreshInputMetadata(
 
 function connectorRefreshOutputMetadata(
   valueRef: ConnectorSecretValueRef,
-): ConnectorRefreshOutputMetadata {
+): ConnectorRefreshTokenOutputMetadata {
   return { valueRef, secretName: connectorSecretNameFromValueRef(valueRef) };
 }
 
@@ -432,7 +436,7 @@ function connectorRefreshMetadata(args: {
   readonly inputs: ConnectorRefreshTokenInputBindings;
   readonly outputs: ConnectorRefreshTokenOutputBindings;
   readonly refreshableSecrets: readonly string[];
-}): ConnectorRefreshMetadata {
+}): ConnectorRefreshTokenMetadata {
   return {
     inputs: Object.fromEntries(
       Object.entries(args.inputs).map(([name, valueRef]) => {
@@ -945,7 +949,9 @@ export type ConnectorAuthClientForConfig<
 export type ConnectorAuthClientForMethod<
   Type extends ConnectorType,
   Method extends ConnectorAuthMethodIds<Type>,
-> = ConnectorAuthClientForConfig<ConnectorAuthMethodClientConfig<Type, Method>>;
+> = ConnectorAuthClientForConfig<
+  ConnectorAuthClientConfigForMethod<Type, Method>
+>;
 
 export type ConnectorAuthClientIdentityForConfig<
   Client extends ConnectorAuthClientConfig,
@@ -961,10 +967,10 @@ export type ConnectorAuthClientIdentityForMethod<
   Type extends ConnectorType,
   Method extends ConnectorAuthMethodIds<Type>,
 > = ConnectorAuthClientIdentityForConfig<
-  ConnectorAuthMethodClientConfig<Type, Method>
+  ConnectorAuthClientConfigForMethod<Type, Method>
 >;
 
-export type ConnectorAuthMethodClientRef<
+export type ConnectorResolvedAuthMethodClient<
   Type extends ConnectorType,
   Method extends ConnectorAuthMethodIds<Type>,
 > = {
@@ -973,27 +979,27 @@ export type ConnectorAuthMethodClientRef<
   readonly authClient: ConnectorAuthClientForMethod<Type, Method>;
 };
 
-export type ConnectorAuthClientGrantKind = "auth-code" | "device-auth";
+export type ConnectorGrantKindWithAuthClient = "auth-code" | "device-auth";
 
-export type ConnectorAuthMethodClientRefByGrantKind<
-  Kind extends ConnectorAuthClientGrantKind,
+export type ConnectorResolvedAuthMethodClientByGrantKind<
+  Kind extends ConnectorGrantKindWithAuthClient,
 > = {
   readonly [Type in ConnectorTypesByGrantKind<Kind>]: {
     readonly [Method in ConnectorAuthMethodIdsByGrantKind<
       Type,
       Kind
-    >]: ConnectorAuthMethodClientRef<Type, Method>;
+    >]: ConnectorResolvedAuthMethodClient<Type, Method>;
   }[ConnectorAuthMethodIdsByGrantKind<Type, Kind>];
 }[ConnectorTypesByGrantKind<Kind>];
 
-export type ConnectorAuthMethodClientRefByAccessKind<
+export type ConnectorResolvedAuthMethodClientByAccessKind<
   Kind extends "refresh-token",
 > = {
   readonly [Type in ConnectorTypesByAccessKind<Kind>]: {
     readonly [Method in ConnectorAuthMethodIdsByAccessKind<
       Type,
       Kind
-    >]: ConnectorAuthMethodClientRef<Type, Method>;
+    >]: ConnectorResolvedAuthMethodClient<Type, Method>;
   }[ConnectorAuthMethodIdsByAccessKind<Type, Kind>];
 }[ConnectorTypesByAccessKind<Kind>];
 
@@ -1056,7 +1062,7 @@ export function getConnectorAuthClientConfigForMethod<
 >(
   type: Type,
   authMethod: Method,
-): ConnectorAuthMethodClientConfig<Type, Method> | undefined;
+): ConnectorAuthClientConfigForMethod<Type, Method> | undefined;
 export function getConnectorAuthClientConfigForMethod(
   type: ConnectorType,
   authMethod: string,
@@ -1145,16 +1151,16 @@ export function resolveConnectorAuthClientForMethod(
   return resolveConnectorAuthClient(clientConfig, readEnv);
 }
 
-type ResolvedConnectorAuthMethodClientRef = {
+type AnyConnectorResolvedAuthMethodClient = {
   readonly type: ConnectorType;
   readonly authMethod: ConnectorAuthMethodId;
   readonly authClient: ConnectorAuthClient;
 };
 
-function resolveConnectorAuthMethodClientRef(
+function resolveConnectorResolvedAuthMethodClient(
   authMethodRef: ConnectorAuthMethodRef,
   readEnv: ConnectorEnvReader,
-): ResolvedConnectorAuthMethodClientRef | undefined {
+): AnyConnectorResolvedAuthMethodClient | undefined {
   const authClient = resolveConnectorAuthClientForMethod(
     authMethodRef.type,
     authMethodRef.authMethod,
@@ -1170,30 +1176,30 @@ function resolveConnectorAuthMethodClientRef(
   };
 }
 
-export function resolveConnectorAuthMethodClientRefByGrantKind(
+export function resolveConnectorResolvedAuthMethodClientByGrantKind(
   authMethodRef: ConnectorAuthMethodRefByGrantKind<"auth-code">,
   readEnv: ConnectorEnvReader,
-): ConnectorAuthMethodClientRefByGrantKind<"auth-code"> | undefined;
-export function resolveConnectorAuthMethodClientRefByGrantKind(
+): ConnectorResolvedAuthMethodClientByGrantKind<"auth-code"> | undefined;
+export function resolveConnectorResolvedAuthMethodClientByGrantKind(
   authMethodRef: ConnectorAuthMethodRefByGrantKind<"device-auth">,
   readEnv: ConnectorEnvReader,
-): ConnectorAuthMethodClientRefByGrantKind<"device-auth"> | undefined;
-export function resolveConnectorAuthMethodClientRefByGrantKind(
-  authMethodRef: ConnectorAuthMethodRefByGrantKind<ConnectorAuthClientGrantKind>,
+): ConnectorResolvedAuthMethodClientByGrantKind<"device-auth"> | undefined;
+export function resolveConnectorResolvedAuthMethodClientByGrantKind(
+  authMethodRef: ConnectorAuthMethodRefByGrantKind<ConnectorGrantKindWithAuthClient>,
   readEnv: ConnectorEnvReader,
-): ResolvedConnectorAuthMethodClientRef | undefined {
-  return resolveConnectorAuthMethodClientRef(authMethodRef, readEnv);
+): AnyConnectorResolvedAuthMethodClient | undefined {
+  return resolveConnectorResolvedAuthMethodClient(authMethodRef, readEnv);
 }
 
-export function resolveConnectorAuthMethodClientRefByAccessKind(
+export function resolveConnectorResolvedAuthMethodClientByAccessKind(
   authMethodRef: ConnectorAuthMethodRefByAccessKind<"refresh-token">,
   readEnv: ConnectorEnvReader,
-): ConnectorAuthMethodClientRefByAccessKind<"refresh-token"> | undefined;
-export function resolveConnectorAuthMethodClientRefByAccessKind(
+): ConnectorResolvedAuthMethodClientByAccessKind<"refresh-token"> | undefined;
+export function resolveConnectorResolvedAuthMethodClientByAccessKind(
   authMethodRef: ConnectorAuthMethodRefByAccessKind<"refresh-token">,
   readEnv: ConnectorEnvReader,
-): ResolvedConnectorAuthMethodClientRef | undefined {
-  return resolveConnectorAuthMethodClientRef(authMethodRef, readEnv);
+): AnyConnectorResolvedAuthMethodClient | undefined {
+  return resolveConnectorResolvedAuthMethodClient(authMethodRef, readEnv);
 }
 
 function hasRuntimeAvailableAuthMethod(

--- a/turbo/packages/connectors/src/connectors.ts
+++ b/turbo/packages/connectors/src/connectors.ts
@@ -1221,7 +1221,7 @@ export type ConnectorRevokeInputValues<
   Record<Extract<keyof ConnectorRevokeInputsFor<Type, Method>, string>, string>
 >;
 
-export type ConnectorAuthMethodClientConfig<
+export type ConnectorAuthClientConfigForMethod<
   Type extends ConnectorType,
   Method extends ConnectorAuthMethodIds<Type>,
 > = "client" extends keyof ConnectorAuthMethodsOf<Type>[Method]


### PR DESCRIPTION
## Summary

- Rename connector auth-client config extractor types to use `...ForMethod` vocabulary.
- Rename refresh-token metadata and manual grant field result types to match connector naming.
- Rename resolved auth-method client payload types and resolver functions so `Ref` stays reserved for `{ type, authMethod }` references.

Closes #16109.

## Behavior

This is intended to be a behavior-preserving vocabulary cleanup. It does not change connector config data, API payloads, database fields, OAuth route names, or runtime object shapes.

## Validation

- `pnpm -F @vm0/connectors check-types`
- `pnpm -F @vm0/connectors lint`
- `pnpm -F @vm0/connectors exec vitest run src/__tests__/connectors.test.ts`
- `pnpm -F api check-types`
- pre-commit `pnpm check-types` via lefthook

Known unrelated local failure:

- `pnpm -F @vm0/connectors test` currently fails only `firewall-secret-consistency.test.ts` for `cronlytic`: generated firewall references `secrets.CRONLYTIC_USER_ID`, while the connector declares `CRONLYTIC_USER_ID` as a variable. This PR does not touch cronlytic or generated firewalls.
