### PR TITLE
fix: log session metadata write results

### DIFF
--- a/crates/guest-agent/src/events.rs
+++ b/crates/guest-agent/src/events.rs
@@ -340,12 +340,30 @@ pub(crate) fn capture_session_metadata(event: &Value) {
     }
 
     log_info!(LOG_TAG, "Captured session ID: {session_id}");
-    let _ = std::fs::write(paths::session_id_file(), &session_id);
-    let _ = std::fs::write(paths::session_history_path_file(), &history_path_payload);
-    log_info!(
-        LOG_TAG,
-        "Session history will be at: {history_path_payload}"
-    );
+    match std::fs::write(paths::session_id_file(), &session_id) {
+        Ok(()) => log_info!(
+            LOG_TAG,
+            "Session ID written to {}",
+            paths::session_id_file()
+        ),
+        Err(e) => log_error!(
+            LOG_TAG,
+            "Failed to write session ID to {}: {e}",
+            paths::session_id_file()
+        ),
+    }
+    match std::fs::write(paths::session_history_path_file(), &history_path_payload) {
+        Ok(()) => log_info!(
+            LOG_TAG,
+            "Session history marker written to {}: {history_path_payload}",
+            paths::session_history_path_file()
+        ),
+        Err(e) => log_error!(
+            LOG_TAG,
+            "Failed to write session history marker to {}: {e}",
+            paths::session_history_path_file()
+        ),
+    }
 }
 
 /// Claude variant — matches `system/init` and computes the project-scoped

--- a/crates/guest-agent/tests/integration/events.rs
+++ b/crates/guest-agent/tests/integration/events.rs
@@ -59,6 +59,10 @@ async fn send_event_captures_session_metadata_before_masking() {
     let _guard = TEST_MUTEX.lock().unwrap();
     let server = &*MOCK_SERVER;
     let _session_files = SessionCheckpointFilesGuard::new();
+    let tmp = tempfile::tempdir().unwrap();
+    let system_log_path = tmp.path().join("system.log");
+    let system_log_path = system_log_path.to_string_lossy().into_owned();
+    let _system_log_guard = SystemLogOverrideGuard::set(&system_log_path);
 
     let sid_file = guest_agent::paths::session_id_file();
     let hist_file = guest_agent::paths::session_history_path_file();
@@ -98,6 +102,15 @@ async fn send_event_captures_session_metadata_before_masking() {
     assert!(
         !history.contains("***"),
         "history path must not be built from masked metadata, got: {history}"
+    );
+    let system_log = std::fs::read_to_string(&system_log_path).unwrap();
+    assert!(
+        system_log.contains(&format!("Session ID written to {sid_file}")),
+        "system log should confirm session ID file creation, got: {system_log}"
+    );
+    assert!(
+        system_log.contains(&format!("Session history marker written to {hist_file}:")),
+        "system log should confirm session history marker creation, got: {system_log}"
     );
 
     mock.delete_async().await;


### PR DESCRIPTION
## Summary
- log successful session ID file writes during session metadata capture
- log write failures for session ID and session history marker files
- assert the new success logs in the existing guest-agent integration test

## Testing
- cargo test -p guest-agent --test integration send_event_captures_session_metadata_before_masking

Related to #16075