### PR TITLE
feat: route platform connector and slack-integration data to api backend

### DIFF
--- a/turbo/apps/platform/src/signals/__tests__/api-client.test.ts
+++ b/turbo/apps/platform/src/signals/__tests__/api-client.test.ts
@@ -9,7 +9,6 @@ import { zeroTeamContract } from "@vm0/api-contracts/contracts/zero-team";
 import { onboardingStatusContract } from "@vm0/api-contracts/contracts/onboarding";
 import { zeroVoiceIoQuotaContract } from "@vm0/api-contracts/contracts/zero-voice-io-quota";
 import { zeroSchedulesMainContract } from "@vm0/api-contracts/contracts/zero-schedules";
-import { zeroConnectorsMainContract } from "@vm0/api-contracts/contracts/zero-connectors";
 import { zeroPersonalModelProvidersMainContract } from "@vm0/api-contracts/contracts/zero-personal-model-providers";
 import { zeroModelProvidersMainContract } from "@vm0/api-contracts/contracts/zero-model-providers";
 import {
@@ -319,22 +318,23 @@ describe("zeroClient$ apiBackend routing", () => {
 
     const requestHosts: string[] = [];
     server.use(
-      mockApi(zeroConnectorsMainContract.list, ({ request, respond }) => {
+      mockApi(zeroFeatureSwitchesContract.get, ({ request, respond }) => {
         requestHosts.push(new URL(request.url).host);
-        return respond(200, {
-          connectors: [],
-          configuredTypes: [],
-          connectorProvidedEnvNames: [],
-        });
+        return respond(200, { switches: {} });
       }),
     );
 
+    // feature-switches stays on www (bootstrap), so it is a stable example of
+    // a policy-routed GET that is intentionally not in the allowlist.
     const createClient = context.store.get(zeroClient$);
-    const client = createClient(zeroConnectorsMainContract);
-    const result = await client.list();
+    const client = createClient(zeroFeatureSwitchesContract);
+    const result = await client.get();
 
     expect(result.status).toBe(200);
-    expect(requestHosts).toStrictEqual(["www.vm0.ai"]);
+    // Bootstrap also loads feature switches; assert every request stays on www,
+    // not the count.
+    expect(requestHosts.length).toBeGreaterThan(0);
+    expect([...new Set(requestHosts)]).toStrictEqual(["www.vm0.ai"]);
   });
 
   it("routes policy allowlisted user preferences contract requests to api host when apiBackend is off", async () => {

--- a/turbo/apps/platform/src/signals/__tests__/fetch.test.ts
+++ b/turbo/apps/platform/src/signals/__tests__/fetch.test.ts
@@ -613,6 +613,44 @@ describe("apiBackend routing", () => {
     ]);
   });
 
+  it("routes connector/integration data to api but keeps connector oauth flows on www", async () => {
+    vi.stubGlobal("location", new URL("https://platform.vm0.ai/"));
+    detachedSetupPage({
+      context,
+      path: "/",
+      withoutRender: true,
+    });
+
+    const hosts: string[] = [];
+    function capture(method: "get" | "post" | "delete", pattern: string): void {
+      server.use(
+        http[method](pattern, ({ request }) => {
+          hosts.push(`${method.toUpperCase()} ${new URL(request.url).host}`);
+          return new Response(null, { status: 200 });
+        }),
+      );
+    }
+    capture("get", "*/api/zero/connectors");
+    capture("delete", "*/api/zero/connectors/:type");
+    capture("get", "*/api/zero/integrations/slack");
+    // OAuth flows under the connectors subtree must stay on www even though
+    // their /connectors/:type prefix is now migrated.
+    capture("post", "*/api/zero/connectors/:type/oauth/start");
+
+    const fch = context.store.get(fetch$);
+    await fch("/api/zero/connectors");
+    await fch("/api/zero/connectors/slack", { method: "DELETE" });
+    await fch("/api/zero/integrations/slack");
+    await fch("/api/zero/connectors/slack/oauth/start", { method: "POST" });
+
+    expect(hosts).toStrictEqual([
+      "GET api.vm0.ai",
+      "DELETE api.vm0.ai",
+      "GET api.vm0.ai",
+      "POST www.vm0.ai",
+    ]);
+  });
+
   it("does not let a :param template over-match a shorter parent path", async () => {
     vi.stubGlobal("location", new URL("https://platform.vm0.ai/"));
     detachedSetupPage({

--- a/turbo/apps/platform/src/signals/api-target-policy.ts
+++ b/turbo/apps/platform/src/signals/api-target-policy.ts
@@ -17,16 +17,21 @@ interface ApiRouteAllowlistEntry {
 // First-party apps/platform routes that resolve to the dedicated `api` host
 // while the global `apiBackend` switch is off. Everything not listed here
 // defaults to `www`. Routes are method-aware: a path's mutations are migrated
-// only when their method is listed. OAuth, connector/integration, billing,
-// bootstrap feature-switches, and web-origin flows are intentionally absent
-// and stay on `www`.
+// only when their method is listed. OAuth start/callbacks and device-auth
+// flows, bootstrap feature-switches, and web-origin navigation flows are
+// intentionally absent and stay on `www`.
 const API_ROUTE_ALLOWLIST: readonly ApiRouteAllowlistEntry[] = [
   { methods: ["GET", "POST"], pathname: "/api/zero/agents" },
   {
     methods: ["GET", "PUT", "PATCH", "DELETE"],
     pathname: "/api/zero/agents/:id",
   },
+  {
+    methods: ["GET", "PUT"],
+    pathname: "/api/zero/agents/:id/custom-connectors",
+  },
   { methods: ["GET", "PUT"], pathname: "/api/zero/agents/:id/instructions" },
+  { methods: ["GET", "PUT"], pathname: "/api/zero/agents/:id/user-connectors" },
   { methods: ["GET", "POST"], pathname: "/api/zero/api-keys" },
   { methods: ["DELETE"], pathname: "/api/zero/api-keys/:id" },
   { methods: ["POST"], pathname: "/api/zero/attribution/signup" },
@@ -52,6 +57,7 @@ const API_ROUTE_ALLOWLIST: readonly ApiRouteAllowlistEntry[] = [
     methods: ["GET", "POST"],
     pathname: "/api/zero/chat-threads/:threadId/artifacts",
   },
+  { methods: ["GET"], pathname: "/api/zero/chat-threads/:threadId/github-prs" },
   { methods: ["GET"], pathname: "/api/zero/chat-threads/:threadId/messages" },
   { methods: ["POST"], pathname: "/api/zero/chat/messages" },
   { methods: ["GET"], pathname: "/api/zero/chat/search" },
@@ -59,9 +65,34 @@ const API_ROUTE_ALLOWLIST: readonly ApiRouteAllowlistEntry[] = [
   { methods: ["GET", "DELETE"], pathname: "/api/zero/composes/:id" },
   { methods: ["PATCH"], pathname: "/api/zero/composes/:id/metadata" },
   { methods: ["GET"], pathname: "/api/zero/composes/list" },
+  { methods: ["GET"], pathname: "/api/zero/connectors" },
+  { methods: ["GET", "DELETE"], pathname: "/api/zero/connectors/:type" },
+  { methods: ["POST"], pathname: "/api/zero/connectors/:type/manual-grant" },
+  { methods: ["GET"], pathname: "/api/zero/connectors/:type/scope-diff" },
+  { methods: ["GET"], pathname: "/api/zero/connectors/search" },
+  { methods: ["GET", "POST"], pathname: "/api/zero/custom-connectors" },
+  { methods: ["PATCH", "DELETE"], pathname: "/api/zero/custom-connectors/:id" },
+  {
+    methods: ["PUT", "DELETE"],
+    pathname: "/api/zero/custom-connectors/:id/secret",
+  },
   { methods: ["PUT"], pathname: "/api/zero/default-agent" },
   { methods: ["GET"], pathname: "/api/zero/insights" },
   { methods: ["GET"], pathname: "/api/zero/insights/range" },
+  { methods: ["GET", "DELETE"], pathname: "/api/zero/integrations/slack" },
+  {
+    methods: ["GET", "POST"],
+    pathname: "/api/zero/integrations/slack/connect",
+  },
+  { methods: ["POST"], pathname: "/api/zero/integrations/slack/message" },
+  {
+    methods: ["POST"],
+    pathname: "/api/zero/integrations/slack/upload-file/complete",
+  },
+  {
+    methods: ["POST"],
+    pathname: "/api/zero/integrations/slack/upload-file/init",
+  },
   { methods: ["GET"], pathname: "/api/zero/logs" },
   { methods: ["GET"], pathname: "/api/zero/logs/:id" },
   { methods: ["GET"], pathname: "/api/zero/logs/search" },
@@ -101,6 +132,7 @@ const API_ROUTE_ALLOWLIST: readonly ApiRouteAllowlistEntry[] = [
   { methods: ["DELETE"], pathname: "/api/zero/secrets/:name" },
   { methods: ["GET", "POST"], pathname: "/api/zero/skills" },
   { methods: ["GET", "PUT", "DELETE"], pathname: "/api/zero/skills/:name" },
+  { methods: ["GET"], pathname: "/api/zero/slack/channels" },
   { methods: ["GET"], pathname: "/api/zero/team" },
   { methods: ["POST"], pathname: "/api/zero/uploads/complete" },
   { methods: ["POST"], pathname: "/api/zero/uploads/prepare" },


### PR DESCRIPTION
## Summary
Migrate the connector / slack-integration **data** routes (the last technically-movable first-party group) from `www` to the dedicated `api` host. OAuth/device-auth flows in the connector subtree stay on `www`. Also fixes the now-stale policy header comment (flagged as a P2 on #16106).

### Migrated (25 routes)
- **Connectors**: `GET connectors`, `GET/DELETE connectors/:type`, `GET connectors/:type/scope-diff`, `GET connectors/search`, `POST connectors/:type/manual-grant`
- **Custom connectors**: `GET/POST custom-connectors`, `PATCH/DELETE custom-connectors/:id`, `PUT/DELETE custom-connectors/:id/secret`
- **Agent connector config**: `GET/PUT agents/:id/user-connectors`, `GET/PUT agents/:id/custom-connectors`
- **Slack integration**: `GET/DELETE integrations/slack`, `GET/POST integrations/slack/connect`, `POST integrations/slack/message`, `POST integrations/slack/upload-file/{init,complete}`, `GET slack/channels`
- `GET chat-threads/:threadId/github-prs`

### Kept on www (OAuth/auth flows)
`POST connectors/:type/oauth/start`, `POST connectors/:type/oauth/device/sessions` (+`/:sessionId/poll`).

## Safety (adversarially verified — one agent per route, 28 candidates → 25 safe / 3 excluded)
Each route's `apps/api` handler was inspected: all are first-party platform calls, none are oauth/device-auth flows, and none read `x-vm0-web-origin`, build URLs from the request origin/host, or set domain-bound cookies. Spot-checks of the two riskiest verdicts confirmed safe:
- `slack/connect` install/connect/reinstall URLs are built from env `APP_URL` (not the request host); the route handler has no request-origin code.
- `manual-grant` stores user-submitted connector credentials (a DB write), not an OAuth redirect flow.

As with all `/api/zero/*`, `www` has no handler (it rewrites to the same `apps/api` backend), so this only removes the proxy hop; CORS already allows all methods + credentials for the platform origin.

### Matcher collision guard
The 3 excluded oauth paths cannot collide with any migrated `:param` template (different segment counts / methods) — covered by a new test asserting `connectors/:type/oauth/start` still routes to `www` while `connectors`, `connectors/:type` (DELETE), and `integrations/slack` route to `api`.

## Other changes
- Default-`www` routing test fixture re-pointed from `connectors` (now migrated) to `feature-switches` (permanently www, bootstrap).
- Refreshed the policy header comment (it no longer claims connector/integration/billing are absent).

## Validation
- `pnpm format`, `pnpm -F @vm0/app lint`, `pnpm -F @vm0/app check-types`, `pnpm knip --workspace apps/platform` — clean; 53 routing tests pass.

## Post-merge verification
Confirm in `vm0-traces-prod` these land on `service.name=vm0-api` with no 5xx and no fallback-to-web, and that connector oauth still works on www.

Closes #16119
Part of #15872

🤖 Generated with [Claude Code](https://claude.com/claude-code)
