### PR TITLE
fix: prevent memory update cards from shrinking

### DIFF
--- a/turbo/apps/platform/src/views/memory-page/__tests__/memory-page-layout.btest.ts
+++ b/turbo/apps/platform/src/views/memory-page/__tests__/memory-page-layout.btest.ts
@@ -57,4 +57,66 @@ describe("memory page layout", () => {
       wrapper.remove();
     }
   });
+
+  it("keeps update cards at their content height inside the scrolling timeline", () => {
+    const wrapper = document.createElement("div");
+    wrapper.style.display = "flex";
+    wrapper.style.height = "220px";
+    wrapper.style.width = "760px";
+    wrapper.innerHTML = `
+      <div aria-label="Memory updates" style="display: flex; min-height: 0; flex: 1 1 0%; flex-direction: column; gap: 16px; overflow: auto; padding-bottom: 8px;">
+        <section class="zero-card shrink-0" style="display: flex; height: 140px; flex-shrink: 0; flex-direction: column; overflow: hidden;">
+          <header style="border-bottom: 1px solid hsl(var(--border)); padding: 12px 16px;">
+            <h2 style="font-size: 14px; font-weight: 600;">Wednesday, June 3, 2026</h2>
+            <p style="margin-top: 4px; font-size: 14px; line-height: 20px;">Zero learned a new development preference.</p>
+          </header>
+          <div style="display: flex; flex-direction: column; gap: 8px; padding: 12px 16px;">
+            <div style="height: 40px; border: 1px solid hsl(var(--border)); border-radius: 6px;"></div>
+          </div>
+        </section>
+        <section class="zero-card shrink-0" style="display: flex; height: 140px; flex-shrink: 0; flex-direction: column; overflow: hidden;">
+          <header style="border-bottom: 1px solid hsl(var(--border)); padding: 12px 16px;">
+            <h2 style="font-size: 14px; font-weight: 600;">Sunday, May 31, 2026</h2>
+            <p style="margin-top: 4px; font-size: 14px; line-height: 20px;">Zero updated existing memory files.</p>
+          </header>
+          <div style="display: flex; flex-direction: column; gap: 8px; padding: 12px 16px;">
+            <div style="height: 40px; border: 1px solid hsl(var(--border)); border-radius: 6px;"></div>
+          </div>
+        </section>
+        <section class="zero-card shrink-0" style="display: flex; height: 460px; flex-shrink: 0; flex-direction: column; overflow: hidden;">
+          <header style="border-bottom: 1px solid hsl(var(--border)); padding: 12px 16px;">
+            <h2 style="font-size: 14px; font-weight: 600;">Thursday, May 21, 2026</h2>
+            <p style="margin-top: 4px; font-size: 14px; line-height: 20px;">Zero learned several repo-specific workflows.</p>
+          </header>
+          <div style="display: flex; flex-direction: column; gap: 8px; padding: 12px 16px;">
+            ${Array.from({ length: 8 }, () => {
+              return '<div style="height: 40px; border: 1px solid hsl(var(--border)); border-radius: 6px;"></div>';
+            }).join("")}
+          </div>
+        </section>
+      </div>
+    `;
+    document.body.appendChild(wrapper);
+
+    try {
+      const scroller = getRequiredElement('[aria-label="Memory updates"]');
+      const firstCard = getRequiredElement(
+        '[aria-label="Memory updates"] .zero-card:nth-of-type(1)',
+      );
+      const secondCard = getRequiredElement(
+        '[aria-label="Memory updates"] .zero-card:nth-of-type(2)',
+      );
+      const thirdCard = getRequiredElement(
+        '[aria-label="Memory updates"] .zero-card:nth-of-type(3)',
+      );
+
+      expect(scroller.scrollHeight).toBeGreaterThan(scroller.clientHeight);
+      expect(getComputedStyle(firstCard).flexShrink).toBe("0");
+      expect(firstCard.getBoundingClientRect().height).toBeGreaterThan(130);
+      expect(secondCard.getBoundingClientRect().height).toBeGreaterThan(130);
+      expect(thirdCard.getBoundingClientRect().height).toBeGreaterThan(450);
+    } finally {
+      wrapper.remove();
+    }
+  });
 });

--- a/turbo/apps/platform/src/views/memory-page/__tests__/memory-page.test.tsx
+++ b/turbo/apps/platform/src/views/memory-page/__tests__/memory-page.test.tsx
@@ -124,12 +124,19 @@ describe("memory page", () => {
       featureSwitches: { [FeatureSwitchKey.MemoryViewer]: true },
     });
 
-    await waitFor(() => {
-      expect(
-        screen.getByText("Zero learned how you prefer to deploy."),
-      ).toBeInTheDocument();
+    const summary = await waitFor(() => {
+      const element = screen.getByText(
+        "Zero learned how you prefer to deploy.",
+      );
+      expect(element).toBeInTheDocument();
+      return element;
     });
 
+    const updateCard = summary.closest("section");
+    if (updateCard === null) {
+      throw new Error("Missing memory update card");
+    }
+    expect(updateCard).toHaveClass("shrink-0");
     expect(screen.getByText("Deploy preference")).toBeInTheDocument();
     expect(screen.getByText("Learned")).toBeInTheDocument();
     expect(screen.getByText("Updated")).toBeInTheDocument();

--- a/turbo/apps/platform/src/views/memory-page/memory-page.tsx
+++ b/turbo/apps/platform/src/views/memory-page/memory-page.tsx
@@ -532,7 +532,7 @@ function MemoryUpdateCard({ entry }: { readonly entry: MemoryActivityEntry }) {
   });
 
   return (
-    <section className="zero-card flex flex-col overflow-hidden">
+    <section className="zero-card flex shrink-0 flex-col overflow-hidden">
       <header className="border-b border-border/70 px-4 py-3">
         <h2 className="text-sm font-semibold tracking-tight text-foreground">
           {formatActivityDate(entry.date)}
@@ -703,7 +703,7 @@ function MemoryUpdatesSkeleton() {
         return (
           <section
             key={cardIndex}
-            className="zero-card flex flex-col overflow-hidden"
+            className="zero-card flex shrink-0 flex-col overflow-hidden"
           >
             <header className="border-b border-border/70 px-4 py-3">
               <div className="h-4 w-40 rounded bg-muted/50" />


### PR DESCRIPTION
## Summary
- keep Memory update cards and loading skeleton cards from shrinking inside the scroll container
- add layout coverage for constrained-height timelines and assert the real update card includes the non-shrinking class

## Verification
- pnpm -F @vm0/app btest -- src/views/memory-page/__tests__/memory-page-layout.btest.ts
- NODE_OPTIONS=--no-experimental-webstorage pnpm -F @vm0/app exec vitest run src/views/memory-page/__tests__/memory-page.test.tsx
- pnpm -F @vm0/app lint
- pnpm -F @vm0/app check-types
- pnpm -F @vm0/app build