### PR TITLE
docs: document artifact archive validation invariants

### DIFF
--- a/crates/guest-agent/src/artifact/archive.rs
+++ b/crates/guest-agent/src/artifact/archive.rs
@@ -187,6 +187,23 @@ pub(super) fn create_archive(
     Ok(())
 }
 
+/// Validate archive inputs for a deduplicated snapshot.
+///
+/// This is the deduplicated-snapshot counterpart to [`create_archive`]. When
+/// `/storages/prepare` reports an existing version, callers must run this before
+/// committing that version as HEAD because the deduplicated path does not build
+/// an archive.
+///
+/// The check reopens each listed file through the same Linux no-follow
+/// root/child path opening used for archive creation, then verifies that
+/// manifest paths are still non-empty relative paths with no root, prefix, `.`,
+/// or `..` components, entries are still regular files, and file size plus
+/// SHA-256 still match the pre-walked manifest.
+/// Empty manifests still validate readable artifact-root access through the
+/// no-follow root-opening path.
+///
+/// This validates the current artifact state before commit; it does not freeze
+/// the filesystem after validation returns.
 pub(super) fn validate_archive_inputs(
     dir_path: &str,
     files: &[FileEntry],

--- a/crates/guest-agent/src/artifact/mod.rs
+++ b/crates/guest-agent/src/artifact/mod.rs
@@ -2,12 +2,12 @@
 //!
 //! Flow (caller first walks the mount via [`walk_files_for_checkpoint`], then
 //! invokes [`create_snapshot`] with the pre-walked file list):
-//! 1. POST `/storages/prepare` with file list → get presigned URLs
-//! 2. If deduplicated, POST `/storages/commit` to update HEAD
-//! 3. Create tar.gz archive
-//! 4. Create manifest.json
-//! 5. PUT archive + manifest to S3
-//! 6. POST `/storages/commit`
+//! 1. POST `/storages/prepare` with file list to get version/upload metadata
+//! 2. If prepare found an existing version, validate the local archive inputs,
+//!    then POST `/storages/commit` to update HEAD
+//! 3. Otherwise, create tar.gz archive and manifest.json
+//! 4. PUT archive + manifest to S3
+//! 5. POST `/storages/commit`
 
 use crate::error::AgentError;
 use crate::http::HttpClient;
@@ -128,6 +128,8 @@ pub(crate) async fn create_snapshot(
             LOG_TAG,
             "Version already exists (deduplicated), updating HEAD"
         );
+        // Validate the local manifest inputs before committing the existing
+        // version as HEAD, since this branch does not build an archive.
         validate_dedup_snapshot(request.mount_path, &request.files).await?;
         commit_existing_snapshot(http, &request, &version_id).await?;
         return Ok(SnapshotResult { version_id });


### PR DESCRIPTION
## Summary

- Update the guest-agent artifact snapshot flow comment so deduplicated snapshots include local archive input validation before committing HEAD.
- Add a call-site comment preserving the deduplicated validation ordering invariant.
- Document `validate_archive_inputs` as the deduplicated counterpart to archive creation, including the path, file type, size/hash, and no-follow root access checks.

## Testing

- `cargo fmt --manifest-path crates/Cargo.toml --all -- --check`
- `cargo test --manifest-path crates/Cargo.toml -p guest-agent artifact`
- pre-commit: `cargo-fmt`, `cargo-clippy`, `cargo-doc`

Closes #16094
