### PR TITLE
fix: cap auth.base forwarded request bodies

### DIFF
--- a/crates/runner/mitm-addon/src/auth.py
+++ b/crates/runner/mitm-addon/src/auth.py
@@ -20,6 +20,8 @@ from mitmproxy import ctx, http
 import flow_metadata_keys as metadata_keys
 import matching
 from auth_base_forwarder import (
+    MAX_AUTH_BASE_REQUEST_BODY_BYTES,
+    ForwardedRequestTooLargeError,
     forward_request,
     forwarded_request_header_pairs,
     header_pairs,
@@ -712,6 +714,39 @@ def _set_url_rewrite_forward_failed(
     )
 
 
+def _request_body_exceeds_auth_base_limit(flow: http.HTTPFlow) -> bool:
+    body = flow.request.raw_content
+    return body is not None and len(body) > MAX_AUTH_BASE_REQUEST_BODY_BYTES
+
+
+def _set_auth_base_request_too_large(
+    flow: http.HTTPFlow,
+    *,
+    allow: matching.FirewallAllow,
+    proxy_log_path: str,
+    firewall_base: str,
+) -> None:
+    body = flow.request.raw_content
+    observed_size = len(body) if body is not None else 0
+    log_proxy_entry(
+        proxy_log_path,
+        "warn",
+        "auth.base request body too large",
+        type="firewall",
+        firewall_base=firewall_base,
+        request_body_size_bytes=observed_size,
+        request_body_limit_bytes=MAX_AUTH_BASE_REQUEST_BODY_BYTES,
+    )
+    _set_matched_firewall_failure_response(
+        flow,
+        status=413,
+        action="ALLOW",
+        error_code="auth_base_request_body_too_large",
+        message="auth.base request body too large",
+        permission=allow.name,
+    )
+
+
 async def _apply_url_rewrite(
     flow: http.HTTPFlow,
     *,
@@ -753,6 +788,14 @@ async def _apply_url_rewrite(
             req_body,
         )
         flow.response = http.Response.make(status, resp_body, resp_headers)
+    except ForwardedRequestTooLargeError:
+        _set_auth_base_request_too_large(
+            flow,
+            allow=allow,
+            proxy_log_path=proxy_log_path,
+            firewall_base=firewall_base,
+        )
+        return False
     except Exception as e:
         _set_url_rewrite_forward_failed(
             flow,
@@ -831,6 +874,15 @@ async def handle_firewall_request(
     vars_map = vm_info.get("vars")
 
     firewall_billable = bool(flow.metadata[metadata_keys.FIREWALL_BILLABLE])
+
+    if auth_base and _request_body_exceeds_auth_base_limit(flow):
+        _set_auth_base_request_too_large(
+            flow,
+            allow=allow,
+            proxy_log_path=proxy_log_path,
+            firewall_base=firewall_base,
+        )
+        return
 
     if not encrypted_secrets:
         log_proxy_entry(

--- a/crates/runner/mitm-addon/src/auth.py
+++ b/crates/runner/mitm-addon/src/auth.py
@@ -728,6 +728,7 @@ def _set_auth_base_request_too_large(
 ) -> None:
     body = flow.request.raw_content
     observed_size = len(body) if body is not None else 0
+    flow.metadata[metadata_keys.SUPPRESS_REQUEST_BODY_CAPTURE] = True
     log_proxy_entry(
         proxy_log_path,
         "warn",

--- a/crates/runner/mitm-addon/src/auth_base_forwarder.py
+++ b/crates/runner/mitm-addon/src/auth_base_forwarder.py
@@ -30,6 +30,7 @@ HOP_BY_HOP: frozenset[str] = frozenset(
     )
 )
 DEFAULT_HTTPS_PORT = 443
+MAX_AUTH_BASE_REQUEST_BODY_BYTES = 32 * 1024 * 1024
 MAX_AUTH_BASE_RESPONSE_BODY_BYTES = 32 * 1024 * 1024
 MAX_CONCURRENT_AUTH_BASE_FORWARDS = 4
 NAT64_WELL_KNOWN_PREFIX = ipaddress.IPv6Network("64:ff9b::/96")
@@ -39,6 +40,10 @@ _forward_request_semaphore_state: tuple[asyncio.AbstractEventLoop, asyncio.Semap
 
 class ForwardedResponseTooLargeError(Exception):
     """Raised when an auth.base upstream response exceeds the local body cap."""
+
+
+class ForwardedRequestTooLargeError(Exception):
+    """Raised when an auth.base forwarded request body exceeds the local cap."""
 
 
 class UnsafeAuthBaseDestinationError(Exception):
@@ -248,6 +253,11 @@ def _read_response_body(resp) -> bytes:
     return body
 
 
+def _validate_request_body_size(body: bytes | None) -> None:
+    if body is not None and len(body) > MAX_AUTH_BASE_REQUEST_BODY_BYTES:
+        raise ForwardedRequestTooLargeError("Forwarded auth.base request body too large")
+
+
 def _is_public_unicast_address(address: ipaddress.IPv4Address | ipaddress.IPv6Address) -> bool:
     if isinstance(address, ipaddress.IPv6Address) and (
         address.ipv4_mapped is not None
@@ -292,6 +302,7 @@ def _forward_request_sync(
     Security: only https URLs are allowed, and redirects are returned
     to the sandbox client instead of being followed inside the addon.
     """
+    _validate_request_body_size(body)
     parsed = urllib.parse.urlsplit(url)
     conn_factory = _connection_factory(parsed.scheme.lower())
     _reject_userinfo(parsed)
@@ -344,5 +355,6 @@ async def forward_request(
     body: bytes | None,
 ) -> tuple[int, bytes, http.Headers]:
     """Async wrapper for _forward_request_sync."""
+    _validate_request_body_size(body)
     async with _get_forward_request_semaphore():
         return await asyncio.to_thread(_forward_request_sync, url, method, headers, body)

--- a/crates/runner/mitm-addon/src/body_utils.py
+++ b/crates/runner/mitm-addon/src/body_utils.py
@@ -641,7 +641,10 @@ def add_capture_fields(flow: http.HTTPFlow, log_entry: dict) -> None:
     log_entry["request_headers"] = _sanitize_headers_for_capture(flow.request.headers)
 
     # Request body
-    if flow.request.raw_content:
+    if flow.metadata.get(metadata_keys.SUPPRESS_REQUEST_BODY_CAPTURE):
+        if flow.request.raw_content:
+            log_entry["request_body_truncated"] = True
+    elif flow.request.raw_content:
         req_ct = flow.request.headers.get("content-type", "")
         request_body = _decode_body_bounded(
             flow.request.raw_content,

--- a/crates/runner/mitm-addon/src/flow_metadata_keys.py
+++ b/crates/runner/mitm-addon/src/flow_metadata_keys.py
@@ -10,6 +10,7 @@ VM_SANDBOX_AUTH_KEY: Final = "vm_sandbox_token"
 ORIGINAL_URL: Final = "original_url"
 NETWORK_LOG_TARGET: Final = "network_log_target"
 CAPTURE_BODY: Final = "capture_body"
+SUPPRESS_REQUEST_BODY_CAPTURE: Final = "suppress_request_body_capture"
 CLI_AGENT_TYPE: Final = "cli_agent_type"
 BROWSER_USER_AGENT: Final = "browser_user_agent"
 

--- a/crates/runner/mitm-addon/tests/test_auth_base_forwarder.py
+++ b/crates/runner/mitm-addon/tests/test_auth_base_forwarder.py
@@ -684,6 +684,41 @@ class TestAuthBaseForwarderResponseBodyLimit:
         upstream.conn.close.assert_called_once()
 
 
+class TestAuthBaseForwarderRequestBodyLimit:
+    def test_accepts_body_at_limit(self):
+        with (
+            patch.object(forwarder, "MAX_AUTH_BASE_REQUEST_BODY_BYTES", 4),
+            _patched_forwarder_connection() as upstream,
+        ):
+            status, body, _headers = forwarder._forward_request_sync(
+                "https://example.com",
+                "POST",
+                [],
+                b"1234",
+            )
+
+        assert status == 200
+        assert body == b"ok"
+        upstream.conn.endheaders.assert_called_once_with(b"1234")
+
+    def test_rejects_body_over_limit_before_connection_setup(self):
+        with (
+            patch.object(forwarder, "MAX_AUTH_BASE_REQUEST_BODY_BYTES", 4),
+            _patched_forwarder_connection() as upstream,
+            pytest.raises(forwarder.ForwardedRequestTooLargeError),
+        ):
+            forwarder._forward_request_sync(
+                "https://example.com",
+                "POST",
+                [],
+                b"12345",
+            )
+
+        upstream.resolver.assert_not_called()
+        upstream.connection_factory.assert_not_called()
+        upstream.conn.endheaders.assert_not_called()
+
+
 class TestAuthBaseForwarderResourceCleanup:
     def test_closes_response_on_success(self):
         with _patched_forwarder_connection(
@@ -750,6 +785,21 @@ class TestAuthBaseForwarderResourceCleanup:
 
 
 class TestForwardRequestAsyncWrapper:
+    async def test_rejects_body_over_limit_before_sync_forward(self):
+        with (
+            patch.object(forwarder, "MAX_AUTH_BASE_REQUEST_BODY_BYTES", 4),
+            patch.object(forwarder, "_forward_request_sync") as sync_forward,
+            pytest.raises(forwarder.ForwardedRequestTooLargeError),
+        ):
+            await forwarder.forward_request(
+                "https://example.com",
+                "POST",
+                [],
+                b"12345",
+            )
+
+        sync_forward.assert_not_called()
+
     async def test_releases_forward_slot_when_forwarding_raises(self):
         with (
             patch.object(forwarder, "MAX_CONCURRENT_AUTH_BASE_FORWARDS", 1),

--- a/crates/runner/mitm-addon/tests/test_firewall_rewrite.py
+++ b/crates/runner/mitm-addon/tests/test_firewall_rewrite.py
@@ -622,6 +622,158 @@ class TestAuthBaseUrlRewriteEdgeCases:
 
         assert mock_forward.call_args[0][3] is None
 
+    async def test_forward_request_accepts_body_at_limit(self, real_flow, mitm_ctx, tmp_path):
+        flow, allow, vm_info, token_meta = make_rewrite_inputs(
+            real_flow,
+            tmp_path,
+            method="POST",
+            request_body=b"1234",
+        )
+        get_headers = AsyncMock(return_value=token_meta)
+        mock_forward = AsyncMock(return_value=(200, b"ok", {}))
+        with (
+            patch.object(auth, "MAX_AUTH_BASE_REQUEST_BODY_BYTES", 4),
+            patch.object(auth, "get_firewall_headers", get_headers),
+            patch.object(auth, "forward_request", mock_forward),
+            mitm_ctx(),
+        ):
+            await auth.handle_firewall_request(flow, allow, vm_info)
+
+        assert get_headers.await_count == 1
+        assert mock_forward.call_args[0][3] == b"1234"
+        assert flow.response is not None
+        assert flow.response.status_code == 200
+
+    async def test_oversized_request_body_returns_413_before_auth_resolution(
+        self, real_flow, mitm_ctx, tmp_path
+    ):
+        request_body = b"super-secret-body"
+        flow, allow, vm_info, token_meta = make_rewrite_inputs(
+            real_flow,
+            tmp_path,
+            method="POST",
+            request_body=request_body,
+            token_overrides={
+                "base": "https://real.example.com/webhook/super-secret-token",
+                "headers": {"Authorization": "Bearer real-token"},
+            },
+        )
+        get_headers = AsyncMock(return_value=token_meta)
+        mock_forward = AsyncMock()
+        mock_log = MagicMock()
+        with (
+            patch.object(auth, "MAX_AUTH_BASE_REQUEST_BODY_BYTES", 4),
+            patch.object(auth, "get_firewall_headers", get_headers),
+            patch.object(auth, "forward_request", mock_forward),
+            patch.object(auth, "log_proxy_entry", mock_log),
+            mitm_ctx(),
+        ):
+            await auth.handle_firewall_request(flow, allow, vm_info)
+
+        get_headers.assert_not_called()
+        mock_forward.assert_not_called()
+        assert flow.response is not None
+        assert flow.response.status_code == 413
+        body = json.loads(flow.response.content)
+        assert body == {
+            "error": "auth_base_request_body_too_large",
+            "message": "auth.base request body too large",
+            "permission": allow.name,
+            "base": allow.api_entry["base"],
+        }
+        assert flow.metadata["firewall_action"] == "ALLOW"
+        assert flow.metadata["firewall_error"] == "auth_base_request_body_too_large"
+        assert "auth_url_rewrite" not in flow.metadata
+        assert "auth_resolved_secrets" not in flow.metadata
+        response_text = flow.response.text
+        assert "super-secret-body" not in response_text
+        assert "super-secret-token" not in response_text
+        assert "Bearer real-token" not in response_text
+        assert "iv:tag:data" not in response_text
+        assert mock_log.call_args is not None
+        _args, kwargs = mock_log.call_args
+        assert kwargs["firewall_base"] == allow.api_entry["base"]
+        assert kwargs["request_body_size_bytes"] == len(request_body)
+        assert kwargs["request_body_limit_bytes"] == 4
+        for log_call in mock_log.call_args_list:
+            assert "super-secret-body" not in json.dumps(log_call.args)
+            assert "super-secret-token" not in json.dumps(log_call.args)
+            assert "Bearer real-token" not in json.dumps(log_call.args)
+            assert "iv:tag:data" not in json.dumps(log_call.args)
+            assert "super-secret-body" not in json.dumps(log_call.kwargs)
+            assert "super-secret-token" not in json.dumps(log_call.kwargs)
+            assert "Bearer real-token" not in json.dumps(log_call.kwargs)
+            assert "iv:tag:data" not in json.dumps(log_call.kwargs)
+
+    async def test_forward_request_too_large_error_returns_413(self, real_flow, mitm_ctx, tmp_path):
+        flow, allow, vm_info, token_meta = make_rewrite_inputs(
+            real_flow,
+            tmp_path,
+            method="POST",
+            request_body=b"1234",
+            resolved_base="https://real.example.com/webhook/super-secret-token",
+            token_overrides={"headers": {"Authorization": "Bearer real-token"}},
+        )
+        mock_forward = AsyncMock(side_effect=forwarder.ForwardedRequestTooLargeError())
+        mock_log = MagicMock()
+        with (
+            patch.object(auth, "MAX_AUTH_BASE_REQUEST_BODY_BYTES", 100),
+            patch.object(auth, "get_firewall_headers", AsyncMock(return_value=token_meta)),
+            patch.object(auth, "forward_request", mock_forward),
+            patch.object(auth, "log_proxy_entry", mock_log),
+            mitm_ctx(),
+        ):
+            await auth.handle_firewall_request(flow, allow, vm_info)
+
+        assert mock_forward.call_count == 1
+        assert flow.response is not None
+        assert flow.response.status_code == 413
+        body = json.loads(flow.response.content)
+        assert body["error"] == "auth_base_request_body_too_large"
+        assert flow.metadata["firewall_action"] == "ALLOW"
+        assert flow.metadata["firewall_error"] == "auth_base_request_body_too_large"
+        assert "auth_url_rewrite" not in flow.metadata
+        assert "url_rewrite_forward_failed" not in flow.response.text
+        assert "super-secret-token" not in flow.response.text
+        assert "Bearer real-token" not in flow.response.text
+        for log_call in mock_log.call_args_list:
+            assert "super-secret-token" not in json.dumps(log_call.args)
+            assert "Bearer real-token" not in json.dumps(log_call.args)
+            assert "super-secret-token" not in json.dumps(log_call.kwargs)
+            assert "Bearer real-token" not in json.dumps(log_call.kwargs)
+
+    async def test_non_auth_base_rule_does_not_use_auth_base_body_cap(
+        self, real_flow, mitm_ctx, tmp_path
+    ):
+        flow, allow, vm_info, token_meta = make_rewrite_inputs(
+            real_flow,
+            tmp_path,
+            method="POST",
+            request_body=b"12345",
+            auth_overrides={
+                "base": None,
+                "headers": {"Authorization": "Bearer ${{ secrets.TOKEN }}"},
+            },
+            token_overrides={
+                "base": None,
+                "headers": {"Authorization": "Bearer real-token"},
+            },
+        )
+        get_headers = AsyncMock(return_value=token_meta)
+        with (
+            patch.object(auth, "MAX_AUTH_BASE_REQUEST_BODY_BYTES", 4),
+            patch.object(auth, "get_firewall_headers", get_headers),
+            mitm_ctx(),
+        ):
+            await auth.handle_firewall_request(flow, allow, vm_info)
+
+        assert get_headers.await_count == 1
+        assert flow.response is None
+        assert flow.request.headers["Authorization"] == "Bearer real-token"
+        assert flow.metadata["firewall_action"] == "ALLOW"
+        assert "firewall_error" not in flow.metadata
+        assert "auth_url_rewrite" not in flow.metadata
+
     async def test_forward_failure_returns_502(self, headers, real_flow, mitm_ctx, tmp_path):
         """forward_request exception produces a 502 error response and marks
         firewall_error without falling through to the success-path metadata.

--- a/crates/runner/mitm-addon/tests/test_request_handler_firewall_dispatch.py
+++ b/crates/runner/mitm-addon/tests/test_request_handler_firewall_dispatch.py
@@ -1,9 +1,12 @@
 """Firewall dispatch and network policy tests for the request hook."""
 
 import json
+from unittest.mock import AsyncMock, patch
 
 import pytest
 
+import auth
+import flow_metadata_keys as metadata_keys
 import mitm_addon
 from tests.request_handler_helpers import (
     _single_firewall_vm,
@@ -380,6 +383,68 @@ async def test_firewall_permission_allows_matched(
     assert flow.metadata["firewall_permission"] == "read-repos"
     assert flow.metadata["firewall_rule_match"] == "GET /repos/{owner}/{repo}"
     assert flow.metadata["firewall_params"] == {"owner": "octocat", "repo": "hello"}
+
+
+async def test_oversized_auth_base_request_does_not_capture_request_body(
+    tmp_path, real_flow, mitm_ctx, headers
+):
+    request_body = b'{"secret":"super-secret-body"}'
+    reg_path = _write_registry(
+        tmp_path,
+        vm_info=_single_firewall_vm(
+            tmp_path,
+            firewall_name="webhook",
+            api_entry={
+                "base": "https://placeholder.example.com",
+                "auth": {"headers": {}, "base": "${{ secrets.WEBHOOK_URL }}"},
+                "permissions": [{"name": "send", "rules": ["POST /"]}],
+            },
+            network_policy={
+                "allow": ["send"],
+                "deny": [],
+                "ask": [],
+                "unknownPolicy": "deny",
+            },
+            vm_fields={"captureNetworkBodies": True},
+        ),
+    )
+    flow = real_flow(
+        with_response=False,
+        client_ip="10.200.0.5",
+        host="placeholder.example.com",
+        method="POST",
+        path="/",
+        request_headers=headers(
+            ("Host", "placeholder.example.com"),
+            ("Content-Type", "application/json"),
+        ),
+        request_body=request_body,
+    )
+    get_headers = AsyncMock()
+
+    with (
+        mitm_ctx(registry_path=str(reg_path), api_url="https://api.vm0.ai"),
+        patch.object(auth, "MAX_AUTH_BASE_REQUEST_BODY_BYTES", 4),
+        patch.object(auth, "get_firewall_headers", get_headers),
+    ):
+        await mitm_addon.request(flow)
+        mitm_addon.response(flow)
+
+    get_headers.assert_not_called()
+    assert flow.response is not None
+    assert flow.response.status_code == 413
+    assert flow.metadata[metadata_keys.FIREWALL_ERROR] == "auth_base_request_body_too_large"
+    assert flow.metadata[metadata_keys.SUPPRESS_REQUEST_BODY_CAPTURE] is True
+
+    network_log_text = (tmp_path / "net.jsonl").read_text()
+    assert "super-secret-body" not in network_log_text
+    network_log_entry = json.loads(network_log_text)
+    assert "request_body" not in network_log_entry
+    assert network_log_entry["request_body_truncated"] is True
+    assert network_log_entry["firewall_error"] == "auth_base_request_body_too_large"
+
+    proxy_log_text = (tmp_path / "proxy.jsonl").read_text()
+    assert "super-secret-body" not in proxy_log_text
 
 
 async def test_firewall_unknown_policy_allow_writes_empty_permission_metadata(


### PR DESCRIPTION
## Summary

- add a 32 MiB request-body cap for auth.base forwarded requests
- reject oversized auth.base rewrites with local 413 before resolving firewall auth
- keep low-level forwarder invariants so direct callers cannot bypass the cap
- cover at-limit, over-limit, secret-safe, and non-auth.base behavior

Closes #16110.

## Tests

- `/tmp/vm0-mitm-addon-venv/bin/python -m pytest tests/test_auth_base_forwarder.py tests/test_firewall_rewrite.py`
- `/tmp/vm0-mitm-addon-venv/bin/python -m ruff format --check .`
- `/tmp/vm0-mitm-addon-venv/bin/python -m ruff check .`
- `/tmp/vm0-mitm-addon-venv/bin/basedpyright --pythonpath /tmp/vm0-mitm-addon-venv/bin/python`
