### PR TITLE
perf: move local queue fs work off async runtime

### DIFF
--- a/crates/runner/src/local_queue/mod.rs
+++ b/crates/runner/src/local_queue/mod.rs
@@ -8,5 +8,5 @@ pub(crate) use paths::{
     cancel_path, cancels_dir, claim_path, claims_dir, job_path, jobs_dir, profile_jobs_dir,
     result_path, results_dir,
 };
-pub(crate) use state::LocalQueue;
+pub(crate) use state::{CancelTargetState, LocalClaimResult, LocalDiscoveredJob, LocalQueue};
 pub(crate) use types::{JobRequest, JobResponse};

--- a/crates/runner/src/local_queue/state.rs
+++ b/crates/runner/src/local_queue/state.rs
@@ -1,8 +1,36 @@
 use std::path::{Path, PathBuf};
 
-use tracing::warn;
+use tracing::{info, warn};
 
+use super::types::{JobRequest, JobResponse};
 use crate::ids::RunId;
+
+#[derive(Clone)]
+pub(crate) struct LocalDiscoveredJob {
+    pub(crate) run_id: RunId,
+    pub(crate) profile_name: String,
+    pub(crate) job_path: PathBuf,
+}
+
+pub(crate) enum LocalClaimResult {
+    Claimed {
+        request: Box<JobRequest>,
+        request_profile: String,
+    },
+    NotClaimed,
+}
+
+#[derive(Clone, Copy, Eq, PartialEq)]
+pub(crate) enum CancelTargetState {
+    Pending,
+    NotPending,
+    Unknown,
+}
+
+pub(crate) struct LocalCancelMarker {
+    pub(crate) run_id: RunId,
+    pub(crate) target_state: CancelTargetState,
+}
 
 /// Shared file-state checks for the local queue protocol.
 #[derive(Clone)]
@@ -21,21 +49,240 @@ impl LocalQueue {
         Self { group_dir }
     }
 
-    pub(crate) fn group_dir(&self) -> &Path {
-        &self.group_dir
+    pub(crate) fn discover_candidate_sync(
+        &self,
+        supported_profiles: &[String],
+        start: usize,
+    ) -> Option<LocalDiscoveredJob> {
+        if supported_profiles.is_empty() {
+            return None;
+        }
+
+        let profile_count = supported_profiles.len();
+        for offset in 0..profile_count {
+            let Some(profile) = supported_profiles.get(start.wrapping_add(offset) % profile_count)
+            else {
+                continue;
+            };
+            let profile_dir = match super::profile_jobs_dir(&self.group_dir, profile) {
+                Ok(dir) => dir,
+                Err(e) => {
+                    warn!(profile, error = %e, "local: invalid supported profile");
+                    continue;
+                }
+            };
+            let entries = match std::fs::read_dir(&profile_dir) {
+                Ok(e) => e,
+                Err(e) if e.kind() == std::io::ErrorKind::NotFound => continue,
+                Err(e) => {
+                    warn!(path = %profile_dir.display(), error = %e, "local: cannot read profile job dir");
+                    continue;
+                }
+            };
+
+            let mut job_paths: Vec<_> = entries
+                .filter_map(Result::ok)
+                .map(|entry| entry.path())
+                .filter(|path| path.extension().and_then(|e| e.to_str()) == Some("job"))
+                .collect();
+            job_paths.sort();
+
+            for path in job_paths {
+                let Some(stem) = path.file_stem().and_then(|s| s.to_str()) else {
+                    continue;
+                };
+                let Ok(run_id) = stem.parse::<RunId>() else {
+                    continue;
+                };
+                if super::claim_path(&self.group_dir, run_id).exists() {
+                    continue;
+                }
+                if self.result_file_has_content(run_id) {
+                    continue;
+                }
+                return Some(LocalDiscoveredJob {
+                    run_id,
+                    profile_name: profile.clone(),
+                    job_path: path,
+                });
+            }
+        }
+        None
     }
 
-    pub(crate) fn has_pending_cancel_target(&self, run_id: RunId) -> bool {
+    pub(crate) fn claim_job_sync(
+        &self,
+        run_id: RunId,
+        partition_profile: &str,
+        job_file: &Path,
+    ) -> LocalClaimResult {
+        // Atomic claim via O_EXCL — only the first runner to create the file wins.
+        let claim_dir = super::claims_dir(&self.group_dir);
+        if let Err(e) = std::fs::create_dir_all(&claim_dir) {
+            warn!(path = %claim_dir.display(), error = %e, "local: failed to create claim dir");
+            return LocalClaimResult::NotClaimed;
+        }
+        let claim_file = super::claim_path(&self.group_dir, run_id);
+        if std::fs::OpenOptions::new()
+            .write(true)
+            .create_new(true)
+            .open(&claim_file)
+            .is_err()
+        {
+            return LocalClaimResult::NotClaimed;
+        }
         if self.result_file_has_content(run_id) {
-            return false;
+            info!(run_id = %run_id, "local: job already has result, skipping claim");
+            let _ = std::fs::remove_file(&claim_file);
+            return LocalClaimResult::NotClaimed;
+        }
+
+        let buf = match std::fs::read(job_file) {
+            Ok(b) => b,
+            Err(e) if e.kind() == std::io::ErrorKind::NotFound => {
+                warn!(run_id = %run_id, error = %e, "local: failed to read job file");
+                let _ = std::fs::remove_file(&claim_file);
+                return LocalClaimResult::NotClaimed;
+            }
+            Err(e) => {
+                warn!(run_id = %run_id, error = %e, "local: unreadable job file, marking job as failed");
+                self.fail_claimed_job_sync_with_claim(
+                    run_id,
+                    &claim_file,
+                    job_file,
+                    format!("failed to read job file: {e}"),
+                );
+                return LocalClaimResult::NotClaimed;
+            }
+        };
+        let request: JobRequest = match serde_json::from_slice(&buf) {
+            Ok(r) => r,
+            Err(e) => {
+                warn!(run_id = %run_id, error = %e, "local: invalid job JSON, marking job as failed");
+                // Submit writes .job atomically (tmp + rename), so a malformed
+                // .job is a permanent error — retrying the parse will just
+                // spin. Keep the claim until after the result attempt so other
+                // local runners do not repeatedly process the same poison job.
+                // If the result write fails, the claim is released and the job
+                // remains retryable. If it succeeds, the result becomes the
+                // durable terminal marker before the bad job is removed.
+                self.fail_claimed_job_sync_with_claim(
+                    run_id,
+                    &claim_file,
+                    job_file,
+                    format!("invalid job JSON: {e}"),
+                );
+                return LocalClaimResult::NotClaimed;
+            }
+        };
+
+        if request.job_id != run_id {
+            let error = format!(
+                "job id mismatch: request={}, filename={run_id}",
+                request.job_id
+            );
+            warn!(run_id = %run_id, error = %error, "local: invalid job id");
+            self.fail_claimed_job_sync_with_claim(run_id, &claim_file, job_file, error);
+            return LocalClaimResult::NotClaimed;
+        }
+
+        let request_profile = match request.profile.clone() {
+            Some(profile) => profile,
+            None if partition_profile == crate::profile::DEFAULT_PROFILE => {
+                crate::profile::DEFAULT_PROFILE.to_owned()
+            }
+            None => {
+                let error =
+                    format!("missing job profile in non-default partition: {partition_profile}");
+                warn!(run_id = %run_id, error = %error, "local: invalid job profile");
+                self.fail_claimed_job_sync_with_claim(run_id, &claim_file, job_file, error);
+                return LocalClaimResult::NotClaimed;
+            }
+        };
+        if request_profile != partition_profile {
+            let error = format!(
+                "job profile mismatch: request={request_profile}, partition={partition_profile}"
+            );
+            warn!(run_id = %run_id, error = %error, "local: invalid job profile");
+            self.fail_claimed_job_sync_with_claim(run_id, &claim_file, job_file, error);
+            return LocalClaimResult::NotClaimed;
+        }
+
+        LocalClaimResult::Claimed {
+            request: Box::new(request),
+            request_profile,
+        }
+    }
+
+    pub(crate) fn fail_claimed_job_sync(&self, run_id: RunId, job_file: &Path, error: String) {
+        let claim_file = super::claim_path(&self.group_dir, run_id);
+        self.fail_claimed_job_sync_with_claim(run_id, &claim_file, job_file, error);
+    }
+
+    pub(crate) fn complete_job_sync(&self, run_id: RunId, exit_code: i32, error: Option<String>) {
+        if !self.write_result_sync(run_id, exit_code, error.as_deref()) {
+            if self.remove_job_file_if_present(run_id) {
+                let _ = std::fs::remove_file(super::cancel_path(&self.group_dir, run_id));
+                let _ = std::fs::remove_file(super::claim_path(&self.group_dir, run_id));
+            }
+            return;
+        }
+        // Best-effort cleanup of cancel file (may have been written after the
+        // last discover() scan but before the job actually finished).
+        let _ = std::fs::remove_file(super::cancel_path(&self.group_dir, run_id));
+        let _ = std::fs::remove_file(super::claim_path(&self.group_dir, run_id));
+    }
+
+    pub(crate) fn collect_cancel_markers_sync(&self) -> Vec<LocalCancelMarker> {
+        let cancel_dir = super::cancels_dir(&self.group_dir);
+        let entries = match std::fs::read_dir(&cancel_dir) {
+            Ok(e) => e,
+            Err(e) if e.kind() == std::io::ErrorKind::NotFound => return Vec::new(),
+            Err(e) => {
+                warn!(path = %cancel_dir.display(), error = %e, "local: cannot read cancel dir");
+                return Vec::new();
+            }
+        };
+        let mut cancel_markers = Vec::new();
+        let mut seen = std::collections::HashSet::new();
+        for entry in entries.filter_map(Result::ok) {
+            let path = entry.path();
+            if path.extension().and_then(|e| e.to_str()) != Some("cancel") {
+                continue;
+            }
+            let Some(stem) = path.file_stem().and_then(|s| s.to_str()) else {
+                continue;
+            };
+            let Ok(run_id) = stem.parse::<RunId>() else {
+                continue;
+            };
+            if seen.insert(run_id) {
+                cancel_markers.push(LocalCancelMarker {
+                    run_id,
+                    target_state: self.cancel_target_state(run_id),
+                });
+            }
+        }
+        cancel_markers
+    }
+
+    pub(crate) fn remove_cancel_files_sync(&self, run_ids: Vec<RunId>) {
+        for run_id in run_ids {
+            let _ = std::fs::remove_file(super::cancel_path(&self.group_dir, run_id));
+        }
+    }
+
+    fn cancel_target_state(&self, run_id: RunId) -> CancelTargetState {
+        if self.result_file_has_content(run_id) {
+            return CancelTargetState::NotPending;
         }
         if super::claim_path(&self.group_dir, run_id).exists() {
-            return true;
+            return CancelTargetState::Pending;
         }
         match self.lookup_job_file(run_id) {
-            JobFileLookup::Found(_) => true,
-            JobFileLookup::NotFound => false,
-            JobFileLookup::ScanFailed => true,
+            JobFileLookup::Found(_) => CancelTargetState::Pending,
+            JobFileLookup::NotFound => CancelTargetState::NotPending,
+            JobFileLookup::ScanFailed => CancelTargetState::Unknown,
         }
     }
 
@@ -59,6 +306,60 @@ impl LocalQueue {
             JobFileLookup::NotFound => true,
             JobFileLookup::ScanFailed => false,
         }
+    }
+
+    pub(crate) fn write_result_sync(
+        &self,
+        run_id: RunId,
+        exit_code: i32,
+        error: Option<&str>,
+    ) -> bool {
+        let response = JobResponse {
+            run_id,
+            exit_code,
+            error: error.map(String::from),
+        };
+        let json = match serde_json::to_vec(&response) {
+            Ok(j) => j,
+            Err(e) => {
+                warn!(run_id = %run_id, error = %e, "local: failed to serialize result");
+                return false;
+            }
+        };
+
+        let result_dir = super::results_dir(&self.group_dir);
+        if let Err(e) = std::fs::create_dir_all(&result_dir) {
+            warn!(path = %result_dir.display(), error = %e, "local: failed to create result dir");
+            return false;
+        }
+
+        // Atomic write: tmp then rename, so submit never reads a partial file.
+        let tmp_file = result_dir.join(format!("{run_id}.{}.result.tmp", RunId::new_v4()));
+        let result_file = super::result_path(&self.group_dir, run_id);
+        if let Err(e) = std::fs::write(&tmp_file, &json) {
+            warn!(run_id = %run_id, error = %e, "local: failed to write result file");
+            let _ = std::fs::remove_file(&tmp_file);
+            return false;
+        }
+        if let Err(e) = std::fs::rename(&tmp_file, &result_file) {
+            warn!(run_id = %run_id, error = %e, "local: failed to rename result file");
+            let _ = std::fs::remove_file(&tmp_file);
+            return false;
+        }
+        true
+    }
+
+    fn fail_claimed_job_sync_with_claim(
+        &self,
+        run_id: RunId,
+        claim_file: &Path,
+        job_file: &Path,
+        error: String,
+    ) {
+        if self.write_result_sync(run_id, 1, Some(&error)) {
+            let _ = std::fs::remove_file(job_file);
+        }
+        let _ = std::fs::remove_file(claim_file);
     }
 
     fn lookup_job_file(&self, run_id: RunId) -> JobFileLookup {

--- a/crates/runner/src/provider/local.rs
+++ b/crates/runner/src/provider/local.rs
@@ -18,7 +18,9 @@ use tracing::{info, warn};
 use super::local_cancel::{LocalCancelScanner, LocalCancelWatcher};
 use super::{ClaimedJob, CompletionAuth, JobCandidate, JobProvider};
 use crate::ids::RunId;
-use crate::local_queue::{self, JobRequest, JobResponse, LocalQueue};
+#[cfg(test)]
+use crate::local_queue::{self, JobRequest, JobResponse};
+use crate::local_queue::{LocalClaimResult, LocalDiscoveredJob, LocalQueue};
 use crate::types::{ExecutionContext, HeartbeatState, SandboxReuseResult};
 use sandbox::SandboxId;
 
@@ -99,115 +101,43 @@ impl LocalProvider {
 
 impl LocalProvider {
     /// Find the first unclaimed job in the supported profile partitions.
+    #[cfg(test)]
     fn find_unclaimed_job(&self) -> Option<JobCandidate> {
-        if self.supported_profiles.is_empty() {
-            return None;
-        }
-
         let start = self.profile_cursor.fetch_add(1, Ordering::Relaxed);
-        let profile_count = self.supported_profiles.len();
-        for offset in 0..profile_count {
-            let Some(profile) = self
-                .supported_profiles
-                .get(start.wrapping_add(offset) % profile_count)
-            else {
-                continue;
-            };
-            let profile_dir = match local_queue::profile_jobs_dir(self.queue.group_dir(), profile) {
-                Ok(dir) => dir,
-                Err(e) => {
-                    warn!(profile, error = %e, "local: invalid supported profile");
-                    continue;
-                }
-            };
-            let entries = match std::fs::read_dir(&profile_dir) {
-                Ok(e) => e,
-                Err(e) if e.kind() == std::io::ErrorKind::NotFound => continue,
-                Err(e) => {
-                    warn!(path = %profile_dir.display(), error = %e, "local: cannot read profile job dir");
-                    continue;
-                }
-            };
-
-            let mut job_paths: Vec<_> = entries
-                .filter_map(Result::ok)
-                .map(|entry| entry.path())
-                .filter(|path| path.extension().and_then(|e| e.to_str()) == Some("job"))
-                .collect();
-            job_paths.sort();
-
-            for path in job_paths {
-                let Some(stem) = path.file_stem().and_then(|s| s.to_str()) else {
-                    continue;
-                };
-                let Ok(job_id) = stem.parse::<RunId>() else {
-                    continue;
-                };
-                let claim_path = local_queue::claim_path(self.queue.group_dir(), job_id);
-                if claim_path.exists() {
-                    continue;
-                }
-                if self.result_file_has_content(job_id) {
-                    continue;
-                }
-                return Some(JobCandidate::local(job_id, profile.clone(), path));
-            }
-        }
-        None
+        self.queue
+            .discover_candidate_sync(&self.supported_profiles, start)
+            .map(job_candidate_from_discovered)
     }
 
-    fn result_file_has_content(&self, run_id: RunId) -> bool {
-        self.queue.result_file_has_content(run_id)
-    }
-
+    #[cfg(test)]
     fn write_result(&self, run_id: RunId, exit_code: i32, error: Option<&str>) -> bool {
-        let response = JobResponse {
-            run_id,
-            exit_code,
-            error: error.map(String::from),
-        };
-        let json = match serde_json::to_vec(&response) {
-            Ok(j) => j,
+        self.queue.write_result_sync(run_id, exit_code, error)
+    }
+
+    async fn find_unclaimed_job_blocking(&self) -> Option<JobCandidate> {
+        let start = self.profile_cursor.fetch_add(1, Ordering::Relaxed);
+        let queue = self.queue.clone();
+        let supported_profiles = self.supported_profiles.clone();
+        match tokio::task::spawn_blocking(move || {
+            queue.discover_candidate_sync(&supported_profiles, start)
+        })
+        .await
+        {
+            Ok(discovered) => discovered.map(job_candidate_from_discovered),
             Err(e) => {
-                warn!(run_id = %run_id, error = %e, "local: failed to serialize result");
-                return false;
+                warn!(error = %e, "local: blocking job discovery failed");
+                None
             }
-        };
-
-        let result_dir = local_queue::results_dir(self.queue.group_dir());
-        if let Err(e) = std::fs::create_dir_all(&result_dir) {
-            warn!(path = %result_dir.display(), error = %e, "local: failed to create result dir");
-            return false;
         }
-
-        // Atomic write: tmp then rename, so submit never reads a partial file.
-        let tmp_file = result_dir.join(format!("{run_id}.{}.result.tmp", RunId::new_v4()));
-        let result_file = local_queue::result_path(self.queue.group_dir(), run_id);
-        if let Err(e) = std::fs::write(&tmp_file, &json) {
-            warn!(run_id = %run_id, error = %e, "local: failed to write result file");
-            let _ = std::fs::remove_file(&tmp_file);
-            return false;
-        }
-        if let Err(e) = std::fs::rename(&tmp_file, &result_file) {
-            warn!(run_id = %run_id, error = %e, "local: failed to rename result file");
-            let _ = std::fs::remove_file(&tmp_file);
-            return false;
-        }
-        true
     }
+}
 
-    async fn fail_claimed_job(
-        &self,
-        run_id: RunId,
-        claim_file: &std::path::Path,
-        job_file: &std::path::Path,
-        error: String,
-    ) {
-        if self.write_result(run_id, 1, Some(&error)) {
-            let _ = std::fs::remove_file(job_file);
-        }
-        let _ = std::fs::remove_file(claim_file);
-    }
+fn job_candidate_from_discovered(discovered: LocalDiscoveredJob) -> JobCandidate {
+    JobCandidate::local(
+        discovered.run_id,
+        discovered.profile_name,
+        discovered.job_path,
+    )
 }
 
 #[async_trait::async_trait]
@@ -219,7 +149,7 @@ impl JobProvider for LocalProvider {
             }
             // Check for cancel requests before looking for new jobs.
             self.cancel_scanner.scan_cancel_files().await;
-            if let Some(candidate) = self.find_unclaimed_job() {
+            if let Some(candidate) = self.find_unclaimed_job_blocking().await {
                 info!(
                     run_id = %candidate.run_id(),
                     profile = %candidate.profile_name(),
@@ -242,100 +172,23 @@ impl JobProvider for LocalProvider {
             return None;
         };
 
-        // Atomic claim via O_EXCL — only the first runner to create the file wins.
-        let claim_dir = local_queue::claims_dir(self.queue.group_dir());
-        if let Err(e) = std::fs::create_dir_all(&claim_dir) {
-            warn!(path = %claim_dir.display(), error = %e, "local: failed to create claim dir");
-            return None;
-        }
-        let claim_file = local_queue::claim_path(self.queue.group_dir(), run_id);
-        if std::fs::OpenOptions::new()
-            .write(true)
-            .create_new(true)
-            .open(&claim_file)
-            .is_err()
-        {
-            return None;
-        }
-        if self.result_file_has_content(run_id) {
-            info!(run_id = %run_id, "local: job already has result, skipping claim");
-            let _ = std::fs::remove_file(&claim_file);
-            return None;
-        }
-
-        // Read the job request.
-        let buf = match std::fs::read(&job_file) {
-            Ok(b) => b,
-            Err(e) if e.kind() == std::io::ErrorKind::NotFound => {
-                warn!(run_id = %run_id, error = %e, "local: failed to read job file");
-                let _ = std::fs::remove_file(&claim_file);
-                return None;
-            }
+        let queue = self.queue.clone();
+        let job_file_for_claim = job_file.clone();
+        let claim_result = tokio::task::spawn_blocking(move || {
+            queue.claim_job_sync(run_id, &partition_profile, &job_file_for_claim)
+        })
+        .await;
+        let (req, request_profile) = match claim_result {
+            Ok(LocalClaimResult::Claimed {
+                request,
+                request_profile,
+            }) => (*request, request_profile),
+            Ok(LocalClaimResult::NotClaimed) => return None,
             Err(e) => {
-                warn!(run_id = %run_id, error = %e, "local: unreadable job file, marking job as failed");
-                self.fail_claimed_job(
-                    run_id,
-                    &claim_file,
-                    &job_file,
-                    format!("failed to read job file: {e}"),
-                )
-                .await;
+                warn!(run_id = %run_id, error = %e, "local: blocking claim failed");
                 return None;
             }
         };
-        let req: JobRequest = match serde_json::from_slice(&buf) {
-            Ok(r) => r,
-            Err(e) => {
-                warn!(run_id = %run_id, error = %e, "local: invalid job JSON, marking job as failed");
-                // Submit writes .job atomically (tmp + rename), so a malformed
-                // .job is a permanent error — retrying the parse will just
-                // spin. Keep the claim until after the result attempt so other
-                // local runners do not repeatedly process the same poison job.
-                // If the result write fails, the claim is released and the job
-                // remains retryable. If it succeeds, the result becomes the
-                // durable terminal marker before the bad job is removed.
-                self.fail_claimed_job(
-                    run_id,
-                    &claim_file,
-                    &job_file,
-                    format!("invalid job JSON: {e}"),
-                )
-                .await;
-                return None;
-            }
-        };
-
-        if req.job_id != run_id {
-            let error = format!("job id mismatch: request={}, filename={run_id}", req.job_id);
-            warn!(run_id = %run_id, error = %error, "local: invalid job id");
-            self.fail_claimed_job(run_id, &claim_file, &job_file, error)
-                .await;
-            return None;
-        }
-
-        let request_profile = match req.profile.clone() {
-            Some(profile) => profile,
-            None if partition_profile == crate::profile::DEFAULT_PROFILE => {
-                crate::profile::DEFAULT_PROFILE.to_owned()
-            }
-            None => {
-                let error =
-                    format!("missing job profile in non-default partition: {partition_profile}");
-                warn!(run_id = %run_id, error = %error, "local: invalid job profile");
-                self.fail_claimed_job(run_id, &claim_file, &job_file, error)
-                    .await;
-                return None;
-            }
-        };
-        if request_profile != partition_profile {
-            let error = format!(
-                "job profile mismatch: request={request_profile}, partition={partition_profile}"
-            );
-            warn!(run_id = %run_id, error = %error, "local: invalid job profile");
-            self.fail_claimed_job(run_id, &claim_file, &job_file, error)
-                .await;
-            return None;
-        }
 
         let context = ExecutionContext {
             run_id,
@@ -386,8 +239,14 @@ impl JobProvider for LocalProvider {
                     err.expected_run_id, err.context_run_id
                 );
                 warn!(run_id = %run_id, error = %error, "local: claimed job invariant violation");
-                self.fail_claimed_job(run_id, &claim_file, &job_file, error)
-                    .await;
+                let queue = self.queue.clone();
+                if let Err(e) = tokio::task::spawn_blocking(move || {
+                    queue.fail_claimed_job_sync(run_id, &job_file, error);
+                })
+                .await
+                {
+                    warn!(run_id = %run_id, error = %e, "local: blocking claimed-job failure cleanup failed");
+                }
                 None
             }
         }
@@ -403,19 +262,14 @@ impl JobProvider for LocalProvider {
         _completion_auth: CompletionAuth,
     ) {
         self.cancel_scanner.remove_owned_claim(run_id).await;
-        if !self.write_result(run_id, exit_code, error) {
-            if self.queue.remove_job_file_if_present(run_id) {
-                let _ =
-                    std::fs::remove_file(local_queue::cancel_path(self.queue.group_dir(), run_id));
-                let _ =
-                    std::fs::remove_file(local_queue::claim_path(self.queue.group_dir(), run_id));
-            }
-            return;
+        let queue = self.queue.clone();
+        let error = error.map(str::to_owned);
+        if let Err(e) =
+            tokio::task::spawn_blocking(move || queue.complete_job_sync(run_id, exit_code, error))
+                .await
+        {
+            warn!(run_id = %run_id, error = %e, "local: blocking completion failed");
         }
-        // Best-effort cleanup of cancel file (may have been written after the
-        // last discover() scan but before the job actually finished).
-        let _ = std::fs::remove_file(local_queue::cancel_path(self.queue.group_dir(), run_id));
-        let _ = std::fs::remove_file(local_queue::claim_path(self.queue.group_dir(), run_id));
     }
 
     async fn heartbeat(&self, _state: &HeartbeatState) {}

--- a/crates/runner/src/provider/local_cancel.rs
+++ b/crates/runner/src/provider/local_cancel.rs
@@ -7,7 +7,9 @@ use tokio_util::sync::CancellationToken;
 use tracing::{info, warn};
 
 use crate::ids::RunId;
-use crate::local_queue::{self, LocalQueue};
+#[cfg(test)]
+use crate::local_queue;
+use crate::local_queue::{CancelTargetState, LocalQueue};
 
 /// Poll interval for scanning local cancel markers.
 const POLL_INTERVAL: Duration = Duration::from_millis(100);
@@ -45,7 +47,20 @@ impl LocalCancelScanner {
     /// token are kept while a claim/job may still exist, and are deleted only
     /// after they no longer have a pending target.
     pub(super) async fn scan_cancel_files(&self) {
-        let cancel_ids = self.collect_cancel_ids();
+        let queue = self.queue.clone();
+        let cancel_markers =
+            match tokio::task::spawn_blocking(move || queue.collect_cancel_markers_sync()).await {
+                Ok(markers) => markers,
+                Err(e) => {
+                    warn!(error = %e, "local: blocking cancel marker scan failed");
+                    return;
+                }
+            };
+        if cancel_markers.is_empty() {
+            return;
+        }
+
+        let cancel_ids: Vec<RunId> = cancel_markers.iter().map(|marker| marker.run_id).collect();
         if cancel_ids.is_empty() {
             return;
         }
@@ -53,56 +68,35 @@ impl LocalCancelScanner {
         let tokens = self.snapshot_cancel_tokens(&cancel_ids).await;
         let owned_claims = self.snapshot_owned_claims(&cancel_ids).await;
 
-        for run_id in cancel_ids {
+        let mut delete_cancel_ids = Vec::new();
+        for marker in cancel_markers {
+            let run_id = marker.run_id;
             if let Some(token) = tokens.get(&run_id) {
                 let was_cancelled = token.is_cancelled();
                 token.cancel();
                 if !was_cancelled {
                     info!(run_id = %run_id, "local: cancel file detected, cancelling job");
                 }
-                let should_delete =
-                    owned_claims.contains(&run_id) || !self.queue.has_pending_cancel_target(run_id);
+                let should_delete = owned_claims.contains(&run_id)
+                    || marker.target_state == CancelTargetState::NotPending;
                 if should_delete {
-                    let _ = std::fs::remove_file(local_queue::cancel_path(
-                        self.queue.group_dir(),
-                        run_id,
-                    ));
+                    delete_cancel_ids.push(run_id);
                 }
-            } else if !self.queue.has_pending_cancel_target(run_id) {
-                let _ =
-                    std::fs::remove_file(local_queue::cancel_path(self.queue.group_dir(), run_id));
+            } else if marker.target_state == CancelTargetState::NotPending {
+                delete_cancel_ids.push(run_id);
             }
         }
-    }
 
-    fn collect_cancel_ids(&self) -> Vec<RunId> {
-        let cancel_dir = local_queue::cancels_dir(self.queue.group_dir());
-        let entries = match std::fs::read_dir(&cancel_dir) {
-            Ok(e) => e,
-            Err(e) if e.kind() == std::io::ErrorKind::NotFound => return Vec::new(),
-            Err(e) => {
-                warn!(path = %cancel_dir.display(), error = %e, "local: cannot read cancel dir");
-                return Vec::new();
-            }
-        };
-        let mut cancel_ids = Vec::new();
-        let mut seen = HashSet::new();
-        for entry in entries.filter_map(Result::ok) {
-            let path = entry.path();
-            if path.extension().and_then(|e| e.to_str()) != Some("cancel") {
-                continue;
-            }
-            let Some(stem) = path.file_stem().and_then(|s| s.to_str()) else {
-                continue;
-            };
-            let Ok(run_id) = stem.parse::<RunId>() else {
-                continue;
-            };
-            if seen.insert(run_id) {
-                cancel_ids.push(run_id);
+        if !delete_cancel_ids.is_empty() {
+            let queue = self.queue.clone();
+            if let Err(e) = tokio::task::spawn_blocking(move || {
+                queue.remove_cancel_files_sync(delete_cancel_ids)
+            })
+            .await
+            {
+                warn!(error = %e, "local: blocking cancel marker cleanup failed");
             }
         }
-        cancel_ids
     }
 
     async fn snapshot_cancel_tokens(


### PR DESCRIPTION
## Summary

- Move local queue discovery, claim, completion, and cancel-marker filesystem transactions into `LocalQueue` sync helpers.
- Execute those transactions through `tokio::task::spawn_blocking` from the async provider/cancel watcher paths.
- Preserve existing local queue ordering, `O_EXCL` claim behavior, result terminal markers, and cancel marker cleanup rules.

Closes #16096

## Tests

- `cargo test --manifest-path crates/Cargo.toml -p runner provider::local`
- `cargo test --manifest-path crates/Cargo.toml -p runner provider::local_cancel`
- `cargo fmt --manifest-path crates/runner/Cargo.toml --check`
- `cargo clippy --manifest-path crates/Cargo.toml -p runner --all-targets -- -D warnings`
- `cargo test --manifest-path crates/Cargo.toml -p runner`
