### PR TITLE
refactor: align connector auth method naming

### DIFF
--- a/turbo/apps/api/src/signals/routes/cli-auth-test.ts
+++ b/turbo/apps/api/src/signals/routes/cli-auth-test.ts
@@ -7,7 +7,7 @@ import {
   cliAuthTestTokenContract,
 } from "@vm0/api-contracts/contracts/cli-auth-test";
 import {
-  type ConnectorAuthProviderType,
+  type AuthGrantConnectorType,
   type ConnectorAuthMethodId,
   type ConnectorType,
   connectorTypeSchema,
@@ -16,7 +16,7 @@ import {
   getConnectorAuthMethod,
   getConnectorAuthMethodAccessMetadata,
   getConnectorAuthMethodGrantMetadata,
-  getConnectorAuthMethodStorageMetadata,
+  getConnectorAuthMethodRuntimeMetadata,
 } from "@vm0/connectors/connector-utils";
 import { agentComposes } from "@vm0/db/schema/agent-compose";
 import { deviceCodes } from "@vm0/db/schema/device-codes";
@@ -71,16 +71,16 @@ function stringError(status: 400 | 404, error: string) {
   return { status, body: { error } };
 }
 
-function connectorTypeHasSelectedProviderDrivenGrant(
+function connectorTypeHasSelectedAuthGrant(
   type: ConnectorType,
   authMethod: ConnectorAuthMethodId,
-): type is ConnectorAuthProviderType {
+): type is AuthGrantConnectorType {
   const grantKind = getConnectorAuthMethod(type, authMethod)?.grant.kind;
   return grantKind === "auth-code" || grantKind === "device-auth";
 }
 
 function testConnectorTokenOutputs(args: {
-  readonly connectorType: ConnectorAuthProviderType;
+  readonly connectorType: AuthGrantConnectorType;
   readonly authMethod: ConnectorAuthMethodId;
   readonly accessToken: string;
   readonly refreshToken: string | undefined;
@@ -89,11 +89,11 @@ function testConnectorTokenOutputs(args: {
     args.connectorType,
     args.authMethod,
   );
-  const storageMetadata = getConnectorAuthMethodStorageMetadata(
+  const runtimeMetadata = getConnectorAuthMethodRuntimeMetadata(
     args.connectorType,
     args.authMethod,
   );
-  if (!grantMetadata || !storageMetadata) {
+  if (!grantMetadata || !runtimeMetadata) {
     throw new Error(
       `${args.connectorType} connector auth method ${args.authMethod} does not expose token outputs`,
     );
@@ -104,7 +104,7 @@ function testConnectorTokenOutputs(args: {
       return [output.secretName, outputName];
     }),
   );
-  const accessOutputName = storageMetadata.runtimeBindings
+  const accessOutputName = runtimeMetadata.runtimeBindings
     .flatMap((binding) => {
       return binding.source.kind === "connector-secret"
         ? [outputNameBySecretName.get(binding.source.name)]
@@ -307,9 +307,7 @@ const createTestConnector$ = command(
       );
     }
 
-    if (
-      !connectorTypeHasSelectedProviderDrivenGrant(connectorType, authMethod)
-    ) {
+    if (!connectorTypeHasSelectedAuthGrant(connectorType, authMethod)) {
       return stringError(
         400,
         `${connectorType} connector auth method ${authMethod} does not use an auth-code or device-auth grant`,

--- a/turbo/apps/api/src/signals/services/__tests__/connector-oauth-state.service.test.ts
+++ b/turbo/apps/api/src/signals/services/__tests__/connector-oauth-state.service.test.ts
@@ -1,6 +1,6 @@
 import { randomUUID } from "node:crypto";
 
-import type { ConnectorAuthProviderType } from "@vm0/connectors/connectors";
+import type { AuthGrantConnectorType } from "@vm0/connectors/connectors";
 import { connectorOauthStates } from "@vm0/db/schema/connector-oauth-state";
 import { createStore } from "ccstate";
 import { inArray } from "drizzle-orm";
@@ -14,7 +14,7 @@ const store = createStore();
 
 type SeedOAuthStateInput = {
   readonly state?: string;
-  readonly type?: ConnectorAuthProviderType;
+  readonly type?: AuthGrantConnectorType;
   readonly consumedAt?: Date | null;
   readonly expiresAt?: Date;
 };

--- a/turbo/apps/api/src/signals/services/agent-run-create.service.ts
+++ b/turbo/apps/api/src/signals/services/agent-run-create.service.ts
@@ -29,7 +29,7 @@ import {
 import {
   getConnectorAuthMethodAccessMetadata,
   getConnectorAuthMethod,
-  getConnectorAuthMethodStorageMetadata,
+  getConnectorAuthMethodRuntimeMetadata,
   type ConnectorRuntimeBindingEntry,
 } from "@vm0/connectors/connector-utils";
 import {
@@ -1689,7 +1689,7 @@ function connectorEnvBindingSets(
       row.connectorType,
       row.authMethod,
     );
-    const metadata = getConnectorAuthMethodStorageMetadata(
+    const metadata = getConnectorAuthMethodRuntimeMetadata(
       row.connectorType,
       row.authMethod,
     );

--- a/turbo/apps/api/src/signals/services/agent-webhook-firewall-auth.service.ts
+++ b/turbo/apps/api/src/signals/services/agent-webhook-firewall-auth.service.ts
@@ -10,7 +10,7 @@ import {
   connectorRefreshMetadataHasRefreshableSecret,
   getConnectorAuthClientConfigForMethod,
   getConnectorAuthMethodAccessMetadata,
-  getConnectorAuthMethodStorageMetadata,
+  getConnectorAuthMethodRuntimeMetadata,
   getConnectorRuntimeBindingSecretName,
   resolveConnectorResolvedAuthMethodClientByAccessKind,
   connectorAuthMethodRefHasAccessKind,
@@ -19,7 +19,7 @@ import {
   type ConnectorAuthMethodRefByAccessKind,
   type ConnectorAuthMethodAccessMetadata,
   type ConnectorRefreshTokenInputMetadata,
-  type ConnectorAuthMethodStorageMetadata,
+  type ConnectorAuthMethodRuntimeMetadata,
   type ConnectorAuthClientForMethod,
 } from "@vm0/connectors/connector-utils";
 import {
@@ -539,7 +539,7 @@ interface RefreshSourceState {
 interface ConnectorAccessState extends RefreshSourceState {
   readonly authMethod: string;
   readonly accessMetadata: ConnectorAuthMethodAccessMetadata;
-  readonly storageMetadata: ConnectorAuthMethodStorageMetadata;
+  readonly runtimeMetadata: ConnectorAuthMethodRuntimeMetadata;
 }
 
 interface BasicArgContext extends BasicAuthTemplateArg {
@@ -856,7 +856,7 @@ function refreshableRuntimeSecretNameForSource(args: {
     return undefined;
   }
   const secretName = getConnectorRuntimeBindingSecretName(
-    connectorAccess.storageMetadata,
+    connectorAccess.runtimeMetadata,
     args.key,
   );
   return secretName &&
@@ -961,17 +961,17 @@ async function loadConnectorAccessStates(
       parsed.data,
       row.authMethod,
     );
-    const storageMetadata = getConnectorAuthMethodStorageMetadata(
+    const runtimeMetadata = getConnectorAuthMethodRuntimeMetadata(
       parsed.data,
       row.authMethod,
     );
-    if (!accessMetadata || !storageMetadata) {
+    if (!accessMetadata || !runtimeMetadata) {
       continue;
     }
     result.set(row.type, {
       authMethod: row.authMethod,
       accessMetadata,
-      storageMetadata,
+      runtimeMetadata,
       ...refreshSourceStateFromRow(row),
     });
   }
@@ -2268,13 +2268,13 @@ function connectorAccessSecretName(
   switch (connectorAccess.accessMetadata.kind) {
     case "refresh-token": {
       return getConnectorRuntimeBindingSecretName(
-        connectorAccess.storageMetadata,
+        connectorAccess.runtimeMetadata,
         key,
       );
     }
     case "static": {
       return getConnectorRuntimeBindingSecretName(
-        connectorAccess.storageMetadata,
+        connectorAccess.runtimeMetadata,
         key,
       );
     }

--- a/turbo/apps/api/src/signals/services/connector-availability.service.ts
+++ b/turbo/apps/api/src/signals/services/connector-availability.service.ts
@@ -1,6 +1,6 @@
 import { computed, type Computed } from "ccstate";
 import {
-  getAvailableConnectorAuthMethods,
+  getAvailableConnectorAuthMethodIds,
   isConnectorAuthMethodAvailable,
   type AvailableConnectorAuthMethodsOptions,
 } from "@vm0/connectors/connector-utils";
@@ -49,8 +49,8 @@ function createUserConnectorAvailability(args: {
       options = USER_CONNECTOR_AUTH_METHOD_OPTIONS,
     ) {
       return (
-        getAvailableConnectorAuthMethods(type, featureStates, options).length >
-        0
+        getAvailableConnectorAuthMethodIds(type, featureStates, options)
+          .length > 0
       );
     },
   };

--- a/turbo/apps/api/src/signals/services/zero-connector-data.service.ts
+++ b/turbo/apps/api/src/signals/services/zero-connector-data.service.ts
@@ -7,15 +7,15 @@ import type {
 import type { ConnectorSearchAuthMethod } from "@vm0/api-contracts/contracts/zero-connectors";
 import {
   connectorAuthMethodRefHasRevokeKind,
-  getAvailableConnectorAuthMethods,
+  getAvailableConnectorAuthMethodIds,
   getConnectorAuthMethodGrantMetadata,
   getConnectorAuthMethodRevokeMetadata,
-  getConnectorAuthMethodStorageMetadata,
+  getConnectorAuthMethodRuntimeMetadata,
   getConnectorAuthMethodScopeDiff,
   getConnectorAuthMethod,
   getConnectorManualGrantFieldNamesForAuthMethod,
   getConnectorOwnedSecretNames,
-  getConnectorVariableNames,
+  getConnectorOwnedVariableNames,
   getRuntimeAvailableConnectorTypes,
   type ConnectorAuthMethodRef,
   type ConnectorAuthMethodRefByRevokeKind,
@@ -30,7 +30,7 @@ import {
   type ConnectorAuthMethodId,
   type ConnectorManualGrantFieldConfig,
   type ConnectorType,
-  type ConnectorAuthProviderType,
+  type AuthGrantConnectorType,
 } from "@vm0/connectors/connectors";
 import {
   getAllFeatureStates,
@@ -169,7 +169,7 @@ function storedConnectorTypeIsVisible(
   featureStates: FeatureStates,
 ): boolean {
   return (
-    getAvailableConnectorAuthMethods(type, featureStates, {
+    getAvailableConnectorAuthMethodIds(type, featureStates, {
       apiAuthMethodPolicy: "include",
     }).length > 0
   );
@@ -421,7 +421,7 @@ function connectorProvidedEnvNamesForStoredConnectors(
 ): Set<string> {
   const provided = new Set<string>();
   for (const connector of connectorList) {
-    const metadata = getConnectorAuthMethodStorageMetadata(
+    const metadata = getConnectorAuthMethodRuntimeMetadata(
       connector.type,
       connector.authMethod,
     );
@@ -776,7 +776,7 @@ export const deleteZeroConnectorLocalState$ = command(
       await deleteConnectorScopedVariableNames(tx, {
         orgId: args.orgId,
         userId: args.userId,
-        names: getConnectorVariableNames(args.type, existing.authMethod),
+        names: getConnectorOwnedVariableNames(args.type, existing.authMethod),
         signal,
       });
 
@@ -1071,7 +1071,7 @@ async function cleanupExistingStoredConnectorForManualGrantConnect(
   await deleteConnectorScopedVariableNames(db, {
     orgId: args.orgId,
     userId: args.userId,
-    names: getConnectorVariableNames(args.type, existing.authMethod),
+    names: getConnectorOwnedVariableNames(args.type, existing.authMethod),
     signal: args.signal,
   });
 
@@ -1317,11 +1317,11 @@ function requiredConnectorTokenSecretRequirements(args: {
   readonly authMethod: string;
   readonly outputSecretNames: Readonly<Record<string, string>>;
 }): ConnectorTokenSecretRequirements {
-  const storageMetadata = getConnectorAuthMethodStorageMetadata(
+  const runtimeMetadata = getConnectorAuthMethodRuntimeMetadata(
     args.type,
     args.authMethod,
   );
-  if (!storageMetadata) {
+  if (!runtimeMetadata) {
     return { requiredOutputNames: [], requiredExtraSecretNames: [] };
   }
 
@@ -1332,7 +1332,7 @@ function requiredConnectorTokenSecretRequirements(args: {
   );
   const requiredOutputNames = new Set<string>();
   const requiredExtraSecretNames = new Set<string>();
-  for (const binding of storageMetadata.runtimeBindings) {
+  for (const binding of runtimeMetadata.runtimeBindings) {
     if (binding.source.kind !== "connector-secret") {
       continue;
     }
@@ -1350,7 +1350,7 @@ function requiredConnectorTokenSecretRequirements(args: {
 }
 
 function validateRequiredConnectorTokenSecrets(args: {
-  readonly type: ConnectorAuthProviderType;
+  readonly type: AuthGrantConnectorType;
   readonly outputs: ConnectorTokenOutputValues;
   readonly requiredOutputNames: readonly string[];
   readonly extraSecrets: readonly (readonly [string, string])[];
@@ -1383,7 +1383,7 @@ function validateRequiredConnectorTokenSecrets(args: {
 }
 
 function allowedConnectorTokenSecretNames(
-  type: ConnectorAuthProviderType,
+  type: AuthGrantConnectorType,
   authMethod: ConnectorAuthMethodId,
 ): Set<string> {
   return new Set(getConnectorOwnedSecretNames(type, authMethod));
@@ -1397,7 +1397,7 @@ function isPrimaryConnectorTokenSecret(args: {
 }
 
 function validateExtraConnectorTokenSecrets(args: {
-  readonly type: ConnectorAuthProviderType;
+  readonly type: AuthGrantConnectorType;
   readonly authMethod: ConnectorAuthMethodId;
   readonly extraConnectorSecrets: Readonly<Record<string, string>> | undefined;
   readonly outputSecretNames: Readonly<Record<string, string>>;
@@ -1434,7 +1434,7 @@ function validateExtraConnectorTokenSecrets(args: {
 }
 
 async function encryptExtraConnectorTokenSecrets(args: {
-  readonly type: ConnectorAuthProviderType;
+  readonly type: AuthGrantConnectorType;
   readonly extraSecrets: readonly (readonly [string, string])[];
   readonly featureSwitchContext: FeatureSwitchContext;
   readonly signal: AbortSignal;
@@ -1455,7 +1455,7 @@ async function encryptExtraConnectorTokenSecrets(args: {
 }
 
 async function encryptConnectorTokenSecretSet(args: {
-  readonly type: ConnectorAuthProviderType;
+  readonly type: AuthGrantConnectorType;
   readonly outputSecretNames: Readonly<Record<string, string>>;
   readonly requiredOutputNames: readonly string[];
   readonly requiredExtraSecretNames: readonly string[];
@@ -1557,7 +1557,7 @@ async function upsertConnectorTokenConnectionRow(
   args: {
     readonly orgId: string;
     readonly userId: string;
-    readonly type: ConnectorAuthProviderType;
+    readonly type: AuthGrantConnectorType;
     readonly authMethod: ConnectorAuthMethodId;
     readonly userInfo: ExternalUserInfo;
     readonly oauthScopes: readonly string[];
@@ -1617,7 +1617,7 @@ async function deleteObsoleteConnectorScopedStateForTokenConnect(
   args: {
     readonly orgId: string;
     readonly userId: string;
-    readonly type: ConnectorAuthProviderType;
+    readonly type: AuthGrantConnectorType;
     readonly authMethod: ConnectorAuthMethodId;
     readonly existingAuthMethod: string | null;
     readonly signal: AbortSignal;
@@ -1637,9 +1637,9 @@ async function deleteObsoleteConnectorScopedStateForTokenConnect(
     return !targetSecretNames.has(name);
   });
   const targetVariableNames = new Set(
-    getConnectorVariableNames(args.type, args.authMethod),
+    getConnectorOwnedVariableNames(args.type, args.authMethod),
   );
-  const obsoleteVariableNames = getConnectorVariableNames(
+  const obsoleteVariableNames = getConnectorOwnedVariableNames(
     args.type,
     args.existingAuthMethod,
   ).filter((name) => {
@@ -1665,7 +1665,7 @@ export const upsertConnectorTokenConnection$ = command(
     args: {
       readonly orgId: string;
       readonly userId: string;
-      readonly type: ConnectorAuthProviderType;
+      readonly type: AuthGrantConnectorType;
       readonly authMethod: ConnectorAuthMethodId;
       readonly outputs: ConnectorTokenOutputValues;
       readonly userInfo: ExternalUserInfo;
@@ -1838,7 +1838,7 @@ export function zeroConnectorSearch(args: {
     return CONNECTOR_TYPE_KEYS.flatMap((type) => {
       const config = CONNECTOR_TYPES[type];
       const authMethods: ConnectorSearchAuthMethod[] =
-        getAvailableConnectorAuthMethods(type, featureStates, {
+        getAvailableConnectorAuthMethodIds(type, featureStates, {
           apiAuthMethodPolicy: "include",
         });
 

--- a/turbo/apps/cli/src/commands/zero/connector/connect.ts
+++ b/turbo/apps/cli/src/commands/zero/connector/connect.ts
@@ -8,7 +8,7 @@ import {
   type ConnectorType,
 } from "@vm0/connectors/connectors";
 import {
-  getConfiguredConnectorAuthMethods,
+  getConfiguredConnectorAuthMethodIds,
   getConnectorAuthMethod,
 } from "@vm0/connectors/connector-utils";
 import { connectZeroConnectorManualGrant } from "../../../lib/api";
@@ -70,8 +70,8 @@ function parseConfiguredAuthMethod(
   type: ConnectorType,
   rawAuthMethod: string,
 ): ConnectorAuthMethodId {
-  const configuredAuthMethods = getConfiguredConnectorAuthMethods(type);
-  const authMethod = configuredAuthMethods.find((method) => {
+  const configuredAuthMethodIds = getConfiguredConnectorAuthMethodIds(type);
+  const authMethod = configuredAuthMethodIds.find((method) => {
     return method === rawAuthMethod;
   });
   if (authMethod) {
@@ -82,7 +82,7 @@ function parseConfiguredAuthMethod(
     `${type} connector does not have ${rawAuthMethod} auth method`,
     {
       cause: new Error(
-        `Available auth methods: ${configuredAuthMethods.join(", ")}`,
+        `Available auth methods: ${configuredAuthMethodIds.join(", ")}`,
       ),
     },
   );
@@ -91,7 +91,7 @@ function parseConfiguredAuthMethod(
 function getManualGrantAuthMethods(
   type: ConnectorType,
 ): ConnectorAuthMethodId[] {
-  return getConfiguredConnectorAuthMethods(type).filter((authMethod) => {
+  return getConfiguredConnectorAuthMethodIds(type).filter((authMethod) => {
     return getConnectorAuthMethod(type, authMethod)?.grant.kind === "manual";
   });
 }

--- a/turbo/apps/cli/src/mocks/handlers/api-handlers.ts
+++ b/turbo/apps/cli/src/mocks/handlers/api-handlers.ts
@@ -5,7 +5,7 @@ import {
   connectorAuthMethodIdSchema,
   type ConnectorAuthMethodId,
 } from "@vm0/connectors/connectors";
-import { getAvailableConnectorAuthMethods } from "@vm0/connectors/connector-utils";
+import { getAvailableConnectorAuthMethodIds } from "@vm0/connectors/connector-utils";
 
 function isRecord(value: unknown): value is Record<string, unknown> {
   return typeof value === "object" && value !== null;
@@ -19,7 +19,7 @@ function isConnectorAuthMethodId(
 
 function defaultAvailableConnectors() {
   return CONNECTOR_TYPE_KEYS.map((type) => {
-    const authMethods = getAvailableConnectorAuthMethods(type, {});
+    const authMethods = getAvailableConnectorAuthMethodIds(type, {});
     return { type, authMethods };
   })
     .filter((item) => {

--- a/turbo/apps/platform/src/signals/zero-page/settings/connectors.ts
+++ b/turbo/apps/platform/src/signals/zero-page/settings/connectors.ts
@@ -12,7 +12,7 @@ import {
 } from "@vm0/connectors/connectors";
 import {
   getConnectorAuthMethod,
-  getConfiguredConnectorAuthMethods,
+  getConfiguredConnectorAuthMethodIds,
   getConnectorTags,
   hasRequiredConnectorAuthMethodScopes,
   hasConnectorDeviceAuthGrant,
@@ -93,7 +93,7 @@ function getAvailableConnectorConnectAuthMethods(
     readonly includeManagedForTypes: readonly ConnectorType[];
   },
 ): ConnectorAuthMethodId[] {
-  return getConfiguredConnectorAuthMethods(type).filter((authMethod) => {
+  return getConfiguredConnectorAuthMethodIds(type).filter((authMethod) => {
     const method = getConnectorAuthMethod(type, authMethod);
     switch (method?.grant.kind) {
       case "managed": {

--- a/turbo/packages/api-contracts/src/contracts/index.ts
+++ b/turbo/packages/api-contracts/src/contracts/index.ts
@@ -711,7 +711,7 @@ export {
   CONNECTOR_DISPLAY_CATEGORY_META,
   CONNECTOR_DISPLAY_CATEGORY_ORDER,
   type ConnectorType,
-  type ConnectorAuthProviderType,
+  type AuthGrantConnectorType,
   type ConnectorConfig,
   type ConnectorDisplayCategory,
   type ConnectorDisplayCategoryGroup,

--- a/turbo/packages/connectors/src/__tests__/connectors.test.ts
+++ b/turbo/packages/connectors/src/__tests__/connectors.test.ts
@@ -34,7 +34,7 @@ import {
   connectorAuthMethodRefHasAccessKind,
   connectorAuthMethodRefHasGrantKind,
   connectorAuthMethodRefHasRevokeKind,
-  getAvailableConnectorAuthMethods,
+  getAvailableConnectorAuthMethodIds,
   getConnectorAuthMethodGrantScopes,
   getConnectorAuthMethodGrantMetadata,
   getConnectorAuthMethodRevokeMetadata,
@@ -42,12 +42,12 @@ import {
   getConnectorAuthMethodIdsForGrantKind,
   getConnectorAuthMethodIdsForRevokeKind,
   getConnectorAuthMethodScopeDiff,
-  getConfiguredConnectorAuthMethods,
+  getConfiguredConnectorAuthMethodIds,
   hasRequiredConnectorAuthMethodScopes,
   getConnectorAuthMethodAuthCodeGrantConfig,
   getConnectorAuthMethodDeviceAuthGrantConfig,
   getConnectorAuthMethodAccessMetadata,
-  getConnectorAuthMethodStorageMetadata,
+  getConnectorAuthMethodRuntimeMetadata,
   getConnectorGrantOutputSecretName,
   getConnectorRefreshOutputSecretName,
   getConnectorStoredSecretDisplayInfo,
@@ -60,7 +60,7 @@ import {
   getConnectorManualGrantFieldNamesForAuthMethod,
   getRuntimeAvailableConnectorTypes,
   getConnectorOwnedSecretNames,
-  getConnectorVariableNames,
+  getConnectorOwnedVariableNames,
   hasConnectorAuthCodeGrant,
   hasConnectorDeviceAuthGrant,
   isStaticConfidentialConnectorAuthClient,
@@ -598,7 +598,7 @@ describe("connector auth method config", () => {
             `${type}:${authMethod}`,
           ]);
         }
-        for (const name of getConnectorVariableNames(type, authMethod)) {
+        for (const name of getConnectorOwnedVariableNames(type, authMethod)) {
           variableOwners.set(name, [
             ...(variableOwners.get(name) ?? []),
             `${type}:${authMethod}`,
@@ -644,14 +644,14 @@ describe("connector auth method config", () => {
 describe("connector selected auth method capability checks", () => {
   it("matches exactly the auth methods that declare auth-code and device-auth grants", () => {
     for (const type of connectorTypeSchema.options) {
-      const authMethods = getConfiguredConnectorAuthMethods(type);
+      const authMethodIds = getConfiguredConnectorAuthMethodIds(type);
       expect(hasConnectorAuthCodeGrant(type)).toBe(
-        authMethods.some((authMethod) => {
+        authMethodIds.some((authMethod) => {
           return connectorAuthMethodHasGrantKind(type, authMethod, "auth-code");
         }),
       );
       expect(hasConnectorDeviceAuthGrant(type)).toBe(
-        authMethods.some((authMethod) => {
+        authMethodIds.some((authMethod) => {
           return connectorAuthMethodHasGrantKind(
             type,
             authMethod,
@@ -659,7 +659,7 @@ describe("connector selected auth method capability checks", () => {
           );
         }),
       );
-      for (const authMethod of getConfiguredConnectorAuthMethods(type)) {
+      for (const authMethod of getConfiguredConnectorAuthMethodIds(type)) {
         expect(
           connectorAuthMethodHasGrantKind(type, authMethod, "auth-code"),
         ).toBe(
@@ -681,7 +681,7 @@ describe("connector selected auth method capability checks", () => {
     expectTypeOf<"github">().not.toMatchTypeOf<RefreshTokenAccessConnectorType>();
 
     for (const type of connectorTypeSchema.options) {
-      for (const authMethod of getConfiguredConnectorAuthMethods(type)) {
+      for (const authMethod of getConfiguredConnectorAuthMethodIds(type)) {
         const hasRefreshTokenAccess =
           getConnectorAuthMethodAccessMetadata(type, authMethod)?.kind ===
           "refresh-token";
@@ -734,7 +734,7 @@ describe("connector selected auth method capability checks", () => {
     expectTypeOf<"notion">().not.toMatchTypeOf<TokenRevokeConnectorType>();
 
     for (const type of connectorTypeSchema.options) {
-      for (const authMethod of getConfiguredConnectorAuthMethods(type)) {
+      for (const authMethod of getConfiguredConnectorAuthMethodIds(type)) {
         const supportsTokenRevoke = connectorAuthMethodRefHasRevokeKind(
           {
             type,
@@ -1812,60 +1812,60 @@ describe("connector selected auth method capability checks", () => {
   });
 });
 
-describe("getConfiguredConnectorAuthMethods", () => {
+describe("getConfiguredConnectorAuthMethodIds", () => {
   it("returns configured auth methods without feature filtering", () => {
-    expect(getConfiguredConnectorAuthMethods("stripe")).toStrictEqual([
+    expect(getConfiguredConnectorAuthMethodIds("stripe")).toStrictEqual([
       "oauth",
       "api-token",
     ]);
   });
 });
 
-describe("getAvailableConnectorAuthMethods", () => {
+describe("getAvailableConnectorAuthMethodIds", () => {
   it("exposes Stripe API-token auth without CLI auth", () => {
-    expect(getAvailableConnectorAuthMethods("stripe", {})).toStrictEqual([
+    expect(getAvailableConnectorAuthMethodIds("stripe", {})).toStrictEqual([
       "api-token",
     ]);
   });
 
   it("exposes BentoML API-token auth only when its switch is enabled", () => {
-    expect(getAvailableConnectorAuthMethods("bentoml", {})).toStrictEqual([]);
+    expect(getAvailableConnectorAuthMethodIds("bentoml", {})).toStrictEqual([]);
     expect(
-      getAvailableConnectorAuthMethods("bentoml", {
+      getAvailableConnectorAuthMethodIds("bentoml", {
         [FeatureSwitchKey.BentomlConnector]: true,
       }),
     ).toStrictEqual(["api-token"]);
   });
 
   it("exposes Base44 OAuth without a feature switch", () => {
-    expect(getAvailableConnectorAuthMethods("base44", {})).toStrictEqual([
+    expect(getAvailableConnectorAuthMethodIds("base44", {})).toStrictEqual([
       "oauth",
     ]);
   });
 
   it("exposes Slock OAuth without a feature switch", () => {
-    expect(getAvailableConnectorAuthMethods("slock", {})).toStrictEqual([
+    expect(getAvailableConnectorAuthMethodIds("slock", {})).toStrictEqual([
       "oauth",
     ]);
   });
 
   it("exposes Lark API-token auth only when its switch is enabled", () => {
-    expect(getAvailableConnectorAuthMethods("lark", {})).toStrictEqual([]);
+    expect(getAvailableConnectorAuthMethodIds("lark", {})).toStrictEqual([]);
     expect(
-      getAvailableConnectorAuthMethods("lark", {
+      getAvailableConnectorAuthMethodIds("lark", {
         [FeatureSwitchKey.LarkConnector]: true,
       }),
     ).toStrictEqual(["api-token"]);
   });
 
   it("exposes Doubao API-token auth without a feature switch", () => {
-    expect(getAvailableConnectorAuthMethods("doubao", {})).toStrictEqual([
+    expect(getAvailableConnectorAuthMethodIds("doubao", {})).toStrictEqual([
       "api-token",
     ]);
   });
 
   it("exposes WeRead API-token auth without a feature switch", () => {
-    expect(getAvailableConnectorAuthMethods("weread", {})).toStrictEqual([
+    expect(getAvailableConnectorAuthMethodIds("weread", {})).toStrictEqual([
       "api-token",
     ]);
   });
@@ -2050,7 +2050,7 @@ describe("getConnectorAuthMethodAccessMetadata", () => {
 
   it("keeps platform-owned secrets referenced by selected env bindings", () => {
     for (const type of connectorTypeSchema.options) {
-      for (const authMethod of getConfiguredConnectorAuthMethods(type)) {
+      for (const authMethod of getConfiguredConnectorAuthMethodIds(type)) {
         const accessMetadata = getConnectorAuthMethodAccessMetadata(
           type,
           authMethod,
@@ -2109,10 +2109,10 @@ describe("getConnectorAuthMethodAccessMetadata", () => {
   });
 });
 
-describe("getConnectorAuthMethodStorageMetadata", () => {
+describe("getConnectorAuthMethodRuntimeMetadata", () => {
   it("returns static provider storage and runtime bindings", () => {
     expect(
-      getConnectorAuthMethodStorageMetadata("github", "oauth"),
+      getConnectorAuthMethodRuntimeMetadata("github", "oauth"),
     ).toStrictEqual({
       storage: {
         secrets: ["GITHUB_ACCESS_TOKEN"],
@@ -2141,7 +2141,7 @@ describe("getConnectorAuthMethodStorageMetadata", () => {
 
   it("keeps manual static API tokens role-free", () => {
     expect(
-      getConnectorAuthMethodStorageMetadata("stripe", "api-token"),
+      getConnectorAuthMethodRuntimeMetadata("stripe", "api-token"),
     ).toStrictEqual({
       storage: {
         secrets: ["STRIPE_TOKEN"],
@@ -2162,7 +2162,7 @@ describe("getConnectorAuthMethodStorageMetadata", () => {
 
   it("represents provider extra secrets as storage-owned runtime sources", () => {
     expect(
-      getConnectorAuthMethodStorageMetadata("slock", "oauth"),
+      getConnectorAuthMethodRuntimeMetadata("slock", "oauth"),
     ).toStrictEqual({
       storage: {
         secrets: [
@@ -2195,7 +2195,7 @@ describe("getConnectorAuthMethodStorageMetadata", () => {
 
   it("represents platform secrets as platform runtime sources", () => {
     expect(
-      getConnectorAuthMethodStorageMetadata("google-ads", "oauth"),
+      getConnectorAuthMethodRuntimeMetadata("google-ads", "oauth"),
     ).toStrictEqual({
       storage: {
         secrets: ["GOOGLE_ADS_ACCESS_TOKEN", "GOOGLE_ADS_REFRESH_TOKEN"],
@@ -2259,15 +2259,15 @@ describe("getConnectorAuthMethodRevokeMetadata", () => {
   });
 });
 
-describe("getConnectorVariableNames", () => {
+describe("getConnectorOwnedVariableNames", () => {
   it("returns manual grant variable fields for the exact auth method", () => {
-    expect(new Set(getConnectorVariableNames("zendesk", "api-token"))).toEqual(
-      new Set(["ZENDESK_EMAIL", "ZENDESK_SUBDOMAIN"]),
-    );
+    expect(
+      new Set(getConnectorOwnedVariableNames("zendesk", "api-token")),
+    ).toEqual(new Set(["ZENDESK_EMAIL", "ZENDESK_SUBDOMAIN"]));
   });
 
   it("returns no variables for an auth method without variable fields", () => {
-    expect(getConnectorVariableNames("ahrefs", "oauth")).toEqual([]);
+    expect(getConnectorOwnedVariableNames("ahrefs", "oauth")).toEqual([]);
   });
 });
 
@@ -2381,11 +2381,11 @@ describe("getConnectorEnvBindingEntries", () => {
         "refresh-token",
       );
       const grantMetadata = getConnectorAuthMethodGrantMetadata(type, "oauth");
-      const storageMetadata = getConnectorAuthMethodStorageMetadata(
+      const runtimeMetadata = getConnectorAuthMethodRuntimeMetadata(
         type,
         "oauth",
       );
-      if (!storageMetadata) {
+      if (!runtimeMetadata) {
         throw new Error(`${type}: missing OAuth storage metadata`);
       }
       if (!grantMetadata) {
@@ -2434,7 +2434,7 @@ describe("getConnectorEnvBindingEntries", () => {
         ).toContain(refreshSecretName);
       }
 
-      const runtimeSecretNames = storageMetadata.runtimeBindings.flatMap(
+      const runtimeSecretNames = runtimeMetadata.runtimeBindings.flatMap(
         (entry) => {
           return entry.source.kind === "connector-secret"
             ? [entry.source.name]

--- a/turbo/packages/connectors/src/auth-providers/connector-auth.ts
+++ b/turbo/packages/connectors/src/auth-providers/connector-auth.ts
@@ -3,7 +3,7 @@ import {
   type AuthCodeGrantConnectorType,
   connectorAuthMethodIdSchema,
   type ConnectorType,
-  type ConnectorAuthProviderType,
+  type AuthGrantConnectorType,
   type ConnectorDeviceAuthGrantAuthMethodId,
   type ConnectorAuthMethodIdsByGrantKind,
   type DeviceAuthGrantConnectorType,
@@ -114,7 +114,7 @@ export type ConnectorAuthProviderAccessTokenRevokeResult =
   | { readonly status: "unsupported" };
 
 type ConnectorProviderBackedType =
-  | ConnectorAuthProviderType
+  | AuthGrantConnectorType
   | RefreshTokenAccessConnectorType
   | TokenRevokeConnectorType;
 

--- a/turbo/packages/connectors/src/auth-providers/types.ts
+++ b/turbo/packages/connectors/src/auth-providers/types.ts
@@ -6,7 +6,7 @@ import type {
   ConnectorAuthMethodIdsByAccessKind,
   ConnectorAuthMethodIdsByRevokeKind,
   ConnectorDeviceAuthGrantAuthMethodId,
-  ConnectorAuthProviderType,
+  AuthGrantConnectorType,
   ConnectorRefreshInputValues,
   ConnectorRefreshOutputValues,
   ConnectorType,
@@ -144,7 +144,7 @@ export interface TokenRevokeProvider<
 }
 
 export type ConnectorAuthProviderRevoke<
-  T extends ConnectorAuthProviderType,
+  T extends AuthGrantConnectorType,
   Method extends ConnectorAuthMethodIds<T> = ConnectorAuthMethodIds<T>,
 > =
   Method extends ConnectorAuthMethodIdsByRevokeKind<

--- a/turbo/packages/connectors/src/connector-utils.ts
+++ b/turbo/packages/connectors/src/connector-utils.ts
@@ -58,7 +58,7 @@ function connectorAuthMethodPriority(
   return CONNECTOR_AUTH_METHOD_PRIORITY[authMethod];
 }
 
-export function getConfiguredConnectorAuthMethods(
+export function getConfiguredConnectorAuthMethodIds(
   type: ConnectorType,
 ): ConnectorAuthMethodId[] {
   // Configured methods are raw registry entries; callers apply feature flags.
@@ -117,7 +117,7 @@ export function getConnectorAuthMethodIdsForGrantKind<
   type: Type,
   grantKind: Kind,
 ): ConnectorAuthMethodIdsByGrantKind<Type, Kind>[] {
-  return getConfiguredConnectorAuthMethods(type).filter(
+  return getConfiguredConnectorAuthMethodIds(type).filter(
     (
       authMethod,
     ): authMethod is ConnectorAuthMethodIdsByGrantKind<Type, Kind> => {
@@ -144,7 +144,7 @@ export function getConnectorAuthMethodIdsForAccessKind<
   type: Type,
   accessKind: Kind,
 ): ConnectorAuthMethodIdsByAccessKind<Type, Kind>[] {
-  return getConfiguredConnectorAuthMethods(type).filter(
+  return getConfiguredConnectorAuthMethodIds(type).filter(
     (
       authMethod,
     ): authMethod is ConnectorAuthMethodIdsByAccessKind<Type, Kind> => {
@@ -171,7 +171,7 @@ export function getConnectorAuthMethodIdsForRevokeKind<
   type: Type,
   revokeKind: Kind,
 ): ConnectorAuthMethodIdsByRevokeKind<Type, Kind>[] {
-  return getConfiguredConnectorAuthMethods(type).filter(
+  return getConfiguredConnectorAuthMethodIds(type).filter(
     (
       authMethod,
     ): authMethod is ConnectorAuthMethodIdsByRevokeKind<Type, Kind> => {
@@ -222,7 +222,7 @@ export function getConnectorManualGrantFieldNames(
 ): ConnectorManualGrantFieldNames | null {
   const secretNames = new Set<string>();
   const variableNames = new Set<string>();
-  for (const authMethod of getConfiguredConnectorAuthMethods(type)) {
+  for (const authMethod of getConfiguredConnectorAuthMethodIds(type)) {
     const fields = getConnectorManualGrantFieldNamesForAuthMethod(
       type,
       authMethod,
@@ -368,7 +368,7 @@ export interface ConnectorRuntimeBindingEntry {
   readonly source: ConnectorRuntimeBindingSource;
 }
 
-export interface ConnectorAuthMethodStorageMetadata {
+export interface ConnectorAuthMethodRuntimeMetadata {
   readonly storage: {
     readonly secrets: readonly string[];
     readonly variables: readonly string[];
@@ -578,7 +578,7 @@ export function getConnectorRefreshOutputSecretName(
 }
 
 export function getConnectorRuntimeBindingSecretName(
-  metadata: ConnectorAuthMethodStorageMetadata,
+  metadata: ConnectorAuthMethodRuntimeMetadata,
   envName: string,
 ): string | undefined {
   const binding = metadata.runtimeBindings.find((entry) => {
@@ -646,10 +646,10 @@ function connectorRuntimeBindingEntries(args: {
   return entries;
 }
 
-export function getConnectorAuthMethodStorageMetadata(
+export function getConnectorAuthMethodRuntimeMetadata(
   type: ConnectorType,
   authMethod: string,
-): ConnectorAuthMethodStorageMetadata | undefined {
+): ConnectorAuthMethodRuntimeMetadata | undefined {
   const method = getConnectorAuthMethod(type, authMethod);
   if (!method) {
     return undefined;
@@ -862,16 +862,16 @@ function shouldIncludeApiAuthMethod(
  *
  * This does not describe persisted connected state.
  */
-export function getAvailableConnectorAuthMethods(
+export function getAvailableConnectorAuthMethodIds(
   type: ConnectorType,
   featureStates: ConnectorFeatureStates,
   options: AvailableConnectorAuthMethodsOptions = {},
 ): ConnectorAuthMethodId[] {
   const apiAuthMethodPolicy = options.apiAuthMethodPolicy ?? "exclude";
-  const availableAuthMethods: ConnectorAuthMethodId[] = [];
-  const configuredAuthMethods = getConfiguredConnectorAuthMethods(type);
+  const availableAuthMethodIds: ConnectorAuthMethodId[] = [];
+  const configuredAuthMethodIds = getConfiguredConnectorAuthMethodIds(type);
 
-  for (const authMethod of configuredAuthMethods) {
+  for (const authMethod of configuredAuthMethodIds) {
     const method = getConnectorAuthMethod(type, authMethod);
     switch (method?.grant.kind) {
       case "managed": {
@@ -890,11 +890,11 @@ export function getAvailableConnectorAuthMethods(
       }
     }
     if (isConnectorAuthMethodAvailable(type, authMethod, featureStates)) {
-      availableAuthMethods.push(authMethod);
+      availableAuthMethodIds.push(authMethod);
     }
   }
 
-  return availableAuthMethods;
+  return availableAuthMethodIds;
 }
 
 export type ConnectorEnvReader = (name: string) => string | undefined;
@@ -1206,7 +1206,7 @@ function hasRuntimeAvailableAuthMethod(
   readEnv: ConnectorEnvReader,
   type: ConnectorType,
 ): boolean {
-  for (const authMethod of getConfiguredConnectorAuthMethods(type)) {
+  for (const authMethod of getConfiguredConnectorAuthMethodIds(type)) {
     const method = getConnectorAuthMethod(type, authMethod);
     switch (method?.grant.kind) {
       case "auth-code":
@@ -1257,28 +1257,30 @@ export function getConnectorOwnedSecretNames(
   type: ConnectorType,
   authMethod: string,
 ): string[] {
-  return connectorMethodOwnedSecretNames(
+  return connectorAuthMethodOwnedSecretNames(
     getConnectorAuthMethod(type, authMethod),
   );
 }
 
 /**
- * Get variable names for a specific auth method
+ * Get connector-owned variable storage names for a specific auth method.
  */
-export function getConnectorVariableNames(
+export function getConnectorOwnedVariableNames(
   type: ConnectorType,
   authMethod: string,
 ): string[] {
-  return connectorMethodVariableNames(getConnectorAuthMethod(type, authMethod));
+  return connectorAuthMethodOwnedVariableNames(
+    getConnectorAuthMethod(type, authMethod),
+  );
 }
 
-function connectorMethodOwnedSecretNames(
+function connectorAuthMethodOwnedSecretNames(
   method: ConnectorAuthMethodConfig | undefined,
 ): string[] {
   return method ? [...method.storage.secrets] : [];
 }
 
-function connectorMethodVariableNames(
+function connectorAuthMethodOwnedVariableNames(
   method: ConnectorAuthMethodConfig | undefined,
 ): string[] {
   return method ? [...method.storage.variables] : [];
@@ -1311,7 +1313,7 @@ export function getConnectorEnvBindingEntries(
   type: ConnectorType,
 ): ConnectorEnvBindingEntry[] {
   const entries: ConnectorEnvBindingEntry[] = [];
-  for (const authMethod of getConfiguredConnectorAuthMethods(type)) {
+  for (const authMethod of getConfiguredConnectorAuthMethodIds(type)) {
     const envBindings = getConnectorAuthMethodEnvBindings(type, authMethod);
     for (const [envName, valueRef] of Object.entries(envBindings)) {
       entries.push({ authMethod, envName, valueRef });
@@ -1341,7 +1343,7 @@ export function getConnectorStoredSecretDisplayInfo(
     const config = CONNECTOR_TYPES[type];
 
     const found = Object.values(config.authMethods).some((method) => {
-      return connectorMethodOwnedSecretNames(method).includes(secretName);
+      return connectorAuthMethodOwnedSecretNames(method).includes(secretName);
     });
     if (!found) {
       continue;

--- a/turbo/packages/connectors/src/connectors.ts
+++ b/turbo/packages/connectors/src/connectors.ts
@@ -1299,7 +1299,7 @@ export type ConnectorTypesByRevokeKind<Kind extends ConnectorRevokeKind> = {
   }[keyof ConnectorAuthMethodsOf<Type>];
 }[ConnectorType];
 
-export type ConnectorAuthProviderType = ConnectorTypesByGrantKind<
+export type AuthGrantConnectorType = ConnectorTypesByGrantKind<
   "auth-code" | "device-auth"
 >;
 export type AuthCodeGrantConnectorType = ConnectorTypesByGrantKind<"auth-code">;

--- a/turbo/packages/core/src/index.ts
+++ b/turbo/packages/core/src/index.ts
@@ -554,7 +554,7 @@ export {
   type TriggerSource,
   type LogsFilters,
   type ConnectorType,
-  type ConnectorAuthProviderType,
+  type AuthGrantConnectorType,
   type ConnectorConfig,
   type ConnectorEnvBindings,
   type ConnectorAuthMethodConfig,


### PR DESCRIPTION
## Summary

- Rename connector auth method id helpers to make returned `ConnectorAuthMethodId[]` explicit.
- Rename connector runtime metadata and owned variable helpers so storage/runtime naming is symmetric.
- Replace the legacy `ConnectorAuthProviderType` name with grant-oriented `AuthGrantConnectorType` and update call sites.

## Tests

- `pnpm format`
- `pnpm -F @vm0/connectors test`
- `pnpm -F @vm0/connectors check-types`
- `pnpm -F @vm0/api-contracts check-types`
- `pnpm -F @vm0/core check-types`
- `pnpm -F api check-types`
- `pnpm -F @vm0/cli check-types`
- `pnpm -F @vm0/app check-types`
- `pnpm -F @vm0/connectors lint`
- `pnpm -F api lint`
- `pnpm -F @vm0/cli lint`
- `pnpm -F @vm0/app lint`
- `pnpm -F @vm0/api-contracts lint`
- `pnpm -F @vm0/core lint`
- `git diff --check`

Fixes #16139
