### PR TITLE
refactor: make firewall auth ownership explicit

### DIFF
--- a/crates/runner/mitm-addon/src/auth.py
+++ b/crates/runner/mitm-addon/src/auth.py
@@ -13,6 +13,7 @@ import urllib.error
 import urllib.parse
 import urllib.request
 from dataclasses import dataclass, field
+from enum import Enum
 from typing import Protocol
 
 from mitmproxy import ctx, http
@@ -69,6 +70,14 @@ class FirewallAuthApiError(Exception):
 class _ResponseBodyReader(Protocol):
     def read(self, n: int = -1) -> bytes:
         raise NotImplementedError
+
+
+class FirewallAuthHandlingResult(Enum):
+    """Request ownership outcome after firewall auth handling."""
+
+    CONTINUE_UPSTREAM = "continue_upstream"
+    INLINE_PROVIDER_RESPONSE = "inline_provider_response"
+    LOCAL_RESPONSE = "local_response"
 
 
 # Vercel bypass secret (still from environment as it's a secret)
@@ -757,7 +766,7 @@ async def _apply_url_rewrite(
     resolved_query: dict | None,
     firewall_base: str,
     proxy_log_path: str,
-) -> bool:
+) -> FirewallAuthHandlingResult:
     # The addon forwards the request itself because mitmproxy's eager
     # connection already connected to the placeholder IP. Setting
     # flow.response bypasses the upstream connection entirely.
@@ -772,7 +781,7 @@ async def _apply_url_rewrite(
             firewall_base=firewall_base,
             error_type=type(e).__name__,
         )
-        return False
+        return FirewallAuthHandlingResult.LOCAL_RESPONSE
 
     # Filter client-controlled hop-by-hop headers before adding trusted
     # auth headers, so Connection tokens cannot suppress injected auth.
@@ -796,7 +805,7 @@ async def _apply_url_rewrite(
             proxy_log_path=proxy_log_path,
             firewall_base=firewall_base,
         )
-        return False
+        return FirewallAuthHandlingResult.LOCAL_RESPONSE
     except Exception as e:
         _set_url_rewrite_forward_failed(
             flow,
@@ -805,7 +814,7 @@ async def _apply_url_rewrite(
             firewall_base=firewall_base,
             error_type=type(e).__name__,
         )
-        return False
+        return FirewallAuthHandlingResult.LOCAL_RESPONSE
 
     flow.metadata[metadata_keys.AUTH_URL_REWRITE] = True
     log_proxy_entry(
@@ -815,7 +824,7 @@ async def _apply_url_rewrite(
         type="firewall",
         firewall_base=firewall_base,
     )
-    return True
+    return FirewallAuthHandlingResult.INLINE_PROVIDER_RESPONSE
 
 
 async def _apply_resolved_firewall_auth(
@@ -825,13 +834,8 @@ async def _apply_resolved_firewall_auth(
     token_meta: dict,
     firewall_base: str,
     proxy_log_path: str,
-) -> bool:
-    """Apply resolved firewall auth.
-
-    Returns True when the caller should record common success metadata.
-    Returns False when this helper already set a local response and the
-    caller must return immediately.
-    """
+) -> FirewallAuthHandlingResult:
+    """Apply resolved firewall auth and return request ownership outcome."""
     headers = token_meta["headers"]
     resolved_query = token_meta.get("query")
     resolved_base = token_meta.get("base")
@@ -852,12 +856,12 @@ async def _apply_resolved_firewall_auth(
         headers=headers,
         resolved_query=resolved_query,
     )
-    return True
+    return FirewallAuthHandlingResult.CONTINUE_UPSTREAM
 
 
 async def handle_firewall_request(
     flow: http.HTTPFlow, allow: matching.FirewallAllow, vm_info: dict
-) -> None:
+) -> FirewallAuthHandlingResult:
     """Handle a firewall-matched request: fetch resolved headers, inject into request."""
     _prepare_firewall_metadata(flow, allow, vm_info)
     api_entry = allow.api_entry
@@ -883,7 +887,7 @@ async def handle_firewall_request(
             proxy_log_path=proxy_log_path,
             firewall_base=firewall_base,
         )
-        return
+        return FirewallAuthHandlingResult.LOCAL_RESPONSE
 
     if not encrypted_secrets:
         log_proxy_entry(
@@ -901,7 +905,7 @@ async def handle_firewall_request(
             message="Auth secrets not configured",
             permission=allow.name,
         )
-        return
+        return FirewallAuthHandlingResult.LOCAL_RESPONSE
 
     try:
         token_meta = await get_firewall_headers(
@@ -934,7 +938,7 @@ async def handle_firewall_request(
             permission=allow.name,
             connectors=[allow.name] if allow.name else None,
         )
-        return
+        return FirewallAuthHandlingResult.LOCAL_RESPONSE
     except InsufficientCreditsError as e:
         log_proxy_entry(
             proxy_log_path,
@@ -951,7 +955,7 @@ async def handle_firewall_request(
             message=str(e),
             permission=allow.name,
         )
-        return
+        return FirewallAuthHandlingResult.LOCAL_RESPONSE
     except InvalidBillableAuthExpiryError as e:
         log_proxy_entry(
             proxy_log_path,
@@ -968,7 +972,7 @@ async def handle_firewall_request(
             message=str(e),
             permission=allow.name,
         )
-        return
+        return FirewallAuthHandlingResult.LOCAL_RESPONSE
     except FirewallAuthApiError as e:
         log_proxy_entry(
             proxy_log_path,
@@ -992,7 +996,7 @@ async def handle_firewall_request(
             connectors=e.connectors,
             failure_reason=e.failure_reason,
         )
-        return
+        return FirewallAuthHandlingResult.LOCAL_RESPONSE
     except Exception as e:
         log_proxy_entry(
             proxy_log_path,
@@ -1009,17 +1013,17 @@ async def handle_firewall_request(
             message=f"Failed to resolve auth headers: {e}",
             permission=allow.name,
         )
-        return
+        return FirewallAuthHandlingResult.LOCAL_RESPONSE
 
-    should_continue = await _apply_resolved_firewall_auth(
+    auth_result = await _apply_resolved_firewall_auth(
         flow,
         allow=allow,
         token_meta=token_meta,
         firewall_base=firewall_base,
         proxy_log_path=proxy_log_path,
     )
-    if not should_continue:
-        return
+    if auth_result is FirewallAuthHandlingResult.LOCAL_RESPONSE:
+        return auth_result
 
     _record_firewall_auth_success_metadata(flow, token_meta)
 
@@ -1035,3 +1039,4 @@ async def handle_firewall_request(
         host=trusted_host,
         request_host_header=flow.request.host_header,
     )
+    return auth_result

--- a/crates/runner/mitm-addon/src/auth.py
+++ b/crates/runner/mitm-addon/src/auth.py
@@ -862,7 +862,7 @@ async def _apply_resolved_firewall_auth(
 async def handle_firewall_request(
     flow: http.HTTPFlow, allow: matching.FirewallAllow, vm_info: dict
 ) -> FirewallAuthHandlingResult:
-    """Handle a firewall-matched request: fetch resolved headers, inject into request."""
+    """Handle firewall auth and return who owns the next response lifecycle."""
     _prepare_firewall_metadata(flow, allow, vm_info)
     api_entry = allow.api_entry
     firewall_base = flow.metadata[metadata_keys.FIREWALL_BASE]

--- a/crates/runner/mitm-addon/src/mitm_addon.py
+++ b/crates/runner/mitm-addon/src/mitm_addon.py
@@ -41,6 +41,7 @@ import registry
 import response_streaming
 import usage
 from auth import (
+    FirewallAuthHandlingResult,
     clear_cached_firewall_headers,
     handle_firewall_request,
     is_billable_firewall,
@@ -575,10 +576,8 @@ async def request(flow: http.HTTPFlow) -> None:
                     is_billable_firewall(result.name, vm_info),
                     _is_model_provider_usage_observable(result.name, vm_info),
                 )
-                await handle_firewall_request(flow, result, vm_info)
-                if flow.response is not None and not flow.metadata.get(
-                    metadata_keys.AUTH_URL_REWRITE
-                ):
+                auth_result = await handle_firewall_request(flow, result, vm_info)
+                if auth_result is FirewallAuthHandlingResult.LOCAL_RESPONSE:
                     # Local firewall/auth errors never reach a provider. They only
                     # need pre-tracking to keep shutdown from racing while auth is
                     # resolving, so release as soon as the local response exists.

--- a/crates/runner/mitm-addon/tests/test_auth_query_injection.py
+++ b/crates/runner/mitm-addon/tests/test_auth_query_injection.py
@@ -100,7 +100,8 @@ class TestAuthQueryInjection:
             patch.object(auth, "get_firewall_headers", AsyncMock(return_value=token_meta)),
             mitm_ctx(),
         ):
-            await auth.handle_firewall_request(flow, allow, vm_info)
+            result = await auth.handle_firewall_request(flow, allow, vm_info)
+        assert result is auth.FirewallAuthHandlingResult.CONTINUE_UPSTREAM
         assert "auth_url_rewrite" not in flow.metadata
         assert flow.request.query["api_key"] == "resolved-key-123"
         assert flow.request.query["empty_auth"] == ""

--- a/crates/runner/mitm-addon/tests/test_firewall_auth.py
+++ b/crates/runner/mitm-addon/tests/test_firewall_auth.py
@@ -715,7 +715,9 @@ class TestHandleFirewallRequest:
             patch.object(auth, "get_firewall_headers", AsyncMock(return_value=token_meta)),
             mitm_ctx(),
         ):
-            await auth.handle_firewall_request(flow, allow, vm_info)
+            result = await auth.handle_firewall_request(flow, allow, vm_info)
+
+        assert result is auth.FirewallAuthHandlingResult.CONTINUE_UPSTREAM
 
         # Headers injected
         assert flow.request.headers["Authorization"] == "Bearer real-token"
@@ -776,8 +778,9 @@ class TestHandleFirewallRequest:
             mitm_ctx(),
             patch.object(auth, "get_api_url", return_value="https://api.vm0.ai"),
         ):
-            await auth.handle_firewall_request(flow, allow, vm_info)
+            result = await auth.handle_firewall_request(flow, allow, vm_info)
 
+        assert result is auth.FirewallAuthHandlingResult.LOCAL_RESPONSE
         assert flow.response is not None
         assert flow.response.status_code == 502
         assert flow.metadata["firewall_action"] == "ALLOW"
@@ -985,8 +988,9 @@ class TestHandleFirewallRequest:
             mitm_ctx(),
             patch.object(auth, "get_api_url", return_value="https://api.vm0.ai"),
         ):
-            await auth.handle_firewall_request(flow, allow, vm_info)
+            result = await auth.handle_firewall_request(flow, allow, vm_info)
 
+        assert result is auth.FirewallAuthHandlingResult.LOCAL_RESPONSE
         assert flow.response is not None
         assert flow.response.status_code == 502
         assert flow.metadata["firewall_action"] == "ALLOW"
@@ -1021,8 +1025,9 @@ class TestHandleFirewallRequest:
             ),
             mitm_ctx(),
         ):
-            await auth.handle_firewall_request(flow, allow, vm_info)
+            result = await auth.handle_firewall_request(flow, allow, vm_info)
 
+        assert result is auth.FirewallAuthHandlingResult.LOCAL_RESPONSE
         assert flow.response is not None
         assert flow.response.status_code == 502
         assert flow.metadata["firewall_action"] == "ALLOW"
@@ -1205,8 +1210,9 @@ class TestHandleFirewallRequest:
         allow = _allow(api_entry)
 
         with mitm_ctx():
-            await auth.handle_firewall_request(flow, allow, vm_info)
+            result = await auth.handle_firewall_request(flow, allow, vm_info)
 
+        assert result is auth.FirewallAuthHandlingResult.LOCAL_RESPONSE
         assert flow.response is not None
         assert flow.response.status_code == 502
         assert flow.metadata["firewall_action"] == "ALLOW"

--- a/crates/runner/mitm-addon/tests/test_firewall_auth.py
+++ b/crates/runner/mitm-addon/tests/test_firewall_auth.py
@@ -1096,8 +1096,9 @@ class TestHandleFirewallRequest:
             mitm_ctx(),
             patch.object(auth, "get_api_url", return_value="https://api.vm0.ai"),
         ):
-            await auth.handle_firewall_request(flow, allow, vm_info)
+            result = await auth.handle_firewall_request(flow, allow, vm_info)
 
+        assert result is auth.FirewallAuthHandlingResult.LOCAL_RESPONSE
         assert flow.response is not None
         assert flow.response.status_code == 424
         assert flow.metadata["firewall_action"] == "BLOCK"
@@ -1125,8 +1126,9 @@ class TestHandleFirewallRequest:
             mitm_ctx(),
             patch.object(auth, "get_api_url", return_value="https://api.vm0.ai"),
         ):
-            await auth.handle_firewall_request(flow, allow, vm_info)
+            result = await auth.handle_firewall_request(flow, allow, vm_info)
 
+        assert result is auth.FirewallAuthHandlingResult.LOCAL_RESPONSE
         assert flow.response is not None
         assert flow.response.status_code == 402
         assert flow.metadata["firewall_action"] == "BLOCK"

--- a/crates/runner/mitm-addon/tests/test_firewall_rewrite.py
+++ b/crates/runner/mitm-addon/tests/test_firewall_rewrite.py
@@ -353,7 +353,8 @@ class TestAuthBaseUrlRewriteEdgeCases:
             patch.object(auth, "forward_request", mock_forward),
             mitm_ctx(),
         ):
-            await auth.handle_firewall_request(flow, allow, vm_info)
+            result = await auth.handle_firewall_request(flow, allow, vm_info)
+        assert result is auth.FirewallAuthHandlingResult.INLINE_PROVIDER_RESPONSE
         assert flow.metadata["auth_url_rewrite"] is True
         assert flow.metadata["firewall_action"] == "ALLOW"
         assert flow.metadata["auth_resolved_secrets"] == ["WEBHOOK"]
@@ -386,8 +387,9 @@ class TestAuthBaseUrlRewriteEdgeCases:
             patch.object(auth, "forward_request", mock_forward),
             mitm_ctx(),
         ):
-            await auth.handle_firewall_request(flow, allow, vm_info)
+            result = await auth.handle_firewall_request(flow, allow, vm_info)
 
+        assert result is auth.FirewallAuthHandlingResult.INLINE_PROVIDER_RESPONSE
         assert flow.response is not None
         assert flow.response.status_code == 500
         assert flow.response.content == b'{"error":"upstream"}'
@@ -668,8 +670,9 @@ class TestAuthBaseUrlRewriteEdgeCases:
             patch.object(auth, "log_proxy_entry", mock_log),
             mitm_ctx(),
         ):
-            await auth.handle_firewall_request(flow, allow, vm_info)
+            result = await auth.handle_firewall_request(flow, allow, vm_info)
 
+        assert result is auth.FirewallAuthHandlingResult.LOCAL_RESPONSE
         get_headers.assert_not_called()
         mock_forward.assert_not_called()
         assert flow.response is not None
@@ -723,8 +726,9 @@ class TestAuthBaseUrlRewriteEdgeCases:
             patch.object(auth, "log_proxy_entry", mock_log),
             mitm_ctx(),
         ):
-            await auth.handle_firewall_request(flow, allow, vm_info)
+            result = await auth.handle_firewall_request(flow, allow, vm_info)
 
+        assert result is auth.FirewallAuthHandlingResult.LOCAL_RESPONSE
         assert mock_forward.call_count == 1
         assert flow.response is not None
         assert flow.response.status_code == 413
@@ -765,8 +769,9 @@ class TestAuthBaseUrlRewriteEdgeCases:
             patch.object(auth, "get_firewall_headers", get_headers),
             mitm_ctx(),
         ):
-            await auth.handle_firewall_request(flow, allow, vm_info)
+            result = await auth.handle_firewall_request(flow, allow, vm_info)
 
+        assert result is auth.FirewallAuthHandlingResult.CONTINUE_UPSTREAM
         assert get_headers.await_count == 1
         assert flow.response is None
         assert flow.request.headers["Authorization"] == "Bearer real-token"
@@ -811,7 +816,8 @@ class TestAuthBaseUrlRewriteEdgeCases:
             patch.object(auth, "forward_request", mock_forward),
             mitm_ctx(),
         ):
-            await auth.handle_firewall_request(flow, allow, vm_info)
+            result = await auth.handle_firewall_request(flow, allow, vm_info)
+        assert result is auth.FirewallAuthHandlingResult.LOCAL_RESPONSE
         failed_url = mock_forward.call_args[0][0]
         failed_query = parse_qs(urlparse(failed_url).query, keep_blank_values=True)
         failed_headers = mock_forward.call_args[0][2]


### PR DESCRIPTION
## Summary

- add an explicit `FirewallAuthHandlingResult` ownership outcome for firewall auth handling
- return the outcome from URL rewrite, resolved auth application, and every `handle_firewall_request()` path
- make the request hook release usage tracking from `LOCAL_RESPONSE` instead of inferring from `flow.response` and `auth_url_rewrite`
- add return-contract assertions for standard auth, inline rewrite, upstream error rewrite responses, and local auth/rewrite failures

Closes #16113.

## Testing

- `cd crates/runner/mitm-addon && ruff check .`
- `cd crates/runner/mitm-addon && ruff format --check .`
- `cd crates/runner/mitm-addon && basedpyright -p .`
- `cd crates/runner/mitm-addon && pytest tests/test_firewall_auth.py tests/test_firewall_rewrite.py tests/test_auth_query_injection.py tests/test_request_handler_usage_tracking.py`
- `cd crates/runner/mitm-addon && pytest tests/test_x_billing.py`
- `cd crates/runner/mitm-addon && pytest`

Note: the first full `pytest` run failed because the local checkout was missing the gitignored `cursor.generated.ts` generated firewall file after pulling latest main. I generated it locally with `cd turbo && pnpm -F @vm0/firewalls-generator generate:cursor`; it is ignored and not part of this PR. After that, `tests/test_x_billing.py` and full mitm-addon `pytest` passed.
