### PR TITLE
fix: share X billing IDNA normalization

### DIFF
--- a/crates/runner/mitm-addon/src/host_normalization.py
+++ b/crates/runner/mitm-addon/src/host_normalization.py
@@ -101,6 +101,10 @@ _UNSAFE_UTS46_IGNORABLE_RANGES = (
 )
 
 
+class UnsafeIdnaCompatibilityMappingError(UnicodeError):
+    """Raised when IDNA normalization would fold an unsafe compatibility alias."""
+
+
 def _is_ascii(value: str) -> bool:
     return all(ord(char) <= _ASCII_MAX for char in value)
 
@@ -308,7 +312,7 @@ def _validate_normalized_label_text(normalized_label: str) -> None:
 
 def _canonical_punycode_label(label: str) -> str:
     if _has_unsafe_uts46_mapping_chars(label):
-        raise UnicodeError("unsafe IDNA compatibility mapping")
+        raise UnsafeIdnaCompatibilityMappingError("unsafe IDNA compatibility mapping")
     normalized_label = _normalize_label_text(label)
     _validate_normalized_label_text(normalized_label)
 
@@ -324,7 +328,7 @@ def _canonical_punycode_label(label: str) -> str:
 def _encode_unicode_label(label: str) -> str:
     normalized_label = _normalize_label_text(label)
     if _is_ascii(normalized_label):
-        raise UnicodeError("unsafe IDNA compatibility mapping")
+        raise UnsafeIdnaCompatibilityMappingError("unsafe IDNA compatibility mapping")
     return _canonical_punycode_label(label)
 
 
@@ -365,6 +369,11 @@ def _normalize_label(label: str) -> str:
     if not _is_valid_alabel(ascii_label):
         raise UnicodeError("invalid IDNA A-label")
     return ascii_label
+
+
+def normalize_idna_label(label: str) -> str:
+    """Normalize one hostname label with the shared IDNA policy."""
+    return _normalize_label(label)
 
 
 def normalize_idna_hostname(host: str) -> str:

--- a/crates/runner/mitm-addon/src/usage/providers/connectors/x_billing.py
+++ b/crates/runner/mitm-addon/src/usage/providers/connectors/x_billing.py
@@ -311,37 +311,50 @@ def _host_from_bare_domain_candidate(candidate: str) -> str | None:
     return host.rstrip(".")
 
 
-def _labels_are_billing_domain(labels: tuple[str, ...]) -> bool:
-    if len(labels) < _MIN_DOMAIN_LABELS:
-        return False
+def _label_is_billing_domain_label(label: str) -> bool:
+    return (
+        bool(label)
+        and _DOMAIN_LABEL_RE.fullmatch(label) is not None
+        and not label.startswith("-")
+        and not label.endswith("-")
+    )
 
-    for label in labels:
-        if (
-            not label
-            or _DOMAIN_LABEL_RE.fullmatch(label) is None
-            or label.startswith("-")
-            or label.endswith("-")
-        ):
-            return False
-    return labels[-1] in IANA_TLDS
+
+def _is_unsafe_idna_compatibility_error(exc: UnicodeError) -> bool:
+    return str(exc) == _UNSAFE_IDNA_COMPATIBILITY_MAPPING_ERROR
 
 
 def _classify_bare_domain_host(host: str) -> _BareDomainClassification:
-    try:
-        normalized_host = normalize_idna_hostname(host)
-    except UnicodeError as exc:
-        # Keep billing conservative for URL-like compatibility aliases, but
-        # do not fold them into unrelated ASCII domains.
-        if str(exc) == _UNSAFE_IDNA_COMPATIBILITY_MAPPING_ERROR:
-            return "ambiguous"
-        return "non_link"
-    except ValueError:
+    labels = tuple(host.split("."))
+    if len(labels) < _MIN_DOMAIN_LABELS or any(not label for label in labels):
         return "non_link"
 
-    labels = tuple(normalized_host.split("."))
-    if _labels_are_billing_domain(labels):
-        return "url"
-    return "non_link"
+    has_ambiguous_label = False
+    normalized_labels: list[str | None] = []
+    for label in labels:
+        try:
+            normalized_label = normalize_idna_hostname(label)
+        except UnicodeError as exc:
+            # Keep billing conservative for URL-like compatibility aliases,
+            # but do not fold them into unrelated ASCII domains.
+            if _is_unsafe_idna_compatibility_error(exc):
+                has_ambiguous_label = True
+                normalized_labels.append(None)
+                continue
+            return "non_link"
+        except ValueError:
+            return "non_link"
+
+        if not _label_is_billing_domain_label(normalized_label):
+            return "non_link"
+        normalized_labels.append(normalized_label)
+
+    normalized_tld = normalized_labels[-1]
+    if normalized_tld is not None and normalized_tld not in IANA_TLDS:
+        return "non_link"
+    if has_ambiguous_label:
+        return "ambiguous"
+    return "url"
 
 
 def _bare_domain_candidate_likely_contains_url(candidate: str) -> bool:

--- a/crates/runner/mitm-addon/src/usage/providers/connectors/x_billing.py
+++ b/crates/runner/mitm-addon/src/usage/providers/connectors/x_billing.py
@@ -56,7 +56,7 @@ from collections.abc import Callable
 from typing import Literal, NamedTuple
 
 import matching
-from host_normalization import normalize_idna_hostname
+from host_normalization import UnsafeIdnaCompatibilityMappingError, normalize_idna_label
 
 from .x_tlds import IANA_TLDS
 
@@ -292,7 +292,6 @@ _DOMAIN_LABEL_RE = re.compile(r"^[a-z0-9-]{1,63}$")
 _MIN_DOMAIN_LABELS = 2
 _URL_TRAILING_PUNCTUATION = ".,:;!?"
 _URL_WRAPPER_CHARS = " \t\r\n<>()[]{}\"'"
-_UNSAFE_IDNA_COMPATIBILITY_MAPPING_ERROR = "unsafe IDNA compatibility mapping"
 _BareDomainClassification = Literal["url", "non_link", "ambiguous"]
 
 
@@ -320,10 +319,6 @@ def _label_is_billing_domain_label(label: str) -> bool:
     )
 
 
-def _is_unsafe_idna_compatibility_error(exc: UnicodeError) -> bool:
-    return str(exc) == _UNSAFE_IDNA_COMPATIBILITY_MAPPING_ERROR
-
-
 def _classify_bare_domain_host(host: str) -> _BareDomainClassification:
     labels = tuple(host.split("."))
     if len(labels) < _MIN_DOMAIN_LABELS or any(not label for label in labels):
@@ -333,16 +328,14 @@ def _classify_bare_domain_host(host: str) -> _BareDomainClassification:
     normalized_labels: list[str | None] = []
     for label in labels:
         try:
-            normalized_label = normalize_idna_hostname(label)
-        except UnicodeError as exc:
+            normalized_label = normalize_idna_label(label)
+        except UnsafeIdnaCompatibilityMappingError:
             # Keep billing conservative for URL-like compatibility aliases,
             # but do not fold them into unrelated ASCII domains.
-            if _is_unsafe_idna_compatibility_error(exc):
-                has_ambiguous_label = True
-                normalized_labels.append(None)
-                continue
-            return "non_link"
-        except ValueError:
+            has_ambiguous_label = True
+            normalized_labels.append(None)
+            continue
+        except UnicodeError:
             return "non_link"
 
         if not _label_is_billing_domain_label(normalized_label):

--- a/crates/runner/mitm-addon/src/usage/providers/connectors/x_billing.py
+++ b/crates/runner/mitm-addon/src/usage/providers/connectors/x_billing.py
@@ -53,9 +53,10 @@ sheet for drift.
 import json
 import re
 from collections.abc import Callable
-from typing import NamedTuple
+from typing import Literal, NamedTuple
 
 import matching
+from host_normalization import normalize_idna_hostname
 
 from .x_tlds import IANA_TLDS
 
@@ -291,6 +292,8 @@ _DOMAIN_LABEL_RE = re.compile(r"^[a-z0-9-]{1,63}$")
 _MIN_DOMAIN_LABELS = 2
 _URL_TRAILING_PUNCTUATION = ".,:;!?"
 _URL_WRAPPER_CHARS = " \t\r\n<>()[]{}\"'"
+_UNSAFE_IDNA_COMPATIBILITY_MAPPING_ERROR = "unsafe IDNA compatibility mapping"
+_BareDomainClassification = Literal["url", "non_link", "ambiguous"]
 
 
 def _host_from_bare_domain_candidate(candidate: str) -> str | None:
@@ -308,36 +311,49 @@ def _host_from_bare_domain_candidate(candidate: str) -> str | None:
     return host.rstrip(".")
 
 
-def _idna_domain_labels(host: str) -> tuple[str, ...] | None:
-    labels = host.split(".")
+def _labels_are_billing_domain(labels: tuple[str, ...]) -> bool:
     if len(labels) < _MIN_DOMAIN_LABELS:
-        return None
+        return False
 
-    normalized_labels = []
     for label in labels:
-        if not label:
-            return None
-        try:
-            normalized = label.encode("idna").decode("ascii").lower()
-        except UnicodeError:
-            return None
         if (
-            _DOMAIN_LABEL_RE.fullmatch(normalized) is None
-            or normalized.startswith("-")
-            or normalized.endswith("-")
+            not label
+            or _DOMAIN_LABEL_RE.fullmatch(label) is None
+            or label.startswith("-")
+            or label.endswith("-")
         ):
-            return None
-        normalized_labels.append(normalized)
+            return False
+    return labels[-1] in IANA_TLDS
 
-    return tuple(normalized_labels)
+
+def _classify_bare_domain_host(host: str) -> _BareDomainClassification:
+    try:
+        normalized_host = normalize_idna_hostname(host)
+    except UnicodeError as exc:
+        # Keep billing conservative for URL-like compatibility aliases, but
+        # do not fold them into unrelated ASCII domains.
+        if str(exc) == _UNSAFE_IDNA_COMPATIBILITY_MAPPING_ERROR:
+            return "ambiguous"
+        return "non_link"
+    except ValueError:
+        return "non_link"
+
+    labels = tuple(normalized_host.split("."))
+    if _labels_are_billing_domain(labels):
+        return "url"
+    return "non_link"
 
 
 def _bare_domain_candidate_likely_contains_url(candidate: str) -> bool:
     host = _host_from_bare_domain_candidate(candidate)
     if host is None:
         return False
-    labels = _idna_domain_labels(host)
-    return labels is not None and labels[-1] in IANA_TLDS
+
+    match _classify_bare_domain_host(host):
+        case "url" | "ambiguous":
+            return True
+        case "non_link":
+            return False
 
 
 def _tweet_text_likely_contains_url(text: str) -> bool:

--- a/crates/runner/mitm-addon/tests/test_connector_usage.py
+++ b/crates/runner/mitm-addon/tests/test_connector_usage.py
@@ -1049,6 +1049,7 @@ class TestReportConnectorUsage:
             "Plus suffix example.com+tag",
             "At suffix example.com@user",
             "Unknown example.notatld",
+            "Fullwidth unknown \uff26\uff2f\uff2f.notatld",
             "Underscore foo_bar.example.com",
             "Leading hyphen -bad.com",
             "Trailing hyphen bad-.com",

--- a/crates/runner/mitm-addon/tests/test_connector_usage.py
+++ b/crates/runner/mitm-addon/tests/test_connector_usage.py
@@ -1012,6 +1012,8 @@ class TestReportConnectorUsage:
             "Open xn--r8jz45g.xn--q9jyb4c",
             "IDN 例え.みんな",
             "Accent mañana.com",
+            "Sharp S faß.de",
+            "Fullwidth compatibility \uff26\uff2f\uff2f.com",
         ],
     )
     def test_tweet_create_with_url_stays_on_with_url_bucket(self, tmp_path, real_flow, text):

--- a/crates/runner/mitm-addon/tests/test_connector_usage.py
+++ b/crates/runner/mitm-addon/tests/test_connector_usage.py
@@ -1006,6 +1006,7 @@ class TestReportConnectorUsage:
             "Param url=example.com",
             "Pipe|example.com",
             "Visit EXAMPLE.COM",
+            "Visit 123.com",
             "Visit blog.example.co.uk",
             "Open example.com/path/to/resource?search=foo&lang=en",
             "Open example.com:443/path",


### PR DESCRIPTION
## Summary

- route X tweet bare-domain IDNA handling through the shared `normalize_idna_hostname()` helper
- keep X billing-specific label/TLD guards for clearly non-link candidates
- treat unsafe IDNA compatibility aliases as ambiguous URL-like text so billing stays conservative
- add connector usage regressions for `faß.de` and fullwidth compatibility aliases

Fixes #16112.

## Tests

- `cd crates/runner/mitm-addon && pytest tests/test_connector_usage.py`
- `cd crates/runner/mitm-addon && ruff format --check .`
- `cd crates/runner/mitm-addon && ruff check .`
- `cd crates/runner/mitm-addon && basedpyright`
