### PR TITLE
fix(runner): document and harden mitm matcher malformed inputs

### DIFF
--- a/crates/runner/mitm-addon/src/matching.py
+++ b/crates/runner/mitm-addon/src/matching.py
@@ -1205,8 +1205,39 @@ def _compile_rule(rule_str: str) -> _CompiledRule | None:
     return _CompiledRule(method, rule_str, pattern, _path_specificity(pattern))
 
 
+# Compiled matcher contract
+#
+# Registry loading stores these compiled objects and request handling later
+# converts FirewallBlock into a 403, so the compile phase deliberately
+# distinguishes inputs that cannot match from malformed inputs that can still
+# match a base and must fail closed at match time.
+#
+# compile_firewalls skips raw entries that cannot participate in base matching:
+# non-object firewalls, firewalls whose "apis" is not a list, non-object APIs,
+# non-string bases, and bases that cannot compile into matcher data. Once an
+# API base compiles, the API is retained and records malformed state for:
+# firewall name, base syntax/authority/params, auth config, and
+# permission/rule config.
+#
+# compile_network_policies preserves malformed policy state for a present
+# non-object top-level networkPolicies payload, non-object per-firewall grants,
+# malformed allow/deny/ask permission sets, and malformed unknownPolicy.
+#
+# match_compiled_firewall_request applies retained malformed state only after a
+# request matches a compiled base. The relevant fail-closed reasons are
+# "malformed_firewall_config", "malformed_network_policy", and "unsafe_path".
+# Malformed config for an unrelated base does not block unrelated traffic.
+#
+# Preserve current decision precedence when changing this code or these docs:
+# unsafe paths block immediately after base match; explicit allow/deny rule
+# decisions resolve before retained malformed state; if no allow/deny resolved,
+# malformed network policy resolves before malformed firewall config; malformed
+# unknownPolicy only affects unknown-endpoint resolution.
 def compile_firewalls(vm_firewalls: list | None) -> CompiledFirewallSet | None:
-    """Compile raw firewall config into immutable matcher-side data."""
+    """Compile firewall data and retain selected malformed state.
+
+    See the compiled matcher contract above for skipped versus retained inputs.
+    """
     if not vm_firewalls:
         return None
 
@@ -1321,7 +1352,10 @@ def _compile_permission_set(raw_value: object | None) -> tuple[frozenset[str], b
 
 
 def compile_network_policies(raw_network_policies: object | None) -> CompiledNetworkPolicies:
-    """Compile raw networkPolicies into immutable matcher-side data."""
+    """Compile networkPolicies and retain selected malformed policy state.
+
+    See the compiled matcher contract above for match-time fail-closed semantics.
+    """
     if raw_network_policies is None:
         return CompiledNetworkPolicies(MappingProxyType({}), False)
     if not isinstance(raw_network_policies, dict):
@@ -1678,6 +1712,13 @@ def match_compiled_firewall_request(
     network_policies: object | None = None,
 ) -> FirewallAllow | FirewallBlock | None:
     """Match request against production precompiled firewall permissions.
+
+    Retained malformed state from the compile functions applies only after the
+    request matches a compiled base. It can surface as FirewallBlock reasons
+    ``malformed_firewall_config`` or ``malformed_network_policy``; unsafe paths
+    use ``unsafe_path`` after base match. Explicit allow/deny rule decisions
+    keep their current precedence over retained malformed state, and malformed
+    ``unknownPolicy`` only affects unknown-endpoint resolution.
 
     Returns:
       FirewallAllow — granted permission matched or unknown endpoint allowed

--- a/crates/runner/mitm-addon/src/matching.py
+++ b/crates/runner/mitm-addon/src/matching.py
@@ -1212,10 +1212,12 @@ def _compile_rule(rule_str: str) -> _CompiledRule | None:
 # distinguishes inputs that cannot match from malformed inputs that can still
 # match a base and must fail closed at match time.
 #
-# compile_firewalls skips raw inputs that cannot participate in base matching:
-# missing, empty, or non-list firewalls payloads; non-object firewall entries;
-# firewalls whose "apis" is not a list; non-object APIs; non-string bases; bases
-# that cannot compile into matcher data; and firewalls with no compiled APIs.
+# Registry loading rejects explicit non-null, non-list firewalls payloads for
+# registered VMs before request handling. Direct compile_firewalls callers still
+# get None for missing, empty, or non-list payloads. compile_firewalls skips raw
+# entries that cannot participate in base matching: non-object firewall entries,
+# firewalls whose "apis" is not a list, non-object APIs, non-string bases, bases
+# that cannot compile into matcher data, and firewalls with no compiled APIs.
 # Once an API base compiles, the API is retained and records malformed state for:
 # firewall name, base syntax/authority/params, auth config, and permission/rule
 # config.

--- a/crates/runner/mitm-addon/src/matching.py
+++ b/crates/runner/mitm-addon/src/matching.py
@@ -1229,10 +1229,14 @@ def _compile_rule(rule_str: str) -> _CompiledRule | None:
 # Malformed config for an unrelated base does not block unrelated traffic.
 #
 # Preserve current decision precedence when changing this code or these docs:
-# unsafe paths block immediately after base match; explicit allow/deny rule
-# decisions resolve before retained malformed state; if no allow/deny resolved,
-# malformed network policy resolves before malformed firewall config; malformed
-# unknownPolicy only affects unknown-endpoint resolution.
+# unsafe paths block immediately after base match. APIs with malformed firewall
+# name, base, or auth config record malformed firewall config and then skip rule
+# evaluation for that API. Malformed permission/rule config records malformed
+# firewall config but still lets valid compiled rules on that API participate.
+# Recorded allow/deny rule decisions resolve before retained malformed state; if
+# no allow/deny resolved, malformed network policy resolves before malformed
+# firewall config; malformed unknownPolicy only affects unknown-endpoint
+# resolution.
 def compile_firewalls(vm_firewalls: list | None) -> CompiledFirewallSet | None:
     """Compile firewall data and retain selected malformed state.
 
@@ -1716,9 +1720,11 @@ def match_compiled_firewall_request(
     Retained malformed state from the compile functions applies only after the
     request matches a compiled base. It can surface as FirewallBlock reasons
     ``malformed_firewall_config`` or ``malformed_network_policy``; unsafe paths
-    use ``unsafe_path`` after base match. Explicit allow/deny rule decisions
-    keep their current precedence over retained malformed state, and malformed
-    ``unknownPolicy`` only affects unknown-endpoint resolution.
+    use ``unsafe_path`` after base match. APIs with malformed firewall name,
+    base, or auth config do not evaluate their rules; malformed permission/rule
+    config can still leave valid compiled rules eligible. Recorded allow/deny
+    rule decisions keep their current precedence over retained malformed state,
+    and malformed ``unknownPolicy`` only affects unknown-endpoint resolution.
 
     Returns:
       FirewallAllow — granted permission matched or unknown endpoint allowed

--- a/crates/runner/mitm-addon/src/matching.py
+++ b/crates/runner/mitm-addon/src/matching.py
@@ -1214,14 +1214,15 @@ def _compile_rule(rule_str: str) -> _CompiledRule | None:
 #
 # compile_firewalls skips raw entries that cannot participate in base matching:
 # non-object firewalls, firewalls whose "apis" is not a list, non-object APIs,
-# non-string bases, and bases that cannot compile into matcher data. Once an
-# API base compiles, the API is retained and records malformed state for:
-# firewall name, base syntax/authority/params, auth config, and
-# permission/rule config.
+# non-string bases, bases that cannot compile into matcher data, and firewalls
+# with no compiled APIs. Once an API base compiles, the API is retained and
+# records malformed state for: firewall name, base syntax/authority/params, auth
+# config, and permission/rule config.
 #
 # compile_network_policies preserves malformed policy state for a present
 # non-object top-level networkPolicies payload, non-object per-firewall grants,
-# malformed allow/deny/ask permission sets, and malformed unknownPolicy.
+# malformed allow/deny/ask permission sets, and malformed unknownPolicy. It
+# skips non-string policy keys because they cannot address a firewall name.
 #
 # match_compiled_firewall_request applies retained malformed state only after a
 # request matches a compiled base. The relevant fail-closed reasons are
@@ -1233,6 +1234,8 @@ def _compile_rule(rule_str: str) -> _CompiledRule | None:
 # name, base, or auth config record malformed firewall config and then skip rule
 # evaluation for that API. Malformed permission/rule config records malformed
 # firewall config but still lets valid compiled rules on that API participate.
+# Malformed top-level policies or malformed allow/deny/ask permission sets record
+# malformed network policy and skip rule evaluation for the matched API.
 # Recorded allow/deny rule decisions resolve before retained malformed state; if
 # no allow/deny resolved, malformed network policy resolves before malformed
 # firewall config; malformed unknownPolicy only affects unknown-endpoint
@@ -1722,9 +1725,11 @@ def match_compiled_firewall_request(
     ``malformed_firewall_config`` or ``malformed_network_policy``; unsafe paths
     use ``unsafe_path`` after base match. APIs with malformed firewall name,
     base, or auth config do not evaluate their rules; malformed permission/rule
-    config can still leave valid compiled rules eligible. Recorded allow/deny
-    rule decisions keep their current precedence over retained malformed state,
-    and malformed ``unknownPolicy`` only affects unknown-endpoint resolution.
+    config can still leave valid compiled rules eligible. Malformed top-level
+    policies or malformed allow/deny/ask permission sets skip rule evaluation
+    for the matched API. Recorded allow/deny rule decisions keep their current
+    precedence over retained malformed state, and malformed ``unknownPolicy``
+    only affects unknown-endpoint resolution.
 
     Returns:
       FirewallAllow — granted permission matched or unknown endpoint allowed

--- a/crates/runner/mitm-addon/src/matching.py
+++ b/crates/runner/mitm-addon/src/matching.py
@@ -1212,12 +1212,13 @@ def _compile_rule(rule_str: str) -> _CompiledRule | None:
 # distinguishes inputs that cannot match from malformed inputs that can still
 # match a base and must fail closed at match time.
 #
-# compile_firewalls skips raw entries that cannot participate in base matching:
-# non-object firewalls, firewalls whose "apis" is not a list, non-object APIs,
-# non-string bases, bases that cannot compile into matcher data, and firewalls
-# with no compiled APIs. Once an API base compiles, the API is retained and
-# records malformed state for: firewall name, base syntax/authority/params, auth
-# config, and permission/rule config.
+# compile_firewalls skips raw inputs that cannot participate in base matching:
+# missing, empty, or non-list firewalls payloads; non-object firewall entries;
+# firewalls whose "apis" is not a list; non-object APIs; non-string bases; bases
+# that cannot compile into matcher data; and firewalls with no compiled APIs.
+# Once an API base compiles, the API is retained and records malformed state for:
+# firewall name, base syntax/authority/params, auth config, and permission/rule
+# config.
 #
 # compile_network_policies preserves malformed policy state for a present
 # non-object top-level networkPolicies payload, non-object per-firewall grants,
@@ -1240,12 +1241,12 @@ def _compile_rule(rule_str: str) -> _CompiledRule | None:
 # no allow/deny resolved, malformed network policy resolves before malformed
 # firewall config; malformed unknownPolicy only affects unknown-endpoint
 # resolution.
-def compile_firewalls(vm_firewalls: list | None) -> CompiledFirewallSet | None:
+def compile_firewalls(vm_firewalls: object | None) -> CompiledFirewallSet | None:
     """Compile firewall data and retain selected malformed state.
 
     See the compiled matcher contract above for skipped versus retained inputs.
     """
-    if not vm_firewalls:
+    if not isinstance(vm_firewalls, list) or not vm_firewalls:
         return None
 
     compiled_firewalls: list[_CompiledFirewall] = []

--- a/crates/runner/mitm-addon/src/registry.py
+++ b/crates/runner/mitm-addon/src/registry.py
@@ -155,6 +155,17 @@ def _classify_registry_vms(raw_registry: dict) -> tuple[dict, dict[str, InvalidV
             )
             continue
 
+        if (
+            "firewalls" in vm
+            and vm["firewalls"] is not None
+            and not isinstance(vm["firewalls"], list)
+        ):
+            invalid_vms[client_ip] = InvalidVmEntry(
+                "invalid_firewalls",
+                "proxy registry VM entry firewalls must be a list",
+            )
+            continue
+
         new_registry[client_ip] = vm
 
     return new_registry, invalid_vms

--- a/crates/runner/mitm-addon/tests/test_compiled_firewall_malformed_config.py
+++ b/crates/runner/mitm-addon/tests/test_compiled_firewall_malformed_config.py
@@ -1195,7 +1195,10 @@ def test_malformed_api_list_shape_is_skipped_without_compile_error():
     assert matching.compile_firewalls([{"name": "github", "apis": None}]) is None
 
 
-@pytest.mark.parametrize("firewalls", [None, [], 1, False, {"name": "github"}, "broken"])
+@pytest.mark.parametrize(
+    "firewalls",
+    [None, [], 0, 1, False, "", {}, {"name": "github"}, "broken"],
+)
 def test_direct_compile_firewalls_ignores_missing_empty_or_non_list_payloads(firewalls):
     assert matching.compile_firewalls(firewalls) is None
 

--- a/crates/runner/mitm-addon/tests/test_compiled_firewall_malformed_config.py
+++ b/crates/runner/mitm-addon/tests/test_compiled_firewall_malformed_config.py
@@ -1195,6 +1195,11 @@ def test_malformed_api_list_shape_is_skipped_without_compile_error():
     assert matching.compile_firewalls([{"name": "github", "apis": None}]) is None
 
 
+@pytest.mark.parametrize("firewalls", [None, [], 1, False, {"name": "github"}, "broken"])
+def test_direct_compile_firewalls_ignores_missing_empty_or_non_list_payloads(firewalls):
+    assert matching.compile_firewalls(firewalls) is None
+
+
 @pytest.mark.parametrize(
     "policies",
     [

--- a/crates/runner/mitm-addon/tests/test_registry.py
+++ b/crates/runner/mitm-addon/tests/test_registry.py
@@ -5,6 +5,8 @@ import os
 from types import SimpleNamespace
 from unittest.mock import MagicMock, patch
 
+import pytest
+
 import matching
 import registry
 from tests.auth_state_helpers import (

--- a/crates/runner/mitm-addon/tests/test_registry.py
+++ b/crates/runner/mitm-addon/tests/test_registry.py
@@ -916,3 +916,26 @@ class TestGetVmContext:
         )
         assert isinstance(result, matching.FirewallBlock)
         assert result.reason == "malformed_firewall_config"
+
+    @pytest.mark.parametrize("firewalls", [1, True, {"name": "example"}, "broken"])
+    def test_malformed_top_level_firewalls_shape_compiles_without_load_failure(
+        self, tmp_path, firewalls
+    ):
+        path = tmp_path / "registry.json"
+        _write_firewall_registry(path)
+        data = json.loads(path.read_text())
+        data["vms"]["10.200.0.1"]["firewalls"] = firewalls
+        path.write_text(json.dumps(data))
+
+        context = registry.get_vm_context("10.200.0.1", str(path))
+
+        assert context is not None
+        _, compiled_firewalls, compiled_network_policies = context
+        assert compiled_firewalls is None
+        result = matching.match_compiled_firewall_request(
+            "https://api.example.com/items",
+            "GET",
+            compiled_firewalls,
+            compiled_network_policies,
+        )
+        assert result is None

--- a/crates/runner/mitm-addon/tests/test_registry.py
+++ b/crates/runner/mitm-addon/tests/test_registry.py
@@ -917,7 +917,10 @@ class TestGetVmContext:
         assert isinstance(result, matching.FirewallBlock)
         assert result.reason == "malformed_firewall_config"
 
-    @pytest.mark.parametrize("firewalls", [1, True, {"name": "example"}, "broken"])
+    @pytest.mark.parametrize(
+        "firewalls",
+        [0, 1, False, True, "", {}, {"name": "example"}, "broken"],
+    )
     def test_malformed_top_level_firewalls_shape_rejects_vm(self, tmp_path, firewalls):
         path = tmp_path / "registry.json"
         _write_firewall_registry(path)

--- a/crates/runner/mitm-addon/tests/test_registry.py
+++ b/crates/runner/mitm-addon/tests/test_registry.py
@@ -918,13 +918,27 @@ class TestGetVmContext:
         assert result.reason == "malformed_firewall_config"
 
     @pytest.mark.parametrize("firewalls", [1, True, {"name": "example"}, "broken"])
-    def test_malformed_top_level_firewalls_shape_compiles_without_load_failure(
-        self, tmp_path, firewalls
-    ):
+    def test_malformed_top_level_firewalls_shape_rejects_vm(self, tmp_path, firewalls):
         path = tmp_path / "registry.json"
         _write_firewall_registry(path)
         data = json.loads(path.read_text())
         data["vms"]["10.200.0.1"]["firewalls"] = firewalls
+        path.write_text(json.dumps(data))
+
+        with patch.object(registry.ctx, "log", MagicMock(), create=True):
+            context = registry.get_vm_context("10.200.0.1", str(path))
+            state = registry.load_registry_state(str(path))
+
+        assert context is None
+        assert not isinstance(state, registry.RegistryUnavailable)
+        assert "10.200.0.1" not in state.vms
+        assert state.invalid_vms["10.200.0.1"].reason == "invalid_firewalls"
+
+    def test_null_top_level_firewalls_shape_is_no_firewall_context(self, tmp_path):
+        path = tmp_path / "registry.json"
+        _write_firewall_registry(path)
+        data = json.loads(path.read_text())
+        data["vms"]["10.200.0.1"]["firewalls"] = None
         path.write_text(json.dumps(data))
 
         context = registry.get_vm_context("10.200.0.1", str(path))
@@ -932,10 +946,4 @@ class TestGetVmContext:
         assert context is not None
         _, compiled_firewalls, compiled_network_policies = context
         assert compiled_firewalls is None
-        result = matching.match_compiled_firewall_request(
-            "https://api.example.com/items",
-            "GET",
-            compiled_firewalls,
-            compiled_network_policies,
-        )
-        assert result is None
+        assert compiled_network_policies is not None

--- a/crates/runner/mitm-addon/tests/test_request_handler_passthrough.py
+++ b/crates/runner/mitm-addon/tests/test_request_handler_passthrough.py
@@ -220,6 +220,89 @@ async def test_invalid_registered_vm_non_object_blocks_before_auth_injection(
     assert flow.metadata["firewall_error"] == "invalid_registry_vm"
 
 
+@pytest.mark.parametrize("firewalls", [1, True, {"name": "github"}, "broken"])
+async def test_invalid_registered_vm_firewalls_shape_blocks_before_auth_injection(
+    tmp_path,
+    real_flow,
+    mitm_ctx,
+    fake_firewall_headers,
+    firewalls,
+):
+    vm_info = _single_firewall_vm(
+        tmp_path,
+        api_entry={
+            "base": "https://api.github.com",
+            "auth": {"headers": {"Authorization": "Bearer secret"}},
+            "permissions": [{"name": "full-access", "rules": ["ANY /{path+}"]}],
+        },
+        network_policy={
+            "allow": ["full-access"],
+            "deny": [],
+            "ask": [],
+            "unknownPolicy": "allow",
+        },
+    )
+    vm_info["firewalls"] = firewalls
+    reg_path = _write_registry(tmp_path, client_ip="10.200.0.5", vm_info=vm_info)
+    flow = real_flow(with_response=False, client_ip="10.200.0.5", host="api.github.com")
+
+    with (
+        mitm_ctx(registry_path=str(reg_path), api_url="https://api.vm0.ai"),
+        fake_firewall_headers() as auth_fetch,
+    ):
+        await mitm_addon.request(flow)
+
+    assert flow.response is not None
+    assert flow.response.status_code == 503
+    assert json.loads(flow.response.content) == {
+        "error": "invalid_registry_vm",
+        "message": "proxy registry VM entry firewalls must be a list",
+        "reason": "invalid_firewalls",
+    }
+    auth_fetch.assert_not_called()
+    assert "vm_run_id" not in flow.metadata
+    assert "firewall_base" not in flow.metadata
+    assert flow.metadata["firewall_action"] == "BLOCK"
+    assert flow.metadata["firewall_error"] == "invalid_registry_vm"
+
+
+async def test_registered_vm_null_firewalls_passes_through_without_auth_injection(
+    tmp_path,
+    real_flow,
+    mitm_ctx,
+    fake_firewall_headers,
+):
+    vm_info = _single_firewall_vm(
+        tmp_path,
+        api_entry={
+            "base": "https://api.github.com",
+            "auth": {"headers": {"Authorization": "Bearer secret"}},
+            "permissions": [{"name": "full-access", "rules": ["ANY /{path+}"]}],
+        },
+        network_policy={
+            "allow": ["full-access"],
+            "deny": [],
+            "ask": [],
+            "unknownPolicy": "allow",
+        },
+    )
+    vm_info["firewalls"] = None
+    reg_path = _write_registry(tmp_path, client_ip="10.200.0.5", vm_info=vm_info)
+    flow = real_flow(with_response=False, client_ip="10.200.0.5", host="api.github.com")
+
+    with (
+        mitm_ctx(registry_path=str(reg_path), api_url="https://api.vm0.ai"),
+        fake_firewall_headers() as auth_fetch,
+    ):
+        await mitm_addon.request(flow)
+
+    assert flow.response is None
+    auth_fetch.assert_not_called()
+    assert flow.metadata["vm_run_id"] == vm_info["runId"]
+    assert "firewall_base" not in flow.metadata
+    assert flow.metadata["firewall_action"] == "ALLOW"
+
+
 async def test_tracks_start_time(registry_file, real_flow, mitm_ctx):
     flow = real_flow(with_response=False, host="api.anthropic.com")
 

--- a/crates/runner/mitm-addon/tests/test_request_handler_passthrough.py
+++ b/crates/runner/mitm-addon/tests/test_request_handler_passthrough.py
@@ -220,7 +220,10 @@ async def test_invalid_registered_vm_non_object_blocks_before_auth_injection(
     assert flow.metadata["firewall_error"] == "invalid_registry_vm"
 
 
-@pytest.mark.parametrize("firewalls", [1, True, {"name": "github"}, "broken"])
+@pytest.mark.parametrize(
+    "firewalls",
+    [0, 1, False, True, "", {}, {"name": "github"}, "broken"],
+)
 async def test_invalid_registered_vm_firewalls_shape_blocks_before_auth_injection(
     tmp_path,
     real_flow,


### PR DESCRIPTION
## Summary
- document the compiled mitm matcher contract for skipped versus retained malformed firewall inputs
- clarify fail-closed precedence for malformed firewall config, malformed network policies, unsafe paths, and unknownPolicy
- reject registered VM entries whose firewalls payload is non-null and non-list so malformed registry data cannot fall through as no-firewall allow
- keep runner-emitted firewalls: null as the normal no-firewall case

## Tests
- python3 -m ruff check src/matching.py src/registry.py tests/test_registry.py tests/test_request_handler_passthrough.py
- python3 -m pytest tests/test_registry.py tests/test_request_handler_passthrough.py tests/test_request_handler_firewall_dispatch.py tests/test_compiled_firewall_malformed_config.py tests/test_firewall_matching.py tests/test_compiled_firewall_precedence.py tests/test_compiled_firewall_unknown_policy.py
- pnpm dlx basedpyright
- lefthook pre-commit: ruff-fmt, ruff-check

Note: full mitm-addon pytest currently fails in test_x_billing.py because local generated connector firewall files are incomplete: index.ts imports ./cursor.generated, which is missing locally. The targeted Python suites above pass.

Closes #16149