### PR TITLE
refactor: extract snapshot provider test fixtures

### DIFF
--- a/crates/sandbox-fc/src/snapshot/output.rs
+++ b/crates/sandbox-fc/src/snapshot/output.rs
@@ -209,6 +209,21 @@ mod tests {
         }
     }
 
+    #[test]
+    fn snapshot_artifact_paths_lists_required_output_artifacts() {
+        let output = SnapshotOutputPaths::new(PathBuf::from("/data/images/test-snapshot"));
+
+        assert_eq!(
+            snapshot_artifact_paths(&output),
+            [
+                output.snapshot(),
+                output.memory(),
+                output.cow(),
+                output.cow_bitmap(),
+            ]
+        );
+    }
+
     #[tokio::test]
     async fn prepare_snapshot_output_removes_snapshot_artifacts_only() {
         let dir = tempfile::tempdir().expect("tempdir");

--- a/crates/sandbox-fc/src/snapshot/provider.rs
+++ b/crates/sandbox-fc/src/snapshot/provider.rs
@@ -45,9 +45,33 @@ mod tests {
 
     use crate::paths::SnapshotOutputPaths;
     use crate::snapshot::SNAPSHOT_COMPLETE_MARKER_CONTENT;
-    use crate::snapshot::output::publish_snapshot_complete_marker;
+    use crate::snapshot::output::{publish_snapshot_complete_marker, snapshot_artifact_paths};
 
     use super::*;
+
+    struct SnapshotOutputFixture {
+        _dir: tempfile::TempDir,
+        output: SnapshotOutputPaths,
+    }
+
+    impl SnapshotOutputFixture {
+        async fn new() -> Self {
+            let dir = tempfile::tempdir().expect("tempdir");
+            let output = SnapshotOutputPaths::new(dir.path().to_path_buf());
+            tokio::fs::create_dir_all(output.dir())
+                .await
+                .expect("create output dir");
+            Self { _dir: dir, output }
+        }
+
+        async fn write_required_snapshot_artifacts(&self) {
+            for artifact in snapshot_artifact_paths(&self.output) {
+                tokio::fs::write(&artifact, b"snapshot artifact")
+                    .await
+                    .unwrap_or_else(|e| panic!("write {}: {e}", artifact.display()));
+            }
+        }
+    }
 
     async fn write_complete_marker(output: &SnapshotOutputPaths) {
         tokio::fs::write(output.complete_marker(), SNAPSHOT_COMPLETE_MARKER_CONTENT)
@@ -57,17 +81,12 @@ mod tests {
 
     #[tokio::test]
     async fn snapshot_provider_requires_cow_bitmap_for_complete_snapshot() {
-        let dir = tempfile::tempdir().expect("tempdir");
-        let output = SnapshotOutputPaths::new(dir.path().to_path_buf());
-        tokio::fs::create_dir_all(output.dir())
+        let fixture = SnapshotOutputFixture::new().await;
+        let output = &fixture.output;
+        fixture.write_required_snapshot_artifacts().await;
+        tokio::fs::remove_file(output.cow_bitmap())
             .await
-            .expect("create output dir");
-
-        for artifact in [output.snapshot(), output.memory(), output.cow()] {
-            tokio::fs::write(&artifact, b"snapshot artifact")
-                .await
-                .unwrap_or_else(|e| panic!("write {}: {e}", artifact.display()));
-        }
+            .expect("remove cow bitmap");
 
         let provider = FirecrackerSnapshotProvider;
         assert!(
@@ -75,7 +94,7 @@ mod tests {
             "snapshot without dirty bitmap sidecar must be incomplete"
         );
         assert!(
-            publish_snapshot_complete_marker(&output).is_err(),
+            publish_snapshot_complete_marker(output).is_err(),
             "complete marker publication must fail before all artifacts exist"
         );
         assert!(
@@ -88,28 +107,15 @@ mod tests {
         tokio::fs::write(output.cow_bitmap(), b"bitmap")
             .await
             .expect("write cow bitmap");
-        publish_snapshot_complete_marker(&output).expect("publish complete marker");
+        publish_snapshot_complete_marker(output).expect("publish complete marker");
         assert!(provider.is_complete(output.dir()).await.unwrap());
     }
 
     #[tokio::test]
     async fn snapshot_provider_requires_complete_marker_for_complete_snapshot() {
-        let dir = tempfile::tempdir().expect("tempdir");
-        let output = SnapshotOutputPaths::new(dir.path().to_path_buf());
-        tokio::fs::create_dir_all(output.dir())
-            .await
-            .expect("create output dir");
-
-        for artifact in [
-            output.snapshot(),
-            output.memory(),
-            output.cow(),
-            output.cow_bitmap(),
-        ] {
-            tokio::fs::write(&artifact, b"snapshot artifact")
-                .await
-                .unwrap_or_else(|e| panic!("write {}: {e}", artifact.display()));
-        }
+        let fixture = SnapshotOutputFixture::new().await;
+        let output = &fixture.output;
+        fixture.write_required_snapshot_artifacts().await;
 
         let provider = FirecrackerSnapshotProvider;
         assert!(
@@ -128,29 +134,16 @@ mod tests {
         tokio::fs::remove_file(output.complete_marker())
             .await
             .expect("remove malformed marker");
-        publish_snapshot_complete_marker(&output).expect("publish complete marker");
+        publish_snapshot_complete_marker(output).expect("publish complete marker");
         assert!(provider.is_complete(output.dir()).await.unwrap());
     }
 
     #[tokio::test]
     async fn snapshot_provider_rejects_valid_marker_with_missing_artifact() {
-        let dir = tempfile::tempdir().expect("tempdir");
-        let output = SnapshotOutputPaths::new(dir.path().to_path_buf());
-        tokio::fs::create_dir_all(output.dir())
-            .await
-            .expect("create output dir");
-
-        for artifact in [
-            output.snapshot(),
-            output.memory(),
-            output.cow(),
-            output.cow_bitmap(),
-        ] {
-            tokio::fs::write(&artifact, b"snapshot artifact")
-                .await
-                .unwrap_or_else(|e| panic!("write {}: {e}", artifact.display()));
-        }
-        publish_snapshot_complete_marker(&output).expect("publish complete marker");
+        let fixture = SnapshotOutputFixture::new().await;
+        let output = &fixture.output;
+        fixture.write_required_snapshot_artifacts().await;
+        publish_snapshot_complete_marker(output).expect("publish complete marker");
         tokio::fs::remove_file(output.cow_bitmap())
             .await
             .expect("remove cow bitmap");
@@ -164,29 +157,16 @@ mod tests {
 
     #[tokio::test]
     async fn snapshot_provider_rejects_valid_marker_with_directory_artifact() {
-        let dir = tempfile::tempdir().expect("tempdir");
-        let output = SnapshotOutputPaths::new(dir.path().to_path_buf());
-        tokio::fs::create_dir_all(output.dir())
-            .await
-            .expect("create output dir");
-
-        for artifact in [
-            output.snapshot(),
-            output.memory(),
-            output.cow(),
-            output.cow_bitmap(),
-        ] {
-            tokio::fs::write(&artifact, b"snapshot artifact")
-                .await
-                .unwrap_or_else(|e| panic!("write {}: {e}", artifact.display()));
-        }
+        let fixture = SnapshotOutputFixture::new().await;
+        let output = &fixture.output;
+        fixture.write_required_snapshot_artifacts().await;
         tokio::fs::remove_file(output.snapshot())
             .await
             .expect("remove snapshot file");
         tokio::fs::create_dir(output.snapshot())
             .await
             .expect("replace snapshot file with directory");
-        write_complete_marker(&output).await;
+        write_complete_marker(output).await;
 
         let provider = FirecrackerSnapshotProvider;
         assert!(
@@ -197,23 +177,10 @@ mod tests {
 
     #[tokio::test]
     async fn snapshot_provider_rejects_valid_marker_with_symlink_artifact() {
-        let dir = tempfile::tempdir().expect("tempdir");
-        let output = SnapshotOutputPaths::new(dir.path().to_path_buf());
-        tokio::fs::create_dir_all(output.dir())
-            .await
-            .expect("create output dir");
-
-        for artifact in [
-            output.snapshot(),
-            output.memory(),
-            output.cow(),
-            output.cow_bitmap(),
-        ] {
-            tokio::fs::write(&artifact, b"snapshot artifact")
-                .await
-                .unwrap_or_else(|e| panic!("write {}: {e}", artifact.display()));
-        }
-        let target = dir.path().join("target-snapshot.bin");
+        let fixture = SnapshotOutputFixture::new().await;
+        let output = &fixture.output;
+        fixture.write_required_snapshot_artifacts().await;
+        let target = output.dir().join("target-snapshot.bin");
         tokio::fs::write(&target, b"target snapshot")
             .await
             .expect("write symlink target");
@@ -222,7 +189,7 @@ mod tests {
             .expect("remove snapshot file");
         std::os::unix::fs::symlink(&target, output.snapshot())
             .expect("replace snapshot file with symlink");
-        write_complete_marker(&output).await;
+        write_complete_marker(output).await;
 
         let provider = FirecrackerSnapshotProvider;
         assert!(


### PR DESCRIPTION
## Summary
- add contract coverage for the snapshot artifact path list
- introduce a local provider test fixture that owns its tempdir and writes required artifacts from the centralized artifact list
- keep invalid marker/artifact provider scenarios as distinct behavior tests

## Testing
- cargo test --manifest-path crates/Cargo.toml -p sandbox-fc snapshot_artifact_paths
- cargo test --manifest-path crates/Cargo.toml -p sandbox-fc snapshot_provider
- cargo test --manifest-path crates/Cargo.toml -p sandbox-fc
- cargo clippy --manifest-path crates/Cargo.toml -p sandbox-fc --all-targets -- -D warnings
- pre-commit hook: cargo-fmt, cargo-clippy, cargo-doc

Closes #16148