### PR TITLE
fix: avoid Ably retry counter overflow

### DIFF
--- a/crates/ably-subscriber/src/connection/event_loop.rs
+++ b/crates/ably-subscriber/src/connection/event_loop.rs
@@ -76,7 +76,7 @@ fn schedule_channel_retry(p: &mut EventLoopState) {
     if p.lifecycle.channel == ChannelLifecycleState::Suspended
         && p.lifecycle.connection.send_events()
     {
-        p.channel_retry_count += 1;
+        p.channel_retry_count = p.channel_retry_count.saturating_add(1);
         p.channel_retry_at = checked_deadline_after(retry_delay(
             p.timing.channel_retry_timeout,
             p.channel_retry_count,
@@ -439,7 +439,7 @@ pub(crate) async fn run_event_loop(mut p: EventLoopState, mut close_rx: oneshot:
             } else if p.lifecycle.connection == ConnectionLifecycleState::Suspended {
                 p.timing.suspended_retry_timeout
             } else {
-                disconnected_retry_count += 1;
+                disconnected_retry_count = disconnected_retry_count.saturating_add(1);
                 retry_delay(
                     p.timing.disconnected_retry_timeout,
                     disconnected_retry_count,
@@ -1113,6 +1113,19 @@ mod tests {
             disconnected_sent,
             "outer loop must not duplicate a Disconnected event sent by reconnect handling"
         );
+    }
+
+    #[test]
+    fn channel_retry_count_saturates_at_max_attempt() {
+        let (event_tx, _event_rx) = mpsc::channel(4);
+        let mut state = test_event_loop_state(event_tx);
+        state.lifecycle.notify_channel_suspended();
+        state.channel_retry_count = u32::MAX;
+
+        schedule_channel_retry(&mut state);
+
+        assert_eq!(state.channel_retry_count, u32::MAX);
+        assert!(state.channel_retry_at.is_some());
     }
 
     #[tokio::test]

--- a/crates/ably-subscriber/src/connection/state.rs
+++ b/crates/ably-subscriber/src/connection/state.rs
@@ -131,7 +131,7 @@ pub(super) fn retry_delay(initial_timeout: Duration, retry_attempt: u32) -> Dura
     // Mirrors ably-js Utils.getRetryTime(): base * min((attempt + 2) / 3, 2)
     // with jitter in [0.8, 1.0). Use wall-clock subsecond nanos as a cheap
     // process-local jitter source; cryptographic randomness is unnecessary.
-    let backoff_num = (retry_attempt + 2).min(6) as u128;
+    let backoff_num = retry_attempt.saturating_add(2).min(6) as u128;
     let base_ms = initial_timeout.as_millis();
     let upper_ms = base_ms.saturating_mul(backoff_num) / 3;
     let nanos = std::time::SystemTime::now()
@@ -489,6 +489,14 @@ mod tests {
         let delay = retry_delay(Duration::MAX, 1);
 
         assert_eq!(delay, Duration::from_millis(u64::MAX));
+    }
+
+    #[test]
+    fn retry_delay_keeps_capped_backoff_at_max_retry_attempt() {
+        let delay = retry_delay(Duration::from_millis(300), u32::MAX);
+
+        assert!(delay >= Duration::from_millis(480));
+        assert!(delay < Duration::from_millis(600));
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- use saturating arithmetic for Ably retry delay attempt math
- saturate channel and disconnected retry counters instead of wrapping
- add boundary coverage for max retry attempts and channel retry scheduling

Closes #16146

## Tests

- cargo test --manifest-path crates/Cargo.toml -p ably-subscriber retry_delay_keeps_capped_backoff_at_max_retry_attempt -- --nocapture
- cargo test --manifest-path crates/Cargo.toml -p ably-subscriber channel_retry_count_saturates_at_max_attempt -- --nocapture
- cargo fmt --manifest-path crates/Cargo.toml --all
- cargo test --manifest-path crates/Cargo.toml -p ably-subscriber
- cargo clippy --manifest-path crates/Cargo.toml -p ably-subscriber --all-targets -- -D warnings
- cargo clippy --all-targets --all-features