### PR TITLE
chore(rust): update dependencies

### DIFF
--- a/crates/Cargo.lock
+++ b/crates/Cargo.lock
@@ -1979,9 +1979,9 @@ dependencies = [
 
 [[package]]
 name = "log"
-version = "0.4.31"
+version = "0.4.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "113b30b4cd05f7c06868fdb2854f66a7b9fece9a48425351cd532e810d74024f"
+checksum = "953f07c43838f8e6f9758cab68bf5bed85465e7587ebe0b823f1bcd81978ad3a"
 
 [[package]]
 name = "lru"


### PR DESCRIPTION
## Summary

- Updated the Rust workspace lockfile under `crates/`.
- Updated 1 dependency: `log` `0.4.31` -> `0.4.32`.

## Dependencies that could not be updated

- `generic-array` remains at `0.14.7` even though `0.14.9` is available.
  - Reason: `crypto-common v0.1.7` exact-pins `generic-array = "=0.14.7"` through the `digest v0.10.7` dependency chain. The blocker is transitive and not controlled by this repository's `Cargo.toml` version specs.
  - Verified with `cargo update -p generic-array@0.14.7 --precise 0.14.9 --dry-run --verbose`.

## Manual version bumps

- None. No safe minor/patch `Cargo.toml` version-spec bumps were needed or available.

## Test status

- Pass: `env -u CLI_AGENT_TYPE CARGO_TARGET_DIR=/home/user/workspace/vm0-rust-deps-target CARGO_INCREMENTAL=0 cargo test --workspace -j1`
- Notes: the sandbox's default `/tmp` filesystem was too small for build artifacts, so `CARGO_TARGET_DIR` was pointed at the larger workspace volume. `-j1` avoids sandbox resource pressure during large test binary linking. `CLI_AGENT_TYPE` was unset because the agent sandbox sets it to `codex`, which changes existing `guest-agent` test expectations; unsetting it matches the workspace's default `claude-code` test path.
