### PR TITLE
refactor: centralize vsock-host mock guest scripting

### DIFF
--- a/crates/vsock-host/src/tests/connection.rs
+++ b/crates/vsock-host/src/tests/connection.rs
@@ -197,7 +197,7 @@ async fn normal_operation_fence_reports_busy_closed_and_not_parkable() {
     let (host_stream, guest) = make_pair();
     let release_exec = Arc::new(tokio::sync::Notify::new());
     let (request_seen_tx, request_seen_rx) = tokio::sync::oneshot::channel();
-    let guest_task = {
+    let mut guest_task = {
         let release_exec = Arc::clone(&release_exec);
         tokio::spawn(async move {
             let mut guest = MockGuest::new(guest);
@@ -222,10 +222,24 @@ async fn normal_operation_fence_reports_busy_closed_and_not_parkable() {
         let host = Arc::clone(&host);
         tokio::spawn(async move { host.exec("sleep", 5000, &[], false).await })
     };
-    tokio::time::timeout(Duration::from_secs(2), request_seen_rx)
-        .await
-        .expect("guest should receive exec start before busy assertion")
-        .unwrap();
+    tokio::select! {
+        result = tokio::time::timeout(Duration::from_secs(2), request_seen_rx) => {
+            match result {
+                Ok(Ok(())) => {}
+                Ok(Err(_)) => {
+                    match (&mut guest_task).await {
+                        Ok(()) => panic!("mock guest finished before exec request"),
+                        Err(err) => panic!("mock guest task panicked before exec request: {err}"),
+                    }
+                }
+                Err(_) => panic!("guest should receive exec start before busy assertion"),
+            }
+        }
+        result = &mut guest_task => {
+            result.expect("mock guest task panicked before exec request");
+            panic!("mock guest finished before exec request");
+        }
+    }
     assert_eq!(
         host.try_fence_normal_operations().unwrap_err(),
         NormalOperationFenceRejection::Busy
@@ -334,7 +348,7 @@ async fn quiesce_operations_times_out_and_late_ack_is_ignored() {
     let (quiesce_seen_tx, quiesce_seen_rx) = tokio::sync::oneshot::channel();
     let (send_late_ack, receive_late_ack) = tokio::sync::oneshot::channel();
 
-    let guest_task = tokio::spawn(async move {
+    let mut guest_task = tokio::spawn(async move {
         let mut guest = MockGuest::new(guest);
         guest.complete_handshake().await;
 
@@ -356,10 +370,24 @@ async fn quiesce_operations_times_out_and_late_ack_is_ignored() {
     let err = host.quiesce_operations(Duration::ZERO).await.unwrap_err();
     assert_eq!(err.kind(), io::ErrorKind::TimedOut);
 
-    tokio::time::timeout(Duration::from_secs(2), quiesce_seen_rx)
-        .await
-        .unwrap()
-        .unwrap();
+    tokio::select! {
+        result = tokio::time::timeout(Duration::from_secs(2), quiesce_seen_rx) => {
+            match result {
+                Ok(Ok(())) => {}
+                Ok(Err(_)) => {
+                    match (&mut guest_task).await {
+                        Ok(()) => panic!("mock guest finished before quiesce request"),
+                        Err(err) => panic!("mock guest task panicked before quiesce request: {err}"),
+                    }
+                }
+                Err(_) => panic!("guest should receive quiesce request before late ack"),
+            }
+        }
+        result = &mut guest_task => {
+            result.expect("mock guest task panicked before quiesce request");
+            panic!("mock guest finished before quiesce request");
+        }
+    }
     assert!(is_connected(&host));
     send_late_ack.send(()).unwrap();
     host.resume_operations(Duration::from_secs(2))

--- a/crates/vsock-host/src/tests/connection.rs
+++ b/crates/vsock-host/src/tests/connection.rs
@@ -8,7 +8,7 @@ use vsock_proto::{
 };
 
 use super::support::{
-    MockGuest, drop_idle_request_write_guard, drop_started_request_write_guard,
+    MockGuest, await_mock_guest, drop_idle_request_write_guard, drop_started_request_write_guard,
     fence_normal_operations, host_from_stream, is_connected, make_pair, normal_operation_readiness,
     poison_connection, setup_host_and_mock_guest,
 };
@@ -92,7 +92,7 @@ async fn test_shutdown() {
 
     let host = host_from_stream(host_stream).await.unwrap();
     assert!(host.shutdown(Duration::from_secs(2)).await);
-    guest_task.await.unwrap();
+    await_mock_guest(guest_task).await;
 }
 
 #[tokio::test]
@@ -115,7 +115,7 @@ async fn quiesce_operations_sends_request_and_accepts_empty_ack() {
     host.quiesce_operations(Duration::from_secs(2))
         .await
         .unwrap();
-    guest_task.await.unwrap();
+    await_mock_guest(guest_task).await;
 }
 
 #[tokio::test]
@@ -138,7 +138,7 @@ async fn resume_operations_sends_request_and_accepts_empty_ack() {
     host.resume_operations(Duration::from_secs(2))
         .await
         .unwrap();
-    guest_task.await.unwrap();
+    await_mock_guest(guest_task).await;
 }
 
 #[tokio::test]
@@ -240,7 +240,7 @@ async fn normal_operation_fence_reports_busy_closed_and_not_parkable() {
         host.try_fence_normal_operations().unwrap_err(),
         NormalOperationFenceRejection::Closed
     );
-    guest_task.await.unwrap();
+    await_mock_guest(guest_task).await;
 
     let (poisoned_host, _guest) = setup_host_and_mock_guest().await;
     poison_connection(&poisoned_host);
@@ -271,7 +271,7 @@ async fn quiesce_operations_surfaces_guest_error() {
         .unwrap_err();
     assert_eq!(err.kind(), io::ErrorKind::Other);
     assert_eq!(err.to_string(), "guest operations still pending: 1");
-    guest_task.await.unwrap();
+    await_mock_guest(guest_task).await;
 }
 
 #[tokio::test]
@@ -298,7 +298,7 @@ async fn quiesce_operations_rejects_wrong_ack_type() {
         err.to_string()
             .contains("unexpected lifecycle response type")
     );
-    guest_task.await.unwrap();
+    await_mock_guest(guest_task).await;
 }
 
 #[tokio::test]
@@ -325,7 +325,7 @@ async fn quiesce_operations_rejects_non_empty_ack_payload() {
         err.to_string()
             .contains("operations_quiesced payload must be empty")
     );
-    guest_task.await.unwrap();
+    await_mock_guest(guest_task).await;
 }
 
 #[tokio::test]
@@ -365,7 +365,7 @@ async fn quiesce_operations_times_out_and_late_ack_is_ignored() {
     host.resume_operations(Duration::from_secs(2))
         .await
         .unwrap();
-    guest_task.await.unwrap();
+    await_mock_guest(guest_task).await;
 }
 
 #[tokio::test]
@@ -384,7 +384,7 @@ async fn test_connection_closed_returns_error() {
     let host = host_from_stream(host_stream).await.unwrap();
     let err = host.exec("echo hi", 5000, &[], false).await.unwrap_err();
     assert_eq!(err.kind(), io::ErrorKind::ConnectionReset);
-    guest_task.await.unwrap();
+    await_mock_guest(guest_task).await;
 }
 
 /// Request made after connection is already closed returns ConnectionReset
@@ -425,7 +425,7 @@ async fn test_request_after_close_returns_immediately() {
         "expected ConnectionReset or BrokenPipe, got {:?}",
         err.kind()
     );
-    guest_task.await.unwrap();
+    await_mock_guest(guest_task).await;
 }
 
 #[tokio::test]
@@ -456,7 +456,7 @@ async fn lifecycle_request_after_connection_close_returns_immediately() {
         normal_operation_readiness(&host),
         NormalOperationReadiness::Closed
     );
-    guest_task.await.unwrap();
+    await_mock_guest(guest_task).await;
 }
 
 #[tokio::test]
@@ -478,7 +478,7 @@ async fn connection_close_marks_normal_operations_closed() {
         normal_operation_readiness(&host),
         NormalOperationReadiness::Closed
     );
-    guest_task.await.unwrap();
+    await_mock_guest(guest_task).await;
 }
 
 #[tokio::test]
@@ -505,7 +505,7 @@ async fn late_poison_after_connection_close_does_not_reclassify_readiness() {
         normal_operation_readiness(&host),
         NormalOperationReadiness::Closed
     );
-    guest_task.await.unwrap();
+    await_mock_guest(guest_task).await;
 }
 
 #[tokio::test]
@@ -525,10 +525,7 @@ async fn connection_poison_marks_normal_operations_not_parkable() {
         normal_operation_readiness(&host),
         NormalOperationReadiness::NotParkable
     );
-    tokio::time::timeout(Duration::from_secs(5), guest_task)
-        .await
-        .unwrap()
-        .unwrap();
+    await_mock_guest(guest_task).await;
 }
 
 #[tokio::test]
@@ -609,7 +606,7 @@ async fn test_concurrent_execs() {
     assert_eq!(out1, "reply:cmd-a");
     assert_eq!(out2, "reply:cmd-b");
     drop(host);
-    guest_task.await.unwrap();
+    await_mock_guest(guest_task).await;
 }
 
 /// Verify that post-handshake request seq starts at 2 (seq=1 is used by handshake ping).
@@ -639,7 +636,7 @@ async fn test_seq_starts_at_2() {
     let host = host_from_stream(host_stream).await.unwrap();
     let result = host.exec("test", 5000, &[], false).await.unwrap();
     assert_eq!(result.exit_code, 0);
-    guest_task.await.unwrap();
+    await_mock_guest(guest_task).await;
 }
 
 /// Regression for #10076: the guest writes the exec response and then
@@ -684,5 +681,5 @@ async fn test_response_then_close_returns_ok() {
     let result = result.expect("response delivered before close must not be lost");
     assert_eq!(result.exit_code, 0);
     assert_eq!(result.stdout, b"race-survived");
-    guest_task.await.unwrap();
+    await_mock_guest(guest_task).await;
 }

--- a/crates/vsock-host/src/tests/connection.rs
+++ b/crates/vsock-host/src/tests/connection.rs
@@ -2,17 +2,16 @@ use std::io;
 use std::sync::Arc;
 use std::time::Duration;
 
-use tokio::io::{AsyncReadExt, AsyncWriteExt};
+use tokio::io::AsyncReadExt;
 use vsock_proto::{
-    Decoder, ExecTermination, MSG_ERROR, MSG_EXEC_START, MSG_OPERATIONS_QUIESCED,
-    MSG_OPERATIONS_RESUMED, MSG_QUIESCE_OPERATIONS, MSG_RESUME_OPERATIONS, MSG_SHUTDOWN,
-    MSG_SHUTDOWN_ACK,
+    ExecTermination, MSG_EXEC_START, MSG_OPERATIONS_QUIESCED, MSG_OPERATIONS_RESUMED,
+    MSG_QUIESCE_OPERATIONS, MSG_RESUME_OPERATIONS, MSG_SHUTDOWN, MSG_SHUTDOWN_ACK,
 };
 
 use super::support::{
-    drop_idle_request_write_guard, drop_started_request_write_guard, fence_normal_operations,
-    host_from_stream, is_connected, make_pair, mock_handshake, normal_operation_readiness,
-    poison_connection, read_guest_message, send_exec_result, setup_host_and_guest,
+    MockGuest, drop_idle_request_write_guard, drop_started_request_write_guard,
+    fence_normal_operations, host_from_stream, is_connected, make_pair, normal_operation_readiness,
+    poison_connection, setup_host_and_mock_guest,
 };
 use crate::{
     NormalOperationFenceRejection, VsockHost, operation_tracker::NormalOperationReadiness,
@@ -80,76 +79,72 @@ async fn wait_for_connection_removes_listener_socket_on_abort() {
 
 #[tokio::test]
 async fn test_shutdown() {
-    let (host_stream, mut guest) = make_pair();
+    let (host_stream, guest) = make_pair();
 
-    tokio::spawn(async move {
-        let mut decoder = Decoder::new();
-        mock_handshake(&mut guest, &mut decoder).await;
+    let guest_task = tokio::spawn(async move {
+        let mut guest = MockGuest::new(guest);
+        guest.complete_handshake().await;
 
-        let mut buf = [0u8; 4096];
-        let n = guest.read(&mut buf).await.unwrap();
-        let msgs = decoder.decode(&buf[..n]).unwrap();
-        assert_eq!(msgs[0].msg_type, MSG_SHUTDOWN);
-
-        let resp = vsock_proto::encode(MSG_SHUTDOWN_ACK, msgs[0].seq, &[]).unwrap();
-        guest.write_all(&resp).await.unwrap();
+        let shutdown = guest.expect_message(MSG_SHUTDOWN).await;
+        guest
+            .send_empty_response(MSG_SHUTDOWN_ACK, shutdown.seq)
+            .await;
     });
 
     let host = host_from_stream(host_stream).await.unwrap();
     assert!(host.shutdown(Duration::from_secs(2)).await);
+    guest_task.await.unwrap();
 }
 
 #[tokio::test]
 async fn quiesce_operations_sends_request_and_accepts_empty_ack() {
-    let (host_stream, mut guest) = make_pair();
+    let (host_stream, guest) = make_pair();
 
-    tokio::spawn(async move {
-        let mut decoder = Decoder::new();
-        mock_handshake(&mut guest, &mut decoder).await;
+    let guest_task = tokio::spawn(async move {
+        let mut guest = MockGuest::new(guest);
+        guest.complete_handshake().await;
 
-        let mut buf = [0u8; 4096];
-        let n = guest.read(&mut buf).await.unwrap();
-        let msgs = decoder.decode(&buf[..n]).unwrap();
-        assert_eq!(msgs[0].msg_type, MSG_QUIESCE_OPERATIONS);
-        assert!(msgs[0].payload.is_empty());
+        let quiesce = guest.expect_message(MSG_QUIESCE_OPERATIONS).await;
+        assert!(quiesce.payload.is_empty());
 
-        let resp = vsock_proto::encode(MSG_OPERATIONS_QUIESCED, msgs[0].seq, &[]).unwrap();
-        guest.write_all(&resp).await.unwrap();
+        guest
+            .send_empty_response(MSG_OPERATIONS_QUIESCED, quiesce.seq)
+            .await;
     });
 
     let host = host_from_stream(host_stream).await.unwrap();
     host.quiesce_operations(Duration::from_secs(2))
         .await
         .unwrap();
+    guest_task.await.unwrap();
 }
 
 #[tokio::test]
 async fn resume_operations_sends_request_and_accepts_empty_ack() {
-    let (host_stream, mut guest) = make_pair();
+    let (host_stream, guest) = make_pair();
 
-    tokio::spawn(async move {
-        let mut decoder = Decoder::new();
-        mock_handshake(&mut guest, &mut decoder).await;
+    let guest_task = tokio::spawn(async move {
+        let mut guest = MockGuest::new(guest);
+        guest.complete_handshake().await;
 
-        let mut buf = [0u8; 4096];
-        let n = guest.read(&mut buf).await.unwrap();
-        let msgs = decoder.decode(&buf[..n]).unwrap();
-        assert_eq!(msgs[0].msg_type, MSG_RESUME_OPERATIONS);
-        assert!(msgs[0].payload.is_empty());
+        let resume = guest.expect_message(MSG_RESUME_OPERATIONS).await;
+        assert!(resume.payload.is_empty());
 
-        let resp = vsock_proto::encode(MSG_OPERATIONS_RESUMED, msgs[0].seq, &[]).unwrap();
-        guest.write_all(&resp).await.unwrap();
+        guest
+            .send_empty_response(MSG_OPERATIONS_RESUMED, resume.seq)
+            .await;
     });
 
     let host = host_from_stream(host_stream).await.unwrap();
     host.resume_operations(Duration::from_secs(2))
         .await
         .unwrap();
+    guest_task.await.unwrap();
 }
 
 #[tokio::test]
 async fn lifecycle_request_bypasses_normal_operation_fence() {
-    let (host, mut guest) = setup_host_and_guest().await;
+    let (host, mut guest) = setup_host_and_mock_guest().await;
     let host = Arc::new(host);
     let _fence = fence_normal_operations(&host);
 
@@ -161,17 +156,17 @@ async fn lifecycle_request_bypasses_normal_operation_fence() {
         tokio::spawn(async move { host.quiesce_operations(Duration::from_secs(2)).await })
     };
 
-    let msg = read_guest_message(&mut guest).await;
-    assert_eq!(msg.msg_type, MSG_QUIESCE_OPERATIONS);
-    let resp = vsock_proto::encode(MSG_OPERATIONS_QUIESCED, msg.seq, &[]).unwrap();
-    guest.write_all(&resp).await.unwrap();
+    let msg = guest.expect_message(MSG_QUIESCE_OPERATIONS).await;
+    guest
+        .send_empty_response(MSG_OPERATIONS_QUIESCED, msg.seq)
+        .await;
 
     quiesce_task.await.unwrap().unwrap();
 }
 
 #[tokio::test]
 async fn normal_operation_fence_rejects_new_normal_operations_until_dropped() {
-    let (host, mut guest) = setup_host_and_guest().await;
+    let (host, mut guest) = setup_host_and_mock_guest().await;
     let fence = host
         .try_fence_normal_operations()
         .expect("idle host should fence normal operations");
@@ -185,42 +180,40 @@ async fn normal_operation_fence_rejects_new_normal_operations_until_dropped() {
 
     drop(fence);
     let exec_task = tokio::spawn(async move { host.exec("echo ok", 5000, &[], false).await });
-    let request = read_guest_message(&mut guest).await;
-    assert_eq!(request.msg_type, MSG_EXEC_START);
-    send_exec_result(
-        &mut guest,
-        request.seq,
-        ExecTermination::Exited { exit_code: 0 },
-        b"ok",
-        b"",
-    )
-    .await;
+    let request = guest.expect_message(MSG_EXEC_START).await;
+    guest
+        .send_exec_result(
+            request.seq,
+            ExecTermination::Exited { exit_code: 0 },
+            b"ok",
+            b"",
+        )
+        .await;
 
     assert_eq!(exec_task.await.unwrap().unwrap().stdout, b"ok");
 }
 
 #[tokio::test]
 async fn normal_operation_fence_reports_busy_closed_and_not_parkable() {
-    let (host_stream, mut guest) = make_pair();
+    let (host_stream, guest) = make_pair();
     let release_exec = Arc::new(tokio::sync::Notify::new());
     let (request_seen_tx, request_seen_rx) = tokio::sync::oneshot::channel();
     let guest_task = {
         let release_exec = Arc::clone(&release_exec);
         tokio::spawn(async move {
-            let mut decoder = Decoder::new();
-            mock_handshake(&mut guest, &mut decoder).await;
-            let request = read_guest_message(&mut guest).await;
-            assert_eq!(request.msg_type, MSG_EXEC_START);
+            let mut guest = MockGuest::new(guest);
+            guest.complete_handshake().await;
+            let request = guest.expect_message(MSG_EXEC_START).await;
             let _ = request_seen_tx.send(());
             release_exec.notified().await;
-            send_exec_result(
-                &mut guest,
-                request.seq,
-                ExecTermination::Exited { exit_code: 0 },
-                b"done",
-                b"",
-            )
-            .await;
+            guest
+                .send_exec_result(
+                    request.seq,
+                    ExecTermination::Exited { exit_code: 0 },
+                    b"done",
+                    b"",
+                )
+                .await;
             drop(guest);
         })
     };
@@ -250,7 +243,7 @@ async fn normal_operation_fence_reports_busy_closed_and_not_parkable() {
     );
     guest_task.await.unwrap();
 
-    let (poisoned_host, _guest) = setup_host_and_guest().await;
+    let (poisoned_host, _guest) = setup_host_and_mock_guest().await;
     poison_connection(&poisoned_host);
     assert_eq!(
         poisoned_host.try_fence_normal_operations().unwrap_err(),
@@ -260,20 +253,16 @@ async fn normal_operation_fence_reports_busy_closed_and_not_parkable() {
 
 #[tokio::test]
 async fn quiesce_operations_surfaces_guest_error() {
-    let (host_stream, mut guest) = make_pair();
+    let (host_stream, guest) = make_pair();
 
-    tokio::spawn(async move {
-        let mut decoder = Decoder::new();
-        mock_handshake(&mut guest, &mut decoder).await;
+    let guest_task = tokio::spawn(async move {
+        let mut guest = MockGuest::new(guest);
+        guest.complete_handshake().await;
 
-        let mut buf = [0u8; 4096];
-        let n = guest.read(&mut buf).await.unwrap();
-        let msgs = decoder.decode(&buf[..n]).unwrap();
-        assert_eq!(msgs[0].msg_type, MSG_QUIESCE_OPERATIONS);
-
-        let payload = vsock_proto::encode_error("guest operations still pending: 1");
-        let resp = vsock_proto::encode(MSG_ERROR, msgs[0].seq, &payload).unwrap();
-        guest.write_all(&resp).await.unwrap();
+        let quiesce = guest.expect_message(MSG_QUIESCE_OPERATIONS).await;
+        guest
+            .send_error_response(quiesce.seq, "guest operations still pending: 1")
+            .await;
     });
 
     let host = host_from_stream(host_stream).await.unwrap();
@@ -283,21 +272,21 @@ async fn quiesce_operations_surfaces_guest_error() {
         .unwrap_err();
     assert_eq!(err.kind(), io::ErrorKind::Other);
     assert_eq!(err.to_string(), "guest operations still pending: 1");
+    guest_task.await.unwrap();
 }
 
 #[tokio::test]
 async fn quiesce_operations_rejects_wrong_ack_type() {
-    let (host_stream, mut guest) = make_pair();
+    let (host_stream, guest) = make_pair();
 
-    tokio::spawn(async move {
-        let mut decoder = Decoder::new();
-        mock_handshake(&mut guest, &mut decoder).await;
+    let guest_task = tokio::spawn(async move {
+        let mut guest = MockGuest::new(guest);
+        guest.complete_handshake().await;
 
-        let mut buf = [0u8; 4096];
-        let n = guest.read(&mut buf).await.unwrap();
-        let msgs = decoder.decode(&buf[..n]).unwrap();
-        let resp = vsock_proto::encode(MSG_OPERATIONS_RESUMED, msgs[0].seq, &[]).unwrap();
-        guest.write_all(&resp).await.unwrap();
+        let quiesce = guest.expect_message(MSG_QUIESCE_OPERATIONS).await;
+        guest
+            .send_empty_response(MSG_OPERATIONS_RESUMED, quiesce.seq)
+            .await;
     });
 
     let host = host_from_stream(host_stream).await.unwrap();
@@ -310,21 +299,21 @@ async fn quiesce_operations_rejects_wrong_ack_type() {
         err.to_string()
             .contains("unexpected lifecycle response type")
     );
+    guest_task.await.unwrap();
 }
 
 #[tokio::test]
 async fn quiesce_operations_rejects_non_empty_ack_payload() {
-    let (host_stream, mut guest) = make_pair();
+    let (host_stream, guest) = make_pair();
 
-    tokio::spawn(async move {
-        let mut decoder = Decoder::new();
-        mock_handshake(&mut guest, &mut decoder).await;
+    let guest_task = tokio::spawn(async move {
+        let mut guest = MockGuest::new(guest);
+        guest.complete_handshake().await;
 
-        let mut buf = [0u8; 4096];
-        let n = guest.read(&mut buf).await.unwrap();
-        let msgs = decoder.decode(&buf[..n]).unwrap();
-        let resp = vsock_proto::encode(MSG_OPERATIONS_QUIESCED, msgs[0].seq, b"x").unwrap();
-        guest.write_all(&resp).await.unwrap();
+        let quiesce = guest.expect_message(MSG_QUIESCE_OPERATIONS).await;
+        guest
+            .send_response(MSG_OPERATIONS_QUIESCED, quiesce.seq, b"x")
+            .await;
     });
 
     let host = host_from_stream(host_stream).await.unwrap();
@@ -337,30 +326,31 @@ async fn quiesce_operations_rejects_non_empty_ack_payload() {
         err.to_string()
             .contains("operations_quiesced payload must be empty")
     );
+    guest_task.await.unwrap();
 }
 
 #[tokio::test]
 async fn quiesce_operations_times_out_and_late_ack_is_ignored() {
-    let (host_stream, mut guest) = make_pair();
+    let (host_stream, guest) = make_pair();
     let (quiesce_seen_tx, quiesce_seen_rx) = tokio::sync::oneshot::channel();
     let (send_late_ack, receive_late_ack) = tokio::sync::oneshot::channel();
 
-    tokio::spawn(async move {
-        let mut decoder = Decoder::new();
-        mock_handshake(&mut guest, &mut decoder).await;
+    let guest_task = tokio::spawn(async move {
+        let mut guest = MockGuest::new(guest);
+        guest.complete_handshake().await;
 
-        let quiesce = read_guest_message(&mut guest).await;
-        assert_eq!(quiesce.msg_type, MSG_QUIESCE_OPERATIONS);
+        let quiesce = guest.expect_message(MSG_QUIESCE_OPERATIONS).await;
         quiesce_seen_tx.send(()).unwrap();
 
         receive_late_ack.await.unwrap();
-        let late = vsock_proto::encode(MSG_OPERATIONS_QUIESCED, quiesce.seq, &[]).unwrap();
-        guest.write_all(&late).await.unwrap();
+        guest
+            .send_empty_response(MSG_OPERATIONS_QUIESCED, quiesce.seq)
+            .await;
 
-        let resume = read_guest_message(&mut guest).await;
-        assert_eq!(resume.msg_type, MSG_RESUME_OPERATIONS);
-        let resp = vsock_proto::encode(MSG_OPERATIONS_RESUMED, resume.seq, &[]).unwrap();
-        guest.write_all(&resp).await.unwrap();
+        let resume = guest.expect_message(MSG_RESUME_OPERATIONS).await;
+        guest
+            .send_empty_response(MSG_OPERATIONS_RESUMED, resume.seq)
+            .await;
     });
 
     let host = host_from_stream(host_stream).await.unwrap();
@@ -376,36 +366,37 @@ async fn quiesce_operations_times_out_and_late_ack_is_ignored() {
     host.resume_operations(Duration::from_secs(2))
         .await
         .unwrap();
+    guest_task.await.unwrap();
 }
 
 #[tokio::test]
 async fn test_connection_closed_returns_error() {
-    let (host_stream, mut guest) = make_pair();
+    let (host_stream, guest) = make_pair();
 
-    tokio::spawn(async move {
-        let mut decoder = Decoder::new();
-        mock_handshake(&mut guest, &mut decoder).await;
+    let guest_task = tokio::spawn(async move {
+        let mut guest = MockGuest::new(guest);
+        guest.complete_handshake().await;
 
         // Read the exec request then close the connection.
-        let mut buf = [0u8; 4096];
-        let _ = guest.read(&mut buf).await.unwrap();
+        let _request = guest.expect_message(MSG_EXEC_START).await;
         drop(guest);
     });
 
     let host = host_from_stream(host_stream).await.unwrap();
     let err = host.exec("echo hi", 5000, &[], false).await.unwrap_err();
     assert_eq!(err.kind(), io::ErrorKind::ConnectionReset);
+    guest_task.await.unwrap();
 }
 
 /// Request made after connection is already closed returns ConnectionReset
 /// immediately (not after timeout).
 #[tokio::test]
 async fn test_request_after_close_returns_immediately() {
-    let (host_stream, mut guest) = make_pair();
+    let (host_stream, guest) = make_pair();
 
-    tokio::spawn(async move {
-        let mut decoder = Decoder::new();
-        mock_handshake(&mut guest, &mut decoder).await;
+    let guest_task = tokio::spawn(async move {
+        let mut guest = MockGuest::new(guest);
+        guest.complete_handshake().await;
         // Close immediately after handshake.
         drop(guest);
     });
@@ -435,15 +426,16 @@ async fn test_request_after_close_returns_immediately() {
         "expected ConnectionReset or BrokenPipe, got {:?}",
         err.kind()
     );
+    guest_task.await.unwrap();
 }
 
 #[tokio::test]
 async fn lifecycle_request_after_connection_close_returns_immediately() {
-    let (host_stream, mut guest) = make_pair();
+    let (host_stream, guest) = make_pair();
 
     let guest_task = tokio::spawn(async move {
-        let mut decoder = Decoder::new();
-        mock_handshake(&mut guest, &mut decoder).await;
+        let mut guest = MockGuest::new(guest);
+        guest.complete_handshake().await;
         drop(guest);
     });
 
@@ -470,11 +462,11 @@ async fn lifecycle_request_after_connection_close_returns_immediately() {
 
 #[tokio::test]
 async fn connection_close_marks_normal_operations_closed() {
-    let (host_stream, mut guest) = make_pair();
+    let (host_stream, guest) = make_pair();
 
     let guest_task = tokio::spawn(async move {
-        let mut decoder = Decoder::new();
-        mock_handshake(&mut guest, &mut decoder).await;
+        let mut guest = MockGuest::new(guest);
+        guest.complete_handshake().await;
         drop(guest);
     });
 
@@ -492,11 +484,11 @@ async fn connection_close_marks_normal_operations_closed() {
 
 #[tokio::test]
 async fn late_poison_after_connection_close_does_not_reclassify_readiness() {
-    let (host_stream, mut guest) = make_pair();
+    let (host_stream, guest) = make_pair();
 
     let guest_task = tokio::spawn(async move {
-        let mut decoder = Decoder::new();
-        mock_handshake(&mut guest, &mut decoder).await;
+        let mut guest = MockGuest::new(guest);
+        guest.complete_handshake().await;
         drop(guest);
     });
 
@@ -519,13 +511,13 @@ async fn late_poison_after_connection_close_does_not_reclassify_readiness() {
 
 #[tokio::test]
 async fn connection_poison_marks_normal_operations_not_parkable() {
-    let (host_stream, mut guest) = make_pair();
+    let (host_stream, guest) = make_pair();
 
     let guest_task = tokio::spawn(async move {
-        let mut decoder = Decoder::new();
-        mock_handshake(&mut guest, &mut decoder).await;
+        let mut guest = MockGuest::new(guest);
+        guest.complete_handshake().await;
         let mut buf = [0u8; 1];
-        let _ = guest.read(&mut buf).await;
+        let _ = guest.stream_mut().read(&mut buf).await;
     });
 
     let host = host_from_stream(host_stream).await.unwrap();
@@ -543,7 +535,7 @@ async fn connection_poison_marks_normal_operations_not_parkable() {
 
 #[tokio::test]
 async fn cancelled_request_before_frame_write_does_not_poison_connection() {
-    let (host, _guest) = setup_host_and_guest().await;
+    let (host, _guest) = setup_host_and_mock_guest().await;
 
     drop_idle_request_write_guard(&host);
 
@@ -556,7 +548,7 @@ async fn cancelled_request_before_frame_write_does_not_poison_connection() {
 
 #[tokio::test]
 async fn cancelled_request_frame_write_poisons_connection() {
-    let (host, _guest) = setup_host_and_guest().await;
+    let (host, _guest) = setup_host_and_mock_guest().await;
 
     drop_started_request_write_guard(&host);
 
@@ -572,20 +564,13 @@ async fn cancelled_request_frame_write_poisons_connection() {
 /// Two concurrent exec calls get the correct response matched by seq.
 #[tokio::test]
 async fn test_concurrent_execs() {
-    let (host_stream, mut guest) = make_pair();
+    let (host_stream, guest) = make_pair();
 
-    tokio::spawn(async move {
-        let mut decoder = Decoder::new();
-        mock_handshake(&mut guest, &mut decoder).await;
+    let guest_task = tokio::spawn(async move {
+        let mut guest = MockGuest::new(guest);
+        guest.complete_handshake().await;
 
-        // Read both exec requests (may arrive in one or two reads).
-        let mut all_msgs = Vec::new();
-        let mut buf = [0u8; 4096];
-        while all_msgs.len() < 2 {
-            let n = guest.read(&mut buf).await.unwrap();
-            let msgs = decoder.decode(&buf[..n]).unwrap();
-            all_msgs.extend(msgs);
-        }
+        let all_msgs = guest.read_messages(2).await;
         assert_eq!(all_msgs.len(), 2);
         assert!(all_msgs.iter().all(|m| m.msg_type == MSG_EXEC_START));
 
@@ -593,18 +578,18 @@ async fn test_concurrent_execs() {
         for msg in all_msgs.iter().rev() {
             let d = vsock_proto::decode_exec_start(&msg.payload).unwrap();
             let out = format!("reply:{}", d.command);
-            send_exec_result(
-                &mut guest,
-                msg.seq,
-                ExecTermination::Exited { exit_code: 0 },
-                out.as_bytes(),
-                b"",
-            )
-            .await;
+            guest
+                .send_exec_result(
+                    msg.seq,
+                    ExecTermination::Exited { exit_code: 0 },
+                    out.as_bytes(),
+                    b"",
+                )
+                .await;
         }
 
         let mut discard = [0u8; 1];
-        let _ = guest.read(&mut discard).await;
+        let _ = guest.stream_mut().read(&mut discard).await;
     });
 
     let host = Arc::new(host_from_stream(host_stream).await.unwrap());
@@ -626,38 +611,38 @@ async fn test_concurrent_execs() {
     let out2 = String::from_utf8_lossy(&r2.stdout);
     assert_eq!(out1, "reply:cmd-a");
     assert_eq!(out2, "reply:cmd-b");
+    drop(host);
+    guest_task.await.unwrap();
 }
 
 /// Verify that post-handshake request seq starts at 2 (seq=1 is used by handshake ping).
 #[tokio::test]
 async fn test_seq_starts_at_2() {
-    let (host_stream, mut guest) = make_pair();
+    let (host_stream, guest) = make_pair();
 
-    tokio::spawn(async move {
-        let mut decoder = Decoder::new();
-        mock_handshake(&mut guest, &mut decoder).await;
+    let guest_task = tokio::spawn(async move {
+        let mut guest = MockGuest::new(guest);
+        guest.complete_handshake().await;
 
         // Read the first exec request and verify its seq.
-        let mut buf = [0u8; 4096];
-        let n = guest.read(&mut buf).await.unwrap();
-        let msgs = decoder.decode(&buf[..n]).unwrap();
-        assert_eq!(msgs[0].msg_type, MSG_EXEC_START);
+        let msg = guest.expect_message(MSG_EXEC_START).await;
         // Handshake used seq=1, so first request must be seq=2.
-        assert_eq!(msgs[0].seq, 2, "first post-handshake seq should be 2");
+        assert_eq!(msg.seq, 2, "first post-handshake seq should be 2");
 
-        send_exec_result(
-            &mut guest,
-            msgs[0].seq,
-            ExecTermination::Exited { exit_code: 0 },
-            b"ok",
-            b"",
-        )
-        .await;
+        guest
+            .send_exec_result(
+                msg.seq,
+                ExecTermination::Exited { exit_code: 0 },
+                b"ok",
+                b"",
+            )
+            .await;
     });
 
     let host = host_from_stream(host_stream).await.unwrap();
     let result = host.exec("test", 5000, &[], false).await.unwrap();
     assert_eq!(result.exit_code, 0);
+    guest_task.await.unwrap();
 }
 
 /// Regression for #10076: the guest writes the exec response and then
@@ -670,29 +655,26 @@ async fn test_seq_starts_at_2() {
 /// returned via the biased `rx` arm of `select!`.
 #[tokio::test]
 async fn test_response_then_close_returns_ok() {
-    let (host_stream, mut guest) = make_pair();
+    let (host_stream, guest) = make_pair();
 
-    tokio::spawn(async move {
-        let mut decoder = Decoder::new();
-        mock_handshake(&mut guest, &mut decoder).await;
+    let guest_task = tokio::spawn(async move {
+        let mut guest = MockGuest::new(guest);
+        guest.complete_handshake().await;
 
         // Read the exec request.
-        let mut buf = [0u8; 4096];
-        let n = guest.read(&mut buf).await.unwrap();
-        let msgs = decoder.decode(&buf[..n]).unwrap();
-        assert_eq!(msgs[0].msg_type, MSG_EXEC_START);
+        let msg = guest.expect_message(MSG_EXEC_START).await;
 
         // Write the response and close the socket. The response must
         // race with EOF such that reader_loop processes both before the
         // host's `request_raw` returns from its select!.
-        send_exec_result(
-            &mut guest,
-            msgs[0].seq,
-            ExecTermination::Exited { exit_code: 0 },
-            b"race-survived",
-            b"",
-        )
-        .await;
+        guest
+            .send_exec_result(
+                msg.seq,
+                ExecTermination::Exited { exit_code: 0 },
+                b"race-survived",
+                b"",
+            )
+            .await;
         drop(guest);
     });
 
@@ -705,4 +687,5 @@ async fn test_response_then_close_returns_ok() {
     let result = result.expect("response delivered before close must not be lost");
     assert_eq!(result.exit_code, 0);
     assert_eq!(result.stdout, b"race-survived");
+    guest_task.await.unwrap();
 }

--- a/crates/vsock-host/src/tests/connection.rs
+++ b/crates/vsock-host/src/tests/connection.rs
@@ -2,7 +2,6 @@ use std::io;
 use std::sync::Arc;
 use std::time::Duration;
 
-use tokio::io::AsyncReadExt;
 use vsock_proto::{
     ExecTermination, MSG_EXEC_START, MSG_OPERATIONS_QUIESCED, MSG_OPERATIONS_RESUMED,
     MSG_QUIESCE_OPERATIONS, MSG_RESUME_OPERATIONS, MSG_SHUTDOWN, MSG_SHUTDOWN_ACK,
@@ -516,8 +515,7 @@ async fn connection_poison_marks_normal_operations_not_parkable() {
     let guest_task = tokio::spawn(async move {
         let mut guest = MockGuest::new(guest);
         guest.complete_handshake().await;
-        let mut buf = [0u8; 1];
-        let _ = guest.stream_mut().read(&mut buf).await;
+        guest.expect_eof().await;
     });
 
     let host = host_from_stream(host_stream).await.unwrap();
@@ -588,8 +586,7 @@ async fn test_concurrent_execs() {
                 .await;
         }
 
-        let mut discard = [0u8; 1];
-        let _ = guest.stream_mut().read(&mut discard).await;
+        guest.expect_eof().await;
     });
 
     let host = Arc::new(host_from_stream(host_stream).await.unwrap());

--- a/crates/vsock-host/src/tests/exec_operation/exec.rs
+++ b/crates/vsock-host/src/tests/exec_operation/exec.rs
@@ -1,11 +1,11 @@
 use std::io;
 use std::sync::Arc;
 
-use tokio::io::{AsyncReadExt, AsyncWriteExt};
-use vsock_proto::{Decoder, ExecTermination, MSG_ERROR, MSG_EXEC_START};
+use tokio::io::AsyncWriteExt;
+use vsock_proto::{ExecTermination, MSG_ERROR, MSG_EXEC_START};
 
 use super::super::support::{
-    host_from_stream, make_pair, mock_handshake, normal_operation_readiness, read_guest_message,
+    MockGuest, host_from_stream, make_pair, normal_operation_readiness, read_guest_message,
     send_exec_result, setup_host_and_guest, wait_for_operation_count,
 };
 use super::start_capture_operation;
@@ -13,18 +13,15 @@ use crate::operation_tracker::NormalOperationReadiness;
 
 #[tokio::test]
 async fn test_exec() {
-    let (host_stream, mut guest) = make_pair();
+    let (host_stream, guest) = make_pair();
 
-    tokio::spawn(async move {
-        let mut decoder = Decoder::new();
-        mock_handshake(&mut guest, &mut decoder).await;
+    let guest_task = tokio::spawn(async move {
+        let mut guest = MockGuest::new(guest);
+        guest.complete_handshake().await;
 
-        let mut buf = [0u8; 4096];
-        let n = guest.read(&mut buf).await.unwrap();
-        let msgs = decoder.decode(&buf[..n]).unwrap();
-        assert_eq!(msgs[0].msg_type, MSG_EXEC_START);
+        let msg = guest.expect_message(MSG_EXEC_START).await;
 
-        let d = vsock_proto::decode_exec_start(&msgs[0].payload).unwrap();
+        let d = vsock_proto::decode_exec_start(&msg.payload).unwrap();
         assert_eq!(d.command, "echo hello");
         assert_eq!(
             d.timeout,
@@ -36,14 +33,14 @@ async fn test_exec() {
         assert!(!d.sudo);
         assert_eq!(d.label, "exec");
 
-        send_exec_result(
-            &mut guest,
-            msgs[0].seq,
-            ExecTermination::Exited { exit_code: 0 },
-            b"hello\n",
-            b"",
-        )
-        .await;
+        guest
+            .send_exec_result(
+                msg.seq,
+                ExecTermination::Exited { exit_code: 0 },
+                b"hello\n",
+                b"",
+            )
+            .await;
     });
 
     let host = host_from_stream(host_stream).await.unwrap();
@@ -51,6 +48,7 @@ async fn test_exec() {
     assert_eq!(result.exit_code, 0);
     assert_eq!(result.stdout, b"hello\n");
     assert!(result.stderr.is_empty());
+    guest_task.await.unwrap();
 }
 
 #[tokio::test]
@@ -103,24 +101,22 @@ async fn test_exec_rejects_zero_timeout() {
 
 #[tokio::test]
 async fn test_exec_error_response() {
-    let (host_stream, mut guest) = make_pair();
+    let (host_stream, guest) = make_pair();
 
-    tokio::spawn(async move {
-        let mut decoder = Decoder::new();
-        mock_handshake(&mut guest, &mut decoder).await;
+    let guest_task = tokio::spawn(async move {
+        let mut guest = MockGuest::new(guest);
+        guest.complete_handshake().await;
 
-        let mut buf = [0u8; 4096];
-        let n = guest.read(&mut buf).await.unwrap();
-        let msgs = decoder.decode(&buf[..n]).unwrap();
-
-        let payload = vsock_proto::encode_error("command not found");
-        let resp = vsock_proto::encode(MSG_ERROR, msgs[0].seq, &payload).unwrap();
-        guest.write_all(&resp).await.unwrap();
+        let msg = guest.expect_message(MSG_EXEC_START).await;
+        guest
+            .send_error_response(msg.seq, "command not found")
+            .await;
     });
 
     let host = host_from_stream(host_stream).await.unwrap();
     let err = host.exec("badcmd", 5000, &[], false).await.unwrap_err();
     assert!(err.to_string().contains("command not found"));
+    guest_task.await.unwrap();
 }
 
 #[tokio::test]

--- a/crates/vsock-host/src/tests/exec_operation/exec.rs
+++ b/crates/vsock-host/src/tests/exec_operation/exec.rs
@@ -5,8 +5,8 @@ use tokio::io::AsyncWriteExt;
 use vsock_proto::{ExecTermination, MSG_ERROR, MSG_EXEC_START};
 
 use super::super::support::{
-    MockGuest, host_from_stream, make_pair, normal_operation_readiness, read_guest_message,
-    send_exec_result, setup_host_and_guest, wait_for_operation_count,
+    MockGuest, await_mock_guest, host_from_stream, make_pair, normal_operation_readiness,
+    read_guest_message, send_exec_result, setup_host_and_guest, wait_for_operation_count,
 };
 use super::start_capture_operation;
 use crate::operation_tracker::NormalOperationReadiness;
@@ -48,7 +48,7 @@ async fn test_exec() {
     assert_eq!(result.exit_code, 0);
     assert_eq!(result.stdout, b"hello\n");
     assert!(result.stderr.is_empty());
-    guest_task.await.unwrap();
+    await_mock_guest(guest_task).await;
 }
 
 #[tokio::test]
@@ -116,7 +116,7 @@ async fn test_exec_error_response() {
     let host = host_from_stream(host_stream).await.unwrap();
     let err = host.exec("badcmd", 5000, &[], false).await.unwrap_err();
     assert!(err.to_string().contains("command not found"));
-    guest_task.await.unwrap();
+    await_mock_guest(guest_task).await;
 }
 
 #[tokio::test]

--- a/crates/vsock-host/src/tests/file/write.rs
+++ b/crates/vsock-host/src/tests/file/write.rs
@@ -7,8 +7,8 @@ use tokio::io::AsyncWriteExt;
 use vsock_proto::MSG_EXEC_START;
 
 use super::super::support::{
-    MockGuest, assert_connection_accepts_exec_operation, host_from_stream, make_pair,
-    normal_operation_readiness, pending_request_count, setup_host_and_guest,
+    MockGuest, assert_connection_accepts_exec_operation, await_mock_guest, host_from_stream,
+    make_pair, normal_operation_readiness, pending_request_count, setup_host_and_guest,
 };
 use super::support::{
     expect_write_file, send_guest_error, send_write_file_failure, send_write_file_success,
@@ -290,7 +290,7 @@ async fn write_file_after_connection_close_returns_immediately_without_not_parka
         normal_operation_readiness(&host),
         NormalOperationReadiness::Closed
     );
-    guest_task.await.unwrap();
+    await_mock_guest(guest_task).await;
 }
 
 #[tokio::test]

--- a/crates/vsock-host/src/tests/file/write.rs
+++ b/crates/vsock-host/src/tests/file/write.rs
@@ -4,10 +4,10 @@ use std::sync::atomic::{AtomicUsize, Ordering};
 use std::time::Duration;
 
 use tokio::io::AsyncWriteExt;
-use vsock_proto::{Decoder, MSG_EXEC_START};
+use vsock_proto::MSG_EXEC_START;
 
 use super::super::support::{
-    assert_connection_accepts_exec_operation, host_from_stream, make_pair, mock_handshake,
+    MockGuest, assert_connection_accepts_exec_operation, host_from_stream, make_pair,
     normal_operation_readiness, pending_request_count, setup_host_and_guest,
 };
 use super::support::{
@@ -264,11 +264,11 @@ async fn write_file_connection_close_after_request_marks_tracker_not_parkable() 
 
 #[tokio::test]
 async fn write_file_after_connection_close_returns_immediately_without_not_parkable() {
-    let (host_stream, mut guest) = make_pair();
+    let (host_stream, guest) = make_pair();
 
     let guest_task = tokio::spawn(async move {
-        let mut decoder = Decoder::new();
-        mock_handshake(&mut guest, &mut decoder).await;
+        let mut guest = MockGuest::new(guest);
+        guest.complete_handshake().await;
         drop(guest);
     });
 

--- a/crates/vsock-host/src/tests/file/write_chunked.rs
+++ b/crates/vsock-host/src/tests/file/write_chunked.rs
@@ -8,9 +8,9 @@ use tokio::sync::oneshot;
 use vsock_proto::{ExecTermination, MSG_EXEC_START, MSG_WRITE_FILE};
 
 use super::super::support::{
-    MockGuest, assert_connection_accepts_exec_operation, host_from_stream, make_pair,
-    normal_operation_readiness, operation_count, pending_request_count, read_guest_message,
-    send_exec_result, setup_host_and_guest,
+    MockGuest, assert_connection_accepts_exec_operation, await_mock_guest, host_from_stream,
+    make_pair, normal_operation_readiness, operation_count, pending_request_count,
+    read_guest_message, send_exec_result, setup_host_and_guest,
 };
 use super::support::{
     ChunkedWriteTempPath, expect_write_file, send_guest_error, send_write_file_failure,
@@ -790,5 +790,5 @@ async fn test_write_file_chunked_cleans_up_when_cancelled() {
         .expect("cleanup sender dropped");
     assert!(cleanup_command.contains("rm -f --"));
 
-    guest_task.await.unwrap();
+    await_mock_guest(guest_task).await;
 }

--- a/crates/vsock-host/src/tests/file/write_chunked.rs
+++ b/crates/vsock-host/src/tests/file/write_chunked.rs
@@ -731,7 +731,7 @@ async fn test_write_file_chunked_cleans_up_when_cancelled() {
     let (first_chunk_tx, first_chunk_rx) = oneshot::channel::<()>();
     let (cleanup_tx, cleanup_rx) = oneshot::channel::<String>();
 
-    let guest_task = tokio::spawn(async move {
+    let mut guest_task = tokio::spawn(async move {
         let mut guest = MockGuest::new(guest);
         guest.complete_handshake().await;
 
@@ -785,7 +785,18 @@ async fn test_write_file_chunked_cleans_up_when_cancelled() {
     let mut write = Box::pin(host.write_file("/tmp/big.bin", &content, false));
     tokio::select! {
         _ = &mut write => panic!("chunked write completed before cancellation"),
-        result = first_chunk_rx => result.unwrap(),
+        result = first_chunk_rx => {
+            if result.is_err() {
+                match (&mut guest_task).await {
+                    Ok(()) => panic!("mock guest finished before first chunk"),
+                    Err(err) => panic!("mock guest task panicked before first chunk: {err}"),
+                }
+            }
+        }
+        result = &mut guest_task => {
+            result.expect("mock guest task panicked before first chunk");
+            panic!("mock guest finished before first chunk");
+        }
     }
     drop(write);
     assert_eq!(
@@ -793,10 +804,25 @@ async fn test_write_file_chunked_cleans_up_when_cancelled() {
         NormalOperationReadiness::NotParkable
     );
 
-    let cleanup_command = tokio::time::timeout(Duration::from_secs(2), cleanup_rx)
-        .await
-        .expect("cleanup command was not sent after cancellation")
-        .expect("cleanup sender dropped");
+    let cleanup_command = tokio::select! {
+        biased;
+        result = tokio::time::timeout(Duration::from_secs(2), cleanup_rx) => {
+            match result {
+                Ok(Ok(command)) => command,
+                Ok(Err(_)) => {
+                    match (&mut guest_task).await {
+                        Ok(()) => panic!("mock guest finished before cleanup command"),
+                        Err(err) => panic!("mock guest task panicked before cleanup command: {err}"),
+                    }
+                }
+                Err(_) => panic!("cleanup command was not sent after cancellation"),
+            }
+        }
+        result = &mut guest_task => {
+            result.expect("mock guest task panicked before cleanup command");
+            panic!("mock guest finished before cleanup command");
+        }
+    };
     assert!(cleanup_command.contains("rm -f --"));
 
     await_mock_guest(guest_task).await;

--- a/crates/vsock-host/src/tests/file/write_chunked.rs
+++ b/crates/vsock-host/src/tests/file/write_chunked.rs
@@ -3,12 +3,12 @@ use std::sync::Arc;
 use std::sync::atomic::{AtomicUsize, Ordering};
 use std::time::Duration;
 
-use tokio::io::{AsyncReadExt, AsyncWriteExt};
+use tokio::io::AsyncWriteExt;
 use tokio::sync::oneshot;
-use vsock_proto::{Decoder, ExecTermination, MSG_EXEC_START, MSG_WRITE_FILE};
+use vsock_proto::{ExecTermination, MSG_EXEC_START, MSG_WRITE_FILE};
 
 use super::super::support::{
-    assert_connection_accepts_exec_operation, host_from_stream, make_pair, mock_handshake,
+    MockGuest, assert_connection_accepts_exec_operation, host_from_stream, make_pair,
     normal_operation_readiness, operation_count, pending_request_count, read_guest_message,
     send_exec_result, setup_host_and_guest,
 };
@@ -724,7 +724,7 @@ async fn test_write_file_chunked_cleans_up_on_mv_failure() {
 
 #[tokio::test]
 async fn test_write_file_chunked_cleans_up_when_cancelled() {
-    let (host_stream, mut guest) = make_pair();
+    let (host_stream, guest) = make_pair();
 
     let chunk_limit = file_impl::test_support::WRITE_FILE_CHUNK_LIMIT;
     let content = vec![0xABu8; chunk_limit + 100];
@@ -732,54 +732,42 @@ async fn test_write_file_chunked_cleans_up_when_cancelled() {
     let (cleanup_tx, cleanup_rx) = oneshot::channel::<String>();
 
     let guest_task = tokio::spawn(async move {
-        let mut decoder = Decoder::new();
-        mock_handshake(&mut guest, &mut decoder).await;
+        let mut guest = MockGuest::new(guest);
+        guest.complete_handshake().await;
 
-        let mut buf = vec![0u8; chunk_limit + 4096];
         let mut temp_path = None::<String>;
         let mut first_chunk_tx = Some(first_chunk_tx);
         let mut cleanup_tx = Some(cleanup_tx);
 
         loop {
-            let n = guest.read(&mut buf).await.unwrap();
-            if n == 0 {
-                break;
-            }
-            let msgs = decoder.decode(&buf[..n]).unwrap();
-            for msg in msgs {
-                if msg.msg_type == MSG_WRITE_FILE {
-                    let (path, _chunk, _sudo, _append) =
-                        vsock_proto::decode_write_file(&msg.payload).unwrap();
-                    if let Some(temp_path) = &temp_path {
-                        assert_eq!(path, temp_path);
-                        continue;
-                    }
-
-                    assert!(path.starts_with("/tmp/big.bin.vm0tmp-"));
-                    temp_path = Some(path.to_string());
-                    send_write_file_success(&mut guest, msg.seq).await;
-                    if let Some(tx) = first_chunk_tx.take() {
-                        let _ = tx.send(());
-                    }
-                } else if msg.msg_type == MSG_EXEC_START {
-                    let decoded = vsock_proto::decode_exec_start(&msg.payload).unwrap();
-                    let temp_path = temp_path.as_ref().expect("temp path");
-                    assert!(decoded.command.contains("rm -f --"));
-                    assert!(decoded.command.contains(temp_path));
-                    assert_eq!(decoded.label, "exec-cleanup");
-                    if let Some(tx) = cleanup_tx.take() {
-                        let _ = tx.send(decoded.command.to_string());
-                    }
-                    send_exec_result(
-                        &mut guest,
-                        msg.seq,
-                        ExecTermination::Exited { exit_code: 0 },
-                        &[],
-                        &[],
-                    )
-                    .await;
-                    return;
+            let msg = guest.read_message().await;
+            if msg.msg_type == MSG_WRITE_FILE {
+                let (path, _chunk, _sudo, _append) =
+                    vsock_proto::decode_write_file(&msg.payload).unwrap();
+                if let Some(temp_path) = &temp_path {
+                    assert_eq!(path, temp_path);
+                    continue;
                 }
+
+                assert!(path.starts_with("/tmp/big.bin.vm0tmp-"));
+                temp_path = Some(path.to_string());
+                send_write_file_success(guest.stream_mut(), msg.seq).await;
+                if let Some(tx) = first_chunk_tx.take() {
+                    let _ = tx.send(());
+                }
+            } else if msg.msg_type == MSG_EXEC_START {
+                let decoded = vsock_proto::decode_exec_start(&msg.payload).unwrap();
+                let temp_path = temp_path.as_ref().expect("temp path");
+                assert!(decoded.command.contains("rm -f --"));
+                assert!(decoded.command.contains(temp_path));
+                assert_eq!(decoded.label, "exec-cleanup");
+                if let Some(tx) = cleanup_tx.take() {
+                    let _ = tx.send(decoded.command.to_string());
+                }
+                guest
+                    .send_exec_result(msg.seq, ExecTermination::Exited { exit_code: 0 }, &[], &[])
+                    .await;
+                return;
             }
         }
     });

--- a/crates/vsock-host/src/tests/file/write_chunked.rs
+++ b/crates/vsock-host/src/tests/file/write_chunked.rs
@@ -741,33 +741,42 @@ async fn test_write_file_chunked_cleans_up_when_cancelled() {
 
         loop {
             let msg = guest.read_message().await;
-            if msg.msg_type == MSG_WRITE_FILE {
-                let (path, _chunk, _sudo, _append) =
-                    vsock_proto::decode_write_file(&msg.payload).unwrap();
-                if let Some(temp_path) = &temp_path {
-                    assert_eq!(path, temp_path);
-                    continue;
-                }
+            match msg.msg_type {
+                MSG_WRITE_FILE => {
+                    let (path, _chunk, _sudo, _append) =
+                        vsock_proto::decode_write_file(&msg.payload).unwrap();
+                    if let Some(temp_path) = &temp_path {
+                        assert_eq!(path, temp_path);
+                        continue;
+                    }
 
-                assert!(path.starts_with("/tmp/big.bin.vm0tmp-"));
-                temp_path = Some(path.to_string());
-                send_write_file_success(guest.stream_mut(), msg.seq).await;
-                if let Some(tx) = first_chunk_tx.take() {
-                    let _ = tx.send(());
+                    assert!(path.starts_with("/tmp/big.bin.vm0tmp-"));
+                    temp_path = Some(path.to_string());
+                    send_write_file_success(guest.stream_mut(), msg.seq).await;
+                    if let Some(tx) = first_chunk_tx.take() {
+                        let _ = tx.send(());
+                    }
                 }
-            } else if msg.msg_type == MSG_EXEC_START {
-                let decoded = vsock_proto::decode_exec_start(&msg.payload).unwrap();
-                let temp_path = temp_path.as_ref().expect("temp path");
-                assert!(decoded.command.contains("rm -f --"));
-                assert!(decoded.command.contains(temp_path));
-                assert_eq!(decoded.label, "exec-cleanup");
-                if let Some(tx) = cleanup_tx.take() {
-                    let _ = tx.send(decoded.command.to_string());
+                MSG_EXEC_START => {
+                    let decoded = vsock_proto::decode_exec_start(&msg.payload).unwrap();
+                    let temp_path = temp_path.as_ref().expect("temp path");
+                    assert!(decoded.command.contains("rm -f --"));
+                    assert!(decoded.command.contains(temp_path));
+                    assert_eq!(decoded.label, "exec-cleanup");
+                    if let Some(tx) = cleanup_tx.take() {
+                        let _ = tx.send(decoded.command.to_string());
+                    }
+                    guest
+                        .send_exec_result(
+                            msg.seq,
+                            ExecTermination::Exited { exit_code: 0 },
+                            &[],
+                            &[],
+                        )
+                        .await;
+                    return;
                 }
-                guest
-                    .send_exec_result(msg.seq, ExecTermination::Exited { exit_code: 0 }, &[], &[])
-                    .await;
-                return;
+                _ => panic!("unexpected guest message type {:#04x}", msg.msg_type),
             }
         }
     });

--- a/crates/vsock-host/src/tests/support.rs
+++ b/crates/vsock-host/src/tests/support.rs
@@ -19,13 +19,14 @@ use crate::operation_tracker::NormalOperationReadiness;
 use crate::{ConnectionState, NormalOperationFence, VsockHost};
 
 const MOCK_GUEST_IO_TIMEOUT: Duration = Duration::from_secs(5);
+const MOCK_GUEST_TASK_TIMEOUT: Duration = Duration::from_secs(6);
 
 pub(crate) fn make_pair() -> (UnixStream, UnixStream) {
     UnixStream::pair().unwrap()
 }
 
 pub(crate) async fn await_mock_guest(mut task: JoinHandle<()>) {
-    match tokio::time::timeout(MOCK_GUEST_IO_TIMEOUT, &mut task).await {
+    match tokio::time::timeout(MOCK_GUEST_TASK_TIMEOUT, &mut task).await {
         Ok(result) => result.expect("mock guest task panicked"),
         Err(_) => {
             task.abort();
@@ -80,7 +81,10 @@ impl MockGuest {
 
     pub(crate) async fn expect_eof(&mut self) {
         let mut buf = [0u8; 1];
-        let n = self.stream.read(&mut buf).await.unwrap();
+        let n = tokio::time::timeout(MOCK_GUEST_IO_TIMEOUT, self.stream.read(&mut buf))
+            .await
+            .expect("timed out waiting for guest stream EOF")
+            .unwrap();
         assert_eq!(n, 0, "expected guest stream EOF, got {n} byte(s)");
     }
 

--- a/crates/vsock-host/src/tests/support.rs
+++ b/crates/vsock-host/src/tests/support.rs
@@ -21,7 +21,7 @@ use crate::{ConnectionState, NormalOperationFence, VsockHost};
 const MOCK_GUEST_IO_TIMEOUT: Duration = Duration::from_secs(5);
 // Keep the task guard wider than multi-frame reads so the per-frame
 // assertions report the actual protocol step that got stuck.
-const MOCK_GUEST_TASK_TIMEOUT: Duration = Duration::from_secs(30);
+const MOCK_GUEST_TASK_TIMEOUT: Duration = Duration::from_secs(60);
 
 pub(crate) fn make_pair() -> (UnixStream, UnixStream) {
     UnixStream::pair().unwrap()

--- a/crates/vsock-host/src/tests/support.rs
+++ b/crates/vsock-host/src/tests/support.rs
@@ -22,11 +22,15 @@ pub(crate) fn make_pair() -> (UnixStream, UnixStream) {
     UnixStream::pair().unwrap()
 }
 
-pub(crate) async fn await_mock_guest(task: JoinHandle<()>) {
-    tokio::time::timeout(Duration::from_secs(5), task)
-        .await
-        .expect("mock guest task did not finish")
-        .expect("mock guest task panicked");
+pub(crate) async fn await_mock_guest(mut task: JoinHandle<()>) {
+    match tokio::time::timeout(Duration::from_secs(5), &mut task).await {
+        Ok(result) => result.expect("mock guest task panicked"),
+        Err(_) => {
+            task.abort();
+            let _ = task.await;
+            panic!("mock guest task did not finish");
+        }
+    }
 }
 
 pub(crate) struct MockGuest {

--- a/crates/vsock-host/src/tests/support.rs
+++ b/crates/vsock-host/src/tests/support.rs
@@ -4,6 +4,7 @@ use std::time::Duration;
 
 use tokio::io::{AsyncReadExt, AsyncWriteExt};
 use tokio::net::UnixStream;
+use tokio::task::JoinHandle;
 use tokio::time::Instant;
 use vsock_proto::{
     ExecCapturedOutput, ExecControlNonce, ExecControlStatus, ExecOutputStream, ExecTermination,
@@ -19,6 +20,13 @@ use crate::{ConnectionState, NormalOperationFence, VsockHost};
 
 pub(crate) fn make_pair() -> (UnixStream, UnixStream) {
     UnixStream::pair().unwrap()
+}
+
+pub(crate) async fn await_mock_guest(task: JoinHandle<()>) {
+    tokio::time::timeout(Duration::from_secs(5), task)
+        .await
+        .expect("mock guest task did not finish")
+        .expect("mock guest task panicked");
 }
 
 pub(crate) struct MockGuest {

--- a/crates/vsock-host/src/tests/support.rs
+++ b/crates/vsock-host/src/tests/support.rs
@@ -18,12 +18,14 @@ use vsock_proto::{
 use crate::operation_tracker::NormalOperationReadiness;
 use crate::{ConnectionState, NormalOperationFence, VsockHost};
 
+const MOCK_GUEST_IO_TIMEOUT: Duration = Duration::from_secs(5);
+
 pub(crate) fn make_pair() -> (UnixStream, UnixStream) {
     UnixStream::pair().unwrap()
 }
 
 pub(crate) async fn await_mock_guest(mut task: JoinHandle<()>) {
-    match tokio::time::timeout(Duration::from_secs(5), &mut task).await {
+    match tokio::time::timeout(MOCK_GUEST_IO_TIMEOUT, &mut task).await {
         Ok(result) => result.expect("mock guest task panicked"),
         Err(_) => {
             task.abort();
@@ -202,7 +204,10 @@ pub(crate) fn drop_started_request_write_guard(host: &VsockHost) {
 
 pub(crate) async fn read_guest_message(stream: &mut UnixStream) -> RawMessage {
     let mut header = [0u8; HEADER_SIZE];
-    stream.read_exact(&mut header).await.unwrap();
+    tokio::time::timeout(MOCK_GUEST_IO_TIMEOUT, stream.read_exact(&mut header))
+        .await
+        .expect("timed out reading guest message header")
+        .unwrap();
 
     let body_len = u32::from_be_bytes(header) as usize;
     assert!(
@@ -211,7 +216,10 @@ pub(crate) async fn read_guest_message(stream: &mut UnixStream) -> RawMessage {
     );
 
     let mut body = vec![0u8; body_len];
-    stream.read_exact(&mut body).await.unwrap();
+    tokio::time::timeout(MOCK_GUEST_IO_TIMEOUT, stream.read_exact(&mut body))
+        .await
+        .expect("timed out reading guest message body")
+        .unwrap();
 
     RawMessage {
         msg_type: body[0],

--- a/crates/vsock-host/src/tests/support.rs
+++ b/crates/vsock-host/src/tests/support.rs
@@ -64,6 +64,12 @@ impl MockGuest {
         message
     }
 
+    pub(crate) async fn expect_eof(&mut self) {
+        let mut buf = [0u8; 1];
+        let n = self.stream.read(&mut buf).await.unwrap();
+        assert_eq!(n, 0, "expected guest stream EOF, got {n} byte(s)");
+    }
+
     pub(crate) async fn send_response(&mut self, msg_type: u8, seq: u32, payload: &[u8]) {
         let frame = vsock_proto::encode(msg_type, seq, payload).unwrap();
         self.stream.write_all(&frame).await.unwrap();

--- a/crates/vsock-host/src/tests/support.rs
+++ b/crates/vsock-host/src/tests/support.rs
@@ -19,7 +19,9 @@ use crate::operation_tracker::NormalOperationReadiness;
 use crate::{ConnectionState, NormalOperationFence, VsockHost};
 
 const MOCK_GUEST_IO_TIMEOUT: Duration = Duration::from_secs(5);
-const MOCK_GUEST_TASK_TIMEOUT: Duration = Duration::from_secs(15);
+// Keep the task guard wider than multi-frame reads so the per-frame
+// assertions report the actual protocol step that got stuck.
+const MOCK_GUEST_TASK_TIMEOUT: Duration = Duration::from_secs(30);
 
 pub(crate) fn make_pair() -> (UnixStream, UnixStream) {
     UnixStream::pair().unwrap()

--- a/crates/vsock-host/src/tests/support.rs
+++ b/crates/vsock-host/src/tests/support.rs
@@ -6,10 +6,12 @@ use tokio::io::{AsyncReadExt, AsyncWriteExt};
 use tokio::net::UnixStream;
 use tokio::time::Instant;
 use vsock_proto::{
-    Decoder, ExecCapturedOutput, ExecControlNonce, ExecControlStatus, ExecOutputStream,
-    ExecTermination, HEADER_SIZE, MAX_MESSAGE_SIZE, MIN_BODY_SIZE, MSG_EXEC_CONTROL_RESULT,
-    MSG_EXEC_OUTPUT, MSG_EXEC_RESULT, MSG_EXEC_START, MSG_EXEC_STARTED, MSG_PING, MSG_PONG,
-    MSG_READY, RawMessage,
+    ExecCapturedOutput, ExecControlNonce, ExecControlStatus, ExecOutputStream, ExecTermination,
+    HEADER_SIZE, MAX_MESSAGE_SIZE, MIN_BODY_SIZE, MSG_ERROR, MSG_EXEC_CANCEL, MSG_EXEC_CONTROL,
+    MSG_EXEC_CONTROL_RESULT, MSG_EXEC_OUTPUT, MSG_EXEC_RESULT, MSG_EXEC_START, MSG_EXEC_STARTED,
+    MSG_OPERATIONS_QUIESCED, MSG_OPERATIONS_RESUMED, MSG_PING, MSG_PONG, MSG_QUIESCE_OPERATIONS,
+    MSG_READY, MSG_RESUME_OPERATIONS, MSG_SHUTDOWN, MSG_SHUTDOWN_ACK, MSG_WRITE_FILE,
+    MSG_WRITE_FILE_RESULT, RawMessage,
 };
 
 use crate::operation_tracker::NormalOperationReadiness;
@@ -19,18 +21,115 @@ pub(crate) fn make_pair() -> (UnixStream, UnixStream) {
     UnixStream::pair().unwrap()
 }
 
+pub(crate) struct MockGuest {
+    stream: UnixStream,
+}
+
+impl MockGuest {
+    pub(crate) fn new(stream: UnixStream) -> Self {
+        Self { stream }
+    }
+
+    pub(crate) fn into_stream(self) -> UnixStream {
+        self.stream
+    }
+
+    pub(crate) fn stream_mut(&mut self) -> &mut UnixStream {
+        &mut self.stream
+    }
+
+    pub(crate) async fn complete_handshake(&mut self) {
+        mock_handshake(&mut self.stream).await;
+    }
+
+    pub(crate) async fn read_message(&mut self) -> RawMessage {
+        read_guest_message(&mut self.stream).await
+    }
+
+    pub(crate) async fn read_messages(&mut self, count: usize) -> Vec<RawMessage> {
+        read_guest_messages(&mut self.stream, count).await
+    }
+
+    pub(crate) async fn expect_message(&mut self, expected_type: u8) -> RawMessage {
+        let message = self.read_message().await;
+        assert_eq!(
+            message.msg_type,
+            expected_type,
+            "expected guest message type {} ({:#04x}), got {} ({:#04x})",
+            message_type_name(expected_type),
+            expected_type,
+            message_type_name(message.msg_type),
+            message.msg_type
+        );
+        message
+    }
+
+    pub(crate) async fn send_response(&mut self, msg_type: u8, seq: u32, payload: &[u8]) {
+        let frame = vsock_proto::encode(msg_type, seq, payload).unwrap();
+        self.stream.write_all(&frame).await.unwrap();
+    }
+
+    pub(crate) async fn send_empty_response(&mut self, msg_type: u8, seq: u32) {
+        self.send_response(msg_type, seq, &[]).await;
+    }
+
+    pub(crate) async fn send_error_response(&mut self, seq: u32, diagnostic: &str) {
+        let payload = vsock_proto::encode_error(diagnostic);
+        self.send_response(MSG_ERROR, seq, &payload).await;
+    }
+
+    pub(crate) async fn send_exec_result(
+        &mut self,
+        seq: u32,
+        termination: ExecTermination,
+        stdout: &[u8],
+        stderr: &[u8],
+    ) {
+        send_exec_result(&mut self.stream, seq, termination, stdout, stderr).await;
+    }
+}
+
 /// Perform mock guest handshake: send ready, receive ping, send pong.
-pub(crate) async fn mock_handshake(stream: &mut UnixStream, decoder: &mut Decoder) {
+pub(crate) async fn mock_handshake(stream: &mut UnixStream) {
     let ready = vsock_proto::encode(MSG_READY, 0, &[]).unwrap();
     stream.write_all(&ready).await.unwrap();
 
-    let mut buf = [0u8; 1024];
-    let n = stream.read(&mut buf).await.unwrap();
-    let msgs = decoder.decode(&buf[..n]).unwrap();
-    assert_eq!(msgs[0].msg_type, MSG_PING);
+    let ping = read_guest_message(stream).await;
+    assert_eq!(
+        ping.msg_type,
+        MSG_PING,
+        "expected handshake ping, got {} ({:#04x})",
+        message_type_name(ping.msg_type),
+        ping.msg_type
+    );
 
-    let pong = vsock_proto::encode(MSG_PONG, msgs[0].seq, &[]).unwrap();
+    let pong = vsock_proto::encode(MSG_PONG, ping.seq, &[]).unwrap();
     stream.write_all(&pong).await.unwrap();
+}
+
+fn message_type_name(msg_type: u8) -> &'static str {
+    match msg_type {
+        MSG_READY => "ready",
+        MSG_PING => "ping",
+        MSG_PONG => "pong",
+        MSG_SHUTDOWN => "shutdown",
+        MSG_SHUTDOWN_ACK => "shutdown_ack",
+        MSG_QUIESCE_OPERATIONS => "quiesce_operations",
+        MSG_OPERATIONS_QUIESCED => "operations_quiesced",
+        MSG_RESUME_OPERATIONS => "resume_operations",
+        MSG_OPERATIONS_RESUMED => "operations_resumed",
+        MSG_WRITE_FILE => "write_file",
+        MSG_WRITE_FILE_RESULT => "write_file_result",
+        MSG_EXEC_START => "exec_start",
+        MSG_EXEC_STARTED => "exec_started",
+        MSG_EXEC_OUTPUT => "exec_output",
+        MSG_EXEC_RESULT => "exec_result",
+        MSG_EXEC_CANCEL => "exec_cancel",
+        MSG_EXEC_CONTROL => "exec_control",
+        MSG_EXEC_CONTROL_RESULT => "exec_control_result",
+        MSG_ERROR => "error",
+        _ => "unknown",
+    }
 }
 
 pub(crate) async fn host_from_stream(stream: UnixStream) -> io::Result<VsockHost> {
@@ -129,13 +228,17 @@ async fn read_guest_message_preserves_coalesced_frames() {
     assert_eq!(second.payload, b"second");
 }
 
-pub(crate) async fn setup_host_and_guest() -> (VsockHost, UnixStream) {
+pub(crate) async fn setup_host_and_mock_guest() -> (VsockHost, MockGuest) {
     let (host_stream, mut guest) = make_pair();
     let host_task = tokio::spawn(async move { host_from_stream(host_stream).await.unwrap() });
-    let mut decoder = Decoder::new();
-    mock_handshake(&mut guest, &mut decoder).await;
+    mock_handshake(&mut guest).await;
     let host = host_task.await.unwrap();
-    (host, guest)
+    (host, MockGuest::new(guest))
+}
+
+pub(crate) async fn setup_host_and_guest() -> (VsockHost, UnixStream) {
+    let (host, guest) = setup_host_and_mock_guest().await;
+    (host, guest.into_stream())
 }
 
 fn exec_result_payload(termination: ExecTermination, stdout: &[u8], stderr: &[u8]) -> Vec<u8> {

--- a/crates/vsock-host/src/tests/support.rs
+++ b/crates/vsock-host/src/tests/support.rs
@@ -19,7 +19,7 @@ use crate::operation_tracker::NormalOperationReadiness;
 use crate::{ConnectionState, NormalOperationFence, VsockHost};
 
 const MOCK_GUEST_IO_TIMEOUT: Duration = Duration::from_secs(5);
-const MOCK_GUEST_TASK_TIMEOUT: Duration = Duration::from_secs(6);
+const MOCK_GUEST_TASK_TIMEOUT: Duration = Duration::from_secs(15);
 
 pub(crate) fn make_pair() -> (UnixStream, UnixStream) {
     UnixStream::pair().unwrap()


### PR DESCRIPTION
## Summary

- Add a lightweight `MockGuest` helper for framed mock guest protocol I/O in `vsock-host` tests.
- Move mock handshake reads to framed header/body handling instead of one-shot raw stream decoding.
- Refactor connection and adjacent raw-read tests to use framed helpers while keeping lifecycle timing explicit.

Closes #16150

## Tests

- `cargo test --manifest-path crates/Cargo.toml -p vsock-host`
- `cargo clippy --manifest-path crates/Cargo.toml -p vsock-host --all-targets --all-features`
- `cargo clippy --all-targets --all-features` from `crates/`