### PR TITLE
feat: route recovered first-party platform routes to api backend

### DIFF
--- a/turbo/apps/platform/src/signals/__tests__/fetch.test.ts
+++ b/turbo/apps/platform/src/signals/__tests__/fetch.test.ts
@@ -651,6 +651,45 @@ describe("apiBackend routing", () => {
     ]);
   });
 
+  it("routes the recovered first-party routes (memory-activity, org-logo, voice stt/tts) to api", async () => {
+    vi.stubGlobal("location", new URL("https://platform.vm0.ai/"));
+    detachedSetupPage({
+      context,
+      path: "/",
+      withoutRender: true,
+    });
+
+    const hosts: string[] = [];
+    function capture(method: "get" | "post" | "delete", pattern: string): void {
+      server.use(
+        http[method](pattern, ({ request }) => {
+          hosts.push(`${method.toUpperCase()} ${new URL(request.url).host}`);
+          return new Response(null, { status: 200 });
+        }),
+      );
+    }
+    capture("get", "*/api/zero/memory/activity");
+    capture("post", "*/api/zero/org/logo");
+    capture("get", "*/api/zero/org/logo");
+    capture("post", "*/api/zero/voice-io/stt");
+    capture("post", "*/api/zero/voice-io/tts");
+
+    const fch = context.store.get(fetch$);
+    await fch("/api/zero/memory/activity");
+    await fch("/api/zero/org/logo", { method: "POST" });
+    await fch("/api/zero/org/logo");
+    await fch("/api/zero/voice-io/stt", { method: "POST" });
+    await fch("/api/zero/voice-io/tts", { method: "POST" });
+
+    expect(hosts).toStrictEqual([
+      "GET api.vm0.ai",
+      "POST api.vm0.ai",
+      "GET api.vm0.ai",
+      "POST api.vm0.ai",
+      "POST api.vm0.ai",
+    ]);
+  });
+
   it("does not let a :param template over-match a shorter parent path", async () => {
     vi.stubGlobal("location", new URL("https://platform.vm0.ai/"));
     detachedSetupPage({

--- a/turbo/apps/platform/src/signals/api-target-policy.ts
+++ b/turbo/apps/platform/src/signals/api-target-policy.ts
@@ -99,6 +99,7 @@ const API_ROUTE_ALLOWLIST: readonly ApiRouteAllowlistEntry[] = [
   { methods: ["GET", "POST"], pathname: "/api/zero/me/model-providers" },
   { methods: ["DELETE"], pathname: "/api/zero/me/model-providers/:type" },
   { methods: ["GET"], pathname: "/api/zero/memory" },
+  { methods: ["GET"], pathname: "/api/zero/memory/activity" },
   { methods: ["GET", "POST"], pathname: "/api/zero/model-providers" },
   { methods: ["DELETE"], pathname: "/api/zero/model-providers/:type" },
   { methods: ["POST"], pathname: "/api/zero/onboarding/setup" },
@@ -107,6 +108,7 @@ const API_ROUTE_ALLOWLIST: readonly ApiRouteAllowlistEntry[] = [
   { methods: ["POST"], pathname: "/api/zero/org/delete" },
   { methods: ["POST", "DELETE"], pathname: "/api/zero/org/invite" },
   { methods: ["POST"], pathname: "/api/zero/org/leave" },
+  { methods: ["GET", "POST", "DELETE"], pathname: "/api/zero/org/logo" },
   { methods: ["GET", "PATCH", "DELETE"], pathname: "/api/zero/org/members" },
   {
     methods: ["POST", "DELETE"],
@@ -143,6 +145,8 @@ const API_ROUTE_ALLOWLIST: readonly ApiRouteAllowlistEntry[] = [
   { methods: ["GET", "POST"], pathname: "/api/zero/variables" },
   { methods: ["DELETE"], pathname: "/api/zero/variables/:name" },
   { methods: ["GET"], pathname: "/api/zero/voice-io/quota" },
+  { methods: ["POST"], pathname: "/api/zero/voice-io/stt" },
+  { methods: ["POST"], pathname: "/api/zero/voice-io/tts" },
 ];
 
 function normalizeMethod(method: string): string {


### PR DESCRIPTION
## Summary
Migrate four first-party `/api/zero/*` routes that the earlier contract-based inventory (batch 4) missed — they are called via **raw `fetch$`** rather than imported ts-rest contracts, so they slipped through. Found while auditing the `api-backend-rewrites.js` list; classified via a 23-route group-D workflow.

### Migrated (4)
| Method | Path | Platform caller |
| --- | --- | --- |
| GET | `/api/zero/memory/activity` | `memoryActivity$` (`zeroClient$`) |
| GET/POST/DELETE | `/api/zero/org/logo` | org-general-tab (`useGet(fetch$)`) |
| POST | `/api/zero/voice-io/stt` | voice-io-stt (`get(fetch$)`) |
| POST | `/api/zero/voice-io/tts` | voice-io-tts (`get(fetch$)`) |

All confirmed: called by apps/platform through the policy-aware `fetch$`/`zeroClient$` (no `apiBase` override), no web-origin dependency in the apps/api handler.

### Intentionally NOT migrated
`POST /api/zero/push-subscriptions` — uses raw `fetch()` against the **global** `apiBase$` (line 64/123 of `lib/push-notifications.ts`), not the per-route policy, so an allowlist entry would have no effect. It follows the global `apiBackend` switch; routing it via `fetch$` is a separate refactor.

### Confirmed staying on www (verified not platform-called)
`banking/*` (cli/runner), `computer-use/*` (desktop/cli), `developer-support` / `image-io/generate` / `video-io/generate` / `voice-io/speech` / `org/list` / `integrations/slack/download-file` (cli), `usage/runs` (api/web). Also surfaced 3 phantom rewrite entries with no implementation (`billing/restore`, `org/domains`, `org/members/credit-cap`) — cleanup candidates for the rewrite-trim work.

## Validation
- New `fetch.test.ts` regression test: the 4 routes → `api`.
- `pnpm format`, `pnpm -F @vm0/app lint`, `pnpm -F @vm0/app check-types`, `pnpm knip --workspace apps/platform` — clean; 54 routing tests pass.

## Post-merge verification
Confirm in `vm0-traces-prod` these land on `service.name=vm0-api` with no 5xx.

Closes #16172
Part of #15872

🤖 Generated with [Claude Code](https://claude.com/claude-code)
