### PR TITLE
perf: reduce guest-agent manifest materialization

### DIFF
--- a/crates/guest-agent/src/artifact/api.rs
+++ b/crates/guest-agent/src/artifact/api.rs
@@ -3,9 +3,10 @@ use crate::constants;
 use crate::error::AgentError;
 use crate::http::HttpClient;
 use api_contracts::generated::types::webhooks::agent::storages::{
-    FileEntryWithHash, commit as storage_commit, prepare as storage_prepare,
+    commit as storage_commit, prepare as storage_prepare,
 };
 use guest_common::log_warn;
+use serde::Serialize;
 
 const LOG_TAG: &str = "sandbox:guest-agent";
 
@@ -49,19 +50,41 @@ pub(super) struct CommitSnapshotRequest<'a> {
     pub(super) message: Option<&'a str>,
 }
 
+#[derive(Serialize)]
+#[serde(rename_all = "camelCase")]
+struct PrepareSnapshotPayload<'a> {
+    run_id: &'a str,
+    storage_name: &'a str,
+    storage_type: &'a str,
+    files: &'a [FileEntry],
+    #[serde(skip_serializing_if = "Option::is_none")]
+    parent_version_id: Option<&'a str>,
+}
+
+#[derive(Serialize)]
+#[serde(rename_all = "camelCase")]
+struct CommitSnapshotPayload<'a> {
+    run_id: &'a str,
+    storage_name: &'a str,
+    storage_type: &'a str,
+    version_id: &'a str,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    parent_version_id: Option<&'a str>,
+    files: &'a [FileEntry],
+    #[serde(skip_serializing_if = "Option::is_none")]
+    message: Option<&'a str>,
+}
+
 pub(super) async fn prepare_snapshot(
     http: &HttpClient,
     request: PrepareSnapshotRequest<'_>,
 ) -> Result<PreparedSnapshot, PrepareSnapshotError> {
-    let payload = storage_prepare::Request {
-        run_id: request.run_id.to_string(),
-        storage_name: request.storage_name.to_string(),
-        storage_type: request.storage_type.to_string(),
-        files: to_request_files(request.files),
-        parent_version_id: non_empty_string(request.parent_version_id),
-        force: None,
-        base_version: None,
-        changes: None,
+    let payload = PrepareSnapshotPayload {
+        run_id: request.run_id,
+        storage_name: request.storage_name,
+        storage_type: request.storage_type,
+        files: request.files,
+        parent_version_id: non_empty_str(request.parent_version_id),
     };
 
     let url = http
@@ -113,14 +136,14 @@ pub(super) async fn commit_snapshot(
     request: CommitSnapshotRequest<'_>,
     parse_error_log: &str,
 ) -> Result<bool, AgentError> {
-    let payload = storage_commit::Request {
-        run_id: request.run_id.to_string(),
-        storage_name: request.storage_name.to_string(),
-        storage_type: request.storage_type.to_string(),
-        version_id: request.version_id.to_string(),
-        parent_version_id: non_empty_string(request.parent_version_id),
-        files: to_request_files(request.files),
-        message: request.message.map(str::to_string),
+    let payload = CommitSnapshotPayload {
+        run_id: request.run_id,
+        storage_name: request.storage_name,
+        storage_type: request.storage_type,
+        version_id: request.version_id,
+        parent_version_id: non_empty_str(request.parent_version_id),
+        files: request.files,
+        message: request.message,
     };
 
     let url = http.storage_commit_url()?;
@@ -140,21 +163,6 @@ pub(super) async fn commit_snapshot(
         .unwrap_or(false))
 }
 
-fn non_empty_string(value: &str) -> Option<String> {
-    if value.is_empty() {
-        None
-    } else {
-        Some(value.to_string())
-    }
-}
-
-fn to_request_files(files: &[FileEntry]) -> Vec<FileEntryWithHash> {
-    files
-        .iter()
-        .map(|file| FileEntryWithHash {
-            path: file.path.clone(),
-            hash: file.hash.clone(),
-            size: file.size,
-        })
-        .collect()
+fn non_empty_str(value: &str) -> Option<&str> {
+    if value.is_empty() { None } else { Some(value) }
 }

--- a/crates/guest-agent/src/artifact/mod.rs
+++ b/crates/guest-agent/src/artifact/mod.rs
@@ -23,7 +23,10 @@ use api::{
     commit_snapshot, prepare_snapshot,
 };
 use archive::{collect_file_metadata, create_archive, validate_archive_inputs};
-use std::path::PathBuf;
+use std::fs::File;
+use std::io::{BufWriter, Write};
+use std::path::{Path, PathBuf};
+use std::sync::Arc;
 
 const LOG_TAG: &str = "sandbox:guest-agent";
 
@@ -32,14 +35,6 @@ pub(crate) struct FileEntry {
     pub(crate) path: String,
     pub(crate) hash: String,
     pub(crate) size: u64,
-}
-
-#[derive(Serialize)]
-struct ArtifactManifest<'a> {
-    version: u8,
-    files: &'a [FileEntry],
-    #[serde(rename = "createdAt")]
-    created_at: String,
 }
 
 pub(crate) struct SnapshotResult {
@@ -54,6 +49,59 @@ pub(crate) struct CreateSnapshotRequest<'a> {
     pub(crate) run_id: &'a str,
     pub(crate) message: &'a str,
     pub(crate) parent_version_id: &'a str,
+}
+
+struct SnapshotRequest<'a> {
+    mount_path: &'a str,
+    files: Arc<[FileEntry]>,
+    storage_name: &'a str,
+    storage_type: &'a str,
+    run_id: &'a str,
+    message: &'a str,
+    parent_version_id: &'a str,
+}
+
+impl<'a> From<CreateSnapshotRequest<'a>> for SnapshotRequest<'a> {
+    fn from(request: CreateSnapshotRequest<'a>) -> Self {
+        Self {
+            mount_path: request.mount_path,
+            files: request.files.into(),
+            storage_name: request.storage_name,
+            storage_type: request.storage_type,
+            run_id: request.run_id,
+            message: request.message,
+            parent_version_id: request.parent_version_id,
+        }
+    }
+}
+
+#[derive(Serialize)]
+#[serde(rename_all = "camelCase")]
+struct ArtifactManifest<'a> {
+    version: u8,
+    files: &'a [FileEntry],
+    created_at: String,
+}
+
+#[derive(Debug, thiserror::Error)]
+enum ArchiveBundleError {
+    #[error(transparent)]
+    Archive(#[from] archive::ArchiveError),
+    #[error(transparent)]
+    Manifest(#[from] ManifestWriteError),
+}
+
+#[derive(Debug, thiserror::Error)]
+enum ManifestWriteError {
+    #[error("failed to create manifest output {}: {source}", path.display())]
+    Create {
+        path: PathBuf,
+        source: std::io::Error,
+    },
+    #[error("failed to serialize manifest: {0}")]
+    Serialize(serde_json::Error),
+    #[error("failed to flush manifest: {0}")]
+    Flush(std::io::Error),
 }
 
 #[derive(Debug)]
@@ -121,6 +169,7 @@ pub(crate) async fn create_snapshot(
     http: &HttpClient,
     request: CreateSnapshotRequest<'_>,
 ) -> Result<SnapshotResult, AgentError> {
+    let request = SnapshotRequest::from(request);
     log_info!(
         LOG_TAG,
         "Creating direct upload snapshot for '{}'",
@@ -137,13 +186,13 @@ pub(crate) async fn create_snapshot(
         );
         // Validate the local manifest inputs before committing the existing
         // version as HEAD, since this branch does not build an archive.
-        validate_dedup_snapshot(request.mount_path, &request.files).await?;
+        validate_dedup_snapshot(request.mount_path, Arc::clone(&request.files)).await?;
         commit_existing_snapshot(http, &request, &version_id).await?;
         return Ok(SnapshotResult { version_id });
     }
 
     let uploads = extract_uploads(prep.uploads)?;
-    let archive = create_archive_bundle(request.mount_path, &request.files).await?;
+    let archive = create_archive_bundle(request.mount_path, Arc::clone(&request.files)).await?;
     upload_archive_bundle(http, &uploads, &archive).await?;
     commit_uploaded_snapshot(http, &request, &version_id).await?;
 
@@ -161,7 +210,7 @@ struct ArchiveBundle {
 
 async fn prepare_snapshot_step(
     http: &HttpClient,
-    request: &CreateSnapshotRequest<'_>,
+    request: &SnapshotRequest<'_>,
 ) -> Result<PreparedSnapshot, AgentError> {
     log_info!(LOG_TAG, "Calling prepare endpoint...");
     let prep_start = std::time::Instant::now();
@@ -171,7 +220,7 @@ async fn prepare_snapshot_step(
             run_id: request.run_id,
             storage_name: request.storage_name,
             storage_type: request.storage_type,
-            files: &request.files,
+            files: request.files.as_ref(),
             parent_version_id: request.parent_version_id,
         },
     )
@@ -194,13 +243,15 @@ async fn prepare_snapshot_step(
     }
 }
 
-async fn validate_dedup_snapshot(mount_path: &str, files: &[FileEntry]) -> Result<(), AgentError> {
+async fn validate_dedup_snapshot(
+    mount_path: &str,
+    files: Arc<[FileEntry]>,
+) -> Result<(), AgentError> {
     log_info!(LOG_TAG, "Validating deduplicated artifact inputs...");
     let validate_start = std::time::Instant::now();
     let validate_mount = mount_path.to_string();
-    let validate_files = files.to_vec();
     let validate_result = match tokio::task::spawn_blocking(move || {
-        validate_archive_inputs(&validate_mount, &validate_files)
+        validate_archive_inputs(&validate_mount, files.as_ref())
     })
     .await
     {
@@ -240,7 +291,7 @@ async fn validate_dedup_snapshot(mount_path: &str, files: &[FileEntry]) -> Resul
 
 async fn commit_existing_snapshot(
     http: &HttpClient,
-    request: &CreateSnapshotRequest<'_>,
+    request: &SnapshotRequest<'_>,
     version_id: &str,
 ) -> Result<(), AgentError> {
     let commit_success = commit_snapshot(
@@ -251,7 +302,7 @@ async fn commit_existing_snapshot(
             storage_type: request.storage_type,
             version_id,
             parent_version_id: request.parent_version_id,
-            files: &request.files,
+            files: request.files.as_ref(),
             message: None,
         },
         "Failed to parse dedup commit response",
@@ -267,29 +318,9 @@ fn extract_uploads(uploads: Option<PreparedUploads>) -> Result<PreparedUploads, 
     uploads.ok_or_else(|| AgentError::Checkpoint("No upload URLs in prepare response".into()))
 }
 
-async fn write_manifest_file(
-    manifest_path: PathBuf,
-    files: Vec<FileEntry>,
-) -> Result<(), AgentError> {
-    tokio::task::spawn_blocking(move || {
-        let manifest = ArtifactManifest {
-            version: 1,
-            files: &files,
-            created_at: guest_common::log::timestamp(),
-        };
-        let file = std::fs::File::create(manifest_path)?;
-        let mut writer = std::io::BufWriter::new(file);
-        serde_json::to_writer_pretty(&mut writer, &manifest)?;
-        std::io::Write::flush(&mut writer)?;
-        Ok::<(), AgentError>(())
-    })
-    .await
-    .map_err(|e| AgentError::Execution(format!("manifest write task panicked: {e}")))?
-}
-
 async fn create_archive_bundle(
     mount_path: &str,
-    files: &[FileEntry],
+    files: Arc<[FileEntry]>,
 ) -> Result<ArchiveBundle, AgentError> {
     let temp_dir = tempfile::tempdir().map_err(AgentError::Io)?;
     let archive_path = temp_dir.path().join("archive.tar.gz");
@@ -299,26 +330,66 @@ async fn create_archive_bundle(
     let arc_start = std::time::Instant::now();
     let archive_mount = mount_path.to_string();
     let archive_path_for_task = archive_path.clone();
-    let archive_files = files.to_vec();
+    let manifest_path_for_task = manifest_path.clone();
     let archive_result = tokio::task::spawn_blocking(move || {
-        create_archive(&archive_mount, &archive_path_for_task, &archive_files)
+        create_archive_bundle_files(
+            &archive_mount,
+            &archive_path_for_task,
+            &manifest_path_for_task,
+            files.as_ref(),
+        )
     })
     .await
     .map_err(|e| AgentError::Execution(format!("archive task panicked: {e}")))?;
-    if let Err(e) = archive_result {
-        log_error!(LOG_TAG, "Failed to create archive: {e}");
+    if let Err(error) = archive_result {
         record_sandbox_op("artifact_archive_create", arc_start.elapsed(), false, None);
-        return Err(AgentError::Checkpoint("Failed to create archive".into()));
+        match error {
+            ArchiveBundleError::Archive(e) => {
+                log_error!(LOG_TAG, "Failed to create archive: {e}");
+                return Err(AgentError::Checkpoint("Failed to create archive".into()));
+            }
+            ArchiveBundleError::Manifest(e) => {
+                log_error!(LOG_TAG, "Failed to write manifest: {e}");
+                return Err(AgentError::Checkpoint(format!(
+                    "Failed to write manifest: {e}"
+                )));
+            }
+        }
     }
     record_sandbox_op("artifact_archive_create", arc_start.elapsed(), true, None);
-
-    write_manifest_file(manifest_path.clone(), files.to_vec()).await?;
 
     Ok(ArchiveBundle {
         _temp_dir: temp_dir,
         archive_path,
         manifest_path,
     })
+}
+
+fn create_archive_bundle_files(
+    mount_path: &str,
+    archive_path: &Path,
+    manifest_path: &Path,
+    files: &[FileEntry],
+) -> Result<(), ArchiveBundleError> {
+    create_archive(mount_path, archive_path, files)?;
+    write_manifest(manifest_path, files)?;
+    Ok(())
+}
+
+fn write_manifest(manifest_path: &Path, files: &[FileEntry]) -> Result<(), ManifestWriteError> {
+    let file = File::create(manifest_path).map_err(|source| ManifestWriteError::Create {
+        path: manifest_path.to_owned(),
+        source,
+    })?;
+    let mut writer = BufWriter::new(file);
+    let manifest = ArtifactManifest {
+        version: 1,
+        files,
+        created_at: guest_common::log::timestamp(),
+    };
+
+    serde_json::to_writer_pretty(&mut writer, &manifest).map_err(ManifestWriteError::Serialize)?;
+    writer.flush().map_err(ManifestWriteError::Flush)
 }
 
 async fn upload_archive_bundle(
@@ -358,7 +429,7 @@ async fn upload_archive_bundle(
 
 async fn commit_uploaded_snapshot(
     http: &HttpClient,
-    request: &CreateSnapshotRequest<'_>,
+    request: &SnapshotRequest<'_>,
     version_id: &str,
 ) -> Result<(), AgentError> {
     log_info!(LOG_TAG, "Calling commit endpoint...");
@@ -371,7 +442,7 @@ async fn commit_uploaded_snapshot(
             storage_type: request.storage_type,
             version_id,
             parent_version_id: request.parent_version_id,
-            files: &request.files,
+            files: request.files.as_ref(),
             message: Some(request.message),
         },
         "Failed to parse commit response",

--- a/crates/guest-agent/src/content_hash.rs
+++ b/crates/guest-agent/src/content_hash.rs
@@ -1,5 +1,5 @@
 //! Content-addressable storage hash — Rust port of the TS implementation
-//! at `turbo/apps/web/src/lib/infra/storage/content-hash.ts`.
+//! at `turbo/apps/api/src/signals/services/storage-content-hash.service.ts`.
 //!
 //! `version_id` in VAS *is* this hash — the TS function is the sole producer
 //! across every prepare/commit route. Guest-side we recompute it locally so
@@ -7,11 +7,17 @@
 //! artifact is unchanged since mount (see issue #10967).
 //!
 //! The two implementations must stay byte-identical. The inline `#[cfg(test)]`
-//! suite below and its TS counterpart at
-//! `turbo/apps/web/src/lib/infra/storage/__tests__/content-hash-parity.test.ts`
-//! hardcode the same fixture vectors — a drift on either side fails CI.
+//! suite below hardcodes fixture vectors for the Rust port; changes here must
+//! be checked against TS `computeContentHashFromHashes`.
 
 use sha2::{Digest, Sha256};
+use std::cmp::Ordering;
+
+#[derive(Clone, Copy)]
+struct ContentHashEntry<'a> {
+    path: &'a str,
+    hash: &'a str,
+}
 
 /// Compute the content hash for a storage version.
 ///
@@ -28,31 +34,62 @@ pub(crate) fn compute_content_hash<'a, I>(storage_id: &str, files: I) -> String
 where
     I: IntoIterator<Item = (&'a str, &'a str)>,
 {
-    let mut entries: Vec<String> = files
+    let mut entries: Vec<ContentHashEntry<'a>> = files
         .into_iter()
-        .map(|(path, hash)| format!("{path}:{hash}"))
+        .map(|(path, hash)| ContentHashEntry { path, hash })
         .collect();
 
     let mut hasher = Sha256::new();
-    if entries.is_empty() {
-        hasher.update(format!("storage:{storage_id}\n").as_bytes());
-    } else {
-        entries.sort();
-        let combined = format!("storage:{storage_id}\n{}", entries.join("\n"));
-        hasher.update(combined.as_bytes());
+    hasher.update(b"storage:");
+    hasher.update(storage_id.as_bytes());
+    hasher.update(b"\n");
+
+    if !entries.is_empty() {
+        entries.sort_by(|left, right| compare_formatted_entries(*left, *right));
+        for (index, entry) in entries.iter().enumerate() {
+            if index > 0 {
+                hasher.update(b"\n");
+            }
+            hasher.update(entry.path.as_bytes());
+            hasher.update(b":");
+            hasher.update(entry.hash.as_bytes());
+        }
     }
+
     hex::encode(hasher.finalize())
+}
+
+fn compare_formatted_entries(left: ContentHashEntry<'_>, right: ContentHashEntry<'_>) -> Ordering {
+    let mut left_bytes = formatted_entry_bytes(left);
+    let mut right_bytes = formatted_entry_bytes(right);
+
+    loop {
+        match (left_bytes.next(), right_bytes.next()) {
+            (Some(left), Some(right)) => match left.cmp(&right) {
+                Ordering::Equal => {}
+                ordering => return ordering,
+            },
+            (Some(_), None) => return Ordering::Greater,
+            (None, Some(_)) => return Ordering::Less,
+            (None, None) => return Ordering::Equal,
+        }
+    }
+}
+
+fn formatted_entry_bytes<'a>(entry: ContentHashEntry<'a>) -> impl Iterator<Item = u8> + 'a {
+    entry
+        .path
+        .bytes()
+        .chain(std::iter::once(b':'))
+        .chain(entry.hash.bytes())
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
 
-    // Fixtures below are shared with the TS parity test at
-    // `turbo/apps/web/src/lib/infra/storage/__tests__/content-hash-parity.test.ts`.
-    // Any change here must be mirrored there (and vice versa); CI runs both
-    // sides, so a drift between TS `computeContentHashFromHashes` and this
-    // Rust port fails fast.
+    // Fixtures below must stay aligned with TS `computeContentHashFromHashes` at
+    // `turbo/apps/api/src/signals/services/storage-content-hash.service.ts`.
     const STORAGE_A: &str = "01234567-89ab-cdef-0123-456789abcdef";
     const STORAGE_B: &str = "ffffffff-ffff-ffff-ffff-ffffffffffff";
 
@@ -109,5 +146,25 @@ mod tests {
             got,
             "e7158d0cbdae3793daa8352a6197eab9f772d8cb8784c941d921e81f5d4b09d6"
         );
+    }
+
+    #[test]
+    fn colon_paths_sort_like_formatted_entries() {
+        let got = compute_content_hash(STORAGE_A, [("a", "b:1"), ("a:b", "0")]);
+
+        assert_eq!(
+            got,
+            sha256_hex(&format!("storage:{STORAGE_A}\na:b:0\na:b:1"))
+        );
+        assert_ne!(
+            got,
+            sha256_hex(&format!("storage:{STORAGE_A}\na:b:1\na:b:0"))
+        );
+    }
+
+    fn sha256_hex(input: &str) -> String {
+        let mut hasher = Sha256::new();
+        hasher.update(input.as_bytes());
+        hex::encode(hasher.finalize())
     }
 }


### PR DESCRIPTION
## Summary

- convert guest-agent artifact snapshot manifests to shared immutable ownership across blocking tasks
- stream manifest JSON writing and manifest upload from disk instead of materializing full buffers
- serialize storage prepare/commit payloads from borrowed file entries
- stream content hash construction while preserving formatted `path:hash` sort semantics

Closes #16152

## Tests

- `cargo fmt --manifest-path crates/Cargo.toml --all`
- `cargo test --manifest-path crates/Cargo.toml -p guest-agent content_hash -- --nocapture`
- `cargo test --manifest-path crates/Cargo.toml -p guest-agent --lib artifact::tests::dedup_snapshot_posts_file_payloads_before_validation_failure_blocks_commit -- --nocapture`
- `cargo test --manifest-path crates/Cargo.toml -p guest-agent --lib artifact::tests::snapshot_uploads_archive_manifest_and_commits_new_version -- --nocapture`
- `cargo test --manifest-path crates/Cargo.toml -p guest-agent -- --nocapture`
- `cargo clippy --manifest-path crates/Cargo.toml -p guest-agent --all-targets -- -D warnings`
- `cargo clippy --manifest-path crates/Cargo.toml --all-targets --all-features -- -D warnings`
