### PR TITLE
fix: drain usage flushes during shutdown

### DIFF
--- a/crates/runner/mitm-addon/src/usage/buffer.py
+++ b/crates/runner/mitm-addon/src/usage/buffer.py
@@ -71,6 +71,12 @@ class _TimerHandle(Protocol):
 _TimerFactory = Callable[[float, Callable[[], None]], _TimerHandle]
 
 
+class _FlushOwnerLock(Protocol):
+    def acquire(self, blocking: bool = True) -> bool: ...
+
+    def release(self) -> None: ...
+
+
 @dataclass(frozen=True)
 class _DestinationKey:
     url: str
@@ -131,7 +137,7 @@ class UsageEventBuffer:
         self._lock = threading.Lock()
         # Serializes snapshot/enqueue ownership. Ordinary flushes defer if busy;
         # shutdown waits so daemon timer work cannot outlive process teardown.
-        self._flush_owner_lock = threading.Lock()
+        self._flush_owner_lock: _FlushOwnerLock = threading.Lock()
         self._buffer_id = str(uuid.uuid4())
         self._flush_sequence = 0
         self._flush_interval_seconds = max(1.0, flush_interval_seconds)

--- a/crates/runner/mitm-addon/src/usage/buffer.py
+++ b/crates/runner/mitm-addon/src/usage/buffer.py
@@ -129,6 +129,7 @@ class UsageEventBuffer:
         timer_factory: _TimerFactory | None = None,
     ) -> None:
         self._lock = threading.Lock()
+        self._flush_owner_lock = threading.Lock()
         self._buffer_id = str(uuid.uuid4())
         self._flush_sequence = 0
         self._flush_interval_seconds = max(1.0, flush_interval_seconds)
@@ -209,9 +210,36 @@ class UsageEventBuffer:
             timer.cancel()
 
     def _flush_usage_events(self, *, trigger: UsageFlushTrigger) -> int:
+        if not self._acquire_flush_ownership(trigger):
+            self._defer_unowned_flush(trigger)
+            return 0
+
+        try:
+            return self._flush_usage_events_owned(trigger=trigger)
+        finally:
+            self._flush_owner_lock.release()
+
+    def _acquire_flush_ownership(self, trigger: UsageFlushTrigger) -> bool:
+        return self._flush_owner_lock.acquire(blocking=trigger == "shutdown")
+
+    def _defer_unowned_flush(self, trigger: UsageFlushTrigger) -> None:
+        timer_to_cancel: _TimerHandle | None = None
+        timer_to_start: _TimerHandle | None = None
+        with self._lock:
+            if trigger == "timer":
+                timer_to_cancel = self._pop_timer_locked()
+            if trigger != "shutdown":
+                timer_to_start = self._schedule_timer_if_buffered_locked()
+            self._sync_buffered_counter_locked()
+        if timer_to_cancel is not None:
+            timer_to_cancel.cancel()
+        if timer_to_start is not None:
+            timer_to_start.start()
+
+    def _flush_usage_events_owned(self, *, trigger: UsageFlushTrigger) -> int:
         flushed_batch_count = 0
         snapshot_live = True
-        if trigger == "timer":
+        if trigger in ("shutdown", "timer"):
             with self._lock:
                 timer = self._pop_timer_locked()
             if timer is not None:
@@ -223,9 +251,13 @@ class UsageEventBuffer:
                 pending_flush, live_snapshot_attempted = self._next_pending_flush_locked(
                     snapshot_live=snapshot_live
                 )
-                if live_snapshot_attempted:
+                if live_snapshot_attempted and trigger != "shutdown":
                     snapshot_live = False
-                if self._enqueuing_source_event_count and pending_flush is None:
+                if (
+                    trigger != "shutdown"
+                    and self._enqueuing_source_event_count
+                    and pending_flush is None
+                ):
                     timer_to_start = self._schedule_timer_if_buffered_locked()
                 if pending_flush is None:
                     self._sync_buffered_counter_locked()

--- a/crates/runner/mitm-addon/src/usage/buffer.py
+++ b/crates/runner/mitm-addon/src/usage/buffer.py
@@ -72,9 +72,11 @@ _TimerFactory = Callable[[float, Callable[[], None]], _TimerHandle]
 
 
 class _FlushOwnerLock(Protocol):
-    def acquire(self, blocking: bool = True) -> bool: ...
+    def acquire(self, blocking: bool = True) -> bool:
+        raise NotImplementedError
 
-    def release(self) -> None: ...
+    def release(self) -> None:
+        raise NotImplementedError
 
 
 @dataclass(frozen=True)

--- a/crates/runner/mitm-addon/src/usage/buffer.py
+++ b/crates/runner/mitm-addon/src/usage/buffer.py
@@ -129,6 +129,8 @@ class UsageEventBuffer:
         timer_factory: _TimerFactory | None = None,
     ) -> None:
         self._lock = threading.Lock()
+        # Serializes snapshot/enqueue ownership. Ordinary flushes defer if busy;
+        # shutdown waits so daemon timer work cannot outlive process teardown.
         self._flush_owner_lock = threading.Lock()
         self._buffer_id = str(uuid.uuid4())
         self._flush_sequence = 0

--- a/crates/runner/mitm-addon/tests/test_usage_buffer.py
+++ b/crates/runner/mitm-addon/tests/test_usage_buffer.py
@@ -635,12 +635,27 @@ def test_flush_preserves_events_buffered_during_enqueue(tmp_path):
 def test_shutdown_flush_waits_for_active_timer_flush_and_drains_live_usage(tmp_path):
     timers = []
 
+    class _InstrumentedFlushOwnerLock:
+        def __init__(self) -> None:
+            self._lock = threading.Lock()
+            self.blocking_acquire_started = threading.Event()
+
+        def acquire(self, blocking: bool = True) -> bool:
+            if blocking:
+                self.blocking_acquire_started.set()
+            return self._lock.acquire(blocking)
+
+        def release(self) -> None:
+            self._lock.release()
+
     def timer_factory(delay: float, callback):
         timer = _FakeTimer(delay, callback)
         timers.append(timer)
         return timer
 
     usage.reset_usage_buffer_for_tests(timer_enabled=True, timer_factory=timer_factory)
+    flush_owner_lock = _InstrumentedFlushOwnerLock()
+    usage_buffer._usage_event_buffer._flush_owner_lock = flush_owner_lock
 
     proxy_log_path = str(tmp_path / "proxy.jsonl")
     usage.buffer_usage_events(
@@ -654,7 +669,6 @@ def test_shutdown_flush_waits_for_active_timer_flush_and_drains_live_usage(tmp_p
 
     timer_enqueue_started = threading.Event()
     release_timer_enqueue = threading.Event()
-    shutdown_started = threading.Event()
     shutdown_returned = threading.Event()
     shutdown_results: list[int] = []
     enqueued_runs: list[str] = []
@@ -679,7 +693,6 @@ def test_shutdown_flush_waits_for_active_timer_flush_and_drains_live_usage(tmp_p
         assert log_type == "usage_event"
 
     def shutdown_flush():
-        shutdown_started.set()
         shutdown_results.append(usage.flush_usage_events(trigger="shutdown"))
         shutdown_returned.set()
 
@@ -690,8 +703,8 @@ def test_shutdown_flush_waits_for_active_timer_flush_and_drains_live_usage(tmp_p
 
         shutdown_thread = threading.Thread(target=shutdown_flush)
         shutdown_thread.start()
-        assert shutdown_started.wait(timeout=1)
-        assert not shutdown_returned.wait(timeout=0.05)
+        assert flush_owner_lock.blocking_acquire_started.wait(timeout=1)
+        assert not shutdown_returned.is_set()
         assert enqueue_call_count == 1
 
         release_timer_enqueue.set()
@@ -705,6 +718,51 @@ def test_shutdown_flush_waits_for_active_timer_flush_and_drains_live_usage(tmp_p
     assert enqueued_runs == ["run-1", "run-2"]
     assert usage.counters._buffered_usage_events == 0
     assert len(timers) == 2
+    assert timers[1].cancelled is True
+
+
+def test_shutdown_flush_drains_live_usage_buffered_during_own_enqueue(tmp_path):
+    timers = []
+
+    def timer_factory(delay: float, callback):
+        timer = _FakeTimer(delay, callback)
+        timers.append(timer)
+        return timer
+
+    usage.reset_usage_buffer_for_tests(timer_enabled=True, timer_factory=timer_factory)
+
+    proxy_log_path = str(tmp_path / "proxy.jsonl")
+    usage.buffer_usage_events(
+        "https://api.test/api/webhooks/agent/usage-event",
+        "token-a",
+        "run-1",
+        [_event(source_key="source-1")],
+        proxy_log_path,
+    )
+    assert len(timers) == 1
+
+    enqueued_runs: list[str] = []
+
+    def enqueue_webhook(url, sandbox_token, payload, path, log_type):
+        enqueued_runs.append(payload["runId"])
+        if payload["runId"] == "run-1":
+            usage.buffer_usage_events(
+                url,
+                sandbox_token,
+                "run-2",
+                [_event(source_key="source-2")],
+                path,
+            )
+            assert len(timers) == 2
+        assert log_type == "usage_event"
+
+    with patch.object(usage_buffer, "_enqueue_webhook", side_effect=enqueue_webhook):
+        assert usage.flush_usage_events(trigger="shutdown") == 2
+
+    assert enqueued_runs == ["run-1", "run-2"]
+    assert usage.counters._buffered_usage_events == 0
+    assert len(timers) == 2
+    assert timers[0].cancelled is True
     assert timers[1].cancelled is True
 
 

--- a/crates/runner/mitm-addon/tests/test_usage_buffer.py
+++ b/crates/runner/mitm-addon/tests/test_usage_buffer.py
@@ -766,6 +766,43 @@ def test_shutdown_flush_drains_live_usage_buffered_during_own_enqueue(tmp_path):
     assert timers[1].cancelled is True
 
 
+def test_shutdown_flush_failure_preserves_retry_without_rescheduling_timer(tmp_path):
+    timers = []
+
+    def timer_factory(delay: float, callback):
+        timer = _FakeTimer(delay, callback)
+        timers.append(timer)
+        return timer
+
+    usage.reset_usage_buffer_for_tests(timer_enabled=True, timer_factory=timer_factory)
+
+    usage.buffer_usage_events(
+        "https://api.test/api/webhooks/agent/usage-event",
+        "token-a",
+        "run-1",
+        [_event(source_key="source-1")],
+        str(tmp_path / "proxy.jsonl"),
+    )
+    assert len(timers) == 1
+
+    with (
+        patch.object(usage_buffer, "_enqueue_webhook", side_effect=OSError("shutdown failed")),
+        pytest.raises(OSError, match="shutdown failed"),
+    ):
+        usage.flush_usage_events(trigger="shutdown")
+
+    assert usage.counters._buffered_usage_events == 1
+    assert len(timers) == 1
+    assert timers[0].cancelled is True
+
+    with patch.object(usage_buffer, "_enqueue_webhook") as enqueue:
+        assert usage.flush_usage_events(trigger="test") == 1
+
+    enqueue.assert_called_once()
+    assert enqueue.call_args.args[2]["runId"] == "run-1"
+    assert usage.counters._buffered_usage_events == 0
+
+
 def test_rejected_events_do_not_leave_empty_destination_buckets(tmp_path):
     with patch.object(usage_buffer, "_enqueue_webhook") as enqueue:
         assert (

--- a/crates/runner/mitm-addon/tests/test_usage_buffer.py
+++ b/crates/runner/mitm-addon/tests/test_usage_buffer.py
@@ -55,6 +55,20 @@ class _FakeTimer:
         self.cancelled = True
 
 
+class _InstrumentedFlushOwnerLock:
+    def __init__(self) -> None:
+        self._lock = threading.Lock()
+        self.blocking_acquire_started = threading.Event()
+
+    def acquire(self, blocking: bool = True) -> bool:
+        if blocking:
+            self.blocking_acquire_started.set()
+        return self._lock.acquire(blocking)
+
+    def release(self) -> None:
+        self._lock.release()
+
+
 def test_flush_aggregates_same_bucket_and_dedupes_source_key(tmp_path):
     proxy_log_path = str(tmp_path / "proxy.jsonl")
     with patch.object(usage_buffer, "_enqueue_webhook") as enqueue:
@@ -635,19 +649,6 @@ def test_flush_preserves_events_buffered_during_enqueue(tmp_path):
 def test_shutdown_flush_waits_for_active_timer_flush_and_drains_live_usage(tmp_path):
     timers = []
 
-    class _InstrumentedFlushOwnerLock:
-        def __init__(self) -> None:
-            self._lock = threading.Lock()
-            self.blocking_acquire_started = threading.Event()
-
-        def acquire(self, blocking: bool = True) -> bool:
-            if blocking:
-                self.blocking_acquire_started.set()
-            return self._lock.acquire(blocking)
-
-        def release(self) -> None:
-            self._lock.release()
-
     def timer_factory(delay: float, callback):
         timer = _FakeTimer(delay, callback)
         timers.append(timer)
@@ -718,6 +719,81 @@ def test_shutdown_flush_waits_for_active_timer_flush_and_drains_live_usage(tmp_p
     assert enqueued_runs == ["run-1", "run-2"]
     assert usage.counters._buffered_usage_events == 0
     assert len(timers) == 2
+    assert timers[1].cancelled is True
+
+
+def test_shutdown_flush_retries_active_timer_failure_without_rescheduling_timer(tmp_path):
+    timers = []
+
+    def timer_factory(delay: float, callback):
+        timer = _FakeTimer(delay, callback)
+        timers.append(timer)
+        return timer
+
+    usage.reset_usage_buffer_for_tests(timer_enabled=True, timer_factory=timer_factory)
+    flush_owner_lock = _InstrumentedFlushOwnerLock()
+    usage_buffer._usage_event_buffer._flush_owner_lock = flush_owner_lock
+
+    usage.buffer_usage_events(
+        "https://api.test/api/webhooks/agent/usage-event",
+        "token-a",
+        "run-1",
+        [_event(source_key="source-1")],
+        str(tmp_path / "proxy.jsonl"),
+    )
+    assert len(timers) == 1
+
+    first_enqueue_started = threading.Event()
+    release_first_enqueue = threading.Event()
+    shutdown_returned = threading.Event()
+    shutdown_results: list[int] = []
+    enqueued_run_ids: list[str] = []
+    enqueued_idempotency_keys: list[str] = []
+    timer_errors: list[str] = []
+
+    def enqueue_webhook(url, sandbox_token, payload, path, log_type):
+        del url, sandbox_token, path
+        assert log_type == "usage_event"
+        enqueued_run_ids.append(payload["runId"])
+        enqueued_idempotency_keys.append(payload["events"][0]["idempotencyKey"])
+        if len(enqueued_run_ids) == 1:
+            first_enqueue_started.set()
+            assert release_first_enqueue.wait(timeout=1)
+            raise OSError("timer failed")
+
+    def timer_flush():
+        try:
+            timers[0].callback()
+        except OSError as exc:
+            timer_errors.append(str(exc))
+
+    def shutdown_flush():
+        shutdown_results.append(usage.flush_usage_events(trigger="shutdown"))
+        shutdown_returned.set()
+
+    with patch.object(usage_buffer, "_enqueue_webhook", side_effect=enqueue_webhook):
+        timer_thread = threading.Thread(target=timer_flush)
+        timer_thread.start()
+        assert first_enqueue_started.wait(timeout=1)
+
+        shutdown_thread = threading.Thread(target=shutdown_flush)
+        shutdown_thread.start()
+        assert flush_owner_lock.blocking_acquire_started.wait(timeout=1)
+        assert not shutdown_returned.is_set()
+
+        release_first_enqueue.set()
+        timer_thread.join(timeout=1)
+        shutdown_thread.join(timeout=1)
+
+    assert not timer_thread.is_alive()
+    assert not shutdown_thread.is_alive()
+    assert timer_errors == ["timer failed"]
+    assert shutdown_results == [1]
+    assert enqueued_run_ids == ["run-1", "run-1"]
+    assert enqueued_idempotency_keys[0] == enqueued_idempotency_keys[1]
+    assert usage.counters._buffered_usage_events == 0
+    assert len(timers) == 2
+    assert timers[0].cancelled is True
     assert timers[1].cancelled is True
 
 

--- a/crates/runner/mitm-addon/tests/test_usage_buffer.py
+++ b/crates/runner/mitm-addon/tests/test_usage_buffer.py
@@ -1,6 +1,7 @@
 """Tests for buffered usage-event aggregation."""
 
 import json
+import threading
 import uuid
 from unittest.mock import patch
 
@@ -629,6 +630,82 @@ def test_flush_preserves_events_buffered_during_enqueue(tmp_path):
 
     enqueue.assert_called_once()
     assert usage.counters._buffered_usage_events == 0
+
+
+def test_shutdown_flush_waits_for_active_timer_flush_and_drains_live_usage(tmp_path):
+    timers = []
+
+    def timer_factory(delay: float, callback):
+        timer = _FakeTimer(delay, callback)
+        timers.append(timer)
+        return timer
+
+    usage.reset_usage_buffer_for_tests(timer_enabled=True, timer_factory=timer_factory)
+
+    proxy_log_path = str(tmp_path / "proxy.jsonl")
+    usage.buffer_usage_events(
+        "https://api.test/api/webhooks/agent/usage-event",
+        "token-a",
+        "run-1",
+        [_event(source_key="source-1")],
+        proxy_log_path,
+    )
+    assert len(timers) == 1
+
+    timer_enqueue_started = threading.Event()
+    release_timer_enqueue = threading.Event()
+    shutdown_started = threading.Event()
+    shutdown_returned = threading.Event()
+    shutdown_results: list[int] = []
+    enqueued_runs: list[str] = []
+    enqueue_call_count = 0
+
+    def enqueue_webhook(url, sandbox_token, payload, path, log_type):
+        nonlocal enqueue_call_count
+        enqueue_call_count += 1
+        enqueued_runs.append(payload["runId"])
+        if payload["runId"] == "run-1":
+            timer_enqueue_started.set()
+            assert usage.flush_usage_events(trigger="runner") == 0
+            usage.buffer_usage_events(
+                url,
+                sandbox_token,
+                "run-2",
+                [_event(source_key="source-2")],
+                path,
+            )
+            assert len(timers) == 2
+            assert release_timer_enqueue.wait(timeout=1)
+        assert log_type == "usage_event"
+
+    def shutdown_flush():
+        shutdown_started.set()
+        shutdown_results.append(usage.flush_usage_events(trigger="shutdown"))
+        shutdown_returned.set()
+
+    with patch.object(usage_buffer, "_enqueue_webhook", side_effect=enqueue_webhook):
+        timer_thread = threading.Thread(target=timers[0].callback)
+        timer_thread.start()
+        assert timer_enqueue_started.wait(timeout=1)
+
+        shutdown_thread = threading.Thread(target=shutdown_flush)
+        shutdown_thread.start()
+        assert shutdown_started.wait(timeout=1)
+        assert not shutdown_returned.wait(timeout=0.05)
+        assert enqueue_call_count == 1
+
+        release_timer_enqueue.set()
+        timer_thread.join(timeout=1)
+        shutdown_thread.join(timeout=1)
+
+    assert not timer_thread.is_alive()
+    assert not shutdown_thread.is_alive()
+    assert shutdown_returned.is_set()
+    assert shutdown_results == [1]
+    assert enqueued_runs == ["run-1", "run-2"]
+    assert usage.counters._buffered_usage_events == 0
+    assert len(timers) == 2
+    assert timers[1].cancelled is True
 
 
 def test_rejected_events_do_not_leave_empty_destination_buckets(tmp_path):

--- a/crates/runner/mitm-addon/tests/test_usage_buffer.py
+++ b/crates/runner/mitm-addon/tests/test_usage_buffer.py
@@ -797,6 +797,82 @@ def test_shutdown_flush_retries_active_timer_failure_without_rescheduling_timer(
     assert timers[1].cancelled is True
 
 
+def test_shutdown_flush_drains_usage_deferred_by_threshold_flush_while_waiting(tmp_path):
+    timers = []
+
+    def timer_factory(delay: float, callback):
+        timer = _FakeTimer(delay, callback)
+        timers.append(timer)
+        return timer
+
+    usage.reset_usage_buffer_for_tests(timer_enabled=True, timer_factory=timer_factory)
+    flush_owner_lock = _InstrumentedFlushOwnerLock()
+    usage_buffer._usage_event_buffer._flush_owner_lock = flush_owner_lock
+
+    usage.buffer_usage_events(
+        "https://api.test/api/webhooks/agent/usage-event",
+        "token-a",
+        "run-1",
+        [_event(source_key="source-1")],
+        str(tmp_path / "proxy.jsonl"),
+    )
+    assert len(timers) == 1
+
+    timer_enqueue_started = threading.Event()
+    release_timer_enqueue = threading.Event()
+    shutdown_returned = threading.Event()
+    shutdown_results: list[int] = []
+    enqueued_run_ids: list[str] = []
+
+    def enqueue_webhook(url, sandbox_token, payload, path, log_type):
+        del url, sandbox_token
+        assert log_type == "usage_event"
+        enqueued_run_ids.append(payload["runId"])
+        if payload["runId"] == "run-1":
+            timer_enqueue_started.set()
+            assert release_timer_enqueue.wait(timeout=1)
+        assert path.endswith("proxy.jsonl")
+
+    def shutdown_flush():
+        shutdown_results.append(usage.flush_usage_events(trigger="shutdown"))
+        shutdown_returned.set()
+
+    with patch.object(usage_buffer, "_enqueue_webhook", side_effect=enqueue_webhook):
+        timer_thread = threading.Thread(target=timers[0].callback)
+        timer_thread.start()
+        assert timer_enqueue_started.wait(timeout=1)
+
+        shutdown_thread = threading.Thread(target=shutdown_flush)
+        shutdown_thread.start()
+        assert flush_owner_lock.blocking_acquire_started.wait(timeout=1)
+
+        usage.buffer_usage_events(
+            "https://api.test/api/webhooks/agent/usage-event",
+            "token-a",
+            "run-2",
+            [
+                _event(source_key=f"source-deferred-{index}", category=f"category-{index}")
+                for index in range(usage_buffer.MAX_AGGREGATE_BUCKETS)
+            ],
+            str(tmp_path / "proxy.jsonl"),
+        )
+        assert not shutdown_returned.is_set()
+        assert len(timers) == 2
+
+        release_timer_enqueue.set()
+        timer_thread.join(timeout=1)
+        shutdown_thread.join(timeout=1)
+
+    assert not timer_thread.is_alive()
+    assert not shutdown_thread.is_alive()
+    assert shutdown_results == [1]
+    assert enqueued_run_ids == ["run-1", "run-2"]
+    assert usage.counters._buffered_usage_events == 0
+    assert len(timers) == 2
+    assert timers[0].cancelled is True
+    assert timers[1].cancelled is True
+
+
 def test_shutdown_flush_drains_live_usage_buffered_during_own_enqueue(tmp_path):
     timers = []
 


### PR DESCRIPTION
## Summary

- Add internal flush ownership to the mitm usage buffer so shutdown waits for an active timer/threshold/runner flush owner before draining.
- Preserve non-blocking behavior for ordinary flush triggers when another flush is active.
- Keep shutdown from scheduling retry timers while draining, and add deterministic coverage for timer-flush/shutdown handoff.

Closes #16154

## Tests

- `python3 -m compileall src tests/test_usage_buffer.py`
- `/tmp/vm0-mitm-addon-venv/bin/python -m ruff check src/usage/buffer.py tests/test_usage_buffer.py`
- `/tmp/vm0-mitm-addon-venv/bin/python -m pytest tests/test_usage_buffer.py::test_shutdown_flush_waits_for_active_timer_flush_and_drains_live_usage tests/test_usage_buffer.py::test_overlapping_flush_defers_live_snapshot_while_enqueueing tests/test_usage_buffer.py::test_flush_preserves_events_buffered_during_enqueue`
- `/tmp/vm0-mitm-addon-venv/bin/python -m pytest tests/test_usage_buffer.py tests/test_connection_hooks.py`

Full mitm-addon pytest was also attempted with `/tmp/vm0-mitm-addon-venv/bin/python -m pytest`; unrelated local failures remain in `tests/test_x_billing.py` because the local checkout cannot load `turbo/packages/connectors/src/firewalls/cursor.generated`.
