### PR TITLE
fix: bound model websocket retention

### DIFF
--- a/crates/runner/mitm-addon/src/mitm_addon.py
+++ b/crates/runner/mitm-addon/src/mitm_addon.py
@@ -11,6 +11,7 @@ This addon runs on the runner HOST (not inside VMs) and:
 6. Participates in runner-triggered usage drain before proxy shutdown
 """
 
+import asyncio
 import functools
 import json
 import signal
@@ -18,6 +19,7 @@ import tempfile
 import threading
 import time
 import urllib.parse
+from collections.abc import Callable
 from pathlib import Path
 
 from mitmproxy import ctx, http, tcp, tls
@@ -67,6 +69,7 @@ _BROWSER_USER_AGENT_MARKERS = (
     " safari/",
 )
 _MODEL_PROVIDER_USAGE_REPORTED = "_model_provider_usage_reported"
+_MODEL_WEBSOCKET_MESSAGE_TRIM_SCHEDULED = "_model_websocket_message_trim_scheduled"
 _USAGE_FLOW_TRACKED = "_usage_flow_tracked"
 # Network log size fields are consumed as JavaScript numbers downstream.
 _MAX_SAFE_NETWORK_LOG_SIZE = 9_007_199_254_740_991
@@ -630,6 +633,39 @@ def _report_model_provider_usage_once(flow: http.HTTPFlow, run_id: str) -> None:
         flow.metadata[_MODEL_PROVIDER_USAGE_REPORTED] = True
 
 
+_WebSocketTrimCallback = Callable[[http.HTTPFlow], None]
+
+
+def _call_soon(callback: _WebSocketTrimCallback, flow: http.HTTPFlow) -> None:
+    asyncio.get_running_loop().call_soon(callback, flow)
+
+
+def _is_model_websocket_usage_flow(flow: http.HTTPFlow) -> bool:
+    return bool(flow.websocket and response_streaming.is_model_websocket_usage_enabled(flow))
+
+
+def _trim_model_websocket_messages(flow: http.HTTPFlow) -> None:
+    flow.metadata.pop(_MODEL_WEBSOCKET_MESSAGE_TRIM_SCHEDULED, None)
+    if not _is_model_websocket_usage_flow(flow):
+        return
+    if not flow.websocket or not flow.websocket.messages:
+        return
+    flow.websocket.messages[:] = flow.websocket.messages[-1:]
+
+
+def _clear_model_websocket_messages(flow: http.HTTPFlow) -> None:
+    flow.metadata.pop(_MODEL_WEBSOCKET_MESSAGE_TRIM_SCHEDULED, None)
+    if _is_model_websocket_usage_flow(flow) and flow.websocket:
+        flow.websocket.messages.clear()
+
+
+def _schedule_model_websocket_message_trim(flow: http.HTTPFlow) -> None:
+    if flow.metadata.get(_MODEL_WEBSOCKET_MESSAGE_TRIM_SCHEDULED, False):
+        return
+    flow.metadata[_MODEL_WEBSOCKET_MESSAGE_TRIM_SCHEDULED] = True
+    _call_soon(_trim_model_websocket_messages, flow)
+
+
 # ============================================================================
 # HTTP Response Handlers
 # ============================================================================
@@ -646,11 +682,15 @@ def websocket_message(flow: http.HTTPFlow) -> None:
         return
     if not flow.metadata.get(metadata_keys.VM_RUN_ID, ""):
         return
+    if not response_streaming.is_model_websocket_usage_enabled(flow):
+        return
 
     message = flow.websocket.messages[-1]
     if getattr(message, "from_client", False):
+        _schedule_model_websocket_message_trim(flow)
         return
     response_streaming.feed_model_websocket_usage(flow, message.content)
+    _schedule_model_websocket_message_trim(flow)
 
 
 def _response_size(flow: http.HTTPFlow) -> int:
@@ -715,6 +755,8 @@ def _single_content_length_response_size(content_length: str, start: int, end: i
 
 
 def _release_usage_hook_state(flow: http.HTTPFlow, *, release_tracking: bool) -> None:
+    if release_tracking:
+        _clear_model_websocket_messages(flow)
     response_streaming.release_response_stream_state(flow)
     if release_tracking:
         _release_tracked_usage_flow(flow)

--- a/crates/runner/mitm-addon/tests/test_model_provider_stream_usage.py
+++ b/crates/runner/mitm-addon/tests/test_model_provider_stream_usage.py
@@ -17,6 +17,9 @@ import usage
 from tests.flow_helpers import header_map, response_stream
 from tests.pending_helpers import assert_pending
 
+_WebSocketTrimCallback = Callable[[http.HTTPFlow], None]
+_ScheduledWebSocketTrim = tuple[_WebSocketTrimCallback, http.HTTPFlow]
+
 
 def _openai_model_websocket_flow(
     tmp_path: Path, real_flow: Callable[..., http.HTTPFlow]
@@ -82,21 +85,80 @@ def _openai_responses_sse_flow(
     )
 
 
+@pytest.fixture(autouse=True)
+def deferred_websocket_trim_scheduler(
+    monkeypatch: pytest.MonkeyPatch,
+) -> list[_ScheduledWebSocketTrim]:
+    scheduled: list[_ScheduledWebSocketTrim] = []
+
+    def call_soon(callback: _WebSocketTrimCallback, flow: http.HTTPFlow) -> None:
+        scheduled.append((callback, flow))
+
+    monkeypatch.setattr(mitm_addon, "_call_soon", call_soon)
+    return scheduled
+
+
+def _run_deferred_websocket_trims(scheduled: list[_ScheduledWebSocketTrim]) -> None:
+    pending = list(scheduled)
+    scheduled.clear()
+    for callback, flow in pending:
+        callback(flow)
+
+
+def _make_websocket_message(
+    *,
+    from_client: bool,
+    content: bytes,
+) -> websocket.WebSocketMessage:
+    return websocket.WebSocketMessage(
+        Opcode.TEXT,
+        from_client=from_client,
+        content=content,
+    )
+
+
+def _append_websocket_message(
+    flow: http.HTTPFlow,
+    *,
+    from_client: bool,
+    content: bytes,
+) -> websocket.WebSocketMessage:
+    message = _make_websocket_message(from_client=from_client, content=content)
+    websocket_data = flow.websocket
+    if websocket_data is None:
+        websocket_data = websocket.WebSocketData(messages=[])
+        flow.websocket = websocket_data
+    websocket_data.messages.append(message)
+    return message
+
+
+def _openai_websocket_usage_frame(
+    response_id: str,
+    *,
+    input_tokens: int = 10,
+    output_tokens: int = 4,
+    model: str = "gpt-5.5",
+) -> bytes:
+    return json.dumps(
+        {
+            "type": "response.completed",
+            "response": {
+                "id": response_id,
+                "model": model,
+                "usage": {"input_tokens": input_tokens, "output_tokens": output_tokens},
+            },
+        }
+    ).encode()
+
+
 def _set_websocket_message(
     flow: http.HTTPFlow,
     *,
     from_client: bool,
     content: bytes,
 ) -> None:
-    flow.websocket = websocket.WebSocketData(
-        messages=[
-            websocket.WebSocketMessage(
-                Opcode.TEXT,
-                from_client=from_client,
-                content=content,
-            )
-        ]
-    )
+    flow.websocket = websocket.WebSocketData(messages=[])
+    _append_websocket_message(flow, from_client=from_client, content=content)
 
 
 def _feed_websocket_server_message(flow: http.HTTPFlow, content: bytes) -> None:
@@ -601,6 +663,175 @@ class TestModelProviderStreamUsage:
 
         assert webhook.request_count == 0
         assert flow.metadata["model_provider_usage"] == {}
+
+    def test_model_websocket_deferred_trim_keeps_latest_server_message(
+        self,
+        tmp_path,
+        real_flow,
+        deferred_websocket_trim_scheduler: list[_ScheduledWebSocketTrim],
+    ):
+        flow = _openai_model_websocket_flow(tmp_path, real_flow)
+        old_client = _append_websocket_message(flow, from_client=True, content=b"client-old")
+        old_server = _append_websocket_message(flow, from_client=False, content=b"server-old")
+        latest_server = _append_websocket_message(
+            flow,
+            from_client=False,
+            content=_openai_websocket_usage_frame("resp_ws_latest"),
+        )
+        assert flow.websocket is not None
+        messages = flow.websocket.messages
+
+        mitm_addon.websocket_message(flow)
+
+        assert messages == [old_client, old_server, latest_server]
+        assert flow.metadata["model_provider_usage"] == {
+            "message_id": "resp_ws_latest",
+            "model": "gpt-5.5",
+            "tokens.input": 10,
+            "tokens.output": 4,
+        }
+        assert len(deferred_websocket_trim_scheduler) == 1
+
+        _run_deferred_websocket_trims(deferred_websocket_trim_scheduler)
+
+        assert flow.websocket.messages is messages
+        assert flow.websocket.messages == [latest_server]
+
+    def test_model_websocket_deferred_trim_keeps_latest_client_message(
+        self,
+        tmp_path,
+        real_flow,
+        deferred_websocket_trim_scheduler: list[_ScheduledWebSocketTrim],
+    ):
+        flow = _openai_model_websocket_flow(tmp_path, real_flow)
+        old_server = _append_websocket_message(flow, from_client=False, content=b"server-old")
+        latest_client = _append_websocket_message(
+            flow,
+            from_client=True,
+            content=_openai_websocket_usage_frame("resp_ws_client"),
+        )
+
+        mitm_addon.websocket_message(flow)
+
+        assert flow.metadata["model_provider_usage"] == {}
+        assert len(deferred_websocket_trim_scheduler) == 1
+
+        _run_deferred_websocket_trims(deferred_websocket_trim_scheduler)
+
+        assert flow.websocket is not None
+        assert flow.websocket.messages == [latest_client]
+        assert old_server not in flow.websocket.messages
+
+    def test_model_websocket_deferred_trim_coalesces_and_keeps_latest_at_callback(
+        self,
+        tmp_path,
+        real_flow,
+        deferred_websocket_trim_scheduler: list[_ScheduledWebSocketTrim],
+    ):
+        flow = _openai_model_websocket_flow(tmp_path, real_flow)
+        first_server = _append_websocket_message(
+            flow,
+            from_client=False,
+            content=_openai_websocket_usage_frame(
+                "resp_ws_first",
+                input_tokens=1,
+                output_tokens=1,
+            ),
+        )
+        mitm_addon.websocket_message(flow)
+        assert len(deferred_websocket_trim_scheduler) == 1
+
+        latest_server = _append_websocket_message(
+            flow,
+            from_client=False,
+            content=_openai_websocket_usage_frame("resp_ws_latest"),
+        )
+        mitm_addon.websocket_message(flow)
+
+        assert len(deferred_websocket_trim_scheduler) == 1
+        assert flow.websocket is not None
+        assert flow.websocket.messages == [first_server, latest_server]
+
+        _run_deferred_websocket_trims(deferred_websocket_trim_scheduler)
+
+        assert flow.websocket.messages == [latest_server]
+        assert flow.metadata["model_provider_usage"] == {
+            "message_id": "resp_ws_latest",
+            "model": "gpt-5.5",
+            "tokens.input": 10,
+            "tokens.output": 4,
+        }
+
+    def test_non_model_websocket_message_retention_is_unchanged(
+        self,
+        real_flow,
+        deferred_websocket_trim_scheduler: list[_ScheduledWebSocketTrim],
+    ):
+        flow = real_flow(with_response=False, host="example.com")
+        flow.metadata["vm_run_id"] = "run-abc-123"
+        first = _append_websocket_message(flow, from_client=True, content=b"client")
+        second = _append_websocket_message(flow, from_client=False, content=b"server")
+
+        mitm_addon.websocket_message(flow)
+
+        assert deferred_websocket_trim_scheduler == []
+        assert flow.websocket is not None
+        assert flow.websocket.messages == [first, second]
+
+    def test_model_websocket_end_clears_final_retained_message(
+        self,
+        tmp_path,
+        real_flow,
+        deferred_websocket_trim_scheduler: list[_ScheduledWebSocketTrim],
+    ):
+        flow = _openai_model_websocket_flow(tmp_path, real_flow)
+        _append_websocket_message(
+            flow,
+            from_client=False,
+            content=_openai_websocket_usage_frame("resp_ws_1"),
+        )
+        mitm_addon.websocket_message(flow)
+        assert len(deferred_websocket_trim_scheduler) == 1
+
+        webhook = self._run_websocket_end(flow)
+
+        assert {event["category"]: event["quantity"] for event in webhook.usage_events()} == {
+            "tokens.input": 10,
+            "tokens.output": 4,
+        }
+        assert flow.websocket is not None
+        assert flow.websocket.messages == []
+
+        _run_deferred_websocket_trims(deferred_websocket_trim_scheduler)
+        assert flow.websocket.messages == []
+
+    def test_model_websocket_error_clears_final_retained_message(
+        self,
+        tmp_path,
+        real_flow,
+        deferred_websocket_trim_scheduler: list[_ScheduledWebSocketTrim],
+    ):
+        flow = _openai_model_websocket_flow(tmp_path, real_flow)
+        flow.error = Error("connection reset by peer")
+        _append_websocket_message(
+            flow,
+            from_client=False,
+            content=_openai_websocket_usage_frame("resp_ws_1"),
+        )
+        mitm_addon.websocket_message(flow)
+        assert len(deferred_websocket_trim_scheduler) == 1
+
+        webhook = self._run_error(flow)
+
+        assert {event["category"]: event["quantity"] for event in webhook.usage_events()} == {
+            "tokens.input": 10,
+            "tokens.output": 4,
+        }
+        assert flow.websocket is not None
+        assert flow.websocket.messages == []
+
+        _run_deferred_websocket_trims(deferred_websocket_trim_scheduler)
+        assert flow.websocket.messages == []
 
 
 class TestModelProviderWebSocketUsageMetadata:


### PR DESCRIPTION
## Summary
- bound model-provider WebSocket flow message retention with a coalesced next-loop trim
- leave non-model-provider WebSocket flows untouched
- clear final retained WebSocket messages on terminal usage cleanup paths

## Tests
- cd crates/runner/mitm-addon && pytest tests/test_model_provider_stream_usage.py
- cd crates/runner/mitm-addon && pytest tests/test_response_streaming.py tests/test_response_handler.py tests/test_error_handler.py
- cd crates/runner/mitm-addon && ruff check .
- cd crates/runner/mitm-addon && ruff format --check .
- cd crates/runner/mitm-addon && basedpyright -p .

Closes #16155