### PR TITLE
fix: show memory index diffs separately

### DIFF
--- a/turbo/apps/api/src/signals/routes/__tests__/cron-summarize-memory.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/cron-summarize-memory.test.ts
@@ -535,7 +535,7 @@ describe("GET /api/cron/summarize-memory", () => {
     expect(items).toStrictEqual(["facts/zero-search.md"]);
   });
 
-  it("folds MEMORY.md churn into the real file change", async () => {
+  it("persists MEMORY.md alongside the real file change", async () => {
     mockLlm();
     const seeded = await seedTwoVersions(
       [{ path: "MEMORY.md", content: "# index v1" }],
@@ -549,7 +549,9 @@ describe("GET /api/cron/summarize-memory", () => {
 
     const summary = await findSummary(seeded.fixture);
     const items = await findItems(summary?.id ?? "");
-    expect(items).toStrictEqual(["facts/coffee.md"]);
+    expect(items).toHaveLength(2);
+    expect(items).toContain("MEMORY.md");
+    expect(items).toContain("facts/coffee.md");
   });
 
   it("backfills quiet cards and makes no LLM call when memory did not change", async () => {

--- a/turbo/apps/api/src/signals/services/__tests__/memory-activity-diff.service.test.ts
+++ b/turbo/apps/api/src/signals/services/__tests__/memory-activity-diff.service.test.ts
@@ -143,7 +143,7 @@ describe("computeChangeSet", () => {
     });
   });
 
-  it("folds MEMORY.md churn into real file changes (does not emit it)", () => {
+  it("emits MEMORY.md alongside real file changes", () => {
     const changeSet = computeChangeSet(
       fileMap([["MEMORY.md", "idx1", "# index v1"]]),
       fileMap([
@@ -152,11 +152,14 @@ describe("computeChangeSet", () => {
       ]),
     );
 
-    expect(changeSet.items).toHaveLength(1);
-    expect(changeSet.items[0]?.filePath).toBe("facts/coffee.md");
+    expect(
+      changeSet.items.map((item) => {
+        return item.filePath;
+      }),
+    ).toStrictEqual(["MEMORY.md", "facts/coffee.md"]);
   });
 
-  it("emits MEMORY.md as its own item when no real file change explains it", () => {
+  it("emits MEMORY.md as its own item when it is the only changed file", () => {
     const changeSet = computeChangeSet(
       fileMap([["MEMORY.md", "idx1", "# index v1"]]),
       fileMap([["MEMORY.md", "idx2", "# index v2 reorganized"]]),

--- a/turbo/apps/api/src/signals/services/memory-activity-diff.service.ts
+++ b/turbo/apps/api/src/signals/services/memory-activity-diff.service.ts
@@ -26,7 +26,6 @@ interface MemoryFileState {
 
 export type MemoryFileMap = ReadonlyMap<string, MemoryFileState>;
 
-const MEMORY_INDEX_PATH = "MEMORY.md";
 const MAX_DIFF_LINES = 300;
 const MAX_DIFF_LINE_CHARS = 500;
 const MAX_LCS_CELLS = 250_000;
@@ -306,9 +305,8 @@ function classifyFile(
  * unchanged files are skipped without byte-diffing. The resulting item stores
  * lifecycle on `diff.beforeExists` / `diff.afterExists`.
  *
- * `MEMORY.md` is a derived index: its churn is folded into the real fact
- * changes. It is only emitted as its own item when it changed AND no other
- * file change explains it (pure index reorg / prose-only edit).
+ * `MEMORY.md` is emitted like any other file because the activity UI renders
+ * file-level diffs.
  */
 export function computeChangeSet(
   fromFiles: MemoryFileMap,
@@ -317,7 +315,6 @@ export function computeChangeSet(
   const paths = new Set<string>([...fromFiles.keys(), ...toFiles.keys()]);
 
   const items: MemoryChangeItem[] = [];
-  let memoryIndexItem: MemoryChangeItem | null = null;
 
   for (const filePath of paths) {
     const item = classifyFile(
@@ -328,15 +325,7 @@ export function computeChangeSet(
     if (!item) {
       continue;
     }
-    if (filePath === MEMORY_INDEX_PATH) {
-      memoryIndexItem = item;
-      continue;
-    }
     items.push(item);
-  }
-
-  if (memoryIndexItem && items.length === 0) {
-    items.push(memoryIndexItem);
   }
 
   return { items, changed: items.length > 0 };


### PR DESCRIPTION
## Summary
- emit `MEMORY.md` like any other changed memory file in memory activity diffs
- remove the special derived-index folding behavior
- update diff and cron tests to expect `MEMORY.md` alongside real memory files

## Tests
- `pnpm -F api check-types`
- `pnpm -F api exec vitest run src/signals/services/__tests__/memory-activity-diff.service.test.ts src/signals/routes/__tests__/cron-summarize-memory.test.ts`
- `pnpm -F api lint`
- `pnpm format`