### PR TITLE
feat: route push-subscriptions through fetch$ and to api backend

### DIFF
--- a/turbo/apps/platform/src/lib/push-notifications.ts
+++ b/turbo/apps/platform/src/lib/push-notifications.ts
@@ -6,9 +6,10 @@
  */
 
 import { command, state } from "ccstate";
-import { clerk$ } from "../signals/auth.ts";
-import { apiBase$ } from "../signals/fetch.ts";
+import { fetch$ } from "../signals/fetch.ts";
 import { bestEffort } from "../signals/utils.ts";
+
+type FetchFn = (url: string, init?: RequestInit) => Promise<Response>;
 
 const swRegistration$ = state<ServiceWorkerRegistration | null>(null);
 const subscribing$ = state(false);
@@ -60,10 +61,8 @@ export const ensurePushSubscription$ = command(
     // TODO: The try-catch block here needs to be cleaned up. confirmed by ethan@vm0.ai
     // eslint-disable-next-line no-restricted-syntax
     try {
-      const clerkPromise = get(clerk$);
-      const apiBase = await get(apiBase$);
-      signal.throwIfAborted();
-      await doSubscribe(registration, clerkPromise, apiBase, signal);
+      const fetchFn = get(fetch$);
+      await doSubscribe(registration, fetchFn, signal);
       signal.throwIfAborted();
     } finally {
       set(subscribing$, false);
@@ -73,10 +72,7 @@ export const ensurePushSubscription$ = command(
 
 async function doSubscribe(
   registration: ServiceWorkerRegistration,
-  clerkPromise: Promise<{
-    session?: { getToken(): Promise<string | null> } | null;
-  }>,
-  apiBase: string,
+  fetchFn: FetchFn,
   signal: AbortSignal,
 ): Promise<void> {
   const vapidPublicKey = import.meta.env.VITE_VAPID_PUBLIC_KEY as
@@ -114,17 +110,12 @@ async function doSubscribe(
   });
   signal.throwIfAborted();
 
-  // Send subscription to backend
-  const clerk = await clerkPromise;
-  signal.throwIfAborted();
-  const token = await clerk.session?.getToken();
-  signal.throwIfAborted();
-
-  await fetch(`${apiBase}/api/zero/push-subscriptions`, {
+  // Send subscription to the backend. fetch$ injects the auth token and
+  // applies the api-target routing policy.
+  await fetchFn("/api/zero/push-subscriptions", {
     method: "POST",
     headers: {
       "Content-Type": "application/json",
-      ...(token ? { Authorization: `Bearer ${token}` } : {}),
     },
     body: JSON.stringify({
       endpoint: subscription.endpoint,

--- a/turbo/apps/platform/src/signals/__tests__/fetch.test.ts
+++ b/turbo/apps/platform/src/signals/__tests__/fetch.test.ts
@@ -690,6 +690,28 @@ describe("apiBackend routing", () => {
     ]);
   });
 
+  it("routes push-subscriptions POST to api host when apiBackend is off", async () => {
+    vi.stubGlobal("location", new URL("https://platform.vm0.ai/"));
+    detachedSetupPage({
+      context,
+      path: "/",
+      withoutRender: true,
+    });
+
+    const hosts: string[] = [];
+    server.use(
+      http.post("*/api/zero/push-subscriptions", ({ request }) => {
+        hosts.push(new URL(request.url).host);
+        return new Response(null, { status: 200 });
+      }),
+    );
+
+    const fch = context.store.get(fetch$);
+    await fch("/api/zero/push-subscriptions", { method: "POST" });
+
+    expect(hosts).toStrictEqual(["api.vm0.ai"]);
+  });
+
   it("does not let a :param template over-match a shorter parent path", async () => {
     vi.stubGlobal("location", new URL("https://platform.vm0.ai/"));
     detachedSetupPage({

--- a/turbo/apps/platform/src/signals/api-target-policy.ts
+++ b/turbo/apps/platform/src/signals/api-target-policy.ts
@@ -114,6 +114,7 @@ const API_ROUTE_ALLOWLIST: readonly ApiRouteAllowlistEntry[] = [
     methods: ["POST", "DELETE"],
     pathname: "/api/zero/org/membership-requests",
   },
+  { methods: ["POST"], pathname: "/api/zero/push-subscriptions" },
   { methods: ["GET"], pathname: "/api/zero/queue-position" },
   { methods: ["POST"], pathname: "/api/zero/realtime/token" },
   { methods: ["POST"], pathname: "/api/zero/report-error" },


### PR DESCRIPTION
## Summary
`push-notifications` sent `POST /api/zero/push-subscriptions` via a raw `fetch()` against the **global** `apiBase$` base, which bypasses the per-route api-target policy — so it could not be migrated by an allowlist entry; its host followed only the global `apiBackend` switch (→ `www`).

This PR:
- Refactors `ensurePushSubscription$` / `doSubscribe` to use the policy-aware **`fetch$`** transport. Since `fetch$` injects the auth token automatically, the manual Clerk `getToken()` + `Authorization` header are dropped (also removes a raw `fetch` usage). `apiBase$` and `clerk$` imports are no longer needed here.
- Adds `POST /api/zero/push-subscriptions` to `API_ROUTE_ALLOWLIST`, so it now resolves to the `api` host while the global `apiBackend` switch is off.

Found during the group-D audit of `api-backend-rewrites.js` — it was the one first-party route that couldn't be migrated by allowlisting alone.

## Validation
- New `fetch.test.ts` test: `POST /api/zero/push-subscriptions` → `api`.
- Existing `push-notifications.test.ts` still passes.
- `pnpm format`, `pnpm -F @vm0/app lint`, `pnpm -F @vm0/app check-types`, `pnpm knip --workspace apps/platform` — clean; 55 routing tests pass.

## Post-merge verification
Confirm in `vm0-traces-prod` that `POST /api/zero/push-subscriptions` lands on `service.name=vm0-api` with no 5xx.

Part of #15872

🤖 Generated with [Claude Code](https://claude.com/claude-code)
