### PR TITLE
docs: document vsock exec lifecycle handles

### DIFF
--- a/crates/vsock-host/src/exec_operation.rs
+++ b/crates/vsock-host/src/exec_operation.rs
@@ -786,8 +786,8 @@ impl ExecOperationDiagnostic {
 ///
 /// Dropping the handle removes the host-side registration only. It never sends
 /// `MSG_EXEC_CANCEL`; callers that need remote cancellation must call
-/// [`ExecOperationHandle::cancel_and_wait`]. See the crate-level exec
-/// operation lifecycle docs for the cross-handle ownership contract.
+/// [`ExecOperationHandle::cancel_and_wait`]. See the Exec Operation Lifecycle
+/// section in the [`crate`] docs for the cross-handle ownership contract.
 #[must_use = "dropping this handle does not cancel the guest; call wait or cancel_and_wait"]
 pub struct ExecOperationHandle {
     shared: Arc<Shared>,
@@ -974,9 +974,9 @@ impl Drop for ExecOperationHandle {
 /// Dropping this handle never sends `MSG_EXEC_CANCEL` and does not remove the
 /// operation lifecycle registration. The host keeps the registration until a
 /// terminal exec result arrives, the connection closes, or a caller explicitly
-/// waits with a timeout that abandons the operation. See the crate-level exec
-/// operation lifecycle docs for how supervised handles share cancellation and
-/// terminal result ownership.
+/// waits with a timeout that abandons the operation. See the Exec Operation
+/// Lifecycle section in the [`crate`] docs for how supervised handles share
+/// cancellation and terminal result ownership.
 #[must_use = "dropping this handle does not cancel the guest or remove lifecycle registration"]
 pub struct SupervisedExecHandle {
     shared: Arc<Shared>,
@@ -1006,7 +1006,7 @@ impl SupervisedExecCancelHandle {
     ///
     /// The paired [`SupervisedExecHandle`] still owns the result receiver and must
     /// be waited or abandoned by its caller. If this times out before the
-    /// cancel frame is written, the paired handle can still observe the
+    /// cancel frame write starts, the paired handle can still observe the
     /// terminal result.
     pub async fn cancel(self, timeout: Duration) -> io::Result<()> {
         tokio::time::timeout(
@@ -1247,7 +1247,7 @@ impl ExecControlHandle {
     /// bound. `payload` must fit the exec-control payload limit. Invalid
     /// inputs fail before the request frame is written. The timeout is encoded
     /// for guest-side control delivery and also bounds the host wait for a
-    /// response.
+    /// response after the request frame is written.
     ///
     /// Only [`ExecControlOutcome::Delivered`] is returned as an
     /// [`ExecControlAck`]. Guest statuses and guest error responses are

--- a/crates/vsock-host/src/exec_operation.rs
+++ b/crates/vsock-host/src/exec_operation.rs
@@ -786,7 +786,9 @@ impl ExecOperationDiagnostic {
 ///
 /// Dropping the handle removes the host-side registration only. It never sends
 /// `MSG_EXEC_CANCEL`; callers that need remote cancellation must call
-/// [`ExecOperationHandle::cancel_and_wait`].
+/// [`ExecOperationHandle::cancel_and_wait`]. See the crate-level exec
+/// operation lifecycle docs for the cross-handle ownership contract.
+#[must_use = "dropping this handle does not cancel the guest; call wait or cancel_and_wait"]
 pub struct ExecOperationHandle {
     shared: Arc<Shared>,
     seq: Option<u32>,
@@ -809,7 +811,9 @@ impl ExecOperationHandle {
     /// Wait for the terminal exec result.
     ///
     /// On timeout, this removes the host-side operation registration but does
-    /// not cancel the guest-side exec operation.
+    /// not cancel the guest-side exec operation. If the request may have
+    /// reached the guest, normal operations can become unavailable on this
+    /// connection even though the connection itself may still be open.
     pub async fn wait(self, timeout: Duration) -> io::Result<ExecOperationResult> {
         self.wait_with_timeout(timeout, false).await
     }
@@ -817,7 +821,9 @@ impl ExecOperationHandle {
     /// Send an explicit cancel request and wait for a cancelled terminal result.
     ///
     /// If the terminal result is already available before cancel is sent, this
-    /// returns that result without sending a duplicate cancel frame.
+    /// returns that result without sending a duplicate cancel frame. If cancel
+    /// is sent but the terminal result does not arrive before `timeout`, the
+    /// connection is poisoned because guest process state is no longer known.
     pub async fn cancel_and_wait(self, timeout: Duration) -> io::Result<ExecOperationResult> {
         let cancel_label_log = self.diagnostic.label_log.clone();
         let registered_at = self.diagnostic.registered_at;
@@ -968,7 +974,10 @@ impl Drop for ExecOperationHandle {
 /// Dropping this handle never sends `MSG_EXEC_CANCEL` and does not remove the
 /// operation lifecycle registration. The host keeps the registration until a
 /// terminal exec result arrives, the connection closes, or a caller explicitly
-/// waits with a timeout that abandons the operation.
+/// waits with a timeout that abandons the operation. See the crate-level exec
+/// operation lifecycle docs for how supervised handles share cancellation and
+/// terminal result ownership.
+#[must_use = "dropping this handle does not cancel the guest or remove lifecycle registration"]
 pub struct SupervisedExecHandle {
     shared: Arc<Shared>,
     seq: Option<u32>,
@@ -981,6 +990,11 @@ pub struct SupervisedExecHandle {
 }
 
 /// One-shot handle that sends `MSG_EXEC_CANCEL` for a supervised exec operation.
+///
+/// Dropping this handle without calling [`SupervisedExecCancelHandle::cancel`]
+/// does not send cancellation. The paired [`SupervisedExecHandle`] owns the
+/// terminal result.
+#[must_use = "dropping this cancel handle does not send MSG_EXEC_CANCEL"]
 pub struct SupervisedExecCancelHandle {
     shared: Arc<Shared>,
     seq: u32,
@@ -991,7 +1005,9 @@ impl SupervisedExecCancelHandle {
     /// Send the cancel frame without consuming the terminal exec result.
     ///
     /// The paired [`SupervisedExecHandle`] still owns the result receiver and must
-    /// be waited or abandoned by its caller.
+    /// be waited or abandoned by its caller. If this times out before the
+    /// cancel frame is written, the paired handle can still observe the
+    /// terminal result.
     pub async fn cancel(self, timeout: Duration) -> io::Result<()> {
         tokio::time::timeout(
             timeout,
@@ -1076,8 +1092,8 @@ impl SupervisedExecHandle {
     ///
     /// On timeout, this abandons the host-side operation registration but does
     /// not send `MSG_EXEC_CANCEL`. Because the terminal proof is abandoned
-    /// after a guest write, the connection should not be reused for later
-    /// normal operations.
+    /// after a guest write, later normal operations become unavailable on this
+    /// connection.
     pub async fn wait(self, timeout: Duration) -> io::Result<ExecOperationResult> {
         self.wait_with_timeout(timeout, false).await
     }
@@ -1085,7 +1101,9 @@ impl SupervisedExecHandle {
     /// Send `MSG_EXEC_CANCEL` and wait for the terminal exec result.
     ///
     /// If the terminal result is already available before cancel is sent, this
-    /// returns that result without sending a duplicate cancel frame.
+    /// returns that result without sending a duplicate cancel frame. If cancel
+    /// is sent but the terminal result does not arrive before `timeout`, the
+    /// connection is poisoned because guest process state is no longer known.
     pub async fn cancel_and_wait(self, timeout: Duration) -> io::Result<ExecOperationResult> {
         let cancel_label_log = self.diagnostic.label_log.clone();
         let registered_at = self.diagnostic.registered_at;
@@ -1224,6 +1242,16 @@ pub struct ExecControlHandle {
 
 impl ExecControlHandle {
     /// Send an exec-control request and require a delivered acknowledgement.
+    ///
+    /// `message_id` must be non-empty and fit the protocol string length
+    /// bound. `payload` must fit the exec-control payload limit. Invalid
+    /// inputs fail before the request frame is written. The timeout is encoded
+    /// for guest-side control delivery and also bounds the host wait for a
+    /// response.
+    ///
+    /// Only [`ExecControlOutcome::Delivered`] is returned as an
+    /// [`ExecControlAck`]. Guest statuses and guest error responses are
+    /// converted into `io::Error` values.
     pub async fn control(
         &self,
         message_id: &str,
@@ -1241,6 +1269,11 @@ impl ExecControlHandle {
     }
 
     /// Send an exec-control request and return the raw guest outcome.
+    ///
+    /// This has the same parameter and timeout contract as
+    /// [`ExecControlHandle::control`], but returns [`ExecControlOutcome`] so
+    /// callers can distinguish delivered requests, non-delivered guest
+    /// statuses, and guest error responses.
     pub async fn control_with_write_observer(
         &self,
         message_id: &str,

--- a/crates/vsock-host/src/lib.rs
+++ b/crates/vsock-host/src/lib.rs
@@ -17,6 +17,48 @@
 //! stream exclusively. All public methods take `&self` and can be called
 //! concurrently. Responses are dispatched to callers via oneshot channels
 //! keyed by sequence number.
+//!
+//! ## Exec Operation Lifecycle
+//!
+//! [`VsockHost`] supports one-shot exec operations with
+//! [`VsockHost::start_exec_operation`] and supervised exec operations with
+//! [`VsockHost::start_supervised_exec`]. One-shot exec is request-scoped: the
+//! guest sends a terminal result for the original request sequence.
+//! Supervised exec first acknowledges a started guest process and then keeps a
+//! lifecycle registration until a terminal result arrives, the connection
+//! closes, or the host explicitly abandons the registration.
+//!
+//! [`ExecOperationHandle`] owns a one-shot terminal result registration.
+//! Dropping it removes only host-side registration and never sends
+//! `MSG_EXEC_CANCEL`; use [`ExecOperationHandle::wait`] to observe the
+//! terminal result or [`ExecOperationHandle::cancel_and_wait`] to send
+//! cancellation and wait for the cancelled terminal result. A plain wait
+//! timeout does not cancel the guest. If terminal proof is abandoned after a
+//! request may have reached the guest, the connection can remain open while
+//! later normal operations become unavailable on that connection. A timeout
+//! after an explicit cancel was sent poisons the connection because the guest
+//! process state is no longer known.
+//!
+//! [`SupervisedExecHandle`] owns the terminal result for a supervised process.
+//! Dropping it does not cancel the guest and does not remove the lifecycle
+//! registration; the host keeps tracking the operation until terminal result
+//! dispatch, connection close, or an explicit wait timeout. Use
+//! [`SupervisedExecHandle::cancel_and_wait`] to send cancellation and consume
+//! the terminal result. [`SupervisedExecCancelHandle::cancel`] sends only the
+//! cancel frame and leaves terminal result ownership with the paired
+//! [`SupervisedExecHandle`].
+//!
+//! Streaming exec operations expose a bounded receiver through
+//! `take_stream_receiver`. Guest-side stream or capture truncation is reported
+//! on individual output/captured-output values, while host-side bounded queue
+//! overflow is reported on [`ExecOperationResult::stream_overflowed`].
+//!
+//! Supervised operations can opt into exec control with
+//! [`SupervisedExecControl::Enabled`]. [`ExecControlHandle::control`] requires
+//! a delivered acknowledgement, while
+//! [`ExecControlHandle::control_with_write_observer`] exposes the raw
+//! [`ExecControlOutcome`] so callers can distinguish delivered requests from
+//! guest statuses and guest error responses.
 
 mod exec_operation;
 mod file;


### PR DESCRIPTION
## Summary

- add a crate-level `vsock-host` exec-operation lifecycle overview covering one-shot vs supervised handles, cancellation, wait timeouts, streaming, and exec control
- tighten public handle/control rustdoc around drop, wait, cancel, timeout, and control outcome semantics
- add targeted `#[must_use]` guardrails for lifecycle-owning exec handles

Closes #16156

## Verification

- `cargo fmt --manifest-path crates/Cargo.toml -p vsock-host`
- `cargo doc --manifest-path crates/Cargo.toml -p vsock-host --no-deps`
- `cargo check --manifest-path crates/Cargo.toml -p vsock-host`
- `cargo check --manifest-path crates/Cargo.toml -p vsock-host --all-targets`
- `cargo clippy --manifest-path crates/Cargo.toml -p vsock-host --all-targets -- -D warnings`
- pre-commit hook: cargo-fmt, cargo-clippy, cargo-doc, commitlint
