### PR TITLE
feat: consolidate usage into Credit balance with per-source records

### DIFF
--- a/turbo/apps/api/src/signals/route.ts
+++ b/turbo/apps/api/src/signals/route.ts
@@ -152,6 +152,7 @@ import { zeroUploadsCompleteRoutes } from "./routes/zero-uploads-complete";
 import { zeroUploadsPrepareRoutes } from "./routes/zero-uploads-prepare";
 import { zeroUsageInsightRoutes } from "./routes/zero-usage-insight";
 import { zeroUsageMembersRoutes } from "./routes/zero-usage-members";
+import { zeroUsageRecordRoutes } from "./routes/zero-usage-record";
 import { zeroUsageRunsRoutes } from "./routes/zero-usage-runs";
 import { zeroUserPreferencesRoutes } from "./routes/zero-user-preferences";
 import { zeroUserPermissionGrantsRoutes } from "./routes/zero-user-permission-grants";
@@ -348,6 +349,7 @@ export const ROUTES: readonly RouteEntry[] = [
   ...storagesPrepareRoutes,
   ...zeroUsageInsightRoutes,
   ...zeroUsageMembersRoutes,
+  ...zeroUsageRecordRoutes,
   ...zeroUsageRunsRoutes,
   ...chatThreadsV1Routes,
   ...audioTranscriptionsV1Routes,

--- a/turbo/apps/api/src/signals/routes/__tests__/helpers/zero-usage.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/helpers/zero-usage.ts
@@ -7,6 +7,7 @@ import {
 } from "@vm0/db/schema/agent-compose";
 import { agentRuns } from "@vm0/db/schema/agent-run";
 import { agentSessions } from "@vm0/db/schema/agent-session";
+import { chatThreads } from "@vm0/db/schema/chat-thread";
 import { orgMembersMetadata } from "@vm0/db/schema/org-members-metadata";
 import { orgMetadata } from "@vm0/db/schema/org-metadata";
 import { usageEvent } from "@vm0/db/schema/usage-event";
@@ -83,6 +84,14 @@ interface SeedRunArgs {
   readonly createdAt?: Date;
   readonly startedAt?: Date | null;
   readonly completedAt?: Date | null;
+}
+
+interface SeedChatThreadRunArgs {
+  readonly orgId: string;
+  readonly userId: string;
+  readonly title?: string | null;
+  readonly triggerSource?: string;
+  readonly createdAt?: Date;
 }
 
 export const seedUsageFixture$ = command(
@@ -402,5 +411,49 @@ export const seedRun$ = command(
     signal.throwIfAborted();
 
     return { runId: run.id, composeId: compose.id };
+  },
+);
+
+// Seed a run that belongs to a chat thread, so it surfaces in the per-chat
+// usage record. Returns the thread id alongside the run/compose ids.
+export const seedChatThreadRun$ = command(
+  async (
+    { set },
+    args: SeedChatThreadRunArgs,
+    signal: AbortSignal,
+  ): Promise<{ runId: string; threadId: string; composeId: string }> => {
+    const db = set(writeDb$);
+    const { runId, composeId } = await set(
+      seedRun$,
+      {
+        orgId: args.orgId,
+        userId: args.userId,
+        triggerSource: args.triggerSource ?? "web",
+        createdAt: args.createdAt,
+      },
+      signal,
+    );
+    signal.throwIfAborted();
+
+    const [thread] = await db
+      .insert(chatThreads)
+      .values({
+        userId: args.userId,
+        agentComposeId: composeId,
+        title: args.title ?? null,
+      })
+      .returning({ id: chatThreads.id });
+    signal.throwIfAborted();
+    if (!thread) {
+      throw new Error("seedChatThreadRun$: thread insert returned no row");
+    }
+
+    await db
+      .update(zeroRuns)
+      .set({ chatThreadId: thread.id })
+      .where(eq(zeroRuns.id, runId));
+    signal.throwIfAborted();
+
+    return { runId, threadId: thread.id, composeId };
   },
 );

--- a/turbo/apps/api/src/signals/routes/__tests__/helpers/zero-usage.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/helpers/zero-usage.ts
@@ -91,6 +91,7 @@ interface SeedChatThreadRunArgs {
   readonly userId: string;
   readonly title?: string | null;
   readonly triggerSource?: string;
+  readonly threadId?: string;
   readonly createdAt?: Date;
 }
 
@@ -435,25 +436,29 @@ export const seedChatThreadRun$ = command(
     );
     signal.throwIfAborted();
 
-    const [thread] = await db
-      .insert(chatThreads)
-      .values({
-        userId: args.userId,
-        agentComposeId: composeId,
-        title: args.title ?? null,
-      })
-      .returning({ id: chatThreads.id });
-    signal.throwIfAborted();
-    if (!thread) {
-      throw new Error("seedChatThreadRun$: thread insert returned no row");
+    let threadId = args.threadId;
+    if (!threadId) {
+      const [thread] = await db
+        .insert(chatThreads)
+        .values({
+          userId: args.userId,
+          agentComposeId: composeId,
+          title: args.title ?? null,
+        })
+        .returning({ id: chatThreads.id });
+      signal.throwIfAborted();
+      if (!thread) {
+        throw new Error("seedChatThreadRun$: thread insert returned no row");
+      }
+      threadId = thread.id;
     }
 
     await db
       .update(zeroRuns)
-      .set({ chatThreadId: thread.id })
+      .set({ chatThreadId: threadId })
       .where(eq(zeroRuns.id, runId));
     signal.throwIfAborted();
 
-    return { runId, threadId: thread.id, composeId };
+    return { runId, threadId, composeId };
   },
 );

--- a/turbo/apps/api/src/signals/routes/__tests__/zero-usage-record.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/zero-usage-record.test.ts
@@ -222,6 +222,146 @@ describe("GET /api/zero/usage/record", () => {
     expect(response.body.rows[0]?.credits).toBe(120);
   });
 
+  it("keeps chat and schedule usage separate within the same thread", async () => {
+    const fixture = await track(
+      store.set(seedUsageFixture$, {}, context.signal),
+    );
+
+    const chat = await store.set(
+      seedChatThreadRun$,
+      {
+        orgId: fixture.orgId,
+        userId: fixture.userId,
+        title: "Shared thread",
+        createdAt: createdAt(30),
+      },
+      context.signal,
+    );
+    await store.set(
+      insertModelUsage$,
+      {
+        orgId: fixture.orgId,
+        userId: fixture.userId,
+        runId: chat.runId,
+        inputTokens: 10,
+        outputTokens: 10,
+        creditsCharged: 10,
+      },
+      context.signal,
+    );
+
+    const schedule = await store.set(
+      seedChatThreadRun$,
+      {
+        orgId: fixture.orgId,
+        userId: fixture.userId,
+        threadId: chat.threadId,
+        triggerSource: "schedule",
+        createdAt: createdAt(5),
+      },
+      context.signal,
+    );
+    await store.set(
+      insertModelUsage$,
+      {
+        orgId: fixture.orgId,
+        userId: fixture.userId,
+        runId: schedule.runId,
+        inputTokens: 50,
+        outputTokens: 50,
+        creditsCharged: 120,
+      },
+      context.signal,
+    );
+
+    mocks.clerk.session(fixture.userId, fixture.orgId);
+
+    const allResponse = await accept(
+      apiClient().get({ query: {}, headers: authHeaders() }),
+      [200],
+    );
+    expect(allResponse.body.rows).toHaveLength(2);
+    expect(allResponse.body.pagination.total).toBe(2);
+    expect(allResponse.body.rows[0]).toMatchObject({
+      source: "schedule",
+      threadId: chat.threadId,
+      runId: null,
+      title: "Shared thread",
+      credits: 120,
+      tokens: 100,
+    });
+    expect(allResponse.body.rows[1]).toMatchObject({
+      source: "chat",
+      threadId: chat.threadId,
+      runId: null,
+      title: "Shared thread",
+      credits: 10,
+      tokens: 20,
+    });
+
+    const chatResponse = await accept(
+      apiClient().get({
+        query: { source: "chat" },
+        headers: authHeaders(),
+      }),
+      [200],
+    );
+    expect(chatResponse.body.rows).toHaveLength(1);
+    expect(chatResponse.body.rows[0]?.source).toBe("chat");
+    expect(chatResponse.body.rows[0]?.credits).toBe(10);
+  });
+
+  it("normalizes unsupported trigger sources to other", async () => {
+    const fixture = await track(
+      store.set(seedUsageFixture$, {}, context.signal),
+    );
+
+    const legacyRun = await store.set(
+      seedRun$,
+      {
+        orgId: fixture.orgId,
+        userId: fixture.userId,
+        prompt: "Legacy manual run",
+        triggerSource: "manual",
+        createdAt: createdAt(10),
+      },
+      context.signal,
+    );
+    await store.set(
+      insertModelUsage$,
+      {
+        orgId: fixture.orgId,
+        userId: fixture.userId,
+        runId: legacyRun.runId,
+        inputTokens: 25,
+        outputTokens: 5,
+        creditsCharged: 30,
+      },
+      context.signal,
+    );
+
+    mocks.clerk.session(fixture.userId, fixture.orgId);
+
+    const response = await accept(
+      apiClient().get({
+        query: { source: "other" },
+        headers: authHeaders(),
+      }),
+      [200],
+    );
+
+    expect(response.body.rows).toHaveLength(1);
+    expect(response.body.pagination.total).toBe(1);
+    expect(response.body.rows[0]).toMatchObject({
+      source: "other",
+      threadId: null,
+      runId: legacyRun.runId,
+      title: "Legacy manual run",
+      credits: 30,
+      tokens: 30,
+    });
+  });
+
   it("paginates by page size", async () => {
     const fixture = await track(
       store.set(seedUsageFixture$, {}, context.signal),

--- a/turbo/apps/api/src/signals/routes/__tests__/zero-usage-record.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/zero-usage-record.test.ts
@@ -11,6 +11,7 @@ import {
   deleteUsageFixture$,
   insertModelUsage$,
   seedChatThreadRun$,
+  seedRun$,
   seedUsageFixture$,
   type UsageFixture,
 } from "./helpers/zero-usage";
@@ -47,7 +48,7 @@ describe("GET /api/zero/usage/record", () => {
     });
   });
 
-  it("returns the user's chats ordered by recent activity", async () => {
+  it("returns rows across sources ordered by recent activity", async () => {
     const fixture = await track(
       store.set(seedUsageFixture$, {}, context.signal),
     );
@@ -71,6 +72,31 @@ describe("GET /api/zero/usage/record", () => {
         inputTokens: 100,
         outputTokens: 50,
         creditsCharged: 80,
+      },
+      context.signal,
+    );
+
+    // Unthreaded Slack run — one row per run, links via runId.
+    const slack = await store.set(
+      seedRun$,
+      {
+        orgId: fixture.orgId,
+        userId: fixture.userId,
+        prompt: "Slack triage",
+        triggerSource: "slack",
+        createdAt: createdAt(60),
+      },
+      context.signal,
+    );
+    await store.set(
+      insertModelUsage$,
+      {
+        orgId: fixture.orgId,
+        userId: fixture.userId,
+        runId: slack.runId,
+        inputTokens: 30,
+        outputTokens: 20,
+        creditsCharged: 40,
       },
       context.signal,
     );
@@ -105,14 +131,95 @@ describe("GET /api/zero/usage/record", () => {
       [200],
     );
 
-    expect(response.body.chats).toHaveLength(2);
-    expect(response.body.pagination.total).toBe(2);
-    expect(response.body.chats[0]?.threadId).toBe(newer.threadId);
-    expect(response.body.chats[0]?.threadTitle).toBe("Newer chat");
-    expect(response.body.chats[0]?.credits).toBe(250);
-    expect(response.body.chats[0]?.tokens).toBe(300);
-    expect(response.body.chats[1]?.threadId).toBe(older.threadId);
-    expect(response.body.chats[1]?.credits).toBe(80);
+    expect(response.body.rows).toHaveLength(3);
+    expect(response.body.pagination.total).toBe(3);
+
+    expect(response.body.rows[0]?.source).toBe("chat");
+    expect(response.body.rows[0]?.threadId).toBe(newer.threadId);
+    expect(response.body.rows[0]?.runId).toBeNull();
+    expect(response.body.rows[0]?.title).toBe("Newer chat");
+    expect(response.body.rows[0]?.credits).toBe(250);
+    expect(response.body.rows[0]?.tokens).toBe(300);
+
+    expect(response.body.rows[1]?.source).toBe("slack");
+    expect(response.body.rows[1]?.threadId).toBeNull();
+    expect(response.body.rows[1]?.runId).toBe(slack.runId);
+    expect(response.body.rows[1]?.title).toBe("Slack triage");
+    expect(response.body.rows[1]?.credits).toBe(40);
+
+    expect(response.body.rows[2]?.source).toBe("chat");
+    expect(response.body.rows[2]?.threadId).toBe(older.threadId);
+    expect(response.body.rows[2]?.credits).toBe(80);
+  });
+
+  it("labels schedule threads and filters by source", async () => {
+    const fixture = await track(
+      store.set(seedUsageFixture$, {}, context.signal),
+    );
+
+    const chat = await store.set(
+      seedChatThreadRun$,
+      {
+        orgId: fixture.orgId,
+        userId: fixture.userId,
+        title: "A chat",
+        createdAt: createdAt(20),
+      },
+      context.signal,
+    );
+    await store.set(
+      insertModelUsage$,
+      {
+        orgId: fixture.orgId,
+        userId: fixture.userId,
+        runId: chat.runId,
+        inputTokens: 10,
+        outputTokens: 10,
+        creditsCharged: 10,
+      },
+      context.signal,
+    );
+
+    const schedule = await store.set(
+      seedChatThreadRun$,
+      {
+        orgId: fixture.orgId,
+        userId: fixture.userId,
+        title: "Daily brief",
+        triggerSource: "schedule",
+        createdAt: createdAt(10),
+      },
+      context.signal,
+    );
+    await store.set(
+      insertModelUsage$,
+      {
+        orgId: fixture.orgId,
+        userId: fixture.userId,
+        runId: schedule.runId,
+        inputTokens: 50,
+        outputTokens: 50,
+        creditsCharged: 120,
+      },
+      context.signal,
+    );
+
+    mocks.clerk.session(fixture.userId, fixture.orgId);
+
+    const response = await accept(
+      apiClient().get({
+        query: { source: "schedule" },
+        headers: authHeaders(),
+      }),
+      [200],
+    );
+
+    expect(response.body.rows).toHaveLength(1);
+    expect(response.body.pagination.total).toBe(1);
+    expect(response.body.rows[0]?.source).toBe("schedule");
+    expect(response.body.rows[0]?.threadId).toBe(schedule.threadId);
+    expect(response.body.rows[0]?.title).toBe("Daily brief");
+    expect(response.body.rows[0]?.credits).toBe(120);
   });
 
   it("paginates by page size", async () => {
@@ -155,9 +262,9 @@ describe("GET /api/zero/usage/record", () => {
       [200],
     );
 
-    expect(response.body.chats).toHaveLength(2);
+    expect(response.body.rows).toHaveLength(2);
     expect(response.body.pagination.total).toBe(3);
-    expect(response.body.chats[0]?.threadTitle).toBe("Chat 10");
-    expect(response.body.chats[1]?.threadTitle).toBe("Chat 20");
+    expect(response.body.rows[0]?.title).toBe("Chat 10");
+    expect(response.body.rows[1]?.title).toBe("Chat 20");
   });
 });

--- a/turbo/apps/api/src/signals/routes/__tests__/zero-usage-record.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/zero-usage-record.test.ts
@@ -1,0 +1,163 @@
+import { zeroUsageRecordContract } from "@vm0/api-contracts/contracts/zero-usage-record";
+import { createStore } from "ccstate";
+
+import { accept, setupApp, testContext } from "../../../__tests__/test-helpers";
+import { nowDate } from "../../../lib/time";
+import {
+  createFixtureTracker,
+  createZeroRouteMocks,
+} from "./helpers/zero-route-test";
+import {
+  deleteUsageFixture$,
+  insertModelUsage$,
+  seedChatThreadRun$,
+  seedUsageFixture$,
+  type UsageFixture,
+} from "./helpers/zero-usage";
+
+const context = testContext();
+const store = createStore();
+const mocks = createZeroRouteMocks(context);
+
+function authHeaders() {
+  return { authorization: "Bearer clerk-session" };
+}
+
+function apiClient() {
+  return setupApp({ context })(zeroUsageRecordContract);
+}
+
+function createdAt(minutesAgo: number): Date {
+  return new Date(nowDate().getTime() - minutesAgo * 60 * 1000);
+}
+
+describe("GET /api/zero/usage/record", () => {
+  const track = createFixtureTracker<UsageFixture>((fixture) => {
+    return store.set(deleteUsageFixture$, fixture, context.signal);
+  });
+
+  it("returns 401 when not authenticated", async () => {
+    const response = await accept(
+      apiClient().get({ query: {}, headers: {} }),
+      [401],
+    );
+
+    expect(response.body).toStrictEqual({
+      error: { message: "Not authenticated", code: "UNAUTHORIZED" },
+    });
+  });
+
+  it("returns the user's chats ordered by recent activity", async () => {
+    const fixture = await track(
+      store.set(seedUsageFixture$, {}, context.signal),
+    );
+
+    const older = await store.set(
+      seedChatThreadRun$,
+      {
+        orgId: fixture.orgId,
+        userId: fixture.userId,
+        title: "Older chat",
+        createdAt: createdAt(120),
+      },
+      context.signal,
+    );
+    await store.set(
+      insertModelUsage$,
+      {
+        orgId: fixture.orgId,
+        userId: fixture.userId,
+        runId: older.runId,
+        inputTokens: 100,
+        outputTokens: 50,
+        creditsCharged: 80,
+      },
+      context.signal,
+    );
+
+    const newer = await store.set(
+      seedChatThreadRun$,
+      {
+        orgId: fixture.orgId,
+        userId: fixture.userId,
+        title: "Newer chat",
+        createdAt: createdAt(5),
+      },
+      context.signal,
+    );
+    await store.set(
+      insertModelUsage$,
+      {
+        orgId: fixture.orgId,
+        userId: fixture.userId,
+        runId: newer.runId,
+        inputTokens: 200,
+        outputTokens: 100,
+        creditsCharged: 250,
+      },
+      context.signal,
+    );
+
+    mocks.clerk.session(fixture.userId, fixture.orgId);
+
+    const response = await accept(
+      apiClient().get({ query: {}, headers: authHeaders() }),
+      [200],
+    );
+
+    expect(response.body.chats).toHaveLength(2);
+    expect(response.body.pagination.total).toBe(2);
+    expect(response.body.chats[0]?.threadId).toBe(newer.threadId);
+    expect(response.body.chats[0]?.threadTitle).toBe("Newer chat");
+    expect(response.body.chats[0]?.credits).toBe(250);
+    expect(response.body.chats[0]?.tokens).toBe(300);
+    expect(response.body.chats[1]?.threadId).toBe(older.threadId);
+    expect(response.body.chats[1]?.credits).toBe(80);
+  });
+
+  it("paginates by page size", async () => {
+    const fixture = await track(
+      store.set(seedUsageFixture$, {}, context.signal),
+    );
+
+    for (const minutesAgo of [30, 20, 10]) {
+      const chat = await store.set(
+        seedChatThreadRun$,
+        {
+          orgId: fixture.orgId,
+          userId: fixture.userId,
+          title: `Chat ${minutesAgo}`,
+          createdAt: createdAt(minutesAgo),
+        },
+        context.signal,
+      );
+      await store.set(
+        insertModelUsage$,
+        {
+          orgId: fixture.orgId,
+          userId: fixture.userId,
+          runId: chat.runId,
+          inputTokens: 10,
+          outputTokens: 10,
+          creditsCharged: 10,
+        },
+        context.signal,
+      );
+    }
+
+    mocks.clerk.session(fixture.userId, fixture.orgId);
+
+    const response = await accept(
+      apiClient().get({
+        query: { page: 1, pageSize: 2 },
+        headers: authHeaders(),
+      }),
+      [200],
+    );
+
+    expect(response.body.chats).toHaveLength(2);
+    expect(response.body.pagination.total).toBe(3);
+    expect(response.body.chats[0]?.threadTitle).toBe("Chat 10");
+    expect(response.body.chats[1]?.threadTitle).toBe("Chat 20");
+  });
+});

--- a/turbo/apps/api/src/signals/routes/zero-usage-record.ts
+++ b/turbo/apps/api/src/signals/routes/zero-usage-record.ts
@@ -1,0 +1,39 @@
+import { command } from "ccstate";
+import { zeroUsageRecordContract } from "@vm0/api-contracts/contracts/zero-usage-record";
+
+import { organizationAuthContext$ } from "../auth/auth-context";
+import { authRoute } from "../auth/auth-route";
+import { queryOf } from "../context/request";
+import { zeroUsageRecord$ } from "../services/zero-usage-record.service";
+import type { RouteEntry } from "../route";
+
+const getUsageRecordInner$ = command(
+  async ({ get, set }, signal: AbortSignal) => {
+    const auth = get(organizationAuthContext$);
+    const query = get(queryOf(zeroUsageRecordContract.get));
+
+    const body = await set(
+      zeroUsageRecord$,
+      {
+        userId: auth.userId,
+        orgId: auth.orgId,
+        page: query.page,
+        pageSize: query.pageSize,
+      },
+      signal,
+    );
+    signal.throwIfAborted();
+
+    return { status: 200 as const, body };
+  },
+);
+
+export const zeroUsageRecordRoutes: readonly RouteEntry[] = [
+  {
+    route: zeroUsageRecordContract.get,
+    handler: authRoute(
+      { requireOrganization: true, missingOrganizationStatus: 401 },
+      getUsageRecordInner$,
+    ),
+  },
+];

--- a/turbo/apps/api/src/signals/routes/zero-usage-record.ts
+++ b/turbo/apps/api/src/signals/routes/zero-usage-record.ts
@@ -19,6 +19,7 @@ const getUsageRecordInner$ = command(
         orgId: auth.orgId,
         page: query.page,
         pageSize: query.pageSize,
+        source: query.source,
       },
       signal,
     );

--- a/turbo/apps/api/src/signals/services/zero-usage-record.service.ts
+++ b/turbo/apps/api/src/signals/services/zero-usage-record.service.ts
@@ -15,6 +15,17 @@ const MODEL_TOKEN_CATEGORIES = [
   "tokens.cache_read",
   "tokens.cache_creation",
 ] as const;
+const THREADED_SOURCES = ["chat", "schedule"] as const;
+const PASSTHROUGH_TRIGGER_SOURCES = [
+  "schedule",
+  "slack",
+  "telegram",
+  "email",
+  "agentphone",
+  "github",
+  "cli",
+  "agent",
+] as const;
 
 interface UsageRecordArgs {
   readonly userId: string;
@@ -43,11 +54,21 @@ function tokenExpr(): string {
   return `CASE WHEN ue.kind = ${pgLit(MODEL_USAGE_KIND)} AND ue.category IN (${list}) THEN ue.quantity ELSE 0 END`;
 }
 
+function sourceExpr(triggerSource: string): string {
+  const passthroughList = PASSTHROUGH_TRIGGER_SOURCES.map(pgLit).join(", ");
+  return `
+    CASE
+      WHEN ${triggerSource} = 'web' THEN 'chat'
+      WHEN ${triggerSource} IN (${passthroughList}) THEN ${triggerSource}
+      ELSE 'other'
+    END`;
+}
+
 // Per-source usage for one user in one org. `record` is the shared CTE so the
-// row query and the count query stay in sync. Threaded sources (web chat,
-// schedule) collapse to one row per thread; everything else is one row per run.
-// `web` is surfaced as the `chat` source.
+// row query and the count query stay in sync. Threaded sources collapse to one
+// row per source/thread; everything else is one row per run.
 function recordWith(userIdLit: string, orgIdLit: string): string {
+  const threadedSourceList = THREADED_SOURCES.map(pgLit).join(", ");
   return `
     WITH usage_rows AS (
       SELECT
@@ -64,7 +85,7 @@ function recordWith(userIdLit: string, orgIdLit: string): string {
         ur.run_id,
         ur.credits,
         ur.tokens,
-        zr.trigger_source,
+        ${sourceExpr("zr.trigger_source")} AS source,
         zr.chat_thread_id,
         zr.summary,
         ar.prompt,
@@ -75,7 +96,7 @@ function recordWith(userIdLit: string, orgIdLit: string): string {
     ),
     threaded AS (
       SELECT
-        (CASE WHEN bool_or(r.trigger_source = 'schedule') THEN 'schedule' ELSE 'chat' END) AS source,
+        r.source,
         r.chat_thread_id::text AS thread_id,
         NULL::text AS run_id,
         ct.title AS title,
@@ -85,11 +106,12 @@ function recordWith(userIdLit: string, orgIdLit: string): string {
       FROM runs r
       LEFT JOIN chat_threads ct ON ct.id = r.chat_thread_id
       WHERE r.chat_thread_id IS NOT NULL
-      GROUP BY r.chat_thread_id, ct.title
+        AND r.source IN (${threadedSourceList})
+      GROUP BY r.source, r.chat_thread_id, ct.title
     ),
     unthreaded AS (
       SELECT
-        (CASE WHEN r.trigger_source = 'web' THEN 'chat' ELSE r.trigger_source END) AS source,
+        r.source,
         NULL::text AS thread_id,
         r.run_id::text AS run_id,
         LEFT(COALESCE(NULLIF(MAX(r.summary), ''), MAX(r.prompt)), 120) AS title,
@@ -98,7 +120,8 @@ function recordWith(userIdLit: string, orgIdLit: string): string {
         MAX(r.created_at) AS last_activity
       FROM runs r
       WHERE r.chat_thread_id IS NULL
-      GROUP BY r.run_id, r.trigger_source
+        OR r.source NOT IN (${threadedSourceList})
+      GROUP BY r.run_id, r.source
     ),
     record AS (
       SELECT * FROM threaded

--- a/turbo/apps/api/src/signals/services/zero-usage-record.service.ts
+++ b/turbo/apps/api/src/signals/services/zero-usage-record.service.ts
@@ -1,0 +1,150 @@
+import { command } from "ccstate";
+import { sql } from "drizzle-orm";
+import type {
+  UsageRecordChatRow,
+  UsageRecordResponse,
+} from "@vm0/api-contracts/contracts/zero-usage-record";
+
+import { writeDb$, type Db } from "../external/db";
+
+const MODEL_USAGE_KIND = "model";
+const MODEL_TOKEN_CATEGORIES = [
+  "tokens.input",
+  "tokens.output",
+  "tokens.cache_read",
+  "tokens.cache_creation",
+] as const;
+
+interface UsageRecordArgs {
+  readonly userId: string;
+  readonly orgId: string;
+  readonly page: number;
+  readonly pageSize: number;
+}
+
+interface UsageRecordRow extends Record<string, unknown> {
+  thread_id: string;
+  thread_title: string | null;
+  credits: string;
+  tokens: string;
+  last_activity: Date | string;
+}
+
+function pgLit(value: string): string {
+  return `'${value.replace(/'/g, "''")}'`;
+}
+
+function tokenExpr(): string {
+  const list = MODEL_TOKEN_CATEGORIES.map(pgLit).join(", ");
+  return `CASE WHEN ue.kind = ${pgLit(MODEL_USAGE_KIND)} AND ue.category IN (${list}) THEN ue.quantity ELSE 0 END`;
+}
+
+// Per-chat usage for one user in one org, aggregated across every run in the
+// chat. `per_chat` is the shared CTE so the row query and the count query stay
+// in sync.
+function perChatWith(userIdLit: string, orgIdLit: string): string {
+  return `
+    WITH usage_rows AS (
+      SELECT
+        ue.run_id,
+        COALESCE(ue.credits_charged, 0)::bigint AS credits_charged,
+        ${tokenExpr()}::bigint AS tokens
+      FROM usage_event ue
+      WHERE ue.user_id = ${userIdLit}
+        AND ue.org_id = ${orgIdLit}
+        AND ue.status = 'processed'
+    ),
+    per_chat AS (
+      SELECT
+        zr.chat_thread_id AS thread_id,
+        ct.title AS thread_title,
+        COALESCE(SUM(ur.credits_charged), 0)::bigint AS credits,
+        COALESCE(SUM(ur.tokens), 0)::bigint AS tokens,
+        MAX(ar.created_at) AS last_activity
+      FROM usage_rows ur
+      INNER JOIN zero_runs zr ON zr.id = ur.run_id
+      INNER JOIN agent_runs ar ON ar.id = ur.run_id
+      LEFT JOIN chat_threads ct ON ct.id = zr.chat_thread_id
+      WHERE zr.chat_thread_id IS NOT NULL
+      GROUP BY zr.chat_thread_id, ct.title
+    )`;
+}
+
+async function queryUsageRecordRows(
+  db: Db,
+  userIdLit: string,
+  orgIdLit: string,
+  pageSize: number,
+  offset: number,
+): Promise<UsageRecordChatRow[]> {
+  const result = await db.execute<UsageRecordRow>(
+    sql.raw(`
+      ${perChatWith(userIdLit, orgIdLit)}
+      SELECT thread_id, thread_title, credits, tokens, last_activity
+      FROM per_chat
+      ORDER BY last_activity DESC
+      LIMIT ${pageSize} OFFSET ${offset}
+    `),
+  );
+  return result.rows.map((row) => {
+    const lastActivity =
+      row.last_activity instanceof Date
+        ? row.last_activity.toISOString()
+        : new Date(row.last_activity).toISOString();
+    return {
+      threadId: row.thread_id,
+      threadTitle: row.thread_title,
+      credits: Number(row.credits),
+      tokens: Number(row.tokens),
+      lastActivityAt: lastActivity,
+    };
+  });
+}
+
+async function queryUsageRecordTotal(
+  db: Db,
+  userIdLit: string,
+  orgIdLit: string,
+): Promise<number> {
+  const result = await db.execute<{ total: string }>(
+    sql.raw(`
+      ${perChatWith(userIdLit, orgIdLit)}
+      SELECT COUNT(*)::bigint AS total FROM per_chat
+    `),
+  );
+  return Number(result.rows[0]?.total ?? 0);
+}
+
+export const zeroUsageRecord$ = command(
+  async (
+    { set },
+    args: UsageRecordArgs,
+    signal: AbortSignal,
+  ): Promise<UsageRecordResponse> => {
+    const db = set(writeDb$);
+    const userIdLit = pgLit(args.userId);
+    const orgIdLit = pgLit(args.orgId);
+    const offset = (args.page - 1) * args.pageSize;
+
+    signal.throwIfAborted();
+    const chats = await queryUsageRecordRows(
+      db,
+      userIdLit,
+      orgIdLit,
+      args.pageSize,
+      offset,
+    );
+    signal.throwIfAborted();
+    const total = await queryUsageRecordTotal(db, userIdLit, orgIdLit);
+    signal.throwIfAborted();
+
+    return {
+      chats,
+      pagination: {
+        page: args.page,
+        pageSize: args.pageSize,
+        total,
+      },
+    };
+  },
+);

--- a/turbo/apps/api/src/signals/services/zero-usage-record.service.ts
+++ b/turbo/apps/api/src/signals/services/zero-usage-record.service.ts
@@ -1,8 +1,9 @@
 import { command } from "ccstate";
 import { sql } from "drizzle-orm";
 import type {
-  UsageRecordChatRow,
+  UsageRecordRow,
   UsageRecordResponse,
+  UsageRecordSource,
 } from "@vm0/api-contracts/contracts/zero-usage-record";
 
 import { writeDb$, type Db } from "../external/db";
@@ -20,11 +21,14 @@ interface UsageRecordArgs {
   readonly orgId: string;
   readonly page: number;
   readonly pageSize: number;
+  readonly source?: UsageRecordSource;
 }
 
-interface UsageRecordRow extends Record<string, unknown> {
-  thread_id: string;
-  thread_title: string | null;
+interface UsageRecordSqlRow extends Record<string, unknown> {
+  source: string;
+  thread_id: string | null;
+  run_id: string | null;
+  title: string | null;
   credits: string;
   tokens: string;
   last_activity: Date | string;
@@ -39,49 +43,83 @@ function tokenExpr(): string {
   return `CASE WHEN ue.kind = ${pgLit(MODEL_USAGE_KIND)} AND ue.category IN (${list}) THEN ue.quantity ELSE 0 END`;
 }
 
-// Per-chat usage for one user in one org, aggregated across every run in the
-// chat. `per_chat` is the shared CTE so the row query and the count query stay
-// in sync.
-function perChatWith(userIdLit: string, orgIdLit: string): string {
+// Per-source usage for one user in one org. `record` is the shared CTE so the
+// row query and the count query stay in sync. Threaded sources (web chat,
+// schedule) collapse to one row per thread; everything else is one row per run.
+// `web` is surfaced as the `chat` source.
+function recordWith(userIdLit: string, orgIdLit: string): string {
   return `
     WITH usage_rows AS (
       SELECT
         ue.run_id,
-        COALESCE(ue.credits_charged, 0)::bigint AS credits_charged,
+        COALESCE(ue.credits_charged, 0)::bigint AS credits,
         ${tokenExpr()}::bigint AS tokens
       FROM usage_event ue
       WHERE ue.user_id = ${userIdLit}
         AND ue.org_id = ${orgIdLit}
         AND ue.status = 'processed'
     ),
-    per_chat AS (
+    runs AS (
       SELECT
-        zr.chat_thread_id AS thread_id,
-        ct.title AS thread_title,
-        COALESCE(SUM(ur.credits_charged), 0)::bigint AS credits,
-        COALESCE(SUM(ur.tokens), 0)::bigint AS tokens,
-        MAX(ar.created_at) AS last_activity
+        ur.run_id,
+        ur.credits,
+        ur.tokens,
+        zr.trigger_source,
+        zr.chat_thread_id,
+        zr.summary,
+        ar.prompt,
+        ar.created_at
       FROM usage_rows ur
       INNER JOIN zero_runs zr ON zr.id = ur.run_id
       INNER JOIN agent_runs ar ON ar.id = ur.run_id
-      LEFT JOIN chat_threads ct ON ct.id = zr.chat_thread_id
-      WHERE zr.chat_thread_id IS NOT NULL
-      GROUP BY zr.chat_thread_id, ct.title
+    ),
+    threaded AS (
+      SELECT
+        (CASE WHEN bool_or(r.trigger_source = 'schedule') THEN 'schedule' ELSE 'chat' END) AS source,
+        r.chat_thread_id::text AS thread_id,
+        NULL::text AS run_id,
+        ct.title AS title,
+        COALESCE(SUM(r.credits), 0)::bigint AS credits,
+        COALESCE(SUM(r.tokens), 0)::bigint AS tokens,
+        MAX(r.created_at) AS last_activity
+      FROM runs r
+      LEFT JOIN chat_threads ct ON ct.id = r.chat_thread_id
+      WHERE r.chat_thread_id IS NOT NULL
+      GROUP BY r.chat_thread_id, ct.title
+    ),
+    unthreaded AS (
+      SELECT
+        (CASE WHEN r.trigger_source = 'web' THEN 'chat' ELSE r.trigger_source END) AS source,
+        NULL::text AS thread_id,
+        r.run_id::text AS run_id,
+        LEFT(COALESCE(NULLIF(r.summary, ''), r.prompt), 120) AS title,
+        r.credits::bigint AS credits,
+        r.tokens::bigint AS tokens,
+        r.created_at AS last_activity
+      FROM runs r
+      WHERE r.chat_thread_id IS NULL
+    ),
+    record AS (
+      SELECT * FROM threaded
+      UNION ALL
+      SELECT * FROM unthreaded
     )`;
 }
 
 async function queryUsageRecordRows(
   db: Db,
-  userIdLit: string,
-  orgIdLit: string,
+  recordCte: string,
+  sourceFilterLit: string | null,
   pageSize: number,
   offset: number,
-): Promise<UsageRecordChatRow[]> {
-  const result = await db.execute<UsageRecordRow>(
+): Promise<UsageRecordRow[]> {
+  const where = sourceFilterLit ? `WHERE source = ${sourceFilterLit}` : "";
+  const result = await db.execute<UsageRecordSqlRow>(
     sql.raw(`
-      ${perChatWith(userIdLit, orgIdLit)}
-      SELECT thread_id, thread_title, credits, tokens, last_activity
-      FROM per_chat
+      ${recordCte}
+      SELECT source, thread_id, run_id, title, credits, tokens, last_activity
+      FROM record
+      ${where}
       ORDER BY last_activity DESC
       LIMIT ${pageSize} OFFSET ${offset}
     `),
@@ -92,8 +130,10 @@ async function queryUsageRecordRows(
         ? row.last_activity.toISOString()
         : new Date(row.last_activity).toISOString();
     return {
+      source: row.source as UsageRecordSource,
       threadId: row.thread_id,
-      threadTitle: row.thread_title,
+      runId: row.run_id,
+      title: row.title,
       credits: Number(row.credits),
       tokens: Number(row.tokens),
       lastActivityAt: lastActivity,
@@ -103,13 +143,14 @@ async function queryUsageRecordRows(
 
 async function queryUsageRecordTotal(
   db: Db,
-  userIdLit: string,
-  orgIdLit: string,
+  recordCte: string,
+  sourceFilterLit: string | null,
 ): Promise<number> {
+  const where = sourceFilterLit ? `WHERE source = ${sourceFilterLit}` : "";
   const result = await db.execute<{ total: string }>(
     sql.raw(`
-      ${perChatWith(userIdLit, orgIdLit)}
-      SELECT COUNT(*)::bigint AS total FROM per_chat
+      ${recordCte}
+      SELECT COUNT(*)::bigint AS total FROM record ${where}
     `),
   );
   return Number(result.rows[0]?.total ?? 0);
@@ -124,22 +165,24 @@ export const zeroUsageRecord$ = command(
     const db = set(writeDb$);
     const userIdLit = pgLit(args.userId);
     const orgIdLit = pgLit(args.orgId);
+    const sourceFilterLit = args.source ? pgLit(args.source) : null;
     const offset = (args.page - 1) * args.pageSize;
+    const recordCte = recordWith(userIdLit, orgIdLit);
 
     signal.throwIfAborted();
-    const chats = await queryUsageRecordRows(
+    const rows = await queryUsageRecordRows(
       db,
-      userIdLit,
-      orgIdLit,
+      recordCte,
+      sourceFilterLit,
       args.pageSize,
       offset,
     );
     signal.throwIfAborted();
-    const total = await queryUsageRecordTotal(db, userIdLit, orgIdLit);
+    const total = await queryUsageRecordTotal(db, recordCte, sourceFilterLit);
     signal.throwIfAborted();
 
     return {
-      chats,
+      rows,
       pagination: {
         page: args.page,
         pageSize: args.pageSize,

--- a/turbo/apps/api/src/signals/services/zero-usage-record.service.ts
+++ b/turbo/apps/api/src/signals/services/zero-usage-record.service.ts
@@ -92,12 +92,13 @@ function recordWith(userIdLit: string, orgIdLit: string): string {
         (CASE WHEN r.trigger_source = 'web' THEN 'chat' ELSE r.trigger_source END) AS source,
         NULL::text AS thread_id,
         r.run_id::text AS run_id,
-        LEFT(COALESCE(NULLIF(r.summary, ''), r.prompt), 120) AS title,
-        r.credits::bigint AS credits,
-        r.tokens::bigint AS tokens,
-        r.created_at AS last_activity
+        LEFT(COALESCE(NULLIF(MAX(r.summary), ''), MAX(r.prompt)), 120) AS title,
+        COALESCE(SUM(r.credits), 0)::bigint AS credits,
+        COALESCE(SUM(r.tokens), 0)::bigint AS tokens,
+        MAX(r.created_at) AS last_activity
       FROM runs r
       WHERE r.chat_thread_id IS NULL
+      GROUP BY r.run_id, r.trigger_source
     ),
     record AS (
       SELECT * FROM threaded

--- a/turbo/apps/platform/src/mocks/handlers/api-usage-record.ts
+++ b/turbo/apps/platform/src/mocks/handlers/api-usage-record.ts
@@ -17,12 +17,32 @@ const defaultResponse: UsageRecordResponse = {
 
 let mockUsageRecordResponse: UsageRecordResponse = { ...defaultResponse };
 
+export function setMockUsageRecord(response: UsageRecordResponse): void {
+  mockUsageRecordResponse = {
+    rows: [...response.rows],
+    pagination: { ...response.pagination },
+  };
+}
+
 export function resetMockUsageRecord(): void {
   mockUsageRecordResponse = { ...defaultResponse };
 }
 
 export const apiUsageRecordHandlers = [
-  mockApi(zeroUsageRecordContract.get, ({ respond }) => {
-    return respond(200, mockUsageRecordResponse);
+  mockApi(zeroUsageRecordContract.get, ({ query, respond }) => {
+    const page = query.page;
+    const pageSize = query.pageSize;
+    const source = query.source;
+    const rows = source
+      ? mockUsageRecordResponse.rows.filter((row) => {
+          return row.source === source;
+        })
+      : mockUsageRecordResponse.rows;
+    const offset = (page - 1) * pageSize;
+
+    return respond(200, {
+      rows: rows.slice(offset, offset + pageSize),
+      pagination: { page, pageSize, total: rows.length },
+    });
   }),
 ];

--- a/turbo/apps/platform/src/mocks/handlers/api-usage-record.ts
+++ b/turbo/apps/platform/src/mocks/handlers/api-usage-record.ts
@@ -1,0 +1,28 @@
+/**
+ * Usage Record API Handlers
+ *
+ * Mock handler for /api/zero/usage/record endpoint.
+ */
+
+import {
+  zeroUsageRecordContract,
+  type UsageRecordResponse,
+} from "@vm0/api-contracts/contracts/zero-usage-record";
+import { mockApi } from "../msw-contract.ts";
+
+const defaultResponse: UsageRecordResponse = {
+  chats: [],
+  pagination: { page: 1, pageSize: 20, total: 0 },
+};
+
+let mockUsageRecordResponse: UsageRecordResponse = { ...defaultResponse };
+
+export function resetMockUsageRecord(): void {
+  mockUsageRecordResponse = { ...defaultResponse };
+}
+
+export const apiUsageRecordHandlers = [
+  mockApi(zeroUsageRecordContract.get, ({ respond }) => {
+    return respond(200, mockUsageRecordResponse);
+  }),
+];

--- a/turbo/apps/platform/src/mocks/handlers/api-usage-record.ts
+++ b/turbo/apps/platform/src/mocks/handlers/api-usage-record.ts
@@ -11,7 +11,7 @@ import {
 import { mockApi } from "../msw-contract.ts";
 
 const defaultResponse: UsageRecordResponse = {
-  chats: [],
+  rows: [],
   pagination: { page: 1, pageSize: 20, total: 0 },
 };
 

--- a/turbo/apps/platform/src/mocks/handlers/index.ts
+++ b/turbo/apps/platform/src/mocks/handlers/index.ts
@@ -20,6 +20,10 @@ import {
   resetMockUsageInsight,
 } from "./api-usage-insight.ts";
 import {
+  apiUsageRecordHandlers,
+  resetMockUsageRecord,
+} from "./api-usage-record.ts";
+import {
   apiOrgModelProvidersHandlers,
   resetMockOrgModelProviders,
 } from "./api-org-model-providers.ts";
@@ -99,6 +103,7 @@ export const handlers = [
   ...apiOrgMembersHandlers,
   ...apiUsageHandlers,
   ...apiUsageInsightHandlers,
+  ...apiUsageRecordHandlers,
   ...apiOrgModelProvidersHandlers,
   ...apiOrgModelPoliciesHandlers,
   ...apiPersonalModelProvidersHandlers,
@@ -153,6 +158,7 @@ export function resetAllMockHandlers(): void {
   resetMockOrgMembers();
   resetMockUsageMembers();
   resetMockUsageInsight();
+  resetMockUsageRecord();
   resetMockSchedules();
   resetMockTeam();
   resetMockSkills();

--- a/turbo/apps/platform/src/signals/api-target-policy.ts
+++ b/turbo/apps/platform/src/signals/api-target-policy.ts
@@ -141,6 +141,7 @@ const API_ROUTE_ALLOWLIST: readonly ApiRouteAllowlistEntry[] = [
   { methods: ["POST"], pathname: "/api/zero/uploads/prepare" },
   { methods: ["GET"], pathname: "/api/zero/usage/insight" },
   { methods: ["GET"], pathname: "/api/zero/usage/members" },
+  { methods: ["GET"], pathname: "/api/zero/usage/record" },
   { methods: ["GET", "PUT"], pathname: "/api/zero/user-permission-grants" },
   { methods: ["GET", "POST"], pathname: "/api/zero/user-preferences" },
   { methods: ["GET", "POST"], pathname: "/api/zero/variables" },

--- a/turbo/apps/platform/src/signals/zero-page/settings/personal-usage-record.ts
+++ b/turbo/apps/platform/src/signals/zero-page/settings/personal-usage-record.ts
@@ -6,6 +6,20 @@ import {
 import { accept } from "../../../lib/accept.ts";
 import { zeroClient$ } from "../../api-client.ts";
 
+export type CreditBalanceTab = "mine" | "team";
+
+const creditBalanceTabState$ = state<CreditBalanceTab>("mine");
+
+export const creditBalanceTab$ = computed((get) => {
+  return get(creditBalanceTabState$);
+});
+
+export const setCreditBalanceTab$ = command(
+  ({ set }, tab: CreditBalanceTab) => {
+    set(creditBalanceTabState$, tab);
+  },
+);
+
 const PAGE_STEP = 20;
 
 // How many rows to request. "Load more" grows this and the async computed

--- a/turbo/apps/platform/src/signals/zero-page/settings/personal-usage-record.ts
+++ b/turbo/apps/platform/src/signals/zero-page/settings/personal-usage-record.ts
@@ -1,0 +1,27 @@
+import { command, computed, state } from "ccstate";
+import { zeroUsageRecordContract } from "@vm0/api-contracts/contracts/zero-usage-record";
+import { accept } from "../../../lib/accept.ts";
+import { zeroClient$ } from "../../api-client.ts";
+
+const PAGE_STEP = 20;
+
+// How many chats to request. "Load more" grows this and the async computed
+// re-fetches from page 1 so the list stays a single contiguous, time-ordered
+// record rather than juggling appended pages.
+const internalPageSize$ = state(PAGE_STEP);
+
+export const loadMoreUsageRecord$ = command(({ get, set }) => {
+  set(internalPageSize$, get(internalPageSize$) + PAGE_STEP);
+});
+
+export const usageRecordAsync$ = computed(async (get) => {
+  const pageSize = get(internalPageSize$);
+  const createClient = get(zeroClient$);
+  const client = createClient(zeroUsageRecordContract);
+  const result = await accept(
+    client.get({ query: { page: 1, pageSize } }),
+    [200],
+    { toast: false },
+  );
+  return result.body;
+});

--- a/turbo/apps/platform/src/signals/zero-page/settings/personal-usage-record.ts
+++ b/turbo/apps/platform/src/signals/zero-page/settings/personal-usage-record.ts
@@ -1,14 +1,32 @@
 import { command, computed, state } from "ccstate";
-import { zeroUsageRecordContract } from "@vm0/api-contracts/contracts/zero-usage-record";
+import {
+  zeroUsageRecordContract,
+  type UsageRecordSource,
+} from "@vm0/api-contracts/contracts/zero-usage-record";
 import { accept } from "../../../lib/accept.ts";
 import { zeroClient$ } from "../../api-client.ts";
 
 const PAGE_STEP = 20;
 
-// How many chats to request. "Load more" grows this and the async computed
+// How many rows to request. "Load more" grows this and the async computed
 // re-fetches from page 1 so the list stays a single contiguous, time-ordered
 // record rather than juggling appended pages.
 const internalPageSize$ = state(PAGE_STEP);
+
+// Active source filter. `null` means all sources.
+const sourceFilter$ = state<UsageRecordSource | null>(null);
+
+export const usageSourceFilter$ = computed((get) => {
+  return get(sourceFilter$);
+});
+
+export const setUsageSourceFilter$ = command(
+  ({ set }, source: UsageRecordSource | null) => {
+    set(sourceFilter$, source);
+    // Reset paging so a narrower filter doesn't start mid-list.
+    set(internalPageSize$, PAGE_STEP);
+  },
+);
 
 export const loadMoreUsageRecord$ = command(({ get, set }) => {
   set(internalPageSize$, get(internalPageSize$) + PAGE_STEP);
@@ -16,10 +34,13 @@ export const loadMoreUsageRecord$ = command(({ get, set }) => {
 
 export const usageRecordAsync$ = computed(async (get) => {
   const pageSize = get(internalPageSize$);
+  const source = get(sourceFilter$);
   const createClient = get(zeroClient$);
   const client = createClient(zeroUsageRecordContract);
   const result = await accept(
-    client.get({ query: { page: 1, pageSize } }),
+    client.get({
+      query: { page: 1, pageSize, ...(source ? { source } : {}) },
+    }),
     [200],
     { toast: false },
   );

--- a/turbo/apps/platform/src/signals/zero-page/settings/settings-dialog.ts
+++ b/turbo/apps/platform/src/signals/zero-page/settings/settings-dialog.ts
@@ -27,11 +27,12 @@ export type SettingsSection = (typeof SETTINGS_SECTIONS)[number];
 type OrgManageOnlySettingsSection = "providers";
 type UnifiedSettingsSection = SettingsSection | OrgManageOnlySettingsSection;
 
+// `usage` (Credit balance) is intentionally not admin-only: it holds personal
+// usage that every member can see. The team layer inside it is gated separately.
 const ADMIN_ONLY_SETTINGS_SECTIONS_LIST = [
   "general",
   "people",
   "billing",
-  "usage",
   "invoices",
 ] as const satisfies readonly SettingsSection[];
 

--- a/turbo/apps/platform/src/views/zero-page/__tests__/credit-balance-section.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/credit-balance-section.test.tsx
@@ -1,0 +1,139 @@
+import { beforeEach, describe, expect, it } from "vitest";
+import { screen, waitFor, within } from "@testing-library/react";
+import type {
+  UsageRecordResponse,
+  UsageRecordRow,
+  UsageRecordSource,
+} from "@vm0/api-contracts/contracts/zero-usage-record";
+
+import {
+  click,
+  detachedSetupPage,
+  queryAllByRoleFast,
+} from "../../../__tests__/page-helper.ts";
+import { resetMockBilling } from "../../../mocks/handlers/api-billing.ts";
+import { resetMockOrg, setMockOrg } from "../../../mocks/handlers/api-org.ts";
+import {
+  resetMockUsageRecord,
+  setMockUsageRecord,
+} from "../../../mocks/handlers/api-usage-record.ts";
+import { testContext } from "../../../signals/__tests__/test-helpers.ts";
+import { openSettingsDialogAt$ } from "../../../signals/zero-page/settings/settings-dialog.ts";
+
+const context = testContext();
+
+function usageRow(args: {
+  title: string;
+  source: UsageRecordSource;
+  index: number;
+}): UsageRecordRow {
+  const suffix = args.index.toString().padStart(12, "0");
+  return {
+    source: args.source,
+    threadId:
+      args.source === "chat" ? `00000000-0000-4000-a000-${suffix}` : null,
+    runId: args.source === "chat" ? null : `10000000-0000-4000-a000-${suffix}`,
+    title: args.title,
+    credits: args.index * 10,
+    tokens: args.index * 100,
+    lastActivityAt: `2026-03-${args.index.toString().padStart(2, "0")}T12:00:00.000Z`,
+  };
+}
+
+function setUsageRows(rows: UsageRecordRow[]): void {
+  const response: UsageRecordResponse = {
+    rows,
+    pagination: { page: 1, pageSize: 20, total: rows.length },
+  };
+  setMockUsageRecord(response);
+}
+
+async function openCreditBalanceSection(): Promise<HTMLElement> {
+  detachedSetupPage({ context, path: "/" });
+  await waitFor(() => {
+    expect(screen.getByText("Default Org")).toBeInTheDocument();
+  });
+
+  await context.store.set(openSettingsDialogAt$, "usage", context.signal);
+
+  await waitFor(() => {
+    expect(screen.getByRole("dialog")).toBeInTheDocument();
+  });
+  return screen.getByRole("dialog");
+}
+
+function findByFastRoleText(
+  role: Parameters<typeof queryAllByRoleFast>[0],
+  label: string | RegExp,
+  container?: ParentNode,
+): HTMLElement {
+  const element = queryAllByRoleFast(role, container).find((el) => {
+    const text = el.textContent?.trim() ?? "";
+    return typeof label === "string" ? text === label : label.test(text);
+  });
+  if (!element) {
+    throw new Error(`Unable to find ${role} with label ${label.toString()}`);
+  }
+  return element;
+}
+
+beforeEach(() => {
+  resetMockBilling();
+  resetMockOrg();
+  resetMockUsageRecord();
+});
+
+describe("credit balance settings section", () => {
+  it("opens personal usage for non-admin members without team controls", async () => {
+    setMockOrg({ role: "member" });
+    setUsageRows([
+      usageRow({ title: "Member chat", source: "chat", index: 1 }),
+    ]);
+
+    const dialog = await openCreditBalanceSection();
+
+    await waitFor(() => {
+      expect(within(dialog).getByText("Member chat")).toBeInTheDocument();
+    });
+    expect(within(dialog).getByText("All sources")).toBeInTheDocument();
+    expect(within(dialog).queryByText("Team usage")).not.toBeInTheDocument();
+  });
+
+  it("loads additional personal rows and filters by source", async () => {
+    setMockOrg({ role: "member" });
+    setUsageRows([
+      ...Array.from({ length: 20 }, (_, index) => {
+        const n = index + 1;
+        return usageRow({
+          title: `Chat ${n.toString().padStart(2, "0")}`,
+          source: "chat",
+          index: n,
+        });
+      }),
+      usageRow({ title: "Slack ticket", source: "slack", index: 21 }),
+    ]);
+
+    const dialog = await openCreditBalanceSection();
+
+    await waitFor(() => {
+      expect(within(dialog).getByText("Chat 01")).toBeInTheDocument();
+    });
+    expect(within(dialog).queryByText("Slack ticket")).not.toBeInTheDocument();
+
+    click(findByFastRoleText("button", "Load more", dialog));
+    await waitFor(() => {
+      expect(within(dialog).getByText("Slack ticket")).toBeInTheDocument();
+    });
+
+    click(findByFastRoleText("button", /All sources/i, dialog));
+    await waitFor(() => {
+      expect(findByFastRoleText("menuitem", "Slack")).toBeInTheDocument();
+    });
+    click(findByFastRoleText("menuitem", "Slack"));
+
+    await waitFor(() => {
+      expect(within(dialog).getByText("Slack ticket")).toBeInTheDocument();
+      expect(within(dialog).queryByText("Chat 01")).not.toBeInTheDocument();
+    });
+  });
+});

--- a/turbo/apps/platform/src/views/zero-page/components/org-manage/org-usage-tab.tsx
+++ b/turbo/apps/platform/src/views/zero-page/components/org-manage/org-usage-tab.tsx
@@ -290,6 +290,46 @@ function CreditBalanceChart({
 }
 
 // ---------------------------------------------------------------------------
+// Credit balance card
+// ---------------------------------------------------------------------------
+
+/**
+ * The org credit balance summary card (total, breakdown bar, grants). Lives at
+ * the top of the Credit balance section — above the Mine/Team tabs — so it stays
+ * visible regardless of the active tab. Also reused standalone in the org-manage
+ * dialog's Credit balance page.
+ */
+export function CreditBalanceCard({
+  onComparePlans,
+}: {
+  onComparePlans?: () => void;
+}) {
+  const billingLoadable = useLoadable(billingStatusAsync$);
+  const billing =
+    billingLoadable.state === "hasData" ? billingLoadable.data : null;
+  const billingLoading = billingLoadable.state === "loading";
+
+  return (
+    <div className="overflow-hidden rounded-xl bg-card zero-border">
+      {billingLoading && !billing ? (
+        <div className="px-5 py-4 space-y-2">
+          <div className="h-4 w-48 rounded bg-muted/50 animate-pulse" />
+          <div className="h-1.5 w-full rounded-full bg-muted/40 animate-pulse" />
+        </div>
+      ) : billing ? (
+        <CreditBalanceChart billing={billing} onComparePlans={onComparePlans} />
+      ) : (
+        <div className="px-5 py-4">
+          <p className="text-sm text-muted-foreground">
+            Credit balance unavailable.
+          </p>
+        </div>
+      )}
+    </div>
+  );
+}
+
+// ---------------------------------------------------------------------------
 // Sub-components
 // ---------------------------------------------------------------------------
 
@@ -338,14 +378,19 @@ function LoadingSkeleton() {
 // Overview section
 // ---------------------------------------------------------------------------
 
-function OverviewSection({ onComparePlans }: { onComparePlans?: () => void }) {
+function OverviewSection({
+  onComparePlans,
+  showCreditBalance = true,
+}: {
+  onComparePlans?: () => void;
+  showCreditBalance?: boolean;
+}) {
   const usageLoadable = useLoadable(usageMembersAsync$);
   const membersLoadable = useLoadable(orgMembers$);
   const billingLoadable = useLoadable(billingStatusAsync$);
 
   const billing =
     billingLoadable.state === "hasData" ? billingLoadable.data : null;
-  const billingLoading = billingLoadable.state === "loading";
   const currentTier = apiTierToBillingTier(billing?.tier);
 
   const usageLoading = usageLoadable.state === "loading";
@@ -368,27 +413,11 @@ function OverviewSection({ onComparePlans }: { onComparePlans?: () => void }) {
 
   return (
     <div className="flex flex-col gap-8">
-      <section className="flex flex-col gap-3">
-        <div className="overflow-hidden rounded-xl bg-card zero-border">
-          {billingLoading && !billing ? (
-            <div className="px-5 py-4 space-y-2">
-              <div className="h-4 w-48 rounded bg-muted/50 animate-pulse" />
-              <div className="h-1.5 w-full rounded-full bg-muted/40 animate-pulse" />
-            </div>
-          ) : billing ? (
-            <CreditBalanceChart
-              billing={billing}
-              onComparePlans={onComparePlans}
-            />
-          ) : (
-            <div className="px-5 py-4">
-              <p className="text-sm text-muted-foreground">
-                Credit balance unavailable.
-              </p>
-            </div>
-          )}
-        </div>
-      </section>
+      {showCreditBalance && (
+        <section className="flex flex-col gap-3">
+          <CreditBalanceCard onComparePlans={onComparePlans} />
+        </section>
+      )}
 
       {/* Members — only for paid plans */}
       {(currentTier === "pro" || currentTier === "team") && (
@@ -494,8 +523,15 @@ function MembersTable({
 
 export function OrgUsageTab({
   onComparePlans,
+  showCreditBalance = true,
 }: {
   onComparePlans?: () => void;
+  showCreditBalance?: boolean;
 }) {
-  return <OverviewSection onComparePlans={onComparePlans} />;
+  return (
+    <OverviewSection
+      onComparePlans={onComparePlans}
+      showCreditBalance={showCreditBalance}
+    />
+  );
 }

--- a/turbo/apps/platform/src/views/zero-page/components/preferences/personal-providers-tab.tsx
+++ b/turbo/apps/platform/src/views/zero-page/components/preferences/personal-providers-tab.tsx
@@ -25,7 +25,6 @@ import { PersonalProviderDialog } from "../settings/personal-provider-dialog.tsx
 import { PersonalClaudeCodeDeviceAuthDialog } from "../settings/claude-code-device-auth-dialog.tsx";
 import { PersonalCodexDeviceAuthDialog } from "../settings/codex-device-auth-dialog.tsx";
 import { SettingsSectionHeading } from "../settings/settings-section-heading.tsx";
-import { PersonalUsageRecord } from "./personal-usage-record.tsx";
 
 type OAuthStatus = "connected" | "stale" | "missing";
 
@@ -33,7 +32,6 @@ export function PersonalProvidersTab() {
   return (
     <div className="flex flex-col gap-8">
       <OAuthCredentialsSection />
-      <PersonalUsageRecord />
       <PersonalProviderDialog />
       <PersonalClaudeCodeDeviceAuthDialog />
       <PersonalCodexDeviceAuthDialog />

--- a/turbo/apps/platform/src/views/zero-page/components/preferences/personal-providers-tab.tsx
+++ b/turbo/apps/platform/src/views/zero-page/components/preferences/personal-providers-tab.tsx
@@ -25,6 +25,7 @@ import { PersonalProviderDialog } from "../settings/personal-provider-dialog.tsx
 import { PersonalClaudeCodeDeviceAuthDialog } from "../settings/claude-code-device-auth-dialog.tsx";
 import { PersonalCodexDeviceAuthDialog } from "../settings/codex-device-auth-dialog.tsx";
 import { SettingsSectionHeading } from "../settings/settings-section-heading.tsx";
+import { PersonalUsageRecord } from "./personal-usage-record.tsx";
 
 type OAuthStatus = "connected" | "stale" | "missing";
 
@@ -32,6 +33,7 @@ export function PersonalProvidersTab() {
   return (
     <div className="flex flex-col gap-8">
       <OAuthCredentialsSection />
+      <PersonalUsageRecord />
       <PersonalProviderDialog />
       <PersonalClaudeCodeDeviceAuthDialog />
       <PersonalCodexDeviceAuthDialog />

--- a/turbo/apps/platform/src/views/zero-page/components/preferences/personal-usage-record.tsx
+++ b/turbo/apps/platform/src/views/zero-page/components/preferences/personal-usage-record.tsx
@@ -24,7 +24,6 @@ import {
 } from "@vm0/ui";
 import {
   loadMoreUsageRecord$,
-  setUsageSourceFilter$,
   usageRecordAsync$,
   usageSourceFilter$,
 } from "../../../../signals/zero-page/settings/personal-usage-record.ts";
@@ -78,7 +77,7 @@ function formatDate(iso: string): string {
   }).format(date);
 }
 
-function SourceFilter({
+export function SourceFilter({
   value,
   onChange,
 }: {
@@ -130,20 +129,23 @@ function SourceFilter({
 function UsageRow({ row }: { row: UsageRecordRow }) {
   const { label, Icon } = SOURCE_META[row.source];
   const title = row.title && row.title.length > 0 ? row.title : "Untitled";
-  const credits = row.credits > 0 ? `−${formatCredits(row.credits)}` : "0";
+  const credits = `${formatCredits(row.credits)} credits`;
   const inner = (
     <>
-      <span className="flex w-28 shrink-0 items-center gap-2 text-xs text-muted-foreground">
-        <Icon size={15} stroke={1.5} className="shrink-0" />
-        <span className="truncate">{label}</span>
+      <span
+        title={label}
+        aria-label={label}
+        className="flex h-8 w-8 shrink-0 items-center justify-center rounded-lg bg-muted/50 text-muted-foreground"
+      >
+        <Icon size={17} stroke={1.5} />
       </span>
       <span className="min-w-0 flex-1 truncate text-sm font-medium text-foreground">
         {title}
       </span>
-      <span className="w-16 shrink-0 text-right text-xs text-muted-foreground tabular-nums">
+      <span className="shrink-0 text-right text-xs text-muted-foreground tabular-nums">
         {formatDate(row.lastActivityAt)}
       </span>
-      <span className="w-16 shrink-0 text-right text-sm font-medium text-foreground tabular-nums">
+      <span className="shrink-0 whitespace-nowrap text-right text-sm font-medium text-foreground tabular-nums">
         {credits}
       </span>
     </>
@@ -200,18 +202,10 @@ function UsageRecordSkeleton() {
 export function PersonalUsageRecord() {
   const loadable = useLastLoadable(usageRecordAsync$);
   const loadMore = useSet(loadMoreUsageRecord$);
-  const setFilter = useSet(setUsageSourceFilter$);
   const filter = useGet(usageSourceFilter$);
 
   return (
     <section className="flex flex-col gap-4">
-      <div className="flex items-center justify-between gap-3">
-        <p className="text-sm text-muted-foreground">
-          What each run has spent, newest first.
-        </p>
-        <SourceFilter value={filter} onChange={setFilter} />
-      </div>
-
       {loadable.state === "loading" && <UsageRecordSkeleton />}
       {loadable.state === "hasError" && (
         <p className="text-sm text-muted-foreground" role="alert">
@@ -227,12 +221,6 @@ export function PersonalUsageRecord() {
           </p>
         ) : (
           <div className="flex flex-col gap-3">
-            <div className="flex items-center gap-3 px-5 text-xs font-medium text-muted-foreground">
-              <span className="w-28 shrink-0">Source</span>
-              <span className="min-w-0 flex-1">Run</span>
-              <span className="w-16 shrink-0 text-right">Date</span>
-              <span className="w-16 shrink-0 text-right">Credits</span>
-            </div>
             <div
               className="overflow-hidden rounded-xl bg-card"
               style={{ border: CARD_BORDER }}

--- a/turbo/apps/platform/src/views/zero-page/components/preferences/personal-usage-record.tsx
+++ b/turbo/apps/platform/src/views/zero-page/components/preferences/personal-usage-record.tsx
@@ -32,10 +32,7 @@ import { Link } from "../../../router/link.tsx";
 
 const CARD_BORDER = "0.7px solid hsl(var(--gray-400))";
 
-const SOURCE_META: Record<
-  UsageRecordSource,
-  { label: string; Icon: typeof IconMessageCircle }
-> = {
+const SOURCE_META = {
   chat: { label: "Chat", Icon: IconMessageCircle },
   schedule: { label: "Schedule", Icon: IconClock },
   slack: { label: "Slack", Icon: IconBrandSlack },
@@ -45,15 +42,18 @@ const SOURCE_META: Record<
   github: { label: "GitHub", Icon: IconBrandGithub },
   cli: { label: "CLI", Icon: IconTerminal2 },
   agent: { label: "Agent", Icon: IconRobot },
-};
+} as const satisfies Record<
+  UsageRecordSource,
+  { label: string; Icon: typeof IconMessageCircle }
+>;
 
 // Sources offered in the filter. Others still appear under "All sources".
-const FILTER_OPTIONS: UsageRecordSource[] = [
+const FILTER_OPTIONS = [
   "chat",
   "schedule",
   "slack",
   "telegram",
-];
+] as const satisfies readonly UsageRecordSource[];
 
 const ROW_CLASS =
   "flex items-center gap-3 px-5 py-3.5 transition-colors hover:bg-[hsl(var(--gray-50))] [&:not(:first-child)]:border-t [&:not(:first-child)]:border-border/50";

--- a/turbo/apps/platform/src/views/zero-page/components/preferences/personal-usage-record.tsx
+++ b/turbo/apps/platform/src/views/zero-page/components/preferences/personal-usage-record.tsx
@@ -79,6 +79,10 @@ function formatDate(iso: string): string {
   }).format(date);
 }
 
+function usageRowKey(row: UsageRecordRow): string {
+  return `${row.source}:${row.threadId ?? row.runId ?? row.lastActivityAt}`;
+}
+
 export function SourceFilter({
   value,
   onChange,
@@ -228,9 +232,7 @@ export function PersonalUsageRecord() {
               style={{ border: CARD_BORDER }}
             >
               {loadable.data.rows.map((row) => {
-                return (
-                  <UsageRow key={row.threadId ?? row.runId ?? ""} row={row} />
-                );
+                return <UsageRow key={usageRowKey(row)} row={row} />;
               })}
             </div>
             {loadable.data.rows.length < loadable.data.pagination.total && (

--- a/turbo/apps/platform/src/views/zero-page/components/preferences/personal-usage-record.tsx
+++ b/turbo/apps/platform/src/views/zero-page/components/preferences/personal-usage-record.tsx
@@ -142,7 +142,7 @@ export function PersonalUsageRecord() {
       {loadable.state === "loading" && <UsageRecordSkeleton />}
       {loadable.state === "hasError" && (
         <p className="text-sm text-muted-foreground" role="alert">
-          Couldn't load your usage record. Please try again later.
+          Couldn&apos;t load your usage record. Please try again later.
         </p>
       )}
       {loadable.state === "hasData" &&

--- a/turbo/apps/platform/src/views/zero-page/components/preferences/personal-usage-record.tsx
+++ b/turbo/apps/platform/src/views/zero-page/components/preferences/personal-usage-record.tsx
@@ -41,6 +41,7 @@ const SOURCE_META = {
   github: { label: "GitHub", Icon: IconBrandGithub },
   cli: { label: "CLI", Icon: IconTerminal2 },
   agent: { label: "Agent", Icon: IconRobot },
+  other: { label: "Other", Icon: IconRobot },
 } as const satisfies Record<
   UsageRecordSource,
   { label: string; Icon: typeof IconMessageCircle }
@@ -52,6 +53,7 @@ const FILTER_OPTIONS = [
   "schedule",
   "slack",
   "telegram",
+  "other",
 ] as const satisfies readonly UsageRecordSource[];
 
 const ROW_CLASS =

--- a/turbo/apps/platform/src/views/zero-page/components/preferences/personal-usage-record.tsx
+++ b/turbo/apps/platform/src/views/zero-page/components/preferences/personal-usage-record.tsx
@@ -1,0 +1,191 @@
+import { useLastLoadable, useSet } from "ccstate-react";
+import type { UsageRecordChatRow } from "@vm0/api-contracts/contracts/zero-usage-record";
+import { Button } from "@vm0/ui";
+import {
+  loadMoreUsageRecord$,
+  usageRecordAsync$,
+} from "../../../../signals/zero-page/settings/personal-usage-record.ts";
+import { Link } from "../../../router/link.tsx";
+import { SettingsSectionHeading } from "../settings/settings-section-heading.tsx";
+
+const CARD_BORDER = "0.7px solid hsl(var(--gray-400))";
+
+function formatCredits(n: number): string {
+  if (n >= 1_000_000) {
+    return `${(n / 1_000_000).toFixed(1)}M`;
+  }
+  if (n >= 1000) {
+    return `${(n / 1000).toFixed(1)}K`;
+  }
+  return n.toLocaleString();
+}
+
+function startOfLocalDay(date: Date): number {
+  return new Date(
+    date.getFullYear(),
+    date.getMonth(),
+    date.getDate(),
+  ).getTime();
+}
+
+// "Today" / "Yesterday" / "Jun 1, 2026" for a chat's most recent activity.
+function dayLabel(date: Date, todayStart: number): string {
+  const dayStart = startOfLocalDay(date);
+  const diffDays = Math.round((todayStart - dayStart) / 86_400_000);
+  if (diffDays <= 0) {
+    return "Today";
+  }
+  if (diffDays === 1) {
+    return "Yesterday";
+  }
+  return new Intl.DateTimeFormat("en-US", {
+    month: "short",
+    day: "numeric",
+    year: "numeric",
+  }).format(date);
+}
+
+// Time of day for today's rows, otherwise the calendar date.
+function rowWhen(date: Date, todayStart: number): string {
+  const isToday = startOfLocalDay(date) >= todayStart;
+  if (isToday) {
+    return new Intl.DateTimeFormat("en-US", {
+      hour: "numeric",
+      minute: "2-digit",
+    }).format(date);
+  }
+  return new Intl.DateTimeFormat("en-US", {
+    month: "short",
+    day: "numeric",
+  }).format(date);
+}
+
+interface DayGroup {
+  label: string;
+  chats: UsageRecordChatRow[];
+}
+
+// Rows arrive newest-first, so grouping consecutively preserves time order.
+function groupByDay(chats: UsageRecordChatRow[]): DayGroup[] {
+  const todayStart = startOfLocalDay(new Date());
+  const groups: DayGroup[] = [];
+  for (const chat of chats) {
+    const label = dayLabel(new Date(chat.lastActivityAt), todayStart);
+    const last = groups[groups.length - 1];
+    if (last && last.label === label) {
+      last.chats.push(chat);
+    } else {
+      groups.push({ label, chats: [chat] });
+    }
+  }
+  return groups;
+}
+
+function UsageRecordRow({ chat }: { chat: UsageRecordChatRow }) {
+  const todayStart = startOfLocalDay(new Date());
+  const when = rowWhen(new Date(chat.lastActivityAt), todayStart);
+  const title =
+    chat.threadTitle && chat.threadTitle.length > 0
+      ? chat.threadTitle
+      : "Untitled chat";
+  return (
+    <Link
+      pathname="/chats/:threadId"
+      options={{ pathParams: { threadId: chat.threadId } }}
+      className="flex items-center gap-3 px-5 py-3.5 transition-colors hover:bg-[hsl(var(--gray-50))] [&:not(:first-child)]:border-t [&:not(:first-child)]:border-border/50"
+    >
+      <span className="min-w-0 flex-1 truncate text-sm font-medium text-foreground">
+        {title}
+      </span>
+      <span className="shrink-0 text-xs text-muted-foreground tabular-nums">
+        {when}
+      </span>
+      <span className="w-16 shrink-0 text-right text-sm font-medium text-foreground tabular-nums">
+        {chat.credits > 0 ? `−${formatCredits(chat.credits)}` : "0"}
+      </span>
+    </Link>
+  );
+}
+
+function UsageRecordSkeleton() {
+  return (
+    <div
+      className="overflow-hidden rounded-xl bg-card"
+      style={{ border: CARD_BORDER }}
+    >
+      {[0, 1, 2].map((i) => {
+        return (
+          <div
+            key={i}
+            className="flex animate-pulse items-center gap-3 px-5 py-3.5 [&:not(:first-child)]:border-t [&:not(:first-child)]:border-border/50"
+          >
+            <span className="h-4 w-40 rounded bg-muted/50" />
+            <span className="ml-auto h-3 w-10 rounded bg-muted/30" />
+            <span className="h-4 w-12 rounded bg-muted/40" />
+          </div>
+        );
+      })}
+    </div>
+  );
+}
+
+export function PersonalUsageRecord() {
+  const loadable = useLastLoadable(usageRecordAsync$);
+  const loadMore = useSet(loadMoreUsageRecord$);
+
+  return (
+    <section className="flex flex-col gap-4">
+      <SettingsSectionHeading
+        title="Usage record"
+        description="What each chat has spent, newest first."
+      />
+      {loadable.state === "loading" && <UsageRecordSkeleton />}
+      {loadable.state === "hasError" && (
+        <p className="text-sm text-muted-foreground" role="alert">
+          Couldn't load your usage record. Please try again later.
+        </p>
+      )}
+      {loadable.state === "hasData" &&
+        (loadable.data.chats.length === 0 ? (
+          <p className="text-sm text-muted-foreground">
+            No usage yet. Your chats will show up here as you use credits.
+          </p>
+        ) : (
+          <div className="flex flex-col gap-5">
+            {groupByDay(loadable.data.chats).map((group) => {
+              return (
+                <div key={group.label} className="flex flex-col gap-2">
+                  <p className="px-1 text-xs font-medium text-muted-foreground">
+                    {group.label}
+                  </p>
+                  <div
+                    className="overflow-hidden rounded-xl bg-card"
+                    style={{ border: CARD_BORDER }}
+                  >
+                    {group.chats.map((chat) => {
+                      return <UsageRecordRow key={chat.threadId} chat={chat} />;
+                    })}
+                  </div>
+                </div>
+              );
+            })}
+            {loadable.data.chats.length < loadable.data.pagination.total && (
+              <div className="flex justify-center">
+                <Button
+                  type="button"
+                  variant="ghost"
+                  size="sm"
+                  className="h-9 rounded-lg text-muted-foreground hover:bg-[hsl(var(--gray-50))] hover:text-foreground"
+                  onClick={() => {
+                    loadMore();
+                  }}
+                >
+                  Load more
+                </Button>
+              </div>
+            )}
+          </div>
+        ))}
+    </section>
+  );
+}

--- a/turbo/apps/platform/src/views/zero-page/components/preferences/personal-usage-record.tsx
+++ b/turbo/apps/platform/src/views/zero-page/components/preferences/personal-usage-record.tsx
@@ -1,14 +1,62 @@
-import { useLastLoadable, useSet } from "ccstate-react";
-import type { UsageRecordChatRow } from "@vm0/api-contracts/contracts/zero-usage-record";
-import { Button } from "@vm0/ui";
+import { useGet, useLastLoadable, useSet } from "ccstate-react";
+import {
+  IconBrandGithub,
+  IconBrandSlack,
+  IconBrandTelegram,
+  IconChevronDown,
+  IconClock,
+  IconMail,
+  IconMessageCircle,
+  IconPhone,
+  IconRobot,
+  IconTerminal2,
+} from "@tabler/icons-react";
+import type {
+  UsageRecordRow,
+  UsageRecordSource,
+} from "@vm0/api-contracts/contracts/zero-usage-record";
+import {
+  Button,
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuTrigger,
+} from "@vm0/ui";
 import {
   loadMoreUsageRecord$,
+  setUsageSourceFilter$,
   usageRecordAsync$,
+  usageSourceFilter$,
 } from "../../../../signals/zero-page/settings/personal-usage-record.ts";
 import { Link } from "../../../router/link.tsx";
-import { SettingsSectionHeading } from "../settings/settings-section-heading.tsx";
 
 const CARD_BORDER = "0.7px solid hsl(var(--gray-400))";
+
+const SOURCE_META: Record<
+  UsageRecordSource,
+  { label: string; Icon: typeof IconMessageCircle }
+> = {
+  chat: { label: "Chat", Icon: IconMessageCircle },
+  schedule: { label: "Schedule", Icon: IconClock },
+  slack: { label: "Slack", Icon: IconBrandSlack },
+  telegram: { label: "Telegram", Icon: IconBrandTelegram },
+  email: { label: "Email", Icon: IconMail },
+  agentphone: { label: "Phone", Icon: IconPhone },
+  github: { label: "GitHub", Icon: IconBrandGithub },
+  cli: { label: "CLI", Icon: IconTerminal2 },
+  agent: { label: "Agent", Icon: IconRobot },
+};
+
+// Sources offered in the filter. Others still appear under "All sources".
+const FILTER_OPTIONS: UsageRecordSource[] = [
+  "chat",
+  "schedule",
+  "slack",
+  "telegram",
+];
+
+const ROW_CLASS =
+  "flex items-center gap-3 px-5 py-3.5 transition-colors hover:bg-[hsl(var(--gray-50))] [&:not(:first-child)]:border-t [&:not(:first-child)]:border-border/50";
 
 function formatCredits(n: number): string {
   if (n >= 1_000_000) {
@@ -20,91 +68,110 @@ function formatCredits(n: number): string {
   return n.toLocaleString();
 }
 
-function startOfLocalDay(date: Date): number {
-  return new Date(
-    date.getFullYear(),
-    date.getMonth(),
-    date.getDate(),
-  ).getTime();
-}
-
-// "Today" / "Yesterday" / "Jun 1, 2026" for a chat's most recent activity.
-function dayLabel(date: Date, todayStart: number): string {
-  const dayStart = startOfLocalDay(date);
-  const diffDays = Math.round((todayStart - dayStart) / 86_400_000);
-  if (diffDays <= 0) {
-    return "Today";
-  }
-  if (diffDays === 1) {
-    return "Yesterday";
-  }
+function formatDate(iso: string): string {
+  const date = new Date(iso);
+  const sameYear = date.getFullYear() === new Date().getFullYear();
   return new Intl.DateTimeFormat("en-US", {
     month: "short",
     day: "numeric",
-    year: "numeric",
+    ...(sameYear ? {} : { year: "numeric" }),
   }).format(date);
 }
 
-// Time of day for today's rows, otherwise the calendar date.
-function rowWhen(date: Date, todayStart: number): string {
-  const isToday = startOfLocalDay(date) >= todayStart;
-  if (isToday) {
-    return new Intl.DateTimeFormat("en-US", {
-      hour: "numeric",
-      minute: "2-digit",
-    }).format(date);
-  }
-  return new Intl.DateTimeFormat("en-US", {
-    month: "short",
-    day: "numeric",
-  }).format(date);
-}
-
-interface DayGroup {
-  label: string;
-  chats: UsageRecordChatRow[];
-}
-
-// Rows arrive newest-first, so grouping consecutively preserves time order.
-function groupByDay(chats: UsageRecordChatRow[]): DayGroup[] {
-  const todayStart = startOfLocalDay(new Date());
-  const groups: DayGroup[] = [];
-  for (const chat of chats) {
-    const label = dayLabel(new Date(chat.lastActivityAt), todayStart);
-    const last = groups[groups.length - 1];
-    if (last && last.label === label) {
-      last.chats.push(chat);
-    } else {
-      groups.push({ label, chats: [chat] });
-    }
-  }
-  return groups;
-}
-
-function UsageRecordRow({ chat }: { chat: UsageRecordChatRow }) {
-  const todayStart = startOfLocalDay(new Date());
-  const when = rowWhen(new Date(chat.lastActivityAt), todayStart);
-  const title =
-    chat.threadTitle && chat.threadTitle.length > 0
-      ? chat.threadTitle
-      : "Untitled chat";
+function SourceFilter({
+  value,
+  onChange,
+}: {
+  value: UsageRecordSource | null;
+  onChange: (source: UsageRecordSource | null) => void;
+}) {
+  const label = value ? SOURCE_META[value].label : "All sources";
   return (
-    <Link
-      pathname="/chats/:threadId"
-      options={{ pathParams: { threadId: chat.threadId } }}
-      className="flex items-center gap-3 px-5 py-3.5 transition-colors hover:bg-[hsl(var(--gray-50))] [&:not(:first-child)]:border-t [&:not(:first-child)]:border-border/50"
-    >
+    <DropdownMenu>
+      <DropdownMenuTrigger asChild>
+        <Button
+          variant="outline"
+          size="sm"
+          className="zero-btn-morandi h-9 shrink-0 rounded-lg border"
+        >
+          {label}
+          <IconChevronDown
+            size={14}
+            stroke={1.5}
+            className="ml-1.5 text-muted-foreground"
+          />
+        </Button>
+      </DropdownMenuTrigger>
+      <DropdownMenuContent align="end" className="w-44">
+        <DropdownMenuItem
+          onClick={() => {
+            onChange(null);
+          }}
+        >
+          All sources
+        </DropdownMenuItem>
+        {FILTER_OPTIONS.map((source) => {
+          return (
+            <DropdownMenuItem
+              key={source}
+              onClick={() => {
+                onChange(source);
+              }}
+            >
+              {SOURCE_META[source].label}
+            </DropdownMenuItem>
+          );
+        })}
+      </DropdownMenuContent>
+    </DropdownMenu>
+  );
+}
+
+function UsageRow({ row }: { row: UsageRecordRow }) {
+  const { label, Icon } = SOURCE_META[row.source];
+  const title = row.title && row.title.length > 0 ? row.title : "Untitled";
+  const credits = row.credits > 0 ? `−${formatCredits(row.credits)}` : "0";
+  const inner = (
+    <>
+      <span className="flex w-28 shrink-0 items-center gap-2 text-xs text-muted-foreground">
+        <Icon size={15} stroke={1.5} className="shrink-0" />
+        <span className="truncate">{label}</span>
+      </span>
       <span className="min-w-0 flex-1 truncate text-sm font-medium text-foreground">
         {title}
       </span>
-      <span className="shrink-0 text-xs text-muted-foreground tabular-nums">
-        {when}
+      <span className="w-16 shrink-0 text-right text-xs text-muted-foreground tabular-nums">
+        {formatDate(row.lastActivityAt)}
       </span>
       <span className="w-16 shrink-0 text-right text-sm font-medium text-foreground tabular-nums">
-        {chat.credits > 0 ? `−${formatCredits(chat.credits)}` : "0"}
+        {credits}
       </span>
-    </Link>
+    </>
   );
+
+  if (row.threadId) {
+    return (
+      <Link
+        pathname="/chats/:threadId"
+        options={{ pathParams: { threadId: row.threadId } }}
+        className={ROW_CLASS}
+      >
+        {inner}
+      </Link>
+    );
+  }
+  if (row.runId) {
+    return (
+      <Link
+        pathname="/activities/:activityRunId"
+        options={{ pathParams: { activityRunId: row.runId } }}
+        className={ROW_CLASS}
+      >
+        {inner}
+      </Link>
+    );
+  }
+  return <div className={ROW_CLASS}>{inner}</div>;
 }
 
 function UsageRecordSkeleton() {
@@ -119,6 +186,7 @@ function UsageRecordSkeleton() {
             key={i}
             className="flex animate-pulse items-center gap-3 px-5 py-3.5 [&:not(:first-child)]:border-t [&:not(:first-child)]:border-border/50"
           >
+            <span className="h-4 w-20 rounded bg-muted/40" />
             <span className="h-4 w-40 rounded bg-muted/50" />
             <span className="ml-auto h-3 w-10 rounded bg-muted/30" />
             <span className="h-4 w-12 rounded bg-muted/40" />
@@ -132,13 +200,18 @@ function UsageRecordSkeleton() {
 export function PersonalUsageRecord() {
   const loadable = useLastLoadable(usageRecordAsync$);
   const loadMore = useSet(loadMoreUsageRecord$);
+  const setFilter = useSet(setUsageSourceFilter$);
+  const filter = useGet(usageSourceFilter$);
 
   return (
     <section className="flex flex-col gap-4">
-      <SettingsSectionHeading
-        title="Usage record"
-        description="What each chat has spent, newest first."
-      />
+      <div className="flex items-center justify-between gap-3">
+        <p className="text-sm text-muted-foreground">
+          What each run has spent, newest first.
+        </p>
+        <SourceFilter value={filter} onChange={setFilter} />
+      </div>
+
       {loadable.state === "loading" && <UsageRecordSkeleton />}
       {loadable.state === "hasError" && (
         <p className="text-sm text-muted-foreground" role="alert">
@@ -146,30 +219,31 @@ export function PersonalUsageRecord() {
         </p>
       )}
       {loadable.state === "hasData" &&
-        (loadable.data.chats.length === 0 ? (
+        (loadable.data.rows.length === 0 ? (
           <p className="text-sm text-muted-foreground">
-            No usage yet. Your chats will show up here as you use credits.
+            {filter
+              ? "No usage from this source yet."
+              : "No usage yet. Your runs will show up here as you use credits."}
           </p>
         ) : (
-          <div className="flex flex-col gap-5">
-            {groupByDay(loadable.data.chats).map((group) => {
-              return (
-                <div key={group.label} className="flex flex-col gap-2">
-                  <p className="px-1 text-xs font-medium text-muted-foreground">
-                    {group.label}
-                  </p>
-                  <div
-                    className="overflow-hidden rounded-xl bg-card"
-                    style={{ border: CARD_BORDER }}
-                  >
-                    {group.chats.map((chat) => {
-                      return <UsageRecordRow key={chat.threadId} chat={chat} />;
-                    })}
-                  </div>
-                </div>
-              );
-            })}
-            {loadable.data.chats.length < loadable.data.pagination.total && (
+          <div className="flex flex-col gap-3">
+            <div className="flex items-center gap-3 px-5 text-xs font-medium text-muted-foreground">
+              <span className="w-28 shrink-0">Source</span>
+              <span className="min-w-0 flex-1">Run</span>
+              <span className="w-16 shrink-0 text-right">Date</span>
+              <span className="w-16 shrink-0 text-right">Credits</span>
+            </div>
+            <div
+              className="overflow-hidden rounded-xl bg-card"
+              style={{ border: CARD_BORDER }}
+            >
+              {loadable.data.rows.map((row) => {
+                return (
+                  <UsageRow key={row.threadId ?? row.runId ?? ""} row={row} />
+                );
+              })}
+            </div>
+            {loadable.data.rows.length < loadable.data.pagination.total && (
               <div className="flex justify-center">
                 <Button
                   type="button"

--- a/turbo/apps/platform/src/views/zero-page/components/settings/sections/credit-balance-section.tsx
+++ b/turbo/apps/platform/src/views/zero-page/components/settings/sections/credit-balance-section.tsx
@@ -1,18 +1,50 @@
-import { useSet } from "ccstate-react";
+import { useState } from "react";
+import { useLoadable, useSet } from "ccstate-react";
+import { Tabs, TabsList, TabsTrigger } from "@vm0/ui";
 import { OrgUsageTab } from "../../org-manage/org-usage-tab.tsx";
+import { PersonalUsageRecord } from "../../preferences/personal-usage-record.tsx";
+import { isOrgAdmin$ } from "../../../../../signals/org.ts";
 import { setSettingsActiveSection$ } from "../../../../../signals/zero-page/settings/settings-dialog.ts";
 import { setBillingSubPage$ } from "../../../../../signals/zero-page/settings/org-manage-tabs-state.ts";
+
+type CreditBalanceTab = "mine" | "team";
 
 export function CreditBalanceSection() {
   const setActiveSection = useSet(setSettingsActiveSection$);
   const setBillingSubPage = useSet(setBillingSubPage$);
+  const isAdminLoadable = useLoadable(isOrgAdmin$);
+  const isAdmin =
+    isAdminLoadable.state === "hasData" ? isAdminLoadable.data : false;
+  const [tab, setTab] = useState<CreditBalanceTab>("mine");
+
+  // Non-admins only have personal usage — no Team layer, so skip the tabs.
+  if (!isAdmin) {
+    return <PersonalUsageRecord />;
+  }
 
   return (
-    <OrgUsageTab
-      onComparePlans={() => {
-        setActiveSection("billing");
-        setBillingSubPage(true);
-      }}
-    />
+    <div className="flex flex-col gap-6">
+      <Tabs
+        value={tab}
+        onValueChange={(value) => {
+          setTab(value as CreditBalanceTab);
+        }}
+      >
+        <TabsList>
+          <TabsTrigger value="mine">Mine</TabsTrigger>
+          <TabsTrigger value="team">Team</TabsTrigger>
+        </TabsList>
+      </Tabs>
+      {tab === "mine" ? (
+        <PersonalUsageRecord />
+      ) : (
+        <OrgUsageTab
+          onComparePlans={() => {
+            setActiveSection("billing");
+            setBillingSubPage(true);
+          }}
+        />
+      )}
+    </div>
   );
 }

--- a/turbo/apps/platform/src/views/zero-page/components/settings/sections/credit-balance-section.tsx
+++ b/turbo/apps/platform/src/views/zero-page/components/settings/sections/credit-balance-section.tsx
@@ -1,6 +1,9 @@
 import { useGet, useLoadable, useSet } from "ccstate-react";
 import { Tabs, TabsList, TabsTrigger } from "@vm0/ui";
-import { OrgUsageTab } from "../../org-manage/org-usage-tab.tsx";
+import {
+  OrgUsageTab,
+  CreditBalanceCard,
+} from "../../org-manage/org-usage-tab.tsx";
 import { PersonalUsageRecord } from "../../preferences/personal-usage-record.tsx";
 import { isOrgAdmin$ } from "../../../../../signals/org.ts";
 import { setSettingsActiveSection$ } from "../../../../../signals/zero-page/settings/settings-dialog.ts";
@@ -20,13 +23,28 @@ export function CreditBalanceSection() {
   const tab = useGet(creditBalanceTab$);
   const setTab = useSet(setCreditBalanceTab$);
 
+  const goToComparePlans = () => {
+    setActiveSection("billing");
+    setBillingSubPage(true);
+  };
+
+  // The credit balance card stays at the section level — above the Mine/Team
+  // tabs — so it's always visible regardless of the active tab.
+  const creditCard = <CreditBalanceCard onComparePlans={goToComparePlans} />;
+
   // Non-admins only have personal usage — no Team layer, so skip the tabs.
   if (!isAdmin) {
-    return <PersonalUsageRecord />;
+    return (
+      <div className="flex flex-col gap-6">
+        {creditCard}
+        <PersonalUsageRecord />
+      </div>
+    );
   }
 
   return (
     <div className="flex flex-col gap-6">
+      {creditCard}
       <Tabs
         value={tab}
         onValueChange={(value) => {
@@ -42,10 +60,8 @@ export function CreditBalanceSection() {
         <PersonalUsageRecord />
       ) : (
         <OrgUsageTab
-          onComparePlans={() => {
-            setActiveSection("billing");
-            setBillingSubPage(true);
-          }}
+          showCreditBalance={false}
+          onComparePlans={goToComparePlans}
         />
       )}
     </div>

--- a/turbo/apps/platform/src/views/zero-page/components/settings/sections/credit-balance-section.tsx
+++ b/turbo/apps/platform/src/views/zero-page/components/settings/sections/credit-balance-section.tsx
@@ -4,13 +4,18 @@ import {
   OrgUsageTab,
   CreditBalanceCard,
 } from "../../org-manage/org-usage-tab.tsx";
-import { PersonalUsageRecord } from "../../preferences/personal-usage-record.tsx";
+import {
+  PersonalUsageRecord,
+  SourceFilter,
+} from "../../preferences/personal-usage-record.tsx";
 import { isOrgAdmin$ } from "../../../../../signals/org.ts";
 import { setSettingsActiveSection$ } from "../../../../../signals/zero-page/settings/settings-dialog.ts";
 import { setBillingSubPage$ } from "../../../../../signals/zero-page/settings/org-manage-tabs-state.ts";
 import {
   creditBalanceTab$,
   setCreditBalanceTab$,
+  usageSourceFilter$,
+  setUsageSourceFilter$,
   type CreditBalanceTab,
 } from "../../../../../signals/zero-page/settings/personal-usage-record.ts";
 
@@ -22,22 +27,34 @@ export function CreditBalanceSection() {
     isAdminLoadable.state === "hasData" ? isAdminLoadable.data : false;
   const tab = useGet(creditBalanceTab$);
   const setTab = useSet(setCreditBalanceTab$);
+  const sourceFilter = useGet(usageSourceFilter$);
+  const setSourceFilter = useSet(setUsageSourceFilter$);
 
   const goToComparePlans = () => {
     setActiveSection("billing");
     setBillingSubPage(true);
   };
 
-  // The credit balance card stays at the section level — above the Mine/Team
-  // tabs — so it's always visible regardless of the active tab.
+  // The credit balance card stays at the section level — above the
+  // My usage / Team usage tabs — so it's always visible regardless of the
+  // active tab.
   const creditCard = <CreditBalanceCard onComparePlans={goToComparePlans} />;
 
-  // Non-admins only have personal usage — no Team layer, so skip the tabs.
+  // The source filter only applies to the personal (My usage) list.
+  const personalFilter = (
+    <SourceFilter value={sourceFilter} onChange={setSourceFilter} />
+  );
+
+  // Non-admins only have personal usage — no Team layer, so skip the tabs and
+  // keep just the filter aligned to the right of the list.
   if (!isAdmin) {
     return (
       <div className="flex flex-col gap-6">
         {creditCard}
-        <PersonalUsageRecord />
+        <div className="flex flex-col gap-4">
+          <div className="flex items-center justify-end">{personalFilter}</div>
+          <PersonalUsageRecord />
+        </div>
       </div>
     );
   }
@@ -45,25 +62,31 @@ export function CreditBalanceSection() {
   return (
     <div className="flex flex-col gap-6">
       {creditCard}
-      <Tabs
-        value={tab}
-        onValueChange={(value) => {
-          setTab(value as CreditBalanceTab);
-        }}
-      >
-        <TabsList>
-          <TabsTrigger value="mine">Mine</TabsTrigger>
-          <TabsTrigger value="team">Team</TabsTrigger>
-        </TabsList>
-      </Tabs>
-      {tab === "mine" ? (
-        <PersonalUsageRecord />
-      ) : (
-        <OrgUsageTab
-          showCreditBalance={false}
-          onComparePlans={goToComparePlans}
-        />
-      )}
+      <div className="flex flex-col gap-4">
+        {/* One compact header row: tabs on the left, source filter on the right. */}
+        <div className="flex items-center justify-between gap-3">
+          <Tabs
+            value={tab}
+            onValueChange={(value) => {
+              setTab(value as CreditBalanceTab);
+            }}
+          >
+            <TabsList>
+              <TabsTrigger value="mine">My usage</TabsTrigger>
+              <TabsTrigger value="team">Team usage</TabsTrigger>
+            </TabsList>
+          </Tabs>
+          {tab === "mine" ? personalFilter : null}
+        </div>
+        {tab === "mine" ? (
+          <PersonalUsageRecord />
+        ) : (
+          <OrgUsageTab
+            showCreditBalance={false}
+            onComparePlans={goToComparePlans}
+          />
+        )}
+      </div>
     </div>
   );
 }

--- a/turbo/apps/platform/src/views/zero-page/components/settings/sections/credit-balance-section.tsx
+++ b/turbo/apps/platform/src/views/zero-page/components/settings/sections/credit-balance-section.tsx
@@ -1,13 +1,15 @@
-import { useState } from "react";
-import { useLoadable, useSet } from "ccstate-react";
+import { useGet, useLoadable, useSet } from "ccstate-react";
 import { Tabs, TabsList, TabsTrigger } from "@vm0/ui";
 import { OrgUsageTab } from "../../org-manage/org-usage-tab.tsx";
 import { PersonalUsageRecord } from "../../preferences/personal-usage-record.tsx";
 import { isOrgAdmin$ } from "../../../../../signals/org.ts";
 import { setSettingsActiveSection$ } from "../../../../../signals/zero-page/settings/settings-dialog.ts";
 import { setBillingSubPage$ } from "../../../../../signals/zero-page/settings/org-manage-tabs-state.ts";
-
-type CreditBalanceTab = "mine" | "team";
+import {
+  creditBalanceTab$,
+  setCreditBalanceTab$,
+  type CreditBalanceTab,
+} from "../../../../../signals/zero-page/settings/personal-usage-record.ts";
 
 export function CreditBalanceSection() {
   const setActiveSection = useSet(setSettingsActiveSection$);
@@ -15,7 +17,8 @@ export function CreditBalanceSection() {
   const isAdminLoadable = useLoadable(isOrgAdmin$);
   const isAdmin =
     isAdminLoadable.state === "hasData" ? isAdminLoadable.data : false;
-  const [tab, setTab] = useState<CreditBalanceTab>("mine");
+  const tab = useGet(creditBalanceTab$);
+  const setTab = useSet(setCreditBalanceTab$);
 
   // Non-admins only have personal usage — no Team layer, so skip the tabs.
   if (!isAdmin) {

--- a/turbo/apps/platform/src/views/zero-page/components/settings/settings-dialog.tsx
+++ b/turbo/apps/platform/src/views/zero-page/components/settings/settings-dialog.tsx
@@ -81,8 +81,7 @@ const SECTION_META = {
   },
   usage: {
     title: "Credit balance",
-    description:
-      "Credit balance and per-member credit consumption this billing period.",
+    description: "Your usage by source, plus the team's credit balance.",
   },
   invoices: {
     title: "Invoices",
@@ -130,14 +129,25 @@ const MODELS_GROUP = {
   items: [{ id: "model", label: "Models", icon: IconCpu }],
 } as const satisfies SidebarGroup;
 
-const BILLING_GROUP = {
-  label: "Billing & pricing",
-  items: [
-    { id: "billing", label: "Billing", icon: IconCreditCard },
-    { id: "usage", label: "Credit balance", icon: IconCoins },
-    { id: "invoices", label: "Invoices", icon: IconFileInvoice },
-  ],
-} as const satisfies SidebarGroup;
+// Credit balance is visible to everyone (it holds personal usage); Billing and
+// Invoices stay admin-only. The group is assembled per-viewer in the component.
+const CREDIT_BALANCE_ITEM = {
+  id: "usage",
+  label: "Credit balance",
+  icon: IconCoins,
+} as const satisfies SidebarItem;
+
+const BILLING_ADMIN_ITEMS = [
+  { id: "billing", label: "Billing", icon: IconCreditCard },
+  { id: "invoices", label: "Invoices", icon: IconFileInvoice },
+] as const satisfies readonly SidebarItem[];
+
+function billingGroup(isAdmin: boolean): SidebarGroup {
+  return {
+    label: "Billing & pricing",
+    items: [CREDIT_BALANCE_ITEM, ...(isAdmin ? BILLING_ADMIN_ITEMS : [])],
+  };
+}
 
 const SECTION_COMPONENTS = {
   preference: () => {
@@ -202,7 +212,7 @@ export function SettingsDialog({ open, onOpenChange }: SettingsDialogProps) {
     PERSONAL_GROUP,
     ...(isAdmin ? [WORKSPACE_GROUP] : []),
     MODELS_GROUP,
-    ...(isAdmin ? [BILLING_GROUP] : []),
+    billingGroup(isAdmin),
   ];
 
   // If the user lost admin while the dialog is open, fall back to a safe section

--- a/turbo/apps/web/api-backend-rewrites.js
+++ b/turbo/apps/web/api-backend-rewrites.js
@@ -973,6 +973,7 @@ export const API_BACKEND_REWRITES = [
   ["/api/zero/onboarding/status", "/api/zero/onboarding/status"],
   ["/api/zero/usage/insight", "/api/zero/usage/insight"],
   ["/api/zero/usage/members", "/api/zero/usage/members"],
+  ["/api/zero/usage/record", "/api/zero/usage/record"],
   ["/api/zero/usage/runs", "/api/zero/usage/runs"],
   ["/api/zero/video-io/generate", "/api/zero/video-io/generate"],
   ["/api/zero/host/deployments/prepare", "/api/zero/host/deployments/prepare"],

--- a/turbo/packages/api-contracts/src/contracts/index.ts
+++ b/turbo/packages/api-contracts/src/contracts/index.ts
@@ -1178,6 +1178,12 @@ export {
   type UsageInsightChatRow,
 } from "./zero-usage-insight";
 export {
+  zeroUsageRecordContract,
+  type ZeroUsageRecordContract,
+  type UsageRecordResponse,
+  type UsageRecordChatRow,
+} from "./zero-usage-record";
+export {
   usageContract,
   type UsageContract,
   type DailyUsage,

--- a/turbo/packages/api-contracts/src/contracts/index.ts
+++ b/turbo/packages/api-contracts/src/contracts/index.ts
@@ -1179,9 +1179,11 @@ export {
 } from "./zero-usage-insight";
 export {
   zeroUsageRecordContract,
+  usageRecordSourceSchema,
   type ZeroUsageRecordContract,
   type UsageRecordResponse,
-  type UsageRecordChatRow,
+  type UsageRecordRow,
+  type UsageRecordSource,
 } from "./zero-usage-record";
 export {
   usageContract,

--- a/turbo/packages/api-contracts/src/contracts/zero-usage-record.ts
+++ b/turbo/packages/api-contracts/src/contracts/zero-usage-record.ts
@@ -4,8 +4,9 @@ import { apiErrorSchema } from "./errors";
 
 const c = initContract();
 
-// Where a run originated. `chat` is web chat (trigger_source 'web'); the rest
-// mirror zero_runs.trigger_source so each row can be attributed to its surface.
+// Where a run originated. `chat` is web chat (trigger_source 'web'); known
+// trigger sources keep their surface, and unsupported historical values are
+// grouped as `other`.
 export const usageRecordSourceSchema = z.enum([
   "chat",
   "schedule",
@@ -16,6 +17,7 @@ export const usageRecordSourceSchema = z.enum([
   "github",
   "cli",
   "agent",
+  "other",
 ]);
 
 export type UsageRecordSource = z.infer<typeof usageRecordSourceSchema>;

--- a/turbo/packages/api-contracts/src/contracts/zero-usage-record.ts
+++ b/turbo/packages/api-contracts/src/contracts/zero-usage-record.ts
@@ -1,0 +1,49 @@
+import { z } from "zod";
+import { authHeadersSchema, initContract } from "./base";
+import { apiErrorSchema } from "./errors";
+
+const c = initContract();
+
+// A single chat thread's usage, aggregated across all its runs. Ordered by
+// the most recent activity so the list reads as a chronological record.
+const usageRecordChatRowSchema = z.object({
+  threadId: z.string(),
+  threadTitle: z.string().nullable(),
+  credits: z.number(),
+  tokens: z.number(),
+  // ISO string of the most recent usage event in this chat.
+  lastActivityAt: z.string(),
+});
+
+const usageRecordResponseSchema = z.object({
+  chats: z.array(usageRecordChatRowSchema),
+  pagination: z.object({
+    page: z.number(),
+    pageSize: z.number(),
+    total: z.number(),
+  }),
+});
+
+export const zeroUsageRecordContract = c.router({
+  get: {
+    method: "GET",
+    path: "/api/zero/usage/record",
+    headers: authHeadersSchema,
+    query: z.object({
+      page: z.coerce.number().int().positive().default(1),
+      pageSize: z.coerce.number().int().positive().max(100).default(20),
+    }),
+    responses: {
+      200: usageRecordResponseSchema,
+      400: apiErrorSchema,
+      401: apiErrorSchema,
+      500: apiErrorSchema,
+    },
+    summary:
+      "Get the signed-in user's per-chat usage record, ordered by recent activity",
+  },
+});
+
+export type ZeroUsageRecordContract = typeof zeroUsageRecordContract;
+export type UsageRecordResponse = z.infer<typeof usageRecordResponseSchema>;
+export type UsageRecordChatRow = z.infer<typeof usageRecordChatRowSchema>;

--- a/turbo/packages/api-contracts/src/contracts/zero-usage-record.ts
+++ b/turbo/packages/api-contracts/src/contracts/zero-usage-record.ts
@@ -4,19 +4,41 @@ import { apiErrorSchema } from "./errors";
 
 const c = initContract();
 
-// A single chat thread's usage, aggregated across all its runs. Ordered by
-// the most recent activity so the list reads as a chronological record.
-const usageRecordChatRowSchema = z.object({
-  threadId: z.string(),
-  threadTitle: z.string().nullable(),
+// Where a run originated. `chat` is web chat (trigger_source 'web'); the rest
+// mirror zero_runs.trigger_source so each row can be attributed to its surface.
+export const usageRecordSourceSchema = z.enum([
+  "chat",
+  "schedule",
+  "slack",
+  "telegram",
+  "email",
+  "agentphone",
+  "github",
+  "cli",
+  "agent",
+]);
+
+export type UsageRecordSource = z.infer<typeof usageRecordSourceSchema>;
+
+// One usage row. Threaded sources (chat, schedule) aggregate every run in the
+// thread into a single row that links to the thread; unthreaded sources are one
+// row per run that links to the run's activity detail. Ordered by most recent
+// activity so the list reads as a chronological record.
+const usageRecordRowSchema = z.object({
+  source: usageRecordSourceSchema,
+  // Set for threaded sources (web chat, schedule) — links to the chat thread.
+  threadId: z.string().nullable(),
+  // Set for unthreaded sources (slack, telegram, …) — links to the run.
+  runId: z.string().nullable(),
+  title: z.string().nullable(),
   credits: z.number(),
   tokens: z.number(),
-  // ISO string of the most recent usage event in this chat.
+  // ISO string of the most recent run in this row.
   lastActivityAt: z.string(),
 });
 
 const usageRecordResponseSchema = z.object({
-  chats: z.array(usageRecordChatRowSchema),
+  rows: z.array(usageRecordRowSchema),
   pagination: z.object({
     page: z.number(),
     pageSize: z.number(),
@@ -32,6 +54,7 @@ export const zeroUsageRecordContract = c.router({
     query: z.object({
       page: z.coerce.number().int().positive().default(1),
       pageSize: z.coerce.number().int().positive().max(100).default(20),
+      source: usageRecordSourceSchema.optional(),
     }),
     responses: {
       200: usageRecordResponseSchema,
@@ -40,10 +63,10 @@ export const zeroUsageRecordContract = c.router({
       500: apiErrorSchema,
     },
     summary:
-      "Get the signed-in user's per-chat usage record, ordered by recent activity",
+      "Get the signed-in user's usage record across sources, ordered by recent activity",
   },
 });
 
 export type ZeroUsageRecordContract = typeof zeroUsageRecordContract;
 export type UsageRecordResponse = z.infer<typeof usageRecordResponseSchema>;
-export type UsageRecordChatRow = z.infer<typeof usageRecordChatRowSchema>;
+export type UsageRecordRow = z.infer<typeof usageRecordRowSchema>;


### PR DESCRIPTION
## What

Reworks the personal usage record into a single **Credit balance** hub, per the design iteration with Ming.

- **One entry point.** Usage now lives under Settings → Billing & pricing → **Credit balance**, reachable by **every member** (it holds personal usage). Billing and Invoices stay admin-only.
- **Mine / Team split.** `Mine` is the personal usage table; `Team` (admins only) keeps the existing org credit balance + per-member consumption.
- **By source, in one table.** Each row is tagged with its source — Chat / Schedule / Slack / Telegram / … — sortable as one chronological list, with an "All sources" filter and load-more. Replaces the old day-grouped, chat-only list.

The per-chat record is **moved out of Models → Personal**; Models is back to credentials only.

## Changes

**Backend (`apps/api` + contract)**
- `GET /api/zero/usage/record` now spans every source via `zero_runs.trigger_source` instead of only chat-thread runs. Threaded sources (web chat, schedule) aggregate per thread; everything else is one row per run. `web` surfaces as `chat`. Added an optional `source` query filter.
- Row shape is now `{ source, threadId, runId, title, credits, tokens, lastActivityAt }`. Threaded rows link to the chat thread; unthreaded rows link to the run's activity detail.

**Frontend (`apps/platform`)**
- `CreditBalanceSection` gains the `Mine / Team` tabs; non-admins see `Mine` only.
- `PersonalUsageRecord` rebuilt as a single source-tagged table (Source / Run / Date / Credits) with a source filter; removed from `PersonalProvidersTab`.
- Settings nav: `Credit balance` is no longer admin-only; the Team layer is gated inside the section.
- MSW handler + signal updated for the new shape and `source` filter.

## Notes
- **iMessage** is not a `trigger_source` today, so it is not surfaced. The source enum mirrors `zero_runs.trigger_source` (chat/schedule/slack/telegram/email/agentphone/github/cli/agent).
- Integration tests updated to cover cross-source rows, schedule labeling, the `source` filter, and pagination.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
