### PR TITLE
test: remove registry internal patch propagation tests

### DIFF
--- a/crates/runner/mitm-addon/tests/test_registry.py
+++ b/crates/runner/mitm-addon/tests/test_registry.py
@@ -5,8 +5,6 @@ import os
 from types import SimpleNamespace
 from unittest.mock import MagicMock, patch
 
-import pytest
-
 import matching
 import registry
 from tests.auth_state_helpers import (
@@ -364,36 +362,6 @@ class TestLoadRegistry:
 
         assert log.warn.call_count == 2
         assert all("Failed to parse" in call.args[0] for call in log.warn.call_args_list)
-
-    def test_compile_registry_failure_propagates(self, registry_file):
-        registry.load_registry(str(registry_file))
-        registry_file.write_text(json.dumps({"vms": {"10.200.0.99": {"runId": "new-run"}}}))
-
-        with (
-            patch.object(registry.ctx, "log", MagicMock(), create=True),
-            patch.object(
-                registry,
-                "_compile_registry",
-                side_effect=RuntimeError("compile failed"),
-            ),
-            pytest.raises(RuntimeError, match="compile failed"),
-        ):
-            registry.load_registry(str(registry_file))
-
-    def test_auth_cache_eviction_failure_propagates(self, registry_file):
-        registry.load_registry(str(registry_file))
-        registry_file.write_text(json.dumps({"vms": {"10.200.0.99": {"runId": "new-run"}}}))
-
-        with (
-            patch.object(registry.ctx, "log", MagicMock(), create=True),
-            patch.object(
-                registry,
-                "evict_stale_cache_keys",
-                side_effect=RuntimeError("evict failed"),
-            ),
-            pytest.raises(RuntimeError, match="evict failed"),
-        ):
-            registry.load_registry(str(registry_file))
 
     def test_read_failure_after_stat_does_not_poison_file_key(self, registry_file):
         registry.load_registry(str(registry_file))


### PR DESCRIPTION
## Summary

Closes #16158.

- Remove two registry tests that only patched internal implementation details to force exceptions.
- Keep the existing behavior-focused coverage that exercises real registry files, matcher compilation, and auth cache eviction.
- Leave production code and malformed firewall/network-policy semantics unchanged.

## Coverage Rationale

Existing tests already cover the relevant observable registry behavior:

- `test_compiled_context_updates_after_successful_registry_change`
- `test_parse_failure_returns_no_compiled_context`
- `test_missing_file_returns_no_compiled_context`
- `test_malformed_network_policy_shape_compiles_without_load_failure`
- `test_malformed_firewall_config_compiles_without_load_failure`
- `test_evicts_header_cache_on_run_removal`
- `test_valid_entry_becoming_invalid_evicts_context_and_cache`
- `test_invalid_vm_entries_do_not_block_header_cache_eviction`

The deleted tests only verified Python propagation through patched internal helpers, so no replacement internal patch test was added.

## Validation

Passed:

- `cd crates/runner/mitm-addon && .venv/bin/pytest tests/test_registry.py -q`
- `cd crates/runner/mitm-addon && .venv/bin/ruff check tests/test_registry.py`
- `cd crates/runner/mitm-addon && .venv/bin/basedpyright tests/test_registry.py`
- `cd turbo && pnpm format`
- `cd turbo && pnpm knip`
- `cd turbo/apps/web && pnpm exec oxlint --threads=1`
- `cd turbo/apps/web && pnpm exec oxlint --threads=1 --type-aware -c ../../.oxlintrc.typeaware.json`
- `cd turbo/apps/web && pnpm exec eslint . --max-warnings 0`

Local full-suite blockers observed:

- `cd turbo && pnpm turbo run lint` failed in `web#lint` because default `oxlint` reported `Cannot allocate memory (os error 12)` while opening files; the same web lint commands passed with `--threads=1`.
- `cd turbo && pnpm check-types` failed in `@vm0/connectors` because `packages/connectors/src/firewalls/index.ts` imports missing `./cursor.generated`.
- `cd turbo && pnpm vitest` failed for the same missing `./cursor.generated` import across platform tests, plus `@vm0/desktop` native computer-use tests that require macOS accessibility support.
