### PR TITLE
fix: add artifact root diagnostics

### DIFF
--- a/crates/guest-agent/src/checkpoint.rs
+++ b/crates/guest-agent/src/checkpoint.rs
@@ -10,7 +10,7 @@ use crate::paths;
 use crate::session_history;
 use bytes::Bytes;
 use guest_common::telemetry::record_sandbox_op;
-use guest_common::{log_error, log_info, log_warn};
+use guest_common::{fs_status, log_error, log_info, log_warn};
 use serde_json::json;
 use sha2::{Digest, Sha256};
 use std::io::ErrorKind;
@@ -181,6 +181,13 @@ async fn snapshot_artifact_entries(
 
     let mut plans = Vec::with_capacity(entries.len());
     for entry in entries {
+        log_info!(
+            LOG_TAG,
+            "Artifact root status before checkpoint walk: name={} version={} {}",
+            entry.name,
+            entry.version_id,
+            fs_status::describe_path(&entry.mount_path)
+        );
         log_info!(
             LOG_TAG,
             "Processing artifact '{}' at {}",

--- a/crates/guest-agent/src/cli/mod.rs
+++ b/crates/guest-agent/src/cli/mod.rs
@@ -38,7 +38,7 @@ use agent_diagnostics::{FailureDetailSource, FailureReason};
 use event_delivery::{AckedEventPrefix, PreparedEvent};
 use framework::CliFrameworkBehavior;
 use guest_common::telemetry::record_sandbox_op;
-use guest_common::{log_info, log_warn};
+use guest_common::{fs_status, log_info, log_warn};
 use std::collections::HashMap;
 use std::path::Path;
 use std::process::Stdio;
@@ -47,6 +47,18 @@ use termination::{TerminationReason, TerminationState};
 use tokio::io::{AsyncBufReadExt, AsyncWriteExt};
 
 const LOG_TAG: &str = "sandbox:guest-agent";
+
+fn log_artifact_root_statuses(phase: &str) {
+    for artifact in env::artifacts() {
+        log_info!(
+            LOG_TAG,
+            "Artifact root status {phase}: name={} version={} {}",
+            artifact.name,
+            artifact.version_id,
+            fs_status::describe_path(&artifact.mount_path)
+        );
+    }
+}
 
 async fn tick_optional_interval(interval: &mut Option<tokio::time::Interval>) {
     match interval {
@@ -168,6 +180,8 @@ pub async fn execute_cli(
             }
         }
     }
+
+    log_artifact_root_statuses("before CLI spawn");
 
     // Open the run log before spawning the CLI. If the run-id-scoped path is
     // invalid or unavailable, fail without starting a child process.
@@ -389,6 +403,7 @@ pub async fn execute_cli(
                     Ok(s) => {
                         cli_exit_at = Some(Instant::now());
                         log_info!(LOG_TAG, "CLI process exited (status: {s}), draining stdout");
+                        log_artifact_root_statuses("after CLI process exit");
                         cli_status = Some(s);
                         // CLI exited on its own (possibly in response to our
                         // SIGTERM). Park the termination FSM so it can't

--- a/crates/guest-common/src/fs_status.rs
+++ b/crates/guest-common/src/fs_status.rs
@@ -1,0 +1,134 @@
+//! Filesystem status helpers for guest diagnostics.
+
+use std::fs;
+use std::io;
+use std::path::Path;
+
+const DIRECTORY_ENTRY_COUNT_LIMIT: usize = 100;
+
+/// Describe a path without reading file contents or logging directory names.
+///
+/// The output is intentionally compact and stable for system-log diagnostics.
+/// Missing paths include parent status so callers can distinguish a missing
+/// mount root from a missing parent tree.
+pub fn describe_path(path: impl AsRef<Path>) -> String {
+    let path = path.as_ref();
+    match fs::symlink_metadata(path) {
+        Ok(metadata) => {
+            let file_type = metadata.file_type();
+            format!(
+                "path={} status={} len={}",
+                path.display(),
+                file_type_label(&file_type),
+                metadata.len()
+            )
+        }
+        Err(error) if error.kind() == io::ErrorKind::NotFound => {
+            format!(
+                "path={} status=missing {}",
+                path.display(),
+                describe_parent(path)
+            )
+        }
+        Err(error) => {
+            format!(
+                "path={} status=error errorKind={:?} error={}",
+                path.display(),
+                error.kind(),
+                error
+            )
+        }
+    }
+}
+
+fn file_type_label(file_type: &fs::FileType) -> &'static str {
+    if file_type.is_dir() {
+        "dir"
+    } else if file_type.is_file() {
+        "file"
+    } else if file_type.is_symlink() {
+        "symlink"
+    } else {
+        "other"
+    }
+}
+
+fn describe_parent(path: &Path) -> String {
+    let Some(parent) = path.parent() else {
+        return "parentPath=<none> parentStatus=none".to_string();
+    };
+
+    match fs::symlink_metadata(parent) {
+        Ok(metadata) => {
+            let file_type = metadata.file_type();
+            let status = file_type_label(&file_type);
+            if file_type.is_dir() {
+                format!(
+                    "parentPath={} parentStatus={} parentEntryCount={}",
+                    parent.display(),
+                    status,
+                    directory_entry_count(parent)
+                )
+            } else {
+                format!("parentPath={} parentStatus={}", parent.display(), status)
+            }
+        }
+        Err(error) if error.kind() == io::ErrorKind::NotFound => {
+            format!("parentPath={} parentStatus=missing", parent.display())
+        }
+        Err(error) => {
+            format!(
+                "parentPath={} parentStatus=error parentErrorKind={:?} parentError={}",
+                parent.display(),
+                error.kind(),
+                error
+            )
+        }
+    }
+}
+
+fn directory_entry_count(path: &Path) -> String {
+    let entries = match fs::read_dir(path) {
+        Ok(entries) => entries,
+        Err(error) => return format!("error({:?})", error.kind()),
+    };
+
+    let mut count = 0usize;
+    for entry in entries {
+        if entry.is_ok() {
+            count += 1;
+        }
+        if count >= DIRECTORY_ENTRY_COUNT_LIMIT {
+            return format!(">={DIRECTORY_ENTRY_COUNT_LIMIT}");
+        }
+    }
+    count.to_string()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn describe_path_reports_existing_directory() {
+        let dir = tempfile::tempdir().unwrap();
+
+        let description = describe_path(dir.path());
+
+        assert!(description.contains("status=dir"));
+        assert!(description.contains("len="));
+    }
+
+    #[test]
+    fn describe_path_reports_missing_path_with_parent_status() {
+        let dir = tempfile::tempdir().unwrap();
+        fs::write(dir.path().join("sibling.txt"), "content").unwrap();
+        let missing = dir.path().join("missing");
+
+        let description = describe_path(&missing);
+
+        assert!(description.contains("status=missing"));
+        assert!(description.contains("parentStatus=dir"));
+        assert!(description.contains("parentEntryCount=1"));
+    }
+}

--- a/crates/guest-common/src/lib.rs
+++ b/crates/guest-common/src/lib.rs
@@ -4,5 +4,6 @@
 //! - Structured stderr logging macros
 //! - Sandbox operation telemetry helpers
 
+pub mod fs_status;
 pub mod log;
 pub mod telemetry;

--- a/crates/guest-download/src/download.rs
+++ b/crates/guest-download/src/download.rs
@@ -2,7 +2,7 @@ use crate::LOG_TAG;
 use crate::archive;
 use crate::error::DownloadError;
 use crate::source;
-use guest_common::{log_error, log_info, log_warn, telemetry::record_sandbox_op};
+use guest_common::{fs_status, log_error, log_info, log_warn, telemetry::record_sandbox_op};
 use std::any::Any;
 use std::collections::VecDeque;
 use std::fs;
@@ -45,6 +45,10 @@ impl DownloadTask {
 
     pub(crate) fn mount_path(&self) -> &str {
         &self.mount_path
+    }
+
+    pub(crate) fn label(&self) -> &str {
+        &self.label
     }
 
     fn failure_detail(&self, error: &DownloadError) -> String {
@@ -228,6 +232,12 @@ fn run_download_task(task: DownloadTask) -> bool {
         Ok(()) => {
             let elapsed = start.elapsed();
             record_sandbox_op(task.op_name, elapsed, true, None);
+            log_info!(
+                LOG_TAG,
+                "Download root status after task success: {} {}",
+                task.label,
+                fs_status::describe_path(&task.mount_path)
+            );
             log_info!(
                 LOG_TAG,
                 "{} downloaded in {}ms",

--- a/crates/guest-download/src/lib.rs
+++ b/crates/guest-download/src/lib.rs
@@ -14,7 +14,7 @@ mod manifest;
 mod plan;
 mod source;
 
-use guest_common::log_error;
+use guest_common::{fs_status, log_error, log_info};
 use manifest::{Manifest, ManifestLoadError};
 use plan::RunPlan;
 use std::fs;
@@ -61,9 +61,25 @@ pub fn run(manifest_path: &str) -> bool {
         }
     }
 
+    let download_roots = download_tasks
+        .iter()
+        .map(|task| (task.label().to_string(), task.mount_path().to_string()))
+        .collect::<Vec<_>>();
+
     let success = download::download_all_parallel(download_tasks);
     if success {
         instructions::normalize_instruction_files(&instruction_files);
+        log_download_root_statuses("after instruction normalization", &download_roots);
     }
     success
+}
+
+fn log_download_root_statuses(phase: &str, roots: &[(String, String)]) {
+    for (label, mount_path) in roots {
+        log_info!(
+            LOG_TAG,
+            "Download root status {phase}: {label} {}",
+            fs_status::describe_path(mount_path)
+        );
+    }
 }


### PR DESCRIPTION
## Summary
- add a shared guest filesystem status helper for compact mount-root diagnostics
- log guest-download root status after each successful download task and after instruction normalization
- log guest-agent artifact root status before CLI spawn, after CLI process exit, and before checkpoint walking

## Why
This adds the missing timeline for #16184 so we can tell whether the auto-memory artifact root:
- fails to materialize during download
- disappears during instruction normalization
- is removed during CLI execution
- is already missing only when checkpointing starts

The helper reports path type, missing-path parent status, and capped parent entry counts without logging directory entry names or file contents.

Refs #16184

## Tests
- `cargo fmt --check`
- `git diff --check`
- `CARGO_BUILD_JOBS=1 cargo test -p guest-common -p guest-download`
- `CARGO_BUILD_JOBS=1 cargo check -p guest-agent`
- pre-commit hook: crates `cargo-fmt`, `cargo-clippy`, `cargo-doc`

Attempted full local guest test coverage with `cargo test -p guest-common -p guest-download -p guest-agent`; it compiled the changed crates but failed while linking guest-agent test binaries with `/usr/bin/ld: cannot find ...: Cannot allocate memory` in this container.
