### PR TITLE
fix: hide empty memory activity days

### DIFF
--- a/turbo/apps/api/src/signals/routes/__tests__/zero-memory-activity.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/zero-memory-activity.test.ts
@@ -166,6 +166,18 @@ describe("GET /api/zero/memory/activity", () => {
       },
       context.signal,
     );
+    await store.set(
+      seedMemoryActivitySummary$,
+      {
+        orgId: fixture.orgId,
+        userId: fixture.userId,
+        date: "2025-05-04",
+        fromVersionId: "v2",
+        toVersionId: "v3",
+        summary: null,
+      },
+      context.signal,
+    );
     mocks.clerk.session(fixture.userId, fixture.orgId);
 
     const response = await accept(
@@ -212,7 +224,7 @@ describe("GET /api/zero/memory/activity", () => {
     });
   });
 
-  it("returns an entry with no items", async () => {
+  it("omits entries with no items", async () => {
     const fixture = await track(
       store.set(seedMemoryFixture$, undefined, context.signal),
     );
@@ -234,15 +246,7 @@ describe("GET /api/zero/memory/activity", () => {
       [200],
     );
 
-    expect(response.body.entries).toStrictEqual([
-      {
-        date: "2025-06-01",
-        summary: "A quiet narrative day",
-        fromVersionId: null,
-        toVersionId: "v9",
-        items: [],
-      },
-    ]);
+    expect(response.body.entries).toStrictEqual([]);
   });
 
   it("orders a summary's items deterministically by file_path", async () => {
@@ -330,6 +334,12 @@ describe("GET /api/zero/memory/activity", () => {
         date: "2025-05-12",
         toVersionId: "mine-v1",
         summary: "My memory",
+        items: [
+          {
+            filePath: "mine.md",
+            diff: addedDiff("Visible"),
+          },
+        ],
       },
       context.signal,
     );
@@ -346,7 +356,12 @@ describe("GET /api/zero/memory/activity", () => {
       summary: "My memory",
       fromVersionId: null,
       toVersionId: "mine-v1",
-      items: [],
+      items: [
+        {
+          filePath: "mine.md",
+          diff: addedDiff("Visible"),
+        },
+      ],
     });
   });
 });

--- a/turbo/apps/api/src/signals/services/zero-memory-activity.service.ts
+++ b/turbo/apps/api/src/signals/services/zero-memory-activity.service.ts
@@ -30,8 +30,8 @@ interface MemoryActivityResult {
  * purely from the precomputed `memory_change_summaries` /
  * `memory_change_items` tables (never touches S3).
  *
- * Summaries are scoped per (orgId, userId) and returned most-recent-day first;
- * each summary's deterministic change items are nested under it.
+ * Summaries are scoped per (orgId, userId) and returned most-recent-day first
+ * when they have deterministic change items to display.
  */
 export function zeroMemoryActivity(
   orgId: string,
@@ -88,15 +88,20 @@ export function zeroMemoryActivity(
       itemsBySummaryId.set(item.summaryId, bucket);
     }
 
-    const entries = summaries.map((summary): MemoryActivityEntry => {
-      return {
+    const entries: MemoryActivityEntry[] = [];
+    for (const summary of summaries) {
+      const summaryItems = itemsBySummaryId.get(summary.id) ?? [];
+      if (summaryItems.length === 0) {
+        continue;
+      }
+      entries.push({
         date: summary.date,
         summary: summary.summary,
         fromVersionId: summary.fromVersionId,
         toVersionId: summary.toVersionId,
-        items: itemsBySummaryId.get(summary.id) ?? [],
-      };
-    });
+        items: summaryItems,
+      });
+    }
 
     return { entries };
   });

--- a/turbo/packages/api-contracts/src/contracts/zero-memory-activity.ts
+++ b/turbo/packages/api-contracts/src/contracts/zero-memory-activity.ts
@@ -49,8 +49,9 @@ const memoryActivityEntrySchema = z.object({
 
 /**
  * Precomputed daily Memory Activity timeline for the current user, ordered
- * most-recent-day first. Each entry is a per-local-day net summary of memory
- * changes with structured diff evidence — served as a pure DB read.
+ * most-recent-day first. Each entry is a per-local-day net summary with at
+ * least one changed memory file and structured diff evidence — served as a
+ * pure DB read.
  */
 export const memoryActivityResponseSchema = z.object({
   entries: z.array(memoryActivityEntrySchema),


### PR DESCRIPTION
Summary:
- Hide Memory Activity days that have no changed memory files.
- Keep changed days ordered most-recent first with their diff items.
- Update the API contract comment and integration coverage for empty-day filtering.

Validation:
- pnpm -F api test src/signals/routes/__tests__/zero-memory-activity.test.ts
- pnpm -F api check-types
- pnpm -F @vm0/api-contracts check-types
- pnpm -F api lint
- pnpm -F @vm0/api-contracts lint
- pnpm exec prettier --check apps/api/src/signals/routes/__tests__/zero-memory-activity.test.ts apps/api/src/signals/services/zero-memory-activity.service.ts packages/api-contracts/src/contracts/zero-memory-activity.ts
- pnpm knip --workspace api

Note:
- pnpm knip --workspace api --workspace @vm0/api-contracts reports existing unused exports in @vm0/api-contracts public contract files.
