### PR TITLE
feat: paginate memory activity updates

### DIFF
--- a/turbo/apps/api/src/signals/routes/__tests__/zero-memory-activity.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/zero-memory-activity.test.ts
@@ -116,7 +116,7 @@ describe("GET /api/zero/memory/activity", () => {
       [200],
     );
 
-    expect(response.body).toStrictEqual({ entries: [] });
+    expect(response.body).toStrictEqual({ entries: [], nextCursor: null });
   });
 
   it("returns entries most-recent-day first with their items", async () => {
@@ -221,7 +221,89 @@ describe("GET /api/zero/memory/activity", () => {
           ],
         },
       ],
+      nextCursor: null,
     });
+  });
+
+  it("paginates summaries with a date cursor", async () => {
+    const fixture = await track(
+      store.set(seedMemoryFixture$, undefined, context.signal),
+    );
+    for (const date of ["2025-05-01", "2025-05-03"]) {
+      await store.set(
+        seedMemoryActivitySummary$,
+        {
+          orgId: fixture.orgId,
+          userId: fixture.userId,
+          date,
+          toVersionId: `v-${date}`,
+          summary: `Summary for ${date}`,
+          items: [
+            {
+              filePath: `${date}.md`,
+              diff: addedDiff(date),
+            },
+          ],
+        },
+        context.signal,
+      );
+    }
+    for (const date of ["2025-05-02", "2025-05-04"]) {
+      await store.set(
+        seedMemoryActivitySummary$,
+        {
+          orgId: fixture.orgId,
+          userId: fixture.userId,
+          date,
+          toVersionId: `empty-${date}`,
+          summary: `Empty summary for ${date}`,
+        },
+        context.signal,
+      );
+    }
+    mocks.clerk.session(fixture.userId, fixture.orgId);
+
+    const firstPage = await accept(
+      activityClient().get({
+        headers: authHeaders(),
+        query: { limit: 1 },
+      }),
+      [200],
+    );
+
+    expect(
+      firstPage.body.entries.map((entry) => {
+        return entry.date;
+      }),
+    ).toStrictEqual(["2025-05-03"]);
+    expect(firstPage.body.entries[0]?.items).toStrictEqual([
+      {
+        filePath: "2025-05-03.md",
+        diff: addedDiff("2025-05-03"),
+      },
+    ]);
+    expect(firstPage.body.nextCursor).toBe("2025-05-03");
+
+    const secondPage = await accept(
+      activityClient().get({
+        headers: authHeaders(),
+        query: { limit: 1, cursor: firstPage.body.nextCursor ?? "" },
+      }),
+      [200],
+    );
+
+    expect(
+      secondPage.body.entries.map((entry) => {
+        return entry.date;
+      }),
+    ).toStrictEqual(["2025-05-01"]);
+    expect(secondPage.body.entries[0]?.items).toStrictEqual([
+      {
+        filePath: "2025-05-01.md",
+        diff: addedDiff("2025-05-01"),
+      },
+    ]);
+    expect(secondPage.body.nextCursor).toBeNull();
   });
 
   it("omits entries with no items", async () => {
@@ -247,6 +329,7 @@ describe("GET /api/zero/memory/activity", () => {
     );
 
     expect(response.body.entries).toStrictEqual([]);
+    expect(response.body.nextCursor).toBeNull();
   });
 
   it("orders a summary's items deterministically by file_path", async () => {

--- a/turbo/apps/api/src/signals/routes/zero-memory-activity.ts
+++ b/turbo/apps/api/src/signals/routes/zero-memory-activity.ts
@@ -3,6 +3,7 @@ import { zeroMemoryActivityContract } from "@vm0/api-contracts/contracts/zero-me
 
 import { organizationAuthContext$ } from "../auth/auth-context";
 import { authRoute } from "../auth/auth-route";
+import { queryOf } from "../context/request";
 import type { RouteEntry } from "../route";
 import { zeroMemoryActivity } from "../services/zero-memory-activity.service";
 
@@ -11,9 +12,19 @@ const memoryAuthOptions = {
   missingOrganizationStatus: 401,
 } as const;
 
+const memoryActivityQuery$ = queryOf(zeroMemoryActivityContract.get);
+
 const getMemoryActivityInner$ = computed(async (get): Promise<unknown> => {
   const auth = get(organizationAuthContext$);
-  const activity = await get(zeroMemoryActivity(auth.orgId, auth.userId));
+  const query = get(memoryActivityQuery$);
+  const activity = await get(
+    zeroMemoryActivity({
+      orgId: auth.orgId,
+      userId: auth.userId,
+      limit: query.limit,
+      cursor: query.cursor,
+    }),
+  );
   return {
     status: 200 as const,
     body: activity,

--- a/turbo/apps/api/src/signals/services/zero-memory-activity.service.ts
+++ b/turbo/apps/api/src/signals/services/zero-memory-activity.service.ts
@@ -4,7 +4,7 @@ import {
   type MemoryChangeDiff,
 } from "@vm0/db/schema/memory-change-item";
 import { memoryChangeSummaries } from "@vm0/db/schema/memory-change-summary";
-import { and, asc, desc, eq, inArray } from "drizzle-orm";
+import { and, asc, desc, eq, inArray, lt } from "drizzle-orm";
 
 import { db$ } from "../external/db";
 
@@ -23,6 +23,14 @@ interface MemoryActivityEntry {
 
 interface MemoryActivityResult {
   readonly entries: readonly MemoryActivityEntry[];
+  readonly nextCursor: string | null;
+}
+
+interface MemoryActivityParams {
+  readonly orgId: string;
+  readonly userId: string;
+  readonly limit: number;
+  readonly cursor?: string;
 }
 
 /**
@@ -34,12 +42,19 @@ interface MemoryActivityResult {
  * when they have deterministic change items to display.
  */
 export function zeroMemoryActivity(
-  orgId: string,
-  userId: string,
+  params: MemoryActivityParams,
 ): Computed<Promise<MemoryActivityResult>> {
   return computed(async (get): Promise<MemoryActivityResult> => {
-    const summaries = await get(db$)
-      .select({
+    const filters = [
+      eq(memoryChangeSummaries.orgId, params.orgId),
+      eq(memoryChangeSummaries.userId, params.userId),
+    ];
+    if (params.cursor !== undefined) {
+      filters.push(lt(memoryChangeSummaries.date, params.cursor));
+    }
+
+    const summaryPage = await get(db$)
+      .selectDistinct({
         id: memoryChangeSummaries.id,
         date: memoryChangeSummaries.date,
         summary: memoryChangeSummaries.summary,
@@ -47,16 +62,24 @@ export function zeroMemoryActivity(
         toVersionId: memoryChangeSummaries.toVersionId,
       })
       .from(memoryChangeSummaries)
-      .where(
-        and(
-          eq(memoryChangeSummaries.orgId, orgId),
-          eq(memoryChangeSummaries.userId, userId),
-        ),
+      .innerJoin(
+        memoryChangeItems,
+        eq(memoryChangeItems.summaryId, memoryChangeSummaries.id),
       )
-      .orderBy(desc(memoryChangeSummaries.date));
+      .where(and(...filters))
+      .orderBy(desc(memoryChangeSummaries.date))
+      .limit(params.limit + 1);
+
+    const hasMore = summaryPage.length > params.limit;
+    const summaries = hasMore
+      ? summaryPage.slice(0, params.limit)
+      : summaryPage;
+    const nextCursor = hasMore
+      ? (summaries[summaries.length - 1]?.date ?? null)
+      : null;
 
     if (summaries.length === 0) {
-      return { entries: [] };
+      return { entries: [], nextCursor: null };
     }
 
     const summaryIds = summaries.map((summary) => {
@@ -103,6 +126,6 @@ export function zeroMemoryActivity(
       });
     }
 
-    return { entries };
+    return { entries, nextCursor };
   });
 }

--- a/turbo/apps/platform/src/mocks/handlers/api-memory-activity.ts
+++ b/turbo/apps/platform/src/mocks/handlers/api-memory-activity.ts
@@ -5,7 +5,10 @@ import {
 
 import { mockApi } from "../msw-contract.ts";
 
-const EMPTY_ACTIVITY: MemoryActivityResponse = { entries: [] };
+const EMPTY_ACTIVITY: MemoryActivityResponse = {
+  entries: [],
+  nextCursor: null,
+};
 
 let mockMemoryActivity: MemoryActivityResponse = { ...EMPTY_ACTIVITY };
 

--- a/turbo/apps/platform/src/signals/memory-page/memory-signals.ts
+++ b/turbo/apps/platform/src/signals/memory-page/memory-signals.ts
@@ -4,12 +4,14 @@ import {
   type MemoryDetailResponse,
 } from "@vm0/api-contracts/contracts/zero-memory";
 import {
+  MEMORY_ACTIVITY_DEFAULT_LIMIT,
   zeroMemoryActivityContract,
   type MemoryActivityResponse,
 } from "@vm0/api-contracts/contracts/zero-memory-activity";
 
 import { accept } from "../../lib/accept.ts";
 import { zeroClient$ } from "../api-client.ts";
+import { settle } from "../utils.ts";
 
 export type MemoryTab = "updates" | "raw";
 
@@ -63,5 +65,151 @@ export const memoryActivity$ = computed(
     const client = get(zeroClient$)(zeroMemoryActivityContract);
     const result = await accept(client.get(), [200], { toast: false });
     return result.body;
+  },
+);
+
+type MemoryActivityEntries = MemoryActivityResponse["entries"];
+
+interface MemoryActivityExtraPage {
+  readonly entries: MemoryActivityEntries;
+  readonly nextCursor: string | null;
+}
+
+interface MemoryActivityPaginationState {
+  readonly key: string;
+  readonly pages: readonly MemoryActivityExtraPage[];
+}
+
+interface MemoryActivityLoadMoreErrorState {
+  readonly key: string;
+  readonly message: string;
+}
+
+function paginationKey(page: MemoryActivityResponse): string {
+  const tailVersionId =
+    page.entries[page.entries.length - 1]?.toVersionId ?? "";
+  return `${page.nextCursor ?? ""}:${tailVersionId}`;
+}
+
+function matchesPaginationKey<T extends { readonly key: string }>(
+  state: T | null,
+  key: string,
+): state is T {
+  return state !== null && state.key === key;
+}
+
+const extraMemoryActivityPages$ = state<MemoryActivityPaginationState | null>(
+  null,
+);
+const loadingMoreMemoryActivity$ = state<string | null>(null);
+const loadMoreMemoryActivityError$ =
+  state<MemoryActivityLoadMoreErrorState | null>(null);
+
+export const memoryActivityExtraEntries$ = computed(async (get) => {
+  const firstPage = await get(memoryActivity$);
+  const key = paginationKey(firstPage);
+  const state = get(extraMemoryActivityPages$);
+  if (!matchesPaginationKey(state, key)) {
+    return [];
+  }
+  return state.pages.flatMap((page) => {
+    return page.entries;
+  });
+});
+
+export const memoryActivityHasLoadedExtraPages$ = computed(async (get) => {
+  const firstPage = await get(memoryActivity$);
+  const state = get(extraMemoryActivityPages$);
+  return matchesPaginationKey(state, paginationKey(firstPage));
+});
+
+export const memoryActivityExtraHasMore$ = computed(async (get) => {
+  const firstPage = await get(memoryActivity$);
+  const key = paginationKey(firstPage);
+  const state = get(extraMemoryActivityPages$);
+  if (!matchesPaginationKey(state, key) || state.pages.length === 0) {
+    return false;
+  }
+  return state.pages[state.pages.length - 1]!.nextCursor !== null;
+});
+
+export const memoryActivityLatestCursor$ = computed(async (get) => {
+  const firstPage = await get(memoryActivity$);
+  const key = paginationKey(firstPage);
+  const state = get(extraMemoryActivityPages$);
+  if (!matchesPaginationKey(state, key) || state.pages.length === 0) {
+    return null;
+  }
+  return state.pages[state.pages.length - 1]!.nextCursor;
+});
+
+export const memoryActivityLoadingMore$ = computed(async (get) => {
+  const firstPage = await get(memoryActivity$);
+  return get(loadingMoreMemoryActivity$) === paginationKey(firstPage);
+});
+
+export const memoryActivityLoadMoreError$ = computed(async (get) => {
+  const firstPage = await get(memoryActivity$);
+  const key = paginationKey(firstPage);
+  const error = get(loadMoreMemoryActivityError$);
+  return matchesPaginationKey(error, key) ? error.message : null;
+});
+
+export const loadMoreMemoryActivity$ = command(
+  async ({ get, set }, cursor: string, signal: AbortSignal): Promise<void> => {
+    const firstPage = await get(memoryActivity$);
+    signal.throwIfAborted();
+    const key = paginationKey(firstPage);
+    if (get(loadingMoreMemoryActivity$) === key) {
+      return;
+    }
+
+    set(loadingMoreMemoryActivity$, key);
+    set(loadMoreMemoryActivityError$, null);
+
+    const client = get(zeroClient$)(zeroMemoryActivityContract);
+    const settled = await settle(
+      accept(
+        client.get({
+          query: {
+            cursor,
+            limit: MEMORY_ACTIVITY_DEFAULT_LIMIT,
+          },
+          fetchOptions: { signal },
+        }),
+        [200],
+        { toast: false },
+      ),
+      signal,
+    );
+
+    set(loadingMoreMemoryActivity$, (current) => {
+      return current === key ? null : current;
+    });
+
+    if (!settled.ok) {
+      set(loadMoreMemoryActivityError$, {
+        key,
+        message:
+          settled.error instanceof Error
+            ? settled.error.message
+            : "Failed to load more updates",
+      });
+      return;
+    }
+
+    set(extraMemoryActivityPages$, (current) => {
+      const pages = matchesPaginationKey(current, key) ? current.pages : [];
+      return {
+        key,
+        pages: [
+          ...pages,
+          {
+            entries: settled.value.body.entries,
+            nextCursor: settled.value.body.nextCursor,
+          },
+        ],
+      };
+    });
   },
 );

--- a/turbo/apps/platform/src/signals/memory-page/memory-signals.ts
+++ b/turbo/apps/platform/src/signals/memory-page/memory-signals.ts
@@ -11,7 +11,7 @@ import {
 
 import { accept } from "../../lib/accept.ts";
 import { zeroClient$ } from "../api-client.ts";
-import { settle } from "../utils.ts";
+import { settle, withCleanup } from "../utils.ts";
 
 export type MemoryTab = "updates" | "raw";
 
@@ -168,24 +168,28 @@ export const loadMoreMemoryActivity$ = command(
     set(loadMoreMemoryActivityError$, null);
 
     const client = get(zeroClient$)(zeroMemoryActivityContract);
-    const settled = await settle(
-      accept(
-        client.get({
-          query: {
-            cursor,
-            limit: MEMORY_ACTIVITY_DEFAULT_LIMIT,
-          },
-          fetchOptions: { signal },
-        }),
-        [200],
-        { toast: false },
+    const settled = await withCleanup(
+      settle(
+        accept(
+          client.get({
+            query: {
+              cursor,
+              limit: MEMORY_ACTIVITY_DEFAULT_LIMIT,
+            },
+            fetchOptions: { signal },
+          }),
+          [200],
+          { toast: false },
+        ),
+        signal,
       ),
-      signal,
+      () => {
+        set(loadingMoreMemoryActivity$, (current) => {
+          return current === key ? null : current;
+        });
+      },
     );
-
-    set(loadingMoreMemoryActivity$, (current) => {
-      return current === key ? null : current;
-    });
+    signal.throwIfAborted();
 
     if (!settled.ok) {
       set(loadMoreMemoryActivityError$, {

--- a/turbo/apps/platform/src/views/memory-page/__tests__/memory-page.test.tsx
+++ b/turbo/apps/platform/src/views/memory-page/__tests__/memory-page.test.tsx
@@ -1,5 +1,6 @@
 import { screen, waitFor, within } from "@testing-library/react";
 import {
+  MEMORY_ACTIVITY_DEFAULT_LIMIT,
   zeroMemoryActivityContract,
   type MemoryActivityResponse,
 } from "@vm0/api-contracts/contracts/zero-memory-activity";
@@ -22,6 +23,7 @@ const context = testContext();
 const mockApi = createMockApi(context);
 type MemoryActivityDiff =
   MemoryActivityResponse["entries"][number]["items"][number]["diff"];
+type MemoryActivityEntry = MemoryActivityResponse["entries"][number];
 
 async function clickTab(name: string): Promise<void> {
   const tab = await waitFor(() => {
@@ -69,6 +71,31 @@ function updatedDiff(
           { op: "remove", beforeLine: 1, afterLine: null, text: beforeText },
           { op: "add", beforeLine: null, afterLine: 1, text: afterText },
         ],
+      },
+    ],
+  };
+}
+
+function memoryActivityEntry({
+  date,
+  summary,
+  toVersionId,
+  filePath,
+}: {
+  readonly date: string;
+  readonly summary: string;
+  readonly toVersionId: string;
+  readonly filePath: string;
+}): MemoryActivityEntry {
+  return {
+    date,
+    summary,
+    fromVersionId: null,
+    toVersionId,
+    items: [
+      {
+        filePath,
+        diff: addedDiff(summary),
       },
     ],
   };
@@ -153,6 +180,7 @@ describe("memory page", () => {
           ],
         },
       ],
+      nextCursor: null,
     });
 
     detachedSetupPage({
@@ -219,6 +247,61 @@ describe("memory page", () => {
     expect(screen.queryByTestId("memory-loading")).not.toBeInTheDocument();
   });
 
+  it("loads more daily activity entries when a next cursor is available", async () => {
+    const firstEntry = memoryActivityEntry({
+      date: "2024-03-02",
+      summary: "First page update",
+      toVersionId: "v2",
+      filePath: "first.md",
+    });
+    const secondEntry = memoryActivityEntry({
+      date: "2024-03-01",
+      summary: "Second page update",
+      toVersionId: "v1",
+      filePath: "second.md",
+    });
+    server.use(
+      mockApi(zeroMemoryActivityContract.get, ({ query, respond }) => {
+        expect(query.limit).toBe(MEMORY_ACTIVITY_DEFAULT_LIMIT);
+        if (query.cursor === "2024-03-02") {
+          return respond(200, { entries: [secondEntry], nextCursor: null });
+        }
+        expect(query.cursor).toBeUndefined();
+        return respond(200, {
+          entries: [firstEntry],
+          nextCursor: "2024-03-02",
+        });
+      }),
+    );
+
+    detachedSetupPage({
+      context,
+      path: "/memory",
+      featureSwitches: { [FeatureSwitchKey.MemoryViewer]: true },
+    });
+
+    await waitFor(() => {
+      expect(screen.getByText("First page update")).toBeInTheDocument();
+    });
+    expect(screen.queryByText("Second page update")).not.toBeInTheDocument();
+
+    const loadMoreButton = queryAllByRoleFast("button").find((button) => {
+      return button.textContent?.includes("Load more");
+    });
+    expect(loadMoreButton).toBeDefined();
+    click(loadMoreButton!);
+
+    await waitFor(() => {
+      expect(screen.getByText("Second page update")).toBeInTheDocument();
+    });
+    expect(screen.getByText("First page update")).toBeInTheDocument();
+    expect(
+      queryAllByRoleFast("button").some((button) => {
+        return button.textContent?.includes("Load more");
+      }),
+    ).toBeFalsy();
+  });
+
   it("falls back to a deterministic summary line when the LLM summary is null", async () => {
     setMockMemoryActivity({
       entries: [
@@ -243,6 +326,7 @@ describe("memory page", () => {
           ],
         },
       ],
+      nextCursor: null,
     });
 
     detachedSetupPage({

--- a/turbo/apps/platform/src/views/memory-page/memory-page.tsx
+++ b/turbo/apps/platform/src/views/memory-page/memory-page.tsx
@@ -1,6 +1,7 @@
-import { useGet, useLoadable, useSet } from "ccstate-react";
+import { useGet, useLastResolved, useLoadable, useSet } from "ccstate-react";
 import type { MouseEvent } from "react";
 import { isMap, isScalar, isSeq, parseDocument } from "yaml";
+import { IconChevronDown, IconLoader2 } from "@tabler/icons-react";
 import type { MemoryDetailResponse } from "@vm0/api-contracts/contracts/zero-memory";
 import type { MemoryActivityResponse } from "@vm0/api-contracts/contracts/zero-memory-activity";
 import { cn } from "@vm0/ui";
@@ -8,7 +9,14 @@ import { Tabs, TabsList, TabsTrigger } from "@vm0/ui/components/ui/tabs";
 
 import {
   expandedMemoryItems$,
+  loadMoreMemoryActivity$,
   memoryActivity$,
+  memoryActivityExtraEntries$,
+  memoryActivityExtraHasMore$,
+  memoryActivityHasLoadedExtraPages$,
+  memoryActivityLatestCursor$,
+  memoryActivityLoadMoreError$,
+  memoryActivityLoadingMore$,
   memoryDetail$,
   memoryTab$,
   selectedMemoryFilePath$,
@@ -17,6 +25,8 @@ import {
   toggleMemoryItemExpanded$,
   type MemoryTab,
 } from "../../signals/memory-page/memory-signals.ts";
+import { pageSignal$ } from "../../signals/page-signal.ts";
+import { detach, Reason } from "../../signals/utils.ts";
 import { Markdown } from "../components/markdown.tsx";
 
 const PREFERRED_FILE = "MEMORY.md";
@@ -502,6 +512,15 @@ function formatLineStatsText(stats: {
 
 function MemoryUpdates() {
   const activityLoadable = useLoadable(memoryActivity$);
+  const extraEntries = useLastResolved(memoryActivityExtraEntries$) ?? [];
+  const hasLoadedExtraPages =
+    useLastResolved(memoryActivityHasLoadedExtraPages$) ?? false;
+  const extraHasMore = useLastResolved(memoryActivityExtraHasMore$) ?? false;
+  const latestCursor = useLastResolved(memoryActivityLatestCursor$);
+  const loadingMore = useLastResolved(memoryActivityLoadingMore$) ?? false;
+  const loadMoreError = useLastResolved(memoryActivityLoadMoreError$) ?? null;
+  const loadMore = useSet(loadMoreMemoryActivity$);
+  const pageSignal = useGet(pageSignal$);
 
   if (activityLoadable.state === "loading") {
     return <MemoryUpdatesSkeleton />;
@@ -510,9 +529,22 @@ function MemoryUpdates() {
     return <MemoryEmptyState errored />;
   }
 
-  const entries = activityLoadable.data.entries;
+  const entries = [...activityLoadable.data.entries, ...extraEntries];
   if (entries.length === 0) {
     return <MemoryUpdatesEmptyState />;
+  }
+  const cursorForLoadMore = hasLoadedExtraPages
+    ? latestCursor
+    : activityLoadable.data.nextCursor;
+  const hasMore = hasLoadedExtraPages
+    ? extraHasMore
+    : activityLoadable.data.nextCursor !== null;
+
+  function handleLoadMore() {
+    if (!cursorForLoadMore || loadingMore) {
+      return;
+    }
+    detach(loadMore(cursorForLoadMore, pageSignal), Reason.DomCallback);
   }
 
   return (
@@ -520,6 +552,42 @@ function MemoryUpdates() {
       {entries.map((entry) => {
         return <MemoryUpdateCard key={entry.toVersionId} entry={entry} />;
       })}
+      {hasMore ? (
+        <MemoryUpdatesLoadMore
+          loading={loadingMore}
+          error={loadMoreError}
+          onLoadMore={handleLoadMore}
+        />
+      ) : null}
+    </div>
+  );
+}
+
+function MemoryUpdatesLoadMore({
+  loading,
+  error,
+  onLoadMore,
+}: {
+  readonly loading: boolean;
+  readonly error: string | null;
+  readonly onLoadMore: () => void;
+}) {
+  return (
+    <div className="flex shrink-0 flex-col items-center gap-2 py-1">
+      <button
+        type="button"
+        disabled={loading}
+        onClick={onLoadMore}
+        className="inline-flex h-9 items-center justify-center gap-2 rounded-md border border-border/70 bg-background px-4 text-sm font-medium text-foreground transition-colors hover:bg-accent/50 disabled:pointer-events-none disabled:opacity-50"
+      >
+        {loading ? (
+          <IconLoader2 size={14} className="animate-spin" />
+        ) : (
+          <IconChevronDown size={14} />
+        )}
+        <span>{loading ? "Loading..." : "Load more"}</span>
+      </button>
+      {error ? <p className="text-sm text-destructive">{error}</p> : null}
     </div>
   );
 }

--- a/turbo/packages/api-contracts/src/contracts/zero-memory-activity.ts
+++ b/turbo/packages/api-contracts/src/contracts/zero-memory-activity.ts
@@ -4,6 +4,9 @@ import { apiErrorSchema } from "./errors";
 
 const c = initContract();
 
+export const MEMORY_ACTIVITY_DEFAULT_LIMIT = 20;
+export const MEMORY_ACTIVITY_MAX_LIMIT = 50;
+
 const memoryActivityDiffLineSchema = z.object({
   op: z.enum(["context", "add", "remove"]),
   beforeLine: z.number().int().positive().nullable(),
@@ -55,6 +58,7 @@ const memoryActivityEntrySchema = z.object({
  */
 export const memoryActivityResponseSchema = z.object({
   entries: z.array(memoryActivityEntrySchema),
+  nextCursor: z.string().nullable(),
 });
 
 export type MemoryActivityResponse = z.infer<
@@ -71,6 +75,15 @@ export const zeroMemoryActivityContract = c.router({
     method: "GET",
     path: "/api/zero/memory/activity",
     headers: authHeadersSchema,
+    query: z.object({
+      limit: z.coerce
+        .number()
+        .int()
+        .min(1)
+        .max(MEMORY_ACTIVITY_MAX_LIMIT)
+        .default(MEMORY_ACTIVITY_DEFAULT_LIMIT),
+      cursor: z.string().min(1).optional(),
+    }),
     responses: {
       200: memoryActivityResponseSchema,
       401: apiErrorSchema,


### PR DESCRIPTION
## Summary
- Add limit/cursor pagination to the memory activity API contract and service
- Wire the memory page to append additional update days with a Load more control
- Cover API cursor paging and frontend load-more behavior with integration tests

Closes #16202

## Tests
- pnpm format
- NODE_OPTIONS=--no-experimental-webstorage pnpm lint
- pnpm check-types
- pnpm -F api exec vitest run src/signals/routes/__tests__/zero-memory-activity.test.ts
- NODE_OPTIONS=--no-experimental-webstorage pnpm -F @vm0/app exec vitest run src/views/memory-page/__tests__/memory-page.test.tsx

## Notes
- pnpm knip still reports existing repo-wide unused files/exports that are unrelated to this change.