### PR TITLE
feat: scope chat header schedule menu to the thread and refresh it in realtime

### DIFF
--- a/turbo/apps/api/src/signals/external/realtime.ts
+++ b/turbo/apps/api/src/signals/external/realtime.ts
@@ -110,6 +110,30 @@ export async function publishThreadListChanged(userId: string): Promise<void> {
   await publishUserSignal([userId], "threadListChanged");
 }
 
+/**
+ * Notify a chat thread's UI that its linked schedule set changed (created,
+ * deleted, enabled, or disabled). The chat-thread header schedule menu
+ * subscribes to this topic and refetches its thread-scoped list.
+ *
+ * Best-effort: a failed publish must not fail the schedule mutation that
+ * triggers it. Payload is intentionally empty — the client re-fetches the
+ * authoritative list on any delivery.
+ */
+export async function publishChatThreadSchedulesChangedSafely(
+  userId: string,
+  threadId: string,
+): Promise<void> {
+  await tapError(
+    publishUserSignal([userId], `chatThreadSchedulesChanged:${threadId}`),
+    (error) => {
+      L.warn("Failed to publish chat thread schedules changed signal", {
+        threadId,
+        error,
+      });
+    },
+  );
+}
+
 export async function publishBuiltInGenerationChanged(
   userId: string,
   generationId: string,

--- a/turbo/apps/api/src/signals/routes/__tests__/zero-schedules.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/zero-schedules.test.ts
@@ -225,6 +225,80 @@ describe("POST /api/zero/schedules — chat-mode linkage", () => {
   });
 });
 
+describe("chat-mode schedule realtime signals", () => {
+  it("publishes chatThreadSchedulesChanged when a chat-mode schedule is created", async () => {
+    const fixture = await seedFixture();
+    await enableChatMode(fixture);
+    const threadId = await seedThread(fixture);
+
+    const response = await deploySchedule({
+      name: "chat-sched",
+      agentId: fixture.composeId,
+      cronExpression: "0 9 * * *",
+      prompt: "daily report",
+      description: "d",
+      chatThreadId: threadId,
+    });
+    expect(response.status).toBe(201);
+
+    expect(context.mocks.ably.publish).toHaveBeenCalledWith(
+      `chatThreadSchedulesChanged:${threadId}`,
+      null,
+    );
+  });
+
+  it("does not publish chatThreadSchedulesChanged for a legacy schedule", async () => {
+    const fixture = await seedFixture();
+    const threadId = await seedThread(fixture);
+
+    const response = await deploySchedule({
+      name: "legacy-sched",
+      agentId: fixture.composeId,
+      cronExpression: "0 9 * * *",
+      prompt: "daily report",
+      description: "d",
+      chatThreadId: threadId,
+    });
+    expect(response.status).toBe(201);
+
+    expect(context.mocks.ably.publish).not.toHaveBeenCalledWith(
+      expect.stringContaining("chatThreadSchedulesChanged:"),
+      expect.anything(),
+    );
+  });
+
+  it("publishes chatThreadSchedulesChanged when a chat-mode schedule is deleted", async () => {
+    const fixture = await seedFixture();
+    await enableChatMode(fixture);
+    const threadId = await seedThread(fixture);
+
+    await deploySchedule({
+      name: "chat-sched",
+      agentId: fixture.composeId,
+      cronExpression: "0 9 * * *",
+      prompt: "daily report",
+      description: "d",
+      chatThreadId: threadId,
+    });
+    context.mocks.ably.publish.mockClear();
+
+    const app = createApp({ signal: context.signal });
+    const del = await app.request(
+      `/api/zero/schedules/chat-sched?agentId=${fixture.composeId}`,
+      {
+        method: "DELETE",
+        headers: { authorization: "Bearer clerk-session" },
+      },
+    );
+    expect(del.status).toBe(204);
+
+    expect(context.mocks.ably.publish).toHaveBeenCalledWith(
+      `chatThreadSchedulesChanged:${threadId}`,
+      null,
+    );
+  });
+});
+
 describe("GET /api/zero/schedules", () => {
   it("returns 401 when the request is unauthenticated", async () => {
     const response = await listSchedules({});

--- a/turbo/apps/api/src/signals/services/zero-schedules.service.ts
+++ b/turbo/apps/api/src/signals/services/zero-schedules.service.ts
@@ -44,6 +44,7 @@ import {
   postScheduleUserMessage,
   resolveScheduleChatThreadModelPin,
 } from "../routes/zero-chat-messages";
+import { publishChatThreadSchedulesChangedSafely } from "../external/realtime";
 
 const log = logger("api:zero:schedules");
 const OPENROUTER_CHAT_COMPLETIONS_URL =
@@ -725,6 +726,15 @@ export const deploySchedule$ = command(
         });
     signal.throwIfAborted();
 
+    // Notify the linked chat thread so its header schedule menu refreshes the
+    // thread-scoped list in real time (chat-mode schedules only).
+    if (schedule.chatThreadId) {
+      await publishChatThreadSchedulesChangedSafely(
+        args.userId,
+        schedule.chatThreadId,
+      );
+    }
+
     const featureSwitchOverrides = await get(
       userFeatureSwitchOverrides(args.orgId, args.userId),
     );
@@ -777,6 +787,13 @@ export const disableSchedule$ = command(
       return { kind: "not_found" };
     }
 
+    if (updated.chatThreadId) {
+      await publishChatThreadSchedulesChangedSafely(
+        args.userId,
+        updated.chatThreadId,
+      );
+    }
+
     const featureSwitchOverrides = await get(
       userFeatureSwitchOverrides(args.orgId, args.userId),
     );
@@ -811,6 +828,7 @@ export const deleteSchedule$ = command(
       return { kind: "not_found" };
     }
 
+    const chatThreadId = ownership.schedule.chatThreadId;
     const [deleted] = await db
       .delete(zeroAgentSchedules)
       .where(eq(zeroAgentSchedules.id, ownership.schedule.id))
@@ -818,6 +836,12 @@ export const deleteSchedule$ = command(
     signal.throwIfAborted();
     if (!deleted) {
       return { kind: "not_found" };
+    }
+
+    // Notify the linked chat thread so its header schedule menu drops the
+    // deleted entry in real time (chat-mode schedules only).
+    if (chatThreadId) {
+      await publishChatThreadSchedulesChangedSafely(args.userId, chatThreadId);
     }
 
     return { kind: "ok" };
@@ -876,6 +900,13 @@ export const enableSchedule$ = command(
     signal.throwIfAborted();
     if (!updated) {
       return { kind: "not_found" };
+    }
+
+    if (updated.chatThreadId) {
+      await publishChatThreadSchedulesChangedSafely(
+        args.userId,
+        updated.chatThreadId,
+      );
     }
 
     const featureSwitchOverrides = await get(

--- a/turbo/apps/platform/src/signals/chat-page/chat-thread-data-source.ts
+++ b/turbo/apps/platform/src/signals/chat-page/chat-thread-data-source.ts
@@ -10,6 +10,7 @@ import type { ChatThread } from "../agent-chat.ts";
 export interface ChatThreadRealtimeHandlers {
   onMessageCreated$: Command<Promise<boolean>, [AbortSignal]>;
   onRunChanged$: Command<Promise<boolean>, [AbortSignal]>;
+  onSchedulesChanged$: Command<Promise<boolean> | boolean, [AbortSignal]>;
 }
 
 export interface InitialPage {

--- a/turbo/apps/platform/src/signals/chat-page/create-chat-thread.ts
+++ b/turbo/apps/platform/src/signals/chat-page/create-chat-thread.ts
@@ -9,6 +9,7 @@ import {
 import { animationFrame, delay } from "signal-timers";
 import { onRef, resetSignal, setLoop } from "../utils.ts";
 import { setAblyLoop$ } from "../realtime.ts";
+import { reloadHeaderScheduleMenu$ } from "./header-schedule-menu.ts";
 import {
   createScrollSignals,
   type ScrollStepDirection,
@@ -1548,13 +1549,22 @@ function createRunTracking({
       return false;
     });
 
+    const onSchedulesChanged$ = command(({ set }) => {
+      L.debug("onSchedulesChanged$ fired", { threadId });
+      set(reloadHeaderScheduleMenu$);
+      return false;
+    });
+
     L.debug("subscribeChatThread$ subscribeRealtime$ start", { threadId });
     await Promise.all([
       set(backfillHistoryBoundary$, signal),
       set(markThreadReadIfNeeded$, signal),
       set(
         dataSource.subscribeRealtime$,
-        { threadId, handlers: { onMessageCreated$, onRunChanged$ } },
+        {
+          threadId,
+          handlers: { onMessageCreated$, onRunChanged$, onSchedulesChanged$ },
+        },
         signal,
       ),
     ]);

--- a/turbo/apps/platform/src/signals/chat-page/header-schedule-menu.ts
+++ b/turbo/apps/platform/src/signals/chat-page/header-schedule-menu.ts
@@ -7,6 +7,7 @@ import { zeroClient$ } from "../api-client.ts";
 interface HeaderScheduleEntry {
   readonly id: string;
   readonly name: string;
+  readonly chatThreadId: string | null;
 }
 
 const headerScheduleMenuReload$ = state(0);
@@ -18,7 +19,9 @@ export const reloadHeaderScheduleMenu$ = command(({ get, set }) => {
 
 /**
  * All of the user's schedules, for the chat-thread header schedule menu. Read
- * via useLastLoadable; refetched on every menu open via reloadHeaderScheduleMenu$.
+ * via useLastLoadable; refetched on every menu open via reloadHeaderScheduleMenu$
+ * and on realtime chatThreadSchedulesChanged signals. Consumers filter this to
+ * the schedules linked to the current chat thread (see schedulesForThread).
  */
 export const headerScheduleMenu$ = computed(
   async (get): Promise<readonly HeaderScheduleEntry[]> => {
@@ -30,7 +33,21 @@ export const headerScheduleMenu$ = computed(
       { toast: false },
     );
     return result.body.schedules.map((schedule) => {
-      return { id: schedule.id, name: schedule.name };
+      return {
+        id: schedule.id,
+        name: schedule.name,
+        chatThreadId: schedule.chatThreadId,
+      };
     });
   },
 );
+
+/** Schedules linked to a specific chat thread, for the header schedule menu. */
+export function schedulesForThread(
+  schedules: readonly HeaderScheduleEntry[],
+  threadId: string,
+): readonly HeaderScheduleEntry[] {
+  return schedules.filter((schedule) => {
+    return schedule.chatThreadId === threadId;
+  });
+}

--- a/turbo/apps/platform/src/signals/chat-page/remote-chat-thread-data-source.ts
+++ b/turbo/apps/platform/src/signals/chat-page/remote-chat-thread-data-source.ts
@@ -259,6 +259,12 @@ const subscribeRealtime$ = command(
         handlers.onRunChanged$,
         signal,
       ),
+      set(
+        setAblyLoop$,
+        `chatThreadSchedulesChanged:${threadId}`,
+        handlers.onSchedulesChanged$,
+        signal,
+      ),
     ]);
     signal.throwIfAborted();
   },

--- a/turbo/apps/platform/src/views/zero-page/zero-chat-thread-page.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-chat-thread-page.tsx
@@ -184,6 +184,7 @@ import {
 import {
   headerScheduleMenu$,
   reloadHeaderScheduleMenu$,
+  schedulesForThread,
 } from "../../signals/chat-page/header-schedule-menu.ts";
 import { detachedNavigateTo$ } from "../../signals/route.ts";
 import { openQueueDrawer$ } from "../../signals/queue-page/queue-drawer-state.ts";
@@ -956,21 +957,24 @@ function GithubPrTrackingButton({
   );
 }
 
-function ScheduleMenuButton() {
+function ScheduleMenuButton({ threadId }: { threadId: string }) {
   const features = useLastResolved(featureSwitch$);
-  // Shown whenever the ScheduledChat switch is on (independent of any thread).
+  // Shown whenever the ScheduledChat switch is on. The list is scoped to the
+  // schedules linked to this chat thread.
   if (!(features?.[FeatureSwitchKey.ScheduledChat] ?? false)) {
     return null;
   }
-  return <ScheduleMenuButtonInner />;
+  return <ScheduleMenuButtonInner threadId={threadId} />;
 }
 
-function ScheduleMenuButtonInner() {
+function ScheduleMenuButtonInner({ threadId }: { threadId: string }) {
   const navigate = useSet(detachedNavigateTo$);
   const reloadSchedules = useSet(reloadHeaderScheduleMenu$);
   const schedulesLoadable = useLastLoadable(headerScheduleMenu$);
   const schedules =
-    schedulesLoadable.state === "hasData" ? schedulesLoadable.data : [];
+    schedulesLoadable.state === "hasData"
+      ? schedulesForThread(schedulesLoadable.data, threadId)
+      : [];
 
   return (
     <DropdownMenu
@@ -1087,7 +1091,7 @@ function ChatThreadHeader({ thread }: { thread: ChatThreadSignals }) {
         )}
       </div>
       <div className="hidden sm:flex items-center gap-0.5">
-        <ScheduleMenuButton />
+        <ScheduleMenuButton threadId={thread.threadId} />
         <ArtifactsButton thread={thread} />
         {githubPrTrackingEnabled && agentId && (
           <GithubPrTrackingButton thread={thread} agentId={agentId} />


### PR DESCRIPTION
## Background

After the `ScheduledChat` switch is on, a schedule can be linked to a chat thread (`zero_agent_schedules.chatThreadId`). Running such a schedule renders as a normal web-chat turn (user message + assistant reply) in that thread.

The chat-thread header **Scheduled** menu, however, listed **every** schedule the user owned, and only refreshed when the menu was reopened.

## What this PR does

1. **Thread-scoped list** — the header schedule menu now shows only the schedules linked to the current chat thread (`chatThreadId === threadId`).
2. **Realtime refresh** — the chat thread subscribes to a new thread-scoped Ably topic `chatThreadSchedulesChanged:<threadId>` and reloads the menu on any delivery, so creating/deleting a schedule updates the list live (no reopen needed).
3. **Server-side publish** — schedule mutations publish that signal whenever the affected schedule is chat-linked:
   - create/update (`deploySchedule$`)
   - delete (`deleteSchedule$`)
   - enable / disable (`enableSchedule$` / `disableSchedule$`)

   Publishing is best-effort (`publishChatThreadSchedulesChangedSafely`, wrapped in `tapError`) so an Ably failure never fails the schedule mutation.

## Changes

**API (`apps/api`)**
- `signals/external/realtime.ts` — add `publishChatThreadSchedulesChangedSafely(userId, threadId)`.
- `signals/services/zero-schedules.service.ts` — publish the signal from deploy/delete/enable/disable when `chatThreadId` is set.

**Platform (`apps/platform`)**
- `chat-thread-data-source.ts` — add `onSchedulesChanged$` to `ChatThreadRealtimeHandlers`.
- `remote-chat-thread-data-source.ts` — subscribe `chatThreadSchedulesChanged:<threadId>`.
- `create-chat-thread.ts` — wire the handler to `reloadHeaderScheduleMenu$`.
- `header-schedule-menu.ts` — carry `chatThreadId`; add `schedulesForThread()` filter.
- `zero-chat-thread-page.tsx` — pass `threadId` into the menu and filter the list.

## Tests
- `zero-schedules.test.ts` — new cases: create and delete of a chat-mode schedule publish `chatThreadSchedulesChanged:<threadId>`; a legacy (unlinked) schedule does not.

## Notes
- The link is set at creation only and is immutable; legacy (unlinked) schedules publish nothing and never appear in a thread menu.
- Filtering is client-side off the existing list endpoint (no contract change), keeping the change small.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
