### PR TITLE
fix: remove follow-up prompt length limit

### DIFF
--- a/turbo/apps/api/src/signals/routes/__tests__/internal-callbacks-chat.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/internal-callbacks-chat.test.ts
@@ -670,7 +670,9 @@ describe("POST /api/internal/callbacks/chat", () => {
       if (
         systemContent.includes("Generate up to three concise follow-up prompts")
       ) {
-        expect(systemContent).toContain("Keep each prompt under 30 characters");
+        expect(systemContent).toContain(
+          "Make each prompt specific to the latest assistant reply",
+        );
         return JSON.stringify([
           {
             prompt: "Turn this into a checklist",

--- a/turbo/apps/api/src/signals/services/zero-chat-title.service.ts
+++ b/turbo/apps/api/src/signals/services/zero-chat-title.service.ts
@@ -438,7 +438,7 @@ async function generateRecommendedFollowups(
         role: "system",
         content: [
           "Generate up to three concise follow-up prompts the user may ask next in this chat.",
-          "Keep each prompt under 30 characters. Make them specific to the latest assistant reply, actionable, and useful. Match the user's language.",
+          "Make each prompt specific to the latest assistant reply, actionable, and useful. Match the user's language.",
           'Classify each item as kind "talk" for normal discussion, planning, analysis, or refinement, or kind "generate" when the prompt asks VM0 to create one of the supported built-in generation outputs.',
           BUILT_IN_GENERATION_FOLLOWUP_CONTEXT,
           "For generate items, include generationType as one of: image, video, presentation, website.",


### PR DESCRIPTION
## Summary
- Remove the hard 30-character limit from recommended follow-up prompt generation.
- Update the callback test to assert the retained specificity instruction instead of the removed length rule.

## Checks
- git diff --check
- rg "Keep each prompt under 30 characters|under 30 characters|30 characters" turbo/apps/api/src/signals -S

Full local vitest was not run in this fresh checkout; relying on the PR pipeline per vm0 PR verification preference.