### PR TITLE
refactor: replace connectorProvidedEnvNames with structured bindings

### DIFF
--- a/turbo/apps/api/src/signals/routes/__tests__/zero-connectors-list.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/zero-connectors-list.test.ts
@@ -74,7 +74,7 @@ describe("GET /api/zero/connectors", () => {
 
     expect(response.body.connectors).toStrictEqual([]);
     expect(Array.isArray(response.body.configuredTypes)).toBeTruthy();
-    expect(Array.isArray(response.body.connectorProvidedEnvNames)).toBeTruthy();
+    expect(Array.isArray(response.body.connectorProvidedBindings)).toBeTruthy();
   });
 
   it("returns connectors when present", async () => {

--- a/turbo/apps/api/src/signals/routes/zero-integrations-slack.ts
+++ b/turbo/apps/api/src/signals/routes/zero-integrations-slack.ts
@@ -6,6 +6,7 @@ import {
   slackOrgStatusSchema,
   zeroIntegrationsSlackContract,
 } from "@vm0/api-contracts/contracts/zero-integrations-slack";
+import { connectorProvidedBindingNames } from "@vm0/api-contracts/contracts/connector-schemas";
 import { authHeadersSchema } from "@vm0/api-contracts/contracts/base";
 import { apiErrorSchema } from "@vm0/api-contracts/contracts/errors";
 import { extractAndGroupVariables } from "@vm0/core/variable-expander";
@@ -136,13 +137,20 @@ const getSlackEnvironment$ = computed(
       ...userSecretList.secrets.map((s) => {
         return s.name;
       }),
-      ...userConnectors.connectorProvidedEnvNames,
+      ...connectorProvidedBindingNames({
+        bindings: userConnectors.connectorProvidedBindings,
+        namespace: "secrets",
+      }),
     ]);
-    const existingVarNames = new Set(
-      userVarList.variables.map((v) => {
+    const existingVarNames = new Set([
+      ...userVarList.variables.map((v) => {
         return v.name;
       }),
-    );
+      ...connectorProvidedBindingNames({
+        bindings: userConnectors.connectorProvidedBindings,
+        namespace: "vars",
+      }),
+    ]);
 
     const missingSecrets = requiredSecrets.filter((name) => {
       return !existingSecretNames.has(name);

--- a/turbo/apps/api/src/signals/services/__tests__/zero-connector-data.service.test.ts
+++ b/turbo/apps/api/src/signals/services/__tests__/zero-connector-data.service.test.ts
@@ -38,24 +38,16 @@ describe("zeroConnectorList", () => {
     expect(openai).toBeUndefined();
   });
 
-  it("returns connector-provided env names only for stored connector credentials", async () => {
+  it("returns connector-provided bindings only for stored connector credentials", async () => {
     const orgId = `org_${randomUUID()}`;
     const userId = `user_${randomUUID()}`;
 
-    await writeDb.insert(connectors).values([
-      {
-        orgId,
-        userId,
-        type: "gitlab",
-        authMethod: "api-token",
-      },
-      {
-        orgId,
-        userId,
-        type: "openai",
-        authMethod: "api-token",
-      },
-    ]);
+    await writeDb.insert(connectors).values({
+      orgId,
+      userId,
+      type: "gitlab",
+      authMethod: "api-token",
+    });
     await writeDb.insert(secrets).values({
       orgId,
       userId,
@@ -66,12 +58,35 @@ describe("zeroConnectorList", () => {
 
     const list = await store.get(zeroConnectorList({ orgId, userId }));
 
-    expect(list.connectorProvidedEnvNames).toContain("GITLAB_TOKEN");
-    expect(list.connectorProvidedEnvNames).not.toContain("GITLAB_HOST");
-    expect(list.connectorProvidedEnvNames).not.toContain("OPENAI_TOKEN");
+    expect(list.connectorProvidedBindings).toStrictEqual(
+      expect.arrayContaining([
+        {
+          connectorType: "gitlab",
+          authMethod: "api-token",
+          namespace: "secrets",
+          name: "GITLAB_TOKEN",
+          required: true,
+          source: {
+            kind: "connector-secret",
+            name: "GITLAB_TOKEN",
+          },
+        },
+        {
+          connectorType: "gitlab",
+          authMethod: "api-token",
+          namespace: "vars",
+          name: "GITLAB_HOST",
+          required: false,
+          source: {
+            kind: "connector-variable",
+            name: "GITLAB_HOST",
+          },
+        },
+      ]),
+    );
   });
 
-  it("returns connector token env names only when the access secret exists", async () => {
+  it("returns connector token env names from selected auth method metadata", async () => {
     const orgId = `org_${randomUUID()}`;
     const userWithoutSecret = `user_${randomUUID()}`;
     const userWithSecret = `user_${randomUUID()}`;
@@ -105,12 +120,35 @@ describe("zeroConnectorList", () => {
       zeroConnectorList({ orgId, userId: userWithSecret }),
     );
 
-    expect(withoutSecret.connectorProvidedEnvNames).not.toContain("GH_TOKEN");
-    expect(withoutSecret.connectorProvidedEnvNames).not.toContain(
-      "GITHUB_TOKEN",
+    const githubTokenBindings = [
+      {
+        connectorType: "github",
+        authMethod: "oauth",
+        namespace: "secrets",
+        name: "GH_TOKEN",
+        required: true,
+        source: {
+          kind: "connector-secret",
+          name: "GITHUB_ACCESS_TOKEN",
+        },
+      },
+      {
+        connectorType: "github",
+        authMethod: "oauth",
+        namespace: "secrets",
+        name: "GITHUB_TOKEN",
+        required: true,
+        source: {
+          kind: "connector-secret",
+          name: "GITHUB_ACCESS_TOKEN",
+        },
+      },
+    ];
+    expect(withoutSecret.connectorProvidedBindings).toStrictEqual(
+      expect.arrayContaining(githubTokenBindings),
     );
-    expect(withSecret.connectorProvidedEnvNames).toStrictEqual(
-      expect.arrayContaining(["GH_TOKEN", "GITHUB_TOKEN"]),
+    expect(withSecret.connectorProvidedBindings).toStrictEqual(
+      expect.arrayContaining(githubTokenBindings),
     );
   });
 
@@ -143,13 +181,29 @@ describe("zeroConnectorList", () => {
 
     const list = await store.get(zeroConnectorList({ orgId, userId }));
 
-    expect(list.connectorProvidedEnvNames).toContain("GOOGLE_ADS_TOKEN");
-    expect(list.connectorProvidedEnvNames).not.toContain(
-      "GOOGLE_ADS_DEVELOPER_TOKEN",
+    expect(list.connectorProvidedBindings).toStrictEqual(
+      expect.arrayContaining([
+        {
+          connectorType: "google-ads",
+          authMethod: "oauth",
+          namespace: "secrets",
+          name: "GOOGLE_ADS_TOKEN",
+          required: true,
+          source: {
+            kind: "connector-secret",
+            name: "GOOGLE_ADS_ACCESS_TOKEN",
+          },
+        },
+      ]),
+    );
+    expect(list.connectorProvidedBindings).not.toContainEqual(
+      expect.objectContaining({
+        name: "GOOGLE_ADS_DEVELOPER_TOKEN",
+      }),
     );
   });
 
-  it("does not report variable-backed connector env names as provided secrets", async () => {
+  it("reports variable-backed connector env names as structured provided bindings", async () => {
     const orgId = `org_${randomUUID()}`;
     const userId = `user_${randomUUID()}`;
 
@@ -176,8 +230,21 @@ describe("zeroConnectorList", () => {
 
     const list = await store.get(zeroConnectorList({ orgId, userId }));
 
-    expect(list.connectorProvidedEnvNames).toContain("GITLAB_TOKEN");
-    expect(list.connectorProvidedEnvNames).not.toContain("GITLAB_HOST");
+    expect(list.connectorProvidedBindings).toStrictEqual(
+      expect.arrayContaining([
+        {
+          connectorType: "gitlab",
+          authMethod: "api-token",
+          namespace: "vars",
+          name: "GITLAB_HOST",
+          required: false,
+          source: {
+            kind: "connector-variable",
+            name: "GITLAB_HOST",
+          },
+        },
+      ]),
+    );
   });
 
   it("returns configuredTypes in sorted order", async () => {

--- a/turbo/apps/api/src/signals/services/integrations-github.service.ts
+++ b/turbo/apps/api/src/signals/services/integrations-github.service.ts
@@ -8,6 +8,7 @@ import type {
   GithubLabelListener,
   UpdateGithubLabelListenerBody,
 } from "@vm0/api-contracts/contracts/integrations-github";
+import { connectorProvidedBindingNames } from "@vm0/api-contracts/contracts/connector-schemas";
 import { extractAndGroupVariables } from "@vm0/core/variable-expander";
 import {
   agentComposes,
@@ -1082,13 +1083,20 @@ export const getGithubInstallation$ = command(
       ...secretList.secrets.map((secret) => {
         return secret.name;
       }),
-      ...connectorList.connectorProvidedEnvNames,
+      ...connectorProvidedBindingNames({
+        bindings: connectorList.connectorProvidedBindings,
+        namespace: "secrets",
+      }),
     ]);
-    const existingVarNames = new Set(
-      variableList.variables.map((variable) => {
+    const existingVarNames = new Set([
+      ...variableList.variables.map((variable) => {
         return variable.name;
       }),
-    );
+      ...connectorProvidedBindingNames({
+        bindings: connectorList.connectorProvidedBindings,
+        namespace: "vars",
+      }),
+    ]);
     const githubConnector =
       connectorList.connectors.find((connector) => {
         return connector.type === "github";

--- a/turbo/apps/api/src/signals/services/zero-connector-data.service.ts
+++ b/turbo/apps/api/src/signals/services/zero-connector-data.service.ts
@@ -1,6 +1,7 @@
 import { command, computed, type Computed } from "ccstate";
 import type {
   ConnectorListResponse,
+  ConnectorProvidedBinding,
   ConnectorResponse,
   ScopeDiffResponse,
 } from "@vm0/api-contracts/contracts/connector-schemas";
@@ -68,10 +69,6 @@ type StoredConnectorRow = {
   readonly createdAt: Date;
   readonly updatedAt: Date;
 };
-
-interface ConnectorScopedSecretNames {
-  readonly secretNames: ReadonlySet<string>;
-}
 
 const oauthScopesSchema = z.array(z.string());
 const DEFAULT_ACCESS_TOKEN_EXPIRES_IN_SECS = 15 * 60;
@@ -343,7 +340,7 @@ export function zeroConnectorList(args: {
 }): Computed<Promise<ConnectorListResponse>> {
   return computed(async (get): Promise<ConnectorListResponse> => {
     const db = get(db$);
-    const [storedRows, connectorSecretRows, overrides] = await Promise.all([
+    const [storedRows, overrides] = await Promise.all([
       db
         .select({
           id: connectors.id,
@@ -364,16 +361,6 @@ export function zeroConnectorList(args: {
             eq(connectors.userId, args.userId),
           ),
         ),
-      db
-        .select({ name: secrets.name })
-        .from(secrets)
-        .where(
-          and(
-            eq(secrets.orgId, args.orgId),
-            eq(secrets.userId, args.userId),
-            eq(secrets.type, "connector"),
-          ),
-        ),
       get(userFeatureSwitchOverrides(args.orgId, args.userId)),
     ]);
     const featureStates = getAllFeatureStates({
@@ -392,34 +379,23 @@ export function zeroConnectorList(args: {
       }
       return [storedConnectorRowToResponse(row, parsed.data)];
     });
-    const connectorScopedSecretNames: ConnectorScopedSecretNames = {
-      secretNames: new Set(
-        connectorSecretRows.map((row) => {
-          return row.name;
-        }),
-      ),
-    };
+    const connectorProvidedBindings =
+      connectorProvidedBindingsForStoredConnectors(connectorList);
 
     return {
       connectors: connectorList,
       configuredTypes: getRuntimeAvailableConnectorTypes((name) => {
         return optionalEnv(name);
       }),
-      connectorProvidedEnvNames: [
-        ...connectorProvidedEnvNamesForStoredConnectors(
-          connectorList,
-          connectorScopedSecretNames,
-        ),
-      ],
+      connectorProvidedBindings,
     };
   });
 }
 
-function connectorProvidedEnvNamesForStoredConnectors(
+function connectorProvidedBindingsForStoredConnectors(
   connectorList: readonly ConnectorResponse[],
-  connectorScopedSecretNames: ConnectorScopedSecretNames,
-): Set<string> {
-  const provided = new Set<string>();
+): ConnectorProvidedBinding[] {
+  const provided: ConnectorProvidedBinding[] = [];
   for (const connector of connectorList) {
     const metadata = getConnectorAuthMethodRuntimeMetadata(
       connector.type,
@@ -428,14 +404,34 @@ function connectorProvidedEnvNamesForStoredConnectors(
     if (!metadata) {
       continue;
     }
-    for (const { envName, source } of metadata.runtimeBindings) {
-      if (source.kind !== "connector-secret") {
-        continue;
+    for (const { envName, required, source } of metadata.runtimeBindings) {
+      switch (source.kind) {
+        case "connector-secret": {
+          provided.push({
+            connectorType: connector.type,
+            authMethod: connector.authMethod,
+            namespace: "secrets",
+            name: envName,
+            required,
+            source,
+          });
+          break;
+        }
+        case "connector-variable": {
+          provided.push({
+            connectorType: connector.type,
+            authMethod: connector.authMethod,
+            namespace: "vars",
+            name: envName,
+            required,
+            source,
+          });
+          break;
+        }
+        case "platform-secret": {
+          break;
+        }
       }
-      if (!connectorScopedSecretNames.secretNames.has(source.name)) {
-        continue;
-      }
-      provided.add(envName);
     }
   }
   return provided;

--- a/turbo/apps/api/src/signals/services/zero-telegram-data.service.ts
+++ b/turbo/apps/api/src/signals/services/zero-telegram-data.service.ts
@@ -4,6 +4,7 @@ import type {
   TelegramBotStatus,
   TelegramLinkStatusResponse,
 } from "@vm0/api-contracts/contracts/zero-integrations-telegram";
+import { connectorProvidedBindingNames } from "@vm0/api-contracts/contracts/connector-schemas";
 import type { FeatureSwitchContext } from "@vm0/core/feature-switch";
 import { extractAndGroupVariables } from "@vm0/core/variable-expander";
 import {
@@ -280,13 +281,20 @@ function telegramEnvironment(args: {
       ...secretList.secrets.map((secret) => {
         return secret.name;
       }),
-      ...connectorList.connectorProvidedEnvNames,
+      ...connectorProvidedBindingNames({
+        bindings: connectorList.connectorProvidedBindings,
+        namespace: "secrets",
+      }),
     ]);
-    const existingVarNames = new Set(
-      variableList.variables.map((variable) => {
+    const existingVarNames = new Set([
+      ...variableList.variables.map((variable) => {
         return variable.name;
       }),
-    );
+      ...connectorProvidedBindingNames({
+        bindings: connectorList.connectorProvidedBindings,
+        namespace: "vars",
+      }),
+    ]);
 
     return {
       requiredSecrets,

--- a/turbo/apps/cli/src/commands/compose/__tests__/index.test.ts
+++ b/turbo/apps/cli/src/commands/compose/__tests__/index.test.ts
@@ -1409,7 +1409,7 @@ agents:
           return HttpResponse.json({
             connectors: [],
             configuredTypes: [],
-            connectorProvidedEnvNames: [],
+            connectorProvidedBindings: [],
           });
         }),
       );
@@ -2508,6 +2508,85 @@ agents:
       expect(logCalls).toContain("Missing secrets/variables detected");
       expect(logCalls).toContain("API_KEY");
       expect(logCalls).toContain("REGION");
+    });
+
+    it("should not show missing items for required connector-provided bindings", async () => {
+      await fs.writeFile(
+        path.join(tempDir, "vm0.yaml"),
+        yaml.stringify({
+          version: "1.0",
+          agents: {
+            test: {
+              framework: "claude-code",
+              environment: {
+                GH_TOKEN: "${{ secrets.GH_TOKEN }}",
+                REGION: "${{ vars.REGION }}",
+                GITLAB_HOST: "${{ vars.GITLAB_HOST }}",
+              },
+            },
+          },
+        }),
+      );
+
+      server.use(
+        composeApiHandler,
+        orgApiHandler,
+        http.get("http://localhost:3000/api/zero/secrets", () => {
+          return HttpResponse.json({ secrets: [] });
+        }),
+        http.get("http://localhost:3000/api/zero/variables", () => {
+          return HttpResponse.json({ variables: [] });
+        }),
+        http.get("http://localhost:3000/api/zero/connectors", () => {
+          return HttpResponse.json({
+            connectors: [],
+            configuredTypes: [],
+            connectorProvidedBindings: [
+              {
+                connectorType: "github",
+                authMethod: "oauth",
+                namespace: "secrets",
+                name: "GH_TOKEN",
+                required: true,
+                source: {
+                  kind: "connector-secret",
+                  name: "GITHUB_ACCESS_TOKEN",
+                },
+              },
+              {
+                connectorType: "gitlab",
+                authMethod: "api-token",
+                namespace: "vars",
+                name: "REGION",
+                required: true,
+                source: {
+                  kind: "connector-variable",
+                  name: "GITLAB_REGION",
+                },
+              },
+              {
+                connectorType: "gitlab",
+                authMethod: "api-token",
+                namespace: "vars",
+                name: "GITLAB_HOST",
+                required: false,
+                source: {
+                  kind: "connector-variable",
+                  name: "GITLAB_HOST",
+                },
+              },
+            ],
+          });
+        }),
+      );
+
+      await composeCommand.parseAsync(["node", "cli"]);
+
+      const logCalls = mockConsoleLog.mock.calls.flat().join("\n");
+      expect(logCalls).toContain("Missing secrets/variables detected");
+      expect(logCalls).not.toContain("GH_TOKEN");
+      expect(logCalls).not.toContain("REGION");
+      expect(logCalls).toContain("GITLAB_HOST");
     });
 
     it("should not include missing items in JSON output", async () => {

--- a/turbo/apps/cli/src/commands/compose/index.ts
+++ b/turbo/apps/cli/src/commands/compose/index.ts
@@ -4,6 +4,7 @@ import { readFile, rm } from "fs/promises";
 import { existsSync } from "fs";
 import { dirname, join } from "path";
 import { parse as parseYaml } from "yaml";
+import { connectorProvidedBindingNames } from "@vm0/api-contracts/contracts/connector-schemas";
 import { extractAndGroupVariables } from "@vm0/core/variable-expander";
 import {
   getComposeByName,
@@ -208,19 +209,22 @@ async function checkAndPromptMissingItems(
     }),
   );
 
-  // Connector-provided environment names (e.g., GH_TOKEN from GitHub connector)
-  // Use server-computed list to avoid CLI/server version skew issues
-  const connectorProvidedEnvNames = new Set(
-    connectorsResponse.connectorProvidedEnvNames,
-  );
+  const connectorProvidedSecretNames = connectorProvidedBindingNames({
+    bindings: connectorsResponse.connectorProvidedBindings,
+    namespace: "secrets",
+  });
+  const connectorProvidedVarNames = connectorProvidedBindingNames({
+    bindings: connectorsResponse.connectorProvidedBindings,
+    namespace: "vars",
+  });
 
   const missingSecrets = [...requiredSecrets].filter((name) => {
     return (
-      !existingSecretNames.has(name) && !connectorProvidedEnvNames.has(name)
+      !existingSecretNames.has(name) && !connectorProvidedSecretNames.has(name)
     );
   });
   const missingVars = [...requiredVars].filter((name) => {
-    return !existingVarNames.has(name);
+    return !existingVarNames.has(name) && !connectorProvidedVarNames.has(name);
   });
 
   if (missingSecrets.length === 0 && missingVars.length === 0) {

--- a/turbo/apps/cli/src/commands/zero/__tests__/whoami.test.ts
+++ b/turbo/apps/cli/src/commands/zero/__tests__/whoami.test.ts
@@ -259,7 +259,7 @@ describe("zero whoami command", () => {
               },
             ],
             configuredTypes: ["github", "google"],
-            connectorProvidedEnvNames: [],
+            connectorProvidedBindings: [],
           });
         }),
       );
@@ -318,7 +318,7 @@ describe("zero whoami command", () => {
               },
             ],
             configuredTypes: ["slack"],
-            connectorProvidedEnvNames: [],
+            connectorProvidedBindings: [],
           });
         }),
       );
@@ -397,7 +397,7 @@ describe("zero whoami command", () => {
           return HttpResponse.json({
             connectors: [],
             configuredTypes: [],
-            connectorProvidedEnvNames: [],
+            connectorProvidedBindings: [],
           });
         }),
       );
@@ -449,7 +449,7 @@ describe("zero whoami command", () => {
               },
             ],
             configuredTypes: ["github"],
-            connectorProvidedEnvNames: [],
+            connectorProvidedBindings: [],
           });
         }),
       );
@@ -514,7 +514,7 @@ describe("zero whoami command", () => {
               },
             ],
             configuredTypes: ["slack"],
-            connectorProvidedEnvNames: [],
+            connectorProvidedBindings: [],
           });
         }),
         mockUserPermissionGrantsHandler([
@@ -593,7 +593,7 @@ describe("zero whoami command", () => {
               },
             ],
             configuredTypes: ["github"],
-            connectorProvidedEnvNames: [],
+            connectorProvidedBindings: [],
           });
         }),
         mockUserPermissionGrantsHandler(),
@@ -652,7 +652,7 @@ describe("zero whoami command", () => {
               },
             ],
             configuredTypes: ["github"],
-            connectorProvidedEnvNames: [],
+            connectorProvidedBindings: [],
           });
         }),
         http.get(
@@ -730,7 +730,7 @@ describe("zero whoami command", () => {
               },
             ],
             configuredTypes: ["github"],
-            connectorProvidedEnvNames: [],
+            connectorProvidedBindings: [],
           });
         }),
         mockUserPermissionGrantsHandler([
@@ -817,7 +817,7 @@ describe("zero whoami command", () => {
               },
             ],
             configuredTypes: ["github", "axiom"],
-            connectorProvidedEnvNames: [],
+            connectorProvidedBindings: [],
           });
         }),
       );

--- a/turbo/apps/cli/src/commands/zero/agent/__tests__/view.test.ts
+++ b/turbo/apps/cli/src/commands/zero/agent/__tests__/view.test.ts
@@ -28,7 +28,7 @@ function mockConnectorListHandler(
     return HttpResponse.json({
       connectors,
       configuredTypes,
-      connectorProvidedEnvNames: [],
+      connectorProvidedBindings: [],
     });
   });
 }

--- a/turbo/apps/cli/src/commands/zero/connector/__tests__/search.test.ts
+++ b/turbo/apps/cli/src/commands/zero/connector/__tests__/search.test.ts
@@ -36,7 +36,7 @@ function stubConnectors(connectors: Array<Record<string, unknown>>) {
       configuredTypes: connectors.map((c) => {
         return c.type as string;
       }),
-      connectorProvidedEnvNames: [],
+      connectorProvidedBindings: [],
     });
   });
 }

--- a/turbo/apps/cli/src/commands/zero/generate/__tests__/lister.test.ts
+++ b/turbo/apps/cli/src/commands/zero/generate/__tests__/lister.test.ts
@@ -43,7 +43,7 @@ function stubConnectorsWithConfiguredTypes(
     return HttpResponse.json({
       connectors,
       configuredTypes,
-      connectorProvidedEnvNames: [],
+      connectorProvidedBindings: [],
     });
   });
 }

--- a/turbo/apps/cli/src/mocks/handlers/api-handlers.ts
+++ b/turbo/apps/cli/src/mocks/handlers/api-handlers.ts
@@ -115,13 +115,13 @@ export const apiHandlers = [
   // GET /api/zero/connectors - listZeroConnectors
   http.get("http://localhost:3000/api/zero/connectors", () => {
     return HttpResponse.json(
-      { connectors: [], configuredTypes: [], connectorProvidedEnvNames: [] },
+      { connectors: [], configuredTypes: [], connectorProvidedBindings: [] },
       { status: 200 },
     );
   }),
   http.get("https://www.vm0.ai/api/zero/connectors", () => {
     return HttpResponse.json(
-      { connectors: [], configuredTypes: [], connectorProvidedEnvNames: [] },
+      { connectors: [], configuredTypes: [], connectorProvidedBindings: [] },
       { status: 200 },
     );
   }),

--- a/turbo/apps/platform/src/mocks/__tests__/msw-contract.test.ts
+++ b/turbo/apps/platform/src/mocks/__tests__/msw-contract.test.ts
@@ -17,7 +17,7 @@ describe("mockApi contract helper", () => {
         return respond(200, {
           connectors: [],
           configuredTypes: [],
-          connectorProvidedEnvNames: [],
+          connectorProvidedBindings: [],
         });
       }),
     );
@@ -27,7 +27,7 @@ describe("mockApi contract helper", () => {
     await expect(response.json()).resolves.toStrictEqual({
       connectors: [],
       configuredTypes: [],
-      connectorProvidedEnvNames: [],
+      connectorProvidedBindings: [],
     });
   });
 

--- a/turbo/apps/platform/src/mocks/handlers/api-connectors.ts
+++ b/turbo/apps/platform/src/mocks/handlers/api-connectors.ts
@@ -123,7 +123,7 @@ export const apiConnectorsHandlers = [
     return respond(200, {
       connectors: mockConnectors,
       configuredTypes: [...CONNECTOR_TYPE_KEYS],
-      connectorProvidedEnvNames: [],
+      connectorProvidedBindings: [],
     });
   }),
 

--- a/turbo/apps/platform/src/signals/zero-page/settings/__tests__/connect-connector.test.ts
+++ b/turbo/apps/platform/src/signals/zero-page/settings/__tests__/connect-connector.test.ts
@@ -35,7 +35,7 @@ function makeEmptyConnectorResponse(): ConnectorListResponse {
   return {
     connectors: [],
     configuredTypes: [],
-    connectorProvidedEnvNames: [],
+    connectorProvidedBindings: [],
   };
 }
 
@@ -56,7 +56,7 @@ function makeGithubConnectorResponse(): ConnectorListResponse {
       },
     ],
     configuredTypes: ["github"],
-    connectorProvidedEnvNames: [],
+    connectorProvidedBindings: [],
   };
 }
 
@@ -80,7 +80,7 @@ function makeTestOauthConnectorResponse(
       },
     ],
     configuredTypes: ["test-oauth"],
-    connectorProvidedEnvNames: [],
+    connectorProvidedBindings: [],
   };
 }
 

--- a/turbo/apps/platform/src/views/conn/__tests__/add-connection-dialog.test.tsx
+++ b/turbo/apps/platform/src/views/conn/__tests__/add-connection-dialog.test.tsx
@@ -347,7 +347,7 @@ describe("connect modal - content by auth method", () => {
           return respond(200, {
             connectors: [],
             configuredTypes: [],
-            connectorProvidedEnvNames: [],
+            connectorProvidedBindings: [],
           });
         }
         return never();
@@ -416,7 +416,7 @@ describe("connect modal - loading states", () => {
           return respond(200, {
             connectors: [],
             configuredTypes: [],
-            connectorProvidedEnvNames: [],
+            connectorProvidedBindings: [],
           });
         }
         return never();

--- a/turbo/apps/platform/src/views/zero-page/__tests__/onboarding-connect-permission.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/onboarding-connect-permission.test.tsx
@@ -43,7 +43,7 @@ function makeGithubConnectedResponse(): ConnectorListResponse {
       },
     ],
     configuredTypes: ["github"],
-    connectorProvidedEnvNames: [],
+    connectorProvidedBindings: [],
   };
 }
 

--- a/turbo/apps/platform/src/views/zero-page/__tests__/zero-chat-composer-interaction.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/zero-chat-composer-interaction.test.tsx
@@ -329,7 +329,7 @@ describe("zero chat composer - connectors popover", () => {
             },
           ],
           configuredTypes: [],
-          connectorProvidedEnvNames: [],
+          connectorProvidedBindings: [],
         });
       }),
       mockApi(zeroUserConnectorsContract.get, ({ respond }) => {

--- a/turbo/packages/api-contracts/src/contracts/connector-schemas.ts
+++ b/turbo/packages/api-contracts/src/contracts/connector-schemas.ts
@@ -20,13 +20,63 @@ export const connectorResponseSchema = z.object({
 
 export type ConnectorResponse = z.infer<typeof connectorResponseSchema>;
 
+export const connectorProvidedBindingNamespaceSchema = z.enum([
+  "secrets",
+  "vars",
+]);
+
+export const connectorProvidedBindingSourceSchema = z.discriminatedUnion(
+  "kind",
+  [
+    z.object({
+      kind: z.literal("connector-secret"),
+      name: z.string(),
+    }),
+    z.object({
+      kind: z.literal("connector-variable"),
+      name: z.string(),
+    }),
+  ],
+);
+
+export const connectorProvidedBindingSchema = z.object({
+  connectorType: connectorTypeSchema,
+  authMethod: z.string(),
+  namespace: connectorProvidedBindingNamespaceSchema,
+  name: z.string(),
+  required: z.boolean(),
+  source: connectorProvidedBindingSourceSchema,
+});
+
+export type ConnectorProvidedBinding = z.infer<
+  typeof connectorProvidedBindingSchema
+>;
+export type ConnectorProvidedBindingNamespace = z.infer<
+  typeof connectorProvidedBindingNamespaceSchema
+>;
+
+export function connectorProvidedBindingNames(args: {
+  readonly bindings: readonly ConnectorProvidedBinding[];
+  readonly namespace: ConnectorProvidedBindingNamespace;
+}): Set<string> {
+  const names = new Set<string>();
+  for (const binding of args.bindings) {
+    if (binding.namespace === args.namespace && binding.required) {
+      names.add(binding.name);
+    }
+  }
+  return names;
+}
+
 /**
  * List connectors response
  */
 export const connectorListResponseSchema = z.object({
   connectors: z.array(connectorResponseSchema),
   configuredTypes: z.array(connectorTypeSchema),
-  connectorProvidedEnvNames: z.array(z.string()),
+  connectorProvidedBindings: z
+    .array(connectorProvidedBindingSchema)
+    .default([]),
 });
 
 export type ConnectorListResponse = z.infer<typeof connectorListResponseSchema>;

--- a/turbo/packages/api-contracts/src/contracts/index.ts
+++ b/turbo/packages/api-contracts/src/contracts/index.ts
@@ -718,6 +718,7 @@ export {
   type ConnectorAuthMethodConfig,
   type ConnectorAuthMethodId,
   type ConnectorEnvBindings,
+  type ConnectorEnvBindingValue,
 } from "@vm0/connectors/connectors";
 export {
   getConnectorOwnedSecretNames,
@@ -727,10 +728,16 @@ export {
 export {
   connectorResponseSchema,
   connectorListResponseSchema,
+  connectorProvidedBindingNames,
+  connectorProvidedBindingNamespaceSchema,
+  connectorProvidedBindingSchema,
+  connectorProvidedBindingSourceSchema,
   scopeDiffResponseSchema,
   type ScopeDiffResponse,
   type ConnectorResponse,
   type ConnectorListResponse,
+  type ConnectorProvidedBinding,
+  type ConnectorProvidedBindingNamespace,
 } from "./connector-schemas";
 
 export {

--- a/turbo/packages/connectors/src/__tests__/connectors.test.ts
+++ b/turbo/packages/connectors/src/__tests__/connectors.test.ts
@@ -2122,6 +2122,7 @@ describe("getConnectorAuthMethodRuntimeMetadata", () => {
         {
           envName: "GH_TOKEN",
           valueRef: "$secrets.GITHUB_ACCESS_TOKEN",
+          required: true,
           source: {
             kind: "connector-secret",
             name: "GITHUB_ACCESS_TOKEN",
@@ -2130,6 +2131,7 @@ describe("getConnectorAuthMethodRuntimeMetadata", () => {
         {
           envName: "GITHUB_TOKEN",
           valueRef: "$secrets.GITHUB_ACCESS_TOKEN",
+          required: true,
           source: {
             kind: "connector-secret",
             name: "GITHUB_ACCESS_TOKEN",
@@ -2151,6 +2153,7 @@ describe("getConnectorAuthMethodRuntimeMetadata", () => {
         {
           envName: "STRIPE_TOKEN",
           valueRef: "$secrets.STRIPE_TOKEN",
+          required: true,
           source: {
             kind: "connector-secret",
             name: "STRIPE_TOKEN",
@@ -2176,6 +2179,7 @@ describe("getConnectorAuthMethodRuntimeMetadata", () => {
         {
           envName: "SLOCK_TOKEN",
           valueRef: "$secrets.SLOCK_ACCESS_TOKEN",
+          required: true,
           source: {
             kind: "connector-secret",
             name: "SLOCK_ACCESS_TOKEN",
@@ -2184,6 +2188,7 @@ describe("getConnectorAuthMethodRuntimeMetadata", () => {
         {
           envName: "SLOCK_SERVER_ID",
           valueRef: "$secrets.SLOCK_SERVER_ID",
+          required: true,
           source: {
             kind: "connector-secret",
             name: "SLOCK_SERVER_ID",
@@ -2205,6 +2210,7 @@ describe("getConnectorAuthMethodRuntimeMetadata", () => {
         {
           envName: "GOOGLE_ADS_TOKEN",
           valueRef: "$secrets.GOOGLE_ADS_ACCESS_TOKEN",
+          required: true,
           source: {
             kind: "connector-secret",
             name: "GOOGLE_ADS_ACCESS_TOKEN",
@@ -2213,6 +2219,7 @@ describe("getConnectorAuthMethodRuntimeMetadata", () => {
         {
           envName: "GOOGLE_ADS_DEVELOPER_TOKEN",
           valueRef: "$secrets.GOOGLE_ADS_DEVELOPER_TOKEN",
+          required: true,
           source: {
             kind: "platform-secret",
             name: "GOOGLE_ADS_DEVELOPER_TOKEN",
@@ -2220,6 +2227,63 @@ describe("getConnectorAuthMethodRuntimeMetadata", () => {
         },
       ],
     });
+  });
+
+  it("preserves optional runtime binding requiredness", () => {
+    expect(
+      getConnectorAuthMethodRuntimeMetadata("agora", "api-token"),
+    ).toMatchObject({
+      runtimeBindings: expect.arrayContaining([
+        {
+          envName: "AGORA_APP_CERTIFICATE",
+          valueRef: "$secrets.AGORA_APP_CERTIFICATE",
+          required: false,
+          source: {
+            kind: "connector-secret",
+            name: "AGORA_APP_CERTIFICATE",
+          },
+        },
+      ]),
+    });
+  });
+
+  it("marks runtime bindings for optional manual fields as optional", () => {
+    for (const type of connectorTypeSchema.options) {
+      for (const authMethod of getConfiguredConnectorAuthMethodIds(type)) {
+        const method = getConnectorAuthMethod(type, authMethod);
+        const runtimeMetadata = getConnectorAuthMethodRuntimeMetadata(
+          type,
+          authMethod,
+        );
+        if (!method || !runtimeMetadata || method.grant.kind !== "manual") {
+          continue;
+        }
+
+        for (const [fieldName, field] of Object.entries(method.grant.fields)) {
+          if (field.required !== false) {
+            continue;
+          }
+          const sourceKind =
+            field.storage === "variable"
+              ? "connector-variable"
+              : "connector-secret";
+          const runtimeBindings = runtimeMetadata.runtimeBindings.filter(
+            (binding) => {
+              return (
+                binding.source.kind === sourceKind &&
+                binding.source.name === fieldName
+              );
+            },
+          );
+          for (const binding of runtimeBindings) {
+            expect(
+              binding.required,
+              `${type}/${authMethod}: optional field ${fieldName} must not be marked as a required runtime binding`,
+            ).toBe(false);
+          }
+        }
+      }
+    }
   });
 });
 

--- a/turbo/packages/connectors/src/connector-search.ts
+++ b/turbo/packages/connectors/src/connector-search.ts
@@ -4,6 +4,7 @@ import {
   type ConnectorAccessConfig,
   type ConnectorAuthMethodConfig,
   type ConnectorConfig,
+  type ConnectorEnvBindingValue,
   type ConnectorType,
 } from "./connectors";
 import { getConnectorEnvBindingEntries } from "./connector-utils";
@@ -48,7 +49,7 @@ function tokenize(input: string): Set<string> {
 
 function connectorAccessEnvBindings(
   access: ConnectorAccessConfig,
-): Record<string, string> {
+): Record<string, ConnectorEnvBindingValue> {
   switch (access.kind) {
     case "static":
     case "refresh-token":
@@ -64,6 +65,10 @@ function getManualGrantFields(
   return method.grant.kind === "manual" ? method.grant.fields : undefined;
 }
 
+function connectorEnvBindingValueRef(value: ConnectorEnvBindingValue): string {
+  return typeof value === "string" ? value : value.valueRef;
+}
+
 function listSecretNames(config: ConnectorConfig): string[] {
   const names: string[] = [];
   for (const method of Object.values(config.authMethods)) {
@@ -73,8 +78,9 @@ function listSecretNames(config: ConnectorConfig): string[] {
     for (const valueRef of Object.values(
       connectorAccessEnvBindings(method.access),
     )) {
-      if (valueRef.startsWith("$secrets.")) {
-        names.push(valueRef.slice("$secrets.".length));
+      const ref = connectorEnvBindingValueRef(valueRef);
+      if (ref.startsWith("$secrets.")) {
+        names.push(ref.slice("$secrets.".length));
       }
     }
   }

--- a/turbo/packages/connectors/src/connector-utils.ts
+++ b/turbo/packages/connectors/src/connector-utils.ts
@@ -35,6 +35,7 @@ import {
   type ConnectorRevokeKind,
   type ConnectorSecretValueRef,
   type ConnectorVariableValueRef,
+  type ConnectorEnvBindingValue,
   type ConnectorType,
   type AuthCodeGrantConnectorType,
   type DeviceAuthGrantConnectorType,
@@ -256,6 +257,12 @@ function connectorAccessEnvBindings(
   }
 }
 
+function connectorAccessRuntimeEnvBindings(
+  access: ConnectorAccessConfig,
+): ConnectorRuntimeEnvBindings {
+  return connectorRuntimeEnvBindings(connectorAccessEnvBindings(access));
+}
+
 function connectorAccessPlatformSecrets(
   access: ConnectorAccessConfig,
 ): readonly ConnectorPlatformSecretName[] {
@@ -271,7 +278,7 @@ function connectorAccessPlatformSecrets(
 export type ConnectorAuthMethodAccessMetadata =
   | {
       readonly kind: "static";
-      readonly envBindings: ConnectorEnvBindings;
+      readonly envBindings: ConnectorRuntimeEnvBindings;
       readonly platformSecrets: readonly ConnectorPlatformSecretName[];
     }
   | {
@@ -283,12 +290,12 @@ export type ConnectorAuthMethodAccessMetadata =
         Record<string, ConnectorRefreshTokenOutputMetadata>
       >;
       readonly refreshableSecrets: readonly string[];
-      readonly envBindings: ConnectorEnvBindings;
+      readonly envBindings: ConnectorRuntimeEnvBindings;
       readonly platformSecrets: readonly ConnectorPlatformSecretName[];
     }
   | {
       readonly kind: "none";
-      readonly envBindings: ConnectorEnvBindings;
+      readonly envBindings: ConnectorRuntimeEnvBindings;
       readonly platformSecrets: readonly ConnectorPlatformSecretName[];
     };
 
@@ -365,6 +372,7 @@ export type ConnectorRuntimeBindingSource =
 export interface ConnectorRuntimeBindingEntry {
   readonly envName: string;
   readonly valueRef: string;
+  readonly required: boolean;
   readonly source: ConnectorRuntimeBindingSource;
 }
 
@@ -473,7 +481,7 @@ export function getConnectorAuthMethodAccessMetadata(
     case "static": {
       return {
         kind: "static",
-        envBindings: method.access.envBindings,
+        envBindings: connectorAccessRuntimeEnvBindings(method.access),
         platformSecrets: method.access.platformSecrets ?? [],
       };
     }
@@ -481,7 +489,7 @@ export function getConnectorAuthMethodAccessMetadata(
       return {
         kind: "refresh-token",
         ...connectorRefreshMetadata(method.access),
-        envBindings: method.access.envBindings,
+        envBindings: connectorAccessRuntimeEnvBindings(method.access),
         platformSecrets: method.access.platformSecrets ?? [],
       };
     case "none":
@@ -610,12 +618,41 @@ function connectorPlatformSecretSource(
   });
 }
 
+export type ConnectorRuntimeEnvBindings = Record<
+  string,
+  ConnectorRefreshTokenInputValueRef
+>;
+
+function connectorEnvBindingValueRef(
+  binding: ConnectorEnvBindingValue,
+): ConnectorRefreshTokenInputValueRef {
+  return typeof binding === "string" ? binding : binding.valueRef;
+}
+
+function connectorEnvBindingRequired(
+  binding: ConnectorEnvBindingValue,
+): boolean {
+  return typeof binding === "string" ? true : (binding.required ?? true);
+}
+
+function connectorRuntimeEnvBindings(
+  envBindings: ConnectorEnvBindings,
+): ConnectorRuntimeEnvBindings {
+  return Object.fromEntries(
+    Object.entries(envBindings).map(([envName, binding]) => {
+      return [envName, connectorEnvBindingValueRef(binding)];
+    }),
+  );
+}
+
 function connectorRuntimeBindingEntries(args: {
   readonly envBindings: ConnectorEnvBindings;
   readonly platformSecrets: readonly ConnectorPlatformSecretName[];
 }): ConnectorRuntimeBindingEntry[] {
   const entries: ConnectorRuntimeBindingEntry[] = [];
-  for (const [envName, valueRef] of Object.entries(args.envBindings)) {
+  for (const [envName, binding] of Object.entries(args.envBindings)) {
+    const valueRef = connectorEnvBindingValueRef(binding);
+    const required = connectorEnvBindingRequired(binding);
     if (valueRef.startsWith(CONNECTOR_SECRET_REF_PREFIX)) {
       const secretName = valueRef.slice(CONNECTOR_SECRET_REF_PREFIX.length);
       const platformSecret = connectorPlatformSecretSource(
@@ -625,6 +662,7 @@ function connectorRuntimeBindingEntries(args: {
       entries.push({
         envName,
         valueRef,
+        required,
         source: platformSecret
           ? { kind: "platform-secret", name: platformSecret }
           : { kind: "connector-secret", name: secretName },
@@ -636,6 +674,7 @@ function connectorRuntimeBindingEntries(args: {
       entries.push({
         envName,
         valueRef,
+        required,
         source: {
           kind: "connector-variable",
           name: valueRef.slice(CONNECTOR_VARIABLE_REF_PREFIX.length),
@@ -1292,9 +1331,9 @@ function connectorAuthMethodOwnedVariableNames(
 export function getConnectorAuthMethodEnvBindings(
   type: ConnectorType,
   authMethod: string,
-): ConnectorEnvBindings {
+): ConnectorRuntimeEnvBindings {
   const method = getConnectorAuthMethod(type, authMethod);
-  return method ? connectorAccessEnvBindings(method.access) : {};
+  return method ? connectorAccessRuntimeEnvBindings(method.access) : {};
 }
 
 export interface ConnectorEnvBindingEntry {

--- a/turbo/packages/connectors/src/connectors.ts
+++ b/turbo/packages/connectors/src/connectors.ts
@@ -353,8 +353,6 @@ export type ConnectorGrantConfig =
 
 export type ConnectorAccessKind = "static" | "refresh-token" | "none";
 
-export type ConnectorEnvBindings = Record<string, string>;
-
 export const CONNECTOR_PLATFORM_SECRET_NAMES = [
   "GOOGLE_ADS_DEVELOPER_TOKEN",
 ] as const;
@@ -366,6 +364,13 @@ export type ConnectorVariableValueRef = `$vars.${string}`;
 export type ConnectorRefreshTokenInputValueRef =
   | ConnectorSecretValueRef
   | ConnectorVariableValueRef;
+export type ConnectorEnvBindingValue =
+  | ConnectorRefreshTokenInputValueRef
+  | {
+      readonly valueRef: ConnectorRefreshTokenInputValueRef;
+      readonly required?: boolean;
+    };
+export type ConnectorEnvBindings = Record<string, ConnectorEnvBindingValue>;
 
 export type ConnectorGrantOutputBindings = Record<
   string,
@@ -650,13 +655,26 @@ type ConnectorRefreshOutputValueRef<Storage> =
 type ConnectorRevokeInputValueRef<Storage> =
   `$secrets.${ConnectorStorageSecretName<Storage>}`;
 
+type ValidatedConnectorEnvBindingValue<Binding, Storage, Access> =
+  Binding extends { readonly valueRef: infer ValueRef }
+    ? Binding & {
+        readonly valueRef: ValueRef extends ConnectorRuntimeValueRef<
+          Storage,
+          Access
+        >
+          ? ValueRef
+          : ConnectorRuntimeValueRef<Storage, Access>;
+      }
+    : Binding extends ConnectorRuntimeValueRef<Storage, Access>
+      ? Binding
+      : ConnectorRuntimeValueRef<Storage, Access>;
+
 type ValidatedConnectorEnvBindings<EnvBindings, Storage, Access> = {
-  readonly [EnvName in keyof EnvBindings]: EnvBindings[EnvName] extends ConnectorRuntimeValueRef<
+  readonly [EnvName in keyof EnvBindings]: ValidatedConnectorEnvBindingValue<
+    EnvBindings[EnvName],
     Storage,
     Access
-  >
-    ? EnvBindings[EnvName]
-    : ConnectorRuntimeValueRef<Storage, Access>;
+  >;
 };
 
 type ValidatedConnectorRefreshInputs<Inputs, Storage> = {

--- a/turbo/packages/connectors/src/connectors/agora.ts
+++ b/turbo/packages/connectors/src/connectors/agora.ts
@@ -52,7 +52,10 @@ export const agora = {
             AGORA_CUSTOMER_ID: "$secrets.AGORA_CUSTOMER_ID",
             AGORA_CUSTOMER_SECRET: "$secrets.AGORA_CUSTOMER_SECRET",
             AGORA_APP_ID: "$vars.AGORA_APP_ID",
-            AGORA_APP_CERTIFICATE: "$secrets.AGORA_APP_CERTIFICATE",
+            AGORA_APP_CERTIFICATE: {
+              valueRef: "$secrets.AGORA_APP_CERTIFICATE",
+              required: false,
+            },
           },
         },
         revoke: { kind: "none" },

--- a/turbo/packages/connectors/src/connectors/gitlab.ts
+++ b/turbo/packages/connectors/src/connectors/gitlab.ts
@@ -35,7 +35,10 @@ export const gitlab = {
           kind: "static",
           envBindings: {
             GITLAB_TOKEN: "$secrets.GITLAB_TOKEN",
-            GITLAB_HOST: "$vars.GITLAB_HOST",
+            GITLAB_HOST: {
+              valueRef: "$vars.GITLAB_HOST",
+              required: false,
+            },
           },
         },
         revoke: { kind: "none" },


### PR DESCRIPTION
## Summary

- Replace the flat `connectorProvidedEnvNames` connector-list field with structured `connectorProvidedBindings` metadata.
- Add runtime binding requiredness to connector `envBindings` while keeping existing string bindings normalized for runtime callers.
- Generate connector-provided secret and var bindings from stored connector auth-method metadata, independent of backing access-token row existence.
- Migrate CLI/API preflight consumers and mocks to use required structured bindings for both `secrets` and `vars`.

Closes #16207

## Tests

- `pnpm -F @vm0/connectors check-types`
- `pnpm -F @vm0/api-contracts check-types`
- `pnpm -F api check-types`
- `pnpm -F @vm0/cli check-types`
- `pnpm -F @vm0/app check-types`
- `pnpm -F @vm0/connectors lint`
- `pnpm -F @vm0/api-contracts lint`
- `pnpm -F api lint`
- `pnpm -F @vm0/cli lint`
- `pnpm -F @vm0/app lint`
- `pnpm -F @vm0/connectors exec vitest src/__tests__/connectors.test.ts`
- `pnpm -F api exec vitest src/signals/services/__tests__/zero-connector-data.service.test.ts`
- `pnpm -F api exec vitest src/signals/routes/__tests__/zero-connectors-list.test.ts`
- `pnpm -F @vm0/cli exec vitest src/commands/compose/__tests__/index.test.ts`
- pre-commit: prettier, knip, `pnpm check-types`
