### PR TITLE
feat: migrate legacy schedules to chat thread from schedules page

### DIFF
--- a/turbo/apps/api/src/signals/routes/__tests__/zero-schedules-migrate-chat.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/zero-schedules-migrate-chat.test.ts
@@ -2,10 +2,12 @@ import { randomUUID } from "node:crypto";
 
 import { zeroScheduleMigrateChatContract } from "@vm0/api-contracts/contracts/zero-schedules";
 import { chatThreads } from "@vm0/db/schema/chat-thread";
+import { zeroAgentSchedules } from "@vm0/db/schema/zero-agent-schedule";
 import { userFeatureSwitches } from "@vm0/db/schema/user-feature-switches";
 import { FeatureSwitchKey } from "@vm0/connectors/feature-switch-key";
 import { createStore } from "ccstate";
 import { eq } from "drizzle-orm";
+import { delay } from "signal-timers";
 
 import { accept, setupApp, testContext } from "../../../__tests__/test-helpers";
 import { writeDb$ } from "../../external/db";
@@ -22,6 +24,20 @@ import {
 const context = testContext();
 const store = createStore();
 const mocks = createZeroRouteMocks(context);
+
+function deferred(): {
+  readonly promise: Promise<void>;
+  readonly resolve: () => void;
+} {
+  let resolveDeferred: (() => void) | undefined;
+  const promise = new Promise<void>((resolve) => {
+    resolveDeferred = resolve;
+  });
+  if (!resolveDeferred) {
+    throw new Error("Failed to create deferred promise");
+  }
+  return { promise, resolve: resolveDeferred };
+}
 
 async function enableChatMode(fixture: SchedulesFixture): Promise<void> {
   const db = store.set(writeDb$);
@@ -105,6 +121,58 @@ describe("POST /api/zero/schedules/:name/migrate-to-chat", () => {
 
     expect(first.body.chatThreadId).not.toBeNull();
     expect(second.body.chatThreadId).toBe(first.body.chatThreadId);
+  });
+
+  it("keeps concurrent migrations linked to one chat thread", async () => {
+    const fixture = await seedLegacy("legacy-race");
+    await enableChatMode(fixture);
+    mocks.clerk.session(fixture.userId, fixture.orgId);
+
+    const scheduleId = fixture.scheduleIds[0];
+    if (!scheduleId) {
+      throw new Error("Expected seeded schedule");
+    }
+
+    const db = store.set(writeDb$);
+    const lockReady = deferred();
+    const releaseLock = deferred();
+    const lock = db.transaction(async (tx) => {
+      await tx
+        .select({ id: zeroAgentSchedules.id })
+        .from(zeroAgentSchedules)
+        .where(eq(zeroAgentSchedules.id, scheduleId))
+        .for("update");
+      lockReady.resolve();
+      await releaseLock.promise;
+    });
+    await lockReady.promise;
+
+    const migrate = () => {
+      return accept(
+        client().migrateToChat({
+          headers: { authorization: "Bearer clerk-session" },
+          params: { name: "legacy-race" },
+          body: { agentId: fixture.composeId },
+        }),
+        [200],
+      );
+    };
+
+    const requests = Promise.all([migrate(), migrate()]);
+    await delay(100, { signal: context.signal });
+    releaseLock.resolve();
+    await lock;
+
+    const [first, second] = await requests;
+    expect(first.body.chatThreadId).not.toBeNull();
+    expect(second.body.chatThreadId).toBe(first.body.chatThreadId);
+
+    const threads = await db
+      .select({ id: chatThreads.id })
+      .from(chatThreads)
+      .where(eq(chatThreads.agentComposeId, fixture.composeId));
+    expect(threads).toHaveLength(1);
+    expect(threads[0]?.id).toBe(first.body.chatThreadId);
   });
 
   it("returns 400 when chat mode is not enabled", async () => {

--- a/turbo/apps/api/src/signals/routes/__tests__/zero-schedules-migrate-chat.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/zero-schedules-migrate-chat.test.ts
@@ -1,0 +1,154 @@
+import { randomUUID } from "node:crypto";
+
+import { zeroScheduleMigrateChatContract } from "@vm0/api-contracts/contracts/zero-schedules";
+import { chatThreads } from "@vm0/db/schema/chat-thread";
+import { userFeatureSwitches } from "@vm0/db/schema/user-feature-switches";
+import { FeatureSwitchKey } from "@vm0/connectors/feature-switch-key";
+import { createStore } from "ccstate";
+import { eq } from "drizzle-orm";
+
+import { accept, setupApp, testContext } from "../../../__tests__/test-helpers";
+import { writeDb$ } from "../../external/db";
+import {
+  type SchedulesFixture,
+  deleteSchedulesScenario$,
+  seedSchedulesScenario$,
+} from "./helpers/zero-schedules";
+import {
+  createFixtureTracker,
+  createZeroRouteMocks,
+} from "./helpers/zero-route-test";
+
+const context = testContext();
+const store = createStore();
+const mocks = createZeroRouteMocks(context);
+
+async function enableChatMode(fixture: SchedulesFixture): Promise<void> {
+  const db = store.set(writeDb$);
+  await db.insert(userFeatureSwitches).values({
+    orgId: fixture.orgId,
+    userId: fixture.userId,
+    switches: { [FeatureSwitchKey.ScheduledChat]: true },
+  });
+}
+
+describe("POST /api/zero/schedules/:name/migrate-to-chat", () => {
+  const track = createFixtureTracker<SchedulesFixture>((fixture) => {
+    return store.set(deleteSchedulesScenario$, fixture, context.signal);
+  });
+
+  const client = () => {
+    return setupApp({ context })(zeroScheduleMigrateChatContract);
+  };
+
+  const seedLegacy = async (name: string): Promise<SchedulesFixture> => {
+    return await track(
+      store.set(
+        seedSchedulesScenario$,
+        {
+          schedules: [
+            { name, cronExpression: "0 9 * * *", prompt: "Legacy task" },
+          ],
+        },
+        context.signal,
+      ),
+    );
+  };
+
+  it("creates and links a chat thread for a legacy schedule", async () => {
+    const fixture = await seedLegacy("legacy-one");
+    await enableChatMode(fixture);
+    mocks.clerk.session(fixture.userId, fixture.orgId);
+
+    const response = await accept(
+      client().migrateToChat({
+        headers: { authorization: "Bearer clerk-session" },
+        params: { name: "legacy-one" },
+        body: { agentId: fixture.composeId },
+      }),
+      [200],
+    );
+
+    expect(response.body.chatThreadId).not.toBeNull();
+
+    const db = store.set(writeDb$);
+    const [thread] = await db
+      .select({ id: chatThreads.id, userId: chatThreads.userId })
+      .from(chatThreads)
+      .where(eq(chatThreads.id, response.body.chatThreadId ?? ""))
+      .limit(1);
+    expect(thread).toBeDefined();
+    expect(thread?.userId).toBe(fixture.userId);
+  });
+
+  it("is idempotent: an already-linked schedule keeps its thread", async () => {
+    const fixture = await seedLegacy("legacy-idem");
+    await enableChatMode(fixture);
+    mocks.clerk.session(fixture.userId, fixture.orgId);
+
+    const first = await accept(
+      client().migrateToChat({
+        headers: { authorization: "Bearer clerk-session" },
+        params: { name: "legacy-idem" },
+        body: { agentId: fixture.composeId },
+      }),
+      [200],
+    );
+    const second = await accept(
+      client().migrateToChat({
+        headers: { authorization: "Bearer clerk-session" },
+        params: { name: "legacy-idem" },
+        body: { agentId: fixture.composeId },
+      }),
+      [200],
+    );
+
+    expect(first.body.chatThreadId).not.toBeNull();
+    expect(second.body.chatThreadId).toBe(first.body.chatThreadId);
+  });
+
+  it("returns 400 when chat mode is not enabled", async () => {
+    const fixture = await seedLegacy("legacy-no-switch");
+    mocks.clerk.session(fixture.userId, fixture.orgId);
+
+    const response = await accept(
+      client().migrateToChat({
+        headers: { authorization: "Bearer clerk-session" },
+        params: { name: "legacy-no-switch" },
+        body: { agentId: fixture.composeId },
+      }),
+      [400],
+    );
+    expect(response.body.error.code).toBe("BAD_REQUEST");
+  });
+
+  it("returns 404 for a non-existent schedule", async () => {
+    const fixture = await track(
+      store.set(seedSchedulesScenario$, { schedules: [] }, context.signal),
+    );
+    await enableChatMode(fixture);
+    mocks.clerk.session(fixture.userId, fixture.orgId);
+
+    const response = await accept(
+      client().migrateToChat({
+        headers: { authorization: "Bearer clerk-session" },
+        params: { name: "missing" },
+        body: { agentId: fixture.composeId },
+      }),
+      [404],
+    );
+    expect(response.body.error.code).toBe("NOT_FOUND");
+  });
+
+  it("returns 401 for an unauthenticated request", async () => {
+    const response = await accept(
+      client().migrateToChat({
+        headers: {},
+        params: { name: "any" },
+        body: { agentId: randomUUID() },
+      }),
+      [401],
+    );
+    expect(response.status).toBe(401);
+  });
+});

--- a/turbo/apps/api/src/signals/routes/zero-schedules.ts
+++ b/turbo/apps/api/src/signals/routes/zero-schedules.ts
@@ -162,39 +162,41 @@ const enableInner$ = command(async ({ get, set }, signal: AbortSignal) => {
   return { status: 200 as const, body: result.response };
 });
 
-const migrateToChatInner$ = command(async ({ get, set }, signal: AbortSignal) => {
-  const auth = get(organizationAuthContext$);
-  const params = get(
-    pathParamsOf(zeroScheduleMigrateChatContract.migrateToChat),
-  );
-  const bodyResult = await get(
-    bodyResultOf(zeroScheduleMigrateChatContract.migrateToChat),
-  );
-  signal.throwIfAborted();
-  if (!bodyResult.ok) {
-    return bodyResult.response;
-  }
+const migrateToChatInner$ = command(
+  async ({ get, set }, signal: AbortSignal) => {
+    const auth = get(organizationAuthContext$);
+    const params = get(
+      pathParamsOf(zeroScheduleMigrateChatContract.migrateToChat),
+    );
+    const bodyResult = await get(
+      bodyResultOf(zeroScheduleMigrateChatContract.migrateToChat),
+    );
+    signal.throwIfAborted();
+    if (!bodyResult.ok) {
+      return bodyResult.response;
+    }
 
-  const result = await set(
-    migrateScheduleToChat$,
-    {
-      userId: auth.userId,
-      orgId: auth.orgId,
-      agentId: bodyResult.data.agentId,
-      name: params.name,
-    },
-    signal,
-  );
-  signal.throwIfAborted();
+    const result = await set(
+      migrateScheduleToChat$,
+      {
+        userId: auth.userId,
+        orgId: auth.orgId,
+        agentId: bodyResult.data.agentId,
+        name: params.name,
+      },
+      signal,
+    );
+    signal.throwIfAborted();
 
-  if (result.kind === "not_found") {
-    return notFound("Resource not found");
-  }
-  if (result.kind === "bad_request") {
-    return badRequestMessage(result.message);
-  }
-  return { status: 200 as const, body: result.response };
-});
+    if (result.kind === "not_found") {
+      return notFound("Resource not found");
+    }
+    if (result.kind === "bad_request") {
+      return badRequestMessage(result.message);
+    }
+    return { status: 200 as const, body: result.response };
+  },
+);
 
 const runNowInner$ = command(async ({ get, set }, signal: AbortSignal) => {
   const auth = get(organizationAuthContext$);

--- a/turbo/apps/api/src/signals/routes/zero-schedules.ts
+++ b/turbo/apps/api/src/signals/routes/zero-schedules.ts
@@ -1,5 +1,6 @@
 import { command, computed } from "ccstate";
 import {
+  zeroScheduleMigrateChatContract,
   zeroScheduleRunContract,
   zeroSchedulesByNameContract,
   zeroSchedulesEnableContract,
@@ -15,6 +16,7 @@ import {
   deploySchedule$,
   disableSchedule$,
   enableSchedule$,
+  migrateScheduleToChat$,
   runScheduleNow$,
   zeroScheduleList,
 } from "../services/zero-schedules.service";
@@ -160,6 +162,40 @@ const enableInner$ = command(async ({ get, set }, signal: AbortSignal) => {
   return { status: 200 as const, body: result.response };
 });
 
+const migrateToChatInner$ = command(async ({ get, set }, signal: AbortSignal) => {
+  const auth = get(organizationAuthContext$);
+  const params = get(
+    pathParamsOf(zeroScheduleMigrateChatContract.migrateToChat),
+  );
+  const bodyResult = await get(
+    bodyResultOf(zeroScheduleMigrateChatContract.migrateToChat),
+  );
+  signal.throwIfAborted();
+  if (!bodyResult.ok) {
+    return bodyResult.response;
+  }
+
+  const result = await set(
+    migrateScheduleToChat$,
+    {
+      userId: auth.userId,
+      orgId: auth.orgId,
+      agentId: bodyResult.data.agentId,
+      name: params.name,
+    },
+    signal,
+  );
+  signal.throwIfAborted();
+
+  if (result.kind === "not_found") {
+    return notFound("Resource not found");
+  }
+  if (result.kind === "bad_request") {
+    return badRequestMessage(result.message);
+  }
+  return { status: 200 as const, body: result.response };
+});
+
 const runNowInner$ = command(async ({ get, set }, signal: AbortSignal) => {
   const auth = get(organizationAuthContext$);
   const bodyResult = await get(bodyResultOf(zeroScheduleRunContract.run));
@@ -245,6 +281,17 @@ export const zeroSchedulesRoutes: readonly RouteEntry[] = [
         requiredCapability: "schedule:write",
       },
       enableInner$,
+    ),
+  },
+  {
+    route: zeroScheduleMigrateChatContract.migrateToChat,
+    handler: authRoute(
+      {
+        requireOrganization: true,
+        missingOrganizationStatus: 401,
+        requiredCapability: "schedule:write",
+      },
+      migrateToChatInner$,
     ),
   },
   {

--- a/turbo/apps/api/src/signals/services/zero-schedules.service.ts
+++ b/turbo/apps/api/src/signals/services/zero-schedules.service.ts
@@ -1009,6 +1009,7 @@ export const migrateScheduleToChat$ = command(
     }
 
     await publishChatThreadSchedulesChangedSafely(args.userId, thread.id);
+    signal.throwIfAborted();
 
     return {
       kind: "ok",

--- a/turbo/apps/api/src/signals/services/zero-schedules.service.ts
+++ b/turbo/apps/api/src/signals/services/zero-schedules.service.ts
@@ -40,6 +40,7 @@ import {
 } from "./zero-model-selection.service";
 import { visibleJoinedZeroAgentCondition } from "./zero-agent-data.service";
 import { createZeroRun$ } from "./zero-runs-create.service";
+import { createChatThread$ } from "./zero-chat-thread.service";
 import {
   postScheduleUserMessage,
   resolveScheduleChatThreadModelPin,
@@ -380,6 +381,11 @@ type EnableScheduleResult =
   | { readonly kind: "ok"; readonly response: ScheduleResponse }
   | { readonly kind: "not_found" }
   | { readonly kind: "schedule_past" };
+
+type MigrateScheduleToChatResult =
+  | { readonly kind: "ok"; readonly response: ScheduleResponse }
+  | { readonly kind: "not_found" }
+  | { readonly kind: "bad_request"; readonly message: string };
 
 interface ScheduleMutationArgs {
   readonly userId: string;
@@ -919,6 +925,97 @@ export const enableSchedule$ = command(
         orgId: args.orgId,
         userId: args.userId,
         overrides: featureSwitchOverrides,
+      }),
+    };
+  },
+);
+
+/**
+ * Migrate a legacy schedule (chatThreadId === null) to chat mode by creating a
+ * new chat thread and linking it. This is the ONLY path that sets chatThreadId
+ * on an existing schedule; it is gated on the ScheduledChat switch and only
+ * performs the null -> set transition. An already-linked schedule is returned
+ * unchanged so the caller can migrate a batch idempotently.
+ */
+export const migrateScheduleToChat$ = command(
+  async (
+    { get, set },
+    args: ScheduleMutationArgs,
+    signal: AbortSignal,
+  ): Promise<MigrateScheduleToChatResult> => {
+    const db = set(writeDb$);
+
+    const overrides = await get(
+      userFeatureSwitchOverrides(args.orgId, args.userId),
+    );
+    signal.throwIfAborted();
+    const chatModeEnabled = isFeatureEnabled(FeatureSwitchKey.ScheduledChat, {
+      orgId: args.orgId,
+      userId: args.userId,
+      overrides,
+    });
+    if (!chatModeEnabled) {
+      return {
+        kind: "bad_request",
+        message: "Chat-mode schedules are not enabled",
+      };
+    }
+
+    const ownership = await verifyScheduleOwnership(
+      db,
+      args.userId,
+      args.orgId,
+      args.agentId,
+      args.name,
+    );
+    signal.throwIfAborted();
+    if (!ownership.ok) {
+      return { kind: "not_found" };
+    }
+    const { schedule, displayName } = ownership;
+
+    // Already linked: return as-is so a batch migration can skip it cleanly.
+    if (schedule.chatThreadId) {
+      return {
+        kind: "ok",
+        response: await scheduleResponse(schedule, displayName, {
+          orgId: args.orgId,
+          userId: args.userId,
+          overrides,
+        }),
+      };
+    }
+
+    const thread = await set(
+      createChatThread$,
+      {
+        userId: args.userId,
+        agentComposeId: args.agentId,
+        title: schedule.description ?? schedule.name,
+        clientThreadId: undefined,
+      },
+      signal,
+    );
+    signal.throwIfAborted();
+
+    const [updated] = await db
+      .update(zeroAgentSchedules)
+      .set({ chatThreadId: thread.id, updatedAt: nowDate() })
+      .where(eq(zeroAgentSchedules.id, schedule.id))
+      .returning();
+    signal.throwIfAborted();
+    if (!updated) {
+      return { kind: "not_found" };
+    }
+
+    await publishChatThreadSchedulesChangedSafely(args.userId, thread.id);
+
+    return {
+      kind: "ok",
+      response: await scheduleResponse(updated, displayName, {
+        orgId: args.orgId,
+        userId: args.userId,
+        overrides,
       }),
     };
   },

--- a/turbo/apps/api/src/signals/services/zero-schedules.service.ts
+++ b/turbo/apps/api/src/signals/services/zero-schedules.service.ts
@@ -24,7 +24,7 @@ import { zeroAgents } from "@vm0/db/schema/zero-agent";
 import { zeroAgentSchedules } from "@vm0/db/schema/zero-agent-schedule";
 import { zeroRuns } from "@vm0/db/schema/zero-run";
 import { Cron } from "croner";
-import { and, eq, inArray, lte } from "drizzle-orm";
+import { and, eq, inArray, isNull, lte } from "drizzle-orm";
 import { z } from "zod";
 
 import { env, optionalEnv } from "../../lib/env";
@@ -40,7 +40,6 @@ import {
 } from "./zero-model-selection.service";
 import { visibleJoinedZeroAgentCondition } from "./zero-agent-data.service";
 import { createZeroRun$ } from "./zero-runs-create.service";
-import { createChatThread$ } from "./zero-chat-thread.service";
 import {
   postScheduleUserMessage,
   resolveScheduleChatThreadModelPin,
@@ -986,34 +985,75 @@ export const migrateScheduleToChat$ = command(
       };
     }
 
-    const thread = await set(
-      createChatThread$,
-      {
-        userId: args.userId,
-        agentComposeId: args.agentId,
-        title: schedule.description ?? schedule.name,
-        clientThreadId: undefined,
-      },
-      signal,
-    );
-    signal.throwIfAborted();
+    const migration = await db.transaction(async (tx) => {
+      const [thread] = await tx
+        .insert(chatThreads)
+        .values({
+          userId: args.userId,
+          agentComposeId: args.agentId,
+          title: schedule.description ?? schedule.name,
+        })
+        .returning({ id: chatThreads.id });
+      if (!thread) {
+        throw new Error("Failed to create chat thread");
+      }
 
-    const [updated] = await db
-      .update(zeroAgentSchedules)
-      .set({ chatThreadId: thread.id, updatedAt: nowDate() })
-      .where(eq(zeroAgentSchedules.id, schedule.id))
-      .returning();
+      const [updated] = await tx
+        .update(zeroAgentSchedules)
+        .set({ chatThreadId: thread.id, updatedAt: nowDate() })
+        .where(
+          and(
+            eq(zeroAgentSchedules.id, schedule.id),
+            isNull(zeroAgentSchedules.chatThreadId),
+          ),
+        )
+        .returning();
+
+      if (updated) {
+        return {
+          kind: "linked" as const,
+          schedule: updated,
+          threadId: thread.id,
+        };
+      }
+
+      await tx.delete(chatThreads).where(eq(chatThreads.id, thread.id));
+
+      const [current] = await tx
+        .select()
+        .from(zeroAgentSchedules)
+        .where(eq(zeroAgentSchedules.id, schedule.id))
+        .limit(1);
+      if (!current) {
+        return { kind: "not_found" as const };
+      }
+      if (!current.chatThreadId) {
+        throw new Error(
+          `Failed to link schedule ${schedule.id} to chat thread`,
+        );
+      }
+      return {
+        kind: "already_linked" as const,
+        schedule: current,
+        threadId: current.chatThreadId,
+      };
+    });
     signal.throwIfAborted();
-    if (!updated) {
+    if (migration.kind === "not_found") {
       return { kind: "not_found" };
     }
 
-    await publishChatThreadSchedulesChangedSafely(args.userId, thread.id);
-    signal.throwIfAborted();
+    if (migration.kind === "linked") {
+      await publishChatThreadSchedulesChangedSafely(
+        args.userId,
+        migration.threadId,
+      );
+      signal.throwIfAborted();
+    }
 
     return {
       kind: "ok",
-      response: await scheduleResponse(updated, displayName, {
+      response: await scheduleResponse(migration.schedule, displayName, {
         orgId: args.orgId,
         userId: args.userId,
         overrides,

--- a/turbo/apps/platform/src/signals/schedule-page/schedule-page-ui.ts
+++ b/turbo/apps/platform/src/signals/schedule-page/schedule-page-ui.ts
@@ -112,6 +112,12 @@ export const { get$: pageRunningIds$, set$: setPageRunningIds$ } = cell<
 export const { get$: pagePendingDelete$, set$: setPagePendingDelete$ } =
   cell<CombinedEntry | null>(null);
 
+// Whether the user has dismissed the "migrate legacy schedules to chat" modal
+// for this session. In-memory only: the modal may re-surface on a fresh page
+// load while legacy schedules remain.
+export const { get$: migrateDialogDismissed$, set$: setMigrateDialogDismissed$ } =
+  cell(false);
+
 // ---------------------------------------------------------------------------
 // Calendar view state
 // ---------------------------------------------------------------------------

--- a/turbo/apps/platform/src/signals/schedule-page/schedule-page-ui.ts
+++ b/turbo/apps/platform/src/signals/schedule-page/schedule-page-ui.ts
@@ -115,8 +115,10 @@ export const { get$: pagePendingDelete$, set$: setPagePendingDelete$ } =
 // Whether the user has dismissed the "migrate legacy schedules to chat" modal
 // for this session. In-memory only: the modal may re-surface on a fresh page
 // load while legacy schedules remain.
-export const { get$: migrateDialogDismissed$, set$: setMigrateDialogDismissed$ } =
-  cell(false);
+export const {
+  get$: migrateDialogDismissed$,
+  set$: setMigrateDialogDismissed$,
+} = cell(false);
 
 // ---------------------------------------------------------------------------
 // Calendar view state

--- a/turbo/apps/platform/src/signals/zero-page/zero-schedule.ts
+++ b/turbo/apps/platform/src/signals/zero-page/zero-schedule.ts
@@ -592,6 +592,7 @@ export const migrateAllLegacySchedules$ = command(
             [200],
             { toast: false },
           );
+          signal.throwIfAborted();
           set(internalMigrationStatus$, patchMigrationStatus(s.id, "done"));
         } catch (error: unknown) {
           throwIfAbort(error);

--- a/turbo/apps/platform/src/signals/zero-page/zero-schedule.ts
+++ b/turbo/apps/platform/src/signals/zero-page/zero-schedule.ts
@@ -11,6 +11,7 @@ import {
   zeroSchedulesByNameContract,
   zeroSchedulesEnableContract,
   zeroScheduleRunContract,
+  zeroScheduleMigrateChatContract,
   type ScheduleResponse,
 } from "@vm0/api-contracts/contracts/zero-schedules";
 import { zeroClient$ } from "../api-client.ts";
@@ -484,6 +485,133 @@ export const deleteOrgSchedule$ = command(
 
     toast.success("Schedule deleted");
     await set(fetchAllOrgSchedules$, signal);
+  },
+);
+
+// ---------------------------------------------------------------------------
+// Migrate legacy schedules (no chat thread) to chat mode
+// ---------------------------------------------------------------------------
+
+/** Per-schedule migration status, surfaced in the migration modal. */
+export type MigrationStatus = "pending" | "migrating" | "done" | "error";
+
+export interface LegacyScheduleEntry {
+  id: string;
+  name: string;
+  agentId: string;
+  displayName: string | null;
+  prompt: string;
+  /** Human-readable schedule cadence (e.g. "Every day at 9:00 AM"). */
+  time: string;
+}
+
+/**
+ * Schedules created before "schedule chat" existed: they have no linked chat
+ * thread and run in legacy mode. These are the candidates the migration modal
+ * offers to convert.
+ */
+export const legacySchedulesNeedingChatThread$ = computed((get) => {
+  return get(internalAllSchedules$)
+    .filter((s) => {
+      return s.chatThreadId === null;
+    })
+    .sort((a, b) => {
+      return b.createdAt.localeCompare(a.createdAt);
+    })
+    .map((s): LegacyScheduleEntry => {
+      return {
+        id: s.id,
+        name: s.name,
+        agentId: s.agentId,
+        displayName: s.displayName,
+        prompt: s.prompt,
+        time: scheduleToTimeString(s),
+      };
+    });
+});
+
+const internalMigrationStatus$ = state<ReadonlyMap<string, MigrationStatus>>(
+  new Map(),
+);
+
+/** Map of schedule id -> migration status for the current/last batch run. */
+export const migrationStatus$ = computed((get) => {
+  return get(internalMigrationStatus$);
+});
+
+const internalMigrationRunning$ = state(false);
+
+/** True while a batch migration is in progress. */
+export const migrationRunning$ = computed((get) => {
+  return get(internalMigrationRunning$);
+});
+
+function patchMigrationStatus(id: string, status: MigrationStatus) {
+  return (prev: ReadonlyMap<string, MigrationStatus>) => {
+    const next = new Map(prev);
+    next.set(id, status);
+    return next;
+  };
+}
+
+/**
+ * Migrate every legacy schedule to chat mode, one at a time, surfacing
+ * per-schedule progress. Each schedule gets a freshly created chat thread linked
+ * server-side. Failures are isolated: one schedule erroring does not abort the
+ * rest. Refetches the schedule list once the batch completes.
+ */
+export const migrateAllLegacySchedules$ = command(
+  async ({ get, set }, signal: AbortSignal) => {
+    const legacy = get(legacySchedulesNeedingChatThread$);
+    if (legacy.length === 0) {
+      return;
+    }
+
+    set(internalMigrationRunning$, true);
+    set(
+      internalMigrationStatus$,
+      new Map(
+        legacy.map((s) => {
+          return [s.id, "pending" as MigrationStatus];
+        }),
+      ),
+    );
+
+    const client = get(zeroClient$)(zeroScheduleMigrateChatContract);
+    try {
+      for (const s of legacy) {
+        signal.throwIfAborted();
+        set(internalMigrationStatus$, patchMigrationStatus(s.id, "migrating"));
+        try {
+          await accept(
+            client.migrateToChat({
+              params: { name: s.name },
+              body: { agentId: s.agentId },
+              fetchOptions: { signal },
+            }),
+            [200],
+            { toast: false },
+          );
+          set(internalMigrationStatus$, patchMigrationStatus(s.id, "done"));
+        } catch (error: unknown) {
+          throwIfAbort(error);
+          set(internalMigrationStatus$, patchMigrationStatus(s.id, "error"));
+        }
+      }
+
+      await set(fetchAllOrgSchedules$, signal);
+
+      const failed = [...get(internalMigrationStatus$).values()].filter((v) => {
+        return v === "error";
+      }).length;
+      if (failed > 0) {
+        toast.error(`${failed} schedule(s) could not be migrated`);
+      } else {
+        toast.success("All schedules migrated to chat");
+      }
+    } finally {
+      set(internalMigrationRunning$, false);
+    }
   },
 );
 

--- a/turbo/apps/platform/src/views/zero-page/migrate-schedules-dialog.tsx
+++ b/turbo/apps/platform/src/views/zero-page/migrate-schedules-dialog.tsx
@@ -1,4 +1,9 @@
-import { useGet, useSet, useLastLoadable, useLastResolved } from "ccstate-react";
+import {
+  useGet,
+  useSet,
+  useLastLoadable,
+  useLastResolved,
+} from "ccstate-react";
 import {
   IconCheck,
   IconLoader2,

--- a/turbo/apps/platform/src/views/zero-page/migrate-schedules-dialog.tsx
+++ b/turbo/apps/platform/src/views/zero-page/migrate-schedules-dialog.tsx
@@ -1,0 +1,161 @@
+import { useGet, useSet, useLastLoadable, useLastResolved } from "ccstate-react";
+import {
+  IconCheck,
+  IconLoader2,
+  IconAlertTriangle,
+  IconMessagePlus,
+} from "@tabler/icons-react";
+import { Button } from "@vm0/ui";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogHeader,
+  DialogTitle,
+  DialogFooter,
+} from "@vm0/ui/components/ui/dialog";
+import { FeatureSwitchKey } from "@vm0/connectors/feature-switch-key";
+import { featureSwitch$ } from "../../signals/external/feature-switch.ts";
+import { pageSignal$ } from "../../signals/page-signal.ts";
+import { detach, Reason } from "../../signals/utils.ts";
+import {
+  allOrgSchedulesLoaded$,
+  legacySchedulesNeedingChatThread$,
+  migrationStatus$,
+  migrationRunning$,
+  migrateAllLegacySchedules$,
+  type LegacyScheduleEntry,
+  type MigrationStatus,
+} from "../../signals/zero-page/zero-schedule.ts";
+import {
+  migrateDialogDismissed$,
+  setMigrateDialogDismissed$,
+} from "../../signals/schedule-page/schedule-page-ui.ts";
+
+function StatusIcon({ status }: { status: MigrationStatus | undefined }) {
+  if (status === "migrating") {
+    return (
+      <IconLoader2
+        size={16}
+        className="shrink-0 animate-spin text-muted-foreground"
+      />
+    );
+  }
+  if (status === "done") {
+    return <IconCheck size={16} className="shrink-0 text-emerald-500" />;
+  }
+  if (status === "error") {
+    return <IconAlertTriangle size={16} className="shrink-0 text-amber-500" />;
+  }
+  return <span className="size-4 shrink-0" aria-hidden />;
+}
+
+function MigrateScheduleRow({
+  schedule,
+  status,
+}: {
+  schedule: LegacyScheduleEntry;
+  status: MigrationStatus | undefined;
+}) {
+  return (
+    <li className="flex items-center gap-3 rounded-lg border border-border/50 bg-card px-3 py-2">
+      <StatusIcon status={status} />
+      <div className="min-w-0 flex-1">
+        <p className="truncate text-sm font-medium text-foreground">
+          {schedule.displayName ?? schedule.name}
+        </p>
+        <p className="truncate text-xs text-muted-foreground">
+          {schedule.time} · {schedule.prompt}
+        </p>
+      </div>
+    </li>
+  );
+}
+
+export function MigrateSchedulesDialogContainer() {
+  const features = useLastResolved(featureSwitch$);
+  const chatEnabled = features?.[FeatureSwitchKey.ScheduledChat] ?? false;
+
+  const loaded = useGet(allOrgSchedulesLoaded$);
+  const legacyLoadable = useLastLoadable(legacySchedulesNeedingChatThread$);
+  const legacy: LegacyScheduleEntry[] =
+    legacyLoadable.state === "hasData" ? legacyLoadable.data : [];
+
+  const status = useGet(migrationStatus$);
+  const running = useGet(migrationRunning$);
+  const dismissed = useGet(migrateDialogDismissed$);
+  const setDismissed = useSet(setMigrateDialogDismissed$);
+  const migrateAll = useSet(migrateAllLegacySchedules$);
+  const pageSignal = useGet(pageSignal$);
+
+  // Auto-surface on entry when chat mode is on and legacy schedules remain.
+  // Stay open while a migration is running so progress stays visible even as
+  // the list drains.
+  const open =
+    chatEnabled && loaded && !dismissed && (running || legacy.length > 0);
+
+  const allDone =
+    legacy.length > 0 &&
+    legacy.every((s) => {
+      return status.get(s.id) === "done";
+    });
+
+  const close = () => {
+    if (running) {
+      return;
+    }
+    setDismissed(true);
+  };
+
+  const startMigration = () => {
+    detach(migrateAll(pageSignal), Reason.DomCallback);
+  };
+
+  return (
+    <Dialog
+      open={open}
+      onOpenChange={(next) => {
+        if (!next) {
+          close();
+        }
+      }}
+    >
+      <DialogContent>
+        <DialogHeader>
+          <DialogTitle>Migrate schedules to chat</DialogTitle>
+          <DialogDescription>
+            {legacy.length} schedule(s) were created before chat was available
+            and have no chat thread yet. Migrate them to give each its own chat
+            thread.
+          </DialogDescription>
+        </DialogHeader>
+
+        <ul className="flex max-h-[18rem] flex-col gap-2 overflow-y-auto py-1">
+          {legacy.map((s) => {
+            return (
+              <MigrateScheduleRow
+                key={s.id}
+                schedule={s}
+                status={status.get(s.id)}
+              />
+            );
+          })}
+        </ul>
+
+        <DialogFooter>
+          <Button variant="outline" disabled={running} onClick={close}>
+            {allDone ? "Close" : "Not now"}
+          </Button>
+          <Button className="gap-2" disabled={running} onClick={startMigration}>
+            {running ? (
+              <IconLoader2 size={14} className="animate-spin" />
+            ) : (
+              <IconMessagePlus size={14} stroke={2} />
+            )}
+            {running ? "Migrating…" : "Migrate to chat thread"}
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/turbo/apps/platform/src/views/zero-page/zero-schedule-page.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-schedule-page.tsx
@@ -32,6 +32,7 @@ import {
 } from "./schedule-dialog.tsx";
 import { ScheduleCalendarView } from "./schedule-calendar-view.tsx";
 import { ScheduleListView } from "./schedule-list-view.tsx";
+import { MigrateSchedulesDialogContainer } from "./migrate-schedules-dialog.tsx";
 import { agents$ } from "../../signals/agent.ts";
 import {
   COMMON_TIMEZONES,
@@ -713,6 +714,7 @@ export function ZeroSchedulePage() {
         }}
       />
       <DeleteScheduleDialogContainer />
+      <MigrateSchedulesDialogContainer />
     </div>
   );
 }

--- a/turbo/apps/web/__tests__/api-backend-rewrite-proxy.test.ts
+++ b/turbo/apps/web/__tests__/api-backend-rewrite-proxy.test.ts
@@ -2734,6 +2734,22 @@ describe("API backend rewrite proxy behavior", () => {
     ).toBe(false);
   });
 
+  it("matches the zero schedules migrate-to-chat rewrite path with one dynamic segment", () => {
+    expect(
+      matchesApiBackendRewritePath(
+        "/api/zero/schedules/nightly/migrate-to-chat",
+      ),
+    ).toBe(true);
+    expect(
+      matchesApiBackendRewritePath(
+        "/api/zero/schedules/nightly/migrate-to-chat/extra",
+      ),
+    ).toBe(false);
+    expect(
+      matchesApiBackendRewritePath("/api/zero/schedules/nightly/migrate"),
+    ).toBe(false);
+  });
+
   it("matches the zero agents collection rewrite path", () => {
     expect(matchesApiBackendRewritePath("/api/zero/agents")).toBe(true);
     expect(matchesApiBackendRewritePath("/api/zero/agent")).toBe(false);

--- a/turbo/apps/web/api-backend-rewrites.js
+++ b/turbo/apps/web/api-backend-rewrites.js
@@ -53,6 +53,10 @@ const ZERO_SCHEDULES_DISABLE_PATH_RE =
   /^\/api\/zero\/schedules\/[^/]+\/disable$/;
 const ZERO_SCHEDULES_ENABLE_REWRITE_SOURCE = "/api/zero/schedules/:name/enable";
 const ZERO_SCHEDULES_ENABLE_PATH_RE = /^\/api\/zero\/schedules\/[^/]+\/enable$/;
+const ZERO_SCHEDULES_MIGRATE_CHAT_REWRITE_SOURCE =
+  "/api/zero/schedules/:name/migrate-to-chat";
+const ZERO_SCHEDULES_MIGRATE_CHAT_PATH_RE =
+  /^\/api\/zero\/schedules\/[^/]+\/migrate-to-chat$/;
 const ZERO_SKILLS_BY_NAME_REWRITE_SOURCE = "/api/zero/skills/:name";
 const ZERO_SKILLS_BY_NAME_PATH_RE = /^\/api\/zero\/skills\/[^/]+$/;
 const ZERO_ME_MODEL_PROVIDERS_REWRITE_SOURCE = "/api/zero/me/model-providers";
@@ -1094,6 +1098,11 @@ export const API_BACKEND_REWRITES = [
     ZERO_SCHEDULES_ENABLE_REWRITE_SOURCE,
     "/api/zero/schedules/:name/enable",
     ZERO_SCHEDULES_ENABLE_PATH_RE,
+  ],
+  [
+    ZERO_SCHEDULES_MIGRATE_CHAT_REWRITE_SOURCE,
+    "/api/zero/schedules/:name/migrate-to-chat",
+    ZERO_SCHEDULES_MIGRATE_CHAT_PATH_RE,
   ],
   ["/api/zero/memory", "/api/zero/memory"],
   ["/api/zero/memory/activity", "/api/zero/memory/activity"],

--- a/turbo/packages/api-contracts/src/contracts/zero-schedules.ts
+++ b/turbo/packages/api-contracts/src/contracts/zero-schedules.ts
@@ -210,11 +210,45 @@ export const zeroScheduleRunContract = c.router({
   },
 });
 
+/**
+ * Zero schedule migrate-to-chat contract
+ * (POST /api/zero/schedules/:name/migrate-to-chat)
+ *
+ * One-way migration for legacy schedules (chatThreadId === null): creates a new
+ * chat thread and links it to the schedule. Only the null -> set transition is
+ * allowed; an already-linked schedule is returned unchanged (idempotent). The
+ * link can never be re-pointed, preserving the create-only immutability of
+ * chatThreadId.
+ */
+export const zeroScheduleMigrateChatContract = c.router({
+  migrateToChat: {
+    method: "POST",
+    path: "/api/zero/schedules/:name/migrate-to-chat",
+    headers: authHeadersSchema,
+    pathParams: z.object({
+      name: z.string().min(1, "Schedule name required"),
+    }),
+    body: z.object({
+      agentId: z.string().uuid("Invalid agent ID"),
+    }),
+    responses: {
+      200: scheduleResponseSchema,
+      400: apiErrorSchema,
+      401: apiErrorSchema,
+      403: apiErrorSchema,
+      404: apiErrorSchema,
+    },
+    summary: "Migrate a legacy schedule to chat mode (create + link a thread)",
+  },
+});
+
 // Contract type exports
 export type ZeroSchedulesMainContract = typeof zeroSchedulesMainContract;
 export type ZeroSchedulesByNameContract = typeof zeroSchedulesByNameContract;
 export type ZeroSchedulesEnableContract = typeof zeroSchedulesEnableContract;
 export type ZeroScheduleRunContract = typeof zeroScheduleRunContract;
+export type ZeroScheduleMigrateChatContract =
+  typeof zeroScheduleMigrateChatContract;
 
 // Inferred types from response schemas
 export type ScheduleResponse = z.infer<typeof scheduleResponseSchema>;


### PR DESCRIPTION
## Problem

Now that "schedule chat" exists, every **new** schedule is linked to a chat thread (`zero_agent_schedules.chat_thread_id`). But schedules created before the feature have `chatThreadId = NULL` and keep running in legacy mode (no rendered chat turn). There was **no way** to give an existing schedule a chat thread — the link is intentionally *create-only / immutable* (`resolveScheduleChatThreadLink` rejects setting it on update).

## What this does

On `app.vm0.ai/schedules`, when the `ScheduledChat` switch is on and any schedule still lacks a chat thread, a modal auto-surfaces listing all of them with a **one-click "Migrate to chat thread"**. Migration runs **one schedule at a time** with per-schedule progress (pending → migrating → done/error). Each schedule gets a freshly created chat thread linked server-side.

## Design notes

- **Immutability preserved.** Rather than relaxing the existing rule, this adds a dedicated one-way migration path that only performs the `null -> set` transition. An already-linked schedule can never be re-pointed; the endpoint is idempotent (returns the schedule unchanged if already linked).
- **Atomic per schedule.** The new endpoint creates the thread *and* links it in one call, so the frontend can't leave orphaned threads on a partial failure.
- **Feature gating.** Reuses the existing `ScheduledChat` switch rather than adding a new one.

## Changes

**Backend**
- `zeroScheduleMigrateChatContract` — `POST /api/zero/schedules/:name/migrate-to-chat`
- `migrateScheduleToChat$` service — ownership check, switch gate, create + link thread, notify thread
- route handler + registration (`schedule:write`)
- `apps/web` -> `apps/api` rewrite for the new path

**Frontend (platform)**
- `legacySchedulesNeedingChatThread$`, `migrateAllLegacySchedules$` (sequential, per-schedule status), progress signals
- `MigrateSchedulesDialogContainer` modal, wired into the schedules page; session-level dismiss flag

**Tests**
- integration tests for migrate (success, idempotent, switch-off 400, 404, 401)
- rewrite-proxy path test for the new route

## Verification

Relying on the PR pipeline for lint/type/test per team preference (no local vitest/dev server run).

🤖 Generated with [Claude Code](https://claude.com/claude-code)