### PR TITLE
fix: auto-create chat threads for scheduled chat

### DIFF
--- a/turbo/apps/api/package.json
+++ b/turbo/apps/api/package.json
@@ -44,7 +44,7 @@
     "drizzle-orm": "^0.45.2",
     "google-auth-library": "^10.6.2",
     "gpt-tokenizer": "^3.4.0",
-    "hono": "^4.12.18",
+    "hono": "^4.12.23",
     "html-to-text": "^9.0.5",
     "pg": "^8.20.0",
     "resend": "^6.12.4",

--- a/turbo/apps/api/src/signals/routes/__tests__/zero-schedules.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/zero-schedules.test.ts
@@ -6,6 +6,7 @@ import {
   scheduleListResponseSchema,
 } from "@vm0/api-contracts/contracts/zero-schedules";
 import { createStore } from "ccstate";
+import { eq } from "drizzle-orm";
 import { HttpResponse, http } from "msw";
 
 import { testContext } from "../../../__tests__/test-helpers";
@@ -162,7 +163,7 @@ describe("POST /api/zero/schedules — chat-mode linkage", () => {
     expect(body.schedule.chatThreadId).toBeNull();
   });
 
-  it("requires a chat thread for a new schedule when the switch is on", async () => {
+  it("creates a chat thread for a new schedule when the switch is on and no thread is supplied", async () => {
     const fixture = await seedFixture();
     await enableChatMode(fixture);
 
@@ -174,8 +175,27 @@ describe("POST /api/zero/schedules — chat-mode linkage", () => {
       description: "d",
     });
 
-    expect(response.status).toBe(400);
-    expectErrorCode(response, "BAD_REQUEST");
+    expect(response.status).toBe(201);
+    const body = deployScheduleResponseSchema.parse(response.body);
+    expect(body.schedule.chatThreadId).not.toBeNull();
+
+    const db = store.set(writeDb$);
+    const [thread] = await db
+      .select({
+        id: chatThreads.id,
+        userId: chatThreads.userId,
+        agentComposeId: chatThreads.agentComposeId,
+        title: chatThreads.title,
+      })
+      .from(chatThreads)
+      .where(eq(chatThreads.id, body.schedule.chatThreadId ?? ""))
+      .limit(1);
+    expect(thread).toStrictEqual({
+      id: body.schedule.chatThreadId,
+      userId: fixture.userId,
+      agentComposeId: fixture.composeId,
+      title: "d",
+    });
   });
 
   it("rejects changing the chat thread on an existing schedule", async () => {

--- a/turbo/apps/api/src/signals/services/zero-schedules.service.ts
+++ b/turbo/apps/api/src/signals/services/zero-schedules.service.ts
@@ -474,13 +474,17 @@ async function isChatThreadLinkable(
 }
 
 type ChatThreadLinkResult =
-  | { readonly ok: true; readonly chatThreadId: string | null }
+  | {
+      readonly ok: true;
+      readonly chatThreadId: string | null;
+      readonly createChatThread: boolean;
+    }
   | { readonly ok: false; readonly error: DeployScheduleResult };
 
 /**
  * Resolve the chat-thread link for a deploy, enforcing the ScheduledChat gate:
- * switch ON requires a NEW schedule to carry an owned chat thread (immutable
- * after create); switch OFF ignores the field (legacy schedule).
+ * switch ON links a NEW schedule to either the supplied owned chat thread or a
+ * server-created thread; switch OFF ignores the field (legacy schedule).
  */
 async function resolveScheduleChatThreadLink(args: {
   readonly db: Db;
@@ -503,7 +507,7 @@ async function resolveScheduleChatThreadLink(args: {
       };
     }
     if (!args.chatModeEnabled) {
-      return { ok: true, chatThreadId: null };
+      return { ok: true, chatThreadId: null, createChatThread: false };
     }
     const linkable = await isChatThreadLinkable(args.db, {
       chatThreadId: args.chatThreadId,
@@ -521,19 +525,16 @@ async function resolveScheduleChatThreadLink(args: {
         },
       };
     }
-    return { ok: true, chatThreadId: args.chatThreadId };
-  }
-  if (!args.existing && args.chatModeEnabled) {
     return {
-      ok: false,
-      error: {
-        kind: "bad_request",
-        message:
-          "chatThreadId is required when chat-mode schedules are enabled",
-      },
+      ok: true,
+      chatThreadId: args.chatThreadId,
+      createChatThread: false,
     };
   }
-  return { ok: true, chatThreadId: null };
+  if (!args.existing && args.chatModeEnabled) {
+    return { ok: true, chatThreadId: null, createChatThread: true };
+  }
+  return { ok: true, chatThreadId: null, createChatThread: false };
 }
 
 async function updateExistingSchedule(
@@ -585,34 +586,58 @@ async function insertNewSchedule(
     // Resolved chat-thread link (null = legacy). Computed in deploySchedule$
     // after the switch + ownership checks — NOT read from the request body.
     readonly chatThreadId: string | null;
+    readonly createChatThread: boolean;
   },
 ): Promise<typeof zeroAgentSchedules.$inferSelect> {
-  const [created] = await db
-    .insert(zeroAgentSchedules)
-    .values({
-      agentId: args.request.agentId,
-      userId: args.userId,
-      orgId: args.orgId,
-      name: args.request.name,
-      triggerType: args.triggerType,
-      cronExpression: args.request.cronExpression ?? null,
-      atTime: args.request.atTime ? new Date(args.request.atTime) : null,
-      intervalSeconds: args.request.intervalSeconds ?? null,
-      timezone: args.request.timezone,
-      prompt: args.request.prompt,
-      description: args.request.description ?? null,
-      appendSystemPrompt: args.request.appendSystemPrompt ?? null,
-      vars: null,
-      encryptedSecrets: null,
-      volumeVersions: args.request.volumeVersions ?? null,
-      chatThreadId: args.chatThreadId,
-      enabled: args.request.enabled ?? false,
-      nextRunAt: args.nextRunAt,
-      consecutiveFailures: 0,
-      createdAt: args.currentTime,
-      updatedAt: args.currentTime,
-    })
-    .returning();
+  const created = await db.transaction(async (tx) => {
+    let chatThreadId = args.chatThreadId;
+    if (args.createChatThread) {
+      const [thread] = await tx
+        .insert(chatThreads)
+        .values({
+          userId: args.userId,
+          agentComposeId: args.request.agentId,
+          title: args.request.description ?? args.request.name,
+          lastMessageAt: args.currentTime,
+          createdAt: args.currentTime,
+          updatedAt: args.currentTime,
+        })
+        .returning({ id: chatThreads.id });
+      if (!thread) {
+        throw new Error("Failed to create chat thread");
+      }
+      chatThreadId = thread.id;
+    }
+
+    const [schedule] = await tx
+      .insert(zeroAgentSchedules)
+      .values({
+        agentId: args.request.agentId,
+        userId: args.userId,
+        orgId: args.orgId,
+        name: args.request.name,
+        triggerType: args.triggerType,
+        cronExpression: args.request.cronExpression ?? null,
+        atTime: args.request.atTime ? new Date(args.request.atTime) : null,
+        intervalSeconds: args.request.intervalSeconds ?? null,
+        timezone: args.request.timezone,
+        prompt: args.request.prompt,
+        description: args.request.description ?? null,
+        appendSystemPrompt: args.request.appendSystemPrompt ?? null,
+        vars: null,
+        encryptedSecrets: null,
+        volumeVersions: args.request.volumeVersions ?? null,
+        chatThreadId,
+        enabled: args.request.enabled ?? false,
+        nextRunAt: args.nextRunAt,
+        consecutiveFailures: 0,
+        createdAt: args.currentTime,
+        updatedAt: args.currentTime,
+      })
+      .returning();
+
+    return schedule;
+  });
 
   if (!created) {
     throw new Error(`Failed to create schedule ${args.request.name}`);
@@ -663,10 +688,9 @@ export const deploySchedule$ = command(
     signal.throwIfAborted();
 
     // Chat-mode linkage, gated by the ScheduledChat switch:
-    // - Switch ON: a NEW schedule MUST be linked to an owned chat thread. The
-    //   CLI/agent default chatThreadId to $ZERO_CHAT_THREAD_ID, so it is
-    //   normally present; a create without one is rejected. The link is
-    //   create-only / immutable.
+    // - Switch ON: a NEW schedule is linked to either an owned supplied thread
+    //   or a server-created web chat thread. The link is create-only /
+    //   immutable.
     // - Switch OFF: chatThreadId is ignored (legacy schedule), so creation from
     //   contexts that auto-send a thread id never breaks.
     const overrides = await get(
@@ -728,6 +752,7 @@ export const deploySchedule$ = command(
           nextRunAt,
           currentTime,
           chatThreadId: chatThreadIdToLink,
+          createChatThread: chatLink.createChatThread,
         });
     signal.throwIfAborted();
 

--- a/turbo/packages/api-contracts/src/contracts/zero-schedules.ts
+++ b/turbo/packages/api-contracts/src/contracts/zero-schedules.ts
@@ -61,9 +61,10 @@ const zeroDeployScheduleRequestSchema = z
     volumeVersions: z.record(z.string(), z.string()).optional(),
     agentId: z.string().uuid("Invalid agent ID"),
     enabled: z.boolean().optional(),
-    // Chat-mode linkage, accepted only on creation of a new schedule. Links the
-    // schedule to an existing chat thread; the run then renders as a web-chat
-    // turn. Rejected on update of an existing schedule (link is immutable).
+    // Chat-mode linkage, accepted only on creation of a new schedule. When
+    // provided, links the schedule to an existing chat thread; when omitted and
+    // chat-mode schedules are enabled, the server creates a web chat thread and
+    // links it. Rejected on update of an existing schedule (link is immutable).
     chatThreadId: z.string().uuid("Invalid chat thread ID").optional(),
   })
   .refine(

--- a/turbo/pnpm-lock.yaml
+++ b/turbo/pnpm-lock.yaml
@@ -132,10 +132,10 @@ importers:
         version: 2.7.0
       '@hono/node-server':
         specifier: ^1.19.14
-        version: 1.19.14(hono@4.12.18)
+        version: 1.19.14(hono@4.12.23)
       '@hono/otel':
         specifier: ^1.1.1
-        version: 1.1.1(hono@4.12.18)
+        version: 1.1.1(hono@4.12.23)
       '@opentelemetry/api':
         specifier: ^1.9.1
         version: 1.9.1
@@ -200,8 +200,8 @@ importers:
         specifier: ^3.4.0
         version: 3.4.0
       hono:
-        specifier: ^4.12.18
-        version: 4.12.18
+        specifier: ^4.12.23
+        version: 4.12.23
       html-to-text:
         specifier: ^9.0.5
         version: 9.0.5
@@ -238,7 +238,7 @@ importers:
     devDependencies:
       '@hono/vite-build':
         specifier: ^1.11.1
-        version: 1.11.1(hono@4.12.18)
+        version: 1.11.1(hono@4.12.23)
       '@ts-rest/core':
         specifier: 3.53.0-rc.1
         version: 3.53.0-rc.1(@types/node@24.3.0)
@@ -7172,8 +7172,8 @@ packages:
   hoist-non-react-statics@3.3.2:
     resolution: {integrity: sha512-/gGivxi8JPKWNm/W0jSmzcMPpfpPLc3dY/6GxhX2hQ9iGj3aDfklV4ET7NjKpSinLpJ5vafa9iiGIEZg10SfBw==}
 
-  hono@4.12.18:
-    resolution: {integrity: sha512-RWzP96k/yv0PQfyXnWjs6zot20TqfpfsNXhOnev8d1InAxubW93L11/oNUc3tQqn2G0bSdAOBpX+2uDFHV7kdQ==}
+  hono@4.12.23:
+    resolution: {integrity: sha512-eIaZ9qDgu7XV0pxOCrg7/WhnQ6Ivm22UcxhXx/A3dcbqbbYgBEkc6e/J/s7j2tS96zoB0S9VBdLwQNCWwUo4LA==}
     engines: {node: '>=16.9.0'}
 
   hosted-git-info@2.8.9:
@@ -11714,19 +11714,19 @@ snapshots:
     dependencies:
       graphql: 16.13.2
 
-  '@hono/node-server@1.19.14(hono@4.12.18)':
+  '@hono/node-server@1.19.14(hono@4.12.23)':
     dependencies:
-      hono: 4.12.18
+      hono: 4.12.23
 
-  '@hono/otel@1.1.1(hono@4.12.18)':
+  '@hono/otel@1.1.1(hono@4.12.23)':
     dependencies:
       '@opentelemetry/api': 1.9.1
       '@opentelemetry/semantic-conventions': 1.40.0
-      hono: 4.12.18
+      hono: 4.12.23
 
-  '@hono/vite-build@1.11.1(hono@4.12.18)':
+  '@hono/vite-build@1.11.1(hono@4.12.23)':
     dependencies:
-      hono: 4.12.18
+      hono: 4.12.23
 
   '@humanfs/core@0.19.1': {}
 
@@ -16806,7 +16806,7 @@ snapshots:
     dependencies:
       react-is: 16.13.1
 
-  hono@4.12.18: {}
+  hono@4.12.23: {}
 
   hosted-git-info@2.8.9: {}
 


### PR DESCRIPTION
## Summary
- auto-create a web chat thread for new chat-mode schedules when no chatThreadId is supplied
- keep explicit chatThreadId ownership validation and existing schedule immutability
- update schedule API contract comments and coverage for the auto-created thread path

## Verification
- pnpm exec prettier --write apps/api/src/signals/routes/__tests__/zero-schedules.test.ts apps/api/src/signals/services/zero-schedules.service.ts packages/api-contracts/src/contracts/zero-schedules.ts
- git diff --check
- NODE_OPTIONS=--max-old-space-size=4096 pnpm -F api check-types
- pnpm -F @vm0/api-contracts check-types
- pnpm -F api lint

## Not Run
- pnpm vitest --run apps/api/src/signals/routes/__tests__/zero-schedules.test.ts (blocked locally: Postgres refused connections on 127.0.0.1:5432 / ::1:5432)
