### PR TITLE
refactor: rename connector env binding availability metadata

### DIFF
--- a/turbo/apps/api/src/signals/routes/__tests__/zero-runs-create.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/zero-runs-create.test.ts
@@ -1674,6 +1674,73 @@ describe("POST /api/zero/runs", () => {
     expect(executionContext.secretConnectorMetadataMap).toBeNull();
   });
 
+  it("injects stored optional API-token connector env fields", async () => {
+    const fx = await fixture();
+    const agent = await seedRunnableZeroAgent({ fixture: fx });
+    const db = store.set(writeDb$);
+    await db.insert(userConnectors).values({
+      orgId: fx.orgId,
+      userId: fx.userId,
+      agentId: agent.agentId,
+      connectorType: "gitlab",
+    });
+    await db.insert(connectors).values({
+      orgId: fx.orgId,
+      userId: fx.userId,
+      type: "gitlab",
+      authMethod: "api-token",
+    });
+    await db.insert(secrets).values({
+      orgId: fx.orgId,
+      userId: fx.userId,
+      name: "GITLAB_TOKEN",
+      encryptedValue: encryptSecretForTests("glpat-token"),
+      type: "connector",
+    });
+    await db.insert(variables).values({
+      orgId: fx.orgId,
+      userId: fx.userId,
+      name: "GITLAB_HOST",
+      value: "gitlab.example.com",
+      type: "connector",
+    });
+
+    const response = await accept(
+      zeroRunsClient().create({
+        headers: { authorization: "Bearer clerk-session" },
+        body: {
+          prompt: "use gitlab with optional host",
+          agentId: agent.agentId,
+        },
+      }),
+      [201],
+    );
+
+    const [job] = await db
+      .select({ executionContext: runnerJobQueue.executionContext })
+      .from(runnerJobQueue)
+      .where(eq(runnerJobQueue.runId, response.body.runId));
+    const executionContext = job?.executionContext as {
+      readonly environment: Record<string, string>;
+      readonly encryptedSecrets: string | null;
+      readonly secretConnectorMap: Record<string, string> | null;
+      readonly secretConnectorMetadataMap: Record<string, unknown> | null;
+    };
+    expect(executionContext.environment.GITLAB_TOKEN).toBe(
+      connectorSecretPlaceholder("gitlab", "GITLAB_TOKEN"),
+    );
+    expect(executionContext.environment.GITLAB_HOST).toBe("gitlab.example.com");
+    expect(
+      decryptSecretsMapForTests(executionContext.encryptedSecrets),
+    ).toMatchObject({
+      GITLAB_TOKEN: "glpat-token",
+    });
+    expect(executionContext.secretConnectorMap).toStrictEqual({
+      GITLAB_TOKEN: "gitlab",
+    });
+    expect(executionContext.secretConnectorMetadataMap).toBeNull();
+  });
+
   it("injects authorized connector token secrets and refresh metadata", async () => {
     const fx = await fixture();
     const db = store.set(writeDb$);

--- a/turbo/apps/api/src/signals/routes/zero-integrations-slack.ts
+++ b/turbo/apps/api/src/signals/routes/zero-integrations-slack.ts
@@ -6,7 +6,7 @@ import {
   slackOrgStatusSchema,
   zeroIntegrationsSlackContract,
 } from "@vm0/api-contracts/contracts/zero-integrations-slack";
-import { connectorProvidedBindingNames } from "@vm0/api-contracts/contracts/connector-schemas";
+import { guaranteedConnectorProvidedBindingNames } from "@vm0/api-contracts/contracts/connector-schemas";
 import { authHeadersSchema } from "@vm0/api-contracts/contracts/base";
 import { apiErrorSchema } from "@vm0/api-contracts/contracts/errors";
 import { extractAndGroupVariables } from "@vm0/core/variable-expander";
@@ -137,7 +137,7 @@ const getSlackEnvironment$ = computed(
       ...userSecretList.secrets.map((s) => {
         return s.name;
       }),
-      ...connectorProvidedBindingNames({
+      ...guaranteedConnectorProvidedBindingNames({
         bindings: userConnectors.connectorProvidedBindings,
         namespace: "secrets",
       }),
@@ -146,7 +146,7 @@ const getSlackEnvironment$ = computed(
       ...userVarList.variables.map((v) => {
         return v.name;
       }),
-      ...connectorProvidedBindingNames({
+      ...guaranteedConnectorProvidedBindingNames({
         bindings: userConnectors.connectorProvidedBindings,
         namespace: "vars",
       }),

--- a/turbo/apps/api/src/signals/services/__tests__/zero-connector-data.service.test.ts
+++ b/turbo/apps/api/src/signals/services/__tests__/zero-connector-data.service.test.ts
@@ -65,7 +65,7 @@ describe("zeroConnectorList", () => {
           authMethod: "api-token",
           namespace: "secrets",
           name: "GITLAB_TOKEN",
-          required: true,
+          optional: false,
           source: {
             kind: "connector-secret",
             name: "GITLAB_TOKEN",
@@ -76,7 +76,7 @@ describe("zeroConnectorList", () => {
           authMethod: "api-token",
           namespace: "vars",
           name: "GITLAB_HOST",
-          required: false,
+          optional: true,
           source: {
             kind: "connector-variable",
             name: "GITLAB_HOST",
@@ -126,7 +126,7 @@ describe("zeroConnectorList", () => {
         authMethod: "oauth",
         namespace: "secrets",
         name: "GH_TOKEN",
-        required: true,
+        optional: false,
         source: {
           kind: "connector-secret",
           name: "GITHUB_ACCESS_TOKEN",
@@ -137,7 +137,7 @@ describe("zeroConnectorList", () => {
         authMethod: "oauth",
         namespace: "secrets",
         name: "GITHUB_TOKEN",
-        required: true,
+        optional: false,
         source: {
           kind: "connector-secret",
           name: "GITHUB_ACCESS_TOKEN",
@@ -188,7 +188,7 @@ describe("zeroConnectorList", () => {
           authMethod: "oauth",
           namespace: "secrets",
           name: "GOOGLE_ADS_TOKEN",
-          required: true,
+          optional: false,
           source: {
             kind: "connector-secret",
             name: "GOOGLE_ADS_ACCESS_TOKEN",
@@ -237,7 +237,7 @@ describe("zeroConnectorList", () => {
           authMethod: "api-token",
           namespace: "vars",
           name: "GITLAB_HOST",
-          required: false,
+          optional: true,
           source: {
             kind: "connector-variable",
             name: "GITLAB_HOST",

--- a/turbo/apps/api/src/signals/services/agent-run-create.service.ts
+++ b/turbo/apps/api/src/signals/services/agent-run-create.service.ts
@@ -1636,8 +1636,6 @@ interface ConnectorEnvBindingSet {
   readonly accessKind: "static" | "refresh-token" | "none";
   readonly refreshableSecretNames: ReadonlySet<string>;
   readonly runtimeBindings: readonly ConnectorRuntimeBindingEntry[];
-  readonly optionalSecretNames: ReadonlySet<string>;
-  readonly optionalVariableNames: ReadonlySet<string>;
 }
 
 interface StoredConnectorRequirements {
@@ -1698,20 +1696,6 @@ function connectorEnvBindingSets(
         `Invalid auth method "${row.authMethod}" for stored connector "${row.connectorType}"`,
       );
     }
-    const optionalSecretNames = new Set<string>();
-    const optionalVariableNames = new Set<string>();
-    if (method.grant.kind === "manual") {
-      for (const [name, field] of Object.entries(method.grant.fields)) {
-        if (field.required !== false) {
-          continue;
-        }
-        if (field.storage === "variable") {
-          optionalVariableNames.add(name);
-        } else {
-          optionalSecretNames.add(name);
-        }
-      }
-    }
     return {
       connectorType: row.connectorType,
       authMethod: row.authMethod,
@@ -1721,8 +1705,6 @@ function connectorEnvBindingSets(
           ? new Set(accessMetadata.refreshableSecrets)
           : new Set<string>(),
       runtimeBindings: metadata.runtimeBindings,
-      optionalSecretNames,
-      optionalVariableNames,
     };
   });
 }
@@ -1839,10 +1821,8 @@ function resolveStoredConnectorState(
     accessKind,
     refreshableSecretNames,
     runtimeBindings,
-    optionalSecretNames,
-    optionalVariableNames,
   } of bindingSets) {
-    for (const { envName, valueRef, source } of runtimeBindings) {
+    for (const { envName, valueRef, optional, source } of runtimeBindings) {
       switch (source.kind) {
         case "connector-secret": {
           const secretName = source.name;
@@ -1850,7 +1830,7 @@ function resolveStoredConnectorState(
           if (secretValue !== undefined) {
             secrets[envName] = secretValue;
             addConnectorEnvironmentTemplate(environment, envName, valueRef);
-          } else if (!optionalSecretNames.has(secretName)) {
+          } else if (!optional) {
             addConnectorEnvironmentTemplate(environment, envName, valueRef);
           }
           break;
@@ -1861,7 +1841,7 @@ function resolveStoredConnectorState(
           if (variableValue !== undefined) {
             vars[envName] = variableValue;
             addConnectorEnvironmentTemplate(environment, envName, valueRef);
-          } else if (!optionalVariableNames.has(variableName)) {
+          } else if (!optional) {
             addConnectorEnvironmentTemplate(environment, envName, valueRef);
           }
           break;

--- a/turbo/apps/api/src/signals/services/integrations-github.service.ts
+++ b/turbo/apps/api/src/signals/services/integrations-github.service.ts
@@ -8,7 +8,7 @@ import type {
   GithubLabelListener,
   UpdateGithubLabelListenerBody,
 } from "@vm0/api-contracts/contracts/integrations-github";
-import { connectorProvidedBindingNames } from "@vm0/api-contracts/contracts/connector-schemas";
+import { guaranteedConnectorProvidedBindingNames } from "@vm0/api-contracts/contracts/connector-schemas";
 import { extractAndGroupVariables } from "@vm0/core/variable-expander";
 import {
   agentComposes,
@@ -1083,7 +1083,7 @@ export const getGithubInstallation$ = command(
       ...secretList.secrets.map((secret) => {
         return secret.name;
       }),
-      ...connectorProvidedBindingNames({
+      ...guaranteedConnectorProvidedBindingNames({
         bindings: connectorList.connectorProvidedBindings,
         namespace: "secrets",
       }),
@@ -1092,7 +1092,7 @@ export const getGithubInstallation$ = command(
       ...variableList.variables.map((variable) => {
         return variable.name;
       }),
-      ...connectorProvidedBindingNames({
+      ...guaranteedConnectorProvidedBindingNames({
         bindings: connectorList.connectorProvidedBindings,
         namespace: "vars",
       }),

--- a/turbo/apps/api/src/signals/services/zero-connector-data.service.ts
+++ b/turbo/apps/api/src/signals/services/zero-connector-data.service.ts
@@ -1329,6 +1329,9 @@ function requiredConnectorTokenSecretRequirements(args: {
   const requiredOutputNames = new Set<string>();
   const requiredExtraSecretNames = new Set<string>();
   for (const binding of runtimeMetadata.runtimeBindings) {
+    if (binding.optional) {
+      continue;
+    }
     if (binding.source.kind !== "connector-secret") {
       continue;
     }

--- a/turbo/apps/api/src/signals/services/zero-connector-data.service.ts
+++ b/turbo/apps/api/src/signals/services/zero-connector-data.service.ts
@@ -404,7 +404,7 @@ function connectorProvidedBindingsForStoredConnectors(
     if (!metadata) {
       continue;
     }
-    for (const { envName, required, source } of metadata.runtimeBindings) {
+    for (const { envName, optional, source } of metadata.runtimeBindings) {
       switch (source.kind) {
         case "connector-secret": {
           provided.push({
@@ -412,7 +412,7 @@ function connectorProvidedBindingsForStoredConnectors(
             authMethod: connector.authMethod,
             namespace: "secrets",
             name: envName,
-            required,
+            optional,
             source,
           });
           break;
@@ -423,7 +423,7 @@ function connectorProvidedBindingsForStoredConnectors(
             authMethod: connector.authMethod,
             namespace: "vars",
             name: envName,
-            required,
+            optional,
             source,
           });
           break;

--- a/turbo/apps/api/src/signals/services/zero-telegram-data.service.ts
+++ b/turbo/apps/api/src/signals/services/zero-telegram-data.service.ts
@@ -4,7 +4,7 @@ import type {
   TelegramBotStatus,
   TelegramLinkStatusResponse,
 } from "@vm0/api-contracts/contracts/zero-integrations-telegram";
-import { connectorProvidedBindingNames } from "@vm0/api-contracts/contracts/connector-schemas";
+import { guaranteedConnectorProvidedBindingNames } from "@vm0/api-contracts/contracts/connector-schemas";
 import type { FeatureSwitchContext } from "@vm0/core/feature-switch";
 import { extractAndGroupVariables } from "@vm0/core/variable-expander";
 import {
@@ -281,7 +281,7 @@ function telegramEnvironment(args: {
       ...secretList.secrets.map((secret) => {
         return secret.name;
       }),
-      ...connectorProvidedBindingNames({
+      ...guaranteedConnectorProvidedBindingNames({
         bindings: connectorList.connectorProvidedBindings,
         namespace: "secrets",
       }),
@@ -290,7 +290,7 @@ function telegramEnvironment(args: {
       ...variableList.variables.map((variable) => {
         return variable.name;
       }),
-      ...connectorProvidedBindingNames({
+      ...guaranteedConnectorProvidedBindingNames({
         bindings: connectorList.connectorProvidedBindings,
         namespace: "vars",
       }),

--- a/turbo/apps/cli/src/commands/compose/__tests__/index.test.ts
+++ b/turbo/apps/cli/src/commands/compose/__tests__/index.test.ts
@@ -2547,7 +2547,7 @@ agents:
                 authMethod: "oauth",
                 namespace: "secrets",
                 name: "GH_TOKEN",
-                required: true,
+                optional: false,
                 source: {
                   kind: "connector-secret",
                   name: "GITHUB_ACCESS_TOKEN",
@@ -2558,7 +2558,7 @@ agents:
                 authMethod: "api-token",
                 namespace: "vars",
                 name: "REGION",
-                required: true,
+                optional: false,
                 source: {
                   kind: "connector-variable",
                   name: "GITLAB_REGION",
@@ -2569,7 +2569,7 @@ agents:
                 authMethod: "api-token",
                 namespace: "vars",
                 name: "GITLAB_HOST",
-                required: false,
+                optional: true,
                 source: {
                   kind: "connector-variable",
                   name: "GITLAB_HOST",

--- a/turbo/apps/cli/src/commands/compose/__tests__/index.test.ts
+++ b/turbo/apps/cli/src/commands/compose/__tests__/index.test.ts
@@ -2510,7 +2510,7 @@ agents:
       expect(logCalls).toContain("REGION");
     });
 
-    it("should not show missing items for required connector-provided bindings", async () => {
+    it("should not show missing items for guaranteed connector-provided bindings", async () => {
       await fs.writeFile(
         path.join(tempDir, "vm0.yaml"),
         yaml.stringify({

--- a/turbo/apps/cli/src/commands/compose/index.ts
+++ b/turbo/apps/cli/src/commands/compose/index.ts
@@ -4,7 +4,7 @@ import { readFile, rm } from "fs/promises";
 import { existsSync } from "fs";
 import { dirname, join } from "path";
 import { parse as parseYaml } from "yaml";
-import { connectorProvidedBindingNames } from "@vm0/api-contracts/contracts/connector-schemas";
+import { guaranteedConnectorProvidedBindingNames } from "@vm0/api-contracts/contracts/connector-schemas";
 import { extractAndGroupVariables } from "@vm0/core/variable-expander";
 import {
   getComposeByName,
@@ -209,22 +209,28 @@ async function checkAndPromptMissingItems(
     }),
   );
 
-  const connectorProvidedSecretNames = connectorProvidedBindingNames({
-    bindings: connectorsResponse.connectorProvidedBindings,
-    namespace: "secrets",
-  });
-  const connectorProvidedVarNames = connectorProvidedBindingNames({
-    bindings: connectorsResponse.connectorProvidedBindings,
-    namespace: "vars",
-  });
+  const guaranteedConnectorProvidedSecretNames =
+    guaranteedConnectorProvidedBindingNames({
+      bindings: connectorsResponse.connectorProvidedBindings,
+      namespace: "secrets",
+    });
+  const guaranteedConnectorProvidedVarNames =
+    guaranteedConnectorProvidedBindingNames({
+      bindings: connectorsResponse.connectorProvidedBindings,
+      namespace: "vars",
+    });
 
   const missingSecrets = [...requiredSecrets].filter((name) => {
     return (
-      !existingSecretNames.has(name) && !connectorProvidedSecretNames.has(name)
+      !existingSecretNames.has(name) &&
+      !guaranteedConnectorProvidedSecretNames.has(name)
     );
   });
   const missingVars = [...requiredVars].filter((name) => {
-    return !existingVarNames.has(name) && !connectorProvidedVarNames.has(name);
+    return (
+      !existingVarNames.has(name) &&
+      !guaranteedConnectorProvidedVarNames.has(name)
+    );
   });
 
   if (missingSecrets.length === 0 && missingVars.length === 0) {

--- a/turbo/packages/api-contracts/src/contracts/connector-schemas.ts
+++ b/turbo/packages/api-contracts/src/contracts/connector-schemas.ts
@@ -57,7 +57,8 @@ export type ConnectorProvidedBindingNamespace = z.infer<
 
 /**
  * Names that a stored connector guarantees at runtime. Optional bindings are
- * omitted because they only exist when the optional connector field is set.
+ * omitted because they are not guaranteed unless the optional connector field
+ * is set.
  */
 export function guaranteedConnectorProvidedBindingNames(args: {
   readonly bindings: readonly ConnectorProvidedBinding[];

--- a/turbo/packages/api-contracts/src/contracts/connector-schemas.ts
+++ b/turbo/packages/api-contracts/src/contracts/connector-schemas.ts
@@ -57,8 +57,8 @@ export type ConnectorProvidedBindingNamespace = z.infer<
 
 /**
  * Names that a stored connector guarantees at runtime. Optional bindings are
- * omitted because they are not guaranteed unless the optional connector field
- * is set.
+ * omitted because they describe possible connector supply, not guaranteed
+ * connector supply.
  */
 export function guaranteedConnectorProvidedBindingNames(args: {
   readonly bindings: readonly ConnectorProvidedBinding[];

--- a/turbo/packages/api-contracts/src/contracts/connector-schemas.ts
+++ b/turbo/packages/api-contracts/src/contracts/connector-schemas.ts
@@ -55,7 +55,11 @@ export type ConnectorProvidedBindingNamespace = z.infer<
   typeof connectorProvidedBindingNamespaceSchema
 >;
 
-export function connectorProvidedBindingNames(args: {
+/**
+ * Names that a stored connector guarantees at runtime. Optional bindings are
+ * omitted because they only exist when the optional connector field is set.
+ */
+export function guaranteedConnectorProvidedBindingNames(args: {
   readonly bindings: readonly ConnectorProvidedBinding[];
   readonly namespace: ConnectorProvidedBindingNamespace;
 }): Set<string> {

--- a/turbo/packages/api-contracts/src/contracts/connector-schemas.ts
+++ b/turbo/packages/api-contracts/src/contracts/connector-schemas.ts
@@ -44,7 +44,7 @@ export const connectorProvidedBindingSchema = z.object({
   authMethod: z.string(),
   namespace: connectorProvidedBindingNamespaceSchema,
   name: z.string(),
-  required: z.boolean(),
+  optional: z.boolean(),
   source: connectorProvidedBindingSourceSchema,
 });
 
@@ -61,7 +61,7 @@ export function connectorProvidedBindingNames(args: {
 }): Set<string> {
   const names = new Set<string>();
   for (const binding of args.bindings) {
-    if (binding.namespace === args.namespace && binding.required) {
+    if (binding.namespace === args.namespace && !binding.optional) {
       names.add(binding.name);
     }
   }

--- a/turbo/packages/api-contracts/src/contracts/index.ts
+++ b/turbo/packages/api-contracts/src/contracts/index.ts
@@ -728,7 +728,7 @@ export {
 export {
   connectorResponseSchema,
   connectorListResponseSchema,
-  connectorProvidedBindingNames,
+  guaranteedConnectorProvidedBindingNames,
   connectorProvidedBindingNamespaceSchema,
   connectorProvidedBindingSchema,
   connectorProvidedBindingSourceSchema,

--- a/turbo/packages/connectors/src/__tests__/connectors.test.ts
+++ b/turbo/packages/connectors/src/__tests__/connectors.test.ts
@@ -2334,7 +2334,7 @@ describe("getConnectorAuthMethodRuntimeMetadata", () => {
     });
   });
 
-  it("preserves optional runtime binding requiredness", () => {
+  it("preserves optional env binding availability as non-required runtime metadata", () => {
     expect(
       getConnectorAuthMethodRuntimeMetadata("agora", "api-token"),
     ).toMatchObject({
@@ -2349,6 +2349,43 @@ describe("getConnectorAuthMethodRuntimeMetadata", () => {
           },
         },
       ]),
+    });
+  });
+
+  it("does not use legacy required metadata in connector envBindings", () => {
+    for (const type of connectorTypeSchema.options) {
+      for (const authMethod of getConfiguredConnectorAuthMethodIds(type)) {
+        const method = getConnectorAuthMethod(type, authMethod);
+        if (!method) {
+          continue;
+        }
+        if (method.access.kind === "none") {
+          continue;
+        }
+        for (const [envName, binding] of Object.entries(
+          method.access.envBindings,
+        )) {
+          if (typeof binding === "string") {
+            continue;
+          }
+          expect(
+            "required" in binding,
+            `${type}/${authMethod}: env binding ${envName} must use optional: true instead of required: false`,
+          ).toBe(false);
+        }
+      }
+    }
+  });
+
+  it("keeps manual grant field requiredness separate from env binding availability", () => {
+    expect(getConnectorAuthMethod("gitlab", "api-token")?.grant).toMatchObject({
+      kind: "manual",
+      fields: {
+        GITLAB_HOST: {
+          required: false,
+          storage: "variable",
+        },
+      },
     });
   });
 

--- a/turbo/packages/connectors/src/__tests__/connectors.test.ts
+++ b/turbo/packages/connectors/src/__tests__/connectors.test.ts
@@ -2227,7 +2227,7 @@ describe("getConnectorAuthMethodRuntimeMetadata", () => {
         {
           envName: "GH_TOKEN",
           valueRef: "$secrets.GITHUB_ACCESS_TOKEN",
-          required: true,
+          optional: false,
           source: {
             kind: "connector-secret",
             name: "GITHUB_ACCESS_TOKEN",
@@ -2236,7 +2236,7 @@ describe("getConnectorAuthMethodRuntimeMetadata", () => {
         {
           envName: "GITHUB_TOKEN",
           valueRef: "$secrets.GITHUB_ACCESS_TOKEN",
-          required: true,
+          optional: false,
           source: {
             kind: "connector-secret",
             name: "GITHUB_ACCESS_TOKEN",
@@ -2258,7 +2258,7 @@ describe("getConnectorAuthMethodRuntimeMetadata", () => {
         {
           envName: "STRIPE_TOKEN",
           valueRef: "$secrets.STRIPE_TOKEN",
-          required: true,
+          optional: false,
           source: {
             kind: "connector-secret",
             name: "STRIPE_TOKEN",
@@ -2284,7 +2284,7 @@ describe("getConnectorAuthMethodRuntimeMetadata", () => {
         {
           envName: "SLOCK_TOKEN",
           valueRef: "$secrets.SLOCK_ACCESS_TOKEN",
-          required: true,
+          optional: false,
           source: {
             kind: "connector-secret",
             name: "SLOCK_ACCESS_TOKEN",
@@ -2293,7 +2293,7 @@ describe("getConnectorAuthMethodRuntimeMetadata", () => {
         {
           envName: "SLOCK_SERVER_ID",
           valueRef: "$secrets.SLOCK_SERVER_ID",
-          required: true,
+          optional: false,
           source: {
             kind: "connector-secret",
             name: "SLOCK_SERVER_ID",
@@ -2315,7 +2315,7 @@ describe("getConnectorAuthMethodRuntimeMetadata", () => {
         {
           envName: "GOOGLE_ADS_TOKEN",
           valueRef: "$secrets.GOOGLE_ADS_ACCESS_TOKEN",
-          required: true,
+          optional: false,
           source: {
             kind: "connector-secret",
             name: "GOOGLE_ADS_ACCESS_TOKEN",
@@ -2324,7 +2324,7 @@ describe("getConnectorAuthMethodRuntimeMetadata", () => {
         {
           envName: "GOOGLE_ADS_DEVELOPER_TOKEN",
           valueRef: "$secrets.GOOGLE_ADS_DEVELOPER_TOKEN",
-          required: true,
+          optional: false,
           source: {
             kind: "platform-secret",
             name: "GOOGLE_ADS_DEVELOPER_TOKEN",
@@ -2334,7 +2334,7 @@ describe("getConnectorAuthMethodRuntimeMetadata", () => {
     });
   });
 
-  it("preserves optional env binding availability as non-required runtime metadata", () => {
+  it("preserves optional env binding availability as optional runtime metadata", () => {
     expect(
       getConnectorAuthMethodRuntimeMetadata("agora", "api-token"),
     ).toMatchObject({
@@ -2342,7 +2342,7 @@ describe("getConnectorAuthMethodRuntimeMetadata", () => {
         {
           envName: "AGORA_APP_CERTIFICATE",
           valueRef: "$secrets.AGORA_APP_CERTIFICATE",
-          required: false,
+          optional: true,
           source: {
             kind: "connector-secret",
             name: "AGORA_APP_CERTIFICATE",
@@ -2419,9 +2419,9 @@ describe("getConnectorAuthMethodRuntimeMetadata", () => {
           );
           for (const binding of runtimeBindings) {
             expect(
-              binding.required,
-              `${type}/${authMethod}: optional field ${fieldName} must not be marked as a required runtime binding`,
-            ).toBe(false);
+              binding.optional,
+              `${type}/${authMethod}: optional field ${fieldName} must be marked as an optional runtime binding`,
+            ).toBe(true);
           }
         }
       }

--- a/turbo/packages/connectors/src/connector-utils.ts
+++ b/turbo/packages/connectors/src/connector-utils.ts
@@ -629,10 +629,10 @@ function connectorEnvBindingValueRef(
   return typeof binding === "string" ? binding : binding.valueRef;
 }
 
-function connectorEnvBindingRequired(
+function connectorEnvBindingIsRequiredProvided(
   binding: ConnectorEnvBindingValue,
 ): boolean {
-  return typeof binding === "string" ? true : (binding.required ?? true);
+  return typeof binding === "string" ? true : !(binding.optional ?? false);
 }
 
 function connectorRuntimeEnvBindings(
@@ -652,7 +652,7 @@ function connectorRuntimeBindingEntries(args: {
   const entries: ConnectorRuntimeBindingEntry[] = [];
   for (const [envName, binding] of Object.entries(args.envBindings)) {
     const valueRef = connectorEnvBindingValueRef(binding);
-    const required = connectorEnvBindingRequired(binding);
+    const required = connectorEnvBindingIsRequiredProvided(binding);
     if (valueRef.startsWith(CONNECTOR_SECRET_REF_PREFIX)) {
       const secretName = valueRef.slice(CONNECTOR_SECRET_REF_PREFIX.length);
       const platformSecret = connectorPlatformSecretSource(

--- a/turbo/packages/connectors/src/connector-utils.ts
+++ b/turbo/packages/connectors/src/connector-utils.ts
@@ -372,7 +372,7 @@ export type ConnectorRuntimeBindingSource =
 export interface ConnectorRuntimeBindingEntry {
   readonly envName: string;
   readonly valueRef: string;
-  readonly required: boolean;
+  readonly optional: boolean;
   readonly source: ConnectorRuntimeBindingSource;
 }
 
@@ -629,10 +629,10 @@ function connectorEnvBindingValueRef(
   return typeof binding === "string" ? binding : binding.valueRef;
 }
 
-function connectorEnvBindingIsRequiredProvided(
+function connectorEnvBindingIsOptional(
   binding: ConnectorEnvBindingValue,
 ): boolean {
-  return typeof binding === "string" ? true : !(binding.optional ?? false);
+  return typeof binding === "string" ? false : (binding.optional ?? false);
 }
 
 function connectorRuntimeEnvBindings(
@@ -652,7 +652,7 @@ function connectorRuntimeBindingEntries(args: {
   const entries: ConnectorRuntimeBindingEntry[] = [];
   for (const [envName, binding] of Object.entries(args.envBindings)) {
     const valueRef = connectorEnvBindingValueRef(binding);
-    const required = connectorEnvBindingIsRequiredProvided(binding);
+    const optional = connectorEnvBindingIsOptional(binding);
     if (valueRef.startsWith(CONNECTOR_SECRET_REF_PREFIX)) {
       const secretName = valueRef.slice(CONNECTOR_SECRET_REF_PREFIX.length);
       const platformSecret = connectorPlatformSecretSource(
@@ -662,7 +662,7 @@ function connectorRuntimeBindingEntries(args: {
       entries.push({
         envName,
         valueRef,
-        required,
+        optional,
         source: platformSecret
           ? { kind: "platform-secret", name: platformSecret }
           : { kind: "connector-secret", name: secretName },
@@ -674,7 +674,7 @@ function connectorRuntimeBindingEntries(args: {
       entries.push({
         envName,
         valueRef,
-        required,
+        optional,
         source: {
           kind: "connector-variable",
           name: valueRef.slice(CONNECTOR_VARIABLE_REF_PREFIX.length),

--- a/turbo/packages/connectors/src/connectors.ts
+++ b/turbo/packages/connectors/src/connectors.ts
@@ -368,7 +368,7 @@ export type ConnectorEnvBindingValue =
   | ConnectorRefreshTokenInputValueRef
   | {
       readonly valueRef: ConnectorRefreshTokenInputValueRef;
-      readonly required?: boolean;
+      readonly optional?: boolean;
     };
 export type ConnectorEnvBindings = Record<string, ConnectorEnvBindingValue>;
 
@@ -655,9 +655,15 @@ type ConnectorRefreshOutputValueRef<Storage> =
 type ConnectorRevokeInputValueRef<Storage> =
   `$secrets.${ConnectorStorageSecretName<Storage>}`;
 
+type RejectLegacyConnectorEnvBindingRequired<Binding> = Binding extends {
+  readonly required: unknown;
+}
+  ? never
+  : Binding;
+
 type ValidatedConnectorEnvBindingValue<Binding, Storage, Access> =
   Binding extends { readonly valueRef: infer ValueRef }
-    ? Binding & {
+    ? RejectLegacyConnectorEnvBindingRequired<Binding> & {
         readonly valueRef: ValueRef extends ConnectorRuntimeValueRef<
           Storage,
           Access

--- a/turbo/packages/connectors/src/connectors/agora.ts
+++ b/turbo/packages/connectors/src/connectors/agora.ts
@@ -54,7 +54,7 @@ export const agora = {
             AGORA_APP_ID: "$vars.AGORA_APP_ID",
             AGORA_APP_CERTIFICATE: {
               valueRef: "$secrets.AGORA_APP_CERTIFICATE",
-              required: false,
+              optional: true,
             },
           },
         },

--- a/turbo/packages/connectors/src/connectors/gitlab.ts
+++ b/turbo/packages/connectors/src/connectors/gitlab.ts
@@ -37,7 +37,7 @@ export const gitlab = {
             GITLAB_TOKEN: "$secrets.GITLAB_TOKEN",
             GITLAB_HOST: {
               valueRef: "$vars.GITLAB_HOST",
-              required: false,
+              optional: true,
             },
           },
         },


### PR DESCRIPTION
## Summary

- replace connector `envBindings.required: false` config metadata with `optional: true`
- expose connector-provided runtime/API bindings with `optional` instead of the old `required` field
- filter guaranteed connector-provided binding names to include only non-optional bindings
- use runtime binding `optional` as the single source of truth for connector env injection and grant output requirements
- add a connector metadata guard so env bindings no longer use the legacy `required` field
- preserve manual grant field `required` semantics separately from env binding availability
- clarify that guaranteed connector binding helpers exclude optional possible supply

## Verification

- `pnpm -F @vm0/connectors exec vitest run src/__tests__/connectors.test.ts`
- `pnpm --filter ./apps/api exec vitest run src/signals/services/__tests__/zero-connector-data.service.test.ts`
- `pnpm --filter ./apps/api exec vitest run src/signals/routes/__tests__/connectors-type-callback.test.ts`
- `pnpm --filter ./apps/api exec vitest run src/signals/routes/__tests__/zero-runs-create.test.ts`
- `pnpm --filter ./apps/cli exec vitest run src/commands/compose/__tests__/index.test.ts`
- `pnpm -F @vm0/api-contracts test`
- `pnpm -F @vm0/connectors check-types`
- `pnpm -F @vm0/api-contracts check-types`
- `pnpm --filter ./apps/api check-types`
- `pnpm --filter ./apps/cli check-types`
- `pnpm -F @vm0/connectors lint`
- `pnpm -F @vm0/api-contracts lint`
- `pnpm --filter ./apps/api lint`
- `pnpm --filter ./apps/cli lint`
- `pnpm exec prettier --check packages/api-contracts/src/contracts/connector-schemas.ts`
- `git diff --check`
- pre-commit hook: prettier, knip, full `pnpm check-types`

Closes #16216
