### PR TITLE
chore: update rootfs package versions

### DIFF
--- a/crates/runner/scripts/build-template.sh
+++ b/crates/runner/scripts/build-template.sh
@@ -111,7 +111,7 @@ CACHE_TMP_TAR=""
 
 # Pinned versions (changes here invalidate the template cache via script hash)
 GO_VERSION="1.26.4"
-CLAUDE_CODE_VERSION="2.1.162"
+CLAUDE_CODE_VERSION="2.1.163"
 CODEX_CLI_VERSION="0.137.0"
 GWS_CLI_VERSION="0.22.5"
 XURL_VERSION="1.0.3"


### PR DESCRIPTION
Updates:
- Claude Code: 2.1.162 -> 2.1.163

Verification:
- Checked Go download feed, npm package metadata, Node.js LTS feed, and the Claude Code standalone manifest.
- Ran `git diff --check`.
- Ran `bash -n crates/runner/scripts/build-template.sh`.
- `shellcheck` was not installed in the runtime.