### PR TITLE
chore(rust): update dependencies

### DIFF
--- a/crates/Cargo.lock
+++ b/crates/Cargo.lock
@@ -738,9 +738,9 @@ checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
 
 [[package]]
 name = "chrono"
-version = "0.4.44"
+version = "0.4.45"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c673075a2e0e5f4a1dde27ce9dee1ea4558c7ffe648f576438a20ca1d2acc4b0"
+checksum = "1aa79e62e7697b8e29b513a68abacf485adcd1fe8284a4316c5ae868e6633327"
 dependencies = [
  "iana-time-zone",
  "num-traits",


### PR DESCRIPTION
## Summary
- Ran `cargo update --verbose` for the Rust workspace at `crates/`.
- Updated 1 dependency in `crates/Cargo.lock`: `chrono` `0.4.44` -> `0.4.45`.
- Re-ran `cargo update --verbose` after rebasing onto the current `main`; no additional updates were available.

## Dependencies not updated
- `generic-array` remains at `0.14.7` while `0.14.9` is available. An explicit update attempt failed because `crypto-common v0.1.7` requires `generic-array = "=0.14.7"` transitively through `digest v0.10.7` / `crc-fast` / `aws-smithy-checksums` / `aws-sdk-s3`.

## Manual version bumps
- None. No safe minor/patch Cargo.toml version constraint bumps were needed.

## Tests
- Pass: `cargo test --workspace`.
- Command used for the final post-rebase verification: `CARGO_TARGET_DIR=/home/user/workspace/vm0-rust-deps-target CARGO_PROFILE_TEST_DEBUG=0 CARGO_INCREMENTAL=0 CARGO_BUILD_JOBS=1 CLI_AGENT_TYPE=claude-code cargo test --workspace`.
- Context: the default `/tmp` target directory ran out of disk space during the first workspace test build, so the final run used a larger Cargo target directory. `CLI_AGENT_TYPE=claude-code` was set to avoid the outer scheduled-agent environment forcing Codex framework defaults in tests that expect the repository's default Claude framework behavior.
