### PR TITLE
Add memory dev refresh

### DIFF
--- a/turbo/apps/api/src/signals/route.ts
+++ b/turbo/apps/api/src/signals/route.ts
@@ -94,6 +94,7 @@ import { zeroFeatureSwitchesRoutes } from "./routes/zero-feature-switches";
 import { zeroHostRoutes } from "./routes/zero-host";
 import { zeroMemoryRoutes } from "./routes/zero-memory";
 import { zeroMemoryActivityRoutes } from "./routes/zero-memory-activity";
+import { zeroMemoryDevRefreshRoutes } from "./routes/zero-memory-dev-refresh";
 import { zeroBuiltInGenerationRoutes } from "./routes/zero-built-in-generation";
 import { zeroInsightsRoutes } from "./routes/zero-insights";
 import { zeroImageIoGenerateRoutes } from "./routes/zero-image-io-generate";
@@ -277,6 +278,7 @@ export const ROUTES: readonly RouteEntry[] = [
   ...zeroHostRoutes,
   ...zeroMemoryRoutes,
   ...zeroMemoryActivityRoutes,
+  ...zeroMemoryDevRefreshRoutes,
   ...zeroBuiltInGenerationRoutes,
   ...zeroInsightsRoutes,
   ...zeroImageIoGenerateRoutes,

--- a/turbo/apps/api/src/signals/routes/__tests__/cron-summarize-memory.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/cron-summarize-memory.test.ts
@@ -1,6 +1,7 @@
 import { randomUUID } from "node:crypto";
 
 import { cronSummarizeMemoryContract } from "@vm0/api-contracts/contracts/cron";
+import { zeroMemoryDevRefreshContract } from "@vm0/api-contracts/contracts/zero-memory-dev-refresh";
 import { FeatureSwitchKey } from "@vm0/core/feature-switch-key";
 import { memoryChangeItems } from "@vm0/db/schema/memory-change-item";
 import { memoryChangeSummaries } from "@vm0/db/schema/memory-change-summary";
@@ -26,10 +27,14 @@ import {
   seedMemoryStorage$,
   seedMemoryVersion$,
 } from "./helpers/zero-memory";
-import { createFixtureTracker } from "./helpers/zero-route-test";
+import {
+  createFixtureTracker,
+  createZeroRouteMocks,
+} from "./helpers/zero-route-test";
 
 const context = testContext();
 const store = createStore();
+const mocks = createZeroRouteMocks(context);
 const OPENROUTER_URL = "https://openrouter.ai/api/v1/chat/completions";
 // Fixed clock: "today" in UTC is 2999-01-03, so the seven most-recently-closed
 // local days are 2998-12-27 through 2999-01-02.
@@ -86,6 +91,14 @@ const track = createFixtureTracker<MemoryFixture>(async (fixture) => {
 
 function apiClient() {
   return setupApp({ context })(cronSummarizeMemoryContract);
+}
+
+function devRefreshClient() {
+  return setupApp({ context })(zeroMemoryDevRefreshContract);
+}
+
+function authHeaders() {
+  return { authorization: "Bearer clerk-session" };
 }
 
 function cronHeaders(secret = "test-cron-secret") {
@@ -840,5 +853,101 @@ describe("GET /api/cron/summarize-memory", () => {
     expect(enabledSummary).not.toBeNull();
     expect(enabledSummary?.toVersionId).toBe(enabled.v2Id);
     await expect(findSummaries(disabled.fixture)).resolves.toHaveLength(0);
+  });
+});
+
+describe("POST /api/zero/memory/dev-refresh", () => {
+  beforeEach(() => {
+    mockNow(new Date(FIXED_NOW_ISO));
+  });
+
+  afterEach(() => {
+    clearMockNow();
+  });
+
+  it("returns 401 when the request is unauthenticated", async () => {
+    const response = await accept(
+      devRefreshClient().refresh({ headers: {} }),
+      [401],
+    );
+    expect(response.body).toStrictEqual({
+      error: { message: "Not authenticated", code: "UNAUTHORIZED" },
+    });
+  });
+
+  it("rejects non-staff users outside development", async () => {
+    mockEnv("ENV", "production");
+    const fixture = await track(
+      store.set(seedMemoryFixture$, undefined, context.signal),
+    );
+    mocks.clerk.session(fixture.userId, fixture.orgId);
+
+    const response = await accept(
+      devRefreshClient().refresh({ headers: authHeaders() }),
+      [403],
+    );
+
+    expect(response.body).toStrictEqual({
+      error: {
+        message: "Memory dev refresh is only available to staff",
+        code: "FORBIDDEN",
+      },
+    });
+  });
+
+  it("force-regenerates only the current user's memory summaries", async () => {
+    const current = await seedTwoVersionsNoMock();
+    const other = await seedTwoVersionsNoMock();
+    mockMemoryVersions(context, [
+      {
+        s3Key: current.v1Key,
+        files: [{ path: "facts/pets.md", content: "Has a dog" }],
+      },
+      {
+        s3Key: current.v2Key,
+        files: [
+          { path: "facts/pets.md", content: "Has a dog" },
+          { path: "facts/coffee.md", content: "Drinks oat milk lattes" },
+        ],
+      },
+      {
+        s3Key: other.v1Key,
+        files: [{ path: "facts/pets.md", content: "Has a dog" }],
+      },
+      {
+        s3Key: other.v2Key,
+        files: [
+          { path: "facts/pets.md", content: "Has a dog" },
+          { path: "facts/coffee.md", content: "Drinks oat milk lattes" },
+        ],
+      },
+    ]);
+    mocks.clerk.session(current.fixture.userId, current.fixture.orgId);
+
+    const oldLlm = mockLlm("Old prompt summary");
+    const first = await accept(
+      devRefreshClient().refresh({ headers: authHeaders() }),
+      [200],
+    );
+    expect(first.body).toStrictEqual({ summarized: 2 });
+    expect(oldLlm.calls).toBe(2);
+
+    const before = await findSummary(current.fixture);
+    expect(before?.summary).toBe("Old prompt summary");
+    await expect(findSummaries(other.fixture)).resolves.toHaveLength(0);
+
+    const newLlm = mockLlm("New prompt summary");
+    const second = await accept(
+      devRefreshClient().refresh({ headers: authHeaders() }),
+      [200],
+    );
+
+    expect(second.body).toStrictEqual({ summarized: 2 });
+    expect(newLlm.calls).toBe(2);
+    const after = await findSummary(current.fixture);
+    expect(after?.id).toBe(before?.id);
+    expect(after?.summary).toBe("New prompt summary");
+    await expect(findSummaries(current.fixture)).resolves.toHaveLength(2);
+    await expect(findSummaries(other.fixture)).resolves.toHaveLength(0);
   });
 });

--- a/turbo/apps/api/src/signals/routes/zero-memory-dev-refresh.ts
+++ b/turbo/apps/api/src/signals/routes/zero-memory-dev-refresh.ts
@@ -1,0 +1,59 @@
+import { zeroMemoryDevRefreshContract } from "@vm0/api-contracts/contracts/zero-memory-dev-refresh";
+import { isStaffOrg } from "@vm0/core/staff-org";
+import { command } from "ccstate";
+
+import { env } from "../../lib/env";
+import { organizationAuthContext$ } from "../auth/auth-context";
+import { authRoute } from "../auth/auth-route";
+import type { RouteEntry } from "../route";
+import { summarizeMemoryForUser$ } from "../services/cron-summarize-memory.service";
+
+const memoryDevRefreshAuthOptions = {
+  requireOrganization: true,
+  missingOrganizationStatus: 401,
+} as const;
+
+function canUseMemoryDevRefresh(orgId: string): boolean {
+  return env("ENV") === "development" || isStaffOrg(orgId);
+}
+
+function memoryDevRefreshForbiddenResponse() {
+  return {
+    status: 403 as const,
+    body: {
+      error: {
+        message: "Memory dev refresh is only available to staff",
+        code: "FORBIDDEN",
+      },
+    },
+  };
+}
+
+const refreshMemoryInner$ = command(
+  async ({ get, set }, signal: AbortSignal) => {
+    const auth = get(organizationAuthContext$);
+    if (!canUseMemoryDevRefresh(auth.orgId)) {
+      return memoryDevRefreshForbiddenResponse();
+    }
+
+    const body = await set(
+      summarizeMemoryForUser$,
+      {
+        orgId: auth.orgId,
+        userId: auth.userId,
+        force: true,
+      },
+      signal,
+    );
+    signal.throwIfAborted();
+
+    return { status: 200 as const, body };
+  },
+);
+
+export const zeroMemoryDevRefreshRoutes: readonly RouteEntry[] = [
+  {
+    route: zeroMemoryDevRefreshContract.refresh,
+    handler: authRoute(memoryDevRefreshAuthOptions, refreshMemoryInner$),
+  },
+];

--- a/turbo/apps/api/src/signals/services/cron-summarize-memory.service.ts
+++ b/turbo/apps/api/src/signals/services/cron-summarize-memory.service.ts
@@ -36,6 +36,17 @@ interface MemoryStorageRow {
   readonly storageId: string;
 }
 
+interface MemoryStorageFilter {
+  readonly orgId?: string;
+  readonly userId?: string;
+}
+
+interface SummarizeUserMemoryOptions {
+  readonly now: Date;
+  readonly signal: AbortSignal;
+  readonly force: boolean;
+}
+
 interface MemoryVersionRow {
   readonly id: string;
   readonly s3Key: string;
@@ -71,7 +82,19 @@ function recentClosedDateLabels(todayLabel: string): readonly string[] {
 async function loadMemoryStorages(
   db: Db,
   signal: AbortSignal,
+  filter: MemoryStorageFilter = {},
 ): Promise<MemoryStorageRow[]> {
+  const filters = [
+    eq(storages.name, MEMORY_ARTIFACT_NAME),
+    eq(storages.type, "artifact"),
+  ];
+  if (filter.orgId !== undefined) {
+    filters.push(eq(storages.orgId, filter.orgId));
+  }
+  if (filter.userId !== undefined) {
+    filters.push(eq(storages.userId, filter.userId));
+  }
+
   const rows = await db
     .select({
       orgId: storages.orgId,
@@ -79,12 +102,7 @@ async function loadMemoryStorages(
       storageId: storages.id,
     })
     .from(storages)
-    .where(
-      and(
-        eq(storages.name, MEMORY_ARTIFACT_NAME),
-        eq(storages.type, "artifact"),
-      ),
-    );
+    .where(and(...filters));
   signal.throwIfAborted();
   return rows;
 }
@@ -223,25 +241,27 @@ function summarizeUserMemory(
   db: Db,
   storage: MemoryStorageRow,
   timezone: string,
-  now: Date,
-  signal: AbortSignal,
+  options: SummarizeUserMemoryOptions,
 ): Computed<Promise<number>> {
   return computed(async (get): Promise<number> => {
+    const { now, signal, force } = options;
     const todayLabel = localDateLabel(timezone, now);
     const dateLabels = recentClosedDateLabels(todayLabel);
     const versions = await loadVersions(db, storage.storageId, signal);
 
     let summarized = 0;
     for (const dateLabel of dateLabels) {
-      // Idempotent: if a date already has a summary row, do nothing.
+      // Idempotent cron path: if a date already has a summary row, do nothing.
+      // Dev refresh sets `force` so prompt changes can regenerate old rows.
       if (
-        await summaryExists(
+        !force &&
+        (await summaryExists(
           db,
           storage.orgId,
           storage.userId,
           dateLabel,
           signal,
-        )
+        ))
       ) {
         continue;
       }
@@ -366,7 +386,13 @@ export const summarizeMemory$ = command(
       // still propagates through `settle`, so a genuine cancellation stops the
       // loop instead of being swallowed.
       const result = await settle(
-        get(summarizeUserMemory(db, storage, timezone, now, signal)),
+        get(
+          summarizeUserMemory(db, storage, timezone, {
+            now,
+            signal,
+            force: false,
+          }),
+        ),
         signal,
       );
       if (result.ok) {
@@ -382,6 +408,63 @@ export const summarizeMemory$ = command(
     }
 
     L.debug("Summarized memory changes", { summarized });
+    if (summarized === 0) {
+      return { skipped: true };
+    }
+    return { summarized };
+  },
+);
+
+export const summarizeMemoryForUser$ = command(
+  async (
+    { get, set },
+    args: {
+      readonly orgId: string;
+      readonly userId: string;
+      readonly force: boolean;
+    },
+    signal: AbortSignal,
+  ): Promise<SummarizeMemoryResult> => {
+    const db = set(writeDb$);
+    const now = nowDate();
+
+    const memoryStorages = await loadMemoryStorages(db, signal, {
+      orgId: args.orgId,
+      userId: args.userId,
+    });
+    if (memoryStorages.length === 0) {
+      L.debug("No memory artifact to summarize for user", {
+        orgId: args.orgId,
+        userId: args.userId,
+      });
+      return { skipped: true };
+    }
+
+    if (!(await get(memoryViewerEnabled(db, args.orgId, args.userId)))) {
+      signal.throwIfAborted();
+      return { skipped: true };
+    }
+    signal.throwIfAborted();
+
+    const timezoneMap = await resolveUserTimezones(
+      db,
+      [{ orgId: args.orgId, userId: args.userId }],
+      signal,
+    );
+    const timezone = timezoneMap.get(`${args.orgId}:${args.userId}`) ?? "UTC";
+
+    let summarized = 0;
+    for (const storage of memoryStorages) {
+      summarized += await get(
+        summarizeUserMemory(db, storage, timezone, {
+          now,
+          signal,
+          force: args.force,
+        }),
+      );
+      signal.throwIfAborted();
+    }
+
     if (summarized === 0) {
       return { skipped: true };
     }

--- a/turbo/apps/platform/src/mocks/handlers/api-memory-activity.ts
+++ b/turbo/apps/platform/src/mocks/handlers/api-memory-activity.ts
@@ -2,6 +2,7 @@ import {
   zeroMemoryActivityContract,
   type MemoryActivityResponse,
 } from "@vm0/api-contracts/contracts/zero-memory-activity";
+import { zeroMemoryDevRefreshContract } from "@vm0/api-contracts/contracts/zero-memory-dev-refresh";
 
 import { mockApi } from "../msw-contract.ts";
 
@@ -23,5 +24,8 @@ export function resetMockMemoryActivity(): void {
 export const apiMemoryActivityHandlers = [
   mockApi(zeroMemoryActivityContract.get, ({ respond }) => {
     return respond(200, mockMemoryActivity);
+  }),
+  mockApi(zeroMemoryDevRefreshContract.refresh, ({ respond }) => {
+    return respond(200, { skipped: true });
   }),
 ];

--- a/turbo/apps/platform/src/signals/memory-page/memory-signals.ts
+++ b/turbo/apps/platform/src/signals/memory-page/memory-signals.ts
@@ -8,6 +8,10 @@ import {
   zeroMemoryActivityContract,
   type MemoryActivityResponse,
 } from "@vm0/api-contracts/contracts/zero-memory-activity";
+import {
+  zeroMemoryDevRefreshContract,
+  type MemoryDevRefreshResponse,
+} from "@vm0/api-contracts/contracts/zero-memory-dev-refresh";
 
 import { accept } from "../../lib/accept.ts";
 import { zeroClient$ } from "../api-client.ts";
@@ -37,6 +41,22 @@ export const setMemoryTab$ = command(({ set }, tab: MemoryTab) => {
   set(internalMemoryTab$, tab);
 });
 
+type MemoryDevRefreshState =
+  | { readonly status: "idle" }
+  | { readonly status: "refreshing" }
+  | { readonly status: "success"; readonly message: string }
+  | { readonly status: "error"; readonly message: string };
+
+const memoryActivityReload$ = state(0);
+
+const internalMemoryDevRefreshState$ = state<MemoryDevRefreshState>({
+  status: "idle",
+});
+
+export const memoryDevRefreshState$ = computed((get) => {
+  return get(internalMemoryDevRefreshState$);
+});
+
 // Per-item expand state for the Updates timeline, keyed by a stable item key.
 // Mirrors the keyed-record ephemeral UI state pattern used elsewhere in the
 // platform (e.g. view-component-state) since `useState` is restricted here.
@@ -62,6 +82,7 @@ export const memoryDetail$ = computed(
 
 export const memoryActivity$ = computed(
   async (get): Promise<MemoryActivityResponse> => {
+    get(memoryActivityReload$);
     const client = get(zeroClient$)(zeroMemoryActivityContract);
     const result = await accept(client.get(), [200], { toast: false });
     return result.body;
@@ -104,6 +125,69 @@ const extraMemoryActivityPages$ = state<MemoryActivityPaginationState | null>(
 const loadingMoreMemoryActivity$ = state<string | null>(null);
 const loadMoreMemoryActivityError$ =
   state<MemoryActivityLoadMoreErrorState | null>(null);
+
+function memoryDevRefreshMessage(body: MemoryDevRefreshResponse): string {
+  if ("skipped" in body) {
+    return "No memory summaries changed";
+  }
+  if (body.summarized === 1) {
+    return "Refreshed 1 memory summary";
+  }
+  return `Refreshed ${body.summarized} memory summaries`;
+}
+
+const reloadMemoryActivity$ = command(({ set }): void => {
+  set(extraMemoryActivityPages$, null);
+  set(loadMoreMemoryActivityError$, null);
+  set(memoryActivityReload$, (current) => {
+    return current + 1;
+  });
+});
+
+export const refreshMemoryDevSummaries$ = command(
+  async ({ get, set }, signal: AbortSignal): Promise<void> => {
+    if (get(internalMemoryDevRefreshState$).status === "refreshing") {
+      return;
+    }
+
+    set(internalMemoryDevRefreshState$, { status: "refreshing" });
+
+    const client = get(zeroClient$)(zeroMemoryDevRefreshContract);
+    const settled = await withCleanup(
+      settle(
+        accept(client.refresh({ fetchOptions: { signal } }), [200], {
+          toast: false,
+        }),
+        signal,
+      ),
+      () => {
+        set(internalMemoryDevRefreshState$, (current) => {
+          return current.status === "refreshing"
+            ? ({ status: "idle" } satisfies MemoryDevRefreshState)
+            : current;
+        });
+      },
+    );
+    signal.throwIfAborted();
+
+    if (!settled.ok) {
+      set(internalMemoryDevRefreshState$, {
+        status: "error",
+        message:
+          settled.error instanceof Error
+            ? settled.error.message
+            : "Memory refresh failed",
+      });
+      return;
+    }
+
+    set(internalMemoryDevRefreshState$, {
+      status: "success",
+      message: memoryDevRefreshMessage(settled.value.body),
+    });
+    set(reloadMemoryActivity$);
+  },
+);
 
 export const memoryActivityExtraEntries$ = computed(async (get) => {
   const firstPage = await get(memoryActivity$);

--- a/turbo/apps/platform/src/views/memory-page/__tests__/memory-page.test.tsx
+++ b/turbo/apps/platform/src/views/memory-page/__tests__/memory-page.test.tsx
@@ -4,6 +4,7 @@ import {
   zeroMemoryActivityContract,
   type MemoryActivityResponse,
 } from "@vm0/api-contracts/contracts/zero-memory-activity";
+import { zeroMemoryDevRefreshContract } from "@vm0/api-contracts/contracts/zero-memory-dev-refresh";
 import { FeatureSwitchKey } from "@vm0/connectors/feature-switch-key";
 import { describe, expect, it } from "vitest";
 
@@ -300,6 +301,65 @@ describe("memory page", () => {
         return button.textContent?.includes("Load more");
       }),
     ).toBeFalsy();
+  });
+
+  it("dev-refreshes memory summaries and reloads the activity timeline", async () => {
+    const beforeEntry = memoryActivityEntry({
+      date: "2024-03-02",
+      summary: "Before refresh",
+      toVersionId: "v2",
+      filePath: "before.md",
+    });
+    const afterEntry = memoryActivityEntry({
+      date: "2024-03-02",
+      summary: "After refresh",
+      toVersionId: "v2",
+      filePath: "after.md",
+    });
+    let activityCalls = 0;
+    let refreshCalls = 0;
+    server.use(
+      mockApi(zeroMemoryActivityContract.get, ({ respond }) => {
+        activityCalls++;
+        return respond(200, {
+          entries: [activityCalls === 1 ? beforeEntry : afterEntry],
+          nextCursor: null,
+        });
+      }),
+      mockApi(zeroMemoryDevRefreshContract.refresh, ({ respond }) => {
+        refreshCalls++;
+        return respond(200, { summarized: 1 });
+      }),
+    );
+
+    detachedSetupPage({
+      context,
+      path: "/memory",
+      featureSwitches: {
+        [FeatureSwitchKey.MemoryViewer]: true,
+        [FeatureSwitchKey.MemoryDevRefresh]: true,
+      },
+    });
+
+    await waitFor(() => {
+      expect(screen.getByText("Before refresh")).toBeInTheDocument();
+    });
+
+    const refreshButton = queryAllByRoleFast("button").find((button) => {
+      return button.textContent?.includes("Dev refresh");
+    });
+    expect(refreshButton).toBeDefined();
+    click(refreshButton!);
+
+    await waitFor(() => {
+      expect(screen.getByText("After refresh")).toBeInTheDocument();
+    });
+    expect(screen.queryByText("Before refresh")).not.toBeInTheDocument();
+    expect(
+      screen.getAllByText("Refreshed 1 memory summary").length,
+    ).toBeGreaterThan(0);
+    expect(refreshCalls).toBe(1);
+    expect(activityCalls).toBe(2);
   });
 
   it("falls back to a deterministic summary line when the LLM summary is null", async () => {

--- a/turbo/apps/platform/src/views/memory-page/memory-page.tsx
+++ b/turbo/apps/platform/src/views/memory-page/memory-page.tsx
@@ -1,10 +1,11 @@
 import { useGet, useLastResolved, useLoadable, useSet } from "ccstate-react";
 import type { MouseEvent } from "react";
 import { isMap, isScalar, isSeq, parseDocument } from "yaml";
-import { IconChevronDown, IconLoader2 } from "@tabler/icons-react";
+import { IconChevronDown, IconLoader2, IconRefresh } from "@tabler/icons-react";
 import type { MemoryDetailResponse } from "@vm0/api-contracts/contracts/zero-memory";
 import type { MemoryActivityResponse } from "@vm0/api-contracts/contracts/zero-memory-activity";
-import { cn } from "@vm0/ui";
+import { FeatureSwitchKey } from "@vm0/connectors/feature-switch-key";
+import { Button, cn } from "@vm0/ui";
 import { Tabs, TabsList, TabsTrigger } from "@vm0/ui/components/ui/tabs";
 
 import {
@@ -17,14 +18,17 @@ import {
   memoryActivityLatestCursor$,
   memoryActivityLoadMoreError$,
   memoryActivityLoadingMore$,
+  memoryDevRefreshState$,
   memoryDetail$,
   memoryTab$,
+  refreshMemoryDevSummaries$,
   selectedMemoryFilePath$,
   setMemoryTab$,
   setSelectedMemoryFilePath$,
   toggleMemoryItemExpanded$,
   type MemoryTab,
 } from "../../signals/memory-page/memory-signals.ts";
+import { featureSwitch$ } from "../../signals/external/feature-switch.ts";
 import { pageSignal$ } from "../../signals/page-signal.ts";
 import { detach, Reason } from "../../signals/utils.ts";
 import { Markdown } from "../components/markdown.tsx";
@@ -183,6 +187,63 @@ function isMemoryTab(value: string): value is MemoryTab {
   return value === "updates" || value === "raw";
 }
 
+function MemoryDevRefreshButton({
+  className,
+}: {
+  readonly className?: string;
+}) {
+  const features = useGet(featureSwitch$);
+  const refreshState = useGet(memoryDevRefreshState$);
+  const refresh = useSet(refreshMemoryDevSummaries$);
+  const pageSignal = useGet(pageSignal$);
+
+  if (!features[FeatureSwitchKey.MemoryDevRefresh]) {
+    return null;
+  }
+
+  const refreshing = refreshState.status === "refreshing";
+  const status =
+    refreshState.status === "success" || refreshState.status === "error"
+      ? refreshState
+      : null;
+
+  return (
+    <div className={cn("flex shrink-0 flex-col items-end gap-1", className)}>
+      <Button
+        type="button"
+        variant="outline"
+        size="sm"
+        className="h-8 gap-1.5 px-2.5 text-xs"
+        disabled={refreshing}
+        title="Force-refresh memory summaries"
+        onClick={() => {
+          detach(refresh(pageSignal), Reason.DomCallback);
+        }}
+      >
+        {refreshing ? (
+          <IconLoader2 className="h-3.5 w-3.5 animate-spin" />
+        ) : (
+          <IconRefresh className="h-3.5 w-3.5" />
+        )}
+        <span>{refreshing ? "Refreshing" : "Dev refresh"}</span>
+      </Button>
+      {status ? (
+        <span
+          role={status.status === "error" ? "alert" : "status"}
+          className={cn(
+            "max-w-[180px] text-right text-[11px] leading-4",
+            status.status === "error"
+              ? "text-destructive"
+              : "text-muted-foreground",
+          )}
+        >
+          {status.message}
+        </span>
+      ) : null}
+    </div>
+  );
+}
+
 export function MemoryPage() {
   const activeTab = useGet(memoryTab$);
   const setTab = useSet(setMemoryTab$);
@@ -191,38 +252,44 @@ export function MemoryPage() {
     <div className="flex min-h-0 flex-1 flex-col">
       <header className="shrink-0 bg-transparent px-4 pb-0 pt-3 sm:px-6 md:pb-3 md:pt-10">
         <div className="mx-auto w-full max-w-[900px]">
-          <div className="hidden min-w-0 md:block">
-            <h1 className="text-lg font-semibold tracking-tight text-foreground">
-              Memory
-            </h1>
-            <p className="mt-0.5 text-sm text-muted-foreground">
-              What Zero remembers from previous work.
-            </p>
+          <div className="hidden min-w-0 items-start justify-between gap-4 md:flex">
+            <div className="min-w-0">
+              <h1 className="text-lg font-semibold tracking-tight text-foreground">
+                Memory
+              </h1>
+              <p className="mt-0.5 text-sm text-muted-foreground">
+                What Zero remembers from previous work.
+              </p>
+            </div>
+            <MemoryDevRefreshButton />
           </div>
-          <Tabs
-            value={activeTab}
-            onValueChange={(value) => {
-              if (isMemoryTab(value)) {
-                setTab(value);
-              }
-            }}
-            className="mt-3"
-          >
-            <TabsList className="zero-tabs h-9 gap-1 px-1 py-1">
-              <TabsTrigger
-                value="updates"
-                className="gap-1.5 px-3 text-sm data-[state=active]:bg-background"
-              >
-                Updates
-              </TabsTrigger>
-              <TabsTrigger
-                value="raw"
-                className="gap-1.5 px-3 text-sm data-[state=active]:bg-background"
-              >
-                Memory files
-              </TabsTrigger>
-            </TabsList>
-          </Tabs>
+          <div className="mt-3 flex min-w-0 items-start justify-between gap-3">
+            <Tabs
+              value={activeTab}
+              onValueChange={(value) => {
+                if (isMemoryTab(value)) {
+                  setTab(value);
+                }
+              }}
+              className="min-w-0"
+            >
+              <TabsList className="zero-tabs h-9 gap-1 px-1 py-1">
+                <TabsTrigger
+                  value="updates"
+                  className="gap-1.5 px-3 text-sm data-[state=active]:bg-background"
+                >
+                  Updates
+                </TabsTrigger>
+                <TabsTrigger
+                  value="raw"
+                  className="gap-1.5 px-3 text-sm data-[state=active]:bg-background"
+                >
+                  Memory files
+                </TabsTrigger>
+              </TabsList>
+            </Tabs>
+            <MemoryDevRefreshButton className="md:hidden" />
+          </div>
         </div>
       </header>
 

--- a/turbo/apps/web/api-backend-rewrites.js
+++ b/turbo/apps/web/api-backend-rewrites.js
@@ -1097,6 +1097,7 @@ export const API_BACKEND_REWRITES = [
   ],
   ["/api/zero/memory", "/api/zero/memory"],
   ["/api/zero/memory/activity", "/api/zero/memory/activity"],
+  ["/api/zero/memory/dev-refresh", "/api/zero/memory/dev-refresh"],
   ["/api/zero/skills", "/api/zero/skills"],
   [
     ZERO_SKILLS_BY_NAME_REWRITE_SOURCE,

--- a/turbo/packages/api-contracts/src/contracts/index.ts
+++ b/turbo/packages/api-contracts/src/contracts/index.ts
@@ -1006,6 +1006,11 @@ export {
 } from "./zero-feature-switches";
 export { zeroMemoryContract, type ZeroMemoryContract } from "./zero-memory";
 export {
+  zeroMemoryDevRefreshContract,
+  type MemoryDevRefreshResponse,
+  type ZeroMemoryDevRefreshContract,
+} from "./zero-memory-dev-refresh";
+export {
   zeroSecretsContract,
   zeroSecretsByNameContract,
   zeroVariablesContract,

--- a/turbo/packages/api-contracts/src/contracts/zero-memory-dev-refresh.ts
+++ b/turbo/packages/api-contracts/src/contracts/zero-memory-dev-refresh.ts
@@ -1,0 +1,44 @@
+import { z } from "zod";
+import { initContract, authHeadersSchema } from "./base";
+import { apiErrorSchema } from "./errors";
+
+const c = initContract();
+
+const memoryDevRefreshSkippedResponseSchema = z.object({
+  skipped: z.literal(true),
+});
+
+const memoryDevRefreshSummarizedResponseSchema = z.object({
+  summarized: z.number(),
+});
+
+export const memoryDevRefreshResponseSchema = z.union([
+  memoryDevRefreshSkippedResponseSchema,
+  memoryDevRefreshSummarizedResponseSchema,
+]);
+
+export type MemoryDevRefreshResponse = z.infer<
+  typeof memoryDevRefreshResponseSchema
+>;
+
+/**
+ * Staff/development-only refresh endpoint for iterating on Memory Activity
+ * summary generation against the current user's memory artifact.
+ */
+export const zeroMemoryDevRefreshContract = c.router({
+  refresh: {
+    method: "POST",
+    path: "/api/zero/memory/dev-refresh",
+    headers: authHeadersSchema,
+    body: c.noBody(),
+    responses: {
+      200: memoryDevRefreshResponseSchema,
+      401: apiErrorSchema,
+      403: apiErrorSchema,
+      500: apiErrorSchema,
+    },
+    summary: "Force-refresh memory summaries for the current user",
+  },
+});
+
+export type ZeroMemoryDevRefreshContract = typeof zeroMemoryDevRefreshContract;

--- a/turbo/packages/connectors/src/feature-switch-key.ts
+++ b/turbo/packages/connectors/src/feature-switch-key.ts
@@ -53,6 +53,7 @@ export enum FeatureSwitchKey {
   ChatGithubPrTracking = "chatGithubPrTracking",
   ChatTemplatePicker = "chatTemplatePicker",
   MemoryViewer = "memoryViewer",
+  MemoryDevRefresh = "memoryDevRefresh",
   ChatRecommendedFollowups = "chatRecommendedFollowups",
   ScheduledChat = "scheduledChat",
 }

--- a/turbo/packages/core/src/feature-switch.ts
+++ b/turbo/packages/core/src/feature-switch.ts
@@ -303,6 +303,13 @@ const FEATURE_SWITCHES: Record<FeatureSwitchKey, FeatureSwitch> = {
     enabled: false,
     enabledOrgIdHashes: STAFF_ORG_ID_HASHES,
   },
+  [FeatureSwitchKey.MemoryDevRefresh]: {
+    maintainer: "lancy@vm0.ai",
+    description:
+      "Show the internal Memory page dev refresh action for staff prompt iteration.",
+    enabled: false,
+    enabledOrgIdHashes: STAFF_ORG_ID_HASHES,
+  },
   [FeatureSwitchKey.ChatRecommendedFollowups]: {
     maintainer: "linghan@vm0.ai",
     description:


### PR DESCRIPTION
## Summary
- Add a staff/development-only Memory dev refresh endpoint that force-regenerates current-user memory summaries through the existing cron summarization path.
- Add a `MemoryDevRefresh` feature switch and wire the Memory page button to refresh summaries and reload the activity timeline.
- Cover API auth/current-user behavior and platform reload behavior with integration tests.

## Tests
- `pnpm format`
- `pnpm -F @vm0/api-contracts check-types`
- `pnpm -F @vm0/connectors check-types`
- `pnpm -F @vm0/core check-types`
- `pnpm -F api check-types`
- `NODE_OPTIONS=--no-experimental-webstorage pnpm -F @vm0/app check-types`
- `pnpm -F @vm0/api-contracts lint`
- `pnpm -F @vm0/connectors lint`
- `pnpm -F @vm0/core lint`
- `pnpm -F api lint`
- `pnpm -F @vm0/app lint`
- `pnpm -F web lint`
- `pnpm -F api exec vitest run src/signals/routes/__tests__/cron-summarize-memory.test.ts`
- `NODE_OPTIONS=--no-experimental-webstorage pnpm -F @vm0/app exec vitest run src/views/memory-page/__tests__/memory-page.test.tsx`
- `pnpm knip --workspace @vm0/app`

Note: full `pnpm knip` still reports existing repository-wide unused export/file debt unrelated to this change.

Closes #16241
