### PR TITLE
fix: preserve missing auto-memory artifact roots

### DIFF
--- a/crates/guest-agent/src/artifact/archive.rs
+++ b/crates/guest-agent/src/artifact/archive.rs
@@ -151,6 +151,16 @@ pub(super) enum ArchiveError {
     FinishGzip { source: io::Error },
 }
 
+impl ArchiveError {
+    pub(super) fn is_root_not_found(&self) -> bool {
+        matches!(
+            self,
+            Self::RootOpen { source, .. } | Self::RootRead { source, .. }
+                if source.kind() == io::ErrorKind::NotFound
+        )
+    }
+}
+
 /// Create a tar.gz archive containing only the listed manifest files.
 ///
 /// This ensures the archive matches the manifest exactly — no symlinks or other

--- a/crates/guest-agent/src/artifact/mod.rs
+++ b/crates/guest-agent/src/artifact/mod.rs
@@ -12,7 +12,7 @@
 use crate::error::AgentError;
 use crate::http::HttpClient;
 use guest_common::telemetry::record_sandbox_op;
-use guest_common::{log_error, log_info};
+use guest_common::{log_error, log_info, log_warn};
 use serde::Serialize;
 
 mod api;
@@ -110,14 +110,42 @@ pub(crate) enum WalkFilesError {
     Checkpoint {
         message: String,
         elapsed: std::time::Duration,
+        missing_root: bool,
     },
 }
 
 impl WalkFilesError {
+    pub(crate) fn is_missing_root(&self) -> bool {
+        matches!(
+            self,
+            Self::Checkpoint {
+                missing_root: true,
+                ..
+            }
+        )
+    }
+
+    pub(crate) fn record_preserved_missing_root(self, storage_name: &str, mount_path: &str) {
+        if let Self::Checkpoint {
+            message, elapsed, ..
+        } = self
+        {
+            log_warn!(
+                LOG_TAG,
+                "Artifact root missing for '{}' at {}; preserving parent version: {message}",
+                storage_name,
+                mount_path
+            );
+            record_sandbox_op("artifact_missing_root_preserved", elapsed, true, None);
+        }
+    }
+
     pub(crate) fn into_agent_error(self) -> AgentError {
         match self {
             Self::Execution(message) => AgentError::Execution(message),
-            Self::Checkpoint { message, elapsed } => {
+            Self::Checkpoint {
+                message, elapsed, ..
+            } => {
                 record_sandbox_op("artifact_hash_compute", elapsed, false, Some(&message));
                 log_error!(LOG_TAG, "{message}");
                 AgentError::Checkpoint(message)
@@ -153,6 +181,7 @@ pub(crate) async fn walk_files_for_checkpoint(
             return Err(WalkFilesError::Checkpoint {
                 message,
                 elapsed: hash_start.elapsed(),
+                missing_root: e.is_root_not_found(),
             });
         }
     };

--- a/crates/guest-agent/src/checkpoint.rs
+++ b/crates/guest-agent/src/checkpoint.rs
@@ -8,6 +8,7 @@ use crate::error::AgentError;
 use crate::http::HttpClient;
 use crate::paths;
 use crate::session_history;
+use api_contracts::generated::types::runners::storage::ArtifactEntryMissingRootPolicy;
 use bytes::Bytes;
 use guest_common::telemetry::record_sandbox_op;
 use guest_common::{log_error, log_info, log_warn};
@@ -63,17 +64,33 @@ fn fail(
 
 /// Shape one entry of the `artifactSnapshots` payload. Keys are the
 /// camelCase names the web Zod receiver (`artifactSnapshotsSchema`) expects.
-fn build_artifact_snapshot_entry(name: &str, version: &str, mount_path: &str) -> serde_json::Value {
-    json!({
+fn build_artifact_snapshot_entry(
+    name: &str,
+    version: &str,
+    mount_path: &str,
+    missing_root_policy: Option<ArtifactEntryMissingRootPolicy>,
+) -> serde_json::Value {
+    let mut entry = json!({
         "name": name,
         "version": version,
         "mountPath": mount_path,
-    })
+    });
+    if let Some(policy) = missing_root_policy
+        && let Some(object) = entry.as_object_mut()
+    {
+        object.insert("missingRootPolicy".to_string(), json!(policy));
+    }
+    entry
 }
 
-struct ArtifactSnapshotPlan<'a> {
-    entry: &'a env::ArtifactEnv,
-    files: Vec<artifact::FileEntry>,
+enum ArtifactSnapshotPlan<'a> {
+    Snapshot {
+        entry: &'a env::ArtifactEnv,
+        files: Vec<artifact::FileEntry>,
+    },
+    PreserveParentVersion {
+        entry: &'a env::ArtifactEnv,
+    },
 }
 
 /// Prepare + upload the session history to S3 via a presigned URL. If the
@@ -187,14 +204,44 @@ async fn snapshot_artifact_entries(
             entry.name,
             entry.mount_path
         );
-        let files = artifact::walk_files_for_checkpoint(&entry.mount_path)
-            .await
-            .map_err(|error| error.into_agent_error())?;
-        plans.push(ArtifactSnapshotPlan { entry, files });
+        match artifact::walk_files_for_checkpoint(&entry.mount_path).await {
+            Ok(files) => {
+                plans.push(ArtifactSnapshotPlan::Snapshot { entry, files });
+            }
+            Err(error)
+                if error.is_missing_root()
+                    && matches!(
+                        entry.missing_root_policy,
+                        Some(ArtifactEntryMissingRootPolicy::PreserveParentVersion)
+                    ) =>
+            {
+                error.record_preserved_missing_root(&entry.name, &entry.mount_path);
+                plans.push(ArtifactSnapshotPlan::PreserveParentVersion { entry });
+            }
+            Err(error) => return Err(error.into_agent_error()),
+        }
     }
 
     let mut results = Vec::with_capacity(plans.len());
-    for ArtifactSnapshotPlan { entry, files } in plans {
+    for plan in plans {
+        let (entry, files) = match plan {
+            ArtifactSnapshotPlan::Snapshot { entry, files } => (entry, files),
+            ArtifactSnapshotPlan::PreserveParentVersion { entry } => {
+                log_info!(
+                    LOG_TAG,
+                    "VAS artifact snapshot preserved parent version for missing root: {}@{}",
+                    entry.name,
+                    entry.version_id
+                );
+                results.push(build_artifact_snapshot_entry(
+                    &entry.name,
+                    &entry.version_id,
+                    &entry.mount_path,
+                    entry.missing_root_policy,
+                ));
+                continue;
+            }
+        };
         // Skip the VAS round-trips when the mount is byte-identical to what
         // was originally mounted. `version_id` in VAS *is* the content hash
         // (same SHA-256 the web producer emits), so an equality check on the
@@ -222,6 +269,7 @@ async fn snapshot_artifact_entries(
                 &entry.name,
                 &entry.version_id,
                 &entry.mount_path,
+                entry.missing_root_policy,
             ));
             continue;
         }
@@ -255,6 +303,7 @@ async fn snapshot_artifact_entries(
             &entry.name,
             &snapshot.version_id,
             &entry.mount_path,
+            entry.missing_root_policy,
         ));
     }
     Ok(Some(serde_json::Value::Array(results)))
@@ -510,7 +559,7 @@ mod tests {
 
     #[test]
     fn artifact_snapshot_entry_shape_matches_receiver_schema() {
-        let entry = build_artifact_snapshot_entry("workspace", "v-abc-123", "/workspace");
+        let entry = build_artifact_snapshot_entry("workspace", "v-abc-123", "/workspace", None);
         assert_eq!(
             entry,
             json!({
@@ -523,15 +572,22 @@ mod tests {
 
     #[test]
     fn artifact_snapshot_entry_uses_camel_case_keys() {
-        let entry = build_artifact_snapshot_entry("n", "v", "/m");
+        let entry = build_artifact_snapshot_entry(
+            "n",
+            "v",
+            "/m",
+            Some(ArtifactEntryMissingRootPolicy::PreserveParentVersion),
+        );
         let obj = entry.as_object().expect("entry must be a JSON object");
         // Contract-boundary invariant: the web Zod receiver requires camelCase
-        // `mountPath`; a snake_case slip would silently cause a 400 on the
-        // webhook side.
+        // `mountPath` and `missingRootPolicy`; a snake_case slip would
+        // silently cause a 400 on the webhook side.
         assert!(obj.contains_key("name"));
         assert!(obj.contains_key("version"));
         assert!(obj.contains_key("mountPath"));
+        assert!(obj.contains_key("missingRootPolicy"));
         assert!(!obj.contains_key("mount_path"));
+        assert!(!obj.contains_key("missing_root_policy"));
     }
 
     #[tokio::test]
@@ -658,7 +714,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn artifact_snapshot_preserve_policy_missing_mount_still_fails() {
+    async fn artifact_snapshot_preserve_policy_missing_mount_preserves_parent_version() {
         let server = MockServer::start();
         let prepare = server.mock(|when, then| {
             when.method(POST)
@@ -682,13 +738,21 @@ mod tests {
             missing_root_policy: Some(ArtifactEntryMissingRootPolicy::PreserveParentVersion),
         }];
 
-        let err = snapshot_artifact_entries(&http, &entries)
+        let snapshots = snapshot_artifact_entries(&http, &entries)
             .await
-            .unwrap_err();
+            .unwrap()
+            .unwrap();
 
-        assert!(
-            err.to_string().contains("Failed to walk artifact files"),
-            "got: {err}"
+        assert_eq!(
+            snapshots,
+            json!([
+                {
+                    "name": "memory",
+                    "version": "old-memory-version",
+                    "mountPath": missing_mount.to_string_lossy(),
+                    "missingRootPolicy": "preserveParentVersion",
+                }
+            ])
         );
         prepare.assert_calls(0);
         commit.assert_calls(0);

--- a/turbo/apps/api/src/signals/routes/__tests__/agent-runs-create.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/agent-runs-create.test.ts
@@ -1497,20 +1497,13 @@ describe("POST /api/agent/runs", () => {
         .sort(),
     ).toStrictEqual(["artifact", "memory"]);
     expect(
-      session?.artifacts.some((artifact) => {
-        return Object.prototype.hasOwnProperty.call(
-          artifact,
-          "missingRootPolicy",
-        );
-      }),
-    ).toBeFalsy();
-    expect(
       session?.artifacts.find((artifact) => {
         return artifact.name === "memory";
       }),
     ).toStrictEqual({
       name: "memory",
       mountPath: CANONICAL_CLAUDE_MEMORY_MOUNT_PATH,
+      missingRootPolicy: "preserveParentVersion",
     });
 
     const [job] = await db
@@ -1564,7 +1557,7 @@ describe("POST /api/agent/runs", () => {
         return artifact.vasStorageName === "artifact";
       },
     );
-    expect(memoryArtifact?.missingRootPolicy).toBeUndefined();
+    expect(memoryArtifact?.missingRootPolicy).toBe("preserveParentVersion");
     expect(requestedArtifact?.missingRootPolicy).toBeUndefined();
   });
 
@@ -2203,7 +2196,7 @@ describe("POST /api/agent/runs", () => {
           artifact.mountPath === CANONICAL_CLAUDE_MEMORY_MOUNT_PATH
         );
       })?.missingRootPolicy,
-    ).toBeUndefined();
+    ).toBe("preserveParentVersion");
     expect(runContextSnapshot(continued.body.runId)).toMatchObject({
       runId: continued.body.runId,
       userId: fx.userId,
@@ -2630,7 +2623,7 @@ describe("POST /api/agent/runs", () => {
     ).toBeUndefined();
   });
 
-  it("does not add missing root policy to continued canonical memory checkpoint artifacts", async () => {
+  it("preserves missing root policy from continued canonical memory checkpoint artifacts", async () => {
     const fx = await fixture();
     const compose = await createCompose({ fixture: fx });
     const first = await accept(
@@ -2695,6 +2688,7 @@ describe("POST /api/agent/runs", () => {
             name: "memory",
             mountPath: CANONICAL_CLAUDE_MEMORY_MOUNT_PATH,
             version: memoryStorage.headVersionId,
+            missingRootPolicy: "preserveParentVersion",
           },
         ],
       })
@@ -2733,6 +2727,6 @@ describe("POST /api/agent/runs", () => {
           artifact.mountPath === CANONICAL_CLAUDE_MEMORY_MOUNT_PATH
         );
       })?.missingRootPolicy,
-    ).toBeUndefined();
+    ).toBe("preserveParentVersion");
   });
 });

--- a/turbo/apps/api/src/signals/routes/__tests__/webhooks-agent-checkpoints.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/webhooks-agent-checkpoints.test.ts
@@ -584,6 +584,7 @@ describe("POST /api/webhooks/agent/checkpoints", () => {
         name: "memory",
         version: "version-bbb",
         mountPath: CANONICAL_CLAUDE_MEMORY_MOUNT_PATH,
+        missingRootPolicy: "preserveParentVersion" as const,
       },
       {
         name: "memory",
@@ -607,6 +608,7 @@ describe("POST /api/webhooks/agent/checkpoints", () => {
         name: "memory",
         version: "version-bbb",
         mountPath: CANONICAL_CLAUDE_MEMORY_MOUNT_PATH,
+        missingRootPolicy: "preserveParentVersion",
       },
       {
         name: "memory",
@@ -683,6 +685,7 @@ describe("POST /api/webhooks/agent/checkpoints", () => {
         version: "version-bbb",
         mountPath: CANONICAL_CLAUDE_MEMORY_MOUNT_PATH,
         generatedBy: "apiAutoMemory" as const,
+        missingRootPolicy: "preserveParentVersion" as const,
       },
     ];
     const body = {
@@ -711,6 +714,7 @@ describe("POST /api/webhooks/agent/checkpoints", () => {
         name: "memory",
         version: "version-bbb",
         mountPath: CANONICAL_CLAUDE_MEMORY_MOUNT_PATH,
+        missingRootPolicy: "preserveParentVersion",
       },
     ]);
   });

--- a/turbo/apps/api/src/signals/services/agent-run-create.service.ts
+++ b/turbo/apps/api/src/signals/services/agent-run-create.service.ts
@@ -139,6 +139,11 @@ import { recordSandboxOperation } from "../external/sandbox-op-log";
 const PENDING_RUN_TTL_MS = 15 * 60 * 1000;
 const QUEUED_RUN_TTL_MS = 2 * 60 * 60 * 1000;
 const AUTO_MEMORY_ARTIFACT_NAME = MEMORY_ARTIFACT_NAME;
+type ArtifactMissingRootPolicy = NonNullable<
+  StorageManifest["artifacts"][number]["missingRootPolicy"]
+>;
+const AUTO_MEMORY_MISSING_ROOT_POLICY: ArtifactMissingRootPolicy =
+  "preserveParentVersion";
 
 const TIER_LIMITS = Object.freeze({
   free: 1,
@@ -185,6 +190,7 @@ interface ContextArtifact {
   readonly name: string;
   readonly version?: string;
   readonly mountPath: string;
+  readonly missingRootPolicy?: ArtifactMissingRootPolicy;
   readonly generatedBy?: "apiAutoMemory";
 }
 
@@ -602,10 +608,10 @@ function autoMemoryMountPath(framework: SupportedFramework): string {
 }
 
 function autoMemoryArtifact(framework: SupportedFramework): ContextArtifact {
-  return {
+  return withAutoMemoryMissingRootPolicy({
     name: AUTO_MEMORY_ARTIFACT_NAME,
     mountPath: autoMemoryMountPath(framework),
-  };
+  });
 }
 
 function isCanonicalAutoMemoryArtifact(
@@ -616,6 +622,15 @@ function isCanonicalAutoMemoryArtifact(
     artifact.name === AUTO_MEMORY_ARTIFACT_NAME &&
     artifact.mountPath === autoMemoryMountPath(framework)
   );
+}
+
+function withAutoMemoryMissingRootPolicy(
+  artifact: ContextArtifact,
+): ContextArtifact {
+  return {
+    ...artifact,
+    missingRootPolicy: AUTO_MEMORY_MISSING_ROOT_POLICY,
+  };
 }
 
 function claimsAutoMemorySlot(

--- a/turbo/apps/api/src/signals/services/agent-webhook-checkpoints.service.ts
+++ b/turbo/apps/api/src/signals/services/agent-webhook-checkpoints.service.ts
@@ -90,6 +90,9 @@ function artifactSnapshotsForDb(args: {
       name: snapshot.name,
       version: snapshot.version,
       mountPath: snapshot.mountPath,
+      ...(snapshot.missingRootPolicy
+        ? { missingRootPolicy: snapshot.missingRootPolicy }
+        : {}),
     };
   });
 }

--- a/turbo/packages/api-contracts/src/contracts/webhooks.ts
+++ b/turbo/packages/api-contracts/src/contracts/webhooks.ts
@@ -1,7 +1,10 @@
 import { z } from "zod";
 import { authHeadersSchema, initContract } from "./base";
 import { apiErrorSchema } from "./errors";
-import { secretConnectorMetadataMapSchema } from "./runners";
+import {
+  artifactMissingRootPolicySchema,
+  secretConnectorMetadataMapSchema,
+} from "./runners";
 import { eventSequenceNumberSchema, networkLogEntrySchema } from "./runs";
 import {
   storageTypeSchema,
@@ -149,18 +152,20 @@ const agentEventSchema = z
   .passthrough();
 
 /**
- * Artifact snapshots schema — canonical `Array<{name, version, mountPath}>`
- * form. Legacy `Record<name, version>` support was removed in #10913 after
- * the DB migration and guest-agent writer flip completed.
+ * Artifact snapshots schema — canonical
+ * `Array<{name, version, mountPath, missingRootPolicy?}>` form. Legacy
+ * `Record<name, version>` support was removed in #10913 after the DB
+ * migration and guest-agent writer flip completed.
  */
 const artifactSnapshotsSchema = z.array(
   z.object({
     name: z.string(),
     version: z.string(),
     mountPath: z.string(),
-    // Legacy internal provenance accepted for older guest agents. Run creation
-    // decides checkpoint-time behavior from the canonical artifact slot.
+    // Legacy internal provenance accepted for older guest agents; checkpoint
+    // storage strips it while preserving the artifact policy below.
     generatedBy: z.literal("apiAutoMemory").optional(),
+    missingRootPolicy: artifactMissingRootPolicySchema.optional(),
   }),
 );
 

--- a/turbo/packages/db/src/types.ts
+++ b/turbo/packages/db/src/types.ts
@@ -1,6 +1,9 @@
+export type ArtifactMissingRootPolicy = "fail" | "preserveParentVersion";
+
 export interface ContextArtifact {
   name: string;
   version?: string;
   mountPath: string;
+  missingRootPolicy?: ArtifactMissingRootPolicy;
   generatedBy?: "apiAutoMemory";
 }


### PR DESCRIPTION
Closes #16213

## Summary
- mark API-injected auto-memory artifacts with `missingRootPolicy: "preserveParentVersion"`
- carry `missingRootPolicy` through checkpoint artifact snapshots while continuing to strip legacy `generatedBy` provenance
- make guest-agent preserve the parent artifact version when a policy-marked artifact root is missing at checkpoint time

## Notes
- runner/infra remains memory-agnostic: it only transports and applies a generic artifact missing-root policy
- user-authored artifacts without the policy continue to fail strictly when their root is missing

## Verification
- `cargo test -p guest-agent artifact_snapshot_ --lib`
- `pnpm -F api exec vitest src/signals/routes/__tests__/agent-runs-create.test.ts src/signals/routes/__tests__/webhooks-agent-checkpoints.test.ts --run`
- `pnpm -F api check-types`
- `pnpm -F @vm0/api-contracts check-types`
- `pnpm -F @vm0/db check-types`
- pre-commit: cargo doc/clippy/fmt, prettier, knip, full `pnpm check-types`