### PR TITLE
docs(mitm-addon): document url syntax helper semantics

### DIFF
--- a/crates/runner/mitm-addon/src/matching.py
+++ b/crates/runner/mitm-addon/src/matching.py
@@ -317,6 +317,11 @@ def _split_base_match_url(
     are rendered as integers. The returned path excludes query and fragment so
     callers can apply base-path prefix semantics without accidentally comparing
     query strings.
+
+    ``allow_runtime_backslash_syntax`` only bypasses the early backslash gate.
+    Compiled firewall matching uses this so a backslash-bearing request can
+    still match a base URL and fail closed as ``unsafe_path`` instead of being
+    treated as an unrelated no-match.
     """
     if not allow_unsafe_runtime_url_syntax and has_unsafe_runtime_url_syntax(
         value,

--- a/crates/runner/mitm-addon/src/url_syntax.py
+++ b/crates/runner/mitm-addon/src/url_syntax.py
@@ -1,5 +1,6 @@
 """Shared URL syntax helpers for firewall matching and rewriting."""
 
+# C0 controls are code points below raw space; raw space is handled separately.
 ASCII_CONTROL_MAX = 0x20
 ASCII_DELETE = 0x7F
 RAW_WHITESPACE_CHARS = frozenset(" \t\n\r\f\v")
@@ -8,6 +9,13 @@ _UNICODE_SURROGATE_MAX = 0xDFFF
 
 
 def has_unsafe_url_codepoint(value: str) -> bool:
+    """Return whether value contains code points unsafe for raw URL parsing.
+
+    Rejects C0 controls U+0000 through U+001F, DEL U+007F, and Unicode
+    surrogates U+D800 through U+DFFF. Raw space U+0020 is intentionally
+    excluded; pair this with has_raw_whitespace() when raw whitespace must be
+    rejected.
+    """
     return any(
         ord(char) < ASCII_CONTROL_MAX
         or ord(char) == ASCII_DELETE
@@ -17,10 +25,22 @@ def has_unsafe_url_codepoint(value: str) -> bool:
 
 
 def has_raw_whitespace(value: str) -> bool:
+    """Return whether value contains raw ASCII whitespace.
+
+    This covers space, tab, LF, CR, form feed, and vertical tab.
+    """
     return any(char in RAW_WHITESPACE_CHARS for char in value)
 
 
 def has_unsafe_runtime_url_syntax(value: str, *, allow_backslash: bool = False) -> bool:
+    """Return whether value has raw syntax that should not enter URL matching.
+
+    By default this rejects backslash, unsafe URL code points, and raw ASCII
+    whitespace before urlsplit() can normalize or reinterpret them. Set
+    allow_backslash only when a caller must preserve base matching for a
+    backslash-bearing URL; the exception still rejects controls, surrogates,
+    and whitespace.
+    """
     return (
         (not allow_backslash and "\\" in value)
         or has_unsafe_url_codepoint(value)
@@ -29,4 +49,5 @@ def has_unsafe_runtime_url_syntax(value: str, *, allow_backslash: bool = False) 
 
 
 def strip_optional_terminal_slash(value: str) -> str:
+    """Remove exactly one trailing slash for base URL matching and rewrite joins."""
     return value[:-1] if value.endswith("/") else value


### PR DESCRIPTION
## Summary

- document the shared URL syntax helpers used by firewall matching and auth rewriting
- clarify that unsafe URL code points exclude raw space and should be paired with raw whitespace checks
- document the narrow runtime backslash exception used for compiled firewall fail-closed matching

Closes #16229

## Tests

```bash
cd crates/runner/mitm-addon
python3 -m ruff check src/url_syntax.py src/matching.py
python3 -m compileall -q src/url_syntax.py src/matching.py
python3 -m pytest tests/test_compiled_firewall_base_matching.py tests/test_matching_patterns.py tests/test_url_utils.py tests/test_compiled_firewall_malformed_config.py tests/test_firewall_matching.py
```
