### PR TITLE
fix: hide removed org members from insights

### DIFF
--- a/turbo/apps/api/src/signals/routes/__tests__/cron-aggregate-insights.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/cron-aggregate-insights.test.ts
@@ -1,5 +1,8 @@
+import { randomUUID } from "node:crypto";
+
 import { cronAggregateInsightsContract } from "@vm0/api-contracts/contracts/cron";
 import { insightsDaily } from "@vm0/db/schema/insights-daily";
+import { orgMembersCache } from "@vm0/db/schema/org-members-cache";
 import { orgMetadata } from "@vm0/db/schema/org-metadata";
 import { userCache } from "@vm0/db/schema/user-cache";
 import { createStore } from "ccstate";
@@ -76,14 +79,10 @@ async function rawCronRequest(
 
 async function cleanupFixture(fixture: UsageFixture): Promise<void> {
   const db = store.set(writeDb$);
+  await db.delete(insightsDaily).where(eq(insightsDaily.orgId, fixture.orgId));
   await db
-    .delete(insightsDaily)
-    .where(
-      and(
-        eq(insightsDaily.orgId, fixture.orgId),
-        eq(insightsDaily.userId, fixture.userId),
-      ),
-    );
+    .delete(orgMembersCache)
+    .where(eq(orgMembersCache.orgId, fixture.orgId));
   await store.set(deleteUsageFixture$, fixture, context.signal);
 }
 
@@ -96,7 +95,7 @@ async function setCreditBalance(fixture: UsageFixture): Promise<void> {
 }
 
 async function seedUserName(
-  fixture: UsageFixture,
+  fixture: Pick<UsageFixture, "userId">,
   email = "test@example.com",
   name: string | null = "Test User",
 ): Promise<void> {
@@ -105,6 +104,19 @@ async function seedUserName(
     userId: fixture.userId,
     email,
     name,
+    cachedAt: new Date(FIXED_NOW_ISO),
+  });
+}
+
+async function seedCachedOrgMember(
+  orgId: string,
+  userId: string,
+): Promise<void> {
+  const db = store.set(writeDb$);
+  await db.insert(orgMembersCache).values({
+    orgId,
+    userId,
+    role: "member",
     cachedAt: new Date(FIXED_NOW_ISO),
   });
 }
@@ -358,6 +370,59 @@ describe("GET /api/cron/aggregate-insights", () => {
       agentNames: ["Other usage"],
       agentCredits: { "Other usage": 333 },
     });
+  });
+
+  it("excludes removed org members from team credit usage", async () => {
+    const fixture = await track(
+      store.set(seedUsageFixture$, {}, context.signal),
+    );
+    const removedUserId = `user_${randomUUID()}`;
+    await seedCachedOrgMember(fixture.orgId, fixture.userId);
+    await seedUserName(fixture, "active@example.com", "Active Member");
+    await seedUserName(
+      { userId: removedUserId },
+      "removed@example.com",
+      "Removed Member",
+    );
+    const processedAt = new Date("2999-01-02T11:55:00.000Z");
+    await store.set(
+      insertUsageEvent$,
+      {
+        orgId: fixture.orgId,
+        userId: fixture.userId,
+        runId: null,
+        creditsCharged: 200,
+        status: "processed",
+        processedAt,
+      },
+      context.signal,
+    );
+    await store.set(
+      insertUsageEvent$,
+      {
+        orgId: fixture.orgId,
+        userId: removedUserId,
+        runId: null,
+        creditsCharged: 900,
+        status: "processed",
+        processedAt,
+      },
+      context.signal,
+    );
+
+    await accept(apiClient().aggregate({ headers: cronHeaders() }), [200]);
+
+    const data = await findInsights(fixture);
+    expect(data?.creditsUsed).toBe(200);
+    expect(data?.teamUsage).toStrictEqual([
+      {
+        userId: fixture.userId,
+        name: "Active Member",
+        credits: 200,
+        agentNames: ["Other usage"],
+        agentCredits: { "Other usage": 200 },
+      },
+    ]);
   });
 
   it("reprocesses activity at the previous aggregation watermark", async () => {

--- a/turbo/apps/api/src/signals/routes/__tests__/cron-aggregate-insights.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/cron-aggregate-insights.test.ts
@@ -121,6 +121,29 @@ async function seedCachedOrgMember(
   });
 }
 
+function mockCurrentOrgMembers(
+  orgId: string,
+  userIds: readonly string[],
+): void {
+  context.mocks.clerk.organizations.getOrganizationMembershipList.mockImplementation(
+    (args: unknown) => {
+      const input = args as {
+        readonly organizationId?: string;
+        readonly limit?: number;
+        readonly offset?: number;
+      };
+      const members = input.organizationId === orgId ? userIds : [];
+      const offset = input.offset ?? 0;
+      const limit = input.limit ?? members.length;
+      return Promise.resolve({
+        data: members.slice(offset, offset + limit).map((userId) => {
+          return { publicUserData: { userId } };
+        }),
+      });
+    },
+  );
+}
+
 async function seedExistingInsights(
   fixture: UsageFixture,
   updatedAt: Date,
@@ -377,7 +400,9 @@ describe("GET /api/cron/aggregate-insights", () => {
       store.set(seedUsageFixture$, {}, context.signal),
     );
     const removedUserId = `user_${randomUUID()}`;
-    await seedCachedOrgMember(fixture.orgId, fixture.userId);
+    const cachedOtherUserId = `user_${randomUUID()}`;
+    await seedCachedOrgMember(fixture.orgId, cachedOtherUserId);
+    mockCurrentOrgMembers(fixture.orgId, [fixture.userId, cachedOtherUserId]);
     await seedUserName(fixture, "active@example.com", "Active Member");
     await seedUserName(
       { userId: removedUserId },

--- a/turbo/apps/api/src/signals/routes/__tests__/helpers/zero-insights.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/helpers/zero-insights.ts
@@ -2,6 +2,7 @@ import { randomUUID } from "node:crypto";
 
 import { command } from "ccstate";
 import { insightsDaily } from "@vm0/db/schema/insights-daily";
+import { orgMembersCache } from "@vm0/db/schema/org-members-cache";
 import { and, eq } from "drizzle-orm";
 
 import { writeDb$ } from "../../../external/db";
@@ -35,6 +36,10 @@ export const deleteInsightsForFixture$ = command(
           eq(insightsDaily.userId, fixture.userId),
         ),
       );
+    signal.throwIfAborted();
+    await db
+      .delete(orgMembersCache)
+      .where(eq(orgMembersCache.orgId, fixture.orgId));
     signal.throwIfAborted();
   },
 );

--- a/turbo/apps/api/src/signals/routes/__tests__/zero-insights.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/zero-insights.test.ts
@@ -4,10 +4,12 @@ import {
   zeroInsightsContract,
   zeroInsightsRangeContract,
 } from "@vm0/api-contracts/contracts/zero-insights";
+import { orgMembersCache } from "@vm0/db/schema/org-members-cache";
 import { createStore } from "ccstate";
 
 import { accept, setupApp, testContext } from "../../../__tests__/test-helpers";
 import { nowDate } from "../../../lib/time";
+import { writeDb$ } from "../../external/db";
 import {
   deleteInsightsForFixture$,
   seedInsightsDaily$,
@@ -70,6 +72,19 @@ function defaultInsightData(
     ],
     ...overrides,
   };
+}
+
+async function seedCachedOrgMember(
+  orgId: string,
+  userId: string,
+): Promise<void> {
+  const writeDb = store.set(writeDb$);
+  await writeDb.insert(orgMembersCache).values({
+    orgId,
+    userId,
+    role: "member",
+    cachedAt: nowDate(),
+  });
 }
 
 describe("GET /api/zero/insights", () => {
@@ -151,6 +166,60 @@ describe("GET /api/zero/insights", () => {
     expect(
       Number.isNaN(new Date(response.body.lastUpdated ?? "").getTime()),
     ).toBeFalsy();
+  });
+
+  it("filters stale team usage entries for users no longer in the org", async () => {
+    const fixture = await track(
+      store.set(seedInsightsFixture$, undefined, context.signal),
+    );
+    const removedUserId = `user_${randomUUID()}`;
+    const yesterday = daysAgo(1);
+    await seedCachedOrgMember(fixture.orgId, fixture.userId);
+    await store.set(
+      seedInsightsDaily$,
+      {
+        orgId: fixture.orgId,
+        userId: fixture.userId,
+        date: yesterday,
+        data: defaultInsightData({
+          creditsUsed: 1000,
+          teamUsage: [
+            {
+              userId: fixture.userId,
+              name: "active",
+              credits: 100,
+              agentNames: ["Test Agent"],
+              agentCredits: { "Test Agent": 100 },
+            },
+            {
+              userId: removedUserId,
+              name: "removed",
+              credits: 900,
+              agentNames: ["Old Agent"],
+              agentCredits: { "Old Agent": 900 },
+            },
+          ],
+        }),
+      },
+      context.signal,
+    );
+    mocks.clerk.session(fixture.userId, fixture.orgId);
+
+    const response = await accept(
+      apiClient().get({ query: {}, headers: authHeaders() }),
+      [200],
+    );
+
+    const day = response.body.days[0];
+    expect(day?.creditsUsed).toBe(100);
+    expect(day?.teamUsage).toHaveLength(1);
+    expect(day?.teamUsage[0]).toMatchObject({
+      name: "active",
+      credits: 100,
+      agentNames: ["Test Agent"],
+      agentCredits: { "Test Agent": 100 },
+    });
+    expect(response.body.totalCredits).toBe(100);
   });
 
   it("normalizes sparse insight rows to the full day shape", async () => {

--- a/turbo/apps/api/src/signals/routes/__tests__/zero-insights.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/zero-insights.test.ts
@@ -87,6 +87,29 @@ async function seedCachedOrgMember(
   });
 }
 
+function mockCurrentOrgMembers(
+  orgId: string,
+  userIds: readonly string[],
+): void {
+  context.mocks.clerk.organizations.getOrganizationMembershipList.mockImplementation(
+    (args: unknown) => {
+      const input = args as {
+        readonly organizationId?: string;
+        readonly limit?: number;
+        readonly offset?: number;
+      };
+      const members = input.organizationId === orgId ? userIds : [];
+      const offset = input.offset ?? 0;
+      const limit = input.limit ?? members.length;
+      return Promise.resolve({
+        data: members.slice(offset, offset + limit).map((userId) => {
+          return { publicUserData: { userId } };
+        }),
+      });
+    },
+  );
+}
+
 describe("GET /api/zero/insights", () => {
   const track = createFixtureTracker<InsightsFixture>((fixture) => {
     return store.set(deleteInsightsForFixture$, fixture, context.signal);
@@ -173,8 +196,10 @@ describe("GET /api/zero/insights", () => {
       store.set(seedInsightsFixture$, undefined, context.signal),
     );
     const removedUserId = `user_${randomUUID()}`;
+    const cachedOtherUserId = `user_${randomUUID()}`;
     const yesterday = daysAgo(1);
-    await seedCachedOrgMember(fixture.orgId, fixture.userId);
+    await seedCachedOrgMember(fixture.orgId, cachedOtherUserId);
+    mockCurrentOrgMembers(fixture.orgId, [fixture.userId, cachedOtherUserId]);
     await store.set(
       seedInsightsDaily$,
       {

--- a/turbo/apps/api/src/signals/services/cron-aggregate-insights.service.ts
+++ b/turbo/apps/api/src/signals/services/cron-aggregate-insights.service.ts
@@ -25,6 +25,7 @@ const L = logger("CronAggregateInsights");
 const OTHER_USAGE_AGENT_NAME = "Other usage";
 const NETWORK_RUN_ATTRIBUTION_BATCH_SIZE = 10_000;
 const AGGREGATION_REPROCESS_OVERLAP_MS = 5 * 60_000;
+const ORG_MEMBERSHIP_PAGE_SIZE = 100;
 
 interface AgentInfo {
   readonly agentId: string | null;
@@ -148,7 +149,7 @@ interface WindowScope {
   readonly users: OrgUserPair[];
   readonly orgIds: string[];
   readonly userIds: string[];
-  readonly cachedOrgMembers: CachedOrgMemberScope;
+  readonly currentOrgMembers: CurrentOrgMemberScope;
 }
 
 interface ClerkUserListUser {
@@ -162,12 +163,25 @@ interface ClerkUserListUser {
   readonly username: string | null;
 }
 
+interface ClerkOrganizationMembership {
+  readonly publicUserData?: {
+    readonly userId?: string | null;
+  } | null;
+}
+
 interface ClerkLike {
   readonly users: {
     readonly getUserList: (args: {
       readonly userId: string[];
       readonly limit: number;
     }) => Promise<{ readonly data: readonly ClerkUserListUser[] }>;
+  };
+  readonly organizations: {
+    readonly getOrganizationMembershipList: (args: {
+      readonly organizationId: string;
+      readonly limit: number;
+      readonly offset: number;
+    }) => Promise<{ readonly data: readonly ClerkOrganizationMembership[] }>;
   };
 }
 
@@ -208,8 +222,8 @@ interface NetworkQueryResult {
   readonly axiomDegraded: boolean;
 }
 
-interface CachedOrgMemberScope {
-  readonly orgsWithCachedMembers: Set<string>;
+interface CurrentOrgMemberScope {
+  readonly orgsWithCurrentMembers: Set<string>;
   readonly memberKeys: Set<string>;
 }
 
@@ -507,46 +521,111 @@ function orgUserKey(args: OrgUserPair): string {
   return `${args.orgId}:${args.userId}`;
 }
 
-function isCachedOrgMember(
-  scope: CachedOrgMemberScope,
+function isCurrentOrgMember(
+  scope: CurrentOrgMemberScope,
   args: OrgUserPair,
 ): boolean {
   return (
-    !scope.orgsWithCachedMembers.has(args.orgId) ||
+    !scope.orgsWithCurrentMembers.has(args.orgId) ||
     scope.memberKeys.has(orgUserKey(args))
   );
 }
 
-async function queryCachedOrgMembers(
+async function queryCachedOrgIdsWithMembers(
   db: Db,
   orgIds: string[],
   signal: AbortSignal,
-): Promise<CachedOrgMemberScope> {
+): Promise<Set<string>> {
   if (orgIds.length === 0) {
-    return { orgsWithCachedMembers: new Set(), memberKeys: new Set() };
+    return new Set();
   }
 
   const rows = await db
     .select({
       orgId: orgMembersCache.orgId,
-      userId: orgMembersCache.userId,
     })
     .from(orgMembersCache)
     .where(inArray(orgMembersCache.orgId, orgIds));
   signal.throwIfAborted();
 
-  return {
-    orgsWithCachedMembers: new Set(
-      rows.map((row) => {
-        return row.orgId;
+  return new Set(
+    rows.map((row) => {
+      return row.orgId;
+    }),
+  );
+}
+
+async function queryClerkOrgMemberUserIds(
+  clerk: ClerkLike,
+  orgId: string,
+  signal: AbortSignal,
+): Promise<string[] | null> {
+  const userIds: string[] = [];
+  for (let offset = 0; ; offset += ORG_MEMBERSHIP_PAGE_SIZE) {
+    const result = await settle(
+      clerk.organizations.getOrganizationMembershipList({
+        organizationId: orgId,
+        limit: ORG_MEMBERSHIP_PAGE_SIZE,
+        offset,
       }),
-    ),
-    memberKeys: new Set(
-      rows.map((row) => {
-        return orgUserKey(row);
-      }),
-    ),
-  };
+    );
+    signal.throwIfAborted();
+
+    if (!result.ok) {
+      L.warn("Failed to query Clerk organization memberships", {
+        orgId,
+        error:
+          result.error instanceof Error
+            ? result.error.message
+            : String(result.error),
+      });
+      return null;
+    }
+
+    for (const membership of result.value.data) {
+      const userId = membership.publicUserData?.userId;
+      if (userId) {
+        userIds.push(userId);
+      }
+    }
+
+    if (result.value.data.length < ORG_MEMBERSHIP_PAGE_SIZE) {
+      return userIds;
+    }
+  }
+}
+
+async function queryCurrentOrgMembers(
+  db: Db,
+  clerk: ClerkLike,
+  orgIds: string[],
+  signal: AbortSignal,
+): Promise<CurrentOrgMemberScope> {
+  const orgIdsWithCache = await queryCachedOrgIdsWithMembers(
+    db,
+    orgIds,
+    signal,
+  );
+  const orgsWithCurrentMembers = new Set<string>();
+  const memberKeys = new Set<string>();
+
+  for (const orgId of orgIdsWithCache) {
+    const memberUserIds = await queryClerkOrgMemberUserIds(
+      clerk,
+      orgId,
+      signal,
+    );
+    if (!memberUserIds) {
+      continue;
+    }
+
+    orgsWithCurrentMembers.add(orgId);
+    for (const userId of memberUserIds) {
+      memberKeys.add(orgUserKey({ orgId, userId }));
+    }
+  }
+
+  return { orgsWithCurrentMembers, memberKeys };
 }
 
 function mergeActiveUserRows(rows: ActiveUserRow[]): ActiveUserRow[] {
@@ -820,7 +899,7 @@ async function queryNetworkRunAgentRows(
 
 function windowScope(
   group: WindowGroup,
-  cachedOrgMembers: CachedOrgMemberScope,
+  currentOrgMembers: CurrentOrgMemberScope,
 ): WindowScope {
   const { dayStart, dayEnd, users } = group;
   return {
@@ -841,7 +920,7 @@ function windowScope(
         }),
       ),
     ],
-    cachedOrgMembers,
+    currentOrgMembers,
   };
 }
 
@@ -864,7 +943,7 @@ async function loadWindowUsageData(
   signal.throwIfAborted();
 
   const currentMemberCreditRows = ledgerCreditRows.filter((row) => {
-    return isCachedOrgMember(scope.cachedOrgMembers, row);
+    return isCurrentOrgMember(scope.currentOrgMembers, row);
   });
   const userAgentMap = mergeAgentRows(
     runRows,
@@ -1031,7 +1110,7 @@ function processWindowGroup(
   db: Db,
   clerk: ClerkLike,
   group: WindowGroup,
-  cachedOrgMembers: CachedOrgMemberScope,
+  currentOrgMembers: CurrentOrgMemberScope,
   signal: AbortSignal,
 ): Computed<
   Promise<{ readonly upserted: number; readonly networkRows: number }>
@@ -1040,7 +1119,7 @@ function processWindowGroup(
     async (
       get,
     ): Promise<{ readonly upserted: number; readonly networkRows: number }> => {
-      const scope = windowScope(group, cachedOrgMembers);
+      const scope = windowScope(group, currentOrgMembers);
       const usageData = await loadWindowUsageData(db, clerk, scope, signal);
       const networkData = await get(queryWindowNetworkData(db, scope, signal));
       const upserted = await upsertWindowInsights(
@@ -1085,8 +1164,9 @@ export const aggregateInsights$ = command(
         }),
       ),
     ];
-    const cachedOrgMembers = await queryCachedOrgMembers(
+    const currentOrgMembers = await queryCurrentOrgMembers(
       db,
+      clerk,
       activeOrgIds,
       signal,
     );
@@ -1156,7 +1236,7 @@ export const aggregateInsights$ = command(
     let totalNetworkRows = 0;
     for (const group of windowGroups.values()) {
       const result = await get(
-        processWindowGroup(db, clerk, group, cachedOrgMembers, signal),
+        processWindowGroup(db, clerk, group, currentOrgMembers, signal),
       );
       signal.throwIfAborted();
       upserted += result.upserted;

--- a/turbo/apps/api/src/signals/services/cron-aggregate-insights.service.ts
+++ b/turbo/apps/api/src/signals/services/cron-aggregate-insights.service.ts
@@ -5,6 +5,7 @@ import {
 import { agentComposeVersions } from "@vm0/db/schema/agent-compose";
 import { agentRuns } from "@vm0/db/schema/agent-run";
 import { insightsDaily } from "@vm0/db/schema/insights-daily";
+import { orgMembersCache } from "@vm0/db/schema/org-members-cache";
 import { orgMetadata } from "@vm0/db/schema/org-metadata";
 import { usageEvent } from "@vm0/db/schema/usage-event";
 import { userCache } from "@vm0/db/schema/user-cache";
@@ -147,6 +148,7 @@ interface WindowScope {
   readonly users: OrgUserPair[];
   readonly orgIds: string[];
   readonly userIds: string[];
+  readonly cachedOrgMembers: CachedOrgMemberScope;
 }
 
 interface ClerkUserListUser {
@@ -204,6 +206,11 @@ interface NetworkQueryResult {
   readonly userNetworkMap: Map<string, UserNetworkData>;
   readonly networkRows: number;
   readonly axiomDegraded: boolean;
+}
+
+interface CachedOrgMemberScope {
+  readonly orgsWithCachedMembers: Set<string>;
+  readonly memberKeys: Set<string>;
 }
 
 function normalizeDbDate(value: Date | string): Date {
@@ -496,6 +503,52 @@ function aggregateOrgCredits(
   return orgCreditsMap;
 }
 
+function orgUserKey(args: OrgUserPair): string {
+  return `${args.orgId}:${args.userId}`;
+}
+
+function isCachedOrgMember(
+  scope: CachedOrgMemberScope,
+  args: OrgUserPair,
+): boolean {
+  return (
+    !scope.orgsWithCachedMembers.has(args.orgId) ||
+    scope.memberKeys.has(orgUserKey(args))
+  );
+}
+
+async function queryCachedOrgMembers(
+  db: Db,
+  orgIds: string[],
+  signal: AbortSignal,
+): Promise<CachedOrgMemberScope> {
+  if (orgIds.length === 0) {
+    return { orgsWithCachedMembers: new Set(), memberKeys: new Set() };
+  }
+
+  const rows = await db
+    .select({
+      orgId: orgMembersCache.orgId,
+      userId: orgMembersCache.userId,
+    })
+    .from(orgMembersCache)
+    .where(inArray(orgMembersCache.orgId, orgIds));
+  signal.throwIfAborted();
+
+  return {
+    orgsWithCachedMembers: new Set(
+      rows.map((row) => {
+        return row.orgId;
+      }),
+    ),
+    memberKeys: new Set(
+      rows.map((row) => {
+        return orgUserKey(row);
+      }),
+    ),
+  };
+}
+
 function mergeActiveUserRows(rows: ActiveUserRow[]): ActiveUserRow[] {
   const byUser = new Map<string, ActiveUserRow>();
   for (const row of rows) {
@@ -765,7 +818,10 @@ async function queryNetworkRunAgentRows(
   return rows;
 }
 
-function windowScope(group: WindowGroup): WindowScope {
+function windowScope(
+  group: WindowGroup,
+  cachedOrgMembers: CachedOrgMemberScope,
+): WindowScope {
   const { dayStart, dayEnd, users } = group;
   return {
     dayStart,
@@ -785,6 +841,7 @@ function windowScope(group: WindowGroup): WindowScope {
         }),
       ),
     ],
+    cachedOrgMembers,
   };
 }
 
@@ -806,10 +863,17 @@ async function loadWindowUsageData(
   ]);
   signal.throwIfAborted();
 
-  const userAgentMap = mergeAgentRows(runRows, ledgerCreditRows, scope.users);
+  const currentMemberCreditRows = ledgerCreditRows.filter((row) => {
+    return isCachedOrgMember(scope.cachedOrgMembers, row);
+  });
+  const userAgentMap = mergeAgentRows(
+    runRows,
+    currentMemberCreditRows,
+    scope.users,
+  );
   const allCreditUserIds = [
     ...new Set(
-      ledgerCreditRows.map((row) => {
+      currentMemberCreditRows.map((row) => {
         return row.userId;
       }),
     ),
@@ -820,7 +884,10 @@ async function loadWindowUsageData(
     allCreditUserIds,
     signal,
   );
-  const orgCreditsMap = aggregateOrgCredits(ledgerCreditRows, userNameMap);
+  const orgCreditsMap = aggregateOrgCredits(
+    currentMemberCreditRows,
+    userNameMap,
+  );
 
   const balanceRows =
     scope.orgIds.length > 0
@@ -964,6 +1031,7 @@ function processWindowGroup(
   db: Db,
   clerk: ClerkLike,
   group: WindowGroup,
+  cachedOrgMembers: CachedOrgMemberScope,
   signal: AbortSignal,
 ): Computed<
   Promise<{ readonly upserted: number; readonly networkRows: number }>
@@ -972,7 +1040,7 @@ function processWindowGroup(
     async (
       get,
     ): Promise<{ readonly upserted: number; readonly networkRows: number }> => {
-      const scope = windowScope(group);
+      const scope = windowScope(group, cachedOrgMembers);
       const usageData = await loadWindowUsageData(db, clerk, scope, signal);
       const networkData = await get(queryWindowNetworkData(db, scope, signal));
       const upserted = await upsertWindowInsights(
@@ -1017,6 +1085,11 @@ export const aggregateInsights$ = command(
         }),
       ),
     ];
+    const cachedOrgMembers = await queryCachedOrgMembers(
+      db,
+      activeOrgIds,
+      signal,
+    );
 
     const lastAggRows = await db
       .select({
@@ -1082,7 +1155,9 @@ export const aggregateInsights$ = command(
     let upserted = 0;
     let totalNetworkRows = 0;
     for (const group of windowGroups.values()) {
-      const result = await get(processWindowGroup(db, clerk, group, signal));
+      const result = await get(
+        processWindowGroup(db, clerk, group, cachedOrgMembers, signal),
+      );
       signal.throwIfAborted();
       upserted += result.upserted;
       totalNetworkRows += result.networkRows;

--- a/turbo/apps/api/src/signals/services/zero-insights.service.ts
+++ b/turbo/apps/api/src/signals/services/zero-insights.service.ts
@@ -9,9 +9,12 @@ import { orgMembersCache } from "@vm0/db/schema/org-members-cache";
 import { and, desc, eq, gte, sql } from "drizzle-orm";
 
 import { nowDate } from "../../lib/time";
+import { clerk$ } from "../external/clerk";
 import { db$ } from "../external/db";
+import { settle } from "../utils";
 
 type DayInsightData = Partial<Omit<DayInsight, "date">>;
+const ORG_MEMBERSHIP_PAGE_SIZE = 100;
 
 interface StoredTeamUsageEntry {
   readonly userId?: string;
@@ -24,6 +27,20 @@ interface StoredTeamUsageEntry {
 type StoredDayInsightData = DayInsightData & {
   readonly teamUsage?: readonly StoredTeamUsageEntry[];
 };
+
+interface ClerkOrganizationMembership {
+  readonly publicUserData?: {
+    readonly userId?: string | null;
+  } | null;
+}
+
+interface ClerkOrganizationsLike {
+  readonly getOrganizationMembershipList: (args: {
+    readonly organizationId: string;
+    readonly limit: number;
+    readonly offset: number;
+  }) => Promise<{ readonly data: readonly ClerkOrganizationMembership[] }>;
+}
 
 function normalizeDays(days: number | undefined): number {
   return Math.min(Math.max(days ?? 30, 1), 90);
@@ -49,6 +66,36 @@ function filterTeamUsageByCurrentMembers(
   });
 }
 
+async function queryCurrentOrgMemberUserIds(
+  organizations: ClerkOrganizationsLike,
+  orgId: string,
+): Promise<Set<string> | null> {
+  const userIds = new Set<string>();
+  for (let offset = 0; ; offset += ORG_MEMBERSHIP_PAGE_SIZE) {
+    const result = await settle(
+      organizations.getOrganizationMembershipList({
+        organizationId: orgId,
+        limit: ORG_MEMBERSHIP_PAGE_SIZE,
+        offset,
+      }),
+    );
+    if (!result.ok) {
+      return null;
+    }
+
+    for (const membership of result.value.data) {
+      const userId = membership.publicUserData?.userId;
+      if (userId) {
+        userIds.add(userId);
+      }
+    }
+
+    if (result.value.data.length < ORG_MEMBERSHIP_PAGE_SIZE) {
+      return userIds;
+    }
+  }
+}
+
 export function zeroInsights(args: {
   readonly orgId: string;
   readonly userId: string;
@@ -62,10 +109,9 @@ export function zeroInsights(args: {
       .where(eq(orgMembersCache.orgId, args.orgId));
     const currentMemberUserIds =
       memberRows.length > 0
-        ? new Set(
-            memberRows.map((row) => {
-              return row.userId;
-            }),
+        ? await queryCurrentOrgMemberUserIds(
+            get(clerk$).organizations,
+            args.orgId,
           )
         : null;
 

--- a/turbo/apps/api/src/signals/services/zero-insights.service.ts
+++ b/turbo/apps/api/src/signals/services/zero-insights.service.ts
@@ -5,12 +5,25 @@ import type {
   InsightsResponse,
 } from "@vm0/api-contracts/contracts/zero-insights";
 import { insightsDaily } from "@vm0/db/schema/insights-daily";
+import { orgMembersCache } from "@vm0/db/schema/org-members-cache";
 import { and, desc, eq, gte, sql } from "drizzle-orm";
 
 import { nowDate } from "../../lib/time";
 import { db$ } from "../external/db";
 
 type DayInsightData = Partial<Omit<DayInsight, "date">>;
+
+interface StoredTeamUsageEntry {
+  readonly userId?: string;
+  readonly name: string;
+  readonly credits: number;
+  readonly agentNames?: string[];
+  readonly agentCredits?: Record<string, number>;
+}
+
+type StoredDayInsightData = DayInsightData & {
+  readonly teamUsage?: readonly StoredTeamUsageEntry[];
+};
 
 function normalizeDays(days: number | undefined): number {
   return Math.min(Math.max(days ?? 30, 1), 90);
@@ -23,13 +36,40 @@ function cutoffDateIso(days: number): string {
   return cutoff.toISOString().split("T")[0]!;
 }
 
+function filterTeamUsageByCurrentMembers(
+  teamUsage: readonly StoredTeamUsageEntry[],
+  currentMemberUserIds: Set<string> | null,
+): StoredTeamUsageEntry[] {
+  if (!currentMemberUserIds) {
+    return [...teamUsage];
+  }
+
+  return teamUsage.filter((member) => {
+    return !member.userId || currentMemberUserIds.has(member.userId);
+  });
+}
+
 export function zeroInsights(args: {
   readonly orgId: string;
   readonly userId: string;
   readonly days: number | undefined;
 }): Computed<Promise<InsightsResponse>> {
   return computed(async (get): Promise<InsightsResponse> => {
-    const rows = await get(db$)
+    const db = get(db$);
+    const memberRows = await db
+      .select({ userId: orgMembersCache.userId })
+      .from(orgMembersCache)
+      .where(eq(orgMembersCache.orgId, args.orgId));
+    const currentMemberUserIds =
+      memberRows.length > 0
+        ? new Set(
+            memberRows.map((row) => {
+              return row.userId;
+            }),
+          )
+        : null;
+
+    const rows = await db
       .select({
         date: insightsDaily.date,
         data: insightsDaily.data,
@@ -49,13 +89,23 @@ export function zeroInsights(args: {
       .orderBy(desc(insightsDaily.date));
 
     const days = rows.map((row): DayInsight => {
-      const data = row.data as DayInsightData;
+      const data = row.data as StoredDayInsightData;
+      const teamUsage = filterTeamUsageByCurrentMembers(
+        data.teamUsage ?? [],
+        currentMemberUserIds,
+      );
+      const creditsUsed =
+        currentMemberUserIds && data.teamUsage
+          ? teamUsage.reduce((sum, member) => {
+              return sum + member.credits;
+            }, 0)
+          : (data.creditsUsed ?? 0);
       return {
         date: row.date,
         agents: data.agents ?? [],
-        creditsUsed: data.creditsUsed ?? 0,
+        creditsUsed,
         creditBalance: data.creditBalance ?? 0,
-        teamUsage: data.teamUsage ?? [],
+        teamUsage,
         topTask: data.topTask ?? null,
         services: data.services ?? [],
         permissions: data.permissions ?? [],


### PR DESCRIPTION
## Summary
- filter org-wide insights team usage to cached current org members when member cache exists
- apply the same filtering on the insights read path so existing snapshots stop showing removed members
- cover cron aggregation and stale snapshot reads with API tests

## Tests
- pnpm -F api exec vitest src/signals/routes/__tests__/cron-aggregate-insights.test.ts
- pnpm -F api exec vitest src/signals/routes/__tests__/zero-insights.test.ts
- pnpm -F api lint
- pnpm -F api check-types
- pnpm exec prettier --check apps/api/src/signals/services/cron-aggregate-insights.service.ts apps/api/src/signals/services/zero-insights.service.ts apps/api/src/signals/routes/__tests__/cron-aggregate-insights.test.ts apps/api/src/signals/routes/__tests__/zero-insights.test.ts apps/api/src/signals/routes/__tests__/helpers/zero-insights.ts
- git diff --check

Note: pre-commit also ran full pnpm check-types after syncing dependencies with pnpm install.