### PR TITLE
fix: focus website artifact previews

### DIFF
--- a/turbo/apps/platform/src/views/zero-page/__tests__/zero-artifact-sidebar.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/zero-artifact-sidebar.test.tsx
@@ -9,7 +9,13 @@
  */
 
 import { describe, expect, it } from "vitest";
-import { fireEvent, render, screen, within } from "@testing-library/react";
+import {
+  fireEvent,
+  render,
+  screen,
+  waitFor,
+  within,
+} from "@testing-library/react";
 import { StoreProvider } from "ccstate-react";
 import { FeatureSwitchKey } from "@vm0/connectors/feature-switch-key";
 import { testContext } from "../../../signals/__tests__/test-helpers.ts";
@@ -19,8 +25,10 @@ import { setPageSignal$ } from "../../../signals/page-signal.ts";
 import {
   closeLightbox$,
   lightboxUrl$,
+  openDocumentLightbox$,
 } from "../../../signals/zero-page/zero-attachment-chips.ts";
 import { AttachmentPreview } from "../zero-attachment-preview.tsx";
+import { AttachmentLightbox } from "../zero-attachment-chips.tsx";
 import {
   ArtifactSidebarSlot,
   ArtifactSidebar,
@@ -265,6 +273,69 @@ describe("chatArtifactSidebar: fullscreen toggle", () => {
     fireEvent.click(screen.getByTestId("artifact-sidebar-fullscreen-toggle"));
     expect(context.store.get(artifactFullscreen$)).toBeFalsy();
     expect(search()).not.toContain("artifact-fullscreen=");
+  });
+
+  it("focuses website artifacts after entering fullscreen", async () => {
+    const url = "about:blank";
+    setup(`/chats/thread-1?artifact=${encodeURIComponent(url)}`);
+    renderWithStore(
+      <ArtifactSidebar
+        artifactRef={{
+          source: "url",
+          url,
+          kind: "html",
+          filename: "demo-site",
+        }}
+      />,
+    );
+
+    fireEvent.click(screen.getByTestId("artifact-sidebar-fullscreen-toggle"));
+
+    await waitFor(() => {
+      expect(screen.getByTestId("artifact-sidebar-body-html")).toHaveFocus();
+    });
+  });
+
+  it("focuses website artifacts when opened directly in fullscreen", async () => {
+    const url = "about:blank";
+    setup(
+      `/chats/thread-1?artifact=${encodeURIComponent(url)}&artifact-fullscreen=1`,
+    );
+    renderWithStore(
+      <ArtifactSidebar
+        artifactRef={{
+          source: "url",
+          url,
+          kind: "html",
+          filename: "demo-site",
+        }}
+      />,
+    );
+
+    await waitFor(() => {
+      expect(screen.getByTestId("artifact-sidebar-body-html")).toHaveFocus();
+    });
+  });
+
+  it("focuses website artifacts in the chat artifact dialog", async () => {
+    const url = "about:blank";
+    setup();
+    context.store.set(openDocumentLightbox$, {
+      kind: "html",
+      filename: "demo-site",
+      url,
+    });
+    renderWithStore(<AttachmentLightbox />);
+
+    await waitFor(() => {
+      expect(screen.getByTestId("artifact-dialog-body-html")).toHaveFocus();
+    });
+
+    fireEvent.click(screen.getByLabelText("Enter fullscreen"));
+
+    await waitFor(() => {
+      expect(screen.getByTestId("artifact-dialog-body-html")).toHaveFocus();
+    });
   });
 });
 

--- a/turbo/apps/platform/src/views/zero-page/auto-focused-artifact-iframe.tsx
+++ b/turbo/apps/platform/src/views/zero-page/auto-focused-artifact-iframe.tsx
@@ -1,0 +1,58 @@
+import type { ComponentPropsWithoutRef, ReactEventHandler } from "react";
+
+type AutoFocusedArtifactIframeProps = Omit<
+  ComponentPropsWithoutRef<"iframe">,
+  "ref"
+> & {
+  focusKey: string;
+  focusOnMount: boolean;
+};
+
+export function AutoFocusedArtifactIframe({
+  focusKey,
+  focusOnMount,
+  onLoad,
+  tabIndex,
+  ...props
+}: AutoFocusedArtifactIframeProps) {
+  const handleLoad: ReactEventHandler<HTMLIFrameElement> = (event) => {
+    onLoad?.(event);
+    scheduleIframeFocus(event.currentTarget, focusKey, focusOnMount, "load");
+  };
+
+  return (
+    <iframe
+      {...props}
+      ref={(element) => {
+        scheduleIframeFocus(element, focusKey, focusOnMount, "mount");
+      }}
+      onLoad={handleLoad}
+      tabIndex={focusOnMount && tabIndex === undefined ? -1 : tabIndex}
+    />
+  );
+}
+
+function scheduleIframeFocus(
+  element: HTMLIFrameElement | null,
+  focusKey: string,
+  focusOnMount: boolean,
+  phase: "load" | "mount",
+) {
+  if (!element || !focusOnMount) {
+    return;
+  }
+  const datasetKey =
+    phase === "load"
+      ? "artifactIframeLoadFocusKey"
+      : "artifactIframeMountFocusKey";
+  if (element.dataset[datasetKey] === focusKey) {
+    return;
+  }
+
+  element.dataset[datasetKey] = focusKey;
+  window.requestAnimationFrame(() => {
+    if (element.isConnected && element.dataset[datasetKey] === focusKey) {
+      element.focus({ preventScroll: true });
+    }
+  });
+}

--- a/turbo/apps/platform/src/views/zero-page/zero-artifact-sidebar.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-artifact-sidebar.tsx
@@ -58,6 +58,7 @@ import {
   artifactFallbackSubtitle,
   artifactTitleSubtitle,
 } from "./zero-artifact-display.ts";
+import { AutoFocusedArtifactIframe } from "./auto-focused-artifact-iframe.tsx";
 
 // ---------------------------------------------------------------------------
 // ArtifactSidebar — page-level pane for previewing the artifact pointed to
@@ -932,9 +933,12 @@ function ArtifactIframeBody({
   // (thumbnails / bookmarks) so the embedded preview shows just the page
   // and toolbar by default. Firefox/PDF.js silently ignores it.
   const src = kind === "pdf" ? `${url}#navpanes=0` : url;
+  const fullscreen = useGet(artifactFullscreen$);
   if (kind === "html") {
     return (
-      <iframe
+      <AutoFocusedArtifactIframe
+        focusKey={`${src}:${fullscreen ? "fullscreen" : "sidebar"}`}
+        focusOnMount={fullscreen}
         src={src}
         title={`${filename} preview`}
         sandbox="allow-scripts"

--- a/turbo/apps/platform/src/views/zero-page/zero-attachment-chips.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-attachment-chips.tsx
@@ -88,6 +88,7 @@ import {
   type ZoomableImageControls,
   zoomableArtifactImageKey,
 } from "./zero-zoomable-image-canvas.tsx";
+import { AutoFocusedArtifactIframe } from "./auto-focused-artifact-iframe.tsx";
 
 export {
   downloadAttachmentUrl,
@@ -1084,12 +1085,15 @@ function ArtifactDialogBody({
         className="h-full w-full bg-background"
         data-testid="artifact-dialog-site-frame"
       >
-        <iframe
+        <AutoFocusedArtifactIframe
+          focusKey={`${preview.url}:${fullscreen ? "fullscreen" : "dialog"}`}
+          focusOnMount
           src={preview.url}
           title={`${filename} preview`}
           sandbox="allow-scripts"
           scrolling="yes"
           className="block h-full w-full border-0 bg-background"
+          data-testid="artifact-dialog-body-html"
         />
       </div>
     );


### PR DESCRIPTION
## Summary
- add a focused iframe wrapper for website artifact previews
- focus website iframes when the chat artifact dialog opens or toggles fullscreen
- focus website iframes when the artifact sidebar enters fullscreen, including direct fullscreen URLs
- add regression coverage for dialog and fullscreen focus behavior

## Test plan
- pnpm format
- pnpm turbo run lint
- pnpm check-types
- pnpm knip
- pnpm -F @vm0/app lint
- pnpm -F @vm0/app check-types
- pnpm -F @vm0/app exec vitest src/views/zero-page/__tests__/zero-artifact-sidebar.test.tsx

## Notes
- Attempted `pnpm vitest`; it failed outside this frontend change with local environment/fixture issues: desktop native CLI tests require macOS accessibility support in this Linux container, and API GitHub/storage fixture tests hit duplicate fixed IDs in the shared local DB.