### PR TITLE
fix: preserve sandbox operation timestamps

### DIFF
--- a/turbo/apps/api/src/signals/external/sandbox-op-log.ts
+++ b/turbo/apps/api/src/signals/external/sandbox-op-log.ts
@@ -20,6 +20,7 @@ interface SandboxOperationAttrs {
   readonly durationMs: number;
   readonly success: boolean;
   readonly runId: string;
+  readonly timestamp?: string;
   readonly dimensions?: Record<string, unknown>;
 }
 
@@ -47,7 +48,7 @@ export function recordSandboxOperation(attrs: SandboxOperationAttrs): void {
       Promise.resolve(
         client.ingest(dataset, [
           {
-            _time: nowDate().toISOString(),
+            _time: attrs.timestamp ?? nowDate().toISOString(),
             source: "api",
             op_type: attrs.actionType,
             sandbox_type: attrs.sandboxType,

--- a/turbo/apps/api/src/signals/routes/__tests__/webhooks-agent-health-usage-telemetry.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/webhooks-agent-health-usage-telemetry.test.ts
@@ -1482,6 +1482,7 @@ describe("POST /api/webhooks/agent/telemetry", () => {
       "vm0-sandbox-op-log-dev",
       [
         expect.objectContaining({
+          _time: "2026-05-14T01:00:02.000Z",
           source: "sandbox",
           op_type: "codex_exec",
           sandbox_type: "runner",

--- a/turbo/apps/api/src/signals/routes/webhooks-agent-health-usage-telemetry.ts
+++ b/turbo/apps/api/src/signals/routes/webhooks-agent-health-usage-telemetry.ts
@@ -333,6 +333,7 @@ const telemetry$ = command(async ({ get }, signal: AbortSignal) => {
         durationMs: op.duration_ms,
         success: op.success,
         runId: body.runId,
+        timestamp: op.ts,
         dimensions: {
           source: "sandbox",
           ...(op.error ? { error: op.error } : {}),


### PR DESCRIPTION
## Summary

- Preserve runner-provided sandbox operation `ts` as the Axiom `_time` for sandbox op rows.
- Keep API-originated sandbox operation rows using server receive time when no timestamp is provided.
- Add a webhook telemetry regression assertion for sandbox op `_time`.

Part of #16254.

## Verification

- `pnpm -F @vm0/db db:migrate`
- `pnpm -F @vm0/firewalls-generator generate`
- `pnpm -F api exec vitest run src/signals/routes/__tests__/webhooks-agent-health-usage-telemetry.test.ts`
- `pnpm -F api check-types`
- `pnpm -F api lint`
- pre-commit hook: prettier, knip, full `pnpm check-types`
