### PR TITLE
fix: delete schedules with chat threads

### DIFF
--- a/turbo/apps/api/src/signals/routes/__tests__/zero-chat-threads-delete.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/zero-chat-threads-delete.test.ts
@@ -5,6 +5,7 @@ import { eq } from "drizzle-orm";
 
 import { chatThreadByIdContract } from "@vm0/api-contracts/contracts/chat-threads";
 import { chatThreads } from "@vm0/db/schema/chat-thread";
+import { zeroAgentSchedules } from "@vm0/db/schema/zero-agent-schedule";
 
 import { accept, setupApp, testContext } from "../../../__tests__/test-helpers";
 import { writeDb$ } from "../../external/db";
@@ -33,6 +34,15 @@ describe("DELETE /api/zero/chat-threads/:id", () => {
       .select({ id: chatThreads.id })
       .from(chatThreads)
       .where(eq(chatThreads.id, threadId));
+    return Boolean(row);
+  }
+
+  async function getScheduleRowExists(scheduleId: string): Promise<boolean> {
+    const writeDb = store.set(writeDb$);
+    const [row] = await writeDb
+      .select({ id: zeroAgentSchedules.id })
+      .from(zeroAgentSchedules)
+      .where(eq(zeroAgentSchedules.id, scheduleId));
     return Boolean(row);
   }
 
@@ -89,6 +99,43 @@ describe("DELETE /api/zero/chat-threads/:id", () => {
     expect(response.body).toBeUndefined();
 
     await expect(getThreadRowExists(fixture.threadId)).resolves.toBeFalsy();
+  });
+
+  it("deletes schedules linked to the deleted thread", async () => {
+    const fixture = await track(
+      store.set(seedZeroChatThread$, {}, context.signal),
+    );
+    const writeDb = store.set(writeDb$);
+    const [schedule] = await writeDb
+      .insert(zeroAgentSchedules)
+      .values({
+        agentId: fixture.composeId,
+        userId: fixture.userId,
+        orgId: fixture.orgId,
+        name: "linked",
+        triggerType: "cron",
+        cronExpression: "0 9 * * *",
+        prompt: "Daily update",
+        timezone: "UTC",
+        chatThreadId: fixture.threadId,
+      })
+      .returning({ id: zeroAgentSchedules.id });
+    if (!schedule) {
+      throw new Error("Expected linked schedule fixture");
+    }
+    mocks.clerk.session(fixture.userId, fixture.orgId);
+
+    const client = setupApp({ context })(chatThreadByIdContract);
+    await accept(
+      client.delete({
+        params: { id: fixture.threadId },
+        headers: { authorization: "Bearer clerk-session" },
+      }),
+      [204],
+    );
+
+    await expect(getThreadRowExists(fixture.threadId)).resolves.toBeFalsy();
+    await expect(getScheduleRowExists(schedule.id)).resolves.toBeFalsy();
   });
 
   it("returns 204 with body undefined (c.noBody contract)", async () => {

--- a/turbo/apps/api/src/signals/routes/__tests__/zero-chat-threads-list.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/zero-chat-threads-list.test.ts
@@ -2,6 +2,7 @@ import { randomUUID } from "node:crypto";
 
 import { chatThreadsContract } from "@vm0/api-contracts/contracts/chat-threads";
 import { chatThreads } from "@vm0/db/schema/chat-thread";
+import { zeroAgentSchedules } from "@vm0/db/schema/zero-agent-schedule";
 import { createStore } from "ccstate";
 import { eq } from "drizzle-orm";
 
@@ -658,6 +659,71 @@ describe("GET /api/zero/chat-threads (list with optional agentId scoping)", () =
     );
 
     expect(allListedThreads(response.body)[0]!.hasDraft).toBeFalsy();
+  });
+
+  it("reports the number of schedules linked to each thread", async () => {
+    const fixture = await track(
+      store.set(
+        seedZeroChatThread$,
+        { title: "Scheduled chat" },
+        context.signal,
+      ),
+    );
+    const unlinkedFixture = await track(
+      store.set(
+        seedZeroChatThread$,
+        {
+          userId: fixture.userId,
+          orgId: fixture.orgId,
+          title: "Unscheduled chat",
+        },
+        context.signal,
+      ),
+    );
+    const writeDb = store.set(writeDb$);
+    await writeDb.insert(zeroAgentSchedules).values([
+      {
+        agentId: fixture.composeId,
+        userId: fixture.userId,
+        orgId: fixture.orgId,
+        name: "morning",
+        triggerType: "cron",
+        cronExpression: "0 9 * * *",
+        prompt: "Morning update",
+        timezone: "UTC",
+        chatThreadId: fixture.threadId,
+      },
+      {
+        agentId: fixture.composeId,
+        userId: fixture.userId,
+        orgId: fixture.orgId,
+        name: "evening",
+        triggerType: "cron",
+        cronExpression: "0 18 * * *",
+        prompt: "Evening update",
+        timezone: "UTC",
+        chatThreadId: fixture.threadId,
+      },
+    ]);
+    mocks.clerk.session(fixture.userId, fixture.orgId);
+
+    const client = setupApp({ context })(chatThreadsContract);
+    const response = await accept(
+      client.list({
+        query: {},
+        headers: { authorization: "Bearer clerk-session" },
+      }),
+      [200],
+    );
+
+    const scheduled = allListedThreads(response.body).find((thread) => {
+      return thread.id === fixture.threadId;
+    });
+    const unscheduled = allListedThreads(response.body).find((thread) => {
+      return thread.id === unlinkedFixture.threadId;
+    });
+    expect(scheduled?.scheduleCount).toBe(2);
+    expect(unscheduled?.scheduleCount).toBe(0);
   });
 
   it("reports running=true when any run is non-terminal even with a terminal sibling", async () => {

--- a/turbo/apps/api/src/signals/services/zero-chat-thread.service.ts
+++ b/turbo/apps/api/src/signals/services/zero-chat-thread.service.ts
@@ -28,6 +28,7 @@ import {
 import { chatThreads } from "@vm0/db/schema/chat-thread";
 import { runUploadedFiles } from "@vm0/db/schema/run-uploaded-file";
 import { zeroAgents } from "@vm0/db/schema/zero-agent";
+import { zeroAgentSchedules } from "@vm0/db/schema/zero-agent-schedule";
 import { zeroRuns } from "@vm0/db/schema/zero-run";
 import {
   and,
@@ -843,6 +844,11 @@ function chatThreadListProjection(lastMessage: LastMessageSubquery) {
         AND jsonb_array_length(${chatThreads.draftAttachments}) > 0
       )
     )`,
+    scheduleCount: sql<number>`(
+      SELECT COUNT(*)::int
+      FROM ${zeroAgentSchedules}
+      WHERE ${zeroAgentSchedules.chatThreadId} = ${chatThreads.id}
+    )`,
   } as const;
 }
 
@@ -859,6 +865,7 @@ type ChatThreadListRow = {
   readonly isRead: boolean;
   readonly running: boolean;
   readonly hasDraft: boolean;
+  readonly scheduleCount: number;
 };
 
 function rowToChatThreadListItem(
@@ -876,6 +883,7 @@ function rowToChatThreadListItem(
     isRead: thread.isRead,
     running: thread.running,
     hasDraft: thread.hasDraft,
+    scheduleCount: thread.scheduleCount,
     pinnedAt: thread.pinnedAt?.toISOString() ?? null,
     renamedAt: thread.renamedAt?.toISOString() ?? null,
   };
@@ -1468,17 +1476,33 @@ export const deleteChatThread$ = command(
     signal: AbortSignal,
   ): Promise<{ deleted: boolean }> => {
     const writeDb = set(writeDb$);
-    const deleted = await writeDb
-      .delete(chatThreads)
-      .where(
-        and(
-          eq(chatThreads.id, args.threadId),
-          eq(chatThreads.userId, args.userId),
-        ),
-      )
-      .returning({ id: chatThreads.id });
+    const deleted = await writeDb.transaction(async (tx) => {
+      const [ownedThread] = await tx
+        .select({ id: chatThreads.id })
+        .from(chatThreads)
+        .where(
+          and(
+            eq(chatThreads.id, args.threadId),
+            eq(chatThreads.userId, args.userId),
+          ),
+        )
+        .limit(1);
+      if (!ownedThread) {
+        return false;
+      }
+
+      await tx
+        .delete(zeroAgentSchedules)
+        .where(eq(zeroAgentSchedules.chatThreadId, ownedThread.id));
+
+      const deletedThreads = await tx
+        .delete(chatThreads)
+        .where(eq(chatThreads.id, ownedThread.id))
+        .returning({ id: chatThreads.id });
+      return deletedThreads.length > 0;
+    });
     signal.throwIfAborted();
-    return { deleted: deleted.length > 0 };
+    return { deleted };
   },
 );
 

--- a/turbo/apps/platform/src/views/zero-page/__tests__/chat-test-helpers.ts
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/chat-test-helpers.ts
@@ -165,6 +165,7 @@ interface ThreadListItem {
   updatedAt: string;
   isRead: boolean;
   running: boolean;
+  scheduleCount?: number;
   pinnedAt?: string | null;
 }
 

--- a/turbo/apps/platform/src/views/zero-page/__tests__/sidebar-chat-delete.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/sidebar-chat-delete.test.tsx
@@ -33,6 +33,7 @@ function makeThread(
   updatedAt: string;
   isRead: boolean;
   running: boolean;
+  scheduleCount?: number;
 } {
   return {
     id,
@@ -165,6 +166,79 @@ describe("sidebar chat delete", () => {
     await waitFor(() => {
       expect(getLastDeletedId()).toBe("thread-1");
     });
+  });
+
+  it("should warn that deleting a scheduled chat deletes linked schedules", async () => {
+    let threads = [
+      {
+        ...makeThread(
+          "thread-scheduled",
+          "Scheduled chat",
+          "2026-03-10T00:00:00Z",
+        ),
+        scheduleCount: 2,
+      },
+    ];
+
+    server.use(
+      mockApi(chatThreadsContract.list, ({ respond }) => {
+        return respond(200, splitChatThreadListResponse(threads));
+      }),
+      mockApi(chatThreadByIdContract.get, ({ params, respond }) => {
+        return respond(200, {
+          id: params.id,
+          title: "Scheduled chat",
+          agentId: AGENT_ID,
+          latestSessionId: null,
+          activeRunIds: [],
+          draftContent: null,
+          draftAttachments: null,
+          createdAt: "2026-03-10T00:00:00Z",
+          updatedAt: "2026-03-10T00:00:00Z",
+        });
+      }),
+      mockApi(chatThreadByIdContract.delete, ({ params, respond }) => {
+        threads = threads.filter((t) => {
+          return t.id !== params.id;
+        });
+        return respond(204);
+      }),
+    );
+
+    detachedSetupPage({ context, path: "/chats/thread-scheduled" });
+
+    await waitFor(() => {
+      expect(screen.getByText("Scheduled chat")).toBeInTheDocument();
+    });
+
+    const menuTrigger = await waitFor(() => {
+      return screen.getByLabelText("Open chat menu");
+    });
+    click(menuTrigger);
+
+    const deleteItem = await waitFor(() => {
+      const item = queryAllByRoleFast("menuitem").find((el) => {
+        return /Delete chat/i.test(el.textContent ?? "");
+      });
+      if (!item) {
+        throw new Error("Delete chat menu item not visible yet");
+      }
+      return item;
+    });
+    click(deleteItem);
+
+    const dialog = await waitFor(() => {
+      return screen.getByRole("dialog");
+    });
+
+    expect(
+      within(dialog).getByText("Delete chat and schedules?"),
+    ).toBeInTheDocument();
+    expect(
+      within(dialog).getByText(
+        "This will permanently delete this chat and 2 linked schedules. This action cannot be undone.",
+      ),
+    ).toBeInTheDocument();
   });
 
   it("should send the correct thread ID when deleting a middle thread", async () => {

--- a/turbo/apps/platform/src/views/zero-page/sidebar-threads.tsx
+++ b/turbo/apps/platform/src/views/zero-page/sidebar-threads.tsx
@@ -639,6 +639,13 @@ function ChatThreads() {
   const cursorForLoadMore = hasLoadedExtraPages
     ? extraLatestCursor
     : firstPageNextCursor;
+  const pendingDeleteThread = pendingDeleteThreadId
+    ? chatThreads.find((thread) => {
+        return thread.id === pendingDeleteThreadId;
+      })
+    : null;
+  const pendingDeleteScheduleCount = pendingDeleteThread?.scheduleCount ?? 0;
+  const pendingDeleteHasSchedules = pendingDeleteScheduleCount > 0;
 
   function handleLoadMore() {
     if (!cursorForLoadMore || loadingMore) {
@@ -686,10 +693,17 @@ function ChatThreads() {
       >
         <DialogContent>
           <DialogHeader>
-            <DialogTitle>Delete chat?</DialogTitle>
+            <DialogTitle>
+              {pendingDeleteHasSchedules
+                ? "Delete chat and schedules?"
+                : "Delete chat?"}
+            </DialogTitle>
             <DialogDescription>
-              This will permanently delete this chat. This action cannot be
-              undone.
+              {pendingDeleteHasSchedules
+                ? `This will permanently delete this chat and ${pendingDeleteScheduleCount} linked ${
+                    pendingDeleteScheduleCount === 1 ? "schedule" : "schedules"
+                  }. This action cannot be undone.`
+                : "This will permanently delete this chat. This action cannot be undone."}
             </DialogDescription>
           </DialogHeader>
           <DialogFooter>
@@ -702,7 +716,9 @@ function ChatThreads() {
               Cancel
             </Button>
             <Button variant="destructive" onClick={confirmDelete}>
-              Delete
+              {pendingDeleteHasSchedules
+                ? "Delete chat and schedules"
+                : "Delete"}
             </Button>
           </DialogFooter>
         </DialogContent>

--- a/turbo/packages/api-contracts/src/contracts/chat-threads.ts
+++ b/turbo/packages/api-contracts/src/contracts/chat-threads.ts
@@ -120,6 +120,12 @@ const chatThreadListItemSchema = z.object({
    */
   hasDraft: z.boolean().optional(),
   /**
+   * Number of schedules linked to this chat thread. Drives the stronger delete
+   * confirmation copy before removing a scheduled chat thread. Optional for
+   * back-compat with fixtures predating the field.
+   */
+  scheduleCount: z.number().int().nonnegative().optional(),
+  /**
    * ISO timestamp at which the user pinned this thread. Null/undefined means
    * unpinned. Pinned threads sort above unpinned in the sidebar; both groups
    * keep recency order. Optional for back-compat with fixtures that predate


### PR DESCRIPTION
## Summary
- add `scheduleCount` to chat thread list items so the sidebar can detect scheduled chat threads
- show stronger delete confirmation copy when a chat has linked schedules
- explicitly delete schedules linked to a chat thread inside the server-side delete transaction

## Testing
- `pnpm exec prettier --write apps/api/src/signals/routes/__tests__/zero-chat-threads-delete.test.ts apps/api/src/signals/routes/__tests__/zero-chat-threads-list.test.ts apps/api/src/signals/services/zero-chat-thread.service.ts apps/platform/src/views/zero-page/__tests__/chat-test-helpers.ts apps/platform/src/views/zero-page/__tests__/sidebar-chat-delete.test.tsx apps/platform/src/views/zero-page/sidebar-threads.tsx packages/api-contracts/src/contracts/chat-threads.ts`
- `pnpm -F @vm0/app lint`
- `pnpm -F @vm0/api-contracts lint`
- `NODE_OPTIONS=--max-old-space-size=4096 pnpm -F api lint`
- `pnpm -F @vm0/api-contracts check-types`
- `pnpm -F @vm0/app check-types`
- `NODE_OPTIONS=--max-old-space-size=4096 pnpm -F api check-types`
- `pnpm -F @vm0/app exec vitest run src/views/zero-page/__tests__/sidebar-chat-delete.test.tsx`
- `DATABASE_URL=postgresql://postgres@localhost:5432/vm0_test pnpm -F api exec vitest run src/signals/routes/__tests__/zero-chat-threads-delete.test.ts src/signals/routes/__tests__/zero-chat-threads-list.test.ts`