### PR TITLE
feat: add sandbox claim timing spans

### DIFF
--- a/turbo/apps/api/src/signals/routes/__tests__/runners.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/runners.test.ts
@@ -23,6 +23,7 @@ import { accept, setupApp, testContext } from "../../../__tests__/test-helpers";
 import { signPatJwtForTests, verifySandboxToken } from "../../auth/tokens";
 import { writeDb$ } from "../../external/db";
 import { now } from "../../external/time";
+import { clearAllDetached } from "../../utils";
 import { createFixtureTracker } from "./helpers/zero-route-test";
 import { encryptSecretForTests } from "./helpers/encrypt-secret";
 import {
@@ -814,9 +815,55 @@ describe("POST /api/runners/*", () => {
       .from(runnerJobQueue)
       .where(eq(runnerJobQueue.runId, queued.runId));
     expect(remainingJobs).toHaveLength(0);
+    await clearAllDetached();
     expect(context.mocks.ably.publish).toHaveBeenCalledWith(
       `run:changed:${queued.runId}`,
       { status: "running" },
+    );
+    expect(context.mocks.axiom.sdkIngest).toHaveBeenCalledWith(
+      "vm0-sandbox-op-log-dev",
+      [
+        expect.objectContaining({
+          op_type: "api_to_claim_request",
+          sandbox_type: "runner",
+          run_id: queued.runId,
+          duration_ms: expect.any(Number),
+          success: true,
+          runner_group: "vm0/test",
+          profile: "vm0/default",
+          auth_type: "user",
+        }),
+      ],
+    );
+    expect(context.mocks.axiom.sdkIngest).toHaveBeenCalledWith(
+      "vm0-sandbox-op-log-dev",
+      [
+        expect.objectContaining({
+          op_type: "api_to_claim",
+          sandbox_type: "runner",
+          run_id: queued.runId,
+          duration_ms: expect.any(Number),
+          success: true,
+          runner_group: "vm0/test",
+          profile: "vm0/default",
+          auth_type: "user",
+        }),
+      ],
+    );
+    expect(context.mocks.axiom.sdkIngest).toHaveBeenCalledWith(
+      "vm0-sandbox-op-log-dev",
+      [
+        expect.objectContaining({
+          op_type: "claim_request_to_running",
+          sandbox_type: "runner",
+          run_id: queued.runId,
+          duration_ms: expect.any(Number),
+          success: true,
+          runner_group: "vm0/test",
+          profile: "vm0/default",
+          auth_type: "user",
+        }),
+      ],
     );
   });
 

--- a/turbo/apps/api/src/signals/routes/runners.ts
+++ b/turbo/apps/api/src/signals/routes/runners.ts
@@ -25,7 +25,7 @@ import {
   publishRunChangedForUserSafely,
 } from "../external/realtime";
 import { recordSandboxOperation } from "../external/sandbox-op-log";
-import { nowDate } from "../external/time";
+import { now, nowDate } from "../external/time";
 import { badRequestMessage, conflict, notFound } from "../../lib/error";
 import { logger } from "../../lib/log";
 import { generateSandboxToken } from "../auth/tokens";
@@ -532,42 +532,68 @@ async function secretValuesForRunner(
 function scheduleClaimSucceededSideEffects(args: {
   readonly runId: string;
   readonly userId: string;
+  readonly runnerGroup: string;
+  readonly profile: string;
+  readonly authType: RunnerAuthContext["type"];
+  readonly apiToClaimRequestMs: number | undefined;
   readonly apiToClaimMs: number | undefined;
+  readonly claimRequestToRunningMs: number;
 }): void {
   waitUntil(
     publishRunChangedForUserSafely(args.userId, args.runId, {
       status: "running",
     }),
   );
-  const apiToClaimMs = args.apiToClaimMs;
-  if (apiToClaimMs === undefined) {
-    return;
-  }
 
   waitUntil(
-    tapError(
-      recordClaimApiToClaimMetric({
-        runId: args.runId,
-        durationMs: apiToClaimMs,
-      }),
-      (error) => {
-        L.warn("recordSandboxOperation failed", { runId: args.runId, error });
-      },
-    ),
+    tapError(recordClaimTimingMetrics(args), (error) => {
+      L.warn("recordSandboxOperation failed", { runId: args.runId, error });
+    }),
   );
 }
 
-async function recordClaimApiToClaimMetric(args: {
+async function recordClaimTimingMetrics(args: {
   readonly runId: string;
-  readonly durationMs: number;
+  readonly runnerGroup: string;
+  readonly profile: string;
+  readonly authType: RunnerAuthContext["type"];
+  readonly apiToClaimRequestMs: number | undefined;
+  readonly apiToClaimMs: number | undefined;
+  readonly claimRequestToRunningMs: number;
 }): Promise<void> {
   await Promise.resolve();
+  const dimensions = {
+    runner_group: args.runnerGroup,
+    profile: args.profile,
+    auth_type: args.authType,
+  };
+  if (args.apiToClaimRequestMs !== undefined) {
+    recordSandboxOperation({
+      sandboxType: "runner",
+      actionType: "api_to_claim_request",
+      durationMs: args.apiToClaimRequestMs,
+      success: true,
+      runId: args.runId,
+      dimensions,
+    });
+  }
+  if (args.apiToClaimMs !== undefined) {
+    recordSandboxOperation({
+      sandboxType: "runner",
+      actionType: "api_to_claim",
+      durationMs: args.apiToClaimMs,
+      success: true,
+      runId: args.runId,
+      dimensions,
+    });
+  }
   recordSandboxOperation({
     sandboxType: "runner",
-    actionType: "api_to_claim",
-    durationMs: args.durationMs,
+    actionType: "claim_request_to_running",
+    durationMs: args.claimRequestToRunningMs,
     success: true,
     runId: args.runId,
+    dimensions,
   });
 }
 
@@ -611,6 +637,7 @@ const scheduleClaimFailedSideEffects$ = command(
 );
 
 const claimInner$ = command(async ({ get, set }, signal: AbortSignal) => {
+  const claimRequestStartedAtMs = now();
   const auth = await set(runnerAuth$, get(authorization$), signal);
   signal.throwIfAborted();
   if (!auth) {
@@ -707,9 +734,20 @@ const claimInner$ = command(async ({ get, set }, signal: AbortSignal) => {
   scheduleClaimSucceededSideEffects({
     runId,
     userId: run.userId,
+    runnerGroup: jobWithRun.job.runnerGroup,
+    profile: jobWithRun.job.profile,
+    authType: auth.type,
+    apiToClaimRequestMs: elapsedSinceApiStartMs(
+      storedContext.apiStartTime,
+      claimRequestStartedAtMs,
+    ),
     apiToClaimMs: elapsedSinceApiStartMs(
       storedContext.apiStartTime,
       claimResult.claimedAt.getTime(),
+    ),
+    claimRequestToRunningMs: Math.max(
+      0,
+      claimResult.claimedAt.getTime() - claimRequestStartedAtMs,
     ),
   });
 


### PR DESCRIPTION
## Summary
- add `api_to_claim_request` to measure run creation to claim request arrival
- add `claim_request_to_running` to measure claim handler/DB transition time
- keep existing `api_to_claim` total span and add `runner_group`, `profile`, and `auth_type` dimensions to claim timing rows

Part of #16254.

## Verification
- `pnpm -F @vm0/db db:migrate`
- `pnpm -F @vm0/firewalls-generator generate`
- `pnpm -F api exec vitest run src/signals/routes/__tests__/runners.test.ts`
- `pnpm -F api check-types`
- `pnpm -F api lint`
- `pnpm format`
- `git diff --check`
- pre-commit hook (`prettier`, `knip`, full `pnpm check-types`)
