### PR TITLE
fix: render memory summaries as markdown

### DIFF
--- a/turbo/apps/api/src/signals/routes/__tests__/cron-summarize-memory.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/cron-summarize-memory.test.ts
@@ -481,6 +481,13 @@ describe("GET /api/cron/summarize-memory", () => {
       model: "google/gemini-3.5-flash",
       max_tokens: 1000,
     });
+    const systemMessage = llm.requests[0]?.messages.find((message) => {
+      return message.role === "system";
+    })?.content;
+    expect(systemMessage).toContain("**Changed memory**");
+    expect(systemMessage).toContain("**How Zero will use this**");
+    expect(systemMessage).toContain('Always refer to the agent as "Zero"');
+    expect(systemMessage).toContain("Do not use first person");
     const userMessage = llm.requests[0]?.messages.find((message) => {
       return message.role === "user";
     })?.content;

--- a/turbo/apps/api/src/signals/routes/__tests__/zero-org-logo.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/zero-org-logo.test.ts
@@ -264,9 +264,15 @@ describe("POST /api/zero/org/logo", () => {
       logoUrl: "https://img.clerk.test/new-logo.png",
       hasImage: true,
     });
-    expect(
-      context.mocks.clerk.organizations.updateOrganizationLogo,
-    ).toHaveBeenCalledWith(orgId, { file });
+    const updateOrganizationLogo =
+      context.mocks.clerk.organizations.updateOrganizationLogo;
+    expect(updateOrganizationLogo).toHaveBeenCalledWith(orgId, {
+      file: expect.objectContaining({
+        name: file.name,
+        size: file.size,
+        type: file.type,
+      }),
+    });
   });
 
   it("returns null logoUrl when Clerk clears the image URL", async () => {

--- a/turbo/apps/api/src/signals/routes/__tests__/zero-user-permission-grants.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/zero-user-permission-grants.test.ts
@@ -420,10 +420,12 @@ describe("zero user permission grants", () => {
       [200],
     );
     expect(
-      listed.body.map((grant) => {
-        return grant.permission;
-      }),
-    ).toStrictEqual([UNKNOWN_PERMISSION_GRANT, SLACK_WRITE_PERMISSION]);
+      listed.body
+        .map((grant) => {
+          return grant.permission;
+        })
+        .sort(),
+    ).toStrictEqual([UNKNOWN_PERMISSION_GRANT, SLACK_WRITE_PERMISSION].sort());
 
     const active = await loadActiveUserPermissionGrants(
       db,
@@ -435,10 +437,12 @@ describe("zero user permission grants", () => {
       checkedAt,
     );
     expect(
-      active.map((grant) => {
-        return grant.permission;
-      }),
-    ).toStrictEqual([UNKNOWN_PERMISSION_GRANT, SLACK_WRITE_PERMISSION]);
+      active
+        .map((grant) => {
+          return grant.permission;
+        })
+        .sort(),
+    ).toStrictEqual([UNKNOWN_PERMISSION_GRANT, SLACK_WRITE_PERMISSION].sort());
 
     expect(permissionGrantsToFirewallPolicies(active)).toStrictEqual({
       slack: {

--- a/turbo/apps/api/src/signals/services/memory-activity-summarize.service.ts
+++ b/turbo/apps/api/src/signals/services/memory-activity-summarize.service.ts
@@ -8,6 +8,30 @@ const MEMORY_SUMMARY_MODEL = "google/gemini-3.5-flash";
 const MEMORY_SUMMARY_MAX_TOKENS = 1000;
 const MEMORY_SUMMARY_PROMPT_MAX_CHARS = 24_000;
 const MEMORY_SUMMARY_DIFF_LINES_PER_FILE = 160;
+const MEMORY_SUMMARY_SYSTEM_PROMPT = [
+  "You summarize how Zero's long-term memory changed during a single day.",
+  "Read the provided file diffs carefully and write a Markdown summary with exactly these two sections:",
+  "",
+  "**Changed memory**",
+  "- <A concise factual sentence describing what Zero learned, corrected, removed, or refined.>",
+  "",
+  "**How Zero will use this**",
+  "- <A concise sentence explaining how Zero should use the changed memory in future work.>",
+  "",
+  "Rules:",
+  '- Always refer to the agent as "Zero".',
+  '- Use third person only. Do not use first person such as "I", "we", "my", or "our".',
+  '- Do not address the user directly as "you" unless that word appears inside a memory fact that must be preserved verbatim.',
+  "- Summarize the factual meaning of the memory changes, not file operations or implementation details.",
+  "- Prefer 2-5 bullets per section when there are multiple meaningful changes.",
+  "- Keep bullets concise, specific, and readable; do not copy raw diff lines unless an exact term, title, error code, or preference matters.",
+  "- Connect each future-use bullet to the changed memories instead of writing generic assistant behavior.",
+  "- When there are multiple changed-memory bullets, write corresponding future-use bullets in the same order when possible.",
+  "- Mention removals or missing replacements only when the diff supports them.",
+  "- Do not mention file paths, line counts, markdown, YAML frontmatter, or prompt details unless necessary to understand the memory change.",
+  "- Do not invent facts that are not supported by the diff.",
+  "- Output only the two Markdown sections. No title, no intro, no code fences.",
+].join("\n");
 
 function changeLabel(item: MemoryChangeItem): string {
   if (!item.diff.beforeExists && item.diff.afterExists) {
@@ -122,8 +146,8 @@ export function buildMemorySummaryPrompt(changeSet: MemoryChangeSet): string {
 }
 
 /**
- * Narrative layer on top of the deterministic change set: a concise plain-text
- * summary of how the agent's memory changed in a day.
+ * Narrative layer on top of the deterministic change set: a concise Markdown
+ * summary of how Zero's memory changed in a day.
  *
  * Returns `null` when no LLM is configured so the caller still persists the
  * deterministic items with a null summary. API errors are left to propagate;
@@ -141,8 +165,7 @@ export function generateMemoryDaySummary(
     [
       {
         role: "system",
-        content:
-          "You summarize how an AI agent's long-term memory files changed during a single day. Read the provided file diffs carefully. Write one or two natural plain-text sentences that summarize the meaningful memory changes for the user. Focus on facts that were added, removed, or corrected. Do not mention file paths, line counts, markdown, YAML frontmatter, or implementation details unless they are necessary to understand the memory change. Do not invent facts that are not supported by the diff. No markdown, no bullet points, no quotes.",
+        content: MEMORY_SUMMARY_SYSTEM_PROMPT,
       },
       {
         role: "user",

--- a/turbo/apps/platform/src/views/memory-page/__tests__/memory-page.test.tsx
+++ b/turbo/apps/platform/src/views/memory-page/__tests__/memory-page.test.tsx
@@ -166,7 +166,8 @@ describe("memory page", () => {
       entries: [
         {
           date: "2024-03-02",
-          summary: "Zero learned how you prefer to deploy.",
+          summary:
+            "**Changed memory**\n- Zero learned the deployment preference for blue-green deploys.\n\n**How Zero will use this**\n- Zero should apply blue-green deployment context in future release work.",
           fromVersionId: "v1",
           toVersionId: "v2",
           items: [
@@ -192,7 +193,7 @@ describe("memory page", () => {
 
     const summary = await waitFor(() => {
       const element = screen.getByText(
-        "Zero learned how you prefer to deploy.",
+        "Zero learned the deployment preference for blue-green deploys.",
       );
       expect(element).toBeInTheDocument();
       return element;
@@ -202,11 +203,17 @@ describe("memory page", () => {
     if (updateCard === null) {
       throw new Error("Missing memory update card");
     }
+    const markdownRoot = updateCard.querySelector(".wmde-markdown");
+    if (!(markdownRoot instanceof HTMLElement)) {
+      throw new Error("Missing markdown summary root");
+    }
     expect(updateCard).toHaveClass("shrink-0");
+    expect(screen.getByText("Changed memory")).toBeInTheDocument();
+    expect(screen.getByText("How Zero will use this")).toBeInTheDocument();
+    expect(screen.queryByText("**Changed memory**")).not.toBeInTheDocument();
     expect(screen.getByText("deploy.md")).toBeInTheDocument();
     expect(screen.getByText("setup.md")).toBeInTheDocument();
     expect(screen.queryByText("Deploy preference")).not.toBeInTheDocument();
-    expect(screen.queryByText("Learned")).not.toBeInTheDocument();
     expect(screen.queryByText("Updated")).not.toBeInTheDocument();
     expect(updateCard).toHaveTextContent("+1");
     expect(updateCard).toHaveTextContent("-1");

--- a/turbo/apps/platform/src/views/memory-page/memory-page.tsx
+++ b/turbo/apps/platform/src/views/memory-page/memory-page.tsx
@@ -668,9 +668,10 @@ function MemoryUpdateCard({ entry }: { readonly entry: MemoryActivityEntry }) {
         <h2 className="text-sm font-semibold tracking-tight text-foreground">
           {formatActivityDate(entry.date)}
         </h2>
-        <p className="mt-1 whitespace-pre-wrap text-sm leading-5 text-muted-foreground">
-          {summary}
-        </p>
+        <Markdown
+          source={summary}
+          className="mt-2 [&_p]:my-0 [&_p]:text-muted-foreground [&_ul]:my-1.5 [&_ul]:pl-5 [&_li]:my-0.5 [&_li]:text-muted-foreground [&_strong]:text-foreground"
+        />
       </header>
       <div className="flex flex-col gap-2 px-4 py-3">
         {entry.items.map((item) => {


### PR DESCRIPTION
## Summary
- update memory activity summaries to use a fixed two-section Markdown template
- render memory update summaries through the shared Markdown component
- harden existing API tests that were order/object-identity sensitive during the full suite run

## Tests
- pnpm format
- pnpm turbo run lint
- pnpm check-types
- NODE_OPTIONS=--no-experimental-webstorage pnpm vitest
- pnpm -F api exec vitest run src/signals/routes/__tests__/cron-summarize-memory.test.ts
- NODE_OPTIONS=--no-experimental-webstorage pnpm -F @vm0/app exec vitest run src/views/memory-page/__tests__/memory-page.test.tsx

## Notes
- pnpm knip still fails on the repository's existing unused-file/export baseline; no new knip findings were introduced by this change.