### PR TITLE
fix: stop schedules and runs when deleting a chat thread

### DIFF
--- a/turbo/apps/api/src/signals/routes/__tests__/zero-chat-threads-delete.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/zero-chat-threads-delete.test.ts
@@ -4,11 +4,14 @@ import { createStore } from "ccstate";
 import { eq } from "drizzle-orm";
 
 import { chatThreadByIdContract } from "@vm0/api-contracts/contracts/chat-threads";
+import { agentRuns } from "@vm0/db/schema/agent-run";
 import { chatThreads } from "@vm0/db/schema/chat-thread";
+import { orgMetadata } from "@vm0/db/schema/org-metadata";
 import { zeroAgentSchedules } from "@vm0/db/schema/zero-agent-schedule";
 
 import { accept, setupApp, testContext } from "../../../__tests__/test-helpers";
 import { writeDb$ } from "../../external/db";
+import { clearAllDetached } from "../../utils";
 import {
   deleteZeroChatThread$,
   seedZeroChatThread$,
@@ -18,6 +21,7 @@ import {
   createFixtureTracker,
   createZeroRouteMocks,
 } from "./helpers/zero-route-test";
+import { seedRun$ } from "./helpers/zero-usage-insight";
 
 const context = testContext();
 const store = createStore();
@@ -44,6 +48,25 @@ describe("DELETE /api/zero/chat-threads/:id", () => {
       .from(zeroAgentSchedules)
       .where(eq(zeroAgentSchedules.id, scheduleId));
     return Boolean(row);
+  }
+
+  async function getRunStatus(runId: string): Promise<string | undefined> {
+    const writeDb = store.set(writeDb$);
+    const [row] = await writeDb
+      .select({ status: agentRuns.status })
+      .from(agentRuns)
+      .where(eq(agentRuns.id, runId));
+    return row?.status;
+  }
+
+  // dispatchCancelSideEffects$ reads org credit metadata during the detached
+  // queue-drain / credit-reconcile pass; seed it so that work runs cleanly.
+  async function seedOrgMetadata(orgId: string): Promise<void> {
+    const writeDb = store.set(writeDb$);
+    await writeDb
+      .insert(orgMetadata)
+      .values({ orgId, tier: "free", credits: 10_000 })
+      .onConflictDoNothing();
   }
 
   it("returns 401 when the request is unauthenticated", async () => {
@@ -225,5 +248,133 @@ describe("DELETE /api/zero/chat-threads/:id", () => {
     // Seeded thread untouched (path validation short-circuits before DB).
     await expect(getThreadRowExists(fixture.threadId)).resolves.toBeTruthy();
     expect(context.mocks.ably.publish).not.toHaveBeenCalled();
+  });
+
+  it("cancels in-flight runs linked to the deleted thread", async () => {
+    const fixture = await track(
+      store.set(seedZeroChatThread$, {}, context.signal),
+    );
+    await seedOrgMetadata(fixture.orgId);
+    const { runId } = await store.set(
+      seedRun$,
+      {
+        orgId: fixture.orgId,
+        userId: fixture.userId,
+        composeId: fixture.composeId,
+        status: "running",
+        chatThreadId: fixture.threadId,
+      },
+      context.signal,
+    );
+    mocks.clerk.session(fixture.userId, fixture.orgId);
+
+    const client = setupApp({ context })(chatThreadByIdContract);
+    await accept(
+      client.delete({
+        params: { id: fixture.threadId },
+        headers: { authorization: "Bearer clerk-session" },
+      }),
+      [204],
+    );
+
+    // The run is cancelled synchronously as part of the delete, and the thread
+    // is gone.
+    await expect(getRunStatus(runId)).resolves.toBe("cancelled");
+    await expect(getThreadRowExists(fixture.threadId)).resolves.toBeFalsy();
+
+    // Post-cancel side effects land on the detached path.
+    await clearAllDetached();
+    expect(context.mocks.ably.publish).toHaveBeenCalledWith(
+      `runChanged:${runId}`,
+      { status: "cancelled" },
+    );
+    expect(context.mocks.ably.publish).toHaveBeenCalledWith(
+      "queue:changed",
+      null,
+    );
+  });
+
+  it("leaves terminal runs linked to the deleted thread untouched", async () => {
+    const fixture = await track(
+      store.set(seedZeroChatThread$, {}, context.signal),
+    );
+    await seedOrgMetadata(fixture.orgId);
+    const { runId } = await store.set(
+      seedRun$,
+      {
+        orgId: fixture.orgId,
+        userId: fixture.userId,
+        composeId: fixture.composeId,
+        status: "completed",
+        chatThreadId: fixture.threadId,
+      },
+      context.signal,
+    );
+    mocks.clerk.session(fixture.userId, fixture.orgId);
+
+    const client = setupApp({ context })(chatThreadByIdContract);
+    await accept(
+      client.delete({
+        params: { id: fixture.threadId },
+        headers: { authorization: "Bearer clerk-session" },
+      }),
+      [204],
+    );
+
+    // A completed run is not cancellable; its status is preserved.
+    await expect(getRunStatus(runId)).resolves.toBe("completed");
+  });
+
+  it("only cancels runs linked to the thread being deleted", async () => {
+    const fixture = await track(
+      store.set(seedZeroChatThread$, {}, context.signal),
+    );
+    const other = await track(
+      store.set(
+        seedZeroChatThread$,
+        { userId: fixture.userId, orgId: fixture.orgId },
+        context.signal,
+      ),
+    );
+    await seedOrgMetadata(fixture.orgId);
+    const { runId: deletedThreadRun } = await store.set(
+      seedRun$,
+      {
+        orgId: fixture.orgId,
+        userId: fixture.userId,
+        composeId: fixture.composeId,
+        status: "running",
+        chatThreadId: fixture.threadId,
+      },
+      context.signal,
+    );
+    const { runId: otherThreadRun } = await store.set(
+      seedRun$,
+      {
+        orgId: fixture.orgId,
+        userId: fixture.userId,
+        composeId: other.composeId,
+        status: "running",
+        chatThreadId: other.threadId,
+      },
+      context.signal,
+    );
+    mocks.clerk.session(fixture.userId, fixture.orgId);
+
+    const client = setupApp({ context })(chatThreadByIdContract);
+    await accept(
+      client.delete({
+        params: { id: fixture.threadId },
+        headers: { authorization: "Bearer clerk-session" },
+      }),
+      [204],
+    );
+
+    // Only the deleted thread's run is cancelled; the sibling thread's run
+    // keeps running.
+    await expect(getRunStatus(deletedThreadRun)).resolves.toBe("cancelled");
+    await expect(getRunStatus(otherThreadRun)).resolves.toBe("running");
+
+    await clearAllDetached();
   });
 });

--- a/turbo/apps/api/src/signals/routes/zero-chat-threads-delete.ts
+++ b/turbo/apps/api/src/signals/routes/zero-chat-threads-delete.ts
@@ -4,10 +4,16 @@ import { chatThreadByIdContract } from "@vm0/api-contracts/contracts/chat-thread
 import { authContext$ } from "../auth/auth-context";
 import { authRoute } from "../auth/auth-route";
 import { pathParamsOf } from "../context/request";
+import { waitUntil } from "../context/wait-until";
 import { publishThreadListChanged } from "../external/realtime";
 import { notFound } from "../../lib/error";
+import { logger } from "../../lib/log";
 import { deleteChatThread$ } from "../services/zero-chat-thread.service";
+import { dispatchCancelSideEffects$ } from "../services/zero-run-cancel.service";
+import { tapError } from "../utils";
 import type { RouteEntry } from "../route";
+
+const L = logger("ChatThreadDelete");
 
 function chatThreadNotFound() {
   return notFound("Chat thread not found");
@@ -26,6 +32,19 @@ const deleteInner$ = command(async ({ get, set }, signal: AbortSignal) => {
 
   if (!result.deleted) {
     return chatThreadNotFound();
+  }
+
+  // Dispatch post-cancel side effects (runner halt, queue drain, credit
+  // reconciliation) for every run we stopped while tearing down the thread.
+  for (const cancelled of result.cancelledRuns) {
+    waitUntil(
+      tapError(set(dispatchCancelSideEffects$, cancelled, signal), (error) => {
+        L.error("dispatchCancelSideEffects failed", {
+          runId: cancelled.runId,
+          error,
+        });
+      }),
+    );
   }
 
   await publishThreadListChanged(auth.userId);

--- a/turbo/apps/api/src/signals/services/zero-chat-thread.service.ts
+++ b/turbo/apps/api/src/signals/services/zero-chat-thread.service.ts
@@ -38,6 +38,7 @@ import {
   gt,
   gte,
   ilike,
+  inArray,
   isNotNull,
   isNull,
   lt,
@@ -59,6 +60,7 @@ import {
 } from "../external/realtime";
 import { listS3Objects } from "../external/s3";
 import { safeJsonParse } from "../utils";
+import { cancelRun$, type CancelRunResult } from "./zero-run-cancel.service";
 
 const REPORT_ERROR_STREAK_THRESHOLD = 2;
 
@@ -1469,40 +1471,94 @@ export const insertAssistantEventMessages$ = command(
   },
 );
 
+const ACTIVE_RUN_STATUSES = ["queued", "pending", "running"] as const;
+
+/**
+ * Delete a chat thread after winding down everything attached to it. Deleting a
+ * thread on its own leaves the linked schedules firing and any in-flight runs
+ * executing: `zero_runs.chatThreadId` is `ON DELETE SET NULL`, so a running run
+ * simply loses its thread reference and keeps consuming credits. We therefore
+ * follow the order: stop related schedules, cancel related active runs, then
+ * delete the thread.
+ *
+ * Run cancellation has side effects that cannot participate in the thread's
+ * delete transaction (`cancelRun$` opens its own transaction and the runner
+ * must be notified), so ownership is verified up front and the cancelled-run
+ * results are returned for the caller to dispatch the post-cancel side effects.
+ */
 export const deleteChatThread$ = command(
   async (
     { set },
     args: { readonly threadId: string; readonly userId: string },
     signal: AbortSignal,
-  ): Promise<{ deleted: boolean }> => {
+  ): Promise<{
+    readonly deleted: boolean;
+    readonly cancelledRuns: readonly CancelRunResult[];
+  }> => {
     const writeDb = set(writeDb$);
-    const deleted = await writeDb.transaction(async (tx) => {
-      const [ownedThread] = await tx
-        .select({ id: chatThreads.id })
-        .from(chatThreads)
-        .where(
-          and(
-            eq(chatThreads.id, args.threadId),
-            eq(chatThreads.userId, args.userId),
-          ),
-        )
-        .limit(1);
-      if (!ownedThread) {
-        return false;
-      }
 
-      await tx
-        .delete(zeroAgentSchedules)
-        .where(eq(zeroAgentSchedules.chatThreadId, ownedThread.id));
-
-      const deletedThreads = await tx
-        .delete(chatThreads)
-        .where(eq(chatThreads.id, ownedThread.id))
-        .returning({ id: chatThreads.id });
-      return deletedThreads.length > 0;
-    });
+    const [ownedThread] = await writeDb
+      .select({ id: chatThreads.id })
+      .from(chatThreads)
+      .where(
+        and(
+          eq(chatThreads.id, args.threadId),
+          eq(chatThreads.userId, args.userId),
+        ),
+      )
+      .limit(1);
     signal.throwIfAborted();
-    return { deleted };
+    if (!ownedThread) {
+      return { deleted: false, cancelledRuns: [] };
+    }
+
+    // Stop related schedules first so none of them can spawn a fresh run while
+    // we are cancelling the in-flight ones.
+    await writeDb
+      .delete(zeroAgentSchedules)
+      .where(eq(zeroAgentSchedules.chatThreadId, ownedThread.id));
+    signal.throwIfAborted();
+
+    // Cancel related active runs. Terminal runs (completed/failed/cancelled)
+    // are left untouched; only queued/pending/running runs need stopping.
+    const activeRuns = await writeDb
+      .select({ runId: agentRuns.id, orgId: agentRuns.orgId })
+      .from(zeroRuns)
+      .innerJoin(agentRuns, eq(agentRuns.id, zeroRuns.id))
+      .where(
+        and(
+          eq(zeroRuns.chatThreadId, ownedThread.id),
+          eq(agentRuns.userId, args.userId),
+          inArray(agentRuns.status, [...ACTIVE_RUN_STATUSES]),
+        ),
+      );
+    signal.throwIfAborted();
+
+    const cancelledRuns: CancelRunResult[] = [];
+    for (const run of activeRuns) {
+      const result = await set(
+        cancelRun$,
+        { runId: run.runId, userId: args.userId, orgId: run.orgId },
+        signal,
+      );
+      signal.throwIfAborted();
+      // Pre-filtered to active runs, but a concurrent transition can still race
+      // a run to a terminal status; cancelRun$ then returns a frozen error
+      // response (no `alreadyCancelled` field), which we skip.
+      if ("alreadyCancelled" in result) {
+        cancelledRuns.push(result);
+      }
+    }
+
+    // Delete the thread last. Cascades chat_messages; the now-cancelled runs
+    // have their zero_runs.chatThreadId set to NULL.
+    const [deletedThread] = await writeDb
+      .delete(chatThreads)
+      .where(eq(chatThreads.id, ownedThread.id))
+      .returning({ id: chatThreads.id });
+    signal.throwIfAborted();
+
+    return { deleted: Boolean(deletedThread), cancelledRuns };
   },
 );
 

--- a/turbo/apps/platform/src/signals/chat-page/header-schedule-menu.ts
+++ b/turbo/apps/platform/src/signals/chat-page/header-schedule-menu.ts
@@ -4,7 +4,6 @@ import { zeroSchedulesMainContract } from "@vm0/api-contracts/contracts/zero-sch
 import { accept } from "../../lib/accept.ts";
 import { zeroClient$ } from "../api-client.ts";
 import { scheduleTitle } from "../zero-page/schedule-title.ts";
-import { pendingDeleteThreadId$ } from "../zero-page/zero-sidebar-state.ts";
 
 interface HeaderScheduleEntry {
   readonly id: string;
@@ -55,20 +54,3 @@ export function schedulesForThread(
     return schedule.chatThreadId === threadId;
   });
 }
-
-/**
- * Schedules linked to the chat thread that is pending deletion, for the delete
- * confirmation dialog. Resolves to an empty list without fetching while no
- * delete is pending, so the sidebar only loads the schedule list once the
- * dialog opens.
- */
-export const pendingDeleteThreadSchedules$ = computed(
-  async (get): Promise<readonly HeaderScheduleEntry[]> => {
-    const threadId = get(pendingDeleteThreadId$);
-    if (!threadId) {
-      return [];
-    }
-    const schedules = await get(headerScheduleMenu$);
-    return schedulesForThread(schedules, threadId);
-  },
-);

--- a/turbo/apps/platform/src/signals/chat-page/header-schedule-menu.ts
+++ b/turbo/apps/platform/src/signals/chat-page/header-schedule-menu.ts
@@ -4,6 +4,7 @@ import { zeroSchedulesMainContract } from "@vm0/api-contracts/contracts/zero-sch
 import { accept } from "../../lib/accept.ts";
 import { zeroClient$ } from "../api-client.ts";
 import { scheduleTitle } from "../zero-page/schedule-title.ts";
+import { pendingDeleteThreadId$ } from "../zero-page/zero-sidebar-state.ts";
 
 interface HeaderScheduleEntry {
   readonly id: string;
@@ -54,3 +55,20 @@ export function schedulesForThread(
     return schedule.chatThreadId === threadId;
   });
 }
+
+/**
+ * Schedules linked to the chat thread that is pending deletion, for the delete
+ * confirmation dialog. Resolves to an empty list without fetching while no
+ * delete is pending, so the sidebar only loads the schedule list once the
+ * dialog opens.
+ */
+export const pendingDeleteThreadSchedules$ = computed(
+  async (get): Promise<readonly HeaderScheduleEntry[]> => {
+    const threadId = get(pendingDeleteThreadId$);
+    if (!threadId) {
+      return [];
+    }
+    const schedules = await get(headerScheduleMenu$);
+    return schedulesForThread(schedules, threadId);
+  },
+);

--- a/turbo/apps/platform/src/views/zero-page/__tests__/sidebar-chat-delete.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/sidebar-chat-delete.test.tsx
@@ -15,6 +15,10 @@ import {
   chatThreadByIdContract,
 } from "@vm0/api-contracts/contracts/chat-threads";
 import { createNewChatThreadOptimistically$ } from "../../../signals/chat-page/optimistic-chat-thread-page.ts";
+import {
+  createMockScheduleResponse,
+  setMockSchedules,
+} from "../../../mocks/handlers/api-schedules.ts";
 
 const context = testContext();
 const mockApi = createMockApi(context);
@@ -180,6 +184,21 @@ describe("sidebar chat delete", () => {
       },
     ];
 
+    setMockSchedules([
+      createMockScheduleResponse({
+        id: "f0000001-0000-4000-a000-000000000010",
+        name: "morning-briefing",
+        description: "Morning briefing",
+        chatThreadId: "thread-scheduled",
+      }),
+      createMockScheduleResponse({
+        id: "f0000001-0000-4000-a000-000000000011",
+        name: "weekly-report",
+        description: "Weekly report",
+        chatThreadId: "thread-scheduled",
+      }),
+    ]);
+
     server.use(
       mockApi(chatThreadsContract.list, ({ respond }) => {
         return respond(200, splitChatThreadListResponse(threads));
@@ -236,9 +255,18 @@ describe("sidebar chat delete", () => {
     ).toBeInTheDocument();
     expect(
       within(dialog).getByText(
-        "This will permanently delete this chat and 2 linked schedules. This action cannot be undone.",
+        "This will permanently delete this chat and its 2 linked schedules. Any task currently running in this chat will be stopped immediately. This action cannot be undone.",
       ),
     ).toBeInTheDocument();
+
+    // The linked schedules are listed by their description.
+    expect(
+      within(dialog).getByText("These schedules will be deleted"),
+    ).toBeInTheDocument();
+    await waitFor(() => {
+      expect(within(dialog).getByText("Morning briefing")).toBeInTheDocument();
+    });
+    expect(within(dialog).getByText("Weekly report")).toBeInTheDocument();
   });
 
   it("should send the correct thread ID when deleting a middle thread", async () => {

--- a/turbo/apps/platform/src/views/zero-page/__tests__/sidebar-chat-delete.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/sidebar-chat-delete.test.tsx
@@ -171,10 +171,13 @@ describe("sidebar chat delete", () => {
   });
 
   it("should warn that deleting a scheduled chat deletes linked schedules", async () => {
+    // chatThreadId is a UUID in the schedule contract, so the thread id must be
+    // a valid UUID for the linked-schedule list to pass response validation.
+    const scheduledThreadId = "a0000000-0000-4000-a000-000000000099";
     let threads = [
       {
         ...makeThread(
-          "thread-scheduled",
+          scheduledThreadId,
           "Scheduled chat",
           "2026-03-10T00:00:00Z",
         ),
@@ -190,13 +193,13 @@ describe("sidebar chat delete", () => {
               id: "f0000001-0000-4000-a000-000000000010",
               name: "morning-briefing",
               description: "Morning briefing",
-              chatThreadId: "thread-scheduled",
+              chatThreadId: scheduledThreadId,
             }),
             createMockScheduleResponse({
               id: "f0000001-0000-4000-a000-000000000011",
               name: "weekly-report",
               description: "Weekly report",
-              chatThreadId: "thread-scheduled",
+              chatThreadId: scheduledThreadId,
             }),
           ],
         });
@@ -225,7 +228,7 @@ describe("sidebar chat delete", () => {
       }),
     );
 
-    detachedSetupPage({ context, path: "/chats/thread-scheduled" });
+    detachedSetupPage({ context, path: `/chats/${scheduledThreadId}` });
 
     await waitFor(() => {
       expect(screen.getByText("Scheduled chat")).toBeInTheDocument();

--- a/turbo/apps/platform/src/views/zero-page/__tests__/sidebar-chat-delete.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/sidebar-chat-delete.test.tsx
@@ -259,13 +259,14 @@ describe("sidebar chat delete", () => {
       ),
     ).toBeInTheDocument();
 
-    // The linked schedules are listed by their description.
-    expect(
-      within(dialog).getByText("These schedules will be deleted"),
-    ).toBeInTheDocument();
+    // The linked schedules are fetched asynchronously and listed by their
+    // description once loaded.
     await waitFor(() => {
       expect(within(dialog).getByText("Morning briefing")).toBeInTheDocument();
     });
+    expect(
+      within(dialog).getByText("These schedules will be deleted"),
+    ).toBeInTheDocument();
     expect(within(dialog).getByText("Weekly report")).toBeInTheDocument();
   });
 

--- a/turbo/apps/platform/src/views/zero-page/__tests__/sidebar-chat-delete.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/sidebar-chat-delete.test.tsx
@@ -14,11 +14,9 @@ import {
   chatThreadsContract,
   chatThreadByIdContract,
 } from "@vm0/api-contracts/contracts/chat-threads";
+import { zeroSchedulesMainContract } from "@vm0/api-contracts/contracts/zero-schedules";
 import { createNewChatThreadOptimistically$ } from "../../../signals/chat-page/optimistic-chat-thread-page.ts";
-import {
-  createMockScheduleResponse,
-  setMockSchedules,
-} from "../../../mocks/handlers/api-schedules.ts";
+import { createMockScheduleResponse } from "../../../mocks/handlers/api-schedules.ts";
 
 const context = testContext();
 const mockApi = createMockApi(context);
@@ -184,22 +182,25 @@ describe("sidebar chat delete", () => {
       },
     ];
 
-    setMockSchedules([
-      createMockScheduleResponse({
-        id: "f0000001-0000-4000-a000-000000000010",
-        name: "morning-briefing",
-        description: "Morning briefing",
-        chatThreadId: "thread-scheduled",
-      }),
-      createMockScheduleResponse({
-        id: "f0000001-0000-4000-a000-000000000011",
-        name: "weekly-report",
-        description: "Weekly report",
-        chatThreadId: "thread-scheduled",
-      }),
-    ]);
-
     server.use(
+      mockApi(zeroSchedulesMainContract.list, ({ respond }) => {
+        return respond(200, {
+          schedules: [
+            createMockScheduleResponse({
+              id: "f0000001-0000-4000-a000-000000000010",
+              name: "morning-briefing",
+              description: "Morning briefing",
+              chatThreadId: "thread-scheduled",
+            }),
+            createMockScheduleResponse({
+              id: "f0000001-0000-4000-a000-000000000011",
+              name: "weekly-report",
+              description: "Weekly report",
+              chatThreadId: "thread-scheduled",
+            }),
+          ],
+        });
+      }),
       mockApi(chatThreadsContract.list, ({ respond }) => {
         return respond(200, splitChatThreadListResponse(threads));
       }),

--- a/turbo/apps/platform/src/views/zero-page/sidebar-threads.tsx
+++ b/turbo/apps/platform/src/views/zero-page/sidebar-threads.tsx
@@ -78,7 +78,10 @@ import {
 } from "../../signals/chat-page/sidebar-chat-threads-pagination.ts";
 import { pathParams$, searchParams$ } from "../../signals/route.ts";
 import { setSidebarExpanded$ } from "../../signals/zero-page/zero-nav.ts";
-import { pendingDeleteThreadSchedules$ } from "../../signals/chat-page/header-schedule-menu.ts";
+import {
+  headerScheduleMenu$,
+  schedulesForThread,
+} from "../../signals/chat-page/header-schedule-menu.ts";
 import {
   pendingDeleteThreadId$,
   setPendingDeleteThreadId$,
@@ -624,8 +627,12 @@ function DeleteChatThreadDialog() {
   const deleteChatThread = useSet(deleteChatThread$);
   const pageSignal = useGet(pageSignal$);
   const chatThreads = useLastResolved(sidebarChatThreads$) ?? [];
-  const pendingDeleteSchedules =
-    useLastResolved(pendingDeleteThreadSchedules$) ?? [];
+  const schedulesLoadable = useLastLoadable(headerScheduleMenu$);
+  const lastResolvedSchedules = useLastResolved(headerScheduleMenu$);
+  const allSchedules =
+    schedulesLoadable.state === "hasData"
+      ? schedulesLoadable.data
+      : (lastResolvedSchedules ?? []);
 
   const pendingDeleteThread = pendingDeleteThreadId
     ? chatThreads.find((thread) => {
@@ -634,6 +641,9 @@ function DeleteChatThreadDialog() {
     : null;
   const scheduleCount = pendingDeleteThread?.scheduleCount ?? 0;
   const hasSchedules = scheduleCount > 0;
+  const pendingDeleteSchedules = pendingDeleteThreadId
+    ? schedulesForThread(allSchedules, pendingDeleteThreadId)
+    : [];
 
   function confirmDelete() {
     if (!pendingDeleteThreadId) {

--- a/turbo/apps/platform/src/views/zero-page/sidebar-threads.tsx
+++ b/turbo/apps/platform/src/views/zero-page/sidebar-threads.tsx
@@ -78,6 +78,7 @@ import {
 } from "../../signals/chat-page/sidebar-chat-threads-pagination.ts";
 import { pathParams$, searchParams$ } from "../../signals/route.ts";
 import { setSidebarExpanded$ } from "../../signals/zero-page/zero-nav.ts";
+import { pendingDeleteThreadSchedules$ } from "../../signals/chat-page/header-schedule-menu.ts";
 import {
   pendingDeleteThreadId$,
   setPendingDeleteThreadId$,
@@ -646,6 +647,8 @@ function ChatThreads() {
     : null;
   const pendingDeleteScheduleCount = pendingDeleteThread?.scheduleCount ?? 0;
   const pendingDeleteHasSchedules = pendingDeleteScheduleCount > 0;
+  const pendingDeleteSchedules =
+    useLastResolved(pendingDeleteThreadSchedules$) ?? [];
 
   function handleLoadMore() {
     if (!cursorForLoadMore || loadingMore) {
@@ -700,12 +703,31 @@ function ChatThreads() {
             </DialogTitle>
             <DialogDescription>
               {pendingDeleteHasSchedules
-                ? `This will permanently delete this chat and ${pendingDeleteScheduleCount} linked ${
+                ? `This will permanently delete this chat and its ${pendingDeleteScheduleCount} linked ${
                     pendingDeleteScheduleCount === 1 ? "schedule" : "schedules"
-                  }. This action cannot be undone.`
-                : "This will permanently delete this chat. This action cannot be undone."}
+                  }. Any task currently running in this chat will be stopped immediately. This action cannot be undone.`
+                : "This will permanently delete this chat. Any task currently running in this chat will be stopped immediately. This action cannot be undone."}
             </DialogDescription>
           </DialogHeader>
+          {pendingDeleteHasSchedules && pendingDeleteSchedules.length > 0 && (
+            <div className="flex flex-col gap-1.5">
+              <p className="text-sm font-medium">
+                These schedules will be deleted
+              </p>
+              <ul className="flex list-disc flex-col gap-1 pl-5">
+                {pendingDeleteSchedules.map((schedule) => {
+                  return (
+                    <li
+                      key={schedule.id}
+                      className="break-words text-sm text-muted-foreground"
+                    >
+                      {schedule.title}
+                    </li>
+                  );
+                })}
+              </ul>
+            </div>
+          )}
           <DialogFooter>
             <Button
               variant="outline"

--- a/turbo/apps/platform/src/views/zero-page/sidebar-threads.tsx
+++ b/turbo/apps/platform/src/views/zero-page/sidebar-threads.tsx
@@ -618,10 +618,92 @@ function LoadMoreThreadsButton({
   );
 }
 
-function ChatThreads() {
+function DeleteChatThreadDialog() {
   const pendingDeleteThreadId = useGet(pendingDeleteThreadId$);
   const setPendingDeleteThreadId = useSet(setPendingDeleteThreadId$);
   const deleteChatThread = useSet(deleteChatThread$);
+  const pageSignal = useGet(pageSignal$);
+  const chatThreads = useLastResolved(sidebarChatThreads$) ?? [];
+  const pendingDeleteSchedules =
+    useLastResolved(pendingDeleteThreadSchedules$) ?? [];
+
+  const pendingDeleteThread = pendingDeleteThreadId
+    ? chatThreads.find((thread) => {
+        return thread.id === pendingDeleteThreadId;
+      })
+    : null;
+  const scheduleCount = pendingDeleteThread?.scheduleCount ?? 0;
+  const hasSchedules = scheduleCount > 0;
+
+  function confirmDelete() {
+    if (!pendingDeleteThreadId) {
+      return;
+    }
+    const threadId = pendingDeleteThreadId;
+    setPendingDeleteThreadId(null);
+    detach(deleteChatThread(threadId, pageSignal), Reason.DomCallback);
+  }
+
+  return (
+    <Dialog
+      open={pendingDeleteThreadId !== null}
+      onOpenChange={(open) => {
+        if (!open) {
+          setPendingDeleteThreadId(null);
+        }
+      }}
+    >
+      <DialogContent>
+        <DialogHeader>
+          <DialogTitle>
+            {hasSchedules ? "Delete chat and schedules?" : "Delete chat?"}
+          </DialogTitle>
+          <DialogDescription>
+            {hasSchedules
+              ? `This will permanently delete this chat and its ${scheduleCount} linked ${
+                  scheduleCount === 1 ? "schedule" : "schedules"
+                }. Any task currently running in this chat will be stopped immediately. This action cannot be undone.`
+              : "This will permanently delete this chat. Any task currently running in this chat will be stopped immediately. This action cannot be undone."}
+          </DialogDescription>
+        </DialogHeader>
+        {hasSchedules && pendingDeleteSchedules.length > 0 && (
+          <div className="flex flex-col gap-1.5">
+            <p className="text-sm font-medium">
+              These schedules will be deleted
+            </p>
+            <ul className="flex list-disc flex-col gap-1 pl-5">
+              {pendingDeleteSchedules.map((schedule) => {
+                return (
+                  <li
+                    key={schedule.id}
+                    className="break-words text-sm text-muted-foreground"
+                  >
+                    {schedule.title}
+                  </li>
+                );
+              })}
+            </ul>
+          </div>
+        )}
+        <DialogFooter>
+          <Button
+            variant="outline"
+            onClick={() => {
+              setPendingDeleteThreadId(null);
+            }}
+          >
+            Cancel
+          </Button>
+          <Button variant="destructive" onClick={confirmDelete}>
+            {hasSchedules ? "Delete chat and schedules" : "Delete"}
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
+}
+
+function ChatThreads() {
   const pageSignal = useGet(pageSignal$);
 
   const chatThreads = useLastResolved(sidebarChatThreads$) ?? [];
@@ -640,30 +722,12 @@ function ChatThreads() {
   const cursorForLoadMore = hasLoadedExtraPages
     ? extraLatestCursor
     : firstPageNextCursor;
-  const pendingDeleteThread = pendingDeleteThreadId
-    ? chatThreads.find((thread) => {
-        return thread.id === pendingDeleteThreadId;
-      })
-    : null;
-  const pendingDeleteScheduleCount = pendingDeleteThread?.scheduleCount ?? 0;
-  const pendingDeleteHasSchedules = pendingDeleteScheduleCount > 0;
-  const pendingDeleteSchedules =
-    useLastResolved(pendingDeleteThreadSchedules$) ?? [];
 
   function handleLoadMore() {
     if (!cursorForLoadMore || loadingMore) {
       return;
     }
     detach(loadMore(cursorForLoadMore, pageSignal), Reason.DomCallback);
-  }
-
-  function confirmDelete() {
-    if (!pendingDeleteThreadId) {
-      return;
-    }
-    const threadId = pendingDeleteThreadId;
-    setPendingDeleteThreadId(null);
-    detach(deleteChatThread(threadId, pageSignal), Reason.DomCallback);
   }
 
   if (chatThreads.length === 0) {
@@ -686,65 +750,7 @@ function ChatThreads() {
         />
       )}
       <ChatThreadRenameDialog />
-      <Dialog
-        open={pendingDeleteThreadId !== null}
-        onOpenChange={(open) => {
-          if (!open) {
-            setPendingDeleteThreadId(null);
-          }
-        }}
-      >
-        <DialogContent>
-          <DialogHeader>
-            <DialogTitle>
-              {pendingDeleteHasSchedules
-                ? "Delete chat and schedules?"
-                : "Delete chat?"}
-            </DialogTitle>
-            <DialogDescription>
-              {pendingDeleteHasSchedules
-                ? `This will permanently delete this chat and its ${pendingDeleteScheduleCount} linked ${
-                    pendingDeleteScheduleCount === 1 ? "schedule" : "schedules"
-                  }. Any task currently running in this chat will be stopped immediately. This action cannot be undone.`
-                : "This will permanently delete this chat. Any task currently running in this chat will be stopped immediately. This action cannot be undone."}
-            </DialogDescription>
-          </DialogHeader>
-          {pendingDeleteHasSchedules && pendingDeleteSchedules.length > 0 && (
-            <div className="flex flex-col gap-1.5">
-              <p className="text-sm font-medium">
-                These schedules will be deleted
-              </p>
-              <ul className="flex list-disc flex-col gap-1 pl-5">
-                {pendingDeleteSchedules.map((schedule) => {
-                  return (
-                    <li
-                      key={schedule.id}
-                      className="break-words text-sm text-muted-foreground"
-                    >
-                      {schedule.title}
-                    </li>
-                  );
-                })}
-              </ul>
-            </div>
-          )}
-          <DialogFooter>
-            <Button
-              variant="outline"
-              onClick={() => {
-                setPendingDeleteThreadId(null);
-              }}
-            >
-              Cancel
-            </Button>
-            <Button variant="destructive" onClick={confirmDelete}>
-              {pendingDeleteHasSchedules
-                ? "Delete chat and schedules"
-                : "Delete"}
-            </Button>
-          </DialogFooter>
-        </DialogContent>
-      </Dialog>
+      <DeleteChatThreadDialog />
     </>
   );
 }


### PR DESCRIPTION
## Problem

Deleting a chat thread only deleted its linked schedules and the thread
row. In-flight runs were left running: `zero_runs.chatThreadId` is
`ON DELETE SET NULL`, so a running run simply lost its thread reference
and kept executing and consuming credits after the thread was gone.

## Change

`deleteChatThread$` now tears the thread down in the intended order:

1. **Stop related schedules** — deleted first so none can spawn a fresh
   run while we cancel the in-flight ones.
2. **Stop related runs** — active (`queued`/`pending`/`running`) runs
   linked to the thread are cancelled via the existing `cancelRun$`
   (status → `cancelled`, queue/job-queue rows removed). Terminal runs
   (`completed`/`failed`/`cancelled`) are left untouched.
3. **Delete the thread** — last, cascading `chat_messages`.

Ownership is verified up front. Because `cancelRun$` opens its own
transaction and the runner must be notified, the cancelled-run results
are returned to the route, which dispatches the post-cancel side effects
(runner halt, `queue:changed` / `runChanged` signals, queue drain,
credit reconciliation) on the detached `waitUntil` path — mirroring the
existing `POST /runs/:id/cancel` route.

## Tests

Added integration tests to `zero-chat-threads-delete.test.ts`:

- cancels in-flight runs linked to the deleted thread (DB status +
  `runChanged` / `queue:changed` publishes)
- leaves terminal runs untouched
- only cancels runs of the thread being deleted (sibling thread's run
  keeps running)

Existing delete-behavior tests (schedule cascade, ownership 404,
`threadListChanged` published once, malformed UUID) are unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
