### PR TITLE
perf: route internal callback dispatch via internal api base url

### DIFF
--- a/turbo/apps/api/src/lib/__tests__/internal-api-url.test.ts
+++ b/turbo/apps/api/src/lib/__tests__/internal-api-url.test.ts
@@ -6,9 +6,9 @@ import { internalApiBaseUrl } from "../internal-api-url";
 // Mocked env is reset after each test by the shared test setup
 // (src/__tests__/setup.ts calls clearMockedEnv in afterEach).
 describe("internalApiBaseUrl", () => {
-  it("uses VM0_INTERNAL_API_URL when set so internal callbacks skip www", () => {
+  it("uses VM0_API_BACKEND_URL when set so internal callbacks skip www", () => {
     mockEnv("VM0_API_URL", "https://www.vm0.ai");
-    mockEnv("VM0_INTERNAL_API_URL", "https://api.vm0.ai");
+    mockEnv("VM0_API_BACKEND_URL", "https://api.vm0.ai");
 
     expect(internalApiBaseUrl()).toBe("https://api.vm0.ai");
     expect(
@@ -16,14 +16,18 @@ describe("internalApiBaseUrl", () => {
     ).toBe("https://api.vm0.ai/api/internal/callbacks/chat");
   });
 
-  it("falls back to VM0_API_URL when VM0_INTERNAL_API_URL is unset", () => {
+  it("defaults to the API backend origin in production when VM0_API_BACKEND_URL is unset", () => {
+    mockEnv("ENV", "production");
     mockEnv("VM0_API_URL", "https://www.vm0.ai");
+    mockEnv("VM0_API_BACKEND_URL", undefined);
 
-    expect(internalApiBaseUrl()).toBe("https://www.vm0.ai");
+    expect(internalApiBaseUrl()).toBe("https://vm0-api.vm6.ai");
   });
 
-  it("falls back to a dev tunnel VM0_API_URL when unset", () => {
+  it("falls back to VM0_API_URL outside production when VM0_API_BACKEND_URL is unset", () => {
+    mockEnv("ENV", "development");
     mockEnv("VM0_API_URL", "https://tunnel-abc.vm0.dev");
+    mockEnv("VM0_API_BACKEND_URL", undefined);
 
     expect(internalApiBaseUrl()).toBe("https://tunnel-abc.vm0.dev");
   });

--- a/turbo/apps/api/src/lib/__tests__/internal-api-url.test.ts
+++ b/turbo/apps/api/src/lib/__tests__/internal-api-url.test.ts
@@ -1,0 +1,30 @@
+import { describe, expect, it } from "vitest";
+
+import { mockEnv } from "../env";
+import { internalApiBaseUrl } from "../internal-api-url";
+
+// Mocked env is reset after each test by the shared test setup
+// (src/__tests__/setup.ts calls clearMockedEnv in afterEach).
+describe("internalApiBaseUrl", () => {
+  it("uses VM0_INTERNAL_API_URL when set so internal callbacks skip www", () => {
+    mockEnv("VM0_API_URL", "https://www.vm0.ai");
+    mockEnv("VM0_INTERNAL_API_URL", "https://api.vm0.ai");
+
+    expect(internalApiBaseUrl()).toBe("https://api.vm0.ai");
+    expect(
+      new URL("/api/internal/callbacks/chat", internalApiBaseUrl()).toString(),
+    ).toBe("https://api.vm0.ai/api/internal/callbacks/chat");
+  });
+
+  it("falls back to VM0_API_URL when VM0_INTERNAL_API_URL is unset", () => {
+    mockEnv("VM0_API_URL", "https://www.vm0.ai");
+
+    expect(internalApiBaseUrl()).toBe("https://www.vm0.ai");
+  });
+
+  it("falls back to a dev tunnel VM0_API_URL when unset", () => {
+    mockEnv("VM0_API_URL", "https://tunnel-abc.vm0.dev");
+
+    expect(internalApiBaseUrl()).toBe("https://tunnel-abc.vm0.dev");
+  });
+});

--- a/turbo/apps/api/src/lib/env.ts
+++ b/turbo/apps/api/src/lib/env.ts
@@ -25,10 +25,11 @@ const SCHEMA = {
   VERCEL_AUTOMATION_BYPASS_SECRET: z.string().min(1).optional(),
   VM0_API_URL: z.url(),
   // Direct origin of the API backend for self-dispatched internal callbacks
-  // (`/api/internal/**`). Optional; when unset it falls back to VM0_API_URL.
-  // In production set this to the API backend origin (not www) so internal
-  // callbacks do not hop through the web rewrite layer.
-  VM0_INTERNAL_API_URL: z.url().optional(),
+  // (`/api/internal/**`). Shared with the apps/web rewrite target, which reads
+  // the same var. Optional; when unset, production defaults to the API backend
+  // origin and other environments fall back to VM0_API_URL — so internal
+  // callbacks do not hop through the web rewrite layer at www.
+  VM0_API_BACKEND_URL: z.url().optional(),
   VM0_WEB_URL: z.url(),
   APP_URL: z.url(),
   RESEND_API_KEY: z.string().min(1).optional(),

--- a/turbo/apps/api/src/lib/env.ts
+++ b/turbo/apps/api/src/lib/env.ts
@@ -24,6 +24,11 @@ const SCHEMA = {
   VM0_DEBUG: z.string().default(""),
   VERCEL_AUTOMATION_BYPASS_SECRET: z.string().min(1).optional(),
   VM0_API_URL: z.url(),
+  // Direct origin of the API backend for self-dispatched internal callbacks
+  // (`/api/internal/**`). Optional; when unset it falls back to VM0_API_URL.
+  // In production set this to the API backend origin (not www) so internal
+  // callbacks do not hop through the web rewrite layer.
+  VM0_INTERNAL_API_URL: z.url().optional(),
   VM0_WEB_URL: z.url(),
   APP_URL: z.url(),
   RESEND_API_KEY: z.string().min(1).optional(),

--- a/turbo/apps/api/src/lib/internal-api-url.ts
+++ b/turbo/apps/api/src/lib/internal-api-url.ts
@@ -1,0 +1,19 @@
+import { env } from "./env";
+
+/**
+ * Base origin for API-originated internal self-dispatch callback URLs
+ * (`/api/internal/**`).
+ *
+ * Resolves to VM0_INTERNAL_API_URL when set, otherwise falls back to
+ * VM0_API_URL. In production VM0_API_URL is `https://www.vm0.ai`, which routes
+ * internal callbacks back through the web rewrite layer; setting
+ * VM0_INTERNAL_API_URL to the direct API backend origin removes that www
+ * self-call hop. When unset (dev/test/CI) the fallback keeps behavior
+ * unchanged, so the dev-tunnel rewrite in the callback dispatcher still applies.
+ *
+ * Use this only for internal self-dispatch URLs. User-provided / external
+ * callbacks and non-callback uses of VM0_API_URL must not be routed through it.
+ */
+export function internalApiBaseUrl(): string {
+  return env("VM0_INTERNAL_API_URL") ?? env("VM0_API_URL");
+}

--- a/turbo/apps/api/src/lib/internal-api-url.ts
+++ b/turbo/apps/api/src/lib/internal-api-url.ts
@@ -4,16 +4,24 @@ import { env } from "./env";
  * Base origin for API-originated internal self-dispatch callback URLs
  * (`/api/internal/**`).
  *
- * Resolves to VM0_INTERNAL_API_URL when set, otherwise falls back to
- * VM0_API_URL. In production VM0_API_URL is `https://www.vm0.ai`, which routes
- * internal callbacks back through the web rewrite layer; setting
- * VM0_INTERNAL_API_URL to the direct API backend origin removes that www
- * self-call hop. When unset (dev/test/CI) the fallback keeps behavior
- * unchanged, so the dev-tunnel rewrite in the callback dispatcher still applies.
+ * Resolves to VM0_API_BACKEND_URL — the direct API backend origin, the same var
+ * apps/web uses as its rewrite target. When unset, production defaults to the
+ * known API backend origin so internal callbacks never hop through the web
+ * rewrite layer at www.vm0.ai; other environments fall back to VM0_API_URL,
+ * keeping dev/test/CI behavior unchanged (the callback dispatcher's dev-tunnel
+ * rewrite still applies). This mirrors how apps/web resolves VM0_API_BACKEND_URL
+ * in next.config.js / env.ts.
  *
  * Use this only for internal self-dispatch URLs. User-provided / external
  * callbacks and non-callback uses of VM0_API_URL must not be routed through it.
  */
 export function internalApiBaseUrl(): string {
-  return env("VM0_INTERNAL_API_URL") ?? env("VM0_API_URL");
+  const backendUrl = env("VM0_API_BACKEND_URL");
+  if (backendUrl) {
+    return backendUrl;
+  }
+  if (env("ENV") === "production") {
+    return "https://vm0-api.vm6.ai";
+  }
+  return env("VM0_API_URL");
 }

--- a/turbo/apps/api/src/signals/routes/__tests__/zero-integrations-telegram-post.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/zero-integrations-telegram-post.test.ts
@@ -1278,6 +1278,51 @@ describe("POST /api/telegram/webhook/:telegramBotId", () => {
     expect(job).toBeDefined();
   });
 
+  it("stores the internal callback url on VM0_INTERNAL_API_URL when set", async () => {
+    mockEnv("VM0_API_URL", "https://www.vm0.ai");
+    mockEnv("VM0_INTERNAL_API_URL", "https://api.vm0.ai");
+    const fixture = await trackFixture(
+      store.set(
+        seedTelegramPostFixture$,
+        { linkTelegramUser: true },
+        context.signal,
+      ),
+    );
+    telegramApiMocks();
+
+    const response = await postWebhook({
+      telegramBotId: fixture.telegramBotId,
+      secret: fixture.webhookSecret,
+      body: {
+        update_id: 1,
+        message: {
+          message_id: 42,
+          chat: { id: 77_001, type: "private" },
+          from: {
+            id: Number(fixture.telegramUserId),
+            username: "alice",
+            first_name: "Alice",
+            language_code: "en",
+          },
+          text: "hello from telegram",
+        },
+      },
+    });
+    expect(response.status).toBe(200);
+    await clearAllDetached();
+
+    const run = await latestRunForFixture(fixture);
+    const db = store.set(writeDb$);
+    const [callback] = await db
+      .select()
+      .from(agentRunCallbacks)
+      .where(eq(agentRunCallbacks.runId, run!.id))
+      .limit(1);
+    expect(callback?.url).toBe(
+      "https://api.vm0.ai/api/internal/callbacks/telegram",
+    );
+  });
+
   it("formats generic failed callback errors for Telegram replies", async () => {
     const fixture = await trackFixture(
       store.set(

--- a/turbo/apps/api/src/signals/routes/__tests__/zero-integrations-telegram-post.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/zero-integrations-telegram-post.test.ts
@@ -1278,9 +1278,9 @@ describe("POST /api/telegram/webhook/:telegramBotId", () => {
     expect(job).toBeDefined();
   });
 
-  it("stores the internal callback url on VM0_INTERNAL_API_URL when set", async () => {
+  it("stores the internal callback url on VM0_API_BACKEND_URL when set", async () => {
     mockEnv("VM0_API_URL", "https://www.vm0.ai");
-    mockEnv("VM0_INTERNAL_API_URL", "https://api.vm0.ai");
+    mockEnv("VM0_API_BACKEND_URL", "https://api.vm0.ai");
     const fixture = await trackFixture(
       store.set(
         seedTelegramPostFixture$,

--- a/turbo/apps/api/src/signals/routes/internal-callbacks-chat.ts
+++ b/turbo/apps/api/src/signals/routes/internal-callbacks-chat.ts
@@ -36,7 +36,7 @@ import {
 } from "../../lib/callback-route/callback-route";
 import { waitForRunEventWatermarkVisible } from "../../lib/agent-event-visibility";
 import { escapeAplString } from "../../lib/axiom-apl";
-import { env } from "../../lib/env";
+import { internalApiBaseUrl } from "../../lib/internal-api-url";
 import { logger } from "../../lib/log";
 import { now, nowDate } from "../../lib/time";
 import type { RouteEntry } from "../route";
@@ -170,7 +170,10 @@ function generateCallbackSecret(): string {
 }
 
 function chatCallbackUrl(): string {
-  return new URL("/api/internal/callbacks/chat", env("VM0_API_URL")).toString();
+  return new URL(
+    "/api/internal/callbacks/chat",
+    internalApiBaseUrl(),
+  ).toString();
 }
 
 function parseModelProviderCredentialScope(

--- a/turbo/apps/api/src/signals/routes/zero-chat-messages.ts
+++ b/turbo/apps/api/src/signals/routes/zero-chat-messages.ts
@@ -46,6 +46,7 @@ import {
 } from "../../lib/error";
 import { env } from "../../lib/env";
 import { buildArtifactKey, sanitizeArtifactFilename } from "../../lib/file-url";
+import { internalApiBaseUrl } from "../../lib/internal-api-url";
 import type { AuthContext } from "../../types/auth";
 import { createZeroRun$ } from "../services/zero-runs-create.service";
 import {
@@ -420,7 +421,10 @@ function generateCallbackSecret(): string {
 }
 
 function chatCallbackUrl(): string {
-  return new URL("/api/internal/callbacks/chat", env("VM0_API_URL")).toString();
+  return new URL(
+    "/api/internal/callbacks/chat",
+    internalApiBaseUrl(),
+  ).toString();
 }
 
 function buildWebChatPrompt(): string {

--- a/turbo/apps/api/src/signals/services/chat-thread-v1-send.service.ts
+++ b/turbo/apps/api/src/signals/services/chat-thread-v1-send.service.ts
@@ -8,8 +8,8 @@ import { orgMetadata } from "@vm0/db/schema/org-metadata";
 import { zeroRuns } from "@vm0/db/schema/zero-run";
 import { and, desc, eq } from "drizzle-orm";
 
-import { env } from "../../lib/env";
 import { badRequestMessage, notFound } from "../../lib/error";
+import { internalApiBaseUrl } from "../../lib/internal-api-url";
 import type { AuthContext } from "../../types/auth";
 import { writeDb$, type Db } from "../external/db";
 import {
@@ -48,7 +48,10 @@ function generateCallbackSecret(): string {
 }
 
 function chatCallbackUrl(): string {
-  return new URL("/api/internal/callbacks/chat", env("VM0_API_URL")).toString();
+  return new URL(
+    "/api/internal/callbacks/chat",
+    internalApiBaseUrl(),
+  ).toString();
 }
 
 export const sendChatThreadMessageV1$ = command(

--- a/turbo/apps/api/src/signals/services/webhooks-github.service.ts
+++ b/turbo/apps/api/src/signals/services/webhooks-github.service.ts
@@ -17,6 +17,7 @@ import { and, asc, eq } from "drizzle-orm";
 import { z } from "zod";
 
 import { env, optionalEnv } from "../../lib/env";
+import { internalApiBaseUrl } from "../../lib/internal-api-url";
 import { logger } from "../../lib/log";
 import { writeDb$, type Db } from "../external/db";
 import { publishUserSignal } from "../external/realtime";
@@ -1075,7 +1076,7 @@ const runAgentForGitHub$ = command(
         selectedModelOverride: args.modelRoute?.selectedModel,
         callbacks: [
           {
-            url: `${env("VM0_API_URL")}/api/internal/callbacks/github/issues`,
+            url: `${internalApiBaseUrl()}/api/internal/callbacks/github/issues`,
             secret: generateCallbackSecret(),
             payload: args.callbackPayload,
           },

--- a/turbo/apps/api/src/signals/services/zero-agentphone.service.ts
+++ b/turbo/apps/api/src/signals/services/zero-agentphone.service.ts
@@ -28,6 +28,7 @@ import { agentphoneUserLinks } from "@vm0/db/schema/agentphone-user-link";
 import { and, desc, eq, isNotNull } from "drizzle-orm";
 
 import { env, optionalEnv } from "../../lib/env";
+import { internalApiBaseUrl } from "../../lib/internal-api-url";
 import { inferMimetype } from "../../lib/mimetype";
 import { logger } from "../../lib/log";
 import { now, nowDate } from "../external/time";
@@ -1926,7 +1927,7 @@ const runAgentForAgentPhone$ = command(
         selectedModelOverride: args.modelRoute?.selectedModel,
         callbacks: [
           {
-            url: `${env("VM0_API_URL")}/api/internal/callbacks/agentphone`,
+            url: `${internalApiBaseUrl()}/api/internal/callbacks/agentphone`,
             secret: randomBytes(32).toString("hex"),
             payload: args.callbackContext,
           },

--- a/turbo/apps/api/src/signals/services/zero-runs-create.service.ts
+++ b/turbo/apps/api/src/signals/services/zero-runs-create.service.ts
@@ -26,8 +26,8 @@ import { command } from "ccstate";
 import { and, eq } from "drizzle-orm";
 import type { z } from "zod";
 
-import { env } from "../../lib/env";
 import { badRequestMessage, notFound } from "../../lib/error";
+import { internalApiBaseUrl } from "../../lib/internal-api-url";
 import type { AuthContext } from "../../types/auth";
 import { writeDb$, type Db } from "../external/db";
 import { createAgentRun$ } from "./agent-run-create.service";
@@ -111,10 +111,6 @@ function forbidden(message: string) {
       },
     },
   };
-}
-
-function apiUrl(): string {
-  return env("VM0_API_URL");
 }
 
 function generateCallbackSecret(): string {
@@ -550,7 +546,7 @@ function callbacksForTriggerAgent(triggerAgentId: string | undefined) {
   return triggerAgentId
     ? [
         {
-          url: `${apiUrl()}/api/internal/callbacks/agent`,
+          url: `${internalApiBaseUrl()}/api/internal/callbacks/agent`,
           secret: generateCallbackSecret(),
           payload: { triggerAgentId },
         },

--- a/turbo/apps/api/src/signals/services/zero-schedules.service.ts
+++ b/turbo/apps/api/src/signals/services/zero-schedules.service.ts
@@ -27,7 +27,8 @@ import { Cron } from "croner";
 import { and, eq, inArray, lte } from "drizzle-orm";
 import { z } from "zod";
 
-import { env, optionalEnv } from "../../lib/env";
+import { optionalEnv } from "../../lib/env";
+import { internalApiBaseUrl } from "../../lib/internal-api-url";
 import { logger } from "../../lib/log";
 import { db$, writeDb$, type Db } from "../external/db";
 import { now, nowDate } from "../external/time";
@@ -1211,10 +1212,6 @@ function buildSchedulePrompt(triggerType: string): string {
   ].join("\n");
 }
 
-function apiUrl(): string {
-  return env("VM0_API_URL");
-}
-
 function generateCallbackSecret(): string {
   return randomBytes(32).toString("hex");
 }
@@ -1227,7 +1224,7 @@ function buildScheduleCallbacks(
   if (schedule.triggerType === "loop") {
     const payload: ScheduleLoopCallbackPayload = { scheduleId: schedule.id };
     callbacks.push({
-      url: `${apiUrl()}/api/internal/callbacks/schedule/loop`,
+      url: `${internalApiBaseUrl()}/api/internal/callbacks/schedule/loop`,
       secret: generateCallbackSecret(),
       payload,
     });
@@ -1243,7 +1240,7 @@ function buildScheduleCallbacks(
       timezone: schedule.timezone,
     };
     callbacks.push({
-      url: `${apiUrl()}/api/internal/callbacks/schedule/cron`,
+      url: `${internalApiBaseUrl()}/api/internal/callbacks/schedule/cron`,
       secret: generateCallbackSecret(),
       payload,
     });
@@ -1255,7 +1252,7 @@ function buildScheduleCallbacks(
   // callback writes the run summary (D9), so callback dispatch order is safe.
   if (isChatMode(schedule)) {
     callbacks.push({
-      url: `${apiUrl()}/api/internal/callbacks/chat`,
+      url: `${internalApiBaseUrl()}/api/internal/callbacks/chat`,
       secret: generateCallbackSecret(),
       payload: { threadId: schedule.chatThreadId, agentId: schedule.agentId },
     });

--- a/turbo/apps/api/src/signals/services/zero-slack-webhooks.service.ts
+++ b/turbo/apps/api/src/signals/services/zero-slack-webhooks.service.ts
@@ -26,6 +26,7 @@ import { and, eq } from "drizzle-orm";
 import type { z } from "zod";
 
 import { env, optionalEnv } from "../../lib/env";
+import { internalApiBaseUrl } from "../../lib/internal-api-url";
 import { logger } from "../../lib/log";
 import {
   getSlackSignatureHeaders,
@@ -1071,7 +1072,7 @@ const runAgentForSlackOrg$ = command(
         selectedModelOverride: params.selectedModelOverride,
         callbacks: [
           {
-            url: `${env("VM0_API_URL")}/api/internal/callbacks/slack/org`,
+            url: `${internalApiBaseUrl()}/api/internal/callbacks/slack/org`,
             secret: generateCallbackSecret(),
             payload: params.callbackContext,
           },

--- a/turbo/apps/api/src/signals/services/zero-telegram-dispatch.service.ts
+++ b/turbo/apps/api/src/signals/services/zero-telegram-dispatch.service.ts
@@ -14,6 +14,7 @@ import { telegramUserLinks } from "@vm0/db/schema/telegram-user-link";
 import { zeroAgents } from "@vm0/db/schema/zero-agent";
 
 import { env } from "../../lib/env";
+import { internalApiBaseUrl } from "../../lib/internal-api-url";
 import { logger } from "../../lib/log";
 import {
   buildTelegramErrorResponse,
@@ -909,7 +910,7 @@ const runAgentForTelegram$ = command(
         userInfoExtras: args.userInfoExtras,
         callbacks: [
           {
-            url: `${env("VM0_API_URL")}/api/internal/callbacks/telegram`,
+            url: `${internalApiBaseUrl()}/api/internal/callbacks/telegram`,
             secret: randomBytes(32).toString("hex"),
             payload: args.callbackPayload,
           },

--- a/turbo/apps/api/src/signals/services/zero-telegram-post.service.ts
+++ b/turbo/apps/api/src/signals/services/zero-telegram-post.service.ts
@@ -32,6 +32,7 @@ import {
   escapeHtml,
 } from "../../lib/telegram-format";
 import { env } from "../../lib/env";
+import { internalApiBaseUrl } from "../../lib/internal-api-url";
 import { logger } from "../../lib/log";
 import { bodyResultOf, pathParamsOf } from "../context/request";
 import { request$ } from "../context/hono";
@@ -1752,7 +1753,7 @@ const runAgentForTelegram$ = command(
         selectedModelOverride: args.modelRoute?.selectedModel,
         callbacks: [
           {
-            url: `${env("VM0_API_URL")}/api/internal/callbacks/telegram`,
+            url: `${internalApiBaseUrl()}/api/internal/callbacks/telegram`,
             secret: generateCallbackSecret(),
             payload: args.callbackPayload,
           },


### PR DESCRIPTION
## Summary

API code builds internal callback URLs (`/api/internal/callbacks/*`) from `VM0_API_URL`, which in production is `https://www.vm0.ai`. Those URLs are persisted on `agentRunCallbacks.url` and later dispatched, hopping through the `apps/web` rewrite layer back to the API backend — a www self-call.

This PR removes that hop for API-originated internal callbacks by reusing the existing `VM0_API_BACKEND_URL` (the direct API backend origin that `apps/web` already rewrites to):

- Adds the **optional** `VM0_API_BACKEND_URL` to the API env schema (`turbo/apps/api/src/lib/env.ts`). It is the same var `apps/web` reads and is already listed in `turbo.json` `globalEnv`, so there is no second knob to keep in sync.
- Adds a single shared helper `internalApiBaseUrl()` (`turbo/apps/api/src/lib/internal-api-url.ts`) — the one source of truth for the internal self-dispatch base. It mirrors how `apps/web` resolves the var: use `VM0_API_BACKEND_URL` when set; when unset, **default to the API backend origin in production** (`https://vm0-api.vm6.ai`) so internal callbacks skip www even without explicit config; otherwise fall back to `VM0_API_URL`.
- Replaces every producer that built an internal `/api/internal/callbacks/*` URL from `VM0_API_URL` with the helper, keeping the path strings byte-for-byte identical. The duplicated inline `apiUrl()` wrappers in `zero-schedules.service.ts` and `zero-runs-create.service.ts` were folded into the shared helper.

Net effect: in production, internal callbacks resolve to the direct API backend origin (not www) — by default, no new infra config required. In dev/test/CI (`ENV` ≠ production, var unset) behavior is unchanged.

### Producers updated
- `signals/services/zero-schedules.service.ts` (schedule/loop, schedule/cron, chat)
- `signals/services/zero-runs-create.service.ts` (agent)
- `signals/services/chat-thread-v1-send.service.ts` (chat)
- `signals/routes/zero-chat-messages.ts` (chat)
- `signals/routes/internal-callbacks-chat.ts` (chat)
- `signals/services/zero-telegram-post.service.ts` (telegram)
- `signals/services/zero-telegram-dispatch.service.ts` (telegram)
- `signals/services/zero-slack-webhooks.service.ts` (slack/org)
- `signals/services/webhooks-github.service.ts` (github/issues)
- `signals/services/zero-agentphone.service.ts` (agentphone)

### Left untouched (out of scope)
- **External / user-provided callback dispatch** — `agent-run-callback.service.ts` and `agent-run-callbacks.service.ts` still dispatch the stored URL to customer endpoints. Their `resolveCallbackUrl` dev-tunnel rewrite is unchanged; because the helper falls back to `VM0_API_URL` outside production, a stored internal URL still resolves correctly for dev/tunnel.
- `agent-webhook-events.service.ts` — owned by #16286 (event consumers → in-process); its `resolveBaseUrl` was not consolidated here.
- Non-callback `VM0_API_URL` uses (email unsubscribe, telegram-avatar, built-in generation provider webhooks, zero-email-common, user-export).

## Acceptance criteria addressed
- (a) Production builds internal callback URLs on the API backend origin (not www) — covered by a new helper test (production default) and an end-to-end producer test asserting the stored `agentRunCallbacks.url` when `VM0_API_BACKEND_URL` is set.
- (b) When `VM0_API_BACKEND_URL` is unset outside production it falls back to `VM0_API_URL` — covered by the helper test and the unchanged existing producer/route tests (which only set `VM0_API_URL`).
- (c) External / user-provided callback URLs are unchanged — the external dispatchers are untouched; existing external-callback tests still assert the stored URL verbatim.
- (d) Dev/tunnel behavior preserved — the dispatcher's `resolveCallbackUrl` tunnel→localhost rewrite is unchanged; the helper falls back to `VM0_API_URL` (the tunnel origin) outside production.

## Tests
- `turbo/apps/api/src/lib/__tests__/internal-api-url.test.ts` — proves: set → API backend origin; unset + `ENV=production` → `https://vm0-api.vm6.ai`; unset outside production → `VM0_API_URL` (incl. a dev-tunnel origin).
- `turbo/apps/api/src/signals/routes/__tests__/zero-integrations-telegram-post.test.ts` — a producer stores the API-backend-origin URL when `VM0_API_BACKEND_URL` is set while `VM0_API_URL` is www.
- All other existing internal-callback tests are unchanged on purpose: they run with `ENV=development` (env-stub default), set `VM0_API_URL=http://localhost:3000`, and leave `VM0_API_BACKEND_URL` unset, so the fallback keeps stored URLs identical — the migration is behavior-preserving outside production. Verified no existing `ENV=production` test asserts a callback `url`.

## Note on local verification
Local `pnpm` / `vitest` / `pnpm check-types` were **NOT** run in this worktree (no `node_modules`). CI is authoritative for lint, typecheck, and tests.

Part of #16256

🤖 Generated with [Claude Code](https://claude.com/claude-code)
