### PR TITLE
fix: remove auto memory generated provenance

### DIFF
--- a/turbo/apps/api/src/signals/routes/__tests__/webhooks-agent-checkpoints.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/webhooks-agent-checkpoints.test.ts
@@ -595,30 +595,6 @@ describe("POST /api/webhooks/agent/checkpoints", () => {
         name: "artifact-c",
         version: "version-ccc",
         mountPath: "/workspace/c",
-        generatedBy: "apiAutoMemory" as const,
-      },
-    ];
-    const persistedArtifactSnapshots = [
-      {
-        name: "artifact-a",
-        version: "version-aaa",
-        mountPath: "/workspace/a",
-      },
-      {
-        name: "memory",
-        version: "version-bbb",
-        mountPath: CANONICAL_CLAUDE_MEMORY_MOUNT_PATH,
-        missingRootPolicy: "preserveParentVersion",
-      },
-      {
-        name: "memory",
-        version: "version-codex",
-        mountPath: CANONICAL_CODEX_MEMORY_MOUNT_PATH,
-      },
-      {
-        name: "artifact-c",
-        version: "version-ccc",
-        mountPath: "/workspace/c",
       },
     ];
     const body = {
@@ -636,12 +612,10 @@ describe("POST /api/webhooks/agent/checkpoints", () => {
       {
         name: "memory",
         mountPath: CANONICAL_CLAUDE_MEMORY_MOUNT_PATH,
-        generatedBy: "apiAutoMemory" as const,
       },
       {
         name: "memory",
         mountPath: CANONICAL_CODEX_MEMORY_MOUNT_PATH,
-        generatedBy: "apiAutoMemory" as const,
       },
     ];
     await db
@@ -666,9 +640,7 @@ describe("POST /api/webhooks/agent/checkpoints", () => {
       .from(checkpoints)
       .where(eq(checkpoints.id, response.body.checkpointId))
       .limit(1);
-    expect(checkpoint?.artifactSnapshots).toStrictEqual(
-      persistedArtifactSnapshots,
-    );
+    expect(checkpoint?.artifactSnapshots).toStrictEqual(artifactSnapshots);
     const [session] = await db
       .select({ artifacts: agentSessions.artifacts })
       .from(agentSessions)
@@ -677,14 +649,14 @@ describe("POST /api/webhooks/agent/checkpoints", () => {
     expect(session?.artifacts).toStrictEqual(originalSessionArtifacts);
   });
 
-  it("strips canonical memory provenance from stored checkpoint snapshots", async () => {
+  it("strips unknown artifact snapshot fields while preserving policy", async () => {
     const fixture = await track(seedFixture());
     const artifactSnapshots = [
       {
         name: "memory",
         version: "version-bbb",
         mountPath: CANONICAL_CLAUDE_MEMORY_MOUNT_PATH,
-        generatedBy: "apiAutoMemory" as const,
+        legacyProvenance: "old-agent" as const,
         missingRootPolicy: "preserveParentVersion" as const,
       },
     ];
@@ -701,7 +673,16 @@ describe("POST /api/webhooks/agent/checkpoints", () => {
       [200],
     );
 
-    expect(response.body.artifacts).toStrictEqual(artifactSnapshots);
+    const sanitizedArtifactSnapshots = [
+      {
+        name: "memory",
+        version: "version-bbb",
+        mountPath: CANONICAL_CLAUDE_MEMORY_MOUNT_PATH,
+        missingRootPolicy: "preserveParentVersion",
+      },
+    ];
+
+    expect(response.body.artifacts).toStrictEqual(sanitizedArtifactSnapshots);
 
     const db = store.set(writeDb$);
     const [checkpoint] = await db
@@ -709,14 +690,9 @@ describe("POST /api/webhooks/agent/checkpoints", () => {
       .from(checkpoints)
       .where(eq(checkpoints.id, response.body.checkpointId))
       .limit(1);
-    expect(checkpoint?.artifactSnapshots).toStrictEqual([
-      {
-        name: "memory",
-        version: "version-bbb",
-        mountPath: CANONICAL_CLAUDE_MEMORY_MOUNT_PATH,
-        missingRootPolicy: "preserveParentVersion",
-      },
-    ]);
+    expect(checkpoint?.artifactSnapshots).toStrictEqual(
+      sanitizedArtifactSnapshots,
+    );
   });
 
   it("creates independent sessions for separate runs", async () => {

--- a/turbo/apps/api/src/signals/services/agent-run-create.service.ts
+++ b/turbo/apps/api/src/signals/services/agent-run-create.service.ts
@@ -191,7 +191,6 @@ interface ContextArtifact {
   readonly version?: string;
   readonly mountPath: string;
   readonly missingRootPolicy?: ArtifactMissingRootPolicy;
-  readonly generatedBy?: "apiAutoMemory";
 }
 
 interface RunArtifacts {

--- a/turbo/packages/api-contracts/src/contracts/webhooks.ts
+++ b/turbo/packages/api-contracts/src/contracts/webhooks.ts
@@ -162,9 +162,6 @@ const artifactSnapshotsSchema = z.array(
     name: z.string(),
     version: z.string(),
     mountPath: z.string(),
-    // Legacy internal provenance accepted for older guest agents; checkpoint
-    // storage strips it while preserving the artifact policy below.
-    generatedBy: z.literal("apiAutoMemory").optional(),
     missingRootPolicy: artifactMissingRootPolicySchema.optional(),
   }),
 );

--- a/turbo/packages/db/src/types.ts
+++ b/turbo/packages/db/src/types.ts
@@ -5,5 +5,4 @@ export interface ContextArtifact {
   version?: string;
   mountPath: string;
   missingRootPolicy?: ArtifactMissingRootPolicy;
-  generatedBy?: "apiAutoMemory";
 }


### PR DESCRIPTION
## Summary
- remove the `apiAutoMemory` generated provenance field from checkpoint artifact contracts and context artifact types
- keep `missingRootPolicy` as the only preserved artifact policy for missing-root handling
- update checkpoint webhook tests to verify unknown artifact snapshot fields are stripped while policy is preserved

## Testing
- `pnpm -F api exec vitest src/signals/routes/__tests__/webhooks-agent-checkpoints.test.ts --run`
- `pnpm -F api check-types`
- `pnpm -F @vm0/api-contracts check-types`
- `pnpm -F @vm0/db check-types`
- `pnpm format`
- pre-commit hook: `pnpm check-types`, `pnpm knip`, staged prettier

Follow-up to #16213.