### PR TITLE
perf: dispatch agent event consumers in-process

### DIFF
--- a/turbo/apps/api/src/lib/event-consumer/route.ts
+++ b/turbo/apps/api/src/lib/event-consumer/route.ts
@@ -10,7 +10,16 @@ interface EventConsumerErrorResponse {
   readonly body: { readonly error: string };
 }
 
-const eventConsumerPayloadState$ = state<EventConsumerPayload | null>(null);
+/**
+ * Backing store for {@link eventConsumerPayload$}. Written by
+ * `eventConsumerRoute` after HMAC verification of an inbound HTTP request, and
+ * also by in-process callers (e.g. the agent events webhook) that invoke an
+ * event-consumer command directly without the network hop — they set this with
+ * an already-trusted payload before calling the consumer command.
+ */
+export const eventConsumerPayloadState$ = state<EventConsumerPayload | null>(
+  null,
+);
 
 /**
  * Parsed event-consumer payload, available inside an `eventConsumerRoute`

--- a/turbo/apps/api/src/signals/routes/__tests__/webhooks-agent-events.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/webhooks-agent-events.test.ts
@@ -10,7 +10,7 @@ import { usageEvent } from "@vm0/db/schema/usage-event";
 
 import { createApp } from "../../../app-factory";
 import { accept, setupApp, testContext } from "../../../__tests__/test-helpers";
-import { mockEnv, mockOptionalEnv } from "../../../lib/env";
+import { mockOptionalEnv } from "../../../lib/env";
 import { now } from "../../../lib/time";
 import { server } from "../../../mocks/server";
 import { signSandboxJwtForTests } from "../../auth/tokens";
@@ -92,33 +92,6 @@ async function postRawWebhook(
   };
 }
 
-async function forwardToApi(request: Request): Promise<Response> {
-  const url = new URL(request.url);
-  const body = await request.text();
-  const app = createApp({ signal: context.signal });
-  const response = await app.request(url.pathname, {
-    method: request.method,
-    headers: request.headers,
-    body,
-  });
-
-  return new HttpResponse(response.body, {
-    status: response.status,
-    headers: response.headers,
-  });
-}
-
-function routeInternalConsumers(): void {
-  server.use(
-    http.post(
-      "http://api.test/api/internal/event-consumers/:consumer",
-      ({ request }) => {
-        return forwardToApi(request);
-      },
-    ),
-  );
-}
-
 async function seedFixture(): Promise<AgentEventsFixture> {
   const fixture = await trackChatFixture(
     store.set(seedZeroChatThread$, {}, context.signal),
@@ -174,10 +147,8 @@ function readUsageEvents(runId: string): Promise<
 }
 
 beforeEach(() => {
-  mockEnv("VM0_API_URL", "http://api.test");
   mockOptionalEnv("AGENTPHONE_API_BASE_URL", "https://api.agentphone.to");
   mockOptionalEnv("AGENTPHONE_API_KEY", "agentphone-test-key");
-  routeInternalConsumers();
 });
 
 describe("POST /api/webhooks/agent/events", () => {
@@ -475,22 +446,21 @@ describe("POST /api/webhooks/agent/events", () => {
   it("does not dispatch optional consumers when required Axiom dispatch fails", async () => {
     const fixture = await seedFixture();
     context.mocks.axiom.ingest.mockReturnValue(false);
-    let chatAssistantCalls = 0;
-    server.use(
-      http.post(
-        "http://api.test/api/internal/event-consumers/chat-assistant",
-        () => {
-          chatAssistantCalls++;
-          return HttpResponse.json({ processed: 1 });
-        },
-      ),
-    );
 
     const response = await accept(
       webhookClient().send({
         body: {
           runId: fixture.runId,
-          events: [{ type: "assistant", sequenceNumber: 1 }],
+          events: [
+            {
+              type: "assistant",
+              sequenceNumber: 1,
+              message: {
+                id: "msg_1",
+                content: [{ type: "text", text: "Should not be persisted" }],
+              },
+            },
+          ],
         },
         headers: authHeaders(fixture),
       }),
@@ -503,7 +473,11 @@ describe("POST /api/webhooks/agent/events", () => {
         code: "INTERNAL_SERVER_ERROR",
       },
     });
-    expect(chatAssistantCalls).toBe(0);
+    // The optional chat-assistant consumer runs in-process; a required-consumer
+    // failure must short-circuit before it, so no assistant message is written.
+    await expect(readAssistantMessages(fixture.runId)).resolves.toStrictEqual(
+      [],
+    );
   });
 
   it("rejects events when Axiom flush fails", async () => {
@@ -531,23 +505,27 @@ describe("POST /api/webhooks/agent/events", () => {
 
   it("accepts events when an optional consumer fails", async () => {
     const fixture = await seedFixture();
-    server.use(
-      http.post(
-        "http://api.test/api/internal/event-consumers/chat-assistant",
-        () => {
-          return HttpResponse.json(
-            { error: "chat assistant unavailable" },
-            { status: 503 },
-          );
-        },
-      ),
+    // The chat-assistant consumer persists the assistant message then publishes
+    // a realtime signal; a rejected publish makes the in-process consumer throw.
+    // Because it is optional, the failure is swallowed and the request succeeds.
+    context.mocks.ably.publish.mockRejectedValueOnce(
+      new Error("chat assistant publish failed"),
     );
 
     const response = await accept(
       webhookClient().send({
         body: {
           runId: fixture.runId,
-          events: [{ type: "assistant", sequenceNumber: 1 }],
+          events: [
+            {
+              type: "assistant",
+              sequenceNumber: 1,
+              message: {
+                id: "msg_1",
+                content: [{ type: "text", text: "Hello from the assistant" }],
+              },
+            },
+          ],
         },
         headers: authHeaders(fixture),
       }),

--- a/turbo/apps/api/src/signals/routes/internal-event-consumers-axiom.ts
+++ b/turbo/apps/api/src/signals/routes/internal-event-consumers-axiom.ts
@@ -11,49 +11,51 @@ import { settle } from "../utils";
 
 const AGENT_RUN_EVENTS_DATASET = "agent-run-events";
 
-const ingestAxiomEvents$ = command(async ({ get }, signal: AbortSignal) => {
-  const payload = get(eventConsumerPayload$);
-  signal.throwIfAborted();
+export const ingestAxiomEvents$ = command(
+  async ({ get }, signal: AbortSignal) => {
+    const payload = get(eventConsumerPayload$);
+    signal.throwIfAborted();
 
-  const axiomEvents = payload.events.map((event) => {
+    const axiomEvents = payload.events.map((event) => {
+      return {
+        runId: payload.runId,
+        userId: payload.context.userId,
+        sequenceNumber: event.sequenceNumber,
+        eventType: event.type,
+        eventData: event,
+      };
+    });
+
+    const ingested = ingestToAxiom(
+      getDatasetName(AGENT_RUN_EVENTS_DATASET),
+      axiomEvents,
+    );
+    if (!ingested) {
+      return {
+        status: 503 as const,
+        body: {
+          error: "Axiom agent-run-events dataset is not configured",
+        },
+      };
+    }
+
+    const flushed = await settle(
+      flushAxiom({ throwOnError: true, client: "sessions" }),
+    );
+    signal.throwIfAborted();
+    if (!flushed.ok) {
+      return {
+        status: 503 as const,
+        body: { error: "Axiom agent-run-events flush failed" },
+      };
+    }
+
     return {
-      runId: payload.runId,
-      userId: payload.context.userId,
-      sequenceNumber: event.sequenceNumber,
-      eventType: event.type,
-      eventData: event,
+      status: 200 as const,
+      body: { received: payload.events.length },
     };
-  });
-
-  const ingested = ingestToAxiom(
-    getDatasetName(AGENT_RUN_EVENTS_DATASET),
-    axiomEvents,
-  );
-  if (!ingested) {
-    return {
-      status: 503 as const,
-      body: {
-        error: "Axiom agent-run-events dataset is not configured",
-      },
-    };
-  }
-
-  const flushed = await settle(
-    flushAxiom({ throwOnError: true, client: "sessions" }),
-  );
-  signal.throwIfAborted();
-  if (!flushed.ok) {
-    return {
-      status: 503 as const,
-      body: { error: "Axiom agent-run-events flush failed" },
-    };
-  }
-
-  return {
-    status: 200 as const,
-    body: { received: payload.events.length },
-  };
-});
+  },
+);
 
 export const internalEventConsumerAxiomRoutes: readonly RouteEntry[] = [
   {

--- a/turbo/apps/api/src/signals/routes/internal-event-consumers-chat-assistant.ts
+++ b/turbo/apps/api/src/signals/routes/internal-event-consumers-chat-assistant.ts
@@ -79,7 +79,7 @@ function eventMessageId(event: AgentEvent): string | undefined {
   return undefined;
 }
 
-const processChatAssistantEvents$ = command(
+export const processChatAssistantEvents$ = command(
   async ({ get, set }, signal: AbortSignal) => {
     const payload = get(eventConsumerPayload$);
     signal.throwIfAborted();

--- a/turbo/apps/api/src/signals/services/agent-webhook-events.service.ts
+++ b/turbo/apps/api/src/signals/services/agent-webhook-events.service.ts
@@ -1,22 +1,35 @@
-import { command } from "ccstate";
+import { command, type Command } from "ccstate";
 import { and, eq } from "drizzle-orm";
 import { agentRuns } from "@vm0/db/schema/agent-run";
 
+import { eventConsumerPayloadState$ } from "../../lib/event-consumer/route";
 import type {
   AgentEvent,
+  EventConsumerPayload,
   RunEventContext,
 } from "../../lib/event-consumer/verify";
-import { computeHmacSignature } from "../../lib/event-consumer/hmac";
-import { env } from "../../lib/env";
 import { notFound } from "../../lib/error";
 import { logger } from "../../lib/log";
 import { now } from "../../lib/time";
 import type { SandboxAuth } from "../../types/auth";
 import { db$ } from "../external/db";
 import { publishRunChangedForUserSafely } from "../external/realtime";
-import { bestEffort, settle } from "../utils";
+import { ingestAxiomEvents$ } from "../routes/internal-event-consumers-axiom";
+import { processChatAssistantEvents$ } from "../routes/internal-event-consumers-chat-assistant";
+import { settle } from "../utils";
 
 const L = logger("webhook:events");
+
+/**
+ * Shape every event-consumer command resolves to. Each route handler returns a
+ * richer `{ status, body }` union, but the dispatcher only needs the status to
+ * decide success — any non-200 (or a thrown error) is treated as a failure.
+ */
+interface ConsumerResult {
+  readonly status: number;
+}
+
+type ConsumerCommand = Command<Promise<ConsumerResult>, [AbortSignal]>;
 
 interface AgentEventsBody {
   readonly runId: string;
@@ -30,14 +43,14 @@ interface ReceiveAgentEventsParams {
 
 interface DispatchableConsumer {
   readonly name: string;
-  readonly path: string;
+  readonly command$: ConsumerCommand;
   readonly required?: boolean;
   readonly eventTypes?: readonly string[];
 }
 
 interface PreparedConsumer {
   readonly name: string;
-  readonly path: string;
+  readonly command$: ConsumerCommand;
   readonly required?: boolean;
   readonly events: readonly AgentEvent[];
 }
@@ -48,23 +61,15 @@ interface DispatchAgentEventConsumersParams {
   readonly context: RunEventContext;
 }
 
-interface DispatchRuntime {
-  readonly runId: string;
-  readonly context: RunEventContext;
-  readonly baseUrl: string;
-  readonly secretsEncryptionKey: string;
-  readonly signal: AbortSignal;
-}
-
 const EVENT_CONSUMERS: readonly DispatchableConsumer[] = [
   {
     name: "axiom",
-    path: "/api/internal/event-consumers/axiom",
+    command$: ingestAxiomEvents$,
     required: true,
   },
   {
     name: "chat-assistant",
-    path: "/api/internal/event-consumers/chat-assistant",
+    command$: processChatAssistantEvents$,
     eventTypes: ["assistant", "item.completed"],
   },
 ];
@@ -97,103 +102,53 @@ function internalServerError(message: string) {
   };
 }
 
-function resolveBaseUrl(baseUrl: string): string {
-  return env("ENV") === "development" && baseUrl.startsWith("https://tunnel-")
-    ? baseUrl.replace(/^https:\/\/tunnel-[^/]+/u, "http://localhost:3000")
-    : baseUrl;
-}
-
-async function readFailureBody(response: Response): Promise<string> {
-  const settled = await settle(response.text());
-  return settled.ok ? settled.value : "";
-}
-
-async function drainResponse(response: Response): Promise<void> {
-  await bestEffort(response.arrayBuffer());
-}
-
-async function dispatchToConsumer(
-  consumer: PreparedConsumer,
-  runtime: DispatchRuntime,
-): Promise<void> {
-  const body = JSON.stringify({
-    runId: runtime.runId,
-    events: consumer.events,
-    context: runtime.context,
-  });
-  const timestamp = Math.floor(now() / 1000);
-  const signature = computeHmacSignature(
-    body,
-    runtime.secretsEncryptionKey,
-    timestamp,
-  );
-
-  const response = await fetch(`${runtime.baseUrl}${consumer.path}`, {
-    method: "POST",
-    headers: {
-      "Content-Type": "application/json",
-      "X-VM0-Signature": signature,
-      "X-VM0-Timestamp": timestamp.toString(),
+/**
+ * Invoke one consumer command in-process. The payload is published via
+ * `eventConsumerPayloadState$` (the same backing store the HTTP route uses)
+ * immediately before the command runs, so the command reads exactly the
+ * `{ runId, events, context }` it would have parsed from a signed request.
+ *
+ * Resolves to `true` on success and `false` on failure — a non-200 status or a
+ * thrown error. Failures are logged here; the caller decides whether a failure
+ * is fatal (required) or swallowed (optional).
+ */
+const runEventConsumer$ = command(
+  async (
+    { set },
+    params: {
+      readonly consumer: PreparedConsumer;
+      readonly payload: EventConsumerPayload;
     },
-    body,
-    signal: runtime.signal,
-  });
-  runtime.signal.throwIfAborted();
+    signal: AbortSignal,
+  ): Promise<boolean> => {
+    set(eventConsumerPayloadState$, params.payload);
+    const result = await settle(set(params.consumer.command$, signal), signal);
 
-  if (!response.ok) {
-    const responseBody = await readFailureBody(response);
-    runtime.signal.throwIfAborted();
-    throw new Error(
-      `HTTP ${response.status}${responseBody ? `: ${responseBody}` : ""}`,
-    );
-  }
-
-  await drainResponse(response);
-  runtime.signal.throwIfAborted();
-}
-
-async function dispatchConsumerGroup(
-  consumers: readonly PreparedConsumer[],
-  runtime: DispatchRuntime,
-): Promise<readonly string[]> {
-  const results = await Promise.allSettled(
-    consumers.map((consumer) => {
-      return dispatchToConsumer(consumer, runtime);
-    }),
-  );
-  runtime.signal.throwIfAborted();
-
-  const failures: string[] = [];
-  for (const [index, result] of results.entries()) {
-    if (result.status === "rejected") {
-      const consumer = consumers[index];
-      L.error(`Event consumer "${consumer?.name}" failed`, {
-        runId: runtime.runId,
-        error: result.reason,
+    if (!result.ok) {
+      L.error(`Event consumer "${params.consumer.name}" failed`, {
+        runId: params.payload.runId,
+        error: result.error,
       });
-      if (consumer?.required) {
-        failures.push(consumer.name);
-      }
+      return false;
     }
-  }
-
-  return failures;
-}
+    if (result.value.status !== 200) {
+      L.error(`Event consumer "${params.consumer.name}" failed`, {
+        runId: params.payload.runId,
+        status: result.value.status,
+      });
+      return false;
+    }
+    return true;
+  },
+);
 
 const dispatchAgentEventConsumers$ = command(
   async (
-    _store,
+    { set },
     params: DispatchAgentEventConsumersParams,
     signal: AbortSignal,
   ): Promise<void> => {
-    const runtime: DispatchRuntime = {
-      runId: params.runId,
-      context: params.context,
-      baseUrl: resolveBaseUrl(env("VM0_API_URL")),
-      secretsEncryptionKey: env("SECRETS_ENCRYPTION_KEY"),
-      signal,
-    };
-
+    const context = params.context;
     const consumers = EVENT_CONSUMERS.map(
       (consumer): PreparedConsumer | null => {
         const matchingEvents = consumer.eventTypes
@@ -208,7 +163,7 @@ const dispatchAgentEventConsumers$ = command(
 
         return {
           name: consumer.name,
-          path: consumer.path,
+          command$: consumer.command$,
           required: consumer.required,
           events: matchingEvents,
         };
@@ -224,18 +179,35 @@ const dispatchAgentEventConsumers$ = command(
       return !consumer.required;
     });
 
-    const requiredFailures = await dispatchConsumerGroup(
-      requiredConsumers,
-      runtime,
-    );
-    signal.throwIfAborted();
+    const requiredFailures: string[] = [];
+    for (const consumer of requiredConsumers) {
+      const ok = await set(
+        runEventConsumer$,
+        {
+          consumer,
+          payload: { runId: params.runId, events: consumer.events, context },
+        },
+        signal,
+      );
+      if (!ok) {
+        requiredFailures.push(consumer.name);
+      }
+    }
 
     if (requiredFailures.length > 0) {
       throw new RequiredEventConsumerDispatchError(requiredFailures);
     }
 
-    await dispatchConsumerGroup(optionalConsumers, runtime);
-    signal.throwIfAborted();
+    for (const consumer of optionalConsumers) {
+      await set(
+        runEventConsumer$,
+        {
+          consumer,
+          payload: { runId: params.runId, events: consumer.events, context },
+        },
+        signal,
+      );
+    }
   },
 );
 


### PR DESCRIPTION
## Summary

`/api/webhooks/agent/events` dispatched its event consumers by issuing HMAC-signed HTTP `POST`s back to `https://www.vm0.ai/api/internal/event-consumers/{axiom,chat-assistant}` (base derived from `VM0_API_URL`). Both consumers are pure in-process work — Axiom ingest and chat-thread DB writes — so the self-call added an avoidable external round trip (DNS + TLS + HMAC sign/verify + JSON re-parse) on the webhook hot path.

This PR replaces the HTTP self-dispatch with direct in-process invocation of the two route commands, removing the `www` self-call hop.

### How

- `dispatchAgentEventConsumers$` no longer builds `fetch()` calls. It publishes the already-trusted payload via the shared `eventConsumerPayloadState$` backing store — the same store `eventConsumerRoute` writes after HMAC verification — and then runs each consumer command via `set(command$, signal)`.
- A consumer "fails" when its command resolves to a non-200 status (e.g. Axiom's `503`) or throws. This maps the previous non-2xx-HTTP-response → failure behavior onto the in-process return shape.
- `ingestAxiomEvents$` and `processChatAssistantEvents$` are now `export`ed (they remain registered as HTTP routes, unchanged); `eventConsumerPayloadState$` is now `export`ed from `lib/event-consumer/route.ts`.
- Removed the now-dead HTTP machinery: `dispatchToConsumer`, `dispatchConsumerGroup`, `resolveBaseUrl`, `readFailureBody`, `drainResponse`, the `DispatchRuntime` interface, the `computeHmacSignature`/`env`/`bestEffort` imports, and the `baseUrl`/`secretsEncryptionKey` wiring.

### Semantics preserved exactly

- **axiom is required**: a failure throws `RequiredEventConsumerDispatchError` and the webhook returns HTTP 500 (the `internalServerError` path and required/optional grouping are kept). Optional consumers do not run when a required one fails.
- **chat-assistant is optional** and only runs for events whose type is `"assistant"` or `"item.completed"` (the `eventTypes` filtering is kept). Its failure is logged and swallowed so it cannot fail the request.
- Each command receives exactly the params its route handler builds from the HTTP body today: `{ runId, events (filtered for chat-assistant), context: { userId, orgId } }`.

### Tests

`webhooks-agent-events.test.ts` previously MSW-mocked `http.post(.../event-consumers/axiom|chat-assistant)` and routed those calls back into the app. Since the webhook no longer makes those HTTP calls, the mocks and the self-forwarder are removed and assertions are re-pointed to the in-process effects:

- axiom ingest still asserted via `context.mocks.axiom.ingest` (mocked at the `external/axiom` module boundary).
- chat-assistant assistant messages asserted via the DB (`readAssistantMessages`).
- required-consumer failure (`axiom.ingest` → `false`, and flush-failure) still yields 500, and the optional consumer is confirmed not to run (no assistant message persisted).
- optional-consumer failure is exercised by rejecting the realtime publish inside the chat-assistant write path; the request still returns 200.
- the existing "does not dispatch typing refresh consumers for agent events" test is kept passing.

## Acceptance criteria addressed (part of #16256)

- Removes the `www` self-call hop for `/api/webhooks/agent/events` event-consumer dispatch (axiom + chat-assistant) by invoking the consumers in-process.
- No behavior change to the inbound webhook contract, the consumer route registrations, callbacks, or `env.ts`.

Part of #16256

## Note on local verification

This worktree has no `node_modules`, so `pnpm`/`vitest`/`tsc`/`turbo`/`knip`/`eslint` were **not** run locally. CI is authoritative for lint, typecheck, and tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)