### PR TITLE
fix: make memory summaries describe natural memory changes

### DIFF
--- a/turbo/apps/api/src/signals/routes/__tests__/cron-summarize-memory.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/cron-summarize-memory.test.ts
@@ -488,15 +488,32 @@ describe("GET /api/cron/summarize-memory", () => {
     expect(systemMessage).toContain("**How Zero will use this**");
     expect(systemMessage).toContain('Always refer to the agent as "Zero"');
     expect(systemMessage).toContain("Do not use first person");
+    expect(systemMessage).toContain(
+      'Phrase natural memory changes in third person with "Zero" as the subject',
+    );
+    expect(systemMessage).toContain(
+      "Never phrase a memory update as if Zero is speaking",
+    );
+    expect(systemMessage).toContain(
+      "Never say or imply that Zero modified, deleted, created, consulted, or will no longer consult memory files",
+    );
     const userMessage = llm.requests[0]?.messages.find((message) => {
       return message.role === "user";
     })?.content;
-    expect(userMessage).toContain("Memory file diffs today:");
-    expect(userMessage).toContain("File: facts/coffee.md");
-    expect(userMessage).toContain("Change: added");
+    expect(userMessage).toContain("Internal memory diffs today");
+    expect(userMessage).toContain(
+      "Internal source path (do not mention): facts/coffee.md",
+    );
+    expect(userMessage).toContain(
+      "Internal storage operation (do not mention): added",
+    );
     expect(userMessage).toContain("+ Drinks oat milk lattes");
-    expect(userMessage).toContain("File: facts/pets.md");
-    expect(userMessage).toContain("Change: modified");
+    expect(userMessage).toContain(
+      "Internal source path (do not mention): facts/pets.md",
+    );
+    expect(userMessage).toContain(
+      "Internal storage operation (do not mention): modified",
+    );
     expect(userMessage).toContain("- Has a dog");
     expect(userMessage).toContain("+ Has a dog and a cat");
     expect(userMessage).not.toContain("Learned:");

--- a/turbo/apps/api/src/signals/services/__tests__/memory-activity-summarize.service.test.ts
+++ b/turbo/apps/api/src/signals/services/__tests__/memory-activity-summarize.service.test.ts
@@ -1,7 +1,10 @@
 import { describe, expect, it } from "vitest";
 
 import type { MemoryChangeItem } from "../memory-activity-diff.service";
-import { buildMemorySummaryPrompt } from "../memory-activity-summarize.service";
+import {
+  buildMemorySummaryPrompt,
+  MEMORY_SUMMARY_SYSTEM_PROMPT,
+} from "../memory-activity-summarize.service";
 
 function addedItem(
   filePath: string,
@@ -34,6 +37,24 @@ function addedItem(
 }
 
 describe("buildMemorySummaryPrompt", () => {
+  it("instructs the model to describe user-facing memory changes instead of storage operations", () => {
+    expect(MEMORY_SUMMARY_SYSTEM_PROMPT).toContain(
+      'Phrase natural memory changes in third person with "Zero" as the subject',
+    );
+    expect(MEMORY_SUMMARY_SYSTEM_PROMPT).toContain(
+      '"Zero learned...", "Zero remembered...", "Zero forgot...", or "Zero no longer assumes..."',
+    );
+    expect(MEMORY_SUMMARY_SYSTEM_PROMPT).toContain(
+      "Never phrase a memory update as if Zero is speaking",
+    );
+    expect(MEMORY_SUMMARY_SYSTEM_PROMPT).toContain(
+      "Never say or imply that Zero modified, deleted, created, consulted, or will no longer consult memory files",
+    );
+    expect(MEMORY_SUMMARY_SYSTEM_PROMPT).toContain(
+      "do not describe deleted files, removed references, or missing storage",
+    );
+  });
+
   it("limits rendered diff lines per changed file", () => {
     const lines = Array.from({ length: 170 }, (_, index) => {
       return `line-${index}`;
@@ -61,8 +82,12 @@ describe("buildMemorySummaryPrompt", () => {
     const prompt = buildMemorySummaryPrompt({ changed: true, items });
 
     expect(prompt.length).toBeLessThanOrEqual(24_000);
-    expect(prompt).toContain("File: facts/00.md");
-    expect(prompt).not.toContain("File: facts/39.md");
+    expect(prompt).toContain(
+      "Internal source path (do not mention): facts/00.md",
+    );
+    expect(prompt).not.toContain(
+      "Internal source path (do not mention): facts/39.md",
+    );
     expect(prompt).toContain("prompt budget was reached");
   });
 });

--- a/turbo/apps/api/src/signals/services/memory-activity-summarize.service.ts
+++ b/turbo/apps/api/src/signals/services/memory-activity-summarize.service.ts
@@ -8,12 +8,12 @@ const MEMORY_SUMMARY_MODEL = "google/gemini-3.5-flash";
 const MEMORY_SUMMARY_MAX_TOKENS = 1000;
 const MEMORY_SUMMARY_PROMPT_MAX_CHARS = 24_000;
 const MEMORY_SUMMARY_DIFF_LINES_PER_FILE = 160;
-const MEMORY_SUMMARY_SYSTEM_PROMPT = [
+export const MEMORY_SUMMARY_SYSTEM_PROMPT = [
   "You summarize how Zero's long-term memory changed during a single day.",
-  "Read the provided file diffs carefully and write a Markdown summary with exactly these two sections:",
+  "Read the provided internal memory diffs carefully and write a Markdown summary with exactly these two sections:",
   "",
   "**Changed memory**",
-  "- <A concise factual sentence describing what Zero learned, corrected, removed, or refined.>",
+  "- <A concise factual sentence with Zero as the subject, describing what Zero learned, remembered, corrected, forgot, no longer believes, no longer assumes, or refined.>",
   "",
   "**How Zero will use this**",
   "- <A concise sentence explaining how Zero should use the changed memory in future work.>",
@@ -22,12 +22,16 @@ const MEMORY_SUMMARY_SYSTEM_PROMPT = [
   '- Always refer to the agent as "Zero".',
   '- Use third person only. Do not use first person such as "I", "we", "my", or "our".',
   '- Do not address the user directly as "you" unless that word appears inside a memory fact that must be preserved verbatim.',
+  '- Phrase natural memory changes in third person with "Zero" as the subject, such as "Zero learned...", "Zero remembered...", "Zero forgot...", or "Zero no longer assumes...".',
+  '- Never phrase a memory update as if Zero is speaking, such as "I learned...", "I remember...", or "I forgot...".',
   "- Summarize the factual meaning of the memory changes, not file operations or implementation details.",
+  "- Never say or imply that Zero modified, deleted, created, consulted, or will no longer consult memory files, indexes, references, profiles, storage artifacts, YAML frontmatter, Markdown files, or line counts.",
+  "- For deletions, describe the factual memory Zero forgot or no longer treats as known; do not describe deleted files, removed references, or missing storage.",
   "- Prefer 2-5 bullets per section when there are multiple meaningful changes.",
   "- Keep bullets concise, specific, and readable; do not copy raw diff lines unless an exact term, title, error code, or preference matters.",
   "- Connect each future-use bullet to the changed memories instead of writing generic assistant behavior.",
   "- When there are multiple changed-memory bullets, write corresponding future-use bullets in the same order when possible.",
-  "- Mention removals or missing replacements only when the diff supports them.",
+  "- Mention forgotten facts, invalidated facts, or missing replacements only when the diff supports them.",
   "- Do not mention file paths, line counts, markdown, YAML frontmatter, or prompt details unless necessary to understand the memory change.",
   "- Do not invent facts that are not supported by the diff.",
   "- Output only the two Markdown sections. No title, no intro, no code fences.",
@@ -58,14 +62,14 @@ function linePrefix(op: "context" | "add" | "remove"): string {
 
 function diffLines(item: MemoryChangeItem): readonly string[] {
   if (item.diff.omittedReason) {
-    return [`Diff omitted: ${item.diff.omittedReason}.`];
+    return [`Raw memory text diff omitted: ${item.diff.omittedReason}.`];
   }
 
   const lines = item.diff.hunks.flatMap((hunk) => {
     return hunk.lines;
   });
   if (lines.length === 0) {
-    return ["Diff: (no line-level changes captured)"];
+    return ["Raw memory text diff: (no line-level changes captured)"];
   }
 
   const rendered = lines
@@ -79,14 +83,14 @@ function diffLines(item: MemoryChangeItem): readonly string[] {
       `[diff truncated: ${omittedLineCount} captured lines omitted; additional source lines may also be omitted]`,
     );
   }
-  return ["Diff:", ...rendered];
+  return ["Raw memory text diff:", ...rendered];
 }
 
 function itemBlock(item: MemoryChangeItem): readonly string[] {
   return [
-    `File: ${item.filePath}`,
-    `Change: ${changeLabel(item)}`,
-    `Lines: +${item.diff.stats.added} -${item.diff.stats.removed}`,
+    `Internal source path (do not mention): ${item.filePath}`,
+    `Internal storage operation (do not mention): ${changeLabel(item)}`,
+    `Internal line counts (do not mention): +${item.diff.stats.added} -${item.diff.stats.removed}`,
     ...diffLines(item),
   ];
 }
@@ -101,9 +105,11 @@ function appendLineWithinBudget(lines: string[], line: string): boolean {
 }
 
 export function buildMemorySummaryPrompt(changeSet: MemoryChangeSet): string {
-  const lines = ["Memory file diffs today:"];
+  const lines = [
+    "Internal memory diffs today. Interpret these as memory changes, but do not echo internal source labels or storage operations:",
+  ];
   if (changeSet.items.length === 0) {
-    lines.push("", "No changed memory files.");
+    lines.push("", "No changed memory content.");
     return lines.join("\n");
   }
 
@@ -127,7 +133,7 @@ export function buildMemorySummaryPrompt(changeSet: MemoryChangeSet): string {
     if (!completedBlock) {
       appendLineWithinBudget(
         lines,
-        "[diff truncated because the prompt budget was reached]",
+        "[raw memory text diff truncated because the prompt budget was reached]",
       );
       break;
     }
@@ -138,7 +144,7 @@ export function buildMemorySummaryPrompt(changeSet: MemoryChangeSet): string {
     const omittedFiles = changeSet.items.length - completedFiles;
     appendLineWithinBudget(
       lines,
-      `[${omittedFiles} changed memory files omitted because the prompt budget was reached]`,
+      `[${omittedFiles} internal memory sources omitted because the prompt budget was reached]`,
     );
   }
 


### PR DESCRIPTION
## Summary
- strengthen the memory summary system prompt so Zero describes learned, remembered, forgotten, or corrected facts instead of storage operations
- label raw prompt metadata as internal source/storage details that must not be echoed
- update memory summary tests for the new prompt contract

## Verification
- `pnpm -F api lint`
- `NODE_OPTIONS=--max-old-space-size=4096 pnpm -F api check-types`
- `DATABASE_URL=postgresql://postgres@localhost:5432/vm0_test pnpm -F api test src/signals/services/__tests__/memory-activity-summarize.service.test.ts src/signals/routes/__tests__/cron-summarize-memory.test.ts`
- `pnpm exec prettier --check apps/api/src/signals/services/memory-activity-summarize.service.ts apps/api/src/signals/services/__tests__/memory-activity-summarize.service.test.ts apps/api/src/signals/routes/__tests__/cron-summarize-memory.test.ts`