### PR TITLE
fix: remove lark connector feature switch

### DIFF
--- a/turbo/apps/api/src/signals/routes/__tests__/zero-connectors-manual-grant-connect.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/zero-connectors-manual-grant-connect.test.ts
@@ -231,11 +231,6 @@ describe("POST /api/zero/connectors/:type/manual-grant", () => {
   it("stores Lark app credentials without writing the logical access token", async () => {
     const fixture = await seedFixture();
     const db = store.set(writeDb$);
-    await db.insert(userFeatureSwitches).values({
-      orgId: fixture.orgId,
-      userId: fixture.userId,
-      switches: { [FeatureSwitchKey.LarkConnector]: true },
-    });
     const client = setupApp({ context })(zeroConnectorManualGrantContract);
 
     await accept(
@@ -280,11 +275,6 @@ describe("POST /api/zero/connectors/:type/manual-grant", () => {
   it("clears stale Lark access token state on reconnect", async () => {
     const fixture = await seedFixture();
     const db = store.set(writeDb$);
-    await db.insert(userFeatureSwitches).values({
-      orgId: fixture.orgId,
-      userId: fixture.userId,
-      switches: { [FeatureSwitchKey.LarkConnector]: true },
-    });
     await db.insert(connectors).values({
       orgId: fixture.orgId,
       userId: fixture.userId,

--- a/turbo/apps/api/src/signals/services/__tests__/zero-connector-data.service.test.ts
+++ b/turbo/apps/api/src/signals/services/__tests__/zero-connector-data.service.test.ts
@@ -303,12 +303,12 @@ describe("zeroConnectorList", () => {
     await writeDb.insert(connectors).values({
       orgId,
       userId,
-      type: "lark",
+      type: "bentoml",
       authMethod: "api-token",
     });
 
     const connector = await store.get(
-      zeroConnectorByType({ orgId, userId, type: "lark" }),
+      zeroConnectorByType({ orgId, userId, type: "bentoml" }),
     );
 
     expect(connector).toBeNull();

--- a/turbo/apps/platform/src/views/zero-page/__tests__/zero-ideation-page.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/zero-ideation-page.test.tsx
@@ -378,29 +378,10 @@ describe("ideation page - ZapierConnector feature switch", () => {
   });
 });
 
-describe("ideation page - LarkConnector feature switch", () => {
-  it("should hide the Lark use case card when LarkConnector switch is off (default)", async () => {
+describe("ideation page - Lark use case", () => {
+  it("should show the Lark use case card by default", async () => {
     mockChatAPI();
     detachedSetupPage({ context, path: IDEAS_PATH });
-
-    await waitFor(() => {
-      expect(
-        screen.getByRole("heading", { name: "Ideas & Use Cases" }),
-      ).toBeInTheDocument();
-    });
-
-    expect(
-      screen.queryByText("Lark \u2194 Slack message relay"),
-    ).not.toBeInTheDocument();
-  });
-
-  it("should show the Lark use case card when LarkConnector switch is on", async () => {
-    mockChatAPI();
-    detachedSetupPage({
-      context,
-      path: IDEAS_PATH,
-      featureSwitches: { [FeatureSwitchKey.LarkConnector]: true },
-    });
 
     await waitFor(() => {
       expect(

--- a/turbo/apps/platform/src/views/zero-page/zero-ideation-data.ts
+++ b/turbo/apps/platform/src/views/zero-page/zero-ideation-data.ts
@@ -235,7 +235,6 @@ const categories: readonly Category[] = [
         prompt:
           "Set up a message relay between a Lark group and a Slack channel so that messages are forwarded both ways",
         connectors: ["lark", "slack"],
-        featureFlag: FeatureSwitchKey.LarkConnector,
       },
       {
         title: "Google Drive file organizer",

--- a/turbo/packages/connectors/src/__tests__/connectors.test.ts
+++ b/turbo/packages/connectors/src/__tests__/connectors.test.ts
@@ -1908,13 +1908,10 @@ describe("getAvailableConnectorAuthMethodIds", () => {
     ]);
   });
 
-  it("exposes Lark API-token auth only when its switch is enabled", () => {
-    expect(getAvailableConnectorAuthMethodIds("lark", {})).toStrictEqual([]);
-    expect(
-      getAvailableConnectorAuthMethodIds("lark", {
-        [FeatureSwitchKey.LarkConnector]: true,
-      }),
-    ).toStrictEqual(["api-token"]);
+  it("exposes Lark API-token auth without a feature switch", () => {
+    expect(getAvailableConnectorAuthMethodIds("lark", {})).toStrictEqual([
+      "api-token",
+    ]);
   });
 
   it("exposes Doubao API-token auth without a feature switch", () => {

--- a/turbo/packages/connectors/src/connectors/lark.ts
+++ b/turbo/packages/connectors/src/connectors/lark.ts
@@ -1,5 +1,4 @@
 import type { ConnectorConfig } from "../connectors";
-import { FeatureSwitchKey } from "../feature-switch-key";
 
 export const lark = {
   lark: {
@@ -9,7 +8,6 @@ export const lark = {
       "Connect your Lark app to manage messages, documents, calendars, and workflows",
     authMethods: {
       "api-token": {
-        featureFlag: FeatureSwitchKey.LarkConnector,
         label: "App Credentials",
         helpText:
           "1. Log in to the [Lark Developer Console](https://open.larksuite.com/app/)\n2. Select your app from the list (or create a new one)\n3. Go to the **Credentials & Basic Info** page\n4. Copy your **App ID** and **App Secret**",

--- a/turbo/packages/connectors/src/feature-switch-key.ts
+++ b/turbo/packages/connectors/src/feature-switch-key.ts
@@ -32,7 +32,6 @@ export enum FeatureSwitchKey {
   ZeroDebug = "zeroDebug",
   ComputerUse = "computerUse",
   Banking = "banking",
-  LarkConnector = "larkConnector",
   Lab = "lab",
   AuditLink = "auditLink",
   AudioOutput = "audioOutput",

--- a/turbo/packages/core/src/feature-switch.ts
+++ b/turbo/packages/core/src/feature-switch.ts
@@ -178,12 +178,6 @@ const FEATURE_SWITCHES: Record<FeatureSwitchKey, FeatureSwitch> = {
     enabled: false,
     enabledOrgIdHashes: STAFF_ORG_ID_HASHES,
   },
-  [FeatureSwitchKey.LarkConnector]: {
-    maintainer: "liangyou@vm0.ai",
-    description:
-      "Enable the Lark connector while tenant access-token exchange is being repaired.",
-    enabled: false,
-  },
   [FeatureSwitchKey.Lab]: {
     maintainer: "ethan@vm0.ai",
     description: "Show the Lab page for toggling experimental features",


### PR DESCRIPTION
## Summary

- Remove the Lark connector feature switch from the registry and connector auth method
- Make the Lark ideation use case visible by default
- Update Lark connector availability/manual grant tests for the ungated behavior

## Tests

- `pnpm -F @vm0/connectors exec vitest src/__tests__/connectors.test.ts`
- `pnpm -F api exec vitest src/signals/routes/__tests__/zero-connectors-manual-grant-connect.test.ts`
- `pnpm -F @vm0/app exec vitest src/views/zero-page/__tests__/zero-ideation-page.test.tsx`
- `git diff --check`
- pre-commit: prettier, knip, check-types