### PR TITLE
feat: collapse memory file diffs

### DIFF
--- a/turbo/apps/platform/src/signals/memory-page/memory-signals.ts
+++ b/turbo/apps/platform/src/signals/memory-page/memory-signals.ts
@@ -57,13 +57,24 @@ export const memoryDevRefreshState$ = computed((get) => {
   return get(internalMemoryDevRefreshState$);
 });
 
-// Per-item expand state for the Updates timeline, keyed by a stable item key.
-// Mirrors the keyed-record ephemeral UI state pattern used elsewhere in the
-// platform (e.g. view-component-state) since `useState` is restricted here.
+// Per-entry and per-item expand state for the Updates timeline, keyed by stable
+// activity keys. Mirrors the keyed-record ephemeral UI state pattern used
+// elsewhere in the platform since `useState` is restricted here.
+const internalExpandedMemoryEntries$ = state<Record<string, boolean>>({});
 const internalExpandedMemoryItems$ = state<Record<string, boolean>>({});
+
+export const expandedMemoryEntries$ = computed((get) => {
+  return get(internalExpandedMemoryEntries$);
+});
 
 export const expandedMemoryItems$ = computed((get) => {
   return get(internalExpandedMemoryItems$);
+});
+
+export const toggleMemoryEntryExpanded$ = command(({ set }, key: string) => {
+  set(internalExpandedMemoryEntries$, (current) => {
+    return { ...current, [key]: !current[key] };
+  });
 });
 
 export const toggleMemoryItemExpanded$ = command(({ set }, key: string) => {

--- a/turbo/apps/platform/src/views/memory-page/__tests__/memory-page.test.tsx
+++ b/turbo/apps/platform/src/views/memory-page/__tests__/memory-page.test.tsx
@@ -211,12 +211,34 @@ describe("memory page", () => {
     expect(screen.getByText("Changed memory")).toBeInTheDocument();
     expect(screen.getByText("How Zero will use this")).toBeInTheDocument();
     expect(screen.queryByText("**Changed memory**")).not.toBeInTheDocument();
-    expect(screen.getByText("deploy.md")).toBeInTheDocument();
-    expect(screen.getByText("setup.md")).toBeInTheDocument();
+    expect(screen.getByText("2 memory files changed")).toBeInTheDocument();
+    expect(screen.queryByText("deploy.md")).not.toBeInTheDocument();
+    expect(screen.queryByText("setup.md")).not.toBeInTheDocument();
     expect(screen.queryByText("Deploy preference")).not.toBeInTheDocument();
     expect(screen.queryByText("Updated")).not.toBeInTheDocument();
-    expect(updateCard).toHaveTextContent("+1");
+    expect(updateCard).toHaveTextContent("+2");
     expect(updateCard).toHaveTextContent("-1");
+
+    const viewFiles = queryAllByRoleFast("button", updateCard).find(
+      (button) => {
+        return button.textContent?.includes("View files");
+      },
+    );
+    expect(viewFiles).toBeDefined();
+    expect(viewFiles).toHaveAttribute("aria-expanded", "false");
+    click(viewFiles!);
+
+    await waitFor(() => {
+      expect(screen.getByText("deploy.md")).toBeInTheDocument();
+      expect(screen.getByText("setup.md")).toBeInTheDocument();
+    });
+    const hideFiles = queryAllByRoleFast("button", updateCard).find(
+      (button) => {
+        return button.textContent?.includes("Hide files");
+      },
+    );
+    expect(hideFiles).toBeDefined();
+    expect(hideFiles).toHaveAttribute("aria-expanded", "true");
 
     // Evidence is hidden until the item is expanded.
     expect(screen.queryByText("new setup")).not.toBeInTheDocument();
@@ -234,6 +256,12 @@ describe("memory page", () => {
     const diff = screen.getByLabelText("Memory diff");
     expect(within(diff).getByText("-")).toBeInTheDocument();
     expect(within(diff).getByText("+")).toBeInTheDocument();
+
+    click(hideFiles!);
+    await waitFor(() => {
+      expect(screen.queryByText("deploy.md")).not.toBeInTheDocument();
+      expect(screen.queryByText("setup.md")).not.toBeInTheDocument();
+    });
   });
 
   it("shows an Updates-shaped skeleton while the default tab is loading", async () => {

--- a/turbo/apps/platform/src/views/memory-page/memory-page.tsx
+++ b/turbo/apps/platform/src/views/memory-page/memory-page.tsx
@@ -9,6 +9,7 @@ import { Button, cn } from "@vm0/ui";
 import { Tabs, TabsList, TabsTrigger } from "@vm0/ui/components/ui/tabs";
 
 import {
+  expandedMemoryEntries$,
   expandedMemoryItems$,
   loadMoreMemoryActivity$,
   memoryActivity$,
@@ -25,6 +26,7 @@ import {
   selectedMemoryFilePath$,
   setMemoryTab$,
   setSelectedMemoryFilePath$,
+  toggleMemoryEntryExpanded$,
   toggleMemoryItemExpanded$,
   type MemoryTab,
 } from "../../signals/memory-page/memory-signals.ts";
@@ -577,6 +579,26 @@ function formatLineStatsText(stats: {
   return parts.length === 0 ? "0" : parts.join(" ");
 }
 
+function getMemoryItemsStats(items: readonly MemoryActivityItem[]): {
+  readonly added: number;
+  readonly removed: number;
+} {
+  return items.reduce(
+    (totals, item) => {
+      return {
+        added: totals.added + item.diff.stats.added,
+        removed: totals.removed + item.diff.stats.removed,
+      };
+    },
+    { added: 0, removed: 0 },
+  );
+}
+
+function formatMemoryFileCount(count: number): string {
+  const noun = count === 1 ? "memory file" : "memory files";
+  return `${count} ${noun} changed`;
+}
+
 function MemoryUpdates() {
   const activityLoadable = useLoadable(memoryActivity$);
   const extraEntries = useLastResolved(memoryActivityExtraEntries$) ?? [];
@@ -660,11 +682,18 @@ function MemoryUpdatesLoadMore({
 }
 
 function MemoryUpdateCard({ entry }: { readonly entry: MemoryActivityEntry }) {
+  const expandedByKey = useGet(expandedMemoryEntries$);
+  const toggleExpanded = useSet(toggleMemoryEntryExpanded$);
   const summary = entry.summary ?? buildFallbackSummary(entry.items);
+  const entryKey = entry.toVersionId;
+  const expanded = expandedByKey[entryKey] ?? false;
+  const hasFiles = entry.items.length > 0;
+  const stats = getMemoryItemsStats(entry.items);
+  const filesListId = `memory-update-files-${entryKey}`;
 
   return (
     <section className="zero-card flex shrink-0 flex-col overflow-hidden">
-      <header className="border-b border-border/70 px-4 py-3">
+      <header className="px-4 py-3">
         <h2 className="text-sm font-semibold tracking-tight text-foreground">
           {formatActivityDate(entry.date)}
         </h2>
@@ -673,13 +702,58 @@ function MemoryUpdateCard({ entry }: { readonly entry: MemoryActivityEntry }) {
           className="mt-2 [&_p]:my-0 [&_p]:text-muted-foreground [&_ul]:my-1.5 [&_ul]:pl-5 [&_li]:my-0.5 [&_li]:text-muted-foreground [&_strong]:text-foreground"
         />
       </header>
-      <div className="flex flex-col gap-2 px-4 py-3">
-        {entry.items.map((item) => {
-          const itemKey = `${entry.toVersionId}:${item.filePath}`;
-          return (
-            <MemoryUpdateItem key={itemKey} itemKey={itemKey} item={item} />
-          );
-        })}
+      <div className="mx-4 border-t border-border/70">
+        <div className="flex min-h-10 items-center justify-between gap-3 py-1.5">
+          <div className="flex min-w-0 items-center gap-2 text-sm text-muted-foreground">
+            <span
+              aria-hidden="true"
+              className="h-1.5 w-1.5 shrink-0 rounded-full bg-muted-foreground/60"
+            />
+            <span className="truncate">
+              {formatMemoryFileCount(entry.items.length)}
+            </span>
+          </div>
+          <div className="flex shrink-0 items-center gap-2">
+            <MemorySummaryLineStats stats={stats} />
+            {hasFiles ? (
+              <button
+                type="button"
+                aria-label={expanded ? "Hide files" : "View files"}
+                aria-controls={filesListId}
+                aria-expanded={expanded}
+                onClick={() => {
+                  toggleExpanded(entryKey);
+                }}
+                className="inline-flex h-7 items-center justify-center gap-1 rounded-md px-2 text-xs font-medium text-muted-foreground transition-colors hover:bg-accent/50 hover:text-foreground"
+              >
+                <span className="hidden sm:inline">
+                  {expanded ? "Hide files" : "View files"}
+                </span>
+                <span className="sm:hidden">{expanded ? "Hide" : "View"}</span>
+                <IconChevronDown
+                  size={13}
+                  className={cn(
+                    "transition-transform",
+                    expanded && "rotate-180",
+                  )}
+                />
+              </button>
+            ) : null}
+          </div>
+        </div>
+        {expanded && hasFiles ? (
+          <div
+            id={filesListId}
+            className="flex flex-col border-t border-border/70 py-2"
+          >
+            {entry.items.map((item) => {
+              const itemKey = `${entry.toVersionId}:${item.filePath}`;
+              return (
+                <MemoryUpdateItem key={itemKey} itemKey={itemKey} item={item} />
+              );
+            })}
+          </div>
+        ) : null}
       </div>
     </section>
   );
@@ -698,7 +772,7 @@ function MemoryUpdateItem({
   const hasEvidence = hasDiffEvidence(item.diff);
 
   return (
-    <div className="rounded-md border border-border/70 bg-background">
+    <div>
       <button
         type="button"
         aria-expanded={expanded}
@@ -707,7 +781,7 @@ function MemoryUpdateItem({
           toggleExpanded(itemKey);
         }}
         className={cn(
-          "flex w-full min-w-0 items-center justify-between gap-3 px-3 py-2 text-left",
+          "flex w-full min-w-0 items-center justify-between gap-3 rounded-md px-2 py-1.5 text-left",
           hasEvidence
             ? "transition-colors hover:bg-accent/40"
             : "cursor-default",
@@ -719,11 +793,43 @@ function MemoryUpdateItem({
         <MemoryLineStats diff={item.diff} />
       </button>
       {expanded && hasEvidence ? (
-        <div className="border-t border-border/70 px-3 py-2">
+        <div className="px-2 pb-2 pt-1">
           <MemoryDiffView diff={item.diff} />
         </div>
       ) : null}
     </div>
+  );
+}
+
+function MemorySummaryLineStats({
+  stats,
+}: {
+  readonly stats: { readonly added: number; readonly removed: number };
+}) {
+  const { added, removed } = stats;
+
+  if (added > 0 && removed > 0) {
+    return (
+      <span className="flex shrink-0 items-center gap-1 font-mono text-xs">
+        <span className="text-emerald-700 dark:text-emerald-300">+{added}</span>
+        <span className="text-muted-foreground">/</span>
+        <span className="text-rose-700 dark:text-rose-300">-{removed}</span>
+      </span>
+    );
+  }
+
+  return (
+    <span className="flex shrink-0 items-center gap-1 font-mono text-xs">
+      {added > 0 ? (
+        <span className="text-emerald-700 dark:text-emerald-300">+{added}</span>
+      ) : null}
+      {removed > 0 ? (
+        <span className="text-rose-700 dark:text-rose-300">-{removed}</span>
+      ) : null}
+      {added === 0 && removed === 0 ? (
+        <span className="text-muted-foreground">0</span>
+      ) : null}
+    </span>
   );
 }
 


### PR DESCRIPTION
## Summary

- Collapse Memory update file diffs behind a quiet per-card summary footer.
- Add per-update `View files` / `Hide files` expansion while keeping detailed diff expansion on individual file rows.
- Update Memory page tests to cover collapsed defaults, file-list expansion, diff expansion, and collapse.

Closes #16280

## Verification

- `pnpm exec prettier --write apps/platform/src/views/memory-page/memory-page.tsx apps/platform/src/views/memory-page/__tests__/memory-page.test.tsx apps/platform/src/signals/memory-page/memory-signals.ts`
- `pnpm exec vitest run apps/platform/src/views/memory-page/__tests__/memory-page.test.tsx`
- `pnpm --filter @vm0/app lint`
- `pnpm --filter @vm0/app check-types`

## Notes

- Per vm0 PR preference, I did not start a local dev server.
- Full `pnpm turbo run lint --log-order grouped` was attempted, but `apps/api` type-aware oxlint was killed with `SIGKILL` in this runtime.
- Full `pnpm check-types` was attempted, but `apps/api` hit a Node heap OOM in this runtime before reaching completion. The affected platform package check-types passed separately.