### PR TITLE
fix: allow recommended followups to wrap

### DIFF
--- a/turbo/apps/platform/src/views/zero-page/__tests__/zero-session-chat-page.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/zero-session-chat-page.test.tsx
@@ -181,7 +181,7 @@ describe("recommended follow-ups", () => {
     );
     expect(
       screen.getByText("Turn this into a week-by-week checklist"),
-    ).toHaveClass("truncate");
+    ).not.toHaveClass("truncate");
     await userEvent.click(followupButton);
 
     await waitFor(() => {

--- a/turbo/apps/platform/src/views/zero-page/zero-chat-thread-page.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-chat-thread-page.tsx
@@ -3546,7 +3546,7 @@ function RecommendedFollowupList({
             <span className="shrink-0 text-muted-foreground/70 transition-colors group-hover:text-foreground">
               <RecommendedFollowupIcon followup={followup} />
             </span>
-            <span className="min-w-0 flex-1 truncate text-xs font-medium leading-5 text-muted-foreground group-hover:text-foreground">
+            <span className="min-w-0 flex-1 break-words text-xs font-medium leading-5 text-muted-foreground group-hover:text-foreground">
               {followup.prompt}
             </span>
             <IconArrowUpRight


### PR DESCRIPTION
## Summary
- remove truncation from recommended follow-up prompt text so full suggestions can wrap on mobile
- update the chat follow-up test to assert the prompt is not truncated

## Tests
- `pnpm -F @vm0/app exec vitest run src/views/zero-page/__tests__/zero-session-chat-page.test.tsx`
- `pnpm exec prettier --check apps/platform/src/views/zero-page/zero-chat-thread-page.tsx apps/platform/src/views/zero-page/__tests__/zero-session-chat-page.test.tsx`
- `git diff --check`