### PR TITLE
fix(mitm-addon): handle tld updater fetch failures

### DIFF
--- a/crates/runner/mitm-addon/scripts/update_x_tlds.py
+++ b/crates/runner/mitm-addon/scripts/update_x_tlds.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import argparse
 import difflib
+import http.client
 import importlib.util
 import re
 import ssl
@@ -29,6 +30,10 @@ TLD_RE = re.compile(r"^[a-z0-9-]+$")
 class _NoRedirect(urllib.request.HTTPRedirectHandler):
     def redirect_request(self, req, fp, code, msg, headers, newurl):
         return None
+
+
+class TldFetchError(RuntimeError):
+    """Raised when the live IANA TLD source cannot be fetched."""
 
 
 class SnapshotComparison(NamedTuple):
@@ -64,11 +69,13 @@ def fetch_source() -> str:
     try:
         with opener.open(request, timeout=FETCH_TIMEOUT_SECONDS) as response:
             if response.status != HTTPStatus.OK:
-                raise RuntimeError(f"failed to fetch {SOURCE_URL}: HTTP {response.status}")
+                raise TldFetchError(f"failed to fetch {SOURCE_URL}: HTTP {response.status}")
             return response.read().decode("utf-8")
     except urllib.error.HTTPError as exc:
         with exc:
-            raise RuntimeError(f"failed to fetch {SOURCE_URL}: HTTP {exc.code}") from exc
+            raise TldFetchError(f"failed to fetch {SOURCE_URL}: HTTP {exc.code}") from exc
+    except (OSError, http.client.HTTPException) as exc:
+        raise TldFetchError(f"failed to fetch {SOURCE_URL}: {exc}") from exc
 
 
 def parse_source(source: str) -> tuple[str, tuple[str, ...]]:
@@ -262,4 +269,8 @@ def main() -> int:
         if args.source_file is None:
             parser.error("--check-source requires --source-file")
         return check_source(args.source_file)
-    return update_generated(args.source_file)
+    try:
+        return update_generated(args.source_file)
+    except TldFetchError as exc:
+        sys.stderr.write(f"{exc}\n")
+        return 1

--- a/crates/runner/mitm-addon/tests/test_update_x_tlds.py
+++ b/crates/runner/mitm-addon/tests/test_update_x_tlds.py
@@ -1,8 +1,12 @@
 from __future__ import annotations
 
+import http.client
+import io
 import subprocess
 import sys
+import urllib.error
 from collections.abc import Iterable
+from email.message import Message
 from pathlib import Path
 
 import pytest
@@ -13,6 +17,52 @@ from usage.providers.connectors.x_tlds import IANA_TLD_VERSION, IANA_TLDS
 _ADDON_ROOT = Path(__file__).resolve().parents[1]
 _UPDATE_SCRIPT = _ADDON_ROOT / "scripts" / "update-x-tlds.py"
 _CLI_TIMEOUT_SECONDS = 30
+
+
+class _FailingOpener:
+    def open(self, request: object, timeout: int) -> None:
+        raise urllib.error.URLError("dns failed")
+
+
+class _HttpErrorOpener:
+    def open(self, request: object, timeout: int) -> None:
+        raise urllib.error.HTTPError(
+            update_x_tlds.SOURCE_URL,
+            503,
+            "Service Unavailable",
+            Message(),
+            io.BytesIO(b""),
+        )
+
+
+class _ReadFailureResponse:
+    status = update_x_tlds.HTTPStatus.OK
+
+    def __enter__(self) -> _ReadFailureResponse:
+        return self
+
+    def __exit__(self, exc_type: object, exc: object, traceback: object) -> None:
+        return None
+
+    def read(self) -> bytes:
+        raise http.client.IncompleteRead(b"partial")
+
+
+class _ReadFailureOpener:
+    def open(self, request: object, timeout: int) -> _ReadFailureResponse:
+        return _ReadFailureResponse()
+
+
+def _build_failing_opener(*handlers: object) -> _FailingOpener:
+    return _FailingOpener()
+
+
+def _build_http_error_opener(*handlers: object) -> _HttpErrorOpener:
+    return _HttpErrorOpener()
+
+
+def _build_read_failure_opener(*handlers: object) -> _ReadFailureOpener:
+    return _ReadFailureOpener()
 
 
 def _source_text(version: str, tlds: Iterable[str]) -> str:
@@ -95,6 +145,57 @@ def test_update_generated_rejects_malformed_source_without_replacing_output(tmp_
     with pytest.raises(ValueError, match="version header"):
         update_x_tlds.update_generated(source)
 
+    assert output.read_text(encoding="utf-8") == original
+
+
+def test_fetch_source_reports_url_error_as_fetch_error(monkeypatch):
+    monkeypatch.setattr(update_x_tlds.urllib.request, "build_opener", _build_failing_opener)
+
+    with pytest.raises(update_x_tlds.TldFetchError) as exc_info:
+        update_x_tlds.fetch_source()
+
+    message = str(exc_info.value)
+    assert f"failed to fetch {update_x_tlds.SOURCE_URL}:" in message
+    assert "dns failed" in message
+
+
+def test_fetch_source_preserves_http_error_status_message(monkeypatch):
+    monkeypatch.setattr(update_x_tlds.urllib.request, "build_opener", _build_http_error_opener)
+
+    with pytest.raises(update_x_tlds.TldFetchError) as exc_info:
+        update_x_tlds.fetch_source()
+
+    assert str(exc_info.value) == f"failed to fetch {update_x_tlds.SOURCE_URL}: HTTP 503"
+
+
+def test_fetch_source_reports_response_read_failure_as_fetch_error(monkeypatch):
+    monkeypatch.setattr(update_x_tlds.urllib.request, "build_opener", _build_read_failure_opener)
+
+    with pytest.raises(update_x_tlds.TldFetchError) as exc_info:
+        update_x_tlds.fetch_source()
+
+    message = str(exc_info.value)
+    assert f"failed to fetch {update_x_tlds.SOURCE_URL}:" in message
+    assert "IncompleteRead" in message
+
+
+def test_default_update_cli_reports_fetch_failure_without_replacing_output(
+    tmp_path, monkeypatch, capsys
+):
+    output = tmp_path / "x_tlds.py"
+    original = "# existing generated snapshot\n"
+    output.write_text(original, encoding="utf-8")
+    monkeypatch.setattr(sys, "argv", [str(_UPDATE_SCRIPT)])
+    monkeypatch.setattr(update_x_tlds, "OUTPUT_PATH", output)
+    monkeypatch.setattr(update_x_tlds.urllib.request, "build_opener", _build_failing_opener)
+
+    assert update_x_tlds.main() == 1
+
+    captured = capsys.readouterr()
+    assert captured.out == ""
+    assert f"failed to fetch {update_x_tlds.SOURCE_URL}:" in captured.err
+    assert "dns failed" in captured.err
+    assert "Traceback" not in captured.err
     assert output.read_text(encoding="utf-8") == original
 
 


### PR DESCRIPTION
## Summary
- add a narrow `TldFetchError` for live IANA TLD source fetch failures
- normalize HTTP and lower-level `OSError` fetch failures into concise updater errors
- make the default updater CLI return `1` without a traceback when live fetch fails
- add regression coverage for fetch failure reporting and output-file preservation

Closes #16236

## Testing
- `cd crates/runner/mitm-addon && ruff format --check scripts/update_x_tlds.py tests/test_update_x_tlds.py`
- `cd crates/runner/mitm-addon && ruff check scripts/update_x_tlds.py tests/test_update_x_tlds.py`
- `cd crates/runner/mitm-addon && basedpyright -p .`
- `cd crates/runner/mitm-addon && python3 -m pytest tests/test_update_x_tlds.py -v`

Additional local check:
- `cd crates/runner/mitm-addon && python3 -m pytest tests/ -v` failed in existing X firewall consistency tests because `turbo/packages/connectors/src/firewalls/index.ts` imports missing generated module `./ashby.generated`; targeted updater tests passed.