### PR TITLE
fix(runner): split guest-agent bootstrap env

### DIFF
--- a/crates/guest-agent/src/cli/child_env.rs
+++ b/crates/guest-agent/src/cli/child_env.rs
@@ -4,7 +4,22 @@ use crate::env;
 
 const DEFAULT_PATH: &str = "/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin";
 const DEFAULT_SHELL: &str = "/bin/bash";
-const OPTIONAL_BASE_ENV_KEYS: &[&str] = &["USER", "LOGNAME", "LANG", "LC_ALL", "LC_CTYPE", "TERM"];
+const OPTIONAL_BASE_ENV_KEYS: &[&str] = &[
+    "USER",
+    "LOGNAME",
+    "LANG",
+    "LC_ALL",
+    "LC_CTYPE",
+    "TERM",
+    // Rootfs-wide runtime settings from /etc/environment. Keep these out of
+    // guest-agent bootstrap control while preserving the CLI contract that
+    // tools trust the injected proxy CA by default.
+    "NPM_CONFIG_UPDATE_NOTIFIER",
+    "NODE_EXTRA_CA_CERTS",
+    "SSL_CERT_FILE",
+    "REQUESTS_CA_BUNDLE",
+    "CARGO_HTTP_CAINFO",
+];
 
 pub(super) fn apply_to_tokio_command(cmd: &mut tokio::process::Command) {
     cmd.env_clear();

--- a/crates/guest-agent/src/cli/child_env.rs
+++ b/crates/guest-agent/src/cli/child_env.rs
@@ -1,0 +1,70 @@
+//! Curated environment for CLI children.
+
+use crate::env;
+
+const DEFAULT_PATH: &str = "/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin";
+const DEFAULT_SHELL: &str = "/bin/bash";
+const OPTIONAL_BASE_ENV_KEYS: &[&str] = &["USER", "LOGNAME", "LANG", "LC_ALL", "LC_CTYPE", "TERM"];
+
+pub(super) fn apply_to_tokio_command(cmd: &mut tokio::process::Command) {
+    cmd.env_clear();
+    for (key, value) in base_child_env() {
+        cmd.env(key, value);
+    }
+    for (key, value) in env::user_env() {
+        cmd.env(key, value);
+    }
+}
+
+pub(super) fn apply_to_std_command(cmd: &mut std::process::Command) {
+    cmd.env_clear();
+    for (key, value) in base_child_env() {
+        cmd.env(key, value);
+    }
+    for (key, value) in env::user_env() {
+        cmd.env(key, value);
+    }
+}
+
+fn base_child_env() -> Vec<(&'static str, String)> {
+    let mut base = Vec::with_capacity(OPTIONAL_BASE_ENV_KEYS.len() + 3);
+    base.push(("HOME", env::home_dir().to_string()));
+    base.push((
+        "PATH",
+        std::env::var("PATH")
+            .ok()
+            .filter(|value| !value.is_empty())
+            .unwrap_or_else(|| DEFAULT_PATH.to_string()),
+    ));
+    base.push((
+        "SHELL",
+        std::env::var("SHELL")
+            .ok()
+            .filter(|value| !value.is_empty())
+            .unwrap_or_else(|| DEFAULT_SHELL.to_string()),
+    ));
+
+    for key in OPTIONAL_BASE_ENV_KEYS {
+        if let Ok(value) = std::env::var(key)
+            && !value.is_empty()
+        {
+            base.push((*key, value));
+        }
+    }
+
+    base
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn base_child_env_includes_stable_minimum() {
+        let keys: Vec<&str> = base_child_env().into_iter().map(|(key, _)| key).collect();
+
+        assert!(keys.contains(&"HOME"));
+        assert!(keys.contains(&"PATH"));
+        assert!(keys.contains(&"SHELL"));
+    }
+}

--- a/crates/guest-agent/src/cli/codex_setup.rs
+++ b/crates/guest-agent/src/cli/codex_setup.rs
@@ -14,6 +14,8 @@ use guest_common::{log_info, log_warn};
 use crate::env;
 use crate::error::AgentError;
 
+use super::child_env;
+
 const LOG_TAG: &str = "sandbox:guest-agent";
 
 /// Set up codex auth on the guest before invoking `codex exec`.
@@ -28,8 +30,8 @@ const LOG_TAG: &str = "sandbox:guest-agent";
 ///
 /// - **API-key mode** (default): pipe `OPENAI_API_KEY` into
 ///   `codex login --with-api-key` to write `~/.codex/auth.json`. If
-///   `OPENAI_API_KEY` is empty, log and return Ok -- `codex exec` reads
-///   the env directly so the env path covers authn even when the login
+///   `OPENAI_API_KEY` is empty, log and return Ok -- `codex exec` receives
+///   the loaded user env so the env path covers authn even when the login
 ///   subcommand isn't available.
 ///
 /// Both paths are best-effort -- failure logs but does not abort init.
@@ -49,7 +51,9 @@ pub fn setup_codex() -> Result<(), AgentError> {
     }
 
     let login_start = Instant::now();
-    let result = std::process::Command::new("codex")
+    let mut cmd = std::process::Command::new("codex");
+    child_env::apply_to_std_command(&mut cmd);
+    let result = cmd
         .args(["login", "--with-api-key"])
         .env("CODEX_HOME", &codex_home)
         .stdin(Stdio::piped())

--- a/crates/guest-agent/src/cli/mod.rs
+++ b/crates/guest-agent/src/cli/mod.rs
@@ -15,6 +15,7 @@
 //! child reaping. Branch ordering and deadline reset timing in that control
 //! flow are part of the runtime contract.
 
+mod child_env;
 mod codex_setup;
 mod command;
 mod diagnostics;
@@ -130,11 +131,11 @@ pub async fn execute_cli(
         .stdin(Stdio::null())
         .stdout(Stdio::piped())
         .stderr(Stdio::piped())
-        .env_remove(process_control_ipc::BOOTSTRAP_ENV)
         .process_group(0)
         // If a future setup step fails after spawn, dropping `Child` must not
         // leave a CLI process running in the VM.
         .kill_on_drop(true);
+    child_env::apply_to_tokio_command(&mut cmd);
     // Set the child cwd explicitly at spawn time so the CLI observes the
     // current canonical workspace mount instead of relying on inherited cwd.
     set_cli_current_dir(&mut cmd, paths::CANONICAL_WORKING_DIR)?;
@@ -160,6 +161,13 @@ pub async fn execute_cli(
             // it to $HOME/.codex so the login state from setup_codex
             // is visible to exec.
             cmd.env("CODEX_HOME", format!("{}/.codex", env::home_dir()));
+            // Test-only mock fixture selector; keep it explicit instead of
+            // reopening inherited env for Codex children.
+            if env::use_mock_codex()
+                && let Ok(fixture) = std::env::var("MOCK_CODEX_FIXTURE")
+            {
+                cmd.env("MOCK_CODEX_FIXTURE", fixture);
+            }
             if env::is_codex_oauth_mode() {
                 cmd.env(
                     "CODEX_REFRESH_TOKEN_URL_OVERRIDE",

--- a/crates/guest-agent/src/env.rs
+++ b/crates/guest-agent/src/env.rs
@@ -6,8 +6,8 @@ use std::sync::LazyLock;
 
 use api_contracts::generated::types::runners::storage::ArtifactEntryMissingRootPolicy;
 
+use crate::constants;
 use crate::error::AgentError;
-use crate::{constants, paths};
 use guest_common::log_warn;
 
 const LOG_TAG: &str = "sandbox:guest-agent";
@@ -286,7 +286,18 @@ fn is_user_env_private_dir(path: &Path) -> bool {
 }
 
 fn validate_user_env_file_path(path: &Path) -> Result<(), String> {
-    validate_user_env_file_path_for_runtime(path, paths::runtime_dir())
+    let runtime_dir = guest_runtime_dir_for_user_env()?;
+    validate_user_env_file_path_for_runtime(path, &runtime_dir)
+}
+
+fn guest_runtime_dir_for_user_env() -> Result<PathBuf, String> {
+    let run_id = env_or_empty("VM0_RUN_ID");
+    guest_runtime_dir_for_user_env_run_id(&run_id)
+}
+
+fn guest_runtime_dir_for_user_env_run_id(run_id: &str) -> Result<PathBuf, String> {
+    guest_runtime_paths::run_dir_from_env(run_id)
+        .map_err(|e| format!("resolve guest runtime dir for {USER_ENV_FILE_ENV_KEY}: {e}"))
 }
 
 fn user_env_file_path_for_runtime(runtime_dir: &Path) -> PathBuf {
@@ -627,6 +638,13 @@ mod tests {
             )
             .is_ok()
         );
+    }
+
+    #[test]
+    fn guest_runtime_dir_for_user_env_returns_error_when_run_id_missing() {
+        let err = guest_runtime_dir_for_user_env_run_id("").unwrap_err();
+
+        assert!(err.contains("VM0_RUN_ID is required"));
     }
 
     #[test]

--- a/crates/guest-agent/src/env.rs
+++ b/crates/guest-agent/src/env.rs
@@ -1,13 +1,19 @@
 //! Environment variable accessors — each value is read once via `LazyLock`.
 
+use std::collections::HashMap;
+use std::path::Path;
 use std::sync::LazyLock;
 
 use api_contracts::generated::types::runners::storage::ArtifactEntryMissingRootPolicy;
 
 use crate::constants;
+use crate::error::AgentError;
 use guest_common::log_warn;
 
 const LOG_TAG: &str = "sandbox:guest-agent";
+const USER_ENV_FILE_ENV_KEY: &str = "VM0_USER_ENV_FILE";
+const USER_ENV_PRIVATE_DIR_PREFIX: &str = "vm0-user-env-";
+const ENV_KEY_DIAGNOSTIC_MAX_CHARS: usize = 128;
 
 fn env_or_empty(name: &str) -> String {
     std::env::var(name).unwrap_or_default()
@@ -94,9 +100,9 @@ static MOCK_CLAUDE_PATH: LazyLock<String> = LazyLock::new(|| {
 // ---------------------------------------------------------------------------
 
 static CLI_AGENT_TYPE: LazyLock<String> = LazyLock::new(|| env_or_empty("CLI_AGENT_TYPE"));
-static OPENAI_API_KEY: LazyLock<String> = LazyLock::new(|| env_or_empty("OPENAI_API_KEY"));
-static OPENAI_MODEL: LazyLock<String> = LazyLock::new(|| env_or_empty("OPENAI_MODEL"));
-static CHATGPT_ACCOUNT_ID: LazyLock<String> = LazyLock::new(|| env_or_empty("CHATGPT_ACCOUNT_ID"));
+static USER_ENV: LazyLock<Result<HashMap<String, String>, String>> =
+    LazyLock::new(load_user_env_from_process);
+static EMPTY_USER_ENV: LazyLock<HashMap<String, String>> = LazyLock::new(HashMap::new);
 
 /// `USE_MOCK_CODEX` accepts both `"true"` and `"1"` (matches the Codex
 /// epic's documented invocation shape `USE_MOCK_CODEX=1`). The
@@ -228,6 +234,109 @@ fn load_artifacts() -> Vec<ArtifactEnv> {
 
 static ARTIFACTS: LazyLock<Vec<ArtifactEnv>> = LazyLock::new(load_artifacts);
 
+fn load_user_env_from_process() -> Result<HashMap<String, String>, String> {
+    let path = env_or_empty(USER_ENV_FILE_ENV_KEY);
+    if path.is_empty() {
+        return Ok(HashMap::new());
+    }
+
+    load_user_env_from_path(Path::new(&path))
+}
+
+fn load_user_env_from_path(path: &Path) -> Result<HashMap<String, String>, String> {
+    let raw = std::fs::read_to_string(path)
+        .map_err(|e| format!("read {USER_ENV_FILE_ENV_KEY} {}: {e}", path.display()))?;
+    let user_env: HashMap<String, String> = serde_json::from_str(&raw)
+        .map_err(|e| format!("parse {USER_ENV_FILE_ENV_KEY} JSON: {e}"))?;
+    validate_user_env(&user_env)?;
+
+    std::fs::remove_file(path)
+        .map_err(|e| format!("remove {USER_ENV_FILE_ENV_KEY} {}: {e}", path.display()))?;
+    if let Some(parent) = path.parent()
+        && is_user_env_private_dir(parent)
+    {
+        std::fs::remove_dir(parent).map_err(|e| {
+            format!(
+                "remove {USER_ENV_FILE_ENV_KEY} parent {}: {e}",
+                parent.display()
+            )
+        })?;
+    }
+
+    Ok(user_env)
+}
+
+fn is_user_env_private_dir(path: &Path) -> bool {
+    path.file_name()
+        .and_then(|name| name.to_str())
+        .is_some_and(|name| name.starts_with(USER_ENV_PRIVATE_DIR_PREFIX))
+}
+
+fn validate_user_env(user_env: &HashMap<String, String>) -> Result<(), String> {
+    let mut entries: Vec<(&String, &String)> = user_env.iter().collect();
+    entries.sort_by_key(|(key, _)| *key);
+
+    for (key, value) in entries {
+        if !is_valid_env_key(key) {
+            return Err(format!(
+                "{USER_ENV_FILE_ENV_KEY} contains invalid env key {:?}",
+                sanitize_env_key_for_diagnostic(key)
+            ));
+        }
+        if value.contains('\0') {
+            return Err(format!(
+                "{USER_ENV_FILE_ENV_KEY} contains NUL byte for env key {:?}",
+                sanitize_env_key_for_diagnostic(key)
+            ));
+        }
+    }
+
+    Ok(())
+}
+
+fn is_valid_env_key(key: &str) -> bool {
+    let mut chars = key.chars();
+    let Some(first) = chars.next() else {
+        return false;
+    };
+    if !(first == '_' || first.is_ascii_alphabetic()) {
+        return false;
+    }
+    chars.all(|ch| ch == '_' || ch.is_ascii_alphanumeric())
+}
+
+fn sanitize_env_key_for_diagnostic(key: &str) -> String {
+    let mut chars = key.escape_debug();
+    let mut truncated = String::new();
+    for _ in 0..ENV_KEY_DIAGNOSTIC_MAX_CHARS {
+        let Some(ch) = chars.next() else {
+            return truncated;
+        };
+        truncated.push(ch);
+    }
+    if chars.next().is_some() {
+        truncated.push_str("...");
+    }
+    truncated
+}
+
+fn user_env_map() -> &'static HashMap<String, String> {
+    match &*USER_ENV {
+        Ok(user_env) => user_env,
+        Err(message) => {
+            log_warn!(
+                LOG_TAG,
+                "{USER_ENV_FILE_ENV_KEY} failed to load before accessor use: {message}"
+            );
+            &EMPTY_USER_ENV
+        }
+    }
+}
+
+fn user_env_value(name: &str) -> &'static str {
+    user_env_map().get(name).map(String::as_str).unwrap_or("")
+}
+
 // ---------------------------------------------------------------------------
 // Public accessors
 // ---------------------------------------------------------------------------
@@ -294,6 +403,17 @@ pub fn tools() -> &'static str {
 pub fn settings() -> &'static str {
     &SETTINGS
 }
+/// Load and validate the runner-provided user env payload once at startup.
+pub fn init_user_env() -> Result<(), AgentError> {
+    match &*USER_ENV {
+        Ok(_) => Ok(()),
+        Err(message) => Err(AgentError::Execution(message.clone())),
+    }
+}
+/// User/model/connector environment loaded from `VM0_USER_ENV_FILE`.
+pub fn user_env() -> &'static HashMap<String, String> {
+    user_env_map()
+}
 /// Whether `USE_MOCK_CLAUDE` is exactly `"true"`; unset or any other value is
 /// false.
 pub fn use_mock_claude() -> bool {
@@ -308,26 +428,26 @@ pub fn mock_claude_path() -> String {
 pub fn cli_agent_type() -> &'static str {
     &CLI_AGENT_TYPE
 }
-/// OpenAI API key from `OPENAI_API_KEY`; empty string means unset.
+/// OpenAI API key from loaded user env; empty string means unset.
 pub fn openai_api_key() -> &'static str {
-    &OPENAI_API_KEY
+    user_env_value("OPENAI_API_KEY")
 }
-/// OpenAI model from `OPENAI_MODEL`; empty string means unset.
+/// OpenAI model from loaded user env; empty string means unset.
 pub fn openai_model() -> &'static str {
-    &OPENAI_MODEL
+    user_env_value("OPENAI_MODEL")
 }
-/// ChatGPT workspace account id from `CHATGPT_ACCOUNT_ID`; empty string
+/// ChatGPT workspace account id from loaded user env; empty string
 /// means unset. Presence is the signal that the sandbox is running in
 /// codex-oauth mode (see `is_codex_oauth_mode`); the value itself is
 /// not consumed by the guest-agent — the firewall replaces the
 /// placeholder bytes in `auth.json` on egress.
 pub fn chatgpt_account_id() -> &'static str {
-    &CHATGPT_ACCOUNT_ID
+    user_env_value("CHATGPT_ACCOUNT_ID")
 }
 /// Whether the sandbox should bootstrap codex into codex-oauth mode
 /// instead of the API-key path. True iff `CHATGPT_ACCOUNT_ID` is set.
 pub fn is_codex_oauth_mode() -> bool {
-    !CHATGPT_ACCOUNT_ID.is_empty()
+    !chatgpt_account_id().is_empty()
 }
 /// Whether `USE_MOCK_CODEX` is `"true"` or `"1"`; unset or any other value is
 /// false.
@@ -379,10 +499,79 @@ pub fn post_result_sigterm_grace_secs() -> u64 {
 pub fn post_result_sigkill_grace_secs() -> u64 {
     *POST_RESULT_SIGKILL_GRACE
 }
+
 /// Whether a backend API is available (token set).
 ///
 /// When false (e.g. local-provider test mode), heartbeat / events / checkpoint
 /// are skipped because there is no API server to call.
 pub fn has_api() -> bool {
     !API_TOKEN.is_empty()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn write_user_env_fixture(json: &str) -> (tempfile::TempDir, std::path::PathBuf) {
+        let tmp = tempfile::tempdir().unwrap();
+        let dir = tmp.path().join("vm0-user-env-test");
+        std::fs::create_dir(&dir).unwrap();
+        let path = dir.join("env.json");
+        std::fs::write(&path, json).unwrap();
+        (tmp, path)
+    }
+
+    #[test]
+    fn load_user_env_from_path_loads_provider_values_and_removes_file() {
+        let (_tmp, path) = write_user_env_fixture(
+            r#"{"OPENAI_API_KEY":"sk-test","OPENAI_MODEL":"gpt-test","CHATGPT_ACCOUNT_ID":"acct"}"#,
+        );
+        let parent = path.parent().unwrap().to_path_buf();
+
+        let user_env = load_user_env_from_path(&path).unwrap();
+
+        assert_eq!(user_env.get("OPENAI_API_KEY").unwrap(), "sk-test");
+        assert_eq!(user_env.get("OPENAI_MODEL").unwrap(), "gpt-test");
+        assert_eq!(user_env.get("CHATGPT_ACCOUNT_ID").unwrap(), "acct");
+        assert!(!path.exists());
+        assert!(!parent.exists());
+    }
+
+    #[test]
+    fn load_user_env_from_path_rejects_invalid_key_without_value_leak() {
+        let (_tmp, path) =
+            write_user_env_fixture(r#"{"BAD-KEY":"secret-value","OPENAI_API_KEY":"sk-test"}"#);
+
+        let err = load_user_env_from_path(&path).unwrap_err();
+
+        assert!(err.contains("BAD-KEY"));
+        assert!(!err.contains("secret-value"));
+        assert!(!err.contains("sk-test"));
+    }
+
+    #[test]
+    fn load_user_env_from_path_keeps_unexpected_parent_dir() {
+        let tmp = tempfile::tempdir().unwrap();
+        let dir = tmp.path().join("unexpected-user-env-dir");
+        std::fs::create_dir(&dir).unwrap();
+        let path = dir.join("env.json");
+        std::fs::write(&path, r#"{"OPENAI_MODEL":"gpt-test"}"#).unwrap();
+
+        let user_env = load_user_env_from_path(&path).unwrap();
+
+        assert_eq!(user_env.get("OPENAI_MODEL").unwrap(), "gpt-test");
+        assert!(!path.exists());
+        assert!(dir.exists());
+    }
+
+    #[test]
+    fn load_user_env_from_path_rejects_nul_value_without_value_leak() {
+        let (_tmp, path) = write_user_env_fixture("{\"OPENAI_API_KEY\":\"sk-test\\u0000secret\"}");
+
+        let err = load_user_env_from_path(&path).unwrap_err();
+
+        assert!(err.contains("OPENAI_API_KEY"));
+        assert!(!err.contains("sk-test"));
+        assert!(!err.contains("secret"));
+    }
 }

--- a/crates/guest-agent/src/env.rs
+++ b/crates/guest-agent/src/env.rs
@@ -123,17 +123,22 @@ static MOCK_CODEX_PATH: LazyLock<String> = LazyLock::new(|| {
     std::env::var("VM0_MOCK_CODEX_PATH").unwrap_or_else(|_| DEFAULT_MOCK_CODEX_PATH.to_string())
 });
 
-/// `$HOME` is always set in the guest sandbox (rootfs init guarantees it).
-/// If it isn't, the rootfs is misconfigured and we want a loud, visible
-/// failure rather than papering over it with a magic path that would
-/// silently land codex auth state in the wrong directory.
+/// `$HOME` is always set in the guest sandbox (rootfs init guarantees it),
+/// unless the loaded user env intentionally overrides it for the CLI child.
+/// If neither source sets it, the rootfs is misconfigured and we want a loud,
+/// visible failure rather than papering over it with a magic path that would
+/// silently land session/auth state in the wrong directory.
 ///
 /// # Panics
-/// Panics if `HOME` is unset. This indicates a rootfs/runner contract
-/// violation and is not user-recoverable; the same fail-fast policy as
-/// `load_artifacts` (`VM0_ARTIFACTS`).
+/// Panics if `HOME` is unset in both loaded user env and the guest process env.
+/// This indicates a rootfs/runner contract violation and is not
+/// user-recoverable; the same fail-fast policy as `load_artifacts`
+/// (`VM0_ARTIFACTS`).
 #[allow(clippy::expect_used)]
 fn load_home_dir() -> String {
+    if let Some(home) = user_env_map().get("HOME") {
+        return home.clone();
+    }
     std::env::var("HOME").expect("HOME must be set in guest sandbox (rootfs init contract)")
 }
 
@@ -484,11 +489,11 @@ pub fn use_mock_codex() -> bool {
 pub fn mock_codex_path() -> String {
     MOCK_CODEX_PATH.clone()
 }
-/// Guest home directory from `HOME`.
+/// Guest home directory from loaded user env `HOME`, or process `HOME`.
 ///
 /// # Panics
-/// Panics if `HOME` is unset, which indicates a rootfs/runner contract
-/// violation.
+/// Panics if `HOME` is unset in both sources, which indicates a rootfs/runner
+/// contract violation.
 pub fn home_dir() -> &'static str {
     &HOME_DIR
 }

--- a/crates/guest-agent/src/env.rs
+++ b/crates/guest-agent/src/env.rs
@@ -1,19 +1,18 @@
 //! Environment variable accessors — each value is read once via `LazyLock`.
 
 use std::collections::HashMap;
-use std::path::Path;
+use std::path::{Path, PathBuf};
 use std::sync::LazyLock;
 
 use api_contracts::generated::types::runners::storage::ArtifactEntryMissingRootPolicy;
 
-use crate::constants;
 use crate::error::AgentError;
+use crate::{constants, paths};
 use guest_common::log_warn;
 
 const LOG_TAG: &str = "sandbox:guest-agent";
 const USER_ENV_FILE_ENV_KEY: &str = "VM0_USER_ENV_FILE";
-const USER_ENV_PRIVATE_DIR_PREFIX: &str = "vm0-user-env-";
-const USER_ENV_PRIVATE_ROOT: &str = "/tmp";
+const USER_ENV_PRIVATE_DIR_NAME: &str = "user-env";
 const USER_ENV_FILENAME: &str = "env.json";
 const ENV_KEY_DIAGNOSTIC_MAX_CHARS: usize = 128;
 
@@ -281,27 +280,28 @@ fn remove_user_env_file(path: &Path) -> Result<(), String> {
 }
 
 fn is_user_env_private_dir(path: &Path) -> bool {
-    if path.parent() != Some(Path::new(USER_ENV_PRIVATE_ROOT)) {
-        return false;
-    }
-
     path.file_name()
         .and_then(|name| name.to_str())
-        .is_some_and(|name| name.starts_with(USER_ENV_PRIVATE_DIR_PREFIX))
+        .is_some_and(|name| name == USER_ENV_PRIVATE_DIR_NAME)
 }
 
 fn validate_user_env_file_path(path: &Path) -> Result<(), String> {
-    let valid_file_name = path
-        .file_name()
-        .and_then(|name| name.to_str())
-        .is_some_and(|name| name == USER_ENV_FILENAME);
-    let valid_parent = path.parent().is_some_and(is_user_env_private_dir);
-    if valid_file_name && valid_parent {
+    validate_user_env_file_path_for_runtime(path, paths::runtime_dir())
+}
+
+fn user_env_file_path_for_runtime(runtime_dir: &Path) -> PathBuf {
+    runtime_dir
+        .join(USER_ENV_PRIVATE_DIR_NAME)
+        .join(USER_ENV_FILENAME)
+}
+
+fn validate_user_env_file_path_for_runtime(path: &Path, runtime_dir: &Path) -> Result<(), String> {
+    if path == user_env_file_path_for_runtime(runtime_dir) {
         return Ok(());
     }
 
     Err(format!(
-        "{USER_ENV_FILE_ENV_KEY} must point to {USER_ENV_PRIVATE_ROOT}/{USER_ENV_PRIVATE_DIR_PREFIX}*/{USER_ENV_FILENAME}"
+        "{USER_ENV_FILE_ENV_KEY} must point to guest runtime {USER_ENV_PRIVATE_DIR_NAME}/{USER_ENV_FILENAME}"
     ))
 }
 
@@ -543,11 +543,10 @@ mod tests {
     use super::*;
 
     fn write_user_env_fixture(json: &str) -> (tempfile::TempDir, std::path::PathBuf) {
-        let tmp = tempfile::Builder::new()
-            .prefix("vm0-user-env-test")
-            .tempdir_in(USER_ENV_PRIVATE_ROOT)
-            .unwrap();
-        let path = tmp.path().join(USER_ENV_FILENAME);
+        let tmp = tempfile::tempdir().unwrap();
+        let dir = tmp.path().join(USER_ENV_PRIVATE_DIR_NAME);
+        std::fs::create_dir(&dir).unwrap();
+        let path = dir.join(USER_ENV_FILENAME);
         std::fs::write(&path, json).unwrap();
         (tmp, path)
     }
@@ -613,11 +612,21 @@ mod tests {
 
     #[test]
     fn validate_user_env_file_path_rejects_unexpected_path() {
-        let err = validate_user_env_file_path(Path::new("/home/user/vm0-user-env-test/env.json"))
-            .unwrap_err();
+        let tmp = tempfile::tempdir().unwrap();
+        let runtime_dir = tmp.path().join("runtime");
+        let unexpected = tmp.path().join("other").join("user-env").join("env.json");
 
-        assert!(err.contains("/tmp/vm0-user-env-"));
-        assert!(!err.contains("/home/user"));
+        let err = validate_user_env_file_path_for_runtime(&unexpected, &runtime_dir).unwrap_err();
+
+        assert!(err.contains("user-env/env.json"));
+        assert!(!err.contains(unexpected.to_string_lossy().as_ref()));
+        assert!(
+            validate_user_env_file_path_for_runtime(
+                &user_env_file_path_for_runtime(&runtime_dir),
+                &runtime_dir,
+            )
+            .is_ok()
+        );
     }
 
     #[test]

--- a/crates/guest-agent/src/env.rs
+++ b/crates/guest-agent/src/env.rs
@@ -13,6 +13,8 @@ use guest_common::log_warn;
 const LOG_TAG: &str = "sandbox:guest-agent";
 const USER_ENV_FILE_ENV_KEY: &str = "VM0_USER_ENV_FILE";
 const USER_ENV_PRIVATE_DIR_PREFIX: &str = "vm0-user-env-";
+const USER_ENV_PRIVATE_ROOT: &str = "/tmp";
+const USER_ENV_FILENAME: &str = "env.json";
 const ENV_KEY_DIAGNOSTIC_MAX_CHARS: usize = 128;
 
 fn env_or_empty(name: &str) -> String {
@@ -102,7 +104,6 @@ static MOCK_CLAUDE_PATH: LazyLock<String> = LazyLock::new(|| {
 static CLI_AGENT_TYPE: LazyLock<String> = LazyLock::new(|| env_or_empty("CLI_AGENT_TYPE"));
 static USER_ENV: LazyLock<Result<HashMap<String, String>, String>> =
     LazyLock::new(load_user_env_from_process);
-static EMPTY_USER_ENV: LazyLock<HashMap<String, String>> = LazyLock::new(HashMap::new);
 
 /// `USE_MOCK_CODEX` accepts both `"true"` and `"1"` (matches the Codex
 /// epic's documented invocation shape `USE_MOCK_CODEX=1`). The
@@ -240,16 +241,24 @@ fn load_user_env_from_process() -> Result<HashMap<String, String>, String> {
         return Ok(HashMap::new());
     }
 
-    load_user_env_from_path(Path::new(&path))
+    let path = Path::new(&path);
+    validate_user_env_file_path(path)?;
+    load_user_env_from_path(path)
 }
 
 fn load_user_env_from_path(path: &Path) -> Result<HashMap<String, String>, String> {
     let raw = std::fs::read_to_string(path)
         .map_err(|e| format!("read {USER_ENV_FILE_ENV_KEY} {}: {e}", path.display()))?;
+    remove_user_env_file(path)?;
+
     let user_env: HashMap<String, String> = serde_json::from_str(&raw)
         .map_err(|e| format!("parse {USER_ENV_FILE_ENV_KEY} JSON: {e}"))?;
     validate_user_env(&user_env)?;
 
+    Ok(user_env)
+}
+
+fn remove_user_env_file(path: &Path) -> Result<(), String> {
     std::fs::remove_file(path)
         .map_err(|e| format!("remove {USER_ENV_FILE_ENV_KEY} {}: {e}", path.display()))?;
     if let Some(parent) = path.parent()
@@ -263,13 +272,32 @@ fn load_user_env_from_path(path: &Path) -> Result<HashMap<String, String>, Strin
         })?;
     }
 
-    Ok(user_env)
+    Ok(())
 }
 
 fn is_user_env_private_dir(path: &Path) -> bool {
+    if path.parent() != Some(Path::new(USER_ENV_PRIVATE_ROOT)) {
+        return false;
+    }
+
     path.file_name()
         .and_then(|name| name.to_str())
         .is_some_and(|name| name.starts_with(USER_ENV_PRIVATE_DIR_PREFIX))
+}
+
+fn validate_user_env_file_path(path: &Path) -> Result<(), String> {
+    let valid_file_name = path
+        .file_name()
+        .and_then(|name| name.to_str())
+        .is_some_and(|name| name == USER_ENV_FILENAME);
+    let valid_parent = path.parent().is_some_and(is_user_env_private_dir);
+    if valid_file_name && valid_parent {
+        return Ok(());
+    }
+
+    Err(format!(
+        "{USER_ENV_FILE_ENV_KEY} must point to {USER_ENV_PRIVATE_ROOT}/{USER_ENV_PRIVATE_DIR_PREFIX}*/{USER_ENV_FILENAME}"
+    ))
 }
 
 fn validate_user_env(user_env: &HashMap<String, String>) -> Result<(), String> {
@@ -320,15 +348,12 @@ fn sanitize_env_key_for_diagnostic(key: &str) -> String {
     truncated
 }
 
+#[allow(clippy::panic)] // Entry points must call init_user_env; bypassing it is a code bug.
 fn user_env_map() -> &'static HashMap<String, String> {
     match &*USER_ENV {
         Ok(user_env) => user_env,
         Err(message) => {
-            log_warn!(
-                LOG_TAG,
-                "{USER_ENV_FILE_ENV_KEY} failed to load before accessor use: {message}"
-            );
-            &EMPTY_USER_ENV
+            panic!("{USER_ENV_FILE_ENV_KEY} failed to load before accessor use: {message}")
         }
     }
 }
@@ -513,10 +538,11 @@ mod tests {
     use super::*;
 
     fn write_user_env_fixture(json: &str) -> (tempfile::TempDir, std::path::PathBuf) {
-        let tmp = tempfile::tempdir().unwrap();
-        let dir = tmp.path().join("vm0-user-env-test");
-        std::fs::create_dir(&dir).unwrap();
-        let path = dir.join("env.json");
+        let tmp = tempfile::Builder::new()
+            .prefix("vm0-user-env-test")
+            .tempdir_in(USER_ENV_PRIVATE_ROOT)
+            .unwrap();
+        let path = tmp.path().join(USER_ENV_FILENAME);
         std::fs::write(&path, json).unwrap();
         (tmp, path)
     }
@@ -541,12 +567,28 @@ mod tests {
     fn load_user_env_from_path_rejects_invalid_key_without_value_leak() {
         let (_tmp, path) =
             write_user_env_fixture(r#"{"BAD-KEY":"secret-value","OPENAI_API_KEY":"sk-test"}"#);
+        let parent = path.parent().unwrap().to_path_buf();
 
         let err = load_user_env_from_path(&path).unwrap_err();
 
         assert!(err.contains("BAD-KEY"));
         assert!(!err.contains("secret-value"));
         assert!(!err.contains("sk-test"));
+        assert!(!path.exists());
+        assert!(!parent.exists());
+    }
+
+    #[test]
+    fn load_user_env_from_path_removes_file_before_parse_error() {
+        let (_tmp, path) = write_user_env_fixture(r#"{"OPENAI_API_KEY":"sk-test""#);
+        let parent = path.parent().unwrap().to_path_buf();
+
+        let err = load_user_env_from_path(&path).unwrap_err();
+
+        assert!(err.contains("parse"));
+        assert!(!err.contains("sk-test"));
+        assert!(!path.exists());
+        assert!(!parent.exists());
     }
 
     #[test]
@@ -565,13 +607,25 @@ mod tests {
     }
 
     #[test]
+    fn validate_user_env_file_path_rejects_unexpected_path() {
+        let err = validate_user_env_file_path(Path::new("/home/user/vm0-user-env-test/env.json"))
+            .unwrap_err();
+
+        assert!(err.contains("/tmp/vm0-user-env-"));
+        assert!(!err.contains("/home/user"));
+    }
+
+    #[test]
     fn load_user_env_from_path_rejects_nul_value_without_value_leak() {
         let (_tmp, path) = write_user_env_fixture("{\"OPENAI_API_KEY\":\"sk-test\\u0000secret\"}");
+        let parent = path.parent().unwrap().to_path_buf();
 
         let err = load_user_env_from_path(&path).unwrap_err();
 
         assert!(err.contains("OPENAI_API_KEY"));
         assert!(!err.contains("sk-test"));
         assert!(!err.contains("secret"));
+        assert!(!path.exists());
+        assert!(!parent.exists());
     }
 }

--- a/crates/guest-agent/src/env.rs
+++ b/crates/guest-agent/src/env.rs
@@ -296,6 +296,8 @@ fn guest_runtime_dir_for_user_env() -> Result<PathBuf, String> {
 }
 
 fn guest_runtime_dir_for_user_env_run_id(run_id: &str) -> Result<PathBuf, String> {
+    guest_runtime_paths::validate_run_id(run_id)
+        .map_err(|e| format!("resolve guest runtime dir for {USER_ENV_FILE_ENV_KEY}: {e}"))?;
     guest_runtime_paths::run_dir_from_env(run_id)
         .map_err(|e| format!("resolve guest runtime dir for {USER_ENV_FILE_ENV_KEY}: {e}"))
 }

--- a/crates/guest-agent/src/main.rs
+++ b/crates/guest-agent/src/main.rs
@@ -44,6 +44,12 @@ async fn run() -> i32 {
     // Record API-to-agent E2E time (as early as possible)
     guest_agent::timing::record_e2e_from_api("api_to_agent_start");
 
+    if let Err(e) = env::init_user_env() {
+        log_error!(LOG_TAG, "Fatal: {e}");
+        log_info!(LOG_TAG, "✗ Sandbox failed (exit code 1)");
+        return 1;
+    }
+
     let http = match HttpClient::for_current_env() {
         Ok(http) => http,
         Err(e) => {
@@ -153,7 +159,7 @@ async fn execute(
     record_sandbox_op("working_dir_setup", wd_start.elapsed(), true, None);
 
     // Codex setup: best-effort `codex login`. Failure is non-fatal —
-    // `codex exec` reads `OPENAI_API_KEY` directly from the env.
+    // `codex exec` also receives `OPENAI_API_KEY` through the curated CLI env.
     if matches!(env::Framework::from_env(), env::Framework::Codex)
         && let Err(e) = cli::setup_codex()
     {

--- a/crates/guest-agent/tests/cli_child_env.rs
+++ b/crates/guest-agent/tests/cli_child_env.rs
@@ -1,0 +1,77 @@
+//! This test lives in its own binary because `guest_agent::env` caches
+//! environment values in process-wide `LazyLock`s.
+
+mod common;
+
+use guest_agent::cli;
+use guest_agent::http::HttpClient;
+use guest_agent::masker::SecretMasker;
+use std::collections::BTreeMap;
+
+#[tokio::test]
+async fn execute_cli_injects_user_env_without_runner_owned_bootstrap_env()
+-> Result<(), Box<dyn std::error::Error>> {
+    let mock = common::build_and_locate_mock()?;
+    let tmp = tempfile::tempdir()?;
+    let cli_env_path = tmp.path().join("cli-env.json");
+    let prompt = format!("@write-env-json:{}", cli_env_path.display());
+
+    unsafe {
+        common::setup_env(&mock, tmp.path(), &prompt, 3, 1)?;
+        std::env::set_var("VM0_SECRET_VALUES", "runner-secret-values");
+        std::env::set_var(
+            process_control_ipc::BOOTSTRAP_ENV,
+            "runner-control-endpoint",
+        );
+    }
+
+    let user_env_dir = tmp.path().join("vm0-user-env-test");
+    std::fs::create_dir(&user_env_dir)?;
+    let user_env_path = user_env_dir.join("env.json");
+    std::fs::write(
+        &user_env_path,
+        serde_json::to_vec(&serde_json::json!({
+            "CUSTOM_USER_ENV": "visible-to-cli",
+            "BASH_ENV": "/tmp/user-bash-env",
+            "OPENAI_API_KEY": "sk-user",
+        }))?,
+    )?;
+    unsafe {
+        std::env::set_var("VM0_USER_ENV_FILE", &user_env_path);
+    }
+
+    guest_agent::env::init_user_env()?;
+    assert!(!user_env_path.exists());
+    assert!(!user_env_dir.exists());
+
+    let result = cli::execute_cli(
+        &SecretMasker::from_raw(""),
+        common::spawn_dummy_heartbeat(),
+        HttpClient::for_current_env()?,
+    )
+    .await?;
+
+    assert_eq!(result.exit_code, common::CLEAN_EXIT);
+    let cli_env: BTreeMap<String, String> = serde_json::from_slice(&std::fs::read(&cli_env_path)?)?;
+
+    assert_eq!(
+        cli_env.get("CUSTOM_USER_ENV").map(String::as_str),
+        Some("visible-to-cli")
+    );
+    assert_eq!(
+        cli_env.get("BASH_ENV").map(String::as_str),
+        Some("/tmp/user-bash-env")
+    );
+    assert_eq!(
+        cli_env.get("OPENAI_API_KEY").map(String::as_str),
+        Some("sk-user")
+    );
+    assert_eq!(cli_env.get("HOME").map(String::as_str), tmp.path().to_str());
+    assert!(cli_env.contains_key("PATH"));
+
+    assert!(!cli_env.contains_key("VM0_SECRET_VALUES"));
+    assert!(!cli_env.contains_key("VM0_USER_ENV_FILE"));
+    assert!(!cli_env.contains_key(process_control_ipc::BOOTSTRAP_ENV));
+
+    Ok(())
+}

--- a/crates/guest-agent/tests/cli_child_env.rs
+++ b/crates/guest-agent/tests/cli_child_env.rs
@@ -15,6 +15,11 @@ async fn execute_cli_injects_user_env_without_runner_owned_bootstrap_env()
     let tmp = tempfile::tempdir()?;
     let cli_env_path = tmp.path().join("cli-env.json");
     let prompt = format!("@write-env-json:{}", cli_env_path.display());
+    let user_home = tmp.path().join("user-home");
+    let user_home_str = user_home
+        .to_str()
+        .ok_or("test user HOME path must be UTF-8")?
+        .to_string();
 
     unsafe {
         common::setup_env(&mock, tmp.path(), &prompt, 3, 1)?;
@@ -35,6 +40,7 @@ async fn execute_cli_injects_user_env_without_runner_owned_bootstrap_env()
             "CUSTOM_USER_ENV": "visible-to-cli",
             "BASH_ENV": "/tmp/user-bash-env",
             "OPENAI_API_KEY": "sk-user",
+            "HOME": user_home_str,
         }))?,
     )?;
     unsafe {
@@ -44,6 +50,7 @@ async fn execute_cli_injects_user_env_without_runner_owned_bootstrap_env()
     guest_agent::env::init_user_env()?;
     assert!(!user_env_path.exists());
     assert!(!user_env_dir.path().exists());
+    assert_eq!(guest_agent::env::home_dir(), user_home_str);
 
     let result = cli::execute_cli(
         &SecretMasker::from_raw(""),
@@ -67,7 +74,10 @@ async fn execute_cli_injects_user_env_without_runner_owned_bootstrap_env()
         cli_env.get("OPENAI_API_KEY").map(String::as_str),
         Some("sk-user")
     );
-    assert_eq!(cli_env.get("HOME").map(String::as_str), tmp.path().to_str());
+    assert_eq!(
+        cli_env.get("HOME").map(String::as_str),
+        Some(user_home_str.as_str())
+    );
     assert!(cli_env.contains_key("PATH"));
 
     assert!(!cli_env.contains_key("VM0_SECRET_VALUES"));

--- a/crates/guest-agent/tests/cli_child_env.rs
+++ b/crates/guest-agent/tests/cli_child_env.rs
@@ -25,9 +25,10 @@ async fn execute_cli_injects_user_env_without_runner_owned_bootstrap_env()
         );
     }
 
-    let user_env_dir = tmp.path().join("vm0-user-env-test");
-    std::fs::create_dir(&user_env_dir)?;
-    let user_env_path = user_env_dir.join("env.json");
+    let user_env_dir = tempfile::Builder::new()
+        .prefix("vm0-user-env-test")
+        .tempdir_in("/tmp")?;
+    let user_env_path = user_env_dir.path().join("env.json");
     std::fs::write(
         &user_env_path,
         serde_json::to_vec(&serde_json::json!({
@@ -42,7 +43,7 @@ async fn execute_cli_injects_user_env_without_runner_owned_bootstrap_env()
 
     guest_agent::env::init_user_env()?;
     assert!(!user_env_path.exists());
-    assert!(!user_env_dir.exists());
+    assert!(!user_env_dir.path().exists());
 
     let result = cli::execute_cli(
         &SecretMasker::from_raw(""),

--- a/crates/guest-agent/tests/cli_child_env.rs
+++ b/crates/guest-agent/tests/cli_child_env.rs
@@ -30,10 +30,11 @@ async fn execute_cli_injects_user_env_without_runner_owned_bootstrap_env()
         );
     }
 
-    let user_env_dir = tempfile::Builder::new()
-        .prefix("vm0-user-env-test")
-        .tempdir_in("/tmp")?;
-    let user_env_path = user_env_dir.path().join("env.json");
+    let run_id = std::env::var("VM0_RUN_ID")?;
+    let runtime_dir = guest_runtime_paths::run_dir_from_env(&run_id)?;
+    let user_env_dir = runtime_dir.join("user-env");
+    std::fs::create_dir_all(&user_env_dir)?;
+    let user_env_path = user_env_dir.join("env.json");
     std::fs::write(
         &user_env_path,
         serde_json::to_vec(&serde_json::json!({
@@ -49,7 +50,7 @@ async fn execute_cli_injects_user_env_without_runner_owned_bootstrap_env()
 
     guest_agent::env::init_user_env()?;
     assert!(!user_env_path.exists());
-    assert!(!user_env_dir.path().exists());
+    assert!(!user_env_dir.exists());
     assert_eq!(guest_agent::env::home_dir(), user_home_str);
 
     let result = cli::execute_cli(

--- a/crates/guest-agent/tests/cli_child_env.rs
+++ b/crates/guest-agent/tests/cli_child_env.rs
@@ -28,6 +28,11 @@ async fn execute_cli_injects_user_env_without_runner_owned_bootstrap_env()
             process_control_ipc::BOOTSTRAP_ENV,
             "runner-control-endpoint",
         );
+        std::env::set_var("NODE_EXTRA_CA_CERTS", "/rootfs/vm0-proxy-ca.crt");
+        std::env::set_var("SSL_CERT_FILE", "/etc/ssl/certs/ca-certificates.crt");
+        std::env::set_var("REQUESTS_CA_BUNDLE", "/etc/ssl/certs/ca-certificates.crt");
+        std::env::set_var("CARGO_HTTP_CAINFO", "/etc/ssl/certs/ca-certificates.crt");
+        std::env::set_var("NPM_CONFIG_UPDATE_NOTIFIER", "false");
     }
 
     let run_id = std::env::var("VM0_RUN_ID")?;
@@ -42,6 +47,7 @@ async fn execute_cli_injects_user_env_without_runner_owned_bootstrap_env()
             "BASH_ENV": "/tmp/user-bash-env",
             "OPENAI_API_KEY": "sk-user",
             "HOME": user_home_str,
+            "NODE_EXTRA_CA_CERTS": "/tmp/user-ca.pem",
         }))?,
     )?;
     unsafe {
@@ -78,6 +84,28 @@ async fn execute_cli_injects_user_env_without_runner_owned_bootstrap_env()
     assert_eq!(
         cli_env.get("HOME").map(String::as_str),
         Some(user_home_str.as_str())
+    );
+    assert_eq!(
+        cli_env.get("NODE_EXTRA_CA_CERTS").map(String::as_str),
+        Some("/tmp/user-ca.pem")
+    );
+    assert_eq!(
+        cli_env.get("SSL_CERT_FILE").map(String::as_str),
+        Some("/etc/ssl/certs/ca-certificates.crt")
+    );
+    assert_eq!(
+        cli_env.get("REQUESTS_CA_BUNDLE").map(String::as_str),
+        Some("/etc/ssl/certs/ca-certificates.crt")
+    );
+    assert_eq!(
+        cli_env.get("CARGO_HTTP_CAINFO").map(String::as_str),
+        Some("/etc/ssl/certs/ca-certificates.crt")
+    );
+    assert_eq!(
+        cli_env
+            .get("NPM_CONFIG_UPDATE_NOTIFIER")
+            .map(String::as_str),
+        Some("false")
     );
     assert!(cli_env.contains_key("PATH"));
 

--- a/crates/guest-mock-claude/src/main.rs
+++ b/crates/guest-mock-claude/src/main.rs
@@ -29,10 +29,13 @@
 //!   @exit-after-result        - Emit result event, exit(0) immediately;
 //!                               tests that reap stays no-op on the
 //!                               happy path
+//!   @write-env-json:<path>    - Write current process env as JSON to path,
+//!                               emit result, and exit(0)
 //!   @ECHO@                    - First-line marker. Validate remaining non-empty
 //!                               lines as JSONL and emit them unchanged.
 
 use serde_json::{Value, json};
+use std::collections::BTreeMap;
 use std::io::Write;
 use std::path::{Component, Path, PathBuf};
 use std::process::{Command, ExitCode, Stdio};
@@ -60,6 +63,7 @@ enum MockScenario<'a> {
     OrphanPipe,
     HangAfterResult { deaf: bool },
     ExitAfterResult,
+    WriteEnvJson(&'a str),
     Shell,
 }
 
@@ -106,6 +110,9 @@ impl<'a> MockScenario<'a> {
         }
         if prompt.starts_with("@exit-after-result") {
             return Self::ExitAfterResult;
+        }
+        if let Some(path) = prompt.strip_prefix("@write-env-json:") {
+            return Self::WriteEnvJson(path);
         }
         if prompt.starts_with("@hang-after-result") {
             return Self::HangAfterResult { deaf: false };
@@ -494,6 +501,35 @@ fn run_hang_after_result_scenario(output_format: &str, deaf: bool) -> ExitCode {
     ExitCode::SUCCESS
 }
 
+fn run_write_env_json_scenario(output_format: &str, path: &str) -> ExitCode {
+    if output_format != "stream-json" {
+        return ExitCode::from(1);
+    }
+
+    let env: BTreeMap<String, String> = std::env::vars().collect();
+    if let Some(parent) = Path::new(path).parent()
+        && !parent.as_os_str().is_empty()
+        && let Err(e) = std::fs::create_dir_all(parent)
+    {
+        eprintln!("create env json parent: {e}");
+        return ExitCode::from(1);
+    }
+    let payload = match serde_json::to_vec(&env) {
+        Ok(payload) => payload,
+        Err(e) => {
+            eprintln!("serialize env json: {e}");
+            return ExitCode::from(1);
+        }
+    };
+    if let Err(e) = std::fs::write(path, payload) {
+        eprintln!("write env json: {e}");
+        return ExitCode::from(1);
+    }
+
+    emit_post_result_pair();
+    ExitCode::SUCCESS
+}
+
 /// Execute prompt in text mode: inherited stdio, propagate exit code.
 fn run_text_mode(prompt: &str) -> ExitCode {
     match Command::new("bash")
@@ -620,6 +656,9 @@ fn main() -> ExitCode {
                 // window elapses, so no signal is ever sent.
             }
             ExitCode::SUCCESS
+        }
+        MockScenario::WriteEnvJson(path) => {
+            run_write_env_json_scenario(&parsed.output_format, path)
         }
         MockScenario::Shell => {
             let session_id = generate_session_id();

--- a/crates/runner/src/executor.rs
+++ b/crates/runner/src/executor.rs
@@ -77,6 +77,14 @@ const BOOTSTRAP_SENSITIVE_ENV_KEYS: &[&str] = &[
     "LD_AUDIT",
     "NODE_OPTIONS",
 ];
+const USER_ENV_FILE_ENV_KEY: &str = "VM0_USER_ENV_FILE";
+const GUEST_USER_ENV_DIR_PREFIX: &str = "/tmp/vm0-user-env-";
+const GUEST_USER_ENV_FILENAME: &str = "env.json";
+const GUEST_AGENT_TUNING_ENV_KEYS: &[&str] = &[
+    "VM0_STUCK_TOOL_TIMEOUT_SECS",
+    "VM0_POST_RESULT_SIGTERM_GRACE_SECS",
+    "VM0_POST_RESULT_SIGKILL_GRACE_SECS",
+];
 const AGENT_ABNORMAL_EXIT_DIAGNOSTIC_SCRIPT: &str =
     include_str!("../scripts/agent-abnormal-exit-diagnostics.sh");
 static INVALID_API_START_TIME_WARNED: AtomicBool = AtomicBool::new(false);
@@ -302,11 +310,14 @@ fn agent_exit_failure_message(exit_code: i32) -> String {
     format!("Agent exited with code {exit_code}")
 }
 
-fn build_agent_env_diagnostics(env: &HashMap<String, String>) -> AgentEnvDiagnostics {
+fn build_agent_env_diagnostics(
+    env: &HashMap<String, String>,
+    user_env: &HashMap<String, String>,
+) -> AgentEnvDiagnostics {
     let mut suspicious_keys: Vec<String> = BOOTSTRAP_SENSITIVE_ENV_KEYS
         .iter()
         .copied()
-        .filter(|key| env.contains_key(*key))
+        .filter(|key| user_env.contains_key(*key))
         .map(sanitize_env_key_for_diagnostic)
         .collect();
     suspicious_keys.sort();
@@ -1455,9 +1466,16 @@ async fn run_in_sandbox_with_process_cancel_timeouts(
         result?;
     }
 
-    // 5. Build env vars (passed directly via vsock protocol)
-    let env_map = build_env_json(context, &config.api_url, sandbox.id(), start.reuse_result)?;
-    let env_diagnostics = build_agent_env_diagnostics(&env_map);
+    // 5. Build env vars. The guest-agent bootstrap env is runner-owned only;
+    // user-provided env is passed through a private guest file and injected
+    // into the CLI child after guest-agent has started.
+    let user_env_map = build_user_env_json(context);
+    let user_env_file = write_user_env_file(sandbox, context.run_id, &user_env_map).await?;
+    let mut env_map = build_env_json(context, &config.api_url, sandbox.id(), start.reuse_result)?;
+    if let Some(path) = user_env_file {
+        env_map.insert(USER_ENV_FILE_ENV_KEY.into(), path);
+    }
+    let env_diagnostics = build_agent_env_diagnostics(&env_map, &user_env_map);
     let env_pairs: Vec<(String, String)> = env_map.into_iter().collect();
     let env_refs: Vec<(&str, &str)> = env_pairs
         .iter()
@@ -2606,13 +2624,81 @@ fn is_valid_session_id(id: &str) -> bool {
             .all(|c| c.is_ascii_alphanumeric() || c == '-' || c == '_')
 }
 
-/// Build the environment variables JSON.
+fn build_user_env_json(context: &ExecutionContext) -> HashMap<String, String> {
+    let mut env = HashMap::new();
+
+    if let Some(user_env) = &context.environment {
+        for (k, v) in user_env {
+            env.insert(k.clone(), v.clone());
+        }
+    }
+    scrub_runner_owned_env(&mut env);
+
+    if let Some(tz) = &context.user_timezone {
+        let has_tz = context
+            .environment
+            .as_ref()
+            .is_some_and(|e| e.contains_key("TZ"));
+        if !has_tz {
+            env.insert("TZ".into(), tz.clone());
+        }
+    }
+
+    env
+}
+
+fn guest_user_env_dir_path(run_id: RunId) -> String {
+    format!("{GUEST_USER_ENV_DIR_PREFIX}{run_id}")
+}
+
+fn guest_user_env_file_path(run_id: RunId) -> String {
+    format!(
+        "{}/{}",
+        guest_user_env_dir_path(run_id),
+        GUEST_USER_ENV_FILENAME
+    )
+}
+
+async fn write_user_env_file(
+    sandbox: &dyn Sandbox,
+    run_id: RunId,
+    user_env: &HashMap<String, String>,
+) -> RunnerResult<Option<String>> {
+    if user_env.is_empty() {
+        return Ok(None);
+    }
+
+    let dir_path = guest_user_env_dir_path(run_id);
+    let file_path = guest_user_env_file_path(run_id);
+    let mkdir_cmd = format!("rm -rf {dir_path} && mkdir -m 700 {dir_path}");
+    let mkdir_result = sandbox
+        .exec(&ExecRequest {
+            cmd: &mkdir_cmd,
+            timeout: DEFAULT_EXEC_TIMEOUT,
+            env: &[],
+            sudo: false,
+            stdin_bytes: None,
+            output_limits: EXEC_OUTPUT_LIMIT_64_KIB,
+        })
+        .await?;
+    if mkdir_result.exit_code != 0 {
+        return Err(RunnerError::Internal(format_guest_exec_failure(
+            "user env directory creation",
+            &mkdir_result,
+        )));
+    }
+
+    let payload = serde_json::to_vec(user_env)
+        .map_err(|e| RunnerError::Internal(format!("serialize user env: {e}")))?;
+    sandbox.write_file(&file_path, &payload).await?;
+
+    Ok(Some(file_path))
+}
+
+/// Build the guest-agent bootstrap environment.
 ///
-/// Priority (lowest → highest):
-///   1. `environment` (user-provided env, includes expanded vars)
-///   2. scrub runner-owned keys from that copied user env
-///   3. `user_timezone` TZ (unless `environment` already sets TZ)
-///   4. System variables (VM0_*, secrets, etc.) — always win
+/// This intentionally excludes `context.environment`. User/model/connector
+/// environment is transferred separately and injected only into the CLI child.
 fn build_env_json(
     context: &ExecutionContext,
     api_url: &str,
@@ -2632,28 +2718,6 @@ fn build_env_json_with_host_env(
 ) -> RunnerResult<HashMap<String, String>> {
     let mut env = HashMap::new();
 
-    // --- User-provided environment ---
-    if let Some(user_env) = &context.environment {
-        for (k, v) in user_env {
-            env.insert(k.clone(), v.clone());
-        }
-    }
-    scrub_runner_owned_env(&mut env);
-
-    // --- User timezone ---
-    // Respects explicit TZ in user environment.
-    if let Some(tz) = &context.user_timezone {
-        let has_tz = context
-            .environment
-            .as_ref()
-            .is_some_and(|e| e.contains_key("TZ"));
-        if !has_tz {
-            env.insert("TZ".into(), tz.clone());
-        }
-    }
-
-    // --- System variables below (override user values) ---
-
     env.insert("VM0_API_URL".into(), api_url.into());
     env.insert("VM0_RUN_ID".into(), context.run_id.to_string());
     env.insert("VM0_API_TOKEN".into(), context.sandbox_token.clone());
@@ -2667,6 +2731,7 @@ fn build_env_json_with_host_env(
         reuse_result.as_wire().into(),
     );
     env.insert("VM0_PROMPT".into(), context.prompt.clone());
+    insert_guest_agent_tuning_env(&mut env, context);
     if let Some(asp) = &context.append_system_prompt
         && !asp.is_empty()
     {
@@ -2773,6 +2838,17 @@ fn build_env_json_with_host_env(
     Ok(env)
 }
 
+fn insert_guest_agent_tuning_env(env: &mut HashMap<String, String>, context: &ExecutionContext) {
+    let Some(user_env) = &context.environment else {
+        return;
+    };
+    for key in GUEST_AGENT_TUNING_ENV_KEYS {
+        if let Some(value) = user_env.get(*key) {
+            env.insert((*key).into(), value.clone());
+        }
+    }
+}
+
 #[derive(Clone, Debug, Default, PartialEq, Eq)]
 struct HostEnv {
     vercel_automation_bypass_secret: Option<String>,
@@ -2823,7 +2899,11 @@ const RUNNER_OWNED_ENV_KEYS: &[&str] = &[
     "VM0_ARTIFACTS",
     "VM0_RESUME_SESSION_ID",
     "VM0_SECRET_VALUES",
+    USER_ENV_FILE_ENV_KEY,
     "VM0_FEATURE_FLAGS",
+    "VM0_STUCK_TOOL_TIMEOUT_SECS",
+    "VM0_POST_RESULT_SIGTERM_GRACE_SECS",
+    "VM0_POST_RESULT_SIGKILL_GRACE_SECS",
     RUNNER_CONCURRENCY_FACTOR_ENV,
     RUNNER_DISK_BANDWIDTH_MIB_PER_SEC_ENV,
     RUNNER_DISK_IOPS_ENV,
@@ -2840,6 +2920,7 @@ const RUNNER_OWNED_ENV_KEYS: &[&str] = &[
 ];
 
 fn scrub_runner_owned_env(env: &mut HashMap<String, String>) {
+    env.retain(|key, _| !key.starts_with("VM0_"));
     for key in RUNNER_OWNED_ENV_KEYS {
         env.remove(*key);
     }
@@ -3146,7 +3227,7 @@ mod tests {
 
     #[test]
     fn agent_env_diagnostics_sort_bounds_and_never_include_values() {
-        let mut env = HashMap::from([
+        let mut bootstrap_env = HashMap::from([
             ("BASH_ENV".to_string(), "super-secret-bash-env".to_string()),
             ("NORMAL_KEY".to_string(), "normal-secret-value".to_string()),
             ("VM0_RUN_ID".to_string(), "runner-secret-value".to_string()),
@@ -3156,14 +3237,16 @@ mod tests {
             ),
         ]);
         for index in 0..AGENT_ENV_KEY_DIAGNOSTIC_LIMIT {
-            env.insert(format!("ZZZ_{index:03}"), format!("value-{index}"));
+            bootstrap_env.insert(format!("ZZZ_{index:03}"), format!("value-{index}"));
         }
-        env.insert(
+        bootstrap_env.insert(
             format!("AAA_{}", "x".repeat(AGENT_ENV_KEY_MAX_CHARS * 4)),
             "long-secret-value".to_string(),
         );
+        let user_env =
+            HashMap::from([("BASH_ENV".to_string(), "user-secret-bash-env".to_string())]);
 
-        let diagnostics = build_agent_env_diagnostics(&env);
+        let diagnostics = build_agent_env_diagnostics(&bootstrap_env, &user_env);
 
         assert_eq!(diagnostics.env_count, AGENT_ENV_KEY_DIAGNOSTIC_LIMIT + 5);
         assert_eq!(diagnostics.runner_owned_count, 2);
@@ -3172,7 +3255,7 @@ mod tests {
             AGENT_ENV_KEY_DIAGNOSTIC_LIMIT + 3
         );
         assert_eq!(diagnostics.suspicious_keys, vec!["BASH_ENV".to_string()]);
-        let env_pairs: Vec<(String, String)> = env.into_iter().collect();
+        let env_pairs: Vec<(String, String)> = bootstrap_env.into_iter().collect();
         let key_diagnostics = build_agent_env_key_diagnostics(&env_pairs);
         assert_eq!(
             key_diagnostics.logged_keys.len(),
@@ -3197,6 +3280,7 @@ mod tests {
         assert!(rendered.contains("BASH_ENV"));
         assert!(rendered.contains("VM0_RUN_ID"));
         assert!(!rendered.contains("super-secret-bash-env"));
+        assert!(!rendered.contains("user-secret-bash-env"));
         assert!(!rendered.contains("normal-secret-value"));
         assert!(!rendered.contains("runner-secret-value"));
         assert!(!rendered.contains("stored-secret-value"));
@@ -3508,6 +3592,7 @@ mod tests {
                 "/user/controlled/runtime".into(),
             ),
             ("VM0_FEATURE_FLAGS".into(), r#"{"bad":true}"#.into()),
+            ("VM0_FUTURE_RUNNER_KEY".into(), "future".into()),
             (RUNNER_CONCURRENCY_FACTOR_ENV.into(), "99".into()),
             (RUNNER_DISK_BANDWIDTH_MIB_PER_SEC_ENV.into(), "999".into()),
             (RUNNER_DISK_IOPS_ENV.into(), "999".into()),
@@ -3522,33 +3607,48 @@ mod tests {
             ("VM0_SETTINGS".into(), r#"{"hooks":{}}"#.into()),
             ("VM0_MOCK_CLAUDE_PATH".into(), "/tmp/mock-claude".into()),
             ("VM0_MOCK_CODEX_PATH".into(), "/tmp/mock-codex".into()),
+            (USER_ENV_FILE_ENV_KEY.into(), "/tmp/user-env".into()),
         ]));
 
-        let env = build_env_for_test(&ctx, "http://localhost");
+        let bootstrap_env = build_env_for_test(&ctx, "http://localhost");
+        let user_env = build_user_env_json(&ctx);
 
-        assert_eq!(env.get("CUSTOM_ENV").unwrap(), "kept");
-        assert_eq!(env.get("VM0_PROMPT").unwrap(), "test prompt");
-        assert_eq!(env.get("VM0_API_TOKEN").unwrap(), "tok");
+        assert!(!bootstrap_env.contains_key("CUSTOM_ENV"));
+        assert_eq!(bootstrap_env.get("VM0_PROMPT").unwrap(), "test prompt");
+        assert_eq!(bootstrap_env.get("VM0_API_TOKEN").unwrap(), "tok");
         assert_eq!(
-            env.get(guest_runtime_paths::GUEST_RUNTIME_DIR_ENV).unwrap(),
+            bootstrap_env
+                .get(guest_runtime_paths::GUEST_RUNTIME_DIR_ENV)
+                .unwrap(),
             &guest_runtime_dir(ctx.run_id).unwrap()
         );
-        assert_eq!(env.get("CLI_AGENT_TYPE").unwrap(), "codex");
-        assert!(!env.contains_key("VM0_WORKING_DIR"));
-        assert!(!env.contains_key("VM0_FEATURE_FLAGS"));
-        assert!(!env.contains_key(RUNNER_CONCURRENCY_FACTOR_ENV));
-        assert!(!env.contains_key(RUNNER_DISK_BANDWIDTH_MIB_PER_SEC_ENV));
-        assert!(!env.contains_key(RUNNER_DISK_IOPS_ENV));
-        assert!(!env.contains_key(RUNNER_NET_RX_MIB_PER_SEC_ENV));
-        assert!(!env.contains_key(RUNNER_NET_TX_MIB_PER_SEC_ENV));
-        assert!(!env.contains_key("USE_MOCK_CLAUDE"));
-        assert!(!env.contains_key("USE_MOCK_CODEX"));
-        assert!(!env.contains_key("VERCEL_PROTECTION_BYPASS"));
-        assert!(!env.contains_key("VM0_DISALLOWED_TOOLS"));
-        assert!(!env.contains_key("VM0_TOOLS"));
-        assert!(!env.contains_key("VM0_SETTINGS"));
-        assert!(!env.contains_key("VM0_MOCK_CLAUDE_PATH"));
-        assert!(!env.contains_key("VM0_MOCK_CODEX_PATH"));
+        assert_eq!(bootstrap_env.get("CLI_AGENT_TYPE").unwrap(), "codex");
+        assert_eq!(user_env.get("CUSTOM_ENV").unwrap(), "kept");
+        for key in [
+            "VM0_PROMPT",
+            "VM0_API_TOKEN",
+            "VM0_WORKING_DIR",
+            guest_runtime_paths::GUEST_RUNTIME_DIR_ENV,
+            "VM0_FEATURE_FLAGS",
+            "VM0_FUTURE_RUNNER_KEY",
+            RUNNER_CONCURRENCY_FACTOR_ENV,
+            RUNNER_DISK_BANDWIDTH_MIB_PER_SEC_ENV,
+            RUNNER_DISK_IOPS_ENV,
+            RUNNER_NET_RX_MIB_PER_SEC_ENV,
+            RUNNER_NET_TX_MIB_PER_SEC_ENV,
+            "CLI_AGENT_TYPE",
+            "USE_MOCK_CLAUDE",
+            "USE_MOCK_CODEX",
+            "VERCEL_PROTECTION_BYPASS",
+            "VM0_DISALLOWED_TOOLS",
+            "VM0_TOOLS",
+            "VM0_SETTINGS",
+            "VM0_MOCK_CLAUDE_PATH",
+            "VM0_MOCK_CODEX_PATH",
+            USER_ENV_FILE_ENV_KEY,
+        ] {
+            assert!(!user_env.contains_key(key), "{key} should be scrubbed");
+        }
     }
 
     #[test]
@@ -3738,9 +3838,12 @@ mod tests {
         ]));
 
         let env = build_env_for_test(&ctx, "http://localhost");
+        let user_env = build_user_env_json(&ctx);
         // System variables take precedence over user environment
         assert_eq!(env.get("VM0_PROMPT").unwrap(), "test prompt");
-        assert_eq!(env.get("CUSTOM").unwrap(), "value");
+        assert!(!env.contains_key("CUSTOM"));
+        assert_eq!(user_env.get("CUSTOM").unwrap(), "value");
+        assert!(!user_env.contains_key("VM0_PROMPT"));
     }
 
     #[test]
@@ -3752,8 +3855,11 @@ mod tests {
         ]));
 
         let env = build_env_for_test(&ctx, "http://localhost");
-        assert_eq!(env.get("MY_VAR").unwrap(), "123");
-        assert_eq!(env.get("OTHER").unwrap(), "abc");
+        let user_env = build_user_env_json(&ctx);
+        assert!(!env.contains_key("MY_VAR"));
+        assert!(!env.contains_key("OTHER"));
+        assert_eq!(user_env.get("MY_VAR").unwrap(), "123");
+        assert_eq!(user_env.get("OTHER").unwrap(), "abc");
     }
 
     #[test]
@@ -3833,7 +3939,9 @@ mod tests {
         ctx.user_timezone = Some("Asia/Shanghai".into());
 
         let env = build_env_for_test(&ctx, "http://localhost");
-        assert_eq!(env.get("TZ").unwrap(), "Asia/Shanghai");
+        let user_env = build_user_env_json(&ctx);
+        assert!(!env.contains_key("TZ"));
+        assert_eq!(user_env.get("TZ").unwrap(), "Asia/Shanghai");
     }
 
     #[test]
@@ -3843,8 +3951,10 @@ mod tests {
         ctx.environment = Some(HashMap::from([("TZ".into(), "America/New_York".into())]));
 
         let env = build_env_for_test(&ctx, "http://localhost");
+        let user_env = build_user_env_json(&ctx);
         // User environment TZ takes precedence
-        assert_eq!(env.get("TZ").unwrap(), "America/New_York");
+        assert!(!env.contains_key("TZ"));
+        assert_eq!(user_env.get("TZ").unwrap(), "America/New_York");
     }
 
     #[test]
@@ -3857,10 +3967,14 @@ mod tests {
         ]));
 
         let env = build_env_for_test(&ctx, "http://localhost");
+        let user_env = build_user_env_json(&ctx);
         // System variables take precedence over user environment
         assert_eq!(env.get("VM0_PROMPT").unwrap(), "test prompt");
         assert_eq!(env.get("VM0_API_TOKEN").unwrap(), "tok");
-        assert_eq!(env.get("CUSTOM_ENV").unwrap(), "kept");
+        assert!(!env.contains_key("CUSTOM_ENV"));
+        assert_eq!(user_env.get("CUSTOM_ENV").unwrap(), "kept");
+        assert!(!user_env.contains_key("VM0_PROMPT"));
+        assert!(!user_env.contains_key("VM0_API_TOKEN"));
     }
 
     #[test]
@@ -3872,8 +3986,10 @@ mod tests {
         ctx.environment = Some(HashMap::from([("ONLY_ENV".into(), "env-value".into())]));
 
         let env = build_env_for_test(&ctx, "http://localhost");
+        let user_env = build_user_env_json(&ctx);
         assert!(!env.contains_key("ONLY_VARS"));
-        assert_eq!(env.get("ONLY_ENV").unwrap(), "env-value");
+        assert!(!env.contains_key("ONLY_ENV"));
+        assert_eq!(user_env.get("ONLY_ENV").unwrap(), "env-value");
     }
 
     #[test]
@@ -6169,6 +6285,75 @@ mod tests {
         assert!(error_msg.is_none());
         let system_stream_log = tokio::fs::read(&system_stream_log_path).await.unwrap();
         assert_eq!(system_stream_log, STDOUT_STREAM_OVERFLOW_MARKER);
+    }
+
+    #[tokio::test]
+    async fn execute_inner_writes_user_env_file_and_starts_agent_with_bootstrap_env_only() {
+        let dir = tempfile::tempdir().unwrap();
+        let config = test_executor_config(dir.path()).await;
+        let overrides = Arc::new(sandbox_mock::MockSandboxOverrides::new());
+        let factory = sandbox_mock::MockSandboxFactory::with_overrides(Arc::clone(&overrides));
+        let mut ctx = minimal_context();
+        ctx.user_timezone = Some("Asia/Shanghai".into());
+        ctx.environment = Some(HashMap::from([
+            ("CUSTOM_USER_ENV".into(), "visible-to-cli".into()),
+            ("BASH_ENV".into(), "/tmp/user-bash-env".into()),
+            ("NODE_OPTIONS".into(), "--require /tmp/user-node.js".into()),
+            ("VM0_API_TOKEN".into(), "stolen-token".into()),
+            (USER_ENV_FILE_ENV_KEY.into(), "/tmp/evil-env.json".into()),
+            ("VM0_STUCK_TOOL_TIMEOUT_SECS".into(), "3".into()),
+        ]));
+
+        let (exit_code, error_msg) = run_execute_inner(&factory, &ctx, &config, &default_params())
+            .await
+            .unwrap();
+
+        assert_eq!(exit_code, 0);
+        assert!(error_msg.is_none());
+
+        let start_calls = overrides.start_process_calls();
+        assert_eq!(start_calls.len(), 1);
+        let start_env: BTreeMap<String, String> = start_calls[0].env.iter().cloned().collect();
+        assert_eq!(start_env.get("VM0_API_TOKEN").unwrap(), "tok");
+        assert_eq!(start_env.get("VM0_STUCK_TOOL_TIMEOUT_SECS").unwrap(), "3");
+        assert_eq!(
+            start_env.get(USER_ENV_FILE_ENV_KEY).map(String::as_str),
+            Some(guest_user_env_file_path(ctx.run_id).as_str())
+        );
+        for key in ["CUSTOM_USER_ENV", "BASH_ENV", "NODE_OPTIONS", "TZ"] {
+            assert!(
+                !start_env.contains_key(key),
+                "{key} should not be passed to guest-agent bootstrap"
+            );
+        }
+
+        let mkdir_call = overrides
+            .exec_calls()
+            .into_iter()
+            .find(|call| call.cmd.contains(GUEST_USER_ENV_DIR_PREFIX))
+            .expect("user env directory should be created before agent start");
+        assert!(mkdir_call.cmd.starts_with("rm -rf "));
+        assert!(mkdir_call.cmd.contains(" && mkdir -m 700 "));
+        assert!(mkdir_call.env_keys.is_empty());
+        assert!(!mkdir_call.sudo);
+
+        let writes = overrides.write_file_calls();
+        let user_env_write = writes
+            .iter()
+            .find(|call| call.path == guest_user_env_file_path(ctx.run_id))
+            .expect("user env JSON should be written");
+        let user_env: HashMap<String, String> =
+            serde_json::from_slice(&user_env_write.content).unwrap();
+        assert_eq!(user_env.get("CUSTOM_USER_ENV").unwrap(), "visible-to-cli");
+        assert_eq!(user_env.get("BASH_ENV").unwrap(), "/tmp/user-bash-env");
+        assert_eq!(
+            user_env.get("NODE_OPTIONS").unwrap(),
+            "--require /tmp/user-node.js"
+        );
+        assert_eq!(user_env.get("TZ").unwrap(), "Asia/Shanghai");
+        assert!(!user_env.contains_key("VM0_API_TOKEN"));
+        assert!(!user_env.contains_key(USER_ENV_FILE_ENV_KEY));
+        assert!(!user_env.contains_key("VM0_STUCK_TOOL_TIMEOUT_SECS"));
     }
 
     #[tokio::test]

--- a/crates/runner/src/executor.rs
+++ b/crates/runner/src/executor.rs
@@ -78,7 +78,7 @@ const BOOTSTRAP_SENSITIVE_ENV_KEYS: &[&str] = &[
     "NODE_OPTIONS",
 ];
 const USER_ENV_FILE_ENV_KEY: &str = "VM0_USER_ENV_FILE";
-const GUEST_USER_ENV_DIR_PREFIX: &str = "/tmp/vm0-user-env-";
+const GUEST_USER_ENV_DIR_NAME: &str = "user-env";
 const GUEST_USER_ENV_FILENAME: &str = "env.json";
 const GUEST_AGENT_TUNING_ENV_KEYS: &[&str] = &[
     "VM0_STUCK_TOOL_TIMEOUT_SECS",
@@ -2647,16 +2647,15 @@ fn build_user_env_json(context: &ExecutionContext) -> HashMap<String, String> {
     env
 }
 
-fn guest_user_env_dir_path(run_id: RunId) -> String {
-    format!("{GUEST_USER_ENV_DIR_PREFIX}{run_id}")
+fn guest_user_env_dir_path(run_id: RunId) -> RunnerResult<String> {
+    guest_runtime_path(run_id, |dir| dir.join(GUEST_USER_ENV_DIR_NAME))
 }
 
-fn guest_user_env_file_path(run_id: RunId) -> String {
-    format!(
-        "{}/{}",
-        guest_user_env_dir_path(run_id),
-        GUEST_USER_ENV_FILENAME
-    )
+fn guest_user_env_file_path(run_id: RunId) -> RunnerResult<String> {
+    guest_runtime_path(run_id, |dir| {
+        dir.join(GUEST_USER_ENV_DIR_NAME)
+            .join(GUEST_USER_ENV_FILENAME)
+    })
 }
 
 async fn write_user_env_file(
@@ -2668,9 +2667,11 @@ async fn write_user_env_file(
         return Ok(None);
     }
 
-    let dir_path = guest_user_env_dir_path(run_id);
-    let file_path = guest_user_env_file_path(run_id);
-    let mkdir_cmd = format!("rm -rf {dir_path} && mkdir -m 700 {dir_path}");
+    let runtime_dir = guest_runtime_dir(run_id)?;
+    let dir_path = guest_user_env_dir_path(run_id)?;
+    let file_path = guest_user_env_file_path(run_id)?;
+    let mkdir_cmd =
+        format!("mkdir -p -m 700 {runtime_dir} {dir_path} && chmod 700 {runtime_dir} {dir_path}");
     let mkdir_result = sandbox
         .exec(&ExecRequest {
             cmd: &mkdir_cmd,
@@ -2691,6 +2692,23 @@ async fn write_user_env_file(
     let payload = serde_json::to_vec(user_env)
         .map_err(|e| RunnerError::Internal(format!("serialize user env: {e}")))?;
     sandbox.write_file(&file_path, &payload).await?;
+    let chmod_cmd = format!("chmod 600 {file_path}");
+    let chmod_result = sandbox
+        .exec(&ExecRequest {
+            cmd: &chmod_cmd,
+            timeout: DEFAULT_EXEC_TIMEOUT,
+            env: &[],
+            sudo: false,
+            stdin_bytes: None,
+            output_limits: EXEC_OUTPUT_LIMIT_64_KIB,
+        })
+        .await?;
+    if chmod_result.exit_code != 0 {
+        return Err(RunnerError::Internal(format_guest_exec_failure(
+            "user env file permission update",
+            &chmod_result,
+        )));
+    }
 
     Ok(Some(file_path))
 }
@@ -6314,11 +6332,13 @@ mod tests {
         let start_calls = overrides.start_process_calls();
         assert_eq!(start_calls.len(), 1);
         let start_env: BTreeMap<String, String> = start_calls[0].env.iter().cloned().collect();
+        let expected_user_env_dir = guest_user_env_dir_path(ctx.run_id).unwrap();
+        let expected_user_env_file = guest_user_env_file_path(ctx.run_id).unwrap();
         assert_eq!(start_env.get("VM0_API_TOKEN").unwrap(), "tok");
         assert_eq!(start_env.get("VM0_STUCK_TOOL_TIMEOUT_SECS").unwrap(), "3");
         assert_eq!(
             start_env.get(USER_ENV_FILE_ENV_KEY).map(String::as_str),
-            Some(guest_user_env_file_path(ctx.run_id).as_str())
+            Some(expected_user_env_file.as_str())
         );
         for key in ["CUSTOM_USER_ENV", "BASH_ENV", "NODE_OPTIONS", "TZ"] {
             assert!(
@@ -6330,17 +6350,24 @@ mod tests {
         let mkdir_call = overrides
             .exec_calls()
             .into_iter()
-            .find(|call| call.cmd.contains(GUEST_USER_ENV_DIR_PREFIX))
+            .find(|call| call.cmd.contains(&expected_user_env_dir))
             .expect("user env directory should be created before agent start");
-        assert!(mkdir_call.cmd.starts_with("rm -rf "));
-        assert!(mkdir_call.cmd.contains(" && mkdir -m 700 "));
+        assert!(mkdir_call.cmd.starts_with("mkdir -p -m 700 "));
+        assert!(mkdir_call.cmd.contains(" && chmod 700 "));
         assert!(mkdir_call.env_keys.is_empty());
         assert!(!mkdir_call.sudo);
+        let chmod_call = overrides
+            .exec_calls()
+            .into_iter()
+            .find(|call| call.cmd == format!("chmod 600 {expected_user_env_file}"))
+            .expect("user env file mode should be tightened after write");
+        assert!(chmod_call.env_keys.is_empty());
+        assert!(!chmod_call.sudo);
 
         let writes = overrides.write_file_calls();
         let user_env_write = writes
             .iter()
-            .find(|call| call.path == guest_user_env_file_path(ctx.run_id))
+            .find(|call| call.path == expected_user_env_file)
             .expect("user env JSON should be written");
         let user_env: HashMap<String, String> =
             serde_json::from_slice(&user_env_write.content).unwrap();

--- a/crates/sandbox-mock/src/lib.rs
+++ b/crates/sandbox-mock/src/lib.rs
@@ -63,6 +63,10 @@ pub struct ExecCall {
 
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub struct StartProcessCall {
+    pub cmd: String,
+    pub timeout: Duration,
+    pub env: Vec<(String, String)>,
+    pub sudo: bool,
     pub output: ProcessOutputMode,
     pub control: ProcessControlMode,
 }
@@ -324,6 +328,8 @@ pub struct MockSandboxOverrides {
     exec_matchers: Mutex<Vec<ExecMatcher>>,
     /// Recorded exec calls across all sandboxes built from this override set.
     exec_calls: Mutex<Vec<ExecCall>>,
+    /// Recorded write_file calls across all sandboxes built from this override set.
+    write_file_calls: Mutex<Vec<WriteFileCall>>,
     /// FIFO queue of read_file results consumed by factory-created sandboxes.
     read_file_results: Mutex<VecDeque<Result<Option<Vec<u8>>>>>,
     /// When `Some`, `wait_process` returns this exit code instead of 0.
@@ -399,6 +405,7 @@ impl MockSandboxOverrides {
         Self {
             exec_matchers: Mutex::new(Vec::new()),
             exec_calls: Mutex::new(Vec::new()),
+            write_file_calls: Mutex::new(Vec::new()),
             read_file_results: Mutex::new(VecDeque::new()),
             wait_process_code: None,
             wait_process_gate: None,
@@ -487,6 +494,12 @@ impl MockSandboxOverrides {
     /// in call order.
     pub fn exec_calls(&self) -> Vec<ExecCall> {
         self.exec_calls.lock_ignoring_poison().clone()
+    }
+
+    /// Recorded write_file calls across all sandboxes built from this override
+    /// set, in call order.
+    pub fn write_file_calls(&self) -> Vec<WriteFileCall> {
+        self.write_file_calls.lock_ignoring_poison().clone()
     }
 
     /// Queue a read_file result applied to the next read made through any
@@ -1074,12 +1087,16 @@ impl Sandbox for MockSandbox {
     }
 
     async fn write_file(&self, path: &str, content: &[u8]) -> Result<()> {
+        let call = WriteFileCall {
+            path: path.to_string(),
+            content: content.to_vec(),
+        };
         self.write_file_calls
             .lock_ignoring_poison()
-            .push(WriteFileCall {
-                path: path.to_string(),
-                content: content.to_vec(),
-            });
+            .push(call.clone());
+        if let Some(overrides) = &self.overrides {
+            overrides.write_file_calls.lock_ignoring_poison().push(call);
+        }
         self.write_file_results
             .lock_ignoring_poison()
             .pop_front()
@@ -1093,6 +1110,14 @@ impl Sandbox for MockSandbox {
                 .start_process_calls
                 .lock_ignoring_poison()
                 .push(StartProcessCall {
+                    cmd: request.cmd.to_string(),
+                    timeout: request.timeout,
+                    env: request
+                        .env
+                        .iter()
+                        .map(|(key, value)| ((*key).to_string(), (*value).to_string()))
+                        .collect(),
+                    sudo: request.sudo,
                     output: request.output,
                     control: request.control,
                 });
@@ -2616,10 +2641,18 @@ mod tests {
             overrides.start_process_calls(),
             vec![
                 StartProcessCall {
+                    cmd: "agent".to_string(),
+                    timeout: Duration::from_secs(5),
+                    env: Vec::new(),
+                    sudo: false,
                     output: ProcessOutputMode::buffered(EXEC_OUTPUT_LIMIT_1_MIB),
                     control: ProcessControlMode::None,
                 },
                 StartProcessCall {
+                    cmd: "agent".to_string(),
+                    timeout: Duration::from_secs(5),
+                    env: Vec::new(),
+                    sudo: false,
                     output: ProcessOutputMode::stream(),
                     control: ProcessControlMode::None,
                 },


### PR DESCRIPTION
Fixes #16234

## Summary
- start guest-agent with bootstrap-only env and pass user env through a private guest JSON file
- load/delete user env in guest-agent and launch Claude/Codex with curated child env
- add regression coverage for bootstrap env isolation and CLI child env inheritance

## Tests
- cargo fmt --manifest-path crates/Cargo.toml --all --check
- cargo test --manifest-path crates/Cargo.toml -p runner
- cargo test --manifest-path crates/Cargo.toml -p guest-agent
- cargo clippy --manifest-path crates/Cargo.toml -p runner --all-targets -- -D warnings
- cargo clippy --manifest-path crates/Cargo.toml -p guest-agent --all-targets -- -D warnings
- cargo clippy --manifest-path crates/Cargo.toml -p sandbox-mock --all-targets -- -D warnings
- cargo clippy --manifest-path crates/Cargo.toml -p guest-mock-claude --all-targets -- -D warnings
