### PR TITLE
fix: prevent runner kill from signaling reused pids

### DIFF
--- a/crates/runner/src/cmd/doctor.rs
+++ b/crates/runner/src/cmd/doctor.rs
@@ -1304,6 +1304,7 @@ mod tests {
             ppid: None,
             sandbox_id: sandbox_id.into(),
             base_dir: Some(PathBuf::from(base_dir)),
+            identity: None,
         }
     }
 
@@ -1411,6 +1412,7 @@ mod tests {
             ppid: None,
             sandbox_id: "sbox-abc".into(),
             base_dir: Some(PathBuf::from("/data/r2")),
+            identity: None,
         }];
         let (jobs, warnings) = correlate_jobs(&status, Path::new("/data/r1"), &fc);
         assert_eq!(jobs.len(), 1);

--- a/crates/runner/src/cmd/kill.rs
+++ b/crates/runner/src/cmd/kill.rs
@@ -136,6 +136,7 @@ struct ResolvedKillTarget {
 enum KillOutcome {
     OwnerAccepted(RemoteKillResult),
     OrphanKilled(KillTarget),
+    OrphanAlreadyExited(KillTarget),
     AlreadyExitedOrChanged(KillTarget),
     SignalFailed(KillTarget),
     RefusedManagedIdle,
@@ -150,6 +151,7 @@ impl KillOutcome {
             KillOutcome::OwnerAccepted(RemoteKillResult::Accepted)
                 | KillOutcome::OwnerAccepted(RemoteKillResult::AlreadyStopped)
                 | KillOutcome::OrphanKilled(_)
+                | KillOutcome::OrphanAlreadyExited(_)
         )
     }
 }
@@ -335,10 +337,10 @@ async fn kill_orphan_process_group(target: &KillTarget) -> KillOutcome {
         return KillOutcome::AlreadyExitedOrChanged(target.clone());
     };
 
-    if signal_process_group(target.pid, pgid) {
-        KillOutcome::OrphanKilled(target.clone())
-    } else {
-        KillOutcome::SignalFailed(target.clone())
+    match signal_process_group(target.pid, pgid) {
+        ProcessGroupSignalResult::Signaled => KillOutcome::OrphanKilled(target.clone()),
+        ProcessGroupSignalResult::AlreadyGone => KillOutcome::OrphanAlreadyExited(target.clone()),
+        ProcessGroupSignalResult::Failed => KillOutcome::SignalFailed(target.clone()),
     }
 }
 
@@ -435,19 +437,26 @@ fn workspace_identity_matches(
     }
 }
 
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+enum ProcessGroupSignalResult {
+    Signaled,
+    AlreadyGone,
+    Failed,
+}
+
 /// Send `SIGKILL` to a validated process group.
-fn signal_process_group(pid: u32, pgid: u32) -> bool {
+fn signal_process_group(pid: u32, pgid: u32) -> ProcessGroupSignalResult {
     if pgid <= 1 {
         tracing::warn!(pid, pgid, "refusing to signal system process group");
-        return false;
+        return ProcessGroupSignalResult::Failed;
     }
 
     let Ok(pgid_i32) = i32::try_from(pgid) else {
-        return false;
+        return ProcessGroupSignalResult::Failed;
     };
     if nix::unistd::getpgrp().as_raw() == pgid_i32 {
         tracing::warn!(pid, pgid = pgid_i32, "refusing to signal own process group");
-        return false;
+        return ProcessGroupSignalResult::Failed;
     }
 
     match nix::sys::signal::killpg(
@@ -456,11 +465,19 @@ fn signal_process_group(pid: u32, pgid: u32) -> bool {
     ) {
         Ok(()) => {
             info!(pid, pgid = pgid_i32, "killed process group");
-            true
+            ProcessGroupSignalResult::Signaled
+        }
+        Err(nix::errno::Errno::ESRCH) => {
+            info!(
+                pid,
+                pgid = pgid_i32,
+                "process group already exited before signal"
+            );
+            ProcessGroupSignalResult::AlreadyGone
         }
         Err(e) => {
             tracing::warn!(pid, pgid = pgid_i32, error = %e, "failed to kill process group");
-            false
+            ProcessGroupSignalResult::Failed
         }
     }
 }
@@ -491,14 +508,14 @@ async fn report_kill_outcome(
                 "Killed orphan sandbox {} (PID {})",
                 target.sandbox_id, target.pid
             );
-            if let Some(base_dir) = target.base_dir.as_deref() {
-                let results = cleanup_orphan(&target.sandbox_id, base_dir, control).await;
-                print_cleanup_results(&results);
-            } else {
-                println!(
-                    "Skipped orphan cleanup because sandbox workspace identity is unavailable."
-                );
-            }
+            cleanup_validated_orphan(target, control).await;
+        }
+        KillOutcome::OrphanAlreadyExited(target) => {
+            println!(
+                "Orphan sandbox {} (PID {}) already exited before signal.",
+                target.sandbox_id, target.pid
+            );
+            cleanup_validated_orphan(target, control).await;
         }
         KillOutcome::AlreadyExitedOrChanged(target) => {
             println!(
@@ -534,6 +551,15 @@ async fn report_kill_outcome(
                 initial.sandbox_id, initial.pid
             );
         }
+    }
+}
+
+async fn cleanup_validated_orphan(target: &KillTarget, control: &dyn SandboxControl) {
+    if let Some(base_dir) = target.base_dir.as_deref() {
+        let results = cleanup_orphan(&target.sandbox_id, base_dir, control).await;
+        print_cleanup_results(&results);
+    } else {
+        println!("Skipped orphan cleanup because sandbox workspace identity is unavailable.");
     }
 }
 
@@ -942,19 +968,46 @@ mod tests {
 
     #[test]
     fn signal_process_group_rejects_zero_pgid() {
-        assert!(!signal_process_group(1234, 0));
+        assert_eq!(
+            signal_process_group(1234, 0),
+            ProcessGroupSignalResult::Failed
+        );
     }
 
     #[test]
     fn signal_process_group_rejects_init_pgid() {
-        assert!(!signal_process_group(1234, 1));
+        assert_eq!(
+            signal_process_group(1234, 1),
+            ProcessGroupSignalResult::Failed
+        );
     }
 
     #[test]
     fn signal_process_group_rejects_own_pgid() {
         let current_pgid = u32::try_from(nix::unistd::getpgrp().as_raw()).unwrap();
 
-        assert!(!signal_process_group(1234, current_pgid));
+        assert_eq!(
+            signal_process_group(1234, current_pgid),
+            ProcessGroupSignalResult::Failed
+        );
+    }
+
+    #[test]
+    fn signal_process_group_reports_already_gone_for_missing_group() {
+        let missing_pgid = i32::MAX as u32;
+
+        assert_eq!(
+            signal_process_group(1234, missing_pgid),
+            ProcessGroupSignalResult::AlreadyGone
+        );
+    }
+
+    #[test]
+    fn orphan_already_exited_outcome_is_success() {
+        let target = make_target(200, "sbox-123");
+        let outcome = KillOutcome::OrphanAlreadyExited(target);
+
+        assert!(outcome.is_success());
     }
 
     #[tokio::test]

--- a/crates/runner/src/cmd/kill.rs
+++ b/crates/runner/src/cmd/kill.rs
@@ -431,9 +431,7 @@ fn workspace_identity_matches(
         (Some(expected_base_dir), Some((sandbox_id, base_dir))) => {
             sandbox_id == &identity.sandbox_id && base_dir == expected_base_dir
         }
-        (Some(_), None) => false,
-        (None, Some(_)) => false,
-        (None, None) => true,
+        _ => false,
     }
 }
 
@@ -869,6 +867,20 @@ mod tests {
             true,
             Some(&cwd_info)
         ));
+    }
+
+    #[test]
+    fn orphan_identity_rejects_missing_workspace_identity() {
+        let mut target = make_target(200, "sbox-123");
+        target.base_dir = None;
+        target.identity.as_mut().unwrap().base_dir = None;
+        let identity = target.identity.as_ref().unwrap();
+        let stat = ProcessStat {
+            pgid: identity.pgid,
+            starttime: identity.starttime,
+        };
+
+        assert!(!orphan_identity_matches_facts(identity, &stat, true, None));
     }
 
     #[tokio::test]

--- a/crates/runner/src/cmd/kill.rs
+++ b/crates/runner/src/cmd/kill.rs
@@ -241,14 +241,23 @@ fn resolve_by_run_id<'a>(
     firecrackers: &'a [FirecrackerProcessInfo],
 ) -> RunnerResult<&'a FirecrackerProcessInfo> {
     let sandbox_id = run_resolution::resolve_run_to_sandbox(input, mappings)?;
-    firecrackers
+    let fc_matches: Vec<&FirecrackerProcessInfo> = firecrackers
         .iter()
-        .find(|fc| fc.sandbox_id == sandbox_id)
-        .ok_or_else(|| {
-            RunnerError::Config(format!(
-                "run '{input}' maps to sandbox '{sandbox_id}' but no firecracker process for it"
-            ))
-        })
+        .filter(|fc| fc.sandbox_id == sandbox_id)
+        .collect();
+    match fc_matches.as_slice() {
+        [] => Err(RunnerError::Config(format!(
+            "run '{input}' maps to sandbox '{sandbox_id}' but no firecracker process for it"
+        ))),
+        [single] => Ok(single),
+        _ => {
+            let pids: Vec<String> = fc_matches.iter().map(|fc| fc.pid.to_string()).collect();
+            Err(RunnerError::Config(format!(
+                "run '{input}' maps to sandbox '{sandbox_id}' but multiple firecracker processes match it: PID {}",
+                pids.join(", ")
+            )))
+        }
+    }
 }
 
 /// Resolve a `--sandbox` prefix to a single Firecracker process.
@@ -662,6 +671,21 @@ mod tests {
         assert!(msg.contains("run 'run-x'"), "{msg}");
         assert!(msg.contains("sandbox-gone"), "{msg}");
         assert!(msg.contains("no firecracker process"), "{msg}");
+    }
+
+    #[test]
+    fn by_run_id_rejects_duplicate_sandbox_processes() {
+        let status = mappings(vec![("run-x-1".into(), "sandbox-dup".into())]);
+        let fcs = vec![make_fc(200, "sandbox-dup"), make_fc(201, "sandbox-dup")];
+
+        let Err(e) = resolve_by_run_id("run-x", &status, &fcs) else {
+            panic!("expected error when multiple firecracker processes share a sandbox id");
+        };
+        let msg = e.to_string();
+
+        assert!(msg.contains("multiple firecracker processes"), "{msg}");
+        assert!(msg.contains("200"), "{msg}");
+        assert!(msg.contains("201"), "{msg}");
     }
 
     // -- resolve_by_sandbox_id tests -----------------------------------------

--- a/crates/runner/src/cmd/kill.rs
+++ b/crates/runner/src/cmd/kill.rs
@@ -69,6 +69,26 @@ pub async fn run_kill(args: KillArgs, control: &dyn SandboxControl) -> RunnerRes
     let current = match rediscover_same_target(&args, &initial.target).await {
         Ok(current) => current,
         Err(error) => {
+            let discovered_after_error = process::discover_all().await;
+            if error.allows_disappeared_orphan_cleanup()
+                && should_cleanup_disappeared_initial_orphan(
+                    &initial.target,
+                    is_initial_orphan,
+                    &discovered_after_error,
+                )
+            {
+                let outcome = KillOutcome::OrphanAlreadyExited(initial.target.clone());
+                report_kill_outcome(&initial.target, &initial.target, &outcome, control).await;
+                info!(
+                    sandbox_id = %initial.target.sandbox_id,
+                    pid = initial.target.pid,
+                    orphan = true,
+                    rediscover_error = %error,
+                    outcome = ?outcome,
+                    "kill command cleaned up orphan target that disappeared during rediscovery"
+                );
+                return Ok(ExitCode::SUCCESS);
+            }
             println!(
                 "Refused to kill sandbox {} (PID {}) - {error}",
                 initial.target.sandbox_id, initial.target.pid
@@ -99,6 +119,25 @@ pub async fn run_kill(args: KillArgs, control: &dyn SandboxControl) -> RunnerRes
         Ok(ExitCode::SUCCESS)
     } else {
         Ok(ExitCode::FAILURE)
+    }
+}
+
+enum RediscoverTargetError {
+    Resolve(String),
+    Changed(String),
+}
+
+impl RediscoverTargetError {
+    fn allows_disappeared_orphan_cleanup(&self) -> bool {
+        matches!(self, Self::Resolve(_))
+    }
+}
+
+impl std::fmt::Display for RediscoverTargetError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::Resolve(error) | Self::Changed(error) => f.write_str(error),
+        }
     }
 }
 
@@ -188,11 +227,12 @@ async fn resolve_target<'a>(
 async fn rediscover_same_target(
     args: &KillArgs,
     initial: &KillTarget,
-) -> Result<ResolvedKillTarget, String> {
+) -> Result<ResolvedKillTarget, RediscoverTargetError> {
     let current = discover_and_resolve_target(args)
         .await
-        .map_err(|error| error.to_string())?;
-    ensure_same_target_after_confirmation(args, initial, &current.target)?;
+        .map_err(|error| RediscoverTargetError::Resolve(error.to_string()))?;
+    ensure_same_target_after_confirmation(args, initial, &current.target)
+        .map_err(RediscoverTargetError::Changed)?;
     Ok(current)
 }
 
@@ -232,6 +272,35 @@ fn same_firecracker_identity(initial: &KillTarget, current: &KillTarget) -> bool
         (Some(initial), Some(current)) => initial == current,
         _ => false,
     }
+}
+
+fn should_cleanup_disappeared_initial_orphan(
+    initial: &KillTarget,
+    was_orphan: bool,
+    discovered_after_error: &DiscoveredProcesses,
+) -> bool {
+    was_orphan
+        && target_has_workspace_identity(initial)
+        && !discovered_has_same_or_unidentified_firecracker(initial, discovered_after_error)
+}
+
+fn target_has_workspace_identity(target: &KillTarget) -> bool {
+    match (&target.base_dir, &target.identity) {
+        (Some(base_dir), Some(identity)) => {
+            identity.sandbox_id == target.sandbox_id && identity.base_dir.as_ref() == Some(base_dir)
+        }
+        _ => false,
+    }
+}
+
+fn discovered_has_same_or_unidentified_firecracker(
+    initial: &KillTarget,
+    discovered: &DiscoveredProcesses,
+) -> bool {
+    discovered
+        .firecrackers
+        .iter()
+        .any(|process| process.sandbox_id == initial.sandbox_id || process.base_dir.is_none())
 }
 
 /// Resolve a `--run` prefix to a single Firecracker process.
@@ -323,7 +392,7 @@ async fn retry_as_orphan_if_owner_disappeared(
 ) -> KillOutcome {
     let refreshed = match rediscover_same_target(args, initial).await {
         Ok(refreshed) => refreshed,
-        Err(error) => return KillOutcome::RefusedTargetChanged(error),
+        Err(error) => return KillOutcome::RefusedTargetChanged(error.to_string()),
     };
     if !process::is_orphan(refreshed.target.pid, &refreshed.runner_pids).await {
         return KillOutcome::RefusedManagedControlFailed(owner_error.to_string());
@@ -803,6 +872,84 @@ mod tests {
         assert!(error.contains("run target changed"), "{error}");
         assert!(error.contains("sbox-old"), "{error}");
         assert!(error.contains("sbox-new"), "{error}");
+    }
+
+    fn discovered_with_firecrackers(
+        firecrackers: Vec<FirecrackerProcessInfo>,
+    ) -> DiscoveredProcesses {
+        DiscoveredProcesses {
+            runners: vec![],
+            firecrackers,
+            mitmdumps: vec![],
+            dnsmasqs: vec![],
+        }
+    }
+
+    #[test]
+    fn disappeared_initial_orphan_with_identity_allows_cleanup() {
+        let initial = make_target(200, "sbox-123");
+        let discovered = discovered_with_firecrackers(vec![]);
+
+        assert!(should_cleanup_disappeared_initial_orphan(
+            &initial,
+            true,
+            &discovered
+        ));
+    }
+
+    #[test]
+    fn disappeared_initial_managed_target_rejects_cleanup() {
+        let initial = make_target(200, "sbox-123");
+        let discovered = discovered_with_firecrackers(vec![]);
+
+        assert!(!should_cleanup_disappeared_initial_orphan(
+            &initial,
+            false,
+            &discovered
+        ));
+    }
+
+    #[test]
+    fn disappeared_initial_without_workspace_identity_rejects_cleanup() {
+        let mut initial = make_target(200, "sbox-123");
+        initial.identity.as_mut().unwrap().base_dir = None;
+        let discovered = discovered_with_firecrackers(vec![]);
+
+        assert!(!should_cleanup_disappeared_initial_orphan(
+            &initial,
+            true,
+            &discovered
+        ));
+    }
+
+    #[test]
+    fn disappeared_initial_with_same_sandbox_still_running_rejects_cleanup() {
+        let initial = make_target(200, "sbox-123");
+        let discovered = discovered_with_firecrackers(vec![make_fc(201, "sbox-123")]);
+
+        assert!(!should_cleanup_disappeared_initial_orphan(
+            &initial,
+            true,
+            &discovered
+        ));
+    }
+
+    #[test]
+    fn disappeared_initial_with_unidentified_firecracker_rejects_cleanup() {
+        let initial = make_target(200, "sbox-123");
+        let discovered = discovered_with_firecrackers(vec![FirecrackerProcessInfo {
+            pid: 201,
+            ppid: None,
+            sandbox_id: "pid-201".into(),
+            base_dir: None,
+            identity: None,
+        }]);
+
+        assert!(!should_cleanup_disappeared_initial_orphan(
+            &initial,
+            true,
+            &discovered
+        ));
     }
 
     #[test]

--- a/crates/runner/src/cmd/kill.rs
+++ b/crates/runner/src/cmd/kill.rs
@@ -14,14 +14,17 @@
 //! directly against running FC processes — useful for orphan sandboxes
 //! whose parent runner has already died and whose `status.json` is gone.
 
+use std::path::{Path, PathBuf};
 use std::process::ExitCode;
 
 use clap::Args;
-use sandbox::SandboxControl;
+use sandbox::{RemoteKillResult, SandboxControl, SandboxControlError};
 use tracing::info;
 
 use crate::error::{RunnerError, RunnerResult};
-use crate::process::{self, FirecrackerProcessInfo};
+use crate::process::{
+    self, DiscoveredProcesses, FirecrackerProcessIdentity, FirecrackerProcessInfo, ProcessStat,
+};
 use crate::run_resolution;
 
 // ---------------------------------------------------------------------------
@@ -51,67 +54,47 @@ pub struct KillArgs {
 // ---------------------------------------------------------------------------
 
 pub async fn run_kill(args: KillArgs, control: &dyn SandboxControl) -> RunnerResult<ExitCode> {
-    // Phase 1: Discover running processes
-    let discovered = process::discover_all().await;
-    let runner_pids: Vec<u32> = discovered.runners.iter().map(|r| r.pid).collect();
+    let initial = discover_and_resolve_target(&args).await?;
+    let is_initial_orphan = process::is_orphan(initial.target.pid, &initial.runner_pids).await;
 
-    // Phase 2: Resolve target — mode depends on which flag was passed.
-    let target = if let Some(ref run_id) = args.run {
-        let mappings = run_resolution::collect_active_run_mappings(&discovered.runners).await;
-        resolve_by_run_id(run_id, &mappings, &discovered.firecrackers)?
-    } else if let Some(ref sandbox_id) = args.sandbox {
-        resolve_by_sandbox_id(sandbox_id, &discovered.firecrackers)?
-    } else {
-        return Err(RunnerError::Config(
-            "one of --run or --sandbox is required".into(),
-        ));
-    };
-    let is_orphan = process::is_orphan(target.pid, &runner_pids).await;
-
-    // Phase 3: Confirm (unless --force)
     if !args.force {
-        print_target_info(target, is_orphan);
+        print_target_info(&initial.target, is_initial_orphan);
         if !confirm().await {
             println!("Aborted.");
             return Ok(ExitCode::SUCCESS);
         }
     }
 
-    // Phase 4: Kill process group
-    let killed = kill_process_group(target.pid).await;
-    if killed {
-        println!("Killed sandbox {} (PID {})", target.sandbox_id, target.pid);
-    } else {
-        println!(
-            "Failed to kill sandbox {} (PID {}) — process may have already exited",
-            target.sandbox_id, target.pid
-        );
-    }
-
-    // Phase 5: Cleanup based on orphan status
-    if is_orphan {
-        let results = cleanup_orphan(&target.sandbox_id, target.base_dir.as_deref(), control).await;
-        if !results.is_empty() {
-            println!("Orphan cleanup:");
-            for (step, success) in &results {
-                let icon = if *success { "ok" } else { "FAIL" };
-                println!("  [{icon}] {step}");
-            }
+    let current = match rediscover_same_target(&args, &initial.target).await {
+        Ok(current) => current,
+        Err(error) => {
+            println!(
+                "Refused to kill sandbox {} (PID {}) - {error}",
+                initial.target.sandbox_id, initial.target.pid
+            );
+            return Ok(ExitCode::FAILURE);
         }
-    } else {
-        let ppid_str = target.ppid.map_or("unknown".into(), |p| p.to_string());
-        println!("Parent runner (PID {ppid_str}) will handle cleanup.");
-    }
+    };
+    let is_orphan = process::is_orphan(current.target.pid, &current.runner_pids).await;
+    let outcome = kill_current_target(
+        &args,
+        &initial.target,
+        current.target.clone(),
+        is_orphan,
+        control,
+    )
+    .await;
+    report_kill_outcome(&initial.target, &current.target, &outcome, control).await;
 
     info!(
-        sandbox_id = %target.sandbox_id,
-        pid = target.pid,
+        sandbox_id = %current.target.sandbox_id,
+        pid = current.target.pid,
         orphan = is_orphan,
-        killed,
+        outcome = ?outcome,
         "kill command completed"
     );
 
-    if killed {
+    if outcome.is_success() {
         Ok(ExitCode::SUCCESS)
     } else {
         Ok(ExitCode::FAILURE)
@@ -121,6 +104,129 @@ pub async fn run_kill(args: KillArgs, control: &dyn SandboxControl) -> RunnerRes
 // ---------------------------------------------------------------------------
 // Target resolution
 // ---------------------------------------------------------------------------
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+struct KillTarget {
+    pid: u32,
+    ppid: Option<u32>,
+    sandbox_id: String,
+    base_dir: Option<PathBuf>,
+    identity: Option<FirecrackerProcessIdentity>,
+}
+
+impl From<&FirecrackerProcessInfo> for KillTarget {
+    fn from(process: &FirecrackerProcessInfo) -> Self {
+        Self {
+            pid: process.pid,
+            ppid: process.ppid,
+            sandbox_id: process.sandbox_id.clone(),
+            base_dir: process.base_dir.clone(),
+            identity: process.identity.clone(),
+        }
+    }
+}
+
+struct ResolvedKillTarget {
+    target: KillTarget,
+    runner_pids: Vec<u32>,
+}
+
+#[derive(Debug)]
+enum KillOutcome {
+    OwnerAccepted(RemoteKillResult),
+    OrphanKilled,
+    AlreadyExitedOrChanged,
+    SignalFailed,
+    RefusedManagedControlFailed(String),
+    RefusedTargetChanged(String),
+}
+
+impl KillOutcome {
+    fn is_success(&self) -> bool {
+        matches!(
+            self,
+            KillOutcome::OwnerAccepted(_) | KillOutcome::OrphanKilled
+        )
+    }
+}
+
+async fn discover_and_resolve_target(args: &KillArgs) -> RunnerResult<ResolvedKillTarget> {
+    let discovered = process::discover_all().await;
+    let runner_pids: Vec<u32> = discovered.runners.iter().map(|r| r.pid).collect();
+    let target = resolve_target(args, &discovered).await?;
+
+    Ok(ResolvedKillTarget {
+        target: target.into(),
+        runner_pids,
+    })
+}
+
+async fn resolve_target<'a>(
+    args: &KillArgs,
+    discovered: &'a DiscoveredProcesses,
+) -> RunnerResult<&'a FirecrackerProcessInfo> {
+    if let Some(ref run_id) = args.run {
+        let mappings = run_resolution::collect_active_run_mappings(&discovered.runners).await;
+        return resolve_by_run_id(run_id, &mappings, &discovered.firecrackers);
+    }
+
+    if let Some(ref sandbox_id) = args.sandbox {
+        return resolve_by_sandbox_id(sandbox_id, &discovered.firecrackers);
+    }
+
+    Err(RunnerError::Config(
+        "one of --run or --sandbox is required".into(),
+    ))
+}
+
+async fn rediscover_same_target(
+    args: &KillArgs,
+    initial: &KillTarget,
+) -> Result<ResolvedKillTarget, String> {
+    let current = discover_and_resolve_target(args)
+        .await
+        .map_err(|error| error.to_string())?;
+    ensure_same_target_after_confirmation(args, initial, &current.target)?;
+    Ok(current)
+}
+
+fn ensure_same_target_after_confirmation(
+    args: &KillArgs,
+    initial: &KillTarget,
+    current: &KillTarget,
+) -> Result<(), String> {
+    if args.run.is_some() {
+        if current.sandbox_id != initial.sandbox_id {
+            return Err(format!(
+                "run target changed from sandbox '{}' to '{}'",
+                initial.sandbox_id, current.sandbox_id
+            ));
+        }
+        return Ok(());
+    }
+
+    if args.sandbox.is_some() {
+        if current.sandbox_id != initial.sandbox_id {
+            return Err(format!(
+                "sandbox target changed from '{}' to '{}'",
+                initial.sandbox_id, current.sandbox_id
+            ));
+        }
+        if !same_firecracker_identity(initial, current) {
+            return Err("sandbox process already exited or changed identity".into());
+        }
+        return Ok(());
+    }
+
+    Err("one of --run or --sandbox is required".into())
+}
+
+fn same_firecracker_identity(initial: &KillTarget, current: &KillTarget) -> bool {
+    match (&initial.identity, &current.identity) {
+        (Some(initial), Some(current)) => initial == current,
+        _ => false,
+    }
+}
 
 /// Resolve a `--run` prefix to a single Firecracker process.
 ///
@@ -177,18 +283,153 @@ fn resolve_by_sandbox_id<'a>(
 // Process kill
 // ---------------------------------------------------------------------------
 
-/// Kill the process group containing the given PID.
-///
-/// Reads the PGID from `/proc/{pid}/stat` and sends `SIGKILL` to the entire
-/// group via `killpg`. This ensures intermediate processes in the spawn chain
-/// (`sudo`, `ip netns exec`) are also terminated.
-async fn kill_process_group(pid: u32) -> bool {
-    // Read the actual PGID — the firecracker PID differs from the PGID
-    // because .process_group(0) is set on the outer sudo command.
-    let Some(pgid) = process::read_pgid(pid).await else {
-        tracing::warn!(pid, "failed to read PGID from /proc");
-        return false;
+async fn kill_current_target(
+    args: &KillArgs,
+    initial: &KillTarget,
+    current: KillTarget,
+    is_orphan: bool,
+    control: &dyn SandboxControl,
+) -> KillOutcome {
+    if is_orphan {
+        return kill_orphan_process_group(initial).await;
+    }
+
+    match control.kill_remote(&current.sandbox_id).await {
+        Ok(result) => KillOutcome::OwnerAccepted(result),
+        Err(error) => retry_as_orphan_if_owner_disappeared(args, initial, error).await,
+    }
+}
+
+async fn retry_as_orphan_if_owner_disappeared(
+    args: &KillArgs,
+    initial: &KillTarget,
+    owner_error: SandboxControlError,
+) -> KillOutcome {
+    let refreshed = match rediscover_same_target(args, initial).await {
+        Ok(refreshed) => refreshed,
+        Err(error) => return KillOutcome::RefusedTargetChanged(error),
     };
+    if !process::is_orphan(refreshed.target.pid, &refreshed.runner_pids).await {
+        return KillOutcome::RefusedManagedControlFailed(owner_error.to_string());
+    }
+
+    kill_orphan_process_group(initial).await
+}
+
+async fn kill_orphan_process_group(target: &KillTarget) -> KillOutcome {
+    let Some(pgid) = validated_orphan_pgid(target).await else {
+        return KillOutcome::AlreadyExitedOrChanged;
+    };
+
+    if signal_process_group(target.pid, pgid) {
+        KillOutcome::OrphanKilled
+    } else {
+        KillOutcome::SignalFailed
+    }
+}
+
+async fn validated_orphan_pgid(target: &KillTarget) -> Option<u32> {
+    let Some(identity) = &target.identity else {
+        tracing::warn!(
+            pid = target.pid,
+            sandbox_id = %target.sandbox_id,
+            "refusing orphan kill without process identity"
+        );
+        return None;
+    };
+
+    if identity.pid != target.pid {
+        tracing::warn!(
+            pid = target.pid,
+            identity_pid = identity.pid,
+            "refusing orphan kill with inconsistent process identity"
+        );
+        return None;
+    }
+
+    let Some(stat) = process::read_process_stat(target.pid).await else {
+        tracing::warn!(
+            pid = target.pid,
+            "failed to read process stat before orphan kill"
+        );
+        return None;
+    };
+    let stat_matches = stat.pgid == identity.pgid && stat.starttime == identity.starttime;
+    if !stat_matches {
+        tracing::warn!(
+            pid = target.pid,
+            expected_pgid = identity.pgid,
+            current_pgid = stat.pgid,
+            expected_starttime = identity.starttime,
+            current_starttime = stat.starttime,
+            "refusing orphan kill after process identity changed"
+        );
+        return None;
+    }
+
+    let Some(cmdline) = process::read_cmdline(target.pid).await else {
+        tracing::warn!(
+            pid = target.pid,
+            "failed to read cmdline before orphan kill"
+        );
+        return None;
+    };
+    if !process::is_firecracker_cmdline(&cmdline) {
+        tracing::warn!(
+            pid = target.pid,
+            "refusing orphan kill for non-firecracker cmdline"
+        );
+        return None;
+    }
+
+    let cwd_info = process::read_cwd(target.pid)
+        .await
+        .and_then(|cwd| process::parse_workspace_cwd(&cwd));
+    if !orphan_identity_matches_facts(identity, &stat, true, cwd_info.as_ref()) {
+        tracing::warn!(
+            pid = target.pid,
+            sandbox_id = %target.sandbox_id,
+            "refusing orphan kill after workspace identity changed"
+        );
+        return None;
+    }
+
+    Some(identity.pgid)
+}
+
+fn orphan_identity_matches_facts(
+    identity: &FirecrackerProcessIdentity,
+    stat: &ProcessStat,
+    is_firecracker_cmdline: bool,
+    cwd_info: Option<&(String, PathBuf)>,
+) -> bool {
+    stat.pgid == identity.pgid
+        && stat.starttime == identity.starttime
+        && is_firecracker_cmdline
+        && workspace_identity_matches(identity, cwd_info)
+}
+
+fn workspace_identity_matches(
+    identity: &FirecrackerProcessIdentity,
+    cwd_info: Option<&(String, PathBuf)>,
+) -> bool {
+    match (&identity.base_dir, cwd_info) {
+        (Some(expected_base_dir), Some((sandbox_id, base_dir))) => {
+            sandbox_id == &identity.sandbox_id && base_dir == expected_base_dir
+        }
+        (Some(_), None) => false,
+        (None, Some(_)) => false,
+        (None, None) => true,
+    }
+}
+
+/// Send `SIGKILL` to a validated process group.
+fn signal_process_group(pid: u32, pgid: u32) -> bool {
+    if pgid == 0 {
+        tracing::warn!(pid, "refusing to signal process group 0");
+        return false;
+    }
+
     let Ok(pgid_i32) = i32::try_from(pgid) else {
         return false;
     };
@@ -208,13 +449,88 @@ async fn kill_process_group(pid: u32) -> bool {
     }
 }
 
+async fn report_kill_outcome(
+    initial: &KillTarget,
+    current: &KillTarget,
+    outcome: &KillOutcome,
+    control: &dyn SandboxControl,
+) {
+    match outcome {
+        KillOutcome::OwnerAccepted(RemoteKillResult::Accepted) => {
+            println!(
+                "Owning runner accepted kill for sandbox {} (PID {}).",
+                current.sandbox_id, current.pid
+            );
+            println!("Owning runner will handle cleanup.");
+        }
+        KillOutcome::OwnerAccepted(RemoteKillResult::AlreadyStopped) => {
+            println!(
+                "Sandbox {} is already stopping or stopped.",
+                current.sandbox_id
+            );
+            println!("Owning runner will handle cleanup.");
+        }
+        KillOutcome::OrphanKilled => {
+            println!(
+                "Killed orphan sandbox {} (PID {})",
+                initial.sandbox_id, initial.pid
+            );
+            if initial.base_dir.is_some() {
+                let results =
+                    cleanup_orphan(&initial.sandbox_id, initial.base_dir.as_deref(), control).await;
+                print_cleanup_results(&results);
+            } else {
+                println!(
+                    "Skipped orphan cleanup because sandbox workspace identity is unavailable."
+                );
+            }
+        }
+        KillOutcome::AlreadyExitedOrChanged => {
+            println!(
+                "Refused to kill sandbox {} (PID {}) - process already exited or changed identity",
+                initial.sandbox_id, initial.pid
+            );
+        }
+        KillOutcome::SignalFailed => {
+            println!(
+                "Failed to kill sandbox {} (PID {})",
+                initial.sandbox_id, initial.pid
+            );
+        }
+        KillOutcome::RefusedManagedControlFailed(error) => {
+            println!(
+                "Refused direct kill for managed sandbox {} (PID {}) - owning runner control failed: {error}",
+                current.sandbox_id, current.pid
+            );
+        }
+        KillOutcome::RefusedTargetChanged(error) => {
+            println!(
+                "Refused to kill sandbox {} (PID {}) - {error}",
+                initial.sandbox_id, initial.pid
+            );
+        }
+    }
+}
+
+fn print_cleanup_results(results: &[(String, bool)]) {
+    if results.is_empty() {
+        return;
+    }
+
+    println!("Orphan cleanup:");
+    for (step, success) in results {
+        let icon = if *success { "ok" } else { "FAIL" };
+        println!("  [{icon}] {step}");
+    }
+}
+
 // ---------------------------------------------------------------------------
 // Orphan cleanup
 // ---------------------------------------------------------------------------
 
 async fn cleanup_orphan(
     sandbox_id: &str,
-    base_dir: Option<&std::path::Path>,
+    base_dir: Option<&Path>,
     control: &dyn SandboxControl,
 ) -> Vec<(String, bool)> {
     let mut results = Vec::new();
@@ -237,7 +553,7 @@ async fn cleanup_orphan(
 }
 
 /// Remove a directory, treating `NotFound` as success.
-async fn remove_dir_if_exists(path: &std::path::Path) -> bool {
+async fn remove_dir_if_exists(path: &Path) -> bool {
     match tokio::fs::remove_dir_all(path).await {
         Ok(()) => true,
         Err(e) if e.kind() == std::io::ErrorKind::NotFound => true,
@@ -252,7 +568,7 @@ async fn remove_dir_if_exists(path: &std::path::Path) -> bool {
 // Confirmation prompt
 // ---------------------------------------------------------------------------
 
-fn print_target_info(fc: &FirecrackerProcessInfo, is_orphan: bool) {
+fn print_target_info(fc: &KillTarget, is_orphan: bool) {
     println!("Kill sandbox {}?", fc.sandbox_id);
     println!("  PID:    {}", fc.pid);
     if is_orphan {
@@ -291,6 +607,8 @@ async fn confirm() -> bool {
 mod tests {
     use std::path::PathBuf;
 
+    use sandbox_mock::MockSandboxControl;
+
     use super::*;
 
     fn make_fc(pid: u32, sandbox_id: &str) -> FirecrackerProcessInfo {
@@ -299,6 +617,23 @@ mod tests {
             ppid: None,
             sandbox_id: sandbox_id.into(),
             base_dir: Some(PathBuf::from("/data/r1")),
+            identity: None,
+        }
+    }
+
+    fn make_target(pid: u32, sandbox_id: &str) -> KillTarget {
+        KillTarget {
+            pid,
+            ppid: None,
+            sandbox_id: sandbox_id.into(),
+            base_dir: Some(PathBuf::from("/data/r1")),
+            identity: Some(FirecrackerProcessIdentity {
+                pid,
+                pgid: pid + 1000,
+                starttime: 123456,
+                sandbox_id: sandbox_id.into(),
+                base_dir: Some(PathBuf::from("/data/r1")),
+            }),
         }
     }
 
@@ -373,17 +708,180 @@ mod tests {
         assert!(result.is_err());
     }
 
+    #[test]
+    fn sandbox_reresolution_requires_same_process_identity() {
+        let args = KillArgs {
+            run: None,
+            sandbox: Some("sbox".into()),
+            force: true,
+        };
+        let initial = make_target(200, "sbox-123");
+        let mut current = make_target(200, "sbox-123");
+        current.identity.as_mut().unwrap().starttime += 1;
+
+        let error = ensure_same_target_after_confirmation(&args, &initial, &current).unwrap_err();
+
+        assert!(error.contains("changed identity"), "{error}");
+    }
+
+    #[test]
+    fn run_reresolution_requires_same_sandbox() {
+        let args = KillArgs {
+            run: Some("run".into()),
+            sandbox: None,
+            force: true,
+        };
+        let initial = make_target(200, "sbox-old");
+        let current = make_target(201, "sbox-new");
+
+        let error = ensure_same_target_after_confirmation(&args, &initial, &current).unwrap_err();
+
+        assert!(error.contains("run target changed"), "{error}");
+        assert!(error.contains("sbox-old"), "{error}");
+        assert!(error.contains("sbox-new"), "{error}");
+    }
+
+    #[test]
+    fn orphan_identity_facts_match() {
+        let target = make_target(200, "sbox-123");
+        let identity = target.identity.as_ref().unwrap();
+        let stat = ProcessStat {
+            pgid: identity.pgid,
+            starttime: identity.starttime,
+        };
+        let cwd_info = ("sbox-123".to_string(), PathBuf::from("/data/r1"));
+
+        assert!(orphan_identity_matches_facts(
+            identity,
+            &stat,
+            true,
+            Some(&cwd_info)
+        ));
+    }
+
+    #[test]
+    fn orphan_identity_rejects_changed_starttime() {
+        let target = make_target(200, "sbox-123");
+        let identity = target.identity.as_ref().unwrap();
+        let stat = ProcessStat {
+            pgid: identity.pgid,
+            starttime: identity.starttime + 1,
+        };
+        let cwd_info = ("sbox-123".to_string(), PathBuf::from("/data/r1"));
+
+        assert!(!orphan_identity_matches_facts(
+            identity,
+            &stat,
+            true,
+            Some(&cwd_info)
+        ));
+    }
+
+    #[test]
+    fn orphan_identity_rejects_changed_pgid() {
+        let target = make_target(200, "sbox-123");
+        let identity = target.identity.as_ref().unwrap();
+        let stat = ProcessStat {
+            pgid: identity.pgid + 1,
+            starttime: identity.starttime,
+        };
+        let cwd_info = ("sbox-123".to_string(), PathBuf::from("/data/r1"));
+
+        assert!(!orphan_identity_matches_facts(
+            identity,
+            &stat,
+            true,
+            Some(&cwd_info)
+        ));
+    }
+
+    #[test]
+    fn orphan_identity_rejects_non_firecracker_cmdline() {
+        let target = make_target(200, "sbox-123");
+        let identity = target.identity.as_ref().unwrap();
+        let stat = ProcessStat {
+            pgid: identity.pgid,
+            starttime: identity.starttime,
+        };
+        let cwd_info = ("sbox-123".to_string(), PathBuf::from("/data/r1"));
+
+        assert!(!orphan_identity_matches_facts(
+            identity,
+            &stat,
+            false,
+            Some(&cwd_info)
+        ));
+    }
+
+    #[test]
+    fn orphan_identity_rejects_changed_workspace() {
+        let target = make_target(200, "sbox-123");
+        let identity = target.identity.as_ref().unwrap();
+        let stat = ProcessStat {
+            pgid: identity.pgid,
+            starttime: identity.starttime,
+        };
+        let cwd_info = ("sbox-other".to_string(), PathBuf::from("/data/r1"));
+
+        assert!(!orphan_identity_matches_facts(
+            identity,
+            &stat,
+            true,
+            Some(&cwd_info)
+        ));
+    }
+
     #[tokio::test]
-    async fn kill_process_group_nonexistent_pid() {
+    async fn managed_target_requests_owner_control() {
+        let control = MockSandboxControl::new("/tmp/test");
+        let initial = make_target(200, "sbox-123");
+        let current = initial.clone();
+        let args = KillArgs {
+            run: None,
+            sandbox: Some("sbox-123".into()),
+            force: true,
+        };
+
+        let outcome = kill_current_target(&args, &initial, current, false, &control).await;
+
+        assert!(matches!(
+            outcome,
+            KillOutcome::OwnerAccepted(RemoteKillResult::Accepted)
+        ));
+        assert_eq!(control.recorded_kill_ids(), vec!["sbox-123"]);
+    }
+
+    #[test]
+    fn signal_process_group_rejects_zero_pgid() {
+        assert!(!signal_process_group(1234, 0));
+    }
+
+    #[tokio::test]
+    async fn orphan_kill_nonexistent_pid_fails_closed() {
         // u32::MAX exceeds any valid PID — /proc/{pid}/stat won't exist
-        assert!(!kill_process_group(u32::MAX).await);
+        let target = KillTarget {
+            pid: u32::MAX,
+            ppid: None,
+            sandbox_id: "sbox-missing".into(),
+            base_dir: Some(PathBuf::from("/data/r1")),
+            identity: Some(FirecrackerProcessIdentity {
+                pid: u32::MAX,
+                pgid: 1234,
+                starttime: 123456,
+                sandbox_id: "sbox-missing".into(),
+                base_dir: Some(PathBuf::from("/data/r1")),
+            }),
+        };
+
+        assert!(matches!(
+            kill_orphan_process_group(&target).await,
+            KillOutcome::AlreadyExitedOrChanged
+        ));
     }
 
     // -----------------------------------------------------------------------
     // Orphan cleanup tests (using sandbox-mock)
     // -----------------------------------------------------------------------
-
-    use sandbox_mock::MockSandboxControl;
 
     #[tokio::test]
     async fn cleanup_orphan_removes_workspace_and_socket_dir() {

--- a/crates/runner/src/cmd/kill.rs
+++ b/crates/runner/src/cmd/kill.rs
@@ -138,6 +138,7 @@ enum KillOutcome {
     OrphanKilled,
     AlreadyExitedOrChanged,
     SignalFailed,
+    RefusedManagedIdle,
     RefusedManagedControlFailed(String),
     RefusedTargetChanged(String),
 }
@@ -146,7 +147,9 @@ impl KillOutcome {
     fn is_success(&self) -> bool {
         matches!(
             self,
-            KillOutcome::OwnerAccepted(_) | KillOutcome::OrphanKilled
+            KillOutcome::OwnerAccepted(RemoteKillResult::Accepted)
+                | KillOutcome::OwnerAccepted(RemoteKillResult::AlreadyStopped)
+                | KillOutcome::OrphanKilled
         )
     }
 }
@@ -305,6 +308,7 @@ async fn kill_current_target(
     }
 
     match control.kill_remote(&current.sandbox_id).await {
+        Ok(RemoteKillResult::RefusedIdle) => KillOutcome::RefusedManagedIdle,
         Ok(result) => KillOutcome::OwnerAccepted(result),
         Err(error) => retry_as_orphan_if_owner_disappeared(args, initial, error).await,
     }
@@ -510,6 +514,16 @@ async fn report_kill_outcome(
             println!(
                 "Refused direct kill for managed sandbox {} (PID {}) - owning runner control failed: {error}",
                 current.sandbox_id, current.pid
+            );
+        }
+        KillOutcome::OwnerAccepted(RemoteKillResult::RefusedIdle)
+        | KillOutcome::RefusedManagedIdle => {
+            println!(
+                "Refused to kill managed idle or parking sandbox {} (PID {}) - owning runner still owns its resources",
+                current.sandbox_id, current.pid
+            );
+            println!(
+                "Use runner drain/shutdown or wait for idle eviction so the owner can destroy it cleanly."
             );
         }
         KillOutcome::RefusedTargetChanged(error) => {
@@ -870,6 +884,24 @@ mod tests {
             outcome,
             KillOutcome::OwnerAccepted(RemoteKillResult::Accepted)
         ));
+        assert_eq!(control.recorded_kill_ids(), vec!["sbox-123"]);
+    }
+
+    #[tokio::test]
+    async fn managed_idle_target_is_refused() {
+        let control = MockSandboxControl::new("/tmp/test");
+        control.push_kill_remote_result(Ok(RemoteKillResult::RefusedIdle));
+        let initial = make_target(200, "sbox-123");
+        let current = initial.clone();
+        let args = KillArgs {
+            run: None,
+            sandbox: Some("sbox-123".into()),
+            force: true,
+        };
+
+        let outcome = kill_current_target(&args, &initial, current, false, &control).await;
+
+        assert!(matches!(outcome, KillOutcome::RefusedManagedIdle));
         assert_eq!(control.recorded_kill_ids(), vec!["sbox-123"]);
     }
 

--- a/crates/runner/src/cmd/kill.rs
+++ b/crates/runner/src/cmd/kill.rs
@@ -402,25 +402,46 @@ async fn retry_as_orphan_if_owner_disappeared(
 }
 
 async fn kill_orphan_process_group(target: &KillTarget) -> KillOutcome {
-    let Some(pgid) = validated_orphan_pgid(target).await else {
-        return KillOutcome::AlreadyExitedOrChanged(target.clone());
+    let pgid = match validate_orphan_target(target).await {
+        OrphanTargetValidation::Valid { pgid } => pgid,
+        OrphanTargetValidation::AlreadyGone => {
+            return already_gone_orphan_outcome(target).await;
+        }
+        OrphanTargetValidation::Changed => {
+            return KillOutcome::AlreadyExitedOrChanged(target.clone());
+        }
     };
 
     match signal_process_group(target.pid, pgid) {
         ProcessGroupSignalResult::Signaled => KillOutcome::OrphanKilled(target.clone()),
-        ProcessGroupSignalResult::AlreadyGone => KillOutcome::OrphanAlreadyExited(target.clone()),
+        ProcessGroupSignalResult::AlreadyGone => already_gone_orphan_outcome(target).await,
         ProcessGroupSignalResult::Failed => KillOutcome::SignalFailed(target.clone()),
     }
 }
 
-async fn validated_orphan_pgid(target: &KillTarget) -> Option<u32> {
+async fn already_gone_orphan_outcome(target: &KillTarget) -> KillOutcome {
+    let discovered = process::discover_all().await;
+    if should_cleanup_disappeared_initial_orphan(target, true, &discovered) {
+        KillOutcome::OrphanAlreadyExited(target.clone())
+    } else {
+        KillOutcome::AlreadyExitedOrChanged(target.clone())
+    }
+}
+
+enum OrphanTargetValidation {
+    Valid { pgid: u32 },
+    AlreadyGone,
+    Changed,
+}
+
+async fn validate_orphan_target(target: &KillTarget) -> OrphanTargetValidation {
     let Some(identity) = &target.identity else {
         tracing::warn!(
             pid = target.pid,
             sandbox_id = %target.sandbox_id,
             "refusing orphan kill without process identity"
         );
-        return None;
+        return OrphanTargetValidation::Changed;
     };
 
     if identity.pid != target.pid {
@@ -429,7 +450,7 @@ async fn validated_orphan_pgid(target: &KillTarget) -> Option<u32> {
             identity_pid = identity.pid,
             "refusing orphan kill with inconsistent process identity"
         );
-        return None;
+        return OrphanTargetValidation::Changed;
     }
 
     let Some(stat) = process::read_process_stat(target.pid).await else {
@@ -437,10 +458,9 @@ async fn validated_orphan_pgid(target: &KillTarget) -> Option<u32> {
             pid = target.pid,
             "failed to read process stat before orphan kill"
         );
-        return None;
+        return OrphanTargetValidation::AlreadyGone;
     };
-    let stat_matches = stat.pgid == identity.pgid && stat.starttime == identity.starttime;
-    if !stat_matches {
+    if !process_stat_matches_identity(identity, &stat) {
         tracing::warn!(
             pid = target.pid,
             expected_pgid = identity.pgid,
@@ -449,7 +469,7 @@ async fn validated_orphan_pgid(target: &KillTarget) -> Option<u32> {
             current_starttime = stat.starttime,
             "refusing orphan kill after process identity changed"
         );
-        return None;
+        return OrphanTargetValidation::Changed;
     }
 
     let Some(cmdline) = process::read_cmdline(target.pid).await else {
@@ -457,14 +477,14 @@ async fn validated_orphan_pgid(target: &KillTarget) -> Option<u32> {
             pid = target.pid,
             "failed to read cmdline before orphan kill"
         );
-        return None;
+        return classify_orphan_validation_after_unreadable_pid_fact(target.pid, identity).await;
     };
     if !process::is_firecracker_cmdline(&cmdline) {
         tracing::warn!(
             pid = target.pid,
             "refusing orphan kill for non-firecracker cmdline"
         );
-        return None;
+        return OrphanTargetValidation::Changed;
     }
 
     let cwd_info = process::read_cwd(target.pid)
@@ -476,10 +496,51 @@ async fn validated_orphan_pgid(target: &KillTarget) -> Option<u32> {
             sandbox_id = %target.sandbox_id,
             "refusing orphan kill after workspace identity changed"
         );
-        return None;
+        return classify_orphan_validation_after_unreadable_pid_fact(target.pid, identity).await;
     }
 
-    Some(identity.pgid)
+    let Some(final_stat) = process::read_process_stat(target.pid).await else {
+        tracing::warn!(
+            pid = target.pid,
+            "failed to reread process stat before orphan kill"
+        );
+        return OrphanTargetValidation::AlreadyGone;
+    };
+    if !process_stat_matches_identity(identity, &final_stat) {
+        tracing::warn!(
+            pid = target.pid,
+            expected_pgid = identity.pgid,
+            current_pgid = final_stat.pgid,
+            expected_starttime = identity.starttime,
+            current_starttime = final_stat.starttime,
+            "refusing orphan kill after process identity changed during validation"
+        );
+        return OrphanTargetValidation::Changed;
+    }
+
+    OrphanTargetValidation::Valid {
+        pgid: identity.pgid,
+    }
+}
+
+async fn classify_orphan_validation_after_unreadable_pid_fact(
+    pid: u32,
+    identity: &FirecrackerProcessIdentity,
+) -> OrphanTargetValidation {
+    match process::read_process_stat(pid).await {
+        Some(stat) if process_stat_matches_identity(identity, &stat) => {
+            OrphanTargetValidation::Changed
+        }
+        Some(_) => OrphanTargetValidation::Changed,
+        None => OrphanTargetValidation::AlreadyGone,
+    }
+}
+
+fn process_stat_matches_identity(
+    identity: &FirecrackerProcessIdentity,
+    stat: &ProcessStat,
+) -> bool {
+    stat.pgid == identity.pgid && stat.starttime == identity.starttime
 }
 
 fn orphan_identity_matches_facts(
@@ -488,8 +549,7 @@ fn orphan_identity_matches_facts(
     is_firecracker_cmdline: bool,
     cwd_info: Option<&(String, PathBuf)>,
 ) -> bool {
-    stat.pgid == identity.pgid
-        && stat.starttime == identity.starttime
+    process_stat_matches_identity(identity, stat)
         && is_firecracker_cmdline
         && workspace_identity_matches(identity, cwd_info)
 }
@@ -1007,6 +1067,28 @@ mod tests {
     }
 
     #[test]
+    fn process_stat_identity_match_requires_stable_pgid_and_starttime() {
+        let target = make_target(200, "sbox-123");
+        let identity = target.identity.as_ref().unwrap();
+        let matching = ProcessStat {
+            pgid: identity.pgid,
+            starttime: identity.starttime,
+        };
+        let changed_starttime = ProcessStat {
+            pgid: identity.pgid,
+            starttime: identity.starttime + 1,
+        };
+        let changed_pgid = ProcessStat {
+            pgid: identity.pgid + 1,
+            starttime: identity.starttime,
+        };
+
+        assert!(process_stat_matches_identity(identity, &matching));
+        assert!(!process_stat_matches_identity(identity, &changed_starttime));
+        assert!(!process_stat_matches_identity(identity, &changed_pgid));
+    }
+
+    #[test]
     fn orphan_identity_rejects_non_firecracker_cmdline() {
         let target = make_target(200, "sbox-123");
         let identity = target.identity.as_ref().unwrap();
@@ -1108,8 +1190,8 @@ mod tests {
         let outcome = kill_current_target(&args, &initial, current.clone(), true, &control).await;
 
         match outcome {
-            KillOutcome::AlreadyExitedOrChanged(target) => assert_eq!(target, current),
-            other => panic!("expected current target to fail closed, got {other:?}"),
+            KillOutcome::OrphanAlreadyExited(target) => assert_eq!(target, current),
+            other => panic!("expected current target to be reported gone, got {other:?}"),
         }
     }
 
@@ -1158,7 +1240,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn orphan_kill_nonexistent_pid_fails_closed() {
+    async fn orphan_kill_nonexistent_pid_reports_gone_when_cleanup_is_safe() {
         // u32::MAX exceeds any valid PID — /proc/{pid}/stat won't exist
         let target = KillTarget {
             pid: u32::MAX,
@@ -1176,7 +1258,7 @@ mod tests {
 
         assert!(matches!(
             kill_orphan_process_group(&target).await,
-            KillOutcome::AlreadyExitedOrChanged(_)
+            KillOutcome::OrphanAlreadyExited(_)
         ));
     }
 

--- a/crates/runner/src/cmd/kill.rs
+++ b/crates/runner/src/cmd/kill.rs
@@ -471,6 +471,13 @@ async fn validate_orphan_target(target: &KillTarget) -> OrphanTargetValidation {
         );
         return OrphanTargetValidation::Changed;
     }
+    if process_stat_is_zombie(&stat) {
+        tracing::warn!(
+            pid = target.pid,
+            "orphan target already exited and is waiting to be reaped"
+        );
+        return OrphanTargetValidation::AlreadyGone;
+    }
 
     let Some(cmdline) = process::read_cmdline(target.pid).await else {
         tracing::warn!(
@@ -517,6 +524,13 @@ async fn validate_orphan_target(target: &KillTarget) -> OrphanTargetValidation {
         );
         return OrphanTargetValidation::Changed;
     }
+    if process_stat_is_zombie(&final_stat) {
+        tracing::warn!(
+            pid = target.pid,
+            "orphan target exited during validation and is waiting to be reaped"
+        );
+        return OrphanTargetValidation::AlreadyGone;
+    }
 
     OrphanTargetValidation::Valid {
         pgid: identity.pgid,
@@ -528,6 +542,11 @@ async fn classify_orphan_validation_after_unreadable_pid_fact(
     identity: &FirecrackerProcessIdentity,
 ) -> OrphanTargetValidation {
     match process::read_process_stat(pid).await {
+        Some(stat)
+            if process_stat_matches_identity(identity, &stat) && process_stat_is_zombie(&stat) =>
+        {
+            OrphanTargetValidation::AlreadyGone
+        }
         Some(stat) if process_stat_matches_identity(identity, &stat) => {
             OrphanTargetValidation::Changed
         }
@@ -541,6 +560,10 @@ fn process_stat_matches_identity(
     stat: &ProcessStat,
 ) -> bool {
     stat.pgid == identity.pgid && stat.starttime == identity.starttime
+}
+
+fn process_stat_is_zombie(stat: &ProcessStat) -> bool {
+    stat.state == 'Z'
 }
 
 fn orphan_identity_matches_facts(
@@ -815,6 +838,14 @@ mod tests {
         }
     }
 
+    fn process_stat(identity: &FirecrackerProcessIdentity) -> ProcessStat {
+        ProcessStat {
+            state: 'S',
+            pgid: identity.pgid,
+            starttime: identity.starttime,
+        }
+    }
+
     /// Build an `ActiveRunMappings` from a vec of `(run_id, sandbox_id)` pairs
     /// with zero read failures — the common test case.
     fn mappings(entries: Vec<(String, String)>) -> run_resolution::ActiveRunMappings {
@@ -1016,10 +1047,7 @@ mod tests {
     fn orphan_identity_facts_match() {
         let target = make_target(200, "sbox-123");
         let identity = target.identity.as_ref().unwrap();
-        let stat = ProcessStat {
-            pgid: identity.pgid,
-            starttime: identity.starttime,
-        };
+        let stat = process_stat(identity);
         let cwd_info = ("sbox-123".to_string(), PathBuf::from("/data/r1"));
 
         assert!(orphan_identity_matches_facts(
@@ -1035,6 +1063,7 @@ mod tests {
         let target = make_target(200, "sbox-123");
         let identity = target.identity.as_ref().unwrap();
         let stat = ProcessStat {
+            state: 'S',
             pgid: identity.pgid,
             starttime: identity.starttime + 1,
         };
@@ -1053,6 +1082,7 @@ mod tests {
         let target = make_target(200, "sbox-123");
         let identity = target.identity.as_ref().unwrap();
         let stat = ProcessStat {
+            state: 'S',
             pgid: identity.pgid + 1,
             starttime: identity.starttime,
         };
@@ -1070,15 +1100,14 @@ mod tests {
     fn process_stat_identity_match_requires_stable_pgid_and_starttime() {
         let target = make_target(200, "sbox-123");
         let identity = target.identity.as_ref().unwrap();
-        let matching = ProcessStat {
-            pgid: identity.pgid,
-            starttime: identity.starttime,
-        };
+        let matching = process_stat(identity);
         let changed_starttime = ProcessStat {
+            state: 'S',
             pgid: identity.pgid,
             starttime: identity.starttime + 1,
         };
         let changed_pgid = ProcessStat {
+            state: 'S',
             pgid: identity.pgid + 1,
             starttime: identity.starttime,
         };
@@ -1092,10 +1121,7 @@ mod tests {
     fn orphan_identity_rejects_non_firecracker_cmdline() {
         let target = make_target(200, "sbox-123");
         let identity = target.identity.as_ref().unwrap();
-        let stat = ProcessStat {
-            pgid: identity.pgid,
-            starttime: identity.starttime,
-        };
+        let stat = process_stat(identity);
         let cwd_info = ("sbox-123".to_string(), PathBuf::from("/data/r1"));
 
         assert!(!orphan_identity_matches_facts(
@@ -1110,10 +1136,7 @@ mod tests {
     fn orphan_identity_rejects_changed_workspace() {
         let target = make_target(200, "sbox-123");
         let identity = target.identity.as_ref().unwrap();
-        let stat = ProcessStat {
-            pgid: identity.pgid,
-            starttime: identity.starttime,
-        };
+        let stat = process_stat(identity);
         let cwd_info = ("sbox-other".to_string(), PathBuf::from("/data/r1"));
 
         assert!(!orphan_identity_matches_facts(
@@ -1130,12 +1153,23 @@ mod tests {
         target.base_dir = None;
         target.identity.as_mut().unwrap().base_dir = None;
         let identity = target.identity.as_ref().unwrap();
-        let stat = ProcessStat {
+        let stat = process_stat(identity);
+
+        assert!(!orphan_identity_matches_facts(identity, &stat, true, None));
+    }
+
+    #[test]
+    fn zombie_process_stat_is_already_exited() {
+        let target = make_target(200, "sbox-123");
+        let identity = target.identity.as_ref().unwrap();
+        let zombie = ProcessStat {
+            state: 'Z',
             pgid: identity.pgid,
             starttime: identity.starttime,
         };
 
-        assert!(!orphan_identity_matches_facts(identity, &stat, true, None));
+        assert!(process_stat_matches_identity(identity, &zombie));
+        assert!(process_stat_is_zombie(&zombie));
     }
 
     #[tokio::test]

--- a/crates/runner/src/cmd/kill.rs
+++ b/crates/runner/src/cmd/kill.rs
@@ -96,7 +96,8 @@ pub async fn run_kill(args: KillArgs, control: &dyn SandboxControl) -> RunnerRes
                     &initial.target,
                     is_initial_orphan,
                     &discovered_after_error,
-                ) {
+                ) && !initial_process_still_live(&initial.target).await
+                {
                     let outcome = KillOutcome::OrphanAlreadyExited(initial.target.clone());
                     report_kill_outcome(&initial.target, &initial.target, &outcome, control).await;
                     info!(
@@ -484,7 +485,9 @@ async fn kill_orphan_process_group(target: &KillTarget) -> KillOutcome {
 
 async fn already_gone_orphan_outcome(target: &KillTarget) -> KillOutcome {
     let discovered = process::discover_all().await;
-    if should_cleanup_disappeared_initial_orphan(target, true, &discovered) {
+    if should_cleanup_disappeared_initial_orphan(target, true, &discovered)
+        && !initial_process_still_live(target).await
+    {
         KillOutcome::OrphanAlreadyExited(target.clone())
     } else {
         KillOutcome::AlreadyExitedOrChanged(target.clone())
@@ -616,6 +619,18 @@ async fn classify_orphan_validation_after_unreadable_pid_fact(
         Some(_) => OrphanTargetValidation::Changed,
         None => OrphanTargetValidation::AlreadyGone,
     }
+}
+
+async fn initial_process_still_live(target: &KillTarget) -> bool {
+    let stat = process::read_process_stat(target.pid).await;
+    same_initial_process_still_live(target, stat.as_ref())
+}
+
+fn same_initial_process_still_live(target: &KillTarget, stat: Option<&ProcessStat>) -> bool {
+    let (Some(identity), Some(stat)) = (&target.identity, stat) else {
+        return false;
+    };
+    process_stat_matches_identity(identity, stat) && !process_stat_is_zombie(stat)
 }
 
 fn process_stat_matches_identity(
@@ -1265,6 +1280,40 @@ mod tests {
 
         assert!(process_stat_matches_identity(identity, &zombie));
         assert!(process_stat_is_zombie(&zombie));
+    }
+
+    #[test]
+    fn same_initial_process_still_live_detects_matching_non_zombie() {
+        let target = make_target(200, "sbox-123");
+        let stat = process_stat(target.identity.as_ref().unwrap());
+
+        assert!(same_initial_process_still_live(&target, Some(&stat)));
+    }
+
+    #[test]
+    fn same_initial_process_still_live_rejects_zombie() {
+        let target = make_target(200, "sbox-123");
+        let identity = target.identity.as_ref().unwrap();
+        let stat = ProcessStat {
+            state: 'Z',
+            pgid: identity.pgid,
+            starttime: identity.starttime,
+        };
+
+        assert!(!same_initial_process_still_live(&target, Some(&stat)));
+    }
+
+    #[test]
+    fn same_initial_process_still_live_rejects_changed_identity() {
+        let target = make_target(200, "sbox-123");
+        let identity = target.identity.as_ref().unwrap();
+        let stat = ProcessStat {
+            state: 'S',
+            pgid: identity.pgid,
+            starttime: identity.starttime + 1,
+        };
+
+        assert!(!same_initial_process_still_live(&target, Some(&stat)));
     }
 
     #[tokio::test]

--- a/crates/runner/src/cmd/kill.rs
+++ b/crates/runner/src/cmd/kill.rs
@@ -1,8 +1,9 @@
 //! Kill a running sandbox and clean up resources.
 //!
-//! When the parent runner daemon is alive, killing the Firecracker process
-//! group is sufficient — the runner detects the exit via `monitor_process` →
-//! `crash_notify` and handles all cleanup (proxy, netns, workspace, status).
+//! When the parent runner daemon is alive, this command asks the owning runner
+//! to terminate the sandbox via the local control socket. The owner still holds
+//! the process monitor and `Child` handle, so it can kill the process group and
+//! handle normal cleanup without reconstructing ownership from `/proc`.
 //!
 //! Manual cleanup (workspace + socket dir) is only performed for orphan
 //! processes whose parent runner has already died.

--- a/crates/runner/src/cmd/kill.rs
+++ b/crates/runner/src/cmd/kill.rs
@@ -439,14 +439,18 @@ fn workspace_identity_matches(
 
 /// Send `SIGKILL` to a validated process group.
 fn signal_process_group(pid: u32, pgid: u32) -> bool {
-    if pgid == 0 {
-        tracing::warn!(pid, "refusing to signal process group 0");
+    if pgid <= 1 {
+        tracing::warn!(pid, pgid, "refusing to signal system process group");
         return false;
     }
 
     let Ok(pgid_i32) = i32::try_from(pgid) else {
         return false;
     };
+    if nix::unistd::getpgrp().as_raw() == pgid_i32 {
+        tracing::warn!(pid, pgid = pgid_i32, "refusing to signal own process group");
+        return false;
+    }
 
     match nix::sys::signal::killpg(
         nix::unistd::Pid::from_raw(pgid_i32),
@@ -908,6 +912,18 @@ mod tests {
     #[test]
     fn signal_process_group_rejects_zero_pgid() {
         assert!(!signal_process_group(1234, 0));
+    }
+
+    #[test]
+    fn signal_process_group_rejects_init_pgid() {
+        assert!(!signal_process_group(1234, 1));
+    }
+
+    #[test]
+    fn signal_process_group_rejects_own_pgid() {
+        let current_pgid = u32::try_from(nix::unistd::getpgrp().as_raw()).unwrap();
+
+        assert!(!signal_process_group(1234, current_pgid));
     }
 
     #[tokio::test]

--- a/crates/runner/src/cmd/kill.rs
+++ b/crates/runner/src/cmd/kill.rs
@@ -69,25 +69,46 @@ pub async fn run_kill(args: KillArgs, control: &dyn SandboxControl) -> RunnerRes
     let current = match rediscover_same_target(&args, &initial.target).await {
         Ok(current) => current,
         Err(error) => {
-            let discovered_after_error = process::discover_all().await;
-            if error.allows_disappeared_orphan_cleanup()
-                && should_cleanup_disappeared_initial_orphan(
+            if error.allows_disappeared_orphan_cleanup() {
+                if let Ok(refreshed) = rediscover_same_sandbox_process(&initial.target).await
+                    && process::is_orphan(refreshed.target.pid, &refreshed.runner_pids).await
+                {
+                    let outcome = kill_orphan_process_group(&refreshed.target).await;
+                    report_kill_outcome(&initial.target, &refreshed.target, &outcome, control)
+                        .await;
+                    info!(
+                        sandbox_id = %refreshed.target.sandbox_id,
+                        pid = refreshed.target.pid,
+                        orphan = true,
+                        rediscover_error = %error,
+                        outcome = ?outcome,
+                        "kill command fell back to orphan kill after target rediscovery failed"
+                    );
+                    return if outcome.is_success() {
+                        Ok(ExitCode::SUCCESS)
+                    } else {
+                        Ok(ExitCode::FAILURE)
+                    };
+                }
+
+                let discovered_after_error = process::discover_all().await;
+                if should_cleanup_disappeared_initial_orphan(
                     &initial.target,
                     is_initial_orphan,
                     &discovered_after_error,
-                )
-            {
-                let outcome = KillOutcome::OrphanAlreadyExited(initial.target.clone());
-                report_kill_outcome(&initial.target, &initial.target, &outcome, control).await;
-                info!(
-                    sandbox_id = %initial.target.sandbox_id,
-                    pid = initial.target.pid,
-                    orphan = true,
-                    rediscover_error = %error,
-                    outcome = ?outcome,
-                    "kill command cleaned up orphan target that disappeared during rediscovery"
-                );
-                return Ok(ExitCode::SUCCESS);
+                ) {
+                    let outcome = KillOutcome::OrphanAlreadyExited(initial.target.clone());
+                    report_kill_outcome(&initial.target, &initial.target, &outcome, control).await;
+                    info!(
+                        sandbox_id = %initial.target.sandbox_id,
+                        pid = initial.target.pid,
+                        orphan = true,
+                        rediscover_error = %error,
+                        outcome = ?outcome,
+                        "kill command cleaned up orphan target that disappeared during rediscovery"
+                    );
+                    return Ok(ExitCode::SUCCESS);
+                }
             }
             println!(
                 "Refused to kill sandbox {} (PID {}) - {error}",
@@ -97,14 +118,7 @@ pub async fn run_kill(args: KillArgs, control: &dyn SandboxControl) -> RunnerRes
         }
     };
     let is_orphan = process::is_orphan(current.target.pid, &current.runner_pids).await;
-    let outcome = kill_current_target(
-        &args,
-        &initial.target,
-        current.target.clone(),
-        is_orphan,
-        control,
-    )
-    .await;
+    let outcome = kill_current_target(current.target.clone(), is_orphan, control).await;
     report_kill_outcome(&initial.target, &current.target, &outcome, control).await;
 
     info!(
@@ -122,6 +136,7 @@ pub async fn run_kill(args: KillArgs, control: &dyn SandboxControl) -> RunnerRes
     }
 }
 
+#[derive(Debug)]
 enum RediscoverTargetError {
     Resolve(String),
     Changed(String),
@@ -234,6 +249,57 @@ async fn rediscover_same_target(
     ensure_same_target_after_confirmation(args, initial, &current.target)
         .map_err(RediscoverTargetError::Changed)?;
     Ok(current)
+}
+
+async fn rediscover_same_sandbox_process(
+    expected: &KillTarget,
+) -> Result<ResolvedKillTarget, RediscoverTargetError> {
+    let discovered = process::discover_all().await;
+    let runner_pids: Vec<u32> = discovered.runners.iter().map(|r| r.pid).collect();
+    let target = resolve_same_sandbox_process(expected, &discovered)?;
+
+    Ok(ResolvedKillTarget {
+        target,
+        runner_pids,
+    })
+}
+
+fn resolve_same_sandbox_process(
+    expected: &KillTarget,
+    discovered: &DiscoveredProcesses,
+) -> Result<KillTarget, RediscoverTargetError> {
+    let matches: Vec<&FirecrackerProcessInfo> = discovered
+        .firecrackers
+        .iter()
+        .filter(|process| process.sandbox_id == expected.sandbox_id)
+        .collect();
+    let process = match matches.as_slice() {
+        [single] => *single,
+        [] => {
+            return Err(RediscoverTargetError::Resolve(format!(
+                "sandbox '{}' no longer has a firecracker process",
+                expected.sandbox_id
+            )));
+        }
+        _ => {
+            let pids: Vec<String> = matches
+                .iter()
+                .map(|process| process.pid.to_string())
+                .collect();
+            return Err(RediscoverTargetError::Resolve(format!(
+                "sandbox '{}' has multiple firecracker processes: PID {}",
+                expected.sandbox_id,
+                pids.join(", ")
+            )));
+        }
+    };
+    let target = KillTarget::from(process);
+    if !same_firecracker_identity(expected, &target) {
+        return Err(RediscoverTargetError::Changed(
+            "sandbox process already exited or changed identity".into(),
+        ));
+    }
+    Ok(target)
 }
 
 fn ensure_same_target_after_confirmation(
@@ -368,8 +434,6 @@ fn resolve_by_sandbox_id<'a>(
 // ---------------------------------------------------------------------------
 
 async fn kill_current_target(
-    args: &KillArgs,
-    initial: &KillTarget,
     current: KillTarget,
     is_orphan: bool,
     control: &dyn SandboxControl,
@@ -381,16 +445,15 @@ async fn kill_current_target(
     match control.kill_remote(&current.sandbox_id).await {
         Ok(RemoteKillResult::RefusedIdle) => KillOutcome::RefusedManagedIdle,
         Ok(result) => KillOutcome::OwnerAccepted(result),
-        Err(error) => retry_as_orphan_if_owner_disappeared(args, initial, error).await,
+        Err(error) => retry_as_orphan_if_owner_disappeared(&current, error).await,
     }
 }
 
 async fn retry_as_orphan_if_owner_disappeared(
-    args: &KillArgs,
-    initial: &KillTarget,
+    expected: &KillTarget,
     owner_error: SandboxControlError,
 ) -> KillOutcome {
-    let refreshed = match rediscover_same_target(args, initial).await {
+    let refreshed = match rediscover_same_sandbox_process(expected).await {
         Ok(refreshed) => refreshed,
         Err(error) => return KillOutcome::RefusedTargetChanged(error.to_string()),
     };
@@ -838,6 +901,16 @@ mod tests {
         }
     }
 
+    fn make_fc_from_target(target: &KillTarget) -> FirecrackerProcessInfo {
+        FirecrackerProcessInfo {
+            pid: target.pid,
+            ppid: target.ppid,
+            sandbox_id: target.sandbox_id.clone(),
+            base_dir: target.base_dir.clone(),
+            identity: target.identity.clone(),
+        }
+    }
+
     fn process_stat(identity: &FirecrackerProcessIdentity) -> ProcessStat {
         ProcessStat {
             state: 'S',
@@ -963,6 +1036,28 @@ mod tests {
         assert!(error.contains("run target changed"), "{error}");
         assert!(error.contains("sbox-old"), "{error}");
         assert!(error.contains("sbox-new"), "{error}");
+    }
+
+    #[test]
+    fn same_sandbox_fallback_accepts_exact_identity_without_run_status() {
+        let expected = make_target(200, "sbox-123");
+        let discovered = discovered_with_firecrackers(vec![make_fc_from_target(&expected)]);
+
+        let target = resolve_same_sandbox_process(&expected, &discovered).unwrap();
+
+        assert_eq!(target, expected);
+    }
+
+    #[test]
+    fn same_sandbox_fallback_rejects_changed_process_identity() {
+        let expected = make_target(200, "sbox-123");
+        let mut changed = make_target(200, "sbox-123");
+        changed.identity.as_mut().unwrap().starttime += 1;
+        let discovered = discovered_with_firecrackers(vec![make_fc_from_target(&changed)]);
+
+        let error = resolve_same_sandbox_process(&expected, &discovered).unwrap_err();
+
+        assert!(error.to_string().contains("changed identity"));
     }
 
     fn discovered_with_firecrackers(
@@ -1175,15 +1270,9 @@ mod tests {
     #[tokio::test]
     async fn managed_target_requests_owner_control() {
         let control = MockSandboxControl::new("/tmp/test");
-        let initial = make_target(200, "sbox-123");
-        let current = initial.clone();
-        let args = KillArgs {
-            run: None,
-            sandbox: Some("sbox-123".into()),
-            force: true,
-        };
+        let current = make_target(200, "sbox-123");
 
-        let outcome = kill_current_target(&args, &initial, current, false, &control).await;
+        let outcome = kill_current_target(current, false, &control).await;
 
         assert!(matches!(
             outcome,
@@ -1196,15 +1285,9 @@ mod tests {
     async fn managed_idle_target_is_refused() {
         let control = MockSandboxControl::new("/tmp/test");
         control.push_kill_remote_result(Ok(RemoteKillResult::RefusedIdle));
-        let initial = make_target(200, "sbox-123");
-        let current = initial.clone();
-        let args = KillArgs {
-            run: None,
-            sandbox: Some("sbox-123".into()),
-            force: true,
-        };
+        let current = make_target(200, "sbox-123");
 
-        let outcome = kill_current_target(&args, &initial, current, false, &control).await;
+        let outcome = kill_current_target(current, false, &control).await;
 
         assert!(matches!(outcome, KillOutcome::RefusedManagedIdle));
         assert_eq!(control.recorded_kill_ids(), vec!["sbox-123"]);
@@ -1213,15 +1296,9 @@ mod tests {
     #[tokio::test]
     async fn orphan_target_uses_current_reresolved_identity() {
         let control = MockSandboxControl::new("/tmp/test");
-        let args = KillArgs {
-            run: Some("run".into()),
-            sandbox: None,
-            force: true,
-        };
-        let initial = make_target(u32::MAX - 3_000, "sbox-123");
         let current = make_target(u32::MAX - 2_000, "sbox-123");
 
-        let outcome = kill_current_target(&args, &initial, current.clone(), true, &control).await;
+        let outcome = kill_current_target(current.clone(), true, &control).await;
 
         match outcome {
             KillOutcome::OrphanAlreadyExited(target) => assert_eq!(target, current),

--- a/crates/runner/src/cmd/kill.rs
+++ b/crates/runner/src/cmd/kill.rs
@@ -135,9 +135,9 @@ struct ResolvedKillTarget {
 #[derive(Debug)]
 enum KillOutcome {
     OwnerAccepted(RemoteKillResult),
-    OrphanKilled,
-    AlreadyExitedOrChanged,
-    SignalFailed,
+    OrphanKilled(KillTarget),
+    AlreadyExitedOrChanged(KillTarget),
+    SignalFailed(KillTarget),
     RefusedManagedIdle,
     RefusedManagedControlFailed(String),
     RefusedTargetChanged(String),
@@ -149,7 +149,7 @@ impl KillOutcome {
             self,
             KillOutcome::OwnerAccepted(RemoteKillResult::Accepted)
                 | KillOutcome::OwnerAccepted(RemoteKillResult::AlreadyStopped)
-                | KillOutcome::OrphanKilled
+                | KillOutcome::OrphanKilled(_)
         )
     }
 }
@@ -304,7 +304,7 @@ async fn kill_current_target(
     control: &dyn SandboxControl,
 ) -> KillOutcome {
     if is_orphan {
-        return kill_orphan_process_group(initial).await;
+        return kill_orphan_process_group(&current).await;
     }
 
     match control.kill_remote(&current.sandbox_id).await {
@@ -327,18 +327,18 @@ async fn retry_as_orphan_if_owner_disappeared(
         return KillOutcome::RefusedManagedControlFailed(owner_error.to_string());
     }
 
-    kill_orphan_process_group(initial).await
+    kill_orphan_process_group(&refreshed.target).await
 }
 
 async fn kill_orphan_process_group(target: &KillTarget) -> KillOutcome {
     let Some(pgid) = validated_orphan_pgid(target).await else {
-        return KillOutcome::AlreadyExitedOrChanged;
+        return KillOutcome::AlreadyExitedOrChanged(target.clone());
     };
 
     if signal_process_group(target.pid, pgid) {
-        KillOutcome::OrphanKilled
+        KillOutcome::OrphanKilled(target.clone())
     } else {
-        KillOutcome::SignalFailed
+        KillOutcome::SignalFailed(target.clone())
     }
 }
 
@@ -486,13 +486,13 @@ async fn report_kill_outcome(
             );
             println!("Owning runner will handle cleanup.");
         }
-        KillOutcome::OrphanKilled => {
+        KillOutcome::OrphanKilled(target) => {
             println!(
                 "Killed orphan sandbox {} (PID {})",
-                initial.sandbox_id, initial.pid
+                target.sandbox_id, target.pid
             );
-            if let Some(base_dir) = initial.base_dir.as_deref() {
-                let results = cleanup_orphan(&initial.sandbox_id, base_dir, control).await;
+            if let Some(base_dir) = target.base_dir.as_deref() {
+                let results = cleanup_orphan(&target.sandbox_id, base_dir, control).await;
                 print_cleanup_results(&results);
             } else {
                 println!(
@@ -500,16 +500,16 @@ async fn report_kill_outcome(
                 );
             }
         }
-        KillOutcome::AlreadyExitedOrChanged => {
+        KillOutcome::AlreadyExitedOrChanged(target) => {
             println!(
                 "Refused to kill sandbox {} (PID {}) - process already exited or changed identity",
-                initial.sandbox_id, initial.pid
+                target.sandbox_id, target.pid
             );
         }
-        KillOutcome::SignalFailed => {
+        KillOutcome::SignalFailed(target) => {
             println!(
                 "Failed to kill sandbox {} (PID {})",
-                initial.sandbox_id, initial.pid
+                target.sandbox_id, target.pid
             );
         }
         KillOutcome::RefusedManagedControlFailed(error) => {
@@ -921,6 +921,25 @@ mod tests {
         assert_eq!(control.recorded_kill_ids(), vec!["sbox-123"]);
     }
 
+    #[tokio::test]
+    async fn orphan_target_uses_current_reresolved_identity() {
+        let control = MockSandboxControl::new("/tmp/test");
+        let args = KillArgs {
+            run: Some("run".into()),
+            sandbox: None,
+            force: true,
+        };
+        let initial = make_target(u32::MAX - 3_000, "sbox-123");
+        let current = make_target(u32::MAX - 2_000, "sbox-123");
+
+        let outcome = kill_current_target(&args, &initial, current.clone(), true, &control).await;
+
+        match outcome {
+            KillOutcome::AlreadyExitedOrChanged(target) => assert_eq!(target, current),
+            other => panic!("expected current target to fail closed, got {other:?}"),
+        }
+    }
+
     #[test]
     fn signal_process_group_rejects_zero_pgid() {
         assert!(!signal_process_group(1234, 0));
@@ -957,7 +976,7 @@ mod tests {
 
         assert!(matches!(
             kill_orphan_process_group(&target).await,
-            KillOutcome::AlreadyExitedOrChanged
+            KillOutcome::AlreadyExitedOrChanged(_)
         ));
     }
 

--- a/crates/runner/src/cmd/kill.rs
+++ b/crates/runner/src/cmd/kill.rs
@@ -519,7 +519,7 @@ async fn report_kill_outcome(
         KillOutcome::OwnerAccepted(RemoteKillResult::RefusedIdle)
         | KillOutcome::RefusedManagedIdle => {
             println!(
-                "Refused to kill managed idle or parking sandbox {} (PID {}) - owning runner still owns its resources",
+                "Refused to kill managed idle sandbox {} (PID {}) - owning runner still owns its resources",
                 current.sandbox_id, current.pid
             );
             println!(

--- a/crates/runner/src/cmd/kill.rs
+++ b/crates/runner/src/cmd/kill.rs
@@ -549,9 +549,10 @@ async fn validate_orphan_target(target: &KillTarget) -> OrphanTargetValidation {
         );
         return OrphanTargetValidation::Changed;
     }
-    if process_stat_is_zombie(&stat) {
+    if !process::process_stat_is_live(&stat) {
         tracing::warn!(
             pid = target.pid,
+            state = %stat.state,
             "orphan target already exited and is waiting to be reaped"
         );
         return OrphanTargetValidation::AlreadyGone;
@@ -602,9 +603,10 @@ async fn validate_orphan_target(target: &KillTarget) -> OrphanTargetValidation {
         );
         return OrphanTargetValidation::Changed;
     }
-    if process_stat_is_zombie(&final_stat) {
+    if !process::process_stat_is_live(&final_stat) {
         tracing::warn!(
             pid = target.pid,
+            state = %final_stat.state,
             "orphan target exited during validation and is waiting to be reaped"
         );
         return OrphanTargetValidation::AlreadyGone;
@@ -621,7 +623,8 @@ async fn classify_orphan_validation_after_unreadable_pid_fact(
 ) -> OrphanTargetValidation {
     match process::read_process_stat(pid).await {
         Some(stat)
-            if process_stat_matches_identity(identity, &stat) && process_stat_is_zombie(&stat) =>
+            if process_stat_matches_identity(identity, &stat)
+                && !process::process_stat_is_live(&stat) =>
         {
             OrphanTargetValidation::AlreadyGone
         }
@@ -642,7 +645,7 @@ fn same_initial_process_still_live(target: &KillTarget, stat: Option<&ProcessSta
     let (Some(identity), Some(stat)) = (&target.identity, stat) else {
         return false;
     };
-    process_stat_matches_identity(identity, stat) && !process_stat_is_zombie(stat)
+    process_stat_matches_identity(identity, stat) && process::process_stat_is_live(stat)
 }
 
 fn process_stat_matches_identity(
@@ -650,10 +653,6 @@ fn process_stat_matches_identity(
     stat: &ProcessStat,
 ) -> bool {
     stat.pgid == identity.pgid && stat.starttime == identity.starttime
-}
-
-fn process_stat_is_zombie(stat: &ProcessStat) -> bool {
-    stat.state == 'Z'
 }
 
 fn orphan_identity_matches_facts(
@@ -1324,7 +1323,21 @@ mod tests {
         };
 
         assert!(process_stat_matches_identity(identity, &zombie));
-        assert!(process_stat_is_zombie(&zombie));
+        assert!(!process::process_stat_is_live(&zombie));
+    }
+
+    #[test]
+    fn dead_process_stat_is_already_exited() {
+        let target = make_target(200, "sbox-123");
+        let identity = target.identity.as_ref().unwrap();
+        let dead = ProcessStat {
+            state: 'X',
+            pgid: identity.pgid,
+            starttime: identity.starttime,
+        };
+
+        assert!(process_stat_matches_identity(identity, &dead));
+        assert!(!process::process_stat_is_live(&dead));
     }
 
     #[test]
@@ -1341,6 +1354,19 @@ mod tests {
         let identity = target.identity.as_ref().unwrap();
         let stat = ProcessStat {
             state: 'Z',
+            pgid: identity.pgid,
+            starttime: identity.starttime,
+        };
+
+        assert!(!same_initial_process_still_live(&target, Some(&stat)));
+    }
+
+    #[test]
+    fn same_initial_process_still_live_rejects_dead_state() {
+        let target = make_target(200, "sbox-123");
+        let identity = target.identity.as_ref().unwrap();
+        let stat = ProcessStat {
+            state: 'x',
             pgid: identity.pgid,
             starttime: identity.starttime,
         };

--- a/crates/runner/src/cmd/kill.rs
+++ b/crates/runner/src/cmd/kill.rs
@@ -485,9 +485,8 @@ async fn report_kill_outcome(
                 "Killed orphan sandbox {} (PID {})",
                 initial.sandbox_id, initial.pid
             );
-            if initial.base_dir.is_some() {
-                let results =
-                    cleanup_orphan(&initial.sandbox_id, initial.base_dir.as_deref(), control).await;
+            if let Some(base_dir) = initial.base_dir.as_deref() {
+                let results = cleanup_orphan(&initial.sandbox_id, base_dir, control).await;
                 print_cleanup_results(&results);
             } else {
                 println!(
@@ -540,18 +539,16 @@ fn print_cleanup_results(results: &[(String, bool)]) {
 
 async fn cleanup_orphan(
     sandbox_id: &str,
-    base_dir: Option<&Path>,
+    base_dir: &Path,
     control: &dyn SandboxControl,
 ) -> Vec<(String, bool)> {
     let mut results = Vec::new();
 
     // Workspace dir
-    if let Some(bd) = base_dir {
-        let workspace = bd.join("workspaces").join(sandbox_id);
-        let label = format!("Workspace: {}", workspace.display());
-        let success = remove_dir_if_exists(&workspace).await;
-        results.push((label, success));
-    }
+    let workspace = base_dir.join("workspaces").join(sandbox_id);
+    let label = format!("Workspace: {}", workspace.display());
+    let success = remove_dir_if_exists(&workspace).await;
+    results.push((label, success));
 
     // Socket dir
     let sock_dir = control.runtime_dir(sandbox_id);
@@ -926,7 +923,7 @@ mod tests {
         let sock_dir = control.runtime_dir("sbox-123");
         tokio::fs::create_dir_all(&sock_dir).await.unwrap();
 
-        let results = cleanup_orphan("sbox-123", Some(base), &control).await;
+        let results = cleanup_orphan("sbox-123", base, &control).await;
 
         assert_eq!(results.len(), 2);
         assert!(results[0].1, "workspace cleanup should succeed");
@@ -940,7 +937,7 @@ mod tests {
         let control = MockSandboxControl::new("/tmp/nonexistent-base");
         let results = cleanup_orphan(
             "sbox-456",
-            Some(std::path::Path::new("/tmp/no-such-dir")),
+            std::path::Path::new("/tmp/no-such-dir"),
             &control,
         )
         .await;
@@ -949,15 +946,5 @@ mod tests {
         assert_eq!(results.len(), 2);
         assert!(results[0].1);
         assert!(results[1].1);
-    }
-
-    #[tokio::test]
-    async fn cleanup_orphan_no_base_dir() {
-        let control = MockSandboxControl::new("/tmp/test");
-        let results = cleanup_orphan("sbox-789", None, &control).await;
-
-        // Only socket dir cleanup, no workspace
-        assert_eq!(results.len(), 1);
-        assert!(results[0].0.contains("Socket dir"));
     }
 }

--- a/crates/runner/src/cmd/kill.rs
+++ b/crates/runner/src/cmd/kill.rs
@@ -73,7 +73,13 @@ pub async fn run_kill(args: KillArgs, control: &dyn SandboxControl) -> RunnerRes
                 if let Ok(refreshed) = rediscover_same_sandbox_process(&initial.target).await
                     && process::is_orphan(refreshed.target.pid, &refreshed.runner_pids).await
                 {
-                    let outcome = kill_orphan_process_group(&refreshed.target).await;
+                    let outcome = if should_refuse_run_orphan_fallback(&args, is_initial_orphan) {
+                        KillOutcome::RefusedTargetChanged(
+                            "run target is no longer active; refusing orphan fallback for an initially managed sandbox".into(),
+                        )
+                    } else {
+                        kill_current_target(refreshed.target.clone(), true, control).await
+                    };
                     report_kill_outcome(&initial.target, &refreshed.target, &outcome, control)
                         .await;
                     info!(
@@ -82,7 +88,7 @@ pub async fn run_kill(args: KillArgs, control: &dyn SandboxControl) -> RunnerRes
                         orphan = true,
                         rediscover_error = %error,
                         outcome = ?outcome,
-                        "kill command fell back to orphan kill after target rediscovery failed"
+                        "kill command fell back to owner-aware orphan handling after target rediscovery failed"
                     );
                     return if outcome.is_success() {
                         Ok(ExitCode::SUCCESS)
@@ -349,6 +355,10 @@ fn should_cleanup_disappeared_initial_orphan(
     was_orphan
         && target_has_workspace_identity(initial)
         && !discovered_has_same_or_unidentified_firecracker(initial, discovered_after_error)
+}
+
+fn should_refuse_run_orphan_fallback(args: &KillArgs, is_initial_orphan: bool) -> bool {
+    args.run.is_some() && !is_initial_orphan
 }
 
 fn target_has_workspace_identity(target: &KillTarget) -> bool {
@@ -1153,6 +1163,39 @@ mod tests {
             true,
             &discovered
         ));
+    }
+
+    #[test]
+    fn run_fallback_refuses_initially_managed_target() {
+        let args = KillArgs {
+            run: Some("run".into()),
+            sandbox: None,
+            force: true,
+        };
+
+        assert!(should_refuse_run_orphan_fallback(&args, false));
+    }
+
+    #[test]
+    fn run_fallback_allows_initial_orphan_target() {
+        let args = KillArgs {
+            run: Some("run".into()),
+            sandbox: None,
+            force: true,
+        };
+
+        assert!(!should_refuse_run_orphan_fallback(&args, true));
+    }
+
+    #[test]
+    fn sandbox_fallback_allows_initially_managed_target() {
+        let args = KillArgs {
+            run: None,
+            sandbox: Some("sbox".into()),
+            force: true,
+        };
+
+        assert!(!should_refuse_run_orphan_fallback(&args, false));
     }
 
     #[test]

--- a/crates/runner/src/cmd/kill.rs
+++ b/crates/runner/src/cmd/kill.rs
@@ -439,24 +439,26 @@ async fn kill_current_target(
     is_orphan: bool,
     control: &dyn SandboxControl,
 ) -> KillOutcome {
-    if is_orphan {
-        return kill_orphan_process_group(&current).await;
-    }
-
     match control.kill_remote(&current.sandbox_id).await {
         Ok(RemoteKillResult::RefusedIdle) => KillOutcome::RefusedManagedIdle,
         Ok(result) => KillOutcome::OwnerAccepted(result),
-        Err(error) => retry_as_orphan_if_owner_disappeared(&current, error).await,
+        Err(error) => retry_as_orphan_if_owner_disappeared(&current, error, is_orphan).await,
     }
 }
 
 async fn retry_as_orphan_if_owner_disappeared(
     expected: &KillTarget,
     owner_error: SandboxControlError,
+    was_orphan: bool,
 ) -> KillOutcome {
     let refreshed = match rediscover_same_sandbox_process(expected).await {
         Ok(refreshed) => refreshed,
-        Err(error) => return KillOutcome::RefusedTargetChanged(error.to_string()),
+        Err(error) => {
+            if was_orphan && error.allows_disappeared_orphan_cleanup() {
+                return already_gone_orphan_outcome(expected).await;
+            }
+            return KillOutcome::RefusedTargetChanged(error.to_string());
+        }
     };
     if !process::is_orphan(refreshed.target.pid, &refreshed.runner_pids).await {
         return KillOutcome::RefusedManagedControlFailed(owner_error.to_string());
@@ -1343,8 +1345,23 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn apparent_orphan_prefers_owner_control_when_available() {
+        let control = MockSandboxControl::new("/tmp/test");
+        let current = make_target(200, "sbox-123");
+
+        let outcome = kill_current_target(current, true, &control).await;
+
+        assert!(matches!(
+            outcome,
+            KillOutcome::OwnerAccepted(RemoteKillResult::Accepted)
+        ));
+        assert_eq!(control.recorded_kill_ids(), vec!["sbox-123"]);
+    }
+
+    #[tokio::test]
     async fn orphan_target_uses_current_reresolved_identity() {
         let control = MockSandboxControl::new("/tmp/test");
+        control.push_kill_remote_result(Err(SandboxControlError::NotFound("missing".into())));
         let current = make_target(u32::MAX - 2_000, "sbox-123");
 
         let outcome = kill_current_target(current.clone(), true, &control).await;

--- a/crates/runner/src/cmd/kill.rs
+++ b/crates/runner/src/cmd/kill.rs
@@ -171,6 +171,7 @@ impl std::fmt::Display for RediscoverTargetError {
 struct KillTarget {
     pid: u32,
     ppid: Option<u32>,
+    run_id: Option<String>,
     sandbox_id: String,
     base_dir: Option<PathBuf>,
     identity: Option<FirecrackerProcessIdentity>,
@@ -181,11 +182,17 @@ impl From<&FirecrackerProcessInfo> for KillTarget {
         Self {
             pid: process.pid,
             ppid: process.ppid,
+            run_id: None,
             sandbox_id: process.sandbox_id.clone(),
             base_dir: process.base_dir.clone(),
             identity: process.identity.clone(),
         }
     }
+}
+
+struct ResolvedProcessTarget<'a> {
+    process: &'a FirecrackerProcessInfo,
+    run_id: Option<String>,
 }
 
 struct ResolvedKillTarget {
@@ -220,10 +227,12 @@ impl KillOutcome {
 async fn discover_and_resolve_target(args: &KillArgs) -> RunnerResult<ResolvedKillTarget> {
     let discovered = process::discover_all().await;
     let runner_pids: Vec<u32> = discovered.runners.iter().map(|r| r.pid).collect();
-    let target = resolve_target(args, &discovered).await?;
+    let resolved = resolve_target(args, &discovered).await?;
+    let mut target = KillTarget::from(resolved.process);
+    target.run_id = resolved.run_id;
 
     Ok(ResolvedKillTarget {
-        target: target.into(),
+        target,
         runner_pids,
     })
 }
@@ -231,14 +240,21 @@ async fn discover_and_resolve_target(args: &KillArgs) -> RunnerResult<ResolvedKi
 async fn resolve_target<'a>(
     args: &KillArgs,
     discovered: &'a DiscoveredProcesses,
-) -> RunnerResult<&'a FirecrackerProcessInfo> {
+) -> RunnerResult<ResolvedProcessTarget<'a>> {
     if let Some(ref run_id) = args.run {
         let mappings = run_resolution::collect_active_run_mappings(&discovered.runners).await;
-        return resolve_by_run_id(run_id, &mappings, &discovered.firecrackers);
+        let resolved = resolve_by_run_id(run_id, &mappings, &discovered.firecrackers)?;
+        return Ok(ResolvedProcessTarget {
+            process: resolved.process,
+            run_id: Some(resolved.run_id),
+        });
     }
 
     if let Some(ref sandbox_id) = args.sandbox {
-        return resolve_by_sandbox_id(sandbox_id, &discovered.firecrackers);
+        return Ok(ResolvedProcessTarget {
+            process: resolve_by_sandbox_id(sandbox_id, &discovered.firecrackers)?,
+            run_id: None,
+        });
     }
 
     Err(RunnerError::Config(
@@ -301,6 +317,10 @@ fn resolve_same_sandbox_process(
         }
     };
     let target = KillTarget::from(process);
+    let target = KillTarget {
+        run_id: expected.run_id.clone(),
+        ..target
+    };
     if !same_firecracker_identity(expected, &target) {
         return Err(RediscoverTargetError::Changed(
             "sandbox process already exited or changed identity".into(),
@@ -315,6 +335,18 @@ fn ensure_same_target_after_confirmation(
     current: &KillTarget,
 ) -> Result<(), String> {
     if args.run.is_some() {
+        match (&initial.run_id, &current.run_id) {
+            (Some(initial_run), Some(current_run)) if initial_run == current_run => {}
+            (Some(initial_run), Some(current_run)) => {
+                return Err(format!(
+                    "run target changed from run '{}' to '{}'",
+                    initial_run, current_run
+                ));
+            }
+            _ => {
+                return Err("run target could not be verified by active run identity".into());
+            }
+        }
         if current.sandbox_id != initial.sandbox_id {
             return Err(format!(
                 "run target changed from sandbox '{}' to '{}'",
@@ -386,26 +418,36 @@ fn discovered_has_same_or_unidentified_firecracker(
 /// by sandbox_id. The caller is responsible for collecting `mappings` via
 /// [`run_resolution::collect_active_run_mappings`] so this function stays pure and
 /// testable.
+struct ResolvedRunProcess<'a> {
+    run_id: String,
+    process: &'a FirecrackerProcessInfo,
+}
+
 fn resolve_by_run_id<'a>(
     input: &str,
     mappings: &run_resolution::ActiveRunMappings,
     firecrackers: &'a [FirecrackerProcessInfo],
-) -> RunnerResult<&'a FirecrackerProcessInfo> {
-    let sandbox_id = run_resolution::resolve_run_to_sandbox(input, mappings)?;
+) -> RunnerResult<ResolvedRunProcess<'a>> {
+    let mapping = run_resolution::resolve_run_mapping(input, mappings)?;
     let fc_matches: Vec<&FirecrackerProcessInfo> = firecrackers
         .iter()
-        .filter(|fc| fc.sandbox_id == sandbox_id)
+        .filter(|fc| fc.sandbox_id == mapping.sandbox_id)
         .collect();
     match fc_matches.as_slice() {
         [] => Err(RunnerError::Config(format!(
-            "run '{input}' maps to sandbox '{sandbox_id}' but no firecracker process for it"
+            "run '{input}' maps to sandbox '{}' but no firecracker process for it",
+            mapping.sandbox_id
         ))),
-        [single] => Ok(single),
+        [single] => Ok(ResolvedRunProcess {
+            run_id: mapping.run_id,
+            process: single,
+        }),
         _ => {
             let pids: Vec<String> = fc_matches.iter().map(|fc| fc.pid.to_string()).collect();
+            let pid_list = pids.join(", ");
             Err(RunnerError::Config(format!(
-                "run '{input}' maps to sandbox '{sandbox_id}' but multiple firecracker processes match it: PID {}",
-                pids.join(", ")
+                "run '{input}' maps to sandbox '{sandbox_id}' but multiple firecracker processes match it: PID {pid_list}",
+                sandbox_id = mapping.sandbox_id,
             )))
         }
     }
@@ -915,6 +957,7 @@ mod tests {
         KillTarget {
             pid,
             ppid: None,
+            run_id: None,
             sandbox_id: sandbox_id.into(),
             base_dir: Some(PathBuf::from("/data/r1")),
             identity: Some(FirecrackerProcessIdentity {
@@ -924,6 +967,13 @@ mod tests {
                 sandbox_id: sandbox_id.into(),
                 base_dir: Some(PathBuf::from("/data/r1")),
             }),
+        }
+    }
+
+    fn make_run_target(pid: u32, run_id: &str, sandbox_id: &str) -> KillTarget {
+        KillTarget {
+            run_id: Some(run_id.into()),
+            ..make_target(pid, sandbox_id)
         }
     }
 
@@ -1054,14 +1104,46 @@ mod tests {
             sandbox: None,
             force: true,
         };
-        let initial = make_target(200, "sbox-old");
-        let current = make_target(201, "sbox-new");
+        let initial = make_run_target(200, "run-123", "sbox-old");
+        let current = make_run_target(201, "run-123", "sbox-new");
 
         let error = ensure_same_target_after_confirmation(&args, &initial, &current).unwrap_err();
 
         assert!(error.contains("run target changed"), "{error}");
         assert!(error.contains("sbox-old"), "{error}");
         assert!(error.contains("sbox-new"), "{error}");
+    }
+
+    #[test]
+    fn run_reresolution_requires_same_run_identity() {
+        let args = KillArgs {
+            run: Some("run".into()),
+            sandbox: None,
+            force: true,
+        };
+        let initial = make_run_target(200, "run-old", "sbox-reused");
+        let current = make_run_target(200, "run-new", "sbox-reused");
+
+        let error = ensure_same_target_after_confirmation(&args, &initial, &current).unwrap_err();
+
+        assert!(error.contains("run target changed from run"), "{error}");
+        assert!(error.contains("run-old"), "{error}");
+        assert!(error.contains("run-new"), "{error}");
+    }
+
+    #[test]
+    fn run_reresolution_rejects_missing_run_identity() {
+        let args = KillArgs {
+            run: Some("run".into()),
+            sandbox: None,
+            force: true,
+        };
+        let initial = make_run_target(200, "run-old", "sbox-reused");
+        let current = make_target(200, "sbox-reused");
+
+        let error = ensure_same_target_after_confirmation(&args, &initial, &current).unwrap_err();
+
+        assert!(error.contains("active run identity"), "{error}");
     }
 
     #[test]
@@ -1491,6 +1573,7 @@ mod tests {
         let target = KillTarget {
             pid: u32::MAX,
             ppid: None,
+            run_id: None,
             sandbox_id: "sbox-missing".into(),
             base_dir: Some(PathBuf::from("/data/r1")),
             identity: Some(FirecrackerProcessIdentity {

--- a/crates/runner/src/cmd/start/orphan_reap.rs
+++ b/crates/runner/src/cmd/start/orphan_reap.rs
@@ -693,6 +693,7 @@ mod tests {
             ppid: Some(1),
             sandbox_id: live_sandbox_id.to_string(),
             base_dir: None,
+            identity: None,
         };
 
         fixture
@@ -736,6 +737,7 @@ mod tests {
             ppid: Some(1),
             sandbox_id: "pid-1234".to_string(),
             base_dir: None,
+            identity: None,
         };
         let discovery = OrphanReapProcessDiscovery {
             firecrackers: Arc::new(vec![unresolved_firecracker]),
@@ -840,6 +842,7 @@ mod tests {
             ppid: Some(1),
             sandbox_id: "pid-1234".to_string(),
             base_dir: None,
+            identity: None,
         };
         fixture
             .reap_current_orphans_with_firecrackers(
@@ -890,6 +893,7 @@ mod tests {
             ppid: Some(1),
             sandbox_id: sandbox_id.to_string(),
             base_dir: None,
+            identity: None,
         };
         fixture
             .reap_current_orphans_with_firecrackers(
@@ -948,6 +952,7 @@ mod tests {
             ppid: Some(1),
             sandbox_id: sandbox_id.to_string(),
             base_dir: None,
+            identity: None,
         };
         fixture
             .reap_current_orphans_with_firecrackers(
@@ -994,6 +999,7 @@ mod tests {
             ppid: Some(1),
             sandbox_id: sandbox_id.to_string(),
             base_dir: None,
+            identity: None,
         };
 
         fixture

--- a/crates/runner/src/process.rs
+++ b/crates/runner/src/process.rs
@@ -10,8 +10,10 @@ mod types;
 
 pub use self::ancestry::{is_orphan, process_has_ancestor};
 pub use self::discovery::{discover_all, firecracker_process_exists_for_sandbox_id};
-pub use self::procfs::{read_pgid, read_service_unit};
+pub(crate) use self::discovery::{is_firecracker_cmdline, parse_workspace_cwd};
+pub use self::procfs::read_service_unit;
+pub(crate) use self::procfs::{read_cmdline, read_cwd, read_process_stat};
 pub use self::types::{
-    DiscoveredProcesses, DnsmasqProcessInfo, FirecrackerProcessInfo, MitmproxyProcessInfo,
-    RunnerProcessInfo,
+    DiscoveredProcesses, DnsmasqProcessInfo, FirecrackerProcessIdentity, FirecrackerProcessInfo,
+    MitmproxyProcessInfo, ProcessStat, RunnerProcessInfo,
 };

--- a/crates/runner/src/process.rs
+++ b/crates/runner/src/process.rs
@@ -13,6 +13,7 @@ pub use self::discovery::{discover_all, firecracker_process_exists_for_sandbox_i
 pub(crate) use self::discovery::{is_firecracker_cmdline, parse_workspace_cwd};
 pub use self::procfs::read_service_unit;
 pub(crate) use self::procfs::{read_cmdline, read_cwd, read_process_stat};
+pub(crate) use self::types::process_stat_is_live;
 pub use self::types::{
     DiscoveredProcesses, DnsmasqProcessInfo, FirecrackerProcessIdentity, FirecrackerProcessInfo,
     MitmproxyProcessInfo, ProcessStat, RunnerProcessInfo,

--- a/crates/runner/src/process/discovery.rs
+++ b/crates/runner/src/process/discovery.rs
@@ -1,9 +1,9 @@
 use std::path::{Path, PathBuf};
 
-use super::procfs::{read_cwd, read_ppid, scan_proc_cmdlines};
+use super::procfs::{read_cwd, read_ppid, read_process_stat, scan_proc_cmdlines};
 use super::types::{
-    DiscoveredProcesses, DnsmasqProcessInfo, FirecrackerProcessInfo, MitmproxyProcessInfo,
-    RunnerProcessInfo,
+    DiscoveredProcesses, DnsmasqProcessInfo, FirecrackerProcessIdentity, FirecrackerProcessInfo,
+    MitmproxyProcessInfo, RunnerProcessInfo,
 };
 
 /// Parse a runner argv for `start`/`benchmark` subcommand and `--config` path.
@@ -26,7 +26,7 @@ fn parse_runner_cmdline(argv: &[String]) -> Option<(PathBuf, String)> {
 /// Looks at the binary name (`argv[0]`) — the run ID and base directory
 /// are resolved from `/proc/{pid}/cwd` instead of argument parsing,
 /// since our sandbox always sets `current_dir` to the workspace.
-fn is_firecracker_cmdline(argv: &[String]) -> bool {
+pub(crate) fn is_firecracker_cmdline(argv: &[String]) -> bool {
     let Some(binary) = argv.first() else {
         return false;
     };
@@ -65,7 +65,7 @@ fn parse_dnsmasq_cmdline(argv: &[String]) -> Option<u16> {
 /// CWD is `{base_dir}/workspaces/{sandbox_id}/`, so:
 /// - `sandbox_id` is the last component
 /// - `base_dir` is the grandparent of `workspaces`
-fn parse_workspace_cwd(cwd: &Path) -> Option<(String, PathBuf)> {
+pub(crate) fn parse_workspace_cwd(cwd: &Path) -> Option<(String, PathBuf)> {
     let sandbox_id = cwd.file_name()?.to_string_lossy().into_owned();
     let workspaces_dir = cwd.parent()?;
     if workspaces_dir.file_name().and_then(|n| n.to_str()) == Some("workspaces") {
@@ -111,15 +111,24 @@ pub async fn discover_all() -> DiscoveredProcesses {
             .await
             .and_then(|cwd| parse_workspace_cwd(&cwd));
         let ppid = read_ppid(pid).await;
+        let process_stat = read_process_stat(pid).await;
         let (sandbox_id, base_dir) = match cwd_info {
             Some((id, bd)) => (id, Some(bd)),
             None => (format!("pid-{pid}"), None),
         };
+        let identity = process_stat.map(|stat| FirecrackerProcessIdentity {
+            pid,
+            pgid: stat.pgid,
+            starttime: stat.starttime,
+            sandbox_id: sandbox_id.clone(),
+            base_dir: base_dir.clone(),
+        });
         fc_infos.push(FirecrackerProcessInfo {
             pid,
             ppid,
             sandbox_id,
             base_dir,
+            identity,
         });
     }
 
@@ -256,6 +265,7 @@ mod tests {
             ppid: Some(1),
             sandbox_id: "sandbox-a".to_string(),
             base_dir: None,
+            identity: None,
         }];
 
         assert!(firecracker_process_exists_for_sandbox_id(

--- a/crates/runner/src/process/discovery.rs
+++ b/crates/runner/src/process/discovery.rs
@@ -1,9 +1,9 @@
 use std::path::{Path, PathBuf};
 
-use super::procfs::{read_cwd, read_ppid, read_process_stat, scan_proc_cmdlines};
+use super::procfs::{read_cmdline, read_cwd, read_ppid, read_process_stat, scan_proc_cmdlines};
 use super::types::{
     DiscoveredProcesses, DnsmasqProcessInfo, FirecrackerProcessIdentity, FirecrackerProcessInfo,
-    MitmproxyProcessInfo, RunnerProcessInfo,
+    MitmproxyProcessInfo, ProcessStat, RunnerProcessInfo,
 };
 
 /// Parse a runner argv for `start`/`benchmark` subcommand and `--config` path.
@@ -76,6 +76,21 @@ pub(crate) fn parse_workspace_cwd(cwd: &Path) -> Option<(String, PathBuf)> {
     }
 }
 
+async fn read_stable_firecracker_stat(pid: u32) -> Option<ProcessStat> {
+    let before = read_process_stat(pid).await?;
+    let argv = read_cmdline(pid).await?;
+    let after = read_process_stat(pid).await?;
+    if process_stat_identity_matches(&before, &after) && is_firecracker_cmdline(&argv) {
+        Some(after)
+    } else {
+        None
+    }
+}
+
+fn process_stat_identity_matches(left: &ProcessStat, right: &ProcessStat) -> bool {
+    left.pgid == right.pgid && left.starttime == right.starttime
+}
+
 /// Scan `/proc` once and discover all runner, firecracker, and mitmdump processes.
 pub async fn discover_all() -> DiscoveredProcesses {
     let procs = scan_proc_cmdlines().await;
@@ -107,19 +122,27 @@ pub async fn discover_all() -> DiscoveredProcesses {
     // Resolve sandbox_id + base_dir + ppid from CWD for firecracker processes
     let mut fc_infos = Vec::with_capacity(firecrackers.len());
     for pid in firecrackers {
+        let Some(initial_stat) = read_stable_firecracker_stat(pid).await else {
+            continue;
+        };
         let cwd_info = read_cwd(pid)
             .await
             .and_then(|cwd| parse_workspace_cwd(&cwd));
         let ppid = read_ppid(pid).await;
-        let process_stat = read_process_stat(pid).await;
+        let Some(process_stat) = read_stable_firecracker_stat(pid).await else {
+            continue;
+        };
+        if !process_stat_identity_matches(&initial_stat, &process_stat) {
+            continue;
+        }
         let (sandbox_id, base_dir) = match cwd_info {
             Some((id, bd)) => (id, Some(bd)),
             None => (format!("pid-{pid}"), None),
         };
-        let identity = process_stat.map(|stat| FirecrackerProcessIdentity {
+        let identity = Some(FirecrackerProcessIdentity {
             pid,
-            pgid: stat.pgid,
-            starttime: stat.starttime,
+            pgid: process_stat.pgid,
+            starttime: process_stat.starttime,
             sandbox_id: sandbox_id.clone(),
             base_dir: base_dir.clone(),
         });
@@ -363,5 +386,33 @@ mod tests {
     #[test]
     fn parse_workspace_cwd_non_workspace() {
         assert!(parse_workspace_cwd(Path::new("/tmp/something")).is_none());
+    }
+
+    #[test]
+    fn process_stat_identity_ignores_state_changes() {
+        let sleeping = ProcessStat {
+            state: 'S',
+            pgid: 1100,
+            starttime: 123456,
+        };
+        let running = ProcessStat {
+            state: 'R',
+            pgid: 1100,
+            starttime: 123456,
+        };
+        let different_group = ProcessStat {
+            state: 'S',
+            pgid: 2200,
+            starttime: 123456,
+        };
+        let different_start = ProcessStat {
+            state: 'S',
+            pgid: 1100,
+            starttime: 654321,
+        };
+
+        assert!(process_stat_identity_matches(&sleeping, &running));
+        assert!(!process_stat_identity_matches(&sleeping, &different_group));
+        assert!(!process_stat_identity_matches(&sleeping, &different_start));
     }
 }

--- a/crates/runner/src/process/discovery.rs
+++ b/crates/runner/src/process/discovery.rs
@@ -80,22 +80,38 @@ async fn read_stable_firecracker_stat(pid: u32) -> Option<ProcessStat> {
     let before = read_process_stat(pid).await?;
     let argv = read_cmdline(pid).await?;
     let after = read_process_stat(pid).await?;
-    if process_stat_identity_matches(&before, &after) && is_firecracker_cmdline(&argv) {
-        Some(after)
-    } else {
-        None
-    }
+    stable_live_firecracker_stat(&before, &argv, after)
 }
 
 fn process_stat_identity_matches(left: &ProcessStat, right: &ProcessStat) -> bool {
     left.pgid == right.pgid && left.starttime == right.starttime
 }
 
+fn process_stat_is_live(stat: &ProcessStat) -> bool {
+    stat.state != 'Z'
+}
+
+fn stable_live_firecracker_stat(
+    before: &ProcessStat,
+    argv: &[String],
+    after: ProcessStat,
+) -> Option<ProcessStat> {
+    if process_stat_is_live(before)
+        && process_stat_is_live(&after)
+        && process_stat_identity_matches(before, &after)
+        && is_firecracker_cmdline(argv)
+    {
+        Some(after)
+    } else {
+        None
+    }
+}
+
 fn should_keep_unidentified_firecracker_candidate(
     stat: &ProcessStat,
     argv: Option<&[String]>,
 ) -> bool {
-    if stat.state == 'Z' {
+    if !process_stat_is_live(stat) {
         return false;
     }
     match argv {
@@ -453,6 +469,63 @@ mod tests {
         assert!(process_stat_identity_matches(&sleeping, &running));
         assert!(!process_stat_identity_matches(&sleeping, &different_group));
         assert!(!process_stat_identity_matches(&sleeping, &different_start));
+    }
+
+    #[test]
+    fn stable_live_firecracker_stat_accepts_live_stable_firecracker() {
+        let before = ProcessStat {
+            state: 'S',
+            pgid: 1100,
+            starttime: 123456,
+        };
+        let after = ProcessStat {
+            state: 'R',
+            pgid: 1100,
+            starttime: 123456,
+        };
+
+        assert_eq!(
+            stable_live_firecracker_stat(&before, &argv(&["firecracker"]), after.clone()),
+            Some(after)
+        );
+    }
+
+    #[test]
+    fn stable_live_firecracker_stat_rejects_zombie_firecracker() {
+        let before = ProcessStat {
+            state: 'Z',
+            pgid: 1100,
+            starttime: 123456,
+        };
+        let after = ProcessStat {
+            state: 'Z',
+            pgid: 1100,
+            starttime: 123456,
+        };
+
+        assert_eq!(
+            stable_live_firecracker_stat(&before, &argv(&["firecracker"]), after),
+            None
+        );
+    }
+
+    #[test]
+    fn stable_live_firecracker_stat_rejects_exit_during_read() {
+        let before = ProcessStat {
+            state: 'S',
+            pgid: 1100,
+            starttime: 123456,
+        };
+        let after = ProcessStat {
+            state: 'Z',
+            pgid: 1100,
+            starttime: 123456,
+        };
+
+        assert_eq!(
+            stable_live_firecracker_stat(&before, &argv(&["firecracker"]), after),
+            None
+        );
     }
 
     #[test]

--- a/crates/runner/src/process/discovery.rs
+++ b/crates/runner/src/process/discovery.rs
@@ -3,7 +3,7 @@ use std::path::{Path, PathBuf};
 use super::procfs::{read_cmdline, read_cwd, read_ppid, read_process_stat, scan_proc_cmdlines};
 use super::types::{
     DiscoveredProcesses, DnsmasqProcessInfo, FirecrackerProcessIdentity, FirecrackerProcessInfo,
-    MitmproxyProcessInfo, ProcessStat, RunnerProcessInfo,
+    MitmproxyProcessInfo, ProcessStat, RunnerProcessInfo, process_stat_is_live,
 };
 
 /// Parse a runner argv for `start`/`benchmark` subcommand and `--config` path.
@@ -85,10 +85,6 @@ async fn read_stable_firecracker_stat(pid: u32) -> Option<ProcessStat> {
 
 fn process_stat_identity_matches(left: &ProcessStat, right: &ProcessStat) -> bool {
     left.pgid == right.pgid && left.starttime == right.starttime
-}
-
-fn process_stat_is_live(stat: &ProcessStat) -> bool {
-    stat.state != 'Z'
 }
 
 fn stable_live_firecracker_stat(
@@ -510,6 +506,25 @@ mod tests {
     }
 
     #[test]
+    fn stable_live_firecracker_stat_rejects_dead_firecracker() {
+        let before = ProcessStat {
+            state: 'X',
+            pgid: 1100,
+            starttime: 123456,
+        };
+        let after = ProcessStat {
+            state: 'x',
+            pgid: 1100,
+            starttime: 123456,
+        };
+
+        assert_eq!(
+            stable_live_firecracker_stat(&before, &argv(&["firecracker"]), after),
+            None
+        );
+    }
+
+    #[test]
     fn stable_live_firecracker_stat_rejects_exit_during_read() {
         let before = ProcessStat {
             state: 'S',
@@ -561,6 +576,21 @@ mod tests {
     fn unidentified_firecracker_candidate_rejects_zombie_processes() {
         let stat = ProcessStat {
             state: 'Z',
+            pgid: 1100,
+            starttime: 123456,
+        };
+
+        assert!(!should_keep_unidentified_firecracker_candidate(&stat, None));
+        assert!(!should_keep_unidentified_firecracker_candidate(
+            &stat,
+            Some(&argv(&["firecracker"]))
+        ));
+    }
+
+    #[test]
+    fn unidentified_firecracker_candidate_rejects_dead_processes() {
+        let stat = ProcessStat {
+            state: 'X',
             pgid: 1100,
             starttime: 123456,
         };

--- a/crates/runner/src/process/discovery.rs
+++ b/crates/runner/src/process/discovery.rs
@@ -91,6 +91,38 @@ fn process_stat_identity_matches(left: &ProcessStat, right: &ProcessStat) -> boo
     left.pgid == right.pgid && left.starttime == right.starttime
 }
 
+fn should_keep_unidentified_firecracker_candidate(
+    stat: &ProcessStat,
+    argv: Option<&[String]>,
+) -> bool {
+    if stat.state == 'Z' {
+        return false;
+    }
+    match argv {
+        Some(argv) => is_firecracker_cmdline(argv),
+        None => true,
+    }
+}
+
+fn unidentified_firecracker_process(pid: u32, ppid: Option<u32>) -> FirecrackerProcessInfo {
+    FirecrackerProcessInfo {
+        pid,
+        ppid,
+        sandbox_id: format!("pid-{pid}"),
+        base_dir: None,
+        identity: None,
+    }
+}
+
+async fn unidentified_firecracker_if_present(pid: u32) -> Option<FirecrackerProcessInfo> {
+    let stat = read_process_stat(pid).await?;
+    let argv = read_cmdline(pid).await;
+    if !should_keep_unidentified_firecracker_candidate(&stat, argv.as_deref()) {
+        return None;
+    }
+    Some(unidentified_firecracker_process(pid, read_ppid(pid).await))
+}
+
 /// Scan `/proc` once and discover all runner, firecracker, and mitmdump processes.
 pub async fn discover_all() -> DiscoveredProcesses {
     let procs = scan_proc_cmdlines().await;
@@ -123,6 +155,9 @@ pub async fn discover_all() -> DiscoveredProcesses {
     let mut fc_infos = Vec::with_capacity(firecrackers.len());
     for pid in firecrackers {
         let Some(initial_stat) = read_stable_firecracker_stat(pid).await else {
+            if let Some(info) = unidentified_firecracker_if_present(pid).await {
+                fc_infos.push(info);
+            }
             continue;
         };
         let cwd_info = read_cwd(pid)
@@ -130,9 +165,13 @@ pub async fn discover_all() -> DiscoveredProcesses {
             .and_then(|cwd| parse_workspace_cwd(&cwd));
         let ppid = read_ppid(pid).await;
         let Some(process_stat) = read_stable_firecracker_stat(pid).await else {
+            if let Some(info) = unidentified_firecracker_if_present(pid).await {
+                fc_infos.push(info);
+            }
             continue;
         };
         if !process_stat_identity_matches(&initial_stat, &process_stat) {
+            fc_infos.push(unidentified_firecracker_process(pid, ppid));
             continue;
         }
         let (sandbox_id, base_dir) = match cwd_info {
@@ -414,5 +453,49 @@ mod tests {
         assert!(process_stat_identity_matches(&sleeping, &running));
         assert!(!process_stat_identity_matches(&sleeping, &different_group));
         assert!(!process_stat_identity_matches(&sleeping, &different_start));
+    }
+
+    #[test]
+    fn unidentified_firecracker_candidate_keeps_uncertain_live_processes() {
+        let stat = ProcessStat {
+            state: 'S',
+            pgid: 1100,
+            starttime: 123456,
+        };
+
+        assert!(should_keep_unidentified_firecracker_candidate(&stat, None));
+        assert!(should_keep_unidentified_firecracker_candidate(
+            &stat,
+            Some(&argv(&["firecracker"]))
+        ));
+    }
+
+    #[test]
+    fn unidentified_firecracker_candidate_rejects_known_non_firecracker() {
+        let stat = ProcessStat {
+            state: 'S',
+            pgid: 1100,
+            starttime: 123456,
+        };
+
+        assert!(!should_keep_unidentified_firecracker_candidate(
+            &stat,
+            Some(&argv(&["bash"]))
+        ));
+    }
+
+    #[test]
+    fn unidentified_firecracker_candidate_rejects_zombie_processes() {
+        let stat = ProcessStat {
+            state: 'Z',
+            pgid: 1100,
+            starttime: 123456,
+        };
+
+        assert!(!should_keep_unidentified_firecracker_candidate(&stat, None));
+        assert!(!should_keep_unidentified_firecracker_candidate(
+            &stat,
+            Some(&argv(&["firecracker"]))
+        ));
     }
 }

--- a/crates/runner/src/process/procfs.rs
+++ b/crates/runner/src/process/procfs.rs
@@ -45,10 +45,15 @@ fn parse_process_stat(content: &str) -> Option<ProcessStat> {
 
     // After the comm field, index 0 is stat field 3 (`state`), index 2 is
     // field 5 (`pgrp`), and index 19 is field 22 (`starttime`).
+    let state = fields.first()?.chars().next()?;
     let pgid = fields.get(2)?.parse().ok()?;
     let starttime = fields.get(19)?.parse().ok()?;
 
-    Some(ProcessStat { pgid, starttime })
+    Some(ProcessStat {
+        state,
+        pgid,
+        starttime,
+    })
 }
 
 /// Read `/proc/{pid}/stat` and extract stable process facts.
@@ -122,10 +127,10 @@ pub(super) async fn scan_proc_cmdlines() -> Vec<(u32, Vec<String>)> {
 mod tests {
     use super::*;
 
-    fn stat_with_comm(comm: &str, pgid: &str, starttime: &str) -> String {
+    fn stat_with_comm(comm: &str, state: &str, pgid: &str, starttime: &str) -> String {
         let fields = vec![
-            "S", "1200", pgid, "1100", "0", "-1", "4194560", "2100", "0", "0", "0", "12", "8", "0",
-            "0", "20", "0", "1", "0", starttime,
+            state, "1200", pgid, "1100", "0", "-1", "4194560", "2100", "0", "0", "0", "12", "8",
+            "0", "0", "20", "0", "1", "0", starttime,
         ];
         format!("1234 ({comm}) {}", fields.join(" "))
     }
@@ -133,10 +138,11 @@ mod tests {
     #[test]
     fn parse_process_stat_simple() {
         // Real /proc/pid/stat: "1234 (firecracker) S 1200 1100 1100 ..."
-        let stat = stat_with_comm("firecracker", "1100", "123456");
+        let stat = stat_with_comm("firecracker", "S", "1100", "123456");
         assert_eq!(
             parse_process_stat(&stat),
             Some(ProcessStat {
+                state: 'S',
                 pgid: 1100,
                 starttime: 123456
             })
@@ -146,10 +152,11 @@ mod tests {
     #[test]
     fn parse_process_stat_comm_with_spaces() {
         // comm can contain spaces
-        let stat = stat_with_comm("Web Content", "200", "999");
+        let stat = stat_with_comm("Web Content", "S", "200", "999");
         assert_eq!(
             parse_process_stat(&stat),
             Some(ProcessStat {
+                state: 'S',
                 pgid: 200,
                 starttime: 999
             })
@@ -159,12 +166,26 @@ mod tests {
     #[test]
     fn parse_process_stat_comm_with_parens() {
         // comm can contain parentheses — last ')' is the delimiter
-        let stat = stat_with_comm("foo (bar)", "600", "888");
+        let stat = stat_with_comm("foo (bar)", "S", "600", "888");
         assert_eq!(
             parse_process_stat(&stat),
             Some(ProcessStat {
+                state: 'S',
                 pgid: 600,
                 starttime: 888
+            })
+        );
+    }
+
+    #[test]
+    fn parse_process_stat_zombie_state() {
+        let stat = stat_with_comm("firecracker", "Z", "1100", "123456");
+        assert_eq!(
+            parse_process_stat(&stat),
+            Some(ProcessStat {
+                state: 'Z',
+                pgid: 1100,
+                starttime: 123456
             })
         );
     }
@@ -182,13 +203,13 @@ mod tests {
 
     #[test]
     fn parse_process_stat_rejects_invalid_pgid() {
-        let stat = stat_with_comm("firecracker", "not-a-number", "123456");
+        let stat = stat_with_comm("firecracker", "S", "not-a-number", "123456");
         assert!(parse_process_stat(&stat).is_none());
     }
 
     #[test]
     fn parse_process_stat_rejects_invalid_starttime() {
-        let stat = stat_with_comm("firecracker", "1100", "not-a-number");
+        let stat = stat_with_comm("firecracker", "S", "1100", "not-a-number");
         assert!(parse_process_stat(&stat).is_none());
     }
 }

--- a/crates/runner/src/process/procfs.rs
+++ b/crates/runner/src/process/procfs.rs
@@ -1,15 +1,17 @@
 use std::path::PathBuf;
 
+use super::types::ProcessStat;
+
 /// Read `/proc/{pid}/cmdline` as the NUL-separated argv.
 ///
 /// Returns `None` for kernel threads (empty cmdline) and for processes whose
 /// cmdline has been rewritten (via `prctl(PR_SET_NAME)` or similar) into a
 /// single NUL-free blob — those aren't the exec-spawned processes we care
 /// about identifying here.
-async fn read_cmdline(pid: u32) -> Option<Vec<String>> {
+pub(crate) async fn read_cmdline(pid: u32) -> Option<Vec<String>> {
     let path = format!("/proc/{pid}/cmdline");
     let bytes = tokio::fs::read(&path).await.ok()?;
-    if bytes.is_empty() {
+    if bytes.is_empty() || !bytes.contains(&0) {
         return None;
     }
     let argv: Vec<String> = bytes
@@ -32,29 +34,32 @@ pub(super) async fn read_ppid(pid: u32) -> Option<u32> {
     None
 }
 
-/// Parse the process group ID from `/proc/{pid}/stat` content.
+/// Parse stable process facts from `/proc/{pid}/stat` content.
 ///
 /// Format: `pid (comm) state ppid pgrp ...`
 /// The comm field may contain spaces and parentheses, so we find the
 /// last `)` to skip past it reliably.
-fn parse_pgid_from_stat(content: &str) -> Option<u32> {
+fn parse_process_stat(content: &str) -> Option<ProcessStat> {
     let after_comm = content.rsplit_once(')')?.1;
-    let mut fields = after_comm.split_whitespace();
-    let _state = fields.next()?;
-    let _ppid = fields.next()?;
-    let pgrp = fields.next()?;
-    pgrp.parse().ok()
+    let fields: Vec<&str> = after_comm.split_whitespace().collect();
+
+    // After the comm field, index 0 is stat field 3 (`state`), index 2 is
+    // field 5 (`pgrp`), and index 19 is field 22 (`starttime`).
+    let pgid = fields.get(2)?.parse().ok()?;
+    let starttime = fields.get(19)?.parse().ok()?;
+
+    Some(ProcessStat { pgid, starttime })
 }
 
-/// Read `/proc/{pid}/stat` and extract the process group ID (field 5).
-pub async fn read_pgid(pid: u32) -> Option<u32> {
+/// Read `/proc/{pid}/stat` and extract stable process facts.
+pub(crate) async fn read_process_stat(pid: u32) -> Option<ProcessStat> {
     let path = format!("/proc/{pid}/stat");
     let content = tokio::fs::read_to_string(&path).await.ok()?;
-    parse_pgid_from_stat(&content)
+    parse_process_stat(&content)
 }
 
 /// Read `/proc/{pid}/cwd` symlink to get the process working directory.
-pub(super) async fn read_cwd(pid: u32) -> Option<PathBuf> {
+pub(crate) async fn read_cwd(pid: u32) -> Option<PathBuf> {
     let link = format!("/proc/{pid}/cwd");
     tokio::fs::read_link(&link).await.ok()
 }
@@ -117,36 +122,73 @@ pub(super) async fn scan_proc_cmdlines() -> Vec<(u32, Vec<String>)> {
 mod tests {
     use super::*;
 
+    fn stat_with_comm(comm: &str, pgid: &str, starttime: &str) -> String {
+        let fields = vec![
+            "S", "1200", pgid, "1100", "0", "-1", "4194560", "2100", "0", "0", "0", "12", "8", "0",
+            "0", "20", "0", "1", "0", starttime,
+        ];
+        format!("1234 ({comm}) {}", fields.join(" "))
+    }
+
     #[test]
-    fn parse_pgid_simple() {
+    fn parse_process_stat_simple() {
         // Real /proc/pid/stat: "1234 (firecracker) S 1200 1100 1100 ..."
-        let stat = "1234 (firecracker) S 1200 1100 1100 0 0 0";
-        assert_eq!(parse_pgid_from_stat(stat), Some(1100));
+        let stat = stat_with_comm("firecracker", "1100", "123456");
+        assert_eq!(
+            parse_process_stat(&stat),
+            Some(ProcessStat {
+                pgid: 1100,
+                starttime: 123456
+            })
+        );
     }
 
     #[test]
-    fn parse_pgid_comm_with_spaces() {
+    fn parse_process_stat_comm_with_spaces() {
         // comm can contain spaces
-        let stat = "5678 (Web Content) S 100 200 200 0 0 0";
-        assert_eq!(parse_pgid_from_stat(stat), Some(200));
+        let stat = stat_with_comm("Web Content", "200", "999");
+        assert_eq!(
+            parse_process_stat(&stat),
+            Some(ProcessStat {
+                pgid: 200,
+                starttime: 999
+            })
+        );
     }
 
     #[test]
-    fn parse_pgid_comm_with_parens() {
+    fn parse_process_stat_comm_with_parens() {
         // comm can contain parentheses — last ')' is the delimiter
-        let stat = "9999 (foo (bar)) S 500 600 600 0 0 0";
-        assert_eq!(parse_pgid_from_stat(stat), Some(600));
+        let stat = stat_with_comm("foo (bar)", "600", "888");
+        assert_eq!(
+            parse_process_stat(&stat),
+            Some(ProcessStat {
+                pgid: 600,
+                starttime: 888
+            })
+        );
     }
 
     #[test]
-    fn parse_pgid_empty() {
-        assert!(parse_pgid_from_stat("").is_none());
+    fn parse_process_stat_empty() {
+        assert!(parse_process_stat("").is_none());
     }
 
     #[test]
-    fn parse_pgid_truncated() {
-        // Missing pgrp field
-        let stat = "1234 (cmd) S 100";
-        assert!(parse_pgid_from_stat(stat).is_none());
+    fn parse_process_stat_truncated_before_starttime() {
+        let stat = "1234 (cmd) S 100 200 200 0 0 0";
+        assert!(parse_process_stat(stat).is_none());
+    }
+
+    #[test]
+    fn parse_process_stat_rejects_invalid_pgid() {
+        let stat = stat_with_comm("firecracker", "not-a-number", "123456");
+        assert!(parse_process_stat(&stat).is_none());
+    }
+
+    #[test]
+    fn parse_process_stat_rejects_invalid_starttime() {
+        let stat = stat_with_comm("firecracker", "1100", "not-a-number");
+        assert!(parse_process_stat(&stat).is_none());
     }
 }

--- a/crates/runner/src/process/types.rs
+++ b/crates/runner/src/process/types.rs
@@ -3,6 +3,7 @@ use std::path::PathBuf;
 /// Stable facts read from `/proc/{pid}/stat`.
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub struct ProcessStat {
+    pub state: char,
     pub pgid: u32,
     pub starttime: u64,
 }

--- a/crates/runner/src/process/types.rs
+++ b/crates/runner/src/process/types.rs
@@ -1,5 +1,22 @@
 use std::path::PathBuf;
 
+/// Stable facts read from `/proc/{pid}/stat`.
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct ProcessStat {
+    pub pgid: u32,
+    pub starttime: u64,
+}
+
+/// Firecracker process identity captured during discovery.
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct FirecrackerProcessIdentity {
+    pub pid: u32,
+    pub pgid: u32,
+    pub starttime: u64,
+    pub sandbox_id: String,
+    pub base_dir: Option<PathBuf>,
+}
+
 /// Info extracted from a runner process cmdline.
 pub struct RunnerProcessInfo {
     pub pid: u32,
@@ -8,6 +25,7 @@ pub struct RunnerProcessInfo {
 }
 
 /// Info extracted from a firecracker process cmdline.
+#[derive(Clone, Debug, Eq, PartialEq)]
 pub struct FirecrackerProcessInfo {
     pub pid: u32,
     pub ppid: Option<u32>,
@@ -16,6 +34,7 @@ pub struct FirecrackerProcessInfo {
     /// sandbox reuse this is stable across successive run_ids.
     pub sandbox_id: String,
     pub base_dir: Option<PathBuf>,
+    pub identity: Option<FirecrackerProcessIdentity>,
 }
 
 /// Info extracted from a mitmdump process cmdline.

--- a/crates/runner/src/process/types.rs
+++ b/crates/runner/src/process/types.rs
@@ -8,6 +8,15 @@ pub struct ProcessStat {
     pub starttime: u64,
 }
 
+/// Return true when the process stat state still represents a live process.
+///
+/// `/proc/<pid>/stat` can briefly expose terminal states before the proc entry
+/// disappears. Treat those as already exited so callers do not resolve or
+/// signal a stale process identity.
+pub(crate) fn process_stat_is_live(stat: &ProcessStat) -> bool {
+    !matches!(stat.state, 'Z' | 'X' | 'x')
+}
+
 /// Firecracker process identity captured during discovery.
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub struct FirecrackerProcessIdentity {

--- a/crates/runner/src/run_resolution.rs
+++ b/crates/runner/src/run_resolution.rs
@@ -82,6 +82,12 @@ pub(crate) struct ActiveRunMappings {
     pub runners_failed: usize,
 }
 
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub(crate) struct ResolvedRunMapping {
+    pub run_id: String,
+    pub sandbox_id: String,
+}
+
 /// Collect all `(run_id, sandbox_id)` pairs from every reachable runner's
 /// `status.json`. Used by `kill --run` and `exec --run` to translate a
 /// user-supplied run_id into the sandbox_id that identifies the FC.
@@ -107,16 +113,17 @@ pub(crate) async fn collect_active_run_mappings(
     }
 }
 
-/// Given a `run_id` prefix, find the unique matching `sandbox_id` from
-/// collected status entries.
+/// Given a `run_id` prefix, find the unique matching active run from collected
+/// status entries.
 ///
-/// Returns the `sandbox_id` on unique match. Errors on empty or ambiguous.
+/// Returns the full `run_id` and `sandbox_id` on unique match. Errors on empty
+/// or ambiguous.
 /// When no match is found and some runners were unreadable, the error
 /// message includes a diagnostic hint so the operator knows why.
-pub(crate) fn resolve_run_to_sandbox(
+pub(crate) fn resolve_run_mapping(
     input: &str,
     mappings: &ActiveRunMappings,
-) -> RunnerResult<String> {
+) -> RunnerResult<ResolvedRunMapping> {
     if input.is_empty() {
         return Err(RunnerError::Config("run id must not be empty".into()));
     }
@@ -130,7 +137,10 @@ pub(crate) fn resolve_run_to_sandbox(
     matching.dedup();
 
     match matching.as_slice() {
-        [(_, sandbox_id)] => Ok(sandbox_id.clone()),
+        [(run_id, sandbox_id)] => Ok(ResolvedRunMapping {
+            run_id: (*run_id).clone(),
+            sandbox_id: (*sandbox_id).clone(),
+        }),
         [] => {
             let mut msg = format!("no active run matches '{input}'");
             if mappings.runners_failed > 0 {
@@ -155,6 +165,15 @@ pub(crate) fn resolve_run_to_sandbox(
             )))
         }
     }
+}
+
+/// Given a `run_id` prefix, find the unique matching `sandbox_id` from
+/// collected status entries.
+pub(crate) fn resolve_run_to_sandbox(
+    input: &str,
+    mappings: &ActiveRunMappings,
+) -> RunnerResult<String> {
+    Ok(resolve_run_mapping(input, mappings)?.sandbox_id)
 }
 
 #[cfg(test)]
@@ -249,6 +268,19 @@ mod tests {
         )]);
         let result = resolve_run_to_sandbox("550e8400", &status);
         assert_eq!(result.unwrap(), "sbox-9999");
+    }
+
+    #[test]
+    fn run_prefix_resolves_full_mapping() {
+        let status = mappings(vec![(
+            "550e8400-run-1111-2222-aaaaaaaaaaaa".into(),
+            "sbox-9999".into(),
+        )]);
+
+        let result = resolve_run_mapping("550e8400", &status).unwrap();
+
+        assert_eq!(result.run_id, "550e8400-run-1111-2222-aaaaaaaaaaaa");
+        assert_eq!(result.sandbox_id, "sbox-9999");
     }
 
     #[test]

--- a/crates/sandbox-fc/src/control.rs
+++ b/crates/sandbox-fc/src/control.rs
@@ -26,4 +26,6 @@ pub use protocol::{
     TerminateStatus,
 };
 pub use provider::FirecrackerControl;
-pub(crate) use server::{ControlServerHandle, ProcessTerminationHandle, bind_server};
+pub(crate) use server::{
+    ControlServerHandle, ProcessTerminationHandle, ProcessTerminationRequest, bind_server,
+};

--- a/crates/sandbox-fc/src/control.rs
+++ b/crates/sandbox-fc/src/control.rs
@@ -1,17 +1,16 @@
-//! Control socket protocol for `runner exec`.
+//! Control socket protocol for local sandbox control.
 //!
 //! Provides a Unix domain socket server that runs alongside each sandbox,
-//! allowing external processes to execute commands inside the VM via IPC.
+//! allowing external processes to execute commands inside the VM or request
+//! host-side sandbox termination via IPC.
 //!
 //! ## Wire format
 //!
 //! Length-prefixed JSON frames: `[4-byte big-endian length][JSON payload]`.
 //! One request per connection, one response per connection.
 //!
-//! The request payload is [`ExecRequest`]. The response payload is
-//! [`ExecResponse`], serialized as an untagged JSON object: command-result
-//! responses contain command result fields, and error responses contain an
-//! `error` field.
+//! Exec request payloads are [`ExecRequest`]. Termination request payloads are
+//! [`TerminateRequest`]. Responses are serialized as untagged JSON objects.
 
 mod client;
 mod protocol;
@@ -21,7 +20,10 @@ mod server;
 
 const CONTROL_SOCKET_OVERHEAD_MS: u64 = 5000;
 
-pub use client::send_exec;
-pub use protocol::{ExecRequest, ExecResponse};
+pub use client::{send_exec, send_terminate};
+pub use protocol::{
+    ExecRequest, ExecResponse, TerminateAction, TerminateRequest, TerminateResponse,
+    TerminateStatus,
+};
 pub use provider::FirecrackerControl;
-pub(crate) use server::{ControlServerHandle, bind_server};
+pub(crate) use server::{ControlServerHandle, ProcessTerminationHandle, bind_server};

--- a/crates/sandbox-fc/src/control/client.rs
+++ b/crates/sandbox-fc/src/control/client.rs
@@ -2,9 +2,13 @@ use std::io;
 use std::path::Path;
 use std::time::Duration;
 
+use serde::Serialize;
+use serde::de::DeserializeOwned;
 use tokio::net::UnixStream;
 
-use super::protocol::{ExecRequest, ExecResponse, read_frame, write_frame};
+use super::protocol::{
+    ExecRequest, ExecResponse, TerminateRequest, TerminateResponse, read_frame, write_frame,
+};
 
 /// Send an exec request to a control socket and return the wire response.
 ///
@@ -21,6 +25,27 @@ pub async fn send_exec(
     request: &ExecRequest,
     timeout: Duration,
 ) -> io::Result<ExecResponse> {
+    send_control_request(sock_path, request, timeout).await
+}
+
+/// Send a host-side terminate request to a control socket.
+pub async fn send_terminate(
+    sock_path: &Path,
+    request: &TerminateRequest,
+    timeout: Duration,
+) -> io::Result<TerminateResponse> {
+    send_control_request(sock_path, request, timeout).await
+}
+
+async fn send_control_request<Request, Response>(
+    sock_path: &Path,
+    request: &Request,
+    timeout: Duration,
+) -> io::Result<Response>
+where
+    Request: Serialize,
+    Response: DeserializeOwned,
+{
     let deadline = deadline_after(timeout)?;
 
     let mut stream = tokio::time::timeout_at(deadline, UnixStream::connect(sock_path))
@@ -33,7 +58,7 @@ pub async fn send_exec(
     tokio::time::timeout_at(deadline, async {
         write_frame(&mut stream, &request_json).await?;
         let frame = read_frame(&mut stream).await?;
-        let response: ExecResponse = serde_json::from_slice(&frame).map_err(|e| {
+        let response: Response = serde_json::from_slice(&frame).map_err(|e| {
             io::Error::new(io::ErrorKind::InvalidData, format!("invalid response: {e}"))
         })?;
         Ok(response)

--- a/crates/sandbox-fc/src/control/protocol.rs
+++ b/crates/sandbox-fc/src/control/protocol.rs
@@ -89,6 +89,9 @@ pub struct TerminateRequest {
 pub enum TerminateStatus {
     Accepted,
     AlreadyStopped,
+    /// The sandbox is parked or entering idle ownership; direct process
+    /// termination would leave runner-owned idle resources retained.
+    RefusedIdle,
 }
 
 /// Response to a host-side termination client.
@@ -296,6 +299,18 @@ mod tests {
             decoded,
             TerminateResponse::Status {
                 status: TerminateStatus::Accepted
+            }
+        );
+
+        let response = TerminateResponse::Status {
+            status: TerminateStatus::RefusedIdle,
+        };
+        let response_json = serde_json::to_vec(&response).unwrap();
+        let decoded: TerminateResponse = serde_json::from_slice(&response_json).unwrap();
+        assert_eq!(
+            decoded,
+            TerminateResponse::Status {
+                status: TerminateStatus::RefusedIdle
             }
         );
 

--- a/crates/sandbox-fc/src/control/protocol.rs
+++ b/crates/sandbox-fc/src/control/protocol.rs
@@ -68,6 +68,35 @@ pub enum ExecResponse {
     },
 }
 
+/// Host-side control action requested over the local control socket.
+#[derive(Debug, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum TerminateAction {
+    Terminate,
+}
+
+/// Request from a host-side termination client.
+#[derive(Debug, Serialize, Deserialize)]
+pub struct TerminateRequest {
+    pub action: TerminateAction,
+}
+
+/// Result status for a host-side termination request.
+#[derive(Clone, Copy, Debug, Eq, PartialEq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum TerminateStatus {
+    Accepted,
+    AlreadyStopped,
+}
+
+/// Response to a host-side termination client.
+#[derive(Debug, Eq, PartialEq, Serialize, Deserialize)]
+#[serde(untagged)]
+pub enum TerminateResponse {
+    Status { status: TerminateStatus },
+    Error { error: String },
+}
+
 /// Maximum frame size: 64 MiB (generous for large stdout/stderr).
 const MAX_FRAME_SIZE: u32 = 64 * 1024 * 1024;
 
@@ -244,5 +273,50 @@ mod tests {
         let json = serde_json::to_value(&resp).unwrap();
         assert_eq!(json["error"], "sandbox not running");
         assert!(json.get("exit_code").is_none());
+    }
+
+    #[test]
+    fn terminate_protocol_round_trip() {
+        let request = TerminateRequest {
+            action: TerminateAction::Terminate,
+        };
+        let request_json = serde_json::to_vec(&request).unwrap();
+
+        let decoded: TerminateRequest = serde_json::from_slice(&request_json).unwrap();
+        assert!(matches!(decoded.action, TerminateAction::Terminate));
+
+        let response = TerminateResponse::Status {
+            status: TerminateStatus::Accepted,
+        };
+        let response_json = serde_json::to_vec(&response).unwrap();
+        let decoded: TerminateResponse = serde_json::from_slice(&response_json).unwrap();
+        assert_eq!(
+            decoded,
+            TerminateResponse::Status {
+                status: TerminateStatus::Accepted
+            }
+        );
+
+        let response = TerminateResponse::Error {
+            error: "sandbox not running".into(),
+        };
+        let response_json = serde_json::to_vec(&response).unwrap();
+        let decoded: TerminateResponse = serde_json::from_slice(&response_json).unwrap();
+        assert_eq!(
+            decoded,
+            TerminateResponse::Error {
+                error: "sandbox not running".into()
+            }
+        );
+    }
+
+    #[test]
+    fn terminate_request_does_not_decode_as_exec_request() {
+        let request = TerminateRequest {
+            action: TerminateAction::Terminate,
+        };
+        let request_json = serde_json::to_vec(&request).unwrap();
+
+        assert!(serde_json::from_slice::<ExecRequest>(&request_json).is_err());
     }
 }

--- a/crates/sandbox-fc/src/control/protocol.rs
+++ b/crates/sandbox-fc/src/control/protocol.rs
@@ -6,6 +6,7 @@ use tokio::net::UnixStream;
 
 /// Request from a `runner exec` client.
 #[derive(Debug, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
 pub struct ExecRequest {
     /// Command text to execute inside the guest.
     pub command: String,
@@ -330,5 +331,16 @@ mod tests {
         });
 
         assert!(serde_json::from_value::<TerminateRequest>(request_json).is_err());
+    }
+
+    #[test]
+    fn exec_request_rejects_terminate_fields() {
+        let request_json = serde_json::json!({
+            "command": "true",
+            "timeout_secs": 1,
+            "action": "terminate",
+        });
+
+        assert!(serde_json::from_value::<ExecRequest>(request_json).is_err());
     }
 }

--- a/crates/sandbox-fc/src/control/protocol.rs
+++ b/crates/sandbox-fc/src/control/protocol.rs
@@ -89,8 +89,8 @@ pub struct TerminateRequest {
 pub enum TerminateStatus {
     Accepted,
     AlreadyStopped,
-    /// The sandbox is parked or entering idle ownership; direct process
-    /// termination would leave runner-owned idle resources retained.
+    /// The sandbox is parked in idle ownership; direct process termination
+    /// would leave runner-owned idle resources retained.
     RefusedIdle,
 }
 

--- a/crates/sandbox-fc/src/control/protocol.rs
+++ b/crates/sandbox-fc/src/control/protocol.rs
@@ -77,6 +77,7 @@ pub enum TerminateAction {
 
 /// Request from a host-side termination client.
 #[derive(Debug, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
 pub struct TerminateRequest {
     pub action: TerminateAction,
 }
@@ -318,5 +319,16 @@ mod tests {
         let request_json = serde_json::to_vec(&request).unwrap();
 
         assert!(serde_json::from_slice::<ExecRequest>(&request_json).is_err());
+    }
+
+    #[test]
+    fn terminate_request_rejects_exec_fields() {
+        let request_json = serde_json::json!({
+            "action": "terminate",
+            "command": "true",
+            "timeout_secs": 1,
+        });
+
+        assert!(serde_json::from_value::<TerminateRequest>(request_json).is_err());
     }
 }

--- a/crates/sandbox-fc/src/control/provider.rs
+++ b/crates/sandbox-fc/src/control/provider.rs
@@ -111,6 +111,9 @@ impl SandboxControl for FirecrackerControl {
             TerminateResponse::Status {
                 status: TerminateStatus::AlreadyStopped,
             } => Ok(RemoteKillResult::AlreadyStopped),
+            TerminateResponse::Status {
+                status: TerminateStatus::RefusedIdle,
+            } => Ok(RemoteKillResult::RefusedIdle),
             TerminateResponse::Error { error } => Err(SandboxControlError::Remote(error)),
         }
     }

--- a/crates/sandbox-fc/src/control/provider.rs
+++ b/crates/sandbox-fc/src/control/provider.rs
@@ -5,11 +5,14 @@ use std::time::Duration;
 use async_trait::async_trait;
 use base64::Engine;
 use base64::engine::general_purpose::STANDARD as BASE64;
-use sandbox::{RemoteExecResult, SandboxControl, SandboxControlError};
+use sandbox::{RemoteExecResult, RemoteKillResult, SandboxControl, SandboxControlError};
 
 use super::CONTROL_SOCKET_OVERHEAD_MS;
-use super::client::send_exec;
-use super::protocol::{ExecRequest, ExecResponse};
+use super::client::{send_exec, send_terminate};
+use super::protocol::{
+    ExecRequest, ExecResponse, TerminateAction, TerminateRequest, TerminateResponse,
+    TerminateStatus,
+};
 use super::resolver::resolve_control_socket;
 use crate::paths::RuntimePaths;
 
@@ -79,6 +82,39 @@ impl SandboxControl for FirecrackerControl {
         }
     }
 
+    async fn kill_remote(&self, sandbox_id: &str) -> Result<RemoteKillResult, SandboxControlError> {
+        if sandbox_id.is_empty() {
+            return Err(SandboxControlError::NotFound(
+                "sandbox id must not be empty".into(),
+            ));
+        }
+
+        let sock_path = resolve_control_socket(sandbox_id)?;
+        let request = TerminateRequest {
+            action: TerminateAction::Terminate,
+        };
+
+        let response = send_terminate(&sock_path, &request, Duration::from_secs(5))
+            .await
+            .map_err(|e| {
+                if e.kind() == io::ErrorKind::InvalidInput {
+                    SandboxControlError::Io(e)
+                } else {
+                    SandboxControlError::Connection(format!("failed to connect to sandbox: {e}"))
+                }
+            })?;
+
+        match response {
+            TerminateResponse::Status {
+                status: TerminateStatus::Accepted,
+            } => Ok(RemoteKillResult::Accepted),
+            TerminateResponse::Status {
+                status: TerminateStatus::AlreadyStopped,
+            } => Ok(RemoteKillResult::AlreadyStopped),
+            TerminateResponse::Error { error } => Err(SandboxControlError::Remote(error)),
+        }
+    }
+
     fn runtime_dir(&self, sandbox_id: &str) -> PathBuf {
         RuntimePaths::new().sock_dir(sandbox_id)
     }
@@ -104,6 +140,16 @@ mod tests {
         let result = control
             .exec_remote("", "echo hi", Duration::from_secs(5), false)
             .await;
+        let Err(e) = result else {
+            panic!("expected error");
+        };
+        assert!(e.to_string().contains("must not be empty"));
+    }
+
+    #[tokio::test]
+    async fn kill_remote_empty_id() {
+        let control = FirecrackerControl;
+        let result = control.kill_remote("").await;
         let Err(e) = result else {
             panic!("expected error");
         };

--- a/crates/sandbox-fc/src/control/server.rs
+++ b/crates/sandbox-fc/src/control/server.rs
@@ -461,7 +461,9 @@ mod tests {
         ExecRequest, ExecResponse, TerminateAction, TerminateRequest, TerminateResponse,
         TerminateStatus, send_exec, send_terminate,
     };
-    use crate::park_coordinator::{CoordinatorState, ParkCoordinator, PrepareParkEvidence};
+    use crate::park_coordinator::{
+        CoordinatorState, DirtyReason, ParkCoordinator, PrepareParkEvidence,
+    };
 
     fn test_gate(
         guest: Arc<tokio::sync::Mutex<Option<Arc<VsockHost>>>>,
@@ -481,6 +483,15 @@ mod tests {
             .complete_prepare_park(&attempt, PrepareParkEvidence::AgentQuiesced)
             .unwrap();
         coordinator.mark_parked(&attempt).unwrap();
+        coordinator
+    }
+
+    fn ready_for_park_coordinator() -> ParkCoordinator {
+        let coordinator = ParkCoordinator::new();
+        let attempt = coordinator.begin_prepare_park().unwrap();
+        coordinator
+            .complete_prepare_park(&attempt, PrepareParkEvidence::AgentQuiesced)
+            .unwrap();
         coordinator
     }
 
@@ -653,6 +664,31 @@ mod tests {
         assert_eq!(termination.request_terminate(), TerminateStatus::Accepted);
         assert_eq!(coordinator.state(), CoordinatorState::Terminating);
         assert!(coordinator.begin_prepare_park().is_err());
+        assert_eq!(kill_rx.len(), 1);
+    }
+
+    #[test]
+    fn termination_handle_accepts_dirty_policy() {
+        let (kill_tx, kill_rx) = mpsc::channel(1);
+        let coordinator = ParkCoordinator::new();
+        coordinator.mark_dirty(DirtyReason::new("transport failed"));
+        let termination =
+            ProcessTerminationHandle::with_park_coordinator(kill_tx, coordinator.clone());
+
+        assert_eq!(termination.request_terminate(), TerminateStatus::Accepted);
+        assert_eq!(coordinator.state(), CoordinatorState::Terminating);
+        assert_eq!(kill_rx.len(), 1);
+    }
+
+    #[test]
+    fn termination_handle_accepts_ready_for_park_policy() {
+        let (kill_tx, kill_rx) = mpsc::channel(1);
+        let coordinator = ready_for_park_coordinator();
+        let termination =
+            ProcessTerminationHandle::with_park_coordinator(kill_tx, coordinator.clone());
+
+        assert_eq!(termination.request_terminate(), TerminateStatus::Accepted);
+        assert_eq!(coordinator.state(), CoordinatorState::Terminating);
         assert_eq!(kill_rx.len(), 1);
     }
 

--- a/crates/sandbox-fc/src/control/server.rs
+++ b/crates/sandbox-fc/src/control/server.rs
@@ -369,11 +369,7 @@ async fn handle_connection(
     };
 
     if let Ok(request) = serde_json::from_slice::<TerminateRequest>(&frame) {
-        let response = tokio::select! {
-            biased;
-            () = shutdown.cancelled() => return Ok(()),
-            response = terminate(request, &termination) => response,
-        };
+        let response = terminate(request, &termination).await;
         return write_json_frame(&mut stream, &response).await;
     }
 
@@ -682,6 +678,45 @@ mod tests {
             Err(mpsc::error::TryRecvError::Empty)
         ));
 
+        handle.shutdown().await;
+    }
+
+    #[tokio::test]
+    async fn terminate_response_survives_shutdown_after_request_is_queued() {
+        let dir = tempfile::tempdir().unwrap();
+        let sock_path = dir.path().join("control.sock");
+        let guest = Arc::new(tokio::sync::Mutex::new(None::<Arc<VsockHost>>));
+        let (kill_tx, mut kill_rx) = mpsc::channel(1);
+        let shutdown = CancellationToken::new();
+        let mut handle = bind_server(
+            sock_path.clone(),
+            test_gate(guest),
+            ProcessTerminationHandle::new(kill_tx),
+        )
+        .unwrap()
+        .spawn(shutdown.clone());
+
+        let client = tokio::spawn({
+            let sock_path = sock_path.clone();
+            async move {
+                let request = TerminateRequest {
+                    action: TerminateAction::Terminate,
+                };
+                send_terminate(&sock_path, &request, Duration::from_secs(5)).await
+            }
+        });
+        let request = recv_termination_request(&mut kill_rx).await;
+
+        shutdown.cancel();
+        request.acknowledge();
+        let response = client.await.unwrap().unwrap();
+
+        assert_eq!(
+            response,
+            TerminateResponse::Status {
+                status: TerminateStatus::Accepted
+            }
+        );
         handle.shutdown().await;
     }
 

--- a/crates/sandbox-fc/src/control/server.rs
+++ b/crates/sandbox-fc/src/control/server.rs
@@ -28,18 +28,19 @@ const CONTROL_HANDLER_SHUTDOWN_GRACE: Duration = Duration::from_millis(250);
 /// terminate the sandbox process group.
 #[derive(Clone)]
 pub(crate) struct ProcessTerminationHandle {
-    kill_tx: mpsc::UnboundedSender<()>,
+    kill_tx: mpsc::Sender<()>,
 }
 
 impl ProcessTerminationHandle {
-    pub(crate) fn new(kill_tx: mpsc::UnboundedSender<()>) -> Self {
+    pub(crate) fn new(kill_tx: mpsc::Sender<()>) -> Self {
         Self { kill_tx }
     }
 
     fn request_terminate(&self) -> TerminateStatus {
-        match self.kill_tx.send(()) {
+        match self.kill_tx.try_send(()) {
             Ok(()) => TerminateStatus::Accepted,
-            Err(_) => TerminateStatus::AlreadyStopped,
+            Err(mpsc::error::TrySendError::Full(())) => TerminateStatus::Accepted,
+            Err(mpsc::error::TrySendError::Closed(())) => TerminateStatus::AlreadyStopped,
         }
     }
 }
@@ -452,7 +453,7 @@ mod tests {
     }
 
     fn test_termination_handle() -> ProcessTerminationHandle {
-        let (kill_tx, _kill_rx) = mpsc::unbounded_channel();
+        let (kill_tx, _kill_rx) = mpsc::channel(1);
         ProcessTerminationHandle::new(kill_tx)
     }
 
@@ -509,7 +510,7 @@ mod tests {
         let dir = tempfile::tempdir().unwrap();
         let sock_path = dir.path().join("control.sock");
         let guest = Arc::new(tokio::sync::Mutex::new(None::<Arc<VsockHost>>));
-        let (kill_tx, mut kill_rx) = mpsc::unbounded_channel();
+        let (kill_tx, mut kill_rx) = mpsc::channel(1);
         let mut handle = bind_server(
             sock_path.clone(),
             test_gate(guest),
@@ -544,7 +545,7 @@ mod tests {
         let dir = tempfile::tempdir().unwrap();
         let sock_path = dir.path().join("control.sock");
         let guest = Arc::new(tokio::sync::Mutex::new(None::<Arc<VsockHost>>));
-        let (kill_tx, kill_rx) = mpsc::unbounded_channel();
+        let (kill_tx, kill_rx) = mpsc::channel(1);
         drop(kill_rx);
         let mut handle = bind_server(
             sock_path.clone(),
@@ -569,6 +570,16 @@ mod tests {
         );
 
         handle.shutdown().await;
+    }
+
+    #[test]
+    fn termination_handle_treats_full_channel_as_accepted() {
+        let (kill_tx, kill_rx) = mpsc::channel(1);
+        let termination = ProcessTerminationHandle::new(kill_tx);
+
+        assert_eq!(termination.request_terminate(), TerminateStatus::Accepted);
+        assert_eq!(termination.request_terminate(), TerminateStatus::Accepted);
+        assert_eq!(kill_rx.len(), 1);
     }
 
     #[tokio::test]

--- a/crates/sandbox-fc/src/control/server.rs
+++ b/crates/sandbox-fc/src/control/server.rs
@@ -6,24 +6,50 @@ use std::time::Duration;
 
 use base64::Engine;
 use base64::engine::general_purpose::STANDARD as BASE64;
+use serde::Serialize;
 use tokio::net::{UnixListener, UnixStream};
+use tokio::sync::mpsc;
 use tokio::task::{JoinHandle, JoinSet};
 use tokio_util::sync::CancellationToken;
 use tracing::{info, warn};
 
 use super::CONTROL_SOCKET_OVERHEAD_MS;
-use super::protocol::{ExecRequest, ExecResponse, read_frame, write_frame};
+use super::protocol::{
+    ExecRequest, ExecResponse, TerminateAction, TerminateRequest, TerminateResponse,
+    TerminateStatus, read_frame, write_frame,
+};
 use crate::guest_operations::{GuestOperationStartError, GuestOperationStartGate};
 
 const RUNNER_EXEC_CAPTURE_LIMIT_BYTES: u32 = 7 * 1024 * 1024;
 const CONTROL_SERVER_SHUTDOWN_TIMEOUT: Duration = Duration::from_secs(1);
 const CONTROL_HANDLER_SHUTDOWN_GRACE: Duration = Duration::from_millis(250);
 
+/// Cloneable handle used by the control server to ask the process monitor to
+/// terminate the sandbox process group.
+#[derive(Clone)]
+pub(crate) struct ProcessTerminationHandle {
+    kill_tx: mpsc::UnboundedSender<()>,
+}
+
+impl ProcessTerminationHandle {
+    pub(crate) fn new(kill_tx: mpsc::UnboundedSender<()>) -> Self {
+        Self { kill_tx }
+    }
+
+    fn request_terminate(&self) -> TerminateStatus {
+        match self.kill_tx.send(()) {
+            Ok(()) => TerminateStatus::Accepted,
+            Err(_) => TerminateStatus::AlreadyStopped,
+        }
+    }
+}
+
 /// A control socket server whose listener has already been bound.
 pub(crate) struct BoundControlServer {
     sock_path: Option<SocketPathGuard>,
     listener: Option<UnixListener>,
     guest_operations: GuestOperationStartGate,
+    termination: ProcessTerminationHandle,
 }
 
 impl BoundControlServer {
@@ -41,6 +67,7 @@ impl BoundControlServer {
             listener,
             sock_path.clone(),
             self.guest_operations.clone(),
+            self.termination.clone(),
             shutdown.clone(),
         );
         ControlServerHandle {
@@ -167,6 +194,7 @@ impl SocketPathGuard {
 pub(crate) fn bind_server(
     sock_path: PathBuf,
     guest_operations: GuestOperationStartGate,
+    termination: ProcessTerminationHandle,
 ) -> io::Result<BoundControlServer> {
     let listener = bind_unix_listener(&sock_path)?;
     let sock_path = SocketPathGuard::new(sock_path);
@@ -174,6 +202,7 @@ pub(crate) fn bind_server(
         sock_path: Some(sock_path),
         listener: Some(listener),
         guest_operations,
+        termination,
     })
 }
 
@@ -198,6 +227,7 @@ fn spawn_bound_server(
     listener: UnixListener,
     sock_path: SocketPathGuard,
     guest_operations: GuestOperationStartGate,
+    termination: ProcessTerminationHandle,
     shutdown: CancellationToken,
 ) -> JoinHandle<()> {
     tokio::spawn(async move {
@@ -227,9 +257,10 @@ fn spawn_bound_server(
                     };
 
                     let guest_operations = guest_operations.clone();
+                    let termination = termination.clone();
                     let handler_shutdown = shutdown.clone();
                     handlers.spawn(async move {
-                        if let Err(e) = handle_connection(stream, guest_operations, handler_shutdown).await {
+                        if let Err(e) = handle_connection(stream, guest_operations, termination, handler_shutdown).await {
                             warn!(error = %e, "control connection handler error");
                         }
                     });
@@ -283,6 +314,7 @@ async fn shutdown_handlers(handlers: &mut JoinSet<()>) {
 async fn handle_connection(
     mut stream: UnixStream,
     guest_operations: GuestOperationStartGate,
+    termination: ProcessTerminationHandle,
     shutdown: CancellationToken,
 ) -> io::Result<()> {
     let frame = tokio::select! {
@@ -290,6 +322,11 @@ async fn handle_connection(
         () = shutdown.cancelled() => return Ok(()),
         result = read_frame(&mut stream) => result?,
     };
+
+    if let Ok(request) = serde_json::from_slice::<TerminateRequest>(&frame) {
+        let response = terminate(request, &termination);
+        return write_json_frame(&mut stream, &response).await;
+    }
 
     let response = match serde_json::from_slice::<ExecRequest>(&frame) {
         Ok(request) => tokio::select! {
@@ -302,8 +339,7 @@ async fn handle_connection(
         },
     };
 
-    let response_json = serde_json::to_vec(&response)
-        .map_err(|e| io::Error::other(format!("serialize response: {e}")))?;
+    let response_json = encode_json_frame(&response)?;
     tokio::select! {
         biased;
         () = shutdown.cancelled() => return Ok(()),
@@ -311,6 +347,29 @@ async fn handle_connection(
     }
 
     Ok(())
+}
+
+fn terminate(
+    request: TerminateRequest,
+    termination: &ProcessTerminationHandle,
+) -> TerminateResponse {
+    match request.action {
+        TerminateAction::Terminate => TerminateResponse::Status {
+            status: termination.request_terminate(),
+        },
+    }
+}
+
+async fn write_json_frame<Response: Serialize>(
+    stream: &mut UnixStream,
+    response: &Response,
+) -> io::Result<()> {
+    let response_json = encode_json_frame(response)?;
+    write_frame(stream, &response_json).await
+}
+
+fn encode_json_frame<Response: Serialize>(response: &Response) -> io::Result<Vec<u8>> {
+    serde_json::to_vec(response).map_err(|e| io::Error::other(format!("serialize response: {e}")))
 }
 
 /// Execute an [`ExecRequest`] through the sandbox operation start gate.
@@ -374,19 +433,34 @@ mod tests {
     use super::*;
 
     use tokio::io::{AsyncReadExt, AsyncWriteExt};
-    use tokio::sync::oneshot;
+    use tokio::sync::{mpsc, oneshot};
     use vsock_host::{NormalOperationFenceRejection, VsockHost};
     use vsock_proto::{
         Decoder, MSG_ERROR, MSG_EXEC_START, MSG_PING, MSG_PONG, MSG_READY, RawMessage,
     };
 
-    use crate::control::{ExecRequest, ExecResponse, send_exec};
+    use crate::control::{
+        ExecRequest, ExecResponse, TerminateAction, TerminateRequest, TerminateResponse,
+        TerminateStatus, send_exec, send_terminate,
+    };
     use crate::park_coordinator::{CoordinatorState, ParkCoordinator};
 
     fn test_gate(
         guest: Arc<tokio::sync::Mutex<Option<Arc<VsockHost>>>>,
     ) -> GuestOperationStartGate {
         GuestOperationStartGate::new(guest, ParkCoordinator::new())
+    }
+
+    fn test_termination_handle() -> ProcessTerminationHandle {
+        let (kill_tx, _kill_rx) = mpsc::unbounded_channel();
+        ProcessTerminationHandle::new(kill_tx)
+    }
+
+    fn bind_test_server(
+        sock_path: PathBuf,
+        guest_operations: GuestOperationStartGate,
+    ) -> io::Result<BoundControlServer> {
+        bind_server(sock_path, guest_operations, test_termination_handle())
     }
 
     fn test_gate_with_coordinator(
@@ -406,7 +480,7 @@ mod tests {
 
         // Server with no guest connected.
         let guest = Arc::new(tokio::sync::Mutex::new(None::<Arc<VsockHost>>));
-        let mut handle = bind_server(sock_path.clone(), test_gate(guest))
+        let mut handle = bind_test_server(sock_path.clone(), test_gate(guest))
             .unwrap()
             .spawn(CancellationToken::new());
 
@@ -431,12 +505,79 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn client_server_terminate_accepted() {
+        let dir = tempfile::tempdir().unwrap();
+        let sock_path = dir.path().join("control.sock");
+        let guest = Arc::new(tokio::sync::Mutex::new(None::<Arc<VsockHost>>));
+        let (kill_tx, mut kill_rx) = mpsc::unbounded_channel();
+        let mut handle = bind_server(
+            sock_path.clone(),
+            test_gate(guest),
+            ProcessTerminationHandle::new(kill_tx),
+        )
+        .unwrap()
+        .spawn(CancellationToken::new());
+
+        let request = TerminateRequest {
+            action: TerminateAction::Terminate,
+        };
+        let response = send_terminate(&sock_path, &request, Duration::from_secs(5))
+            .await
+            .unwrap();
+
+        assert_eq!(
+            response,
+            TerminateResponse::Status {
+                status: TerminateStatus::Accepted
+            }
+        );
+        tokio::time::timeout(Duration::from_secs(1), kill_rx.recv())
+            .await
+            .unwrap()
+            .expect("terminate request should notify process monitor");
+
+        handle.shutdown().await;
+    }
+
+    #[tokio::test]
+    async fn client_server_terminate_already_stopped() {
+        let dir = tempfile::tempdir().unwrap();
+        let sock_path = dir.path().join("control.sock");
+        let guest = Arc::new(tokio::sync::Mutex::new(None::<Arc<VsockHost>>));
+        let (kill_tx, kill_rx) = mpsc::unbounded_channel();
+        drop(kill_rx);
+        let mut handle = bind_server(
+            sock_path.clone(),
+            test_gate(guest),
+            ProcessTerminationHandle::new(kill_tx),
+        )
+        .unwrap()
+        .spawn(CancellationToken::new());
+
+        let request = TerminateRequest {
+            action: TerminateAction::Terminate,
+        };
+        let response = send_terminate(&sock_path, &request, Duration::from_secs(5))
+            .await
+            .unwrap();
+
+        assert_eq!(
+            response,
+            TerminateResponse::Status {
+                status: TerminateStatus::AlreadyStopped
+            }
+        );
+
+        handle.shutdown().await;
+    }
+
+    #[tokio::test]
     async fn bound_control_server_close_removes_socket() {
         let dir = tempfile::tempdir().unwrap();
         let sock_path = dir.path().join("control.sock");
         let guest = Arc::new(tokio::sync::Mutex::new(None::<Arc<VsockHost>>));
 
-        let server = bind_server(sock_path.clone(), test_gate(guest)).unwrap();
+        let server = bind_test_server(sock_path.clone(), test_gate(guest)).unwrap();
         assert!(sock_path.exists());
 
         server.close();
@@ -451,7 +592,7 @@ mod tests {
         let guest = Arc::new(tokio::sync::Mutex::new(None::<Arc<VsockHost>>));
 
         {
-            let _server = bind_server(sock_path.clone(), test_gate(guest)).unwrap();
+            let _server = bind_test_server(sock_path.clone(), test_gate(guest)).unwrap();
             assert!(sock_path.exists());
         }
 
@@ -463,7 +604,7 @@ mod tests {
         let dir = tempfile::tempdir().unwrap();
         let sock_path = dir.path().join("control.sock");
         let guest = Arc::new(tokio::sync::Mutex::new(None::<Arc<VsockHost>>));
-        let mut handle = bind_server(sock_path.clone(), test_gate(guest))
+        let mut handle = bind_test_server(sock_path.clone(), test_gate(guest))
             .unwrap()
             .spawn(CancellationToken::new());
 
@@ -483,7 +624,7 @@ mod tests {
         let sock_path = dir.path().join("control.sock");
         let guest = Arc::new(tokio::sync::Mutex::new(None::<Arc<VsockHost>>));
         let shutdown = CancellationToken::new();
-        let mut handle = bind_server(sock_path.clone(), test_gate(guest))
+        let mut handle = bind_test_server(sock_path.clone(), test_gate(guest))
             .unwrap()
             .spawn(shutdown.clone());
 
@@ -500,7 +641,7 @@ mod tests {
         let sock_path = dir.path().join("control.sock");
         let guest = Arc::new(tokio::sync::Mutex::new(None::<Arc<VsockHost>>));
         let shutdown = CancellationToken::new();
-        let mut handle = bind_server(sock_path.clone(), test_gate(guest))
+        let mut handle = bind_test_server(sock_path.clone(), test_gate(guest))
             .unwrap()
             .spawn(shutdown.clone());
         let mut stream = UnixStream::connect(&sock_path).await.unwrap();
@@ -520,7 +661,7 @@ mod tests {
         let dir = tempfile::tempdir().unwrap();
         let sock_path = dir.path().join("control.sock");
         let guest = Arc::new(tokio::sync::Mutex::new(None::<Arc<VsockHost>>));
-        let mut handle = bind_server(sock_path.clone(), test_gate(guest))
+        let mut handle = bind_test_server(sock_path.clone(), test_gate(guest))
             .unwrap()
             .spawn(CancellationToken::new());
         let mut stream = UnixStream::connect(&sock_path).await.unwrap();
@@ -550,7 +691,7 @@ mod tests {
         let sock_path = dir.path().join("control.sock");
         let guest = Arc::new(tokio::sync::Mutex::new(Some(Arc::clone(&vsock))));
         let (gate, coordinator) = test_gate_with_coordinator(guest);
-        let mut handle = bind_server(sock_path.clone(), gate)
+        let mut handle = bind_test_server(sock_path.clone(), gate)
             .unwrap()
             .spawn(CancellationToken::new());
         let client = tokio::spawn({
@@ -612,7 +753,7 @@ mod tests {
         let attempt = coordinator
             .begin_prepare_park()
             .expect("gate should enter closing state");
-        let mut handle = bind_server(sock_path.clone(), gate)
+        let mut handle = bind_test_server(sock_path.clone(), gate)
             .unwrap()
             .spawn(CancellationToken::new());
 
@@ -661,7 +802,7 @@ mod tests {
         let sock_path = dir.path().join("control.sock");
         let guest = Arc::new(tokio::sync::Mutex::new(Some(Arc::clone(&vsock))));
         let (gate, coordinator) = test_gate_with_coordinator(guest);
-        let mut handle = bind_server(sock_path.clone(), gate)
+        let mut handle = bind_test_server(sock_path.clone(), gate)
             .unwrap()
             .spawn(CancellationToken::new());
 
@@ -711,7 +852,7 @@ mod tests {
         let sock_path = dir.path().join("control.sock");
         let guest = Arc::new(tokio::sync::Mutex::new(Some(Arc::clone(&vsock))));
         let (gate, coordinator) = test_gate_with_coordinator(guest);
-        let mut handle = bind_server(sock_path.clone(), gate)
+        let mut handle = bind_test_server(sock_path.clone(), gate)
             .unwrap()
             .spawn(CancellationToken::new());
 
@@ -755,7 +896,7 @@ mod tests {
         let _existing = UnixListener::bind(&sock_path).unwrap();
         let guest = Arc::new(tokio::sync::Mutex::new(None::<Arc<VsockHost>>));
 
-        let result = bind_server(sock_path.clone(), test_gate(guest));
+        let result = bind_test_server(sock_path.clone(), test_gate(guest));
 
         let Err(err) = result else {
             panic!("binding an occupied control socket should fail");

--- a/crates/sandbox-fc/src/control/server.rs
+++ b/crates/sandbox-fc/src/control/server.rs
@@ -559,9 +559,8 @@ mod tests {
                 status: TerminateStatus::Accepted
             }
         );
-        tokio::time::timeout(Duration::from_secs(1), kill_rx.recv())
-            .await
-            .unwrap()
+        kill_rx
+            .try_recv()
             .expect("terminate request should notify process monitor");
 
         handle.shutdown().await;

--- a/crates/sandbox-fc/src/control/server.rs
+++ b/crates/sandbox-fc/src/control/server.rs
@@ -8,7 +8,7 @@ use base64::Engine;
 use base64::engine::general_purpose::STANDARD as BASE64;
 use serde::Serialize;
 use tokio::net::{UnixListener, UnixStream};
-use tokio::sync::mpsc;
+use tokio::sync::{mpsc, oneshot};
 use tokio::task::{JoinHandle, JoinSet};
 use tokio_util::sync::CancellationToken;
 use tracing::{info, warn};
@@ -29,18 +29,18 @@ const CONTROL_HANDLER_SHUTDOWN_GRACE: Duration = Duration::from_millis(250);
 /// terminate the sandbox process group.
 #[derive(Clone)]
 pub(crate) struct ProcessTerminationHandle {
-    kill_tx: mpsc::Sender<()>,
+    kill_tx: mpsc::Sender<ProcessTerminationRequest>,
     park_coordinator: ParkCoordinator,
 }
 
 impl ProcessTerminationHandle {
     #[cfg(test)]
-    pub(crate) fn new(kill_tx: mpsc::Sender<()>) -> Self {
+    pub(crate) fn new(kill_tx: mpsc::Sender<ProcessTerminationRequest>) -> Self {
         Self::with_park_coordinator(kill_tx, ParkCoordinator::new())
     }
 
     pub(crate) fn with_park_coordinator(
-        kill_tx: mpsc::Sender<()>,
+        kill_tx: mpsc::Sender<ProcessTerminationRequest>,
         park_coordinator: ParkCoordinator,
     ) -> Self {
         Self {
@@ -49,15 +49,42 @@ impl ProcessTerminationHandle {
         }
     }
 
-    fn request_terminate(&self) -> TerminateStatus {
+    async fn request_terminate(&self) -> TerminateStatus {
         if !self.park_coordinator.begin_terminate() {
             return TerminateStatus::RefusedIdle;
         }
 
-        match self.kill_tx.try_send(()) {
-            Ok(()) => TerminateStatus::Accepted,
-            Err(mpsc::error::TrySendError::Full(())) => TerminateStatus::Accepted,
-            Err(mpsc::error::TrySendError::Closed(())) => TerminateStatus::AlreadyStopped,
+        let (ack_tx, ack_rx) = oneshot::channel();
+        match self
+            .kill_tx
+            .try_send(ProcessTerminationRequest::with_ack(ack_tx))
+        {
+            Ok(()) => match ack_rx.await {
+                Ok(()) => TerminateStatus::Accepted,
+                Err(_) => TerminateStatus::AlreadyStopped,
+            },
+            Err(mpsc::error::TrySendError::Full(_)) => TerminateStatus::Accepted,
+            Err(mpsc::error::TrySendError::Closed(_)) => TerminateStatus::AlreadyStopped,
+        }
+    }
+}
+
+pub(crate) struct ProcessTerminationRequest {
+    ack: Option<oneshot::Sender<()>>,
+}
+
+impl ProcessTerminationRequest {
+    pub(crate) fn fire_and_forget() -> Self {
+        Self { ack: None }
+    }
+
+    fn with_ack(ack: oneshot::Sender<()>) -> Self {
+        Self { ack: Some(ack) }
+    }
+
+    pub(crate) fn acknowledge(self) {
+        if let Some(ack) = self.ack {
+            let _ = ack.send(());
         }
     }
 }
@@ -342,7 +369,11 @@ async fn handle_connection(
     };
 
     if let Ok(request) = serde_json::from_slice::<TerminateRequest>(&frame) {
-        let response = terminate(request, &termination);
+        let response = tokio::select! {
+            biased;
+            () = shutdown.cancelled() => return Ok(()),
+            response = terminate(request, &termination) => response,
+        };
         return write_json_frame(&mut stream, &response).await;
     }
 
@@ -367,13 +398,13 @@ async fn handle_connection(
     Ok(())
 }
 
-fn terminate(
+async fn terminate(
     request: TerminateRequest,
     termination: &ProcessTerminationHandle,
 ) -> TerminateResponse {
     match request.action {
         TerminateAction::Terminate => TerminateResponse::Status {
-            status: termination.request_terminate(),
+            status: termination.request_terminate().await,
         },
     }
 }
@@ -512,6 +543,15 @@ mod tests {
         )
     }
 
+    async fn recv_termination_request(
+        kill_rx: &mut mpsc::Receiver<ProcessTerminationRequest>,
+    ) -> ProcessTerminationRequest {
+        kill_rx
+            .recv()
+            .await
+            .expect("terminate request should notify process monitor")
+    }
+
     #[tokio::test]
     async fn client_server_no_guest() {
         let dir = tempfile::tempdir().unwrap();
@@ -557,12 +597,17 @@ mod tests {
         .unwrap()
         .spawn(CancellationToken::new());
 
-        let request = TerminateRequest {
-            action: TerminateAction::Terminate,
-        };
-        let response = send_terminate(&sock_path, &request, Duration::from_secs(5))
-            .await
-            .unwrap();
+        let client = tokio::spawn({
+            let sock_path = sock_path.clone();
+            async move {
+                let request = TerminateRequest {
+                    action: TerminateAction::Terminate,
+                };
+                send_terminate(&sock_path, &request, Duration::from_secs(5)).await
+            }
+        });
+        recv_termination_request(&mut kill_rx).await.acknowledge();
+        let response = client.await.unwrap().unwrap();
 
         assert_eq!(
             response,
@@ -570,10 +615,6 @@ mod tests {
                 status: TerminateStatus::Accepted
             }
         );
-        kill_rx
-            .try_recv()
-            .expect("terminate request should notify process monitor");
-
         handle.shutdown().await;
     }
 
@@ -644,62 +685,85 @@ mod tests {
         handle.shutdown().await;
     }
 
-    #[test]
-    fn termination_handle_treats_full_channel_as_accepted() {
+    #[tokio::test]
+    async fn termination_handle_treats_full_channel_as_accepted() {
         let (kill_tx, kill_rx) = mpsc::channel(1);
+        kill_tx
+            .try_send(ProcessTerminationRequest::fire_and_forget())
+            .unwrap();
         let termination = ProcessTerminationHandle::new(kill_tx);
 
-        assert_eq!(termination.request_terminate(), TerminateStatus::Accepted);
-        assert_eq!(termination.request_terminate(), TerminateStatus::Accepted);
+        assert_eq!(
+            termination.request_terminate().await,
+            TerminateStatus::Accepted
+        );
         assert_eq!(kill_rx.len(), 1);
     }
 
-    #[test]
-    fn termination_handle_blocks_future_park_before_queueing_kill() {
-        let (kill_tx, kill_rx) = mpsc::channel(1);
+    #[tokio::test]
+    async fn termination_handle_waits_for_monitor_ack_before_accepting() {
+        let (kill_tx, mut kill_rx) = mpsc::channel(1);
+        let termination = ProcessTerminationHandle::new(kill_tx);
+        let terminate_task = tokio::spawn(async move { termination.request_terminate().await });
+
+        let request = recv_termination_request(&mut kill_rx).await;
+
+        assert!(!terminate_task.is_finished());
+        request.acknowledge();
+        assert_eq!(terminate_task.await.unwrap(), TerminateStatus::Accepted);
+    }
+
+    #[tokio::test]
+    async fn termination_handle_blocks_future_park_before_queueing_kill() {
+        let (kill_tx, mut kill_rx) = mpsc::channel(1);
         let coordinator = ParkCoordinator::new();
         let termination =
             ProcessTerminationHandle::with_park_coordinator(kill_tx, coordinator.clone());
+        let terminate_task = tokio::spawn(async move { termination.request_terminate().await });
 
-        assert_eq!(termination.request_terminate(), TerminateStatus::Accepted);
+        let request = recv_termination_request(&mut kill_rx).await;
         assert_eq!(coordinator.state(), CoordinatorState::Terminating);
         assert!(coordinator.begin_prepare_park().is_err());
-        assert_eq!(kill_rx.len(), 1);
+        assert!(!terminate_task.is_finished());
+        request.acknowledge();
+        assert_eq!(terminate_task.await.unwrap(), TerminateStatus::Accepted);
     }
 
-    #[test]
-    fn termination_handle_accepts_dirty_policy() {
-        let (kill_tx, kill_rx) = mpsc::channel(1);
+    #[tokio::test]
+    async fn termination_handle_accepts_dirty_policy() {
+        let (kill_tx, mut kill_rx) = mpsc::channel(1);
         let coordinator = ParkCoordinator::new();
         coordinator.mark_dirty(DirtyReason::new("transport failed"));
         let termination =
             ProcessTerminationHandle::with_park_coordinator(kill_tx, coordinator.clone());
+        let terminate_task = tokio::spawn(async move { termination.request_terminate().await });
 
-        assert_eq!(termination.request_terminate(), TerminateStatus::Accepted);
+        recv_termination_request(&mut kill_rx).await.acknowledge();
+        assert_eq!(terminate_task.await.unwrap(), TerminateStatus::Accepted);
         assert_eq!(coordinator.state(), CoordinatorState::Terminating);
-        assert_eq!(kill_rx.len(), 1);
     }
 
-    #[test]
-    fn termination_handle_accepts_ready_for_park_policy() {
-        let (kill_tx, kill_rx) = mpsc::channel(1);
+    #[tokio::test]
+    async fn termination_handle_accepts_ready_for_park_policy() {
+        let (kill_tx, mut kill_rx) = mpsc::channel(1);
         let coordinator = ready_for_park_coordinator();
         let termination =
             ProcessTerminationHandle::with_park_coordinator(kill_tx, coordinator.clone());
+        let terminate_task = tokio::spawn(async move { termination.request_terminate().await });
 
-        assert_eq!(termination.request_terminate(), TerminateStatus::Accepted);
+        recv_termination_request(&mut kill_rx).await.acknowledge();
+        assert_eq!(terminate_task.await.unwrap(), TerminateStatus::Accepted);
         assert_eq!(coordinator.state(), CoordinatorState::Terminating);
-        assert_eq!(kill_rx.len(), 1);
     }
 
-    #[test]
-    fn termination_handle_refuses_when_parked_without_queueing() {
+    #[tokio::test]
+    async fn termination_handle_refuses_when_parked_without_queueing() {
         let (kill_tx, kill_rx) = mpsc::channel(1);
         let termination =
             ProcessTerminationHandle::with_park_coordinator(kill_tx, parked_coordinator());
 
         assert_eq!(
-            termination.request_terminate(),
+            termination.request_terminate().await,
             TerminateStatus::RefusedIdle
         );
         assert_eq!(kill_rx.len(), 0);

--- a/crates/sandbox-fc/src/control/server.rs
+++ b/crates/sandbox-fc/src/control/server.rs
@@ -57,14 +57,14 @@ impl ProcessTerminationHandle {
         let (ack_tx, ack_rx) = oneshot::channel();
         match self
             .kill_tx
-            .try_send(ProcessTerminationRequest::with_ack(ack_tx))
+            .send(ProcessTerminationRequest::with_ack(ack_tx))
+            .await
         {
             Ok(()) => match ack_rx.await {
                 Ok(()) => TerminateStatus::Accepted,
                 Err(_) => TerminateStatus::AlreadyStopped,
             },
-            Err(mpsc::error::TrySendError::Full(_)) => TerminateStatus::Accepted,
-            Err(mpsc::error::TrySendError::Closed(_)) => TerminateStatus::AlreadyStopped,
+            Err(_) => TerminateStatus::AlreadyStopped,
         }
     }
 }
@@ -686,18 +686,22 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn termination_handle_treats_full_channel_as_accepted() {
-        let (kill_tx, kill_rx) = mpsc::channel(1);
+    async fn termination_handle_waits_behind_full_channel() {
+        let (kill_tx, mut kill_rx) = mpsc::channel(1);
         kill_tx
             .try_send(ProcessTerminationRequest::fire_and_forget())
             .unwrap();
         let termination = ProcessTerminationHandle::new(kill_tx);
+        let terminate_task = tokio::spawn(async move { termination.request_terminate().await });
 
-        assert_eq!(
-            termination.request_terminate().await,
-            TerminateStatus::Accepted
-        );
-        assert_eq!(kill_rx.len(), 1);
+        let queued_request = recv_termination_request(&mut kill_rx).await;
+
+        assert!(!terminate_task.is_finished());
+        queued_request.acknowledge();
+        let request = recv_termination_request(&mut kill_rx).await;
+        assert!(!terminate_task.is_finished());
+        request.acknowledge();
+        assert_eq!(terminate_task.await.unwrap(), TerminateStatus::Accepted);
     }
 
     #[tokio::test]

--- a/crates/sandbox-fc/src/control/server.rs
+++ b/crates/sandbox-fc/src/control/server.rs
@@ -19,6 +19,7 @@ use super::protocol::{
     TerminateStatus, read_frame, write_frame,
 };
 use crate::guest_operations::{GuestOperationStartError, GuestOperationStartGate};
+use crate::park_coordinator::ParkCoordinator;
 
 const RUNNER_EXEC_CAPTURE_LIMIT_BYTES: u32 = 7 * 1024 * 1024;
 const CONTROL_SERVER_SHUTDOWN_TIMEOUT: Duration = Duration::from_secs(1);
@@ -29,14 +30,30 @@ const CONTROL_HANDLER_SHUTDOWN_GRACE: Duration = Duration::from_millis(250);
 #[derive(Clone)]
 pub(crate) struct ProcessTerminationHandle {
     kill_tx: mpsc::Sender<()>,
+    park_coordinator: ParkCoordinator,
 }
 
 impl ProcessTerminationHandle {
+    #[cfg(test)]
     pub(crate) fn new(kill_tx: mpsc::Sender<()>) -> Self {
-        Self { kill_tx }
+        Self::with_park_coordinator(kill_tx, ParkCoordinator::new())
+    }
+
+    pub(crate) fn with_park_coordinator(
+        kill_tx: mpsc::Sender<()>,
+        park_coordinator: ParkCoordinator,
+    ) -> Self {
+        Self {
+            kill_tx,
+            park_coordinator,
+        }
     }
 
     fn request_terminate(&self) -> TerminateStatus {
+        if !self.park_coordinator.begin_terminate() {
+            return TerminateStatus::RefusedIdle;
+        }
+
         match self.kill_tx.try_send(()) {
             Ok(()) => TerminateStatus::Accepted,
             Err(mpsc::error::TrySendError::Full(())) => TerminateStatus::Accepted,
@@ -444,7 +461,7 @@ mod tests {
         ExecRequest, ExecResponse, TerminateAction, TerminateRequest, TerminateResponse,
         TerminateStatus, send_exec, send_terminate,
     };
-    use crate::park_coordinator::{CoordinatorState, ParkCoordinator};
+    use crate::park_coordinator::{CoordinatorState, ParkCoordinator, PrepareParkEvidence};
 
     fn test_gate(
         guest: Arc<tokio::sync::Mutex<Option<Arc<VsockHost>>>>,
@@ -455,6 +472,16 @@ mod tests {
     fn test_termination_handle() -> ProcessTerminationHandle {
         let (kill_tx, _kill_rx) = mpsc::channel(1);
         ProcessTerminationHandle::new(kill_tx)
+    }
+
+    fn parked_coordinator() -> ParkCoordinator {
+        let coordinator = ParkCoordinator::new();
+        let attempt = coordinator.begin_prepare_park().unwrap();
+        coordinator
+            .complete_prepare_park(&attempt, PrepareParkEvidence::AgentQuiesced)
+            .unwrap();
+        coordinator.mark_parked(&attempt).unwrap();
+        coordinator
     }
 
     fn bind_test_server(
@@ -572,6 +599,41 @@ mod tests {
         handle.shutdown().await;
     }
 
+    #[tokio::test]
+    async fn client_server_terminate_refuses_idle_sandbox() {
+        let dir = tempfile::tempdir().unwrap();
+        let sock_path = dir.path().join("control.sock");
+        let guest = Arc::new(tokio::sync::Mutex::new(None::<Arc<VsockHost>>));
+        let (kill_tx, mut kill_rx) = mpsc::channel(1);
+        let mut handle = bind_server(
+            sock_path.clone(),
+            test_gate(guest),
+            ProcessTerminationHandle::with_park_coordinator(kill_tx, parked_coordinator()),
+        )
+        .unwrap()
+        .spawn(CancellationToken::new());
+
+        let request = TerminateRequest {
+            action: TerminateAction::Terminate,
+        };
+        let response = send_terminate(&sock_path, &request, Duration::from_secs(5))
+            .await
+            .unwrap();
+
+        assert_eq!(
+            response,
+            TerminateResponse::Status {
+                status: TerminateStatus::RefusedIdle
+            }
+        );
+        assert!(matches!(
+            kill_rx.try_recv(),
+            Err(mpsc::error::TryRecvError::Empty)
+        ));
+
+        handle.shutdown().await;
+    }
+
     #[test]
     fn termination_handle_treats_full_channel_as_accepted() {
         let (kill_tx, kill_rx) = mpsc::channel(1);
@@ -580,6 +642,32 @@ mod tests {
         assert_eq!(termination.request_terminate(), TerminateStatus::Accepted);
         assert_eq!(termination.request_terminate(), TerminateStatus::Accepted);
         assert_eq!(kill_rx.len(), 1);
+    }
+
+    #[test]
+    fn termination_handle_blocks_future_park_before_queueing_kill() {
+        let (kill_tx, kill_rx) = mpsc::channel(1);
+        let coordinator = ParkCoordinator::new();
+        let termination =
+            ProcessTerminationHandle::with_park_coordinator(kill_tx, coordinator.clone());
+
+        assert_eq!(termination.request_terminate(), TerminateStatus::Accepted);
+        assert_eq!(coordinator.state(), CoordinatorState::Terminating);
+        assert!(coordinator.begin_prepare_park().is_err());
+        assert_eq!(kill_rx.len(), 1);
+    }
+
+    #[test]
+    fn termination_handle_refuses_when_parked_without_queueing() {
+        let (kill_tx, kill_rx) = mpsc::channel(1);
+        let termination =
+            ProcessTerminationHandle::with_park_coordinator(kill_tx, parked_coordinator());
+
+        assert_eq!(
+            termination.request_terminate(),
+            TerminateStatus::RefusedIdle
+        );
+        assert_eq!(kill_rx.len(), 0);
     }
 
     #[tokio::test]

--- a/crates/sandbox-fc/src/park_coordinator.rs
+++ b/crates/sandbox-fc/src/park_coordinator.rs
@@ -105,6 +105,23 @@ impl ParkCoordinator {
         }
     }
 
+    /// Linearize host-side termination against idle parking.
+    ///
+    /// Once this moves `Open -> Terminating`, future park attempts cannot enter
+    /// `ClosingForPark`, so a terminate request cannot race with the active
+    /// job finalizer parking the sandbox into the idle pool.
+    pub(crate) fn begin_terminate(&self) -> bool {
+        let mut inner = self.inner();
+        match inner.state {
+            CoordinatorState::Open => {
+                inner.state = CoordinatorState::Terminating;
+                true
+            }
+            CoordinatorState::Terminating => true,
+            _ => false,
+        }
+    }
+
     pub(crate) fn mark_dirty(&self, reason: DirtyReason) {
         self.inner().mark_dirty(reason);
     }
@@ -120,6 +137,7 @@ pub(crate) enum CoordinatorState {
     ClosingForPark { attempt_id: ParkAttemptId },
     ReadyForPark { attempt_id: ParkAttemptId },
     Parked,
+    Terminating,
     Dirty { reason: DirtyReason },
 }
 
@@ -321,6 +339,15 @@ mod tests {
             parked.ensure_operation_start_allowed(),
             Err(OperationStartRejection::GateClosed {
                 state: CoordinatorState::Parked
+            })
+        );
+
+        let terminating = ParkCoordinator::new();
+        assert!(terminating.begin_terminate());
+        assert_eq!(
+            terminating.ensure_operation_start_allowed(),
+            Err(OperationStartRejection::GateClosed {
+                state: CoordinatorState::Terminating
             })
         );
 
@@ -557,6 +584,78 @@ mod tests {
             }
 
             assert_eq!(coordinator.state(), CoordinatorState::Open);
+        }
+    }
+
+    #[test]
+    fn terminate_blocks_future_park_attempts() {
+        let coordinator = ParkCoordinator::new();
+
+        assert!(coordinator.begin_terminate());
+        assert!(coordinator.begin_terminate());
+        assert_eq!(coordinator.state(), CoordinatorState::Terminating);
+
+        assert_eq!(
+            coordinator.begin_prepare_park(),
+            Err(PrepareParkError::InvalidState {
+                state: CoordinatorState::Terminating
+            })
+        );
+    }
+
+    #[test]
+    fn terminate_is_refused_after_park_begins() {
+        let coordinator = ParkCoordinator::new();
+        let attempt = begin_attempt(&coordinator);
+
+        assert!(!coordinator.begin_terminate());
+
+        coordinator.abort_prepare_park(&attempt).unwrap();
+        assert!(coordinator.begin_terminate());
+    }
+
+    #[test]
+    fn concurrent_prepare_and_terminate_are_linearized() {
+        for _ in 0..64 {
+            let coordinator = ParkCoordinator::new();
+            let barrier = std::sync::Arc::new(std::sync::Barrier::new(2));
+
+            let prepare_coordinator = coordinator.clone();
+            let prepare_barrier = std::sync::Arc::clone(&barrier);
+            let prepare_thread = std::thread::spawn(move || {
+                prepare_barrier.wait();
+                prepare_coordinator.begin_prepare_park()
+            });
+
+            let terminate_coordinator = coordinator.clone();
+            let terminate_barrier = std::sync::Arc::clone(&barrier);
+            let terminate_thread = std::thread::spawn(move || {
+                terminate_barrier.wait();
+                terminate_coordinator.begin_terminate()
+            });
+
+            let prepare_result = prepare_thread
+                .join()
+                .expect("prepare thread should not panic");
+            let terminate_result = terminate_thread
+                .join()
+                .expect("terminate thread should not panic");
+
+            match (prepare_result, terminate_result) {
+                (Ok(attempt), false) => {
+                    assert!(coordinator.abort_prepare_park(&attempt).is_ok());
+                    assert_eq!(coordinator.state(), CoordinatorState::Open);
+                }
+                (
+                    Err(PrepareParkError::InvalidState {
+                        state: CoordinatorState::Terminating,
+                    }),
+                    true,
+                ) => {
+                    assert_eq!(coordinator.state(), CoordinatorState::Terminating);
+                }
+                other => panic!("unexpected concurrent prepare/terminate result: {other:?}"),
+            }
         }
     }
 

--- a/crates/sandbox-fc/src/park_coordinator.rs
+++ b/crates/sandbox-fc/src/park_coordinator.rs
@@ -107,18 +107,18 @@ impl ParkCoordinator {
 
     /// Linearize host-side termination against idle parking.
     ///
-    /// Once this moves `Open -> Terminating`, future park attempts cannot enter
-    /// `ClosingForPark`, so a terminate request cannot race with the active
-    /// job finalizer parking the sandbox into the idle pool.
+    /// Once this moves the policy to `Terminating`, future or in-flight park
+    /// attempts cannot reach `Parked`, so a terminate request cannot race with
+    /// the active job finalizer transferring ownership to the idle pool.
     pub(crate) fn begin_terminate(&self) -> bool {
         let mut inner = self.inner();
         match inner.state {
-            CoordinatorState::Open => {
+            CoordinatorState::Parked => false,
+            CoordinatorState::Terminating => true,
+            _ => {
                 inner.state = CoordinatorState::Terminating;
                 true
             }
-            CoordinatorState::Terminating => true,
-            _ => false,
         }
     }
 
@@ -232,7 +232,10 @@ impl Inner {
     }
 
     fn mark_dirty(&mut self, reason: DirtyReason) {
-        if matches!(self.state, CoordinatorState::Dirty { .. }) {
+        if matches!(
+            self.state,
+            CoordinatorState::Dirty { .. } | CoordinatorState::Terminating
+        ) {
             return;
         }
 
@@ -604,14 +607,66 @@ mod tests {
     }
 
     #[test]
-    fn terminate_is_refused_after_park_begins() {
+    fn terminate_preempts_in_progress_park() {
         let coordinator = ParkCoordinator::new();
         let attempt = begin_attempt(&coordinator);
 
-        assert!(!coordinator.begin_terminate());
-
-        coordinator.abort_prepare_park(&attempt).unwrap();
         assert!(coordinator.begin_terminate());
+        assert_eq!(coordinator.state(), CoordinatorState::Terminating);
+
+        assert_eq!(
+            coordinator.complete_prepare_park(&attempt, PrepareParkEvidence::AgentQuiesced),
+            Err(PrepareParkError::StaleAttempt {
+                attempt_id: attempt.id,
+                state: CoordinatorState::Terminating,
+            })
+        );
+    }
+
+    #[test]
+    fn terminate_preempts_ready_for_park_before_idle_transfer() {
+        let coordinator = ParkCoordinator::new();
+        let attempt = begin_attempt(&coordinator);
+        complete_attempt(&coordinator, &attempt);
+
+        assert!(coordinator.begin_terminate());
+        assert_eq!(coordinator.state(), CoordinatorState::Terminating);
+        assert_eq!(
+            coordinator.mark_parked(&attempt),
+            Err(PrepareParkError::InvalidState {
+                state: CoordinatorState::Terminating
+            })
+        );
+    }
+
+    #[test]
+    fn terminate_refuses_parked_sandbox() {
+        let coordinator = ParkCoordinator::new();
+        let attempt = begin_attempt(&coordinator);
+        complete_attempt(&coordinator, &attempt);
+        coordinator.mark_parked(&attempt).unwrap();
+
+        assert!(!coordinator.begin_terminate());
+        assert_eq!(coordinator.state(), CoordinatorState::Parked);
+    }
+
+    #[test]
+    fn terminate_accepts_dirty_policy() {
+        let coordinator = ParkCoordinator::new();
+        coordinator.mark_dirty(DirtyReason::new("transport failed"));
+
+        assert!(coordinator.begin_terminate());
+        assert_eq!(coordinator.state(), CoordinatorState::Terminating);
+    }
+
+    #[test]
+    fn dirty_does_not_override_terminating() {
+        let coordinator = ParkCoordinator::new();
+
+        assert!(coordinator.begin_terminate());
+        coordinator.mark_dirty(DirtyReason::new("late park failure"));
+
+        assert_eq!(coordinator.state(), CoordinatorState::Terminating);
     }
 
     #[test]
@@ -642,9 +697,16 @@ mod tests {
                 .expect("terminate thread should not panic");
 
             match (prepare_result, terminate_result) {
-                (Ok(attempt), false) => {
-                    assert!(coordinator.abort_prepare_park(&attempt).is_ok());
-                    assert_eq!(coordinator.state(), CoordinatorState::Open);
+                (Ok(attempt), true) => {
+                    assert_eq!(coordinator.state(), CoordinatorState::Terminating);
+                    assert_eq!(
+                        coordinator
+                            .complete_prepare_park(&attempt, PrepareParkEvidence::AgentQuiesced,),
+                        Err(PrepareParkError::StaleAttempt {
+                            attempt_id: attempt.id,
+                            state: CoordinatorState::Terminating,
+                        })
+                    );
                 }
                 (
                     Err(PrepareParkError::InvalidState {

--- a/crates/sandbox-fc/src/sandbox.rs
+++ b/crates/sandbox-fc/src/sandbox.rs
@@ -424,6 +424,10 @@ impl ProcessMonitorHandle {
         let _ = self.kill_tx.send(());
     }
 
+    fn termination_handle(&self) -> control::ProcessTerminationHandle {
+        control::ProcessTerminationHandle::new(self.kill_tx.clone())
+    }
+
     async fn wait(self) {
         let _ = self.task.await;
     }
@@ -447,6 +451,12 @@ impl SandboxRuntimeHandles {
 
     fn set_balloon(&mut self, balloon: balloon::ControllerHandle) {
         self.balloon = Some(balloon);
+    }
+
+    fn process_termination_handle(&self) -> Option<control::ProcessTerminationHandle> {
+        self.process
+            .as_ref()
+            .map(ProcessMonitorHandle::termination_handle)
     }
 
     fn balloon_mut(&mut self) -> &mut Option<balloon::ControllerHandle> {
@@ -1675,9 +1685,17 @@ impl Sandbox for FirecrackerSandbox {
         *self.guest.lock().await = Some(Arc::new(vsock_guest));
 
         let control_sock_path = self.sock_paths.control_sock();
+        let Some(termination_handle) = self.runtime.process_termination_handle() else {
+            self.guest.lock().await.take();
+            self.runtime.kill_process().await;
+            return Err(SandboxError::Start {
+                message: "process monitor missing before control socket bind".into(),
+            });
+        };
         let control_server = match control::bind_server(
             control_sock_path.clone(),
             self.guest_operation_start_gate(),
+            termination_handle,
         ) {
             Ok(server) => server,
             Err(e) => {
@@ -5538,7 +5556,7 @@ mod tests {
             Arc::clone(&state),
             Arc::clone(&state_publish_lock),
             state_tx,
-            guest,
+            Arc::clone(&guest),
             runtime_cancel.clone(),
         );
 
@@ -5567,12 +5585,6 @@ mod tests {
         let (state_tx, _state_rx) = watch::channel(SandboxState::Running);
         let guest = Arc::new(tokio::sync::Mutex::new(None::<Arc<VsockHost>>));
         let runtime_cancel = CancellationToken::new();
-        let mut control = crate::control::bind_server(
-            sock_path.clone(),
-            GuestOperationStartGate::new(Arc::clone(&guest), ParkCoordinator::new()),
-        )
-        .unwrap()
-        .spawn(runtime_cancel.clone());
         let mut child = monitored_cat_process();
         let stdin = child.stdin.take();
 
@@ -5582,9 +5594,16 @@ mod tests {
             Arc::clone(&state),
             Arc::clone(&state_publish_lock),
             state_tx,
-            guest,
-            runtime_cancel,
+            Arc::clone(&guest),
+            runtime_cancel.clone(),
         );
+        let mut control = crate::control::bind_server(
+            sock_path.clone(),
+            GuestOperationStartGate::new(Arc::clone(&guest), ParkCoordinator::new()),
+            handle.termination_handle(),
+        )
+        .unwrap()
+        .spawn(runtime_cancel.clone());
 
         drop(stdin);
         wait_for_path_removed(&sock_path).await;

--- a/crates/sandbox-fc/src/sandbox.rs
+++ b/crates/sandbox-fc/src/sandbox.rs
@@ -424,8 +424,14 @@ impl ProcessMonitorHandle {
         let _ = self.kill_tx.try_send(());
     }
 
-    fn termination_handle(&self) -> control::ProcessTerminationHandle {
-        control::ProcessTerminationHandle::new(self.kill_tx.clone())
+    fn termination_handle(
+        &self,
+        park_coordinator: ParkCoordinator,
+    ) -> control::ProcessTerminationHandle {
+        control::ProcessTerminationHandle::with_park_coordinator(
+            self.kill_tx.clone(),
+            park_coordinator,
+        )
     }
 
     async fn wait(self) {
@@ -453,10 +459,13 @@ impl SandboxRuntimeHandles {
         self.balloon = Some(balloon);
     }
 
-    fn process_termination_handle(&self) -> Option<control::ProcessTerminationHandle> {
+    fn process_termination_handle(
+        &self,
+        park_coordinator: ParkCoordinator,
+    ) -> Option<control::ProcessTerminationHandle> {
         self.process
             .as_ref()
-            .map(ProcessMonitorHandle::termination_handle)
+            .map(|process| process.termination_handle(park_coordinator))
     }
 
     fn balloon_mut(&mut self) -> &mut Option<balloon::ControllerHandle> {
@@ -1685,7 +1694,10 @@ impl Sandbox for FirecrackerSandbox {
         *self.guest.lock().await = Some(Arc::new(vsock_guest));
 
         let control_sock_path = self.sock_paths.control_sock();
-        let Some(termination_handle) = self.runtime.process_termination_handle() else {
+        let Some(termination_handle) = self
+            .runtime
+            .process_termination_handle(self.park_coordinator.clone())
+        else {
             self.guest.lock().await.take();
             self.runtime.kill_process().await;
             return Err(SandboxError::Start {
@@ -5600,7 +5612,7 @@ mod tests {
         let mut control = crate::control::bind_server(
             sock_path.clone(),
             GuestOperationStartGate::new(Arc::clone(&guest), ParkCoordinator::new()),
-            handle.termination_handle(),
+            handle.termination_handle(ParkCoordinator::new()),
         )
         .unwrap()
         .spawn(runtime_cancel.clone());

--- a/crates/sandbox-fc/src/sandbox.rs
+++ b/crates/sandbox-fc/src/sandbox.rs
@@ -415,13 +415,15 @@ async fn unmount_snapshot_drive_bind_target(path: &Path) -> Result<(), SandboxEr
 }
 
 struct ProcessMonitorHandle {
-    kill_tx: mpsc::Sender<()>,
+    kill_tx: mpsc::Sender<control::ProcessTerminationRequest>,
     task: tokio::task::JoinHandle<()>,
 }
 
 impl ProcessMonitorHandle {
     fn kill(&self) {
-        let _ = self.kill_tx.try_send(());
+        let _ = self
+            .kill_tx
+            .try_send(control::ProcessTerminationRequest::fire_and_forget());
     }
 
     fn termination_handle(
@@ -1390,13 +1392,14 @@ fn monitor_process_with_log_readers(
 ) -> ProcessMonitorHandle {
     let process_group_pid = child.id();
     let id = id.to_owned();
-    let (kill_tx, mut kill_rx) = mpsc::channel(1);
+    let (kill_tx, mut kill_rx) = mpsc::channel::<control::ProcessTerminationRequest>(1);
     let task = tokio::spawn(async move {
         let status = tokio::select! {
             status = child.wait() => status,
             request = kill_rx.recv() => {
-                if request.is_some() {
+                if let Some(request) = request {
                     kill_process_group(&child);
+                    request.acknowledge();
                 }
                 child.wait().await
             }

--- a/crates/sandbox-fc/src/sandbox.rs
+++ b/crates/sandbox-fc/src/sandbox.rs
@@ -1740,7 +1740,8 @@ impl Sandbox for FirecrackerSandbox {
             });
         }
 
-        // Start control socket server for `runner exec`.
+        // Start control socket server for `runner exec` and host-side
+        // termination requests.
         self.runtime
             .set_control(control_server.spawn(runtime_cancel));
 

--- a/crates/sandbox-fc/src/sandbox.rs
+++ b/crates/sandbox-fc/src/sandbox.rs
@@ -415,13 +415,13 @@ async fn unmount_snapshot_drive_bind_target(path: &Path) -> Result<(), SandboxEr
 }
 
 struct ProcessMonitorHandle {
-    kill_tx: mpsc::UnboundedSender<()>,
+    kill_tx: mpsc::Sender<()>,
     task: tokio::task::JoinHandle<()>,
 }
 
 impl ProcessMonitorHandle {
     fn kill(&self) {
-        let _ = self.kill_tx.send(());
+        let _ = self.kill_tx.try_send(());
     }
 
     fn termination_handle(&self) -> control::ProcessTerminationHandle {
@@ -1381,7 +1381,7 @@ fn monitor_process_with_log_readers(
 ) -> ProcessMonitorHandle {
     let process_group_pid = child.id();
     let id = id.to_owned();
-    let (kill_tx, mut kill_rx) = mpsc::unbounded_channel();
+    let (kill_tx, mut kill_rx) = mpsc::channel(1);
     let task = tokio::spawn(async move {
         let status = tokio::select! {
             status = child.wait() => status,

--- a/crates/sandbox-fc/src/sandbox.rs
+++ b/crates/sandbox-fc/src/sandbox.rs
@@ -1400,6 +1400,12 @@ fn monitor_process_with_log_readers(
                 if let Some(request) = request {
                     kill_process_group(&child);
                     request.acknowledge();
+                    kill_rx.close();
+                    // Closed receivers can still observe sends that already
+                    // reserved capacity, so drain through `None` before wait.
+                    while let Some(request) = kill_rx.recv().await {
+                        request.acknowledge();
+                    }
                 }
                 child.wait().await
             }

--- a/crates/sandbox-mock/src/lib.rs
+++ b/crates/sandbox-mock/src/lib.rs
@@ -2,7 +2,8 @@
 //!
 //! All mocks succeed by default with exit code 0 and empty output.
 //! Use [`MockSandbox::push_exec_result`], [`MockSandbox::push_write_file_result`],
-//! or [`MockSandboxControl::push_exec_remote_result`] to queue custom responses
+//! [`MockSandboxControl::push_exec_remote_result`], or
+//! [`MockSandboxControl::push_kill_remote_result`] to queue custom responses
 //! consumed in FIFO order.
 //!
 //! For advanced control, create [`MockSandboxOverrides`] and pass it via
@@ -1430,12 +1431,15 @@ impl SnapshotProvider for MockSnapshotProvider {
 
 /// A mock [`SandboxControl`] for testing exec/kill commands.
 ///
-/// Queue custom results with [`push_exec_remote_result`](Self::push_exec_remote_result).
-/// When the queue is empty, returns exit code 0 with empty output.
+/// Queue custom results with [`push_exec_remote_result`](Self::push_exec_remote_result)
+/// or [`push_kill_remote_result`](Self::push_kill_remote_result).
+/// When queues are empty, exec returns exit code 0 and kill returns accepted.
 pub struct MockSandboxControl {
     base_dir: PathBuf,
     exec_results: Mutex<VecDeque<std::result::Result<RemoteExecResult, SandboxControlError>>>,
+    kill_results: Mutex<VecDeque<std::result::Result<RemoteKillResult, SandboxControlError>>>,
     recorded_commands: Mutex<Vec<String>>,
+    recorded_kill_ids: Mutex<Vec<String>>,
 }
 
 impl MockSandboxControl {
@@ -1443,7 +1447,9 @@ impl MockSandboxControl {
         Self {
             base_dir: base_dir.into(),
             exec_results: Mutex::new(VecDeque::new()),
+            kill_results: Mutex::new(VecDeque::new()),
             recorded_commands: Mutex::new(Vec::new()),
+            recorded_kill_ids: Mutex::new(Vec::new()),
         }
     }
 
@@ -1458,6 +1464,19 @@ impl MockSandboxControl {
     /// Return every command string passed to `exec_remote`, in call order.
     pub fn recorded_commands(&self) -> Vec<String> {
         self.recorded_commands.lock_ignoring_poison().clone()
+    }
+
+    /// Queue a kill remote result. Results are consumed in FIFO order.
+    pub fn push_kill_remote_result(
+        &self,
+        result: std::result::Result<RemoteKillResult, SandboxControlError>,
+    ) {
+        self.kill_results.lock_ignoring_poison().push_back(result);
+    }
+
+    /// Return every sandbox id passed to `kill_remote`, in call order.
+    pub fn recorded_kill_ids(&self) -> Vec<String> {
+        self.recorded_kill_ids.lock_ignoring_poison().clone()
     }
 }
 
@@ -1485,6 +1504,19 @@ impl SandboxControl for MockSandboxControl {
                     stderr_truncated: false,
                 })
             })
+    }
+
+    async fn kill_remote(
+        &self,
+        sandbox_id: &str,
+    ) -> std::result::Result<RemoteKillResult, SandboxControlError> {
+        self.recorded_kill_ids
+            .lock_ignoring_poison()
+            .push(sandbox_id.to_string());
+        self.kill_results
+            .lock_ignoring_poison()
+            .pop_front()
+            .unwrap_or(Ok(RemoteKillResult::Accepted))
     }
 
     fn runtime_dir(&self, sandbox_id: &str) -> PathBuf {
@@ -3023,6 +3055,10 @@ mod tests {
             .unwrap();
         assert_eq!(result.exit_code, 0);
         assert_eq!(
+            control.kill_remote("sandbox-1").await.unwrap(),
+            RemoteKillResult::Accepted
+        );
+        assert_eq!(
             control.runtime_dir("sandbox-1"),
             PathBuf::from("/tmp/test/sandbox-1")
         );
@@ -3084,6 +3120,18 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn sandbox_control_records_kill_ids() {
+        let control = MockSandboxControl::new("/tmp/test");
+        control.kill_remote("sandbox-1").await.unwrap();
+        control.kill_remote("sandbox-2").await.unwrap();
+
+        assert_eq!(
+            control.recorded_kill_ids(),
+            vec!["sandbox-1".to_string(), "sandbox-2".to_string()],
+        );
+    }
+
+    #[tokio::test]
     async fn sandbox_control_queued_results() {
         let control = MockSandboxControl::new("/tmp/test");
         control.push_exec_remote_result(Err(SandboxControlError::NotFound("gone".into())));
@@ -3099,5 +3147,19 @@ mod tests {
             .await
             .unwrap();
         assert_eq!(result.exit_code, 0);
+    }
+
+    #[tokio::test]
+    async fn sandbox_control_queued_kill_results() {
+        let control = MockSandboxControl::new("/tmp/test");
+        control.push_kill_remote_result(Err(SandboxControlError::NotFound("gone".into())));
+
+        let result = control.kill_remote("sandbox-1").await;
+        assert!(result.is_err());
+
+        assert_eq!(
+            control.kill_remote("sandbox-1").await.unwrap(),
+            RemoteKillResult::Accepted
+        );
     }
 }

--- a/crates/sandbox/src/control.rs
+++ b/crates/sandbox/src/control.rs
@@ -18,6 +18,15 @@ pub struct RemoteExecResult {
     pub stderr_truncated: bool,
 }
 
+/// Result of requesting host-side sandbox termination.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum RemoteKillResult {
+    /// The owning sandbox runtime accepted the termination request.
+    Accepted,
+    /// The owning sandbox runtime is already stopping or stopped.
+    AlreadyStopped,
+}
+
 /// Errors from sandbox control operations.
 #[derive(Debug, thiserror::Error)]
 pub enum SandboxControlError {
@@ -51,6 +60,10 @@ pub trait SandboxControl: Send + Sync {
         timeout: Duration,
         sudo: bool,
     ) -> Result<RemoteExecResult, SandboxControlError>;
+
+    /// Request host-side termination of a running sandbox identified by
+    /// sandbox ID (full UUID or unique prefix).
+    async fn kill_remote(&self, sandbox_id: &str) -> Result<RemoteKillResult, SandboxControlError>;
 
     /// Return the runtime socket directory for a given sandbox ID.
     ///

--- a/crates/sandbox/src/control.rs
+++ b/crates/sandbox/src/control.rs
@@ -25,8 +25,8 @@ pub enum RemoteKillResult {
     Accepted,
     /// The owning sandbox runtime is already stopping or stopped.
     AlreadyStopped,
-    /// The owning sandbox is parked or entering idle ownership, so direct
-    /// process termination would leave idle-pool resources retained.
+    /// The owning sandbox is parked in idle ownership, so direct process
+    /// termination would leave idle-pool resources retained.
     RefusedIdle,
 }
 

--- a/crates/sandbox/src/control.rs
+++ b/crates/sandbox/src/control.rs
@@ -47,8 +47,8 @@ pub enum SandboxControlError {
 
 /// Remote control interface for running sandboxes.
 ///
-/// Provides exec and path-resolution capabilities without exposing
-/// backend-specific types (sockets, paths, wire protocol).
+/// Provides exec, host-side termination, and path-resolution capabilities
+/// without exposing backend-specific types (sockets, paths, wire protocol).
 #[async_trait]
 pub trait SandboxControl: Send + Sync {
     /// Execute a command inside a running sandbox identified by sandbox ID

--- a/crates/sandbox/src/control.rs
+++ b/crates/sandbox/src/control.rs
@@ -25,6 +25,9 @@ pub enum RemoteKillResult {
     Accepted,
     /// The owning sandbox runtime is already stopping or stopped.
     AlreadyStopped,
+    /// The owning sandbox is parked or entering idle ownership, so direct
+    /// process termination would leave idle-pool resources retained.
+    RefusedIdle,
 }
 
 /// Errors from sandbox control operations.

--- a/crates/sandbox/src/lib.rs
+++ b/crates/sandbox/src/lib.rs
@@ -30,7 +30,7 @@ pub use config::{
     BlockRateLimits, DeviceRateLimits, FactoryConfig, NetworkRateLimits, ResourceLimits,
     RuntimeConfig, SandboxConfig, SandboxId, SnapshotRef, WorkspaceDriveConfig,
 };
-pub use control::{RemoteExecResult, SandboxControl, SandboxControlError};
+pub use control::{RemoteExecResult, RemoteKillResult, SandboxControl, SandboxControlError};
 pub use error::{
     Result, SandboxError, SandboxIdleTransition, SandboxInitializationPhase,
     SandboxInvalidStateContext, SandboxOperation, SandboxOperationReason,


### PR DESCRIPTION
## Summary
- route managed runner kill requests through the owning sandbox control socket and process monitor
- add Firecracker process identity snapshots and fail-closed orphan kill validation before direct killpg
- gate orphan cleanup on a verified orphan kill and extend control/mock tests

## Tests
- cargo fmt --manifest-path crates/Cargo.toml --all -- --check
- cargo test --manifest-path crates/Cargo.toml -p runner cmd::kill
- cargo test --manifest-path crates/Cargo.toml -p runner process
- cargo test --manifest-path crates/Cargo.toml -p sandbox-fc control
- cargo test --manifest-path crates/Cargo.toml -p sandbox
- cargo test --manifest-path crates/Cargo.toml -p sandbox-mock
- cargo test --manifest-path crates/Cargo.toml -p runner
- cargo test --manifest-path crates/Cargo.toml -p sandbox-fc

Closes #16235