### PR TITLE
[codex] fix billing queue drain after entitlement updates

### DIFF
--- a/turbo/apps/api/src/signals/routes/__tests__/webhooks-third-party.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/webhooks-third-party.test.ts
@@ -6,12 +6,14 @@ import {
   randomUUID,
 } from "node:crypto";
 
+import type { StoredExecutionContext } from "@vm0/api-contracts/contracts/runners";
 import {
   agentComposes,
   agentComposeVersions,
 } from "@vm0/db/schema/agent-compose";
 import { agentSessions } from "@vm0/db/schema/agent-session";
 import { agentRunCallbacks } from "@vm0/db/schema/agent-run-callback";
+import { agentRunQueue } from "@vm0/db/schema/agent-run-queue";
 import { agentRuns } from "@vm0/db/schema/agent-run";
 import { connectorOauthDeviceAuthorizationSessions } from "@vm0/db/schema/connector-oauth-device-authorization-session";
 import { creditExpiresRecord } from "@vm0/db/schema/credit-expires-record";
@@ -45,6 +47,10 @@ import { nowDate } from "../../../lib/time";
 import { server } from "../../../mocks/server";
 import { writeDb$ } from "../../external/db";
 import { mockStripeClient } from "../../external/stripe-client";
+import {
+  encryptQueuedRunnerJobPayload,
+  queuedRunnerJobPayload,
+} from "../../services/agent-run-queue-payload.service";
 import { clearAllDetached } from "../../utils";
 import {
   createFixtureTracker,
@@ -52,6 +58,8 @@ import {
 } from "./helpers/zero-route-test";
 import {
   deleteUsageInsightFixture$,
+  seedCompose$,
+  seedRun$,
   seedUsageInsightFixture$,
   type UsageInsightFixture,
 } from "./helpers/zero-usage-insight";
@@ -751,6 +759,72 @@ async function selectStripeCreditExpiresRecords(
     .where(eq(creditExpiresRecord.orgId, fixture.orgId));
 }
 
+async function seedStripeRun(
+  fixture: StripeFixture,
+  args: {
+    readonly composeId: string;
+    readonly status: string;
+    readonly createdAt?: Date;
+    readonly startedAt?: Date | null;
+  },
+): Promise<string> {
+  const { runId } = await store.set(
+    seedRun$,
+    {
+      orgId: fixture.orgId,
+      userId: fixture.userId,
+      composeId: args.composeId,
+      status: args.status,
+      createdAt: args.createdAt,
+      startedAt: args.startedAt,
+    },
+    context.signal,
+  );
+  return runId;
+}
+
+async function seedStripeQueuedRun(
+  fixture: StripeFixture,
+  args: {
+    readonly composeId: string;
+    readonly createdAt: Date;
+    readonly runnerGroup?: string;
+  },
+): Promise<string> {
+  const db = store.set(writeDb$);
+  const runId = await seedStripeRun(fixture, {
+    composeId: args.composeId,
+    status: "queued",
+    createdAt: args.createdAt,
+  });
+  const runnerGroup = args.runnerGroup ?? "vm0/test";
+  const executionContext = {
+    storageManifest: null,
+    environment: null,
+    resumeSession: null,
+    encryptedSecrets: null,
+    cliAgentType: "codex",
+  } satisfies StoredExecutionContext;
+
+  await db.insert(agentRunQueue).values({
+    runId,
+    orgId: fixture.orgId,
+    userId: fixture.userId,
+    encryptedParams: await encryptQueuedRunnerJobPayload(
+      queuedRunnerJobPayload({
+        runnerGroup,
+        profile: "vm0/default",
+        sessionId: null,
+        executionContext,
+      }),
+    ),
+    createdAt: args.createdAt,
+    expiresAt: new Date(nowDate().getTime() + 60_000),
+  });
+
+  return runId;
+}
+
 const deleteGitHubFixture$ = command(
   async (
     { set },
@@ -942,16 +1016,80 @@ const deleteStripeFixture$ = command(
   async (
     { set },
     fixture: StripeFixture,
-    _signal: AbortSignal,
+    signal: AbortSignal,
   ): Promise<void> => {
     const db = set(writeDb$);
+    const runRows = await db
+      .select({ id: agentRuns.id })
+      .from(agentRuns)
+      .where(
+        and(
+          eq(agentRuns.orgId, fixture.orgId),
+          eq(agentRuns.userId, fixture.userId),
+        ),
+      );
+    signal.throwIfAborted();
+    const runIds = runRows.map((row) => {
+      return row.id;
+    });
+    if (runIds.length > 0) {
+      await db
+        .delete(agentRunQueue)
+        .where(inArray(agentRunQueue.runId, runIds));
+      signal.throwIfAborted();
+      await db
+        .delete(runnerJobQueue)
+        .where(inArray(runnerJobQueue.runId, runIds));
+      signal.throwIfAborted();
+      await db.delete(zeroRuns).where(inArray(zeroRuns.id, runIds));
+      signal.throwIfAborted();
+      await db.delete(agentRuns).where(inArray(agentRuns.id, runIds));
+      signal.throwIfAborted();
+    }
+    await db
+      .delete(agentSessions)
+      .where(
+        and(
+          eq(agentSessions.orgId, fixture.orgId),
+          eq(agentSessions.userId, fixture.userId),
+        ),
+      );
+    signal.throwIfAborted();
+    const composeRows = await db
+      .select({ id: agentComposes.id })
+      .from(agentComposes)
+      .where(
+        and(
+          eq(agentComposes.orgId, fixture.orgId),
+          eq(agentComposes.userId, fixture.userId),
+        ),
+      );
+    signal.throwIfAborted();
+    const composeIds = composeRows.map((row) => {
+      return row.id;
+    });
+    if (composeIds.length > 0) {
+      await db.delete(zeroAgents).where(inArray(zeroAgents.id, composeIds));
+      signal.throwIfAborted();
+      await db
+        .delete(agentComposeVersions)
+        .where(inArray(agentComposeVersions.composeId, composeIds));
+      signal.throwIfAborted();
+      await db
+        .delete(agentComposes)
+        .where(inArray(agentComposes.id, composeIds));
+      signal.throwIfAborted();
+    }
     await db
       .delete(creditExpiresRecord)
       .where(eq(creditExpiresRecord.orgId, fixture.orgId));
+    signal.throwIfAborted();
     await db
       .delete(orgMembersMetadata)
       .where(eq(orgMembersMetadata.orgId, fixture.orgId));
+    signal.throwIfAborted();
     await db.delete(orgMetadata).where(eq(orgMetadata.orgId, fixture.orgId));
+    signal.throwIfAborted();
   },
 );
 
@@ -2748,6 +2886,106 @@ describe("POST /api/webhooks/stripe", () => {
         120_000,
       );
       expect(context.mocks.stripe.subscriptions.cancel).not.toHaveBeenCalled();
+    });
+
+    it("drains queued runs to the new team capacity after a paid invoice", async () => {
+      const fixture = await trackStripe(
+        store.set(seedStripeFixture$, undefined, context.signal),
+      );
+      mockStripeWebhookEnv();
+      const db = store.set(writeDb$);
+      const subId = stripeId("sub");
+      const invId = stripeId("inv");
+      const periodEnd = 1_800_000_000;
+      const now = nowDate();
+      await updateStripeOrg(fixture, {
+        credits: 100_000,
+        tier: "free",
+      });
+      const compose = await store.set(
+        seedCompose$,
+        { orgId: fixture.orgId, userId: fixture.userId },
+        context.signal,
+      );
+      await seedStripeRun(fixture, {
+        composeId: compose.composeId,
+        status: "running",
+        startedAt: now,
+      });
+      const firstQueuedRunId = await seedStripeQueuedRun(fixture, {
+        composeId: compose.composeId,
+        createdAt: new Date(now.getTime() + 1000),
+      });
+      const secondQueuedRunId = await seedStripeQueuedRun(fixture, {
+        composeId: compose.composeId,
+        createdAt: new Date(now.getTime() + 2000),
+      });
+      const queuedRunIds = [firstQueuedRunId, secondQueuedRunId];
+      context.mocks.stripe.subscriptions.retrieve.mockResolvedValue({
+        id: subId,
+        status: "active",
+        cancel_at_period_end: false,
+        items: { data: [{ price: { id: STRIPE_PRICE_TEAM } }] },
+      });
+
+      const response = await postStripeWebhookEvent({
+        type: "invoice.paid",
+        dataObject: {
+          id: invId,
+          customer: fixture.stripeCustomerId,
+          metadata: null,
+          lines: invoiceLinesWithSubscriptionPeriod(periodEnd),
+          parent: { subscription_details: { subscription: subId } },
+        },
+      });
+
+      expect(response.status).toBe(200);
+      expect((await selectStripeBilling(fixture)).tier).toBe("team");
+      const promotedRuns = await db
+        .select({ id: agentRuns.id, status: agentRuns.status })
+        .from(agentRuns)
+        .where(inArray(agentRuns.id, queuedRunIds));
+      const promotedStatuses = new Map(
+        promotedRuns.map((run) => {
+          return [run.id, run.status];
+        }),
+      );
+      expect(promotedStatuses.get(firstQueuedRunId)).toBe("pending");
+      expect(promotedStatuses.get(secondQueuedRunId)).toBe("pending");
+
+      const queueRows = await db
+        .select({ runId: agentRunQueue.runId })
+        .from(agentRunQueue)
+        .where(inArray(agentRunQueue.runId, queuedRunIds));
+      expect(queueRows).toHaveLength(0);
+
+      const runnerJobs = await db
+        .select({ runId: runnerJobQueue.runId })
+        .from(runnerJobQueue)
+        .where(inArray(runnerJobQueue.runId, queuedRunIds));
+      expect(runnerJobs).toHaveLength(2);
+
+      const duplicateQueuedRunId = await seedStripeQueuedRun(fixture, {
+        composeId: compose.composeId,
+        createdAt: new Date(now.getTime() + 3000),
+      });
+      const duplicateResponse = await postStripeWebhookEvent({
+        type: "invoice.paid",
+        dataObject: {
+          id: invId,
+          customer: fixture.stripeCustomerId,
+          metadata: null,
+          lines: invoiceLinesWithSubscriptionPeriod(periodEnd),
+          parent: { subscription_details: { subscription: subId } },
+        },
+      });
+      expect(duplicateResponse.status).toBe(200);
+      const [duplicateRun] = await db
+        .select({ status: agentRuns.status })
+        .from(agentRuns)
+        .where(eq(agentRuns.id, duplicateQueuedRunId))
+        .limit(1);
+      expect(duplicateRun?.status).toBe("pending");
     });
 
     it("cancels the replaced Pro subscription after the Team invoice is paid", async () => {

--- a/turbo/apps/api/src/signals/services/webhooks-stripe.service.ts
+++ b/turbo/apps/api/src/signals/services/webhooks-stripe.service.ts
@@ -17,6 +17,7 @@ import {
   tierForKnownPriceId,
   tierFromPriceId,
 } from "./zero-billing-checkout.service";
+import { drainOrgQueueToCapacity$ } from "./zero-run-queue.service";
 
 const L = logger("WebhookStripe");
 
@@ -103,6 +104,11 @@ interface SubscriptionInvoiceDetails {
   readonly credits: number;
   readonly periodEndDate: Date;
   readonly expiresAt: Date;
+}
+
+interface PaidWebhookOutcome {
+  readonly handled: boolean;
+  readonly drainOrgId: string | null;
 }
 
 function subscriptionPeriodEnd(subscription: SubscriptionInput): Date | null {
@@ -390,10 +396,10 @@ async function expireCredits(tx: WriteTx, orgId: string): Promise<number> {
 async function handleAutoRechargeInvoicePaid(
   db: Db,
   invoice: Pick<InvoiceInput, "id" | "metadata">,
-): Promise<boolean> {
+): Promise<PaidWebhookOutcome> {
   const metadata = invoice.metadata;
   if (!metadata || metadata.type !== "auto_recharge") {
-    return false;
+    return { handled: false, drainOrgId: null };
   }
 
   const orgId = metadata.orgId;
@@ -403,34 +409,36 @@ async function handleAutoRechargeInvoicePaid(
       invoiceId: invoice.id,
       metadata,
     });
-    return false;
+    return { handled: false, drainOrgId: null };
   }
 
-  const granted = await db.transaction(async (tx) => {
-    const inserted = await createExpiresRecord(tx, orgId, {
-      source: "auto_recharge",
-      stripeInvoiceId: invoice.id,
-      amount: creditsAmount,
-      expiresAt: autoRechargeNeverExpiresAt(),
-    });
-
-    if (!inserted) {
-      L.debug("Auto-recharge invoice already processed", {
-        orgId,
-        invoiceId: invoice.id,
+  const grantResult = await db.transaction(
+    async (tx): Promise<"duplicate" | "granted"> => {
+      const inserted = await createExpiresRecord(tx, orgId, {
+        source: "auto_recharge",
+        stripeInvoiceId: invoice.id,
+        amount: creditsAmount,
+        expiresAt: autoRechargeNeverExpiresAt(),
       });
-      return false;
-    }
 
-    await grantOrgCredits(tx, orgId, creditsAmount);
-    await tx
-      .update(orgMetadata)
-      .set({ autoRechargePendingAt: null, updatedAt: nowDate() })
-      .where(eq(orgMetadata.orgId, orgId));
-    return true;
-  });
+      if (!inserted) {
+        L.debug("Auto-recharge invoice already processed", {
+          orgId,
+          invoiceId: invoice.id,
+        });
+        return "duplicate";
+      }
 
-  if (granted) {
+      await grantOrgCredits(tx, orgId, creditsAmount);
+      await tx
+        .update(orgMetadata)
+        .set({ autoRechargePendingAt: null, updatedAt: nowDate() })
+        .where(eq(orgMetadata.orgId, orgId));
+      return "granted";
+    },
+  );
+
+  if (grantResult === "granted") {
     L.debug("Auto-recharge credits granted", {
       orgId,
       creditsAmount,
@@ -438,13 +446,13 @@ async function handleAutoRechargeInvoicePaid(
     });
   }
 
-  return true;
+  return { handled: true, drainOrgId: orgId };
 }
 
 async function handleOneTimePurchaseCompleted(
   db: Db,
   session: CheckoutSessionInput,
-): Promise<void> {
+): Promise<string | null> {
   const metadata = session.metadata ?? {};
   const orgId = metadata.orgId;
   const campaignKey = metadata.campaignKey;
@@ -455,7 +463,7 @@ async function handleOneTimePurchaseCompleted(
       hasOrgId: Boolean(orgId),
       hasCampaignKey: Boolean(campaignKey),
     });
-    return;
+    return null;
   }
 
   const campaign = getCampaign(campaignKey);
@@ -464,7 +472,7 @@ async function handleOneTimePurchaseCompleted(
       sessionId: session.id,
       campaignKey,
     });
-    return;
+    return null;
   }
 
   const expiresAt = new Date(
@@ -489,12 +497,14 @@ async function handleOneTimePurchaseCompleted(
 
     await grantOrgCredits(tx, orgId, campaign.credits);
   });
+
+  return orgId;
 }
 
 async function handleCreditPurchaseCompleted(
   db: Db,
   session: CheckoutSessionInput,
-): Promise<void> {
+): Promise<string | null> {
   const metadata = session.metadata ?? {};
   const orgId = metadata.orgId;
   const creditsAmount = creditPurchaseAmount(session);
@@ -505,7 +515,7 @@ async function handleCreditPurchaseCompleted(
       hasOrgId: Boolean(orgId),
       creditsAmount: metadata.creditsAmount ?? null,
     });
-    return;
+    return null;
   }
 
   await db.transaction(async (tx) => {
@@ -526,15 +536,17 @@ async function handleCreditPurchaseCompleted(
 
     await grantOrgCredits(tx, orgId, creditsAmount);
   });
+
+  return orgId;
 }
 
 async function handlePaidCheckoutPurpose(
   db: Db,
   session: CheckoutSessionInput,
   purpose: "credit_purchase" | "one_time_purchase",
-): Promise<boolean> {
+): Promise<PaidWebhookOutcome> {
   if (session.metadata?.purpose !== purpose) {
-    return false;
+    return { handled: false, drainOrgId: null };
   }
 
   if (session.payment_status !== "paid") {
@@ -542,16 +554,15 @@ async function handlePaidCheckoutPurpose(
       sessionId: session.id,
       paymentStatus: session.payment_status ?? null,
     });
-    return true;
+    return { handled: true, drainOrgId: null };
   }
 
-  if (purpose === "credit_purchase") {
-    await handleCreditPurchaseCompleted(db, session);
-  } else {
-    await handleOneTimePurchaseCompleted(db, session);
-  }
+  const drainOrgId =
+    purpose === "credit_purchase"
+      ? await handleCreditPurchaseCompleted(db, session)
+      : await handleOneTimePurchaseCompleted(db, session);
 
-  return true;
+  return { handled: true, drainOrgId };
 }
 
 function checkoutSubscriptionContext(
@@ -1035,10 +1046,10 @@ async function processSubscriptionInvoicePaid(
     readonly orgId: string;
     readonly details: SubscriptionInvoiceDetails;
   },
-): Promise<void> {
+): Promise<boolean> {
   const lockedOrg = await lockInvoicePaidOrg(tx, args.orgId);
   if (!lockedOrg) {
-    return;
+    return false;
   }
   const replacedSubscriptionId = replacedProSubscriptionId({
     currentSubscriptionId: lockedOrg.stripeSubscriptionId,
@@ -1061,7 +1072,7 @@ async function processSubscriptionInvoicePaid(
       invoiceId: args.invoice.id,
       orgId: args.orgId,
     });
-    return;
+    return true;
   }
 
   if (
@@ -1084,7 +1095,7 @@ async function processSubscriptionInvoicePaid(
         targetTier: args.details.tier,
       }),
     });
-    return;
+    return false;
   }
 
   const trialingExistingSubscription =
@@ -1108,7 +1119,7 @@ async function processSubscriptionInvoicePaid(
       subscriptionId: args.subscriptionId,
       details: args.details,
     });
-    return;
+    return true;
   }
 
   await expireCredits(tx, args.orgId);
@@ -1124,7 +1135,7 @@ async function processSubscriptionInvoicePaid(
       invoiceId: args.invoice.id,
       orgId: args.orgId,
     });
-    return;
+    return true;
   }
 
   await grantOrgCredits(tx, args.orgId, args.details.credits);
@@ -1142,23 +1153,34 @@ async function processSubscriptionInvoicePaid(
     targetTier: args.details.tier,
     knownOldSubscriptionId: replacedSubscriptionId,
   });
+  return true;
 }
 
 async function handleCheckoutCompleted(
   db: Db,
   session: CheckoutSessionInput,
-): Promise<void> {
-  if (await handlePaidCheckoutPurpose(db, session, "credit_purchase")) {
-    return;
+): Promise<string | null> {
+  const creditPurchaseResult = await handlePaidCheckoutPurpose(
+    db,
+    session,
+    "credit_purchase",
+  );
+  if (creditPurchaseResult.handled) {
+    return creditPurchaseResult.drainOrgId;
   }
 
-  if (await handlePaidCheckoutPurpose(db, session, "one_time_purchase")) {
-    return;
+  const oneTimePurchaseResult = await handlePaidCheckoutPurpose(
+    db,
+    session,
+    "one_time_purchase",
+  );
+  if (oneTimePurchaseResult.handled) {
+    return oneTimePurchaseResult.drainOrgId;
   }
 
   const checkoutContext = checkoutSubscriptionContext(session);
   if (!checkoutContext) {
-    return;
+    return null;
   }
   const { customerId, subscriptionId } = checkoutContext;
 
@@ -1169,6 +1191,7 @@ async function handleCheckoutCompleted(
     subscription,
     source: "checkout.session.completed",
   });
+  return null;
 }
 
 async function handleSubscriptionCreated(
@@ -1190,10 +1213,13 @@ async function handleSubscriptionCreated(
   });
 }
 
-async function handleInvoicePaid(db: Db, invoice: InvoiceInput): Promise<void> {
-  const handled = await handleAutoRechargeInvoicePaid(db, invoice);
-  if (handled) {
-    return;
+async function handleInvoicePaid(
+  db: Db,
+  invoice: InvoiceInput,
+): Promise<string | null> {
+  const autoRechargeResult = await handleAutoRechargeInvoicePaid(db, invoice);
+  if (autoRechargeResult.handled) {
+    return autoRechargeResult.drainOrgId;
   }
 
   const subscriptionId = subscriptionIdFromInvoice(invoice);
@@ -1201,13 +1227,13 @@ async function handleInvoicePaid(db: Db, invoice: InvoiceInput): Promise<void> {
     L.warn("invoice.paid without subscription; skipping", {
       invoiceId: invoice.id,
     });
-    return;
+    return null;
   }
 
   const customerId = customerIdFromInvoice(invoice);
   if (!customerId) {
     L.warn("invoice.paid without customer ID", { invoiceId: invoice.id });
-    return;
+    return null;
   }
 
   const org = await invoicePaidOrgForCustomerOrMetadata(db, {
@@ -1219,7 +1245,7 @@ async function handleInvoicePaid(db: Db, invoice: InvoiceInput): Promise<void> {
       customerId,
       invoiceId: invoice.id,
     });
-    return;
+    return null;
   }
 
   if (org.lastProcessedInvoiceId === invoice.id) {
@@ -1235,7 +1261,7 @@ async function handleInvoicePaid(db: Db, invoice: InvoiceInput): Promise<void> {
       invoiceId: invoice.id,
       orgId: org.orgId,
     });
-    return;
+    return org.orgId;
   }
 
   const details = await subscriptionInvoiceDetails(invoice, {
@@ -1243,11 +1269,11 @@ async function handleInvoicePaid(db: Db, invoice: InvoiceInput): Promise<void> {
     orgId: org.orgId,
   });
   if (!details) {
-    return;
+    return null;
   }
 
-  await db.transaction(async (tx) => {
-    await processSubscriptionInvoicePaid(tx, {
+  const processed = await db.transaction(async (tx) => {
+    return await processSubscriptionInvoicePaid(tx, {
       invoice,
       customerId,
       subscriptionId,
@@ -1255,6 +1281,7 @@ async function handleInvoicePaid(db: Db, invoice: InvoiceInput): Promise<void> {
       details,
     });
   });
+  return processed ? org.orgId : null;
 }
 
 async function handleSubscriptionUpdated(
@@ -1402,21 +1429,22 @@ async function handleSubscriptionDeleted(
 export const handleStripeWebhookEvent$ = command(
   async ({ set }, event: Stripe.Event, signal: AbortSignal): Promise<void> => {
     const db = set(writeDb$);
+    let drainOrgId: string | null = null;
     L.debug("stripe webhook received", { type: event.type, id: event.id });
 
     switch (event.type) {
       case "checkout.session.completed": {
-        await handleCheckoutCompleted(db, event.data.object);
+        drainOrgId = await handleCheckoutCompleted(db, event.data.object);
         signal.throwIfAborted();
         break;
       }
       case "checkout.session.async_payment_succeeded": {
-        await handleCheckoutCompleted(db, event.data.object);
+        drainOrgId = await handleCheckoutCompleted(db, event.data.object);
         signal.throwIfAborted();
         break;
       }
       case "invoice.paid": {
-        await handleInvoicePaid(db, event.data.object);
+        drainOrgId = await handleInvoicePaid(db, event.data.object);
         signal.throwIfAborted();
         break;
       }
@@ -1456,5 +1484,9 @@ export const handleStripeWebhookEvent$ = command(
     }
 
     signal.throwIfAborted();
+    if (drainOrgId) {
+      await set(drainOrgQueueToCapacity$, { orgId: drainOrgId }, signal);
+      signal.throwIfAborted();
+    }
   },
 );

--- a/turbo/apps/api/src/signals/services/zero-run-queue.service.ts
+++ b/turbo/apps/api/src/signals/services/zero-run-queue.service.ts
@@ -24,6 +24,7 @@ import {
   publishThreadListChanged,
   publishUserSignal,
 } from "../external/realtime";
+import { env } from "../../lib/env";
 import { logger } from "../../lib/log";
 import { decryptQueuedRunnerJobPayload } from "./agent-run-queue-payload.service";
 import { loadUserFeatureSwitchContext } from "./feature-switches.service";
@@ -46,11 +47,22 @@ const TIER_CONCURRENCY_LIMITS: Readonly<Record<OrgTier, number>> =
     team: 10,
   });
 
-function tierLimit(tier: OrgTier | null | undefined): number {
+function effectiveOrgConcurrencyLimit(
+  tier: OrgTier | null | undefined,
+): number {
   if (!tier) {
     return TIER_CONCURRENCY_LIMITS["pro-suspend"];
   }
-  return TIER_CONCURRENCY_LIMITS[tier];
+  const tierLimit = TIER_CONCURRENCY_LIMITS[tier];
+  if (tierLimit === 0) {
+    return 0;
+  }
+
+  const cap = env("CONCURRENT_RUN_LIMIT_CAP");
+  if (cap === 0) {
+    return Number.POSITIVE_INFINITY;
+  }
+  return cap === undefined ? tierLimit : Math.min(tierLimit, cap);
 }
 
 type DbTransaction = Parameters<Parameters<Db["transaction"]>[0]>[0];
@@ -138,7 +150,9 @@ async function loadDrainCandidates(
       .from(orgMetadata)
       .where(eq(orgMetadata.orgId, orgId))
       .limit(1);
-    const limit = tierLimit(orgRow?.tier as OrgTier | null | undefined);
+    const limit = effectiveOrgConcurrencyLimit(
+      orgRow?.tier as OrgTier | null | undefined,
+    );
 
     const staleThreshold = new Date(now() - PENDING_RUN_TTL_MS);
     const [activeRow] = await tx
@@ -194,7 +208,9 @@ async function promoteQueuedCandidate(
       .from(orgMetadata)
       .where(eq(orgMetadata.orgId, args.orgId))
       .limit(1);
-    const limit = tierLimit(orgRow?.tier as OrgTier | null | undefined);
+    const limit = effectiveOrgConcurrencyLimit(
+      orgRow?.tier as OrgTier | null | undefined,
+    );
 
     const staleThreshold = new Date(now() - PENDING_RUN_TTL_MS);
     const [activeRow] = await tx
@@ -418,6 +434,24 @@ export const drainOrgQueue$ = command(
     }
 
     return 0;
+  },
+);
+
+export const drainOrgQueueToCapacity$ = command(
+  async (
+    { set },
+    args: { readonly orgId: string },
+    signal: AbortSignal,
+  ): Promise<number> => {
+    let drained = 0;
+    while (true) {
+      const promoted = await set(drainOrgQueue$, args, signal);
+      signal.throwIfAborted();
+      if (promoted === 0) {
+        return drained;
+      }
+      drained += promoted;
+    }
   },
 );
 


### PR DESCRIPTION
## Summary
- drain org run queues after paid Stripe entitlement or credit updates finish
- drain repeatedly until the org reaches its effective concurrency capacity
- keep duplicate paid webhook deliveries eligible to retry queue drain
- add a Stripe webhook regression test for team upgrade queue promotion and duplicate invoice redelivery

Fixes #16190

## Verification
- pnpm format
- pnpm -F @vm0/db db:migrate
- pnpm -F api exec vitest run src/signals/routes/__tests__/webhooks-third-party.test.ts
- pnpm -F api check-types
- pnpm -F api lint
- pnpm knip --workspace api
- pnpm check-types
- pre-commit: prettier, knip --cache, check-types