### PR TITLE
fix(api): block claude loop skill in zero runs

### DIFF
--- a/turbo/apps/api/src/signals/routes/__tests__/zero-runs-create.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/zero-runs-create.test.ts
@@ -681,6 +681,8 @@ describe("POST /api/zero/runs", () => {
       "CronDelete",
       "ScheduleWakeup",
       "AskUserQuestion",
+      "Skill(loop)",
+      "Skill(loop *)",
     ]);
     expect(executionContext.environment.ZERO_AGENT_ID).toBe(agent.agentId);
 

--- a/turbo/apps/api/src/signals/services/zero-runs-create.service.ts
+++ b/turbo/apps/api/src/signals/services/zero-runs-create.service.ts
@@ -41,6 +41,8 @@ const DISALLOWED_TOOLS = [
   "CronDelete",
   "ScheduleWakeup",
   "AskUserQuestion",
+  "Skill(loop)",
+  "Skill(loop *)",
 ] as const;
 
 const TONE_INSTRUCTIONS: Readonly<Record<string, string>> = {


### PR DESCRIPTION
## Summary
- block Claude Code's bundled `loop` skill in Zero runtime permissions
- keep existing cron and schedule tools disallowed as the scheduling safety net
- update Zero run context coverage for the expanded disallowed tool list

Closes #16186

## Testing
- `pnpm -F @vm0/db db:migrate`
- `pnpm -F api exec vitest src/signals/routes/__tests__/zero-runs-create.test.ts -t "creates a zero run and injects zero-specific runner context"`
- `pnpm -F api exec vitest src/signals/routes/__tests__/zero-runs-create.test.ts`
- `pnpm -F api lint`
- `pnpm -F api check-types`
- pre-commit: prettier, knip, turbo check-types
