### PR TITLE
ci: cache pnpm for cli deploy

### DIFF
--- a/.github/workflows/turbo.yml
+++ b/.github/workflows/turbo.yml
@@ -1462,6 +1462,14 @@ jobs:
       )
     steps:
       - uses: actions/checkout@v6
+      - uses: pnpm/action-setup@v6
+        with:
+          version: 10.33.4
+      - uses: actions/setup-node@v6
+        with:
+          node-version: 22
+          cache: pnpm
+          cache-dependency-path: turbo/pnpm-lock.yaml
       - name: Configure git safe directory
         run: git config --global --add safe.directory "$GITHUB_WORKSPACE"
       - name: Install CLI dependencies
@@ -1494,7 +1502,7 @@ jobs:
           done
           echo "CLI package verification passed"
       - name: Deploy CLI with production dependencies
-        run: cd turbo && pnpm deploy --filter @vm0/cli --prod --legacy --config.node-linker=hoisted /tmp/cli-deploy
+        run: cd turbo && pnpm deploy --filter @vm0/cli --prod --legacy --config.node-linker=hoisted --config.ignore-scripts=true /tmp/cli-deploy
       - name: Smoke test deployed CLI
         shell: bash
         run: |


### PR DESCRIPTION
## Summary

- add pnpm setup and setup-node pnpm cache to the `build-cli` job
- skip deploy-time lifecycle scripts during `pnpm deploy` with `--config.ignore-scripts=true`
- keep the existing legacy hoisted deploy shape and smoke tests intact

Fixes #16299
Refs #15905

## Validation

Local workflow-like validation from `turbo`:

```text
pnpm install --frozen-lockfile --filter @vm0/cli -> 3s
pnpm --filter @vm0/cli build -> 25s
pnpm deploy --filter @vm0/cli --prod --legacy --config.node-linker=hoisted --config.ignore-scripts=true /tmp/cli-deploy-pr-16299 -> 6s
node /tmp/cli-deploy-pr-16299/dist/index.js --help -> passed
node /tmp/cli-deploy-pr-16299/dist/zero.js --help -> passed
```

## CI timing to watch

After this PR run completes, compare the `build-cli` job duration and especially the `Deploy CLI with production dependencies` step against the recent baseline of roughly 65s for the whole job on run `26999346664`.
