### PR TITLE
test: decouple usage tracking tests from metadata sentinel

### DIFF
--- a/crates/runner/mitm-addon/tests/test_counters.py
+++ b/crates/runner/mitm-addon/tests/test_counters.py
@@ -5,7 +5,6 @@ from unittest.mock import MagicMock, patch
 
 import pytest
 
-import mitm_addon
 import usage
 from tests.pending_helpers import assert_pending
 
@@ -359,41 +358,6 @@ class TestUsagePendingCounter:
         assert usage.webhook._pending_delivery_payload_count_for_tests() == 0
         usage.write_pending_snapshot(flush_request_id="request-1")
         assert_pending(pending_path, flows=0, buffered=0, reports=0, flush_request_id="request-1")
-
-    def test_decorator_pop_prevents_double_decrement(self, tmp_path, real_flow):
-        """If both response() and error() fire for the same flow, decrement only once."""
-        usage.set_pending_path(str(tmp_path / "usage-pending"))
-        usage.increment_in_flight_flows()
-        assert usage.counters._in_flight_flows == 1
-
-        flow = real_flow(with_response=False)
-        flow.metadata["_usage_flow_tracked"] = True
-
-        # Simulate response() followed by error() on the same flow.
-        @mitm_addon._track_usage_flow
-        def fake_handler(f):
-            pass
-
-        fake_handler(flow)  # first call: pops flag, decrements
-        assert usage.counters._in_flight_flows == 0
-
-        fake_handler(flow)  # second call: flag already popped, no decrement
-        assert usage.counters._in_flight_flows == 0  # stays at 0, not -1
-
-    def test_untracked_flow_not_decremented(self, tmp_path, real_flow):
-        """Flows without _usage_flow_tracked should not touch the counter."""
-        usage.set_pending_path(str(tmp_path / "usage-pending"))
-        usage.increment_in_flight_flows()  # simulate one tracked flow in flight
-
-        flow = real_flow(with_response=False)
-        # No _usage_flow_tracked in metadata — this is a regular flow.
-
-        @mitm_addon._track_usage_flow
-        def fake_handler(f):
-            pass
-
-        fake_handler(flow)
-        assert usage.counters._in_flight_flows == 1  # unchanged
 
     def test_sync_fallback_decrements_reports(
         self, tmp_path, real_flow, fresh_usage_executor, usage_webhook_api

--- a/crates/runner/mitm-addon/tests/test_model_provider_stream_usage.py
+++ b/crates/runner/mitm-addon/tests/test_model_provider_stream_usage.py
@@ -16,6 +16,7 @@ import response_streaming
 import usage
 from tests.flow_helpers import header_map, response_stream
 from tests.pending_helpers import assert_pending
+from tests.request_handler_helpers import _single_firewall_vm, _write_registry
 
 _WebSocketTrimCallback = Callable[[http.HTTPFlow], None]
 _ScheduledWebSocketTrim = tuple[_WebSocketTrimCallback, http.HTTPFlow]
@@ -41,6 +42,44 @@ def _openai_model_websocket_flow(
 
     mitm_addon.responseheaders(flow)
     return flow
+
+
+def _write_openai_model_websocket_registry(tmp_path: Path) -> Path:
+    firewall_name = "model-provider:openai-api-key"
+    return _write_registry(
+        tmp_path,
+        vm_info=_single_firewall_vm(
+            tmp_path,
+            run_id="run-abc-123",
+            sandbox_marker="tok-xyz",
+            firewall_name=firewall_name,
+            api_entry={
+                "base": "https://api.openai.com",
+                "auth": {"headers": {"Authorization": "Bearer token"}},
+                "permissions": [{"name": "responses", "rules": ["POST /v1/responses"]}],
+            },
+            network_policy={
+                "allow": ["responses"],
+                "deny": [],
+                "ask": [],
+                "unknownPolicy": "deny",
+            },
+            billable_firewalls=[firewall_name],
+            vm_fields={"cliAgentType": "codex"},
+        ),
+    )
+
+
+def _openai_model_websocket_request_flow(
+    real_flow: Callable[..., http.HTTPFlow],
+) -> http.HTTPFlow:
+    return real_flow(
+        with_response=False,
+        client_ip="10.200.0.5",
+        host="api.openai.com",
+        path="/v1/responses",
+        method="POST",
+    )
 
 
 def _model_provider_sse_flow(
@@ -523,26 +562,41 @@ class TestModelProviderStreamUsage:
             "tokens.cache_read": 10,
         }
 
-    def test_model_websocket_response_keeps_usage_flow_tracked_until_end(self, tmp_path, real_flow):
+    async def test_model_websocket_response_keeps_usage_flow_tracked_until_end(
+        self,
+        tmp_path,
+        real_flow,
+        mitm_ctx,
+        fake_firewall_headers,
+        usage_webhook_server,
+    ):
         """The HTTP 101 response hook must not complete the WebSocket usage lifecycle."""
         pending_path = tmp_path / "usage-pending"
         usage.set_pending_path(str(pending_path), usage_state_id="test-usage-state-id")
-        usage.increment_in_flight_flows()
+        reg_path = _write_openai_model_websocket_registry(tmp_path)
 
-        flow = _openai_model_websocket_flow(tmp_path, real_flow)
-        flow.metadata["_usage_flow_tracked"] = True
-        usage.write_pending_snapshot(flush_request_id="before-response")
-        assert_pending(
-            pending_path,
-            flows=1,
-            buffered=0,
-            reports=0,
-            flush_request_id="before-response",
-        )
+        flow = _openai_model_websocket_request_flow(real_flow)
 
-        with self._usage_webhook_api() as webhook:
+        with (
+            mitm_ctx(registry_path=str(reg_path), api_url=usage_webhook_server.api_url),
+            fake_firewall_headers(),
+        ):
+            await mitm_addon.request(flow)
+            usage.write_pending_snapshot(flush_request_id="before-response")
+            assert_pending(
+                pending_path,
+                flows=1,
+                buffered=0,
+                reports=0,
+                flush_request_id="before-response",
+            )
+
+            flow.response = tutils.tresp(
+                status_code=101,
+                headers=http.Headers(upgrade="websocket"),
+            )
+            mitm_addon.responseheaders(flow)
             mitm_addon.response(flow)
-            assert flow.metadata["_usage_flow_tracked"] is True
             usage.write_pending_snapshot(flush_request_id="after-response")
             assert_pending(
                 pending_path,
@@ -572,14 +626,18 @@ class TestModelProviderStreamUsage:
             mitm_addon.websocket_end(flow)
             usage.flush_usage_events(trigger="test")
 
-        events = webhook.usage_events()
+        events = usage_webhook_server.usage_events()
+        assert len(events) == 3
         by_category = {event["category"]: event["quantity"] for event in events}
         assert by_category == {
             "tokens.input": 40,
             "tokens.output": 20,
             "tokens.cache_read": 10,
         }
-        assert "_usage_flow_tracked" not in flow.metadata
+        observation_events = usage_webhook_server.model_usage_observation_events()
+        assert len(observation_events) == len(events)
+        assert {event["category"]: event["quantity"] for event in observation_events} == by_category
+        assert {event["model"] for event in observation_events} == {"gpt-5.5"}
         usage.write_pending_snapshot(flush_request_id="after-websocket-end")
         assert_pending(
             pending_path,
@@ -587,6 +645,81 @@ class TestModelProviderStreamUsage:
             buffered=0,
             reports=0,
             flush_request_id="after-websocket-end",
+        )
+
+    async def test_model_websocket_error_releases_usage_flow_after_upgrade(
+        self,
+        tmp_path,
+        real_flow,
+        mitm_ctx,
+        fake_firewall_headers,
+        usage_webhook_server,
+    ):
+        """A WebSocket connection error after HTTP 101 is terminal for usage tracking."""
+        pending_path = tmp_path / "usage-pending"
+        usage.set_pending_path(str(pending_path), usage_state_id="test-usage-state-id")
+        reg_path = _write_openai_model_websocket_registry(tmp_path)
+
+        flow = _openai_model_websocket_request_flow(real_flow)
+
+        with (
+            mitm_ctx(registry_path=str(reg_path), api_url=usage_webhook_server.api_url),
+            fake_firewall_headers(),
+        ):
+            await mitm_addon.request(flow)
+            flow.response = tutils.tresp(
+                status_code=101,
+                headers=http.Headers(upgrade="websocket"),
+            )
+            mitm_addon.responseheaders(flow)
+            mitm_addon.response(flow)
+            usage.write_pending_snapshot(flush_request_id="after-response")
+            assert_pending(
+                pending_path,
+                flows=1,
+                buffered=0,
+                reports=0,
+                flush_request_id="after-response",
+            )
+
+            _feed_websocket_server_message(
+                flow,
+                json.dumps(
+                    {
+                        "type": "response.completed",
+                        "response": {
+                            "id": "resp_ws_error",
+                            "model": "gpt-5.5",
+                            "usage": {
+                                "input_tokens": 10,
+                                "output_tokens": 4,
+                            },
+                        },
+                    }
+                ).encode(),
+            )
+            flow.error = Error("connection reset by peer")
+            mitm_addon.error(flow)
+            usage.flush_usage_events(trigger="test")
+
+        events = usage_webhook_server.usage_events()
+        assert len(events) == 2
+        by_category = {event["category"]: event["quantity"] for event in events}
+        assert by_category == {
+            "tokens.input": 10,
+            "tokens.output": 4,
+        }
+        observation_events = usage_webhook_server.model_usage_observation_events()
+        assert len(observation_events) == len(events)
+        assert {event["category"]: event["quantity"] for event in observation_events} == by_category
+        assert {event["model"] for event in observation_events} == {"gpt-5.5"}
+        usage.write_pending_snapshot(flush_request_id="after-error")
+        assert_pending(
+            pending_path,
+            flows=0,
+            buffered=0,
+            reports=0,
+            flush_request_id="after-error",
         )
 
     def test_full_pipeline_model_websocket_zero_frame_preserves_billed_usage_and_id(

--- a/crates/runner/mitm-addon/tests/test_request_handler_firewall_dispatch.py
+++ b/crates/runner/mitm-addon/tests/test_request_handler_firewall_dispatch.py
@@ -8,6 +8,8 @@ import pytest
 import auth
 import flow_metadata_keys as metadata_keys
 import mitm_addon
+import usage
+from tests.pending_helpers import assert_pending
 from tests.request_handler_helpers import (
     _single_firewall_vm,
     _write_github_firewall_registry,
@@ -502,6 +504,8 @@ async def test_browser_firewall_match_skips_auth_injection(
     tmp_path, real_flow, mitm_ctx, fake_firewall_headers, headers
 ):
     """Browser-looking UAs pass through without connector auth mutation."""
+    pending_path = tmp_path / "usage-pending"
+    usage.set_pending_path(str(pending_path), usage_state_id="test-usage-state-id")
     reg_path = _write_registry(
         tmp_path,
         vm_info=_single_firewall_vm(
@@ -554,7 +558,14 @@ async def test_browser_firewall_match_skips_auth_injection(
     assert "firewall_api_id" not in flow.metadata
     assert "auth_resolved_secrets" not in flow.metadata
     assert "auth_url_rewrite" not in flow.metadata
-    assert "_usage_flow_tracked" not in flow.metadata
+    usage.write_pending_snapshot(flush_request_id="browser-passthrough")
+    assert_pending(
+        pending_path,
+        flows=0,
+        buffered=0,
+        reports=0,
+        flush_request_id="browser-passthrough",
+    )
 
     flow.response = mitm_addon.http.Response.make(200)
     mitm_addon.response(flow)

--- a/crates/runner/mitm-addon/tests/test_request_handler_usage_tracking.py
+++ b/crates/runner/mitm-addon/tests/test_request_handler_usage_tracking.py
@@ -93,6 +93,63 @@ def usage_pending_path(tmp_path: Path) -> Iterator[Path]:
         usage.counters.reset_for_tests()
 
 
+def _write_billable_tracking_registry(tmp_path: Path) -> Path:
+    firewall_name = "model-provider:anthropic-api-key"
+    return _write_registry(
+        tmp_path,
+        vm_info=_single_firewall_vm(
+            tmp_path,
+            firewall_name=firewall_name,
+            api_entry={
+                "base": "https://api.anthropic.com",
+                "auth": {"headers": {"x-api-key": "test-key"}},
+                "permissions": [{"name": "messages", "rules": ["POST /v1/messages"]}],
+            },
+            network_policy={
+                "allow": ["messages"],
+                "deny": [],
+                "ask": [],
+                "unknownPolicy": "deny",
+            },
+            billable_firewalls=[firewall_name],
+        ),
+    )
+
+
+def _write_non_billable_tracking_registry(tmp_path: Path) -> Path:
+    registry_dir = tmp_path / "non-billable-registry"
+    registry_dir.mkdir()
+    firewall_name = "model-provider:anthropic-api-key"
+    return _write_registry(
+        registry_dir,
+        vm_info=_single_firewall_vm(
+            registry_dir,
+            firewall_name=firewall_name,
+            api_entry={
+                "base": "https://api.anthropic.com",
+                "auth": {"headers": {"x-api-key": "test-key"}},
+                "permissions": [{"name": "messages", "rules": ["POST /v1/messages"]}],
+            },
+            network_policy={
+                "allow": ["messages"],
+                "deny": [],
+                "ask": [],
+                "unknownPolicy": "deny",
+            },
+        ),
+    )
+
+
+def _billable_tracking_flow(real_flow):
+    return real_flow(
+        with_response=False,
+        client_ip="10.200.0.5",
+        host="api.anthropic.com",
+        path="/v1/messages",
+        method="POST",
+    )
+
+
 async def test_billable_flow_is_tracked_before_responseheaders(
     tmp_path,
     usage_pending_path,
@@ -132,7 +189,6 @@ async def test_billable_flow_is_tracked_before_responseheaders(
     ):
         await mitm_addon.request(flow)
 
-    assert flow.metadata["_usage_flow_tracked"] is True
     usage.write_pending_snapshot(flush_request_id="request-1")
     assert_pending(
         usage_pending_path,
@@ -181,7 +237,6 @@ async def test_billable_flow_error_releases_tracking_after_request(
     ):
         await mitm_addon.request(flow)
 
-        assert flow.metadata["_usage_flow_tracked"] is True
         usage.write_pending_snapshot(flush_request_id="request-1")
         assert_pending(
             usage_pending_path,
@@ -194,7 +249,6 @@ async def test_billable_flow_error_releases_tracking_after_request(
         flow.error = Error("connection reset")
         mitm_addon.error(flow)
 
-    assert "_usage_flow_tracked" not in flow.metadata
     assert metadata_keys.HTTP_REQUEST_START_MONOTONIC not in flow.metadata
     usage.write_pending_snapshot(flush_request_id="request-1")
     assert_pending(
@@ -206,7 +260,137 @@ async def test_billable_flow_error_releases_tracking_after_request(
     )
 
 
-async def test_local_firewall_error_does_not_track_usage_flow(
+async def test_duplicate_terminal_hooks_do_not_double_decrement_usage_flow(
+    tmp_path,
+    usage_pending_path,
+    real_flow,
+    mitm_ctx,
+    fake_firewall_headers,
+):
+    """Duplicate terminal hooks release a tracked flow at most once."""
+    reg_path = _write_billable_tracking_registry(tmp_path)
+    first_flow = _billable_tracking_flow(real_flow)
+    second_flow = _billable_tracking_flow(real_flow)
+
+    with (
+        mitm_ctx(registry_path=str(reg_path), api_url="https://api.vm0.ai"),
+        fake_firewall_headers(),
+    ):
+        await mitm_addon.request(first_flow)
+        await mitm_addon.request(second_flow)
+
+        usage.write_pending_snapshot(flush_request_id="before-terminal-hooks")
+        assert_pending(
+            usage_pending_path,
+            flows=2,
+            buffered=0,
+            reports=0,
+            flush_request_id="before-terminal-hooks",
+        )
+
+        first_flow.response = mitm_addon.http.Response.make(200)
+        mitm_addon.response(first_flow)
+        usage.write_pending_snapshot(flush_request_id="after-response")
+        assert_pending(
+            usage_pending_path,
+            flows=1,
+            buffered=0,
+            reports=0,
+            flush_request_id="after-response",
+        )
+
+        first_flow.error = Error("connection reset")
+        mitm_addon.error(first_flow)
+        usage.write_pending_snapshot(flush_request_id="after-duplicate-error")
+        assert_pending(
+            usage_pending_path,
+            flows=1,
+            buffered=0,
+            reports=0,
+            flush_request_id="after-duplicate-error",
+        )
+
+        second_flow.response = mitm_addon.http.Response.make(200)
+        mitm_addon.response(second_flow)
+
+    usage.write_pending_snapshot(flush_request_id="after-all-terminal-hooks")
+    assert_pending(
+        usage_pending_path,
+        flows=0,
+        buffered=0,
+        reports=0,
+        flush_request_id="after-all-terminal-hooks",
+    )
+
+
+async def test_untracked_terminal_hook_does_not_decrement_other_usage_flow(
+    tmp_path,
+    usage_pending_path,
+    real_flow,
+    mitm_ctx,
+    fake_firewall_headers,
+):
+    """A terminal hook for an untracked flow leaves other tracked flows in flight."""
+    billable_reg_path = _write_billable_tracking_registry(tmp_path)
+    non_billable_reg_path = _write_non_billable_tracking_registry(tmp_path)
+    tracked_flow = _billable_tracking_flow(real_flow)
+    untracked_flow = _billable_tracking_flow(real_flow)
+
+    with (
+        mitm_ctx(registry_path=str(billable_reg_path), api_url="https://api.vm0.ai"),
+        fake_firewall_headers(),
+    ):
+        await mitm_addon.request(tracked_flow)
+        usage.write_pending_snapshot(flush_request_id="before-untracked-error")
+        assert_pending(
+            usage_pending_path,
+            flows=1,
+            buffered=0,
+            reports=0,
+            flush_request_id="before-untracked-error",
+        )
+
+    with (
+        mitm_ctx(registry_path=str(non_billable_reg_path), api_url="https://api.vm0.ai"),
+        fake_firewall_headers(),
+    ):
+        await mitm_addon.request(untracked_flow)
+        assert untracked_flow.metadata["firewall_billable"] is False
+        usage.write_pending_snapshot(flush_request_id="after-untracked-request")
+        assert_pending(
+            usage_pending_path,
+            flows=1,
+            buffered=0,
+            reports=0,
+            flush_request_id="after-untracked-request",
+        )
+
+        untracked_flow.error = Error("connection reset")
+        mitm_addon.error(untracked_flow)
+        usage.write_pending_snapshot(flush_request_id="after-untracked-error")
+        assert_pending(
+            usage_pending_path,
+            flows=1,
+            buffered=0,
+            reports=0,
+            flush_request_id="after-untracked-error",
+        )
+
+    with mitm_ctx(registry_path=str(billable_reg_path), api_url="https://api.vm0.ai"):
+        tracked_flow.response = mitm_addon.http.Response.make(200)
+        mitm_addon.response(tracked_flow)
+
+    usage.write_pending_snapshot(flush_request_id="after-tracked-response")
+    assert_pending(
+        usage_pending_path,
+        flows=0,
+        buffered=0,
+        reports=0,
+        flush_request_id="after-tracked-response",
+    )
+
+
+async def test_local_firewall_error_leaves_usage_flows_drained(
     tmp_path, usage_pending_path, real_flow, mitm_ctx, headers
 ):
     """Local auth failures do not enqueue usage and must not leak drain counters."""
@@ -241,7 +425,6 @@ async def test_local_firewall_error_does_not_track_usage_flow(
     assert flow.response is not None
     assert flow.response.status_code == 502
     assert flow.metadata["firewall_error"] == "auth_unavailable"
-    assert "_usage_flow_tracked" not in flow.metadata
     usage.write_pending_snapshot(flush_request_id="request-1")
     assert_pending(
         usage_pending_path,
@@ -280,15 +463,25 @@ async def test_unexpected_request_exception_releases_tracking(
         with_response=False, client_ip="10.200.0.5", host="api.x.com", path="/2/users/by"
     )
 
+    async def return_invalid_auth_after_tracking(*_args, **_kwargs):
+        usage.write_pending_snapshot(flush_request_id="during-auth-failure")
+        assert_pending(
+            usage_pending_path,
+            flows=1,
+            buffered=0,
+            reports=0,
+            flush_request_id="during-auth-failure",
+        )
+        return {}
+
     with (
         mitm_ctx(registry_path=str(reg_path), api_url="https://api.vm0.ai"),
-        patch.object(auth, "get_firewall_headers", AsyncMock(return_value={})),
+        patch.object(auth, "get_firewall_headers", return_invalid_auth_after_tracking),
         pytest.raises(KeyError),
     ):
         await mitm_addon.request(flow)
 
     assert metadata_keys.HTTP_REQUEST_START_MONOTONIC not in flow.metadata
-    assert "_usage_flow_tracked" not in flow.metadata
     usage.write_pending_snapshot(flush_request_id="request-1")
     assert_pending(
         usage_pending_path,
@@ -347,7 +540,6 @@ async def test_non_billable_model_provider_is_not_tracked_before_responseheaders
     assert flow.metadata["firewall_name"] == firewall_name
     assert flow.metadata["cli_agent_type"] == "claude-code"
     assert flow.metadata["firewall_billable"] is False
-    assert "_usage_flow_tracked" not in flow.metadata
     usage.write_pending_snapshot(flush_request_id="request-1")
     assert_pending(
         usage_pending_path,
@@ -402,7 +594,6 @@ async def test_non_billable_observable_model_provider_is_tracked_before_response
     assert flow.metadata["firewall_name"] == firewall_name
     assert flow.metadata["firewall_billable"] is False
     assert flow.metadata["model_usage_provider"] == "claude-sonnet-4-6"
-    assert flow.metadata["_usage_flow_tracked"] is True
     usage.write_pending_snapshot(flush_request_id="request-1")
     assert_pending(
         usage_pending_path,
@@ -462,7 +653,6 @@ async def test_billable_model_provider_records_model_usage_provider(
     assert flow.metadata["cli_agent_type"] == "codex"
     assert flow.metadata["firewall_billable"] is True
     assert flow.metadata["model_usage_provider"] == "claude-opus-4-6"
-    assert flow.metadata["_usage_flow_tracked"] is True
     usage.write_pending_snapshot(flush_request_id="request-1")
     assert_pending(
         usage_pending_path,
@@ -537,7 +727,6 @@ async def test_billable_auth_url_rewrite_flow_drains_after_response(
             await _wait_for_forward_start(probe, request_task)
 
             assert probe.calls == 1
-            assert flow.metadata["_usage_flow_tracked"] is True
             usage.write_pending_snapshot(flush_request_id="request-1")
             assert_pending(
                 usage_pending_path,
@@ -555,7 +744,6 @@ async def test_billable_auth_url_rewrite_flow_drains_after_response(
 
         assert flow.response is not None
         assert flow.metadata["auth_url_rewrite"] is True
-        assert flow.metadata["_usage_flow_tracked"] is True
         usage.write_pending_snapshot(flush_request_id="request-1")
         assert_pending(
             usage_pending_path,
@@ -567,7 +755,6 @@ async def test_billable_auth_url_rewrite_flow_drains_after_response(
 
         mitm_addon.response(flow)
 
-    assert "_usage_flow_tracked" not in flow.metadata
     usage.write_pending_snapshot(flush_request_id="request-1")
     assert_pending(
         usage_pending_path,
@@ -640,7 +827,6 @@ async def test_billable_auth_url_rewrite_forward_failure_releases_tracking(
             await _wait_for_forward_start(probe, request_task)
 
             assert probe.calls == 1
-            assert flow.metadata["_usage_flow_tracked"] is True
             usage.write_pending_snapshot(flush_request_id="request-1")
             assert_pending(
                 usage_pending_path,
@@ -660,7 +846,6 @@ async def test_billable_auth_url_rewrite_forward_failure_releases_tracking(
     assert flow.response.status_code == 502
     assert flow.metadata["firewall_error"] == "url_rewrite_forward_failed"
     assert "auth_url_rewrite" not in flow.metadata
-    assert "_usage_flow_tracked" not in flow.metadata
     usage.write_pending_snapshot(flush_request_id="request-1")
     assert_pending(
         usage_pending_path,


### PR DESCRIPTION
## Summary

- Remove mitm-addon test assertions against the private `_usage_flow_tracked` metadata sentinel.
- Replace private decorator/counter tests with real request/response/error hook lifecycle coverage using pending usage snapshots.
- Rework the model WebSocket lifecycle coverage so tracking is established through `request()`, HTTP 101 keeps the flow in flight, and both `websocket_end()` and `error()` release/report through the real hook path.
- Cover browser passthrough and model observation webhook counts with public behavior assertions.

## Verification

- `python3 -m pytest tests/test_request_handler_usage_tracking.py tests/test_model_provider_stream_usage.py tests/test_request_handler_firewall_dispatch.py tests/test_counters.py` (85 passed)
- `python3 -m ruff check tests/test_request_handler_usage_tracking.py tests/test_model_provider_stream_usage.py tests/test_request_handler_firewall_dispatch.py tests/test_counters.py`
- `rg -n '"_usage_flow_tracked"|_track_usage_flow' tests/test_request_handler_usage_tracking.py tests/test_model_provider_stream_usage.py tests/test_request_handler_firewall_dispatch.py tests/test_counters.py` (expected no output)
- `git diff --check`

Closes #16238