### PR TITLE
fix: reject incomplete memory summaries

### DIFF
--- a/turbo/apps/api/src/signals/external/openrouter.ts
+++ b/turbo/apps/api/src/signals/external/openrouter.ts
@@ -11,6 +11,8 @@ interface OpenRouterMessage {
 
 interface OpenRouterResponse {
   readonly choices: readonly {
+    readonly finish_reason: string | null;
+    readonly native_finish_reason?: string | null;
     readonly message: {
       readonly content: string;
     };
@@ -62,7 +64,20 @@ export async function generateText(
   }
 
   const data = (await response.json()) as OpenRouterResponse;
-  const content = data.choices[0]?.message.content.trim();
+  const choice = data.choices[0];
+  if (!choice) {
+    throw new Error("OpenRouter returned no choices");
+  }
+  if (choice.finish_reason !== "stop") {
+    const nativeReason = choice.native_finish_reason
+      ? ` (native: ${choice.native_finish_reason})`
+      : "";
+    throw new Error(
+      `OpenRouter completion finished with ${choice.finish_reason ?? "unknown"}${nativeReason}`,
+    );
+  }
+
+  const content = choice.message.content.trim();
   if (!content) {
     throw new Error("OpenRouter returned empty content");
   }

--- a/turbo/apps/api/src/signals/routes/__tests__/cron-summarize-memory.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/cron-summarize-memory.test.ts
@@ -402,7 +402,10 @@ async function findItems(summaryId: string): Promise<string[]> {
   });
 }
 
-function mockLlm(content = "Today Zero learned one new thing about you."): {
+function mockLlm(
+  content = "Today Zero learned one new thing about you.",
+  finishReason = "stop",
+): {
   calls: number;
   requests: OpenRouterRequestBody[];
 } {
@@ -415,7 +418,9 @@ function mockLlm(content = "Today Zero learned one new thing about you."): {
     http.post(OPENROUTER_URL, async ({ request }) => {
       state.calls++;
       state.requests.push((await request.json()) as OpenRouterRequestBody);
-      return HttpResponse.json({ choices: [{ message: { content } }] });
+      return HttpResponse.json({
+        choices: [{ finish_reason: finishReason, message: { content } }],
+      });
     }),
   );
   return state;
@@ -634,6 +639,28 @@ describe("GET /api/cron/summarize-memory", () => {
     );
 
     expect(response.body).toStrictEqual({ summarized: 7 });
+    const summary = await findSummary(seeded.fixture);
+    expect(summary?.summary).toBeNull();
+    await expect(findItems(summary?.id ?? "")).resolves.toHaveLength(2);
+  });
+
+  it("persists deterministic items with a null summary when the LLM response is incomplete", async () => {
+    const llm = mockLlm(
+      "Zero learned about a runner claim bug followed by a",
+      "length",
+    );
+    const seeded = await seedTwoVersions(
+      [{ path: "facts/pets.md", content: "Has a dog" }],
+      [{ path: "facts/coffee.md", content: "Drinks oat milk lattes" }],
+    );
+
+    const response = await accept(
+      apiClient().summarize({ headers: cronHeaders() }),
+      [200],
+    );
+
+    expect(response.body).toStrictEqual({ summarized: 7 });
+    expect(llm.calls).toBe(1);
     const summary = await findSummary(seeded.fixture);
     expect(summary?.summary).toBeNull();
     await expect(findItems(summary?.id ?? "")).resolves.toHaveLength(2);


### PR DESCRIPTION
## Summary
- reject OpenRouter text completions whose `finish_reason` is not `stop`
- keep memory activity from persisting partial LLM summaries by letting the cron fall back to `summary: null`
- add regression coverage for an incomplete memory summary response

Closes #16307

## Tests
- `pnpm -F api exec vitest run src/signals/routes/__tests__/cron-summarize-memory.test.ts`
- `pnpm exec prettier --write apps/api/src/signals/external/openrouter.ts apps/api/src/signals/routes/__tests__/cron-summarize-memory.test.ts`
- `pnpm -F api lint`
- `pnpm -F api check-types`