### PR TITLE
fix: strip guest-agent reqwest urls from logs

### DIFF
--- a/crates/guest-agent/src/http.rs
+++ b/crates/guest-agent/src/http.rs
@@ -23,6 +23,10 @@ const LOG_TAG: &str = "sandbox:guest-agent";
 const HTTP_TOO_MANY_REQUESTS: u16 = 429;
 const DEFAULT_RETRY_DELAY: Duration = Duration::from_secs(1);
 
+fn format_reqwest_error(error: reqwest::Error) -> String {
+    error.without_url().to_string()
+}
+
 /// Shared guest-agent HTTP client.
 ///
 /// API-enabled runs build this during initialization and pass cheap clones to
@@ -261,10 +265,11 @@ where
                     "HTTP {label} failed (attempt {attempt}/{max_retries}): HTTP {status}",
                 );
             }
-            Err(e) => {
+            Err(error) => {
+                let error = format_reqwest_error(error);
                 log_warn!(
                     LOG_TAG,
-                    "HTTP {label} failed (attempt {attempt}/{max_retries}): {e}"
+                    "HTTP {label} failed (attempt {attempt}/{max_retries}): {error}"
                 );
             }
         }
@@ -340,7 +345,7 @@ impl HttpClient {
         let text = resp
             .text()
             .await
-            .map_err(|e| AgentError::Http(e.to_string()))?;
+            .map_err(|error| AgentError::Http(format_reqwest_error(error)))?;
         if text.is_empty() {
             return Ok(None);
         }

--- a/crates/guest-agent/tests/integration/presigned_upload.rs
+++ b/crates/guest-agent/tests/integration/presigned_upload.rs
@@ -154,6 +154,46 @@ async fn put_presigned_429_retries() {
     mock.delete_async().await;
 }
 
+#[tokio::test]
+async fn put_presigned_transport_error_does_not_log_presigned_url() {
+    let _guard = TEST_MUTEX.lock().unwrap();
+
+    let tmp = tempfile::tempdir().unwrap();
+    let system_log_path = tmp.path().join("system.log");
+    let system_log_path = system_log_path.to_string_lossy().into_owned();
+    let _system_log_guard = SystemLogOverrideGuard::set(&system_log_path);
+
+    let signature = "super-secret-signature";
+    let url =
+        format!("http://127.0.0.1:0/upload?X-Amz-Signature={signature}&X-Amz-Credential=test");
+    let result = http_client!()
+        .put_presigned(
+            &url,
+            Bytes::from_static(b"secret upload"),
+            "application/octet-stream",
+        )
+        .await;
+
+    assert!(result.is_err());
+    let system_log = std::fs::read_to_string(&system_log_path).unwrap();
+    assert!(
+        system_log.contains("HTTP PUT presigned failed (attempt 1/3)"),
+        "system log should keep retry context, got: {system_log}"
+    );
+    assert!(
+        !system_log.contains(&url),
+        "system log leaked full presigned URL: {system_log}"
+    );
+    assert!(
+        !system_log.contains("X-Amz-Signature"),
+        "system log leaked presigned query key: {system_log}"
+    );
+    assert!(
+        !system_log.contains(signature),
+        "system log leaked presigned signature: {system_log}"
+    );
+}
+
 // =========================================================================
 // put_presigned_file (streaming upload)
 // =========================================================================


### PR DESCRIPTION
## Summary

- Strip related URLs before formatting `reqwest::Error` values in the guest-agent HTTP module.
- Apply the safe formatter to retry send-error logs and `post_json` response body read errors.
- Add a presigned upload regression test that captures the guest system log and verifies secret-bearing query values are not logged.

Closes #16277

## Tests

- `cargo test --manifest-path crates/Cargo.toml -p guest-agent --test integration put_presigned_transport_error_does_not_log_presigned_url -- --nocapture`
- `cargo test --manifest-path crates/Cargo.toml -p guest-agent --test integration presigned`
- `cargo fmt --manifest-path crates/Cargo.toml --package guest-agent`
- `cargo test --manifest-path crates/Cargo.toml -p guest-agent`
- `cargo clippy --manifest-path crates/Cargo.toml -p guest-agent --all-targets -- -D warnings`
- `git diff --check`

Pre-commit also passed crates `cargo-fmt`, `cargo-clippy`, and `cargo-doc` via lefthook.
