### PR TITLE
feat: preserve hosted artifact kind

### DIFF
--- a/turbo/apps/api/src/signals/routes/__tests__/zero-host.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/zero-host.test.ts
@@ -471,4 +471,91 @@ describe("POST /api/zero/host/deployments/:deploymentId/complete", () => {
       },
     });
   });
+
+  it("records presentation html artifact metadata when requested", async () => {
+    const fixture = await seedHostedSiteFixture();
+    const { composeId } = await store.set(
+      seedCompose$,
+      { orgId: fixture.orgId, userId: fixture.userId },
+      context.signal,
+    );
+    const { runId } = await store.set(
+      seedRun$,
+      {
+        orgId: fixture.orgId,
+        userId: fixture.userId,
+        composeId,
+        triggerSource: "cli",
+        status: "completed",
+      },
+      context.signal,
+    );
+    mocks.clerk.session(fixture.userId, fixture.orgId);
+
+    const client = setupApp({ context })(zeroHostContract);
+    const prepared = await accept(
+      client.prepare({
+        headers: { authorization: "Bearer clerk-session" },
+        body: {
+          site: "deck-site",
+          slugSuffix: "release-01",
+          artifactKind: "presentation-html",
+          spaFallback: false,
+          files: validFiles(),
+        },
+      }),
+      [200],
+    );
+
+    await store
+      .set(writeDb$)
+      .update(hostedDeployments)
+      .set({ runId })
+      .where(eq(hostedDeployments.id, prepared.body.deploymentId));
+
+    const prefix = `sites/${prepared.body.publicSlug}/deployments/${prepared.body.deploymentId}`;
+    mockUploadedKeys([
+      `${prefix}/index.html`,
+      `${prefix}/assets/index-a1b2c3d4.js`,
+    ]);
+
+    const completed = await accept(
+      client.complete({
+        params: { deploymentId: prepared.body.deploymentId },
+        headers: { authorization: "Bearer clerk-session" },
+        body: {},
+      }),
+      [200],
+    );
+
+    const [deployment] = await store
+      .set(writeDb$)
+      .select()
+      .from(hostedDeployments)
+      .where(eq(hostedDeployments.id, prepared.body.deploymentId));
+    expect(deployment?.manifest).toMatchObject({
+      artifactKind: "presentation-html",
+    });
+
+    const artifactRows = await store
+      .set(writeDb$)
+      .select()
+      .from(runUploadedFiles)
+      .where(eq(runUploadedFiles.runId, runId));
+    expect(artifactRows).toHaveLength(1);
+    expect(artifactRows[0]?.metadata).toMatchObject({
+      generatedBy: "zero-official-website",
+      artifactKind: "presentation-html",
+      publicSlug: prepared.body.publicSlug,
+      deploymentId: prepared.body.deploymentId,
+      entrypoint: "/index.html",
+      spaFallback: false,
+    });
+    expect(artifactRows[0]).toMatchObject({
+      externalId: completed.body.url,
+      filename: `${prepared.body.publicSlug}.html`,
+      contentType: "text/html",
+      url: completed.body.url,
+    });
+  });
 });

--- a/turbo/apps/api/src/signals/services/run-uploaded-files.service.ts
+++ b/turbo/apps/api/src/signals/services/run-uploaded-files.service.ts
@@ -1,4 +1,5 @@
 import { command } from "ccstate";
+import type { HostedArtifactKind } from "@vm0/api-contracts/contracts/zero-host";
 import { eq, sql } from "drizzle-orm";
 import { chatMessages } from "@vm0/db/schema/chat-message";
 import { chatThreads } from "@vm0/db/schema/chat-thread";
@@ -29,6 +30,7 @@ interface RecordHostedSiteArtifactArgs {
   readonly runId: string | null | undefined;
   readonly userId: string;
   readonly orgId: string;
+  readonly artifactKind: HostedArtifactKind;
   readonly siteId: string;
   readonly deploymentId: string;
   readonly publicSlug: string;
@@ -143,7 +145,7 @@ export const recordHostedSiteArtifact$ = command(
         url: args.url,
         metadata: {
           generatedBy: "zero-official-website",
-          artifactKind: "hosted-site",
+          artifactKind: args.artifactKind,
           siteId: args.siteId,
           deploymentId: args.deploymentId,
           publicSlug: args.publicSlug,
@@ -167,7 +169,7 @@ export const recordHostedSiteArtifact$ = command(
           url: args.url,
           metadata: {
             generatedBy: "zero-official-website",
-            artifactKind: "hosted-site",
+            artifactKind: args.artifactKind,
             siteId: args.siteId,
             deploymentId: args.deploymentId,
             publicSlug: args.publicSlug,

--- a/turbo/apps/api/src/signals/services/zero-host.service.ts
+++ b/turbo/apps/api/src/signals/services/zero-host.service.ts
@@ -1,7 +1,10 @@
 import { createHash } from "node:crypto";
 
 import { command } from "ccstate";
-import type { HostedSitePrepareRequest } from "@vm0/api-contracts/contracts/zero-host";
+import type {
+  HostedArtifactKind,
+  HostedSitePrepareRequest,
+} from "@vm0/api-contracts/contracts/zero-host";
 import {
   hostedDeployments,
   hostedSites,
@@ -232,6 +235,7 @@ function buildManifest(args: {
   readonly deploymentId: string;
   readonly siteId: string;
   readonly publicSlug: string;
+  readonly artifactKind: HostedArtifactKind;
   readonly spaFallback: boolean;
   readonly files: readonly HostedSitePrepareRequest["files"][number][];
   readonly createdAt: Date;
@@ -252,16 +256,19 @@ function buildManifest(args: {
     siteId: args.siteId,
     publicSlug: args.publicSlug,
     createdAt: args.createdAt.toISOString(),
+    artifactKind: args.artifactKind,
     spaFallback: args.spaFallback,
     files: manifestFiles,
   };
 }
 
 function hostedSiteArtifactArgs(deployment: HostedDeploymentRow) {
+  const artifactKind = deployment.manifest.artifactKind ?? "hosted-site";
   return {
     runId: deployment.runId,
     userId: deployment.userId,
     orgId: deployment.orgId,
+    artifactKind,
     siteId: deployment.siteId,
     deploymentId: deployment.id,
     publicSlug: deployment.manifest.publicSlug,
@@ -324,6 +331,7 @@ function createHostedSiteDeployment(
       deploymentId,
       siteId: site.id,
       publicSlug: context.publicSlug,
+      artifactKind: args.body.artifactKind,
       spaFallback: args.body.spaFallback,
       files: args.body.files,
       createdAt: context.now,

--- a/turbo/apps/cli/src/commands/zero/host/index.ts
+++ b/turbo/apps/cli/src/commands/zero/host/index.ts
@@ -1,13 +1,22 @@
 import { Command } from "commander";
 import chalk from "chalk";
+import {
+  hostedArtifactKindSchema,
+  type HostedArtifactKind,
+} from "@vm0/api-contracts/contracts/zero-host";
 import { withErrorHandler } from "../../../lib/command";
 import { publishStaticSite } from "../../../lib/host/publish-static-site";
 
 interface HostOptions {
   readonly site: string;
   readonly slugSuffix?: string;
+  readonly artifactKind?: HostedArtifactKind;
   readonly spa?: boolean;
   readonly json?: boolean;
+}
+
+function parseArtifactKind(value: string): HostedArtifactKind {
+  return hostedArtifactKindSchema.parse(value);
 }
 
 function formatBytes(bytes: number): string {
@@ -22,6 +31,11 @@ export const zeroHostCommand = new Command()
   .argument("<dir>", "Static build directory, for example ./dist")
   .requiredOption("--site <slug>", "Public site slug, e.g. my-product-demo")
   .option("--slug-suffix <suffix>", "Reuse a generated site URL suffix")
+  .option(
+    "--artifact-kind <kind>",
+    "Artifact kind to record for this hosted deployment",
+    parseArtifactKind,
+  )
   .option("--spa", "Serve unknown HTML navigation paths from index.html")
   .option("--json", "Output only the final result as JSON")
   .addHelpText(
@@ -44,6 +58,7 @@ Notes:
         dir,
         site: options.site,
         slugSuffix: options.slugSuffix,
+        artifactKind: options.artifactKind,
         spaFallback: Boolean(options.spa),
         onProgress: options.json
           ? undefined

--- a/turbo/apps/cli/src/lib/host/publish-static-site.ts
+++ b/turbo/apps/cli/src/lib/host/publish-static-site.ts
@@ -1,5 +1,6 @@
 import { readFile } from "node:fs/promises";
 
+import type { HostedArtifactKind } from "@vm0/api-contracts/contracts/zero-host";
 import { completeHostedSite, prepareHostedSite } from "../api";
 import { scanStaticSite } from "./static-site";
 
@@ -22,6 +23,7 @@ interface PublishStaticSiteOptions {
   readonly dir: string;
   readonly site: string;
   readonly slugSuffix?: string;
+  readonly artifactKind?: HostedArtifactKind;
   readonly spaFallback?: boolean;
   readonly onProgress?: (progress: PublishStaticSiteProgress) => void;
 }
@@ -42,6 +44,7 @@ export async function publishStaticSite(
   const prepared = await prepareHostedSite({
     site: options.site,
     ...(options.slugSuffix !== undefined && { slugSuffix: options.slugSuffix }),
+    artifactKind: options.artifactKind ?? "hosted-site",
     spaFallback: Boolean(options.spaFallback),
     files: scan.files.map((file) => {
       return {

--- a/turbo/packages/api-contracts/src/contracts/zero-host.ts
+++ b/turbo/packages/api-contracts/src/contracts/zero-host.ts
@@ -9,6 +9,12 @@ const RANDOM_SLUG_SUFFIX_LENGTH = 8;
 const PUBLIC_SLUG_SEPARATOR_LENGTH = 2;
 const MAX_HOSTED_SITE_PUBLIC_SLUG_LENGTH = 96;
 
+export const hostedArtifactKindSchema = z.enum([
+  "hosted-site",
+  "presentation-html",
+]);
+export type HostedArtifactKind = z.infer<typeof hostedArtifactKindSchema>;
+
 export const hostedSiteSlugSchema = z
   .string()
   .trim()
@@ -41,6 +47,7 @@ export const hostedSitePrepareRequestSchema = z
   .object({
     site: hostedSiteSlugSchema,
     slugSuffix: hostedSiteSlugSuffixSchema.optional(),
+    artifactKind: hostedArtifactKindSchema.default("hosted-site"),
     spaFallback: z.boolean().default(false),
     files: z.array(hostedSiteFileSchema).min(1).max(5000),
   })

--- a/turbo/packages/db/src/schema/hosted-site.ts
+++ b/turbo/packages/db/src/schema/hosted-site.ts
@@ -35,6 +35,7 @@ export interface HostedSiteManifest {
   readonly siteId: string;
   readonly publicSlug: string;
   readonly createdAt: string;
+  readonly artifactKind?: "hosted-site" | "presentation-html";
   readonly spaFallback: boolean;
   readonly files: Record<string, HostedSiteManifestFile>;
 }


### PR DESCRIPTION
## Summary

- add `hosted-site | presentation-html` as a hosted artifact kind in the host contract
- let `zero host` accept an optional `--artifact-kind` flag while defaulting to `hosted-site`
- persist the hosted artifact kind through deployment manifests and `run_uploaded_files.metadata`
- add coverage for manually recording a `presentation-html` hosted artifact

## Notes

This is the first split from #16306. It only adds backward-compatible support for preserving the artifact kind through the hosting pipeline. It does not yet change `zero generate presentation` to emit `--artifact-kind presentation-html`; that can land in a follow-up after the API support is deployed.

## Validation

- `pnpm -F @vm0/cli exec vitest src/commands/zero/generate/__tests__/presentation.test.ts src/commands/zero/generate/__tests__/website.test.ts`
- `pnpm -F @vm0/cli run check-types`
- `pnpm -F api run check-types`
- `pnpm -F @vm0/db run check-types`
- `pnpm -F @vm0/api-contracts exec tsc --noEmit`
- `pnpm format --check`
- `pnpm -F @vm0/cli run lint`
- `pnpm -F api run lint`
- `pnpm -F @vm0/db run lint`
- `pnpm -F @vm0/api-contracts run lint`

`pnpm -F api exec vitest src/signals/routes/__tests__/zero-host.test.ts` was attempted locally but could not complete because local Postgres was not running (`ECONNREFUSED 5432`).

Closes #16306
