### PR TITLE
feat: emit presentation artifact kind

### DIFF
--- a/turbo/apps/cli/src/commands/zero/generate/__tests__/presentation.test.ts
+++ b/turbo/apps/cli/src/commands/zero/generate/__tests__/presentation.test.ts
@@ -60,7 +60,7 @@ describe("zero generate presentation command", () => {
       "Write the artifact under `./generated/mockups/api-migration-plan/`.",
     );
     expect(stdout).toContain(
-      "zero host ./generated/mockups/api-migration-plan --site api-migration-plan",
+      "zero host ./generated/mockups/api-migration-plan --site api-migration-plan --artifact-kind presentation-html",
     );
     expect(stdout).toContain("Slide count: 10");
     expect(stdout).toContain("Use a fixed 1920x1080 slide canvas");

--- a/turbo/apps/cli/src/commands/zero/shared/html-artifact-authoring.ts
+++ b/turbo/apps/cli/src/commands/zero/shared/html-artifact-authoring.ts
@@ -95,7 +95,9 @@ export function createHtmlArtifactAuthoringPacket(
   const site =
     options.siteSlug ?? slugify(options.slugSource ?? options.prompt);
   const outputDir = outputDirForSite(site);
-  const hostCommand = `zero host ${outputDir} --site ${site}${
+  const artifactKindFlag =
+    options.kind === "presentation" ? " --artifact-kind presentation-html" : "";
+  const hostCommand = `zero host ${outputDir} --site ${site}${artifactKindFlag}${
     options.kind === "website" ? " --spa" : ""
   }`;
   const title = titleForKind(options.kind);


### PR DESCRIPTION
## Summary

- make presentation source-selection packets publish with `--artifact-kind presentation-html`
- keep website generation publishing behavior unchanged
- update the presentation generation command test expectation

## Notes

This is stacked on #16316 and should merge after the host API accepts and preserves hosted artifact kinds.

## Validation

- `pnpm -F @vm0/cli exec vitest src/commands/zero/generate/__tests__/presentation.test.ts src/commands/zero/generate/__tests__/website.test.ts`
- `pnpm -F @vm0/cli run check-types`
- `pnpm -F @vm0/cli run lint`
- `pnpm format --check`

Refs #16306
