### PR TITLE
feat: emit presentation artifact kind

### DIFF
--- a/turbo/apps/cli/src/commands/zero/generate/__tests__/presentation.test.ts
+++ b/turbo/apps/cli/src/commands/zero/generate/__tests__/presentation.test.ts
@@ -60,7 +60,7 @@ describe("zero generate presentation command", () => {
       "Write the artifact under `./generated/mockups/api-migration-plan/`.",
     );
     expect(stdout).toContain(
-      "zero host ./generated/mockups/api-migration-plan --site api-migration-plan",
+      "zero host ./generated/mockups/api-migration-plan --site api-migration-plan --artifact-kind presentation-html",
     );
     expect(stdout).toContain("Slide count: 10");
     expect(stdout).toContain("Use a fixed 1920x1080 slide canvas");

--- a/turbo/apps/cli/src/commands/zero/shared/html-artifact-authoring.ts
+++ b/turbo/apps/cli/src/commands/zero/shared/html-artifact-authoring.ts
@@ -95,7 +95,9 @@ export function createHtmlArtifactAuthoringPacket(
   const site =
     options.siteSlug ?? slugify(options.slugSource ?? options.prompt);
   const outputDir = outputDirForSite(site);
-  const hostCommand = `zero host ${outputDir} --site ${site}${
+  const artifactKindFlag =
+    options.kind === "presentation" ? " --artifact-kind presentation-html" : "";
+  const hostCommand = `zero host ${outputDir} --site ${site}${artifactKindFlag}${
     options.kind === "website" ? " --spa" : ""
   }`;
   const title = titleForKind(options.kind);


### PR DESCRIPTION
## Summary

- carry the reviewed PR #16320 change onto `main`
- make presentation source-selection packets publish with `--artifact-kind presentation-html`
- keep website generation publishing behavior unchanged

## Context

PR #16320 was stacked on `codex/preserve-hosted-artifact-kind`. That base PR (#16316) had already merged to `main`, but #16320 still targeted the old stack branch, so its squash commit landed there instead of on `main`. This PR cherry-picks the same reviewed squash commit onto current `main` so the change lands through normal PR protections.

## Validation

- CI pending on this PR
- Original PR #16320 CI passed before the stale-base merge