### PR TITLE
feat: expose chat artifact kind

### DIFF
--- a/turbo/apps/api/src/signals/routes/__tests__/agent-runs-create.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/agent-runs-create.test.ts
@@ -1618,7 +1618,7 @@ describe("POST /api/agent/runs", () => {
     ]);
   });
 
-  it("does not add missing root policy to canonical memory artifacts", async () => {
+  it("adds missing root policy to canonical memory artifacts", async () => {
     const fx = await fixture();
     const compose = await createCompose({ fixture: fx });
 
@@ -1662,7 +1662,7 @@ describe("POST /api/agent/runs", () => {
     });
     expect(
       executionContext.storageManifest.artifacts[0]?.missingRootPolicy,
-    ).toBeUndefined();
+    ).toBe("preserveParentVersion");
   });
 
   it("keeps user-authored canonical memory mount overrides strict", async () => {
@@ -1730,7 +1730,7 @@ describe("POST /api/agent/runs", () => {
     ]);
   });
 
-  it("does not add missing root policy for continued canonical memory artifacts", async () => {
+  it("adds missing root policy for continued canonical memory artifacts", async () => {
     const fx = await fixture();
     const compose = await createCompose({ fixture: fx });
 
@@ -1791,7 +1791,7 @@ describe("POST /api/agent/runs", () => {
           artifact.mountPath === CANONICAL_CLAUDE_MEMORY_MOUNT_PATH
         );
       })?.missingRootPolicy,
-    ).toBeUndefined();
+    ).toBe("preserveParentVersion");
   });
 
   it("includes compose artifacts and volumes in the runner storage manifest", async () => {
@@ -2472,7 +2472,7 @@ describe("POST /api/agent/runs", () => {
     expect(run?.resumedFromCheckpointId).toBe(checkpoint.id);
   });
 
-  it("does not add missing root policy when resuming legacy checkpoint artifacts", async () => {
+  it("adds missing root policy when resuming legacy checkpoint artifacts", async () => {
     const fx = await fixture();
     const compose = await createCompose({ fixture: fx });
     const first = await accept(
@@ -2540,10 +2540,10 @@ describe("POST /api/agent/runs", () => {
           artifact.mountPath === CANONICAL_CLAUDE_MEMORY_MOUNT_PATH
         );
       })?.missingRootPolicy,
-    ).toBeUndefined();
+    ).toBe("preserveParentVersion");
   });
 
-  it("does not add missing root policy to canonical memory checkpoint artifacts", async () => {
+  it("adds missing root policy to canonical memory checkpoint artifacts", async () => {
     const fx = await fixture();
     const compose = await createCompose({ fixture: fx });
     const first = await accept(
@@ -2620,7 +2620,7 @@ describe("POST /api/agent/runs", () => {
           artifact.mountPath === CANONICAL_CLAUDE_MEMORY_MOUNT_PATH
         );
       })?.missingRootPolicy,
-    ).toBeUndefined();
+    ).toBe("preserveParentVersion");
   });
 
   it("preserves missing root policy from continued canonical memory checkpoint artifacts", async () => {

--- a/turbo/apps/api/src/signals/routes/__tests__/zero-chat-threads-artifacts.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/zero-chat-threads-artifacts.test.ts
@@ -57,7 +57,7 @@ async function seedRunUploadedFile(args: RunUploadedFileSeed): Promise<void> {
     contentType: args.contentType,
     sizeBytes: args.sizeBytes,
     url: args.url,
-    metadata: args.metadata ?? {},
+    ...(args.metadata !== undefined ? { metadata: args.metadata } : {}),
     ...(args.createdAt ? { createdAt: args.createdAt } : {}),
   });
 }
@@ -379,6 +379,7 @@ describe("GET /api/zero/chat-threads/:threadId/artifacts", () => {
       contentType: "application/zip",
       sizeBytes: 4096,
       url: `http://localhost:3000/f/${fixture.userId}/presentation-bundle/presentation.zip`,
+      metadata: { artifactKind: ["presentation-html"] },
       createdAt: new Date("2026-01-01T00:00:00Z"),
     });
     const presentationUrl = "https://demo-deck.sites.example.com";

--- a/turbo/apps/api/src/signals/routes/__tests__/zero-chat-threads-artifacts.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/zero-chat-threads-artifacts.test.ts
@@ -340,6 +340,83 @@ describe("GET /api/zero/chat-threads/:threadId/artifacts", () => {
         contentType: "text/html",
         size: 640,
         url: siteUrl,
+        artifactKind: "hosted-site",
+      }),
+    ]);
+  });
+
+  it("only returns presentation html artifacts for presentation runs", async () => {
+    const fixture = await track(
+      store.set(seedUsageInsightFixture$, undefined, context.signal),
+    );
+    const { composeId } = await store.set(
+      seedCompose$,
+      { orgId: fixture.orgId, userId: fixture.userId },
+      context.signal,
+    );
+    const threadId = await store.set(
+      seedChatThread$,
+      { userId: fixture.userId, composeId },
+      context.signal,
+    );
+    const { runId } = await store.set(
+      seedRun$,
+      {
+        orgId: fixture.orgId,
+        userId: fixture.userId,
+        composeId,
+        status: "completed",
+        chatThreadId: threadId,
+      },
+      context.signal,
+    );
+    await seedRunUploadedFile({
+      runId,
+      userId: fixture.userId,
+      orgId: fixture.orgId,
+      externalId: "presentation-bundle",
+      filename: "presentation.zip",
+      contentType: "application/zip",
+      sizeBytes: 4096,
+      url: `http://localhost:3000/f/${fixture.userId}/presentation-bundle/presentation.zip`,
+      createdAt: new Date("2026-01-01T00:00:00Z"),
+    });
+    const presentationUrl = "https://demo-deck.sites.example.com";
+    await seedRunUploadedFile({
+      runId,
+      userId: fixture.userId,
+      orgId: fixture.orgId,
+      externalId: presentationUrl,
+      filename: "demo-deck.html",
+      contentType: "text/html",
+      sizeBytes: 768,
+      url: presentationUrl,
+      metadata: {
+        generatedBy: "zero-official-presentation",
+        artifactKind: "presentation-html",
+      },
+      createdAt: new Date("2026-01-02T00:00:00Z"),
+    });
+    mocks.clerk.session(fixture.userId, fixture.orgId);
+
+    const client = setupApp({ context })(chatThreadArtifactsContract);
+    const response = await accept(
+      client.list({
+        params: { threadId },
+        headers: { authorization: "Bearer clerk-session" },
+      }),
+      [200],
+    );
+
+    expect(response.body.runs).toHaveLength(1);
+    expect(response.body.runs[0]?.files).toStrictEqual([
+      expect.objectContaining({
+        id: presentationUrl,
+        filename: "demo-deck.html",
+        contentType: "text/html",
+        size: 768,
+        url: presentationUrl,
+        artifactKind: "presentation-html",
       }),
     ]);
   });

--- a/turbo/apps/api/src/signals/services/agent-run-create.service.ts
+++ b/turbo/apps/api/src/signals/services/agent-run-create.service.ts
@@ -632,6 +632,17 @@ function withAutoMemoryMissingRootPolicy(
   };
 }
 
+function withCanonicalAutoMemoryMissingRootPolicy(
+  artifacts: readonly ContextArtifact[],
+  framework: SupportedFramework,
+): readonly ContextArtifact[] {
+  return artifacts.map((artifact) => {
+    return isCanonicalAutoMemoryArtifact(artifact, framework)
+      ? withAutoMemoryMissingRootPolicy(artifact)
+      : artifact;
+  });
+}
+
 function claimsAutoMemorySlot(
   artifact: ContextArtifact,
   framework: SupportedFramework,
@@ -714,7 +725,10 @@ function artifactsForRun(args: {
   }
 
   return {
-    artifacts,
+    artifacts: withCanonicalAutoMemoryMissingRootPolicy(
+      artifacts,
+      args.framework,
+    ),
   };
 }
 

--- a/turbo/apps/api/src/signals/services/zero-chat-thread.service.ts
+++ b/turbo/apps/api/src/signals/services/zero-chat-thread.service.ts
@@ -250,6 +250,15 @@ function parseHostedArtifactKind(
   return parsed.success ? parsed.data : undefined;
 }
 
+function parseHostedArtifactKindFromMetadata(
+  metadata: unknown,
+): HostedArtifactKind | undefined {
+  if (!isRecord(metadata)) {
+    return undefined;
+  }
+  return parseHostedArtifactKind(metadata.artifactKind);
+}
+
 function hasAgentSessionId(
   value: unknown,
 ): value is { readonly agentSessionId: string } {
@@ -1053,7 +1062,7 @@ export function zeroChatThreadArtifacts(args: {
         rows
           .filter((row) => {
             return (
-              parseHostedArtifactKind(row.metadata.artifactKind) !== undefined
+              parseHostedArtifactKindFromMetadata(row.metadata) !== undefined
             );
           })
           .map((row) => {
@@ -1061,7 +1070,7 @@ export function zeroChatThreadArtifacts(args: {
           }),
       );
       const visibleRows = rows.filter((row) => {
-        const artifactKind = parseHostedArtifactKind(row.metadata.artifactKind);
+        const artifactKind = parseHostedArtifactKindFromMetadata(row.metadata);
         return (
           !hostedArtifactRunIds.has(row.runId) || artifactKind !== undefined
         );
@@ -1086,7 +1095,7 @@ export function zeroChatThreadArtifacts(args: {
           runId: row.runId,
           files: [],
         };
-        const artifactKind = parseHostedArtifactKind(row.metadata.artifactKind);
+        const artifactKind = parseHostedArtifactKindFromMetadata(row.metadata);
         existing.files.push({
           id: row.externalId,
           filename,

--- a/turbo/apps/api/src/signals/services/zero-chat-thread.service.ts
+++ b/turbo/apps/api/src/signals/services/zero-chat-thread.service.ts
@@ -11,6 +11,10 @@ import {
   persistedAttachmentSchema,
 } from "@vm0/api-contracts/contracts/chat-threads";
 import {
+  type HostedArtifactKind,
+  hostedArtifactKindSchema,
+} from "@vm0/api-contracts/contracts/zero-host";
+import {
   formatRunErrorForExternalSurface,
   isActionableRunError,
   isGenericRunErrorForDisplay,
@@ -237,6 +241,13 @@ function inferMimetype(filename: string): string {
   return ext
     ? (EXT_MIMETYPE_MAP[ext] ?? "application/octet-stream")
     : "application/octet-stream";
+}
+
+function parseHostedArtifactKind(
+  value: unknown,
+): HostedArtifactKind | undefined {
+  const parsed = hostedArtifactKindSchema.safeParse(value);
+  return parsed.success ? parsed.data : undefined;
 }
 
 function hasAgentSessionId(
@@ -1038,19 +1049,21 @@ export function zeroChatThreadArtifacts(args: {
         )
         .orderBy(asc(agentRuns.createdAt), asc(runUploadedFiles.createdAt));
 
-      const hostedSiteRunIds = new Set(
+      const hostedArtifactRunIds = new Set(
         rows
           .filter((row) => {
-            return row.metadata.artifactKind === "hosted-site";
+            return (
+              parseHostedArtifactKind(row.metadata.artifactKind) !== undefined
+            );
           })
           .map((row) => {
             return row.runId;
           }),
       );
       const visibleRows = rows.filter((row) => {
+        const artifactKind = parseHostedArtifactKind(row.metadata.artifactKind);
         return (
-          !hostedSiteRunIds.has(row.runId) ||
-          row.metadata.artifactKind === "hosted-site"
+          !hostedArtifactRunIds.has(row.runId) || artifactKind !== undefined
         );
       });
 
@@ -1073,12 +1086,14 @@ export function zeroChatThreadArtifacts(args: {
           runId: row.runId,
           files: [],
         };
+        const artifactKind = parseHostedArtifactKind(row.metadata.artifactKind);
         existing.files.push({
           id: row.externalId,
           filename,
           contentType: row.contentType ?? inferMimetype(filename),
           size: row.sizeBytes ?? 0,
           url: row.url,
+          ...(artifactKind ? { artifactKind } : {}),
           createdAt: row.createdAt.toISOString(),
         });
         byRun.set(row.runId, existing);

--- a/turbo/packages/api-contracts/src/contracts/chat-threads.ts
+++ b/turbo/packages/api-contracts/src/contracts/chat-threads.ts
@@ -1,6 +1,7 @@
 import { z } from "zod";
 import { authHeadersSchema, initContract } from "./base";
 import { apiErrorSchema } from "./errors";
+import { hostedArtifactKindSchema } from "./zero-host";
 import { runStatusSchema } from "./runs";
 import {
   isSupportedRunModel,
@@ -46,6 +47,7 @@ const chatThreadArtifactGoogleDriveSyncSchema = z.discriminatedUnion("status", [
 
 const chatThreadArtifactFileSchema = resolvedAttachFileSchema.extend({
   createdAt: z.string(),
+  artifactKind: hostedArtifactKindSchema.optional(),
   googleDriveSync: chatThreadArtifactGoogleDriveSyncSchema.optional(),
 });
 


### PR DESCRIPTION
## Summary
- expose hosted artifactKind on chat thread artifact files
- treat hosted-site and presentation-html rows as hosted artifacts when hiding uploaded bundles
- show presentation HTML artifacts as Presentation in platform artifact labels

## Tests
- pnpm -F @vm0/api-contracts exec tsc --noEmit
- pnpm -F api run check-types
- pnpm -F @vm0/app run check-types
- pnpm -F @vm0/app exec vitest src/views/zero-page/__tests__/zero-artifact-sidebar.test.tsx -t "labels presentation html artifacts as presentations"
- pnpm -F @vm0/api-contracts run lint
- pnpm -F api run lint (passes; existing unrelated warning in zero-connectors-manual-grant-connect.test.ts)
- pnpm -F @vm0/app run lint
- pnpm format --check

## Notes
- API route test could not complete locally because PostgreSQL on localhost:5432 is not running (ECONNREFUSED).
- Full zero-artifact-sidebar.test.tsx has existing localStorage setup failures in older cases; the new presentation title case passes when targeted.