### PR TITLE
fix: remove memory summary token cap

### DIFF
--- a/turbo/apps/api/src/signals/external/openrouter.ts
+++ b/turbo/apps/api/src/signals/external/openrouter.ts
@@ -36,7 +36,7 @@ export function isLlmConfigured(): boolean {
 export async function generateText(
   model: string,
   messages: readonly OpenRouterMessage[],
-  maxTokens: number,
+  maxTokens?: number,
 ): Promise<string | null> {
   const apiKey = optionalEnv("OPENROUTER_API_KEY");
   if (!apiKey) {
@@ -52,7 +52,7 @@ export async function generateText(
     body: JSON.stringify({
       model,
       messages,
-      max_tokens: maxTokens,
+      ...(maxTokens === undefined ? {} : { max_tokens: maxTokens }),
       temperature: 0.3,
     }),
   });

--- a/turbo/apps/api/src/signals/routes/__tests__/cron-summarize-memory.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/cron-summarize-memory.test.ts
@@ -60,7 +60,7 @@ interface OpenRouterRequestMessage {
 interface OpenRouterRequestBody {
   readonly model: string;
   readonly messages: readonly OpenRouterRequestMessage[];
-  readonly max_tokens: number;
+  readonly max_tokens?: number;
 }
 
 /**
@@ -484,8 +484,8 @@ describe("GET /api/cron/summarize-memory", () => {
     expect(llm.calls).toBe(1);
     expect(llm.requests[0]).toMatchObject({
       model: "google/gemini-3.5-flash",
-      max_tokens: 1000,
     });
+    expect(llm.requests[0]).not.toHaveProperty("max_tokens");
     const systemMessage = llm.requests[0]?.messages.find((message) => {
       return message.role === "system";
     })?.content;

--- a/turbo/apps/api/src/signals/services/memory-activity-summarize.service.ts
+++ b/turbo/apps/api/src/signals/services/memory-activity-summarize.service.ts
@@ -5,7 +5,6 @@ import type {
 } from "./memory-activity-diff.service";
 
 const MEMORY_SUMMARY_MODEL = "google/gemini-3.5-flash";
-const MEMORY_SUMMARY_MAX_TOKENS = 1000;
 const MEMORY_SUMMARY_PROMPT_MAX_CHARS = 24_000;
 const MEMORY_SUMMARY_DIFF_LINES_PER_FILE = 160;
 export const MEMORY_SUMMARY_SYSTEM_PROMPT = [
@@ -166,18 +165,14 @@ export function generateMemoryDaySummary(
     return Promise.resolve(null);
   }
 
-  return generateText(
-    MEMORY_SUMMARY_MODEL,
-    [
-      {
-        role: "system",
-        content: MEMORY_SUMMARY_SYSTEM_PROMPT,
-      },
-      {
-        role: "user",
-        content: buildMemorySummaryPrompt(changeSet),
-      },
-    ],
-    MEMORY_SUMMARY_MAX_TOKENS,
-  );
+  return generateText(MEMORY_SUMMARY_MODEL, [
+    {
+      role: "system",
+      content: MEMORY_SUMMARY_SYSTEM_PROMPT,
+    },
+    {
+      role: "user",
+      content: buildMemorySummaryPrompt(changeSet),
+    },
+  ]);
 }


### PR DESCRIPTION
Summary: remove the explicit max_tokens cap from memory summary OpenRouter calls only. The shared OpenRouter helper now omits max_tokens when no cap is provided; existing callers that pass a cap are unchanged. Tests: pnpm -F api exec vitest run src/signals/routes/__tests__/cron-summarize-memory.test.ts src/signals/services/__tests__/memory-activity-summarize.service.test.ts; pnpm -F api lint; pnpm -F api check-types.