### PR TITLE
fix(platform): fix Honcho connector icon loading

### DIFF
--- a/turbo/apps/platform/src/views/zero-page/components/settings/icons/honcho.svg
+++ b/turbo/apps/platform/src/views/zero-page/components/settings/icons/honcho.svg
@@ -1,14 +1,5 @@
-<!-- Official brand asset source: https://honcho.dev/Honcho_Pixel-05.svg -->
-<?xml version="1.0" encoding="UTF-8"?>
 <svg id="Layer_1" data-name="Layer 1" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 144 144">
-  <defs>
-    <style>
-      .cls-1 {
-        fill: #b7d7f1;
-      }
-    </style>
-  </defs>
-  <circle class="cls-1" cx="72" cy="72" r="72"/>
+  <circle fill="#b7d7f1" cx="72" cy="72" r="72"/>
   <g>
     <rect x="66.57" y="34.41" width="16.52" height="6.89"/>
     <rect x="83.09" y="41.3" width="10.66" height="6.8"/>


### PR DESCRIPTION
## Summary

- Remove the comment before the Honcho SVG XML declaration, which caused browser parsing to fail once the asset was encoded as a data URI.
- Remove the XML declaration entirely so the data URI starts with `<svg>`.
- Inline the circle fill instead of using an internal style/class.

## Testing

```bash
cd turbo && pnpm exec prettier --check --ignore-unknown apps/platform/src/views/zero-page/components/settings/icons/honcho.svg
cd turbo && pnpm -F @vm0/app exec vitest src/views/zero-page/__tests__/connector-icons.test.tsx --run
cd turbo && pnpm -F @vm0/app lint
git diff --check
```
