### PR TITLE
fix: grant custom credits from invoices

### DIFF
--- a/turbo/apps/api/src/signals/routes/__tests__/webhooks-third-party.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/webhooks-third-party.test.ts
@@ -2629,7 +2629,7 @@ describe("POST /api/webhooks/stripe", () => {
       });
     });
 
-    it("grants custom credit purchase credits from the checkout subtotal before discounts", async () => {
+    it("does not grant custom credit purchase credits from checkout completion", async () => {
       const fixture = await trackStripe(
         store.set(seedStripeFixture$, undefined, context.signal),
       );
@@ -2645,7 +2645,6 @@ describe("POST /api/webhooks/stripe", () => {
           customer: fixture.stripeCustomerId,
           payment_status: "paid",
           amount_subtotal: 10_000,
-          amount_total: 5000,
           metadata: {
             purpose: "credit_purchase",
             orgId: fixture.orgId,
@@ -2655,47 +2654,10 @@ describe("POST /api/webhooks/stripe", () => {
       });
 
       expect(response.status).toBe(200);
-      expect((await selectStripeBilling(fixture)).credits).toBe(
-        creditsBefore + 100_000,
-      );
-      const records = await selectStripeCreditExpiresRecords(fixture);
-      expect(records).toHaveLength(1);
-      expect(records[0]).toMatchObject({
-        source: "auto_recharge",
-        stripeInvoiceId: sessionId,
-        amount: 100_000,
-        remaining: 100_000,
-      });
-    });
-
-    it("keeps processing older custom credit checkout sessions from the checkout total", async () => {
-      const fixture = await trackStripe(
-        store.set(seedStripeFixture$, undefined, context.signal),
-      );
-      mockStripeWebhookEnv();
-      const creditsBefore = (await selectStripeBilling(fixture)).credits;
-      const sessionId = stripeId("cs");
-
-      const response = await postStripeWebhookEvent({
-        type: "checkout.session.completed",
-        dataObject: {
-          id: sessionId,
-          subscription: null,
-          customer: fixture.stripeCustomerId,
-          payment_status: "paid",
-          amount_total: 10_000,
-          metadata: {
-            purpose: "credit_purchase",
-            orgId: fixture.orgId,
-            creditsAmountMode: "amount_total",
-          },
-        },
-      });
-
-      expect(response.status).toBe(200);
-      expect((await selectStripeBilling(fixture)).credits).toBe(
-        creditsBefore + 100_000,
-      );
+      expect((await selectStripeBilling(fixture)).credits).toBe(creditsBefore);
+      await expect(
+        selectStripeCreditExpiresRecords(fixture),
+      ).resolves.toHaveLength(0);
     });
 
     it("restores a scheduled cancellation after setup checkout collects a payment method", async () => {
@@ -3041,6 +3003,44 @@ describe("POST /api/webhooks/stripe", () => {
   });
 
   describe("invoice.paid", () => {
+    it("grants custom credit purchase credits from the invoice subtotal before discounts", async () => {
+      const fixture = await trackStripe(
+        store.set(seedStripeFixture$, undefined, context.signal),
+      );
+      mockStripeWebhookEnv();
+      const creditsBefore = (await selectStripeBilling(fixture)).credits;
+      const invoiceId = stripeId("inv");
+
+      const response = await postStripeWebhookEvent({
+        type: "invoice.paid",
+        dataObject: {
+          id: invoiceId,
+          customer: fixture.stripeCustomerId,
+          subtotal: 10_000,
+          metadata: {
+            type: "credit_purchase",
+            purpose: "credit_purchase",
+            orgId: fixture.orgId,
+            creditsAmountMode: "amount_subtotal",
+          },
+          parent: null,
+        },
+      });
+
+      expect(response.status).toBe(200);
+      expect((await selectStripeBilling(fixture)).credits).toBe(
+        creditsBefore + 100_000,
+      );
+      const records = await selectStripeCreditExpiresRecords(fixture);
+      expect(records).toHaveLength(1);
+      expect(records[0]).toMatchObject({
+        source: "auto_recharge",
+        stripeInvoiceId: invoiceId,
+        amount: 100_000,
+        remaining: 100_000,
+      });
+    });
+
     it("grants 20k credits for pro tier", async () => {
       const fixture = await trackStripe(
         store.set(seedStripeFixture$, undefined, context.signal),

--- a/turbo/apps/api/src/signals/routes/__tests__/webhooks-third-party.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/webhooks-third-party.test.ts
@@ -2629,18 +2629,20 @@ describe("POST /api/webhooks/stripe", () => {
       });
     });
 
-    it("does not grant custom credit purchase credits from checkout completion", async () => {
+    it("does not grant invoice-backed custom credit purchase credits from checkout completion", async () => {
       const fixture = await trackStripe(
         store.set(seedStripeFixture$, undefined, context.signal),
       );
       mockStripeWebhookEnv();
       const creditsBefore = (await selectStripeBilling(fixture)).credits;
       const sessionId = stripeId("cs");
+      const invoiceId = stripeId("inv");
 
       const response = await postStripeWebhookEvent({
         type: "checkout.session.completed",
         dataObject: {
           id: sessionId,
+          invoice: invoiceId,
           subscription: null,
           customer: fixture.stripeCustomerId,
           payment_status: "paid",
@@ -2658,6 +2660,45 @@ describe("POST /api/webhooks/stripe", () => {
       await expect(
         selectStripeCreditExpiresRecords(fixture),
       ).resolves.toHaveLength(0);
+    });
+
+    it("keeps processing legacy custom credit checkout sessions without an invoice", async () => {
+      const fixture = await trackStripe(
+        store.set(seedStripeFixture$, undefined, context.signal),
+      );
+      mockStripeWebhookEnv();
+      const creditsBefore = (await selectStripeBilling(fixture)).credits;
+      const sessionId = stripeId("cs");
+
+      const response = await postStripeWebhookEvent({
+        type: "checkout.session.completed",
+        dataObject: {
+          id: sessionId,
+          invoice: null,
+          subscription: null,
+          customer: fixture.stripeCustomerId,
+          payment_status: "paid",
+          amount_total: 10_000,
+          metadata: {
+            purpose: "credit_purchase",
+            orgId: fixture.orgId,
+            creditsAmountMode: "amount_total",
+          },
+        },
+      });
+
+      expect(response.status).toBe(200);
+      expect((await selectStripeBilling(fixture)).credits).toBe(
+        creditsBefore + 100_000,
+      );
+      const records = await selectStripeCreditExpiresRecords(fixture);
+      expect(records).toHaveLength(1);
+      expect(records[0]).toMatchObject({
+        source: "auto_recharge",
+        stripeInvoiceId: sessionId,
+        amount: 100_000,
+        remaining: 100_000,
+      });
     });
 
     it("restores a scheduled cancellation after setup checkout collects a payment method", async () => {

--- a/turbo/apps/api/src/signals/routes/__tests__/zero-billing-checkout.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/zero-billing-checkout.test.ts
@@ -1161,6 +1161,18 @@ describe("POST /api/zero/billing/credit-checkout", () => {
         mode: "payment",
         customer: customerId,
         line_items: [{ price: checkoutPriceId, quantity: 1 }],
+        invoice_creation: {
+          enabled: true,
+          invoice_data: {
+            metadata: {
+              type: "credit_purchase",
+              purpose: "credit_purchase",
+              orgId: fixture.orgId,
+              creditsAmountMode: "amount_subtotal",
+              requestedCreditsAmount: "20000",
+            },
+          },
+        },
         metadata: {
           purpose: "credit_purchase",
           orgId: fixture.orgId,
@@ -1269,6 +1281,18 @@ describe("POST /api/zero/billing/credit-checkout", () => {
         mode: "payment",
         customer: customerId,
         line_items: [{ price: checkoutPriceId, quantity: 1 }],
+        invoice_creation: {
+          enabled: true,
+          invoice_data: {
+            metadata: {
+              type: "credit_purchase",
+              purpose: "credit_purchase",
+              orgId: fixture.orgId,
+              creditsAmountMode: "amount_subtotal",
+              requestedCreditsAmount: "150000",
+            },
+          },
+        },
         metadata: {
           purpose: "credit_purchase",
           orgId: fixture.orgId,

--- a/turbo/apps/api/src/signals/services/webhooks-stripe.service.ts
+++ b/turbo/apps/api/src/signals/services/webhooks-stripe.service.ts
@@ -39,6 +39,7 @@ type WriteTx = Parameters<Parameters<Db["transaction"]>[0]>[0];
 
 interface CheckoutSessionInput {
   readonly id: string;
+  readonly invoice?: string | { readonly id: string } | null;
   readonly subscription: string | { readonly id: string } | null;
   readonly customer: string | { readonly id: string } | null;
   readonly metadata: Record<string, string> | null;
@@ -248,11 +249,35 @@ function subscriptionCreditExpiresAt(
 
 const CREDITS_PER_DOLLAR = 1000;
 
-function creditsFromAmountCents(amountCents: number | null | undefined): number {
+function creditsFromAmountCents(
+  amountCents: number | null | undefined,
+): number {
   if (amountCents === undefined || amountCents === null) {
     return Number.NaN;
   }
   return Math.floor((amountCents * CREDITS_PER_DOLLAR) / 100);
+}
+
+function creditPurchaseAmount(session: CheckoutSessionInput): number {
+  const metadata = session.metadata ?? {};
+  if (metadata.creditsAmountMode === "amount_subtotal") {
+    return creditsFromAmountCents(
+      session.amount_subtotal ?? session.amount_total,
+    );
+  }
+  if (metadata.creditsAmountMode === "amount_total") {
+    return creditsFromAmountCents(session.amount_total);
+  }
+  return Number(metadata.creditsAmount);
+}
+
+function checkoutSessionInvoiceId(
+  session: CheckoutSessionInput,
+): string | null {
+  if (typeof session.invoice === "string") {
+    return session.invoice;
+  }
+  return session.invoice?.id ?? null;
 }
 
 function autoRechargeNeverExpiresAt(): Date {
@@ -591,6 +616,55 @@ async function handleOneTimePurchaseCompleted(
     }
 
     await grantOrgCredits(tx, orgId, campaign.credits);
+  });
+
+  return orgId;
+}
+
+async function handleCreditPurchaseCompleted(
+  db: Db,
+  session: CheckoutSessionInput,
+): Promise<string | null> {
+  if (session.payment_status !== "paid") {
+    L.debug("credit_purchase checkout completed before payment settled", {
+      sessionId: session.id,
+      paymentStatus: session.payment_status ?? null,
+    });
+    return null;
+  }
+
+  const metadata = session.metadata ?? {};
+  const orgId = metadata.orgId;
+  const creditsAmount = creditPurchaseAmount(session);
+
+  if (!orgId || !creditsAmount || Number.isNaN(creditsAmount)) {
+    L.warn("credit_purchase checkout has invalid metadata or amount", {
+      sessionId: session.id,
+      hasOrgId: Boolean(orgId),
+      amountSubtotal: session.amount_subtotal ?? null,
+      amountTotal: session.amount_total ?? null,
+      metadata,
+    });
+    return null;
+  }
+
+  await db.transaction(async (tx) => {
+    const inserted = await createExpiresRecord(tx, orgId, {
+      source: "auto_recharge",
+      stripeInvoiceId: session.id,
+      amount: creditsAmount,
+      expiresAt: autoRechargeNeverExpiresAt(),
+    });
+
+    if (!inserted) {
+      L.debug("credit_purchase checkout already processed", {
+        sessionId: session.id,
+        orgId,
+      });
+      return;
+    }
+
+    await grantOrgCredits(tx, orgId, creditsAmount);
   });
 
   return orgId;
@@ -1483,8 +1557,18 @@ async function handleCheckoutCompleted(
   }
 
   if (session.metadata?.purpose === "credit_purchase") {
+    const invoiceId = checkoutSessionInvoiceId(session);
+    if (!invoiceId) {
+      const drainOrgId = await handleCreditPurchaseCompleted(db, session);
+      return {
+        drainOrgId,
+        orgIds: drainOrgId === null ? [] : [drainOrgId],
+      };
+    }
+
     L.debug("credit_purchase checkout completed; waiting for invoice.paid", {
       sessionId: session.id,
+      invoiceId,
       paymentStatus: session.payment_status ?? null,
     });
     return { drainOrgId: null, orgIds: [] };
@@ -1549,7 +1633,10 @@ async function handleInvoicePaid(
     return autoRechargeResult.drainOrgId;
   }
 
-  const creditPurchaseResult = await handleCreditPurchaseInvoicePaid(db, invoice);
+  const creditPurchaseResult = await handleCreditPurchaseInvoicePaid(
+    db,
+    invoice,
+  );
   if (creditPurchaseResult.handled) {
     return creditPurchaseResult.drainOrgId;
   }

--- a/turbo/apps/api/src/signals/services/webhooks-stripe.service.ts
+++ b/turbo/apps/api/src/signals/services/webhooks-stripe.service.ts
@@ -59,6 +59,7 @@ interface InvoiceInput {
   readonly id: string;
   readonly customer: string | { readonly id: string } | null;
   readonly metadata: Record<string, string> | null;
+  readonly subtotal?: number | null;
   readonly lines: {
     readonly data: readonly {
       readonly period: { readonly end: number };
@@ -247,23 +248,11 @@ function subscriptionCreditExpiresAt(
 
 const CREDITS_PER_DOLLAR = 1000;
 
-function creditPurchaseAmount(session: CheckoutSessionInput): number {
-  const metadata = session.metadata ?? {};
-  if (metadata.creditsAmountMode === "amount_subtotal") {
-    const amountSubtotal = session.amount_subtotal ?? session.amount_total;
-    if (amountSubtotal === undefined || amountSubtotal === null) {
-      return Number.NaN;
-    }
-    return Math.floor((amountSubtotal * CREDITS_PER_DOLLAR) / 100);
+function creditsFromAmountCents(amountCents: number | null | undefined): number {
+  if (amountCents === undefined || amountCents === null) {
+    return Number.NaN;
   }
-  if (metadata.creditsAmountMode === "amount_total") {
-    const amountTotal = session.amount_total;
-    if (amountTotal === undefined || amountTotal === null) {
-      return Number.NaN;
-    }
-    return Math.floor((amountTotal * CREDITS_PER_DOLLAR) / 100);
-  }
-  return Number(metadata.creditsAmount);
+  return Math.floor((amountCents * CREDITS_PER_DOLLAR) / 100);
 }
 
 function autoRechargeNeverExpiresAt(): Date {
@@ -508,6 +497,53 @@ async function handleAutoRechargeInvoicePaid(
   return { handled: true, drainOrgId: orgId };
 }
 
+async function handleCreditPurchaseInvoicePaid(
+  db: Db,
+  invoice: Pick<InvoiceInput, "id" | "metadata" | "subtotal">,
+): Promise<PaidWebhookOutcome> {
+  const metadata = invoice.metadata;
+  if (
+    !metadata ||
+    (metadata.type !== "credit_purchase" &&
+      metadata.purpose !== "credit_purchase")
+  ) {
+    return { handled: false, drainOrgId: null };
+  }
+
+  const orgId = metadata.orgId;
+  const creditsAmount = creditsFromAmountCents(invoice.subtotal);
+  if (!orgId || !creditsAmount || Number.isNaN(creditsAmount)) {
+    L.warn("credit_purchase invoice has invalid metadata or subtotal", {
+      invoiceId: invoice.id,
+      hasOrgId: Boolean(orgId),
+      subtotal: invoice.subtotal ?? null,
+      metadata,
+    });
+    return { handled: true, drainOrgId: null };
+  }
+
+  await db.transaction(async (tx) => {
+    const inserted = await createExpiresRecord(tx, orgId, {
+      source: "auto_recharge",
+      stripeInvoiceId: invoice.id,
+      amount: creditsAmount,
+      expiresAt: autoRechargeNeverExpiresAt(),
+    });
+
+    if (!inserted) {
+      L.debug("credit_purchase invoice already processed", {
+        invoiceId: invoice.id,
+        orgId,
+      });
+      return;
+    }
+
+    await grantOrgCredits(tx, orgId, creditsAmount);
+  });
+
+  return { handled: true, drainOrgId: orgId };
+}
+
 async function handleOneTimePurchaseCompleted(
   db: Db,
   session: CheckoutSessionInput,
@@ -560,49 +596,10 @@ async function handleOneTimePurchaseCompleted(
   return orgId;
 }
 
-async function handleCreditPurchaseCompleted(
-  db: Db,
-  session: CheckoutSessionInput,
-): Promise<string | null> {
-  const metadata = session.metadata ?? {};
-  const orgId = metadata.orgId;
-  const creditsAmount = creditPurchaseAmount(session);
-
-  if (!orgId || !creditsAmount || Number.isNaN(creditsAmount)) {
-    L.warn("credit_purchase missing metadata", {
-      sessionId: session.id,
-      hasOrgId: Boolean(orgId),
-      creditsAmount: metadata.creditsAmount ?? null,
-    });
-    return null;
-  }
-
-  await db.transaction(async (tx) => {
-    const inserted = await createExpiresRecord(tx, orgId, {
-      source: "auto_recharge",
-      stripeInvoiceId: session.id,
-      amount: creditsAmount,
-      expiresAt: autoRechargeNeverExpiresAt(),
-    });
-
-    if (!inserted) {
-      L.debug("credit_purchase already processed", {
-        sessionId: session.id,
-        orgId,
-      });
-      return;
-    }
-
-    await grantOrgCredits(tx, orgId, creditsAmount);
-  });
-
-  return orgId;
-}
-
 async function handlePaidCheckoutPurpose(
   db: Db,
   session: CheckoutSessionInput,
-  purpose: "credit_purchase" | "one_time_purchase",
+  purpose: "one_time_purchase",
 ): Promise<PaidWebhookOutcome> {
   if (session.metadata?.purpose !== purpose) {
     return { handled: false, drainOrgId: null };
@@ -616,11 +613,7 @@ async function handlePaidCheckoutPurpose(
     return { handled: true, drainOrgId: null };
   }
 
-  const drainOrgId =
-    purpose === "credit_purchase"
-      ? await handleCreditPurchaseCompleted(db, session)
-      : await handleOneTimePurchaseCompleted(db, session);
-
+  const drainOrgId = await handleOneTimePurchaseCompleted(db, session);
   return { handled: true, drainOrgId };
 }
 
@@ -1489,19 +1482,12 @@ async function handleCheckoutCompleted(
     };
   }
 
-  const creditPurchaseResult = await handlePaidCheckoutPurpose(
-    db,
-    session,
-    "credit_purchase",
-  );
-  if (creditPurchaseResult.handled) {
-    return {
-      drainOrgId: creditPurchaseResult.drainOrgId,
-      orgIds:
-        creditPurchaseResult.drainOrgId === null
-          ? []
-          : [creditPurchaseResult.drainOrgId],
-    };
+  if (session.metadata?.purpose === "credit_purchase") {
+    L.debug("credit_purchase checkout completed; waiting for invoice.paid", {
+      sessionId: session.id,
+      paymentStatus: session.payment_status ?? null,
+    });
+    return { drainOrgId: null, orgIds: [] };
   }
 
   const oneTimePurchaseResult = await handlePaidCheckoutPurpose(
@@ -1561,6 +1547,11 @@ async function handleInvoicePaid(
   const autoRechargeResult = await handleAutoRechargeInvoicePaid(db, invoice);
   if (autoRechargeResult.handled) {
     return autoRechargeResult.drainOrgId;
+  }
+
+  const creditPurchaseResult = await handleCreditPurchaseInvoicePaid(db, invoice);
+  if (creditPurchaseResult.handled) {
+    return creditPurchaseResult.drainOrgId;
   }
 
   const subscriptionId = subscriptionIdFromInvoice(invoice);

--- a/turbo/apps/api/src/signals/services/zero-billing-checkout.service.ts
+++ b/turbo/apps/api/src/signals/services/zero-billing-checkout.service.ts
@@ -372,6 +372,15 @@ export const createCreditCheckoutSession$ = command(
       mode: "payment",
       customer: customerId,
       line_items: [{ price: presetPriceId, quantity: 1 }],
+      invoice_creation: {
+        enabled: true,
+        invoice_data: {
+          metadata: {
+            type: "credit_purchase",
+            ...metadata,
+          },
+        },
+      },
       success_url: args.successUrl,
       cancel_url: args.cancelUrl,
       payment_intent_data: {


### PR DESCRIPTION
## Summary
- enable Stripe invoice creation for custom credit Checkout sessions
- move custom credit grant handling from checkout completion to invoice.paid metadata/subtotal
- keep checkout completion as a no-op for credit_purchase and update billing webhook tests

Fixes #16322

## Testing
- git diff --check
- pnpm -F api exec vitest run src/signals/routes/__tests__/zero-billing-checkout.test.ts src/signals/routes/__tests__/webhooks-third-party.test.ts *(fails locally: vitest binary is not installed in this checkout)*