### PR TITLE
fix(platform): treat groq connector icon as colorful

### DIFF
--- a/turbo/apps/platform/src/views/zero-page/__tests__/connector-icons.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/connector-icons.test.tsx
@@ -73,9 +73,12 @@ describe("connector icon component", () => {
   });
 
   it("should not apply zero-icon-mono to colorful icons", () => {
-    const { container } = render(<ConnectorIcon type="slack" />);
-    const img = container.querySelector("img");
-    expect(img).not.toHaveClass("zero-icon-mono");
+    for (const type of ["slack", "groq"] as const) {
+      const { container, unmount } = render(<ConnectorIcon type={type} />);
+      const img = container.querySelector("img");
+      expect(img).not.toHaveClass("zero-icon-mono");
+      unmount();
+    }
   });
 
   it("should scale slack icon (has loose viewbox)", () => {

--- a/turbo/apps/platform/src/views/zero-page/components/settings/connector-icons.tsx
+++ b/turbo/apps/platform/src/views/zero-page/components/settings/connector-icons.tsx
@@ -135,6 +135,7 @@ const CONNECTOR_ICON_COLORFUL = {
   "google-sheets": true,
   granola: true,
   greenhouse: true,
+  groq: true,
   helicone: true,
   heygen: true,
   honcho: true,


### PR DESCRIPTION
## Summary
- Mark the Groq connector icon as a colorful brand mark so it skips `zero-icon-mono` dark-mode inversion.
- Keep the existing official favicon SVG unchanged.
- Add connector icon coverage to ensure Groq does not receive the mono inversion class.

## Testing
- `cd turbo && pnpm -F @vm0/app exec vitest src/views/zero-page/__tests__/connector-icons.test.tsx --run`
- `cd turbo && pnpm -F @vm0/app lint`
- `cd turbo && pnpm exec prettier --check apps/platform/src/views/zero-page/components/settings/connector-icons.tsx apps/platform/src/views/zero-page/__tests__/connector-icons.test.tsx`
- `cd turbo && git diff --check`
- pre-commit hook: `knip`, `check-types`, `prettier`