### PR TITLE
Add PostHog funnel instrumentation

### DIFF
--- a/turbo/apps/api/src/lib/posthog.ts
+++ b/turbo/apps/api/src/lib/posthog.ts
@@ -1,0 +1,121 @@
+import { optionalEnv } from "./env";
+import { logger } from "./log";
+import { tapError } from "../signals/utils";
+
+const L = logger("PostHog");
+const POSTHOG_CAPTURE_URL = "https://us.i.posthog.com/capture/";
+const SAFE_ATTRIBUTION_KEYS = [
+  "source_type",
+  "referrer_domain",
+  "landing_host",
+  "landing_path",
+  "vm0_source",
+  "utm_source",
+  "utm_medium",
+  "utm_campaign",
+  "utm_content",
+  "utm_term",
+  "vm0_experiment",
+  "vm0_variant",
+  "lp_variant",
+] as const;
+const CLICK_ID_PRESENT_KEYS = [
+  ["gclid", "gclid_present"],
+  ["gbraid", "gbraid_present"],
+  ["wbraid", "wbraid_present"],
+] as const;
+
+type PostHogProperties = Readonly<Record<string, unknown>>;
+type SafeAttributionKey = (typeof SAFE_ATTRIBUTION_KEYS)[number];
+type ClickIdKey = (typeof CLICK_ID_PRESENT_KEYS)[number][0];
+type ClickIdPresentKey = (typeof CLICK_ID_PRESENT_KEYS)[number][1];
+type SafeAttribution = Partial<
+  Record<SafeAttributionKey | ClickIdKey | ClickIdPresentKey, string>
+>;
+
+interface CapturePostHogEventInput {
+  readonly event: string;
+  readonly distinctId: string;
+  readonly properties?: PostHogProperties;
+  readonly groups?: {
+    readonly organizationId?: string;
+  };
+}
+
+function postHogProjectKey(): string | undefined {
+  return (
+    optionalEnv("POSTHOG_PROJECT_API_KEY") ??
+    optionalEnv("POSTHOG_KEY") ??
+    optionalEnv("VITE_POSTHOG_KEY") ??
+    optionalEnv("NEXT_PUBLIC_POSTHOG_KEY")
+  );
+}
+
+function cleanProperties(
+  properties: PostHogProperties | undefined,
+): Record<string, unknown> {
+  const cleaned: Record<string, unknown> = {};
+  for (const [key, value] of Object.entries(properties ?? {})) {
+    if (value !== undefined) {
+      cleaned[key] = value;
+    }
+  }
+  return cleaned;
+}
+
+export function safeAcquisitionAttributionProperties(
+  attribution: SafeAttribution | undefined,
+): Record<string, unknown> {
+  const properties: Record<string, unknown> = {};
+  for (const key of SAFE_ATTRIBUTION_KEYS) {
+    properties[key] = attribution?.[key];
+  }
+  for (const [clickIdKey, presentKey] of CLICK_ID_PRESENT_KEYS) {
+    properties[presentKey] =
+      attribution?.[presentKey] === "true" ||
+      Boolean(attribution?.[clickIdKey]);
+  }
+  return properties;
+}
+
+export async function capturePostHogEvent(
+  args: CapturePostHogEventInput,
+): Promise<void> {
+  const apiKey = postHogProjectKey();
+  if (!apiKey) {
+    return;
+  }
+
+  const properties = cleanProperties({
+    ...args.properties,
+    ...(args.groups?.organizationId
+      ? { $groups: { organization: args.groups.organizationId } }
+      : {}),
+    distinct_id: args.distinctId,
+    $lib: "vm0-api",
+  });
+  const response = await tapError(
+    fetch(POSTHOG_CAPTURE_URL, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        api_key: apiKey,
+        event: args.event,
+        distinct_id: args.distinctId,
+        properties,
+      }),
+    }),
+    (error) => {
+      L.warn("capture failed", { event: args.event, error });
+    },
+  );
+  if (!response) {
+    return;
+  }
+  if (!response.ok) {
+    L.warn("capture failed", {
+      event: args.event,
+      status: response.status,
+    });
+  }
+}

--- a/turbo/apps/api/src/signals/routes/connectors-type-callback.ts
+++ b/turbo/apps/api/src/signals/routes/connectors-type-callback.ts
@@ -32,6 +32,7 @@ import {
 } from "../services/github-oauth.service";
 import { settle } from "../utils";
 import type { RouteEntry } from "../route";
+import { capturePostHogEvent } from "../../lib/posthog";
 import {
   getConnectorOAuthCanonicalRedirectUrl,
   getConnectorOAuthOrigin,
@@ -419,6 +420,31 @@ const completeOAuthCallback$ = command(
       identity: args.identity,
       token,
       signal,
+    });
+    signal.throwIfAborted();
+
+    const telemetryProperties = {
+      org_id: args.identity.orgId,
+      user_id: args.identity.userId,
+      connector_type: args.connectorType,
+      auth_method: args.authMethod,
+      connection_method: "oauth",
+      needs_reconnect: result.connector.needsReconnect,
+      has_external_username: Boolean(result.connector.externalUsername),
+      has_external_email: Boolean(result.connector.externalEmail),
+    };
+    await capturePostHogEvent({
+      event: "connector_connection_success",
+      distinctId: args.identity.userId,
+      groups: { organizationId: args.identity.orgId },
+      properties: telemetryProperties,
+    });
+    signal.throwIfAborted();
+    await capturePostHogEvent({
+      event: "connector_connected",
+      distinctId: args.identity.userId,
+      groups: { organizationId: args.identity.orgId },
+      properties: telemetryProperties,
     });
     signal.throwIfAborted();
 

--- a/turbo/apps/api/src/signals/routes/zero-attribution.ts
+++ b/turbo/apps/api/src/signals/routes/zero-attribution.ts
@@ -7,6 +7,10 @@ import { bodyResultOf } from "../context/request";
 import { clerk$ } from "../external/clerk";
 import { nowDate } from "../external/time";
 import type { RouteEntry } from "../route";
+import {
+  capturePostHogEvent,
+  safeAcquisitionAttributionProperties,
+} from "../../lib/posthog";
 
 const SIGNUP_ATTRIBUTION_KEY = "signup_attribution";
 
@@ -57,6 +61,20 @@ const recordSignupInner$ = command(async ({ get }, signal: AbortSignal) => {
         ...bodyResult.data.attribution,
         recorded_at: nowDate().toISOString(),
       },
+    },
+  });
+  signal.throwIfAborted();
+
+  const groups = auth.orgId ? { organizationId: auth.orgId } : undefined;
+  await capturePostHogEvent({
+    event: "signup_attribution_recorded",
+    distinctId: auth.userId,
+    ...(groups ? { groups } : {}),
+    properties: {
+      ...safeAcquisitionAttributionProperties(bodyResult.data.attribution),
+      user_id: auth.userId,
+      org_id: auth.orgId,
+      recorded: true,
     },
   });
   signal.throwIfAborted();

--- a/turbo/apps/api/src/signals/routes/zero-billing-checkout.ts
+++ b/turbo/apps/api/src/signals/routes/zero-billing-checkout.ts
@@ -6,6 +6,10 @@ import { eq } from "drizzle-orm";
 import { optionalEnv } from "../../lib/env";
 import { billingRedirectAllowed } from "../../lib/billing-redirect";
 import { badRequestMessage, providerUnavailable } from "../../lib/error";
+import {
+  capturePostHogEvent,
+  safeAcquisitionAttributionProperties,
+} from "../../lib/posthog";
 import { organizationAuthContext$ } from "../auth/auth-context";
 import { authRoute } from "../auth/auth-route";
 import { bodyResultOf } from "../context/request";
@@ -110,6 +114,21 @@ const checkoutAuthed$ = command(async ({ get, set }, signal: AbortSignal) => {
     signal,
   );
   signal.throwIfAborted();
+  await capturePostHogEvent({
+    event: "stripe_checkout_created",
+    distinctId: auth.userId,
+    groups: { organizationId: auth.orgId },
+    properties: {
+      ...safeAcquisitionAttributionProperties(adAttribution),
+      org_id: auth.orgId,
+      user_id: auth.userId,
+      tier,
+      trial_days: trialDays,
+      has_trial: trialDays !== undefined,
+    },
+  });
+  signal.throwIfAborted();
+
   return { status: 200 as const, body: { url } };
 });
 
@@ -163,6 +182,19 @@ const checkoutCompleteAuthed$ = command(
         }),
       );
     }
+
+    await capturePostHogEvent({
+      event: "stripe_checkout_complete_checked",
+      distinctId: auth.userId,
+      groups: { organizationId: auth.orgId },
+      properties: {
+        org_id: auth.orgId,
+        user_id: auth.userId,
+        completion_status: result.status,
+        completed: result.status === "completed",
+      },
+    });
+    signal.throwIfAborted();
 
     return {
       status: 200 as const,

--- a/turbo/apps/api/src/signals/routes/zero-connectors.ts
+++ b/turbo/apps/api/src/signals/routes/zero-connectors.ts
@@ -23,6 +23,7 @@ import { request$ } from "../context/hono";
 import { bodyResultOf, pathParamsOf, queryOf } from "../context/request";
 import { badRequestMessage, notFound } from "../../lib/error";
 import { optionalEnv } from "../../lib/env";
+import { capturePostHogEvent } from "../../lib/posthog";
 import { nowDate } from "../../lib/time";
 import { writeDb$ } from "../external/db";
 import {
@@ -258,6 +259,29 @@ const connectManualGrantConnectorInner$ = command(
     if (result.status === "invalid") {
       return badRequestMessage(result.message);
     }
+
+    const telemetryProperties = {
+      org_id: auth.orgId,
+      user_id: auth.userId,
+      connector_type: params.type,
+      auth_method: bodyResult.data.authMethod,
+      connection_method: "manual",
+      needs_reconnect: result.connector.needsReconnect,
+    };
+    await capturePostHogEvent({
+      event: "connector_connection_success",
+      distinctId: auth.userId,
+      groups: { organizationId: auth.orgId },
+      properties: telemetryProperties,
+    });
+    signal.throwIfAborted();
+    await capturePostHogEvent({
+      event: "connector_connected",
+      distinctId: auth.userId,
+      groups: { organizationId: auth.orgId },
+      properties: telemetryProperties,
+    });
+    signal.throwIfAborted();
 
     return { status: 200 as const, body: result.connector };
   },

--- a/turbo/apps/api/src/signals/services/agent-run-create.service.ts
+++ b/turbo/apps/api/src/signals/services/agent-run-create.service.ts
@@ -134,6 +134,7 @@ import { dispatchRunCallbacks } from "./agent-run-callback.service";
 import { drainOrgQueue$ } from "./zero-run-queue.service";
 import { notifyRunnerJob } from "./runner-dispatch.service";
 import { logger } from "../../lib/log";
+import { capturePostHogEvent } from "../../lib/posthog";
 import { recordSandboxOperation } from "../external/sandbox-op-log";
 
 const PENDING_RUN_TTL_MS = 15 * 60 * 1000;
@@ -3975,6 +3976,53 @@ function completePendingRun(input: {
   );
 }
 
+async function captureRunStartedTelemetry(args: {
+  readonly run: RunRecord;
+  readonly input: CreateAgentRunArgs;
+  readonly context: PreparedRunContext;
+  readonly response: Extract<CreateRunRouteResult, { readonly status: 201 }>;
+}): Promise<void> {
+  if (args.response.body.status === "failed") {
+    return;
+  }
+
+  const connectorTypes = args.context.connectorContext.connectorTypes;
+  const properties = {
+    org_id: args.input.orgId,
+    user_id: args.input.userId,
+    run_id: args.run.id,
+    run_status: args.response.body.status,
+    trigger_source: args.context.body.triggerSource ?? "cli",
+    model_provider_type: args.context.modelProvider?.type,
+    concrete_model_provider_type: args.context.modelProvider?.concreteType,
+    selected_model: args.context.modelProvider?.selectedModel,
+    chat_thread_id: args.input.chatThreadId,
+    has_chat_thread: Boolean(args.input.chatThreadId),
+    trigger_agent_id: args.input.zeroRunMetadata?.triggerAgentId,
+    schedule_id: args.input.zeroRunMetadata?.scheduleId,
+    connector_count: connectorTypes.length,
+    connector_types: connectorTypes,
+  };
+
+  await capturePostHogEvent({
+    event: "task_started",
+    distinctId: args.input.userId,
+    groups: { organizationId: args.input.orgId },
+    properties,
+  });
+
+  if (connectorTypes.length === 0) {
+    return;
+  }
+
+  await capturePostHogEvent({
+    event: "connector_used_in_task",
+    distinctId: args.input.userId,
+    groups: { organizationId: args.input.orgId },
+    properties,
+  });
+}
+
 export const createAgentRun$ = command(
   async (
     { get, set },
@@ -4010,7 +4058,7 @@ export const createAgentRun$ = command(
     }
 
     if (transactionResult.status === "queued") {
-      return await get(
+      const response = await get(
         completeQueuedRun({
           db,
           args,
@@ -4019,9 +4067,18 @@ export const createAgentRun$ = command(
           signal,
         }),
       );
+      signal.throwIfAborted();
+      await captureRunStartedTelemetry({
+        run: transactionResult,
+        input: args,
+        context,
+        response,
+      });
+      signal.throwIfAborted();
+      return response;
     }
 
-    return await get(
+    const response = await get(
       completePendingRun({
         db,
         args,
@@ -4033,5 +4090,14 @@ export const createAgentRun$ = command(
         signal,
       }),
     );
+    signal.throwIfAborted();
+    await captureRunStartedTelemetry({
+      run: transactionResult,
+      input: args,
+      context,
+      response,
+    });
+    signal.throwIfAborted();
+    return response;
   },
 );

--- a/turbo/apps/api/src/signals/services/agent-webhook-complete.service.ts
+++ b/turbo/apps/api/src/signals/services/agent-webhook-complete.service.ts
@@ -9,6 +9,7 @@ import { checkpoints } from "@vm0/db/schema/checkpoint";
 
 import { notFound } from "../../lib/error";
 import { logger } from "../../lib/log";
+import { capturePostHogEvent } from "../../lib/posthog";
 import { nowDate } from "../../lib/time";
 import type { SandboxAuth } from "../../types/auth";
 import { writeDb$, type Db } from "../external/db";
@@ -216,6 +217,28 @@ function successResponse(
   };
 }
 
+async function captureRunTerminalTelemetry(args: {
+  readonly event: "task_completed_successfully" | "task_failed";
+  readonly runId: string;
+  readonly orgId: string;
+  readonly userId: string;
+  readonly status: TerminalStatus;
+  readonly exitCode: number | undefined;
+}): Promise<void> {
+  await capturePostHogEvent({
+    event: args.event,
+    distinctId: args.userId,
+    groups: { organizationId: args.orgId },
+    properties: {
+      org_id: args.orgId,
+      user_id: args.userId,
+      run_id: args.runId,
+      run_status: args.status,
+      exit_code: args.exitCode,
+    },
+  });
+}
+
 async function currentStatusResponse(
   db: Db,
   input: CompleteAgentRunInput,
@@ -330,6 +353,16 @@ async function handleSuccessfulCompletion(
   });
   signal.throwIfAborted();
 
+  await captureRunTerminalTelemetry({
+    event: "task_completed_successfully",
+    runId: input.body.runId,
+    orgId: run.orgId,
+    userId: run.userId,
+    status: "completed",
+    exitCode: input.body.exitCode,
+  });
+  signal.throwIfAborted();
+
   L.debug("Run completed successfully", { runId: input.body.runId });
   return successResponse(input.body.runId, run.orgId, "completed");
 }
@@ -362,6 +395,16 @@ async function handleFailedCompletion(
 
   await publishRunChangedForUserSafely(run.userId, input.body.runId, {
     status: "failed",
+  });
+  signal.throwIfAborted();
+
+  await captureRunTerminalTelemetry({
+    event: "task_failed",
+    runId: input.body.runId,
+    orgId: run.orgId,
+    userId: run.userId,
+    status: "failed",
+    exitCode: input.body.exitCode,
   });
   signal.throwIfAborted();
 

--- a/turbo/apps/api/src/signals/services/webhooks-stripe.service.ts
+++ b/turbo/apps/api/src/signals/services/webhooks-stripe.service.ts
@@ -16,6 +16,7 @@ import {
   type SubscriptionCheckoutTier,
   tierFromPriceId,
 } from "./zero-billing-checkout.service";
+import { capturePostHogEvent } from "../../lib/posthog";
 
 const L = logger("WebhookStripe");
 
@@ -93,6 +94,22 @@ interface SubscriptionInvoiceDetails {
   readonly credits: number;
   readonly periodEndDate: Date;
   readonly expiresAt: Date;
+}
+
+async function captureOrgStripeEvent(args: {
+  readonly event: string;
+  readonly orgId: string;
+  readonly properties?: Readonly<Record<string, unknown>>;
+}): Promise<void> {
+  await capturePostHogEvent({
+    event: args.event,
+    distinctId: args.orgId,
+    groups: { organizationId: args.orgId },
+    properties: {
+      ...args.properties,
+      org_id: args.orgId,
+    },
+  });
 }
 
 function subscriptionPeriodEnd(subscription: SubscriptionInput): Date | null {
@@ -701,7 +718,7 @@ async function bindSubscriptionToCustomerOrg(
       | "checkout.session.completed"
       | "customer.subscription.created";
   },
-): Promise<void> {
+): Promise<readonly string[]> {
   if (
     args.source === "customer.subscription.created" &&
     !(await bindStripeCustomerFromMetadata(db, {
@@ -709,7 +726,7 @@ async function bindSubscriptionToCustomerOrg(
       subscriptionId: args.subscription.id,
     }))
   ) {
-    return;
+    return [];
   }
 
   const priceId = args.subscription.items.data[0]?.price?.id;
@@ -725,7 +742,7 @@ async function bindSubscriptionToCustomerOrg(
       tier: tierFromPriceId(priceId),
     })
   ) {
-    return;
+    return [];
   }
 
   const rows = await db
@@ -746,6 +763,9 @@ async function bindSubscriptionToCustomerOrg(
       source: args.source,
     });
   }
+  return rows.map((row) => {
+    return row.orgId;
+  });
 }
 
 function invoiceWouldReplaceWithSameOrLowerTier(args: {
@@ -864,10 +884,10 @@ async function processSubscriptionInvoicePaid(
     readonly orgId: string;
     readonly details: SubscriptionInvoiceDetails;
   },
-): Promise<void> {
+): Promise<boolean> {
   const lockedOrg = await lockInvoicePaidOrg(tx, args.orgId);
   if (!lockedOrg) {
-    return;
+    return false;
   }
 
   if (lockedOrg.lastProcessedInvoiceId === args.invoice.id) {
@@ -875,7 +895,7 @@ async function processSubscriptionInvoicePaid(
       invoiceId: args.invoice.id,
       orgId: args.orgId,
     });
-    return;
+    return false;
   }
 
   if (
@@ -898,7 +918,7 @@ async function processSubscriptionInvoicePaid(
         targetTier: args.details.tier,
       }),
     });
-    return;
+    return false;
   }
 
   const trialingExistingSubscription =
@@ -922,7 +942,7 @@ async function processSubscriptionInvoicePaid(
       subscriptionId: args.subscriptionId,
       details: args.details,
     });
-    return;
+    return true;
   }
 
   await expireCredits(tx, args.orgId);
@@ -938,7 +958,7 @@ async function processSubscriptionInvoicePaid(
       invoiceId: args.invoice.id,
       orgId: args.orgId,
     });
-    return;
+    return false;
   }
 
   await grantOrgCredits(tx, args.orgId, args.details.credits);
@@ -948,6 +968,7 @@ async function processSubscriptionInvoicePaid(
     subscriptionId: args.subscriptionId,
     details: args.details,
   });
+  return true;
 }
 
 async function handleCheckoutCompleted(
@@ -970,11 +991,22 @@ async function handleCheckoutCompleted(
 
   const stripe = getStripeClient();
   const subscription = await stripe.subscriptions.retrieve(subscriptionId);
-  await bindSubscriptionToCustomerOrg(db, {
+  const orgIds = await bindSubscriptionToCustomerOrg(db, {
     customerId,
     subscription,
     source: "checkout.session.completed",
   });
+  for (const orgId of orgIds) {
+    await captureOrgStripeEvent({
+      event: "stripe_checkout_completed",
+      orgId,
+      properties: {
+        subscription_status: subscription.status,
+        stripe_subscription_id: subscription.id,
+        payment_status: session.payment_status ?? null,
+      },
+    });
+  }
 }
 
 async function handleSubscriptionCreated(
@@ -989,11 +1021,21 @@ async function handleSubscriptionCreated(
     return;
   }
 
-  await bindSubscriptionToCustomerOrg(db, {
+  const orgIds = await bindSubscriptionToCustomerOrg(db, {
     customerId,
     subscription,
     source: "customer.subscription.created",
   });
+  for (const orgId of orgIds) {
+    await captureOrgStripeEvent({
+      event: "stripe_subscription_created",
+      orgId,
+      properties: {
+        subscription_status: subscription.status,
+        stripe_subscription_id: subscription.id,
+      },
+    });
+  }
 }
 
 async function handleInvoicePaid(db: Db, invoice: InvoiceInput): Promise<void> {
@@ -1044,14 +1086,29 @@ async function handleInvoicePaid(db: Db, invoice: InvoiceInput): Promise<void> {
     return;
   }
 
-  await db.transaction(async (tx) => {
-    await processSubscriptionInvoicePaid(tx, {
+  const processed = await db.transaction(async (tx) => {
+    return await processSubscriptionInvoicePaid(tx, {
       invoice,
       customerId,
       subscriptionId,
       orgId: org.orgId,
       details,
     });
+  });
+  if (!processed) {
+    return;
+  }
+
+  await captureOrgStripeEvent({
+    event: "stripe_invoice_paid",
+    orgId: org.orgId,
+    properties: {
+      stripe_invoice_id: invoice.id,
+      stripe_subscription_id: subscriptionId,
+      subscription_status: details.subscription.status,
+      tier: details.tier,
+      credits: details.credits,
+    },
   });
 }
 
@@ -1074,7 +1131,7 @@ async function handleSubscriptionUpdated(
     previousTrialEnd !== null &&
     trialEnd < previousTrialEnd;
 
-  await db.transaction(async (tx) => {
+  const rows = await db.transaction(async (tx) => {
     const rows = await tx
       .update(orgMetadata)
       .set({
@@ -1088,7 +1145,7 @@ async function handleSubscriptionUpdated(
       .returning({ orgId: orgMetadata.orgId });
 
     if (!trialShortened) {
-      return;
+      return rows;
     }
 
     for (const row of rows) {
@@ -1104,14 +1161,47 @@ async function handleSubscriptionUpdated(
           ),
         );
     }
+    return rows;
   });
+  for (const row of rows) {
+    await captureOrgStripeEvent({
+      event: "stripe_subscription_updated",
+      orgId: row.orgId,
+      properties: {
+        stripe_subscription_id: subscription.id,
+        subscription_status: subscription.status,
+        trial_shortened: trialShortened,
+        cancel_at_period_end: subscription.cancel_at_period_end,
+      },
+    });
+    if (subscription.status === "trialing") {
+      await captureOrgStripeEvent({
+        event: "stripe_subscription_trialing",
+        orgId: row.orgId,
+        properties: {
+          stripe_subscription_id: subscription.id,
+          subscription_status: subscription.status,
+        },
+      });
+    }
+    if (subscription.status === "active") {
+      await captureOrgStripeEvent({
+        event: "stripe_subscription_active",
+        orgId: row.orgId,
+        properties: {
+          stripe_subscription_id: subscription.id,
+          subscription_status: subscription.status,
+        },
+      });
+    }
+  }
 }
 
 async function handleSubscriptionDeleted(
   db: Db,
   subscription: SubscriptionDeletedInput,
 ): Promise<void> {
-  await db
+  const rows = await db
     .update(orgMetadata)
     .set({
       tier: "pro-suspend",
@@ -1121,7 +1211,18 @@ async function handleSubscriptionDeleted(
       currentPeriodEnd: null,
       updatedAt: nowDate(),
     })
-    .where(eq(orgMetadata.stripeSubscriptionId, subscription.id));
+    .where(eq(orgMetadata.stripeSubscriptionId, subscription.id))
+    .returning({ orgId: orgMetadata.orgId });
+  for (const row of rows) {
+    await captureOrgStripeEvent({
+      event: "stripe_subscription_deleted",
+      orgId: row.orgId,
+      properties: {
+        stripe_subscription_id: subscription.id,
+        subscription_status: "canceled",
+      },
+    });
+  }
 }
 
 export const handleStripeWebhookEvent$ = command(

--- a/turbo/apps/platform/src/lib/posthog.ts
+++ b/turbo/apps/platform/src/lib/posthog.ts
@@ -142,6 +142,48 @@ export function capturePageView(): void {
   posthog.capture("$pageview");
 }
 
+interface OnboardingStepViewedTelemetry {
+  readonly telemetryKey: string;
+  readonly step: string;
+  readonly stepKey: string;
+  readonly currentStepIndex: number;
+  readonly visibleSteps: readonly string[];
+  readonly selectedConnectors: readonly string[];
+  readonly isUseCase: boolean;
+  readonly isAdmin: boolean;
+}
+
+const lastOnboardingStepTelemetryKey$ = state<string | null>(null);
+
+export function captureOnboardingStepViewed(
+  args: Omit<OnboardingStepViewedTelemetry, "telemetryKey">,
+): void {
+  if (!POSTHOG_KEY) {
+    return;
+  }
+  posthog.capture("onboarding_step_viewed", {
+    step: args.step,
+    step_key: args.stepKey,
+    current_step_index: args.currentStepIndex,
+    visible_step_count: args.visibleSteps.length,
+    visible_steps: args.visibleSteps,
+    selected_connector_count: args.selectedConnectors.length,
+    selected_connectors: args.selectedConnectors,
+    is_use_case: args.isUseCase,
+    is_admin: args.isAdmin,
+  });
+}
+
+export const captureOnboardingStepViewed$ = command(
+  ({ get, set }, args: OnboardingStepViewedTelemetry): void => {
+    if (get(lastOnboardingStepTelemetryKey$) === args.telemetryKey) {
+      return;
+    }
+    set(lastOnboardingStepTelemetryKey$, args.telemetryKey);
+    captureOnboardingStepViewed(args);
+  },
+);
+
 const firstSkeletonHideReported$ = state(false);
 
 /**

--- a/turbo/apps/platform/src/views/zero-page/zero-onboarding.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-onboarding.tsx
@@ -1,5 +1,6 @@
 // TODO(#8609): split large components to comply with max-lines-per-function (128)
 // oxlint-disable max-lines-per-function
+import type { ReactNode } from "react";
 import {
   useGet,
   useSet,
@@ -87,6 +88,7 @@ import { ZeroOrgSwitcher } from "./zero-org-switcher.tsx";
 import { clerk$ } from "../../signals/auth.ts";
 import { userInvitations$ } from "../../signals/user-invitations.ts";
 import { handleZeroAccountAction$ } from "../../signals/zero-page/zero-nav.ts";
+import { captureOnboardingStepViewed$ } from "../../lib/posthog.ts";
 
 // ---------------------------------------------------------------------------
 // Progress bar
@@ -1151,7 +1153,7 @@ function OnboardingOrgSwitcher() {
   return <ZeroOrgSwitcher />;
 }
 
-function OnboardingPageLayout({ children }: { children: React.ReactNode }) {
+function OnboardingPageLayout({ children }: { children: ReactNode }) {
   return (
     <div className="zero-app flex h-dvh bg-muted/30 relative">
       {/* Left panel — brand / illustration */}
@@ -1319,6 +1321,57 @@ function OnboardingStepContent() {
   }
 }
 
+function OnboardingStepTelemetry() {
+  const captureStepViewed = useSet(captureOnboardingStepViewed$);
+  const effectiveStep = useLastResolved(onboardingEffectiveStep$);
+  const stepKey = useLastResolved(onboardingStepKey$);
+  const currentStepIndex = useLastResolved(onboardingCurrentStepIndex$) ?? 0;
+  const visibleSteps = useLastResolved(onboardingVisibleSteps$) ?? [];
+  const selectedConnectors =
+    useLastResolved(onboardingEffectiveConnectors$) ?? [];
+  const isUseCase = useGet(onboardingIsUseCase$);
+  const isAdmin = useLastResolved(onboardingIsAdmin$) ?? false;
+  const visibleStepsKey = visibleSteps.join(",");
+  const selectedConnectorsKey = selectedConnectors.join(",");
+
+  if (!effectiveStep || !stepKey) {
+    return null;
+  }
+
+  const telemetryKey = [
+    effectiveStep,
+    stepKey,
+    currentStepIndex,
+    visibleStepsKey,
+    selectedConnectorsKey,
+    isUseCase ? "use-case" : "default",
+    isAdmin ? "admin" : "member",
+  ].join("|");
+
+  return (
+    <span
+      hidden
+      ref={(node) => {
+        if (!node) {
+          return;
+        }
+        captureStepViewed({
+          telemetryKey,
+          step: effectiveStep,
+          stepKey,
+          currentStepIndex,
+          visibleSteps: visibleStepsKey ? visibleStepsKey.split(",") : [],
+          selectedConnectors: selectedConnectorsKey
+            ? selectedConnectorsKey.split(",")
+            : [],
+          isUseCase,
+          isAdmin,
+        });
+      }}
+    />
+  );
+}
+
 // ---------------------------------------------------------------------------
 // Zero onboarding — main export
 // ---------------------------------------------------------------------------
@@ -1342,6 +1395,7 @@ export function ZeroOnboarding() {
 
   return (
     <>
+      <OnboardingStepTelemetry />
       <OnboardingPageLayout>
         <OnboardingStepContent />
       </OnboardingPageLayout>


### PR DESCRIPTION
## Summary
- Add server-side PostHog capture helper for API routes and services.
- Track identified signup attribution, connector connection success, connector connected, task start, connector used in task, task completion or failure, checkout creation, Stripe checkout completion, subscription lifecycle, and invoice paid events.
- Add app-side onboarding step view tracking with local dedupe.

## Data-source audit before adding events
- PostHog had paid onboarding events, but production paid onboarding was mostly anonymous and could not reliably bridge to user or org.
- mask-db has connector, run, and subscription state, but no campaign or UTM attribution columns.
- Clerk connector currently points to development and had no production so.vm0.ai attribution users.
- Stripe has orgId on recent checkout and subscription objects, but no campaign metadata in the sampled recent objects.
- Plausible can validate landing traffic and UTM visitors, but cannot provide user_id, org_id, run, checkout, or subscription joins.

## Review focus
- Event naming and properties match the PostHog dashboard contract.
- Server-side events include only safe identifiers and status fields, with no prompts, task results, error text, Stripe customer IDs, or raw click IDs.
- Events should not block product flows if PostHog is unavailable.

## Validation
- NODE_OPTIONS=--max-old-space-size=4096 pnpm -F api check-types
- NODE_OPTIONS=--max-old-space-size=4096 pnpm -F api lint
- pnpm -F @vm0/app check-types
- pnpm -F @vm0/app lint

Note: Targeted tests were attempted earlier but local API tests required Postgres and platform tests did not settle cleanly in happy-dom, so they were not used as validation for this PR.