### PR TITLE
feat: add connector device auth start options

### DIFF
--- a/turbo/apps/api/src/signals/routes/__tests__/test-oauth-provider-get.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/test-oauth-provider-get.test.ts
@@ -263,6 +263,30 @@ describe("/api/test/oauth-provider/*", () => {
       });
     });
 
+    it("starts a device authorization session for the API device client", async () => {
+      mockEnv("ENV", "development");
+
+      const response = await requestApp(
+        DEVICE_AUTHORIZATION_ROUTE,
+        tokenRequest({
+          client_id: "test-oauth-device-api-client",
+          scope: "read",
+          mode: "live",
+        }),
+      );
+
+      expect(response.status).toBe(200);
+      await expect(readJson<DeviceAuthBody>(response)).resolves.toStrictEqual({
+        device_code: "test-device:test-oauth-device-api-client:read:live",
+        user_code: "TEST-DEVICE",
+        verification_uri: "https://oauth-device.test/device",
+        verification_uri_complete:
+          "https://oauth-device.test/device?user_code=TEST-DEVICE",
+        expires_in: 600,
+        interval: 0,
+      });
+    });
+
     it("requires the preview bypass secret", async () => {
       mockEnv("ENV", "preview");
       mockOptionalEnv("VERCEL_AUTOMATION_BYPASS_SECRET", "preview-secret");
@@ -685,6 +709,37 @@ describe("/api/test/oauth-provider/*", () => {
       await expect(readJson<TokenBody>(response)).resolves.toStrictEqual({
         access_token:
           "test-device-access:test-oauth-device-client:test-device:test-oauth-device-client:read",
+        token_type: "Bearer",
+        expires_in: 3600,
+        scope: "read",
+      });
+    });
+
+    it("exchanges an API client device code for an access token", async () => {
+      mockEnv("ENV", "development");
+
+      const device = await requestApp(
+        DEVICE_AUTHORIZATION_ROUTE,
+        tokenRequest({
+          client_id: "test-oauth-device-api-client",
+          scope: "read",
+          mode: "test",
+        }),
+      );
+      const deviceBody = await readJson<DeviceAuthBody>(device);
+      const response = await requestApp(
+        TOKEN_ROUTE,
+        tokenRequest({
+          grant_type: "urn:ietf:params:oauth:grant-type:device_code",
+          client_id: "test-oauth-device-api-client",
+          device_code: deviceBody.device_code,
+        }),
+      );
+
+      expect(response.status).toBe(200);
+      await expect(readJson<TokenBody>(response)).resolves.toStrictEqual({
+        access_token:
+          "test-device-access:test-oauth-device-api-client:test-device:test-oauth-device-api-client:read:test",
         token_type: "Bearer",
         expires_in: 3600,
         scope: "read",

--- a/turbo/apps/api/src/signals/routes/__tests__/zero-connectors-oauth-device-auth.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/zero-connectors-oauth-device-auth.test.ts
@@ -3,7 +3,10 @@ import { createHash, randomUUID } from "node:crypto";
 import { zeroConnectorOauthDeviceAuthSessionContract } from "@vm0/api-contracts/contracts/zero-connectors";
 import { FeatureSwitchKey } from "@vm0/connectors/feature-switch-key";
 import { slockProvider } from "@vm0/connectors/auth-providers/connectors/slock/provider";
-import { testOauthDeviceProvider } from "@vm0/connectors/auth-providers/connectors/test-oauth-device/provider";
+import {
+  testOauthDeviceApiProvider,
+  testOauthDeviceProvider,
+} from "@vm0/connectors/auth-providers/connectors/test-oauth-device/provider";
 import { connectors } from "@vm0/db/schema/connector";
 import { connectorOauthDeviceAuthorizationSessions } from "@vm0/db/schema/connector-oauth-device-authorization-session";
 import { secrets } from "@vm0/db/schema/secret";
@@ -33,6 +36,9 @@ import { createZeroRouteMocks } from "./helpers/zero-route-test";
 const context = testContext();
 const store = createStore();
 const mocks = createZeroRouteMocks(context);
+const originalStartDeviceAuth = testOauthDeviceProvider.grant.startDeviceAuth;
+const originalApiStartDeviceAuth =
+  testOauthDeviceApiProvider.grant.startDeviceAuth;
 const originalPollDeviceAuth = testOauthDeviceProvider.grant.pollDeviceAuth;
 const originalSlockPollDeviceAuth = slockProvider.grant.pollDeviceAuth;
 const TEST_OAUTH_DEVICE_CODE_URL =
@@ -130,8 +136,9 @@ function mockTestOAuthDeviceProvider(): void {
   server.use(
     http.post(TEST_OAUTH_DEVICE_CODE_URL, async ({ request }) => {
       const body = new URLSearchParams(await request.text());
+      const modeSuffix = body.get("mode") ? `:${body.get("mode")}` : "";
       return HttpResponse.json({
-        device_code: `test-device:${body.get("client_id")}:${body.get("scope")}`,
+        device_code: `test-device:${body.get("client_id")}:${body.get("scope")}${modeSuffix}`,
         user_code: "TEST-DEVICE",
         verification_uri: "https://oauth-device.test/device",
         verification_uri_complete:
@@ -417,6 +424,9 @@ describe("OAuth device authorization connector routes", () => {
   afterEach(async () => {
     clearMockedEnv();
     resetSecretKmsClientForTests();
+    testOauthDeviceProvider.grant.startDeviceAuth = originalStartDeviceAuth;
+    testOauthDeviceApiProvider.grant.startDeviceAuth =
+      originalApiStartDeviceAuth;
     testOauthDeviceProvider.grant.pollDeviceAuth = originalPollDeviceAuth;
     slockProvider.grant.pollDeviceAuth = originalSlockPollDeviceAuth;
     while (users.length > 0) {
@@ -584,6 +594,163 @@ describe("OAuth device authorization connector routes", () => {
         status: "awaiting_user_authorization",
       },
     );
+  });
+
+  it("applies default start options for an options-capable device auth method", async () => {
+    const { userId, orgId } = await setupUser();
+    const client = setupApp({ context })(
+      zeroConnectorOauthDeviceAuthSessionContract,
+    );
+
+    const response = await accept(
+      client.create({
+        params: { type: "test-oauth-device" },
+        body: { authMethod: "api" },
+        headers: { authorization: "Bearer clerk-session" },
+      }),
+      [200],
+    );
+
+    const session = await onlySession(response.body.sessionId);
+    const decryptedProviderState = await decryptPersistentSecretValue(
+      session.encryptedProviderState,
+      { orgId, userId },
+    );
+    expect(decryptedProviderState).toContain(
+      "test-device:test-oauth-device-api-client:read:test",
+    );
+  });
+
+  it("passes valid start options to the selected device auth provider", async () => {
+    const { userId, orgId } = await setupUser();
+    const client = setupApp({ context })(
+      zeroConnectorOauthDeviceAuthSessionContract,
+    );
+
+    const response = await accept(
+      client.create({
+        params: { type: "test-oauth-device" },
+        body: { authMethod: "api", options: { mode: "live" } },
+        headers: { authorization: "Bearer clerk-session" },
+      }),
+      [200],
+    );
+
+    const session = await onlySession(response.body.sessionId);
+    const decryptedProviderState = await decryptPersistentSecretValue(
+      session.encryptedProviderState,
+      { orgId, userId },
+    );
+    expect(decryptedProviderState).toContain(
+      "test-device:test-oauth-device-api-client:read:live",
+    );
+  });
+
+  it("rejects start options for no-options device auth methods before provider start", async () => {
+    await setupUser();
+    const client = setupApp({ context })(
+      zeroConnectorOauthDeviceAuthSessionContract,
+    );
+    let startCalled = false;
+    testOauthDeviceProvider.grant.startDeviceAuth = async (args) => {
+      startCalled = true;
+      return await originalStartDeviceAuth(args);
+    };
+
+    const response = await accept(
+      client.create({
+        params: { type: "test-oauth-device" },
+        body: { authMethod: "oauth", options: { mode: "live" } },
+        headers: { authorization: "Bearer clerk-session" },
+      }),
+      [400],
+    );
+
+    expect(response.body.error.message).toBe(
+      "test-oauth-device oauth device-auth start options are not supported: mode",
+    );
+    expect(startCalled).toBeFalsy();
+  });
+
+  it("rejects invalid start option values before provider start", async () => {
+    await setupUser();
+    const client = setupApp({ context })(
+      zeroConnectorOauthDeviceAuthSessionContract,
+    );
+    let startCalled = false;
+    testOauthDeviceApiProvider.grant.startDeviceAuth = async (args) => {
+      startCalled = true;
+      return await originalApiStartDeviceAuth(args);
+    };
+
+    const response = await accept(
+      client.create({
+        params: { type: "test-oauth-device" },
+        body: { authMethod: "api", options: { mode: "production" } },
+        headers: { authorization: "Bearer clerk-session" },
+      }),
+      [400],
+    );
+
+    expect(response.body.error.message).toBe(
+      "test-oauth-device api device-auth start option mode must be one of: test, live",
+    );
+    expect(startCalled).toBeFalsy();
+  });
+
+  it("rejects unexpected start option keys before provider start", async () => {
+    await setupUser();
+    const client = setupApp({ context })(
+      zeroConnectorOauthDeviceAuthSessionContract,
+    );
+    let startCalled = false;
+    testOauthDeviceApiProvider.grant.startDeviceAuth = async (args) => {
+      startCalled = true;
+      return await originalApiStartDeviceAuth(args);
+    };
+
+    const response = await accept(
+      client.create({
+        params: { type: "test-oauth-device" },
+        body: { authMethod: "api", options: { region: "us" } },
+        headers: { authorization: "Bearer clerk-session" },
+      }),
+      [400],
+    );
+
+    expect(response.body.error.message).toBe(
+      "test-oauth-device api device-auth start option region is not supported",
+    );
+    expect(startCalled).toBeFalsy();
+  });
+
+  it("rejects start option keys that collide with object prototype names before provider start", async () => {
+    await setupUser();
+    const client = setupApp({ context })(
+      zeroConnectorOauthDeviceAuthSessionContract,
+    );
+    let startCalled = false;
+    testOauthDeviceApiProvider.grant.startDeviceAuth = async (args) => {
+      startCalled = true;
+      return await originalApiStartDeviceAuth(args);
+    };
+
+    const response = await accept(
+      client.create({
+        params: { type: "test-oauth-device" },
+        body: {
+          authMethod: "api",
+          options: Object.fromEntries([["toString", "live"]]),
+        },
+        headers: { authorization: "Bearer clerk-session" },
+      }),
+      [400],
+    );
+
+    expect(response.body.error.message).toBe(
+      "test-oauth-device api device-auth start option toString is not supported",
+    );
+    expect(startCalled).toBeFalsy();
   });
 
   it("does not persist a superseded session that completes after a new session starts", async () => {
@@ -931,7 +1098,7 @@ describe("OAuth device authorization connector routes", () => {
     await expect(
       connectorSecretValue(userId, orgId, "TEST_OAUTH_DEVICE_API_ACCESS_TOKEN"),
     ).resolves.toBe(
-      "test-device-access:test-oauth-device-api-client:test-device:test-oauth-device-api-client:read",
+      "test-device-access:test-oauth-device-api-client:test-device:test-oauth-device-api-client:read:test",
     );
 
     const stored = await store

--- a/turbo/apps/api/src/signals/routes/test-oauth-provider-device-auth.ts
+++ b/turbo/apps/api/src/signals/routes/test-oauth-provider-device-auth.ts
@@ -4,8 +4,8 @@ import { testOAuthProviderDeviceAuthContract } from "@vm0/api-contracts/contract
 import { request$ } from "../context/hono";
 import type { RouteEntry } from "../route";
 import {
+  isTestOAuthDeviceClientId,
   isTestEndpointAllowed,
-  TEST_OAUTH_DEVICE_CLIENT_ID,
   TEST_OAUTH_DEVICE_USER_CODE,
   TEST_OAUTH_DEVICE_VERIFICATION_URI,
   testEndpointNotFoundResponse,
@@ -43,12 +43,13 @@ const deviceAuth$ = command(async ({ get }, signal: AbortSignal) => {
 
   const body = new URLSearchParams(text);
   const clientId = body.get("client_id");
-  if (clientId !== TEST_OAUTH_DEVICE_CLIENT_ID) {
+  if (!isTestOAuthDeviceClientId(clientId)) {
     return errorResponse(401, "invalid_client");
   }
 
   const scope = body.get("scope") ?? "";
-  const deviceCode = `test-device:${clientId}:${scope}`;
+  const mode = body.get("mode");
+  const deviceCode = `test-device:${clientId}:${scope}${mode ? `:${mode}` : ""}`;
   return {
     status: 200 as const,
     body: {

--- a/turbo/apps/api/src/signals/routes/test-oauth-provider-helpers.ts
+++ b/turbo/apps/api/src/signals/routes/test-oauth-provider-helpers.ts
@@ -5,10 +5,12 @@ import { now } from "../../lib/time";
 
 export const TEST_OAUTH_CLIENT_ID = "test-oauth-client";
 export const TEST_OAUTH_CLIENT_SECRET = "test-oauth-secret";
-export const TEST_OAUTH_DEVICE_CLIENT_ID = "test-oauth-device-client";
 export const TEST_OAUTH_DEVICE_USER_CODE = "TEST-DEVICE";
 export const TEST_OAUTH_DEVICE_VERIFICATION_URI =
   "https://oauth-device.test/device";
+
+const TEST_OAUTH_DEVICE_CLIENT_ID = "test-oauth-device-client";
+const TEST_OAUTH_DEVICE_API_CLIENT_ID = "test-oauth-device-api-client";
 
 const TEST_OAUTH_SCENARIOS = [
   "success",
@@ -78,6 +80,13 @@ export function isTestEndpointAllowed(request: HeaderReader): boolean {
 
 export function testEndpointNotFoundResponse(): Response {
   return new Response("Not found", { status: 404 });
+}
+
+export function isTestOAuthDeviceClientId(clientId: string | null): boolean {
+  return (
+    clientId === TEST_OAUTH_DEVICE_CLIENT_ID ||
+    clientId === TEST_OAUTH_DEVICE_API_CLIENT_ID
+  );
 }
 
 export function parseTestOAuthScenario(

--- a/turbo/apps/api/src/signals/routes/test-oauth-provider-token.ts
+++ b/turbo/apps/api/src/signals/routes/test-oauth-provider-token.ts
@@ -9,6 +9,7 @@ import { request$ } from "../context/hono";
 import type { RouteEntry } from "../route";
 import {
   isTestEndpointAllowed,
+  isTestOAuthDeviceClientId,
   isTestOAuthRefreshToken,
   mintAccessToken,
   mintRefreshToken,
@@ -16,7 +17,6 @@ import {
   parseScenarioFromRefreshToken,
   TEST_OAUTH_CLIENT_ID,
   TEST_OAUTH_CLIENT_SECRET,
-  TEST_OAUTH_DEVICE_CLIENT_ID,
   testEndpointNotFoundResponse,
   type TestOAuthScenario,
 } from "./test-oauth-provider-helpers";
@@ -126,7 +126,7 @@ function deviceGrantErrorForDeviceCode(
 
 function handleDeviceCode(body: URLSearchParams) {
   const clientId = body.get("client_id");
-  if (clientId !== TEST_OAUTH_DEVICE_CLIENT_ID) {
+  if (!isTestOAuthDeviceClientId(clientId)) {
     return errorResponse(401, "invalid_client");
   }
 

--- a/turbo/apps/api/src/signals/routes/zero-connectors-oauth-device-auth.ts
+++ b/turbo/apps/api/src/signals/routes/zero-connectors-oauth-device-auth.ts
@@ -36,6 +36,7 @@ const startConnectorOauthDeviceAuthSessionInner$ = command(
         userId: auth.userId,
         type: params.type,
         authMethod: body.data.authMethod,
+        options: body.data.options,
       },
       signal,
     );

--- a/turbo/apps/api/src/signals/services/connector-oauth-device-auth.service.ts
+++ b/turbo/apps/api/src/signals/services/connector-oauth-device-auth.service.ts
@@ -15,6 +15,7 @@ import {
   connectorAuthMethodRefHasGrantKind,
   getConnectorAuthMethod,
   getConnectorAuthMethodIdsForGrantKind,
+  parseConnectorDeviceAuthStartOptions,
   resolveConnectorResolvedAuthMethodClientByGrantKind,
   type ConnectorResolvedAuthMethodClientByGrantKind,
   type ConnectorAuthMethodRef,
@@ -721,6 +722,7 @@ export const startConnectorOauthDeviceAuthSession$ = command(
       readonly userId: string;
       readonly type: ConnectorType;
       readonly authMethod: ConnectorAuthMethodId;
+      readonly options?: Readonly<Record<string, string>>;
     },
     signal: AbortSignal,
   ) => {
@@ -748,7 +750,19 @@ export const startConnectorOauthDeviceAuthSession$ = command(
       return resolvedClient;
     }
 
-    const startResult = await startConnectorDeviceAuthorization(resolvedClient);
+    const startOptionsResult = parseConnectorDeviceAuthStartOptions({
+      type: resolvedMethod.type,
+      authMethod: resolvedMethod.authMethod,
+      options: args.options,
+    });
+    if (!startOptionsResult.success) {
+      return badRequestMessage(startOptionsResult.message);
+    }
+
+    const startResult = await startConnectorDeviceAuthorization({
+      ...resolvedClient,
+      options: startOptionsResult.options,
+    });
     signal.throwIfAborted();
 
     const sessionToken = generateSessionToken();

--- a/turbo/apps/platform/src/signals/zero-page/settings/__tests__/connect-connector.test.ts
+++ b/turbo/apps/platform/src/signals/zero-page/settings/__tests__/connect-connector.test.ts
@@ -646,9 +646,11 @@ describe("connectConnectorOAuthDeviceAuth$", () => {
 
     const connectPromise = context.store.set(
       connectConnectorOAuthDeviceAuth$,
-      "test-oauth-device",
-      "oauth",
-      {},
+      {
+        type: "test-oauth-device",
+        authMethod: "oauth",
+        options: {},
+      },
       context.signal,
     );
 
@@ -675,6 +677,75 @@ describe("connectConnectorOAuthDeviceAuth$", () => {
       "_blank",
     );
     expect(context.store.get(pollingOAuthDeviceAuthConnectorType$)).toBeNull();
+  });
+
+  it("sends selected start options when creating a device auth session", async () => {
+    detachedSetupPage({
+      context,
+      path: "/",
+      withoutRender: true,
+      featureSwitches: { [FeatureSwitchKey.TestOauthConnector]: true },
+    });
+
+    let submittedBody:
+      | {
+          readonly authMethod: string;
+          readonly options?: Record<string, string>;
+        }
+      | undefined;
+    server.use(
+      mockApi(
+        zeroConnectorOauthDeviceAuthSessionContract.create,
+        ({ body, params, respond }) => {
+          submittedBody = body;
+          return respond(200, {
+            sessionId: "00000000-0000-4000-8000-000000000124",
+            sessionToken: "device-session-token",
+            type: params.type,
+            status: "pending",
+            userCode: "VM0-DEVICE",
+            verificationUri: "https://oauth.test/device",
+            verificationUriComplete:
+              "https://oauth.test/device?user_code=VM0-DEVICE",
+            expiresIn: 300,
+            interval: 1,
+          });
+        },
+      ),
+      mockApi(zeroConnectorOauthDeviceAuthSessionContract.poll, ({ never }) => {
+        return never();
+      }),
+    );
+
+    const connectPromise = (async () => {
+      try {
+        return await context.store.set(
+          connectConnectorOAuthDeviceAuth$,
+          {
+            type: "test-oauth-device",
+            authMethod: "api",
+            options: {},
+            startOptions: { mode: "live" },
+          },
+          context.signal,
+        );
+      } catch (error) {
+        return returnFalseForAbortError(error);
+      }
+    })();
+
+    await vi.waitFor(() => {
+      expect(context.store.get(connectorOAuthDeviceAuthState$).status).toBe(
+        "pending",
+      );
+    });
+    expect(submittedBody).toStrictEqual({
+      authMethod: "api",
+      options: { mode: "live" },
+    });
+
+    context.store.set(clearConnectorOAuthDeviceAuth$);
+    await expect(connectPromise).resolves.toBeFalsy();
   });
 
   it("opens the verification URI when complete verification URI is absent", async () => {
@@ -718,9 +789,11 @@ describe("connectConnectorOAuthDeviceAuth$", () => {
 
     const connectPromise = context.store.set(
       connectConnectorOAuthDeviceAuth$,
-      "test-oauth-device",
-      "oauth",
-      {},
+      {
+        type: "test-oauth-device",
+        authMethod: "oauth",
+        options: {},
+      },
       context.signal,
     );
 
@@ -784,9 +857,11 @@ describe("connectConnectorOAuthDeviceAuth$", () => {
       try {
         return await context.store.set(
           connectConnectorOAuthDeviceAuth$,
-          "test-oauth-device",
-          "oauth",
-          {},
+          {
+            type: "test-oauth-device",
+            authMethod: "oauth",
+            options: {},
+          },
           context.signal,
         );
       } catch (error) {
@@ -860,9 +935,11 @@ describe("connectConnectorOAuthDeviceAuth$", () => {
       try {
         return await context.store.set(
           connectConnectorOAuthDeviceAuth$,
-          "test-oauth-device",
-          "oauth",
-          {},
+          {
+            type: "test-oauth-device",
+            authMethod: "oauth",
+            options: {},
+          },
           flowSignal,
         );
       } catch (error) {

--- a/turbo/apps/platform/src/signals/zero-page/settings/connectors.ts
+++ b/turbo/apps/platform/src/signals/zero-page/settings/connectors.ts
@@ -7,6 +7,7 @@ import {
   CONNECTOR_TYPES,
   connectorAuthMethodIdSchema,
   type ConnectorAuthMethodId,
+  type ConnectorDeviceAuthStartOptions,
   type ConnectorType,
   type ConnectorDisplayCategory,
 } from "@vm0/connectors/connectors";
@@ -593,6 +594,9 @@ const internalConnectorOAuthDeviceAuthState$ =
     createIdleConnectorOAuthDeviceAuthState(),
   );
 const resetConnectorOAuthDeviceAuthFlowSignal$ = resetSignal();
+const connectorOAuthDeviceAuthStartOptionValues$ = state<
+  Record<string, Record<string, string>>
+>({});
 
 export const selectedConnectorType$ = computed((get) => {
   return get(internalSelectedConnectorType$);
@@ -614,6 +618,51 @@ export const setSelectedConnectorType$ = command(
 export const connectorOAuthDeviceAuthState$ = computed((get) => {
   return get(internalConnectorOAuthDeviceAuthState$);
 });
+
+function connectorOAuthDeviceAuthStartOptionsKey(
+  type: ConnectorType,
+  authMethod: ConnectorAuthMethodId,
+): string {
+  return `${type}:${authMethod}`;
+}
+
+export const connectorOAuthDeviceAuthStartOptionValuesFor$ = (
+  type: ConnectorType,
+  authMethod: ConnectorAuthMethodId,
+) => {
+  return computed((get) => {
+    return (
+      get(connectorOAuthDeviceAuthStartOptionValues$)[
+        connectorOAuthDeviceAuthStartOptionsKey(type, authMethod)
+      ] ?? {}
+    );
+  });
+};
+
+export const setConnectorOAuthDeviceAuthStartOptionValue$ = command(
+  (
+    { get, set },
+    args: {
+      readonly type: ConnectorType;
+      readonly authMethod: ConnectorAuthMethodId;
+      readonly name: string;
+      readonly value: string;
+    },
+  ) => {
+    const key = connectorOAuthDeviceAuthStartOptionsKey(
+      args.type,
+      args.authMethod,
+    );
+    const current = get(connectorOAuthDeviceAuthStartOptionValues$);
+    set(connectorOAuthDeviceAuthStartOptionValues$, {
+      ...current,
+      [key]: {
+        ...current[key],
+        [args.name]: args.value,
+      },
+    });
+  },
+);
 
 // ---------------------------------------------------------------------------
 // Scope review modal state
@@ -905,6 +954,13 @@ type PollConnectorOAuthDeviceAuthArgs = {
   readonly options: PostConnectOptions;
 };
 
+type ConnectConnectorOAuthDeviceAuthParams = {
+  readonly type: ConnectorType;
+  readonly authMethod: ConnectorAuthMethodId;
+  readonly options: PostConnectOptions;
+  readonly startOptions?: ConnectorDeviceAuthStartOptions;
+};
+
 function createConnectorOAuthDeviceAuthRequestId(type: ConnectorType): string {
   return `${type}-oauth-device-${Date.now()}-${Math.random().toString(36).slice(2)}`;
 }
@@ -1134,11 +1190,10 @@ const pollConnectorOAuthDeviceAuth$ = command(
 export const connectConnectorOAuthDeviceAuth$ = command(
   async (
     { get, set },
-    type: ConnectorType,
-    authMethod: ConnectorAuthMethodId,
-    options: PostConnectOptions,
+    args: ConnectConnectorOAuthDeviceAuthParams,
     signal: AbortSignal,
   ): Promise<boolean> => {
+    const { type, authMethod, options, startOptions } = args;
     if (!hasConnectorDeviceAuthGrant(type)) {
       throw new Error(`${type} does not use device authorization OAuth`);
     }
@@ -1165,11 +1220,18 @@ export const connectConnectorOAuthDeviceAuth$ = command(
         const client = createClient(
           zeroConnectorOauthDeviceAuthSessionContract,
         );
+        const startOptionEntries = Object.entries(startOptions ?? {});
         const startSettled = await settle(
           accept(
             client.create({
               params: { type },
-              body: { authMethod },
+              body:
+                startOptionEntries.length > 0
+                  ? {
+                      authMethod,
+                      options: Object.fromEntries(startOptionEntries),
+                    }
+                  : { authMethod },
               fetchOptions: { signal: flowSignal },
             }),
             [200],
@@ -1258,14 +1320,18 @@ export const connectConnectorOAuthDeviceAuthAndSettle$ = command(
       readonly authMethod: ConnectorAuthMethodId;
       readonly onSuccess: () => void | Promise<void>;
       readonly options: PostConnectOptions;
+      readonly startOptions?: ConnectorDeviceAuthStartOptions;
     },
     signal: AbortSignal,
   ): Promise<void> => {
     const connected = await set(
       connectConnectorOAuthDeviceAuth$,
-      args.type,
-      args.authMethod,
-      args.options,
+      {
+        type: args.type,
+        authMethod: args.authMethod,
+        options: args.options,
+        startOptions: args.startOptions,
+      },
       signal,
     );
     if (connected) {

--- a/turbo/apps/platform/src/views/conn/__tests__/add-connection-dialog.test.tsx
+++ b/turbo/apps/platform/src/views/conn/__tests__/add-connection-dialog.test.tsx
@@ -14,6 +14,7 @@ import type { ConnectorType } from "@vm0/connectors/connectors";
 import { FeatureSwitchKey } from "@vm0/connectors/feature-switch-key";
 import {
   zeroConnectorManualGrantContract,
+  zeroConnectorOauthDeviceAuthSessionContract,
   zeroConnectorOauthStartContract,
   zeroConnectorsMainContract,
 } from "@vm0/api-contracts/contracts/zero-connectors";
@@ -74,14 +75,7 @@ function getButtonByText(matcher: string | RegExp): HTMLElement {
 }
 
 async function clickTestOAuthDeviceConnectButton() {
-  const heading = await screen.findByRole("heading", {
-    name: "OAuth Device Authorization",
-  });
-  const section = heading.parentElement;
-  if (!section) {
-    throw new Error("OAuth Device Authorization section not found");
-  }
-
+  const section = await findConnectMethodSection("OAuth Device Authorization");
   const button = queryAllByRoleFast("button", section).find((element) => {
     return elementTextMatches(element, "Connect Test OAuth Device (internal)");
   });
@@ -89,6 +83,27 @@ async function clickTestOAuthDeviceConnectButton() {
     throw new Error("Test OAuth device connect button not found");
   }
 
+  await userEvent.click(button);
+}
+
+async function findConnectMethodSection(name: string): Promise<HTMLElement> {
+  const heading = await screen.findByRole("heading", { name });
+  const section = heading.parentElement;
+  if (!section) {
+    throw new Error(`${name} section not found`);
+  }
+  return section;
+}
+
+async function clickConnectButtonInSection(
+  section: HTMLElement,
+): Promise<void> {
+  const button = queryAllByRoleFast("button", section).find((element) => {
+    return elementTextMatches(element, "Connect Test OAuth Device (internal)");
+  });
+  if (!button) {
+    throw new Error("Connect button not found");
+  }
   await userEvent.click(button);
 }
 
@@ -257,6 +272,59 @@ describe("connect modal - content by auth method", () => {
     expect(
       screen.queryByText("Connection methods unavailable"),
     ).not.toBeInTheDocument();
+  });
+
+  it("renders device auth start options and sends the selected value", async () => {
+    let submittedBody:
+      | {
+          readonly authMethod: string;
+          readonly options?: Record<string, string>;
+        }
+      | undefined;
+    server.use(
+      mockApi(
+        zeroConnectorOauthDeviceAuthSessionContract.create,
+        ({ body, params, respond }) => {
+          submittedBody = body;
+          return respond(200, {
+            sessionId: "00000000-0000-4000-8000-000000000103",
+            sessionToken: "device-session-token",
+            type: params.type,
+            status: "pending",
+            userCode: "VM0-DEVICE",
+            verificationUri: "https://oauth.test/test-oauth-device/device",
+            verificationUriComplete:
+              "https://oauth.test/test-oauth-device/device?user_code=VM0-DEVICE",
+            expiresIn: 300,
+            interval: 1,
+          });
+        },
+      ),
+    );
+
+    await openConnectModal("test-oauth-device", {
+      featureSwitches: { [FeatureSwitchKey.TestOauthConnector]: true },
+    });
+
+    const section = await findConnectMethodSection("API Device Authorization");
+    const modeSelect = within(section).getByRole("combobox", { name: "Mode" });
+    expect(modeSelect).toHaveTextContent("Test");
+
+    await userEvent.click(modeSelect);
+    await userEvent.click(await screen.findByRole("option", { name: "Live" }));
+    expect(modeSelect).toHaveTextContent("Live");
+
+    await clickConnectButtonInSection(section);
+
+    await waitFor(() => {
+      expect(
+        screen.getByTestId("connector-oauth-device-code"),
+      ).toHaveTextContent("VM0-DEVICE");
+    });
+    expect(submittedBody).toStrictEqual({
+      authMethod: "api",
+      options: { mode: "live" },
+    });
   });
 
   it("opens the verification URI when the complete verification URI is absent", async () => {

--- a/turbo/apps/platform/src/views/zero-page/components/settings/add-connection-dialog.tsx
+++ b/turbo/apps/platform/src/views/zero-page/components/settings/add-connection-dialog.tsx
@@ -4,6 +4,13 @@ import { Input } from "@vm0/ui/components/ui/input";
 import { Button } from "@vm0/ui/components/ui/button";
 import { CopyButton } from "@vm0/ui/components/ui/copy-button";
 import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@vm0/ui/components/ui/select";
+import {
   Dialog,
   DialogContent,
   DialogHeader,
@@ -13,6 +20,8 @@ import {
   CONNECTOR_TYPES,
   type ConnectorAuthMethodConfig,
   type ConnectorAuthMethodId,
+  type ConnectorDeviceAuthStartOptions,
+  type ConnectorDeviceAuthStartOptionsConfig,
   type ConnectorManualGrantConfig,
   type ConnectorType,
 } from "@vm0/connectors/connectors";
@@ -27,6 +36,8 @@ import {
   connectConnectorOAuthDeviceAuthAndSettle$,
   openConnectorOAuthDeviceAuthVerificationPage$,
   clearConnectorOAuthDeviceAuth$,
+  connectorOAuthDeviceAuthStartOptionValuesFor$,
+  setConnectorOAuthDeviceAuthStartOptionValue$,
   runConnectorConnectSuccess$,
   submitManualGrant$,
   setManualGrantFormValue$,
@@ -90,10 +101,13 @@ type ConnectOAuthAuthCodeAndSettleFn = (
 ) => Promise<void>;
 
 type ConnectOAuthDeviceAuthAndSettleFn = (
-  type: ConnectorType,
-  authMethod: ConnectorAuthMethodId,
-  onSuccess: () => void | Promise<void>,
-  options: PostConnectOptions,
+  args: {
+    readonly type: ConnectorType;
+    readonly authMethod: ConnectorAuthMethodId;
+    readonly onSuccess: () => void | Promise<void>;
+    readonly options: PostConnectOptions;
+    readonly startOptions?: ConnectorDeviceAuthStartOptions;
+  },
   signal: AbortSignal,
 ) => Promise<void>;
 
@@ -391,11 +405,153 @@ function OAuthDeviceAuthCodePanel({
   );
 }
 
+function defaultDeviceAuthStartOptionValues(
+  startOptions: ConnectorDeviceAuthStartOptionsConfig | undefined,
+): Record<string, string> {
+  if (!startOptions) {
+    return {};
+  }
+  return Object.fromEntries(
+    Object.entries(startOptions).flatMap(([name, config]) => {
+      return config.defaultValue === undefined
+        ? []
+        : ([[name, config.defaultValue]] as const);
+    }),
+  );
+}
+
+function deviceAuthStartOptionValue(
+  values: Record<string, string>,
+  name: string,
+): string | undefined {
+  return Object.hasOwn(values, name) ? values[name] : undefined;
+}
+
+function selectedDeviceAuthStartOptions(
+  startOptions: ConnectorDeviceAuthStartOptionsConfig | undefined,
+  values: Record<string, string>,
+): ConnectorDeviceAuthStartOptions | undefined {
+  if (!startOptions) {
+    return undefined;
+  }
+  const selectedEntries = Object.entries(startOptions).flatMap(
+    ([name, config]) => {
+      const value =
+        deviceAuthStartOptionValue(values, name) ?? config.defaultValue;
+      return value === undefined ? [] : ([[name, value]] as const);
+    },
+  );
+  return selectedEntries.length === 0
+    ? undefined
+    : Object.fromEntries(selectedEntries);
+}
+
+function deviceAuthStartOptionsFilled(
+  startOptions: ConnectorDeviceAuthStartOptionsConfig | undefined,
+  values: Record<string, string>,
+): boolean {
+  if (!startOptions) {
+    return true;
+  }
+  return Object.entries(startOptions).every(([name, config]) => {
+    return (
+      !config.required ||
+      Boolean(deviceAuthStartOptionValue(values, name) ?? config.defaultValue)
+    );
+  });
+}
+
+function OAuthDeviceAuthStartOptionsForm({
+  type,
+  authMethod,
+  startOptions,
+  values,
+  setValue,
+}: {
+  type: ConnectorType;
+  authMethod: ConnectorAuthMethodId;
+  startOptions: ConnectorDeviceAuthStartOptionsConfig | undefined;
+  values: Record<string, string>;
+  setValue: (name: string, value: string) => void;
+}) {
+  if (!startOptions) {
+    return null;
+  }
+
+  return (
+    <>
+      {Object.entries(startOptions).map(([name, config]) => {
+        const inputId = `connector-device-auth-option-${type}-${authMethod}-${name}`;
+        return (
+          <div key={name} className="flex flex-col gap-1.5">
+            <label
+              htmlFor={inputId}
+              className="text-sm font-medium text-foreground"
+            >
+              {config.label}
+            </label>
+            <Select
+              value={
+                deviceAuthStartOptionValue(values, name) ?? config.defaultValue
+              }
+              onValueChange={(value) => {
+                setValue(name, value);
+              }}
+            >
+              <SelectTrigger id={inputId} className="h-9">
+                <SelectValue placeholder={`Select ${config.label}`} />
+              </SelectTrigger>
+              <SelectContent>
+                {config.options.map((option) => {
+                  return (
+                    <SelectItem key={option.value} value={option.value}>
+                      {option.label}
+                    </SelectItem>
+                  );
+                })}
+              </SelectContent>
+            </Select>
+          </div>
+        );
+      })}
+    </>
+  );
+}
+
 function OAuthDeviceAuthConnectMethodContent(props: ConnectMethodContentProps) {
   const state = useGet(connectorOAuthDeviceAuthState$);
   const openVerificationPage = useSet(
     openConnectorOAuthDeviceAuthVerificationPage$,
   );
+  const setStartOptionValueCommand = useSet(
+    setConnectorOAuthDeviceAuthStartOptionValue$,
+  );
+  const startOptions =
+    props.method.grant.kind === "device-auth"
+      ? props.method.grant.startOptions
+      : undefined;
+  const startOptionValues = useGet(
+    connectorOAuthDeviceAuthStartOptionValuesFor$(
+      props.item.type,
+      props.authMethod,
+    ),
+  );
+  const effectiveStartOptionValues = {
+    ...defaultDeviceAuthStartOptionValues(startOptions),
+    ...startOptionValues,
+  };
+  const startOptionsFilled = deviceAuthStartOptionsFilled(
+    startOptions,
+    effectiveStartOptionValues,
+  );
+  const setStartOptionValue = (name: string, value: string) => {
+    setStartOptionValueCommand({
+      type: props.item.type,
+      authMethod: props.authMethod,
+      name,
+      value,
+    });
+  };
   const current = connectorOAuthDeviceAuthStateForMethod(
     state,
     props.item.type,
@@ -405,11 +561,17 @@ function OAuthDeviceAuthConnectMethodContent(props: ConnectMethodContentProps) {
 
   const start = onDomEventFn(async () => {
     await props.connectOAuthDeviceAuthAndSettle(
-      props.item.type,
-      props.authMethod,
-      props.onSuccess,
       {
-        showPermissionDialog: props.showPermissionDialogOnConnect,
+        type: props.item.type,
+        authMethod: props.authMethod,
+        onSuccess: props.onSuccess,
+        options: {
+          showPermissionDialog: props.showPermissionDialogOnConnect,
+        },
+        startOptions: selectedDeviceAuthStartOptions(
+          startOptions,
+          effectiveStartOptionValues,
+        ),
       },
       props.signal,
     );
@@ -439,6 +601,13 @@ function OAuthDeviceAuthConnectMethodContent(props: ConnectMethodContentProps) {
   ) {
     return (
       <div className="flex flex-col gap-3">
+        <OAuthDeviceAuthStartOptionsForm
+          type={props.item.type}
+          authMethod={props.authMethod}
+          startOptions={startOptions}
+          values={effectiveStartOptionValues}
+          setValue={setStartOptionValue}
+        />
         <p className="text-sm text-destructive" role="alert">
           {current.message}
         </p>
@@ -446,7 +615,7 @@ function OAuthDeviceAuthConnectMethodContent(props: ConnectMethodContentProps) {
           type="button"
           variant="outline"
           onClick={start}
-          disabled={starting}
+          disabled={starting || !startOptionsFilled}
           className="w-full"
         >
           {starting ? "Starting..." : "Try again"}
@@ -461,11 +630,18 @@ function OAuthDeviceAuthConnectMethodContent(props: ConnectMethodContentProps) {
         Connect to get a verification code, then use it on the provider&apos;s
         verification page to approve access.
       </p>
+      <OAuthDeviceAuthStartOptionsForm
+        type={props.item.type}
+        authMethod={props.authMethod}
+        startOptions={startOptions}
+        values={effectiveStartOptionValues}
+        setValue={setStartOptionValue}
+      />
       <Button
         type="button"
         variant="outline"
         onClick={start}
-        disabled={starting}
+        disabled={starting || !startOptionsFilled}
         className="w-full"
       >
         {starting
@@ -590,7 +766,10 @@ function ConnectMethodsContent({
     <>
       {entries.map(({ authMethod, method, Content }, index) => {
         return (
-          <div key={authMethod} className="flex flex-col gap-3">
+          <div
+            key={`${props.item.type}:${authMethod}`}
+            className="flex flex-col gap-3"
+          >
             {index > 0 && <AuthMethodDivider />}
             <ConnectMethodHeading method={method} show={showMethodHeadings} />
             <Content {...props} authMethod={authMethod} method={method} />
@@ -697,9 +876,15 @@ function ConnectModalContent({
     );
   };
   const connectOAuthDeviceAuthAndSettleCommandFn: ConnectOAuthDeviceAuthAndSettleFn =
-    async (type, authMethod, connectSuccess, options, signal) => {
+    async (args, signal) => {
       await connectOAuthDeviceAuthAndSettle(
-        { type, authMethod, onSuccess: connectSuccess, options },
+        {
+          type: args.type,
+          authMethod: args.authMethod,
+          onSuccess: args.onSuccess,
+          options: args.options,
+          startOptions: args.startOptions,
+        },
         signal,
       );
     };

--- a/turbo/packages/api-contracts/src/contracts/zero-connectors.ts
+++ b/turbo/packages/api-contracts/src/contracts/zero-connectors.ts
@@ -134,7 +134,10 @@ export const zeroConnectorOauthDeviceAuthSessionContract = c.router({
     path: "/api/zero/connectors/:type/oauth/device/sessions",
     headers: authHeadersSchema,
     pathParams: z.object({ type: connectorTypeSchema }),
-    body: z.object({ authMethod: connectorAuthMethodIdSchema }),
+    body: z.object({
+      authMethod: connectorAuthMethodIdSchema,
+      options: z.record(z.string(), z.string()).optional(),
+    }),
     responses: {
       200: connectorOauthDeviceAuthSessionStartResponseSchema,
       400: apiErrorSchema,

--- a/turbo/packages/connectors/src/__tests__/connectors.test.ts
+++ b/turbo/packages/connectors/src/__tests__/connectors.test.ts
@@ -46,6 +46,7 @@ import {
   hasRequiredConnectorAuthMethodScopes,
   getConnectorAuthMethodAuthCodeGrantConfig,
   getConnectorAuthMethodDeviceAuthGrantConfig,
+  getConnectorAuthMethodDeviceAuthStartOptionsConfig,
   getConnectorAuthMethodAccessMetadata,
   getConnectorAuthMethodRuntimeMetadata,
   getConnectorGrantOutputSecretName,
@@ -59,6 +60,7 @@ import {
   getConnectorManualGrantFieldNames,
   getConnectorManualGrantFieldNamesForAuthMethod,
   getRuntimeAvailableConnectorTypes,
+  parseConnectorDeviceAuthStartOptions,
   getConnectorOwnedSecretNames,
   getConnectorOwnedVariableNames,
   hasConnectorAuthCodeGrant,
@@ -1097,6 +1099,7 @@ describe("connector selected auth method capability checks", () => {
       type: "test-oauth-device",
       authMethod: "oauth",
       authClient: oauthClient,
+      options: {},
     });
     expect(startResult).toStrictEqual({
       deviceCode: "test-device:test-oauth-device-client:read",
@@ -1206,6 +1209,100 @@ describe("connector selected auth method capability checks", () => {
       getConnectorAuthMethodGrantMetadata("test-oauth-device", "api")?.outputs
         .accessToken?.secretName,
     ).toBe(TEST_OAUTH_DEVICE_API_ACCESS_SECRET_NAME);
+  });
+
+  it("passes validated start options to the test OAuth device API provider", async () => {
+    server.use(
+      http.post(
+        /\/api\/test\/oauth-provider\/device\/code$/,
+        async ({ request }) => {
+          const body = new URLSearchParams(await request.text());
+          expect(body.get("client_id")).toBe("test-oauth-device-api-client");
+          expect(body.get("scope")).toBe("read");
+          expect(body.get("mode")).toBe("live");
+          return HttpResponse.json({
+            device_code: `test-device:${body.get("client_id")}:${body.get("scope")}:${body.get("mode")}`,
+            user_code: "TEST-DEVICE",
+            verification_uri: "https://oauth-device.test/device",
+            verification_uri_complete:
+              "https://oauth-device.test/device?user_code=TEST-DEVICE",
+            expires_in: 600,
+            interval: 0,
+          });
+        },
+      ),
+    );
+
+    const apiClient = resolveConnectorAuthClientForMethod(
+      "test-oauth-device",
+      "api",
+      () => {
+        return undefined;
+      },
+    );
+    expect(apiClient).toBeDefined();
+
+    if (!apiClient) {
+      throw new Error("Expected test-oauth-device API client");
+    }
+
+    await expect(
+      startConnectorDeviceAuthorization({
+        type: "test-oauth-device",
+        authMethod: "api",
+        authClient: apiClient,
+        options: { mode: "live" },
+      }),
+    ).resolves.toMatchObject({
+      deviceCode: "test-device:test-oauth-device-api-client:read:live",
+    });
+  });
+
+  it("applies default start options in the device authorization dispatcher", async () => {
+    server.use(
+      http.post(
+        /\/api\/test\/oauth-provider\/device\/code$/,
+        async ({ request }) => {
+          const body = new URLSearchParams(await request.text());
+          expect(body.get("client_id")).toBe("test-oauth-device-api-client");
+          expect(body.get("scope")).toBe("read");
+          expect(body.get("mode")).toBe("test");
+          return HttpResponse.json({
+            device_code: `test-device:${body.get("client_id")}:${body.get("scope")}:${body.get("mode")}`,
+            user_code: "TEST-DEVICE",
+            verification_uri: "https://oauth-device.test/device",
+            verification_uri_complete:
+              "https://oauth-device.test/device?user_code=TEST-DEVICE",
+            expires_in: 600,
+            interval: 0,
+          });
+        },
+      ),
+    );
+
+    const apiClient = resolveConnectorAuthClientForMethod(
+      "test-oauth-device",
+      "api",
+      () => {
+        return undefined;
+      },
+    );
+    expect(apiClient).toBeDefined();
+
+    if (!apiClient) {
+      throw new Error("Expected test-oauth-device API client");
+    }
+
+    await expect(
+      startConnectorDeviceAuthorization({
+        type: "test-oauth-device",
+        authMethod: "api",
+        authClient: apiClient,
+        options: {},
+      }),
+    ).resolves.toMatchObject({
+      deviceCode: "test-device:test-oauth-device-api-client:read:test",
+    });
   });
 
   it("refreshes an input-only connector access provider without an auth client", async () => {
@@ -1377,6 +1474,7 @@ describe("connector selected auth method capability checks", () => {
         type: "base44",
         authMethod: "oauth",
         authClient: oauthClient,
+        options: {},
       }),
     ).resolves.toStrictEqual({
       deviceCode: "base44-device-code",
@@ -1677,6 +1775,7 @@ describe("connector selected auth method capability checks", () => {
         type: "slock",
         authMethod: "oauth",
         authClient: oauthClient,
+        options: {},
       }),
     ).resolves.toStrictEqual({
       deviceCode: "slock-device-code",
@@ -3180,6 +3279,107 @@ describe("connector OAuth device authorization config", () => {
         clientType: "public",
         clientId: "test-oauth-device-api-client",
       },
+    });
+  });
+
+  it("normalizes and rejects device authorization start options from connector config", () => {
+    expect(
+      getConnectorAuthMethodDeviceAuthStartOptionsConfig(
+        "test-oauth-device",
+        "oauth",
+      ),
+    ).toBeUndefined();
+    expect(
+      getConnectorAuthMethodDeviceAuthStartOptionsConfig(
+        "test-oauth-device",
+        "api",
+      ),
+    ).toStrictEqual({
+      mode: {
+        kind: "select",
+        label: "Mode",
+        required: true,
+        defaultValue: "test",
+        options: [
+          { value: "test", label: "Test" },
+          { value: "live", label: "Live" },
+        ],
+      },
+    });
+
+    expect(
+      parseConnectorDeviceAuthStartOptions({
+        type: "test-oauth-device",
+        authMethod: "oauth",
+        options: undefined,
+      }),
+    ).toStrictEqual({ success: true, options: {} });
+    expect(
+      parseConnectorDeviceAuthStartOptions({
+        type: "test-oauth-device",
+        authMethod: "oauth",
+        options: { mode: "live" },
+      }),
+    ).toStrictEqual({
+      success: false,
+      message:
+        "test-oauth-device oauth device-auth start options are not supported: mode",
+    });
+    expect(
+      parseConnectorDeviceAuthStartOptions({
+        type: "test-oauth-device",
+        authMethod: "api",
+        options: undefined,
+      }),
+    ).toStrictEqual({ success: true, options: { mode: "test" } });
+    const inheritedModeOptions: Record<string, string> = {};
+    Object.setPrototypeOf(inheritedModeOptions, { mode: "live" });
+    expect(
+      parseConnectorDeviceAuthStartOptions({
+        type: "test-oauth-device",
+        authMethod: "api",
+        options: inheritedModeOptions,
+      }),
+    ).toStrictEqual({ success: true, options: { mode: "test" } });
+    expect(
+      parseConnectorDeviceAuthStartOptions({
+        type: "test-oauth-device",
+        authMethod: "api",
+        options: { mode: "live" },
+      }),
+    ).toStrictEqual({ success: true, options: { mode: "live" } });
+    expect(
+      parseConnectorDeviceAuthStartOptions({
+        type: "test-oauth-device",
+        authMethod: "api",
+        options: { mode: "production" },
+      }),
+    ).toStrictEqual({
+      success: false,
+      message:
+        "test-oauth-device api device-auth start option mode must be one of: test, live",
+    });
+    expect(
+      parseConnectorDeviceAuthStartOptions({
+        type: "test-oauth-device",
+        authMethod: "api",
+        options: { region: "us" },
+      }),
+    ).toStrictEqual({
+      success: false,
+      message:
+        "test-oauth-device api device-auth start option region is not supported",
+    });
+    expect(
+      parseConnectorDeviceAuthStartOptions({
+        type: "test-oauth-device",
+        authMethod: "api",
+        options: Object.fromEntries([["toString", "live"]]),
+      }),
+    ).toStrictEqual({
+      success: false,
+      message:
+        "test-oauth-device api device-auth start option toString is not supported",
     });
   });
 

--- a/turbo/packages/connectors/src/auth-providers/connector-auth.ts
+++ b/turbo/packages/connectors/src/auth-providers/connector-auth.ts
@@ -5,6 +5,7 @@ import {
   type ConnectorType,
   type AuthGrantConnectorType,
   type ConnectorDeviceAuthGrantAuthMethodId,
+  type ConnectorDeviceAuthStartOptions,
   type ConnectorAuthMethodIdsByGrantKind,
   type DeviceAuthGrantConnectorType,
   type ConnectorAuthMethodIdsByAccessKind,
@@ -21,6 +22,7 @@ import {
   getConnectorAuthMethodAuthCodeGrantConfig,
   getConnectorAuthMethodGrantScopes,
   isStaticConfidentialConnectorAuthClient,
+  parseConnectorDeviceAuthStartOptions,
   resolveConnectorAuthClientForMethod,
   type ConnectorAuthClientForMethod,
   type ConnectorResolvedAuthMethodClientByGrantKind,
@@ -471,7 +473,9 @@ type ConnectorAuthCodeExchangeCallArgs =
   };
 
 type ConnectorDeviceAuthorizationStartCallArgs =
-  ConnectorDeviceAuthResolvedMethodClient;
+  ConnectorDeviceAuthResolvedMethodClient & {
+    readonly options: ConnectorDeviceAuthStartOptions;
+  };
 
 type ConnectorDeviceAuthorizationPollCallArgs =
   ConnectorDeviceAuthResolvedMethodClient & {
@@ -610,6 +614,7 @@ export function startConnectorDeviceAuthorization<
   readonly type: T;
   readonly authMethod: Method;
   readonly authClient: ConnectorAuthClientForMethod<T, Method>;
+  readonly options: ConnectorDeviceAuthStartOptions;
 }): Promise<OAuthDeviceAuthStartResult>;
 export function startConnectorDeviceAuthorization(
   args: ConnectorDeviceAuthorizationStartCallArgs,
@@ -621,14 +626,24 @@ export async function startConnectorDeviceAuthorization<
   readonly type: T;
   readonly authMethod: Method;
   readonly authClient: ConnectorAuthClientForMethod<T, Method>;
+  readonly options: ConnectorDeviceAuthStartOptions;
 }): Promise<OAuthDeviceAuthStartResult> {
   const provider = connectorDeviceAuthGrantProviderFor(
     args.type,
     args.authMethod,
   );
+  const startOptionsResult = parseConnectorDeviceAuthStartOptions({
+    type: args.type,
+    authMethod: args.authMethod,
+    options: args.options,
+  });
+  if (!startOptionsResult.success) {
+    throw new Error(startOptionsResult.message);
+  }
   return await provider.startDeviceAuth({
     authClient: connectorAuthClientIdentityForMethod(args.authClient),
     scopes: getConnectorAuthMethodGrantScopes(args.type, args.authMethod),
+    options: startOptionsResult.options,
   });
 }
 

--- a/turbo/packages/connectors/src/auth-providers/connectors/test-oauth-device/oauth.ts
+++ b/turbo/packages/connectors/src/auth-providers/connectors/test-oauth-device/oauth.ts
@@ -71,17 +71,23 @@ function getDeviceTokenUrl(): string {
 export async function startTestOAuthDeviceAuth(args: {
   readonly clientId: string;
   readonly scopes: readonly string[];
+  readonly mode?: string;
 }): Promise<OAuthDeviceAuthStartResult> {
+  const body = new URLSearchParams({
+    client_id: args.clientId,
+    scope: args.scopes.join(" "),
+  });
+  if (args.mode !== undefined) {
+    body.set("mode", args.mode);
+  }
+
   const response = await fetch(getDeviceAuthUrl(), {
     method: "POST",
     headers: {
       "Content-Type": "application/x-www-form-urlencoded",
       ...testOAuthPreviewBypassHeaders(),
     },
-    body: new URLSearchParams({
-      client_id: args.clientId,
-      scope: args.scopes.join(" "),
-    }),
+    body,
   });
 
   if (!response.ok) {

--- a/turbo/packages/connectors/src/auth-providers/connectors/test-oauth-device/provider.ts
+++ b/turbo/packages/connectors/src/auth-providers/connectors/test-oauth-device/provider.ts
@@ -38,6 +38,7 @@ function createTestOauthDeviceApiGrant(): DeviceAuthGrantProvider<
       return await startTestOAuthDeviceAuth({
         clientId,
         scopes: args.scopes,
+        mode: args.options.mode,
       });
     },
     pollDeviceAuth: async (args) => {

--- a/turbo/packages/connectors/src/auth-providers/provider-flow-types.ts
+++ b/turbo/packages/connectors/src/auth-providers/provider-flow-types.ts
@@ -5,6 +5,7 @@ import type {
   ConnectorAuthCodeGrantAuthMethodId,
   ConnectorDeviceAuthGrantAuthMethodId,
   ConnectorAuthMethodIdsByRevokeKind,
+  ConnectorDeviceAuthStartOptions,
   ConnectorRevokeInputValues,
   ConnectorType,
   DeviceAuthGrantConnectorType,
@@ -44,6 +45,7 @@ interface OAuthExchangeFlowArgs {
 
 interface OAuthDeviceAuthStartFlowArgs {
   readonly scopes: readonly string[];
+  readonly options: ConnectorDeviceAuthStartOptions;
 }
 
 interface OAuthDeviceAuthPollFlowArgs {

--- a/turbo/packages/connectors/src/connector-utils.ts
+++ b/turbo/packages/connectors/src/connector-utils.ts
@@ -21,6 +21,9 @@ import {
   type ConnectorAuthCodeGrantConfig,
   type ConnectorAuthClientConfig,
   type ConnectorDeviceAuthGrantConfig,
+  type ConnectorDeviceAuthStartOptionConfig,
+  type ConnectorDeviceAuthStartOptions,
+  type ConnectorDeviceAuthStartOptionsConfig,
   type ConnectorEnvBindings,
   type ConnectorGenerationType,
   type ConnectorGrantOutputBindings,
@@ -819,6 +822,138 @@ export function getConnectorAuthMethodDeviceAuthGrantConfig(
 ): ConnectorDeviceAuthGrantConfig | undefined {
   const grant = getConnectorAuthMethod(type, authMethod)?.grant;
   return grant?.kind === "device-auth" ? grant : undefined;
+}
+
+export function getConnectorAuthMethodDeviceAuthStartOptionsConfig<
+  Type extends DeviceAuthGrantConnectorType,
+>(
+  type: Type,
+  authMethod: ConnectorDeviceAuthGrantAuthMethodId<Type>,
+): ConnectorDeviceAuthStartOptionsConfig | undefined;
+export function getConnectorAuthMethodDeviceAuthStartOptionsConfig(
+  type: ConnectorType,
+  authMethod: string,
+): ConnectorDeviceAuthStartOptionsConfig | undefined;
+export function getConnectorAuthMethodDeviceAuthStartOptionsConfig(
+  type: ConnectorType,
+  authMethod: string,
+): ConnectorDeviceAuthStartOptionsConfig | undefined {
+  return getConnectorAuthMethodDeviceAuthGrantConfig(type, authMethod)
+    ?.startOptions;
+}
+
+export type ConnectorDeviceAuthStartOptionsParseResult =
+  | {
+      readonly success: true;
+      readonly options: ConnectorDeviceAuthStartOptions;
+    }
+  | {
+      readonly success: false;
+      readonly message: string;
+    };
+
+function parseConnectorDeviceAuthStartOption(args: {
+  readonly type: ConnectorType;
+  readonly authMethod: string;
+  readonly optionName: string;
+  readonly config: ConnectorDeviceAuthStartOptionConfig;
+  readonly requestedValue: string | undefined;
+}): ConnectorDeviceAuthStartOptionsParseResult {
+  const value = args.requestedValue ?? args.config.defaultValue;
+  if (value === undefined) {
+    if (args.config.required) {
+      return {
+        success: false,
+        message: `${args.type} ${args.authMethod} device-auth start option ${args.optionName} is required`,
+      };
+    }
+    return { success: true, options: {} };
+  }
+
+  switch (args.config.kind) {
+    case "select": {
+      if (
+        !args.config.options.some((option) => {
+          return option.value === value;
+        })
+      ) {
+        return {
+          success: false,
+          message: `${args.type} ${args.authMethod} device-auth start option ${args.optionName} must be one of: ${args.config.options
+            .map((option) => {
+              return option.value;
+            })
+            .join(", ")}`,
+        };
+      }
+      return { success: true, options: { [args.optionName]: value } };
+    }
+  }
+}
+
+function connectorDeviceAuthStartOptionValue(
+  options: ConnectorDeviceAuthStartOptions | undefined,
+  optionName: string,
+): string | undefined {
+  if (!options || !Object.hasOwn(options, optionName)) {
+    return undefined;
+  }
+  return options[optionName];
+}
+
+export function parseConnectorDeviceAuthStartOptions(args: {
+  readonly type: ConnectorType;
+  readonly authMethod: string;
+  readonly options: ConnectorDeviceAuthStartOptions | undefined;
+}): ConnectorDeviceAuthStartOptionsParseResult {
+  const configuredOptions = getConnectorAuthMethodDeviceAuthStartOptionsConfig(
+    args.type,
+    args.authMethod,
+  );
+  const requestedOptionKeys = Object.keys(args.options ?? {});
+
+  if (!configuredOptions || Object.keys(configuredOptions).length === 0) {
+    if (requestedOptionKeys.length === 0) {
+      return { success: true, options: {} };
+    }
+    return {
+      success: false,
+      message: `${args.type} ${args.authMethod} device-auth start options are not supported: ${requestedOptionKeys.join(", ")}`,
+    };
+  }
+
+  for (const optionName of requestedOptionKeys) {
+    if (!Object.hasOwn(configuredOptions, optionName)) {
+      return {
+        success: false,
+        message: `${args.type} ${args.authMethod} device-auth start option ${optionName} is not supported`,
+      };
+    }
+  }
+
+  const normalizedOptions: Record<string, string> = {};
+  for (const [optionName, config] of Object.entries(configuredOptions)) {
+    const parsedOption = parseConnectorDeviceAuthStartOption({
+      type: args.type,
+      authMethod: args.authMethod,
+      optionName,
+      config,
+      requestedValue: connectorDeviceAuthStartOptionValue(
+        args.options,
+        optionName,
+      ),
+    });
+    if (!parsedOption.success) {
+      return parsedOption;
+    }
+    for (const [parsedOptionName, parsedOptionValue] of Object.entries(
+      parsedOption.options,
+    )) {
+      normalizedOptions[parsedOptionName] = parsedOptionValue;
+    }
+  }
+
+  return { success: true, options: normalizedOptions };
 }
 
 function connectorGrantScopes(

--- a/turbo/packages/connectors/src/connectors.ts
+++ b/turbo/packages/connectors/src/connectors.ts
@@ -338,10 +338,38 @@ export interface ConnectorAuthCodeGrantConfig {
   readonly outputs: ConnectorGrantOutputBindings;
 }
 
+export interface ConnectorDeviceAuthStartSelectOptionChoiceConfig {
+  readonly value: string;
+  readonly label: string;
+}
+
+type ConnectorDeviceAuthStartSelectOptionChoicesConfig = readonly [
+  ConnectorDeviceAuthStartSelectOptionChoiceConfig,
+  ...ConnectorDeviceAuthStartSelectOptionChoiceConfig[],
+];
+
+export interface ConnectorDeviceAuthStartSelectOptionConfig {
+  readonly kind: "select";
+  readonly label: string;
+  readonly required: boolean;
+  readonly defaultValue?: string;
+  readonly options: ConnectorDeviceAuthStartSelectOptionChoicesConfig;
+}
+
+export type ConnectorDeviceAuthStartOptionConfig =
+  ConnectorDeviceAuthStartSelectOptionConfig;
+
+export type ConnectorDeviceAuthStartOptionsConfig = Readonly<
+  Record<string, ConnectorDeviceAuthStartOptionConfig>
+>;
+
+export type ConnectorDeviceAuthStartOptions = Readonly<Record<string, string>>;
+
 export interface ConnectorDeviceAuthGrantConfig {
   readonly kind: "device-auth";
   readonly scopes: string[];
   readonly outputs: ConnectorGrantOutputBindings;
+  readonly startOptions?: ConnectorDeviceAuthStartOptionsConfig;
 }
 
 export interface ConnectorManagedGrantConfig {
@@ -827,8 +855,40 @@ type ValidatedConnectorGrantConfig<Grant, Storage> = Grant extends {
       }
     ? Grant & {
         readonly outputs: ValidatedConnectorGrantOutputs<Outputs, Storage>;
-      }
+      } & ValidatedConnectorDeviceAuthStartOptions<Grant>
     : Grant;
+
+type ConnectorDeviceAuthStartSelectOptionValue<Option> = Option extends {
+  readonly options: readonly (infer Choice)[];
+}
+  ? Choice extends { readonly value: infer Value }
+    ? Value
+    : never
+  : never;
+
+type ValidatedConnectorDeviceAuthStartOption<Option> = Option extends {
+  readonly kind: "select";
+  readonly defaultValue: infer DefaultValue;
+}
+  ? DefaultValue extends ConnectorDeviceAuthStartSelectOptionValue<Option>
+    ? Option
+    : never
+  : Option;
+
+type ValidatedConnectorDeviceAuthStartOptionMap<Options> = {
+  readonly [OptionName in keyof Options]: ValidatedConnectorDeviceAuthStartOption<
+    Options[OptionName]
+  >;
+};
+
+type ValidatedConnectorDeviceAuthStartOptions<Grant> = Grant extends {
+  readonly kind: "device-auth";
+  readonly startOptions: infer StartOptions;
+}
+  ? {
+      readonly startOptions: ValidatedConnectorDeviceAuthStartOptionMap<StartOptions>;
+    }
+  : object;
 
 type ValidatedConnectorRevokeConfig<Revoke, Storage> = Revoke extends {
   readonly kind: "token-revoke";

--- a/turbo/packages/connectors/src/connectors/test-oauth-device.ts
+++ b/turbo/packages/connectors/src/connectors/test-oauth-device.ts
@@ -56,6 +56,18 @@ export const testOauthDevice = {
           outputs: {
             accessToken: "$secrets.TEST_OAUTH_DEVICE_API_ACCESS_TOKEN",
           },
+          startOptions: {
+            mode: {
+              kind: "select",
+              label: "Mode",
+              required: true,
+              defaultValue: "test",
+              options: [
+                { value: "test", label: "Test" },
+                { value: "live", label: "Live" },
+              ],
+            },
+          },
         },
         access: {
           kind: "static",


### PR DESCRIPTION
## Summary

- Add connector-defined device auth start option config and runtime validation.
- Extend the zero connector device auth session create request to accept validated string options.
- Add platform dialog/state support for selecting and submitting device auth start options.
- Wire the test OAuth device connector API method with a `mode` select option and cover default, valid, and invalid option paths.

Closes #16342

## Testing

- `pnpm -F @vm0/connectors test -- src/__tests__/connectors.test.ts`
- `pnpm -F api exec vitest src/signals/routes/__tests__/zero-connectors-oauth-device-auth.test.ts`
- `pnpm -F @vm0/app exec vitest src/signals/zero-page/settings/__tests__/connect-connector.test.ts`
- `pnpm -F @vm0/app exec vitest src/views/conn/__tests__/add-connection-dialog.test.tsx`
- `pnpm format`
- `pnpm turbo run lint`
- `pnpm check-types`
- `pnpm knip`
- `TZ=UTC pnpm -F @vm0/app exec vitest src/views/network-insights/__tests__/network-insights-page-interaction.test.tsx`

`TZ=UTC pnpm vitest` was also run. It completed with only the existing Linux-local failure in `@vm0/desktop/src/computer-use-native.test.ts`, where the native desktop backend reports `accessibility_unavailable: Desktop Computer Use is currently implemented for macOS`.
