### PR TITLE
Add homepage paid funnel tracking

### DIFF
--- a/turbo/apps/web/app/components/LandingPage.tsx
+++ b/turbo/apps/web/app/components/LandingPage.tsx
@@ -5,10 +5,58 @@ import NextLink from "next/link";
 import { useUser } from "@clerk/nextjs";
 import { useTranslations } from "next-intl";
 import { getAppUrl } from "../../src/lib/zero/url";
-import { buildSignupHref } from "../../src/lib/adAttribution";
+import {
+  buildHomepageAttributionProperties,
+  buildSignupHref,
+  currentLandingAttributionContext,
+  hasAdAttributionParams,
+} from "../../src/lib/adAttribution";
 import { Footer } from "./Footer";
 import Image from "next/image";
 import { AvatarCustomizer } from "./AvatarCustomizer";
+import { capturePostHogEvent } from "./PostHogProvider";
+
+type PlausibleEvent = (
+  eventName: string,
+  options?: { props?: Record<string, unknown> },
+) => void;
+
+function capturePlausibleEvent(
+  eventName: string,
+  properties: Record<string, unknown>,
+): void {
+  if (typeof window === "undefined") {
+    return;
+  }
+
+  const plausible = (window as unknown as { plausible?: PlausibleEvent })
+    .plausible;
+  plausible?.(eventName, { props: properties });
+}
+
+function captureHomepagePaidFunnelEvent(
+  eventName: "LP Viewed" | "LP CTA Clicked",
+  landingSearch: string,
+  properties: Record<string, unknown> = {},
+): void {
+  if (!hasAdAttributionParams(landingSearch)) {
+    return;
+  }
+
+  const eventProperties = {
+    ...buildHomepageAttributionProperties(
+      landingSearch,
+      currentLandingAttributionContext(),
+    ),
+    route_path:
+      typeof window === "undefined" ? undefined : window.location.pathname,
+    surface: "homepage",
+    ...properties,
+  };
+
+  capturePostHogEvent(eventName, eventProperties);
+  capturePlausibleEvent(eventName, eventProperties);
+}
 
 function useScrollReveal() {
   const ref = useRef<HTMLDivElement>(null);
@@ -84,11 +132,13 @@ function CtaButton({
   isSignedIn,
   ctaText,
   ctaHref,
+  onClick,
   className,
 }: {
   isSignedIn: boolean;
   ctaText: string;
   ctaHref: string;
+  onClick?: () => void;
   className?: string;
 }) {
   const baseClassName = `inline-flex items-center justify-center whitespace-nowrap rounded-xl px-8 py-3.5 text-base font-medium transition-all hover:bg-[#ff6a1f] sm:px-14 ${className ?? ""}`;
@@ -106,6 +156,7 @@ function CtaButton({
         rel="noopener noreferrer"
         className={baseClassName}
         style={style}
+        onClick={onClick}
       >
         {ctaText}
       </a>
@@ -113,7 +164,12 @@ function CtaButton({
   }
 
   return (
-    <NextLink href={ctaHref} className={baseClassName} style={style}>
+    <NextLink
+      href={ctaHref}
+      className={baseClassName}
+      style={style}
+      onClick={onClick}
+    >
       {ctaText}
     </NextLink>
   );
@@ -830,11 +886,14 @@ export function LandingPage({ initialIsSignedIn = false }: LandingPageProps) {
   const appUrl = getAppUrl();
   const [landingSearch, setLandingSearch] = useState("");
   useEffect(() => {
-    setLandingSearch(window.location.search);
+    const search = window.location.search;
+    setLandingSearch(search);
+    captureHomepagePaidFunnelEvent("LP Viewed", search);
   }, []);
 
   const ctaText = isSignedIn ? t("hero.ctaOpenApp") : t("hero.ctaGetStarted");
   const ctaHref = isSignedIn ? appUrl : buildSignupHref(landingSearch);
+  const ctaDestination = isSignedIn ? "app" : "signup";
 
   return (
     <div
@@ -946,6 +1005,14 @@ export function LandingPage({ initialIsSignedIn = false }: LandingPageProps) {
                 isSignedIn={isSignedIn ?? false}
                 ctaText={ctaText}
                 ctaHref={ctaHref}
+                onClick={() => {
+                  const search = landingSearch || window.location.search;
+                  captureHomepagePaidFunnelEvent("LP CTA Clicked", search, {
+                    cta_destination: ctaDestination,
+                    cta_href: ctaHref,
+                    cta_label: ctaText,
+                  });
+                }}
               />
               <AddToSlackButton />
             </div>

--- a/turbo/apps/web/src/__tests__/adAttribution.test.ts
+++ b/turbo/apps/web/src/__tests__/adAttribution.test.ts
@@ -1,7 +1,9 @@
 import { describe, expect, it } from "vitest";
 import {
+  buildHomepageAttributionProperties,
   buildSignupHref,
   buildSignupRedirectUrl,
+  hasAdAttributionParams,
   writeAcquisitionAttributionCookie,
 } from "../lib/adAttribution";
 import { ACQUISITION_ATTRIBUTION_COOKIE } from "@vm0/api-contracts/contracts/zero-attribution";
@@ -161,6 +163,40 @@ describe("buildSignupHref", () => {
     expect(url.searchParams.get("utm_medium")).toBe("cpc");
     expect(url.searchParams.get("utm_campaign")).toBe("homepage_search");
     expect(url.searchParams.get("unused")).toBeNull();
+  });
+});
+
+describe("homepage paid funnel properties", () => {
+  it("detects ad attribution params", () => {
+    expect(hasAdAttributionParams("")).toBe(false);
+    expect(hasAdAttributionParams("?unused=value")).toBe(false);
+    expect(hasAdAttributionParams("?utm_source=newsletter")).toBe(true);
+    expect(hasAdAttributionParams("?utm_campaign=hyp_b_developer")).toBe(true);
+    expect(hasAdAttributionParams("?gclid=test-click")).toBe(true);
+  });
+
+  it("builds PostHog/Plausible properties from paid homepage traffic", () => {
+    const properties = buildHomepageAttributionProperties(
+      "?gclid=test-click&utm_source=google&utm_medium=cpc&utm_campaign=hyp_b_developer&utm_content=ad_1&utm_term=developer+productivity",
+      {
+        hostname: "www.vm0.ai",
+        pathname: "/en",
+        referrer: "https://www.google.com/",
+      },
+    );
+
+    expect(properties.vm0_source).toBe("homepage");
+    expect(properties.source_type).toBe("paid");
+    expect(properties.referrer_domain).toBe("google.com");
+    expect(properties.landing_host).toBe("vm0.ai");
+    expect(properties.landing_path).toBe("/en");
+    expect(properties.gclid).toBe("test-click");
+    expect(properties.gclid_present).toBe("true");
+    expect(properties.utm_source).toBe("google");
+    expect(properties.utm_medium).toBe("cpc");
+    expect(properties.utm_campaign).toBe("hyp_b_developer");
+    expect(properties.utm_content).toBe("ad_1");
+    expect(properties.utm_term).toBe("developer productivity");
   });
 });
 

--- a/turbo/apps/web/src/lib/adAttribution.ts
+++ b/turbo/apps/web/src/lib/adAttribution.ts
@@ -211,6 +211,36 @@ function hasAdTraffic(params: URLSearchParams): boolean {
   });
 }
 
+export function hasAdAttributionParams(landingSearch: string): boolean {
+  return hasAdTraffic(new URLSearchParams(landingSearch));
+}
+
+export function buildHomepageAttributionProperties(
+  landingSearch: string,
+  context: LandingAttributionContext = {},
+): Record<string, string> {
+  const attribution = acquisitionAttributionParams(landingSearch, context);
+  const properties: Record<string, string> = {};
+
+  attribution.forEach((value, key) => {
+    if (properties[key] === undefined) {
+      properties[key] = value;
+    }
+  });
+
+  if (attribution.has("gclid")) {
+    properties.gclid_present = "true";
+  }
+  if (attribution.has("gbraid")) {
+    properties.gbraid_present = "true";
+  }
+  if (attribution.has("wbraid")) {
+    properties.wbraid_present = "true";
+  }
+
+  return properties;
+}
+
 function appendHomepageAttributionParams(
   url: URLSearchParams,
   landingSearch: string,


### PR DESCRIPTION
## Summary
- Add homepage paid funnel captures for attributed traffic: `LP Viewed` on landing and `LP CTA Clicked` on primary CTA click
- Reuse existing homepage attribution helpers so events carry `utm_campaign`, `gclid/gbraid/wbraid`, `source_type`, `vm0_source=homepage`, and landing context
- Add unit coverage for homepage paid funnel attribution properties

## PostHog follow-up already applied
- Fixed the Ha/Hb ad group dashboard HogQL to remove the left-join artifact that counted empty ad groups as 1
- The dashboards now use real event rollups only

## Verification
- `pnpm --filter web test -- src/__tests__/adAttribution.test.ts` passed: 44 files, 914 tests
- `pnpm --filter web check-types` passed
- `pnpm --filter web lint` passed
- `pnpm --filter web build` completed with exit 0; local build emitted expected missing env warnings for `CLERK_SECRET_KEY`, `NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY`, and `NEXT_PUBLIC_APP_URL` in this fresh clone environment

No Google Ads changes. No fake purchases or fake conversions.