### PR TITLE
feat: roll out sessionWorkspaceImageCache to all orgs

### DIFF
--- a/turbo/packages/core/src/__tests__/feature-switch.test.ts
+++ b/turbo/packages/core/src/__tests__/feature-switch.test.ts
@@ -119,8 +119,9 @@ describe("getAllFeatureStates", () => {
     });
     expect(otherOrgStates[FeatureSwitchKey.Lab]).toBe(false);
     expect(otherOrgStates[FeatureSwitchKey.SkillsViewer]).toBe(false);
+    // Fully rolled out: enabled for all orgs, including non-staff orgs.
     expect(otherOrgStates[FeatureSwitchKey.SessionWorkspaceImageCache]).toBe(
-      false,
+      true,
     );
     expect(otherOrgStates[FeatureSwitchKey.ChatRecommendedFollowups]).toBe(
       false,

--- a/turbo/packages/core/src/feature-switch.ts
+++ b/turbo/packages/core/src/feature-switch.ts
@@ -266,8 +266,7 @@ const FEATURE_SWITCHES: Record<FeatureSwitchKey, FeatureSwitch> = {
     maintainer: "liangyou@vm0.ai",
     description:
       "Enable runner session workspace image cache reuse for canonical workspace drives.",
-    enabled: false,
-    enabledOrgIdHashes: STAFF_ORG_ID_HASHES,
+    enabled: true,
   },
   [FeatureSwitchKey.ChatArtifactSidebar]: {
     maintainer: "ethan@vm0.ai",


### PR DESCRIPTION
## What

Promotes the `sessionWorkspaceImageCache` feature switch from staff-only gating to full rollout (`enabled: true`) for all orgs.

## Why

The runner session workspace image cache (introduced in #15780, closes #15635) has been running under `STAFF_ORG_ID_HASHES` gating on internal staff orgs. This flips it to a default-on flag for everyone.

## Change

In `turbo/packages/core/src/feature-switch.ts`:

- `enabled: false` → `enabled: true`
- Removed the now-redundant `enabledOrgIdHashes: STAFF_ORG_ID_HASHES` line (once `enabled` is `true`, gating short-circuits to true for all orgs, matching the convention used by other fully-enabled flags such as `Dummy`).

Runner side (`crates/runner/src/types.rs`) already reads the flag with a `false` fallback, so no runner change is needed.

cc @seven332 (maintainer)
