### PR TITLE
feat: show next run time in chat thread schedule menu

### DIFF
--- a/turbo/apps/platform/src/signals/chat-page/header-schedule-menu.ts
+++ b/turbo/apps/platform/src/signals/chat-page/header-schedule-menu.ts
@@ -5,11 +5,13 @@ import { accept } from "../../lib/accept.ts";
 import { zeroClient$ } from "../api-client.ts";
 import { scheduleTitle } from "../zero-page/schedule-title.ts";
 
-interface HeaderScheduleEntry {
+export interface HeaderScheduleEntry {
   readonly id: string;
   readonly name: string;
   readonly title: string;
   readonly chatThreadId: string;
+  readonly enabled: boolean;
+  readonly nextRunAt: string | null;
 }
 
 const headerScheduleMenuReload$ = state(0);
@@ -40,6 +42,8 @@ export const headerScheduleMenu$ = computed(
         name: schedule.name,
         title: scheduleTitle(schedule),
         chatThreadId: schedule.chatThreadId,
+        enabled: schedule.enabled,
+        nextRunAt: schedule.nextRunAt,
       };
     });
   },

--- a/turbo/apps/platform/src/views/zero-page/__tests__/zero-chat-thread-page-display.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/zero-chat-thread-page-display.test.tsx
@@ -181,6 +181,67 @@ describe("zero chat thread page display - schedule menu", () => {
     ).not.toBeInTheDocument();
     expect(screen.queryByText("Other thread schedule")).not.toBeInTheDocument();
   });
+
+  it("shows linked schedule status sublines from schedule API data", async () => {
+    const user = userEvent.setup();
+    const threadId = "d0000000-0000-4000-a000-000000000001";
+    const nextRunAt = "2026-06-07T14:30:00.000Z";
+    mockChatLifecycle({ threadId });
+    setMockSchedules([
+      createMockScheduleResponse({
+        id: "e0000000-0000-4000-a000-000000000011",
+        name: "next-run-schedule",
+        description: "Daily morning briefing",
+        chatThreadId: threadId,
+        enabled: true,
+        nextRunAt,
+      }),
+      createMockScheduleResponse({
+        id: "e0000000-0000-4000-a000-000000000012",
+        name: "inactive-schedule",
+        description: "Paused sync",
+        chatThreadId: threadId,
+        enabled: false,
+        nextRunAt: "2026-06-08T09:00:00.000Z",
+      }),
+      createMockScheduleResponse({
+        id: "e0000000-0000-4000-a000-000000000013",
+        name: "no-upcoming-run-schedule",
+        description: "Manual follow-up",
+        chatThreadId: threadId,
+        enabled: true,
+        nextRunAt: null,
+      }),
+    ]);
+
+    detachedSetupPage({
+      context,
+      path: `/chats/${threadId}`,
+      featureSwitches: {
+        ...chatArtifactSidebarOff(),
+      },
+    });
+
+    await user.click(await screen.findByLabelText("Schedules"));
+
+    const menu = await screen.findByRole("menu");
+    const expectedNextRun = `Next run ${new Date(nextRunAt).toLocaleString(
+      "en-US",
+      {
+        dateStyle: "medium",
+        timeStyle: "short",
+      },
+    )}`;
+
+    expect(
+      within(menu).getByText("Daily morning briefing"),
+    ).toBeInTheDocument();
+    expect(within(menu).getByText(expectedNextRun)).toBeInTheDocument();
+    expect(within(menu).getByText("Paused sync")).toBeInTheDocument();
+    expect(within(menu).getByText("Schedule inactive")).toBeInTheDocument();
+    expect(within(menu).getByText("Manual follow-up")).toBeInTheDocument();
+    expect(within(menu).getByText("No upcoming run")).toBeInTheDocument();
+  });
 });
 
 describe("zero chat thread page display - permission action card", () => {

--- a/turbo/apps/platform/src/views/zero-page/zero-chat-thread-page.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-chat-thread-page.tsx
@@ -184,6 +184,7 @@ import {
   headerScheduleMenu$,
   reloadHeaderScheduleMenu$,
   schedulesForThread,
+  type HeaderScheduleEntry,
 } from "../../signals/chat-page/header-schedule-menu.ts";
 import { detachedNavigateTo$ } from "../../signals/route.ts";
 import { openQueueDrawer$ } from "../../signals/queue-page/queue-drawer-state.ts";
@@ -955,6 +956,22 @@ function GithubPrTrackingButton({
   );
 }
 
+// Second line shown under each schedule in the header menu: the next scheduled
+// run time, or a note that the schedule is inactive when it has been disabled.
+function scheduleMenuSubline(schedule: HeaderScheduleEntry): string {
+  if (!schedule.enabled) {
+    return "Schedule inactive";
+  }
+  if (!schedule.nextRunAt) {
+    return "No upcoming run";
+  }
+  const nextRun = new Date(schedule.nextRunAt).toLocaleString("en-US", {
+    dateStyle: "medium",
+    timeStyle: "short",
+  });
+  return `Next run ${nextRun}`;
+}
+
 // Loads schedules and only renders once this thread has at least one linked
 // schedule.
 export function ScheduleMenuButton({
@@ -1005,12 +1022,18 @@ export function ScheduleMenuButton({
                   pathParams: { scheduleId: schedule.id },
                 });
               }}
+              className="items-start gap-2"
             >
               <IconClock
                 size={15}
-                className="mr-2 shrink-0 text-muted-foreground"
+                className="mt-0.5 shrink-0 text-muted-foreground"
               />
-              <span className="truncate">{schedule.title}</span>
+              <div className="flex min-w-0 flex-col">
+                <span className="truncate">{schedule.title}</span>
+                <span className="truncate text-xs text-muted-foreground">
+                  {scheduleMenuSubline(schedule)}
+                </span>
+              </div>
             </DropdownMenuItem>
           );
         })}


### PR DESCRIPTION
## What

The clock dropdown next to the chat thread title now shows each linked schedule on **two lines** instead of one:

- **Line 1** — the schedule description (existing title text, derived from description → prompt → name).
- **Line 2** — the scheduled next run time (`Next run <date, time>`). When the schedule is **disabled**, this line shows `Schedule inactive` instead; when enabled but with no upcoming run, it shows `No upcoming run`.

## Why

Previously the menu only displayed the description, giving no signal about *when* the schedule would fire or whether it was paused. Surfacing the next run time (and inactive state) lets users understand a thread's schedule at a glance without opening the schedule detail page.

## Changes

- `header-schedule-menu.ts`: extend `HeaderScheduleEntry` with `enabled` and `nextRunAt`, mapped from the schedule API response (`export`ed the type for reuse).
- `zero-chat-thread-page.tsx`: render the two-line layout in `ScheduleMenuButton` and add a `scheduleMenuSubline` helper for the second line.

## Test plan

- [ ] Open a chat thread with a linked active schedule → clock dropdown shows description + `Next run …`.
- [ ] Disable the schedule → second line reads `Schedule inactive`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
