### PR TITLE
fix: label BYOK model routes in composer picker

### DIFF
--- a/turbo/apps/platform/src/views/zero-page/__tests__/chat-composer-model-picker.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/chat-composer-model-picker.test.tsx
@@ -14,11 +14,13 @@ import {
 import { setMockFeatureSwitches } from "../../../mocks/handlers/api-feature-switches.helpers.ts";
 import { setChatShortcutHelpOpen$ } from "../../../signals/chat-page/chat-shortcut-help.ts";
 import { mockChatLifecycle, PLACEHOLDER } from "./chat-test-helpers.ts";
+import type { OrgModelPolicy } from "@vm0/api-contracts/contracts/model-providers";
 
 const context = testContext();
 const THREAD_ID = "thread-test-model-picker";
 const PROVIDER_ID = "00000000-0000-4000-a000-000000000001";
 const DEFAULT_MODEL = "claude-sonnet-4-6";
+const NOW = "2026-05-08T00:00:00.000Z";
 
 function enableModelPicker(): void {
   setMockFeatureSwitches({});
@@ -82,6 +84,61 @@ describe("chat composer — model picker", () => {
     expect(
       screen.getByRole("option", { name: /Claude Opus 4\.8/ }),
     ).toBeInTheDocument();
+  });
+
+  it("labels BYOK model routes instead of showing built-in multipliers", async () => {
+    const user = userEvent.setup();
+    setMockFeatureSwitches({});
+    setMockOrgModelProviders([]);
+    setMockOrgModelPolicies([
+      {
+        id: "00000000-0000-4000-a000-000000000101",
+        model: DEFAULT_MODEL,
+        modelLabel: "Claude Sonnet 4.6",
+        isDefault: true,
+        defaultProviderType: "vm0",
+        credentialScope: "org",
+        modelProviderId: null,
+        routeStatus: "valid",
+        routeStatusReason: null,
+        createdAt: NOW,
+        updatedAt: NOW,
+      },
+      {
+        id: "00000000-0000-4000-a000-000000000102",
+        model: "kimi-k2.6",
+        modelLabel: "Kimi K2.6",
+        isDefault: false,
+        defaultProviderType: "moonshot-api-key",
+        credentialScope: "org",
+        modelProviderId: PROVIDER_ID,
+        routeStatus: "valid",
+        routeStatusReason: null,
+        createdAt: NOW,
+        updatedAt: NOW,
+      },
+    ] satisfies OrgModelPolicy[]);
+
+    mockChatLifecycle({ threadId: THREAD_ID });
+    detachedSetupPage({ context, path: `/chats/${THREAD_ID}` });
+
+    await waitFor(() => {
+      expect(
+        screen.getByRole("combobox", { name: "Claude Sonnet 4.6" }),
+      ).toBeInTheDocument();
+    });
+    await user.click(
+      screen.getByRole("combobox", { name: "Claude Sonnet 4.6" }),
+    );
+
+    await waitFor(() => {
+      expect(screen.getByRole("listbox")).toBeInTheDocument();
+    });
+    expect(
+      screen.getByRole("option", { name: /Kimi K2\.6 BYOK/ }),
+    ).toBeInTheDocument();
+    expect(screen.getByText("×1")).toBeInTheDocument();
+    expect(screen.queryByText("×0.3")).toBeNull();
   });
 
   it("does not open the model picker from mod+alt+.", async () => {

--- a/turbo/apps/platform/src/views/zero-page/components/model-provider-picker.tsx
+++ b/turbo/apps/platform/src/views/zero-page/components/model-provider-picker.tsx
@@ -101,6 +101,23 @@ function MultiplierBadge({ multiplier }: { multiplier: number }) {
   );
 }
 
+function ByokBadge() {
+  return (
+    <TooltipProvider delayDuration={300}>
+      <Tooltip>
+        <TooltipTrigger asChild>
+          <span className="shrink-0 cursor-help text-xs font-medium text-muted-foreground underline decoration-dotted decoration-muted-foreground/50 underline-offset-2 hover:text-foreground hover:decoration-muted-foreground">
+            BYOK
+          </span>
+        </TooltipTrigger>
+        <TooltipContent side="top" className="text-xs">
+          Uses your configured provider
+        </TooltipContent>
+      </Tooltip>
+    </TooltipProvider>
+  );
+}
+
 function ResponsiveTriggerContent({
   mobileIcon,
   iconType,
@@ -285,7 +302,10 @@ function modelFirstSelectionFromRaw(
 
 function ModelFirstPolicyRow({ policy }: { policy: OrgModelPolicy }) {
   const iconType = getModelFirstIconType(policy.model);
-  const multiplier = getVm0ModelMultiplier(policy.model);
+  const builtInMultiplier =
+    policy.defaultProviderType === "vm0"
+      ? getVm0ModelMultiplier(policy.model)
+      : undefined;
   return (
     <SelectItem
       key={policy.id}
@@ -297,8 +317,10 @@ function ModelFirstPolicyRow({ policy }: { policy: OrgModelPolicy }) {
         <span className="truncate">
           {policy.modelLabel || getCanonicalModelDisplayName(policy.model)}
         </span>
-        {multiplier !== undefined && (
-          <MultiplierBadge multiplier={multiplier} />
+        {builtInMultiplier !== undefined ? (
+          <MultiplierBadge multiplier={builtInMultiplier} />
+        ) : (
+          <ByokBadge />
         )}
       </span>
     </SelectItem>


### PR DESCRIPTION
## Summary
- show `BYOK` for non-built-in model policy routes in the composer model picker
- keep built-in `vm0` routes showing their credit multiplier
- add composer picker coverage for BYOK route labeling

## Checks
- `pnpm -F @vm0/app exec vitest run src/views/zero-page/__tests__/chat-composer-model-picker.test.tsx`
- `pnpm -F @vm0/app check-types`
- `pnpm -F @vm0/app exec eslint src/views/zero-page/components/model-provider-picker.tsx src/views/zero-page/__tests__/chat-composer-model-picker.test.tsx --max-warnings 0`
- `pnpm -F @vm0/app exec oxlint src/views/zero-page/components/model-provider-picker.tsx src/views/zero-page/__tests__/chat-composer-model-picker.test.tsx`
- `pnpm -F @vm0/app exec prettier --check src/views/zero-page/components/model-provider-picker.tsx src/views/zero-page/__tests__/chat-composer-model-picker.test.tsx`

## Notes
- Browser verification was attempted, but this fresh local checkout could not render the app shell because `VITE_API_URL` is not configured.