### PR TITLE
chore: update rootfs package versions

### DIFF
--- a/crates/runner/scripts/build-template.sh
+++ b/crates/runner/scripts/build-template.sh
@@ -111,12 +111,12 @@ CACHE_TMP_TAR=""
 
 # Pinned versions (changes here invalidate the template cache via script hash)
 GO_VERSION="1.26.4"
-CLAUDE_CODE_VERSION="2.1.163"
+CLAUDE_CODE_VERSION="2.1.167"
 CODEX_CLI_VERSION="0.137.0"
 GWS_CLI_VERSION="0.22.5"
 XURL_VERSION="1.0.3"
 AGENT_BROWSER_VERSION="0.27.1"
-PNPM_VERSION="11.5.1"
+PNPM_VERSION="11.5.2"
 
 # ---------------------------------------------------------------------------
 # Dependency checks


### PR DESCRIPTION
Updates pinned rootfs dependency versions in `crates/runner/scripts/build-template.sh`.

Updated:
- Claude Code CLI: `2.1.163` -> `2.1.167`
- pnpm: `11.5.1` -> `11.5.2`

Checked and left unchanged because they are already current or still on the latest LTS/available configured package line:
- Go: `1.26.4`
- Node.js: `24.x` (latest LTS line)
- OpenAI Codex CLI: `0.137.0`
- Google Workspace CLI: `0.22.5`
- xurl: `1.0.3`
- agent-browser: `0.27.1`
- PostgreSQL: `postgresql-16` (latest PostgreSQL major available in the configured Ubuntu Noble repositories)

Validation:
- `bash -n crates/runner/scripts/build-template.sh`