### PR TITLE
chore(rust): update dependencies

### DIFF
--- a/crates/Cargo.lock
+++ b/crates/Cargo.lock
@@ -619,9 +619,9 @@ dependencies = [
 
 [[package]]
 name = "bitflags"
-version = "2.12.1"
+version = "2.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "84d7ced0ae9557296835c32bf1b1e02b44c746701f898460fb000d7eaa84f00a"
+checksum = "b4388bee8683e3d04af747c73422af53102d2bd24d9eadb6cbc100baef4b43f8"
 
 [[package]]
 name = "bitvec"


### PR DESCRIPTION
## Summary
- Updated the Rust workspace lockfile under `crates/`.
- `bitflags` updated from `2.12.1` to `2.13.0`.

## Dependencies not updated
- `generic-array` remains at `0.14.7` although `0.14.9` is available. Cargo reports it is held by a transitive exact requirement from `crypto-common v0.1.7` (`generic-array = "=0.14.7"`), reached through `digest -> crc-fast -> aws-smithy-checksums -> aws-sdk-s3 -> runner`. This is not controlled by a direct workspace `Cargo.toml` dependency specifier.

## Manual version bumps
- None. I checked the direct external workspace dependencies and did not find any safe same-major updates blocked by the current `Cargo.toml` version requirements.

## Test status
- Passed: `cargo fmt --check`
- Passed: `CARGO_TARGET_DIR=/home/user/workspace/vm0-rust-deps-target CARGO_INCREMENTAL=0 CARGO_BUILD_JOBS=1 CARGO_PROFILE_TEST_DEBUG=0 RUSTFLAGS='-C debuginfo=0' cargo test --workspace`

Notes: the first default `cargo test --workspace` attempt exhausted the small `/tmp` filesystem, and a retry with the target directory moved to `/home/user/workspace` was SIGKILLed while compiling the `runner` test binary. The final full workspace test passed after reducing build memory/debug-info pressure as shown above.