### PR TITLE
fix: remove chat header new button feature

### DIFF
--- a/turbo/apps/platform/src/signals/agent-chat.ts
+++ b/turbo/apps/platform/src/signals/agent-chat.ts
@@ -166,26 +166,3 @@ export const chatThreadsNextCursor$ = computed(async (get) => {
   const page = await get(chatThreadsFirstPage$);
   return page?.nextCursor ?? null;
 });
-
-/**
- * The earliest ended-but-unread thread that is not the currently open thread.
- * Used by the mobile header to prompt the user to check pending replies.
- */
-export const earliestUnreadEndedThread$ = computed(
-  async (get): Promise<ChatThreadListItem | null> => {
-    const threads = await get(chatThreads$);
-    const currentThreadId = get(currentChatThreadId$);
-
-    const candidates = threads
-      .filter((t) => {
-        return !t.running && !t.isRead && t.id !== currentThreadId;
-      })
-      .sort((a, b) => {
-        return (
-          new Date(a.createdAt).getTime() - new Date(b.createdAt).getTime()
-        );
-      });
-
-    return candidates[0] ?? null;
-  },
-);

--- a/turbo/apps/platform/src/views/zero-page/__tests__/sidebar-layout.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/sidebar-layout.test.tsx
@@ -24,6 +24,7 @@ import {
   setSidebarExpanded$,
   sidebarOff$,
 } from "../../../signals/zero-page/zero-nav.ts";
+import { isOrgAdmin$ } from "../../../signals/org.ts";
 import { setMockOrg } from "../../../mocks/handlers/api-org.ts";
 import { setMockOrgMembers } from "../../../mocks/handlers/api-org-members.ts";
 import { setMockTeam } from "../../../mocks/handlers/api-agents.ts";
@@ -123,6 +124,28 @@ describe("sidebar layout - invite button hidden for non-admins (SIDEBAR-D-049)",
     await waitFor(() => {
       expect(screen.queryByText("Invite")).not.toBeInTheDocument();
     });
+  });
+});
+
+describe("sidebar layout - invite button hidden on mobile thread routes", () => {
+  it("does not render the Invite fallback in the chat thread top bar for admins", async () => {
+    mockBaseAPIs();
+    detachedSetupPage({
+      context,
+      path: "/chats/b0000000-0000-4000-a000-000000000001",
+    });
+
+    await waitFor(async () => {
+      await expect(context.store.get(isOrgAdmin$)).resolves.toBe(true);
+    });
+
+    await waitFor(() => {
+      expect(
+        screen.getByLabelText("Open mobile artifacts"),
+      ).toBeInTheDocument();
+    });
+
+    expect(screen.queryByText("Invite")).not.toBeInTheDocument();
   });
 });
 

--- a/turbo/apps/platform/src/views/zero-page/__tests__/sidebar-layout.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/sidebar-layout.test.tsx
@@ -136,7 +136,7 @@ describe("sidebar layout - invite button hidden on mobile thread routes", () => 
     });
 
     await waitFor(async () => {
-      await expect(context.store.get(isOrgAdmin$)).resolves.toBe(true);
+      await expect(context.store.get(isOrgAdmin$)).resolves.toBeTruthy();
     });
 
     await waitFor(() => {

--- a/turbo/apps/platform/src/views/zero-page/__tests__/talk-navigation.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/talk-navigation.test.tsx
@@ -1,7 +1,6 @@
 import { describe, expect, it } from "vitest";
-import { act, screen, waitFor } from "@testing-library/react";
+import { screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
-import { FeatureSwitchKey } from "@vm0/connectors/feature-switch-key";
 import { server } from "../../../mocks/server.ts";
 import { testContext } from "../../../signals/__tests__/test-helpers.ts";
 import {
@@ -345,61 +344,5 @@ describe("talk navigation", () => {
     await waitFor(() => {
       expect(checkoutBody).toMatchObject({ tier: "pro", trialDays: 7 });
     });
-  });
-});
-
-describe("optimistic message preservation on thread resolution", () => {
-  it("preserves messages sent during the optimistic window after the thread resolves", async () => {
-    const user = userEvent.setup();
-    const createDeferred = createDeferredPromise<void>(context.signal);
-
-    mockChatAPIs();
-    server.use(
-      mockApi(chatThreadsContract.create, async ({ body, respond }) => {
-        await createDeferred.promise;
-        return respond(201, {
-          id: body.clientThreadId ?? "fallback",
-          title: null,
-          createdAt: "2026-03-10T00:00:00Z",
-        });
-      }),
-    );
-
-    detachedSetupPage({
-      context,
-      path: "/agents/c0000000-0000-4000-a000-000000000001/chat",
-      featureSwitches: { [FeatureSwitchKey.ChatHeaderNewButton]: true },
-    });
-
-    const newButton = await waitFor(() => {
-      return screen.getByTestId("chat-header-new-button");
-    });
-    await user.click(newButton);
-
-    const textarea = await waitFor(() => {
-      return screen.getByPlaceholderText(PLACEHOLDER) as HTMLTextAreaElement;
-    });
-
-    await fill(textarea, "Message during optimistic window");
-    await user.keyboard("{Enter}");
-
-    await waitFor(() => {
-      expect(
-        screen.getByText("Message during optimistic window"),
-      ).toBeInTheDocument();
-    });
-
-    // Resolve the thread creation, triggering the optimistic→remote handoff
-    // in resolvePaneThread$. The message must survive the transition.
-    await act(async () => {
-      createDeferred.resolve();
-      for (let i = 0; i < 30; i++) {
-        await Promise.resolve();
-      }
-    });
-
-    expect(
-      screen.getByText("Message during optimistic window"),
-    ).toBeInTheDocument();
   });
 });

--- a/turbo/apps/platform/src/views/zero-page/agent-chat-page.tsx
+++ b/turbo/apps/platform/src/views/zero-page/agent-chat-page.tsx
@@ -1,20 +1,9 @@
-import {
-  useGet,
-  useSet,
-  useLoadable,
-  useLastResolved,
-  useResolved,
-} from "ccstate-react";
+import { useGet, useSet, useLoadable, useLastResolved } from "ccstate-react";
 import { useLoadableSet } from "ccstate-react/experimental";
 import { pageSignal$ } from "../../signals/page-signal.ts";
 import { rootSignal$ } from "../../signals/root-signal.ts";
 import { user$ } from "../../signals/auth.ts";
-import {
-  IconArrowUpRight,
-  IconPin,
-  IconPlus,
-  IconUserPlus,
-} from "@tabler/icons-react";
+import { IconArrowUpRight, IconPin, IconUserPlus } from "@tabler/icons-react";
 import type { ConnectorType } from "@vm0/connectors/connectors";
 import { isSupportedRunModel } from "@vm0/api-contracts/contracts/model-providers";
 import type { GenerationTemplateRequest } from "@vm0/api-contracts/contracts/chat-threads";
@@ -25,8 +14,6 @@ import {
   TooltipProvider,
   TooltipTrigger,
 } from "@vm0/ui";
-import { FeatureSwitchKey } from "@vm0/connectors/feature-switch-key";
-import { featureSwitch$ } from "../../signals/external/feature-switch.ts";
 import {
   currentChatAgentId$,
   currentChatAgentDisplayName$,
@@ -65,12 +52,7 @@ import { ConnectorIcon } from "./components/settings/connector-icons.tsx";
 import { detachedNavigateTo$ } from "../../signals/route.ts";
 import { AgentAvatarImg } from "./zero-sidebar-shared.tsx";
 import { Link } from "../router/link.tsx";
-import {
-  createNewChatThreadOptimistically$,
-  optimisticChatThread$,
-  sendNewThreadOptimistically$,
-  type OptimisticChatPane,
-} from "../../signals/chat-page/optimistic-chat-thread-page.ts";
+import { sendNewThreadOptimistically$ } from "../../signals/chat-page/optimistic-chat-thread-page.ts";
 import { startChatNavigationTiming$ } from "../../lib/posthog.ts";
 import {
   typewriterDisplayed$,
@@ -180,51 +162,6 @@ function InviteButton({ pageSignal }: { pageSignal: AbortSignal }) {
       <IconUserPlus size={14} stroke={1.5} />
       Invite people
     </Button>
-  );
-}
-
-function NewChatButton() {
-  const currentChatAgentId = useResolved(currentChatAgentId$);
-  const createNewChat = useSet(createNewChatThreadOptimistically$);
-  const creating = useGet(optimisticChatThread$) !== null;
-  const rootSignal = useGet(rootSignal$);
-
-  const handleNewChat = (pane: OptimisticChatPane) => {
-    if (!currentChatAgentId) {
-      return;
-    }
-
-    detach(
-      createNewChat(currentChatAgentId, pane, rootSignal),
-      Reason.DomCallback,
-    );
-  };
-
-  return (
-    <Button
-      variant="outline"
-      size="sm"
-      onClick={(event) => {
-        handleNewChat(event.altKey ? "sidebar" : "main");
-      }}
-      disabled={!currentChatAgentId || creating}
-      className="zero-btn-morandi gap-1.5"
-      data-testid="chat-header-new-button"
-    >
-      <IconPlus size={14} stroke={1.5} />
-      New
-    </Button>
-  );
-}
-
-function ChatHeaderAction({ pageSignal }: { pageSignal: AbortSignal }) {
-  const features = useLastResolved(featureSwitch$);
-  const newButtonEnabled =
-    features?.[FeatureSwitchKey.ChatHeaderNewButton] ?? false;
-  return newButtonEnabled ? (
-    <NewChatButton />
-  ) : (
-    <InviteButton pageSignal={pageSignal} />
   );
 }
 
@@ -542,7 +479,7 @@ export function AgentChatPage() {
     <div className="relative flex flex-1 flex-col min-h-0">
       <header className="hidden md:block shrink-0 bg-transparent px-4 sm:px-6 pt-4 pb-2">
         <div className="flex justify-end items-center gap-2">
-          <ChatHeaderAction pageSignal={pageSignal} />
+          <InviteButton pageSignal={pageSignal} />
         </div>
       </header>
 

--- a/turbo/apps/platform/src/views/zero-page/sidebar-layout.tsx
+++ b/turbo/apps/platform/src/views/zero-page/sidebar-layout.tsx
@@ -4,12 +4,10 @@ import {
   useSet,
   useLastLoadable,
   useLastResolved,
-  useResolved,
 } from "ccstate-react";
 import {
   IconMenu2,
   IconPackage,
-  IconPlus,
   IconUserPlus,
   IconVolume2,
 } from "@tabler/icons-react";
@@ -18,21 +16,12 @@ import type { RouteKey } from "../../signals/route-paths.ts";
 import { cn } from "@vm0/ui";
 import { ZeroSidebar } from "./zero-sidebar.tsx";
 import { ScheduleMenuButton } from "./zero-chat-thread-page.tsx";
-import {
-  currentChatAgent$,
-  currentChatAgentId$,
-  earliestUnreadEndedThread$,
-} from "../../signals/agent-chat.ts";
+import { currentChatAgent$ } from "../../signals/agent-chat.ts";
 import {
   currentLeftThread$,
   currentRightThread$,
 } from "../../signals/chat-page/chat-thread-panes.ts";
 import type { ChatThreadSignals } from "../../signals/chat-page/create-chat-thread.ts";
-import {
-  createNewChatThreadOptimistically$,
-  optimisticChatThread$,
-  type OptimisticChatPane,
-} from "../../signals/chat-page/optimistic-chat-thread-page.ts";
 import { AvatarFromUrl } from "./zero-sidebar-shared.tsx";
 import { QueueDrawer } from "../queue-page/queue-drawer.tsx";
 import {
@@ -41,7 +30,6 @@ import {
   sidebarExpanded$,
   setSidebarExpanded$,
   isChatRoute,
-  navigateToChat$,
 } from "../../signals/zero-page/zero-nav.ts";
 import { featureSwitch$ } from "../../signals/external/feature-switch.ts";
 import { activeRoute$ } from "../../signals/active-route.ts";
@@ -62,7 +50,6 @@ import {
   setSettingsDialogOpen$,
 } from "../../signals/zero-page/settings/settings-dialog.ts";
 import { pageSignal$ } from "../../signals/page-signal.ts";
-import { rootSignal$ } from "../../signals/root-signal.ts";
 import { detach, Reason } from "../../signals/utils.ts";
 import {
   autoReadEnabled$,
@@ -144,57 +131,6 @@ function InviteButtonLeaf() {
   );
 }
 
-function NewOrUnreadChatButtonLeaf() {
-  const currentChatAgentId = useResolved(currentChatAgentId$);
-  const createNewChat = useSet(createNewChatThreadOptimistically$);
-  const navigateToChatFn = useSet(navigateToChat$);
-  const rootSignal = useGet(rootSignal$);
-  const creating = useGet(optimisticChatThread$) !== null;
-  const unreadThread = useLastResolved(earliestUnreadEndedThread$);
-
-  if (unreadThread) {
-    return (
-      <button
-        type="button"
-        onClick={() => {
-          navigateToChatFn(unreadThread.id);
-        }}
-        className="flex items-center gap-1.5 h-8 px-3 rounded-lg text-sm text-muted-foreground hover:text-foreground hover:bg-muted/50 transition-colors shrink-0"
-      >
-        <span
-          className="shrink-0 h-2 w-2 rounded-full bg-primary"
-          aria-label="Unread"
-        />
-        unread
-      </button>
-    );
-  }
-
-  const handleNewChat = (pane: OptimisticChatPane) => {
-    if (!currentChatAgentId) {
-      return;
-    }
-    detach(
-      createNewChat(currentChatAgentId, pane, rootSignal),
-      Reason.DomCallback,
-    );
-  };
-
-  return (
-    <button
-      type="button"
-      onClick={(event) => {
-        handleNewChat(event.altKey ? "sidebar" : "main");
-      }}
-      disabled={!currentChatAgentId || creating}
-      className="flex items-center gap-1.5 h-8 px-3 rounded-lg text-sm text-muted-foreground hover:text-foreground hover:bg-muted/50 transition-colors shrink-0 disabled:opacity-50"
-    >
-      <IconPlus size={14} stroke={1.5} />
-      New
-    </button>
-  );
-}
-
 function MobileArtifactsButtonInner({ thread }: { thread: ChatThreadSignals }) {
   const inboxThreadId = useGet(currentArtifactInboxThreadId$);
   const reloadArtifacts = useSet(thread.reloadArtifacts$);
@@ -254,18 +190,13 @@ function MobileScheduleButtonLeaf() {
 function MobileTopBarActions({ activeId }: { activeId: RouteKey | null }) {
   const inChatRoute = isChatRoute(activeId);
   const features = useLastResolved(featureSwitch$);
-  const newButtonEnabled =
-    features?.[FeatureSwitchKey.ChatHeaderNewButton] ?? false;
-  const showNewButton = inChatRoute && newButtonEnabled;
-  const showInviteFallback =
-    inChatRoute && !newButtonEnabled && activeId !== "chat";
+  const showInviteFallback = inChatRoute && activeId !== "chat";
   const audioOutputEnabled = features?.[FeatureSwitchKey.AudioOutput] ?? false;
   return (
     <>
       {inChatRoute && <MobileScheduleButtonLeaf />}
       {inChatRoute && <MobileArtifactsButtonLeaf />}
       {inChatRoute && audioOutputEnabled && <AutoReadToggleLeaf />}
-      {showNewButton && <NewOrUnreadChatButtonLeaf />}
       {showInviteFallback && <InviteButtonLeaf />}
     </>
   );

--- a/turbo/apps/platform/src/views/zero-page/sidebar-layout.tsx
+++ b/turbo/apps/platform/src/views/zero-page/sidebar-layout.tsx
@@ -256,18 +256,17 @@ function MobileTopBarActions({ activeId }: { activeId: RouteKey | null }) {
   const features = useLastResolved(featureSwitch$);
   const newButtonEnabled =
     features?.[FeatureSwitchKey.ChatHeaderNewButton] ?? false;
+  const showNewButton = inChatRoute && newButtonEnabled;
+  const showInviteFallback =
+    inChatRoute && !newButtonEnabled && activeId !== "chat";
   const audioOutputEnabled = features?.[FeatureSwitchKey.AudioOutput] ?? false;
   return (
     <>
       {inChatRoute && <MobileScheduleButtonLeaf />}
       {inChatRoute && <MobileArtifactsButtonLeaf />}
       {inChatRoute && audioOutputEnabled && <AutoReadToggleLeaf />}
-      {inChatRoute &&
-        (newButtonEnabled ? (
-          <NewOrUnreadChatButtonLeaf />
-        ) : (
-          <InviteButtonLeaf />
-        ))}
+      {showNewButton && <NewOrUnreadChatButtonLeaf />}
+      {showInviteFallback && <InviteButtonLeaf />}
     </>
   );
 }

--- a/turbo/packages/connectors/src/feature-switch-key.ts
+++ b/turbo/packages/connectors/src/feature-switch-key.ts
@@ -37,7 +37,6 @@ export enum FeatureSwitchKey {
   AudioOutput = "audioOutput",
   SkillsViewer = "skillsViewer",
   TestOauthConnector = "testOauthConnector",
-  ChatHeaderNewButton = "chatHeaderNewButton",
   ChatThreadRename = "chatThreadRename",
   FreshdeskConnector = "freshdeskConnector",
   StabilityAiConnector = "stabilityAiConnector",

--- a/turbo/packages/core/src/__tests__/feature-switch.test.ts
+++ b/turbo/packages/core/src/__tests__/feature-switch.test.ts
@@ -101,7 +101,6 @@ describe("getAllFeatureStates", () => {
     });
     expect(staffOrgStates[FeatureSwitchKey.Lab]).toBe(true);
     expect(staffOrgStates[FeatureSwitchKey.SkillsViewer]).toBe(true);
-    expect(staffOrgStates[FeatureSwitchKey.ChatHeaderNewButton]).toBe(false);
     expect(staffOrgStates[FeatureSwitchKey.ChatThreadRename]).toBe(false);
     expect(staffOrgStates[FeatureSwitchKey.ChatRecommendedFollowups]).toBe(
       true,

--- a/turbo/packages/core/src/feature-switch.ts
+++ b/turbo/packages/core/src/feature-switch.ts
@@ -207,12 +207,6 @@ const FEATURE_SWITCHES: Record<FeatureSwitchKey, FeatureSwitch> = {
       "Enable the test-oauth connector, a synthetic OAuth 2.0 provider used only for automated tests. Off in prod.",
     enabled: false,
   },
-  [FeatureSwitchKey.ChatHeaderNewButton]: {
-    maintainer: "ethan@vm0.ai",
-    description:
-      "Replace the Invite people button in the agent chat page header with a New button that creates a new chat thread",
-    enabled: false,
-  },
   [FeatureSwitchKey.ChatThreadRename]: {
     maintainer: "ethan@vm0.ai",
     description:


### PR DESCRIPTION
## Summary
- Remove the `ChatHeaderNewButton` feature switch from the shared feature-switch registry
- Remove the agent chat header/mobile top bar New-button branches and keep the Invite path as the desktop chat header action
- Keep mobile `/chats/:threadId` from showing the Invite fallback in the top bar
- Drop the test that only covered the deleted header New-button entry point

## Tests
- `pnpm exec prettier --write apps/platform/src/views/zero-page/agent-chat-page.tsx apps/platform/src/views/zero-page/sidebar-layout.tsx apps/platform/src/views/zero-page/__tests__/sidebar-layout.test.tsx apps/platform/src/views/zero-page/__tests__/talk-navigation.test.tsx packages/connectors/src/feature-switch-key.ts packages/core/src/feature-switch.ts packages/core/src/__tests__/feature-switch.test.ts`
- `pnpm -F @vm0/app exec eslint src/views/zero-page/agent-chat-page.tsx src/views/zero-page/sidebar-layout.tsx src/views/zero-page/__tests__/sidebar-layout.test.tsx src/views/zero-page/__tests__/talk-navigation.test.tsx --max-warnings 0`
- `pnpm -F @vm0/core exec eslint src/feature-switch.ts src/__tests__/feature-switch.test.ts --max-warnings 0`
- `pnpm -F @vm0/connectors exec eslint src/feature-switch-key.ts --max-warnings 0`
- `pnpm -F @vm0/app check-types`
- `pnpm -F @vm0/core check-types`
- `pnpm -F @vm0/connectors check-types`
- `pnpm exec vitest run apps/platform/src/views/zero-page/__tests__/sidebar-layout.test.tsx`
- `pnpm exec vitest run apps/platform/src/views/zero-page/__tests__/talk-navigation.test.tsx`
- `pnpm exec vitest run packages/core/src/__tests__/feature-switch.test.ts`