### PR TITLE
fix: make nbd orphan detection lock-aware

### DIFF
--- a/crates/runner/src/cmd/doctor.rs
+++ b/crates/runner/src/cmd/doctor.rs
@@ -78,7 +78,7 @@ enum Warning {
     NoDnsmasq { port: u16, base_dir: PathBuf },
     /// A network namespace whose pool lock is not held by any process.
     OrphanNamespace { ns_name: String, pool_idx: u32 },
-    /// An NBD device whose owning process has exited without disconnecting.
+    /// An NBD device whose recorded owner task has exited and whose lock is free.
     OrphanNbdDevice { device_index: u32, pid: u32 },
     /// The NBD orphan scan task panicked (bug in find_nbd_orphans).
     NbdScanFailed,
@@ -251,17 +251,10 @@ impl Warning {
                 is_lock_free(&lock_path).await
             }
             Self::OrphanNbdDevice { device_index, pid } => {
-                // Re-read sysfs to check if the device is still connected with a dead owner.
                 let idx = *device_index;
                 let original_pid = *pid;
                 tokio::task::spawn_blocking(move || {
-                    match super::nbd::read_nbd_pid(idx) {
-                        Some(current_pid) => {
-                            // Still orphaned if same dead PID
-                            current_pid == original_pid && !pid_exists(current_pid)
-                        }
-                        None => false, // device freed or pid cleared
-                    }
+                    super::nbd::nbd_orphan_is_reportable(idx, original_pid)
                 })
                 .await
                 .unwrap_or(false)
@@ -1010,7 +1003,7 @@ fn parse_netns_list_line(line: &str) -> Option<(&str, u32)> {
     Some((ns_name, parsed.pool_index))
 }
 
-/// Scan for NBD devices whose owning process has exited without disconnecting.
+/// Scan for lock-free NBD devices whose recorded owner task has exited.
 async fn detect_nbd_orphans() -> Vec<Warning> {
     let (_, orphans) = match tokio::task::spawn_blocking(super::nbd::find_nbd_orphans).await {
         Ok(result) => result,

--- a/crates/runner/src/cmd/gc.rs
+++ b/crates/runner/src/cmd/gc.rs
@@ -1033,7 +1033,7 @@ async fn gc_versions(
     Ok(removed)
 }
 
-/// Scan for NBD devices whose owning process has exited (orphans) and
+/// Scan for lock-free NBD devices whose recorded owner task has exited and
 /// optionally disconnect them. Returns the number of orphans cleaned.
 async fn gc_nbd_orphans(dry_run: bool) -> RunnerResult<u32> {
     let (max_devs, orphans) = tokio::task::spawn_blocking(super::nbd::find_nbd_orphans)

--- a/crates/runner/src/cmd/nbd.rs
+++ b/crates/runner/src/cmd/nbd.rs
@@ -2,6 +2,15 @@
 
 use std::path::Path;
 
+#[derive(Debug, Eq, PartialEq)]
+enum NbdOrphanProbe {
+    Orphan,
+    Locked,
+    Changed,
+    Live,
+    LockFailed(String),
+}
+
 #[derive(Debug)]
 pub(crate) enum NbdOrphanDisconnect {
     Disconnected,
@@ -17,7 +26,7 @@ pub(crate) fn read_nbds_max() -> u32 {
     nbd_cow::netlink::nbds_max()
 }
 
-/// Parse the PID from `/sys/block/nbd{i}/pid`. Returns `None` if the file
+/// Parse the PID/TID from `/sys/block/nbd{i}/pid`. Returns `None` if the file
 /// doesn't exist, is empty, or contains a non-positive value (-1, 0).
 pub(crate) fn read_nbd_pid(device_index: u32) -> Option<u32> {
     let content = std::fs::read_to_string(format!("/sys/block/nbd{device_index}/pid")).ok()?;
@@ -28,20 +37,99 @@ pub(crate) fn read_nbd_pid(device_index: u32) -> Option<u32> {
     trimmed.parse::<u32>().ok()
 }
 
-/// Scan all NBD devices for orphans: devices whose owning PID has exited.
+fn proc_pid_exists(pid: u32) -> bool {
+    Path::new(&format!("/proc/{pid}")).exists()
+}
+
+/// Recheck one NBD candidate with the per-index lock held.
+pub(crate) fn nbd_orphan_is_reportable(device_index: u32, pid: u32) -> bool {
+    let mut try_lock = nbd_cow::device_lock::try_acquire_device_claim;
+    let mut read_pid = read_nbd_pid;
+    let mut pid_exists = proc_pid_exists;
+    nbd_orphan_is_reportable_with(
+        device_index,
+        pid,
+        &mut try_lock,
+        &mut read_pid,
+        &mut pid_exists,
+    )
+}
+
+fn nbd_orphan_is_reportable_with<Guard>(
+    device_index: u32,
+    pid: u32,
+    try_lock: &mut impl FnMut(u32) -> std::io::Result<Option<Guard>>,
+    read_pid: &mut impl FnMut(u32) -> Option<u32>,
+    pid_exists: &mut impl FnMut(u32) -> bool,
+) -> bool {
+    match classify_nbd_orphan_candidate_with(device_index, pid, try_lock, read_pid, pid_exists) {
+        NbdOrphanProbe::Orphan => true,
+        NbdOrphanProbe::LockFailed(message) => {
+            tracing::warn!(
+                device_index,
+                pid,
+                error = %message,
+                "skipping NBD orphan candidate because device lock probe failed"
+            );
+            false
+        }
+        NbdOrphanProbe::Locked | NbdOrphanProbe::Changed | NbdOrphanProbe::Live => false,
+    }
+}
+
+fn classify_nbd_orphan_candidate_with<Guard>(
+    device_index: u32,
+    pid: u32,
+    try_lock: &mut impl FnMut(u32) -> std::io::Result<Option<Guard>>,
+    read_pid: &mut impl FnMut(u32) -> Option<u32>,
+    pid_exists: &mut impl FnMut(u32) -> bool,
+) -> NbdOrphanProbe {
+    let _guard = match try_lock(device_index) {
+        Ok(Some(guard)) => guard,
+        Ok(None) => return NbdOrphanProbe::Locked,
+        Err(e) => return NbdOrphanProbe::LockFailed(e.to_string()),
+    };
+
+    match read_pid(device_index) {
+        Some(current_pid) if current_pid == pid && !pid_exists(current_pid) => {
+            NbdOrphanProbe::Orphan
+        }
+        Some(current_pid) if current_pid == pid => NbdOrphanProbe::Live,
+        _ => NbdOrphanProbe::Changed,
+    }
+}
+
+/// Scan all NBD devices for reportable orphans: lock-free devices whose
+/// recorded owner task has exited.
 ///
 /// Returns `(max_devs_scanned, orphans)` where each orphan is `(device_index, pid)`.
 pub(crate) fn find_nbd_orphans() -> (u32, Vec<(u32, u32)>) {
     let max_devs = read_nbds_max();
+    let orphans = find_nbd_orphans_with(
+        max_devs,
+        nbd_cow::device_lock::try_acquire_device_claim,
+        read_nbd_pid,
+        proc_pid_exists,
+    );
+    (max_devs, orphans)
+}
+
+fn find_nbd_orphans_with<Guard>(
+    max_devs: u32,
+    mut try_lock: impl FnMut(u32) -> std::io::Result<Option<Guard>>,
+    mut read_pid: impl FnMut(u32) -> Option<u32>,
+    mut pid_exists: impl FnMut(u32) -> bool,
+) -> Vec<(u32, u32)> {
     let mut orphans: Vec<(u32, u32)> = Vec::new();
     for i in 0..max_devs {
-        if let Some(pid) = read_nbd_pid(i)
-            && !std::path::Path::new(&format!("/proc/{pid}")).exists()
+        if let Some(pid) = read_pid(i)
+            && !pid_exists(pid)
+            && nbd_orphan_is_reportable_with(i, pid, &mut try_lock, &mut read_pid, &mut pid_exists)
         {
             orphans.push((i, pid));
         }
     }
-    (max_devs, orphans)
+    orphans
 }
 
 /// Disconnect an orphan-looking NBD device only while holding its per-index
@@ -52,7 +140,7 @@ pub(crate) fn disconnect_orphan_if_still_dead(device_index: u32, pid: u32) -> Nb
         pid,
         nbd_cow::device_lock::try_acquire_device_claim,
         read_nbd_pid,
-        |pid| Path::new(&format!("/proc/{pid}")).exists(),
+        proc_pid_exists,
         nbd_cow::netlink::disconnect,
     )
 }
@@ -97,6 +185,149 @@ mod tests {
         fn drop(&mut self) {
             self.0.set(true);
         }
+    }
+
+    #[test]
+    fn find_nbd_orphans_skips_locked_dead_pid() {
+        let orphans = find_nbd_orphans_with(
+            1,
+            |_| Ok::<Option<()>, std::io::Error>(None),
+            |_| Some(123),
+            |_| false,
+        );
+
+        assert!(orphans.is_empty());
+    }
+
+    #[test]
+    fn find_nbd_orphans_reports_lock_free_dead_pid() {
+        let orphans = find_nbd_orphans_with(
+            1,
+            |_| Ok::<Option<()>, std::io::Error>(Some(())),
+            |_| Some(123),
+            |_| false,
+        );
+
+        assert_eq!(orphans, vec![(0, 123)]);
+    }
+
+    #[test]
+    fn find_nbd_orphans_does_not_lock_live_pid_candidates() {
+        let lock_attempts = Cell::new(0);
+        let orphans = find_nbd_orphans_with(
+            1,
+            |_| {
+                lock_attempts.set(lock_attempts.get() + 1);
+                Ok::<Option<()>, std::io::Error>(Some(()))
+            },
+            |_| Some(123),
+            |_| true,
+        );
+
+        assert!(orphans.is_empty());
+        assert_eq!(lock_attempts.get(), 0);
+    }
+
+    #[test]
+    fn orphan_probe_clears_when_pid_changes_after_lock() {
+        let mut try_lock = |_| Ok::<Option<()>, std::io::Error>(Some(()));
+        let mut read_pid = |_| Some(456);
+        let mut pid_exists = |_| false;
+
+        let status = classify_nbd_orphan_candidate_with(
+            3,
+            123,
+            &mut try_lock,
+            &mut read_pid,
+            &mut pid_exists,
+        );
+
+        assert_eq!(status, NbdOrphanProbe::Changed);
+    }
+
+    #[test]
+    fn orphan_probe_clears_when_pid_clears_after_lock() {
+        let mut try_lock = |_| Ok::<Option<()>, std::io::Error>(Some(()));
+        let mut read_pid = |_| None;
+        let mut pid_exists = |_| panic!("pid_exists should not run after pid is cleared");
+
+        let status = classify_nbd_orphan_candidate_with(
+            3,
+            123,
+            &mut try_lock,
+            &mut read_pid,
+            &mut pid_exists,
+        );
+
+        assert_eq!(status, NbdOrphanProbe::Changed);
+    }
+
+    #[test]
+    fn orphan_probe_clears_when_same_pid_is_live_after_lock() {
+        let mut try_lock = |_| Ok::<Option<()>, std::io::Error>(Some(()));
+        let mut read_pid = |_| Some(123);
+        let mut pid_exists = |_| true;
+
+        let status = classify_nbd_orphan_candidate_with(
+            3,
+            123,
+            &mut try_lock,
+            &mut read_pid,
+            &mut pid_exists,
+        );
+
+        assert_eq!(status, NbdOrphanProbe::Live);
+    }
+
+    #[test]
+    fn orphan_probe_reports_lock_error_as_not_reportable() {
+        let mut try_lock = |_| Err::<Option<()>, std::io::Error>(std::io::Error::other("boom"));
+        let mut read_pid = |_| panic!("read_pid should not run after lock failure");
+        let mut pid_exists = |_| panic!("pid_exists should not run after lock failure");
+
+        assert!(!nbd_orphan_is_reportable_with(
+            3,
+            123,
+            &mut try_lock,
+            &mut read_pid,
+            &mut pid_exists,
+        ));
+    }
+
+    #[test]
+    fn orphan_probe_holds_lock_through_recheck() {
+        let dropped = Rc::new(Cell::new(false));
+        let dropped_for_lock = dropped.clone();
+        let dropped_for_read = dropped.clone();
+        let dropped_for_pid = dropped.clone();
+        let mut try_lock = move |_| {
+            Ok::<Option<DropGuard>, std::io::Error>(Some(DropGuard(dropped_for_lock.clone())))
+        };
+        let mut read_pid = |_| {
+            assert!(
+                !dropped_for_read.get(),
+                "lock must be held while sysfs pid is re-read"
+            );
+            Some(123)
+        };
+        let mut pid_exists = |_| {
+            assert!(
+                !dropped_for_pid.get(),
+                "lock must be held while pid liveness is rechecked"
+            );
+            false
+        };
+
+        let status = classify_nbd_orphan_candidate_with(
+            3,
+            123,
+            &mut try_lock,
+            &mut read_pid,
+            &mut pid_exists,
+        );
+
+        assert_eq!(status, NbdOrphanProbe::Orphan);
+        assert!(dropped.get(), "lock should drop after orphan probe");
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- make shared NBD orphan detection require both a dead sysfs owner task and an acquirable per-index NBD lock
- route `runner doctor` NBD warning persistence through the same lock-aware recheck
- keep `runner gc` destructive cleanup protected by its final lock + pid recheck, while dry-run now uses the lock-aware orphan list
- add focused tests for locked, lock-free, changed, cleared, live, lock-error, and guard-lifetime NBD orphan probes

Fixes #16363

## Testing

- `cargo test --manifest-path crates/Cargo.toml -p runner cmd::nbd`
- `cargo test --manifest-path crates/Cargo.toml -p runner cmd::doctor`
- `cargo fmt --manifest-path crates/Cargo.toml --all`
- `cargo test --manifest-path crates/Cargo.toml -p runner`
- `cargo clippy --manifest-path crates/Cargo.toml -p runner --all-targets -- -D warnings`
- pre-commit hook: crates cargo-fmt, cargo-clippy, cargo-doc
