### PR TITLE
perf: preallocate exec env vector while decoding

### DIFF
--- a/crates/vsock-proto/src/payloads/exec_operation.rs
+++ b/crates/vsock-proto/src/payloads/exec_operation.rs
@@ -788,7 +788,7 @@ pub fn decode_exec_start(payload: &[u8]) -> Result<DecodedExecStart<'_>, Protoco
     if min_env_bytes > remaining_for_env {
         return Err(ProtocolError::InvalidPayload("exec start env truncated"));
     }
-    let mut env = Vec::new();
+    let mut env = Vec::with_capacity(env_count as usize);
     for _ in 0..env_count {
         let key_len = read_u32(payload, &mut offset, "exec start env key_len truncated")? as usize;
         let key = read_str(


### PR DESCRIPTION
## Summary
- Preallocate the decoded exec-start env vector using the already validated env count.
- Preserve the existing decoder validation and malformed-payload error behavior.

Closes #16372

## Tests
- `cargo test -p vsock-proto exec_start`
- `cargo fmt -p vsock-proto --check`
- `git diff --check`
- pre-commit hook: Rust cargo fmt, clippy, and doc checks