### PR TITLE
feat: add device auth provider poll state

### DIFF
--- a/turbo/apps/api/src/signals/routes/__tests__/zero-connectors-oauth-device-auth.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/zero-connectors-oauth-device-auth.test.ts
@@ -122,11 +122,13 @@ async function cleanupUser(userId: string, orgId: string) {
 async function encryptedProviderState(args: {
   readonly connectorType?: "test-oauth-device" | "slock";
   readonly deviceCode: string;
+  readonly pollState?: string;
 }): Promise<string> {
   return await encryptPersistentSecretValue(
     JSON.stringify({
       connectorType: args.connectorType ?? "test-oauth-device",
       deviceCode: args.deviceCode,
+      ...(args.pollState === undefined ? {} : { pollState: args.pollState }),
     }),
     {},
   );
@@ -335,6 +337,7 @@ async function createSession(args: {
   readonly deviceCode: string;
   readonly status?: "awaiting_user_authorization" | "polling";
   readonly intervalSeconds?: number;
+  readonly pollState?: string;
   readonly updatedAt?: Date;
   readonly expiresAt?: Date;
 }): Promise<{ readonly id: string; readonly sessionToken: string }> {
@@ -354,6 +357,7 @@ async function createSession(args: {
       encryptedProviderState: await encryptedProviderState({
         connectorType: args.connectorType ?? "test-oauth-device",
         deviceCode: args.deviceCode,
+        ...(args.pollState === undefined ? {} : { pollState: args.pollState }),
       }),
       userCode: "TEST-DEVICE",
       verificationUri: "https://oauth-device.test/device",
@@ -499,6 +503,73 @@ describe("OAuth device authorization connector routes", () => {
     );
     expect(decryptedProviderState).not.toContain("scopes");
     expect(kms.calls).toHaveLength(2);
+  });
+
+  it("stores provider poll state encrypted without exposing it in the start response", async () => {
+    const { userId, orgId } = await setupUser();
+    const pollState = "secret-provider-poll-state";
+    testOauthDeviceProvider.grant.startDeviceAuth = async (args) => {
+      return { ...(await originalStartDeviceAuth(args)), pollState };
+    };
+    const client = setupApp({ context })(
+      zeroConnectorOauthDeviceAuthSessionContract,
+    );
+
+    const response = await accept(
+      client.create({
+        params: { type: "test-oauth-device" },
+        body: { authMethod: "oauth" },
+        headers: { authorization: "Bearer clerk-session" },
+      }),
+      [200],
+    );
+
+    expect(JSON.stringify(response.body)).not.toContain(pollState);
+    const session = await onlySession(response.body.sessionId);
+    expect(session.encryptedProviderState).not.toContain(pollState);
+    const decryptedProviderState = await decryptPersistentSecretValue(
+      session.encryptedProviderState,
+      { orgId, userId },
+    );
+    const parsedProviderState = z
+      .object({ pollState: z.string() })
+      .parse(JSON.parse(decryptedProviderState) as unknown);
+    expect(parsedProviderState.pollState).toBe(pollState);
+  });
+
+  it("rejects oversized provider poll state before creating a session", async () => {
+    const { userId, orgId } = await setupUser();
+    testOauthDeviceProvider.grant.startDeviceAuth = async (args) => {
+      return {
+        ...(await originalStartDeviceAuth(args)),
+        pollState: "x".repeat(4097),
+      };
+    };
+    const client = setupApp({ context })(
+      zeroConnectorOauthDeviceAuthSessionContract,
+    );
+
+    const response = await accept(
+      client.create({
+        params: { type: "test-oauth-device" },
+        body: { authMethod: "oauth" },
+        headers: { authorization: "Bearer clerk-session" },
+      }),
+      [500],
+    );
+
+    expect(response.body).toStrictEqual({ error: "Internal server error" });
+    const sessions = await store
+      .set(writeDb$)
+      .select({ id: connectorOauthDeviceAuthorizationSessions.id })
+      .from(connectorOauthDeviceAuthorizationSessions)
+      .where(
+        and(
+          eq(connectorOauthDeviceAuthorizationSessions.orgId, orgId),
+          eq(connectorOauthDeviceAuthorizationSessions.userId, userId),
+        ),
+      );
+    expect(sessions).toStrictEqual([]);
   });
 
   it("marks the previous active session as superseded when a new session starts", async () => {
@@ -956,6 +1027,109 @@ describe("OAuth device authorization connector routes", () => {
     expect(response.body.error.message).toBe(
       "OAuth device authorization is not enabled for this connector",
     );
+  });
+
+  it("passes encrypted provider poll state back to the provider during poll", async () => {
+    const { userId, orgId } = await setupUser();
+    const pollState = "secret-provider-poll-state";
+    const session = await createSession({
+      userId,
+      orgId,
+      deviceCode: "pending",
+      pollState,
+    });
+    const client = setupApp({ context })(
+      zeroConnectorOauthDeviceAuthSessionContract,
+    );
+    let observedPollState: string | undefined;
+    testOauthDeviceProvider.grant.pollDeviceAuth = (args) => {
+      observedPollState = args.pollState;
+      return Promise.resolve({ status: "pending" });
+    };
+
+    const response = await accept(
+      client.poll({
+        params: { type: "test-oauth-device", sessionId: session.id },
+        body: { sessionToken: session.sessionToken },
+        headers: { authorization: "Bearer clerk-session" },
+      }),
+      [200],
+    );
+
+    expect(response.body).toStrictEqual({ status: "pending", interval: 5 });
+    expect(JSON.stringify(response.body)).not.toContain(pollState);
+    expect(observedPollState).toBe(pollState);
+  });
+
+  it("polls existing provider state that omits poll state", async () => {
+    const { userId, orgId } = await setupUser();
+    const session = await createSession({
+      userId,
+      orgId,
+      deviceCode: "pending",
+    });
+    const client = setupApp({ context })(
+      zeroConnectorOauthDeviceAuthSessionContract,
+    );
+    let pollCalled = false;
+    let observedPollState: string | undefined;
+    testOauthDeviceProvider.grant.pollDeviceAuth = (args) => {
+      pollCalled = true;
+      observedPollState = args.pollState;
+      return Promise.resolve({ status: "pending" });
+    };
+
+    const response = await accept(
+      client.poll({
+        params: { type: "test-oauth-device", sessionId: session.id },
+        body: { sessionToken: session.sessionToken },
+        headers: { authorization: "Bearer clerk-session" },
+      }),
+      [200],
+    );
+
+    expect(response.body).toStrictEqual({ status: "pending", interval: 5 });
+    expect(pollCalled).toBeTruthy();
+    expect(observedPollState).toBeUndefined();
+  });
+
+  it("fails safely for malformed encrypted provider state", async () => {
+    const { userId, orgId } = await setupUser();
+    const session = await createSession({
+      userId,
+      orgId,
+      deviceCode: "pending",
+    });
+    await store
+      .set(writeDb$)
+      .update(connectorOauthDeviceAuthorizationSessions)
+      .set({
+        encryptedProviderState: await encryptPersistentSecretValue(
+          JSON.stringify({ connectorType: "test-oauth-device" }),
+          {},
+        ),
+      })
+      .where(eq(connectorOauthDeviceAuthorizationSessions.id, session.id));
+    const client = setupApp({ context })(
+      zeroConnectorOauthDeviceAuthSessionContract,
+    );
+    let pollCalled = false;
+    testOauthDeviceProvider.grant.pollDeviceAuth = () => {
+      pollCalled = true;
+      return Promise.resolve({ status: "pending" });
+    };
+
+    const response = await accept(
+      client.poll({
+        params: { type: "test-oauth-device", sessionId: session.id },
+        body: { sessionToken: session.sessionToken },
+        headers: { authorization: "Bearer clerk-session" },
+      }),
+      [500],
+    );
+
+    expect(response.body).toStrictEqual({ error: "Internal server error" });
+    expect(pollCalled).toBeFalsy();
   });
 
   it("polls pending and restores the session to awaiting authorization", async () => {

--- a/turbo/apps/api/src/signals/routes/__tests__/zero-connectors-oauth-device-auth.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/zero-connectors-oauth-device-auth.test.ts
@@ -537,13 +537,11 @@ describe("OAuth device authorization connector routes", () => {
     expect(parsedProviderState.pollState).toBe(pollState);
   });
 
-  it("rejects oversized provider poll state before creating a session", async () => {
-    const { userId, orgId } = await setupUser();
+  it("accepts provider poll state at the byte limit", async () => {
+    const { orgId, userId } = await setupUser();
+    const pollState = "x".repeat(4096);
     testOauthDeviceProvider.grant.startDeviceAuth = async (args) => {
-      return {
-        ...(await originalStartDeviceAuth(args)),
-        pollState: "x".repeat(4097),
-      };
+      return { ...(await originalStartDeviceAuth(args)), pollState };
     };
     const client = setupApp({ context })(
       zeroConnectorOauthDeviceAuthSessionContract,
@@ -555,22 +553,66 @@ describe("OAuth device authorization connector routes", () => {
         body: { authMethod: "oauth" },
         headers: { authorization: "Bearer clerk-session" },
       }),
-      [500],
+      [200],
     );
 
-    expect(response.body).toStrictEqual({ error: "Internal server error" });
-    const sessions = await store
-      .set(writeDb$)
-      .select({ id: connectorOauthDeviceAuthorizationSessions.id })
-      .from(connectorOauthDeviceAuthorizationSessions)
-      .where(
-        and(
-          eq(connectorOauthDeviceAuthorizationSessions.orgId, orgId),
-          eq(connectorOauthDeviceAuthorizationSessions.userId, userId),
-        ),
-      );
-    expect(sessions).toStrictEqual([]);
+    const session = await onlySession(response.body.sessionId);
+    const decryptedProviderState = await decryptPersistentSecretValue(
+      session.encryptedProviderState,
+      { orgId, userId },
+    );
+    const parsedProviderState = z
+      .object({ pollState: z.string() })
+      .parse(JSON.parse(decryptedProviderState) as unknown);
+    expect(parsedProviderState.pollState).toBe(pollState);
   });
+
+  it.each([
+    {
+      caseName: "ascii",
+      pollState: "x".repeat(4097),
+    },
+    {
+      caseName: "multibyte",
+      pollState: `${"x".repeat(4095)}\u00e9`,
+    },
+  ])(
+    "rejects oversized $caseName provider poll state before creating a session",
+    async ({ pollState }) => {
+      const { userId, orgId } = await setupUser();
+      testOauthDeviceProvider.grant.startDeviceAuth = async (args) => {
+        return {
+          ...(await originalStartDeviceAuth(args)),
+          pollState,
+        };
+      };
+      const client = setupApp({ context })(
+        zeroConnectorOauthDeviceAuthSessionContract,
+      );
+
+      const response = await accept(
+        client.create({
+          params: { type: "test-oauth-device" },
+          body: { authMethod: "oauth" },
+          headers: { authorization: "Bearer clerk-session" },
+        }),
+        [500],
+      );
+
+      expect(response.body).toStrictEqual({ error: "Internal server error" });
+      const sessions = await store
+        .set(writeDb$)
+        .select({ id: connectorOauthDeviceAuthorizationSessions.id })
+        .from(connectorOauthDeviceAuthorizationSessions)
+        .where(
+          and(
+            eq(connectorOauthDeviceAuthorizationSessions.orgId, orgId),
+            eq(connectorOauthDeviceAuthorizationSessions.userId, userId),
+          ),
+        );
+      expect(sessions).toStrictEqual([]);
+    },
+  );
 
   it("marks the previous active session as superseded when a new session starts", async () => {
     const { userId, orgId } = await setupUser();

--- a/turbo/apps/api/src/signals/services/connector-oauth-device-auth.service.ts
+++ b/turbo/apps/api/src/signals/services/connector-oauth-device-auth.service.ts
@@ -1,3 +1,4 @@
+import { Buffer } from "node:buffer";
 import { createHash, randomBytes } from "node:crypto";
 
 import type {
@@ -78,12 +79,29 @@ type PollSuccess = {
   readonly body: ConnectorOauthDeviceAuthSessionPollResponse;
 };
 
+const DEVICE_AUTH_POLL_STATE_MAX_BYTES = 4096;
+
 const encryptedProviderStateSchema = z.object({
   connectorType: z.string(),
   deviceCode: z.string(),
+  pollState: z.string().optional(),
 });
 
 type EncryptedProviderState = z.infer<typeof encryptedProviderStateSchema>;
+
+function validatedDeviceAuthPollState(
+  pollState: string | undefined,
+): string | undefined {
+  if (pollState === undefined) {
+    return undefined;
+  }
+  if (Buffer.byteLength(pollState, "utf8") > DEVICE_AUTH_POLL_STATE_MAX_BYTES) {
+    throw new Error(
+      `Connector OAuth device authorization provider poll state exceeds ${DEVICE_AUTH_POLL_STATE_MAX_BYTES} bytes`,
+    );
+  }
+  return pollState;
+}
 
 type DeviceAuthMethodRef = ConnectorAuthMethodRefByGrantKind<"device-auth">;
 type DeviceAuthResolvedMethodClient =
@@ -645,6 +663,9 @@ async function runClaimedSession(
   const pollResult = await pollConnectorDeviceAuthorization({
     ...args,
     deviceCode: providerState.deviceCode,
+    ...(providerState.pollState === undefined
+      ? {}
+      : { pollState: providerState.pollState }),
   });
   args.signal.throwIfAborted();
 
@@ -770,10 +791,12 @@ export const startConnectorOauthDeviceAuthSession$ = command(
       startResult.interval ?? DEFAULT_POLL_INTERVAL_SECONDS;
     const now = nowDate();
     const expiresAt = new Date(now.getTime() + startResult.expiresIn * 1000);
+    const pollState = validatedDeviceAuthPollState(startResult.pollState);
     const encryptedProviderState = await encryptPersistentSecretValue(
       JSON.stringify({
         connectorType: resolvedMethod.type,
         deviceCode: startResult.deviceCode,
+        ...(pollState === undefined ? {} : { pollState }),
       }),
       {
         orgId: args.orgId,

--- a/turbo/packages/connectors/src/auth-providers/connector-auth.ts
+++ b/turbo/packages/connectors/src/auth-providers/connector-auth.ts
@@ -480,6 +480,7 @@ type ConnectorDeviceAuthorizationStartCallArgs =
 type ConnectorDeviceAuthorizationPollCallArgs =
   ConnectorDeviceAuthResolvedMethodClient & {
     readonly deviceCode: string;
+    readonly pollState?: string;
   };
 
 type ConnectorRefreshTokenAccessCallArgs<
@@ -655,6 +656,7 @@ export function pollConnectorDeviceAuthorization<
   readonly authMethod: Method;
   readonly authClient: ConnectorAuthClientForMethod<T, Method>;
   readonly deviceCode: string;
+  readonly pollState?: string;
 }): Promise<OAuthDeviceAuthPollResult<T, Method>>;
 export function pollConnectorDeviceAuthorization(
   args: ConnectorDeviceAuthorizationPollCallArgs,
@@ -667,6 +669,7 @@ export async function pollConnectorDeviceAuthorization<
   readonly authMethod: Method;
   readonly authClient: ConnectorAuthClientForMethod<T, Method>;
   readonly deviceCode: string;
+  readonly pollState?: string;
 }): Promise<OAuthDeviceAuthPollResult<T, Method>> {
   const provider = connectorDeviceAuthGrantProviderFor(
     args.type,
@@ -675,6 +678,7 @@ export async function pollConnectorDeviceAuthorization<
   return await provider.pollDeviceAuth({
     authClient: args.authClient,
     deviceCode: args.deviceCode,
+    ...(args.pollState === undefined ? {} : { pollState: args.pollState }),
   });
 }
 

--- a/turbo/packages/connectors/src/auth-providers/provider-flow-types.ts
+++ b/turbo/packages/connectors/src/auth-providers/provider-flow-types.ts
@@ -50,10 +50,12 @@ interface OAuthDeviceAuthStartFlowArgs {
 
 interface OAuthDeviceAuthPollFlowArgs {
   readonly deviceCode: string;
+  readonly pollState?: string;
 }
 
 export interface OAuthDeviceAuthStartResult {
   readonly deviceCode: string;
+  readonly pollState?: string;
   readonly userCode: string;
   readonly verificationUri: string;
   readonly verificationUriComplete?: string;


### PR DESCRIPTION
## Summary

- Add optional `pollState` plumbing to connector device-auth start/poll provider types.
- Persist optional poll state inside the existing encrypted device-auth session provider state blob with a 4096-byte UTF-8 bound.
- Pass decrypted poll state back to providers during poll without exposing it through public API responses.
- Add route-level integration coverage for encrypted persistence, poll delivery, omitted poll state compatibility, oversized state rejection, and malformed encrypted state behavior.

Closes #16400

## Testing

- `pnpm -F api exec vitest run src/signals/routes/__tests__/zero-connectors-oauth-device-auth.test.ts`
- `pnpm -F api lint`
- `pnpm -F api check-types`
- `pnpm -F @vm0/connectors check-types`
- `pnpm -F @vm0/connectors lint`
- `pnpm format`
- `pnpm exec prettier --check apps/api/src/signals/routes/__tests__/zero-connectors-oauth-device-auth.test.ts apps/api/src/signals/services/connector-oauth-device-auth.service.ts packages/connectors/src/auth-providers/connector-auth.ts packages/connectors/src/auth-providers/provider-flow-types.ts`
- `pnpm lint`
- `pnpm check-types`
- `pnpm knip`

Full `OPENAI_API_KEY= pnpm test` was run. It failed only in `@vm0/desktop src/computer-use-native.test.ts` because the local container is not macOS (`accessibility_unavailable: Desktop Computer Use is currently implemented for macOS`). The target API route test passed.
