### PR TITLE
fix: restrict runner runtime state permissions

### DIFF
--- a/crates/runner/src/cmd/benchmark.rs
+++ b/crates/runner/src/cmd/benchmark.rs
@@ -76,6 +76,7 @@ pub async fn run_benchmark(
     // 1. Load config, force concurrency=1
     let mut runner_config = config::load(&args.config).await?;
     runner_config.sandbox.max_concurrent = 1;
+    crate::private_fs::ensure_private_dir(&runner_config.base_dir).await?;
 
     let home = HomePaths::new()?;
 

--- a/crates/runner/src/cmd/doctor.rs
+++ b/crates/runner/src/cmd/doctor.rs
@@ -776,7 +776,13 @@ fn is_inactive_mode(mode: &str) -> bool {
 
 async fn read_status(base_dir: &Path) -> Option<StatusInfo> {
     let path = base_dir.join("status.json");
-    let content = tokio::fs::read_to_string(&path).await.ok()?;
+    let content = crate::private_fs::read_private_file_to_string_with_max(
+        &path,
+        crate::private_fs::PRIVATE_STATUS_FILE_READ_MAX_BYTES,
+    )
+    .await
+    .ok()
+    .flatten()?;
     let file: StatusFile = serde_json::from_str(&content).ok()?;
     Some(StatusInfo {
         mode: file.mode,

--- a/crates/runner/src/cmd/service.rs
+++ b/crates/runner/src/cmd/service.rs
@@ -1355,7 +1355,7 @@ mod tests {
         );
 
         let result = tokio::time::timeout(
-            std::time::Duration::from_millis(100),
+            std::time::Duration::from_secs(1),
             read_runner_status(dir.path()),
         )
         .await

--- a/crates/runner/src/cmd/service.rs
+++ b/crates/runner/src/cmd/service.rs
@@ -504,6 +504,22 @@ fn decide_gate(status: &RunnerStatusSnapshot) -> GateDecision {
 /// Returns an error on any I/O or parse failure — the caller should log the
 /// reason and fall through to forceful stop (status unknown → cannot protect
 /// jobs).
+async fn read_private_status_json(path: &Path) -> std::io::Result<String> {
+    match crate::private_fs::read_private_file_to_string_with_max(
+        path,
+        crate::private_fs::PRIVATE_STATUS_FILE_READ_MAX_BYTES,
+    )
+    .await
+    {
+        Ok(Some(content)) => Ok(content),
+        Ok(None) => Err(std::io::Error::new(
+            std::io::ErrorKind::NotFound,
+            format!("{} not found", path.display()),
+        )),
+        Err(error) => Err(std::io::Error::other(error.to_string())),
+    }
+}
+
 async fn read_runner_status(
     base_dir: &Path,
 ) -> Result<RunnerStatusSnapshot, RunnerStatusReadError> {
@@ -520,7 +536,7 @@ async fn read_runner_status(
     }
     let path = base_dir.join("status.json");
     let content =
-        tokio::fs::read_to_string(&path)
+        read_private_status_json(&path)
             .await
             .map_err(|error| RunnerStatusReadError::Read {
                 path: path.clone(),
@@ -1320,6 +1336,32 @@ mod tests {
             .await
             .unwrap();
         assert!(read_runner_status(dir.path()).await.is_err());
+    }
+
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn read_runner_status_rejects_fifo_without_blocking() {
+        use std::os::unix::ffi::OsStrExt;
+
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("status.json");
+        let c_path = std::ffi::CString::new(path.as_os_str().as_bytes()).unwrap();
+        let result = unsafe { nix::libc::mkfifo(c_path.as_ptr(), 0o600) };
+        assert_eq!(
+            result,
+            0,
+            "mkfifo failed: {}",
+            std::io::Error::last_os_error()
+        );
+
+        let result = tokio::time::timeout(
+            std::time::Duration::from_millis(100),
+            read_runner_status(dir.path()),
+        )
+        .await
+        .expect("status.json FIFO read should not block");
+
+        assert!(result.is_err(), "status.json FIFO should be rejected");
     }
 
     #[tokio::test]

--- a/crates/runner/src/cmd/setup.rs
+++ b/crates/runner/src/cmd/setup.rs
@@ -5,7 +5,7 @@
 //! used by sandbox startup.
 
 use std::io::Read;
-use std::os::unix::fs::PermissionsExt;
+use std::os::unix::fs::{MetadataExt, PermissionsExt};
 use std::path::{Path, PathBuf};
 
 use sha2::{Digest, Sha256};
@@ -22,6 +22,7 @@ use crate::paths::HomePaths;
 
 const GROUP_OR_OTHER_WRITE_BITS: u32 = 0o022;
 const OWNER_DIRECTORY_BITS: u32 = 0o700;
+const ROOT_UID: u32 = 0;
 const SHARED_DIRECTORY_CREATE_MODE: u32 = 0o755;
 
 /// Run the host setup workflow for sandbox execution.
@@ -191,6 +192,8 @@ fn secure_shared_directory_permissions(dir: &Path) -> RunnerResult<()> {
             dir.display()
         )));
     }
+    let expected_uid = nix::unistd::geteuid().as_raw();
+    ensure_trusted_shared_directory_owner(dir, stat.st_uid, expected_uid)?;
 
     let current_mode = (stat.st_mode as u32) & 0o7777;
     let secure_mode = (current_mode | OWNER_DIRECTORY_BITS) & !GROUP_OR_OTHER_WRITE_BITS;
@@ -198,6 +201,26 @@ fn secure_shared_directory_permissions(dir: &Path) -> RunnerResult<()> {
         chmod_open_shared_directory(&fd, dir, secure_mode)?;
     }
     Ok(())
+}
+
+#[cfg(unix)]
+fn ensure_trusted_shared_directory_owner(
+    dir: &Path,
+    owner_uid: u32,
+    expected_uid: u32,
+) -> RunnerResult<()> {
+    if !is_trusted_setup_owner(owner_uid, expected_uid) {
+        return Err(RunnerError::Internal(format!(
+            "shared directory {} is owned by untrusted uid {owner_uid}; fix ownership before running setup",
+            dir.display()
+        )));
+    }
+    Ok(())
+}
+
+#[cfg(unix)]
+fn is_trusted_setup_owner(owner_uid: u32, expected_uid: u32) -> bool {
+    owner_uid == ROOT_UID || owner_uid == expected_uid
 }
 
 #[cfg(all(unix, target_os = "linux"))]
@@ -517,6 +540,10 @@ async fn ensure_artifact_installed(
     if file_sha256(path).await? != expected_sha {
         return Ok(false);
     }
+    #[cfg(unix)]
+    if !is_trusted_setup_owner(metadata.uid(), nix::unistd::geteuid().as_raw()) {
+        return Ok(false);
+    }
 
     let Some(mode) = mode else {
         return Ok(true);
@@ -535,6 +562,10 @@ async fn ensure_artifact_installed(
         .map_err(|e| RunnerError::Internal(format!("stat {}: {e}", path.display())))?;
 
     if !metadata.is_file() || (metadata.permissions().mode() & 0o7777) != mode {
+        return Ok(false);
+    }
+    #[cfg(unix)]
+    if !is_trusted_setup_owner(metadata.uid(), nix::unistd::geteuid().as_raw()) {
         return Ok(false);
     }
 
@@ -802,6 +833,25 @@ mod tests {
         assert_eq!(bin_mode, 0o700);
         let logs_mode = std::fs::metadata(&logs_dir).unwrap().permissions().mode() & 0o777;
         assert_eq!(logs_mode, 0o700);
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn shared_directory_owner_must_be_current_user_or_root() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("shared");
+
+        assert!(is_trusted_setup_owner(0, 1000));
+        assert!(is_trusted_setup_owner(1000, 1000));
+        assert!(!is_trusted_setup_owner(1001, 1000));
+        ensure_trusted_shared_directory_owner(&path, 0, 1000).unwrap();
+        ensure_trusted_shared_directory_owner(&path, 1000, 1000).unwrap();
+        let error = ensure_trusted_shared_directory_owner(&path, 1001, 1000).unwrap_err();
+
+        assert!(
+            error.to_string().contains("untrusted uid"),
+            "unexpected error: {error}"
+        );
     }
 
     #[tokio::test]

--- a/crates/runner/src/cmd/setup.rs
+++ b/crates/runner/src/cmd/setup.rs
@@ -5,6 +5,7 @@
 //! used by sandbox startup.
 
 use std::io::Read;
+use std::os::fd::AsRawFd;
 use std::os::unix::fs::{MetadataExt, PermissionsExt};
 use std::path::{Path, PathBuf};
 
@@ -332,9 +333,7 @@ async fn create_setup_temp_file(path: &Path, label: &'static str) -> RunnerResul
         .map_err(|e| RunnerError::Internal(format!("create {label} {}: {e}", path.display())))?;
 
     #[cfg(unix)]
-    tokio::fs::set_permissions(path, std::fs::Permissions::from_mode(SETUP_TEMP_FILE_MODE))
-        .await
-        .map_err(|e| RunnerError::Internal(format!("chmod {label} {}: {e}", path.display())))?;
+    chmod_setup_file_fd(&file, label, path, SETUP_TEMP_FILE_MODE)?;
 
     Ok(file)
 }
@@ -364,10 +363,46 @@ fn create_setup_temp_file_sync(path: &Path, label: &'static str) -> RunnerResult
         .map_err(|e| RunnerError::Internal(format!("create {label} {}: {e}", path.display())))?;
 
     #[cfg(unix)]
-    std::fs::set_permissions(path, std::fs::Permissions::from_mode(SETUP_TEMP_FILE_MODE))
-        .map_err(|e| RunnerError::Internal(format!("chmod {label} {}: {e}", path.display())))?;
+    chmod_setup_file_fd(&file, label, path, SETUP_TEMP_FILE_MODE)?;
 
     Ok(file)
+}
+
+#[cfg(unix)]
+fn chmod_setup_file_fd(
+    file: &impl AsRawFd,
+    label: &str,
+    path: &Path,
+    mode: u32,
+) -> RunnerResult<()> {
+    let mut stat = std::mem::MaybeUninit::<libc::stat>::uninit();
+    // SAFETY: `stat` points to valid writable memory and `file` owns a live fd.
+    let stat_result = unsafe { libc::fstat(file.as_raw_fd(), stat.as_mut_ptr()) };
+    if stat_result != 0 {
+        return Err(RunnerError::Internal(format!(
+            "stat {label} {}: {}",
+            path.display(),
+            std::io::Error::last_os_error()
+        )));
+    }
+    // SAFETY: successful `fstat` initialized the full `stat` struct.
+    let stat = unsafe { stat.assume_init() };
+    if stat.st_mode & libc::S_IFMT != libc::S_IFREG {
+        return Err(RunnerError::Internal(format!(
+            "{label} {} is not a regular file",
+            path.display()
+        )));
+    }
+    // SAFETY: `fchmod` operates on the live fd and does not follow paths.
+    let chmod_result = unsafe { libc::fchmod(file.as_raw_fd(), mode as libc::mode_t) };
+    if chmod_result != 0 {
+        return Err(RunnerError::Internal(format!(
+            "chmod {label} {}: {}",
+            path.display(),
+            std::io::Error::last_os_error()
+        )));
+    }
+    Ok(())
 }
 
 /// Download a URL to a temp file. Cleans up on failure. Returns hex SHA256.
@@ -514,9 +549,7 @@ async fn verify_and_install(
 async fn atomic_rename(tmp_path: &Path, target: &Path, mode: Option<u32>) -> RunnerResult<()> {
     let result = async {
         if let Some(mode) = mode {
-            tokio::fs::set_permissions(tmp_path, std::fs::Permissions::from_mode(mode))
-                .await
-                .map_err(|e| RunnerError::Internal(format!("chmod {}: {e}", target.display())))?;
+            chmod_setup_file_path(tmp_path, "temp artifact", mode).await?;
         }
         tokio::fs::rename(tmp_path, target)
             .await
@@ -528,6 +561,25 @@ async fn atomic_rename(tmp_path: &Path, target: &Path, mode: Option<u32>) -> Run
         let _ = tokio::fs::remove_file(tmp_path).await;
     }
     result
+}
+
+#[cfg(unix)]
+async fn chmod_setup_file_path(path: &Path, label: &str, mode: u32) -> RunnerResult<()> {
+    let mut options = tokio::fs::OpenOptions::new();
+    options
+        .read(true)
+        .custom_flags(libc::O_NOFOLLOW | libc::O_CLOEXEC | libc::O_NONBLOCK);
+    let file = options.open(path).await.map_err(|e| {
+        RunnerError::Internal(format!("open {label} {} for chmod: {e}", path.display()))
+    })?;
+    chmod_setup_file_fd(&file, label, path, mode)
+}
+
+#[cfg(not(unix))]
+async fn chmod_setup_file_path(path: &Path, label: &str, mode: u32) -> RunnerResult<()> {
+    tokio::fs::set_permissions(path, std::fs::Permissions::from_mode(mode))
+        .await
+        .map_err(|e| RunnerError::Internal(format!("chmod {label} {}: {e}", path.display())))
 }
 
 #[allow(clippy::unreachable)] // arch validated by check_architecture
@@ -617,9 +669,7 @@ async fn ensure_artifact_installed(
         return Ok(true);
     }
 
-    tokio::fs::set_permissions(path, std::fs::Permissions::from_mode(mode))
-        .await
-        .map_err(|e| RunnerError::Internal(format!("chmod {}: {e}", path.display())))?;
+    chmod_setup_file_path(path, "existing artifact", mode).await?;
 
     let metadata = tokio::fs::symlink_metadata(path)
         .await
@@ -1048,6 +1098,24 @@ mod tests {
 
     #[cfg(unix)]
     #[tokio::test]
+    async fn ensure_artifact_installed_repairs_matching_readonly_file_mode() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("file.bin");
+        std::fs::write(&path, b"content").unwrap();
+        std::fs::set_permissions(&path, std::fs::Permissions::from_mode(0o444)).unwrap();
+        let sha = file_sha256(&path).await.unwrap();
+
+        assert!(
+            ensure_artifact_installed(&path, &sha, Some(0o755))
+                .await
+                .unwrap()
+        );
+        let mode = std::fs::metadata(&path).unwrap().permissions().mode() & 0o777;
+        assert_eq!(mode, 0o755);
+    }
+
+    #[cfg(unix)]
+    #[tokio::test]
     async fn ensure_artifact_installed_returns_false_for_untrusted_owner() {
         use nix::unistd::{Uid, chown};
 
@@ -1092,6 +1160,62 @@ mod tests {
         assert_eq!(std::fs::read(&target).unwrap(), b"kernel");
         let mode = std::fs::metadata(&target).unwrap().permissions().mode() & 0o777;
         assert_eq!(mode, KERNEL_ARTIFACT_MODE);
+    }
+
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn atomic_rename_rejects_tmp_symlink_without_chmodding_target() {
+        let dir = tempfile::tempdir().unwrap();
+        let tmp_path = dir.path().join("kernel.tmp");
+        let target = dir.path().join("vmlinux");
+        let outside = dir.path().join("outside");
+        std::fs::write(&outside, b"outside").unwrap();
+        std::fs::set_permissions(&outside, std::fs::Permissions::from_mode(0o644)).unwrap();
+        std::os::unix::fs::symlink(&outside, &tmp_path).unwrap();
+
+        let error = atomic_rename(&tmp_path, &target, Some(EXECUTABLE_ARTIFACT_MODE))
+            .await
+            .unwrap_err();
+
+        assert!(
+            error.to_string().contains("open temp artifact"),
+            "unexpected error: {error}"
+        );
+        assert_eq!(
+            std::fs::metadata(&outside).unwrap().permissions().mode() & 0o777,
+            0o644
+        );
+        assert_eq!(std::fs::read(&outside).unwrap(), b"outside");
+        assert!(!target.exists());
+        assert!(
+            !tmp_path.exists(),
+            "failed install should clean temp symlink"
+        );
+    }
+
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn chmod_setup_file_path_rejects_symlink_without_chmodding_target() {
+        let dir = tempfile::tempdir().unwrap();
+        let link = dir.path().join("artifact");
+        let outside = dir.path().join("outside");
+        std::fs::write(&outside, b"outside").unwrap();
+        std::fs::set_permissions(&outside, std::fs::Permissions::from_mode(0o644)).unwrap();
+        std::os::unix::fs::symlink(&outside, &link).unwrap();
+
+        let error = chmod_setup_file_path(&link, "existing artifact", EXECUTABLE_ARTIFACT_MODE)
+            .await
+            .unwrap_err();
+
+        assert!(
+            error.to_string().contains("open existing artifact"),
+            "unexpected error: {error}"
+        );
+        assert_eq!(
+            std::fs::metadata(&outside).unwrap().permissions().mode() & 0o777,
+            0o644
+        );
+        assert_eq!(std::fs::read(&outside).unwrap(), b"outside");
     }
 
     #[tokio::test]

--- a/crates/runner/src/cmd/setup.rs
+++ b/crates/runner/src/cmd/setup.rs
@@ -24,6 +24,9 @@ const GROUP_OR_OTHER_WRITE_BITS: u32 = 0o022;
 const OWNER_DIRECTORY_BITS: u32 = 0o700;
 const ROOT_UID: u32 = 0;
 const SHARED_DIRECTORY_CREATE_MODE: u32 = 0o755;
+const SETUP_TEMP_FILE_MODE: u32 = 0o600;
+const EXECUTABLE_ARTIFACT_MODE: u32 = 0o755;
+const KERNEL_ARTIFACT_MODE: u32 = 0o644;
 
 /// Run the host setup workflow for sandbox execution.
 ///
@@ -283,9 +286,7 @@ fn chmod_open_shared_directory<Fd: std::os::fd::AsFd>(
 /// Stream an HTTP response to a file, computing SHA256 incrementally.
 /// Returns the hex-encoded digest.
 async fn stream_to_file(mut response: reqwest::Response, path: &Path) -> RunnerResult<String> {
-    let mut file = tokio::fs::File::create(path)
-        .await
-        .map_err(|e| RunnerError::Internal(format!("create {}: {e}", path.display())))?;
+    let mut file = create_setup_temp_file(path, "download temp").await?;
     let mut hasher = Sha256::new();
 
     while let Some(chunk) = response
@@ -304,6 +305,69 @@ async fn stream_to_file(mut response: reqwest::Response, path: &Path) -> RunnerR
         .map_err(|e| RunnerError::Internal(format!("flush {}: {e}", path.display())))?;
 
     Ok(hex::encode(hasher.finalize()))
+}
+
+async fn create_setup_temp_file(path: &Path, label: &'static str) -> RunnerResult<tokio::fs::File> {
+    match tokio::fs::remove_file(path).await {
+        Ok(()) => {}
+        Err(e) if e.kind() == std::io::ErrorKind::NotFound => {}
+        Err(e) => {
+            return Err(RunnerError::Internal(format!(
+                "remove stale {label} {}: {e}",
+                path.display()
+            )));
+        }
+    }
+
+    let mut options = tokio::fs::OpenOptions::new();
+    options.write(true).create_new(true);
+    #[cfg(unix)]
+    {
+        options.mode(SETUP_TEMP_FILE_MODE);
+    }
+
+    let file = options
+        .open(path)
+        .await
+        .map_err(|e| RunnerError::Internal(format!("create {label} {}: {e}", path.display())))?;
+
+    #[cfg(unix)]
+    tokio::fs::set_permissions(path, std::fs::Permissions::from_mode(SETUP_TEMP_FILE_MODE))
+        .await
+        .map_err(|e| RunnerError::Internal(format!("chmod {label} {}: {e}", path.display())))?;
+
+    Ok(file)
+}
+
+fn create_setup_temp_file_sync(path: &Path, label: &'static str) -> RunnerResult<std::fs::File> {
+    match std::fs::remove_file(path) {
+        Ok(()) => {}
+        Err(e) if e.kind() == std::io::ErrorKind::NotFound => {}
+        Err(e) => {
+            return Err(RunnerError::Internal(format!(
+                "remove stale {label} {}: {e}",
+                path.display()
+            )));
+        }
+    }
+
+    let mut options = std::fs::OpenOptions::new();
+    options.write(true).create_new(true);
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::OpenOptionsExt;
+        options.mode(SETUP_TEMP_FILE_MODE);
+    }
+
+    let file = options
+        .open(path)
+        .map_err(|e| RunnerError::Internal(format!("create {label} {}: {e}", path.display())))?;
+
+    #[cfg(unix)]
+    std::fs::set_permissions(path, std::fs::Permissions::from_mode(SETUP_TEMP_FILE_MODE))
+        .map_err(|e| RunnerError::Internal(format!("chmod {label} {}: {e}", path.display())))?;
+
+    Ok(file)
 }
 
 /// Download a URL to a temp file. Cleans up on failure. Returns hex SHA256.
@@ -386,8 +450,7 @@ async fn extract_tar_entry(
                 .unwrap_or_default();
 
             if file_name == entry_name {
-                let mut out = std::fs::File::create(&tmp)
-                    .map_err(|e| RunnerError::Internal(format!("create temp binary: {e}")))?;
+                let mut out = create_setup_temp_file_sync(&tmp, "extracted temp binary")?;
                 let mut hasher = Sha256::new();
                 let mut buf = [0u8; 64 * 1024];
                 loop {
@@ -576,7 +639,7 @@ async fn download_firecracker(paths: &HomePaths, arch: &str) -> RunnerResult<()>
     let bin_path = paths.firecracker_bin(FIRECRACKER_VERSION);
     let expected_sha = select_sha(arch, FIRECRACKER_SHA256_X86_64, FIRECRACKER_SHA256_AARCH64);
 
-    if ensure_artifact_installed(&bin_path, expected_sha, Some(0o755)).await? {
+    if ensure_artifact_installed(&bin_path, expected_sha, Some(EXECUTABLE_ARTIFACT_MODE)).await? {
         tracing::info!(
             "[OK] firecracker {FIRECRACKER_VERSION} already installed, skipping download"
         );
@@ -598,7 +661,7 @@ async fn download_firecracker(paths: &HomePaths, arch: &str) -> RunnerResult<()>
         "firecracker",
         &tmp_path,
         &bin_path,
-        Some(0o755),
+        Some(EXECUTABLE_ARTIFACT_MODE),
     )
     .await?;
     tracing::info!("[OK] firecracker {FIRECRACKER_VERSION} installed");
@@ -609,7 +672,7 @@ async fn download_kernel(paths: &HomePaths, arch: &str) -> RunnerResult<()> {
     let kernel_path = paths.kernel_bin(FIRECRACKER_VERSION, KERNEL_VERSION);
     let expected_sha = select_sha(arch, KERNEL_SHA256_X86_64, KERNEL_SHA256_AARCH64);
 
-    if ensure_artifact_installed(&kernel_path, expected_sha, None).await? {
+    if ensure_artifact_installed(&kernel_path, expected_sha, Some(KERNEL_ARTIFACT_MODE)).await? {
         tracing::info!("[OK] kernel vmlinux-{KERNEL_VERSION} already installed, skipping download");
         return Ok(());
     }
@@ -626,7 +689,7 @@ async fn download_kernel(paths: &HomePaths, arch: &str) -> RunnerResult<()> {
         "kernel",
         &tmp_path,
         &kernel_path,
-        None,
+        Some(KERNEL_ARTIFACT_MODE),
     )
     .await?;
     tracing::info!("[OK] kernel vmlinux-{KERNEL_VERSION} installed");
@@ -637,7 +700,7 @@ async fn download_mitmdump(paths: &HomePaths, arch: &str) -> RunnerResult<()> {
     let bin_path = paths.mitmdump_bin(MITMPROXY_VERSION);
     let expected_sha = select_sha(arch, MITMDUMP_SHA256_X86_64, MITMDUMP_SHA256_AARCH64);
 
-    if ensure_artifact_installed(&bin_path, expected_sha, Some(0o755)).await? {
+    if ensure_artifact_installed(&bin_path, expected_sha, Some(EXECUTABLE_ARTIFACT_MODE)).await? {
         tracing::info!("[OK] mitmdump {MITMPROXY_VERSION} already installed, skipping download");
         return Ok(());
     }
@@ -662,7 +725,7 @@ async fn download_mitmdump(paths: &HomePaths, arch: &str) -> RunnerResult<()> {
         "mitmdump",
         &tmp_path,
         &bin_path,
-        Some(0o755),
+        Some(EXECUTABLE_ARTIFACT_MODE),
     )
     .await?;
     tracing::info!("[OK] mitmdump {MITMPROXY_VERSION} installed");
@@ -867,6 +930,38 @@ mod tests {
         );
     }
 
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn create_setup_temp_file_replaces_stale_wide_file_privately() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("download.tmp");
+        std::fs::write(&path, b"stale").unwrap();
+        std::fs::set_permissions(&path, std::fs::Permissions::from_mode(0o666)).unwrap();
+
+        let file = create_setup_temp_file(&path, "test temp").await.unwrap();
+        drop(file);
+
+        assert_eq!(std::fs::read(&path).unwrap(), b"");
+        let mode = std::fs::metadata(&path).unwrap().permissions().mode() & 0o777;
+        assert_eq!(mode, SETUP_TEMP_FILE_MODE);
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn create_setup_temp_file_sync_replaces_stale_wide_file_privately() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("extract.tmp");
+        std::fs::write(&path, b"stale").unwrap();
+        std::fs::set_permissions(&path, std::fs::Permissions::from_mode(0o666)).unwrap();
+
+        let file = create_setup_temp_file_sync(&path, "test temp").unwrap();
+        drop(file);
+
+        assert_eq!(std::fs::read(&path).unwrap(), b"");
+        let mode = std::fs::metadata(&path).unwrap().permissions().mode() & 0o777;
+        assert_eq!(mode, SETUP_TEMP_FILE_MODE);
+    }
+
     #[tokio::test]
     async fn ensure_artifact_installed_returns_false_for_missing() {
         let dir = tempfile::tempdir().unwrap();
@@ -929,6 +1024,32 @@ mod tests {
         );
         let mode = std::fs::metadata(&path).unwrap().permissions().mode() & 0o777;
         assert_eq!(mode, 0o755);
+    }
+
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn verify_and_install_sets_kernel_artifact_mode() {
+        let dir = tempfile::tempdir().unwrap();
+        let tmp_path = dir.path().join("kernel.tmp");
+        let target = dir.path().join("vmlinux");
+        std::fs::write(&tmp_path, b"kernel").unwrap();
+        std::fs::set_permissions(&tmp_path, std::fs::Permissions::from_mode(0o666)).unwrap();
+        let sha = file_sha256(&tmp_path).await.unwrap();
+
+        verify_and_install(
+            &sha,
+            &sha,
+            "kernel",
+            &tmp_path,
+            &target,
+            Some(KERNEL_ARTIFACT_MODE),
+        )
+        .await
+        .unwrap();
+
+        assert_eq!(std::fs::read(&target).unwrap(), b"kernel");
+        let mode = std::fs::metadata(&target).unwrap().permissions().mode() & 0o777;
+        assert_eq!(mode, KERNEL_ARTIFACT_MODE);
     }
 
     #[tokio::test]

--- a/crates/runner/src/cmd/setup.rs
+++ b/crates/runner/src/cmd/setup.rs
@@ -600,11 +600,12 @@ async fn ensure_artifact_installed(
         return Ok(false);
     }
 
-    if file_sha256(path).await? != expected_sha {
-        return Ok(false);
-    }
     #[cfg(unix)]
     if !is_trusted_setup_owner(metadata.uid(), nix::unistd::geteuid().as_raw()) {
+        return Ok(false);
+    }
+
+    if file_sha256(path).await? != expected_sha {
         return Ok(false);
     }
 
@@ -624,11 +625,14 @@ async fn ensure_artifact_installed(
         .await
         .map_err(|e| RunnerError::Internal(format!("stat {}: {e}", path.display())))?;
 
-    if !metadata.is_file() || (metadata.permissions().mode() & 0o7777) != mode {
+    if !metadata.is_file() {
         return Ok(false);
     }
     #[cfg(unix)]
     if !is_trusted_setup_owner(metadata.uid(), nix::unistd::geteuid().as_raw()) {
+        return Ok(false);
+    }
+    if (metadata.permissions().mode() & 0o7777) != mode {
         return Ok(false);
     }
 
@@ -1024,6 +1028,28 @@ mod tests {
         );
         let mode = std::fs::metadata(&path).unwrap().permissions().mode() & 0o777;
         assert_eq!(mode, 0o755);
+    }
+
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn ensure_artifact_installed_returns_false_for_untrusted_owner() {
+        use nix::unistd::{Uid, chown};
+
+        if !nix::unistd::geteuid().is_root() {
+            return;
+        }
+
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("file.bin");
+        std::fs::write(&path, b"content").unwrap();
+        let sha = file_sha256(&path).await.unwrap();
+        chown(&path, Some(Uid::from_raw(1)), None).unwrap();
+
+        assert!(
+            !ensure_artifact_installed(&path, &sha, Some(0o755))
+                .await
+                .unwrap()
+        );
     }
 
     #[cfg(unix)]

--- a/crates/runner/src/cmd/setup.rs
+++ b/crates/runner/src/cmd/setup.rs
@@ -21,6 +21,7 @@ use crate::error::{RunnerError, RunnerResult};
 use crate::paths::HomePaths;
 
 const GROUP_OR_OTHER_WRITE_BITS: u32 = 0o022;
+const OWNER_DIRECTORY_BITS: u32 = 0o700;
 const SHARED_DIRECTORY_CREATE_MODE: u32 = 0o755;
 
 /// Run the host setup workflow for sandbox execution.
@@ -192,7 +193,7 @@ fn secure_shared_directory_permissions(dir: &Path) -> RunnerResult<()> {
     }
 
     let current_mode = (stat.st_mode as u32) & 0o7777;
-    let secure_mode = current_mode & !GROUP_OR_OTHER_WRITE_BITS;
+    let secure_mode = (current_mode | OWNER_DIRECTORY_BITS) & !GROUP_OR_OTHER_WRITE_BITS;
     if secure_mode != current_mode {
         chmod_open_shared_directory(&fd, dir, secure_mode)?;
     }
@@ -746,15 +747,18 @@ mod tests {
 
     #[cfg(unix)]
     #[test]
-    fn create_directories_removes_shared_write_bits_without_widening_modes() {
+    fn create_directories_secures_shared_directory_modes() {
         let dir = tempfile::tempdir().unwrap();
         let paths = HomePaths::with_root(dir.path().join("vm0-runner"));
+        let bin_dir = paths.bin_dir();
         let runners_dir = paths.runners_dir();
         let logs_dir = paths.logs_dir();
 
+        std::fs::create_dir_all(&bin_dir).unwrap();
         std::fs::create_dir_all(&runners_dir).unwrap();
         std::fs::create_dir_all(&logs_dir).unwrap();
         std::fs::set_permissions(paths.root_dir(), std::fs::Permissions::from_mode(0o777)).unwrap();
+        std::fs::set_permissions(&bin_dir, std::fs::Permissions::from_mode(0o000)).unwrap();
         std::fs::set_permissions(&runners_dir, std::fs::Permissions::from_mode(0o777)).unwrap();
         std::fs::set_permissions(&logs_dir, std::fs::Permissions::from_mode(0o700)).unwrap();
 
@@ -786,8 +790,16 @@ mod tests {
                 "{} mode should not be group/other writable: {mode:o}",
                 path.display()
             );
+            assert_eq!(
+                mode & OWNER_DIRECTORY_BITS,
+                OWNER_DIRECTORY_BITS,
+                "{} mode should preserve owner rwx access: {mode:o}",
+                path.display()
+            );
         }
 
+        let bin_mode = std::fs::metadata(&bin_dir).unwrap().permissions().mode() & 0o777;
+        assert_eq!(bin_mode, 0o700);
         let logs_mode = std::fs::metadata(&logs_dir).unwrap().permissions().mode() & 0o777;
         assert_eq!(logs_mode, 0o700);
     }

--- a/crates/runner/src/cmd/setup.rs
+++ b/crates/runner/src/cmd/setup.rs
@@ -126,7 +126,6 @@ fn create_directories(paths: &HomePaths) -> RunnerResult<()> {
         parent_dir(&mitmproxy_version_dir)?,
         mitmproxy_version_dir,
         paths.images_dir(),
-        paths.logs_dir(),
         paths.runners_dir(),
         paths.workspace_image_cache_dir(),
         paths.groups_dir(),
@@ -137,6 +136,7 @@ fn create_directories(paths: &HomePaths) -> RunnerResult<()> {
     for dir in &dirs {
         ensure_shared_directory(dir)?;
     }
+    crate::log_fs::ensure_log_dir_sync(&paths.logs_dir())?;
     tracing::info!("[OK] directory structure created");
     Ok(())
 }
@@ -899,6 +899,22 @@ mod tests {
         let bin_mode = std::fs::metadata(&bin_dir).unwrap().permissions().mode() & 0o777;
         assert_eq!(bin_mode, 0o700);
         let logs_mode = std::fs::metadata(&logs_dir).unwrap().permissions().mode() & 0o777;
+        assert_eq!(logs_mode, 0o700);
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn create_directories_creates_logs_dir_private() {
+        let dir = tempfile::tempdir().unwrap();
+        let paths = HomePaths::with_root(dir.path().join("vm0-runner"));
+
+        create_directories(&paths).unwrap();
+
+        let logs_mode = std::fs::metadata(paths.logs_dir())
+            .unwrap()
+            .permissions()
+            .mode()
+            & 0o777;
         assert_eq!(logs_mode, 0o700);
     }
 

--- a/crates/runner/src/cmd/setup.rs
+++ b/crates/runner/src/cmd/setup.rs
@@ -6,7 +6,7 @@
 
 use std::io::Read;
 use std::os::unix::fs::PermissionsExt;
-use std::path::Path;
+use std::path::{Path, PathBuf};
 
 use sha2::{Digest, Sha256};
 use tokio::io::AsyncWriteExt;
@@ -20,6 +20,9 @@ use crate::deps::{
 use crate::error::{RunnerError, RunnerResult};
 use crate::paths::HomePaths;
 
+const GROUP_OR_OTHER_WRITE_BITS: u32 = 0o022;
+const SHARED_DIRECTORY_CREATE_MODE: u32 = 0o755;
+
 /// Run the host setup workflow for sandbox execution.
 ///
 /// Returns `RunnerError::Config` when the host configuration is unsupported or
@@ -31,7 +34,7 @@ pub async fn run_setup() -> RunnerResult<()> {
     let missing_required = check_system_dependencies();
 
     let paths = HomePaths::new()?;
-    create_directories(&paths).await?;
+    create_directories(&paths)?;
     download_firecracker(&paths, arch).await?;
     download_kernel(&paths, arch).await?;
     download_mitmdump(&paths, arch).await?;
@@ -107,20 +110,146 @@ fn check_system_dependencies() -> Vec<&'static str> {
     missing_required
 }
 
-async fn create_directories(paths: &HomePaths) -> RunnerResult<()> {
+fn create_directories(paths: &HomePaths) -> RunnerResult<()> {
+    let firecracker_version_dir = paths.firecracker_dir(FIRECRACKER_VERSION);
+    let mitmproxy_version_dir = paths.mitmproxy_dir(MITMPROXY_VERSION);
     let dirs = [
+        paths.root_dir().to_path_buf(),
         paths.bin_dir(),
-        paths.firecracker_dir(FIRECRACKER_VERSION),
-        paths.mitmproxy_dir(MITMPROXY_VERSION),
+        parent_dir(&firecracker_version_dir)?,
+        firecracker_version_dir,
+        parent_dir(&mitmproxy_version_dir)?,
+        mitmproxy_version_dir,
+        paths.images_dir(),
+        paths.logs_dir(),
         paths.runners_dir(),
+        paths.workspace_image_cache_dir(),
+        paths.groups_dir(),
+        paths.debootstrap_dir(),
+        paths.locks_dir(),
+        paths.storages_dir(),
     ];
     for dir in &dirs {
-        tokio::fs::create_dir_all(dir)
-            .await
-            .map_err(|e| RunnerError::Internal(format!("create {}: {e}", dir.display())))?;
+        ensure_shared_directory(dir)?;
     }
     tracing::info!("[OK] directory structure created");
     Ok(())
+}
+
+fn parent_dir(path: &Path) -> RunnerResult<PathBuf> {
+    path.parent().map(Path::to_path_buf).ok_or_else(|| {
+        RunnerError::Internal(format!(
+            "{} does not have a parent directory",
+            path.display()
+        ))
+    })
+}
+
+fn ensure_shared_directory(dir: &Path) -> RunnerResult<()> {
+    create_shared_directory_all(dir)?;
+    secure_shared_directory_permissions(dir)
+}
+
+#[cfg(unix)]
+fn create_shared_directory_all(dir: &Path) -> RunnerResult<()> {
+    use std::os::unix::fs::DirBuilderExt;
+
+    std::fs::DirBuilder::new()
+        .recursive(true)
+        .mode(SHARED_DIRECTORY_CREATE_MODE)
+        .create(dir)
+        .map_err(|e| RunnerError::Internal(format!("create {}: {e}", dir.display())))?;
+    Ok(())
+}
+
+#[cfg(not(unix))]
+fn create_shared_directory_all(dir: &Path) -> RunnerResult<()> {
+    std::fs::create_dir_all(dir)
+        .map_err(|e| RunnerError::Internal(format!("create {}: {e}", dir.display())))?;
+    Ok(())
+}
+
+#[cfg(unix)]
+fn secure_shared_directory_permissions(dir: &Path) -> RunnerResult<()> {
+    use nix::fcntl::open;
+    use nix::sys::stat::{Mode, SFlag, fstat};
+
+    let fd = open(dir, shared_directory_open_flags(), Mode::empty()).map_err(|e| {
+        RunnerError::Internal(format!(
+            "open shared directory {} without following symlinks: {e}",
+            dir.display()
+        ))
+    })?;
+    let stat = fstat(&fd).map_err(|e| {
+        RunnerError::Internal(format!("stat shared directory {}: {e}", dir.display()))
+    })?;
+    let file_type = SFlag::from_bits_truncate(stat.st_mode & SFlag::S_IFMT.bits());
+    if file_type != SFlag::S_IFDIR {
+        return Err(RunnerError::Internal(format!(
+            "{} is not a directory",
+            dir.display()
+        )));
+    }
+
+    let current_mode = (stat.st_mode as u32) & 0o7777;
+    let secure_mode = current_mode & !GROUP_OR_OTHER_WRITE_BITS;
+    if secure_mode != current_mode {
+        chmod_open_shared_directory(&fd, dir, secure_mode)?;
+    }
+    Ok(())
+}
+
+#[cfg(all(unix, target_os = "linux"))]
+fn shared_directory_open_flags() -> nix::fcntl::OFlag {
+    nix::fcntl::OFlag::O_PATH
+        | nix::fcntl::OFlag::O_DIRECTORY
+        | nix::fcntl::OFlag::O_NOFOLLOW
+        | nix::fcntl::OFlag::O_CLOEXEC
+}
+
+#[cfg(all(unix, not(target_os = "linux")))]
+fn shared_directory_open_flags() -> nix::fcntl::OFlag {
+    nix::fcntl::OFlag::O_RDONLY
+        | nix::fcntl::OFlag::O_DIRECTORY
+        | nix::fcntl::OFlag::O_NOFOLLOW
+        | nix::fcntl::OFlag::O_CLOEXEC
+}
+
+#[cfg(not(unix))]
+fn secure_shared_directory_permissions(dir: &Path) -> RunnerResult<()> {
+    let metadata = std::fs::metadata(dir).map_err(|e| {
+        RunnerError::Internal(format!("stat shared directory {}: {e}", dir.display()))
+    })?;
+    if !metadata.is_dir() {
+        return Err(RunnerError::Internal(format!(
+            "{} is not a directory",
+            dir.display()
+        )));
+    }
+    Ok(())
+}
+
+#[cfg(all(unix, target_os = "linux"))]
+fn chmod_open_shared_directory<Fd: std::os::fd::AsRawFd>(
+    fd: &Fd,
+    dir: &Path,
+    mode: u32,
+) -> RunnerResult<()> {
+    let fd_path = PathBuf::from(format!("/proc/self/fd/{}", fd.as_raw_fd()));
+    std::fs::set_permissions(&fd_path, std::fs::Permissions::from_mode(mode)).map_err(|e| {
+        RunnerError::Internal(format!("chmod shared directory {}: {e}", dir.display()))
+    })
+}
+
+#[cfg(all(unix, not(target_os = "linux")))]
+fn chmod_open_shared_directory<Fd: std::os::fd::AsFd>(
+    fd: &Fd,
+    dir: &Path,
+    mode: u32,
+) -> RunnerResult<()> {
+    nix::sys::stat::fchmod(fd, nix::sys::stat::Mode::from_bits_truncate(mode)).map_err(|e| {
+        RunnerError::Internal(format!("chmod shared directory {}: {e}", dir.display()))
+    })
 }
 
 // ---------------------------------------------------------------------------
@@ -613,6 +742,54 @@ mod tests {
             sha,
             "b94d27b9934d3e08a52e52d7da7dabfac484efe37a5380ee9088f7ace2efcde9"
         );
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn create_directories_removes_shared_write_bits_without_widening_modes() {
+        let dir = tempfile::tempdir().unwrap();
+        let paths = HomePaths::with_root(dir.path().join("vm0-runner"));
+        let runners_dir = paths.runners_dir();
+        let logs_dir = paths.logs_dir();
+
+        std::fs::create_dir_all(&runners_dir).unwrap();
+        std::fs::create_dir_all(&logs_dir).unwrap();
+        std::fs::set_permissions(paths.root_dir(), std::fs::Permissions::from_mode(0o777)).unwrap();
+        std::fs::set_permissions(&runners_dir, std::fs::Permissions::from_mode(0o777)).unwrap();
+        std::fs::set_permissions(&logs_dir, std::fs::Permissions::from_mode(0o700)).unwrap();
+
+        create_directories(&paths).unwrap();
+
+        let firecracker_version_dir = paths.firecracker_dir(FIRECRACKER_VERSION);
+        let mitmproxy_version_dir = paths.mitmproxy_dir(MITMPROXY_VERSION);
+        let checked_dirs = [
+            paths.root_dir().to_path_buf(),
+            paths.bin_dir(),
+            parent_dir(&firecracker_version_dir).unwrap(),
+            firecracker_version_dir,
+            parent_dir(&mitmproxy_version_dir).unwrap(),
+            mitmproxy_version_dir,
+            paths.images_dir(),
+            paths.runners_dir(),
+            paths.workspace_image_cache_dir(),
+            paths.groups_dir(),
+            paths.debootstrap_dir(),
+            paths.locks_dir(),
+            paths.storages_dir(),
+        ];
+
+        for path in checked_dirs {
+            let mode = std::fs::metadata(&path).unwrap().permissions().mode() & 0o777;
+            assert_eq!(
+                mode & GROUP_OR_OTHER_WRITE_BITS,
+                0,
+                "{} mode should not be group/other writable: {mode:o}",
+                path.display()
+            );
+        }
+
+        let logs_mode = std::fs::metadata(&logs_dir).unwrap().permissions().mode() & 0o777;
+        assert_eq!(logs_mode, 0o700);
     }
 
     #[tokio::test]

--- a/crates/runner/src/cmd/start/identity.rs
+++ b/crates/runner/src/cmd/start/identity.rs
@@ -70,6 +70,32 @@ mod tests {
         );
     }
 
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn runner_id_rejects_fifo_without_blocking() {
+        use std::os::unix::ffi::OsStrExt;
+
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("runner_id");
+        let c_path = std::ffi::CString::new(path.as_os_str().as_bytes()).unwrap();
+        let result = unsafe { libc::mkfifo(c_path.as_ptr(), 0o600) };
+        assert_eq!(
+            result,
+            0,
+            "mkfifo failed: {}",
+            std::io::Error::last_os_error()
+        );
+
+        let result = tokio::time::timeout(
+            std::time::Duration::from_secs(1),
+            load_or_generate_runner_id(dir.path()),
+        )
+        .await
+        .expect("runner_id FIFO should not block");
+
+        assert!(result.is_err());
+    }
+
     #[tokio::test]
     async fn runner_id_rejects_invalid() {
         let dir = tempfile::tempdir().unwrap();

--- a/crates/runner/src/cmd/start/identity.rs
+++ b/crates/runner/src/cmd/start/identity.rs
@@ -8,26 +8,20 @@ use crate::error::{RunnerError, RunnerResult};
 /// Load runner ID from `{base_dir}/runner_id`, or generate a new UUID and persist it.
 pub(super) async fn load_or_generate_runner_id(base_dir: &Path) -> RunnerResult<String> {
     let path = base_dir.join("runner_id");
-    match tokio::fs::read_to_string(&path).await {
-        Ok(contents) => {
+    match crate::private_fs::read_private_file_to_string(&path).await? {
+        Some(contents) => {
             let id = contents.trim().to_string();
             Uuid::parse_str(&id).map_err(|e| {
                 RunnerError::Config(format!("invalid runner_id in {}: {e}", path.display()))
             })?;
             Ok(id)
         }
-        Err(e) if e.kind() == std::io::ErrorKind::NotFound => {
+        None => {
             let id = Uuid::new_v4().to_string();
-            tokio::fs::write(&path, &id).await.map_err(|e| {
-                RunnerError::Config(format!("write runner_id to {}: {e}", path.display()))
-            })?;
+            crate::private_fs::write_private_file(&path, id.as_bytes()).await?;
             info!(runner_id = %id, "generated new runner ID");
             Ok(id)
         }
-        Err(e) => Err(RunnerError::Config(format!(
-            "read runner_id from {}: {e}",
-            path.display()
-        ))),
     }
 }
 
@@ -55,6 +49,25 @@ mod tests {
             .unwrap();
         let id = load_or_generate_runner_id(dir.path()).await.unwrap();
         assert_eq!(id, expected);
+    }
+
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn runner_id_rejects_symlink_without_reading_target() {
+        let dir = tempfile::tempdir().unwrap();
+        let target = dir.path().join("outside-runner-id");
+        let link = dir.path().join("runner_id");
+        let outside_id = Uuid::new_v4().to_string();
+        tokio::fs::write(&target, &outside_id).await.unwrap();
+        std::os::unix::fs::symlink(&target, &link).unwrap();
+
+        let result = load_or_generate_runner_id(dir.path()).await;
+
+        assert!(result.is_err());
+        assert_eq!(
+            tokio::fs::read_to_string(&target).await.unwrap(),
+            outside_id
+        );
     }
 
     #[tokio::test]

--- a/crates/runner/src/cmd/start/mod.rs
+++ b/crates/runner/src/cmd/start/mod.rs
@@ -224,14 +224,7 @@ pub async fn run_start(
         );
     }
 
-    tokio::fs::create_dir_all(&runner_config.base_dir)
-        .await
-        .map_err(|e| {
-            RunnerError::Config(format!(
-                "create base_dir {}: {e}",
-                runner_config.base_dir.display()
-            ))
-        })?;
+    crate::private_fs::ensure_private_dir(&runner_config.base_dir).await?;
 
     // Exclusive lock — prevents two runner processes from sharing the same base_dir.
     // Canonicalize so that equivalent paths (e.g. with `..`) produce the same lock.

--- a/crates/runner/src/cmd/start/mod.rs
+++ b/crates/runner/src/cmd/start/mod.rs
@@ -284,14 +284,7 @@ pub async fn run_start(
     }
 
     let log_paths = LogPaths::new(home.logs_dir());
-    tokio::fs::create_dir_all(log_paths.dir())
-        .await
-        .map_err(|e| {
-            RunnerError::Config(format!(
-                "create logs_dir {}: {e}",
-                log_paths.dir().display()
-            ))
-        })?;
+    crate::log_fs::ensure_log_dir(log_paths.dir()).await?;
 
     // Start background prefetch of snapshot memory for all profiles.
     let memory_prefetch =

--- a/crates/runner/src/config.rs
+++ b/crates/runner/src/config.rs
@@ -189,17 +189,13 @@ async fn load_with_home(
 /// Generate a runner.yaml config file from a `RunnerConfig`.
 pub async fn generate(config: &RunnerConfig) -> RunnerResult<()> {
     let runner_dir = &config.base_dir;
-    tokio::fs::create_dir_all(runner_dir)
-        .await
-        .map_err(|e| RunnerError::Config(format!("create {}: {e}", runner_dir.display())))?;
+    crate::private_fs::ensure_private_dir(runner_dir).await?;
 
     let content = serde_yaml_ng::to_string(config)
         .map_err(|e| RunnerError::Config(format!("serialize config: {e}")))?;
 
     let config_path = runner_dir.join("runner.yaml");
-    tokio::fs::write(&config_path, content)
-        .await
-        .map_err(|e| RunnerError::Config(format!("write {}: {e}", config_path.display())))?;
+    crate::private_fs::write_private_file(&config_path, content.as_bytes()).await?;
     Ok(())
 }
 

--- a/crates/runner/src/config_tests.rs
+++ b/crates/runner/src/config_tests.rs
@@ -155,6 +155,12 @@ fn make_profiles() -> BTreeMap<String, ProfileConfig> {
     profiles
 }
 
+#[cfg(unix)]
+fn mode_of(path: &std::path::Path) -> u32 {
+    use std::os::unix::fs::PermissionsExt;
+    std::fs::metadata(path).unwrap().permissions().mode() & 0o777
+}
+
 #[tokio::test]
 async fn load_config_with_profiles() {
     let fixture = ConfigFixture::new().await;
@@ -716,9 +722,8 @@ async fn generate_then_load_round_trip() {
 
     generate(&config).await.unwrap();
 
-    let generated = tokio::fs::read_to_string(runner_dir.join("runner.yaml"))
-        .await
-        .unwrap();
+    let config_path = runner_dir.join("runner.yaml");
+    let generated = tokio::fs::read_to_string(&config_path).await.unwrap();
     assert!(generated.contains("rootfs_disk_mb: 8192"));
     assert!(generated.contains("workspace_disk_mb: 16384"));
     assert!(
@@ -726,8 +731,55 @@ async fn generate_then_load_round_trip() {
             .lines()
             .all(|line| !line.trim_start().starts_with("disk_mb:"))
     );
+    #[cfg(unix)]
+    {
+        assert_eq!(mode_of(&runner_dir), 0o700);
+        assert_eq!(mode_of(&config_path), 0o600);
+    }
 
-    let loaded = load_with_home(&runner_dir.join("runner.yaml"), &fixture.home, true)
+    let loaded = load_with_home(&config_path, &fixture.home, true)
+        .await
+        .unwrap();
+    assert_eq!(loaded, config);
+}
+
+#[cfg(unix)]
+#[tokio::test]
+async fn generate_tightens_existing_runner_dir_and_config_file() {
+    use std::os::unix::fs::PermissionsExt;
+
+    let fixture = ConfigFixture::new().await;
+    let runner_dir = fixture.path().join("my-runner");
+    tokio::fs::create_dir_all(&runner_dir).await.unwrap();
+    std::fs::set_permissions(&runner_dir, std::fs::Permissions::from_mode(0o755)).unwrap();
+    let config_path = runner_dir.join("runner.yaml");
+    tokio::fs::write(&config_path, "server:\n  token: old\n")
+        .await
+        .unwrap();
+    std::fs::set_permissions(&config_path, std::fs::Permissions::from_mode(0o644)).unwrap();
+
+    let config = RunnerConfig {
+        name: "test-runner".into(),
+        group: "vm0/prod".into(),
+        base_dir: runner_dir.clone(),
+        ca_dir: fixture.path().to_path_buf(),
+        firecracker: FirecrackerConfig {
+            binary: fixture.firecracker.clone(),
+            kernel: fixture.kernel.clone(),
+        },
+        profiles: make_profiles(),
+        sandbox: SandboxConfig::default(),
+        server: Some(ServerConfig {
+            url: "https://api.example.com".into(),
+            token: "secret".into(),
+        }),
+    };
+
+    generate(&config).await.unwrap();
+
+    assert_eq!(mode_of(&runner_dir), 0o700);
+    assert_eq!(mode_of(&config_path), 0o600);
+    let loaded = load_with_home(&config_path, &fixture.home, true)
         .await
         .unwrap();
     assert_eq!(loaded, config);

--- a/crates/runner/src/executor/diagnostics.rs
+++ b/crates/runner/src/executor/diagnostics.rs
@@ -536,6 +536,9 @@ pub(super) async fn copy_guest_logs(
     };
 
     for (guest_path, host_path) in &files {
+        if !prepare_guest_log_copy_destination(run_id, host_path).await {
+            continue;
+        }
         let copy_result = sandbox
             .copy_file(
                 guest_path,
@@ -559,6 +562,28 @@ pub(super) async fn copy_guest_logs(
             Ok(_) => secure_copied_guest_log(run_id, host_path).await,
         }
     }
+}
+
+async fn prepare_guest_log_copy_destination(run_id: RunId, host_path: &Path) -> bool {
+    let metadata = match tokio::fs::symlink_metadata(host_path).await {
+        Ok(metadata) => metadata,
+        Err(e) if e.kind() == std::io::ErrorKind::NotFound => return true,
+        Err(e) => {
+            warn!(run_id = %run_id, path = %host_path.display(), error = %e, "failed to check guest log destination");
+            return false;
+        }
+    };
+
+    if !metadata.file_type().is_file() {
+        warn!(run_id = %run_id, path = %host_path.display(), "guest log destination is not a regular file");
+        return false;
+    }
+
+    if let Err(e) = crate::log_fs::secure_log_file(host_path).await {
+        warn!(run_id = %run_id, path = %host_path.display(), error = %e, "failed to secure guest log destination");
+        return false;
+    }
+    true
 }
 
 async fn secure_copied_guest_log(run_id: RunId, host_path: &Path) {

--- a/crates/runner/src/executor/diagnostics.rs
+++ b/crates/runner/src/executor/diagnostics.rs
@@ -1,5 +1,7 @@
 use std::collections::HashMap;
 use std::io::{self, SeekFrom};
+#[cfg(unix)]
+use std::os::unix::fs::OpenOptionsExt;
 use std::path::{Path, PathBuf};
 use std::time::Duration;
 
@@ -381,6 +383,8 @@ pub(super) fn host_dmesg_indicates_oom(dmesg: &str, pid: u32) -> bool {
 pub(super) enum StdoutDrainError {
     #[error("failed to open host log file {path}: {source}")]
     Open { path: PathBuf, source: io::Error },
+    #[error("failed to secure host log file {path}: {source}")]
+    Permissions { path: PathBuf, source: io::Error },
     #[error("failed to write stdout chunk to host log {path}: {source}")]
     Write { path: PathBuf, source: io::Error },
     #[error("failed to flush stdout log {path}: {source}")]
@@ -397,17 +401,24 @@ pub(super) async fn drain_stdout_to_file(
     mut rx: ProcessOutputReceiver,
     path: PathBuf,
 ) -> Result<StdoutDrainReport, StdoutDrainError> {
-    let file = tokio::fs::OpenOptions::new()
-        .create(true)
-        .append(true)
-        .open(&path)
-        .await;
+    let mut options = tokio::fs::OpenOptions::new();
+    options.create(true).append(true);
+    #[cfg(unix)]
+    {
+        options
+            .mode(crate::log_fs::LOG_FILE_MODE)
+            .custom_flags(nix::libc::O_NOFOLLOW | nix::libc::O_CLOEXEC | nix::libc::O_NONBLOCK);
+    }
+    let file = options.open(&path).await;
     let mut file = match file {
         Ok(f) => f,
         Err(e) => {
             return Err(StdoutDrainError::Open { path, source: e });
         }
     };
+    if let Err(e) = crate::log_fs::secure_open_log_fd_sync(&file, &path) {
+        return Err(StdoutDrainError::Permissions { path, source: e });
+    }
     let mut report = StdoutDrainReport::default();
     while let Some(chunk) = rx.recv().await {
         if chunk.truncated {
@@ -454,12 +465,16 @@ pub(super) async fn append_stdout_stream_diagnostics(
         return Ok(());
     }
 
-    let mut file = tokio::fs::OpenOptions::new()
-        .create(true)
-        .append(true)
-        .read(true)
-        .open(path)
-        .await?;
+    let mut options = tokio::fs::OpenOptions::new();
+    options.create(true).append(true).read(true);
+    #[cfg(unix)]
+    {
+        options
+            .mode(crate::log_fs::LOG_FILE_MODE)
+            .custom_flags(nix::libc::O_NOFOLLOW | nix::libc::O_CLOEXEC | nix::libc::O_NONBLOCK);
+    }
+    let mut file = options.open(path).await?;
+    crate::log_fs::secure_open_log_fd_sync(&file, path)?;
 
     if file.metadata().await?.len() > 0 {
         file.seek(SeekFrom::End(-1)).await?;
@@ -523,7 +538,7 @@ pub(super) async fn copy_guest_logs(
     };
 
     for (guest_path, host_path) in &files {
-        if let Err(e) = sandbox
+        let copy_result = sandbox
             .copy_file(
                 guest_path,
                 host_path,
@@ -533,16 +548,33 @@ pub(super) async fn copy_guest_logs(
                     missing_ok: true,
                 },
             )
-            .await
-        {
-            match guest_log_copy_failure_kind(cancelled) {
+            .await;
+        match copy_result {
+            Err(e) => match guest_log_copy_failure_kind(cancelled) {
                 GuestLogCopyFailureKind::SkippedAfterCancellation => {
                     info!(run_id = %run_id, error = %e, guest_path = %guest_path, host_path = %host_path.display(), "guest log copy skipped after cancellation");
                 }
                 GuestLogCopyFailureKind::Failed => {
                     warn!(run_id = %run_id, error = %e, guest_path = %guest_path, host_path = %host_path.display(), "failed to copy guest log");
                 }
-            }
+            },
+            Ok(_) => secure_copied_guest_log(run_id, host_path).await,
         }
+    }
+}
+
+async fn secure_copied_guest_log(run_id: RunId, host_path: &Path) {
+    let exists = match tokio::fs::try_exists(host_path).await {
+        Ok(exists) => exists,
+        Err(e) => {
+            warn!(run_id = %run_id, path = %host_path.display(), error = %e, "failed to check copied guest log");
+            return;
+        }
+    };
+    if !exists {
+        return;
+    }
+    if let Err(e) = crate::log_fs::secure_log_file(host_path).await {
+        warn!(run_id = %run_id, path = %host_path.display(), error = %e, "failed to secure copied guest log");
     }
 }

--- a/crates/runner/src/executor/diagnostics.rs
+++ b/crates/runner/src/executor/diagnostics.rs
@@ -1,7 +1,5 @@
 use std::collections::HashMap;
 use std::io::{self, SeekFrom};
-#[cfg(unix)]
-use std::os::unix::fs::OpenOptionsExt;
 use std::path::{Path, PathBuf};
 use std::time::Duration;
 

--- a/crates/runner/src/executor/tests/diagnostics_tests.rs
+++ b/crates/runner/src/executor/tests/diagnostics_tests.rs
@@ -425,6 +425,40 @@ async fn copy_guest_logs_keeps_existing_logs_when_sandbox_ops_missing() {
     );
 }
 
+#[cfg(unix)]
+#[tokio::test]
+async fn copy_guest_logs_skips_symlink_host_log_without_writing_target() {
+    let dir = tempfile::tempdir().unwrap();
+    let log_paths = LogPaths::new(dir.path().to_path_buf());
+    let sandbox = MockSandbox::new("test");
+    let ctx = minimal_context();
+    let system_log_path = log_paths.system_log(ctx.run_id);
+    let outside = dir.path().join("outside-system.log");
+    tokio::fs::write(&outside, b"outside\n").await.unwrap();
+    std::os::unix::fs::symlink(&outside, &system_log_path).unwrap();
+
+    sandbox.push_copy_file_result(Ok(b"{\"cpu\":0.5}\n".to_vec()));
+    sandbox.push_copy_file_result(Ok(
+        b"{\"action_type\":\"final_telemetry_upload\",\"duration_ms\":10,\"success\":true}\n"
+            .to_vec(),
+    ));
+
+    copy_guest_logs(&sandbox, &ctx, &log_paths, false).await;
+
+    assert_eq!(tokio::fs::read(&outside).await.unwrap(), b"outside\n");
+    assert!(
+        std::fs::symlink_metadata(&system_log_path)
+            .unwrap()
+            .file_type()
+            .is_symlink()
+    );
+
+    let calls = sandbox.copy_file_calls();
+    assert_eq!(calls.len(), 2);
+    assert_eq!(calls[0].host_path, log_paths.metrics_log(ctx.run_id));
+    assert_eq!(calls[1].host_path, log_paths.sandbox_ops_log(ctx.run_id));
+}
+
 #[tokio::test]
 async fn copy_guest_logs_skips_on_nonzero_exit() {
     let dir = tempfile::tempdir().unwrap();

--- a/crates/runner/src/executor/tests/diagnostics_tests.rs
+++ b/crates/runner/src/executor/tests/diagnostics_tests.rs
@@ -1,5 +1,12 @@
 use super::*;
 
+#[cfg(unix)]
+fn file_mode(path: &std::path::Path) -> u32 {
+    use std::os::unix::fs::PermissionsExt;
+
+    std::fs::metadata(path).unwrap().permissions().mode() & 0o777
+}
+
 #[test]
 fn agent_env_diagnostics_sort_bounds_and_never_include_values() {
     let mut bootstrap_env = HashMap::from([
@@ -341,24 +348,34 @@ async fn copy_guest_logs_writes_files_to_host() {
 
     copy_guest_logs(&sandbox, &ctx, &log_paths, false).await;
 
-    let system_log = tokio::fs::read_to_string(log_paths.system_log(ctx.run_id))
-        .await
-        .unwrap();
+    let system_log_path = log_paths.system_log(ctx.run_id);
+    let metrics_log_path = log_paths.metrics_log(ctx.run_id);
+    let sandbox_ops_log_path = log_paths.sandbox_ops_log(ctx.run_id);
+
+    let system_log = tokio::fs::read_to_string(&system_log_path).await.unwrap();
     assert_eq!(system_log, "system log line 1\nsystem log line 2\n");
     let system_stream_log = tokio::fs::read_to_string(system_stream_log_path)
         .await
         .unwrap();
     assert_eq!(system_stream_log, "transient host-streamed stdout\n");
 
-    let metrics_log = tokio::fs::read_to_string(log_paths.metrics_log(ctx.run_id))
-        .await
-        .unwrap();
+    let metrics_log = tokio::fs::read_to_string(&metrics_log_path).await.unwrap();
     assert_eq!(metrics_log, "{\"cpu\":0.5}\n");
 
-    let sandbox_ops_log = tokio::fs::read_to_string(log_paths.sandbox_ops_log(ctx.run_id))
+    let sandbox_ops_log = tokio::fs::read_to_string(&sandbox_ops_log_path)
         .await
         .unwrap();
     assert!(sandbox_ops_log.contains("final_telemetry_upload"));
+
+    #[cfg(unix)]
+    {
+        assert_eq!(file_mode(&system_log_path), crate::log_fs::LOG_FILE_MODE);
+        assert_eq!(file_mode(&metrics_log_path), crate::log_fs::LOG_FILE_MODE);
+        assert_eq!(
+            file_mode(&sandbox_ops_log_path),
+            crate::log_fs::LOG_FILE_MODE
+        );
+    }
 
     let calls = sandbox.copy_file_calls();
     assert_eq!(calls.len(), 3);
@@ -384,16 +401,21 @@ async fn copy_guest_logs_keeps_existing_logs_when_sandbox_ops_missing() {
 
     copy_guest_logs(&sandbox, &ctx, &log_paths, false).await;
 
-    let system_log = tokio::fs::read_to_string(log_paths.system_log(ctx.run_id))
-        .await
-        .unwrap();
+    let system_log_path = log_paths.system_log(ctx.run_id);
+    let metrics_log_path = log_paths.metrics_log(ctx.run_id);
+
+    let system_log = tokio::fs::read_to_string(&system_log_path).await.unwrap();
     assert_eq!(system_log, "system log\n");
 
-    let metrics_log = tokio::fs::read_to_string(log_paths.metrics_log(ctx.run_id))
-        .await
-        .unwrap();
+    let metrics_log = tokio::fs::read_to_string(&metrics_log_path).await.unwrap();
     assert_eq!(metrics_log, "{\"cpu\":0.5}\n");
     assert!(!log_paths.sandbox_ops_log(ctx.run_id).exists());
+
+    #[cfg(unix)]
+    {
+        assert_eq!(file_mode(&system_log_path), crate::log_fs::LOG_FILE_MODE);
+        assert_eq!(file_mode(&metrics_log_path), crate::log_fs::LOG_FILE_MODE);
+    }
 
     let calls = sandbox.copy_file_calls();
     assert_eq!(calls.len(), 3);
@@ -476,6 +498,15 @@ async fn post_job_cleanup_appends_stream_markers_after_guest_log_copy() {
     expected_stream_log.extend_from_slice(STDOUT_STREAM_LIMIT_MARKER);
     expected_stream_log.extend_from_slice(STDOUT_STREAM_OVERFLOW_MARKER);
     assert_eq!(system_stream_log, expected_stream_log);
+
+    #[cfg(unix)]
+    {
+        assert_eq!(file_mode(&system_log_path), crate::log_fs::LOG_FILE_MODE);
+        assert_eq!(
+            file_mode(&system_stream_log_path),
+            crate::log_fs::LOG_FILE_MODE
+        );
+    }
 }
 
 // -----------------------------------------------------------------------
@@ -507,6 +538,8 @@ async fn drain_stdout_writes_chunks_to_file() {
     let content = tokio::fs::read_to_string(&path).await.unwrap();
     assert_eq!(content, "chunk 1\nchunk 2\n");
     assert!(!report.chunk_truncated);
+    #[cfg(unix)]
+    assert_eq!(file_mode(&path), crate::log_fs::LOG_FILE_MODE);
 }
 
 #[tokio::test]
@@ -528,6 +561,8 @@ async fn drain_stdout_reports_truncated_chunk_without_changing_bytes() {
     let content = tokio::fs::read(&path).await.unwrap();
     assert_eq!(content, b"partial chunk");
     assert!(report.chunk_truncated);
+    #[cfg(unix)]
+    assert_eq!(file_mode(&path), crate::log_fs::LOG_FILE_MODE);
 }
 
 #[tokio::test]
@@ -543,6 +578,8 @@ async fn drain_stdout_empty_channel() {
     let content = tokio::fs::read_to_string(&path).await.unwrap();
     assert!(content.is_empty());
     assert!(!report.chunk_truncated);
+    #[cfg(unix)]
+    assert_eq!(file_mode(&path), crate::log_fs::LOG_FILE_MODE);
 }
 
 #[tokio::test]
@@ -553,6 +590,54 @@ async fn drain_stdout_invalid_path_returns_error() {
         .await
         .unwrap_err();
     assert!(matches!(error, StdoutDrainError::Open { .. }));
+}
+
+#[cfg(unix)]
+#[tokio::test]
+async fn drain_stdout_rejects_symlink_log_file() {
+    use std::os::unix::fs::PermissionsExt;
+
+    let dir = tempfile::tempdir().unwrap();
+    let target = dir.path().join("target.log");
+    let link = dir.path().join("stdout.log");
+    tokio::fs::write(&target, b"existing\n").await.unwrap();
+    std::fs::set_permissions(&target, std::fs::Permissions::from_mode(0o644)).unwrap();
+    std::os::unix::fs::symlink(&target, &link).unwrap();
+    let (_tx, rx) = tokio::sync::mpsc::channel::<ProcessOutputChunk>(1);
+    drop(_tx);
+
+    let error = drain_stdout_to_file(rx, link).await.unwrap_err();
+
+    assert!(matches!(error, StdoutDrainError::Open { .. }));
+    assert_eq!(file_mode(&target), 0o644);
+    assert_eq!(tokio::fs::read(&target).await.unwrap(), b"existing\n");
+}
+
+#[cfg(unix)]
+#[tokio::test]
+async fn drain_stdout_rejects_fifo_without_blocking() {
+    let dir = tempfile::tempdir().unwrap();
+    let path = dir.path().join("stdout.log");
+    let c_path = std::ffi::CString::new(path.as_os_str().as_encoded_bytes()).unwrap();
+    let result = unsafe { libc::mkfifo(c_path.as_ptr(), 0o600) };
+    assert_eq!(
+        result,
+        0,
+        "mkfifo failed: {}",
+        std::io::Error::last_os_error()
+    );
+    let (_tx, rx) = tokio::sync::mpsc::channel::<ProcessOutputChunk>(1);
+    drop(_tx);
+
+    let error = tokio::time::timeout(Duration::from_secs(1), drain_stdout_to_file(rx, path))
+        .await
+        .expect("drain_stdout_to_file should not block on FIFO")
+        .unwrap_err();
+
+    assert!(matches!(
+        error,
+        StdoutDrainError::Open { .. } | StdoutDrainError::Permissions { .. }
+    ));
 }
 
 #[tokio::test]
@@ -590,4 +675,61 @@ async fn append_stdout_stream_diagnostics_writes_markers() {
     expected.extend_from_slice(STDOUT_STREAM_LIMIT_MARKER);
     expected.extend_from_slice(STDOUT_STREAM_OVERFLOW_MARKER);
     assert_eq!(content, expected);
+    #[cfg(unix)]
+    assert_eq!(file_mode(&path), crate::log_fs::LOG_FILE_MODE);
+}
+
+#[cfg(unix)]
+#[tokio::test]
+async fn append_stdout_stream_diagnostics_rejects_symlink_log_file() {
+    use std::os::unix::fs::PermissionsExt;
+
+    let dir = tempfile::tempdir().unwrap();
+    let target = dir.path().join("target.log");
+    let link = dir.path().join("stdout.log");
+    tokio::fs::write(&target, b"existing\n").await.unwrap();
+    std::fs::set_permissions(&target, std::fs::Permissions::from_mode(0o644)).unwrap();
+    std::os::unix::fs::symlink(&target, &link).unwrap();
+
+    append_stdout_stream_diagnostics(
+        &link,
+        AgentStdoutStreamDiagnostics {
+            chunk_truncated: true,
+            stream_overflowed: false,
+        },
+    )
+    .await
+    .unwrap_err();
+
+    assert_eq!(file_mode(&target), 0o644);
+    assert_eq!(tokio::fs::read(&target).await.unwrap(), b"existing\n");
+}
+
+#[cfg(unix)]
+#[tokio::test]
+async fn append_stdout_stream_diagnostics_rejects_fifo_without_blocking() {
+    let dir = tempfile::tempdir().unwrap();
+    let path = dir.path().join("stdout.log");
+    let c_path = std::ffi::CString::new(path.as_os_str().as_encoded_bytes()).unwrap();
+    let result = unsafe { libc::mkfifo(c_path.as_ptr(), 0o600) };
+    assert_eq!(
+        result,
+        0,
+        "mkfifo failed: {}",
+        std::io::Error::last_os_error()
+    );
+
+    tokio::time::timeout(
+        Duration::from_secs(1),
+        append_stdout_stream_diagnostics(
+            &path,
+            AgentStdoutStreamDiagnostics {
+                chunk_truncated: true,
+                stream_overflowed: false,
+            },
+        ),
+    )
+    .await
+    .expect("append_stdout_stream_diagnostics should not block on FIFO")
+    .unwrap_err();
 }

--- a/crates/runner/src/lock.rs
+++ b/crates/runner/src/lock.rs
@@ -7,6 +7,7 @@ use nix::fcntl::{Flock, FlockArg};
 use crate::error::{RunnerError, RunnerResult};
 
 const LOCK_BUSY_ERROR: &str = "lock is already held by another process";
+const LOCK_FILE_MODE: u32 = 0o600;
 
 /// Open (or create) the lock file, creating parent directories as needed.
 pub(crate) fn open_lock_file(path: &Path) -> RunnerResult<File> {
@@ -15,13 +16,33 @@ pub(crate) fn open_lock_file(path: &Path) -> RunnerResult<File> {
             RunnerError::Internal(format!("create lock dir {}: {e}", parent.display()))
         })?;
     }
-    File::options()
-        .create(true)
-        .truncate(false)
-        .read(true)
-        .write(true)
+    let mut options = File::options();
+    options.create(true).truncate(false).read(true).write(true);
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::OpenOptionsExt;
+        options
+            .mode(LOCK_FILE_MODE)
+            .custom_flags(nix::libc::O_NOFOLLOW);
+    }
+    let file = options
         .open(path)
-        .map_err(|e| RunnerError::Internal(format!("open lock {}: {e}", path.display())))
+        .map_err(|e| RunnerError::Internal(format!("open lock {}: {e}", path.display())))?;
+    secure_lock_file_permissions(&file, path)?;
+    Ok(file)
+}
+
+#[cfg(unix)]
+fn secure_lock_file_permissions(file: &File, path: &Path) -> RunnerResult<()> {
+    use std::os::unix::fs::PermissionsExt;
+
+    file.set_permissions(std::fs::Permissions::from_mode(LOCK_FILE_MODE))
+        .map_err(|e| RunnerError::Internal(format!("chmod lock {}: {e}", path.display())))
+}
+
+#[cfg(not(unix))]
+fn secure_lock_file_permissions(_file: &File, _path: &Path) -> RunnerResult<()> {
+    Ok(())
 }
 
 /// Check whether the locked fd still refers to the file currently at `path`.
@@ -131,6 +152,11 @@ pub async fn try_acquire_or_busy(path: PathBuf) -> RunnerResult<TryLock> {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use std::os::unix::fs::{PermissionsExt, symlink};
+
+    fn file_mode(path: &Path) -> u32 {
+        std::fs::metadata(path).unwrap().permissions().mode() & 0o777
+    }
 
     #[tokio::test]
     async fn acquire_creates_lock_file() {
@@ -140,6 +166,48 @@ mod tests {
         let guard = acquire(path.clone()).await.unwrap();
         assert!(path.exists());
         drop(guard);
+    }
+
+    #[tokio::test]
+    async fn acquire_creates_private_lock_file() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("test.lock");
+
+        let guard = acquire(path.clone()).await.unwrap();
+
+        assert_eq!(file_mode(&path), LOCK_FILE_MODE);
+        drop(guard);
+    }
+
+    #[tokio::test]
+    async fn acquire_tightens_existing_wide_lock_file() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("test.lock");
+        std::fs::write(&path, b"lock").unwrap();
+        std::fs::set_permissions(&path, std::fs::Permissions::from_mode(0o666)).unwrap();
+
+        let guard = acquire(path.clone()).await.unwrap();
+
+        assert_eq!(file_mode(&path), LOCK_FILE_MODE);
+        drop(guard);
+    }
+
+    #[tokio::test]
+    async fn acquire_rejects_lock_symlink_without_chmodding_target() {
+        let dir = tempfile::tempdir().unwrap();
+        let target = dir.path().join("target");
+        let path = dir.path().join("test.lock");
+        std::fs::write(&target, b"target").unwrap();
+        std::fs::set_permissions(&target, std::fs::Permissions::from_mode(0o644)).unwrap();
+        symlink(&target, &path).unwrap();
+
+        let error = acquire(path).await.unwrap_err();
+
+        assert!(
+            error.to_string().contains("open lock"),
+            "unexpected error: {error}"
+        );
+        assert_eq!(file_mode(&target), 0o644);
     }
 
     #[tokio::test]

--- a/crates/runner/src/lock.rs
+++ b/crates/runner/src/lock.rs
@@ -7,14 +7,16 @@ use nix::fcntl::{Flock, FlockArg};
 use crate::error::{RunnerError, RunnerResult};
 
 const LOCK_BUSY_ERROR: &str = "lock is already held by another process";
+const GROUP_OR_OTHER_WRITE_BITS: u32 = 0o022;
+const LOCK_DIR_MODE: u32 = 0o755;
 const LOCK_FILE_MODE: u32 = 0o600;
+const OWNER_DIRECTORY_BITS: u32 = 0o700;
+const ROOT_UID: u32 = 0;
 
 /// Open (or create) the lock file, creating parent directories as needed.
 pub(crate) fn open_lock_file(path: &Path) -> RunnerResult<File> {
     if let Some(parent) = path.parent() {
-        std::fs::create_dir_all(parent).map_err(|e| {
-            RunnerError::Internal(format!("create lock dir {}: {e}", parent.display()))
-        })?;
+        ensure_lock_parent_dir(parent)?;
     }
     let mut options = File::options();
     options.create(true).truncate(false).read(true).write(true);
@@ -32,12 +34,153 @@ pub(crate) fn open_lock_file(path: &Path) -> RunnerResult<File> {
     Ok(file)
 }
 
+fn ensure_lock_parent_dir(parent: &Path) -> RunnerResult<()> {
+    create_lock_parent_dir_all(parent)?;
+    secure_lock_parent_dir_permissions(parent)
+}
+
+#[cfg(unix)]
+fn create_lock_parent_dir_all(parent: &Path) -> RunnerResult<()> {
+    use std::os::unix::fs::DirBuilderExt;
+
+    std::fs::DirBuilder::new()
+        .recursive(true)
+        .mode(LOCK_DIR_MODE)
+        .create(parent)
+        .map_err(|e| RunnerError::Internal(format!("create lock dir {}: {e}", parent.display())))?;
+    Ok(())
+}
+
+#[cfg(not(unix))]
+fn create_lock_parent_dir_all(parent: &Path) -> RunnerResult<()> {
+    std::fs::create_dir_all(parent)
+        .map_err(|e| RunnerError::Internal(format!("create lock dir {}: {e}", parent.display())))?;
+    Ok(())
+}
+
+#[cfg(unix)]
+fn secure_lock_parent_dir_permissions(parent: &Path) -> RunnerResult<()> {
+    use nix::fcntl::open;
+    use nix::sys::stat::{Mode, SFlag, fstat};
+
+    let fd = open(parent, lock_parent_dir_open_flags(), Mode::empty()).map_err(|e| {
+        RunnerError::Internal(format!(
+            "open lock dir {} without following symlinks: {e}",
+            parent.display()
+        ))
+    })?;
+    let stat = fstat(&fd)
+        .map_err(|e| RunnerError::Internal(format!("stat lock dir {}: {e}", parent.display())))?;
+    let file_type = SFlag::from_bits_truncate(stat.st_mode & SFlag::S_IFMT.bits());
+    if file_type != SFlag::S_IFDIR {
+        return Err(RunnerError::Internal(format!(
+            "{} is not a lock directory",
+            parent.display()
+        )));
+    }
+    let expected_uid = nix::unistd::geteuid().as_raw();
+    ensure_trusted_lock_parent_dir_owner(parent, stat.st_uid, expected_uid)?;
+
+    let current_mode = (stat.st_mode as u32) & 0o7777;
+    let secure_mode = (current_mode | OWNER_DIRECTORY_BITS) & !GROUP_OR_OTHER_WRITE_BITS;
+    if secure_mode != current_mode {
+        chmod_open_lock_parent_dir(&fd, parent, secure_mode)?;
+    }
+    Ok(())
+}
+
+#[cfg(unix)]
+fn ensure_trusted_lock_parent_dir_owner(
+    parent: &Path,
+    owner_uid: u32,
+    expected_uid: u32,
+) -> RunnerResult<()> {
+    if owner_uid != ROOT_UID && owner_uid != expected_uid {
+        return Err(RunnerError::Internal(format!(
+            "lock dir {} is owned by untrusted uid {owner_uid}; fix ownership before acquiring locks",
+            parent.display()
+        )));
+    }
+    Ok(())
+}
+
+#[cfg(not(unix))]
+fn secure_lock_parent_dir_permissions(parent: &Path) -> RunnerResult<()> {
+    let metadata = std::fs::metadata(parent)
+        .map_err(|e| RunnerError::Internal(format!("stat lock dir {}: {e}", parent.display())))?;
+    if !metadata.is_dir() {
+        return Err(RunnerError::Internal(format!(
+            "{} is not a lock directory",
+            parent.display()
+        )));
+    }
+    Ok(())
+}
+
+#[cfg(all(unix, target_os = "linux"))]
+fn lock_parent_dir_open_flags() -> nix::fcntl::OFlag {
+    nix::fcntl::OFlag::O_PATH
+        | nix::fcntl::OFlag::O_DIRECTORY
+        | nix::fcntl::OFlag::O_NOFOLLOW
+        | nix::fcntl::OFlag::O_CLOEXEC
+}
+
+#[cfg(all(unix, not(target_os = "linux")))]
+fn lock_parent_dir_open_flags() -> nix::fcntl::OFlag {
+    nix::fcntl::OFlag::O_RDONLY
+        | nix::fcntl::OFlag::O_DIRECTORY
+        | nix::fcntl::OFlag::O_NOFOLLOW
+        | nix::fcntl::OFlag::O_CLOEXEC
+}
+
+#[cfg(all(unix, target_os = "linux"))]
+fn chmod_open_lock_parent_dir<Fd: std::os::fd::AsRawFd>(
+    fd: &Fd,
+    parent: &Path,
+    mode: u32,
+) -> RunnerResult<()> {
+    use std::os::unix::fs::PermissionsExt;
+
+    let fd_path = PathBuf::from(format!("/proc/self/fd/{}", fd.as_raw_fd()));
+    std::fs::set_permissions(&fd_path, std::fs::Permissions::from_mode(mode))
+        .map_err(|e| RunnerError::Internal(format!("chmod lock dir {}: {e}", parent.display())))
+}
+
+#[cfg(all(unix, not(target_os = "linux")))]
+fn chmod_open_lock_parent_dir<Fd: std::os::fd::AsFd>(
+    fd: &Fd,
+    parent: &Path,
+    mode: u32,
+) -> RunnerResult<()> {
+    nix::sys::stat::fchmod(fd, nix::sys::stat::Mode::from_bits_truncate(mode))
+        .map_err(|e| RunnerError::Internal(format!("chmod lock dir {}: {e}", parent.display())))
+}
+
 #[cfg(unix)]
 fn secure_lock_file_permissions(file: &File, path: &Path) -> RunnerResult<()> {
     use std::os::unix::fs::PermissionsExt;
 
+    let metadata = file
+        .metadata()
+        .map_err(|e| RunnerError::Internal(format!("stat lock {}: {e}", path.display())))?;
+    ensure_trusted_lock_file_owner(path, metadata.uid(), nix::unistd::geteuid().as_raw())?;
     file.set_permissions(std::fs::Permissions::from_mode(LOCK_FILE_MODE))
         .map_err(|e| RunnerError::Internal(format!("chmod lock {}: {e}", path.display())))
+}
+
+#[cfg(unix)]
+fn ensure_trusted_lock_file_owner(
+    path: &Path,
+    owner_uid: u32,
+    expected_uid: u32,
+) -> RunnerResult<()> {
+    if owner_uid != ROOT_UID && owner_uid != expected_uid {
+        return Err(RunnerError::Internal(format!(
+            "lock {} is owned by untrusted uid {owner_uid}; fix ownership before acquiring locks",
+            path.display()
+        )));
+    }
+    Ok(())
 }
 
 #[cfg(not(unix))]
@@ -158,6 +301,22 @@ mod tests {
         std::fs::metadata(path).unwrap().permissions().mode() & 0o777
     }
 
+    fn assert_secure_lock_dir(path: &Path) {
+        let mode = file_mode(path);
+        assert_eq!(
+            mode & GROUP_OR_OTHER_WRITE_BITS,
+            0,
+            "{} should not be group/other writable: {mode:o}",
+            path.display()
+        );
+        assert_eq!(
+            mode & OWNER_DIRECTORY_BITS,
+            OWNER_DIRECTORY_BITS,
+            "{} should preserve owner rwx access: {mode:o}",
+            path.display()
+        );
+    }
+
     #[tokio::test]
     async fn acquire_creates_lock_file() {
         let dir = tempfile::tempdir().unwrap();
@@ -251,8 +410,73 @@ mod tests {
         let path = dir.path().join("a").join("b").join("test.lock");
 
         let guard = acquire(path.clone()).await.unwrap();
+
         assert!(path.exists());
+        assert_secure_lock_dir(&dir.path().join("a"));
+        assert_secure_lock_dir(&dir.path().join("a").join("b"));
         drop(guard);
+    }
+
+    #[tokio::test]
+    async fn acquire_tightens_existing_wide_parent_directory() {
+        let dir = tempfile::tempdir().unwrap();
+        let parent = dir.path().join("locks");
+        let path = parent.join("test.lock");
+        std::fs::create_dir(&parent).unwrap();
+        std::fs::set_permissions(&parent, std::fs::Permissions::from_mode(0o777)).unwrap();
+
+        let guard = acquire(path).await.unwrap();
+
+        assert_secure_lock_dir(&parent);
+        drop(guard);
+    }
+
+    #[tokio::test]
+    async fn acquire_rejects_lock_parent_symlink_without_chmodding_target() {
+        let dir = tempfile::tempdir().unwrap();
+        let target = dir.path().join("target");
+        let parent = dir.path().join("locks");
+        std::fs::create_dir(&target).unwrap();
+        std::fs::set_permissions(&target, std::fs::Permissions::from_mode(0o777)).unwrap();
+        symlink(&target, &parent).unwrap();
+
+        let error = acquire(parent.join("test.lock")).await.unwrap_err();
+
+        assert!(
+            error.to_string().contains("open lock dir"),
+            "unexpected error: {error}"
+        );
+        assert_eq!(file_mode(&target), 0o777);
+    }
+
+    #[test]
+    fn lock_parent_dir_owner_must_be_current_user_or_root() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("locks");
+
+        ensure_trusted_lock_parent_dir_owner(&path, 0, 1000).unwrap();
+        ensure_trusted_lock_parent_dir_owner(&path, 1000, 1000).unwrap();
+        let error = ensure_trusted_lock_parent_dir_owner(&path, 1001, 1000).unwrap_err();
+
+        assert!(
+            error.to_string().contains("untrusted uid"),
+            "unexpected error: {error}"
+        );
+    }
+
+    #[test]
+    fn lock_file_owner_must_be_current_user_or_root() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("test.lock");
+
+        ensure_trusted_lock_file_owner(&path, 0, 1000).unwrap();
+        ensure_trusted_lock_file_owner(&path, 1000, 1000).unwrap();
+        let error = ensure_trusted_lock_file_owner(&path, 1001, 1000).unwrap_err();
+
+        assert!(
+            error.to_string().contains("untrusted uid"),
+            "unexpected error: {error}"
+        );
     }
 
     #[tokio::test]

--- a/crates/runner/src/lock.rs
+++ b/crates/runner/src/lock.rs
@@ -1,6 +1,7 @@
 use std::fs::File;
+use std::os::fd::{AsFd, AsRawFd, OwnedFd};
 use std::os::unix::fs::MetadataExt;
-use std::path::{Path, PathBuf};
+use std::path::{Component, Path, PathBuf};
 
 use nix::fcntl::{Flock, FlockArg};
 
@@ -15,7 +16,10 @@ const ROOT_UID: u32 = 0;
 
 /// Open (or create) the lock file, creating parent directories as needed.
 pub(crate) fn open_lock_file(path: &Path) -> RunnerResult<File> {
-    if let Some(parent) = path.parent() {
+    if let Some(parent) = path
+        .parent()
+        .filter(|parent| !parent.as_os_str().is_empty())
+    {
         ensure_lock_parent_dir(parent)?;
     }
     let mut options = File::options();
@@ -34,42 +38,166 @@ pub(crate) fn open_lock_file(path: &Path) -> RunnerResult<File> {
     Ok(file)
 }
 
+#[cfg(unix)]
 fn ensure_lock_parent_dir(parent: &Path) -> RunnerResult<()> {
-    create_lock_parent_dir_all(parent)?;
+    let expected_uid = nix::unistd::geteuid().as_raw();
+    let fd = ensure_lock_parent_dir_exists_without_symlinks(parent, expected_uid)?;
+    secure_open_lock_parent_dir(&fd, parent, expected_uid)
+}
+
+#[cfg(not(unix))]
+fn ensure_lock_parent_dir(parent: &Path) -> RunnerResult<()> {
+    std::fs::create_dir_all(parent)
+        .map_err(|e| RunnerError::Internal(format!("create lock dir {}: {e}", parent.display())))?;
     secure_lock_parent_dir_permissions(parent)
 }
 
 #[cfg(unix)]
-fn create_lock_parent_dir_all(parent: &Path) -> RunnerResult<()> {
-    use std::os::unix::fs::DirBuilderExt;
+fn ensure_lock_parent_dir_exists_without_symlinks(
+    parent: &Path,
+    expected_uid: u32,
+) -> RunnerResult<OwnedFd> {
+    use nix::fcntl::open;
+    use nix::sys::stat::Mode;
 
-    std::fs::DirBuilder::new()
-        .recursive(true)
-        .mode(LOCK_DIR_MODE)
-        .create(parent)
-        .map_err(|e| RunnerError::Internal(format!("create lock dir {}: {e}", parent.display())))?;
-    Ok(())
+    let start = if parent.is_absolute() {
+        Path::new("/")
+    } else {
+        Path::new(".")
+    };
+    let mut current = open(start, lock_parent_dir_open_flags(), Mode::empty()).map_err(|e| {
+        RunnerError::Internal(format!("open lock dir root for {}: {e}", parent.display()))
+    })?;
+    let mut current_path = start.to_path_buf();
+    let components: Vec<_> = parent
+        .components()
+        .filter_map(|component| match component {
+            Component::RootDir | Component::CurDir => None,
+            Component::Normal(name) => Some(Ok(name.to_owned())),
+            Component::ParentDir => Some(Err(RunnerError::Internal(format!(
+                "lock dir {} contains a parent directory segment",
+                parent.display()
+            )))),
+            Component::Prefix(prefix) => Some(Err(RunnerError::Internal(format!(
+                "lock dir {} contains unsupported path prefix {}",
+                parent.display(),
+                prefix.as_os_str().to_string_lossy()
+            )))),
+        })
+        .collect::<RunnerResult<Vec<_>>>()?;
+
+    for name in &components {
+        ensure_lock_dir_parent_not_replaceable(&current, &current_path, parent, expected_uid)?;
+        current = open_or_create_lock_dir_component(&current, name, &current_path, parent)?;
+        current_path = lock_dir_component_path(&current_path, name);
+    }
+
+    Ok(current)
 }
 
-#[cfg(not(unix))]
-fn create_lock_parent_dir_all(parent: &Path) -> RunnerResult<()> {
-    std::fs::create_dir_all(parent)
-        .map_err(|e| RunnerError::Internal(format!("create lock dir {}: {e}", parent.display())))?;
+#[cfg(unix)]
+fn ensure_lock_dir_parent_not_replaceable(
+    fd: &(impl AsFd + AsRawFd),
+    current_path: &Path,
+    full_parent: &Path,
+    expected_uid: u32,
+) -> RunnerResult<()> {
+    use nix::sys::stat::fstat;
+
+    let stat = fstat(fd).map_err(|e| {
+        RunnerError::Internal(format!(
+            "stat lock dir parent {} for {}: {e}",
+            current_path.display(),
+            full_parent.display()
+        ))
+    })?;
+    ensure_trusted_lock_parent_dir_owner(current_path, stat.st_uid, expected_uid)?;
+    let mode = (stat.st_mode as u32) & 0o7777;
+    if mode & GROUP_OR_OTHER_WRITE_BITS != 0 && mode & 0o1000 == 0 {
+        return Err(RunnerError::Internal(format!(
+            "lock dir parent {} is group/other writable without the sticky bit; fix parent permissions before acquiring locks",
+            current_path.display()
+        )));
+    }
     Ok(())
 }
 
 #[cfg(unix)]
-fn secure_lock_parent_dir_permissions(parent: &Path) -> RunnerResult<()> {
-    use nix::fcntl::open;
-    use nix::sys::stat::{Mode, SFlag, fstat};
+fn open_or_create_lock_dir_component(
+    parent_fd: &(impl AsFd + AsRawFd),
+    name: &std::ffi::OsStr,
+    current_path: &Path,
+    full_parent: &Path,
+) -> RunnerResult<OwnedFd> {
+    use nix::errno::Errno;
+    use nix::fcntl::openat;
+    use nix::sys::stat::{Mode, mkdirat};
 
-    let fd = open(parent, lock_parent_dir_open_flags(), Mode::empty()).map_err(|e| {
-        RunnerError::Internal(format!(
-            "open lock dir {} without following symlinks: {e}",
-            parent.display()
-        ))
-    })?;
-    let stat = fstat(&fd)
+    match openat(parent_fd, name, lock_parent_dir_open_flags(), Mode::empty()) {
+        Ok(fd) => Ok(fd),
+        Err(Errno::ENOENT) => {
+            let created = match mkdirat(parent_fd, name, Mode::from_bits_truncate(LOCK_DIR_MODE)) {
+                Ok(()) => true,
+                Err(Errno::EEXIST) => false,
+                Err(e) => {
+                    return Err(RunnerError::Internal(format!(
+                        "create lock dir component {} for {}: {e}",
+                        name.to_string_lossy(),
+                        full_parent.display()
+                    )));
+                }
+            };
+            let fd = openat(parent_fd, name, lock_parent_dir_open_flags(), Mode::empty())
+                .map_err(|e| lock_dir_component_error("open", name, full_parent, e))?;
+            if created {
+                chmod_open_lock_parent_dir(
+                    &fd,
+                    &lock_dir_component_path(current_path, name),
+                    LOCK_DIR_MODE,
+                )?;
+            }
+            Ok(fd)
+        }
+        Err(e) => Err(lock_dir_component_error("open", name, full_parent, e)),
+    }
+}
+
+#[cfg(unix)]
+fn lock_dir_component_path(parent: &Path, name: &std::ffi::OsStr) -> PathBuf {
+    let mut path = parent.to_path_buf();
+    path.push(Path::new(name));
+    path
+}
+
+#[cfg(unix)]
+fn lock_dir_component_error(
+    operation: &str,
+    name: &std::ffi::OsStr,
+    full_parent: &Path,
+    error: nix::errno::Errno,
+) -> RunnerError {
+    match error {
+        nix::errno::Errno::ELOOP => RunnerError::Internal(format!(
+            "{} contains symlink component {}; refusing to use it as a lock directory",
+            full_parent.display(),
+            name.to_string_lossy()
+        )),
+        nix::errno::Errno::ENOTDIR => {
+            RunnerError::Internal(format!("{} is not a lock directory", full_parent.display()))
+        }
+        _ => RunnerError::Internal(format!(
+            "{operation} lock dir component {} for {}: {error}",
+            name.to_string_lossy(),
+            full_parent.display()
+        )),
+    }
+}
+
+#[cfg(unix)]
+fn secure_open_lock_parent_dir(fd: &OwnedFd, parent: &Path, expected_uid: u32) -> RunnerResult<()> {
+    use nix::sys::stat::{SFlag, fstat};
+
+    let stat = fstat(fd)
         .map_err(|e| RunnerError::Internal(format!("stat lock dir {}: {e}", parent.display())))?;
     let file_type = SFlag::from_bits_truncate(stat.st_mode & SFlag::S_IFMT.bits());
     if file_type != SFlag::S_IFDIR {
@@ -78,13 +206,16 @@ fn secure_lock_parent_dir_permissions(parent: &Path) -> RunnerResult<()> {
             parent.display()
         )));
     }
-    let expected_uid = nix::unistd::geteuid().as_raw();
     ensure_trusted_lock_parent_dir_owner(parent, stat.st_uid, expected_uid)?;
 
     let current_mode = (stat.st_mode as u32) & 0o7777;
-    let secure_mode = (current_mode | OWNER_DIRECTORY_BITS) & !GROUP_OR_OTHER_WRITE_BITS;
+    let secure_mode = if current_mode & 0o1000 == 0 {
+        (current_mode | OWNER_DIRECTORY_BITS) & !GROUP_OR_OTHER_WRITE_BITS
+    } else {
+        current_mode | OWNER_DIRECTORY_BITS
+    };
     if secure_mode != current_mode {
-        chmod_open_lock_parent_dir(&fd, parent, secure_mode)?;
+        chmod_open_lock_parent_dir(fd, parent, secure_mode)?;
     }
     Ok(())
 }
@@ -432,6 +563,21 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn acquire_preserves_sticky_lock_parent_directory_mode() {
+        let dir = tempfile::tempdir().unwrap();
+        let parent = dir.path().join("sticky-locks");
+        let path = parent.join("test.lock");
+        std::fs::create_dir(&parent).unwrap();
+        std::fs::set_permissions(&parent, std::fs::Permissions::from_mode(0o1777)).unwrap();
+
+        let guard = acquire(path).await.unwrap();
+
+        let mode = std::fs::metadata(&parent).unwrap().permissions().mode() & 0o7777;
+        assert_eq!(mode, 0o1777);
+        drop(guard);
+    }
+
+    #[tokio::test]
     async fn acquire_rejects_lock_parent_symlink_without_chmodding_target() {
         let dir = tempfile::tempdir().unwrap();
         let target = dir.path().join("target");
@@ -442,11 +588,54 @@ mod tests {
 
         let error = acquire(parent.join("test.lock")).await.unwrap_err();
 
+        let message = error.to_string();
         assert!(
-            error.to_string().contains("open lock dir"),
+            message.contains("symlink component") || message.contains("not a lock directory"),
             "unexpected error: {error}"
         );
         assert_eq!(file_mode(&target), 0o777);
+    }
+
+    #[tokio::test]
+    async fn acquire_rejects_intermediate_lock_parent_symlink_without_creating_target_child() {
+        let dir = tempfile::tempdir().unwrap();
+        let target = dir.path().join("target");
+        let link = dir.path().join("link");
+        std::fs::create_dir(&target).unwrap();
+        symlink(&target, &link).unwrap();
+        let path = link.join("locks").join("test.lock");
+
+        let error = acquire(path).await.unwrap_err();
+
+        let message = error.to_string();
+        assert!(
+            message.contains("symlink component") || message.contains("not a lock directory"),
+            "unexpected error: {error}"
+        );
+        assert!(
+            !target.join("locks").exists(),
+            "lock parent should not be created through an intermediate symlink"
+        );
+    }
+
+    #[tokio::test]
+    async fn acquire_rejects_replaceable_lock_parent_ancestor() {
+        let dir = tempfile::tempdir().unwrap();
+        let ancestor = dir.path().join("shared");
+        std::fs::create_dir(&ancestor).unwrap();
+        std::fs::set_permissions(&ancestor, std::fs::Permissions::from_mode(0o777)).unwrap();
+        let path = ancestor.join("locks").join("test.lock");
+
+        let error = acquire(path).await.unwrap_err();
+
+        assert!(
+            error.to_string().contains("group/other writable"),
+            "unexpected error: {error}"
+        );
+        assert!(
+            !ancestor.join("locks").exists(),
+            "lock parent should not be created under a replaceable ancestor"
+        );
     }
 
     #[test]

--- a/crates/runner/src/lock.rs
+++ b/crates/runner/src/lock.rs
@@ -294,6 +294,12 @@ fn secure_lock_file_permissions(file: &File, path: &Path) -> RunnerResult<()> {
     let metadata = file
         .metadata()
         .map_err(|e| RunnerError::Internal(format!("stat lock {}: {e}", path.display())))?;
+    if !metadata.file_type().is_file() {
+        return Err(RunnerError::Internal(format!(
+            "{} is not a regular lock file",
+            path.display()
+        )));
+    }
     ensure_trusted_lock_file_owner(path, metadata.uid(), nix::unistd::geteuid().as_raw())?;
     file.set_permissions(std::fs::Permissions::from_mode(LOCK_FILE_MODE))
         .map_err(|e| RunnerError::Internal(format!("chmod lock {}: {e}", path.display())))
@@ -498,6 +504,30 @@ mod tests {
             "unexpected error: {error}"
         );
         assert_eq!(file_mode(&target), 0o644);
+    }
+
+    #[tokio::test]
+    async fn acquire_rejects_non_regular_lock_file() {
+        use std::ffi::CString;
+        use std::os::unix::ffi::OsStrExt;
+
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("test.lock");
+        let c_path = CString::new(path.as_os_str().as_bytes()).unwrap();
+        let result = unsafe { libc::mkfifo(c_path.as_ptr(), 0o600) };
+        assert_eq!(
+            result,
+            0,
+            "mkfifo failed: {}",
+            std::io::Error::last_os_error()
+        );
+
+        let error = acquire(path).await.unwrap_err();
+
+        assert!(
+            error.to_string().contains("not a regular lock file"),
+            "unexpected error: {error}"
+        );
     }
 
     #[tokio::test]

--- a/crates/runner/src/lock.rs
+++ b/crates/runner/src/lock.rs
@@ -333,7 +333,7 @@ fn is_current_inode(lock: &Flock<File>, path: &Path) -> bool {
     let Ok(lock_meta) = lock.metadata() else {
         return true;
     };
-    let Ok(path_meta) = std::fs::metadata(path) else {
+    let Ok(path_meta) = std::fs::symlink_metadata(path) else {
         return false;
     };
     lock_meta.dev() == path_meta.dev() && lock_meta.ino() == path_meta.ino()
@@ -504,6 +504,20 @@ mod tests {
             "unexpected error: {error}"
         );
         assert_eq!(file_mode(&target), 0o644);
+    }
+
+    #[test]
+    fn current_inode_rejects_symlink_replacement_to_same_inode() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("test.lock");
+        let target = dir.path().join("held.lock");
+        std::fs::write(&path, b"lock").unwrap();
+        let file = open_lock_file(&path).unwrap();
+        let lock = Flock::lock(file, FlockArg::LockExclusiveNonblock).unwrap();
+        std::fs::rename(&path, &target).unwrap();
+        symlink(&target, &path).unwrap();
+
+        assert!(!is_current_inode(&lock, &path));
     }
 
     #[tokio::test]

--- a/crates/runner/src/log_fs.rs
+++ b/crates/runner/src/log_fs.rs
@@ -1,0 +1,146 @@
+use std::path::Path;
+
+use crate::error::{RunnerError, RunnerResult};
+
+pub(crate) const LOG_DIR_MODE: u32 = 0o700;
+pub(crate) const LOG_FILE_MODE: u32 = 0o600;
+
+#[cfg(unix)]
+pub(crate) fn ensure_log_dir_sync(dir: &Path) -> RunnerResult<()> {
+    use std::os::unix::fs::{DirBuilderExt, PermissionsExt};
+
+    std::fs::DirBuilder::new()
+        .recursive(true)
+        .mode(LOG_DIR_MODE)
+        .create(dir)
+        .map_err(|e| RunnerError::Internal(format!("create logs_dir {}: {e}", dir.display())))?;
+    let metadata = std::fs::symlink_metadata(dir)
+        .map_err(|e| RunnerError::Internal(format!("stat logs_dir {}: {e}", dir.display())))?;
+    if !metadata.file_type().is_dir() {
+        return Err(RunnerError::Internal(format!(
+            "{} is not a directory",
+            dir.display()
+        )));
+    }
+    std::fs::set_permissions(dir, std::fs::Permissions::from_mode(LOG_DIR_MODE))
+        .map_err(|e| RunnerError::Internal(format!("chmod logs_dir {}: {e}", dir.display())))
+}
+
+#[cfg(not(unix))]
+pub(crate) fn ensure_log_dir_sync(dir: &Path) -> RunnerResult<()> {
+    std::fs::create_dir_all(dir)
+        .map_err(|e| RunnerError::Internal(format!("create logs_dir {}: {e}", dir.display())))
+}
+
+#[cfg(unix)]
+pub(crate) async fn ensure_log_dir(dir: &Path) -> RunnerResult<()> {
+    use std::os::unix::fs::PermissionsExt;
+
+    let mut builder = tokio::fs::DirBuilder::new();
+    builder.recursive(true).mode(LOG_DIR_MODE);
+    builder
+        .create(dir)
+        .await
+        .map_err(|e| RunnerError::Internal(format!("create logs_dir {}: {e}", dir.display())))?;
+    let metadata = tokio::fs::symlink_metadata(dir)
+        .await
+        .map_err(|e| RunnerError::Internal(format!("stat logs_dir {}: {e}", dir.display())))?;
+    if !metadata.file_type().is_dir() {
+        return Err(RunnerError::Internal(format!(
+            "{} is not a directory",
+            dir.display()
+        )));
+    }
+    tokio::fs::set_permissions(dir, std::fs::Permissions::from_mode(LOG_DIR_MODE))
+        .await
+        .map_err(|e| RunnerError::Internal(format!("chmod logs_dir {}: {e}", dir.display())))
+}
+
+#[cfg(not(unix))]
+pub(crate) async fn ensure_log_dir(dir: &Path) -> RunnerResult<()> {
+    tokio::fs::create_dir_all(dir)
+        .await
+        .map_err(|e| RunnerError::Internal(format!("create logs_dir {}: {e}", dir.display())))
+}
+
+#[cfg(unix)]
+pub(crate) fn secure_open_log_file_sync(file: &std::fs::File, path: &Path) -> std::io::Result<()> {
+    use std::os::unix::fs::PermissionsExt;
+
+    let metadata = file.metadata()?;
+    if !metadata.file_type().is_file() {
+        return Err(std::io::Error::other(format!(
+            "{} is not a regular log file",
+            path.display()
+        )));
+    }
+    if metadata.permissions().mode() & 0o777 == LOG_FILE_MODE {
+        return Ok(());
+    }
+    file.set_permissions(std::fs::Permissions::from_mode(LOG_FILE_MODE))
+}
+
+#[cfg(not(unix))]
+pub(crate) fn secure_open_log_file_sync(
+    _file: &std::fs::File,
+    _path: &Path,
+) -> std::io::Result<()> {
+    Ok(())
+}
+
+#[cfg(unix)]
+pub(crate) async fn secure_log_file(path: &Path) -> RunnerResult<()> {
+    use std::os::unix::fs::PermissionsExt;
+
+    let metadata = tokio::fs::symlink_metadata(path)
+        .await
+        .map_err(|e| RunnerError::Internal(format!("stat log file {}: {e}", path.display())))?;
+    if !metadata.file_type().is_file() {
+        return Err(RunnerError::Internal(format!(
+            "{} is not a regular log file",
+            path.display()
+        )));
+    }
+    if metadata.permissions().mode() & 0o777 == LOG_FILE_MODE {
+        return Ok(());
+    }
+    tokio::fs::set_permissions(path, std::fs::Permissions::from_mode(LOG_FILE_MODE))
+        .await
+        .map_err(|e| RunnerError::Internal(format!("chmod log file {}: {e}", path.display())))
+}
+
+#[cfg(not(unix))]
+pub(crate) async fn secure_log_file(_path: &Path) -> RunnerResult<()> {
+    Ok(())
+}
+
+#[cfg(test)]
+#[cfg(unix)]
+mod tests {
+    use super::*;
+    use std::os::unix::fs::PermissionsExt;
+
+    #[test]
+    fn ensure_log_dir_sync_creates_private_dir() {
+        let dir = tempfile::tempdir().unwrap();
+        let logs_dir = dir.path().join("logs");
+
+        ensure_log_dir_sync(&logs_dir).unwrap();
+
+        let mode = std::fs::metadata(&logs_dir).unwrap().permissions().mode() & 0o777;
+        assert_eq!(mode, LOG_DIR_MODE);
+    }
+
+    #[tokio::test]
+    async fn ensure_log_dir_tightens_existing_dir() {
+        let dir = tempfile::tempdir().unwrap();
+        let logs_dir = dir.path().join("logs");
+        std::fs::create_dir(&logs_dir).unwrap();
+        std::fs::set_permissions(&logs_dir, std::fs::Permissions::from_mode(0o755)).unwrap();
+
+        ensure_log_dir(&logs_dir).await.unwrap();
+
+        let mode = std::fs::metadata(&logs_dir).unwrap().permissions().mode() & 0o777;
+        assert_eq!(mode, LOG_DIR_MODE);
+    }
+}

--- a/crates/runner/src/log_fs.rs
+++ b/crates/runner/src/log_fs.rs
@@ -1,29 +1,21 @@
-use std::path::Path;
+use std::path::{Component, Path, PathBuf};
 
 use crate::error::{RunnerError, RunnerResult};
 
 pub(crate) const LOG_DIR_MODE: u32 = 0o700;
 pub(crate) const LOG_FILE_MODE: u32 = 0o600;
+#[cfg(unix)]
+const GROUP_OR_OTHER_WRITE_BITS: u32 = 0o022;
+#[cfg(unix)]
+const ROOT_UID: u32 = 0;
+#[cfg(unix)]
+const STICKY_BIT: u32 = 0o1000;
 
 #[cfg(unix)]
 pub(crate) fn ensure_log_dir_sync(dir: &Path) -> RunnerResult<()> {
-    use std::os::unix::fs::{DirBuilderExt, PermissionsExt};
-
-    std::fs::DirBuilder::new()
-        .recursive(true)
-        .mode(LOG_DIR_MODE)
-        .create(dir)
-        .map_err(|e| RunnerError::Internal(format!("create logs_dir {}: {e}", dir.display())))?;
-    let metadata = std::fs::symlink_metadata(dir)
-        .map_err(|e| RunnerError::Internal(format!("stat logs_dir {}: {e}", dir.display())))?;
-    if !metadata.file_type().is_dir() {
-        return Err(RunnerError::Internal(format!(
-            "{} is not a directory",
-            dir.display()
-        )));
-    }
-    std::fs::set_permissions(dir, std::fs::Permissions::from_mode(LOG_DIR_MODE))
-        .map_err(|e| RunnerError::Internal(format!("chmod logs_dir {}: {e}", dir.display())))
+    let expected_uid = nix::unistd::geteuid().as_raw();
+    let fd = ensure_log_dir_exists_without_symlinks(dir, expected_uid)?;
+    secure_open_log_dir(&fd, dir, expected_uid, true)
 }
 
 #[cfg(not(unix))]
@@ -34,26 +26,7 @@ pub(crate) fn ensure_log_dir_sync(dir: &Path) -> RunnerResult<()> {
 
 #[cfg(unix)]
 pub(crate) async fn ensure_log_dir(dir: &Path) -> RunnerResult<()> {
-    use std::os::unix::fs::PermissionsExt;
-
-    let mut builder = tokio::fs::DirBuilder::new();
-    builder.recursive(true).mode(LOG_DIR_MODE);
-    builder
-        .create(dir)
-        .await
-        .map_err(|e| RunnerError::Internal(format!("create logs_dir {}: {e}", dir.display())))?;
-    let metadata = tokio::fs::symlink_metadata(dir)
-        .await
-        .map_err(|e| RunnerError::Internal(format!("stat logs_dir {}: {e}", dir.display())))?;
-    if !metadata.file_type().is_dir() {
-        return Err(RunnerError::Internal(format!(
-            "{} is not a directory",
-            dir.display()
-        )));
-    }
-    tokio::fs::set_permissions(dir, std::fs::Permissions::from_mode(LOG_DIR_MODE))
-        .await
-        .map_err(|e| RunnerError::Internal(format!("chmod logs_dir {}: {e}", dir.display())))
+    ensure_log_dir_sync(dir)
 }
 
 #[cfg(not(unix))]
@@ -65,7 +38,7 @@ pub(crate) async fn ensure_log_dir(dir: &Path) -> RunnerResult<()> {
 
 #[cfg(unix)]
 pub(crate) fn secure_open_log_file_sync(file: &std::fs::File, path: &Path) -> std::io::Result<()> {
-    use std::os::unix::fs::PermissionsExt;
+    use std::os::unix::fs::{MetadataExt, PermissionsExt};
 
     let metadata = file.metadata()?;
     if !metadata.file_type().is_file() {
@@ -74,10 +47,26 @@ pub(crate) fn secure_open_log_file_sync(file: &std::fs::File, path: &Path) -> st
             path.display()
         )));
     }
+    ensure_trusted_log_owner_io(path, metadata.uid(), nix::unistd::geteuid().as_raw())?;
     if metadata.permissions().mode() & 0o777 == LOG_FILE_MODE {
         return Ok(());
     }
     file.set_permissions(std::fs::Permissions::from_mode(LOG_FILE_MODE))
+}
+
+#[cfg(unix)]
+pub(crate) fn secure_existing_log_file_sync(path: &Path) -> std::io::Result<()> {
+    match std::fs::symlink_metadata(path) {
+        Ok(_) => {}
+        Err(e) if e.kind() == std::io::ErrorKind::NotFound => return Ok(()),
+        Err(e) => return Err(e),
+    }
+    secure_log_file_sync(path).map_err(|e| std::io::Error::other(e.to_string()))
+}
+
+#[cfg(not(unix))]
+pub(crate) fn secure_existing_log_file_sync(_path: &Path) -> std::io::Result<()> {
+    Ok(())
 }
 
 #[cfg(not(unix))]
@@ -90,28 +79,345 @@ pub(crate) fn secure_open_log_file_sync(
 
 #[cfg(unix)]
 pub(crate) async fn secure_log_file(path: &Path) -> RunnerResult<()> {
-    use std::os::unix::fs::PermissionsExt;
+    secure_log_file_sync(path)
+}
 
-    let metadata = tokio::fs::symlink_metadata(path)
-        .await
-        .map_err(|e| RunnerError::Internal(format!("stat log file {}: {e}", path.display())))?;
-    if !metadata.file_type().is_file() {
-        return Err(RunnerError::Internal(format!(
-            "{} is not a regular log file",
-            path.display()
-        )));
-    }
-    if metadata.permissions().mode() & 0o777 == LOG_FILE_MODE {
-        return Ok(());
-    }
-    tokio::fs::set_permissions(path, std::fs::Permissions::from_mode(LOG_FILE_MODE))
-        .await
-        .map_err(|e| RunnerError::Internal(format!("chmod log file {}: {e}", path.display())))
+#[cfg(unix)]
+pub(crate) async fn secure_existing_log_file(path: &Path) -> RunnerResult<()> {
+    secure_existing_log_file_sync(path).map_err(|e| {
+        RunnerError::Internal(format!("secure existing log file {}: {e}", path.display()))
+    })
+}
+
+#[cfg(not(unix))]
+pub(crate) async fn secure_existing_log_file(_path: &Path) -> RunnerResult<()> {
+    Ok(())
 }
 
 #[cfg(not(unix))]
 pub(crate) async fn secure_log_file(_path: &Path) -> RunnerResult<()> {
     Ok(())
+}
+
+#[cfg(unix)]
+fn ensure_log_dir_exists_without_symlinks(
+    path: &Path,
+    expected_uid: u32,
+) -> RunnerResult<std::os::fd::OwnedFd> {
+    use nix::fcntl::open;
+    use nix::sys::stat::Mode;
+
+    if path.as_os_str().is_empty() {
+        return Err(RunnerError::Internal(
+            "empty logs_dir path is not a directory".to_string(),
+        ));
+    }
+
+    let start = if path.is_absolute() {
+        Path::new("/")
+    } else {
+        Path::new(".")
+    };
+    let mut current = open(start, log_dir_open_flags(), Mode::empty()).map_err(|e| {
+        RunnerError::Internal(format!("open logs_dir root for {}: {e}", path.display()))
+    })?;
+    let mut current_path = start.to_path_buf();
+    let mut saw_normal_component = false;
+    let mut components = path.components().peekable();
+    while let Some(component) = components.next() {
+        match component {
+            Component::RootDir | Component::CurDir => {}
+            Component::ParentDir => {
+                return Err(RunnerError::Internal(format!(
+                    "{} contains a parent directory segment; refusing to use it as logs_dir",
+                    path.display()
+                )));
+            }
+            Component::Normal(name) => {
+                saw_normal_component = true;
+                let is_final = components.peek().is_none();
+                current = open_or_create_log_dir_component(
+                    &current,
+                    name,
+                    &current_path,
+                    path,
+                    expected_uid,
+                    is_final,
+                )?;
+                current_path = log_dir_component_path(&current_path, name);
+            }
+            Component::Prefix(prefix) => {
+                return Err(RunnerError::Internal(format!(
+                    "{} contains unsupported path prefix {}; refusing to use it as logs_dir",
+                    path.display(),
+                    prefix.as_os_str().to_string_lossy()
+                )));
+            }
+        }
+    }
+
+    if !saw_normal_component {
+        return Err(RunnerError::Internal(format!(
+            "{} does not name a logs_dir",
+            path.display()
+        )));
+    }
+    Ok(current)
+}
+
+#[cfg(unix)]
+fn open_or_create_log_dir_component(
+    parent: &(impl std::os::fd::AsFd + std::os::fd::AsRawFd),
+    name: &std::ffi::OsStr,
+    parent_path: &Path,
+    full_path: &Path,
+    expected_uid: u32,
+    is_final: bool,
+) -> RunnerResult<std::os::fd::OwnedFd> {
+    use nix::errno::Errno;
+    use nix::fcntl::openat;
+    use nix::sys::stat::{Mode, mkdirat};
+
+    ensure_log_dir_parent_not_replaceable(parent, parent_path, full_path, expected_uid)?;
+    let component_path = log_dir_component_path(parent_path, name);
+    match openat(parent, name, log_dir_open_flags(), Mode::empty()) {
+        Ok(fd) => {
+            secure_open_log_dir(&fd, &component_path, expected_uid, is_final)?;
+            Ok(fd)
+        }
+        Err(Errno::ENOENT) => {
+            let created = match mkdirat(parent, name, Mode::from_bits_truncate(LOG_DIR_MODE)) {
+                Ok(()) => true,
+                Err(Errno::EEXIST) => false,
+                Err(e) => {
+                    return Err(RunnerError::Internal(format!(
+                        "create logs_dir component {} for {}: {e}",
+                        name.to_string_lossy(),
+                        full_path.display()
+                    )));
+                }
+            };
+            let fd = openat(parent, name, log_dir_open_flags(), Mode::empty())
+                .map_err(|e| log_dir_component_error("open", name, full_path, e))?;
+            secure_open_log_dir(&fd, &component_path, expected_uid, created || is_final)?;
+            Ok(fd)
+        }
+        Err(e) => Err(log_dir_component_error("open", name, full_path, e)),
+    }
+}
+
+#[cfg(unix)]
+fn ensure_log_dir_parent_not_replaceable(
+    parent: &(impl std::os::fd::AsFd + std::os::fd::AsRawFd),
+    parent_path: &Path,
+    full_path: &Path,
+    expected_uid: u32,
+) -> RunnerResult<()> {
+    use nix::sys::stat::{SFlag, fstat};
+
+    let stat = fstat(parent).map_err(|e| {
+        RunnerError::Internal(format!(
+            "stat logs_dir parent {} for {}: {e}",
+            parent_path.display(),
+            full_path.display()
+        ))
+    })?;
+    let file_type = SFlag::from_bits_truncate(stat.st_mode & SFlag::S_IFMT.bits());
+    if file_type != SFlag::S_IFDIR {
+        return Err(RunnerError::Internal(format!(
+            "{} is not a logs_dir parent",
+            parent_path.display()
+        )));
+    }
+    ensure_trusted_log_owner(parent_path, stat.st_uid, expected_uid)?;
+    let mode = (stat.st_mode as u32) & 0o7777;
+    if mode & GROUP_OR_OTHER_WRITE_BITS != 0 && mode & STICKY_BIT == 0 {
+        return Err(RunnerError::Internal(format!(
+            "logs_dir parent {} is group/other writable without the sticky bit; fix parent permissions before starting the runner",
+            parent_path.display()
+        )));
+    }
+    Ok(())
+}
+
+#[cfg(unix)]
+fn secure_open_log_dir(
+    fd: &std::os::fd::OwnedFd,
+    dir: &Path,
+    expected_uid: u32,
+    enforce_private_mode: bool,
+) -> RunnerResult<()> {
+    use nix::sys::stat::{SFlag, fstat};
+
+    let stat = fstat(fd)
+        .map_err(|e| RunnerError::Internal(format!("stat logs_dir {}: {e}", dir.display())))?;
+    let file_type = SFlag::from_bits_truncate(stat.st_mode & SFlag::S_IFMT.bits());
+    if file_type != SFlag::S_IFDIR {
+        return Err(RunnerError::Internal(format!(
+            "{} is not a logs_dir",
+            dir.display()
+        )));
+    }
+    ensure_trusted_log_owner(dir, stat.st_uid, expected_uid)?;
+    if enforce_private_mode && (stat.st_mode as u32) & 0o777 != LOG_DIR_MODE {
+        chmod_open_log_dir(fd, dir)?;
+    }
+    Ok(())
+}
+
+#[cfg(unix)]
+fn log_dir_component_path(parent: &Path, name: &std::ffi::OsStr) -> PathBuf {
+    let mut path = parent.to_path_buf();
+    path.push(Path::new(name));
+    path
+}
+
+#[cfg(unix)]
+fn log_dir_component_error(
+    operation: &str,
+    name: &std::ffi::OsStr,
+    full_path: &Path,
+    error: nix::errno::Errno,
+) -> RunnerError {
+    match error {
+        nix::errno::Errno::ELOOP => RunnerError::Internal(format!(
+            "{} contains symlink component {}; refusing to use it as logs_dir",
+            full_path.display(),
+            name.to_string_lossy()
+        )),
+        nix::errno::Errno::ENOTDIR => {
+            RunnerError::Internal(format!("{} is not a logs_dir", full_path.display()))
+        }
+        _ => RunnerError::Internal(format!(
+            "{operation} logs_dir component {} for {}: {error}",
+            name.to_string_lossy(),
+            full_path.display()
+        )),
+    }
+}
+
+#[cfg(all(unix, target_os = "linux"))]
+fn log_dir_open_flags() -> nix::fcntl::OFlag {
+    nix::fcntl::OFlag::O_PATH
+        | nix::fcntl::OFlag::O_DIRECTORY
+        | nix::fcntl::OFlag::O_NOFOLLOW
+        | nix::fcntl::OFlag::O_CLOEXEC
+}
+
+#[cfg(all(unix, not(target_os = "linux")))]
+fn log_dir_open_flags() -> nix::fcntl::OFlag {
+    nix::fcntl::OFlag::O_RDONLY
+        | nix::fcntl::OFlag::O_DIRECTORY
+        | nix::fcntl::OFlag::O_NOFOLLOW
+        | nix::fcntl::OFlag::O_CLOEXEC
+}
+
+#[cfg(all(unix, target_os = "linux"))]
+fn chmod_open_log_dir<Fd: std::os::fd::AsRawFd>(fd: &Fd, path: &Path) -> RunnerResult<()> {
+    use std::os::unix::fs::PermissionsExt;
+
+    let fd_path = PathBuf::from(format!("/proc/self/fd/{}", fd.as_raw_fd()));
+    std::fs::set_permissions(&fd_path, std::fs::Permissions::from_mode(LOG_DIR_MODE))
+        .map_err(|e| RunnerError::Internal(format!("chmod logs_dir {}: {e}", path.display())))
+}
+
+#[cfg(all(unix, not(target_os = "linux")))]
+fn chmod_open_log_dir<Fd: std::os::fd::AsFd>(fd: &Fd, path: &Path) -> RunnerResult<()> {
+    nix::sys::stat::fchmod(fd, nix::sys::stat::Mode::from_bits_truncate(LOG_DIR_MODE))
+        .map_err(|e| RunnerError::Internal(format!("chmod logs_dir {}: {e}", path.display())))
+}
+
+#[cfg(unix)]
+fn secure_log_file_sync(path: &Path) -> RunnerResult<()> {
+    use nix::fcntl::open;
+    use nix::sys::stat::Mode;
+
+    let fd = open(path, log_file_open_flags(), Mode::empty()).map_err(|e| {
+        RunnerError::Internal(format!(
+            "open log file {} without following symlinks: {e}",
+            path.display()
+        ))
+    })?;
+    secure_open_log_file_fd(&fd, path)
+}
+
+#[cfg(unix)]
+fn secure_open_log_file_fd(fd: &std::os::fd::OwnedFd, path: &Path) -> RunnerResult<()> {
+    use nix::sys::stat::{SFlag, fstat};
+
+    let stat = fstat(fd)
+        .map_err(|e| RunnerError::Internal(format!("stat log file {}: {e}", path.display())))?;
+    let file_type = SFlag::from_bits_truncate(stat.st_mode & SFlag::S_IFMT.bits());
+    if file_type != SFlag::S_IFREG {
+        return Err(RunnerError::Internal(format!(
+            "{} is not a regular log file",
+            path.display()
+        )));
+    }
+    ensure_trusted_log_owner(path, stat.st_uid, nix::unistd::geteuid().as_raw())?;
+    if (stat.st_mode as u32) & 0o777 != LOG_FILE_MODE {
+        chmod_open_log_file(fd, path)?;
+    }
+    Ok(())
+}
+
+#[cfg(all(unix, target_os = "linux"))]
+fn log_file_open_flags() -> nix::fcntl::OFlag {
+    nix::fcntl::OFlag::O_PATH | nix::fcntl::OFlag::O_NOFOLLOW | nix::fcntl::OFlag::O_CLOEXEC
+}
+
+#[cfg(all(unix, not(target_os = "linux")))]
+fn log_file_open_flags() -> nix::fcntl::OFlag {
+    nix::fcntl::OFlag::O_RDONLY | nix::fcntl::OFlag::O_NOFOLLOW | nix::fcntl::OFlag::O_CLOEXEC
+}
+
+#[cfg(all(unix, target_os = "linux"))]
+fn chmod_open_log_file<Fd: std::os::fd::AsRawFd>(fd: &Fd, path: &Path) -> RunnerResult<()> {
+    use std::os::unix::fs::PermissionsExt;
+
+    let fd_path = PathBuf::from(format!("/proc/self/fd/{}", fd.as_raw_fd()));
+    std::fs::set_permissions(&fd_path, std::fs::Permissions::from_mode(LOG_FILE_MODE))
+        .map_err(|e| RunnerError::Internal(format!("chmod log file {}: {e}", path.display())))
+}
+
+#[cfg(all(unix, not(target_os = "linux")))]
+fn chmod_open_log_file<Fd: std::os::fd::AsFd>(fd: &Fd, path: &Path) -> RunnerResult<()> {
+    nix::sys::stat::fchmod(fd, nix::sys::stat::Mode::from_bits_truncate(LOG_FILE_MODE))
+        .map_err(|e| RunnerError::Internal(format!("chmod log file {}: {e}", path.display())))
+}
+
+#[cfg(unix)]
+fn ensure_trusted_log_owner(path: &Path, owner_uid: u32, expected_uid: u32) -> RunnerResult<()> {
+    if !is_trusted_log_owner(owner_uid, expected_uid) {
+        return Err(RunnerError::Internal(format!(
+            "{} is owned by untrusted uid {owner_uid}; fix ownership before starting the runner",
+            path.display()
+        )));
+    }
+    Ok(())
+}
+
+#[cfg(unix)]
+fn ensure_trusted_log_owner_io(
+    path: &Path,
+    owner_uid: u32,
+    expected_uid: u32,
+) -> std::io::Result<()> {
+    if !is_trusted_log_owner(owner_uid, expected_uid) {
+        return Err(std::io::Error::new(
+            std::io::ErrorKind::PermissionDenied,
+            format!(
+                "{} is owned by untrusted uid {owner_uid}; fix ownership before starting the runner",
+                path.display()
+            ),
+        ));
+    }
+    Ok(())
+}
+
+#[cfg(unix)]
+fn is_trusted_log_owner(owner_uid: u32, expected_uid: u32) -> bool {
+    owner_uid == ROOT_UID || owner_uid == expected_uid
 }
 
 #[cfg(test)]
@@ -120,6 +426,10 @@ mod tests {
     use super::*;
     use std::os::unix::fs::PermissionsExt;
 
+    fn mode(path: &Path) -> u32 {
+        std::fs::metadata(path).unwrap().permissions().mode() & 0o777
+    }
+
     #[test]
     fn ensure_log_dir_sync_creates_private_dir() {
         let dir = tempfile::tempdir().unwrap();
@@ -127,8 +437,7 @@ mod tests {
 
         ensure_log_dir_sync(&logs_dir).unwrap();
 
-        let mode = std::fs::metadata(&logs_dir).unwrap().permissions().mode() & 0o777;
-        assert_eq!(mode, LOG_DIR_MODE);
+        assert_eq!(mode(&logs_dir), LOG_DIR_MODE);
     }
 
     #[tokio::test]
@@ -140,7 +449,92 @@ mod tests {
 
         ensure_log_dir(&logs_dir).await.unwrap();
 
-        let mode = std::fs::metadata(&logs_dir).unwrap().permissions().mode() & 0o777;
-        assert_eq!(mode, LOG_DIR_MODE);
+        assert_eq!(mode(&logs_dir), LOG_DIR_MODE);
+    }
+
+    #[test]
+    fn ensure_log_dir_sync_rejects_symlink_component() {
+        let dir = tempfile::tempdir().unwrap();
+        let target = dir.path().join("target");
+        let link = dir.path().join("link");
+        std::fs::create_dir(&target).unwrap();
+        std::os::unix::fs::symlink(&target, &link).unwrap();
+
+        let error = ensure_log_dir_sync(&link.join("logs")).unwrap_err();
+
+        assert!(
+            error.to_string().contains("logs_dir"),
+            "unexpected error: {error}"
+        );
+        assert!(!target.join("logs").exists());
+    }
+
+    #[test]
+    fn trusted_log_owner_allows_root_or_current_user_only() {
+        assert!(is_trusted_log_owner(0, 1000));
+        assert!(is_trusted_log_owner(1000, 1000));
+        assert!(!is_trusted_log_owner(1001, 1000));
+    }
+
+    #[tokio::test]
+    async fn secure_log_file_tightens_existing_file() {
+        let dir = tempfile::tempdir().unwrap();
+        let log_file = dir.path().join("network.jsonl");
+        std::fs::write(&log_file, "{}\n").unwrap();
+        std::fs::set_permissions(&log_file, std::fs::Permissions::from_mode(0o644)).unwrap();
+
+        secure_log_file(&log_file).await.unwrap();
+
+        assert_eq!(mode(&log_file), LOG_FILE_MODE);
+    }
+
+    #[tokio::test]
+    async fn secure_log_file_rejects_symlink_without_chmodding_target() {
+        let dir = tempfile::tempdir().unwrap();
+        let target = dir.path().join("target.log");
+        let link = dir.path().join("link.log");
+        std::fs::write(&target, "secret\n").unwrap();
+        std::fs::set_permissions(&target, std::fs::Permissions::from_mode(0o644)).unwrap();
+        std::os::unix::fs::symlink(&target, &link).unwrap();
+
+        let error = secure_log_file(&link).await.unwrap_err();
+
+        assert!(
+            error.to_string().contains("regular log file")
+                || error.to_string().contains("without following symlinks"),
+            "unexpected error: {error}"
+        );
+        assert_eq!(mode(&target), 0o644);
+    }
+
+    #[test]
+    fn secure_existing_log_file_allows_missing_file() {
+        let dir = tempfile::tempdir().unwrap();
+        let log_file = dir.path().join("missing.log");
+
+        secure_existing_log_file_sync(&log_file).unwrap();
+
+        assert!(!log_file.exists());
+    }
+
+    #[test]
+    fn secure_existing_log_file_rejects_fifo_without_blocking() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("stdout.log");
+        let c_path = std::ffi::CString::new(path.as_os_str().as_encoded_bytes()).unwrap();
+        let result = unsafe { libc::mkfifo(c_path.as_ptr(), 0o600) };
+        assert_eq!(
+            result,
+            0,
+            "mkfifo failed: {}",
+            std::io::Error::last_os_error()
+        );
+
+        let error = secure_existing_log_file_sync(&path).unwrap_err();
+
+        assert!(
+            error.to_string().contains("regular log file"),
+            "unexpected error: {error}"
+        );
     }
 }

--- a/crates/runner/src/log_fs.rs
+++ b/crates/runner/src/log_fs.rs
@@ -54,21 +54,6 @@ pub(crate) fn secure_open_log_file_sync(file: &std::fs::File, path: &Path) -> st
     file.set_permissions(std::fs::Permissions::from_mode(LOG_FILE_MODE))
 }
 
-#[cfg(unix)]
-pub(crate) fn secure_existing_log_file_sync(path: &Path) -> std::io::Result<()> {
-    match std::fs::symlink_metadata(path) {
-        Ok(_) => {}
-        Err(e) if e.kind() == std::io::ErrorKind::NotFound => return Ok(()),
-        Err(e) => return Err(e),
-    }
-    secure_log_file_sync(path).map_err(|e| std::io::Error::other(e.to_string()))
-}
-
-#[cfg(not(unix))]
-pub(crate) fn secure_existing_log_file_sync(_path: &Path) -> std::io::Result<()> {
-    Ok(())
-}
-
 #[cfg(not(unix))]
 pub(crate) fn secure_open_log_file_sync(
     _file: &std::fs::File,
@@ -80,18 +65,6 @@ pub(crate) fn secure_open_log_file_sync(
 #[cfg(unix)]
 pub(crate) async fn secure_log_file(path: &Path) -> RunnerResult<()> {
     secure_log_file_sync(path)
-}
-
-#[cfg(unix)]
-pub(crate) async fn secure_existing_log_file(path: &Path) -> RunnerResult<()> {
-    secure_existing_log_file_sync(path).map_err(|e| {
-        RunnerError::Internal(format!("secure existing log file {}: {e}", path.display()))
-    })
-}
-
-#[cfg(not(unix))]
-pub(crate) async fn secure_existing_log_file(_path: &Path) -> RunnerResult<()> {
-    Ok(())
 }
 
 #[cfg(not(unix))]
@@ -508,17 +481,7 @@ mod tests {
     }
 
     #[test]
-    fn secure_existing_log_file_allows_missing_file() {
-        let dir = tempfile::tempdir().unwrap();
-        let log_file = dir.path().join("missing.log");
-
-        secure_existing_log_file_sync(&log_file).unwrap();
-
-        assert!(!log_file.exists());
-    }
-
-    #[test]
-    fn secure_existing_log_file_rejects_fifo_without_blocking() {
+    fn secure_log_file_rejects_fifo_without_blocking() {
         let dir = tempfile::tempdir().unwrap();
         let path = dir.path().join("stdout.log");
         let c_path = std::ffi::CString::new(path.as_os_str().as_encoded_bytes()).unwrap();
@@ -530,10 +493,19 @@ mod tests {
             std::io::Error::last_os_error()
         );
 
-        let error = secure_existing_log_file_sync(&path).unwrap_err();
+        let (tx, rx) = std::sync::mpsc::channel();
+        let path_for_thread = path.clone();
+        std::thread::spawn(move || {
+            let result = secure_log_file_sync(&path_for_thread).map_err(|e| e.to_string());
+            let _ = tx.send(result);
+        });
+        let error = rx
+            .recv_timeout(std::time::Duration::from_secs(1))
+            .expect("secure_log_file_sync should not block on FIFO")
+            .unwrap_err();
 
         assert!(
-            error.to_string().contains("regular log file"),
+            error.contains("regular log file"),
             "unexpected error: {error}"
         );
     }

--- a/crates/runner/src/log_fs.rs
+++ b/crates/runner/src/log_fs.rs
@@ -38,20 +38,40 @@ pub(crate) async fn ensure_log_dir(dir: &Path) -> RunnerResult<()> {
 
 #[cfg(unix)]
 pub(crate) fn secure_open_log_file_sync(file: &std::fs::File, path: &Path) -> std::io::Result<()> {
-    use std::os::unix::fs::{MetadataExt, PermissionsExt};
+    secure_open_log_fd_sync(file, path)
+}
 
-    let metadata = file.metadata()?;
-    if !metadata.file_type().is_file() {
+#[cfg(unix)]
+pub(crate) fn secure_open_log_fd_sync<Fd: std::os::fd::AsRawFd>(
+    file: &Fd,
+    path: &Path,
+) -> std::io::Result<()> {
+    let mut stat = std::mem::MaybeUninit::<nix::libc::stat>::uninit();
+    // SAFETY: `stat` points to valid writable memory and `file` owns a live fd.
+    let result = unsafe { nix::libc::fstat(file.as_raw_fd(), stat.as_mut_ptr()) };
+    if result != 0 {
+        return Err(std::io::Error::last_os_error());
+    }
+    // SAFETY: successful `fstat` initialized the full `stat` struct.
+    let stat = unsafe { stat.assume_init() };
+    let file_type = stat.st_mode & nix::libc::S_IFMT;
+    if file_type != nix::libc::S_IFREG {
         return Err(std::io::Error::other(format!(
             "{} is not a regular log file",
             path.display()
         )));
     }
-    ensure_trusted_log_owner_io(path, metadata.uid(), nix::unistd::geteuid().as_raw())?;
-    if metadata.permissions().mode() & 0o777 == LOG_FILE_MODE {
+    ensure_trusted_log_owner_io(path, stat.st_uid, nix::unistd::geteuid().as_raw())?;
+    if stat.st_mode & 0o777 == LOG_FILE_MODE {
         return Ok(());
     }
-    file.set_permissions(std::fs::Permissions::from_mode(LOG_FILE_MODE))
+    // SAFETY: `fchmod` operates on the live fd and does not affect Rust aliasing.
+    let result = unsafe { nix::libc::fchmod(file.as_raw_fd(), LOG_FILE_MODE as nix::libc::mode_t) };
+    if result == 0 {
+        Ok(())
+    } else {
+        Err(std::io::Error::last_os_error())
+    }
 }
 
 #[cfg(not(unix))]
@@ -59,6 +79,11 @@ pub(crate) fn secure_open_log_file_sync(
     _file: &std::fs::File,
     _path: &Path,
 ) -> std::io::Result<()> {
+    Ok(())
+}
+
+#[cfg(not(unix))]
+pub(crate) fn secure_open_log_fd_sync<Fd>(_file: &Fd, _path: &Path) -> std::io::Result<()> {
     Ok(())
 }
 
@@ -459,6 +484,36 @@ mod tests {
         secure_log_file(&log_file).await.unwrap();
 
         assert_eq!(mode(&log_file), LOG_FILE_MODE);
+    }
+
+    #[test]
+    fn secure_open_log_file_checks_open_fd_after_path_replacement() {
+        use nix::unistd::{Uid, chown};
+
+        if !nix::unistd::geteuid().is_root() {
+            return;
+        }
+
+        let dir = tempfile::tempdir().unwrap();
+        let log_file = dir.path().join("network.jsonl");
+        std::fs::write(&log_file, "{}\n").unwrap();
+        let file = std::fs::OpenOptions::new()
+            .read(true)
+            .write(true)
+            .open(&log_file)
+            .unwrap();
+        chown(&log_file, Some(Uid::from_raw(1)), None).unwrap();
+        std::fs::remove_file(&log_file).unwrap();
+        std::fs::write(&log_file, "{}\n").unwrap();
+        std::fs::set_permissions(&log_file, std::fs::Permissions::from_mode(0o644)).unwrap();
+
+        let error = secure_open_log_file_sync(&file, &log_file).unwrap_err();
+
+        assert!(
+            error.to_string().contains("untrusted uid"),
+            "unexpected error: {error}"
+        );
+        assert_eq!(mode(&log_file), 0o644);
     }
 
     #[tokio::test]

--- a/crates/runner/src/log_fs.rs
+++ b/crates/runner/src/log_fs.rs
@@ -62,7 +62,8 @@ pub(crate) fn secure_open_log_fd_sync<Fd: std::os::fd::AsRawFd>(
         )));
     }
     ensure_trusted_log_owner_io(path, stat.st_uid, nix::unistd::geteuid().as_raw())?;
-    if stat.st_mode & 0o777 == LOG_FILE_MODE {
+    let mode = stat.st_mode & 0o7777;
+    if mode == LOG_FILE_MODE {
         return Ok(());
     }
     // SAFETY: `fchmod` operates on the live fd and does not affect Rust aliasing.
@@ -257,7 +258,8 @@ fn secure_open_log_dir(
         )));
     }
     ensure_trusted_log_owner(dir, stat.st_uid, expected_uid)?;
-    if enforce_private_mode && (stat.st_mode as u32) & 0o777 != LOG_DIR_MODE {
+    let mode = (stat.st_mode as u32) & 0o7777;
+    if enforce_private_mode && mode != LOG_DIR_MODE {
         chmod_open_log_dir(fd, dir)?;
     }
     Ok(())
@@ -353,7 +355,8 @@ fn secure_open_log_file_fd(fd: &std::os::fd::OwnedFd, path: &Path) -> RunnerResu
         )));
     }
     ensure_trusted_log_owner(path, stat.st_uid, nix::unistd::geteuid().as_raw())?;
-    if (stat.st_mode as u32) & 0o777 != LOG_FILE_MODE {
+    let mode = (stat.st_mode as u32) & 0o7777;
+    if mode != LOG_FILE_MODE {
         chmod_open_log_file(fd, path)?;
     }
     Ok(())
@@ -425,7 +428,7 @@ mod tests {
     use std::os::unix::fs::PermissionsExt;
 
     fn mode(path: &Path) -> u32 {
-        std::fs::metadata(path).unwrap().permissions().mode() & 0o777
+        std::fs::metadata(path).unwrap().permissions().mode() & 0o7777
     }
 
     #[test]
@@ -446,6 +449,18 @@ mod tests {
         std::fs::set_permissions(&logs_dir, std::fs::Permissions::from_mode(0o755)).unwrap();
 
         ensure_log_dir(&logs_dir).await.unwrap();
+
+        assert_eq!(mode(&logs_dir), LOG_DIR_MODE);
+    }
+
+    #[test]
+    fn ensure_log_dir_sync_clears_existing_special_bits() {
+        let dir = tempfile::tempdir().unwrap();
+        let logs_dir = dir.path().join("logs");
+        std::fs::create_dir(&logs_dir).unwrap();
+        std::fs::set_permissions(&logs_dir, std::fs::Permissions::from_mode(0o1700)).unwrap();
+
+        ensure_log_dir_sync(&logs_dir).unwrap();
 
         assert_eq!(mode(&logs_dir), LOG_DIR_MODE);
     }
@@ -482,6 +497,35 @@ mod tests {
         std::fs::set_permissions(&log_file, std::fs::Permissions::from_mode(0o644)).unwrap();
 
         secure_log_file(&log_file).await.unwrap();
+
+        assert_eq!(mode(&log_file), LOG_FILE_MODE);
+    }
+
+    #[tokio::test]
+    async fn secure_log_file_clears_existing_special_bits() {
+        let dir = tempfile::tempdir().unwrap();
+        let log_file = dir.path().join("network.jsonl");
+        std::fs::write(&log_file, "{}\n").unwrap();
+        std::fs::set_permissions(&log_file, std::fs::Permissions::from_mode(0o4600)).unwrap();
+
+        secure_log_file(&log_file).await.unwrap();
+
+        assert_eq!(mode(&log_file), LOG_FILE_MODE);
+    }
+
+    #[test]
+    fn secure_open_log_file_clears_existing_special_bits() {
+        let dir = tempfile::tempdir().unwrap();
+        let log_file = dir.path().join("network.jsonl");
+        std::fs::write(&log_file, "{}\n").unwrap();
+        std::fs::set_permissions(&log_file, std::fs::Permissions::from_mode(0o4600)).unwrap();
+        let file = std::fs::OpenOptions::new()
+            .read(true)
+            .write(true)
+            .open(&log_file)
+            .unwrap();
+
+        secure_open_log_file_sync(&file, &log_file).unwrap();
 
         assert_eq!(mode(&log_file), LOG_FILE_MODE);
     }

--- a/crates/runner/src/main.rs
+++ b/crates/runner/src/main.rs
@@ -22,6 +22,7 @@ mod network_log_manager;
 mod network_logs;
 mod paths;
 mod prefetch;
+mod private_fs;
 mod process;
 mod profile;
 mod provider;

--- a/crates/runner/src/main.rs
+++ b/crates/runner/src/main.rs
@@ -17,6 +17,7 @@ mod io_limits;
 mod kmsg_log;
 mod local_queue;
 mod lock;
+mod log_fs;
 mod network_log_drain;
 mod network_log_manager;
 mod network_logs;
@@ -152,7 +153,7 @@ fn init_tracing_with_file(
 ) -> Result<tracing_appender::non_blocking::WorkerGuard, Box<dyn std::error::Error>> {
     let home = paths::HomePaths::new()?;
     let log_dir = home.logs_dir();
-    std::fs::create_dir_all(&log_dir).map_err(|e| format!("create {}: {e}", log_dir.display()))?;
+    log_fs::ensure_log_dir_sync(&log_dir)?;
 
     let name = runner_name_from_config(config_path);
     let prefix = format!("runner-{name}");

--- a/crates/runner/src/network_log_manager.rs
+++ b/crates/runner/src/network_log_manager.rs
@@ -373,11 +373,14 @@ impl NetworkLogManager {
 }
 
 fn append_line(path: &Path, line: &str) -> std::io::Result<()> {
-    let mut file = std::fs::OpenOptions::new()
-        .create(true)
-        .append(true)
+    crate::log_fs::secure_existing_log_file_sync(path)?;
+    let mut options = std::fs::OpenOptions::new();
+    options.create(true).append(true);
+    #[cfg(unix)]
+    options
         .mode(crate::log_fs::LOG_FILE_MODE)
-        .open(path)?;
+        .custom_flags(nix::libc::O_NOFOLLOW | nix::libc::O_CLOEXEC);
+    let mut file = options.open(path)?;
     crate::log_fs::secure_open_log_file_sync(&file, path)?;
     file.write_all(line.as_bytes())
 }
@@ -486,6 +489,27 @@ mod tests {
         let content = std::fs::read_to_string(path).unwrap();
         assert!(content.contains("\"old\""));
         assert!(content.contains("\"dns\""));
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn append_line_rejects_symlink_without_chmodding_target() {
+        use std::os::unix::fs::PermissionsExt;
+
+        let dir = tempfile::tempdir().unwrap();
+        let target = dir.path().join("target.jsonl");
+        let link = dir.path().join("network.jsonl");
+        std::fs::write(&target, "{\"type\":\"old\"}\n").unwrap();
+        std::fs::set_permissions(&target, std::fs::Permissions::from_mode(0o644)).unwrap();
+        std::os::unix::fs::symlink(&target, &link).unwrap();
+
+        assert!(append_line(&link, "{\"type\":\"dns\"}\n").is_err());
+
+        assert_eq!(file_mode(&target), 0o644);
+        assert_eq!(
+            std::fs::read_to_string(&target).unwrap(),
+            "{\"type\":\"old\"}\n"
+        );
     }
 
     #[tokio::test]

--- a/crates/runner/src/network_log_manager.rs
+++ b/crates/runner/src/network_log_manager.rs
@@ -373,13 +373,12 @@ impl NetworkLogManager {
 }
 
 fn append_line(path: &Path, line: &str) -> std::io::Result<()> {
-    crate::log_fs::secure_existing_log_file_sync(path)?;
     let mut options = std::fs::OpenOptions::new();
     options.create(true).append(true);
     #[cfg(unix)]
     options
         .mode(crate::log_fs::LOG_FILE_MODE)
-        .custom_flags(nix::libc::O_NOFOLLOW | nix::libc::O_CLOEXEC);
+        .custom_flags(nix::libc::O_NOFOLLOW | nix::libc::O_CLOEXEC | nix::libc::O_NONBLOCK);
     let mut file = options.open(path)?;
     crate::log_fs::secure_open_log_file_sync(&file, path)?;
     file.write_all(line.as_bytes())
@@ -509,6 +508,34 @@ mod tests {
         assert_eq!(
             std::fs::read_to_string(&target).unwrap(),
             "{\"type\":\"old\"}\n"
+        );
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn append_line_rejects_fifo_without_blocking() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("network.jsonl");
+        let c_path = std::ffi::CString::new(path.as_os_str().as_encoded_bytes()).unwrap();
+        let result = unsafe { libc::mkfifo(c_path.as_ptr(), 0o600) };
+        assert_eq!(
+            result,
+            0,
+            "mkfifo failed: {}",
+            std::io::Error::last_os_error()
+        );
+
+        let (tx, rx) = std::sync::mpsc::channel();
+        let path_for_thread = path.clone();
+        std::thread::spawn(move || {
+            let result = append_line(&path_for_thread, "{\"type\":\"dns\"}\n").is_err();
+            let _ = tx.send(result);
+        });
+
+        assert!(
+            rx.recv_timeout(std::time::Duration::from_secs(1))
+                .expect("append_line should not block on FIFO"),
+            "append_line should reject FIFO paths"
         );
     }
 

--- a/crates/runner/src/network_log_manager.rs
+++ b/crates/runner/src/network_log_manager.rs
@@ -373,12 +373,13 @@ impl NetworkLogManager {
 }
 
 fn append_line(path: &Path, line: &str) -> std::io::Result<()> {
-    std::fs::OpenOptions::new()
+    let mut file = std::fs::OpenOptions::new()
         .create(true)
         .append(true)
-        .mode(0o644)
-        .open(path)
-        .and_then(|mut f| f.write_all(line.as_bytes()))
+        .mode(crate::log_fs::LOG_FILE_MODE)
+        .open(path)?;
+    crate::log_fs::secure_open_log_file_sync(&file, path)?;
+    file.write_all(line.as_bytes())
 }
 
 #[cfg(test)]
@@ -400,6 +401,13 @@ mod tests {
             .lines()
             .map(|line| serde_json::from_str(line).unwrap())
             .collect()
+    }
+
+    #[cfg(unix)]
+    fn file_mode(path: &Path) -> u32 {
+        use std::os::unix::fs::PermissionsExt;
+
+        std::fs::metadata(path).unwrap().permissions().mode() & 0o777
     }
 
     async fn source_ip_registered(manager: &NetworkLogManager, source_ip: &str) -> bool {
@@ -449,6 +457,35 @@ mod tests {
         assert_eq!(lines[0]["type"], "dns");
         assert_eq!(lines[0]["host"], "example.com");
         assert_eq!(lines[0]["port"], 53);
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn append_line_creates_private_log_file() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("network.jsonl");
+
+        append_line(&path, "{\"type\":\"dns\"}\n").unwrap();
+
+        assert_eq!(file_mode(&path), crate::log_fs::LOG_FILE_MODE);
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn append_line_tightens_existing_log_file() {
+        use std::os::unix::fs::PermissionsExt;
+
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("network.jsonl");
+        std::fs::write(&path, "{\"type\":\"old\"}\n").unwrap();
+        std::fs::set_permissions(&path, std::fs::Permissions::from_mode(0o644)).unwrap();
+
+        append_line(&path, "{\"type\":\"dns\"}\n").unwrap();
+
+        assert_eq!(file_mode(&path), crate::log_fs::LOG_FILE_MODE);
+        let content = std::fs::read_to_string(path).unwrap();
+        assert!(content.contains("\"old\""));
+        assert!(content.contains("\"dns\""));
     }
 
     #[tokio::test]

--- a/crates/runner/src/paths.rs
+++ b/crates/runner/src/paths.rs
@@ -190,6 +190,10 @@ impl HomePaths {
         Self { root }
     }
 
+    pub fn root_dir(&self) -> &Path {
+        &self.root
+    }
+
     pub fn bin_dir(&self) -> PathBuf {
         self.root.join("bin")
     }

--- a/crates/runner/src/private_fs.rs
+++ b/crates/runner/src/private_fs.rs
@@ -3,6 +3,7 @@ use std::path::{Component, Path, PathBuf};
 use crate::error::{RunnerError, RunnerResult};
 
 const PRIVATE_DIR_MODE: u32 = 0o700;
+const PRIVATE_FILE_MODE: u32 = 0o600;
 const RESERVED_PRIVATE_DIR_PATHS: &[&str] = &[
     "/",
     "/bin",
@@ -57,6 +58,57 @@ pub async fn ensure_private_dir(path: &Path) -> RunnerResult<()> {
     tokio::fs::create_dir_all(path)
         .await
         .map_err(|e| RunnerError::Config(format!("create private dir {}: {e}", path.display())))
+}
+
+#[cfg(unix)]
+pub async fn write_private_file(path: &Path, content: &[u8]) -> RunnerResult<()> {
+    use std::ffi::OsString;
+    use std::os::unix::fs::PermissionsExt;
+    use tokio::io::AsyncWriteExt;
+
+    let file_name = path.file_name().ok_or_else(|| {
+        RunnerError::Config(format!(
+            "{} does not have a file name; refusing to write private file",
+            path.display()
+        ))
+    })?;
+    let mut tmp_name = OsString::from(".");
+    tmp_name.push(file_name);
+    tmp_name.push(format!(".{}.tmp", uuid::Uuid::new_v4()));
+    let tmp = path.with_file_name(tmp_name);
+
+    let mut options = tokio::fs::OpenOptions::new();
+    options.write(true).create_new(true).mode(PRIVATE_FILE_MODE);
+    let mut file = options.open(&tmp).await.map_err(|e| {
+        RunnerError::Config(format!("open private file tmp {}: {e}", tmp.display()))
+    })?;
+    tokio::fs::set_permissions(&tmp, std::fs::Permissions::from_mode(PRIVATE_FILE_MODE))
+        .await
+        .map_err(|e| {
+            RunnerError::Config(format!("chmod private file tmp {}: {e}", tmp.display()))
+        })?;
+    file.write_all(content).await.map_err(|e| {
+        RunnerError::Config(format!("write private file tmp {}: {e}", tmp.display()))
+    })?;
+    file.flush().await.map_err(|e| {
+        RunnerError::Config(format!("flush private file tmp {}: {e}", tmp.display()))
+    })?;
+    drop(file);
+
+    tokio::fs::rename(&tmp, path)
+        .await
+        .map_err(|e| RunnerError::Config(format!("rename private file {}: {e}", path.display())))?;
+    tokio::fs::set_permissions(path, std::fs::Permissions::from_mode(PRIVATE_FILE_MODE))
+        .await
+        .map_err(|e| RunnerError::Config(format!("chmod private file {}: {e}", path.display())))?;
+    Ok(())
+}
+
+#[cfg(not(unix))]
+pub async fn write_private_file(path: &Path, content: &[u8]) -> RunnerResult<()> {
+    tokio::fs::write(path, content)
+        .await
+        .map_err(|e| RunnerError::Config(format!("write private file {}: {e}", path.display())))
 }
 
 #[cfg(unix)]

--- a/crates/runner/src/private_fs.rs
+++ b/crates/runner/src/private_fs.rs
@@ -1,0 +1,151 @@
+use std::path::Path;
+
+use crate::error::{RunnerError, RunnerResult};
+
+const PRIVATE_DIR_MODE: u32 = 0o700;
+
+/// Ensure `path` is private runtime state for the current runner process.
+///
+/// The runner normally runs as root. This intentionally keeps runtime state
+/// owned by the effective uid instead of chowning it back to `SUDO_USER`.
+#[cfg(unix)]
+pub async fn ensure_private_dir(path: &Path) -> RunnerResult<()> {
+    let mut builder = tokio::fs::DirBuilder::new();
+    builder.recursive(true);
+    builder.mode(PRIVATE_DIR_MODE);
+    match builder.create(path).await {
+        Ok(()) => {}
+        Err(e) if e.kind() == std::io::ErrorKind::AlreadyExists => {}
+        Err(e) => {
+            return Err(RunnerError::Config(format!(
+                "create private dir {}: {e}",
+                path.display()
+            )));
+        }
+    }
+
+    ensure_private_dir_owned_by(path, nix::unistd::geteuid().as_raw()).await
+}
+
+#[cfg(not(unix))]
+pub async fn ensure_private_dir(path: &Path) -> RunnerResult<()> {
+    tokio::fs::create_dir_all(path)
+        .await
+        .map_err(|e| RunnerError::Config(format!("create private dir {}: {e}", path.display())))
+}
+
+#[cfg(unix)]
+async fn ensure_private_dir_owned_by(path: &Path, expected_uid: u32) -> RunnerResult<()> {
+    use std::os::unix::fs::{MetadataExt, PermissionsExt};
+
+    let metadata = tokio::fs::symlink_metadata(path)
+        .await
+        .map_err(|e| RunnerError::Config(format!("stat private dir {}: {e}", path.display())))?;
+    let file_type = metadata.file_type();
+    if file_type.is_symlink() {
+        return Err(RunnerError::Config(format!(
+            "{} is a symlink; refusing to use it as private runner state",
+            path.display()
+        )));
+    }
+    if !file_type.is_dir() {
+        return Err(RunnerError::Config(format!(
+            "{} is not a directory; refusing to use it as private runner state",
+            path.display()
+        )));
+    }
+
+    let actual_uid = metadata.uid();
+    if actual_uid != expected_uid {
+        return Err(RunnerError::Config(format!(
+            "{} is owned by uid {actual_uid}, but runner euid is {expected_uid}; fix ownership before starting the runner",
+            path.display()
+        )));
+    }
+
+    tokio::fs::set_permissions(path, std::fs::Permissions::from_mode(PRIVATE_DIR_MODE))
+        .await
+        .map_err(|e| RunnerError::Config(format!("chmod private dir {}: {e}", path.display())))?;
+    Ok(())
+}
+
+#[cfg(test)]
+#[cfg(unix)]
+mod tests {
+    use super::*;
+    use std::os::unix::fs::{MetadataExt, PermissionsExt, symlink};
+
+    fn mode(path: &Path) -> u32 {
+        std::fs::metadata(path).unwrap().permissions().mode() & 0o777
+    }
+
+    #[tokio::test]
+    async fn ensure_private_dir_creates_missing_dir_with_private_mode() {
+        let dir = tempfile::tempdir().unwrap();
+        let private_dir = dir.path().join("runner");
+
+        ensure_private_dir(&private_dir).await.unwrap();
+
+        assert_eq!(mode(&private_dir), PRIVATE_DIR_MODE);
+    }
+
+    #[tokio::test]
+    async fn ensure_private_dir_tightens_existing_dir() {
+        let dir = tempfile::tempdir().unwrap();
+        let private_dir = dir.path().join("runner");
+        std::fs::create_dir(&private_dir).unwrap();
+        std::fs::set_permissions(&private_dir, std::fs::Permissions::from_mode(0o755)).unwrap();
+
+        ensure_private_dir(&private_dir).await.unwrap();
+
+        assert_eq!(mode(&private_dir), PRIVATE_DIR_MODE);
+    }
+
+    #[tokio::test]
+    async fn ensure_private_dir_rejects_regular_file() {
+        let dir = tempfile::tempdir().unwrap();
+        let private_dir = dir.path().join("runner");
+        std::fs::write(&private_dir, b"not a dir").unwrap();
+
+        let error = ensure_private_dir(&private_dir).await.unwrap_err();
+
+        assert!(
+            error.to_string().contains("not a directory"),
+            "unexpected error: {error}"
+        );
+    }
+
+    #[tokio::test]
+    async fn ensure_private_dir_rejects_symlink() {
+        let dir = tempfile::tempdir().unwrap();
+        let target = dir.path().join("target");
+        let private_dir = dir.path().join("runner");
+        std::fs::create_dir(&target).unwrap();
+        symlink(&target, &private_dir).unwrap();
+
+        let error = ensure_private_dir(&private_dir).await.unwrap_err();
+
+        assert!(
+            error.to_string().contains("symlink"),
+            "unexpected error: {error}"
+        );
+    }
+
+    #[tokio::test]
+    async fn ensure_private_dir_rejects_owner_mismatch() {
+        let dir = tempfile::tempdir().unwrap();
+        let private_dir = dir.path().join("runner");
+        std::fs::create_dir(&private_dir).unwrap();
+        let actual_uid = std::fs::metadata(&private_dir).unwrap().uid();
+        let mismatched_uid = if actual_uid == 0 { 1 } else { 0 };
+
+        let error = ensure_private_dir_owned_by(&private_dir, mismatched_uid)
+            .await
+            .unwrap_err();
+
+        assert!(
+            error.to_string().contains("owned by uid"),
+            "unexpected error: {error}"
+        );
+    }
+}

--- a/crates/runner/src/private_fs.rs
+++ b/crates/runner/src/private_fs.rs
@@ -243,16 +243,30 @@ fn open_or_create_private_dir_component(
     use nix::fcntl::openat;
     use nix::sys::stat::Mode;
 
+    let component_path = private_dir_component_path(parent_path, name);
     ensure_private_dir_parent_not_replaceable(parent, parent_path, full_path, expected_uid)?;
     match openat(parent, name, private_dir_open_flags(), Mode::empty()) {
-        Ok(fd) => Ok(fd),
+        Ok(fd) => {
+            secure_existing_private_dir_component(&fd, &component_path, full_path, expected_uid)?;
+            Ok(fd)
+        }
         Err(Errno::EACCES) => {
             repair_private_dir_parent_for_traversal(parent, parent_path, full_path, expected_uid)?;
-            open_or_create_accessible_private_dir_component(parent, name, parent_path, full_path)
+            open_or_create_accessible_private_dir_component(
+                parent,
+                name,
+                parent_path,
+                full_path,
+                expected_uid,
+            )
         }
-        Err(Errno::ENOENT) => {
-            create_and_open_private_dir_component(parent, name, parent_path, full_path)
-        }
+        Err(Errno::ENOENT) => create_and_open_private_dir_component(
+            parent,
+            name,
+            parent_path,
+            full_path,
+            expected_uid,
+        ),
         Err(e) => Err(private_dir_component_error("open", name, full_path, e)),
     }
 }
@@ -296,16 +310,25 @@ fn open_or_create_accessible_private_dir_component(
     name: &OsStr,
     parent_path: &Path,
     full_path: &Path,
+    expected_uid: u32,
 ) -> RunnerResult<OwnedFd> {
     use nix::errno::Errno;
     use nix::fcntl::openat;
     use nix::sys::stat::Mode;
 
+    let component_path = private_dir_component_path(parent_path, name);
     match openat(parent, name, private_dir_open_flags(), Mode::empty()) {
-        Ok(fd) => Ok(fd),
-        Err(Errno::ENOENT) => {
-            create_and_open_private_dir_component(parent, name, parent_path, full_path)
+        Ok(fd) => {
+            secure_existing_private_dir_component(&fd, &component_path, full_path, expected_uid)?;
+            Ok(fd)
         }
+        Err(Errno::ENOENT) => create_and_open_private_dir_component(
+            parent,
+            name,
+            parent_path,
+            full_path,
+            expected_uid,
+        ),
         Err(e) => Err(private_dir_component_error("open", name, full_path, e)),
     }
 }
@@ -316,6 +339,7 @@ fn create_and_open_private_dir_component(
     name: &OsStr,
     parent_path: &Path,
     full_path: &Path,
+    expected_uid: u32,
 ) -> RunnerResult<OwnedFd> {
     use nix::errno::Errno;
     use nix::fcntl::openat;
@@ -331,9 +355,9 @@ fn create_and_open_private_dir_component(
         )));
     }
 
-    let created = match mkdirat(parent, name, Mode::from_bits_truncate(PRIVATE_DIR_MODE)) {
-        Ok(()) => true,
-        Err(Errno::EEXIST) => false,
+    match mkdirat(parent, name, Mode::from_bits_truncate(PRIVATE_DIR_MODE)) {
+        Ok(()) => {}
+        Err(Errno::EEXIST) => {}
         Err(e) => {
             return Err(RunnerError::Config(format!(
                 "create private dir component {} for {}: {e}",
@@ -344,9 +368,7 @@ fn create_and_open_private_dir_component(
     };
     let fd = openat(parent, name, private_dir_open_flags(), Mode::empty())
         .map_err(|e| private_dir_component_error("open", name, full_path, e))?;
-    if created {
-        chmod_open_private_dir(&fd, full_path)?;
-    }
+    secure_existing_private_dir_component(&fd, &component_path, full_path, expected_uid)?;
     Ok(fd)
 }
 
@@ -355,6 +377,58 @@ fn private_dir_component_path(parent_path: &Path, name: &OsStr) -> PathBuf {
     let mut path = parent_path.to_path_buf();
     path.push(Path::new(name));
     path
+}
+
+#[cfg(unix)]
+fn secure_existing_private_dir_component(
+    fd: &(impl AsFd + AsRawFd),
+    component_path: &Path,
+    full_path: &Path,
+    expected_uid: u32,
+) -> RunnerResult<()> {
+    use nix::sys::stat::{SFlag, fstat};
+
+    let stat = fstat(fd).map_err(|e| {
+        RunnerError::Config(format!(
+            "stat private dir component {} for {}: {e}",
+            component_path.display(),
+            full_path.display()
+        ))
+    })?;
+    let fd_file_type = SFlag::from_bits_truncate(stat.st_mode & SFlag::S_IFMT.bits());
+    if fd_file_type != SFlag::S_IFDIR {
+        return Err(RunnerError::Config(format!(
+            "{} is not a directory; refusing to use it as private runner state",
+            full_path.display()
+        )));
+    }
+
+    let normalized_component = normalize_private_dir_policy_path(component_path)?;
+    if is_reserved_normalized_private_dir_path(&normalized_component) {
+        return Ok(());
+    }
+
+    let actual_uid = stat.st_uid;
+    if actual_uid != expected_uid {
+        return Err(RunnerError::Config(format!(
+            "private dir component {} for {} is owned by uid {actual_uid}, but runner euid is {expected_uid}; fix ownership before starting the runner",
+            component_path.display(),
+            full_path.display()
+        )));
+    }
+
+    let mode = (stat.st_mode as u32) & 0o7777;
+    if mode & GROUP_OR_OTHER_WRITE_BITS != 0 && mode & STICKY_BIT == 0 {
+        return Err(RunnerError::Config(format!(
+            "private dir component {} for {} is group/other writable without the sticky bit; fix permissions before starting the runner",
+            component_path.display(),
+            full_path.display()
+        )));
+    }
+    if mode != PRIVATE_DIR_MODE {
+        chmod_open_private_dir(fd, component_path)?;
+    }
+    Ok(())
 }
 
 #[cfg(unix)]
@@ -610,6 +684,20 @@ mod tests {
         assert_eq!(mode(&private_dir), PRIVATE_DIR_MODE);
     }
 
+    #[tokio::test]
+    async fn ensure_private_dir_tightens_existing_intermediate_dir() {
+        let dir = tempfile::tempdir().unwrap();
+        let intermediate = dir.path().join("nested");
+        let private_dir = intermediate.join("runner");
+        std::fs::create_dir(&intermediate).unwrap();
+        std::fs::set_permissions(&intermediate, std::fs::Permissions::from_mode(0o755)).unwrap();
+
+        ensure_private_dir(&private_dir).await.unwrap();
+
+        assert_eq!(mode(&intermediate), PRIVATE_DIR_MODE);
+        assert_eq!(mode(&private_dir), PRIVATE_DIR_MODE);
+    }
+
     #[cfg(target_os = "linux")]
     #[tokio::test]
     async fn ensure_private_dir_repairs_unreadable_existing_dir() {
@@ -678,6 +766,7 @@ mod tests {
             OsStr::new("runners"),
             Path::new("/var/lib/vm0-runner"),
             Path::new("/var/lib/vm0-runner/runners/runner-01"),
+            nix::unistd::geteuid().as_raw(),
         )
         .unwrap_err();
 

--- a/crates/runner/src/private_fs.rs
+++ b/crates/runner/src/private_fs.rs
@@ -185,6 +185,7 @@ fn ensure_private_dir_exists_without_symlinks(
     let mut current = open(start, private_dir_open_flags(), Mode::empty()).map_err(|e| {
         RunnerError::Config(format!("open private dir root for {}: {e}", path.display()))
     })?;
+    let mut current_path = start.to_path_buf();
     for component in path.components() {
         match component {
             Component::RootDir | Component::CurDir => {}
@@ -195,7 +196,14 @@ fn ensure_private_dir_exists_without_symlinks(
                 )));
             }
             Component::Normal(name) => {
-                current = open_or_create_private_dir_component(&current, name, path, expected_uid)?;
+                current = open_or_create_private_dir_component(
+                    &current,
+                    name,
+                    &current_path,
+                    path,
+                    expected_uid,
+                )?;
+                current_path.push(Path::new(name));
             }
             Component::Prefix(prefix) => {
                 return Err(RunnerError::Config(format!(
@@ -214,6 +222,7 @@ fn ensure_private_dir_exists_without_symlinks(
 fn open_or_create_private_dir_component(
     parent: &(impl AsFd + AsRawFd),
     name: &OsStr,
+    parent_path: &Path,
     full_path: &Path,
     expected_uid: u32,
 ) -> RunnerResult<OwnedFd> {
@@ -224,7 +233,7 @@ fn open_or_create_private_dir_component(
     match openat(parent, name, private_dir_open_flags(), Mode::empty()) {
         Ok(fd) => Ok(fd),
         Err(Errno::EACCES) => {
-            repair_private_dir_parent_for_traversal(parent, full_path, expected_uid)?;
+            repair_private_dir_parent_for_traversal(parent, parent_path, full_path, expected_uid)?;
             open_or_create_accessible_private_dir_component(parent, name, full_path)
         }
         Err(Errno::ENOENT) => create_and_open_private_dir_component(parent, name, full_path),
@@ -281,10 +290,20 @@ fn create_and_open_private_dir_component(
 #[cfg(unix)]
 fn repair_private_dir_parent_for_traversal(
     parent: &(impl AsFd + AsRawFd),
+    parent_path: &Path,
     full_path: &Path,
     expected_uid: u32,
 ) -> RunnerResult<()> {
     use nix::sys::stat::fstat;
+
+    let normalized_parent = normalize_private_dir_policy_path(parent_path)?;
+    if is_reserved_normalized_private_dir_path(&normalized_parent) {
+        return Err(RunnerError::Config(format!(
+            "{} requires traversing reserved system path {}; fix parent permissions before starting the runner",
+            full_path.display(),
+            parent_path.display()
+        )));
+    }
 
     let stat = fstat(parent).map_err(|e| {
         RunnerError::Config(format!(
@@ -427,19 +446,23 @@ fn reject_reserved_normalized_private_dir_path(
     original: &Path,
     normalized: &Path,
 ) -> RunnerResult<()> {
-    if RESERVED_PRIVATE_DIR_PATHS
-        .iter()
-        .any(|reserved| normalized == Path::new(reserved))
-        || RESERVED_PRIVATE_DIR_SUBTREES
-            .iter()
-            .any(|reserved| normalized.starts_with(Path::new(reserved)))
-    {
+    if is_reserved_normalized_private_dir_path(normalized) {
         return Err(RunnerError::Config(format!(
             "{} is a reserved system path; refusing to use it as private runner state",
             original.display()
         )));
     }
     Ok(())
+}
+
+#[cfg(unix)]
+fn is_reserved_normalized_private_dir_path(normalized: &Path) -> bool {
+    RESERVED_PRIVATE_DIR_PATHS
+        .iter()
+        .any(|reserved| normalized == Path::new(reserved))
+        || RESERVED_PRIVATE_DIR_SUBTREES
+            .iter()
+            .any(|reserved| normalized.starts_with(Path::new(reserved)))
 }
 
 #[cfg(unix)]
@@ -543,6 +566,33 @@ mod tests {
 
         assert_eq!(mode(&intermediate), PRIVATE_DIR_MODE);
         assert_eq!(mode(&private_dir), PRIVATE_DIR_MODE);
+    }
+
+    #[cfg(target_os = "linux")]
+    #[test]
+    fn repair_private_dir_parent_rejects_reserved_parent() {
+        use nix::fcntl::open;
+        use nix::sys::stat::Mode;
+
+        let dir = tempfile::tempdir().unwrap();
+        let parent = dir.path().join("parent");
+        std::fs::create_dir(&parent).unwrap();
+        std::fs::set_permissions(&parent, std::fs::Permissions::from_mode(0o000)).unwrap();
+        let fd = open(&parent, private_dir_open_flags(), Mode::empty()).unwrap();
+
+        let error = repair_private_dir_parent_for_traversal(
+            &fd,
+            Path::new("/var/lib/vm0-runner/runners"),
+            &parent.join("runner"),
+            nix::unistd::geteuid().as_raw(),
+        )
+        .unwrap_err();
+
+        assert!(
+            error.to_string().contains("reserved system path"),
+            "unexpected error: {error}"
+        );
+        assert_eq!(mode(&parent), 0o000);
     }
 
     #[tokio::test]

--- a/crates/runner/src/private_fs.rs
+++ b/crates/runner/src/private_fs.rs
@@ -1,5 +1,5 @@
 use std::ffi::OsStr;
-use std::os::fd::{AsFd, OwnedFd};
+use std::os::fd::{AsFd, AsRawFd, OwnedFd};
 use std::path::{Component, Path, PathBuf};
 
 use crate::error::{RunnerError, RunnerResult};
@@ -52,8 +52,9 @@ pub async fn ensure_private_dir(path: &Path) -> RunnerResult<()> {
     reject_reserved_private_dir_path(path)?;
     reject_parent_dir_components(path)?;
     reject_existing_symlink_components(path).await?;
-    let fd = ensure_private_dir_exists_without_symlinks(path)?;
-    ensure_private_dir_fd_owned_by(path, &fd, nix::unistd::geteuid().as_raw())
+    let expected_uid = nix::unistd::geteuid().as_raw();
+    let fd = ensure_private_dir_exists_without_symlinks(path, expected_uid)?;
+    ensure_private_dir_fd_owned_by(path, &fd, expected_uid)
 }
 
 #[cfg(not(unix))]
@@ -85,6 +86,7 @@ async fn reject_existing_symlink_components(path: &Path) -> RunnerResult<()> {
         let metadata = match tokio::fs::symlink_metadata(&current).await {
             Ok(metadata) => metadata,
             Err(e) if e.kind() == std::io::ErrorKind::NotFound => return Ok(()),
+            Err(e) if e.kind() == std::io::ErrorKind::PermissionDenied => return Ok(()),
             Err(e) if e.kind() == std::io::ErrorKind::NotADirectory => {
                 return Err(RunnerError::Config(format!(
                     "{} is not a directory; refusing to use it as private runner state",
@@ -161,7 +163,10 @@ pub async fn write_private_file(path: &Path, content: &[u8]) -> RunnerResult<()>
 }
 
 #[cfg(unix)]
-fn ensure_private_dir_exists_without_symlinks(path: &Path) -> RunnerResult<OwnedFd> {
+fn ensure_private_dir_exists_without_symlinks(
+    path: &Path,
+    expected_uid: u32,
+) -> RunnerResult<OwnedFd> {
     use nix::fcntl::open;
     use nix::sys::stat::Mode;
 
@@ -190,7 +195,7 @@ fn ensure_private_dir_exists_without_symlinks(path: &Path) -> RunnerResult<Owned
                 )));
             }
             Component::Normal(name) => {
-                current = open_or_create_private_dir_component(&current, name, path)?;
+                current = open_or_create_private_dir_component(&current, name, path, expected_uid)?;
             }
             Component::Prefix(prefix) => {
                 return Err(RunnerError::Config(format!(
@@ -207,7 +212,46 @@ fn ensure_private_dir_exists_without_symlinks(path: &Path) -> RunnerResult<Owned
 
 #[cfg(unix)]
 fn open_or_create_private_dir_component(
-    parent: &impl AsFd,
+    parent: &(impl AsFd + AsRawFd),
+    name: &OsStr,
+    full_path: &Path,
+    expected_uid: u32,
+) -> RunnerResult<OwnedFd> {
+    use nix::errno::Errno;
+    use nix::fcntl::openat;
+    use nix::sys::stat::Mode;
+
+    match openat(parent, name, private_dir_open_flags(), Mode::empty()) {
+        Ok(fd) => Ok(fd),
+        Err(Errno::EACCES) => {
+            repair_private_dir_parent_for_traversal(parent, full_path, expected_uid)?;
+            open_or_create_accessible_private_dir_component(parent, name, full_path)
+        }
+        Err(Errno::ENOENT) => create_and_open_private_dir_component(parent, name, full_path),
+        Err(e) => Err(private_dir_component_error("open", name, full_path, e)),
+    }
+}
+
+#[cfg(unix)]
+fn open_or_create_accessible_private_dir_component(
+    parent: &(impl AsFd + AsRawFd),
+    name: &OsStr,
+    full_path: &Path,
+) -> RunnerResult<OwnedFd> {
+    use nix::errno::Errno;
+    use nix::fcntl::openat;
+    use nix::sys::stat::Mode;
+
+    match openat(parent, name, private_dir_open_flags(), Mode::empty()) {
+        Ok(fd) => Ok(fd),
+        Err(Errno::ENOENT) => create_and_open_private_dir_component(parent, name, full_path),
+        Err(e) => Err(private_dir_component_error("open", name, full_path, e)),
+    }
+}
+
+#[cfg(unix)]
+fn create_and_open_private_dir_component(
+    parent: &(impl AsFd + AsRawFd),
     name: &OsStr,
     full_path: &Path,
 ) -> RunnerResult<OwnedFd> {
@@ -215,29 +259,47 @@ fn open_or_create_private_dir_component(
     use nix::fcntl::openat;
     use nix::sys::stat::{Mode, mkdirat};
 
-    match openat(parent, name, private_dir_open_flags(), Mode::empty()) {
-        Ok(fd) => Ok(fd),
-        Err(Errno::ENOENT) => {
-            let created = match mkdirat(parent, name, Mode::from_bits_truncate(PRIVATE_DIR_MODE)) {
-                Ok(()) => true,
-                Err(Errno::EEXIST) => false,
-                Err(e) => {
-                    return Err(RunnerError::Config(format!(
-                        "create private dir component {} for {}: {e}",
-                        name.to_string_lossy(),
-                        full_path.display()
-                    )));
-                }
-            };
-            let fd = openat(parent, name, private_dir_open_flags(), Mode::empty())
-                .map_err(|e| private_dir_component_error("open", name, full_path, e))?;
-            if created {
-                chmod_open_private_dir(&fd, full_path)?;
-            }
-            Ok(fd)
+    let created = match mkdirat(parent, name, Mode::from_bits_truncate(PRIVATE_DIR_MODE)) {
+        Ok(()) => true,
+        Err(Errno::EEXIST) => false,
+        Err(e) => {
+            return Err(RunnerError::Config(format!(
+                "create private dir component {} for {}: {e}",
+                name.to_string_lossy(),
+                full_path.display()
+            )));
         }
-        Err(e) => Err(private_dir_component_error("open", name, full_path, e)),
+    };
+    let fd = openat(parent, name, private_dir_open_flags(), Mode::empty())
+        .map_err(|e| private_dir_component_error("open", name, full_path, e))?;
+    if created {
+        chmod_open_private_dir(&fd, full_path)?;
     }
+    Ok(fd)
+}
+
+#[cfg(unix)]
+fn repair_private_dir_parent_for_traversal(
+    parent: &(impl AsFd + AsRawFd),
+    full_path: &Path,
+    expected_uid: u32,
+) -> RunnerResult<()> {
+    use nix::sys::stat::fstat;
+
+    let stat = fstat(parent).map_err(|e| {
+        RunnerError::Config(format!(
+            "stat private dir parent for {}: {e}",
+            full_path.display()
+        ))
+    })?;
+    if stat.st_uid != expected_uid {
+        return Err(RunnerError::Config(format!(
+            "private dir parent for {} is owned by uid {}, but runner euid is {expected_uid}; fix ownership before starting the runner",
+            full_path.display(),
+            stat.st_uid
+        )));
+    }
+    chmod_open_private_dir(parent, full_path)
 }
 
 #[cfg(unix)]
@@ -468,6 +530,21 @@ mod tests {
         assert_eq!(mode(&private_dir), PRIVATE_DIR_MODE);
     }
 
+    #[cfg(target_os = "linux")]
+    #[tokio::test]
+    async fn ensure_private_dir_repairs_unreadable_existing_intermediate_dir() {
+        let dir = tempfile::tempdir().unwrap();
+        let intermediate = dir.path().join("nested");
+        let private_dir = intermediate.join("runner");
+        std::fs::create_dir(&intermediate).unwrap();
+        std::fs::set_permissions(&intermediate, std::fs::Permissions::from_mode(0o000)).unwrap();
+
+        ensure_private_dir(&private_dir).await.unwrap();
+
+        assert_eq!(mode(&intermediate), PRIVATE_DIR_MODE);
+        assert_eq!(mode(&private_dir), PRIVATE_DIR_MODE);
+    }
+
     #[tokio::test]
     async fn ensure_private_dir_rejects_regular_file() {
         let dir = tempfile::tempdir().unwrap();
@@ -553,6 +630,32 @@ mod tests {
         );
     }
 
+    #[cfg(target_os = "linux")]
+    #[tokio::test]
+    async fn ensure_private_dir_rejects_symlink_under_unreadable_intermediate_dir() {
+        let dir = tempfile::tempdir().unwrap();
+        let intermediate = dir.path().join("nested");
+        let target = dir.path().join("target");
+        let link = intermediate.join("link");
+        let private_dir = link.join("runner");
+        std::fs::create_dir(&intermediate).unwrap();
+        std::fs::create_dir(&target).unwrap();
+        symlink(&target, &link).unwrap();
+        std::fs::set_permissions(&intermediate, std::fs::Permissions::from_mode(0o000)).unwrap();
+
+        let error = ensure_private_dir(&private_dir).await.unwrap_err();
+        let message = error.to_string();
+
+        assert!(
+            message.contains("symlink component") || message.contains("not a directory"),
+            "unexpected error: {error}"
+        );
+        assert!(
+            !target.join("runner").exists(),
+            "private dir should not be created through a symlink hidden by an unreadable parent"
+        );
+    }
+
     #[tokio::test]
     async fn ensure_private_dir_rejects_parent_segments_before_creating_prefix() {
         let dir = tempfile::tempdir().unwrap();
@@ -633,7 +736,11 @@ mod tests {
         let actual_uid = std::fs::metadata(&private_dir).unwrap().uid();
         let mismatched_uid = if actual_uid == 0 { 1 } else { 0 };
 
-        let fd = ensure_private_dir_exists_without_symlinks(&private_dir).unwrap();
+        let fd = ensure_private_dir_exists_without_symlinks(
+            &private_dir,
+            nix::unistd::geteuid().as_raw(),
+        )
+        .unwrap();
         let error = ensure_private_dir_fd_owned_by(&private_dir, &fd, mismatched_uid).unwrap_err();
 
         assert!(

--- a/crates/runner/src/private_fs.rs
+++ b/crates/runner/src/private_fs.rs
@@ -10,6 +10,7 @@ const GROUP_OR_OTHER_WRITE_BITS: u32 = 0o022;
 const ROOT_UID: u32 = 0;
 const STICKY_BIT: u32 = 0o1000;
 const PRIVATE_FILE_READ_MAX_BYTES: u64 = 64 * 1024;
+pub(crate) const PRIVATE_STATUS_FILE_READ_MAX_BYTES: u64 = 1024 * 1024;
 const RESERVED_PRIVATE_DIR_PATHS: &[&str] = &[
     "/",
     "/bin",
@@ -117,6 +118,14 @@ async fn reject_existing_symlink_components(path: &Path) -> RunnerResult<()> {
 
 #[cfg(unix)]
 pub async fn read_private_file_to_string(path: &Path) -> RunnerResult<Option<String>> {
+    read_private_file_to_string_with_max(path, PRIVATE_FILE_READ_MAX_BYTES).await
+}
+
+#[cfg(unix)]
+pub async fn read_private_file_to_string_with_max(
+    path: &Path,
+    max_bytes: u64,
+) -> RunnerResult<Option<String>> {
     let mut options = tokio::fs::OpenOptions::new();
     options
         .read(true)
@@ -132,30 +141,49 @@ pub async fn read_private_file_to_string(path: &Path) -> RunnerResult<Option<Str
         }
     };
     secure_open_private_file(&file, path)?;
-    read_private_file_contents(file, path).await.map(Some)
+    read_private_file_contents(file, path, max_bytes)
+        .await
+        .map(Some)
 }
 
-async fn read_private_file_contents(file: tokio::fs::File, path: &Path) -> RunnerResult<String> {
+async fn read_private_file_contents(
+    file: tokio::fs::File,
+    path: &Path,
+    max_bytes: u64,
+) -> RunnerResult<String> {
     use tokio::io::AsyncReadExt;
 
-    let mut limited = file.take(PRIVATE_FILE_READ_MAX_BYTES + 1);
-    let mut contents = String::new();
+    let mut limited = file.take(max_bytes + 1);
+    let mut contents = Vec::new();
     limited
-        .read_to_string(&mut contents)
+        .read_to_end(&mut contents)
         .await
         .map_err(|e| RunnerError::Config(format!("read private file {}: {e}", path.display())))?;
-    if contents.len() as u64 > PRIVATE_FILE_READ_MAX_BYTES {
+    if contents.len() as u64 > max_bytes {
         return Err(RunnerError::Config(format!(
             "private file {} exceeds {} bytes",
             path.display(),
-            PRIVATE_FILE_READ_MAX_BYTES
+            max_bytes
         )));
     }
-    Ok(contents)
+    String::from_utf8(contents).map_err(|e| {
+        RunnerError::Config(format!(
+            "read private file {} as UTF-8: {e}",
+            path.display()
+        ))
+    })
 }
 
 #[cfg(not(unix))]
 pub async fn read_private_file_to_string(path: &Path) -> RunnerResult<Option<String>> {
+    read_private_file_to_string_with_max(path, PRIVATE_FILE_READ_MAX_BYTES).await
+}
+
+#[cfg(not(unix))]
+pub async fn read_private_file_to_string_with_max(
+    path: &Path,
+    max_bytes: u64,
+) -> RunnerResult<Option<String>> {
     let file = match tokio::fs::File::open(path).await {
         Ok(file) => file,
         Err(e) if e.kind() == std::io::ErrorKind::NotFound => return Ok(None),
@@ -166,7 +194,9 @@ pub async fn read_private_file_to_string(path: &Path) -> RunnerResult<Option<Str
             )));
         }
     };
-    read_private_file_contents(file, path).await.map(Some)
+    read_private_file_contents(file, path, max_bytes)
+        .await
+        .map(Some)
 }
 
 #[cfg(unix)]

--- a/crates/runner/src/private_fs.rs
+++ b/crates/runner/src/private_fs.rs
@@ -131,31 +131,41 @@ pub async fn write_private_file(path: &Path, content: &[u8]) -> RunnerResult<()>
     tmp_name.push(format!(".{}.tmp", uuid::Uuid::new_v4()));
     let tmp = path.with_file_name(tmp_name);
 
-    let mut options = tokio::fs::OpenOptions::new();
-    options.write(true).create_new(true).mode(PRIVATE_FILE_MODE);
-    let mut file = options.open(&tmp).await.map_err(|e| {
-        RunnerError::Config(format!("open private file tmp {}: {e}", tmp.display()))
-    })?;
-    tokio::fs::set_permissions(&tmp, std::fs::Permissions::from_mode(PRIVATE_FILE_MODE))
-        .await
-        .map_err(|e| {
-            RunnerError::Config(format!("chmod private file tmp {}: {e}", tmp.display()))
+    let result = async {
+        let mut options = tokio::fs::OpenOptions::new();
+        options.write(true).create_new(true).mode(PRIVATE_FILE_MODE);
+        let mut file = options.open(&tmp).await.map_err(|e| {
+            RunnerError::Config(format!("open private file tmp {}: {e}", tmp.display()))
         })?;
-    file.write_all(content).await.map_err(|e| {
-        RunnerError::Config(format!("write private file tmp {}: {e}", tmp.display()))
-    })?;
-    file.flush().await.map_err(|e| {
-        RunnerError::Config(format!("flush private file tmp {}: {e}", tmp.display()))
-    })?;
-    drop(file);
+        tokio::fs::set_permissions(&tmp, std::fs::Permissions::from_mode(PRIVATE_FILE_MODE))
+            .await
+            .map_err(|e| {
+                RunnerError::Config(format!("chmod private file tmp {}: {e}", tmp.display()))
+            })?;
+        file.write_all(content).await.map_err(|e| {
+            RunnerError::Config(format!("write private file tmp {}: {e}", tmp.display()))
+        })?;
+        file.flush().await.map_err(|e| {
+            RunnerError::Config(format!("flush private file tmp {}: {e}", tmp.display()))
+        })?;
+        drop(file);
 
-    tokio::fs::rename(&tmp, path)
-        .await
-        .map_err(|e| RunnerError::Config(format!("rename private file {}: {e}", path.display())))?;
-    tokio::fs::set_permissions(path, std::fs::Permissions::from_mode(PRIVATE_FILE_MODE))
-        .await
-        .map_err(|e| RunnerError::Config(format!("chmod private file {}: {e}", path.display())))?;
-    Ok(())
+        tokio::fs::rename(&tmp, path).await.map_err(|e| {
+            RunnerError::Config(format!("rename private file {}: {e}", path.display()))
+        })?;
+        tokio::fs::set_permissions(path, std::fs::Permissions::from_mode(PRIVATE_FILE_MODE))
+            .await
+            .map_err(|e| {
+                RunnerError::Config(format!("chmod private file {}: {e}", path.display()))
+            })?;
+        Ok(())
+    }
+    .await;
+
+    if result.is_err() {
+        let _ = tokio::fs::remove_file(&tmp).await;
+    }
+    result
 }
 
 #[cfg(not(unix))]
@@ -962,5 +972,33 @@ mod tests {
             error.to_string().contains("owned by uid"),
             "unexpected error: {error}"
         );
+    }
+
+    #[tokio::test]
+    async fn write_private_file_removes_tmp_after_rename_failure() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("runner.yaml");
+        std::fs::create_dir(&path).unwrap();
+
+        let error = write_private_file(&path, b"secret").await.unwrap_err();
+
+        assert!(
+            error.to_string().contains("rename private file"),
+            "unexpected error: {error}"
+        );
+        let leftover_tmp_files: Vec<_> = std::fs::read_dir(dir.path())
+            .unwrap()
+            .filter_map(Result::ok)
+            .filter(|entry| {
+                let name = entry.file_name();
+                let name = name.to_string_lossy();
+                name.starts_with(".runner.yaml.") && name.ends_with(".tmp")
+            })
+            .collect();
+        assert!(
+            leftover_tmp_files.is_empty(),
+            "private file tmp should be removed after rename failure"
+        );
+        assert!(path.is_dir());
     }
 }

--- a/crates/runner/src/private_fs.rs
+++ b/crates/runner/src/private_fs.rs
@@ -203,7 +203,7 @@ fn ensure_private_dir_exists_without_symlinks(
                     path,
                     expected_uid,
                 )?;
-                current_path.push(Path::new(name));
+                current_path = private_dir_component_path(&current_path, name);
             }
             Component::Prefix(prefix) => {
                 return Err(RunnerError::Config(format!(
@@ -234,9 +234,11 @@ fn open_or_create_private_dir_component(
         Ok(fd) => Ok(fd),
         Err(Errno::EACCES) => {
             repair_private_dir_parent_for_traversal(parent, parent_path, full_path, expected_uid)?;
-            open_or_create_accessible_private_dir_component(parent, name, full_path)
+            open_or_create_accessible_private_dir_component(parent, name, parent_path, full_path)
         }
-        Err(Errno::ENOENT) => create_and_open_private_dir_component(parent, name, full_path),
+        Err(Errno::ENOENT) => {
+            create_and_open_private_dir_component(parent, name, parent_path, full_path)
+        }
         Err(e) => Err(private_dir_component_error("open", name, full_path, e)),
     }
 }
@@ -245,6 +247,7 @@ fn open_or_create_private_dir_component(
 fn open_or_create_accessible_private_dir_component(
     parent: &(impl AsFd + AsRawFd),
     name: &OsStr,
+    parent_path: &Path,
     full_path: &Path,
 ) -> RunnerResult<OwnedFd> {
     use nix::errno::Errno;
@@ -253,7 +256,9 @@ fn open_or_create_accessible_private_dir_component(
 
     match openat(parent, name, private_dir_open_flags(), Mode::empty()) {
         Ok(fd) => Ok(fd),
-        Err(Errno::ENOENT) => create_and_open_private_dir_component(parent, name, full_path),
+        Err(Errno::ENOENT) => {
+            create_and_open_private_dir_component(parent, name, parent_path, full_path)
+        }
         Err(e) => Err(private_dir_component_error("open", name, full_path, e)),
     }
 }
@@ -262,11 +267,22 @@ fn open_or_create_accessible_private_dir_component(
 fn create_and_open_private_dir_component(
     parent: &(impl AsFd + AsRawFd),
     name: &OsStr,
+    parent_path: &Path,
     full_path: &Path,
 ) -> RunnerResult<OwnedFd> {
     use nix::errno::Errno;
     use nix::fcntl::openat;
     use nix::sys::stat::{Mode, mkdirat};
+
+    let component_path = private_dir_component_path(parent_path, name);
+    let normalized_component = normalize_private_dir_policy_path(&component_path)?;
+    if is_reserved_normalized_private_dir_path(&normalized_component) {
+        return Err(RunnerError::Config(format!(
+            "{} requires creating reserved system path {}; create runner home directories before starting the runner",
+            full_path.display(),
+            component_path.display()
+        )));
+    }
 
     let created = match mkdirat(parent, name, Mode::from_bits_truncate(PRIVATE_DIR_MODE)) {
         Ok(()) => true,
@@ -285,6 +301,13 @@ fn create_and_open_private_dir_component(
         chmod_open_private_dir(&fd, full_path)?;
     }
     Ok(fd)
+}
+
+#[cfg(unix)]
+fn private_dir_component_path(parent_path: &Path, name: &OsStr) -> PathBuf {
+    let mut path = parent_path.to_path_buf();
+    path.push(Path::new(name));
+    path
 }
 
 #[cfg(unix)]
@@ -593,6 +616,32 @@ mod tests {
             "unexpected error: {error}"
         );
         assert_eq!(mode(&parent), 0o000);
+    }
+
+    #[test]
+    fn create_private_dir_component_rejects_reserved_component() {
+        use nix::fcntl::open;
+        use nix::sys::stat::Mode;
+
+        let dir = tempfile::tempdir().unwrap();
+        let fd = open(dir.path(), private_dir_open_flags(), Mode::empty()).unwrap();
+
+        let error = create_and_open_private_dir_component(
+            &fd,
+            OsStr::new("runners"),
+            Path::new("/var/lib/vm0-runner"),
+            Path::new("/var/lib/vm0-runner/runners/runner-01"),
+        )
+        .unwrap_err();
+
+        assert!(
+            error.to_string().contains("reserved system path"),
+            "unexpected error: {error}"
+        );
+        assert!(
+            !dir.path().join("runners").exists(),
+            "reserved component should not be created"
+        );
     }
 
     #[tokio::test]

--- a/crates/runner/src/private_fs.rs
+++ b/crates/runner/src/private_fs.rs
@@ -35,6 +35,7 @@ const RESERVED_PRIVATE_DIR_PATHS: &[&str] = &[
 #[cfg(unix)]
 pub async fn ensure_private_dir(path: &Path) -> RunnerResult<()> {
     reject_reserved_private_dir_path(path)?;
+    reject_parent_dir_components(path)?;
     reject_existing_symlink_components(path).await?;
 
     let mut builder = tokio::fs::DirBuilder::new();
@@ -59,6 +60,20 @@ pub async fn ensure_private_dir(path: &Path) -> RunnerResult<()> {
     tokio::fs::create_dir_all(path)
         .await
         .map_err(|e| RunnerError::Config(format!("create private dir {}: {e}", path.display())))
+}
+
+#[cfg(unix)]
+fn reject_parent_dir_components(path: &Path) -> RunnerResult<()> {
+    if path
+        .components()
+        .any(|component| matches!(component, Component::ParentDir))
+    {
+        return Err(RunnerError::Config(format!(
+            "{} contains a parent directory segment; refusing to use it as private runner state",
+            path.display()
+        )));
+    }
+    Ok(())
 }
 
 #[cfg(unix)]
@@ -368,6 +383,24 @@ mod tests {
         assert!(
             !target.join("runner").exists(),
             "private dir should not be created through an intermediate symlink"
+        );
+    }
+
+    #[tokio::test]
+    async fn ensure_private_dir_rejects_parent_segments_before_creating_prefix() {
+        let dir = tempfile::tempdir().unwrap();
+        let missing = dir.path().join("missing-prefix");
+        let private_dir = missing.join("..").join("runner");
+
+        let error = ensure_private_dir(&private_dir).await.unwrap_err();
+
+        assert!(
+            error.to_string().contains("parent directory segment"),
+            "unexpected error: {error}"
+        );
+        assert!(
+            !missing.exists(),
+            "private dir validation should not create path prefixes before rejecting parent segments"
         );
     }
 

--- a/crates/runner/src/private_fs.rs
+++ b/crates/runner/src/private_fs.rs
@@ -111,14 +111,47 @@ fn path_for_final_component_lstat(path: &Path) -> PathBuf {
 
 #[cfg(unix)]
 fn reject_reserved_private_dir_path(path: &Path) -> RunnerResult<()> {
-    let normalized = normalize_path_lexically(path);
+    let normalized = normalize_private_dir_policy_path(path)?;
+    reject_reserved_normalized_private_dir_path(path, &normalized)
+}
+
+#[cfg(unix)]
+fn normalize_private_dir_policy_path(path: &Path) -> RunnerResult<PathBuf> {
+    let path = if path.is_relative() {
+        std::env::current_dir()
+            .map_err(|e| {
+                RunnerError::Config(format!("resolve private dir {}: {e}", path.display()))
+            })?
+            .join(path)
+    } else {
+        path.to_path_buf()
+    };
+    Ok(normalize_path_lexically(&path))
+}
+
+#[cfg(test)]
+#[cfg(unix)]
+fn reject_reserved_private_dir_path_with_cwd(path: &Path, cwd: &Path) -> RunnerResult<()> {
+    let normalized = normalize_path_lexically(&if path.is_relative() {
+        cwd.join(path)
+    } else {
+        path.to_path_buf()
+    });
+    reject_reserved_normalized_private_dir_path(path, &normalized)
+}
+
+#[cfg(unix)]
+fn reject_reserved_normalized_private_dir_path(
+    original: &Path,
+    normalized: &Path,
+) -> RunnerResult<()> {
     if RESERVED_PRIVATE_DIR_PATHS
         .iter()
         .any(|reserved| normalized == Path::new(reserved))
     {
         return Err(RunnerError::Config(format!(
             "{} is a reserved system path; refusing to use it as private runner state",
-            path.display()
+            original.display()
         )));
     }
     Ok(())
@@ -242,6 +275,21 @@ mod tests {
     fn reserved_private_dir_path_rejects_lexical_parent_segments() {
         for path in ["/var/lib/../lib", "/..", "/var/../.."] {
             let error = reject_reserved_private_dir_path(Path::new(path))
+                .expect_err("reserved path should be rejected");
+
+            assert!(
+                error.to_string().contains("reserved system path"),
+                "unexpected error for {path}: {error}"
+            );
+        }
+    }
+
+    #[test]
+    fn reserved_private_dir_path_rejects_relative_escape_from_cwd() {
+        let cwd = Path::new("/var/lib/vm0-runner/runners/runner-01");
+
+        for path in ["..", "../../.."] {
+            let error = reject_reserved_private_dir_path_with_cwd(Path::new(path), cwd)
                 .expect_err("reserved path should be rejected");
 
             assert!(

--- a/crates/runner/src/private_fs.rs
+++ b/crates/runner/src/private_fs.rs
@@ -202,7 +202,6 @@ pub async fn read_private_file_to_string_with_max(
 #[cfg(unix)]
 pub async fn write_private_file(path: &Path, content: &[u8]) -> RunnerResult<()> {
     use std::ffi::OsString;
-    use std::os::unix::fs::PermissionsExt;
     use tokio::io::AsyncWriteExt;
 
     let file_name = path.file_name().ok_or_else(|| {
@@ -222,11 +221,7 @@ pub async fn write_private_file(path: &Path, content: &[u8]) -> RunnerResult<()>
         let mut file = options.open(&tmp).await.map_err(|e| {
             RunnerError::Config(format!("open private file tmp {}: {e}", tmp.display()))
         })?;
-        tokio::fs::set_permissions(&tmp, std::fs::Permissions::from_mode(PRIVATE_FILE_MODE))
-            .await
-            .map_err(|e| {
-                RunnerError::Config(format!("chmod private file tmp {}: {e}", tmp.display()))
-            })?;
+        chmod_private_file_fd(&file, &tmp)?;
         file.write_all(content).await.map_err(|e| {
             RunnerError::Config(format!("write private file tmp {}: {e}", tmp.display()))
         })?;
@@ -238,11 +233,6 @@ pub async fn write_private_file(path: &Path, content: &[u8]) -> RunnerResult<()>
         tokio::fs::rename(&tmp, path).await.map_err(|e| {
             RunnerError::Config(format!("rename private file {}: {e}", path.display()))
         })?;
-        tokio::fs::set_permissions(path, std::fs::Permissions::from_mode(PRIVATE_FILE_MODE))
-            .await
-            .map_err(|e| {
-                RunnerError::Config(format!("chmod private file {}: {e}", path.display()))
-            })?;
         Ok(())
     }
     .await;
@@ -638,6 +628,11 @@ fn secure_open_private_file<Fd: std::os::fd::AsRawFd>(file: &Fd, path: &Path) ->
     if mode == PRIVATE_FILE_MODE {
         return Ok(());
     }
+    chmod_private_file_fd(file, path)
+}
+
+#[cfg(unix)]
+fn chmod_private_file_fd<Fd: std::os::fd::AsRawFd>(file: &Fd, path: &Path) -> RunnerResult<()> {
     // SAFETY: `fchmod` operates on the live fd and does not affect Rust aliasing.
     let result =
         unsafe { nix::libc::fchmod(file.as_raw_fd(), PRIVATE_FILE_MODE as nix::libc::mode_t) };

--- a/crates/runner/src/private_fs.rs
+++ b/crates/runner/src/private_fs.rs
@@ -7,6 +7,7 @@ use crate::error::{RunnerError, RunnerResult};
 const PRIVATE_DIR_MODE: u32 = 0o700;
 const PRIVATE_FILE_MODE: u32 = 0o600;
 const GROUP_OR_OTHER_WRITE_BITS: u32 = 0o022;
+const ROOT_UID: u32 = 0;
 const STICKY_BIT: u32 = 0o1000;
 const RESERVED_PRIVATE_DIR_PATHS: &[&str] = &[
     "/",
@@ -232,7 +233,7 @@ fn open_or_create_private_dir_component(
     use nix::fcntl::openat;
     use nix::sys::stat::Mode;
 
-    ensure_private_dir_parent_not_replaceable(parent, parent_path, full_path)?;
+    ensure_private_dir_parent_not_replaceable(parent, parent_path, full_path, expected_uid)?;
     match openat(parent, name, private_dir_open_flags(), Mode::empty()) {
         Ok(fd) => Ok(fd),
         Err(Errno::EACCES) => {
@@ -251,6 +252,7 @@ fn ensure_private_dir_parent_not_replaceable(
     parent: &(impl AsFd + AsRawFd),
     parent_path: &Path,
     full_path: &Path,
+    expected_uid: u32,
 ) -> RunnerResult<()> {
     use nix::sys::stat::fstat;
 
@@ -262,6 +264,13 @@ fn ensure_private_dir_parent_not_replaceable(
         ))
     })?;
     let mode = (stat.st_mode as u32) & 0o7777;
+    if stat.st_uid != ROOT_UID && stat.st_uid != expected_uid {
+        return Err(RunnerError::Config(format!(
+            "private dir parent {} is owned by untrusted uid {}; fix parent ownership before starting the runner",
+            parent_path.display(),
+            stat.st_uid
+        )));
+    }
     if mode & GROUP_OR_OTHER_WRITE_BITS != 0 && mode & STICKY_BIT == 0 {
         return Err(RunnerError::Config(format!(
             "private dir parent {} is group/other writable without the sticky bit; fix parent permissions before starting the runner",
@@ -832,6 +841,52 @@ mod tests {
         ensure_private_dir(&private_dir).await.unwrap();
 
         assert_eq!(mode(&private_dir), PRIVATE_DIR_MODE);
+    }
+
+    #[test]
+    fn private_dir_parent_rejects_untrusted_owner() {
+        use nix::fcntl::open;
+        use nix::sys::stat::Mode;
+        use nix::unistd::{Uid, chown};
+
+        let dir = tempfile::tempdir().unwrap();
+        let parent = dir.path().join("owned-by-other-user");
+        std::fs::create_dir(&parent).unwrap();
+        std::fs::set_permissions(&parent, std::fs::Permissions::from_mode(0o555)).unwrap();
+        if nix::unistd::geteuid().is_root() {
+            chown(&parent, Some(Uid::from_raw(1)), None).unwrap();
+        }
+        let fd = open(&parent, private_dir_open_flags(), Mode::empty()).unwrap();
+
+        let error =
+            ensure_private_dir_parent_not_replaceable(&fd, &parent, &parent.join("runner"), 0)
+                .unwrap_err();
+
+        assert!(
+            error.to_string().contains("untrusted uid"),
+            "unexpected error: {error}"
+        );
+    }
+
+    #[test]
+    fn private_dir_parent_allows_root_owned_parent_for_non_root_expected_uid() {
+        use nix::fcntl::open;
+        use nix::sys::stat::Mode;
+        use nix::unistd::{Uid, chown};
+
+        if !nix::unistd::geteuid().is_root() {
+            return;
+        }
+
+        let dir = tempfile::tempdir().unwrap();
+        let parent = dir.path().join("root-owned");
+        std::fs::create_dir(&parent).unwrap();
+        std::fs::set_permissions(&parent, std::fs::Permissions::from_mode(0o755)).unwrap();
+        chown(&parent, Some(Uid::from_raw(0)), None).unwrap();
+        let fd = open(&parent, private_dir_open_flags(), Mode::empty()).unwrap();
+
+        ensure_private_dir_parent_not_replaceable(&fd, &parent, &parent.join("runner"), 1000)
+            .unwrap();
     }
 
     #[test]

--- a/crates/runner/src/private_fs.rs
+++ b/crates/runner/src/private_fs.rs
@@ -274,7 +274,8 @@ fn ensure_private_dir_exists_without_symlinks(
         RunnerError::Config(format!("open private dir root for {}: {e}", path.display()))
     })?;
     let mut current_path = start.to_path_buf();
-    for component in path.components() {
+    let mut components = path.components().peekable();
+    while let Some(component) = components.next() {
         match component {
             Component::RootDir | Component::CurDir => {}
             Component::ParentDir => {
@@ -284,12 +285,14 @@ fn ensure_private_dir_exists_without_symlinks(
                 )));
             }
             Component::Normal(name) => {
+                let is_final = components.peek().is_none();
                 current = open_or_create_private_dir_component(
                     &current,
                     name,
                     &current_path,
                     path,
                     expected_uid,
+                    is_final,
                 )?;
                 current_path = private_dir_component_path(&current_path, name);
             }
@@ -313,6 +316,7 @@ fn open_or_create_private_dir_component(
     parent_path: &Path,
     full_path: &Path,
     expected_uid: u32,
+    is_final: bool,
 ) -> RunnerResult<OwnedFd> {
     use nix::errno::Errno;
     use nix::fcntl::openat;
@@ -322,18 +326,14 @@ fn open_or_create_private_dir_component(
     ensure_private_dir_parent_not_replaceable(parent, parent_path, full_path, expected_uid)?;
     match openat(parent, name, private_dir_open_flags(), Mode::empty()) {
         Ok(fd) => {
-            secure_existing_private_dir_component(&fd, &component_path, full_path, expected_uid)?;
-            Ok(fd)
-        }
-        Err(Errno::EACCES) => {
-            repair_private_dir_parent_for_traversal(parent, parent_path, full_path, expected_uid)?;
-            open_or_create_accessible_private_dir_component(
-                parent,
-                name,
-                parent_path,
+            secure_existing_private_dir_component(
+                &fd,
+                &component_path,
                 full_path,
                 expected_uid,
-            )
+                is_final,
+            )?;
+            Ok(fd)
         }
         Err(Errno::ENOENT) => create_and_open_private_dir_component(
             parent,
@@ -341,6 +341,7 @@ fn open_or_create_private_dir_component(
             parent_path,
             full_path,
             expected_uid,
+            is_final,
         ),
         Err(e) => Err(private_dir_component_error("open", name, full_path, e)),
     }
@@ -379,42 +380,13 @@ fn ensure_private_dir_parent_not_replaceable(
     Ok(())
 }
 
-#[cfg(unix)]
-fn open_or_create_accessible_private_dir_component(
-    parent: &(impl AsFd + AsRawFd),
-    name: &OsStr,
-    parent_path: &Path,
-    full_path: &Path,
-    expected_uid: u32,
-) -> RunnerResult<OwnedFd> {
-    use nix::errno::Errno;
-    use nix::fcntl::openat;
-    use nix::sys::stat::Mode;
-
-    let component_path = private_dir_component_path(parent_path, name);
-    match openat(parent, name, private_dir_open_flags(), Mode::empty()) {
-        Ok(fd) => {
-            secure_existing_private_dir_component(&fd, &component_path, full_path, expected_uid)?;
-            Ok(fd)
-        }
-        Err(Errno::ENOENT) => create_and_open_private_dir_component(
-            parent,
-            name,
-            parent_path,
-            full_path,
-            expected_uid,
-        ),
-        Err(e) => Err(private_dir_component_error("open", name, full_path, e)),
-    }
-}
-
-#[cfg(unix)]
 fn create_and_open_private_dir_component(
     parent: &(impl AsFd + AsRawFd),
     name: &OsStr,
     parent_path: &Path,
     full_path: &Path,
     expected_uid: u32,
+    is_final: bool,
 ) -> RunnerResult<OwnedFd> {
     use nix::errno::Errno;
     use nix::fcntl::openat;
@@ -430,9 +402,9 @@ fn create_and_open_private_dir_component(
         )));
     }
 
-    match mkdirat(parent, name, Mode::from_bits_truncate(PRIVATE_DIR_MODE)) {
-        Ok(()) => {}
-        Err(Errno::EEXIST) => {}
+    let created = match mkdirat(parent, name, Mode::from_bits_truncate(PRIVATE_DIR_MODE)) {
+        Ok(()) => true,
+        Err(Errno::EEXIST) => false,
         Err(e) => {
             return Err(RunnerError::Config(format!(
                 "create private dir component {} for {}: {e}",
@@ -443,7 +415,13 @@ fn create_and_open_private_dir_component(
     };
     let fd = openat(parent, name, private_dir_open_flags(), Mode::empty())
         .map_err(|e| private_dir_component_error("open", name, full_path, e))?;
-    secure_existing_private_dir_component(&fd, &component_path, full_path, expected_uid)?;
+    secure_existing_private_dir_component(
+        &fd,
+        &component_path,
+        full_path,
+        expected_uid,
+        created || is_final,
+    )?;
     Ok(fd)
 }
 
@@ -460,6 +438,7 @@ fn secure_existing_private_dir_component(
     component_path: &Path,
     full_path: &Path,
     expected_uid: u32,
+    enforce_private_mode: bool,
 ) -> RunnerResult<()> {
     use nix::sys::stat::{SFlag, fstat};
 
@@ -500,44 +479,10 @@ fn secure_existing_private_dir_component(
             full_path.display()
         )));
     }
-    if mode != PRIVATE_DIR_MODE {
+    if enforce_private_mode && mode != PRIVATE_DIR_MODE {
         chmod_open_private_dir(fd, component_path)?;
     }
     Ok(())
-}
-
-#[cfg(unix)]
-fn repair_private_dir_parent_for_traversal(
-    parent: &(impl AsFd + AsRawFd),
-    parent_path: &Path,
-    full_path: &Path,
-    expected_uid: u32,
-) -> RunnerResult<()> {
-    use nix::sys::stat::fstat;
-
-    let normalized_parent = normalize_private_dir_policy_path(parent_path)?;
-    if is_reserved_normalized_private_dir_path(&normalized_parent) {
-        return Err(RunnerError::Config(format!(
-            "{} requires traversing reserved system path {}; fix parent permissions before starting the runner",
-            full_path.display(),
-            parent_path.display()
-        )));
-    }
-
-    let stat = fstat(parent).map_err(|e| {
-        RunnerError::Config(format!(
-            "stat private dir parent for {}: {e}",
-            full_path.display()
-        ))
-    })?;
-    if stat.st_uid != expected_uid {
-        return Err(RunnerError::Config(format!(
-            "private dir parent for {} is owned by uid {}, but runner euid is {expected_uid}; fix ownership before starting the runner",
-            full_path.display(),
-            stat.st_uid
-        )));
-    }
-    chmod_open_private_dir(parent, full_path)
 }
 
 #[cfg(unix)]
@@ -830,7 +775,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn ensure_private_dir_tightens_existing_intermediate_dir() {
+    async fn ensure_private_dir_preserves_existing_intermediate_dir_mode() {
         let dir = tempfile::tempdir().unwrap();
         let intermediate = dir.path().join("nested");
         let private_dir = intermediate.join("runner");
@@ -839,7 +784,7 @@ mod tests {
 
         ensure_private_dir(&private_dir).await.unwrap();
 
-        assert_eq!(mode(&intermediate), PRIVATE_DIR_MODE);
+        assert_eq!(mode(&intermediate), 0o755);
         assert_eq!(mode(&private_dir), PRIVATE_DIR_MODE);
     }
 
@@ -856,48 +801,6 @@ mod tests {
         assert_eq!(mode(&private_dir), PRIVATE_DIR_MODE);
     }
 
-    #[cfg(target_os = "linux")]
-    #[tokio::test]
-    async fn ensure_private_dir_repairs_unreadable_existing_intermediate_dir() {
-        let dir = tempfile::tempdir().unwrap();
-        let intermediate = dir.path().join("nested");
-        let private_dir = intermediate.join("runner");
-        std::fs::create_dir(&intermediate).unwrap();
-        std::fs::set_permissions(&intermediate, std::fs::Permissions::from_mode(0o000)).unwrap();
-
-        ensure_private_dir(&private_dir).await.unwrap();
-
-        assert_eq!(mode(&intermediate), PRIVATE_DIR_MODE);
-        assert_eq!(mode(&private_dir), PRIVATE_DIR_MODE);
-    }
-
-    #[cfg(target_os = "linux")]
-    #[test]
-    fn repair_private_dir_parent_rejects_reserved_parent() {
-        use nix::fcntl::open;
-        use nix::sys::stat::Mode;
-
-        let dir = tempfile::tempdir().unwrap();
-        let parent = dir.path().join("parent");
-        std::fs::create_dir(&parent).unwrap();
-        std::fs::set_permissions(&parent, std::fs::Permissions::from_mode(0o000)).unwrap();
-        let fd = open(&parent, private_dir_open_flags(), Mode::empty()).unwrap();
-
-        let error = repair_private_dir_parent_for_traversal(
-            &fd,
-            Path::new("/var/lib/vm0-runner/runners"),
-            &parent.join("runner"),
-            nix::unistd::geteuid().as_raw(),
-        )
-        .unwrap_err();
-
-        assert!(
-            error.to_string().contains("reserved system path"),
-            "unexpected error: {error}"
-        );
-        assert_eq!(mode(&parent), 0o000);
-    }
-
     #[test]
     fn create_private_dir_component_rejects_reserved_component() {
         use nix::fcntl::open;
@@ -912,6 +815,7 @@ mod tests {
             Path::new("/var/lib/vm0-runner"),
             Path::new("/var/lib/vm0-runner/runners/runner-01"),
             nix::unistd::geteuid().as_raw(),
+            true,
         )
         .unwrap_err();
 
@@ -1027,7 +931,10 @@ mod tests {
         let message = error.to_string();
 
         assert!(
-            message.contains("symlink component") || message.contains("not a directory"),
+            message.contains("symlink component")
+                || message.contains("not a directory")
+                || message.contains("EACCES")
+                || message.contains("Permission denied"),
             "unexpected error: {error}"
         );
         assert!(

--- a/crates/runner/src/private_fs.rs
+++ b/crates/runner/src/private_fs.rs
@@ -1,3 +1,5 @@
+use std::ffi::OsStr;
+use std::os::fd::{AsFd, OwnedFd};
 use std::path::{Component, Path, PathBuf};
 
 use crate::error::{RunnerError, RunnerResult};
@@ -50,22 +52,8 @@ pub async fn ensure_private_dir(path: &Path) -> RunnerResult<()> {
     reject_reserved_private_dir_path(path)?;
     reject_parent_dir_components(path)?;
     reject_existing_symlink_components(path).await?;
-
-    let mut builder = tokio::fs::DirBuilder::new();
-    builder.recursive(true);
-    builder.mode(PRIVATE_DIR_MODE);
-    match builder.create(path).await {
-        Ok(()) => {}
-        Err(e) if e.kind() == std::io::ErrorKind::AlreadyExists => {}
-        Err(e) => {
-            return Err(RunnerError::Config(format!(
-                "create private dir {}: {e}",
-                path.display()
-            )));
-        }
-    }
-
-    ensure_private_dir_owned_by(path, nix::unistd::geteuid().as_raw()).await
+    let fd = ensure_private_dir_exists_without_symlinks(path)?;
+    ensure_private_dir_fd_owned_by(path, &fd, nix::unistd::geteuid().as_raw())
 }
 
 #[cfg(not(unix))]
@@ -97,6 +85,12 @@ async fn reject_existing_symlink_components(path: &Path) -> RunnerResult<()> {
         let metadata = match tokio::fs::symlink_metadata(&current).await {
             Ok(metadata) => metadata,
             Err(e) if e.kind() == std::io::ErrorKind::NotFound => return Ok(()),
+            Err(e) if e.kind() == std::io::ErrorKind::NotADirectory => {
+                return Err(RunnerError::Config(format!(
+                    "{} is not a directory; refusing to use it as private runner state",
+                    path.display()
+                )));
+            }
             Err(e) => {
                 return Err(RunnerError::Config(format!(
                     "stat private dir component {}: {e}",
@@ -167,32 +161,119 @@ pub async fn write_private_file(path: &Path, content: &[u8]) -> RunnerResult<()>
 }
 
 #[cfg(unix)]
-async fn ensure_private_dir_owned_by(path: &Path, expected_uid: u32) -> RunnerResult<()> {
+fn ensure_private_dir_exists_without_symlinks(path: &Path) -> RunnerResult<OwnedFd> {
     use nix::fcntl::open;
-    use nix::sys::stat::{Mode, SFlag, fstat};
+    use nix::sys::stat::Mode;
 
-    let lstat_path = path_for_final_component_lstat(path);
-    let metadata = tokio::fs::symlink_metadata(&lstat_path)
-        .await
-        .map_err(|e| RunnerError::Config(format!("stat private dir {}: {e}", path.display())))?;
-    let file_type = metadata.file_type();
-    if file_type.is_symlink() {
+    if path.as_os_str().is_empty() {
         return Err(RunnerError::Config(format!(
-            "{} is a symlink; refusing to use it as private runner state",
+            "{} does not name a directory; refusing to use it as private runner state",
             path.display()
         )));
     }
-    if !file_type.is_dir() {
-        return Err(RunnerError::Config(format!(
+
+    let start = if path.is_absolute() {
+        Path::new("/")
+    } else {
+        Path::new(".")
+    };
+    let mut current = open(start, private_dir_open_flags(), Mode::empty()).map_err(|e| {
+        RunnerError::Config(format!("open private dir root for {}: {e}", path.display()))
+    })?;
+    for component in path.components() {
+        match component {
+            Component::RootDir | Component::CurDir => {}
+            Component::ParentDir => {
+                return Err(RunnerError::Config(format!(
+                    "{} contains a parent directory segment; refusing to use it as private runner state",
+                    path.display()
+                )));
+            }
+            Component::Normal(name) => {
+                current = open_or_create_private_dir_component(&current, name, path)?;
+            }
+            Component::Prefix(prefix) => {
+                return Err(RunnerError::Config(format!(
+                    "{} contains unsupported path prefix {}; refusing to use it as private runner state",
+                    path.display(),
+                    prefix.as_os_str().to_string_lossy()
+                )));
+            }
+        }
+    }
+
+    Ok(current)
+}
+
+#[cfg(unix)]
+fn open_or_create_private_dir_component(
+    parent: &impl AsFd,
+    name: &OsStr,
+    full_path: &Path,
+) -> RunnerResult<OwnedFd> {
+    use nix::errno::Errno;
+    use nix::fcntl::openat;
+    use nix::sys::stat::{Mode, mkdirat};
+
+    match openat(parent, name, private_dir_open_flags(), Mode::empty()) {
+        Ok(fd) => Ok(fd),
+        Err(Errno::ENOENT) => {
+            let created = match mkdirat(parent, name, Mode::from_bits_truncate(PRIVATE_DIR_MODE)) {
+                Ok(()) => true,
+                Err(Errno::EEXIST) => false,
+                Err(e) => {
+                    return Err(RunnerError::Config(format!(
+                        "create private dir component {} for {}: {e}",
+                        name.to_string_lossy(),
+                        full_path.display()
+                    )));
+                }
+            };
+            let fd = openat(parent, name, private_dir_open_flags(), Mode::empty())
+                .map_err(|e| private_dir_component_error("open", name, full_path, e))?;
+            if created {
+                chmod_open_private_dir(&fd, full_path)?;
+            }
+            Ok(fd)
+        }
+        Err(e) => Err(private_dir_component_error("open", name, full_path, e)),
+    }
+}
+
+#[cfg(unix)]
+fn private_dir_component_error(
+    operation: &str,
+    name: &OsStr,
+    full_path: &Path,
+    error: nix::errno::Errno,
+) -> RunnerError {
+    match error {
+        nix::errno::Errno::ELOOP => RunnerError::Config(format!(
+            "{} contains symlink component {}; refusing to use it as private runner state",
+            full_path.display(),
+            name.to_string_lossy()
+        )),
+        nix::errno::Errno::ENOTDIR => RunnerError::Config(format!(
             "{} is not a directory; refusing to use it as private runner state",
-            path.display()
-        )));
+            full_path.display()
+        )),
+        _ => RunnerError::Config(format!(
+            "{operation} private dir component {} for {}: {error}",
+            name.to_string_lossy(),
+            full_path.display()
+        )),
     }
+}
 
-    // Keep chmod tied to the opened directory, not a path that could be swapped.
-    let fd = open(&lstat_path, private_dir_open_flags(), Mode::empty())
-        .map_err(|e| RunnerError::Config(format!("open private dir {}: {e}", path.display())))?;
-    let stat = fstat(&fd)
+#[cfg(unix)]
+fn ensure_private_dir_fd_owned_by(
+    path: &Path,
+    fd: &OwnedFd,
+    expected_uid: u32,
+) -> RunnerResult<()> {
+    use nix::sys::stat::{SFlag, fstat};
+
+    let stat = fstat(fd)
         .map_err(|e| RunnerError::Config(format!("stat private dir fd {}: {e}", path.display())))?;
     let fd_file_type = SFlag::from_bits_truncate(stat.st_mode & SFlag::S_IFMT.bits());
     if fd_file_type != SFlag::S_IFDIR {
@@ -210,25 +291,21 @@ async fn ensure_private_dir_owned_by(path: &Path, expected_uid: u32) -> RunnerRe
         )));
     }
 
-    chmod_open_private_dir(&fd, path).await?;
+    chmod_open_private_dir(fd, path)?;
     Ok(())
 }
 
 #[cfg(all(unix, target_os = "linux"))]
-async fn chmod_open_private_dir<Fd: std::os::fd::AsRawFd>(
-    fd: &Fd,
-    path: &Path,
-) -> RunnerResult<()> {
+fn chmod_open_private_dir<Fd: std::os::fd::AsRawFd>(fd: &Fd, path: &Path) -> RunnerResult<()> {
     use std::os::unix::fs::PermissionsExt;
 
     let fd_path = PathBuf::from(format!("/proc/self/fd/{}", fd.as_raw_fd()));
-    tokio::fs::set_permissions(&fd_path, std::fs::Permissions::from_mode(PRIVATE_DIR_MODE))
-        .await
+    std::fs::set_permissions(&fd_path, std::fs::Permissions::from_mode(PRIVATE_DIR_MODE))
         .map_err(|e| RunnerError::Config(format!("chmod private dir {}: {e}", path.display())))
 }
 
 #[cfg(all(unix, not(target_os = "linux")))]
-async fn chmod_open_private_dir<Fd: std::os::fd::AsFd>(fd: &Fd, path: &Path) -> RunnerResult<()> {
+fn chmod_open_private_dir<Fd: std::os::fd::AsFd>(fd: &Fd, path: &Path) -> RunnerResult<()> {
     nix::sys::stat::fchmod(
         fd,
         nix::sys::stat::Mode::from_bits_truncate(PRIVATE_DIR_MODE),
@@ -250,17 +327,6 @@ fn private_dir_open_flags() -> nix::fcntl::OFlag {
         | nix::fcntl::OFlag::O_DIRECTORY
         | nix::fcntl::OFlag::O_NOFOLLOW
         | nix::fcntl::OFlag::O_CLOEXEC
-}
-
-#[cfg(unix)]
-fn path_for_final_component_lstat(path: &Path) -> PathBuf {
-    // Unix lstat follows a final symlink when the input has a trailing separator.
-    let lstat_path: PathBuf = path.components().collect();
-    if lstat_path.as_os_str().is_empty() {
-        path.to_path_buf()
-    } else {
-        lstat_path
-    }
 }
 
 #[cfg(unix)]
@@ -358,6 +424,16 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn ensure_private_dir_creates_missing_nested_dir_with_private_mode() {
+        let dir = tempfile::tempdir().unwrap();
+        let private_dir = dir.path().join("nested").join("runner");
+
+        ensure_private_dir(&private_dir).await.unwrap();
+
+        assert_eq!(mode(&private_dir), PRIVATE_DIR_MODE);
+    }
+
+    #[tokio::test]
     async fn ensure_private_dir_rejects_filesystem_root() {
         let error = ensure_private_dir(Path::new("/")).await.unwrap_err();
 
@@ -397,6 +473,21 @@ mod tests {
         let dir = tempfile::tempdir().unwrap();
         let private_dir = dir.path().join("runner");
         std::fs::write(&private_dir, b"not a dir").unwrap();
+
+        let error = ensure_private_dir(&private_dir).await.unwrap_err();
+
+        assert!(
+            error.to_string().contains("not a directory"),
+            "unexpected error: {error}"
+        );
+    }
+
+    #[tokio::test]
+    async fn ensure_private_dir_rejects_intermediate_regular_file() {
+        let dir = tempfile::tempdir().unwrap();
+        let file = dir.path().join("file");
+        let private_dir = file.join("runner");
+        std::fs::write(&file, b"not a dir").unwrap();
 
         let error = ensure_private_dir(&private_dir).await.unwrap_err();
 
@@ -542,9 +633,8 @@ mod tests {
         let actual_uid = std::fs::metadata(&private_dir).unwrap().uid();
         let mismatched_uid = if actual_uid == 0 { 1 } else { 0 };
 
-        let error = ensure_private_dir_owned_by(&private_dir, mismatched_uid)
-            .await
-            .unwrap_err();
+        let fd = ensure_private_dir_exists_without_symlinks(&private_dir).unwrap();
+        let error = ensure_private_dir_fd_owned_by(&private_dir, &fd, mismatched_uid).unwrap_err();
 
         assert!(
             error.to_string().contains("owned by uid"),

--- a/crates/runner/src/private_fs.rs
+++ b/crates/runner/src/private_fs.rs
@@ -9,6 +9,7 @@ const PRIVATE_FILE_MODE: u32 = 0o600;
 const GROUP_OR_OTHER_WRITE_BITS: u32 = 0o022;
 const ROOT_UID: u32 = 0;
 const STICKY_BIT: u32 = 0o1000;
+const PRIVATE_FILE_READ_MAX_BYTES: u64 = 64 * 1024;
 const RESERVED_PRIVATE_DIR_PATHS: &[&str] = &[
     "/",
     "/bin",
@@ -116,13 +117,11 @@ async fn reject_existing_symlink_components(path: &Path) -> RunnerResult<()> {
 
 #[cfg(unix)]
 pub async fn read_private_file_to_string(path: &Path) -> RunnerResult<Option<String>> {
-    use tokio::io::AsyncReadExt;
-
     let mut options = tokio::fs::OpenOptions::new();
     options
         .read(true)
         .custom_flags(nix::libc::O_NOFOLLOW | nix::libc::O_CLOEXEC | nix::libc::O_NONBLOCK);
-    let mut file = match options.open(path).await {
+    let file = match options.open(path).await {
         Ok(file) => file,
         Err(e) if e.kind() == std::io::ErrorKind::NotFound => return Ok(None),
         Err(e) => {
@@ -133,23 +132,41 @@ pub async fn read_private_file_to_string(path: &Path) -> RunnerResult<Option<Str
         }
     };
     secure_open_private_file(&file, path)?;
+    read_private_file_contents(file, path).await.map(Some)
+}
+
+async fn read_private_file_contents(file: tokio::fs::File, path: &Path) -> RunnerResult<String> {
+    use tokio::io::AsyncReadExt;
+
+    let mut limited = file.take(PRIVATE_FILE_READ_MAX_BYTES + 1);
     let mut contents = String::new();
-    file.read_to_string(&mut contents)
+    limited
+        .read_to_string(&mut contents)
         .await
         .map_err(|e| RunnerError::Config(format!("read private file {}: {e}", path.display())))?;
-    Ok(Some(contents))
+    if contents.len() as u64 > PRIVATE_FILE_READ_MAX_BYTES {
+        return Err(RunnerError::Config(format!(
+            "private file {} exceeds {} bytes",
+            path.display(),
+            PRIVATE_FILE_READ_MAX_BYTES
+        )));
+    }
+    Ok(contents)
 }
 
 #[cfg(not(unix))]
 pub async fn read_private_file_to_string(path: &Path) -> RunnerResult<Option<String>> {
-    match tokio::fs::read_to_string(path).await {
-        Ok(contents) => Ok(Some(contents)),
-        Err(e) if e.kind() == std::io::ErrorKind::NotFound => Ok(None),
-        Err(e) => Err(RunnerError::Config(format!(
-            "read private file {}: {e}",
-            path.display()
-        ))),
-    }
+    let file = match tokio::fs::File::open(path).await {
+        Ok(file) => file,
+        Err(e) if e.kind() == std::io::ErrorKind::NotFound => return Ok(None),
+        Err(e) => {
+            return Err(RunnerError::Config(format!(
+                "open private file {}: {e}",
+                path.display()
+            )));
+        }
+    };
+    read_private_file_contents(file, path).await.map(Some)
 }
 
 #[cfg(unix)]
@@ -725,6 +742,24 @@ mod tests {
 
     fn mode(path: &Path) -> u32 {
         std::fs::metadata(path).unwrap().permissions().mode() & 0o777
+    }
+
+    #[tokio::test]
+    async fn read_private_file_rejects_large_file() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("runner_id");
+        std::fs::write(
+            &path,
+            vec![b'x'; (PRIVATE_FILE_READ_MAX_BYTES + 1) as usize],
+        )
+        .unwrap();
+
+        let error = read_private_file_to_string(&path).await.unwrap_err();
+
+        assert!(
+            error.to_string().contains("exceeds"),
+            "unexpected error: {error}"
+        );
     }
 
     #[tokio::test]

--- a/crates/runner/src/private_fs.rs
+++ b/crates/runner/src/private_fs.rs
@@ -1,4 +1,4 @@
-use std::path::Path;
+use std::path::{Path, PathBuf};
 
 use crate::error::{RunnerError, RunnerResult};
 
@@ -38,7 +38,8 @@ pub async fn ensure_private_dir(path: &Path) -> RunnerResult<()> {
 async fn ensure_private_dir_owned_by(path: &Path, expected_uid: u32) -> RunnerResult<()> {
     use std::os::unix::fs::{MetadataExt, PermissionsExt};
 
-    let metadata = tokio::fs::symlink_metadata(path)
+    let lstat_path = path_for_final_component_lstat(path);
+    let metadata = tokio::fs::symlink_metadata(&lstat_path)
         .await
         .map_err(|e| RunnerError::Config(format!("stat private dir {}: {e}", path.display())))?;
     let file_type = metadata.file_type();
@@ -63,10 +64,24 @@ async fn ensure_private_dir_owned_by(path: &Path, expected_uid: u32) -> RunnerRe
         )));
     }
 
-    tokio::fs::set_permissions(path, std::fs::Permissions::from_mode(PRIVATE_DIR_MODE))
-        .await
-        .map_err(|e| RunnerError::Config(format!("chmod private dir {}: {e}", path.display())))?;
+    tokio::fs::set_permissions(
+        &lstat_path,
+        std::fs::Permissions::from_mode(PRIVATE_DIR_MODE),
+    )
+    .await
+    .map_err(|e| RunnerError::Config(format!("chmod private dir {}: {e}", path.display())))?;
     Ok(())
+}
+
+#[cfg(unix)]
+fn path_for_final_component_lstat(path: &Path) -> PathBuf {
+    // Unix lstat follows a final symlink when the input has a trailing separator.
+    let lstat_path: PathBuf = path.components().collect();
+    if lstat_path.as_os_str().is_empty() {
+        path.to_path_buf()
+    } else {
+        lstat_path
+    }
 }
 
 #[cfg(test)]
@@ -124,6 +139,25 @@ mod tests {
         symlink(&target, &private_dir).unwrap();
 
         let error = ensure_private_dir(&private_dir).await.unwrap_err();
+
+        assert!(
+            error.to_string().contains("symlink"),
+            "unexpected error: {error}"
+        );
+    }
+
+    #[tokio::test]
+    async fn ensure_private_dir_rejects_symlink_with_trailing_separator() {
+        let dir = tempfile::tempdir().unwrap();
+        let target = dir.path().join("target");
+        let private_dir = dir.path().join("runner");
+        std::fs::create_dir(&target).unwrap();
+        symlink(&target, &private_dir).unwrap();
+        let private_dir_with_separator = PathBuf::from(format!("{}/", private_dir.display()));
+
+        let error = ensure_private_dir(&private_dir_with_separator)
+            .await
+            .unwrap_err();
 
         assert!(
             error.to_string().contains("symlink"),

--- a/crates/runner/src/private_fs.rs
+++ b/crates/runner/src/private_fs.rs
@@ -1,8 +1,31 @@
-use std::path::{Path, PathBuf};
+use std::path::{Component, Path, PathBuf};
 
 use crate::error::{RunnerError, RunnerResult};
 
 const PRIVATE_DIR_MODE: u32 = 0o700;
+const RESERVED_PRIVATE_DIR_PATHS: &[&str] = &[
+    "/",
+    "/bin",
+    "/boot",
+    "/dev",
+    "/etc",
+    "/home",
+    "/lib",
+    "/lib64",
+    "/opt",
+    "/proc",
+    "/root",
+    "/run",
+    "/sbin",
+    "/srv",
+    "/sys",
+    "/tmp",
+    "/usr",
+    "/var",
+    "/var/lib",
+    "/var/lib/vm0-runner",
+    "/var/lib/vm0-runner/runners",
+];
 
 /// Ensure `path` is private runtime state for the current runner process.
 ///
@@ -10,6 +33,8 @@ const PRIVATE_DIR_MODE: u32 = 0o700;
 /// owned by the effective uid instead of chowning it back to `SUDO_USER`.
 #[cfg(unix)]
 pub async fn ensure_private_dir(path: &Path) -> RunnerResult<()> {
+    reject_reserved_private_dir_path(path)?;
+
     let mut builder = tokio::fs::DirBuilder::new();
     builder.recursive(true);
     builder.mode(PRIVATE_DIR_MODE);
@@ -84,6 +109,44 @@ fn path_for_final_component_lstat(path: &Path) -> PathBuf {
     }
 }
 
+#[cfg(unix)]
+fn reject_reserved_private_dir_path(path: &Path) -> RunnerResult<()> {
+    let normalized = normalize_path_lexically(path);
+    if RESERVED_PRIVATE_DIR_PATHS
+        .iter()
+        .any(|reserved| normalized == Path::new(reserved))
+    {
+        return Err(RunnerError::Config(format!(
+            "{} is a reserved system path; refusing to use it as private runner state",
+            path.display()
+        )));
+    }
+    Ok(())
+}
+
+#[cfg(unix)]
+fn normalize_path_lexically(path: &Path) -> PathBuf {
+    let mut normalized = PathBuf::new();
+    for component in path.components() {
+        match component {
+            Component::Prefix(prefix) => normalized.push(prefix.as_os_str()),
+            Component::RootDir => normalized.push(component.as_os_str()),
+            Component::CurDir => {}
+            Component::ParentDir => {
+                if !normalized.pop() && !normalized.has_root() {
+                    normalized.push(component.as_os_str());
+                }
+            }
+            Component::Normal(part) => normalized.push(part),
+        }
+    }
+    if normalized.as_os_str().is_empty() {
+        path.to_path_buf()
+    } else {
+        normalized
+    }
+}
+
 #[cfg(test)]
 #[cfg(unix)]
 mod tests {
@@ -102,6 +165,16 @@ mod tests {
         ensure_private_dir(&private_dir).await.unwrap();
 
         assert_eq!(mode(&private_dir), PRIVATE_DIR_MODE);
+    }
+
+    #[tokio::test]
+    async fn ensure_private_dir_rejects_filesystem_root() {
+        let error = ensure_private_dir(Path::new("/")).await.unwrap_err();
+
+        assert!(
+            error.to_string().contains("reserved system path"),
+            "unexpected error: {error}"
+        );
     }
 
     #[tokio::test]
@@ -163,6 +236,26 @@ mod tests {
             error.to_string().contains("symlink"),
             "unexpected error: {error}"
         );
+    }
+
+    #[test]
+    fn reserved_private_dir_path_rejects_lexical_parent_segments() {
+        for path in ["/var/lib/../lib", "/..", "/var/../.."] {
+            let error = reject_reserved_private_dir_path(Path::new(path))
+                .expect_err("reserved path should be rejected");
+
+            assert!(
+                error.to_string().contains("reserved system path"),
+                "unexpected error for {path}: {error}"
+            );
+        }
+    }
+
+    #[test]
+    fn reserved_private_dir_path_allows_runner_child_dir() {
+        reject_reserved_private_dir_path(Path::new("/var/lib/vm0-runner/runners/runner-01"))
+            .unwrap();
+        reject_reserved_private_dir_path(Path::new("/data/runner-01")).unwrap();
     }
 
     #[tokio::test]

--- a/crates/runner/src/private_fs.rs
+++ b/crates/runner/src/private_fs.rs
@@ -115,6 +115,44 @@ async fn reject_existing_symlink_components(path: &Path) -> RunnerResult<()> {
 }
 
 #[cfg(unix)]
+pub async fn read_private_file_to_string(path: &Path) -> RunnerResult<Option<String>> {
+    use tokio::io::AsyncReadExt;
+
+    let mut options = tokio::fs::OpenOptions::new();
+    options
+        .read(true)
+        .custom_flags(nix::libc::O_NOFOLLOW | nix::libc::O_CLOEXEC);
+    let mut file = match options.open(path).await {
+        Ok(file) => file,
+        Err(e) if e.kind() == std::io::ErrorKind::NotFound => return Ok(None),
+        Err(e) => {
+            return Err(RunnerError::Config(format!(
+                "open private file {}: {e}",
+                path.display()
+            )));
+        }
+    };
+    secure_open_private_file(&file, path)?;
+    let mut contents = String::new();
+    file.read_to_string(&mut contents)
+        .await
+        .map_err(|e| RunnerError::Config(format!("read private file {}: {e}", path.display())))?;
+    Ok(Some(contents))
+}
+
+#[cfg(not(unix))]
+pub async fn read_private_file_to_string(path: &Path) -> RunnerResult<Option<String>> {
+    match tokio::fs::read_to_string(path).await {
+        Ok(contents) => Ok(Some(contents)),
+        Err(e) if e.kind() == std::io::ErrorKind::NotFound => Ok(None),
+        Err(e) => Err(RunnerError::Config(format!(
+            "read private file {}: {e}",
+            path.display()
+        ))),
+    }
+}
+
+#[cfg(unix)]
 pub async fn write_private_file(path: &Path, content: &[u8]) -> RunnerResult<()> {
     use std::ffi::OsString;
     use std::os::unix::fs::PermissionsExt;
@@ -518,6 +556,53 @@ fn ensure_private_dir_fd_owned_by(
 
     chmod_open_private_dir(fd, path)?;
     Ok(())
+}
+
+#[cfg(unix)]
+fn secure_open_private_file<Fd: std::os::fd::AsRawFd>(file: &Fd, path: &Path) -> RunnerResult<()> {
+    let mut stat = std::mem::MaybeUninit::<nix::libc::stat>::uninit();
+    // SAFETY: `stat` points to valid writable memory and `file` owns a live fd.
+    let result = unsafe { nix::libc::fstat(file.as_raw_fd(), stat.as_mut_ptr()) };
+    if result != 0 {
+        return Err(RunnerError::Config(format!(
+            "stat private file {}: {}",
+            path.display(),
+            std::io::Error::last_os_error()
+        )));
+    }
+    // SAFETY: successful `fstat` initialized the full `stat` struct.
+    let stat = unsafe { stat.assume_init() };
+    let file_type = stat.st_mode & nix::libc::S_IFMT;
+    if file_type != nix::libc::S_IFREG {
+        return Err(RunnerError::Config(format!(
+            "{} is not a regular private file",
+            path.display()
+        )));
+    }
+    let expected_uid = nix::unistd::geteuid().as_raw();
+    if stat.st_uid != expected_uid {
+        return Err(RunnerError::Config(format!(
+            "{} is owned by uid {}, but runner euid is {expected_uid}; fix ownership before starting the runner",
+            path.display(),
+            stat.st_uid
+        )));
+    }
+    let mode = stat.st_mode & 0o7777;
+    if mode == PRIVATE_FILE_MODE {
+        return Ok(());
+    }
+    // SAFETY: `fchmod` operates on the live fd and does not affect Rust aliasing.
+    let result =
+        unsafe { nix::libc::fchmod(file.as_raw_fd(), PRIVATE_FILE_MODE as nix::libc::mode_t) };
+    if result == 0 {
+        Ok(())
+    } else {
+        Err(RunnerError::Config(format!(
+            "chmod private file {}: {}",
+            path.display(),
+            std::io::Error::last_os_error()
+        )))
+    }
 }
 
 #[cfg(all(unix, target_os = "linux"))]

--- a/crates/runner/src/private_fs.rs
+++ b/crates/runner/src/private_fs.rs
@@ -168,7 +168,8 @@ pub async fn write_private_file(path: &Path, content: &[u8]) -> RunnerResult<()>
 
 #[cfg(unix)]
 async fn ensure_private_dir_owned_by(path: &Path, expected_uid: u32) -> RunnerResult<()> {
-    use std::os::unix::fs::{MetadataExt, PermissionsExt};
+    use nix::fcntl::{OFlag, open};
+    use nix::sys::stat::{Mode, SFlag, fchmod, fstat};
 
     let lstat_path = path_for_final_component_lstat(path);
     let metadata = tokio::fs::symlink_metadata(&lstat_path)
@@ -188,7 +189,24 @@ async fn ensure_private_dir_owned_by(path: &Path, expected_uid: u32) -> RunnerRe
         )));
     }
 
-    let actual_uid = metadata.uid();
+    // Keep chmod tied to the opened directory, not a path that could be swapped.
+    let fd = open(
+        &lstat_path,
+        OFlag::O_RDONLY | OFlag::O_DIRECTORY | OFlag::O_NOFOLLOW | OFlag::O_CLOEXEC,
+        Mode::empty(),
+    )
+    .map_err(|e| RunnerError::Config(format!("open private dir {}: {e}", path.display())))?;
+    let stat = fstat(&fd)
+        .map_err(|e| RunnerError::Config(format!("stat private dir fd {}: {e}", path.display())))?;
+    let fd_file_type = SFlag::from_bits_truncate(stat.st_mode);
+    if !fd_file_type.contains(SFlag::S_IFDIR) {
+        return Err(RunnerError::Config(format!(
+            "{} is not a directory; refusing to use it as private runner state",
+            path.display()
+        )));
+    }
+
+    let actual_uid = stat.st_uid;
     if actual_uid != expected_uid {
         return Err(RunnerError::Config(format!(
             "{} is owned by uid {actual_uid}, but runner euid is {expected_uid}; fix ownership before starting the runner",
@@ -196,12 +214,8 @@ async fn ensure_private_dir_owned_by(path: &Path, expected_uid: u32) -> RunnerRe
         )));
     }
 
-    tokio::fs::set_permissions(
-        &lstat_path,
-        std::fs::Permissions::from_mode(PRIVATE_DIR_MODE),
-    )
-    .await
-    .map_err(|e| RunnerError::Config(format!("chmod private dir {}: {e}", path.display())))?;
+    fchmod(&fd, Mode::from_bits_truncate(PRIVATE_DIR_MODE))
+        .map_err(|e| RunnerError::Config(format!("chmod private dir {}: {e}", path.display())))?;
     Ok(())
 }
 

--- a/crates/runner/src/private_fs.rs
+++ b/crates/runner/src/private_fs.rs
@@ -168,8 +168,8 @@ pub async fn write_private_file(path: &Path, content: &[u8]) -> RunnerResult<()>
 
 #[cfg(unix)]
 async fn ensure_private_dir_owned_by(path: &Path, expected_uid: u32) -> RunnerResult<()> {
-    use nix::fcntl::{OFlag, open};
-    use nix::sys::stat::{Mode, SFlag, fchmod, fstat};
+    use nix::fcntl::open;
+    use nix::sys::stat::{Mode, SFlag, fstat};
 
     let lstat_path = path_for_final_component_lstat(path);
     let metadata = tokio::fs::symlink_metadata(&lstat_path)
@@ -190,16 +190,12 @@ async fn ensure_private_dir_owned_by(path: &Path, expected_uid: u32) -> RunnerRe
     }
 
     // Keep chmod tied to the opened directory, not a path that could be swapped.
-    let fd = open(
-        &lstat_path,
-        OFlag::O_RDONLY | OFlag::O_DIRECTORY | OFlag::O_NOFOLLOW | OFlag::O_CLOEXEC,
-        Mode::empty(),
-    )
-    .map_err(|e| RunnerError::Config(format!("open private dir {}: {e}", path.display())))?;
+    let fd = open(&lstat_path, private_dir_open_flags(), Mode::empty())
+        .map_err(|e| RunnerError::Config(format!("open private dir {}: {e}", path.display())))?;
     let stat = fstat(&fd)
         .map_err(|e| RunnerError::Config(format!("stat private dir fd {}: {e}", path.display())))?;
-    let fd_file_type = SFlag::from_bits_truncate(stat.st_mode);
-    if !fd_file_type.contains(SFlag::S_IFDIR) {
+    let fd_file_type = SFlag::from_bits_truncate(stat.st_mode & SFlag::S_IFMT.bits());
+    if fd_file_type != SFlag::S_IFDIR {
         return Err(RunnerError::Config(format!(
             "{} is not a directory; refusing to use it as private runner state",
             path.display()
@@ -214,9 +210,46 @@ async fn ensure_private_dir_owned_by(path: &Path, expected_uid: u32) -> RunnerRe
         )));
     }
 
-    fchmod(&fd, Mode::from_bits_truncate(PRIVATE_DIR_MODE))
-        .map_err(|e| RunnerError::Config(format!("chmod private dir {}: {e}", path.display())))?;
+    chmod_open_private_dir(&fd, path).await?;
     Ok(())
+}
+
+#[cfg(all(unix, target_os = "linux"))]
+async fn chmod_open_private_dir<Fd: std::os::fd::AsRawFd>(
+    fd: &Fd,
+    path: &Path,
+) -> RunnerResult<()> {
+    use std::os::unix::fs::PermissionsExt;
+
+    let fd_path = PathBuf::from(format!("/proc/self/fd/{}", fd.as_raw_fd()));
+    tokio::fs::set_permissions(&fd_path, std::fs::Permissions::from_mode(PRIVATE_DIR_MODE))
+        .await
+        .map_err(|e| RunnerError::Config(format!("chmod private dir {}: {e}", path.display())))
+}
+
+#[cfg(all(unix, not(target_os = "linux")))]
+async fn chmod_open_private_dir<Fd: std::os::fd::AsFd>(fd: &Fd, path: &Path) -> RunnerResult<()> {
+    nix::sys::stat::fchmod(
+        fd,
+        nix::sys::stat::Mode::from_bits_truncate(PRIVATE_DIR_MODE),
+    )
+    .map_err(|e| RunnerError::Config(format!("chmod private dir {}: {e}", path.display())))
+}
+
+#[cfg(all(unix, target_os = "linux"))]
+fn private_dir_open_flags() -> nix::fcntl::OFlag {
+    nix::fcntl::OFlag::O_PATH
+        | nix::fcntl::OFlag::O_DIRECTORY
+        | nix::fcntl::OFlag::O_NOFOLLOW
+        | nix::fcntl::OFlag::O_CLOEXEC
+}
+
+#[cfg(all(unix, not(target_os = "linux")))]
+fn private_dir_open_flags() -> nix::fcntl::OFlag {
+    nix::fcntl::OFlag::O_RDONLY
+        | nix::fcntl::OFlag::O_DIRECTORY
+        | nix::fcntl::OFlag::O_NOFOLLOW
+        | nix::fcntl::OFlag::O_CLOEXEC
 }
 
 #[cfg(unix)]
@@ -340,6 +373,19 @@ mod tests {
         let private_dir = dir.path().join("runner");
         std::fs::create_dir(&private_dir).unwrap();
         std::fs::set_permissions(&private_dir, std::fs::Permissions::from_mode(0o755)).unwrap();
+
+        ensure_private_dir(&private_dir).await.unwrap();
+
+        assert_eq!(mode(&private_dir), PRIVATE_DIR_MODE);
+    }
+
+    #[cfg(target_os = "linux")]
+    #[tokio::test]
+    async fn ensure_private_dir_repairs_unreadable_existing_dir() {
+        let dir = tempfile::tempdir().unwrap();
+        let private_dir = dir.path().join("runner");
+        std::fs::create_dir(&private_dir).unwrap();
+        std::fs::set_permissions(&private_dir, std::fs::Permissions::from_mode(0o000)).unwrap();
 
         ensure_private_dir(&private_dir).await.unwrap();
 

--- a/crates/runner/src/private_fs.rs
+++ b/crates/runner/src/private_fs.rs
@@ -121,7 +121,7 @@ pub async fn read_private_file_to_string(path: &Path) -> RunnerResult<Option<Str
     let mut options = tokio::fs::OpenOptions::new();
     options
         .read(true)
-        .custom_flags(nix::libc::O_NOFOLLOW | nix::libc::O_CLOEXEC);
+        .custom_flags(nix::libc::O_NOFOLLOW | nix::libc::O_CLOEXEC | nix::libc::O_NONBLOCK);
     let mut file = match options.open(path).await {
         Ok(file) => file,
         Err(e) if e.kind() == std::io::ErrorKind::NotFound => return Ok(None),

--- a/crates/runner/src/private_fs.rs
+++ b/crates/runner/src/private_fs.rs
@@ -27,6 +27,19 @@ const RESERVED_PRIVATE_DIR_PATHS: &[&str] = &[
     "/var/lib/vm0-runner",
     "/var/lib/vm0-runner/runners",
 ];
+const RESERVED_PRIVATE_DIR_SUBTREES: &[&str] = &[
+    "/var/lib/vm0-runner/bin",
+    "/var/lib/vm0-runner/ca",
+    "/var/lib/vm0-runner/debootstrap",
+    "/var/lib/vm0-runner/firecracker",
+    "/var/lib/vm0-runner/groups",
+    "/var/lib/vm0-runner/images",
+    "/var/lib/vm0-runner/locks",
+    "/var/lib/vm0-runner/logs",
+    "/var/lib/vm0-runner/mitmproxy",
+    "/var/lib/vm0-runner/storages",
+    "/var/lib/vm0-runner/workspace-image-cache",
+];
 
 /// Ensure `path` is private runtime state for the current runner process.
 ///
@@ -242,6 +255,9 @@ fn reject_reserved_normalized_private_dir_path(
     if RESERVED_PRIVATE_DIR_PATHS
         .iter()
         .any(|reserved| normalized == Path::new(reserved))
+        || RESERVED_PRIVATE_DIR_SUBTREES
+            .iter()
+            .any(|reserved| normalized.starts_with(Path::new(reserved)))
     {
         return Err(RunnerError::Config(format!(
             "{} is a reserved system path; refusing to use it as private runner state",
@@ -424,6 +440,25 @@ mod tests {
         for path in ["..", "../../.."] {
             let error = reject_reserved_private_dir_path_with_cwd(Path::new(path), cwd)
                 .expect_err("reserved path should be rejected");
+
+            assert!(
+                error.to_string().contains("reserved system path"),
+                "unexpected error for {path}: {error}"
+            );
+        }
+    }
+
+    #[test]
+    fn reserved_private_dir_path_rejects_shared_home_subtrees() {
+        for path in [
+            "/var/lib/vm0-runner/images",
+            "/var/lib/vm0-runner/images/rootfs-hash",
+            "/var/lib/vm0-runner/locks/base-dir.lock",
+            "/var/lib/vm0-runner/ca",
+            "/var/lib/vm0-runner/storages/cache-entry",
+        ] {
+            let error = reject_reserved_private_dir_path(Path::new(path))
+                .expect_err("shared home subtree should be rejected");
 
             assert!(
                 error.to_string().contains("reserved system path"),

--- a/crates/runner/src/private_fs.rs
+++ b/crates/runner/src/private_fs.rs
@@ -6,6 +6,8 @@ use crate::error::{RunnerError, RunnerResult};
 
 const PRIVATE_DIR_MODE: u32 = 0o700;
 const PRIVATE_FILE_MODE: u32 = 0o600;
+const GROUP_OR_OTHER_WRITE_BITS: u32 = 0o022;
+const STICKY_BIT: u32 = 0o1000;
 const RESERVED_PRIVATE_DIR_PATHS: &[&str] = &[
     "/",
     "/bin",
@@ -230,6 +232,7 @@ fn open_or_create_private_dir_component(
     use nix::fcntl::openat;
     use nix::sys::stat::Mode;
 
+    ensure_private_dir_parent_not_replaceable(parent, parent_path, full_path)?;
     match openat(parent, name, private_dir_open_flags(), Mode::empty()) {
         Ok(fd) => Ok(fd),
         Err(Errno::EACCES) => {
@@ -241,6 +244,31 @@ fn open_or_create_private_dir_component(
         }
         Err(e) => Err(private_dir_component_error("open", name, full_path, e)),
     }
+}
+
+#[cfg(unix)]
+fn ensure_private_dir_parent_not_replaceable(
+    parent: &(impl AsFd + AsRawFd),
+    parent_path: &Path,
+    full_path: &Path,
+) -> RunnerResult<()> {
+    use nix::sys::stat::fstat;
+
+    let stat = fstat(parent).map_err(|e| {
+        RunnerError::Config(format!(
+            "stat private dir parent {} for {}: {e}",
+            parent_path.display(),
+            full_path.display()
+        ))
+    })?;
+    let mode = (stat.st_mode as u32) & 0o7777;
+    if mode & GROUP_OR_OTHER_WRITE_BITS != 0 && mode & STICKY_BIT == 0 {
+        return Err(RunnerError::Config(format!(
+            "private dir parent {} is group/other writable without the sticky bit; fix parent permissions before starting the runner",
+            parent_path.display()
+        )));
+    }
+    Ok(())
 }
 
 #[cfg(unix)]
@@ -771,6 +799,39 @@ mod tests {
             !missing.exists(),
             "private dir validation should not create path prefixes before rejecting parent segments"
         );
+    }
+
+    #[tokio::test]
+    async fn ensure_private_dir_rejects_group_writable_parent_without_sticky_bit() {
+        let dir = tempfile::tempdir().unwrap();
+        let parent = dir.path().join("shared");
+        let private_dir = parent.join("runner");
+        std::fs::create_dir(&parent).unwrap();
+        std::fs::set_permissions(&parent, std::fs::Permissions::from_mode(0o777)).unwrap();
+
+        let error = ensure_private_dir(&private_dir).await.unwrap_err();
+
+        assert!(
+            error.to_string().contains("group/other writable"),
+            "unexpected error: {error}"
+        );
+        assert!(
+            !private_dir.exists(),
+            "private dir should not be created under a replaceable parent"
+        );
+    }
+
+    #[tokio::test]
+    async fn ensure_private_dir_allows_sticky_group_writable_parent() {
+        let dir = tempfile::tempdir().unwrap();
+        let parent = dir.path().join("sticky");
+        let private_dir = parent.join("runner");
+        std::fs::create_dir(&parent).unwrap();
+        std::fs::set_permissions(&parent, std::fs::Permissions::from_mode(0o1777)).unwrap();
+
+        ensure_private_dir(&private_dir).await.unwrap();
+
+        assert_eq!(mode(&private_dir), PRIVATE_DIR_MODE);
     }
 
     #[test]

--- a/crates/runner/src/private_fs.rs
+++ b/crates/runner/src/private_fs.rs
@@ -35,6 +35,7 @@ const RESERVED_PRIVATE_DIR_PATHS: &[&str] = &[
 #[cfg(unix)]
 pub async fn ensure_private_dir(path: &Path) -> RunnerResult<()> {
     reject_reserved_private_dir_path(path)?;
+    reject_existing_symlink_components(path).await?;
 
     let mut builder = tokio::fs::DirBuilder::new();
     builder.recursive(true);
@@ -58,6 +59,32 @@ pub async fn ensure_private_dir(path: &Path) -> RunnerResult<()> {
     tokio::fs::create_dir_all(path)
         .await
         .map_err(|e| RunnerError::Config(format!("create private dir {}: {e}", path.display())))
+}
+
+#[cfg(unix)]
+async fn reject_existing_symlink_components(path: &Path) -> RunnerResult<()> {
+    let mut current = PathBuf::new();
+    for component in path.components() {
+        current.push(component.as_os_str());
+        let metadata = match tokio::fs::symlink_metadata(&current).await {
+            Ok(metadata) => metadata,
+            Err(e) if e.kind() == std::io::ErrorKind::NotFound => return Ok(()),
+            Err(e) => {
+                return Err(RunnerError::Config(format!(
+                    "stat private dir component {}: {e}",
+                    current.display()
+                )));
+            }
+        };
+        if metadata.file_type().is_symlink() {
+            return Err(RunnerError::Config(format!(
+                "{} contains symlink component {}; refusing to use it as private runner state",
+                path.display(),
+                current.display()
+            )));
+        }
+    }
+    Ok(())
 }
 
 #[cfg(unix)]
@@ -320,6 +347,27 @@ mod tests {
         assert!(
             error.to_string().contains("symlink"),
             "unexpected error: {error}"
+        );
+    }
+
+    #[tokio::test]
+    async fn ensure_private_dir_rejects_intermediate_symlink() {
+        let dir = tempfile::tempdir().unwrap();
+        let target = dir.path().join("target");
+        let link = dir.path().join("link");
+        let private_dir = link.join("runner");
+        std::fs::create_dir(&target).unwrap();
+        symlink(&target, &link).unwrap();
+
+        let error = ensure_private_dir(&private_dir).await.unwrap_err();
+
+        assert!(
+            error.to_string().contains("symlink component"),
+            "unexpected error: {error}"
+        );
+        assert!(
+            !target.join("runner").exists(),
+            "private dir should not be created through an intermediate symlink"
         );
     }
 

--- a/crates/runner/src/proxy.rs
+++ b/crates/runner/src/proxy.rs
@@ -925,27 +925,35 @@ async fn write_registry(path: &std::path::Path, value: &ProxyRegistry) -> Runner
         }
     }
 
-    let mut options = tokio::fs::OpenOptions::new();
-    options.write(true).create_new(true);
-    #[cfg(unix)]
-    options.mode(0o600);
-    let mut file = options
-        .open(&tmp)
-        .await
-        .map_err(|e| RunnerError::Internal(format!("open registry tmp: {e}")))?;
-    set_private_registry_file_permissions(&tmp, "registry tmp").await?;
-    file.write_all(content.as_bytes())
-        .await
-        .map_err(|e| RunnerError::Internal(format!("write registry tmp: {e}")))?;
-    file.flush()
-        .await
-        .map_err(|e| RunnerError::Internal(format!("flush registry tmp: {e}")))?;
-    drop(file);
+    let result = async {
+        let mut options = tokio::fs::OpenOptions::new();
+        options.write(true).create_new(true);
+        #[cfg(unix)]
+        options.mode(0o600);
+        let mut file = options
+            .open(&tmp)
+            .await
+            .map_err(|e| RunnerError::Internal(format!("open registry tmp: {e}")))?;
+        set_private_registry_file_permissions(&tmp, "registry tmp").await?;
+        file.write_all(content.as_bytes())
+            .await
+            .map_err(|e| RunnerError::Internal(format!("write registry tmp: {e}")))?;
+        file.flush()
+            .await
+            .map_err(|e| RunnerError::Internal(format!("flush registry tmp: {e}")))?;
+        drop(file);
 
-    tokio::fs::rename(&tmp, path)
-        .await
-        .map_err(|e| RunnerError::Internal(format!("rename registry: {e}")))?;
-    set_private_registry_file_permissions(path, "registry").await
+        tokio::fs::rename(&tmp, path)
+            .await
+            .map_err(|e| RunnerError::Internal(format!("rename registry: {e}")))?;
+        set_private_registry_file_permissions(path, "registry").await
+    }
+    .await;
+
+    if result.is_err() {
+        let _ = tokio::fs::remove_file(&tmp).await;
+    }
+    result
 }
 
 async fn set_private_registry_file_permissions(
@@ -1373,6 +1381,27 @@ PY
         assert_eq!(file_mode(&registry_path), 0o600);
         let loaded = read_registry(&registry_path).await.unwrap();
         assert_eq!(loaded.updated_at, 2);
+    }
+
+    #[tokio::test]
+    async fn write_registry_removes_tmp_after_rename_failure() {
+        let dir = tempfile::tempdir().unwrap();
+        let registry_path = dir.path().join("proxy-registry.json");
+        let tmp_path = registry_path.with_extension("json.tmp");
+        std::fs::create_dir(&registry_path).unwrap();
+        let registry = ProxyRegistry {
+            vms: HashMap::new(),
+            updated_at: 3,
+        };
+
+        let error = write_registry(&registry_path, &registry).await.unwrap_err();
+
+        assert!(
+            error.to_string().contains("rename registry"),
+            "unexpected error: {error}"
+        );
+        assert!(!tmp_path.exists(), "registry tmp should be cleaned up");
+        assert!(registry_path.is_dir());
     }
 
     #[tokio::test]

--- a/crates/runner/src/proxy.rs
+++ b/crates/runner/src/proxy.rs
@@ -5,7 +5,7 @@ use std::sync::atomic::{AtomicBool, Ordering};
 use std::time::{Duration, SystemTime, UNIX_EPOCH};
 
 use serde::{Deserialize, Serialize};
-use tokio::io::{AsyncBufReadExt, AsyncWriteExt};
+use tokio::io::{AsyncBufReadExt, AsyncReadExt, AsyncWriteExt};
 use tokio::sync::mpsc;
 use tracing::{info, warn};
 use uuid::Uuid;
@@ -495,6 +495,30 @@ fn parse_usage_pending_state(content: &str) -> Result<UsagePendingState, String>
         .map_err(|e| format!("state file is not valid usage-pending JSON: {e}"))
 }
 
+#[cfg(unix)]
+async fn read_usage_pending_file(path: &Path) -> std::io::Result<String> {
+    let mut options = tokio::fs::OpenOptions::new();
+    options
+        .read(true)
+        .custom_flags(nix::libc::O_NOFOLLOW | nix::libc::O_CLOEXEC | nix::libc::O_NONBLOCK);
+    let mut file = options.open(path).await?;
+    let metadata = file.metadata().await?;
+    if !metadata.is_file() {
+        return Err(std::io::Error::new(
+            std::io::ErrorKind::InvalidData,
+            format!("{} is not a regular usage-pending file", path.display()),
+        ));
+    }
+    let mut content = String::new();
+    file.read_to_string(&mut content).await?;
+    Ok(content)
+}
+
+#[cfg(not(unix))]
+async fn read_usage_pending_file(path: &Path) -> std::io::Result<String> {
+    tokio::fs::read_to_string(path).await
+}
+
 fn validate_usage_pending_state(
     state: &UsagePendingState,
     request: &UsageFlushRequest,
@@ -561,7 +585,7 @@ pub async fn wait_usage_flush_requesting(
     let deadline = started_at + timeout;
     let mut next_flush_request_at = started_at + USAGE_FLUSH_REQUEST_INTERVAL;
     loop {
-        let (not_ready, snapshot) = match tokio::fs::read_to_string(&path).await {
+        let (not_ready, snapshot) = match read_usage_pending_file(&path).await {
             Ok(content) => match parse_usage_pending_state(&content) {
                 Ok(state) => {
                     let snapshot = Some(UsagePendingSnapshot::from(&state));
@@ -2272,6 +2296,30 @@ while True:
         let dir = tempfile::tempdir().unwrap();
         let request = usage_request();
         assert!(!wait_usage_flush(dir.path(), Duration::from_millis(50), &request).await);
+    }
+
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn read_usage_pending_file_rejects_fifo_without_blocking() {
+        use std::os::unix::ffi::OsStrExt;
+
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("usage-pending");
+        let c_path = std::ffi::CString::new(path.as_os_str().as_bytes()).unwrap();
+        let result = unsafe { nix::libc::mkfifo(c_path.as_ptr(), 0o600) };
+        assert_eq!(
+            result,
+            0,
+            "mkfifo failed: {}",
+            std::io::Error::last_os_error()
+        );
+
+        let result =
+            tokio::time::timeout(Duration::from_millis(100), read_usage_pending_file(&path))
+                .await
+                .expect("usage-pending FIFO read should not block");
+
+        assert!(result.is_err(), "usage-pending FIFO should be rejected");
     }
 
     #[tokio::test(start_paused = true)]

--- a/crates/runner/src/proxy.rs
+++ b/crates/runner/src/proxy.rs
@@ -204,7 +204,16 @@ impl MitmProxy {
         // Write addon scripts to directory.
         // Remove-and-recreate to purge stale files from previous binary versions
         // (e.g. a renamed module would leave an orphan .py that Python could import).
-        let _ = tokio::fs::remove_dir_all(&config.addon_dir).await;
+        match tokio::fs::remove_dir_all(&config.addon_dir).await {
+            Ok(()) => {}
+            Err(e) if e.kind() == std::io::ErrorKind::NotFound => {}
+            Err(e) => {
+                return Err(RunnerError::Internal(format!(
+                    "remove addon dir {}: {e}",
+                    config.addon_dir.display()
+                )));
+            }
+        }
         tokio::fs::create_dir_all(&config.addon_dir)
             .await
             .map_err(|e| RunnerError::Internal(format!("create addon dir: {e}")))?;
@@ -1564,6 +1573,68 @@ PY
         .unwrap();
 
         assert_eq!(file_mode(&registry_path), 0o600);
+    }
+
+    #[tokio::test]
+    async fn mitm_proxy_new_purges_stale_addon_files() {
+        let dir = tempfile::tempdir().unwrap();
+        let addon_dir = dir.path().join("addon");
+        let stale_addon = addon_dir.join("old_module.py");
+        std::fs::create_dir(&addon_dir).unwrap();
+        std::fs::write(&stale_addon, b"stale").unwrap();
+
+        let (_proxy, _crash_rx) = MitmProxy::new(ProxyConfig {
+            mitmdump_bin: dir.path().join("mitmdump"),
+            ca_dir: dir.path().join("ca"),
+            addon_dir: addon_dir.clone(),
+            registry_path: dir.path().join("proxy-registry.json"),
+            registry_lock_path: dir.path().join("proxy-registry.json.lock"),
+            api_url: None,
+        })
+        .await
+        .unwrap();
+
+        assert!(
+            !stale_addon.exists(),
+            "stale addon files should be purged before writing embedded addons"
+        );
+    }
+
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn mitm_proxy_new_returns_error_when_addon_dir_removal_fails() {
+        if nix::unistd::geteuid().is_root() {
+            return;
+        }
+
+        let dir = tempfile::tempdir().unwrap();
+        let addon_dir = dir.path().join("addon");
+        let blocked_dir = addon_dir.join("blocked");
+        std::fs::create_dir(&addon_dir).unwrap();
+        std::fs::create_dir(&blocked_dir).unwrap();
+        std::fs::write(blocked_dir.join("stale.py"), b"stale").unwrap();
+        std::fs::set_permissions(&blocked_dir, std::fs::Permissions::from_mode(0o500)).unwrap();
+
+        let result = MitmProxy::new(ProxyConfig {
+            mitmdump_bin: dir.path().join("mitmdump"),
+            ca_dir: dir.path().join("ca"),
+            addon_dir: addon_dir.clone(),
+            registry_path: dir.path().join("proxy-registry.json"),
+            registry_lock_path: dir.path().join("proxy-registry.json.lock"),
+            api_url: None,
+        })
+        .await;
+
+        if blocked_dir.exists() {
+            std::fs::set_permissions(&blocked_dir, std::fs::Permissions::from_mode(0o700)).unwrap();
+        }
+        match result {
+            Ok(_) => panic!("MitmProxy::new should fail when addon dir removal fails"),
+            Err(error) => assert!(
+                error.to_string().contains("remove addon dir"),
+                "unexpected error: {error}"
+            ),
+        }
     }
 
     #[tokio::test]

--- a/crates/runner/src/proxy.rs
+++ b/crates/runner/src/proxy.rs
@@ -1,4 +1,6 @@
 use std::collections::HashMap;
+#[cfg(unix)]
+use std::os::fd::AsRawFd;
 use std::path::{Path, PathBuf};
 use std::sync::Arc;
 use std::sync::atomic::{AtomicBool, Ordering};
@@ -1022,7 +1024,7 @@ async fn write_registry(path: &std::path::Path, value: &ProxyRegistry) -> Runner
             .open(&tmp)
             .await
             .map_err(|e| RunnerError::Internal(format!("open registry tmp: {e}")))?;
-        set_private_registry_file_permissions(&tmp, "registry tmp").await?;
+        set_private_registry_file_permissions(&file, "registry tmp")?;
         file.write_all(content.as_bytes())
             .await
             .map_err(|e| RunnerError::Internal(format!("write registry tmp: {e}")))?;
@@ -1033,8 +1035,7 @@ async fn write_registry(path: &std::path::Path, value: &ProxyRegistry) -> Runner
 
         tokio::fs::rename(&tmp, path)
             .await
-            .map_err(|e| RunnerError::Internal(format!("rename registry: {e}")))?;
-        set_private_registry_file_permissions(path, "registry").await
+            .map_err(|e| RunnerError::Internal(format!("rename registry: {e}")))
     }
     .await;
 
@@ -1044,19 +1045,20 @@ async fn write_registry(path: &std::path::Path, value: &ProxyRegistry) -> Runner
     result
 }
 
-async fn set_private_registry_file_permissions(
-    path: &std::path::Path,
-    label: &str,
-) -> RunnerResult<()> {
+fn set_private_registry_file_permissions(file: &tokio::fs::File, label: &str) -> RunnerResult<()> {
     #[cfg(unix)]
     {
-        use std::os::unix::fs::PermissionsExt;
-        tokio::fs::set_permissions(path, std::fs::Permissions::from_mode(0o600))
-            .await
-            .map_err(|e| RunnerError::Internal(format!("chmod {label}: {e}")))?;
+        // SAFETY: `fchmod` operates on the live fd and does not follow paths.
+        let result = unsafe { nix::libc::fchmod(file.as_raw_fd(), 0o600) };
+        if result != 0 {
+            return Err(RunnerError::Internal(format!(
+                "chmod {label}: {}",
+                std::io::Error::last_os_error()
+            )));
+        }
     }
     #[cfg(not(unix))]
-    let _ = (path, label);
+    let _ = (file, label);
     Ok(())
 }
 

--- a/crates/runner/src/proxy.rs
+++ b/crates/runner/src/proxy.rs
@@ -5,7 +5,7 @@ use std::sync::atomic::{AtomicBool, Ordering};
 use std::time::{Duration, SystemTime, UNIX_EPOCH};
 
 use serde::{Deserialize, Serialize};
-use tokio::io::AsyncBufReadExt;
+use tokio::io::{AsyncBufReadExt, AsyncWriteExt};
 use tokio::sync::mpsc;
 use tracing::{info, warn};
 use uuid::Uuid;
@@ -914,12 +914,54 @@ async fn write_registry(path: &std::path::Path, value: &ProxyRegistry) -> Runner
     let content = serde_json::to_string(value)
         .map_err(|e| RunnerError::Internal(format!("serialize registry: {e}")))?;
     let tmp = path.with_extension("json.tmp");
-    tokio::fs::write(&tmp, content)
+
+    match tokio::fs::remove_file(&tmp).await {
+        Ok(()) => {}
+        Err(e) if e.kind() == std::io::ErrorKind::NotFound => {}
+        Err(e) => {
+            return Err(RunnerError::Internal(format!(
+                "remove stale registry tmp: {e}"
+            )));
+        }
+    }
+
+    let mut options = tokio::fs::OpenOptions::new();
+    options.write(true).create_new(true);
+    #[cfg(unix)]
+    options.mode(0o600);
+    let mut file = options
+        .open(&tmp)
+        .await
+        .map_err(|e| RunnerError::Internal(format!("open registry tmp: {e}")))?;
+    set_private_registry_file_permissions(&tmp, "registry tmp").await?;
+    file.write_all(content.as_bytes())
         .await
         .map_err(|e| RunnerError::Internal(format!("write registry tmp: {e}")))?;
+    file.flush()
+        .await
+        .map_err(|e| RunnerError::Internal(format!("flush registry tmp: {e}")))?;
+    drop(file);
+
     tokio::fs::rename(&tmp, path)
         .await
-        .map_err(|e| RunnerError::Internal(format!("rename registry: {e}")))
+        .map_err(|e| RunnerError::Internal(format!("rename registry: {e}")))?;
+    set_private_registry_file_permissions(path, "registry").await
+}
+
+async fn set_private_registry_file_permissions(
+    path: &std::path::Path,
+    label: &str,
+) -> RunnerResult<()> {
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt;
+        tokio::fs::set_permissions(path, std::fs::Permissions::from_mode(0o600))
+            .await
+            .map_err(|e| RunnerError::Internal(format!("chmod {label}: {e}")))?;
+    }
+    #[cfg(not(unix))]
+    let _ = (path, label);
+    Ok(())
 }
 
 /// Lightweight, cloneable handle for proxy registry operations.
@@ -1069,6 +1111,10 @@ PY
         let mut perms = std::fs::metadata(path).unwrap().permissions();
         perms.set_mode(0o755);
         std::fs::set_permissions(path, perms).unwrap();
+    }
+
+    fn file_mode(path: &Path) -> u32 {
+        std::fs::metadata(path).unwrap().permissions().mode() & 0o777
     }
 
     #[cfg(target_os = "linux")]
@@ -1275,6 +1321,77 @@ PY
             !loaded.vms.contains_key("10.200.0.2"),
             "VM should be removed from registry"
         );
+    }
+
+    #[tokio::test]
+    async fn write_registry_creates_private_file() {
+        let dir = tempfile::tempdir().unwrap();
+        let registry_path = dir.path().join("proxy-registry.json");
+        let registry = ProxyRegistry {
+            vms: HashMap::new(),
+            updated_at: 0,
+        };
+
+        write_registry(&registry_path, &registry).await.unwrap();
+
+        assert_eq!(file_mode(&registry_path), 0o600);
+    }
+
+    #[tokio::test]
+    async fn write_registry_tightens_existing_wide_file() {
+        let dir = tempfile::tempdir().unwrap();
+        let registry_path = dir.path().join("proxy-registry.json");
+        std::fs::write(&registry_path, r#"{"vms":{},"updatedAt":0}"#).unwrap();
+        std::fs::set_permissions(&registry_path, std::fs::Permissions::from_mode(0o644)).unwrap();
+        let registry = ProxyRegistry {
+            vms: HashMap::new(),
+            updated_at: 1,
+        };
+
+        write_registry(&registry_path, &registry).await.unwrap();
+
+        assert_eq!(file_mode(&registry_path), 0o600);
+        let loaded = read_registry(&registry_path).await.unwrap();
+        assert_eq!(loaded.updated_at, 1);
+    }
+
+    #[tokio::test]
+    async fn write_registry_removes_stale_wide_tmp_file() {
+        let dir = tempfile::tempdir().unwrap();
+        let registry_path = dir.path().join("proxy-registry.json");
+        let tmp_path = registry_path.with_extension("json.tmp");
+        std::fs::write(&tmp_path, r#"{"vms":{},"updatedAt":999}"#).unwrap();
+        std::fs::set_permissions(&tmp_path, std::fs::Permissions::from_mode(0o644)).unwrap();
+        let registry = ProxyRegistry {
+            vms: HashMap::new(),
+            updated_at: 2,
+        };
+
+        write_registry(&registry_path, &registry).await.unwrap();
+
+        assert!(!tmp_path.exists(), "stale registry tmp should not remain");
+        assert_eq!(file_mode(&registry_path), 0o600);
+        let loaded = read_registry(&registry_path).await.unwrap();
+        assert_eq!(loaded.updated_at, 2);
+    }
+
+    #[tokio::test]
+    async fn mitm_proxy_new_creates_private_registry() {
+        let dir = tempfile::tempdir().unwrap();
+        let registry_path = dir.path().join("proxy-registry.json");
+
+        let (_proxy, _crash_rx) = MitmProxy::new(ProxyConfig {
+            mitmdump_bin: dir.path().join("mitmdump"),
+            ca_dir: dir.path().join("ca"),
+            addon_dir: dir.path().join("addon"),
+            registry_path: registry_path.clone(),
+            registry_lock_path: dir.path().join("proxy-registry.json.lock"),
+            api_url: None,
+        })
+        .await
+        .unwrap();
+
+        assert_eq!(file_mode(&registry_path), 0o600);
     }
 
     #[tokio::test]

--- a/crates/runner/src/proxy.rs
+++ b/crates/runner/src/proxy.rs
@@ -89,6 +89,7 @@ pub const USAGE_FLUSH_TIMEOUT: Duration = Duration::from_secs(30);
 
 /// Poll interval when waiting for usage flush.
 const USAGE_FLUSH_POLL: Duration = Duration::from_millis(200);
+const USAGE_PENDING_MAX_BYTES: u64 = 64 * 1024;
 
 /// Minimum interval between repeated runner-triggered usage flush requests
 /// while the addon is not ready.
@@ -501,7 +502,7 @@ async fn read_usage_pending_file(path: &Path) -> std::io::Result<String> {
     options
         .read(true)
         .custom_flags(nix::libc::O_NOFOLLOW | nix::libc::O_CLOEXEC | nix::libc::O_NONBLOCK);
-    let mut file = options.open(path).await?;
+    let file = options.open(path).await?;
     let metadata = file.metadata().await?;
     if !metadata.is_file() {
         return Err(std::io::Error::new(
@@ -509,14 +510,33 @@ async fn read_usage_pending_file(path: &Path) -> std::io::Result<String> {
             format!("{} is not a regular usage-pending file", path.display()),
         ));
     }
+    read_usage_pending_file_content(file, path).await
+}
+
+async fn read_usage_pending_file_content(
+    file: tokio::fs::File,
+    path: &Path,
+) -> std::io::Result<String> {
+    let mut limited = file.take(USAGE_PENDING_MAX_BYTES + 1);
     let mut content = String::new();
-    file.read_to_string(&mut content).await?;
+    limited.read_to_string(&mut content).await?;
+    if content.len() as u64 > USAGE_PENDING_MAX_BYTES {
+        return Err(std::io::Error::new(
+            std::io::ErrorKind::InvalidData,
+            format!(
+                "{} exceeds {} bytes",
+                path.display(),
+                USAGE_PENDING_MAX_BYTES
+            ),
+        ));
+    }
     Ok(content)
 }
 
 #[cfg(not(unix))]
 async fn read_usage_pending_file(path: &Path) -> std::io::Result<String> {
-    tokio::fs::read_to_string(path).await
+    let file = tokio::fs::File::open(path).await?;
+    read_usage_pending_file_content(file, path).await
 }
 
 fn validate_usage_pending_state(
@@ -2320,6 +2340,20 @@ while True:
                 .expect("usage-pending FIFO read should not block");
 
         assert!(result.is_err(), "usage-pending FIFO should be rejected");
+    }
+
+    #[tokio::test]
+    async fn read_usage_pending_file_rejects_large_file() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("usage-pending");
+        std::fs::write(&path, vec![b'x'; (USAGE_PENDING_MAX_BYTES + 1) as usize]).unwrap();
+
+        let result = read_usage_pending_file(&path).await;
+
+        assert!(
+            result.is_err(),
+            "oversized usage-pending file should be rejected"
+        );
     }
 
     #[tokio::test(start_paused = true)]

--- a/crates/runner/src/proxy.rs
+++ b/crates/runner/src/proxy.rs
@@ -518,8 +518,8 @@ async fn read_usage_pending_file_content(
     path: &Path,
 ) -> std::io::Result<String> {
     let mut limited = file.take(USAGE_PENDING_MAX_BYTES + 1);
-    let mut content = String::new();
-    limited.read_to_string(&mut content).await?;
+    let mut content = Vec::new();
+    limited.read_to_end(&mut content).await?;
     if content.len() as u64 > USAGE_PENDING_MAX_BYTES {
         return Err(std::io::Error::new(
             std::io::ErrorKind::InvalidData,
@@ -530,7 +530,7 @@ async fn read_usage_pending_file_content(
             ),
         ));
     }
-    Ok(content)
+    String::from_utf8(content).map_err(|e| std::io::Error::new(std::io::ErrorKind::InvalidData, e))
 }
 
 #[cfg(not(unix))]

--- a/crates/runner/src/proxy.rs
+++ b/crates/runner/src/proxy.rs
@@ -90,6 +90,7 @@ pub const USAGE_FLUSH_TIMEOUT: Duration = Duration::from_secs(30);
 /// Poll interval when waiting for usage flush.
 const USAGE_FLUSH_POLL: Duration = Duration::from_millis(200);
 const USAGE_PENDING_MAX_BYTES: u64 = 64 * 1024;
+const PROXY_REGISTRY_MAX_BYTES: u64 = 1024 * 1024;
 
 /// Minimum interval between repeated runner-triggered usage flush requests
 /// while the addon is not ready.
@@ -944,11 +945,54 @@ fn find_available_port() -> RunnerResult<u16> {
 
 /// Read the proxy registry JSON file.
 async fn read_registry(path: &std::path::Path) -> RunnerResult<ProxyRegistry> {
-    let content = tokio::fs::read_to_string(path)
+    let content = read_registry_file(path)
         .await
         .map_err(|e| RunnerError::Internal(format!("read registry: {e}")))?;
     serde_json::from_str(&content)
         .map_err(|e| RunnerError::Internal(format!("parse registry: {e}")))
+}
+
+#[cfg(unix)]
+async fn read_registry_file(path: &std::path::Path) -> std::io::Result<String> {
+    let mut options = tokio::fs::OpenOptions::new();
+    options
+        .read(true)
+        .custom_flags(nix::libc::O_NOFOLLOW | nix::libc::O_CLOEXEC | nix::libc::O_NONBLOCK);
+    let file = options.open(path).await?;
+    let metadata = file.metadata().await?;
+    if !metadata.is_file() {
+        return Err(std::io::Error::new(
+            std::io::ErrorKind::InvalidData,
+            format!("{} is not a regular proxy registry file", path.display()),
+        ));
+    }
+    read_registry_file_content(file, path).await
+}
+
+async fn read_registry_file_content(
+    file: tokio::fs::File,
+    path: &std::path::Path,
+) -> std::io::Result<String> {
+    let mut limited = file.take(PROXY_REGISTRY_MAX_BYTES + 1);
+    let mut content = Vec::new();
+    limited.read_to_end(&mut content).await?;
+    if content.len() as u64 > PROXY_REGISTRY_MAX_BYTES {
+        return Err(std::io::Error::new(
+            std::io::ErrorKind::InvalidData,
+            format!(
+                "{} exceeds {} bytes",
+                path.display(),
+                PROXY_REGISTRY_MAX_BYTES
+            ),
+        ));
+    }
+    String::from_utf8(content).map_err(|e| std::io::Error::new(std::io::ErrorKind::InvalidData, e))
+}
+
+#[cfg(not(unix))]
+async fn read_registry_file(path: &std::path::Path) -> std::io::Result<String> {
+    let file = tokio::fs::File::open(path).await?;
+    read_registry_file_content(file, path).await
 }
 
 /// Write the proxy registry JSON file atomically (write tmp + rename).
@@ -1446,6 +1490,59 @@ PY
         );
         assert!(!tmp_path.exists(), "registry tmp should be cleaned up");
         assert!(registry_path.is_dir());
+    }
+
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn read_registry_rejects_fifo_without_blocking() {
+        use std::os::unix::ffi::OsStrExt;
+
+        let dir = tempfile::tempdir().unwrap();
+        let registry_path = dir.path().join("proxy-registry.json");
+        let c_path = std::ffi::CString::new(registry_path.as_os_str().as_bytes()).unwrap();
+        let result = unsafe { nix::libc::mkfifo(c_path.as_ptr(), 0o600) };
+        assert_eq!(
+            result,
+            0,
+            "mkfifo failed: {}",
+            std::io::Error::last_os_error()
+        );
+
+        let result =
+            tokio::time::timeout(Duration::from_millis(100), read_registry(&registry_path))
+                .await
+                .expect("registry FIFO read should not block");
+
+        assert!(result.is_err(), "registry FIFO should be rejected");
+    }
+
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn read_registry_rejects_symlink_without_following_it() {
+        let dir = tempfile::tempdir().unwrap();
+        let registry_path = dir.path().join("proxy-registry.json");
+        let outside = dir.path().join("outside-registry.json");
+        std::fs::write(&outside, r#"{"vms":{},"updatedAt":42}"#).unwrap();
+        std::os::unix::fs::symlink(&outside, &registry_path).unwrap();
+
+        let result = read_registry(&registry_path).await;
+
+        assert!(result.is_err(), "registry symlink should be rejected");
+    }
+
+    #[tokio::test]
+    async fn read_registry_rejects_large_file() {
+        let dir = tempfile::tempdir().unwrap();
+        let registry_path = dir.path().join("proxy-registry.json");
+        std::fs::write(
+            &registry_path,
+            vec![b'x'; (PROXY_REGISTRY_MAX_BYTES + 1) as usize],
+        )
+        .unwrap();
+
+        let result = read_registry(&registry_path).await;
+
+        assert!(result.is_err(), "oversized registry should be rejected");
     }
 
     #[tokio::test]

--- a/crates/runner/src/proxy.rs
+++ b/crates/runner/src/proxy.rs
@@ -1519,10 +1519,9 @@ PY
             std::io::Error::last_os_error()
         );
 
-        let result =
-            tokio::time::timeout(Duration::from_millis(100), read_registry(&registry_path))
-                .await
-                .expect("registry FIFO read should not block");
+        let result = tokio::time::timeout(Duration::from_secs(1), read_registry(&registry_path))
+            .await
+            .expect("registry FIFO read should not block");
 
         assert!(result.is_err(), "registry FIFO should be rejected");
     }
@@ -2504,10 +2503,9 @@ while True:
             std::io::Error::last_os_error()
         );
 
-        let result =
-            tokio::time::timeout(Duration::from_millis(100), read_usage_pending_file(&path))
-                .await
-                .expect("usage-pending FIFO read should not block");
+        let result = tokio::time::timeout(Duration::from_secs(1), read_usage_pending_file(&path))
+            .await
+            .expect("usage-pending FIFO read should not block");
 
         assert!(result.is_err(), "usage-pending FIFO should be rejected");
     }

--- a/crates/runner/src/run_resolution.rs
+++ b/crates/runner/src/run_resolution.rs
@@ -286,7 +286,7 @@ mod tests {
         );
 
         let result = tokio::time::timeout(
-            std::time::Duration::from_millis(100),
+            std::time::Duration::from_secs(1),
             read_active_runs(dir.path()),
         )
         .await

--- a/crates/runner/src/run_resolution.rs
+++ b/crates/runner/src/run_resolution.rs
@@ -50,8 +50,17 @@ async fn read_active_runs(base_dir: &Path) -> Option<Vec<(String, String)>> {
         sandbox_id: String,
     }
     let path = base_dir.join("status.json");
-    let content = match tokio::fs::read_to_string(&path).await {
-        Ok(c) => c,
+    let content = match crate::private_fs::read_private_file_to_string_with_max(
+        &path,
+        crate::private_fs::PRIVATE_STATUS_FILE_READ_MAX_BYTES,
+    )
+    .await
+    {
+        Ok(Some(c)) => c,
+        Ok(None) => {
+            tracing::warn!(path = %path.display(), "skipping runner: status.json not found");
+            return None;
+        }
         Err(e) => {
             tracing::warn!(path = %path.display(), error = %e, "skipping runner: cannot read status.json");
             return None;
@@ -258,6 +267,32 @@ mod tests {
         let dir = tempfile::tempdir().unwrap();
         std::fs::write(dir.path().join("status.json"), "not json").unwrap();
         assert!(read_active_runs(dir.path()).await.is_none());
+    }
+
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn read_active_runs_rejects_fifo_without_blocking() {
+        use std::os::unix::ffi::OsStrExt;
+
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("status.json");
+        let c_path = std::ffi::CString::new(path.as_os_str().as_bytes()).unwrap();
+        let result = unsafe { nix::libc::mkfifo(c_path.as_ptr(), 0o600) };
+        assert_eq!(
+            result,
+            0,
+            "mkfifo failed: {}",
+            std::io::Error::last_os_error()
+        );
+
+        let result = tokio::time::timeout(
+            std::time::Duration::from_millis(100),
+            read_active_runs(dir.path()),
+        )
+        .await
+        .expect("status.json FIFO read should not block");
+
+        assert!(result.is_none(), "status.json FIFO should be skipped");
     }
 
     #[test]

--- a/crates/runner/src/status.rs
+++ b/crates/runner/src/status.rs
@@ -234,13 +234,8 @@ impl StatusTracker {
             }
         };
 
-        let tmp = self.path.with_extension("tmp");
-        if let Err(e) = tokio::fs::write(&tmp, json.as_bytes()).await {
-            warn!(error = %e, path = %tmp.display(), "failed to write status temp file");
-            return;
-        }
-        if let Err(e) = tokio::fs::rename(&tmp, &self.path).await {
-            warn!(error = %e, "failed to rename status file");
+        if let Err(e) = crate::private_fs::write_private_file(&self.path, json.as_bytes()).await {
+            warn!(error = %e, path = %self.path.display(), "failed to write status file");
         }
     }
 }
@@ -281,6 +276,30 @@ mod tests {
         assert!(status["active_runs"].as_array().unwrap().is_empty());
         assert!(status["started_at"].as_str().is_some());
         assert!(status["updated_at"].as_str().is_some());
+    }
+
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn write_initial_does_not_follow_stale_status_temp_symlink() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("status.json");
+        let stale_target = dir.path().join("outside-status-target");
+        let stale_tmp = dir.path().join("status.tmp");
+        std::fs::write(&stale_target, b"do not overwrite").unwrap();
+        std::os::unix::fs::symlink(&stale_target, &stale_tmp).unwrap();
+        let tracker = StatusTracker::new(path.clone(), 4, None, None);
+
+        tracker.write_initial().await;
+
+        assert_eq!(std::fs::read(&stale_target).unwrap(), b"do not overwrite");
+        assert!(
+            std::fs::symlink_metadata(&stale_tmp)
+                .unwrap()
+                .file_type()
+                .is_symlink()
+        );
+        let status = read_status(&path);
+        assert_eq!(status["mode"], "running");
     }
 
     #[tokio::test]

--- a/crates/runner/src/workspace_image_cache.rs
+++ b/crates/runner/src/workspace_image_cache.rs
@@ -3765,7 +3765,7 @@ mod tests {
         );
 
         let result = tokio::time::timeout(
-            Duration::from_millis(100),
+            Duration::from_secs(1),
             cache.read_metadata_file(&metadata_path),
         )
         .await

--- a/crates/runner/src/workspace_image_cache.rs
+++ b/crates/runner/src/workspace_image_cache.rs
@@ -3587,8 +3587,9 @@ mod tests {
 
         let err = cache.inspect().await.unwrap_err();
 
+        let message = err.to_string();
         assert!(
-            err.to_string().contains("create lock dir"),
+            message.contains("create lock dir") || message.contains("not a lock directory"),
             "unexpected error: {err}"
         );
     }

--- a/crates/runner/src/workspace_image_cache.rs
+++ b/crates/runner/src/workspace_image_cache.rs
@@ -32,6 +32,7 @@ const WORKSPACE_DRIVE_LAYOUT: &str = "workspace-drive-v1";
 const GIB: u64 = 1024 * 1024 * 1024;
 const MIN_FREE_BYTES_FLOOR: u64 = 50 * GIB;
 const MAX_ENTRY_BYTES_CAP: u64 = 32 * GIB;
+const WORKSPACE_METADATA_MAX_BYTES: u64 = 1024 * 1024;
 const WORKSPACE_IMAGE_COPY_TIMEOUT: Duration = Duration::from_secs(300);
 
 #[cfg(test)]
@@ -1679,14 +1680,7 @@ impl SessionWorkspaceCache {
         &self,
         metadata_path: &Path,
     ) -> RunnerResult<WorkspaceCacheMetadata> {
-        let metadata = fs::symlink_metadata(metadata_path).await?;
-        if !metadata.is_file() {
-            return Err(RunnerError::Internal(format!(
-                "workspace image cache metadata is not a file: {}",
-                metadata_path.display()
-            )));
-        }
-        let bytes = fs::read(metadata_path).await?;
+        let bytes = read_workspace_metadata_bytes(metadata_path).await?;
         serde_json::from_slice(&bytes)
             .map_err(|e| RunnerError::Internal(format!("parse {}: {e}", metadata_path.display())))
     }
@@ -2613,6 +2607,54 @@ fn is_workspace_tmp_path_name(name: &str) -> bool {
 
 fn allocated_bytes(metadata: &std::fs::Metadata) -> u64 {
     metadata.blocks().saturating_mul(512)
+}
+
+async fn read_workspace_metadata_bytes(path: &Path) -> RunnerResult<Vec<u8>> {
+    let mut options = fs::OpenOptions::new();
+    options
+        .read(true)
+        .custom_flags(nix::libc::O_NOFOLLOW | nix::libc::O_CLOEXEC | nix::libc::O_NONBLOCK);
+    let file = options.open(path).await.map_err(|e| {
+        RunnerError::Internal(format!(
+            "open workspace image cache metadata {}: {e}",
+            path.display()
+        ))
+    })?;
+    let metadata = file.metadata().await.map_err(|e| {
+        RunnerError::Internal(format!(
+            "stat workspace image cache metadata {}: {e}",
+            path.display()
+        ))
+    })?;
+    if !metadata.is_file() {
+        return Err(RunnerError::Internal(format!(
+            "workspace image cache metadata is not a file: {}",
+            path.display()
+        )));
+    }
+    read_workspace_metadata_file_contents(file, path).await
+}
+
+async fn read_workspace_metadata_file_contents(
+    file: fs::File,
+    path: &Path,
+) -> RunnerResult<Vec<u8>> {
+    let mut limited = file.take(WORKSPACE_METADATA_MAX_BYTES + 1);
+    let mut bytes = Vec::new();
+    limited.read_to_end(&mut bytes).await.map_err(|e| {
+        RunnerError::Internal(format!(
+            "read workspace image cache metadata {}: {e}",
+            path.display()
+        ))
+    })?;
+    if bytes.len() as u64 > WORKSPACE_METADATA_MAX_BYTES {
+        return Err(RunnerError::Internal(format!(
+            "workspace image cache metadata {} exceeds {} bytes",
+            path.display(),
+            WORKSPACE_METADATA_MAX_BYTES
+        )));
+    }
+    Ok(bytes)
 }
 
 fn fs_stats_with_additional_available(stats: FsStats, bytes: u64) -> FsStats {
@@ -3674,6 +3716,62 @@ mod tests {
         let entry = &inspection.entries[0];
         assert_eq!(entry.status, WorkspaceImageCacheInspectionStatus::Invalid);
         assert_eq!(entry.reason.as_deref(), Some("missing or invalid metadata"));
+    }
+
+    #[tokio::test]
+    async fn read_metadata_file_rejects_large_file() {
+        let dir = tempfile::tempdir().unwrap();
+        let paths = RunnerPaths::new(dir.path().join("runner"));
+        let cache = SessionWorkspaceCache::new(paths.clone());
+        let key = session_workspace_cache_key("sess-1", "/workspace");
+        fs::create_dir_all(paths.session_workspace_cache_entry_dir(&key))
+            .await
+            .unwrap();
+        let metadata_path = paths.session_workspace_cache_metadata(&key);
+        fs::write(
+            &metadata_path,
+            vec![b'x'; (WORKSPACE_METADATA_MAX_BYTES + 1) as usize],
+        )
+        .await
+        .unwrap();
+
+        let error = cache.read_metadata_file(&metadata_path).await.unwrap_err();
+
+        assert!(
+            error.to_string().contains("exceeds"),
+            "unexpected error: {error}"
+        );
+    }
+
+    #[tokio::test]
+    async fn read_metadata_file_rejects_fifo_without_blocking() {
+        use std::os::unix::ffi::OsStrExt;
+
+        let dir = tempfile::tempdir().unwrap();
+        let paths = RunnerPaths::new(dir.path().join("runner"));
+        let cache = SessionWorkspaceCache::new(paths.clone());
+        let key = session_workspace_cache_key("sess-1", "/workspace");
+        fs::create_dir_all(paths.session_workspace_cache_entry_dir(&key))
+            .await
+            .unwrap();
+        let metadata_path = paths.session_workspace_cache_metadata(&key);
+        let c_path = std::ffi::CString::new(metadata_path.as_os_str().as_bytes()).unwrap();
+        let result = unsafe { nix::libc::mkfifo(c_path.as_ptr(), 0o600) };
+        assert_eq!(
+            result,
+            0,
+            "mkfifo failed: {}",
+            std::io::Error::last_os_error()
+        );
+
+        let result = tokio::time::timeout(
+            Duration::from_millis(100),
+            cache.read_metadata_file(&metadata_path),
+        )
+        .await
+        .expect("metadata FIFO read should not block");
+
+        assert!(result.is_err(), "metadata FIFO should be rejected");
     }
 
     #[tokio::test]


### PR DESCRIPTION
## Summary

- enforce runner filesystem hardening around private runtime state, logs, locks, and setup artifacts
- make runner `base_dir` current-euid-owned private state, created/tightened to `0700`
- write same-boundary runtime files (`runner_id`, `status.json`, generated `runner.yaml`) through private `0600` temp-file + rename helpers
- read private runtime files with no symlink following, nonblocking opens, regular-file validation, owner checks, and bounded file sizes
- write proxy registry temp/final files with `0600` permissions, stale temp cleanup, and same-directory atomic rename
- harden runner logs and copied guest logs with private modes, no symlink following, and special-file rejection
- harden lock/setup filesystem paths against symlink/path replacement, untrusted owners, and unsafe inherited modes
- harden workspace image cache metadata reads against symlink/special-file replacement and oversized metadata files

## Compatibility

- runner runtime state is owned by the runner effective uid, normally root
- runtime state should not be chowned back to `SUDO_USER`
- direct non-root reads of runner runtime state and logs are unsupported
- hosts with unexpected ownership or unsafe modes should fail fast with actionable errors; fix ownership/modes intentionally outside the runner

## Tests

- cargo test --manifest-path crates/Cargo.toml -p runner private_fs
- cargo test --manifest-path crates/Cargo.toml -p runner proxy
- cargo test --manifest-path crates/Cargo.toml -p runner log_fs
- cargo test --manifest-path crates/Cargo.toml -p runner lock
- cargo test --manifest-path crates/Cargo.toml -p runner workspace_image_cache
- cargo test --manifest-path crates/Cargo.toml -p runner
- cargo fmt --manifest-path crates/Cargo.toml --all -- --check
- cargo clippy --manifest-path crates/Cargo.toml -p runner --all-targets -- -D warnings
- CI runner image/build and runner e2e jobs

Closes #16377
