### PR TITLE
refactor: centralize exec operation test layouts

### DIFF
--- a/crates/vsock-proto/src/payloads/exec_operation/tests/exec_control.rs
+++ b/crates/vsock-proto/src/payloads/exec_operation/tests/exec_control.rs
@@ -1,4 +1,5 @@
 use super::super::*;
+use super::shared::{ExecControlLayout, set_byte_at, write_u16_at, write_u32_at};
 use super::{NONCE, assert_invalid_payload};
 use crate::payloads::exec_control::EXEC_CONTROL_MAX_PAYLOAD_BYTES;
 
@@ -9,33 +10,10 @@ fn exec_control_payload() -> Vec<u8> {
     encode_exec_control(7, NONCE, MESSAGE_ID, BODY, 5000).unwrap()
 }
 
-fn request_timeout_field_offset() -> usize {
-    4
-}
-
-fn nonce_byte_offset() -> usize {
-    request_timeout_field_offset() + 4
-}
-
-fn message_id_len_field_offset() -> usize {
-    nonce_byte_offset() + EXEC_CONTROL_NONCE_LEN
-}
-
-fn message_id_byte_offset() -> usize {
-    message_id_len_field_offset() + 2
-}
-
-fn payload_len_field_offset(message_id: &str) -> usize {
-    message_id_byte_offset() + message_id.len()
-}
-
-fn payload_byte_offset(message_id: &str) -> usize {
-    payload_len_field_offset(message_id) + 4
-}
-
 #[test]
 fn exec_control_roundtrip_and_rejects_malformed_payloads() {
     let payload = exec_control_payload();
+    let layout = ExecControlLayout::new(MESSAGE_ID, BODY);
     let decoded = decode_exec_control(&payload).unwrap();
     assert_eq!(decoded.target_seq, 7);
     assert_eq!(decoded.request_timeout_ms, 5000);
@@ -61,7 +39,7 @@ fn exec_control_roundtrip_and_rejects_malformed_payloads() {
     ));
 
     let mut zero_target_seq = payload.clone();
-    zero_target_seq[..4].copy_from_slice(&0u32.to_be_bytes());
+    write_u32_at(&mut zero_target_seq, layout.target_seq_offset, 0);
     assert!(matches!(
         decode_exec_control(&zero_target_seq),
         Err(ProtocolError::InvalidPayload(
@@ -80,26 +58,25 @@ fn exec_control_roundtrip_and_rejects_malformed_payloads() {
     ));
 
     let mut empty_message_id = exec_control_payload();
-    let message_id_len_offset = message_id_len_field_offset();
-    empty_message_id[message_id_len_offset..message_id_len_offset + 2]
-        .copy_from_slice(&0u16.to_be_bytes());
+    write_u16_at(&mut empty_message_id, layout.message_id_len_offset, 0);
     assert_invalid_payload(
         decode_exec_control(&empty_message_id).unwrap_err(),
         "exec_control message_id empty",
     );
 
     let mut invalid_message_id = exec_control_payload();
-    let message_id_offset = message_id_byte_offset();
-    invalid_message_id[message_id_offset] = 0xFF;
+    set_byte_at(&mut invalid_message_id, layout.message_id_offset, 0xFF);
     assert_invalid_payload(
         decode_exec_control(&invalid_message_id).unwrap_err(),
         "invalid UTF-8 in exec_control message_id",
     );
 
     let mut oversized_payload_len = exec_control_payload();
-    let payload_len_offset = payload_len_field_offset(MESSAGE_ID);
-    oversized_payload_len[payload_len_offset..payload_len_offset + 4]
-        .copy_from_slice(&((EXEC_CONTROL_MAX_PAYLOAD_BYTES as u32) + 1).to_be_bytes());
+    write_u32_at(
+        &mut oversized_payload_len,
+        layout.payload_len_offset,
+        (EXEC_CONTROL_MAX_PAYLOAD_BYTES as u32) + 1,
+    );
     assert_invalid_payload(
         decode_exec_control(&oversized_payload_len).unwrap_err(),
         "exec_control payload too large",
@@ -115,39 +92,35 @@ fn exec_control_roundtrip_and_rejects_malformed_payloads() {
 #[test]
 fn exec_control_rejects_truncated_fields() {
     let payload = exec_control_payload();
-    let request_timeout_offset = request_timeout_field_offset();
-    let nonce_offset = nonce_byte_offset();
-    let message_id_len_offset = message_id_len_field_offset();
-    let message_id_offset = message_id_byte_offset();
-    let payload_len_offset = payload_len_field_offset(MESSAGE_ID);
-    let payload_offset = payload_byte_offset(MESSAGE_ID);
+    let layout = ExecControlLayout::new(MESSAGE_ID, BODY);
 
     assert_invalid_payload(
         decode_exec_control(&payload[..3]).unwrap_err(),
         "exec_control target_seq truncated",
     );
     assert_invalid_payload(
-        decode_exec_control(&payload[..request_timeout_offset + 3]).unwrap_err(),
+        decode_exec_control(&payload[..layout.request_timeout_offset + 3]).unwrap_err(),
         "exec_control request_timeout_ms truncated",
     );
     assert_invalid_payload(
-        decode_exec_control(&payload[..nonce_offset + EXEC_CONTROL_NONCE_LEN - 1]).unwrap_err(),
+        decode_exec_control(&payload[..layout.nonce_offset + EXEC_CONTROL_NONCE_LEN - 1])
+            .unwrap_err(),
         "exec_control nonce truncated",
     );
     assert_invalid_payload(
-        decode_exec_control(&payload[..message_id_len_offset + 1]).unwrap_err(),
+        decode_exec_control(&payload[..layout.message_id_len_offset + 1]).unwrap_err(),
         "exec_control message_id_len truncated",
     );
     assert_invalid_payload(
-        decode_exec_control(&payload[..message_id_offset + 2]).unwrap_err(),
+        decode_exec_control(&payload[..layout.message_id_offset + 2]).unwrap_err(),
         "exec_control message_id truncated",
     );
     assert_invalid_payload(
-        decode_exec_control(&payload[..payload_len_offset + 3]).unwrap_err(),
+        decode_exec_control(&payload[..layout.payload_len_offset + 3]).unwrap_err(),
         "exec_control payload_len truncated",
     );
     assert_invalid_payload(
-        decode_exec_control(&payload[..payload_offset + 2]).unwrap_err(),
+        decode_exec_control(&payload[..layout.payload_end_offset - 2]).unwrap_err(),
         "exec_control payload truncated",
     );
 }

--- a/crates/vsock-proto/src/payloads/exec_operation/tests/exec_control_result.rs
+++ b/crates/vsock-proto/src/payloads/exec_operation/tests/exec_control_result.rs
@@ -1,4 +1,5 @@
 use super::super::*;
+use super::shared::{ExecControlResultLayout, set_byte_at, write_u16_at, write_u32_at};
 use super::{NONCE, assert_invalid_payload};
 
 const MESSAGE_ID: &str = "message";
@@ -15,29 +16,10 @@ fn delivered_result_payload() -> Vec<u8> {
     .unwrap()
 }
 
-fn message_id_len_field_offset() -> usize {
-    4 + EXEC_CONTROL_NONCE_LEN
-}
-
-fn message_id_byte_offset() -> usize {
-    message_id_len_field_offset() + 2
-}
-
-fn status_tag_offset(message_id: &str) -> usize {
-    message_id_byte_offset() + message_id.len()
-}
-
-fn diagnostic_len_field_offset(message_id: &str) -> usize {
-    status_tag_offset(message_id) + 1
-}
-
-fn diagnostic_byte_offset(message_id: &str) -> usize {
-    diagnostic_len_field_offset(message_id) + 2
-}
-
 #[test]
 fn exec_control_result_roundtrip_and_rejects_malformed_payloads() {
     let payload = delivered_result_payload();
+    let layout = ExecControlResultLayout::new(MESSAGE_ID, DIAGNOSTIC);
     let decoded = decode_exec_control_result(&payload).unwrap();
     assert_eq!(decoded.target_seq, 7);
     assert_eq!(decoded.control_nonce, NONCE);
@@ -62,7 +44,7 @@ fn exec_control_result_roundtrip_and_rejects_malformed_payloads() {
     ));
 
     let mut zero_target_seq = payload.clone();
-    zero_target_seq[..4].copy_from_slice(&0u32.to_be_bytes());
+    write_u32_at(&mut zero_target_seq, layout.target_seq_offset, 0);
     assert!(matches!(
         decode_exec_control_result(&zero_target_seq),
         Err(ProtocolError::InvalidPayload(
@@ -75,25 +57,21 @@ fn exec_control_result_roundtrip_and_rejects_malformed_payloads() {
     assert_invalid_payload(err, "exec_control_result message_id empty");
 
     let mut empty_message_id = delivered_result_payload();
-    let message_id_len_offset = message_id_len_field_offset();
-    empty_message_id[message_id_len_offset..message_id_len_offset + 2]
-        .copy_from_slice(&0u16.to_be_bytes());
+    write_u16_at(&mut empty_message_id, layout.message_id_len_offset, 0);
     assert_invalid_payload(
         decode_exec_control_result(&empty_message_id).unwrap_err(),
         "exec_control_result message_id empty",
     );
 
     let mut invalid_message_id = delivered_result_payload();
-    let message_id_offset = message_id_byte_offset();
-    invalid_message_id[message_id_offset] = 0xFF;
+    set_byte_at(&mut invalid_message_id, layout.message_id_offset, 0xFF);
     assert_invalid_payload(
         decode_exec_control_result(&invalid_message_id).unwrap_err(),
         "invalid UTF-8 in exec_control_result message_id",
     );
 
     let mut unknown_status = payload.clone();
-    let status_offset = status_tag_offset(MESSAGE_ID);
-    unknown_status[status_offset] = 0xFE;
+    set_byte_at(&mut unknown_status, layout.status_offset, 0xFE);
     assert!(matches!(
         decode_exec_control_result(&unknown_status),
         Err(ProtocolError::InvalidPayload(
@@ -102,8 +80,7 @@ fn exec_control_result_roundtrip_and_rejects_malformed_payloads() {
     ));
 
     let mut invalid_diagnostic = payload.clone();
-    let diagnostic_offset = diagnostic_byte_offset(MESSAGE_ID);
-    invalid_diagnostic[diagnostic_offset] = 0xFF;
+    set_byte_at(&mut invalid_diagnostic, layout.diagnostic_offset, 0xFF);
     assert_invalid_payload(
         decode_exec_control_result(&invalid_diagnostic).unwrap_err(),
         "invalid UTF-8 in exec_control_result diagnostic",
@@ -131,50 +108,47 @@ fn exec_control_result_status_wire_values_are_stable() {
         (ExecControlStatus::QueueFull, 0x07),
         (ExecControlStatus::SinkError, 0x08),
     ];
-    let status_offset = status_tag_offset(MESSAGE_ID);
+    let layout = ExecControlResultLayout::new(MESSAGE_ID, DIAGNOSTIC);
 
     for &(status, expected_wire) in cases {
         let payload = encode_exec_control_result(7, NONCE, MESSAGE_ID, status, DIAGNOSTIC).unwrap();
 
-        assert_eq!(payload[status_offset], expected_wire);
+        assert_eq!(payload[layout.status_offset], expected_wire);
         assert_eq!(decode_exec_control_result(&payload).unwrap().status, status);
     }
 }
 #[test]
 fn exec_control_result_rejects_truncated_fields() {
     let payload = delivered_result_payload();
-    let message_id_len_offset = message_id_len_field_offset();
-    let message_id_offset = message_id_byte_offset();
-    let status_offset = status_tag_offset(MESSAGE_ID);
-    let diagnostic_len_offset = diagnostic_len_field_offset(MESSAGE_ID);
-    let diagnostic_offset = diagnostic_byte_offset(MESSAGE_ID);
+    let layout = ExecControlResultLayout::new(MESSAGE_ID, DIAGNOSTIC);
 
     assert_invalid_payload(
-        decode_exec_control_result(&payload[..3]).unwrap_err(),
+        decode_exec_control_result(&payload[..layout.target_seq_offset + 3]).unwrap_err(),
         "exec_control_result target_seq truncated",
     );
     assert_invalid_payload(
-        decode_exec_control_result(&payload[..4 + EXEC_CONTROL_NONCE_LEN - 1]).unwrap_err(),
+        decode_exec_control_result(&payload[..layout.nonce_offset + EXEC_CONTROL_NONCE_LEN - 1])
+            .unwrap_err(),
         "exec_control_result nonce truncated",
     );
     assert_invalid_payload(
-        decode_exec_control_result(&payload[..message_id_len_offset + 1]).unwrap_err(),
+        decode_exec_control_result(&payload[..layout.message_id_len_offset + 1]).unwrap_err(),
         "exec_control_result message_id_len truncated",
     );
     assert_invalid_payload(
-        decode_exec_control_result(&payload[..message_id_offset + 2]).unwrap_err(),
+        decode_exec_control_result(&payload[..layout.message_id_offset + 2]).unwrap_err(),
         "exec_control_result message_id truncated",
     );
     assert_invalid_payload(
-        decode_exec_control_result(&payload[..status_offset]).unwrap_err(),
+        decode_exec_control_result(&payload[..layout.status_offset]).unwrap_err(),
         "exec_control_result status truncated",
     );
     assert_invalid_payload(
-        decode_exec_control_result(&payload[..diagnostic_len_offset + 1]).unwrap_err(),
+        decode_exec_control_result(&payload[..layout.diagnostic_len_offset + 1]).unwrap_err(),
         "exec_control_result diagnostic_len truncated",
     );
     assert_invalid_payload(
-        decode_exec_control_result(&payload[..diagnostic_offset + 1]).unwrap_err(),
+        decode_exec_control_result(&payload[..layout.diagnostic_end_offset - 1]).unwrap_err(),
         "exec_control_result diagnostic truncated",
     );
 }

--- a/crates/vsock-proto/src/payloads/exec_operation/tests/exec_output.rs
+++ b/crates/vsock-proto/src/payloads/exec_operation/tests/exec_output.rs
@@ -1,4 +1,5 @@
 use super::super::*;
+use super::shared::{ExecOutputLayout, set_byte_at};
 
 #[test]
 fn exec_output_roundtrip_stdout() {
@@ -26,16 +27,17 @@ fn exec_output_roundtrip_stderr_truncated() {
 #[test]
 fn exec_output_rejects_invalid_stream_flags_and_trailing_bytes() {
     let payload = encode_exec_output(ExecOutputStream::Stdout, 1, b"chunk", false).unwrap();
+    let layout = ExecOutputLayout::new(b"chunk");
 
     let mut invalid_stream = payload.clone();
-    invalid_stream[0] = 0x99;
+    set_byte_at(&mut invalid_stream, layout.stream_offset, 0x99);
     assert!(matches!(
         decode_exec_output(&invalid_stream),
         Err(ProtocolError::InvalidPayload("invalid exec output stream"))
     ));
 
     let mut unknown_flags = payload.clone();
-    unknown_flags[5] = 0x80;
+    set_byte_at(&mut unknown_flags, layout.flags_offset, 0x80);
     assert!(matches!(
         decode_exec_output(&unknown_flags),
         Err(ProtocolError::InvalidPayload("exec output unknown flags"))
@@ -62,7 +64,8 @@ fn exec_output_rejects_truncated_fields() {
     ));
 
     let mut payload = encode_exec_output(ExecOutputStream::Stdout, 1, b"chunk", false).unwrap();
-    payload.truncate(6);
+    let layout = ExecOutputLayout::new(b"chunk");
+    payload.truncate(layout.chunk_len_offset);
     assert!(matches!(
         decode_exec_output(&payload),
         Err(ProtocolError::InvalidPayload(
@@ -71,7 +74,8 @@ fn exec_output_rejects_truncated_fields() {
     ));
 
     let mut payload = encode_exec_output(ExecOutputStream::Stdout, 1, b"chunk", false).unwrap();
-    payload.truncate(payload.len() - 1);
+    let layout = ExecOutputLayout::new(b"chunk");
+    payload.truncate(layout.chunk_end_offset - 1);
     assert!(matches!(
         decode_exec_output(&payload),
         Err(ProtocolError::InvalidPayload("exec output chunk truncated"))

--- a/crates/vsock-proto/src/payloads/exec_operation/tests/exec_result.rs
+++ b/crates/vsock-proto/src/payloads/exec_operation/tests/exec_result.rs
@@ -1,4 +1,5 @@
 use super::super::*;
+use super::shared::{ExecResultLayout, set_byte_at};
 
 #[test]
 fn exec_result_roundtrip_exited_with_captured_outputs() {
@@ -87,20 +88,20 @@ fn exec_result_roundtrip_non_exit_terminal_states() {
 }
 #[test]
 fn exec_result_rejects_invalid_tags_flags_and_trailing_bytes() {
-    let payload = encode_exec_result(
-        ExecTermination::Cancelled,
-        1,
-        ExecCapturedOutput::Captured {
-            bytes: b"out",
-            truncated: false,
-        },
-        ExecCapturedOutput::Discarded,
-        "",
-    )
-    .unwrap();
+    let stdout = ExecCapturedOutput::Captured {
+        bytes: b"out",
+        truncated: false,
+    };
+    let stderr = ExecCapturedOutput::Discarded;
+    let payload = encode_exec_result(ExecTermination::Cancelled, 1, stdout, stderr, "").unwrap();
+    let layout = ExecResultLayout::new(ExecTermination::Cancelled, stdout, stderr, "");
 
     let mut invalid_termination = payload.clone();
-    invalid_termination[0] = 0x99;
+    set_byte_at(
+        &mut invalid_termination,
+        layout.termination_tag_offset,
+        0x99,
+    );
     assert!(matches!(
         decode_exec_result(&invalid_termination),
         Err(ProtocolError::InvalidPayload(
@@ -109,7 +110,7 @@ fn exec_result_rejects_invalid_tags_flags_and_trailing_bytes() {
     ));
 
     let mut invalid_captured_tag = payload.clone();
-    invalid_captured_tag[1 + 4] = 0x99;
+    set_byte_at(&mut invalid_captured_tag, layout.stdout.tag_offset, 0x99);
     assert!(matches!(
         decode_exec_result(&invalid_captured_tag),
         Err(ProtocolError::InvalidPayload(
@@ -118,7 +119,11 @@ fn exec_result_rejects_invalid_tags_flags_and_trailing_bytes() {
     ));
 
     let mut unknown_captured_flags = payload.clone();
-    unknown_captured_flags[1 + 4 + 1] = 0x80;
+    set_byte_at(
+        &mut unknown_captured_flags,
+        layout.stdout.flags_offset.unwrap(),
+        0x80,
+    );
     assert!(matches!(
         decode_exec_result(&unknown_captured_flags),
         Err(ProtocolError::InvalidPayload(
@@ -156,7 +161,13 @@ fn exec_result_rejects_truncated_fields() {
         "",
     )
     .unwrap();
-    payload.truncate(4);
+    let layout = ExecResultLayout::new(
+        ExecTermination::Exited { exit_code: 1 },
+        ExecCapturedOutput::Discarded,
+        ExecCapturedOutput::Discarded,
+        "",
+    );
+    payload.truncate(layout.exit_code_offset.unwrap() + 3);
     assert!(matches!(
         decode_exec_result(&payload),
         Err(ProtocolError::InvalidPayload(
@@ -175,7 +186,16 @@ fn exec_result_rejects_truncated_fields() {
         "",
     )
     .unwrap();
-    payload.truncate(1 + 4 + 1 + 1 + 4 + 2);
+    let layout = ExecResultLayout::new(
+        ExecTermination::Cancelled,
+        ExecCapturedOutput::Captured {
+            bytes: b"out",
+            truncated: false,
+        },
+        ExecCapturedOutput::Discarded,
+        "",
+    );
+    payload.truncate(layout.stdout.bytes_offset.unwrap() + 2);
     assert!(matches!(
         decode_exec_result(&payload),
         Err(ProtocolError::InvalidPayload(
@@ -191,7 +211,13 @@ fn exec_result_rejects_truncated_fields() {
         "diag",
     )
     .unwrap();
-    payload.truncate(payload.len() - 1);
+    let layout = ExecResultLayout::new(
+        ExecTermination::Cancelled,
+        ExecCapturedOutput::Discarded,
+        ExecCapturedOutput::Discarded,
+        "diag",
+    );
+    payload.truncate(layout.diagnostic_end_offset - 1);
     assert!(matches!(
         decode_exec_result(&payload),
         Err(ProtocolError::InvalidPayload(
@@ -209,8 +235,13 @@ fn exec_result_rejects_invalid_diagnostic_utf8() {
         "x",
     )
     .unwrap();
-    let diagnostic_offset = payload.len() - 1;
-    payload[diagnostic_offset] = 0xFF;
+    let layout = ExecResultLayout::new(
+        ExecTermination::Cancelled,
+        ExecCapturedOutput::Discarded,
+        ExecCapturedOutput::Discarded,
+        "x",
+    );
+    set_byte_at(&mut payload, layout.diagnostic_offset, 0xFF);
 
     assert!(matches!(
         decode_exec_result(&payload),

--- a/crates/vsock-proto/src/payloads/exec_operation/tests/exec_start.rs
+++ b/crates/vsock-proto/src/payloads/exec_operation/tests/exec_start.rs
@@ -1,7 +1,8 @@
 use super::super::*;
+use super::shared::{
+    ExecStartLayout, ExecStartLayoutRequest, set_byte_at, write_u16_at, write_u32_at,
+};
 use super::{NONCE, assert_invalid_payload};
-
-const ONE_SHOT_DURATION_START_HEADER_LEN: usize = 1 + 1 + 4 + 1;
 
 fn exec_start_payload(command: &str, env: &[(&str, &str)], label: &str) -> Vec<u8> {
     encode_exec_start(
@@ -22,50 +23,6 @@ fn default_exec_start_payload() -> Vec<u8> {
 
 fn env_label_exec_start_payload() -> Vec<u8> {
     exec_start_payload("cmd", &[("K", "V")], "ok")
-}
-
-fn command_byte_offset() -> usize {
-    ONE_SHOT_DURATION_START_HEADER_LEN + 4
-}
-
-fn flags_byte_offset() -> usize {
-    ONE_SHOT_DURATION_START_HEADER_LEN - 1
-}
-
-fn env_count_field_offset(command: &str) -> usize {
-    command_byte_offset() + command.len()
-}
-
-fn env_key_byte_offset(command: &str) -> usize {
-    env_count_field_offset(command) + 4 + 4
-}
-
-fn env_value_byte_offset(command: &str, key: &str) -> usize {
-    env_key_byte_offset(command) + key.len() + 4
-}
-
-fn label_len_field_offset(command: &str, env: &[(&str, &str)]) -> usize {
-    let env_bytes = env
-        .iter()
-        .map(|(key, value)| 4 + key.len() + 4 + value.len())
-        .sum::<usize>();
-    env_count_field_offset(command) + 4 + env_bytes
-}
-
-fn label_byte_offset(command: &str, env: &[(&str, &str)]) -> usize {
-    label_len_field_offset(command, env) + 2
-}
-
-fn stdout_policy_tag_offset(command: &str, env: &[(&str, &str)], label: &str) -> usize {
-    label_byte_offset(command, env) + label.len()
-}
-
-fn stream_chunk_limit_field_offset(command: &str, label: &str) -> usize {
-    stdout_policy_tag_offset(command, &[], label) + 1 + 4
-}
-
-fn capture_and_stream_chunk_limit_field_offset(command: &str, label: &str) -> usize {
-    stdout_policy_tag_offset(command, &[], label) + 1 + 4 + 4
 }
 
 fn supervised_control_exec_start_payload() -> Vec<u8> {
@@ -149,9 +106,19 @@ fn exec_start_wire_layout_places_label_before_output_policies() {
     )
     .unwrap();
 
-    let label_len_offset = label_len_field_offset("cmd", &[]);
+    let layout = ExecStartLayout::new(ExecStartLayoutRequest {
+        timeout: ExecTimeoutPolicy::Duration { timeout_ms: 5000 },
+        command: "cmd",
+        env: &[],
+        label: "abc",
+        stdout: ExecOutputPolicy::Discard,
+        stderr: ExecOutputPolicy::Capture { limit_bytes: 7 },
+        expected_exit_codes: &[],
+        control: ExecControlPolicy::Disabled,
+        stdin_bytes: None,
+    });
     assert_eq!(
-        &payload[label_len_offset..payload.len() - 2],
+        &payload[layout.label_len_offset..layout.control.tag_offset],
         &[
             0,
             3,
@@ -365,7 +332,8 @@ fn exec_start_rejects_zero_duration_timeout() {
     assert_invalid_payload(err, "exec start timeout duration must be positive");
 
     let mut payload = default_exec_start_payload();
-    payload[2..6].copy_from_slice(&0u32.to_be_bytes());
+    let layout = ExecStartLayout::one_shot_duration_discard("cmd", &[], "");
+    write_u32_at(&mut payload, layout.timeout_value_offset.unwrap(), 0);
 
     let err = decode_exec_start(&payload).unwrap_err();
     assert_invalid_payload(err, "exec start timeout duration must be positive");
@@ -412,7 +380,8 @@ fn exec_start_roundtrip_capture_and_stream_policy() {
 #[test]
 fn exec_start_rejects_unknown_flags() {
     let mut payload = default_exec_start_payload();
-    payload[flags_byte_offset()] = 0x80;
+    let layout = ExecStartLayout::one_shot_duration_discard("cmd", &[], "");
+    set_byte_at(&mut payload, layout.flags_offset, 0x80);
 
     let err = decode_exec_start(&payload).unwrap_err();
     assert!(matches!(
@@ -422,31 +391,31 @@ fn exec_start_rejects_unknown_flags() {
 }
 #[test]
 fn exec_start_rejects_invalid_utf8_fields() {
+    let layout = ExecStartLayout::one_shot_duration_discard("cmd", &[("K", "V")], "ok");
+
     let mut payload = env_label_exec_start_payload();
-    payload[command_byte_offset()] = 0xFF;
+    set_byte_at(&mut payload, layout.command_offset, 0xFF);
     assert!(matches!(
         decode_exec_start(&payload),
         Err(ProtocolError::InvalidPayload("invalid UTF-8 in command"))
     ));
 
     let mut payload = env_label_exec_start_payload();
-    let key_offset = env_key_byte_offset("cmd");
-    payload[key_offset] = 0xFF;
+    set_byte_at(&mut payload, layout.env[0].key_offset, 0xFF);
     assert!(matches!(
         decode_exec_start(&payload),
         Err(ProtocolError::InvalidPayload("invalid UTF-8 in env key"))
     ));
 
     let mut payload = env_label_exec_start_payload();
-    let val_offset = env_value_byte_offset("cmd", "K");
-    payload[val_offset] = 0xFF;
+    set_byte_at(&mut payload, layout.env[0].value_offset, 0xFF);
     assert!(matches!(
         decode_exec_start(&payload),
         Err(ProtocolError::InvalidPayload("invalid UTF-8 in env value"))
     ));
 
     let mut payload = env_label_exec_start_payload();
-    payload[label_byte_offset("cmd", &[("K", "V")])] = 0xFF;
+    set_byte_at(&mut payload, layout.label_offset, 0xFF);
     assert!(matches!(
         decode_exec_start(&payload),
         Err(ProtocolError::InvalidPayload("invalid UTF-8 in label"))
@@ -466,8 +435,8 @@ fn exec_start_rejects_trailing_bytes() {
 #[test]
 fn exec_start_rejects_malformed_env_count_without_preallocating() {
     let mut payload = exec_start_payload("", &[], "");
-    let env_count_offset = env_count_field_offset("");
-    payload[env_count_offset..env_count_offset + 4].copy_from_slice(&u32::MAX.to_be_bytes());
+    let layout = ExecStartLayout::one_shot_duration_discard("", &[], "");
+    write_u32_at(&mut payload, layout.env_count_offset, u32::MAX);
 
     assert!(matches!(
         decode_exec_start(&payload),
@@ -493,9 +462,12 @@ fn exec_start_rejects_env_count_above_limit() {
     ));
 
     let mut payload = exec_start_payload("", &[], "");
-    let env_count_offset = env_count_field_offset("");
-    payload[env_count_offset..env_count_offset + 4]
-        .copy_from_slice(&((MAX_EXEC_ENV_VARS as u32) + 1).to_be_bytes());
+    let layout = ExecStartLayout::one_shot_duration_discard("", &[], "");
+    write_u32_at(
+        &mut payload,
+        layout.env_count_offset,
+        (MAX_EXEC_ENV_VARS as u32) + 1,
+    );
 
     assert!(matches!(
         decode_exec_start(&payload),
@@ -544,7 +516,8 @@ fn exec_start_rejects_truncated_fields() {
     ));
 
     let mut payload = env_label_exec_start_payload();
-    payload.truncate(command_byte_offset() + 2);
+    let layout = ExecStartLayout::one_shot_duration_discard("cmd", &[("K", "V")], "ok");
+    payload.truncate(layout.command_offset + 2);
     assert!(matches!(
         decode_exec_start(&payload),
         Err(ProtocolError::InvalidPayload(
@@ -553,8 +526,8 @@ fn exec_start_rejects_truncated_fields() {
     ));
 
     let mut payload = env_label_exec_start_payload();
-    let env_count_offset = env_count_field_offset("cmd");
-    payload.truncate(env_count_offset + 3);
+    let layout = ExecStartLayout::one_shot_duration_discard("cmd", &[("K", "V")], "ok");
+    payload.truncate(layout.env_count_offset + 3);
     assert!(matches!(
         decode_exec_start(&payload),
         Err(ProtocolError::InvalidPayload(
@@ -563,8 +536,8 @@ fn exec_start_rejects_truncated_fields() {
     ));
 
     let mut payload = exec_start_payload("cmd", &[], "ok");
-    let label_len_offset = label_len_field_offset("cmd", &[]);
-    payload.truncate(label_len_offset + 1);
+    let layout = ExecStartLayout::one_shot_duration_discard("cmd", &[], "ok");
+    payload.truncate(layout.label_len_offset + 1);
     assert!(matches!(
         decode_exec_start(&payload),
         Err(ProtocolError::InvalidPayload(
@@ -573,15 +546,16 @@ fn exec_start_rejects_truncated_fields() {
     ));
 
     let mut payload = exec_start_payload("cmd", &[], "ok");
-    let label_start = label_byte_offset("cmd", &[]);
-    payload.truncate(label_start + 1);
+    let layout = ExecStartLayout::one_shot_duration_discard("cmd", &[], "ok");
+    payload.truncate(layout.label_offset + 1);
     assert!(matches!(
         decode_exec_start(&payload),
         Err(ProtocolError::InvalidPayload("exec start label truncated"))
     ));
 
     let mut payload = exec_start_payload("cmd", &[], "ok");
-    payload.truncate(payload.len() - 2);
+    let layout = ExecStartLayout::one_shot_duration_discard("cmd", &[], "ok");
+    payload.truncate(layout.control.tag_offset);
     assert!(matches!(
         decode_exec_start(&payload),
         Err(ProtocolError::InvalidPayload(
@@ -592,8 +566,8 @@ fn exec_start_rejects_truncated_fields() {
 #[test]
 fn exec_start_rejects_invalid_policy_tag() {
     let mut payload = default_exec_start_payload();
-    let stdout_policy_offset = stdout_policy_tag_offset("cmd", &[], "");
-    payload[stdout_policy_offset] = 0x99;
+    let layout = ExecStartLayout::one_shot_duration_discard("cmd", &[], "");
+    set_byte_at(&mut payload, layout.stdout_policy.tag_offset, 0x99);
 
     let err = decode_exec_start(&payload).unwrap_err();
     assert!(matches!(
@@ -634,8 +608,25 @@ fn exec_start_rejects_zero_stream_chunk_limit() {
         ExecOutputPolicy::Discard,
     )
     .unwrap();
-    let chunk_limit_offset = stream_chunk_limit_field_offset("cmd", "");
-    payload[chunk_limit_offset..chunk_limit_offset + 4].copy_from_slice(&0u32.to_be_bytes());
+    let layout = ExecStartLayout::new(ExecStartLayoutRequest {
+        timeout: ExecTimeoutPolicy::Duration { timeout_ms: 1 },
+        command: "cmd",
+        env: &[],
+        label: "",
+        stdout: ExecOutputPolicy::Stream {
+            limit_bytes: 1,
+            chunk_limit_bytes: 1,
+        },
+        stderr: ExecOutputPolicy::Discard,
+        expected_exit_codes: &[],
+        control: ExecControlPolicy::Disabled,
+        stdin_bytes: None,
+    });
+    write_u32_at(
+        &mut payload,
+        layout.stdout_policy.chunk_limit_offset.unwrap(),
+        0,
+    );
 
     let err = decode_exec_start(&payload).unwrap_err();
     assert!(matches!(
@@ -675,8 +666,26 @@ fn exec_start_rejects_zero_capture_and_stream_chunk_limit() {
         ExecOutputPolicy::Discard,
     )
     .unwrap();
-    let chunk_limit_offset = capture_and_stream_chunk_limit_field_offset("cmd", "");
-    payload[chunk_limit_offset..chunk_limit_offset + 4].copy_from_slice(&0u32.to_be_bytes());
+    let layout = ExecStartLayout::new(ExecStartLayoutRequest {
+        timeout: ExecTimeoutPolicy::Duration { timeout_ms: 1 },
+        command: "cmd",
+        env: &[],
+        label: "",
+        stdout: ExecOutputPolicy::CaptureAndStream {
+            capture_limit_bytes: 1,
+            stream_limit_bytes: 1,
+            chunk_limit_bytes: 1,
+        },
+        stderr: ExecOutputPolicy::Discard,
+        expected_exit_codes: &[],
+        control: ExecControlPolicy::Disabled,
+        stdin_bytes: None,
+    });
+    write_u32_at(
+        &mut payload,
+        layout.stdout_policy.chunk_limit_offset.unwrap(),
+        0,
+    );
 
     let err = decode_exec_start(&payload).unwrap_err();
     assert_invalid_payload(err, "exec output chunk limit must be non-zero");
@@ -704,9 +713,12 @@ fn exec_start_rejects_expected_exit_count_above_limit() {
     ));
 
     let mut payload = default_exec_start_payload();
-    let count_offset = payload.len() - 2 - 2;
-    payload[count_offset..count_offset + 2]
-        .copy_from_slice(&((MAX_EXEC_EXPECTED_EXIT_CODES as u16) + 1).to_be_bytes());
+    let layout = ExecStartLayout::one_shot_duration_discard("cmd", &[], "");
+    write_u16_at(
+        &mut payload,
+        layout.expected_exit_count_offset,
+        (MAX_EXEC_EXPECTED_EXIT_CODES as u16) + 1,
+    );
     let err = decode_exec_start(&payload).unwrap_err();
     assert!(matches!(
         err,
@@ -716,7 +728,8 @@ fn exec_start_rejects_expected_exit_count_above_limit() {
 #[test]
 fn exec_start_rejects_truncated_expected_exit_count() {
     let mut payload = default_exec_start_payload();
-    payload.truncate(payload.len() - 3);
+    let layout = ExecStartLayout::one_shot_duration_discard("cmd", &[], "");
+    payload.truncate(layout.expected_exit_count_offset + 1);
 
     let err = decode_exec_start(&payload).unwrap_err();
     assert_invalid_payload(err, "exec start expected_exit_count truncated");
@@ -737,7 +750,18 @@ fn exec_start_rejects_truncated_expected_exit_codes() {
         stdin_bytes: None,
     })
     .unwrap();
-    payload.truncate(payload.len() - 3);
+    let layout = ExecStartLayout::new(ExecStartLayoutRequest {
+        timeout: ExecTimeoutPolicy::Duration { timeout_ms: 1 },
+        command: "cmd",
+        env: &[],
+        label: "",
+        stdout: ExecOutputPolicy::Discard,
+        stderr: ExecOutputPolicy::Discard,
+        expected_exit_codes: &[66],
+        control: ExecControlPolicy::Disabled,
+        stdin_bytes: None,
+    });
+    payload.truncate(layout.expected_exit_codes_offset + 3);
 
     let err = decode_exec_start(&payload).unwrap_err();
     assert!(matches!(
@@ -760,8 +784,21 @@ fn exec_start_rejects_truncated_policy_fields() {
         ExecOutputPolicy::Discard,
     )
     .unwrap();
-    let stream_chunk_limit_offset = stream_chunk_limit_field_offset("cmd", "");
-    stream_payload.truncate(stream_chunk_limit_offset + 3);
+    let stream_layout = ExecStartLayout::new(ExecStartLayoutRequest {
+        timeout: ExecTimeoutPolicy::Duration { timeout_ms: 1 },
+        command: "cmd",
+        env: &[],
+        label: "",
+        stdout: ExecOutputPolicy::Stream {
+            limit_bytes: 1,
+            chunk_limit_bytes: 1,
+        },
+        stderr: ExecOutputPolicy::Discard,
+        expected_exit_codes: &[],
+        control: ExecControlPolicy::Disabled,
+        stdin_bytes: None,
+    });
+    stream_payload.truncate(stream_layout.stdout_policy.chunk_limit_offset.unwrap() + 3);
     assert!(matches!(
         decode_exec_start(&stream_payload),
         Err(ProtocolError::InvalidPayload(
@@ -783,9 +820,28 @@ fn exec_start_rejects_truncated_policy_fields() {
         ExecOutputPolicy::Discard,
     )
     .unwrap();
-    let capture_and_stream_chunk_limit_offset =
-        capture_and_stream_chunk_limit_field_offset("cmd", "");
-    capture_and_stream_payload.truncate(capture_and_stream_chunk_limit_offset + 3);
+    let capture_and_stream_layout = ExecStartLayout::new(ExecStartLayoutRequest {
+        timeout: ExecTimeoutPolicy::Duration { timeout_ms: 1 },
+        command: "cmd",
+        env: &[],
+        label: "",
+        stdout: ExecOutputPolicy::CaptureAndStream {
+            capture_limit_bytes: 1,
+            stream_limit_bytes: 1,
+            chunk_limit_bytes: 1,
+        },
+        stderr: ExecOutputPolicy::Discard,
+        expected_exit_codes: &[],
+        control: ExecControlPolicy::Disabled,
+        stdin_bytes: None,
+    });
+    capture_and_stream_payload.truncate(
+        capture_and_stream_layout
+            .stdout_policy
+            .chunk_limit_offset
+            .unwrap()
+            + 3,
+    );
     assert!(matches!(
         decode_exec_start(&capture_and_stream_payload),
         Err(ProtocolError::InvalidPayload(
@@ -795,8 +851,10 @@ fn exec_start_rejects_truncated_policy_fields() {
 }
 #[test]
 fn exec_start_rejects_invalid_lifecycle_timeout_and_control() {
+    let layout = ExecStartLayout::one_shot_duration_discard("cmd", &[], "");
+
     let mut payload = default_exec_start_payload();
-    payload[0] = 0xFE;
+    set_byte_at(&mut payload, layout.lifecycle_offset, 0xFE);
     assert!(matches!(
         decode_exec_start(&payload),
         Err(ProtocolError::InvalidPayload(
@@ -805,7 +863,7 @@ fn exec_start_rejects_invalid_lifecycle_timeout_and_control() {
     ));
 
     let mut payload = default_exec_start_payload();
-    payload[1] = 0xFE;
+    set_byte_at(&mut payload, layout.timeout_policy_offset, 0xFE);
     assert!(matches!(
         decode_exec_start(&payload),
         Err(ProtocolError::InvalidPayload(
@@ -814,8 +872,21 @@ fn exec_start_rejects_invalid_lifecycle_timeout_and_control() {
     ));
 
     let mut payload = supervised_control_exec_start_payload();
-    let control_tag_offset = payload.len() - (1 + 1 + 1 + EXEC_CONTROL_NONCE_LEN);
-    payload[control_tag_offset] = 0xFE;
+    let layout = ExecStartLayout::new(ExecStartLayoutRequest {
+        timeout: ExecTimeoutPolicy::None,
+        command: "cmd",
+        env: &[],
+        label: "",
+        stdout: ExecOutputPolicy::Discard,
+        stderr: ExecOutputPolicy::Discard,
+        expected_exit_codes: &[],
+        control: ExecControlPolicy::Enabled {
+            control_nonce: NONCE,
+            sink: false,
+        },
+        stdin_bytes: None,
+    });
+    set_byte_at(&mut payload, layout.control.tag_offset, 0xFE);
     assert!(matches!(
         decode_exec_start(&payload),
         Err(ProtocolError::InvalidPayload(
@@ -825,9 +896,23 @@ fn exec_start_rejects_invalid_lifecycle_timeout_and_control() {
 }
 #[test]
 fn exec_start_rejects_control_unknown_flags_and_truncated_nonce() {
+    let layout = ExecStartLayout::new(ExecStartLayoutRequest {
+        timeout: ExecTimeoutPolicy::None,
+        command: "cmd",
+        env: &[],
+        label: "",
+        stdout: ExecOutputPolicy::Discard,
+        stderr: ExecOutputPolicy::Discard,
+        expected_exit_codes: &[],
+        control: ExecControlPolicy::Enabled {
+            control_nonce: NONCE,
+            sink: false,
+        },
+        stdin_bytes: None,
+    });
+
     let mut payload = supervised_control_exec_start_payload();
-    let control_tag_offset = payload.len() - (1 + 1 + 1 + EXEC_CONTROL_NONCE_LEN);
-    payload.truncate(control_tag_offset + 1);
+    payload.truncate(layout.control.flags_offset.unwrap());
     assert!(matches!(
         decode_exec_start(&payload),
         Err(ProtocolError::InvalidPayload(
@@ -836,8 +921,7 @@ fn exec_start_rejects_control_unknown_flags_and_truncated_nonce() {
     ));
 
     let mut payload = supervised_control_exec_start_payload();
-    let control_flags_offset = payload.len() - (1 + 1 + EXEC_CONTROL_NONCE_LEN);
-    payload[control_flags_offset] = 0x80;
+    set_byte_at(&mut payload, layout.control.flags_offset.unwrap(), 0x80);
     assert!(matches!(
         decode_exec_start(&payload),
         Err(ProtocolError::InvalidPayload(
@@ -846,7 +930,7 @@ fn exec_start_rejects_control_unknown_flags_and_truncated_nonce() {
     ));
 
     let mut payload = supervised_control_exec_start_payload();
-    payload.truncate(payload.len() - 2);
+    payload.truncate(layout.control.nonce_offset.unwrap() + EXEC_CONTROL_NONCE_LEN - 2);
     assert!(matches!(
         decode_exec_start(&payload),
         Err(ProtocolError::InvalidPayload(
@@ -857,7 +941,8 @@ fn exec_start_rejects_control_unknown_flags_and_truncated_nonce() {
 #[test]
 fn exec_start_rejects_invalid_or_truncated_stdin_policy() {
     let mut payload = default_exec_start_payload();
-    *payload.last_mut().unwrap() = 0xFE;
+    let layout = ExecStartLayout::one_shot_duration_discard("cmd", &[], "");
+    set_byte_at(&mut payload, layout.stdin.tag_offset, 0xFE);
     assert!(matches!(
         decode_exec_start(&payload),
         Err(ProtocolError::InvalidPayload(
@@ -866,8 +951,18 @@ fn exec_start_rejects_invalid_or_truncated_stdin_policy() {
     ));
 
     let mut payload = stdin_exec_start_payload(b"x");
-    let stdin_tag_offset = payload.len() - (1 + 4 + 1);
-    payload.truncate(stdin_tag_offset + 2);
+    let layout = ExecStartLayout::new(ExecStartLayoutRequest {
+        timeout: ExecTimeoutPolicy::Duration { timeout_ms: 1 },
+        command: "cmd",
+        env: &[],
+        label: "",
+        stdout: ExecOutputPolicy::Discard,
+        stderr: ExecOutputPolicy::Discard,
+        expected_exit_codes: &[],
+        control: ExecControlPolicy::Disabled,
+        stdin_bytes: Some(b"x"),
+    });
+    payload.truncate(layout.stdin.len_offset.unwrap() + 1);
     assert!(matches!(
         decode_exec_start(&payload),
         Err(ProtocolError::InvalidPayload(
@@ -876,7 +971,7 @@ fn exec_start_rejects_invalid_or_truncated_stdin_policy() {
     ));
 
     let mut payload = stdin_exec_start_payload(b"x");
-    payload.pop();
+    payload.truncate(layout.stdin.bytes_end_offset.unwrap() - 1);
     assert!(matches!(
         decode_exec_start(&payload),
         Err(ProtocolError::InvalidPayload("exec start stdin truncated"))
@@ -905,9 +1000,22 @@ fn exec_start_rejects_stdin_above_limit() {
     ));
 
     let mut payload = stdin_exec_start_payload(b"x");
-    let stdin_len_offset = payload.len() - (4 + 1);
-    payload[stdin_len_offset..stdin_len_offset + 4]
-        .copy_from_slice(&((MAX_EXEC_STDIN_BYTES as u32) + 1).to_be_bytes());
+    let layout = ExecStartLayout::new(ExecStartLayoutRequest {
+        timeout: ExecTimeoutPolicy::Duration { timeout_ms: 1 },
+        command: "cmd",
+        env: &[],
+        label: "",
+        stdout: ExecOutputPolicy::Discard,
+        stderr: ExecOutputPolicy::Discard,
+        expected_exit_codes: &[],
+        control: ExecControlPolicy::Disabled,
+        stdin_bytes: Some(b"x"),
+    });
+    write_u32_at(
+        &mut payload,
+        layout.stdin.len_offset.unwrap(),
+        (MAX_EXEC_STDIN_BYTES as u32) + 1,
+    );
     let err = decode_exec_start(&payload).unwrap_err();
     assert_invalid_payload(err, "exec start stdin too large");
 }

--- a/crates/vsock-proto/src/payloads/exec_operation/tests/shared.rs
+++ b/crates/vsock-proto/src/payloads/exec_operation/tests/shared.rs
@@ -2,6 +2,415 @@ use super::super::*;
 use super::NONCE;
 use crate::wire::MAX_PAYLOAD_SIZE;
 
+pub(super) fn set_byte_at(payload: &mut [u8], offset: usize, value: u8) {
+    payload[offset] = value;
+}
+
+pub(super) fn write_u16_at(payload: &mut [u8], offset: usize, value: u16) {
+    payload[offset..offset + 2].copy_from_slice(&value.to_be_bytes());
+}
+
+pub(super) fn write_u32_at(payload: &mut [u8], offset: usize, value: u32) {
+    payload[offset..offset + 4].copy_from_slice(&value.to_be_bytes());
+}
+
+#[derive(Clone, Copy)]
+pub(super) struct ExecCapturedOutputLayout {
+    pub tag_offset: usize,
+    pub flags_offset: Option<usize>,
+    pub bytes_offset: Option<usize>,
+    pub end_offset: usize,
+}
+
+impl ExecCapturedOutputLayout {
+    fn new(start_offset: usize, output: ExecCapturedOutput<'_>) -> Self {
+        match output {
+            ExecCapturedOutput::Discarded => Self {
+                tag_offset: start_offset,
+                flags_offset: None,
+                bytes_offset: None,
+                end_offset: start_offset + 1,
+            },
+            ExecCapturedOutput::Captured { bytes, .. } => {
+                let bytes_offset = start_offset + 1 + 1 + 4;
+
+                Self {
+                    tag_offset: start_offset,
+                    flags_offset: Some(start_offset + 1),
+                    bytes_offset: Some(bytes_offset),
+                    end_offset: bytes_offset + bytes.len(),
+                }
+            }
+        }
+    }
+}
+
+pub(super) struct ExecResultLayout {
+    pub termination_tag_offset: usize,
+    pub exit_code_offset: Option<usize>,
+    pub stdout: ExecCapturedOutputLayout,
+    pub diagnostic_offset: usize,
+    pub diagnostic_end_offset: usize,
+}
+
+impl ExecResultLayout {
+    pub fn new(
+        termination: ExecTermination,
+        stdout: ExecCapturedOutput<'_>,
+        stderr: ExecCapturedOutput<'_>,
+        diagnostic: &str,
+    ) -> Self {
+        let mut offset = 0;
+        let termination_tag_offset = offset;
+        offset += 1;
+
+        let exit_code_offset = match termination {
+            ExecTermination::Exited { .. } => {
+                let exit_code_offset = offset;
+                offset += 4;
+                Some(exit_code_offset)
+            }
+            ExecTermination::TimedOut
+            | ExecTermination::Cancelled
+            | ExecTermination::StartFailed
+            | ExecTermination::WaitFailed => None,
+        };
+
+        offset += 4;
+
+        let stdout = ExecCapturedOutputLayout::new(offset, stdout);
+        offset = stdout.end_offset;
+
+        let stderr = ExecCapturedOutputLayout::new(offset, stderr);
+        offset = stderr.end_offset;
+
+        offset += 2;
+
+        let diagnostic_offset = offset;
+        let diagnostic_end_offset = diagnostic_offset + diagnostic.len();
+
+        Self {
+            termination_tag_offset,
+            exit_code_offset,
+            stdout,
+            diagnostic_offset,
+            diagnostic_end_offset,
+        }
+    }
+}
+
+pub(super) struct ExecOutputLayout {
+    pub stream_offset: usize,
+    pub flags_offset: usize,
+    pub chunk_len_offset: usize,
+    pub chunk_end_offset: usize,
+}
+
+impl ExecOutputLayout {
+    pub fn new(chunk: &[u8]) -> Self {
+        let chunk_offset = 1 + 4 + 1 + 4;
+
+        Self {
+            stream_offset: 0,
+            flags_offset: 1 + 4,
+            chunk_len_offset: 1 + 4 + 1,
+            chunk_end_offset: chunk_offset + chunk.len(),
+        }
+    }
+}
+
+pub(super) struct ExecControlLayout {
+    pub target_seq_offset: usize,
+    pub request_timeout_offset: usize,
+    pub nonce_offset: usize,
+    pub message_id_len_offset: usize,
+    pub message_id_offset: usize,
+    pub payload_len_offset: usize,
+    pub payload_end_offset: usize,
+}
+
+impl ExecControlLayout {
+    pub fn new(message_id: &str, payload: &[u8]) -> Self {
+        let target_seq_offset = 0;
+        let request_timeout_offset = target_seq_offset + 4;
+        let nonce_offset = request_timeout_offset + 4;
+        let message_id_len_offset = nonce_offset + EXEC_CONTROL_NONCE_LEN;
+        let message_id_offset = message_id_len_offset + 2;
+        let payload_len_offset = message_id_offset + message_id.len();
+        let payload_offset = payload_len_offset + 4;
+
+        Self {
+            target_seq_offset,
+            request_timeout_offset,
+            nonce_offset,
+            message_id_len_offset,
+            message_id_offset,
+            payload_len_offset,
+            payload_end_offset: payload_offset + payload.len(),
+        }
+    }
+}
+
+pub(super) struct ExecControlResultLayout {
+    pub target_seq_offset: usize,
+    pub nonce_offset: usize,
+    pub message_id_len_offset: usize,
+    pub message_id_offset: usize,
+    pub status_offset: usize,
+    pub diagnostic_len_offset: usize,
+    pub diagnostic_offset: usize,
+    pub diagnostic_end_offset: usize,
+}
+
+impl ExecControlResultLayout {
+    pub fn new(message_id: &str, diagnostic: &str) -> Self {
+        let target_seq_offset = 0;
+        let nonce_offset = target_seq_offset + 4;
+        let message_id_len_offset = nonce_offset + EXEC_CONTROL_NONCE_LEN;
+        let message_id_offset = message_id_len_offset + 2;
+        let status_offset = message_id_offset + message_id.len();
+        let diagnostic_len_offset = status_offset + 1;
+        let diagnostic_offset = diagnostic_len_offset + 2;
+
+        Self {
+            target_seq_offset,
+            nonce_offset,
+            message_id_len_offset,
+            message_id_offset,
+            status_offset,
+            diagnostic_len_offset,
+            diagnostic_offset,
+            diagnostic_end_offset: diagnostic_offset + diagnostic.len(),
+        }
+    }
+}
+
+#[derive(Clone, Copy)]
+pub(super) struct ExecOutputPolicyLayout {
+    pub tag_offset: usize,
+    pub chunk_limit_offset: Option<usize>,
+    end_offset: usize,
+}
+
+impl ExecOutputPolicyLayout {
+    fn new(start_offset: usize, policy: ExecOutputPolicy) -> Self {
+        match policy {
+            ExecOutputPolicy::Discard => Self {
+                tag_offset: start_offset,
+                chunk_limit_offset: None,
+                end_offset: start_offset + 1,
+            },
+            ExecOutputPolicy::Capture { .. } => Self {
+                tag_offset: start_offset,
+                chunk_limit_offset: None,
+                end_offset: start_offset + 1 + 4,
+            },
+            ExecOutputPolicy::Stream { .. } => Self {
+                tag_offset: start_offset,
+                chunk_limit_offset: Some(start_offset + 1 + 4),
+                end_offset: start_offset + 1 + 4 + 4,
+            },
+            ExecOutputPolicy::CaptureAndStream { .. } => Self {
+                tag_offset: start_offset,
+                chunk_limit_offset: Some(start_offset + 1 + 4 + 4),
+                end_offset: start_offset + 1 + 4 + 4 + 4,
+            },
+        }
+    }
+}
+
+#[derive(Clone, Copy)]
+pub(super) struct ExecStartEnvLayout {
+    pub key_offset: usize,
+    pub value_offset: usize,
+}
+
+#[derive(Clone, Copy)]
+pub(super) struct ExecStartControlLayout {
+    pub tag_offset: usize,
+    pub flags_offset: Option<usize>,
+    pub nonce_offset: Option<usize>,
+    end_offset: usize,
+}
+
+impl ExecStartControlLayout {
+    fn new(start_offset: usize, control: ExecControlPolicy) -> Self {
+        match control {
+            ExecControlPolicy::Disabled => Self {
+                tag_offset: start_offset,
+                flags_offset: None,
+                nonce_offset: None,
+                end_offset: start_offset + 1,
+            },
+            ExecControlPolicy::Enabled { .. } => Self {
+                tag_offset: start_offset,
+                flags_offset: Some(start_offset + 1),
+                nonce_offset: Some(start_offset + 1 + 1),
+                end_offset: start_offset + 1 + 1 + EXEC_CONTROL_NONCE_LEN,
+            },
+        }
+    }
+}
+
+#[derive(Clone, Copy)]
+pub(super) struct ExecStartStdinLayout {
+    pub tag_offset: usize,
+    pub len_offset: Option<usize>,
+    pub bytes_end_offset: Option<usize>,
+}
+
+impl ExecStartStdinLayout {
+    fn new(start_offset: usize, stdin_bytes: Option<&[u8]>) -> Self {
+        match stdin_bytes {
+            None => Self {
+                tag_offset: start_offset,
+                len_offset: None,
+                bytes_end_offset: None,
+            },
+            Some(bytes) => {
+                let bytes_offset = start_offset + 1 + 4;
+
+                Self {
+                    tag_offset: start_offset,
+                    len_offset: Some(start_offset + 1),
+                    bytes_end_offset: Some(bytes_offset + bytes.len()),
+                }
+            }
+        }
+    }
+}
+
+pub(super) struct ExecStartLayout {
+    pub lifecycle_offset: usize,
+    pub timeout_policy_offset: usize,
+    pub timeout_value_offset: Option<usize>,
+    pub flags_offset: usize,
+    pub command_offset: usize,
+    pub env_count_offset: usize,
+    pub env: Vec<ExecStartEnvLayout>,
+    pub label_len_offset: usize,
+    pub label_offset: usize,
+    pub stdout_policy: ExecOutputPolicyLayout,
+    pub expected_exit_count_offset: usize,
+    pub expected_exit_codes_offset: usize,
+    pub control: ExecStartControlLayout,
+    pub stdin: ExecStartStdinLayout,
+}
+
+impl ExecStartLayout {
+    pub fn new(request: ExecStartLayoutRequest<'_>) -> Self {
+        let mut offset = 0;
+
+        let lifecycle_offset = offset;
+        offset += 1;
+
+        let timeout_policy_offset = offset;
+        offset += 1;
+        let timeout_value_offset = match request.timeout {
+            ExecTimeoutPolicy::Duration { .. } => {
+                let timeout_value_offset = offset;
+                offset += 4;
+                Some(timeout_value_offset)
+            }
+            ExecTimeoutPolicy::None => None,
+        };
+
+        let flags_offset = offset;
+        offset += 1;
+
+        offset += 4;
+
+        let command_offset = offset;
+        offset += request.command.len();
+
+        let env_count_offset = offset;
+        offset += 4;
+
+        let mut env = Vec::with_capacity(request.env.len());
+        for (key, value) in request.env {
+            offset += 4;
+
+            let key_offset = offset;
+            offset += key.len();
+
+            offset += 4;
+
+            let value_offset = offset;
+            offset += value.len();
+
+            env.push(ExecStartEnvLayout {
+                key_offset,
+                value_offset,
+            });
+        }
+
+        let label_len_offset = offset;
+        offset += 2;
+
+        let label_offset = offset;
+        offset += request.label.len();
+
+        let stdout_policy = ExecOutputPolicyLayout::new(offset, request.stdout);
+        offset = stdout_policy.end_offset;
+
+        offset = ExecOutputPolicyLayout::new(offset, request.stderr).end_offset;
+
+        let expected_exit_count_offset = offset;
+        offset += 2;
+
+        let expected_exit_codes_offset = offset;
+        offset += request.expected_exit_codes.len() * 4;
+
+        let control = ExecStartControlLayout::new(offset, request.control);
+        offset = control.end_offset;
+
+        let stdin = ExecStartStdinLayout::new(offset, request.stdin_bytes);
+
+        Self {
+            lifecycle_offset,
+            timeout_policy_offset,
+            timeout_value_offset,
+            flags_offset,
+            command_offset,
+            env_count_offset,
+            env,
+            label_len_offset,
+            label_offset,
+            stdout_policy,
+            expected_exit_count_offset,
+            expected_exit_codes_offset,
+            control,
+            stdin,
+        }
+    }
+
+    pub fn one_shot_duration_discard(command: &str, env: &[(&str, &str)], label: &str) -> Self {
+        Self::new(ExecStartLayoutRequest {
+            timeout: ExecTimeoutPolicy::Duration { timeout_ms: 1 },
+            command,
+            env,
+            label,
+            stdout: ExecOutputPolicy::Discard,
+            stderr: ExecOutputPolicy::Discard,
+            expected_exit_codes: &[],
+            control: ExecControlPolicy::Disabled,
+            stdin_bytes: None,
+        })
+    }
+}
+
+pub(super) struct ExecStartLayoutRequest<'a> {
+    pub timeout: ExecTimeoutPolicy,
+    pub command: &'a str,
+    pub env: &'a [(&'a str, &'a str)],
+    pub label: &'a str,
+    pub stdout: ExecOutputPolicy,
+    pub stderr: ExecOutputPolicy,
+    pub expected_exit_codes: &'a [i32],
+    pub control: ExecControlPolicy,
+    pub stdin_bytes: Option<&'a [u8]>,
+}
+
 #[test]
 fn exec_operation_encoders_reject_oversized_payloads() {
     let command = "x".repeat(MAX_PAYLOAD_SIZE);


### PR DESCRIPTION
## Summary

- Add test-only exec operation wire-layout helpers in `tests/shared.rs`
- Replace duplicated local offset helpers and raw byte arithmetic in malformed-payload tests
- Keep existing encode-mutate-decode coverage and error-message assertions unchanged

## Tests

- `cargo test --manifest-path crates/Cargo.toml -p vsock-proto exec_operation`
- `cargo test --manifest-path crates/Cargo.toml -p vsock-proto`
- `cargo clippy --manifest-path crates/Cargo.toml -p vsock-proto --tests`
- pre-commit hook: cargo-fmt, cargo-clippy, cargo-doc

Closes #16376
