### PR TITLE
fix: update altium 365 connector icon

### DIFF
--- a/turbo/apps/platform/src/views/zero-page/components/settings/icons/altium-365.svg
+++ b/turbo/apps/platform/src/views/zero-page/components/settings/icons/altium-365.svg
@@ -1,9 +1,39 @@
 <svg width="24" height="24" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
-  <rect width="24" height="24" fill="black"/>
-  <path
-    d="M12.7267 0C10.375 0.0692307 8.36917 1.38461 7.2625 3.39231L0 17.1H5.46417L6.77833 14.1231H10.8592L10.7208 17.1H16.185L15.5625 0H12.7267ZM11.0667 10.8692H8.23083L11.4817 3.73846L11.0667 10.8692Z"
-    fill="white"
-    fill-rule="evenodd"
-    transform="translate(3.9075 3.45)"
-  />
+<g clip-path="url(#clip0_3250_160)">
+<path fill-rule="evenodd" clip-rule="evenodd" d="M18.6672 20.3134C18.6672 20.3134 21.1754 18.8642 22.133 18.3122C22.359 18.1809 22.4975 17.9401 22.4975 17.68C22.4975 16.5006 22.4756 13.2544 22.4756 13.2544L14.4141 17.8988L18.6672 20.3134Z" fill="url(#paint0_linear_3250_160)"/>
+<path fill-rule="evenodd" clip-rule="evenodd" d="M1.5 13.6368V17.6538C1.5 17.914 1.63853 18.1548 1.86456 18.2861C2.88532 18.877 5.70213 20.4794 5.70213 20.4794V11.1638L1.5 13.6368Z" fill="url(#paint1_linear_3250_160)"/>
+<path fill-rule="evenodd" clip-rule="evenodd" d="M15.8592 2.07182C15.8592 2.07182 13.3631 0.642017 12.4104 0.0973321C12.1844 -0.0315444 11.9073 -0.0315444 11.6838 0.0997637C10.663 0.688218 7.84375 2.34173 7.84375 2.34173L15.8956 6.94237L15.8592 2.07182Z" fill="url(#paint2_linear_3250_160)"/>
+<path fill-rule="evenodd" clip-rule="evenodd" d="M12.0479 4.72952V6.62376C12.0479 7.22681 11.7271 7.78122 11.2069 8.08517L2.25585 13.2864C1.81838 13.5272 1.51944 13.9843 1.5 14.512V6.54109C1.5 6.19336 1.68471 5.87239 1.98608 5.69974C3.84046 4.62739 11.6857 0.0972652 11.6857 0.0972652C11.7975 0.0316112 11.9239 0 12.0479 0V4.72952Z" fill="url(#paint3_linear_3250_160)"/>
+<path fill-rule="evenodd" clip-rule="evenodd" d="M7.31678 14.6747C7.83688 14.3732 8.48093 14.3707 9.00347 14.6698L17.9594 19.8176C18.1855 19.9611 18.4528 20.0437 18.7396 20.0437C19.0264 20.0437 19.2743 19.9659 19.4954 19.8322C19.4954 19.8322 14.1729 22.9106 12.5178 23.8687C12.2164 24.0438 11.847 24.0438 11.5456 23.8687C9.75202 22.8328 1.84356 18.2613 1.84356 18.2613C1.73419 18.1957 1.6467 18.1057 1.58594 17.9987L2.6067 17.4054C2.6067 17.4054 3.30422 17.0018 3.70037 16.7708L7.31678 14.6747Z" fill="url(#paint4_linear_3250_160)"/>
+<path fill-rule="evenodd" clip-rule="evenodd" d="M22.4939 17.0288V17.678C22.4939 17.8069 22.4599 17.9333 22.3967 18.0403L18.3015 15.6622C17.7182 15.3242 17.1325 14.9838 16.627 14.6895C16.1069 14.388 15.7885 13.8336 15.7861 13.2354L15.7593 2.8864V2.86452C15.7593 2.31983 15.4604 1.84323 15.0156 1.59277C15.0156 1.59277 20.3527 4.68338 22.0103 5.64387C22.3116 5.81652 22.4963 6.13749 22.4963 6.48521L22.4939 17.0288Z" fill="url(#paint5_linear_3250_160)"/>
+</g>
+<defs>
+<linearGradient id="paint0_linear_3250_160" x1="20.9737" y1="16.6922" x2="16.5985" y2="17.6863" gradientUnits="userSpaceOnUse">
+<stop stop-color="#003E89"/>
+<stop offset="1" stop-color="#1368BC"/>
+</linearGradient>
+<linearGradient id="paint1_linear_3250_160" x1="2.25245" y1="13.6832" x2="5.90674" y2="16.1698" gradientUnits="userSpaceOnUse">
+<stop stop-color="#003E89"/>
+<stop offset="1" stop-color="#1368BC"/>
+</linearGradient>
+<linearGradient id="paint2_linear_3250_160" x1="10.5138" y1="2.74124" x2="16.0451" y2="3.89562" gradientUnits="userSpaceOnUse">
+<stop stop-color="#1368BC"/>
+<stop offset="1" stop-color="#003E89"/>
+</linearGradient>
+<linearGradient id="paint3_linear_3250_160" x1="10.455" y1="8.68992" x2="2.27297" y2="5.50562" gradientUnits="userSpaceOnUse">
+<stop stop-color="#57BFFF"/>
+<stop offset="1" stop-color="#0B55D9"/>
+</linearGradient>
+<linearGradient id="paint4_linear_3250_160" x1="11.4334" y1="16.8228" x2="9.22295" y2="21.9987" gradientUnits="userSpaceOnUse">
+<stop stop-color="#5EB9FC"/>
+<stop offset="1" stop-color="#0B55D9"/>
+</linearGradient>
+<linearGradient id="paint5_linear_3250_160" x1="22.4609" y1="7.17847" x2="15.7043" y2="11.9205" gradientUnits="userSpaceOnUse">
+<stop stop-color="#0B55D9"/>
+<stop offset="1" stop-color="#57BFFF"/>
+</linearGradient>
+<clipPath id="clip0_3250_160">
+<rect width="24" height="24" fill="white"/>
+</clipPath>
+</defs>
 </svg>


### PR DESCRIPTION
## Summary
- Replace the Altium 365 connector icon with the official Altium 365 SVG from the Altium CDN.
- Keep the connector on the existing colorful icon path; no component logic changes.

Fixes #16412

## Testing
- `pnpm format`
- `pnpm lint`
- `pnpm check-types`
- `pnpm knip`
- `pnpm -F @vm0/db db:migrate`
- `pnpm -F @vm0/app exec vitest src/views/zero-page/__tests__/connector-icons.test.tsx --run`
- `curl -fsSL https://cdn.files.altium.com/sites/default/files/media_icon/2025-07/AppLogo.svg | cmp - apps/platform/src/views/zero-page/components/settings/icons/altium-365.svg`
- `pnpm test` (local Linux container: 10314 passed, 4 failed in `@vm0/desktop` `src/computer-use-native.test.ts` because the native computer-use CLI reports `Desktop Computer Use is currently implemented for macOS`)
