### PR TITLE
feat: add Stripe CLI dashboard connector

### DIFF
--- a/turbo/apps/api/src/signals/routes/__tests__/webhooks-agent-firewall-auth.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/webhooks-agent-firewall-auth.test.ts
@@ -646,9 +646,10 @@ function useLarkTenantAccessTokenEndpoint(
   return calls;
 }
 
-async function seedStripeApiTokenConnector(
+async function seedStripeStaticConnector(
   fixture: FirewallFixture,
   args: {
+    readonly authMethod?: "api-token" | "cli";
     readonly token?: string;
     readonly tokenExpiresAt?: Date | null;
     readonly needsReconnect?: boolean;
@@ -659,7 +660,7 @@ async function seedStripeApiTokenConnector(
     orgId: fixture.orgId,
     userId: fixture.userId,
     type: "stripe",
-    authMethod: "api-token",
+    authMethod: args.authMethod ?? "api-token",
     externalId: "stripe-account",
     externalUsername: "stripe-account",
     externalEmail: "stripe@example.com",
@@ -3215,7 +3216,7 @@ describe("POST /api/webhooks/agent/firewall/auth", () => {
 
   it("keeps missing static connector access secrets as missing configuration", async () => {
     const fixture = await track(seedFixture());
-    await seedStripeApiTokenConnector(fixture);
+    await seedStripeStaticConnector(fixture);
 
     const response = await accept(
       firewallClient().resolve({
@@ -3243,7 +3244,7 @@ describe("POST /api/webhooks/agent/firewall/auth", () => {
 
   it("loads current static connector access instead of stale encrypted access", async () => {
     const fixture = await track(seedFixture());
-    await seedStripeApiTokenConnector(fixture, {
+    await seedStripeStaticConnector(fixture, {
       token: "current-stripe-token",
     });
 
@@ -3274,7 +3275,7 @@ describe("POST /api/webhooks/agent/firewall/auth", () => {
 
   it("loads current future-expiring static connector access", async () => {
     const fixture = await track(seedFixture());
-    await seedStripeApiTokenConnector(fixture, {
+    await seedStripeStaticConnector(fixture, {
       token: "current-stripe-token",
       tokenExpiresAt: new Date(now() + 60 * 60 * 1000),
     });
@@ -3304,9 +3305,43 @@ describe("POST /api/webhooks/agent/firewall/auth", () => {
     expect(response.body.refreshedSecrets).toStrictEqual([]);
   });
 
-  it("rejects expired static connector access as reconnect required", async () => {
+  it("loads current Stripe CLI static connector access", async () => {
     const fixture = await track(seedFixture());
-    await seedStripeApiTokenConnector(fixture, {
+    await seedStripeStaticConnector(fixture, {
+      authMethod: "cli",
+      token: "current-stripe-cli-token",
+      tokenExpiresAt: new Date(now() + 60 * 60 * 1000),
+    });
+
+    const response = await accept(
+      firewallClient().resolve({
+        body: {
+          encryptedSecrets: encryptedSecrets({
+            STRIPE_TOKEN: "stale-stripe-token",
+          }),
+          authHeaders: {
+            Authorization: `Bearer ${secretTemplate("STRIPE_TOKEN")}`,
+          },
+          secretConnectorMap: {
+            STRIPE_TOKEN: "stripe",
+          },
+        },
+        headers: authHeaders(fixture),
+      }),
+      [200],
+    );
+
+    expect(response.body.headers.Authorization).toBe(
+      "Bearer current-stripe-cli-token",
+    );
+    expect(response.body.refreshedConnectors).toStrictEqual([]);
+    expect(response.body.refreshedSecrets).toStrictEqual([]);
+  });
+
+  it("rejects expired Stripe CLI static connector access as reconnect required", async () => {
+    const fixture = await track(seedFixture());
+    await seedStripeStaticConnector(fixture, {
+      authMethod: "cli",
       token: "expired-stripe-token",
       tokenExpiresAt: new Date(now() - 60_000),
     });
@@ -3338,7 +3373,7 @@ describe("POST /api/webhooks/agent/firewall/auth", () => {
 
   it("rejects reconnect-required static connector access", async () => {
     const fixture = await track(seedFixture());
-    await seedStripeApiTokenConnector(fixture, {
+    await seedStripeStaticConnector(fixture, {
       token: "current-stripe-token",
       needsReconnect: true,
     });
@@ -3433,7 +3468,7 @@ describe("POST /api/webhooks/agent/firewall/auth", () => {
 
   it("rejects stale encrypted static connector access when current storage is missing", async () => {
     const fixture = await track(seedFixture());
-    await seedStripeApiTokenConnector(fixture);
+    await seedStripeStaticConnector(fixture);
 
     const response = await accept(
       firewallClient().resolve({
@@ -3492,7 +3527,7 @@ describe("POST /api/webhooks/agent/firewall/auth", () => {
 
   it("rejects encrypted connector secrets outside the selected access method", async () => {
     const fixture = await track(seedFixture());
-    await seedStripeApiTokenConnector(fixture);
+    await seedStripeStaticConnector(fixture);
 
     const response = await accept(
       firewallClient().resolve({

--- a/turbo/apps/api/src/signals/routes/__tests__/zero-connectors-oauth-device-auth.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/zero-connectors-oauth-device-auth.test.ts
@@ -54,6 +54,11 @@ const SLOCK_DEVICE_CODE_URL = "https://api.slock.ai/api/auth/device/authorize";
 const SLOCK_TOKEN_URL = "https://api.slock.ai/api/auth/device/token";
 const SLOCK_USERINFO_URL = "https://api.slock.ai/api/auth/me";
 const SLOCK_SERVERS_URL = "https://api.slock.ai/api/servers";
+const STRIPE_CLI_AUTH_URL = "https://dashboard.stripe.com/stripecli/auth";
+const STRIPE_CLI_BROWSER_URL =
+  "https://dashboard.stripe.com/stripecli/confirm_auth?code=STRIPE-CLI";
+const STRIPE_CLI_TEST_SECRET = "rk_test_api123";
+const STRIPE_CLI_LIVE_SECRET = "rk_live_api456";
 const SLOCK_ACCESS_TOKEN_TTL_SECONDS = 900;
 const DEVICE_CODE_GRANT_TYPE = "urn:ietf:params:oauth:grant-type:device_code";
 
@@ -120,7 +125,7 @@ async function cleanupUser(userId: string, orgId: string) {
 }
 
 async function encryptedProviderState(args: {
-  readonly connectorType?: "test-oauth-device" | "slock";
+  readonly connectorType?: "test-oauth-device" | "slock" | "stripe";
   readonly deviceCode: string;
   readonly pollState?: string;
 }): Promise<string> {
@@ -329,10 +334,71 @@ function mockSlockOAuthProvider(): { readonly accessToken: string } {
   return { accessToken };
 }
 
+function mockStripeCliDashboardProvider(args?: {
+  readonly pollToken?: string;
+}): { readonly startBodies: URLSearchParams[] } {
+  const startBodies: URLSearchParams[] = [];
+  server.use(
+    http.post(STRIPE_CLI_AUTH_URL, async ({ request }) => {
+      const body = new URLSearchParams(await request.text());
+      startBodies.push(body);
+      return HttpResponse.json({
+        browser_url: STRIPE_CLI_BROWSER_URL,
+        poll_url: `${STRIPE_CLI_AUTH_URL}?poll_token=${args?.pollToken ?? "test-complete"}`,
+        verification_code: "STRIPE-CLI",
+      });
+    }),
+    http.get(STRIPE_CLI_AUTH_URL, ({ request }) => {
+      const pollToken = new URL(request.url).searchParams.get("poll_token");
+      if (pollToken === "pending") {
+        return HttpResponse.json({
+          redeemed: false,
+          account_id: null,
+          account_display_name: null,
+          testmode_key_secret: null,
+          testmode_key_publishable: null,
+          livemode_key_secret: null,
+          livemode_key_publishable: null,
+        });
+      }
+      if (pollToken === "live-complete") {
+        return HttpResponse.json({
+          redeemed: true,
+          account_id: "acct_live",
+          account_display_name: "Live Stripe Account",
+          testmode_key_secret: STRIPE_CLI_TEST_SECRET,
+          livemode_key_secret: STRIPE_CLI_LIVE_SECRET,
+        });
+      }
+      if (pollToken === "missing-test-key") {
+        return HttpResponse.json({
+          redeemed: true,
+          account_id: "acct_missing",
+          livemode_key_secret: STRIPE_CLI_LIVE_SECRET,
+        });
+      }
+      if (pollToken === "malformed") {
+        return HttpResponse.text(
+          `not json ${STRIPE_CLI_AUTH_URL}?poll_token=secret-poll ${STRIPE_CLI_TEST_SECRET}`,
+        );
+      }
+      expect(pollToken).toBe("test-complete");
+      return HttpResponse.json({
+        redeemed: true,
+        account_id: "acct_test",
+        account_display_name: "Test Stripe Account",
+        testmode_key_secret: STRIPE_CLI_TEST_SECRET,
+        livemode_key_secret: STRIPE_CLI_LIVE_SECRET,
+      });
+    }),
+  );
+  return { startBodies };
+}
+
 async function createSession(args: {
   readonly userId: string;
   readonly orgId: string;
-  readonly connectorType?: "test-oauth-device" | "slock";
+  readonly connectorType?: "test-oauth-device" | "slock" | "stripe";
   readonly authMethod?: string;
   readonly deviceCode: string;
   readonly status?: "awaiting_user_authorization" | "polling";
@@ -448,6 +514,14 @@ describe("OAuth device authorization connector routes", () => {
     users.push({ userId, orgId });
     mocks.clerk.session(userId, orgId);
     await enableTestOauthDevice(userId, orgId);
+    return { userId, orgId };
+  }
+
+  function setupStripeUser() {
+    const userId = `user_${randomUUID()}`;
+    const orgId = `org_${randomUUID()}`;
+    users.push({ userId, orgId });
+    mocks.clerk.session(userId, orgId);
     return { userId, orgId };
   }
 
@@ -864,6 +938,290 @@ describe("OAuth device authorization connector routes", () => {
       "test-oauth-device api device-auth start option toString is not supported",
     );
     expect(startCalled).toBeFalsy();
+  });
+
+  it("starts a Stripe CLI session without exposing the Dashboard poll URL", async () => {
+    const { userId, orgId } = await setupStripeUser();
+    const stripeMock = mockStripeCliDashboardProvider();
+    const client = setupApp({ context })(
+      zeroConnectorOauthDeviceAuthSessionContract,
+    );
+
+    const response = await accept(
+      client.create({
+        params: { type: "stripe" },
+        body: { authMethod: "cli", options: { mode: "test" } },
+        headers: { authorization: "Bearer clerk-session" },
+      }),
+      [200],
+    );
+
+    expect(stripeMock.startBodies).toHaveLength(1);
+    expect(stripeMock.startBodies[0]?.get("client_version")).toBeTruthy();
+    expect(stripeMock.startBodies[0]?.get("device_name")).toBe(
+      "vm0-stripe-connector",
+    );
+    expect(response.body).toMatchObject({
+      type: "stripe",
+      status: "pending",
+      userCode: "STRIPE-CLI",
+      verificationUri: STRIPE_CLI_BROWSER_URL,
+      verificationUriComplete: STRIPE_CLI_BROWSER_URL,
+      expiresIn: 600,
+      interval: 1,
+    });
+    expect(JSON.stringify(response.body)).not.toContain("poll_token");
+
+    const session = await onlySession(response.body.sessionId);
+    expect(session.orgId).toBe(orgId);
+    expect(session.userId).toBe(userId);
+    expect(session.authMethod).toBe("cli");
+    expect(session.encryptedProviderState).not.toContain("poll_token");
+    const decryptedProviderState = await decryptPersistentSecretValue(
+      session.encryptedProviderState,
+      { orgId, userId },
+    );
+    const providerState = z
+      .object({
+        connectorType: z.literal("stripe"),
+        deviceCode: z.literal("stripe-cli-dashboard-auth"),
+        pollState: z.string(),
+      })
+      .parse(JSON.parse(decryptedProviderState) as unknown);
+    expect(providerState.pollState).toContain("test-complete");
+    expect(providerState.pollState).toContain('"mode":"test"');
+  });
+
+  it("rejects invalid Stripe CLI mode before provider start", async () => {
+    await setupStripeUser();
+    const stripeMock = mockStripeCliDashboardProvider();
+    const client = setupApp({ context })(
+      zeroConnectorOauthDeviceAuthSessionContract,
+    );
+
+    const response = await accept(
+      client.create({
+        params: { type: "stripe" },
+        body: { authMethod: "cli", options: { mode: "production" } },
+        headers: { authorization: "Bearer clerk-session" },
+      }),
+      [400],
+    );
+
+    expect(response.body.error.message).toBe(
+      "stripe cli device-auth start option mode must be one of: test, live",
+    );
+    expect(stripeMock.startBodies).toStrictEqual([]);
+  });
+
+  it("polls a pending Stripe CLI session without persisting a connector", async () => {
+    const { userId, orgId } = await setupStripeUser();
+    mockStripeCliDashboardProvider({ pollToken: "pending" });
+    const client = setupApp({ context })(
+      zeroConnectorOauthDeviceAuthSessionContract,
+    );
+    const start = await accept(
+      client.create({
+        params: { type: "stripe" },
+        body: { authMethod: "cli", options: { mode: "test" } },
+        headers: { authorization: "Bearer clerk-session" },
+      }),
+      [200],
+    );
+    await makeSessionPollable(start.body.sessionId);
+
+    const response = await accept(
+      client.poll({
+        params: { type: "stripe", sessionId: start.body.sessionId },
+        body: { sessionToken: start.body.sessionToken },
+        headers: { authorization: "Bearer clerk-session" },
+      }),
+      [200],
+    );
+
+    expect(response.body).toStrictEqual({ status: "pending", interval: 1 });
+    await expect(
+      connectorSecretValue(userId, orgId, "STRIPE_TOKEN"),
+    ).resolves.toBeNull();
+    await expect(onlySession(start.body.sessionId)).resolves.toMatchObject({
+      status: "awaiting_user_authorization",
+      intervalSeconds: 1,
+    });
+  });
+
+  it("completes a Stripe CLI test session and stores STRIPE_TOKEN plus expiry", async () => {
+    const { userId, orgId } = await setupStripeUser();
+    mockStripeCliDashboardProvider({ pollToken: "test-complete" });
+    const client = setupApp({ context })(
+      zeroConnectorOauthDeviceAuthSessionContract,
+    );
+    const start = await accept(
+      client.create({
+        params: { type: "stripe" },
+        body: { authMethod: "cli", options: { mode: "test" } },
+        headers: { authorization: "Bearer clerk-session" },
+      }),
+      [200],
+    );
+    await makeSessionPollable(start.body.sessionId);
+
+    const response = await accept(
+      client.poll({
+        params: { type: "stripe", sessionId: start.body.sessionId },
+        body: { sessionToken: start.body.sessionToken },
+        headers: { authorization: "Bearer clerk-session" },
+      }),
+      [200],
+    );
+
+    expect(response.body.status).toBe("complete");
+    expect(JSON.stringify(response.body)).not.toContain(STRIPE_CLI_TEST_SECRET);
+    await expect(
+      connectorSecretValue(userId, orgId, "STRIPE_TOKEN"),
+    ).resolves.toBe(STRIPE_CLI_TEST_SECRET);
+
+    const stored = await store
+      .set(writeDb$)
+      .select({
+        authMethod: connectors.authMethod,
+        externalId: connectors.externalId,
+        externalUsername: connectors.externalUsername,
+        externalEmail: connectors.externalEmail,
+        oauthScopes: connectors.oauthScopes,
+        tokenExpiresAt: connectors.tokenExpiresAt,
+      })
+      .from(connectors)
+      .where(
+        and(
+          eq(connectors.userId, userId),
+          eq(connectors.orgId, orgId),
+          eq(connectors.type, "stripe"),
+        ),
+      );
+    expect(stored).toHaveLength(1);
+    expect(stored[0]).toMatchObject({
+      authMethod: "cli",
+      externalId: "acct_test",
+      externalUsername: "Test Stripe Account",
+      externalEmail: null,
+      oauthScopes: JSON.stringify([]),
+    });
+    const tokenExpiresAt = stored[0]?.tokenExpiresAt;
+    if (!tokenExpiresAt) {
+      throw new Error("Expected Stripe CLI token expiry to be stored");
+    }
+    expect(tokenExpiresAt.getTime()).toBeGreaterThan(
+      nowDate().getTime() + 89 * 24 * 60 * 60 * 1000,
+    );
+    expect(tokenExpiresAt.getTime()).toBeLessThanOrEqual(
+      nowDate().getTime() + 90 * 24 * 60 * 60 * 1000,
+    );
+  });
+
+  it("completes a Stripe CLI live session with the live key", async () => {
+    const { userId, orgId } = await setupStripeUser();
+    mockStripeCliDashboardProvider({ pollToken: "live-complete" });
+    const client = setupApp({ context })(
+      zeroConnectorOauthDeviceAuthSessionContract,
+    );
+    const start = await accept(
+      client.create({
+        params: { type: "stripe" },
+        body: { authMethod: "cli", options: { mode: "live" } },
+        headers: { authorization: "Bearer clerk-session" },
+      }),
+      [200],
+    );
+    await makeSessionPollable(start.body.sessionId);
+
+    const response = await accept(
+      client.poll({
+        params: { type: "stripe", sessionId: start.body.sessionId },
+        body: { sessionToken: start.body.sessionToken },
+        headers: { authorization: "Bearer clerk-session" },
+      }),
+      [200],
+    );
+
+    expect(response.body.status).toBe("complete");
+    await expect(
+      connectorSecretValue(userId, orgId, "STRIPE_TOKEN"),
+    ).resolves.toBe(STRIPE_CLI_LIVE_SECRET);
+  });
+
+  it("returns a terminal Stripe CLI error when the selected key is missing", async () => {
+    const { userId, orgId } = await setupStripeUser();
+    mockStripeCliDashboardProvider({ pollToken: "missing-test-key" });
+    const client = setupApp({ context })(
+      zeroConnectorOauthDeviceAuthSessionContract,
+    );
+    const start = await accept(
+      client.create({
+        params: { type: "stripe" },
+        body: { authMethod: "cli", options: { mode: "test" } },
+        headers: { authorization: "Bearer clerk-session" },
+      }),
+      [200],
+    );
+    await makeSessionPollable(start.body.sessionId);
+
+    const response = await accept(
+      client.poll({
+        params: { type: "stripe", sessionId: start.body.sessionId },
+        body: { sessionToken: start.body.sessionToken },
+        headers: { authorization: "Bearer clerk-session" },
+      }),
+      [200],
+    );
+
+    expect(response.body).toStrictEqual({
+      status: "error",
+      errorCode: "stripe_cli_auth_error",
+      errorMessage: "Stripe CLI auth did not return a test mode key",
+    });
+    await expect(
+      connectorSecretValue(userId, orgId, "STRIPE_TOKEN"),
+    ).resolves.toBeNull();
+    await expect(onlySession(start.body.sessionId)).resolves.toMatchObject({
+      status: "error",
+      errorCode: "stripe_cli_auth_error",
+    });
+  });
+
+  it("redacts malformed Stripe CLI poll responses", async () => {
+    const { userId, orgId } = await setupStripeUser();
+    mockStripeCliDashboardProvider({ pollToken: "malformed" });
+    const client = setupApp({ context })(
+      zeroConnectorOauthDeviceAuthSessionContract,
+    );
+    const start = await accept(
+      client.create({
+        params: { type: "stripe" },
+        body: { authMethod: "cli", options: { mode: "test" } },
+        headers: { authorization: "Bearer clerk-session" },
+      }),
+      [200],
+    );
+    await makeSessionPollable(start.body.sessionId);
+
+    const response = await accept(
+      client.poll({
+        params: { type: "stripe", sessionId: start.body.sessionId },
+        body: { sessionToken: start.body.sessionToken },
+        headers: { authorization: "Bearer clerk-session" },
+      }),
+      [200],
+    );
+
+    expect(response.body.status).toBe("error");
+    if (response.body.status !== "error") {
+      throw new Error("Expected Stripe CLI malformed poll to return an error");
+    }
+    expect(response.body.errorMessage).not.toContain("secret-poll");
+    expect(response.body.errorMessage).not.toContain(STRIPE_CLI_TEST_SECRET);
+    await expect(
+      connectorSecretValue(userId, orgId, "STRIPE_TOKEN"),
+    ).resolves.toBeNull();
   });
 
   it("does not persist a superseded session that completes after a new session starts", async () => {

--- a/turbo/apps/api/src/signals/services/__tests__/zero-connector-data.service.test.ts
+++ b/turbo/apps/api/src/signals/services/__tests__/zero-connector-data.service.test.ts
@@ -468,9 +468,17 @@ describe("zeroConnectorSearch", () => {
     expect(zapier?.authMethods).toStrictEqual(["api-token"]);
   });
 
-  it("returns Stripe API-token search auth without CLI auth", async () => {
+  it("returns Stripe API-token and CLI search auth without the Stripe switch", async () => {
     const authMethods = await stripeSearchAuthMethods({});
 
-    expect(authMethods).toStrictEqual(["api-token"]);
+    expect(authMethods).toStrictEqual(["cli", "api-token"]);
+  });
+
+  it("returns Stripe OAuth search auth when the Stripe switch is enabled", async () => {
+    const authMethods = await stripeSearchAuthMethods({
+      [FeatureSwitchKey.StripeConnector]: true,
+    });
+
+    expect(authMethods).toStrictEqual(["oauth", "cli", "api-token"]);
   });
 });

--- a/turbo/apps/platform/src/signals/zero-page/__tests__/zero-connectors.test.ts
+++ b/turbo/apps/platform/src/signals/zero-page/__tests__/zero-connectors.test.ts
@@ -5,7 +5,11 @@ import {
   detachedSetupPage,
   setupPage,
 } from "../../../__tests__/page-helper.ts";
-import { allConnectorTypes$ } from "../settings/connectors.ts";
+import {
+  allConnectorTypes$,
+  connectorCurrentConnectionStatus,
+  connectorExpiryCountdownText,
+} from "../settings/connectors.ts";
 import { zeroAuthorizedConnectors$ } from "../zero-connectors.ts";
 import { authorizeConnector$ as directedAuthorizeConnector$ } from "../../connectors-page/directed-authorize-type.ts";
 import { FeatureSwitchKey } from "@vm0/connectors/feature-switch-key";
@@ -281,9 +285,63 @@ describe("connectors — Stripe auth availability", () => {
     return stripe?.availableAuthMethods ?? [];
   }
 
-  it("returns Stripe API-token auth without CLI auth", async () => {
+  it("returns Stripe API-token and CLI auth without the Stripe switch", async () => {
     const authMethods = await stripeAuthMethods({});
 
-    expect(authMethods).toStrictEqual(["api-token"]);
+    expect(authMethods).toStrictEqual(["cli", "api-token"]);
+  });
+
+  it("returns Stripe OAuth auth when the Stripe switch is enabled", async () => {
+    const authMethods = await stripeAuthMethods({
+      [FeatureSwitchKey.StripeConnector]: true,
+    });
+
+    expect(authMethods).toStrictEqual(["oauth", "cli", "api-token"]);
+  });
+
+  it("shows expiry text only while a non-refreshable Stripe CLI connector is connected", async () => {
+    setMockConnectors([
+      {
+        id: "d0000001-0000-4000-a000-000000000097",
+        type: "stripe",
+        authMethod: "cli",
+        externalId: "acct_test",
+        externalUsername: "Test Stripe Account",
+        externalEmail: null,
+        oauthScopes: [],
+        connectionStatus: "connected",
+        tokenExpiresAt: "2026-01-01T02:00:00.000Z",
+        createdAt: "2026-01-01T00:00:00Z",
+        updatedAt: "2026-01-01T00:00:00Z",
+      },
+    ]);
+    detachedSetupPage({
+      context,
+      path: "/",
+      featureSwitches: { [FeatureSwitchKey.StripeConnector]: true },
+      withoutRender: true,
+    });
+
+    const connectorTypes = await context.store.get(allConnectorTypes$);
+    const stripe = connectorTypes.find((c) => {
+      return c.type === "stripe";
+    });
+    expect(stripe).toBeDefined();
+    if (!stripe) {
+      throw new Error("Expected Stripe connector type");
+    }
+    expect(stripe.authMethodSupportsRefresh).toBeFalsy();
+    expect(
+      connectorExpiryCountdownText(stripe, Date.parse("2026-01-01T00:00:00Z")),
+    ).toBe("Expires in 2 hours");
+    expect(
+      connectorCurrentConnectionStatus(
+        stripe,
+        Date.parse("2026-01-01T03:00:00Z"),
+      ),
+    ).toBe("reconnect-required");
+    expect(
+      connectorExpiryCountdownText(stripe, Date.parse("2026-01-01T03:00:00Z")),
+    ).toBeNull();
   });
 });

--- a/turbo/apps/platform/src/views/zero-page/__tests__/zero-connectors-page-test-helpers.ts
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/zero-connectors-page-test-helpers.ts
@@ -1,10 +1,13 @@
-import type { ConnectorType } from "@vm0/connectors/connectors";
+import type {
+  ConnectorAuthMethodId,
+  ConnectorType,
+} from "@vm0/connectors/connectors";
 import { setMockConnectors } from "../../../mocks/handlers/api-connectors.ts";
 
 export function mockConnectors(
   connectors: {
     type: ConnectorType;
-    authMethod?: "oauth" | "api-token";
+    authMethod?: ConnectorAuthMethodId;
     externalUsername?: string;
     connectionStatus?: "connected" | "reconnect-required";
     oauthScopes?: string[];

--- a/turbo/packages/connectors/src/__tests__/connectors.test.ts
+++ b/turbo/packages/connectors/src/__tests__/connectors.test.ts
@@ -112,6 +112,11 @@ function hasConnectorAuthorizationGrant(type: ConnectorType): boolean {
 
 const server = setupServer();
 const SLOCK_ACCESS_TOKEN_TTL_SECONDS = 900;
+const STRIPE_CLI_AUTH_URL = "https://dashboard.stripe.com/stripecli/auth";
+const STRIPE_CLI_BROWSER_URL =
+  "https://dashboard.stripe.com/stripecli/confirm_auth?code=STRIPE-CLI";
+const STRIPE_CLI_TEST_SECRET = "rk_test_connector123";
+const STRIPE_CLI_LIVE_SECRET = "rk_live_connector456";
 
 type OAuthAuthMethodConnectorType = {
   readonly [Type in ConnectorType]: "oauth" extends ConnectorAuthMethodIds<Type>
@@ -226,6 +231,31 @@ function restoreEnv(values: Record<string, string | undefined>): void {
   }
 }
 
+function stripeCliAuthClient() {
+  const authClient = resolveConnectorAuthClientForMethod(
+    "stripe",
+    "cli",
+    () => {
+      return undefined;
+    },
+  );
+  if (!authClient) {
+    throw new Error("Expected Stripe CLI auth client");
+  }
+  return authClient;
+}
+
+function stripeCliProviderPollState(args: {
+  readonly mode: "test" | "live";
+  readonly token: string;
+}): string {
+  return JSON.stringify({
+    version: 1,
+    mode: args.mode,
+    pollUrl: `${STRIPE_CLI_AUTH_URL}?poll_token=${args.token}`,
+  });
+}
+
 const manualAuthMethodConfig = {
   label: "API Token",
   helpText: "Enter an API token.",
@@ -304,11 +334,14 @@ describe("connector auth method lifecycle helpers", () => {
       getConnectorAuthMethodIdsForGrantKind("stripe", "manual"),
     ).toStrictEqual(["api-token"]);
     expect(
+      getConnectorAuthMethodIdsForGrantKind("stripe", "device-auth"),
+    ).toStrictEqual(["cli"]);
+    expect(
       getConnectorAuthMethodIdsForAccessKind("stripe", "refresh-token"),
     ).toStrictEqual(["oauth"]);
     expect(
       getConnectorAuthMethodIdsForAccessKind("stripe", "static"),
-    ).toStrictEqual(["api-token"]);
+    ).toStrictEqual(["cli", "api-token"]);
     expect(
       getConnectorAuthMethodIdsForAccessKind("lark", "refresh-token"),
     ).toStrictEqual(["api-token"]);
@@ -320,7 +353,7 @@ describe("connector auth method lifecycle helpers", () => {
     ).toStrictEqual([]);
     expect(
       getConnectorAuthMethodIdsForRevokeKind("stripe", "none"),
-    ).toStrictEqual(["oauth", "api-token"]);
+    ).toStrictEqual(["oauth", "cli", "api-token"]);
 
     expect(
       getConnectorAuthMethodIdsForGrantKind("test-oauth-device", "device-auth"),
@@ -407,7 +440,7 @@ describe("connector auth method config", () => {
       (typeof multiAuthMethodFixture)["multi-auth-method-fixture"];
 
     expectTypeOf<ConnectorAuthMethodId>().toEqualTypeOf<
-      "oauth" | "api-token" | "api"
+      "oauth" | "api-token" | "cli" | "api"
     >();
     expectTypeOf<"app-credential">().not.toMatchTypeOf<ConnectorAuthMethodId>();
     expectTypeOf<"app-credential">().not.toMatchTypeOf<
@@ -616,10 +649,20 @@ describe("connector auth method config", () => {
     }
 
     const duplicateSecrets = [...secretOwners].filter(([, owners]) => {
-      return owners.length > 1;
+      const ownerTypes = new Set(
+        owners.map((owner) => {
+          return owner.split(":")[0];
+        }),
+      );
+      return ownerTypes.size > 1;
     });
     const duplicateVariables = [...variableOwners].filter(([, owners]) => {
-      return owners.length > 1;
+      const ownerTypes = new Set(
+        owners.map((owner) => {
+          return owner.split(":")[0];
+        }),
+      );
+      return ownerTypes.size > 1;
     });
 
     expect(duplicateSecrets).toStrictEqual([]);
@@ -1305,6 +1348,387 @@ describe("connector selected auth method capability checks", () => {
     });
   });
 
+  it("starts and polls the Stripe CLI Dashboard provider", async () => {
+    let startBody: URLSearchParams | undefined;
+    server.use(
+      http.post(STRIPE_CLI_AUTH_URL, async ({ request }) => {
+        expect(request.headers.get("content-type")).toContain(
+          "application/x-www-form-urlencoded",
+        );
+        startBody = new URLSearchParams(await request.text());
+        return HttpResponse.json({
+          browser_url: STRIPE_CLI_BROWSER_URL,
+          poll_url: `${STRIPE_CLI_AUTH_URL}?poll_token=test-poll`,
+          verification_code: "STRIPE-CLI",
+        });
+      }),
+      http.get(STRIPE_CLI_AUTH_URL, ({ request }) => {
+        const url = new URL(request.url);
+        if (url.searchParams.get("poll_token") === "pending") {
+          return HttpResponse.json({
+            redeemed: false,
+            account_id: null,
+            account_display_name: null,
+            testmode_key_secret: null,
+            testmode_key_publishable: null,
+            livemode_key_secret: null,
+            livemode_key_publishable: null,
+          });
+        }
+        expect(url.searchParams.get("poll_token")).toBe("test-poll");
+        return HttpResponse.json({
+          redeemed: true,
+          account_id: "acct_test",
+          account_display_name: "Test Stripe Account",
+          testmode_key_secret: STRIPE_CLI_TEST_SECRET,
+          livemode_key_secret: STRIPE_CLI_LIVE_SECRET,
+        });
+      }),
+    );
+
+    const authClient = stripeCliAuthClient();
+    const startResult = await startConnectorDeviceAuthorization({
+      type: "stripe",
+      authMethod: "cli",
+      authClient,
+      options: { mode: "test" },
+    });
+    expect(startBody?.get("client_version")).toBeTruthy();
+    expect(startBody?.get("device_name")).toBe("vm0-stripe-connector");
+    expect(startResult).toMatchObject({
+      deviceCode: "stripe-cli-dashboard-auth",
+      pollState: expect.any(String),
+      userCode: "STRIPE-CLI",
+      verificationUri: STRIPE_CLI_BROWSER_URL,
+      verificationUriComplete: STRIPE_CLI_BROWSER_URL,
+      expiresIn: 600,
+      interval: 1,
+    });
+    expect(startResult.deviceCode).not.toContain("poll_token");
+
+    await expect(
+      pollConnectorDeviceAuthorization({
+        type: "stripe",
+        authMethod: "cli",
+        authClient,
+        deviceCode: startResult.deviceCode,
+        pollState: stripeCliProviderPollState({
+          mode: "test",
+          token: "pending",
+        }),
+      }),
+    ).resolves.toStrictEqual({ status: "pending", interval: 1 });
+
+    await expect(
+      pollConnectorDeviceAuthorization({
+        type: "stripe",
+        authMethod: "cli",
+        authClient,
+        deviceCode: startResult.deviceCode,
+        pollState: startResult.pollState,
+      }),
+    ).resolves.toStrictEqual({
+      status: "complete",
+      token: {
+        outputs: { token: STRIPE_CLI_TEST_SECRET },
+        expiresIn: 90 * 24 * 60 * 60,
+        scopes: [],
+        userInfo: {
+          id: "acct_test",
+          username: "Test Stripe Account",
+          email: null,
+        },
+      },
+    });
+  });
+
+  it("imports the Stripe CLI live key when live mode was selected", async () => {
+    server.use(
+      http.get(STRIPE_CLI_AUTH_URL, ({ request }) => {
+        expect(new URL(request.url).searchParams.get("poll_token")).toBe(
+          "live-poll",
+        );
+        return HttpResponse.json({
+          redeemed: true,
+          account_id: "acct_live",
+          livemode_key_secret: STRIPE_CLI_LIVE_SECRET,
+          testmode_key_secret: STRIPE_CLI_TEST_SECRET,
+        });
+      }),
+    );
+
+    await expect(
+      pollConnectorDeviceAuthorization({
+        type: "stripe",
+        authMethod: "cli",
+        authClient: stripeCliAuthClient(),
+        deviceCode: "stripe-cli-dashboard-auth",
+        pollState: stripeCliProviderPollState({
+          mode: "live",
+          token: "live-poll",
+        }),
+      }),
+    ).resolves.toMatchObject({
+      status: "complete",
+      token: {
+        outputs: { token: STRIPE_CLI_LIVE_SECRET },
+      },
+    });
+  });
+
+  it("rejects unexpected Stripe CLI Dashboard URLs without leaking poll URLs", async () => {
+    server.use(
+      http.post(STRIPE_CLI_AUTH_URL, () => {
+        return HttpResponse.json({
+          browser_url:
+            "https://evil.test/stripecli/confirm_auth?poll_token=secret-poll",
+          poll_url: `${STRIPE_CLI_AUTH_URL}?poll_token=secret-poll`,
+          verification_code: "STRIPE-CLI",
+        });
+      }),
+    );
+
+    await expect(
+      startConnectorDeviceAuthorization({
+        type: "stripe",
+        authMethod: "cli",
+        authClient: stripeCliAuthClient(),
+        options: { mode: "test" },
+      }),
+    ).rejects.toThrow("Stripe CLI auth returned an unexpected browser URL");
+  });
+
+  it("does not follow Stripe CLI start redirects", async () => {
+    let redirected = false;
+    server.use(
+      http.post(STRIPE_CLI_AUTH_URL, () => {
+        return new Response(null, {
+          status: 302,
+          headers: { Location: "https://evil.test/stripecli/auth" },
+        });
+      }),
+      http.get("https://evil.test/stripecli/auth", () => {
+        redirected = true;
+        return HttpResponse.json({
+          browser_url: STRIPE_CLI_BROWSER_URL,
+          poll_url: `${STRIPE_CLI_AUTH_URL}?poll_token=redirected`,
+          verification_code: "STRIPE-CLI",
+        });
+      }),
+    );
+
+    await expect(
+      startConnectorDeviceAuthorization({
+        type: "stripe",
+        authMethod: "cli",
+        authClient: stripeCliAuthClient(),
+        options: { mode: "test" },
+      }),
+    ).rejects.toThrow();
+    expect(redirected).toBe(false);
+  });
+
+  it("returns redacted Stripe CLI poll errors", async () => {
+    const unusualStripeKey = "sk_test_connector123.extra";
+    server.use(
+      http.get(STRIPE_CLI_AUTH_URL, () => {
+        return HttpResponse.text(
+          `${STRIPE_CLI_AUTH_URL}?poll_token=secret-poll ${STRIPE_CLI_TEST_SECRET} ${unusualStripeKey}`,
+          { status: 500 },
+        );
+      }),
+    );
+
+    const result = await pollConnectorDeviceAuthorization({
+      type: "stripe",
+      authMethod: "cli",
+      authClient: stripeCliAuthClient(),
+      deviceCode: "stripe-cli-dashboard-auth",
+      pollState: stripeCliProviderPollState({
+        mode: "test",
+        token: "secret-poll",
+      }),
+    });
+
+    expect(result).toMatchObject({
+      status: "error",
+      error: "stripe_cli_auth_error",
+    });
+    if (result.status !== "error") {
+      throw new Error("Expected Stripe CLI poll to return an error");
+    }
+    expect(result.errorDescription).toContain(
+      "https://dashboard.stripe.com/stripecli/[redacted]",
+    );
+    expect(result.errorDescription).toContain("[stripe-key]");
+    expect(result.errorDescription).not.toContain("secret-poll");
+    expect(result.errorDescription).not.toContain(STRIPE_CLI_TEST_SECRET);
+    expect(result.errorDescription).not.toContain(unusualStripeKey);
+  });
+
+  it("does not follow Stripe CLI poll redirects", async () => {
+    let redirected = false;
+    server.use(
+      http.get(STRIPE_CLI_AUTH_URL, () => {
+        return new Response(null, {
+          status: 302,
+          headers: { Location: "https://evil.test/stripecli/auth" },
+        });
+      }),
+      http.get("https://evil.test/stripecli/auth", () => {
+        redirected = true;
+        return HttpResponse.json({ redeemed: true });
+      }),
+    );
+
+    const result = await pollConnectorDeviceAuthorization({
+      type: "stripe",
+      authMethod: "cli",
+      authClient: stripeCliAuthClient(),
+      deviceCode: "stripe-cli-dashboard-auth",
+      pollState: stripeCliProviderPollState({
+        mode: "test",
+        token: "redirect-poll",
+      }),
+    });
+
+    expect(redirected).toBe(false);
+    expect(result).toMatchObject({
+      status: "error",
+      error: "stripe_cli_auth_error",
+    });
+  });
+
+  it("returns an error for malformed Stripe CLI poll responses", async () => {
+    server.use(
+      http.get(STRIPE_CLI_AUTH_URL, () => {
+        return HttpResponse.text(
+          `not json ${STRIPE_CLI_AUTH_URL}?poll_token=secret-poll ${STRIPE_CLI_TEST_SECRET}`,
+        );
+      }),
+    );
+
+    const result = await pollConnectorDeviceAuthorization({
+      type: "stripe",
+      authMethod: "cli",
+      authClient: stripeCliAuthClient(),
+      deviceCode: "stripe-cli-dashboard-auth",
+      pollState: stripeCliProviderPollState({
+        mode: "test",
+        token: "secret-poll",
+      }),
+    });
+
+    expect(result).toMatchObject({
+      status: "error",
+      error: "stripe_cli_auth_error",
+    });
+    if (result.status !== "error") {
+      throw new Error("Expected malformed Stripe CLI poll to return an error");
+    }
+    expect(result.errorDescription).not.toContain("secret-poll");
+    expect(result.errorDescription).not.toContain(STRIPE_CLI_TEST_SECRET);
+  });
+
+  it("returns an error when Stripe CLI poll omits the selected mode key", async () => {
+    server.use(
+      http.get(STRIPE_CLI_AUTH_URL, () => {
+        return HttpResponse.json({
+          redeemed: true,
+          account_id: "acct_test",
+          livemode_key_secret: STRIPE_CLI_LIVE_SECRET,
+        });
+      }),
+    );
+
+    await expect(
+      pollConnectorDeviceAuthorization({
+        type: "stripe",
+        authMethod: "cli",
+        authClient: stripeCliAuthClient(),
+        deviceCode: "stripe-cli-dashboard-auth",
+        pollState: stripeCliProviderPollState({
+          mode: "test",
+          token: "missing-test-key",
+        }),
+      }),
+    ).resolves.toStrictEqual({
+      status: "error",
+      error: "stripe_cli_auth_error",
+      errorDescription: "Stripe CLI auth did not return a test mode key",
+    });
+  });
+
+  it("returns an error when Stripe CLI poll returns a key for the wrong mode", async () => {
+    server.use(
+      http.get(STRIPE_CLI_AUTH_URL, () => {
+        return HttpResponse.json({
+          redeemed: true,
+          account_id: "acct_wrong_mode",
+          account_display_name: "Wrong Mode Stripe Account",
+          testmode_key_secret: STRIPE_CLI_LIVE_SECRET,
+        });
+      }),
+    );
+
+    await expect(
+      pollConnectorDeviceAuthorization({
+        type: "stripe",
+        authMethod: "cli",
+        authClient: stripeCliAuthClient(),
+        deviceCode: "stripe-cli-dashboard-auth",
+        pollState: stripeCliProviderPollState({
+          mode: "test",
+          token: "wrong-mode-key",
+        }),
+      }),
+    ).resolves.toStrictEqual({
+      status: "error",
+      error: "stripe_cli_auth_error",
+      errorDescription: "Stripe CLI auth returned an invalid test mode key",
+    });
+  });
+
+  it("returns an error for invalid Stripe CLI provider state", async () => {
+    await expect(
+      pollConnectorDeviceAuthorization({
+        type: "stripe",
+        authMethod: "cli",
+        authClient: stripeCliAuthClient(),
+        deviceCode: "stripe-cli-dashboard-auth",
+        pollState: JSON.stringify({
+          version: 1,
+          mode: "test",
+          pollUrl:
+            "https://dashboard.stripe.com/stripecli/authx?poll_token=secret-poll",
+        }),
+      }),
+    ).resolves.toStrictEqual({
+      status: "error",
+      error: "stripe_cli_auth_error",
+      errorDescription: "Stripe CLI auth returned an unexpected poll URL",
+    });
+
+    await expect(
+      pollConnectorDeviceAuthorization({
+        type: "stripe",
+        authMethod: "cli",
+        authClient: stripeCliAuthClient(),
+        deviceCode: "stripe-cli-dashboard-auth",
+        pollState: JSON.stringify({
+          version: 1,
+          mode: "test",
+          pollUrl:
+            "https://dashboard.stripe.com:444/stripecli/auth?poll_token=secret-poll",
+        }),
+      }),
+    ).resolves.toStrictEqual({
+      status: "error",
+      error: "stripe_cli_auth_error",
+      errorDescription: "Stripe CLI auth returned an unexpected poll URL",
+    });
+  });
+
   it("refreshes an input-only connector access provider without an auth client", async () => {
     await expect(
       refreshConnectorAuthProviderAccessToken({
@@ -1968,16 +2392,26 @@ describe("getConfiguredConnectorAuthMethodIds", () => {
   it("returns configured auth methods without feature filtering", () => {
     expect(getConfiguredConnectorAuthMethodIds("stripe")).toStrictEqual([
       "oauth",
+      "cli",
       "api-token",
     ]);
   });
 });
 
 describe("getAvailableConnectorAuthMethodIds", () => {
-  it("exposes Stripe API-token auth without CLI auth", () => {
+  it("exposes Stripe API-token and CLI auth without gated auth methods", () => {
     expect(getAvailableConnectorAuthMethodIds("stripe", {})).toStrictEqual([
+      "cli",
       "api-token",
     ]);
+  });
+
+  it("exposes Stripe OAuth auth when the Stripe switch is enabled", () => {
+    expect(
+      getAvailableConnectorAuthMethodIds("stripe", {
+        [FeatureSwitchKey.StripeConnector]: true,
+      }),
+    ).toStrictEqual(["oauth", "cli", "api-token"]);
   });
 
   it("exposes BentoML API-token auth only when its switch is enabled", () => {
@@ -2084,6 +2518,18 @@ describe("getConnectorAuthMethodAccessMetadata", () => {
       },
       platformSecrets: [],
     });
+  });
+
+  it("returns static access metadata for the Stripe CLI method", () => {
+    expect(getConnectorAuthMethodAccessMetadata("stripe", "cli")).toStrictEqual(
+      {
+        kind: "static",
+        envBindings: {
+          STRIPE_TOKEN: "$secrets.STRIPE_TOKEN",
+        },
+        platformSecrets: [],
+      },
+    );
   });
 
   it("returns platform-owned secret metadata for Google Ads", () => {
@@ -2351,6 +2797,28 @@ describe("getConnectorAuthMethodRuntimeMetadata", () => {
   it("keeps manual static API tokens role-free", () => {
     expect(
       getConnectorAuthMethodRuntimeMetadata("stripe", "api-token"),
+    ).toStrictEqual({
+      storage: {
+        secrets: ["STRIPE_TOKEN"],
+        variables: [],
+      },
+      runtimeBindings: [
+        {
+          envName: "STRIPE_TOKEN",
+          valueRef: "$secrets.STRIPE_TOKEN",
+          optional: false,
+          source: {
+            kind: "connector-secret",
+            name: "STRIPE_TOKEN",
+          },
+        },
+      ],
+    });
+  });
+
+  it("keeps Stripe CLI runtime access on STRIPE_TOKEN", () => {
+    expect(
+      getConnectorAuthMethodRuntimeMetadata("stripe", "cli"),
     ).toStrictEqual({
       storage: {
         secrets: ["STRIPE_TOKEN"],
@@ -3306,6 +3774,20 @@ describe("connector OAuth device authorization config", () => {
         ],
       },
     });
+    expect(
+      getConnectorAuthMethodDeviceAuthStartOptionsConfig("stripe", "cli"),
+    ).toStrictEqual({
+      mode: {
+        kind: "select",
+        label: "Mode",
+        required: true,
+        defaultValue: "test",
+        options: [
+          { value: "test", label: "Test" },
+          { value: "live", label: "Live" },
+        ],
+      },
+    });
 
     expect(
       parseConnectorDeviceAuthStartOptions({
@@ -3350,6 +3832,31 @@ describe("connector OAuth device authorization config", () => {
     ).toStrictEqual({ success: true, options: { mode: "live" } });
     expect(
       parseConnectorDeviceAuthStartOptions({
+        type: "stripe",
+        authMethod: "cli",
+        options: undefined,
+      }),
+    ).toStrictEqual({ success: true, options: { mode: "test" } });
+    expect(
+      parseConnectorDeviceAuthStartOptions({
+        type: "stripe",
+        authMethod: "cli",
+        options: { mode: "live" },
+      }),
+    ).toStrictEqual({ success: true, options: { mode: "live" } });
+    expect(
+      parseConnectorDeviceAuthStartOptions({
+        type: "stripe",
+        authMethod: "cli",
+        options: { mode: "production" },
+      }),
+    ).toStrictEqual({
+      success: false,
+      message:
+        "stripe cli device-auth start option mode must be one of: test, live",
+    });
+    expect(
+      parseConnectorDeviceAuthStartOptions({
         type: "test-oauth-device",
         authMethod: "api",
         options: { mode: "production" },
@@ -3380,6 +3887,32 @@ describe("connector OAuth device authorization config", () => {
       success: false,
       message:
         "test-oauth-device api device-auth start option toString is not supported",
+    });
+  });
+
+  it("declares the Stripe CLI connector as a device authorization flow", () => {
+    expect(hasConnectorDeviceAuthGrant("stripe")).toBe(true);
+    expect(
+      getConnectorAuthMethodDeviceAuthGrantConfig("stripe", "cli"),
+    ).toMatchObject({
+      kind: "device-auth",
+      scopes: [],
+      outputs: {
+        token: "$secrets.STRIPE_TOKEN",
+      },
+    });
+    expect(getConnectorAuthMethod("stripe", "cli")).toMatchObject({
+      label: "Sign in with Stripe",
+      client: {
+        clientRegistration: "dynamic",
+        clientType: "public",
+      },
+      access: {
+        kind: "static",
+        envBindings: {
+          STRIPE_TOKEN: "$secrets.STRIPE_TOKEN",
+        },
+      },
     });
   });
 

--- a/turbo/packages/connectors/src/auth-providers/connector-auth.ts
+++ b/turbo/packages/connectors/src/auth-providers/connector-auth.ts
@@ -84,7 +84,10 @@ import { sentryProvider } from "./connectors/sentry/provider";
 import { slackProvider } from "./connectors/slack/provider";
 import { slockProvider } from "./connectors/slock/provider";
 import { stravaProvider } from "./connectors/strava/provider";
-import { stripeProvider } from "./connectors/stripe/provider";
+import {
+  stripeCliProvider,
+  stripeProvider,
+} from "./connectors/stripe/provider";
 import { todoistProvider } from "./connectors/todoist/provider";
 import { vercelProvider } from "./connectors/vercel/provider";
 import { webflowProvider } from "./connectors/webflow/provider";
@@ -428,7 +431,10 @@ const CONNECTOR_AUTH_METHOD_PROVIDERS = {
   slock: { oauth: deviceAuthRefreshProviderEntry(slockProvider) },
   spotify: { oauth: authCodeRefreshProviderEntry(spotifyProvider) },
   strava: { oauth: authCodeRefreshProviderEntry(stravaProvider) },
-  stripe: { oauth: authCodeRefreshProviderEntry(stripeProvider) },
+  stripe: {
+    oauth: authCodeRefreshProviderEntry(stripeProvider),
+    cli: deviceAuthProviderEntry(stripeCliProvider),
+  },
   supabase: { oauth: authCodeRefreshProviderEntry(supabaseProvider) },
   "test-oauth": {
     oauth: authCodeRefreshProviderEntry(testOauthProvider),

--- a/turbo/packages/connectors/src/auth-providers/connectors/stripe/cli.ts
+++ b/turbo/packages/connectors/src/auth-providers/connectors/stripe/cli.ts
@@ -1,0 +1,391 @@
+import { z } from "zod";
+
+import type { ConnectorDeviceAuthStartOptions } from "@vm0/connectors/connectors";
+import type {
+  OAuthDeviceAuthPollResult,
+  OAuthDeviceAuthStartResult,
+} from "../../provider-flow-types";
+
+const STRIPE_DASHBOARD_ORIGIN = "https://dashboard.stripe.com";
+const STRIPE_CLI_AUTH_PATH = "/stripecli/auth";
+const STRIPE_CLI_CONFIRM_AUTH_PATH = "/stripecli/confirm_auth";
+const STRIPE_CLI_CLIENT_VERSION = "1.42.1";
+const STRIPE_CLI_DEVICE_NAME = "vm0-stripe-connector";
+const STRIPE_CLI_AUTH_START_EXPIRES_IN_SECONDS = 10 * 60;
+const STRIPE_CLI_AUTH_POLL_INTERVAL_SECONDS = 1;
+const STRIPE_CLI_KEY_EXPIRES_IN_SECONDS = 90 * 24 * 60 * 60;
+const STRIPE_CLI_AUTH_RESPONSE_MAX_BYTES = 16 * 1024;
+const STRIPE_CLI_DEVICE_CODE = "stripe-cli-dashboard-auth";
+
+const stripeCliModeSchema = z.enum(["test", "live"]);
+
+const stripeCliStartResponseSchema = z.object({
+  browser_url: z.string().min(1),
+  poll_url: z.string().min(1),
+  verification_code: z.string().min(1),
+});
+
+const stripeCliPollResponseSchema = z.object({
+  redeemed: z.boolean(),
+  account_id: z.string().nullish(),
+  account_display_name: z.string().nullish(),
+  livemode_key_secret: z.string().nullish(),
+  livemode_key_publishable: z.string().nullish(),
+  testmode_key_secret: z.string().nullish(),
+  testmode_key_publishable: z.string().nullish(),
+  error: z.string().optional(),
+  error_description: z.string().optional(),
+});
+
+const stripeCliPollStateSchema = z.object({
+  version: z.literal(1),
+  mode: stripeCliModeSchema,
+  pollUrl: z.string().min(1),
+});
+
+type StripeCliMode = z.infer<typeof stripeCliModeSchema>;
+
+type StripeCliPollState = z.infer<typeof stripeCliPollStateSchema>;
+
+type StripeCliPollResponse = z.infer<typeof stripeCliPollResponseSchema>;
+
+export function redactStripeCliDashboardAuthText(value: string): string {
+  return value
+    .replace(
+      /https:\/\/dashboard\.stripe\.com\/stripecli\/[^\s"'<>)]*/gu,
+      "https://dashboard.stripe.com/stripecli/[redacted]",
+    )
+    .replace(/\b(?:sk|rk)_(?:test|live)_[^\s"'<>),]+/gu, "[stripe-key]");
+}
+
+async function readBoundedResponseText(response: Response): Promise<string> {
+  const contentLength = response.headers.get("content-length");
+  if (contentLength !== null) {
+    const parsedContentLength = Number.parseInt(contentLength, 10);
+    if (
+      Number.isFinite(parsedContentLength) &&
+      parsedContentLength > STRIPE_CLI_AUTH_RESPONSE_MAX_BYTES
+    ) {
+      throw new Error("Stripe CLI auth response exceeded the size limit");
+    }
+  }
+
+  if (!response.body) {
+    const text = await response.text();
+    if (
+      new TextEncoder().encode(text).byteLength >
+      STRIPE_CLI_AUTH_RESPONSE_MAX_BYTES
+    ) {
+      throw new Error("Stripe CLI auth response exceeded the size limit");
+    }
+    return text;
+  }
+
+  const reader = response.body.getReader();
+  const chunks: Uint8Array[] = [];
+  let receivedBytes = 0;
+
+  for (;;) {
+    const { done, value } = await reader.read();
+    if (done) {
+      break;
+    }
+    if (!value) {
+      continue;
+    }
+    receivedBytes += value.byteLength;
+    if (receivedBytes > STRIPE_CLI_AUTH_RESPONSE_MAX_BYTES) {
+      await reader.cancel();
+      throw new Error("Stripe CLI auth response exceeded the size limit");
+    }
+    chunks.push(value);
+  }
+
+  const body = new Uint8Array(receivedBytes);
+  let offset = 0;
+  for (const chunk of chunks) {
+    body.set(chunk, offset);
+    offset += chunk.byteLength;
+  }
+  return new TextDecoder().decode(body);
+}
+
+async function readStripeJsonResponse(response: Response): Promise<unknown> {
+  const text = await readBoundedResponseText(response);
+  try {
+    return JSON.parse(text) as unknown;
+  } catch {
+    const redactedText = redactStripeCliDashboardAuthText(text).slice(0, 500);
+    const suffix = redactedText ? `: ${redactedText}` : "";
+    throw new Error(`Stripe CLI auth response was not valid JSON${suffix}`);
+  }
+}
+
+function validatedStripeDashboardUrl(
+  value: string,
+  expectedPath: "auth" | "confirm_auth",
+  label: string,
+): string {
+  let url: URL;
+  try {
+    url = new URL(value);
+  } catch {
+    throw new Error(`Stripe CLI auth returned an invalid ${label} URL`);
+  }
+
+  const pathPrefix =
+    expectedPath === "auth"
+      ? STRIPE_CLI_AUTH_PATH
+      : STRIPE_CLI_CONFIRM_AUTH_PATH;
+  const hasExpectedPath =
+    url.pathname === pathPrefix || url.pathname.startsWith(`${pathPrefix}/`);
+  if (
+    url.protocol !== "https:" ||
+    url.hostname !== "dashboard.stripe.com" ||
+    url.port !== "" ||
+    url.username !== "" ||
+    url.password !== "" ||
+    !hasExpectedPath
+  ) {
+    throw new Error(`Stripe CLI auth returned an unexpected ${label} URL`);
+  }
+
+  return url.toString();
+}
+
+function parseStartMode(
+  options: ConnectorDeviceAuthStartOptions,
+): StripeCliMode {
+  return stripeCliModeSchema.parse(options.mode);
+}
+
+function stripeCliPollStateString(state: StripeCliPollState): string {
+  return JSON.stringify(state);
+}
+
+function stripeCliPollState(
+  pollState: string | undefined,
+): StripeCliPollState | null {
+  if (pollState === undefined) {
+    return null;
+  }
+
+  let json: unknown;
+  try {
+    json = JSON.parse(pollState) as unknown;
+  } catch {
+    return null;
+  }
+
+  const parsedState = stripeCliPollStateSchema.safeParse(json);
+  return parsedState.success ? parsedState.data : null;
+}
+
+function selectedStripeCliKey(args: {
+  readonly mode: StripeCliMode;
+  readonly testKey: string | null | undefined;
+  readonly liveKey: string | null | undefined;
+}): string | null {
+  return args.mode === "test" ? (args.testKey ?? null) : (args.liveKey ?? null);
+}
+
+function stripeCliKeyMatchesMode(key: string, mode: StripeCliMode): boolean {
+  switch (mode) {
+    case "test":
+      return /^(?:sk|rk)_test_[A-Za-z0-9]+$/u.test(key);
+    case "live":
+      return /^(?:sk|rk)_live_[A-Za-z0-9]+$/u.test(key);
+  }
+}
+
+function stripeCliProviderError(
+  message: string,
+): OAuthDeviceAuthPollResult<"stripe", "cli"> {
+  return {
+    status: "error",
+    error: "stripe_cli_auth_error",
+    errorDescription: redactStripeCliDashboardAuthText(message),
+  };
+}
+
+function stripeCliProviderErrorFromUnknown(
+  error: unknown,
+  fallbackMessage: string,
+): OAuthDeviceAuthPollResult<"stripe", "cli"> {
+  return stripeCliProviderError(
+    error instanceof Error ? error.message : fallbackMessage,
+  );
+}
+
+async function stripeCliHttpErrorMessage(
+  phase: "start" | "poll",
+  response: Response,
+): Promise<string> {
+  const body = await readBoundedResponseText(response);
+  const redactedBody = redactStripeCliDashboardAuthText(body).slice(0, 500);
+  const suffix = redactedBody ? `: ${redactedBody}` : "";
+  return `Stripe CLI auth ${phase} failed with HTTP ${response.status}${suffix}`;
+}
+
+async function readStripeCliPollResponse(
+  response: Response,
+): Promise<StripeCliPollResponse | OAuthDeviceAuthPollResult<"stripe", "cli">> {
+  try {
+    return stripeCliPollResponseSchema.parse(
+      await readStripeJsonResponse(response),
+    );
+  } catch (error) {
+    return stripeCliProviderError(
+      error instanceof Error
+        ? error.message
+        : "Stripe CLI auth response was invalid",
+    );
+  }
+}
+
+export async function startStripeCliDashboardAuth(args: {
+  readonly options: ConnectorDeviceAuthStartOptions;
+}): Promise<OAuthDeviceAuthStartResult> {
+  const mode = parseStartMode(args.options);
+  const response = await fetch(
+    `${STRIPE_DASHBOARD_ORIGIN}${STRIPE_CLI_AUTH_PATH}`,
+    {
+      method: "POST",
+      redirect: "error",
+      headers: {
+        "Content-Type": "application/x-www-form-urlencoded",
+      },
+      body: new URLSearchParams({
+        client_version: STRIPE_CLI_CLIENT_VERSION,
+        device_name: STRIPE_CLI_DEVICE_NAME,
+      }),
+    },
+  );
+
+  if (!response.ok) {
+    throw new Error(await stripeCliHttpErrorMessage("start", response));
+  }
+
+  const data = stripeCliStartResponseSchema.parse(
+    await readStripeJsonResponse(response),
+  );
+  const browserUrl = validatedStripeDashboardUrl(
+    data.browser_url,
+    "confirm_auth",
+    "browser",
+  );
+  const pollUrl = validatedStripeDashboardUrl(data.poll_url, "auth", "poll");
+
+  return {
+    deviceCode: STRIPE_CLI_DEVICE_CODE,
+    pollState: stripeCliPollStateString({
+      version: 1,
+      mode,
+      pollUrl,
+    }),
+    userCode: data.verification_code,
+    verificationUri: browserUrl,
+    verificationUriComplete: browserUrl,
+    expiresIn: STRIPE_CLI_AUTH_START_EXPIRES_IN_SECONDS,
+    interval: STRIPE_CLI_AUTH_POLL_INTERVAL_SECONDS,
+  };
+}
+
+export async function pollStripeCliDashboardAuth(args: {
+  readonly pollState: string | undefined;
+}): Promise<OAuthDeviceAuthPollResult<"stripe", "cli">> {
+  const providerState = stripeCliPollState(args.pollState);
+  if (!providerState) {
+    return stripeCliProviderError(
+      "Stripe CLI auth session is invalid. Start again to retry.",
+    );
+  }
+
+  let pollUrl: string;
+  try {
+    pollUrl = validatedStripeDashboardUrl(
+      providerState.pollUrl,
+      "auth",
+      "poll",
+    );
+  } catch (error) {
+    return stripeCliProviderErrorFromUnknown(
+      error,
+      "Stripe CLI auth session is invalid. Start again to retry.",
+    );
+  }
+
+  let response: Response;
+  try {
+    response = await fetch(pollUrl, {
+      method: "GET",
+      redirect: "error",
+    });
+  } catch (error) {
+    return stripeCliProviderErrorFromUnknown(
+      error,
+      "Stripe CLI auth poll failed",
+    );
+  }
+
+  if (!response.ok) {
+    try {
+      return stripeCliProviderError(
+        await stripeCliHttpErrorMessage("poll", response),
+      );
+    } catch (error) {
+      return stripeCliProviderErrorFromUnknown(
+        error,
+        "Stripe CLI auth poll failed",
+      );
+    }
+  }
+
+  const data = await readStripeCliPollResponse(response);
+  if ("status" in data) {
+    return data;
+  }
+
+  if (data.error) {
+    return stripeCliProviderError(data.error_description ?? data.error);
+  }
+  if (!data.redeemed) {
+    return {
+      status: "pending",
+      interval: STRIPE_CLI_AUTH_POLL_INTERVAL_SECONDS,
+    };
+  }
+
+  const token = selectedStripeCliKey({
+    mode: providerState.mode,
+    testKey: data.testmode_key_secret,
+    liveKey: data.livemode_key_secret,
+  });
+  if (!token) {
+    return stripeCliProviderError(
+      `Stripe CLI auth did not return a ${providerState.mode} mode key`,
+    );
+  }
+  if (!stripeCliKeyMatchesMode(token, providerState.mode)) {
+    return stripeCliProviderError(
+      `Stripe CLI auth returned an invalid ${providerState.mode} mode key`,
+    );
+  }
+
+  const accountId = data.account_id ?? "stripe";
+  const displayName = data.account_display_name ?? accountId;
+
+  return {
+    status: "complete",
+    token: {
+      outputs: { token },
+      expiresIn: STRIPE_CLI_KEY_EXPIRES_IN_SECONDS,
+      scopes: [],
+      userInfo: {
+        id: accountId,
+        username: displayName,
+        email: null,
+      },
+    },
+  };
+}

--- a/turbo/packages/connectors/src/auth-providers/connectors/stripe/provider.ts
+++ b/turbo/packages/connectors/src/auth-providers/connectors/stripe/provider.ts
@@ -1,10 +1,15 @@
-import type { AuthCodeConnectorAuthProvider } from "../../types";
+import type {
+  AuthCodeConnectorAuthProvider,
+  DeviceAuthConnectorAuthProvider,
+} from "../../types";
 import {
   buildStripeAuthorizationUrl,
   exchangeStripeCode,
   refreshStripeToken,
 } from "./oauth";
+import { pollStripeCliDashboardAuth, startStripeCliDashboardAuth } from "./cli";
 import { oauthRefreshResultToProviderResult } from "../../oauth/types";
+
 export const stripeProvider: AuthCodeConnectorAuthProvider<"stripe"> = {
   grant: {
     kind: "auth-code",
@@ -53,6 +58,29 @@ export const stripeProvider: AuthCodeConnectorAuthProvider<"stripe"> = {
         ),
       );
     },
+  },
+  revoke: { kind: "none" },
+};
+
+export const stripeCliProvider: DeviceAuthConnectorAuthProvider<
+  "stripe",
+  "cli"
+> = {
+  grant: {
+    kind: "device-auth",
+    startDeviceAuth: async (args) => {
+      return await startStripeCliDashboardAuth({
+        options: args.options,
+      });
+    },
+    pollDeviceAuth: async (args) => {
+      return await pollStripeCliDashboardAuth({
+        pollState: args.pollState,
+      });
+    },
+  },
+  access: {
+    kind: "none",
   },
   revoke: { kind: "none" },
 };

--- a/turbo/packages/connectors/src/connector-utils.ts
+++ b/turbo/packages/connectors/src/connector-utils.ts
@@ -50,8 +50,9 @@ import type { FeatureSwitchKey } from "./feature-switch-key";
 
 const CONNECTOR_AUTH_METHOD_PRIORITY = {
   oauth: 0,
-  "api-token": 1,
-  api: 2,
+  cli: 1,
+  "api-token": 2,
+  api: 3,
 } as const satisfies Record<ConnectorAuthMethodId, number>;
 const CONNECTOR_SECRET_REF_PREFIX = "$secrets.";
 const CONNECTOR_VARIABLE_REF_PREFIX = "$vars.";

--- a/turbo/packages/connectors/src/connectors.ts
+++ b/turbo/packages/connectors/src/connectors.ts
@@ -511,7 +511,12 @@ export type ConnectorAuthMethodConfig =
  * These values are connector registry keys, not lifecycle categories. Behavior
  * must be derived from the selected auth method lifecycle config.
  */
-export const CONNECTOR_AUTH_METHOD_IDS = ["oauth", "api-token", "api"] as const;
+export const CONNECTOR_AUTH_METHOD_IDS = [
+  "oauth",
+  "api-token",
+  "cli",
+  "api",
+] as const;
 export const connectorAuthMethodIdSchema = z.enum(CONNECTOR_AUTH_METHOD_IDS);
 export type ConnectorAuthMethodId = z.infer<typeof connectorAuthMethodIdSchema>;
 

--- a/turbo/packages/connectors/src/connectors/stripe.ts
+++ b/turbo/packages/connectors/src/connectors/stripe.ts
@@ -73,6 +73,45 @@ export const stripe = {
         },
         revoke: { kind: "none" },
       },
+      cli: {
+        label: "Sign in with Stripe",
+        helpText:
+          "Approve access in the Stripe Dashboard so vm0 can import a restricted API key.",
+        client: {
+          clientRegistration: "dynamic",
+          clientType: "public",
+        },
+        storage: {
+          secrets: ["STRIPE_TOKEN"],
+          variables: [],
+        },
+        grant: {
+          kind: "device-auth",
+          scopes: [],
+          outputs: {
+            token: "$secrets.STRIPE_TOKEN",
+          },
+          startOptions: {
+            mode: {
+              kind: "select",
+              label: "Mode",
+              required: true,
+              defaultValue: "test",
+              options: [
+                { value: "test", label: "Test" },
+                { value: "live", label: "Live" },
+              ],
+            },
+          },
+        },
+        access: {
+          kind: "static",
+          envBindings: {
+            STRIPE_TOKEN: "$secrets.STRIPE_TOKEN",
+          },
+        },
+        revoke: { kind: "none" },
+      },
     },
     defaultAuthMethod: "oauth",
   },


### PR DESCRIPTION
## Summary
- add a Stripe `cli` connector auth method using the Stripe Dashboard CLI auth/poll protocol
- import the selected test/live restricted key into `STRIPE_TOKEN` while keeping the Dashboard poll URL in encrypted provider state only
- cover provider validation, API device-auth persistence, firewall static access, search availability, and UI expiry behavior

Closes #16297

## Tests
- pnpm -F @vm0/connectors check-types
- pnpm -F @vm0/connectors exec vitest run src/__tests__/connectors.test.ts
- pnpm -F api exec vitest run src/signals/routes/__tests__/zero-connectors-oauth-device-auth.test.ts
- pnpm -F api exec vitest run src/signals/routes/__tests__/webhooks-agent-firewall-auth.test.ts
- pnpm -F api exec vitest run src/signals/services/__tests__/zero-connector-data.service.test.ts
- pnpm -F @vm0/app exec vitest run src/signals/zero-page/settings/__tests__/connect-connector.test.ts src/signals/zero-page/__tests__/zero-connectors.test.ts
- pnpm format
- pnpm check-types
- pnpm lint
- pnpm knip
- pnpm vitest (fails locally in the Linux container on `@vm0/desktop` macOS-only native computer-use tests: Desktop Computer Use is currently implemented for macOS)
