### PR TITLE
docs: document snapshot publish cleanup semantics

### DIFF
--- a/crates/sandbox-fc/src/snapshot/mod.rs
+++ b/crates/sandbox-fc/src/snapshot/mod.rs
@@ -31,6 +31,12 @@ use self::runtime::run_snapshot_workflow;
 
 /// Create a snapshot by booting a fresh VM, configuring it, and capturing state.
 ///
+/// This helper creates an uncommitted snapshot, commits the pending publish,
+/// and returns only after the provider-specific completion marker and stable
+/// output artifacts have been published. If publishing fails, it best-effort
+/// discards the uncommitted artifacts and returns the original publish error;
+/// any discard error is intentionally suppressed.
+///
 /// This is the Rust equivalent of the TS `commands/snapshot.ts` workflow:
 ///  1. Create work directory
 ///  2. Create NBD COW device backed by the rootfs image

--- a/crates/sandbox/src/snapshot.rs
+++ b/crates/sandbox/src/snapshot.rs
@@ -130,6 +130,20 @@ pub trait SnapshotProvider: Send + Sync {
 
     /// Create a snapshot by booting a temporary VM, configuring it, and
     /// capturing its state to the output directory.
+    ///
+    /// The default implementation calls
+    /// [`create_uncommitted_snapshot`](Self::create_uncommitted_snapshot),
+    /// then commits the returned [`PendingSnapshotPublish`]. It returns the
+    /// stable output paths only after the pending publish commits successfully.
+    ///
+    /// If the pending publish commit fails, the default implementation calls
+    /// [`PendingSnapshotPublish::discard`] best-effort and returns the original
+    /// commit error. Any discard error is intentionally suppressed, and callers
+    /// should treat the attempted output as incomplete.
+    ///
+    /// Providers that override this method should preserve the same
+    /// cleanup/error semantics or explicitly document a stronger
+    /// provider-specific guarantee.
     async fn create_snapshot(
         &self,
         config: SnapshotCreateConfig,


### PR DESCRIPTION
## Summary

- Document the default `SnapshotProvider::create_snapshot` publish sequence and commit-failure cleanup behavior.
- Document the matching public `sandbox-fc::snapshot::create_snapshot` helper semantics.
- Clarify override expectations without changing runtime behavior.

Closes #16378

## Validation

- `cargo doc -p sandbox --manifest-path crates/Cargo.toml --no-deps`
- `cargo doc -p sandbox-fc --manifest-path crates/Cargo.toml --no-deps`
- pre-commit: crates `cargo-doc`
- pre-commit: crates `cargo-clippy`
