### PR TITLE
test(mitm-addon): centralize usage timer scaffolding

### DIFF
--- a/crates/runner/mitm-addon/tests/test_addon_configuration.py
+++ b/crates/runner/mitm-addon/tests/test_addon_configuration.py
@@ -1,7 +1,7 @@
 """Tests for mitm addon configuration hooks."""
 
 import uuid
-from collections.abc import Callable, Sequence
+from collections.abc import Sequence
 from dataclasses import dataclass
 from pathlib import Path
 from unittest.mock import patch
@@ -12,6 +12,7 @@ import mitm_addon
 import usage
 import usage.buffer as usage_buffer
 from tests.pending_helpers import assert_pending
+from tests.usage_helpers import install_recording_usage_timer
 
 
 @dataclass(frozen=True)
@@ -58,21 +59,6 @@ class _Options:
     ) -> None:
         self.vm0_usage_state_id = usage_state_id
         self.vm0_usage_flush_interval_seconds = flush_interval_seconds
-
-
-class _FakeTimer:
-    def __init__(self, delay: float, callback: Callable[[], None]) -> None:
-        self.delay = delay
-        self.callback = callback
-        self.daemon = False
-        self.cancelled = False
-        self.started = False
-
-    def start(self) -> None:
-        self.started = True
-
-    def cancel(self) -> None:
-        self.cancelled = True
 
 
 def _addon_file_path(tmp_path: Path) -> str:
@@ -155,16 +141,9 @@ class TestAddonConfiguration:
         assert not pending_path.exists()
 
     def test_configure_updates_usage_flush_interval(self, tmp_path):
-        timers: list[_FakeTimer] = []
+        timers = install_recording_usage_timer()
         flush_interval_seconds = 15.0
         jitter_seconds = flush_interval_seconds * usage_buffer.DEFAULT_FLUSH_JITTER_RATIO
-
-        def timer_factory(delay: float, callback: Callable[[], None]) -> _FakeTimer:
-            timer = _FakeTimer(delay, callback)
-            timers.append(timer)
-            return timer
-
-        usage.reset_usage_buffer_for_tests(timer_enabled=True, timer_factory=timer_factory)
 
         with patch.object(
             mitm_addon.ctx,

--- a/crates/runner/mitm-addon/tests/test_usage_buffer.py
+++ b/crates/runner/mitm-addon/tests/test_usage_buffer.py
@@ -9,6 +9,7 @@ import pytest
 
 import usage
 import usage.buffer as usage_buffer
+from tests.usage_helpers import install_recording_usage_timer
 
 
 def _event(
@@ -38,21 +39,6 @@ def _flush_log_entries(proxy_log_path):
         for line in proxy_log_path.read_text().splitlines()
         if '"usage_event_buffer_flush"' in line
     ]
-
-
-class _FakeTimer:
-    def __init__(self, delay: float, callback):
-        self.delay = delay
-        self.callback = callback
-        self.daemon = False
-        self.cancelled = False
-        self.started = False
-
-    def start(self) -> None:
-        self.started = True
-
-    def cancel(self) -> None:
-        self.cancelled = True
 
 
 class _InstrumentedFlushOwnerLock:
@@ -647,14 +633,7 @@ def test_flush_preserves_events_buffered_during_enqueue(tmp_path):
 
 
 def test_shutdown_flush_waits_for_active_timer_flush_and_drains_live_usage(tmp_path):
-    timers = []
-
-    def timer_factory(delay: float, callback):
-        timer = _FakeTimer(delay, callback)
-        timers.append(timer)
-        return timer
-
-    usage.reset_usage_buffer_for_tests(timer_enabled=True, timer_factory=timer_factory)
+    timers = install_recording_usage_timer()
     flush_owner_lock = _InstrumentedFlushOwnerLock()
     usage_buffer._usage_event_buffer._flush_owner_lock = flush_owner_lock
 
@@ -723,14 +702,7 @@ def test_shutdown_flush_waits_for_active_timer_flush_and_drains_live_usage(tmp_p
 
 
 def test_shutdown_flush_retries_active_timer_failure_without_rescheduling_timer(tmp_path):
-    timers = []
-
-    def timer_factory(delay: float, callback):
-        timer = _FakeTimer(delay, callback)
-        timers.append(timer)
-        return timer
-
-    usage.reset_usage_buffer_for_tests(timer_enabled=True, timer_factory=timer_factory)
+    timers = install_recording_usage_timer()
     flush_owner_lock = _InstrumentedFlushOwnerLock()
     usage_buffer._usage_event_buffer._flush_owner_lock = flush_owner_lock
 
@@ -798,14 +770,7 @@ def test_shutdown_flush_retries_active_timer_failure_without_rescheduling_timer(
 
 
 def test_shutdown_flush_drains_usage_deferred_by_threshold_flush_while_waiting(tmp_path):
-    timers = []
-
-    def timer_factory(delay: float, callback):
-        timer = _FakeTimer(delay, callback)
-        timers.append(timer)
-        return timer
-
-    usage.reset_usage_buffer_for_tests(timer_enabled=True, timer_factory=timer_factory)
+    timers = install_recording_usage_timer()
     flush_owner_lock = _InstrumentedFlushOwnerLock()
     usage_buffer._usage_event_buffer._flush_owner_lock = flush_owner_lock
 
@@ -874,14 +839,7 @@ def test_shutdown_flush_drains_usage_deferred_by_threshold_flush_while_waiting(t
 
 
 def test_shutdown_flush_drains_live_usage_buffered_during_own_enqueue(tmp_path):
-    timers = []
-
-    def timer_factory(delay: float, callback):
-        timer = _FakeTimer(delay, callback)
-        timers.append(timer)
-        return timer
-
-    usage.reset_usage_buffer_for_tests(timer_enabled=True, timer_factory=timer_factory)
+    timers = install_recording_usage_timer()
 
     proxy_log_path = str(tmp_path / "proxy.jsonl")
     usage.buffer_usage_events(
@@ -919,14 +877,7 @@ def test_shutdown_flush_drains_live_usage_buffered_during_own_enqueue(tmp_path):
 
 
 def test_shutdown_flush_failure_preserves_retry_without_rescheduling_timer(tmp_path):
-    timers = []
-
-    def timer_factory(delay: float, callback):
-        timer = _FakeTimer(delay, callback)
-        timers.append(timer)
-        return timer
-
-    usage.reset_usage_buffer_for_tests(timer_enabled=True, timer_factory=timer_factory)
+    timers = install_recording_usage_timer()
 
     usage.buffer_usage_events(
         "https://api.test/api/webhooks/agent/usage-event",
@@ -999,14 +950,7 @@ def test_rejected_events_do_not_leave_empty_destination_buckets(tmp_path):
 
 
 def test_timer_flush_uses_scheduled_callback_without_real_sleep(tmp_path):
-    timers = []
-
-    def timer_factory(delay: float, callback):
-        timer = _FakeTimer(delay, callback)
-        timers.append(timer)
-        return timer
-
-    usage.reset_usage_buffer_for_tests(timer_enabled=True, timer_factory=timer_factory)
+    timers = install_recording_usage_timer()
 
     with patch.object(usage_buffer, "_enqueue_webhook") as enqueue:
         usage.buffer_usage_events(
@@ -1030,14 +974,7 @@ def test_timer_flush_uses_scheduled_callback_without_real_sleep(tmp_path):
 
 
 def test_timer_flush_failure_reschedules_retry_without_real_sleep(tmp_path):
-    timers = []
-
-    def timer_factory(delay: float, callback):
-        timer = _FakeTimer(delay, callback)
-        timers.append(timer)
-        return timer
-
-    usage.reset_usage_buffer_for_tests(timer_enabled=True, timer_factory=timer_factory)
+    timers = install_recording_usage_timer()
 
     usage.buffer_usage_events(
         "https://api.test/api/webhooks/agent/usage-event",
@@ -1064,14 +1001,7 @@ def test_timer_flush_failure_reschedules_retry_without_real_sleep(tmp_path):
 
 
 def test_threshold_flush_cancels_scheduled_timer_and_allows_reschedule(tmp_path):
-    timers = []
-
-    def timer_factory(delay: float, callback):
-        timer = _FakeTimer(delay, callback)
-        timers.append(timer)
-        return timer
-
-    usage.reset_usage_buffer_for_tests(timer_enabled=True, timer_factory=timer_factory)
+    timers = install_recording_usage_timer()
 
     with patch.object(usage_buffer, "_enqueue_webhook") as enqueue:
         for index in range(usage_buffer.MAX_BUFFERED_WEBHOOK_BATCHES - 1):

--- a/crates/runner/mitm-addon/tests/usage_helpers.py
+++ b/crates/runner/mitm-addon/tests/usage_helpers.py
@@ -6,10 +6,40 @@ import contextlib
 import json
 import threading
 from collections import deque
-from collections.abc import Iterator, Sequence
+from collections.abc import Callable, Iterator, Sequence
 from dataclasses import dataclass
 from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
 from typing import Any
+
+import usage
+
+
+class RecordingTimer:
+    def __init__(self, delay: float, callback: Callable[[], None]) -> None:
+        self.delay = delay
+        self.callback = callback
+        self.daemon = False
+        self.cancelled = False
+        self.started = False
+
+    def start(self) -> None:
+        self.started = True
+
+    def cancel(self) -> None:
+        self.cancelled = True
+
+
+def install_recording_usage_timer() -> list[RecordingTimer]:
+    """Reset the usage buffer with a timer factory that records scheduled timers."""
+    timers: list[RecordingTimer] = []
+
+    def timer_factory(delay: float, callback: Callable[[], None]) -> RecordingTimer:
+        timer = RecordingTimer(delay, callback)
+        timers.append(timer)
+        return timer
+
+    usage.reset_usage_buffer_for_tests(timer_enabled=True, timer_factory=timer_factory)
+    return timers
 
 
 @dataclass(frozen=True)


### PR DESCRIPTION
## Summary
- Add a shared `RecordingTimer` and explicit `install_recording_usage_timer()` helper for usage-buffer timer tests.
- Replace duplicated fake timer classes and repeated timer factory/reset setup in usage buffer and addon configuration tests.
- Keep concurrency orchestration and behavior-specific assertions local to each test.

## Verification
- `pytest tests/test_usage_buffer.py tests/test_addon_configuration.py`
- `ruff format tests/usage_helpers.py tests/test_usage_buffer.py tests/test_addon_configuration.py`
- `ruff check tests/usage_helpers.py tests/test_usage_buffer.py tests/test_addon_configuration.py`
- `git diff --check`

Closes #16382