### PR TITLE
fix(mitm-addon): harden X billing JSON parser failures

### DIFF
--- a/crates/runner/mitm-addon/src/usage/providers/connectors/x.py
+++ b/crates/runner/mitm-addon/src/usage/providers/connectors/x.py
@@ -305,7 +305,7 @@ class _NdjsonExtractor:
             return  # keep-alive blank line
         try:
             obj = json.loads(line)
-        except (json.JSONDecodeError, UnicodeDecodeError):
+        except (ValueError, RecursionError):
             self.state["lines_failed"] += 1
             return
         self.state["lines_parsed"] += 1

--- a/crates/runner/mitm-addon/src/usage/providers/connectors/x_billing.py
+++ b/crates/runner/mitm-addon/src/usage/providers/connectors/x_billing.py
@@ -394,7 +394,7 @@ def _tweet_create_body_is_plain_text_without_url(body: bytes | None) -> bool:
         return False
     try:
         obj = json.loads(body)
-    except (json.JSONDecodeError, UnicodeDecodeError):
+    except (ValueError, RecursionError):
         return False
     if not isinstance(obj, dict):
         return False

--- a/crates/runner/mitm-addon/tests/test_x_connector_pipeline.py
+++ b/crates/runner/mitm-addon/tests/test_x_connector_pipeline.py
@@ -10,7 +10,12 @@ import body_utils
 import mitm_addon
 import usage
 from tests.flow_helpers import response_stream
-from tests.x_flow_helpers import make_x_pipeline_flow, make_x_stream_pipeline_flow
+from tests.x_flow_helpers import (
+    json_body_that_exceeds_decoder_recursion,
+    json_body_that_exceeds_integer_digit_limit,
+    make_x_pipeline_flow,
+    make_x_stream_pipeline_flow,
+)
 
 
 class TestXConnectorResponsePipeline:
@@ -240,6 +245,39 @@ class TestXConnectorResponsePipeline:
         payloads = webhook.usage_events()
         by_cat = {payload["category"]: payload["quantity"] for payload in payloads}
         assert by_cat == {"posts.read": 1, "media.read": 1}
+
+    @pytest.mark.parametrize(
+        "failed_line",
+        [
+            pytest.param(json_body_that_exceeds_decoder_recursion(), id="decoder-recursion"),
+            pytest.param(json_body_that_exceeds_integer_digit_limit(), id="integer-digit-limit"),
+        ],
+    )
+    def test_full_streaming_pipeline_continues_after_json_parser_failure(
+        self, tmp_path, real_flow, mitm_ctx, headers, fresh_usage_executor, failed_line
+    ):
+        """A hostile NDJSON row must not stop later valid rows from billing."""
+        flow = make_x_stream_pipeline_flow(real_flow, tmp_path)
+
+        mitm_addon.responseheaders(flow)
+        callback = response_stream(flow)
+
+        callback(failed_line + b'\n{"data":{"id":"1"},"includes":{"users":[{"id":"u1"}]}}\n')
+
+        state = flow.metadata["x_ndjson_state"]
+        assert state["lines_failed"] == 1
+        assert state["lines_parsed"] == 1
+        assert state["data_count"] == 1
+        assert state["includes"] == {"users": 1}
+
+        with self._usage_webhook_api() as webhook:
+            mitm_addon.response(flow)
+            usage.flush_usage_events(trigger="test")
+            usage.webhook.usage_executor.shutdown(wait=True)
+
+        payloads = webhook.usage_events()
+        by_cat = {payload["category"]: payload["quantity"] for payload in payloads}
+        assert by_cat == {"posts.read": 1, "user.read": 1}
 
     def test_full_streaming_pipeline_bounds_unknown_include_categories(
         self, tmp_path, real_flow, mitm_ctx, headers, fresh_usage_executor

--- a/crates/runner/mitm-addon/tests/test_x_connector_usage.py
+++ b/crates/runner/mitm-addon/tests/test_x_connector_usage.py
@@ -9,7 +9,11 @@ import pytest
 
 import body_utils
 import usage
-from tests.x_flow_helpers import make_x_usage_flow
+from tests.x_flow_helpers import (
+    json_body_that_exceeds_decoder_recursion,
+    json_body_that_exceeds_integer_digit_limit,
+    make_x_usage_flow,
+)
 
 
 class TestXConnectorUsage:
@@ -857,6 +861,34 @@ class TestXConnectorUsage:
         flow.request.content = b"not valid json at all"
         p = self._call_and_get_single_billing(flow)
         assert p["category"] == "content.create_with_url"
+
+    @pytest.mark.parametrize(
+        "request_body",
+        [
+            pytest.param(json_body_that_exceeds_decoder_recursion(), id="decoder-recursion"),
+            pytest.param(json_body_that_exceeds_integer_digit_limit(), id="integer-digit-limit"),
+        ],
+    )
+    def test_tweet_create_json_parser_failure_stays_conservative(
+        self, tmp_path, real_flow, request_body
+    ):
+        """Stdlib JSON parser failures must not interrupt tweet-create billing."""
+        flow = self._make_x_flow(
+            real_flow,
+            tmp_path,
+            path="/2/tweets",
+            body=json.dumps({"data": {"id": "1"}}).encode(),
+            status=201,
+            permission="tweet.write",
+            rule="POST /2/tweets",
+        )
+        flow.request.method = "POST"
+        flow.request.content = request_body
+
+        p = self._call_and_get_single_billing(flow)
+
+        assert p["category"] == "content.create_with_url"
+        assert p["quantity"] == 1
 
     def test_query_string_does_not_break_literal_suffix_override(self, tmp_path, real_flow):
         """``flow.request.path`` from mitmproxy includes the query string;

--- a/crates/runner/mitm-addon/tests/x_flow_helpers.py
+++ b/crates/runner/mitm-addon/tests/x_flow_helpers.py
@@ -1,4 +1,4 @@
-"""Shared X connector flow builders for mitm-addon tests."""
+"""Shared X connector flow and payload builders for mitm-addon tests."""
 
 from collections.abc import Callable
 from pathlib import Path
@@ -9,10 +9,26 @@ from mitmproxy.test import tutils
 from tests.flow_helpers import header_map
 
 RealFlowFactory = Callable[..., http.HTTPFlow]
+_JSON_RECURSION_FAILURE_DEPTH = 10_000
+_JSON_INTEGER_DIGIT_LIMIT_DIGITS = 10_000
 
 
 def x_original_url(path: str, query: str = "") -> str:
     return f"https://api.x.com{path}?{query}" if query else f"https://api.x.com{path}"
+
+
+def json_body_that_exceeds_decoder_recursion() -> bytes:
+    return (
+        b'{"text":"hi","x":'
+        + b"[" * _JSON_RECURSION_FAILURE_DEPTH
+        + b"0"
+        + b"]" * _JSON_RECURSION_FAILURE_DEPTH
+        + b"}"
+    )
+
+
+def json_body_that_exceeds_integer_digit_limit() -> bytes:
+    return b'{"n":' + b"1" * _JSON_INTEGER_DIGIT_LIMIT_DIGITS + b"}"
 
 
 def make_x_response_flow(


### PR DESCRIPTION
## Summary

- Treat stdlib JSON parser failures as malformed input in X tweet-create body refinement.
- Treat X NDJSON row parser failures as failed rows so later valid rows still bill.
- Add integration coverage for deep nesting and Python integer digit-limit parser failures.

Closes #16383

## Tests

- `.venv/bin/python -m pytest tests/test_x_connector_usage.py::TestXConnectorUsage::test_tweet_create_json_parser_failure_stays_conservative tests/test_x_connector_pipeline.py::TestXConnectorResponsePipeline::test_full_streaming_pipeline_continues_after_json_parser_failure`
- `.venv/bin/ruff format src/usage/providers/connectors/x.py src/usage/providers/connectors/x_billing.py tests/test_x_connector_usage.py tests/test_x_connector_pipeline.py tests/x_flow_helpers.py`
- `.venv/bin/python -m pytest tests/test_x_connector_usage.py tests/test_x_connector_pipeline.py`
- `.venv/bin/ruff check src/usage/providers/connectors/x.py src/usage/providers/connectors/x_billing.py tests/test_x_connector_usage.py tests/test_x_connector_pipeline.py tests/x_flow_helpers.py`
- `.venv/bin/python -m pytest tests/`
