### PR TITLE
chore: update rootfs package versions

### DIFF
--- a/crates/runner/scripts/build-template.sh
+++ b/crates/runner/scripts/build-template.sh
@@ -111,7 +111,7 @@ CACHE_TMP_TAR=""
 
 # Pinned versions (changes here invalidate the template cache via script hash)
 GO_VERSION="1.26.4"
-CLAUDE_CODE_VERSION="2.1.167"
+CLAUDE_CODE_VERSION="2.1.168"
 CODEX_CLI_VERSION="0.137.0"
 GWS_CLI_VERSION="0.22.5"
 XURL_VERSION="1.0.3"


### PR DESCRIPTION
## Summary

Updated the pinned rootfs dependency versions in `crates/runner/scripts/build-template.sh`.

## Updates

- Claude Code CLI: `2.1.167` -> `2.1.168`

## Checked with no update needed

- Go: `1.26.4` is the latest stable release from `go.dev/dl`.
- Codex CLI: `0.137.0` matches the latest npm release for `@openai/codex`.
- Google Workspace CLI: `0.22.5` matches the latest npm release for `@googleworkspace/cli`.
- xurl: `1.0.3` matches the latest npm release for `@xdevplatform/xurl`.
- agent-browser: `0.27.1` matches the latest npm release for `agent-browser`.
- pnpm: `11.5.2` matches the latest npm release for `pnpm`.
- Node.js: kept on NodeSource `node_24.x`, the current LTS major line.
- PostgreSQL: kept `postgresql-16`; it is the available PostgreSQL major in the Ubuntu Noble repositories used by the rootfs.

## Validation

- `bash -n crates/runner/scripts/build-template.sh`