### PR TITLE
fix: bound guest telemetry delta reads

### DIFF
--- a/crates/guest-agent/src/telemetry.rs
+++ b/crates/guest-agent/src/telemetry.rs
@@ -253,7 +253,7 @@ fn read_file_delta_with_behavior(
         let Some((boundary_buf, boundary_unread_len)) =
             read_bounded_at(&mut file, file_len, boundary_pos)
         else {
-            return TextDelta::progressed(String::new(), boundary_pos);
+            return TextDelta::empty(last_pos);
         };
         let delta = read_from_line_boundary(
             &boundary_buf,

--- a/crates/guest-agent/src/telemetry.rs
+++ b/crates/guest-agent/src/telemetry.rs
@@ -47,7 +47,8 @@ const OVERSIZED_SYSTEM_LOG_LINE_MARKER: &str =
 /// pick them up once the producer completes the line.
 ///
 /// `Final` is the very last upload before agent exit. There is no next
-/// pass, so the EOF tail is consumed verbatim.
+/// pass, so the EOF tail is consumed verbatim when it fits in one bounded
+/// read after any required line-boundary resync.
 #[derive(Clone, Copy, PartialEq, Eq, Debug)]
 pub enum UploadMode {
     Live,
@@ -107,6 +108,48 @@ fn is_line_boundary(file: &mut std::fs::File, pos: u64) -> Option<bool> {
     Some(previous[0] == b'\n')
 }
 
+fn read_from_line_boundary(
+    buf: &[u8],
+    base_pos: u64,
+    unread_len: u64,
+    mode: UploadMode,
+    oversized_line_behavior: OversizedLineBehavior,
+) -> TextDelta {
+    if mode == UploadMode::Final && unread_len <= buf.len() as u64 {
+        return TextDelta::progressed(
+            String::from_utf8_lossy(buf).into_owned(),
+            base_pos + unread_len,
+        );
+    }
+
+    match buf.iter().rposition(|&b| b == b'\n') {
+        Some(idx) => {
+            let consumed = idx + 1;
+            let new_pos = base_pos + consumed as u64;
+            // `consumed <= buf.len()` by construction (rposition returns
+            // a valid index into buf, so idx + 1 <= buf.len()), so this
+            // `get` always returns Some. The let-else exists only to
+            // satisfy `clippy::indexing_slicing = "deny"` without an
+            // explicit suppression or `expect`.
+            let Some(slice) = buf.get(..consumed) else {
+                return TextDelta::empty(base_pos);
+            };
+            TextDelta::progressed(String::from_utf8_lossy(slice).into_owned(), new_pos)
+        }
+        None if unread_len <= TELEMETRY_DELTA_READ_LIMIT as u64 => TextDelta::empty(base_pos),
+        None => {
+            let new_pos = base_pos + buf.len() as u64;
+            let content = match oversized_line_behavior {
+                OversizedLineBehavior::EmitSystemLogMarker => {
+                    OVERSIZED_SYSTEM_LOG_LINE_MARKER.to_string()
+                }
+                OversizedLineBehavior::Drop => String::new(),
+            };
+            TextDelta::progressed(content, new_pos)
+        }
+    }
+}
+
 /// Read new bytes from `file_path` starting at the position stored in `pos_path`.
 /// Returns the new content, updated position, and whether the position advanced.
 ///
@@ -118,9 +161,8 @@ fn is_line_boundary(file: &mut std::fs::File, pos: u64) -> Option<bool> {
 /// by U+FFFD and permanently lost, since the position has already advanced
 /// past it).
 ///
-/// In `Final` mode, the tail is consumed as-is — there will be no subsequent
-/// pass to pick it up. Any trailing fragment without a newline is uploaded
-/// verbatim when it fits within the bounded read window.
+/// In `Final` mode, the tail is consumed as-is when it fits within the bounded
+/// read window after any required line-boundary resync.
 fn read_file_delta(file_path: &str, pos_path: &str, mode: UploadMode) -> TextDelta {
     read_file_delta_with_behavior(
         file_path,
@@ -166,55 +208,37 @@ fn read_file_delta_with_behavior(
         return TextDelta::empty(last_pos);
     }
 
-    if mode == UploadMode::Final
-        && at_line_boundary
-        && unread_len <= TELEMETRY_DELTA_READ_LIMIT as u64
-    {
-        return TextDelta::progressed(String::from_utf8_lossy(&buf).into_owned(), file_len);
-    }
-
     if !at_line_boundary {
-        return match buf.iter().position(|&b| b == b'\n') {
-            Some(idx) => {
-                let consumed = idx + 1;
-                TextDelta::progressed(String::new(), last_pos + consumed as u64)
-            }
-            None => TextDelta::progressed(String::new(), last_pos + to_read as u64),
+        let Some(idx) = buf.iter().position(|&b| b == b'\n') else {
+            return TextDelta::progressed(String::new(), last_pos + to_read as u64);
+        };
+
+        let consumed = idx + 1;
+        let boundary_pos = last_pos + consumed as u64;
+        let Some(remaining) = buf.get(consumed..) else {
+            return TextDelta::progressed(String::new(), boundary_pos);
+        };
+
+        if remaining.is_empty() {
+            return TextDelta::progressed(String::new(), boundary_pos);
+        }
+
+        let remaining_unread_len = unread_len.saturating_sub(consumed as u64);
+        let delta = read_from_line_boundary(
+            remaining,
+            boundary_pos,
+            remaining_unread_len,
+            mode,
+            oversized_line_behavior,
+        );
+        return if delta.made_progress {
+            delta
+        } else {
+            TextDelta::progressed(String::new(), boundary_pos)
         };
     }
 
-    match buf.iter().rposition(|&b| b == b'\n') {
-        Some(idx) => {
-            let consumed = idx + 1;
-            let new_pos = last_pos + consumed as u64;
-            // `consumed <= buf.len()` by construction (rposition returns
-            // a valid index into buf, so idx + 1 <= buf.len()), so this
-            // `get` always returns Some. The let-else exists only to
-            // satisfy `clippy::indexing_slicing = "deny"` without an
-            // explicit suppression or `expect`.
-            let Some(slice) = buf.get(..consumed) else {
-                return TextDelta::empty(last_pos);
-            };
-            TextDelta::progressed(String::from_utf8_lossy(slice).into_owned(), new_pos)
-        }
-        None if at_line_boundary && unread_len <= TELEMETRY_DELTA_READ_LIMIT as u64 => {
-            TextDelta::empty(last_pos)
-        }
-        None => {
-            let new_pos = last_pos + to_read as u64;
-            let content = if at_line_boundary {
-                match oversized_line_behavior {
-                    OversizedLineBehavior::EmitSystemLogMarker => {
-                        OVERSIZED_SYSTEM_LOG_LINE_MARKER.to_string()
-                    }
-                    OversizedLineBehavior::Drop => String::new(),
-                }
-            } else {
-                String::new()
-            };
-            TextDelta::progressed(content, new_pos)
-        }
-    }
+    read_from_line_boundary(&buf, last_pos, unread_len, mode, oversized_line_behavior)
 }
 
 /// Read new JSONL entries from a file, skipping invalid lines.
@@ -249,12 +273,11 @@ fn save_position(pos_path: &str, pos: u64) {
 /// Perform one telemetry upload cycle.
 ///
 /// `UploadMode::Final` should be used only for the very last upload before
-/// the agent exits — any trailing fragment after the last newline is then
-/// consumed as-is, accepting a small mid-write race window in exchange for
-/// not losing the tail. Every earlier upload (periodic tick and the
-/// pre-checkpoint `flush(UploadMode::Live)`) must use `UploadMode::Live`
-/// so a later pass can safely pick up the tail once the producer
-/// completes the line.
+/// the agent exits. It consumes a trailing fragment as-is only when the
+/// fragment fits inside this pass's bounded read. Every earlier upload
+/// (periodic tick and the pre-checkpoint `flush(UploadMode::Live)`) must use
+/// `UploadMode::Live` so a later pass can safely pick up the tail once the
+/// producer completes the line.
 async fn upload_telemetry(
     http: &HttpClient,
     masker: &SecretMasker,
@@ -366,7 +389,8 @@ impl Telemetry {
     ///
     /// Use [`UploadMode::Live`] for any flush while the agent is still
     /// running (the producer continues writing). Use [`UploadMode::Final`]
-    /// for the very last flush before exit, which consumes the EOF tail.
+    /// for the very last flush before exit, which consumes the EOF tail when
+    /// it fits in one bounded read.
     pub async fn flush(&self, mode: UploadMode) -> Result<(), AgentError> {
         let (reply_tx, reply_rx) = oneshot::channel();
         self.tx
@@ -493,7 +517,7 @@ mod tests {
     }
 
     #[test]
-    fn read_file_delta_from_middle_of_line_skips_without_uploading_suffix() {
+    fn read_file_delta_from_middle_of_line_skips_suffix_then_resumes() {
         let dir = tempfile::tempdir().unwrap();
         let file = dir.path().join("log.txt");
         let pos = dir.path().join("log.pos");
@@ -505,8 +529,8 @@ mod tests {
             pos.to_str().unwrap(),
             UploadMode::Live,
         );
-        assert!(delta.content.is_empty());
-        assert_eq!(delta.new_pos, 12);
+        assert_eq!(delta.content, "next\n");
+        assert_eq!(delta.new_pos, 17);
         assert!(delta.made_progress);
     }
 
@@ -830,7 +854,7 @@ mod tests {
     }
 
     #[test]
-    fn read_file_delta_mid_oversized_line_skips_to_first_newline() {
+    fn read_file_delta_mid_oversized_line_skips_suffix_then_resumes() {
         let dir = tempfile::tempdir().unwrap();
         let file = dir.path().join("log.txt");
         let pos = dir.path().join("log.pos");
@@ -843,24 +867,12 @@ mod tests {
             pos.to_str().unwrap(),
             UploadMode::Live,
         );
-        assert!(delta.content.is_empty());
+        assert_eq!(delta.content, "next\n");
         assert_eq!(
             delta.new_pos,
-            (TELEMETRY_DELTA_READ_LIMIT + "tail\n".len()) as u64
-        );
-        assert!(delta.made_progress);
-
-        fs::write(&pos, delta.new_pos.to_string()).unwrap();
-        let (content2, new_pos2) = read_file_delta_parts(
-            file.to_str().unwrap(),
-            pos.to_str().unwrap(),
-            UploadMode::Live,
-        );
-        assert_eq!(content2, "next\n");
-        assert_eq!(
-            new_pos2,
             (TELEMETRY_DELTA_READ_LIMIT + "tail\nnext\n".len()) as u64,
         );
+        assert!(delta.made_progress);
     }
 
     #[test]
@@ -877,6 +889,25 @@ mod tests {
         );
         assert!(delta.entries.is_empty());
         assert_eq!(delta.new_pos, TELEMETRY_DELTA_READ_LIMIT as u64);
+        assert!(delta.made_progress);
+    }
+
+    #[test]
+    fn read_file_delta_final_from_middle_of_line_resumes_and_consumes_tail() {
+        let dir = tempfile::tempdir().unwrap();
+        let file = dir.path().join("log.txt");
+        let pos = dir.path().join("log.pos");
+        let content = "old suffix\nnext\ntail";
+        fs::write(&file, content).unwrap();
+        fs::write(&pos, "4").unwrap();
+
+        let delta = read_file_delta(
+            file.to_str().unwrap(),
+            pos.to_str().unwrap(),
+            UploadMode::Final,
+        );
+        assert_eq!(delta.content, "next\ntail");
+        assert_eq!(delta.new_pos, content.len() as u64);
         assert!(delta.made_progress);
     }
 

--- a/crates/guest-agent/src/telemetry.rs
+++ b/crates/guest-agent/src/telemetry.rs
@@ -31,7 +31,7 @@ const LOG_TAG: &str = "sandbox:guest-agent";
 /// time during cleanup, so a small bounded queue is plenty.
 const COMMAND_CHANNEL_CAPACITY: usize = 8;
 
-/// Maximum bytes read from a single telemetry source in one upload pass.
+/// Maximum bytes held for a single line-aligned telemetry read.
 const TELEMETRY_DELTA_READ_LIMIT: usize = 256 * 1024;
 
 /// Marker uploaded when a single system-log line is too large to send safely.
@@ -150,6 +150,21 @@ fn read_from_line_boundary(
     }
 }
 
+fn read_bounded_at(file: &mut std::fs::File, file_len: u64, pos: u64) -> Option<(Vec<u8>, u64)> {
+    let unread_len = file_len.checked_sub(pos)?;
+    let to_read = unread_len.min(TELEMETRY_DELTA_READ_LIMIT as u64) as usize;
+    let mut buf = vec![0u8; to_read];
+
+    if file.seek(SeekFrom::Start(pos)).is_err() {
+        return None;
+    }
+    if file.read_exact(&mut buf).is_err() {
+        return None;
+    }
+
+    Some((buf, unread_len))
+}
+
 /// Read new bytes from `file_path` starting at the position stored in `pos_path`.
 /// Returns the new content, updated position, and whether the position advanced.
 ///
@@ -197,37 +212,53 @@ fn read_file_delta_with_behavior(
         return TextDelta::empty(last_pos);
     };
 
-    if file.seek(SeekFrom::Start(last_pos)).is_err() {
+    let Some((buf, unread_len)) = read_bounded_at(&mut file, file_len, last_pos) else {
         return TextDelta::empty(last_pos);
-    }
-
-    let unread_len = file_len - last_pos;
-    let to_read = unread_len.min(TELEMETRY_DELTA_READ_LIMIT as u64) as usize;
-    let mut buf = vec![0u8; to_read];
-    if file.read_exact(&mut buf).is_err() {
-        return TextDelta::empty(last_pos);
-    }
+    };
 
     if !at_line_boundary {
         let Some(idx) = buf.iter().position(|&b| b == b'\n') else {
-            return TextDelta::progressed(String::new(), last_pos + to_read as u64);
+            return TextDelta::progressed(String::new(), last_pos + buf.len() as u64);
         };
 
         let consumed = idx + 1;
         let boundary_pos = last_pos + consumed as u64;
-        let Some(remaining) = buf.get(consumed..) else {
-            return TextDelta::progressed(String::new(), boundary_pos);
-        };
+        let remaining_unread_len = file_len - boundary_pos;
+        let remaining_len = buf.len().saturating_sub(consumed);
 
-        if remaining.is_empty() {
+        if remaining_unread_len == 0 {
             return TextDelta::progressed(String::new(), boundary_pos);
         }
 
-        let remaining_unread_len = unread_len.saturating_sub(consumed as u64);
+        if remaining_unread_len <= remaining_len as u64 {
+            let Some(remaining) = buf.get(consumed..) else {
+                return TextDelta::progressed(String::new(), boundary_pos);
+            };
+
+            let delta = read_from_line_boundary(
+                remaining,
+                boundary_pos,
+                remaining_unread_len,
+                mode,
+                oversized_line_behavior,
+            );
+            return if delta.made_progress {
+                delta
+            } else {
+                TextDelta::progressed(String::new(), boundary_pos)
+            };
+        }
+
+        drop(buf);
+        let Some((boundary_buf, boundary_unread_len)) =
+            read_bounded_at(&mut file, file_len, boundary_pos)
+        else {
+            return TextDelta::progressed(String::new(), boundary_pos);
+        };
         let delta = read_from_line_boundary(
-            remaining,
+            &boundary_buf,
             boundary_pos,
-            remaining_unread_len,
+            boundary_unread_len,
             mode,
             oversized_line_behavior,
         );
@@ -907,6 +938,27 @@ mod tests {
             UploadMode::Final,
         );
         assert_eq!(delta.content, "next\ntail");
+        assert_eq!(delta.new_pos, content.len() as u64);
+        assert!(delta.made_progress);
+    }
+
+    #[test]
+    fn read_file_delta_final_resync_reads_full_bounded_tail_window() {
+        let dir = tempfile::tempdir().unwrap();
+        let file = dir.path().join("log.txt");
+        let pos = dir.path().join("log.pos");
+        let skipped_suffix = "x".repeat(TELEMETRY_DELTA_READ_LIMIT / 2);
+        let tail = "t".repeat(TELEMETRY_DELTA_READ_LIMIT - 8);
+        let content = format!("{skipped_suffix}\n{tail}");
+        fs::write(&file, &content).unwrap();
+        fs::write(&pos, "1").unwrap();
+
+        let delta = read_file_delta(
+            file.to_str().unwrap(),
+            pos.to_str().unwrap(),
+            UploadMode::Final,
+        );
+        assert_eq!(delta.content, tail);
         assert_eq!(delta.new_pos, content.len() as u64);
         assert!(delta.made_progress);
     }

--- a/crates/guest-agent/src/telemetry.rs
+++ b/crates/guest-agent/src/telemetry.rs
@@ -31,6 +31,13 @@ const LOG_TAG: &str = "sandbox:guest-agent";
 /// time during cleanup, so a small bounded queue is plenty.
 const COMMAND_CHANNEL_CAPACITY: usize = 8;
 
+/// Maximum bytes read from a single telemetry source in one upload pass.
+const TELEMETRY_DELTA_READ_LIMIT: usize = 256 * 1024;
+
+/// Marker uploaded when a single system-log line is too large to send safely.
+const OVERSIZED_SYSTEM_LOG_LINE_MARKER: &str =
+    "[vm0 telemetry omitted oversized system log line]\n";
+
 /// Whether an upload pass should defer a trailing fragment to the next
 /// pass, or consume it as-is because no next pass is coming.
 ///
@@ -47,8 +54,61 @@ pub enum UploadMode {
     Final,
 }
 
+struct TextDelta {
+    content: String,
+    new_pos: u64,
+    made_progress: bool,
+}
+
+impl TextDelta {
+    fn empty(pos: u64) -> Self {
+        Self {
+            content: String::new(),
+            new_pos: pos,
+            made_progress: false,
+        }
+    }
+
+    fn progressed(content: String, new_pos: u64) -> Self {
+        Self {
+            content,
+            new_pos,
+            made_progress: true,
+        }
+    }
+}
+
+struct JsonlDelta {
+    entries: Vec<Value>,
+    new_pos: u64,
+    made_progress: bool,
+}
+
+#[derive(Clone, Copy)]
+enum OversizedLineBehavior {
+    EmitSystemLogMarker,
+    Drop,
+}
+
+fn is_line_boundary(file: &mut std::fs::File, pos: u64) -> Option<bool> {
+    if pos == 0 {
+        return Some(true);
+    }
+
+    if file.seek(SeekFrom::Start(pos - 1)).is_err() {
+        return None;
+    }
+
+    let mut previous = [0u8; 1];
+    if file.read_exact(&mut previous).is_err() {
+        return None;
+    }
+
+    Some(previous[0] == b'\n')
+}
+
 /// Read new bytes from `file_path` starting at the position stored in `pos_path`.
-/// Returns the new content and the updated position.
+/// Returns the new content, updated position, and whether the position advanced.
 ///
 /// In `Live` mode, the read is aligned to the last newline: any trailing
 /// bytes after the last `\n` are treated as an in-progress write by the
@@ -60,8 +120,22 @@ pub enum UploadMode {
 ///
 /// In `Final` mode, the tail is consumed as-is — there will be no subsequent
 /// pass to pick it up. Any trailing fragment without a newline is uploaded
-/// verbatim.
-fn read_file_delta(file_path: &str, pos_path: &str, mode: UploadMode) -> (String, u64) {
+/// verbatim when it fits within the bounded read window.
+fn read_file_delta(file_path: &str, pos_path: &str, mode: UploadMode) -> TextDelta {
+    read_file_delta_with_behavior(
+        file_path,
+        pos_path,
+        mode,
+        OversizedLineBehavior::EmitSystemLogMarker,
+    )
+}
+
+fn read_file_delta_with_behavior(
+    file_path: &str,
+    pos_path: &str,
+    mode: UploadMode,
+    oversized_line_behavior: OversizedLineBehavior,
+) -> TextDelta {
     let last_pos: u64 = std::fs::read_to_string(pos_path)
         .ok()
         .and_then(|s| s.trim().parse().ok())
@@ -69,26 +143,44 @@ fn read_file_delta(file_path: &str, pos_path: &str, mode: UploadMode) -> (String
 
     let mut file = match std::fs::File::open(file_path) {
         Ok(f) => f,
-        Err(_) => return (String::new(), last_pos),
+        Err(_) => return TextDelta::empty(last_pos),
     };
 
     let file_len = file.metadata().map(|m| m.len()).unwrap_or(0);
     if file_len <= last_pos {
-        return (String::new(), last_pos);
+        return TextDelta::empty(last_pos);
     }
+
+    let Some(at_line_boundary) = is_line_boundary(&mut file, last_pos) else {
+        return TextDelta::empty(last_pos);
+    };
 
     if file.seek(SeekFrom::Start(last_pos)).is_err() {
-        return (String::new(), last_pos);
+        return TextDelta::empty(last_pos);
     }
 
-    let to_read = (file_len - last_pos) as usize;
+    let unread_len = file_len - last_pos;
+    let to_read = unread_len.min(TELEMETRY_DELTA_READ_LIMIT as u64) as usize;
     let mut buf = vec![0u8; to_read];
     if file.read_exact(&mut buf).is_err() {
-        return (String::new(), last_pos);
+        return TextDelta::empty(last_pos);
     }
 
-    if mode == UploadMode::Final {
-        return (String::from_utf8_lossy(&buf).into_owned(), file_len);
+    if mode == UploadMode::Final
+        && at_line_boundary
+        && unread_len <= TELEMETRY_DELTA_READ_LIMIT as u64
+    {
+        return TextDelta::progressed(String::from_utf8_lossy(&buf).into_owned(), file_len);
+    }
+
+    if !at_line_boundary {
+        return match buf.iter().position(|&b| b == b'\n') {
+            Some(idx) => {
+                let consumed = idx + 1;
+                TextDelta::progressed(String::new(), last_pos + consumed as u64)
+            }
+            None => TextDelta::progressed(String::new(), last_pos + to_read as u64),
+        };
     }
 
     match buf.iter().rposition(|&b| b == b'\n') {
@@ -101,26 +193,52 @@ fn read_file_delta(file_path: &str, pos_path: &str, mode: UploadMode) -> (String
             // satisfy `clippy::indexing_slicing = "deny"` without an
             // explicit suppression or `expect`.
             let Some(slice) = buf.get(..consumed) else {
-                return (String::new(), last_pos);
+                return TextDelta::empty(last_pos);
             };
-            (String::from_utf8_lossy(slice).into_owned(), new_pos)
+            TextDelta::progressed(String::from_utf8_lossy(slice).into_owned(), new_pos)
         }
-        None => (String::new(), last_pos),
+        None if at_line_boundary && unread_len <= TELEMETRY_DELTA_READ_LIMIT as u64 => {
+            TextDelta::empty(last_pos)
+        }
+        None => {
+            let new_pos = last_pos + to_read as u64;
+            let content = if at_line_boundary {
+                match oversized_line_behavior {
+                    OversizedLineBehavior::EmitSystemLogMarker => {
+                        OVERSIZED_SYSTEM_LOG_LINE_MARKER.to_string()
+                    }
+                    OversizedLineBehavior::Drop => String::new(),
+                }
+            } else {
+                String::new()
+            };
+            TextDelta::progressed(content, new_pos)
+        }
     }
 }
 
 /// Read new JSONL entries from a file, skipping invalid lines.
-fn read_jsonl_delta(file_path: &str, pos_path: &str, mode: UploadMode) -> (Vec<Value>, u64) {
-    let (content, new_pos) = read_file_delta(file_path, pos_path, mode);
-    if content.is_empty() {
-        return (Vec::new(), new_pos);
+fn read_jsonl_delta(file_path: &str, pos_path: &str, mode: UploadMode) -> JsonlDelta {
+    let delta =
+        read_file_delta_with_behavior(file_path, pos_path, mode, OversizedLineBehavior::Drop);
+    if delta.content.is_empty() {
+        return JsonlDelta {
+            entries: Vec::new(),
+            new_pos: delta.new_pos,
+            made_progress: delta.made_progress,
+        };
     }
-    let entries: Vec<Value> = content
+    let entries: Vec<Value> = delta
+        .content
         .lines()
         .filter(|l| !l.is_empty())
         .filter_map(|l| serde_json::from_str(l).ok())
         .collect();
-    (entries, new_pos)
+    JsonlDelta {
+        entries,
+        new_pos: delta.new_pos,
+        made_progress: delta.made_progress,
+    }
 }
 
 /// Persist the current read position for a file.
@@ -143,39 +261,52 @@ async fn upload_telemetry(
     mode: UploadMode,
 ) -> Result<(), AgentError> {
     // Read deltas
-    let (system_log, log_pos) = read_file_delta(
+    let system_log = read_file_delta(
         paths::system_log_file(),
         paths::telemetry_system_log_pos_file(),
         mode,
     );
-    let (metrics, metrics_pos) = read_jsonl_delta(
+    let metrics = read_jsonl_delta(
         paths::metrics_log_file(),
         paths::telemetry_metrics_pos_file(),
         mode,
     );
-    let (sandbox_ops, sandbox_ops_pos) = read_jsonl_delta(
+    let sandbox_ops = read_jsonl_delta(
         paths::sandbox_ops_file(),
         paths::telemetry_sandbox_ops_pos_file(),
         mode,
     );
+    let log_pos = system_log.new_pos;
+    let metrics_pos = metrics.new_pos;
+    let sandbox_ops_pos = sandbox_ops.new_pos;
+    let made_progress =
+        system_log.made_progress || metrics.made_progress || sandbox_ops.made_progress;
 
     // Nothing new
-    if system_log.is_empty() && metrics.is_empty() && sandbox_ops.is_empty() {
+    if system_log.content.is_empty() && metrics.entries.is_empty() && sandbox_ops.entries.is_empty()
+    {
+        if made_progress {
+            save_position(paths::telemetry_system_log_pos_file(), log_pos);
+            save_position(paths::telemetry_metrics_pos_file(), metrics_pos);
+            save_position(paths::telemetry_sandbox_ops_pos_file(), sandbox_ops_pos);
+        }
         return Ok(());
     }
 
     // Mask secrets in text content
-    let masked_log = if system_log.is_empty() {
+    let masked_log = if system_log.content.is_empty() {
         String::new()
     } else {
-        masker.mask_owned_string(system_log)
+        masker.mask_owned_string(system_log.content)
     };
+    let metrics_entries = metrics.entries;
+    let sandbox_ops_entries = sandbox_ops.entries;
 
     let payload = json!({
         "runId": env::run_id(),
         "systemLog": masked_log,
-        "metrics": metrics,
-        "sandboxOperations": sandbox_ops,
+        "metrics": metrics_entries,
+        "sandboxOperations": sandbox_ops_entries,
     });
 
     // Use 1 attempt for telemetry (non-critical, best-effort)
@@ -313,6 +444,20 @@ mod tests {
     use super::*;
     use std::fs;
 
+    fn read_file_delta_parts(file_path: &str, pos_path: &str, mode: UploadMode) -> (String, u64) {
+        let delta = read_file_delta(file_path, pos_path, mode);
+        (delta.content, delta.new_pos)
+    }
+
+    fn read_jsonl_delta_parts(
+        file_path: &str,
+        pos_path: &str,
+        mode: UploadMode,
+    ) -> (Vec<Value>, u64) {
+        let delta = read_jsonl_delta(file_path, pos_path, mode);
+        (delta.entries, delta.new_pos)
+    }
+
     #[test]
     fn read_file_delta_from_start() {
         let dir = tempfile::tempdir().unwrap();
@@ -320,7 +465,7 @@ mod tests {
         let pos = dir.path().join("log.pos");
         fs::write(&file, "hello world\n").unwrap();
 
-        let (content, new_pos) = read_file_delta(
+        let (content, new_pos) = read_file_delta_parts(
             file.to_str().unwrap(),
             pos.to_str().unwrap(),
             UploadMode::Live,
@@ -334,17 +479,35 @@ mod tests {
         let dir = tempfile::tempdir().unwrap();
         let file = dir.path().join("log.txt");
         let pos = dir.path().join("log.pos");
-        fs::write(&file, "hello world\n").unwrap();
-        // Simulate having already read 6 bytes
+        fs::write(&file, "hello\nworld\n").unwrap();
+        // Simulate having already consumed the first complete line.
         fs::write(&pos, "6").unwrap();
 
-        let (content, new_pos) = read_file_delta(
+        let (content, new_pos) = read_file_delta_parts(
             file.to_str().unwrap(),
             pos.to_str().unwrap(),
             UploadMode::Live,
         );
         assert_eq!(content, "world\n");
         assert_eq!(new_pos, 12);
+    }
+
+    #[test]
+    fn read_file_delta_from_middle_of_line_skips_without_uploading_suffix() {
+        let dir = tempfile::tempdir().unwrap();
+        let file = dir.path().join("log.txt");
+        let pos = dir.path().join("log.pos");
+        fs::write(&file, "hello world\nnext\n").unwrap();
+        fs::write(&pos, "6").unwrap();
+
+        let delta = read_file_delta(
+            file.to_str().unwrap(),
+            pos.to_str().unwrap(),
+            UploadMode::Live,
+        );
+        assert!(delta.content.is_empty());
+        assert_eq!(delta.new_pos, 12);
+        assert!(delta.made_progress);
     }
 
     #[test]
@@ -355,7 +518,7 @@ mod tests {
         fs::write(&file, "done").unwrap();
         fs::write(&pos, "4").unwrap();
 
-        let (content, new_pos) = read_file_delta(
+        let (content, new_pos) = read_file_delta_parts(
             file.to_str().unwrap(),
             pos.to_str().unwrap(),
             UploadMode::Live,
@@ -370,7 +533,7 @@ mod tests {
         let file = dir.path().join("missing.txt");
         let pos = dir.path().join("missing.pos");
 
-        let (content, new_pos) = read_file_delta(
+        let (content, new_pos) = read_file_delta_parts(
             file.to_str().unwrap(),
             pos.to_str().unwrap(),
             UploadMode::Live,
@@ -386,7 +549,7 @@ mod tests {
         let pos = dir.path().join("data.pos");
         fs::write(&file, "{\"a\":1}\n{\"b\":2}\ninvalid\n").unwrap();
 
-        let (entries, new_pos) = read_jsonl_delta(
+        let (entries, new_pos) = read_jsonl_delta_parts(
             file.to_str().unwrap(),
             pos.to_str().unwrap(),
             UploadMode::Live,
@@ -415,7 +578,7 @@ mod tests {
         fs::write(&file, "short").unwrap();
         fs::write(&pos, "100").unwrap();
 
-        let (content, new_pos) = read_file_delta(
+        let (content, new_pos) = read_file_delta_parts(
             file.to_str().unwrap(),
             pos.to_str().unwrap(),
             UploadMode::Live,
@@ -433,7 +596,7 @@ mod tests {
         fs::write(&file, "data\n").unwrap();
         fs::write(&pos, "notanumber").unwrap();
 
-        let (content, new_pos) = read_file_delta(
+        let (content, new_pos) = read_file_delta_parts(
             file.to_str().unwrap(),
             pos.to_str().unwrap(),
             UploadMode::Live,
@@ -449,7 +612,7 @@ mod tests {
         let pos = dir.path().join("empty.pos");
         fs::write(&file, "").unwrap();
 
-        let (entries, new_pos) = read_jsonl_delta(
+        let (entries, new_pos) = read_jsonl_delta_parts(
             file.to_str().unwrap(),
             pos.to_str().unwrap(),
             UploadMode::Live,
@@ -465,7 +628,7 @@ mod tests {
         let pos = dir.path().join("bad.pos");
         fs::write(&file, "bad1\nbad2\nbad3\n").unwrap();
 
-        let (entries, new_pos) = read_jsonl_delta(
+        let (entries, new_pos) = read_jsonl_delta_parts(
             file.to_str().unwrap(),
             pos.to_str().unwrap(),
             UploadMode::Live,
@@ -485,7 +648,7 @@ mod tests {
         fs::write(&file, "line1\nline2\npartial").unwrap();
 
         // First pass: read up to the last newline, leave "partial" behind.
-        let (content, new_pos) = read_file_delta(
+        let (content, new_pos) = read_file_delta_parts(
             file.to_str().unwrap(),
             pos.to_str().unwrap(),
             UploadMode::Live,
@@ -498,7 +661,7 @@ mod tests {
         fs::write(&pos, "12").unwrap();
 
         // Second pass: now "partial done\n" is complete.
-        let (content2, new_pos2) = read_file_delta(
+        let (content2, new_pos2) = read_file_delta_parts(
             file.to_str().unwrap(),
             pos.to_str().unwrap(),
             UploadMode::Live,
@@ -516,7 +679,7 @@ mod tests {
         let pos = dir.path().join("log.pos");
         fs::write(&file, "line1\npartial").unwrap();
 
-        let (content, new_pos) = read_file_delta(
+        let (content, new_pos) = read_file_delta_parts(
             file.to_str().unwrap(),
             pos.to_str().unwrap(),
             UploadMode::Final,
@@ -541,7 +704,7 @@ mod tests {
         fs::write(&file, &partial).unwrap();
 
         // First pass: stops at the newline, leaves the orphan 0xE4 behind.
-        let (content, new_pos) = read_file_delta(
+        let (content, new_pos) = read_file_delta_parts(
             file.to_str().unwrap(),
             pos.to_str().unwrap(),
             UploadMode::Live,
@@ -557,7 +720,7 @@ mod tests {
         fs::write(&file, &complete).unwrap();
 
         // Second pass: reads the complete multibyte character.
-        let (content2, new_pos2) = read_file_delta(
+        let (content2, new_pos2) = read_file_delta_parts(
             file.to_str().unwrap(),
             pos.to_str().unwrap(),
             UploadMode::Live,
@@ -579,7 +742,7 @@ mod tests {
         fs::write(&file, "{\"a\":1}\n{\"b\":2").unwrap();
 
         // First pass: only {"a":1} is complete.
-        let (entries, new_pos) = read_jsonl_delta(
+        let (entries, new_pos) = read_jsonl_delta_parts(
             file.to_str().unwrap(),
             pos.to_str().unwrap(),
             UploadMode::Live,
@@ -591,7 +754,7 @@ mod tests {
 
         // Producer completes the record.
         fs::write(&file, "{\"a\":1}\n{\"b\":2}\n").unwrap();
-        let (entries2, new_pos2) = read_jsonl_delta(
+        let (entries2, new_pos2) = read_jsonl_delta_parts(
             file.to_str().unwrap(),
             pos.to_str().unwrap(),
             UploadMode::Live,
@@ -611,7 +774,7 @@ mod tests {
         let pos = dir.path().join("log.pos");
         fs::write(&file, "partial").unwrap();
 
-        let (content, new_pos) = read_file_delta(
+        let (content, new_pos) = read_file_delta_parts(
             file.to_str().unwrap(),
             pos.to_str().unwrap(),
             UploadMode::Live,
@@ -621,13 +784,100 @@ mod tests {
 
         // Producer completes the line — the next pass picks up everything.
         fs::write(&file, "partial done\n").unwrap();
-        let (content2, new_pos2) = read_file_delta(
+        let (content2, new_pos2) = read_file_delta_parts(
             file.to_str().unwrap(),
             pos.to_str().unwrap(),
             UploadMode::Live,
         );
         assert_eq!(content2, "partial done\n");
         assert_eq!(new_pos2, 13);
+    }
+
+    #[test]
+    fn read_file_delta_large_unread_delta_reads_bounded_complete_prefix() {
+        let dir = tempfile::tempdir().unwrap();
+        let file = dir.path().join("log.txt");
+        let pos = dir.path().join("log.pos");
+        let line = format!("{}\n", "x".repeat(1023));
+        let content = line.repeat((TELEMETRY_DELTA_READ_LIMIT / line.len()) + 2);
+        fs::write(&file, content).unwrap();
+
+        let delta = read_file_delta(
+            file.to_str().unwrap(),
+            pos.to_str().unwrap(),
+            UploadMode::Live,
+        );
+        assert_eq!(delta.content.len(), TELEMETRY_DELTA_READ_LIMIT);
+        assert_eq!(delta.new_pos, TELEMETRY_DELTA_READ_LIMIT as u64);
+        assert!(delta.made_progress);
+    }
+
+    #[test]
+    fn read_file_delta_oversized_no_newline_system_log_emits_marker() {
+        let dir = tempfile::tempdir().unwrap();
+        let file = dir.path().join("log.txt");
+        let pos = dir.path().join("log.pos");
+        fs::write(&file, "x".repeat(TELEMETRY_DELTA_READ_LIMIT + 1)).unwrap();
+
+        let delta = read_file_delta(
+            file.to_str().unwrap(),
+            pos.to_str().unwrap(),
+            UploadMode::Live,
+        );
+        assert_eq!(delta.content, OVERSIZED_SYSTEM_LOG_LINE_MARKER);
+        assert_eq!(delta.new_pos, TELEMETRY_DELTA_READ_LIMIT as u64);
+        assert!(delta.made_progress);
+    }
+
+    #[test]
+    fn read_file_delta_mid_oversized_line_skips_to_first_newline() {
+        let dir = tempfile::tempdir().unwrap();
+        let file = dir.path().join("log.txt");
+        let pos = dir.path().join("log.pos");
+        let content = format!("{}tail\nnext\n", "x".repeat(TELEMETRY_DELTA_READ_LIMIT));
+        fs::write(&file, content).unwrap();
+        fs::write(&pos, TELEMETRY_DELTA_READ_LIMIT.to_string()).unwrap();
+
+        let delta = read_file_delta(
+            file.to_str().unwrap(),
+            pos.to_str().unwrap(),
+            UploadMode::Live,
+        );
+        assert!(delta.content.is_empty());
+        assert_eq!(
+            delta.new_pos,
+            (TELEMETRY_DELTA_READ_LIMIT + "tail\n".len()) as u64
+        );
+        assert!(delta.made_progress);
+
+        fs::write(&pos, delta.new_pos.to_string()).unwrap();
+        let (content2, new_pos2) = read_file_delta_parts(
+            file.to_str().unwrap(),
+            pos.to_str().unwrap(),
+            UploadMode::Live,
+        );
+        assert_eq!(content2, "next\n");
+        assert_eq!(
+            new_pos2,
+            (TELEMETRY_DELTA_READ_LIMIT + "tail\nnext\n".len()) as u64,
+        );
+    }
+
+    #[test]
+    fn read_jsonl_delta_oversized_invalid_line_advances_without_entries() {
+        let dir = tempfile::tempdir().unwrap();
+        let file = dir.path().join("data.jsonl");
+        let pos = dir.path().join("data.pos");
+        fs::write(&file, "x".repeat(TELEMETRY_DELTA_READ_LIMIT + 1)).unwrap();
+
+        let delta = read_jsonl_delta(
+            file.to_str().unwrap(),
+            pos.to_str().unwrap(),
+            UploadMode::Live,
+        );
+        assert!(delta.entries.is_empty());
+        assert_eq!(delta.new_pos, TELEMETRY_DELTA_READ_LIMIT as u64);
+        assert!(delta.made_progress);
     }
 
     /// Final pass must consume the whole buffer even when the file contains
@@ -639,7 +889,7 @@ mod tests {
         let pos = dir.path().join("log.pos");
         fs::write(&file, "no_newline").unwrap();
 
-        let (content, new_pos) = read_file_delta(
+        let (content, new_pos) = read_file_delta_parts(
             file.to_str().unwrap(),
             pos.to_str().unwrap(),
             UploadMode::Final,
@@ -663,7 +913,7 @@ mod tests {
         fs::write(&file, &partial).unwrap();
 
         // First pass stops at \n, defers the orphan bytes.
-        let (content, new_pos) = read_file_delta(
+        let (content, new_pos) = read_file_delta_parts(
             file.to_str().unwrap(),
             pos.to_str().unwrap(),
             UploadMode::Live,
@@ -678,7 +928,7 @@ mod tests {
         complete.extend_from_slice(b"\n");
         fs::write(&file, &complete).unwrap();
 
-        let (content2, new_pos2) = read_file_delta(
+        let (content2, new_pos2) = read_file_delta_parts(
             file.to_str().unwrap(),
             pos.to_str().unwrap(),
             UploadMode::Live,
@@ -705,7 +955,7 @@ mod tests {
         torn.push(0xE4);
         fs::write(&file, &torn).unwrap();
 
-        let (content, new_pos) = read_file_delta(
+        let (content, new_pos) = read_file_delta_parts(
             file.to_str().unwrap(),
             pos.to_str().unwrap(),
             UploadMode::Final,
@@ -731,7 +981,7 @@ mod tests {
         fs::write(&file, &partial).unwrap();
 
         // Pre-checkpoint Live flush: newline-aligned, defers the orphan byte.
-        let (content, new_pos) = read_file_delta(
+        let (content, new_pos) = read_file_delta_parts(
             file.to_str().unwrap(),
             pos.to_str().unwrap(),
             UploadMode::Live,
@@ -747,7 +997,7 @@ mod tests {
         fs::write(&file, &complete).unwrap();
 
         // Catch-up final pass: consumes the rest including the no-newline tail.
-        let (content2, new_pos2) = read_file_delta(
+        let (content2, new_pos2) = read_file_delta_parts(
             file.to_str().unwrap(),
             pos.to_str().unwrap(),
             UploadMode::Final,

--- a/crates/guest-agent/tests/integration/telemetry.rs
+++ b/crates/guest-agent/tests/integration/telemetry.rs
@@ -3,6 +3,26 @@ use guest_agent::masker::SecretMasker;
 use httpmock::prelude::*;
 use std::time::Duration;
 
+const TELEMETRY_DELTA_READ_LIMIT: usize = 256 * 1024;
+const OVERSIZED_SYSTEM_LOG_LINE_MARKER_FRAGMENT: &str =
+    "vm0 telemetry omitted oversized system log line";
+
+fn remove_telemetry_files() {
+    let _ = std::fs::remove_file(guest_agent::paths::system_log_file());
+    let _ = std::fs::remove_file(guest_agent::paths::metrics_log_file());
+    let _ = std::fs::remove_file(guest_agent::paths::sandbox_ops_file());
+    let _ = std::fs::remove_file(guest_agent::paths::telemetry_system_log_pos_file());
+    let _ = std::fs::remove_file(guest_agent::paths::telemetry_metrics_pos_file());
+    let _ = std::fs::remove_file(guest_agent::paths::telemetry_sandbox_ops_pos_file());
+}
+
+fn ensure_parent_dir(path: &str) {
+    let Some(parent) = std::path::Path::new(path).parent() else {
+        return;
+    };
+    let _ = std::fs::create_dir_all(parent);
+}
+
 // =========================================================================
 // Telemetry flush delta semantics
 //
@@ -248,4 +268,101 @@ async fn flush_propagates_error_then_loop_recovers() {
     success_mock.delete_async().await;
     let _ = std::fs::remove_file(ops_file);
     let _ = std::fs::remove_file(pos_file);
+}
+
+#[tokio::test]
+async fn skip_only_metrics_progress_saves_position_without_posting_empty_payload() {
+    let _guard = TEST_MUTEX.lock().unwrap();
+    let server = &*MOCK_SERVER;
+    remove_telemetry_files();
+
+    let metrics_file = guest_agent::paths::metrics_log_file();
+    let metrics_pos_file = guest_agent::paths::telemetry_metrics_pos_file();
+    ensure_parent_dir(metrics_file);
+    assert!(
+        std::fs::write(metrics_file, "x".repeat(TELEMETRY_DELTA_READ_LIMIT + 1)).is_ok(),
+        "oversized metrics log should be written",
+    );
+
+    let upload_mock = server.mock(|when, then| {
+        when.method(POST).path("/api/webhooks/agent/telemetry");
+        then.status(200);
+    });
+
+    let masker = std::sync::Arc::new(SecretMasker::from_raw(""));
+    let telemetry = guest_agent::telemetry::Telemetry::spawn(masker, http_client!());
+
+    telemetry
+        .flush(guest_agent::telemetry::UploadMode::Live)
+        .await
+        .expect("skip-only flush should succeed without HTTP");
+    telemetry.shutdown().await;
+
+    upload_mock.assert_calls_async(0).await;
+    let pos_text = std::fs::read_to_string(metrics_pos_file)
+        .expect("metrics telemetry position should be written");
+    let pos: u64 = pos_text
+        .trim()
+        .parse()
+        .expect("metrics telemetry position should be numeric");
+    assert_eq!(pos, TELEMETRY_DELTA_READ_LIMIT as u64);
+
+    upload_mock.delete_async().await;
+    remove_telemetry_files();
+}
+
+#[tokio::test]
+async fn oversized_system_log_uploads_marker_without_raw_line_fragment() {
+    let _guard = TEST_MUTEX.lock().unwrap();
+    let server = &*MOCK_SERVER;
+    remove_telemetry_files();
+
+    let system_log = guest_agent::paths::system_log_file();
+    let system_log_pos_file = guest_agent::paths::telemetry_system_log_pos_file();
+    let raw_token = "raw-secret-token";
+    ensure_parent_dir(system_log);
+    assert!(
+        std::fs::write(
+            system_log,
+            raw_token.repeat((TELEMETRY_DELTA_READ_LIMIT / raw_token.len()) + 1),
+        )
+        .is_ok(),
+        "oversized system log should be written",
+    );
+
+    let raw_fragment_mock = server.mock(|when, then| {
+        when.method(POST)
+            .path("/api/webhooks/agent/telemetry")
+            .body_includes(raw_token);
+        then.status(500);
+    });
+    let marker_mock = server.mock(|when, then| {
+        when.method(POST)
+            .path("/api/webhooks/agent/telemetry")
+            .body_includes(OVERSIZED_SYSTEM_LOG_LINE_MARKER_FRAGMENT);
+        then.status(200);
+    });
+
+    let masker = std::sync::Arc::new(SecretMasker::from_raw(""));
+    let telemetry = guest_agent::telemetry::Telemetry::spawn(masker, http_client!());
+
+    telemetry
+        .flush(guest_agent::telemetry::UploadMode::Live)
+        .await
+        .expect("oversized system log marker upload should succeed");
+    telemetry.shutdown().await;
+
+    raw_fragment_mock.assert_calls_async(0).await;
+    marker_mock.assert_calls_async(1).await;
+    let pos_text = std::fs::read_to_string(system_log_pos_file)
+        .expect("system log telemetry position should be written");
+    let pos: u64 = pos_text
+        .trim()
+        .parse()
+        .expect("system log telemetry position should be numeric");
+    assert_eq!(pos, TELEMETRY_DELTA_READ_LIMIT as u64);
+
+    raw_fragment_mock.delete_async().await;
+    marker_mock.delete_async().await;
+    remove_telemetry_files();
 }


### PR DESCRIPTION
## Summary

- cap guest-agent telemetry delta reads per source before allocating buffers
- add progress-aware line-boundary handling so oversized no-newline lines cannot stall telemetry flushes
- emit a fixed omission marker for oversized system-log lines and skip oversized JSONL fragments without sending empty telemetry POSTs
- add unit and integration coverage for bounded reads, oversized-line skipping, and skip-only position persistence

Closes #16270

## Tests

- `cd crates && cargo test -p guest-agent telemetry`
- `cd crates && cargo test -p guest-agent --test integration telemetry`
- `cd crates && cargo clippy -p guest-agent --tests`
- `cd crates && cargo fmt -p guest-agent -- --check`
- `git diff --check`

Pre-commit also ran `cargo-fmt`, `cargo-clippy`, and `cargo-doc` through lefthook.
