### PR TITLE
chore: update Browserbase connector icon

### DIFF
--- a/turbo/apps/platform/src/views/zero-page/components/settings/icons/browserbase.svg
+++ b/turbo/apps/platform/src/views/zero-page/components/settings/icons/browserbase.svg
@@ -1,16 +1,6 @@
-<svg width="100" height="100" viewBox="0 0 100 100" fill="none" xmlns="http://www.w3.org/2000/svg">
-<g clipPath="url(#clip0_2240_1722)">
-<mask id="mask0_2240_1722" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="0" y="0" width="100" height="100">
-<path d="M100 0H0V100H100V0Z" fill="white"/>
-</mask>
-<g mask="url(#mask0_2240_1722)">
-<path d="M0 0H100V100H0V0Z" fill="#F03603"/>
-<path d="M36 72.2222V27.7778H51.2381C57.5873 27.7778 62.6667 32.8571 62.6667 39.2063V41.746C62.6667 44.6667 61.5873 47.3968 59.7461 49.3651C62.2858 51.4603 63.9366 54.6349 63.9366 58.254V60.7936C63.9366 67.1428 58.8572 72.2222 52.508 72.2222H36ZM42.3493 65.873H52.508C55.3651 65.873 57.5873 63.6508 57.5873 60.7936V58.254C57.5873 55.3968 55.3651 53.1746 52.508 53.1746H42.3493V65.873ZM42.3493 46.8254H51.2381C54.0953 46.8254 56.3175 44.6032 56.3175 41.746V39.2063C56.3175 36.3492 54.0953 34.127 51.2381 34.127H42.3493V46.8254Z" fill="white"/>
-</g>
-</g>
-<defs>
-<clipPath id="clip0_2240_1722">
-<rect width="100" height="100" fill="white"/>
-</clipPath>
-</defs>
+<svg width="200" height="200" viewBox="0 0 200 200" fill="none" xmlns="http://www.w3.org/2000/svg">
+  <rect x="30" y="36" width="134" height="124" fill="white" />
+  <path d="M111.168 116.901H83.168V109.901H111.168V116.901Z" fill="#FF4500" />
+  <path d="M111.168 86.208H83.168V79.208H111.168V86.208Z" fill="#FF4500" />
+  <path fill-rule="evenodd" clip-rule="evenodd" d="M200 200H0V0H200V200ZM55.4453 147.815H128.678L145.259 131.234V111.891L131.441 98.0723L142.495 87.0186V69.0557L125.914 52.4756H55.4453V147.815Z" fill="#FF4500" />
 </svg>


### PR DESCRIPTION
## Summary
- Replace the Browserbase connector icon with the current official favicon from https://www.browserbase.com/favicon.svg
- Keep the icon as a static square SVG and preserve Browserbase in the colorful connector icon list

Closes #16467

## Checks
- pnpm format
- pnpm lint
- pnpm check-types
- pnpm -F @vm0/app exec vitest run src/views/zero-page/__tests__/connector-icons.test.tsx