### PR TITLE
fix(runner): preserve systemctl service query errors

### DIFF
--- a/crates/runner/src/cmd/service.rs
+++ b/crates/runner/src/cmd/service.rs
@@ -1,5 +1,6 @@
+use std::collections::BTreeMap;
 use std::path::{Path, PathBuf};
-use std::process::ExitStatus;
+use std::process::{ExitStatus, Output};
 
 use crate::error::{ActiveJobsError, RunnerError, RunnerResult};
 use crate::ids::RunId;
@@ -324,27 +325,172 @@ fn write_unit_file(path: &Path, content: &str) -> RunnerResult<()> {
 /// Check whether a systemd unit is active (running or activating).
 pub(crate) async fn is_unit_active(name: &str) -> RunnerResult<bool> {
     let svc = format!("{name}.service");
-    let status = tokio::process::Command::new("systemctl")
-        .args(["is-active", "--quiet", &svc])
-        .status()
-        .await
-        .map_err(|e| RunnerError::Internal(format!("spawn systemctl is-active: {e}")))?;
-    Ok(status.success())
+    let properties = ["LoadState", "ActiveState"];
+    let output = run_systemctl_show(&svc, &properties).await?;
+    let values = match parse_systemctl_show_properties(&svc, &properties, &output.stdout) {
+        Ok(values) => values,
+        Err(_) if !output.status.success() => {
+            return Err(systemctl_show_status_error(
+                &svc,
+                &properties,
+                &output.status,
+                &output.stderr,
+            ));
+        }
+        Err(e) => return Err(e),
+    };
+    unit_active_from_systemctl_show(&svc, &properties, &output.status, &values, &output.stderr)
 }
 
 /// Get the main PID of a systemd unit.
 async fn get_service_pid(unit: &str) -> RunnerResult<Option<u32>> {
     let svc = format!("{unit}.service");
-    let output = tokio::process::Command::new("systemctl")
-        .args(["show", &svc, "--property=MainPID", "--value"])
-        .output()
-        .await
-        .map_err(|e| RunnerError::Internal(format!("spawn systemctl show: {e}")))?;
+    let properties = ["MainPID"];
+    let output = run_systemctl_show(&svc, &properties).await?;
+    if !output.status.success() {
+        return Err(systemctl_show_status_error(
+            &svc,
+            &properties,
+            &output.status,
+            &output.stderr,
+        ));
+    }
+    let values = parse_systemctl_show_properties(&svc, &properties, &output.stdout)?;
+    let pid_str = required_systemctl_property(&svc, &values, "MainPID")?;
+    parse_main_pid(&svc, pid_str)
+}
 
-    let pid_str = String::from_utf8_lossy(&output.stdout).trim().to_string();
-    match pid_str.parse::<u32>() {
-        Ok(0) | Err(_) => Ok(None),
-        Ok(pid) => Ok(Some(pid)),
+async fn run_systemctl_show(svc: &str, properties: &[&str]) -> RunnerResult<Output> {
+    let mut cmd = tokio::process::Command::new("systemctl");
+    cmd.args(["show", svc]);
+    for property in properties {
+        cmd.arg(format!("--property={property}"));
+    }
+    cmd.output()
+        .await
+        .map_err(|e| RunnerError::Internal(format!("spawn systemctl show: {e}")))
+}
+
+fn parse_systemctl_show_properties(
+    svc: &str,
+    properties: &[&str],
+    stdout: &[u8],
+) -> RunnerResult<BTreeMap<String, String>> {
+    let stdout = std::str::from_utf8(stdout).map_err(|e| {
+        RunnerError::Internal(format!(
+            "systemctl show {svc} returned non-UTF-8 output: {e}"
+        ))
+    })?;
+    let mut values = BTreeMap::new();
+    for line in stdout.lines().filter(|line| !line.is_empty()) {
+        let Some((property, value)) = line.split_once('=') else {
+            return Err(RunnerError::Internal(format!(
+                "malformed systemctl show output for {svc}: {:?}",
+                status_field_preview(line)
+            )));
+        };
+        if !properties.contains(&property) {
+            return Err(RunnerError::Internal(format!(
+                "unexpected systemctl show property for {svc}: {property}"
+            )));
+        }
+        if values
+            .insert(property.to_string(), value.to_string())
+            .is_some()
+        {
+            return Err(RunnerError::Internal(format!(
+                "duplicate systemctl show property for {svc}: {property}"
+            )));
+        }
+    }
+    for property in properties {
+        if !values.contains_key(*property) {
+            return Err(RunnerError::Internal(format!(
+                "missing systemctl show property for {svc}: {property}"
+            )));
+        }
+    }
+    Ok(values)
+}
+
+fn required_systemctl_property<'a>(
+    svc: &str,
+    values: &'a BTreeMap<String, String>,
+    property: &str,
+) -> RunnerResult<&'a str> {
+    let value = values.get(property).ok_or_else(|| {
+        RunnerError::Internal(format!(
+            "missing systemctl show property for {svc}: {property}"
+        ))
+    })?;
+    let value = value.trim();
+    if value.is_empty() {
+        return Err(RunnerError::Internal(format!(
+            "empty systemctl show property for {svc}: {property}"
+        )));
+    }
+    Ok(value)
+}
+
+fn classify_unit_active(svc: &str, load_state: &str, active_state: &str) -> RunnerResult<bool> {
+    match active_state {
+        "active" | "activating" | "reloading" | "refreshing" => Ok(true),
+        "inactive" | "failed" | "deactivating" | "maintenance" => Ok(false),
+        _ => Err(RunnerError::Internal(format!(
+            "unknown ActiveState for {svc}: {active_state} (LoadState={load_state})"
+        ))),
+    }
+}
+
+fn unit_active_from_systemctl_show(
+    svc: &str,
+    properties: &[&str],
+    status: &ExitStatus,
+    values: &BTreeMap<String, String>,
+    stderr: &[u8],
+) -> RunnerResult<bool> {
+    let load_state = required_systemctl_property(svc, values, "LoadState")?;
+    let active_state = required_systemctl_property(svc, values, "ActiveState")?;
+    let active = classify_unit_active(svc, load_state, active_state)?;
+    let missing_unit = load_state == "not-found" && !active;
+    if !status.success() && !missing_unit {
+        return Err(systemctl_show_status_error(svc, properties, status, stderr));
+    }
+    Ok(active)
+}
+
+fn parse_main_pid(svc: &str, value: &str) -> RunnerResult<Option<u32>> {
+    let value = value.trim();
+    if value.is_empty() {
+        return Err(RunnerError::Internal(format!("empty MainPID for {svc}")));
+    }
+    let pid = value.parse::<u32>().map_err(|e| {
+        RunnerError::Internal(format!(
+            "parse MainPID for {svc}: {:?}: {e}",
+            status_field_preview(value)
+        ))
+    })?;
+    if pid == 0 { Ok(None) } else { Ok(Some(pid)) }
+}
+
+fn systemctl_show_status_error(
+    svc: &str,
+    properties: &[&str],
+    status: &ExitStatus,
+    stderr: &[u8],
+) -> RunnerError {
+    let property_args = properties.join(",");
+    let stderr = String::from_utf8_lossy(stderr);
+    let stderr = stderr.trim();
+    if stderr.is_empty() {
+        RunnerError::Internal(format!(
+            "systemctl show {svc} --property={property_args} exited with {status}"
+        ))
+    } else {
+        RunnerError::Internal(format!(
+            "systemctl show {svc} --property={property_args} exited with {status}: stderr={:?}",
+            status_field_preview(stderr)
+        ))
     }
 }
 
@@ -357,6 +503,9 @@ async fn get_service_pid(unit: &str) -> RunnerResult<Option<u32>> {
 ///    exited, or systemd is mid-transition and has cleared MainPID.
 /// 2. MainPID resolved to a live value but `kill(2)` returned `ESRCH`
 ///    because the process exited in the ~µs window before signal delivery.
+///
+/// Failed or malformed MainPID lookups are not `AlreadyGone`; they propagate
+/// as errors because the signal may still be needed.
 ///
 /// Either way the signal was not delivered, and the cause is the same:
 /// the runner is no longer around to receive it. `Sent` carries the PID
@@ -1007,6 +1156,206 @@ mod tests {
         let status = ExitStatus::from_raw(libc::SIGPIPE);
 
         assert!(journalctl_logs_status("vm0-runner-test.service", status).is_ok());
+    }
+
+    #[test]
+    fn parse_systemctl_show_properties_extracts_values() {
+        let values = parse_systemctl_show_properties(
+            "vm0-runner-test.service",
+            &["MainPID"],
+            b"MainPID=123\n",
+        )
+        .unwrap();
+
+        assert_eq!(
+            required_systemctl_property("vm0-runner-test.service", &values, "MainPID").unwrap(),
+            "123"
+        );
+    }
+
+    #[test]
+    fn parse_systemctl_show_properties_rejects_missing_property() {
+        let err = parse_systemctl_show_properties("vm0-runner-test.service", &["MainPID"], b"")
+            .unwrap_err();
+        let message = err.to_string();
+
+        assert!(message.contains("missing systemctl show property"));
+    }
+
+    #[test]
+    fn parse_systemctl_show_properties_rejects_unexpected_property() {
+        let err = parse_systemctl_show_properties(
+            "vm0-runner-test.service",
+            &["MainPID"],
+            b"ActiveState=active\n",
+        )
+        .unwrap_err();
+        let message = err.to_string();
+
+        assert!(message.contains("unexpected systemctl show property"));
+    }
+
+    #[test]
+    fn parse_systemctl_show_properties_rejects_duplicate_property() {
+        let err = parse_systemctl_show_properties(
+            "vm0-runner-test.service",
+            &["MainPID"],
+            b"MainPID=123\nMainPID=456\n",
+        )
+        .unwrap_err();
+        let message = err.to_string();
+
+        assert!(message.contains("duplicate systemctl show property"));
+    }
+
+    #[test]
+    fn parse_systemctl_show_properties_rejects_malformed_line() {
+        let err = parse_systemctl_show_properties(
+            "vm0-runner-test.service",
+            &["MainPID"],
+            b"MainPID 123\n",
+        )
+        .unwrap_err();
+        let message = err.to_string();
+
+        assert!(message.contains("malformed systemctl show output"));
+    }
+
+    #[test]
+    fn required_systemctl_property_rejects_empty_value() {
+        let values =
+            parse_systemctl_show_properties("vm0-runner-test.service", &["MainPID"], b"MainPID=\n")
+                .unwrap();
+        let err =
+            required_systemctl_property("vm0-runner-test.service", &values, "MainPID").unwrap_err();
+        let message = err.to_string();
+
+        assert!(message.contains("empty systemctl show property"));
+    }
+
+    #[test]
+    fn systemctl_show_status_error_includes_stderr() {
+        use std::os::unix::process::ExitStatusExt;
+
+        let status = ExitStatus::from_raw(0x100);
+        let err = systemctl_show_status_error(
+            "vm0-runner-test.service",
+            &["MainPID"],
+            &status,
+            b"Failed to connect to bus: Host is down\n",
+        );
+        let message = err.to_string();
+
+        assert!(message.contains("systemctl show vm0-runner-test.service --property=MainPID"));
+        assert!(message.contains("Failed to connect to bus"));
+    }
+
+    #[test]
+    fn classify_unit_active_accepts_active_states() {
+        for active_state in ["active", "activating", "reloading", "refreshing"] {
+            assert!(
+                classify_unit_active("vm0-runner-test.service", "loaded", active_state).unwrap()
+            );
+        }
+    }
+
+    #[test]
+    fn classify_unit_active_accepts_inactive_states() {
+        for active_state in ["inactive", "failed", "deactivating", "maintenance"] {
+            assert!(
+                !classify_unit_active("vm0-runner-test.service", "loaded", active_state).unwrap()
+            );
+        }
+    }
+
+    #[test]
+    fn classify_unit_active_treats_not_found_inactive_as_inactive() {
+        assert!(!classify_unit_active("vm0-runner-test.service", "not-found", "inactive").unwrap());
+    }
+
+    #[test]
+    fn classify_unit_active_rejects_unknown_active_state() {
+        let err =
+            classify_unit_active("vm0-runner-test.service", "loaded", "half-active").unwrap_err();
+        let message = err.to_string();
+
+        assert!(message.contains("unknown ActiveState"));
+    }
+
+    #[test]
+    fn unit_active_from_systemctl_show_allows_not_found_inactive_on_failed_status() {
+        use std::os::unix::process::ExitStatusExt;
+
+        let properties = ["LoadState", "ActiveState"];
+        let values = parse_systemctl_show_properties(
+            "vm0-runner-test.service",
+            &properties,
+            b"LoadState=not-found\nActiveState=inactive\n",
+        )
+        .unwrap();
+        let status = ExitStatus::from_raw(0x100);
+
+        assert!(
+            !unit_active_from_systemctl_show(
+                "vm0-runner-test.service",
+                &properties,
+                &status,
+                &values,
+                b"Unit not found\n",
+            )
+            .unwrap()
+        );
+    }
+
+    #[test]
+    fn unit_active_from_systemctl_show_rejects_nonzero_loaded_inactive() {
+        use std::os::unix::process::ExitStatusExt;
+
+        let properties = ["LoadState", "ActiveState"];
+        let values = parse_systemctl_show_properties(
+            "vm0-runner-test.service",
+            &properties,
+            b"LoadState=loaded\nActiveState=inactive\n",
+        )
+        .unwrap();
+        let status = ExitStatus::from_raw(0x100);
+        let err = unit_active_from_systemctl_show(
+            "vm0-runner-test.service",
+            &properties,
+            &status,
+            &values,
+            b"Failed to connect to bus\n",
+        )
+        .unwrap_err();
+        let message = err.to_string();
+
+        assert!(message.contains("Failed to connect to bus"));
+    }
+
+    #[test]
+    fn parse_main_pid_zero_returns_none() {
+        assert_eq!(
+            parse_main_pid("vm0-runner-test.service", "0").unwrap(),
+            None
+        );
+    }
+
+    #[test]
+    fn parse_main_pid_positive_returns_pid() {
+        assert_eq!(
+            parse_main_pid("vm0-runner-test.service", "123").unwrap(),
+            Some(123)
+        );
+    }
+
+    #[test]
+    fn parse_main_pid_rejects_malformed_values() {
+        for value in ["abc", "", "-1", "4294967296"] {
+            assert!(
+                parse_main_pid("vm0-runner-test.service", value).is_err(),
+                "value should fail: {value}"
+            );
+        }
     }
 
     #[test]

--- a/crates/runner/src/cmd/service.rs
+++ b/crates/runner/src/cmd/service.rs
@@ -345,19 +345,21 @@ pub(crate) async fn is_unit_active(name: &str) -> RunnerResult<bool> {
 /// Get the main PID of a systemd unit.
 async fn get_service_pid(unit: &str) -> RunnerResult<Option<u32>> {
     let svc = format!("{unit}.service");
-    let properties = ["MainPID"];
+    let properties = ["LoadState", "MainPID"];
     let output = run_systemctl_show(&svc, &properties).await?;
-    if !output.status.success() {
-        return Err(systemctl_show_status_error(
-            &svc,
-            &properties,
-            &output.status,
-            &output.stderr,
-        ));
-    }
-    let values = parse_systemctl_show_properties(&svc, &properties, &output.stdout)?;
-    let pid_str = required_systemctl_property(&svc, &values, "MainPID")?;
-    parse_main_pid(&svc, pid_str)
+    let values = match parse_systemctl_show_properties(&svc, &properties, &output.stdout) {
+        Ok(values) => values,
+        Err(_) if !output.status.success() => {
+            return Err(systemctl_show_status_error(
+                &svc,
+                &properties,
+                &output.status,
+                &output.stderr,
+            ));
+        }
+        Err(e) => return Err(e),
+    };
+    service_pid_from_systemctl_show(&svc, &properties, &output.status, &values, &output.stderr)
 }
 
 async fn run_systemctl_show(svc: &str, properties: &[&str]) -> RunnerResult<Output> {
@@ -459,6 +461,29 @@ fn unit_active_from_systemctl_show(
     Ok(active)
 }
 
+fn service_pid_from_systemctl_show(
+    svc: &str,
+    properties: &[&str],
+    status: &ExitStatus,
+    values: &BTreeMap<String, String>,
+    stderr: &[u8],
+) -> RunnerResult<Option<u32>> {
+    let load_state = required_systemctl_property(svc, values, "LoadState")?;
+    let pid_str = required_systemctl_property(svc, values, "MainPID")?;
+    let pid = match parse_main_pid(svc, pid_str) {
+        Ok(pid) => pid,
+        Err(_) if !status.success() => {
+            return Err(systemctl_show_status_error(svc, properties, status, stderr));
+        }
+        Err(e) => return Err(e),
+    };
+    let missing_unit = load_state == "not-found" && pid.is_none();
+    if !status.success() && !missing_unit {
+        return Err(systemctl_show_status_error(svc, properties, status, stderr));
+    }
+    Ok(pid)
+}
+
 fn parse_main_pid(svc: &str, value: &str) -> RunnerResult<Option<u32>> {
     let value = value.trim();
     if value.is_empty() {
@@ -499,8 +524,9 @@ fn systemctl_show_status_error(
 /// The `AlreadyGone` variant collapses two distinct races into a single
 /// state so callers can encode one policy instead of two:
 ///
-/// 1. `systemctl show --property=MainPID` read `0` — the runner either
-///    exited, or systemd is mid-transition and has cleared MainPID.
+/// 1. `systemctl show` read `MainPID=0` — the runner either exited, systemd
+///    is mid-transition and has cleared MainPID, or the unit was explicitly
+///    reported as not found after a prior active-state check.
 /// 2. MainPID resolved to a live value but `kill(2)` returned `ESRCH`
 ///    because the process exited in the ~µs window before signal delivery.
 ///
@@ -1330,6 +1356,108 @@ mod tests {
         let message = err.to_string();
 
         assert!(message.contains("Failed to connect to bus"));
+    }
+
+    #[test]
+    fn service_pid_from_systemctl_show_returns_pid_on_success() {
+        use std::os::unix::process::ExitStatusExt;
+
+        let properties = ["LoadState", "MainPID"];
+        let values = parse_systemctl_show_properties(
+            "vm0-runner-test.service",
+            &properties,
+            b"LoadState=loaded\nMainPID=123\n",
+        )
+        .unwrap();
+        let status = ExitStatus::from_raw(0);
+
+        assert_eq!(
+            service_pid_from_systemctl_show(
+                "vm0-runner-test.service",
+                &properties,
+                &status,
+                &values,
+                b"",
+            )
+            .unwrap(),
+            Some(123)
+        );
+    }
+
+    #[test]
+    fn service_pid_from_systemctl_show_allows_not_found_zero_on_failed_status() {
+        use std::os::unix::process::ExitStatusExt;
+
+        let properties = ["LoadState", "MainPID"];
+        let values = parse_systemctl_show_properties(
+            "vm0-runner-test.service",
+            &properties,
+            b"LoadState=not-found\nMainPID=0\n",
+        )
+        .unwrap();
+        let status = ExitStatus::from_raw(0x100);
+
+        assert_eq!(
+            service_pid_from_systemctl_show(
+                "vm0-runner-test.service",
+                &properties,
+                &status,
+                &values,
+                b"Unit not found\n",
+            )
+            .unwrap(),
+            None
+        );
+    }
+
+    #[test]
+    fn service_pid_from_systemctl_show_rejects_nonzero_loaded_zero() {
+        use std::os::unix::process::ExitStatusExt;
+
+        let properties = ["LoadState", "MainPID"];
+        let values = parse_systemctl_show_properties(
+            "vm0-runner-test.service",
+            &properties,
+            b"LoadState=loaded\nMainPID=0\n",
+        )
+        .unwrap();
+        let status = ExitStatus::from_raw(0x100);
+        let err = service_pid_from_systemctl_show(
+            "vm0-runner-test.service",
+            &properties,
+            &status,
+            &values,
+            b"Failed to connect to bus\n",
+        )
+        .unwrap_err();
+        let message = err.to_string();
+
+        assert!(message.contains("Failed to connect to bus"));
+    }
+
+    #[test]
+    fn service_pid_from_systemctl_show_rejects_malformed_pid_on_failed_status() {
+        use std::os::unix::process::ExitStatusExt;
+
+        let properties = ["LoadState", "MainPID"];
+        let values = parse_systemctl_show_properties(
+            "vm0-runner-test.service",
+            &properties,
+            b"LoadState=not-found\nMainPID=abc\n",
+        )
+        .unwrap();
+        let status = ExitStatus::from_raw(0x100);
+        let err = service_pid_from_systemctl_show(
+            "vm0-runner-test.service",
+            &properties,
+            &status,
+            &values,
+            b"Unit not found\n",
+        )
+        .unwrap_err();
+        let message = err.to_string();
+
+        assert!(message.contains("Unit not found"));
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- replace service activity checks with parsed `systemctl show` state so systemd query failures propagate instead of being treated as inactive
- make `get_service_pid` fail on non-zero, malformed, or missing `MainPID` output while still treating `MainPID=0` as already gone
- add parser/state classification coverage for systemctl output and MainPID edge cases

Closes #16273

## Test Plan

- `pnpm -F @vm0/db db:migrate`
- `cargo test --manifest-path crates/Cargo.toml -p runner cmd::service`
- `cargo fmt --manifest-path crates/Cargo.toml -p runner -- --check`
- `cargo clippy --manifest-path crates/Cargo.toml -p runner --all-targets`
- `cargo check --manifest-path crates/Cargo.toml -p runner`
- `git diff --check`
- `pnpm format`
- `pnpm turbo run lint`
- `pnpm check-types`
- `pnpm knip`
- `pnpm vitest` (fails locally in unrelated existing tests: `@vm0/app` network-insights date assertions around `Yesterday` in Asia/Shanghai vs UTC, and `@vm0/desktop` native CLI assertions on Linux where Desktop Computer Use is macOS-only)
- `pnpm -F @vm0/app exec vitest src/views/network-insights/__tests__/network-insights-page-interaction.test.tsx` (same 3 unrelated date assertion failures)
- `pnpm -F @vm0/desktop exec vitest src/computer-use-native.test.ts` (same 4 unrelated Linux/macOS native CLI failures)