### PR TITLE
chore: replace DefiLlama raster connector icon

### DIFF
--- a/turbo/apps/platform/src/views/zero-page/components/settings/icons/defillama.svg
+++ b/turbo/apps/platform/src/views/zero-page/components/settings/icons/defillama.svg
@@ -1,4 +1,86 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 256 256" role="img" aria-label="connector logo">
-  <!-- Official brand asset source: https://defillama.com/favicon.ico -->
-  <image href="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAADAAAAAwCAYAAABXAvmHAAAACXBIWXMAAAsTAAALEwB3nayOAAAKr0lEQVR4nO2ZeVBURx7H2zPWZjWpra3U7lbl2q3aqk1tNpVlN1ESQcQziuCBoEZBTcxGY8xhro3ZmGx2EyQS8SCiRsWgKCIoh8hhmINrhAEGhvuYYUAeciqnw8yb73b3m5GRaOIbSfYfu/jW1Lx5zHw//ft1969fE3Kv3Ws/T/s4C+O3JeNP7yfA7fVYuL16HG5BR+G28iDc/KgmvHTVjdxK67v+QoK6HyObcd//zfynyQj+JAXd/zwHvH0G2HQSWP8t8OIRYNkBYEEEBsi6Lvyg1nZa6Gs5fT1GgjsDyIauB34W89T4/O3JsH2UBLwbD9Dex4bjwJooIOAQ4Ps1MDscxh8F+J46zVRRZF330z8tQDLSKADePwu8eRp4NQZYewxYeRhYEgm8sA/4++cWlXwAu+bEZpGpO5LIM6GP/1QATR8mAltp6rx2CngpGlhNU8f/IOATAczZDTz0Zm+BS+YX52vItB0iFci0kAGqLaMO8FEihPcSgC00dV45AQTT1An8BvDbD8zbC0z/EnqyvtMm2/yLDSZq/Jpk/iYdJU98PHHUAD44C+GtOGAjTZ11dOCuoqmzlA1cmjreu3D9V5t79HsyB5VTNnX3yAKYvrvAYXqSR9jg8m2JBWPcQ2z82tSQZOL58aRRAXgnHsJmmjovs4F7FFhOB+4iOnDnhsP26Du96oe2tHcBsF0fQsOcsJ7SkUan/qenqrNP1HX3i6XTP79WIaVOTr7D/FOrj9T3DQxV0u/AY0v2X74Riak7Uoh/7Li7BthyGsI/TkgDdwVNncVs4O7B4CNbr2lIUAtIkICGNqsGUrPl1lqUk17pHnwjpi+32GRVmy0w2D/DkBWmIqNVve1gXuZEj53mlJx6BbvMPmtp7y38XjpNDQm9a4BNMRDWR0tzPk0d0TPUnPOLl1pMZLUJZHUTyJpmPP1RWz31YHYY7RsUq/Ajjfa68z0W9w3RlbcYDyDPhiy6K4CASHP6vF39yj9v61TdF9zQRlbVgayqp4PQQGWkEI1gMKfy+5U/Zvp2LTmnTnFL89LsZCLuIZPvgqBMIIHlIIEVICuqqKpBVtZQ1Uogqxo4zPg1RrGjx6qXa76331w10SPMfHsArv+6DrC8RCABpaAgcIAUGQbq4vJ7in63sb6AwtgcUfn9W6aWfrNYc6fmr5ut9U+8eMxAntsF8txXVDv7p204odLXtxtf/iIti0wLdQBcJc+ET3ENwL9IIP7FoCBUOg4yJbi8rLrF3MjDX0QHn1NUzlzqy7pTgAuaRgXx2Een1L0YPyPC2NrZ38muR6dVFYz12NUmQTGFUYidb7sGsKRAIMsKQZZpQWEgwegwZrmu55O4VnX4+XYNT6/ASp5iFiua7xTAahU7xnhF2ohnJMZ5RTan5DWWzHzjHIOykekSGJm+B+T53VThBa4BLM4VyFINyNJLFKIAHMZfi5ujUoqxAWVimk7qfZH+pVeguMSEbK0JOQ7DzV3QFpugUtdBZRUxwK6pSlvV472PWInXNyAzDlEdlOR5AAyMeO4H8fgaHMpr76PyAfyyBbrwgCzJo8rHMMzNUdl2UlA7926qHmVJpQDTxUpoc+uRk1iKa+z9hXLonO/9IkafTbyPgcyMojpKdQTE67BdzmCRQfIBfJUC8VPR1VMNCSRXglmaf1NU9Kb+bGdTl4zIYmaj1L1tCcXWoYQSq+WYuq+DXdM14zvnexuE3ktk9gmQWUzHqaJBvL8Fh/KOGgbzOvyVfIBFFwXimwXiqwAH8WMg2U4wUlR0xn71rQAe9Y3IJn/bbmF62Hdvth1A4Xxvlak3j8w9zUprqlOSZp+kioEEdtyubzPkA/ikC8QnExSE6jsqhZVGxQmGgizORfCeOo2zqfN66JnZxGJRfNA7VDvZK6T4nE60smsZFShwvnfjPp2GzDsLMi+BKh5k7hm74iiME9ismGL5AAsvCGRhGsb7Zpo/0zR1JZSJ2JJRaxyOivJGVNJKuvggpjXP1UQdbI4x4L/9osrng1Sl4z1Vt8O8sqxDTRakgLzAlEyVBDI/kW4DSxQJJaJl8yEjhUsY5GBz4gzyAeYnCWTBeUxclD4QXnqljxn4QFV/+aaocBgl/n3KqHIYU1RD4TDM8j9BazE73msbh1No51mjmkYZrJNoZ0lakIplO6pU7N5P49vKyAuJfXawBvkA884K9Auk3qE99UBAZu+YhRdE/oPsh30yKIQEsyup6YYxUYSFTqEZSTr0OozTqFyn5tkAtjnui0xrUfEO4Ol5Ufou9p0LM8QxPukdw2Cp9PfPF8oHmBsv8Nycf5aHlveEHYb1lPTlEsyhtOYsjGhDFnQ2diDH2IHcwSEIIz8/oWpX8hmOpSEfV0opNXlUR4AtTE+XDzD7tMAHExtUfJAxkHNOMAzkPO+hk8qWLLpAQY7O5Hcq+UzG15k8PiFIE0O2E5SKpygFC3MBIEaQpjY6E7CpjoPE41ZRic+9knXdQos0GUopuqbiCyJfGAuktYVLg2EwO5Rfzgr5ALOiBb7A8Dn5pH2ePo3hqMTfiEpqYYeij25r5CizrE9NlpdKJQkrTViJwld3LW4G09jIkhwXSgnvKIGvimx1ZIvJbDsMBZniF6//bWBiIYehIJmlncqrtMKRI3XlYLZUDJZbnnynXj0uUN/CS/cAB5QdbFlxnnzzrHl9I/DahC3nfGnnMENrQnJpvoti5zXzFUeKKcu7szv6ADnKrTPnsTL8/rW1FWxQt/dYuh5/vT6PrKiEHYxKT4H0r7kGMOOAwIspVlR5HeE1yWmFoZCZj0yqyZ/sE1vuiEpedW9uaw8gR5cMFg3fmtJd3R+3mnJyawb5XnnmZ5cVfNfH9hmB1V0kyPCgawAe+wVe1s44AAfIY4GxeRNmRxl4gTUcFWhq+zTNdI2VI63BqmUPBrjYQwK6v/71q03F969vrJT23Qa22/vQNfOsPb9PIB4RUk3OanNWp/PS1hGVw/YSOArahgFtI91TyVGJSdSR4Csgwa38EY2kFgp02QHVTPyv/NJ1gOd2CXxXxHZHbPvHYDiIIyoHb4AUG6/r6tsBOSppEivsT6tB1nZQtUsKbqMgrSKVt+vmWXMPE/im+/lwaWt3A8Y5KpEY7324VmeyVFS3AnKka0Lt7c8UunbcnXnWpoUKxP1LUBD7BtsBswdjPSNMDweeUQbta9J/ksLr/LryFkCOik1i420ORBKIP+7+0eIY99Case47TROmh1VNnrv/0h9WxSlmvJer3nSsw8BMO4vud00UAnJUZIJwi55PpeZH5wk1NSaMNHo7FTailVabkCP6P10jACLJBkwYFfMcIBlNP2R6O9W/koBtiUC+AVc1BkCO8uvFAXuvXyXrOtaNmnFH256EVIdBdsjHjpreTQC2xgPs3IAdO7HDD/YIPqcWgzl19FWGsmshUvPHSdCV34y6edbeiMOs10/Bxo6XNp4E2KN2dsj3crR0UskeuwdFAauPQqS7MJuyhm4T70CKGpiV1YhVVePZn8S4c1sdhaBVh9HNDvbYGQE7nWRnZOykZvF+6aRycST6L9Ii4HbKrMIQVVlmJaLo++Xna+Dis04Xm+cRTFqwG08tiIDbnHBJXg59CbeZkfhrWiXcRiqjEk9m6PFIrH6UZpV77V4b3fY/k7JE/jL30XwAAAAASUVORK5CYII=" x="0" y="0" width="256" height="256" preserveAspectRatio="xMidYMid meet"/>
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="-26.3 -12.275 156 156" role="img" aria-label="connector logo">
+  <!-- Official brand asset source: https://github.com/DefiLlama/defillama-app/blob/main/public/icons/favicon.svg -->
+  <defs>
+    <style>
+      .cls-1 {
+        fill: #0dff81;
+      }
+
+      .cls-1,
+      .cls-2,
+      .cls-4,
+      .cls-9 {
+        fill-rule: evenodd;
+      }
+
+      .cls-2,
+      .cls-10 {
+        fill: #fff;
+      }
+
+      .cls-3,
+      .cls-5,
+      .cls-6,
+      .cls-7,
+      .cls-8 {
+        isolation: isolate;
+      }
+
+      .cls-3 {
+        fill: url(#linear-gradient);
+      }
+
+      .cls-4 {
+        fill: #b3d2ff;
+      }
+
+      .cls-5 {
+        fill: url(#linear-gradient-2);
+      }
+
+      .cls-6 {
+        fill: url(#linear-gradient-3);
+      }
+
+      .cls-7 {
+        fill: url(#linear-gradient-4);
+      }
+
+      .cls-8 {
+        fill: url(#linear-gradient-5);
+      }
+
+      .cls-9 {
+        fill: #003580;
+      }
+    </style>
+    <linearGradient id="linear-gradient" x1="21.35" y1="140.45" x2="18.88" y2="120.25" gradientUnits="userSpaceOnUse">
+      <stop offset="0.29" stop-color="#3a8bff" />
+      <stop offset="1" stop-color="#81b5ff" />
+    </linearGradient>
+    <linearGradient id="linear-gradient-2" x1="53.25" y1="-13.54" x2="4.51" y2="112.02" gradientUnits="userSpaceOnUse">
+      <stop offset="0.29" stop-color="#0062ee" />
+      <stop offset="1" stop-color="#00398a" />
+    </linearGradient>
+    <linearGradient id="linear-gradient-3" x1="77.94" y1="130.62" x2="94.45" y2="36.26" href="#linear-gradient-2" />
+    <linearGradient id="linear-gradient-4" x1="58.26" y1="162.52" x2="58.26" y2="74.89" gradientUnits="userSpaceOnUse">
+      <stop offset="0.29" stop-color="#b3d2ff" />
+      <stop offset="1" stop-color="#fff" />
+    </linearGradient>
+    <linearGradient id="linear-gradient-5" x1="34.76" y1="27.73" x2="4.26" y2="8.77" href="#linear-gradient" />
+  </defs>
+  <path class="cls-1" d="M17.07 68.77a3.57 3.57 0 0 1-3.24.48l-3.18-1.09a2.43 2.43 0 0 1 0-4.6l3.18-1.09a3.58 3.58 0 0 1 3.24 6.3" />
+  <path class="cls-2" d="M16.37 95.44a2 2 0 0 1 .56-2.62l7.41-5.34a2.93 2.93 0 0 1 4.09.66l.16.25a2.92 2.92 0 0 1-1.07 4l-.27.14-8.33 3.75a2 2 0 0 1-2.55-.83" />
+  <path class="cls-2" d="M28.59 44.35a3 3 0 0 1-1.92 1.39 2.92 2.92 0 0 1-2.33-.48l-7.41-5.35a2 2 0 0 1 2-3.44l8.33 3.74a2.92 2.92 0 0 1 1.48 3.86l-.14.27" />
+  <path class="cls-3" d="m36.09 106.54-.84 24.91h-23.4A11.86 11.86 0 0 1 0 119.6v-5.3a87.21 87.21 0 0 0 36.09-7.76" />
+  <path class="cls-2" d="M99.1 95.44a2 2 0 0 1-2.55.83l-8.33-3.75a2.91 2.91 0 0 1-1.48-3.84l.15-.29a2.91 2.91 0 0 1 4-1.07l.25.16 7.41 5.34a2 2 0 0 1 .56 2.62" />
+  <path class="cls-2" d="m98.54 39.92-7.41 5.35a2.94 2.94 0 0 1-4.1-.69l-.14-.22a2.91 2.91 0 0 1 1-4l.29-.15 8.33-3.74a2 2 0 0 1 2 3.44" />
+  <path class="cls-4" d="M107.47 65.86a2.42 2.42 0 0 1-1.64 2.3l-3.19 1.09a3.58 3.58 0 0 1-2.3-6.78 3.62 3.62 0 0 1 2.3 0l3.19 1.09a2.43 2.43 0 0 1 1.64 2.3" />
+  <path class="cls-5" d="M28.84 42a3 3 0 0 1-.25 2.36 3 3 0 0 1-1.92 1.39 2.92 2.92 0 0 1-2.33-.48l-7.41-5.35a2 2 0 0 1 2-3.44l8.33 3.74A2.93 2.93 0 0 1 28.84 42m0 48.76a2.93 2.93 0 0 1-1.59 1.77l-8.33 3.75a2 2 0 0 1-2-3.45l7.41-5.34a2.93 2.93 0 0 1 4.09.66l.16.25a3 3 0 0 1 .25 2.36m-15-21.5-3.18-1.09a2.43 2.43 0 0 1 0-4.6l3.18-1.09a3.58 3.58 0 1 1 2.3 6.78 3.62 3.62 0 0 1-2.3 0M50.72 0H32.34A32.36 32.36 0 0 1 0 32.35v81.95a87.21 87.21 0 0 0 36.09-7.76l1.43-42.36c-2.53-1.25-4.34-4.57-4.34-8.45 0-4.37 2.28-8 5.29-8.82a20 20 0 0 1 2.74-7.42A4.36 4.36 0 0 1 38 37.41c-2.72-4-6.39-8.1-9.2-14.73a3.52 3.52 0 0 1 .38-3.55 1.75 1.75 0 0 1 2.45-.33l.22.2c4.35 4.12 9.58 5.35 12.47 9.3a5.57 5.57 0 0 1 .83-1.36 6.06 6.06 0 0 1 7.16-1.88 6.19 6.19 0 0 1 11.87 0 5.7 5.7 0 0 1 4.16-.2A86.69 86.69 0 0 1 80.64 7.19 65.4 65.4 0 0 0 50.72 0" />
+  <path class="cls-4" d="M17.07 68.77a3.57 3.57 0 0 1-3.24.48l-3.18-1.09a2.43 2.43 0 0 1 0-4.6l3.18-1.09a3.58 3.58 0 0 1 3.24 6.3" />
+  <path class="cls-6" d="m105.83 68.16-3.19 1.09a3.58 3.58 0 0 1-2.3-6.78 3.62 3.62 0 0 1 2.3 0l3.19 1.09a2.43 2.43 0 0 1 0 4.6M99.1 95.44a2 2 0 0 1-2.55.83l-8.33-3.75a2.91 2.91 0 0 1-1.48-3.84l.15-.29a2.91 2.91 0 0 1 4-1.07l.25.16 7.41 5.34a2 2 0 0 1 .56 2.62M86.63 42a2.93 2.93 0 0 1 1.59-1.77l8.33-3.74a2 2 0 0 1 2 3.44l-7.41 5.35a2.94 2.94 0 0 1-4.1-.69l-.14-.22a2.94 2.94 0 0 1-.27-2.36M86.3 10.46c-1.83-1.18-3.71-2.27-5.66-3.27a86.69 86.69 0 0 0-12.3 17.67 6.25 6.25 0 0 1 3 2.08 6.52 6.52 0 0 1 .83 1.36c2.71-3.71 7.48-4.55 11.66-8.53A2.45 2.45 0 0 1 87 19.46a2 2 0 0 1 .55.54 2.41 2.41 0 0 1 .29 2.5l-.12.28c-2.8 6.5-6.45 10.64-9.15 14.63a4.39 4.39 0 0 1-3.26 2.08A19.74 19.74 0 0 1 78 46.91c2.71.74 4.82 3.74 5.22 7.52a11.33 11.33 0 0 1 .07 1.3c0 3.65-1.6 6.81-3.91 8.2a2.67 2.67 0 0 1-.43.25v.63l2 59.26a65.72 65.72 0 0 0 35.45-58.34 65.69 65.69 0 0 0-30.1-55.27" />
+  <path class="cls-7" d="M70.73 62a3.93 3.93 0 0 1-.22 4.17c-2.85 4.16-6.84 7.32-11.92 7.32h-1.08c-4.39-.38-9-3.25-11.85-6.7a4 4 0 0 1-.37-4.53A12 12 0 0 0 47 56.09a12.43 12.43 0 0 0-1.46-5.85 3.92 3.92 0 0 1 .22-4.13 4.68 4.68 0 0 0 .75.79 5.84 5.84 0 0 0 7.09.1c0 2.27 2.29 4.11 5.1 4.11a5 5 0 0 0 .77 0c2.46-.3 4.34-2 4.34-4.06A5.84 5.84 0 0 0 71 46.9l.28-.25a4 4 0 0 1-.37 3.35 11.9 11.9 0 0 0-1.68 6.13 12.4 12.4 0 0 0 1.5 5.9M87.52 20a2 2 0 0 0-.55-.54 2.45 2.45 0 0 0-3.13.31c-4.18 4-9 4.82-11.66 8.53a6.52 6.52 0 0 0-.83-1.36 6.25 6.25 0 0 0-3-2.08 5.7 5.7 0 0 0-4.16.2 6.19 6.19 0 0 0-11.87 0 6.06 6.06 0 0 0-7.16 1.88 5.57 5.57 0 0 0-.83 1.36c-2.89-3.95-8.12-5.18-12.47-9.3a1.74 1.74 0 0 0-2.47-.13 1.48 1.48 0 0 0-.24.26 3.52 3.52 0 0 0-.38 3.55c2.81 6.63 6.48 10.71 9.2 14.73a4.36 4.36 0 0 0 3.25 2.08 20 20 0 0 0-2.74 7.42c-3 .82-5.29 4.45-5.29 8.82 0 3.88 1.81 7.2 4.34 8.45l.57 42.36-.84 24.91h15.46a65.4 65.4 0 0 0 29.92-7.19l.35-.19-2-59.26v-.63a2.67 2.67 0 0 0 .43-.25c2.31-1.39 3.91-4.55 3.91-8.2a11.33 11.33 0 0 0-.07-1.3c-.4-3.78-2.51-6.78-5.22-7.52a19.59 19.59 0 0 0-2.74-7.42 4.39 4.39 0 0 0 3.26-2.08c2.7-4 6.35-8.13 9.15-14.63l.12-.28a2.41 2.41 0 0 0-.29-2.5" />
+  <path class="cls-8" d="M32.34 0A32.36 32.36 0 0 1 0 32.35v-20.5A11.86 11.86 0 0 1 11.85 0Z" />
+  <path class="cls-4" d="m64.18 57.21-3.33 3.06a2.09 2.09 0 0 0-.59 1c-.22.88-.65 2.61-1 4.25a1 1 0 0 1-1 .76 1 1 0 0 1-1-.76l-1.06-4.25a2 2 0 0 0-.59-1l-3.33-3.06a1 1 0 0 1 .85-1.72l5 .68h.27l.39-.05 4.61-.63a1 1 0 0 1 1 .56 1 1 0 0 1-.23 1.16m5-1.12A11.93 11.93 0 0 1 70.91 50a4 4 0 0 0 .32-3.31l-.23.21a5.84 5.84 0 0 1-7.14.06c0 2.04-1.86 3.76-4.34 4.04a5 5 0 0 1-.77 0c-2.81 0-5.1-1.84-5.1-4.11a5.84 5.84 0 0 1-7.14-.06 4.68 4.68 0 0 1-.75-.79 3.92 3.92 0 0 0-.22 4.13A12.39 12.39 0 0 1 47 56.09a11.93 11.93 0 0 1-1.66 6.11 4 4 0 0 0 .37 4.53c2.87 3.45 7.46 6.32 11.85 6.7h1.08c5.08 0 9.07-3.16 11.92-7.32A3.93 3.93 0 0 0 70.73 62a12.4 12.4 0 0 1-1.5-5.9" />
+  <path class="cls-9" d="m64.18 57.21-3.33 3.06a2.09 2.09 0 0 0-.59 1c-.22.88-.65 2.61-1 4.25a1 1 0 0 1-1 .76 1 1 0 0 1-1-.76l-1.06-4.25a2 2 0 0 0-.59-1l-3.33-3.06a1 1 0 0 1 .85-1.72l5 .68h.27l.39-.05 4.61-.63a1 1 0 0 1 1 .56 1 1 0 0 1-.23 1.16" />
 </svg>


### PR DESCRIPTION
## Summary

- Replace the DefiLlama connector SVG that embedded a base64 PNG with the official vector favicon from DefiLlama's app repository.
- Keep the connector icon SVG-only and preserve the colorful icon classification.

## Verification

- Rendered the updated SVG with sharp to confirm it parses and is non-empty.
- `pnpm --filter @vm0/app lint`
- `pnpm --filter @vm0/app check-types`
- `git diff --check`

Closes #16511
