### PR TITLE
fix(runner): clean workspace holders before unmount retry

### DIFF
--- a/crates/runner/scripts/unmount-workspace-drive.sh
+++ b/crates/runner/scripts/unmount-workspace-drive.sh
@@ -31,5 +31,234 @@ if [ -z "$workspace_dev" ] || [ "$target_dev" != "$workspace_dev" ]; then
   exit 64
 fi
 
+cd /
+sync -f -- "$workspace_dir" 2>/dev/null || true
+if umount -- "$workspace_dir"; then
+  exit 0
+fi
+
+WORKSPACE_HOLDER_DIAGNOSTIC_LIMIT=40
+WORKSPACE_HOLDER_VALUE_LIMIT=240
+WORKSPACE_HOLDER_KILL_GRACE_SECONDS=1
+WORKSPACE_HOLDER_TERM_GRACE_SECONDS=1
+
+is_workspace_ref() {
+  target=$1
+  case "$target" in
+    "$workspace_dir"|"$workspace_dir"/*) return 0 ;;
+  esac
+
+  deleted_suffix=" (deleted)"
+  case "$target" in
+    *"$deleted_suffix")
+      stripped_target=${target%"$deleted_suffix"}
+      case "$stripped_target" in
+        "$workspace_dir"/*) return 0 ;;
+      esac
+      ;;
+  esac
+
+  return 1
+}
+
+proc_uid() {
+  stat -c %u "/proc/$1" 2>/dev/null || true
+}
+
+proc_comm() {
+  cat "/proc/$1/comm" 2>/dev/null || true
+}
+
+sanitize_log_value() {
+  value="$(printf '%s' "$1" | tr '\n\t' '  ')"
+  if [ "${#value}" -gt "$WORKSPACE_HOLDER_VALUE_LIMIT" ]; then
+    value="$(printf '%s' "$value" | cut -c 1-"$WORKSPACE_HOLDER_VALUE_LIMIT")..."
+  fi
+  printf '%s' "$value"
+}
+
+scan_proc_target() {
+  pid=$1
+  ref_type=$2
+  target=$3
+
+  [ -n "$target" ] || return 0
+  is_workspace_ref "$target" || return 0
+
+  uid="$(proc_uid "$pid")"
+  [ -n "$uid" ] || uid=unknown
+  comm="$(proc_comm "$pid")"
+  [ -n "$comm" ] || comm=unknown
+  comm="$(sanitize_log_value "$comm")"
+  target="$(sanitize_log_value "$target")"
+
+  printf '%s\t%s\t%s\t%s\t%s\n' "$pid" "$uid" "$comm" "$ref_type" "$target"
+}
+
+scan_proc_ref() {
+  pid=$1
+  ref_type=$2
+  ref_path=$3
+
+  target="$(readlink -- "$ref_path" 2>/dev/null || true)"
+  scan_proc_target "$pid" "$ref_type" "$target"
+}
+
+scan_proc_maps() {
+  pid=$1
+  maps_path=$2
+  [ -r "$maps_path" ] || return 0
+
+  {
+    while read -r maps_address maps_perms maps_offset maps_dev maps_inode maps_target; do
+      [ -n "$maps_target" ] || continue
+      if is_workspace_ref "$maps_target"; then
+        scan_proc_target "$pid" maps "$maps_target"
+        return 0
+      fi
+    done < "$maps_path"
+  } 2>/dev/null || return 0
+
+  return 0
+}
+
+scan_workspace_holder_refs() {
+  for proc_dir in /proc/[0-9]*; do
+    pid=${proc_dir#/proc/}
+    scan_proc_holder_refs "$pid"
+  done
+}
+
+scan_proc_holder_refs() {
+  pid=$1
+  proc_dir="/proc/$pid"
+  [ -d "$proc_dir" ] || return 0
+  [ "$pid" != "$$" ] || return 0
+  [ "$pid" != "1" ] || return 0
+
+  scan_proc_ref "$pid" cwd "$proc_dir/cwd"
+  scan_proc_ref "$pid" root "$proc_dir/root"
+  scan_proc_ref "$pid" exe "$proc_dir/exe"
+  for fd_ref in "$proc_dir"/fd/*; do
+    [ -L "$fd_ref" ] || [ -e "$fd_ref" ] || continue
+    scan_proc_ref "$pid" fd "$fd_ref"
+  done
+  scan_proc_maps "$pid" "$proc_dir/maps"
+}
+
+workspace_holder_pids() {
+  for proc_dir in /proc/[0-9]*; do
+    pid=${proc_dir#/proc/}
+    if pid_has_workspace_ref "$pid"; then
+      printf '%s\n' "$pid"
+    fi
+  done | sort -u
+}
+
+proc_path_has_workspace_ref() {
+  target="$(readlink -- "$1" 2>/dev/null || true)"
+  [ -n "$target" ] || return 1
+  is_workspace_ref "$target"
+}
+
+proc_maps_has_workspace_ref() {
+  maps_path=$1
+  [ -r "$maps_path" ] || return 1
+
+  {
+    while read -r maps_address maps_perms maps_offset maps_dev maps_inode maps_target; do
+      [ -n "$maps_target" ] || continue
+      if is_workspace_ref "$maps_target"; then
+        return 0
+      fi
+    done < "$maps_path"
+  } 2>/dev/null || return 1
+
+  return 1
+}
+
+pid_has_workspace_ref() {
+  pid=$1
+  proc_dir="/proc/$pid"
+  [ -d "$proc_dir" ] || return 1
+  [ "$pid" != "$$" ] || return 1
+  [ "$pid" != "1" ] || return 1
+
+  if proc_path_has_workspace_ref "$proc_dir/cwd"; then
+    return 0
+  fi
+  if proc_path_has_workspace_ref "$proc_dir/root"; then
+    return 0
+  fi
+  if proc_path_has_workspace_ref "$proc_dir/exe"; then
+    return 0
+  fi
+  for fd_ref in "$proc_dir"/fd/*; do
+    [ -L "$fd_ref" ] || [ -e "$fd_ref" ] || continue
+    if proc_path_has_workspace_ref "$fd_ref"; then
+      return 0
+    fi
+  done
+  if proc_maps_has_workspace_ref "$proc_dir/maps"; then
+    return 0
+  fi
+
+  return 1
+}
+
+log_workspace_holders() {
+  count=0
+  tab="$(printf '\t')"
+  scan_workspace_holder_refs | while IFS="$tab" read -r pid uid comm ref_type target; do
+    count=$((count + 1))
+    if [ "$count" -le "$WORKSPACE_HOLDER_DIAGNOSTIC_LIMIT" ]; then
+      comm="$(sanitize_log_value "$comm")"
+      target="$(sanitize_log_value "$target")"
+      printf 'workspace holder: pid=%s uid=%s comm=%s ref=%s path=%s\n' \
+        "$pid" "$uid" "$comm" "$ref_type" "$target" >&2
+    elif [ "$count" -eq "$((WORKSPACE_HOLDER_DIAGNOSTIC_LIMIT + 1))" ]; then
+      echo "workspace holder diagnostics truncated after $WORKSPACE_HOLDER_DIAGNOSTIC_LIMIT entries" >&2
+    fi
+  done
+}
+
+term_workspace_holder_pids() {
+  pids=$1
+  for pid in $pids; do
+    [ "$pid" != "$$" ] || continue
+    [ "$pid" != "1" ] || continue
+    pid_has_workspace_ref "$pid" || continue
+    kill -TERM "$pid" 2>/dev/null || true
+  done
+}
+
+kill_workspace_holder_pids() {
+  pids=$1
+  for pid in $pids; do
+    [ "$pid" != "$$" ] || continue
+    [ "$pid" != "1" ] || continue
+    pid_has_workspace_ref "$pid" || continue
+    kill -KILL "$pid" 2>/dev/null || true
+  done
+}
+
+echo "workspace drive unmount failed; diagnosing holders under $workspace_dir" >&2
+holder_pids="$(workspace_holder_pids)"
+if [ -z "$holder_pids" ]; then
+  echo "no workspace holder processes found" >&2
+else
+  log_workspace_holders
+  term_workspace_holder_pids "$holder_pids"
+  sleep "$WORKSPACE_HOLDER_TERM_GRACE_SECONDS"
+
+  remaining_holder_pids="$(workspace_holder_pids)"
+  if [ -n "$remaining_holder_pids" ]; then
+    echo "workspace holders remain after TERM; sending KILL" >&2
+    log_workspace_holders
+    kill_workspace_holder_pids "$remaining_holder_pids"
+    sleep "$WORKSPACE_HOLDER_KILL_GRACE_SECONDS"
+  fi
+fi
+
 sync -f -- "$workspace_dir" 2>/dev/null || true
 umount -- "$workspace_dir"

--- a/crates/runner/src/workspace_mount.rs
+++ b/crates/runner/src/workspace_mount.rs
@@ -81,6 +81,209 @@ fn workspace_unmount_command() -> String {
 mod tests {
     use super::*;
 
+    use std::fs;
+    use std::os::unix::fs::PermissionsExt;
+    use std::path::Path;
+    #[cfg(target_os = "linux")]
+    use std::process::{Child, ExitStatus};
+    use std::process::{Command, Output};
+    #[cfg(target_os = "linux")]
+    use std::time::Instant;
+
+    fn find_after(haystack: &str, needle: &str, start: usize) -> usize {
+        start
+            + haystack[start..]
+                .find(needle)
+                .unwrap_or_else(|| panic!("missing {needle} after byte {start}"))
+    }
+
+    fn write_executable(path: &Path, content: &str) {
+        fs::write(path, content).unwrap();
+        let mut permissions = fs::metadata(path).unwrap().permissions();
+        permissions.set_mode(0o755);
+        fs::set_permissions(path, permissions).unwrap();
+    }
+
+    fn fake_path_env(fake_bin: &Path) -> String {
+        let path = std::env::var("PATH").unwrap_or_default();
+        if path.is_empty() {
+            fake_bin.display().to_string()
+        } else {
+            format!("{}:{path}", fake_bin.display())
+        }
+    }
+
+    fn write_fake_mountpoint(fake_bin: &Path, workspace_dir: &Path, workspace_device: &Path) {
+        let workspace_dir = shell_quote(workspace_dir.to_str().unwrap());
+        let workspace_device = shell_quote(workspace_device.to_str().unwrap());
+        write_executable(
+            &fake_bin.join("mountpoint"),
+            &format!(
+                r#"#!/bin/sh
+set -eu
+workspace_dir={workspace_dir}
+workspace_device={workspace_device}
+case "$1" in
+  -x)
+    if [ "$2" = "--" ] && [ "$3" = "$workspace_device" ]; then
+      echo 123
+      exit 0
+    fi
+    ;;
+  -q)
+    if [ "$2" = "--" ] && [ "$3" = "$workspace_dir" ]; then
+      exit 0
+    fi
+    ;;
+  -d)
+    if [ "$2" = "--" ] && [ "$3" = "$workspace_dir" ]; then
+      echo 123
+      exit 0
+    fi
+    ;;
+esac
+exit 1
+"#
+            ),
+        );
+    }
+
+    fn write_fake_sync(fake_bin: &Path, log_path: &Path) {
+        let log_path = shell_quote(log_path.to_str().unwrap());
+        write_executable(
+            &fake_bin.join("sync"),
+            &format!(
+                r#"#!/bin/sh
+set -eu
+printf 'sync cwd=%s args=%s\n' "$(pwd)" "$*" >> {log_path}
+"#
+            ),
+        );
+    }
+
+    fn write_successful_fake_umount(fake_bin: &Path, log_path: &Path) {
+        let log_path = shell_quote(log_path.to_str().unwrap());
+        write_executable(
+            &fake_bin.join("umount"),
+            &format!(
+                r#"#!/bin/sh
+set -eu
+printf 'umount cwd=%s args=%s\n' "$(pwd)" "$*" >> {log_path}
+exit 0
+"#
+            ),
+        );
+    }
+
+    fn write_busy_then_successful_fake_umount(fake_bin: &Path, log_path: &Path, count_path: &Path) {
+        let log_path = shell_quote(log_path.to_str().unwrap());
+        let count_path = shell_quote(count_path.to_str().unwrap());
+        write_executable(
+            &fake_bin.join("umount"),
+            &format!(
+                r#"#!/bin/sh
+set -eu
+count=0
+if [ -f {count_path} ]; then
+  count="$(cat {count_path})"
+fi
+count=$((count + 1))
+printf '%s\n' "$count" > {count_path}
+printf 'umount call=%s cwd=%s args=%s\n' "$count" "$(pwd)" "$*" >> {log_path}
+if [ "$count" -eq 1 ]; then
+  echo "target is busy" >&2
+  exit 32
+fi
+exit 0
+"#
+            ),
+        );
+    }
+
+    fn run_unmount_script(
+        workspace_dir: &Path,
+        workspace_device: &Path,
+        fake_bin: &Path,
+    ) -> Output {
+        let cmd = format!(
+            "workspace_dir={}\nworkspace_device={}\n{}",
+            shell_quote(workspace_dir.to_str().unwrap()),
+            shell_quote(workspace_device.to_str().unwrap()),
+            WORKSPACE_UNMOUNT_SCRIPT
+        );
+        Command::new("sh")
+            .arg("-c")
+            .arg(cmd)
+            .current_dir(workspace_dir)
+            .env("PATH", fake_path_env(fake_bin))
+            .output()
+            .unwrap()
+    }
+
+    #[cfg(target_os = "linux")]
+    fn wait_for_child_workspace_cwd(child: &Child, workspace_dir: &Path) {
+        let cwd_path = format!("/proc/{}/cwd", child.id());
+        let deadline = Instant::now() + Duration::from_secs(2);
+        while Instant::now() < deadline {
+            if fs::read_link(&cwd_path).ok().as_deref() == Some(workspace_dir) {
+                return;
+            }
+            std::thread::sleep(Duration::from_millis(10));
+        }
+        panic!(
+            "holder process did not enter workspace cwd: pid={} workspace={}",
+            child.id(),
+            workspace_dir.display()
+        );
+    }
+
+    #[cfg(target_os = "linux")]
+    fn wait_for_child_workspace_exe(child: &Child, workspace_dir: &Path) {
+        let exe_path = format!("/proc/{}/exe", child.id());
+        let deadline = Instant::now() + Duration::from_secs(2);
+        while Instant::now() < deadline {
+            if fs::read_link(&exe_path)
+                .ok()
+                .is_some_and(|path| path.starts_with(workspace_dir))
+            {
+                return;
+            }
+            std::thread::sleep(Duration::from_millis(10));
+        }
+        panic!(
+            "holder process did not execute from workspace: pid={} workspace={}",
+            child.id(),
+            workspace_dir.display()
+        );
+    }
+
+    #[cfg(target_os = "linux")]
+    fn sleep_binary_path() -> &'static str {
+        for candidate in ["/bin/sleep", "/usr/bin/sleep"] {
+            if Path::new(candidate).is_file() {
+                return candidate;
+            }
+        }
+        panic!("sleep binary not found");
+    }
+
+    #[cfg(target_os = "linux")]
+    fn wait_for_child_exit_or_kill(child: &mut Child) -> Option<ExitStatus> {
+        let deadline = Instant::now() + Duration::from_secs(2);
+        while Instant::now() < deadline {
+            if let Some(status) = child.try_wait().unwrap() {
+                return Some(status);
+            }
+            std::thread::sleep(Duration::from_millis(10));
+        }
+        if let Some(status) = child.try_wait().unwrap() {
+            return Some(status);
+        }
+        let _ = child.kill();
+        let _ = child.wait().unwrap();
+        None
+    }
+
     #[test]
     fn shell_quote_handles_single_quotes() {
         assert_eq!(shell_quote("/tmp/a'b"), "'/tmp/a'\\''b'");
@@ -165,6 +368,173 @@ mod tests {
         assert!(cmd.contains("workspace_device='/dev/vdb'"));
         assert!(cmd.contains("sync -f -- \"$workspace_dir\""));
         assert!(cmd.contains("umount -- \"$workspace_dir\""));
+        assert_eq!(cmd.matches("umount -- \"$workspace_dir\"").count(), 2);
+    }
+
+    #[test]
+    fn unmount_script_leaves_workspace_cwd_before_clean_unmount() {
+        let temp = tempfile::tempdir().unwrap();
+        let workspace_dir = temp.path().join("workspace");
+        let workspace_device = temp.path().join("vdb");
+        let fake_bin = temp.path().join("bin");
+        let log_path = temp.path().join("calls.log");
+        fs::create_dir(&workspace_dir).unwrap();
+        fs::create_dir(&fake_bin).unwrap();
+        write_fake_mountpoint(&fake_bin, &workspace_dir, &workspace_device);
+        write_fake_sync(&fake_bin, &log_path);
+        write_successful_fake_umount(&fake_bin, &log_path);
+
+        let output = run_unmount_script(&workspace_dir, &workspace_device, &fake_bin);
+
+        assert!(
+            output.status.success(),
+            "stderr={} stdout={}",
+            String::from_utf8_lossy(&output.stderr),
+            String::from_utf8_lossy(&output.stdout)
+        );
+        let log = fs::read_to_string(log_path).unwrap();
+        assert!(log.contains("sync cwd=/ args=-f --"));
+        assert!(log.contains("umount cwd=/ args=--"));
+        assert!(log.contains(&workspace_dir.display().to_string()));
+        assert_eq!(log.matches("umount cwd=").count(), 1);
+    }
+
+    #[test]
+    #[cfg(target_os = "linux")]
+    fn unmount_script_terminates_workspace_cwd_holder_before_retry() {
+        let temp = tempfile::tempdir().unwrap();
+        let workspace_dir = temp.path().join("workspace");
+        let workspace_device = temp.path().join("vdb");
+        let fake_bin = temp.path().join("bin");
+        let log_path = temp.path().join("calls.log");
+        let count_path = temp.path().join("umount-count");
+        fs::create_dir(&workspace_dir).unwrap();
+        fs::create_dir(&fake_bin).unwrap();
+        write_fake_mountpoint(&fake_bin, &workspace_dir, &workspace_device);
+        write_fake_sync(&fake_bin, &log_path);
+        write_busy_then_successful_fake_umount(&fake_bin, &log_path, &count_path);
+
+        let mut holder = Command::new("sh")
+            .arg("-c")
+            .arg("cd \"$1\" && exec sleep 60")
+            .arg("holder")
+            .arg(&workspace_dir)
+            .spawn()
+            .unwrap();
+        wait_for_child_workspace_cwd(&holder, &workspace_dir);
+
+        let output = run_unmount_script(&workspace_dir, &workspace_device, &fake_bin);
+        let holder_status = wait_for_child_exit_or_kill(&mut holder);
+        let stderr = String::from_utf8_lossy(&output.stderr);
+        let stdout = String::from_utf8_lossy(&output.stdout);
+
+        assert!(output.status.success(), "stderr={stderr} stdout={stdout}");
+        let holder_status = holder_status
+            .unwrap_or_else(|| panic!("holder process was still running: stderr={stderr}"));
+        assert!(
+            !holder_status.success(),
+            "holder should be terminated by signal"
+        );
+        assert!(stderr.contains("workspace drive unmount failed; diagnosing holders"));
+        assert!(stderr.contains("workspace holder:"));
+        assert!(stderr.contains(&format!("pid={}", holder.id())));
+        assert!(stderr.contains("ref=cwd"));
+        let log = fs::read_to_string(log_path).unwrap();
+        assert_eq!(log.matches("umount call=").count(), 2);
+        assert!(log.contains("umount call=1 cwd=/ args=--"));
+        assert!(log.contains("umount call=2 cwd=/ args=--"));
+    }
+
+    #[test]
+    #[cfg(target_os = "linux")]
+    fn unmount_script_terminates_workspace_exe_holder_before_retry() {
+        let temp = tempfile::tempdir().unwrap();
+        let workspace_dir = temp.path().join("workspace");
+        let workspace_device = temp.path().join("vdb");
+        let fake_bin = temp.path().join("bin");
+        let log_path = temp.path().join("calls.log");
+        let count_path = temp.path().join("umount-count");
+        let holder_bin = workspace_dir.join("holder-sleep");
+        fs::create_dir(&workspace_dir).unwrap();
+        fs::create_dir(&fake_bin).unwrap();
+        fs::copy(sleep_binary_path(), &holder_bin).unwrap();
+        let mut permissions = fs::metadata(&holder_bin).unwrap().permissions();
+        permissions.set_mode(0o755);
+        fs::set_permissions(&holder_bin, permissions).unwrap();
+        write_fake_mountpoint(&fake_bin, &workspace_dir, &workspace_device);
+        write_fake_sync(&fake_bin, &log_path);
+        write_busy_then_successful_fake_umount(&fake_bin, &log_path, &count_path);
+
+        let mut holder = Command::new(&holder_bin)
+            .arg("60")
+            .current_dir(temp.path())
+            .spawn()
+            .unwrap();
+        wait_for_child_workspace_exe(&holder, &workspace_dir);
+
+        let output = run_unmount_script(&workspace_dir, &workspace_device, &fake_bin);
+        let holder_status = wait_for_child_exit_or_kill(&mut holder);
+        let stderr = String::from_utf8_lossy(&output.stderr);
+        let stdout = String::from_utf8_lossy(&output.stdout);
+
+        assert!(output.status.success(), "stderr={stderr} stdout={stdout}");
+        let holder_status = holder_status
+            .unwrap_or_else(|| panic!("holder process was still running: stderr={stderr}"));
+        assert!(
+            !holder_status.success(),
+            "holder should be terminated by signal"
+        );
+        assert!(stderr.contains("workspace holder:"));
+        assert!(stderr.contains(&format!("pid={}", holder.id())));
+        assert!(stderr.contains("ref=exe"));
+        let log = fs::read_to_string(log_path).unwrap();
+        assert_eq!(log.matches("umount call=").count(), 2);
+        assert!(log.contains("umount call=1 cwd=/ args=--"));
+        assert!(log.contains("umount call=2 cwd=/ args=--"));
+    }
+
+    #[test]
+    #[cfg(target_os = "linux")]
+    fn unmount_script_kills_workspace_cwd_holder_that_ignores_term() {
+        let temp = tempfile::tempdir().unwrap();
+        let workspace_dir = temp.path().join("workspace");
+        let workspace_device = temp.path().join("vdb");
+        let fake_bin = temp.path().join("bin");
+        let log_path = temp.path().join("calls.log");
+        let count_path = temp.path().join("umount-count");
+        fs::create_dir(&workspace_dir).unwrap();
+        fs::create_dir(&fake_bin).unwrap();
+        write_fake_mountpoint(&fake_bin, &workspace_dir, &workspace_device);
+        write_fake_sync(&fake_bin, &log_path);
+        write_busy_then_successful_fake_umount(&fake_bin, &log_path, &count_path);
+
+        let mut holder = Command::new("sh")
+            .arg("-c")
+            .arg("trap '' TERM; cd \"$1\" && exec sleep 60")
+            .arg("holder")
+            .arg(&workspace_dir)
+            .spawn()
+            .unwrap();
+        wait_for_child_workspace_cwd(&holder, &workspace_dir);
+
+        let output = run_unmount_script(&workspace_dir, &workspace_device, &fake_bin);
+        let holder_status = wait_for_child_exit_or_kill(&mut holder);
+        let stderr = String::from_utf8_lossy(&output.stderr);
+        let stdout = String::from_utf8_lossy(&output.stdout);
+
+        assert!(output.status.success(), "stderr={stderr} stdout={stdout}");
+        let holder_status = holder_status
+            .unwrap_or_else(|| panic!("holder process was still running: stderr={stderr}"));
+        assert!(
+            !holder_status.success(),
+            "holder should be killed after ignoring TERM"
+        );
+        assert!(stderr.contains("workspace holders remain after TERM; sending KILL"));
+        assert!(stderr.contains(&format!("pid={}", holder.id())));
+        let log = fs::read_to_string(log_path).unwrap();
+        assert_eq!(log.matches("umount call=").count(), 2);
+        assert!(log.contains("umount call=1 cwd=/ args=--"));
+        assert!(log.contains("umount call=2 cwd=/ args=--"));
     }
 
     #[test]
@@ -182,7 +552,7 @@ mod tests {
     }
 
     #[test]
-    fn unmount_command_checks_mount_identity_before_sync_and_unmount() {
+    fn unmount_command_checks_mount_identity_before_sync_unmount_and_cleanup() {
         let cmd = workspace_unmount_command();
         let mountpoint_check = cmd
             .find("if ! mountpoint -q -- \"$workspace_dir\"")
@@ -190,8 +560,13 @@ mod tests {
         let identity_check = cmd
             .find("if [ -z \"$workspace_dev\" ] || [ \"$target_dev\" != \"$workspace_dev\" ]")
             .expect("workspace device identity check");
+        let leave_workspace_cwd = cmd.find("cd /").expect("leave workspace cwd");
         let sync = cmd.find("sync -f -- \"$workspace_dir\"").expect("sync");
         let unmount = cmd.find("umount -- \"$workspace_dir\"").expect("umount");
+        let holder_scan = cmd
+            .find("for proc_dir in /proc/[0-9]*")
+            .expect("holder scan");
+        let kill = cmd.find("kill -TERM").expect("holder kill");
 
         assert!(
             mountpoint_check < identity_check,
@@ -202,8 +577,114 @@ mod tests {
             "device identity must be verified before sync"
         );
         assert!(
+            identity_check < leave_workspace_cwd,
+            "device identity must be verified before leaving cwd"
+        );
+        assert!(
+            leave_workspace_cwd < sync,
+            "script must leave a possible workspace cwd before sync"
+        );
+        assert!(
+            leave_workspace_cwd < unmount,
+            "script must leave a possible workspace cwd before unmount"
+        );
+        assert!(
             identity_check < unmount,
             "device identity must be verified before unmount"
         );
+        assert!(
+            identity_check < holder_scan,
+            "device identity must be verified before scanning holders"
+        );
+        assert!(
+            identity_check < kill,
+            "device identity must be verified before killing holders"
+        );
+        assert!(
+            unmount < holder_scan,
+            "clean unmount must be attempted before scanning holders"
+        );
+        assert!(
+            unmount < kill,
+            "clean unmount must be attempted before killing holders"
+        );
+    }
+
+    #[test]
+    fn unmount_command_diagnoses_and_cleans_workspace_holders_before_retry() {
+        let cmd = workspace_unmount_command();
+
+        assert!(cmd.contains("scan_proc_ref \"$pid\" cwd \"$proc_dir/cwd\""));
+        assert!(cmd.contains("scan_proc_ref \"$pid\" root \"$proc_dir/root\""));
+        assert!(cmd.contains("scan_proc_ref \"$pid\" exe \"$proc_dir/exe\""));
+        assert!(cmd.contains("for fd_ref in \"$proc_dir\"/fd/*"));
+        assert!(cmd.contains("scan_proc_maps \"$pid\" \"$proc_dir/maps\""));
+        assert!(cmd.contains("\"$workspace_dir\"|\"$workspace_dir\"/*) return 0 ;;"));
+        assert!(cmd.contains("stripped_target=${target%\"$deleted_suffix\"}"));
+        assert!(cmd.contains("proc_path_has_workspace_ref()"));
+        assert!(cmd.contains("proc_maps_has_workspace_ref()"));
+        assert!(cmd.contains("if pid_has_workspace_ref \"$pid\"; then"));
+        assert!(cmd.contains("if proc_path_has_workspace_ref \"$proc_dir/exe\"; then"));
+        assert!(cmd.contains("if proc_maps_has_workspace_ref \"$proc_dir/maps\"; then"));
+        assert!(cmd.contains("WORKSPACE_HOLDER_DIAGNOSTIC_LIMIT=40"));
+        assert!(cmd.contains("WORKSPACE_HOLDER_VALUE_LIMIT=240"));
+        assert!(cmd.contains("WORKSPACE_HOLDER_KILL_GRACE_SECONDS=1"));
+        assert!(cmd.contains("workspace holder diagnostics truncated"));
+        assert!(cmd.contains("pid=%s uid=%s comm=%s ref=%s path=%s"));
+        assert!(cmd.contains("comm=\"$(sanitize_log_value \"$comm\")\""));
+        assert!(cmd.contains("target=\"$(sanitize_log_value \"$target\")\""));
+        assert!(cmd.contains("pid_has_workspace_ref \"$pid\" || continue"));
+        assert!(cmd.contains("[ \"$pid\" != \"$$\" ] || continue"));
+        assert!(cmd.contains("[ \"$pid\" != \"1\" ] || continue"));
+
+        let clean_unmount = cmd
+            .find("if umount -- \"$workspace_dir\"")
+            .expect("clean unmount");
+        let diagnose = cmd
+            .find("holder_pids=\"$(workspace_holder_pids)\"")
+            .expect("holder pid collection");
+        let term = cmd
+            .find("term_workspace_holder_pids \"$holder_pids\"")
+            .expect("TERM holders");
+        let rescan = cmd
+            .find("remaining_holder_pids=\"$(workspace_holder_pids)\"")
+            .expect("holder rescan");
+        let kill = cmd
+            .find("kill_workspace_holder_pids \"$remaining_holder_pids\"")
+            .expect("KILL remaining holders");
+        let kill_sleep = find_after(&cmd, "sleep \"$WORKSPACE_HOLDER_KILL_GRACE_SECONDS\"", kill);
+        let retry_sync = find_after(&cmd, "sync -f -- \"$workspace_dir\"", kill_sleep);
+        let retry_unmount = find_after(&cmd, "umount -- \"$workspace_dir\"", retry_sync);
+
+        assert!(
+            clean_unmount < diagnose,
+            "holder diagnosis must only happen after clean unmount fails"
+        );
+        assert!(diagnose < term, "holders must be diagnosed before TERM");
+        assert!(term < rescan, "holders must be rescanned after TERM");
+        assert!(
+            rescan < kill,
+            "KILL must only target holders confirmed by the rescan"
+        );
+        assert!(kill < retry_sync, "cleanup must happen before retry sync");
+        assert!(
+            kill < kill_sleep,
+            "KILL must have a short grace period before retry sync"
+        );
+        assert!(
+            retry_sync < retry_unmount,
+            "retry sync must happen before retry unmount"
+        );
+    }
+
+    #[test]
+    fn unmount_command_avoids_lazy_unmount_and_broad_cleanup() {
+        let cmd = workspace_unmount_command();
+
+        assert!(!cmd.contains("umount -l"));
+        assert!(!cmd.contains("pkill"));
+        assert!(!cmd.contains("killall"));
+        assert!(!cmd.contains("cmdline"));
+        assert!(!cmd.contains("environ"));
     }
 }


### PR DESCRIPTION
## Summary
- keep the workspace unmount clean path first and only inspect processes after the first unmount fails
- diagnose bounded /proc cwd/root/fd workspace holders without logging cmdline or environment data
- TERM confirmed workspace holders, rescan, KILL only remaining confirmed holders, then retry sync and unmount
- add script-shape tests for ordering, diagnostics, retry behavior, and no lazy or broad cleanup

## Testing
- sh -n crates/runner/scripts/unmount-workspace-drive.sh
- cargo test --manifest-path crates/Cargo.toml -p runner workspace_mount
- cargo test --manifest-path crates/Cargo.toml -p runner workspace_promotion
- cargo fmt --manifest-path crates/Cargo.toml --all --check
- cargo test --manifest-path crates/Cargo.toml -p runner
- cargo clippy --manifest-path crates/Cargo.toml -p runner --all-targets -- -D warnings
- pre-commit hook: cargo-fmt, cargo-clippy --all-targets --all-features, cargo-doc, commitlint

Closes #16386