### PR TITLE
ci: manage stripe preview webhooks per pr

### DIFF
--- a/.github/actions/web-api-env/action.yml
+++ b/.github/actions/web-api-env/action.yml
@@ -193,6 +193,9 @@ runs:
         if [[ "$INPUT_APP" == "api" ]]; then
           add_env VM0_WEB_URL "$web_url"
           add_env ENV "$deploy_env"
+          if [[ "$INPUT_ENVIRONMENT" == "preview" && -n "$INPUT_JOB_REF" ]]; then
+            add_env VM0_PREVIEW_JOB_REF "$INPUT_JOB_REF"
+          fi
         fi
         # Inject the workflow head commit explicitly so OTel / Sentry can tag
         # service.version and release on every deploy. Vercel CLI prebuilt

--- a/.github/scripts/stripe-preview-webhook.sh
+++ b/.github/scripts/stripe-preview-webhook.sh
@@ -89,8 +89,11 @@ list_matching_endpoint_ids() {
     ids="$(jq -r --arg job_ref "$JOB_REF" --arg url "$webhook_url" '
       .data[]
       | select(
-          (.metadata.job_ref // "") == $job_ref
-          or ($url != "" and .url == $url)
+          (.metadata.managed_by // "") == "github-actions"
+          and (
+            (.metadata.job_ref // "") == $job_ref
+            or ($url != "" and .url == $url)
+          )
         )
       | .id
     ' <<<"$response")"

--- a/.github/scripts/stripe-preview-webhook.sh
+++ b/.github/scripts/stripe-preview-webhook.sh
@@ -1,0 +1,236 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+EVENTS=(
+  checkout.session.completed
+  checkout.session.async_payment_succeeded
+  invoice.paid
+  customer.subscription.created
+  customer.subscription.updated
+  customer.subscription.deleted
+  subscription_schedule.released
+  subscription_schedule.canceled
+  subscription_schedule.aborted
+)
+
+usage() {
+  cat >&2 <<'USAGE'
+Usage:
+  .github/scripts/stripe-preview-webhook.sh upsert
+  .github/scripts/stripe-preview-webhook.sh cleanup
+
+Required environment:
+  STRIPE_SECRET_KEY
+  JOB_REF
+
+Additional environment for upsert:
+  API_ENV_FILE
+
+Optional environment:
+  API_PREVIEW_URL
+USAGE
+}
+
+require_env() {
+  local key="$1"
+  if [[ -z "${!key:-}" ]]; then
+    echo "::error::${key} is required" >&2
+    exit 1
+  fi
+}
+
+install_stripe_cli() {
+  export PATH="$HOME/.local/bin:$PATH"
+  bash e2e/scripts/ensure-stripe-cli.sh >/dev/null
+}
+
+stripe_with_retry() {
+  local attempt
+  local delay=2
+  local output
+  local status
+
+  for attempt in 1 2 3 4 5; do
+    status=0
+    output="$(stripe --api-key "$STRIPE_SECRET_KEY" "$@" 2>&1)" || status=$?
+    if [[ "$status" -eq 0 ]]; then
+      printf '%s\n' "$output"
+      return 0
+    fi
+
+    if [[ "$attempt" -eq 5 ]] || ! grep -Eiq 'rate limit|too many requests| 429\b|status=429' <<<"$output"; then
+      printf '%s\n' "$output" >&2
+      return "$status"
+    fi
+
+    echo "Stripe API rate limited; retrying in ${delay}s (attempt ${attempt}/5)" >&2
+    sleep "$delay"
+    delay=$((delay * 2))
+  done
+}
+
+preview_pr_number() {
+  sed -nE 's/^pr-([0-9]+)$/\1/p' <<<"$JOB_REF"
+}
+
+list_matching_endpoint_ids() {
+  local webhook_url="${1:-}"
+  local starting_after=""
+  local response
+  local ids
+
+  while true; do
+    if [[ -n "$starting_after" ]]; then
+      response="$(stripe_with_retry webhook_endpoints list --limit 100 --starting-after "$starting_after")"
+    else
+      response="$(stripe_with_retry webhook_endpoints list --limit 100)"
+    fi
+
+    ids="$(jq -r --arg job_ref "$JOB_REF" --arg url "$webhook_url" '
+      .data[]
+      | select(
+          (.metadata.job_ref // "") == $job_ref
+          or ($url != "" and .url == $url)
+        )
+      | .id
+    ' <<<"$response")"
+    if [[ -n "$ids" ]]; then
+      printf '%s\n' "$ids"
+    fi
+
+    if [[ "$(jq -r '.has_more' <<<"$response")" != "true" ]]; then
+      break
+    fi
+
+    starting_after="$(jq -r '.data[-1].id // ""' <<<"$response")"
+    if [[ -z "$starting_after" ]]; then
+      break
+    fi
+  done
+}
+
+delete_matching_endpoints() {
+  local webhook_url="${1:-}"
+  local endpoint_id
+  local endpoint_ids
+
+  endpoint_ids="$(list_matching_endpoint_ids "$webhook_url")"
+
+  while IFS= read -r endpoint_id; do
+    if [[ -z "$endpoint_id" ]]; then
+      continue
+    fi
+    echo "Deleting Stripe webhook endpoint ${endpoint_id} for ${JOB_REF}"
+    stripe_with_retry webhook_endpoints delete "$endpoint_id" --confirm >/dev/null
+  done <<<"$endpoint_ids"
+}
+
+write_env_secret() {
+  local webhook_secret="$1"
+
+  if grep -q '^STRIPE_WEBHOOK_SECRET=' "$API_ENV_FILE"; then
+    sed -i "s|^STRIPE_WEBHOOK_SECRET=.*|STRIPE_WEBHOOK_SECRET=${webhook_secret}|" "$API_ENV_FILE"
+  else
+    printf 'STRIPE_WEBHOOK_SECRET=%s\n' "$webhook_secret" >> "$API_ENV_FILE"
+  fi
+}
+
+upsert_endpoint() {
+  require_env API_ENV_FILE
+
+  local pr_number
+  pr_number="$(preview_pr_number)"
+  if [[ -z "$pr_number" ]]; then
+    echo "Skipping Stripe preview webhook setup for non-PR job ref: ${JOB_REF}"
+    return 0
+  fi
+  if [[ -z "${API_PREVIEW_URL:-}" ]]; then
+    echo "Skipping Stripe preview webhook setup because API_PREVIEW_URL is empty"
+    return 0
+  fi
+
+  local webhook_url="${API_PREVIEW_URL%/}/api/webhooks/stripe"
+  delete_matching_endpoints "$webhook_url"
+
+  local create_args=(
+    webhook_endpoints create
+    --confirm
+    --description "vm0 API preview webhook for ${JOB_REF}"
+    --url "$webhook_url"
+    -d "metadata[managed_by]=github-actions"
+    -d "metadata[job_ref]=${JOB_REF}"
+    -d "metadata[github_pr]=${pr_number}"
+  )
+  if [[ -n "${GITHUB_REPOSITORY:-}" ]]; then
+    create_args+=(-d "metadata[github_repository]=${GITHUB_REPOSITORY}")
+  fi
+  if [[ -n "${GITHUB_RUN_ID:-}" ]]; then
+    create_args+=(-d "metadata[github_run_id]=${GITHUB_RUN_ID}")
+  fi
+  local event
+  for event in "${EVENTS[@]}"; do
+    create_args+=(--enabled-events "$event")
+  done
+
+  local endpoint
+  endpoint="$(stripe_with_retry "${create_args[@]}")"
+
+  local endpoint_id webhook_secret
+  endpoint_id="$(jq -r '.id // ""' <<<"$endpoint")"
+  webhook_secret="$(jq -r '.secret // ""' <<<"$endpoint")"
+  echo "::add-mask::${webhook_secret}"
+
+  if [[ "$endpoint_id" != we_* ]]; then
+    echo "::error::Stripe did not return a webhook endpoint id" >&2
+    exit 1
+  fi
+  if [[ "$webhook_secret" != whsec_* ]]; then
+    echo "::error::Stripe did not return a webhook signing secret" >&2
+    exit 1
+  fi
+
+  write_env_secret "$webhook_secret"
+  echo "Configured Stripe webhook endpoint ${endpoint_id} for ${webhook_url}"
+}
+
+cleanup_endpoint() {
+  local pr_number
+  pr_number="$(preview_pr_number)"
+  if [[ -z "$pr_number" ]]; then
+    echo "Skipping Stripe preview webhook cleanup for non-PR job ref: ${JOB_REF}"
+    return 0
+  fi
+
+  local webhook_url="${API_PREVIEW_URL:-}"
+  if [[ -n "$webhook_url" ]]; then
+    webhook_url="${webhook_url%/}/api/webhooks/stripe"
+  fi
+  delete_matching_endpoints "$webhook_url"
+  echo "Cleaned up Stripe webhook endpoints for ${JOB_REF}"
+}
+
+main() {
+  if [[ "$#" -ne 1 ]]; then
+    usage
+    exit 1
+  fi
+
+  require_env STRIPE_SECRET_KEY
+  require_env JOB_REF
+  install_stripe_cli
+
+  case "$1" in
+    upsert)
+      upsert_endpoint
+      ;;
+    cleanup)
+      cleanup_endpoint
+      ;;
+    *)
+      usage
+      exit 1
+      ;;
+  esac
+}
+
+main "$@"

--- a/.github/scripts/tests/stripe-preview-webhook-test.sh
+++ b/.github/scripts/tests/stripe-preview-webhook-test.sh
@@ -1,0 +1,153 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../../.." && pwd)"
+SCRIPT="${REPO_ROOT}/.github/scripts/stripe-preview-webhook.sh"
+TMPDIR="$(mktemp -d)"
+trap 'rm -rf "$TMPDIR"' EXIT
+
+fail() {
+  echo "FAIL: $1" >&2
+  exit 1
+}
+
+assert_contains() {
+  local file="$1"
+  local expected="$2"
+  grep -Fq -- "$expected" "$file" ||
+    fail "expected ${file} to contain: ${expected}"
+}
+
+assert_not_contains() {
+  local file="$1"
+  local unexpected="$2"
+  if grep -Fq -- "$unexpected" "$file"; then
+    fail "did not expect ${file} to contain: ${unexpected}"
+  fi
+}
+
+HOME_DIR="${TMPDIR}/home"
+FAKE_BIN="${HOME_DIR}/.local/bin"
+mkdir -p "$FAKE_BIN"
+
+cat > "${FAKE_BIN}/stripe" <<'BASH'
+#!/usr/bin/env bash
+set -euo pipefail
+
+if [[ "${1:-}" == "--version" ]]; then
+  echo "stripe version fake"
+  exit 0
+fi
+
+printf '%s\n' "$*" >> "$STRIPE_ARGS_LOG"
+
+if [[ "${1:-}" == "--api-key" ]]; then
+  shift 2
+fi
+
+case "${1:-} ${2:-}" in
+  "webhook_endpoints list")
+    cat "$FAKE_STRIPE_LIST_JSON"
+    ;;
+  "webhook_endpoints delete")
+    printf '{"id":"%s","deleted":true}\n' "$3"
+    ;;
+  "webhook_endpoints create")
+    printf '{"id":"we_new","secret":"whsec_new"}\n'
+    ;;
+  *)
+    echo "unexpected stripe call: $*" >&2
+    exit 1
+    ;;
+esac
+BASH
+chmod +x "${FAKE_BIN}/stripe"
+
+LIST_JSON="${TMPDIR}/endpoints.json"
+cat > "$LIST_JSON" <<'JSON'
+{
+  "data": [
+    {
+      "id": "we_managed_job",
+      "url": "https://old.example.test/api/webhooks/stripe",
+      "metadata": {
+        "managed_by": "github-actions",
+        "job_ref": "pr-123"
+      }
+    },
+    {
+      "id": "we_managed_url",
+      "url": "https://pr-123-api.vm0.test/api/webhooks/stripe",
+      "metadata": {
+        "managed_by": "github-actions",
+        "job_ref": "pr-456"
+      }
+    },
+    {
+      "id": "we_unmanaged_job",
+      "url": "https://unmanaged.example.test/api/webhooks/stripe",
+      "metadata": {
+        "job_ref": "pr-123"
+      }
+    },
+    {
+      "id": "we_unmanaged_url",
+      "url": "https://pr-123-api.vm0.test/api/webhooks/stripe",
+      "metadata": {}
+    }
+  ],
+  "has_more": false
+}
+JSON
+
+ARGS_LOG="${TMPDIR}/stripe-args.log"
+API_ENV_FILE="${TMPDIR}/api.env"
+printf 'STRIPE_WEBHOOK_SECRET=whsec_old\n' > "$API_ENV_FILE"
+
+HOME="$HOME_DIR" \
+  PATH="${FAKE_BIN}:${PATH}" \
+  STRIPE_ARGS_LOG="$ARGS_LOG" \
+  FAKE_STRIPE_LIST_JSON="$LIST_JSON" \
+  STRIPE_SECRET_KEY="sk_test_fake" \
+  JOB_REF="pr-123" \
+  API_PREVIEW_URL="https://pr-123-api.vm0.test" \
+  API_ENV_FILE="$API_ENV_FILE" \
+  bash "$SCRIPT" upsert >/tmp/stripe-preview-webhook-upsert.out
+
+assert_contains "$ARGS_LOG" "webhook_endpoints delete we_managed_job --confirm"
+assert_contains "$ARGS_LOG" "webhook_endpoints delete we_managed_url --confirm"
+assert_not_contains "$ARGS_LOG" "webhook_endpoints delete we_unmanaged_job --confirm"
+assert_not_contains "$ARGS_LOG" "webhook_endpoints delete we_unmanaged_url --confirm"
+assert_contains "$ARGS_LOG" "webhook_endpoints create"
+assert_contains "$ARGS_LOG" "--url https://pr-123-api.vm0.test/api/webhooks/stripe"
+assert_contains "$ARGS_LOG" "metadata[job_ref]=pr-123"
+assert_contains "$ARGS_LOG" "--enabled-events invoice.paid"
+assert_contains "$API_ENV_FILE" "STRIPE_WEBHOOK_SECRET=whsec_new"
+
+: > "$ARGS_LOG"
+HOME="$HOME_DIR" \
+  PATH="${FAKE_BIN}:${PATH}" \
+  STRIPE_ARGS_LOG="$ARGS_LOG" \
+  FAKE_STRIPE_LIST_JSON="$LIST_JSON" \
+  STRIPE_SECRET_KEY="sk_test_fake" \
+  JOB_REF="pr-123" \
+  bash "$SCRIPT" cleanup >/tmp/stripe-preview-webhook-cleanup.out
+
+assert_contains "$ARGS_LOG" "webhook_endpoints delete we_managed_job --confirm"
+assert_not_contains "$ARGS_LOG" "webhook_endpoints delete we_unmanaged_job --confirm"
+
+: > "$ARGS_LOG"
+HOME="$HOME_DIR" \
+  PATH="${FAKE_BIN}:${PATH}" \
+  STRIPE_ARGS_LOG="$ARGS_LOG" \
+  FAKE_STRIPE_LIST_JSON="$LIST_JSON" \
+  STRIPE_SECRET_KEY="sk_test_fake" \
+  JOB_REF="staging" \
+  API_ENV_FILE="$API_ENV_FILE" \
+  bash "$SCRIPT" upsert >/tmp/stripe-preview-webhook-staging.out
+
+if [[ -s "$ARGS_LOG" ]]; then
+  fail "expected non-PR upsert to skip Stripe API calls"
+fi
+
+echo "stripe-preview-webhook-test: ok"

--- a/.github/scripts/tests/web-api-env-action-test.sh
+++ b/.github/scripts/tests/web-api-env-action-test.sh
@@ -155,6 +155,7 @@ assert_env_value "$success_env_file" GOOGLE_ADS_DEVELOPER_TOKEN "github-google-a
 assert_env_value "$success_env_file" FINICITY_APP_KEY "github-finicity-app-key"
 assert_env_value "$success_env_file" FINICITY_APP_SECRET "github-finicity-app-secret"
 assert_env_value "$success_env_file" FINICITY_PARTNER_ID "github-finicity-partner-id"
+assert_env_value "$success_env_file" VM0_PREVIEW_JOB_REF "pr-123"
 assert_env_absent_value "$success_env_file" "github-gh-client-id"
 assert_env_absent_value "$success_env_file" "github-gh-client-secret"
 assert_env_absent_value "$success_env_file" "github-slack-client-id"

--- a/.github/workflows/cleanup-stale.yml
+++ b/.github/workflows/cleanup-stale.yml
@@ -326,6 +326,7 @@ jobs:
   cleanup-stripe-webhooks:
     runs-on: ubuntu-latest
     permissions:
+      contents: read
       pull-requests: read
     steps:
       - uses: actions/checkout@v6

--- a/.github/workflows/cleanup-stale.yml
+++ b/.github/workflows/cleanup-stale.yml
@@ -323,6 +323,69 @@ jobs:
           echo "Cleaned: $CLEANED"
           echo "Failures: $FAILED"
 
+  cleanup-stripe-webhooks:
+    runs-on: ubuntu-latest
+    permissions:
+      pull-requests: read
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Check if cleanup needed
+        id: check
+        env:
+          STRIPE_SECRET_KEY: ${{ secrets.STRIPE_SECRET_KEY }}
+        run: |
+          if [ -z "$STRIPE_SECRET_KEY" ]; then
+            echo "Stripe secret not available, skipping webhook cleanup"
+            echo "should-cleanup=false" >> "$GITHUB_OUTPUT"
+          else
+            echo "should-cleanup=true" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Find recently closed PRs
+        if: steps.check.outputs.should-cleanup == 'true'
+        id: prs
+        uses: actions/github-script@v9
+        with:
+          script: |
+            const since = new Date(Date.now() - 2 * 24 * 60 * 60 * 1000).toISOString();
+            const { data: pulls } = await github.rest.pulls.list({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              state: 'closed',
+              sort: 'updated',
+              direction: 'desc',
+              per_page: 100
+            });
+            const recent = pulls
+              .filter(pr => pr.closed_at && pr.closed_at >= since)
+              .map(pr => pr.number);
+            console.log(`Found ${recent.length} PRs closed since ${since}: ${recent.join(', ')}`);
+            core.setOutput('numbers', JSON.stringify(recent));
+            core.setOutput('has-prs', recent.length > 0 ? 'true' : 'false');
+
+      - name: Cleanup stale Stripe webhooks
+        if: steps.check.outputs.should-cleanup == 'true' && steps.prs.outputs.has-prs == 'true'
+        env:
+          PR_NUMBERS: ${{ steps.prs.outputs.numbers }}
+          STRIPE_SECRET_KEY: ${{ secrets.STRIPE_SECRET_KEY }}
+          DRY_RUN: ${{ env.DRY_RUN }}
+        run: |
+          CLEANED=0
+          for PR_NUMBER in $(echo "$PR_NUMBERS" | jq -r '.[]'); do
+            JOB_REF="pr-${PR_NUMBER}"
+            if [ "$DRY_RUN" = "true" ]; then
+              echo "[DRY-RUN] Would cleanup Stripe webhook endpoint for ${JOB_REF}"
+            else
+              JOB_REF="$JOB_REF" bash .github/scripts/stripe-preview-webhook.sh cleanup
+            fi
+            CLEANED=$((CLEANED + 1))
+          done
+
+          echo ""
+          echo "=== Stripe Webhook Cleanup Summary ==="
+          echo "Cleaned: $CLEANED"
+
   cleanup-clerk-test-users:
     runs-on: ubuntu-latest
     permissions:

--- a/.github/workflows/cleanup.yml
+++ b/.github/workflows/cleanup.yml
@@ -94,6 +94,24 @@ jobs:
           branch-name: "pr-${{ github.event.pull_request.number }}"
           action: "cleanup"
 
+  cleanup-stripe-webhook:
+    # Delete the per-PR Stripe webhook endpoint created for API preview.
+    if: "!startsWith(github.head_ref || '', 'release-please--branches--')"
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Delete Stripe webhook endpoint
+        env:
+          JOB_REF: pr-${{ github.event.pull_request.number }}
+          STRIPE_SECRET_KEY: ${{ secrets.STRIPE_SECRET_KEY }}
+        run: |
+          if [ -z "$STRIPE_SECRET_KEY" ]; then
+            echo "Stripe secret not available, skipping webhook cleanup"
+            exit 0
+          fi
+          bash .github/scripts/stripe-preview-webhook.sh cleanup
+
   cleanup-test-users:
     # Delete Clerk test users created by e2e browser tests for this PR
     if: "!startsWith(github.head_ref || '', 'release-please--branches--')"

--- a/.github/workflows/turbo.yml
+++ b/.github/workflows/turbo.yml
@@ -883,7 +883,7 @@ jobs:
           REPO_SECRETS_JSON: ${{ toJSON(secrets) }}
           DOPPLER_SECRETS_JSON: ${{ toJSON(steps.doppler-oauth.outputs) }}
 
-      - name: Use Stripe CLI webhook secret for API preview
+      - name: Configure Stripe webhook endpoint for API preview
         if: |
           needs.prepare.outputs.web-changed == 'true' ||
           needs.prepare.outputs.api-changed == 'true' ||
@@ -895,25 +895,11 @@ jobs:
           needs.prepare.outputs.api-backend-needed == 'true'
         run: |
           set -euo pipefail
-          export PATH="$HOME/.local/bin:$PATH"
-          bash e2e/scripts/ensure-stripe-cli.sh
-
-          stripe_webhook_secret="$(stripe listen --api-key "$STRIPE_SECRET_KEY" --print-secret 2>/dev/null)"
-          echo "::add-mask::$stripe_webhook_secret"
-          if [[ "$stripe_webhook_secret" != whsec_* ]]; then
-            echo "Stripe CLI did not return a webhook signing secret" >&2
-            exit 1
-          fi
-
-          if grep -q '^STRIPE_WEBHOOK_SECRET=' "$API_ENV_FILE"; then
-            sed -i "s|^STRIPE_WEBHOOK_SECRET=.*|STRIPE_WEBHOOK_SECRET=${stripe_webhook_secret}|" "$API_ENV_FILE"
-          else
-            printf 'STRIPE_WEBHOOK_SECRET=%s\n' "$stripe_webhook_secret" >> "$API_ENV_FILE"
-          fi
-
-          echo "Configured API preview to trust Stripe CLI webhooks"
+          bash .github/scripts/stripe-preview-webhook.sh upsert
         env:
           API_ENV_FILE: ${{ steps.api-deploy-env.outputs.file }}
+          API_PREVIEW_URL: ${{ needs.prepare.outputs.api-preview-url }}
+          JOB_REF: ${{ needs.prepare.outputs.job-ref }}
           STRIPE_SECRET_KEY: ${{ secrets.STRIPE_SECRET_KEY }}
 
       - name: Deploy API to Vercel
@@ -1360,42 +1346,6 @@ jobs:
         run: cd e2e && npm ci
       - name: Install Playwright browsers
         run: cd e2e && npx playwright install --with-deps chromium
-      - name: Start Stripe webhook forwarding
-        run: |
-          set -euo pipefail
-          export PATH="$HOME/.local/bin:$PATH"
-          bash e2e/scripts/ensure-stripe-cli.sh
-
-          stripe_webhook_secret="$(stripe listen --api-key "$STRIPE_SECRET_KEY" --print-secret 2>/dev/null)"
-          echo "::add-mask::$stripe_webhook_secret"
-
-          forward_url="${API_PREVIEW_URL%/}/api/webhooks/stripe"
-          stripe listen \
-            --api-key "$STRIPE_SECRET_KEY" \
-            --events checkout.session.completed,invoice.paid,customer.subscription.updated,customer.subscription.deleted \
-            --forward-to "$forward_url" \
-            > /tmp/stripe-listen.log 2>&1 &
-          stripe_pid="$!"
-          echo "$stripe_pid" > /tmp/stripe-listen.pid
-
-          for _ in {1..10}; do
-            if grep -qi 'ready' /tmp/stripe-listen.log; then
-              echo "Stripe webhook forwarding started for $forward_url"
-              exit 0
-            fi
-            if ! kill -0 "$stripe_pid" 2>/dev/null; then
-              sed -E 's/whsec_[[:alnum:]_]+/[masked-stripe-webhook-secret]/g' /tmp/stripe-listen.log >&2
-              exit 1
-            fi
-            sleep 1
-          done
-
-          echo "Stripe CLI did not become ready" >&2
-          sed -E 's/whsec_[[:alnum:]_]+/[masked-stripe-webhook-secret]/g' /tmp/stripe-listen.log >&2
-          exit 1
-        env:
-          API_PREVIEW_URL: ${{ needs.prepare.outputs.api-preview-url }}
-          STRIPE_SECRET_KEY: ${{ secrets.STRIPE_SECRET_KEY }}
       - name: Run Playwright E2E tests
         run: cd e2e && npx playwright test --config playwright/playwright.config.ts
         env:
@@ -1403,18 +1353,6 @@ jobs:
           CLERK_PUBLISHABLE_KEY: ${{ vars.CLERK_PUBLISHABLE_KEY }}
           CLERK_SECRET_KEY: ${{ secrets.CLERK_SECRET_KEY }}
           JOB_REF: ${{ needs.prepare.outputs.job-ref }}
-      - name: Print Stripe webhook forwarding log
-        if: always()
-        run: |
-          if [[ -f /tmp/stripe-listen.log ]]; then
-            tail -200 /tmp/stripe-listen.log | sed -E 's/whsec_[[:alnum:]_]+/[masked-stripe-webhook-secret]/g'
-          fi
-      - name: Stop Stripe webhook forwarding
-        if: always()
-        run: |
-          if [[ -f /tmp/stripe-listen.pid ]]; then
-            kill "$(cat /tmp/stripe-listen.pid)" 2>/dev/null || true
-          fi
       - name: Upload Playwright report
         if: always()
         uses: actions/upload-artifact@v7

--- a/turbo/apps/api/src/signals/routes/__tests__/webhooks-third-party.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/webhooks-third-party.test.ts
@@ -2329,6 +2329,130 @@ describe("POST /api/webhooks/stripe", () => {
     );
   });
 
+  it("ignores preview Stripe invoices for a different job ref", async () => {
+    mockStripeWebhookEnv();
+    mockEnv("ENV", "preview");
+    mockOptionalEnv("VM0_PREVIEW_JOB_REF", "pr-123");
+
+    const response = await postStripeWebhookEvent({
+      type: "invoice.paid",
+      dataObject: {
+        id: stripeId("inv"),
+        customer: stripeId("cus"),
+        metadata: {},
+        lines: invoiceLinesWithSubscriptionPeriod(1_800_000_000),
+        parent: {
+          subscription_details: {
+            subscription: stripeId("sub"),
+            metadata: {
+              vm0_environment: "preview",
+              job_ref: "pr-456",
+            },
+          },
+        },
+      },
+    });
+
+    expect(response.status).toBe(200);
+    expect(response.body).toBe("OK");
+    expect(context.mocks.stripe.customers.retrieve).not.toHaveBeenCalled();
+    expect(context.mocks.stripe.subscriptions.retrieve).not.toHaveBeenCalled();
+  });
+
+  it("ignores preview Stripe checkout sessions for a different job ref", async () => {
+    mockStripeWebhookEnv();
+    mockEnv("ENV", "preview");
+    mockOptionalEnv("VM0_PREVIEW_JOB_REF", "pr-123");
+
+    const response = await postStripeWebhookEvent({
+      type: "checkout.session.completed",
+      dataObject: {
+        id: stripeId("cs"),
+        subscription: stripeId("sub"),
+        customer: stripeId("cus"),
+        metadata: {
+          vm0_environment: "preview",
+          job_ref: "pr-456",
+        },
+      },
+    });
+
+    expect(response.status).toBe(200);
+    expect(response.body).toBe("OK");
+    expect(context.mocks.stripe.subscriptions.retrieve).not.toHaveBeenCalled();
+  });
+
+  it("ignores preview Stripe subscriptions for a different job ref", async () => {
+    mockStripeWebhookEnv();
+    mockEnv("ENV", "preview");
+    mockOptionalEnv("VM0_PREVIEW_JOB_REF", "pr-123");
+
+    const response = await postStripeWebhookEvent({
+      type: "customer.subscription.created",
+      dataObject: {
+        id: stripeId("sub"),
+        customer: stripeId("cus"),
+        status: "active",
+        metadata: {
+          vm0_environment: "preview",
+          job_ref: "pr-456",
+        },
+        cancel_at_period_end: false,
+        items: {
+          data: [{ price: { id: STRIPE_PRICE_PRO } }],
+        },
+      },
+    });
+
+    expect(response.status).toBe(200);
+    expect(response.body).toBe("OK");
+    expect(context.mocks.stripe.customers.retrieve).not.toHaveBeenCalled();
+  });
+
+  it("processes preview Stripe invoices with the current subscription job ref", async () => {
+    const fixture = await trackStripe(
+      store.set(seedStripeFixture$, undefined, context.signal),
+    );
+    mockStripeWebhookEnv();
+    mockEnv("ENV", "preview");
+    mockOptionalEnv("VM0_PREVIEW_JOB_REF", "pr-123");
+    const subId = stripeId("sub");
+    const invId = stripeId("inv");
+    const periodEnd = 1_800_000_000;
+    context.mocks.stripe.subscriptions.retrieve.mockResolvedValue({
+      id: subId,
+      status: "active",
+      cancel_at_period_end: false,
+      items: { data: [{ price: { id: STRIPE_PRICE_PRO } }] },
+    });
+
+    const response = await postStripeWebhookEvent({
+      type: "invoice.paid",
+      dataObject: {
+        id: invId,
+        customer: fixture.stripeCustomerId,
+        metadata: {},
+        lines: invoiceLinesWithSubscriptionPeriod(periodEnd),
+        parent: {
+          subscription_details: {
+            subscription: subId,
+            metadata: {
+              vm0_environment: "preview",
+              job_ref: "pr-123",
+            },
+          },
+        },
+      },
+    });
+
+    expect(response.status).toBe(200);
+    const billing = await selectStripeBilling(fixture);
+    expect(billing.credits).toBe(20_000);
+    expect(billing.tier).toBe("pro");
+    expect(billing.stripeSubscriptionId).toBe(subId);
+    expect(billing.lastProcessedInvoiceId).toBe(invId);
+  });
+
   describe("checkout.session.completed", () => {
     it("records subscription checkout without granting invoice-backed entitlement", async () => {
       const fixture = await trackStripe(

--- a/turbo/apps/api/src/signals/routes/__tests__/zero-billing-checkout.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/zero-billing-checkout.test.ts
@@ -280,6 +280,65 @@ describe("POST /api/zero/billing/checkout", () => {
     });
   });
 
+  it("tags preview Stripe checkout objects with the current job ref", async () => {
+    mockEnv("ENV", "preview");
+    mockOptionalEnv("VM0_PREVIEW_JOB_REF", "pr-123");
+    const fixture = await trackedSeed();
+    mocks.clerk.session(fixture.userId, fixture.orgId, "org:admin");
+
+    const customerId = `cus_${randomUUID().slice(0, 8)}`;
+    context.mocks.stripe.customers.create.mockResolvedValue({ id: customerId });
+    context.mocks.stripe.checkout.sessions.create.mockResolvedValue({
+      url: "https://checkout.stripe.com/session/preview",
+    });
+
+    const client = setupApp({ context })(zeroBillingCheckoutContract);
+
+    const response = await accept(
+      client.create({
+        body: {
+          tier: "pro",
+          successUrl: `${APP_ORIGIN}/billing?billing=success`,
+          cancelUrl: `${APP_ORIGIN}/billing?billing=canceled`,
+        },
+        headers: { authorization: "Bearer clerk-session" },
+      }),
+      [200],
+    );
+
+    expect(response.body).toStrictEqual({
+      url: "https://checkout.stripe.com/session/preview",
+    });
+    const expectedPreviewMetadata = {
+      vm0_environment: "preview",
+      job_ref: "pr-123",
+    };
+    expect(context.mocks.stripe.customers.create).toHaveBeenCalledWith({
+      metadata: {
+        orgId: fixture.orgId,
+        ...expectedPreviewMetadata,
+      },
+    });
+    expect(context.mocks.stripe.checkout.sessions.create).toHaveBeenCalledWith(
+      expect.objectContaining({
+        metadata: {
+          orgId: fixture.orgId,
+          tier: "pro",
+          priceId: TEST_PRICE_PRO,
+          ...expectedPreviewMetadata,
+        },
+        subscription_data: expect.objectContaining({
+          metadata: {
+            orgId: fixture.orgId,
+            tier: "pro",
+            priceId: TEST_PRICE_PRO,
+            ...expectedPreviewMetadata,
+          },
+        }),
+      }),
+    );
+  });
+
   it("returns 400 when checkout would downgrade the current tier", async () => {
     const fixture = await trackedBillingSeed({
       stripeCustomerId: `cus_${randomUUID().slice(0, 8)}`,

--- a/turbo/apps/api/src/signals/services/billing-customer.service.ts
+++ b/turbo/apps/api/src/signals/services/billing-customer.service.ts
@@ -5,6 +5,7 @@ import { orgMetadata } from "@vm0/db/schema/org-metadata";
 import { writeDb$ } from "../external/db";
 import { nowDate } from "../external/time";
 import { getStripeClient } from "../external/stripe-client";
+import { stripePreviewMetadata } from "./stripe-preview-metadata.service";
 
 interface GetOrCreateStripeCustomerArgs {
   readonly orgId: string;
@@ -50,6 +51,7 @@ export const getOrCreateStripeCustomer$ = command(
           metadata[key] = value;
         }
       }
+      Object.assign(metadata, stripePreviewMetadata());
       const customer = await stripe.customers.create({ metadata });
       signal.throwIfAborted();
 

--- a/turbo/apps/api/src/signals/services/stripe-preview-metadata.service.ts
+++ b/turbo/apps/api/src/signals/services/stripe-preview-metadata.service.ts
@@ -1,0 +1,35 @@
+import { env, optionalEnv } from "../../lib/env";
+
+const PREVIEW_ENVIRONMENT_METADATA_KEY = "vm0_environment";
+const PREVIEW_JOB_REF_METADATA_KEY = "job_ref";
+
+function stripePreviewJobRef(): string | null {
+  if (env("ENV") !== "preview") {
+    return null;
+  }
+  return optionalEnv("VM0_PREVIEW_JOB_REF") ?? null;
+}
+
+export function stripePreviewMetadata(): Record<string, string> {
+  const jobRef = stripePreviewJobRef();
+  if (!jobRef) {
+    return {};
+  }
+  return {
+    [PREVIEW_ENVIRONMENT_METADATA_KEY]: "preview",
+    [PREVIEW_JOB_REF_METADATA_KEY]: jobRef,
+  };
+}
+
+export function isCurrentStripePreviewMetadata(
+  metadata: Readonly<Record<string, string>> | null | undefined,
+): boolean {
+  const jobRef = stripePreviewJobRef();
+  if (!jobRef) {
+    return true;
+  }
+  return (
+    metadata?.[PREVIEW_ENVIRONMENT_METADATA_KEY] === "preview" &&
+    metadata[PREVIEW_JOB_REF_METADATA_KEY] === jobRef
+  );
+}

--- a/turbo/apps/api/src/signals/services/webhooks-stripe.service.ts
+++ b/turbo/apps/api/src/signals/services/webhooks-stripe.service.ts
@@ -17,6 +17,7 @@ import {
   tierForKnownPriceId,
   tierFromPriceId,
 } from "./zero-billing-checkout.service";
+import { isCurrentStripePreviewMetadata } from "./stripe-preview-metadata.service";
 import { drainOrgQueueToCapacity$ } from "./zero-run-queue.service";
 
 const L = logger("WebhookStripe");
@@ -47,6 +48,7 @@ interface InvoiceInput {
   };
   readonly parent: {
     readonly subscription_details: {
+      readonly metadata?: Record<string, string> | null;
       readonly subscription: string | { readonly id: string };
     } | null;
   } | null;
@@ -56,6 +58,7 @@ interface SubscriptionInput {
   readonly id: string;
   readonly customer?: string | { readonly id: string } | null;
   readonly status: string;
+  readonly metadata?: Record<string, string> | null;
   readonly trial_end?: number | null;
   readonly cancel_at?: number | null;
   readonly cancel_at_period_end: boolean;
@@ -70,6 +73,7 @@ interface SubscriptionInput {
 
 interface SubscriptionDeletedInput {
   readonly id: string;
+  readonly metadata?: Record<string, string> | null;
 }
 
 interface SubscriptionPreviousAttributes {
@@ -244,6 +248,41 @@ function creditPurchaseAmount(session: CheckoutSessionInput): number {
 
 function autoRechargeNeverExpiresAt(): Date {
   return new Date("2999-12-31T00:00:00Z");
+}
+
+function stripePreviewMetadataForEvent(
+  event: Stripe.Event,
+): readonly (Readonly<Record<string, string>> | null | undefined)[] | null {
+  switch (event.type) {
+    case "checkout.session.completed":
+    case "checkout.session.async_payment_succeeded": {
+      return [event.data.object.metadata];
+    }
+    case "invoice.paid": {
+      return [
+        event.data.object.metadata,
+        event.data.object.parent?.subscription_details?.metadata,
+      ];
+    }
+    case "customer.subscription.created":
+    case "customer.subscription.updated":
+    case "customer.subscription.deleted": {
+      return [event.data.object.metadata];
+    }
+    default: {
+      return null;
+    }
+  }
+}
+
+function shouldHandleStripePreviewEvent(event: Stripe.Event): boolean {
+  const metadataCandidates = stripePreviewMetadataForEvent(event);
+  if (metadataCandidates === null) {
+    return true;
+  }
+  return metadataCandidates.some((metadata) => {
+    return isCurrentStripePreviewMetadata(metadata);
+  });
 }
 
 async function grantOrgCredits(
@@ -1431,6 +1470,14 @@ export const handleStripeWebhookEvent$ = command(
     const db = set(writeDb$);
     let drainOrgId: string | null = null;
     L.debug("stripe webhook received", { type: event.type, id: event.id });
+
+    if (!shouldHandleStripePreviewEvent(event)) {
+      L.debug("ignoring Stripe preview event for a different job", {
+        type: event.type,
+        id: event.id,
+      });
+      return;
+    }
 
     switch (event.type) {
       case "checkout.session.completed": {

--- a/turbo/apps/api/src/signals/services/zero-billing-checkout.service.ts
+++ b/turbo/apps/api/src/signals/services/zero-billing-checkout.service.ts
@@ -8,6 +8,7 @@ import { nowDate } from "../external/time";
 import { writeDb$ } from "../external/db";
 import { getStripeClient } from "../external/stripe-client";
 import { getOrCreateStripeCustomer$ } from "./billing-customer.service";
+import { stripePreviewMetadata } from "./stripe-preview-metadata.service";
 
 interface CreateCheckoutSessionArgs {
   readonly orgId: string;
@@ -147,6 +148,7 @@ function checkoutSessionMetadata(args: {
       metadata[key] = value;
     }
   }
+  Object.assign(metadata, stripePreviewMetadata());
   return metadata;
 }
 
@@ -347,6 +349,7 @@ export const createCreditCheckoutSession$ = command(
     const baseMetadata = {
       purpose: "credit_purchase",
       orgId: args.orgId,
+      ...stripePreviewMetadata(),
     };
     const customCreditPriceId = activeCustomCreditPriceId();
     if (!customCreditPriceId) {

--- a/turbo/apps/api/src/signals/services/zero-billing-redeem.service.ts
+++ b/turbo/apps/api/src/signals/services/zero-billing-redeem.service.ts
@@ -11,6 +11,7 @@ import { getStripeClient } from "../external/stripe-client";
 import { settle } from "../utils";
 import { getOrCreateStripeCustomer$ } from "./billing-customer.service";
 import { getCampaign } from "./one-time-products";
+import { stripePreviewMetadata } from "./stripe-preview-metadata.service";
 
 const log = logger("zero-billing-redeem");
 
@@ -359,6 +360,7 @@ const createOneTimeCheckoutSession$ = command(
         orgId: args.orgId,
         campaignKey: args.campaignKey,
         purpose: "one_time_purchase",
+        ...stripePreviewMetadata(),
       },
     });
     signal.throwIfAborted();

--- a/turbo/apps/api/src/signals/services/zero-credit-recharge.service.ts
+++ b/turbo/apps/api/src/signals/services/zero-credit-recharge.service.ts
@@ -8,6 +8,7 @@ import { getStripeClient } from "../external/stripe-client";
 import { nowDate } from "../external/time";
 import { settle } from "../utils";
 import { logger } from "../../lib/log";
+import { stripePreviewMetadata } from "./stripe-preview-metadata.service";
 
 const L = logger("CreditRecharge");
 
@@ -157,6 +158,7 @@ export const triggerAutoRecharge$ = command(
             type: "auto_recharge",
             orgId,
             creditsAmount: String(creditsAmount),
+            ...stripePreviewMetadata(),
           },
         });
         signal.throwIfAborted();


### PR DESCRIPTION
## Summary
- add a GitHub Actions helper that creates one Stripe webhook endpoint per PR preview API deployment and writes its signing secret into the API deploy env file
- expose the preview `job-ref` to API runtimes as `VM0_PREVIEW_JOB_REF`
- tag preview Stripe customers, checkout sessions, subscriptions, one-time sessions, and auto-recharge invoices with `vm0_environment=preview` and the current `job_ref`
- make preview Stripe webhooks ignore billing events whose session/subscription/invoice metadata belongs to a different preview job before doing DB or Stripe customer lookups
- remove the Playwright job's long-running `stripe listen` forwarding process
- clean up PR-scoped Stripe webhook endpoints when PRs close and from the stale-resource cleanup workflow

## Test plan
- `bash -n .github/scripts/stripe-preview-webhook.sh`
- `.github/scripts/tests/web-api-env-action-test.sh`
- `git diff --check`
- `pnpm format`
- `pnpm lint`
- `pnpm -F api exec vitest src/signals/routes/__tests__/zero-billing-checkout.test.ts src/signals/routes/__tests__/webhooks-third-party.test.ts --run`
- `pnpm -F api check-types`
- `pnpm check-types` (after generating ignored local `ashby.generated.ts` with `pnpm -F @vm0/firewalls-generator generate:ashby`)
- `pnpm knip`
- `pnpm test` (fails on unrelated existing local issues: Linux container cannot run macOS-only `@vm0/desktop` native computer-use CLI tests, and local DB fixture collisions on fixed GitHub installation/storage IDs cause API tests to fail)
- dry-run/fake-CLI checks for Stripe webhook upsert and cleanup paths
