### PR TITLE
fix(runner): serialize service unit installs

### DIFF
--- a/crates/runner/src/cmd/gc.rs
+++ b/crates/runner/src/cmd/gc.rs
@@ -795,12 +795,16 @@ async fn remove_unused_lock_after_probe(
     name: &str,
     dry_run: bool,
 ) -> bool {
+    if !lock_guard_matches_path(lock_path, lock) {
+        return false;
+    }
+
     if dry_run {
         info!("[dry-run] would remove unused lock {name}");
         return true;
     }
 
-    if remove_current_lock_file(lock_path, lock).await {
+    if remove_lock_file(lock_path).await {
         info!("removed unused lock {name}");
         true
     } else {
@@ -808,16 +812,18 @@ async fn remove_unused_lock_after_probe(
     }
 }
 
-async fn remove_current_lock_file(lock_path: &Path, lock: &Flock<std::fs::File>) -> bool {
+fn lock_guard_matches_path(lock_path: &Path, lock: &Flock<std::fs::File>) -> bool {
     match lock_probe_inode_is_current(lock, lock_path) {
-        Ok(true) => {}
-        Ok(false) => return false,
+        Ok(true) => true,
+        Ok(false) => false,
         Err(e) => {
             warn!("{e}");
-            return false;
+            false
         }
     }
+}
 
+async fn remove_lock_file(lock_path: &Path) -> bool {
     match tokio::fs::remove_file(lock_path).await {
         Ok(()) => true,
         Err(e) => {
@@ -1064,25 +1070,39 @@ async fn gc_versions(
             .and_then(|name| name.to_str())
             .unwrap_or("service lock")
             .to_string();
-        let service_lock_existed = match service_lock_path.try_exists() {
-            Ok(existed) => existed,
-            Err(e) => {
-                warn!(
-                    "version {name}: cannot check service lock {} before acquire ({e})",
-                    service_lock_path.display()
-                );
-                true
+        let service_lock = if dry_run {
+            match service_lock_path.try_exists() {
+                Ok(false) => None,
+                Ok(true) => match lock::try_acquire_or_busy(service_lock_path.clone()).await {
+                    Ok(lock::TryLock::Acquired(lock)) => Some(lock),
+                    Ok(lock::TryLock::Busy) => {
+                        info!("version {name}: service lock held, skipping");
+                        continue;
+                    }
+                    Err(e) => {
+                        warn!("version {name}: cannot acquire service lock ({e}), skipping");
+                        continue;
+                    }
+                },
+                Err(e) => {
+                    warn!(
+                        "version {name}: cannot check service lock {} before dry-run ({e}), skipping",
+                        service_lock_path.display()
+                    );
+                    continue;
+                }
             }
-        };
-        let service_lock = match lock::try_acquire_or_busy(service_lock_path.clone()).await {
-            Ok(lock::TryLock::Acquired(lock)) => lock,
-            Ok(lock::TryLock::Busy) => {
-                info!("version {name}: service lock held, skipping");
-                continue;
-            }
-            Err(e) => {
-                warn!("version {name}: cannot acquire service lock ({e}), skipping");
-                continue;
+        } else {
+            match lock::try_acquire_or_busy(service_lock_path.clone()).await {
+                Ok(lock::TryLock::Acquired(lock)) => Some(lock),
+                Ok(lock::TryLock::Busy) => {
+                    info!("version {name}: service lock held, skipping");
+                    continue;
+                }
+                Err(e) => {
+                    warn!("version {name}: cannot acquire service lock ({e}), skipping");
+                    continue;
+                }
             }
         };
 
@@ -1114,12 +1134,11 @@ async fn gc_versions(
 
         if dry_run {
             info!("[dry-run] would remove version {name}");
-            if !service_lock_existed
-                && remove_current_lock_file(&service_lock_path, &service_lock).await
-            {
-                tracing::debug!("removed service lock created by dry-run for version {name}");
-            }
         } else {
+            let Some(service_lock) = service_lock.as_ref() else {
+                warn!("version {name}: service lock missing before delete, skipping");
+                continue;
+            };
             // Best-effort uninstall the systemd service (may not exist).
             let _ = service::uninstall_service_unit(&unit).await;
 
@@ -1137,7 +1156,7 @@ async fn gc_versions(
             info!("removed version {name}");
             remove_unused_lock_after_probe(
                 &service_lock_path,
-                &service_lock,
+                service_lock,
                 &service_lock_name,
                 false,
             )
@@ -2446,6 +2465,28 @@ mod tests {
         assert!(
             !service_lock_path.exists(),
             "dry-run should not leave a service lock it created"
+        );
+    }
+
+    #[tokio::test]
+    async fn gc_versions_dry_run_preserves_existing_service_lock() {
+        let dir = tempfile::tempdir().unwrap();
+        let home = test_home(dir.path());
+        let bin_dir = home.bin_dir();
+        let version = "v1.0.0";
+
+        std::fs::create_dir_all(bin_dir.join(version)).unwrap();
+        age_version_past_gc_min_age(&home, version);
+        let unit = service::unit_name(version).unwrap();
+        let service_lock_path = home.service_lock(&unit);
+        drop(lock::open_lock_file(&service_lock_path).unwrap());
+
+        let removed = gc_versions(&home, true, None, None).await.unwrap();
+
+        assert_eq!(removed, [version]);
+        assert!(
+            service_lock_path.exists(),
+            "dry-run must not remove an existing service lock"
         );
     }
 

--- a/crates/runner/src/cmd/gc.rs
+++ b/crates/runner/src/cmd/gc.rs
@@ -2385,6 +2385,7 @@ mod tests {
         let unit = service::unit_name(version).unwrap();
         std::fs::create_dir_all(bin_dir.join(version)).unwrap();
         std::fs::create_dir_all(runners_dir.join(version)).unwrap();
+        age_version_past_gc_min_age(&home, version);
         let _service_lock = lock::acquire(home.service_lock(&unit)).await.unwrap();
 
         let removed = gc_versions(&home, false, None, None).await.unwrap();

--- a/crates/runner/src/cmd/gc.rs
+++ b/crates/runner/src/cmd/gc.rs
@@ -549,7 +549,7 @@ fn lock_metadata_inode_is_current(
         Err(e) if e.kind() == std::io::ErrorKind::NotFound => return Ok(false),
         Err(e) => return Err(format!("stat lock {}: {e}", path.display())),
     };
-    Ok(lock_meta.ino() == path_meta.ino())
+    Ok(lock_meta.dev() == path_meta.dev() && lock_meta.ino() == path_meta.ino())
 }
 
 fn lock_probe_inode_is_current(lock: &Flock<std::fs::File>, path: &Path) -> Result<bool, String> {
@@ -933,6 +933,34 @@ fn parse_semver(name: &str) -> Option<(u32, u32, u32)> {
     Some((major, minor, patch))
 }
 
+async fn version_newest_mtime(home: &HomePaths, bin_dir: &Path, name: &str) -> SystemTime {
+    let version_bin = bin_dir.join(name);
+    let version_config = home.runners_dir().join(name);
+    let version_binary = version_bin.join("runner");
+    let version_config_file = version_config.join("runner.yaml");
+    let mut newest_mtime = SystemTime::UNIX_EPOCH;
+    for path in [
+        &version_bin,
+        &version_binary,
+        &version_config,
+        &version_config_file,
+    ] {
+        if let Ok(meta) = tokio::fs::metadata(path).await
+            && let Ok(mtime) = meta.modified()
+            && mtime > newest_mtime
+        {
+            newest_mtime = mtime;
+        }
+    }
+    newest_mtime
+}
+
+async fn version_gc_age(home: &HomePaths, bin_dir: &Path, name: &str) -> Duration {
+    SystemTime::now()
+        .duration_since(version_newest_mtime(home, bin_dir, name).await)
+        .unwrap_or_default()
+}
+
 /// Remove old deployment version directories that are not actively running.
 ///
 /// Scans `home.bin_dir()` for semver-named subdirectories (e.g. `v0.2.0`) and
@@ -944,6 +972,10 @@ fn parse_semver(name: &str) -> Option<(u32, u32, u32)> {
 ///   the "staged but not yet installed" case where two overlapping releases
 ///   race: the older release's promote must not wipe the newer release's
 ///   just-staged binary even though the newer unit isn't active yet.
+/// - The version binary, config file, or their directories are too recent to
+///   safely delete.
+/// - The corresponding service lifecycle lock is held by another install,
+///   uninstall, or GC pass.
 /// - The corresponding systemd unit is active.
 async fn gc_versions(
     home: &HomePaths,
@@ -961,6 +993,19 @@ async fn gc_versions(
     // in one pass.
     let mut semver_dirs: Vec<(String, (u32, u32, u32))> = Vec::new();
     while let Some(entry) = next_entry_warn(&mut entries, "gc_versions", &bin_dir).await {
+        let file_type = match entry.file_type().await {
+            Ok(file_type) => file_type,
+            Err(e) => {
+                warn!(
+                    "version entry {}: cannot read file type ({e}), skipping",
+                    entry.path().display()
+                );
+                continue;
+            }
+        };
+        if !file_type.is_dir() {
+            continue;
+        }
         let name = entry.file_name();
         let Some(name) = name.to_str() else { continue };
         if let Some(ver) = parse_semver(name) {
@@ -995,7 +1040,14 @@ async fn gc_versions(
             continue;
         }
 
-        // Check if the corresponding systemd unit is active — skip if so.
+        let version_bin = bin_dir.join(name);
+        let version_config = home.runners_dir().join(name);
+        let age = version_gc_age(home, &bin_dir, name).await;
+        if age < GC_MIN_AGE {
+            info!("version {name}: too recent ({}s), skipping", age.as_secs());
+            continue;
+        }
+
         let unit = match service::unit_name(name) {
             Ok(u) => u,
             Err(_) => continue,
@@ -1012,6 +1064,17 @@ async fn gc_versions(
             }
         };
 
+        let age = version_gc_age(home, &bin_dir, name).await;
+        if age < GC_MIN_AGE {
+            info!(
+                "version {name}: became too recent before delete ({}s), skipping",
+                age.as_secs()
+            );
+            continue;
+        }
+
+        // Check while holding the service lifecycle lock so install cannot
+        // race between the active probe and the remove path.
         match service::is_unit_active(&unit).await {
             Ok(true) => {
                 info!("version {name}: active, skipping");
@@ -1034,7 +1097,6 @@ async fn gc_versions(
             let _ = service::uninstall_service_unit(&unit).await;
 
             // Remove bin directory.
-            let version_bin = bin_dir.join(name);
             if let Err(e) = tokio::fs::remove_dir_all(&version_bin).await
                 && e.kind() != std::io::ErrorKind::NotFound
             {
@@ -1043,7 +1105,6 @@ async fn gc_versions(
             }
 
             // Best-effort remove runner config directory.
-            let version_config = home.runners_dir().join(name);
             let _ = tokio::fs::remove_dir_all(&version_config).await;
 
             info!("removed version {name}");
@@ -1963,6 +2024,29 @@ mod tests {
         HomePaths::with_root(root.to_path_buf())
     }
 
+    fn age_version_past_gc_min_age(home: &HomePaths, name: &str) {
+        let old_time = SystemTime::now() - Duration::from_secs(GC_MIN_AGE.as_secs() + 60);
+        for path in [
+            home.bin_dir().join(name),
+            home.bin_dir().join(name).join("runner"),
+            home.runners_dir().join(name),
+            home.runners_dir().join(name).join("runner.yaml"),
+        ] {
+            if path.exists() {
+                std::fs::File::open(path)
+                    .unwrap()
+                    .set_times(std::fs::FileTimes::new().set_modified(old_time))
+                    .unwrap();
+            }
+        }
+    }
+
+    fn age_versions_past_gc_min_age(home: &HomePaths, names: &[&str]) {
+        for name in names {
+            age_version_past_gc_min_age(home, name);
+        }
+    }
+
     #[tokio::test]
     async fn gc_debootstrap_missing_cache_dir_does_not_create_lock() {
         let dir = tempfile::tempdir().unwrap();
@@ -2276,6 +2360,7 @@ mod tests {
 
         // Create corresponding runner config dirs
         std::fs::create_dir_all(runners_dir.join("v1.0.0")).unwrap();
+        age_versions_past_gc_min_age(&home, &["v1.0.0", "v2.0.0"]);
 
         // systemctl will fail in test env, so versions are treated as inactive
         let mut removed = gc_versions(&home, false, None, None).await.unwrap();
@@ -2316,10 +2401,155 @@ mod tests {
         let bin_dir = home.bin_dir();
 
         std::fs::create_dir_all(bin_dir.join("v1.0.0")).unwrap();
+        age_version_past_gc_min_age(&home, "v1.0.0");
 
         let removed = gc_versions(&home, true, None, None).await.unwrap();
         assert_eq!(removed, ["v1.0.0"]);
         assert!(bin_dir.join("v1.0.0").exists(), "dry-run should not delete");
+    }
+
+    #[tokio::test]
+    async fn gc_versions_keeps_recent_version() {
+        let dir = tempfile::tempdir().unwrap();
+        let home = test_home(dir.path());
+        let bin_dir = home.bin_dir();
+        let runners_dir = home.runners_dir();
+
+        std::fs::create_dir_all(bin_dir.join("v1.0.0")).unwrap();
+        std::fs::create_dir_all(runners_dir.join("v1.0.0")).unwrap();
+
+        let removed = gc_versions(&home, false, None, None).await.unwrap();
+
+        assert!(removed.is_empty());
+        assert!(
+            bin_dir.join("v1.0.0").exists(),
+            "recent version bin dir should survive"
+        );
+        assert!(
+            runners_dir.join("v1.0.0").exists(),
+            "recent version config dir should survive"
+        );
+    }
+
+    #[tokio::test]
+    async fn gc_versions_keeps_recent_runner_binary_file() {
+        let dir = tempfile::tempdir().unwrap();
+        let home = test_home(dir.path());
+        let bin_dir = home.bin_dir();
+
+        std::fs::create_dir_all(bin_dir.join("v1.0.0")).unwrap();
+        age_version_past_gc_min_age(&home, "v1.0.0");
+        std::fs::write(bin_dir.join("v1.0.0").join("runner"), "binary").unwrap();
+
+        let removed = gc_versions(&home, false, None, None).await.unwrap();
+
+        assert!(removed.is_empty());
+        assert!(
+            bin_dir.join("v1.0.0").exists(),
+            "recent runner binary file should protect its version"
+        );
+    }
+
+    #[tokio::test]
+    async fn gc_versions_keeps_recent_runner_config_file() {
+        let dir = tempfile::tempdir().unwrap();
+        let home = test_home(dir.path());
+        let bin_dir = home.bin_dir();
+        let runners_dir = home.runners_dir();
+
+        std::fs::create_dir_all(bin_dir.join("v1.0.0")).unwrap();
+        std::fs::create_dir_all(runners_dir.join("v1.0.0")).unwrap();
+        age_version_past_gc_min_age(&home, "v1.0.0");
+        std::fs::write(runners_dir.join("v1.0.0").join("runner.yaml"), "config").unwrap();
+
+        let removed = gc_versions(&home, false, None, None).await.unwrap();
+
+        assert!(removed.is_empty());
+        assert!(
+            bin_dir.join("v1.0.0").exists(),
+            "recent runner config file should protect its version"
+        );
+        assert!(
+            runners_dir.join("v1.0.0").exists(),
+            "recent runner config file should protect its config directory"
+        );
+    }
+
+    #[tokio::test]
+    async fn gc_versions_ignores_semver_named_file() {
+        let dir = tempfile::tempdir().unwrap();
+        let home = test_home(dir.path());
+        let bin_dir = home.bin_dir();
+        let runners_dir = home.runners_dir();
+
+        std::fs::create_dir_all(&bin_dir).unwrap();
+        std::fs::write(bin_dir.join("v1.0.0"), "not a directory").unwrap();
+        std::fs::create_dir_all(runners_dir.join("v1.0.0")).unwrap();
+        age_version_past_gc_min_age(&home, "v1.0.0");
+
+        let removed = gc_versions(&home, false, None, None).await.unwrap();
+
+        assert!(removed.is_empty());
+        assert!(
+            bin_dir.join("v1.0.0").is_file(),
+            "semver-named files are not version dirs"
+        );
+        assert!(
+            runners_dir.join("v1.0.0").exists(),
+            "config dir must not be removed for a non-directory bin entry"
+        );
+    }
+
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn gc_versions_ignores_semver_named_symlink() {
+        let dir = tempfile::tempdir().unwrap();
+        let home = test_home(dir.path());
+        let bin_dir = home.bin_dir();
+        let target_dir = dir.path().join("external-version");
+
+        std::fs::create_dir_all(&bin_dir).unwrap();
+        std::fs::create_dir_all(&target_dir).unwrap();
+        std::os::unix::fs::symlink(&target_dir, bin_dir.join("v1.0.0")).unwrap();
+
+        let removed = gc_versions(&home, false, None, None).await.unwrap();
+
+        assert!(removed.is_empty());
+        assert!(
+            std::fs::symlink_metadata(bin_dir.join("v1.0.0"))
+                .unwrap()
+                .file_type()
+                .is_symlink(),
+            "semver-named symlinks are not version dirs"
+        );
+    }
+
+    #[tokio::test]
+    async fn gc_versions_skips_when_service_lock_is_held() {
+        let dir = tempfile::tempdir().unwrap();
+        let home = test_home(dir.path());
+        let bin_dir = home.bin_dir();
+        let runners_dir = home.runners_dir();
+
+        std::fs::create_dir_all(bin_dir.join("v1.0.0")).unwrap();
+        std::fs::create_dir_all(runners_dir.join("v1.0.0")).unwrap();
+        age_version_past_gc_min_age(&home, "v1.0.0");
+
+        let unit = service::unit_name("v1.0.0").unwrap();
+        let lock_file = lock::open_lock_file(&home.service_lock(&unit)).unwrap();
+        let _held_lock = Flock::lock(lock_file, FlockArg::LockExclusive).unwrap();
+
+        let removed = gc_versions(&home, false, None, None).await.unwrap();
+
+        assert!(removed.is_empty());
+        assert!(
+            bin_dir.join("v1.0.0").exists(),
+            "locked version bin dir should survive"
+        );
+        assert!(
+            runners_dir.join("v1.0.0").exists(),
+            "locked version config dir should survive"
+        );
     }
 
     #[tokio::test]
@@ -2349,6 +2579,7 @@ mod tests {
 
         std::fs::create_dir_all(bin_dir.join("v1.0.0")).unwrap();
         std::fs::create_dir_all(bin_dir.join("v2.0.0")).unwrap();
+        age_versions_past_gc_min_age(&home, &["v1.0.0", "v2.0.0"]);
 
         let mut removed = gc_versions(&home, false, Some("v1.0.0"), None)
             .await
@@ -2375,6 +2606,7 @@ mod tests {
         for v in ["v0.88.0", "v0.88.1", "v0.88.2", "v0.88.3"] {
             std::fs::create_dir_all(bin_dir.join(v)).unwrap();
         }
+        age_versions_past_gc_min_age(&home, &["v0.88.0", "v0.88.1", "v0.88.2", "v0.88.3"]);
 
         // Simulating v0.88.2's own promote: protects itself, keeps top 1.
         // v0.88.3 must survive via keep_latest even though protect is v0.88.2.
@@ -2403,6 +2635,7 @@ mod tests {
         for v in ["v0.9.0", "v0.10.0"] {
             std::fs::create_dir_all(bin_dir.join(v)).unwrap();
         }
+        age_versions_past_gc_min_age(&home, &["v0.9.0", "v0.10.0"]);
 
         let removed = gc_versions(&home, false, None, Some(1)).await.unwrap();
         assert_eq!(removed, ["v0.9.0"]);

--- a/crates/runner/src/cmd/gc.rs
+++ b/crates/runner/src/cmd/gc.rs
@@ -795,6 +795,20 @@ async fn remove_unused_lock_after_probe(
     name: &str,
     dry_run: bool,
 ) -> bool {
+    if dry_run {
+        info!("[dry-run] would remove unused lock {name}");
+        return true;
+    }
+
+    if remove_current_lock_file(lock_path, lock).await {
+        info!("removed unused lock {name}");
+        true
+    } else {
+        false
+    }
+}
+
+async fn remove_current_lock_file(lock_path: &Path, lock: &Flock<std::fs::File>) -> bool {
     match lock_probe_inode_is_current(lock, lock_path) {
         Ok(true) => {}
         Ok(false) => return false,
@@ -804,16 +818,8 @@ async fn remove_unused_lock_after_probe(
         }
     }
 
-    if dry_run {
-        info!("[dry-run] would remove unused lock {name}");
-        return true;
-    }
-
     match tokio::fs::remove_file(lock_path).await {
-        Ok(()) => {
-            info!("removed unused lock {name}");
-            true
-        }
+        Ok(()) => true,
         Err(e) => {
             warn!("cannot remove {}: {e}", lock_path.display());
             false
@@ -1052,7 +1058,23 @@ async fn gc_versions(
             Ok(u) => u,
             Err(_) => continue,
         };
-        let _service_lock = match lock::try_acquire_or_busy(home.service_lock(&unit)).await {
+        let service_lock_path = home.service_lock(&unit);
+        let service_lock_name = service_lock_path
+            .file_name()
+            .and_then(|name| name.to_str())
+            .unwrap_or("service lock")
+            .to_string();
+        let service_lock_existed = match service_lock_path.try_exists() {
+            Ok(existed) => existed,
+            Err(e) => {
+                warn!(
+                    "version {name}: cannot check service lock {} before acquire ({e})",
+                    service_lock_path.display()
+                );
+                true
+            }
+        };
+        let service_lock = match lock::try_acquire_or_busy(service_lock_path.clone()).await {
             Ok(lock::TryLock::Acquired(lock)) => lock,
             Ok(lock::TryLock::Busy) => {
                 info!("version {name}: service lock held, skipping");
@@ -1092,6 +1114,11 @@ async fn gc_versions(
 
         if dry_run {
             info!("[dry-run] would remove version {name}");
+            if !service_lock_existed
+                && remove_current_lock_file(&service_lock_path, &service_lock).await
+            {
+                tracing::debug!("removed service lock created by dry-run for version {name}");
+            }
         } else {
             // Best-effort uninstall the systemd service (may not exist).
             let _ = service::uninstall_service_unit(&unit).await;
@@ -1108,6 +1135,13 @@ async fn gc_versions(
             let _ = tokio::fs::remove_dir_all(&version_config).await;
 
             info!("removed version {name}");
+            remove_unused_lock_after_probe(
+                &service_lock_path,
+                &service_lock,
+                &service_lock_name,
+                false,
+            )
+            .await;
         }
         removed.push(name.clone());
     }
@@ -2403,10 +2437,16 @@ mod tests {
 
         std::fs::create_dir_all(bin_dir.join("v1.0.0")).unwrap();
         age_version_past_gc_min_age(&home, "v1.0.0");
+        let unit = service::unit_name("v1.0.0").unwrap();
+        let service_lock_path = home.service_lock(&unit);
 
         let removed = gc_versions(&home, true, None, None).await.unwrap();
         assert_eq!(removed, ["v1.0.0"]);
         assert!(bin_dir.join("v1.0.0").exists(), "dry-run should not delete");
+        assert!(
+            !service_lock_path.exists(),
+            "dry-run should not leave a service lock it created"
+        );
     }
 
     #[tokio::test]
@@ -2550,6 +2590,30 @@ mod tests {
         assert!(
             runners_dir.join("v1.0.0").exists(),
             "locked version config dir should survive"
+        );
+    }
+
+    #[tokio::test]
+    async fn gc_versions_removes_service_lock_after_version_removal() {
+        let dir = tempfile::tempdir().unwrap();
+        let home = test_home(dir.path());
+        let bin_dir = home.bin_dir();
+        let runners_dir = home.runners_dir();
+        let version = "v1.0.0";
+
+        std::fs::create_dir_all(bin_dir.join(version)).unwrap();
+        std::fs::create_dir_all(runners_dir.join(version)).unwrap();
+        age_version_past_gc_min_age(&home, version);
+        let unit = service::unit_name(version).unwrap();
+        let service_lock_path = home.service_lock(&unit);
+        drop(lock::open_lock_file(&service_lock_path).unwrap());
+
+        let removed = gc_versions(&home, false, None, None).await.unwrap();
+
+        assert_eq!(removed, [version]);
+        assert!(
+            !service_lock_path.exists(),
+            "removed version should not leave its service lock behind"
         );
     }
 

--- a/crates/runner/src/cmd/service.rs
+++ b/crates/runner/src/cmd/service.rs
@@ -6,7 +6,7 @@ use std::os::unix::fs::{OpenOptionsExt, PermissionsExt};
 use std::path::{Path, PathBuf};
 use std::process::{ExitStatus, Output};
 use std::sync::atomic::{AtomicU64, Ordering};
-use std::time::{SystemTime, UNIX_EPOCH};
+use std::time::{Duration, SystemTime, UNIX_EPOCH};
 
 use crate::error::{ActiveJobsError, RunnerError, RunnerResult};
 use crate::ids::RunId;
@@ -135,6 +135,9 @@ pub async fn run_service(args: ServiceArgs) -> RunnerResult<()> {
 const UNIT_PREFIX: &str = "vm0-runner-";
 const UNIT_STAGING_MARKER: &str = ".tmp@";
 const UNIT_STAGING_MAX_ATTEMPTS: u64 = 32;
+// Older runner binaries created dot-UUID staging files without holding the
+// service lock, so only age them out after the rolling-upgrade window.
+const LEGACY_UNIT_STAGING_MIN_AGE: Duration = Duration::from_secs(10 * 60);
 #[cfg(unix)]
 const UNIT_FILE_MODE: u32 = 0o600;
 static UNIT_STAGING_COUNTER: AtomicU64 = AtomicU64::new(0);
@@ -404,21 +407,29 @@ fn is_generated_unit_staging_suffix(value: &str) -> bool {
         && attempt.parse::<u64>().is_ok()
 }
 
-fn is_unit_staging_file_name(
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+enum UnitStagingFileKind {
+    Current,
+    Legacy,
+}
+
+fn unit_staging_file_kind(
     name: &str,
     staging_prefix: &str,
     legacy_staging_prefix: &str,
-) -> bool {
+) -> Option<UnitStagingFileKind> {
     if let Some(suffix) = name.strip_prefix(staging_prefix) {
-        return is_generated_unit_staging_suffix(suffix);
+        return is_generated_unit_staging_suffix(suffix).then_some(UnitStagingFileKind::Current);
     }
     if let Some(suffix) = name.strip_prefix(legacy_staging_prefix) {
-        return uuid::Uuid::parse_str(suffix).is_ok();
+        return uuid::Uuid::parse_str(suffix)
+            .is_ok()
+            .then_some(UnitStagingFileKind::Legacy);
     }
-    false
+    None
 }
 
-fn remove_stale_unit_staging_file(path: &Path) -> RunnerResult<()> {
+fn remove_stale_unit_staging_file(path: &Path, min_age: Option<Duration>) -> RunnerResult<()> {
     let meta = match std::fs::symlink_metadata(path) {
         Ok(meta) => meta,
         Err(e) if e.kind() == std::io::ErrorKind::NotFound => return Ok(()),
@@ -432,6 +443,21 @@ fn remove_stale_unit_staging_file(path: &Path) -> RunnerResult<()> {
     let file_type = meta.file_type();
     if !meta.is_file() && !file_type.is_symlink() {
         return Ok(());
+    }
+    if let Some(min_age) = min_age {
+        let modified = meta.modified().map_err(|e| {
+            RunnerError::Internal(format!(
+                "stat stale unit staging file mtime {}: {e}",
+                path.display()
+            ))
+        })?;
+        if SystemTime::now()
+            .duration_since(modified)
+            .unwrap_or_default()
+            < min_age
+        {
+            return Ok(());
+        }
     }
     std::fs::remove_file(path).map_err(|e| {
         RunnerError::Internal(format!(
@@ -466,8 +492,14 @@ fn cleanup_unit_staging_files(path: &Path) -> RunnerResult<()> {
         let Some(name) = file_name.to_str() else {
             continue;
         };
-        if is_unit_staging_file_name(name, &prefix, &legacy_prefix) {
-            remove_stale_unit_staging_file(&entry.path())?;
+        match unit_staging_file_kind(name, &prefix, &legacy_prefix) {
+            Some(UnitStagingFileKind::Current) => {
+                remove_stale_unit_staging_file(&entry.path(), None)?;
+            }
+            Some(UnitStagingFileKind::Legacy) => {
+                remove_stale_unit_staging_file(&entry.path(), Some(LEGACY_UNIT_STAGING_MIN_AGE))?;
+            }
+            None => {}
         }
     }
     Ok(())
@@ -2132,7 +2164,11 @@ mod tests {
         let path = dir.path().join("vm0-runner-test.service");
         let legacy_tmp = path.with_extension("tmp");
         let stale_unique = dir.path().join("vm0-runner-test.service.tmp@123.456.0");
-        let legacy_unique = dir.path().join(format!(
+        let old_legacy_unique = dir.path().join(format!(
+            ".vm0-runner-test.service.tmp.{}",
+            uuid::Uuid::new_v4()
+        ));
+        let recent_legacy_unique = dir.path().join(format!(
             ".vm0-runner-test.service.tmp.{}",
             uuid::Uuid::new_v4()
         ));
@@ -2146,11 +2182,18 @@ mod tests {
         std::fs::write(&path, "current").unwrap();
         std::fs::write(&legacy_tmp, "legacy").unwrap();
         std::fs::write(&stale_unique, "stale").unwrap();
-        std::fs::write(&legacy_unique, "legacy unique").unwrap();
+        std::fs::write(&old_legacy_unique, "old legacy unique").unwrap();
+        std::fs::write(&recent_legacy_unique, "recent legacy unique").unwrap();
         std::fs::write(&invalid_staging, "manual").unwrap();
         std::fs::write(&other_unit_staging, "other").unwrap();
         std::fs::write(&colliding_unit_staging, "colliding").unwrap();
         std::fs::create_dir(&staging_dir).unwrap();
+        let old_legacy_mtime =
+            SystemTime::now() - LEGACY_UNIT_STAGING_MIN_AGE - Duration::from_secs(60);
+        std::fs::File::open(&old_legacy_unique)
+            .unwrap()
+            .set_times(std::fs::FileTimes::new().set_modified(old_legacy_mtime))
+            .unwrap();
 
         cleanup_unit_staging_files(&path).unwrap();
 
@@ -2161,8 +2204,12 @@ mod tests {
         );
         assert!(!stale_unique.exists(), "unique staging must be removed");
         assert!(
-            !legacy_unique.exists(),
-            "legacy dot-prefixed unique staging must be removed"
+            !old_legacy_unique.exists(),
+            "old legacy dot-prefixed unique staging must be removed"
+        );
+        assert!(
+            recent_legacy_unique.exists(),
+            "recent legacy dot-prefixed staging may be in use by an older runner binary"
         );
         assert!(
             invalid_staging.exists(),

--- a/crates/runner/src/cmd/service.rs
+++ b/crates/runner/src/cmd/service.rs
@@ -374,6 +374,50 @@ fn unit_staging_prefix(path: &Path) -> RunnerResult<String> {
     Ok(format!("{file_name}{UNIT_STAGING_MARKER}"))
 }
 
+fn legacy_unit_staging_prefix(path: &Path) -> RunnerResult<String> {
+    let file_name = path
+        .file_name()
+        .and_then(|name| name.to_str())
+        .ok_or_else(|| {
+            RunnerError::Internal(format!(
+                "unit file path has no UTF-8 file name: {}",
+                path.display()
+            ))
+        })?;
+    Ok(format!(".{file_name}.tmp."))
+}
+
+fn is_generated_unit_staging_suffix(value: &str) -> bool {
+    let mut parts = value.split('.');
+    let Some(pid) = parts.next() else {
+        return false;
+    };
+    let Some(nanos) = parts.next() else {
+        return false;
+    };
+    let Some(attempt) = parts.next() else {
+        return false;
+    };
+    parts.next().is_none()
+        && pid.parse::<u32>().is_ok()
+        && nanos.parse::<u128>().is_ok()
+        && attempt.parse::<u64>().is_ok()
+}
+
+fn is_unit_staging_file_name(
+    name: &str,
+    staging_prefix: &str,
+    legacy_staging_prefix: &str,
+) -> bool {
+    if let Some(suffix) = name.strip_prefix(staging_prefix) {
+        return is_generated_unit_staging_suffix(suffix);
+    }
+    if let Some(suffix) = name.strip_prefix(legacy_staging_prefix) {
+        return uuid::Uuid::parse_str(suffix).is_ok();
+    }
+    false
+}
+
 fn remove_stale_unit_staging_file(path: &Path) -> RunnerResult<()> {
     let meta = match std::fs::symlink_metadata(path) {
         Ok(meta) => meta,
@@ -400,6 +444,7 @@ fn remove_stale_unit_staging_file(path: &Path) -> RunnerResult<()> {
 fn cleanup_unit_staging_files(path: &Path) -> RunnerResult<()> {
     let parent = path.parent().unwrap_or_else(|| Path::new("."));
     let prefix = unit_staging_prefix(path)?;
+    let legacy_prefix = legacy_unit_staging_prefix(path)?;
 
     // Do not remove the old fixed `<target>.tmp` path here: during a rolling
     // deploy an older runner binary may still be using it as its staging file.
@@ -421,7 +466,7 @@ fn cleanup_unit_staging_files(path: &Path) -> RunnerResult<()> {
         let Some(name) = file_name.to_str() else {
             continue;
         };
-        if name.starts_with(&prefix) {
+        if is_unit_staging_file_name(name, &prefix, &legacy_prefix) {
             remove_stale_unit_staging_file(&entry.path())?;
         }
     }
@@ -2087,6 +2132,11 @@ mod tests {
         let path = dir.path().join("vm0-runner-test.service");
         let legacy_tmp = path.with_extension("tmp");
         let stale_unique = dir.path().join("vm0-runner-test.service.tmp@123.456.0");
+        let legacy_unique = dir.path().join(format!(
+            ".vm0-runner-test.service.tmp.{}",
+            uuid::Uuid::new_v4()
+        ));
+        let invalid_staging = dir.path().join("vm0-runner-test.service.tmp@manual");
         let other_unit_staging = dir.path().join("vm0-runner-other.service.tmp@123.456.0");
         let colliding_unit_staging = dir
             .path()
@@ -2096,6 +2146,8 @@ mod tests {
         std::fs::write(&path, "current").unwrap();
         std::fs::write(&legacy_tmp, "legacy").unwrap();
         std::fs::write(&stale_unique, "stale").unwrap();
+        std::fs::write(&legacy_unique, "legacy unique").unwrap();
+        std::fs::write(&invalid_staging, "manual").unwrap();
         std::fs::write(&other_unit_staging, "other").unwrap();
         std::fs::write(&colliding_unit_staging, "colliding").unwrap();
         std::fs::create_dir(&staging_dir).unwrap();
@@ -2108,6 +2160,14 @@ mod tests {
             "legacy fixed staging may be in use by an older runner binary"
         );
         assert!(!stale_unique.exists(), "unique staging must be removed");
+        assert!(
+            !legacy_unique.exists(),
+            "legacy dot-prefixed unique staging must be removed"
+        );
+        assert!(
+            invalid_staging.exists(),
+            "invalid staging-like files must not be removed"
+        );
         assert!(
             other_unit_staging.exists(),
             "other unit staging must not be removed"

--- a/crates/runner/src/cmd/service.rs
+++ b/crates/runner/src/cmd/service.rs
@@ -1,9 +1,12 @@
 use std::collections::BTreeMap;
-use std::ffi::{OsStr, OsString};
+use std::ffi::OsString;
 use std::io::Write;
-use std::os::unix::ffi::OsStrExt;
+#[cfg(unix)]
+use std::os::unix::fs::{OpenOptionsExt, PermissionsExt};
 use std::path::{Path, PathBuf};
 use std::process::{ExitStatus, Output};
+use std::sync::atomic::{AtomicU64, Ordering};
+use std::time::{SystemTime, UNIX_EPOCH};
 
 use crate::error::{ActiveJobsError, RunnerError, RunnerResult};
 use crate::ids::RunId;
@@ -130,7 +133,11 @@ pub async fn run_service(args: ServiceArgs) -> RunnerResult<()> {
 // ---------------------------------------------------------------------------
 
 const UNIT_PREFIX: &str = "vm0-runner-";
-const UNIT_FILE_TMP_ATTEMPTS: usize = 16;
+const UNIT_STAGING_MARKER: &str = ".tmp@";
+const UNIT_STAGING_MAX_ATTEMPTS: u64 = 32;
+#[cfg(unix)]
+const UNIT_FILE_MODE: u32 = 0o600;
+static UNIT_STAGING_COUNTER: AtomicU64 = AtomicU64::new(0);
 
 /// Build the full systemd unit name from the user-supplied suffix.
 ///
@@ -267,6 +274,16 @@ fn validate_env_vars(vars: &[String]) -> RunnerResult<()> {
     Ok(())
 }
 
+fn validate_systemd_path(label: &str, path: &Path) -> RunnerResult<()> {
+    let value = path.display().to_string();
+    if value.contains(['\n', '\r', '\0']) {
+        return Err(RunnerError::Config(format!(
+            "{label} cannot contain newline or NUL characters"
+        )));
+    }
+    Ok(())
+}
+
 fn journalctl_logs_status(svc: &str, status: ExitStatus) -> RunnerResult<()> {
     if status.success() {
         return Ok(());
@@ -303,74 +320,111 @@ async fn run_systemctl(args: &[&str]) -> RunnerResult<()> {
     Ok(())
 }
 
-fn unit_tmp_name_prefix(path: &Path) -> RunnerResult<OsString> {
-    let file_name = path.file_name().ok_or_else(|| {
-        RunnerError::Internal(format!("unit path has no file name: {}", path.display()))
+fn validate_current_exe_path(path: PathBuf) -> RunnerResult<PathBuf> {
+    let meta = std::fs::metadata(&path).map_err(|e| {
+        RunnerError::Internal(format!("stat current executable {}: {e}", path.display()))
     })?;
-    let mut tmp_name = OsString::from(".");
-    tmp_name.push(file_name);
-    tmp_name.push(".tmp.");
-    Ok(tmp_name)
+    if !meta.is_file() {
+        return Err(RunnerError::Internal(format!(
+            "current executable {} is not a file",
+            path.display()
+        )));
+    }
+    #[cfg(unix)]
+    if meta.permissions().mode() & 0o111 == 0 {
+        return Err(RunnerError::Internal(format!(
+            "current executable {} is not executable",
+            path.display()
+        )));
+    }
+    Ok(path)
 }
 
-fn unique_unit_tmp_path(path: &Path) -> RunnerResult<PathBuf> {
+fn unit_staging_path(path: &Path, attempt: u64) -> RunnerResult<PathBuf> {
     let parent = path.parent().unwrap_or_else(|| Path::new("."));
-    let mut tmp_name = unit_tmp_name_prefix(path)?;
-    tmp_name.push(uuid::Uuid::new_v4().to_string());
-    Ok(parent.join(tmp_name))
+    let file_name = path.file_name().ok_or_else(|| {
+        RunnerError::Internal(format!(
+            "unit file path has no file name: {}",
+            path.display()
+        ))
+    })?;
+    let mut staging_name = OsString::from(file_name);
+    let nanos = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .map_or(0, |duration| duration.as_nanos());
+    staging_name.push(format!(
+        "{UNIT_STAGING_MARKER}{}.{}.{}",
+        std::process::id(),
+        nanos,
+        attempt
+    ));
+    Ok(parent.join(staging_name))
 }
 
-fn is_unit_tmp_file_name(value: &OsStr, prefix: &OsStr) -> bool {
-    let Some(suffix) = value.as_bytes().strip_prefix(prefix.as_bytes()) else {
-        return false;
-    };
-    let Ok(suffix) = std::str::from_utf8(suffix) else {
-        return false;
-    };
-    uuid::Uuid::parse_str(suffix).is_ok()
+fn unit_staging_prefix(path: &Path) -> RunnerResult<String> {
+    let file_name = path
+        .file_name()
+        .and_then(|name| name.to_str())
+        .ok_or_else(|| {
+            RunnerError::Internal(format!(
+                "unit file path has no UTF-8 file name: {}",
+                path.display()
+            ))
+        })?;
+    Ok(format!("{file_name}{UNIT_STAGING_MARKER}"))
 }
 
-fn cleanup_stale_unit_tmp_files(path: &Path) -> RunnerResult<()> {
+fn remove_stale_unit_staging_file(path: &Path) -> RunnerResult<()> {
+    let meta = match std::fs::symlink_metadata(path) {
+        Ok(meta) => meta,
+        Err(e) if e.kind() == std::io::ErrorKind::NotFound => return Ok(()),
+        Err(e) => {
+            return Err(RunnerError::Internal(format!(
+                "stat stale unit staging file {}: {e}",
+                path.display()
+            )));
+        }
+    };
+    let file_type = meta.file_type();
+    if !meta.is_file() && !file_type.is_symlink() {
+        return Ok(());
+    }
+    std::fs::remove_file(path).map_err(|e| {
+        RunnerError::Internal(format!(
+            "remove stale unit staging file {}: {e}",
+            path.display()
+        ))
+    })
+}
+
+fn cleanup_unit_staging_files(path: &Path) -> RunnerResult<()> {
     let parent = path.parent().unwrap_or_else(|| Path::new("."));
-    let prefix = unit_tmp_name_prefix(path)?;
+    let prefix = unit_staging_prefix(path)?;
+
+    // Do not remove the old fixed `<target>.tmp` path here: during a rolling
+    // deploy an older runner binary may still be using it as its staging file.
     let entries = match std::fs::read_dir(parent) {
         Ok(entries) => entries,
         Err(e) if e.kind() == std::io::ErrorKind::NotFound => return Ok(()),
         Err(e) => {
             return Err(RunnerError::Internal(format!(
-                "read unit dir {}: {e}",
+                "read unit directory {}: {e}",
                 parent.display()
             )));
         }
     };
-
     for entry in entries {
         let entry = entry.map_err(|e| {
-            RunnerError::Internal(format!("read unit dir {}: {e}", parent.display()))
+            RunnerError::Internal(format!("read unit directory {}: {e}", parent.display()))
         })?;
         let file_name = entry.file_name();
-        if !is_unit_tmp_file_name(&file_name, &prefix) {
+        let Some(name) = file_name.to_str() else {
             continue;
-        }
-
-        let file_type = entry
-            .file_type()
-            .map_err(|e| RunnerError::Internal(format!("stat {}: {e}", entry.path().display())))?;
-        if !file_type.is_file() && !file_type.is_symlink() {
-            continue;
-        }
-
-        let stale = entry.path();
-        if let Err(e) = std::fs::remove_file(&stale)
-            && e.kind() != std::io::ErrorKind::NotFound
-        {
-            return Err(RunnerError::Internal(format!(
-                "remove stale unit temp {}: {e}",
-                stale.display()
-            )));
+        };
+        if name.starts_with(&prefix) {
+            remove_stale_unit_staging_file(&entry.path())?;
         }
     }
-
     Ok(())
 }
 
@@ -381,27 +435,39 @@ fn cleanup_stale_unit_tmp_files(path: &Path) -> RunnerResult<()> {
 /// on the host) sees either the old file or the new file — never a
 /// half-written one. Without this, the truncate+write window inside
 /// `std::fs::write` could let systemd parse a partial unit file and leave
-/// the unit in a broken state.
+/// the unit in a broken state. The staging file is unique so concurrent
+/// installs for the same unit do not share a writable temp path.
 fn write_unit_file(path: &Path, content: &str) -> RunnerResult<()> {
-    cleanup_stale_unit_tmp_files(path)?;
-
-    for _ in 0..UNIT_FILE_TMP_ATTEMPTS {
-        let tmp = unique_unit_tmp_path(path)?;
-        let mut file = match std::fs::OpenOptions::new()
-            .write(true)
-            .create_new(true)
-            .open(&tmp)
+    for _ in 0..UNIT_STAGING_MAX_ATTEMPTS {
+        let attempt = UNIT_STAGING_COUNTER.fetch_add(1, Ordering::Relaxed);
+        let tmp = unit_staging_path(path, attempt)?;
+        let mut options = std::fs::OpenOptions::new();
+        options.write(true).create_new(true);
+        #[cfg(unix)]
         {
+            options.mode(UNIT_FILE_MODE);
+        }
+        let mut file = match options.open(&tmp) {
             Ok(file) => file,
             Err(e) if e.kind() == std::io::ErrorKind::AlreadyExists => continue,
             Err(e) => {
                 return Err(RunnerError::Internal(format!(
-                    "create {}: {e}",
+                    "create staging unit file {}: {e}",
                     tmp.display()
                 )));
             }
         };
 
+        #[cfg(unix)]
+        {
+            if let Err(e) = file.set_permissions(std::fs::Permissions::from_mode(UNIT_FILE_MODE)) {
+                let _ = std::fs::remove_file(&tmp);
+                return Err(RunnerError::Internal(format!(
+                    "set permissions on staging unit file {}: {e}",
+                    tmp.display()
+                )));
+            }
+        }
         if let Err(e) = file.write_all(content.as_bytes()) {
             let _ = std::fs::remove_file(&tmp);
             return Err(RunnerError::Internal(format!(
@@ -409,28 +475,37 @@ fn write_unit_file(path: &Path, content: &str) -> RunnerResult<()> {
                 tmp.display()
             )));
         }
+        #[cfg(not(unix))]
         drop(file);
-
-        let result = std::fs::rename(&tmp, path).map_err(|e| {
-            RunnerError::Internal(format!(
+        if let Err(e) = std::fs::rename(&tmp, path) {
+            // Unlike short-lived dirs elsewhere in the crate, unit files live
+            // in /etc/systemd/system/ which no GC path sweeps, and the staged
+            // content contains Environment= secrets.
+            let _ = std::fs::remove_file(&tmp);
+            return Err(RunnerError::Internal(format!(
                 "rename {} -> {}: {e}",
                 tmp.display(),
                 path.display()
-            ))
-        });
-        // Unlike short-lived dirs elsewhere in the crate, unit files live in
-        // /etc/systemd/system/ which no GC path sweeps, and the staged content
-        // contains Environment= secrets.
-        if result.is_err() {
-            let _ = std::fs::remove_file(&tmp);
+            )));
         }
-        return result;
+        return Ok(());
     }
 
     Err(RunnerError::Internal(format!(
-        "create unique unit temp file for {}: exhausted {UNIT_FILE_TMP_ATTEMPTS} attempts",
+        "create unique staging unit file for {}: exhausted {UNIT_STAGING_MAX_ATTEMPTS} attempts",
         path.display()
     )))
+}
+
+fn remove_unit_file_if_exists(path: &Path) -> RunnerResult<()> {
+    match std::fs::remove_file(path) {
+        Ok(()) => Ok(()),
+        Err(e) if e.kind() == std::io::ErrorKind::NotFound => Ok(()),
+        Err(e) => Err(RunnerError::Internal(format!(
+            "remove unit file {}: {e}",
+            path.display()
+        ))),
+    }
 }
 
 /// Check whether a systemd unit is active (running or activating).
@@ -963,8 +1038,11 @@ async fn start(args: ServiceRunArgs) -> RunnerResult<()> {
     }
 
     let config_path = resolve_config_path(&args.config)?;
-    let exe_path =
-        std::env::current_exe().map_err(|e| RunnerError::Internal(format!("current_exe: {e}")))?;
+    let exe_path = validate_current_exe_path(
+        std::env::current_exe().map_err(|e| RunnerError::Internal(format!("current_exe: {e}")))?,
+    )?;
+    validate_systemd_path("current executable path", &exe_path)?;
+    validate_systemd_path("config path", &config_path)?;
 
     let unit_arg = format!("--unit={unit}");
     let desc_arg = format!("--description=VM0 Runner ({unit})");
@@ -1043,13 +1121,18 @@ async fn install(args: ServiceRunArgs) -> RunnerResult<()> {
     let _service_lock = acquire_service_lock(&unit).await?;
 
     validate_env_vars(&args.env)?;
+
     let config_path = resolve_config_path(&args.config)?;
-    let exe_path =
-        std::env::current_exe().map_err(|e| RunnerError::Internal(format!("current_exe: {e}")))?;
+    let exe_path = validate_current_exe_path(
+        std::env::current_exe().map_err(|e| RunnerError::Internal(format!("current_exe: {e}")))?,
+    )?;
+    validate_systemd_path("current executable path", &exe_path)?;
+    validate_systemd_path("config path", &config_path)?;
 
     let unit_content = generate_unit_file(&unit, &exe_path, &config_path, &args.env, args.local);
     let upath = unit_file_path(&unit);
 
+    cleanup_unit_staging_files(&upath)?;
     write_unit_file(&upath, &unit_content)?;
 
     run_systemctl(&["daemon-reload"]).await?;
@@ -1074,9 +1157,10 @@ pub(crate) async fn uninstall_service_unit(unit: &str) -> RunnerResult<()> {
 
     // Remove the unit file if it exists.
     let upath = unit_file_path(unit);
-    if upath.exists()
-        && let Err(e) = std::fs::remove_file(&upath)
-    {
+    if let Err(e) = cleanup_unit_staging_files(&upath) {
+        warn!(unit = %unit, error = %e, "failed to remove stale unit staging files");
+    }
+    if let Err(e) = remove_unit_file_if_exists(&upath) {
         warn!(unit = %unit, error = %e, "failed to remove unit file");
     }
 
@@ -1624,6 +1708,49 @@ mod tests {
         );
     }
 
+    #[cfg(unix)]
+    #[test]
+    fn validate_current_exe_path_accepts_executable_file() {
+        use std::os::unix::fs::PermissionsExt;
+
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("vm0-runner");
+        std::fs::write(&path, "binary").unwrap();
+        std::fs::set_permissions(&path, std::fs::Permissions::from_mode(0o755)).unwrap();
+
+        assert_eq!(validate_current_exe_path(path.clone()).unwrap(), path);
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn validate_current_exe_path_rejects_non_executable_file() {
+        use std::os::unix::fs::PermissionsExt;
+
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("vm0-runner");
+        std::fs::write(&path, "binary").unwrap();
+        std::fs::set_permissions(&path, std::fs::Permissions::from_mode(0o600)).unwrap();
+
+        assert!(validate_current_exe_path(path).is_err());
+    }
+
+    #[test]
+    fn validate_current_exe_path_rejects_missing_path() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("missing-runner");
+
+        assert!(validate_current_exe_path(path).is_err());
+    }
+
+    #[test]
+    fn validate_current_exe_path_rejects_directory() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("vm0-runner");
+        std::fs::create_dir(&path).unwrap();
+
+        assert!(validate_current_exe_path(path).is_err());
+    }
+
     #[test]
     fn test_generate_unit_file() {
         let content = generate_unit_file(
@@ -1830,25 +1957,17 @@ mod tests {
         assert!(validate_env_vars(&["KEY=with\0nul".to_string()]).is_err());
     }
 
-    fn unit_staging_entries(dir: &Path) -> Vec<PathBuf> {
-        let mut entries = std::fs::read_dir(dir)
-            .unwrap()
-            .map(|entry| entry.unwrap().path())
-            .filter(|path| {
-                path.file_name()
-                    .and_then(|name| name.to_str())
-                    .is_some_and(|name| name.contains(".service.tmp."))
-            })
-            .collect::<Vec<_>>();
-        entries.sort();
-        entries
-    }
-
-    fn assert_no_unit_staging_entries(dir: &Path) {
-        let entries = unit_staging_entries(dir);
+    #[test]
+    fn validate_systemd_path_rejects_line_breaks() {
+        assert!(validate_systemd_path("config path", Path::new("/tmp/runner config.yaml")).is_ok());
         assert!(
-            entries.is_empty(),
-            "unit staging entries must be cleaned up: {entries:?}"
+            validate_systemd_path("config path", Path::new("/tmp/runner\nconfig.yaml")).is_err()
+        );
+        assert!(
+            validate_systemd_path("config path", Path::new("/tmp/runner\rconfig.yaml")).is_err()
+        );
+        assert!(
+            validate_systemd_path("config path", Path::new("/tmp/runner\0config.yaml")).is_err()
         );
     }
 
@@ -1875,16 +1994,77 @@ mod tests {
         assert_eq!(std::fs::read_to_string(&path).unwrap(), "new content");
     }
 
+    #[cfg(unix)]
+    #[test]
+    fn write_unit_file_uses_restrictive_permissions_for_new_unit() {
+        use std::os::unix::fs::PermissionsExt;
+
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("vm0-runner-test.service");
+
+        write_unit_file(&path, "content").unwrap();
+
+        let mode = std::fs::metadata(&path).unwrap().permissions().mode() & 0o777;
+        assert_eq!(mode, 0o600);
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn write_unit_file_tightens_existing_permissions() {
+        use std::os::unix::fs::PermissionsExt;
+
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("vm0-runner-test.service");
+        std::fs::write(&path, "old content").unwrap();
+        std::fs::set_permissions(&path, std::fs::Permissions::from_mode(0o644)).unwrap();
+
+        write_unit_file(&path, "new content").unwrap();
+
+        let mode = std::fs::metadata(&path).unwrap().permissions().mode() & 0o777;
+        assert_eq!(mode, 0o600);
+        assert_eq!(std::fs::read_to_string(&path).unwrap(), "new content");
+    }
+
+    #[test]
+    fn write_unit_file_allows_concurrent_writers() {
+        use std::sync::{Arc, Barrier};
+
+        let dir = tempfile::tempdir().unwrap();
+        let path = Arc::new(dir.path().join("vm0-runner-test.service"));
+        let writer_count = 16;
+        let barrier = Arc::new(Barrier::new(writer_count));
+        let contents: Vec<String> = (0..writer_count)
+            .map(|idx| format!("content-{idx}-{}", "x".repeat(4096)))
+            .collect();
+
+        let handles: Vec<_> = contents
+            .iter()
+            .cloned()
+            .map(|content| {
+                let path = Arc::clone(&path);
+                let barrier = Arc::clone(&barrier);
+                std::thread::spawn(move || {
+                    barrier.wait();
+                    write_unit_file(path.as_path(), &content)
+                })
+            })
+            .collect();
+
+        for handle in handles {
+            handle.join().unwrap().unwrap();
+        }
+
+        let final_content = std::fs::read_to_string(path.as_path()).unwrap();
+        assert!(contents.contains(&final_content));
+        assert_no_unit_staging_files(dir.path(), "vm0-runner-test.service");
+    }
+
     #[test]
     fn write_unit_file_does_not_leave_tmp_on_success() {
         let dir = tempfile::tempdir().unwrap();
         let path = dir.path().join("vm0-runner-test.service");
         write_unit_file(&path, "content").unwrap();
-        assert_no_unit_staging_entries(dir.path());
-        assert!(
-            !path.with_extension("tmp").exists(),
-            "legacy fixed tmp path must not be created"
-        );
+        assert_no_unit_staging_files(dir.path(), "vm0-runner-test.service");
     }
 
     #[test]
@@ -1892,65 +2072,113 @@ mod tests {
         let dir = tempfile::tempdir().unwrap();
         let path = dir.path().join("vm0-runner-test.service");
         let legacy_tmp = path.with_extension("tmp");
-        std::fs::create_dir(&legacy_tmp).unwrap();
+        std::fs::write(&legacy_tmp, "legacy").unwrap();
 
         write_unit_file(&path, "content").unwrap();
 
         assert_eq!(std::fs::read_to_string(&path).unwrap(), "content");
-        assert!(legacy_tmp.is_dir(), "legacy tmp path must be untouched");
-        assert_no_unit_staging_entries(dir.path());
+        assert_eq!(std::fs::read_to_string(&legacy_tmp).unwrap(), "legacy");
+        assert_no_unit_staging_files(dir.path(), "vm0-runner-test.service");
     }
 
     #[test]
-    fn write_unit_file_removes_prior_staging_for_same_unit() {
+    fn cleanup_unit_staging_files_preserves_legacy_fixed_tmp() {
         let dir = tempfile::tempdir().unwrap();
         let path = dir.path().join("vm0-runner-test.service");
-        let stale = dir.path().join(format!(
-            ".vm0-runner-test.service.tmp.{}",
-            uuid::Uuid::new_v4()
-        ));
-        std::fs::write(&stale, "Environment=\"SECRET=value\"\n").unwrap();
+        let legacy_tmp = path.with_extension("tmp");
+        let stale_unique = dir.path().join("vm0-runner-test.service.tmp@123.456.0");
+        let other_unit_staging = dir.path().join("vm0-runner-other.service.tmp@123.456.0");
+        let colliding_unit_staging = dir
+            .path()
+            .join("vm0-runner-test.service.tmp.other.service.tmp@123.456.0");
+        let staging_dir = dir.path().join("vm0-runner-test.service.tmp.dir");
 
-        write_unit_file(&path, "content").unwrap();
+        std::fs::write(&path, "current").unwrap();
+        std::fs::write(&legacy_tmp, "legacy").unwrap();
+        std::fs::write(&stale_unique, "stale").unwrap();
+        std::fs::write(&other_unit_staging, "other").unwrap();
+        std::fs::write(&colliding_unit_staging, "colliding").unwrap();
+        std::fs::create_dir(&staging_dir).unwrap();
 
-        assert_eq!(std::fs::read_to_string(&path).unwrap(), "content");
-        assert!(!stale.exists(), "same-unit stale staging must be removed");
-        assert_no_unit_staging_entries(dir.path());
-    }
+        cleanup_unit_staging_files(&path).unwrap();
 
-    #[test]
-    fn write_unit_file_preserves_staging_for_other_units() {
-        let dir = tempfile::tempdir().unwrap();
-        let path = dir.path().join("vm0-runner-test.service");
-        let other = dir.path().join(format!(
-            ".vm0-runner-test.service.tmp.other.service.tmp.{}",
-            uuid::Uuid::new_v4()
-        ));
-        std::fs::write(&other, "other content").unwrap();
-
-        write_unit_file(&path, "content").unwrap();
-
-        assert_eq!(std::fs::read_to_string(&path).unwrap(), "content");
+        assert_eq!(std::fs::read_to_string(&path).unwrap(), "current");
         assert!(
-            other.exists(),
-            "staging residue for a different unit must be untouched"
+            legacy_tmp.exists(),
+            "legacy fixed staging may be in use by an older runner binary"
         );
-        assert_eq!(std::fs::read_to_string(&other).unwrap(), "other content");
-        std::fs::remove_file(other).unwrap();
-        assert_no_unit_staging_entries(dir.path());
+        assert!(!stale_unique.exists(), "unique staging must be removed");
+        assert!(
+            other_unit_staging.exists(),
+            "other unit staging must not be removed"
+        );
+        assert!(
+            colliding_unit_staging.exists(),
+            "dot-prefixed unit names must not collide with this unit staging"
+        );
+        assert!(staging_dir.exists(), "directories must not be removed");
     }
 
     #[test]
-    fn write_unit_file_cleans_up_tmp_on_rename_failure() {
+    fn write_unit_file_cleans_up_staging_on_rename_failure() {
         // Rename fails when the target path is an existing directory
-        // (EISDIR). Staged content may contain Environment= secrets and must
-        // not persist in /etc/systemd/system/.
+        // (EISDIR). Verifies the staged content — which may contain
+        // Environment= secrets — is removed so it doesn't persist in
+        // /etc/systemd/system/.
         let dir = tempfile::tempdir().unwrap();
         let path = dir.path().join("target.service");
         std::fs::create_dir(&path).unwrap();
         let result = write_unit_file(&path, "secret=xyz");
         assert!(result.is_err(), "rename onto existing dir must fail");
-        assert_no_unit_staging_entries(dir.path());
+        assert_no_unit_staging_files(dir.path(), "target.service");
+    }
+
+    #[test]
+    fn remove_unit_file_if_exists_removes_regular_file() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("target.service");
+        std::fs::write(&path, "unit").unwrap();
+
+        remove_unit_file_if_exists(&path).unwrap();
+
+        assert!(!path.exists());
+    }
+
+    #[test]
+    fn remove_unit_file_if_exists_ignores_missing_file() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("target.service");
+
+        remove_unit_file_if_exists(&path).unwrap();
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn remove_unit_file_if_exists_removes_broken_symlink() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("target.service");
+        std::os::unix::fs::symlink(dir.path().join("missing-target"), &path).unwrap();
+
+        remove_unit_file_if_exists(&path).unwrap();
+
+        assert!(
+            std::fs::symlink_metadata(&path).is_err(),
+            "broken unit symlink should be removed"
+        );
+    }
+
+    fn assert_no_unit_staging_files(dir: &Path, unit_file_name: &str) {
+        let staging_prefix = format!("{unit_file_name}{UNIT_STAGING_MARKER}");
+        let staging_files: Vec<_> = std::fs::read_dir(dir)
+            .unwrap()
+            .filter_map(Result::ok)
+            .map(|entry| entry.file_name().to_string_lossy().into_owned())
+            .filter(|name| name.starts_with(&staging_prefix))
+            .collect();
+        assert!(
+            staging_files.is_empty(),
+            "staging files must be cleaned up: {staging_files:?}"
+        );
     }
 
     // -----------------------------------------------------------------

--- a/crates/runner/src/paths.rs
+++ b/crates/runner/src/paths.rs
@@ -251,6 +251,13 @@ impl HomePaths {
         self.debootstrap_dir().join(".lock")
     }
 
+    /// Lock file for persistent service unit lifecycle operations.
+    ///
+    /// Callers should pass full unit names produced by `service::unit_name`.
+    pub fn service_lock(&self, unit: &str) -> PathBuf {
+        self.locks_dir().join(format!("service-{unit}.lock"))
+    }
+
     pub fn base_dir_lock(&self, base_dir: &Path) -> PathBuf {
         let hash = hex::encode(Sha256::digest(base_dir.as_os_str().as_encoded_bytes()));
         self.locks_dir().join(format!("base-dir-{hash}.lock"))
@@ -274,11 +281,6 @@ impl HomePaths {
 
     pub fn snapshot_lock(&self, hash: &str) -> PathBuf {
         self.locks_dir().join(format!("snapshot-{hash}.lock"))
-    }
-
-    /// Per-systemd-unit flock path. Pass a full name produced by `service::unit_name`.
-    pub fn service_lock(&self, unit: &str) -> PathBuf {
-        self.locks_dir().join(format!("service-{unit}.lock"))
     }
 
     /// Root directory for the runner-side storage archive cache.
@@ -578,6 +580,17 @@ mod tests {
     }
 
     #[test]
+    fn service_lock_path() {
+        let home = HomePaths::with_root(PathBuf::from("/test"));
+        let service_lock = home.service_lock("vm0-runner-v1.2.3");
+        assert_eq!(
+            service_lock,
+            PathBuf::from("/test/locks/service-vm0-runner-v1.2.3.lock")
+        );
+        assert_eq!(service_lock.parent(), Some(home.locks_dir().as_path()));
+    }
+
+    #[test]
     fn base_dir_lock_is_deterministic() {
         let home = HomePaths::with_root(PathBuf::from("/test"));
         let lock1 = home.base_dir_lock(Path::new("/data/runner-01"));
@@ -667,16 +680,6 @@ mod tests {
         let home = HomePaths::with_root(PathBuf::from("/test"));
         let lock = home.snapshot_lock("bbb");
         assert_eq!(lock, PathBuf::from("/test/locks/snapshot-bbb.lock"));
-    }
-
-    #[test]
-    fn service_lock_path() {
-        let home = HomePaths::with_root(PathBuf::from("/test"));
-        let lock = home.service_lock("vm0-runner-v0.2.0");
-        assert_eq!(
-            lock,
-            PathBuf::from("/test/locks/service-vm0-runner-v0.2.0.lock")
-        );
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- write systemd unit files through unique sibling staging files instead of a shared .tmp path
- add per-unit service lifecycle locks around persistent install/uninstall and GC version cleanup
- keep transient service commands unlocked while covering staging cleanup and GC lock-skip behavior with tests

## Tests
- cargo test --manifest-path crates/Cargo.toml -p runner write_unit_file
- cargo test --manifest-path crates/Cargo.toml -p runner gc_versions
- cargo test --manifest-path crates/Cargo.toml -p runner service_lock
- cargo test --manifest-path crates/Cargo.toml -p runner
- cargo fmt --manifest-path crates/Cargo.toml -p runner -- --check
- cargo clippy --manifest-path crates/Cargo.toml -p runner --tests
- pnpm turbo run lint
- pnpm check-types
- pnpm format
- pnpm knip

## Notes
- pnpm vitest was run and failed only in @vm0/desktop src/computer-use-native.test.ts on this Linux container because the vm0-computer CLI reports: accessibility_unavailable: Desktop Computer Use is currently implemented for macOS. Re-running that file produced the same unrelated environment failure.

Closes #16274