### PR TITLE
chore: preserve Anthropic Managed Agents icon color

### DIFF
--- a/turbo/apps/platform/src/views/zero-page/components/settings/connector-icons.tsx
+++ b/turbo/apps/platform/src/views/zero-page/components/settings/connector-icons.tsx
@@ -60,7 +60,8 @@ function connectorIconHasLooseViewBox(type: ConnectorType): boolean {
 }
 
 /**
- * Multi-color / gradient brand marks: skip `zero-icon-mono` so `filter: invert(1)` does not distort them.
+ * Multi-color, gradient, and distinctive single-color brand marks: skip `zero-icon-mono`
+ * so `filter: invert(1)` does not distort their official colors.
  * Dark single-fill logos (e.g. navy) are *not* listed here—they invert for contrast on dark UI.
  */
 const CONNECTOR_ICON_COLORFUL = {
@@ -72,7 +73,7 @@ const CONNECTOR_ICON_COLORFUL = {
   alchemy: true,
   amadeus: true,
   amplitude: true,
-  anthropic: true,
+  "anthropic-managed-agents": true,
   apify: true,
   asana: true,
   ashby: true,


### PR DESCRIPTION
## Summary

- Replace the stale non-connector `anthropic` colorful entry with `anthropic-managed-agents`
- Keep the Anthropic Managed Agents SVG untouched so it preserves `#C97D5D`
- Preserve the official single-color brand mark by skipping `zero-icon-mono` for the actual connector key

## Verification

- `git diff --check`
- `pnpm --filter @vm0/app lint`
- commit hook: prettier, knip, `pnpm check-types`

Closes #16537