### PR TITLE
chore: preserve Atlassian connector icon color

### DIFF
--- a/turbo/apps/platform/src/views/zero-page/components/settings/connector-icons.tsx
+++ b/turbo/apps/platform/src/views/zero-page/components/settings/connector-icons.tsx
@@ -76,6 +76,7 @@ const CONNECTOR_ICON_COLORFUL = {
   apify: true,
   asana: true,
   ashby: true,
+  atlassian: true,
   aviationstack: true,
   azure: true,
   base44: true,


### PR DESCRIPTION
## Summary

- Add `atlassian` to `CONNECTOR_ICON_COLORFUL` so the official blue mark skips `zero-icon-mono`
- Keep the Atlassian SVG untouched and avoid adding any raster assets

## Verification

- `git diff --check`
- `pnpm --filter @vm0/app lint`
- commit hook: prettier, knip, `pnpm check-types`

Closes #16538