### PR TITLE
fix: require developer id for local desktop signing

### DIFF
--- a/turbo/apps/desktop/README.md
+++ b/turbo/apps/desktop/README.md
@@ -36,6 +36,10 @@ pnpm desktop:dev
 
 This packages and runs `Zero Dev.app` with `VM0_DESKTOP_PLATFORM_URL` set to the
 local proxy. Use it for sign-in callback, URL scheme, and permission testing.
+Non-CI packaged desktop builds require the `Developer ID Application: Max &
+Zoe, Inc. (C5UWSXYB67)` signing identity in the local keychain. This keeps the
+app's code requirement stable across rebuilds so macOS Accessibility and Screen
+Recording permissions are not reset by ad-hoc signatures.
 
 The desktop build compiles both Electron entrypoints and the Swift native helper:
 
@@ -106,15 +110,16 @@ oracle independent from `vm0-computer` output.
 
 ## Internal macOS artifacts
 
-The `Desktop` GitHub Actions workflow builds unsigned macOS artifacts for
-internal testing. Run the workflow manually from GitHub Actions, then download
-the `zero-desktop-macos-arm64-unsigned` artifact.
+The `Desktop` GitHub Actions workflow builds macOS artifacts for internal
+testing. Run the workflow manually from GitHub Actions, then download the
+`zero-desktop-macos-arm64-unsigned` artifact.
 
 The downloaded GitHub artifact contains `Zero-darwin-arm64.zip`. Unzip both
 layers, then open `Zero.app`.
 
-These artifacts are intentionally unsigned and unnotarized. macOS Gatekeeper may
-require right-clicking the app and choosing Open, or removing quarantine locally:
+These artifacts are ad-hoc signed, not Developer ID signed, and not notarized.
+macOS Gatekeeper may require right-clicking the app and choosing Open, or
+removing quarantine locally:
 
 ```bash
 xattr -dr com.apple.quarantine Zero.app

--- a/turbo/apps/desktop/forge.config.js
+++ b/turbo/apps/desktop/forge.config.js
@@ -3,6 +3,10 @@ const path = require("node:path");
 const desktopIdentities = require("./src/desktop-identities.json");
 
 const PRODUCTION_PLATFORM_HOSTNAME = "app.vm0.ai";
+const DEVELOPER_ID_APPLICATION_IDENTITY =
+  "Developer ID Application: Max & Zoe, Inc. (C5UWSXYB67)";
+const codeSigningIdentity =
+  process.env.CI === "true" ? "-" : DEVELOPER_ID_APPLICATION_IDENTITY;
 
 function platformHostname(rawUrl) {
   if (!rawUrl || !rawUrl.trim()) {
@@ -34,14 +38,8 @@ module.exports = {
     asar: false,
     extraResource: [path.join(__dirname, "native", "dist", "native")],
     osxSign: {
-      hardenedRuntime: false,
-      identity: "-",
-      identityValidation: false,
-      optionsForFile: () => ({
-        hardenedRuntime: false,
-      }),
-      preAutoEntitlements: false,
-      preEmbedProvisioningProfile: false,
+      identity: codeSigningIdentity,
+      identityValidation: codeSigningIdentity !== "-",
     },
     protocols: [
       {


### PR DESCRIPTION
## Summary
- require the Max & Zoe Developer ID Application identity for non-CI desktop packaging
- keep GitHub Actions desktop artifacts on ad-hoc signing for this PR
- document the local signing requirement and CI artifact signing state

## Tests
- pnpm -F @vm0/desktop check-types
- pnpm -F @vm0/desktop lint
- pnpm -F @vm0/desktop test (requires non-sandbox local Unix socket access)
- pnpm -F @vm0/desktop test:native (requires non-sandbox Swift/clang cache access)
- VM0_DESKTOP_PLATFORM_URL=https://app.vm7.ai:8443 pnpm -F @vm0/desktop package
- codesign --verify --deep --strict --verbose=4 apps/desktop/out/Zero Dev-darwin-arm64/Zero Dev.app
- CI=true VM0_DESKTOP_PLATFORM_URL=https://app.vm7.ai:8443 pnpm -F @vm0/desktop package
- codesign -dv --verbose=4 apps/desktop/out/Zero Dev-darwin-arm64/Zero Dev.app (verified Signature=adhoc, TeamIdentifier=not set under CI=true)
