### PR TITLE
chore(rust): update dependencies

### DIFF
--- a/crates/Cargo.lock
+++ b/crates/Cargo.lock
@@ -3892,9 +3892,9 @@ dependencies = [
 
 [[package]]
 name = "which"
-version = "8.0.2"
+version = "8.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "81995fafaaaf6ae47a7d0cc83c67caf92aeb7e5331650ae6ff856f7c0c60c459"
+checksum = "c789537cf2f7f55be8e6192f92e464174ee55f91af622777f7f1ceb0dbccd03e"
 dependencies = [
  "libc",
 ]


### PR DESCRIPTION
## Summary

- Ran `cargo update --verbose` for the Rust workspace rooted at `crates/`.
- Updated `which` from `8.0.2` to `8.0.3` in `crates/Cargo.lock`.

## Dependencies not updated

- `generic-array` stayed at `0.14.7` even though `0.14.9` is available. `cargo update -p generic-array --precise 0.14.9 --verbose` reports that `crypto-common v0.1.7` requires `generic-array = "=0.14.7"`, via `digest v0.10.7` and the transitive AWS/httpmock/tungstenite dependency graph. There is no direct workspace `Cargo.toml` version specifier to safely bump for this.

## Manual version bumps

- None. No `Cargo.toml` changes were needed; direct `[workspace.dependencies]` specs already allow their latest same-major/same-minor releases.

## Test status

- PASS: `CARGO_INCREMENTAL=0 CARGO_TARGET_DIR=/home/user/workspace/vm0-rust-target cargo test --workspace --jobs 1`
- Note: initial runs using the default target directory on `/tmp` hit the container root disk limit during compilation/linking. The final full workspace run passed after moving `CARGO_TARGET_DIR` to the larger workspace volume.
