### PR TITLE
feat: add expiring permission grants

### DIFF
--- a/turbo/apps/api/src/signals/routes/__tests__/zero-runs-create.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/zero-runs-create.test.ts
@@ -645,6 +645,7 @@ describe("POST /api/zero/runs", () => {
       "zero credit <credits>",
       "zero doctor permission-deny --help",
       "zero doctor permission-change --help",
+      "--duration 1h|24h|7d|always",
       "zero skill --help",
       "zero developer-support --help",
       "zero maps --help",

--- a/turbo/apps/api/src/signals/routes/__tests__/zero-runs-create.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/zero-runs-create.test.ts
@@ -5,6 +5,7 @@ import {
   type ModelProviderType,
 } from "@vm0/api-contracts/contracts/model-providers";
 import type { OrgTier } from "@vm0/api-contracts/contracts/orgs";
+import { zeroUserPermissionGrantsContract } from "@vm0/api-contracts/contracts/zero-user-permission-grants";
 import { zeroRunsMainContract } from "@vm0/api-contracts/contracts/zero-runs";
 import { UNKNOWN_PERMISSION_GRANT } from "@vm0/connectors/firewall-types";
 import { getConnectorFirewall } from "@vm0/connectors/firewalls";
@@ -220,6 +221,10 @@ const seedSession$ = command(
 
 function zeroRunsClient() {
   return setupApp({ context })(zeroRunsMainContract);
+}
+
+function userPermissionGrantsClient() {
+  return setupApp({ context })(zeroUserPermissionGrantsContract);
 }
 
 const track = createFixtureTracker<UsageInsightFixture>((fixture) => {
@@ -2774,6 +2779,31 @@ describe("POST /api/zero/runs", () => {
       action: "allow",
       expiresAt: new Date("2999-01-01T00:00:00.000Z"),
     });
+
+    const policy = await createZeroRunNetworkPolicy(agent.agentId);
+
+    expect(policy.allow).toContain(SLACK_WRITE_PERMISSION);
+    expect(policy.deny).not.toContain(SLACK_WRITE_PERMISSION);
+  });
+
+  it("applies finite grants created through the user grant API", async () => {
+    const fx = await fixture();
+    const agent = await seedRunnableZeroAgent({ fixture: fx });
+    await seedSlackConnector({ fixture: fx, agentId: agent.agentId });
+
+    await accept(
+      userPermissionGrantsClient().upsert({
+        headers: { authorization: "Bearer clerk-session" },
+        body: {
+          agentId: agent.agentId,
+          connectorRef: SLACK_CONNECTOR,
+          permission: SLACK_WRITE_PERMISSION,
+          action: "allow",
+          expiresIn: "1h",
+        },
+      }),
+      [200],
+    );
 
     const policy = await createZeroRunNetworkPolicy(agent.agentId);
 

--- a/turbo/apps/api/src/signals/routes/__tests__/zero-user-permission-grants.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/zero-user-permission-grants.test.ts
@@ -11,6 +11,7 @@ import { userPermissionGrants } from "@vm0/db/schema/user-permission-grant";
 
 import { accept, setupApp, testContext } from "../../../__tests__/test-helpers";
 import { createApp } from "../../../app-factory";
+import { clearMockNow, mockNow } from "../../../lib/time";
 import { writeDb$ } from "../../external/db";
 import { loadActiveUserPermissionGrants } from "../../services/zero-user-permission-grants.service";
 import {
@@ -115,6 +116,7 @@ describe("zero user permission grants", () => {
   }
 
   afterEach(async () => {
+    clearMockNow();
     const db = store.set(writeDb$);
     if (trackedOrgIds.length > 0) {
       await db
@@ -518,5 +520,106 @@ describe("zero user permission grants", () => {
     expect(stored?.createdAt.getTime()).toBe(oldTimestamp.getTime());
     expect(stored?.updatedAt.getTime()).toBeGreaterThan(oldTimestamp.getTime());
     expect(stored?.expiresAt).toBeNull();
+  });
+
+  it("computes grant expiration from server-side expiresIn", async () => {
+    const fixture = await createFixture();
+    const agentId = await seedAgent(fixture);
+    mocks.clerk.session(fixture.userId, fixture.orgId, "org:member");
+    const client = setupApp({ context })(zeroUserPermissionGrantsContract);
+    const timestamp = new Date("2026-02-01T12:00:00.000Z");
+    mockNow(timestamp);
+
+    const oneHour = await accept(
+      client.upsert({
+        body: {
+          agentId,
+          connectorRef: SLACK_CONNECTOR,
+          permission: SLACK_READ_PERMISSION,
+          action: "allow",
+          expiresIn: "1h",
+        },
+        headers: AUTH_HEADERS,
+      }),
+      [200],
+    );
+    expect(oneHour.body.expiresAt).toBe("2026-02-01T13:00:00.000Z");
+
+    const oneDay = await accept(
+      client.upsert({
+        body: {
+          agentId,
+          connectorRef: SLACK_CONNECTOR,
+          permission: SLACK_READ_PERMISSION,
+          action: "allow",
+          expiresIn: "24h",
+        },
+        headers: AUTH_HEADERS,
+      }),
+      [200],
+    );
+    expect(oneDay.body.expiresAt).toBe("2026-02-02T12:00:00.000Z");
+
+    const sevenDays = await accept(
+      client.upsert({
+        body: {
+          agentId,
+          connectorRef: SLACK_CONNECTOR,
+          permission: SLACK_READ_PERMISSION,
+          action: "allow",
+          expiresIn: "7d",
+        },
+        headers: AUTH_HEADERS,
+      }),
+      [200],
+    );
+    expect(sevenDays.body.expiresAt).toBe("2026-02-08T12:00:00.000Z");
+
+    const forever = await accept(
+      client.upsert({
+        body: {
+          agentId,
+          connectorRef: SLACK_CONNECTOR,
+          permission: SLACK_READ_PERMISSION,
+          action: "allow",
+          expiresIn: "forever",
+        },
+        headers: AUTH_HEADERS,
+      }),
+      [200],
+    );
+    expect(forever.body.expiresAt).toBeNull();
+
+    const stored = await readStoredGrant({
+      orgId: fixture.orgId,
+      userId: fixture.userId,
+      agentId,
+      connectorRef: SLACK_CONNECTOR,
+      permission: SLACK_READ_PERMISSION,
+    });
+    expect(stored?.expiresAt).toBeNull();
+  });
+
+  it("rejects invalid grant expiration options", async () => {
+    const fixture = await createFixture();
+    const agentId = await seedAgent(fixture);
+    mocks.clerk.session(fixture.userId, fixture.orgId, "org:member");
+    const app = createApp({ signal: context.signal });
+
+    const response = await app.request("/api/zero/user-permission-grants", {
+      method: "PUT",
+      headers: {
+        authorization: AUTH_HEADERS.authorization,
+        "content-type": "application/json",
+      },
+      body: JSON.stringify({
+        agentId,
+        connectorRef: SLACK_CONNECTOR,
+        permission: SLACK_READ_PERMISSION,
+        action: "allow",
+        expiresIn: "2h",
+      }),
+    });
+    expect(response.status).toBe(400);
   });
 });

--- a/turbo/apps/api/src/signals/routes/__tests__/zero-user-permission-grants.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/zero-user-permission-grants.test.ts
@@ -455,7 +455,7 @@ describe("zero user permission grants", () => {
     expect(permissionGrantsToFirewallPolicies([])).toBeNull();
   });
 
-  it("updates action and preserves active expiration when expiresIn is omitted", async () => {
+  it("preserves active allow expiration when expiresIn is omitted", async () => {
     const fixture = await createFixture();
     const agentId = await seedAgent(fixture);
     mocks.clerk.session(fixture.userId, fixture.orgId, "org:member");
@@ -500,13 +500,13 @@ describe("zero user permission grants", () => {
           agentId,
           connectorRef: SLACK_CONNECTOR,
           permission: SLACK_READ_PERMISSION,
-          action: "deny",
+          action: "allow",
         },
         headers: AUTH_HEADERS,
       }),
       [200],
     );
-    expect(second.body.action).toBe("deny");
+    expect(second.body.action).toBe("allow");
     expect(second.body.expiresAt).toBe(oldExpiresAt.toISOString());
 
     const stored = await readStoredGrant({
@@ -516,10 +516,56 @@ describe("zero user permission grants", () => {
       connectorRef: SLACK_CONNECTOR,
       permission: SLACK_READ_PERMISSION,
     });
-    expect(stored?.action).toBe("deny");
+    expect(stored?.action).toBe("allow");
     expect(stored?.createdAt.getTime()).toBe(oldTimestamp.getTime());
     expect(stored?.updatedAt.getTime()).toBeGreaterThan(oldTimestamp.getTime());
     expect(stored?.expiresAt?.getTime()).toBe(oldExpiresAt.getTime());
+  });
+
+  it("clears active expiration when action changes to deny", async () => {
+    const fixture = await createFixture();
+    const agentId = await seedAgent(fixture);
+    mocks.clerk.session(fixture.userId, fixture.orgId, "org:member");
+    const client = setupApp({ context })(zeroUserPermissionGrantsContract);
+
+    await accept(
+      client.upsert({
+        body: {
+          agentId,
+          connectorRef: SLACK_CONNECTOR,
+          permission: SLACK_READ_PERMISSION,
+          action: "allow",
+          expiresIn: "1h",
+        },
+        headers: AUTH_HEADERS,
+      }),
+      [200],
+    );
+
+    const denied = await accept(
+      client.upsert({
+        body: {
+          agentId,
+          connectorRef: SLACK_CONNECTOR,
+          permission: SLACK_READ_PERMISSION,
+          action: "deny",
+        },
+        headers: AUTH_HEADERS,
+      }),
+      [200],
+    );
+    expect(denied.body.action).toBe("deny");
+    expect(denied.body.expiresAt).toBeNull();
+
+    const stored = await readStoredGrant({
+      orgId: fixture.orgId,
+      userId: fixture.userId,
+      agentId,
+      connectorRef: SLACK_CONNECTOR,
+      permission: SLACK_READ_PERMISSION,
+    });
+    expect(stored?.action).toBe("deny");
+    expect(stored?.expiresAt).toBeNull();
   });
 
   it("clears active expiration only when expiresIn is forever", async () => {
@@ -695,6 +741,29 @@ describe("zero user permission grants", () => {
         permission: SLACK_READ_PERMISSION,
         action: "allow",
         expiresIn: "2h",
+      }),
+    });
+    expect(response.status).toBe(400);
+  });
+
+  it("rejects expiration options for deny grants", async () => {
+    const fixture = await createFixture();
+    const agentId = await seedAgent(fixture);
+    mocks.clerk.session(fixture.userId, fixture.orgId, "org:member");
+    const app = createApp({ signal: context.signal });
+
+    const response = await app.request("/api/zero/user-permission-grants", {
+      method: "PUT",
+      headers: {
+        authorization: AUTH_HEADERS.authorization,
+        "content-type": "application/json",
+      },
+      body: JSON.stringify({
+        agentId,
+        connectorRef: SLACK_CONNECTOR,
+        permission: SLACK_READ_PERMISSION,
+        action: "deny",
+        expiresIn: "1h",
       }),
     });
     expect(response.status).toBe(400);

--- a/turbo/apps/api/src/signals/routes/__tests__/zero-user-permission-grants.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/zero-user-permission-grants.test.ts
@@ -568,7 +568,7 @@ describe("zero user permission grants", () => {
     expect(stored?.expiresAt).toBeNull();
   });
 
-  it("clears active expiration only when expiresIn is forever", async () => {
+  it("clears active expiration only when expiresIn is always", async () => {
     const fixture = await createFixture();
     const agentId = await seedAgent(fixture);
     mocks.clerk.session(fixture.userId, fixture.orgId, "org:member");
@@ -595,7 +595,7 @@ describe("zero user permission grants", () => {
           connectorRef: SLACK_CONNECTOR,
           permission: SLACK_READ_PERMISSION,
           action: "allow",
-          expiresIn: "forever",
+          expiresIn: "always",
         },
         headers: AUTH_HEADERS,
       }),
@@ -698,20 +698,20 @@ describe("zero user permission grants", () => {
     );
     expect(sevenDays.body.expiresAt).toBe("2026-02-08T12:00:00.000Z");
 
-    const forever = await accept(
+    const always = await accept(
       client.upsert({
         body: {
           agentId,
           connectorRef: SLACK_CONNECTOR,
           permission: SLACK_READ_PERMISSION,
           action: "allow",
-          expiresIn: "forever",
+          expiresIn: "always",
         },
         headers: AUTH_HEADERS,
       }),
       [200],
     );
-    expect(forever.body.expiresAt).toBeNull();
+    expect(always.body.expiresAt).toBeNull();
 
     const stored = await readStoredGrant({
       orgId: fixture.orgId,

--- a/turbo/apps/api/src/signals/routes/__tests__/zero-user-permission-grants.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/zero-user-permission-grants.test.ts
@@ -455,7 +455,7 @@ describe("zero user permission grants", () => {
     expect(permissionGrantsToFirewallPolicies([])).toBeNull();
   });
 
-  it("updates action and updatedAt without changing createdAt", async () => {
+  it("updates action and preserves active expiration when expiresIn is omitted", async () => {
     const fixture = await createFixture();
     const agentId = await seedAgent(fixture);
     mocks.clerk.session(fixture.userId, fixture.orgId, "org:member");
@@ -475,7 +475,7 @@ describe("zero user permission grants", () => {
     );
 
     const oldTimestamp = new Date("2024-01-01T00:00:00.000Z");
-    const oldExpiresAt = new Date("2024-01-01T00:05:00.000Z");
+    const oldExpiresAt = new Date("2099-01-01T00:05:00.000Z");
     const db = store.set(writeDb$);
     await db
       .update(userPermissionGrants)
@@ -507,7 +507,7 @@ describe("zero user permission grants", () => {
       [200],
     );
     expect(second.body.action).toBe("deny");
-    expect(second.body.expiresAt).toBeNull();
+    expect(second.body.expiresAt).toBe(oldExpiresAt.toISOString());
 
     const stored = await readStoredGrant({
       orgId: fixture.orgId,
@@ -519,7 +519,84 @@ describe("zero user permission grants", () => {
     expect(stored?.action).toBe("deny");
     expect(stored?.createdAt.getTime()).toBe(oldTimestamp.getTime());
     expect(stored?.updatedAt.getTime()).toBeGreaterThan(oldTimestamp.getTime());
+    expect(stored?.expiresAt?.getTime()).toBe(oldExpiresAt.getTime());
+  });
+
+  it("clears active expiration only when expiresIn is forever", async () => {
+    const fixture = await createFixture();
+    const agentId = await seedAgent(fixture);
+    mocks.clerk.session(fixture.userId, fixture.orgId, "org:member");
+    const client = setupApp({ context })(zeroUserPermissionGrantsContract);
+
+    await accept(
+      client.upsert({
+        body: {
+          agentId,
+          connectorRef: SLACK_CONNECTOR,
+          permission: SLACK_READ_PERMISSION,
+          action: "allow",
+          expiresIn: "1h",
+        },
+        headers: AUTH_HEADERS,
+      }),
+      [200],
+    );
+
+    const cleared = await accept(
+      client.upsert({
+        body: {
+          agentId,
+          connectorRef: SLACK_CONNECTOR,
+          permission: SLACK_READ_PERMISSION,
+          action: "allow",
+          expiresIn: "forever",
+        },
+        headers: AUTH_HEADERS,
+      }),
+      [200],
+    );
+    expect(cleared.body.expiresAt).toBeNull();
+
+    const stored = await readStoredGrant({
+      orgId: fixture.orgId,
+      userId: fixture.userId,
+      agentId,
+      connectorRef: SLACK_CONNECTOR,
+      permission: SLACK_READ_PERMISSION,
+    });
     expect(stored?.expiresAt).toBeNull();
+  });
+
+  it("revives expired grants as permanent grants when expiresIn is omitted", async () => {
+    const fixture = await createFixture();
+    const agentId = await seedAgent(fixture);
+    mocks.clerk.session(fixture.userId, fixture.orgId, "org:member");
+    const client = setupApp({ context })(zeroUserPermissionGrantsContract);
+    const db = store.set(writeDb$);
+    await db.insert(userPermissionGrants).values({
+      orgId: fixture.orgId,
+      userId: fixture.userId,
+      agentId,
+      connectorRef: SLACK_CONNECTOR,
+      permission: SLACK_READ_PERMISSION,
+      action: "allow",
+      expiresAt: new Date("2000-01-01T00:00:00.000Z"),
+    });
+
+    const revived = await accept(
+      client.upsert({
+        body: {
+          agentId,
+          connectorRef: SLACK_CONNECTOR,
+          permission: SLACK_READ_PERMISSION,
+          action: "deny",
+        },
+        headers: AUTH_HEADERS,
+      }),
+      [200],
+    );
+    expect(revived.body.action).toBe("deny");
+    expect(revived.body.expiresAt).toBeNull();
   });
 
   it("computes grant expiration from server-side expiresIn", async () => {

--- a/turbo/apps/api/src/signals/routes/__tests__/zero-user-permission-grants.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/zero-user-permission-grants.test.ts
@@ -635,13 +635,13 @@ describe("zero user permission grants", () => {
           agentId,
           connectorRef: SLACK_CONNECTOR,
           permission: SLACK_READ_PERMISSION,
-          action: "deny",
+          action: "allow",
         },
         headers: AUTH_HEADERS,
       }),
       [200],
     );
-    expect(revived.body.action).toBe("deny");
+    expect(revived.body.action).toBe("allow");
     expect(revived.body.expiresAt).toBeNull();
   });
 

--- a/turbo/apps/api/src/signals/services/zero-runs-create.service.ts
+++ b/turbo/apps/api/src/signals/services/zero-runs-create.service.ts
@@ -214,7 +214,7 @@ function buildAgentToolsPrompt(triggerSource: TriggerSource): string {
     '- When the user asks to generate anything (supported generation content: image, video, presentation, voice/audio, and connector-backed text, code, document, or website), run `zero generate -h`. Use `zero generate <type>` (no --prompt) to list every provider available for that type; then run `zero generate <type> --provider built-in --prompt "..."` to execute via vm0, or `zero generate <type> --provider <connector>` to get connector skill-invocation guidance. Do not claim support for other generated content.',
     "- If you choose a Zero generation command, wait for it to finish and use its returned artifact. Do not abandon it, switch to your own generation approach, or recreate the output yourself just because generation takes a long time.",
     "- Troubleshoot permission denials: `zero doctor permission-deny --help` to identify which permission covers a blocked request.",
-    "- Request permission changes: `zero doctor permission-change --help` to enable or disable a permission.",
+    "- Request permission changes: `zero doctor permission-change --help` to enable or disable a permission. For enable requests, pass `--duration 1h|24h|7d|always`: default to `--duration 1h` for one-off work, use `24h` or `7d` for longer user-approved work, and use `always` only when the user explicitly asks for persistent access.",
     "- Inspect yourself: `zero whoami` for identity and permissions, `zero agent view $ZERO_AGENT_ID --instructions` for your current settings.",
     "- When the user asks to change your behavior, update your own configuration (instructions, tone, description): `zero agent edit --help`.",
     "- Manage custom skills: `zero skill --help`.",

--- a/turbo/apps/api/src/signals/services/zero-user-permission-grants.service.ts
+++ b/turbo/apps/api/src/signals/services/zero-user-permission-grants.service.ts
@@ -9,6 +9,7 @@ import { zeroAgents } from "@vm0/db/schema/zero-agent";
 import { and, asc, eq, gt, isNull, or } from "drizzle-orm";
 import type {
   UpsertUserPermissionGrantRequest,
+  UserPermissionGrantExpiresIn,
   UserPermissionGrantResponse,
 } from "@vm0/api-contracts/contracts/zero-user-permission-grants";
 
@@ -56,6 +57,9 @@ type UpsertUserPermissionGrantResult =
     }
   | NotFoundResponse
   | ValidationErrorResponse;
+
+const HOUR_MS = 60 * 60 * 1000;
+const DAY_MS = 24 * HOUR_MS;
 
 function validationError(message: string): ValidationErrorResponse {
   return {
@@ -133,6 +137,27 @@ function activeGrantCondition(checkedAt: Date) {
     isNull(userPermissionGrants.expiresAt),
     gt(userPermissionGrants.expiresAt, checkedAt),
   );
+}
+
+function resolveGrantExpiresAt(
+  expiresIn: UserPermissionGrantExpiresIn | undefined,
+  timestamp: Date,
+): Date | null {
+  switch (expiresIn) {
+    case "1h": {
+      return new Date(timestamp.getTime() + HOUR_MS);
+    }
+    case "24h": {
+      return new Date(timestamp.getTime() + DAY_MS);
+    }
+    case "7d": {
+      return new Date(timestamp.getTime() + 7 * DAY_MS);
+    }
+    case "forever":
+    case undefined: {
+      return null;
+    }
+  }
 }
 
 function formatUserPermissionGrant(
@@ -223,6 +248,7 @@ async function upsertVisibleGrantRow(
     }
 
     const timestamp = nowDate();
+    const expiresAt = resolveGrantExpiresAt(args.grant.expiresIn, timestamp);
     const [row] = await tx
       .insert(userPermissionGrants)
       .values({
@@ -232,7 +258,7 @@ async function upsertVisibleGrantRow(
         connectorRef: args.grant.connectorRef,
         permission: args.grant.permission,
         action: args.grant.action,
-        expiresAt: null,
+        expiresAt,
         createdAt: timestamp,
         updatedAt: timestamp,
       })
@@ -246,7 +272,7 @@ async function upsertVisibleGrantRow(
         ],
         set: {
           action: args.grant.action,
-          expiresAt: null,
+          expiresAt,
           updatedAt: timestamp,
         },
       })

--- a/turbo/apps/api/src/signals/services/zero-user-permission-grants.service.ts
+++ b/turbo/apps/api/src/signals/services/zero-user-permission-grants.service.ts
@@ -160,6 +160,16 @@ function resolveGrantExpiresAt(
   }
 }
 
+function preservedActiveGrantExpiresAt(
+  expiresAt: Date | null,
+  timestamp: Date,
+): Date | null {
+  if (!expiresAt) {
+    return null;
+  }
+  return expiresAt.getTime() > timestamp.getTime() ? expiresAt : null;
+}
+
 function formatUserPermissionGrant(
   row: Pick<
     UserPermissionGrantRow,
@@ -248,35 +258,58 @@ async function upsertVisibleGrantRow(
     }
 
     const timestamp = nowDate();
-    const expiresAt = resolveGrantExpiresAt(args.grant.expiresIn, timestamp);
-    const [row] = await tx
-      .insert(userPermissionGrants)
-      .values({
-        orgId: args.orgId,
-        userId: args.userId,
-        agentId: args.grant.agentId,
-        connectorRef: args.grant.connectorRef,
-        permission: args.grant.permission,
-        action: args.grant.action,
-        expiresAt,
-        createdAt: timestamp,
-        updatedAt: timestamp,
-      })
-      .onConflictDoUpdate({
-        target: [
-          userPermissionGrants.orgId,
-          userPermissionGrants.userId,
-          userPermissionGrants.agentId,
-          userPermissionGrants.connectorRef,
-          userPermissionGrants.permission,
-        ],
-        set: {
-          action: args.grant.action,
-          expiresAt,
-          updatedAt: timestamp,
-        },
-      })
-      .returning();
+    const [existing] = await tx
+      .select()
+      .from(userPermissionGrants)
+      .where(
+        and(
+          eq(userPermissionGrants.orgId, args.orgId),
+          eq(userPermissionGrants.userId, args.userId),
+          eq(userPermissionGrants.agentId, args.grant.agentId),
+          eq(userPermissionGrants.connectorRef, args.grant.connectorRef),
+          eq(userPermissionGrants.permission, args.grant.permission),
+        ),
+      )
+      .for("update")
+      .limit(1);
+
+    const expiresAt =
+      args.grant.expiresIn === undefined
+        ? preservedActiveGrantExpiresAt(existing?.expiresAt ?? null, timestamp)
+        : resolveGrantExpiresAt(args.grant.expiresIn, timestamp);
+
+    const [row] = existing
+      ? await tx
+          .update(userPermissionGrants)
+          .set({
+            action: args.grant.action,
+            expiresAt,
+            updatedAt: timestamp,
+          })
+          .where(
+            and(
+              eq(userPermissionGrants.orgId, args.orgId),
+              eq(userPermissionGrants.userId, args.userId),
+              eq(userPermissionGrants.agentId, args.grant.agentId),
+              eq(userPermissionGrants.connectorRef, args.grant.connectorRef),
+              eq(userPermissionGrants.permission, args.grant.permission),
+            ),
+          )
+          .returning()
+      : await tx
+          .insert(userPermissionGrants)
+          .values({
+            orgId: args.orgId,
+            userId: args.userId,
+            agentId: args.grant.agentId,
+            connectorRef: args.grant.connectorRef,
+            permission: args.grant.permission,
+            action: args.grant.action,
+            expiresAt,
+            createdAt: timestamp,
+            updatedAt: timestamp,
+          })
+          .returning();
 
     if (!row) {
       throw new Error("User permission grant upsert did not return a row");

--- a/turbo/apps/api/src/signals/services/zero-user-permission-grants.service.ts
+++ b/turbo/apps/api/src/signals/services/zero-user-permission-grants.service.ts
@@ -132,6 +132,17 @@ function validateGrantTarget(
   return null;
 }
 
+function validateGrantExpiration(
+  grant: UpsertUserPermissionGrantRequest,
+): ValidationErrorResponse | null {
+  if (grant.action === "allow" || grant.expiresIn === undefined) {
+    return null;
+  }
+  return validationError(
+    "Permission grant expiration is only supported for allow grants",
+  );
+}
+
 function activeGrantCondition(checkedAt: Date) {
   return or(
     isNull(userPermissionGrants.expiresAt),
@@ -274,9 +285,14 @@ async function upsertVisibleGrantRow(
       .limit(1);
 
     const expiresAt =
-      args.grant.expiresIn === undefined
-        ? preservedActiveGrantExpiresAt(existing?.expiresAt ?? null, timestamp)
-        : resolveGrantExpiresAt(args.grant.expiresIn, timestamp);
+      args.grant.action === "allow"
+        ? args.grant.expiresIn === undefined
+          ? preservedActiveGrantExpiresAt(
+              existing?.action === "allow" ? existing.expiresAt : null,
+              timestamp,
+            )
+          : resolveGrantExpiresAt(args.grant.expiresIn, timestamp)
+        : null;
 
     const [row] = existing
       ? await tx
@@ -353,6 +369,10 @@ export const upsertUserPermissionGrant$ = command(
     );
     if (validation) {
       return validation;
+    }
+    const expirationValidation = validateGrantExpiration(args.grant);
+    if (expirationValidation) {
+      return expirationValidation;
     }
 
     const writeDb = set(writeDb$);

--- a/turbo/apps/api/src/signals/services/zero-user-permission-grants.service.ts
+++ b/turbo/apps/api/src/signals/services/zero-user-permission-grants.service.ts
@@ -164,7 +164,7 @@ function resolveGrantExpiresAt(
     case "7d": {
       return new Date(timestamp.getTime() + 7 * DAY_MS);
     }
-    case "forever":
+    case "always":
     case undefined: {
       return null;
     }

--- a/turbo/apps/cli/src/commands/zero/doctor/__tests__/permission-change.test.ts
+++ b/turbo/apps/cli/src/commands/zero/doctor/__tests__/permission-change.test.ts
@@ -45,7 +45,30 @@ describe("zero doctor permission-change command", () => {
     expect(logCalls).toContain("ref=slack");
     expect(logCalls).toContain("permission=channels%3Aread");
     expect(logCalls).toContain("action=allow");
+    expect(logCalls).toContain("expiresIn=1h");
+    expect(logCalls).toContain("Requested duration: 1h");
     expect(logCalls).not.toContain("admin approval");
+  });
+
+  it("outputs an allow grant link with an explicit duration", async () => {
+    vi.stubEnv("VM0_API_URL", "https://app.vm0.ai");
+    vi.stubEnv("ZERO_AGENT_ID", "agent-abc-123");
+
+    await permissionChangeCommand.parseAsync([
+      "node",
+      "cli",
+      "slack",
+      "--permission",
+      "channels:read",
+      "--enable",
+      "--duration",
+      "24h",
+    ]);
+
+    const logCalls = mockConsoleLog.mock.calls.flat().join("\n");
+    expect(logCalls).toContain("action=allow");
+    expect(logCalls).toContain("expiresIn=24h");
+    expect(logCalls).toContain("Requested duration: 24h");
   });
 
   it("outputs a deny grant link for --disable", async () => {
@@ -67,6 +90,8 @@ describe("zero doctor permission-change command", () => {
     );
     expect(logCalls).toContain("[Manage Slack permissions]");
     expect(logCalls).toContain("action=deny");
+    expect(logCalls).not.toContain("expiresIn=");
+    expect(logCalls).not.toContain("Requested duration");
     expect(logCalls).not.toContain("admin approval");
   });
 
@@ -214,6 +239,25 @@ describe("zero doctor permission-change command", () => {
 
     expect(mockConsoleError).toHaveBeenCalledWith(
       expect.stringContaining("Either --enable or --disable is required"),
+    );
+  });
+
+  it("exits with an error when --duration is used with --disable", async () => {
+    await expect(async () => {
+      await permissionChangeCommand.parseAsync([
+        "node",
+        "cli",
+        "slack",
+        "--permission",
+        "channels:read",
+        "--disable",
+        "--duration",
+        "1h",
+      ]);
+    }).rejects.toThrow("process.exit called");
+
+    expect(mockConsoleError).toHaveBeenCalledWith(
+      expect.stringContaining("--duration is only supported with --enable"),
     );
   });
 });

--- a/turbo/apps/cli/src/commands/zero/doctor/__tests__/permission-deny.test.ts
+++ b/turbo/apps/cli/src/commands/zero/doctor/__tests__/permission-deny.test.ts
@@ -54,6 +54,7 @@ describe("zero doctor permission-deny command", () => {
         "zero doctor permission-change slack --permission",
       );
       expect(logCalls).toContain("--enable");
+      expect(logCalls).toContain("--duration 1h");
       expect(logCalls).not.toContain("--reason");
       expect(mockConsoleDebug).not.toHaveBeenCalled();
     });
@@ -117,7 +118,7 @@ describe("zero doctor permission-deny command", () => {
       );
       expect(logCalls).toContain('covered by the "chat:write"');
       expect(logCalls).toContain(
-        "zero doctor permission-change slack --permission chat:write --enable",
+        "zero doctor permission-change slack --permission chat:write --enable --duration 1h",
       );
     });
   });
@@ -136,7 +137,9 @@ describe("zero doctor permission-deny command", () => {
 
       const logCalls = mockConsoleLog.mock.calls.flat().join("\n");
       expect(logCalls).toContain('covered by the "gmail.send"');
-      expect(logCalls).toContain("--permission gmail.send --enable");
+      expect(logCalls).toContain(
+        "--permission gmail.send --enable --duration 1h",
+      );
     });
   });
 
@@ -155,7 +158,7 @@ describe("zero doctor permission-deny command", () => {
       const logCalls = mockConsoleLog.mock.calls.flat().join("\n");
       // The suggested command should contain the ref, permission, and --enable.
       expect(logCalls).toMatch(
-        /zero doctor permission-change slack --permission \S+ --enable/,
+        /zero doctor permission-change slack --permission \S+ --enable --duration 1h/,
       );
       expect(logCalls).not.toContain("--reason");
     });

--- a/turbo/apps/cli/src/commands/zero/doctor/index.ts
+++ b/turbo/apps/cli/src/commands/zero/doctor/index.ts
@@ -20,7 +20,7 @@ Examples:
   Check credits?         zero doctor credit
   Check with permission? zero doctor check-connector --env-name SLACK_TOKEN --check-permission chat:write
   Permission denied?     zero doctor permission-deny github --method GET --path /repos/owner/repo
-  Change a permission?   zero doctor permission-change github --permission contents:read --enable
+  Change a permission?   zero doctor permission-change github --permission contents:read --enable --duration 1h
 
 Notes:
   - Use zero doctor credit when a run or generation fails because the org has insufficient credits, when a user asks how to recharge, or before trying to buy credits

--- a/turbo/apps/cli/src/commands/zero/doctor/permission-change.ts
+++ b/turbo/apps/cli/src/commands/zero/doctor/permission-change.ts
@@ -1,4 +1,5 @@
 import { Command, Option } from "commander";
+import type { UserPermissionGrantExpiresIn } from "@vm0/api-contracts/contracts/zero-user-permission-grants";
 import { CONNECTOR_TYPES } from "@vm0/connectors/connectors";
 import {
   getConnectorFirewall,
@@ -6,6 +7,14 @@ import {
 } from "@vm0/connectors/firewalls";
 import { withErrorHandler } from "../../../lib/command";
 import { getPlatformOrigin } from "./platform-url";
+
+const DEFAULT_PERMISSION_GRANT_DURATION: UserPermissionGrantExpiresIn = "1h";
+const PERMISSION_GRANT_DURATIONS = [
+  "1h",
+  "24h",
+  "7d",
+  "always",
+] as const satisfies readonly UserPermissionGrantExpiresIn[];
 
 function findPermissionInConfig(ref: string, permissionName: string): boolean {
   if (!isFirewallConnectorType(ref)) return false;
@@ -63,17 +72,24 @@ function printPermissionActionMessage(args: {
   readonly permission: string;
   readonly label: string;
   readonly url: string;
+  readonly duration: UserPermissionGrantExpiresIn | undefined;
 }): void {
   const grantAction = args.action === "enable" ? "allow" : "deny";
   console.log(
     `You can ${grantAction} the "${args.permission}" permission for your connector access: [Manage ${args.label} permissions](${args.url})`,
   );
+  if (args.duration) {
+    console.log(
+      `Requested duration: ${args.duration}. Use --duration 1h|24h|7d|always to choose a different grant lifetime.`,
+    );
+  }
 }
 
 async function outputPermissionChangeMessage(
   connectorRef: string,
   permission: string,
   action: PermissionAction,
+  duration: UserPermissionGrantExpiresIn | undefined,
 ): Promise<void> {
   const { label } =
     CONNECTOR_TYPES[connectorRef as keyof typeof CONNECTOR_TYPES];
@@ -86,6 +102,9 @@ async function outputPermissionChangeMessage(
     permission,
     action: action === "enable" ? "allow" : "deny",
   });
+  if (action === "enable") {
+    urlParams.set("expiresIn", duration ?? DEFAULT_PERMISSION_GRANT_DURATION);
+  }
 
   const pagePath = agentId ? `/agents/${agentId}/permissions` : "/agents";
   const url = `${platformOrigin}${pagePath}?${urlParams.toString()}`;
@@ -96,6 +115,10 @@ async function outputPermissionChangeMessage(
     permission,
     label,
     url,
+    duration:
+      action === "enable"
+        ? (duration ?? DEFAULT_PERMISSION_GRANT_DURATION)
+        : undefined,
   });
 }
 
@@ -122,6 +145,12 @@ export const permissionChangeCommand = new Command()
     ).conflicts("enable"),
   )
   .addOption(
+    new Option(
+      "--duration <duration>",
+      "Requested allow duration: 1h, 24h, 7d, or always (default: 1h)",
+    ).choices([...PERMISSION_GRANT_DURATIONS]),
+  )
+  .addOption(
     new Option("--reason <text>", "Brief reason for the permission change"),
   )
   .addHelpText(
@@ -129,10 +158,13 @@ export const permissionChangeCommand = new Command()
     `
 Examples:
   zero doctor permission-change github --permission contents:read --enable
+  zero doctor permission-change github --permission contents:write --enable --duration 24h
   zero doctor permission-change slack --permission chat:write --disable
 
 Notes:
   - Outputs a platform URL for the user to adjust the permission
+  - Enable requests default to --duration 1h; use 24h or 7d for longer user-approved work
+  - Use --duration always only when the user explicitly asks for persistent access
   - Permission changes update the current user's connector grants`,
   )
   .action(
@@ -143,11 +175,15 @@ Notes:
           permission: string;
           enable?: boolean;
           disable?: boolean;
+          duration?: UserPermissionGrantExpiresIn;
           reason?: string;
         },
       ) => {
         if (!opts.enable && !opts.disable) {
           throw new Error("Either --enable or --disable is required");
+        }
+        if (opts.disable && opts.duration !== undefined) {
+          throw new Error("--duration is only supported with --enable");
         }
 
         if (!isFirewallConnectorType(connectorRef)) {
@@ -165,6 +201,7 @@ Notes:
           connectorRef,
           opts.permission,
           action,
+          opts.duration,
         );
       },
     ),

--- a/turbo/apps/cli/src/commands/zero/doctor/permission-deny.ts
+++ b/turbo/apps/cli/src/commands/zero/doctor/permission-deny.ts
@@ -31,7 +31,8 @@ Examples:
 
 Notes:
   - Identifies which named permission covers a denied request
-  - Use permission-change to request or enable the permission`,
+  - Use permission-change to request or enable the permission
+  - Permission-change enable requests default to --duration 1h; pick 24h, 7d, or always only when appropriate`,
   )
   .action(
     withErrorHandler(
@@ -78,7 +79,7 @@ Notes:
         });
         console.log(`This is covered by the "${permission}" permission.`);
         console.log(
-          `To allow this permission, run: zero doctor permission-change ${connectorRef} --permission ${permission} --enable`,
+          `To allow this permission, run: zero doctor permission-change ${connectorRef} --permission ${permission} --enable --duration 1h`,
         );
       },
     ),

--- a/turbo/apps/platform/src/mocks/handlers/api-user-permission-grants.ts
+++ b/turbo/apps/platform/src/mocks/handlers/api-user-permission-grants.ts
@@ -22,13 +22,17 @@ function isActiveGrant(grant: UserPermissionGrantResponse, checkedAt: Date) {
 
 function resolvedMockExpiresAt(
   existing: UserPermissionGrantResponse | undefined,
+  action: UserPermissionGrantResponse["action"],
   expiresIn: Parameters<typeof userPermissionGrantExpiresAt>[0],
   now: Date,
 ): string | null {
+  if (action !== "allow") {
+    return null;
+  }
   if (expiresIn !== undefined) {
     return userPermissionGrantExpiresAt(expiresIn, now.getTime());
   }
-  if (existing && isActiveGrant(existing, now)) {
+  if (existing?.action === "allow" && isActiveGrant(existing, now)) {
     return existing.expiresAt;
   }
   return null;
@@ -83,7 +87,12 @@ export const apiUserPermissionGrantsHandlers = [
       connectorRef: body.connectorRef,
       permission: body.permission,
       action: body.action,
-      expiresAt: resolvedMockExpiresAt(existing, body.expiresIn, now),
+      expiresAt: resolvedMockExpiresAt(
+        existing,
+        body.action,
+        body.expiresIn,
+        now,
+      ),
       createdAt: existing?.createdAt ?? now.toISOString(),
       updatedAt: now.toISOString(),
     };

--- a/turbo/apps/platform/src/mocks/handlers/api-user-permission-grants.ts
+++ b/turbo/apps/platform/src/mocks/handlers/api-user-permission-grants.ts
@@ -2,6 +2,7 @@ import {
   type UserPermissionGrantResponse,
   zeroUserPermissionGrantsContract,
 } from "@vm0/api-contracts/contracts/zero-user-permission-grants";
+import { userPermissionGrantExpiresAt } from "../../signals/permission-allow/permission-grant-expiration.ts";
 import { mockApi } from "../msw-contract.ts";
 
 let mockUserPermissionGrants: UserPermissionGrantResponse[] = [];
@@ -13,6 +14,10 @@ function grantKey(
   >,
 ): string {
   return `${grant.agentId}:${grant.connectorRef}:${grant.permission}`;
+}
+
+function isActiveGrant(grant: UserPermissionGrantResponse, checkedAt: Date) {
+  return grant.expiresAt === null || new Date(grant.expiresAt) > checkedAt;
 }
 
 export function createMockUserPermissionGrantResponse(
@@ -43,10 +48,13 @@ export function resetMockUserPermissionGrants(): void {
 
 export const apiUserPermissionGrantsHandlers = [
   mockApi(zeroUserPermissionGrantsContract.list, ({ query, respond }) => {
+    const checkedAt = new Date();
     return respond(
       200,
       mockUserPermissionGrants.filter((grant) => {
-        return grant.agentId === query.agentId;
+        return (
+          grant.agentId === query.agentId && isActiveGrant(grant, checkedAt)
+        );
       }),
     );
   }),
@@ -61,7 +69,7 @@ export const apiUserPermissionGrantsHandlers = [
       connectorRef: body.connectorRef,
       permission: body.permission,
       action: body.action,
-      expiresAt: null,
+      expiresAt: userPermissionGrantExpiresAt(body.expiresIn, now.getTime()),
       createdAt: existing?.createdAt ?? now.toISOString(),
       updatedAt: now.toISOString(),
     };

--- a/turbo/apps/platform/src/mocks/handlers/api-user-permission-grants.ts
+++ b/turbo/apps/platform/src/mocks/handlers/api-user-permission-grants.ts
@@ -20,6 +20,20 @@ function isActiveGrant(grant: UserPermissionGrantResponse, checkedAt: Date) {
   return grant.expiresAt === null || new Date(grant.expiresAt) > checkedAt;
 }
 
+function resolvedMockExpiresAt(
+  existing: UserPermissionGrantResponse | undefined,
+  expiresIn: Parameters<typeof userPermissionGrantExpiresAt>[0],
+  now: Date,
+): string | null {
+  if (expiresIn !== undefined) {
+    return userPermissionGrantExpiresAt(expiresIn, now.getTime());
+  }
+  if (existing && isActiveGrant(existing, now)) {
+    return existing.expiresAt;
+  }
+  return null;
+}
+
 export function createMockUserPermissionGrantResponse(
   overrides: Partial<UserPermissionGrantResponse>,
 ): UserPermissionGrantResponse {
@@ -69,7 +83,7 @@ export const apiUserPermissionGrantsHandlers = [
       connectorRef: body.connectorRef,
       permission: body.permission,
       action: body.action,
-      expiresAt: userPermissionGrantExpiresAt(body.expiresIn, now.getTime()),
+      expiresAt: resolvedMockExpiresAt(existing, body.expiresIn, now),
       createdAt: existing?.createdAt ?? now.toISOString(),
       updatedAt: now.toISOString(),
     };

--- a/turbo/apps/platform/src/signals/chat-page/__tests__/parse-body-blocks.test.ts
+++ b/turbo/apps/platform/src/signals/chat-page/__tests__/parse-body-blocks.test.ts
@@ -266,6 +266,26 @@ describe("parseBodyRenderBlocks", () => {
     });
   });
 
+  it("parses permission link expiration options", () => {
+    vi.stubEnv("VITE_API_URL", "https://app.vm0.ai");
+    const url =
+      "https://app.vm0.ai/agents/4f189ea8-ada2-416d-83a9-9c25ddb960c9/permissions?ref=slack&permission=channels%3Aread&action=allow&expiresIn=24h";
+
+    const { blocks } = parseBodyRenderBlocks(url, {
+      previews: false,
+    });
+
+    expect(blocks).toHaveLength(1);
+    expect(blocks[0]).toMatchObject({
+      type: "permission-action",
+      connectorRef: "slack",
+      permission: "channels:read",
+      action: "allow",
+      expiresIn: "24h",
+      href: "/agents/4f189ea8-ada2-416d-83a9-9c25ddb960c9/permissions?ref=slack&permission=channels%3Aread&action=allow&expiresIn=24h",
+    });
+  });
+
   it("renders tunnel host variant permission links as permission action blocks", () => {
     vi.stubEnv("VITE_API_URL", "https://tunnel-yuma-vm0-api.vm7.ai");
     const url =

--- a/turbo/apps/platform/src/signals/chat-page/__tests__/parse-body-blocks.test.ts
+++ b/turbo/apps/platform/src/signals/chat-page/__tests__/parse-body-blocks.test.ts
@@ -378,6 +378,46 @@ describe("parseBodyRenderBlocks", () => {
     ]);
   });
 
+  it("does not render protocol-relative external permission links as permission action blocks", () => {
+    vi.stubEnv("VITE_API_URL", "https://app.vm0.ai");
+    const url =
+      "//evil.example/agents/b431c9a7-4f78-4977-aba1-dec4c04b212c/permissions?ref=slack&permission=chat%3Awrite&action=allow";
+
+    const { cleanContent, blocks } = parseBodyRenderBlocks(
+      `[Manage Slack permissions](${url})`,
+      { previews: false },
+    );
+
+    expect(cleanContent).toBe(`[Manage Slack permissions](${url})`);
+    expect(blocks).toStrictEqual([
+      {
+        type: "markdown",
+        id: "markdown-1",
+        content: `[Manage Slack permissions](${url})`,
+      },
+    ]);
+  });
+
+  it("does not render non-http platform permission links as permission action blocks", () => {
+    vi.stubEnv("VITE_API_URL", "https://app.vm0.ai");
+    const url =
+      "javascript://app.vm0.ai/agents/b431c9a7-4f78-4977-aba1-dec4c04b212c/permissions?ref=slack&permission=chat%3Awrite&action=allow";
+
+    const { cleanContent, blocks } = parseBodyRenderBlocks(
+      `[Manage Slack permissions](${url})`,
+      { previews: false },
+    );
+
+    expect(cleanContent).toBe(`[Manage Slack permissions](${url})`);
+    expect(blocks).toStrictEqual([
+      {
+        type: "markdown",
+        id: "markdown-1",
+        content: `[Manage Slack permissions](${url})`,
+      },
+    ]);
+  });
+
   it("does not render external connector authorize URLs as action blocks", () => {
     const url =
       "https://evil.example/connectors/strapi/authorize?agentId=4f189ea8-ada2-416d-83a9-9c25ddb960c9";

--- a/turbo/apps/platform/src/signals/chat-page/__tests__/permission-action-block.test.ts
+++ b/turbo/apps/platform/src/signals/chat-page/__tests__/permission-action-block.test.ts
@@ -1,0 +1,17 @@
+import { describe, expect, it, vi } from "vitest";
+import { parsePermissionActionUrl } from "../permission-action-block.ts";
+
+const PERMISSION_PATH =
+  "/agents/b431c9a7-4f78-4977-aba1-dec4c04b212c/permissions?ref=slack&permission=chat%3Awrite&action=allow";
+
+describe("parsePermissionActionUrl", () => {
+  it.each([
+    `\u0000https://evil.example${PERMISSION_PATH}`,
+    `https:\n//evil.example${PERMISSION_PATH}`,
+    ` \t//evil.example${PERMISSION_PATH}`,
+  ])("rejects parser-normalized external permission URLs: %s", (url) => {
+    vi.stubEnv("VITE_API_URL", "https://app.vm0.ai");
+
+    expect(parsePermissionActionUrl(url)).toBeNull();
+  });
+});

--- a/turbo/apps/platform/src/signals/chat-page/permission-action-block.ts
+++ b/turbo/apps/platform/src/signals/chat-page/permission-action-block.ts
@@ -2,6 +2,8 @@ import {
   isFirewallConnectorType,
   type FirewallConnectorType,
 } from "@vm0/connectors/firewalls";
+import type { UserPermissionGrantExpiresIn } from "@vm0/api-contracts/contracts/zero-user-permission-grants";
+import { parseUserPermissionGrantExpiresIn } from "../permission-allow/permission-grant-expiration.ts";
 
 type PermissionAction = "allow" | "deny";
 type PlatformHostTarget = "api" | "www" | "app" | "platform";
@@ -14,6 +16,7 @@ export interface PermissionActionDescriptor {
   method: string | null;
   path: string | null;
   reason: string | null;
+  expiresIn: UserPermissionGrantExpiresIn | null;
   search: string;
   originalUrl: string;
 }
@@ -138,6 +141,9 @@ export function parsePermissionActionUrl(
   const method = url.searchParams.get("method");
   const path = url.searchParams.get("path");
   const reason = url.searchParams.get("reason");
+  const expiresIn = parseUserPermissionGrantExpiresIn(
+    url.searchParams.get("expiresIn"),
+  );
 
   if (
     !agentId ||
@@ -157,6 +163,7 @@ export function parsePermissionActionUrl(
     method,
     path,
     reason,
+    expiresIn,
     search: url.searchParams.toString(),
     originalUrl: value,
   };

--- a/turbo/apps/platform/src/signals/chat-page/permission-action-block.ts
+++ b/turbo/apps/platform/src/signals/chat-page/permission-action-block.ts
@@ -141,9 +141,10 @@ export function parsePermissionActionUrl(
   const method = url.searchParams.get("method");
   const path = url.searchParams.get("path");
   const reason = url.searchParams.get("reason");
-  const expiresIn = parseUserPermissionGrantExpiresIn(
-    url.searchParams.get("expiresIn"),
-  );
+  const expiresIn =
+    action === "allow"
+      ? parseUserPermissionGrantExpiresIn(url.searchParams.get("expiresIn"))
+      : null;
 
   if (
     !agentId ||

--- a/turbo/apps/platform/src/signals/chat-page/permission-action-block.ts
+++ b/turbo/apps/platform/src/signals/chat-page/permission-action-block.ts
@@ -79,8 +79,18 @@ function permissionActionBaseUrl(): string | null {
   return browserOrigin() ?? configuredApiUrl ?? null;
 }
 
+function stripUrlParserIgnoredPrefix(value: string): string {
+  let index = 0;
+  while (index < value.length && value.charCodeAt(index) <= 0x20) {
+    index += 1;
+  }
+  return value.slice(index);
+}
+
 function hasExplicitUrlOrigin(value: string): boolean {
-  return /^(?:[a-z][a-z\d+\-.]*:)?\/\//i.test(value);
+  return (
+    URL.canParse(value) || stripUrlParserIgnoredPrefix(value).startsWith("//")
+  );
 }
 
 function isPlatformPermissionHostname(hostname: string): boolean {

--- a/turbo/apps/platform/src/signals/chat-page/permission-action-block.ts
+++ b/turbo/apps/platform/src/signals/chat-page/permission-action-block.ts
@@ -80,7 +80,7 @@ function permissionActionBaseUrl(): string | null {
 }
 
 function hasExplicitUrlOrigin(value: string): boolean {
-  return /^[a-z][a-z\d+\-.]*:\/\//i.test(value);
+  return /^(?:[a-z][a-z\d+\-.]*:)?\/\//i.test(value);
 }
 
 function isPlatformPermissionHostname(hostname: string): boolean {
@@ -94,9 +94,18 @@ function isPlatformPermissionHostname(hostname: string): boolean {
   return /(^|-)(platform|app|www|api)\./.test(hostname);
 }
 
+function isHttpUrl(url: URL): boolean {
+  return url.protocol === "http:" || url.protocol === "https:";
+}
+
 function isAllowedPermissionActionUrl(url: URL, sourceUrl: string): boolean {
+  const explicitOrigin = hasExplicitUrlOrigin(sourceUrl);
+  if (explicitOrigin && !isHttpUrl(url)) {
+    return false;
+  }
+
   return (
-    !hasExplicitUrlOrigin(sourceUrl) ||
+    !explicitOrigin ||
     permissionActionOrigins().has(url.origin) ||
     isPlatformPermissionHostname(url.hostname)
   );

--- a/turbo/apps/platform/src/signals/permission-allow/permission-allow-signals.ts
+++ b/turbo/apps/platform/src/signals/permission-allow/permission-allow-signals.ts
@@ -164,11 +164,24 @@ export const upsertUserPermissionGrant$ = command(
     signal: AbortSignal,
   ): Promise<UserPermissionGrantResponse> => {
     const client = get(zeroClient$)(zeroUserPermissionGrantsContract);
+    const body =
+      params.action === "allow"
+        ? {
+            agentId: params.agentId,
+            connectorRef: params.connectorRef,
+            permission: params.permission,
+            action: "allow" as const,
+            ...(params.expiresIn ? { expiresIn: params.expiresIn } : {}),
+          }
+        : {
+            agentId: params.agentId,
+            connectorRef: params.connectorRef,
+            permission: params.permission,
+            action: "deny" as const,
+          };
     const result = await accept(
       client.upsert({
-        body: {
-          ...params,
-        },
+        body,
         fetchOptions: { signal },
       }),
       [200],

--- a/turbo/apps/platform/src/signals/permission-allow/permission-allow-signals.ts
+++ b/turbo/apps/platform/src/signals/permission-allow/permission-allow-signals.ts
@@ -1,5 +1,6 @@
 import { command, computed, state, type Computed } from "ccstate";
 import {
+  type UserPermissionGrantExpiresIn,
   type UserPermissionGrantAction,
   type UserPermissionGrantResponse,
   zeroUserPermissionGrantsContract,
@@ -15,6 +16,7 @@ import { zeroClient$ } from "../api-client.ts";
 import { pathParams$, searchParams$ } from "../route.ts";
 import { accept } from "../../lib/accept.ts";
 import { agentById, reloadAgentById$ } from "../agent.ts";
+import { parseUserPermissionGrantExpiresIn } from "./permission-grant-expiration.ts";
 
 // ---------------------------------------------------------------------------
 // Route params
@@ -37,6 +39,10 @@ export const permissionAllowPermission$ = computed((get) => {
 export const permissionAllowAction$ = computed((get) => {
   const action = get(searchParams$).get("action");
   return action === "allow" || action === "deny" ? action : null;
+});
+
+export const permissionAllowExpiresIn$ = computed((get) => {
+  return parseUserPermissionGrantExpiresIn(get(searchParams$).get("expiresIn"));
 });
 
 // ---------------------------------------------------------------------------
@@ -153,11 +159,12 @@ export const upsertUserPermissionGrant$ = command(
       connectorRef: string;
       permission: string;
       action: UserPermissionGrantAction;
+      expiresIn?: UserPermissionGrantExpiresIn;
     },
     signal: AbortSignal,
-  ): Promise<void> => {
+  ): Promise<UserPermissionGrantResponse> => {
     const client = get(zeroClient$)(zeroUserPermissionGrantsContract);
-    await accept(
+    const result = await accept(
       client.upsert({
         body: {
           ...params,
@@ -174,5 +181,6 @@ export const upsertUserPermissionGrant$ = command(
       return prev + 1;
     });
     set(reloadAgentById$);
+    return result.body;
   },
 );

--- a/turbo/apps/platform/src/signals/permission-allow/permission-grant-expiration.ts
+++ b/turbo/apps/platform/src/signals/permission-allow/permission-grant-expiration.ts
@@ -15,7 +15,7 @@ export const USER_PERMISSION_GRANT_EXPIRES_IN_OPTIONS: readonly {
   { value: "1h", label: "1 hour" },
   { value: "24h", label: "24 hours" },
   { value: "7d", label: "7 days" },
-  { value: "forever", label: "Always" },
+  { value: "always", label: "Always" },
 ];
 
 export function parseUserPermissionGrantExpiresIn(
@@ -43,7 +43,7 @@ export function userPermissionGrantExpiresAt(
     case "7d": {
       return new Date(nowMs + 7 * DAY_MS).toISOString();
     }
-    case "forever":
+    case "always":
     case undefined: {
       return null;
     }

--- a/turbo/apps/platform/src/signals/permission-allow/permission-grant-expiration.ts
+++ b/turbo/apps/platform/src/signals/permission-allow/permission-grant-expiration.ts
@@ -50,6 +50,22 @@ export function userPermissionGrantExpiresAt(
   }
 }
 
+export function requestedUserPermissionGrantExpirationAlreadyApplies({
+  expiresIn,
+  currentExpiresAt,
+}: {
+  expiresIn: UserPermissionGrantExpiresIn | null;
+  currentExpiresAt: string | null | undefined;
+}): boolean {
+  if (expiresIn === null) {
+    return true;
+  }
+  if (expiresIn === "always") {
+    return currentExpiresAt === null;
+  }
+  return false;
+}
+
 export function permissionGrantExpiryText(
   expiresAt: string | null,
   nowMs = Date.now(),

--- a/turbo/apps/platform/src/signals/permission-allow/permission-grant-expiration.ts
+++ b/turbo/apps/platform/src/signals/permission-allow/permission-grant-expiration.ts
@@ -1,0 +1,116 @@
+import { command, computed, state } from "ccstate";
+import type { UserPermissionGrantExpiresIn } from "@vm0/api-contracts/contracts/zero-user-permission-grants";
+
+const HOUR_MS = 60 * 60 * 1000;
+const MINUTE_MS = 60 * 1000;
+const DAY_MS = 24 * HOUR_MS;
+
+export const DEFAULT_USER_PERMISSION_GRANT_EXPIRES_IN: UserPermissionGrantExpiresIn =
+  "1h";
+
+export const USER_PERMISSION_GRANT_EXPIRES_IN_OPTIONS: readonly {
+  readonly value: UserPermissionGrantExpiresIn;
+  readonly label: string;
+}[] = [
+  { value: "1h", label: "1 hour" },
+  { value: "24h", label: "24 hours" },
+  { value: "7d", label: "7 days" },
+  { value: "forever", label: "Always" },
+];
+
+export function parseUserPermissionGrantExpiresIn(
+  value: string | null,
+): UserPermissionGrantExpiresIn | null {
+  for (const option of USER_PERMISSION_GRANT_EXPIRES_IN_OPTIONS) {
+    if (option.value === value) {
+      return option.value;
+    }
+  }
+  return null;
+}
+
+export function userPermissionGrantExpiresAt(
+  expiresIn: UserPermissionGrantExpiresIn | undefined,
+  nowMs = Date.now(),
+): string | null {
+  switch (expiresIn) {
+    case "1h": {
+      return new Date(nowMs + HOUR_MS).toISOString();
+    }
+    case "24h": {
+      return new Date(nowMs + DAY_MS).toISOString();
+    }
+    case "7d": {
+      return new Date(nowMs + 7 * DAY_MS).toISOString();
+    }
+    case "forever":
+    case undefined: {
+      return null;
+    }
+  }
+}
+
+export function permissionGrantExpiryText(
+  expiresAt: string | null,
+  nowMs = Date.now(),
+): string | null {
+  if (!expiresAt) {
+    return null;
+  }
+  const expiresAtMs = Date.parse(expiresAt);
+  if (!Number.isFinite(expiresAtMs)) {
+    return null;
+  }
+  const remainingMs = expiresAtMs - nowMs;
+  if (remainingMs <= 0) {
+    return "Expired";
+  }
+  if (remainingMs >= DAY_MS) {
+    const days = Math.ceil(remainingMs / DAY_MS);
+    return `Expires in ${days} day${days === 1 ? "" : "s"}`;
+  }
+  if (remainingMs < HOUR_MS - MINUTE_MS) {
+    return "Expires in less than 1 hour";
+  }
+  const hours = Math.ceil(remainingMs / HOUR_MS);
+  return `Expires in ${hours} hour${hours === 1 ? "" : "s"}`;
+}
+
+export function expiresInFromGrantExpiresAt(
+  expiresAt: string | null,
+  nowMs = Date.now(),
+): UserPermissionGrantExpiresIn {
+  if (!expiresAt) {
+    return "forever";
+  }
+  const expiresAtMs = Date.parse(expiresAt);
+  if (!Number.isFinite(expiresAtMs)) {
+    return "forever";
+  }
+  const remainingMs = expiresAtMs - nowMs;
+  if (remainingMs <= HOUR_MS) {
+    return "1h";
+  }
+  if (remainingMs <= DAY_MS) {
+    return "24h";
+  }
+  return "7d";
+}
+
+const internalPermissionGrantExpiresInByScope$ = state<
+  Record<string, UserPermissionGrantExpiresIn>
+>({});
+
+export const permissionGrantExpiresInByScope$ = computed((get) => {
+  return get(internalPermissionGrantExpiresInByScope$);
+});
+
+export const setPermissionGrantExpiresIn$ = command(
+  ({ get, set }, scope: string, expiresIn: UserPermissionGrantExpiresIn) => {
+    const current = get(internalPermissionGrantExpiresInByScope$);
+    set(internalPermissionGrantExpiresInByScope$, {
+      ...current,
+      [scope]: expiresIn,
+    });
+  },
+);

--- a/turbo/apps/platform/src/signals/permission-allow/permission-grant-expiration.ts
+++ b/turbo/apps/platform/src/signals/permission-allow/permission-grant-expiration.ts
@@ -76,27 +76,6 @@ export function permissionGrantExpiryText(
   return `Expires in ${hours} hour${hours === 1 ? "" : "s"}`;
 }
 
-export function expiresInFromGrantExpiresAt(
-  expiresAt: string | null,
-  nowMs = Date.now(),
-): UserPermissionGrantExpiresIn {
-  if (!expiresAt) {
-    return "forever";
-  }
-  const expiresAtMs = Date.parse(expiresAt);
-  if (!Number.isFinite(expiresAtMs)) {
-    return "forever";
-  }
-  const remainingMs = expiresAtMs - nowMs;
-  if (remainingMs <= HOUR_MS) {
-    return "1h";
-  }
-  if (remainingMs <= DAY_MS) {
-    return "24h";
-  }
-  return "7d";
-}
-
 const internalPermissionGrantExpiresInByScope$ = state<
   Record<string, UserPermissionGrantExpiresIn>
 >({});

--- a/turbo/apps/platform/src/signals/zero-page/settings/permissions-dialog.ts
+++ b/turbo/apps/platform/src/signals/zero-page/settings/permissions-dialog.ts
@@ -60,9 +60,15 @@ export const setPermissionGrantExpiration$ = command(
   (
     { get, set },
     permission: string,
-    expiresIn: UserPermissionGrantExpiresIn,
+    expiresIn: UserPermissionGrantExpiresIn | null,
   ) => {
     const current = get(internalGrantExpirations$);
+    if (expiresIn === null) {
+      const next = { ...current };
+      delete next[permission];
+      set(internalGrantExpirations$, next);
+      return;
+    }
     set(internalGrantExpirations$, {
       ...current,
       [permission]: expiresIn,

--- a/turbo/apps/platform/src/signals/zero-page/settings/permissions-dialog.ts
+++ b/turbo/apps/platform/src/signals/zero-page/settings/permissions-dialog.ts
@@ -1,5 +1,6 @@
 import { command, computed, state } from "ccstate";
 import type { FirewallPolicyValue } from "@vm0/connectors/firewall-types";
+import type { UserPermissionGrantExpiresIn } from "@vm0/api-contracts/contracts/zero-user-permission-grants";
 import type { PermissionPolicy } from "./permissions.ts";
 
 // ---------------------------------------------------------------------------
@@ -45,6 +46,27 @@ export const setPermissionAllPolicies$ = command(
   ({ get, set }, ref: string, policies: Record<string, PermissionPolicy>) => {
     const all = get(internalAllPolicies$);
     set(internalAllPolicies$, { ...all, [ref]: policies });
+  },
+);
+
+const internalGrantExpirationFormKey$ = state<string | null>(null);
+const internalGrantExpirations$ = state<
+  Record<string, UserPermissionGrantExpiresIn>
+>({});
+export const permissionGrantExpirations$ = computed((get) => {
+  return get(internalGrantExpirations$);
+});
+export const setPermissionGrantExpiration$ = command(
+  (
+    { get, set },
+    permission: string,
+    expiresIn: UserPermissionGrantExpiresIn,
+  ) => {
+    const current = get(internalGrantExpirations$);
+    set(internalGrantExpirations$, {
+      ...current,
+      [permission]: expiresIn,
+    });
   },
 );
 
@@ -99,6 +121,20 @@ export const initPermissionPolicies$ = command(
   },
 );
 
+export const initPermissionGrantExpirations$ = command(
+  (
+    { get, set },
+    formKey: string,
+    expirations: Record<string, UserPermissionGrantExpiresIn>,
+  ) => {
+    if (get(internalGrantExpirationFormKey$) === formKey) {
+      return;
+    }
+    set(internalGrantExpirationFormKey$, formKey);
+    set(internalGrantExpirations$, expirations);
+  },
+);
+
 export const resetPermissionPolicies$ = command(
   ({ get, set }, formKey: string) => {
     if (get(internalFormKey$) !== formKey) {
@@ -109,6 +145,16 @@ export const resetPermissionPolicies$ = command(
     set(internalUnknownPolicy$, "allow");
     set(internalScrolled$, false);
     set(internalExpandedGroups$, new Set());
+  },
+);
+
+export const resetPermissionGrantExpirations$ = command(
+  ({ get, set }, formKey: string) => {
+    if (get(internalGrantExpirationFormKey$) !== formKey) {
+      return;
+    }
+    set(internalGrantExpirationFormKey$, null);
+    set(internalGrantExpirations$, {});
   },
 );
 

--- a/turbo/apps/platform/src/views/components/permission-grant-duration-select.tsx
+++ b/turbo/apps/platform/src/views/components/permission-grant-duration-select.tsx
@@ -1,0 +1,56 @@
+import type { UserPermissionGrantExpiresIn } from "@vm0/api-contracts/contracts/zero-user-permission-grants";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+  cn,
+} from "@vm0/ui";
+import {
+  parseUserPermissionGrantExpiresIn,
+  USER_PERMISSION_GRANT_EXPIRES_IN_OPTIONS,
+} from "../../signals/permission-allow/permission-grant-expiration.ts";
+
+export function PermissionGrantDurationSelect({
+  value,
+  onValueChange,
+  disabled,
+  ariaLabel,
+  className,
+}: {
+  value: UserPermissionGrantExpiresIn;
+  onValueChange: (value: UserPermissionGrantExpiresIn) => void;
+  disabled?: boolean;
+  ariaLabel: string;
+  className?: string;
+}) {
+  return (
+    <Select
+      value={value}
+      onValueChange={(nextValue) => {
+        const parsed = parseUserPermissionGrantExpiresIn(nextValue);
+        if (parsed) {
+          onValueChange(parsed);
+        }
+      }}
+      disabled={disabled}
+    >
+      <SelectTrigger
+        aria-label={ariaLabel}
+        className={cn("h-8 w-[116px] rounded-lg text-xs", className)}
+      >
+        <SelectValue />
+      </SelectTrigger>
+      <SelectContent>
+        {USER_PERMISSION_GRANT_EXPIRES_IN_OPTIONS.map((option) => {
+          return (
+            <SelectItem key={option.value} value={option.value}>
+              {option.label}
+            </SelectItem>
+          );
+        })}
+      </SelectContent>
+    </Select>
+  );
+}

--- a/turbo/apps/platform/src/views/components/permission-grant-duration-select.tsx
+++ b/turbo/apps/platform/src/views/components/permission-grant-duration-select.tsx
@@ -12,33 +12,23 @@ import {
   USER_PERMISSION_GRANT_EXPIRES_IN_OPTIONS,
 } from "../../signals/permission-allow/permission-grant-expiration.ts";
 
-const KEEP_CURRENT_EXPIRATION_VALUE = "keep-current";
-
 export function PermissionGrantDurationSelect({
   value,
   onValueChange,
-  onClear,
   disabled,
   ariaLabel,
   className,
-  showKeepCurrent,
 }: {
-  value: UserPermissionGrantExpiresIn | null;
+  value: UserPermissionGrantExpiresIn;
   onValueChange: (value: UserPermissionGrantExpiresIn) => void;
-  onClear?: () => void;
   disabled?: boolean;
   ariaLabel: string;
   className?: string;
-  showKeepCurrent?: boolean;
 }) {
   return (
     <Select
-      value={value ?? KEEP_CURRENT_EXPIRATION_VALUE}
+      value={value}
       onValueChange={(nextValue) => {
-        if (nextValue === KEEP_CURRENT_EXPIRATION_VALUE) {
-          onClear?.();
-          return;
-        }
         const parsed = parseUserPermissionGrantExpiresIn(nextValue);
         if (parsed) {
           onValueChange(parsed);
@@ -53,11 +43,6 @@ export function PermissionGrantDurationSelect({
         <SelectValue />
       </SelectTrigger>
       <SelectContent>
-        {showKeepCurrent && (
-          <SelectItem value={KEEP_CURRENT_EXPIRATION_VALUE}>
-            Keep current
-          </SelectItem>
-        )}
         {USER_PERMISSION_GRANT_EXPIRES_IN_OPTIONS.map((option) => {
           return (
             <SelectItem key={option.value} value={option.value}>

--- a/turbo/apps/platform/src/views/components/permission-grant-duration-select.tsx
+++ b/turbo/apps/platform/src/views/components/permission-grant-duration-select.tsx
@@ -12,23 +12,33 @@ import {
   USER_PERMISSION_GRANT_EXPIRES_IN_OPTIONS,
 } from "../../signals/permission-allow/permission-grant-expiration.ts";
 
+const KEEP_CURRENT_EXPIRATION_VALUE = "keep-current";
+
 export function PermissionGrantDurationSelect({
   value,
   onValueChange,
+  onClear,
   disabled,
   ariaLabel,
   className,
+  showKeepCurrent,
 }: {
-  value: UserPermissionGrantExpiresIn;
+  value: UserPermissionGrantExpiresIn | null;
   onValueChange: (value: UserPermissionGrantExpiresIn) => void;
+  onClear?: () => void;
   disabled?: boolean;
   ariaLabel: string;
   className?: string;
+  showKeepCurrent?: boolean;
 }) {
   return (
     <Select
-      value={value}
+      value={value ?? KEEP_CURRENT_EXPIRATION_VALUE}
       onValueChange={(nextValue) => {
+        if (nextValue === KEEP_CURRENT_EXPIRATION_VALUE) {
+          onClear?.();
+          return;
+        }
         const parsed = parseUserPermissionGrantExpiresIn(nextValue);
         if (parsed) {
           onValueChange(parsed);
@@ -43,6 +53,11 @@ export function PermissionGrantDurationSelect({
         <SelectValue />
       </SelectTrigger>
       <SelectContent>
+        {showKeepCurrent && (
+          <SelectItem value={KEEP_CURRENT_EXPIRATION_VALUE}>
+            Keep current
+          </SelectItem>
+        )}
         {USER_PERMISSION_GRANT_EXPIRES_IN_OPTIONS.map((option) => {
           return (
             <SelectItem key={option.value} value={option.value}>

--- a/turbo/apps/platform/src/views/fw/__tests__/permissions-dialog.test.tsx
+++ b/turbo/apps/platform/src/views/fw/__tests__/permissions-dialog.test.tsx
@@ -307,11 +307,12 @@ describe("permissions dialog - flat list connector (Notion)", () => {
     });
     const row = getPermissionRow("insert_comments");
     const allowButton = getPolicyButton(row, "Allow");
-    expect(allowButton).toHaveTextContent("Allow");
+    expect(allowButton).toHaveTextContent(/^Allow$/);
     expect(screen.getByText("Apply")).toBeDisabled();
 
     await selectAllowDuration(row, "insert_comments", "Allow for 7d");
-    expect(allowButton).toHaveTextContent("Allow · 7d");
+    expect(allowButton).toHaveTextContent(/^Allow$/);
+    expect(within(row).getByText("Expires in 7d")).toBeInTheDocument();
     expect(screen.getByText("Apply")).toBeEnabled();
 
     click(screen.getByText("Apply"));
@@ -347,15 +348,16 @@ describe("permissions dialog - flat list connector (Notion)", () => {
     const row = getPermissionRow("insert_comments");
     expect(within(row).getAllByText("Always").length).toBeGreaterThan(0);
     const allowButton = getPolicyButton(row, "Allow");
-    expect(allowButton).toHaveTextContent("Allow");
+    expect(allowButton).toHaveTextContent(/^Allow$/);
     expect(screen.getByText("Apply")).toBeDisabled();
 
     await selectAllowDuration(row, "insert_comments", "Allow always");
-    expect(allowButton).toHaveTextContent("Allow");
+    expect(allowButton).toHaveTextContent(/^Allow$/);
     expect(screen.getByText("Apply")).toBeDisabled();
 
     await selectAllowDuration(row, "insert_comments", "Allow for 24h");
-    expect(allowButton).toHaveTextContent("Allow · 24h");
+    expect(allowButton).toHaveTextContent(/^Allow$/);
+    expect(within(row).getByText("Expires in 24h")).toBeInTheDocument();
     expect(screen.getByText("Apply")).toBeEnabled();
     click(screen.getByText("Apply"));
 
@@ -402,7 +404,7 @@ describe("permissions dialog - flat list connector (Notion)", () => {
     expect(screen.queryByText("Expires in 2 hours")).not.toBeInTheDocument();
     expect(within(row).queryByText("Always")).not.toBeInTheDocument();
     click(getPolicyButton(row, "Allow"));
-    expect(getPolicyButton(row, "Allow")).toHaveTextContent("Allow");
+    expect(getPolicyButton(row, "Allow")).toHaveTextContent(/^Allow$/);
     expect(within(row).getByText("Always")).toBeInTheDocument();
     click(screen.getByText("Apply"));
 
@@ -494,7 +496,8 @@ describe("permissions dialog - flat list connector (Notion)", () => {
     }
     click(allowFor24h);
 
-    expect(getPolicyButton(row, "Allow")).toHaveTextContent("Allow · 24h");
+    expect(getPolicyButton(row, "Allow")).toHaveTextContent(/^Allow$/);
+    expect(within(row).getByText("Expires in 24h")).toBeInTheDocument();
     expect(screen.getByText("Apply")).toBeEnabled();
 
     click(getResetChangesButton(row, "insert_comments"));
@@ -503,7 +506,7 @@ describe("permissions dialog - flat list connector (Notion)", () => {
       "aria-pressed",
       "true",
     );
-    expect(getPolicyButton(row, "Allow")).toHaveTextContent("Allow");
+    expect(getPolicyButton(row, "Allow")).toHaveTextContent(/^Allow$/);
     expect(screen.getByText("Apply")).toBeDisabled();
   });
 
@@ -649,8 +652,11 @@ describe("permissions dialog - grouped connector (Slack)", () => {
     });
     const channelsReadRow = getPermissionRow("channels:read");
     expect(getPolicyButton(channelsReadRow, "Allow")).toHaveTextContent(
-      "Allow · 24h",
+      /^Allow$/,
     );
+    expect(
+      within(channelsReadRow).getByText("Expires in 24h"),
+    ).toBeInTheDocument();
 
     click(getResetChangesButton(readGroup, "Read"));
     expect(getPolicyButton(channelsReadRow, "Allow")).toHaveTextContent(

--- a/turbo/apps/platform/src/views/fw/__tests__/permissions-dialog.test.tsx
+++ b/turbo/apps/platform/src/views/fw/__tests__/permissions-dialog.test.tsx
@@ -231,7 +231,7 @@ describe("permissions dialog - flat list connector (Notion)", () => {
           agentId: AGENT_ID,
           connectorRef: "notion",
           permission: "insert_comments",
-          action: "deny",
+          action: "allow",
           expiresAt: new Date(Date.now() + 2 * 60 * 60 * 1000).toISOString(),
         }),
       ],
@@ -271,12 +271,12 @@ describe("permissions dialog - flat list connector (Notion)", () => {
       agentId: AGENT_ID,
       connectorRef: "notion",
       permission: "insert_comments",
-      action: "deny",
+      action: "allow",
       expiresIn: "7d",
     });
   });
 
-  it("keeps current expiration when an existing grant action changes", async () => {
+  it("does not keep deny expiration when an existing grant action changes", async () => {
     const grantBodies: unknown[] = [];
     mockAPIs({
       connectorType: "notion",
@@ -304,12 +304,18 @@ describe("permissions dialog - flat list connector (Notion)", () => {
     await openPermissionsDrawer("Notion");
 
     const row = getPermissionRow("insert_comments");
+    expect(screen.queryByText("Expires in 2 hours")).not.toBeInTheDocument();
+    expect(
+      screen.queryByRole("combobox", {
+        name: "insert_comments grant duration",
+      }),
+    ).not.toBeInTheDocument();
+    click(getPolicyButton(row, "Allow"));
     expect(
       screen.getByRole("combobox", {
         name: "insert_comments grant duration",
       }),
-    ).toHaveTextContent("Keep current");
-    click(getPolicyButton(row, "Allow"));
+    ).toHaveTextContent("Always");
     click(screen.getByText("Apply"));
 
     await waitFor(() => {
@@ -328,6 +334,47 @@ describe("permissions dialog - flat list connector (Notion)", () => {
 
   it("saves selected expiration for a newly changed grant", async () => {
     const grantBodies: unknown[] = [];
+    mockAPIs({
+      connectorType: "notion",
+      userPermissionGrants: [mockGrant("notion", "insert_comments", "deny")],
+    });
+    server.use(
+      mockApi(zeroUserPermissionGrantsContract.upsert, ({ body, respond }) => {
+        grantBodies.push(body);
+        return respond(200, createMockUserPermissionGrantResponse(body));
+      }),
+    );
+    detachedSetupPage({
+      context,
+      path: "/agents/my-agent",
+      featureSwitches: { [FeatureSwitchKey.ExpiringPermissionGrants]: true },
+    });
+    await openPermissionsDrawer("Notion");
+
+    const row = getPermissionRow("insert_comments");
+    click(getPolicyButton(row, "Allow"));
+    click(
+      screen.getByRole("combobox", {
+        name: "insert_comments grant duration",
+      }),
+    );
+    click(await screen.findByRole("option", { name: "24 hours" }));
+    click(screen.getByText("Apply"));
+
+    await waitFor(() => {
+      expect(grantBodies).toHaveLength(1);
+    });
+    expect(grantBodies[0]).toMatchObject({
+      agentId: AGENT_ID,
+      connectorRef: "notion",
+      permission: "insert_comments",
+      action: "allow",
+      expiresIn: "24h",
+    });
+  });
+
+  it("does not show expiration controls for deny changes", async () => {
+    const grantBodies: unknown[] = [];
     mockAPIs({ connectorType: "notion" });
     server.use(
       mockApi(zeroUserPermissionGrantsContract.upsert, ({ body, respond }) => {
@@ -344,12 +391,12 @@ describe("permissions dialog - flat list connector (Notion)", () => {
 
     const row = getPermissionRow("insert_comments");
     click(getPolicyButton(row, "Deny"));
-    click(
-      screen.getByRole("combobox", {
+    expect(
+      screen.queryByRole("combobox", {
         name: "insert_comments grant duration",
       }),
-    );
-    click(await screen.findByRole("option", { name: "24 hours" }));
+    ).not.toBeInTheDocument();
+    expect(screen.queryByText("Always")).not.toBeInTheDocument();
     click(screen.getByText("Apply"));
 
     await waitFor(() => {
@@ -360,7 +407,9 @@ describe("permissions dialog - flat list connector (Notion)", () => {
       connectorRef: "notion",
       permission: "insert_comments",
       action: "deny",
-      expiresIn: "24h",
+    });
+    expect(grantBodies[0]).not.toMatchObject({
+      expiresIn: expect.any(String),
     });
   });
 });

--- a/turbo/apps/platform/src/views/fw/__tests__/permissions-dialog.test.tsx
+++ b/turbo/apps/platform/src/views/fw/__tests__/permissions-dialog.test.tsx
@@ -172,6 +172,17 @@ function getUnknownEndpointsRow(): HTMLElement {
   return row;
 }
 
+function getPermissionGroupHeader(category: string): HTMLElement {
+  const label = screen.getByText((text) => {
+    return text.startsWith(`${category} (`);
+  });
+  const row = label.closest("button")?.parentElement;
+  if (!(row instanceof HTMLElement)) {
+    throw new Error(`Permission group header not found: ${category}`);
+  }
+  return row;
+}
+
 function getAllowOptionsButton(
   row: HTMLElement,
   permission: string,
@@ -616,6 +627,35 @@ describe("permissions dialog - grouped connector (Slack)", () => {
         screen.queryByText("channels:read"),
       ).not.toBeInTheDocument();
     });
+  });
+
+  it("sets and resets expiration from grouped permission controls", async () => {
+    mockAPIs({ connectorType: "slack" });
+    detachedSetupPage({
+      context,
+      path: "/agents/my-agent",
+      featureSwitches: { [FeatureSwitchKey.ExpiringPermissionGrants]: true },
+    });
+    await openPermissionsDrawer("Slack");
+
+    const readGroup = getPermissionGroupHeader("Read");
+    await selectAllowDuration(readGroup, "Read", "Allow for 24h");
+    expect(screen.getByText("Apply")).toBeEnabled();
+
+    click(screen.getByText(/Read \(\d+\)/i));
+    await waitFor(() => {
+      expect(screen.getByText("channels:read")).toBeInTheDocument();
+    });
+    const channelsReadRow = getPermissionRow("channels:read");
+    expect(getPolicyButton(channelsReadRow, "Allow")).toHaveTextContent(
+      "Allow · 24h",
+    );
+
+    click(getResetChangesButton(readGroup, "Read"));
+    expect(getPolicyButton(channelsReadRow, "Allow")).toHaveTextContent(
+      "Allow",
+    );
+    expect(screen.getByText("Apply")).toBeDisabled();
   });
 
   it("saves changed grants and closes drawer when Apply is clicked (FW-D-036)", async () => {

--- a/turbo/apps/platform/src/views/fw/__tests__/permissions-dialog.test.tsx
+++ b/turbo/apps/platform/src/views/fw/__tests__/permissions-dialog.test.tsx
@@ -297,7 +297,7 @@ describe("permissions dialog - flat list connector (Notion)", () => {
     const durationSelect = within(row).getByRole("combobox", {
       name: "insert_comments grant duration",
     });
-    expect(durationSelect).toHaveTextContent("Always");
+    expect(durationSelect).toHaveTextContent("Keep current");
     expect(screen.getByText("Apply")).toBeDisabled();
 
     click(durationSelect);
@@ -356,7 +356,7 @@ describe("permissions dialog - flat list connector (Notion)", () => {
       screen.getByRole("combobox", {
         name: "insert_comments grant duration",
       }),
-    ).toHaveTextContent("Always");
+    ).toHaveTextContent("Keep current");
     click(screen.getByText("Apply"));
 
     await waitFor(() => {

--- a/turbo/apps/platform/src/views/fw/__tests__/permissions-dialog.test.tsx
+++ b/turbo/apps/platform/src/views/fw/__tests__/permissions-dialog.test.tsx
@@ -285,7 +285,7 @@ describe("permissions dialog - flat list connector (Notion)", () => {
           connectorRef: "notion",
           permission: "insert_comments",
           action: "allow",
-          expiresAt: new Date(Date.now() + 2 * 60 * 60 * 1000).toISOString(),
+          expiresAt: new Date(Date.now() + 30 * 60 * 1000).toISOString(),
         }),
       ],
     });
@@ -303,7 +303,7 @@ describe("permissions dialog - flat list connector (Notion)", () => {
     await openPermissionsDrawer("Notion");
 
     await waitFor(() => {
-      expect(screen.getByText("Expires in 2 hours")).toBeInTheDocument();
+      expect(screen.getByText("< 1 hour")).toBeInTheDocument();
     });
     const row = getPermissionRow("insert_comments");
     const allowButton = getPolicyButton(row, "Allow");
@@ -312,7 +312,7 @@ describe("permissions dialog - flat list connector (Notion)", () => {
 
     await selectAllowDuration(row, "insert_comments", "Allow for 7d");
     expect(allowButton).toHaveTextContent(/^Allow$/);
-    expect(within(row).getByText("Expires in 7d")).toBeInTheDocument();
+    expect(within(row).getByText("7d")).toBeInTheDocument();
     expect(screen.getByText("Apply")).toBeEnabled();
 
     click(screen.getByText("Apply"));
@@ -357,7 +357,7 @@ describe("permissions dialog - flat list connector (Notion)", () => {
 
     await selectAllowDuration(row, "insert_comments", "Allow for 24h");
     expect(allowButton).toHaveTextContent(/^Allow$/);
-    expect(within(row).getByText("Expires in 24h")).toBeInTheDocument();
+    expect(within(row).getByText("24h")).toBeInTheDocument();
     expect(screen.getByText("Apply")).toBeEnabled();
     click(screen.getByText("Apply"));
 
@@ -401,7 +401,7 @@ describe("permissions dialog - flat list connector (Notion)", () => {
     await openPermissionsDrawer("Notion");
 
     const row = getPermissionRow("insert_comments");
-    expect(screen.queryByText("Expires in 2 hours")).not.toBeInTheDocument();
+    expect(screen.queryByText("2 hours")).not.toBeInTheDocument();
     expect(within(row).queryByText("Always")).not.toBeInTheDocument();
     click(getPolicyButton(row, "Allow"));
     expect(getPolicyButton(row, "Allow")).toHaveTextContent(/^Allow$/);
@@ -497,7 +497,7 @@ describe("permissions dialog - flat list connector (Notion)", () => {
     click(allowFor24h);
 
     expect(getPolicyButton(row, "Allow")).toHaveTextContent(/^Allow$/);
-    expect(within(row).getByText("Expires in 24h")).toBeInTheDocument();
+    expect(within(row).getByText("24h")).toBeInTheDocument();
     expect(screen.getByText("Apply")).toBeEnabled();
 
     click(getResetChangesButton(row, "insert_comments"));
@@ -654,9 +654,7 @@ describe("permissions dialog - grouped connector (Slack)", () => {
     expect(getPolicyButton(channelsReadRow, "Allow")).toHaveTextContent(
       /^Allow$/,
     );
-    expect(
-      within(channelsReadRow).getByText("Expires in 24h"),
-    ).toBeInTheDocument();
+    expect(within(channelsReadRow).getByText("24h")).toBeInTheDocument();
 
     click(getResetChangesButton(readGroup, "Read"));
     expect(getPolicyButton(channelsReadRow, "Allow")).toHaveTextContent(

--- a/turbo/apps/platform/src/views/fw/__tests__/permissions-dialog.test.tsx
+++ b/turbo/apps/platform/src/views/fw/__tests__/permissions-dialog.test.tsx
@@ -185,6 +185,19 @@ function getAllowOptionsButton(
   return button;
 }
 
+function getResetChangesButton(
+  row: HTMLElement,
+  permission: string,
+): HTMLElement {
+  const button = queryAllByRoleFast("button", row).find((el) => {
+    return el.getAttribute("aria-label") === `Reset ${permission} changes`;
+  });
+  if (!(button instanceof HTMLElement)) {
+    throw new Error(`Reset changes button not found: ${permission}`);
+  }
+  return button;
+}
+
 async function selectAllowDuration(
   row: HTMLElement,
   permission: string,
@@ -326,6 +339,10 @@ describe("permissions dialog - flat list connector (Notion)", () => {
     expect(allowButton).toHaveTextContent("Allow");
     expect(screen.getByText("Apply")).toBeDisabled();
 
+    await selectAllowDuration(row, "insert_comments", "Allow always");
+    expect(allowButton).toHaveTextContent("Allow");
+    expect(screen.getByText("Apply")).toBeDisabled();
+
     await selectAllowDuration(row, "insert_comments", "Allow for 24h");
     expect(allowButton).toHaveTextContent("Allow · 24h");
     expect(screen.getByText("Apply")).toBeEnabled();
@@ -426,7 +443,7 @@ describe("permissions dialog - flat list connector (Notion)", () => {
     });
   });
 
-  it("keeps deny policy when choosing current duration from allow options", async () => {
+  it("resets pending allow duration changes from allow options", async () => {
     mockAPIs({
       connectorType: "notion",
       userPermissionGrants: [mockGrant("notion", "insert_comments", "deny")],
@@ -451,19 +468,30 @@ describe("permissions dialog - flat list connector (Notion)", () => {
         return item.textContent?.trim() === "Allow";
       }),
     ).toBeFalsy();
+    expect(
+      menuItems.some((item) => {
+        return item.textContent?.includes("Keep current") ?? false;
+      }),
+    ).toBeFalsy();
 
-    const keepCurrent = menuItems.find((item) => {
-      return item.textContent?.includes("Keep current") ?? false;
+    const allowFor24h = menuItems.find((item) => {
+      return item.textContent?.includes("Allow for 24h") ?? false;
     });
-    if (!(keepCurrent instanceof HTMLElement)) {
-      throw new Error("Keep current menu item not found");
+    if (!(allowFor24h instanceof HTMLElement)) {
+      throw new Error("Allow for 24h menu item not found");
     }
-    click(keepCurrent);
+    click(allowFor24h);
+
+    expect(getPolicyButton(row, "Allow")).toHaveTextContent("Allow · 24h");
+    expect(screen.getByText("Apply")).toBeEnabled();
+
+    click(getResetChangesButton(row, "insert_comments"));
 
     expect(getPolicyButton(row, "Deny")).toHaveAttribute(
       "aria-pressed",
       "true",
     );
+    expect(getPolicyButton(row, "Allow")).toHaveTextContent("Allow");
     expect(screen.getByText("Apply")).toBeDisabled();
   });
 

--- a/turbo/apps/platform/src/views/fw/__tests__/permissions-dialog.test.tsx
+++ b/turbo/apps/platform/src/views/fw/__tests__/permissions-dialog.test.tsx
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest";
-import { screen, waitFor } from "@testing-library/react";
+import { screen, waitFor, within } from "@testing-library/react";
 import type { ConnectorType } from "@vm0/connectors/connectors";
 import { FeatureSwitchKey } from "@vm0/connectors/feature-switch-key";
 import { UNKNOWN_PERMISSION_GRANT } from "@vm0/connectors/firewall-types";
@@ -276,6 +276,47 @@ describe("permissions dialog - flat list connector (Notion)", () => {
     });
   });
 
+  it("treats default allow permissions as always and saves selected expiration", async () => {
+    const grantBodies: unknown[] = [];
+    mockAPIs({ connectorType: "notion" });
+    server.use(
+      mockApi(zeroUserPermissionGrantsContract.upsert, ({ body, respond }) => {
+        grantBodies.push(body);
+        return respond(200, createMockUserPermissionGrantResponse(body));
+      }),
+    );
+    detachedSetupPage({
+      context,
+      path: "/agents/my-agent",
+      featureSwitches: { [FeatureSwitchKey.ExpiringPermissionGrants]: true },
+    });
+    await openPermissionsDrawer("Notion");
+
+    const row = getPermissionRow("insert_comments");
+    expect(within(row).getAllByText("Always").length).toBeGreaterThan(0);
+    const durationSelect = within(row).getByRole("combobox", {
+      name: "insert_comments grant duration",
+    });
+    expect(durationSelect).toHaveTextContent("Always");
+    expect(screen.getByText("Apply")).toBeDisabled();
+
+    click(durationSelect);
+    click(await screen.findByRole("option", { name: "24 hours" }));
+    expect(screen.getByText("Apply")).toBeEnabled();
+    click(screen.getByText("Apply"));
+
+    await waitFor(() => {
+      expect(grantBodies).toHaveLength(1);
+    });
+    expect(grantBodies[0]).toMatchObject({
+      agentId: AGENT_ID,
+      connectorRef: "notion",
+      permission: "insert_comments",
+      action: "allow",
+      expiresIn: "24h",
+    });
+  });
+
   it("does not keep deny expiration when an existing grant action changes", async () => {
     const grantBodies: unknown[] = [];
     mockAPIs({
@@ -392,11 +433,11 @@ describe("permissions dialog - flat list connector (Notion)", () => {
     const row = getPermissionRow("insert_comments");
     click(getPolicyButton(row, "Deny"));
     expect(
-      screen.queryByRole("combobox", {
+      within(row).queryByRole("combobox", {
         name: "insert_comments grant duration",
       }),
     ).not.toBeInTheDocument();
-    expect(screen.queryByText("Always")).not.toBeInTheDocument();
+    expect(within(row).queryByText("Always")).not.toBeInTheDocument();
     click(screen.getByText("Apply"));
 
     await waitFor(() => {

--- a/turbo/apps/platform/src/views/fw/__tests__/permissions-dialog.test.tsx
+++ b/turbo/apps/platform/src/views/fw/__tests__/permissions-dialog.test.tsx
@@ -403,6 +403,7 @@ describe("permissions dialog - flat list connector (Notion)", () => {
     expect(within(row).queryByText("Always")).not.toBeInTheDocument();
     click(getPolicyButton(row, "Allow"));
     expect(getPolicyButton(row, "Allow")).toHaveTextContent("Allow");
+    expect(within(row).getByText("Always")).toBeInTheDocument();
     click(screen.getByText("Apply"));
 
     await waitFor(() => {
@@ -656,6 +657,31 @@ describe("permissions dialog - grouped connector (Slack)", () => {
       "Allow",
     );
     expect(screen.getByText("Apply")).toBeDisabled();
+  });
+
+  it("shows always when a grouped deny change returns to allow", async () => {
+    mockAPIs({ connectorType: "slack" });
+    detachedSetupPage({
+      context,
+      path: "/agents/my-agent",
+      featureSwitches: { [FeatureSwitchKey.ExpiringPermissionGrants]: true },
+    });
+    await openPermissionsDrawer("Slack");
+
+    const readGroup = getPermissionGroupHeader("Read");
+    click(getPolicyButton(readGroup, "Deny"));
+    expect(within(readGroup).queryByText("Always")).not.toBeInTheDocument();
+
+    click(getPolicyButton(readGroup, "Allow"));
+    expect(within(readGroup).getByText("Always")).toBeInTheDocument();
+
+    click(screen.getByText(/Read \(\d+\)/i));
+    await waitFor(() => {
+      expect(screen.getByText("channels:read")).toBeInTheDocument();
+    });
+    expect(
+      within(getPermissionRow("channels:read")).getByText("Always"),
+    ).toBeInTheDocument();
   });
 
   it("saves changed grants and closes drawer when Apply is clicked (FW-D-036)", async () => {

--- a/turbo/apps/platform/src/views/fw/__tests__/permissions-dialog.test.tsx
+++ b/turbo/apps/platform/src/views/fw/__tests__/permissions-dialog.test.tsx
@@ -1,6 +1,7 @@
 import { describe, expect, it } from "vitest";
 import { screen, waitFor } from "@testing-library/react";
 import type { ConnectorType } from "@vm0/connectors/connectors";
+import { FeatureSwitchKey } from "@vm0/connectors/feature-switch-key";
 import { UNKNOWN_PERMISSION_GRANT } from "@vm0/connectors/firewall-types";
 import {
   zeroAgentsByIdContract,
@@ -219,6 +220,95 @@ describe("permissions dialog - flat list connector (Notion)", () => {
       return b.textContent?.includes("Allow") ?? false;
     });
     expect(allowBtn).toHaveAttribute("aria-pressed", "true");
+  });
+
+  it("allows updating expiration on an existing explicit grant", async () => {
+    const grantBodies: unknown[] = [];
+    mockAPIs({
+      connectorType: "notion",
+      userPermissionGrants: [
+        createMockUserPermissionGrantResponse({
+          agentId: AGENT_ID,
+          connectorRef: "notion",
+          permission: "insert_comments",
+          action: "deny",
+          expiresAt: new Date(Date.now() + 2 * 60 * 60 * 1000).toISOString(),
+        }),
+      ],
+    });
+    server.use(
+      mockApi(zeroUserPermissionGrantsContract.upsert, ({ body, respond }) => {
+        grantBodies.push(body);
+        return respond(200, createMockUserPermissionGrantResponse(body));
+      }),
+    );
+    detachedSetupPage({
+      context,
+      path: "/agents/my-agent",
+      featureSwitches: { [FeatureSwitchKey.ExpiringPermissionGrants]: true },
+    });
+    await openPermissionsDrawer("Notion");
+
+    await waitFor(() => {
+      expect(screen.getByText("Expires in 2 hours")).toBeInTheDocument();
+    });
+    click(
+      screen.getByRole("combobox", {
+        name: "insert_comments grant duration",
+      }),
+    );
+    click(await screen.findByRole("option", { name: "7 days" }));
+
+    click(screen.getByText("Apply"));
+
+    await waitFor(() => {
+      expect(grantBodies).toHaveLength(1);
+    });
+    expect(grantBodies[0]).toMatchObject({
+      agentId: AGENT_ID,
+      connectorRef: "notion",
+      permission: "insert_comments",
+      action: "deny",
+      expiresIn: "7d",
+    });
+  });
+
+  it("saves selected expiration for a newly changed grant", async () => {
+    const grantBodies: unknown[] = [];
+    mockAPIs({ connectorType: "notion" });
+    server.use(
+      mockApi(zeroUserPermissionGrantsContract.upsert, ({ body, respond }) => {
+        grantBodies.push(body);
+        return respond(200, createMockUserPermissionGrantResponse(body));
+      }),
+    );
+    detachedSetupPage({
+      context,
+      path: "/agents/my-agent",
+      featureSwitches: { [FeatureSwitchKey.ExpiringPermissionGrants]: true },
+    });
+    await openPermissionsDrawer("Notion");
+
+    const row = getPermissionRow("insert_comments");
+    click(getPolicyButton(row, "Deny"));
+    click(
+      screen.getByRole("combobox", {
+        name: "insert_comments grant duration",
+      }),
+    );
+    click(await screen.findByRole("option", { name: "24 hours" }));
+    click(screen.getByText("Apply"));
+
+    await waitFor(() => {
+      expect(grantBodies).toHaveLength(1);
+    });
+    expect(grantBodies[0]).toMatchObject({
+      agentId: AGENT_ID,
+      connectorRef: "notion",
+      permission: "insert_comments",
+      action: "deny",
+      expiresIn: "24h",
+    });
   });
 });
 

--- a/turbo/apps/platform/src/views/fw/__tests__/permissions-dialog.test.tsx
+++ b/turbo/apps/platform/src/views/fw/__tests__/permissions-dialog.test.tsx
@@ -426,6 +426,47 @@ describe("permissions dialog - flat list connector (Notion)", () => {
     });
   });
 
+  it("keeps deny policy when choosing current duration from allow options", async () => {
+    mockAPIs({
+      connectorType: "notion",
+      userPermissionGrants: [mockGrant("notion", "insert_comments", "deny")],
+    });
+    detachedSetupPage({
+      context,
+      path: "/agents/my-agent",
+      featureSwitches: { [FeatureSwitchKey.ExpiringPermissionGrants]: true },
+    });
+    await openPermissionsDrawer("Notion");
+
+    const row = getPermissionRow("insert_comments");
+    click(getAllowOptionsButton(row, "insert_comments"));
+
+    let menuItems: HTMLElement[] = [];
+    await waitFor(() => {
+      menuItems = queryAllByRoleFast("menuitem");
+      expect(menuItems.length).toBeGreaterThan(0);
+    });
+    expect(
+      menuItems.some((item) => {
+        return item.textContent?.trim() === "Allow";
+      }),
+    ).toBeFalsy();
+
+    const keepCurrent = menuItems.find((item) => {
+      return item.textContent?.includes("Keep current") ?? false;
+    });
+    if (!(keepCurrent instanceof HTMLElement)) {
+      throw new Error("Keep current menu item not found");
+    }
+    click(keepCurrent);
+
+    expect(getPolicyButton(row, "Deny")).toHaveAttribute(
+      "aria-pressed",
+      "true",
+    );
+    expect(screen.getByText("Apply")).toBeDisabled();
+  });
+
   it("does not show expiration controls for deny changes", async () => {
     const grantBodies: unknown[] = [];
     mockAPIs({ connectorType: "notion" });

--- a/turbo/apps/platform/src/views/fw/__tests__/permissions-dialog.test.tsx
+++ b/turbo/apps/platform/src/views/fw/__tests__/permissions-dialog.test.tsx
@@ -252,12 +252,15 @@ describe("permissions dialog - flat list connector (Notion)", () => {
     await waitFor(() => {
       expect(screen.getByText("Expires in 2 hours")).toBeInTheDocument();
     });
-    click(
-      screen.getByRole("combobox", {
-        name: "insert_comments grant duration",
-      }),
-    );
+    const durationSelect = screen.getByRole("combobox", {
+      name: "insert_comments grant duration",
+    });
+    expect(durationSelect).toHaveTextContent("Keep current");
+    expect(screen.getByText("Apply")).toBeDisabled();
+
+    click(durationSelect);
     click(await screen.findByRole("option", { name: "7 days" }));
+    expect(screen.getByText("Apply")).toBeEnabled();
 
     click(screen.getByText("Apply"));
 
@@ -270,6 +273,56 @@ describe("permissions dialog - flat list connector (Notion)", () => {
       permission: "insert_comments",
       action: "deny",
       expiresIn: "7d",
+    });
+  });
+
+  it("keeps current expiration when an existing grant action changes", async () => {
+    const grantBodies: unknown[] = [];
+    mockAPIs({
+      connectorType: "notion",
+      userPermissionGrants: [
+        createMockUserPermissionGrantResponse({
+          agentId: AGENT_ID,
+          connectorRef: "notion",
+          permission: "insert_comments",
+          action: "deny",
+          expiresAt: new Date(Date.now() + 2 * 60 * 60 * 1000).toISOString(),
+        }),
+      ],
+    });
+    server.use(
+      mockApi(zeroUserPermissionGrantsContract.upsert, ({ body, respond }) => {
+        grantBodies.push(body);
+        return respond(200, createMockUserPermissionGrantResponse(body));
+      }),
+    );
+    detachedSetupPage({
+      context,
+      path: "/agents/my-agent",
+      featureSwitches: { [FeatureSwitchKey.ExpiringPermissionGrants]: true },
+    });
+    await openPermissionsDrawer("Notion");
+
+    const row = getPermissionRow("insert_comments");
+    expect(
+      screen.getByRole("combobox", {
+        name: "insert_comments grant duration",
+      }),
+    ).toHaveTextContent("Keep current");
+    click(getPolicyButton(row, "Allow"));
+    click(screen.getByText("Apply"));
+
+    await waitFor(() => {
+      expect(grantBodies).toHaveLength(1);
+    });
+    expect(grantBodies[0]).toMatchObject({
+      agentId: AGENT_ID,
+      connectorRef: "notion",
+      permission: "insert_comments",
+      action: "allow",
+    });
+    expect(grantBodies[0]).not.toMatchObject({
+      expiresIn: expect.any(String),
     });
   });
 

--- a/turbo/apps/platform/src/views/fw/__tests__/permissions-dialog.test.tsx
+++ b/turbo/apps/platform/src/views/fw/__tests__/permissions-dialog.test.tsx
@@ -172,6 +172,35 @@ function getUnknownEndpointsRow(): HTMLElement {
   return row;
 }
 
+function getAllowOptionsButton(
+  row: HTMLElement,
+  permission: string,
+): HTMLElement {
+  const button = queryAllByRoleFast("button", row).find((el) => {
+    return el.getAttribute("aria-label") === `${permission} allow options`;
+  });
+  if (!(button instanceof HTMLElement)) {
+    throw new Error(`Allow options button not found: ${permission}`);
+  }
+  return button;
+}
+
+async function selectAllowDuration(
+  row: HTMLElement,
+  permission: string,
+  option: string,
+) {
+  click(getAllowOptionsButton(row, permission));
+  let item: HTMLElement | undefined;
+  await waitFor(() => {
+    item = queryAllByRoleFast("menuitem").find((el) => {
+      return el.textContent?.includes(option) ?? false;
+    });
+    expect(item).toBeDefined();
+  });
+  click(item!);
+}
+
 describe("permissions dialog - flat list connector (Notion)", () => {
   it("renders permission names and descriptions in flat list (FW-D-031)", async () => {
     mockAPIs({ connectorType: "notion" });
@@ -252,14 +281,13 @@ describe("permissions dialog - flat list connector (Notion)", () => {
     await waitFor(() => {
       expect(screen.getByText("Expires in 2 hours")).toBeInTheDocument();
     });
-    const durationSelect = screen.getByRole("combobox", {
-      name: "insert_comments grant duration",
-    });
-    expect(durationSelect).toHaveTextContent("Keep current");
+    const row = getPermissionRow("insert_comments");
+    const allowButton = getPolicyButton(row, "Allow");
+    expect(allowButton).toHaveTextContent("Allow");
     expect(screen.getByText("Apply")).toBeDisabled();
 
-    click(durationSelect);
-    click(await screen.findByRole("option", { name: "7 days" }));
+    await selectAllowDuration(row, "insert_comments", "Allow for 7d");
+    expect(allowButton).toHaveTextContent("Allow · 7d");
     expect(screen.getByText("Apply")).toBeEnabled();
 
     click(screen.getByText("Apply"));
@@ -294,14 +322,12 @@ describe("permissions dialog - flat list connector (Notion)", () => {
 
     const row = getPermissionRow("insert_comments");
     expect(within(row).getAllByText("Always").length).toBeGreaterThan(0);
-    const durationSelect = within(row).getByRole("combobox", {
-      name: "insert_comments grant duration",
-    });
-    expect(durationSelect).toHaveTextContent("Keep current");
+    const allowButton = getPolicyButton(row, "Allow");
+    expect(allowButton).toHaveTextContent("Allow");
     expect(screen.getByText("Apply")).toBeDisabled();
 
-    click(durationSelect);
-    click(await screen.findByRole("option", { name: "24 hours" }));
+    await selectAllowDuration(row, "insert_comments", "Allow for 24h");
+    expect(allowButton).toHaveTextContent("Allow · 24h");
     expect(screen.getByText("Apply")).toBeEnabled();
     click(screen.getByText("Apply"));
 
@@ -346,17 +372,9 @@ describe("permissions dialog - flat list connector (Notion)", () => {
 
     const row = getPermissionRow("insert_comments");
     expect(screen.queryByText("Expires in 2 hours")).not.toBeInTheDocument();
-    expect(
-      screen.queryByRole("combobox", {
-        name: "insert_comments grant duration",
-      }),
-    ).not.toBeInTheDocument();
+    expect(within(row).queryByText("Always")).not.toBeInTheDocument();
     click(getPolicyButton(row, "Allow"));
-    expect(
-      screen.getByRole("combobox", {
-        name: "insert_comments grant duration",
-      }),
-    ).toHaveTextContent("Keep current");
+    expect(getPolicyButton(row, "Allow")).toHaveTextContent("Allow");
     click(screen.getByText("Apply"));
 
     await waitFor(() => {
@@ -393,13 +411,7 @@ describe("permissions dialog - flat list connector (Notion)", () => {
     await openPermissionsDrawer("Notion");
 
     const row = getPermissionRow("insert_comments");
-    click(getPolicyButton(row, "Allow"));
-    click(
-      screen.getByRole("combobox", {
-        name: "insert_comments grant duration",
-      }),
-    );
-    click(await screen.findByRole("option", { name: "24 hours" }));
+    await selectAllowDuration(row, "insert_comments", "Allow for 24h");
     click(screen.getByText("Apply"));
 
     await waitFor(() => {
@@ -431,12 +443,9 @@ describe("permissions dialog - flat list connector (Notion)", () => {
     await openPermissionsDrawer("Notion");
 
     const row = getPermissionRow("insert_comments");
-    click(getPolicyButton(row, "Deny"));
-    expect(
-      within(row).queryByRole("combobox", {
-        name: "insert_comments grant duration",
-      }),
-    ).not.toBeInTheDocument();
+    const denyButton = getPolicyButton(row, "Deny");
+    click(denyButton);
+    expect(denyButton).toHaveAttribute("aria-pressed", "true");
     expect(within(row).queryByText("Always")).not.toBeInTheDocument();
     click(screen.getByText("Apply"));
 

--- a/turbo/apps/platform/src/views/permission-allow/__tests__/permission-allow-page.test.tsx
+++ b/turbo/apps/platform/src/views/permission-allow/__tests__/permission-allow-page.test.tsx
@@ -212,6 +212,52 @@ describe("permission allow page", () => {
     expect(screen.getByText("Expires in 1 hour")).toBeInTheDocument();
   });
 
+  it("confirms a requested duration when an allow grant already matches", async () => {
+    let grantBody: unknown;
+    mockAgent();
+    setMockUserPermissionGrants([
+      createMockUserPermissionGrantResponse({
+        agentId: AGENT_ID,
+        connectorRef: "slack",
+        permission: "chat:write",
+        action: "allow",
+      }),
+    ]);
+    server.use(
+      mockApi(zeroUserPermissionGrantsContract.upsert, ({ body, respond }) => {
+        grantBody = body;
+        return respond(
+          200,
+          createMockUserPermissionGrantResponse({
+            ...body,
+            expiresAt: new Date(Date.now() + 60 * 60 * 1000).toISOString(),
+          }),
+        );
+      }),
+    );
+
+    detachedSetupPage({
+      context,
+      path: `/agents/${AGENT_ID}/permissions?ref=slack&permission=chat:write&action=allow&expiresIn=1h`,
+      featureSwitches: { [FeatureSwitchKey.ExpiringPermissionGrants]: true },
+    });
+
+    await waitFor(() => {
+      expect(screen.getByText("Research agent")).toBeInTheDocument();
+      expect(
+        screen.getByRole("combobox", { name: "Permission duration" }),
+      ).toHaveTextContent("1 hour");
+      expect(getButtonByText("Confirm")).toBeEnabled();
+    });
+
+    await click(getButtonByText("Confirm"));
+
+    await waitFor(() => {
+      expect(grantBody).toMatchObject({ expiresIn: "1h" });
+    });
+    expect(screen.getByText("Permissions updated")).toBeInTheDocument();
+  });
+
   it("submits the selected duration when expiring grants are enabled", async () => {
     let grantBody: unknown;
     mockAgent();

--- a/turbo/apps/platform/src/views/permission-allow/__tests__/permission-allow-page.test.tsx
+++ b/turbo/apps/platform/src/views/permission-allow/__tests__/permission-allow-page.test.tsx
@@ -1,6 +1,8 @@
 import { describe, expect, it } from "vitest";
 import { screen, waitFor } from "@testing-library/react";
 import { zeroAgentsByIdContract } from "@vm0/api-contracts/contracts/zero-agents";
+import { zeroUserPermissionGrantsContract } from "@vm0/api-contracts/contracts/zero-user-permission-grants";
+import { FeatureSwitchKey } from "@vm0/connectors/feature-switch-key";
 import { server } from "../../../mocks/server.ts";
 import { createMockApi } from "../../../mocks/msw-contract.ts";
 import {
@@ -93,9 +95,38 @@ describe("permission allow page", () => {
     });
   });
 
+  it("ignores expired matching grants", async () => {
+    mockAgent();
+    setMockUserPermissionGrants([
+      createMockUserPermissionGrantResponse({
+        agentId: AGENT_ID,
+        connectorRef: "slack",
+        permission: "chat:write",
+        action: "allow",
+        expiresAt: new Date(Date.now() - 60 * 1000).toISOString(),
+      }),
+    ]);
+
+    setupPermissionPage(
+      `/agents/${AGENT_ID}/permissions?ref=slack&permission=chat:write&action=allow`,
+    );
+
+    await waitFor(() => {
+      expect(screen.getByText("Research agent")).toBeInTheDocument();
+      expect(getButtonByText("Confirm")).toBeEnabled();
+    });
+  });
+
   it("writes a current-user grant from the confirm action", async () => {
+    let grantBody: unknown;
     mockAgent();
     setMockUserPermissionGrants([]);
+    server.use(
+      mockApi(zeroUserPermissionGrantsContract.upsert, ({ body, respond }) => {
+        grantBody = body;
+        return respond(200, createMockUserPermissionGrantResponse(body));
+      }),
+    );
 
     setupPermissionPage(
       `/agents/${AGENT_ID}/permissions?ref=slack&permission=chat:write&action=allow`,
@@ -110,6 +141,81 @@ describe("permission allow page", () => {
 
     await waitFor(() => {
       expect(screen.getByText("Permissions updated")).toBeInTheDocument();
+    });
+    expect(grantBody).toMatchObject({
+      agentId: AGENT_ID,
+      connectorRef: "slack",
+      permission: "chat:write",
+      action: "allow",
+    });
+    expect(grantBody).not.toMatchObject({ expiresIn: expect.any(String) });
+  });
+
+  it("submits the default duration when expiring grants are enabled", async () => {
+    let grantBody: unknown;
+    mockAgent();
+    setMockUserPermissionGrants([]);
+    server.use(
+      mockApi(zeroUserPermissionGrantsContract.upsert, ({ body, respond }) => {
+        grantBody = body;
+        return respond(
+          200,
+          createMockUserPermissionGrantResponse({
+            ...body,
+            expiresAt: new Date(Date.now() + 60 * 60 * 1000).toISOString(),
+          }),
+        );
+      }),
+    );
+
+    detachedSetupPage({
+      context,
+      path: `/agents/${AGENT_ID}/permissions?ref=slack&permission=chat:write&action=allow`,
+      featureSwitches: { [FeatureSwitchKey.ExpiringPermissionGrants]: true },
+    });
+
+    await waitFor(() => {
+      expect(screen.getByText("Research agent")).toBeInTheDocument();
+      expect(
+        screen.getByRole("combobox", { name: "Permission duration" }),
+      ).toHaveTextContent("1 hour");
+    });
+
+    await click(getButtonByText("Confirm"));
+
+    await waitFor(() => {
+      expect(grantBody).toMatchObject({ expiresIn: "1h" });
+    });
+    expect(screen.getByText("Permissions updated")).toBeInTheDocument();
+    expect(screen.getByText("Expires in 1 hour")).toBeInTheDocument();
+  });
+
+  it("submits the selected duration when expiring grants are enabled", async () => {
+    let grantBody: unknown;
+    mockAgent();
+    setMockUserPermissionGrants([]);
+    server.use(
+      mockApi(zeroUserPermissionGrantsContract.upsert, ({ body, respond }) => {
+        grantBody = body;
+        return respond(200, createMockUserPermissionGrantResponse(body));
+      }),
+    );
+
+    detachedSetupPage({
+      context,
+      path: `/agents/${AGENT_ID}/permissions?ref=slack&permission=chat:write&action=allow`,
+      featureSwitches: { [FeatureSwitchKey.ExpiringPermissionGrants]: true },
+    });
+
+    const durationSelect = await screen.findByRole("combobox", {
+      name: "Permission duration",
+    });
+    click(durationSelect);
+    click(await screen.findByRole("option", { name: "7 days" }));
+    await click(getButtonByText("Confirm"));
+
+    await waitFor(() => {
+      expect(grantBody).toMatchObject({ expiresIn: "7d" });
     });
   });
 });

--- a/turbo/apps/platform/src/views/permission-allow/__tests__/permission-allow-page.test.tsx
+++ b/turbo/apps/platform/src/views/permission-allow/__tests__/permission-allow-page.test.tsx
@@ -95,6 +95,28 @@ describe("permission allow page", () => {
     });
   });
 
+  it("hides existing grant expiry when expiring grants are disabled", async () => {
+    mockAgent();
+    setMockUserPermissionGrants([
+      createMockUserPermissionGrantResponse({
+        agentId: AGENT_ID,
+        connectorRef: "slack",
+        permission: "users:read",
+        action: "allow",
+        expiresAt: new Date(Date.now() + 60 * 60 * 1000).toISOString(),
+      }),
+    ]);
+
+    setupPermissionPage(
+      `/agents/${AGENT_ID}/permissions?ref=slack&permission=users:read&action=allow`,
+    );
+
+    await waitFor(() => {
+      expect(screen.getByText("Permissions updated")).toBeInTheDocument();
+    });
+    expect(screen.queryByText(/Expires in/)).not.toBeInTheDocument();
+  });
+
   it("ignores expired matching grants", async () => {
     mockAgent();
     setMockUserPermissionGrants([

--- a/turbo/apps/platform/src/views/permission-allow/__tests__/permission-allow-page.test.tsx
+++ b/turbo/apps/platform/src/views/permission-allow/__tests__/permission-allow-page.test.tsx
@@ -240,4 +240,41 @@ describe("permission allow page", () => {
       expect(grantBody).toMatchObject({ expiresIn: "7d" });
     });
   });
+
+  it("does not show or submit duration for deny grants", async () => {
+    let grantBody: unknown;
+    mockAgent();
+    setMockUserPermissionGrants([]);
+    server.use(
+      mockApi(zeroUserPermissionGrantsContract.upsert, ({ body, respond }) => {
+        grantBody = body;
+        return respond(200, createMockUserPermissionGrantResponse(body));
+      }),
+    );
+
+    detachedSetupPage({
+      context,
+      path: `/agents/${AGENT_ID}/permissions?ref=slack&permission=channels:read&action=deny`,
+      featureSwitches: { [FeatureSwitchKey.ExpiringPermissionGrants]: true },
+    });
+
+    await waitFor(() => {
+      expect(screen.getByText("Research agent")).toBeInTheDocument();
+      expect(
+        screen.queryByRole("combobox", { name: "Permission duration" }),
+      ).not.toBeInTheDocument();
+    });
+
+    await click(getButtonByText("Confirm"));
+
+    await waitFor(() => {
+      expect(grantBody).toMatchObject({
+        permission: "channels:read",
+        action: "deny",
+      });
+    });
+    expect(grantBody).not.toMatchObject({ expiresIn: expect.any(String) });
+    expect(screen.getByText("Permissions denied")).toBeInTheDocument();
+    expect(screen.queryByText(/Expires in/)).not.toBeInTheDocument();
+  });
 });

--- a/turbo/apps/platform/src/views/permission-allow/__tests__/permission-allow-page.test.tsx
+++ b/turbo/apps/platform/src/views/permission-allow/__tests__/permission-allow-page.test.tsx
@@ -3,6 +3,7 @@ import { screen, waitFor } from "@testing-library/react";
 import { zeroAgentsByIdContract } from "@vm0/api-contracts/contracts/zero-agents";
 import { zeroUserPermissionGrantsContract } from "@vm0/api-contracts/contracts/zero-user-permission-grants";
 import { FeatureSwitchKey } from "@vm0/connectors/feature-switch-key";
+import { UNKNOWN_PERMISSION_GRANT } from "@vm0/connectors/firewall-types";
 import { server } from "../../../mocks/server.ts";
 import { createMockApi } from "../../../mocks/msw-contract.ts";
 import {
@@ -256,6 +257,64 @@ describe("permission allow page", () => {
       expect(grantBody).toMatchObject({ expiresIn: "1h" });
     });
     expect(screen.getByText("Permissions updated")).toBeInTheDocument();
+  });
+
+  it("treats requested always as already applied for permanent allow grants", async () => {
+    mockAgent();
+    setMockUserPermissionGrants([
+      createMockUserPermissionGrantResponse({
+        agentId: AGENT_ID,
+        connectorRef: "slack",
+        permission: "chat:write",
+        action: "allow",
+        expiresAt: null,
+      }),
+    ]);
+
+    detachedSetupPage({
+      context,
+      path: `/agents/${AGENT_ID}/permissions?ref=slack&permission=chat:write&action=allow&expiresIn=always`,
+      featureSwitches: { [FeatureSwitchKey.ExpiringPermissionGrants]: true },
+    });
+
+    await waitFor(() => {
+      expect(screen.getByText("Permissions updated")).toBeInTheDocument();
+    });
+    expect(
+      screen.queryByRole("combobox", { name: "Permission duration" }),
+    ).not.toBeInTheDocument();
+    expect(
+      queryAllByRoleFast("button").find((element) => {
+        return element.textContent?.trim() === "Confirm";
+      }),
+    ).toBeUndefined();
+  });
+
+  it("confirms requested always when permission is allowed by an expiring unknown grant", async () => {
+    mockAgent();
+    setMockUserPermissionGrants([
+      createMockUserPermissionGrantResponse({
+        agentId: AGENT_ID,
+        connectorRef: "slack",
+        permission: UNKNOWN_PERMISSION_GRANT,
+        action: "allow",
+        expiresAt: new Date(Date.now() + 60 * 60 * 1000).toISOString(),
+      }),
+    ]);
+
+    detachedSetupPage({
+      context,
+      path: `/agents/${AGENT_ID}/permissions?ref=slack&permission=chat:write&action=allow&expiresIn=always`,
+      featureSwitches: { [FeatureSwitchKey.ExpiringPermissionGrants]: true },
+    });
+
+    await waitFor(() => {
+      expect(screen.getByText("Research agent")).toBeInTheDocument();
+      expect(
+        screen.getByRole("combobox", { name: "Permission duration" }),
+      ).toHaveTextContent("Always");
+      expect(getButtonByText("Confirm")).toBeEnabled();
+    });
   });
 
   it("submits the selected duration when expiring grants are enabled", async () => {

--- a/turbo/apps/platform/src/views/permission-allow/permission-allow-page.tsx
+++ b/turbo/apps/platform/src/views/permission-allow/permission-allow-page.tsx
@@ -387,7 +387,9 @@ function PermissionAllowDoctorPage({
       grant.action === action
     );
   });
-  if (effectivePolicy === action) {
+  const requestedExpirationChange =
+    expirationEnabled && action === "allow" && initialExpiresIn !== null;
+  if (effectivePolicy === action && !requestedExpirationChange) {
     return (
       <ResultCard
         action={action}

--- a/turbo/apps/platform/src/views/permission-allow/permission-allow-page.tsx
+++ b/turbo/apps/platform/src/views/permission-allow/permission-allow-page.tsx
@@ -29,6 +29,7 @@ import {
   DEFAULT_USER_PERMISSION_GRANT_EXPIRES_IN,
   permissionGrantExpiresInByScope$,
   permissionGrantExpiryText,
+  requestedUserPermissionGrantExpirationAlreadyApplies,
   setPermissionGrantExpiresIn$,
 } from "../../signals/permission-allow/permission-grant-expiration.ts";
 import { featureSwitch$ } from "../../signals/external/feature-switch.ts";
@@ -387,9 +388,14 @@ function PermissionAllowDoctorPage({
       grant.action === action
     );
   });
-  const requestedExpirationChange =
-    expirationEnabled && action === "allow" && initialExpiresIn !== null;
-  if (effectivePolicy === action && !requestedExpirationChange) {
+  const requestedExpirationAlreadyApplies =
+    !expirationEnabled ||
+    action !== "allow" ||
+    requestedUserPermissionGrantExpirationAlreadyApplies({
+      expiresIn: initialExpiresIn,
+      currentExpiresAt: explicitGrant?.expiresAt,
+    });
+  if (effectivePolicy === action && requestedExpirationAlreadyApplies) {
     return (
       <ResultCard
         action={action}

--- a/turbo/apps/platform/src/views/permission-allow/permission-allow-page.tsx
+++ b/turbo/apps/platform/src/views/permission-allow/permission-allow-page.tsx
@@ -242,6 +242,7 @@ function ConfirmGrantCard({
     expiresInByScope[durationScope] ??
     initialExpiresIn ??
     DEFAULT_USER_PERMISSION_GRANT_EXPIRES_IN;
+  const expirationAvailable = expirationEnabled && action === "allow";
   const [grantLoadable, upsertGrant] = useLoadableSet(
     upsertUserPermissionGrant$,
   );
@@ -252,7 +253,7 @@ function ConfirmGrantCard({
       <ResultCard
         action={action}
         expiresAt={grantLoadable.data.expiresAt}
-        showExpiry={expirationEnabled}
+        showExpiry={expirationAvailable}
       />
     );
   }
@@ -265,7 +266,7 @@ function ConfirmGrantCard({
           connectorRef,
           permission: permission.name,
           action,
-          ...(expirationEnabled ? { expiresIn } : {}),
+          ...(expirationAvailable ? { expiresIn } : {}),
         },
         pageSignal,
       ),
@@ -296,7 +297,7 @@ function ConfirmGrantCard({
               action={action}
             />
           </div>
-          {expirationEnabled && (
+          {expirationAvailable && (
             <div className="flex w-full items-center justify-between gap-3 rounded-lg border border-border/70 px-3 py-2">
               <span className="text-sm font-medium text-foreground">
                 Duration
@@ -391,7 +392,7 @@ function PermissionAllowDoctorPage({
       <ResultCard
         action={action}
         expiresAt={explicitGrant?.expiresAt}
-        showExpiry={expirationEnabled}
+        showExpiry={expirationEnabled && action === "allow"}
       />
     );
   }

--- a/turbo/apps/platform/src/views/permission-allow/permission-allow-page.tsx
+++ b/turbo/apps/platform/src/views/permission-allow/permission-allow-page.tsx
@@ -1,4 +1,4 @@
-import { useGet, useLastLoadable } from "ccstate-react";
+import { useGet, useLastLoadable, useSet } from "ccstate-react";
 import { useLoadableSet } from "ccstate-react/experimental";
 import { Button } from "@vm0/ui";
 import {
@@ -7,7 +7,9 @@ import {
   IconCheck,
   IconLoader2,
 } from "@tabler/icons-react";
+import type { UserPermissionGrantExpiresIn } from "@vm0/api-contracts/contracts/zero-user-permission-grants";
 import { CONNECTOR_TYPES } from "@vm0/connectors/connectors";
+import { FeatureSwitchKey } from "@vm0/connectors/feature-switch-key";
 import { isFirewallConnectorType } from "@vm0/connectors/firewalls";
 import { pageSignal$ } from "../../signals/page-signal.ts";
 import { user$ } from "../../signals/auth.ts";
@@ -16,14 +18,23 @@ import {
   permissionAllowAction$,
   permissionAllowAgent$,
   permissionAllowAgentId$,
+  permissionAllowExpiresIn$,
   permissionAllowPermission$,
   permissionAllowRef$,
   permissionAllowUserPermissionGrants$,
   resolveUserPermissionGrantPolicy,
   upsertUserPermissionGrant$,
 } from "../../signals/permission-allow/permission-allow-signals.ts";
+import {
+  DEFAULT_USER_PERMISSION_GRANT_EXPIRES_IN,
+  permissionGrantExpiresInByScope$,
+  permissionGrantExpiryText,
+  setPermissionGrantExpiresIn$,
+} from "../../signals/permission-allow/permission-grant-expiration.ts";
+import { featureSwitch$ } from "../../signals/external/feature-switch.ts";
 import { detach, Reason } from "../../signals/utils.ts";
 import { VM0Logo } from "../components/vm0-logo.tsx";
+import { PermissionGrantDurationSelect } from "../components/permission-grant-duration-select.tsx";
 import { ConnectorIcon } from "../zero-page/components/settings/connector-icons.tsx";
 import { AvatarFromUrl } from "../zero-page/zero-sidebar-shared.tsx";
 
@@ -121,8 +132,15 @@ function LoadingCard() {
   );
 }
 
-function ResultCard({ action }: { action: "allow" | "deny" }) {
+function ResultCard({
+  action,
+  expiresAt,
+}: {
+  action: "allow" | "deny";
+  expiresAt?: string | null;
+}) {
   const allowed = action === "allow";
+  const expiryText = permissionGrantExpiryText(expiresAt ?? null);
   return (
     <div className="fixed inset-0 z-10 flex items-center justify-center pointer-events-none">
       <div className="pointer-events-auto flex w-[500px] max-w-[calc(100vw-96px)] flex-col items-center gap-10 rounded-[20px] border border-border bg-background px-[50px] py-12">
@@ -141,6 +159,11 @@ function ResultCard({ action }: { action: "allow" | "deny" }) {
               ? "Your connector permission grant has been updated"
               : "Your connector permission grant has been denied"}
           </p>
+          {expiryText && (
+            <p className="text-center text-xs font-medium text-amber-700 dark:text-amber-400">
+              {expiryText}
+            </p>
+          )}
         </div>
       </div>
     </div>
@@ -191,6 +214,8 @@ function ConfirmGrantCard({
   connectorRef,
   permission,
   action,
+  expirationEnabled,
+  initialExpiresIn,
   agentDisplayName,
   agentAvatarUrl,
   userName,
@@ -199,18 +224,29 @@ function ConfirmGrantCard({
   connectorRef: string;
   permission: Permission;
   action: "allow" | "deny";
+  expirationEnabled: boolean;
+  initialExpiresIn: UserPermissionGrantExpiresIn | null;
   agentDisplayName: string;
   agentAvatarUrl: string | null;
   userName: string;
 }) {
   const pageSignal = useGet(pageSignal$);
+  const durationScope = `${agentId}\u0000${connectorRef}\u0000${permission.name}\u0000${action}\u0000${initialExpiresIn ?? ""}`;
+  const expiresInByScope = useGet(permissionGrantExpiresInByScope$);
+  const setExpiresInForScope = useSet(setPermissionGrantExpiresIn$);
+  const expiresIn =
+    expiresInByScope[durationScope] ??
+    initialExpiresIn ??
+    DEFAULT_USER_PERMISSION_GRANT_EXPIRES_IN;
   const [grantLoadable, upsertGrant] = useLoadableSet(
     upsertUserPermissionGrant$,
   );
   const saving = grantLoadable.state === "loading";
 
   if (grantLoadable.state === "hasData") {
-    return <ResultCard action={action} />;
+    return (
+      <ResultCard action={action} expiresAt={grantLoadable.data.expiresAt} />
+    );
   }
 
   const handleSave = () => {
@@ -221,6 +257,7 @@ function ConfirmGrantCard({
           connectorRef,
           permission: permission.name,
           action,
+          ...(expirationEnabled ? { expiresIn } : {}),
         },
         pageSignal,
       ),
@@ -251,6 +288,21 @@ function ConfirmGrantCard({
               action={action}
             />
           </div>
+          {expirationEnabled && (
+            <div className="flex w-full items-center justify-between gap-3 rounded-lg border border-border/70 px-3 py-2">
+              <span className="text-sm font-medium text-foreground">
+                Duration
+              </span>
+              <PermissionGrantDurationSelect
+                value={expiresIn}
+                onValueChange={(value) => {
+                  setExpiresInForScope(durationScope, value);
+                }}
+                disabled={saving}
+                ariaLabel="Permission duration"
+              />
+            </div>
+          )}
         </div>
 
         <div className="w-[500px] max-w-[calc(100vw-96px)] px-[26px]">
@@ -273,15 +325,20 @@ function PermissionAllowDoctorPage({
   ref,
   permission,
   action,
+  initialExpiresIn,
 }: {
   agentId: string;
   ref: string;
   permission: string;
   action: "allow" | "deny";
+  initialExpiresIn: UserPermissionGrantExpiresIn | null;
 }) {
   const agentLoadable = useLastLoadable(permissionAllowAgent$);
   const userLoadable = useLastLoadable(user$);
   const grantsLoadable = useLastLoadable(permissionAllowUserPermissionGrants$);
+  const features = useGet(featureSwitch$);
+  const expirationEnabled =
+    features[FeatureSwitchKey.ExpiringPermissionGrants] ?? false;
 
   if (
     agentLoadable.state === "loading" ||
@@ -314,8 +371,15 @@ function PermissionAllowDoctorPage({
     ref,
     focusedPermission.name,
   );
+  const explicitGrant = grants.find((grant) => {
+    return (
+      grant.connectorRef === ref &&
+      grant.permission === focusedPermission.name &&
+      grant.action === action
+    );
+  });
   if (effectivePolicy === action) {
-    return <ResultCard action={action} />;
+    return <ResultCard action={action} expiresAt={explicitGrant?.expiresAt} />;
   }
 
   const currentUser =
@@ -327,6 +391,8 @@ function PermissionAllowDoctorPage({
       connectorRef={ref}
       permission={focusedPermission}
       action={action}
+      expirationEnabled={expirationEnabled}
+      initialExpiresIn={initialExpiresIn}
       agentDisplayName={agent.displayName ?? agentId}
       agentAvatarUrl={agent.avatarUrl}
       userName={resolveUserName(currentUser)}
@@ -339,6 +405,7 @@ export function PermissionAllowPage() {
   const ref = useGet(permissionAllowRef$);
   const permission = useGet(permissionAllowPermission$);
   const action = useGet(permissionAllowAction$);
+  const expiresIn = useGet(permissionAllowExpiresIn$);
 
   if (!agentId) {
     return <ErrorMessage message="Missing agent ID in URL parameters" />;
@@ -358,6 +425,7 @@ export function PermissionAllowPage() {
       ref={ref}
       permission={permission}
       action={action ?? "allow"}
+      initialExpiresIn={expiresIn}
     />
   );
 }

--- a/turbo/apps/platform/src/views/permission-allow/permission-allow-page.tsx
+++ b/turbo/apps/platform/src/views/permission-allow/permission-allow-page.tsx
@@ -135,12 +135,16 @@ function LoadingCard() {
 function ResultCard({
   action,
   expiresAt,
+  showExpiry,
 }: {
   action: "allow" | "deny";
   expiresAt?: string | null;
+  showExpiry: boolean;
 }) {
   const allowed = action === "allow";
-  const expiryText = permissionGrantExpiryText(expiresAt ?? null);
+  const expiryText = showExpiry
+    ? permissionGrantExpiryText(expiresAt ?? null)
+    : null;
   return (
     <div className="fixed inset-0 z-10 flex items-center justify-center pointer-events-none">
       <div className="pointer-events-auto flex w-[500px] max-w-[calc(100vw-96px)] flex-col items-center gap-10 rounded-[20px] border border-border bg-background px-[50px] py-12">
@@ -245,7 +249,11 @@ function ConfirmGrantCard({
 
   if (grantLoadable.state === "hasData") {
     return (
-      <ResultCard action={action} expiresAt={grantLoadable.data.expiresAt} />
+      <ResultCard
+        action={action}
+        expiresAt={grantLoadable.data.expiresAt}
+        showExpiry={expirationEnabled}
+      />
     );
   }
 
@@ -379,7 +387,13 @@ function PermissionAllowDoctorPage({
     );
   });
   if (effectivePolicy === action) {
-    return <ResultCard action={action} expiresAt={explicitGrant?.expiresAt} />;
+    return (
+      <ResultCard
+        action={action}
+        expiresAt={explicitGrant?.expiresAt}
+        showExpiry={expirationEnabled}
+      />
+    );
   }
 
   const currentUser =

--- a/turbo/apps/platform/src/views/team-page/zero-job-detail-page.tsx
+++ b/turbo/apps/platform/src/views/team-page/zero-job-detail-page.tsx
@@ -452,8 +452,12 @@ function selectedGrantExpiresIn(
   expirationEnabled: boolean,
   expiresInByPermission: GrantExpirationSelections,
   permission: string,
+  action: UserPermissionGrantAction,
 ): UserPermissionGrantExpiresIn | undefined {
-  return expirationEnabled ? expiresInByPermission[permission] : undefined;
+  if (!expirationEnabled || action !== "allow") {
+    return undefined;
+  }
+  return expiresInByPermission[permission];
 }
 
 function setChangedGrantPolicy(
@@ -465,7 +469,7 @@ function setChangedGrantPolicy(
   changes.set(permission, {
     permission,
     action,
-    ...(expiresIn ? { expiresIn } : {}),
+    ...(action === "allow" && expiresIn ? { expiresIn } : {}),
   });
 }
 
@@ -484,14 +488,16 @@ function addNamedPolicyChanges({
 }): void {
   for (const [permission, action] of Object.entries(current?.policies ?? {})) {
     if (initial?.policies[permission] !== action) {
+      const grantAction = userGrantAction(action);
       setChangedGrantPolicy(
         changes,
         permission,
-        userGrantAction(action),
+        grantAction,
         selectedGrantExpiresIn(
           expirationEnabled,
           expiresInByPermission,
           permission,
+          grantAction,
         ),
       );
     }
@@ -515,14 +521,16 @@ function addUnknownPolicyChange({
   if (unknownPolicy === undefined || initial?.unknownPolicy === unknownPolicy) {
     return;
   }
+  const grantAction = userGrantAction(unknownPolicy);
   setChangedGrantPolicy(
     changes,
     UNKNOWN_PERMISSION_GRANT,
-    userGrantAction(unknownPolicy),
+    grantAction,
     selectedGrantExpiresIn(
       expirationEnabled,
       expiresInByPermission,
       UNKNOWN_PERMISSION_GRANT,
+      grantAction,
     ),
   );
 }
@@ -552,9 +560,13 @@ function addExpirationOnlyChanges({
       grant.permission === UNKNOWN_PERMISSION_GRANT
         ? current?.unknownPolicy
         : current?.policies[grant.permission];
+    const action = userGrantAction(currentPolicy ?? grant.action);
+    if (grant.action !== "allow" || action !== "allow") {
+      continue;
+    }
     changes.set(grant.permission, {
       permission: grant.permission,
-      action: userGrantAction(currentPolicy ?? grant.action),
+      action,
       expiresIn,
     });
   }
@@ -644,7 +656,7 @@ async function saveUserGrantPolicies({
         connectorRef: connectorType,
         permission,
         action,
-        ...(expiresIn ? { expiresIn } : {}),
+        ...(action === "allow" && expiresIn ? { expiresIn } : {}),
       },
       pageSignal,
     );

--- a/turbo/apps/platform/src/views/team-page/zero-job-detail-page.tsx
+++ b/turbo/apps/platform/src/views/team-page/zero-job-detail-page.tsx
@@ -572,6 +572,55 @@ function addExpirationOnlyChanges({
   }
 }
 
+function addDefaultAllowExpirationChanges({
+  changes,
+  connectorType,
+  initialGrants,
+  current,
+  expiresInByPermission,
+}: {
+  changes: Map<string, ChangedUserGrantPolicy>;
+  connectorType: ConnectorType;
+  initialGrants: readonly UserPermissionGrantResponse[];
+  current: FirewallPolicies[ConnectorType] | undefined;
+  expiresInByPermission: GrantExpirationSelections;
+}): void {
+  const initialGrantPermissions = new Set(
+    initialGrants
+      .filter((grant) => {
+        return grant.connectorRef === connectorType;
+      })
+      .map((grant) => {
+        return grant.permission;
+      }),
+  );
+  for (const [permission, expiresIn] of Object.entries(expiresInByPermission)) {
+    if (
+      expiresIn === "forever" ||
+      changes.has(permission) ||
+      initialGrantPermissions.has(permission)
+    ) {
+      continue;
+    }
+    const currentPolicy =
+      permission === UNKNOWN_PERMISSION_GRANT
+        ? current?.unknownPolicy
+        : current?.policies[permission];
+    if (currentPolicy === "ask") {
+      continue;
+    }
+    const action = userGrantAction(currentPolicy ?? "allow");
+    if (action !== "allow") {
+      continue;
+    }
+    changes.set(permission, {
+      permission,
+      action,
+      expiresIn,
+    });
+  }
+}
+
 function changedUserGrantPolicies({
   connectorType,
   initialPolicies,
@@ -610,6 +659,13 @@ function changedUserGrantPolicies({
 
   if (expirationEnabled) {
     addExpirationOnlyChanges({
+      changes,
+      connectorType,
+      initialGrants,
+      current,
+      expiresInByPermission,
+    });
+    addDefaultAllowExpirationChanges({
       changes,
       connectorType,
       initialGrants,

--- a/turbo/apps/platform/src/views/team-page/zero-job-detail-page.tsx
+++ b/turbo/apps/platform/src/views/team-page/zero-job-detail-page.tsx
@@ -22,6 +22,7 @@ import {
   IconWand,
 } from "@tabler/icons-react";
 import type { ConnectorType } from "@vm0/connectors/connectors";
+import { FeatureSwitchKey } from "@vm0/connectors/feature-switch-key";
 import {
   Button,
   Tabs,
@@ -93,6 +94,8 @@ import {
   upsertUserPermissionGrant$,
   userPermissionGrantsByAgent,
 } from "../../signals/permission-allow/permission-allow-signals.ts";
+import { expiresInFromGrantExpiresAt } from "../../signals/permission-allow/permission-grant-expiration.ts";
+import { featureSwitch$ } from "../../signals/external/feature-switch.ts";
 import {
   allConnectorTypes$,
   matchesConnectorSearch,
@@ -118,7 +121,11 @@ import {
   permissionGrantsToFirewallPolicies,
   resolveFirewallPolicies,
 } from "@vm0/connectors/firewalls";
-import type { UserPermissionGrantAction } from "@vm0/api-contracts/contracts/zero-user-permission-grants";
+import type {
+  UserPermissionGrantAction,
+  UserPermissionGrantExpiresIn,
+  UserPermissionGrantResponse,
+} from "@vm0/api-contracts/contracts/zero-user-permission-grants";
 
 type UpsertUserPermissionGrant = (
   params: {
@@ -126,9 +133,10 @@ type UpsertUserPermissionGrant = (
     connectorRef: string;
     permission: string;
     action: UserPermissionGrantAction;
+    expiresIn?: UserPermissionGrantExpiresIn;
   },
   signal: AbortSignal,
-) => Promise<void>;
+) => Promise<UserPermissionGrantResponse>;
 
 // ---------------------------------------------------------------------------
 // Page shell: skeleton, error, header
@@ -431,63 +439,215 @@ function userGrantAction(
   return policy;
 }
 
+type GrantExpirationSelections = Readonly<
+  Record<string, UserPermissionGrantExpiresIn>
+>;
+
+interface ChangedUserGrantPolicy {
+  readonly permission: string;
+  readonly action: UserPermissionGrantAction;
+  readonly expiresIn?: UserPermissionGrantExpiresIn;
+}
+
+function grantExpirationChanged(
+  grant: UserPermissionGrantResponse,
+  selected: UserPermissionGrantExpiresIn | undefined,
+): boolean {
+  if (!selected) {
+    return false;
+  }
+  return expiresInFromGrantExpiresAt(grant.expiresAt) !== selected;
+}
+
+function selectedGrantExpiresIn(
+  expirationEnabled: boolean,
+  expiresInByPermission: GrantExpirationSelections,
+  permission: string,
+): UserPermissionGrantExpiresIn | undefined {
+  return expirationEnabled ? expiresInByPermission[permission] : undefined;
+}
+
+function setChangedGrantPolicy(
+  changes: Map<string, ChangedUserGrantPolicy>,
+  permission: string,
+  action: UserPermissionGrantAction,
+  expiresIn: UserPermissionGrantExpiresIn | undefined,
+): void {
+  changes.set(permission, {
+    permission,
+    action,
+    ...(expiresIn ? { expiresIn } : {}),
+  });
+}
+
+function addNamedPolicyChanges({
+  changes,
+  initial,
+  current,
+  expirationEnabled,
+  expiresInByPermission,
+}: {
+  changes: Map<string, ChangedUserGrantPolicy>;
+  initial: FirewallPolicies[ConnectorType] | undefined;
+  current: FirewallPolicies[ConnectorType] | undefined;
+  expirationEnabled: boolean;
+  expiresInByPermission: GrantExpirationSelections;
+}): void {
+  for (const [permission, action] of Object.entries(current?.policies ?? {})) {
+    if (initial?.policies[permission] !== action) {
+      setChangedGrantPolicy(
+        changes,
+        permission,
+        userGrantAction(action),
+        selectedGrantExpiresIn(
+          expirationEnabled,
+          expiresInByPermission,
+          permission,
+        ),
+      );
+    }
+  }
+}
+
+function addUnknownPolicyChange({
+  changes,
+  initial,
+  current,
+  expirationEnabled,
+  expiresInByPermission,
+}: {
+  changes: Map<string, ChangedUserGrantPolicy>;
+  initial: FirewallPolicies[ConnectorType] | undefined;
+  current: FirewallPolicies[ConnectorType] | undefined;
+  expirationEnabled: boolean;
+  expiresInByPermission: GrantExpirationSelections;
+}): void {
+  const unknownPolicy = current?.unknownPolicy;
+  if (unknownPolicy === undefined || initial?.unknownPolicy === unknownPolicy) {
+    return;
+  }
+  setChangedGrantPolicy(
+    changes,
+    UNKNOWN_PERMISSION_GRANT,
+    userGrantAction(unknownPolicy),
+    selectedGrantExpiresIn(
+      expirationEnabled,
+      expiresInByPermission,
+      UNKNOWN_PERMISSION_GRANT,
+    ),
+  );
+}
+
+function addExpirationOnlyChanges({
+  changes,
+  connectorType,
+  initialGrants,
+  current,
+  expiresInByPermission,
+}: {
+  changes: Map<string, ChangedUserGrantPolicy>;
+  connectorType: ConnectorType;
+  initialGrants: readonly UserPermissionGrantResponse[];
+  current: FirewallPolicies[ConnectorType] | undefined;
+  expiresInByPermission: GrantExpirationSelections;
+}): void {
+  for (const grant of initialGrants) {
+    if (grant.connectorRef !== connectorType || changes.has(grant.permission)) {
+      continue;
+    }
+    const expiresIn = expiresInByPermission[grant.permission];
+    if (!expiresIn || !grantExpirationChanged(grant, expiresIn)) {
+      continue;
+    }
+    const currentPolicy =
+      grant.permission === UNKNOWN_PERMISSION_GRANT
+        ? current?.unknownPolicy
+        : current?.policies[grant.permission];
+    changes.set(grant.permission, {
+      permission: grant.permission,
+      action: userGrantAction(currentPolicy ?? grant.action),
+      expiresIn,
+    });
+  }
+}
+
 function changedUserGrantPolicies({
   connectorType,
   initialPolicies,
+  initialGrants,
   policies,
+  expirationEnabled,
+  expiresInByPermission,
 }: {
   connectorType: ConnectorType;
   initialPolicies: FirewallPolicies;
+  initialGrants: readonly UserPermissionGrantResponse[];
   policies: FirewallPolicies;
-}): {
-  readonly permission: string;
-  readonly action: UserPermissionGrantAction;
-}[] {
+  expirationEnabled: boolean;
+  expiresInByPermission: GrantExpirationSelections;
+}): ChangedUserGrantPolicy[] {
   const initial = resolveFirewallPolicies(initialPolicies, [connectorType])?.[
     connectorType
   ];
   const current = policies[connectorType];
-  const changes: {
-    permission: string;
-    action: UserPermissionGrantAction;
-  }[] = [];
+  const changes = new Map<string, ChangedUserGrantPolicy>();
 
-  for (const [permission, action] of Object.entries(current?.policies ?? {})) {
-    if (initial?.policies[permission] !== action) {
-      changes.push({ permission, action: userGrantAction(action) });
-    }
-  }
+  addNamedPolicyChanges({
+    changes,
+    initial,
+    current,
+    expirationEnabled,
+    expiresInByPermission,
+  });
+  addUnknownPolicyChange({
+    changes,
+    initial,
+    current,
+    expirationEnabled,
+    expiresInByPermission,
+  });
 
-  const unknownPolicy = current?.unknownPolicy;
-  if (unknownPolicy !== undefined && initial?.unknownPolicy !== unknownPolicy) {
-    changes.push({
-      permission: UNKNOWN_PERMISSION_GRANT,
-      action: userGrantAction(unknownPolicy),
+  if (expirationEnabled) {
+    addExpirationOnlyChanges({
+      changes,
+      connectorType,
+      initialGrants,
+      current,
+      expiresInByPermission,
     });
   }
 
-  return changes;
+  return [...changes.values()];
 }
 
 async function saveUserGrantPolicies({
   agentId,
   connectorType,
   initialPolicies,
+  initialGrants,
   policies,
+  expirationEnabled,
+  expiresInByPermission,
   pageSignal,
   upsertGrant,
 }: {
   agentId: string;
   connectorType: ConnectorType;
   initialPolicies: FirewallPolicies;
+  initialGrants: readonly UserPermissionGrantResponse[];
   policies: FirewallPolicies;
+  expirationEnabled: boolean;
+  expiresInByPermission: GrantExpirationSelections;
   pageSignal: AbortSignal;
   upsertGrant: UpsertUserPermissionGrant;
 }): Promise<void> {
-  for (const { permission, action } of changedUserGrantPolicies({
+  for (const { permission, action, expiresIn } of changedUserGrantPolicies({
     connectorType,
     initialPolicies,
+    initialGrants,
     policies,
+    expirationEnabled,
+    expiresInByPermission,
   })) {
     await upsertGrant(
       {
@@ -495,6 +655,7 @@ async function saveUserGrantPolicies({
         connectorRef: connectorType,
         permission,
         action,
+        ...(expiresIn ? { expiresIn } : {}),
       },
       pageSignal,
     );
@@ -505,14 +666,20 @@ async function saveDrawerPolicies({
   agentId,
   connectorType,
   initialPolicies,
+  initialGrants,
   policies,
+  expirationEnabled,
+  expiresInByPermission,
   pageSignal,
   upsertGrant,
 }: {
   agentId: string;
   connectorType: ConnectorType;
   initialPolicies: FirewallPolicies;
+  initialGrants: readonly UserPermissionGrantResponse[];
   policies: FirewallPolicies;
+  expirationEnabled: boolean;
+  expiresInByPermission: GrantExpirationSelections;
   pageSignal: AbortSignal;
   upsertGrant: UpsertUserPermissionGrant;
 }): Promise<void> {
@@ -520,7 +687,10 @@ async function saveDrawerPolicies({
     agentId,
     connectorType,
     initialPolicies,
+    initialGrants,
     policies,
+    expirationEnabled,
+    expiresInByPermission,
     pageSignal,
     upsertGrant,
   });
@@ -714,6 +884,8 @@ function AgentPermissionsDrawer({
   connectorType,
   displayName,
   initialPolicies,
+  initialGrants,
+  expirationEnabled,
   readOnly,
   onApply,
   onClose,
@@ -722,8 +894,13 @@ function AgentPermissionsDrawer({
   connectorType: ConnectorType | null;
   displayName: string;
   initialPolicies: FirewallPolicies;
+  initialGrants: readonly UserPermissionGrantResponse[];
+  expirationEnabled: boolean;
   readOnly: boolean;
-  onApply: (policies: FirewallPolicies) => Promise<void>;
+  onApply: (
+    policies: FirewallPolicies,
+    expiresInByPermission: GrantExpirationSelections,
+  ) => Promise<void>;
   onClose: () => void;
 }) {
   if (!connectorType) {
@@ -735,6 +912,8 @@ function AgentPermissionsDrawer({
       connectorType={connectorType}
       displayName={displayName}
       initialPolicies={initialPolicies}
+      initialGrants={initialGrants}
+      expirationEnabled={expirationEnabled}
       readOnly={readOnly}
       onApply={onApply}
       onClose={onClose}
@@ -769,11 +948,16 @@ function JobPermissionsTab({
       agentId,
     }),
   );
+  const userGrants =
+    userGrantsLoadable.state === "hasData" ? userGrantsLoadable.data : [];
   const userGrantPolicies =
     userGrantsLoadable.state === "hasData"
-      ? permissionGrantsToFirewallPolicies(userGrantsLoadable.data)
+      ? permissionGrantsToFirewallPolicies(userGrants)
       : null;
   const drawerInitialPolicies = userGrantPolicies ?? {};
+  const features = useLastResolved(featureSwitch$);
+  const expirationEnabled =
+    features?.[FeatureSwitchKey.ExpiringPermissionGrants] ?? false;
   const [, upsertGrant] = useLoadableSet(upsertUserPermissionGrant$);
   const connectorType = useGet(permConnectorType$);
   const setConnectorType = useSet(setPermConnectorType$);
@@ -852,8 +1036,10 @@ function JobPermissionsTab({
             connectorType={connectorType}
             displayName={displayName}
             initialPolicies={drawerInitialPolicies}
+            initialGrants={userGrants}
+            expirationEnabled={expirationEnabled}
             readOnly={!canManagePermissions}
-            onApply={async (policies) => {
+            onApply={async (policies, expiresInByPermission) => {
               if (connectorType === null) {
                 throw new Error("Cannot save permissions without a connector");
               }
@@ -861,7 +1047,10 @@ function JobPermissionsTab({
                 agentId,
                 connectorType,
                 initialPolicies: drawerInitialPolicies,
+                initialGrants: userGrants,
                 policies,
+                expirationEnabled,
+                expiresInByPermission,
                 pageSignal,
                 upsertGrant,
               });

--- a/turbo/apps/platform/src/views/team-page/zero-job-detail-page.tsx
+++ b/turbo/apps/platform/src/views/team-page/zero-job-detail-page.tsx
@@ -94,7 +94,6 @@ import {
   upsertUserPermissionGrant$,
   userPermissionGrantsByAgent,
 } from "../../signals/permission-allow/permission-allow-signals.ts";
-import { expiresInFromGrantExpiresAt } from "../../signals/permission-allow/permission-grant-expiration.ts";
 import { featureSwitch$ } from "../../signals/external/feature-switch.ts";
 import {
   allConnectorTypes$,
@@ -449,16 +448,6 @@ interface ChangedUserGrantPolicy {
   readonly expiresIn?: UserPermissionGrantExpiresIn;
 }
 
-function grantExpirationChanged(
-  grant: UserPermissionGrantResponse,
-  selected: UserPermissionGrantExpiresIn | undefined,
-): boolean {
-  if (!selected) {
-    return false;
-  }
-  return expiresInFromGrantExpiresAt(grant.expiresAt) !== selected;
-}
-
 function selectedGrantExpiresIn(
   expirationEnabled: boolean,
   expiresInByPermission: GrantExpirationSelections,
@@ -556,7 +545,7 @@ function addExpirationOnlyChanges({
       continue;
     }
     const expiresIn = expiresInByPermission[grant.permission];
-    if (!expiresIn || !grantExpirationChanged(grant, expiresIn)) {
+    if (!expiresIn) {
       continue;
     }
     const currentPolicy =

--- a/turbo/apps/platform/src/views/team-page/zero-job-detail-page.tsx
+++ b/turbo/apps/platform/src/views/team-page/zero-job-detail-page.tsx
@@ -596,7 +596,7 @@ function addDefaultAllowExpirationChanges({
   );
   for (const [permission, expiresIn] of Object.entries(expiresInByPermission)) {
     if (
-      expiresIn === "forever" ||
+      expiresIn === "always" ||
       changes.has(permission) ||
       initialGrantPermissions.has(permission)
     ) {

--- a/turbo/apps/platform/src/views/zero-page/__tests__/zero-chat-thread-page-display.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/zero-chat-thread-page-display.test.tsx
@@ -21,7 +21,10 @@ import {
 import { zeroSchedulesMainContract } from "@vm0/api-contracts/contracts/zero-schedules";
 import { FeatureSwitchKey } from "@vm0/connectors/feature-switch-key";
 import { zeroAgentsByIdContract } from "@vm0/api-contracts/contracts/zero-agents";
-import { zeroUserPermissionGrantsContract } from "@vm0/api-contracts/contracts/zero-user-permission-grants";
+import {
+  type UserPermissionGrantExpiresIn,
+  zeroUserPermissionGrantsContract,
+} from "@vm0/api-contracts/contracts/zero-user-permission-grants";
 import { zeroConnectorOauthStartContract } from "@vm0/api-contracts/contracts/zero-connectors";
 import { zeroUserConnectorsContract } from "@vm0/api-contracts/contracts/user-connectors";
 import { setMockConnectors } from "../../../mocks/handlers/api-connectors.ts";
@@ -252,12 +255,14 @@ describe("zero chat thread page display - permission action card", () => {
   function mockPermissionMessage(
     permission = "channels:write",
     action: "allow" | "deny" = "allow",
+    expiresIn?: UserPermissionGrantExpiresIn,
   ) {
+    const expiresInQuery = expiresIn ? `&expiresIn=${expiresIn}` : "";
     mockChatLifecycle({
       chatMessages: [
         {
           role: "assistant",
-          content: `https://app.vm0.ai/agents/4f189ea8-ada2-416d-83a9-9c25ddb960c9/permissions?ref=slack&permission=${encodeURIComponent(permission)}&action=${action}`,
+          content: `https://app.vm0.ai/agents/4f189ea8-ada2-416d-83a9-9c25ddb960c9/permissions?ref=slack&permission=${encodeURIComponent(permission)}&action=${action}${expiresInQuery}`,
           runId: "run-user-grant-permission-action",
           status: "completed",
           createdAt: "2026-03-10T00:00:00Z",
@@ -406,6 +411,49 @@ describe("zero chat thread page display - permission action card", () => {
         return element.textContent?.trim() === "Confirm";
       }),
     ).toBeUndefined();
+  });
+
+  it("confirms requested expiration changes for already-applied permission actions", async () => {
+    let grantBody: unknown;
+    mockPermissionAgent();
+    mockPermissionMessage("channels:write", "allow", "24h");
+    setMockUserPermissionGrants([
+      createMockUserPermissionGrantResponse({
+        agentId: "4f189ea8-ada2-416d-83a9-9c25ddb960c9",
+        connectorRef: "slack",
+        permission: "channels:write",
+        action: "allow",
+      }),
+    ]);
+    server.use(
+      mockApi(zeroUserPermissionGrantsContract.upsert, ({ body, respond }) => {
+        grantBody = body;
+        return respond(200, createMockUserPermissionGrantResponse(body));
+      }),
+    );
+
+    detachedSetupPage({
+      context,
+      path: "/chats/thread-test-1",
+      featureSwitches: { [FeatureSwitchKey.ExpiringPermissionGrants]: true },
+    });
+
+    const card = await waitFor(() => {
+      return screen.getByTestId("permission-action-card");
+    });
+    expect(
+      within(card).getByRole("combobox", { name: "Permission duration" }),
+    ).toHaveTextContent("24 hours");
+
+    click(await within(card).findByText("Confirm"));
+
+    await waitFor(() => {
+      expect(grantBody).toMatchObject({
+        permission: "channels:write",
+        action: "allow",
+        expiresIn: "24h",
+      });
+    });
   });
 
   it("shows existing expiration for already-applied permission actions", async () => {

--- a/turbo/apps/platform/src/views/zero-page/__tests__/zero-chat-thread-page-display.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/zero-chat-thread-page-display.test.tsx
@@ -408,6 +408,35 @@ describe("zero chat thread page display - permission action card", () => {
     ).toBeUndefined();
   });
 
+  it("shows existing expiration for already-applied permission actions", async () => {
+    mockPermissionAgent();
+    mockPermissionMessage();
+    setMockUserPermissionGrants([
+      createMockUserPermissionGrantResponse({
+        agentId: "4f189ea8-ada2-416d-83a9-9c25ddb960c9",
+        connectorRef: "slack",
+        permission: "channels:write",
+        action: "allow",
+        expiresAt: new Date(Date.now() + 2 * 60 * 60 * 1000).toISOString(),
+      }),
+    ]);
+
+    detachedSetupPage({
+      context,
+      path: "/chats/thread-test-1",
+      featureSwitches: { [FeatureSwitchKey.ExpiringPermissionGrants]: true },
+    });
+
+    const card = await waitFor(() => {
+      return screen.getByTestId("permission-action-card");
+    });
+    expect(within(card).getByText("Permissions updated")).toBeInTheDocument();
+    expect(within(card).getByText("Expires in 2 hours")).toBeInTheDocument();
+    expect(
+      within(card).queryByRole("combobox", { name: "Permission duration" }),
+    ).not.toBeInTheDocument();
+  });
+
   it("does not write grants for unknown permission actions", async () => {
     let grantWritten = false;
     mockPermissionAgent();

--- a/turbo/apps/platform/src/views/zero-page/__tests__/zero-chat-thread-page-display.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/zero-chat-thread-page-display.test.tsx
@@ -456,6 +456,39 @@ describe("zero chat thread page display - permission action card", () => {
     });
   });
 
+  it("treats requested always as already applied for permanent allow permission actions", async () => {
+    mockPermissionAgent();
+    mockPermissionMessage("channels:write", "allow", "always");
+    setMockUserPermissionGrants([
+      createMockUserPermissionGrantResponse({
+        agentId: "4f189ea8-ada2-416d-83a9-9c25ddb960c9",
+        connectorRef: "slack",
+        permission: "channels:write",
+        action: "allow",
+        expiresAt: null,
+      }),
+    ]);
+
+    detachedSetupPage({
+      context,
+      path: "/chats/thread-test-1",
+      featureSwitches: { [FeatureSwitchKey.ExpiringPermissionGrants]: true },
+    });
+
+    const card = await waitFor(() => {
+      return screen.getByTestId("permission-action-card");
+    });
+    expect(within(card).getByText("Permissions updated")).toBeInTheDocument();
+    expect(
+      within(card).queryByRole("combobox", { name: "Permission duration" }),
+    ).not.toBeInTheDocument();
+    expect(
+      queryAllByRoleFast("button", card).find((element) => {
+        return element.textContent?.trim() === "Confirm";
+      }),
+    ).toBeUndefined();
+  });
+
   it("shows existing expiration for already-applied permission actions", async () => {
     mockPermissionAgent();
     mockPermissionMessage();

--- a/turbo/apps/platform/src/views/zero-page/__tests__/zero-chat-thread-page-display.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/zero-chat-thread-page-display.test.tsx
@@ -249,12 +249,15 @@ describe("zero chat thread page display - permission action card", () => {
     );
   }
 
-  function mockPermissionMessage(permission = "channels:write") {
+  function mockPermissionMessage(
+    permission = "channels:write",
+    action: "allow" | "deny" = "allow",
+  ) {
     mockChatLifecycle({
       chatMessages: [
         {
           role: "assistant",
-          content: `https://app.vm0.ai/agents/4f189ea8-ada2-416d-83a9-9c25ddb960c9/permissions?ref=slack&permission=${encodeURIComponent(permission)}&action=allow`,
+          content: `https://app.vm0.ai/agents/4f189ea8-ada2-416d-83a9-9c25ddb960c9/permissions?ref=slack&permission=${encodeURIComponent(permission)}&action=${action}`,
           runId: "run-user-grant-permission-action",
           status: "completed",
           createdAt: "2026-03-10T00:00:00Z",
@@ -340,6 +343,41 @@ describe("zero chat thread page display - permission action card", () => {
         expiresIn: "1h",
       });
     });
+  });
+
+  it("does not show or submit duration for deny permission action cards", async () => {
+    let grantBody: unknown;
+    mockPermissionAgent();
+    mockPermissionMessage("channels:read", "deny");
+    setMockUserPermissionGrants([]);
+    server.use(
+      mockApi(zeroUserPermissionGrantsContract.upsert, ({ body, respond }) => {
+        grantBody = body;
+        return respond(200, createMockUserPermissionGrantResponse(body));
+      }),
+    );
+
+    detachedSetupPage({
+      context,
+      path: "/chats/thread-test-1",
+      featureSwitches: { [FeatureSwitchKey.ExpiringPermissionGrants]: true },
+    });
+
+    const card = await waitFor(() => {
+      return screen.getByTestId("permission-action-card");
+    });
+    expect(
+      within(card).queryByRole("combobox", { name: "Permission duration" }),
+    ).not.toBeInTheDocument();
+    click(await within(card).findByText("Confirm"));
+
+    await waitFor(() => {
+      expect(grantBody).toMatchObject({
+        permission: "channels:read",
+        action: "deny",
+      });
+    });
+    expect(grantBody).not.toMatchObject({ expiresIn: expect.any(String) });
   });
 
   it("uses current-user grants for already-applied permission actions", async () => {

--- a/turbo/apps/platform/src/views/zero-page/__tests__/zero-chat-thread-page-display.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/zero-chat-thread-page-display.test.tsx
@@ -301,9 +301,45 @@ describe("zero chat thread page display - permission action card", () => {
         action: "allow",
       });
     });
+    expect(grantBody).not.toMatchObject({ expiresIn: expect.any(String) });
     const status = within(card).getByText("Permissions updated");
     expect(status).toBeInTheDocument();
     expect(status.closest("button")).toBeNull();
+  });
+
+  it("submits the default duration from permission action cards when enabled", async () => {
+    let grantBody: unknown;
+    mockPermissionAgent();
+    mockPermissionMessage();
+    setMockUserPermissionGrants([]);
+    server.use(
+      mockApi(zeroUserPermissionGrantsContract.upsert, ({ body, respond }) => {
+        grantBody = body;
+        return respond(200, createMockUserPermissionGrantResponse(body));
+      }),
+    );
+
+    detachedSetupPage({
+      context,
+      path: "/chats/thread-test-1",
+      featureSwitches: { [FeatureSwitchKey.ExpiringPermissionGrants]: true },
+    });
+
+    const card = await waitFor(() => {
+      return screen.getByTestId("permission-action-card");
+    });
+    expect(
+      within(card).getByRole("combobox", { name: "Permission duration" }),
+    ).toHaveTextContent("1 hour");
+    click(await within(card).findByText("Confirm"));
+
+    await waitFor(() => {
+      expect(grantBody).toMatchObject({
+        permission: "channels:write",
+        action: "allow",
+        expiresIn: "1h",
+      });
+    });
   });
 
   it("uses current-user grants for already-applied permission actions", async () => {

--- a/turbo/apps/platform/src/views/zero-page/components/settings/permissions-dialog.tsx
+++ b/turbo/apps/platform/src/views/zero-page/components/settings/permissions-dialog.tsx
@@ -463,8 +463,7 @@ function PermissionExpirationControl({
   }
 
   const showSetting = !readOnly;
-  const showKeepCurrent = allowGrant !== undefined;
-  const settingValue = selected ?? (showKeepCurrent ? null : "forever");
+  const settingValue = selected ?? null;
 
   return (
     <div className="flex shrink-0 flex-col items-end gap-1.5">
@@ -472,7 +471,7 @@ function PermissionExpirationControl({
       {showSetting && (
         <PermissionGrantDurationSelect
           value={settingValue}
-          showKeepCurrent={showKeepCurrent}
+          showKeepCurrent
           onClear={() => {
             onChange(permission, null);
           }}

--- a/turbo/apps/platform/src/views/zero-page/components/settings/permissions-dialog.tsx
+++ b/turbo/apps/platform/src/views/zero-page/components/settings/permissions-dialog.tsx
@@ -12,6 +12,11 @@ import {
   SheetFooter,
   Button,
   cn,
+  DropdownMenu,
+  DropdownMenuTrigger,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuSeparator,
 } from "@vm0/ui";
 import {
   CONNECTOR_TYPES,
@@ -34,7 +39,6 @@ import type {
   UserPermissionGrantResponse,
 } from "@vm0/api-contracts/contracts/zero-user-permission-grants";
 import { ConnectorIcon } from "./connector-icons.tsx";
-import { PermissionGrantDurationSelect } from "../../../components/permission-grant-duration-select.tsx";
 import { permissionGrantExpiryText } from "../../../../signals/permission-allow/permission-grant-expiration.ts";
 import type { PermissionPolicy } from "../../../../signals/zero-page/settings/permissions.ts";
 import {
@@ -60,6 +64,7 @@ import {
   IconBan,
   IconChevronRight,
   IconClock,
+  IconChevronDown,
 } from "@tabler/icons-react";
 import { detach, Reason } from "../../../../signals/utils.ts";
 import { pageSignal$ } from "../../../../signals/page-signal.ts";
@@ -160,7 +165,7 @@ function PolicyPill({
   onChange,
   disabled,
 }: {
-  policy: PermissionPolicy | "mixed";
+  policy: FirewallPolicyValue | "mixed";
   onChange?: (p: PermissionPolicy) => void;
   disabled?: boolean;
 }) {
@@ -387,15 +392,9 @@ function canApplyPermissionPolicies({
 }
 
 function UnknownEndpointsToggle({
-  policy,
-  disabled,
-  expirationControl,
-  onChange,
+  policyControl,
 }: {
-  policy: PermissionPolicy | "mixed";
-  disabled?: boolean;
-  expirationControl?: ReactNode;
-  onChange: (p: PermissionPolicy) => void;
+  policyControl: ReactNode;
 }) {
   return (
     <div className="border-t border-border/40 -mx-6 px-3 pt-3 pb-1">
@@ -408,10 +407,7 @@ function UnknownEndpointsToggle({
             API endpoints not matched by any permission above
           </p>
         </div>
-        <div className="flex shrink-0 items-center gap-2">
-          {expirationControl}
-          <PolicyPill policy={policy} disabled={disabled} onChange={onChange} />
-        </div>
+        <div className="flex shrink-0 items-center gap-2">{policyControl}</div>
       </div>
     </div>
   );
@@ -435,18 +431,67 @@ function GrantExpirationStatus({ expiresAt }: { expiresAt: string | null }) {
   );
 }
 
-function PermissionExpirationControl({
+const ALLOW_DURATION_MENU_OPTIONS: readonly {
+  readonly value: UserPermissionGrantExpiresIn;
+  readonly label: string;
+  readonly buttonLabel: string;
+}[] = [
+  { value: "1h", label: "Allow for 1h", buttonLabel: "1h" },
+  { value: "24h", label: "Allow for 24h", buttonLabel: "24h" },
+  { value: "7d", label: "Allow for 7d", buttonLabel: "7d" },
+  { value: "forever", label: "Allow always", buttonLabel: "Always" },
+];
+
+function allowButtonLabel(
+  selected: UserPermissionGrantExpiresIn | undefined,
+): string {
+  const option = ALLOW_DURATION_MENU_OPTIONS.find((item) => {
+    return item.value === selected;
+  });
+  return option ? `Allow · ${option.buttonLabel}` : "Allow";
+}
+
+function permissionPolicyButtonClass({
+  active,
+  disabled,
+  tone,
+}: {
+  active: boolean;
+  disabled?: boolean;
+  tone: "allow" | "deny";
+}): string {
+  return `flex h-7 items-center gap-1 px-2.5 text-xs font-medium transition-colors ${
+    active
+      ? tone === "allow"
+        ? "bg-emerald-500/10 text-emerald-700 dark:text-emerald-400"
+        : "bg-rose-500/10 text-rose-700 dark:text-rose-400"
+      : disabled
+        ? "text-muted-foreground/50"
+        : "text-muted-foreground hover:text-foreground hover:bg-muted/50"
+  } ${disabled ? "cursor-default" : "cursor-pointer"}`;
+}
+
+function MenuItemCheck({ active }: { active: boolean }) {
+  return active ? (
+    <IconCheck size={14} stroke={2.5} />
+  ) : (
+    <span className="h-3.5 w-3.5 shrink-0" />
+  );
+}
+
+function PermissionGrantPolicyControl({
   permission,
-  action,
+  policy,
   grant,
   selected,
   expirationEnabled,
   readOnly,
   saving,
   onChange,
+  onPolicyChange,
 }: {
   permission: string;
-  action: FirewallPolicyValue;
+  policy: FirewallPolicyValue;
   grant: UserPermissionGrantResponse | undefined;
   selected: UserPermissionGrantExpiresIn | undefined;
   expirationEnabled: boolean;
@@ -456,32 +501,118 @@ function PermissionExpirationControl({
     permission: string,
     expiresIn: UserPermissionGrantExpiresIn | null,
   ) => void;
+  onPolicyChange: (policy: PermissionPolicy) => void;
 }) {
   const allowGrant = grant?.action === "allow" ? grant : undefined;
-  if (!expirationEnabled || action !== "allow") {
-    return null;
-  }
-
-  const showSetting = !readOnly;
-  const settingValue = selected ?? null;
+  const showExpirationStatus = expirationEnabled && policy === "allow";
+  const showSplitPolicy = expirationEnabled && !readOnly;
 
   return (
-    <div className="flex shrink-0 flex-col items-end gap-1.5">
-      <GrantExpirationStatus expiresAt={allowGrant?.expiresAt ?? null} />
-      {showSetting && (
-        <PermissionGrantDurationSelect
-          value={settingValue}
-          showKeepCurrent
-          onClear={() => {
-            onChange(permission, null);
+    <div className="flex shrink-0 items-center gap-2">
+      {showExpirationStatus && (
+        <GrantExpirationStatus expiresAt={allowGrant?.expiresAt ?? null} />
+      )}
+      {!showSplitPolicy ? (
+        <PolicyPill
+          policy={policy}
+          disabled={readOnly}
+          onChange={(nextPolicy) => {
+            onPolicyChange(nextPolicy);
           }}
-          onValueChange={(value) => {
-            onChange(permission, value);
-          }}
-          disabled={saving}
-          ariaLabel={`${permission} grant duration`}
-          className="h-7 w-[132px] rounded-md text-[11px]"
         />
+      ) : (
+        <span className="inline-flex shrink-0 overflow-hidden rounded-md text-xs font-medium zero-border">
+          <button
+            type="button"
+            disabled={saving}
+            aria-pressed={policy === "allow"}
+            onClick={() => {
+              onPolicyChange("allow");
+            }}
+            className={permissionPolicyButtonClass({
+              active: policy === "allow",
+              disabled: saving,
+              tone: "allow",
+            })}
+          >
+            <IconCheck size={12} stroke={2.5} />
+            {allowButtonLabel(selected)}
+          </button>
+          <DropdownMenu>
+            <DropdownMenuTrigger asChild>
+              <button
+                type="button"
+                disabled={saving}
+                aria-label={`${permission} allow options`}
+                className={`flex h-7 items-center border-l border-[hsl(var(--gray-400))] px-1.5 transition-colors ${
+                  policy === "allow"
+                    ? "bg-emerald-500/10 text-emerald-700 dark:text-emerald-400"
+                    : saving
+                      ? "text-muted-foreground/50"
+                      : "text-muted-foreground hover:text-foreground hover:bg-muted/50"
+                } ${saving ? "cursor-default" : "cursor-pointer"}`}
+              >
+                <IconChevronDown size={13} stroke={2.5} />
+              </button>
+            </DropdownMenuTrigger>
+            <DropdownMenuContent align="end" className="w-40">
+              {policy === "allow" ? (
+                <DropdownMenuItem
+                  onSelect={() => {
+                    onPolicyChange("allow");
+                    onChange(permission, null);
+                  }}
+                >
+                  <MenuItemCheck active={selected === undefined} />
+                  Keep current
+                </DropdownMenuItem>
+              ) : (
+                <DropdownMenuItem
+                  onSelect={() => {
+                    onPolicyChange("allow");
+                    onChange(permission, null);
+                  }}
+                >
+                  <MenuItemCheck active={false} />
+                  Allow
+                </DropdownMenuItem>
+              )}
+              <DropdownMenuSeparator />
+              {ALLOW_DURATION_MENU_OPTIONS.map((option) => {
+                return (
+                  <DropdownMenuItem
+                    key={option.value}
+                    onSelect={() => {
+                      onPolicyChange("allow");
+                      onChange(permission, option.value);
+                    }}
+                  >
+                    <MenuItemCheck active={selected === option.value} />
+                    {option.label}
+                  </DropdownMenuItem>
+                );
+              })}
+            </DropdownMenuContent>
+          </DropdownMenu>
+          <button
+            type="button"
+            disabled={saving}
+            aria-pressed={policy === "deny"}
+            style={{ borderLeft: "0.7px solid hsl(var(--gray-400))" }}
+            onClick={() => {
+              onPolicyChange("deny");
+              onChange(permission, null);
+            }}
+            className={permissionPolicyButtonClass({
+              active: policy === "deny",
+              disabled: saving,
+              tone: "deny",
+            })}
+          >
+            <IconBan size={12} stroke={2.5} />
+            Deny
+          </button>
+        </span>
       )}
     </div>
   );
@@ -642,20 +773,16 @@ function PermissionRow({
             </p>
           )}
         </div>
-        <PermissionExpirationControl
+        <PermissionGrantPolicyControl
           permission={permission.name}
-          action={policy}
+          policy={policy}
           grant={explicitGrants.get(permission.name)}
           selected={expirationSelections[permission.name]}
           expirationEnabled={expirationEnabled}
           readOnly={readOnly}
           saving={saving}
           onChange={onGrantExpirationChange}
-        />
-        <PolicyPill
-          policy={policy}
-          disabled={readOnly}
-          onChange={(p) => {
+          onPolicyChange={(p) => {
             onPolicyChange(permission.name, p);
           }}
         />
@@ -858,23 +985,21 @@ export function PermissionsDrawer({
             </div>
 
             <UnknownEndpointsToggle
-              policy={unknownPolicy}
-              disabled={readOnly}
-              expirationControl={
-                <PermissionExpirationControl
+              policyControl={
+                <PermissionGrantPolicyControl
                   permission={UNKNOWN_PERMISSION_GRANT}
-                  action={unknownPolicy}
+                  policy={unknownPolicy}
                   grant={explicitGrants.get(UNKNOWN_PERMISSION_GRANT)}
                   selected={expirationSelections[UNKNOWN_PERMISSION_GRANT]}
                   expirationEnabled={expirationEnabled}
                   readOnly={readOnly}
                   saving={saving}
                   onChange={setGrantExpiration}
+                  onPolicyChange={(p) => {
+                    setUnknownPolicy(p);
+                  }}
                 />
               }
-              onChange={(p) => {
-                setUnknownPolicy(p);
-              }}
             />
           </div>
         )}

--- a/turbo/apps/platform/src/views/zero-page/components/settings/permissions-dialog.tsx
+++ b/turbo/apps/platform/src/views/zero-page/components/settings/permissions-dialog.tsx
@@ -1,5 +1,6 @@
 // TODO(#8609): split large components to comply with max-lines-per-function (128)
 // oxlint-disable max-lines-per-function
+import type { ReactNode } from "react";
 import { useGet, useSet } from "ccstate-react";
 import { useLoadableSet } from "ccstate-react/experimental";
 import {
@@ -21,12 +22,22 @@ import {
   isFirewallConnectorType,
   resolveFirewallPolicies,
 } from "@vm0/connectors/firewalls";
-import type {
-  FirewallConfig,
-  FirewallPolicies,
-  FirewallPolicyValue,
+import {
+  UNKNOWN_PERMISSION_GRANT,
+  type FirewallConfig,
+  type FirewallPolicies,
+  type FirewallPolicyValue,
 } from "@vm0/connectors/firewall-types";
+import type {
+  UserPermissionGrantExpiresIn,
+  UserPermissionGrantResponse,
+} from "@vm0/api-contracts/contracts/zero-user-permission-grants";
 import { ConnectorIcon } from "./connector-icons.tsx";
+import { PermissionGrantDurationSelect } from "../../../components/permission-grant-duration-select.tsx";
+import {
+  expiresInFromGrantExpiresAt,
+  permissionGrantExpiryText,
+} from "../../../../signals/permission-allow/permission-grant-expiration.ts";
 import type { PermissionPolicy } from "../../../../signals/zero-page/settings/permissions.ts";
 import {
   permissionAllPolicies$,
@@ -41,6 +52,10 @@ import {
   applyPermissionPolicies$,
   permissionUnknownPolicy$,
   setPermissionUnknownPolicy$,
+  permissionGrantExpirations$,
+  setPermissionGrantExpiration$,
+  initPermissionGrantExpirations$,
+  resetPermissionGrantExpirations$,
 } from "../../../../signals/zero-page/settings/permissions-dialog.ts";
 import { IconCheck, IconBan, IconChevronRight } from "@tabler/icons-react";
 import { detach, Reason } from "../../../../signals/utils.ts";
@@ -56,8 +71,15 @@ interface PermissionsDrawerProps {
   connectorType: ConnectorType;
   displayName: string;
   initialPolicies: FirewallPolicies;
+  initialGrants: readonly UserPermissionGrantResponse[];
+  expirationEnabled: boolean;
   readOnly?: boolean;
-  onApply: (policies: FirewallPolicies) => Promise<void>;
+  onApply: (
+    policies: FirewallPolicies,
+    expiresInByPermission: Readonly<
+      Record<string, UserPermissionGrantExpiresIn>
+    >,
+  ) => Promise<void>;
   onClose: () => void;
 }
 
@@ -194,6 +216,27 @@ function buildSortedGroups(
   );
 }
 
+function permissionDrawerConfig(ref: ConnectorType): FirewallConfig | null {
+  return isFirewallConnectorType(ref) ? getConnectorFirewall(ref) : null;
+}
+
+function sortedPermissionsForConfig(
+  config: FirewallConfig | null,
+): ConnectorPermission[] {
+  return config ? sortPermissions(extractPermissions(config)) : [];
+}
+
+function permissionPolicyRecord(
+  permissions: readonly ConnectorPermission[],
+  policy: PermissionPolicy,
+): Record<string, PermissionPolicy> {
+  const next: Record<string, PermissionPolicy> = {};
+  for (const permission of permissions) {
+    next[permission.name] = policy;
+  }
+  return next;
+}
+
 function buildInitialPolicies(
   ref: string,
   config: FirewallConfig | null,
@@ -210,6 +253,52 @@ function buildInitialPolicies(
     refPolicies[p.name] = resolved?.[ref]?.policies[p.name] ?? "allow";
   }
   result[ref] = refPolicies;
+  return result;
+}
+
+function mergeDrawerPolicies({
+  initialPolicies,
+  ref,
+  policies,
+  unknownPolicy,
+}: {
+  initialPolicies: FirewallPolicies;
+  ref: string;
+  policies: Record<string, Record<string, PermissionPolicy>>;
+  unknownPolicy: FirewallPolicyValue;
+}): FirewallPolicies {
+  const unified: FirewallPolicies = { ...initialPolicies };
+  for (const [r, p] of Object.entries(policies)) {
+    const nextUnknownPolicy =
+      r === ref ? unknownPolicy : initialPolicies[r]?.unknownPolicy;
+    unified[r] =
+      nextUnknownPolicy === undefined
+        ? { policies: p }
+        : { policies: p, unknownPolicy: nextUnknownPolicy };
+  }
+  return unified;
+}
+
+function buildExplicitGrantMap(
+  ref: string,
+  grants: readonly UserPermissionGrantResponse[],
+): Map<string, UserPermissionGrantResponse> {
+  const result = new Map<string, UserPermissionGrantResponse>();
+  for (const grant of grants) {
+    if (grant.connectorRef === ref) {
+      result.set(grant.permission, grant);
+    }
+  }
+  return result;
+}
+
+function buildInitialExpirationSelections(
+  grants: Map<string, UserPermissionGrantResponse>,
+): Record<string, UserPermissionGrantExpiresIn> {
+  const result: Record<string, UserPermissionGrantExpiresIn> = {};
+  for (const [permission, grant] of grants) {
+    result[permission] = expiresInFromGrantExpiresAt(grant.expiresAt);
+  }
   return result;
 }
 
@@ -249,6 +338,27 @@ function hasPermissionPolicyChanges({
   return !permissionPoliciesEqual(currentPolicies, initialPolicies);
 }
 
+function hasGrantExpirationChanges({
+  expirationEnabled,
+  explicitGrants,
+  selections,
+}: {
+  expirationEnabled: boolean;
+  explicitGrants: Map<string, UserPermissionGrantResponse>;
+  selections: Readonly<Record<string, UserPermissionGrantExpiresIn>>;
+}): boolean {
+  if (!expirationEnabled) {
+    return false;
+  }
+  for (const [permission, grant] of explicitGrants) {
+    const selected = selections[permission];
+    if (selected && expiresInFromGrantExpiresAt(grant.expiresAt) !== selected) {
+      return true;
+    }
+  }
+  return false;
+}
+
 function canApplyPermissionPolicies({
   config,
   saving,
@@ -264,10 +374,12 @@ function canApplyPermissionPolicies({
 function UnknownEndpointsToggle({
   policy,
   disabled,
+  expirationControl,
   onChange,
 }: {
   policy: PermissionPolicy | "mixed";
   disabled?: boolean;
+  expirationControl?: ReactNode;
   onChange: (p: PermissionPolicy) => void;
 }) {
   return (
@@ -281,7 +393,246 @@ function UnknownEndpointsToggle({
             API endpoints not matched by any permission above
           </p>
         </div>
-        <PolicyPill policy={policy} disabled={disabled} onChange={onChange} />
+        <div className="flex shrink-0 items-center gap-2">
+          {expirationControl}
+          <PolicyPill policy={policy} disabled={disabled} onChange={onChange} />
+        </div>
+      </div>
+    </div>
+  );
+}
+
+function PermissionExpirationControl({
+  permission,
+  grant,
+  selected,
+  policyChanged,
+  expirationEnabled,
+  readOnly,
+  saving,
+  onChange,
+}: {
+  permission: string;
+  grant: UserPermissionGrantResponse | undefined;
+  selected: UserPermissionGrantExpiresIn;
+  policyChanged: boolean;
+  expirationEnabled: boolean;
+  readOnly?: boolean;
+  saving: boolean;
+  onChange: (
+    permission: string,
+    expiresIn: UserPermissionGrantExpiresIn,
+  ) => void;
+}) {
+  if (!expirationEnabled || (!grant && !policyChanged)) {
+    return null;
+  }
+
+  const expiryText = permissionGrantExpiryText(grant?.expiresAt ?? null);
+  if (readOnly && !expiryText) {
+    return null;
+  }
+
+  return (
+    <div className="flex shrink-0 items-center gap-2">
+      {expiryText && (
+        <span className="text-[11px] font-medium text-amber-700 dark:text-amber-400">
+          {expiryText}
+        </span>
+      )}
+      {!readOnly && (
+        <PermissionGrantDurationSelect
+          value={selected}
+          onValueChange={(value) => {
+            onChange(permission, value);
+          }}
+          disabled={saving}
+          ariaLabel={`${permission} grant duration`}
+        />
+      )}
+    </div>
+  );
+}
+
+function PermissionRows({
+  groups,
+  permissions,
+  policies,
+  initialPolicies,
+  expandedGroups,
+  explicitGrants,
+  expirationSelections,
+  expirationEnabled,
+  readOnly,
+  saving,
+  onToggleGroup,
+  onSetGroupAll,
+  onPolicyChange,
+  onGrantExpirationChange,
+}: {
+  groups: { category: string; permissions: ConnectorPermission[] }[] | null;
+  permissions: ConnectorPermission[];
+  policies: Record<string, PermissionPolicy>;
+  initialPolicies: Record<string, PermissionPolicy>;
+  expandedGroups: Set<string>;
+  explicitGrants: Map<string, UserPermissionGrantResponse>;
+  expirationSelections: Readonly<Record<string, UserPermissionGrantExpiresIn>>;
+  expirationEnabled: boolean;
+  readOnly?: boolean;
+  saving: boolean;
+  onToggleGroup: (category: string) => void;
+  onSetGroupAll: (
+    groupPerms: ConnectorPermission[],
+    policy: PermissionPolicy,
+  ) => void;
+  onPolicyChange: (name: string, policy: PermissionPolicy) => void;
+  onGrantExpirationChange: (
+    permission: string,
+    expiresIn: UserPermissionGrantExpiresIn,
+  ) => void;
+}) {
+  if (groups) {
+    return groups.map((group, groupIdx) => {
+      const expanded = expandedGroups.has(group.category);
+      const groupPolicy = getGroupPolicy(group.permissions, policies);
+      return (
+        <div key={group.category}>
+          {groupIdx > 0 && (
+            <div className="mx-3 border-t border-border/40 my-1" />
+          )}
+          <div className="flex items-center justify-between px-3 py-2">
+            <button
+              type="button"
+              onClick={() => {
+                onToggleGroup(group.category);
+              }}
+              className="flex items-center gap-1.5 text-xs font-medium text-foreground hover:text-foreground/80 transition-colors"
+            >
+              <IconChevronRight
+                size={14}
+                stroke={2}
+                className={`transition-transform ${expanded ? "rotate-90" : ""}`}
+              />
+              {group.category} ({group.permissions.length})
+            </button>
+            <PolicyPill
+              policy={groupPolicy}
+              disabled={readOnly}
+              onChange={(p) => {
+                onSetGroupAll(group.permissions, p);
+              }}
+            />
+          </div>
+          {expanded &&
+            group.permissions.map((perm, idx) => {
+              return (
+                <PermissionRow
+                  key={perm.name}
+                  permission={perm}
+                  showSeparator={idx > 0}
+                  indent
+                  policies={policies}
+                  initialPolicies={initialPolicies}
+                  explicitGrants={explicitGrants}
+                  expirationSelections={expirationSelections}
+                  expirationEnabled={expirationEnabled}
+                  readOnly={readOnly}
+                  saving={saving}
+                  onPolicyChange={onPolicyChange}
+                  onGrantExpirationChange={onGrantExpirationChange}
+                />
+              );
+            })}
+        </div>
+      );
+    });
+  }
+
+  return permissions.map((perm, idx) => {
+    return (
+      <PermissionRow
+        key={perm.name}
+        permission={perm}
+        showSeparator={idx > 0}
+        policies={policies}
+        initialPolicies={initialPolicies}
+        explicitGrants={explicitGrants}
+        expirationSelections={expirationSelections}
+        expirationEnabled={expirationEnabled}
+        readOnly={readOnly}
+        saving={saving}
+        onPolicyChange={onPolicyChange}
+        onGrantExpirationChange={onGrantExpirationChange}
+      />
+    );
+  });
+}
+
+function PermissionRow({
+  permission,
+  showSeparator,
+  indent,
+  policies,
+  initialPolicies,
+  explicitGrants,
+  expirationSelections,
+  expirationEnabled,
+  readOnly,
+  saving,
+  onPolicyChange,
+  onGrantExpirationChange,
+}: {
+  permission: ConnectorPermission;
+  showSeparator: boolean;
+  indent?: boolean;
+  policies: Record<string, PermissionPolicy>;
+  initialPolicies: Record<string, PermissionPolicy>;
+  explicitGrants: Map<string, UserPermissionGrantResponse>;
+  expirationSelections: Readonly<Record<string, UserPermissionGrantExpiresIn>>;
+  expirationEnabled: boolean;
+  readOnly?: boolean;
+  saving: boolean;
+  onPolicyChange: (name: string, policy: PermissionPolicy) => void;
+  onGrantExpirationChange: (
+    permission: string,
+    expiresIn: UserPermissionGrantExpiresIn,
+  ) => void;
+}) {
+  const policy = policies[permission.name] ?? "allow";
+  const initialPolicy = initialPolicies[permission.name] ?? "allow";
+  return (
+    <div>
+      {showSeparator && <div className="mx-3 border-t border-border/40" />}
+      <div
+        className={`flex items-center gap-2.5 px-3 py-2.5 rounded-md hover:bg-muted/50 transition-colors ${indent ? "pl-8" : ""}`}
+      >
+        <div className="min-w-0 flex-1">
+          <code className="text-xs font-medium text-foreground truncate block">
+            {permission.name}
+          </code>
+          {permission.description && (
+            <p className="mt-0.5 text-xs text-muted-foreground leading-relaxed">
+              {permission.description}
+            </p>
+          )}
+        </div>
+        <PermissionExpirationControl
+          permission={permission.name}
+          grant={explicitGrants.get(permission.name)}
+          selected={expirationSelections[permission.name] ?? "forever"}
+          policyChanged={policy !== initialPolicy}
+          expirationEnabled={expirationEnabled}
+          readOnly={readOnly}
+          saving={saving}
+          onChange={onGrantExpirationChange}
+        />
+        <PolicyPill
+          policy={policy}
+          disabled={readOnly}
+          onChange={(p) => {
+            onPolicyChange(permission.name, p);
+          }}
+        />
       </div>
     </div>
   );
@@ -292,23 +643,30 @@ export function PermissionsDrawer({
   connectorType,
   displayName,
   initialPolicies,
+  initialGrants,
+  expirationEnabled,
   readOnly,
   onApply,
   onClose,
 }: PermissionsDrawerProps) {
   const ref = connectorType;
 
-  const config = isFirewallConnectorType(ref)
-    ? getConnectorFirewall(ref)
-    : null;
+  const config = permissionDrawerConfig(ref);
 
   const initialUnknownPolicy = initialPolicies[ref]?.unknownPolicy ?? "allow";
   const initialPolicyState = buildInitialPolicies(ref, config, initialPolicies);
-  const initialPolicyKey = `${agentId}\u0000${ref}\u0000${initialUnknownPolicy}\u0000${JSON.stringify(initialPolicyState[ref] ?? {})}`;
+  const explicitGrants = buildExplicitGrantMap(ref, initialGrants);
+  const initialExpirationSelections =
+    buildInitialExpirationSelections(explicitGrants);
+  const initialPolicyKey = `${agentId}\u0000${ref}\u0000${initialUnknownPolicy}\u0000${JSON.stringify(initialPolicyState[ref] ?? {})}\u0000${JSON.stringify(initialExpirationSelections)}`;
   useSet(initPermissionPolicies$)(
     initialPolicyKey,
     initialPolicyState,
     initialUnknownPolicy,
+  );
+  useSet(initPermissionGrantExpirations$)(
+    initialPolicyKey,
+    initialExpirationSelections,
   );
 
   const allPolicies = useGet(permissionAllPolicies$);
@@ -320,12 +678,15 @@ export function PermissionsDrawer({
   const toggleGroup = useSet(togglePermissionGroup$);
   const setPolicyFn = useSet(setPermissionPolicy$);
   const setAllPoliciesFn = useSet(setPermissionAllPolicies$);
+  const expirationSelections = useGet(permissionGrantExpirations$);
+  const setGrantExpiration = useSet(setPermissionGrantExpiration$);
   const resetPermissionPolicies = useSet(resetPermissionPolicies$);
+  const resetGrantExpirations = useSet(resetPermissionGrantExpirations$);
   const [applyLoadable, applyFn] = useLoadableSet(applyPermissionPolicies$);
   const saving = applyLoadable.state === "loading";
   const pageSignal = useGet(pageSignal$);
 
-  const permissions = config ? sortPermissions(extractPermissions(config)) : [];
+  const permissions = sortedPermissionsForConfig(config);
   const policiesForRef = allPolicies[ref];
   const policies = policiesForRef ?? {};
   const groups = buildSortedGroups(config, ref);
@@ -335,10 +696,15 @@ export function PermissionsDrawer({
     currentUnknownPolicy: unknownPolicy,
     initialUnknownPolicy,
   });
+  const hasExpirationChanges = hasGrantExpirationChanges({
+    expirationEnabled,
+    explicitGrants,
+    selections: expirationSelections,
+  });
   const canApply = canApplyPermissionPolicies({
     config,
     saving,
-    hasChanges: hasPermissionChanges,
+    hasChanges: hasPermissionChanges || hasExpirationChanges,
   });
 
   const handlePolicyChange = (name: string, policy: PermissionPolicy) => {
@@ -346,11 +712,7 @@ export function PermissionsDrawer({
   };
 
   const handleSetAll = (policy: PermissionPolicy) => {
-    const next: Record<string, PermissionPolicy> = {};
-    for (const p of permissions) {
-      next[p.name] = policy;
-    }
-    setAllPoliciesFn(ref, next);
+    setAllPoliciesFn(ref, permissionPolicyRecord(permissions, policy));
     setUnknownPolicy(policy);
   };
 
@@ -358,15 +720,15 @@ export function PermissionsDrawer({
     groupPerms: ConnectorPermission[],
     policy: PermissionPolicy,
   ) => {
-    const next = { ...policies };
-    for (const p of groupPerms) {
-      next[p.name] = policy;
-    }
-    setAllPoliciesFn(ref, next);
+    setAllPoliciesFn(ref, {
+      ...policies,
+      ...permissionPolicyRecord(groupPerms, policy),
+    });
   };
 
   const handleClose = () => {
     resetPermissionPolicies(initialPolicyKey);
+    resetGrantExpirations(initialPolicyKey);
     onClose();
   };
 
@@ -375,17 +737,15 @@ export function PermissionsDrawer({
       perms: Record<string, Record<string, PermissionPolicy>>,
       unknownFlag: FirewallPolicyValue,
     ): Promise<void> => {
-      // Convert dialog state (flat perms + unknownPolicy) to unified FirewallPolicies
-      const unified: FirewallPolicies = { ...initialPolicies };
-      for (const [r, p] of Object.entries(perms)) {
-        const nextUnknownPolicy =
-          r === ref ? unknownFlag : initialPolicies[r]?.unknownPolicy;
-        unified[r] =
-          nextUnknownPolicy === undefined
-            ? { policies: p }
-            : { policies: p, unknownPolicy: nextUnknownPolicy };
-      }
-      await onApply(unified);
+      await onApply(
+        mergeDrawerPolicies({
+          initialPolicies,
+          ref,
+          policies: perms,
+          unknownPolicy: unknownFlag,
+        }),
+        expirationSelections,
+      );
     };
     detach(
       applyFn(
@@ -456,108 +816,41 @@ export function PermissionsDrawer({
                 setScrolled(target.scrollTop > 0);
               }}
             >
-              {groups
-                ? groups.map((group, groupIdx) => {
-                    const expanded = expandedGroups.has(group.category);
-                    const groupPolicy = getGroupPolicy(
-                      group.permissions,
-                      policies,
-                    );
-                    return (
-                      <div key={group.category}>
-                        {groupIdx > 0 && (
-                          <div className="mx-3 border-t border-border/40 my-1" />
-                        )}
-                        <div className="flex items-center justify-between px-3 py-2">
-                          <button
-                            type="button"
-                            onClick={() => {
-                              return toggleGroup(group.category);
-                            }}
-                            className="flex items-center gap-1.5 text-xs font-medium text-foreground hover:text-foreground/80 transition-colors"
-                          >
-                            <IconChevronRight
-                              size={14}
-                              stroke={2}
-                              className={`transition-transform ${expanded ? "rotate-90" : ""}`}
-                            />
-                            {group.category} ({group.permissions.length})
-                          </button>
-                          <PolicyPill
-                            policy={groupPolicy}
-                            disabled={readOnly}
-                            onChange={(p) => {
-                              return handleSetGroupAll(group.permissions, p);
-                            }}
-                          />
-                        </div>
-                        {expanded &&
-                          group.permissions.map((perm, idx) => {
-                            const pol = policies[perm.name] ?? "allow";
-                            return (
-                              <div key={perm.name}>
-                                {idx > 0 && (
-                                  <div className="mx-3 border-t border-border/40" />
-                                )}
-                                <div className="flex items-center gap-2.5 px-3 py-2.5 pl-8 rounded-md hover:bg-muted/50 transition-colors">
-                                  <div className="min-w-0 flex-1">
-                                    <code className="text-xs font-medium text-foreground truncate block">
-                                      {perm.name}
-                                    </code>
-                                    {perm.description && (
-                                      <p className="mt-0.5 text-xs text-muted-foreground leading-relaxed">
-                                        {perm.description}
-                                      </p>
-                                    )}
-                                  </div>
-                                  <PolicyPill
-                                    policy={pol}
-                                    disabled={readOnly}
-                                    onChange={(p) => {
-                                      return handlePolicyChange(perm.name, p);
-                                    }}
-                                  />
-                                </div>
-                              </div>
-                            );
-                          })}
-                      </div>
-                    );
-                  })
-                : permissions.map((perm, idx) => {
-                    const pol = policies[perm.name] ?? "allow";
-                    return (
-                      <div key={perm.name}>
-                        {idx > 0 && (
-                          <div className="mx-3 border-t border-border/40" />
-                        )}
-                        <div className="flex items-center gap-2.5 px-3 py-2.5 rounded-md hover:bg-muted/50 transition-colors">
-                          <div className="min-w-0 flex-1">
-                            <code className="text-xs font-medium text-foreground truncate block">
-                              {perm.name}
-                            </code>
-                            {perm.description && (
-                              <p className="mt-0.5 text-xs text-muted-foreground leading-relaxed">
-                                {perm.description}
-                              </p>
-                            )}
-                          </div>
-                          <PolicyPill
-                            policy={pol}
-                            disabled={readOnly}
-                            onChange={(p) => {
-                              return handlePolicyChange(perm.name, p);
-                            }}
-                          />
-                        </div>
-                      </div>
-                    );
-                  })}
+              <PermissionRows
+                groups={groups}
+                permissions={permissions}
+                policies={policies}
+                initialPolicies={initialPolicyState[ref] ?? {}}
+                expandedGroups={expandedGroups}
+                explicitGrants={explicitGrants}
+                expirationSelections={expirationSelections}
+                expirationEnabled={expirationEnabled}
+                readOnly={readOnly}
+                saving={saving}
+                onToggleGroup={toggleGroup}
+                onSetGroupAll={handleSetGroupAll}
+                onPolicyChange={handlePolicyChange}
+                onGrantExpirationChange={setGrantExpiration}
+              />
             </div>
 
             <UnknownEndpointsToggle
               policy={unknownPolicy}
               disabled={readOnly}
+              expirationControl={
+                <PermissionExpirationControl
+                  permission={UNKNOWN_PERMISSION_GRANT}
+                  grant={explicitGrants.get(UNKNOWN_PERMISSION_GRANT)}
+                  selected={
+                    expirationSelections[UNKNOWN_PERMISSION_GRANT] ?? "forever"
+                  }
+                  policyChanged={unknownPolicy !== initialUnknownPolicy}
+                  expirationEnabled={expirationEnabled}
+                  readOnly={readOnly}
+                  saving={saving}
+                  onChange={setGrantExpiration}
+                />
+              }
               onChange={(p) => {
                 setUnknownPolicy(p);
               }}

--- a/turbo/apps/platform/src/views/zero-page/components/settings/permissions-dialog.tsx
+++ b/turbo/apps/platform/src/views/zero-page/components/settings/permissions-dialog.tsx
@@ -538,20 +538,18 @@ function menuOptionExpiresIn(
 }
 
 function isDurationMenuOptionActive({
-  allowGrant,
-  policy,
+  allowAlwaysActive,
   selected,
   value,
 }: {
-  allowGrant: UserPermissionGrantResponse | undefined;
-  policy: FirewallPolicyValue;
+  allowAlwaysActive: boolean;
   selected: UserPermissionGrantExpiresIn | undefined;
   value: UserPermissionGrantExpiresIn;
 }): boolean {
   if (selected !== undefined) {
     return selected === value;
   }
-  return policy === "allow" && value === "forever" && !allowGrant?.expiresAt;
+  return value === "forever" && allowAlwaysActive;
 }
 
 function PermissionGrantResetButton({
@@ -602,29 +600,33 @@ function PermissionGrantPolicyControl({
   selected,
   hasPendingChange,
   expirationEnabled,
+  allowAlwaysActive,
   readOnly,
   saving,
-  onChange,
+  showCurrentExpirationStatus = true,
+  onClearExpiration,
+  onAllowDurationChange,
   onPolicyChange,
   onReset,
 }: {
   permission: string;
-  policy: FirewallPolicyValue;
+  policy: FirewallPolicyValue | "mixed";
   grant: UserPermissionGrantResponse | undefined;
   selected: UserPermissionGrantExpiresIn | undefined;
   hasPendingChange: boolean;
   expirationEnabled: boolean;
+  allowAlwaysActive: boolean;
   readOnly?: boolean;
   saving: boolean;
-  onChange: (
-    permission: string,
-    expiresIn: UserPermissionGrantExpiresIn | null,
-  ) => void;
+  showCurrentExpirationStatus?: boolean;
+  onClearExpiration: () => void;
+  onAllowDurationChange: (expiresIn: UserPermissionGrantExpiresIn) => void;
   onPolicyChange: (policy: PermissionPolicy) => void;
   onReset: () => void;
 }) {
   const allowGrant = grant?.action === "allow" ? grant : undefined;
-  const showExpirationStatus = expirationEnabled && policy === "allow";
+  const showExpirationStatus =
+    showCurrentExpirationStatus && expirationEnabled && policy === "allow";
   const showSplitPolicy = expirationEnabled && !readOnly;
 
   return (
@@ -682,16 +684,12 @@ function PermissionGrantPolicyControl({
                     key={option.value}
                     onSelect={() => {
                       onPolicyChange("allow");
-                      onChange(
-                        permission,
-                        menuOptionExpiresIn(option.value, allowGrant),
-                      );
+                      onAllowDurationChange(option.value);
                     }}
                   >
                     <MenuItemCheck
                       active={isDurationMenuOptionActive({
-                        allowGrant,
-                        policy,
+                        allowAlwaysActive,
                         selected,
                         value: option.value,
                       })}
@@ -709,7 +707,7 @@ function PermissionGrantPolicyControl({
             style={{ borderLeft: "0.7px solid hsl(var(--gray-400))" }}
             onClick={() => {
               onPolicyChange("deny");
-              onChange(permission, null);
+              onClearExpiration();
             }}
             className={permissionPolicyButtonClass({
               active: policy === "deny",
@@ -732,6 +730,77 @@ function PermissionGrantPolicyControl({
       )}
     </div>
   );
+}
+
+function groupExpirationSelection(
+  permissions: readonly ConnectorPermission[],
+  selections: Readonly<Record<string, UserPermissionGrantExpiresIn>>,
+): UserPermissionGrantExpiresIn | undefined {
+  if (permissions.length === 0) {
+    return undefined;
+  }
+  const first = selections[permissions[0].name];
+  if (first === undefined) {
+    return undefined;
+  }
+  for (let i = 1; i < permissions.length; i++) {
+    if (selections[permissions[i].name] !== first) {
+      return undefined;
+    }
+  }
+  return first;
+}
+
+function hasPendingGroupControlChange({
+  expirationEnabled,
+  explicitGrants,
+  initialPolicies,
+  permissions,
+  policies,
+  selections,
+}: {
+  expirationEnabled: boolean;
+  explicitGrants: Map<string, UserPermissionGrantResponse>;
+  initialPolicies: Record<string, PermissionPolicy>;
+  permissions: readonly ConnectorPermission[];
+  policies: Record<string, PermissionPolicy>;
+  selections: Readonly<Record<string, UserPermissionGrantExpiresIn>>;
+}): boolean {
+  return permissions.some((permission) => {
+    const name = permission.name;
+    return hasPendingPermissionControlChange({
+      expirationEnabled,
+      grant: explicitGrants.get(name),
+      initialPolicy: initialPolicies[name] ?? "allow",
+      policy: policies[name] ?? "allow",
+      selected: selections[name],
+    });
+  });
+}
+
+function hasAllowAlwaysPolicy(
+  grant: UserPermissionGrantResponse | undefined,
+  policy: FirewallPolicyValue,
+): boolean {
+  return policy === "allow" && !(grant?.action === "allow" && grant.expiresAt);
+}
+
+function hasGroupAllowAlwaysPolicy({
+  explicitGrants,
+  permissions,
+  policies,
+}: {
+  explicitGrants: Map<string, UserPermissionGrantResponse>;
+  permissions: readonly ConnectorPermission[];
+  policies: Record<string, PermissionPolicy>;
+}): boolean {
+  return permissions.every((permission) => {
+    const name = permission.name;
+    return hasAllowAlwaysPolicy(
+      explicitGrants.get(name),
+      policies[name] ?? "allow",
+    );
+  });
 }
 
 function PermissionRows({
@@ -777,6 +846,23 @@ function PermissionRows({
     return groups.map((group, groupIdx) => {
       const expanded = expandedGroups.has(group.category);
       const groupPolicy = getGroupPolicy(group.permissions, policies);
+      const groupSelectedExpiration = groupExpirationSelection(
+        group.permissions,
+        expirationSelections,
+      );
+      const groupHasPendingChange = hasPendingGroupControlChange({
+        expirationEnabled,
+        explicitGrants,
+        initialPolicies,
+        permissions: group.permissions,
+        policies,
+        selections: expirationSelections,
+      });
+      const groupAllowAlwaysActive = hasGroupAllowAlwaysPolicy({
+        explicitGrants,
+        permissions: group.permissions,
+        policies,
+      });
       return (
         <div key={group.category}>
           {groupIdx > 0 && (
@@ -797,11 +883,41 @@ function PermissionRows({
               />
               {group.category} ({group.permissions.length})
             </button>
-            <PolicyPill
+            <PermissionGrantPolicyControl
+              permission={group.category}
               policy={groupPolicy}
-              disabled={readOnly}
-              onChange={(p) => {
+              grant={undefined}
+              selected={groupSelectedExpiration}
+              hasPendingChange={groupHasPendingChange}
+              expirationEnabled={expirationEnabled}
+              allowAlwaysActive={groupAllowAlwaysActive}
+              readOnly={readOnly}
+              saving={saving}
+              showCurrentExpirationStatus={false}
+              onClearExpiration={() => {
+                for (const permission of group.permissions) {
+                  onGrantExpirationChange(permission.name, null);
+                }
+              }}
+              onAllowDurationChange={(expiresIn) => {
+                for (const permission of group.permissions) {
+                  const grant = explicitGrants.get(permission.name);
+                  onGrantExpirationChange(
+                    permission.name,
+                    menuOptionExpiresIn(
+                      expiresIn,
+                      grant?.action === "allow" ? grant : undefined,
+                    ),
+                  );
+                }
+              }}
+              onPolicyChange={(p) => {
                 onSetGroupAll(group.permissions, p);
+              }}
+              onReset={() => {
+                for (const permission of group.permissions) {
+                  onResetPermission(permission.name);
+                }
               }}
             />
           </div>
@@ -917,9 +1033,21 @@ function PermissionRow({
           selected={selected}
           hasPendingChange={hasPendingChange}
           expirationEnabled={expirationEnabled}
+          allowAlwaysActive={hasAllowAlwaysPolicy(grant, policy)}
           readOnly={readOnly}
           saving={saving}
-          onChange={onGrantExpirationChange}
+          onClearExpiration={() => {
+            onGrantExpirationChange(permission.name, null);
+          }}
+          onAllowDurationChange={(expiresIn) => {
+            onGrantExpirationChange(
+              permission.name,
+              menuOptionExpiresIn(
+                expiresIn,
+                grant?.action === "allow" ? grant : undefined,
+              ),
+            );
+          }}
           onPolicyChange={(p) => {
             onPolicyChange(permission.name, p);
           }}
@@ -999,6 +1127,9 @@ export function PermissionsDrawer({
     saving,
     hasChanges: hasPermissionChanges || hasExpirationChanges,
   });
+  const unknownGrant = explicitGrants.get(UNKNOWN_PERMISSION_GRANT);
+  const unknownSelectedExpiration =
+    expirationSelections[UNKNOWN_PERMISSION_GRANT];
 
   const handlePolicyChange = (name: string, policy: PermissionPolicy) => {
     setPolicyFn(ref, name, policy);
@@ -1154,19 +1285,36 @@ export function PermissionsDrawer({
                 <PermissionGrantPolicyControl
                   permission={UNKNOWN_PERMISSION_GRANT}
                   policy={unknownPolicy}
-                  grant={explicitGrants.get(UNKNOWN_PERMISSION_GRANT)}
-                  selected={expirationSelections[UNKNOWN_PERMISSION_GRANT]}
+                  grant={unknownGrant}
+                  selected={unknownSelectedExpiration}
                   hasPendingChange={hasPendingPermissionControlChange({
                     expirationEnabled,
-                    grant: explicitGrants.get(UNKNOWN_PERMISSION_GRANT),
+                    grant: unknownGrant,
                     initialPolicy: initialUnknownPolicy,
                     policy: unknownPolicy,
-                    selected: expirationSelections[UNKNOWN_PERMISSION_GRANT],
+                    selected: unknownSelectedExpiration,
                   })}
                   expirationEnabled={expirationEnabled}
+                  allowAlwaysActive={hasAllowAlwaysPolicy(
+                    unknownGrant,
+                    unknownPolicy,
+                  )}
                   readOnly={readOnly}
                   saving={saving}
-                  onChange={setGrantExpiration}
+                  onClearExpiration={() => {
+                    setGrantExpiration(UNKNOWN_PERMISSION_GRANT, null);
+                  }}
+                  onAllowDurationChange={(expiresIn) => {
+                    setGrantExpiration(
+                      UNKNOWN_PERMISSION_GRANT,
+                      menuOptionExpiresIn(
+                        expiresIn,
+                        unknownGrant?.action === "allow"
+                          ? unknownGrant
+                          : undefined,
+                      ),
+                    );
+                  }}
                   onPolicyChange={(p) => {
                     setUnknownPolicy(p);
                   }}

--- a/turbo/apps/platform/src/views/zero-page/components/settings/permissions-dialog.tsx
+++ b/turbo/apps/platform/src/views/zero-page/components/settings/permissions-dialog.tsx
@@ -1270,7 +1270,7 @@ export function PermissionsDrawer({
         return !open && handleClose();
       }}
     >
-      <SheetContent side="right">
+      <SheetContent side="right" className="w-[90vw] sm:max-w-[640px]">
         <SheetHeader>
           <div className="flex items-center gap-3">
             <ConnectorIcon type={connectorType} size={24} />

--- a/turbo/apps/platform/src/views/zero-page/components/settings/permissions-dialog.tsx
+++ b/turbo/apps/platform/src/views/zero-page/components/settings/permissions-dialog.tsx
@@ -556,27 +556,14 @@ function PermissionGrantPolicyControl({
               </button>
             </DropdownMenuTrigger>
             <DropdownMenuContent align="end" className="w-40">
-              {policy === "allow" ? (
-                <DropdownMenuItem
-                  onSelect={() => {
-                    onPolicyChange("allow");
-                    onChange(permission, null);
-                  }}
-                >
-                  <MenuItemCheck active={selected === undefined} />
-                  Keep current
-                </DropdownMenuItem>
-              ) : (
-                <DropdownMenuItem
-                  onSelect={() => {
-                    onPolicyChange("allow");
-                    onChange(permission, null);
-                  }}
-                >
-                  <MenuItemCheck active={false} />
-                  Allow
-                </DropdownMenuItem>
-              )}
+              <DropdownMenuItem
+                onSelect={() => {
+                  onChange(permission, null);
+                }}
+              >
+                <MenuItemCheck active={selected === undefined} />
+                Keep current
+              </DropdownMenuItem>
               <DropdownMenuSeparator />
               {ALLOW_DURATION_MENU_OPTIONS.map((option) => {
                 return (

--- a/turbo/apps/platform/src/views/zero-page/components/settings/permissions-dialog.tsx
+++ b/turbo/apps/platform/src/views/zero-page/components/settings/permissions-dialog.tsx
@@ -344,17 +344,26 @@ function hasPermissionPolicyChanges({
 function hasGrantExpirationChanges({
   expirationEnabled,
   explicitGrants,
+  policies,
+  unknownPolicy,
   selections,
 }: {
   expirationEnabled: boolean;
   explicitGrants: Map<string, UserPermissionGrantResponse>;
+  policies: Record<string, PermissionPolicy>;
+  unknownPolicy: FirewallPolicyValue;
   selections: Readonly<Record<string, UserPermissionGrantExpiresIn>>;
 }): boolean {
   if (!expirationEnabled) {
     return false;
   }
   for (const permission of Object.keys(selections)) {
-    if (explicitGrants.has(permission)) {
+    const grant = explicitGrants.get(permission);
+    const currentAction =
+      permission === UNKNOWN_PERMISSION_GRANT
+        ? unknownPolicy
+        : (policies[permission] ?? grant?.action);
+    if (grant?.action === "allow" && currentAction === "allow") {
       return true;
     }
   }
@@ -431,6 +440,7 @@ function GrantExpirationStatus({
 
 function PermissionExpirationControl({
   permission,
+  action,
   grant,
   selected,
   policyChanged,
@@ -440,6 +450,7 @@ function PermissionExpirationControl({
   onChange,
 }: {
   permission: string;
+  action: FirewallPolicyValue;
   grant: UserPermissionGrantResponse | undefined;
   selected: UserPermissionGrantExpiresIn | undefined;
   policyChanged: boolean;
@@ -451,17 +462,22 @@ function PermissionExpirationControl({
     expiresIn: UserPermissionGrantExpiresIn | null,
   ) => void;
 }) {
-  if (!expirationEnabled || (!grant && !policyChanged)) {
+  const allowGrant = grant?.action === "allow" ? grant : undefined;
+  if (
+    !expirationEnabled ||
+    action !== "allow" ||
+    (!allowGrant && !policyChanged)
+  ) {
     return null;
   }
 
   const showSetting = !readOnly;
-  const showKeepCurrent = grant !== undefined;
+  const showKeepCurrent = allowGrant !== undefined;
   const settingValue = selected ?? (showKeepCurrent ? null : "forever");
 
   return (
     <div className="flex shrink-0 flex-col items-end gap-1.5">
-      <GrantExpirationStatus grant={grant} />
+      <GrantExpirationStatus grant={allowGrant} />
       {showSetting && (
         <PermissionGrantDurationSelect
           value={settingValue}
@@ -645,6 +661,7 @@ function PermissionRow({
         </div>
         <PermissionExpirationControl
           permission={permission.name}
+          action={policy}
           grant={explicitGrants.get(permission.name)}
           selected={expirationSelections[permission.name]}
           policyChanged={policy !== initialPolicy}
@@ -722,6 +739,8 @@ export function PermissionsDrawer({
   const hasExpirationChanges = hasGrantExpirationChanges({
     expirationEnabled,
     explicitGrants,
+    policies,
+    unknownPolicy,
     selections: expirationSelections,
   });
   const canApply = canApplyPermissionPolicies({
@@ -863,6 +882,7 @@ export function PermissionsDrawer({
               expirationControl={
                 <PermissionExpirationControl
                   permission={UNKNOWN_PERMISSION_GRANT}
+                  action={unknownPolicy}
                   grant={explicitGrants.get(UNKNOWN_PERMISSION_GRANT)}
                   selected={expirationSelections[UNKNOWN_PERMISSION_GRANT]}
                   policyChanged={unknownPolicy !== initialUnknownPolicy}

--- a/turbo/apps/platform/src/views/zero-page/components/settings/permissions-dialog.tsx
+++ b/turbo/apps/platform/src/views/zero-page/components/settings/permissions-dialog.tsx
@@ -1278,7 +1278,7 @@ export function PermissionsDrawer({
         return !open && handleClose();
       }}
     >
-      <SheetContent side="right" className="w-[90vw] sm:max-w-[600px]">
+      <SheetContent side="right" className="w-[90vw] sm:max-w-[560px]">
         <SheetHeader>
           <div className="flex items-center gap-3">
             <ConnectorIcon type={connectorType} size={24} />

--- a/turbo/apps/platform/src/views/zero-page/components/settings/permissions-dialog.tsx
+++ b/turbo/apps/platform/src/views/zero-page/components/settings/permissions-dialog.tsx
@@ -601,6 +601,7 @@ function PermissionGrantPolicyControl({
   hasPendingChange,
   expirationEnabled,
   allowAlwaysActive,
+  expirationStatusExpiresAt,
   readOnly,
   saving,
   showCurrentExpirationStatus = true,
@@ -616,6 +617,7 @@ function PermissionGrantPolicyControl({
   hasPendingChange: boolean;
   expirationEnabled: boolean;
   allowAlwaysActive: boolean;
+  expirationStatusExpiresAt?: string | null;
   readOnly?: boolean;
   saving: boolean;
   showCurrentExpirationStatus?: boolean;
@@ -627,12 +629,14 @@ function PermissionGrantPolicyControl({
   const allowGrant = grant?.action === "allow" ? grant : undefined;
   const showExpirationStatus =
     showCurrentExpirationStatus && expirationEnabled && policy === "allow";
+  const expirationStatusValue =
+    expirationStatusExpiresAt ?? allowGrant?.expiresAt ?? null;
   const showSplitPolicy = expirationEnabled && !readOnly;
 
   return (
     <div className="flex shrink-0 items-center gap-2">
       {showExpirationStatus && (
-        <GrantExpirationStatus expiresAt={allowGrant?.expiresAt ?? null} />
+        <GrantExpirationStatus expiresAt={expirationStatusValue} />
       )}
       {!showSplitPolicy ? (
         <PolicyPill
@@ -803,6 +807,41 @@ function hasGroupAllowAlwaysPolicy({
   });
 }
 
+function groupExpirationStatusExpiresAt({
+  explicitGrants,
+  permissions,
+  policies,
+}: {
+  explicitGrants: Map<string, UserPermissionGrantResponse>;
+  permissions: readonly ConnectorPermission[];
+  policies: Record<string, PermissionPolicy>;
+}): string | null | undefined {
+  if (permissions.length === 0) {
+    return null;
+  }
+
+  let firstExpiresAt: string | null | undefined;
+  for (const permission of permissions) {
+    const name = permission.name;
+    if ((policies[name] ?? "allow") !== "allow") {
+      return undefined;
+    }
+
+    const grant = explicitGrants.get(name);
+    const expiresAt =
+      grant?.action === "allow" && grant.expiresAt ? grant.expiresAt : null;
+    if (firstExpiresAt === undefined) {
+      firstExpiresAt = expiresAt;
+      continue;
+    }
+    if (firstExpiresAt !== expiresAt) {
+      return undefined;
+    }
+  }
+
+  return firstExpiresAt ?? null;
+}
+
 function PermissionRows({
   groups,
   permissions,
@@ -863,6 +902,11 @@ function PermissionRows({
         permissions: group.permissions,
         policies,
       });
+      const groupExpirationStatus = groupExpirationStatusExpiresAt({
+        explicitGrants,
+        permissions: group.permissions,
+        policies,
+      });
       return (
         <div key={group.category}>
           {groupIdx > 0 && (
@@ -891,9 +935,10 @@ function PermissionRows({
               hasPendingChange={groupHasPendingChange}
               expirationEnabled={expirationEnabled}
               allowAlwaysActive={groupAllowAlwaysActive}
+              expirationStatusExpiresAt={groupExpirationStatus ?? null}
               readOnly={readOnly}
               saving={saving}
-              showCurrentExpirationStatus={false}
+              showCurrentExpirationStatus={groupExpirationStatus !== undefined}
               onClearExpiration={() => {
                 for (const permission of group.permissions) {
                   onGrantExpirationChange(permission.name, null);

--- a/turbo/apps/platform/src/views/zero-page/components/settings/permissions-dialog.tsx
+++ b/turbo/apps/platform/src/views/zero-page/components/settings/permissions-dialog.tsx
@@ -375,7 +375,7 @@ function hasGrantExpirationChanges({
         : (policies[permission] ?? grant?.action ?? "allow");
     if (
       currentAction === "allow" &&
-      (grant?.action === "allow" || (!grant && selected !== "forever"))
+      (grant?.action === "allow" || (!grant && selected !== "always"))
     ) {
       return true;
     }
@@ -398,9 +398,9 @@ function hasPendingGrantExpirationChange({
     return false;
   }
   if (grant?.action === "allow") {
-    return selected !== "forever" || Boolean(grant.expiresAt);
+    return selected !== "always" || Boolean(grant.expiresAt);
   }
-  return selected !== "forever";
+  return selected !== "always";
 }
 
 function hasPendingPermissionControlChange({
@@ -472,7 +472,7 @@ function GrantExpirationStatus({
   const expiryText =
     selectedStatus ?? permissionGrantExpiryText(expiresAt) ?? "Always";
   const hasExpiringGrant =
-    selected === undefined ? Boolean(expiresAt) : selected !== "forever";
+    selected === undefined ? Boolean(expiresAt) : selected !== "always";
 
   return (
     <span
@@ -497,7 +497,7 @@ const ALLOW_DURATION_MENU_OPTIONS: readonly {
   { value: "1h", label: "Allow for 1h", statusLabel: "Expires in 1h" },
   { value: "24h", label: "Allow for 24h", statusLabel: "Expires in 24h" },
   { value: "7d", label: "Allow for 7d", statusLabel: "Expires in 7d" },
-  { value: "forever", label: "Allow always", statusLabel: "Always" },
+  { value: "always", label: "Allow always", statusLabel: "Always" },
 ];
 
 function allowDurationStatusLabel(
@@ -541,7 +541,7 @@ function menuOptionExpiresIn(
   value: UserPermissionGrantExpiresIn,
   allowGrant: UserPermissionGrantResponse | undefined,
 ): UserPermissionGrantExpiresIn | null {
-  if (value === "forever" && !allowGrant?.expiresAt) {
+  if (value === "always" && !allowGrant?.expiresAt) {
     return null;
   }
   return value;
@@ -559,7 +559,7 @@ function isDurationMenuOptionActive({
   if (selected !== undefined) {
     return selected === value;
   }
-  return value === "forever" && allowAlwaysActive;
+  return value === "always" && allowAlwaysActive;
 }
 
 function PermissionGrantResetButton({

--- a/turbo/apps/platform/src/views/zero-page/components/settings/permissions-dialog.tsx
+++ b/turbo/apps/platform/src/views/zero-page/components/settings/permissions-dialog.tsx
@@ -1270,7 +1270,7 @@ export function PermissionsDrawer({
         return !open && handleClose();
       }}
     >
-      <SheetContent side="right" className="w-[90vw] sm:max-w-[640px]">
+      <SheetContent side="right" className="w-[90vw] sm:max-w-[600px]">
         <SheetHeader>
           <div className="flex items-center gap-3">
             <ConnectorIcon type={connectorType} size={24} />

--- a/turbo/apps/platform/src/views/zero-page/components/settings/permissions-dialog.tsx
+++ b/turbo/apps/platform/src/views/zero-page/components/settings/permissions-dialog.tsx
@@ -11,6 +11,7 @@ import {
   SheetTitle,
   SheetFooter,
   Button,
+  cn,
 } from "@vm0/ui";
 import {
   CONNECTOR_TYPES,
@@ -34,10 +35,7 @@ import type {
 } from "@vm0/api-contracts/contracts/zero-user-permission-grants";
 import { ConnectorIcon } from "./connector-icons.tsx";
 import { PermissionGrantDurationSelect } from "../../../components/permission-grant-duration-select.tsx";
-import {
-  expiresInFromGrantExpiresAt,
-  permissionGrantExpiryText,
-} from "../../../../signals/permission-allow/permission-grant-expiration.ts";
+import { permissionGrantExpiryText } from "../../../../signals/permission-allow/permission-grant-expiration.ts";
 import type { PermissionPolicy } from "../../../../signals/zero-page/settings/permissions.ts";
 import {
   permissionAllPolicies$,
@@ -57,7 +55,12 @@ import {
   initPermissionGrantExpirations$,
   resetPermissionGrantExpirations$,
 } from "../../../../signals/zero-page/settings/permissions-dialog.ts";
-import { IconCheck, IconBan, IconChevronRight } from "@tabler/icons-react";
+import {
+  IconCheck,
+  IconBan,
+  IconChevronRight,
+  IconClock,
+} from "@tabler/icons-react";
 import { detach, Reason } from "../../../../signals/utils.ts";
 import { pageSignal$ } from "../../../../signals/page-signal.ts";
 
@@ -292,14 +295,14 @@ function buildExplicitGrantMap(
   return result;
 }
 
-function buildInitialExpirationSelections(
+function explicitGrantStateKey(
   grants: Map<string, UserPermissionGrantResponse>,
-): Record<string, UserPermissionGrantExpiresIn> {
-  const result: Record<string, UserPermissionGrantExpiresIn> = {};
-  for (const [permission, grant] of grants) {
-    result[permission] = expiresInFromGrantExpiresAt(grant.expiresAt);
-  }
-  return result;
+): string {
+  return JSON.stringify(
+    [...grants.entries()].map(([permission, grant]) => {
+      return [permission, grant.action, grant.expiresAt] as const;
+    }),
+  );
 }
 
 function permissionPoliciesEqual(
@@ -350,9 +353,8 @@ function hasGrantExpirationChanges({
   if (!expirationEnabled) {
     return false;
   }
-  for (const [permission, grant] of explicitGrants) {
-    const selected = selections[permission];
-    if (selected && expiresInFromGrantExpiresAt(grant.expiresAt) !== selected) {
+  for (const permission of Object.keys(selections)) {
+    if (explicitGrants.has(permission)) {
       return true;
     }
   }
@@ -402,6 +404,31 @@ function UnknownEndpointsToggle({
   );
 }
 
+function GrantExpirationStatus({
+  grant,
+}: {
+  grant: UserPermissionGrantResponse | undefined;
+}) {
+  if (!grant) {
+    return null;
+  }
+  const expiryText = permissionGrantExpiryText(grant.expiresAt) ?? "Always";
+
+  return (
+    <span
+      className={cn(
+        "inline-flex h-6 max-w-[150px] items-center gap-1.5 rounded-md border px-2 text-[11px] font-medium",
+        grant.expiresAt
+          ? "border-amber-500/20 bg-amber-500/10 text-amber-700 dark:text-amber-400"
+          : "border-border bg-muted/40 text-muted-foreground",
+      )}
+    >
+      <IconClock size={12} className="shrink-0" />
+      <span className="truncate">{expiryText}</span>
+    </span>
+  );
+}
+
 function PermissionExpirationControl({
   permission,
   grant,
@@ -414,40 +441,40 @@ function PermissionExpirationControl({
 }: {
   permission: string;
   grant: UserPermissionGrantResponse | undefined;
-  selected: UserPermissionGrantExpiresIn;
+  selected: UserPermissionGrantExpiresIn | undefined;
   policyChanged: boolean;
   expirationEnabled: boolean;
   readOnly?: boolean;
   saving: boolean;
   onChange: (
     permission: string,
-    expiresIn: UserPermissionGrantExpiresIn,
+    expiresIn: UserPermissionGrantExpiresIn | null,
   ) => void;
 }) {
   if (!expirationEnabled || (!grant && !policyChanged)) {
     return null;
   }
 
-  const expiryText = permissionGrantExpiryText(grant?.expiresAt ?? null);
-  if (readOnly && !expiryText) {
-    return null;
-  }
+  const showSetting = !readOnly;
+  const showKeepCurrent = grant !== undefined;
+  const settingValue = selected ?? (showKeepCurrent ? null : "forever");
 
   return (
-    <div className="flex shrink-0 items-center gap-2">
-      {expiryText && (
-        <span className="text-[11px] font-medium text-amber-700 dark:text-amber-400">
-          {expiryText}
-        </span>
-      )}
-      {!readOnly && (
+    <div className="flex shrink-0 flex-col items-end gap-1.5">
+      <GrantExpirationStatus grant={grant} />
+      {showSetting && (
         <PermissionGrantDurationSelect
-          value={selected}
+          value={settingValue}
+          showKeepCurrent={showKeepCurrent}
+          onClear={() => {
+            onChange(permission, null);
+          }}
           onValueChange={(value) => {
             onChange(permission, value);
           }}
           disabled={saving}
           ariaLabel={`${permission} grant duration`}
+          className="h-7 w-[132px] rounded-md text-[11px]"
         />
       )}
     </div>
@@ -488,7 +515,7 @@ function PermissionRows({
   onPolicyChange: (name: string, policy: PermissionPolicy) => void;
   onGrantExpirationChange: (
     permission: string,
-    expiresIn: UserPermissionGrantExpiresIn,
+    expiresIn: UserPermissionGrantExpiresIn | null,
   ) => void;
 }) {
   if (groups) {
@@ -595,7 +622,7 @@ function PermissionRow({
   onPolicyChange: (name: string, policy: PermissionPolicy) => void;
   onGrantExpirationChange: (
     permission: string,
-    expiresIn: UserPermissionGrantExpiresIn,
+    expiresIn: UserPermissionGrantExpiresIn | null,
   ) => void;
 }) {
   const policy = policies[permission.name] ?? "allow";
@@ -619,7 +646,7 @@ function PermissionRow({
         <PermissionExpirationControl
           permission={permission.name}
           grant={explicitGrants.get(permission.name)}
-          selected={expirationSelections[permission.name] ?? "forever"}
+          selected={expirationSelections[permission.name]}
           policyChanged={policy !== initialPolicy}
           expirationEnabled={expirationEnabled}
           readOnly={readOnly}
@@ -656,18 +683,14 @@ export function PermissionsDrawer({
   const initialUnknownPolicy = initialPolicies[ref]?.unknownPolicy ?? "allow";
   const initialPolicyState = buildInitialPolicies(ref, config, initialPolicies);
   const explicitGrants = buildExplicitGrantMap(ref, initialGrants);
-  const initialExpirationSelections =
-    buildInitialExpirationSelections(explicitGrants);
-  const initialPolicyKey = `${agentId}\u0000${ref}\u0000${initialUnknownPolicy}\u0000${JSON.stringify(initialPolicyState[ref] ?? {})}\u0000${JSON.stringify(initialExpirationSelections)}`;
+  const grantStateKey = explicitGrantStateKey(explicitGrants);
+  const initialPolicyKey = `${agentId}\u0000${ref}\u0000${initialUnknownPolicy}\u0000${JSON.stringify(initialPolicyState[ref] ?? {})}\u0000${grantStateKey}`;
   useSet(initPermissionPolicies$)(
     initialPolicyKey,
     initialPolicyState,
     initialUnknownPolicy,
   );
-  useSet(initPermissionGrantExpirations$)(
-    initialPolicyKey,
-    initialExpirationSelections,
-  );
+  useSet(initPermissionGrantExpirations$)(initialPolicyKey, {});
 
   const allPolicies = useGet(permissionAllPolicies$);
   const unknownPolicy = useGet(permissionUnknownPolicy$);
@@ -841,9 +864,7 @@ export function PermissionsDrawer({
                 <PermissionExpirationControl
                   permission={UNKNOWN_PERMISSION_GRANT}
                   grant={explicitGrants.get(UNKNOWN_PERMISSION_GRANT)}
-                  selected={
-                    expirationSelections[UNKNOWN_PERMISSION_GRANT] ?? "forever"
-                  }
+                  selected={expirationSelections[UNKNOWN_PERMISSION_GRANT]}
                   policyChanged={unknownPolicy !== initialUnknownPolicy}
                   expirationEnabled={expirationEnabled}
                   readOnly={readOnly}

--- a/turbo/apps/platform/src/views/zero-page/components/settings/permissions-dialog.tsx
+++ b/turbo/apps/platform/src/views/zero-page/components/settings/permissions-dialog.tsx
@@ -470,7 +470,7 @@ function GrantExpirationStatus({
 }) {
   const selectedStatus = allowDurationStatusLabel(selected);
   const expiryText =
-    selectedStatus ?? permissionGrantExpiryText(expiresAt) ?? "Always";
+    selectedStatus ?? compactGrantExpirationText(expiresAt) ?? "Always";
   const hasExpiringGrant =
     selected === undefined ? Boolean(expiresAt) : selected !== "always";
 
@@ -494,11 +494,19 @@ const ALLOW_DURATION_MENU_OPTIONS: readonly {
   readonly label: string;
   readonly statusLabel: string;
 }[] = [
-  { value: "1h", label: "Allow for 1h", statusLabel: "Expires in 1h" },
-  { value: "24h", label: "Allow for 24h", statusLabel: "Expires in 24h" },
-  { value: "7d", label: "Allow for 7d", statusLabel: "Expires in 7d" },
+  { value: "1h", label: "Allow for 1h", statusLabel: "1h" },
+  { value: "24h", label: "Allow for 24h", statusLabel: "24h" },
+  { value: "7d", label: "Allow for 7d", statusLabel: "7d" },
   { value: "always", label: "Allow always", statusLabel: "Always" },
 ];
+
+function compactGrantExpirationText(expiresAt: string | null): string | null {
+  const text = permissionGrantExpiryText(expiresAt);
+  if (text === "Expires in less than 1 hour") {
+    return "< 1 hour";
+  }
+  return text?.replace(/^Expires in /, "") ?? null;
+}
 
 function allowDurationStatusLabel(
   selected: UserPermissionGrantExpiresIn | undefined,

--- a/turbo/apps/platform/src/views/zero-page/components/settings/permissions-dialog.tsx
+++ b/turbo/apps/platform/src/views/zero-page/components/settings/permissions-dialog.tsx
@@ -1278,7 +1278,7 @@ export function PermissionsDrawer({
         return !open && handleClose();
       }}
     >
-      <SheetContent side="right" className="w-[90vw] sm:max-w-[560px]">
+      <SheetContent side="right">
         <SheetHeader>
           <div className="flex items-center gap-3">
             <ConnectorIcon type={connectorType} size={24} />

--- a/turbo/apps/platform/src/views/zero-page/components/settings/permissions-dialog.tsx
+++ b/turbo/apps/platform/src/views/zero-page/components/settings/permissions-dialog.tsx
@@ -359,11 +359,15 @@ function hasGrantExpirationChanges({
   }
   for (const permission of Object.keys(selections)) {
     const grant = explicitGrants.get(permission);
+    const selected = selections[permission];
     const currentAction =
       permission === UNKNOWN_PERMISSION_GRANT
         ? unknownPolicy
-        : (policies[permission] ?? grant?.action);
-    if (grant?.action === "allow" && currentAction === "allow") {
+        : (policies[permission] ?? grant?.action ?? "allow");
+    if (
+      currentAction === "allow" &&
+      (grant?.action === "allow" || (!grant && selected !== "forever"))
+    ) {
       return true;
     }
   }
@@ -413,21 +417,14 @@ function UnknownEndpointsToggle({
   );
 }
 
-function GrantExpirationStatus({
-  grant,
-}: {
-  grant: UserPermissionGrantResponse | undefined;
-}) {
-  if (!grant) {
-    return null;
-  }
-  const expiryText = permissionGrantExpiryText(grant.expiresAt) ?? "Always";
+function GrantExpirationStatus({ expiresAt }: { expiresAt: string | null }) {
+  const expiryText = permissionGrantExpiryText(expiresAt) ?? "Always";
 
   return (
     <span
       className={cn(
         "inline-flex h-6 max-w-[150px] items-center gap-1.5 rounded-md border px-2 text-[11px] font-medium",
-        grant.expiresAt
+        expiresAt
           ? "border-amber-500/20 bg-amber-500/10 text-amber-700 dark:text-amber-400"
           : "border-border bg-muted/40 text-muted-foreground",
       )}
@@ -443,7 +440,6 @@ function PermissionExpirationControl({
   action,
   grant,
   selected,
-  policyChanged,
   expirationEnabled,
   readOnly,
   saving,
@@ -453,7 +449,6 @@ function PermissionExpirationControl({
   action: FirewallPolicyValue;
   grant: UserPermissionGrantResponse | undefined;
   selected: UserPermissionGrantExpiresIn | undefined;
-  policyChanged: boolean;
   expirationEnabled: boolean;
   readOnly?: boolean;
   saving: boolean;
@@ -463,11 +458,7 @@ function PermissionExpirationControl({
   ) => void;
 }) {
   const allowGrant = grant?.action === "allow" ? grant : undefined;
-  if (
-    !expirationEnabled ||
-    action !== "allow" ||
-    (!allowGrant && !policyChanged)
-  ) {
+  if (!expirationEnabled || action !== "allow") {
     return null;
   }
 
@@ -477,7 +468,7 @@ function PermissionExpirationControl({
 
   return (
     <div className="flex shrink-0 flex-col items-end gap-1.5">
-      <GrantExpirationStatus grant={allowGrant} />
+      <GrantExpirationStatus expiresAt={allowGrant?.expiresAt ?? null} />
       {showSetting && (
         <PermissionGrantDurationSelect
           value={settingValue}
@@ -501,7 +492,6 @@ function PermissionRows({
   groups,
   permissions,
   policies,
-  initialPolicies,
   expandedGroups,
   explicitGrants,
   expirationSelections,
@@ -516,7 +506,6 @@ function PermissionRows({
   groups: { category: string; permissions: ConnectorPermission[] }[] | null;
   permissions: ConnectorPermission[];
   policies: Record<string, PermissionPolicy>;
-  initialPolicies: Record<string, PermissionPolicy>;
   expandedGroups: Set<string>;
   explicitGrants: Map<string, UserPermissionGrantResponse>;
   expirationSelections: Readonly<Record<string, UserPermissionGrantExpiresIn>>;
@@ -575,7 +564,6 @@ function PermissionRows({
                   showSeparator={idx > 0}
                   indent
                   policies={policies}
-                  initialPolicies={initialPolicies}
                   explicitGrants={explicitGrants}
                   expirationSelections={expirationSelections}
                   expirationEnabled={expirationEnabled}
@@ -598,7 +586,6 @@ function PermissionRows({
         permission={perm}
         showSeparator={idx > 0}
         policies={policies}
-        initialPolicies={initialPolicies}
         explicitGrants={explicitGrants}
         expirationSelections={expirationSelections}
         expirationEnabled={expirationEnabled}
@@ -616,7 +603,6 @@ function PermissionRow({
   showSeparator,
   indent,
   policies,
-  initialPolicies,
   explicitGrants,
   expirationSelections,
   expirationEnabled,
@@ -629,7 +615,6 @@ function PermissionRow({
   showSeparator: boolean;
   indent?: boolean;
   policies: Record<string, PermissionPolicy>;
-  initialPolicies: Record<string, PermissionPolicy>;
   explicitGrants: Map<string, UserPermissionGrantResponse>;
   expirationSelections: Readonly<Record<string, UserPermissionGrantExpiresIn>>;
   expirationEnabled: boolean;
@@ -642,7 +627,6 @@ function PermissionRow({
   ) => void;
 }) {
   const policy = policies[permission.name] ?? "allow";
-  const initialPolicy = initialPolicies[permission.name] ?? "allow";
   return (
     <div>
       {showSeparator && <div className="mx-3 border-t border-border/40" />}
@@ -664,7 +648,6 @@ function PermissionRow({
           action={policy}
           grant={explicitGrants.get(permission.name)}
           selected={expirationSelections[permission.name]}
-          policyChanged={policy !== initialPolicy}
           expirationEnabled={expirationEnabled}
           readOnly={readOnly}
           saving={saving}
@@ -862,7 +845,6 @@ export function PermissionsDrawer({
                 groups={groups}
                 permissions={permissions}
                 policies={policies}
-                initialPolicies={initialPolicyState[ref] ?? {}}
                 expandedGroups={expandedGroups}
                 explicitGrants={explicitGrants}
                 expirationSelections={expirationSelections}
@@ -885,7 +867,6 @@ export function PermissionsDrawer({
                   action={unknownPolicy}
                   grant={explicitGrants.get(UNKNOWN_PERMISSION_GRANT)}
                   selected={expirationSelections[UNKNOWN_PERMISSION_GRANT]}
-                  policyChanged={unknownPolicy !== initialUnknownPolicy}
                   expirationEnabled={expirationEnabled}
                   readOnly={readOnly}
                   saving={saving}

--- a/turbo/apps/platform/src/views/zero-page/components/settings/permissions-dialog.tsx
+++ b/turbo/apps/platform/src/views/zero-page/components/settings/permissions-dialog.tsx
@@ -461,14 +461,24 @@ function UnknownEndpointsToggle({
   );
 }
 
-function GrantExpirationStatus({ expiresAt }: { expiresAt: string | null }) {
-  const expiryText = permissionGrantExpiryText(expiresAt) ?? "Always";
+function GrantExpirationStatus({
+  expiresAt,
+  selected,
+}: {
+  expiresAt: string | null;
+  selected: UserPermissionGrantExpiresIn | undefined;
+}) {
+  const selectedStatus = allowDurationStatusLabel(selected);
+  const expiryText =
+    selectedStatus ?? permissionGrantExpiryText(expiresAt) ?? "Always";
+  const hasExpiringGrant =
+    selected === undefined ? Boolean(expiresAt) : selected !== "forever";
 
   return (
     <span
       className={cn(
         "inline-flex h-6 max-w-[150px] items-center gap-1.5 rounded-md border px-2 text-[11px] font-medium",
-        expiresAt
+        hasExpiringGrant
           ? "border-amber-500/20 bg-amber-500/10 text-amber-700 dark:text-amber-400"
           : "border-border bg-muted/40 text-muted-foreground",
       )}
@@ -482,21 +492,21 @@ function GrantExpirationStatus({ expiresAt }: { expiresAt: string | null }) {
 const ALLOW_DURATION_MENU_OPTIONS: readonly {
   readonly value: UserPermissionGrantExpiresIn;
   readonly label: string;
-  readonly buttonLabel: string;
+  readonly statusLabel: string;
 }[] = [
-  { value: "1h", label: "Allow for 1h", buttonLabel: "1h" },
-  { value: "24h", label: "Allow for 24h", buttonLabel: "24h" },
-  { value: "7d", label: "Allow for 7d", buttonLabel: "7d" },
-  { value: "forever", label: "Allow always", buttonLabel: "Always" },
+  { value: "1h", label: "Allow for 1h", statusLabel: "Expires in 1h" },
+  { value: "24h", label: "Allow for 24h", statusLabel: "Expires in 24h" },
+  { value: "7d", label: "Allow for 7d", statusLabel: "Expires in 7d" },
+  { value: "forever", label: "Allow always", statusLabel: "Always" },
 ];
 
-function allowButtonLabel(
+function allowDurationStatusLabel(
   selected: UserPermissionGrantExpiresIn | undefined,
-): string {
+): string | null {
   const option = ALLOW_DURATION_MENU_OPTIONS.find((item) => {
     return item.value === selected;
   });
-  return option ? `Allow · ${option.buttonLabel}` : "Allow";
+  return option?.statusLabel ?? null;
 }
 
 function permissionPolicyButtonClass({
@@ -636,7 +646,10 @@ function PermissionGrantPolicyControl({
   return (
     <div className="flex shrink-0 items-center gap-2">
       {showExpirationStatus && (
-        <GrantExpirationStatus expiresAt={expirationStatusValue} />
+        <GrantExpirationStatus
+          expiresAt={expirationStatusValue}
+          selected={selected}
+        />
       )}
       {!showSplitPolicy ? (
         <PolicyPill
@@ -662,7 +675,7 @@ function PermissionGrantPolicyControl({
             })}
           >
             <IconCheck size={12} stroke={2.5} />
-            {allowButtonLabel(selected)}
+            Allow
           </button>
           <DropdownMenu>
             <DropdownMenuTrigger asChild>

--- a/turbo/apps/platform/src/views/zero-page/components/settings/permissions-dialog.tsx
+++ b/turbo/apps/platform/src/views/zero-page/components/settings/permissions-dialog.tsx
@@ -16,7 +16,10 @@ import {
   DropdownMenuTrigger,
   DropdownMenuContent,
   DropdownMenuItem,
-  DropdownMenuSeparator,
+  Tooltip,
+  TooltipTrigger,
+  TooltipContent,
+  TooltipProvider,
 } from "@vm0/ui";
 import {
   CONNECTOR_TYPES,
@@ -65,6 +68,7 @@ import {
   IconChevronRight,
   IconClock,
   IconChevronDown,
+  IconRefresh,
 } from "@tabler/icons-react";
 import { detach, Reason } from "../../../../signals/utils.ts";
 import { pageSignal$ } from "../../../../signals/page-signal.ts";
@@ -379,6 +383,50 @@ function hasGrantExpirationChanges({
   return false;
 }
 
+function hasPendingGrantExpirationChange({
+  expirationEnabled,
+  grant,
+  policy,
+  selected,
+}: {
+  expirationEnabled: boolean;
+  grant: UserPermissionGrantResponse | undefined;
+  policy: FirewallPolicyValue;
+  selected: UserPermissionGrantExpiresIn | undefined;
+}): boolean {
+  if (!expirationEnabled || selected === undefined || policy !== "allow") {
+    return false;
+  }
+  if (grant?.action === "allow") {
+    return selected !== "forever" || Boolean(grant.expiresAt);
+  }
+  return selected !== "forever";
+}
+
+function hasPendingPermissionControlChange({
+  expirationEnabled,
+  grant,
+  initialPolicy,
+  policy,
+  selected,
+}: {
+  expirationEnabled: boolean;
+  grant: UserPermissionGrantResponse | undefined;
+  initialPolicy: PermissionPolicy;
+  policy: FirewallPolicyValue;
+  selected: UserPermissionGrantExpiresIn | undefined;
+}): boolean {
+  return (
+    policy !== initialPolicy ||
+    hasPendingGrantExpirationChange({
+      expirationEnabled,
+      grant,
+      policy,
+      selected,
+    })
+  );
+}
+
 function canApplyPermissionPolicies({
   config,
   saving,
@@ -479,21 +527,92 @@ function MenuItemCheck({ active }: { active: boolean }) {
   );
 }
 
+function menuOptionExpiresIn(
+  value: UserPermissionGrantExpiresIn,
+  allowGrant: UserPermissionGrantResponse | undefined,
+): UserPermissionGrantExpiresIn | null {
+  if (value === "forever" && !allowGrant?.expiresAt) {
+    return null;
+  }
+  return value;
+}
+
+function isDurationMenuOptionActive({
+  allowGrant,
+  policy,
+  selected,
+  value,
+}: {
+  allowGrant: UserPermissionGrantResponse | undefined;
+  policy: FirewallPolicyValue;
+  selected: UserPermissionGrantExpiresIn | undefined;
+  value: UserPermissionGrantExpiresIn;
+}): boolean {
+  if (selected !== undefined) {
+    return selected === value;
+  }
+  return policy === "allow" && value === "forever" && !allowGrant?.expiresAt;
+}
+
+function PermissionGrantResetButton({
+  disabled,
+  permission,
+  visible,
+  onReset,
+}: {
+  disabled?: boolean;
+  permission: string;
+  visible: boolean;
+  onReset: () => void;
+}) {
+  return (
+    <span className="flex h-7 w-7 shrink-0 items-center justify-center">
+      {visible && (
+        <TooltipProvider delayDuration={200}>
+          <Tooltip>
+            <TooltipTrigger asChild>
+              <button
+                type="button"
+                disabled={disabled}
+                aria-label={`Reset ${permission} changes`}
+                onClick={() => {
+                  onReset();
+                }}
+                className={`flex h-7 w-7 items-center justify-center rounded-md text-muted-foreground transition-colors ${
+                  disabled
+                    ? "cursor-default text-muted-foreground/50"
+                    : "hover:bg-muted/50 hover:text-foreground"
+                }`}
+              >
+                <IconRefresh size={13} stroke={2.2} />
+              </button>
+            </TooltipTrigger>
+            <TooltipContent side="top">Reset changes</TooltipContent>
+          </Tooltip>
+        </TooltipProvider>
+      )}
+    </span>
+  );
+}
+
 function PermissionGrantPolicyControl({
   permission,
   policy,
   grant,
   selected,
+  hasPendingChange,
   expirationEnabled,
   readOnly,
   saving,
   onChange,
   onPolicyChange,
+  onReset,
 }: {
   permission: string;
   policy: FirewallPolicyValue;
   grant: UserPermissionGrantResponse | undefined;
   selected: UserPermissionGrantExpiresIn | undefined;
+  hasPendingChange: boolean;
   expirationEnabled: boolean;
   readOnly?: boolean;
   saving: boolean;
@@ -502,6 +621,7 @@ function PermissionGrantPolicyControl({
     expiresIn: UserPermissionGrantExpiresIn | null,
   ) => void;
   onPolicyChange: (policy: PermissionPolicy) => void;
+  onReset: () => void;
 }) {
   const allowGrant = grant?.action === "allow" ? grant : undefined;
   const showExpirationStatus = expirationEnabled && policy === "allow";
@@ -556,25 +676,26 @@ function PermissionGrantPolicyControl({
               </button>
             </DropdownMenuTrigger>
             <DropdownMenuContent align="end" className="w-40">
-              <DropdownMenuItem
-                onSelect={() => {
-                  onChange(permission, null);
-                }}
-              >
-                <MenuItemCheck active={selected === undefined} />
-                Keep current
-              </DropdownMenuItem>
-              <DropdownMenuSeparator />
               {ALLOW_DURATION_MENU_OPTIONS.map((option) => {
                 return (
                   <DropdownMenuItem
                     key={option.value}
                     onSelect={() => {
                       onPolicyChange("allow");
-                      onChange(permission, option.value);
+                      onChange(
+                        permission,
+                        menuOptionExpiresIn(option.value, allowGrant),
+                      );
                     }}
                   >
-                    <MenuItemCheck active={selected === option.value} />
+                    <MenuItemCheck
+                      active={isDurationMenuOptionActive({
+                        allowGrant,
+                        policy,
+                        selected,
+                        value: option.value,
+                      })}
+                    />
                     {option.label}
                   </DropdownMenuItem>
                 );
@@ -601,6 +722,14 @@ function PermissionGrantPolicyControl({
           </button>
         </span>
       )}
+      {showSplitPolicy && (
+        <PermissionGrantResetButton
+          disabled={saving}
+          permission={permission}
+          visible={hasPendingChange}
+          onReset={onReset}
+        />
+      )}
     </div>
   );
 }
@@ -608,6 +737,7 @@ function PermissionGrantPolicyControl({
 function PermissionRows({
   groups,
   permissions,
+  initialPolicies,
   policies,
   expandedGroups,
   explicitGrants,
@@ -619,9 +749,11 @@ function PermissionRows({
   onSetGroupAll,
   onPolicyChange,
   onGrantExpirationChange,
+  onResetPermission,
 }: {
   groups: { category: string; permissions: ConnectorPermission[] }[] | null;
   permissions: ConnectorPermission[];
+  initialPolicies: Record<string, PermissionPolicy>;
   policies: Record<string, PermissionPolicy>;
   expandedGroups: Set<string>;
   explicitGrants: Map<string, UserPermissionGrantResponse>;
@@ -639,6 +771,7 @@ function PermissionRows({
     permission: string,
     expiresIn: UserPermissionGrantExpiresIn | null,
   ) => void;
+  onResetPermission: (name: string) => void;
 }) {
   if (groups) {
     return groups.map((group, groupIdx) => {
@@ -680,6 +813,7 @@ function PermissionRows({
                   permission={perm}
                   showSeparator={idx > 0}
                   indent
+                  initialPolicy={initialPolicies[perm.name] ?? "allow"}
                   policies={policies}
                   explicitGrants={explicitGrants}
                   expirationSelections={expirationSelections}
@@ -688,6 +822,7 @@ function PermissionRows({
                   saving={saving}
                   onPolicyChange={onPolicyChange}
                   onGrantExpirationChange={onGrantExpirationChange}
+                  onResetPermission={onResetPermission}
                 />
               );
             })}
@@ -702,6 +837,7 @@ function PermissionRows({
         key={perm.name}
         permission={perm}
         showSeparator={idx > 0}
+        initialPolicy={initialPolicies[perm.name] ?? "allow"}
         policies={policies}
         explicitGrants={explicitGrants}
         expirationSelections={expirationSelections}
@@ -710,6 +846,7 @@ function PermissionRows({
         saving={saving}
         onPolicyChange={onPolicyChange}
         onGrantExpirationChange={onGrantExpirationChange}
+        onResetPermission={onResetPermission}
       />
     );
   });
@@ -719,6 +856,7 @@ function PermissionRow({
   permission,
   showSeparator,
   indent,
+  initialPolicy,
   policies,
   explicitGrants,
   expirationSelections,
@@ -727,10 +865,12 @@ function PermissionRow({
   saving,
   onPolicyChange,
   onGrantExpirationChange,
+  onResetPermission,
 }: {
   permission: ConnectorPermission;
   showSeparator: boolean;
   indent?: boolean;
+  initialPolicy: PermissionPolicy;
   policies: Record<string, PermissionPolicy>;
   explicitGrants: Map<string, UserPermissionGrantResponse>;
   expirationSelections: Readonly<Record<string, UserPermissionGrantExpiresIn>>;
@@ -742,8 +882,18 @@ function PermissionRow({
     permission: string,
     expiresIn: UserPermissionGrantExpiresIn | null,
   ) => void;
+  onResetPermission: (name: string) => void;
 }) {
   const policy = policies[permission.name] ?? "allow";
+  const grant = explicitGrants.get(permission.name);
+  const selected = expirationSelections[permission.name];
+  const hasPendingChange = hasPendingPermissionControlChange({
+    expirationEnabled,
+    grant,
+    initialPolicy,
+    policy,
+    selected,
+  });
   return (
     <div>
       {showSeparator && <div className="mx-3 border-t border-border/40" />}
@@ -763,14 +913,18 @@ function PermissionRow({
         <PermissionGrantPolicyControl
           permission={permission.name}
           policy={policy}
-          grant={explicitGrants.get(permission.name)}
-          selected={expirationSelections[permission.name]}
+          grant={grant}
+          selected={selected}
+          hasPendingChange={hasPendingChange}
           expirationEnabled={expirationEnabled}
           readOnly={readOnly}
           saving={saving}
           onChange={onGrantExpirationChange}
           onPolicyChange={(p) => {
             onPolicyChange(permission.name, p);
+          }}
+          onReset={() => {
+            onResetPermission(permission.name);
           }}
         />
       </div>
@@ -825,10 +979,11 @@ export function PermissionsDrawer({
   const permissions = sortedPermissionsForConfig(config);
   const policiesForRef = allPolicies[ref];
   const policies = policiesForRef ?? {};
+  const initialPoliciesForRef = initialPolicyState[ref] ?? {};
   const groups = buildSortedGroups(config, ref);
   const hasPermissionChanges = hasPermissionPolicyChanges({
     currentPolicies: policiesForRef,
-    initialPolicies: initialPolicyState[ref] ?? {},
+    initialPolicies: initialPoliciesForRef,
     currentUnknownPolicy: unknownPolicy,
     initialUnknownPolicy,
   });
@@ -852,6 +1007,12 @@ export function PermissionsDrawer({
   const handleSetAll = (policy: PermissionPolicy) => {
     setAllPoliciesFn(ref, permissionPolicyRecord(permissions, policy));
     setUnknownPolicy(policy);
+    if (policy === "deny") {
+      for (const permission of permissions) {
+        setGrantExpiration(permission.name, null);
+      }
+      setGrantExpiration(UNKNOWN_PERMISSION_GRANT, null);
+    }
   };
 
   const handleSetGroupAll = (
@@ -862,6 +1023,21 @@ export function PermissionsDrawer({
       ...policies,
       ...permissionPolicyRecord(groupPerms, policy),
     });
+    if (policy === "deny") {
+      for (const permission of groupPerms) {
+        setGrantExpiration(permission.name, null);
+      }
+    }
+  };
+
+  const handleResetPermission = (name: string) => {
+    setPolicyFn(ref, name, initialPoliciesForRef[name] ?? "allow");
+    setGrantExpiration(name, null);
+  };
+
+  const handleResetUnknownPermission = () => {
+    setUnknownPolicy(initialUnknownPolicy);
+    setGrantExpiration(UNKNOWN_PERMISSION_GRANT, null);
   };
 
   const handleClose = () => {
@@ -957,6 +1133,7 @@ export function PermissionsDrawer({
               <PermissionRows
                 groups={groups}
                 permissions={permissions}
+                initialPolicies={initialPoliciesForRef}
                 policies={policies}
                 expandedGroups={expandedGroups}
                 explicitGrants={explicitGrants}
@@ -968,6 +1145,7 @@ export function PermissionsDrawer({
                 onSetGroupAll={handleSetGroupAll}
                 onPolicyChange={handlePolicyChange}
                 onGrantExpirationChange={setGrantExpiration}
+                onResetPermission={handleResetPermission}
               />
             </div>
 
@@ -978,6 +1156,13 @@ export function PermissionsDrawer({
                   policy={unknownPolicy}
                   grant={explicitGrants.get(UNKNOWN_PERMISSION_GRANT)}
                   selected={expirationSelections[UNKNOWN_PERMISSION_GRANT]}
+                  hasPendingChange={hasPendingPermissionControlChange({
+                    expirationEnabled,
+                    grant: explicitGrants.get(UNKNOWN_PERMISSION_GRANT),
+                    initialPolicy: initialUnknownPolicy,
+                    policy: unknownPolicy,
+                    selected: expirationSelections[UNKNOWN_PERMISSION_GRANT],
+                  })}
                   expirationEnabled={expirationEnabled}
                   readOnly={readOnly}
                   saving={saving}
@@ -985,6 +1170,7 @@ export function PermissionsDrawer({
                   onPolicyChange={(p) => {
                     setUnknownPolicy(p);
                   }}
+                  onReset={handleResetUnknownPermission}
                 />
               }
             />

--- a/turbo/apps/platform/src/views/zero-page/components/settings/permissions-dialog.tsx
+++ b/turbo/apps/platform/src/views/zero-page/components/settings/permissions-dialog.tsx
@@ -68,7 +68,7 @@ import {
   IconChevronRight,
   IconClock,
   IconChevronDown,
-  IconRefresh,
+  IconArrowBackUp,
 } from "@tabler/icons-react";
 import { detach, Reason } from "../../../../signals/utils.ts";
 import { pageSignal$ } from "../../../../signals/page-signal.ts";
@@ -584,7 +584,7 @@ function PermissionGrantResetButton({
                     : "hover:bg-muted/50 hover:text-foreground"
                 }`}
               >
-                <IconRefresh size={13} stroke={2.2} />
+                <IconArrowBackUp size={13} stroke={2.2} />
               </button>
             </TooltipTrigger>
             <TooltipContent side="top">Reset changes</TooltipContent>

--- a/turbo/apps/platform/src/views/zero-page/zero-chat-thread-page.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-chat-thread-page.tsx
@@ -3637,7 +3637,7 @@ function createPermissionActionHandler(params: {
   focusedPermission: { name: string } | undefined;
   state: PermissionActionButtonState;
   finished: boolean;
-  expirationEnabled: boolean;
+  expirationAvailable: boolean;
   expiresIn: UserPermissionGrantExpiresIn;
   upsertGrant: UpsertUserPermissionGrantFn;
 }): () => void {
@@ -3657,7 +3657,7 @@ function createPermissionActionHandler(params: {
               connectorRef: params.block.connectorRef,
               permission: permissionName,
               action: params.block.action,
-              ...(params.expirationEnabled
+              ...(params.expirationAvailable
                 ? { expiresIn: params.expiresIn }
                 : {}),
             },
@@ -3676,7 +3676,7 @@ function PermissionActionCardContent({
   actionLabel,
   permissionName,
   buttonState,
-  expirationEnabled,
+  expirationAvailable,
   expiresIn,
   onExpiresInChange,
   expiresAt,
@@ -3687,17 +3687,17 @@ function PermissionActionCardContent({
   actionLabel: string;
   permissionName: string;
   buttonState: PermissionActionButtonState;
-  expirationEnabled: boolean;
+  expirationAvailable: boolean;
   expiresIn: UserPermissionGrantExpiresIn;
   onExpiresInChange: (value: UserPermissionGrantExpiresIn) => void;
   expiresAt: string | null;
   onClick: () => void;
 }) {
-  const expiryText = expirationEnabled
+  const expiryText = expirationAvailable
     ? permissionGrantExpiryText(expiresAt)
     : null;
   const showDurationSelect =
-    expirationEnabled && !buttonState.alreadyApplied && !buttonState.saveDone;
+    expirationAvailable && !buttonState.alreadyApplied && !buttonState.saveDone;
   return (
     <div
       data-testid="permission-action-card"
@@ -3746,6 +3746,7 @@ function PermissionActionCard({ block }: { block: PermissionActionBlock }) {
   const features = useLastResolved(featureSwitch$);
   const expirationEnabled =
     features?.[FeatureSwitchKey.ExpiringPermissionGrants] ?? false;
+  const expirationAvailable = expirationEnabled && block.action === "allow";
   const durationScope = `${block.id}\u0000${block.expiresIn ?? ""}`;
   const expiresInByScope = useGet(permissionGrantExpiresInByScope$);
   const setExpiresInForScope = useSet(setPermissionGrantExpiresIn$);
@@ -3779,7 +3780,7 @@ function PermissionActionCard({ block }: { block: PermissionActionBlock }) {
       actionLabel={actionState.actionLabel}
       permissionName={actionState.focusedPermission?.name ?? block.permission}
       buttonState={actionState.buttonState}
-      expirationEnabled={expirationEnabled}
+      expirationAvailable={expirationAvailable}
       expiresIn={expiresIn}
       onExpiresInChange={(value) => {
         setExpiresInForScope(durationScope, value);
@@ -3794,7 +3795,7 @@ function PermissionActionCard({ block }: { block: PermissionActionBlock }) {
         focusedPermission: actionState.focusedPermission,
         state: actionState.buttonState,
         finished: actionState.finished,
-        expirationEnabled,
+        expirationAvailable,
         expiresIn,
         upsertGrant,
       })}

--- a/turbo/apps/platform/src/views/zero-page/zero-chat-thread-page.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-chat-thread-page.tsx
@@ -62,7 +62,10 @@ import type {
   ChatThreadGithubPr,
 } from "@vm0/api-contracts/contracts/chat-threads";
 import { PRESENTATION_TEMPLATE_ITEMS } from "@vm0/core";
-import type { UserPermissionGrantResponse } from "@vm0/api-contracts/contracts/zero-user-permission-grants";
+import type {
+  UserPermissionGrantExpiresIn,
+  UserPermissionGrantResponse,
+} from "@vm0/api-contracts/contracts/zero-user-permission-grants";
 import { IN_VITEST } from "../../env.ts";
 import emptyChatImg from "./assets/empty-chat.webp";
 import emptyArtifactImg from "./assets/empty-artifact.webp";
@@ -107,7 +110,14 @@ import { AttachmentPreview } from "./zero-attachment-preview.tsx";
 import { FilePreviewIcon } from "./zero-file-preview-icon.tsx";
 import { ConnectorIcon } from "./components/settings/connector-icons.tsx";
 import { ConnectModal } from "./components/settings/add-connection-dialog.tsx";
+import { PermissionGrantDurationSelect } from "../components/permission-grant-duration-select.tsx";
 import { lightboxUrl$ as attachmentLightboxUrl$ } from "../../signals/zero-page/zero-attachment-chips.ts";
+import {
+  DEFAULT_USER_PERMISSION_GRANT_EXPIRES_IN,
+  permissionGrantExpiresInByScope$,
+  permissionGrantExpiryText,
+  setPermissionGrantExpiresIn$,
+} from "../../signals/permission-allow/permission-grant-expiration.ts";
 import {
   artifactFullscreen$,
   artifactInboxQuery$,
@@ -3373,9 +3383,10 @@ type UpsertUserPermissionGrantFn = (
     connectorRef: string;
     permission: string;
     action: PermissionAction;
+    expiresIn?: UserPermissionGrantExpiresIn;
   },
   signal: AbortSignal,
-) => Promise<void>;
+) => Promise<UserPermissionGrantResponse>;
 
 function loadableData<T>(loadable: LoadableLike<T>): T | undefined {
   return loadable.state === "hasData" ? loadable.data : undefined;
@@ -3626,6 +3637,8 @@ function createPermissionActionHandler(params: {
   focusedPermission: { name: string } | undefined;
   state: PermissionActionButtonState;
   finished: boolean;
+  expirationEnabled: boolean;
+  expiresIn: UserPermissionGrantExpiresIn;
   upsertGrant: UpsertUserPermissionGrantFn;
 }): () => void {
   return () => {
@@ -3644,6 +3657,9 @@ function createPermissionActionHandler(params: {
               connectorRef: params.block.connectorRef,
               permission: permissionName,
               action: params.block.action,
+              ...(params.expirationEnabled
+                ? { expiresIn: params.expiresIn }
+                : {}),
             },
             params.pageSignal,
           ),
@@ -3660,6 +3676,10 @@ function PermissionActionCardContent({
   actionLabel,
   permissionName,
   buttonState,
+  expirationEnabled,
+  expiresIn,
+  onExpiresInChange,
+  expiresAt,
   onClick,
 }: {
   block: PermissionActionBlock;
@@ -3667,8 +3687,15 @@ function PermissionActionCardContent({
   actionLabel: string;
   permissionName: string;
   buttonState: PermissionActionButtonState;
+  expirationEnabled: boolean;
+  expiresIn: UserPermissionGrantExpiresIn;
+  onExpiresInChange: (value: UserPermissionGrantExpiresIn) => void;
+  expiresAt: string | null;
   onClick: () => void;
 }) {
+  const expiryText = permissionGrantExpiryText(expiresAt);
+  const showDurationSelect =
+    expirationEnabled && !buttonState.alreadyApplied && !buttonState.saveDone;
   return (
     <div
       data-testid="permission-action-card"
@@ -3685,13 +3712,28 @@ function PermissionActionCardContent({
           <div className="mt-0.5 line-clamp-2 text-sm leading-5 text-muted-foreground">
             {actionLabel} {permissionName}
           </div>
+          {expiryText && (
+            <div className="mt-0.5 text-xs font-medium text-amber-700 dark:text-amber-400">
+              {expiryText}
+            </div>
+          )}
         </div>
       </div>
-      <PermissionActionButton
-        state={buttonState}
-        action={block.action}
-        onClick={onClick}
-      />
+      <div className="flex w-full shrink-0 flex-col gap-2 sm:w-auto sm:flex-row sm:items-center">
+        {showDurationSelect && (
+          <PermissionGrantDurationSelect
+            value={expiresIn}
+            onValueChange={onExpiresInChange}
+            disabled={buttonState.loading || buttonState.saving}
+            ariaLabel="Permission duration"
+          />
+        )}
+        <PermissionActionButton
+          state={buttonState}
+          action={block.action}
+          onClick={onClick}
+        />
+      </div>
     </div>
   );
 }
@@ -3699,6 +3741,16 @@ function PermissionActionCardContent({
 function PermissionActionCard({ block }: { block: PermissionActionBlock }) {
   const pageSignal = useGet(pageSignal$);
   const config = CONNECTOR_TYPES[block.connectorRef];
+  const features = useLastResolved(featureSwitch$);
+  const expirationEnabled =
+    features?.[FeatureSwitchKey.ExpiringPermissionGrants] ?? false;
+  const durationScope = `${block.id}\u0000${block.expiresIn ?? ""}`;
+  const expiresInByScope = useGet(permissionGrantExpiresInByScope$);
+  const setExpiresInForScope = useSet(setPermissionGrantExpiresIn$);
+  const expiresIn =
+    expiresInByScope[durationScope] ??
+    block.expiresIn ??
+    DEFAULT_USER_PERMISSION_GRANT_EXPIRES_IN;
   const agentLoadable = useLastLoadable(agentById(block.agentId));
   const [grantLoadable, upsertGrant] = useLoadableSet(
     upsertUserPermissionGrant$,
@@ -3725,6 +3777,14 @@ function PermissionActionCard({ block }: { block: PermissionActionBlock }) {
       actionLabel={actionState.actionLabel}
       permissionName={actionState.focusedPermission?.name ?? block.permission}
       buttonState={actionState.buttonState}
+      expirationEnabled={expirationEnabled}
+      expiresIn={expiresIn}
+      onExpiresInChange={(value) => {
+        setExpiresInForScope(durationScope, value);
+      }}
+      expiresAt={
+        grantLoadable.state === "hasData" ? grantLoadable.data.expiresAt : null
+      }
       onClick={createPermissionActionHandler({
         block,
         pageSignal,
@@ -3732,6 +3792,8 @@ function PermissionActionCard({ block }: { block: PermissionActionBlock }) {
         focusedPermission: actionState.focusedPermission,
         state: actionState.buttonState,
         finished: actionState.finished,
+        expirationEnabled,
+        expiresIn,
         upsertGrant,
       })}
     />

--- a/turbo/apps/platform/src/views/zero-page/zero-chat-thread-page.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-chat-thread-page.tsx
@@ -3693,7 +3693,9 @@ function PermissionActionCardContent({
   expiresAt: string | null;
   onClick: () => void;
 }) {
-  const expiryText = permissionGrantExpiryText(expiresAt);
+  const expiryText = expirationEnabled
+    ? permissionGrantExpiryText(expiresAt)
+    : null;
   const showDurationSelect =
     expirationEnabled && !buttonState.alreadyApplied && !buttonState.saveDone;
   return (

--- a/turbo/apps/platform/src/views/zero-page/zero-chat-thread-page.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-chat-thread-page.tsx
@@ -3493,11 +3493,15 @@ function isPermissionActionAlreadyApplied(params: {
   hasAgent: boolean;
   userGrantPolicy: FirewallPolicyValue | undefined;
   action: "allow" | "deny";
+  requestedExpirationChange: boolean;
 }): boolean {
   if (!params.hasAgent) {
     return false;
   }
-  return params.userGrantPolicy === params.action;
+  return (
+    params.userGrantPolicy === params.action &&
+    !params.requestedExpirationChange
+  );
 }
 
 function findPermissionActionPermission(block: PermissionActionBlock) {
@@ -3584,6 +3588,7 @@ function createPermissionActionCardViewState(params: {
   agentLoadableState: string;
   userGrantsLoadable: LoadableLike<readonly PermissionActionUserGrant[]>;
   grantLoadableState: string;
+  requestedExpirationChange: boolean;
 }) {
   const focusedPermission = findPermissionActionPermission(params.block);
   const actionLabel = permissionActionVerb(params.block.action);
@@ -3606,6 +3611,7 @@ function createPermissionActionCardViewState(params: {
     hasAgent: params.hasAgent,
     userGrantPolicy,
     action: params.block.action,
+    requestedExpirationChange: params.requestedExpirationChange,
   });
   const saveDone = params.grantLoadableState === "hasData";
   const buttonState = createPermissionActionCardButtonState({
@@ -3764,6 +3770,8 @@ function PermissionActionCard({ block }: { block: PermissionActionBlock }) {
   const expirationEnabled =
     features?.[FeatureSwitchKey.ExpiringPermissionGrants] ?? false;
   const expirationAvailable = expirationEnabled && block.action === "allow";
+  const requestedExpirationChange =
+    expirationAvailable && block.expiresIn !== null;
   const durationScope = `${block.id}\u0000${block.expiresIn ?? ""}`;
   const expiresInByScope = useGet(permissionGrantExpiresInByScope$);
   const setExpiresInForScope = useSet(setPermissionGrantExpiresIn$);
@@ -3788,6 +3796,7 @@ function PermissionActionCard({ block }: { block: PermissionActionBlock }) {
     agentLoadableState: agentLoadable.state,
     userGrantsLoadable,
     grantLoadableState: grantLoadable.state,
+    requestedExpirationChange,
   });
   const existingGrant = permissionActionUserGrant(userGrantsLoadable, block);
   const grantExpiresAt =

--- a/turbo/apps/platform/src/views/zero-page/zero-chat-thread-page.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-chat-thread-page.tsx
@@ -3521,6 +3521,23 @@ function permissionActionUserGrantPolicy(
   );
 }
 
+function permissionActionUserGrant(
+  loadable: LoadableLike<readonly PermissionActionUserGrant[]>,
+  block: PermissionActionBlock,
+): PermissionActionUserGrant | undefined {
+  const grants = loadableData(loadable);
+  if (!grants) {
+    return undefined;
+  }
+  return grants.find((grant) => {
+    return (
+      grant.connectorRef === block.connectorRef &&
+      grant.permission === block.permission &&
+      grant.action === block.action
+    );
+  });
+}
+
 function createPermissionActionButtonState(params: {
   hasAgent: boolean;
   hasPermission: boolean;
@@ -3772,6 +3789,11 @@ function PermissionActionCard({ block }: { block: PermissionActionBlock }) {
     userGrantsLoadable,
     grantLoadableState: grantLoadable.state,
   });
+  const existingGrant = permissionActionUserGrant(userGrantsLoadable, block);
+  const grantExpiresAt =
+    grantLoadable.state === "hasData"
+      ? grantLoadable.data.expiresAt
+      : (existingGrant?.expiresAt ?? null);
 
   return (
     <PermissionActionCardContent
@@ -3785,9 +3807,7 @@ function PermissionActionCard({ block }: { block: PermissionActionBlock }) {
       onExpiresInChange={(value) => {
         setExpiresInForScope(durationScope, value);
       }}
-      expiresAt={
-        grantLoadable.state === "hasData" ? grantLoadable.data.expiresAt : null
-      }
+      expiresAt={grantExpiresAt}
       onClick={createPermissionActionHandler({
         block,
         pageSignal,

--- a/turbo/apps/platform/src/views/zero-page/zero-chat-thread-page.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-chat-thread-page.tsx
@@ -116,6 +116,7 @@ import {
   DEFAULT_USER_PERMISSION_GRANT_EXPIRES_IN,
   permissionGrantExpiresInByScope$,
   permissionGrantExpiryText,
+  requestedUserPermissionGrantExpirationAlreadyApplies,
   setPermissionGrantExpiresIn$,
 } from "../../signals/permission-allow/permission-grant-expiration.ts";
 import {
@@ -3493,15 +3494,23 @@ function isPermissionActionAlreadyApplied(params: {
   hasAgent: boolean;
   userGrantPolicy: FirewallPolicyValue | undefined;
   action: "allow" | "deny";
-  requestedExpirationChange: boolean;
+  expirationAvailable: boolean;
+  requestedExpiresIn: UserPermissionGrantExpiresIn | null;
+  currentExpiresAt: string | null | undefined;
 }): boolean {
   if (!params.hasAgent) {
     return false;
   }
-  return (
-    params.userGrantPolicy === params.action &&
-    !params.requestedExpirationChange
-  );
+  if (params.userGrantPolicy !== params.action) {
+    return false;
+  }
+  if (!params.expirationAvailable || params.action !== "allow") {
+    return true;
+  }
+  return requestedUserPermissionGrantExpirationAlreadyApplies({
+    expiresIn: params.requestedExpiresIn,
+    currentExpiresAt: params.currentExpiresAt,
+  });
 }
 
 function findPermissionActionPermission(block: PermissionActionBlock) {
@@ -3588,7 +3597,8 @@ function createPermissionActionCardViewState(params: {
   agentLoadableState: string;
   userGrantsLoadable: LoadableLike<readonly PermissionActionUserGrant[]>;
   grantLoadableState: string;
-  requestedExpirationChange: boolean;
+  expirationAvailable: boolean;
+  currentGrantExpiresAt: string | null | undefined;
 }) {
   const focusedPermission = findPermissionActionPermission(params.block);
   const actionLabel = permissionActionVerb(params.block.action);
@@ -3611,7 +3621,9 @@ function createPermissionActionCardViewState(params: {
     hasAgent: params.hasAgent,
     userGrantPolicy,
     action: params.block.action,
-    requestedExpirationChange: params.requestedExpirationChange,
+    expirationAvailable: params.expirationAvailable,
+    requestedExpiresIn: params.block.expiresIn,
+    currentExpiresAt: params.currentGrantExpiresAt,
   });
   const saveDone = params.grantLoadableState === "hasData";
   const buttonState = createPermissionActionCardButtonState({
@@ -3770,8 +3782,6 @@ function PermissionActionCard({ block }: { block: PermissionActionBlock }) {
   const expirationEnabled =
     features?.[FeatureSwitchKey.ExpiringPermissionGrants] ?? false;
   const expirationAvailable = expirationEnabled && block.action === "allow";
-  const requestedExpirationChange =
-    expirationAvailable && block.expiresIn !== null;
   const durationScope = `${block.id}\u0000${block.expiresIn ?? ""}`;
   const expiresInByScope = useGet(permissionGrantExpiresInByScope$);
   const setExpiresInForScope = useSet(setPermissionGrantExpiresIn$);
@@ -3790,15 +3800,16 @@ function PermissionActionCard({ block }: { block: PermissionActionBlock }) {
   );
   const hasAgent =
     agentLoadable.state === "hasData" && Boolean(agentLoadable.data);
+  const existingGrant = permissionActionUserGrant(userGrantsLoadable, block);
   const actionState = createPermissionActionCardViewState({
     block,
     hasAgent,
     agentLoadableState: agentLoadable.state,
     userGrantsLoadable,
     grantLoadableState: grantLoadable.state,
-    requestedExpirationChange,
+    expirationAvailable,
+    currentGrantExpiresAt: existingGrant?.expiresAt,
   });
-  const existingGrant = permissionActionUserGrant(userGrantsLoadable, block);
   const grantExpiresAt =
     grantLoadable.state === "hasData"
       ? grantLoadable.data.expiresAt

--- a/turbo/packages/api-contracts/src/contracts/index.ts
+++ b/turbo/packages/api-contracts/src/contracts/index.ts
@@ -891,10 +891,12 @@ export {
 export {
   zeroUserPermissionGrantsContract,
   userPermissionGrantActionSchema,
+  userPermissionGrantExpiresInSchema,
   userPermissionGrantResponseSchema,
   listUserPermissionGrantsQuerySchema,
   upsertUserPermissionGrantRequestSchema,
   type UserPermissionGrantAction,
+  type UserPermissionGrantExpiresIn,
   type UserPermissionGrantResponse,
   type ListUserPermissionGrantsQuery,
   type UpsertUserPermissionGrantRequest,

--- a/turbo/packages/api-contracts/src/contracts/zero-user-permission-grants.ts
+++ b/turbo/packages/api-contracts/src/contracts/zero-user-permission-grants.ts
@@ -9,6 +9,12 @@ const connectorRefSchema = z.string().min(1).max(64);
 const permissionSchema = z.string().min(1).max(128);
 
 export const userPermissionGrantActionSchema = z.enum(["allow", "deny"]);
+export const userPermissionGrantExpiresInSchema = z.enum([
+  "1h",
+  "24h",
+  "7d",
+  "forever",
+]);
 
 export const userPermissionGrantResponseSchema = z.object({
   agentId: agentIdSchema,
@@ -29,6 +35,7 @@ export const upsertUserPermissionGrantRequestSchema = z.object({
   connectorRef: connectorRefSchema,
   permission: permissionSchema,
   action: userPermissionGrantActionSchema,
+  expiresIn: userPermissionGrantExpiresInSchema.optional(),
 });
 
 export const zeroUserPermissionGrantsContract = c.router({
@@ -64,6 +71,9 @@ export const zeroUserPermissionGrantsContract = c.router({
 
 export type UserPermissionGrantAction = z.infer<
   typeof userPermissionGrantActionSchema
+>;
+export type UserPermissionGrantExpiresIn = z.infer<
+  typeof userPermissionGrantExpiresInSchema
 >;
 export type UserPermissionGrantResponse = z.infer<
   typeof userPermissionGrantResponseSchema

--- a/turbo/packages/api-contracts/src/contracts/zero-user-permission-grants.ts
+++ b/turbo/packages/api-contracts/src/contracts/zero-user-permission-grants.ts
@@ -13,7 +13,7 @@ export const userPermissionGrantExpiresInSchema = z.enum([
   "1h",
   "24h",
   "7d",
-  "forever",
+  "always",
 ]);
 
 export const userPermissionGrantResponseSchema = z.object({

--- a/turbo/packages/api-contracts/src/contracts/zero-user-permission-grants.ts
+++ b/turbo/packages/api-contracts/src/contracts/zero-user-permission-grants.ts
@@ -30,13 +30,25 @@ export const listUserPermissionGrantsQuerySchema = z.object({
   agentId: agentIdSchema,
 });
 
-export const upsertUserPermissionGrantRequestSchema = z.object({
+const upsertUserPermissionGrantBaseRequestSchema = z.object({
   agentId: agentIdSchema,
   connectorRef: connectorRefSchema,
   permission: permissionSchema,
-  action: userPermissionGrantActionSchema,
-  expiresIn: userPermissionGrantExpiresInSchema.optional(),
 });
+
+export const upsertUserPermissionGrantRequestSchema = z.discriminatedUnion(
+  "action",
+  [
+    upsertUserPermissionGrantBaseRequestSchema.extend({
+      action: z.literal("allow"),
+      expiresIn: userPermissionGrantExpiresInSchema.optional(),
+    }),
+    upsertUserPermissionGrantBaseRequestSchema.extend({
+      action: z.literal("deny"),
+      expiresIn: z.never().optional(),
+    }),
+  ],
+);
 
 export const zeroUserPermissionGrantsContract = c.router({
   list: {

--- a/turbo/packages/connectors/src/feature-switch-key.ts
+++ b/turbo/packages/connectors/src/feature-switch-key.ts
@@ -53,4 +53,5 @@ export enum FeatureSwitchKey {
   MemoryDevRefresh = "memoryDevRefresh",
   ChatRecommendedFollowups = "chatRecommendedFollowups",
   PresentationHtmlPptxDownload = "presentationHtmlPptxDownload",
+  ExpiringPermissionGrants = "expiringPermissionGrants",
 }

--- a/turbo/packages/core/src/feature-switch.ts
+++ b/turbo/packages/core/src/feature-switch.ts
@@ -304,6 +304,13 @@ const FEATURE_SWITCHES: Record<FeatureSwitchKey, FeatureSwitch> = {
     enabled: false,
     enabledOrgIdHashes: STAFF_ORG_ID_HASHES,
   },
+  [FeatureSwitchKey.ExpiringPermissionGrants]: {
+    maintainer: "liangyou@vm0.ai",
+    description:
+      "Show duration controls for explicit current-user permission grants.",
+    enabled: false,
+    enabledOrgIdHashes: STAFF_ORG_ID_HASHES,
+  },
 };
 
 interface ResolvedHashes {


### PR DESCRIPTION
## Summary
- add an optional expiresIn enum to current-user permission grant upserts and compute expiresAt server-side
- filter expired grants from API/runtime reads and platform mocks
- add duration controls to permission prompts and permission management behind ExpiringPermissionGrants
- add tests for API expiration semantics, runtime grant filtering, prompt UI, drawer editing, and expired mock grants

Closes #16533

## Testing
- pnpm format
- pnpm check-types
- pnpm turbo run lint --filter=api --filter=@vm0/app --filter=@vm0/api-contracts --filter=@vm0/connectors --filter=@vm0/core
- pnpm knip
- pnpm -F api exec vitest src/signals/routes/__tests__/zero-user-permission-grants.test.ts src/signals/routes/__tests__/zero-runs-create.test.ts
- pnpm -F @vm0/app exec vitest src/views/permission-allow/__tests__/permission-allow-page.test.tsx src/signals/chat-page/__tests__/parse-body-blocks.test.ts src/views/zero-page/__tests__/zero-chat-thread-page-display.test.tsx src/views/fw/__tests__/permissions-dialog.test.tsx src/views/zero-page/__tests__/permissions-dialog.test.tsx
- pnpm -F @vm0/app exec vitest src/views/zero-page/__tests__/zero-connectors-page.test.tsx src/views/zero-page/__tests__/zero-connectors-page-display.test.tsx src/views/conn/__tests__/add-connection-dialog.test.tsx

Notes:
- pnpm vitest was also run. It passed 10,347 tests and failed only local-environment/unrelated checks: desktop native CLI tests require macOS in this Linux container, and three connector UI tests timed out during the full concurrent run but passed when rerun directly.