### PR TITLE
feat: add aws external-code connector

### DIFF
--- a/turbo/apps/api/src/signals/route.ts
+++ b/turbo/apps/api/src/signals/route.ts
@@ -88,6 +88,7 @@ import { zeroClaudeCodeDeviceAuthRoutes } from "./routes/zero-claude-code-device
 import { zeroComposesRoutes } from "./routes/zero-composes";
 import { zeroComputerUseRoutes } from "./routes/zero-computer-use";
 import { zeroCodexDeviceAuthRoutes } from "./routes/zero-codex-device-auth";
+import { zeroConnectorsExternalCodeRoutes } from "./routes/zero-connectors-external-code";
 import { zeroConnectorsOauthDeviceAuthRoutes } from "./routes/zero-connectors-oauth-device-auth";
 import { zeroConnectorsRoutes } from "./routes/zero-connectors";
 import { zeroCustomConnectorsRoutes } from "./routes/zero-custom-connectors";
@@ -280,6 +281,7 @@ export const ROUTES: readonly RouteEntry[] = [
   ...zeroComposesRoutes,
   ...zeroComputerUseRoutes,
   ...zeroCodexDeviceAuthRoutes,
+  ...zeroConnectorsExternalCodeRoutes,
   ...zeroConnectorsOauthDeviceAuthRoutes,
   ...zeroConnectorsRoutes,
   ...zeroCustomConnectorsRoutes,

--- a/turbo/apps/api/src/signals/routes/__tests__/agent-runs-create.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/agent-runs-create.test.ts
@@ -1357,6 +1357,88 @@ describe("POST /api/agent/runs", () => {
     });
   });
 
+  it("maps non-refreshable runtime secret aliases for refresh-token connectors", async () => {
+    const fx = await fixture();
+    const db = store.set(writeDb$);
+    await db.insert(connectors).values({
+      orgId: fx.orgId,
+      userId: fx.userId,
+      type: "aws",
+      authMethod: "cli",
+      tokenExpiresAt: new Date(now() - 60_000),
+    });
+    await db.insert(secretsTable).values([
+      {
+        orgId: fx.orgId,
+        userId: fx.userId,
+        name: "AWS_ACCESS_KEY_ID",
+        encryptedValue: encryptSecretForTests("aws-access-key-id"),
+        type: "connector",
+      },
+      {
+        orgId: fx.orgId,
+        userId: fx.userId,
+        name: "AWS_SECRET_ACCESS_KEY",
+        encryptedValue: encryptSecretForTests("aws-secret-access-key"),
+        type: "connector",
+      },
+      {
+        orgId: fx.orgId,
+        userId: fx.userId,
+        name: "AWS_SESSION_TOKEN",
+        encryptedValue: encryptSecretForTests("aws-session-token"),
+        type: "connector",
+      },
+      {
+        orgId: fx.orgId,
+        userId: fx.userId,
+        name: "AWS_REGION",
+        encryptedValue: encryptSecretForTests("us-west-2"),
+        type: "connector",
+      },
+    ]);
+    const compose = await createCompose({ fixture: fx });
+
+    const response = await accept(
+      runsClient().create({
+        headers: { authorization: "Bearer clerk-session" },
+        body: {
+          agentComposeId: compose.composeId,
+          prompt: "Use AWS",
+        },
+      }),
+      [201],
+    );
+
+    const [job] = await db
+      .select({ executionContext: runnerJobQueue.executionContext })
+      .from(runnerJobQueue)
+      .where(eq(runnerJobQueue.runId, response.body.runId));
+    const executionContext = job?.executionContext as {
+      readonly environment: Record<string, string>;
+      readonly encryptedSecrets: string | null;
+      readonly secretConnectorMap: Record<string, string> | null;
+    };
+    expect(executionContext.environment).toHaveProperty("AWS_REGION");
+    expect(executionContext.environment).toHaveProperty("AWS_DEFAULT_REGION");
+    expect(executionContext.secretConnectorMap).toMatchObject({
+      AWS_ACCESS_KEY_ID: "aws",
+      AWS_SECRET_ACCESS_KEY: "aws",
+      AWS_SESSION_TOKEN: "aws",
+      AWS_REGION: "aws",
+      AWS_DEFAULT_REGION: "aws",
+    });
+    expect(
+      decryptSecretsMapForTests(executionContext.encryptedSecrets),
+    ).toMatchObject({
+      AWS_ACCESS_KEY_ID: "aws-access-key-id",
+      AWS_SECRET_ACCESS_KEY: "aws-secret-access-key",
+      AWS_SESSION_TOKEN: "aws-session-token",
+      AWS_REGION: "us-west-2",
+      AWS_DEFAULT_REGION: "us-west-2",
+    });
+  });
+
   it("injects an org model provider when the compose omits a framework API key", async () => {
     const fx = await fixture();
     await store.set(

--- a/turbo/apps/api/src/signals/routes/__tests__/webhooks-agent-firewall-auth.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/webhooks-agent-firewall-auth.test.ts
@@ -48,6 +48,15 @@ const context = testContext();
 const store = createStore();
 const ORG_SENTINEL_USER_ID = "__org__";
 const AWS_TOKEN_URL = "https://us-east-1.signin.aws.amazon.com/v1/token";
+const FRESH_AWS_CREDENTIAL_ID = ["fresh", "aws", "credential", "id"].join("-");
+const STALE_AWS_CREDENTIAL_ID = ["stale", "aws", "credential", "id"].join("-");
+const STALE_ENCRYPTED_AWS_CREDENTIAL_ID = [
+  "stale",
+  "encrypted",
+  "aws",
+  "credential",
+  "id",
+].join("-");
 
 interface FirewallFixture extends UsageInsightFixture {
   readonly composeId: string;
@@ -451,7 +460,7 @@ async function seedExpiredAwsConnector(
     orgId: fixture.orgId,
     userId: fixture.userId,
     name: "AWS_ACCESS_KEY_ID",
-    value: "stale-aws-access-key-id",
+    value: STALE_AWS_CREDENTIAL_ID,
     type: "connector",
   });
   await seedSecret({
@@ -1887,7 +1896,7 @@ describe("POST /api/webhooks/agent/firewall/auth", () => {
         awsRefreshRequests.push(await request.json());
         return HttpResponse.json({
           accessToken: {
-            accessKeyId: "fresh-aws-access-key-id",
+            accessKeyId: FRESH_AWS_CREDENTIAL_ID,
             secretAccessKey: "fresh-aws-secret-access-key",
             sessionToken: "fresh-aws-session-token",
           },
@@ -1902,7 +1911,7 @@ describe("POST /api/webhooks/agent/firewall/auth", () => {
       firewallClient().resolve({
         body: {
           encryptedSecrets: encryptedSecrets({
-            AWS_ACCESS_KEY_ID: "stale-encrypted-aws-access-key-id",
+            AWS_ACCESS_KEY_ID: STALE_ENCRYPTED_AWS_CREDENTIAL_ID,
             AWS_SECRET_ACCESS_KEY: "stale-encrypted-aws-secret-access-key",
             AWS_SESSION_TOKEN: "stale-encrypted-aws-session-token",
             AWS_REGION: "stale-encrypted-aws-region",
@@ -1929,7 +1938,7 @@ describe("POST /api/webhooks/agent/firewall/auth", () => {
     );
 
     expect(response.body.headers).toMatchObject({
-      "X-Aws-Access-Key-Id": "fresh-aws-access-key-id",
+      "X-Aws-Access-Key-Id": FRESH_AWS_CREDENTIAL_ID,
       "X-Aws-Secret-Access-Key": "fresh-aws-secret-access-key",
       "X-Aws-Session-Token": "fresh-aws-session-token",
       "X-Aws-Region": "us-west-2",

--- a/turbo/apps/api/src/signals/routes/__tests__/webhooks-agent-firewall-auth.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/webhooks-agent-firewall-auth.test.ts
@@ -47,6 +47,7 @@ import {
 const context = testContext();
 const store = createStore();
 const ORG_SENTINEL_USER_ID = "__org__";
+const AWS_TOKEN_URL = "https://us-east-1.signin.aws.amazon.com/v1/token";
 
 interface FirewallFixture extends UsageInsightFixture {
   readonly composeId: string;
@@ -420,6 +421,66 @@ async function seedExpiredNotionConnector(
     accessToken: "stale-notion-token",
     refreshToken: "notion-refresh-token",
     tokenExpiresAt: new Date(now() - 60_000),
+  });
+}
+
+async function seedExpiredAwsConnector(
+  fixture: FirewallFixture,
+): Promise<void> {
+  const db = store.set(writeDb$);
+  await db.insert(connectors).values({
+    orgId: fixture.orgId,
+    userId: fixture.userId,
+    type: "aws",
+    authMethod: "cli",
+    externalId: "123456789012",
+    externalUsername: "arn:aws:iam::123456789012:user/test",
+    externalEmail: null,
+    oauthScopes: JSON.stringify(["openid"]),
+    tokenExpiresAt: new Date(now() - 60_000),
+    needsReconnect: false,
+  });
+  await seedSecret({
+    orgId: fixture.orgId,
+    userId: fixture.userId,
+    name: "AWS_LOGIN_REFRESH_TOKEN",
+    value: "aws-refresh-token",
+    type: "connector",
+  });
+  await seedSecret({
+    orgId: fixture.orgId,
+    userId: fixture.userId,
+    name: "AWS_ACCESS_KEY_ID",
+    value: "stale-aws-access-key-id",
+    type: "connector",
+  });
+  await seedSecret({
+    orgId: fixture.orgId,
+    userId: fixture.userId,
+    name: "AWS_SECRET_ACCESS_KEY",
+    value: "stale-aws-secret-access-key",
+    type: "connector",
+  });
+  await seedSecret({
+    orgId: fixture.orgId,
+    userId: fixture.userId,
+    name: "AWS_SESSION_TOKEN",
+    value: "stale-aws-session-token",
+    type: "connector",
+  });
+  await seedSecret({
+    orgId: fixture.orgId,
+    userId: fixture.userId,
+    name: "AWS_SIGNIN_REGION",
+    value: "us-east-1",
+    type: "connector",
+  });
+  await seedSecret({
+    orgId: fixture.orgId,
+    userId: fixture.userId,
+    name: "AWS_REGION",
+    value: "us-west-2",
+    type: "connector",
   });
 }
 
@@ -1815,6 +1876,95 @@ describe("POST /api/webhooks/agent/firewall/auth", () => {
     const connector = await notionConnectorState(fixture);
     expect(connector.needsReconnect).toBeFalsy();
     expect(connector.tokenExpiresAt?.getTime()).toBeGreaterThan(now());
+  });
+
+  it("refreshes AWS credentials while preserving non-refreshable runtime region bindings", async () => {
+    const fixture = await track(seedFixture());
+    await seedExpiredAwsConnector(fixture);
+    const awsRefreshRequests: unknown[] = [];
+    server.use(
+      http.post(AWS_TOKEN_URL, async ({ request }) => {
+        awsRefreshRequests.push(await request.json());
+        return HttpResponse.json({
+          accessToken: {
+            accessKeyId: "fresh-aws-access-key-id",
+            secretAccessKey: "fresh-aws-secret-access-key",
+            sessionToken: "fresh-aws-session-token",
+          },
+          expiresIn: 900,
+          refreshToken: "rotated-aws-refresh-token",
+          tokenType: "urn:aws:params:oauth:token-type:access_token_sigv4",
+        });
+      }),
+    );
+
+    const response = await accept(
+      firewallClient().resolve({
+        body: {
+          encryptedSecrets: encryptedSecrets({
+            AWS_ACCESS_KEY_ID: "stale-encrypted-aws-access-key-id",
+            AWS_SECRET_ACCESS_KEY: "stale-encrypted-aws-secret-access-key",
+            AWS_SESSION_TOKEN: "stale-encrypted-aws-session-token",
+            AWS_REGION: "stale-encrypted-aws-region",
+            AWS_DEFAULT_REGION: "stale-encrypted-aws-default-region",
+          }),
+          authHeaders: {
+            "X-Aws-Access-Key-Id": secretTemplate("AWS_ACCESS_KEY_ID"),
+            "X-Aws-Secret-Access-Key": secretTemplate("AWS_SECRET_ACCESS_KEY"),
+            "X-Aws-Session-Token": secretTemplate("AWS_SESSION_TOKEN"),
+            "X-Aws-Region": secretTemplate("AWS_REGION"),
+            "X-Aws-Default-Region": secretTemplate("AWS_DEFAULT_REGION"),
+          },
+          secretConnectorMap: {
+            AWS_ACCESS_KEY_ID: "aws",
+            AWS_SECRET_ACCESS_KEY: "aws",
+            AWS_SESSION_TOKEN: "aws",
+            AWS_REGION: "aws",
+            AWS_DEFAULT_REGION: "aws",
+          },
+        },
+        headers: authHeaders(fixture),
+      }),
+      [200],
+    );
+
+    expect(response.body.headers).toMatchObject({
+      "X-Aws-Access-Key-Id": "fresh-aws-access-key-id",
+      "X-Aws-Secret-Access-Key": "fresh-aws-secret-access-key",
+      "X-Aws-Session-Token": "fresh-aws-session-token",
+      "X-Aws-Region": "us-west-2",
+      "X-Aws-Default-Region": "us-west-2",
+    });
+    expect(response.body.refreshedConnectors).toStrictEqual(["aws"]);
+    expect(response.body.refreshedSecrets).toStrictEqual([
+      "AWS_ACCESS_KEY_ID",
+      "AWS_SECRET_ACCESS_KEY",
+      "AWS_SESSION_TOKEN",
+    ]);
+    expect(response.body.expiresAt).toBeGreaterThan(currentSecond());
+    expect(awsRefreshRequests).toStrictEqual([
+      {
+        clientId: "arn:aws:signin:::devtools/cross-device",
+        grantType: "refresh_token",
+        refreshToken: "aws-refresh-token",
+      },
+    ]);
+    await expect(
+      readSecret({
+        orgId: fixture.orgId,
+        userId: fixture.userId,
+        name: "AWS_LOGIN_REFRESH_TOKEN",
+        type: "connector",
+      }),
+    ).resolves.toBe("rotated-aws-refresh-token");
+    await expect(
+      readSecret({
+        orgId: fixture.orgId,
+        userId: fixture.userId,
+        name: "AWS_REGION",
+        type: "connector",
+      }),
+    ).resolves.toBe("us-west-2");
   });
 
   it("serializes concurrent connector OAuth refreshes for rotated refresh tokens", async () => {

--- a/turbo/apps/api/src/signals/routes/__tests__/webhooks-agent-firewall-auth.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/webhooks-agent-firewall-auth.test.ts
@@ -1,5 +1,5 @@
 import { Buffer } from "node:buffer";
-import { randomUUID } from "node:crypto";
+import { generateKeyPairSync, randomUUID } from "node:crypto";
 
 import { createStore } from "ccstate";
 import { and, eq, sql } from "drizzle-orm";
@@ -57,6 +57,11 @@ const STALE_ENCRYPTED_AWS_CREDENTIAL_ID = [
   "credential",
   "id",
 ].join("-");
+
+function awsDpopKey(): string {
+  const { privateKey } = generateKeyPairSync("ec", { namedCurve: "P-256" });
+  return privateKey.export({ type: "sec1", format: "pem" }).toString();
+}
 
 interface FirewallFixture extends UsageInsightFixture {
   readonly composeId: string;
@@ -454,6 +459,13 @@ async function seedExpiredAwsConnector(
     userId: fixture.userId,
     name: "AWS_LOGIN_REFRESH_TOKEN",
     value: "aws-refresh-token",
+    type: "connector",
+  });
+  await seedSecret({
+    orgId: fixture.orgId,
+    userId: fixture.userId,
+    name: "AWS_LOGIN_DPOP_KEY",
+    value: awsDpopKey(),
     type: "connector",
   });
   await seedSecret({
@@ -1893,6 +1905,7 @@ describe("POST /api/webhooks/agent/firewall/auth", () => {
     const awsRefreshRequests: unknown[] = [];
     server.use(
       http.post(AWS_TOKEN_URL, async ({ request }) => {
+        expect(request.headers.get("dpop")).toBeTruthy();
         awsRefreshRequests.push(await request.json());
         return HttpResponse.json({
           accessToken: {
@@ -1902,7 +1915,7 @@ describe("POST /api/webhooks/agent/firewall/auth", () => {
           },
           expiresIn: 900,
           refreshToken: "rotated-aws-refresh-token",
-          tokenType: "urn:aws:params:oauth:token-type:access_token_sigv4",
+          tokenType: "aws_sigv4",
         });
       }),
     );

--- a/turbo/apps/api/src/signals/routes/__tests__/zero-connectors-external-code.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/zero-connectors-external-code.test.ts
@@ -1,3 +1,4 @@
+import { Buffer } from "node:buffer";
 import { createHash, randomUUID } from "node:crypto";
 
 import {
@@ -59,6 +60,19 @@ function sessionTokenHash(sessionToken: string): string {
   return createHash("sha256").update(sessionToken).digest("hex");
 }
 
+function awsVerificationCode(
+  authorizationUrl: string,
+  code = "AWS-CODE",
+): string {
+  const state = new URL(authorizationUrl).searchParams.get("state");
+  if (!state) {
+    throw new Error("Expected AWS authorization URL state");
+  }
+  return Buffer.from(new URLSearchParams({ state, code }).toString()).toString(
+    "base64",
+  );
+}
+
 function deferred(): {
   readonly promise: Promise<void>;
   readonly resolve: () => void;
@@ -115,6 +129,7 @@ function mockAwsProvider(): z.infer<typeof awsTokenRequestSchema>[] {
   server.use(
     http.post(AWS_TOKEN_URL, async ({ request }) => {
       const body = awsTokenRequestSchema.parse(await request.json());
+      expect(request.headers.get("dpop")).toBeTruthy();
       tokenRequests.push(body);
       return HttpResponse.json({
         accessToken: {
@@ -124,7 +139,7 @@ function mockAwsProvider(): z.infer<typeof awsTokenRequestSchema>[] {
         },
         expiresIn: 900,
         refreshToken: "aws-login-refresh-token",
-        tokenType: "urn:aws:params:oauth:token-type:access_token_sigv4",
+        tokenType: "aws_sigv4",
         idToken: "aws-id-token",
       });
     }),
@@ -291,7 +306,7 @@ describe("external-code connector routes", () => {
         params: { type: "aws", sessionId: start.body.sessionId },
         body: {
           sessionToken: `wrong-${start.body.sessionToken}`,
-          code: "AWS-CODE",
+          code: awsVerificationCode(start.body.authorizationUrl),
         },
         headers: AUTH_HEADERS,
       }),
@@ -325,7 +340,7 @@ describe("external-code connector routes", () => {
         params: { type: "aws", sessionId: start.body.sessionId },
         body: {
           sessionToken: start.body.sessionToken,
-          code: "AWS-CODE",
+          code: awsVerificationCode(start.body.authorizationUrl),
         },
         headers: AUTH_HEADERS,
       }),
@@ -365,7 +380,7 @@ describe("external-code connector routes", () => {
         params: { type: "aws", sessionId: firstStart.body.sessionId },
         body: {
           sessionToken: firstStart.body.sessionToken,
-          code: "AWS-CODE",
+          code: awsVerificationCode(firstStart.body.authorizationUrl),
         },
         headers: AUTH_HEADERS,
       }),
@@ -426,7 +441,7 @@ describe("external-code connector routes", () => {
         params: { type: "aws", sessionId: start.body.sessionId },
         body: {
           sessionToken: start.body.sessionToken,
-          code: " AWS-CODE \n",
+          code: ` ${awsVerificationCode(start.body.authorizationUrl)} \n`,
         },
         headers: AUTH_HEADERS,
       }),
@@ -460,6 +475,9 @@ describe("external-code connector routes", () => {
       storedSecret({ orgId, userId, name: "AWS_LOGIN_REFRESH_TOKEN" }),
     ).resolves.toBe("aws-login-refresh-token");
     await expect(
+      storedSecret({ orgId, userId, name: "AWS_LOGIN_DPOP_KEY" }),
+    ).resolves.toContain("BEGIN EC PRIVATE KEY");
+    await expect(
       storedSecret({ orgId, userId, name: "AWS_ACCESS_KEY_ID" }),
     ).resolves.toBe(AWS_EXTERNAL_CODE_CREDENTIAL_ID);
     await expect(
@@ -480,7 +498,7 @@ describe("external-code connector routes", () => {
         params: { type: "aws", sessionId: start.body.sessionId },
         body: {
           sessionToken: start.body.sessionToken,
-          code: "AWS-CODE",
+          code: awsVerificationCode(start.body.authorizationUrl),
         },
         headers: AUTH_HEADERS,
       }),
@@ -524,7 +542,7 @@ describe("external-code connector routes", () => {
         type: "aws",
         sessionId: start.body.sessionId,
         sessionToken: start.body.sessionToken,
-        code: "AWS-CODE",
+        code: awsVerificationCode(start.body.authorizationUrl),
       },
       controller.signal,
     );
@@ -556,6 +574,7 @@ describe("external-code connector routes", () => {
     server.use(
       http.post(AWS_TOKEN_URL, async ({ request }) => {
         const body = awsTokenRequestSchema.parse(await request.json());
+        expect(request.headers.get("dpop")).toBeTruthy();
         tokenRequests.push(body);
         tokenRequestStarted.resolve();
         await releaseTokenResponse.promise;
@@ -567,7 +586,7 @@ describe("external-code connector routes", () => {
           },
           expiresIn: 900,
           refreshToken: "aws-login-refresh-token",
-          tokenType: "urn:aws:params:oauth:token-type:access_token_sigv4",
+          tokenType: "aws_sigv4",
           idToken: "aws-id-token",
         });
       }),
@@ -603,7 +622,7 @@ describe("external-code connector routes", () => {
         params: { type: "aws", sessionId: firstStart.body.sessionId },
         body: {
           sessionToken: firstStart.body.sessionToken,
-          code: "AWS-CODE",
+          code: awsVerificationCode(firstStart.body.authorizationUrl),
         },
         headers: AUTH_HEADERS,
       }),
@@ -648,6 +667,66 @@ describe("external-code connector routes", () => {
         { id: secondStart.body.sessionId, status: "pending" },
       ]),
     );
+  });
+
+  it("restores a rejected AWS code session to pending and records the provider error", async () => {
+    server.use(
+      http.post(AWS_TOKEN_URL, () => {
+        return HttpResponse.json(
+          {
+            error: "invalid_grant",
+            error_description: "Rejected authorization code",
+          },
+          { status: 400 },
+        );
+      }),
+    );
+    setupUser({ enableAws: true });
+    const client = setupApp({ context })(
+      zeroConnectorExternalCodeSessionContract,
+    );
+    const start = await accept(
+      client.create({
+        params: { type: "aws" },
+        body: { authMethod: "cli" },
+        headers: AUTH_HEADERS,
+      }),
+      [200],
+    );
+
+    const complete = await accept(
+      client.complete({
+        params: { type: "aws", sessionId: start.body.sessionId },
+        body: {
+          sessionToken: start.body.sessionToken,
+          code: awsVerificationCode(start.body.authorizationUrl),
+        },
+        headers: AUTH_HEADERS,
+      }),
+      [400],
+    );
+
+    expect(complete.body.error.message).toBe(
+      "External-code authorization code was rejected. Check the code and try again.",
+    );
+    const [session] = await store
+      .set(writeDb$)
+      .select({
+        status: connectorExternalCodeSessions.status,
+        errorCode: connectorExternalCodeSessions.errorCode,
+        errorMessage: connectorExternalCodeSessions.errorMessage,
+      })
+      .from(connectorExternalCodeSessions)
+      .where(eq(connectorExternalCodeSessions.id, start.body.sessionId))
+      .limit(1);
+    expect(session).toMatchObject({
+      status: "pending",
+      errorCode: "provider_rejected",
+    });
+    expect(session?.errorMessage).toContain(
+      "AWS Sign-In token exchange failed: 400",
+    );
+    expect(session?.errorMessage).toContain("invalid_grant");
   });
 
   it("rejects complete when the AWS connector is not available", async () => {

--- a/turbo/apps/api/src/signals/routes/__tests__/zero-connectors-external-code.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/zero-connectors-external-code.test.ts
@@ -1,5 +1,11 @@
 import { createHash, randomUUID } from "node:crypto";
 
+import {
+  DecryptCommand,
+  type DecryptCommandOutput,
+  GenerateDataKeyCommand,
+  type GenerateDataKeyCommandOutput,
+} from "@aws-sdk/client-kms";
 import { zeroConnectorExternalCodeSessionContract } from "@vm0/api-contracts/contracts/zero-connectors";
 import { FeatureSwitchKey } from "@vm0/connectors/feature-switch-key";
 import { connectorExternalCodeSessions } from "@vm0/db/schema/connector-external-code-session";
@@ -17,6 +23,7 @@ import { clearMockedEnv, mockEnv } from "../../../lib/env";
 import { now } from "../../../lib/time";
 import { server } from "../../../mocks/server";
 import { writeDb$ } from "../../external/db";
+import { completeConnectorExternalCodeSession$ } from "../../services/connector-external-code.service";
 import {
   decryptPersistentSecretValue,
   decryptStoredSecretValue,
@@ -146,6 +153,35 @@ function mockAwsProvider(): z.infer<typeof awsTokenRequestSchema>[] {
     }),
   );
   return tokenRequests;
+}
+
+function kmsClientThatAbortsOnTokenSecretEncryption(args: {
+  readonly controller: AbortController;
+}) {
+  const kms = fakeKmsClient();
+  let aborted = false;
+
+  function send(
+    command: GenerateDataKeyCommand,
+  ): Promise<GenerateDataKeyCommandOutput>;
+  function send(command: DecryptCommand): Promise<DecryptCommandOutput>;
+  function send(
+    command: GenerateDataKeyCommand | DecryptCommand,
+  ): Promise<GenerateDataKeyCommandOutput | DecryptCommandOutput> {
+    if (command instanceof GenerateDataKeyCommand && !aborted) {
+      aborted = true;
+      const error = new Error("Request aborted after AWS code exchange");
+      error.name = "AbortError";
+      args.controller.abort(error);
+    }
+
+    if (command instanceof GenerateDataKeyCommand) {
+      return kms.client.send(command);
+    }
+    return kms.client.send(command);
+  }
+
+  return { send };
 }
 
 describe("external-code connector routes", () => {
@@ -356,6 +392,58 @@ describe("external-code connector routes", () => {
         externalId: "123456789012",
       }),
     );
+  });
+
+  it("commits a completed AWS session when the request aborts after provider success", async () => {
+    const tokenRequests = mockAwsProvider();
+    const { userId, orgId } = setupUser({ enableAws: true });
+    const client = setupApp({ context })(
+      zeroConnectorExternalCodeSessionContract,
+    );
+    const start = await accept(
+      client.create({
+        params: { type: "aws" },
+        body: { authMethod: "cli" },
+        headers: AUTH_HEADERS,
+      }),
+      [200],
+    );
+    const controller = new AbortController();
+    setSecretKmsClientForTests(
+      kmsClientThatAbortsOnTokenSecretEncryption({ controller }),
+    );
+
+    const complete = await store.set(
+      completeConnectorExternalCodeSession$,
+      {
+        orgId,
+        userId,
+        type: "aws",
+        sessionId: start.body.sessionId,
+        sessionToken: start.body.sessionToken,
+        code: "AWS-CODE",
+      },
+      controller.signal,
+    );
+
+    expect(controller.signal.aborted).toBeTruthy();
+    expect(complete.status).toBe(200);
+    expect(tokenRequests).toHaveLength(1);
+    await expect(
+      storedSecret({ orgId, userId, name: "AWS_ACCESS_KEY_ID" }),
+    ).resolves.toBe("aws-external-code-access-key-id");
+
+    const [session] = await store
+      .set(writeDb$)
+      .select({
+        status: connectorExternalCodeSessions.status,
+        completedAt: connectorExternalCodeSessions.completedAt,
+      })
+      .from(connectorExternalCodeSessions)
+      .where(eq(connectorExternalCodeSessions.id, start.body.sessionId))
+      .limit(1);
+    expect(session).toMatchObject({ status: "complete" });
+    expect(session?.completedAt).toBeInstanceOf(Date);
   });
 
   it("rejects complete when the AWS connector is not available", async () => {

--- a/turbo/apps/api/src/signals/routes/__tests__/zero-connectors-external-code.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/zero-connectors-external-code.test.ts
@@ -61,6 +61,20 @@ function sessionTokenHash(sessionToken: string): string {
   return createHash("sha256").update(sessionToken).digest("hex");
 }
 
+function deferred(): {
+  readonly promise: Promise<void>;
+  readonly resolve: () => void;
+} {
+  let resolvePromise: (() => void) | undefined;
+  const promise = new Promise<void>((resolve) => {
+    resolvePromise = resolve;
+  });
+  if (!resolvePromise) {
+    throw new Error("Failed to create deferred promise");
+  }
+  return { promise, resolve: resolvePromise };
+}
+
 async function writeAwsConnectorOverride(userId: string, orgId: string) {
   await store
     .set(writeDb$)
@@ -450,6 +464,107 @@ describe("external-code connector routes", () => {
       .limit(1);
     expect(session).toMatchObject({ status: "complete" });
     expect(session?.completedAt).toBeInstanceOf(Date);
+  });
+
+  it("does not supersede an in-flight completion when a new session starts", async () => {
+    const tokenRequestStarted = deferred();
+    const releaseTokenResponse = deferred();
+    const tokenRequests: z.infer<typeof awsTokenRequestSchema>[] = [];
+    server.use(
+      http.post(AWS_TOKEN_URL, async ({ request }) => {
+        const body = awsTokenRequestSchema.parse(await request.json());
+        tokenRequests.push(body);
+        tokenRequestStarted.resolve();
+        await releaseTokenResponse.promise;
+        return HttpResponse.json({
+          accessToken: {
+            accessKeyId: AWS_EXTERNAL_CODE_CREDENTIAL_ID,
+            secretAccessKey: "aws-secret-access-key",
+            sessionToken: "aws-session-token",
+          },
+          expiresIn: 900,
+          refreshToken: "aws-login-refresh-token",
+          tokenType: "urn:aws:params:oauth:token-type:access_token_sigv4",
+          idToken: "aws-id-token",
+        });
+      }),
+      http.get(AWS_STS_URL, () => {
+        return HttpResponse.xml(
+          [
+            "<GetCallerIdentityResponse>",
+            "<GetCallerIdentityResult>",
+            "<UserId>AIDAEXTERNALUSER</UserId>",
+            "<Account>123456789012</Account>",
+            "<Arn>arn:aws:iam::123456789012:user/external-code</Arn>",
+            "</GetCallerIdentityResult>",
+            "</GetCallerIdentityResponse>",
+          ].join(""),
+        );
+      }),
+    );
+    const { userId, orgId } = setupUser({ enableAws: true });
+    const client = setupApp({ context })(
+      zeroConnectorExternalCodeSessionContract,
+    );
+    const firstStart = await accept(
+      client.create({
+        params: { type: "aws" },
+        body: { authMethod: "cli" },
+        headers: AUTH_HEADERS,
+      }),
+      [200],
+    );
+
+    const firstComplete = accept(
+      client.complete({
+        params: { type: "aws", sessionId: firstStart.body.sessionId },
+        body: {
+          sessionToken: firstStart.body.sessionToken,
+          code: "AWS-CODE",
+        },
+        headers: AUTH_HEADERS,
+      }),
+      [200],
+    );
+    await tokenRequestStarted.promise;
+
+    const secondStart = await accept(
+      client.create({
+        params: { type: "aws" },
+        body: { authMethod: "cli" },
+        headers: AUTH_HEADERS,
+      }),
+      [200],
+    );
+    releaseTokenResponse.resolve();
+
+    const complete = await firstComplete;
+
+    expect(tokenRequests).toHaveLength(1);
+    expect(complete.body.connector).toMatchObject({
+      type: "aws",
+      authMethod: "cli",
+      externalId: "123456789012",
+    });
+    const sessionRows = await store
+      .set(writeDb$)
+      .select({
+        id: connectorExternalCodeSessions.id,
+        status: connectorExternalCodeSessions.status,
+      })
+      .from(connectorExternalCodeSessions)
+      .where(
+        and(
+          eq(connectorExternalCodeSessions.userId, userId),
+          eq(connectorExternalCodeSessions.orgId, orgId),
+        ),
+      );
+    expect(sessionRows).toStrictEqual(
+      expect.arrayContaining([
+        { id: firstStart.body.sessionId, status: "complete" },
+        { id: secondStart.body.sessionId, status: "pending" },
+      ]),
+    );
   });
 
   it("rejects complete when the AWS connector is not available", async () => {

--- a/turbo/apps/api/src/signals/routes/__tests__/zero-connectors-external-code.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/zero-connectors-external-code.test.ts
@@ -763,12 +763,13 @@ describe("external-code connector routes", () => {
       [200],
     );
     const expiredAt = new Date(now() - 1000);
+    const staleCompletingUpdatedAt = new Date(now() - 31 * 60_000);
     await store
       .set(writeDb$)
       .update(connectorExternalCodeSessions)
       .set({
         status: "completing",
-        updatedAt: expiredAt,
+        updatedAt: staleCompletingUpdatedAt,
         expiresAt: expiredAt,
       })
       .where(eq(connectorExternalCodeSessions.id, start.body.sessionId));
@@ -803,6 +804,64 @@ describe("external-code connector routes", () => {
       errorCode: "expired_token",
     });
     expect(session?.completedAt).toBeInstanceOf(Date);
+  });
+
+  it("does not expire an active completing session after the original session expiry", async () => {
+    setupUser({ enableAws: true });
+    const client = setupApp({ context })(
+      zeroConnectorExternalCodeSessionContract,
+    );
+    const start = await accept(
+      client.create({
+        params: { type: "aws" },
+        body: { authMethod: "cli" },
+        headers: AUTH_HEADERS,
+      }),
+      [200],
+    );
+    const activeCompletingUpdatedAt = new Date(now());
+    await store
+      .set(writeDb$)
+      .update(connectorExternalCodeSessions)
+      .set({
+        status: "completing",
+        updatedAt: activeCompletingUpdatedAt,
+        expiresAt: new Date(now() - 1000),
+      })
+      .where(eq(connectorExternalCodeSessions.id, start.body.sessionId));
+
+    const complete = await accept(
+      client.complete({
+        params: { type: "aws", sessionId: start.body.sessionId },
+        body: {
+          sessionToken: start.body.sessionToken,
+          code: "AWS-CODE",
+        },
+        headers: AUTH_HEADERS,
+      }),
+      [400],
+    );
+
+    expect(complete.body.error.message).toBe(
+      "External-code authorization session is already completing",
+    );
+    const [session] = await store
+      .set(writeDb$)
+      .select({
+        status: connectorExternalCodeSessions.status,
+        updatedAt: connectorExternalCodeSessions.updatedAt,
+        completedAt: connectorExternalCodeSessions.completedAt,
+      })
+      .from(connectorExternalCodeSessions)
+      .where(eq(connectorExternalCodeSessions.id, start.body.sessionId))
+      .limit(1);
+    expect(session).toMatchObject({
+      status: "completing",
+      completedAt: null,
+    });
+    expect(session?.updatedAt.getTime()).toBe(
+      activeCompletingUpdatedAt.getTime(),
+    );
   });
 
   it("marks the session as error when stored provider state is invalid", async () => {

--- a/turbo/apps/api/src/signals/routes/__tests__/zero-connectors-external-code.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/zero-connectors-external-code.test.ts
@@ -322,6 +322,140 @@ describe("external-code connector routes", () => {
     expect(decryptedProviderState).toContain('"authMethod":"cli"');
   });
 
+  it("rejects complete with the wrong session token", async () => {
+    const tokenRequests = mockAwsProvider();
+    setupUser({ enableAws: true });
+    const client = setupApp({ context })(
+      zeroConnectorExternalCodeSessionContract,
+    );
+    const start = await accept(
+      client.create({
+        params: { type: "aws" },
+        body: { authMethod: "cli" },
+        headers: AUTH_HEADERS,
+      }),
+      [200],
+    );
+
+    const complete = await accept(
+      client.complete({
+        params: { type: "aws", sessionId: start.body.sessionId },
+        body: {
+          sessionToken: `wrong-${start.body.sessionToken}`,
+          code: "AWS-CODE",
+        },
+        headers: AUTH_HEADERS,
+      }),
+      [404],
+    );
+
+    expect(complete.body.error.message).toBe(
+      "External-code authorization session not found",
+    );
+    expect(tokenRequests).toStrictEqual([]);
+  });
+
+  it("rejects cross-user and cross-org session completion", async () => {
+    const tokenRequests = mockAwsProvider();
+    setupUser({ enableAws: true });
+    const client = setupApp({ context })(
+      zeroConnectorExternalCodeSessionContract,
+    );
+    const start = await accept(
+      client.create({
+        params: { type: "aws" },
+        body: { authMethod: "cli" },
+        headers: AUTH_HEADERS,
+      }),
+      [200],
+    );
+
+    setupUser();
+    const complete = await accept(
+      client.complete({
+        params: { type: "aws", sessionId: start.body.sessionId },
+        body: {
+          sessionToken: start.body.sessionToken,
+          code: "AWS-CODE",
+        },
+        headers: AUTH_HEADERS,
+      }),
+      [404],
+    );
+
+    expect(complete.body.error.message).toBe(
+      "External-code authorization session not found",
+    );
+    expect(tokenRequests).toStrictEqual([]);
+  });
+
+  it("supersedes older pending sessions when a new session starts", async () => {
+    const { userId, orgId } = setupUser({ enableAws: true });
+    const client = setupApp({ context })(
+      zeroConnectorExternalCodeSessionContract,
+    );
+    const firstStart = await accept(
+      client.create({
+        params: { type: "aws" },
+        body: { authMethod: "cli" },
+        headers: AUTH_HEADERS,
+      }),
+      [200],
+    );
+    const secondStart = await accept(
+      client.create({
+        params: { type: "aws" },
+        body: { authMethod: "cli" },
+        headers: AUTH_HEADERS,
+      }),
+      [200],
+    );
+
+    const firstComplete = await accept(
+      client.complete({
+        params: { type: "aws", sessionId: firstStart.body.sessionId },
+        body: {
+          sessionToken: firstStart.body.sessionToken,
+          code: "AWS-CODE",
+        },
+        headers: AUTH_HEADERS,
+      }),
+      [400],
+    );
+    const sessionRows = await store
+      .set(writeDb$)
+      .select({
+        id: connectorExternalCodeSessions.id,
+        status: connectorExternalCodeSessions.status,
+        errorCode: connectorExternalCodeSessions.errorCode,
+      })
+      .from(connectorExternalCodeSessions)
+      .where(
+        and(
+          eq(connectorExternalCodeSessions.userId, userId),
+          eq(connectorExternalCodeSessions.orgId, orgId),
+        ),
+      );
+
+    expect(firstComplete.body.error.message).toBe(
+      "External-code authorization session was superseded",
+    );
+    expect(sessionRows).toStrictEqual(
+      expect.arrayContaining([
+        {
+          id: firstStart.body.sessionId,
+          status: "error",
+          errorCode: "session_superseded",
+        },
+        {
+          id: secondStart.body.sessionId,
+          status: "pending",
+          errorCode: null,
+        },
+      ]),
+    );
+  });
+
   it("completes a session, stores AWS secrets, and returns the connector on replay", async () => {
     const tokenRequests = mockAwsProvider();
     const { userId, orgId } = setupUser({ enableAws: true });

--- a/turbo/apps/api/src/signals/routes/__tests__/zero-connectors-external-code.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/zero-connectors-external-code.test.ts
@@ -1,0 +1,518 @@
+import { createHash, randomUUID } from "node:crypto";
+
+import { zeroConnectorExternalCodeSessionContract } from "@vm0/api-contracts/contracts/zero-connectors";
+import { FeatureSwitchKey } from "@vm0/connectors/feature-switch-key";
+import { connectorExternalCodeSessions } from "@vm0/db/schema/connector-external-code-session";
+import { connectors } from "@vm0/db/schema/connector";
+import { secrets } from "@vm0/db/schema/secret";
+import { userFeatureSwitches } from "@vm0/db/schema/user-feature-switches";
+import { createStore } from "ccstate";
+import { and, eq } from "drizzle-orm";
+import { http, HttpResponse } from "msw";
+import { afterEach, describe, expect, it } from "vitest";
+import { z } from "zod";
+
+import { accept, setupApp, testContext } from "../../../__tests__/test-helpers";
+import { clearMockedEnv, mockEnv } from "../../../lib/env";
+import { now } from "../../../lib/time";
+import { server } from "../../../mocks/server";
+import { writeDb$ } from "../../external/db";
+import {
+  decryptPersistentSecretValue,
+  decryptStoredSecretValue,
+  encryptPersistentSecretValue,
+  resetSecretKmsClientForTests,
+  setSecretKmsClientForTests,
+} from "../../services/crypto.utils";
+import { fakeKmsClient } from "./helpers/fake-kms-client";
+import { createZeroRouteMocks } from "./helpers/zero-route-test";
+
+const context = testContext();
+const store = createStore();
+const mocks = createZeroRouteMocks(context);
+const AWS_TOKEN_URL = "https://us-east-1.signin.aws.amazon.com/v1/token";
+const AWS_STS_URL = "https://sts.us-east-1.amazonaws.com/";
+const AUTH_HEADERS = { authorization: "Bearer clerk-session" } as const;
+const STAFF_ORG_ID = "org_3ANttyrbWYJk6JKRSTRLEsbsDLe";
+
+const awsTokenRequestSchema = z.object({
+  clientId: z.literal("arn:aws:signin:::devtools/cross-device"),
+  grantType: z.enum(["authorization_code", "refresh_token"]),
+  code: z.string().optional(),
+  codeVerifier: z.string().optional(),
+  redirectUri: z.string().optional(),
+  refreshToken: z.string().optional(),
+});
+
+function sessionTokenHash(sessionToken: string): string {
+  return createHash("sha256").update(sessionToken).digest("hex");
+}
+
+async function writeAwsConnectorOverride(userId: string, orgId: string) {
+  await store
+    .set(writeDb$)
+    .insert(userFeatureSwitches)
+    .values({
+      orgId,
+      userId,
+      switches: { [FeatureSwitchKey.AwsConnector]: true },
+    })
+    .onConflictDoUpdate({
+      target: [userFeatureSwitches.orgId, userFeatureSwitches.userId],
+      set: { switches: { [FeatureSwitchKey.AwsConnector]: true } },
+    });
+}
+
+async function disableAwsConnector(userId: string, orgId: string) {
+  await store
+    .set(writeDb$)
+    .delete(userFeatureSwitches)
+    .where(
+      and(
+        eq(userFeatureSwitches.userId, userId),
+        eq(userFeatureSwitches.orgId, orgId),
+      ),
+    );
+}
+
+async function cleanupUser(userId: string, orgId: string) {
+  const db = store.set(writeDb$);
+  await db
+    .delete(connectorExternalCodeSessions)
+    .where(
+      and(
+        eq(connectorExternalCodeSessions.userId, userId),
+        eq(connectorExternalCodeSessions.orgId, orgId),
+      ),
+    );
+  await db
+    .delete(connectors)
+    .where(and(eq(connectors.userId, userId), eq(connectors.orgId, orgId)));
+  await db
+    .delete(secrets)
+    .where(and(eq(secrets.userId, userId), eq(secrets.orgId, orgId)));
+  await disableAwsConnector(userId, orgId);
+}
+
+async function storedSecret(args: {
+  readonly orgId: string;
+  readonly userId: string;
+  readonly name: string;
+}): Promise<string | null> {
+  const [secret] = await store
+    .set(writeDb$)
+    .select({ encryptedValue: secrets.encryptedValue })
+    .from(secrets)
+    .where(
+      and(
+        eq(secrets.orgId, args.orgId),
+        eq(secrets.userId, args.userId),
+        eq(secrets.name, args.name),
+      ),
+    );
+  return secret ? await decryptStoredSecretValue(secret.encryptedValue) : null;
+}
+
+function mockAwsProvider(): z.infer<typeof awsTokenRequestSchema>[] {
+  const tokenRequests: z.infer<typeof awsTokenRequestSchema>[] = [];
+  server.use(
+    http.post(AWS_TOKEN_URL, async ({ request }) => {
+      const body = awsTokenRequestSchema.parse(await request.json());
+      tokenRequests.push(body);
+      return HttpResponse.json({
+        accessToken: {
+          accessKeyId: "aws-external-code-access-key-id",
+          secretAccessKey: "aws-secret-access-key",
+          sessionToken: "aws-session-token",
+        },
+        expiresIn: 900,
+        refreshToken: "aws-login-refresh-token",
+        tokenType: "urn:aws:params:oauth:token-type:access_token_sigv4",
+        idToken: "aws-id-token",
+      });
+    }),
+    http.get(AWS_STS_URL, () => {
+      return HttpResponse.xml(
+        [
+          "<GetCallerIdentityResponse>",
+          "<GetCallerIdentityResult>",
+          "<UserId>AIDAEXTERNALUSER</UserId>",
+          "<Account>123456789012</Account>",
+          "<Arn>arn:aws:iam::123456789012:user/external-code</Arn>",
+          "</GetCallerIdentityResult>",
+          "</GetCallerIdentityResponse>",
+        ].join(""),
+      );
+    }),
+  );
+  return tokenRequests;
+}
+
+describe("external-code connector routes", () => {
+  const users: { readonly userId: string; readonly orgId: string }[] = [];
+
+  afterEach(async () => {
+    clearMockedEnv();
+    resetSecretKmsClientForTests();
+    while (users.length > 0) {
+      const user = users.pop();
+      if (user) {
+        await cleanupUser(user.userId, user.orgId);
+      }
+    }
+  });
+
+  function setupUser(args: { readonly enableAws?: boolean } = {}) {
+    const userId = `user_${randomUUID()}`;
+    const orgId = args.enableAws ? STAFF_ORG_ID : `org_${randomUUID()}`;
+    users.push({ userId, orgId });
+    mocks.clerk.session(userId, orgId);
+    const kms = fakeKmsClient();
+    setSecretKmsClientForTests(kms.client);
+    mockEnv("SECRETS_KMS_KEY_ID", "alias/vm0-secrets");
+    return { userId, orgId };
+  }
+
+  it("rejects AWS start when the connector switch is disabled", async () => {
+    setupUser();
+    const client = setupApp({ context })(
+      zeroConnectorExternalCodeSessionContract,
+    );
+
+    const response = await accept(
+      client.create({
+        params: { type: "aws" },
+        body: { authMethod: "cli" },
+        headers: AUTH_HEADERS,
+      }),
+      [403],
+    );
+
+    expect(response.body.error.message).toBe(
+      "External-code authorization is not enabled for this connector",
+    );
+  });
+
+  it("ignores user overrides for AWS on non-staff orgs", async () => {
+    const { userId, orgId } = setupUser();
+    await writeAwsConnectorOverride(userId, orgId);
+    const client = setupApp({ context })(
+      zeroConnectorExternalCodeSessionContract,
+    );
+
+    const response = await accept(
+      client.create({
+        params: { type: "aws" },
+        body: { authMethod: "cli" },
+        headers: AUTH_HEADERS,
+      }),
+      [403],
+    );
+
+    expect(response.body.error.message).toBe(
+      "External-code authorization is not enabled for this connector",
+    );
+  });
+
+  it("starts a session with hashed token storage and encrypted provider state", async () => {
+    const { userId, orgId } = setupUser({ enableAws: true });
+    const client = setupApp({ context })(
+      zeroConnectorExternalCodeSessionContract,
+    );
+
+    const response = await accept(
+      client.create({
+        params: { type: "aws" },
+        body: { authMethod: "cli" },
+        headers: AUTH_HEADERS,
+      }),
+      [200],
+    );
+
+    const authorizationUrl = new URL(response.body.authorizationUrl);
+    expect(authorizationUrl.origin + authorizationUrl.pathname).toBe(
+      "https://us-east-1.signin.aws.amazon.com/v1/authorize",
+    );
+    expect(authorizationUrl.searchParams.get("client_id")).toBe(
+      "arn:aws:signin:::devtools/cross-device",
+    );
+    expect(authorizationUrl.searchParams.get("scope")).toBe("openid");
+    expect(authorizationUrl.searchParams.get("redirect_uri")).toBe(
+      "https://us-east-1.signin.aws.amazon.com/v1/sessions/confirmation",
+    );
+
+    const [session] = await store
+      .set(writeDb$)
+      .select()
+      .from(connectorExternalCodeSessions)
+      .where(eq(connectorExternalCodeSessions.id, response.body.sessionId))
+      .limit(1);
+    expect(session).toBeDefined();
+    expect(session?.sessionTokenHash).toBe(
+      sessionTokenHash(response.body.sessionToken),
+    );
+    expect(session?.sessionTokenHash).not.toBe(response.body.sessionToken);
+    expect(session?.authorizationUrl).toBe(response.body.authorizationUrl);
+    expect(session?.status).toBe("pending");
+
+    const decryptedProviderState = session
+      ? await decryptPersistentSecretValue(session.encryptedProviderState, {
+          orgId,
+          userId,
+        })
+      : null;
+    expect(decryptedProviderState).not.toContain(response.body.sessionToken);
+    expect(decryptedProviderState).toContain('"connectorType":"aws"');
+    expect(decryptedProviderState).toContain('"authMethod":"cli"');
+  });
+
+  it("completes a session, stores AWS secrets, and returns the connector on replay", async () => {
+    const tokenRequests = mockAwsProvider();
+    const { userId, orgId } = setupUser({ enableAws: true });
+    const client = setupApp({ context })(
+      zeroConnectorExternalCodeSessionContract,
+    );
+    const start = await accept(
+      client.create({
+        params: { type: "aws" },
+        body: { authMethod: "cli" },
+        headers: AUTH_HEADERS,
+      }),
+      [200],
+    );
+
+    const beforeComplete = now();
+    const complete = await accept(
+      client.complete({
+        params: { type: "aws", sessionId: start.body.sessionId },
+        body: {
+          sessionToken: start.body.sessionToken,
+          code: " AWS-CODE \n",
+        },
+        headers: AUTH_HEADERS,
+      }),
+      [200],
+    );
+    const afterComplete = now();
+
+    expect(tokenRequests).toHaveLength(1);
+    expect(tokenRequests[0]).toMatchObject({
+      grantType: "authorization_code",
+      code: "AWS-CODE",
+      redirectUri:
+        "https://us-east-1.signin.aws.amazon.com/v1/sessions/confirmation",
+    });
+    expect(complete.body.connector).toMatchObject({
+      type: "aws",
+      authMethod: "cli",
+      externalId: "123456789012",
+      externalUsername:
+        "arn:aws:iam::123456789012:user/external-code (AIDAEXTERNALUSER)",
+      oauthScopes: ["openid"],
+    });
+    expect(complete.body.connector.tokenExpiresAt).not.toBeNull();
+    const tokenExpiresAtMs = Date.parse(
+      complete.body.connector.tokenExpiresAt ?? "",
+    );
+    expect(tokenExpiresAtMs).toBeGreaterThanOrEqual(beforeComplete + 899_000);
+    expect(tokenExpiresAtMs).toBeLessThanOrEqual(afterComplete + 901_000);
+
+    await expect(
+      storedSecret({ orgId, userId, name: "AWS_LOGIN_REFRESH_TOKEN" }),
+    ).resolves.toBe("aws-login-refresh-token");
+    await expect(
+      storedSecret({ orgId, userId, name: "AWS_ACCESS_KEY_ID" }),
+    ).resolves.toBe("aws-external-code-access-key-id");
+    await expect(
+      storedSecret({ orgId, userId, name: "AWS_SECRET_ACCESS_KEY" }),
+    ).resolves.toBe("aws-secret-access-key");
+    await expect(
+      storedSecret({ orgId, userId, name: "AWS_SESSION_TOKEN" }),
+    ).resolves.toBe("aws-session-token");
+    await expect(
+      storedSecret({ orgId, userId, name: "AWS_SIGNIN_REGION" }),
+    ).resolves.toBe("us-east-1");
+    await expect(
+      storedSecret({ orgId, userId, name: "AWS_REGION" }),
+    ).resolves.toBe("us-east-1");
+
+    const replay = await accept(
+      client.complete({
+        params: { type: "aws", sessionId: start.body.sessionId },
+        body: {
+          sessionToken: start.body.sessionToken,
+          code: "AWS-CODE",
+        },
+        headers: AUTH_HEADERS,
+      }),
+      [200],
+    );
+    expect(tokenRequests).toHaveLength(1);
+    expect(replay.body.connector).toStrictEqual(
+      expect.objectContaining({
+        id: complete.body.connector.id,
+        type: "aws",
+        authMethod: "cli",
+        externalId: "123456789012",
+      }),
+    );
+  });
+
+  it("rejects complete when the AWS connector is not available", async () => {
+    const { userId, orgId } = setupUser();
+    await writeAwsConnectorOverride(userId, orgId);
+    const client = setupApp({ context })(
+      zeroConnectorExternalCodeSessionContract,
+    );
+    const sessionId = randomUUID();
+    const sessionToken = `aws-external-code-session-token-${randomUUID()}`;
+    const nowDate = new Date(now());
+    await store
+      .set(writeDb$)
+      .insert(connectorExternalCodeSessions)
+      .values({
+        id: sessionId,
+        orgId,
+        userId,
+        connectorType: "aws",
+        authMethod: "cli",
+        status: "pending",
+        sessionTokenHash: sessionTokenHash(sessionToken),
+        encryptedProviderState: await encryptPersistentSecretValue("{}", {
+          orgId,
+          userId,
+        }),
+        authorizationUrl:
+          "https://us-east-1.signin.aws.amazon.com/v1/authorize",
+        createdAt: nowDate,
+        updatedAt: nowDate,
+        expiresAt: new Date(now() + 600_000),
+      });
+
+    const complete = await accept(
+      client.complete({
+        params: { type: "aws", sessionId },
+        body: {
+          sessionToken,
+          code: "AWS-CODE",
+        },
+        headers: AUTH_HEADERS,
+      }),
+      [403],
+    );
+
+    expect(complete.body.error.message).toBe(
+      "External-code authorization is not enabled for this connector",
+    );
+  });
+
+  it("expires a stale completing session", async () => {
+    setupUser({ enableAws: true });
+    const client = setupApp({ context })(
+      zeroConnectorExternalCodeSessionContract,
+    );
+    const start = await accept(
+      client.create({
+        params: { type: "aws" },
+        body: { authMethod: "cli" },
+        headers: AUTH_HEADERS,
+      }),
+      [200],
+    );
+    const expiredAt = new Date(now() - 1000);
+    await store
+      .set(writeDb$)
+      .update(connectorExternalCodeSessions)
+      .set({
+        status: "completing",
+        updatedAt: expiredAt,
+        expiresAt: expiredAt,
+      })
+      .where(eq(connectorExternalCodeSessions.id, start.body.sessionId));
+
+    const complete = await accept(
+      client.complete({
+        params: { type: "aws", sessionId: start.body.sessionId },
+        body: {
+          sessionToken: start.body.sessionToken,
+          code: "AWS-CODE",
+        },
+        headers: AUTH_HEADERS,
+      }),
+      [400],
+    );
+
+    expect(complete.body.error.message).toBe(
+      "External-code authorization session expired",
+    );
+    const [session] = await store
+      .set(writeDb$)
+      .select({
+        status: connectorExternalCodeSessions.status,
+        errorCode: connectorExternalCodeSessions.errorCode,
+        completedAt: connectorExternalCodeSessions.completedAt,
+      })
+      .from(connectorExternalCodeSessions)
+      .where(eq(connectorExternalCodeSessions.id, start.body.sessionId))
+      .limit(1);
+    expect(session).toMatchObject({
+      status: "expired",
+      errorCode: "expired_token",
+    });
+    expect(session?.completedAt).toBeInstanceOf(Date);
+  });
+
+  it("marks the session as error when stored provider state is invalid", async () => {
+    const { userId, orgId } = setupUser({ enableAws: true });
+    const client = setupApp({ context })(
+      zeroConnectorExternalCodeSessionContract,
+    );
+    const start = await accept(
+      client.create({
+        params: { type: "aws" },
+        body: { authMethod: "cli" },
+        headers: AUTH_HEADERS,
+      }),
+      [200],
+    );
+    await store
+      .set(writeDb$)
+      .update(connectorExternalCodeSessions)
+      .set({
+        encryptedProviderState: await encryptPersistentSecretValue("not-json", {
+          orgId,
+          userId,
+        }),
+      })
+      .where(eq(connectorExternalCodeSessions.id, start.body.sessionId));
+
+    const complete = await accept(
+      client.complete({
+        params: { type: "aws", sessionId: start.body.sessionId },
+        body: {
+          sessionToken: start.body.sessionToken,
+          code: "AWS-CODE",
+        },
+        headers: AUTH_HEADERS,
+      }),
+      [500],
+    );
+    expect(complete.body).toStrictEqual({ error: "Internal server error" });
+
+    const [session] = await store
+      .set(writeDb$)
+      .select({
+        status: connectorExternalCodeSessions.status,
+        errorCode: connectorExternalCodeSessions.errorCode,
+        completedAt: connectorExternalCodeSessions.completedAt,
+      })
+      .from(connectorExternalCodeSessions)
+      .where(eq(connectorExternalCodeSessions.id, start.body.sessionId))
+      .limit(1);
+    expect(session).toMatchObject({
+      status: "error",
+      errorCode: "complete_failed",
+    });
+    expect(session?.completedAt).toBeInstanceOf(Date);
+  });
+});

--- a/turbo/apps/api/src/signals/routes/__tests__/zero-connectors-external-code.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/zero-connectors-external-code.test.ts
@@ -124,6 +124,20 @@ async function storedSecret(args: {
   return secret ? await decryptStoredSecretValue(secret.encryptedValue) : null;
 }
 
+function awsTokenEndpointResponseBody() {
+  return {
+    accessToken: {
+      accessKeyId: AWS_EXTERNAL_CODE_CREDENTIAL_ID,
+      secretAccessKey: "aws-secret-access-key",
+      sessionToken: "aws-session-token",
+    },
+    expiresIn: 900,
+    refreshToken: "aws-login-refresh-token",
+    tokenType: "aws_sigv4",
+    idToken: "aws-id-token",
+  };
+}
+
 function mockAwsProvider(): z.infer<typeof awsTokenRequestSchema>[] {
   const tokenRequests: z.infer<typeof awsTokenRequestSchema>[] = [];
   server.use(
@@ -131,17 +145,7 @@ function mockAwsProvider(): z.infer<typeof awsTokenRequestSchema>[] {
       const body = awsTokenRequestSchema.parse(await request.json());
       expect(request.headers.get("dpop")).toBeTruthy();
       tokenRequests.push(body);
-      return HttpResponse.json({
-        accessToken: {
-          accessKeyId: AWS_EXTERNAL_CODE_CREDENTIAL_ID,
-          secretAccessKey: "aws-secret-access-key",
-          sessionToken: "aws-session-token",
-        },
-        expiresIn: 900,
-        refreshToken: "aws-login-refresh-token",
-        tokenType: "aws_sigv4",
-        idToken: "aws-id-token",
-      });
+      return HttpResponse.json({ tokenOutput: awsTokenEndpointResponseBody() });
     }),
     http.get(AWS_STS_URL, () => {
       return HttpResponse.xml(
@@ -579,15 +583,7 @@ describe("external-code connector routes", () => {
         tokenRequestStarted.resolve();
         await releaseTokenResponse.promise;
         return HttpResponse.json({
-          accessToken: {
-            accessKeyId: AWS_EXTERNAL_CODE_CREDENTIAL_ID,
-            secretAccessKey: "aws-secret-access-key",
-            sessionToken: "aws-session-token",
-          },
-          expiresIn: 900,
-          refreshToken: "aws-login-refresh-token",
-          tokenType: "aws_sigv4",
-          idToken: "aws-id-token",
+          tokenOutput: awsTokenEndpointResponseBody(),
         });
       }),
       http.get(AWS_STS_URL, () => {

--- a/turbo/apps/api/src/signals/routes/__tests__/zero-connectors-external-code.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/zero-connectors-external-code.test.ts
@@ -41,6 +41,12 @@ const AWS_TOKEN_URL = "https://us-east-1.signin.aws.amazon.com/v1/token";
 const AWS_STS_URL = "https://sts.us-east-1.amazonaws.com/";
 const AUTH_HEADERS = { authorization: "Bearer clerk-session" } as const;
 const STAFF_ORG_ID = "org_3ANttyrbWYJk6JKRSTRLEsbsDLe";
+const AWS_EXTERNAL_CODE_CREDENTIAL_ID = [
+  "aws",
+  "external-code",
+  "credential",
+  "id",
+].join("-");
 
 const awsTokenRequestSchema = z.object({
   clientId: z.literal("arn:aws:signin:::devtools/cross-device"),
@@ -128,7 +134,7 @@ function mockAwsProvider(): z.infer<typeof awsTokenRequestSchema>[] {
       tokenRequests.push(body);
       return HttpResponse.json({
         accessToken: {
-          accessKeyId: "aws-external-code-access-key-id",
+          accessKeyId: AWS_EXTERNAL_CODE_CREDENTIAL_ID,
           secretAccessKey: "aws-secret-access-key",
           sessionToken: "aws-session-token",
         },
@@ -358,7 +364,7 @@ describe("external-code connector routes", () => {
     ).resolves.toBe("aws-login-refresh-token");
     await expect(
       storedSecret({ orgId, userId, name: "AWS_ACCESS_KEY_ID" }),
-    ).resolves.toBe("aws-external-code-access-key-id");
+    ).resolves.toBe(AWS_EXTERNAL_CODE_CREDENTIAL_ID);
     await expect(
       storedSecret({ orgId, userId, name: "AWS_SECRET_ACCESS_KEY" }),
     ).resolves.toBe("aws-secret-access-key");
@@ -431,7 +437,7 @@ describe("external-code connector routes", () => {
     expect(tokenRequests).toHaveLength(1);
     await expect(
       storedSecret({ orgId, userId, name: "AWS_ACCESS_KEY_ID" }),
-    ).resolves.toBe("aws-external-code-access-key-id");
+    ).resolves.toBe(AWS_EXTERNAL_CODE_CREDENTIAL_ID);
 
     const [session] = await store
       .set(writeDb$)

--- a/turbo/apps/api/src/signals/routes/__tests__/zero-connectors-external-code.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/zero-connectors-external-code.test.ts
@@ -7,11 +7,9 @@ import {
   type GenerateDataKeyCommandOutput,
 } from "@aws-sdk/client-kms";
 import { zeroConnectorExternalCodeSessionContract } from "@vm0/api-contracts/contracts/zero-connectors";
-import { FeatureSwitchKey } from "@vm0/connectors/feature-switch-key";
 import { connectorExternalCodeSessions } from "@vm0/db/schema/connector-external-code-session";
 import { connectors } from "@vm0/db/schema/connector";
 import { secrets } from "@vm0/db/schema/secret";
-import { userFeatureSwitches } from "@vm0/db/schema/user-feature-switches";
 import { createStore } from "ccstate";
 import { and, eq } from "drizzle-orm";
 import { http, HttpResponse } from "msw";
@@ -75,33 +73,6 @@ function deferred(): {
   return { promise, resolve: resolvePromise };
 }
 
-async function writeAwsConnectorOverride(userId: string, orgId: string) {
-  await store
-    .set(writeDb$)
-    .insert(userFeatureSwitches)
-    .values({
-      orgId,
-      userId,
-      switches: { [FeatureSwitchKey.AwsConnector]: true },
-    })
-    .onConflictDoUpdate({
-      target: [userFeatureSwitches.orgId, userFeatureSwitches.userId],
-      set: { switches: { [FeatureSwitchKey.AwsConnector]: true } },
-    });
-}
-
-async function disableAwsConnector(userId: string, orgId: string) {
-  await store
-    .set(writeDb$)
-    .delete(userFeatureSwitches)
-    .where(
-      and(
-        eq(userFeatureSwitches.userId, userId),
-        eq(userFeatureSwitches.orgId, orgId),
-      ),
-    );
-}
-
 async function cleanupUser(userId: string, orgId: string) {
   const db = store.set(writeDb$);
   await db
@@ -118,7 +89,6 @@ async function cleanupUser(userId: string, orgId: string) {
   await db
     .delete(secrets)
     .where(and(eq(secrets.userId, userId), eq(secrets.orgId, orgId)));
-  await disableAwsConnector(userId, orgId);
 }
 
 async function storedSecret(args: {
@@ -246,30 +216,6 @@ describe("external-code connector routes", () => {
 
     expect(response.body.error.message).toBe(
       "External-code authorization is not enabled for this connector",
-    );
-  });
-
-  it("allows user overrides for AWS on non-staff orgs", async () => {
-    const { userId, orgId } = setupUser();
-    await writeAwsConnectorOverride(userId, orgId);
-    const client = setupApp({ context })(
-      zeroConnectorExternalCodeSessionContract,
-    );
-
-    const response = await accept(
-      client.create({
-        params: { type: "aws" },
-        body: { authMethod: "cli" },
-        headers: AUTH_HEADERS,
-      }),
-      [200],
-    );
-
-    expect(response.body).toMatchObject(
-      expect.objectContaining({
-        type: "aws",
-        status: "pending",
-      }),
     );
   });
 

--- a/turbo/apps/api/src/signals/routes/__tests__/zero-connectors-external-code.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/zero-connectors-external-code.test.ts
@@ -249,7 +249,7 @@ describe("external-code connector routes", () => {
     );
   });
 
-  it("ignores user overrides for AWS on non-staff orgs", async () => {
+  it("allows user overrides for AWS on non-staff orgs", async () => {
     const { userId, orgId } = setupUser();
     await writeAwsConnectorOverride(userId, orgId);
     const client = setupApp({ context })(
@@ -262,11 +262,14 @@ describe("external-code connector routes", () => {
         body: { authMethod: "cli" },
         headers: AUTH_HEADERS,
       }),
-      [403],
+      [200],
     );
 
-    expect(response.body.error.message).toBe(
-      "External-code authorization is not enabled for this connector",
+    expect(response.body).toMatchObject(
+      expect.objectContaining({
+        type: "aws",
+        status: "pending",
+      }),
     );
   });
 
@@ -703,7 +706,6 @@ describe("external-code connector routes", () => {
 
   it("rejects complete when the AWS connector is not available", async () => {
     const { userId, orgId } = setupUser();
-    await writeAwsConnectorOverride(userId, orgId);
     const client = setupApp({ context })(
       zeroConnectorExternalCodeSessionContract,
     );

--- a/turbo/apps/api/src/signals/routes/__tests__/zero-feature-switches.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/zero-feature-switches.test.ts
@@ -189,7 +189,7 @@ describe("POST /api/zero/feature-switches", () => {
     });
   });
 
-  it("ignores switches that cannot be user-overridden", async () => {
+  it("stores AWS connector overrides like other user feature switches", async () => {
     const orgId = `org_${randomUUID()}`;
     const userId = `user_${randomUUID()}`;
     await track(Promise.resolve({ orgId, userId }));
@@ -210,9 +210,12 @@ describe("POST /api/zero/feature-switches", () => {
       [200],
     );
 
-    expect(response.body).toStrictEqual({ switches: { dummy: true } });
+    expect(response.body).toStrictEqual({
+      switches: { dummy: true, [FeatureSwitchKey.AwsConnector]: true },
+    });
     await expect(getRowSwitches(orgId, userId)).resolves.toStrictEqual({
       dummy: true,
+      [FeatureSwitchKey.AwsConnector]: true,
     });
   });
 

--- a/turbo/apps/api/src/signals/routes/__tests__/zero-feature-switches.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/zero-feature-switches.test.ts
@@ -1,7 +1,6 @@
 import { randomUUID } from "node:crypto";
 
 import { zeroFeatureSwitchesContract } from "@vm0/api-contracts/contracts/zero-feature-switches";
-import { FeatureSwitchKey } from "@vm0/connectors/feature-switch-key";
 import { createStore } from "ccstate";
 import { and, eq } from "drizzle-orm";
 import { userFeatureSwitches } from "@vm0/db/schema/user-feature-switches";
@@ -78,7 +77,7 @@ describe("GET /api/zero/feature-switches", () => {
     });
   });
 
-  it("returns persisted feature switch overrides that can be stored", async () => {
+  it("returns persisted feature switch overrides", async () => {
     const fixture = await track(
       store.set(
         seedFeatureSwitches$,
@@ -186,36 +185,6 @@ describe("POST /api/zero/feature-switches", () => {
 
     await expect(getRowSwitches(orgId, userId)).resolves.toStrictEqual({
       dummy: true,
-    });
-  });
-
-  it("stores AWS connector overrides like other user feature switches", async () => {
-    const orgId = `org_${randomUUID()}`;
-    const userId = `user_${randomUUID()}`;
-    await track(Promise.resolve({ orgId, userId }));
-    mocks.clerk.session(userId, orgId);
-
-    const client = setupApp({ context })(zeroFeatureSwitchesContract);
-
-    const response = await accept(
-      client.update({
-        headers: { authorization: "Bearer clerk-session" },
-        body: {
-          switches: {
-            dummy: true,
-            [FeatureSwitchKey.AwsConnector]: true,
-          },
-        },
-      }),
-      [200],
-    );
-
-    expect(response.body).toStrictEqual({
-      switches: { dummy: true, [FeatureSwitchKey.AwsConnector]: true },
-    });
-    await expect(getRowSwitches(orgId, userId)).resolves.toStrictEqual({
-      dummy: true,
-      [FeatureSwitchKey.AwsConnector]: true,
     });
   });
 

--- a/turbo/apps/api/src/signals/routes/__tests__/zero-feature-switches.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/zero-feature-switches.test.ts
@@ -1,6 +1,7 @@
 import { randomUUID } from "node:crypto";
 
 import { zeroFeatureSwitchesContract } from "@vm0/api-contracts/contracts/zero-feature-switches";
+import { FeatureSwitchKey } from "@vm0/connectors/feature-switch-key";
 import { createStore } from "ccstate";
 import { and, eq } from "drizzle-orm";
 import { userFeatureSwitches } from "@vm0/db/schema/user-feature-switches";
@@ -77,7 +78,7 @@ describe("GET /api/zero/feature-switches", () => {
     });
   });
 
-  it("returns persisted feature switch overrides", async () => {
+  it("returns persisted feature switch overrides that can be stored", async () => {
     const fixture = await track(
       store.set(
         seedFeatureSwitches$,
@@ -183,6 +184,33 @@ describe("POST /api/zero/feature-switches", () => {
 
     expect(response.body).toStrictEqual({ switches: { dummy: true } });
 
+    await expect(getRowSwitches(orgId, userId)).resolves.toStrictEqual({
+      dummy: true,
+    });
+  });
+
+  it("ignores switches that cannot be user-overridden", async () => {
+    const orgId = `org_${randomUUID()}`;
+    const userId = `user_${randomUUID()}`;
+    await track(Promise.resolve({ orgId, userId }));
+    mocks.clerk.session(userId, orgId);
+
+    const client = setupApp({ context })(zeroFeatureSwitchesContract);
+
+    const response = await accept(
+      client.update({
+        headers: { authorization: "Bearer clerk-session" },
+        body: {
+          switches: {
+            dummy: true,
+            [FeatureSwitchKey.AwsConnector]: true,
+          },
+        },
+      }),
+      [200],
+    );
+
+    expect(response.body).toStrictEqual({ switches: { dummy: true } });
     await expect(getRowSwitches(orgId, userId)).resolves.toStrictEqual({
       dummy: true,
     });

--- a/turbo/apps/api/src/signals/routes/__tests__/zero-runs-create.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/zero-runs-create.test.ts
@@ -2289,6 +2289,7 @@ describe("POST /api/zero/runs", () => {
     expect(decrypted).not.toHaveProperty("SLOCK_REFRESH_TOKEN");
     expect(decrypted).not.toHaveProperty("GOOGLE_ADS_DEVELOPER_TOKEN");
     expect(executionContext.secretConnectorMap).toStrictEqual({
+      SLOCK_SERVER_ID: "slock",
       SLOCK_TOKEN: "slock",
     });
     expect(executionContext.secretConnectorMetadataMap).toBeNull();

--- a/turbo/apps/api/src/signals/routes/zero-connectors-external-code.ts
+++ b/turbo/apps/api/src/signals/routes/zero-connectors-external-code.ts
@@ -1,0 +1,89 @@
+import { zeroConnectorExternalCodeSessionContract } from "@vm0/api-contracts/contracts/zero-connectors";
+import { command } from "ccstate";
+
+import { organizationAuthContext$ } from "../auth/auth-context";
+import { authRoute } from "../auth/auth-route";
+import { bodyResultOf, pathParamsOf } from "../context/request";
+import type { RouteEntry } from "../route";
+import {
+  completeConnectorExternalCodeSession$,
+  startConnectorExternalCodeSession$,
+} from "../services/connector-external-code.service";
+
+const connectorWriteAuth = {
+  requireOrganization: true,
+  missingOrganizationStatus: 401,
+} as const;
+
+const startConnectorExternalCodeSessionInner$ = command(
+  async ({ get, set }, signal: AbortSignal) => {
+    const auth = get(organizationAuthContext$);
+    const params = get(
+      pathParamsOf(zeroConnectorExternalCodeSessionContract.create),
+    );
+    const body = await get(
+      bodyResultOf(zeroConnectorExternalCodeSessionContract.create),
+    );
+    signal.throwIfAborted();
+    if (!body.ok) {
+      return body.response;
+    }
+
+    return await set(
+      startConnectorExternalCodeSession$,
+      {
+        orgId: auth.orgId,
+        userId: auth.userId,
+        type: params.type,
+        authMethod: body.data.authMethod,
+      },
+      signal,
+    );
+  },
+);
+
+const completeConnectorExternalCodeSessionInner$ = command(
+  async ({ get, set }, signal: AbortSignal) => {
+    const auth = get(organizationAuthContext$);
+    const params = get(
+      pathParamsOf(zeroConnectorExternalCodeSessionContract.complete),
+    );
+    const body = await get(
+      bodyResultOf(zeroConnectorExternalCodeSessionContract.complete),
+    );
+    signal.throwIfAborted();
+    if (!body.ok) {
+      return body.response;
+    }
+
+    return await set(
+      completeConnectorExternalCodeSession$,
+      {
+        orgId: auth.orgId,
+        userId: auth.userId,
+        type: params.type,
+        sessionId: params.sessionId,
+        sessionToken: body.data.sessionToken,
+        code: body.data.code,
+      },
+      signal,
+    );
+  },
+);
+
+export const zeroConnectorsExternalCodeRoutes: readonly RouteEntry[] = [
+  {
+    route: zeroConnectorExternalCodeSessionContract.create,
+    handler: authRoute(
+      connectorWriteAuth,
+      startConnectorExternalCodeSessionInner$,
+    ),
+  },
+  {
+    route: zeroConnectorExternalCodeSessionContract.complete,
+    handler: authRoute(
+      connectorWriteAuth,
+      completeConnectorExternalCodeSessionInner$,
+    ),
+  },
+];

--- a/turbo/apps/api/src/signals/services/agent-run-create.service.ts
+++ b/turbo/apps/api/src/signals/services/agent-run-create.service.ts
@@ -27,7 +27,6 @@ import {
   type ModelProviderType,
 } from "@vm0/api-contracts/contracts/model-providers";
 import {
-  getConnectorAuthMethodAccessMetadata,
   getConnectorAuthMethod,
   getConnectorAuthMethodRuntimeMetadata,
   type ConnectorRuntimeBindingEntry,
@@ -1667,8 +1666,6 @@ interface StoredConnectorRuntimeRow {
 interface ConnectorEnvBindingSet {
   readonly connectorType: ConnectorType;
   readonly authMethod: string;
-  readonly accessKind: "static" | "refresh-token" | "none";
-  readonly refreshableSecretNames: ReadonlySet<string>;
   readonly runtimeBindings: readonly ConnectorRuntimeBindingEntry[];
 }
 
@@ -1744,10 +1741,6 @@ function connectorEnvBindingSets(
 ): readonly ConnectorEnvBindingSet[] {
   return rows.map((row) => {
     const method = getConnectorAuthMethod(row.connectorType, row.authMethod);
-    const accessMetadata = getConnectorAuthMethodAccessMetadata(
-      row.connectorType,
-      row.authMethod,
-    );
     const metadata = getConnectorAuthMethodRuntimeMetadata(
       row.connectorType,
       row.authMethod,
@@ -1760,11 +1753,6 @@ function connectorEnvBindingSets(
     return {
       connectorType: row.connectorType,
       authMethod: row.authMethod,
-      accessKind: method.access.kind,
-      refreshableSecretNames:
-        accessMetadata?.kind === "refresh-token"
-          ? new Set(accessMetadata.refreshableSecrets)
-          : new Set<string>(),
       runtimeBindings: metadata.runtimeBindings,
     };
   });
@@ -1877,12 +1865,7 @@ function resolveStoredConnectorState(
   const secretConnectorMap: Record<string, string> = {};
   const environment: Record<string, string> = {};
 
-  for (const {
-    connectorType,
-    accessKind,
-    refreshableSecretNames,
-    runtimeBindings,
-  } of bindingSets) {
+  for (const { connectorType, runtimeBindings } of bindingSets) {
     for (const { envName, valueRef, optional, source } of runtimeBindings) {
       switch (source.kind) {
         case "connector-secret": {
@@ -1918,21 +1901,11 @@ function resolveStoredConnectorState(
     }
 
     // Firewall auth templates can only reference env aliases from envBindings;
-    // store the alias that points at the access secret, not the backing secret name.
-    if (accessKind === "refresh-token") {
-      for (const { envName, source } of runtimeBindings) {
-        if (
-          source.kind === "connector-secret" &&
-          refreshableSecretNames.has(source.name)
-        ) {
-          secretConnectorMap[envName] = connectorType;
-        }
-      }
-    } else if (accessKind === "static") {
-      for (const { envName, source } of runtimeBindings) {
-        if (source.kind === "connector-secret") {
-          secretConnectorMap[envName] = connectorType;
-        }
+    // store the alias that points at the connector runtime secret, not the
+    // backing secret name. Refreshability is resolved later from access metadata.
+    for (const { envName, source } of runtimeBindings) {
+      if (source.kind === "connector-secret") {
+        secretConnectorMap[envName] = connectorType;
       }
     }
   }

--- a/turbo/apps/api/src/signals/services/agent-webhook-firewall-auth.service.ts
+++ b/turbo/apps/api/src/signals/services/agent-webhook-firewall-auth.service.ts
@@ -2279,11 +2279,18 @@ function getOwnConnectorOwner(
     : undefined;
 }
 
-function isSelectedAccessSecretKey(
+function isConnectorRuntimeSecretKey(
   key: string,
   connectorAccess: ConnectorAccessState,
 ): boolean {
-  const secretName = connectorAccessSecretName(key, connectorAccess);
+  return connectorRuntimeSecretName(key, connectorAccess) !== undefined;
+}
+
+function isRefreshableConnectorRuntimeSecretKey(
+  key: string,
+  connectorAccess: ConnectorAccessState,
+): boolean {
+  const secretName = connectorRuntimeSecretName(key, connectorAccess);
   if (!secretName) {
     return false;
   }
@@ -2295,7 +2302,7 @@ function isSelectedAccessSecretKey(
     : true;
 }
 
-function connectorAccessSecretName(
+function connectorRuntimeSecretName(
   key: string,
   connectorAccess: ConnectorAccessState,
 ): string | undefined {
@@ -2372,7 +2379,7 @@ function referencedModelProviderAccessMap(args: {
   return refreshable;
 }
 
-async function syncStaticConnectorAccessSecrets(args: {
+async function syncStoredConnectorRuntimeSecrets(args: {
   readonly db: Db;
   readonly orgId: string;
   readonly userId: string;
@@ -2402,10 +2409,20 @@ async function syncStaticConnectorAccessSecrets(args: {
       return [];
     }
     const connectorAccess = args.connectorAccessByType.get(connectorType);
-    if (connectorAccess?.accessMetadata.kind !== "static") {
+    if (!connectorAccess) {
       return [];
     }
-    const secretName = connectorAccessSecretName(key, connectorAccess);
+    const secretName = connectorRuntimeSecretName(key, connectorAccess);
+    if (
+      secretName &&
+      connectorAccess.accessMetadata.kind === "refresh-token" &&
+      connectorRefreshMetadataHasRefreshableSecret(
+        connectorAccess.accessMetadata,
+        secretName,
+      )
+    ) {
+      return [];
+    }
     return secretName ? [{ key, secretName }] : [];
   });
   if (lookups.length === 0) {
@@ -2482,7 +2499,7 @@ function canResolveMissingAccessSecret(args: {
   if (connectorAccess?.accessMetadata.kind !== "refresh-token") {
     return false;
   }
-  return isSelectedAccessSecretKey(args.key, connectorAccess);
+  return isRefreshableConnectorRuntimeSecretKey(args.key, connectorAccess);
 }
 
 function referencedConnectorTypes(args: {
@@ -2550,7 +2567,9 @@ function hasUnavailableAccessSource(args: {
     }
 
     const connectorAccess = args.connectorAccessByType.get(connectorType);
-    return !connectorAccess || !isSelectedAccessSecretKey(key, connectorAccess);
+    return (
+      !connectorAccess || !isConnectorRuntimeSecretKey(key, connectorAccess)
+    );
   });
 }
 
@@ -2595,7 +2614,10 @@ function connectorAccessSourcesWithReconnectRequiredStatus(args: {
       continue;
     }
     const connectorAccess = args.connectorAccessByType.get(connectorType);
-    if (!connectorAccess || !isSelectedAccessSecretKey(key, connectorAccess)) {
+    if (
+      !connectorAccess ||
+      !isConnectorRuntimeSecretKey(key, connectorAccess)
+    ) {
       continue;
     }
     if (
@@ -2711,7 +2733,7 @@ async function prepareFirewallAuthResolutionContext(args: {
       response: connectorReconnectRequired(reconnectRequiredConnectorTypes),
     };
   }
-  await syncStaticConnectorAccessSecrets({
+  await syncStoredConnectorRuntimeSecrets({
     db: args.db,
     orgId: args.orgId,
     userId: args.auth.userId,

--- a/turbo/apps/api/src/signals/services/connector-external-code.service.ts
+++ b/turbo/apps/api/src/signals/services/connector-external-code.service.ts
@@ -51,6 +51,7 @@ const SUPERSEDED_SESSION_ERROR_CODE = "session_superseded";
 const SUPERSEDED_SESSION_ERROR_MESSAGE =
   "External-code authorization session was superseded";
 const PROVIDER_STATE_MAX_BYTES = 16 * 1024;
+const COMPLETING_SESSION_STALE_AFTER_MS = 30 * 60 * 1000;
 
 type ExternalCodeSessionRow = typeof connectorExternalCodeSessions.$inferSelect;
 
@@ -281,6 +282,20 @@ async function expireSession(args: {
     );
   args.signal.throwIfAborted();
   return badRequestMessage("External-code authorization session expired");
+}
+
+function isSessionExpired(session: ExternalCodeSessionRow, now: Date): boolean {
+  return now > session.expiresAt;
+}
+
+function isCompletingSessionStale(
+  session: ExternalCodeSessionRow,
+  now: Date,
+): boolean {
+  return (
+    now.getTime() - session.updatedAt.getTime() >
+    COMPLETING_SESSION_STALE_AFTER_MS
+  );
 }
 
 async function claimSession(args: {
@@ -776,13 +791,19 @@ export const completeConnectorExternalCodeSession$ = command(
     }
 
     const now = nowDate();
-    if (now > session.expiresAt) {
-      return await expireSession({ writeDb, session, now, signal });
-    }
     if (session.status === "completing") {
+      if (
+        isSessionExpired(session, now) &&
+        isCompletingSessionStale(session, now)
+      ) {
+        return await expireSession({ writeDb, session, now, signal });
+      }
       return badRequestMessage(
         "External-code authorization session is already completing",
       );
+    }
+    if (isSessionExpired(session, now)) {
+      return await expireSession({ writeDb, session, now, signal });
     }
 
     const claimStartedAt = now;

--- a/turbo/apps/api/src/signals/services/connector-external-code.service.ts
+++ b/turbo/apps/api/src/signals/services/connector-external-code.service.ts
@@ -344,12 +344,15 @@ async function markClaimPending(args: {
   readonly writeDb: Db;
   readonly session: ExternalCodeSessionRow;
   readonly claimStartedAt: Date;
+  readonly errorMessage?: string;
   readonly signal: AbortSignal;
 }): Promise<void> {
   await args.writeDb
     .update(connectorExternalCodeSessions)
     .set({
       status: "pending",
+      errorCode: args.errorMessage ? "provider_rejected" : null,
+      errorMessage: args.errorMessage ?? null,
       updatedAt: nowDate(),
     })
     .where(
@@ -399,7 +402,13 @@ async function markClaimComplete(args: {
   const completedAt = nowDate();
   const [completedSession] = await args.writeDb
     .update(connectorExternalCodeSessions)
-    .set({ status: "complete", updatedAt: completedAt, completedAt })
+    .set({
+      status: "complete",
+      errorCode: null,
+      errorMessage: null,
+      updatedAt: completedAt,
+      completedAt,
+    })
     .where(
       and(
         eq(connectorExternalCodeSessions.id, args.session.id),
@@ -536,6 +545,7 @@ async function completeClaimedExternalCodeSession(
         writeDb: args.writeDb,
         session: args.session,
         claimStartedAt: args.claimStartedAt,
+        errorMessage: errorMessage(providerResult.error),
         signal: args.signal,
       });
       const badRequest = providerBadRequest(providerResult.error);

--- a/turbo/apps/api/src/signals/services/connector-external-code.service.ts
+++ b/turbo/apps/api/src/signals/services/connector-external-code.service.ts
@@ -418,6 +418,7 @@ async function persistClaimedConnector(
     readonly signal: AbortSignal;
     readonly persistConnector: (args: {
       readonly token: ConnectorAuthProviderGrantResult;
+      readonly signal: AbortSignal;
     }) => Promise<ConnectorResponse>;
   },
 ): Promise<CompleteSuccess> {
@@ -439,7 +440,10 @@ async function persistClaimedConnector(
       );
     }
 
-    const connector = await args.persistConnector({ token: args.token });
+    const connector = await args.persistConnector({
+      token: args.token,
+      signal: args.signal,
+    });
     args.signal.throwIfAborted();
 
     return await markClaimComplete({
@@ -495,6 +499,7 @@ async function completeClaimedExternalCodeSession(
     readonly signal: AbortSignal;
     readonly persistConnector: (args: {
       readonly token: ConnectorAuthProviderGrantResult;
+      readonly signal: AbortSignal;
     }) => Promise<ConnectorResponse>;
   },
 ) {
@@ -537,12 +542,15 @@ async function completeClaimedExternalCodeSession(
     throw providerResult.error;
   }
 
+  // The provider code may already be consumed; finish DB commit even if the
+  // client disconnects after provider success.
+  const commitSignal = new AbortController().signal;
   const persistedConnector = await settle(
     persistClaimedConnector({
       ...args,
       token: providerResult.value,
+      signal: commitSignal,
     }),
-    args.signal,
   );
   if (!persistedConnector.ok) {
     await markClaimError({
@@ -550,7 +558,7 @@ async function completeClaimedExternalCodeSession(
       session: args.session,
       claimStartedAt: args.claimStartedAt,
       errorMessage: errorMessage(persistedConnector.error),
-      signal: args.signal,
+      signal: commitSignal,
     });
     throw persistedConnector.error;
   }
@@ -802,7 +810,7 @@ export const completeConnectorExternalCodeSession$ = command(
       session: claimedSession,
       claimStartedAt,
       signal,
-      persistConnector: async ({ token }) => {
+      persistConnector: async ({ token, signal: persistSignal }) => {
         const connectorResult = await set(
           upsertConnectorTokenConnection$,
           {
@@ -816,7 +824,7 @@ export const completeConnectorExternalCodeSession$ = command(
             expiresIn: token.expiresIn,
             extraConnectorSecrets: token.extraConnectorSecrets,
           },
-          signal,
+          persistSignal,
         );
         return connectorResult.connector;
       },

--- a/turbo/apps/api/src/signals/services/connector-external-code.service.ts
+++ b/turbo/apps/api/src/signals/services/connector-external-code.service.ts
@@ -46,10 +46,7 @@ import {
   zeroConnectorByType,
 } from "./zero-connector-data.service";
 
-const ACTIVE_EXTERNAL_CODE_SESSION_STATUSES = [
-  "pending",
-  "completing",
-] as const;
+const SUPERSEDABLE_EXTERNAL_CODE_SESSION_STATUSES = ["pending"] as const;
 const SUPERSEDED_SESSION_ERROR_CODE = "session_superseded";
 const SUPERSEDED_SESSION_ERROR_MESSAGE =
   "External-code authorization session was superseded";
@@ -178,7 +175,7 @@ async function lockExternalCodeSessionOwner(
   );
 }
 
-async function markActiveSessionsSuperseded(
+async function markPendingSessionsSuperseded(
   args: ExternalCodeSessionOwner & {
     readonly writeDb: Db;
     readonly now: Date;
@@ -200,7 +197,7 @@ async function markActiveSessionsSuperseded(
         eq(connectorExternalCodeSessions.connectorType, args.type),
         eq(connectorExternalCodeSessions.authMethod, args.authMethod),
         inArray(connectorExternalCodeSessions.status, [
-          ...ACTIVE_EXTERNAL_CODE_SESSION_STATUSES,
+          ...SUPERSEDABLE_EXTERNAL_CODE_SESSION_STATUSES,
         ]),
       ),
     );
@@ -662,7 +659,7 @@ export const startConnectorExternalCodeSession$ = command(
         orgId: args.orgId,
         userId: args.userId,
       });
-      await markActiveSessionsSuperseded({
+      await markPendingSessionsSuperseded({
         ...resolvedMethod,
         writeDb: tx,
         orgId: args.orgId,

--- a/turbo/apps/api/src/signals/services/connector-external-code.service.ts
+++ b/turbo/apps/api/src/signals/services/connector-external-code.service.ts
@@ -1,0 +1,825 @@
+import { Buffer } from "node:buffer";
+import { createHash, randomBytes } from "node:crypto";
+
+import type {
+  ConnectorExternalCodeSessionCompleteResponse,
+  ConnectorExternalCodeSessionStartResponse,
+  ConnectorResponse,
+} from "@vm0/api-contracts/contracts/connector-schemas";
+import {
+  connectorAuthMethodIdSchema,
+  type ConnectorAuthMethodId,
+  type ConnectorType,
+} from "@vm0/connectors/connectors";
+import {
+  connectorAuthMethodRefHasGrantKind,
+  getConnectorAuthMethod,
+  getConnectorAuthMethodIdsForGrantKind,
+  resolveConnectorResolvedAuthMethodClientByGrantKind,
+  type ConnectorAuthMethodRef,
+  type ConnectorAuthMethodRefByGrantKind,
+  type ConnectorResolvedAuthMethodClientByGrantKind,
+} from "@vm0/connectors/connector-utils";
+import {
+  completeConnectorExternalCodeAuthorization,
+  startConnectorExternalCodeAuthorization,
+  type ConnectorAuthProviderGrantResult,
+} from "@vm0/connectors/auth-providers";
+import { isOAuthProviderHttpError } from "@vm0/connectors/auth-providers/oauth/error";
+import { connectorExternalCodeSessions } from "@vm0/db/schema/connector-external-code-session";
+import { command } from "ccstate";
+import { and, eq, inArray, or, sql } from "drizzle-orm";
+import { z } from "zod";
+
+import { badRequestMessage, notFound } from "../../lib/error";
+import { optionalEnv } from "../../lib/env";
+import { nowDate } from "../../lib/time";
+import { writeDb$, type Db } from "../external/db";
+import { settle } from "../utils";
+import {
+  decryptPersistentSecretValue,
+  encryptPersistentSecretValue,
+} from "./crypto.utils";
+import { userConnectorAvailability } from "./connector-availability.service";
+import {
+  upsertConnectorTokenConnection$,
+  zeroConnectorByType,
+} from "./zero-connector-data.service";
+
+const ACTIVE_EXTERNAL_CODE_SESSION_STATUSES = [
+  "pending",
+  "completing",
+] as const;
+const SUPERSEDED_SESSION_ERROR_CODE = "session_superseded";
+const SUPERSEDED_SESSION_ERROR_MESSAGE =
+  "External-code authorization session was superseded";
+const PROVIDER_STATE_MAX_BYTES = 16 * 1024;
+
+type ExternalCodeSessionRow = typeof connectorExternalCodeSessions.$inferSelect;
+
+type ExternalCodeMethodRef = ConnectorAuthMethodRefByGrantKind<"external-code">;
+type ExternalCodeResolvedMethodClient =
+  ConnectorResolvedAuthMethodClientByGrantKind<"external-code">;
+
+type ExternalCodeSessionOwner = ExternalCodeMethodRef & {
+  readonly orgId: string;
+  readonly userId: string;
+};
+
+type CompleteSuccess = {
+  readonly status: 200;
+  readonly body: ConnectorExternalCodeSessionCompleteResponse;
+};
+
+const encryptedProviderStateSchema = z.object({
+  connectorType: z.string(),
+  authMethod: z.string(),
+  providerState: z.string(),
+});
+
+const connectorExternalCodeDisabled = Object.freeze({
+  status: 403 as const,
+  body: Object.freeze({
+    error: Object.freeze({
+      message: "External-code authorization is not enabled for this connector",
+      code: "FORBIDDEN",
+    }),
+  }),
+});
+
+function internalServerError(message: string) {
+  return {
+    status: 500 as const,
+    body: {
+      error: {
+        message,
+        code: "INTERNAL_SERVER_ERROR",
+      },
+    },
+  };
+}
+
+function sessionTokenHash(sessionToken: string): string {
+  return createHash("sha256").update(sessionToken).digest("hex");
+}
+
+function generateSessionToken(): string {
+  return randomBytes(32).toString("base64url");
+}
+
+function connectorMissingExternalCodeGrantMessage(type: ConnectorType): string {
+  return `${type} connector does not support an external-code grant`;
+}
+
+function resolveExternalCodeMethod(
+  type: ConnectorType,
+  authMethod: string,
+): ExternalCodeMethodRef | ReturnType<typeof badRequestMessage> {
+  const authMethodResult = connectorAuthMethodIdSchema.safeParse(authMethod);
+  if (!authMethodResult.success) {
+    return badRequestMessage(`${type} connector auth method is invalid`);
+  }
+
+  const authMethodRef: ConnectorAuthMethodRef = {
+    type,
+    authMethod: authMethodResult.data,
+  };
+  const method = getConnectorAuthMethod(type, authMethodResult.data);
+  if (!method) {
+    if (
+      getConnectorAuthMethodIdsForGrantKind(type, "external-code").length === 0
+    ) {
+      return badRequestMessage(connectorMissingExternalCodeGrantMessage(type));
+    }
+    return badRequestMessage(
+      `${type} connector does not have ${authMethod} auth method`,
+    );
+  }
+  if (!connectorAuthMethodRefHasGrantKind(authMethodRef, "external-code")) {
+    return badRequestMessage(
+      `${type} ${authMethod} auth method does not use an external-code grant`,
+    );
+  }
+
+  return authMethodRef;
+}
+
+function resolveStoredExternalCodeMethod(
+  type: ConnectorType,
+  authMethod: string,
+): ExternalCodeMethodRef | ReturnType<typeof internalServerError> {
+  const resolved = resolveExternalCodeMethod(type, authMethod);
+  if ("status" in resolved) {
+    return internalServerError("Invalid external-code authorization session");
+  }
+  return resolved;
+}
+
+function resolveRequiredAuthClient(
+  method: ExternalCodeMethodRef,
+): ExternalCodeResolvedMethodClient | ReturnType<typeof internalServerError> {
+  const resolvedClient = resolveConnectorResolvedAuthMethodClientByGrantKind(
+    method,
+    optionalEnv,
+  );
+  if (!resolvedClient) {
+    return internalServerError(`${method.type} auth client not configured`);
+  }
+  return resolvedClient;
+}
+
+async function lockExternalCodeSessionOwner(
+  args: ExternalCodeSessionOwner & {
+    readonly writeDb: Db;
+  },
+): Promise<void> {
+  await args.writeDb.execute(
+    sql`SELECT pg_advisory_xact_lock(hashtext('connector_external_code:' || ${args.orgId} || ':' || ${args.userId} || ':' || ${args.type} || ':' || ${args.authMethod}))`,
+  );
+}
+
+async function markActiveSessionsSuperseded(
+  args: ExternalCodeSessionOwner & {
+    readonly writeDb: Db;
+    readonly now: Date;
+  },
+): Promise<void> {
+  await args.writeDb
+    .update(connectorExternalCodeSessions)
+    .set({
+      status: "error",
+      errorCode: SUPERSEDED_SESSION_ERROR_CODE,
+      errorMessage: SUPERSEDED_SESSION_ERROR_MESSAGE,
+      updatedAt: args.now,
+      completedAt: args.now,
+    })
+    .where(
+      and(
+        eq(connectorExternalCodeSessions.orgId, args.orgId),
+        eq(connectorExternalCodeSessions.userId, args.userId),
+        eq(connectorExternalCodeSessions.connectorType, args.type),
+        eq(connectorExternalCodeSessions.authMethod, args.authMethod),
+        inArray(connectorExternalCodeSessions.status, [
+          ...ACTIVE_EXTERNAL_CODE_SESSION_STATUSES,
+        ]),
+      ),
+    );
+}
+
+async function loadOwnedSession(args: {
+  readonly writeDb: Db;
+  readonly orgId: string;
+  readonly userId: string;
+  readonly type: ConnectorType;
+  readonly sessionId: string;
+  readonly sessionToken: string;
+  readonly signal: AbortSignal;
+}): Promise<ExternalCodeSessionRow | null> {
+  const [session] = await args.writeDb
+    .select()
+    .from(connectorExternalCodeSessions)
+    .where(
+      and(
+        eq(connectorExternalCodeSessions.id, args.sessionId),
+        eq(connectorExternalCodeSessions.orgId, args.orgId),
+        eq(connectorExternalCodeSessions.userId, args.userId),
+        eq(connectorExternalCodeSessions.connectorType, args.type),
+        eq(
+          connectorExternalCodeSessions.sessionTokenHash,
+          sessionTokenHash(args.sessionToken),
+        ),
+      ),
+    )
+    .limit(1);
+  args.signal.throwIfAborted();
+  return session ?? null;
+}
+
+async function parseEncryptedProviderState(args: {
+  readonly session: ExternalCodeSessionRow;
+  readonly method: ExternalCodeMethodRef;
+}): Promise<string> {
+  const decrypted = await decryptPersistentSecretValue(
+    args.session.encryptedProviderState,
+    {
+      orgId: args.session.orgId,
+      userId: args.session.userId,
+    },
+  );
+  const providerState = encryptedProviderStateSchema.parse(
+    JSON.parse(decrypted) as unknown,
+  );
+  if (
+    providerState.connectorType !== args.method.type ||
+    providerState.authMethod !== args.method.authMethod
+  ) {
+    throw new Error("External-code provider state connector method mismatch");
+  }
+  return providerState.providerState;
+}
+
+async function expireSession(args: {
+  readonly writeDb: Db;
+  readonly session: ExternalCodeSessionRow;
+  readonly now: Date;
+  readonly signal: AbortSignal;
+}) {
+  await args.writeDb
+    .update(connectorExternalCodeSessions)
+    .set({
+      status: "expired",
+      errorCode: "expired_token",
+      errorMessage: "External-code authorization session expired",
+      updatedAt: args.now,
+      completedAt: args.now,
+    })
+    .where(
+      and(
+        eq(connectorExternalCodeSessions.id, args.session.id),
+        or(
+          eq(connectorExternalCodeSessions.status, "pending"),
+          eq(connectorExternalCodeSessions.status, "completing"),
+        ),
+      ),
+    );
+  args.signal.throwIfAborted();
+  return badRequestMessage("External-code authorization session expired");
+}
+
+async function claimSession(args: {
+  readonly writeDb: Db;
+  readonly session: ExternalCodeSessionRow;
+  readonly claimStartedAt: Date;
+  readonly signal: AbortSignal;
+}): Promise<ExternalCodeSessionRow | null> {
+  const [claimedSession] = await args.writeDb
+    .update(connectorExternalCodeSessions)
+    .set({ status: "completing", updatedAt: args.claimStartedAt })
+    .where(
+      and(
+        eq(connectorExternalCodeSessions.id, args.session.id),
+        eq(connectorExternalCodeSessions.status, "pending"),
+      ),
+    )
+    .returning();
+  args.signal.throwIfAborted();
+  return claimedSession ?? null;
+}
+
+async function claimStillCurrent(args: {
+  readonly writeDb: Db;
+  readonly sessionId: string;
+  readonly claimStartedAt: Date;
+  readonly signal: AbortSignal;
+}): Promise<boolean> {
+  const [currentClaim] = await args.writeDb
+    .select({
+      status: connectorExternalCodeSessions.status,
+      updatedAt: connectorExternalCodeSessions.updatedAt,
+    })
+    .from(connectorExternalCodeSessions)
+    .where(eq(connectorExternalCodeSessions.id, args.sessionId))
+    .limit(1);
+  args.signal.throwIfAborted();
+
+  return (
+    currentClaim?.status === "completing" &&
+    currentClaim.updatedAt.getTime() === args.claimStartedAt.getTime()
+  );
+}
+
+async function markClaimPending(args: {
+  readonly writeDb: Db;
+  readonly session: ExternalCodeSessionRow;
+  readonly claimStartedAt: Date;
+  readonly signal: AbortSignal;
+}): Promise<void> {
+  await args.writeDb
+    .update(connectorExternalCodeSessions)
+    .set({
+      status: "pending",
+      updatedAt: nowDate(),
+    })
+    .where(
+      and(
+        eq(connectorExternalCodeSessions.id, args.session.id),
+        eq(connectorExternalCodeSessions.status, "completing"),
+        eq(connectorExternalCodeSessions.updatedAt, args.claimStartedAt),
+      ),
+    );
+  args.signal.throwIfAborted();
+}
+
+async function markClaimError(args: {
+  readonly writeDb: Db;
+  readonly session: ExternalCodeSessionRow;
+  readonly claimStartedAt: Date;
+  readonly errorMessage: string;
+  readonly signal: AbortSignal;
+}): Promise<void> {
+  const completedAt = nowDate();
+  await args.writeDb
+    .update(connectorExternalCodeSessions)
+    .set({
+      status: "error",
+      errorCode: "complete_failed",
+      errorMessage: args.errorMessage,
+      updatedAt: completedAt,
+      completedAt,
+    })
+    .where(
+      and(
+        eq(connectorExternalCodeSessions.id, args.session.id),
+        eq(connectorExternalCodeSessions.status, "completing"),
+        eq(connectorExternalCodeSessions.updatedAt, args.claimStartedAt),
+      ),
+    );
+  args.signal.throwIfAborted();
+}
+
+async function markClaimComplete(args: {
+  readonly writeDb: Db;
+  readonly session: ExternalCodeSessionRow;
+  readonly claimStartedAt: Date;
+  readonly connector: ConnectorResponse;
+  readonly signal: AbortSignal;
+}): Promise<CompleteSuccess> {
+  const completedAt = nowDate();
+  const [completedSession] = await args.writeDb
+    .update(connectorExternalCodeSessions)
+    .set({ status: "complete", updatedAt: completedAt, completedAt })
+    .where(
+      and(
+        eq(connectorExternalCodeSessions.id, args.session.id),
+        eq(connectorExternalCodeSessions.status, "completing"),
+        eq(connectorExternalCodeSessions.updatedAt, args.claimStartedAt),
+      ),
+    )
+    .returning({ id: connectorExternalCodeSessions.id });
+  args.signal.throwIfAborted();
+
+  if (!completedSession) {
+    throw new Error("External-code authorization session is no longer active");
+  }
+  return {
+    status: 200,
+    body: { status: "complete", connector: args.connector },
+  };
+}
+
+async function persistClaimedConnector(
+  args: ExternalCodeMethodRef & {
+    readonly writeDb: Db;
+    readonly orgId: string;
+    readonly userId: string;
+    readonly session: ExternalCodeSessionRow;
+    readonly claimStartedAt: Date;
+    readonly token: ConnectorAuthProviderGrantResult;
+    readonly signal: AbortSignal;
+    readonly persistConnector: (args: {
+      readonly token: ConnectorAuthProviderGrantResult;
+    }) => Promise<ConnectorResponse>;
+  },
+): Promise<CompleteSuccess> {
+  return await args.writeDb.transaction(async (tx) => {
+    await lockExternalCodeSessionOwner({
+      ...args,
+      writeDb: tx,
+    });
+    if (
+      !(await claimStillCurrent({
+        writeDb: tx,
+        sessionId: args.session.id,
+        claimStartedAt: args.claimStartedAt,
+        signal: args.signal,
+      }))
+    ) {
+      throw new Error(
+        "External-code authorization session is no longer active",
+      );
+    }
+
+    const connector = await args.persistConnector({ token: args.token });
+    args.signal.throwIfAborted();
+
+    return await markClaimComplete({
+      writeDb: tx,
+      session: args.session,
+      claimStartedAt: args.claimStartedAt,
+      connector,
+      signal: args.signal,
+    });
+  });
+}
+
+function terminalErrorResponse(session: ExternalCodeSessionRow) {
+  switch (session.status) {
+    case "expired": {
+      return badRequestMessage(
+        session.errorMessage ?? "External-code authorization session expired",
+      );
+    }
+    case "error": {
+      return badRequestMessage(
+        session.errorMessage ?? "External-code authorization session failed",
+      );
+    }
+    case "complete":
+    case "pending":
+    case "completing": {
+      return null;
+    }
+  }
+}
+
+async function completeSessionResponse(args: {
+  readonly connectorLoader: () => Promise<ConnectorResponse | null>;
+  readonly signal: AbortSignal;
+}): Promise<CompleteSuccess> {
+  const connector = await args.connectorLoader();
+  args.signal.throwIfAborted();
+  if (!connector) {
+    throw new Error("Completed external-code connector not found");
+  }
+  return { status: 200, body: { status: "complete", connector } };
+}
+
+async function completeClaimedExternalCodeSession(
+  args: ExternalCodeResolvedMethodClient & {
+    readonly writeDb: Db;
+    readonly orgId: string;
+    readonly userId: string;
+    readonly code: string;
+    readonly session: ExternalCodeSessionRow;
+    readonly claimStartedAt: Date;
+    readonly signal: AbortSignal;
+    readonly persistConnector: (args: {
+      readonly token: ConnectorAuthProviderGrantResult;
+    }) => Promise<ConnectorResponse>;
+  },
+) {
+  const providerResult = await settle(
+    (async () => {
+      const providerState = await parseEncryptedProviderState({
+        session: args.session,
+        method: args,
+      });
+      return await completeConnectorExternalCodeAuthorization({
+        ...args,
+        code: args.code,
+        providerState,
+        signal: args.signal,
+      });
+    })(),
+    args.signal,
+  );
+  if (!providerResult.ok) {
+    if (shouldRestorePendingAfterProviderError(providerResult.error)) {
+      await markClaimPending({
+        writeDb: args.writeDb,
+        session: args.session,
+        claimStartedAt: args.claimStartedAt,
+        signal: args.signal,
+      });
+      const badRequest = providerBadRequest(providerResult.error);
+      if (badRequest) {
+        return badRequest;
+      }
+    } else {
+      await markClaimError({
+        writeDb: args.writeDb,
+        session: args.session,
+        claimStartedAt: args.claimStartedAt,
+        errorMessage: errorMessage(providerResult.error),
+        signal: args.signal,
+      });
+    }
+    throw providerResult.error;
+  }
+
+  const persistedConnector = await settle(
+    persistClaimedConnector({
+      ...args,
+      token: providerResult.value,
+    }),
+    args.signal,
+  );
+  if (!persistedConnector.ok) {
+    await markClaimError({
+      writeDb: args.writeDb,
+      session: args.session,
+      claimStartedAt: args.claimStartedAt,
+      errorMessage: errorMessage(persistedConnector.error),
+      signal: args.signal,
+    });
+    throw persistedConnector.error;
+  }
+  return persistedConnector.value;
+}
+
+function providerBadRequest(error: unknown) {
+  if (
+    isOAuthProviderHttpError(error) &&
+    (error.oauthError === "invalid_grant" ||
+      (error.status >= 400 && error.status < 500 && error.status !== 429))
+  ) {
+    return badRequestMessage(
+      "External-code authorization code was rejected. Check the code and try again.",
+    );
+  }
+  return null;
+}
+
+function shouldRestorePendingAfterProviderError(error: unknown): boolean {
+  return isOAuthProviderHttpError(error);
+}
+
+function providerStateWithinLimit(providerState: string): string {
+  if (Buffer.byteLength(providerState, "utf8") > PROVIDER_STATE_MAX_BYTES) {
+    throw new Error(
+      `External-code provider state exceeds ${PROVIDER_STATE_MAX_BYTES} bytes`,
+    );
+  }
+  return providerState;
+}
+
+function errorMessage(error: unknown): string {
+  return error instanceof Error
+    ? error.message
+    : "External-code completion failed";
+}
+
+export const startConnectorExternalCodeSession$ = command(
+  async (
+    { get, set },
+    args: {
+      readonly orgId: string;
+      readonly userId: string;
+      readonly type: ConnectorType;
+      readonly authMethod: ConnectorAuthMethodId;
+    },
+    signal: AbortSignal,
+  ) => {
+    const resolvedMethod = resolveExternalCodeMethod(
+      args.type,
+      args.authMethod,
+    );
+    if ("status" in resolvedMethod) {
+      return resolvedMethod;
+    }
+
+    const availability = await get(
+      userConnectorAvailability(args.orgId, args.userId),
+    );
+    signal.throwIfAborted();
+
+    if (
+      !availability.isAuthMethodAvailable(
+        resolvedMethod.type,
+        resolvedMethod.authMethod,
+      )
+    ) {
+      return connectorExternalCodeDisabled;
+    }
+
+    const resolvedClient = resolveRequiredAuthClient(resolvedMethod);
+    if ("status" in resolvedClient) {
+      return resolvedClient;
+    }
+
+    const startResult =
+      await startConnectorExternalCodeAuthorization(resolvedClient);
+    signal.throwIfAborted();
+
+    const sessionToken = generateSessionToken();
+    const now = nowDate();
+    const expiresAt = new Date(now.getTime() + startResult.expiresIn * 1000);
+    const encryptedProviderState = await encryptPersistentSecretValue(
+      JSON.stringify({
+        connectorType: resolvedMethod.type,
+        authMethod: resolvedMethod.authMethod,
+        providerState: providerStateWithinLimit(startResult.providerState),
+      }),
+      {
+        orgId: args.orgId,
+        userId: args.userId,
+      },
+    );
+    signal.throwIfAborted();
+
+    const [session] = await set(writeDb$).transaction(async (tx) => {
+      await lockExternalCodeSessionOwner({
+        ...resolvedMethod,
+        writeDb: tx,
+        orgId: args.orgId,
+        userId: args.userId,
+      });
+      await markActiveSessionsSuperseded({
+        ...resolvedMethod,
+        writeDb: tx,
+        orgId: args.orgId,
+        userId: args.userId,
+        now,
+      });
+      return await tx
+        .insert(connectorExternalCodeSessions)
+        .values({
+          orgId: args.orgId,
+          userId: args.userId,
+          connectorType: resolvedMethod.type,
+          authMethod: resolvedMethod.authMethod,
+          status: "pending",
+          sessionTokenHash: sessionTokenHash(sessionToken),
+          encryptedProviderState,
+          authorizationUrl: startResult.authorizationUrl,
+          createdAt: now,
+          updatedAt: now,
+          expiresAt,
+        })
+        .returning({ id: connectorExternalCodeSessions.id });
+    });
+    signal.throwIfAborted();
+
+    if (!session) {
+      throw new Error("Failed to create external-code authorization session");
+    }
+
+    const body: ConnectorExternalCodeSessionStartResponse = {
+      sessionId: session.id,
+      sessionToken,
+      type: resolvedMethod.type,
+      status: "pending",
+      authorizationUrl: startResult.authorizationUrl,
+      expiresIn: startResult.expiresIn,
+    };
+    return { status: 200 as const, body };
+  },
+);
+
+export const completeConnectorExternalCodeSession$ = command(
+  async (
+    { get, set },
+    args: {
+      readonly orgId: string;
+      readonly userId: string;
+      readonly type: ConnectorType;
+      readonly sessionId: string;
+      readonly sessionToken: string;
+      readonly code: string;
+    },
+    signal: AbortSignal,
+  ) => {
+    const writeDb = set(writeDb$);
+    const session = await loadOwnedSession({
+      writeDb,
+      orgId: args.orgId,
+      userId: args.userId,
+      type: args.type,
+      sessionId: args.sessionId,
+      sessionToken: args.sessionToken,
+      signal,
+    });
+    if (!session) {
+      return notFound("External-code authorization session not found");
+    }
+
+    const resolvedMethod = resolveStoredExternalCodeMethod(
+      args.type,
+      session.authMethod,
+    );
+    if ("status" in resolvedMethod) {
+      return resolvedMethod;
+    }
+
+    const availability = await get(
+      userConnectorAvailability(args.orgId, args.userId),
+    );
+    signal.throwIfAborted();
+    if (
+      !availability.isAuthMethodAvailable(
+        resolvedMethod.type,
+        resolvedMethod.authMethod,
+      )
+    ) {
+      return connectorExternalCodeDisabled;
+    }
+
+    const resolvedClient = resolveRequiredAuthClient(resolvedMethod);
+    if ("status" in resolvedClient) {
+      return resolvedClient;
+    }
+
+    if (session.status === "complete") {
+      return await completeSessionResponse({
+        connectorLoader: () => {
+          return get(
+            zeroConnectorByType({
+              orgId: args.orgId,
+              userId: args.userId,
+              type: resolvedMethod.type,
+              includeHiddenStoredConnector: true,
+            }),
+          );
+        },
+        signal,
+      });
+    }
+
+    const terminal = terminalErrorResponse(session);
+    if (terminal) {
+      return terminal;
+    }
+
+    const now = nowDate();
+    if (now > session.expiresAt) {
+      return await expireSession({ writeDb, session, now, signal });
+    }
+    if (session.status === "completing") {
+      return badRequestMessage(
+        "External-code authorization session is already completing",
+      );
+    }
+
+    const claimStartedAt = now;
+    const claimedSession = await claimSession({
+      writeDb,
+      session,
+      claimStartedAt,
+      signal,
+    });
+    if (!claimedSession) {
+      return badRequestMessage(
+        "External-code authorization session is no longer active",
+      );
+    }
+
+    return await completeClaimedExternalCodeSession({
+      ...resolvedClient,
+      writeDb,
+      orgId: args.orgId,
+      userId: args.userId,
+      code: args.code,
+      session: claimedSession,
+      claimStartedAt,
+      signal,
+      persistConnector: async ({ token }) => {
+        const connectorResult = await set(
+          upsertConnectorTokenConnection$,
+          {
+            orgId: args.orgId,
+            userId: args.userId,
+            type: resolvedMethod.type,
+            authMethod: resolvedMethod.authMethod,
+            outputs: token.outputs,
+            userInfo: token.userInfo,
+            oauthScopes: token.scopes,
+            expiresIn: token.expiresIn,
+            extraConnectorSecrets: token.extraConnectorSecrets,
+          },
+          signal,
+        );
+        return connectorResult.connector;
+      },
+    });
+  },
+);

--- a/turbo/apps/api/src/signals/services/feature-switches.service.ts
+++ b/turbo/apps/api/src/signals/services/feature-switches.service.ts
@@ -1,23 +1,10 @@
 import { command, computed, type Computed } from "ccstate";
-import {
-  shouldPersistUserFeatureSwitchOverride,
-  type FeatureSwitchContext,
-} from "@vm0/core/feature-switch";
+import type { FeatureSwitchContext } from "@vm0/core/feature-switch";
 import { userFeatureSwitches } from "@vm0/db/schema/user-feature-switches";
 import { and, eq } from "drizzle-orm";
 
 import { db$, writeDb$, type ReadonlyDb } from "../external/db";
 import { nowDate } from "../external/time";
-
-function persistableUserSwitchOverrides(
-  switches: Record<string, boolean>,
-): Record<string, boolean> {
-  return Object.fromEntries(
-    Object.entries(switches).filter(([key]) => {
-      return shouldPersistUserFeatureSwitchOverride(key);
-    }),
-  );
-}
 
 async function loadUserFeatureSwitchOverrides(
   db: ReadonlyDb,
@@ -35,7 +22,7 @@ async function loadUserFeatureSwitchOverrides(
     )
     .limit(1);
 
-  return persistableUserSwitchOverrides(row?.switches ?? {});
+  return row?.switches ?? {};
 }
 
 export function userFeatureSwitchOverrides(
@@ -97,12 +84,11 @@ export const updateUserFeatureSwitches$ = command(
       .limit(1);
     signal.throwIfAborted();
 
-    const existing = persistableUserSwitchOverrides(
-      (existingRow?.switches as Record<string, boolean> | undefined) ?? {},
-    );
+    const existing =
+      (existingRow?.switches as Record<string, boolean> | undefined) ?? {};
     const merged: Record<string, boolean> = {
       ...existing,
-      ...persistableUserSwitchOverrides(args.switches),
+      ...args.switches,
     };
     const now = nowDate();
 

--- a/turbo/apps/api/src/signals/services/feature-switches.service.ts
+++ b/turbo/apps/api/src/signals/services/feature-switches.service.ts
@@ -1,10 +1,23 @@
 import { command, computed, type Computed } from "ccstate";
-import type { FeatureSwitchContext } from "@vm0/core/feature-switch";
+import {
+  shouldPersistUserFeatureSwitchOverride,
+  type FeatureSwitchContext,
+} from "@vm0/core/feature-switch";
 import { userFeatureSwitches } from "@vm0/db/schema/user-feature-switches";
 import { and, eq } from "drizzle-orm";
 
 import { db$, writeDb$, type ReadonlyDb } from "../external/db";
 import { nowDate } from "../external/time";
+
+function persistableUserSwitchOverrides(
+  switches: Record<string, boolean>,
+): Record<string, boolean> {
+  return Object.fromEntries(
+    Object.entries(switches).filter(([key]) => {
+      return shouldPersistUserFeatureSwitchOverride(key);
+    }),
+  );
+}
 
 async function loadUserFeatureSwitchOverrides(
   db: ReadonlyDb,
@@ -22,7 +35,7 @@ async function loadUserFeatureSwitchOverrides(
     )
     .limit(1);
 
-  return row?.switches ?? {};
+  return persistableUserSwitchOverrides(row?.switches ?? {});
 }
 
 export function userFeatureSwitchOverrides(
@@ -84,9 +97,13 @@ export const updateUserFeatureSwitches$ = command(
       .limit(1);
     signal.throwIfAborted();
 
-    const existing =
-      (existingRow?.switches as Record<string, boolean> | undefined) ?? {};
-    const merged: Record<string, boolean> = { ...existing, ...args.switches };
+    const existing = persistableUserSwitchOverrides(
+      (existingRow?.switches as Record<string, boolean> | undefined) ?? {},
+    );
+    const merged: Record<string, boolean> = {
+      ...existing,
+      ...persistableUserSwitchOverrides(args.switches),
+    };
     const now = nowDate();
 
     await writeDb

--- a/turbo/apps/api/src/signals/services/feature-switches.service.ts
+++ b/turbo/apps/api/src/signals/services/feature-switches.service.ts
@@ -86,10 +86,7 @@ export const updateUserFeatureSwitches$ = command(
 
     const existing =
       (existingRow?.switches as Record<string, boolean> | undefined) ?? {};
-    const merged: Record<string, boolean> = {
-      ...existing,
-      ...args.switches,
-    };
+    const merged: Record<string, boolean> = { ...existing, ...args.switches };
     const now = nowDate();
 
     await writeDb

--- a/turbo/apps/api/src/signals/services/webhooks-clerk-cleanup.service.ts
+++ b/turbo/apps/api/src/signals/services/webhooks-clerk-cleanup.service.ts
@@ -7,6 +7,7 @@ import { agentRunQueue } from "@vm0/db/schema/agent-run-queue";
 import { agentRuns } from "@vm0/db/schema/agent-run";
 import { cliTokens } from "@vm0/db/schema/cli-tokens";
 import { composeJobs } from "@vm0/db/schema/compose-job";
+import { connectorExternalCodeSessions } from "@vm0/db/schema/connector-external-code-session";
 import { connectorOauthDeviceAuthorizationSessions } from "@vm0/db/schema/connector-oauth-device-authorization-session";
 import { connectors } from "@vm0/db/schema/connector";
 import { deviceCodes } from "@vm0/db/schema/device-codes";
@@ -492,6 +493,9 @@ async function deleteOrgData(db: Db, orgId: string): Promise<void> {
   await db
     .delete(connectorOauthDeviceAuthorizationSessions)
     .where(eq(connectorOauthDeviceAuthorizationSessions.orgId, orgId));
+  await db
+    .delete(connectorExternalCodeSessions)
+    .where(eq(connectorExternalCodeSessions.orgId, orgId));
   await db.delete(variables).where(eq(variables.orgId, orgId));
   await db.delete(usageDaily).where(eq(usageDaily.orgId, orgId));
   await db.delete(exportJobs).where(eq(exportJobs.orgId, orgId));
@@ -551,6 +555,9 @@ async function deleteUserData(db: Db, userId: string): Promise<void> {
   await db
     .delete(connectorOauthDeviceAuthorizationSessions)
     .where(eq(connectorOauthDeviceAuthorizationSessions.userId, userId));
+  await db
+    .delete(connectorExternalCodeSessions)
+    .where(eq(connectorExternalCodeSessions.userId, userId));
   await db.delete(deviceCodes).where(eq(deviceCodes.userId, userId));
   await db
     .delete(userPermissionGrants)

--- a/turbo/apps/api/src/signals/services/zero-connector-data.service.ts
+++ b/turbo/apps/api/src/signals/services/zero-connector-data.service.ts
@@ -1307,6 +1307,7 @@ function connectorTokenOutputMetadataForAuthMethod(args: {
 
   switch (method.grant.kind) {
     case "auth-code":
+    case "external-code":
     case "device-auth": {
       const outputSecretNames = Object.fromEntries(
         Object.entries(grantMetadata.outputs).map(([outputName, output]) => {

--- a/turbo/apps/platform/src/__tests__/page-helper.ts
+++ b/turbo/apps/platform/src/__tests__/page-helper.ts
@@ -115,12 +115,17 @@ export async function setupPage(options: {
   // Reading featureSwitch$ is synchronous, so the cache must be in place
   // before bootstrap runs (especially for `detachedSetupPage`, which does
   // not await the bootstrap-driven SWR refresh).
+  const defaultOrgId = "org_default";
+  const activeOrgId = options.org ? options.org.activeOrg?.id : defaultOrgId;
   options.context.store.set(clearFeatureSwitchCacheForTest$);
   if (options.featureSwitches) {
     setMockFeatureSwitches(options.featureSwitches);
     options.context.store.set(
       setFeatureSwitchCacheForTest$,
-      getAllFeatureStates({ overrides: options.featureSwitches }),
+      getAllFeatureStates({
+        orgId: activeOrgId,
+        overrides: options.featureSwitches,
+      }),
     );
   }
 
@@ -143,8 +148,8 @@ export async function setupPage(options: {
     mockOrganization(options.org);
   } else {
     mockOrganization({
-      activeOrg: { id: "org_default", name: "Default Org" },
-      memberships: [{ id: "org_default" }],
+      activeOrg: { id: defaultOrgId, name: "Default Org" },
+      memberships: [{ id: defaultOrgId }],
     });
   }
   options.context.signal.addEventListener("abort", () => {

--- a/turbo/apps/platform/src/mocks/handlers/api-connectors.ts
+++ b/turbo/apps/platform/src/mocks/handlers/api-connectors.ts
@@ -4,11 +4,13 @@ import {
   type ConnectorType,
 } from "@vm0/connectors/connectors";
 import type {
+  ConnectorExternalCodeSessionStartResponse,
   ConnectorOauthDeviceAuthSessionPollResponse,
   ConnectorOauthDeviceAuthSessionStartResponse,
   ConnectorResponse,
 } from "@vm0/api-contracts/contracts/connector-schemas";
 import {
+  zeroConnectorExternalCodeSessionContract,
   zeroConnectorManualGrantContract,
   zeroConnectorOauthDeviceAuthSessionContract,
   zeroConnectorsByTypeContract,
@@ -30,6 +32,10 @@ let mockOauthDeviceAuthSessionStartResponse:
   | undefined;
 let mockOauthDeviceAuthSessionPollResponses: ConnectorOauthDeviceAuthSessionPollResponse[] =
   [];
+
+let mockExternalCodeSessionStartResponse:
+  | Partial<ConnectorExternalCodeSessionStartResponse>
+  | undefined;
 
 function createMockOauthDeviceAuthConnector(
   type: ConnectorType,
@@ -85,6 +91,39 @@ function createMockManualGrantConnector(
   };
 }
 
+function createMockExternalCodeConnector(
+  type: ConnectorType,
+  authMethod: ConnectorAuthMethodId,
+): ConnectorResponse {
+  const now = "2026-01-01T00:00:00.000Z";
+  return {
+    id: crypto.randomUUID(),
+    type,
+    authMethod,
+    externalId: `mock-${type}-account`,
+    externalUsername: `arn:aws:iam::000000000000:user/mock-${type}`,
+    externalEmail: null,
+    oauthScopes: ["openid"],
+    connectionStatus: "connected",
+    tokenExpiresAt: new Date(Date.parse(now) + 15 * 60 * 1000).toISOString(),
+    createdAt: now,
+    updatedAt: now,
+  };
+}
+
+function defaultExternalCodeSessionStartResponse(
+  type: ConnectorType,
+): ConnectorExternalCodeSessionStartResponse {
+  return {
+    sessionId: "00000000-0000-4000-8000-000000000002",
+    sessionToken: `mock-${type}-external-code-session-token`,
+    type,
+    status: "pending",
+    authorizationUrl: `https://oauth.test/${type}/external-code`,
+    expiresIn: 600,
+  };
+}
+
 export function setMockConnectors(connectors: ConnectorResponse[]): void {
   mockConnectors = connectors;
 }
@@ -106,6 +145,7 @@ function upsertMockConnector(connector: ConnectorResponse): void {
 function resetMockOauthDeviceAuth(): void {
   mockOauthDeviceAuthSessionStartResponse = undefined;
   mockOauthDeviceAuthSessionPollResponses = [];
+  mockExternalCodeSessionStartResponse = undefined;
 }
 
 export function setMockOauthDeviceAuthSessionStartResponse(
@@ -202,6 +242,31 @@ export const apiConnectorsHandlers = [
         upsertMockConnector(response.connector);
       }
       return respond(200, response);
+    },
+  ),
+
+  mockApi(
+    zeroConnectorExternalCodeSessionContract.create,
+    ({ params, respond }) => {
+      return respond(200, {
+        ...defaultExternalCodeSessionStartResponse(params.type),
+        ...mockExternalCodeSessionStartResponse,
+        type: mockExternalCodeSessionStartResponse?.type ?? params.type,
+      });
+    },
+  ),
+
+  mockApi(
+    zeroConnectorExternalCodeSessionContract.complete,
+    ({ body, params, respond }) => {
+      if (!body.code) {
+        return respond(400, {
+          error: { message: "Missing authorization code", code: "BAD_REQUEST" },
+        });
+      }
+      const connector = createMockExternalCodeConnector(params.type, "cli");
+      upsertMockConnector(connector);
+      return respond(200, { status: "complete", connector });
     },
   ),
 ];

--- a/turbo/apps/platform/src/signals/external/feature-switch.ts
+++ b/turbo/apps/platform/src/signals/external/feature-switch.ts
@@ -1,5 +1,8 @@
 import { command, computed } from "ccstate";
-import { getAllFeatureStates } from "@vm0/core/feature-switch";
+import {
+  getAllFeatureStates,
+  isFeatureSwitchUserOverridable,
+} from "@vm0/core/feature-switch";
 import { zeroFeatureSwitchesContract } from "@vm0/api-contracts/contracts/zero-feature-switches";
 import { FeatureSwitchKey } from "@vm0/connectors/feature-switch-key";
 import { clerk$ } from "../auth";
@@ -36,7 +39,7 @@ function applySwitches(
   }
   for (const key of Object.values(FeatureSwitchKey)) {
     const value = overrides[key];
-    if (value !== undefined) {
+    if (value !== undefined && isFeatureSwitchUserOverridable(key)) {
       result[key] = Boolean(value);
     }
   }

--- a/turbo/apps/platform/src/signals/external/feature-switch.ts
+++ b/turbo/apps/platform/src/signals/external/feature-switch.ts
@@ -1,8 +1,5 @@
 import { command, computed } from "ccstate";
-import {
-  getAllFeatureStates,
-  isFeatureSwitchUserOverridable,
-} from "@vm0/core/feature-switch";
+import { getAllFeatureStates } from "@vm0/core/feature-switch";
 import { zeroFeatureSwitchesContract } from "@vm0/api-contracts/contracts/zero-feature-switches";
 import { FeatureSwitchKey } from "@vm0/connectors/feature-switch-key";
 import { clerk$ } from "../auth";
@@ -39,7 +36,7 @@ function applySwitches(
   }
   for (const key of Object.values(FeatureSwitchKey)) {
     const value = overrides[key];
-    if (value !== undefined && isFeatureSwitchUserOverridable(key)) {
+    if (value !== undefined) {
       result[key] = Boolean(value);
     }
   }

--- a/turbo/apps/platform/src/signals/zero-page/settings/connectors.ts
+++ b/turbo/apps/platform/src/signals/zero-page/settings/connectors.ts
@@ -18,10 +18,12 @@ import {
   getConnectorTags,
   hasRequiredConnectorAuthMethodScopes,
   hasConnectorDeviceAuthGrant,
+  hasConnectorExternalCodeGrant,
 } from "@vm0/connectors/connector-utils";
 import { shouldShowGoogleSecurityWarningNotice } from "../../../lib/google-security-warning.ts";
 import {
   zeroConnectorScopeDiffContract,
+  zeroConnectorExternalCodeSessionContract,
   zeroConnectorOauthDeviceAuthSessionContract,
   zeroConnectorOauthStartContract,
   zeroConnectorManualGrantContract,
@@ -117,6 +119,7 @@ function getAvailableConnectorConnectAuthMethods(
         break;
       }
       case "auth-code":
+      case "external-code":
       case "device-auth":
       case "manual": {
         break;
@@ -557,6 +560,19 @@ type ActiveConnectorOAuthDeviceAuthState = {
   readonly errorMessage: string | null;
 };
 
+type ActiveConnectorExternalCodeState = {
+  readonly connectorType: ConnectorType;
+  readonly authMethod: ConnectorAuthMethodId;
+  readonly requestId: string;
+  readonly sessionId: string;
+  readonly sessionToken: string;
+  readonly authorizationUrl: string;
+  readonly expiresAtMs: number;
+  readonly authorizationOpened: boolean;
+  readonly code: string;
+  readonly errorMessage: string | null;
+};
+
 export type ConnectorOAuthDeviceAuthState =
   | {
       readonly status: "idle";
@@ -578,6 +594,27 @@ export type ConnectorOAuthDeviceAuthState =
       readonly message: string;
     };
 
+export type ConnectorExternalCodeState =
+  | {
+      readonly status: "idle";
+      readonly connectorType: ConnectorType | null;
+    }
+  | {
+      readonly status: "starting";
+      readonly connectorType: ConnectorType;
+      readonly authMethod: ConnectorAuthMethodId;
+      readonly requestId: string;
+    }
+  | (ActiveConnectorExternalCodeState & {
+      readonly status: "pending" | "completing";
+    })
+  | {
+      readonly status: "expired" | "error";
+      readonly connectorType: ConnectorType;
+      readonly authMethod: ConnectorAuthMethodId;
+      readonly message: string;
+    };
+
 type ConnectorConnectFlowState = {
   readonly type: ConnectorType;
   readonly id: string;
@@ -593,7 +630,18 @@ const internalConnectorOAuthDeviceAuthState$ =
   state<ConnectorOAuthDeviceAuthState>(
     createIdleConnectorOAuthDeviceAuthState(),
   );
+
+function createIdleConnectorExternalCodeState(
+  connectorType: ConnectorType | null = null,
+): ConnectorExternalCodeState {
+  return { status: "idle", connectorType };
+}
+
+const internalConnectorExternalCodeState$ = state<ConnectorExternalCodeState>(
+  createIdleConnectorExternalCodeState(),
+);
 const resetConnectorOAuthDeviceAuthFlowSignal$ = resetSignal();
+const resetConnectorExternalCodeFlowSignal$ = resetSignal();
 const connectorOAuthDeviceAuthStartOptionValues$ = state<
   Record<string, Record<string, string>>
 >({});
@@ -612,11 +660,23 @@ export const setSelectedConnectorType$ = command(
         createIdleConnectorOAuthDeviceAuthState(type),
       );
     }
+    const externalCodeCurrent = get(internalConnectorExternalCodeState$);
+    if (type !== externalCodeCurrent.connectorType) {
+      set(resetConnectorExternalCodeFlowSignal$);
+      set(
+        internalConnectorExternalCodeState$,
+        createIdleConnectorExternalCodeState(type),
+      );
+    }
   },
 );
 
 export const connectorOAuthDeviceAuthState$ = computed((get) => {
   return get(internalConnectorOAuthDeviceAuthState$);
+});
+
+export const connectorExternalCodeState$ = computed((get) => {
+  return get(internalConnectorExternalCodeState$);
 });
 
 function connectorOAuthDeviceAuthStartOptionsKey(
@@ -1341,6 +1401,332 @@ export const connectConnectorOAuthDeviceAuthAndSettle$ = command(
 );
 
 // ---------------------------------------------------------------------------
+// External-code authorization flow state
+// ---------------------------------------------------------------------------
+
+type ConnectConnectorExternalCodeParams = {
+  readonly type: ConnectorType;
+  readonly authMethod: ConnectorAuthMethodId;
+};
+
+type CompleteConnectorExternalCodeParams = {
+  readonly type: ConnectorType;
+  readonly authMethod: ConnectorAuthMethodId;
+  readonly options: PostConnectOptions;
+};
+
+function createConnectorExternalCodeRequestId(type: ConnectorType): string {
+  return `${type}-external-code-${Date.now()}-${Math.random().toString(36).slice(2)}`;
+}
+
+function externalCodeErrorMessage(error: unknown): string {
+  return error instanceof Error ? error.message : "Connection failed";
+}
+
+function isCurrentConnectorExternalCodeRequest(
+  state: ConnectorExternalCodeState,
+  type: ConnectorType,
+  authMethod: ConnectorAuthMethodId,
+  requestId: string,
+): state is ActiveConnectorExternalCodeState & {
+  readonly status: "pending" | "completing";
+} {
+  return (
+    (state.status === "pending" || state.status === "completing") &&
+    state.connectorType === type &&
+    state.authMethod === authMethod &&
+    state.requestId === requestId
+  );
+}
+
+export const clearConnectorExternalCode$ = command(({ set }) => {
+  set(resetConnectorExternalCodeFlowSignal$);
+  set(
+    internalConnectorExternalCodeState$,
+    createIdleConnectorExternalCodeState(),
+  );
+});
+
+export const setConnectorExternalCodeAuthorizationCode$ = command(
+  (
+    { get, set },
+    args: {
+      readonly type: ConnectorType;
+      readonly authMethod: ConnectorAuthMethodId;
+      readonly code: string;
+    },
+  ) => {
+    const current = get(internalConnectorExternalCodeState$);
+    if (
+      (current.status !== "pending" && current.status !== "completing") ||
+      current.connectorType !== args.type ||
+      current.authMethod !== args.authMethod
+    ) {
+      return false;
+    }
+    set(internalConnectorExternalCodeState$, {
+      ...current,
+      code: args.code,
+      errorMessage: null,
+    });
+    return true;
+  },
+);
+
+export const openConnectorExternalCodeAuthorizationPage$ = command(
+  (
+    { get, set },
+    type: ConnectorType,
+    authMethod: ConnectorAuthMethodId,
+  ): boolean => {
+    const current = get(internalConnectorExternalCodeState$);
+    if (
+      current.status !== "pending" ||
+      current.connectorType !== type ||
+      current.authMethod !== authMethod
+    ) {
+      return false;
+    }
+
+    const authWindow = window.open(
+      current.authorizationUrl,
+      "_blank",
+      "noopener,noreferrer",
+    );
+    if (authWindow) {
+      authWindow.opener = null;
+    }
+
+    set(internalConnectorExternalCodeState$, {
+      ...current,
+      authorizationOpened: true,
+      errorMessage: null,
+    });
+    return true;
+  },
+);
+
+export const connectConnectorExternalCode$ = command(
+  async (
+    { get, set },
+    args: ConnectConnectorExternalCodeParams,
+    signal: AbortSignal,
+  ): Promise<boolean> => {
+    const { type, authMethod } = args;
+    if (!hasConnectorExternalCodeGrant(type)) {
+      throw new Error(`${type} does not use external-code authorization`);
+    }
+    assertConnectorUsesExternalCodeMethod(type, authMethod);
+
+    const flow = createConnectorConnectFlowState(type);
+    set(internalConnectFlowState$, flow);
+    let requestId: string | null = null;
+    return await withCleanup(
+      (async () => {
+        requestId = createConnectorExternalCodeRequestId(type);
+        const flowSignal = set(resetConnectorExternalCodeFlowSignal$, signal);
+        set(internalConnectorExternalCodeState$, {
+          status: "starting",
+          connectorType: type,
+          authMethod,
+          requestId,
+        });
+
+        const createClient = get(zeroClient$);
+        const client = createClient(zeroConnectorExternalCodeSessionContract);
+        const startSettled = await settle(
+          accept(
+            client.create({
+              params: { type },
+              body: { authMethod },
+              fetchOptions: { signal: flowSignal },
+            }),
+            [200],
+            { toast: false },
+          ),
+          flowSignal,
+        );
+        const startResult = startSettled.ok ? startSettled.value.body : null;
+        if (!startSettled.ok) {
+          if (flowSignal.aborted) {
+            return false;
+          }
+          set(internalConnectorExternalCodeState$, {
+            status: "error",
+            connectorType: type,
+            authMethod,
+            message: externalCodeErrorMessage(startSettled.error),
+          });
+        }
+        flowSignal.throwIfAborted();
+        if (!startResult) {
+          return false;
+        }
+
+        set(internalConnectorExternalCodeState$, {
+          status: "pending",
+          connectorType: type,
+          authMethod,
+          requestId,
+          sessionId: startResult.sessionId,
+          sessionToken: startResult.sessionToken,
+          authorizationUrl: startResult.authorizationUrl,
+          expiresAtMs:
+            Date.now() + secondsToMilliseconds(startResult.expiresIn),
+          authorizationOpened: false,
+          code: "",
+          errorMessage: null,
+        });
+        return true;
+      })(),
+      () => {
+        set(internalConnectFlowState$, (current) => {
+          return current?.id === flow.id ? null : current;
+        });
+        set(internalConnectorExternalCodeState$, (current) => {
+          if (
+            !signal.aborted ||
+            requestId === null ||
+            current.connectorType !== type ||
+            (current.status !== "starting" &&
+              current.status !== "pending" &&
+              current.status !== "completing") ||
+            current.authMethod !== authMethod ||
+            current.requestId !== requestId
+          ) {
+            return current;
+          }
+          return createIdleConnectorExternalCodeState(type);
+        });
+      },
+    );
+  },
+);
+
+const completeConnectorExternalCode$ = command(
+  async (
+    { get, set },
+    args: CompleteConnectorExternalCodeParams,
+    signal: AbortSignal,
+  ): Promise<boolean> => {
+    const { type, authMethod, options } = args;
+    assertConnectorUsesExternalCodeMethod(type, authMethod);
+
+    const current = get(internalConnectorExternalCodeState$);
+    if (
+      current.status !== "pending" ||
+      current.connectorType !== type ||
+      current.authMethod !== authMethod
+    ) {
+      return false;
+    }
+    if (Date.now() > current.expiresAtMs) {
+      set(internalConnectorExternalCodeState$, {
+        status: "expired",
+        connectorType: type,
+        authMethod,
+        message: "Connection session expired. Start again to retry.",
+      });
+      return false;
+    }
+
+    const code = current.code.trim();
+    if (!code) {
+      const connectorLabel = CONNECTOR_TYPES[type].label;
+      set(internalConnectorExternalCodeState$, {
+        ...current,
+        errorMessage: `Enter the authorization code from ${connectorLabel}.`,
+      });
+      return false;
+    }
+
+    set(internalConnectorExternalCodeState$, {
+      ...current,
+      status: "completing",
+      code,
+      errorMessage: null,
+    });
+
+    const flowSignal = set(resetConnectorExternalCodeFlowSignal$, signal);
+    const createClient = get(zeroClient$);
+    const client = createClient(zeroConnectorExternalCodeSessionContract);
+    const completeSettled = await settle(
+      accept(
+        client.complete({
+          params: { type, sessionId: current.sessionId },
+          body: {
+            sessionToken: current.sessionToken,
+            code,
+          },
+          fetchOptions: { signal: flowSignal },
+        }),
+        [200],
+        { toast: false },
+      ),
+      flowSignal,
+    );
+    signal.throwIfAborted();
+    flowSignal.throwIfAborted();
+    const latest = get(internalConnectorExternalCodeState$);
+    if (
+      !isCurrentConnectorExternalCodeRequest(
+        latest,
+        type,
+        authMethod,
+        current.requestId,
+      )
+    ) {
+      return false;
+    }
+
+    if (!completeSettled.ok) {
+      if (flowSignal.aborted) {
+        return false;
+      }
+      set(internalConnectorExternalCodeState$, {
+        ...latest,
+        status: "pending",
+        errorMessage: externalCodeErrorMessage(completeSettled.error),
+      });
+      return false;
+    }
+
+    set(finishConnectorConnection$, type, {
+      ...options,
+      clearSelectedConnector: true,
+    });
+    set(
+      internalConnectorExternalCodeState$,
+      createIdleConnectorExternalCodeState(),
+    );
+    return true;
+  },
+);
+
+export const completeConnectorExternalCodeAndSettle$ = command(
+  async (
+    { set },
+    args: CompleteConnectorExternalCodeParams & {
+      readonly onSuccess: () => void | Promise<void>;
+    },
+    signal: AbortSignal,
+  ): Promise<void> => {
+    const connected = await set(
+      completeConnectorExternalCode$,
+      {
+        type: args.type,
+        authMethod: args.authMethod,
+        options: args.options,
+      },
+      signal,
+    );
+    if (connected) {
+      await args.onSuccess();
+    }
+  },
+);
+
+// ---------------------------------------------------------------------------
 // Standalone mode detection
 // ---------------------------------------------------------------------------
 
@@ -1440,6 +1826,21 @@ function assertConnectorUsesDeviceAuthMethod(
   }
   if (method.grant.kind !== "device-auth") {
     throw new Error(`${type} ${authMethod} does not use a device-auth grant`);
+  }
+}
+
+function assertConnectorUsesExternalCodeMethod(
+  type: ConnectorType,
+  authMethod: ConnectorAuthMethodId,
+): void {
+  const method = getConnectorAuthMethod(type, authMethod);
+  if (!method) {
+    throw new Error(`${type} does not have ${authMethod} auth method`);
+  }
+  if (method.grant.kind !== "external-code") {
+    throw new Error(
+      `${type} ${authMethod} does not use an external-code grant`,
+    );
   }
 }
 

--- a/turbo/apps/platform/src/signals/zero-page/settings/connectors.ts
+++ b/turbo/apps/platform/src/signals/zero-page/settings/connectors.ts
@@ -568,7 +568,6 @@ type ActiveConnectorExternalCodeState = {
   readonly sessionToken: string;
   readonly authorizationUrl: string;
   readonly expiresAtMs: number;
-  readonly authorizationOpened: boolean;
   readonly code: string;
   readonly errorMessage: string | null;
 };
@@ -1499,7 +1498,6 @@ export const openConnectorExternalCodeAuthorizationPage$ = command(
 
     set(internalConnectorExternalCodeState$, {
       ...current,
-      authorizationOpened: true,
       errorMessage: null,
     });
     return true;
@@ -1573,7 +1571,6 @@ export const connectConnectorExternalCode$ = command(
           authorizationUrl: startResult.authorizationUrl,
           expiresAtMs:
             Date.now() + secondsToMilliseconds(startResult.expiresIn),
-          authorizationOpened: false,
           code: "",
           errorMessage: null,
         });

--- a/turbo/apps/platform/src/views/conn/__tests__/add-connection-dialog.test.tsx
+++ b/turbo/apps/platform/src/views/conn/__tests__/add-connection-dialog.test.tsx
@@ -476,9 +476,11 @@ describe("connect modal - content by auth method", () => {
         "Sign in with AWS and paste the authorization code that AWS displays.",
       ),
     ).toBeInTheDocument();
-    expect(
-      screen.getByText(/temporary AWS connector.*up to 12 hours/),
-    ).toBeInTheDocument();
+    const expiryText = screen.getByText(
+      /temporary AWS connector.*up to 12 hours/i,
+    );
+    expect(expiryText).toBeInTheDocument();
+    expect(expiryText.tagName).toBe("STRONG");
     expect(screen.getByText("Start AWS sign-in")).toBeInTheDocument();
     expect(open).not.toHaveBeenCalled();
 
@@ -487,6 +489,9 @@ describe("connect modal - content by auth method", () => {
     await waitFor(() => {
       expect(screen.getByText("Open AWS sign-in")).toBeInTheDocument();
     });
+    expect(
+      screen.getByText(/temporary AWS connector.*up to 12 hours/i),
+    ).toBeInTheDocument();
     expect(submittedStartBody).toStrictEqual({ authMethod: "cli" });
     expect(open).not.toHaveBeenCalled();
 

--- a/turbo/apps/platform/src/views/conn/__tests__/add-connection-dialog.test.tsx
+++ b/turbo/apps/platform/src/views/conn/__tests__/add-connection-dialog.test.tsx
@@ -13,6 +13,7 @@ import userEvent from "@testing-library/user-event";
 import type { ConnectorType } from "@vm0/connectors/connectors";
 import { FeatureSwitchKey } from "@vm0/connectors/feature-switch-key";
 import {
+  zeroConnectorExternalCodeSessionContract,
   zeroConnectorManualGrantContract,
   zeroConnectorOauthDeviceAuthSessionContract,
   zeroConnectorOauthStartContract,
@@ -36,17 +37,27 @@ import {
 
 const context = testContext();
 const mockApi = createMockApi(context);
+const STAFF_ORG_ID = "org_3ANttyrbWYJk6JKRSTRLEsbsDLe";
 
 async function openConnectModal(
   connectorType: ConnectorType,
   options: {
     featureSwitches?: Partial<Record<FeatureSwitchKey, boolean>>;
+    orgId?: string;
   } = {},
 ) {
   detachedSetupPage({
     context,
     path: "/connectors",
-    ...options,
+    featureSwitches: options.featureSwitches,
+    ...(options.orgId
+      ? {
+          org: {
+            activeOrg: { id: options.orgId, name: "Test Org" },
+            memberships: [{ id: options.orgId }],
+          },
+        }
+      : {}),
   });
   await waitFor(() => {
     expect(
@@ -427,6 +438,171 @@ describe("connect modal - content by auth method", () => {
     expect(
       screen.queryByTestId("connector-oauth-device-code"),
     ).not.toBeInTheDocument();
+  });
+
+  it("runs AWS external-code sign-in after showing the authorization page", async () => {
+    let submittedStartBody:
+      | {
+          readonly authMethod: string;
+        }
+      | undefined;
+    server.use(
+      mockApi(
+        zeroConnectorExternalCodeSessionContract.create,
+        ({ body, params, respond }) => {
+          submittedStartBody = body;
+          return respond(200, {
+            sessionId: "00000000-0000-4000-8000-000000000201",
+            sessionToken: "aws-external-code-session-token",
+            type: params.type,
+            status: "pending",
+            authorizationUrl: "https://oauth.test/aws/external-code",
+            expiresIn: 600,
+          });
+        },
+      ),
+    );
+    const open = vi
+      .spyOn(window, "open")
+      .mockReturnValue(createMockAuthWindow(false) as unknown as Window);
+
+    await openConnectModal("aws", { featureSwitches: {}, orgId: STAFF_ORG_ID });
+
+    await waitFor(() => {
+      expect(screen.getByRole("heading", { name: "AWS" })).toBeInTheDocument();
+    });
+    expect(
+      screen.getByText(
+        "Sign in with AWS and paste the authorization code that AWS displays.",
+      ),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByText(
+        /vm0 can call AWS APIs allowed by the selected AWS identity/,
+      ),
+    ).toBeInTheDocument();
+    expect(screen.getByText("Start AWS sign-in")).toBeInTheDocument();
+    expect(open).not.toHaveBeenCalled();
+
+    await userEvent.click(screen.getByText("Start AWS sign-in"));
+
+    await waitFor(() => {
+      expect(screen.getByText("Open AWS sign-in")).toBeInTheDocument();
+    });
+    expect(submittedStartBody).toStrictEqual({ authMethod: "cli" });
+    expect(open).not.toHaveBeenCalled();
+
+    await userEvent.click(screen.getByText("Open AWS sign-in"));
+
+    await waitFor(() => {
+      expect(open).toHaveBeenCalledWith(
+        "https://oauth.test/aws/external-code",
+        "_blank",
+        "noopener,noreferrer",
+      );
+    });
+
+    await userEvent.type(
+      screen.getByTestId("connector-external-code-input"),
+      "AWS-CODE",
+    );
+    await userEvent.click(
+      screen.getByTestId("connector-external-code-complete"),
+    );
+
+    await waitFor(() => {
+      expect(
+        screen.getByText(/You've successfully connected with\s+AWS/),
+      ).toBeInTheDocument();
+    });
+    expect(
+      screen.queryByTestId("connector-external-code-input"),
+    ).not.toBeInTheDocument();
+  });
+
+  it("keeps AWS external-code sign-in usable when noopener returns no window handle", async () => {
+    const open = vi.spyOn(window, "open").mockReturnValue(null);
+
+    await openConnectModal("aws", { featureSwitches: {}, orgId: STAFF_ORG_ID });
+    await userEvent.click(await screen.findByText("Start AWS sign-in"));
+    await userEvent.click(await screen.findByText("Open AWS sign-in"));
+
+    expect(open).toHaveBeenCalledWith(
+      "https://oauth.test/aws/external-code",
+      "_blank",
+      "noopener,noreferrer",
+    );
+    expect(screen.queryByText(/Could not open/)).not.toBeInTheDocument();
+
+    await userEvent.type(
+      screen.getByTestId("connector-external-code-input"),
+      "AWS-CODE",
+    );
+    await userEvent.click(
+      screen.getByTestId("connector-external-code-complete"),
+    );
+
+    await waitFor(() => {
+      expect(
+        screen.getByText(/You've successfully connected with\s+AWS/),
+      ).toBeInTheDocument();
+    });
+  });
+
+  it("aborts an in-flight AWS external-code completion when the dialog closes", async () => {
+    let completeStarted = false;
+    let completeAborted = false;
+    server.use(
+      mockApi(
+        zeroConnectorExternalCodeSessionContract.create,
+        ({ body, params, respond }) => {
+          expect(body).toStrictEqual({ authMethod: "cli" });
+          return respond(200, {
+            sessionId: "00000000-0000-4000-8000-000000000202",
+            sessionToken: "aws-external-code-session-token",
+            type: params.type,
+            status: "pending",
+            authorizationUrl: "https://oauth.test/aws/external-code",
+            expiresIn: 600,
+          });
+        },
+      ),
+      mockApi(
+        zeroConnectorExternalCodeSessionContract.complete,
+        ({ signal, never }) => {
+          completeStarted = true;
+          signal.addEventListener(
+            "abort",
+            () => {
+              completeAborted = true;
+            },
+            { once: true },
+          );
+          return never();
+        },
+      ),
+    );
+
+    await openConnectModal("aws", { featureSwitches: {}, orgId: STAFF_ORG_ID });
+    await userEvent.click(await screen.findByText("Start AWS sign-in"));
+    await userEvent.type(
+      await screen.findByTestId("connector-external-code-input"),
+      "AWS-CODE",
+    );
+    await userEvent.click(
+      screen.getByTestId("connector-external-code-complete"),
+    );
+
+    await waitFor(() => {
+      expect(completeStarted).toBeTruthy();
+    });
+
+    click(screen.getByLabelText(/close/i));
+
+    await waitFor(() => {
+      expect(completeAborted).toBeTruthy();
+    });
+    expect(screen.queryByRole("dialog")).not.toBeInTheDocument();
   });
 
   it("shows manual grant form for api-token connectors (CONN-C-019)", async () => {

--- a/turbo/apps/platform/src/views/conn/__tests__/add-connection-dialog.test.tsx
+++ b/turbo/apps/platform/src/views/conn/__tests__/add-connection-dialog.test.tsx
@@ -477,9 +477,7 @@ describe("connect modal - content by auth method", () => {
       ),
     ).toBeInTheDocument();
     expect(
-      screen.getByText(
-        /vm0 can call AWS APIs allowed by the selected AWS identity/,
-      ),
+      screen.getByText(/temporary AWS connector.*up to 12 hours/),
     ).toBeInTheDocument();
     expect(screen.getByText("Start AWS sign-in")).toBeInTheDocument();
     expect(open).not.toHaveBeenCalled();

--- a/turbo/apps/platform/src/views/zero-page/components/settings/add-connection-dialog.tsx
+++ b/turbo/apps/platform/src/views/zero-page/components/settings/add-connection-dialog.tsx
@@ -795,13 +795,13 @@ function ExternalCodePendingContent({
   const connectorLabel = CONNECTOR_TYPES[type].label;
   return (
     <div className="flex flex-col gap-3">
-      {method.connectNotice ? (
-        <ConnectorAuthMethodConnectNotice notice={method.connectNotice} />
-      ) : null}
       <p className="text-sm text-muted-foreground">
         Open {connectorLabel} sign-in, then paste the authorization code
         displayed by {connectorLabel}.
       </p>
+      {method.connectNotice ? (
+        <ConnectorAuthMethodConnectNotice notice={method.connectNotice} />
+      ) : null}
       <div className="flex items-center gap-2">
         <Button
           type="button"

--- a/turbo/apps/platform/src/views/zero-page/components/settings/add-connection-dialog.tsx
+++ b/turbo/apps/platform/src/views/zero-page/components/settings/add-connection-dialog.tsx
@@ -31,13 +31,19 @@ import {
   allConnectorTypes$,
   connectFlowType$,
   pollingOAuthAuthCodeConnectorType$,
+  connectorExternalCodeState$,
   connectorOAuthDeviceAuthState$,
   connectConnectorOAuthAuthCodeAndSettle$,
   connectConnectorOAuthDeviceAuthAndSettle$,
+  connectConnectorExternalCode$,
+  completeConnectorExternalCodeAndSettle$,
+  openConnectorExternalCodeAuthorizationPage$,
   openConnectorOAuthDeviceAuthVerificationPage$,
+  clearConnectorExternalCode$,
   clearConnectorOAuthDeviceAuth$,
   connectorOAuthDeviceAuthStartOptionValuesFor$,
   setConnectorOAuthDeviceAuthStartOptionValue$,
+  setConnectorExternalCodeAuthorizationCode$,
   runConnectorConnectSuccess$,
   submitManualGrant$,
   setManualGrantFormValue$,
@@ -47,6 +53,7 @@ import {
   isStandaloneMode,
   connectorCurrentConnectionStatus,
   connectorExpiryCountdownText,
+  type ConnectorExternalCodeState,
   type ConnectorOAuthDeviceAuthState,
   type ConnectorTypeWithStatus,
 } from "../../../../signals/zero-page/settings/connectors.ts";
@@ -75,6 +82,9 @@ function connectedStatusText(item: ConnectorTypeWithStatus): string {
     return expiryText;
   }
   if (item.connector?.externalUsername) {
+    if (item.connector.externalUsername.startsWith("arn:")) {
+      return `Connected as ${item.connector.externalUsername}`;
+    }
     return `Connected as @${item.connector.externalUsername}`;
   }
   return "Connected";
@@ -111,6 +121,24 @@ type ConnectOAuthDeviceAuthAndSettleFn = (
   signal: AbortSignal,
 ) => Promise<void>;
 
+type ConnectExternalCodeFn = (
+  args: {
+    readonly type: ConnectorType;
+    readonly authMethod: ConnectorAuthMethodId;
+  },
+  signal: AbortSignal,
+) => Promise<void>;
+
+type CompleteExternalCodeAndSettleFn = (
+  args: {
+    readonly type: ConnectorType;
+    readonly authMethod: ConnectorAuthMethodId;
+    readonly onSuccess: () => void | Promise<void>;
+    readonly options: PostConnectOptions;
+  },
+  signal: AbortSignal,
+) => Promise<void>;
+
 type ConnectModalContentProps = {
   item: ConnectorTypeWithStatus;
   onSuccess: () => void | Promise<void>;
@@ -122,6 +150,8 @@ type ConnectMethodContentProps = ConnectModalContentProps & {
   method: ConnectorAuthMethodConfig;
   connectOAuthAuthCodeAndSettle: ConnectOAuthAuthCodeAndSettleFn;
   connectOAuthDeviceAuthAndSettle: ConnectOAuthDeviceAuthAndSettleFn;
+  connectExternalCode: ConnectExternalCodeFn;
+  completeExternalCodeAndSettle: CompleteExternalCodeAndSettleFn;
   submitManualGrant: SubmitManualGrantFn;
   manualGrantSubmitting: boolean;
   signal: AbortSignal;
@@ -154,11 +184,34 @@ function connectorOAuthDeviceAuthFlowIsActive(
   );
 }
 
+function connectorExternalCodeFlowIsActive(
+  state: ConnectorExternalCodeState,
+  type: ConnectorType,
+): boolean {
+  return (
+    state.connectorType === type &&
+    (state.status === "starting" ||
+      state.status === "pending" ||
+      state.status === "completing")
+  );
+}
+
 function connectorOAuthDeviceAuthStateForMethod(
   state: ConnectorOAuthDeviceAuthState,
   type: ConnectorType,
   authMethod: ConnectorAuthMethodId,
 ): ConnectorOAuthDeviceAuthState | null {
+  if (state.connectorType !== type || state.status === "idle") {
+    return null;
+  }
+  return state.authMethod === authMethod ? state : null;
+}
+
+function connectorExternalCodeStateForMethod(
+  state: ConnectorExternalCodeState,
+  type: ConnectorType,
+  authMethod: ConnectorAuthMethodId,
+): ConnectorExternalCodeState | null {
   if (state.connectorType !== type || state.status === "idle") {
     return null;
   }
@@ -652,6 +705,203 @@ function OAuthDeviceAuthConnectMethodContent(props: ConnectMethodContentProps) {
   );
 }
 
+type PendingConnectorExternalCodeState = Extract<
+  ConnectorExternalCodeState,
+  { readonly status: "pending" | "completing" }
+>;
+type ExternalCodeButtonHandler = (event: unknown) => void;
+
+function AwsExternalCodeWarning({ type }: { type: ConnectorType }) {
+  if (type !== "aws") {
+    return null;
+  }
+  return (
+    <div className="rounded-md border border-amber-300 bg-amber-50 p-3 text-sm text-amber-950 dark:border-amber-900/60 dark:bg-amber-950/30 dark:text-amber-100">
+      vm0 can call AWS APIs allowed by the selected AWS identity. This temporary
+      login may require reconnect after the AWS session expires.
+    </div>
+  );
+}
+
+function ExternalCodeStartContent({
+  type,
+  method,
+  current,
+  starting,
+  onStart,
+}: {
+  type: ConnectorType;
+  method: ConnectorAuthMethodConfig;
+  current: ConnectorExternalCodeState | null;
+  starting: boolean;
+  onStart: ExternalCodeButtonHandler;
+}) {
+  const terminalMessage =
+    current?.status === "expired" || current?.status === "error"
+      ? current.message
+      : null;
+  return (
+    <div className="flex flex-col gap-3">
+      {method.helpText && <ConnectorHelpText text={method.helpText} />}
+      <AwsExternalCodeWarning type={type} />
+      {terminalMessage ? (
+        <p className="text-sm text-destructive" role="alert">
+          {terminalMessage}
+        </p>
+      ) : null}
+      <Button
+        type="button"
+        variant="outline"
+        onClick={onStart}
+        disabled={starting}
+        className="w-full"
+      >
+        {starting
+          ? "Starting..."
+          : `Start ${CONNECTOR_TYPES[type].label} sign-in`}
+      </Button>
+    </div>
+  );
+}
+
+function ExternalCodePendingContent({
+  type,
+  current,
+  onOpen,
+  onCodeChange,
+  onComplete,
+}: {
+  type: ConnectorType;
+  current: PendingConnectorExternalCodeState;
+  onOpen: ExternalCodeButtonHandler;
+  onCodeChange: (code: string) => void;
+  onComplete: ExternalCodeButtonHandler;
+}) {
+  const completing = current.status === "completing";
+  const connectorLabel = CONNECTOR_TYPES[type].label;
+  return (
+    <div className="flex flex-col gap-3">
+      <AwsExternalCodeWarning type={type} />
+      <p className="text-sm text-muted-foreground">
+        Open {connectorLabel} sign-in, then paste the authorization code
+        displayed by {connectorLabel}.
+      </p>
+      <div className="flex items-center gap-2">
+        <Button
+          type="button"
+          variant="outline"
+          className="min-w-0 flex-1"
+          onClick={onOpen}
+        >
+          Open {connectorLabel} sign-in
+        </Button>
+        <CopyButton
+          type="button"
+          text={current.authorizationUrl}
+          className="p-2 hover:bg-accent"
+        />
+      </div>
+      <Input
+        value={current.code}
+        onChange={(event) => {
+          onCodeChange(event.target.value);
+        }}
+        placeholder="Authorization code"
+        autoComplete="one-time-code"
+        data-testid="connector-external-code-input"
+      />
+      {current.errorMessage && (
+        <p className="text-xs text-destructive" role="alert">
+          {current.errorMessage}
+        </p>
+      )}
+      <Button
+        type="button"
+        onClick={onComplete}
+        disabled={completing || current.code.trim().length === 0}
+        className="w-full"
+        data-testid="connector-external-code-complete"
+      >
+        {completing ? "Connecting..." : "Complete connection"}
+      </Button>
+    </div>
+  );
+}
+
+function ExternalCodeConnectMethodContent(props: ConnectMethodContentProps) {
+  const state = useGet(connectorExternalCodeState$);
+  const setCode = useSet(setConnectorExternalCodeAuthorizationCode$);
+  const openAuthorizationPage = useSet(
+    openConnectorExternalCodeAuthorizationPage$,
+  );
+  const current = connectorExternalCodeStateForMethod(
+    state,
+    props.item.type,
+    props.authMethod,
+  );
+  const starting = current?.status === "starting";
+
+  const start = onDomEventFn(async () => {
+    await props.connectExternalCode(
+      {
+        type: props.item.type,
+        authMethod: props.authMethod,
+      },
+      props.signal,
+    );
+  });
+
+  const complete = onDomEventFn(async () => {
+    await props.completeExternalCodeAndSettle(
+      {
+        type: props.item.type,
+        authMethod: props.authMethod,
+        onSuccess: props.onSuccess,
+        options: {
+          showPermissionDialog: props.showPermissionDialogOnConnect,
+        },
+      },
+      props.signal,
+    );
+  });
+
+  if (starting) {
+    return (
+      <p className="text-sm text-muted-foreground">Starting connection...</p>
+    );
+  }
+
+  if (current?.status === "pending" || current?.status === "completing") {
+    return (
+      <ExternalCodePendingContent
+        type={props.item.type}
+        current={current}
+        onOpen={() => {
+          openAuthorizationPage(props.item.type, props.authMethod);
+        }}
+        onCodeChange={(code) => {
+          setCode({
+            type: props.item.type,
+            authMethod: props.authMethod,
+            code,
+          });
+        }}
+        onComplete={complete}
+      />
+    );
+  }
+
+  return (
+    <ExternalCodeStartContent
+      type={props.item.type}
+      method={props.method}
+      current={current}
+      starting={starting}
+      onStart={start}
+    />
+  );
+}
+
 function ManualGrantConnectMethodContent(props: ConnectMethodContentProps) {
   if (props.method.grant.kind !== "manual") {
     return null;
@@ -679,6 +929,9 @@ function getConnectMethodContentComponent(
     }
     case "device-auth": {
       return OAuthDeviceAuthConnectMethodContent;
+    }
+    case "external-code": {
+      return ExternalCodeConnectMethodContent;
     }
     case "manual": {
       return ManualGrantConnectMethodContent;
@@ -786,6 +1039,8 @@ function StandardConnectMethodsContent({
   showPermissionDialogOnConnect,
   connectOAuthAuthCodeAndSettle,
   connectOAuthDeviceAuthAndSettle,
+  connectExternalCode,
+  completeExternalCodeAndSettle,
   submitManualGrant,
   manualGrantSubmitting,
   signal,
@@ -793,6 +1048,8 @@ function StandardConnectMethodsContent({
 }: ConnectModalContentProps & {
   connectOAuthAuthCodeAndSettle: ConnectOAuthAuthCodeAndSettleFn;
   connectOAuthDeviceAuthAndSettle: ConnectOAuthDeviceAuthAndSettleFn;
+  connectExternalCode: ConnectExternalCodeFn;
+  completeExternalCodeAndSettle: CompleteExternalCodeAndSettleFn;
   submitManualGrant: SubmitManualGrantFn;
   manualGrantSubmitting: boolean;
   signal: AbortSignal;
@@ -819,6 +1076,8 @@ function StandardConnectMethodsContent({
           showPermissionDialogOnConnect,
           connectOAuthAuthCodeAndSettle,
           connectOAuthDeviceAuthAndSettle,
+          connectExternalCode,
+          completeExternalCodeAndSettle,
           submitManualGrant,
           manualGrantSubmitting,
           signal,
@@ -838,6 +1097,12 @@ function ConnectModalContent({
   );
   const [, connectOAuthDeviceAuthAndSettle] = useLoadableSet(
     connectConnectorOAuthDeviceAuthAndSettle$,
+  );
+  const [, connectExternalCodeCommand] = useLoadableSet(
+    connectConnectorExternalCode$,
+  );
+  const [, completeExternalCodeAndSettleCommand] = useLoadableSet(
+    completeConnectorExternalCodeAndSettle$,
   );
   const [manualGrantLoadable, submitManualGrantCommand] =
     useLoadableSet(submitManualGrant$);
@@ -888,6 +1153,15 @@ function ConnectModalContent({
         signal,
       );
     };
+  const connectExternalCode: ConnectExternalCodeFn = async (args, signal) => {
+    await connectExternalCodeCommand(args, signal);
+  };
+  const completeExternalCodeAndSettle: CompleteExternalCodeAndSettleFn = async (
+    args,
+    signal,
+  ) => {
+    await completeExternalCodeAndSettleCommand(args, signal);
+  };
 
   const progressContent = hasAuthCodeGrant(item.type, item.availableAuthMethods)
     ? getOAuthAuthCodeProgressContent({
@@ -906,6 +1180,8 @@ function ConnectModalContent({
       showPermissionDialogOnConnect={showPermissionDialogOnConnect}
       connectOAuthAuthCodeAndSettle={connectOAuthAuthCodeAndSettle}
       connectOAuthDeviceAuthAndSettle={connectOAuthDeviceAuthAndSettleCommandFn}
+      connectExternalCode={connectExternalCode}
+      completeExternalCodeAndSettle={completeExternalCodeAndSettle}
       submitManualGrant={submitManualGrant}
       manualGrantSubmitting={manualGrantSubmitting}
       signal={pageSignal}
@@ -930,9 +1206,11 @@ export function ConnectModal({
   const selectedType = useGet(selectedConnectorType$);
   const connectorTypes = useLastResolved(allConnectorTypes$);
   const clearConnectorOAuthDeviceAuth = useSet(clearConnectorOAuthDeviceAuth$);
+  const clearConnectorExternalCode = useSet(clearConnectorExternalCode$);
   const connectFlowType = useGet(connectFlowType$);
   const pollingType = useGet(pollingOAuthAuthCodeConnectorType$);
   const connectorOAuthDeviceAuthState = useGet(connectorOAuthDeviceAuthState$);
+  const connectorExternalCodeState = useGet(connectorExternalCodeState$);
 
   const item = connectorTypes?.find((c) => {
     return c.type === selectedType;
@@ -949,7 +1227,8 @@ export function ConnectModal({
     connectorOAuthDeviceAuthFlowIsActive(
       connectorOAuthDeviceAuthState,
       selectedType,
-    );
+    ) ||
+    connectorExternalCodeFlowIsActive(connectorExternalCodeState, selectedType);
 
   return (
     <Dialog
@@ -957,6 +1236,7 @@ export function ConnectModal({
       onOpenChange={(open) => {
         if (!open) {
           clearConnectorOAuthDeviceAuth();
+          clearConnectorExternalCode();
           onClose();
         }
       }}
@@ -991,6 +1271,7 @@ export function ConnectModal({
           onSuccess={async () => {
             await onSuccess?.();
             clearConnectorOAuthDeviceAuth();
+            clearConnectorExternalCode();
             onClose();
           }}
         />

--- a/turbo/apps/platform/src/views/zero-page/components/settings/add-connection-dialog.tsx
+++ b/turbo/apps/platform/src/views/zero-page/components/settings/add-connection-dialog.tsx
@@ -18,6 +18,7 @@ import {
 } from "@vm0/ui/components/ui/dialog";
 import {
   CONNECTOR_TYPES,
+  type ConnectorAuthMethodConnectNoticeConfig,
   type ConnectorAuthMethodConfig,
   type ConnectorAuthMethodId,
   type ConnectorDeviceAuthStartOptions,
@@ -711,14 +712,23 @@ type PendingConnectorExternalCodeState = Extract<
 >;
 type ExternalCodeButtonHandler = (event: unknown) => void;
 
-function AwsExternalCodeWarning({ type }: { type: ConnectorType }) {
-  if (type !== "aws") {
-    return null;
-  }
+const connectorAuthMethodConnectNoticeClassNameByVariant = {
+  warning:
+    "rounded-md border border-amber-300 bg-amber-50 p-3 text-sm text-amber-950 dark:border-amber-900/60 dark:bg-amber-950/30 dark:text-amber-100",
+} satisfies Record<ConnectorAuthMethodConnectNoticeConfig["variant"], string>;
+
+function ConnectorAuthMethodConnectNotice({
+  notice,
+}: {
+  notice: ConnectorAuthMethodConnectNoticeConfig;
+}) {
   return (
-    <div className="rounded-md border border-amber-300 bg-amber-50 p-3 text-sm text-amber-950 dark:border-amber-900/60 dark:bg-amber-950/30 dark:text-amber-100">
-      vm0 can call AWS APIs allowed by the selected AWS identity. This temporary
-      login may require reconnect after the AWS session expires.
+    <div
+      className={
+        connectorAuthMethodConnectNoticeClassNameByVariant[notice.variant]
+      }
+    >
+      {notice.text}
     </div>
   );
 }
@@ -743,7 +753,9 @@ function ExternalCodeStartContent({
   return (
     <div className="flex flex-col gap-3">
       {method.helpText && <ConnectorHelpText text={method.helpText} />}
-      <AwsExternalCodeWarning type={type} />
+      {method.grant.kind === "external-code" && method.grant.connectNotice ? (
+        <ConnectorAuthMethodConnectNotice notice={method.grant.connectNotice} />
+      ) : null}
       {terminalMessage ? (
         <p className="text-sm text-destructive" role="alert">
           {terminalMessage}
@@ -779,9 +791,16 @@ function ExternalCodePendingContent({
 }) {
   const completing = current.status === "completing";
   const connectorLabel = CONNECTOR_TYPES[type].label;
+  const method = getConnectorAuthMethod(type, current.authMethod);
+  const connectNotice =
+    method?.grant.kind === "external-code"
+      ? method.grant.connectNotice
+      : undefined;
   return (
     <div className="flex flex-col gap-3">
-      <AwsExternalCodeWarning type={type} />
+      {connectNotice ? (
+        <ConnectorAuthMethodConnectNotice notice={connectNotice} />
+      ) : null}
       <p className="text-sm text-muted-foreground">
         Open {connectorLabel} sign-in, then paste the authorization code
         displayed by {connectorLabel}.

--- a/turbo/apps/platform/src/views/zero-page/components/settings/add-connection-dialog.tsx
+++ b/turbo/apps/platform/src/views/zero-page/components/settings/add-connection-dialog.tsx
@@ -753,8 +753,8 @@ function ExternalCodeStartContent({
   return (
     <div className="flex flex-col gap-3">
       {method.helpText && <ConnectorHelpText text={method.helpText} />}
-      {method.grant.kind === "external-code" && method.grant.connectNotice ? (
-        <ConnectorAuthMethodConnectNotice notice={method.grant.connectNotice} />
+      {method.connectNotice ? (
+        <ConnectorAuthMethodConnectNotice notice={method.connectNotice} />
       ) : null}
       {terminalMessage ? (
         <p className="text-sm text-destructive" role="alert">
@@ -778,12 +778,14 @@ function ExternalCodeStartContent({
 
 function ExternalCodePendingContent({
   type,
+  method,
   current,
   onOpen,
   onCodeChange,
   onComplete,
 }: {
   type: ConnectorType;
+  method: ConnectorAuthMethodConfig;
   current: PendingConnectorExternalCodeState;
   onOpen: ExternalCodeButtonHandler;
   onCodeChange: (code: string) => void;
@@ -791,15 +793,10 @@ function ExternalCodePendingContent({
 }) {
   const completing = current.status === "completing";
   const connectorLabel = CONNECTOR_TYPES[type].label;
-  const method = getConnectorAuthMethod(type, current.authMethod);
-  const connectNotice =
-    method?.grant.kind === "external-code"
-      ? method.grant.connectNotice
-      : undefined;
   return (
     <div className="flex flex-col gap-3">
-      {connectNotice ? (
-        <ConnectorAuthMethodConnectNotice notice={connectNotice} />
+      {method.connectNotice ? (
+        <ConnectorAuthMethodConnectNotice notice={method.connectNotice} />
       ) : null}
       <p className="text-sm text-muted-foreground">
         Open {connectorLabel} sign-in, then paste the authorization code
@@ -894,6 +891,7 @@ function ExternalCodeConnectMethodContent(props: ConnectMethodContentProps) {
     return (
       <ExternalCodePendingContent
         type={props.item.type}
+        method={props.method}
         current={current}
         onOpen={() => {
           openAuthorizationPage(props.item.type, props.authMethod);

--- a/turbo/apps/platform/src/views/zero-page/components/settings/add-connection-dialog.tsx
+++ b/turbo/apps/platform/src/views/zero-page/components/settings/add-connection-dialog.tsx
@@ -18,7 +18,6 @@ import {
 } from "@vm0/ui/components/ui/dialog";
 import {
   CONNECTOR_TYPES,
-  type ConnectorAuthMethodConnectNoticeConfig,
   type ConnectorAuthMethodConfig,
   type ConnectorAuthMethodId,
   type ConnectorDeviceAuthStartOptions,
@@ -712,27 +711,6 @@ type PendingConnectorExternalCodeState = Extract<
 >;
 type ExternalCodeButtonHandler = (event: unknown) => void;
 
-const connectorAuthMethodConnectNoticeClassNameByVariant = {
-  warning:
-    "rounded-md border border-amber-300 bg-amber-50 p-3 text-sm text-amber-950 dark:border-amber-900/60 dark:bg-amber-950/30 dark:text-amber-100",
-} satisfies Record<ConnectorAuthMethodConnectNoticeConfig["variant"], string>;
-
-function ConnectorAuthMethodConnectNotice({
-  notice,
-}: {
-  notice: ConnectorAuthMethodConnectNoticeConfig;
-}) {
-  return (
-    <div
-      className={
-        connectorAuthMethodConnectNoticeClassNameByVariant[notice.variant]
-      }
-    >
-      {notice.text}
-    </div>
-  );
-}
-
 function ExternalCodeStartContent({
   type,
   method,
@@ -753,9 +731,6 @@ function ExternalCodeStartContent({
   return (
     <div className="flex flex-col gap-3">
       {method.helpText && <ConnectorHelpText text={method.helpText} />}
-      {method.connectNotice ? (
-        <ConnectorAuthMethodConnectNotice notice={method.connectNotice} />
-      ) : null}
       {terminalMessage ? (
         <p className="text-sm text-destructive" role="alert">
           {terminalMessage}
@@ -795,13 +770,11 @@ function ExternalCodePendingContent({
   const connectorLabel = CONNECTOR_TYPES[type].label;
   return (
     <div className="flex flex-col gap-3">
+      {method.helpText && <ConnectorHelpText text={method.helpText} />}
       <p className="text-sm text-muted-foreground">
         Open {connectorLabel} sign-in, then paste the authorization code
         displayed by {connectorLabel}.
       </p>
-      {method.connectNotice ? (
-        <ConnectorAuthMethodConnectNotice notice={method.connectNotice} />
-      ) : null}
       <div className="flex items-center gap-2">
         <Button
           type="button"

--- a/turbo/apps/platform/src/views/zero-page/components/settings/connector-icons.tsx
+++ b/turbo/apps/platform/src/views/zero-page/components/settings/connector-icons.tsx
@@ -78,6 +78,7 @@ const CONNECTOR_ICON_COLORFUL = {
   asana: true,
   ashby: true,
   atlassian: true,
+  aws: true,
   aviationstack: true,
   azure: true,
   base44: true,

--- a/turbo/apps/platform/src/views/zero-page/components/settings/icons/aws.svg
+++ b/turbo/apps/platform/src/views/zero-page/components/settings/icons/aws.svg
@@ -1,0 +1,6 @@
+<svg width="24" height="24" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
+  <rect width="24" height="24" rx="4" fill="#232F3E"/>
+  <text x="12" y="11.2" text-anchor="middle" font-family="Arial, Helvetica, sans-serif" font-size="6.2" font-weight="700" fill="#FFFFFF">AWS</text>
+  <path d="M6.1 15.1C8.9 17 14.1 17.5 18 15.5" stroke="#FF9900" stroke-width="1.5" stroke-linecap="round"/>
+  <path d="M16.4 14.4L18.6 14.7L17.8 16.8" stroke="#FF9900" stroke-width="1.2" stroke-linecap="round" stroke-linejoin="round"/>
+</svg>

--- a/turbo/apps/web/api-backend-rewrites.js
+++ b/turbo/apps/web/api-backend-rewrites.js
@@ -305,6 +305,14 @@ const ZERO_CONNECTORS_OAUTH_DEVICE_AUTHORIZATION_SESSION_POLL_PATH_RE =
   new RegExp(
     `^/api/zero/connectors/[^/]+/oauth/device/sessions/${UUID_PATH_SEGMENT_PATTERN}/poll$`,
   );
+const ZERO_CONNECTORS_EXTERNAL_CODE_SESSIONS_REWRITE_SOURCE =
+  "/api/zero/connectors/:type/external-code/sessions";
+const ZERO_CONNECTORS_EXTERNAL_CODE_SESSIONS_PATH_RE =
+  /^\/api\/zero\/connectors\/[^/]+\/external-code\/sessions$/;
+const ZERO_CONNECTORS_EXTERNAL_CODE_SESSION_COMPLETE_REWRITE_SOURCE = `/api/zero/connectors/:type/external-code/sessions/:sessionId(${UUID_PATH_SEGMENT_PATTERN})/complete`;
+const ZERO_CONNECTORS_EXTERNAL_CODE_SESSION_COMPLETE_PATH_RE = new RegExp(
+  `^/api/zero/connectors/[^/]+/external-code/sessions/${UUID_PATH_SEGMENT_PATTERN}/complete$`,
+);
 const ZERO_SLACK_OAUTH_INSTALL_REWRITE_SOURCE = "/api/zero/slack/oauth/install";
 const ZERO_SLACK_OAUTH_CONNECT_REWRITE_SOURCE = "/api/zero/slack/oauth/connect";
 const ZERO_SLACK_OAUTH_CALLBACK_REWRITE_SOURCE =
@@ -757,6 +765,16 @@ export const API_BACKEND_REWRITES = [
     ZERO_CONNECTORS_OAUTH_DEVICE_AUTHORIZATION_SESSION_POLL_REWRITE_SOURCE,
     "/api/zero/connectors/:type/oauth/device/sessions/:sessionId/poll",
     ZERO_CONNECTORS_OAUTH_DEVICE_AUTHORIZATION_SESSION_POLL_PATH_RE,
+  ],
+  [
+    ZERO_CONNECTORS_EXTERNAL_CODE_SESSIONS_REWRITE_SOURCE,
+    "/api/zero/connectors/:type/external-code/sessions",
+    ZERO_CONNECTORS_EXTERNAL_CODE_SESSIONS_PATH_RE,
+  ],
+  [
+    ZERO_CONNECTORS_EXTERNAL_CODE_SESSION_COMPLETE_REWRITE_SOURCE,
+    "/api/zero/connectors/:type/external-code/sessions/:sessionId/complete",
+    ZERO_CONNECTORS_EXTERNAL_CODE_SESSION_COMPLETE_PATH_RE,
   ],
   [ZERO_SLACK_OAUTH_INSTALL_REWRITE_SOURCE, "/api/zero/slack/oauth/install"],
   [ZERO_SLACK_OAUTH_CONNECT_REWRITE_SOURCE, "/api/zero/slack/oauth/connect"],

--- a/turbo/knip.json
+++ b/turbo/knip.json
@@ -69,6 +69,7 @@
       ],
       "ignoreDependencies": [
         "idb",
+        "dom-to-pptx",
         "katex",
         "tailwindcss",
         "typescript-eslint",

--- a/turbo/knip.json
+++ b/turbo/knip.json
@@ -68,6 +68,7 @@
         "src/views/zero-page/zero-sidebar-upgrade.tsx"
       ],
       "ignoreDependencies": [
+        "dom-to-pptx",
         "idb",
         "katex",
         "tailwindcss",

--- a/turbo/knip.json
+++ b/turbo/knip.json
@@ -68,7 +68,6 @@
         "src/views/zero-page/zero-sidebar-upgrade.tsx"
       ],
       "ignoreDependencies": [
-        "dom-to-pptx",
         "idb",
         "katex",
         "tailwindcss",

--- a/turbo/packages/api-contracts/src/contracts/connector-schemas.ts
+++ b/turbo/packages/api-contracts/src/contracts/connector-schemas.ts
@@ -170,3 +170,34 @@ export const connectorOauthDeviceAuthSessionPollResponseSchema =
 export type ConnectorOauthDeviceAuthSessionPollResponse = z.infer<
   typeof connectorOauthDeviceAuthSessionPollResponseSchema
 >;
+
+export const connectorExternalCodeSessionStartResponseSchema = z.object({
+  sessionId: z.uuid(),
+  sessionToken: z.string(),
+  type: connectorTypeSchema,
+  status: z.literal("pending"),
+  authorizationUrl: z.string(),
+  expiresIn: z.number(),
+});
+
+export type ConnectorExternalCodeSessionStartResponse = z.infer<
+  typeof connectorExternalCodeSessionStartResponseSchema
+>;
+
+export const connectorExternalCodeSessionCompleteRequestSchema = z.object({
+  sessionToken: z.string(),
+  code: z.string().trim().min(1).max(4096),
+});
+
+export type ConnectorExternalCodeSessionCompleteRequest = z.infer<
+  typeof connectorExternalCodeSessionCompleteRequestSchema
+>;
+
+export const connectorExternalCodeSessionCompleteResponseSchema = z.object({
+  status: z.literal("complete"),
+  connector: connectorResponseSchema,
+});
+
+export type ConnectorExternalCodeSessionCompleteResponse = z.infer<
+  typeof connectorExternalCodeSessionCompleteResponseSchema
+>;

--- a/turbo/packages/api-contracts/src/contracts/zero-connectors.ts
+++ b/turbo/packages/api-contracts/src/contracts/zero-connectors.ts
@@ -9,6 +9,9 @@ import {
   connectorOauthDeviceAuthSessionPollRequestSchema,
   connectorOauthDeviceAuthSessionPollResponseSchema,
   connectorOauthDeviceAuthSessionStartResponseSchema,
+  connectorExternalCodeSessionCompleteRequestSchema,
+  connectorExternalCodeSessionCompleteResponseSchema,
+  connectorExternalCodeSessionStartResponseSchema,
   connectorOauthStartResponseSchema,
   connectorListResponseSchema,
   connectorResponseSchema,
@@ -168,6 +171,45 @@ export const zeroConnectorOauthDeviceAuthSessionContract = c.router({
   },
 });
 
+export const zeroConnectorExternalCodeSessionContract = c.router({
+  create: {
+    method: "POST",
+    path: "/api/zero/connectors/:type/external-code/sessions",
+    headers: authHeadersSchema,
+    pathParams: z.object({ type: connectorTypeSchema }),
+    body: z.object({
+      authMethod: connectorAuthMethodIdSchema,
+    }),
+    responses: {
+      200: connectorExternalCodeSessionStartResponseSchema,
+      400: apiErrorSchema,
+      401: apiErrorSchema,
+      403: apiErrorSchema,
+      500: apiErrorSchema,
+    },
+    summary: "Create connector external-code authorization session",
+  },
+  complete: {
+    method: "POST",
+    path: "/api/zero/connectors/:type/external-code/sessions/:sessionId/complete",
+    headers: authHeadersSchema,
+    pathParams: z.object({
+      type: connectorTypeSchema,
+      sessionId: z.uuid(),
+    }),
+    body: connectorExternalCodeSessionCompleteRequestSchema,
+    responses: {
+      200: connectorExternalCodeSessionCompleteResponseSchema,
+      400: apiErrorSchema,
+      401: apiErrorSchema,
+      403: apiErrorSchema,
+      404: apiErrorSchema,
+      500: apiErrorSchema,
+    },
+    summary: "Complete connector external-code authorization session",
+  },
+});
+
 export type ConnectorSearchAuthMethod = z.infer<
   typeof connectorAuthMethodIdSchema
 >;
@@ -215,4 +257,6 @@ export type ZeroConnectorManualGrantContract =
   typeof zeroConnectorManualGrantContract;
 export type ZeroConnectorOauthDeviceAuthSessionContract =
   typeof zeroConnectorOauthDeviceAuthSessionContract;
+export type ZeroConnectorExternalCodeSessionContract =
+  typeof zeroConnectorExternalCodeSessionContract;
 export type ZeroConnectorsSearchContract = typeof zeroConnectorsSearchContract;

--- a/turbo/packages/connectors/src/__tests__/connectors.test.ts
+++ b/turbo/packages/connectors/src/__tests__/connectors.test.ts
@@ -21,10 +21,12 @@ import {
   type ConnectorAuthCodeGrantConfig,
   type ConnectorConfig,
   type ConnectorDeviceAuthGrantConfig,
+  type ConnectorExternalCodeGrantConfig,
   type ConnectorInvalidDefaultAuthMethodType,
   type ConnectorManualGrantFieldConfig,
   type ConnectorType,
   type AuthCodeGrantConnectorType,
+  type ExternalCodeGrantConnectorType,
   type RefreshTokenAccessConnectorType,
   type TokenRevokeConnectorType,
 } from "../connectors";
@@ -46,6 +48,7 @@ import {
   hasRequiredConnectorAuthMethodScopes,
   getConnectorAuthMethodAuthCodeGrantConfig,
   getConnectorAuthMethodDeviceAuthGrantConfig,
+  getConnectorAuthMethodExternalCodeGrantConfig,
   getConnectorAuthMethodDeviceAuthStartOptionsConfig,
   getConnectorAuthMethodAccessMetadata,
   getConnectorAuthMethodRuntimeMetadata,
@@ -65,6 +68,7 @@ import {
   getConnectorOwnedVariableNames,
   hasConnectorAuthCodeGrant,
   hasConnectorDeviceAuthGrant,
+  hasConnectorExternalCodeGrant,
   isStaticConfidentialConnectorAuthClient,
   isStaticConnectorAuthClient,
   type ConnectorAuthClient,
@@ -107,7 +111,11 @@ function getApiTokenManualGrantFields(
 }
 
 function hasConnectorAuthorizationGrant(type: ConnectorType): boolean {
-  return hasConnectorAuthCodeGrant(type) || hasConnectorDeviceAuthGrant(type);
+  return (
+    hasConnectorAuthCodeGrant(type) ||
+    hasConnectorExternalCodeGrant(type) ||
+    hasConnectorDeviceAuthGrant(type)
+  );
 }
 
 const server = setupServer();
@@ -693,12 +701,21 @@ describe("connector auth method config", () => {
 });
 
 describe("connector selected auth method capability checks", () => {
-  it("matches exactly the auth methods that declare auth-code and device-auth grants", () => {
+  it("matches exactly the auth methods that declare authorization grants", () => {
     for (const type of connectorTypeSchema.options) {
       const authMethodIds = getConfiguredConnectorAuthMethodIds(type);
       expect(hasConnectorAuthCodeGrant(type)).toBe(
         authMethodIds.some((authMethod) => {
           return connectorAuthMethodHasGrantKind(type, authMethod, "auth-code");
+        }),
+      );
+      expect(hasConnectorExternalCodeGrant(type)).toBe(
+        authMethodIds.some((authMethod) => {
+          return connectorAuthMethodHasGrantKind(
+            type,
+            authMethod,
+            "external-code",
+          );
         }),
       );
       expect(hasConnectorDeviceAuthGrant(type)).toBe(
@@ -721,6 +738,12 @@ describe("connector selected auth method capability checks", () => {
         ).toBe(
           getConnectorAuthMethod(type, authMethod)?.grant.kind ===
             "device-auth",
+        );
+        expect(
+          connectorAuthMethodHasGrantKind(type, authMethod, "external-code"),
+        ).toBe(
+          getConnectorAuthMethod(type, authMethod)?.grant.kind ===
+            "external-code",
         );
       }
     }
@@ -2414,6 +2437,15 @@ describe("getAvailableConnectorAuthMethodIds", () => {
     ).toStrictEqual(["oauth", "cli", "api-token"]);
   });
 
+  it("exposes AWS CLI auth only when the AWS switch is enabled", () => {
+    expect(getAvailableConnectorAuthMethodIds("aws", {})).toStrictEqual([]);
+    expect(
+      getAvailableConnectorAuthMethodIds("aws", {
+        [FeatureSwitchKey.AwsConnector]: true,
+      }),
+    ).toStrictEqual(["cli"]);
+  });
+
   it("exposes BentoML API-token auth only when its switch is enabled", () => {
     expect(getAvailableConnectorAuthMethodIds("bentoml", {})).toStrictEqual([]);
     expect(
@@ -2530,6 +2562,59 @@ describe("getConnectorAuthMethodAccessMetadata", () => {
         platformSecrets: [],
       },
     );
+  });
+
+  it("returns refresh-token access metadata for the AWS CLI method", () => {
+    expect(getConnectorAuthMethodAccessMetadata("aws", "cli")).toStrictEqual({
+      kind: "refresh-token",
+      inputs: {
+        refreshToken: {
+          valueRef: "$secrets.AWS_LOGIN_REFRESH_TOKEN",
+          source: {
+            kind: "connector-secret",
+            name: "AWS_LOGIN_REFRESH_TOKEN",
+          },
+        },
+        signinRegion: {
+          valueRef: "$secrets.AWS_SIGNIN_REGION",
+          source: {
+            kind: "connector-secret",
+            name: "AWS_SIGNIN_REGION",
+          },
+        },
+      },
+      outputs: {
+        refreshToken: {
+          valueRef: "$secrets.AWS_LOGIN_REFRESH_TOKEN",
+          secretName: "AWS_LOGIN_REFRESH_TOKEN",
+        },
+        accessKeyId: {
+          valueRef: "$secrets.AWS_ACCESS_KEY_ID",
+          secretName: "AWS_ACCESS_KEY_ID",
+        },
+        secretAccessKey: {
+          valueRef: "$secrets.AWS_SECRET_ACCESS_KEY",
+          secretName: "AWS_SECRET_ACCESS_KEY",
+        },
+        sessionToken: {
+          valueRef: "$secrets.AWS_SESSION_TOKEN",
+          secretName: "AWS_SESSION_TOKEN",
+        },
+      },
+      refreshableSecrets: [
+        "AWS_ACCESS_KEY_ID",
+        "AWS_SECRET_ACCESS_KEY",
+        "AWS_SESSION_TOKEN",
+      ],
+      envBindings: {
+        AWS_ACCESS_KEY_ID: "$secrets.AWS_ACCESS_KEY_ID",
+        AWS_SECRET_ACCESS_KEY: "$secrets.AWS_SECRET_ACCESS_KEY",
+        AWS_SESSION_TOKEN: "$secrets.AWS_SESSION_TOKEN",
+        AWS_REGION: "$secrets.AWS_REGION",
+        AWS_DEFAULT_REGION: "$secrets.AWS_REGION",
+      },
+      platformSecrets: [],
+    });
   });
 
   it("returns platform-owned secret metadata for Google Ads", () => {
@@ -3148,16 +3233,21 @@ describe("getConnectorEnvBindingEntries", () => {
     expect(firewall.apis[0]?.permissions).toStrictEqual([]);
   });
 
-  it("authorization-grant auth methods keep the documented secret naming convention", () => {
+  it("OAuth auth-code auth methods keep the documented secret naming convention", () => {
     // This is a registry naming convention. Runtime behavior must use
     // grant output metadata and runtimeBindings, not infer roles from names.
     for (const type of connectorTypeSchema.options) {
-      if (!hasConnectorAuthorizationGrant(type)) continue;
+      if (!hasConnectorAuthCodeGrant(type)) continue;
 
       const oauthAuthMethodRef: ConnectorAuthMethodRef = {
         type,
         authMethod: "oauth",
       };
+      if (
+        !connectorAuthMethodRefHasGrantKind(oauthAuthMethodRef, "auth-code")
+      ) {
+        continue;
+      }
       const hasRefreshTokenAccess = connectorAuthMethodRefHasAccessKind(
         oauthAuthMethodRef,
         "refresh-token",
@@ -3637,6 +3727,27 @@ describe("connector OAuth lifecycle grant helpers", () => {
     });
   });
 
+  it("returns external-code grant config for external-code connectors", () => {
+    expectTypeOf(
+      getConnectorAuthMethodExternalCodeGrantConfig("aws", "cli"),
+    ).toEqualTypeOf<ConnectorExternalCodeGrantConfig>();
+    expect(getConnectorAuthMethodExternalCodeGrantConfig("aws", "cli")).toEqual(
+      {
+        kind: "external-code",
+        scopes: ["openid"],
+        outputs: {
+          refreshToken: "$secrets.AWS_LOGIN_REFRESH_TOKEN",
+          accessKeyId: "$secrets.AWS_ACCESS_KEY_ID",
+          secretAccessKey: "$secrets.AWS_SECRET_ACCESS_KEY",
+          sessionToken: "$secrets.AWS_SESSION_TOKEN",
+          signinRegion: "$secrets.AWS_SIGNIN_REGION",
+          runtimeRegion: "$secrets.AWS_REGION",
+        },
+      },
+    );
+    expectTypeOf<"aws">().toMatchTypeOf<ExternalCodeGrantConnectorType>();
+  });
+
   it("returns undefined for connectors without authorization grants", () => {
     expect(hasConnectorAuthorizationGrant("axiom")).toBe(false);
     expect(
@@ -3644,6 +3755,9 @@ describe("connector OAuth lifecycle grant helpers", () => {
     ).toBeUndefined();
     expect(
       getConnectorAuthMethodDeviceAuthGrantConfig("github", "oauth"),
+    ).toBeUndefined();
+    expect(
+      getConnectorAuthMethodExternalCodeGrantConfig("github", "oauth"),
     ).toBeUndefined();
   });
 });

--- a/turbo/packages/connectors/src/__tests__/connectors.test.ts
+++ b/turbo/packages/connectors/src/__tests__/connectors.test.ts
@@ -2575,6 +2575,13 @@ describe("getConnectorAuthMethodAccessMetadata", () => {
             name: "AWS_LOGIN_REFRESH_TOKEN",
           },
         },
+        dpopKey: {
+          valueRef: "$secrets.AWS_LOGIN_DPOP_KEY",
+          source: {
+            kind: "connector-secret",
+            name: "AWS_LOGIN_DPOP_KEY",
+          },
+        },
         signinRegion: {
           valueRef: "$secrets.AWS_SIGNIN_REGION",
           source: {
@@ -3737,6 +3744,7 @@ describe("connector OAuth lifecycle grant helpers", () => {
         scopes: ["openid"],
         outputs: {
           refreshToken: "$secrets.AWS_LOGIN_REFRESH_TOKEN",
+          dpopKey: "$secrets.AWS_LOGIN_DPOP_KEY",
           accessKeyId: "$secrets.AWS_ACCESS_KEY_ID",
           secretAccessKey: "$secrets.AWS_SECRET_ACCESS_KEY",
           sessionToken: "$secrets.AWS_SESSION_TOKEN",

--- a/turbo/packages/connectors/src/__tests__/connectors.test.ts
+++ b/turbo/packages/connectors/src/__tests__/connectors.test.ts
@@ -3742,6 +3742,10 @@ describe("connector OAuth lifecycle grant helpers", () => {
       {
         kind: "external-code",
         scopes: ["openid"],
+        connectNotice: {
+          variant: "warning",
+          text: "vm0 can call AWS APIs allowed by the selected AWS identity. This temporary login may require reconnect after the AWS session expires.",
+        },
         outputs: {
           refreshToken: "$secrets.AWS_LOGIN_REFRESH_TOKEN",
           dpopKey: "$secrets.AWS_LOGIN_DPOP_KEY",

--- a/turbo/packages/connectors/src/__tests__/connectors.test.ts
+++ b/turbo/packages/connectors/src/__tests__/connectors.test.ts
@@ -499,6 +499,13 @@ describe("connector auth method config", () => {
     expect(getConnectorAuthMethod("github", "api-token")).toBeUndefined();
   });
 
+  it("keeps connect notices on auth method config", () => {
+    expect(getConnectorAuthMethod("aws", "cli")?.connectNotice).toStrictEqual({
+      variant: "warning",
+      text: "This is a temporary AWS connector that expires after up to 12 hours. Reconnect after it expires.",
+    });
+  });
+
   it("does not silently choose one type-only auth-code grant when ambiguous", () => {
     const authMethods = CONNECTOR_TYPES.github.authMethods;
     Object.defineProperty(authMethods, "api", {
@@ -3742,10 +3749,6 @@ describe("connector OAuth lifecycle grant helpers", () => {
       {
         kind: "external-code",
         scopes: ["openid"],
-        connectNotice: {
-          variant: "warning",
-          text: "vm0 can call AWS APIs allowed by the selected AWS identity. This temporary login may require reconnect after the AWS session expires.",
-        },
         outputs: {
           refreshToken: "$secrets.AWS_LOGIN_REFRESH_TOKEN",
           dpopKey: "$secrets.AWS_LOGIN_DPOP_KEY",

--- a/turbo/packages/connectors/src/__tests__/connectors.test.ts
+++ b/turbo/packages/connectors/src/__tests__/connectors.test.ts
@@ -499,13 +499,6 @@ describe("connector auth method config", () => {
     expect(getConnectorAuthMethod("github", "api-token")).toBeUndefined();
   });
 
-  it("keeps connect notices on auth method config", () => {
-    expect(getConnectorAuthMethod("aws", "cli")?.connectNotice).toStrictEqual({
-      variant: "warning",
-      text: "This is a temporary AWS connector that expires after up to 12 hours. Reconnect after it expires.",
-    });
-  });
-
   it("does not silently choose one type-only auth-code grant when ambiguous", () => {
     const authMethods = CONNECTOR_TYPES.github.authMethods;
     Object.defineProperty(authMethods, "api", {

--- a/turbo/packages/connectors/src/auth-providers/connector-auth.ts
+++ b/turbo/packages/connectors/src/auth-providers/connector-auth.ts
@@ -5,9 +5,11 @@ import {
   type ConnectorType,
   type AuthGrantConnectorType,
   type ConnectorDeviceAuthGrantAuthMethodId,
+  type ConnectorExternalCodeGrantAuthMethodId,
   type ConnectorDeviceAuthStartOptions,
   type ConnectorAuthMethodIdsByGrantKind,
   type DeviceAuthGrantConnectorType,
+  type ExternalCodeGrantConnectorType,
   type ConnectorAuthMethodIdsByAccessKind,
   type ConnectorAuthMethodIdsByRevokeKind,
   type ConnectorRefreshInputValues,
@@ -20,6 +22,7 @@ import {
   connectorAuthMethodRefHasRevokeKind,
   getConnectorAuthMethodAccessMetadata,
   getConnectorAuthMethodAuthCodeGrantConfig,
+  getConnectorAuthMethodExternalCodeGrantConfig,
   getConnectorAuthMethodGrantScopes,
   isStaticConfidentialConnectorAuthClient,
   parseConnectorDeviceAuthStartOptions,
@@ -34,6 +37,7 @@ import type {
   ConnectorAuthProviderRefreshResultBase,
   ConnectorAuthProviderRefreshResult,
   DeviceAuthConnectorAuthProvider,
+  ExternalCodeConnectorAuthProvider,
   RefreshTokenAccessProvider,
   TokenRevokeProvider,
 } from "./types";
@@ -43,6 +47,7 @@ import type {
 } from "./grant-result";
 import {
   type AuthUrlResult,
+  type ExternalCodeAuthorizationStartResult,
   type OAuthDeviceAuthPollResult,
   type OAuthDeviceAuthPollResultBase,
   type OAuthDeviceAuthStartResult,
@@ -51,6 +56,7 @@ import { providerEnvFromObject, type ProviderEnv } from "./provider-env";
 import { ahrefsProvider } from "./connectors/ahrefs/provider";
 import { airtableProvider } from "./connectors/airtable/provider";
 import { asanaProvider } from "./connectors/asana/provider";
+import { awsProvider } from "./connectors/aws/provider";
 import { base44Provider } from "./connectors/base44/provider";
 import { canvaProvider } from "./connectors/canva/provider";
 import { closeProvider } from "./connectors/close/provider";
@@ -109,6 +115,8 @@ import {
 } from "./connectors/test-oauth-device/provider";
 
 export type {
+  ConnectorAuthProviderGrantResult,
+  ConnectorAuthProviderGrantResultForMethod,
   ConnectorAuthProviderRefreshResultBase,
   ConnectorAuthProviderRefreshResult,
 };
@@ -136,6 +144,12 @@ type ConnectorDeviceAuthGrantProvider<
     ConnectorDeviceAuthGrantAuthMethodId<Type>,
 > = DeviceAuthConnectorAuthProvider<Type, Method>["grant"];
 
+type ConnectorExternalCodeGrantProvider<
+  Type extends ExternalCodeGrantConnectorType,
+  Method extends ConnectorExternalCodeGrantAuthMethodId<Type> =
+    ConnectorExternalCodeGrantAuthMethodId<Type>,
+> = ExternalCodeConnectorAuthProvider<Type, Method>["grant"];
+
 type ConnectorAuthCodeProviderEntry<
   Type extends AuthCodeGrantConnectorType,
   Method extends ConnectorAuthCodeGrantAuthMethodId<Type>,
@@ -148,6 +162,13 @@ type ConnectorDeviceAuthProviderEntry<
   Method extends ConnectorDeviceAuthGrantAuthMethodId<Type>,
 > = {
   readonly grant: ConnectorDeviceAuthGrantProvider<Type, Method>;
+};
+
+type ConnectorExternalCodeProviderEntry<
+  Type extends ExternalCodeGrantConnectorType,
+  Method extends ConnectorExternalCodeGrantAuthMethodId<Type>,
+> = {
+  readonly grant: ConnectorExternalCodeGrantProvider<Type, Method>;
 };
 
 type ConnectorRefreshTokenAccessProviderEntry<
@@ -186,6 +207,19 @@ type ConnectorDeviceAuthGrantProviderEntries<Type extends ConnectorType> = {
   >;
 };
 
+type ConnectorExternalCodeGrantProviderEntries<Type extends ConnectorType> = {
+  readonly [Method in ConnectorAuthMethodIdsByGrantKind<
+    Type,
+    "external-code"
+  >]: ConnectorExternalCodeProviderEntry<
+    Type & ExternalCodeGrantConnectorType,
+    Method &
+      ConnectorExternalCodeGrantAuthMethodId<
+        Type & ExternalCodeGrantConnectorType
+      >
+  >;
+};
+
 type ConnectorRefreshTokenAccessProviderEntries<Type extends ConnectorType> = {
   readonly [Method in ConnectorAuthMethodIdsByAccessKind<
     Type,
@@ -218,6 +252,7 @@ type ConnectorProviderBackedAuthMethodEntries<
   Type extends ConnectorProviderBackedType,
 > = ConnectorAuthCodeGrantProviderEntries<Type> &
   ConnectorDeviceAuthGrantProviderEntries<Type> &
+  ConnectorExternalCodeGrantProviderEntries<Type> &
   ConnectorRefreshTokenAccessProviderEntries<Type> &
   ConnectorTokenRevokeProviderEntries<Type>;
 
@@ -304,6 +339,19 @@ function deviceAuthRefreshProviderEntry<
   return { grant: provider.grant, access: provider.access };
 }
 
+function externalCodeRefreshProviderEntry<
+  Type extends ExternalCodeGrantConnectorType & RefreshTokenAccessConnectorType,
+  Method extends ConnectorExternalCodeGrantAuthMethodId<Type> &
+    ConnectorAuthMethodIdsByAccessKind<Type, "refresh-token">,
+>(
+  provider: ExternalCodeConnectorAuthProvider<Type, Method> & {
+    readonly access: RefreshTokenAccessProvider<Type, Method>;
+  },
+): ConnectorExternalCodeProviderEntry<Type, Method> &
+  ConnectorRefreshTokenAccessProviderEntry<Type, Method> {
+  return { grant: provider.grant, access: provider.access };
+}
+
 function refreshProviderEntry<
   Type extends RefreshTokenAccessConnectorType,
   Method extends ConnectorAuthMethodIdsByAccessKind<Type, "refresh-token">,
@@ -333,6 +381,13 @@ function connectorDeviceAuthGrantProviderFor<
   T extends DeviceAuthGrantConnectorType,
   Method extends ConnectorDeviceAuthGrantAuthMethodId<T>,
 >(type: T, authMethod: Method): ConnectorDeviceAuthGrantProvider<T, Method> {
+  return CONNECTOR_AUTH_METHOD_PROVIDER_REGISTRY[type][authMethod].grant;
+}
+
+function connectorExternalCodeGrantProviderFor<
+  T extends ExternalCodeGrantConnectorType,
+  Method extends ConnectorExternalCodeGrantAuthMethodId<T>,
+>(type: T, authMethod: Method): ConnectorExternalCodeGrantProvider<T, Method> {
   return CONNECTOR_AUTH_METHOD_PROVIDER_REGISTRY[type][authMethod].grant;
 }
 
@@ -378,6 +433,7 @@ const CONNECTOR_AUTH_METHOD_PROVIDERS = {
   ahrefs: { oauth: authCodeRefreshProviderEntry(ahrefsProvider) },
   airtable: { oauth: authCodeRefreshProviderEntry(airtableProvider) },
   asana: { oauth: authCodeRefreshProviderEntry(asanaProvider) },
+  aws: { cli: externalCodeRefreshProviderEntry(awsProvider) },
   base44: { oauth: deviceAuthRefreshProviderEntry(base44Provider) },
   canva: { oauth: authCodeRefreshProviderEntry(canvaProvider) },
   close: { oauth: authCodeRefreshProviderEntry(closeProvider) },
@@ -463,6 +519,9 @@ type ConnectorAuthCodeResolvedMethodClient =
 type ConnectorDeviceAuthResolvedMethodClient =
   ConnectorResolvedAuthMethodClientByGrantKind<"device-auth">;
 
+type ConnectorExternalCodeResolvedMethodClient =
+  ConnectorResolvedAuthMethodClientByGrantKind<"external-code">;
+
 type ConnectorAuthCodeAuthorizationUrlArgs =
   ConnectorAuthCodeResolvedMethodClient & {
     readonly redirectUri: string;
@@ -487,6 +546,16 @@ type ConnectorDeviceAuthorizationPollCallArgs =
   ConnectorDeviceAuthResolvedMethodClient & {
     readonly deviceCode: string;
     readonly pollState?: string;
+  };
+
+type ConnectorExternalCodeAuthorizationStartCallArgs =
+  ConnectorExternalCodeResolvedMethodClient;
+
+type ConnectorExternalCodeAuthorizationCompleteCallArgs =
+  ConnectorExternalCodeResolvedMethodClient & {
+    readonly code: string;
+    readonly providerState: string;
+    readonly signal: AbortSignal;
   };
 
 type ConnectorRefreshTokenAccessCallArgs<
@@ -611,6 +680,81 @@ export async function exchangeConnectorAuthCode<
     state: args.state,
     codeVerifier: args.codeVerifier,
     oauthContext: args.oauthContext,
+  });
+}
+
+export function startConnectorExternalCodeAuthorization<
+  T extends ExternalCodeGrantConnectorType,
+  Method extends ConnectorExternalCodeGrantAuthMethodId<T>,
+>(args: {
+  readonly type: T;
+  readonly authMethod: Method;
+  readonly authClient: ConnectorAuthClientForMethod<T, Method>;
+}): Promise<ExternalCodeAuthorizationStartResult>;
+export function startConnectorExternalCodeAuthorization(
+  args: ConnectorExternalCodeAuthorizationStartCallArgs,
+): Promise<ExternalCodeAuthorizationStartResult>;
+export async function startConnectorExternalCodeAuthorization<
+  T extends ExternalCodeGrantConnectorType,
+  Method extends ConnectorExternalCodeGrantAuthMethodId<T>,
+>(args: {
+  readonly type: T;
+  readonly authMethod: Method;
+  readonly authClient: ConnectorAuthClientForMethod<T, Method>;
+}): Promise<ExternalCodeAuthorizationStartResult> {
+  const provider = connectorExternalCodeGrantProviderFor(
+    args.type,
+    args.authMethod,
+  );
+  const externalCodeGrant = getConnectorAuthMethodExternalCodeGrantConfig(
+    args.type,
+    args.authMethod,
+  );
+  return await provider.startExternalCodeAuthorization({
+    authClient: connectorAuthClientIdentityForMethod(args.authClient),
+    externalCodeGrant,
+  });
+}
+
+export function completeConnectorExternalCodeAuthorization<
+  T extends ExternalCodeGrantConnectorType,
+  Method extends ConnectorExternalCodeGrantAuthMethodId<T>,
+>(args: {
+  readonly type: T;
+  readonly authMethod: Method;
+  readonly authClient: ConnectorAuthClientForMethod<T, Method>;
+  readonly code: string;
+  readonly providerState: string;
+  readonly signal: AbortSignal;
+}): Promise<ConnectorAuthProviderGrantResultForMethod<T, Method>>;
+export function completeConnectorExternalCodeAuthorization(
+  args: ConnectorExternalCodeAuthorizationCompleteCallArgs,
+): Promise<ConnectorAuthProviderGrantResult>;
+export async function completeConnectorExternalCodeAuthorization<
+  T extends ExternalCodeGrantConnectorType,
+  Method extends ConnectorExternalCodeGrantAuthMethodId<T>,
+>(args: {
+  readonly type: T;
+  readonly authMethod: Method;
+  readonly authClient: ConnectorAuthClientForMethod<T, Method>;
+  readonly code: string;
+  readonly providerState: string;
+  readonly signal: AbortSignal;
+}): Promise<ConnectorAuthProviderGrantResultForMethod<T, Method>> {
+  const provider = connectorExternalCodeGrantProviderFor(
+    args.type,
+    args.authMethod,
+  );
+  const externalCodeGrant = getConnectorAuthMethodExternalCodeGrantConfig(
+    args.type,
+    args.authMethod,
+  );
+  return await provider.completeExternalCodeAuthorization({
+    authClient: args.authClient,
+    externalCodeGrant,
+    code: args.code,
+    providerState: args.providerState,
+    signal: args.signal,
   });
 }
 

--- a/turbo/packages/connectors/src/auth-providers/connectors/__tests__/aws.test.ts
+++ b/turbo/packages/connectors/src/auth-providers/connectors/__tests__/aws.test.ts
@@ -149,6 +149,10 @@ function expectJsonWebTokenPart<T>(schema: z.ZodType<T>, value: string): T {
 
 function awsTokenEndpointResponseBody(
   body: z.infer<typeof awsTokenRequestSchema>,
+  options: {
+    readonly expiresIn?: number;
+    readonly tokenType?: string;
+  } = {},
 ) {
   return {
     accessToken: {
@@ -165,12 +169,12 @@ function awsTokenEndpointResponseBody(
           ? "refresh-session-token"
           : "exchange-session-token",
     },
-    expiresIn: 900,
+    expiresIn: options.expiresIn ?? 900,
     refreshToken:
       body.grantType === "refresh_token"
         ? "aws-refresh-token-rotated"
         : "aws-refresh-token",
-    tokenType: "aws_sigv4",
+    tokenType: options.tokenType ?? "aws_sigv4",
     ...(body.grantType === "authorization_code"
       ? { idToken: "aws-id-token" }
       : {}),
@@ -179,7 +183,9 @@ function awsTokenEndpointResponseBody(
 
 function mockAwsTokenEndpoint(
   options: {
+    readonly expiresIn?: number;
     readonly responseShape?: "flat" | "tokenOutput";
+    readonly tokenType?: string;
   } = {},
 ): void {
   server.use(
@@ -187,7 +193,7 @@ function mockAwsTokenEndpoint(
       const body = awsTokenRequestSchema.parse(await request.json());
       tokenRequests.push(body);
       dpopHeaders.push(request.headers.get("dpop") ?? "");
-      const responseBody = awsTokenEndpointResponseBody(body);
+      const responseBody = awsTokenEndpointResponseBody(body, options);
       if (options.responseShape === "tokenOutput") {
         return HttpResponse.json({ tokenOutput: responseBody });
       }
@@ -293,6 +299,28 @@ describe("AWS external-code provider", () => {
         email: null,
       },
     });
+  });
+
+  it("accepts AWS token metadata that the AWS CLI does not validate", async () => {
+    mockAwsTokenEndpoint({ expiresIn: 3600, tokenType: "Bearer" });
+    const start = await startConnectorExternalCodeAuthorization({
+      type: "aws",
+      authMethod: "cli",
+      authClient: awsAuthClient(),
+    });
+    const providerState = parseProviderState(start.providerState);
+
+    const result = await completeConnectorExternalCodeAuthorization({
+      type: "aws",
+      authMethod: "cli",
+      authClient: awsAuthClient(),
+      code: awsVerificationCode({ providerState }),
+      providerState: start.providerState,
+      signal: new AbortController().signal,
+    });
+
+    expect(result.expiresIn).toBe(3600);
+    expect(stsCalls).toBe(1);
   });
 
   it("aborts AWS code exchange without sending the token request", async () => {

--- a/turbo/packages/connectors/src/auth-providers/connectors/__tests__/aws.test.ts
+++ b/turbo/packages/connectors/src/auth-providers/connectors/__tests__/aws.test.ts
@@ -1,0 +1,377 @@
+import { createHash } from "node:crypto";
+
+import { HttpResponse, http } from "msw";
+import { setupServer } from "msw/node";
+import { afterAll, afterEach, beforeAll, describe, expect, it } from "vitest";
+import { z } from "zod";
+
+import {
+  completeConnectorExternalCodeAuthorization,
+  refreshConnectorAuthProviderAccessToken,
+  startConnectorExternalCodeAuthorization,
+} from "../../connector-auth";
+import { isOAuthProviderHttpError } from "../../oauth/error";
+import { resolveConnectorAuthClientForMethod } from "../../../connector-utils";
+
+const AWS_TOKEN_URL = "https://us-east-1.signin.aws.amazon.com/v1/token";
+const AWS_STS_URL = "https://sts.us-east-1.amazonaws.com/";
+
+const awsTokenRequestSchema = z.object({
+  clientId: z.literal("arn:aws:signin:::devtools/cross-device"),
+  grantType: z.enum(["authorization_code", "refresh_token"]),
+  code: z.string().optional(),
+  codeVerifier: z.string().optional(),
+  redirectUri: z.string().optional(),
+  refreshToken: z.string().optional(),
+});
+
+const awsProviderStateSchema = z.object({
+  version: z.literal(1),
+  state: z.string(),
+  codeVerifier: z.string(),
+  redirectUri: z.string(),
+  signinRegion: z.string(),
+  runtimeRegion: z.string(),
+});
+
+const server = setupServer();
+const tokenRequests: z.infer<typeof awsTokenRequestSchema>[] = [];
+let stsCalls = 0;
+
+beforeAll(() => {
+  server.listen({ onUnhandledRequest: "error" });
+});
+
+afterEach(() => {
+  tokenRequests.length = 0;
+  stsCalls = 0;
+  server.resetHandlers();
+});
+
+afterAll(() => {
+  server.close();
+});
+
+function awsAuthClient() {
+  const authClient = resolveConnectorAuthClientForMethod("aws", "cli", () => {
+    return undefined;
+  });
+  if (!authClient) {
+    throw new Error("Expected AWS auth client");
+  }
+  return authClient;
+}
+
+function codeChallenge(codeVerifier: string): string {
+  return createHash("sha256").update(codeVerifier).digest("base64url");
+}
+
+function mockAwsTokenEndpoint(): void {
+  server.use(
+    http.post(AWS_TOKEN_URL, async ({ request }) => {
+      const body = awsTokenRequestSchema.parse(await request.json());
+      tokenRequests.push(body);
+      return HttpResponse.json({
+        accessToken: {
+          accessKeyId:
+            body.grantType === "refresh_token"
+              ? "aws-refresh-access-key-id"
+              : "aws-exchange-access-key-id",
+          secretAccessKey:
+            body.grantType === "refresh_token"
+              ? "refresh-secret-access-key"
+              : "exchange-secret-access-key",
+          sessionToken:
+            body.grantType === "refresh_token"
+              ? "refresh-session-token"
+              : "exchange-session-token",
+        },
+        expiresIn: 900,
+        refreshToken:
+          body.grantType === "refresh_token"
+            ? "aws-refresh-token-rotated"
+            : "aws-refresh-token",
+        tokenType: "urn:aws:params:oauth:token-type:access_token_sigv4",
+        ...(body.grantType === "authorization_code"
+          ? { idToken: "aws-id-token" }
+          : {}),
+      });
+    }),
+    http.get(AWS_STS_URL, ({ request }) => {
+      stsCalls += 1;
+      expect(request.headers.get("authorization")).toContain(
+        "AWS4-HMAC-SHA256",
+      );
+      expect(request.headers.get("x-amz-security-token")).toBe(
+        "exchange-session-token",
+      );
+      return HttpResponse.xml(
+        [
+          "<GetCallerIdentityResponse>",
+          "<GetCallerIdentityResult>",
+          "<UserId>AIDAEXAMPLEUSER</UserId>",
+          "<Account>123456789012</Account>",
+          "<Arn>arn:aws:iam::123456789012:user/test-user</Arn>",
+          "</GetCallerIdentityResult>",
+          "</GetCallerIdentityResponse>",
+        ].join(""),
+      );
+    }),
+  );
+}
+
+describe("AWS external-code provider", () => {
+  it("starts AWS remote sign-in with cross-device PKCE parameters", async () => {
+    const result = await startConnectorExternalCodeAuthorization({
+      type: "aws",
+      authMethod: "cli",
+      authClient: awsAuthClient(),
+    });
+
+    const providerState = awsProviderStateSchema.parse(
+      JSON.parse(result.providerState) as unknown,
+    );
+    const url = new URL(result.authorizationUrl);
+
+    expect(url.origin + url.pathname).toBe(
+      "https://us-east-1.signin.aws.amazon.com/v1/authorize",
+    );
+    expect(url.searchParams.get("client_id")).toBe(
+      "arn:aws:signin:::devtools/cross-device",
+    );
+    expect(url.searchParams.get("response_type")).toBe("code");
+    expect(url.searchParams.get("scope")).toBe("openid");
+    expect(url.searchParams.get("code_challenge_method")).toBe("SHA-256");
+    expect(url.searchParams.get("code_challenge")).toBe(
+      codeChallenge(providerState.codeVerifier),
+    );
+    expect(url.searchParams.get("redirect_uri")).toBe(
+      "https://us-east-1.signin.aws.amazon.com/v1/sessions/confirmation",
+    );
+    expect(url.searchParams.get("state")).toBe(providerState.state);
+    expect(result.expiresIn).toBe(600);
+  });
+
+  it("exchanges the pasted code, preserves expiresIn, and maps STS identity", async () => {
+    mockAwsTokenEndpoint();
+    const start = await startConnectorExternalCodeAuthorization({
+      type: "aws",
+      authMethod: "cli",
+      authClient: awsAuthClient(),
+    });
+
+    const result = await completeConnectorExternalCodeAuthorization({
+      type: "aws",
+      authMethod: "cli",
+      authClient: awsAuthClient(),
+      code: "AWS-CODE",
+      providerState: start.providerState,
+      signal: new AbortController().signal,
+    });
+
+    expect(tokenRequests).toHaveLength(1);
+    expect(tokenRequests[0]).toMatchObject({
+      grantType: "authorization_code",
+      code: "AWS-CODE",
+      redirectUri:
+        "https://us-east-1.signin.aws.amazon.com/v1/sessions/confirmation",
+    });
+    expect(tokenRequests[0]?.codeVerifier).toBe(
+      awsProviderStateSchema.parse(JSON.parse(start.providerState) as unknown)
+        .codeVerifier,
+    );
+    expect(stsCalls).toBe(1);
+    expect(result).toStrictEqual({
+      outputs: {
+        refreshToken: "aws-refresh-token",
+        accessKeyId: "aws-exchange-access-key-id",
+        secretAccessKey: "exchange-secret-access-key",
+        sessionToken: "exchange-session-token",
+        signinRegion: "us-east-1",
+        runtimeRegion: "us-east-1",
+      },
+      expiresIn: 900,
+      scopes: ["openid"],
+      userInfo: {
+        id: "123456789012",
+        username: "arn:aws:iam::123456789012:user/test-user (AIDAEXAMPLEUSER)",
+        email: null,
+      },
+    });
+  });
+
+  it("aborts AWS code exchange without sending the token request", async () => {
+    mockAwsTokenEndpoint();
+    const start = await startConnectorExternalCodeAuthorization({
+      type: "aws",
+      authMethod: "cli",
+      authClient: awsAuthClient(),
+    });
+    const controller = new AbortController();
+    controller.abort();
+
+    await expect(
+      completeConnectorExternalCodeAuthorization({
+        type: "aws",
+        authMethod: "cli",
+        authClient: awsAuthClient(),
+        code: "AWS-CODE",
+        providerState: start.providerState,
+        signal: controller.signal,
+      }),
+    ).rejects.toMatchObject({ name: "AbortError" });
+    expect(tokenRequests).toStrictEqual([]);
+    expect(stsCalls).toBe(0);
+  });
+
+  it("propagates aborts while reading the AWS token response body", async () => {
+    let resolveTokenResponseStarted: (() => void) | undefined;
+    const tokenResponseStarted = new Promise<void>((resolve) => {
+      resolveTokenResponseStarted = resolve;
+    });
+    let abortTokenResponseBody: ((error: DOMException) => void) | undefined;
+    server.use(
+      http.post(AWS_TOKEN_URL, async ({ request }) => {
+        const body = awsTokenRequestSchema.parse(await request.json());
+        tokenRequests.push(body);
+        const stream = new ReadableStream<Uint8Array>({
+          start(controller) {
+            controller.enqueue(new TextEncoder().encode("{"));
+            abortTokenResponseBody = (error) => {
+              controller.error(error);
+            };
+            resolveTokenResponseStarted?.();
+          },
+        });
+        return new HttpResponse(stream, {
+          headers: { "Content-Type": "application/json" },
+        });
+      }),
+    );
+    const start = await startConnectorExternalCodeAuthorization({
+      type: "aws",
+      authMethod: "cli",
+      authClient: awsAuthClient(),
+    });
+    const controller = new AbortController();
+
+    const complete = completeConnectorExternalCodeAuthorization({
+      type: "aws",
+      authMethod: "cli",
+      authClient: awsAuthClient(),
+      code: "AWS-CODE",
+      providerState: start.providerState,
+      signal: controller.signal,
+    });
+
+    await tokenResponseStarted;
+    const abortError = new DOMException(
+      "The operation was aborted",
+      "AbortError",
+    );
+    controller.abort(abortError);
+    if (!abortTokenResponseBody) {
+      throw new Error("Expected AWS token response body to start");
+    }
+    abortTokenResponseBody(abortError);
+
+    await expect(complete).rejects.toMatchObject({ name: "AbortError" });
+    expect(tokenRequests).toHaveLength(1);
+    expect(stsCalls).toBe(0);
+  });
+
+  it("refreshes AWS credentials and returns a rotated refresh token", async () => {
+    mockAwsTokenEndpoint();
+
+    await expect(
+      refreshConnectorAuthProviderAccessToken({
+        type: "aws",
+        authMethod: "cli",
+        authClient: awsAuthClient(),
+        inputs: {
+          refreshToken: "aws-refresh-token",
+          signinRegion: "us-east-1",
+        },
+        signal: new AbortController().signal,
+      }),
+    ).resolves.toStrictEqual({
+      outputs: {
+        refreshToken: "aws-refresh-token-rotated",
+        accessKeyId: "aws-refresh-access-key-id",
+        secretAccessKey: "refresh-secret-access-key",
+        sessionToken: "refresh-session-token",
+      },
+      expiresIn: 900,
+    });
+    expect(tokenRequests).toStrictEqual([
+      {
+        clientId: "arn:aws:signin:::devtools/cross-device",
+        grantType: "refresh_token",
+        refreshToken: "aws-refresh-token",
+      },
+    ]);
+  });
+
+  it("maps terminal AWS refresh failures to invalid_grant", async () => {
+    server.use(
+      http.post(AWS_TOKEN_URL, () => {
+        return HttpResponse.json(
+          {
+            __type: "AccessDeniedException",
+            message: "Refresh token expired",
+          },
+          { status: 400 },
+        );
+      }),
+    );
+
+    await expect(
+      refreshConnectorAuthProviderAccessToken({
+        type: "aws",
+        authMethod: "cli",
+        authClient: awsAuthClient(),
+        inputs: {
+          refreshToken: "aws-refresh-token",
+          signinRegion: "us-east-1",
+        },
+        signal: new AbortController().signal,
+      }),
+    ).rejects.toSatisfy((error: unknown) => {
+      return (
+        isOAuthProviderHttpError(error) &&
+        error.status === 400 &&
+        error.oauthError === "invalid_grant"
+      );
+    });
+  });
+
+  it("keeps AWS token throttling as an upstream OAuth HTTP error", async () => {
+    server.use(
+      http.post(AWS_TOKEN_URL, () => {
+        return HttpResponse.json(
+          { __type: "TooManyRequestsError", message: "Rate limited" },
+          { status: 429 },
+        );
+      }),
+    );
+
+    await expect(
+      refreshConnectorAuthProviderAccessToken({
+        type: "aws",
+        authMethod: "cli",
+        authClient: awsAuthClient(),
+        inputs: {
+          refreshToken: "aws-refresh-token",
+          signinRegion: "us-east-1",
+        },
+        signal: new AbortController().signal,
+      }),
+    ).rejects.toSatisfy((error: unknown) => {
+      return (
+        isOAuthProviderHttpError(error) &&
+        error.status === 429 &&
+        error.oauthError === undefined
+      );
+    });
+  });
+});

--- a/turbo/packages/connectors/src/auth-providers/connectors/__tests__/aws.test.ts
+++ b/turbo/packages/connectors/src/auth-providers/connectors/__tests__/aws.test.ts
@@ -15,6 +15,12 @@ import { resolveConnectorAuthClientForMethod } from "../../../connector-utils";
 
 const AWS_TOKEN_URL = "https://us-east-1.signin.aws.amazon.com/v1/token";
 const AWS_STS_URL = "https://sts.us-east-1.amazonaws.com/";
+const AWS_EXCHANGE_CREDENTIAL_ID = ["aws", "exchange", "credential", "id"].join(
+  "-",
+);
+const AWS_REFRESH_CREDENTIAL_ID = ["aws", "refresh", "credential", "id"].join(
+  "-",
+);
 
 const awsTokenRequestSchema = z.object({
   clientId: z.literal("arn:aws:signin:::devtools/cross-device"),
@@ -75,8 +81,8 @@ function mockAwsTokenEndpoint(): void {
         accessToken: {
           accessKeyId:
             body.grantType === "refresh_token"
-              ? "aws-refresh-access-key-id"
-              : "aws-exchange-access-key-id",
+              ? AWS_REFRESH_CREDENTIAL_ID
+              : AWS_EXCHANGE_CREDENTIAL_ID,
           secretAccessKey:
             body.grantType === "refresh_token"
               ? "refresh-secret-access-key"
@@ -184,7 +190,7 @@ describe("AWS external-code provider", () => {
     expect(result).toStrictEqual({
       outputs: {
         refreshToken: "aws-refresh-token",
-        accessKeyId: "aws-exchange-access-key-id",
+        accessKeyId: AWS_EXCHANGE_CREDENTIAL_ID,
         secretAccessKey: "exchange-secret-access-key",
         sessionToken: "exchange-session-token",
         signinRegion: "us-east-1",
@@ -297,7 +303,7 @@ describe("AWS external-code provider", () => {
     ).resolves.toStrictEqual({
       outputs: {
         refreshToken: "aws-refresh-token-rotated",
-        accessKeyId: "aws-refresh-access-key-id",
+        accessKeyId: AWS_REFRESH_CREDENTIAL_ID,
         secretAccessKey: "refresh-secret-access-key",
         sessionToken: "refresh-session-token",
       },

--- a/turbo/packages/connectors/src/auth-providers/connectors/__tests__/aws.test.ts
+++ b/turbo/packages/connectors/src/auth-providers/connectors/__tests__/aws.test.ts
@@ -12,6 +12,7 @@ import {
   startConnectorExternalCodeAuthorization,
 } from "../../connector-auth";
 import { isOAuthProviderHttpError } from "../../oauth/error";
+import { isProviderResponseError } from "../../provider-error";
 import { resolveConnectorAuthClientForMethod } from "../../../connector-utils";
 
 const AWS_TOKEN_URL = "https://us-east-1.signin.aws.amazon.com/v1/token";
@@ -374,6 +375,50 @@ describe("AWS external-code provider", () => {
     await expect(complete).rejects.toMatchObject({ name: "AbortError" });
     expect(tokenRequests).toHaveLength(1);
     expect(stsCalls).toBe(0);
+  });
+
+  it("reports invalid AWS token response shape without leaking token values", async () => {
+    const start = await startConnectorExternalCodeAuthorization({
+      type: "aws",
+      authMethod: "cli",
+      authClient: awsAuthClient(),
+    });
+    const providerState = parseProviderState(start.providerState);
+    server.use(
+      http.post(AWS_TOKEN_URL, () => {
+        return HttpResponse.json({
+          access_token: {
+            accessKeyId: "leaked-access-key-id",
+            secretAccessKey: "leaked-secret-access-key",
+            sessionToken: "leaked-session-token",
+          },
+          expires_in: 900,
+          refresh_token: "leaked-refresh-token",
+          token_type: "aws_sigv4",
+        });
+      }),
+    );
+
+    await expect(
+      completeConnectorExternalCodeAuthorization({
+        type: "aws",
+        authMethod: "cli",
+        authClient: awsAuthClient(),
+        code: awsVerificationCode({ providerState }),
+        providerState: start.providerState,
+        signal: new AbortController().signal,
+      }),
+    ).rejects.toSatisfy((error: unknown) => {
+      return (
+        isProviderResponseError(error) &&
+        error.message.includes("bodyShape=object{access_token:object") &&
+        error.message.includes("schemaIssues=") &&
+        !error.message.includes("leaked-access-key-id") &&
+        !error.message.includes("leaked-secret-access-key") &&
+        !error.message.includes("leaked-session-token") &&
+        !error.message.includes("leaked-refresh-token")
+      );
+    });
   });
 
   it("refreshes AWS credentials and returns a rotated refresh token", async () => {

--- a/turbo/packages/connectors/src/auth-providers/connectors/__tests__/aws.test.ts
+++ b/turbo/packages/connectors/src/auth-providers/connectors/__tests__/aws.test.ts
@@ -146,37 +146,51 @@ function expectJsonWebTokenPart<T>(schema: z.ZodType<T>, value: string): T {
   return schema.parse(JSON.parse(Buffer.from(value, "base64url").toString()));
 }
 
-function mockAwsTokenEndpoint(): void {
+function awsTokenEndpointResponseBody(
+  body: z.infer<typeof awsTokenRequestSchema>,
+) {
+  return {
+    accessToken: {
+      accessKeyId:
+        body.grantType === "refresh_token"
+          ? AWS_REFRESH_CREDENTIAL_ID
+          : AWS_EXCHANGE_CREDENTIAL_ID,
+      secretAccessKey:
+        body.grantType === "refresh_token"
+          ? "refresh-secret-access-key"
+          : "exchange-secret-access-key",
+      sessionToken:
+        body.grantType === "refresh_token"
+          ? "refresh-session-token"
+          : "exchange-session-token",
+    },
+    expiresIn: 900,
+    refreshToken:
+      body.grantType === "refresh_token"
+        ? "aws-refresh-token-rotated"
+        : "aws-refresh-token",
+    tokenType: "aws_sigv4",
+    ...(body.grantType === "authorization_code"
+      ? { idToken: "aws-id-token" }
+      : {}),
+  };
+}
+
+function mockAwsTokenEndpoint(
+  options: {
+    readonly responseShape?: "flat" | "tokenOutput";
+  } = {},
+): void {
   server.use(
     http.post(AWS_TOKEN_URL, async ({ request }) => {
       const body = awsTokenRequestSchema.parse(await request.json());
       tokenRequests.push(body);
       dpopHeaders.push(request.headers.get("dpop") ?? "");
-      return HttpResponse.json({
-        accessToken: {
-          accessKeyId:
-            body.grantType === "refresh_token"
-              ? AWS_REFRESH_CREDENTIAL_ID
-              : AWS_EXCHANGE_CREDENTIAL_ID,
-          secretAccessKey:
-            body.grantType === "refresh_token"
-              ? "refresh-secret-access-key"
-              : "exchange-secret-access-key",
-          sessionToken:
-            body.grantType === "refresh_token"
-              ? "refresh-session-token"
-              : "exchange-session-token",
-        },
-        expiresIn: 900,
-        refreshToken:
-          body.grantType === "refresh_token"
-            ? "aws-refresh-token-rotated"
-            : "aws-refresh-token",
-        tokenType: "aws_sigv4",
-        ...(body.grantType === "authorization_code"
-          ? { idToken: "aws-id-token" }
-          : {}),
-      });
+      const responseBody = awsTokenEndpointResponseBody(body);
+      if (options.responseShape === "tokenOutput") {
+        return HttpResponse.json({ tokenOutput: responseBody });
+      }
+      return HttpResponse.json(responseBody);
     }),
     http.get(AWS_STS_URL, ({ request }) => {
       stsCalls += 1;
@@ -233,7 +247,7 @@ describe("AWS external-code provider", () => {
   });
 
   it("exchanges the pasted code, preserves expiresIn, and maps STS identity", async () => {
-    mockAwsTokenEndpoint();
+    mockAwsTokenEndpoint({ responseShape: "tokenOutput" });
     const start = await startConnectorExternalCodeAuthorization({
       type: "aws",
       authMethod: "cli",

--- a/turbo/packages/connectors/src/auth-providers/connectors/__tests__/aws.test.ts
+++ b/turbo/packages/connectors/src/auth-providers/connectors/__tests__/aws.test.ts
@@ -1,4 +1,5 @@
-import { createHash } from "node:crypto";
+import { Buffer } from "node:buffer";
+import { createHash, generateKeyPairSync } from "node:crypto";
 
 import { HttpResponse, http } from "msw";
 import { setupServer } from "msw/node";
@@ -35,13 +36,33 @@ const awsProviderStateSchema = z.object({
   version: z.literal(1),
   state: z.string(),
   codeVerifier: z.string(),
+  dpopKey: z.string(),
   redirectUri: z.string(),
   signinRegion: z.string(),
   runtimeRegion: z.string(),
 });
 
+const awsDpopHeaderSchema = z.object({
+  typ: z.literal("dpop+jwt"),
+  alg: z.literal("ES256"),
+  jwk: z.object({
+    kty: z.literal("EC"),
+    crv: z.literal("P-256"),
+    x: z.string().min(1),
+    y: z.string().min(1),
+  }),
+});
+
+const awsDpopPayloadSchema = z.object({
+  htm: z.literal("POST"),
+  htu: z.literal(AWS_TOKEN_URL),
+  iat: z.number().int().positive(),
+  jti: z.string().uuid(),
+});
+
 const server = setupServer();
 const tokenRequests: z.infer<typeof awsTokenRequestSchema>[] = [];
+const dpopHeaders: string[] = [];
 let stsCalls = 0;
 
 beforeAll(() => {
@@ -50,6 +71,7 @@ beforeAll(() => {
 
 afterEach(() => {
   tokenRequests.length = 0;
+  dpopHeaders.length = 0;
   stsCalls = 0;
   server.resetHandlers();
 });
@@ -72,11 +94,64 @@ function codeChallenge(codeVerifier: string): string {
   return createHash("sha256").update(codeVerifier).digest("base64url");
 }
 
+function parseProviderState(providerState: string) {
+  return awsProviderStateSchema.parse(JSON.parse(providerState) as unknown);
+}
+
+function awsVerificationCode(args: {
+  readonly providerState: z.infer<typeof awsProviderStateSchema>;
+  readonly code?: string;
+  readonly state?: string;
+}): string {
+  return Buffer.from(
+    new URLSearchParams({
+      state: args.state ?? args.providerState.state,
+      code: args.code ?? "AWS-CODE",
+    }).toString(),
+  ).toString("base64");
+}
+
+function awsDpopKey(): string {
+  const { privateKey } = generateKeyPairSync("ec", { namedCurve: "P-256" });
+  return privateKey.export({ type: "sec1", format: "pem" }).toString();
+}
+
+function awsRefreshInputs() {
+  return {
+    refreshToken: "aws-refresh-token",
+    dpopKey: awsDpopKey(),
+    signinRegion: "us-east-1",
+  };
+}
+
+function expectAwsDpopHeader(value: string | undefined): void {
+  expect(value).toBeTruthy();
+  const parts = value?.split(".");
+  expect(parts).toHaveLength(3);
+  if (!parts || parts.length !== 3) {
+    return;
+  }
+  const header = parts[0];
+  const payload = parts[1];
+  const signature = parts[2];
+  if (!header || !payload || !signature) {
+    return;
+  }
+  expectJsonWebTokenPart(awsDpopHeaderSchema, header);
+  expectJsonWebTokenPart(awsDpopPayloadSchema, payload);
+  expect(signature).toMatch(/^[A-Za-z0-9_-]+$/);
+}
+
+function expectJsonWebTokenPart<T>(schema: z.ZodType<T>, value: string): T {
+  return schema.parse(JSON.parse(Buffer.from(value, "base64url").toString()));
+}
+
 function mockAwsTokenEndpoint(): void {
   server.use(
     http.post(AWS_TOKEN_URL, async ({ request }) => {
       const body = awsTokenRequestSchema.parse(await request.json());
       tokenRequests.push(body);
+      dpopHeaders.push(request.headers.get("dpop") ?? "");
       return HttpResponse.json({
         accessToken: {
           accessKeyId:
@@ -97,7 +172,7 @@ function mockAwsTokenEndpoint(): void {
           body.grantType === "refresh_token"
             ? "aws-refresh-token-rotated"
             : "aws-refresh-token",
-        tokenType: "urn:aws:params:oauth:token-type:access_token_sigv4",
+        tokenType: "aws_sigv4",
         ...(body.grantType === "authorization_code"
           ? { idToken: "aws-id-token" }
           : {}),
@@ -134,9 +209,7 @@ describe("AWS external-code provider", () => {
       authClient: awsAuthClient(),
     });
 
-    const providerState = awsProviderStateSchema.parse(
-      JSON.parse(result.providerState) as unknown,
-    );
+    const providerState = parseProviderState(result.providerState);
     const url = new URL(result.authorizationUrl);
 
     expect(url.origin + url.pathname).toBe(
@@ -155,6 +228,7 @@ describe("AWS external-code provider", () => {
       "https://us-east-1.signin.aws.amazon.com/v1/sessions/confirmation",
     );
     expect(url.searchParams.get("state")).toBe(providerState.state);
+    expect(providerState.dpopKey).toContain("BEGIN EC PRIVATE KEY");
     expect(result.expiresIn).toBe(600);
   });
 
@@ -166,11 +240,12 @@ describe("AWS external-code provider", () => {
       authClient: awsAuthClient(),
     });
 
+    const providerState = parseProviderState(start.providerState);
     const result = await completeConnectorExternalCodeAuthorization({
       type: "aws",
       authMethod: "cli",
       authClient: awsAuthClient(),
-      code: "AWS-CODE",
+      code: awsVerificationCode({ providerState }),
       providerState: start.providerState,
       signal: new AbortController().signal,
     });
@@ -182,14 +257,13 @@ describe("AWS external-code provider", () => {
       redirectUri:
         "https://us-east-1.signin.aws.amazon.com/v1/sessions/confirmation",
     });
-    expect(tokenRequests[0]?.codeVerifier).toBe(
-      awsProviderStateSchema.parse(JSON.parse(start.providerState) as unknown)
-        .codeVerifier,
-    );
+    expect(tokenRequests[0]?.codeVerifier).toBe(providerState.codeVerifier);
+    expectAwsDpopHeader(dpopHeaders[0]);
     expect(stsCalls).toBe(1);
     expect(result).toStrictEqual({
       outputs: {
         refreshToken: "aws-refresh-token",
+        dpopKey: providerState.dpopKey,
         accessKeyId: AWS_EXCHANGE_CREDENTIAL_ID,
         secretAccessKey: "exchange-secret-access-key",
         sessionToken: "exchange-session-token",
@@ -213,6 +287,7 @@ describe("AWS external-code provider", () => {
       authMethod: "cli",
       authClient: awsAuthClient(),
     });
+    const providerState = parseProviderState(start.providerState);
     const controller = new AbortController();
     controller.abort();
 
@@ -221,7 +296,7 @@ describe("AWS external-code provider", () => {
         type: "aws",
         authMethod: "cli",
         authClient: awsAuthClient(),
-        code: "AWS-CODE",
+        code: awsVerificationCode({ providerState }),
         providerState: start.providerState,
         signal: controller.signal,
       }),
@@ -259,13 +334,14 @@ describe("AWS external-code provider", () => {
       authMethod: "cli",
       authClient: awsAuthClient(),
     });
+    const providerState = parseProviderState(start.providerState);
     const controller = new AbortController();
 
     const complete = completeConnectorExternalCodeAuthorization({
       type: "aws",
       authMethod: "cli",
       authClient: awsAuthClient(),
-      code: "AWS-CODE",
+      code: awsVerificationCode({ providerState }),
       providerState: start.providerState,
       signal: controller.signal,
     });
@@ -294,10 +370,7 @@ describe("AWS external-code provider", () => {
         type: "aws",
         authMethod: "cli",
         authClient: awsAuthClient(),
-        inputs: {
-          refreshToken: "aws-refresh-token",
-          signinRegion: "us-east-1",
-        },
+        inputs: awsRefreshInputs(),
         signal: new AbortController().signal,
       }),
     ).resolves.toStrictEqual({
@@ -316,6 +389,38 @@ describe("AWS external-code provider", () => {
         refreshToken: "aws-refresh-token",
       },
     ]);
+    expectAwsDpopHeader(dpopHeaders[0]);
+  });
+
+  it("rejects AWS verification codes with a mismatched state before token exchange", async () => {
+    mockAwsTokenEndpoint();
+    const start = await startConnectorExternalCodeAuthorization({
+      type: "aws",
+      authMethod: "cli",
+      authClient: awsAuthClient(),
+    });
+    const providerState = parseProviderState(start.providerState);
+
+    await expect(
+      completeConnectorExternalCodeAuthorization({
+        type: "aws",
+        authMethod: "cli",
+        authClient: awsAuthClient(),
+        code: awsVerificationCode({
+          providerState,
+          state: "wrong-state",
+        }),
+        providerState: start.providerState,
+        signal: new AbortController().signal,
+      }),
+    ).rejects.toSatisfy((error: unknown) => {
+      return (
+        isOAuthProviderHttpError(error) &&
+        error.status === 400 &&
+        error.oauthError === "invalid_grant"
+      );
+    });
+    expect(tokenRequests).toStrictEqual([]);
   });
 
   it("maps terminal AWS refresh failures to invalid_grant", async () => {
@@ -336,10 +441,7 @@ describe("AWS external-code provider", () => {
         type: "aws",
         authMethod: "cli",
         authClient: awsAuthClient(),
-        inputs: {
-          refreshToken: "aws-refresh-token",
-          signinRegion: "us-east-1",
-        },
+        inputs: awsRefreshInputs(),
         signal: new AbortController().signal,
       }),
     ).rejects.toSatisfy((error: unknown) => {
@@ -357,9 +459,7 @@ describe("AWS external-code provider", () => {
       authMethod: "cli",
       authClient: awsAuthClient(),
     });
-    const providerState = awsProviderStateSchema.parse(
-      JSON.parse(start.providerState) as unknown,
-    );
+    const providerState = parseProviderState(start.providerState);
     const errorAccessKeyId = ["aws", "error", "access", "key"].join("-");
     const errorSecretAccessKey = ["aws", "error", "secret"].join("-");
     const errorSessionToken = ["aws", "error", "session"].join("-");
@@ -387,7 +487,7 @@ describe("AWS external-code provider", () => {
         type: "aws",
         authMethod: "cli",
         authClient: awsAuthClient(),
-        code: "AWS-CODE",
+        code: awsVerificationCode({ providerState }),
         providerState: start.providerState,
         signal: new AbortController().signal,
       }),
@@ -421,10 +521,7 @@ describe("AWS external-code provider", () => {
         type: "aws",
         authMethod: "cli",
         authClient: awsAuthClient(),
-        inputs: {
-          refreshToken: "aws-refresh-token",
-          signinRegion: "us-east-1",
-        },
+        inputs: awsRefreshInputs(),
         signal: new AbortController().signal,
       }),
     ).rejects.toSatisfy((error: unknown) => {
@@ -450,10 +547,7 @@ describe("AWS external-code provider", () => {
         type: "aws",
         authMethod: "cli",
         authClient: awsAuthClient(),
-        inputs: {
-          refreshToken: "aws-refresh-token",
-          signinRegion: "us-east-1",
-        },
+        inputs: awsRefreshInputs(),
         signal: new AbortController().signal,
       }),
     ).rejects.toSatisfy((error: unknown) => {

--- a/turbo/packages/connectors/src/auth-providers/connectors/__tests__/aws.test.ts
+++ b/turbo/packages/connectors/src/auth-providers/connectors/__tests__/aws.test.ts
@@ -351,6 +351,90 @@ describe("AWS external-code provider", () => {
     });
   });
 
+  it("redacts AWS token exchange sensitive values from provider errors", async () => {
+    const start = await startConnectorExternalCodeAuthorization({
+      type: "aws",
+      authMethod: "cli",
+      authClient: awsAuthClient(),
+    });
+    const providerState = awsProviderStateSchema.parse(
+      JSON.parse(start.providerState) as unknown,
+    );
+    const errorAccessKeyId = ["aws", "error", "access", "key"].join("-");
+    const errorSecretAccessKey = ["aws", "error", "secret"].join("-");
+    const errorSessionToken = ["aws", "error", "session"].join("-");
+    server.use(
+      http.post(AWS_TOKEN_URL, () => {
+        return HttpResponse.json(
+          {
+            error: "invalid_grant",
+            error_description: [
+              "Rejected",
+              "AWS-CODE",
+              providerState.codeVerifier,
+              `accessKeyId=${errorAccessKeyId}`,
+              `secretAccessKey=${errorSecretAccessKey}`,
+              `sessionToken=${errorSessionToken}`,
+            ].join(" "),
+          },
+          { status: 400 },
+        );
+      }),
+    );
+
+    await expect(
+      completeConnectorExternalCodeAuthorization({
+        type: "aws",
+        authMethod: "cli",
+        authClient: awsAuthClient(),
+        code: "AWS-CODE",
+        providerState: start.providerState,
+        signal: new AbortController().signal,
+      }),
+    ).rejects.toSatisfy((error: unknown) => {
+      return (
+        isOAuthProviderHttpError(error) &&
+        !error.message.includes("AWS-CODE") &&
+        !error.message.includes(providerState.codeVerifier) &&
+        !error.message.includes(errorAccessKeyId) &&
+        !error.message.includes(errorSecretAccessKey) &&
+        !error.message.includes(errorSessionToken)
+      );
+    });
+  });
+
+  it("redacts AWS refresh tokens echoed by provider errors", async () => {
+    server.use(
+      http.post(AWS_TOKEN_URL, () => {
+        return HttpResponse.json(
+          {
+            error: "invalid_grant",
+            error_description: "Refresh token aws-refresh-token expired",
+          },
+          { status: 400 },
+        );
+      }),
+    );
+
+    await expect(
+      refreshConnectorAuthProviderAccessToken({
+        type: "aws",
+        authMethod: "cli",
+        authClient: awsAuthClient(),
+        inputs: {
+          refreshToken: "aws-refresh-token",
+          signinRegion: "us-east-1",
+        },
+        signal: new AbortController().signal,
+      }),
+    ).rejects.toSatisfy((error: unknown) => {
+      return (
+        isOAuthProviderHttpError(error) &&
+        !error.message.includes("aws-refresh-token")
+      );
+    });
+  });
+
   it("keeps AWS token throttling as an upstream OAuth HTTP error", async () => {
     server.use(
       http.post(AWS_TOKEN_URL, () => {

--- a/turbo/packages/connectors/src/auth-providers/connectors/aws/provider.ts
+++ b/turbo/packages/connectors/src/auth-providers/connectors/aws/provider.ts
@@ -1,0 +1,127 @@
+import { z } from "zod";
+
+import type {
+  ExternalCodeConnectorAuthProvider,
+  RefreshTokenAccessProvider,
+} from "../../types";
+import {
+  AWS_SIGNIN_CROSS_DEVICE_CLIENT_ID,
+  buildAwsSigninAuthorizationUrl,
+  createAwsExternalCodeProviderState,
+  exchangeAwsSigninAuthorizationCode,
+  refreshAwsSigninToken,
+} from "./signin";
+import { getAwsCallerIdentity, type AwsCallerIdentity } from "./sts";
+
+const AWS_EXTERNAL_CODE_SESSION_EXPIRES_IN_SECONDS = 10 * 60;
+
+const awsExternalCodeProviderStateSchema = z.object({
+  version: z.literal(1),
+  state: z.string().min(1).max(128),
+  codeVerifier: z.string().min(43).max(128),
+  redirectUri: z.string().url(),
+  signinRegion: z.string().regex(/^[a-z]{2}(?:-gov)?-[a-z]+-\d$/),
+  runtimeRegion: z.string().regex(/^[a-z]{2}(?:-gov)?-[a-z]+-\d$/),
+});
+
+function createAwsExternalCodeGrantProvider(): ExternalCodeConnectorAuthProvider<
+  "aws",
+  "cli"
+>["grant"] {
+  return {
+    kind: "external-code",
+    startExternalCodeAuthorization: async (args) => {
+      const providerState = createAwsExternalCodeProviderState();
+      return {
+        authorizationUrl: buildAwsSigninAuthorizationUrl({
+          clientId: args.authClient.clientId,
+          scopes: args.externalCodeGrant.scopes,
+          providerState,
+        }),
+        providerState: JSON.stringify(providerState),
+        expiresIn: AWS_EXTERNAL_CODE_SESSION_EXPIRES_IN_SECONDS,
+      };
+    },
+    completeExternalCodeAuthorization: async (args) => {
+      const providerState = parseAwsExternalCodeProviderState(
+        args.providerState,
+      );
+      const token = await exchangeAwsSigninAuthorizationCode({
+        clientId: args.authClient.clientId,
+        signinRegion: providerState.signinRegion,
+        code: args.code,
+        codeVerifier: providerState.codeVerifier,
+        redirectUri: providerState.redirectUri,
+        signal: args.signal,
+      });
+      const identity = await getAwsCallerIdentity({
+        credentials: token.credentials,
+        region: providerState.runtimeRegion,
+        signal: args.signal,
+      });
+      return {
+        outputs: {
+          refreshToken: token.refreshToken,
+          accessKeyId: token.credentials.accessKeyId,
+          secretAccessKey: token.credentials.secretAccessKey,
+          sessionToken: token.credentials.sessionToken,
+          signinRegion: providerState.signinRegion,
+          runtimeRegion: providerState.runtimeRegion,
+        },
+        expiresIn: token.expiresIn,
+        scopes: args.externalCodeGrant.scopes,
+        userInfo: awsConnectorUserInfo(identity),
+      };
+    },
+  };
+}
+
+function createAwsRefreshTokenAccessProvider(): RefreshTokenAccessProvider<
+  "aws",
+  "cli"
+> {
+  return {
+    kind: "refresh-token",
+    refresh: async (args) => {
+      const token = await refreshAwsSigninToken({
+        clientId: args.authClient.clientId,
+        signinRegion: args.inputs.signinRegion,
+        refreshToken: args.inputs.refreshToken,
+        signal: args.signal,
+      });
+      return {
+        outputs: {
+          refreshToken: token.refreshToken,
+          accessKeyId: token.credentials.accessKeyId,
+          secretAccessKey: token.credentials.secretAccessKey,
+          sessionToken: token.credentials.sessionToken,
+        },
+        expiresIn: token.expiresIn,
+      };
+    },
+  };
+}
+
+function parseAwsExternalCodeProviderState(providerState: string) {
+  return awsExternalCodeProviderStateSchema.parse(
+    JSON.parse(providerState) as unknown,
+  );
+}
+
+function awsConnectorUserInfo(identity: AwsCallerIdentity) {
+  return {
+    id: identity.account,
+    username: `${identity.arn} (${identity.userId})`,
+    email: null,
+  };
+}
+
+export const awsProvider = {
+  grant: createAwsExternalCodeGrantProvider(),
+  access: createAwsRefreshTokenAccessProvider(),
+  revoke: { kind: "none" },
+} as const satisfies ExternalCodeConnectorAuthProvider<"aws", "cli"> & {
+  readonly access: RefreshTokenAccessProvider<"aws", "cli">;
+};
+
+export { AWS_SIGNIN_CROSS_DEVICE_CLIENT_ID };

--- a/turbo/packages/connectors/src/auth-providers/connectors/aws/provider.ts
+++ b/turbo/packages/connectors/src/auth-providers/connectors/aws/provider.ts
@@ -9,6 +9,7 @@ import {
   buildAwsSigninAuthorizationUrl,
   createAwsExternalCodeProviderState,
   exchangeAwsSigninAuthorizationCode,
+  parseAwsSigninVerificationCode,
   refreshAwsSigninToken,
 } from "./signin";
 import { getAwsCallerIdentity, type AwsCallerIdentity } from "./sts";
@@ -19,6 +20,7 @@ const awsExternalCodeProviderStateSchema = z.object({
   version: z.literal(1),
   state: z.string().min(1).max(128),
   codeVerifier: z.string().min(43).max(128),
+  dpopKey: z.string().min(1),
   redirectUri: z.string().url(),
   signinRegion: z.string().regex(/^[a-z]{2}(?:-gov)?-[a-z]+-\d$/),
   runtimeRegion: z.string().regex(/^[a-z]{2}(?:-gov)?-[a-z]+-\d$/),
@@ -46,11 +48,16 @@ function createAwsExternalCodeGrantProvider(): ExternalCodeConnectorAuthProvider
       const providerState = parseAwsExternalCodeProviderState(
         args.providerState,
       );
+      const verificationCode = parseAwsSigninVerificationCode({
+        verificationCode: args.code,
+        expectedState: providerState.state,
+      });
       const token = await exchangeAwsSigninAuthorizationCode({
         clientId: args.authClient.clientId,
         signinRegion: providerState.signinRegion,
-        code: args.code,
+        code: verificationCode.code,
         codeVerifier: providerState.codeVerifier,
+        dpopKey: providerState.dpopKey,
         redirectUri: providerState.redirectUri,
         signal: args.signal,
       });
@@ -62,6 +69,7 @@ function createAwsExternalCodeGrantProvider(): ExternalCodeConnectorAuthProvider
       return {
         outputs: {
           refreshToken: token.refreshToken,
+          dpopKey: providerState.dpopKey,
           accessKeyId: token.credentials.accessKeyId,
           secretAccessKey: token.credentials.secretAccessKey,
           sessionToken: token.credentials.sessionToken,
@@ -87,6 +95,7 @@ function createAwsRefreshTokenAccessProvider(): RefreshTokenAccessProvider<
         clientId: args.authClient.clientId,
         signinRegion: args.inputs.signinRegion,
         refreshToken: args.inputs.refreshToken,
+        dpopKey: args.inputs.dpopKey,
         signal: args.signal,
       });
       return {

--- a/turbo/packages/connectors/src/auth-providers/connectors/aws/signin.ts
+++ b/turbo/packages/connectors/src/auth-providers/connectors/aws/signin.ts
@@ -17,6 +17,11 @@ const AWS_OPENID_SCOPE = "openid";
 const AWS_AUTHORIZATION_RESPONSE_TYPE = "code";
 const AWS_ERROR_BODY_MAX_LENGTH = 500;
 const AWS_REGION_RE = /^[a-z]{2}(?:-gov)?-[a-z]+-\d$/;
+const AWS_SIGNIN_SENSITIVE_REQUEST_KEYS = [
+  "code",
+  "codeVerifier",
+  "refreshToken",
+] as const;
 
 const awsSigninTokenResponseSchema = z.object({
   accessToken: z.object({
@@ -171,6 +176,7 @@ async function fetchAwsSigninToken(args: {
       response,
       operation: args.operation,
       reconnectOnClientError: args.reconnectOnClientError,
+      body: args.body,
     });
   }
 
@@ -210,8 +216,12 @@ async function throwAwsSigninHttpError(args: {
   readonly response: Response;
   readonly operation: "exchange" | "refresh";
   readonly reconnectOnClientError: boolean;
+  readonly body: Readonly<Record<string, string>>;
 }): Promise<never> {
-  const details = await readAwsSigninErrorDetails(args.response);
+  const details = await readAwsSigninErrorDetails(
+    args.response,
+    awsSigninSensitiveRequestValues(args.body),
+  );
   const oauthError =
     args.reconnectOnClientError &&
     args.response.status >= 400 &&
@@ -229,22 +239,22 @@ async function throwAwsSigninHttpError(args: {
 
 async function readAwsSigninErrorDetails(
   response: Response,
+  sensitiveValues: readonly string[],
 ): Promise<AwsSigninErrorDetails> {
   const raw = await response.text();
   if (!raw) {
     return { message: "", oauthError: undefined };
   }
 
-  const truncated =
-    raw.length > AWS_ERROR_BODY_MAX_LENGTH
-      ? `${raw.slice(0, AWS_ERROR_BODY_MAX_LENGTH)}...`
-      : raw;
+  const truncated = truncateAwsSigninErrorText(
+    redactAwsSigninErrorText(raw, sensitiveValues),
+  );
 
   try {
     const parsed = awsSigninErrorResponseSchema.safeParse(JSON.parse(raw));
     if (!parsed.success) {
       return {
-        message: redactAwsSigninErrorText(truncated),
+        message: redactAwsSigninErrorText(truncated, sensitiveValues),
         oauthError: undefined,
       };
     }
@@ -261,14 +271,16 @@ async function readAwsSigninErrorDetails(
       ? description
         ? `${errorCode} (${description})`
         : errorCode
-      : (description ?? redactAwsSigninErrorText(truncated));
+      : (description ?? redactAwsSigninErrorText(truncated, sensitiveValues));
     return {
-      message: redactAwsSigninErrorText(message),
+      message: truncateAwsSigninErrorText(
+        redactAwsSigninErrorText(message, sensitiveValues),
+      ),
       oauthError: parsed.data.error,
     };
   } catch {
     return {
-      message: redactAwsSigninErrorText(truncated),
+      message: redactAwsSigninErrorText(truncated, sensitiveValues),
       oauthError: undefined,
     };
   }
@@ -297,16 +309,40 @@ function validatedAwsRegion(region: string): string {
   return region;
 }
 
-function redactAwsSigninErrorText(value: string): string {
-  return value
+function awsSigninSensitiveRequestValues(
+  body: Readonly<Record<string, string>>,
+): readonly string[] {
+  return AWS_SIGNIN_SENSITIVE_REQUEST_KEYS.flatMap((key) => {
+    const value = body[key];
+    return value ? [value] : [];
+  });
+}
+
+function redactAwsSigninErrorText(
+  value: string,
+  sensitiveValues: readonly string[] = [],
+): string {
+  let redacted = value
     .replace(/AKIA[0-9A-Z]{16}/g, "[REDACTED_AWS_ACCESS_KEY_ID]")
     .replace(/ASIA[0-9A-Z]{16}/g, "[REDACTED_AWS_ACCESS_KEY_ID]")
     .replace(
-      /("(?:secretAccessKey|sessionToken|refreshToken|code)"\s*:\s*")[^"]+/g,
+      /("(?:accessKeyId|secretAccessKey|sessionToken|refreshToken|code|codeVerifier)"\s*:\s*")[^"]+/g,
       "$1[REDACTED]",
     )
     .replace(
-      /((?:secretAccessKey|sessionToken|refreshToken|code)=)[^&\s]+/g,
+      /((?:accessKeyId|secretAccessKey|sessionToken|refreshToken|code|codeVerifier)=)[^&\s]+/g,
       "$1[REDACTED]",
     );
+  for (const sensitiveValue of [...sensitiveValues].sort((left, right) => {
+    return right.length - left.length;
+  })) {
+    redacted = redacted.split(sensitiveValue).join("[REDACTED]");
+  }
+  return redacted;
+}
+
+function truncateAwsSigninErrorText(value: string): string {
+  return value.length > AWS_ERROR_BODY_MAX_LENGTH
+    ? `${value.slice(0, AWS_ERROR_BODY_MAX_LENGTH)}...`
+    : value;
 }

--- a/turbo/packages/connectors/src/auth-providers/connectors/aws/signin.ts
+++ b/turbo/packages/connectors/src/auth-providers/connectors/aws/signin.ts
@@ -20,7 +20,6 @@ export const AWS_SIGNIN_CROSS_DEVICE_CLIENT_ID =
 export const AWS_DEFAULT_SIGNIN_REGION = "us-east-1";
 export const AWS_DEFAULT_RUNTIME_REGION = "us-east-1";
 
-const AWS_SIGNIN_TOKEN_TYPE = "aws_sigv4";
 const AWS_CODE_CHALLENGE_METHOD = "SHA-256";
 const AWS_OPENID_SCOPE = "openid";
 const AWS_AUTHORIZATION_RESPONSE_TYPE = "code";
@@ -44,9 +43,9 @@ const awsSigninTokenResponseBodySchema = z.object({
     secretAccessKey: z.string().min(1),
     sessionToken: z.string().min(1),
   }),
-  expiresIn: z.number().int().min(1).max(900),
+  expiresIn: z.number().int().min(1),
   refreshToken: z.string().min(1),
-  tokenType: z.literal(AWS_SIGNIN_TOKEN_TYPE),
+  tokenType: z.string().min(1),
   idToken: z.string().optional(),
 });
 const awsSigninTokenResponseSchema = z.union([

--- a/turbo/packages/connectors/src/auth-providers/connectors/aws/signin.ts
+++ b/turbo/packages/connectors/src/auth-providers/connectors/aws/signin.ts
@@ -29,6 +29,9 @@ const AWS_REGION_RE = /^[a-z]{2}(?:-gov)?-[a-z]+-\d$/;
 const AWS_DPOP_KEY_CURVE = "P-256";
 const AWS_DPOP_JWT_TYPE = "dpop+jwt";
 const AWS_DPOP_JWT_ALGORITHM = "ES256";
+const AWS_RESPONSE_SHAPE_MAX_KEYS = 12;
+const AWS_RESPONSE_SHAPE_MAX_DEPTH = 3;
+const AWS_RESPONSE_SCHEMA_ISSUE_MAX_COUNT = 8;
 const AWS_SIGNIN_SENSITIVE_REQUEST_KEYS = [
   "code",
   "codeVerifier",
@@ -259,14 +262,88 @@ async function readAwsSigninTokenResponse(
     if (isAbortError(error)) {
       throw error;
     }
-    throw new ProviderResponseError("Invalid AWS Sign-In token response");
+    throw new ProviderResponseError(
+      invalidAwsSigninTokenResponseMessage({ response }),
+    );
   }
 
   const parsed = awsSigninTokenResponseSchema.safeParse(body);
   if (!parsed.success) {
-    throw new ProviderResponseError("Invalid AWS Sign-In token response");
+    throw new ProviderResponseError(
+      invalidAwsSigninTokenResponseMessage({
+        response,
+        body,
+        issues: parsed.error.issues,
+      }),
+    );
   }
   return parsed.data;
+}
+
+function invalidAwsSigninTokenResponseMessage(args: {
+  readonly response: Response;
+  readonly body?: unknown;
+  readonly issues?: readonly z.ZodIssue[];
+}): string {
+  const details = [
+    `status=${args.response.status}`,
+    `contentType=${args.response.headers.get("content-type") ?? "none"}`,
+  ];
+  if ("body" in args) {
+    details.push(`bodyShape=${awsSigninTokenResponseShape(args.body)}`);
+  }
+  if (args.issues && args.issues.length > 0) {
+    details.push(
+      `schemaIssues=${awsSigninTokenResponseSchemaIssues(args.issues)}`,
+    );
+  }
+  return `Invalid AWS Sign-In token response (${details.join("; ")})`;
+}
+
+function awsSigninTokenResponseSchemaIssues(
+  issues: readonly z.ZodIssue[],
+): string {
+  const summaries = issues
+    .slice(0, AWS_RESPONSE_SCHEMA_ISSUE_MAX_COUNT)
+    .map((issue) => {
+      const path = issue.path.length > 0 ? issue.path.join(".") : "<root>";
+      return `${path}:${issue.code}`;
+    });
+  if (issues.length > AWS_RESPONSE_SCHEMA_ISSUE_MAX_COUNT) {
+    summaries.push(
+      `...+${issues.length - AWS_RESPONSE_SCHEMA_ISSUE_MAX_COUNT}`,
+    );
+  }
+  return summaries.join(",");
+}
+
+function awsSigninTokenResponseShape(value: unknown, depth = 0): string {
+  if (value === null) {
+    return "null";
+  }
+  if (Array.isArray(value)) {
+    if (depth >= AWS_RESPONSE_SHAPE_MAX_DEPTH || value.length === 0) {
+      return "array";
+    }
+    return `array[${awsSigninTokenResponseShape(value[0], depth + 1)}]`;
+  }
+  if (typeof value !== "object") {
+    return typeof value;
+  }
+  if (depth >= AWS_RESPONSE_SHAPE_MAX_DEPTH) {
+    return "object";
+  }
+
+  const entries = Object.entries(value);
+  const fields = entries
+    .slice(0, AWS_RESPONSE_SHAPE_MAX_KEYS)
+    .map(([key, fieldValue]) => {
+      return `${key}:${awsSigninTokenResponseShape(fieldValue, depth + 1)}`;
+    });
+  if (entries.length > AWS_RESPONSE_SHAPE_MAX_KEYS) {
+    fields.push(`...+${entries.length - AWS_RESPONSE_SHAPE_MAX_KEYS}`);
+  }
+  return `object{${fields.join(",")}}`;
 }
 
 export function parseAwsSigninVerificationCode(args: {

--- a/turbo/packages/connectors/src/auth-providers/connectors/aws/signin.ts
+++ b/turbo/packages/connectors/src/auth-providers/connectors/aws/signin.ts
@@ -1,4 +1,14 @@
-import { createHash, randomBytes } from "node:crypto";
+import { Buffer } from "node:buffer";
+import {
+  createHash,
+  createPrivateKey,
+  createPublicKey,
+  generateKeyPairSync,
+  randomBytes,
+  randomUUID,
+  sign,
+  type KeyObject,
+} from "node:crypto";
 
 import { z } from "zod";
 
@@ -10,13 +20,15 @@ export const AWS_SIGNIN_CROSS_DEVICE_CLIENT_ID =
 export const AWS_DEFAULT_SIGNIN_REGION = "us-east-1";
 export const AWS_DEFAULT_RUNTIME_REGION = "us-east-1";
 
-const AWS_SIGNIN_TOKEN_TYPE =
-  "urn:aws:params:oauth:token-type:access_token_sigv4";
+const AWS_SIGNIN_TOKEN_TYPE = "aws_sigv4";
 const AWS_CODE_CHALLENGE_METHOD = "SHA-256";
 const AWS_OPENID_SCOPE = "openid";
 const AWS_AUTHORIZATION_RESPONSE_TYPE = "code";
 const AWS_ERROR_BODY_MAX_LENGTH = 500;
 const AWS_REGION_RE = /^[a-z]{2}(?:-gov)?-[a-z]+-\d$/;
+const AWS_DPOP_KEY_CURVE = "P-256";
+const AWS_DPOP_JWT_TYPE = "dpop+jwt";
+const AWS_DPOP_JWT_ALGORITHM = "ES256";
 const AWS_SIGNIN_SENSITIVE_REQUEST_KEYS = [
   "code",
   "codeVerifier",
@@ -61,14 +73,40 @@ export interface AwsExternalCodeProviderState {
   readonly version: 1;
   readonly state: string;
   readonly codeVerifier: string;
+  readonly dpopKey: string;
   readonly redirectUri: string;
   readonly signinRegion: string;
   readonly runtimeRegion: string;
 }
 
+interface AwsSigninVerificationCode {
+  readonly code: string;
+  readonly state: string;
+}
+
 interface AwsSigninErrorDetails {
   readonly message: string;
   readonly oauthError: string | undefined;
+}
+
+interface AwsDpopPublicJwk {
+  readonly kty: "EC";
+  readonly crv: "P-256";
+  readonly x: string;
+  readonly y: string;
+}
+
+interface AwsDpopJwtHeader {
+  readonly typ: "dpop+jwt";
+  readonly alg: "ES256";
+  readonly jwk: AwsDpopPublicJwk;
+}
+
+interface AwsDpopJwtPayload {
+  readonly htm: "POST";
+  readonly htu: string;
+  readonly iat: number;
+  readonly jti: string;
 }
 
 export function awsSigninRedirectUri(signinRegion: string): string {
@@ -89,6 +127,7 @@ export function createAwsExternalCodeProviderState(): AwsExternalCodeProviderSta
     version: 1,
     state: randomBase64UrlBytes(32),
     codeVerifier: randomBase64UrlBytes(64),
+    dpopKey: createAwsDpopPrivateKey(),
     redirectUri: awsSigninRedirectUri(signinRegion),
     signinRegion,
     runtimeRegion: AWS_DEFAULT_RUNTIME_REGION,
@@ -118,6 +157,7 @@ export async function exchangeAwsSigninAuthorizationCode(args: {
   readonly signinRegion: string;
   readonly code: string;
   readonly codeVerifier: string;
+  readonly dpopKey: string;
   readonly redirectUri: string;
   readonly signal: AbortSignal;
 }): Promise<AwsSigninTokenResult> {
@@ -125,6 +165,7 @@ export async function exchangeAwsSigninAuthorizationCode(args: {
     signinRegion: args.signinRegion,
     operation: "exchange",
     reconnectOnClientError: true,
+    dpopKey: args.dpopKey,
     signal: args.signal,
     body: {
       clientId: args.clientId,
@@ -140,12 +181,14 @@ export async function refreshAwsSigninToken(args: {
   readonly clientId: string;
   readonly signinRegion: string;
   readonly refreshToken: string;
+  readonly dpopKey: string;
   readonly signal: AbortSignal;
 }): Promise<AwsSigninTokenResult> {
   return await fetchAwsSigninToken({
     signinRegion: args.signinRegion,
     operation: "refresh",
     reconnectOnClientError: true,
+    dpopKey: args.dpopKey,
     signal: args.signal,
     body: {
       clientId: args.clientId,
@@ -159,13 +202,19 @@ async function fetchAwsSigninToken(args: {
   readonly signinRegion: string;
   readonly operation: "exchange" | "refresh";
   readonly reconnectOnClientError: boolean;
+  readonly dpopKey: string;
   readonly body: Readonly<Record<string, string>>;
   readonly signal?: AbortSignal;
 }): Promise<AwsSigninTokenResult> {
-  const response = await fetch(awsSigninTokenUrl(args.signinRegion), {
+  const tokenUrl = awsSigninTokenUrl(args.signinRegion);
+  const response = await fetch(tokenUrl, {
     method: "POST",
     headers: {
       "Content-Type": "application/json",
+      DPoP: buildAwsDpopHeader({
+        privateKeyPem: args.dpopKey,
+        uri: tokenUrl,
+      }),
     },
     body: JSON.stringify(args.body),
     signal: args.signal,
@@ -210,6 +259,108 @@ async function readAwsSigninTokenResponse(
     throw new ProviderResponseError("Invalid AWS Sign-In token response");
   }
   return parsed.data;
+}
+
+export function parseAwsSigninVerificationCode(args: {
+  readonly verificationCode: string;
+  readonly expectedState: string;
+}): AwsSigninVerificationCode {
+  const decoded = decodeAwsSigninVerificationCode(args.verificationCode);
+  const params = new URLSearchParams(decoded);
+  const code = params.get("code");
+  const state = params.get("state");
+  if (!code || !state) {
+    throw invalidAwsSigninVerificationCode(
+      "missing state or authorization code",
+    );
+  }
+  if (state !== args.expectedState) {
+    throw invalidAwsSigninVerificationCode("state mismatch");
+  }
+  return { code, state };
+}
+
+function decodeAwsSigninVerificationCode(verificationCode: string): string {
+  const value = verificationCode.trim();
+  if (!/^[A-Za-z0-9+/]+={0,2}$/.test(value) || value.length % 4 === 1) {
+    throw invalidAwsSigninVerificationCode("invalid base64");
+  }
+  return Buffer.from(value, "base64").toString("utf8");
+}
+
+function invalidAwsSigninVerificationCode(
+  reason: string,
+): OAuthProviderHttpError {
+  return new OAuthProviderHttpError(
+    `Invalid AWS Sign-In authorization code: ${reason}`,
+    400,
+    "invalid_grant",
+  );
+}
+
+function createAwsDpopPrivateKey(): string {
+  const { privateKey } = generateKeyPairSync("ec", {
+    namedCurve: AWS_DPOP_KEY_CURVE,
+  });
+  return privateKey.export({ type: "sec1", format: "pem" }).toString();
+}
+
+function buildAwsDpopHeader(args: {
+  readonly privateKeyPem: string;
+  readonly uri: string;
+}): string {
+  const privateKey = parseAwsDpopPrivateKey(args.privateKeyPem);
+  const header = awsDpopHeader(privateKey);
+  const payload: AwsDpopJwtPayload = {
+    htm: "POST",
+    htu: args.uri,
+    iat: Math.floor(Date.now() / 1000),
+    jti: randomUUID(),
+  };
+  const signingInput = `${base64UrlJson(header)}.${base64UrlJson(payload)}`;
+  const signature = sign("sha256", Buffer.from(signingInput), {
+    key: privateKey,
+    dsaEncoding: "ieee-p1363",
+  });
+  return `${signingInput}.${signature.toString("base64url")}`;
+}
+
+function parseAwsDpopPrivateKey(privateKeyPem: string): KeyObject {
+  try {
+    return createPrivateKey(privateKeyPem);
+  } catch {
+    throw new ProviderResponseError("Invalid AWS DPoP key");
+  }
+}
+
+function awsDpopHeader(privateKey: KeyObject): AwsDpopJwtHeader {
+  return {
+    typ: AWS_DPOP_JWT_TYPE,
+    alg: AWS_DPOP_JWT_ALGORITHM,
+    jwk: awsDpopPublicJwk(privateKey),
+  };
+}
+
+function awsDpopPublicJwk(privateKey: KeyObject): AwsDpopPublicJwk {
+  const jwk = createPublicKey(privateKey).export({ format: "jwk" });
+  if (
+    jwk.kty !== "EC" ||
+    jwk.crv !== AWS_DPOP_KEY_CURVE ||
+    typeof jwk.x !== "string" ||
+    typeof jwk.y !== "string"
+  ) {
+    throw new ProviderResponseError("Invalid AWS DPoP key");
+  }
+  return {
+    kty: "EC",
+    crv: "P-256",
+    x: jwk.x,
+    y: jwk.y,
+  };
+}
+
+function base64UrlJson(value: AwsDpopJwtHeader | AwsDpopJwtPayload): string {
+  return Buffer.from(JSON.stringify(value)).toString("base64url");
 }
 
 async function throwAwsSigninHttpError(args: {

--- a/turbo/packages/connectors/src/auth-providers/connectors/aws/signin.ts
+++ b/turbo/packages/connectors/src/auth-providers/connectors/aws/signin.ts
@@ -1,0 +1,312 @@
+import { createHash, randomBytes } from "node:crypto";
+
+import { z } from "zod";
+
+import { OAuthProviderHttpError } from "../../oauth/error";
+import { ProviderResponseError } from "../../provider-error";
+
+export const AWS_SIGNIN_CROSS_DEVICE_CLIENT_ID =
+  "arn:aws:signin:::devtools/cross-device";
+export const AWS_DEFAULT_SIGNIN_REGION = "us-east-1";
+export const AWS_DEFAULT_RUNTIME_REGION = "us-east-1";
+
+const AWS_SIGNIN_TOKEN_TYPE =
+  "urn:aws:params:oauth:token-type:access_token_sigv4";
+const AWS_CODE_CHALLENGE_METHOD = "SHA-256";
+const AWS_OPENID_SCOPE = "openid";
+const AWS_AUTHORIZATION_RESPONSE_TYPE = "code";
+const AWS_ERROR_BODY_MAX_LENGTH = 500;
+const AWS_REGION_RE = /^[a-z]{2}(?:-gov)?-[a-z]+-\d$/;
+
+const awsSigninTokenResponseSchema = z.object({
+  accessToken: z.object({
+    accessKeyId: z.string().min(1),
+    secretAccessKey: z.string().min(1),
+    sessionToken: z.string().min(1),
+  }),
+  expiresIn: z.number().int().min(1).max(900),
+  refreshToken: z.string().min(1),
+  tokenType: z.literal(AWS_SIGNIN_TOKEN_TYPE),
+  idToken: z.string().optional(),
+});
+
+const awsSigninErrorResponseSchema = z.object({
+  error: z.string().optional(),
+  error_description: z.string().optional(),
+  message: z.string().optional(),
+  Message: z.string().optional(),
+  code: z.string().optional(),
+  Code: z.string().optional(),
+  __type: z.string().optional(),
+});
+
+export interface AwsSigV4Credentials {
+  readonly accessKeyId: string;
+  readonly secretAccessKey: string;
+  readonly sessionToken: string;
+}
+
+export interface AwsSigninTokenResult {
+  readonly credentials: AwsSigV4Credentials;
+  readonly expiresIn: number;
+  readonly refreshToken: string;
+}
+
+export interface AwsExternalCodeProviderState {
+  readonly version: 1;
+  readonly state: string;
+  readonly codeVerifier: string;
+  readonly redirectUri: string;
+  readonly signinRegion: string;
+  readonly runtimeRegion: string;
+}
+
+interface AwsSigninErrorDetails {
+  readonly message: string;
+  readonly oauthError: string | undefined;
+}
+
+export function awsSigninRedirectUri(signinRegion: string): string {
+  return `https://${validatedAwsRegion(signinRegion)}.signin.aws.amazon.com/v1/sessions/confirmation`;
+}
+
+export function awsSigninAuthorizeUrl(signinRegion: string): string {
+  return `https://${validatedAwsRegion(signinRegion)}.signin.aws.amazon.com/v1/authorize`;
+}
+
+export function awsSigninTokenUrl(signinRegion: string): string {
+  return `https://${validatedAwsRegion(signinRegion)}.signin.aws.amazon.com/v1/token`;
+}
+
+export function createAwsExternalCodeProviderState(): AwsExternalCodeProviderState {
+  const signinRegion = AWS_DEFAULT_SIGNIN_REGION;
+  return {
+    version: 1,
+    state: randomBase64UrlBytes(32),
+    codeVerifier: randomBase64UrlBytes(64),
+    redirectUri: awsSigninRedirectUri(signinRegion),
+    signinRegion,
+    runtimeRegion: AWS_DEFAULT_RUNTIME_REGION,
+  };
+}
+
+export function buildAwsSigninAuthorizationUrl(args: {
+  readonly clientId: string;
+  readonly scopes: readonly string[];
+  readonly providerState: AwsExternalCodeProviderState;
+}): string {
+  const params = new URLSearchParams({
+    client_id: args.clientId,
+    response_type: AWS_AUTHORIZATION_RESPONSE_TYPE,
+    scope: awsSigninScope(args.scopes),
+    code_challenge_method: AWS_CODE_CHALLENGE_METHOD,
+    code_challenge: codeChallenge(args.providerState.codeVerifier),
+    redirect_uri: args.providerState.redirectUri,
+    state: args.providerState.state,
+  });
+
+  return `${awsSigninAuthorizeUrl(args.providerState.signinRegion)}?${params.toString()}`;
+}
+
+export async function exchangeAwsSigninAuthorizationCode(args: {
+  readonly clientId: string;
+  readonly signinRegion: string;
+  readonly code: string;
+  readonly codeVerifier: string;
+  readonly redirectUri: string;
+  readonly signal: AbortSignal;
+}): Promise<AwsSigninTokenResult> {
+  return await fetchAwsSigninToken({
+    signinRegion: args.signinRegion,
+    operation: "exchange",
+    reconnectOnClientError: true,
+    signal: args.signal,
+    body: {
+      clientId: args.clientId,
+      grantType: "authorization_code",
+      code: args.code,
+      codeVerifier: args.codeVerifier,
+      redirectUri: args.redirectUri,
+    },
+  });
+}
+
+export async function refreshAwsSigninToken(args: {
+  readonly clientId: string;
+  readonly signinRegion: string;
+  readonly refreshToken: string;
+  readonly signal: AbortSignal;
+}): Promise<AwsSigninTokenResult> {
+  return await fetchAwsSigninToken({
+    signinRegion: args.signinRegion,
+    operation: "refresh",
+    reconnectOnClientError: true,
+    signal: args.signal,
+    body: {
+      clientId: args.clientId,
+      grantType: "refresh_token",
+      refreshToken: args.refreshToken,
+    },
+  });
+}
+
+async function fetchAwsSigninToken(args: {
+  readonly signinRegion: string;
+  readonly operation: "exchange" | "refresh";
+  readonly reconnectOnClientError: boolean;
+  readonly body: Readonly<Record<string, string>>;
+  readonly signal?: AbortSignal;
+}): Promise<AwsSigninTokenResult> {
+  const response = await fetch(awsSigninTokenUrl(args.signinRegion), {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json",
+    },
+    body: JSON.stringify(args.body),
+    signal: args.signal,
+  });
+
+  if (!response.ok) {
+    await throwAwsSigninHttpError({
+      response,
+      operation: args.operation,
+      reconnectOnClientError: args.reconnectOnClientError,
+    });
+  }
+
+  const data = await readAwsSigninTokenResponse(response);
+  return {
+    credentials: {
+      accessKeyId: data.accessToken.accessKeyId,
+      secretAccessKey: data.accessToken.secretAccessKey,
+      sessionToken: data.accessToken.sessionToken,
+    },
+    expiresIn: data.expiresIn,
+    refreshToken: data.refreshToken,
+  };
+}
+
+async function readAwsSigninTokenResponse(
+  response: Response,
+): Promise<z.infer<typeof awsSigninTokenResponseSchema>> {
+  let body: unknown;
+  try {
+    body = await response.json();
+  } catch (error) {
+    if (isAbortError(error)) {
+      throw error;
+    }
+    throw new ProviderResponseError("Invalid AWS Sign-In token response");
+  }
+
+  const parsed = awsSigninTokenResponseSchema.safeParse(body);
+  if (!parsed.success) {
+    throw new ProviderResponseError("Invalid AWS Sign-In token response");
+  }
+  return parsed.data;
+}
+
+async function throwAwsSigninHttpError(args: {
+  readonly response: Response;
+  readonly operation: "exchange" | "refresh";
+  readonly reconnectOnClientError: boolean;
+}): Promise<never> {
+  const details = await readAwsSigninErrorDetails(args.response);
+  const oauthError =
+    args.reconnectOnClientError &&
+    args.response.status >= 400 &&
+    args.response.status < 500 &&
+    args.response.status !== 429
+      ? "invalid_grant"
+      : details.oauthError;
+  const suffix = details.message ? ` ${details.message}` : "";
+  throw new OAuthProviderHttpError(
+    `AWS Sign-In token ${args.operation} failed: ${args.response.status}${suffix}`,
+    args.response.status,
+    oauthError,
+  );
+}
+
+async function readAwsSigninErrorDetails(
+  response: Response,
+): Promise<AwsSigninErrorDetails> {
+  const raw = await response.text();
+  if (!raw) {
+    return { message: "", oauthError: undefined };
+  }
+
+  const truncated =
+    raw.length > AWS_ERROR_BODY_MAX_LENGTH
+      ? `${raw.slice(0, AWS_ERROR_BODY_MAX_LENGTH)}...`
+      : raw;
+
+  try {
+    const parsed = awsSigninErrorResponseSchema.safeParse(JSON.parse(raw));
+    if (!parsed.success) {
+      return {
+        message: redactAwsSigninErrorText(truncated),
+        oauthError: undefined,
+      };
+    }
+    const errorCode =
+      parsed.data.error ??
+      parsed.data.code ??
+      parsed.data.Code ??
+      parsed.data.__type;
+    const description =
+      parsed.data.error_description ??
+      parsed.data.message ??
+      parsed.data.Message;
+    const message = errorCode
+      ? description
+        ? `${errorCode} (${description})`
+        : errorCode
+      : (description ?? redactAwsSigninErrorText(truncated));
+    return {
+      message: redactAwsSigninErrorText(message),
+      oauthError: parsed.data.error,
+    };
+  } catch {
+    return {
+      message: redactAwsSigninErrorText(truncated),
+      oauthError: undefined,
+    };
+  }
+}
+
+function awsSigninScope(scopes: readonly string[]): string {
+  return scopes.length === 0 ? AWS_OPENID_SCOPE : scopes.join(" ");
+}
+
+function codeChallenge(codeVerifier: string): string {
+  return createHash("sha256").update(codeVerifier).digest("base64url");
+}
+
+function randomBase64UrlBytes(byteLength: number): string {
+  return randomBytes(byteLength).toString("base64url");
+}
+
+function isAbortError(error: unknown): boolean {
+  return error instanceof Error && error.name === "AbortError";
+}
+
+function validatedAwsRegion(region: string): string {
+  if (!AWS_REGION_RE.test(region)) {
+    throw new Error(`Invalid AWS Sign-In region ${region}`);
+  }
+  return region;
+}
+
+function redactAwsSigninErrorText(value: string): string {
+  return value
+    .replace(/AKIA[0-9A-Z]{16}/g, "[REDACTED_AWS_ACCESS_KEY_ID]")
+    .replace(/ASIA[0-9A-Z]{16}/g, "[REDACTED_AWS_ACCESS_KEY_ID]")
+    .replace(
+      /("(?:secretAccessKey|sessionToken|refreshToken|code)"\s*:\s*")[^"]+/g,
+      "$1[REDACTED]",
+    )
+    .replace(
+      /((?:secretAccessKey|sessionToken|refreshToken|code)=)[^&\s]+/g,
+      "$1[REDACTED]",
+    );
+}

--- a/turbo/packages/connectors/src/auth-providers/connectors/aws/signin.ts
+++ b/turbo/packages/connectors/src/auth-providers/connectors/aws/signin.ts
@@ -35,7 +35,7 @@ const AWS_SIGNIN_SENSITIVE_REQUEST_KEYS = [
   "refreshToken",
 ] as const;
 
-const awsSigninTokenResponseSchema = z.object({
+const awsSigninTokenResponseBodySchema = z.object({
   accessToken: z.object({
     accessKeyId: z.string().min(1),
     secretAccessKey: z.string().min(1),
@@ -46,6 +46,14 @@ const awsSigninTokenResponseSchema = z.object({
   tokenType: z.literal(AWS_SIGNIN_TOKEN_TYPE),
   idToken: z.string().optional(),
 });
+const awsSigninTokenResponseSchema = z.union([
+  awsSigninTokenResponseBodySchema,
+  z
+    .object({ tokenOutput: awsSigninTokenResponseBodySchema })
+    .transform(({ tokenOutput }) => {
+      return tokenOutput;
+    }),
+]);
 
 const awsSigninErrorResponseSchema = z.object({
   error: z.string().optional(),
@@ -243,7 +251,7 @@ async function fetchAwsSigninToken(args: {
 
 async function readAwsSigninTokenResponse(
   response: Response,
-): Promise<z.infer<typeof awsSigninTokenResponseSchema>> {
+): Promise<z.infer<typeof awsSigninTokenResponseBodySchema>> {
   let body: unknown;
   try {
     body = await response.json();

--- a/turbo/packages/connectors/src/auth-providers/connectors/aws/sts.ts
+++ b/turbo/packages/connectors/src/auth-providers/connectors/aws/sts.ts
@@ -15,6 +15,14 @@ export interface AwsCallerIdentity {
   readonly userId: string;
 }
 
+const AWS_STS_IDENTITY_XML_TAGS = {
+  Account: /<Account>([^<]+)<\/Account>/,
+  Arn: /<Arn>([^<]+)<\/Arn>/,
+  UserId: /<UserId>([^<]+)<\/UserId>/,
+} as const;
+
+type AwsStsIdentityXmlTag = keyof typeof AWS_STS_IDENTITY_XML_TAGS;
+
 export async function getAwsCallerIdentity(args: {
   readonly credentials: AwsSigV4Credentials;
   readonly region: string;
@@ -162,8 +170,8 @@ function parseGetCallerIdentityResponse(xml: string): AwsCallerIdentity {
   return { account, arn, userId };
 }
 
-function xmlElement(xml: string, tagName: string): string | null {
-  const match = new RegExp(`<${tagName}>([^<]+)</${tagName}>`).exec(xml);
+function xmlElement(xml: string, tagName: AwsStsIdentityXmlTag): string | null {
+  const match = AWS_STS_IDENTITY_XML_TAGS[tagName].exec(xml);
   return match?.[1] ? decodeXmlText(match[1]) : null;
 }
 

--- a/turbo/packages/connectors/src/auth-providers/connectors/aws/sts.ts
+++ b/turbo/packages/connectors/src/auth-providers/connectors/aws/sts.ts
@@ -1,0 +1,177 @@
+import { createHash, createHmac } from "node:crypto";
+
+import { ProviderHttpError, ProviderResponseError } from "../../provider-error";
+import type { AwsSigV4Credentials } from "./signin";
+
+const AWS_STS_SERVICE = "sts";
+const AWS_SIGV4_ALGORITHM = "AWS4-HMAC-SHA256";
+const AWS_SIGV4_REQUEST = "aws4_request";
+const AWS_STS_ACTION = "GetCallerIdentity";
+const AWS_STS_VERSION = "2011-06-15";
+
+export interface AwsCallerIdentity {
+  readonly account: string;
+  readonly arn: string;
+  readonly userId: string;
+}
+
+export async function getAwsCallerIdentity(args: {
+  readonly credentials: AwsSigV4Credentials;
+  readonly region: string;
+  readonly signal: AbortSignal;
+}): Promise<AwsCallerIdentity> {
+  const host = `sts.${args.region}.amazonaws.com`;
+  const query = canonicalQuery({
+    Action: AWS_STS_ACTION,
+    Version: AWS_STS_VERSION,
+  });
+  const url = `https://${host}/?${query}`;
+  const headers = signedGetCallerIdentityHeaders({
+    credentials: args.credentials,
+    host,
+    query,
+    region: args.region,
+    now: new Date(),
+  });
+
+  const response = await fetch(url, {
+    method: "GET",
+    headers,
+    signal: args.signal,
+  });
+  if (!response.ok) {
+    throw new ProviderHttpError(
+      `AWS STS GetCallerIdentity failed: ${response.status}`,
+      response.status,
+    );
+  }
+
+  return parseGetCallerIdentityResponse(await response.text());
+}
+
+function signedGetCallerIdentityHeaders(args: {
+  readonly credentials: AwsSigV4Credentials;
+  readonly host: string;
+  readonly query: string;
+  readonly region: string;
+  readonly now: Date;
+}): Headers {
+  const amzDate = amzDateString(args.now);
+  const dateStamp = amzDate.slice(0, 8);
+  const canonicalHeaders =
+    `host:${args.host}\n` +
+    `x-amz-date:${amzDate}\n` +
+    `x-amz-security-token:${canonicalHeaderValue(args.credentials.sessionToken)}\n`;
+  const signedHeaders = "host;x-amz-date;x-amz-security-token";
+  const canonicalRequest = [
+    "GET",
+    "/",
+    args.query,
+    canonicalHeaders,
+    signedHeaders,
+    sha256Hex(""),
+  ].join("\n");
+  const credentialScope = [
+    dateStamp,
+    args.region,
+    AWS_STS_SERVICE,
+    AWS_SIGV4_REQUEST,
+  ].join("/");
+  const stringToSign = [
+    AWS_SIGV4_ALGORITHM,
+    amzDate,
+    credentialScope,
+    sha256Hex(canonicalRequest),
+  ].join("\n");
+  const signingKey = awsSigV4SigningKey({
+    secretAccessKey: args.credentials.secretAccessKey,
+    dateStamp,
+    region: args.region,
+    service: AWS_STS_SERVICE,
+  });
+  const signature = hmacHex(signingKey, stringToSign);
+
+  return new Headers({
+    Authorization:
+      `${AWS_SIGV4_ALGORITHM} ` +
+      `Credential=${args.credentials.accessKeyId}/${credentialScope}, ` +
+      `SignedHeaders=${signedHeaders}, Signature=${signature}`,
+    "x-amz-date": amzDate,
+    "x-amz-security-token": args.credentials.sessionToken,
+  });
+}
+
+function awsSigV4SigningKey(args: {
+  readonly secretAccessKey: string;
+  readonly dateStamp: string;
+  readonly region: string;
+  readonly service: string;
+}): Buffer {
+  const dateKey = hmacBuffer(`AWS4${args.secretAccessKey}`, args.dateStamp);
+  const regionKey = hmacBuffer(dateKey, args.region);
+  const serviceKey = hmacBuffer(regionKey, args.service);
+  return hmacBuffer(serviceKey, AWS_SIGV4_REQUEST);
+}
+
+function canonicalQuery(values: Readonly<Record<string, string>>): string {
+  return Object.entries(values)
+    .sort(([left], [right]) => {
+      return left.localeCompare(right);
+    })
+    .map(([key, value]) => {
+      return `${encodeRfc3986(key)}=${encodeRfc3986(value)}`;
+    })
+    .join("&");
+}
+
+function encodeRfc3986(value: string): string {
+  return encodeURIComponent(value).replace(/[!'()*]/g, (char) => {
+    return `%${char.charCodeAt(0).toString(16).toUpperCase()}`;
+  });
+}
+
+function canonicalHeaderValue(value: string): string {
+  return value.trim().replace(/\s+/g, " ");
+}
+
+function amzDateString(date: Date): string {
+  return date.toISOString().replace(/[:-]|\.\d{3}/g, "");
+}
+
+function sha256Hex(value: string): string {
+  return createHash("sha256").update(value, "utf8").digest("hex");
+}
+
+function hmacBuffer(key: Buffer | string, value: string): Buffer {
+  return createHmac("sha256", key).update(value, "utf8").digest();
+}
+
+function hmacHex(key: Buffer, value: string): string {
+  return createHmac("sha256", key).update(value, "utf8").digest("hex");
+}
+
+function parseGetCallerIdentityResponse(xml: string): AwsCallerIdentity {
+  const account = xmlElement(xml, "Account");
+  const arn = xmlElement(xml, "Arn");
+  const userId = xmlElement(xml, "UserId");
+  if (!account || !arn || !userId) {
+    throw new ProviderResponseError(
+      "Invalid AWS STS GetCallerIdentity response",
+    );
+  }
+  return { account, arn, userId };
+}
+
+function xmlElement(xml: string, tagName: string): string | null {
+  const match = new RegExp(`<${tagName}>([^<]+)</${tagName}>`).exec(xml);
+  return match?.[1] ? decodeXmlText(match[1]) : null;
+}
+
+function decodeXmlText(value: string): string {
+  return value
+    .replace(/&lt;/g, "<")
+    .replace(/&gt;/g, ">")
+    .replace(/&quot;/g, '"')
+    .replace(/&apos;/g, "'")
+    .replace(/&amp;/g, "&");
+}

--- a/turbo/packages/connectors/src/auth-providers/grant-result.ts
+++ b/turbo/packages/connectors/src/auth-providers/grant-result.ts
@@ -4,6 +4,7 @@ import type {
   ConnectorAuthMethodIdsByGrantKind,
   ConnectorGrantOutputValues,
   DeviceAuthGrantConnectorType,
+  ExternalCodeGrantConnectorType,
 } from "../connectors";
 
 export interface ConnectorAuthProviderGrantUserInfo {
@@ -29,11 +30,20 @@ export interface ConnectorAuthProviderGrantResult<
 }
 
 type ConnectorAuthProviderGrantMethodId<
-  T extends AuthCodeGrantConnectorType | DeviceAuthGrantConnectorType,
-> = ConnectorAuthMethodIdsByGrantKind<T, "auth-code" | "device-auth">;
+  T extends
+    | AuthCodeGrantConnectorType
+    | ExternalCodeGrantConnectorType
+    | DeviceAuthGrantConnectorType,
+> = ConnectorAuthMethodIdsByGrantKind<
+  T,
+  "auth-code" | "external-code" | "device-auth"
+>;
 
 export type ConnectorAuthProviderGrantResultForMethod<
-  T extends AuthCodeGrantConnectorType | DeviceAuthGrantConnectorType,
+  T extends
+    | AuthCodeGrantConnectorType
+    | ExternalCodeGrantConnectorType
+    | DeviceAuthGrantConnectorType,
   Method extends ConnectorAuthMethodIds<T>,
 > = [Method] extends [ConnectorAuthProviderGrantMethodId<T>]
   ? ConnectorAuthProviderGrantResult<ConnectorGrantOutputValues<T, Method>>

--- a/turbo/packages/connectors/src/auth-providers/provider-flow-types.ts
+++ b/turbo/packages/connectors/src/auth-providers/provider-flow-types.ts
@@ -4,11 +4,14 @@ import type {
   ConnectorAuthMethodIds,
   ConnectorAuthCodeGrantAuthMethodId,
   ConnectorDeviceAuthGrantAuthMethodId,
+  ConnectorExternalCodeGrantAuthMethodId,
+  ConnectorExternalCodeGrantConfig,
   ConnectorAuthMethodIdsByRevokeKind,
   ConnectorDeviceAuthStartOptions,
   ConnectorRevokeInputValues,
   ConnectorType,
   DeviceAuthGrantConnectorType,
+  ExternalCodeGrantConnectorType,
   TokenRevokeConnectorType,
 } from "@vm0/connectors/connectors";
 import type {
@@ -51,6 +54,18 @@ interface OAuthDeviceAuthStartFlowArgs {
 interface OAuthDeviceAuthPollFlowArgs {
   readonly deviceCode: string;
   readonly pollState?: string;
+}
+
+interface ExternalCodeCompleteFlowArgs {
+  readonly code: string;
+  readonly providerState: string;
+  readonly signal: AbortSignal;
+}
+
+export interface ExternalCodeAuthorizationStartResult {
+  readonly authorizationUrl: string;
+  readonly providerState: string;
+  readonly expiresIn: number;
 }
 
 export interface OAuthDeviceAuthStartResult {
@@ -157,6 +172,23 @@ export type ConnectorAuthCodeExchangeArgs<
 > = OAuthExchangeFlowArgs &
   ConnectorAuthMethodClientArgs<T, Method> & {
     readonly authCodeGrant: ConnectorAuthCodeGrantConfig;
+  };
+
+export type ConnectorExternalCodeAuthorizationStartArgs<
+  T extends ExternalCodeGrantConnectorType,
+  Method extends ConnectorExternalCodeGrantAuthMethodId<T> =
+    ConnectorExternalCodeGrantAuthMethodId<T>,
+> = ConnectorAuthMethodClientIdentityArgs<T, Method> & {
+  readonly externalCodeGrant: ConnectorExternalCodeGrantConfig;
+};
+
+export type ConnectorExternalCodeAuthorizationCompleteArgs<
+  T extends ExternalCodeGrantConnectorType,
+  Method extends ConnectorExternalCodeGrantAuthMethodId<T> =
+    ConnectorExternalCodeGrantAuthMethodId<T>,
+> = ExternalCodeCompleteFlowArgs &
+  ConnectorAuthMethodClientArgs<T, Method> & {
+    readonly externalCodeGrant: ConnectorExternalCodeGrantConfig;
   };
 
 export type ConnectorAuthProviderRevokeArgs<

--- a/turbo/packages/connectors/src/auth-providers/types.ts
+++ b/turbo/packages/connectors/src/auth-providers/types.ts
@@ -6,11 +6,13 @@ import type {
   ConnectorAuthMethodIdsByAccessKind,
   ConnectorAuthMethodIdsByRevokeKind,
   ConnectorDeviceAuthGrantAuthMethodId,
+  ConnectorExternalCodeGrantAuthMethodId,
   AuthGrantConnectorType,
   ConnectorRefreshInputValues,
   ConnectorRefreshOutputValues,
   ConnectorType,
   DeviceAuthGrantConnectorType,
+  ExternalCodeGrantConnectorType,
   RefreshTokenAccessConnectorType,
   TokenRevokeConnectorType,
 } from "../connectors";
@@ -23,8 +25,11 @@ import type {
   ConnectorAuthCodeAuthorizeArgs,
   ConnectorDeviceAuthorizationPollArgs,
   ConnectorDeviceAuthorizationStartArgs,
+  ConnectorExternalCodeAuthorizationCompleteArgs,
+  ConnectorExternalCodeAuthorizationStartArgs,
   ConnectorAuthCodeExchangeArgs,
   ConnectorAuthProviderRevokeArgs,
+  ExternalCodeAuthorizationStartResult,
   OAuthDeviceAuthPollResult,
   OAuthDeviceAuthStartResult,
 } from "./provider-flow-types";
@@ -61,6 +66,20 @@ export interface DeviceAuthGrantProvider<
   pollDeviceAuth(
     args: ConnectorDeviceAuthorizationPollArgs<T, Method>,
   ): Promise<OAuthDeviceAuthPollResult<T, Method>>;
+}
+
+export interface ExternalCodeGrantProvider<
+  T extends ExternalCodeGrantConnectorType,
+  Method extends ConnectorExternalCodeGrantAuthMethodId<T> =
+    ConnectorExternalCodeGrantAuthMethodId<T>,
+> {
+  readonly kind: "external-code";
+  startExternalCodeAuthorization(
+    args: ConnectorExternalCodeAuthorizationStartArgs<T, Method>,
+  ): Promise<ExternalCodeAuthorizationStartResult>;
+  completeExternalCodeAuthorization(
+    args: ConnectorExternalCodeAuthorizationCompleteArgs<T, Method>,
+  ): Promise<ConnectorAuthProviderGrantResultForMethod<T, Method>>;
 }
 
 export interface NoneAccessProvider {
@@ -183,6 +202,16 @@ export type DeviceAuthConnectorAuthProvider<
     ConnectorDeviceAuthGrantAuthMethodId<T>,
 > = AuthProvider<
   DeviceAuthGrantProvider<T, Method>,
+  ConnectorAuthProviderAccess<T, Method>,
+  ConnectorAuthProviderRevoke<T, Method>
+>;
+
+export type ExternalCodeConnectorAuthProvider<
+  T extends ExternalCodeGrantConnectorType,
+  Method extends ConnectorExternalCodeGrantAuthMethodId<T> =
+    ConnectorExternalCodeGrantAuthMethodId<T>,
+> = AuthProvider<
+  ExternalCodeGrantProvider<T, Method>,
   ConnectorAuthProviderAccess<T, Method>,
   ConnectorAuthProviderRevoke<T, Method>
 >;

--- a/turbo/packages/connectors/src/connector-utils.ts
+++ b/turbo/packages/connectors/src/connector-utils.ts
@@ -6,6 +6,7 @@ import {
   type ConnectorAuthMethodId,
   type ConnectorAuthCodeGrantAuthMethodId,
   type ConnectorDeviceAuthGrantAuthMethodId,
+  type ConnectorExternalCodeGrantAuthMethodId,
   type ConnectorAuthMethodIds,
   type ConnectorAuthMethodIdsByAccessKind,
   type ConnectorAuthMethodIdsByGrantKind,
@@ -21,6 +22,7 @@ import {
   type ConnectorAuthCodeGrantConfig,
   type ConnectorAuthClientConfig,
   type ConnectorDeviceAuthGrantConfig,
+  type ConnectorExternalCodeGrantConfig,
   type ConnectorDeviceAuthStartOptionConfig,
   type ConnectorDeviceAuthStartOptions,
   type ConnectorDeviceAuthStartOptionsConfig,
@@ -42,6 +44,7 @@ import {
   type ConnectorType,
   type AuthCodeGrantConnectorType,
   type DeviceAuthGrantConnectorType,
+  type ExternalCodeGrantConnectorType,
   type DynamicPublicConnectorAuthClientConfig,
   type StaticConfidentialConnectorAuthClientConfig,
   type StaticPublicConnectorAuthClientConfig,
@@ -336,7 +339,7 @@ export interface ConnectorGrantOutputMetadata {
 
 export type ConnectorAuthMethodGrantMetadata =
   | {
-      readonly kind: "auth-code" | "device-auth";
+      readonly kind: "auth-code" | "external-code" | "device-auth";
       readonly outputs: Readonly<Record<string, ConnectorGrantOutputMetadata>>;
     }
   | {
@@ -526,6 +529,7 @@ export function getConnectorAuthMethodGrantMetadata(
 
   switch (method.grant.kind) {
     case "auth-code":
+    case "external-code":
     case "device-auth":
       return {
         kind: method.grant.kind,
@@ -807,6 +811,24 @@ export function getConnectorAuthMethodAuthCodeGrantConfig(
   return grant?.kind === "auth-code" ? grant : undefined;
 }
 
+export function getConnectorAuthMethodExternalCodeGrantConfig<
+  Type extends ExternalCodeGrantConnectorType,
+>(
+  type: Type,
+  authMethod: ConnectorExternalCodeGrantAuthMethodId<Type>,
+): ConnectorExternalCodeGrantConfig;
+export function getConnectorAuthMethodExternalCodeGrantConfig(
+  type: ConnectorType,
+  authMethod: string,
+): ConnectorExternalCodeGrantConfig | undefined;
+export function getConnectorAuthMethodExternalCodeGrantConfig(
+  type: ConnectorType,
+  authMethod: string,
+): ConnectorExternalCodeGrantConfig | undefined {
+  const grant = getConnectorAuthMethod(type, authMethod)?.grant;
+  return grant?.kind === "external-code" ? grant : undefined;
+}
+
 export function getConnectorAuthMethodDeviceAuthGrantConfig<
   Type extends DeviceAuthGrantConnectorType,
 >(
@@ -962,6 +984,7 @@ function connectorGrantScopes(
 ): readonly string[] {
   switch (grant?.kind) {
     case "auth-code":
+    case "external-code":
     case "device-auth":
       return grant.scopes;
     case "manual":
@@ -1056,6 +1079,7 @@ export function getAvailableConnectorAuthMethodIds(
         break;
       }
       case "auth-code":
+      case "external-code":
       case "device-auth":
       case "manual": {
         break;
@@ -1154,7 +1178,10 @@ export type ConnectorResolvedAuthMethodClient<
   readonly authClient: ConnectorAuthClientForMethod<Type, Method>;
 };
 
-export type ConnectorGrantKindWithAuthClient = "auth-code" | "device-auth";
+export type ConnectorGrantKindWithAuthClient =
+  | "auth-code"
+  | "external-code"
+  | "device-auth";
 
 export type ConnectorResolvedAuthMethodClientByGrantKind<
   Kind extends ConnectorGrantKindWithAuthClient,
@@ -1356,6 +1383,10 @@ export function resolveConnectorResolvedAuthMethodClientByGrantKind(
   readEnv: ConnectorEnvReader,
 ): ConnectorResolvedAuthMethodClientByGrantKind<"auth-code"> | undefined;
 export function resolveConnectorResolvedAuthMethodClientByGrantKind(
+  authMethodRef: ConnectorAuthMethodRefByGrantKind<"external-code">,
+  readEnv: ConnectorEnvReader,
+): ConnectorResolvedAuthMethodClientByGrantKind<"external-code"> | undefined;
+export function resolveConnectorResolvedAuthMethodClientByGrantKind(
   authMethodRef: ConnectorAuthMethodRefByGrantKind<"device-auth">,
   readEnv: ConnectorEnvReader,
 ): ConnectorResolvedAuthMethodClientByGrantKind<"device-auth"> | undefined;
@@ -1385,6 +1416,7 @@ function hasRuntimeAvailableAuthMethod(
     const method = getConnectorAuthMethod(type, authMethod);
     switch (method?.grant.kind) {
       case "auth-code":
+      case "external-code":
       case "device-auth": {
         if (resolveConnectorAuthClientForMethod(type, authMethod, readEnv)) {
           return true;
@@ -1568,6 +1600,14 @@ export function hasConnectorAuthCodeGrant(
   type: ConnectorType,
 ): type is AuthCodeGrantConnectorType {
   return getConnectorAuthMethodIdsForGrantKind(type, "auth-code").length > 0;
+}
+
+export function hasConnectorExternalCodeGrant(
+  type: ConnectorType,
+): type is ExternalCodeGrantConnectorType {
+  return (
+    getConnectorAuthMethodIdsForGrantKind(type, "external-code").length > 0
+  );
 }
 
 export function hasConnectorDeviceAuthGrant(

--- a/turbo/packages/connectors/src/connectors.ts
+++ b/turbo/packages/connectors/src/connectors.ts
@@ -42,6 +42,7 @@ import { atlassian } from "./connectors/atlassian";
 import { attio } from "./connectors/attio";
 import { atlascloud } from "./connectors/atlascloud";
 import { aviationstack } from "./connectors/aviationstack";
+import { aws } from "./connectors/aws";
 import { axiom } from "./connectors/axiom";
 import { base44 } from "./connectors/base44";
 import { bentoml } from "./connectors/bentoml";
@@ -325,6 +326,7 @@ export type PublicConnectorAuthClientConfig =
 export type ConnectorGrantKind =
   | "manual"
   | "auth-code"
+  | "external-code"
   | "device-auth"
   | "managed";
 
@@ -335,6 +337,12 @@ export interface ConnectorManualGrantConfig {
 
 export interface ConnectorAuthCodeGrantConfig {
   readonly kind: "auth-code";
+  readonly scopes: string[];
+  readonly outputs: ConnectorGrantOutputBindings;
+}
+
+export interface ConnectorExternalCodeGrantConfig {
+  readonly kind: "external-code";
   readonly scopes: string[];
   readonly outputs: ConnectorGrantOutputBindings;
 }
@@ -380,6 +388,7 @@ export interface ConnectorManagedGrantConfig {
 export type ConnectorGrantConfig =
   | ConnectorManualGrantConfig
   | ConnectorAuthCodeGrantConfig
+  | ConnectorExternalCodeGrantConfig
   | ConnectorDeviceAuthGrantConfig
   | ConnectorManagedGrantConfig;
 
@@ -490,6 +499,12 @@ export type ConnectorAuthMethodConfig =
   | (ConnectorAuthMethodConfigBase & {
       readonly client: ConnectorAuthClientConfig;
       readonly grant: ConnectorAuthCodeGrantConfig;
+      readonly access: ConnectorAccessConfig;
+      readonly revoke: ConnectorRevokeConfig;
+    })
+  | (ConnectorAuthMethodConfigBase & {
+      readonly client: ConnectorAuthClientConfig;
+      readonly grant: ConnectorExternalCodeGrantConfig;
       readonly access: ConnectorAccessConfig;
       readonly revoke: ConnectorRevokeConfig;
     })
@@ -856,7 +871,7 @@ type ValidatedConnectorGrantConfig<Grant, Storage> = Grant extends {
       };
     }
   : Grant extends {
-        readonly kind: "auth-code" | "device-auth";
+        readonly kind: "auth-code" | "external-code" | "device-auth";
         readonly outputs: infer Outputs;
       }
     ? Grant & {
@@ -992,6 +1007,7 @@ const CONNECTOR_TYPES_DEF = defineConnectors({
   ...attio,
   ...atlascloud,
   ...aviationstack,
+  ...aws,
   ...axiom,
   ...base44,
   ...bentoml,
@@ -1242,7 +1258,7 @@ type ConnectorGrantOutputsFor<
   Method extends ConnectorAuthMethodIds<Type>,
 > = ConnectorAuthMethodsOf<Type>[Method] extends {
   readonly grant: {
-    readonly kind: "auth-code" | "device-auth";
+    readonly kind: "auth-code" | "external-code" | "device-auth";
     readonly outputs: infer Outputs;
   };
 }
@@ -1399,14 +1415,19 @@ export type ConnectorTypesByRevokeKind<Kind extends ConnectorRevokeKind> = {
 }[ConnectorType];
 
 export type AuthGrantConnectorType = ConnectorTypesByGrantKind<
-  "auth-code" | "device-auth"
+  "auth-code" | "external-code" | "device-auth"
 >;
 export type AuthCodeGrantConnectorType = ConnectorTypesByGrantKind<"auth-code">;
+export type ExternalCodeGrantConnectorType =
+  ConnectorTypesByGrantKind<"external-code">;
 export type DeviceAuthGrantConnectorType =
   ConnectorTypesByGrantKind<"device-auth">;
 export type ConnectorAuthCodeGrantAuthMethodId<
   Type extends AuthCodeGrantConnectorType = AuthCodeGrantConnectorType,
 > = ConnectorAuthMethodIdsByGrantKind<Type, "auth-code">;
+export type ConnectorExternalCodeGrantAuthMethodId<
+  Type extends ExternalCodeGrantConnectorType = ExternalCodeGrantConnectorType,
+> = ConnectorAuthMethodIdsByGrantKind<Type, "external-code">;
 export type ConnectorDeviceAuthGrantAuthMethodId<
   Type extends DeviceAuthGrantConnectorType = DeviceAuthGrantConnectorType,
 > = ConnectorAuthMethodIdsByGrantKind<Type, "device-auth">;

--- a/turbo/packages/connectors/src/connectors.ts
+++ b/turbo/packages/connectors/src/connectors.ts
@@ -347,11 +347,6 @@ export interface ConnectorExternalCodeGrantConfig {
   readonly outputs: ConnectorGrantOutputBindings;
 }
 
-export interface ConnectorAuthMethodConnectNoticeConfig {
-  readonly variant: "warning";
-  readonly text: string;
-}
-
 export interface ConnectorDeviceAuthStartSelectOptionChoiceConfig {
   readonly value: string;
   readonly label: string;
@@ -484,7 +479,6 @@ export type ConnectorRevokeConfig =
 interface ConnectorAuthMethodConfigBase {
   label: string;
   helpText?: string;
-  connectNotice?: ConnectorAuthMethodConnectNoticeConfig;
   /** When set, this auth method is only available while the feature is enabled. */
   featureFlag?: FeatureSwitchKey;
   /** When false, feature-gated UI surfaces should not add an experimental label. */

--- a/turbo/packages/connectors/src/connectors.ts
+++ b/turbo/packages/connectors/src/connectors.ts
@@ -345,7 +345,6 @@ export interface ConnectorExternalCodeGrantConfig {
   readonly kind: "external-code";
   readonly scopes: string[];
   readonly outputs: ConnectorGrantOutputBindings;
-  readonly connectNotice?: ConnectorAuthMethodConnectNoticeConfig;
 }
 
 export interface ConnectorAuthMethodConnectNoticeConfig {
@@ -485,6 +484,7 @@ export type ConnectorRevokeConfig =
 interface ConnectorAuthMethodConfigBase {
   label: string;
   helpText?: string;
+  connectNotice?: ConnectorAuthMethodConnectNoticeConfig;
   /** When set, this auth method is only available while the feature is enabled. */
   featureFlag?: FeatureSwitchKey;
   /** When false, feature-gated UI surfaces should not add an experimental label. */

--- a/turbo/packages/connectors/src/connectors.ts
+++ b/turbo/packages/connectors/src/connectors.ts
@@ -345,6 +345,12 @@ export interface ConnectorExternalCodeGrantConfig {
   readonly kind: "external-code";
   readonly scopes: string[];
   readonly outputs: ConnectorGrantOutputBindings;
+  readonly connectNotice?: ConnectorAuthMethodConnectNoticeConfig;
+}
+
+export interface ConnectorAuthMethodConnectNoticeConfig {
+  readonly variant: "warning";
+  readonly text: string;
 }
 
 export interface ConnectorDeviceAuthStartSelectOptionChoiceConfig {

--- a/turbo/packages/connectors/src/connectors/aws.ts
+++ b/turbo/packages/connectors/src/connectors/aws.ts
@@ -23,6 +23,7 @@ export const aws = {
         storage: {
           secrets: [
             "AWS_LOGIN_REFRESH_TOKEN",
+            "AWS_LOGIN_DPOP_KEY",
             "AWS_ACCESS_KEY_ID",
             "AWS_SECRET_ACCESS_KEY",
             "AWS_SESSION_TOKEN",
@@ -36,6 +37,7 @@ export const aws = {
           scopes: ["openid"],
           outputs: {
             refreshToken: "$secrets.AWS_LOGIN_REFRESH_TOKEN",
+            dpopKey: "$secrets.AWS_LOGIN_DPOP_KEY",
             accessKeyId: "$secrets.AWS_ACCESS_KEY_ID",
             secretAccessKey: "$secrets.AWS_SECRET_ACCESS_KEY",
             sessionToken: "$secrets.AWS_SESSION_TOKEN",
@@ -47,6 +49,7 @@ export const aws = {
           kind: "refresh-token",
           inputs: {
             refreshToken: "$secrets.AWS_LOGIN_REFRESH_TOKEN",
+            dpopKey: "$secrets.AWS_LOGIN_DPOP_KEY",
             signinRegion: "$secrets.AWS_SIGNIN_REGION",
           },
           outputs: {

--- a/turbo/packages/connectors/src/connectors/aws.ts
+++ b/turbo/packages/connectors/src/connectors/aws.ts
@@ -35,6 +35,10 @@ export const aws = {
         grant: {
           kind: "external-code",
           scopes: ["openid"],
+          connectNotice: {
+            variant: "warning",
+            text: "vm0 can call AWS APIs allowed by the selected AWS identity. This temporary login may require reconnect after the AWS session expires.",
+          },
           outputs: {
             refreshToken: "$secrets.AWS_LOGIN_REFRESH_TOKEN",
             dpopKey: "$secrets.AWS_LOGIN_DPOP_KEY",

--- a/turbo/packages/connectors/src/connectors/aws.ts
+++ b/turbo/packages/connectors/src/connectors/aws.ts
@@ -14,11 +14,7 @@ export const aws = {
         showExperimentalLabel: false,
         label: "Sign in with AWS",
         helpText:
-          "Sign in with AWS and paste the authorization code that AWS displays.",
-        connectNotice: {
-          variant: "warning",
-          text: "This is a temporary AWS connector that expires after up to 12 hours. Reconnect after it expires.",
-        },
+          "Sign in with AWS and paste the authorization code that AWS displays.\n**This temporary AWS connector expires after up to 12 hours.**",
         client: {
           clientRegistration: "static",
           clientType: "public",

--- a/turbo/packages/connectors/src/connectors/aws.ts
+++ b/turbo/packages/connectors/src/connectors/aws.ts
@@ -15,6 +15,10 @@ export const aws = {
         label: "Sign in with AWS",
         helpText:
           "Sign in with AWS and paste the authorization code that AWS displays.",
+        connectNotice: {
+          variant: "warning",
+          text: "This is a temporary AWS connector that expires after up to 12 hours. Reconnect after it expires.",
+        },
         client: {
           clientRegistration: "static",
           clientType: "public",
@@ -35,10 +39,6 @@ export const aws = {
         grant: {
           kind: "external-code",
           scopes: ["openid"],
-          connectNotice: {
-            variant: "warning",
-            text: "vm0 can call AWS APIs allowed by the selected AWS identity. This temporary login may require reconnect after the AWS session expires.",
-          },
           outputs: {
             refreshToken: "$secrets.AWS_LOGIN_REFRESH_TOKEN",
             dpopKey: "$secrets.AWS_LOGIN_DPOP_KEY",

--- a/turbo/packages/connectors/src/connectors/aws.ts
+++ b/turbo/packages/connectors/src/connectors/aws.ts
@@ -1,0 +1,76 @@
+import type { ConnectorConfig } from "../connectors";
+import { FeatureSwitchKey } from "../feature-switch-key";
+
+export const aws = {
+  aws: {
+    label: "AWS",
+    category: "data-automation-infrastructure",
+    tags: ["cloud", "infrastructure", "storage", "compute"],
+    helpText:
+      "Connect a temporary AWS session to call AWS APIs with the selected AWS identity.",
+    authMethods: {
+      cli: {
+        featureFlag: FeatureSwitchKey.AwsConnector,
+        showExperimentalLabel: false,
+        label: "Sign in with AWS",
+        helpText:
+          "Sign in with AWS and paste the authorization code that AWS displays.",
+        client: {
+          clientRegistration: "static",
+          clientType: "public",
+          clientId: "arn:aws:signin:::devtools/cross-device",
+        },
+        storage: {
+          secrets: [
+            "AWS_LOGIN_REFRESH_TOKEN",
+            "AWS_ACCESS_KEY_ID",
+            "AWS_SECRET_ACCESS_KEY",
+            "AWS_SESSION_TOKEN",
+            "AWS_SIGNIN_REGION",
+            "AWS_REGION",
+          ],
+          variables: [],
+        },
+        grant: {
+          kind: "external-code",
+          scopes: ["openid"],
+          outputs: {
+            refreshToken: "$secrets.AWS_LOGIN_REFRESH_TOKEN",
+            accessKeyId: "$secrets.AWS_ACCESS_KEY_ID",
+            secretAccessKey: "$secrets.AWS_SECRET_ACCESS_KEY",
+            sessionToken: "$secrets.AWS_SESSION_TOKEN",
+            signinRegion: "$secrets.AWS_SIGNIN_REGION",
+            runtimeRegion: "$secrets.AWS_REGION",
+          },
+        },
+        access: {
+          kind: "refresh-token",
+          inputs: {
+            refreshToken: "$secrets.AWS_LOGIN_REFRESH_TOKEN",
+            signinRegion: "$secrets.AWS_SIGNIN_REGION",
+          },
+          outputs: {
+            refreshToken: "$secrets.AWS_LOGIN_REFRESH_TOKEN",
+            accessKeyId: "$secrets.AWS_ACCESS_KEY_ID",
+            secretAccessKey: "$secrets.AWS_SECRET_ACCESS_KEY",
+            sessionToken: "$secrets.AWS_SESSION_TOKEN",
+          },
+          refreshableSecrets: [
+            "AWS_ACCESS_KEY_ID",
+            "AWS_SECRET_ACCESS_KEY",
+            "AWS_SESSION_TOKEN",
+          ],
+          envBindings: {
+            AWS_ACCESS_KEY_ID: "$secrets.AWS_ACCESS_KEY_ID",
+            AWS_SECRET_ACCESS_KEY: "$secrets.AWS_SECRET_ACCESS_KEY",
+            AWS_SESSION_TOKEN: "$secrets.AWS_SESSION_TOKEN",
+            AWS_REGION: "$secrets.AWS_REGION",
+            AWS_DEFAULT_REGION: "$secrets.AWS_REGION",
+          },
+        },
+        revoke: { kind: "none" },
+      },
+    },
+    defaultAuthMethod: "cli",
+  },
+} as const satisfies Record<string, ConnectorConfig>;

--- a/turbo/packages/connectors/src/feature-switch-key.ts
+++ b/turbo/packages/connectors/src/feature-switch-key.ts
@@ -23,6 +23,7 @@ export enum FeatureSwitchKey {
   OutlookCalendarConnector = "outlookCalendarConnector",
   MetaAdsConnector = "metaAdsConnector",
   StripeConnector = "stripeConnector",
+  AwsConnector = "awsConnector",
   PosthogConnector = "posthogConnector",
   MailchimpConnector = "mailchimpConnector",
   ResendConnector = "resendConnector",

--- a/turbo/packages/connectors/src/firewalls/index.ts
+++ b/turbo/packages/connectors/src/firewalls/index.ts
@@ -723,6 +723,7 @@ export function groupPermissionsByCategory<T extends { name: string }>(
  */
 export type NonFirewallConnectorType =
   // Signature-based auth — requires computing signatures, not simple header injection
+  | "aws" // AWS Signature V4 + broad service surface
   | "cloudinary" // SHA signature in form body + api_key param
   | "minio" // AWS Signature V4
   // Other

--- a/turbo/packages/connectors/src/firewalls/index.ts
+++ b/turbo/packages/connectors/src/firewalls/index.ts
@@ -723,7 +723,9 @@ export function groupPermissionsByCategory<T extends { name: string }>(
  */
 export type NonFirewallConnectorType =
   // Signature-based auth — requires computing signatures, not simple header injection
-  | "aws" // AWS Signature V4 + broad service surface
+  // AWS is feature-gated while SigV4 firewall auth is pending; do not treat it
+  // as a full firewall connector until request signing is handled by firewall auth.
+  | "aws"
   | "cloudinary" // SHA signature in form body + api_key param
   | "minio" // AWS Signature V4
   // Other

--- a/turbo/packages/core/src/__tests__/feature-switch.test.ts
+++ b/turbo/packages/core/src/__tests__/feature-switch.test.ts
@@ -108,7 +108,6 @@ describe("getAllFeatureStates", () => {
     expect(staffOrgStates[FeatureSwitchKey.SessionWorkspaceImageCache]).toBe(
       true,
     );
-    expect(staffOrgStates[FeatureSwitchKey.AwsConnector]).toBe(true);
 
     const otherOrgStates = getAllFeatureStates({
       orgId: "org_nonexistent",
@@ -121,7 +120,6 @@ describe("getAllFeatureStates", () => {
     expect(otherOrgStates[FeatureSwitchKey.SessionWorkspaceImageCache]).toBe(
       false,
     );
-    expect(otherOrgStates[FeatureSwitchKey.AwsConnector]).toBe(false);
   });
 
   it("should apply overrides to enable disabled features", () => {
@@ -150,15 +148,6 @@ describe("getAllFeatureStates", () => {
     });
 
     expect("removedFeature" in states).toBe(false);
-  });
-
-  it("should allow user overrides for AWS outside the staff org rollout", () => {
-    const states = getAllFeatureStates({
-      orgId: "org_nonexistent",
-      overrides: { [FeatureSwitchKey.AwsConnector]: true },
-    });
-
-    expect(states[FeatureSwitchKey.AwsConnector]).toBe(true);
   });
 });
 
@@ -208,15 +197,6 @@ describe("overrides", () => {
     expect(isFeatureEnabled(FeatureSwitchKey.AhrefsConnector, {})).toBe(false);
     expect(
       isFeatureEnabled(FeatureSwitchKey.Dummy, { userId: "any-user" }),
-    ).toBe(true);
-  });
-
-  it("should allow overrides for AWS outside the staff org rollout", () => {
-    expect(
-      isFeatureEnabled(FeatureSwitchKey.AwsConnector, {
-        orgId: "org_nonexistent",
-        overrides: { [FeatureSwitchKey.AwsConnector]: true },
-      }),
     ).toBe(true);
   });
 });

--- a/turbo/packages/core/src/__tests__/feature-switch.test.ts
+++ b/turbo/packages/core/src/__tests__/feature-switch.test.ts
@@ -108,6 +108,7 @@ describe("getAllFeatureStates", () => {
     expect(staffOrgStates[FeatureSwitchKey.SessionWorkspaceImageCache]).toBe(
       true,
     );
+    expect(staffOrgStates[FeatureSwitchKey.AwsConnector]).toBe(true);
 
     const otherOrgStates = getAllFeatureStates({
       orgId: "org_nonexistent",
@@ -120,6 +121,7 @@ describe("getAllFeatureStates", () => {
     expect(otherOrgStates[FeatureSwitchKey.SessionWorkspaceImageCache]).toBe(
       false,
     );
+    expect(otherOrgStates[FeatureSwitchKey.AwsConnector]).toBe(false);
   });
 
   it("should apply overrides to enable disabled features", () => {
@@ -148,6 +150,15 @@ describe("getAllFeatureStates", () => {
     });
 
     expect("removedFeature" in states).toBe(false);
+  });
+
+  it("should ignore user overrides for non-overridable switches", () => {
+    const states = getAllFeatureStates({
+      orgId: "org_nonexistent",
+      overrides: { [FeatureSwitchKey.AwsConnector]: true },
+    });
+
+    expect(states[FeatureSwitchKey.AwsConnector]).toBe(false);
   });
 });
 
@@ -198,5 +209,14 @@ describe("overrides", () => {
     expect(
       isFeatureEnabled(FeatureSwitchKey.Dummy, { userId: "any-user" }),
     ).toBe(true);
+  });
+
+  it("should ignore overrides for non-overridable switches", () => {
+    expect(
+      isFeatureEnabled(FeatureSwitchKey.AwsConnector, {
+        orgId: "org_nonexistent",
+        overrides: { [FeatureSwitchKey.AwsConnector]: true },
+      }),
+    ).toBe(false);
   });
 });

--- a/turbo/packages/core/src/__tests__/feature-switch.test.ts
+++ b/turbo/packages/core/src/__tests__/feature-switch.test.ts
@@ -152,13 +152,13 @@ describe("getAllFeatureStates", () => {
     expect("removedFeature" in states).toBe(false);
   });
 
-  it("should ignore user overrides for non-overridable switches", () => {
+  it("should allow user overrides for AWS outside the staff org rollout", () => {
     const states = getAllFeatureStates({
       orgId: "org_nonexistent",
       overrides: { [FeatureSwitchKey.AwsConnector]: true },
     });
 
-    expect(states[FeatureSwitchKey.AwsConnector]).toBe(false);
+    expect(states[FeatureSwitchKey.AwsConnector]).toBe(true);
   });
 });
 
@@ -211,12 +211,12 @@ describe("overrides", () => {
     ).toBe(true);
   });
 
-  it("should ignore overrides for non-overridable switches", () => {
+  it("should allow overrides for AWS outside the staff org rollout", () => {
     expect(
       isFeatureEnabled(FeatureSwitchKey.AwsConnector, {
         orgId: "org_nonexistent",
         overrides: { [FeatureSwitchKey.AwsConnector]: true },
       }),
-    ).toBe(false);
+    ).toBe(true);
   });
 });

--- a/turbo/packages/core/src/feature-switch.ts
+++ b/turbo/packages/core/src/feature-switch.ts
@@ -349,6 +349,10 @@ function evaluateSwitch(fs: FeatureSwitch, hashes: ResolvedHashes): boolean {
   return false;
 }
 
+function isKnownFeatureSwitchKey(key: string): key is FeatureSwitchKey {
+  return key in FEATURE_SWITCHES;
+}
+
 /**
  * Evaluate all feature switches at once for the given context.
  *
@@ -387,12 +391,10 @@ export function getAllFeatureStates(
     result[key] = evaluateSwitch(FEATURE_SWITCHES[key], hashes);
   }
 
-  const overrides = ctx?.overrides;
-  if (overrides) {
-    for (const key of Object.values(FeatureSwitchKey)) {
-      const value = overrides[key];
-      if (value !== undefined) {
-        result[key] = value;
+  if (ctx?.overrides) {
+    for (const [key, value] of Object.entries(ctx.overrides)) {
+      if (isKnownFeatureSwitchKey(key) && value !== undefined) {
+        result[key as FeatureSwitchKey] = value;
       }
     }
   }

--- a/turbo/packages/core/src/feature-switch.ts
+++ b/turbo/packages/core/src/feature-switch.ts
@@ -5,10 +5,11 @@
  * User IDs are stored as FNV-1a hashes to avoid exposing plain-text identifiers in source code.
  *
  * NOT AN AUTHORIZATION BOUNDARY. Any authenticated user can self-enable any
- * switch via `POST /api/zero/feature-switches` — overrides are read by
- * `isFeatureEnabled` before the registry. For money-granting, credential,
- * or privilege-escalation endpoints, gate with a hard identity check
- * (e.g. `isStaffOrg()` from `./staff-org`) instead of this system.
+ * switch via `POST /api/zero/feature-switches` unless a switch opts out with
+ * `userOverridable: false`. For money-granting, credential, or
+ * privilege-escalation endpoints, gate with a hard identity check
+ * (e.g. `isStaffOrg()` from `./staff-org`) instead of relying only on this
+ * system.
  */
 
 import { FeatureSwitchKey } from "./feature-switch-key";
@@ -18,6 +19,8 @@ export interface FeatureSwitch {
   readonly maintainer: string;
   readonly description?: string;
   readonly enabled: boolean;
+  /** Defaults to true. Set false when user-level overrides must not enable it. */
+  readonly userOverridable?: boolean;
   readonly enabledUserHashes?: readonly string[];
   readonly enabledEmailHashes?: readonly string[];
   readonly enabledOrgIdHashes?: readonly string[];
@@ -128,6 +131,13 @@ const FEATURE_SWITCHES: Record<FeatureSwitchKey, FeatureSwitch> = {
     maintainer: "ethan@vm0.ai",
     description: "Enable the Stripe payment connector integration",
     enabled: false,
+  },
+  [FeatureSwitchKey.AwsConnector]: {
+    maintainer: "ethan@vm0.ai",
+    description: "Enable the temporary AWS remote login connector",
+    enabled: false,
+    userOverridable: false,
+    enabledOrgIdHashes: STAFF_ORG_ID_HASHES,
   },
   [FeatureSwitchKey.PosthogConnector]: {
     maintainer: "ethan@vm0.ai",
@@ -344,6 +354,24 @@ function evaluateSwitch(fs: FeatureSwitch, hashes: ResolvedHashes): boolean {
   return false;
 }
 
+function isKnownFeatureSwitchKey(key: string): key is FeatureSwitchKey {
+  return key in FEATURE_SWITCHES;
+}
+
+function featureSwitchAllowsUserOverride(key: FeatureSwitchKey): boolean {
+  return FEATURE_SWITCHES[key].userOverridable !== false;
+}
+
+export function isFeatureSwitchUserOverridable(
+  key: string,
+): key is FeatureSwitchKey {
+  return isKnownFeatureSwitchKey(key) && featureSwitchAllowsUserOverride(key);
+}
+
+export function shouldPersistUserFeatureSwitchOverride(key: string): boolean {
+  return !isKnownFeatureSwitchKey(key) || featureSwitchAllowsUserOverride(key);
+}
+
 /**
  * Evaluate all feature switches at once for the given context.
  *
@@ -384,7 +412,7 @@ export function getAllFeatureStates(
 
   if (ctx?.overrides) {
     for (const [key, value] of Object.entries(ctx.overrides)) {
-      if (key in FEATURE_SWITCHES && value !== undefined) {
+      if (isFeatureSwitchUserOverridable(key) && value !== undefined) {
         result[key as FeatureSwitchKey] = value;
       }
     }
@@ -420,7 +448,9 @@ export function isFeatureEnabled(
   key: FeatureSwitchKey,
   ctx: FeatureSwitchContext,
 ): boolean {
-  const override = ctx.overrides?.[key];
+  const override = isFeatureSwitchUserOverridable(key)
+    ? ctx.overrides?.[key]
+    : undefined;
   if (override !== undefined) {
     return override;
   }

--- a/turbo/packages/core/src/feature-switch.ts
+++ b/turbo/packages/core/src/feature-switch.ts
@@ -4,12 +4,10 @@
  * Provides centralized feature flag management with user-identity based overrides.
  * User IDs are stored as FNV-1a hashes to avoid exposing plain-text identifiers in source code.
  *
- * NOT AN AUTHORIZATION BOUNDARY. Any authenticated user can self-enable any
- * switch via `POST /api/zero/feature-switches` unless a switch opts out with
- * `userOverridable: false`. For money-granting, credential, or
- * privilege-escalation endpoints, gate with a hard identity check
- * (e.g. `isStaffOrg()` from `./staff-org`) instead of relying only on this
- * system.
+ * NOT AN AUTHORIZATION BOUNDARY. Any authenticated user can self-enable
+ * switches via `POST /api/zero/feature-switches`. For money-granting,
+ * credential, or privilege-escalation endpoints, gate with a hard identity check
+ * instead of relying only on this system.
  */
 
 import { FeatureSwitchKey } from "./feature-switch-key";
@@ -19,8 +17,6 @@ export interface FeatureSwitch {
   readonly maintainer: string;
   readonly description?: string;
   readonly enabled: boolean;
-  /** Defaults to true. Set false when user-level overrides must not enable it. */
-  readonly userOverridable?: boolean;
   readonly enabledUserHashes?: readonly string[];
   readonly enabledEmailHashes?: readonly string[];
   readonly enabledOrgIdHashes?: readonly string[];
@@ -136,7 +132,6 @@ const FEATURE_SWITCHES: Record<FeatureSwitchKey, FeatureSwitch> = {
     maintainer: "ethan@vm0.ai",
     description: "Enable the temporary AWS remote login connector",
     enabled: false,
-    userOverridable: false,
     enabledOrgIdHashes: STAFF_ORG_ID_HASHES,
   },
   [FeatureSwitchKey.PosthogConnector]: {
@@ -358,20 +353,6 @@ function isKnownFeatureSwitchKey(key: string): key is FeatureSwitchKey {
   return key in FEATURE_SWITCHES;
 }
 
-function featureSwitchAllowsUserOverride(key: FeatureSwitchKey): boolean {
-  return FEATURE_SWITCHES[key].userOverridable !== false;
-}
-
-export function isFeatureSwitchUserOverridable(
-  key: string,
-): key is FeatureSwitchKey {
-  return isKnownFeatureSwitchKey(key) && featureSwitchAllowsUserOverride(key);
-}
-
-export function shouldPersistUserFeatureSwitchOverride(key: string): boolean {
-  return !isKnownFeatureSwitchKey(key) || featureSwitchAllowsUserOverride(key);
-}
-
 /**
  * Evaluate all feature switches at once for the given context.
  *
@@ -412,7 +393,7 @@ export function getAllFeatureStates(
 
   if (ctx?.overrides) {
     for (const [key, value] of Object.entries(ctx.overrides)) {
-      if (isFeatureSwitchUserOverridable(key) && value !== undefined) {
+      if (isKnownFeatureSwitchKey(key) && value !== undefined) {
         result[key as FeatureSwitchKey] = value;
       }
     }
@@ -448,9 +429,7 @@ export function isFeatureEnabled(
   key: FeatureSwitchKey,
   ctx: FeatureSwitchContext,
 ): boolean {
-  const override = isFeatureSwitchUserOverridable(key)
-    ? ctx.overrides?.[key]
-    : undefined;
+  const override = ctx.overrides?.[key];
   if (override !== undefined) {
     return override;
   }

--- a/turbo/packages/core/src/feature-switch.ts
+++ b/turbo/packages/core/src/feature-switch.ts
@@ -349,10 +349,6 @@ function evaluateSwitch(fs: FeatureSwitch, hashes: ResolvedHashes): boolean {
   return false;
 }
 
-function isKnownFeatureSwitchKey(key: string): key is FeatureSwitchKey {
-  return key in FEATURE_SWITCHES;
-}
-
 /**
  * Evaluate all feature switches at once for the given context.
  *
@@ -391,10 +387,12 @@ export function getAllFeatureStates(
     result[key] = evaluateSwitch(FEATURE_SWITCHES[key], hashes);
   }
 
-  if (ctx?.overrides) {
-    for (const [key, value] of Object.entries(ctx.overrides)) {
-      if (isKnownFeatureSwitchKey(key) && value !== undefined) {
-        result[key as FeatureSwitchKey] = value;
+  const overrides = ctx?.overrides;
+  if (overrides) {
+    for (const key of Object.values(FeatureSwitchKey)) {
+      const value = overrides[key];
+      if (value !== undefined) {
+        result[key] = value;
       }
     }
   }

--- a/turbo/packages/core/src/feature-switch.ts
+++ b/turbo/packages/core/src/feature-switch.ts
@@ -4,10 +4,11 @@
  * Provides centralized feature flag management with user-identity based overrides.
  * User IDs are stored as FNV-1a hashes to avoid exposing plain-text identifiers in source code.
  *
- * NOT AN AUTHORIZATION BOUNDARY. Any authenticated user can self-enable
- * switches via `POST /api/zero/feature-switches`. For money-granting,
- * credential, or privilege-escalation endpoints, gate with a hard identity check
- * instead of relying only on this system.
+ * NOT AN AUTHORIZATION BOUNDARY. Any authenticated user can self-enable any
+ * switch via `POST /api/zero/feature-switches` — overrides are read by
+ * `isFeatureEnabled` before the registry. For money-granting, credential,
+ * or privilege-escalation endpoints, gate with a hard identity check
+ * (e.g. `isStaffOrg()` from `./staff-org`) instead of this system.
  */
 
 import { FeatureSwitchKey } from "./feature-switch-key";
@@ -349,10 +350,6 @@ function evaluateSwitch(fs: FeatureSwitch, hashes: ResolvedHashes): boolean {
   return false;
 }
 
-function isKnownFeatureSwitchKey(key: string): key is FeatureSwitchKey {
-  return key in FEATURE_SWITCHES;
-}
-
 /**
  * Evaluate all feature switches at once for the given context.
  *
@@ -393,7 +390,7 @@ export function getAllFeatureStates(
 
   if (ctx?.overrides) {
     for (const [key, value] of Object.entries(ctx.overrides)) {
-      if (isKnownFeatureSwitchKey(key) && value !== undefined) {
+      if (key in FEATURE_SWITCHES && value !== undefined) {
         result[key as FeatureSwitchKey] = value;
       }
     }

--- a/turbo/packages/db/src/index.ts
+++ b/turbo/packages/db/src/index.ts
@@ -23,6 +23,7 @@ import * as modelUsageObservationSchema from "./schema/model-usage-observation";
 import * as variableSchema from "./schema/variable";
 import * as composeJobSchema from "./schema/compose-job";
 import * as connectorSchema from "./schema/connector";
+import * as connectorExternalCodeSessionSchema from "./schema/connector-external-code-session";
 import * as modelProviderAuthSessionSchema from "./schema/model-provider-auth-session";
 import * as connectorOauthDeviceAuthorizationSessionSchema from "./schema/connector-oauth-device-authorization-session";
 import * as connectorOauthStateSchema from "./schema/connector-oauth-state";
@@ -112,6 +113,7 @@ export const schema = {
   ...variableSchema,
   ...composeJobSchema,
   ...connectorSchema,
+  ...connectorExternalCodeSessionSchema,
   ...modelProviderAuthSessionSchema,
   ...connectorOauthDeviceAuthorizationSessionSchema,
   ...connectorOauthStateSchema,

--- a/turbo/packages/db/src/migrations/0439_premium_wendigo.sql
+++ b/turbo/packages/db/src/migrations/0439_premium_wendigo.sql
@@ -1,0 +1,22 @@
+CREATE TYPE "public"."connector_external_code_session_status" AS ENUM('pending', 'completing', 'complete', 'expired', 'error');--> statement-breakpoint
+CREATE TABLE "connector_external_code_sessions" (
+	"id" uuid PRIMARY KEY DEFAULT gen_random_uuid() NOT NULL,
+	"org_id" text NOT NULL,
+	"user_id" text NOT NULL,
+	"connector_type" varchar(50) NOT NULL,
+	"auth_method" varchar(50) NOT NULL,
+	"status" "connector_external_code_session_status" DEFAULT 'pending' NOT NULL,
+	"session_token_hash" varchar(128) NOT NULL,
+	"encrypted_provider_state" text NOT NULL,
+	"authorization_url" text NOT NULL,
+	"error_code" varchar(255),
+	"error_message" text,
+	"created_at" timestamp DEFAULT now() NOT NULL,
+	"updated_at" timestamp DEFAULT now() NOT NULL,
+	"expires_at" timestamp NOT NULL,
+	"completed_at" timestamp
+);
+--> statement-breakpoint
+CREATE UNIQUE INDEX "idx_connector_external_code_sessions_token" ON "connector_external_code_sessions" USING btree ("session_token_hash");--> statement-breakpoint
+CREATE INDEX "idx_connector_external_code_sessions_owner_status" ON "connector_external_code_sessions" USING btree ("org_id","user_id","connector_type","auth_method","status");--> statement-breakpoint
+CREATE INDEX "idx_connector_external_code_sessions_expiration" ON "connector_external_code_sessions" USING btree ("status","expires_at");

--- a/turbo/packages/db/src/migrations/meta/0439_snapshot.json
+++ b/turbo/packages/db/src/migrations/meta/0439_snapshot.json
@@ -1,0 +1,13453 @@
+{
+  "id": "a443da73-0447-43d4-8529-6f8a640a3477",
+  "prevId": "12bb6514-d85e-4049-9ec6-1fad4ec86523",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.agent_compose_versions": {
+      "name": "agent_compose_versions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(64)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "compose_id": {
+          "name": "compose_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "content": {
+          "name": "content",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_agent_compose_versions_compose_id": {
+          "name": "idx_agent_compose_versions_compose_id",
+          "columns": [
+            {
+              "expression": "compose_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "agent_compose_versions_compose_id_agent_composes_id_fk": {
+          "name": "agent_compose_versions_compose_id_agent_composes_id_fk",
+          "tableFrom": "agent_compose_versions",
+          "tableTo": "agent_composes",
+          "columnsFrom": [
+            "compose_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.agent_composes": {
+      "name": "agent_composes",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "head_version_id": {
+          "name": "head_version_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "org_id": {
+          "name": "org_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_agent_composes_org": {
+          "name": "idx_agent_composes_org",
+          "columns": [
+            {
+              "expression": "org_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_agent_composes_org_name": {
+          "name": "idx_agent_composes_org_name",
+          "columns": [
+            {
+              "expression": "org_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.agent_run_callbacks": {
+      "name": "agent_run_callbacks",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "run_id": {
+          "name": "run_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "url": {
+          "name": "url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "encrypted_secret": {
+          "name": "encrypted_secret",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "payload": {
+          "name": "payload",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "attempts": {
+          "name": "attempts",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "last_attempt_at": {
+          "name": "last_attempt_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_error": {
+          "name": "last_error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "delivered_at": {
+          "name": "delivered_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_agent_run_callbacks_run_id": {
+          "name": "idx_agent_run_callbacks_run_id",
+          "columns": [
+            {
+              "expression": "run_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_agent_run_callbacks_pending": {
+          "name": "idx_agent_run_callbacks_pending",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "status = 'pending'",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "agent_run_callbacks_run_id_agent_runs_id_fk": {
+          "name": "agent_run_callbacks_run_id_agent_runs_id_fk",
+          "tableFrom": "agent_run_callbacks",
+          "tableTo": "agent_runs",
+          "columnsFrom": [
+            "run_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.agent_run_queue": {
+      "name": "agent_run_queue",
+      "schema": "",
+      "columns": {
+        "run_id": {
+          "name": "run_id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "org_id": {
+          "name": "org_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "encrypted_params": {
+          "name": "encrypted_params",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "agent_run_queue_user_created_idx": {
+          "name": "agent_run_queue_user_created_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "agent_run_queue_org_created_idx": {
+          "name": "agent_run_queue_org_created_idx",
+          "columns": [
+            {
+              "expression": "org_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "agent_run_queue_expires_at_idx": {
+          "name": "agent_run_queue_expires_at_idx",
+          "columns": [
+            {
+              "expression": "expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "agent_run_queue_run_id_agent_runs_id_fk": {
+          "name": "agent_run_queue_run_id_agent_runs_id_fk",
+          "tableFrom": "agent_run_queue",
+          "tableTo": "agent_runs",
+          "columnsFrom": [
+            "run_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.agent_runs": {
+      "name": "agent_runs",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "agent_compose_version_id": {
+          "name": "agent_compose_version_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "resumed_from_checkpoint_id": {
+          "name": "resumed_from_checkpoint_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "continued_from_session_id": {
+          "name": "continued_from_session_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "session_id": {
+          "name": "session_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "prompt": {
+          "name": "prompt",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "append_system_prompt": {
+          "name": "append_system_prompt",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "vars": {
+          "name": "vars",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "secret_names": {
+          "name": "secret_names",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "additional_volumes": {
+          "name": "additional_volumes",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "sandbox_id": {
+          "name": "sandbox_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "sandbox_reuse_result": {
+          "name": "sandbox_reuse_result",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "result": {
+          "name": "result",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "error": {
+          "name": "error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_event_sequence": {
+          "name": "last_event_sequence",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "org_id": {
+          "name": "org_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "completed_at": {
+          "name": "completed_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_heartbeat_at": {
+          "name": "last_heartbeat_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "runner_group": {
+          "name": "runner_group",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "idx_agent_runs_user_created": {
+          "name": "idx_agent_runs_user_created",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_agent_runs_org": {
+          "name": "idx_agent_runs_org",
+          "columns": [
+            {
+              "expression": "org_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_agent_runs_status_heartbeat": {
+          "name": "idx_agent_runs_status_heartbeat",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "last_heartbeat_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_agent_runs_running_heartbeat": {
+          "name": "idx_agent_runs_running_heartbeat",
+          "columns": [
+            {
+              "expression": "last_heartbeat_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "status = 'running'",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_agent_runs_org_status_created": {
+          "name": "idx_agent_runs_org_status_created",
+          "columns": [
+            {
+              "expression": "org_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_agent_runs_session": {
+          "name": "idx_agent_runs_session",
+          "columns": [
+            {
+              "expression": "session_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_agent_runs_completed_org_user": {
+          "name": "idx_agent_runs_completed_org_user",
+          "columns": [
+            {
+              "expression": "completed_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            },
+            {
+              "expression": "org_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"agent_runs\".\"completed_at\" IS NOT NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "agent_runs_agent_compose_version_id_agent_compose_versions_id_fk": {
+          "name": "agent_runs_agent_compose_version_id_agent_compose_versions_id_fk",
+          "tableFrom": "agent_runs",
+          "tableTo": "agent_compose_versions",
+          "columnsFrom": [
+            "agent_compose_version_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "agent_runs_session_id_agent_sessions_id_fk": {
+          "name": "agent_runs_session_id_agent_sessions_id_fk",
+          "tableFrom": "agent_runs",
+          "tableTo": "agent_sessions",
+          "columnsFrom": [
+            "session_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.agent_sessions": {
+      "name": "agent_sessions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "org_id": {
+          "name": "org_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "agent_compose_id": {
+          "name": "agent_compose_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "conversation_id": {
+          "name": "conversation_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "artifacts": {
+          "name": "artifacts",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_agent_sessions_user_compose": {
+          "name": "idx_agent_sessions_user_compose",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "agent_compose_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_agent_sessions_org": {
+          "name": "idx_agent_sessions_org",
+          "columns": [
+            {
+              "expression": "org_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "agent_sessions_agent_compose_id_agent_composes_id_fk": {
+          "name": "agent_sessions_agent_compose_id_agent_composes_id_fk",
+          "tableFrom": "agent_sessions",
+          "tableTo": "agent_composes",
+          "columnsFrom": [
+            "agent_compose_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "agent_sessions_conversation_id_conversations_id_fk": {
+          "name": "agent_sessions_conversation_id_conversations_id_fk",
+          "tableFrom": "agent_sessions",
+          "tableTo": "conversations",
+          "columnsFrom": [
+            "conversation_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.conversations": {
+      "name": "conversations",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "run_id": {
+          "name": "run_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "cli_agent_type": {
+          "name": "cli_agent_type",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "cli_agent_session_id": {
+          "name": "cli_agent_session_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "cli_agent_session_history": {
+          "name": "cli_agent_session_history",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "cli_agent_session_history_hash": {
+          "name": "cli_agent_session_history_hash",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "conversations_run_id_agent_runs_id_fk": {
+          "name": "conversations_run_id_agent_runs_id_fk",
+          "tableFrom": "conversations",
+          "tableTo": "agent_runs",
+          "columnsFrom": [
+            "run_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "conversations_run_id_unique": {
+          "name": "conversations_run_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "run_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.agentphone_messages": {
+      "name": "agentphone_messages",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "webhook_id": {
+          "name": "webhook_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "agentphone_message_id": {
+          "name": "agentphone_message_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "conversation_id": {
+          "name": "conversation_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "agentphone_agent_id": {
+          "name": "agentphone_agent_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "agentphone_user_link_id": {
+          "name": "agentphone_user_link_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "phone_handle": {
+          "name": "phone_handle",
+          "type": "varchar(254)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "from_number": {
+          "name": "from_number",
+          "type": "varchar(254)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "to_number": {
+          "name": "to_number",
+          "type": "varchar(254)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "direction": {
+          "name": "direction",
+          "type": "varchar(16)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "channel": {
+          "name": "channel",
+          "type": "varchar(16)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "body": {
+          "name": "body",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "media_url": {
+          "name": "media_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_bot": {
+          "name": "is_bot",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "received_at": {
+          "name": "received_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_agentphone_messages_agentphone_message": {
+          "name": "idx_agentphone_messages_agentphone_message",
+          "columns": [
+            {
+              "expression": "agentphone_message_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_agentphone_messages_webhook_id": {
+          "name": "idx_agentphone_messages_webhook_id",
+          "columns": [
+            {
+              "expression": "webhook_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "webhook_id IS NOT NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_agentphone_messages_handle_created": {
+          "name": "idx_agentphone_messages_handle_created",
+          "columns": [
+            {
+              "expression": "phone_handle",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_agentphone_messages_user_link": {
+          "name": "idx_agentphone_messages_user_link",
+          "columns": [
+            {
+              "expression": "agentphone_user_link_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "agentphone_messages_agentphone_user_link_id_agentphone_user_links_id_fk": {
+          "name": "agentphone_messages_agentphone_user_link_id_agentphone_user_links_id_fk",
+          "tableFrom": "agentphone_messages",
+          "tableTo": "agentphone_user_links",
+          "columnsFrom": [
+            "agentphone_user_link_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.agentphone_thread_sessions": {
+      "name": "agentphone_thread_sessions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "agentphone_user_link_id": {
+          "name": "agentphone_user_link_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "conversation_id": {
+          "name": "conversation_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "root_message_id": {
+          "name": "root_message_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "agent_session_id": {
+          "name": "agent_session_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "last_processed_message_id": {
+          "name": "last_processed_message_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_agentphone_thread_sessions_link_root": {
+          "name": "idx_agentphone_thread_sessions_link_root",
+          "columns": [
+            {
+              "expression": "agentphone_user_link_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "root_message_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_agentphone_thread_sessions_user_link": {
+          "name": "idx_agentphone_thread_sessions_user_link",
+          "columns": [
+            {
+              "expression": "agentphone_user_link_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "agentphone_thread_sessions_agentphone_user_link_id_agentphone_user_links_id_fk": {
+          "name": "agentphone_thread_sessions_agentphone_user_link_id_agentphone_user_links_id_fk",
+          "tableFrom": "agentphone_thread_sessions",
+          "tableTo": "agentphone_user_links",
+          "columnsFrom": [
+            "agentphone_user_link_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "agentphone_thread_sessions_agent_session_id_agent_sessions_id_fk": {
+          "name": "agentphone_thread_sessions_agent_session_id_agent_sessions_id_fk",
+          "tableFrom": "agentphone_thread_sessions",
+          "tableTo": "agent_sessions",
+          "columnsFrom": [
+            "agent_session_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.agentphone_user_agent_preferences": {
+      "name": "agentphone_user_agent_preferences",
+      "schema": "",
+      "columns": {
+        "vm0_user_id": {
+          "name": "vm0_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "org_id": {
+          "name": "org_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "selected_compose_id": {
+          "name": "selected_compose_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "agentphone_user_agent_preferences_selected_compose_id_agent_composes_id_fk": {
+          "name": "agentphone_user_agent_preferences_selected_compose_id_agent_composes_id_fk",
+          "tableFrom": "agentphone_user_agent_preferences",
+          "tableTo": "agent_composes",
+          "columnsFrom": [
+            "selected_compose_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "agentphone_user_agent_preferences_pkey": {
+          "name": "agentphone_user_agent_preferences_pkey",
+          "columns": [
+            "vm0_user_id",
+            "org_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.agentphone_user_links": {
+      "name": "agentphone_user_links",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "phone_handle": {
+          "name": "phone_handle",
+          "type": "varchar(254)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "vm0_user_id": {
+          "name": "vm0_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "org_id": {
+          "name": "org_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_agentphone_user_links_phone_handle": {
+          "name": "idx_agentphone_user_links_phone_handle",
+          "columns": [
+            {
+              "expression": "phone_handle",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_agentphone_user_links_vm0_org": {
+          "name": "idx_agentphone_user_links_vm0_org",
+          "columns": [
+            {
+              "expression": "vm0_user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "org_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_agentphone_user_links_org": {
+          "name": "idx_agentphone_user_links_org",
+          "columns": [
+            {
+              "expression": "org_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.agentphone_verification_send_cooldowns": {
+      "name": "agentphone_verification_send_cooldowns",
+      "schema": "",
+      "columns": {
+        "scope": {
+          "name": "scope",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "scope_key": {
+          "name": "scope_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "last_sent_at": {
+          "name": "last_sent_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "agentphone_verification_send_cooldowns_pkey": {
+          "name": "agentphone_verification_send_cooldowns_pkey",
+          "columns": [
+            "scope",
+            "scope_key"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.archived_task_runs": {
+      "name": "archived_task_runs",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "org_id": {
+          "name": "org_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "task_id": {
+          "name": "task_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "task_type": {
+          "name": "task_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "archived_run_id": {
+          "name": "archived_run_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_archived_task_runs_unique": {
+          "name": "idx_archived_task_runs_unique",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "org_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "task_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "task_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.automation_triggers": {
+      "name": "automation_triggers",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "automation_id": {
+          "name": "automation_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "kind": {
+          "name": "kind",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "config": {
+          "name": "config",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "webhook_token": {
+          "name": "webhook_token",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "encrypted_secret": {
+          "name": "encrypted_secret",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_automation_triggers_automation": {
+          "name": "idx_automation_triggers_automation",
+          "columns": [
+            {
+              "expression": "automation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_automation_triggers_webhook_token": {
+          "name": "idx_automation_triggers_webhook_token",
+          "columns": [
+            {
+              "expression": "webhook_token",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "automation_triggers_automation_id_automations_id_fk": {
+          "name": "automation_triggers_automation_id_automations_id_fk",
+          "tableFrom": "automation_triggers",
+          "tableTo": "automations",
+          "columnsFrom": [
+            "automation_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.automations": {
+      "name": "automations",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "org_id": {
+          "name": "org_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "instruction": {
+          "name": "instruction",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "agent_id": {
+          "name": "agent_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "chat_thread_id": {
+          "name": "chat_thread_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "interpreter_kind": {
+          "name": "interpreter_kind",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_automations_agent": {
+          "name": "idx_automations_agent",
+          "columns": [
+            {
+              "expression": "agent_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_automations_org": {
+          "name": "idx_automations_org",
+          "columns": [
+            {
+              "expression": "org_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_automations_user_org": {
+          "name": "idx_automations_user_org",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "org_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_automations_chat_thread": {
+          "name": "idx_automations_chat_thread",
+          "columns": [
+            {
+              "expression": "chat_thread_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_automations_agent_name_org_user": {
+          "name": "idx_automations_agent_name_org_user",
+          "columns": [
+            {
+              "expression": "agent_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "org_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "automations_agent_id_agent_composes_id_fk": {
+          "name": "automations_agent_id_agent_composes_id_fk",
+          "tableFrom": "automations",
+          "tableTo": "agent_composes",
+          "columnsFrom": [
+            "agent_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "automations_chat_thread_id_chat_threads_id_fk": {
+          "name": "automations_chat_thread_id_chat_threads_id_fk",
+          "tableFrom": "automations",
+          "tableTo": "chat_threads",
+          "columnsFrom": [
+            "chat_thread_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.banking_access_audit_events": {
+      "name": "banking_access_audit_events",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "org_id": {
+          "name": "org_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "run_id": {
+          "name": "run_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "agent_id": {
+          "name": "agent_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "connection_id": {
+          "name": "connection_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "provider": {
+          "name": "provider",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'finicity'"
+        },
+        "provider_account_id": {
+          "name": "provider_account_id",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "action": {
+          "name": "action",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "varchar(16)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "failure_code": {
+          "name": "failure_code",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_banking_access_audit_org_user": {
+          "name": "idx_banking_access_audit_org_user",
+          "columns": [
+            {
+              "expression": "org_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_banking_access_audit_run": {
+          "name": "idx_banking_access_audit_run",
+          "columns": [
+            {
+              "expression": "run_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_banking_access_audit_created": {
+          "name": "idx_banking_access_audit_created",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.banking_accounts": {
+      "name": "banking_accounts",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "connection_id": {
+          "name": "connection_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "org_id": {
+          "name": "org_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider_account_id": {
+          "name": "provider_account_id",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "display_name": {
+          "name": "display_name",
+          "type": "varchar(256)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "institution_name": {
+          "name": "institution_name",
+          "type": "varchar(256)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "account_type": {
+          "name": "account_type",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "account_number_last4": {
+          "name": "account_number_last4",
+          "type": "varchar(8)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_banking_accounts_connection_provider_account": {
+          "name": "idx_banking_accounts_connection_provider_account",
+          "columns": [
+            {
+              "expression": "connection_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "provider_account_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_banking_accounts_org_user": {
+          "name": "idx_banking_accounts_org_user",
+          "columns": [
+            {
+              "expression": "org_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "banking_accounts_connection_id_banking_connections_id_fk": {
+          "name": "banking_accounts_connection_id_banking_connections_id_fk",
+          "tableFrom": "banking_accounts",
+          "tableTo": "banking_connections",
+          "columnsFrom": [
+            "connection_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.banking_agent_enablements": {
+      "name": "banking_agent_enablements",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "org_id": {
+          "name": "org_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "agent_id": {
+          "name": "agent_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "connection_id": {
+          "name": "connection_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "account_provider_ids": {
+          "name": "account_provider_ids",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "operation_scopes": {
+          "name": "operation_scopes",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[\"accounts.read\",\"balances.read\",\"transactions.read\"]'::jsonb"
+        },
+        "allow_scheduled_runs": {
+          "name": "allow_scheduled_runs",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "revoked_at": {
+          "name": "revoked_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_banking_agent_enablements_unique": {
+          "name": "idx_banking_agent_enablements_unique",
+          "columns": [
+            {
+              "expression": "org_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "agent_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "connection_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_banking_agent_enablements_agent_user": {
+          "name": "idx_banking_agent_enablements_agent_user",
+          "columns": [
+            {
+              "expression": "agent_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "banking_agent_enablements_agent_id_zero_agents_id_fk": {
+          "name": "banking_agent_enablements_agent_id_zero_agents_id_fk",
+          "tableFrom": "banking_agent_enablements",
+          "tableTo": "zero_agents",
+          "columnsFrom": [
+            "agent_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "banking_agent_enablements_connection_id_banking_connections_id_fk": {
+          "name": "banking_agent_enablements_connection_id_banking_connections_id_fk",
+          "tableFrom": "banking_agent_enablements",
+          "tableTo": "banking_connections",
+          "columnsFrom": [
+            "connection_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.banking_connections": {
+      "name": "banking_connections",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "org_id": {
+          "name": "org_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider": {
+          "name": "provider",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'finicity'"
+        },
+        "provider_customer_id": {
+          "name": "provider_customer_id",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'active'"
+        },
+        "consent_expires_at": {
+          "name": "consent_expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "repair_required_at": {
+          "name": "repair_required_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "revoked_at": {
+          "name": "revoked_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "audit_metadata": {
+          "name": "audit_metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_banking_connections_owner_provider": {
+          "name": "idx_banking_connections_owner_provider",
+          "columns": [
+            {
+              "expression": "org_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "provider",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_banking_connections_org_user": {
+          "name": "idx_banking_connections_org_user",
+          "columns": [
+            {
+              "expression": "org_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.blobs": {
+      "name": "blobs",
+      "schema": "",
+      "columns": {
+        "hash": {
+          "name": "hash",
+          "type": "varchar(64)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "size": {
+          "name": "size",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ref_count": {
+          "name": "ref_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_blobs_ref_count": {
+          "name": "idx_blobs_ref_count",
+          "columns": [
+            {
+              "expression": "ref_count",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.built_in_generation_jobs": {
+      "name": "built_in_generation_jobs",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "type": {
+          "name": "type",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'queued'"
+        },
+        "org_id": {
+          "name": "org_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "run_id": {
+          "name": "run_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "request": {
+          "name": "request",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "result": {
+          "name": "result",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "error": {
+          "name": "error",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "completed_at": {
+          "name": "completed_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "idx_built_in_generation_jobs_user_created": {
+          "name": "idx_built_in_generation_jobs_user_created",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_built_in_generation_jobs_org_status": {
+          "name": "idx_built_in_generation_jobs_org_status",
+          "columns": [
+            {
+              "expression": "org_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_built_in_generation_jobs_run": {
+          "name": "idx_built_in_generation_jobs_run",
+          "columns": [
+            {
+              "expression": "run_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "built_in_generation_jobs_run_id_agent_runs_id_fk": {
+          "name": "built_in_generation_jobs_run_id_agent_runs_id_fk",
+          "tableFrom": "built_in_generation_jobs",
+          "tableTo": "agent_runs",
+          "columnsFrom": [
+            "run_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.chat_messages": {
+      "name": "chat_messages",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "chat_thread_id": {
+          "name": "chat_thread_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "run_id": {
+          "name": "run_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "revokes_message_id": {
+          "name": "revokes_message_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "interrupts_run_id": {
+          "name": "interrupts_run_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "schedule_id": {
+          "name": "schedule_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "schedule_title": {
+          "name": "schedule_title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "schedule_snapshot": {
+          "name": "schedule_snapshot",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "content": {
+          "name": "content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "error": {
+          "name": "error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "run_lifecycle_event": {
+          "name": "run_lifecycle_event",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "sequence_number": {
+          "name": "sequence_number",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "run_event_id": {
+          "name": "run_event_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "attach_files": {
+          "name": "attach_files",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "attach_file_metadata": {
+          "name": "attach_file_metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "generation_template": {
+          "name": "generation_template",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "recommended_followups": {
+          "name": "recommended_followups",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_chat_messages_thread_created": {
+          "name": "idx_chat_messages_thread_created",
+          "columns": [
+            {
+              "expression": "chat_thread_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_chat_messages_run_id": {
+          "name": "idx_chat_messages_run_id",
+          "columns": [
+            {
+              "expression": "run_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "chat_messages_revokes_message_id_unique": {
+          "name": "chat_messages_revokes_message_id_unique",
+          "columns": [
+            {
+              "expression": "revokes_message_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "chat_messages_interrupts_run_id_unique": {
+          "name": "chat_messages_interrupts_run_id_unique",
+          "columns": [
+            {
+              "expression": "interrupts_run_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "chat_messages_run_seq_unique": {
+          "name": "chat_messages_run_seq_unique",
+          "columns": [
+            {
+              "expression": "run_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "sequence_number",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "chat_messages_run_lifecycle_unique": {
+          "name": "chat_messages_run_lifecycle_unique",
+          "columns": [
+            {
+              "expression": "run_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"chat_messages\".\"run_lifecycle_event\" IS NOT NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "chat_messages_chat_thread_id_chat_threads_id_fk": {
+          "name": "chat_messages_chat_thread_id_chat_threads_id_fk",
+          "tableFrom": "chat_messages",
+          "tableTo": "chat_threads",
+          "columnsFrom": [
+            "chat_thread_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "chat_messages_run_id_agent_runs_id_fk": {
+          "name": "chat_messages_run_id_agent_runs_id_fk",
+          "tableFrom": "chat_messages",
+          "tableTo": "agent_runs",
+          "columnsFrom": [
+            "run_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "chat_messages_revokes_message_id_chat_messages_id_fk": {
+          "name": "chat_messages_revokes_message_id_chat_messages_id_fk",
+          "tableFrom": "chat_messages",
+          "tableTo": "chat_messages",
+          "columnsFrom": [
+            "revokes_message_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "chat_messages_interrupts_run_id_agent_runs_id_fk": {
+          "name": "chat_messages_interrupts_run_id_agent_runs_id_fk",
+          "tableFrom": "chat_messages",
+          "tableTo": "agent_runs",
+          "columnsFrom": [
+            "interrupts_run_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "chat_messages_schedule_id_zero_agent_schedules_id_fk": {
+          "name": "chat_messages_schedule_id_zero_agent_schedules_id_fk",
+          "tableFrom": "chat_messages",
+          "tableTo": "zero_agent_schedules",
+          "columnsFrom": [
+            "schedule_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.chat_threads": {
+      "name": "chat_threads",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "agent_compose_id": {
+          "name": "agent_compose_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source_schedule_run_id": {
+          "name": "source_schedule_run_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "draft_content": {
+          "name": "draft_content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "draft_attachments": {
+          "name": "draft_attachments",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_read_at": {
+          "name": "last_read_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_read_message_id": {
+          "name": "last_read_message_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "model_provider_id": {
+          "name": "model_provider_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "model_provider_type": {
+          "name": "model_provider_type",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "model_provider_credential_scope": {
+          "name": "model_provider_credential_scope",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "selected_model": {
+          "name": "selected_model",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "pinned_at": {
+          "name": "pinned_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "renamed_at": {
+          "name": "renamed_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_message_at": {
+          "name": "last_message_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_chat_threads_user_compose_updated": {
+          "name": "idx_chat_threads_user_compose_updated",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "agent_compose_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "updated_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_chat_threads_user_last_read": {
+          "name": "idx_chat_threads_user_last_read",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "last_read_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_chat_threads_user_last_read_message": {
+          "name": "idx_chat_threads_user_last_read_message",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "last_read_message_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_chat_threads_user_compose_pinned": {
+          "name": "idx_chat_threads_user_compose_pinned",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "agent_compose_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"chat_threads\".\"pinned_at\" IS NOT NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_chat_threads_user_compose_last_message": {
+          "name": "idx_chat_threads_user_compose_last_message",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "agent_compose_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "last_message_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "chat_threads_agent_compose_id_agent_composes_id_fk": {
+          "name": "chat_threads_agent_compose_id_agent_composes_id_fk",
+          "tableFrom": "chat_threads",
+          "tableTo": "agent_composes",
+          "columnsFrom": [
+            "agent_compose_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.checkpoints": {
+      "name": "checkpoints",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "run_id": {
+          "name": "run_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "conversation_id": {
+          "name": "conversation_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "agent_compose_snapshot": {
+          "name": "agent_compose_snapshot",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "artifact_snapshots": {
+          "name": "artifact_snapshots",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "volume_versions_snapshot": {
+          "name": "volume_versions_snapshot",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "checkpoints_run_id_agent_runs_id_fk": {
+          "name": "checkpoints_run_id_agent_runs_id_fk",
+          "tableFrom": "checkpoints",
+          "tableTo": "agent_runs",
+          "columnsFrom": [
+            "run_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "checkpoints_conversation_id_conversations_id_fk": {
+          "name": "checkpoints_conversation_id_conversations_id_fk",
+          "tableFrom": "checkpoints",
+          "tableTo": "conversations",
+          "columnsFrom": [
+            "conversation_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "checkpoints_run_id_unique": {
+          "name": "checkpoints_run_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "run_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.cli_tokens": {
+      "name": "cli_tokens",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "token": {
+          "name": "token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "last_used_at": {
+          "name": "last_used_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "cli_tokens_token_unique": {
+          "name": "cli_tokens_token_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "token"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.compose_jobs": {
+      "name": "compose_jobs",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "github_url": {
+          "name": "github_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "overwrite": {
+          "name": "overwrite",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "content": {
+          "name": "content",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "instructions": {
+          "name": "instructions",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source": {
+          "name": "source",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'github'"
+        },
+        "status": {
+          "name": "status",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "sandbox_id": {
+          "name": "sandbox_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "result": {
+          "name": "result",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "error": {
+          "name": "error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "completed_at": {
+          "name": "completed_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "idx_compose_jobs_user_status": {
+          "name": "idx_compose_jobs_user_status",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_compose_jobs_created": {
+          "name": "idx_compose_jobs_created",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_compose_jobs_user_active": {
+          "name": "idx_compose_jobs_user_active",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "status IN ('pending', 'running')",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.computer_use_command_audit_events": {
+      "name": "computer_use_command_audit_events",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "command_id": {
+          "name": "command_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "org_id": {
+          "name": "org_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "run_id": {
+          "name": "run_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "host_id": {
+          "name": "host_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "kind": {
+          "name": "kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "app": {
+          "name": "app",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "event": {
+          "name": "event",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "approval_outcome": {
+          "name": "approval_outcome",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "redacted_result": {
+          "name": "redacted_result",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "error": {
+          "name": "error",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_computer_use_command_audit_command": {
+          "name": "idx_computer_use_command_audit_command",
+          "columns": [
+            {
+              "expression": "command_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_computer_use_command_audit_org_user": {
+          "name": "idx_computer_use_command_audit_org_user",
+          "columns": [
+            {
+              "expression": "org_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_computer_use_command_audit_created": {
+          "name": "idx_computer_use_command_audit_created",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "computer_use_command_audit_events_command_id_computer_use_commands_id_fk": {
+          "name": "computer_use_command_audit_events_command_id_computer_use_commands_id_fk",
+          "tableFrom": "computer_use_command_audit_events",
+          "tableTo": "computer_use_commands",
+          "columnsFrom": [
+            "command_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "computer_use_command_audit_events_host_id_computer_use_hosts_id_fk": {
+          "name": "computer_use_command_audit_events_host_id_computer_use_hosts_id_fk",
+          "tableFrom": "computer_use_command_audit_events",
+          "tableTo": "computer_use_hosts",
+          "columnsFrom": [
+            "host_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.computer_use_commands": {
+      "name": "computer_use_commands",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "org_id": {
+          "name": "org_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "run_id": {
+          "name": "run_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "host_id": {
+          "name": "host_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "kind": {
+          "name": "kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'queued'"
+        },
+        "payload": {
+          "name": "payload",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "result": {
+          "name": "result",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "error": {
+          "name": "error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "timeout_ms": {
+          "name": "timeout_ms",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "claimed_at": {
+          "name": "claimed_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "completed_at": {
+          "name": "completed_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_computer_use_commands_host_status": {
+          "name": "idx_computer_use_commands_host_status",
+          "columns": [
+            {
+              "expression": "host_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_computer_use_commands_org_user": {
+          "name": "idx_computer_use_commands_org_user",
+          "columns": [
+            {
+              "expression": "org_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_computer_use_commands_created": {
+          "name": "idx_computer_use_commands_created",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "computer_use_commands_host_id_computer_use_hosts_id_fk": {
+          "name": "computer_use_commands_host_id_computer_use_hosts_id_fk",
+          "tableFrom": "computer_use_commands",
+          "tableTo": "computer_use_hosts",
+          "columnsFrom": [
+            "host_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.computer_use_hosts": {
+      "name": "computer_use_hosts",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "org_id": {
+          "name": "org_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "display_name": {
+          "name": "display_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token_hash": {
+          "name": "token_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "app_version": {
+          "name": "app_version",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "os_version": {
+          "name": "os_version",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "supported_capabilities": {
+          "name": "supported_capabilities",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "permissions": {
+          "name": "permissions",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{\"accessibility\":false,\"screenRecording\":false}'::jsonb"
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'online'"
+        },
+        "last_seen_at": {
+          "name": "last_seen_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "revoked_at": {
+          "name": "revoked_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_computer_use_hosts_token_hash": {
+          "name": "idx_computer_use_hosts_token_hash",
+          "columns": [
+            {
+              "expression": "token_hash",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_computer_use_hosts_org_user": {
+          "name": "idx_computer_use_hosts_org_user",
+          "columns": [
+            {
+              "expression": "org_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_computer_use_hosts_last_seen": {
+          "name": "idx_computer_use_hosts_last_seen",
+          "columns": [
+            {
+              "expression": "last_seen_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.connector_external_code_sessions": {
+      "name": "connector_external_code_sessions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "org_id": {
+          "name": "org_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "connector_type": {
+          "name": "connector_type",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "auth_method": {
+          "name": "auth_method",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "connector_external_code_session_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "session_token_hash": {
+          "name": "session_token_hash",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "encrypted_provider_state": {
+          "name": "encrypted_provider_state",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "authorization_url": {
+          "name": "authorization_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "error_code": {
+          "name": "error_code",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "error_message": {
+          "name": "error_message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "completed_at": {
+          "name": "completed_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "idx_connector_external_code_sessions_token": {
+          "name": "idx_connector_external_code_sessions_token",
+          "columns": [
+            {
+              "expression": "session_token_hash",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_connector_external_code_sessions_owner_status": {
+          "name": "idx_connector_external_code_sessions_owner_status",
+          "columns": [
+            {
+              "expression": "org_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "connector_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "auth_method",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_connector_external_code_sessions_expiration": {
+          "name": "idx_connector_external_code_sessions_expiration",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.connector_oauth_device_authorization_sessions": {
+      "name": "connector_oauth_device_authorization_sessions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "org_id": {
+          "name": "org_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "connector_type": {
+          "name": "connector_type",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "auth_method": {
+          "name": "auth_method",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "connector_oauth_device_authorization_session_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'awaiting_user_authorization'"
+        },
+        "session_token_hash": {
+          "name": "session_token_hash",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "encrypted_provider_state": {
+          "name": "encrypted_provider_state",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_code": {
+          "name": "user_code",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "verification_uri": {
+          "name": "verification_uri",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "verification_uri_complete": {
+          "name": "verification_uri_complete",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "interval_seconds": {
+          "name": "interval_seconds",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "error_code": {
+          "name": "error_code",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "error_message": {
+          "name": "error_message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "completed_at": {
+          "name": "completed_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "idx_connector_oauth_device_authorization_sessions_token": {
+          "name": "idx_connector_oauth_device_authorization_sessions_token",
+          "columns": [
+            {
+              "expression": "session_token_hash",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_connector_oauth_device_authorization_sessions_owner_status": {
+          "name": "idx_connector_oauth_device_authorization_sessions_owner_status",
+          "columns": [
+            {
+              "expression": "org_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "connector_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "auth_method",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_connector_oauth_device_authorization_sessions_expiration": {
+          "name": "idx_connector_oauth_device_authorization_sessions_expiration",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.connector_oauth_states": {
+      "name": "connector_oauth_states",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "state": {
+          "name": "state",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "auth_method": {
+          "name": "auth_method",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "org_id": {
+          "name": "org_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "redirect_uri": {
+          "name": "redirect_uri",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "code_verifier": {
+          "name": "code_verifier",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "oauth_context": {
+          "name": "oauth_context",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "consumed_at": {
+          "name": "consumed_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "idx_connector_oauth_states_state": {
+          "name": "idx_connector_oauth_states_state",
+          "columns": [
+            {
+              "expression": "state",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_connector_oauth_states_user_org": {
+          "name": "idx_connector_oauth_states_user_org",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "org_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_connector_oauth_states_expires_at": {
+          "name": "idx_connector_oauth_states_expires_at",
+          "columns": [
+            {
+              "expression": "expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.connectors": {
+      "name": "connectors",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "type": {
+          "name": "type",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "auth_method": {
+          "name": "auth_method",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "external_id": {
+          "name": "external_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "external_username": {
+          "name": "external_username",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "external_email": {
+          "name": "external_email",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "oauth_scopes": {
+          "name": "oauth_scopes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "token_expires_at": {
+          "name": "token_expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "org_id": {
+          "name": "org_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "needs_reconnect": {
+          "name": "needs_reconnect",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_connectors_org": {
+          "name": "idx_connectors_org",
+          "columns": [
+            {
+              "expression": "org_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_connectors_org_user_type": {
+          "name": "idx_connectors_org_user_type",
+          "columns": [
+            {
+              "expression": "org_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.credit_expires_record": {
+      "name": "credit_expires_record",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "org_id": {
+          "name": "org_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source": {
+          "name": "source",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "stripe_invoice_id": {
+          "name": "stripe_invoice_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "amount": {
+          "name": "amount",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "remaining": {
+          "name": "remaining",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_credit_expires_org_active": {
+          "name": "idx_credit_expires_org_active",
+          "columns": [
+            {
+              "expression": "org_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "remaining > 0",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "uq_credit_expires_invoice": {
+          "name": "uq_credit_expires_invoice",
+          "columns": [
+            {
+              "expression": "org_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "stripe_invoice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "stripe_invoice_id IS NOT NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "uq_credit_expires_starter_grant": {
+          "name": "uq_credit_expires_starter_grant",
+          "columns": [
+            {
+              "expression": "org_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "source = 'starter_grant'",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.desktop_auth_handoff_codes": {
+      "name": "desktop_auth_handoff_codes",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "code_hash": {
+          "name": "code_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "consumed_at": {
+          "name": "consumed_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "idx_desktop_auth_handoff_codes_expires": {
+          "name": "idx_desktop_auth_handoff_codes_expires",
+          "columns": [
+            {
+              "expression": "expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_desktop_auth_handoff_codes_user_created": {
+          "name": "idx_desktop_auth_handoff_codes_user_created",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "desktop_auth_handoff_codes_code_hash_unique": {
+          "name": "desktop_auth_handoff_codes_code_hash_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "code_hash"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.device_codes": {
+      "name": "device_codes",
+      "schema": "",
+      "columns": {
+        "code": {
+          "name": "code",
+          "type": "varchar(9)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "purpose": {
+          "name": "purpose",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'cli'"
+        },
+        "status": {
+          "name": "status",
+          "type": "device_code_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "org_id": {
+          "name": "org_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ble_session_nonce": {
+          "name": "ble_session_nonce",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "poll_token_hash": {
+          "name": "poll_token_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "poll_interval_seconds": {
+          "name": "poll_interval_seconds",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "cli_token_id": {
+          "name": "cli_token_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "chat_thread_id": {
+          "name": "chat_thread_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "approved_at": {
+          "name": "approved_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "consumed_at": {
+          "name": "consumed_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.e2e_slack_mock_call_log": {
+      "name": "e2e_slack_mock_call_log",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "method": {
+          "name": "method",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "team_id": {
+          "name": "team_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "channel_id": {
+          "name": "channel_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "body": {
+          "name": "body",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "body_json": {
+          "name": "body_json",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_e2e_slack_mock_call_log_created_at": {
+          "name": "idx_e2e_slack_mock_call_log_created_at",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_e2e_slack_mock_call_log_method": {
+          "name": "idx_e2e_slack_mock_call_log_method",
+          "columns": [
+            {
+              "expression": "method",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.e2e_telegram_mock_call_log": {
+      "name": "e2e_telegram_mock_call_log",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "method": {
+          "name": "method",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "bot_token": {
+          "name": "bot_token",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "chat_id": {
+          "name": "chat_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "body": {
+          "name": "body",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "body_json": {
+          "name": "body_json",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_e2e_telegram_mock_call_log_created_at": {
+          "name": "idx_e2e_telegram_mock_call_log_created_at",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_e2e_telegram_mock_call_log_method": {
+          "name": "idx_e2e_telegram_mock_call_log_method",
+          "columns": [
+            {
+              "expression": "method",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_e2e_telegram_mock_call_log_chat_id": {
+          "name": "idx_e2e_telegram_mock_call_log_chat_id",
+          "columns": [
+            {
+              "expression": "chat_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.email_outbox": {
+      "name": "email_outbox",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "from_address": {
+          "name": "from_address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "to_addresses": {
+          "name": "to_addresses",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "cc_addresses": {
+          "name": "cc_addresses",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "subject": {
+          "name": "subject",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "reply_to": {
+          "name": "reply_to",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "headers": {
+          "name": "headers",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "template": {
+          "name": "template",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "post_send_action": {
+          "name": "post_send_action",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "attempts": {
+          "name": "attempts",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "last_error": {
+          "name": "last_error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "next_retry_at": {
+          "name": "next_retry_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "resend_id": {
+          "name": "resend_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "email_outbox_drain_idx": {
+          "name": "email_outbox_drain_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "next_retry_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "email_outbox_created_at_idx": {
+          "name": "email_outbox_created_at_idx",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.email_reply_requests": {
+      "name": "email_reply_requests",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "run_id": {
+          "name": "run_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email_thread_session_id": {
+          "name": "email_thread_session_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "inbound_email_id": {
+          "name": "inbound_email_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "inbound_message_id": {
+          "name": "inbound_message_id",
+          "type": "varchar(512)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_email_reply_requests_run": {
+          "name": "idx_email_reply_requests_run",
+          "columns": [
+            {
+              "expression": "run_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "email_reply_requests_run_id_agent_runs_id_fk": {
+          "name": "email_reply_requests_run_id_agent_runs_id_fk",
+          "tableFrom": "email_reply_requests",
+          "tableTo": "agent_runs",
+          "columnsFrom": [
+            "run_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "email_reply_requests_email_thread_session_id_email_thread_sessions_id_fk": {
+          "name": "email_reply_requests_email_thread_session_id_email_thread_sessions_id_fk",
+          "tableFrom": "email_reply_requests",
+          "tableTo": "email_thread_sessions",
+          "columnsFrom": [
+            "email_thread_session_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.email_suppressions": {
+      "name": "email_suppressions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "email_address": {
+          "name": "email_address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "reason": {
+          "name": "reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "resend_email_id": {
+          "name": "resend_email_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "email_suppressions_email_lower_idx": {
+          "name": "email_suppressions_email_lower_idx",
+          "columns": [
+            {
+              "expression": "lower(\"email_address\")",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.email_thread_sessions": {
+      "name": "email_thread_sessions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "agent_id": {
+          "name": "agent_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "agent_session_id": {
+          "name": "agent_session_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "org_id": {
+          "name": "org_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_email_message_id": {
+          "name": "last_email_message_id",
+          "type": "varchar(512)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reply_to_token": {
+          "name": "reply_to_token",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_email_thread_sessions_reply_token": {
+          "name": "idx_email_thread_sessions_reply_token",
+          "columns": [
+            {
+              "expression": "reply_to_token",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_email_thread_sessions_user": {
+          "name": "idx_email_thread_sessions_user",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "email_thread_sessions_agent_id_agent_composes_id_fk": {
+          "name": "email_thread_sessions_agent_id_agent_composes_id_fk",
+          "tableFrom": "email_thread_sessions",
+          "tableTo": "agent_composes",
+          "columnsFrom": [
+            "agent_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "email_thread_sessions_agent_session_id_agent_sessions_id_fk": {
+          "name": "email_thread_sessions_agent_session_id_agent_sessions_id_fk",
+          "tableFrom": "email_thread_sessions",
+          "tableTo": "agent_sessions",
+          "columnsFrom": [
+            "agent_session_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.export_jobs": {
+      "name": "export_jobs",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "org_id": {
+          "name": "org_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "s3_key": {
+          "name": "s3_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "artifact_urls": {
+          "name": "artifact_urls",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "error": {
+          "name": "error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "completed_at": {
+          "name": "completed_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "idx_export_jobs_user_status": {
+          "name": "idx_export_jobs_user_status",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_export_jobs_created": {
+          "name": "idx_export_jobs_created",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_export_jobs_user_active": {
+          "name": "idx_export_jobs_user_active",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "status IN ('pending', 'running')",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.github_installations": {
+      "name": "github_installations",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "installation_id": {
+          "name": "installation_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "encrypted_access_token": {
+          "name": "encrypted_access_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'active'"
+        },
+        "org_id": {
+          "name": "org_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "target_type": {
+          "name": "target_type",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "target_id": {
+          "name": "target_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "target_name": {
+          "name": "target_name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "admin_github_user_id": {
+          "name": "admin_github_user_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "default_compose_id": {
+          "name": "default_compose_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "repo_configs": {
+          "name": "repo_configs",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "github_installations_installation_id_unique": {
+          "name": "github_installations_installation_id_unique",
+          "columns": [
+            {
+              "expression": "installation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "installation_id IS NOT NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_github_installations_org": {
+          "name": "idx_github_installations_org",
+          "columns": [
+            {
+              "expression": "org_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "github_installations_default_compose_id_agent_composes_id_fk": {
+          "name": "github_installations_default_compose_id_agent_composes_id_fk",
+          "tableFrom": "github_installations",
+          "tableTo": "agent_composes",
+          "columnsFrom": [
+            "default_compose_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.github_issue_sessions": {
+      "name": "github_issue_sessions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "installation_id": {
+          "name": "installation_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "repo": {
+          "name": "repo",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "issue_number": {
+          "name": "issue_number",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "agent_session_id": {
+          "name": "agent_session_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "last_comment_id": {
+          "name": "last_comment_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_github_issue_sessions_installation_repo_issue": {
+          "name": "idx_github_issue_sessions_installation_repo_issue",
+          "columns": [
+            {
+              "expression": "installation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "repo",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "issue_number",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_github_issue_sessions_installation": {
+          "name": "idx_github_issue_sessions_installation",
+          "columns": [
+            {
+              "expression": "installation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "github_issue_sessions_installation_id_github_installations_id_fk": {
+          "name": "github_issue_sessions_installation_id_github_installations_id_fk",
+          "tableFrom": "github_issue_sessions",
+          "tableTo": "github_installations",
+          "columnsFrom": [
+            "installation_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "github_issue_sessions_agent_session_id_agent_sessions_id_fk": {
+          "name": "github_issue_sessions_agent_session_id_agent_sessions_id_fk",
+          "tableFrom": "github_issue_sessions",
+          "tableTo": "agent_sessions",
+          "columnsFrom": [
+            "agent_session_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.github_label_listeners": {
+      "name": "github_label_listeners",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "installation_id": {
+          "name": "installation_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "org_id": {
+          "name": "org_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_by_user_id": {
+          "name": "created_by_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "label_name": {
+          "name": "label_name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "label_name_normalized": {
+          "name": "label_name_normalized",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "trigger_mode": {
+          "name": "trigger_mode",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'created_by_me'"
+        },
+        "prompt": {
+          "name": "prompt",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "compose_id": {
+          "name": "compose_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_github_label_listeners_installation_label": {
+          "name": "idx_github_label_listeners_installation_label",
+          "columns": [
+            {
+              "expression": "installation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "label_name_normalized",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_github_label_listeners_org": {
+          "name": "idx_github_label_listeners_org",
+          "columns": [
+            {
+              "expression": "org_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_github_label_listeners_installation": {
+          "name": "idx_github_label_listeners_installation",
+          "columns": [
+            {
+              "expression": "installation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "github_label_listeners_installation_id_github_installations_id_fk": {
+          "name": "github_label_listeners_installation_id_github_installations_id_fk",
+          "tableFrom": "github_label_listeners",
+          "tableTo": "github_installations",
+          "columnsFrom": [
+            "installation_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "github_label_listeners_compose_id_agent_composes_id_fk": {
+          "name": "github_label_listeners_compose_id_agent_composes_id_fk",
+          "tableFrom": "github_label_listeners",
+          "tableTo": "agent_composes",
+          "columnsFrom": [
+            "compose_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.github_user_links": {
+      "name": "github_user_links",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "github_user_id": {
+          "name": "github_user_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "installation_id": {
+          "name": "installation_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "vm0_user_id": {
+          "name": "vm0_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_github_user_links_user_installation": {
+          "name": "idx_github_user_links_user_installation",
+          "columns": [
+            {
+              "expression": "github_user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "installation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "github_user_links_installation_id_github_installations_id_fk": {
+          "name": "github_user_links_installation_id_github_installations_id_fk",
+          "tableFrom": "github_user_links",
+          "tableTo": "github_installations",
+          "columnsFrom": [
+            "installation_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.hosted_deployments": {
+      "name": "hosted_deployments",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "site_id": {
+          "name": "site_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "org_id": {
+          "name": "org_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "run_id": {
+          "name": "run_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'uploading'"
+        },
+        "r2_prefix": {
+          "name": "r2_prefix",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "manifest": {
+          "name": "manifest",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "manifest_hash": {
+          "name": "manifest_hash",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "content_hash": {
+          "name": "content_hash",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "entrypoint": {
+          "name": "entrypoint",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'/index.html'"
+        },
+        "spa_fallback": {
+          "name": "spa_fallback",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "file_count": {
+          "name": "file_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "size_bytes": {
+          "name": "size_bytes",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "url": {
+          "name": "url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "error": {
+          "name": "error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "ready_at": {
+          "name": "ready_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "idx_hosted_deployments_site": {
+          "name": "idx_hosted_deployments_site",
+          "columns": [
+            {
+              "expression": "site_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_hosted_deployments_org": {
+          "name": "idx_hosted_deployments_org",
+          "columns": [
+            {
+              "expression": "org_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_hosted_deployments_status": {
+          "name": "idx_hosted_deployments_status",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "hosted_deployments_site_id_hosted_sites_id_fk": {
+          "name": "hosted_deployments_site_id_hosted_sites_id_fk",
+          "tableFrom": "hosted_deployments",
+          "tableTo": "hosted_sites",
+          "columnsFrom": [
+            "site_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.hosted_sites": {
+      "name": "hosted_sites",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "org_id": {
+          "name": "org_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "slug": {
+          "name": "slug",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "public_slug": {
+          "name": "public_slug",
+          "type": "varchar(96)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "active_deployment_id": {
+          "name": "active_deployment_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_from_run_id": {
+          "name": "created_from_run_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "idx_hosted_sites_org": {
+          "name": "idx_hosted_sites_org",
+          "columns": [
+            {
+              "expression": "org_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_hosted_sites_org_slug": {
+          "name": "idx_hosted_sites_org_slug",
+          "columns": [
+            {
+              "expression": "org_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "slug",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_hosted_sites_public_slug": {
+          "name": "idx_hosted_sites_public_slug",
+          "columns": [
+            {
+              "expression": "public_slug",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.insights_daily": {
+      "name": "insights_daily",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "org_id": {
+          "name": "org_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "date": {
+          "name": "date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "data": {
+          "name": "data",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "uq_insights_daily_org_user_date": {
+          "name": "uq_insights_daily_org_user_date",
+          "columns": [
+            {
+              "expression": "org_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "date",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_insights_daily_org_user_date_desc": {
+          "name": "idx_insights_daily_org_user_date_desc",
+          "columns": [
+            {
+              "expression": "org_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "date",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.memory_change_items": {
+      "name": "memory_change_items",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "summary_id": {
+          "name": "summary_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "file_path": {
+          "name": "file_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "diff": {
+          "name": "diff",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_memory_change_items_summary": {
+          "name": "idx_memory_change_items_summary",
+          "columns": [
+            {
+              "expression": "summary_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "memory_change_items_summary_id_memory_change_summaries_id_fk": {
+          "name": "memory_change_items_summary_id_memory_change_summaries_id_fk",
+          "tableFrom": "memory_change_items",
+          "tableTo": "memory_change_summaries",
+          "columnsFrom": [
+            "summary_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.memory_change_summaries": {
+      "name": "memory_change_summaries",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "org_id": {
+          "name": "org_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "date": {
+          "name": "date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "from_version_id": {
+          "name": "from_version_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "to_version_id": {
+          "name": "to_version_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "summary": {
+          "name": "summary",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "uq_memory_change_summaries_org_user_date": {
+          "name": "uq_memory_change_summaries_org_user_date",
+          "columns": [
+            {
+              "expression": "org_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "date",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_memory_change_summaries_org_user_date_desc": {
+          "name": "idx_memory_change_summaries_org_user_date_desc",
+          "columns": [
+            {
+              "expression": "org_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "date",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.model_provider_auth_sessions": {
+      "name": "model_provider_auth_sessions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "org_id": {
+          "name": "org_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "connector_type": {
+          "name": "connector_type",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source": {
+          "name": "source",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "model_provider_auth_session_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'initializing'"
+        },
+        "sandbox_id": {
+          "name": "sandbox_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "approval_url": {
+          "name": "approval_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "verification_code": {
+          "name": "verification_code",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "encrypted_provider_state": {
+          "name": "encrypted_provider_state",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "error_message": {
+          "name": "error_message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "completed_at": {
+          "name": "completed_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "cancelled_at": {
+          "name": "cancelled_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "idx_model_provider_auth_sessions_owner_status": {
+          "name": "idx_model_provider_auth_sessions_owner_status",
+          "columns": [
+            {
+              "expression": "org_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "connector_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "source",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_model_provider_auth_sessions_expiration": {
+          "name": "idx_model_provider_auth_sessions_expiration",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_model_provider_auth_sessions_sandbox": {
+          "name": "idx_model_provider_auth_sessions_sandbox",
+          "columns": [
+            {
+              "expression": "sandbox_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"model_provider_auth_sessions\".\"sandbox_id\" IS NOT NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.model_providers": {
+      "name": "model_providers",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "type": {
+          "name": "type",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "secret_id": {
+          "name": "secret_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "auth_method": {
+          "name": "auth_method",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_default": {
+          "name": "is_default",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "selected_model": {
+          "name": "selected_model",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "org_id": {
+          "name": "org_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token_expires_at": {
+          "name": "token_expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "needs_reconnect": {
+          "name": "needs_reconnect",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "last_refresh_error_code": {
+          "name": "last_refresh_error_code",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "workspace_name": {
+          "name": "workspace_name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "plan_type": {
+          "name": "plan_type",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_model_providers_secret": {
+          "name": "idx_model_providers_secret",
+          "columns": [
+            {
+              "expression": "secret_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_model_providers_org": {
+          "name": "idx_model_providers_org",
+          "columns": [
+            {
+              "expression": "org_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_model_providers_org_user_type": {
+          "name": "idx_model_providers_org_user_type",
+          "columns": [
+            {
+              "expression": "org_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_model_providers_one_default_per_user": {
+          "name": "idx_model_providers_one_default_per_user",
+          "columns": [
+            {
+              "expression": "org_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "is_default = true",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "model_providers_secret_id_secrets_id_fk": {
+          "name": "model_providers_secret_id_secrets_id_fk",
+          "tableFrom": "model_providers",
+          "tableTo": "secrets",
+          "columnsFrom": [
+            "secret_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.model_stat": {
+      "name": "model_stat",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "hour_start": {
+          "name": "hour_start",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "model": {
+          "name": "model",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "model_provider": {
+          "name": "model_provider",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "request_count": {
+          "name": "request_count",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "org_count": {
+          "name": "org_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "user_count": {
+          "name": "user_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "input_tokens": {
+          "name": "input_tokens",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "output_tokens": {
+          "name": "output_tokens",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "cache_read_input_tokens": {
+          "name": "cache_read_input_tokens",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "cache_creation_input_tokens": {
+          "name": "cache_creation_input_tokens",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "total_tokens": {
+          "name": "total_tokens",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "credits_charged": {
+          "name": "credits_charged",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "uq_model_stat_hour_model_provider": {
+          "name": "uq_model_stat_hour_model_provider",
+          "columns": [
+            {
+              "expression": "hour_start",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "model",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "model_provider",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_model_stat_hour_start": {
+          "name": "idx_model_stat_hour_start",
+          "columns": [
+            {
+              "expression": "hour_start",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_model_stat_model_hour": {
+          "name": "idx_model_stat_model_hour",
+          "columns": [
+            {
+              "expression": "model",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "hour_start",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.model_usage_observation": {
+      "name": "model_usage_observation",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "run_id": {
+          "name": "run_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "idempotency_key": {
+          "name": "idempotency_key",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "org_id": {
+          "name": "org_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "model": {
+          "name": "model",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "model_provider_type": {
+          "name": "model_provider_type",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "category": {
+          "name": "category",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "quantity": {
+          "name": "quantity",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "observed_at": {
+          "name": "observed_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "uq_model_usage_observation_idempotency_key": {
+          "name": "uq_model_usage_observation_idempotency_key",
+          "columns": [
+            {
+              "expression": "idempotency_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_model_usage_observation_run_id": {
+          "name": "idx_model_usage_observation_run_id",
+          "columns": [
+            {
+              "expression": "run_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_model_usage_observation_observed_at": {
+          "name": "idx_model_usage_observation_observed_at",
+          "columns": [
+            {
+              "expression": "observed_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_model_usage_observation_model_observed_at": {
+          "name": "idx_model_usage_observation_model_observed_at",
+          "columns": [
+            {
+              "expression": "model",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "observed_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_model_usage_observation_org_observed_at": {
+          "name": "idx_model_usage_observation_org_observed_at",
+          "columns": [
+            {
+              "expression": "org_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "observed_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "model_usage_observation_run_id_agent_runs_id_fk": {
+          "name": "model_usage_observation_run_id_agent_runs_id_fk",
+          "tableFrom": "model_usage_observation",
+          "tableTo": "agent_runs",
+          "columnsFrom": [
+            "run_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.org_cache": {
+      "name": "org_cache",
+      "schema": "",
+      "columns": {
+        "org_id": {
+          "name": "org_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "cached_at": {
+          "name": "cached_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_org_cache_slug": {
+          "name": "idx_org_cache_slug",
+          "columns": [
+            {
+              "expression": "slug",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.org_custom_connector_secrets": {
+      "name": "org_custom_connector_secrets",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "connector_id": {
+          "name": "connector_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "org_id": {
+          "name": "org_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "encrypted_value": {
+          "name": "encrypted_value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_org_custom_connector_secrets_connector": {
+          "name": "idx_org_custom_connector_secrets_connector",
+          "columns": [
+            {
+              "expression": "connector_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_org_custom_connector_secrets_user": {
+          "name": "idx_org_custom_connector_secrets_user",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_org_custom_connector_secrets_connector_user": {
+          "name": "idx_org_custom_connector_secrets_connector_user",
+          "columns": [
+            {
+              "expression": "connector_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.org_custom_connectors": {
+      "name": "org_custom_connectors",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "org_id": {
+          "name": "org_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "slug": {
+          "name": "slug",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "display_name": {
+          "name": "display_name",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "prefixes": {
+          "name": "prefixes",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "header_name": {
+          "name": "header_name",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "header_template": {
+          "name": "header_template",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_org_custom_connectors_org": {
+          "name": "idx_org_custom_connectors_org",
+          "columns": [
+            {
+              "expression": "org_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_org_custom_connectors_org_slug": {
+          "name": "idx_org_custom_connectors_org_slug",
+          "columns": [
+            {
+              "expression": "org_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "slug",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.org_members_cache": {
+      "name": "org_members_cache",
+      "schema": "",
+      "columns": {
+        "org_id": {
+          "name": "org_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'member'"
+        },
+        "cached_at": {
+          "name": "cached_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "org_members_cache_org_id_user_id_pk": {
+          "name": "org_members_cache_org_id_user_id_pk",
+          "columns": [
+            "org_id",
+            "user_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.org_members_metadata": {
+      "name": "org_members_metadata",
+      "schema": "",
+      "columns": {
+        "org_id": {
+          "name": "org_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "timezone": {
+          "name": "timezone",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "onboarding_role": {
+          "name": "onboarding_role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "pinned_agent_ids": {
+          "name": "pinned_agent_ids",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'[]'::jsonb"
+        },
+        "send_mode": {
+          "name": "send_mode",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'enter'"
+        },
+        "selected_model": {
+          "name": "selected_model",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "onboarding_done": {
+          "name": "onboarding_done",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "capture_network_bodies_remaining": {
+          "name": "capture_network_bodies_remaining",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "org_members_metadata_org_id_user_id_pk": {
+          "name": "org_members_metadata_org_id_user_id_pk",
+          "columns": [
+            "org_id",
+            "user_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.org_metadata": {
+      "name": "org_metadata",
+      "schema": "",
+      "columns": {
+        "org_id": {
+          "name": "org_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "credits": {
+          "name": "credits",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "tier": {
+          "name": "tier",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pro-suspend'"
+        },
+        "default_agent_id": {
+          "name": "default_agent_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "onboarding_payment_pending": {
+          "name": "onboarding_payment_pending",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "stripe_customer_id": {
+          "name": "stripe_customer_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "stripe_subscription_id": {
+          "name": "stripe_subscription_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "subscription_status": {
+          "name": "subscription_status",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "current_period_end": {
+          "name": "current_period_end",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "cancel_at_period_end": {
+          "name": "cancel_at_period_end",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "pending_subscription_schedule_id": {
+          "name": "pending_subscription_schedule_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "pending_subscription_target_tier": {
+          "name": "pending_subscription_target_tier",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "pending_subscription_change_at": {
+          "name": "pending_subscription_change_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_processed_invoice_id": {
+          "name": "last_processed_invoice_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "auto_recharge_enabled": {
+          "name": "auto_recharge_enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "auto_recharge_threshold": {
+          "name": "auto_recharge_threshold",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "auto_recharge_amount": {
+          "name": "auto_recharge_amount",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "auto_recharge_pending_at": {
+          "name": "auto_recharge_pending_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "uq_org_stripe_customer": {
+          "name": "uq_org_stripe_customer",
+          "columns": [
+            {
+              "expression": "stripe_customer_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "org_metadata_default_agent_id_agent_composes_id_fk": {
+          "name": "org_metadata_default_agent_id_agent_composes_id_fk",
+          "tableFrom": "org_metadata",
+          "tableTo": "agent_composes",
+          "columnsFrom": [
+            "default_agent_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.org_model_policies": {
+      "name": "org_model_policies",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "org_id": {
+          "name": "org_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "model": {
+          "name": "model",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "is_default": {
+          "name": "is_default",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "default_provider_type": {
+          "name": "default_provider_type",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'vm0'"
+        },
+        "credential_scope": {
+          "name": "credential_scope",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'org'"
+        },
+        "model_provider_id": {
+          "name": "model_provider_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_by_user_id": {
+          "name": "created_by_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_by_user_id": {
+          "name": "updated_by_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_org_model_policies_org_model": {
+          "name": "idx_org_model_policies_org_model",
+          "columns": [
+            {
+              "expression": "org_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "model",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_org_model_policies_one_default_per_org": {
+          "name": "idx_org_model_policies_one_default_per_org",
+          "columns": [
+            {
+              "expression": "org_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "is_default = true",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_org_model_policies_provider": {
+          "name": "idx_org_model_policies_provider",
+          "columns": [
+            {
+              "expression": "model_provider_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "model_provider_id IS NOT NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "org_model_policies_model_provider_id_model_providers_id_fk": {
+          "name": "org_model_policies_model_provider_id_model_providers_id_fk",
+          "tableFrom": "org_model_policies",
+          "tableTo": "model_providers",
+          "columnsFrom": [
+            "model_provider_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "chk_org_model_policies_credential_scope": {
+          "name": "chk_org_model_policies_credential_scope",
+          "value": "credential_scope IN ('org', 'member')"
+        },
+        "chk_org_model_policies_member_scope_no_provider_id": {
+          "name": "chk_org_model_policies_member_scope_no_provider_id",
+          "value": "credential_scope <> 'member' OR model_provider_id IS NULL"
+        },
+        "chk_org_model_policies_builtin_route_no_provider_id": {
+          "name": "chk_org_model_policies_builtin_route_no_provider_id",
+          "value": "default_provider_type <> 'vm0' OR model_provider_id IS NULL"
+        },
+        "chk_org_model_policies_member_scope_oauth_provider": {
+          "name": "chk_org_model_policies_member_scope_oauth_provider",
+          "value": "credential_scope <> 'member' OR default_provider_type IN ('claude-code-oauth-token', 'codex-oauth-token')"
+        },
+        "chk_org_model_policies_oauth_provider_member_scope": {
+          "name": "chk_org_model_policies_oauth_provider_member_scope",
+          "value": "default_provider_type NOT IN ('claude-code-oauth-token', 'codex-oauth-token') OR credential_scope = 'member'"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.org_promo_redemption": {
+      "name": "org_promo_redemption",
+      "schema": "",
+      "columns": {
+        "org_id": {
+          "name": "org_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "campaign_key": {
+          "name": "campaign_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "stripe_session_id": {
+          "name": "stripe_session_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "uq_org_promo_redemption": {
+          "name": "uq_org_promo_redemption",
+          "columns": [
+            {
+              "expression": "org_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "campaign_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.push_subscriptions": {
+      "name": "push_subscriptions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "endpoint": {
+          "name": "endpoint",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "p256dh": {
+          "name": "p256dh",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "auth": {
+          "name": "auth",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_push_subscriptions_user_id": {
+          "name": "idx_push_subscriptions_user_id",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_push_subscriptions_endpoint": {
+          "name": "idx_push_subscriptions_endpoint",
+          "columns": [
+            {
+              "expression": "endpoint",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.run_built_in_admissions": {
+      "name": "run_built_in_admissions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "run_id": {
+          "name": "run_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "kind": {
+          "name": "kind",
+          "type": "varchar(30)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'active'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "completed_at": {
+          "name": "completed_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "idx_run_builtin_admissions_run_status": {
+          "name": "idx_run_builtin_admissions_run_status",
+          "columns": [
+            {
+              "expression": "run_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_run_builtin_admissions_run_created": {
+          "name": "idx_run_builtin_admissions_run_created",
+          "columns": [
+            {
+              "expression": "run_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_run_builtin_admissions_expires_at": {
+          "name": "idx_run_builtin_admissions_expires_at",
+          "columns": [
+            {
+              "expression": "expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "run_built_in_admissions_run_id_agent_runs_id_fk": {
+          "name": "run_built_in_admissions_run_id_agent_runs_id_fk",
+          "tableFrom": "run_built_in_admissions",
+          "tableTo": "agent_runs",
+          "columnsFrom": [
+            "run_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.run_uploaded_files": {
+      "name": "run_uploaded_files",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "run_id": {
+          "name": "run_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source": {
+          "name": "source",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "external_id": {
+          "name": "external_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "org_id": {
+          "name": "org_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "filename": {
+          "name": "filename",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "content_type": {
+          "name": "content_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "size_bytes": {
+          "name": "size_bytes",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "url": {
+          "name": "url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_run_uploaded_files_run": {
+          "name": "idx_run_uploaded_files_run",
+          "columns": [
+            {
+              "expression": "run_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_run_uploaded_files_run_source_external": {
+          "name": "idx_run_uploaded_files_run_source_external",
+          "columns": [
+            {
+              "expression": "run_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "source",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "external_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_run_uploaded_files_source_external": {
+          "name": "idx_run_uploaded_files_source_external",
+          "columns": [
+            {
+              "expression": "source",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "external_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "run_uploaded_files_run_id_agent_runs_id_fk": {
+          "name": "run_uploaded_files_run_id_agent_runs_id_fk",
+          "tableFrom": "run_uploaded_files",
+          "tableTo": "agent_runs",
+          "columnsFrom": [
+            "run_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.runner_job_queue": {
+      "name": "runner_job_queue",
+      "schema": "",
+      "columns": {
+        "run_id": {
+          "name": "run_id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "runner_group": {
+          "name": "runner_group",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "profile": {
+          "name": "profile",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'vm0/default'"
+        },
+        "session_id": {
+          "name": "session_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "claimed_at": {
+          "name": "claimed_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "execution_context": {
+          "name": "execution_context",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "runner_job_queue_group_profile_unclaimed_idx": {
+          "name": "runner_job_queue_group_profile_unclaimed_idx",
+          "columns": [
+            {
+              "expression": "runner_group",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "profile",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "claimed_at IS NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "runner_job_queue_session_id_unclaimed_idx": {
+          "name": "runner_job_queue_session_id_unclaimed_idx",
+          "columns": [
+            {
+              "expression": "session_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "claimed_at IS NULL AND session_id IS NOT NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "runner_job_queue_expires_at_idx": {
+          "name": "runner_job_queue_expires_at_idx",
+          "columns": [
+            {
+              "expression": "expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "runner_job_queue_run_id_agent_runs_id_fk": {
+          "name": "runner_job_queue_run_id_agent_runs_id_fk",
+          "tableFrom": "runner_job_queue",
+          "tableTo": "agent_runs",
+          "columnsFrom": [
+            "run_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.runner_state": {
+      "name": "runner_state",
+      "schema": "",
+      "columns": {
+        "runner_id": {
+          "name": "runner_id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "runner_name": {
+          "name": "runner_name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "runner_group": {
+          "name": "runner_group",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "profiles": {
+          "name": "profiles",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "total_vcpu": {
+          "name": "total_vcpu",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "total_memory_mb": {
+          "name": "total_memory_mb",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "max_concurrent": {
+          "name": "max_concurrent",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "allocated_vcpu": {
+          "name": "allocated_vcpu",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "allocated_memory_mb": {
+          "name": "allocated_memory_mb",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "running_count": {
+          "name": "running_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "held_session_states": {
+          "name": "held_session_states",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "mode": {
+          "name": "mode",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'running'"
+        },
+        "last_seen_at": {
+          "name": "last_seen_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "runner_state_group_idx": {
+          "name": "runner_state_group_idx",
+          "columns": [
+            {
+              "expression": "runner_group",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "runner_state_last_seen_idx": {
+          "name": "runner_state_last_seen_idx",
+          "columns": [
+            {
+              "expression": "last_seen_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.sandbox_telemetry": {
+      "name": "sandbox_telemetry",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "run_id": {
+          "name": "run_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "data": {
+          "name": "data",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_sandbox_telemetry_run_id": {
+          "name": "idx_sandbox_telemetry_run_id",
+          "columns": [
+            {
+              "expression": "run_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "sandbox_telemetry_run_id_agent_runs_id_fk": {
+          "name": "sandbox_telemetry_run_id_agent_runs_id_fk",
+          "tableFrom": "sandbox_telemetry",
+          "tableTo": "agent_runs",
+          "columnsFrom": [
+            "run_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.secrets": {
+      "name": "secrets",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "encrypted_value": {
+          "name": "encrypted_value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "type": {
+          "name": "type",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'user'"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "org_id": {
+          "name": "org_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_secrets_type": {
+          "name": "idx_secrets_type",
+          "columns": [
+            {
+              "expression": "type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_secrets_org": {
+          "name": "idx_secrets_org",
+          "columns": [
+            {
+              "expression": "org_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_secrets_org_user_name_type": {
+          "name": "idx_secrets_org_user_name_type",
+          "columns": [
+            {
+              "expression": "org_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.skills": {
+      "name": "skills",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "url": {
+          "name": "url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "full_path": {
+          "name": "full_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "storage_id": {
+          "name": "storage_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "version_hash": {
+          "name": "version_hash",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "commit_sha": {
+          "name": "commit_sha",
+          "type": "varchar(40)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "frontmatter": {
+          "name": "frontmatter",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "s3_key": {
+          "name": "s3_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "size": {
+          "name": "size",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "file_count": {
+          "name": "file_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "synced_at": {
+          "name": "synced_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_skills_name": {
+          "name": "idx_skills_name",
+          "columns": [
+            {
+              "expression": "name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_skills_storage_id": {
+          "name": "idx_skills_storage_id",
+          "columns": [
+            {
+              "expression": "storage_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "skills_storage_id_storages_id_fk": {
+          "name": "skills_storage_id_storages_id_fk",
+          "tableFrom": "skills",
+          "tableTo": "storages",
+          "columnsFrom": [
+            "storage_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "skills_url_unique": {
+          "name": "skills_url_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "url"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.slack_org_connections": {
+      "name": "slack_org_connections",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "slack_user_id": {
+          "name": "slack_user_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "slack_workspace_id": {
+          "name": "slack_workspace_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "vm0_user_id": {
+          "name": "vm0_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "dm_welcome_sent": {
+          "name": "dm_welcome_sent",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_slack_org_connections_user_workspace": {
+          "name": "idx_slack_org_connections_user_workspace",
+          "columns": [
+            {
+              "expression": "slack_user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "slack_workspace_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_slack_org_connections_workspace": {
+          "name": "idx_slack_org_connections_workspace",
+          "columns": [
+            {
+              "expression": "slack_workspace_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_slack_org_connections_vm0_user_workspace": {
+          "name": "idx_slack_org_connections_vm0_user_workspace",
+          "columns": [
+            {
+              "expression": "vm0_user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "slack_workspace_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "slack_org_connections_slack_workspace_id_slack_org_installations_slack_workspace_id_fk": {
+          "name": "slack_org_connections_slack_workspace_id_slack_org_installations_slack_workspace_id_fk",
+          "tableFrom": "slack_org_connections",
+          "tableTo": "slack_org_installations",
+          "columnsFrom": [
+            "slack_workspace_id"
+          ],
+          "columnsTo": [
+            "slack_workspace_id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.slack_org_installations": {
+      "name": "slack_org_installations",
+      "schema": "",
+      "columns": {
+        "slack_workspace_id": {
+          "name": "slack_workspace_id",
+          "type": "varchar(255)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "slack_workspace_name": {
+          "name": "slack_workspace_name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "org_id": {
+          "name": "org_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "encrypted_bot_token": {
+          "name": "encrypted_bot_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "bot_user_id": {
+          "name": "bot_user_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "installed_by_user_id": {
+          "name": "installed_by_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "bot_scopes": {
+          "name": "bot_scopes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_slack_org_installations_org": {
+          "name": "idx_slack_org_installations_org",
+          "columns": [
+            {
+              "expression": "org_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_slack_org_installations_org_unique": {
+          "name": "idx_slack_org_installations_org_unique",
+          "columns": [
+            {
+              "expression": "org_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "org_id IS NOT NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.slack_org_thread_sessions": {
+      "name": "slack_org_thread_sessions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "connection_id": {
+          "name": "connection_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "slack_channel_id": {
+          "name": "slack_channel_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "slack_thread_ts": {
+          "name": "slack_thread_ts",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "agent_session_id": {
+          "name": "agent_session_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_slack_org_thread_sessions_conn_channel_thread": {
+          "name": "idx_slack_org_thread_sessions_conn_channel_thread",
+          "columns": [
+            {
+              "expression": "connection_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "slack_channel_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "slack_thread_ts",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_slack_org_thread_sessions_connection": {
+          "name": "idx_slack_org_thread_sessions_connection",
+          "columns": [
+            {
+              "expression": "connection_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "slack_org_thread_sessions_connection_id_slack_org_connections_id_fk": {
+          "name": "slack_org_thread_sessions_connection_id_slack_org_connections_id_fk",
+          "tableFrom": "slack_org_thread_sessions",
+          "tableTo": "slack_org_connections",
+          "columnsFrom": [
+            "connection_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "slack_org_thread_sessions_agent_session_id_agent_sessions_id_fk": {
+          "name": "slack_org_thread_sessions_agent_session_id_agent_sessions_id_fk",
+          "tableFrom": "slack_org_thread_sessions",
+          "tableTo": "agent_sessions",
+          "columnsFrom": [
+            "agent_session_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.slack_user_agent_preferences": {
+      "name": "slack_user_agent_preferences",
+      "schema": "",
+      "columns": {
+        "vm0_user_id": {
+          "name": "vm0_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "org_id": {
+          "name": "org_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "selected_compose_id": {
+          "name": "selected_compose_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "slack_user_agent_preferences_selected_compose_id_agent_composes_id_fk": {
+          "name": "slack_user_agent_preferences_selected_compose_id_agent_composes_id_fk",
+          "tableFrom": "slack_user_agent_preferences",
+          "tableTo": "agent_composes",
+          "columnsFrom": [
+            "selected_compose_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "slack_user_agent_preferences_pkey": {
+          "name": "slack_user_agent_preferences_pkey",
+          "columns": [
+            "vm0_user_id",
+            "org_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.storage_version_lineage": {
+      "name": "storage_version_lineage",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "storage_id": {
+          "name": "storage_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "version_id": {
+          "name": "version_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "parent_version_id": {
+          "name": "parent_version_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "run_id": {
+          "name": "run_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "storage_type": {
+          "name": "storage_type",
+          "type": "varchar(16)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_storage_version_lineage_storage_version": {
+          "name": "idx_storage_version_lineage_storage_version",
+          "columns": [
+            {
+              "expression": "storage_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "version_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_storage_version_lineage_storage_parent": {
+          "name": "idx_storage_version_lineage_storage_parent",
+          "columns": [
+            {
+              "expression": "storage_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "parent_version_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_storage_version_lineage_run": {
+          "name": "idx_storage_version_lineage_run",
+          "columns": [
+            {
+              "expression": "run_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "storage_version_lineage_storage_id_storages_id_fk": {
+          "name": "storage_version_lineage_storage_id_storages_id_fk",
+          "tableFrom": "storage_version_lineage",
+          "tableTo": "storages",
+          "columnsFrom": [
+            "storage_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "storage_version_lineage_run_id_agent_runs_id_fk": {
+          "name": "storage_version_lineage_run_id_agent_runs_id_fk",
+          "tableFrom": "storage_version_lineage",
+          "tableTo": "agent_runs",
+          "columnsFrom": [
+            "run_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.storage_versions": {
+      "name": "storage_versions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(64)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "storage_id": {
+          "name": "storage_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "s3_key": {
+          "name": "s3_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "size": {
+          "name": "size",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "file_count": {
+          "name": "file_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "message": {
+          "name": "message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "storage_versions_storage_id_storages_id_fk": {
+          "name": "storage_versions_storage_id_storages_id_fk",
+          "tableFrom": "storage_versions",
+          "tableTo": "storages",
+          "columnsFrom": [
+            "storage_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.storages": {
+      "name": "storages",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(256)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "varchar(16)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'volume'"
+        },
+        "org_id": {
+          "name": "org_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "s3_prefix": {
+          "name": "s3_prefix",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "size": {
+          "name": "size",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "file_count": {
+          "name": "file_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "head_version_id": {
+          "name": "head_version_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_storages_org": {
+          "name": "idx_storages_org",
+          "columns": [
+            {
+              "expression": "org_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_storages_org_user_name_type": {
+          "name": "idx_storages_org_user_name_type",
+          "columns": [
+            {
+              "expression": "org_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "storages_head_version_id_storage_versions_id_fk": {
+          "name": "storages_head_version_id_storage_versions_id_fk",
+          "tableFrom": "storages",
+          "tableTo": "storage_versions",
+          "columnsFrom": [
+            "head_version_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.telegram_installations": {
+      "name": "telegram_installations",
+      "schema": "",
+      "columns": {
+        "telegram_bot_id": {
+          "name": "telegram_bot_id",
+          "type": "varchar(255)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "bot_username": {
+          "name": "bot_username",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "encrypted_bot_token": {
+          "name": "encrypted_bot_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "webhook_secret": {
+          "name": "webhook_secret",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "default_compose_id": {
+          "name": "default_compose_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "owner_user_id": {
+          "name": "owner_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "org_id": {
+          "name": "org_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_telegram_installations_owner": {
+          "name": "idx_telegram_installations_owner",
+          "columns": [
+            {
+              "expression": "owner_user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_telegram_installations_org": {
+          "name": "idx_telegram_installations_org",
+          "columns": [
+            {
+              "expression": "org_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "telegram_installations_default_compose_id_agent_composes_id_fk": {
+          "name": "telegram_installations_default_compose_id_agent_composes_id_fk",
+          "tableFrom": "telegram_installations",
+          "tableTo": "agent_composes",
+          "columnsFrom": [
+            "default_compose_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.telegram_messages": {
+      "name": "telegram_messages",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "installation_id": {
+          "name": "installation_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "official_org_id": {
+          "name": "official_org_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "official_user_link_id": {
+          "name": "official_user_link_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "chat_id": {
+          "name": "chat_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "message_id": {
+          "name": "message_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "from_user_id": {
+          "name": "from_user_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "from_username": {
+          "name": "from_username",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "from_display_name": {
+          "name": "from_display_name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "text": {
+          "name": "text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "file_id": {
+          "name": "file_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "file_type": {
+          "name": "file_type",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "file_name": {
+          "name": "file_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "file_mime_type": {
+          "name": "file_mime_type",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "file_size": {
+          "name": "file_size",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "file_width": {
+          "name": "file_width",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "file_height": {
+          "name": "file_height",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "file_duration": {
+          "name": "file_duration",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "entities": {
+          "name": "entities",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_bot": {
+          "name": "is_bot",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_telegram_messages_unique": {
+          "name": "idx_telegram_messages_unique",
+          "columns": [
+            {
+              "expression": "installation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "chat_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "message_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "installation_id IS NOT NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_telegram_messages_official_unique": {
+          "name": "idx_telegram_messages_official_unique",
+          "columns": [
+            {
+              "expression": "official_org_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "chat_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "message_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "official_org_id IS NOT NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_telegram_messages_chat": {
+          "name": "idx_telegram_messages_chat",
+          "columns": [
+            {
+              "expression": "installation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "chat_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "installation_id IS NOT NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_telegram_messages_official_chat": {
+          "name": "idx_telegram_messages_official_chat",
+          "columns": [
+            {
+              "expression": "official_org_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "chat_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "official_org_id IS NOT NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_telegram_messages_created_at": {
+          "name": "idx_telegram_messages_created_at",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "telegram_messages_installation_id_telegram_installations_telegram_bot_id_fk": {
+          "name": "telegram_messages_installation_id_telegram_installations_telegram_bot_id_fk",
+          "tableFrom": "telegram_messages",
+          "tableTo": "telegram_installations",
+          "columnsFrom": [
+            "installation_id"
+          ],
+          "columnsTo": [
+            "telegram_bot_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "telegram_messages_official_user_link_id_telegram_official_user_links_id_fk": {
+          "name": "telegram_messages_official_user_link_id_telegram_official_user_links_id_fk",
+          "tableFrom": "telegram_messages",
+          "tableTo": "telegram_official_user_links",
+          "columnsFrom": [
+            "official_user_link_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "chk_telegram_messages_one_owner": {
+          "name": "chk_telegram_messages_one_owner",
+          "value": "(installation_id IS NOT NULL) <> (official_org_id IS NOT NULL)"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.telegram_official_user_links": {
+      "name": "telegram_official_user_links",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "telegram_user_id": {
+          "name": "telegram_user_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "telegram_username": {
+          "name": "telegram_username",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "telegram_display_name": {
+          "name": "telegram_display_name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "vm0_user_id": {
+          "name": "vm0_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "org_id": {
+          "name": "org_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "dm_welcome_sent": {
+          "name": "dm_welcome_sent",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_telegram_official_user_links_tg_user": {
+          "name": "idx_telegram_official_user_links_tg_user",
+          "columns": [
+            {
+              "expression": "telegram_user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_telegram_official_user_links_vm0_org": {
+          "name": "idx_telegram_official_user_links_vm0_org",
+          "columns": [
+            {
+              "expression": "vm0_user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "org_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_telegram_official_user_links_org": {
+          "name": "idx_telegram_official_user_links_org",
+          "columns": [
+            {
+              "expression": "org_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.telegram_thread_sessions": {
+      "name": "telegram_thread_sessions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "telegram_user_link_id": {
+          "name": "telegram_user_link_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "telegram_official_user_link_id": {
+          "name": "telegram_official_user_link_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "chat_id": {
+          "name": "chat_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "root_message_id": {
+          "name": "root_message_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "agent_session_id": {
+          "name": "agent_session_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "last_processed_message_id": {
+          "name": "last_processed_message_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_telegram_thread_sessions_chat_user_link": {
+          "name": "idx_telegram_thread_sessions_chat_user_link",
+          "columns": [
+            {
+              "expression": "telegram_user_link_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "chat_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "root_message_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "telegram_user_link_id IS NOT NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_telegram_thread_sessions_chat_official_link": {
+          "name": "idx_telegram_thread_sessions_chat_official_link",
+          "columns": [
+            {
+              "expression": "telegram_official_user_link_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "chat_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "root_message_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "telegram_official_user_link_id IS NOT NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_telegram_thread_sessions_user_link": {
+          "name": "idx_telegram_thread_sessions_user_link",
+          "columns": [
+            {
+              "expression": "telegram_user_link_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "telegram_user_link_id IS NOT NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_telegram_thread_sessions_official_user_link": {
+          "name": "idx_telegram_thread_sessions_official_user_link",
+          "columns": [
+            {
+              "expression": "telegram_official_user_link_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "telegram_official_user_link_id IS NOT NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "telegram_thread_sessions_telegram_user_link_id_telegram_user_links_id_fk": {
+          "name": "telegram_thread_sessions_telegram_user_link_id_telegram_user_links_id_fk",
+          "tableFrom": "telegram_thread_sessions",
+          "tableTo": "telegram_user_links",
+          "columnsFrom": [
+            "telegram_user_link_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "telegram_thread_sessions_telegram_official_user_link_id_telegram_official_user_links_id_fk": {
+          "name": "telegram_thread_sessions_telegram_official_user_link_id_telegram_official_user_links_id_fk",
+          "tableFrom": "telegram_thread_sessions",
+          "tableTo": "telegram_official_user_links",
+          "columnsFrom": [
+            "telegram_official_user_link_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "telegram_thread_sessions_agent_session_id_agent_sessions_id_fk": {
+          "name": "telegram_thread_sessions_agent_session_id_agent_sessions_id_fk",
+          "tableFrom": "telegram_thread_sessions",
+          "tableTo": "agent_sessions",
+          "columnsFrom": [
+            "agent_session_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "chk_telegram_thread_sessions_one_owner": {
+          "name": "chk_telegram_thread_sessions_one_owner",
+          "value": "(telegram_user_link_id IS NOT NULL) <> (telegram_official_user_link_id IS NOT NULL)"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.telegram_user_agent_preferences": {
+      "name": "telegram_user_agent_preferences",
+      "schema": "",
+      "columns": {
+        "vm0_user_id": {
+          "name": "vm0_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "org_id": {
+          "name": "org_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "selected_compose_id": {
+          "name": "selected_compose_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "telegram_user_agent_preferences_selected_compose_id_agent_composes_id_fk": {
+          "name": "telegram_user_agent_preferences_selected_compose_id_agent_composes_id_fk",
+          "tableFrom": "telegram_user_agent_preferences",
+          "tableTo": "agent_composes",
+          "columnsFrom": [
+            "selected_compose_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "telegram_user_agent_preferences_pkey": {
+          "name": "telegram_user_agent_preferences_pkey",
+          "columns": [
+            "vm0_user_id",
+            "org_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.telegram_user_links": {
+      "name": "telegram_user_links",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "telegram_user_id": {
+          "name": "telegram_user_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "telegram_username": {
+          "name": "telegram_username",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "telegram_display_name": {
+          "name": "telegram_display_name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "installation_id": {
+          "name": "installation_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "vm0_user_id": {
+          "name": "vm0_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "dm_welcome_sent": {
+          "name": "dm_welcome_sent",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_telegram_user_links_user_installation": {
+          "name": "idx_telegram_user_links_user_installation",
+          "columns": [
+            {
+              "expression": "telegram_user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "installation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_telegram_user_links_vm0_installation": {
+          "name": "idx_telegram_user_links_vm0_installation",
+          "columns": [
+            {
+              "expression": "vm0_user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "installation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "telegram_user_links_installation_id_telegram_installations_telegram_bot_id_fk": {
+          "name": "telegram_user_links_installation_id_telegram_installations_telegram_bot_id_fk",
+          "tableFrom": "telegram_user_links",
+          "tableTo": "telegram_installations",
+          "columnsFrom": [
+            "installation_id"
+          ],
+          "columnsTo": [
+            "telegram_bot_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.usage_daily": {
+      "name": "usage_daily",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "org_id": {
+          "name": "org_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "date": {
+          "name": "date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "run_count": {
+          "name": "run_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "run_time_ms": {
+          "name": "run_time_ms",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "uq_usage_daily_user_org_date": {
+          "name": "uq_usage_daily_user_org_date",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "org_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "date",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.usage_event": {
+      "name": "usage_event",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "run_id": {
+          "name": "run_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "idempotency_key": {
+          "name": "idempotency_key",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "org_id": {
+          "name": "org_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "kind": {
+          "name": "kind",
+          "type": "varchar(30)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider": {
+          "name": "provider",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "category": {
+          "name": "category",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "quantity": {
+          "name": "quantity",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "credits_charged": {
+          "name": "credits_charged",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "billing_error": {
+          "name": "billing_error",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "processed_at": {
+          "name": "processed_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "uq_usage_event_idempotency_key": {
+          "name": "uq_usage_event_idempotency_key",
+          "columns": [
+            {
+              "expression": "idempotency_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_usage_event_run_id": {
+          "name": "idx_usage_event_run_id",
+          "columns": [
+            {
+              "expression": "run_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_usage_event_org_status": {
+          "name": "idx_usage_event_org_status",
+          "columns": [
+            {
+              "expression": "org_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_usage_event_org_created": {
+          "name": "idx_usage_event_org_created",
+          "columns": [
+            {
+              "expression": "org_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_usage_event_model_created": {
+          "name": "idx_usage_event_model_created",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"usage_event\".\"kind\" = 'model'",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_usage_event_org_user_status_processed": {
+          "name": "idx_usage_event_org_user_status_processed",
+          "columns": [
+            {
+              "expression": "org_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "processed_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_usage_event_processed_org_user": {
+          "name": "idx_usage_event_processed_org_user",
+          "columns": [
+            {
+              "expression": "processed_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            },
+            {
+              "expression": "org_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"usage_event\".\"status\" = 'processed' AND \"usage_event\".\"processed_at\" IS NOT NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "usage_event_run_id_agent_runs_id_fk": {
+          "name": "usage_event_run_id_agent_runs_id_fk",
+          "tableFrom": "usage_event",
+          "tableTo": "agent_runs",
+          "columnsFrom": [
+            "run_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.usage_pricing": {
+      "name": "usage_pricing",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "kind": {
+          "name": "kind",
+          "type": "varchar(30)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider": {
+          "name": "provider",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "category": {
+          "name": "category",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "unit_price": {
+          "name": "unit_price",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "unit_size": {
+          "name": "unit_size",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "uq_usage_pricing_kind_provider_category": {
+          "name": "uq_usage_pricing_kind_provider_category",
+          "columns": [
+            {
+              "expression": "kind",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "provider",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "category",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user_behavior_count": {
+      "name": "user_behavior_count",
+      "schema": "",
+      "columns": {
+        "org_id": {
+          "name": "org_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "behavior_key": {
+          "name": "behavior_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "count": {
+          "name": "count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "first_at": {
+          "name": "first_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "last_at": {
+          "name": "last_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "user_behavior_count_org_id_user_id_behavior_key_pk": {
+          "name": "user_behavior_count_org_id_user_id_behavior_key_pk",
+          "columns": [
+            "org_id",
+            "user_id",
+            "behavior_key"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user_cache": {
+      "name": "user_cache",
+      "schema": "",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "org_list_cached_at": {
+          "name": "org_list_cached_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "cached_at": {
+          "name": "cached_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user_connectors": {
+      "name": "user_connectors",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "org_id": {
+          "name": "org_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "agent_id": {
+          "name": "agent_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "connector_type": {
+          "name": "connector_type",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_user_connectors_unique": {
+          "name": "idx_user_connectors_unique",
+          "columns": [
+            {
+              "expression": "org_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "agent_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "connector_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_user_connectors_agent_user": {
+          "name": "idx_user_connectors_agent_user",
+          "columns": [
+            {
+              "expression": "agent_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "user_connectors_agent_id_zero_agents_id_fk": {
+          "name": "user_connectors_agent_id_zero_agents_id_fk",
+          "tableFrom": "user_connectors",
+          "tableTo": "zero_agents",
+          "columnsFrom": [
+            "agent_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user_custom_connectors": {
+      "name": "user_custom_connectors",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "org_id": {
+          "name": "org_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "agent_id": {
+          "name": "agent_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "custom_connector_id": {
+          "name": "custom_connector_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_user_custom_connectors_unique": {
+          "name": "idx_user_custom_connectors_unique",
+          "columns": [
+            {
+              "expression": "org_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "agent_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "custom_connector_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_user_custom_connectors_agent_user": {
+          "name": "idx_user_custom_connectors_agent_user",
+          "columns": [
+            {
+              "expression": "agent_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "user_custom_connectors_agent_id_zero_agents_id_fk": {
+          "name": "user_custom_connectors_agent_id_zero_agents_id_fk",
+          "tableFrom": "user_custom_connectors",
+          "tableTo": "zero_agents",
+          "columnsFrom": [
+            "agent_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "user_custom_connectors_custom_connector_id_org_custom_connectors_id_fk": {
+          "name": "user_custom_connectors_custom_connector_id_org_custom_connectors_id_fk",
+          "tableFrom": "user_custom_connectors",
+          "tableTo": "org_custom_connectors",
+          "columnsFrom": [
+            "custom_connector_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user_feature_switches": {
+      "name": "user_feature_switches",
+      "schema": "",
+      "columns": {
+        "org_id": {
+          "name": "org_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "switches": {
+          "name": "switches",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "user_feature_switches_org_id_user_id_pk": {
+          "name": "user_feature_switches_org_id_user_id_pk",
+          "columns": [
+            "org_id",
+            "user_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user_permission_grants": {
+      "name": "user_permission_grants",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "org_id": {
+          "name": "org_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "agent_id": {
+          "name": "agent_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "connector_ref": {
+          "name": "connector_ref",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "permission": {
+          "name": "permission",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "action": {
+          "name": "action",
+          "type": "varchar(8)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "uq_user_permission_grants_grant": {
+          "name": "uq_user_permission_grants_grant",
+          "columns": [
+            {
+              "expression": "org_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "agent_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "connector_ref",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "permission",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_user_permission_grants_lookup": {
+          "name": "idx_user_permission_grants_lookup",
+          "columns": [
+            {
+              "expression": "org_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "agent_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_user_permission_grants_user_id": {
+          "name": "idx_user_permission_grants_user_id",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_user_permission_grants_agent_id": {
+          "name": "idx_user_permission_grants_agent_id",
+          "columns": [
+            {
+              "expression": "agent_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "user_permission_grants_agent_id_zero_agents_id_fk": {
+          "name": "user_permission_grants_agent_id_zero_agents_id_fk",
+          "tableFrom": "user_permission_grants",
+          "tableTo": "zero_agents",
+          "columnsFrom": [
+            "agent_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "chk_user_permission_grants_action": {
+          "name": "chk_user_permission_grants_action",
+          "value": "\"user_permission_grants\".\"action\" IN ('allow', 'deny')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.users": {
+      "name": "users",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "email_unsubscribed": {
+          "name": "email_unsubscribed",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.variables": {
+      "name": "variables",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "type": {
+          "name": "type",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'user'"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "org_id": {
+          "name": "org_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_variables_org": {
+          "name": "idx_variables_org",
+          "columns": [
+            {
+              "expression": "org_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_variables_org_user_type_name": {
+          "name": "idx_variables_org_user_type_name",
+          "columns": [
+            {
+              "expression": "org_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.vm0_api_keys": {
+      "name": "vm0_api_keys",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "vendor": {
+          "name": "vendor",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "model": {
+          "name": "model",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "api_key": {
+          "name": "api_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "label": {
+          "name": "label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_vm0_api_keys_vendor": {
+          "name": "idx_vm0_api_keys_vendor",
+          "columns": [
+            {
+              "expression": "vendor",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.zero_agent_schedules": {
+      "name": "zero_agent_schedules",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "agent_id": {
+          "name": "agent_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "org_id": {
+          "name": "org_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "trigger_type": {
+          "name": "trigger_type",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'cron'"
+        },
+        "cron_expression": {
+          "name": "cron_expression",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "at_time": {
+          "name": "at_time",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "interval_seconds": {
+          "name": "interval_seconds",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "timezone": {
+          "name": "timezone",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'UTC'"
+        },
+        "prompt": {
+          "name": "prompt",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "append_system_prompt": {
+          "name": "append_system_prompt",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "vars": {
+          "name": "vars",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "encrypted_secrets": {
+          "name": "encrypted_secrets",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "volume_versions": {
+          "name": "volume_versions",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "chat_thread_id": {
+          "name": "chat_thread_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "next_run_at": {
+          "name": "next_run_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_run_at": {
+          "name": "last_run_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_run_id": {
+          "name": "last_run_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "retry_started_at": {
+          "name": "retry_started_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "consecutive_failures": {
+          "name": "consecutive_failures",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_zero_agent_schedules_zero_agent": {
+          "name": "idx_zero_agent_schedules_zero_agent",
+          "columns": [
+            {
+              "expression": "agent_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_zero_agent_schedules_org": {
+          "name": "idx_zero_agent_schedules_org",
+          "columns": [
+            {
+              "expression": "org_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_zero_agent_schedules_agent_name_org_user": {
+          "name": "idx_zero_agent_schedules_agent_name_org_user",
+          "columns": [
+            {
+              "expression": "agent_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "org_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_zero_agent_schedules_next_run": {
+          "name": "idx_zero_agent_schedules_next_run",
+          "columns": [
+            {
+              "expression": "next_run_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "enabled = true",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_zero_agent_schedules_user_org": {
+          "name": "idx_zero_agent_schedules_user_org",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "org_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_zero_agent_schedules_chat_thread": {
+          "name": "idx_zero_agent_schedules_chat_thread",
+          "columns": [
+            {
+              "expression": "chat_thread_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "zero_agent_schedules_agent_id_agent_composes_id_fk": {
+          "name": "zero_agent_schedules_agent_id_agent_composes_id_fk",
+          "tableFrom": "zero_agent_schedules",
+          "tableTo": "agent_composes",
+          "columnsFrom": [
+            "agent_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "zero_agent_schedules_chat_thread_id_chat_threads_id_fk": {
+          "name": "zero_agent_schedules_chat_thread_id_chat_threads_id_fk",
+          "tableFrom": "zero_agent_schedules",
+          "tableTo": "chat_threads",
+          "columnsFrom": [
+            "chat_thread_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "zero_agent_schedules_last_run_id_agent_runs_id_fk": {
+          "name": "zero_agent_schedules_last_run_id_agent_runs_id_fk",
+          "tableFrom": "zero_agent_schedules",
+          "tableTo": "agent_runs",
+          "columnsFrom": [
+            "last_run_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.zero_agents": {
+      "name": "zero_agents",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "org_id": {
+          "name": "org_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "owner": {
+          "name": "owner",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "visibility": {
+          "name": "visibility",
+          "type": "varchar(16)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'public'"
+        },
+        "display_name": {
+          "name": "display_name",
+          "type": "varchar(256)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "sound": {
+          "name": "sound",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "avatar_url": {
+          "name": "avatar_url",
+          "type": "varchar(1024)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "custom_skills": {
+          "name": "custom_skills",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "model_provider_id": {
+          "name": "model_provider_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "selected_model": {
+          "name": "selected_model",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "prefer_personal_provider": {
+          "name": "prefer_personal_provider",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_zero_agents_org_name": {
+          "name": "idx_zero_agents_org_name",
+          "columns": [
+            {
+              "expression": "org_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_zero_agents_org": {
+          "name": "idx_zero_agents_org",
+          "columns": [
+            {
+              "expression": "org_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "zero_agents_id_agent_composes_id_fk": {
+          "name": "zero_agents_id_agent_composes_id_fk",
+          "tableFrom": "zero_agents",
+          "tableTo": "agent_composes",
+          "columnsFrom": [
+            "id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "zero_agents_model_provider_id_model_providers_id_fk": {
+          "name": "zero_agents_model_provider_id_model_providers_id_fk",
+          "tableFrom": "zero_agents",
+          "tableTo": "model_providers",
+          "columnsFrom": [
+            "model_provider_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.zero_runs": {
+      "name": "zero_runs",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "trigger_source": {
+          "name": "trigger_source",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "schedule_id": {
+          "name": "schedule_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "trigger_agent_id": {
+          "name": "trigger_agent_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "model_provider": {
+          "name": "model_provider",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "model_provider_id": {
+          "name": "model_provider_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "model_provider_credential_scope": {
+          "name": "model_provider_credential_scope",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "selected_model": {
+          "name": "selected_model",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "chat_thread_id": {
+          "name": "chat_thread_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "summary": {
+          "name": "summary",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "idx_zero_runs_schedule": {
+          "name": "idx_zero_runs_schedule",
+          "columns": [
+            {
+              "expression": "schedule_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "schedule_id IS NOT NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_zero_runs_chat_thread_id": {
+          "name": "idx_zero_runs_chat_thread_id",
+          "columns": [
+            {
+              "expression": "chat_thread_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "chat_thread_id IS NOT NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "zero_runs_id_agent_runs_id_fk": {
+          "name": "zero_runs_id_agent_runs_id_fk",
+          "tableFrom": "zero_runs",
+          "tableTo": "agent_runs",
+          "columnsFrom": [
+            "id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "zero_runs_schedule_id_zero_agent_schedules_id_fk": {
+          "name": "zero_runs_schedule_id_zero_agent_schedules_id_fk",
+          "tableFrom": "zero_runs",
+          "tableTo": "zero_agent_schedules",
+          "columnsFrom": [
+            "schedule_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "zero_runs_trigger_agent_id_agent_composes_id_fk": {
+          "name": "zero_runs_trigger_agent_id_agent_composes_id_fk",
+          "tableFrom": "zero_runs",
+          "tableTo": "agent_composes",
+          "columnsFrom": [
+            "trigger_agent_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "zero_runs_chat_thread_id_chat_threads_id_fk": {
+          "name": "zero_runs_chat_thread_id_chat_threads_id_fk",
+          "tableFrom": "zero_runs",
+          "tableTo": "chat_threads",
+          "columnsFrom": [
+            "chat_thread_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.zero_skills": {
+      "name": "zero_skills",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "org_id": {
+          "name": "org_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "display_name": {
+          "name": "display_name",
+          "type": "varchar(256)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_zero_skills_org_name": {
+          "name": "idx_zero_skills_org_name",
+          "columns": [
+            {
+              "expression": "org_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_zero_skills_org": {
+          "name": "idx_zero_skills_org",
+          "columns": [
+            {
+              "expression": "org_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {
+    "public.connector_external_code_session_status": {
+      "name": "connector_external_code_session_status",
+      "schema": "public",
+      "values": [
+        "pending",
+        "completing",
+        "complete",
+        "expired",
+        "error"
+      ]
+    },
+    "public.connector_oauth_device_authorization_session_status": {
+      "name": "connector_oauth_device_authorization_session_status",
+      "schema": "public",
+      "values": [
+        "awaiting_user_authorization",
+        "polling",
+        "complete",
+        "denied",
+        "expired",
+        "error"
+      ]
+    },
+    "public.device_code_status": {
+      "name": "device_code_status",
+      "schema": "public",
+      "values": [
+        "pending",
+        "authenticated",
+        "approved",
+        "consumed",
+        "expired",
+        "denied"
+      ]
+    },
+    "public.model_provider_auth_session_status": {
+      "name": "model_provider_auth_session_status",
+      "schema": "public",
+      "values": [
+        "initializing",
+        "awaiting_user_approval",
+        "completing",
+        "imported",
+        "expired",
+        "cancelled",
+        "error"
+      ]
+    }
+  },
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/turbo/packages/db/src/migrations/meta/_journal.json
+++ b/turbo/packages/db/src/migrations/meta/_journal.json
@@ -3074,6 +3074,13 @@
       "when": 1780974019944,
       "tag": "0438_slow_klaw",
       "breakpoints": true
+    },
+    {
+      "idx": 439,
+      "version": "7",
+      "when": 1780986126784,
+      "tag": "0439_premium_wendigo",
+      "breakpoints": true
     }
   ]
 }

--- a/turbo/packages/db/src/schema/connector-external-code-session.ts
+++ b/turbo/packages/db/src/schema/connector-external-code-session.ts
@@ -1,0 +1,56 @@
+import {
+  index,
+  pgEnum,
+  pgTable,
+  text,
+  timestamp,
+  uniqueIndex,
+  uuid,
+  varchar,
+} from "drizzle-orm/pg-core";
+
+export const connectorExternalCodeSessionStatusEnum = pgEnum(
+  "connector_external_code_session_status",
+  ["pending", "completing", "complete", "expired", "error"],
+);
+
+export const connectorExternalCodeSessions = pgTable(
+  "connector_external_code_sessions",
+  {
+    id: uuid("id").defaultRandom().primaryKey(),
+    orgId: text("org_id").notNull(),
+    userId: text("user_id").notNull(),
+    connectorType: varchar("connector_type", { length: 50 }).notNull(),
+    authMethod: varchar("auth_method", { length: 50 }).notNull(),
+    status: connectorExternalCodeSessionStatusEnum("status")
+      .default("pending")
+      .notNull(),
+    sessionTokenHash: varchar("session_token_hash", { length: 128 }).notNull(),
+    encryptedProviderState: text("encrypted_provider_state").notNull(),
+    authorizationUrl: text("authorization_url").notNull(),
+    errorCode: varchar("error_code", { length: 255 }),
+    errorMessage: text("error_message"),
+    createdAt: timestamp("created_at").defaultNow().notNull(),
+    updatedAt: timestamp("updated_at").defaultNow().notNull(),
+    expiresAt: timestamp("expires_at").notNull(),
+    completedAt: timestamp("completed_at"),
+  },
+  (table) => {
+    return [
+      uniqueIndex("idx_connector_external_code_sessions_token").on(
+        table.sessionTokenHash,
+      ),
+      index("idx_connector_external_code_sessions_owner_status").on(
+        table.orgId,
+        table.userId,
+        table.connectorType,
+        table.authMethod,
+        table.status,
+      ),
+      index("idx_connector_external_code_sessions_expiration").on(
+        table.status,
+        table.expiresAt,
+      ),
+    ];
+  },
+);


### PR DESCRIPTION
## Summary\n- add a generic external-code connector grant flow with API contracts, encrypted session storage, and platform UI\n- add the AWS remote login connector using AWS Sign-In token exchange, refresh-token access, and STS identity lookup\n- gate AWS behind the staff-only awsConnector feature switch and keep AWS_LOGIN_REFRESH_TOKEN out of runtime env bindings\n\n## Validation\n- pnpm -F @vm0/connectors exec vitest run src/__tests__/connectors.test.ts src/auth-providers/connectors/__tests__/aws.test.ts\n- pnpm -F api exec vitest run src/signals/routes/__tests__/zero-connectors-external-code.test.ts\n- pnpm -F @vm0/app lint\n- pnpm -F @vm0/app exec vitest run src/views/conn/__tests__/add-connection-dialog.test.tsx\n- pnpm -F @vm0/db test:migration-consistency\n- pre-commit: prettier, knip --cache, turbo run check-types --concurrency=1\n\nCloses #16532