### PR TITLE
fix(mitm-addon): handle concatenated zlib bodies

### DIFF
--- a/crates/runner/mitm-addon/src/body_utils.py
+++ b/crates/runner/mitm-addon/src/body_utils.py
@@ -273,7 +273,8 @@ def decompress_body(
     bombs.  Cap enforcement varies by codec:
 
     - gzip/deflate: hard cap via ``decompressobj.decompress(data, max_length=)``;
-      zlib stops decoding once the cap is reached.
+      zlib stops decoding once the cap is reached. Concatenated members are
+      decoded until the shared cap is exhausted.
     - zstd: hard cap via ``ZstdDecompressor.stream_reader(data).read(max_output)``;
       zstd reads incrementally so total memory is bounded by
       ``max_output`` plus library internal buffers.
@@ -284,9 +285,11 @@ def decompress_body(
       full response before slicing.
 
     Returns the original data unchanged when the encoding is missing,
-    ``identity``, or unrecognised, and on decompression error.  A valid
-    frame that decodes to an empty body returns ``b""`` — callers that
-    short-circuit via ``if not body`` rely on that (see #10287).
+    ``identity``, unrecognised, or invalid before any compressed member
+    completes. Once a member has completed, later invalid trailing data is
+    ignored on this best-effort path. A valid frame that decodes to an empty
+    body returns ``b""`` — callers that short-circuit via ``if not body`` rely
+    on that (see #10287).
     """
     result = _decode_body_bounded(data, headers, max_output=max_output)
     if result.failed and result.error is not None:
@@ -297,6 +300,48 @@ def decompress_body(
                 f"({headers.get('content-encoding', '').strip().lower()}): {result.error}"
             )
     return result.body
+
+
+def _decompress_zlib_best_effort_bounded(
+    data: bytes, encoding: Literal["gzip", "deflate"], max_output: int
+) -> _BoundedDecodeResult:
+    if max_output <= 0:
+        return _BoundedDecodeResult(b"", False)
+
+    wbits = 16 + zlib.MAX_WBITS if encoding == "gzip" else zlib.MAX_WBITS
+    remaining_data = data
+    out = bytearray()
+    completed_member = False
+
+    while remaining_data and len(out) < max_output:
+        obj = zlib.decompressobj(wbits)
+        member_data = remaining_data
+
+        while member_data and len(out) < max_output:
+            try:
+                decoded = obj.decompress(member_data, max_length=max_output - len(out))
+            except zlib.error as exc:
+                if completed_member:
+                    return _BoundedDecodeResult(bytes(out), False)
+                return _BoundedDecodeResult(data, True, exc)
+
+            out.extend(decoded)
+            if obj.unconsumed_tail:
+                member_data = obj.unconsumed_tail
+                continue
+            break
+
+        if len(out) >= max_output:
+            return _BoundedDecodeResult(bytes(out), False)
+        if obj.eof:
+            completed_member = True
+            if obj.unused_data:
+                remaining_data = obj.unused_data
+                continue
+            return _BoundedDecodeResult(bytes(out), False)
+        return _BoundedDecodeResult(bytes(out), False)
+
+    return _BoundedDecodeResult(bytes(out), False)
 
 
 def _decode_body_bounded(
@@ -311,13 +356,7 @@ def _decode_body_bounded(
         return _BoundedDecodeResult(data, False)
     try:
         if encoding in ("gzip", "deflate"):
-            # wbits: gzip=16+MAX_WBITS, deflate=MAX_WBITS
-            wbits = 16 + zlib.MAX_WBITS if encoding == "gzip" else zlib.MAX_WBITS
-            obj = zlib.decompressobj(wbits)
-            return _BoundedDecodeResult(
-                obj.decompress(data, max_length=max_output),
-                False,
-            )
+            return _decompress_zlib_best_effort_bounded(data, encoding, max_output)
         if encoding == "br":
             return _BoundedDecodeResult(_decompress_brotli_bounded(data, max_output), False)
         if encoding == "zstd":

--- a/crates/runner/mitm-addon/tests/test_body_capture.py
+++ b/crates/runner/mitm-addon/tests/test_body_capture.py
@@ -1064,6 +1064,21 @@ class TestDecompression:
         add_capture_fields(flow, entry)
         assert entry["response_body"] == '{"result": "hello world"}'
 
+    @pytest.mark.parametrize("encoding", ["gzip", "deflate"])
+    def test_concatenated_zlib_members_decompressed(self, real_flow, encoding):
+        original = b'{"result": "hello world"}'
+        if encoding == "gzip":
+            compressed = gzip.compress(b"") + gzip.compress(original)
+        else:
+            compressed = zlib.compress(b"") + zlib.compress(original)
+
+        flow = self._make_flow_with_compressed_buffer(real_flow, compressed, encoding)
+        entry = {}
+        add_capture_fields(flow, entry)
+
+        assert entry["response_body"] == '{"result": "hello world"}'
+        assert entry["response_body_encoding"] == "utf-8"
+
     def test_brotli_decompressed(self, real_flow):
         original = b'{"result": "hello world"}'
         flow = self._make_flow_with_compressed_buffer(real_flow, brotli.compress(original), "br")
@@ -1705,6 +1720,73 @@ class TestDecompressBody:
         result = decompress_body(compressed, hdrs, max_output=64 * 1024)
         assert len(result) <= 64 * 1024
         assert result == plaintext[: len(result)]
+
+    @pytest.mark.parametrize("encoding", ["gzip", "deflate"])
+    def test_concatenated_zlib_members_after_empty_prefix(self, headers, encoding):
+        plaintext = b'{"ok":true}'
+        if encoding == "gzip":
+            compressed = gzip.compress(b"") + gzip.compress(plaintext)
+        else:
+            compressed = zlib.compress(b"") + zlib.compress(plaintext)
+
+        hdrs = headers(("Content-Encoding", encoding))
+        result = decompress_body(compressed, hdrs, max_output=64 * 1024)
+
+        assert result == plaintext
+
+    @pytest.mark.parametrize("encoding", ["gzip", "deflate"])
+    def test_concatenated_zlib_members_share_max_output_cap(self, headers, encoding):
+        first = b"A" * 8
+        second = b"B" * 8
+        if encoding == "gzip":
+            compressed = gzip.compress(first) + gzip.compress(second)
+        else:
+            compressed = zlib.compress(first) + zlib.compress(second)
+
+        hdrs = headers(("Content-Encoding", encoding))
+        result = decompress_body(compressed, hdrs, max_output=12)
+
+        assert result == first + second[:4]
+
+    @pytest.mark.parametrize("encoding", ["gzip", "deflate"])
+    def test_concatenated_zlib_empty_member_before_garbage_returns_empty(self, headers, encoding):
+        if encoding == "gzip":
+            compressed = gzip.compress(b"") + b"garbage"
+        else:
+            compressed = zlib.compress(b"") + b"garbage"
+
+        hdrs = headers(("Content-Encoding", encoding))
+        result = decompress_body(compressed, hdrs, max_output=64 * 1024)
+
+        assert result == b""
+
+    @pytest.mark.parametrize("encoding", ["gzip", "deflate"])
+    def test_concatenated_zlib_member_before_garbage_returns_decoded_prefix(
+        self, headers, encoding
+    ):
+        if encoding == "gzip":
+            compressed = gzip.compress(b"prefix") + b"garbage"
+        else:
+            compressed = zlib.compress(b"prefix") + b"garbage"
+
+        hdrs = headers(("Content-Encoding", encoding))
+        result = decompress_body(compressed, hdrs, max_output=64 * 1024)
+
+        assert result == b"prefix"
+
+    @pytest.mark.parametrize("encoding", ["gzip", "deflate"])
+    def test_invalid_zlib_first_member_returns_original_data(self, headers, encoding):
+        if encoding == "gzip":
+            corrupted = bytearray(gzip.compress(b"payload"))
+        else:
+            corrupted = bytearray(zlib.compress(b"payload"))
+        corrupted[-1] ^= 0xFF
+        compressed = bytes(corrupted)
+
+        hdrs = headers(("Content-Encoding", encoding))
+        result = decompress_body(compressed, hdrs, max_output=64 * 1024)
+
+        assert result == compressed
 
     def test_zstd_respects_max_output(self, headers):
         # Bug #10128: before the fix the zstd branch used


### PR DESCRIPTION
## Summary

- Add a bounded best-effort gzip/deflate member decoder for `decompress_body()`.
- Decode concatenated gzip/deflate members while enforcing one global `max_output` cap.
- Preserve existing best-effort behavior for invalid, truncated, and empty compressed bodies.
- Add regression coverage for direct `decompress_body()` and response body capture paths.

Closes #16465.

## Tests

- `pytest tests/test_body_capture.py::TestDecompression::test_concatenated_zlib_members_decompressed tests/test_body_capture.py::TestDecompressBody::test_concatenated_zlib_members_after_empty_prefix tests/test_body_capture.py::TestDecompressBody::test_concatenated_zlib_members_share_max_output_cap tests/test_body_capture.py::TestDecompressBody::test_concatenated_zlib_empty_member_before_garbage_returns_empty`
- `pytest tests/test_body_capture.py`
- `ruff check src/body_utils.py tests/test_body_capture.py`
- `ruff format --check src/body_utils.py tests/test_body_capture.py`
- `basedpyright src/body_utils.py tests/test_body_capture.py`
- `pytest tests/`

Local note: the full mitm-addon pytest suite initially failed in existing X billing tests because the ignored generated file `turbo/packages/connectors/src/firewalls/ashby.generated.ts` was missing locally. Running `pnpm -F @vm0/firewalls-generator generate:ashby` restored that postinstall-generated artifact; `pytest tests/` then passed with 2389 tests.