### PR TITLE
chore: update Gmail connector icon

### DIFF
--- a/turbo/apps/platform/src/views/zero-page/components/settings/icons/gmail.svg
+++ b/turbo/apps/platform/src/views/zero-page/components/settings/icons/gmail.svg
@@ -1,14 +1,1 @@
-<svg width="134" height="100" viewBox="0 0 134 100" fill="none" xmlns="http://www.w3.org/2000/svg">
-  <g clipPath="url(#clip0)">
-    <path d="M9.09091 100H30.303V48.4848L0 25.7576V90.9091C0 95.9394 4.07576 100 9.09091 100Z" fill="#4285F4"/>
-    <path d="M103.03 100H124.242C129.273 100 133.333 95.9242 133.333 90.9091V25.7576L103.03 48.4848" fill="#34A853"/>
-    <path d="M103.03 9.09091V48.4848L133.333 25.7576V13.6364C133.333 2.39394 120.5 -4.01515 111.515 2.72727" fill="#FBBC04"/>
-    <path d="M30.303 48.4848V9.09091L66.6667 36.3636L103.03 9.09091V48.4848L66.6667 75.7576" fill="#EA4335"/>
-    <path d="M0 13.6364V25.7576L30.303 48.4848V9.09091L21.8182 2.72727C12.8182 -4.01515 0 2.39394 0 13.6364" fill="#C5221F"/>
-  </g>
-  <defs>
-    <clipPath id="clip0">
-      <rect width="133.333" height="100" fill="white"/>
-    </clipPath>
-  </defs>
-</svg>
+<svg xmlns="http://www.w3.org/2000/svg" width="192" height="192" fill="none" viewBox="0 0 192 192"><path fill="url(#a)" d="M146 44h38v110c0 6.627-5.373 12-12 12h-20a6 6 0 0 1-6-6z"/><path fill="#fc413d" d="M46 44H8v110c0 6.627 5.373 12 12 12h20a6 6 0 0 0 6-6z"/><path fill="url(#b)" d="M39.226 30.456c-8.033-6.752-20.018-5.714-26.77 2.319-6.752 8.032-5.714 20.017 2.319 26.77l76.078 63.949a8 8 0 0 0 10.295 0l76.078-63.95c8.032-6.752 9.07-18.737 2.318-26.77-6.752-8.032-18.737-9.07-26.769-2.318L96 78.18z"/><defs><linearGradient id="a" x1="165" x2="165" y1="44" y2="166" gradientUnits="userSpaceOnUse"><stop stop-color="#60d673"/><stop offset=".17" stop-color="#42c868"/><stop offset=".39" stop-color="#0ebc5f"/><stop offset=".62" stop-color="#00a9bb"/><stop offset=".86" stop-color="#3c90ff"/><stop offset="1" stop-color="#3186ff"/></linearGradient><linearGradient id="b" x1="8" x2="184" y1="46.13" y2="46.13" gradientUnits="userSpaceOnUse"><stop offset=".08" stop-color="#ff63a0"/><stop offset=".3" stop-color="#fc413d"/><stop offset=".5" stop-color="#fc413d"/><stop offset=".65" stop-color="#fc413d"/><stop offset=".72" stop-color="#fc5c30"/><stop offset=".86" stop-color="#feb10c"/><stop offset=".91" stop-color="#fec700"/><stop offset=".96" stop-color="#ffdb0f"/></linearGradient></defs></svg>


### PR DESCRIPTION
## Summary

- Replace the Gmail connector icon with Google's official 2026 Gmail product SVG
- Preserve the official multi-color gradient artwork and explicit colors
- Keep the icon SVG-only with no embedded raster assets

## Official Source

- https://www.google.com/drive/
- https://www.gstatic.com/images/branding/productlogos/gmail_2026/v2/web/192px.svg

## Verification

- `rg -n "currentColor|<image|data:image|href=|\\.png|\\.jpg|\\.jpeg|\\.webp|\\.gif|<script|onload|onerror" turbo/apps/platform/src/views/zero-page/components/settings/icons/gmail.svg`
- `git diff --check`
- `pnpm --filter @vm0/app lint`
- commit hook: prettier, check-file-size, block-generated-firewalls

Closes #16569