### PR TITLE
chore: update Google Docs connector icon

### DIFF
--- a/turbo/apps/platform/src/views/zero-page/components/settings/icons/google-docs.svg
+++ b/turbo/apps/platform/src/views/zero-page/components/settings/icons/google-docs.svg
@@ -1,1 +1,25 @@
-<svg role="img" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg"><title>Google Docs</title><path fill="#4285F4" d="M14.727 6.727H14V0H4.91c-.905 0-1.637.732-1.637 1.636v20.728c0 .904.732 1.636 1.636 1.636h14.182c.904 0 1.636-.732 1.636-1.636V6.727h-6zm-.545 10.455H7.09v-1.364h7.09v1.364zm2.727-3.273H7.091v-1.364h9.818v1.364zm0-3.273H7.091V9.273h9.818v1.363zM14.727 6h6l-6-6v6z"/></svg>
+<svg width="192" height="192" viewBox="0 0 192 192" fill="none" xmlns="http://www.w3.org/2000/svg">
+<mask id="mask0_37242_8762" style="mask-type:alpha" maskUnits="userSpaceOnUse" x="32" y="8" width="128" height="176">
+<path d="M130.334 184L61.6 184C52.6565 184 48.1848 184 44.6375 182.596C39.5029 180.563 35.4374 176.497 33.4045 171.362C32 167.815 32 163.343 32 154.4L32 37.6C32 28.6565 32 24.1848 33.4045 20.6375C35.4374 15.5029 39.5029 11.4374 44.6375 9.40447C48.1848 8 52.6565 8 61.6 8L100 8L154.793 62.7933L154.793 62.7934C156.454 64.4543 157.285 65.2848 157.923 66.2239C158.845 67.5811 159.479 69.1131 159.785 70.725C159.997 71.8404 159.997 73.0264 159.995 75.3985C159.96 124.317 159.938 124.799 159.937 154.366C159.937 163.332 159.937 167.816 158.532 171.363C156.499 176.498 152.434 180.562 147.299 182.596C143.752 184 139.279 184 130.334 184Z" fill="#3186FF"/>
+</mask>
+<g mask="url(#mask0_37242_8762)">
+<path d="M159.94 184L31.9999 184L31.9999 8.00001L99.9999 8L159.999 68L159.94 184Z" fill="#3186FF"/>
+<g filter="url(#filter0_f_37242_8762)">
+<path d="M43 192H149V70.2271V20H43V192Z" fill="url(#paint0_linear_37242_8762)"/>
+</g>
+</g>
+<path d="M154.995 62.9951C152.489 61.1143 149.375 60 146 60H112.8C105.731 60 100 54.2692 100 47.2002V8L154.995 62.9951Z" fill="#76BBFF"/>
+<rect x="64.001" y="114" width="64" height="12" rx="6" fill="white"/>
+<rect x="64.001" y="143" width="48" height="12" rx="6" fill="white"/>
+<defs>
+<filter id="filter0_f_37242_8762" x="31" y="8" width="130" height="196" filterUnits="userSpaceOnUse" color-interpolation-filters="sRGB">
+<feFlood flood-opacity="0" result="BackgroundImageFix"/>
+<feBlend mode="normal" in="SourceGraphic" in2="BackgroundImageFix" result="shape"/>
+<feGaussianBlur stdDeviation="6" result="effect1_foregroundBlur_37242_8762"/>
+</filter>
+<linearGradient id="paint0_linear_37242_8762" x1="96" y1="59.2839" x2="54.6124" y2="171.338" gradientUnits="userSpaceOnUse">
+<stop offset="0.33" stop-color="#3186FF"/>
+<stop offset="1" stop-color="#A9A8FF"/>
+</linearGradient>
+</defs>
+</svg>


### PR DESCRIPTION
## Summary

- Replace the Google Docs connector icon with Google's official 2026 Docs product SVG
- Preserve the official multi-color gradient artwork and explicit colors
- Keep the icon SVG-only with no embedded raster assets

## Official Source

- https://www.google.com/drive/
- https://www.gstatic.com/images/branding/productlogos/docs_2026/v2/web/192px.svg

## Verification

- `rg -n "currentColor|<image|data:image|href=|\\.png|\\.jpg|\\.jpeg|\\.webp|\\.gif|<script|onload|onerror" turbo/apps/platform/src/views/zero-page/components/settings/icons/google-docs.svg`
- `git diff --check`
- `pnpm --filter @vm0/app lint`
- commit hook: prettier, check-file-size, block-generated-firewalls

Closes #16571