### PR TITLE
chore: preserve Gumroad connector icon color

### DIFF
--- a/turbo/apps/platform/src/views/zero-page/components/settings/connector-icons.tsx
+++ b/turbo/apps/platform/src/views/zero-page/components/settings/connector-icons.tsx
@@ -145,6 +145,7 @@ const CONNECTOR_ICON_COLORFUL = {
   granola: true,
   greenhouse: true,
   groq: true,
+  gumroad: true,
   helicone: true,
   heygen: true,
   honcho: true,


### PR DESCRIPTION
## Summary
- add `gumroad` to `CONNECTOR_ICON_COLORFUL` so the official pink connector icon is not inverted in dark theme

## Verification
- `pnpm exec prettier --check apps/platform/src/views/zero-page/components/settings/connector-icons.tsx`
- `pnpm -F @vm0/app lint`
- pre-commit hook: knip and `pnpm check-types`

Closes #16594