### PR TITLE
perf(runner): offload mitm jsonl log writes

### DIFF
--- a/crates/runner/mitm-addon/src/jsonl_writer.py
+++ b/crates/runner/mitm-addon/src/jsonl_writer.py
@@ -1,0 +1,274 @@
+"""Bounded asynchronous JSONL writer for mitmproxy hook paths."""
+
+import os
+import queue
+import threading
+from collections import defaultdict
+from contextlib import suppress
+from dataclasses import dataclass
+
+from mitmproxy import ctx
+
+MAX_PENDING_JSONL_WRITES = 4096
+MAX_PENDING_JSONL_BYTES = 32 * 1024 * 1024
+
+
+@dataclass(frozen=True)
+class _WriteItem:
+    log_path: str
+    line: bytes
+    log_name: str
+    sequence: int
+
+
+_STOP = object()
+_lock = threading.Lock()
+_condition = threading.Condition(_lock)
+_queue: queue.Queue[_WriteItem | object] = queue.Queue(maxsize=MAX_PENDING_JSONL_WRITES)
+_worker: threading.Thread | None = None
+_shutdown = False
+_accepted_by_path: defaultdict[str, int] = defaultdict(int)
+_completed_by_path: defaultdict[str, int] = defaultdict(int)
+_flush_waiters_by_path: defaultdict[str, int] = defaultdict(int)
+_pending_bytes = 0
+_drop_warning_logged = False
+
+
+def write_jsonl_line(log_path: str, line: bytes, log_name: str) -> None:
+    """Queue a JSONL line for best-effort append without blocking hook latency."""
+    global _pending_bytes
+
+    if not log_path:
+        return
+
+    dropped = False
+    with _condition:
+        if _shutdown:
+            _warn(f"Skipping {log_name} log write after JSONL writer shutdown")
+            return
+        line_size = len(line)
+        if _pending_bytes + line_size > MAX_PENDING_JSONL_BYTES:
+            dropped = True
+        elif not _ensure_worker_locked():
+            _warn(f"Failed to start JSONL writer for {log_name} log")
+            return
+        else:
+            sequence = _accepted_by_path.get(log_path, 0) + 1
+            item = _WriteItem(
+                log_path=log_path,
+                line=line,
+                log_name=log_name,
+                sequence=sequence,
+            )
+            try:
+                _queue.put_nowait(item)
+            except queue.Full:
+                dropped = True
+            else:
+                _accepted_by_path[log_path] = sequence
+                _pending_bytes += line_size
+
+    if dropped:
+        _warn_drop_once(log_name)
+
+
+def flush_log_path(log_path: str) -> None:
+    """Wait until all writes accepted so far for ``log_path`` are completed."""
+    if not log_path:
+        return
+
+    with _condition:
+        target = _accepted_by_path.get(log_path, 0)
+        _increment_flush_waiter_locked(log_path)
+        try:
+            while _completed_by_path.get(log_path, 0) < target:
+                _condition.wait()
+        finally:
+            _decrement_flush_waiter_locked(log_path)
+            _prune_completed_path_locked(log_path, target)
+
+
+def flush_all_logs() -> None:
+    """Wait until all writes accepted so far for every path are completed."""
+    with _condition:
+        targets = dict(_accepted_by_path)
+        for path in targets:
+            _increment_flush_waiter_locked(path)
+        try:
+            while any(_completed_by_path.get(path, 0) < target for path, target in targets.items()):
+                _condition.wait()
+        finally:
+            for path in targets:
+                _decrement_flush_waiter_locked(path)
+            for path, target in targets.items():
+                _prune_completed_path_locked(path, target)
+
+
+def shutdown_writer() -> None:
+    """Drain accepted writes and stop the background writer."""
+    global _worker, _shutdown
+
+    with _condition:
+        worker = _worker
+        if worker is None:
+            _shutdown = True
+            return
+        should_signal_stop = not _shutdown
+        _shutdown = True
+
+    if should_signal_stop:
+        _queue.put(_STOP)
+    if worker is not threading.current_thread():
+        worker.join()
+
+    with _condition:
+        if _worker is worker:
+            _worker = None
+        _condition.notify_all()
+
+
+def reset_for_tests() -> None:
+    """Reset writer state between tests."""
+    global _queue, _worker, _shutdown, _accepted_by_path, _completed_by_path, _flush_waiters_by_path
+    global _pending_bytes, _drop_warning_logged
+
+    shutdown_writer()
+    with _condition:
+        _queue = queue.Queue(maxsize=MAX_PENDING_JSONL_WRITES)
+        _worker = None
+        _shutdown = False
+        _accepted_by_path = defaultdict(int)
+        _completed_by_path = defaultdict(int)
+        _flush_waiters_by_path = defaultdict(int)
+        _pending_bytes = 0
+        _drop_warning_logged = False
+        _condition.notify_all()
+
+
+def _ensure_worker_locked() -> bool:
+    global _worker
+
+    if _worker is not None and _worker.is_alive():
+        return True
+
+    worker = threading.Thread(
+        target=_run_writer,
+        name="jsonl-writer",
+        daemon=True,
+    )
+    try:
+        worker.start()
+    except RuntimeError:
+        return False
+    _worker = worker
+    return True
+
+
+def _run_writer() -> None:
+    while True:
+        item = _queue.get()
+        if item is _STOP:
+            _queue.task_done()
+            return
+
+        batch = [item]
+        should_stop = False
+        while True:
+            try:
+                next_item = _queue.get_nowait()
+            except queue.Empty:
+                break
+            if next_item is _STOP:
+                _queue.task_done()
+                should_stop = True
+                break
+            batch.append(next_item)
+
+        _write_batch(batch)
+        for completed in batch:
+            if isinstance(completed, _WriteItem):
+                _complete_item(completed)
+            _queue.task_done()
+
+        if should_stop:
+            return
+
+
+def _write_batch(items: list[object]) -> None:
+    batches: dict[str, list[_WriteItem]] = {}
+    for item in items:
+        if isinstance(item, _WriteItem):
+            batches.setdefault(item.log_path, []).append(item)
+
+    for log_path, path_items in batches.items():
+        if not path_items:
+            continue
+        try:
+            _append_lines(log_path, b"".join(item.line for item in path_items))
+        except Exception as exc:
+            log_name = path_items[0].log_name
+            _warn(f"Failed to write {log_name} log: {type(exc).__name__}: {exc}")
+
+
+def _append_lines(log_path: str, content: bytes) -> None:
+    fd = os.open(log_path, os.O_CREAT | os.O_APPEND | os.O_WRONLY, 0o644)
+    try:
+        written = 0
+        while written < len(content):
+            chunk = os.write(fd, content[written:])
+            if chunk == 0:
+                raise OSError("write returned 0 bytes")
+            written += chunk
+    finally:
+        os.close(fd)
+
+
+def _complete_item(item: _WriteItem) -> None:
+    global _pending_bytes
+
+    with _condition:
+        _completed_by_path[item.log_path] = max(
+            _completed_by_path[item.log_path],
+            item.sequence,
+        )
+        _pending_bytes = max(0, _pending_bytes - len(item.line))
+        _prune_completed_path_locked(item.log_path, item.sequence)
+        _condition.notify_all()
+
+
+def _increment_flush_waiter_locked(log_path: str) -> None:
+    _flush_waiters_by_path[log_path] += 1
+
+
+def _decrement_flush_waiter_locked(log_path: str) -> None:
+    current = _flush_waiters_by_path.get(log_path, 0)
+    if current <= 1:
+        _flush_waiters_by_path.pop(log_path, None)
+    else:
+        _flush_waiters_by_path[log_path] = current - 1
+
+
+def _prune_completed_path_locked(log_path: str, target: int) -> None:
+    if _flush_waiters_by_path.get(log_path, 0) > 0:
+        return
+    if (
+        _accepted_by_path.get(log_path, 0) == target
+        and _completed_by_path.get(log_path, 0) >= target
+    ):
+        _accepted_by_path.pop(log_path, None)
+        _completed_by_path.pop(log_path, None)
+
+
+def _warn_drop_once(log_name: str) -> None:
+    global _drop_warning_logged
+
+    with _condition:
+        if _drop_warning_logged:
+            return
+        _drop_warning_logged = True
+    _warn(f"Dropping {log_name} log because the JSONL writer backlog is full")
+
+
+def _warn(message: str) -> None:
+    with suppress(Exception):
+        ctx.log.warn(message)

--- a/crates/runner/mitm-addon/src/logging_utils.py
+++ b/crates/runner/mitm-addon/src/logging_utils.py
@@ -5,13 +5,13 @@ log entries, and extracting firewall metadata.
 """
 
 import json
-import os
 from collections.abc import Mapping
 from datetime import datetime, timezone
 
 from mitmproxy import ctx, http
 
 import flow_metadata_keys as metadata_keys
+import jsonl_writer
 import network_log_sanitization
 
 _PROXY_LOG_RESERVED_FIELDS = {"timestamp", "level", "message"}
@@ -31,14 +31,27 @@ def _write_jsonl_entry(log_path: str, entry: dict, log_name: str) -> None:
         ctx.log.warn(f"Failed to encode {log_name} log: {type(e).__name__}: {e}")
         return
 
-    try:
-        fd = os.open(log_path, os.O_CREAT | os.O_APPEND | os.O_WRONLY, 0o644)
-        try:
-            os.write(fd, line)
-        finally:
-            os.close(fd)
-    except Exception as e:
-        ctx.log.warn(f"Failed to write {log_name} log: {type(e).__name__}: {e}")
+    jsonl_writer.write_jsonl_line(log_path, line, log_name)
+
+
+def flush_log_path(log_path: str) -> None:
+    """Flush accepted JSONL writes for a path."""
+    jsonl_writer.flush_log_path(log_path)
+
+
+def flush_all_logs() -> None:
+    """Flush accepted JSONL writes for all paths."""
+    jsonl_writer.flush_all_logs()
+
+
+def shutdown_log_writer() -> None:
+    """Drain and stop the JSONL writer."""
+    jsonl_writer.shutdown_writer()
+
+
+def reset_log_writer_for_tests() -> None:
+    """Reset JSONL writer state between tests."""
+    jsonl_writer.reset_for_tests()
 
 
 def log_network_entry(log_path: str, entry: dict) -> None:

--- a/crates/runner/mitm-addon/src/mitm_addon.py
+++ b/crates/runner/mitm-addon/src/mitm_addon.py
@@ -14,12 +14,14 @@ This addon runs on the runner HOST (not inside VMs) and:
 import asyncio
 import functools
 import json
+import os
 import signal
 import tempfile
 import threading
 import time
 import urllib.parse
 from collections.abc import Callable
+from contextlib import suppress
 from pathlib import Path
 
 from mitmproxy import ctx, http, tcp, tls
@@ -49,7 +51,13 @@ from auth import (
     is_billable_firewall,
     request_force_refresh,
 )
-from logging_utils import add_firewall_metadata, log_network_entry, log_proxy_entry
+from logging_utils import (
+    add_firewall_metadata,
+    flush_log_path,
+    log_network_entry,
+    log_proxy_entry,
+    shutdown_log_writer,
+)
 from url_utils import AuthorityValidationError, get_trusted_authority
 
 # HTTP status boundaries used in response-phase classification.
@@ -75,19 +83,26 @@ _USAGE_FLOW_TRACKED = "_usage_flow_tracked"
 _MAX_SAFE_NETWORK_LOG_SIZE = 9_007_199_254_740_991
 _MAX_SAFE_NETWORK_LOG_SIZE_DIGITS = len(str(_MAX_SAFE_NETWORK_LOG_SIZE))
 
-# Runner-triggered usage drain protocol:
+# Runner-triggered flush protocols:
 # - Rust writes `usage-flush-request` with the active usageStateId and a fresh
 #   flushRequestId, then sends SIGUSR1 to this addon process.
 # - This addon flushes buffered usage and writes `usage-pending` with the
 #   matching flushRequestId so the runner can observe a fresh snapshot.
 # - Rust performs a bounded wait for the acknowledged snapshot to have zero
 #   flows, buffered events, and reports before stopping the proxy.
+# - Rust may also write `jsonl-flush-request` for a concrete network log path.
+#   This addon drains accepted JSONL writes for that path and acknowledges with
+#   `jsonl-flush-state` before the runner uploads the file.
 #
 # Keep this in sync with usage/counters.py and the Rust wait path in
 # crates/runner/src/proxy.rs plus crates/runner/src/cmd/start/mod.rs.
 _RUNNER_USAGE_FLUSH_SIGNAL = signal.SIGUSR1
 _usage_flush_requested = threading.Event()
 _usage_flush_signal_lock = threading.Lock()
+_jsonl_flush_state_write_lock = threading.Lock()
+_last_jsonl_flush_request_id: str | None = None
+_JSONL_FLUSH_REQUEST_FILE = "jsonl-flush-request"
+_JSONL_FLUSH_STATE_FILE = "jsonl-flush-state"
 
 # ============================================================================
 # Addon Configuration
@@ -143,11 +158,11 @@ def configure(updated: set[str]) -> None:
 
 
 def _handle_runner_usage_flush_signal(signum: int, _frame: object) -> None:
-    """Schedule runner-requested usage drain from the SIGUSR1 handler.
+    """Schedule runner-requested flush work from the SIGUSR1 handler.
 
     Keep this handler minimal: it may interrupt mitmproxy's event loop, so it
     only records that work is needed and lets the background worker perform
-    file I/O and usage flushing.
+    file I/O, usage flushing, and JSONL flushing.
     """
     del signum
     _usage_flush_requested.set()
@@ -155,13 +170,13 @@ def _handle_runner_usage_flush_signal(signum: int, _frame: object) -> None:
 
 
 def _start_usage_flush_worker() -> None:
-    """Start one usage-flush worker, coalescing repeated signals while active."""
+    """Start one flush worker, coalescing repeated signals while active."""
     if not _usage_flush_signal_lock.acquire(blocking=False):
         return
 
     thread = threading.Thread(
         target=_run_usage_flush_worker,
-        name="usage-flush-request",
+        name="runner-flush-request",
         daemon=True,
     )
     started = False
@@ -184,6 +199,7 @@ def _run_usage_flush_worker() -> None:
         while True:
             _usage_flush_requested.clear()
             _flush_usage_for_runner_request()
+            _flush_jsonl_for_runner_request()
             if not _usage_flush_requested.is_set():
                 return
     finally:
@@ -205,6 +221,82 @@ def _flush_usage_for_runner_request() -> None:
         ctx.log.warn(f"Failed to flush usage events after runner request ({type(exc).__name__})")
     finally:
         usage.write_pending_snapshot(flush_request_id=flush_request_id)
+
+
+def _flush_jsonl_for_runner_request() -> None:
+    global _last_jsonl_flush_request_id
+
+    request = _read_jsonl_flush_request()
+    if request is None:
+        return
+
+    log_path, flush_request_id = request
+    pending = 0
+    try:
+        flush_log_path(log_path)
+    except Exception as exc:
+        pending = 1
+        ctx.log.warn(f"Failed to flush JSONL logs after runner request ({type(exc).__name__})")
+    finally:
+        state_written = _write_jsonl_flush_state(log_path, flush_request_id, pending=pending)
+        if pending == 0 and state_written:
+            _last_jsonl_flush_request_id = flush_request_id
+
+
+def _read_jsonl_flush_request() -> tuple[str, str] | None:
+    marker_path = Path(__file__).resolve().parent / _JSONL_FLUSH_REQUEST_FILE
+    try:
+        marker = json.loads(marker_path.read_text())
+    except (OSError, json.JSONDecodeError):
+        return None
+
+    if not isinstance(marker, dict):
+        return None
+    if marker.get("usageStateId") != usage.current_usage_state_id():
+        return None
+    flush_request_id = marker.get("flushRequestId")
+    if (
+        not isinstance(flush_request_id, str)
+        or not flush_request_id
+        or not _is_safe_jsonl_flush_request_id(flush_request_id)
+        or flush_request_id == _last_jsonl_flush_request_id
+    ):
+        return None
+    log_path = marker.get("path")
+    if not isinstance(log_path, str) or not log_path:
+        return None
+    return log_path, flush_request_id
+
+
+def _is_safe_jsonl_flush_request_id(flush_request_id: str) -> bool:
+    return all(
+        ("a" <= char <= "z") or ("A" <= char <= "Z") or ("0" <= char <= "9") or char in "-_"
+        for char in flush_request_id
+    )
+
+
+def _write_jsonl_flush_state(log_path: str, flush_request_id: str, *, pending: int = 0) -> bool:
+    state_path = Path(__file__).resolve().parent / _JSONL_FLUSH_STATE_FILE
+    state = {
+        "pid": os.getpid(),
+        "usageStateId": usage.current_usage_state_id(),
+        "updatedAtMs": int(time.time() * 1000),
+        "flushRequestId": flush_request_id,
+        "path": log_path,
+        "pending": pending,
+    }
+    tmp_path = state_path.with_name(f"{state_path.name}.{flush_request_id}.tmp")
+    with _jsonl_flush_state_write_lock:
+        try:
+            with tmp_path.open("w") as f:
+                json.dump(state, f, separators=(",", ":"))
+            tmp_path.replace(state_path)
+            return True
+        except OSError as exc:
+            with suppress(OSError):
+                tmp_path.unlink()
+            ctx.log.warn(f"Failed to write JSONL flush state: {type(exc).__name__}: {exc}")
+            return False
 
 
 def get_api_url() -> str:
@@ -1008,7 +1100,10 @@ def done():
         with _usage_flush_signal_lock:
             usage.flush_usage_events(trigger="shutdown")
     finally:
-        usage.webhook.usage_executor.shutdown(wait=True)
+        try:
+            usage.webhook.usage_executor.shutdown(wait=True)
+        finally:
+            shutdown_log_writer()
 
 
 # ============================================================================

--- a/crates/runner/mitm-addon/src/usage/__init__.py
+++ b/crates/runner/mitm-addon/src/usage/__init__.py
@@ -34,6 +34,7 @@ from .buffer import (
     reset_usage_buffer_for_tests,
 )
 from .counters import (
+    current_usage_state_id,
     decrement_in_flight_flows,
     increment_in_flight_flows,
     read_usage_flush_request_id,
@@ -65,6 +66,7 @@ __all__ = [
     "create_connector_response_parser",
     "create_openai_responses_json_usage_extractor",
     "create_openai_responses_sse_usage_extractor",
+    "current_usage_state_id",
     "decrement_in_flight_flows",
     "extract_anthropic_messages_usage_from_json",
     "extract_anthropic_messages_usage_with_error_from_json",

--- a/crates/runner/mitm-addon/src/usage/counters.py
+++ b/crates/runner/mitm-addon/src/usage/counters.py
@@ -61,6 +61,12 @@ def set_pending_path(path: str, usage_state_id: str | None = None) -> None:
     _write_pending_state(pending_path, state)
 
 
+def current_usage_state_id() -> str:
+    """Return the current runner-generated usage state id."""
+    with _counter_lock:
+        return _usage_state_id
+
+
 def _pending_snapshot_locked(flush_request_id: str | None = None) -> tuple[str, dict[str, Any]]:
     state: dict[str, Any] = {
         "pid": os.getpid(),

--- a/crates/runner/mitm-addon/tests/conftest.py
+++ b/crates/runner/mitm-addon/tests/conftest.py
@@ -17,6 +17,7 @@ import contextlib
 import json
 from collections.abc import Callable, Iterator
 from concurrent.futures import Future, ThreadPoolExecutor
+from pathlib import Path
 from typing import Any
 from unittest.mock import AsyncMock, MagicMock, patch
 
@@ -26,6 +27,7 @@ from mitmproxy.test import tflow, tutils
 
 import auth
 import auth_base_forwarder
+import logging_utils
 import mitm_addon
 import registry
 import usage
@@ -35,7 +37,7 @@ from usage.providers import connectors as _usage_connectors
 
 
 @pytest.fixture(autouse=True)
-def _reset_module_state() -> Iterator[None]:
+def _reset_module_state(monkeypatch: pytest.MonkeyPatch) -> Iterator[None]:
     """Clear cached singletons between tests.
 
     ``registry`` and ``auth`` cache registry data and firewall header
@@ -52,7 +54,29 @@ def _reset_module_state() -> Iterator[None]:
     usage.counters.reset_for_tests()
     usage.webhook.reset_delivery_capacity_for_tests()
     usage.reset_usage_buffer_for_tests()
+    logging_utils.reset_log_writer_for_tests()
+
+    original_read_text = Path.read_text
+    original_exists = Path.exists
+
+    def read_text_after_jsonl_flush(
+        path: Path,
+        *args: Any,
+        **kwargs: Any,
+    ) -> str:
+        if path.suffix == ".jsonl":
+            logging_utils.flush_all_logs()
+        return original_read_text(path, *args, **kwargs)
+
+    def exists_after_jsonl_flush(path: Path) -> bool:
+        if path.suffix == ".jsonl":
+            logging_utils.flush_all_logs()
+        return original_exists(path)
+
+    monkeypatch.setattr(Path, "read_text", read_text_after_jsonl_flush)
+    monkeypatch.setattr(Path, "exists", exists_after_jsonl_flush)
     yield
+    logging_utils.reset_log_writer_for_tests()
     auth_base_forwarder.reset_forward_request_state_for_tests()
     usage.reset_usage_buffer_for_tests()
     usage.webhook.reset_delivery_capacity_for_tests()

--- a/crates/runner/mitm-addon/tests/test_connection_hooks.py
+++ b/crates/runner/mitm-addon/tests/test_connection_hooks.py
@@ -10,6 +10,7 @@ import pytest
 from mitmproxy.flow import Error
 
 import flow_metadata_keys as metadata_keys
+import logging_utils
 import mitm_addon
 import registry
 import usage
@@ -26,6 +27,7 @@ def wait_for_usage_flush_worker_to_stop(timeout: float = 1.0) -> None:
 
 def reset_runner_usage_flush_state() -> None:
     mitm_addon._usage_flush_requested.clear()
+    mitm_addon._last_jsonl_flush_request_id = None
     wait_for_usage_flush_worker_to_stop()
 
 
@@ -38,11 +40,13 @@ class TestDoneHook:
         with (
             patch.object(usage, "flush_usage_events") as flush_usage_events,
             patch.object(usage.webhook, "usage_executor", mock_executor),
+            patch.object(mitm_addon, "shutdown_log_writer") as shutdown_log_writer,
         ):
             mitm_addon.done()
         flush_usage_events.assert_called_once_with(trigger="shutdown")
         # concurrent.futures boundary: done() must gracefully shut down the pool (#9991).
         mock_executor.shutdown.assert_called_once_with(wait=True)
+        shutdown_log_writer.assert_called_once_with()
 
     def test_done_waits_for_runner_flush_before_executor_shutdown(self):
         """done() must not shut down the executor while a SIGUSR1 flush is enqueueing."""
@@ -93,6 +97,7 @@ class TestDoneHook:
             patch.object(mitm_addon, "_usage_flush_signal_lock", lock),
             patch.object(usage, "flush_usage_events", side_effect=flush_usage_events),
             patch.object(usage.webhook, "usage_executor", mock_executor),
+            patch.object(mitm_addon, "shutdown_log_writer", lambda: calls.append("jsonl:shutdown")),
         ):
             mitm_addon._handle_runner_usage_flush_signal(0, None)
             assert runner_flush_started.wait(timeout=1)
@@ -106,7 +111,7 @@ class TestDoneHook:
             done_thread.join(timeout=1)
 
         assert not done_thread.is_alive()
-        assert calls == ["flush:runner", "flush:shutdown", "shutdown:True"]
+        assert calls == ["flush:runner", "flush:shutdown", "shutdown:True", "jsonl:shutdown"]
 
     def test_done_shuts_down_executor_when_flush_fails(self):
         mock_executor = MagicMock()
@@ -118,12 +123,14 @@ class TestDoneHook:
                 side_effect=RuntimeError("flush failed"),
             ) as flush_usage_events,
             patch.object(usage.webhook, "usage_executor", mock_executor),
+            patch.object(mitm_addon, "shutdown_log_writer") as shutdown_log_writer,
             pytest.raises(RuntimeError, match="flush failed"),
         ):
             mitm_addon.done()
 
         flush_usage_events.assert_called_once_with(trigger="shutdown")
         mock_executor.shutdown.assert_called_once_with(wait=True)
+        shutdown_log_writer.assert_called_once_with()
 
 
 class TestRunnerUsageFlushSignal:
@@ -233,6 +240,196 @@ class TestRunnerUsageFlushSignal:
             )
         finally:
             usage.counters.decrement_pending_reports()
+            usage.set_pending_path("")
+
+    def test_signal_handler_acknowledges_jsonl_flush_request(self, tmp_path):
+        reset_runner_usage_flush_state()
+        pending_path = tmp_path / "usage-pending"
+        request_path = tmp_path / "jsonl-flush-request"
+        state_path = tmp_path / "jsonl-flush-state"
+        log_path = tmp_path / "network.jsonl"
+        usage.set_pending_path(str(pending_path), usage_state_id="runner-state")
+        request_path.write_text(
+            json.dumps(
+                {
+                    "usageStateId": "runner-state",
+                    "flushRequestId": "jsonl-request-1",
+                    "requestedAtMs": 1_770_000_000_000,
+                    "path": str(log_path),
+                }
+            )
+        )
+
+        try:
+            with (
+                patch.object(mitm_addon, "__file__", str(tmp_path / "mitm_addon.py")),
+                patch.object(logging_utils.ctx, "log", MagicMock(), create=True),
+            ):
+                logging_utils.log_network_entry(str(log_path), {"action": "ALLOW"})
+                mitm_addon._handle_runner_usage_flush_signal(0, None)
+                wait_for_usage_flush_worker_to_stop()
+
+            entry = json.loads(log_path.read_text().strip())
+            assert entry["action"] == "ALLOW"
+            state = json.loads(state_path.read_text())
+            assert state == {
+                "pid": state["pid"],
+                "usageStateId": "runner-state",
+                "updatedAtMs": state["updatedAtMs"],
+                "flushRequestId": "jsonl-request-1",
+                "path": str(log_path),
+                "pending": 0,
+            }
+        finally:
+            usage.set_pending_path("")
+
+    def test_jsonl_flush_request_rejects_unsafe_request_id(self, tmp_path):
+        reset_runner_usage_flush_state()
+        pending_path = tmp_path / "usage-pending"
+        request_path = tmp_path / "jsonl-flush-request"
+        state_path = tmp_path / "jsonl-flush-state"
+        log_path = tmp_path / "network.jsonl"
+        usage.set_pending_path(str(pending_path), usage_state_id="runner-state")
+        request_path.write_text(
+            json.dumps(
+                {
+                    "usageStateId": "runner-state",
+                    "flushRequestId": "../jsonl-request-1",
+                    "requestedAtMs": 1_770_000_000_000,
+                    "path": str(log_path),
+                }
+            )
+        )
+
+        try:
+            with (
+                patch.object(mitm_addon, "__file__", str(tmp_path / "mitm_addon.py")),
+                patch.object(mitm_addon, "flush_log_path") as flush_log_path,
+            ):
+                mitm_addon._handle_runner_usage_flush_signal(0, None)
+                wait_for_usage_flush_worker_to_stop()
+
+            flush_log_path.assert_not_called()
+            assert not state_path.exists()
+        finally:
+            usage.set_pending_path("")
+
+    def test_jsonl_flush_failure_writes_pending_state(self, tmp_path):
+        reset_runner_usage_flush_state()
+        pending_path = tmp_path / "usage-pending"
+        request_path = tmp_path / "jsonl-flush-request"
+        state_path = tmp_path / "jsonl-flush-state"
+        log_path = tmp_path / "network.jsonl"
+        log = MagicMock()
+        usage.set_pending_path(str(pending_path), usage_state_id="runner-state")
+        request_path.write_text(
+            json.dumps(
+                {
+                    "usageStateId": "runner-state",
+                    "flushRequestId": "jsonl-request-1",
+                    "requestedAtMs": 1_770_000_000_000,
+                    "path": str(log_path),
+                }
+            )
+        )
+
+        try:
+            with (
+                patch.object(mitm_addon, "__file__", str(tmp_path / "mitm_addon.py")),
+                patch.object(mitm_addon, "flush_log_path", side_effect=RuntimeError("secret")),
+                patch.object(mitm_addon.ctx, "log", log, create=True),
+            ):
+                mitm_addon._handle_runner_usage_flush_signal(0, None)
+                wait_for_usage_flush_worker_to_stop()
+
+            state = json.loads(state_path.read_text())
+            assert state == {
+                "pid": state["pid"],
+                "usageStateId": "runner-state",
+                "updatedAtMs": state["updatedAtMs"],
+                "flushRequestId": "jsonl-request-1",
+                "path": str(log_path),
+                "pending": 1,
+            }
+            log.warn.assert_called_once()
+            warning = log.warn.call_args.args[0]
+            assert "RuntimeError" in warning
+            assert "secret" not in warning
+        finally:
+            usage.set_pending_path("")
+
+    def test_signal_handler_does_not_reprocess_acknowledged_jsonl_flush_request(self, tmp_path):
+        reset_runner_usage_flush_state()
+        pending_path = tmp_path / "usage-pending"
+        request_path = tmp_path / "jsonl-flush-request"
+        log_path = tmp_path / "network.jsonl"
+        usage.set_pending_path(str(pending_path), usage_state_id="runner-state")
+        request_path.write_text(
+            json.dumps(
+                {
+                    "usageStateId": "runner-state",
+                    "flushRequestId": "jsonl-request-1",
+                    "requestedAtMs": 1_770_000_000_000,
+                    "path": str(log_path),
+                }
+            )
+        )
+
+        try:
+            with (
+                patch.object(mitm_addon, "__file__", str(tmp_path / "mitm_addon.py")),
+                patch.object(mitm_addon, "flush_log_path") as flush_log_path,
+                patch.object(mitm_addon.ctx, "log", MagicMock(), create=True),
+            ):
+                mitm_addon._handle_runner_usage_flush_signal(0, None)
+                wait_for_usage_flush_worker_to_stop()
+                mitm_addon._handle_runner_usage_flush_signal(0, None)
+                wait_for_usage_flush_worker_to_stop()
+
+            flush_log_path.assert_called_once_with(str(log_path))
+        finally:
+            usage.set_pending_path("")
+
+    def test_jsonl_flush_failure_is_retryable(self, tmp_path):
+        reset_runner_usage_flush_state()
+        pending_path = tmp_path / "usage-pending"
+        request_path = tmp_path / "jsonl-flush-request"
+        state_path = tmp_path / "jsonl-flush-state"
+        log_path = tmp_path / "network.jsonl"
+        usage.set_pending_path(str(pending_path), usage_state_id="runner-state")
+        request_path.write_text(
+            json.dumps(
+                {
+                    "usageStateId": "runner-state",
+                    "flushRequestId": "jsonl-request-1",
+                    "requestedAtMs": 1_770_000_000_000,
+                    "path": str(log_path),
+                }
+            )
+        )
+
+        try:
+            with (
+                patch.object(mitm_addon, "__file__", str(tmp_path / "mitm_addon.py")),
+                patch.object(mitm_addon.ctx, "log", MagicMock(), create=True),
+            ):
+                with patch.object(
+                    mitm_addon,
+                    "flush_log_path",
+                    side_effect=RuntimeError("flush failed"),
+                ) as failed_flush:
+                    mitm_addon._handle_runner_usage_flush_signal(0, None)
+                    wait_for_usage_flush_worker_to_stop()
+
+                with patch.object(mitm_addon, "flush_log_path") as retry_flush:
+                    mitm_addon._handle_runner_usage_flush_signal(0, None)
+                    wait_for_usage_flush_worker_to_stop()
+
+            failed_flush.assert_called_once_with(str(log_path))
+            retry_flush.assert_called_once_with(str(log_path))
+            state = json.loads(state_path.read_text())
+            assert state["pending"] == 0
+        finally:
             usage.set_pending_path("")
 
     def test_runner_flush_failure_warns_without_error_text(self):

--- a/crates/runner/mitm-addon/tests/test_logging_utils.py
+++ b/crates/runner/mitm-addon/tests/test_logging_utils.py
@@ -1,10 +1,13 @@
 """Tests for mitm addon logging utilities."""
 
 import json
+import queue
+import threading
 from pathlib import Path
 from unittest.mock import MagicMock, patch
 
 import flow_metadata_keys as metadata_keys
+import jsonl_writer
 import logging_utils
 from tests.timestamp_helpers import assert_utc_millisecond_timestamp
 
@@ -61,6 +64,7 @@ class TestLogNetworkEntry:
 
         with patch.object(logging_utils.ctx, "log", log, create=True):
             logging_utils.log_network_entry(str(log_path), {"action": "ALLOW"})
+            logging_utils.flush_log_path(str(log_path))
 
         log.warn.assert_called_once()
         warning = log.warn.call_args.args[0]
@@ -78,6 +82,106 @@ class TestLogNetworkEntry:
         warning = log.warn.call_args.args[0]
         assert "Failed to encode network log: TypeError:" in warning
         assert not log_path.exists()
+
+    def test_full_backlog_warns_without_creating_file(self, tmp_path):
+        log_path = tmp_path / "net.jsonl"
+        log = MagicMock()
+
+        with (
+            patch.object(jsonl_writer, "MAX_PENDING_JSONL_BYTES", 1),
+            patch.object(logging_utils.ctx, "log", log, create=True),
+        ):
+            logging_utils.log_network_entry(str(log_path), {"action": "ALLOW"})
+
+        log.warn.assert_called_once()
+        warning = log.warn.call_args.args[0]
+        assert warning == "Dropping network log because the JSONL writer backlog is full"
+        assert not log_path.exists()
+
+    def test_full_write_queue_does_not_track_dropped_path_state(self, tmp_path):
+        log_path = str(tmp_path / "net.jsonl")
+        log = MagicMock()
+
+        with (
+            patch.object(jsonl_writer, "_ensure_worker_locked", return_value=True),
+            patch.object(jsonl_writer._queue, "put_nowait", side_effect=queue.Full),
+            patch.object(logging_utils.ctx, "log", log, create=True),
+        ):
+            logging_utils.log_network_entry(log_path, {"action": "ALLOW"})
+
+        log.warn.assert_called_once()
+        warning = log.warn.call_args.args[0]
+        assert warning == "Dropping network log because the JSONL writer backlog is full"
+        assert log_path not in jsonl_writer._accepted_by_path
+        assert log_path not in jsonl_writer._completed_by_path
+        assert log_path not in jsonl_writer._flush_waiters_by_path
+        assert not Path(log_path).exists()
+
+    def test_completed_write_prunes_path_state_without_explicit_flush(self, tmp_path):
+        log_path = str(tmp_path / "proxy.jsonl")
+
+        with patch.object(logging_utils.ctx, "log", MagicMock(), create=True):
+            logging_utils.log_proxy_entry(log_path, "info", "done")
+            jsonl_writer._queue.join()
+
+        assert log_path not in jsonl_writer._accepted_by_path
+        assert log_path not in jsonl_writer._completed_by_path
+        assert log_path not in jsonl_writer._flush_waiters_by_path
+        assert Path(log_path).read_text().splitlines()
+
+    def test_flush_prunes_completed_path_state(self, tmp_path):
+        log_path = str(tmp_path / "net.jsonl")
+
+        with patch.object(logging_utils.ctx, "log", MagicMock(), create=True):
+            logging_utils.log_network_entry(log_path, {"action": "ALLOW"})
+            logging_utils.flush_log_path(log_path)
+
+        assert log_path not in jsonl_writer._accepted_by_path
+        assert log_path not in jsonl_writer._completed_by_path
+
+    def test_concurrent_flushes_prune_after_all_waiters_complete(self, tmp_path):
+        log_path = str(tmp_path / "net.jsonl")
+        append_started = threading.Event()
+        release_append = threading.Event()
+        flush_threads: list[threading.Thread] = []
+        original_append_lines = jsonl_writer._append_lines
+
+        def append_lines(path: str, content: bytes) -> None:
+            append_started.set()
+            release_append.wait()
+            original_append_lines(path, content)
+
+        with (
+            patch.object(logging_utils.ctx, "log", MagicMock(), create=True),
+            patch.object(jsonl_writer, "_append_lines", side_effect=append_lines),
+        ):
+            try:
+                logging_utils.log_network_entry(log_path, {"action": "ALLOW"})
+                assert append_started.wait(timeout=1)
+
+                flush_threads = [
+                    threading.Thread(target=logging_utils.flush_log_path, args=(log_path,)),
+                    threading.Thread(target=logging_utils.flush_log_path, args=(log_path,)),
+                ]
+                for thread in flush_threads:
+                    thread.start()
+
+                with jsonl_writer._condition:
+                    assert jsonl_writer._condition.wait_for(
+                        lambda: jsonl_writer._flush_waiters_by_path.get(log_path, 0) == 2,
+                        timeout=1,
+                    )
+            finally:
+                release_append.set()
+                for thread in flush_threads:
+                    thread.join(timeout=1)
+
+        for thread in flush_threads:
+            assert not thread.is_alive()
+
+        assert log_path not in jsonl_writer._accepted_by_path
+        assert log_path not in jsonl_writer._completed_by_path
+        assert log_path not in jsonl_writer._flush_waiters_by_path
 
 
 class TestAddFirewallMetadata:

--- a/crates/runner/mitm-addon/tests/test_utils.py
+++ b/crates/runner/mitm-addon/tests/test_utils.py
@@ -158,6 +158,7 @@ class TestLogProxyEntry:
             logging_utils.log_proxy_entry(
                 str(tmp_path / "missing" / "proxy.jsonl"), "warn", "message"
             )
+            logging_utils.flush_log_path(str(tmp_path / "missing" / "proxy.jsonl"))
 
         log.warn.assert_called_once()
         warning = log.warn.call_args.args[0]
@@ -169,6 +170,7 @@ class TestLogProxyEntry:
 
         with patch.object(logging_utils.ctx, "log", log, create=True):
             logging_utils.log_proxy_entry(str(tmp_path), "warn", "message")
+            logging_utils.flush_log_path(str(tmp_path))
 
         log.warn.assert_called_once()
         warning = log.warn.call_args.args[0]

--- a/crates/runner/src/cmd/start/job_spawn.rs
+++ b/crates/runner/src/cmd/start/job_spawn.rs
@@ -380,6 +380,16 @@ impl DeferredUploadPhase {
                 .network_log_manager
                 .flush_path(&network_log_path)
                 .await;
+            if let Some(mitm_jsonl_flush) = exec_config.mitm_jsonl_flush.as_ref() {
+                let flushed = mitm_jsonl_flush.flush_path(&network_log_path).await;
+                if !flushed {
+                    warn!(
+                        run_id = %run_id,
+                        path = %network_log_path.display(),
+                        "proxy network log flush did not complete before upload"
+                    );
+                }
+            }
             network_logs::upload_network_logs(
                 &exec_config.http,
                 run_id,

--- a/crates/runner/src/cmd/start/mod.rs
+++ b/crates/runner/src/cmd/start/mod.rs
@@ -34,6 +34,7 @@ use std::time::{Duration, Instant};
 
 use clap::Args;
 use sandbox::{RuntimeProvider, SandboxRuntime};
+use tokio::sync::mpsc;
 use tokio::task::JoinSet;
 use tokio_util::sync::CancellationToken;
 use tracing::{info, warn};
@@ -453,6 +454,7 @@ pub async fn run_start(
     let group = runner_config.group;
     let cancel_tokens: Arc<tokio::sync::Mutex<HashMap<RunId, CancellationToken>>> =
         Arc::new(tokio::sync::Mutex::new(HashMap::new()));
+    let (usage_flush_tx, usage_flush_rx) = mpsc::channel(1);
 
     let (provider, group_name): (Arc<dyn JobProvider>, String) = if args.local {
         let group_dir = home.groups_dir().join(&group);
@@ -490,6 +492,7 @@ pub async fn run_start(
         log_paths,
         network_log_manager,
         network_log_drain,
+        mitm_jsonl_flush: Some(mitm.jsonl_flush_handle(usage_flush_tx.clone())),
         home: home.clone(),
         workspace_cache: Some(SessionWorkspaceCache::shared(
             paths.clone(),
@@ -539,6 +542,8 @@ pub async fn run_start(
             dns_handle,
             memory_prefetch,
         },
+        usage_flush_tx,
+        usage_flush_rx,
         signals: SignalState {
             signal_source: SignalSource::Real(signals),
         },
@@ -565,6 +570,8 @@ struct RunConfig {
     proxy: ProxyState,
     exec_config: Arc<ExecutorConfig>,
     shutdown: ShutdownHandles,
+    usage_flush_tx: mpsc::Sender<()>,
+    usage_flush_rx: mpsc::Receiver<()>,
     signals: SignalState,
     orphan_reap: OrphanReapState,
     #[cfg(test)]
@@ -927,6 +934,8 @@ async fn run(config: RunConfig) -> RunnerResult<()> {
         proxy,
         exec_config,
         shutdown,
+        usage_flush_tx,
+        mut usage_flush_rx,
         signals,
         orphan_reap,
         #[cfg(test)]
@@ -1028,7 +1037,6 @@ async fn run(config: RunConfig) -> RunnerResult<()> {
     // learns about a held session VM or workspace image cache without waiting
     // for the next 10-second tick.
     let park_notify = Arc::new(tokio::sync::Notify::new());
-    let (usage_flush_tx, mut usage_flush_rx) = tokio::sync::mpsc::channel(1);
     let orphaned_active_runs = OrphanedActiveRuns::new();
     let active_sessions = new_active_sessions();
     let mut orphan_reap_tick = tokio::time::interval_at(

--- a/crates/runner/src/cmd/start/tests/main_loop.rs
+++ b/crates/runner/src/cmd/start/tests/main_loop.rs
@@ -49,6 +49,7 @@ async fn install_usage_flush_child(config: &mut RunConfig) {
     use std::os::unix::fs::PermissionsExt;
     use tokio::io::AsyncBufReadExt;
 
+    std::fs::create_dir_all(config.paths.base_dir.join("mitm-addon")).unwrap();
     let script = config.paths.base_dir.join("usage-flush-child.sh");
     std::fs::write(
         &script,
@@ -58,6 +59,8 @@ fifo="$0.fifo"
 base_dir="$(dirname "$0")"
 request="$base_dir/mitm-addon/usage-flush-request"
 pending="$base_dir/mitm-addon/usage-pending"
+jsonl_request="$base_dir/mitm-addon/jsonl-flush-request"
+jsonl_state="$base_dir/mitm-addon/jsonl-flush-state"
 write_pending_snapshot() {
   [[ -f "$request" ]] || return 0
   flush_id="$(sed -n 's/.*"flushRequestId":"\([^"]*\)".*/\1/p' "$request")"
@@ -66,9 +69,22 @@ write_pending_snapshot() {
   now_ms="$(date +%s%3N)"
   printf '{"pid":%s,"usageStateId":"%s","updatedAtMs":%s,"flows":0,"buffered":0,"reports":0,"flushRequestId":"%s"}' "$$" "$state_id" "$now_ms" "$flush_id" > "$pending"
 }
+write_jsonl_flush_state() {
+  [[ -f "$jsonl_request" ]] || return 0
+  flush_id="$(sed -n 's/.*"flushRequestId":"\([^"]*\)".*/\1/p' "$jsonl_request")"
+  state_id="$(sed -n 's/.*"usageStateId":"\([^"]*\)".*/\1/p' "$jsonl_request")"
+  path="$(sed -n 's/.*"path":"\([^"]*\)".*/\1/p' "$jsonl_request")"
+  [[ -n "$flush_id" && -n "$state_id" && -n "$path" ]] || return 0
+  now_ms="$(date +%s%3N)"
+  printf '{"pid":%s,"usageStateId":"%s","updatedAtMs":%s,"flushRequestId":"%s","path":"%s","pending":0}' "$$" "$state_id" "$now_ms" "$flush_id" "$path" > "$jsonl_state"
+}
+handle_flush_request() {
+  write_pending_snapshot
+  write_jsonl_flush_state
+}
 mkfifo "$fifo"
 exec 3<>"$fifo"
-trap write_pending_snapshot USR1
+trap handle_flush_request USR1
 trap 'exit 0' TERM
 echo ready
 while true; do read -r _ <&3 || true; done
@@ -203,13 +219,21 @@ async fn deferred_network_log_upload_drains_on_graceful_shutdown() {
 
     let (mut config, env) =
         mock_run_config_with_api_url(test_profiles(), 8, 32768, 4, &server.base_url());
+    install_usage_flush_child(&mut config).await;
+    let addon_dir = config.paths.base_dir.join("mitm-addon");
+    config.proxy.mitm.set_addon_dir_for_test(addon_dir.clone());
+    let mitm_jsonl_flush = config
+        .proxy
+        .mitm
+        .jsonl_flush_handle(config.usage_flush_tx.clone());
     let write_started = Arc::new(tokio::sync::Notify::new());
     let release_write = Arc::new(tokio::sync::Semaphore::new(0));
     let network_log_manager =
         NetworkLogManager::new_with_write_gate(write_started.clone(), release_write.clone());
-    Arc::get_mut(&mut config.exec_config)
-        .expect("test config should not share exec_config before run starts")
-        .network_log_manager = network_log_manager.clone();
+    let exec_config = Arc::get_mut(&mut config.exec_config)
+        .expect("test config should not share exec_config before run starts");
+    exec_config.network_log_manager = network_log_manager.clone();
+    exec_config.mitm_jsonl_flush = Some(mitm_jsonl_flush);
 
     // Seed a network log file so `upload_network_logs` has a payload to POST
     // (otherwise it early-returns on NotFound and the assertion below would
@@ -264,6 +288,22 @@ async fn deferred_network_log_upload_drains_on_graceful_shutdown() {
     let shutdown_elapsed = shutdown_start.elapsed();
 
     network_log_mock.assert_calls_async(1).await;
+    let jsonl_request: serde_json::Value = serde_json::from_str(
+        &std::fs::read_to_string(addon_dir.join("jsonl-flush-request")).unwrap(),
+    )
+    .unwrap();
+    let jsonl_state: serde_json::Value = serde_json::from_str(
+        &std::fs::read_to_string(addon_dir.join("jsonl-flush-state")).unwrap(),
+    )
+    .unwrap();
+    let network_log_path_string = network_log_path.to_string_lossy().to_string();
+    assert_eq!(jsonl_request["path"], network_log_path_string);
+    assert_eq!(
+        jsonl_state["flushRequestId"],
+        jsonl_request["flushRequestId"]
+    );
+    assert_eq!(jsonl_state["path"], network_log_path_string);
+    assert_eq!(jsonl_state["pending"], 0);
 
     // Stronger invariant: drain must actually WAIT for the deferred work.
     // With a 400 ms mock delay, a well-behaved drain takes ≥ the delay;

--- a/crates/runner/src/cmd/start/tests/support/env.rs
+++ b/crates/runner/src/cmd/start/tests/support/env.rs
@@ -162,6 +162,7 @@ fn build_mock_run_config_with_runtime(
     std::fs::create_dir_all(&log_dir).unwrap();
 
     let (mitm, mitm_crash_rx) = proxy::MitmProxy::noop();
+    let (usage_flush_tx, usage_flush_rx) = mpsc::channel(1);
     let min_vcpu = profiles_min_vcpu(&profiles);
     let min_memory_mb = profiles_min_memory(&profiles);
     let idle_pool: SharedIdlePool =
@@ -232,6 +233,7 @@ fn build_mock_run_config_with_runtime(
             log_paths: crate::paths::LogPaths::new(log_dir),
             network_log_manager: NetworkLogManager::new(),
             network_log_drain: NetworkLogDrainCoordinator::noop(),
+            mitm_jsonl_flush: None,
             home,
             workspace_cache: None,
         }),
@@ -240,6 +242,8 @@ fn build_mock_run_config_with_runtime(
             dns_handle: crate::dns::DnsProxy::noop(),
             memory_prefetch: prefetch::MemoryPrefetchTasks::empty(),
         },
+        usage_flush_tx,
+        usage_flush_rx,
         signals: SignalState {
             signal_source: SignalSource::Override(SignalController {
                 mode_rx,

--- a/crates/runner/src/executor/mod.rs
+++ b/crates/runner/src/executor/mod.rs
@@ -102,7 +102,7 @@ use crate::network_log_drain::NetworkLogDrainCoordinator;
 use crate::network_log_manager::NetworkLogManager;
 use crate::network_log_manager::NetworkLogSession;
 use crate::paths::{HomePaths, LogPaths};
-use crate::proxy::ProxyRegistryHandle;
+use crate::proxy::{MitmJsonlFlushHandle, ProxyRegistryHandle};
 use crate::telemetry::JobTelemetry;
 use crate::types::{ExecutionContext, SandboxReuseResult};
 use crate::workspace_image_cache::{
@@ -134,6 +134,7 @@ pub struct ExecutorConfig {
     pub log_paths: LogPaths,
     pub network_log_manager: NetworkLogManager,
     pub network_log_drain: NetworkLogDrainCoordinator,
+    pub mitm_jsonl_flush: Option<MitmJsonlFlushHandle>,
     pub home: HomePaths,
     pub workspace_cache: Option<SessionWorkspaceCache>,
 }

--- a/crates/runner/src/executor/tests/mod.rs
+++ b/crates/runner/src/executor/tests/mod.rs
@@ -299,6 +299,7 @@ async fn test_executor_config(dir: &std::path::Path) -> ExecutorConfig {
         log_paths: LogPaths::new(log_dir),
         network_log_manager: NetworkLogManager::new(),
         network_log_drain: NetworkLogDrainCoordinator::noop(),
+        mitm_jsonl_flush: None,
         home: HomePaths::with_root(dir.to_path_buf()),
         workspace_cache: None,
     }

--- a/crates/runner/src/proxy.rs
+++ b/crates/runner/src/proxy.rs
@@ -1,12 +1,12 @@
 use std::collections::HashMap;
 use std::path::{Path, PathBuf};
-use std::sync::Arc;
 use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::{Arc, Mutex};
 use std::time::{Duration, SystemTime, UNIX_EPOCH};
 
 use serde::{Deserialize, Serialize};
 use tokio::io::AsyncBufReadExt;
-use tokio::sync::mpsc;
+use tokio::sync::{Mutex as AsyncMutex, mpsc};
 use tracing::{info, warn};
 use uuid::Uuid;
 
@@ -87,12 +87,21 @@ const STOP_TIMEOUT: Duration = Duration::from_secs(10);
 /// headroom for request delivery and mitmproxy event-loop drain.
 pub const USAGE_FLUSH_TIMEOUT: Duration = Duration::from_secs(30);
 
+/// Maximum time to wait for mitmproxy JSONL writes to become visible before upload.
+pub const JSONL_FLUSH_TIMEOUT: Duration = Duration::from_secs(5);
+
 /// Poll interval when waiting for usage flush.
 const USAGE_FLUSH_POLL: Duration = Duration::from_millis(200);
 
 /// Minimum interval between repeated runner-triggered usage flush requests
 /// while the addon is not ready.
 const USAGE_FLUSH_REQUEST_INTERVAL: Duration = Duration::from_secs(1);
+
+/// Poll interval when waiting for a single JSONL path flush.
+const JSONL_FLUSH_POLL: Duration = Duration::from_millis(50);
+
+/// Minimum interval between repeated JSONL flush signals while the addon is not ready.
+const JSONL_FLUSH_REQUEST_INTERVAL: Duration = Duration::from_millis(250);
 
 /// Tolerated wall-clock skew when validating addon timestamps.
 const USAGE_PENDING_CLOCK_SKEW: Duration = Duration::from_secs(300);
@@ -157,6 +166,66 @@ impl From<&UsagePendingState> for UsagePendingSnapshot {
     }
 }
 
+#[derive(Debug, Clone)]
+struct JsonlFlushRequest {
+    expected_usage_state_id: String,
+    usage_state_started_at_ms: u64,
+    flush_request_id: String,
+    requested_at_ms: u64,
+    path: String,
+}
+
+#[derive(Debug, Serialize)]
+#[serde(rename_all = "camelCase")]
+struct JsonlFlushRequestMarker<'a> {
+    usage_state_id: &'a str,
+    flush_request_id: &'a str,
+    requested_at_ms: u64,
+    path: &'a str,
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
+struct JsonlFlushState {
+    pid: u32,
+    usage_state_id: String,
+    updated_at_ms: u64,
+    flush_request_id: String,
+    path: String,
+    pending: u32,
+}
+
+#[derive(Debug, Clone)]
+struct JsonlFlushSnapshot {
+    pid: u32,
+    usage_state_id: String,
+    updated_at_ms: u64,
+    flush_request_id: String,
+    path: String,
+    pending: u32,
+}
+
+impl From<&JsonlFlushState> for JsonlFlushSnapshot {
+    fn from(state: &JsonlFlushState) -> Self {
+        Self {
+            pid: state.pid,
+            usage_state_id: state.usage_state_id.clone(),
+            updated_at_ms: state.updated_at_ms,
+            flush_request_id: state.flush_request_id.clone(),
+            path: state.path.clone(),
+            pending: state.pending,
+        }
+    }
+}
+
+#[derive(Clone)]
+pub struct MitmJsonlFlushHandle {
+    addon_dir: PathBuf,
+    usage_state: Arc<Mutex<UsageFlushTarget>>,
+    request_lock: Arc<AsyncMutex<()>>,
+    request_flush_tx: mpsc::Sender<()>,
+}
+
 /// Configuration for starting the proxy.
 #[derive(Clone)]
 pub struct ProxyConfig {
@@ -187,6 +256,8 @@ pub struct MitmProxy {
     usage_state_id: String,
     /// Host timestamp from when `usage_state_id` was minted.
     usage_state_started_at_ms: u64,
+    usage_flush_state: Arc<Mutex<UsageFlushTarget>>,
+    jsonl_flush_request_lock: Arc<AsyncMutex<()>>,
 }
 
 impl MitmProxy {
@@ -231,6 +302,11 @@ impl MitmProxy {
 
         let (crash_tx, crash_rx) = mpsc::channel(1);
         let (usage_state_id, usage_state_started_at_ms) = new_usage_state_id();
+        let usage_flush_state = Arc::new(Mutex::new(UsageFlushTarget {
+            expected_usage_state_id: usage_state_id.clone(),
+            usage_state_started_at_ms,
+        }));
+        let jsonl_flush_request_lock = Arc::new(AsyncMutex::new(()));
 
         Ok((
             Self {
@@ -241,6 +317,8 @@ impl MitmProxy {
                 stopping: Arc::new(AtomicBool::new(false)),
                 usage_state_id,
                 usage_state_started_at_ms,
+                usage_flush_state,
+                jsonl_flush_request_lock,
             },
             crash_rx,
         ))
@@ -274,6 +352,16 @@ impl MitmProxy {
         ProxyRegistryHandle {
             registry_path: self.config.registry_path.clone(),
             lock_path: self.config.registry_lock_path.clone(),
+        }
+    }
+
+    /// Create a cloneable handle for asking the addon to flush accepted JSONL writes.
+    pub fn jsonl_flush_handle(&self, request_flush_tx: mpsc::Sender<()>) -> MitmJsonlFlushHandle {
+        MitmJsonlFlushHandle {
+            addon_dir: self.config.addon_dir.clone(),
+            usage_state: Arc::clone(&self.usage_flush_state),
+            request_lock: Arc::clone(&self.jsonl_flush_request_lock),
+            request_flush_tx,
         }
     }
 
@@ -392,6 +480,10 @@ impl MitmProxy {
         let (usage_state_id, usage_state_started_at_ms) = new_usage_state_id();
         self.usage_state_id = usage_state_id.clone();
         self.usage_state_started_at_ms = usage_state_started_at_ms;
+        *usage_flush_state_guard(&self.usage_flush_state) = UsageFlushTarget {
+            expected_usage_state_id: usage_state_id.clone(),
+            usage_state_started_at_ms,
+        };
         MitmRestartParams {
             config: self.config.clone(),
             port: self.port,
@@ -443,6 +535,18 @@ fn new_usage_state_id() -> (String, u64) {
     (Uuid::new_v4().to_string(), now_millis())
 }
 
+fn usage_flush_state_guard(
+    usage_state: &Arc<Mutex<UsageFlushTarget>>,
+) -> std::sync::MutexGuard<'_, UsageFlushTarget> {
+    match usage_state.lock() {
+        Ok(guard) => guard,
+        Err(poisoned) => {
+            warn!("usage flush state lock was poisoned, continuing with inner state");
+            poisoned.into_inner()
+        }
+    }
+}
+
 impl UsageFlushRequest {
     fn new(target: &UsageFlushTarget) -> Self {
         Self {
@@ -450,6 +554,47 @@ impl UsageFlushRequest {
             usage_state_started_at_ms: target.usage_state_started_at_ms,
             flush_request_id: Uuid::new_v4().to_string(),
             requested_at_ms: now_millis(),
+        }
+    }
+}
+
+impl JsonlFlushRequest {
+    fn new(target: &UsageFlushTarget, path: &Path) -> Self {
+        Self {
+            expected_usage_state_id: target.expected_usage_state_id.clone(),
+            usage_state_started_at_ms: target.usage_state_started_at_ms,
+            flush_request_id: Uuid::new_v4().to_string(),
+            requested_at_ms: now_millis(),
+            path: path.to_string_lossy().into_owned(),
+        }
+    }
+}
+
+impl MitmJsonlFlushHandle {
+    pub async fn flush_path(&self, path: &Path) -> bool {
+        let _request_guard = self.request_lock.lock().await;
+        let target = usage_flush_state_guard(&self.usage_state).clone();
+        let request = match write_jsonl_flush_request(&self.addon_dir, &target, path).await {
+            Ok(request) => request,
+            Err(e) => {
+                warn!(error = %e, path = %path.display(), "failed to create JSONL flush request");
+                return false;
+            }
+        };
+        if !self.request_flush() {
+            warn!(path = %path.display(), "failed to request JSONL flush");
+            return false;
+        }
+        wait_jsonl_flush_requesting(&self.addon_dir, JSONL_FLUSH_TIMEOUT, &request, || {
+            self.request_flush()
+        })
+        .await
+    }
+
+    fn request_flush(&self) -> bool {
+        match self.request_flush_tx.try_send(()) {
+            Ok(()) | Err(mpsc::error::TrySendError::Full(())) => true,
+            Err(mpsc::error::TrySendError::Closed(())) => false,
         }
     }
 }
@@ -481,6 +626,40 @@ pub async fn write_usage_flush_request(
         let _ = tokio::fs::remove_file(&tmp).await;
         return Err(RunnerError::Internal(format!(
             "rename usage flush request: {e}"
+        )));
+    }
+    Ok(request)
+}
+
+async fn write_jsonl_flush_request(
+    addon_dir: &Path,
+    target: &UsageFlushTarget,
+    log_path: &Path,
+) -> RunnerResult<JsonlFlushRequest> {
+    let request = JsonlFlushRequest::new(target, log_path);
+    let marker = JsonlFlushRequestMarker {
+        usage_state_id: &request.expected_usage_state_id,
+        flush_request_id: &request.flush_request_id,
+        requested_at_ms: request.requested_at_ms,
+        path: &request.path,
+    };
+    let path = addon_dir.join("jsonl-flush-request");
+    let tmp = addon_dir.join(format!(
+        "jsonl-flush-request.{}.tmp",
+        request.flush_request_id
+    ));
+    let content = serde_json::to_vec(&marker)
+        .map_err(|e| RunnerError::Internal(format!("serialize JSONL flush request: {e}")))?;
+    if let Err(e) = tokio::fs::write(&tmp, content).await {
+        let _ = tokio::fs::remove_file(&tmp).await;
+        return Err(RunnerError::Internal(format!(
+            "write JSONL flush request tmp: {e}"
+        )));
+    }
+    if let Err(e) = tokio::fs::rename(&tmp, &path).await {
+        let _ = tokio::fs::remove_file(&tmp).await;
+        return Err(RunnerError::Internal(format!(
+            "rename JSONL flush request: {e}"
         )));
     }
     Ok(request)
@@ -524,6 +703,48 @@ fn validate_usage_pending_state(
             return Err("usage flush request id does not match current request".to_string());
         }
         None => return Err("usage flush request id is missing".to_string()),
+    }
+
+    Ok(())
+}
+
+fn parse_jsonl_flush_state(content: &str) -> Result<JsonlFlushState, String> {
+    let trimmed = content.trim();
+    if trimmed.is_empty() {
+        return Err("state file is empty".to_string());
+    }
+    serde_json::from_str::<JsonlFlushState>(trimmed)
+        .map_err(|e| format!("state file is not valid JSONL flush JSON: {e}"))
+}
+
+fn validate_jsonl_flush_state(
+    state: &JsonlFlushState,
+    request: &JsonlFlushRequest,
+    now_ms: u64,
+) -> Result<(), String> {
+    if state.usage_state_id != request.expected_usage_state_id {
+        return Err("usage state id does not match current mitmdump process".to_string());
+    }
+
+    let skew_ms = USAGE_PENDING_CLOCK_SKEW.as_millis() as u64;
+    let min_updated_at = request.usage_state_started_at_ms.saturating_sub(skew_ms);
+    if state.updated_at_ms < min_updated_at {
+        return Err(format!(
+            "updatedAtMs {} predates current usage state id start {}",
+            state.updated_at_ms, request.usage_state_started_at_ms
+        ));
+    }
+    if state.updated_at_ms > now_ms.saturating_add(skew_ms) {
+        return Err(format!(
+            "updatedAtMs {} is too far in the future",
+            state.updated_at_ms
+        ));
+    }
+    if state.flush_request_id != request.flush_request_id {
+        return Err("JSONL flush request id does not match current request".to_string());
+    }
+    if state.path != request.path {
+        return Err("JSONL flush path does not match current request".to_string());
     }
 
     Ok(())
@@ -623,6 +844,80 @@ pub async fn wait_usage_flush_requesting(
 }
 
 #[cfg(test)]
+async fn wait_jsonl_flush(
+    addon_dir: &Path,
+    timeout: Duration,
+    request: &JsonlFlushRequest,
+) -> bool {
+    wait_jsonl_flush_requesting(addon_dir, timeout, request, || true).await
+}
+
+async fn wait_jsonl_flush_requesting(
+    addon_dir: &Path,
+    timeout: Duration,
+    request: &JsonlFlushRequest,
+    mut request_flush: impl FnMut() -> bool,
+) -> bool {
+    let path = addon_dir.join("jsonl-flush-state");
+    let started_at = tokio::time::Instant::now();
+    let deadline = started_at + timeout;
+    let mut next_flush_request_at = started_at + JSONL_FLUSH_REQUEST_INTERVAL;
+    loop {
+        let (not_ready, snapshot) = match tokio::fs::read_to_string(&path).await {
+            Ok(content) => match parse_jsonl_flush_state(&content) {
+                Ok(state) => {
+                    let snapshot = Some(JsonlFlushSnapshot::from(&state));
+                    match validate_jsonl_flush_state(&state, request, now_millis()) {
+                        Ok(()) => {
+                            if state.pending == 0 {
+                                return true;
+                            }
+                            (format!("pending writes={}", state.pending), snapshot)
+                        }
+                        Err(reason) => (reason, snapshot),
+                    }
+                }
+                Err(reason) => (reason, None),
+            },
+            Err(e) => (format!("cannot read {}: {e}", path.display()), None),
+        };
+        let now = tokio::time::Instant::now();
+        if now >= next_flush_request_at {
+            if !request_flush() {
+                warn!(
+                    reason = %not_ready,
+                    "JSONL flush request failed, proceeding with network log upload"
+                );
+                return false;
+            }
+            next_flush_request_at = now + JSONL_FLUSH_REQUEST_INTERVAL;
+        }
+        if now >= deadline {
+            match snapshot {
+                Some(snapshot) => warn!(
+                    timeout_secs = timeout.as_secs(),
+                    reason = %not_ready,
+                    pid = snapshot.pid,
+                    usage_state_id = %snapshot.usage_state_id,
+                    updated_at_ms = snapshot.updated_at_ms,
+                    flush_request_id = %snapshot.flush_request_id,
+                    path = %snapshot.path,
+                    pending = snapshot.pending,
+                    "JSONL flush timed out, proceeding with network log upload"
+                ),
+                None => warn!(
+                    timeout_secs = timeout.as_secs(),
+                    reason = %not_ready,
+                    "JSONL flush timed out, proceeding with network log upload"
+                ),
+            }
+            return false;
+        }
+        tokio::time::sleep(std::cmp::min(JSONL_FLUSH_POLL, deadline - now)).await;
+    }
+}
+
+#[cfg(test)]
 impl MitmProxy {
     /// Create a noop proxy for testing. No real process is spawned.
     ///
@@ -647,6 +942,11 @@ impl MitmProxy {
                 stopping: Arc::new(AtomicBool::new(false)),
                 usage_state_id: "test-usage-state-id".to_string(),
                 usage_state_started_at_ms: now_millis(),
+                usage_flush_state: Arc::new(Mutex::new(UsageFlushTarget {
+                    expected_usage_state_id: "test-usage-state-id".to_string(),
+                    usage_state_started_at_ms: now_millis(),
+                })),
+                jsonl_flush_request_lock: Arc::new(AsyncMutex::new(())),
             },
             crash_rx,
         )
@@ -658,6 +958,10 @@ impl MitmProxy {
 
     pub fn set_child_for_test(&mut self, child: tokio::process::Child) {
         self.child = Some(child);
+    }
+
+    pub fn set_addon_dir_for_test(&mut self, addon_dir: PathBuf) {
+        self.config.addon_dir = addon_dir;
     }
 }
 
@@ -2016,6 +2320,28 @@ while True:
         }
     }
 
+    fn jsonl_request(path: &Path) -> JsonlFlushRequest {
+        JsonlFlushRequest {
+            expected_usage_state_id: "state-test".to_string(),
+            usage_state_started_at_ms: 1_770_000_000_000,
+            flush_request_id: "jsonl-request-test".to_string(),
+            requested_at_ms: 1_770_000_000_000,
+            path: path.to_string_lossy().into_owned(),
+        }
+    }
+
+    fn jsonl_state(path: &Path, pending: u32) -> String {
+        serde_json::json!({
+            "pid": 1234,
+            "usageStateId": "state-test",
+            "updatedAtMs": 1_770_000_000_001u64,
+            "flushRequestId": "jsonl-request-test",
+            "path": path.to_string_lossy().to_string(),
+            "pending": pending,
+        })
+        .to_string()
+    }
+
     fn usage_state(flows: u32, buffered: u32, reports: u32) -> String {
         usage_state_with_request(flows, buffered, reports, Some("request-test"))
     }
@@ -2075,6 +2401,44 @@ while True:
         assert!(!leaked_tmp, "usage flush request tmp file leaked");
     }
 
+    #[tokio::test]
+    async fn write_jsonl_flush_request_writes_marker() {
+        let dir = tempfile::tempdir().unwrap();
+        let target = usage_target();
+        let log_path = dir.path().join("network.jsonl");
+
+        let request = write_jsonl_flush_request(dir.path(), &target, &log_path)
+            .await
+            .unwrap();
+
+        let marker: serde_json::Value = serde_json::from_str(
+            &std::fs::read_to_string(dir.path().join("jsonl-flush-request")).unwrap(),
+        )
+        .unwrap();
+        assert_eq!(marker["usageStateId"], "state-test");
+        assert_eq!(marker["flushRequestId"], request.flush_request_id);
+        assert_eq!(marker["requestedAtMs"], request.requested_at_ms);
+        assert_eq!(marker["path"], log_path.to_string_lossy().to_string());
+    }
+
+    #[tokio::test]
+    async fn write_jsonl_flush_request_removes_tmp_when_rename_fails() {
+        let dir = tempfile::tempdir().unwrap();
+        let target = usage_target();
+        let log_path = dir.path().join("network.jsonl");
+        std::fs::create_dir(dir.path().join("jsonl-flush-request")).unwrap();
+
+        let result = write_jsonl_flush_request(dir.path(), &target, &log_path).await;
+
+        assert!(result.is_err());
+        let leaked_tmp = std::fs::read_dir(dir.path())
+            .unwrap()
+            .filter_map(Result::ok)
+            .map(|entry| entry.file_name())
+            .any(|name| name.to_string_lossy().ends_with(".tmp"));
+        assert!(!leaked_tmp, "JSONL flush request tmp file leaked");
+    }
+
     fn usage_state_without_request(flows: u32, buffered: u32, reports: u32) -> String {
         serde_json::json!({
             "pid": 1234,
@@ -2088,6 +2452,266 @@ while True:
     }
 
     const USAGE_FLUSH_TEST_DELAY: Duration = Duration::from_millis(1);
+
+    #[tokio::test(start_paused = true)]
+    async fn wait_jsonl_flush_returns_true_when_zero() {
+        let dir = tempfile::tempdir().unwrap();
+        let log_path = dir.path().join("network.jsonl");
+        let request = jsonl_request(&log_path);
+        std::fs::write(
+            dir.path().join("jsonl-flush-state"),
+            jsonl_state(&log_path, 0),
+        )
+        .unwrap();
+        assert!(wait_jsonl_flush(dir.path(), Duration::from_millis(50), &request).await);
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn wait_jsonl_flush_rejects_wrong_request_id() {
+        let dir = tempfile::tempdir().unwrap();
+        let log_path = dir.path().join("network.jsonl");
+        let request = jsonl_request(&log_path);
+        let state = serde_json::json!({
+            "pid": 1234,
+            "usageStateId": "state-test",
+            "updatedAtMs": 1_770_000_000_001u64,
+            "flushRequestId": "old-request",
+            "path": log_path.to_string_lossy().to_string(),
+            "pending": 0,
+        });
+        std::fs::write(dir.path().join("jsonl-flush-state"), state.to_string()).unwrap();
+        assert!(!wait_jsonl_flush(dir.path(), Duration::from_millis(50), &request).await);
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn wait_jsonl_flush_rejects_wrong_path() {
+        let dir = tempfile::tempdir().unwrap();
+        let log_path = dir.path().join("network.jsonl");
+        let request = jsonl_request(&log_path);
+        std::fs::write(
+            dir.path().join("jsonl-flush-state"),
+            jsonl_state(&dir.path().join("other.jsonl"), 0),
+        )
+        .unwrap();
+        assert!(!wait_jsonl_flush(dir.path(), Duration::from_millis(50), &request).await);
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn wait_jsonl_flush_rejects_wrong_usage_state_id() {
+        let dir = tempfile::tempdir().unwrap();
+        let log_path = dir.path().join("network.jsonl");
+        let request = jsonl_request(&log_path);
+        let state = serde_json::json!({
+            "pid": 1234,
+            "usageStateId": "old-state",
+            "updatedAtMs": 1_770_000_000_001u64,
+            "flushRequestId": "jsonl-request-test",
+            "path": log_path.to_string_lossy().to_string(),
+            "pending": 0,
+        });
+        std::fs::write(dir.path().join("jsonl-flush-state"), state.to_string()).unwrap();
+        assert!(!wait_jsonl_flush(dir.path(), Duration::from_millis(50), &request).await);
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn wait_jsonl_flush_requests_flush_when_pending() {
+        let dir = tempfile::tempdir().unwrap();
+        let log_path = dir.path().join("network.jsonl");
+        let request = jsonl_request(&log_path);
+        let path = dir.path().join("jsonl-flush-state");
+        std::fs::write(&path, jsonl_state(&log_path, 1)).unwrap();
+        let request_count = std::sync::Arc::new(std::sync::atomic::AtomicUsize::new(0));
+
+        let p = path.clone();
+        let l = log_path.clone();
+        let requests = std::sync::Arc::clone(&request_count);
+        let flushed =
+            wait_jsonl_flush_requesting(dir.path(), Duration::from_secs(5), &request, || {
+                requests.fetch_add(1, Ordering::SeqCst);
+                std::fs::write(&p, jsonl_state(&l, 0)).unwrap();
+                true
+            })
+            .await;
+
+        assert!(flushed);
+        assert_eq!(request_count.load(Ordering::SeqCst), 1);
+    }
+
+    #[tokio::test]
+    async fn jsonl_flush_handle_writes_request_and_sends_flush_signal() {
+        let dir = tempfile::tempdir().unwrap();
+        let log_path = dir.path().join("network.jsonl");
+        let (tx, mut rx) = mpsc::channel(1);
+        let usage_state = Arc::new(Mutex::new(usage_target()));
+        let handle = MitmJsonlFlushHandle {
+            addon_dir: dir.path().to_path_buf(),
+            usage_state,
+            request_lock: Arc::new(AsyncMutex::new(())),
+            request_flush_tx: tx,
+        };
+
+        let d = dir.path().to_path_buf();
+        let l = log_path.clone();
+        let waiter = tokio::spawn(async move { handle.flush_path(&l).await });
+
+        rx.recv().await.unwrap();
+        let marker: serde_json::Value =
+            serde_json::from_str(&std::fs::read_to_string(d.join("jsonl-flush-request")).unwrap())
+                .unwrap();
+        let state = serde_json::json!({
+            "pid": 1234,
+            "usageStateId": "state-test",
+            "updatedAtMs": 1_770_000_000_001u64,
+            "flushRequestId": marker["flushRequestId"],
+            "path": log_path.to_string_lossy().to_string(),
+            "pending": 0,
+        });
+        std::fs::write(d.join("jsonl-flush-state"), state.to_string()).unwrap();
+
+        assert!(waiter.await.unwrap());
+    }
+
+    #[tokio::test]
+    async fn jsonl_flush_handle_serializes_concurrent_requests() {
+        let dir = tempfile::tempdir().unwrap();
+        let first_log_path = dir.path().join("network-a.jsonl");
+        let second_log_path = dir.path().join("network-b.jsonl");
+        let (tx, mut rx) = mpsc::channel(1);
+        let handle = MitmJsonlFlushHandle {
+            addon_dir: dir.path().to_path_buf(),
+            usage_state: Arc::new(Mutex::new(usage_target())),
+            request_lock: Arc::new(AsyncMutex::new(())),
+            request_flush_tx: tx,
+        };
+
+        let first_handle = handle.clone();
+        let first_path = first_log_path.clone();
+        let first = tokio::spawn(async move { first_handle.flush_path(&first_path).await });
+
+        rx.recv().await.unwrap();
+        let first_marker: serde_json::Value = serde_json::from_str(
+            &std::fs::read_to_string(dir.path().join("jsonl-flush-request")).unwrap(),
+        )
+        .unwrap();
+        assert_eq!(
+            first_marker["path"],
+            first_log_path.to_string_lossy().to_string()
+        );
+
+        let second_handle = handle.clone();
+        let second_path = second_log_path.clone();
+        let second = tokio::spawn(async move { second_handle.flush_path(&second_path).await });
+        tokio::task::yield_now().await;
+        assert!(rx.try_recv().is_err());
+
+        let first_state = serde_json::json!({
+            "pid": 1234,
+            "usageStateId": "state-test",
+            "updatedAtMs": 1_770_000_000_001u64,
+            "flushRequestId": first_marker["flushRequestId"],
+            "path": first_log_path.to_string_lossy().to_string(),
+            "pending": 0,
+        });
+        std::fs::write(
+            dir.path().join("jsonl-flush-state"),
+            first_state.to_string(),
+        )
+        .unwrap();
+        assert!(first.await.unwrap());
+
+        rx.recv().await.unwrap();
+        let second_marker: serde_json::Value = serde_json::from_str(
+            &std::fs::read_to_string(dir.path().join("jsonl-flush-request")).unwrap(),
+        )
+        .unwrap();
+        assert_eq!(
+            second_marker["path"],
+            second_log_path.to_string_lossy().to_string()
+        );
+        let second_state = serde_json::json!({
+            "pid": 1234,
+            "usageStateId": "state-test",
+            "updatedAtMs": 1_770_000_000_001u64,
+            "flushRequestId": second_marker["flushRequestId"],
+            "path": second_log_path.to_string_lossy().to_string(),
+            "pending": 0,
+        });
+        std::fs::write(
+            dir.path().join("jsonl-flush-state"),
+            second_state.to_string(),
+        )
+        .unwrap();
+        assert!(second.await.unwrap());
+    }
+
+    #[tokio::test]
+    async fn jsonl_flush_handles_from_same_proxy_serialize_concurrent_requests() {
+        let dir = tempfile::tempdir().unwrap();
+        let first_log_path = dir.path().join("network-a.jsonl");
+        let second_log_path = dir.path().join("network-b.jsonl");
+        let (mut proxy, _crash_rx) = MitmProxy::noop();
+        proxy.set_addon_dir_for_test(dir.path().to_path_buf());
+        let (tx, mut rx) = mpsc::channel(1);
+        let first_handle = proxy.jsonl_flush_handle(tx.clone());
+        let second_handle = proxy.jsonl_flush_handle(tx);
+
+        let first_path = first_log_path.clone();
+        let first = tokio::spawn(async move { first_handle.flush_path(&first_path).await });
+
+        rx.recv().await.unwrap();
+        let first_marker: serde_json::Value = serde_json::from_str(
+            &std::fs::read_to_string(dir.path().join("jsonl-flush-request")).unwrap(),
+        )
+        .unwrap();
+        assert_eq!(
+            first_marker["path"],
+            first_log_path.to_string_lossy().to_string()
+        );
+
+        let second_path = second_log_path.clone();
+        let second = tokio::spawn(async move { second_handle.flush_path(&second_path).await });
+        tokio::task::yield_now().await;
+        assert!(rx.try_recv().is_err());
+
+        let first_state = serde_json::json!({
+            "pid": 1234,
+            "usageStateId": first_marker["usageStateId"],
+            "updatedAtMs": now_millis(),
+            "flushRequestId": first_marker["flushRequestId"],
+            "path": first_log_path.to_string_lossy().to_string(),
+            "pending": 0,
+        });
+        std::fs::write(
+            dir.path().join("jsonl-flush-state"),
+            first_state.to_string(),
+        )
+        .unwrap();
+        assert!(first.await.unwrap());
+
+        rx.recv().await.unwrap();
+        let second_marker: serde_json::Value = serde_json::from_str(
+            &std::fs::read_to_string(dir.path().join("jsonl-flush-request")).unwrap(),
+        )
+        .unwrap();
+        assert_eq!(
+            second_marker["path"],
+            second_log_path.to_string_lossy().to_string()
+        );
+        let second_state = serde_json::json!({
+            "pid": 1234,
+            "usageStateId": second_marker["usageStateId"],
+            "updatedAtMs": now_millis(),
+            "flushRequestId": second_marker["flushRequestId"],
+            "path": second_log_path.to_string_lossy().to_string(),
+            "pending": 0,
+        });
+        std::fs::write(
+            dir.path().join("jsonl-flush-state"),
+            second_state.to_string(),
+        )
+        .unwrap();
+        assert!(second.await.unwrap());
+    }
 
     #[tokio::test(start_paused = true)]
     async fn wait_usage_flush_returns_true_when_zero() {


### PR DESCRIPTION
## Summary
- Move mitm-addon network/proxy JSONL appends off hook paths into a bounded background writer with per-path flush support.
- Add a separate runner/addon JSONL flush request protocol so deferred network log uploads wait for accepted mitm writes before reading the file.
- Serialize per-runner JSONL flush requests because the addon protocol uses one request/state file pair.
- Reuse the existing SIGUSR1 request channel while keeping usage drain and JSONL flush state files separate.

## Tests
- crates/runner/mitm-addon/.venv/bin/pytest crates/runner/mitm-addon/tests
- crates/runner/mitm-addon/.venv/bin/ruff check crates/runner/mitm-addon/src crates/runner/mitm-addon/tests
- crates/runner/mitm-addon/.venv/bin/ruff format --check crates/runner/mitm-addon/src crates/runner/mitm-addon/tests
- cargo clippy --manifest-path crates/Cargo.toml -p runner --tests -- -D warnings
- cargo test --manifest-path crates/Cargo.toml -p runner proxy::tests
- cargo test --manifest-path crates/Cargo.toml -p runner cmd::start::tests::main_loop

Closes #16464