### PR TITLE
chore: preserve Hitem3D connector icon color

### DIFF
--- a/turbo/apps/platform/src/views/zero-page/components/settings/connector-icons.tsx
+++ b/turbo/apps/platform/src/views/zero-page/components/settings/connector-icons.tsx
@@ -148,6 +148,7 @@ const CONNECTOR_ICON_COLORFUL = {
   gumroad: true,
   helicone: true,
   heygen: true,
+  hitem3d: true,
   honcho: true,
   hubspot: true,
   "hugging-face": true,


### PR DESCRIPTION
## Summary
- add `hitem3d` to `CONNECTOR_ICON_COLORFUL` so the official black and light-green favicon is not inverted in dark theme

## Verification
- `pnpm exec prettier --check apps/platform/src/views/zero-page/components/settings/connector-icons.tsx`
- `pnpm -F @vm0/app lint`
- pre-commit hook: knip and `pnpm check-types`

Closes #16595