### PR TITLE
fix: scope model provider usage source keys to flows

### DIFF
--- a/crates/runner/mitm-addon/src/usage/providers/model_provider.py
+++ b/crates/runner/mitm-addon/src/usage/providers/model_provider.py
@@ -73,9 +73,8 @@ def report_model_provider_usage(flow: http.HTTPFlow, run_id: str) -> bool:
     usage = flow.metadata.get(metadata_keys.MODEL_PROVIDER_USAGE)
     if not usage or not isinstance(usage, dict):
         return False
-    message_id = _string_or_none(usage.get("message_id")) or flow.id
     provider = _reported_model(flow, usage)
-    events = _build_usage_events(run_id, message_id, provider, usage, USAGE_EVENT_NAMESPACE_MODEL)
+    events = _build_usage_events(run_id, flow.id, provider, usage, USAGE_EVENT_NAMESPACE_MODEL)
     if not events:
         return False
     sandbox_token = flow.metadata.get(metadata_keys.VM_SANDBOX_AUTH_KEY, "")
@@ -109,11 +108,10 @@ def report_model_provider_usage_observation(flow: http.HTTPFlow, run_id: str) ->
     usage = flow.metadata.get(metadata_keys.MODEL_PROVIDER_USAGE)
     if not usage or not isinstance(usage, dict):
         return False
-    message_id = _string_or_none(usage.get("message_id")) or flow.id
     model = _reported_model(flow, usage)
     events = _build_usage_events(
         run_id,
-        message_id,
+        flow.id,
         model,
         usage,
         USAGE_OBSERVATION_NAMESPACE_MODEL,
@@ -143,7 +141,7 @@ def report_model_provider_usage_observation(flow: http.HTTPFlow, run_id: str) ->
 
 
 def _build_usage_events(
-    run_id: str, message_id: str, provider: str, usage: dict, namespace: uuid.UUID
+    run_id: str, source_id: str, provider: str, usage: dict, namespace: uuid.UUID
 ) -> list[UsageEvent]:
     events: list[UsageEvent] = []
     for category in MODEL_USAGE_CATEGORIES:
@@ -152,7 +150,7 @@ def _build_usage_events(
             continue
         events.append(
             {
-                "idempotencyKey": _derive_idempotency_key(namespace, run_id, message_id, category),
+                "idempotencyKey": _derive_idempotency_key(namespace, run_id, source_id, category),
                 "kind": MODEL_USAGE_KIND,
                 "provider": provider,
                 "category": category,
@@ -163,12 +161,12 @@ def _build_usage_events(
 
 
 def _derive_idempotency_key(
-    namespace: uuid.UUID, run_id: str, message_id: str, category: str
+    namespace: uuid.UUID, run_id: str, source_id: str, category: str
 ) -> str:
     return str(
         uuid.uuid5(
             namespace,
-            encode_uuid_name((run_id, message_id, category)),
+            encode_uuid_name((run_id, source_id, category)),
         )
     )
 

--- a/crates/runner/mitm-addon/tests/test_model_provider_usage.py
+++ b/crates/runner/mitm-addon/tests/test_model_provider_usage.py
@@ -94,8 +94,15 @@ class TestReportModelProviderUsage:
         body = webhook.requests[0].json_body()
         assert body["events"][0]["provider"] == "unknown"
 
-        flow.metadata["model_provider_usage"]["message_id"] = "msg-usage-2"
-        flow.metadata["model_provider_usage"]["model"] = "claude-sonnet-4-6"
+        flow = real_flow(with_response=False, host="api.anthropic.com")
+        flow.metadata["firewall_name"] = "model-provider:anthropic-api-key"
+        flow.metadata["firewall_billable"] = True
+        flow.metadata["vm_sandbox_token"] = "tok-xyz"
+        flow.metadata["model_provider_usage"] = {
+            "message_id": "msg-usage-2",
+            "model": "claude-sonnet-4-6",
+            "tokens.input": 100,
+        }
         with usage_webhook_api() as webhook:
             usage.report_model_provider_usage(flow, "run-abc-123")
             usage.flush_usage_events(trigger="test")
@@ -342,6 +349,29 @@ class TestReportModelProviderUsage:
         body = webhook.requests[0].json_body()
         assert body["events"][0]["quantity"] == 10
 
+    def test_source_dedupe_uses_flow_id_when_message_id_present(
+        self, real_flow, fresh_usage_executor, usage_webhook_api
+    ):
+        flow = real_flow(with_response=False, host="api.anthropic.com")
+        flow.id = "flow-uuid-xyz-123"
+        flow.metadata["firewall_name"] = "model-provider:anthropic-api-key"
+        flow.metadata["firewall_billable"] = True
+        flow.metadata["vm_sandbox_token"] = "tok-xyz"
+        flow.metadata["model_provider_usage"] = {
+            "model": "claude-sonnet-4-6",
+            "message_id": "msg_real_anthropic_id",
+            "tokens.input": 10,
+        }
+
+        with usage_webhook_api() as webhook:
+            usage.report_model_provider_usage(flow, "run-fallback")
+            usage.report_model_provider_usage(flow, "run-fallback")
+            usage.flush_usage_events(trigger="test")
+            usage.webhook.usage_executor.shutdown(wait=True)
+
+        body = webhook.requests[0].json_body()
+        assert body["events"][0]["quantity"] == 10
+
     def test_source_dedupe_separates_flows_when_message_id_missing(
         self, real_flow, fresh_usage_executor, usage_webhook_api
     ):
@@ -367,7 +397,7 @@ class TestReportModelProviderUsage:
         body = webhook.requests[0].json_body()
         assert body["events"][0]["quantity"] == 20
 
-    def test_source_dedupe_preserves_message_id_over_flow_id(
+    def test_source_dedupe_separates_flows_when_message_id_matches(
         self, real_flow, fresh_usage_executor, usage_webhook_api
     ):
         first = real_flow(with_response=False, host="api.anthropic.com")
@@ -391,4 +421,31 @@ class TestReportModelProviderUsage:
             usage.webhook.usage_executor.shutdown(wait=True)
 
         body = webhook.requests[0].json_body()
-        assert body["events"][0]["quantity"] == 10
+        assert body["events"][0]["quantity"] == 20
+
+    def test_observation_source_dedupe_separates_flows_when_message_id_matches(
+        self, real_flow, fresh_usage_executor, usage_webhook_api
+    ):
+        first = real_flow(with_response=False, host="api.anthropic.com")
+        first.id = "flow-first"
+        second = real_flow(with_response=False, host="api.anthropic.com")
+        second.id = "flow-second"
+        for flow in (first, second):
+            flow.metadata["firewall_name"] = "model-provider:anthropic-api-key"
+            flow.metadata["firewall_billable"] = False
+            flow.metadata["model_usage_provider"] = "claude-sonnet-4-6"
+            flow.metadata["vm_sandbox_token"] = "tok-xyz"
+            flow.metadata["model_provider_usage"] = {
+                "model": "ignored-runtime-model",
+                "message_id": "msg_real_anthropic_id",
+                "tokens.input": 10,
+            }
+
+        with usage_webhook_api() as webhook:
+            usage.report_model_provider_usage_observation(first, "run-preserved")
+            usage.report_model_provider_usage_observation(second, "run-preserved")
+            usage.flush_usage_events(trigger="test")
+            usage.webhook.usage_executor.shutdown(wait=True)
+
+        body = webhook.requests[0].json_body()
+        assert body["events"][0]["quantity"] == 20

--- a/crates/runner/mitm-addon/tests/test_usage_reporting_idempotency.py
+++ b/crates/runner/mitm-addon/tests/test_usage_reporting_idempotency.py
@@ -95,10 +95,10 @@ class TestUsageReportingIdempotency:
         events = webhook.usage_events()
         assert [event["category"] for event in events] == ["tokens.output"]
 
-    def test_uses_flow_id_when_message_id_missing(
+    def test_reports_usage_without_provider_message_id(
         self, tmp_path, real_flow, mitm_ctx, headers, fresh_usage_executor, usage_webhook_api
     ):
-        """Missing message_id in model_provider_usage falls back to flow.id.
+        """Missing message_id in model_provider_usage still reports usage.
 
         Without a stable per-flow source key, duplicate response/error
         observations could be aggregated twice before the webhook payload is
@@ -148,11 +148,10 @@ class TestUsageReportingIdempotency:
         uuid.UUID(observation_key)
         assert observation_key != billing_key
 
-    def test_preserves_message_id_from_response(
+    def test_reports_usage_with_provider_message_id(
         self, tmp_path, real_flow, mitm_ctx, headers, fresh_usage_executor, usage_webhook_api
     ):
-        """When model_provider_usage already has a message_id, flow.id fallback
-        must not override it."""
+        """Provider message_id metadata must not block ordinary usage reporting."""
         flow = real_flow(with_response=False, host="api.anthropic.com")
         flow.id = "flow-should-not-win"
         log_path = str(tmp_path / "network.jsonl")


### PR DESCRIPTION
## Summary

- derive model-provider source idempotency keys from the mitm flow id instead of provider message ids
- keep same-flow duplicate reporting idempotent while separating distinct flows with matching provider ids
- add billing and model usage observation regression coverage for duplicate provider message ids

## Tests

- pytest tests/test_model_provider_usage.py::TestReportModelProviderUsage::test_source_dedupe_separates_flows_when_message_id_matches tests/test_model_provider_usage.py::TestReportModelProviderUsage::test_observation_source_dedupe_separates_flows_when_message_id_matches
- pytest tests/test_model_provider_usage.py tests/test_usage_reporting_idempotency.py
- ruff format --check src/usage/providers/model_provider.py tests/test_model_provider_usage.py tests/test_usage_reporting_idempotency.py
- ruff check src/usage/providers/model_provider.py tests/test_model_provider_usage.py tests/test_usage_reporting_idempotency.py
- pytest tests
- basedpyright

Closes #16463