### PR TITLE
refactor: throw typed schedule run errors

### DIFF
--- a/turbo/apps/api/src/lib/error.ts
+++ b/turbo/apps/api/src/lib/error.ts
@@ -1,8 +1,23 @@
+export interface ApiErrorBody<CODE extends string = string> {
+  readonly error: {
+    readonly message: string;
+    readonly code: CODE;
+  };
+}
+
+export interface ApiErrorResponse<
+  STATUS extends number = number,
+  CODE extends string = string,
+> {
+  readonly status: STATUS;
+  readonly body: ApiErrorBody<CODE>;
+}
+
 function httpError<STATUS extends number, CODE extends string>(
   status: STATUS,
   code: CODE,
   message: string,
-) {
+): ApiErrorResponse<STATUS, CODE> {
   return Object.freeze({
     status,
     body: {
@@ -12,6 +27,24 @@ function httpError<STATUS extends number, CODE extends string>(
       },
     },
   });
+}
+
+export class ApiRouteError extends Error {
+  readonly response: ApiErrorResponse;
+
+  constructor(response: ApiErrorResponse, options?: ErrorOptions) {
+    super(response.body.error.message, options);
+    this.name = "ApiRouteError";
+    this.response = response;
+  }
+}
+
+export function isApiRouteError(error: unknown): error is ApiRouteError {
+  return error instanceof ApiRouteError;
+}
+
+export function throwApiError(response: ApiErrorResponse): never {
+  throw new ApiRouteError(response);
 }
 
 export function notFound(message: string) {

--- a/turbo/apps/api/src/signals/context/__tests__/route.test.ts
+++ b/turbo/apps/api/src/signals/context/__tests__/route.test.ts
@@ -4,6 +4,7 @@ import { describe, expect, it } from "vitest";
 import { z } from "zod";
 
 import { accept, setupApp, testContext } from "../../../__tests__/test-helpers";
+import { ApiRouteError, conflict } from "../../../lib/error";
 import { ROUTES } from "../../route";
 
 const context = testContext();
@@ -45,6 +46,18 @@ const routeTestContract = c.router({
     responses: {
       200: z.object({
         ok: z.literal(true),
+      }),
+    },
+  },
+  apiError: {
+    method: "GET",
+    path: "/__test/api-error",
+    responses: {
+      409: z.object({
+        error: z.object({
+          message: z.string(),
+          code: z.string(),
+        }),
       }),
     },
   },
@@ -139,5 +152,24 @@ describe("honoSignalHandler", () => {
     );
 
     expect(response.body).toStrictEqual({ ok: true });
+  });
+
+  it("translates thrown typed API errors into route responses", async () => {
+    const handler$ = computed((): never => {
+      throw new ApiRouteError(conflict("Already running"));
+    });
+    const client = setupApp({
+      context,
+      routes: [
+        ...ROUTES,
+        { route: routeTestContract.apiError, handler: handler$ },
+      ],
+    })(routeTestContract);
+
+    const response = await accept(client.apiError(), [409]);
+
+    expect(response.body).toStrictEqual({
+      error: { message: "Already running", code: "CONFLICT" },
+    });
   });
 });

--- a/turbo/apps/api/src/signals/context/route.ts
+++ b/turbo/apps/api/src/signals/context/route.ts
@@ -3,6 +3,8 @@ import { createStore, type Command, type Computed } from "ccstate";
 import type { Handler } from "hono";
 import type { ContentfulStatusCode, StatusCode } from "hono/utils/http-status";
 
+import { isApiRouteError } from "../../lib/error";
+import { settle } from "../utils";
 import { initHono$ } from "./hono";
 import { requestValidation$ } from "./request";
 import { setRootSignal$ } from "./root";
@@ -85,6 +87,27 @@ function isContentlessStatus(status: StatusCode): boolean {
   return status === 101 || status === 204 || status === 205 || status === 304;
 }
 
+function routeResultToHonoResponse(
+  context: Parameters<Handler>[0],
+  contract: AppRoute,
+  data: RouteResult,
+): Response | Promise<Response> {
+  const response = validateResponse({
+    appRoute: contract,
+    response: data,
+  });
+  const status = response.status as StatusCode;
+  if (
+    isContentlessStatus(status) ||
+    !("body" in response) ||
+    response.body === undefined
+  ) {
+    return context.body(null, status);
+  }
+
+  return context.json(response.body, status as ContentfulStatusCode);
+}
+
 export function honoSignalHandler(
   handler$: SignalRouteHandler<unknown>,
   contract: AppRoute,
@@ -103,9 +126,19 @@ export function honoSignalHandler(
       return context.json(validationError.body, validationError.status);
     }
 
-    const data = await (isCommand(handler$)
-      ? store.set(handler$, signal)
-      : store.get(handler$));
+    const resolveRouteData = async (): Promise<unknown> => {
+      return isCommand(handler$)
+        ? await store.set(handler$, signal)
+        : store.get(handler$);
+    };
+    const settled = await settle(resolveRouteData(), signal);
+    const data = settled.ok ? settled.value : settled.error;
+    if (!settled.ok) {
+      if (!isApiRouteError(data)) {
+        throw data;
+      }
+      return routeResultToHonoResponse(context, contract, data.response);
+    }
 
     if (data instanceof Response) {
       return data;
@@ -119,19 +152,6 @@ export function honoSignalHandler(
       throw new Error("Route handler must return a ts-rest response object");
     }
 
-    const response = validateResponse({
-      appRoute: contract,
-      response: data,
-    });
-    const status = response.status as StatusCode;
-    if (
-      isContentlessStatus(status) ||
-      !("body" in response) ||
-      response.body === undefined
-    ) {
-      return context.body(null, status);
-    }
-
-    return context.json(response.body, status as ContentfulStatusCode);
+    return routeResultToHonoResponse(context, contract, data);
   };
 }

--- a/turbo/apps/api/src/signals/routes/zero-schedules.ts
+++ b/turbo/apps/api/src/signals/routes/zero-schedules.ts
@@ -6,7 +6,7 @@ import {
   zeroSchedulesMainContract,
 } from "@vm0/api-contracts/contracts/zero-schedules";
 
-import { badRequestMessage, conflict, notFound } from "../../lib/error";
+import { badRequestMessage, notFound } from "../../lib/error";
 import { organizationAuthContext$ } from "../auth/auth-context";
 import { authRoute } from "../auth/auth-route";
 import { bodyResultOf, pathParamsOf, queryOf } from "../context/request";
@@ -179,15 +179,6 @@ const runNowInner$ = command(async ({ get, set }, signal: AbortSignal) => {
   );
   signal.throwIfAborted();
 
-  if (result.kind === "not_found") {
-    return notFound(result.message);
-  }
-  if (result.kind === "conflict") {
-    return conflict(result.message);
-  }
-  if (result.kind === "run_error") {
-    return result.response;
-  }
   return { status: 201 as const, body: { runId: result.runId } };
 });
 

--- a/turbo/apps/api/src/signals/services/zero-schedules.service.ts
+++ b/turbo/apps/api/src/signals/services/zero-schedules.service.ts
@@ -23,6 +23,12 @@ import { Cron } from "croner";
 import { and, eq, inArray, lte } from "drizzle-orm";
 import { z } from "zod";
 
+import {
+  conflict,
+  isApiRouteError,
+  notFound,
+  throwApiError,
+} from "../../lib/error";
 import { optionalEnv } from "../../lib/env";
 import { internalApiBaseUrl } from "../../lib/internal-api-url";
 import { logger } from "../../lib/log";
@@ -106,26 +112,7 @@ type DeployScheduleResult =
   | { readonly kind: "bad_request"; readonly message: string }
   | { readonly kind: "schedule_past"; readonly message: string };
 
-type RunCreationErrorResponse = {
-  readonly status: 400 | 402 | 403 | 404 | 429 | 503;
-  readonly body: {
-    readonly error: {
-      readonly message: string;
-      readonly code: string;
-    };
-  };
-};
-
-type RunScheduleNowResult =
-  | { readonly kind: "ok"; readonly runId: string }
-  | { readonly kind: "not_found"; readonly message: string }
-  | { readonly kind: "conflict"; readonly message: string }
-  | {
-      readonly kind: "run_error";
-      readonly response: RunCreationErrorResponse;
-    };
-
-type ExecuteScheduleFailure = Exclude<RunScheduleNowResult, { kind: "ok" }>;
+type RunScheduleNowResult = { readonly runId: string };
 
 interface ExecuteDueSchedulesResult {
   readonly executed: number;
@@ -911,33 +898,17 @@ function isActivePreviousRunStatus(status: string): boolean {
   return status === "pending" || status === "running";
 }
 
-function isExecuteScheduleFailure(
-  error: unknown,
-): error is ExecuteScheduleFailure {
-  return (
-    typeof error === "object" &&
-    error !== null &&
-    "kind" in error &&
-    (error.kind === "not_found" ||
-      error.kind === "conflict" ||
-      error.kind === "run_error")
-  );
-}
-
 function scheduleFailureMessage(error: unknown): string {
-  if (!isExecuteScheduleFailure(error)) {
-    return error instanceof Error ? error.message : String(error);
+  if (isApiRouteError(error)) {
+    const { response } = error;
+    return `${response.status} ${response.body.error.code}: ${response.body.error.message}`;
   }
-  if (error.kind === "run_error") {
-    return `${error.response.status} ${error.response.body.error.code}: ${error.response.body.error.message}`;
-  }
-  return error.message;
+  return error instanceof Error ? error.message : String(error);
 }
 
 function isInsufficientCreditsFailure(error: unknown): boolean {
   return (
-    isExecuteScheduleFailure(error) &&
-    error.kind === "run_error" &&
+    isApiRouteError(error) &&
     error.response.body.error.code === "INSUFFICIENT_CREDITS"
   );
 }
@@ -1110,12 +1081,6 @@ export const executeDueSchedules$ = command(
         skipped++;
         continue;
       }
-      const result = runResult.value;
-      if (result.kind !== "ok") {
-        await recordSchedulePreRunFailure(db, schedule, result, signal);
-        skipped++;
-        continue;
-      }
       executed++;
     }
 
@@ -1221,7 +1186,7 @@ export const runScheduleNow$ = command(
     signal.throwIfAborted();
 
     if (!schedule) {
-      return { kind: "not_found", message: "Schedule not found" };
+      throwApiError(notFound("Schedule not found"));
     }
 
     if (schedule.lastRunId) {
@@ -1236,10 +1201,7 @@ export const runScheduleNow$ = command(
         lastRun &&
         (lastRun.status === "pending" || lastRun.status === "running")
       ) {
-        return {
-          kind: "conflict",
-          message: "Previous run is still active",
-        };
+        throwApiError(conflict("Previous run is still active"));
       }
     }
 
@@ -1252,12 +1214,9 @@ export const runScheduleNow$ = command(
     signal.throwIfAborted();
     if ("status" in threadModelPin) {
       // No user is present to receive a model-config error; surface it as a
-      // run_error (normalized to 400) so it feeds consecutiveFailures / the
+      // typed run error (normalized to 400) so it feeds consecutiveFailures / the
       // manual run-now response.
-      return {
-        kind: "run_error",
-        response: { status: 400, body: threadModelPin.body },
-      };
+      throwApiError({ status: 400, body: threadModelPin.body });
     }
 
     const providerAdmission = await resolveModelFirstProviderAdmission({
@@ -1269,7 +1228,7 @@ export const runScheduleNow$ = command(
     });
     signal.throwIfAborted();
     if (providerAdmission.error) {
-      return { kind: "run_error", response: providerAdmission.error };
+      throwApiError(providerAdmission.error);
     }
 
     const result = await set(
@@ -1304,7 +1263,7 @@ export const runScheduleNow$ = command(
     signal.throwIfAborted();
 
     if (result.status !== 201) {
-      return { kind: "run_error", response: result };
+      throwApiError(result);
     }
 
     await postScheduleUserMessage({
@@ -1337,7 +1296,7 @@ export const runScheduleNow$ = command(
       .where(eq(zeroAgentSchedules.id, schedule.id));
     signal.throwIfAborted();
 
-    return { kind: "ok", runId: result.body.runId };
+    return { runId: result.body.runId };
   },
 );
 


### PR DESCRIPTION
## Summary
- Add `ApiRouteError` / typed API error helpers and make the ccstate-to-Hono route adapter convert them into validated API responses.
- Normalize `runScheduleNow$` so success returns `{ runId }` and expected failures throw typed API errors instead of returning error union variants.
- Keep cron schedule execution bookkeeping by recording thrown typed errors as pre-run failures.

Closes #16575

## Validation
- `pnpm vitest run apps/api/src/signals/context/__tests__/route.test.ts`
- `NODE_OPTIONS=--max-old-space-size=4096 pnpm check-types --filter=api`
- `pnpm --filter api lint`
- `pnpm exec prettier --check apps/api/src/lib/error.ts apps/api/src/signals/context/route.ts apps/api/src/signals/context/__tests__/route.test.ts apps/api/src/signals/routes/zero-schedules.ts apps/api/src/signals/services/zero-schedules.service.ts`
- `git diff --check`

## Notes
- Attempted targeted schedule/cron route tests, but local Postgres was not running, so fixtures failed with `ECONNREFUSED 127.0.0.1:5432` / `::1:5432` before reaching assertions.