### PR TITLE
fix: move memory entry to account menu

### DIFF
--- a/e2e/tests/03-runner/t45-vm0-profile.bats
+++ b/e2e/tests/03-runner/t45-vm0-profile.bats
@@ -66,7 +66,7 @@ EOF
 
     run $VM0_CLI run "$AGENT_NAME" \
         --artifact "$ARTIFACT_NAME:/home/user/workspace" \
-        "agent-browser open https://github.com && agent-browser get title && agent-browser close"
+        "agent-browser open https://github.com && agent-browser get title | grep -Fq GitHub && agent-browser close"
     assert_success
-    assert_output --partial "GitHub"
+    assert_output --partial "https://github.com/"
 }

--- a/turbo/apps/platform/src/views/zero-page/__tests__/zero-sidebar-interaction.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/zero-sidebar-interaction.test.tsx
@@ -274,6 +274,86 @@ describe("zero sidebar - account dropdown opens (SIDEBAR-D-013)", () => {
     expect(screen.queryByText("Lab")).not.toBeInTheDocument();
   });
 
+  it("shows Memory above Settings in the account dropdown when MemoryViewer is on", async () => {
+    mockBaseAPIs();
+    detachedSetupPage({
+      context,
+      path: "/",
+      featureSwitches: { [FeatureSwitchKey.MemoryViewer]: true },
+    });
+
+    await waitFor(() => {
+      expect(screen.getByText("Test User")).toBeInTheDocument();
+    });
+    expect(
+      within(screen.getByRole("navigation", { name: "Sidebar" })).queryByText(
+        "Memory",
+      ),
+    ).not.toBeInTheDocument();
+
+    click(screen.getByText("Test User"));
+
+    const menu = await screen.findByRole("menu");
+    await waitFor(() => {
+      expect(within(menu).getByText("Memory")).toBeInTheDocument();
+      expect(within(menu).getByText("Settings")).toBeInTheDocument();
+    });
+    const itemLabels = queryAllByRoleFast("menuitem", menu).map((element) => {
+      return element.textContent ?? "";
+    });
+    const memoryIndex = itemLabels.findIndex((label) => {
+      return label.includes("Memory");
+    });
+    const settingsIndex = itemLabels.findIndex((label) => {
+      return label.includes("Settings");
+    });
+    expect(memoryIndex).toBeGreaterThanOrEqual(0);
+    expect(settingsIndex).toBeGreaterThan(memoryIndex);
+  });
+
+  it("hides Memory in the account dropdown when MemoryViewer is off", async () => {
+    mockBaseAPIs();
+    detachedSetupPage({
+      context,
+      path: "/",
+      featureSwitches: { [FeatureSwitchKey.MemoryViewer]: false },
+    });
+
+    await waitFor(() => {
+      expect(screen.getByText("Test User")).toBeInTheDocument();
+    });
+
+    click(screen.getByText("Test User"));
+
+    const menu = await screen.findByRole("menu");
+    await waitFor(() => {
+      expect(within(menu).getByText("Settings")).toBeInTheDocument();
+    });
+    expect(within(menu).queryByText("Memory")).not.toBeInTheDocument();
+  });
+
+  it("navigates to Memory from the account dropdown", async () => {
+    mockBaseAPIs();
+    detachedSetupPage({
+      context,
+      path: "/",
+      featureSwitches: { [FeatureSwitchKey.MemoryViewer]: true },
+    });
+
+    await waitFor(() => {
+      expect(screen.getByText("Test User")).toBeInTheDocument();
+    });
+
+    click(screen.getByText("Test User"));
+
+    const menu = await screen.findByRole("menu");
+    click(within(menu).getByText("Memory"));
+
+    await waitFor(() => {
+      expect(pathname()).toBe("/memory");
+    });
+  });
+
   it("hides Lab entry in account dropdown during onboarding even when FeatureSwitchKey.Lab is on", async () => {
     server.use(
       mockApi(onboardingStatusContract.getStatus, ({ respond }) => {

--- a/turbo/apps/platform/src/views/zero-page/zero-sidebar-account.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-sidebar-account.tsx
@@ -16,6 +16,7 @@ import {
   IconDatabaseExport,
   IconFlask,
   IconCoins,
+  IconBrain,
 } from "@tabler/icons-react";
 import { FeatureSwitchKey } from "@vm0/connectors/feature-switch-key";
 import {
@@ -35,6 +36,7 @@ import {
 } from "../../signals/auth.ts";
 import { detach, Reason } from "../../signals/utils.ts";
 import {
+  handleZeroNavSelect$,
   setSidebarExpanded$,
   type ZeroAccountAction,
 } from "../../signals/zero-page/zero-nav.ts";
@@ -256,16 +258,29 @@ function AdminCreditBalanceItemContent({
 }
 
 function UnifiedSettingsGroup({
+  memoryEnabled,
   labEnabled,
+  onOpenMemory,
   onAccountAction,
   onOpenSettings,
 }: {
+  memoryEnabled: boolean;
   labEnabled: boolean;
+  onOpenMemory: () => void;
   onAccountAction: (action: ZeroAccountAction) => void;
   onOpenSettings: () => void;
 }) {
   return (
     <>
+      {memoryEnabled && (
+        <DropdownMenuItem
+          onClick={onOpenMemory}
+          className="gap-3 px-3 py-2.5 rounded-lg"
+        >
+          <IconBrain size={18} stroke={1.5} className="text-muted-foreground" />
+          <span>Memory</span>
+        </DropdownMenuItem>
+      )}
       <DropdownMenuItem
         onClick={onOpenSettings}
         className="gap-3 px-3 py-2.5 rounded-lg"
@@ -432,7 +447,9 @@ export function AccountDropdown({
   const features = useLastResolved(featureSwitch$);
   const apiBase = useLastResolved(apiBaseForNavigation$);
   const showExportData = features?.[FeatureSwitchKey.DataExport] ?? false;
+  const memoryEnabled = features?.[FeatureSwitchKey.MemoryViewer] ?? false;
   const labEnabled = features?.[FeatureSwitchKey.Lab] ?? false;
+  const selectNav = useSet(handleZeroNavSelect$);
   const openSettings = useSet(openSettingsDialogAt$);
   const setSidebarExpanded = useSet(setSidebarExpanded$);
   const pageSignal = useGet(pageSignal$);
@@ -477,6 +494,11 @@ export function AccountDropdown({
     detach(clerk?.openSignIn(), Reason.DomCallback);
   };
 
+  const handleOpenMemory = () => {
+    selectNav("memory", pageSignal);
+    setSidebarExpanded(false);
+  };
+
   const handleOpenSettings = () => {
     setSidebarExpanded(false);
     detach(openSettings("preference", pageSignal), Reason.DomCallback);
@@ -510,7 +532,9 @@ export function AccountDropdown({
         )}
         {!hidePreferences && (
           <UnifiedSettingsGroup
+            memoryEnabled={memoryEnabled}
             labEnabled={labEnabled}
+            onOpenMemory={handleOpenMemory}
             onAccountAction={handleAccountAction}
             onOpenSettings={handleOpenSettings}
           />

--- a/turbo/apps/platform/src/views/zero-page/zero-sidebar.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-sidebar.tsx
@@ -12,7 +12,6 @@ import {
   IconLayoutGrid,
   IconCalendar,
   IconFileText,
-  IconBrain,
   IconUsers,
   IconEdit,
   IconChevronRight,
@@ -92,14 +91,6 @@ const MANAGE_NAV: readonly ManageNavItem[] = [
     label: "Skills",
     icon: IconFileText as NavIcon,
     featureGate: FeatureSwitchKey.SkillsViewer,
-  },
-  {
-    id: "memory",
-    activeKeys: ["memory"],
-    pathname: "/memory",
-    label: "Memory",
-    icon: IconBrain as NavIcon,
-    featureGate: FeatureSwitchKey.MemoryViewer,
   },
   {
     id: "connectors",


### PR DESCRIPTION
## Summary
- remove the Memory item from the Zero sidebar Manage section
- add the Memory item above Settings in the account dropdown behind the existing MemoryViewer feature switch
- cover the new placement, feature gate, and /memory navigation from the account dropdown
- stabilize the profile browser E2E assertion by checking the page title inside the sandbox and asserting stable CLI output

## Test plan
- pnpm exec prettier --check apps/platform/src/views/zero-page/zero-sidebar.tsx apps/platform/src/views/zero-page/zero-sidebar-account.tsx apps/platform/src/views/zero-page/__tests__/zero-sidebar-interaction.test.tsx
- pnpm -F @vm0/app exec oxlint src/views/zero-page/zero-sidebar.tsx src/views/zero-page/zero-sidebar-account.tsx src/views/zero-page/__tests__/zero-sidebar-interaction.test.tsx
- NODE_OPTIONS=--no-webstorage pnpm -F @vm0/app exec vitest run src/views/zero-page/__tests__/zero-sidebar-interaction.test.tsx
- NODE_OPTIONS=--no-webstorage pnpm -F @vm0/app check-types
- git diff --check

## Notes
- Browser smoke test against the local Vite app was attempted, but the page did not boot locally because VITE_API_URL is not set.
- The full profile browser E2E requires the CI runner environment; this PR relies on the Turbo CI shard for end-to-end validation.
- A temporary Stripe webhook endpoint capacity workaround was removed from this PR to avoid conflicting with #16624, which removes the per-PR Stripe preview webhook setup entirely.
