### PR TITLE
chore: preserve ironclad connector icon color

### DIFF
--- a/turbo/apps/platform/src/views/zero-page/components/settings/connector-icons.tsx
+++ b/turbo/apps/platform/src/views/zero-page/components/settings/connector-icons.tsx
@@ -155,6 +155,7 @@ const CONNECTOR_ICON_COLORFUL = {
   instagram: true,
   instantly: true,
   "intervals-icu": true,
+  ironclad: true,
   jam: true,
   jira: true,
   jotform: true,


### PR DESCRIPTION
## Summary

- Adds `ironclad` to `CONNECTOR_ICON_COLORFUL`.
- Keeps the existing Ironclad SVG and explicit official green `#00ca88` fill unchanged.

## Verification

- `pnpm --dir turbo exec prettier --check apps/platform/src/views/zero-page/components/settings/connector-icons.tsx`
- `git diff --check`
- `pnpm --dir turbo -F @vm0/app lint`
- pre-commit hook: `knip` and `check-types`

Closes #16610
