### PR TITLE
ci: harden stripe preview webhook setup

### DIFF
--- a/.github/scripts/stripe-preview-webhook.sh
+++ b/.github/scripts/stripe-preview-webhook.sh
@@ -39,34 +39,92 @@ require_env() {
   fi
 }
 
-install_stripe_cli() {
-  export PATH="$HOME/.local/bin:$PATH"
-  bash e2e/scripts/ensure-stripe-cli.sh >/dev/null
+STRIPE_API_BASE_URL="${STRIPE_API_BASE_URL:-https://api.stripe.com/v1}"
+
+print_stripe_error() {
+  local response="$1"
+  local fallback="$2"
+  local error_message
+
+  error_message="$(jq -r '
+    if .error then
+      [
+        (.error.type // "unknown_error"),
+        (.error.code // empty),
+        (.error.message // "no message")
+      ]
+      | map(select(. != ""))
+      | join(": ")
+    else
+      empty
+    end
+  ' <<<"$response" 2>/dev/null || true)"
+  if [[ -n "$error_message" ]]; then
+    echo "::error::${fallback}: ${error_message}" >&2
+    return
+  fi
+
+  local object keys
+  object="$(jq -r '.object // empty' <<<"$response" 2>/dev/null || true)"
+  keys="$(jq -r 'if type == "object" then keys_unsorted | join(",") else empty end' <<<"$response" 2>/dev/null || true)"
+  if [[ -n "$object" || -n "$keys" ]]; then
+    echo "::error::${fallback}; response object=${object:-unknown}, keys=${keys:-unknown}" >&2
+  elif [[ -n "$response" ]]; then
+    echo "::error::${fallback}; Stripe returned a non-JSON response" >&2
+  else
+    echo "::error::${fallback}; Stripe returned an empty response" >&2
+  fi
 }
 
-stripe_with_retry() {
-  local attempt
-  local delay=2
-  local output
-  local status
+json_field() {
+  local response="$1"
+  local filter="$2"
+  jq -r "${filter} // \"\"" <<<"$response" 2>/dev/null || true
+}
 
-  for attempt in 1 2 3 4 5; do
-    status=0
-    output="$(stripe --api-key "$STRIPE_SECRET_KEY" "$@" 2>&1)" || status=$?
-    if [[ "$status" -eq 0 ]]; then
-      printf '%s\n' "$output"
-      return 0
-    fi
+stripe_api_request() {
+  local method="$1"
+  local path="$2"
+  shift 2
 
-    if [[ "$attempt" -eq 5 ]] || ! grep -Eiq 'rate limit|too many requests| 429\b|status=429' <<<"$output"; then
-      printf '%s\n' "$output" >&2
-      return "$status"
-    fi
+  local response_file
+  response_file="$(mktemp)"
+  local http_status=""
+  local status=0
 
-    echo "Stripe API rate limited; retrying in ${delay}s (attempt ${attempt}/5)" >&2
-    sleep "$delay"
-    delay=$((delay * 2))
-  done
+  http_status="$(
+    curl \
+      --silent \
+      --show-error \
+      --request "$method" \
+      --user "${STRIPE_SECRET_KEY}:" \
+      --retry 5 \
+      --retry-delay 2 \
+      --retry-max-time 60 \
+      --retry-all-errors \
+      --connect-timeout 10 \
+      --max-time 30 \
+      --output "$response_file" \
+      --write-out '%{http_code}' \
+      "$@" \
+      "${STRIPE_API_BASE_URL}${path}"
+  )" || status=$?
+
+  local response
+  response="$(cat "$response_file")"
+  rm -f "$response_file"
+
+  if [[ "$status" -ne 0 ]]; then
+    print_stripe_error "$response" "Stripe API ${method} ${path} failed"
+    return "$status"
+  fi
+
+  if [[ ! "$http_status" =~ ^2[0-9][0-9]$ ]]; then
+    print_stripe_error "$response" "Stripe API ${method} ${path} failed with HTTP ${http_status:-unknown}"
+    return 1
+  fi
+
+  printf '%s\n' "$response"
 }
 
 preview_pr_number() {
@@ -80,10 +138,18 @@ list_matching_endpoint_ids() {
   local ids
 
   while true; do
+    local list_args=(
+      --get
+      --data-urlencode "limit=100"
+    )
     if [[ -n "$starting_after" ]]; then
-      response="$(stripe_with_retry webhook_endpoints list --limit 100 --starting-after "$starting_after")"
-    else
-      response="$(stripe_with_retry webhook_endpoints list --limit 100)"
+      list_args+=(--data-urlencode "starting_after=${starting_after}")
+    fi
+
+    response="$(stripe_api_request GET "/webhook_endpoints" "${list_args[@]}")"
+    if ! jq -e '.data | type == "array"' >/dev/null 2>&1 <<<"$response"; then
+      print_stripe_error "$response" "Stripe did not return a webhook endpoint list"
+      exit 1
     fi
 
     ids="$(jq -r --arg job_ref "$JOB_REF" --arg url "$webhook_url" '
@@ -95,17 +161,17 @@ list_matching_endpoint_ids() {
             or ($url != "" and .url == $url)
           )
         )
-      | .id
+      | .id // empty
     ' <<<"$response")"
     if [[ -n "$ids" ]]; then
       printf '%s\n' "$ids"
     fi
 
-    if [[ "$(jq -r '.has_more' <<<"$response")" != "true" ]]; then
+    if [[ "$(json_field "$response" '.has_more')" != "true" ]]; then
       break
     fi
 
-    starting_after="$(jq -r '.data[-1].id // ""' <<<"$response")"
+    starting_after="$(json_field "$response" '.data[-1].id')"
     if [[ -z "$starting_after" ]]; then
       break
     fi
@@ -124,7 +190,7 @@ delete_matching_endpoints() {
       continue
     fi
     echo "Deleting Stripe webhook endpoint ${endpoint_id} for ${JOB_REF}"
-    stripe_with_retry webhook_endpoints delete "$endpoint_id" --confirm >/dev/null
+    stripe_api_request DELETE "/webhook_endpoints/${endpoint_id}" >/dev/null
   done <<<"$endpoint_ids"
 }
 
@@ -156,39 +222,40 @@ upsert_endpoint() {
   delete_matching_endpoints "$webhook_url"
 
   local create_args=(
-    webhook_endpoints create
-    --confirm
-    --description "vm0 API preview webhook for ${JOB_REF}"
-    --url "$webhook_url"
-    -d "metadata[managed_by]=github-actions"
-    -d "metadata[job_ref]=${JOB_REF}"
-    -d "metadata[github_pr]=${pr_number}"
+    --header "Idempotency-Key: vm0-preview-webhook-${JOB_REF}-${GITHUB_RUN_ID:-local}-${GITHUB_RUN_ATTEMPT:-0}"
+    --data-urlencode "description=vm0 API preview webhook for ${JOB_REF}"
+    --data-urlencode "url=${webhook_url}"
+    --data-urlencode "metadata[managed_by]=github-actions"
+    --data-urlencode "metadata[job_ref]=${JOB_REF}"
+    --data-urlencode "metadata[github_pr]=${pr_number}"
   )
   if [[ -n "${GITHUB_REPOSITORY:-}" ]]; then
-    create_args+=(-d "metadata[github_repository]=${GITHUB_REPOSITORY}")
+    create_args+=(--data-urlencode "metadata[github_repository]=${GITHUB_REPOSITORY}")
   fi
   if [[ -n "${GITHUB_RUN_ID:-}" ]]; then
-    create_args+=(-d "metadata[github_run_id]=${GITHUB_RUN_ID}")
+    create_args+=(--data-urlencode "metadata[github_run_id]=${GITHUB_RUN_ID}")
   fi
   local event
   for event in "${EVENTS[@]}"; do
-    create_args+=(--enabled-events "$event")
+    create_args+=(--data-urlencode "enabled_events[]=${event}")
   done
 
   local endpoint
-  endpoint="$(stripe_with_retry "${create_args[@]}")"
+  endpoint="$(stripe_api_request POST "/webhook_endpoints" "${create_args[@]}")"
 
   local endpoint_id webhook_secret
-  endpoint_id="$(jq -r '.id // ""' <<<"$endpoint")"
-  webhook_secret="$(jq -r '.secret // ""' <<<"$endpoint")"
-  echo "::add-mask::${webhook_secret}"
+  endpoint_id="$(json_field "$endpoint" '.id')"
+  webhook_secret="$(json_field "$endpoint" '.secret')"
+  if [[ -n "$webhook_secret" ]]; then
+    echo "::add-mask::${webhook_secret}"
+  fi
 
   if [[ "$endpoint_id" != we_* ]]; then
-    echo "::error::Stripe did not return a webhook endpoint id" >&2
+    print_stripe_error "$endpoint" "Stripe did not return a webhook endpoint id"
     exit 1
   fi
   if [[ "$webhook_secret" != whsec_* ]]; then
-    echo "::error::Stripe did not return a webhook signing secret" >&2
+    print_stripe_error "$endpoint" "Stripe did not return a webhook signing secret"
     exit 1
   fi
 
@@ -220,7 +287,6 @@ main() {
 
   require_env STRIPE_SECRET_KEY
   require_env JOB_REF
-  install_stripe_cli
 
   case "$1" in
     upsert)

--- a/.github/scripts/tests/stripe-preview-webhook-test.sh
+++ b/.github/scripts/tests/stripe-preview-webhook-test.sh
@@ -30,38 +30,90 @@ HOME_DIR="${TMPDIR}/home"
 FAKE_BIN="${HOME_DIR}/.local/bin"
 mkdir -p "$FAKE_BIN"
 
-cat > "${FAKE_BIN}/stripe" <<'BASH'
+cat > "${FAKE_BIN}/curl" <<'BASH'
 #!/usr/bin/env bash
 set -euo pipefail
 
-if [[ "${1:-}" == "--version" ]]; then
-  echo "stripe version fake"
-  exit 0
+method=""
+output_file=""
+url=""
+data=()
+headers=()
+
+while [[ "$#" -gt 0 ]]; do
+  case "$1" in
+    --request)
+      method="$2"
+      shift 2
+      ;;
+    --user | --retry | --retry-delay | --retry-max-time | --connect-timeout | --max-time | --write-out)
+      shift 2
+      ;;
+    --header)
+      headers+=("$2")
+      shift 2
+      ;;
+    --output)
+      output_file="$2"
+      shift 2
+      ;;
+    --data-urlencode)
+      data+=("$2")
+      shift 2
+      ;;
+    --silent | --show-error | --retry-all-errors | --get)
+      shift
+      ;;
+    http://* | https://*)
+      url="$1"
+      shift
+      ;;
+    *)
+      echo "unexpected curl argument: $1" >&2
+      exit 1
+      ;;
+  esac
+done
+
+if [[ -z "$method" || -z "$output_file" || -z "$url" ]]; then
+  echo "missing fake curl method, output file, or url" >&2
+  exit 1
 fi
 
-printf '%s\n' "$*" >> "$STRIPE_ARGS_LOG"
+printf '%s %s\n' "$method" "$url" >> "$STRIPE_ARGS_LOG"
+for item in "${data[@]}"; do
+  printf 'data %s\n' "$item" >> "$STRIPE_ARGS_LOG"
+done
+for item in "${headers[@]}"; do
+  printf 'header %s\n' "$item" >> "$STRIPE_ARGS_LOG"
+done
 
-if [[ "${1:-}" == "--api-key" ]]; then
-  shift 2
-fi
+path="${url#https://api.stripe.com/v1}"
+http_status=200
+body=""
 
-case "${1:-} ${2:-}" in
-  "webhook_endpoints list")
-    cat "$FAKE_STRIPE_LIST_JSON"
+case "$method $path" in
+  "GET /webhook_endpoints")
+    body="$(cat "$FAKE_STRIPE_LIST_JSON")"
     ;;
-  "webhook_endpoints delete")
-    printf '{"id":"%s","deleted":true}\n' "$3"
+  DELETE\ /webhook_endpoints/*)
+    endpoint_id="${path##*/}"
+    body="{\"id\":\"${endpoint_id}\",\"deleted\":true}"
     ;;
-  "webhook_endpoints create")
-    printf '{"id":"we_new","secret":"whsec_new"}\n'
+  "POST /webhook_endpoints")
+    http_status="${FAKE_STRIPE_CREATE_STATUS:-200}"
+    body="${FAKE_STRIPE_CREATE_JSON:-{\"id\":\"we_new\",\"secret\":\"whsec_new\"}}"
     ;;
   *)
-    echo "unexpected stripe call: $*" >&2
+    echo "unexpected fake curl request: $method $path" >&2
     exit 1
     ;;
 esac
+
+printf '%s\n' "$body" > "$output_file"
+printf '%s' "$http_status"
 BASH
-chmod +x "${FAKE_BIN}/stripe"
+chmod +x "${FAKE_BIN}/curl"
 
 LIST_JSON="${TMPDIR}/endpoints.json"
 cat > "$LIST_JSON" <<'JSON'
@@ -112,16 +164,17 @@ HOME="$HOME_DIR" \
   JOB_REF="pr-123" \
   API_PREVIEW_URL="https://pr-123-api.vm0.test" \
   API_ENV_FILE="$API_ENV_FILE" \
-  bash "$SCRIPT" upsert >/tmp/stripe-preview-webhook-upsert.out
+  bash "$SCRIPT" upsert >"${TMPDIR}/stripe-preview-webhook-upsert.out"
 
-assert_contains "$ARGS_LOG" "webhook_endpoints delete we_managed_job --confirm"
-assert_contains "$ARGS_LOG" "webhook_endpoints delete we_managed_url --confirm"
-assert_not_contains "$ARGS_LOG" "webhook_endpoints delete we_unmanaged_job --confirm"
-assert_not_contains "$ARGS_LOG" "webhook_endpoints delete we_unmanaged_url --confirm"
-assert_contains "$ARGS_LOG" "webhook_endpoints create"
-assert_contains "$ARGS_LOG" "--url https://pr-123-api.vm0.test/api/webhooks/stripe"
-assert_contains "$ARGS_LOG" "metadata[job_ref]=pr-123"
-assert_contains "$ARGS_LOG" "--enabled-events invoice.paid"
+assert_contains "$ARGS_LOG" "DELETE https://api.stripe.com/v1/webhook_endpoints/we_managed_job"
+assert_contains "$ARGS_LOG" "DELETE https://api.stripe.com/v1/webhook_endpoints/we_managed_url"
+assert_not_contains "$ARGS_LOG" "DELETE https://api.stripe.com/v1/webhook_endpoints/we_unmanaged_job"
+assert_not_contains "$ARGS_LOG" "DELETE https://api.stripe.com/v1/webhook_endpoints/we_unmanaged_url"
+assert_contains "$ARGS_LOG" "POST https://api.stripe.com/v1/webhook_endpoints"
+assert_contains "$ARGS_LOG" "header Idempotency-Key: vm0-preview-webhook-pr-123-local-0"
+assert_contains "$ARGS_LOG" "data url=https://pr-123-api.vm0.test/api/webhooks/stripe"
+assert_contains "$ARGS_LOG" "data metadata[job_ref]=pr-123"
+assert_contains "$ARGS_LOG" "data enabled_events[]=invoice.paid"
 assert_contains "$API_ENV_FILE" "STRIPE_WEBHOOK_SECRET=whsec_new"
 
 : > "$ARGS_LOG"
@@ -131,10 +184,10 @@ HOME="$HOME_DIR" \
   FAKE_STRIPE_LIST_JSON="$LIST_JSON" \
   STRIPE_SECRET_KEY="sk_test_fake" \
   JOB_REF="pr-123" \
-  bash "$SCRIPT" cleanup >/tmp/stripe-preview-webhook-cleanup.out
+  bash "$SCRIPT" cleanup >"${TMPDIR}/stripe-preview-webhook-cleanup.out"
 
-assert_contains "$ARGS_LOG" "webhook_endpoints delete we_managed_job --confirm"
-assert_not_contains "$ARGS_LOG" "webhook_endpoints delete we_unmanaged_job --confirm"
+assert_contains "$ARGS_LOG" "DELETE https://api.stripe.com/v1/webhook_endpoints/we_managed_job"
+assert_not_contains "$ARGS_LOG" "DELETE https://api.stripe.com/v1/webhook_endpoints/we_unmanaged_job"
 
 : > "$ARGS_LOG"
 HOME="$HOME_DIR" \
@@ -144,10 +197,55 @@ HOME="$HOME_DIR" \
   STRIPE_SECRET_KEY="sk_test_fake" \
   JOB_REF="staging" \
   API_ENV_FILE="$API_ENV_FILE" \
-  bash "$SCRIPT" upsert >/tmp/stripe-preview-webhook-staging.out
+  bash "$SCRIPT" upsert >"${TMPDIR}/stripe-preview-webhook-staging.out"
 
 if [[ -s "$ARGS_LOG" ]]; then
   fail "expected non-PR upsert to skip Stripe API calls"
 fi
+
+: > "$ARGS_LOG"
+ERROR_JSON='{"error":{"type":"invalid_request_error","code":"url_invalid","message":"Invalid webhook URL"}}'
+set +e
+HOME="$HOME_DIR" \
+  PATH="${FAKE_BIN}:${PATH}" \
+  STRIPE_ARGS_LOG="$ARGS_LOG" \
+  FAKE_STRIPE_LIST_JSON="$LIST_JSON" \
+  FAKE_STRIPE_CREATE_JSON="$ERROR_JSON" \
+  FAKE_STRIPE_CREATE_STATUS=400 \
+  STRIPE_SECRET_KEY="sk_test_fake" \
+  JOB_REF="pr-123" \
+  API_PREVIEW_URL="https://pr-123-api.vm0.test" \
+  API_ENV_FILE="$API_ENV_FILE" \
+  bash "$SCRIPT" upsert >"${TMPDIR}/stripe-preview-webhook-error.out" 2>"${TMPDIR}/stripe-preview-webhook-error.err"
+status=$?
+set -e
+if [[ "$status" -eq 0 ]]; then
+  fail "expected Stripe HTTP error to fail"
+fi
+assert_contains "${TMPDIR}/stripe-preview-webhook-error.err" "Stripe API POST /webhook_endpoints failed with HTTP 400"
+assert_contains "${TMPDIR}/stripe-preview-webhook-error.err" "invalid_request_error: url_invalid: Invalid webhook URL"
+assert_not_contains "${TMPDIR}/stripe-preview-webhook-error.out" "::add-mask::"
+
+: > "$ARGS_LOG"
+UNEXPECTED_JSON='{"dry_run":{"method":"POST","url":"https://api.stripe.com/v1/webhook_endpoints"}}'
+set +e
+HOME="$HOME_DIR" \
+  PATH="${FAKE_BIN}:${PATH}" \
+  STRIPE_ARGS_LOG="$ARGS_LOG" \
+  FAKE_STRIPE_LIST_JSON="$LIST_JSON" \
+  FAKE_STRIPE_CREATE_JSON="$UNEXPECTED_JSON" \
+  STRIPE_SECRET_KEY="sk_test_fake" \
+  JOB_REF="pr-123" \
+  API_PREVIEW_URL="https://pr-123-api.vm0.test" \
+  API_ENV_FILE="$API_ENV_FILE" \
+  bash "$SCRIPT" upsert >"${TMPDIR}/stripe-preview-webhook-unexpected.out" 2>"${TMPDIR}/stripe-preview-webhook-unexpected.err"
+status=$?
+set -e
+if [[ "$status" -eq 0 ]]; then
+  fail "expected unexpected Stripe response to fail"
+fi
+assert_contains "${TMPDIR}/stripe-preview-webhook-unexpected.err" "Stripe did not return a webhook endpoint id"
+assert_contains "${TMPDIR}/stripe-preview-webhook-unexpected.err" "keys=dry_run"
+assert_not_contains "${TMPDIR}/stripe-preview-webhook-unexpected.out" "::add-mask::"
 
 echo "stripe-preview-webhook-test: ok"


### PR DESCRIPTION
## Summary
- replace Stripe CLI preview webhook provisioning with direct Stripe REST API calls
- add curl retry handling, create idempotency keys, and safer diagnostics for non-endpoint responses
- update shell tests to fake curl and cover HTTP error / unexpected JSON responses

## Test plan
- `bash -n .github/scripts/*.sh .github/scripts/tests/*.sh`
- `for test_script in .github/scripts/tests/*.sh; do bash "$test_script"; done`
- `git diff --check`