### PR TITLE
perf: offload snapshot filesystem critical sections

### DIFF
--- a/crates/sandbox-fc/src/snapshot/output.rs
+++ b/crates/sandbox-fc/src/snapshot/output.rs
@@ -1,6 +1,8 @@
 use std::io::{self, Write};
 use std::path::{Path, PathBuf};
 
+use tokio::runtime::{Handle, RuntimeFlavor};
+
 use crate::paths::SnapshotOutputPaths;
 
 use super::SnapshotError;
@@ -40,6 +42,17 @@ fn require_snapshot_artifact_regular_file_sync(path: &Path) -> io::Result<()> {
         return Err(non_file_snapshot_artifact_error(path));
     }
     Ok(())
+}
+
+pub(super) fn run_snapshot_blocking_fs<T>(f: impl FnOnce() -> T) -> T {
+    match Handle::try_current() {
+        Ok(handle) => match handle.runtime_flavor() {
+            RuntimeFlavor::MultiThread => tokio::task::block_in_place(f),
+            RuntimeFlavor::CurrentThread => f(),
+            _ => f(),
+        },
+        Err(_) => f(),
+    }
 }
 
 pub(super) async fn snapshot_artifacts_are_regular_files(
@@ -125,6 +138,10 @@ pub(super) async fn prepare_snapshot_output(
     // Use synchronous filesystem calls for shared snapshot-hash paths while the
     // caller holds the snapshot lock. A cancelled Tokio fs operation can keep
     // running on the blocking pool after the lock is dropped.
+    run_snapshot_blocking_fs(|| prepare_snapshot_output_sync(output))
+}
+
+fn prepare_snapshot_output_sync(output: &SnapshotOutputPaths) -> Result<PathBuf, SnapshotError> {
     let work = output.work_dir();
     remove_file_if_exists_sync(&output.complete_marker())?;
     remove_dir_all_if_exists_sync(&work)?;
@@ -192,6 +209,27 @@ mod tests {
     use crate::paths::SnapshotOutputPaths;
 
     use super::*;
+
+    #[test]
+    fn snapshot_blocking_fs_runs_without_tokio_runtime() {
+        assert_eq!(run_snapshot_blocking_fs(|| "done"), "done");
+    }
+
+    #[test]
+    #[should_panic(expected = "snapshot blocking fs panic")]
+    fn snapshot_blocking_fs_propagates_panic() {
+        run_snapshot_blocking_fs(|| panic!("snapshot blocking fs panic"));
+    }
+
+    #[tokio::test(flavor = "current_thread")]
+    async fn snapshot_blocking_fs_current_thread_runtime_runs() {
+        assert_eq!(run_snapshot_blocking_fs(|| "done"), "done");
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn snapshot_blocking_fs_multi_thread_runtime_runs() {
+        assert_eq!(run_snapshot_blocking_fs(|| "done"), "done");
+    }
 
     async fn write_required_snapshot_artifacts(output: &SnapshotOutputPaths) {
         tokio::fs::create_dir_all(output.dir())

--- a/crates/sandbox-fc/src/snapshot/publish.rs
+++ b/crates/sandbox-fc/src/snapshot/publish.rs
@@ -16,7 +16,7 @@ use super::cow::{
 };
 use super::output::{
     cleanup_remove_file_result, publish_snapshot_complete_marker, remove_dir_all_if_exists_sync,
-    remove_file_if_exists_sync, sync_snapshot_output_dir,
+    remove_file_if_exists_sync, run_snapshot_blocking_fs, sync_snapshot_output_dir,
 };
 
 type KeepCowFinalizer =
@@ -223,7 +223,9 @@ impl FirecrackerPendingSnapshotPublish {
         );
         match state {
             FirecrackerPendingSnapshotPublishState::Pending(kept_cow) => {
-                match commit_snapshot_cow_output(&kept_cow, &self.output) {
+                match run_snapshot_blocking_fs(|| {
+                    commit_snapshot_cow_output(&kept_cow, &self.output)
+                }) {
                     Ok(()) => {
                         self.state = FirecrackerPendingSnapshotPublishState::Committed;
                         Ok(self.snapshot_config.clone())
@@ -256,15 +258,20 @@ impl FirecrackerPendingSnapshotPublish {
             | FirecrackerPendingSnapshotPublishState::Discarded => return Ok(()),
         };
 
-        let output_artifacts_cleaned = cleanup_uncommitted_snapshot_output_artifacts(&self.output);
-        let cow_cleaned = cleanup_kept_cow_paths_after_publish_cancellation(&cleanup_paths).await;
-        let work_cleaned = if cow_cleaned {
-            cleanup_snapshot_work_dir(&self.output)
-        } else {
-            false
-        };
+        let cleaned = run_snapshot_blocking_fs(|| {
+            let output_artifacts_cleaned =
+                cleanup_uncommitted_snapshot_output_artifacts(&self.output);
+            let cow_cleaned = cleanup_kept_cow_paths_after_publish_discard(&cleanup_paths);
+            let work_cleaned = if cow_cleaned {
+                cleanup_snapshot_work_dir(&self.output)
+            } else {
+                false
+            };
 
-        if output_artifacts_cleaned && cow_cleaned && work_cleaned {
+            output_artifacts_cleaned && cow_cleaned && work_cleaned
+        });
+
+        if cleaned {
             self.state = FirecrackerPendingSnapshotPublishState::Discarded;
             Ok(())
         } else {
@@ -379,14 +386,24 @@ fn cleanup_kept_cow_after_publish_drop(kept_cow: &KeptCow) -> bool {
     cleanup_kept_cow_paths_after_publish_drop(&KeptCowCleanupPaths::from_kept_cow(kept_cow))
 }
 
+fn cleanup_kept_cow_paths_after_publish_discard(paths: &KeptCowCleanupPaths) -> bool {
+    cleanup_kept_cow_paths_sync(
+        paths,
+        "failed to cleanup kept COW artifact after pending snapshot publish discard",
+    )
+}
+
 fn cleanup_kept_cow_paths_after_publish_drop(paths: &KeptCowCleanupPaths) -> bool {
+    cleanup_kept_cow_paths_sync(
+        paths,
+        "failed to cleanup kept COW artifact after pending snapshot publish drop",
+    )
+}
+
+fn cleanup_kept_cow_paths_sync(paths: &KeptCowCleanupPaths, warning: &'static str) -> bool {
     let mut cleaned = true;
     for path in [&paths.bitmap_file, &paths.cow_file] {
-        if !cleanup_remove_file_result(
-            std::fs::remove_file(path),
-            path,
-            "failed to cleanup kept COW artifact after pending snapshot publish drop",
-        ) {
+        if !cleanup_remove_file_result(std::fs::remove_file(path), path, warning) {
             cleaned = false;
         }
     }
@@ -533,6 +550,34 @@ mod tests {
         assert!(provider.is_complete(output.dir()).await.unwrap());
     }
 
+    #[tokio::test(flavor = "multi_thread")]
+    async fn pending_snapshot_publish_commit_multi_thread_runtime_writes_complete_marker() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let output = SnapshotOutputPaths::new(dir.path().join("output"));
+        write_required_snapshot_artifacts(&output).await;
+        let kept_cow =
+            write_kept_cow_for_test(&output.work_dir(), "pending-commit-multi-thread").await;
+        let mut pending: Box<dyn PendingSnapshotPublish> =
+            Box::new(FirecrackerPendingSnapshotPublish::new(
+                output.snapshot_config("pending-commit-multi-thread"),
+                SnapshotOutputPaths::new(output.dir().to_path_buf()),
+                kept_cow,
+            ));
+
+        pending
+            .commit()
+            .await
+            .expect("multi-thread commit should publish snapshot");
+
+        assert!(
+            FirecrackerSnapshotProvider
+                .is_complete(output.dir())
+                .await
+                .unwrap(),
+            "multi-thread commit should write a complete snapshot"
+        );
+    }
+
     #[tokio::test]
     async fn pending_snapshot_publish_commit_failure_does_not_publish_marker() {
         let dir = tempfile::tempdir().expect("tempdir");
@@ -572,7 +617,7 @@ mod tests {
         );
     }
 
-    #[tokio::test]
+    #[tokio::test(flavor = "current_thread")]
     async fn pending_snapshot_publish_discard_does_not_publish_marker_or_stable_cow() {
         let dir = tempfile::tempdir().expect("tempdir");
         let output = SnapshotOutputPaths::new(dir.path().join("output"));


### PR DESCRIPTION
## Summary

Fixes #16451.

- Add a runtime-aware snapshot filesystem helper that uses `block_in_place` on multi-thread Tokio runtimes and inline fallback for current-thread/no-runtime callers.
- Route snapshot output preparation, final COW publish, and pending publish discard cleanup through that synchronous critical-section helper.
- Preserve complete-marker no-await semantics, failed commit retry state, narrow Drop cleanup, and runner cancellation shielding.
- Add runtime compatibility tests and multi-thread pending publish coverage.

## Tests

- `cargo test --manifest-path crates/Cargo.toml -p sandbox-fc snapshot::output`
- `cargo test --manifest-path crates/Cargo.toml -p sandbox-fc snapshot::publish`
- `cargo test --manifest-path crates/Cargo.toml -p runner shielded_snapshot_publish`
- `cargo test --manifest-path crates/Cargo.toml -p sandbox-fc`
- `cargo test --manifest-path crates/Cargo.toml -p runner build_snapshot`
- `cargo clippy --manifest-path crates/Cargo.toml -p sandbox-fc --all-targets -- -D warnings`
- Pre-commit hook: crates `cargo-fmt`, `cargo-clippy`, `cargo-doc`
