### PR TITLE
refactor(sandbox-fc): clarify cow cleanup outcome

### DIFF
--- a/crates/sandbox-fc/src/cow_cleanup.rs
+++ b/crates/sandbox-fc/src/cow_cleanup.rs
@@ -1,0 +1,106 @@
+use std::time::Duration;
+
+use nbd_cow::{DestroyRetryPolicy, PooledDestroyError};
+
+/// Maximum attempts to destroy a COW device after killing Firecracker.
+/// After kill_process_group + child.wait(), the kernel may still be
+/// releasing file descriptors (particularly the NBD device fd).
+const DESTROY_RETRIES: u32 = 5;
+
+/// Delay between COW device destroy retries.
+const DESTROY_RETRY_DELAY: Duration = Duration::from_millis(500);
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub(crate) enum CowCleanupOutcome {
+    BackingFilesSafeToDelete,
+    DeviceMayStillReferenceBackingFiles,
+}
+
+impl CowCleanupOutcome {
+    pub(crate) fn backing_files_safe_to_delete(self) -> bool {
+        matches!(self, Self::BackingFilesSafeToDelete)
+    }
+}
+
+pub(crate) trait CowDestroyErrorSafety {
+    fn backing_files_safe_to_delete(&self) -> bool;
+}
+
+impl CowDestroyErrorSafety for PooledDestroyError {
+    fn backing_files_safe_to_delete(&self) -> bool {
+        self.backing_files_safe_to_delete()
+    }
+}
+
+pub(crate) fn cow_destroy_retry_policy() -> DestroyRetryPolicy {
+    DestroyRetryPolicy {
+        attempts: DESTROY_RETRIES,
+        delay: DESTROY_RETRY_DELAY,
+    }
+}
+
+pub(crate) fn classify_cow_destroy_result<E>(
+    result: &std::result::Result<(), E>,
+) -> CowCleanupOutcome
+where
+    E: CowDestroyErrorSafety,
+{
+    match result {
+        Ok(()) => CowCleanupOutcome::BackingFilesSafeToDelete,
+        Err(e) if e.backing_files_safe_to_delete() => CowCleanupOutcome::BackingFilesSafeToDelete,
+        Err(_) => CowCleanupOutcome::DeviceMayStillReferenceBackingFiles,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[derive(Clone, Copy)]
+    struct FakeCowDestroyError {
+        backing_files_safe_to_delete: bool,
+    }
+
+    impl CowDestroyErrorSafety for FakeCowDestroyError {
+        fn backing_files_safe_to_delete(&self) -> bool {
+            self.backing_files_safe_to_delete
+        }
+    }
+
+    #[test]
+    fn cow_destroy_success_makes_backing_files_safe_to_delete() {
+        let result: std::result::Result<(), FakeCowDestroyError> = Ok(());
+
+        let outcome = classify_cow_destroy_result(&result);
+
+        assert_eq!(outcome, CowCleanupOutcome::BackingFilesSafeToDelete);
+        assert!(outcome.backing_files_safe_to_delete());
+    }
+
+    #[test]
+    fn cow_destroy_storage_cleanup_failure_makes_backing_files_safe_to_delete() {
+        let result = Err(FakeCowDestroyError {
+            backing_files_safe_to_delete: true,
+        });
+
+        let outcome = classify_cow_destroy_result(&result);
+
+        assert_eq!(outcome, CowCleanupOutcome::BackingFilesSafeToDelete);
+        assert!(outcome.backing_files_safe_to_delete());
+    }
+
+    #[test]
+    fn cow_destroy_device_cleanup_failure_preserves_backing_files() {
+        let result = Err(FakeCowDestroyError {
+            backing_files_safe_to_delete: false,
+        });
+
+        let outcome = classify_cow_destroy_result(&result);
+
+        assert_eq!(
+            outcome,
+            CowCleanupOutcome::DeviceMayStillReferenceBackingFiles
+        );
+        assert!(!outcome.backing_files_safe_to_delete());
+    }
+}

--- a/crates/sandbox-fc/src/factory/cow_cleanup.rs
+++ b/crates/sandbox-fc/src/factory/cow_cleanup.rs
@@ -1,44 +1,33 @@
-use std::time::Duration;
-
 use tracing::warn;
 
-use nbd_cow::{DestroyRetryPolicy, PooledNbdCowDevice};
+use nbd_cow::PooledNbdCowDevice;
 
-/// Maximum attempts to destroy a COW device after killing Firecracker.
-/// After kill_process_group + child.wait(), the kernel may still be
-/// releasing file descriptors (particularly the NBD device fd).
-const DESTROY_RETRIES: u32 = 5;
-
-/// Delay between COW device destroy retries.
-const DESTROY_RETRY_DELAY: Duration = Duration::from_millis(500);
-
-pub(crate) fn cow_destroy_retry_policy() -> DestroyRetryPolicy {
-    DestroyRetryPolicy {
-        attempts: DESTROY_RETRIES,
-        delay: DESTROY_RETRY_DELAY,
-    }
-}
+use crate::cow_cleanup::{
+    CowCleanupOutcome, classify_cow_destroy_result, cow_destroy_retry_policy,
+};
 
 pub(super) async fn destroy_cow_device_with_retries(
     id: &str,
     cow_device: PooledNbdCowDevice,
-) -> bool {
-    match cow_device
+) -> CowCleanupOutcome {
+    let result = cow_device
         .destroy_with_retries_detailed(cow_destroy_retry_policy())
-        .await
-    {
-        Ok(()) => true,
-        Err(e) if e.backing_files_safe_to_delete() => {
+        .await;
+    let outcome = classify_cow_destroy_result(&result);
+
+    match (result, outcome) {
+        (Ok(()), outcome) => outcome,
+        (Err(e), CowCleanupOutcome::BackingFilesSafeToDelete) => {
             warn!(
                 id = %id,
                 error = %e,
                 "COW device released but file cleanup failed; continuing directory cleanup"
             );
-            true
+            outcome
         }
-        Err(e) => {
+        (Err(e), CowCleanupOutcome::DeviceMayStillReferenceBackingFiles) => {
             warn!(id = %id, error = %e, "destroy failed after retries — abandoned device");
-            false
+            outcome
         }
     }
 }

--- a/crates/sandbox-fc/src/factory/create_transaction.rs
+++ b/crates/sandbox-fc/src/factory/create_transaction.rs
@@ -6,6 +6,7 @@ use tracing::warn;
 
 use nbd_cow::PooledNbdCowDevice;
 
+use crate::cow_cleanup::CowCleanupOutcome;
 use crate::cow_pool::PrewarmedSlot;
 use crate::factory::cleanup_group::{FactoryCleanupGroup, FactoryCleanupTaskKind};
 use crate::factory::cow_cleanup::destroy_cow_device_with_retries;
@@ -15,7 +16,7 @@ use crate::paths::{SandboxPaths, SockPaths};
 
 #[async_trait]
 pub(super) trait CreateRollbackCleanup {
-    async fn destroy_cow_device(&self, cow_device: PooledNbdCowDevice) -> bool;
+    async fn destroy_cow_device(&self, cow_device: PooledNbdCowDevice) -> CowCleanupOutcome;
     async fn release_network(&self, network: &mut Option<NetnsLease>);
     async fn remove_dir(&self, kind: &'static str, path: PathBuf);
     async fn destroy_slot(&self, slot: PrewarmedSlot);
@@ -28,7 +29,7 @@ pub(super) struct FactoryCreateRollbackCleanup {
 
 #[async_trait]
 impl CreateRollbackCleanup for FactoryCreateRollbackCleanup {
-    async fn destroy_cow_device(&self, cow_device: PooledNbdCowDevice) -> bool {
+    async fn destroy_cow_device(&self, cow_device: PooledNbdCowDevice) -> CowCleanupOutcome {
         destroy_cow_device_with_retries(&self.id, cow_device).await
     }
 
@@ -308,11 +309,13 @@ impl SandboxCreateTransaction {
     {
         let keep_workspace = if let Some(cow_device) = self.cow_device.take() {
             // The COW finalizer continues in the background if this future is
-            // cancelled. Keep the workspace until the finalizer reports success.
+            // cancelled. Keep the workspace until backing files are safe to
+            // delete.
             self.delete_workspace_on_leak_cleanup = false;
-            let cow_destroyed = cleanup.destroy_cow_device(cow_device).await;
-            self.delete_workspace_on_leak_cleanup = cow_destroyed;
-            !cow_destroyed
+            let cow_cleanup_outcome = cleanup.destroy_cow_device(cow_device).await;
+            let backing_files_safe_to_delete = cow_cleanup_outcome.backing_files_safe_to_delete();
+            self.delete_workspace_on_leak_cleanup = backing_files_safe_to_delete;
+            !backing_files_safe_to_delete
         } else {
             false
         };
@@ -611,7 +614,7 @@ mod tests {
 
     #[async_trait]
     impl CreateRollbackCleanup for BlockingRemoveDirCleanup {
-        async fn destroy_cow_device(&self, _cow_device: PooledNbdCowDevice) -> bool {
+        async fn destroy_cow_device(&self, _cow_device: PooledNbdCowDevice) -> CowCleanupOutcome {
             panic!("test cleanup should not receive a real COW device");
         }
 
@@ -652,7 +655,7 @@ mod tests {
 
     #[async_trait]
     impl CreateRollbackCleanup for FailingNetworkReleaseCleanup {
-        async fn destroy_cow_device(&self, _cow_device: PooledNbdCowDevice) -> bool {
+        async fn destroy_cow_device(&self, _cow_device: PooledNbdCowDevice) -> CowCleanupOutcome {
             panic!("test cleanup should not receive a real COW device");
         }
 
@@ -679,7 +682,7 @@ mod tests {
 
     #[async_trait]
     impl CreateRollbackCleanup for RecordingCreateRollbackCleanup {
-        async fn destroy_cow_device(&self, _cow_device: PooledNbdCowDevice) -> bool {
+        async fn destroy_cow_device(&self, _cow_device: PooledNbdCowDevice) -> CowCleanupOutcome {
             panic!("test cleanup should not receive a real COW device");
         }
 

--- a/crates/sandbox-fc/src/factory/leak_cleaner.rs
+++ b/crates/sandbox-fc/src/factory/leak_cleaner.rs
@@ -1,5 +1,6 @@
 use tracing::{info, warn};
 
+use crate::cow_cleanup::CowCleanupOutcome;
 use crate::factory::cow_cleanup::destroy_cow_device_with_retries;
 use crate::leaked_resources::LeakedResources;
 use crate::network::NetnsPoolHandle;
@@ -176,10 +177,10 @@ async fn cleanup_leaked_resource(leaked: LeakedResources, netns_pool: &NetnsPool
         "cleaning up leaked sandbox resources"
     );
 
-    let mut cow_destroyed = true;
-    if let Some(cow_device) = leaked.cow_device {
-        cow_destroyed = destroy_cow_device_with_retries(&leaked.sandbox_id, cow_device).await;
-    }
+    let cow_cleanup_outcome = match leaked.cow_device {
+        Some(cow_device) => destroy_cow_device_with_retries(&leaked.sandbox_id, cow_device).await,
+        None => CowCleanupOutcome::BackingFilesSafeToDelete,
+    };
 
     if let Some(network) = leaked.network {
         let mut network = Some(network);
@@ -191,7 +192,7 @@ async fn cleanup_leaked_resource(leaked: LeakedResources, netns_pool: &NetnsPool
     if let Err(e) = tokio::fs::remove_dir_all(&leaked.sock_dir).await {
         warn!(id = %leaked.sandbox_id, error = %e, "failed to delete leaked sock dir");
     }
-    if cow_destroyed
+    if cow_cleanup_outcome.backing_files_safe_to_delete()
         && leaked.delete_workspace
         && let Err(e) = tokio::fs::remove_dir_all(&leaked.workspace).await
     {
@@ -211,7 +212,7 @@ mod tests {
         },
     };
 
-    use crate::factory::cow_cleanup::cow_destroy_retry_policy;
+    use crate::cow_cleanup::cow_destroy_retry_policy;
     use crate::network::NetnsPool;
 
     fn test_leaked_resource(sandbox_id: &str) -> LeakedResources {

--- a/crates/sandbox-fc/src/factory/mod.rs
+++ b/crates/sandbox-fc/src/factory/mod.rs
@@ -16,6 +16,7 @@ use tracing::{info, warn};
 
 use crate::command;
 use crate::config::{FirecrackerConfig, FirecrackerDeviceRateLimits};
+use crate::cow_cleanup::CowCleanupOutcome;
 use crate::factory::cleanup_group::{FactoryCleanupGroup, FactoryCleanupTaskKind};
 use crate::factory::cow_cleanup::destroy_cow_device_with_retries;
 use crate::factory::create_transaction::{
@@ -28,7 +29,6 @@ use crate::paths::{FactoryPaths, RuntimePaths, SockPaths};
 use crate::prerequisites;
 use crate::sandbox::{FirecrackerSandbox, FirecrackerSandboxInit};
 
-pub(crate) use cow_cleanup::cow_destroy_retry_policy;
 pub(crate) use invariant::InvariantConfig;
 pub use invariant::{PREWARM_SCRIPT, config_hash};
 
@@ -588,23 +588,24 @@ async fn destroy_firecracker_sandbox(mut sandbox: FirecrackerSandbox, netns_pool
         cow_device.log_status().await;
     }
 
-    // Destroy the NBD COW device (flushes data, disconnects, removes COW file).
+    // Destroy the NBD COW device and classify whether backing files can be
+    // deleted. Storage cleanup may fail after the device is already released.
     //
     // After kill_process_group + child.wait(), the kernel may still be
     // releasing file descriptors (particularly the NBD device fd).
     // Retry a few times to let it finish.
-    let cow_destroyed = match sandbox.cow_device.take() {
+    let cow_cleanup_outcome = match sandbox.cow_device.take() {
         Some(cow_device) => {
             // If shutdown aborts this task while the COW finalizer is running,
             // Drop-based leak cleanup must not delete the backing workspace.
             sandbox.preserve_workspace_on_leak_cleanup();
-            let cow_destroyed = destroy_cow_device_with_retries(&sandbox_id, cow_device).await;
-            if cow_destroyed {
+            let outcome = destroy_cow_device_with_retries(&sandbox_id, cow_device).await;
+            if outcome.backing_files_safe_to_delete() {
                 sandbox.allow_workspace_delete_on_leak_cleanup();
             }
-            cow_destroyed
+            outcome
         }
-        None => true,
+        None => CowCleanupOutcome::BackingFilesSafeToDelete,
     };
 
     // Return the network namespace to the pool.
@@ -618,10 +619,12 @@ async fn destroy_firecracker_sandbox(mut sandbox: FirecrackerSandbox, netns_pool
         warn!(id = %sandbox_id, error = %e, "failed to delete sock dir");
     }
 
-    // Delete the workspace directory only if the COW device was fully torn
-    // down.  When destroy() failed, the NBD device may still reference
-    // the COW file — keep the workspace intact for debugging.
-    if cow_destroyed && let Err(e) = tokio::fs::remove_dir_all(&workspace).await {
+    // Delete the workspace directory only if the COW device no longer
+    // references backing files. When device cleanup failed, keep the
+    // workspace intact for debugging.
+    if cow_cleanup_outcome.backing_files_safe_to_delete()
+        && let Err(e) = tokio::fs::remove_dir_all(&workspace).await
+    {
         warn!(id = %sandbox_id, error = %e, "failed to delete workspace");
     }
 

--- a/crates/sandbox-fc/src/lib.rs
+++ b/crates/sandbox-fc/src/lib.rs
@@ -28,6 +28,7 @@ mod balloon;
 mod command;
 mod config;
 pub mod control;
+mod cow_cleanup;
 mod cow_pool;
 mod factory;
 mod guest_operations;

--- a/crates/sandbox-fc/src/snapshot/cow.rs
+++ b/crates/sandbox-fc/src/snapshot/cow.rs
@@ -3,15 +3,15 @@ use std::path::{Path, PathBuf};
 use std::pin::Pin;
 use std::task::{Context, Poll};
 
-use nbd_cow::{DestroyRetryPolicy, PooledNbdCowDevice};
+use nbd_cow::PooledNbdCowDevice;
 use tokio::task::JoinHandle;
+
+use crate::cow_cleanup::{
+    CowCleanupOutcome, classify_cow_destroy_result, cow_destroy_retry_policy,
+};
 
 use super::SnapshotError;
 use super::output::cleanup_remove_dir_result;
-
-pub(super) fn cow_destroy_retry_policy() -> DestroyRetryPolicy {
-    crate::factory::cow_destroy_retry_policy()
-}
 
 pub(super) struct SnapshotCowCleanupFinalizer {
     handle: Option<JoinHandle<nbd_cow::error::Result<()>>>,
@@ -96,18 +96,22 @@ pub(super) fn destroy_snapshot_cow_and_cleanup_attempt_dir(
 ) -> SnapshotCowCleanupFinalizer {
     let cow_file = cow_device.cow_file().to_path_buf();
     SnapshotCowCleanupFinalizer::new(tokio::spawn(async move {
-        match cow_device
+        let result = cow_device
             .destroy_with_retries_detailed(cow_destroy_retry_policy())
-            .await
-        {
-            Ok(()) => {}
-            Err(e) if e.backing_files_safe_to_delete() => {
+            .await;
+        let outcome = classify_cow_destroy_result(&result);
+
+        match (result, outcome) {
+            (Ok(()), _) => {}
+            (Err(e), CowCleanupOutcome::BackingFilesSafeToDelete) => {
                 tracing::warn!(
                     error = %e,
                     "snapshot COW device released but file cleanup failed; continuing attempt-dir cleanup"
                 );
             }
-            Err(e) => return Err(e.into_inner()),
+            (Err(e), CowCleanupOutcome::DeviceMayStillReferenceBackingFiles) => {
+                return Err(e.into_inner());
+            }
         }
         cleanup_snapshot_attempt_dir_for_cow(&cow_file).await;
         Ok(())

--- a/crates/sandbox-fc/src/snapshot/publish.rs
+++ b/crates/sandbox-fc/src/snapshot/publish.rs
@@ -7,12 +7,13 @@ use nbd_cow::{KeptCow, PooledNbdCowDevice};
 use sandbox::{PendingSnapshotPublish, SnapshotOutput};
 
 use crate::config::SnapshotConfig;
+use crate::cow_cleanup::cow_destroy_retry_policy;
 use crate::paths::SnapshotOutputPaths;
 
 use super::SnapshotError;
 use super::cow::{
     cleanup_snapshot_attempt_dir_for_cow, cleanup_snapshot_attempt_dir_for_cow_sync,
-    cow_destroy_retry_policy, destroy_snapshot_cow_and_cleanup_attempt_dir,
+    destroy_snapshot_cow_and_cleanup_attempt_dir,
 };
 use super::output::{
     cleanup_remove_file_result, publish_snapshot_complete_marker, remove_dir_all_if_exists_sync,


### PR DESCRIPTION
## Summary

- Add a crate-internal COW cleanup outcome that models whether backing files are safe to delete
- Carry that semantic outcome through factory teardown, leak cleanup, and create rollback instead of using a raw bool
- Move shared COW destroy retry/classification logic out of factory internals and reuse it from snapshot cleanup
- Add focused classifier coverage for success, safe storage cleanup failure, and unsafe device cleanup failure

## Tests

- `cargo fmt --manifest-path crates/Cargo.toml -p sandbox-fc -- --check`
- `cargo clippy --manifest-path crates/Cargo.toml -p sandbox-fc --tests`
- `cargo test --manifest-path crates/Cargo.toml -p sandbox-fc cow_cleanup`
- `cargo test --manifest-path crates/Cargo.toml -p sandbox-fc`
- `git diff --check`

Closes #16452