### PR TITLE
refactor: share mitm authority primitives

### DIFF
--- a/crates/runner/mitm-addon/src/authority_utils.py
+++ b/crates/runner/mitm-addon/src/authority_utils.py
@@ -1,0 +1,98 @@
+"""Policy-neutral authority parsing helpers.
+
+This module intentionally does not expose a single configurable authority
+normalizer. Trusted request authority, firewall matching, and auth.base rewrite
+targets are separate trust boundaries with different policies. Helpers here
+only handle shared string mechanics; callers decide whether a result is allowed,
+malformed-but-matchable, or rejected.
+"""
+
+import ipaddress
+from types import MappingProxyType
+from typing import NamedTuple
+from urllib.parse import unquote_to_bytes
+
+from url_syntax import ASCII_CONTROL_MAX, ASCII_DELETE
+
+IPV6_VERSION = 6
+
+_AUTHORITY_PORT_MAX = 65535
+_PERCENT_ESCAPE_LENGTH = 3
+_HEX_DIGITS = frozenset("0123456789abcdefABCDEF")
+_DEFAULT_SCHEME_PORTS = MappingProxyType({"http": 80, "https": 443})
+
+
+class PercentDecodedHost(NamedTuple):
+    value: str
+    invalid_encoding: bool
+    decoded_syntax: bool
+
+
+def has_ascii_space_or_control(value: str) -> bool:
+    return any(
+        char.isspace() or ord(char) < ASCII_CONTROL_MAX or ord(char) == ASCII_DELETE
+        for char in value
+    )
+
+
+def percent_decode_host(
+    host: str,
+    *,
+    syntax_chars: frozenset[str],
+) -> PercentDecodedHost:
+    if "%" not in host:
+        return PercentDecodedHost(host, invalid_encoding=False, decoded_syntax=False)
+
+    index = host.find("%")
+    decoded_syntax = False
+    while index != -1:
+        run_end = index
+        while run_end < len(host) and host[run_end] == "%":
+            hex_start = run_end + 1
+            hex_end = hex_start + 2
+            hex_value = host[hex_start:hex_end]
+            if hex_end > len(host) or not all(char in _HEX_DIGITS for char in hex_value):
+                return PercentDecodedHost(host, invalid_encoding=True, decoded_syntax=False)
+            run_end += _PERCENT_ESCAPE_LENGTH
+
+        try:
+            decoded_run = unquote_to_bytes(host[index:run_end]).decode("utf-8")
+        except UnicodeError:
+            return PercentDecodedHost(host, invalid_encoding=True, decoded_syntax=False)
+        if any(char in syntax_chars for char in decoded_run):
+            decoded_syntax = True
+        index = host.find("%", run_end)
+
+    try:
+        decoded = unquote_to_bytes(host).decode("utf-8")
+    except UnicodeError:
+        return PercentDecodedHost(host, invalid_encoding=True, decoded_syntax=False)
+    return PercentDecodedHost(decoded, invalid_encoding=False, decoded_syntax=decoded_syntax)
+
+
+def format_url_host(host: str) -> str:
+    candidate = host
+    if candidate.startswith("[") and candidate.endswith("]"):
+        candidate = candidate[1:-1]
+    if ":" not in candidate:
+        return host
+    try:
+        parsed = ipaddress.ip_address(candidate)
+    except ValueError:
+        return host
+    if parsed.version == IPV6_VERSION:
+        return f"[{candidate}]"
+    return candidate
+
+
+def is_default_scheme_port(scheme: str, port: int) -> bool:
+    return port == _DEFAULT_SCHEME_PORTS.get(scheme.lower())
+
+
+def parse_authority_port(raw_port: str) -> int:
+    if not raw_port or not raw_port.isdigit():
+        raise ValueError("invalid authority port")
+    port = int(raw_port)
+    if port > _AUTHORITY_PORT_MAX:
+        raise ValueError("authority port out of range")
+    return port

--- a/crates/runner/mitm-addon/src/matching.py
+++ b/crates/runner/mitm-addon/src/matching.py
@@ -1,6 +1,11 @@
 """Firewall URL/host/path pattern matching functions.
 
 Pure functions with no module-level state or I/O.
+
+Firewall authority matching intentionally differs from trusted request
+authority and auth.base rewrite validation: config parsing may preserve
+malformed authority metadata so matched malformed configs can fail closed, and
+parameterized hosts are meaningful only for firewall config bases.
 """
 
 import ipaddress

--- a/crates/runner/mitm-addon/src/matching.py
+++ b/crates/runner/mitm-addon/src/matching.py
@@ -13,13 +13,17 @@ import re
 from collections.abc import Mapping
 from types import MappingProxyType
 from typing import Literal, NamedTuple
-from urllib.parse import unquote_to_bytes, urlsplit
+from urllib.parse import urlsplit
 
+from authority_utils import (
+    IPV6_VERSION,
+    has_ascii_space_or_control,
+    is_default_scheme_port,
+    percent_decode_host,
+)
 from host_normalization import normalize_idna_hostname
 from path_security import has_unsafe_path
 from url_syntax import (
-    ASCII_CONTROL_MAX,
-    ASCII_DELETE,
     has_raw_whitespace,
     has_unsafe_runtime_url_syntax,
     has_unsafe_url_codepoint,
@@ -38,8 +42,6 @@ _MULTI_PARAM_BRACE_COUNT = 2
 _RULE_TOKEN_COUNT = 2
 _MIN_HOST_SEGMENTS = 2
 _ASCII_MAX = 0x7F
-_PERCENT_ESCAPE_LENGTH = 3
-_IPV6_VERSION = 6
 _IDNA_DOT_TRANSLATION = str.maketrans(
     {
         "\u3002": ".",
@@ -50,7 +52,6 @@ _IDNA_DOT_TRANSLATION = str.maketrans(
 _FORBIDDEN_AUTHORITY_HOST_CHARS = frozenset("#%/<>?@[\\]^|[]")
 _FORBIDDEN_RUNTIME_AUTHORITY_HOST_CHARS = _FORBIDDEN_AUTHORITY_HOST_CHARS | frozenset("{}")
 _PERCENT_DECODED_AUTHORITY_SYNTAX_CHARS = frozenset("{}.\u3002\uff0e\uff61")
-_HEX_DIGITS = frozenset("0123456789abcdefABCDEF")
 _VALID_RULE_METHODS = frozenset(
     (
         "GET",
@@ -65,7 +66,6 @@ _VALID_RULE_METHODS = frozenset(
 )
 _VALID_BASE_SCHEMES = frozenset(("http", "https"))
 _VALID_AUTH_BASE_SCHEME = "https"
-_DEFAULT_SCHEME_PORTS = MappingProxyType({"http": 80, "https": 443})
 _AUTH_TEMPLATE_START = "${{"
 _AUTH_REFERENCE_PATTERN = re.compile(r"\$\{\{\s*(?:secrets|vars)\.[a-zA-Z_][a-zA-Z0-9_]*\s*\}\}")
 _AUTH_REFERENCE_PREFIX_PATTERN = re.compile(
@@ -92,48 +92,21 @@ def _has_invalid_authority_host_chars(host: str, *, allow_host_params: bool = Fa
         if allow_host_params
         else _FORBIDDEN_RUNTIME_AUTHORITY_HOST_CHARS
     )
-    return any(
-        char.isspace()
-        or ord(char) < ASCII_CONTROL_MAX
-        or ord(char) == ASCII_DELETE
-        or char in forbidden_chars
-        for char in host
-    )
+    return has_ascii_space_or_control(host) or any(char in forbidden_chars for char in host)
 
 
 def _percent_decode_authority_host(host: str) -> tuple[str, bool]:
     if "%" not in host:
         return host, False
 
-    index = host.find("%")
-    has_percent_encoded_syntax = False
-    while index != -1:
-        run_end = index
-        while run_end < len(host) and host[run_end] == "%":
-            hex_start = run_end + 1
-            hex_end = hex_start + 2
-            hex_value = host[hex_start:hex_end]
-            if hex_end > len(host) or not all(char in _HEX_DIGITS for char in hex_value):
-                return host, True
-            run_end += _PERCENT_ESCAPE_LENGTH
-
-        try:
-            decoded_run = unquote_to_bytes(host[index:run_end]).decode("utf-8")
-        except UnicodeError:
-            return host, True
-        if any(char in _PERCENT_DECODED_AUTHORITY_SYNTAX_CHARS for char in decoded_run):
-            has_percent_encoded_syntax = True
-        index = host.find("%", run_end)
-
-    try:
-        decoded = unquote_to_bytes(host).decode("utf-8")
-    except UnicodeError:
-        return host, True
-    if has_percent_encoded_syntax:
-        return decoded.translate(_IDNA_DOT_TRANSLATION), True
-    if ":" in decoded:
-        return decoded, True
-    return decoded, False
+    decoded = percent_decode_host(host, syntax_chars=_PERCENT_DECODED_AUTHORITY_SYNTAX_CHARS)
+    if decoded.invalid_encoding:
+        return decoded.value, True
+    if decoded.decoded_syntax:
+        return decoded.value.translate(_IDNA_DOT_TRANSLATION), True
+    if ":" in decoded.value:
+        return decoded.value, True
+    return decoded.value, False
 
 
 def _is_ascii(value: str) -> bool:
@@ -392,7 +365,7 @@ def _normalize_authority_host(host: str, *, allow_host_params: bool = False) -> 
             parsed_ip = ipaddress.ip_address(normalized)
         except ValueError:
             return normalized.lower(), True
-        if parsed_ip.version != _IPV6_VERSION:
+        if parsed_ip.version != IPV6_VERSION:
             return normalized.lower(), True
         return f"[{parsed_ip.compressed.lower()}]", False
     try:
@@ -419,7 +392,7 @@ def _normalize_authority(
     if port is None:
         return normalized_host, host_malformed
 
-    if port == _DEFAULT_SCHEME_PORTS.get(scheme.lower()):
+    if is_default_scheme_port(scheme, port):
         return normalized_host, host_malformed
     return f"{normalized_host}:{port}", host_malformed
 

--- a/crates/runner/mitm-addon/src/url_utils.py
+++ b/crates/runner/mitm-addon/src/url_utils.py
@@ -16,25 +16,23 @@ from typing import Literal
 
 from mitmproxy import http
 
+from authority_utils import (
+    IPV6_VERSION,
+    format_url_host,
+    has_ascii_space_or_control,
+    is_default_scheme_port,
+    parse_authority_port,
+    percent_decode_host,
+)
 from host_normalization import normalize_idna_hostname
 from path_security import has_unsafe_path
 from url_syntax import (
-    ASCII_CONTROL_MAX,
-    ASCII_DELETE,
     has_raw_whitespace,
     has_unsafe_url_codepoint,
     strip_optional_terminal_slash,
 )
 
-# Well-known IANA ports for HTTP and HTTPS.  When the connection uses the
-# default port for its scheme we omit ``:port`` from the reconstructed URL.
-_HTTP_DEFAULT_PORT = 80
-_HTTPS_DEFAULT_PORT = 443
-_IPV6_VERSION = 6
-_MAX_PORT = 65535
-_PERCENT_ESCAPE_LENGTH = 3
 _FORBIDDEN_HOST_CHARS = frozenset("#%,/<>?@[\\]^|{}")
-_HEX_DIGITS = frozenset("0123456789abcdefABCDEF")
 _PERCENT_DECODED_HOST_SYNTAX_CHARS = frozenset("{}.\u3002\uff0e\uff61,")
 _URL_PATH_SAFE_CHARS = "/%:@!$&'()*+,;="
 _URL_QUERY_SAFE_CHARS = "/?%:@!$&'()*+,;="
@@ -103,13 +101,7 @@ class AuthorityValidationError(Exception):
 
 
 def _has_invalid_hostname_chars(host: str) -> bool:
-    return any(
-        char.isspace()
-        or ord(char) < ASCII_CONTROL_MAX
-        or ord(char) == ASCII_DELETE
-        or char in _FORBIDDEN_HOST_CHARS
-        for char in host
-    )
+    return has_ascii_space_or_control(host) or any(char in _FORBIDDEN_HOST_CHARS for char in host)
 
 
 def _normalize_hostname(host: str) -> str:
@@ -120,7 +112,7 @@ def _normalize_hostname(host: str) -> str:
             parsed = ipaddress.ip_address(host)
         except ValueError as exc:
             raise ValueError("invalid IPv6 hostname") from exc
-        if parsed.version == _IPV6_VERSION:
+        if parsed.version == IPV6_VERSION:
             return parsed.compressed.lower()
         raise ValueError("colon host must be IPv6")
     if _has_invalid_hostname_chars(host):
@@ -128,26 +120,9 @@ def _normalize_hostname(host: str) -> str:
     return normalize_idna_hostname(host)
 
 
-def _format_url_host(host: str) -> str:
-    candidate = host
-    if candidate.startswith("[") and candidate.endswith("]"):
-        candidate = candidate[1:-1]
-    if ":" not in candidate:
-        return host
-    try:
-        parsed = ipaddress.ip_address(candidate)
-    except ValueError:
-        return host
-    if parsed.version == _IPV6_VERSION:
-        return f"[{candidate}]"
-    return candidate
-
-
 def _host_with_port(scheme: str, host: str, port: int) -> str:
-    url_host = _format_url_host(host)
-    if (scheme == "https" and port != _HTTPS_DEFAULT_PORT) or (
-        scheme == "http" and port != _HTTP_DEFAULT_PORT
-    ):
+    url_host = format_url_host(host)
+    if scheme in ("http", "https") and not is_default_scheme_port(scheme, port):
         return f"{url_host}:{port}"
     return url_host
 
@@ -156,20 +131,8 @@ def _build_url(scheme: str, host: str, port: int, path: str) -> str:
     return f"{scheme}://{_host_with_port(scheme, host, port)}{path}"
 
 
-def _parse_authority_port(raw_port: str) -> int:
-    if not raw_port or not raw_port.isdigit():
-        raise ValueError("invalid authority port")
-    port = int(raw_port)
-    if port > _MAX_PORT:
-        raise ValueError("authority port out of range")
-    return port
-
-
 def _parse_host_authority(authority: str) -> tuple[str, int | None]:
-    if not authority or any(
-        char.isspace() or ord(char) < ASCII_CONTROL_MAX or ord(char) == ASCII_DELETE
-        for char in authority
-    ):
+    if not authority or has_ascii_space_or_control(authority):
         raise ValueError("invalid authority")
 
     if authority.startswith("["):
@@ -181,13 +144,13 @@ def _parse_host_authority(authority: str) -> tuple[str, int | None]:
         if rest == "":
             port = None
         elif rest.startswith(":"):
-            port = _parse_authority_port(rest[1:])
+            port = parse_authority_port(rest[1:])
         else:
             raise ValueError("invalid IPv6 authority")
         if "%" in host:
             raise ValueError("IPv6 scope identifiers are not allowed")
         parsed = ipaddress.ip_address(host)
-        if parsed.version != _IPV6_VERSION:
+        if parsed.version != IPV6_VERSION:
             raise ValueError("bracketed authority must be IPv6")
         return host, port
 
@@ -201,7 +164,7 @@ def _parse_host_authority(authority: str) -> tuple[str, int | None]:
     host, raw_port = authority.rsplit(":", maxsplit=1)
     if not host:
         raise ValueError("missing authority host")
-    return host, _parse_authority_port(raw_port)
+    return host, parse_authority_port(raw_port)
 
 
 def get_trusted_authority(flow: http.HTTPFlow) -> TrustedAuthority:
@@ -412,32 +375,12 @@ def _merge_rewrite_query(
 
 
 def _percent_decode_host(host: str) -> str:
-    if "%" not in host:
-        return host
-
-    index = host.find("%")
-    while index != -1:
-        run_end = index
-        while run_end < len(host) and host[run_end] == "%":
-            hex_start = run_end + 1
-            hex_end = hex_start + 2
-            hex_value = host[hex_start:hex_end]
-            if hex_end > len(host) or not all(char in _HEX_DIGITS for char in hex_value):
-                raise ValueError("Invalid auth.base URL: host has invalid percent encoding")
-            run_end += _PERCENT_ESCAPE_LENGTH
-
-        try:
-            decoded_run = urllib.parse.unquote_to_bytes(host[index:run_end]).decode("utf-8")
-        except UnicodeDecodeError as exc:
-            raise ValueError("Invalid auth.base URL: host has invalid percent encoding") from exc
-        if any(char in _PERCENT_DECODED_HOST_SYNTAX_CHARS for char in decoded_run):
-            raise ValueError("Invalid auth.base URL: host has unsafe percent encoding")
-        index = host.find("%", run_end)
-
-    try:
-        return urllib.parse.unquote_to_bytes(host).decode("utf-8")
-    except UnicodeDecodeError as exc:
-        raise ValueError("Invalid auth.base URL: host has invalid percent encoding") from exc
+    decoded = percent_decode_host(host, syntax_chars=_PERCENT_DECODED_HOST_SYNTAX_CHARS)
+    if decoded.invalid_encoding:
+        raise ValueError("Invalid auth.base URL: host has invalid percent encoding")
+    if decoded.decoded_syntax:
+        raise ValueError("Invalid auth.base URL: host has unsafe percent encoding")
+    return decoded.value
 
 
 def _validated_rewrite_base(resolved_base: str) -> tuple[urllib.parse.SplitResult, str]:
@@ -474,7 +417,7 @@ def _validated_rewrite_base(resolved_base: str) -> tuple[urllib.parse.SplitResul
         port = parsed.port
     except ValueError as exc:
         raise ValueError(str(exc)) from exc
-    authority = _format_url_host(normalized_host)
+    authority = format_url_host(normalized_host)
     if port is not None:
         authority = f"{authority}:{port}"
     return parsed, authority

--- a/crates/runner/mitm-addon/src/url_utils.py
+++ b/crates/runner/mitm-addon/src/url_utils.py
@@ -1,6 +1,12 @@
 """URL reconstruction and rewriting utilities.
 
 Pure functions with no module-level state or I/O.
+
+Trusted request authority validation and auth.base rewrite validation share
+low-level host canonicalization primitives, but they are different trust
+boundaries: Host/SNI input must not accept percent-encoded authority syntax,
+while auth.base targets reject unsafe percent-encoded host syntax before
+forwarding credential-bearing requests.
 """
 
 import ipaddress

--- a/crates/runner/mitm-addon/tests/test_compiled_firewall_malformed_config.py
+++ b/crates/runner/mitm-addon/tests/test_compiled_firewall_malformed_config.py
@@ -599,6 +599,7 @@ def test_malformed_parameterized_base_query_or_fragment_respects_base_path_scope
         ("https://api.github.com:bad", "https://api.github.com/repos/org/repo"),
         ("https://api.github.com:99999", "https://api.github.com/repos/org/repo"),
         ("https://api%2egithub.com", "https://api.github.com/repos/org/repo"),
+        ("https://{sub}%2egithub.com", "https://api.github.com/repos/org/repo"),
         ("https://user@{sub}.github.com", "https://api.github.com/repos/org/repo"),
         ("https://user:pass@{sub}.github.com", "https://api.github.com/repos/org/repo"),
         ("https://{sub}.github.com:bad", "https://api.github.com/repos/org/repo"),

--- a/crates/runner/mitm-addon/tests/test_request_handler_authority_validation.py
+++ b/crates/runner/mitm-addon/tests/test_request_handler_authority_validation.py
@@ -825,6 +825,8 @@ async def test_rejects_idna_compatibility_host_alias_before_firewall_auth(
         (8443, "", "missing_authority", "https://api.github.com:8443/repos"),
         (443, "api.github.com:bad", "invalid_authority", "https://api.github.com/repos"),
         (443, "api.github.com..", "invalid_authority", "https://api.github.com/repos"),
+        (443, "api%2egithub.com", "invalid_authority", "https://api.github.com/repos"),
+        (443, "b%C3%BCcher.example", "invalid_authority", "https://api.github.com/repos"),
         (443, "{api}.github.com", "invalid_authority", "https://api.github.com/repos"),
         (443, "xn--.com", "invalid_authority", "https://api.github.com/repos"),
         (443, "xn--a.com", "invalid_authority", "https://api.github.com/repos"),
@@ -970,6 +972,13 @@ async def test_rejects_missing_https_sni_before_firewall_auth(
             443,
             "xn--ph7c.example",
             "xn--ph7c.example",
+            "https://203.0.113.10/repos",
+        ),
+        (
+            "203.0.113.10",
+            443,
+            "api%2egithub.com",
+            "api%2egithub.com",
             "https://203.0.113.10/repos",
         ),
         (

--- a/crates/runner/mitm-addon/tests/test_url_utils.py
+++ b/crates/runner/mitm-addon/tests/test_url_utils.py
@@ -72,6 +72,14 @@ class TestBuildRewriteUrl:
         )
         assert url == "https://xn--bcher-kva.example/hook/sub"
 
+    def test_base_explicit_default_port_preserved_for_forwarding(self):
+        url = url_utils.build_rewrite_url(
+            "https://example.com:443/hook",
+            "/sub",
+            "",
+        )
+        assert url == "https://example.com:443/hook/sub"
+
     def test_base_unicode_path_and_query_are_encoded_for_forwarding(self):
         url = url_utils.build_rewrite_url(
             "https://example.com/hook/路径?token=é",
@@ -113,6 +121,7 @@ class TestBuildRewriteUrl:
             ("https://example%2ecom/hook", "unsafe percent encoding"),
             ("https://example%2ccom/hook", "unsafe percent encoding"),
             ("https://example%3a443.com/hook", "invalid host"),
+            ("https://{tenant}.example.com/hook", "invalid host"),
             ("https://example.com/hook/%2e%2e/admin", "unsafe path"),
             ("https://example.com/hook/..;matrix=1/admin", "unsafe path"),
             ("https://example.com/hook/%252e%252e/admin", "unsafe path"),


### PR DESCRIPTION
## Summary

- Document the distinct mitm authority policies for firewall matching, trusted request authority, and auth.base rewrites.
- Add contract coverage for percent-encoded Host/SNI rejection, auth.base explicit default-port preservation, raw auth.base host params, and malformed parameterized firewall authority fail-closed behavior.
- Extract policy-neutral authority primitives into `authority_utils.py` and route matching/url rewrite code through them without introducing a flag-heavy normalizer.

Fixes #16462

## Testing

- `/tmp/mitm-addon-venv/bin/pytest tests/test_matching_patterns.py tests/test_compiled_firewall_base_matching.py tests/test_compiled_firewall_malformed_config.py tests/test_request_handler_authority_validation.py tests/test_url_utils.py tests/test_firewall_rewrite.py`
- `/tmp/mitm-addon-venv/bin/ruff check src tests`
- `/tmp/mitm-addon-venv/bin/basedpyright --pythonpath /tmp/mitm-addon-venv/bin/python`
- `/tmp/mitm-addon-venv/bin/pytest tests/`
