### PR TITLE
fix(mitm-addon): bound tcp message retention

### DIFF
--- a/crates/runner/mitm-addon/src/mitm_addon.py
+++ b/crates/runner/mitm-addon/src/mitm_addon.py
@@ -21,6 +21,7 @@ import time
 import urllib.parse
 from collections.abc import Callable
 from pathlib import Path
+from typing import TypeVar
 
 from mitmproxy import ctx, http, tcp, tls
 from mitmproxy.addonmanager import Loader
@@ -70,6 +71,9 @@ _BROWSER_USER_AGENT_MARKERS = (
 )
 _MODEL_PROVIDER_USAGE_REPORTED = "_model_provider_usage_reported"
 _MODEL_WEBSOCKET_MESSAGE_TRIM_SCHEDULED = "_model_websocket_message_trim_scheduled"
+_TCP_MESSAGE_DRAIN_SCHEDULED = "_tcp_message_drain_scheduled"
+_TCP_REQUEST_SIZE = "_tcp_request_size"
+_TCP_RESPONSE_SIZE = "_tcp_response_size"
 _USAGE_FLOW_TRACKED = "_usage_flow_tracked"
 # Network log size fields are consumed as JavaScript numbers downstream.
 _MAX_SAFE_NETWORK_LOG_SIZE = 9_007_199_254_740_991
@@ -633,10 +637,10 @@ def _report_model_provider_usage_once(flow: http.HTTPFlow, run_id: str) -> None:
         flow.metadata[_MODEL_PROVIDER_USAGE_REPORTED] = True
 
 
-_WebSocketTrimCallback = Callable[[http.HTTPFlow], None]
+_ScheduledFlow = TypeVar("_ScheduledFlow", http.HTTPFlow, tcp.TCPFlow)
 
 
-def _call_soon(callback: _WebSocketTrimCallback, flow: http.HTTPFlow) -> None:
+def _call_soon(callback: Callable[[_ScheduledFlow], None], flow: _ScheduledFlow) -> None:
     asyncio.get_running_loop().call_soon(callback, flow)
 
 
@@ -1039,6 +1043,11 @@ def tcp_start(flow: tcp.TCPFlow) -> None:
     flow.metadata[metadata_keys.TCP_START_MONOTONIC] = time.monotonic()
 
 
+def tcp_message(flow: tcp.TCPFlow) -> None:
+    """Schedule bounded retention cleanup for registered TCP flows."""
+    _schedule_tcp_message_drain(flow)
+
+
 def tcp_end(flow: tcp.TCPFlow) -> None:
     """Log TCP connection details when it closes."""
     _log_tcp(flow)
@@ -1047,6 +1056,86 @@ def tcp_end(flow: tcp.TCPFlow) -> None:
 def tcp_error(flow: tcp.TCPFlow) -> None:
     """Log TCP connection errors."""
     _log_tcp(flow)
+
+
+def _is_registered_tcp_log_flow(flow: tcp.TCPFlow) -> bool:
+    return bool(
+        flow.metadata.get(metadata_keys.VM_RUN_ID, "")
+        and flow.metadata.get(metadata_keys.VM_NETWORK_LOG_PATH, "")
+    )
+
+
+def _tcp_counter_value(flow: tcp.TCPFlow, key: str) -> int:
+    value = flow.metadata.get(key)
+    if type(value) is not int:
+        return 0
+    return max(0, min(value, _MAX_SAFE_NETWORK_LOG_SIZE))
+
+
+def _has_tcp_size_counters(flow: tcp.TCPFlow) -> bool:
+    return (
+        type(flow.metadata.get(_TCP_REQUEST_SIZE)) is int
+        or type(flow.metadata.get(_TCP_RESPONSE_SIZE)) is int
+    )
+
+
+def _add_tcp_size(flow: tcp.TCPFlow, key: str, delta: int) -> None:
+    flow.metadata[key] = min(
+        _MAX_SAFE_NETWORK_LOG_SIZE,
+        _tcp_counter_value(flow, key) + delta,
+    )
+
+
+def _schedule_tcp_message_drain(flow: tcp.TCPFlow) -> None:
+    if not _is_registered_tcp_log_flow(flow):
+        return
+    if flow.metadata.get(_TCP_MESSAGE_DRAIN_SCHEDULED, False):
+        return
+    flow.metadata[_TCP_MESSAGE_DRAIN_SCHEDULED] = True
+    _call_soon(_drain_tcp_messages, flow)
+
+
+def _drain_tcp_messages(flow: tcp.TCPFlow) -> None:
+    flow.metadata.pop(_TCP_MESSAGE_DRAIN_SCHEDULED, None)
+    if not _is_registered_tcp_log_flow(flow):
+        return
+    if not flow.messages:
+        return
+
+    for message in flow.messages:
+        key = _TCP_REQUEST_SIZE if message.from_client else _TCP_RESPONSE_SIZE
+        _add_tcp_size(flow, key, len(message.content))
+    flow.messages.clear()
+
+
+def _sum_tcp_messages(flow: tcp.TCPFlow) -> tuple[int, int]:
+    request_size = 0
+    response_size = 0
+    for message in flow.messages:
+        if message.from_client:
+            request_size = min(
+                _MAX_SAFE_NETWORK_LOG_SIZE,
+                request_size + len(message.content),
+            )
+        else:
+            response_size = min(
+                _MAX_SAFE_NETWORK_LOG_SIZE,
+                response_size + len(message.content),
+            )
+    return request_size, response_size
+
+
+def _tcp_log_sizes(flow: tcp.TCPFlow) -> tuple[int, int]:
+    if flow.metadata.get(_TCP_MESSAGE_DRAIN_SCHEDULED, False) or _has_tcp_size_counters(flow):
+        _drain_tcp_messages(flow)
+        return (
+            _tcp_counter_value(flow, _TCP_REQUEST_SIZE),
+            _tcp_counter_value(flow, _TCP_RESPONSE_SIZE),
+        )
+
+    request_size, response_size = _sum_tcp_messages(flow)
+    flow.messages.clear()
+    return request_size, response_size
 
 
 def _log_tcp(flow: tcp.TCPFlow) -> None:
@@ -1058,8 +1147,7 @@ def _log_tcp(flow: tcp.TCPFlow) -> None:
     start_time = flow.metadata.get(metadata_keys.TCP_START_MONOTONIC)
     latency_ms = _elapsed_ms(start_time)
 
-    request_size = sum(len(m.content) for m in flow.messages if m.from_client)
-    response_size = sum(len(m.content) for m in flow.messages if not m.from_client)
+    request_size, response_size = _tcp_log_sizes(flow)
 
     server_addr = flow.server_conn.address if flow.server_conn else None
     host = server_addr[0] if server_addr else "unknown"
@@ -1091,6 +1179,7 @@ addons = [
     response,
     error,
     tcp_start,
+    tcp_message,
     tcp_end,
     tcp_error,
 ]

--- a/crates/runner/mitm-addon/tests/test_connection_hooks.py
+++ b/crates/runner/mitm-addon/tests/test_connection_hooks.py
@@ -3,10 +3,12 @@
 import json
 import threading
 import time
+from collections.abc import Callable
 from pathlib import Path
 from unittest.mock import MagicMock, patch
 
 import pytest
+from mitmproxy import tcp
 from mitmproxy.flow import Error
 
 import flow_metadata_keys as metadata_keys
@@ -27,6 +29,26 @@ def wait_for_usage_flush_worker_to_stop(timeout: float = 1.0) -> None:
 def reset_runner_usage_flush_state() -> None:
     mitm_addon._usage_flush_requested.clear()
     wait_for_usage_flush_worker_to_stop()
+
+
+_ScheduledTcpDrain = tuple[Callable[[tcp.TCPFlow], None], tcp.TCPFlow]
+
+
+def _capture_tcp_drains(monkeypatch: pytest.MonkeyPatch) -> list[_ScheduledTcpDrain]:
+    scheduled: list[_ScheduledTcpDrain] = []
+
+    def call_soon(callback: Callable[[tcp.TCPFlow], None], flow: tcp.TCPFlow) -> None:
+        scheduled.append((callback, flow))
+
+    monkeypatch.setattr(mitm_addon, "_call_soon", call_soon)
+    return scheduled
+
+
+def _run_scheduled_tcp_drains(scheduled: list[_ScheduledTcpDrain]) -> None:
+    pending = list(scheduled)
+    scheduled.clear()
+    for callback, flow in pending:
+        callback(flow)
 
 
 class TestDoneHook:
@@ -551,3 +573,124 @@ class TestTcpLog:
 
         entry = json.loads(Path(log_path).read_text().strip())
         assert entry["latency_ms"] == 0
+
+    def test_tcp_message_defers_registered_flow_drain(
+        self, tmp_path, monkeypatch, mitm_ctx, real_tcp_flow
+    ):
+        messages = [
+            tcp.TCPMessage(True, b"client-one"),
+            tcp.TCPMessage(False, b"server-one"),
+            tcp.TCPMessage(True, b"client-two"),
+        ]
+        flow = real_tcp_flow(messages=messages)
+        log_path = str(tmp_path / "network.jsonl")
+        flow.metadata["vm_run_id"] = "run-abc-123"
+        flow.metadata["vm_network_log_path"] = log_path
+        scheduled = _capture_tcp_drains(monkeypatch)
+
+        with mitm_ctx():
+            mitm_addon.tcp_message(flow)
+            mitm_addon.tcp_message(flow)
+
+        assert flow.messages == messages
+        assert len(scheduled) == 1
+
+        _run_scheduled_tcp_drains(scheduled)
+
+        assert flow.messages == []
+
+        with mitm_ctx():
+            mitm_addon.tcp_end(flow)
+
+        entry = json.loads(Path(log_path).read_text().strip())
+        assert entry["request_size"] == len(b"client-one") + len(b"client-two")
+        assert entry["response_size"] == len(b"server-one")
+
+    def test_tcp_end_drains_pending_messages_before_deferred_callback(
+        self, tmp_path, monkeypatch, mitm_ctx, real_tcp_flow
+    ):
+        messages = [
+            tcp.TCPMessage(True, b"client"),
+            tcp.TCPMessage(False, b"server-response"),
+        ]
+        flow = real_tcp_flow(messages=messages)
+        log_path = str(tmp_path / "network.jsonl")
+        flow.metadata["vm_run_id"] = "run-abc-123"
+        flow.metadata["vm_network_log_path"] = log_path
+        scheduled = _capture_tcp_drains(monkeypatch)
+
+        with mitm_ctx():
+            mitm_addon.tcp_message(flow)
+            mitm_addon.tcp_end(flow)
+
+        entry = json.loads(Path(log_path).read_text().strip())
+        assert entry["request_size"] == len(b"client")
+        assert entry["response_size"] == len(b"server-response")
+        assert flow.messages == []
+
+        _run_scheduled_tcp_drains(scheduled)
+        assert flow.messages == []
+
+    def test_tcp_message_reschedules_after_previous_drain(
+        self, tmp_path, monkeypatch, mitm_ctx, real_tcp_flow
+    ):
+        first_client = tcp.TCPMessage(True, b"first-client")
+        first_server = tcp.TCPMessage(False, b"first-server")
+        flow = real_tcp_flow(messages=[first_client, first_server])
+        log_path = str(tmp_path / "network.jsonl")
+        flow.metadata["vm_run_id"] = "run-abc-123"
+        flow.metadata["vm_network_log_path"] = log_path
+        scheduled = _capture_tcp_drains(monkeypatch)
+
+        with mitm_ctx():
+            mitm_addon.tcp_message(flow)
+
+        _run_scheduled_tcp_drains(scheduled)
+        assert flow.messages == []
+
+        second_client = tcp.TCPMessage(True, b"second-client")
+        second_server = tcp.TCPMessage(False, b"second-server")
+        flow.messages.extend([second_client, second_server])
+
+        with mitm_ctx():
+            mitm_addon.tcp_message(flow)
+
+        assert len(scheduled) == 1
+
+        _run_scheduled_tcp_drains(scheduled)
+
+        with mitm_ctx():
+            mitm_addon.tcp_end(flow)
+
+        entry = json.loads(Path(log_path).read_text().strip())
+        assert entry["request_size"] == len(first_client.content) + len(second_client.content)
+        assert entry["response_size"] == len(first_server.content) + len(second_server.content)
+        assert flow.messages == []
+
+    def test_tcp_message_leaves_unregistered_flow_messages(
+        self, monkeypatch, mitm_ctx, real_tcp_flow
+    ):
+        messages = [tcp.TCPMessage(True, b"client")]
+        flow = real_tcp_flow(messages=messages)
+        scheduled = _capture_tcp_drains(monkeypatch)
+
+        with mitm_ctx():
+            mitm_addon.tcp_message(flow)
+
+        assert scheduled == []
+        assert flow.messages == messages
+
+    def test_tcp_size_counter_saturates_at_network_log_max(self, tmp_path, mitm_ctx, real_tcp_flow):
+        flow = real_tcp_flow(messages=[tcp.TCPMessage(True, b"overflow")])
+        log_path = str(tmp_path / "network.jsonl")
+        flow.metadata["vm_run_id"] = "run-abc-123"
+        flow.metadata["vm_network_log_path"] = log_path
+        flow.metadata[mitm_addon._TCP_REQUEST_SIZE] = mitm_addon._MAX_SAFE_NETWORK_LOG_SIZE - 1
+
+        with mitm_ctx():
+            mitm_addon.tcp_end(flow)
+
+        entry = json.loads(Path(log_path).read_text().strip())
+        assert entry["request_size"] == mitm_addon._MAX_SAFE_NETWORK_LOG_SIZE
+        assert entry["response_size"] == 0
+        assert flow.messages == []


### PR DESCRIPTION
## Summary

- add a `tcp_message` hook that schedules deferred draining for registered TCP flows
- accumulate TCP request/response byte totals in JS-safe saturated counters before clearing retained messages
- preserve terminal logging fallback for direct/replayed flows and add regression coverage for pending drains, unregistered flows, and saturation

## Tests

- `pytest tests/test_connection_hooks.py`
- `ruff format --check src/mitm_addon.py tests/test_connection_hooks.py`
- `ruff check src/mitm_addon.py tests/test_connection_hooks.py`
- `basedpyright`
- `pytest tests`

Closes #16461
