### PR TITLE
ci: manage stripe cli listener per pr

### DIFF
--- a/.github/actions/web-api-env/action.yml
+++ b/.github/actions/web-api-env/action.yml
@@ -193,6 +193,9 @@ runs:
         if [[ "$INPUT_APP" == "api" ]]; then
           add_env VM0_WEB_URL "$web_url"
           add_env ENV "$deploy_env"
+          if [[ "$INPUT_ENVIRONMENT" == "preview" && -n "$INPUT_JOB_REF" ]]; then
+            add_env VM0_PREVIEW_JOB_REF "$INPUT_JOB_REF"
+          fi
         fi
         # Inject the workflow head commit explicitly so OTel / Sentry can tag
         # service.version and release on every deploy. Vercel CLI prebuilt

--- a/.github/scripts/tests/web-api-env-action-test.sh
+++ b/.github/scripts/tests/web-api-env-action-test.sh
@@ -155,6 +155,7 @@ assert_env_value "$success_env_file" GOOGLE_ADS_DEVELOPER_TOKEN "github-google-a
 assert_env_value "$success_env_file" FINICITY_APP_KEY "github-finicity-app-key"
 assert_env_value "$success_env_file" FINICITY_APP_SECRET "github-finicity-app-secret"
 assert_env_value "$success_env_file" FINICITY_PARTNER_ID "github-finicity-partner-id"
+assert_env_value "$success_env_file" VM0_PREVIEW_JOB_REF "pr-123"
 assert_env_absent_value "$success_env_file" "github-gh-client-id"
 assert_env_absent_value "$success_env_file" "github-gh-client-secret"
 assert_env_absent_value "$success_env_file" "github-slack-client-id"

--- a/.github/workflows/cleanup-stale.yml
+++ b/.github/workflows/cleanup-stale.yml
@@ -282,6 +282,7 @@ jobs:
 
             if [ "$DRY_RUN" = "true" ]; then
               echo "[DRY-RUN] Would cleanup turbo runner pr-${PR_NUMBER}"
+              echo "[DRY-RUN] Would cleanup Stripe CLI listener pr-${PR_NUMBER}"
               echo "[DRY-RUN] Would cleanup crates runner pr-${PR_NUMBER}-test"
               CLEANED=$((CLEANED + 1))
               continue
@@ -297,6 +298,17 @@ jobs:
               -e "job_ref=pr-${PR_NUMBER}" \
               -v; then
               echo "::warning::Turbo runner cleanup failed for pr-${PR_NUMBER}"
+              PR_FAILED=1
+            fi
+
+            # Cleanup Stripe CLI listener
+            if ! ansible-playbook \
+              -i "${METAL_HOSTS}," \
+              playbooks/cleanup-stripe-listener.yml \
+              -e "ansible_user=${METAL_USER}" \
+              -e "job_ref=pr-${PR_NUMBER}" \
+              -v; then
+              echo "::warning::Stripe CLI listener cleanup failed for pr-${PR_NUMBER}"
               PR_FAILED=1
             fi
 

--- a/.github/workflows/cleanup.yml
+++ b/.github/workflows/cleanup.yml
@@ -59,6 +59,24 @@ jobs:
             echo "::warning::Turbo runner cleanup failed for ${JOB_REF} — stale services may remain on metal hosts"
           fi
 
+      - name: Cleanup Stripe CLI listener on all metal hosts
+        if: steps.check.outputs.should-cleanup == 'true'
+        env:
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          METAL_USER: ${{ vars.AWS_METAL_RUNNER_USER }}
+          METAL_HOSTS: ${{ secrets.AWS_METAL_RUNNER_HOSTS }}
+        run: |
+          cd ansible
+          JOB_REF="pr-${PR_NUMBER}"
+          if ! ansible-playbook \
+            -i "${METAL_HOSTS}," \
+            playbooks/cleanup-stripe-listener.yml \
+            -e "ansible_user=${METAL_USER}" \
+            -e "job_ref=${JOB_REF}" \
+            -v; then
+            echo "::warning::Stripe CLI listener cleanup failed for ${JOB_REF} — stale Stripe forwarding may remain on metal hosts"
+          fi
+
       - name: Cleanup crates runner on all metal hosts
         if: steps.check.outputs.should-cleanup == 'true'
         env:

--- a/.github/workflows/turbo.yml
+++ b/.github/workflows/turbo.yml
@@ -1330,13 +1330,84 @@ jobs:
           retention-days: 7
           if-no-files-found: ignore
 
+  deploy-stripe-listener:
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    concurrency:
+      group: deploy-stripe-listener-${{ needs.prepare.outputs.job-ref }}
+      cancel-in-progress: true
+    needs: [prepare, deploy-api]
+    if: |
+      always() &&
+      github.event_name != 'push' &&
+      needs.prepare.outputs.job-ref != '' && (
+        needs.prepare.outputs.web-changed == 'true' ||
+        needs.prepare.outputs.cli-changed == 'true' ||
+        needs.prepare.outputs.ci-changed == 'true' ||
+        needs.prepare.outputs.e2e-changed == 'true'
+      ) &&
+      needs.deploy-api.result == 'success'
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Install Ansible
+        run: pip3 install ansible-core
+
+      - name: Setup SSH via Cloudflare Tunnel
+        uses: ./.github/actions/setup-ssh-tunnel
+        with:
+          ssh-key: ${{ secrets.AWS_METAL_RUNNER_SSH_KEY }}
+          cf-access-client-id: ${{ secrets.CF_ACCESS_CLIENT_ID }}
+          cf-access-client-secret: ${{ secrets.CF_ACCESS_CLIENT_SECRET }}
+
+      - name: Start Stripe CLI listener on one metal host
+        env:
+          METAL_USER: ${{ vars.AWS_METAL_RUNNER_USER }}
+          METAL_HOSTS: ${{ secrets.AWS_METAL_RUNNER_HOSTS }}
+          JOB_REF: ${{ needs.prepare.outputs.job-ref }}
+          API_PREVIEW_URL: ${{ needs.prepare.outputs.api-preview-url }}
+          STRIPE_SECRET_KEY: ${{ secrets.STRIPE_SECRET_KEY }}
+        run: |
+          set -euo pipefail
+          cd ansible
+
+          STRIPE_LISTENER_HOST="$(printf '%s\n' "$METAL_HOSTS" | tr ',' '\n' | sed 's/^[[:space:]]*//;s/[[:space:]]*$//' | sed '/^$/d' | head -n 1)"
+          if [[ -z "$STRIPE_LISTENER_HOST" ]]; then
+            echo "::error::AWS_METAL_RUNNER_HOSTS is empty"
+            exit 1
+          fi
+
+          CLEANUP_EXTRA_VARS="$(jq -nc \
+            --arg ansible_user "$METAL_USER" \
+            --arg job_ref "$JOB_REF" \
+            '{ansible_user: $ansible_user, job_ref: $job_ref}')"
+          ansible-playbook \
+            -i "${METAL_HOSTS}," \
+            playbooks/cleanup-stripe-listener.yml \
+            --extra-vars "$CLEANUP_EXTRA_VARS" \
+            -v
+
+          FORWARD_URL="${API_PREVIEW_URL%/}/api/webhooks/stripe"
+          EXTRA_VARS="$(jq -nc \
+            --arg ansible_user "$METAL_USER" \
+            --arg job_ref "$JOB_REF" \
+            --arg forward_url "$FORWARD_URL" \
+            --arg stripe_secret_key "$STRIPE_SECRET_KEY" \
+            '{ansible_user: $ansible_user, job_ref: $job_ref, forward_url: $forward_url, stripe_secret_key: $stripe_secret_key}')"
+
+          ansible-playbook \
+            -i "${STRIPE_LISTENER_HOST}," \
+            playbooks/start-stripe-listener.yml \
+            --extra-vars "$EXTRA_VARS" \
+            -v
+
   cli-e2e-02-playwright:
     runs-on: ubuntu-latest
     timeout-minutes: 8
     concurrency:
       group: cli-e2e-02-playwright-${{ needs.prepare.outputs.job-ref }}
       cancel-in-progress: true
-    needs: [prepare, deploy-api, deploy-web, deploy-app]
+    needs: [prepare, deploy-api, deploy-web, deploy-app, deploy-stripe-listener]
     if: |
       always() &&
       (github.event_name != 'push' || !startsWith(github.event.head_commit.message, 'chore: release')) &&
@@ -1348,7 +1419,8 @@ jobs:
       ) &&
       needs.deploy-api.result == 'success' &&
       needs.deploy-web.result == 'success' &&
-      needs.deploy-app.result == 'success'
+      needs.deploy-app.result == 'success' &&
+      (github.event_name == 'push' || needs.deploy-stripe-listener.result == 'success')
     steps:
       - uses: actions/checkout@v6
         with:
@@ -1361,6 +1433,7 @@ jobs:
       - name: Install Playwright browsers
         run: cd e2e && npx playwright install --with-deps chromium
       - name: Start Stripe webhook forwarding
+        if: github.event_name == 'push'
         run: |
           set -euo pipefail
           export PATH="$HOME/.local/bin:$PATH"
@@ -1404,13 +1477,13 @@ jobs:
           CLERK_SECRET_KEY: ${{ secrets.CLERK_SECRET_KEY }}
           JOB_REF: ${{ needs.prepare.outputs.job-ref }}
       - name: Print Stripe webhook forwarding log
-        if: always()
+        if: always() && github.event_name == 'push'
         run: |
           if [[ -f /tmp/stripe-listen.log ]]; then
             tail -200 /tmp/stripe-listen.log | sed -E 's/whsec_[[:alnum:]_]+/[masked-stripe-webhook-secret]/g'
           fi
       - name: Stop Stripe webhook forwarding
-        if: always()
+        if: always() && github.event_name == 'push'
         run: |
           if [[ -f /tmp/stripe-listen.pid ]]; then
             kill "$(cat /tmp/stripe-listen.pid)" 2>/dev/null || true
@@ -2310,6 +2383,7 @@ jobs:
       - deploy-api
       - deploy-web
       - deploy-app
+      - deploy-stripe-listener
       - build-cli
       - build-e2b-template
       - cli-e2e-02-browser
@@ -2394,6 +2468,7 @@ jobs:
           check_result "deploy-api" "${{ needs.deploy-api.result }}" "true"
           check_result "deploy-web" "${{ needs.deploy-web.result }}" "$WEB_DEPLOY_SKIP_ALLOWED"
           check_result "deploy-app" "${{ needs.deploy-app.result }}" "true"
+          check_result "deploy-stripe-listener" "${{ needs.deploy-stripe-listener.result }}" "true"
           check_result "build-cli" "${{ needs.build-cli.result }}" "true"
           check_result "build-e2b-template" "${{ needs.build-e2b-template.result }}" "true"
           check_result "cli-e2e-02-browser" "${{ needs.cli-e2e-02-browser.result }}" "${{ vars.CI_CHECK_BROWSER_E2E == '1' && 'true' || 'informational' }}"

--- a/ansible/playbooks/cleanup-stripe-listener.yml
+++ b/ansible/playbooks/cleanup-stripe-listener.yml
@@ -1,0 +1,59 @@
+# Cleanup Stripe CLI Listener
+#
+# Stops and removes the PR-scoped Stripe CLI listener deployed by turbo.yml.
+#
+# Usage:
+#   ansible-playbook -i "host1,host2," playbooks/cleanup-stripe-listener.yml \
+#     -e "ansible_user=ubuntu" \
+#     -e "job_ref=pr-123"
+
+- name: Cleanup Stripe CLI Listener
+  hosts: all
+  become: true
+
+  vars:
+    base_dir: /var/lib/vm0-runner
+    stripe_dir: "{{ base_dir }}/stripe/{{ job_ref }}"
+    service_name: "vm0-stripe-listener-{{ job_ref }}"
+    unit_path: "/etc/systemd/system/{{ service_name }}.service"
+
+  tasks:
+    - name: Check required variables
+      assert:
+        that:
+          - job_ref is defined
+          - job_ref | length > 0
+        fail_msg: "Required variable: job_ref"
+
+    - name: Stop Stripe listener service
+      command: systemctl stop {{ service_name }}.service
+      register: stop_listener
+      changed_when: stop_listener.rc == 0
+      failed_when: false
+
+    - name: Disable Stripe listener service
+      command: systemctl disable {{ service_name }}.service
+      register: disable_listener
+      changed_when: disable_listener.rc == 0
+      failed_when: false
+
+    - name: Remove Stripe listener unit
+      file:
+        path: "{{ unit_path }}"
+        state: absent
+      register: remove_unit
+
+    - name: Reset failed Stripe listener service
+      command: systemctl reset-failed {{ service_name }}.service
+      register: reset_failed
+      changed_when: reset_failed.rc == 0
+      failed_when: false
+
+    - name: Reload systemd
+      command: systemctl daemon-reload
+      when: remove_unit.changed
+
+    - name: Remove Stripe listener directory
+      file:
+        path: "{{ stripe_dir }}"
+        state: absent

--- a/ansible/playbooks/start-stripe-listener.yml
+++ b/ansible/playbooks/start-stripe-listener.yml
@@ -1,0 +1,147 @@
+# Start Stripe CLI Listener
+#
+# Starts one PR-scoped Stripe CLI listener on a selected metal host. The API
+# preview already trusts the Stripe CLI webhook secret; this listener only
+# forwards matching test-mode events into that preview.
+#
+# Usage:
+#   ansible-playbook -i "host," playbooks/start-stripe-listener.yml \
+#     -e "ansible_user=ubuntu" \
+#     -e "job_ref=pr-123" \
+#     -e "forward_url=https://api-preview.example.com/api/webhooks/stripe" \
+#     -e "stripe_secret_key=sk_test_..."
+
+- name: Start Stripe CLI Listener
+  hosts: all
+  become: true
+
+  vars:
+    base_dir: /var/lib/vm0-runner
+    stripe_dir: "{{ base_dir }}/stripe/{{ job_ref }}"
+    stripe_bin_dir: "{{ stripe_dir }}/bin"
+    stripe_bin: "{{ stripe_bin_dir }}/stripe"
+    stripe_log: "{{ stripe_dir }}/stripe-listen.log"
+    stripe_cli_version: "1.41.2"
+    stripe_events: checkout.session.completed,invoice.paid,customer.subscription.updated,customer.subscription.deleted
+    service_name: "vm0-stripe-listener-{{ job_ref }}"
+
+  tasks:
+    - name: Check required variables
+      assert:
+        that:
+          - job_ref is defined
+          - forward_url is defined
+          - stripe_secret_key is defined
+          - job_ref | length > 0
+          - forward_url | length > 0
+          - stripe_secret_key | length > 0
+        fail_msg: "Required variables: job_ref, forward_url, stripe_secret_key"
+
+    - name: Create Stripe listener directory
+      file:
+        path: "{{ item }}"
+        state: directory
+        mode: "0755"
+      loop:
+        - "{{ stripe_dir }}"
+        - "{{ stripe_bin_dir }}"
+
+    - name: Install Stripe CLI
+      shell: |
+        set -euo pipefail
+        case "$(uname -m)" in
+          x86_64 | amd64)
+            stripe_arch="x86_64"
+            ;;
+          aarch64 | arm64)
+            stripe_arch="arm64"
+            ;;
+          *)
+            echo "Unsupported Stripe CLI architecture: $(uname -m)" >&2
+            exit 1
+            ;;
+        esac
+
+        tmp_dir="$(mktemp -d)"
+        trap 'rm -rf "$tmp_dir"' EXIT
+
+        curl -fsSL \
+          --retry 5 \
+          --retry-delay 2 \
+          --retry-max-time 60 \
+          --retry-all-errors \
+          "https://github.com/stripe/stripe-cli/releases/download/v{{ stripe_cli_version }}/stripe_{{ stripe_cli_version }}_linux_${stripe_arch}.tar.gz" \
+          -o "$tmp_dir/stripe.tar.gz"
+        tar -xzf "$tmp_dir/stripe.tar.gz" -C "$tmp_dir"
+        install -m 0755 "$tmp_dir/stripe" "{{ stripe_bin }}"
+      args:
+        executable: /bin/bash
+        creates: "{{ stripe_bin }}"
+
+    - name: Stop existing listener service
+      command: systemctl stop {{ service_name }}.service
+      register: stop_existing
+      changed_when: stop_existing.rc == 0
+      failed_when: false
+
+    - name: Write Stripe listener environment
+      copy:
+        dest: "{{ stripe_dir }}/env"
+        mode: "0600"
+        content: |
+          STRIPE_API_KEY={{ stripe_secret_key }}
+      no_log: true
+
+    - name: Write Stripe listener systemd unit
+      copy:
+        dest: "/etc/systemd/system/{{ service_name }}.service"
+        mode: "0644"
+        content: |
+          [Unit]
+          Description=vm0 Stripe CLI listener for {{ job_ref }}
+          After=network-online.target
+          Wants=network-online.target
+
+          [Service]
+          Type=simple
+          EnvironmentFile={{ stripe_dir }}/env
+          WorkingDirectory={{ stripe_dir }}
+          ExecStart={{ stripe_bin }} listen --events {{ stripe_events }} --forward-to {{ forward_url }}
+          Restart=always
+          RestartSec=3
+          StandardOutput=append:{{ stripe_log }}
+          StandardError=append:{{ stripe_log }}
+
+          [Install]
+          WantedBy=multi-user.target
+
+    - name: Start Stripe listener service
+      systemd:
+        name: "{{ service_name }}.service"
+        state: started
+        enabled: false
+        daemon_reload: true
+
+    - name: Wait for Stripe listener readiness
+      shell: |
+        set -euo pipefail
+        for _ in $(seq 1 20); do
+          if systemctl is-active --quiet "{{ service_name }}.service" && grep -qi ready "{{ stripe_log }}" 2>/dev/null; then
+            echo "Stripe CLI listener is ready"
+            exit 0
+          fi
+          if systemctl is-failed --quiet "{{ service_name }}.service"; then
+            break
+          fi
+          sleep 1
+        done
+
+        echo "Stripe CLI listener did not become ready" >&2
+        systemctl show "{{ service_name }}.service" --property=ActiveState,SubState,Result --no-pager >&2 || true
+        if [ -f "{{ stripe_log }}" ]; then
+          tail -100 "{{ stripe_log }}" | sed -E 's/whsec_[[:alnum:]_]+/[masked-stripe-webhook-secret]/g' >&2
+        fi
+        exit 1
+      args:
+        executable: /bin/bash
+      changed_when: false

--- a/turbo/apps/api/src/signals/routes/__tests__/webhooks-third-party.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/webhooks-third-party.test.ts
@@ -2329,6 +2329,130 @@ describe("POST /api/webhooks/stripe", () => {
     );
   });
 
+  it("ignores preview Stripe invoices for a different job ref", async () => {
+    mockStripeWebhookEnv();
+    mockEnv("ENV", "preview");
+    mockOptionalEnv("VM0_PREVIEW_JOB_REF", "pr-123");
+
+    const response = await postStripeWebhookEvent({
+      type: "invoice.paid",
+      dataObject: {
+        id: stripeId("inv"),
+        customer: stripeId("cus"),
+        metadata: {},
+        lines: invoiceLinesWithSubscriptionPeriod(1_800_000_000),
+        parent: {
+          subscription_details: {
+            subscription: stripeId("sub"),
+            metadata: {
+              vm0_environment: "preview",
+              job_ref: "pr-456",
+            },
+          },
+        },
+      },
+    });
+
+    expect(response.status).toBe(200);
+    expect(response.body).toBe("OK");
+    expect(context.mocks.stripe.customers.retrieve).not.toHaveBeenCalled();
+    expect(context.mocks.stripe.subscriptions.retrieve).not.toHaveBeenCalled();
+  });
+
+  it("ignores preview Stripe checkout sessions for a different job ref", async () => {
+    mockStripeWebhookEnv();
+    mockEnv("ENV", "preview");
+    mockOptionalEnv("VM0_PREVIEW_JOB_REF", "pr-123");
+
+    const response = await postStripeWebhookEvent({
+      type: "checkout.session.completed",
+      dataObject: {
+        id: stripeId("cs"),
+        subscription: stripeId("sub"),
+        customer: stripeId("cus"),
+        metadata: {
+          vm0_environment: "preview",
+          job_ref: "pr-456",
+        },
+      },
+    });
+
+    expect(response.status).toBe(200);
+    expect(response.body).toBe("OK");
+    expect(context.mocks.stripe.subscriptions.retrieve).not.toHaveBeenCalled();
+  });
+
+  it("ignores preview Stripe subscriptions for a different job ref", async () => {
+    mockStripeWebhookEnv();
+    mockEnv("ENV", "preview");
+    mockOptionalEnv("VM0_PREVIEW_JOB_REF", "pr-123");
+
+    const response = await postStripeWebhookEvent({
+      type: "customer.subscription.created",
+      dataObject: {
+        id: stripeId("sub"),
+        customer: stripeId("cus"),
+        status: "active",
+        metadata: {
+          vm0_environment: "preview",
+          job_ref: "pr-456",
+        },
+        cancel_at_period_end: false,
+        items: {
+          data: [{ price: { id: STRIPE_PRICE_PRO } }],
+        },
+      },
+    });
+
+    expect(response.status).toBe(200);
+    expect(response.body).toBe("OK");
+    expect(context.mocks.stripe.customers.retrieve).not.toHaveBeenCalled();
+  });
+
+  it("processes preview Stripe invoices with the current subscription job ref", async () => {
+    const fixture = await trackStripe(
+      store.set(seedStripeFixture$, undefined, context.signal),
+    );
+    mockStripeWebhookEnv();
+    mockEnv("ENV", "preview");
+    mockOptionalEnv("VM0_PREVIEW_JOB_REF", "pr-123");
+    const subId = stripeId("sub");
+    const invId = stripeId("inv");
+    const periodEnd = 1_800_000_000;
+    context.mocks.stripe.subscriptions.retrieve.mockResolvedValue({
+      id: subId,
+      status: "active",
+      cancel_at_period_end: false,
+      items: { data: [{ price: { id: STRIPE_PRICE_PRO } }] },
+    });
+
+    const response = await postStripeWebhookEvent({
+      type: "invoice.paid",
+      dataObject: {
+        id: invId,
+        customer: fixture.stripeCustomerId,
+        metadata: {},
+        lines: invoiceLinesWithSubscriptionPeriod(periodEnd),
+        parent: {
+          subscription_details: {
+            subscription: subId,
+            metadata: {
+              vm0_environment: "preview",
+              job_ref: "pr-123",
+            },
+          },
+        },
+      },
+    });
+
+    expect(response.status).toBe(200);
+    const billing = await selectStripeBilling(fixture);
+    expect(billing.credits).toBe(20_000);
+    expect(billing.tier).toBe("pro");
+    expect(billing.stripeSubscriptionId).toBe(subId);
+    expect(billing.lastProcessedInvoiceId).toBe(invId);
+  });
+
   describe("checkout.session.completed", () => {
     it("records subscription checkout without granting invoice-backed entitlement", async () => {
       const fixture = await trackStripe(

--- a/turbo/apps/api/src/signals/routes/__tests__/zero-billing-checkout.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/zero-billing-checkout.test.ts
@@ -280,6 +280,65 @@ describe("POST /api/zero/billing/checkout", () => {
     });
   });
 
+  it("tags preview Stripe checkout objects with the current job ref", async () => {
+    mockEnv("ENV", "preview");
+    mockOptionalEnv("VM0_PREVIEW_JOB_REF", "pr-123");
+    const fixture = await trackedSeed();
+    mocks.clerk.session(fixture.userId, fixture.orgId, "org:admin");
+
+    const customerId = `cus_${randomUUID().slice(0, 8)}`;
+    context.mocks.stripe.customers.create.mockResolvedValue({ id: customerId });
+    context.mocks.stripe.checkout.sessions.create.mockResolvedValue({
+      url: "https://checkout.stripe.com/session/preview",
+    });
+
+    const client = setupApp({ context })(zeroBillingCheckoutContract);
+
+    const response = await accept(
+      client.create({
+        body: {
+          tier: "pro",
+          successUrl: `${APP_ORIGIN}/billing?billing=success`,
+          cancelUrl: `${APP_ORIGIN}/billing?billing=canceled`,
+        },
+        headers: { authorization: "Bearer clerk-session" },
+      }),
+      [200],
+    );
+
+    expect(response.body).toStrictEqual({
+      url: "https://checkout.stripe.com/session/preview",
+    });
+    const expectedPreviewMetadata = {
+      vm0_environment: "preview",
+      job_ref: "pr-123",
+    };
+    expect(context.mocks.stripe.customers.create).toHaveBeenCalledWith({
+      metadata: {
+        orgId: fixture.orgId,
+        ...expectedPreviewMetadata,
+      },
+    });
+    expect(context.mocks.stripe.checkout.sessions.create).toHaveBeenCalledWith(
+      expect.objectContaining({
+        metadata: {
+          orgId: fixture.orgId,
+          tier: "pro",
+          priceId: TEST_PRICE_PRO,
+          ...expectedPreviewMetadata,
+        },
+        subscription_data: expect.objectContaining({
+          metadata: {
+            orgId: fixture.orgId,
+            tier: "pro",
+            priceId: TEST_PRICE_PRO,
+            ...expectedPreviewMetadata,
+          },
+        }),
+      }),
+    );
+  });
+
   it("returns 400 when checkout would downgrade the current tier", async () => {
     const fixture = await trackedBillingSeed({
       stripeCustomerId: `cus_${randomUUID().slice(0, 8)}`,

--- a/turbo/apps/api/src/signals/services/billing-customer.service.ts
+++ b/turbo/apps/api/src/signals/services/billing-customer.service.ts
@@ -5,6 +5,7 @@ import { orgMetadata } from "@vm0/db/schema/org-metadata";
 import { writeDb$ } from "../external/db";
 import { nowDate } from "../external/time";
 import { getStripeClient } from "../external/stripe-client";
+import { stripePreviewMetadata } from "./stripe-preview-metadata.service";
 
 interface GetOrCreateStripeCustomerArgs {
   readonly orgId: string;
@@ -50,6 +51,7 @@ export const getOrCreateStripeCustomer$ = command(
           metadata[key] = value;
         }
       }
+      Object.assign(metadata, stripePreviewMetadata());
       const customer = await stripe.customers.create({ metadata });
       signal.throwIfAborted();
 

--- a/turbo/apps/api/src/signals/services/stripe-preview-metadata.service.ts
+++ b/turbo/apps/api/src/signals/services/stripe-preview-metadata.service.ts
@@ -1,0 +1,35 @@
+import { env, optionalEnv } from "../../lib/env";
+
+const PREVIEW_ENVIRONMENT_METADATA_KEY = "vm0_environment";
+const PREVIEW_JOB_REF_METADATA_KEY = "job_ref";
+
+function stripePreviewJobRef(): string | null {
+  if (env("ENV") !== "preview") {
+    return null;
+  }
+  return optionalEnv("VM0_PREVIEW_JOB_REF") ?? null;
+}
+
+export function stripePreviewMetadata(): Record<string, string> {
+  const jobRef = stripePreviewJobRef();
+  if (!jobRef) {
+    return {};
+  }
+  return {
+    [PREVIEW_ENVIRONMENT_METADATA_KEY]: "preview",
+    [PREVIEW_JOB_REF_METADATA_KEY]: jobRef,
+  };
+}
+
+export function isCurrentStripePreviewMetadata(
+  metadata: Readonly<Record<string, string>> | null | undefined,
+): boolean {
+  const jobRef = stripePreviewJobRef();
+  if (!jobRef) {
+    return true;
+  }
+  return (
+    metadata?.[PREVIEW_ENVIRONMENT_METADATA_KEY] === "preview" &&
+    metadata[PREVIEW_JOB_REF_METADATA_KEY] === jobRef
+  );
+}

--- a/turbo/apps/api/src/signals/services/webhooks-stripe.service.ts
+++ b/turbo/apps/api/src/signals/services/webhooks-stripe.service.ts
@@ -17,6 +17,7 @@ import {
   tierForKnownPriceId,
   tierFromPriceId,
 } from "./zero-billing-checkout.service";
+import { isCurrentStripePreviewMetadata } from "./stripe-preview-metadata.service";
 import { drainOrgQueueToCapacity$ } from "./zero-run-queue.service";
 
 const L = logger("WebhookStripe");
@@ -47,6 +48,7 @@ interface InvoiceInput {
   };
   readonly parent: {
     readonly subscription_details: {
+      readonly metadata?: Record<string, string> | null;
       readonly subscription: string | { readonly id: string };
     } | null;
   } | null;
@@ -56,6 +58,7 @@ interface SubscriptionInput {
   readonly id: string;
   readonly customer?: string | { readonly id: string } | null;
   readonly status: string;
+  readonly metadata?: Record<string, string> | null;
   readonly trial_end?: number | null;
   readonly cancel_at?: number | null;
   readonly cancel_at_period_end: boolean;
@@ -70,6 +73,7 @@ interface SubscriptionInput {
 
 interface SubscriptionDeletedInput {
   readonly id: string;
+  readonly metadata?: Record<string, string> | null;
 }
 
 interface SubscriptionPreviousAttributes {
@@ -244,6 +248,41 @@ function creditPurchaseAmount(session: CheckoutSessionInput): number {
 
 function autoRechargeNeverExpiresAt(): Date {
   return new Date("2999-12-31T00:00:00Z");
+}
+
+function stripePreviewMetadataForEvent(
+  event: Stripe.Event,
+): readonly (Readonly<Record<string, string>> | null | undefined)[] | null {
+  switch (event.type) {
+    case "checkout.session.completed":
+    case "checkout.session.async_payment_succeeded": {
+      return [event.data.object.metadata];
+    }
+    case "invoice.paid": {
+      return [
+        event.data.object.metadata,
+        event.data.object.parent?.subscription_details?.metadata,
+      ];
+    }
+    case "customer.subscription.created":
+    case "customer.subscription.updated":
+    case "customer.subscription.deleted": {
+      return [event.data.object.metadata];
+    }
+    default: {
+      return null;
+    }
+  }
+}
+
+function shouldHandleStripePreviewEvent(event: Stripe.Event): boolean {
+  const metadataCandidates = stripePreviewMetadataForEvent(event);
+  if (metadataCandidates === null) {
+    return true;
+  }
+  return metadataCandidates.some((metadata) => {
+    return isCurrentStripePreviewMetadata(metadata);
+  });
 }
 
 async function grantOrgCredits(
@@ -1431,6 +1470,14 @@ export const handleStripeWebhookEvent$ = command(
     const db = set(writeDb$);
     let drainOrgId: string | null = null;
     L.debug("stripe webhook received", { type: event.type, id: event.id });
+
+    if (!shouldHandleStripePreviewEvent(event)) {
+      L.debug("ignoring Stripe preview event for a different job", {
+        type: event.type,
+        id: event.id,
+      });
+      return;
+    }
 
     switch (event.type) {
       case "checkout.session.completed": {

--- a/turbo/apps/api/src/signals/services/zero-billing-checkout.service.ts
+++ b/turbo/apps/api/src/signals/services/zero-billing-checkout.service.ts
@@ -8,6 +8,7 @@ import { nowDate } from "../external/time";
 import { writeDb$ } from "../external/db";
 import { getStripeClient } from "../external/stripe-client";
 import { getOrCreateStripeCustomer$ } from "./billing-customer.service";
+import { stripePreviewMetadata } from "./stripe-preview-metadata.service";
 
 interface CreateCheckoutSessionArgs {
   readonly orgId: string;
@@ -147,6 +148,7 @@ function checkoutSessionMetadata(args: {
       metadata[key] = value;
     }
   }
+  Object.assign(metadata, stripePreviewMetadata());
   return metadata;
 }
 
@@ -347,6 +349,7 @@ export const createCreditCheckoutSession$ = command(
     const baseMetadata = {
       purpose: "credit_purchase",
       orgId: args.orgId,
+      ...stripePreviewMetadata(),
     };
     const customCreditPriceId = activeCustomCreditPriceId();
     if (!customCreditPriceId) {

--- a/turbo/apps/api/src/signals/services/zero-billing-redeem.service.ts
+++ b/turbo/apps/api/src/signals/services/zero-billing-redeem.service.ts
@@ -11,6 +11,7 @@ import { getStripeClient } from "../external/stripe-client";
 import { settle } from "../utils";
 import { getOrCreateStripeCustomer$ } from "./billing-customer.service";
 import { getCampaign } from "./one-time-products";
+import { stripePreviewMetadata } from "./stripe-preview-metadata.service";
 
 const log = logger("zero-billing-redeem");
 
@@ -359,6 +360,7 @@ const createOneTimeCheckoutSession$ = command(
         orgId: args.orgId,
         campaignKey: args.campaignKey,
         purpose: "one_time_purchase",
+        ...stripePreviewMetadata(),
       },
     });
     signal.throwIfAborted();

--- a/turbo/apps/api/src/signals/services/zero-credit-recharge.service.ts
+++ b/turbo/apps/api/src/signals/services/zero-credit-recharge.service.ts
@@ -8,6 +8,7 @@ import { getStripeClient } from "../external/stripe-client";
 import { nowDate } from "../external/time";
 import { settle } from "../utils";
 import { logger } from "../../lib/log";
+import { stripePreviewMetadata } from "./stripe-preview-metadata.service";
 
 const L = logger("CreditRecharge");
 
@@ -157,6 +158,7 @@ export const triggerAutoRecharge$ = command(
             type: "auto_recharge",
             orgId,
             creditsAmount: String(creditsAmount),
+            ...stripePreviewMetadata(),
           },
         });
         signal.throwIfAborted();


### PR DESCRIPTION
## Summary
- start one PR-scoped Stripe CLI listener on a selected metal host for Playwright Stripe webhook forwarding
- clean any existing listener before start, then stop/remove listeners on PR close and stale cleanup
- tag preview Stripe objects with `job_ref` metadata and ignore webhook events from other PR previews

## Verification
- `bash .github/scripts/tests/web-api-env-action-test.sh && bash .github/scripts/tests/runner-image-context-test.sh`
- `pnpm -F api exec vitest src/signals/routes/__tests__/zero-billing-checkout.test.ts src/signals/routes/__tests__/webhooks-third-party.test.ts --run`
- `pnpm -F @vm0/firewalls-generator generate`
- YAML parse check for changed workflows and Ansible playbooks
- `ansible-playbook -i 'localhost,' ansible/playbooks/start-stripe-listener.yml --syntax-check && ansible-playbook -i 'localhost,' ansible/playbooks/cleanup-stripe-listener.yml --syntax-check`\n- `pnpm -F api lint`\n- CI passed on PR #16655, including `lint-types`, `deploy-stripe-listener`, Playwright, runner E2E, and both CI gates