### PR TITLE
feat: add desktop auto-update feed

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -236,6 +236,48 @@ jobs:
           TAG_NAME: desktop-v${{ needs.release-please.outputs.desktop_version }}
         run: gh release upload "$TAG_NAME" "${{ steps.build-desktop.outputs.path }}" --repo "${{ github.repository }}" --clobber
 
+      - name: Publish Desktop update manifest
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          MANIFEST_TAG: desktop-updates
+          RELEASE_TAG: desktop-v${{ needs.release-please.outputs.desktop_version }}
+        run: |
+          manifest_dir="apps/desktop/out/update-manifest"
+          manifest_path="$manifest_dir/desktop-update-manifest.json"
+          zip_url="https://github.com/${{ github.repository }}/releases/download/$RELEASE_TAG/Zero-darwin-arm64-$DESKTOP_VERSION.zip"
+
+          mkdir -p "$manifest_dir"
+          if gh release view "$MANIFEST_TAG" --repo "${{ github.repository }}" >/dev/null 2>&1; then
+            if gh release view "$MANIFEST_TAG" \
+              --repo "${{ github.repository }}" \
+              --json assets \
+              --jq '.assets[].name' | grep -qx desktop-update-manifest.json; then
+              gh release download "$MANIFEST_TAG" \
+                --repo "${{ github.repository }}" \
+                --pattern desktop-update-manifest.json \
+                --dir "$manifest_dir" \
+                --clobber
+            fi
+          else
+            gh release create "$MANIFEST_TAG" \
+              --repo "${{ github.repository }}" \
+              --title "Desktop Updates" \
+              --notes "Mutable manifest used by the Desktop auto-update feed." \
+              --latest=false
+          fi
+
+          node apps/desktop/scripts/update-desktop-release-manifest.mjs \
+            --manifest "$manifest_path" \
+            --version "$DESKTOP_VERSION" \
+            --zip-url "$zip_url" \
+            --channel stable \
+            --platform darwin \
+            --arch arm64
+
+          gh release upload "$MANIFEST_TAG" "$manifest_path" \
+            --repo "${{ github.repository }}" \
+            --clobber
+
       - name: Delete temporary keychain
         if: ${{ always() && steps.signing-certificate.outputs.keychain_path != '' }}
         run: security delete-keychain "${{ steps.signing-certificate.outputs.keychain_path }}" || true

--- a/turbo/apps/api/src/signals/route.ts
+++ b/turbo/apps/api/src/signals/route.ts
@@ -31,6 +31,7 @@ import { cronSyncSkillsRoutes } from "./routes/cron-sync-skills";
 import { cronTelegramCleanupRoutes } from "./routes/cron-telegram-cleanup";
 import { deviceTokenRoutes } from "./routes/device-token";
 import { desktopAuthRoutes } from "./routes/desktop-auth";
+import { desktopUpdateRoutes } from "./routes/desktop-updates";
 import { emailUnsubscribeRoutes } from "./routes/email-unsubscribe";
 import { generateImageRoutes } from "./routes/generate-image";
 import { apiHealth$ } from "./routes/health";
@@ -194,6 +195,7 @@ export const ROUTES: readonly RouteEntry[] = [
   ...cliAuthRoutes,
   ...cliAuthTestRoutes,
   ...desktopAuthRoutes,
+  ...desktopUpdateRoutes,
   ...healthAuthProbeRoutes,
   ...githubOauthRoutes,
   ...internalCallbacksAgentRoutes,

--- a/turbo/apps/api/src/signals/routes/__tests__/desktop-updates.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/desktop-updates.test.ts
@@ -1,0 +1,137 @@
+import { desktopUpdatesContract } from "@vm0/api-contracts/contracts/desktop-updates";
+import { beforeEach, describe, expect, it } from "vitest";
+
+import { accept, setupApp, testContext } from "../../../__tests__/test-helpers";
+import {
+  clearDesktopUpdateManifestCacheForTest,
+  mockDesktopUpdateManifestForTest,
+  type DesktopUpdateManifest,
+} from "../../services/desktop-updates.service";
+
+const context = testContext();
+
+function client() {
+  return setupApp({ context })(desktopUpdatesContract);
+}
+
+function stableManifest(
+  latest: string,
+  releases: DesktopUpdateManifest["releases"],
+  blocked: readonly string[] = [],
+): DesktopUpdateManifest {
+  return {
+    schemaVersion: 1,
+    channels: {
+      stable: { latest, blocked: [...blocked] },
+    },
+    releases,
+  };
+}
+
+function darwinArm64Release(version: string, url: string) {
+  return {
+    version,
+    name: `Zero ${version}`,
+    notes: `Release ${version}`,
+    pubDate: "2026-06-08T00:00:00.000Z",
+    platforms: {
+      darwin: {
+        arm64: { url },
+      },
+    },
+  };
+}
+
+describe("desktop update routes", () => {
+  beforeEach(() => {
+    clearDesktopUpdateManifestCacheForTest();
+  });
+
+  it("serves the current stable macOS arm64 update from the manifest", async () => {
+    const zipUrl =
+      "https://github.com/vm0-ai/vm0/releases/download/desktop-v0.2.1/Zero-darwin-arm64-0.2.1.zip";
+    mockDesktopUpdateManifestForTest(
+      stableManifest("0.2.1", {
+        "0.2.1": darwinArm64Release("0.2.1", zipUrl),
+      }),
+    );
+
+    const response = await accept(
+      client().feed({
+        params: { channel: "stable", platform: "darwin", arch: "arm64" },
+      }),
+      [200],
+    );
+
+    expect(response.body).toStrictEqual({
+      currentRelease: "0.2.1",
+      releases: [
+        {
+          version: "0.2.1",
+          updateTo: {
+            name: "Zero 0.2.1",
+            version: "0.2.1",
+            pub_date: "2026-06-08T00:00:00.000Z",
+            url: zipUrl,
+            notes: "Release 0.2.1",
+          },
+        },
+      ],
+    });
+  });
+
+  it("does not return a blocked latest release", async () => {
+    const previousUrl =
+      "https://github.com/vm0-ai/vm0/releases/download/desktop-v0.2.1/Zero-darwin-arm64-0.2.1.zip";
+    mockDesktopUpdateManifestForTest(
+      stableManifest(
+        "0.2.2",
+        {
+          "0.2.1": darwinArm64Release("0.2.1", previousUrl),
+          "0.2.2": darwinArm64Release(
+            "0.2.2",
+            "https://github.com/vm0-ai/vm0/releases/download/desktop-v0.2.2/Zero-darwin-arm64-0.2.2.zip",
+          ),
+          "0.3.0": darwinArm64Release(
+            "0.3.0",
+            "https://github.com/vm0-ai/vm0/releases/download/desktop-v0.3.0/Zero-darwin-arm64-0.3.0.zip",
+          ),
+        },
+        ["0.2.2"],
+      ),
+    );
+
+    const response = await accept(
+      client().feed({
+        params: { channel: "stable", platform: "darwin", arch: "arm64" },
+      }),
+      [200],
+    );
+
+    expect(response.body.currentRelease).toBe("0.2.1");
+    expect(response.body.releases[0]?.updateTo.url).toBe(previousUrl);
+  });
+
+  it("returns not found when the manifest has no matching asset", async () => {
+    mockDesktopUpdateManifestForTest(
+      stableManifest("0.2.1", {
+        "0.2.1": {
+          version: "0.2.1",
+          pubDate: "2026-06-08T00:00:00.000Z",
+          platforms: {
+            darwin: {},
+          },
+        },
+      }),
+    );
+
+    const response = await accept(
+      client().feed({
+        params: { channel: "stable", platform: "darwin", arch: "arm64" },
+      }),
+      [404],
+    );
+
+    expect(response.body.error.code).toBe("NOT_FOUND");
+  });
+});

--- a/turbo/apps/api/src/signals/routes/desktop-updates.ts
+++ b/turbo/apps/api/src/signals/routes/desktop-updates.ts
@@ -1,0 +1,30 @@
+import { desktopUpdatesContract } from "@vm0/api-contracts/contracts/desktop-updates";
+import { command } from "ccstate";
+
+import { notFound } from "../../lib/error";
+import { pathParamsOf } from "../context/request";
+import type { RouteEntry } from "../route";
+import { loadDesktopUpdateFeed } from "../services/desktop-updates.service";
+
+const feedParams$ = pathParamsOf(desktopUpdatesContract.feed);
+
+const getDesktopUpdateFeed$ = command(async ({ get }, signal: AbortSignal) => {
+  const feed = await loadDesktopUpdateFeed(get(feedParams$), signal);
+  signal.throwIfAborted();
+
+  if (!feed) {
+    return notFound("No desktop update is available for this feed.");
+  }
+
+  return {
+    status: 200 as const,
+    body: feed,
+  };
+});
+
+export const desktopUpdateRoutes: readonly RouteEntry[] = [
+  {
+    route: desktopUpdatesContract.feed,
+    handler: getDesktopUpdateFeed$,
+  },
+];

--- a/turbo/apps/api/src/signals/services/desktop-updates.service.ts
+++ b/turbo/apps/api/src/signals/services/desktop-updates.service.ts
@@ -1,0 +1,220 @@
+import type {
+  DesktopUpdateArchitecture,
+  DesktopUpdateChannel,
+  DesktopUpdatePlatform,
+  SquirrelMacReleases,
+} from "@vm0/api-contracts/contracts/desktop-updates";
+import { z } from "zod";
+
+import { testOverride } from "../../lib/singleton";
+import { now } from "../../lib/time";
+
+const DESKTOP_UPDATE_MANIFEST_URL =
+  "https://github.com/vm0-ai/vm0/releases/download/desktop-updates/desktop-update-manifest.json";
+
+const DESKTOP_UPDATE_MANIFEST_CACHE_TTL_MS = 60_000;
+
+const desktopUpdateAssetSchema = z.object({
+  url: z.string().url(),
+});
+
+const desktopUpdateReleaseSchema = z.object({
+  version: z.string().min(1),
+  name: z.string().optional(),
+  notes: z.string().optional(),
+  pubDate: z.string().datetime(),
+  platforms: z.record(
+    z.string(),
+    z.record(z.string(), desktopUpdateAssetSchema),
+  ),
+});
+
+const desktopUpdateChannelSchema = z.object({
+  latest: z.string().min(1),
+  blocked: z.array(z.string().min(1)).optional(),
+});
+
+const desktopUpdateManifestSchema = z.object({
+  schemaVersion: z.literal(1),
+  channels: z.record(z.string(), desktopUpdateChannelSchema),
+  releases: z.record(z.string(), desktopUpdateReleaseSchema),
+});
+
+export type DesktopUpdateManifest = z.infer<typeof desktopUpdateManifestSchema>;
+
+interface DesktopUpdateFeedRequest {
+  readonly channel: DesktopUpdateChannel;
+  readonly platform: DesktopUpdatePlatform;
+  readonly arch: DesktopUpdateArchitecture;
+}
+
+interface DesktopUpdateManifestCacheEntry {
+  readonly expiresAt: number;
+  readonly manifest: DesktopUpdateManifest;
+}
+
+const desktopUpdateManifestCache =
+  testOverride<DesktopUpdateManifestCacheEntry | null>(() => {
+    return null;
+  });
+
+const desktopUpdateManifestOverride = testOverride<
+  DesktopUpdateManifest | undefined
+>(() => {
+  return undefined;
+});
+
+export function clearDesktopUpdateManifestCacheForTest(): void {
+  desktopUpdateManifestCache.clear();
+  desktopUpdateManifestOverride.clear();
+}
+
+export function mockDesktopUpdateManifestForTest(
+  manifest: DesktopUpdateManifest,
+): void {
+  desktopUpdateManifestCache.clear();
+  desktopUpdateManifestOverride.set(manifest);
+}
+
+function compareDesktopVersions(left: string, right: string): number {
+  const leftParts = left.split(/[+-]/, 1)[0]?.split(".").map(Number) ?? [];
+  const rightParts = right.split(/[+-]/, 1)[0]?.split(".").map(Number) ?? [];
+
+  for (let index = 0; index < 3; index += 1) {
+    const diff = (leftParts[index] ?? 0) - (rightParts[index] ?? 0);
+    if (diff !== 0) {
+      return diff;
+    }
+  }
+
+  return left.localeCompare(right);
+}
+
+function compareDesktopVersionsDesc(left: string, right: string): number {
+  return compareDesktopVersions(right, left);
+}
+
+function assetForRelease(
+  release: DesktopUpdateManifest["releases"][string],
+  request: DesktopUpdateFeedRequest,
+): { readonly url: string } | null {
+  return release.platforms[request.platform]?.[request.arch] ?? null;
+}
+
+function squirrelRelease(
+  release: DesktopUpdateManifest["releases"][string],
+  asset: { readonly url: string },
+) {
+  return {
+    version: release.version,
+    updateTo: {
+      name: release.name ?? `Zero ${release.version}`,
+      version: release.version,
+      pub_date: release.pubDate,
+      url: asset.url,
+      notes: release.notes ?? "",
+    },
+  };
+}
+
+function selectDesktopRelease(
+  manifest: DesktopUpdateManifest,
+  request: DesktopUpdateFeedRequest,
+) {
+  const channel = manifest.channels[request.channel];
+  if (!channel) {
+    return null;
+  }
+
+  const blocked = new Set(channel.blocked ?? []);
+  const latest = manifest.releases[channel.latest];
+  if (latest && !blocked.has(latest.version)) {
+    const latestAsset = assetForRelease(latest, request);
+    if (latestAsset) {
+      return { release: latest, asset: latestAsset };
+    }
+  }
+
+  const [fallback] = Object.values(manifest.releases)
+    .filter((release) => {
+      return (
+        !blocked.has(release.version) &&
+        compareDesktopVersions(release.version, channel.latest) <= 0 &&
+        assetForRelease(release, request)
+      );
+    })
+    .sort((left, right) => {
+      return compareDesktopVersionsDesc(left.version, right.version);
+    });
+  if (!fallback) {
+    return null;
+  }
+
+  const asset = assetForRelease(fallback, request);
+  if (!asset) {
+    return null;
+  }
+
+  return { release: fallback, asset };
+}
+
+function buildDesktopUpdateFeed(
+  manifest: DesktopUpdateManifest,
+  request: DesktopUpdateFeedRequest,
+): SquirrelMacReleases | null {
+  const selected = selectDesktopRelease(manifest, request);
+  if (!selected) {
+    return null;
+  }
+
+  return {
+    currentRelease: selected.release.version,
+    releases: [squirrelRelease(selected.release, selected.asset)],
+  };
+}
+
+async function fetchDesktopUpdateManifest(
+  signal: AbortSignal,
+): Promise<DesktopUpdateManifest> {
+  const override = desktopUpdateManifestOverride.get();
+  if (override) {
+    return override;
+  }
+
+  const response = await fetch(DESKTOP_UPDATE_MANIFEST_URL, {
+    headers: { accept: "application/json" },
+    signal,
+  });
+  if (!response.ok) {
+    throw new Error(
+      `Desktop update manifest fetch failed with ${response.status}`,
+    );
+  }
+
+  return desktopUpdateManifestSchema.parse(await response.json());
+}
+
+async function loadDesktopUpdateManifest(
+  signal: AbortSignal,
+): Promise<DesktopUpdateManifest> {
+  const cacheEntry = desktopUpdateManifestCache.get();
+  const nowMs = now();
+  if (cacheEntry && cacheEntry.expiresAt > nowMs) {
+    return cacheEntry.manifest;
+  }
+
+  const manifest = await fetchDesktopUpdateManifest(signal);
+  desktopUpdateManifestCache.set({
+    expiresAt: nowMs + DESKTOP_UPDATE_MANIFEST_CACHE_TTL_MS,
+    manifest,
+  });
+  return manifest;
+}
+
+export async function loadDesktopUpdateFeed(
+  request: DesktopUpdateFeedRequest,
+  signal: AbortSignal,
+): Promise<SquirrelMacReleases | null> {
+  const manifest = await loadDesktopUpdateManifest(signal);
+  return buildDesktopUpdateFeed(manifest, request);
+}

--- a/turbo/apps/desktop/package.json
+++ b/turbo/apps/desktop/package.json
@@ -31,7 +31,8 @@
     "ccstate": "^5.3.0",
     "ccstate-react": "^5.3.0",
     "react": "^19.2.6",
-    "react-dom": "^19.2.6"
+    "react-dom": "^19.2.6",
+    "update-electron-app": "3.2.0"
   },
   "devDependencies": {
     "@electron-forge/cli": "7.11.1",

--- a/turbo/apps/desktop/scripts/update-desktop-release-manifest.mjs
+++ b/turbo/apps/desktop/scripts/update-desktop-release-manifest.mjs
@@ -1,0 +1,86 @@
+import { existsSync, mkdirSync, readFileSync, writeFileSync } from "node:fs";
+import { dirname } from "node:path";
+
+function parseArgs(argv) {
+  const args = new Map();
+  for (let index = 0; index < argv.length; index += 2) {
+    const key = argv[index];
+    const value = argv[index + 1];
+    if (!key?.startsWith("--") || value === undefined) {
+      throw new Error(`Invalid argument near ${key ?? "end of input"}`);
+    }
+    args.set(key.slice(2), value);
+  }
+  return args;
+}
+
+function requiredArg(args, name) {
+  const value = args.get(name);
+  if (!value) {
+    throw new Error(`Missing required --${name}`);
+  }
+  return value;
+}
+
+function readManifest(path) {
+  if (!existsSync(path)) {
+    return {
+      schemaVersion: 1,
+      channels: {},
+      releases: {},
+    };
+  }
+
+  return JSON.parse(readFileSync(path, "utf8"));
+}
+
+function ensureRecord(value, fallback = {}) {
+  if (typeof value === "object" && value !== null && !Array.isArray(value)) {
+    return value;
+  }
+  return fallback;
+}
+
+const args = parseArgs(process.argv.slice(2));
+const manifestPath = requiredArg(args, "manifest");
+const version = requiredArg(args, "version");
+const zipUrl = requiredArg(args, "zip-url");
+const channel = args.get("channel") ?? "stable";
+const platform = args.get("platform") ?? "darwin";
+const arch = args.get("arch") ?? "arm64";
+const pubDate = args.get("pub-date") ?? new Date().toISOString();
+
+const manifest = ensureRecord(readManifest(manifestPath));
+manifest.schemaVersion = 1;
+manifest.channels = ensureRecord(manifest.channels);
+manifest.releases = ensureRecord(manifest.releases);
+
+const currentChannel = ensureRecord(manifest.channels[channel], {
+  blocked: [],
+});
+const blocked = Array.isArray(currentChannel.blocked)
+  ? currentChannel.blocked
+  : [];
+manifest.channels[channel] = {
+  ...currentChannel,
+  latest: version,
+  blocked,
+};
+
+const currentRelease = ensureRecord(manifest.releases[version]);
+const platforms = ensureRecord(currentRelease.platforms);
+const platformAssets = ensureRecord(platforms[platform]);
+platformAssets[arch] = { url: zipUrl };
+platforms[platform] = platformAssets;
+
+manifest.releases[version] = {
+  ...currentRelease,
+  version,
+  name: currentRelease.name ?? `Zero ${version}`,
+  notes: currentRelease.notes ?? "",
+  pubDate,
+  platforms,
+};
+
+mkdirSync(dirname(manifestPath), { recursive: true });
+writeFileSync(manifestPath, `${JSON.stringify(manifest, null, 2)}\n`);

--- a/turbo/apps/desktop/src/config.ts
+++ b/turbo/apps/desktop/src/config.ts
@@ -5,7 +5,7 @@ import desktopIdentities from "./desktop-identities.json";
 const PRODUCTION_PLATFORM_URL = "https://app.vm0.ai";
 const DESKTOP_RUNTIME_CONFIG_FILE = "desktop-runtime-config.json";
 
-type DesktopEnvironment = "production" | "staging" | "development";
+export type DesktopEnvironment = "production" | "staging" | "development";
 type DesktopIdentityKind = "production" | "development";
 
 interface DesktopIdentity {
@@ -18,7 +18,7 @@ interface DesktopIdentity {
 const DESKTOP_IDENTITIES: Record<DesktopIdentityKind, DesktopIdentity> =
   desktopIdentities;
 
-interface DesktopConfig {
+export interface DesktopConfig {
   readonly platformUrl: URL;
   readonly webUrl: URL;
   readonly environment: DesktopEnvironment;

--- a/turbo/apps/desktop/src/desktop-auto-updates.ts
+++ b/turbo/apps/desktop/src/desktop-auto-updates.ts
@@ -1,0 +1,79 @@
+import { app, autoUpdater, dialog } from "electron";
+import {
+  UpdateSourceType,
+  updateElectronApp,
+  type IUpdateInfo,
+} from "update-electron-app";
+
+import type { DesktopConfig } from "./config";
+import {
+  desktopUpdateFeedBaseUrl,
+  shouldInstallDesktopAutoUpdates,
+} from "./desktop-update-feed";
+
+interface DesktopAutoUpdateOptions {
+  readonly config: DesktopConfig;
+  readonly apiBaseUrl: string;
+  readonly prepareForQuitAndInstall: () => Promise<void>;
+}
+
+async function promptToRestartForUpdate(
+  info: IUpdateInfo,
+  prepareForQuitAndInstall: () => Promise<void>,
+): Promise<void> {
+  const result = await dialog.showMessageBox({
+    type: "info",
+    buttons: ["Restart", "Later"],
+    defaultId: 0,
+    cancelId: 1,
+    title: "Update Ready",
+    message: info.releaseName,
+    detail: "A new version has been downloaded. Restart Zero to install it.",
+  });
+
+  if (result.response !== 0) {
+    return;
+  }
+
+  await prepareForQuitAndInstall();
+  autoUpdater.quitAndInstall();
+}
+
+export function installDesktopAutoUpdates(
+  options: DesktopAutoUpdateOptions,
+): boolean {
+  if (
+    !shouldInstallDesktopAutoUpdates({
+      environment: options.config.environment,
+      isPackaged: app.isPackaged,
+      platform: process.platform,
+      arch: process.arch,
+    })
+  ) {
+    return false;
+  }
+
+  const baseUrl = desktopUpdateFeedBaseUrl(options.apiBaseUrl);
+  if (new URL(baseUrl).protocol !== "https:") {
+    console.warn("Desktop auto-updates require an HTTPS feed URL");
+    return false;
+  }
+
+  updateElectronApp({
+    updateSource: {
+      type: UpdateSourceType.StaticStorage,
+      baseUrl,
+    },
+    updateInterval: "30 minutes",
+    notifyUser: true,
+    onNotifyUser: (info) => {
+      void promptToRestartForUpdate(
+        info,
+        options.prepareForQuitAndInstall,
+      ).catch((error) => {
+        console.error("Desktop update restart prompt failed", error);
+      });
+    },
+  });
+  return true;
+}

--- a/turbo/apps/desktop/src/desktop-update-feed.test.ts
+++ b/turbo/apps/desktop/src/desktop-update-feed.test.ts
@@ -1,0 +1,50 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  desktopUpdateFeedBaseUrl,
+  shouldInstallDesktopAutoUpdates,
+} from "./desktop-update-feed";
+
+describe("desktop update feed", () => {
+  it("enables updates only for packaged production macOS arm64 builds", () => {
+    expect(
+      shouldInstallDesktopAutoUpdates({
+        environment: "production",
+        isPackaged: true,
+        platform: "darwin",
+        arch: "arm64",
+      }),
+    ).toBe(true);
+
+    expect(
+      shouldInstallDesktopAutoUpdates({
+        environment: "development",
+        isPackaged: true,
+        platform: "darwin",
+        arch: "arm64",
+      }),
+    ).toBe(false);
+    expect(
+      shouldInstallDesktopAutoUpdates({
+        environment: "production",
+        isPackaged: false,
+        platform: "darwin",
+        arch: "arm64",
+      }),
+    ).toBe(false);
+    expect(
+      shouldInstallDesktopAutoUpdates({
+        environment: "production",
+        isPackaged: true,
+        platform: "linux",
+        arch: "arm64",
+      }),
+    ).toBe(false);
+  });
+
+  it("builds the static feed base URL used by update-electron-app", () => {
+    expect(desktopUpdateFeedBaseUrl("https://api.vm0.ai")).toBe(
+      "https://api.vm0.ai/api/desktop/updates/stable/darwin/arm64",
+    );
+  });
+});

--- a/turbo/apps/desktop/src/desktop-update-feed.ts
+++ b/turbo/apps/desktop/src/desktop-update-feed.ts
@@ -1,0 +1,31 @@
+import type { DesktopConfig } from "./config";
+
+const DESKTOP_UPDATE_CHANNEL = "stable";
+const DESKTOP_UPDATE_PLATFORM = "darwin";
+const DESKTOP_UPDATE_ARCH = "arm64";
+
+interface DesktopAutoUpdateEligibility {
+  readonly environment: DesktopConfig["environment"];
+  readonly isPackaged: boolean;
+  readonly platform: NodeJS.Platform;
+  readonly arch: NodeJS.Architecture;
+}
+
+export function shouldInstallDesktopAutoUpdates(
+  eligibility: DesktopAutoUpdateEligibility,
+): boolean {
+  return (
+    eligibility.environment === "production" &&
+    eligibility.isPackaged &&
+    eligibility.platform === DESKTOP_UPDATE_PLATFORM &&
+    eligibility.arch === DESKTOP_UPDATE_ARCH
+  );
+}
+
+export function desktopUpdateFeedBaseUrl(apiBaseUrl: string): string {
+  const url = new URL(apiBaseUrl);
+  url.pathname = `/api/desktop/updates/${DESKTOP_UPDATE_CHANNEL}/${DESKTOP_UPDATE_PLATFORM}/${DESKTOP_UPDATE_ARCH}`;
+  url.search = "";
+  url.hash = "";
+  return url.toString().replace(/\/$/, "");
+}

--- a/turbo/apps/desktop/src/main.ts
+++ b/turbo/apps/desktop/src/main.ts
@@ -41,6 +41,7 @@ import {
 } from "./computer-use-permissions";
 import { createComputerUseNativeBackend } from "./computer-use-native";
 import { resolveDesktopConfig } from "./config";
+import { installDesktopAutoUpdates } from "./desktop-auto-updates";
 import { createDesktopComputerUseSessionFetch } from "./desktop-computer-use-api";
 import { DesktopAuthSession } from "./desktop-auth-session";
 import {
@@ -90,6 +91,7 @@ const COMPUTER_USE_QUIT_STOP_TIMEOUT_MS = 1_000;
 let mainWindow: BrowserWindow | null = null;
 let appIsQuitting = false;
 let computerUseQuitStopStarted = false;
+let computerUseNativeBackendDisposed = false;
 const desktopAuthStartGate = createDesktopAuthStartGate();
 let computerUseRuntime: ComputerUseHostRuntime | null = null;
 let computerUseBlockedHostState: ComputerUseHostRuntimeState | null = null;
@@ -315,6 +317,23 @@ async function stopComputerUseRuntimeForQuit(): Promise<void> {
       setTimeout(resolve, COMPUTER_USE_QUIT_STOP_TIMEOUT_MS);
     }),
   ]);
+}
+
+function disposeComputerUseNativeBackend(): void {
+  if (computerUseNativeBackendDisposed) {
+    return;
+  }
+  computerUseNativeBackendDisposed = true;
+  computerUseNativeBackend.dispose();
+}
+
+async function prepareForQuitAndInstall(): Promise<void> {
+  appIsQuitting = true;
+  if (!computerUseQuitStopStarted) {
+    computerUseQuitStopStarted = true;
+    await stopComputerUseRuntimeForQuit();
+  }
+  disposeComputerUseNativeBackend();
 }
 
 function installDesktopAuth(): void {
@@ -735,13 +754,13 @@ if (!hasSingleInstanceLock) {
   app.on("before-quit", (event) => {
     appIsQuitting = true;
     if (!computerUseRuntime || computerUseQuitStopStarted) {
-      computerUseNativeBackend.dispose();
+      disposeComputerUseNativeBackend();
       return;
     }
     computerUseQuitStopStarted = true;
     event.preventDefault();
     void stopComputerUseRuntimeForQuit().finally(() => {
-      computerUseNativeBackend.dispose();
+      disposeComputerUseNativeBackend();
       app.quit();
     });
   });
@@ -751,6 +770,11 @@ if (!hasSingleInstanceLock) {
     applyApplicationMenu();
     registerDesktopAuthProtocol();
     installDesktopRendererProtocol();
+    installDesktopAutoUpdates({
+      config,
+      apiBaseUrl: desktopApiBaseUrl,
+      prepareForQuitAndInstall,
+    });
     installComputerUse();
     refreshComputerUsePermissionsForState();
     const desktopAuthSession = getAuthSession();

--- a/turbo/apps/web/api-backend-rewrites.js
+++ b/turbo/apps/web/api-backend-rewrites.js
@@ -390,6 +390,10 @@ export const API_BACKEND_REWRITES = [
   ["/api/desktop-auth/handoff", "/api/desktop-auth/handoff"],
   ["/api/desktop-auth/consume", "/api/desktop-auth/consume"],
   [
+    "/api/desktop/updates/:channel/:platform/:arch/RELEASES.json",
+    "/api/desktop/updates/:channel/:platform/:arch/RELEASES.json",
+  ],
+  [
     AGENT_RUN_CANCEL_REWRITE_SOURCE,
     "/api/agent/runs/:id/cancel",
     AGENT_RUN_CANCEL_PATH_RE,

--- a/turbo/packages/api-contracts/src/contracts/desktop-updates.ts
+++ b/turbo/packages/api-contracts/src/contracts/desktop-updates.ts
@@ -1,0 +1,51 @@
+import { z } from "zod";
+import { initContract } from "./base";
+import { apiErrorSchema } from "./errors";
+
+const c = initContract();
+
+const desktopUpdateChannelSchema = z.enum(["stable"]);
+const desktopUpdatePlatformSchema = z.enum(["darwin"]);
+const desktopUpdateArchitectureSchema = z.enum(["arm64"]);
+
+export type DesktopUpdateChannel = z.infer<typeof desktopUpdateChannelSchema>;
+export type DesktopUpdatePlatform = z.infer<typeof desktopUpdatePlatformSchema>;
+export type DesktopUpdateArchitecture = z.infer<
+  typeof desktopUpdateArchitectureSchema
+>;
+
+const squirrelMacReleaseSchema = z.object({
+  version: z.string(),
+  updateTo: z.object({
+    name: z.string(),
+    version: z.string(),
+    pub_date: z.string(),
+    url: z.string().url(),
+    notes: z.string(),
+  }),
+});
+
+const squirrelMacReleasesSchema = z.object({
+  currentRelease: z.string(),
+  releases: z.array(squirrelMacReleaseSchema),
+});
+
+export type SquirrelMacReleases = z.infer<typeof squirrelMacReleasesSchema>;
+
+export const desktopUpdatesContract = c.router({
+  feed: {
+    method: "GET",
+    path: "/api/desktop/updates/:channel/:platform/:arch/RELEASES.json",
+    pathParams: z.object({
+      channel: desktopUpdateChannelSchema,
+      platform: desktopUpdatePlatformSchema,
+      arch: desktopUpdateArchitectureSchema,
+    }),
+    responses: {
+      200: squirrelMacReleasesSchema,
+      400: apiErrorSchema,
+      404: apiErrorSchema,
+    },
+    summary: "Get the desktop auto-update feed",
+  },
+});

--- a/turbo/pnpm-lock.yaml
+++ b/turbo/pnpm-lock.yaml
@@ -414,6 +414,9 @@ importers:
       react-dom:
         specifier: ^19.2.6
         version: 19.2.6(react@19.2.6)
+      update-electron-app:
+        specifier: 3.2.0
+        version: 3.2.0
     devDependencies:
       '@electron-forge/cli':
         specifier: 7.11.1
@@ -6997,6 +7000,9 @@ packages:
   github-slugger@2.0.0:
     resolution: {integrity: sha512-IaOQ9puYtjrkq7Y0Ygl9KDZnrf/aiUJYUpVf89y8kyaxbRG7Y1SrX/jaumrv81vc61+kiMempujsM3Yw7w5qcw==}
 
+  github-url-to-object@4.0.6:
+    resolution: {integrity: sha512-NaqbYHMUAlPcmWFdrAB7bcxrNIiiJWJe8s/2+iOc9vlcHlwHqSGrPk+Yi3nu6ebTwgsZEa7igz+NH2vEq3gYwQ==}
+
   glob-parent@5.1.2:
     resolution: {integrity: sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==}
     engines: {node: '>= 6'}
@@ -7445,6 +7451,9 @@ packages:
   is-unicode-supported@0.1.0:
     resolution: {integrity: sha512-knxG2q4UC3u8stRGyAVJCOdxFmv5DZiRcdlIaAQXAbSfJya+OhopNotLQrstBhququ4ZpuKbDc/8S6mgXgPFPw==}
     engines: {node: '>=10'}
+
+  is-url@1.2.4:
+    resolution: {integrity: sha512-ITvGim8FhRiYe4IQ5uHSkj7pVaPDrCTkNd3yq3cV7iZAcJdHTUMPMEHcqSOy9xZ9qFenQCvi+2wjH9a1nXqHww==}
 
   is-weakmap@2.0.2:
     resolution: {integrity: sha512-K5pXYOm9wqY1RgjpL3YTkF39tni1XajUIkawTLUo9EZEVUFga5gSQJF8nNS7ZwJQ02y+1YCNYcMh+HIf1ZqE+w==}
@@ -9774,6 +9783,9 @@ packages:
     hasBin: true
     peerDependencies:
       browserslist: '>= 4.21.0'
+
+  update-electron-app@3.2.0:
+    resolution: {integrity: sha512-l2e7bzsW+rw70pfyyQeA9E/ofpNY2ZS99XuYxD2qWL4fEy3qMjpqwwgB0me7ESpGogIQE1CM0SaDvKGsK4Jg3Q==}
 
   uri-js@4.4.1:
     resolution: {integrity: sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg==}
@@ -16518,6 +16530,10 @@ snapshots:
 
   github-slugger@2.0.0: {}
 
+  github-url-to-object@4.0.6:
+    dependencies:
+      is-url: 1.2.4
+
   glob-parent@5.1.2:
     dependencies:
       is-glob: 4.0.3
@@ -17053,6 +17069,8 @@ snapshots:
       which-typed-array: 1.1.20
 
   is-unicode-supported@0.1.0: {}
+
+  is-url@1.2.4: {}
 
   is-weakmap@2.0.2: {}
 
@@ -19881,6 +19899,11 @@ snapshots:
       browserslist: 4.28.1
       escalade: 3.2.0
       picocolors: 1.1.1
+
+  update-electron-app@3.2.0:
+    dependencies:
+      github-url-to-object: 4.0.6
+      ms: 2.1.3
 
   uri-js@4.4.1:
     dependencies:


### PR DESCRIPTION
## Summary
- add a public Desktop update feed contract and API route for `stable/darwin/arm64/RELEASES.json`
- read a small GitHub Release-hosted manifest, cache it briefly in the API, and render Squirrel.Mac JSON without proxying ZIP downloads
- generate and upload the mutable `desktop-update-manifest.json` asset in the Desktop release workflow
- enable `update-electron-app` only for packaged production macOS arm64 builds and prompt users to restart after the update downloads

Closes #16650

## Tests
- `pnpm -F @vm0/api-contracts check-types`
- `pnpm -F @vm0/api-contracts lint`
- `pnpm -F api check-types`
- `pnpm -F api lint`
- `pnpm -F api exec vitest run src/signals/routes/__tests__/desktop-updates.test.ts`
- `pnpm -F @vm0/desktop exec vitest run src/desktop-update-feed.test.ts`
- `pnpm -F @vm0/desktop check-types`
- `pnpm -F @vm0/desktop lint`
- `pnpm -F @vm0/desktop build`
- `node apps/desktop/scripts/update-desktop-release-manifest.mjs ...` with a temp manifest path
