### PR TITLE
fix(runner): harden proxy and workspace state files

### DIFF
--- a/crates/runner/mitm-addon/src/registry.py
+++ b/crates/runner/mitm-addon/src/registry.py
@@ -1,6 +1,8 @@
 """Proxy registry loading and VM lookup cache."""
 
 import json
+import os
+import stat
 from dataclasses import dataclass, field
 from pathlib import Path
 
@@ -15,6 +17,8 @@ VmContext = tuple[
     matching.CompiledNetworkPolicies,
 ]
 _RegistryCacheKey = tuple[str, int, int, int, int]
+MAX_REGISTRY_BYTES = 16 * 1024 * 1024
+_READ_CHUNK_BYTES = 1024 * 1024
 
 
 class _RegistryFormatError(ValueError):
@@ -64,7 +68,7 @@ class _RegistryCacheState:
     # means the current snapshot belongs to an older file state and this key
     # should short-circuit until the file changes again.
     failed_key: _RegistryCacheKey | None = None
-    # Stat failures do not provide a key, so use a one-shot guard. Open/read
+    # Open/stat failures do not provide a key, so use a one-shot guard. Read
     # errors have a key but are retried on every call; track their last warning
     # key only to avoid request-path log spam without poisoning the file state.
     stat_error_logged: bool = False
@@ -171,9 +175,43 @@ def _classify_registry_vms(raw_registry: dict) -> tuple[dict, dict[str, InvalidV
     return new_registry, invalid_vms
 
 
-def _read_registry_vms(path: Path) -> dict:
-    with path.open() as f:
-        raw_registry = json.load(f)
+def _open_registry_for_read(path: Path) -> tuple[int, os.stat_result]:
+    flags = os.O_RDONLY
+    for flag_name in ("O_CLOEXEC", "O_NOFOLLOW", "O_NONBLOCK"):
+        flags |= getattr(os, flag_name, 0)
+    fd = os.open(path, flags)
+    try:
+        st = os.fstat(fd)
+    except OSError:
+        os.close(fd)
+        raise
+    if not stat.S_ISREG(st.st_mode):
+        os.close(fd)
+        raise OSError(f"proxy registry is not a regular file: {path}")
+    return fd, st
+
+
+def _read_registry_bytes(fd: int, path: Path, st_size: int) -> bytes:
+    if st_size > MAX_REGISTRY_BYTES:
+        raise OSError(f"proxy registry {path} exceeds {MAX_REGISTRY_BYTES} bytes")
+
+    chunks: list[bytes] = []
+    total = 0
+    while total <= MAX_REGISTRY_BYTES:
+        to_read = min(_READ_CHUNK_BYTES, MAX_REGISTRY_BYTES + 1 - total)
+        chunk = os.read(fd, to_read)
+        if not chunk:
+            break
+        chunks.append(chunk)
+        total += len(chunk)
+
+    if total > MAX_REGISTRY_BYTES:
+        raise OSError(f"proxy registry {path} exceeds {MAX_REGISTRY_BYTES} bytes")
+    return b"".join(chunks)
+
+
+def _read_registry_vms(fd: int, path: Path, st_size: int) -> dict:
+    raw_registry = json.loads(_read_registry_bytes(fd, path, st_size).decode("utf-8"))
     if not isinstance(raw_registry, dict):
         raise _RegistryFormatError("proxy registry must be an object")
     raw_vms = raw_registry.get("vms", {})
@@ -199,7 +237,7 @@ def load_registry_state(registry_path: str) -> RegistryState:
 
     Cache state is scoped to one active registry path. A successful load
     publishes raw and compiled registry state together in a snapshot keyed by
-    file identity metadata. Registry file stat/read/parse failures publish a
+    file identity metadata. Registry file open/stat/read/parse failures publish a
     separate unavailable state instead of returning a stale snapshot for
     enforcement. Malformed registry document input is recorded separately as a
     failed key so repeated reads of the same bad bytes do not reparse or
@@ -211,7 +249,7 @@ def load_registry_state(registry_path: str) -> RegistryState:
     state = _state_for_path(path_key)
 
     try:
-        st = path.stat()
+        fd, st = _open_registry_for_read(path)
     except OSError as e:
         message = str(e)
         if not state.stat_error_logged:
@@ -219,34 +257,37 @@ def load_registry_state(registry_path: str) -> RegistryState:
             ctx.log.warn(f"Failed to stat proxy registry: {message}")
         return _mark_unavailable(state, reason="stat_failed", message=message)
 
-    key = (path_key, st.st_dev, st.st_ino, st.st_mtime_ns, st.st_size)
-    if key == state.snapshot.loaded_key:
-        state.unavailable = None
-        state.stat_error_logged = False
-        state.read_error_key = None
-        return state.snapshot
-    if key == state.failed_key:
-        return state.unavailable or _mark_unavailable(
-            state,
-            reason="parse_failed",
-            message="proxy registry is unavailable",
-        )
-
     try:
-        raw_registry = _read_registry_vms(path)
-    except OSError as e:
-        message = str(e)
-        state.failed_key = None
-        if key != state.read_error_key:
-            state.read_error_key = key
-            ctx.log.warn(f"Failed to read proxy registry: {message}")
-        return _mark_unavailable(state, reason="read_failed", message=message)
-    except (json.JSONDecodeError, UnicodeDecodeError, _RegistryFormatError) as e:
-        message = str(e)
-        state.failed_key = key
-        state.read_error_key = None
-        ctx.log.warn(f"Failed to parse proxy registry: {message}")
-        return _mark_unavailable(state, reason="parse_failed", message=message)
+        key = (path_key, st.st_dev, st.st_ino, st.st_mtime_ns, st.st_size)
+        if key == state.snapshot.loaded_key:
+            state.unavailable = None
+            state.stat_error_logged = False
+            state.read_error_key = None
+            return state.snapshot
+        if key == state.failed_key:
+            return state.unavailable or _mark_unavailable(
+                state,
+                reason="parse_failed",
+                message="proxy registry is unavailable",
+            )
+
+        try:
+            raw_registry = _read_registry_vms(fd, path, st.st_size)
+        except OSError as e:
+            message = str(e)
+            state.failed_key = None
+            if key != state.read_error_key:
+                state.read_error_key = key
+                ctx.log.warn(f"Failed to read proxy registry: {message}")
+            return _mark_unavailable(state, reason="read_failed", message=message)
+        except (json.JSONDecodeError, UnicodeDecodeError, _RegistryFormatError) as e:
+            message = str(e)
+            state.failed_key = key
+            state.read_error_key = None
+            ctx.log.warn(f"Failed to parse proxy registry: {message}")
+            return _mark_unavailable(state, reason="parse_failed", message=message)
+    finally:
+        os.close(fd)
 
     new_registry, invalid_vms = _classify_registry_vms(raw_registry)
     if invalid_vms:

--- a/crates/runner/mitm-addon/tests/test_registry.py
+++ b/crates/runner/mitm-addon/tests/test_registry.py
@@ -2,6 +2,8 @@
 
 import json
 import os
+import queue
+import threading
 from types import SimpleNamespace
 from unittest.mock import MagicMock, patch
 
@@ -271,6 +273,87 @@ class TestLoadRegistry:
         assert log.warn.call_count == 1
         assert "Failed to stat" in log.warn.call_args_list[0].args[0]
 
+    def test_symlink_registry_is_unavailable_without_following_target(self, tmp_path):
+        path = tmp_path / "registry.json"
+        target = tmp_path / "outside-registry.json"
+        _write_simple_registry(target, run_id="outside-run")
+        path.symlink_to(target)
+
+        with patch.object(registry.ctx, "log", MagicMock(), create=True):
+            result = registry.load_registry(str(path))
+            state = registry.load_registry_state(str(path))
+
+        assert result == {}
+        assert isinstance(state, registry.RegistryUnavailable)
+        assert state.reason == "stat_failed"
+
+    def test_symlink_after_success_does_not_return_previous_snapshot(
+        self,
+        registry_file,
+        tmp_path,
+    ):
+        loaded = registry.load_registry(str(registry_file))
+        assert loaded["10.200.0.1"]["runId"] == "run-abc-123"
+        target = tmp_path / "outside-registry.json"
+        _write_simple_registry(target, run_id="outside-run")
+        registry_file.unlink()
+        registry_file.symlink_to(target)
+
+        with patch.object(registry.ctx, "log", MagicMock(), create=True):
+            result = registry.load_registry(str(registry_file))
+            state = registry.load_registry_state(str(registry_file))
+
+        assert result == {}
+        assert isinstance(state, registry.RegistryUnavailable)
+        assert state.reason == "stat_failed"
+
+    def test_fifo_registry_is_unavailable_without_blocking(self, tmp_path):
+        path = tmp_path / "registry.json"
+        os.mkfifo(path)
+        results = queue.Queue()
+        log = MagicMock()
+
+        def load_state():
+            with patch.object(registry.ctx, "log", log, create=True):
+                results.put(registry.load_registry_state(str(path)))
+
+        thread = threading.Thread(target=load_state, daemon=True)
+        thread.start()
+        thread.join(1)
+
+        assert not thread.is_alive(), "registry load blocked on FIFO"
+        state = results.get_nowait()
+        assert isinstance(state, registry.RegistryUnavailable)
+        assert state.reason == "stat_failed"
+
+    def test_directory_registry_is_unavailable(self, tmp_path):
+        path = tmp_path / "registry.json"
+        path.mkdir()
+
+        with patch.object(registry.ctx, "log", MagicMock(), create=True):
+            result = registry.load_registry(str(path))
+            state = registry.load_registry_state(str(path))
+
+        assert result == {}
+        assert isinstance(state, registry.RegistryUnavailable)
+        assert state.reason == "stat_failed"
+
+    def test_oversized_registry_is_unavailable_before_parsing(self, tmp_path):
+        path = tmp_path / "registry.json"
+        path.write_bytes(b" " * (registry.MAX_REGISTRY_BYTES + 1))
+        log = MagicMock()
+        with (
+            patch.object(registry.ctx, "log", log, create=True),
+            patch.object(registry.json, "loads", wraps=registry.json.loads) as spy,
+        ):
+            state = registry.load_registry_state(str(path))
+
+        assert isinstance(state, registry.RegistryUnavailable)
+        assert state.reason == "read_failed"
+        assert spy.call_count == 0
+        assert log.warn.call_count == 1
+        assert "exceeds" in log.warn.call_args_list[0].args[0]
+
     def test_parse_failure_logs_once_and_does_not_reparse(self, tmp_path):
         """Parse failure on a fixed file: key match short-circuits re-parse."""
         bad = tmp_path / "bad.json"
@@ -278,7 +361,7 @@ class TestLoadRegistry:
         log = MagicMock()
         with (
             patch.object(registry.ctx, "log", log, create=True),
-            patch.object(registry.json, "load", wraps=registry.json.load) as spy,
+            patch.object(registry.json, "loads", wraps=registry.json.loads) as spy,
         ):
             for _ in range(5):
                 assert registry.load_registry(str(bad)) == {}
@@ -294,7 +377,7 @@ class TestLoadRegistry:
         log = MagicMock()
         with (
             patch.object(registry.ctx, "log", log, create=True),
-            patch.object(registry.json, "load", wraps=registry.json.load) as spy,
+            patch.object(registry.json, "loads", wraps=registry.json.loads) as spy,
         ):
             result1 = registry.load_registry(str(registry_file))
             result2 = registry.load_registry(str(registry_file))
@@ -315,7 +398,7 @@ class TestLoadRegistry:
         log = MagicMock()
         with (
             patch.object(registry.ctx, "log", log, create=True),
-            patch.object(registry.json, "load", wraps=registry.json.load) as spy,
+            patch.object(registry.json, "loads", wraps=registry.json.loads) as spy,
         ):
             result1 = registry.load_registry(str(registry_file))
             result2 = registry.load_registry(str(registry_file))
@@ -336,7 +419,7 @@ class TestLoadRegistry:
         log = MagicMock()
         with (
             patch.object(registry.ctx, "log", log, create=True),
-            patch.object(registry.json, "load", wraps=registry.json.load) as spy,
+            patch.object(registry.json, "loads", wraps=registry.json.loads) as spy,
         ):
             result1 = registry.load_registry(str(registry_file))
             result2 = registry.load_registry(str(registry_file))
@@ -365,26 +448,35 @@ class TestLoadRegistry:
         assert log.warn.call_count == 2
         assert all("Failed to parse" in call.args[0] for call in log.warn.call_args_list)
 
-    def test_read_failure_after_stat_does_not_poison_file_key(self, registry_file):
+    def test_read_failure_after_open_does_not_poison_file_key(self, registry_file):
         registry.load_registry(str(registry_file))
         new_registry = {"vms": {"10.200.0.99": {"runId": "new-run"}}, "updatedAt": 0}
         registry_file.write_text(json.dumps(new_registry))
+        read_results = iter(
+            [
+                OSError("read failed"),
+                json.dumps(new_registry).encode(),
+                b"",
+            ]
+        )
+
+        def read_with_one_failure(_fd, _count):
+            result = next(read_results)
+            if isinstance(result, OSError):
+                raise result
+            return result
 
         log = MagicMock()
         with (
             patch.object(registry.ctx, "log", log, create=True),
-            patch.object(
-                registry.json,
-                "load",
-                side_effect=[OSError("read failed"), new_registry],
-            ) as spy,
+            patch.object(registry.os, "read", side_effect=read_with_one_failure) as spy,
         ):
             failed = registry.load_registry(str(registry_file))
             recovered = registry.load_registry(str(registry_file))
 
         assert failed == {}
         assert recovered == {"10.200.0.99": {"runId": "new-run"}}
-        assert spy.call_count == 2
+        assert spy.call_count == 3
         assert log.warn.call_count == 1
         assert "Failed to read" in log.warn.call_args_list[0].args[0]
 
@@ -394,19 +486,35 @@ class TestLoadRegistry:
         first_key = SimpleNamespace(st_dev=1, st_ino=1, st_mtime_ns=100, st_size=10)
         second_key = SimpleNamespace(st_dev=1, st_ino=1, st_mtime_ns=200, st_size=20)
         valid_registry = {"vms": {"10.0.0.1": {"runId": "r1"}}}
+        read_results = iter(
+            [
+                b"{ broken",
+                b"",
+                OSError("read failed"),
+                json.dumps(valid_registry).encode(),
+                b"",
+            ]
+        )
+
+        stats = iter([first_key, second_key, first_key])
+
+        def open_with_fake_stat(_path):
+            return os.open(path, os.O_RDONLY), next(stats)
+
+        def read_parse_fail_then_read_fail_then_recover(_fd, _count):
+            result = next(read_results)
+            if isinstance(result, OSError):
+                raise result
+            return result
 
         log = MagicMock()
         with (
             patch.object(registry.ctx, "log", log, create=True),
-            patch.object(registry.Path, "stat", side_effect=[first_key, second_key, first_key]),
+            patch.object(registry, "_open_registry_for_read", side_effect=open_with_fake_stat),
             patch.object(
-                registry.json,
-                "load",
-                side_effect=[
-                    json.JSONDecodeError("broken", "", 0),
-                    OSError("read failed"),
-                    valid_registry,
-                ],
+                registry.os,
+                "read",
+                side_effect=read_parse_fail_then_read_fail_then_recover,
             ) as spy,
         ):
             assert registry.load_registry(str(path)) == {}
@@ -414,7 +522,7 @@ class TestLoadRegistry:
             recovered = registry.load_registry(str(path))
 
         assert recovered == {"10.0.0.1": {"runId": "r1"}}
-        assert spy.call_count == 3
+        assert spy.call_count == 5
         assert log.warn.call_count == 2
         assert "Failed to parse" in log.warn.call_args_list[0].args[0]
         assert "Failed to read" in log.warn.call_args_list[1].args[0]

--- a/crates/runner/src/main.rs
+++ b/crates/runner/src/main.rs
@@ -33,6 +33,7 @@ mod retry;
 mod run_resolution;
 mod runner_dirname;
 mod runtime_overrides;
+mod state_file;
 mod status;
 mod storage_cache;
 mod telemetry;

--- a/crates/runner/src/proxy.rs
+++ b/crates/runner/src/proxy.rs
@@ -271,7 +271,16 @@ impl MitmProxy {
         // Write addon scripts to directory.
         // Remove-and-recreate to purge stale files from previous binary versions
         // (e.g. a renamed module would leave an orphan .py that Python could import).
-        let _ = tokio::fs::remove_dir_all(&config.addon_dir).await;
+        match tokio::fs::remove_dir_all(&config.addon_dir).await {
+            Ok(()) => {}
+            Err(e) if e.kind() == std::io::ErrorKind::NotFound => {}
+            Err(e) => {
+                return Err(RunnerError::Internal(format!(
+                    "remove stale addon dir {}: {e}",
+                    config.addon_dir.display()
+                )));
+            }
+        }
         tokio::fs::create_dir_all(&config.addon_dir)
             .await
             .map_err(|e| RunnerError::Internal(format!("create addon dir: {e}")))?;
@@ -782,8 +791,8 @@ pub async fn wait_usage_flush_requesting(
     let deadline = started_at + timeout;
     let mut next_flush_request_at = started_at + USAGE_FLUSH_REQUEST_INTERVAL;
     loop {
-        let (not_ready, snapshot) = match tokio::fs::read_to_string(&path).await {
-            Ok(content) => match parse_usage_pending_state(&content) {
+        let (not_ready, snapshot) = match read_addon_state_file(&path).await {
+            Ok(Some(content)) => match parse_usage_pending_state(&content) {
                 Ok(state) => {
                     let snapshot = Some(UsagePendingSnapshot::from(&state));
                     match validate_usage_pending_state(&state, request, now_millis()) {
@@ -804,6 +813,7 @@ pub async fn wait_usage_flush_requesting(
                 }
                 Err(reason) => (reason, None),
             },
+            Ok(None) => (format!("cannot read {}: not found", path.display()), None),
             Err(e) => (format!("cannot read {}: {e}", path.display()), None),
         };
         let now = tokio::time::Instant::now();
@@ -863,8 +873,8 @@ async fn wait_jsonl_flush_requesting(
     let deadline = started_at + timeout;
     let mut next_flush_request_at = started_at + JSONL_FLUSH_REQUEST_INTERVAL;
     loop {
-        let (not_ready, snapshot) = match tokio::fs::read_to_string(&path).await {
-            Ok(content) => match parse_jsonl_flush_state(&content) {
+        let (not_ready, snapshot) = match read_addon_state_file(&path).await {
+            Ok(Some(content)) => match parse_jsonl_flush_state(&content) {
                 Ok(state) => {
                     let snapshot = Some(JsonlFlushSnapshot::from(&state));
                     match validate_jsonl_flush_state(&state, request, now_millis()) {
@@ -879,6 +889,7 @@ async fn wait_jsonl_flush_requesting(
                 }
                 Err(reason) => (reason, None),
             },
+            Ok(None) => (format!("cannot read {}: not found", path.display()), None),
             Err(e) => (format!("cannot read {}: {e}", path.display()), None),
         };
         let now = tokio::time::Instant::now();
@@ -1202,11 +1213,24 @@ fn find_available_port() -> RunnerResult<u16> {
     Ok(port)
 }
 
+async fn read_addon_state_file(path: &Path) -> RunnerResult<Option<String>> {
+    crate::state_file::read_to_string(
+        path,
+        crate::state_file::USAGE_PENDING_MAX_BYTES,
+        crate::state_file::OwnerCheck::None,
+    )
+    .await
+}
+
 /// Read the proxy registry JSON file.
 async fn read_registry(path: &std::path::Path) -> RunnerResult<ProxyRegistry> {
-    let content = tokio::fs::read_to_string(path)
-        .await
-        .map_err(|e| RunnerError::Internal(format!("read registry: {e}")))?;
+    let content = crate::state_file::read_to_string(
+        path,
+        crate::state_file::PROXY_REGISTRY_MAX_BYTES,
+        crate::state_file::OwnerCheck::CurrentEuid,
+    )
+    .await?
+    .ok_or_else(|| RunnerError::Internal(format!("read registry {}: not found", path.display())))?;
     serde_json::from_str(&content)
         .map_err(|e| RunnerError::Internal(format!("parse registry: {e}")))
 }
@@ -1217,13 +1241,20 @@ async fn read_registry(path: &std::path::Path) -> RunnerResult<ProxyRegistry> {
 async fn write_registry(path: &std::path::Path, value: &ProxyRegistry) -> RunnerResult<()> {
     let content = serde_json::to_string(value)
         .map_err(|e| RunnerError::Internal(format!("serialize registry: {e}")))?;
+    remove_legacy_registry_tmp(path).await?;
+    crate::state_file::write_private_atomic(path, content.as_bytes()).await
+}
+
+async fn remove_legacy_registry_tmp(path: &Path) -> RunnerResult<()> {
     let tmp = path.with_extension("json.tmp");
-    tokio::fs::write(&tmp, content)
-        .await
-        .map_err(|e| RunnerError::Internal(format!("write registry tmp: {e}")))?;
-    tokio::fs::rename(&tmp, path)
-        .await
-        .map_err(|e| RunnerError::Internal(format!("rename registry: {e}")))
+    match tokio::fs::remove_file(&tmp).await {
+        Ok(()) => Ok(()),
+        Err(e) if e.kind() == std::io::ErrorKind::NotFound => Ok(()),
+        Err(e) => Err(RunnerError::Internal(format!(
+            "remove stale registry tmp {}: {e}",
+            tmp.display()
+        ))),
+    }
 }
 
 /// Lightweight, cloneable handle for proxy registry operations.
@@ -1373,6 +1404,18 @@ PY
         let mut perms = std::fs::metadata(path).unwrap().permissions();
         perms.set_mode(0o755);
         std::fs::set_permissions(path, perms).unwrap();
+    }
+
+    fn make_fifo(path: &Path) {
+        let c_path = std::ffi::CString::new(path.to_string_lossy().as_bytes()).unwrap();
+        // SAFETY: `c_path` is a valid nul-terminated path for `mkfifo`.
+        let result = unsafe { libc::mkfifo(c_path.as_ptr(), 0o600) };
+        assert_eq!(
+            result,
+            0,
+            "mkfifo failed: {}",
+            std::io::Error::last_os_error()
+        );
     }
 
     #[cfg(target_os = "linux")]
@@ -1530,6 +1573,56 @@ PY
     }
 
     #[tokio::test]
+    async fn mitm_proxy_new_fails_when_stale_addon_dir_cleanup_fails() {
+        let dir = tempfile::tempdir().unwrap();
+        let addon_dir = dir.path().join("addon");
+        tokio::fs::write(&addon_dir, b"not a directory")
+            .await
+            .unwrap();
+        let config = ProxyConfig {
+            mitmdump_bin: dir.path().join("mitmdump"),
+            ca_dir: dir.path().join("ca"),
+            addon_dir: addon_dir.clone(),
+            registry_path: dir.path().join("proxy-registry.json"),
+            registry_lock_path: dir.path().join("proxy-registry.json.lock"),
+            api_url: None,
+        };
+
+        let result = MitmProxy::new(config).await;
+
+        let error = result.err().expect("expected addon cleanup failure");
+        assert!(
+            error.to_string().contains("remove stale addon dir"),
+            "unexpected error: {error}"
+        );
+        assert_eq!(
+            tokio::fs::read(&addon_dir).await.unwrap(),
+            b"not a directory"
+        );
+    }
+
+    #[tokio::test]
+    async fn mitm_proxy_new_succeeds_when_addon_dir_is_missing() {
+        let dir = tempfile::tempdir().unwrap();
+        let addon_dir = dir.path().join("addon");
+        let registry_path = dir.path().join("proxy-registry.json");
+        let config = ProxyConfig {
+            mitmdump_bin: dir.path().join("mitmdump"),
+            ca_dir: dir.path().join("ca"),
+            addon_dir: addon_dir.clone(),
+            registry_path: registry_path.clone(),
+            registry_lock_path: dir.path().join("proxy-registry.json.lock"),
+            api_url: None,
+        };
+
+        let (_proxy, _crash_rx) = MitmProxy::new(config).await.unwrap();
+
+        assert!(addon_dir.join("mitm_addon.py").is_file());
+        let registry = read_registry(&registry_path).await.unwrap();
+        assert!(registry.vms.is_empty());
+    }
+
+    #[tokio::test]
     async fn registry_register_and_unregister() {
         let dir = tempfile::tempdir().unwrap();
         let registry_path = dir.path().join("proxy-registry.json");
@@ -1578,6 +1671,168 @@ PY
         assert!(
             !loaded.vms.contains_key("10.200.0.2"),
             "VM should be removed from registry"
+        );
+    }
+
+    #[tokio::test]
+    async fn write_registry_writes_private_file() {
+        let dir = tempfile::tempdir().unwrap();
+        let registry_path = dir.path().join("proxy-registry.json");
+        let empty = ProxyRegistry {
+            vms: HashMap::new(),
+            updated_at: 0,
+        };
+
+        write_registry(&registry_path, &empty).await.unwrap();
+
+        assert_eq!(
+            std::fs::metadata(&registry_path)
+                .unwrap()
+                .permissions()
+                .mode()
+                & 0o777,
+            0o600
+        );
+    }
+
+    #[tokio::test]
+    async fn write_registry_repairs_existing_wide_file_mode() {
+        let dir = tempfile::tempdir().unwrap();
+        let registry_path = dir.path().join("proxy-registry.json");
+        std::fs::write(&registry_path, r#"{"vms":{},"updatedAt":0}"#).unwrap();
+        let mut permissions = std::fs::metadata(&registry_path).unwrap().permissions();
+        permissions.set_mode(0o644);
+        std::fs::set_permissions(&registry_path, permissions).unwrap();
+        let empty = ProxyRegistry {
+            vms: HashMap::new(),
+            updated_at: 0,
+        };
+
+        write_registry(&registry_path, &empty).await.unwrap();
+
+        assert_eq!(
+            std::fs::metadata(&registry_path)
+                .unwrap()
+                .permissions()
+                .mode()
+                & 0o777,
+            0o600
+        );
+    }
+
+    #[tokio::test]
+    async fn write_registry_removes_stale_fixed_tmp_file() {
+        let dir = tempfile::tempdir().unwrap();
+        let registry_path = dir.path().join("proxy-registry.json");
+        let legacy_tmp = registry_path.with_extension("json.tmp");
+        std::fs::write(&legacy_tmp, b"stale").unwrap();
+        let empty = ProxyRegistry {
+            vms: HashMap::new(),
+            updated_at: 0,
+        };
+
+        write_registry(&registry_path, &empty).await.unwrap();
+
+        assert!(
+            !legacy_tmp.exists(),
+            "stale fixed registry tmp was not removed"
+        );
+        read_registry(&registry_path).await.unwrap();
+    }
+
+    #[tokio::test]
+    async fn write_registry_removes_stale_fixed_tmp_symlink_without_following_it() {
+        let dir = tempfile::tempdir().unwrap();
+        let registry_path = dir.path().join("proxy-registry.json");
+        let legacy_tmp = registry_path.with_extension("json.tmp");
+        let outside = dir.path().join("outside-target");
+        std::fs::write(&outside, b"outside").unwrap();
+        std::os::unix::fs::symlink(&outside, &legacy_tmp).unwrap();
+        let empty = ProxyRegistry {
+            vms: HashMap::new(),
+            updated_at: 0,
+        };
+
+        write_registry(&registry_path, &empty).await.unwrap();
+
+        assert_eq!(std::fs::read(&outside).unwrap(), b"outside");
+        assert!(
+            std::fs::symlink_metadata(&legacy_tmp).is_err(),
+            "stale fixed registry tmp symlink was not removed"
+        );
+    }
+
+    #[tokio::test]
+    async fn read_registry_rejects_symlink_without_following_it() {
+        let dir = tempfile::tempdir().unwrap();
+        let registry_path = dir.path().join("proxy-registry.json");
+        let outside = dir.path().join("outside-registry.json");
+        std::fs::write(&outside, r#"{"vms":{},"updatedAt":0}"#).unwrap();
+        std::os::unix::fs::symlink(&outside, &registry_path).unwrap();
+
+        let error = read_registry(&registry_path)
+            .await
+            .err()
+            .expect("expected symlink registry rejection");
+
+        assert!(
+            error.to_string().contains("open state file"),
+            "unexpected error: {error}"
+        );
+    }
+
+    #[tokio::test]
+    async fn read_registry_rejects_fifo_without_blocking() {
+        let dir = tempfile::tempdir().unwrap();
+        let registry_path = dir.path().join("proxy-registry.json");
+        make_fifo(&registry_path);
+
+        let error = read_registry(&registry_path)
+            .await
+            .err()
+            .expect("expected fifo registry rejection");
+
+        assert!(
+            error.to_string().contains("not a regular state file"),
+            "unexpected error: {error}"
+        );
+    }
+
+    #[tokio::test]
+    async fn read_registry_rejects_directory() {
+        let dir = tempfile::tempdir().unwrap();
+        let registry_path = dir.path().join("proxy-registry.json");
+        std::fs::create_dir(&registry_path).unwrap();
+
+        let error = read_registry(&registry_path)
+            .await
+            .err()
+            .expect("expected directory registry rejection");
+
+        assert!(
+            error.to_string().contains("not a regular state file"),
+            "unexpected error: {error}"
+        );
+    }
+
+    #[tokio::test]
+    async fn read_registry_rejects_oversized_file() {
+        let dir = tempfile::tempdir().unwrap();
+        let registry_path = dir.path().join("proxy-registry.json");
+        std::fs::write(
+            &registry_path,
+            vec![b' '; crate::state_file::PROXY_REGISTRY_MAX_BYTES as usize + 1],
+        )
+        .unwrap();
+
+        let error = read_registry(&registry_path)
+            .await
+            .err()
+            .expect("expected oversized registry rejection");
+
+        assert!(
+            error.to_string().contains("exceeds"),
+            "unexpected error: {error}"
         );
     }
 
@@ -2514,6 +2769,28 @@ while True:
     }
 
     #[tokio::test(start_paused = true)]
+    async fn wait_jsonl_flush_rejects_state_symlink_without_following_it() {
+        let dir = tempfile::tempdir().unwrap();
+        let log_path = dir.path().join("network.jsonl");
+        let request = jsonl_request(&log_path);
+        let outside = dir.path().join("outside-jsonl-flush-state");
+        std::fs::write(&outside, jsonl_state(&log_path, 0)).unwrap();
+        std::os::unix::fs::symlink(&outside, dir.path().join("jsonl-flush-state")).unwrap();
+
+        assert!(!wait_jsonl_flush(dir.path(), Duration::from_millis(50), &request).await);
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn wait_jsonl_flush_rejects_fifo_state_without_blocking() {
+        let dir = tempfile::tempdir().unwrap();
+        let log_path = dir.path().join("network.jsonl");
+        let request = jsonl_request(&log_path);
+        make_fifo(&dir.path().join("jsonl-flush-state"));
+
+        assert!(!wait_jsonl_flush(dir.path(), Duration::from_millis(50), &request).await);
+    }
+
+    #[tokio::test(start_paused = true)]
     async fn wait_jsonl_flush_requests_flush_when_pending() {
         let dir = tempfile::tempdir().unwrap();
         let log_path = dir.path().join("network.jsonl");
@@ -2742,6 +3019,39 @@ while True:
             usage_state_with_request(0, 0, 0, Some("old-request")),
         )
         .unwrap();
+        assert!(!wait_usage_flush(dir.path(), Duration::from_millis(50), &request).await);
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn wait_usage_flush_rejects_state_symlink_without_following_it() {
+        let dir = tempfile::tempdir().unwrap();
+        let request = usage_request();
+        let outside = dir.path().join("outside-usage-pending");
+        std::fs::write(&outside, usage_state(0, 0, 0)).unwrap();
+        std::os::unix::fs::symlink(&outside, dir.path().join("usage-pending")).unwrap();
+
+        assert!(!wait_usage_flush(dir.path(), Duration::from_millis(50), &request).await);
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn wait_usage_flush_rejects_fifo_state_without_blocking() {
+        let dir = tempfile::tempdir().unwrap();
+        let request = usage_request();
+        make_fifo(&dir.path().join("usage-pending"));
+
+        assert!(!wait_usage_flush(dir.path(), Duration::from_millis(50), &request).await);
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn wait_usage_flush_rejects_oversized_state() {
+        let dir = tempfile::tempdir().unwrap();
+        let request = usage_request();
+        std::fs::write(
+            dir.path().join("usage-pending"),
+            vec![b' '; crate::state_file::USAGE_PENDING_MAX_BYTES as usize + 1],
+        )
+        .unwrap();
+
         assert!(!wait_usage_flush(dir.path(), Duration::from_millis(50), &request).await);
     }
 

--- a/crates/runner/src/state_file.rs
+++ b/crates/runner/src/state_file.rs
@@ -1,0 +1,334 @@
+use std::path::Path;
+
+use crate::error::{RunnerError, RunnerResult};
+
+pub(crate) const PROXY_REGISTRY_MAX_BYTES: u64 = 16 * 1024 * 1024;
+pub(crate) const USAGE_PENDING_MAX_BYTES: u64 = 64 * 1024;
+pub(crate) const WORKSPACE_METADATA_MAX_BYTES: u64 = 1024 * 1024;
+
+const PRIVATE_FILE_MODE: u32 = 0o600;
+
+#[derive(Debug, Clone, Copy)]
+pub(crate) enum OwnerCheck {
+    None,
+    CurrentEuid,
+}
+
+pub(crate) async fn read_to_string(
+    path: &Path,
+    max_bytes: u64,
+    owner_check: OwnerCheck,
+) -> RunnerResult<Option<String>> {
+    let Some(bytes) = read_to_bytes(path, max_bytes, owner_check).await? else {
+        return Ok(None);
+    };
+    String::from_utf8(bytes).map(Some).map_err(|e| {
+        RunnerError::Internal(format!("read state file {} as UTF-8: {e}", path.display()))
+    })
+}
+
+pub(crate) async fn read_to_bytes_required(
+    path: &Path,
+    max_bytes: u64,
+    owner_check: OwnerCheck,
+) -> RunnerResult<Vec<u8>> {
+    match read_to_bytes(path, max_bytes, owner_check).await? {
+        Some(bytes) => Ok(bytes),
+        None => Err(std::io::Error::new(
+            std::io::ErrorKind::NotFound,
+            format!("state file {} not found", path.display()),
+        )
+        .into()),
+    }
+}
+
+async fn read_to_bytes(
+    path: &Path,
+    max_bytes: u64,
+    owner_check: OwnerCheck,
+) -> RunnerResult<Option<Vec<u8>>> {
+    #[cfg(unix)]
+    {
+        read_to_bytes_unix(path, max_bytes, owner_check).await
+    }
+
+    #[cfg(not(unix))]
+    {
+        let _ = owner_check;
+        read_to_bytes_fallback(path, max_bytes).await
+    }
+}
+
+#[cfg(unix)]
+async fn read_to_bytes_unix(
+    path: &Path,
+    max_bytes: u64,
+    owner_check: OwnerCheck,
+) -> RunnerResult<Option<Vec<u8>>> {
+    let mut options = tokio::fs::OpenOptions::new();
+    options
+        .read(true)
+        .custom_flags(libc::O_NOFOLLOW | libc::O_CLOEXEC | libc::O_NONBLOCK);
+    let file = match options.open(path).await {
+        Ok(file) => file,
+        Err(e) if e.kind() == std::io::ErrorKind::NotFound => return Ok(None),
+        Err(e) => {
+            return Err(RunnerError::Internal(format!(
+                "open state file {}: {e}",
+                path.display()
+            )));
+        }
+    };
+    validate_open_state_file(&file, path, owner_check)?;
+    read_open_file_bytes(file, path, max_bytes).await.map(Some)
+}
+
+#[cfg(not(unix))]
+async fn read_to_bytes_fallback(path: &Path, max_bytes: u64) -> RunnerResult<Option<Vec<u8>>> {
+    let file = match tokio::fs::File::open(path).await {
+        Ok(file) => file,
+        Err(e) if e.kind() == std::io::ErrorKind::NotFound => return Ok(None),
+        Err(e) => {
+            return Err(RunnerError::Internal(format!(
+                "open state file {}: {e}",
+                path.display()
+            )));
+        }
+    };
+    read_open_file_bytes(file, path, max_bytes).await.map(Some)
+}
+
+async fn read_open_file_bytes(
+    file: tokio::fs::File,
+    path: &Path,
+    max_bytes: u64,
+) -> RunnerResult<Vec<u8>> {
+    use tokio::io::AsyncReadExt;
+
+    let read_limit = max_bytes.checked_add(1).ok_or_else(|| {
+        RunnerError::Internal(format!(
+            "state file {} read limit is too large",
+            path.display()
+        ))
+    })?;
+    let mut limited = file.take(read_limit);
+    let mut contents = Vec::new();
+    limited
+        .read_to_end(&mut contents)
+        .await
+        .map_err(|e| RunnerError::Internal(format!("read state file {}: {e}", path.display())))?;
+    if contents.len() as u64 > max_bytes {
+        return Err(RunnerError::Internal(format!(
+            "state file {} exceeds {} bytes",
+            path.display(),
+            max_bytes
+        )));
+    }
+    Ok(contents)
+}
+
+#[cfg(unix)]
+fn validate_open_state_file<Fd: std::os::fd::AsRawFd>(
+    file: &Fd,
+    path: &Path,
+    owner_check: OwnerCheck,
+) -> RunnerResult<()> {
+    let mut stat = std::mem::MaybeUninit::<libc::stat>::uninit();
+    // SAFETY: `stat` points to valid writable memory and `file` owns a live fd.
+    let result = unsafe { libc::fstat(file.as_raw_fd(), stat.as_mut_ptr()) };
+    if result != 0 {
+        return Err(RunnerError::Internal(format!(
+            "stat state file {}: {}",
+            path.display(),
+            std::io::Error::last_os_error()
+        )));
+    }
+    // SAFETY: successful `fstat` initialized the full `stat` struct.
+    let stat = unsafe { stat.assume_init() };
+    let file_type = stat.st_mode & libc::S_IFMT;
+    if file_type != libc::S_IFREG {
+        return Err(RunnerError::Internal(format!(
+            "{} is not a regular state file",
+            path.display()
+        )));
+    }
+    if matches!(owner_check, OwnerCheck::CurrentEuid) {
+        let expected_uid = nix::unistd::geteuid().as_raw();
+        if stat.st_uid != expected_uid {
+            return Err(RunnerError::Internal(format!(
+                "{} is owned by uid {}, but runner euid is {expected_uid}",
+                path.display(),
+                stat.st_uid
+            )));
+        }
+    }
+    Ok(())
+}
+
+pub(crate) async fn write_private_atomic(path: &Path, content: &[u8]) -> RunnerResult<()> {
+    #[cfg(unix)]
+    {
+        write_private_atomic_unix(path, content).await
+    }
+
+    #[cfg(not(unix))]
+    {
+        tokio::fs::write(path, content)
+            .await
+            .map_err(|e| RunnerError::Internal(format!("write state file {}: {e}", path.display())))
+    }
+}
+
+#[cfg(unix)]
+async fn write_private_atomic_unix(path: &Path, content: &[u8]) -> RunnerResult<()> {
+    use std::ffi::OsString;
+    use tokio::io::AsyncWriteExt;
+
+    let file_name = path.file_name().ok_or_else(|| {
+        RunnerError::Internal(format!(
+            "{} does not have a file name; refusing to write state file",
+            path.display()
+        ))
+    })?;
+    let mut tmp_name = OsString::from(".");
+    tmp_name.push(file_name);
+    tmp_name.push(format!(".{}.tmp", uuid::Uuid::new_v4()));
+    let tmp = path.with_file_name(tmp_name);
+
+    let result = async {
+        let mut options = tokio::fs::OpenOptions::new();
+        options.write(true).create_new(true).mode(PRIVATE_FILE_MODE);
+        let mut file = options.open(&tmp).await.map_err(|e| {
+            RunnerError::Internal(format!("open state file tmp {}: {e}", tmp.display()))
+        })?;
+        chmod_private_file_fd(&file, &tmp)?;
+        file.write_all(content).await.map_err(|e| {
+            RunnerError::Internal(format!("write state file tmp {}: {e}", tmp.display()))
+        })?;
+        file.flush().await.map_err(|e| {
+            RunnerError::Internal(format!("flush state file tmp {}: {e}", tmp.display()))
+        })?;
+        drop(file);
+        tokio::fs::rename(&tmp, path).await.map_err(|e| {
+            RunnerError::Internal(format!("rename state file {}: {e}", path.display()))
+        })?;
+        Ok(())
+    }
+    .await;
+
+    if result.is_err() {
+        let _ = tokio::fs::remove_file(&tmp).await;
+    }
+    result
+}
+
+#[cfg(unix)]
+fn chmod_private_file_fd<Fd: std::os::fd::AsRawFd>(file: &Fd, path: &Path) -> RunnerResult<()> {
+    // SAFETY: `fchmod` operates on the live fd.
+    let result = unsafe { libc::fchmod(file.as_raw_fd(), PRIVATE_FILE_MODE as libc::mode_t) };
+    if result == 0 {
+        Ok(())
+    } else {
+        Err(RunnerError::Internal(format!(
+            "chmod state file {}: {}",
+            path.display(),
+            std::io::Error::last_os_error()
+        )))
+    }
+}
+
+#[cfg(test)]
+#[cfg(unix)]
+mod tests {
+    use super::*;
+    use std::ffi::CString;
+    use std::os::unix::fs::{PermissionsExt, symlink};
+
+    #[tokio::test]
+    async fn read_to_string_rejects_symlink_without_reading_target() {
+        let dir = tempfile::tempdir().unwrap();
+        let target = dir.path().join("target");
+        std::fs::write(&target, "target").unwrap();
+        let link = dir.path().join("link");
+        symlink(&target, &link).unwrap();
+
+        let error = read_to_string(&link, 1024, OwnerCheck::None)
+            .await
+            .unwrap_err();
+
+        assert!(
+            error.to_string().contains("open state file"),
+            "unexpected error: {error}"
+        );
+    }
+
+    #[tokio::test]
+    async fn read_to_string_rejects_fifo_without_blocking() {
+        let dir = tempfile::tempdir().unwrap();
+        let fifo = dir.path().join("fifo");
+        let c_path = CString::new(fifo.to_string_lossy().as_bytes()).unwrap();
+        // SAFETY: `c_path` is a valid nul-terminated path for `mkfifo`.
+        let result = unsafe { libc::mkfifo(c_path.as_ptr(), 0o600) };
+        assert_eq!(
+            result,
+            0,
+            "mkfifo failed: {}",
+            std::io::Error::last_os_error()
+        );
+
+        let error = read_to_string(&fifo, 1024, OwnerCheck::None)
+            .await
+            .unwrap_err();
+
+        assert!(
+            error.to_string().contains("not a regular state file"),
+            "unexpected error: {error}"
+        );
+    }
+
+    #[tokio::test]
+    async fn read_to_string_rejects_directory() {
+        let dir = tempfile::tempdir().unwrap();
+        let state_dir = dir.path().join("state.json");
+        std::fs::create_dir(&state_dir).unwrap();
+
+        let error = read_to_string(&state_dir, 1024, OwnerCheck::None)
+            .await
+            .unwrap_err();
+
+        assert!(
+            error.to_string().contains("not a regular state file"),
+            "unexpected error: {error}"
+        );
+    }
+
+    #[tokio::test]
+    async fn read_to_string_rejects_oversized_file() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("state.json");
+        std::fs::write(&path, b"abcdef").unwrap();
+
+        let error = read_to_string(&path, 5, OwnerCheck::None)
+            .await
+            .unwrap_err();
+
+        assert!(
+            error.to_string().contains("exceeds 5 bytes"),
+            "unexpected error: {error}"
+        );
+    }
+
+    #[tokio::test]
+    async fn write_private_atomic_writes_private_file() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("state.json");
+
+        write_private_atomic(&path, b"{}").await.unwrap();
+
+        assert_eq!(std::fs::read(&path).unwrap(), b"{}");
+        assert_eq!(
+            std::fs::metadata(&path).unwrap().permissions().mode() & 0o777,
+            0o600
+        );
+    }
+}

--- a/crates/runner/src/workspace_image_cache.rs
+++ b/crates/runner/src/workspace_image_cache.rs
@@ -1679,14 +1679,12 @@ impl SessionWorkspaceCache {
         &self,
         metadata_path: &Path,
     ) -> RunnerResult<WorkspaceCacheMetadata> {
-        let metadata = fs::symlink_metadata(metadata_path).await?;
-        if !metadata.is_file() {
-            return Err(RunnerError::Internal(format!(
-                "workspace image cache metadata is not a file: {}",
-                metadata_path.display()
-            )));
-        }
-        let bytes = fs::read(metadata_path).await?;
+        let bytes = crate::state_file::read_to_bytes_required(
+            metadata_path,
+            crate::state_file::WORKSPACE_METADATA_MAX_BYTES,
+            crate::state_file::OwnerCheck::None,
+        )
+        .await?;
         serde_json::from_slice(&bytes)
             .map_err(|e| RunnerError::Internal(format!("parse {}: {e}", metadata_path.display())))
     }
@@ -2879,6 +2877,18 @@ mod tests {
         format!("2026-05-01T00:{:02}:{:02}.000Z", index / 60, index % 60)
     }
 
+    fn make_fifo(path: &Path) {
+        let c_path = std::ffi::CString::new(path.to_string_lossy().as_bytes()).unwrap();
+        // SAFETY: `c_path` is a valid nul-terminated path for `mkfifo`.
+        let result = unsafe { libc::mkfifo(c_path.as_ptr(), 0o600) };
+        assert_eq!(
+            result,
+            0,
+            "mkfifo failed: {}",
+            std::io::Error::last_os_error()
+        );
+    }
+
     async fn write_current_cache_entry(
         cache: &SessionWorkspaceCache,
         paths: &RunnerPaths,
@@ -3666,6 +3676,55 @@ mod tests {
         let outside = dir.path().join("outside-metadata.json");
         fs::write(&outside, b"{\"unexpected\":true}").await.unwrap();
         std::os::unix::fs::symlink(&outside, paths.session_workspace_cache_metadata(&key)).unwrap();
+
+        let inspection = cache.inspect().await.unwrap();
+
+        assert_eq!(inspection.summary.invalid_entries, 1);
+        let entry = &inspection.entries[0];
+        assert_eq!(entry.status, WorkspaceImageCacheInspectionStatus::Invalid);
+        assert_eq!(entry.reason.as_deref(), Some("missing or invalid metadata"));
+    }
+
+    #[tokio::test]
+    async fn inspect_rejects_fifo_metadata_without_blocking() {
+        let dir = tempfile::tempdir().unwrap();
+        let paths = RunnerPaths::new(dir.path().join("runner"));
+        let cache = SessionWorkspaceCache::new(paths.clone());
+        let key = session_workspace_cache_key("sess-1", "/workspace");
+        fs::create_dir_all(paths.session_workspace_cache_entry_dir(&key))
+            .await
+            .unwrap();
+        fs::write(paths.session_workspace_cache_current_image(&key), b"image")
+            .await
+            .unwrap();
+        make_fifo(&paths.session_workspace_cache_metadata(&key));
+
+        let inspection = cache.inspect().await.unwrap();
+
+        assert_eq!(inspection.summary.invalid_entries, 1);
+        let entry = &inspection.entries[0];
+        assert_eq!(entry.status, WorkspaceImageCacheInspectionStatus::Invalid);
+        assert_eq!(entry.reason.as_deref(), Some("missing or invalid metadata"));
+    }
+
+    #[tokio::test]
+    async fn inspect_rejects_oversized_metadata() {
+        let dir = tempfile::tempdir().unwrap();
+        let paths = RunnerPaths::new(dir.path().join("runner"));
+        let cache = SessionWorkspaceCache::new(paths.clone());
+        let key = session_workspace_cache_key("sess-1", "/workspace");
+        fs::create_dir_all(paths.session_workspace_cache_entry_dir(&key))
+            .await
+            .unwrap();
+        fs::write(paths.session_workspace_cache_current_image(&key), b"image")
+            .await
+            .unwrap();
+        fs::write(
+            paths.session_workspace_cache_metadata(&key),
+            vec![b' '; crate::state_file::WORKSPACE_METADATA_MAX_BYTES as usize + 1],
+        )
+        .await
+        .unwrap();
 
         let inspection = cache.inspect().await.unwrap();
 


### PR DESCRIPTION
## Summary

- add runner state-file helpers for no-follow, nonblocking, bounded regular-file reads and private atomic writes
- harden Rust proxy registry reads/writes, stale fixed tmp cleanup, usage/jsonl addon state polling, and addon directory cleanup failure handling
- harden workspace image cache metadata reads and Python mitm addon registry loading with opened-fd identity and bounded parsing

Closes #16561

## Tests

- cd crates/runner/mitm-addon && python3 -m ruff format src/registry.py tests/test_registry.py && python3 -m ruff check src/registry.py tests/test_registry.py
- cd crates/runner/mitm-addon && python3 -m pytest tests/test_registry.py
- cd crates/runner && cargo fmt && cargo test --no-run
- cd crates/runner && cargo test proxy::tests
- cd crates/runner && cargo test workspace_image_cache::tests
- cd crates/runner && cargo test state_file::tests
- git diff --check

## Notes

- The JSONL flush state file uses the same addon-written polling-state pattern as usage-pending, so it is routed through the same bounded safe-read helper.