### PR TITLE
refactor(zero): extract AutomationInterpreter seam with TimeInterpreter

### DIFF
--- a/turbo/apps/api/src/signals/services/automations/time-interpreter.ts
+++ b/turbo/apps/api/src/signals/services/automations/time-interpreter.ts
@@ -1,0 +1,189 @@
+import { randomBytes } from "node:crypto";
+
+import type {
+  ScheduleCronCallbackPayload,
+  ScheduleLoopCallbackPayload,
+} from "@vm0/api-contracts/contracts/internal-callbacks-schedule";
+import type { zeroAgentSchedules } from "@vm0/db/schema/zero-agent-schedule";
+
+import { internalApiBaseUrl } from "../../../lib/internal-api-url";
+
+/**
+ * Identifies how an Automation should be interpreted into an agent run. The
+ * interpreter is keyed off the Automation (this kind), not off the trigger.
+ * Only the time-based interpreter exists today.
+ */
+export type InterpreterKind = "time";
+
+/**
+ * Domain view of an Automation as the interpreter sees it. This is a thin
+ * projection of a `zero_agent_schedules` row down to the fields needed to build
+ * an agent-run input: the prompt, the append-prompt context, the agent /
+ * chat-thread linkage, and the owning org / user.
+ */
+export interface Automation {
+  readonly interpreterKind: InterpreterKind;
+  readonly id: string;
+  readonly agentId: string;
+  readonly orgId: string;
+  readonly userId: string;
+  readonly chatThreadId: string;
+  readonly prompt: string;
+  readonly appendSystemPrompt: string | null;
+  readonly triggerType: "cron" | "once" | "loop";
+  readonly cronExpression: string | null;
+  readonly timezone: string;
+}
+
+interface RunCallback {
+  readonly url: string;
+  readonly secret: string;
+  readonly payload: unknown;
+}
+
+/**
+ * The automation-derived portion of a Zero agent-run request: the parts an
+ * interpreter constructs from the Automation definition (and trigger event).
+ * Runtime concerns resolved from live state (model pin, provider admission) are
+ * layered on by the caller, not by the interpreter.
+ */
+export interface ZeroRunInput {
+  readonly prompt: string;
+  readonly agentId: string;
+  readonly chatThreadId: string;
+  readonly appendSystemPrompt: string;
+  readonly callbacks: readonly RunCallback[];
+  readonly zeroRunMetadata: { readonly scheduleId: string };
+}
+
+/**
+ * Builds the agent-run input for an Automation. Async and trigger-event aware
+ * so it can later accommodate event triggers; the time interpreter ignores the
+ * event payload beyond its identity.
+ */
+export interface AutomationInterpreter<TriggerEvent> {
+  interpret(
+    automation: Automation,
+    triggerEvent: TriggerEvent,
+  ): Promise<ZeroRunInput>;
+}
+
+/**
+ * Trigger event for a time-based Automation: the run request payload. The time
+ * interpreter is driven entirely by the Automation definition, so the event
+ * only carries the schedule identity for now.
+ */
+export interface TimeTriggerEvent {
+  readonly scheduleId: string;
+}
+
+/**
+ * Maps a `zero_agent_schedules` row to the Automation view the interpreter
+ * consumes. All time-based schedules use the `time` interpreter.
+ */
+export function scheduleToAutomation(
+  schedule: typeof zeroAgentSchedules.$inferSelect,
+): Automation {
+  return {
+    interpreterKind: "time",
+    id: schedule.id,
+    agentId: schedule.agentId,
+    orgId: schedule.orgId,
+    userId: schedule.userId,
+    chatThreadId: schedule.chatThreadId,
+    prompt: schedule.prompt,
+    appendSystemPrompt: schedule.appendSystemPrompt,
+    triggerType: schedule.triggerType as "cron" | "once" | "loop",
+    cronExpression: schedule.cronExpression,
+    timezone: schedule.timezone,
+  };
+}
+
+function buildSchedulePrompt(triggerType: string): string {
+  return [
+    "# Current Integration",
+    "You are currently running inside: Schedule",
+    `Trigger type: ${triggerType}`,
+  ].join("\n");
+}
+
+function buildAppendSystemPrompt(automation: Automation): string {
+  const integrationContext = [
+    buildSchedulePrompt(automation.triggerType),
+    "",
+    "This scheduled run is linked to a web chat thread. Everything you output is automatically shown to the user as a chat message in that thread.",
+  ].join("\n");
+  const baseAppendPrompt = automation.appendSystemPrompt ?? undefined;
+  return baseAppendPrompt
+    ? `${integrationContext}\n\n${baseAppendPrompt}`
+    : integrationContext;
+}
+
+function generateCallbackSecret(): string {
+  return randomBytes(32).toString("hex");
+}
+
+function buildCallbacks(automation: Automation): RunCallback[] {
+  const callbacks: RunCallback[] = [];
+
+  if (automation.triggerType === "loop") {
+    const payload: ScheduleLoopCallbackPayload = { scheduleId: automation.id };
+    callbacks.push({
+      url: `${internalApiBaseUrl()}/api/internal/callbacks/schedule/loop`,
+      secret: generateCallbackSecret(),
+      payload,
+    });
+  } else if (
+    automation.triggerType === "cron" ||
+    automation.triggerType === "once"
+  ) {
+    const payload: ScheduleCronCallbackPayload = {
+      scheduleId: automation.id,
+      ...(automation.cronExpression && {
+        cronExpression: automation.cronExpression,
+      }),
+      timezone: automation.timezone,
+    };
+    callbacks.push({
+      url: `${internalApiBaseUrl()}/api/internal/callbacks/schedule/cron`,
+      secret: generateCallbackSecret(),
+      payload,
+    });
+  }
+
+  // Also drive the chat callback so the run renders as a web-chat turn
+  // (summary/title/lifecycle + autoSend). The reschedule callback above is
+  // retained for next_run_at / consecutive-failure bookkeeping; only the chat
+  // callback writes the run summary (D9), so callback dispatch order is safe.
+  callbacks.push({
+    url: `${internalApiBaseUrl()}/api/internal/callbacks/chat`,
+    secret: generateCallbackSecret(),
+    payload: {
+      threadId: automation.chatThreadId,
+      agentId: automation.agentId,
+    },
+  });
+
+  return callbacks;
+}
+
+/**
+ * Time-based Automation interpreter: renders the schedule as a web-chat turn in
+ * its linked thread. Behavior-preserving extraction of the run-input
+ * construction that used to be inline in `runScheduleNow$`.
+ */
+export class TimeInterpreter implements AutomationInterpreter<TimeTriggerEvent> {
+  interpret(
+    automation: Automation,
+    _triggerEvent: TimeTriggerEvent,
+  ): Promise<ZeroRunInput> {
+    return Promise.resolve({
+      prompt: automation.prompt,
+      agentId: automation.agentId,
+      chatThreadId: automation.chatThreadId,
+      appendSystemPrompt: buildAppendSystemPrompt(automation),
+      callbacks: buildCallbacks(automation),
+      zeroRunMetadata: { scheduleId: automation.id },
+    });
+  }
+}

--- a/turbo/apps/api/src/signals/services/zero-schedules.service.ts
+++ b/turbo/apps/api/src/signals/services/zero-schedules.service.ts
@@ -1,5 +1,3 @@
-import { randomBytes } from "node:crypto";
-
 import { command, computed, type Computed } from "ccstate";
 import {
   zeroScheduleRunContract,
@@ -8,10 +6,6 @@ import {
   ScheduleListResponse,
   ScheduleResponse,
 } from "@vm0/api-contracts/contracts/zero-schedules";
-import type {
-  ScheduleCronCallbackPayload,
-  ScheduleLoopCallbackPayload,
-} from "@vm0/api-contracts/contracts/internal-callbacks-schedule";
 import { agentComposes } from "@vm0/db/schema/agent-compose";
 import { agentRuns } from "@vm0/db/schema/agent-run";
 import { chatThreads } from "@vm0/db/schema/chat-thread";
@@ -23,12 +17,21 @@ import { and, eq, inArray, lte } from "drizzle-orm";
 import { z } from "zod";
 
 import { optionalEnv } from "../../lib/env";
-import { internalApiBaseUrl } from "../../lib/internal-api-url";
 import { logger } from "../../lib/log";
 import { db$, writeDb$, type Db } from "../external/db";
 import { now, nowDate } from "../external/time";
 import { isValidTimeZone, settle } from "../utils";
-import { resolveModelFirstProviderAdmission } from "./zero-model-selection.service";
+import {
+  scheduleToAutomation,
+  TimeInterpreter,
+  type Automation,
+  type AutomationInterpreter,
+  type TimeTriggerEvent,
+} from "./automations/time-interpreter";
+import {
+  resolveModelFirstProviderAdmission,
+  type ModelFirstPin,
+} from "./zero-model-selection.service";
 import { visibleJoinedZeroAgentCondition } from "./zero-agent-data.service";
 import { createZeroRun$ } from "./zero-runs-create.service";
 import {
@@ -1083,73 +1086,60 @@ export const executeDueSchedules$ = command(
   },
 );
 
-function buildSchedulePrompt(triggerType: string): string {
-  return [
-    "# Current Integration",
-    "You are currently running inside: Schedule",
-    `Trigger type: ${triggerType}`,
-  ].join("\n");
-}
+type ScheduleRunModelContext =
+  | {
+      readonly ok: true;
+      readonly modelPin: ModelFirstPin;
+      readonly effectiveModelProvider: string | null | undefined;
+    }
+  | { readonly ok: false; readonly failure: ExecuteScheduleFailure };
 
-function generateCallbackSecret(): string {
-  return randomBytes(32).toString("hex");
-}
-
-function buildScheduleCallbacks(
-  schedule: typeof zeroAgentSchedules.$inferSelect,
-): { url: string; secret: string; payload: unknown }[] {
-  const callbacks: { url: string; secret: string; payload: unknown }[] = [];
-
-  if (schedule.triggerType === "loop") {
-    const payload: ScheduleLoopCallbackPayload = { scheduleId: schedule.id };
-    callbacks.push({
-      url: `${internalApiBaseUrl()}/api/internal/callbacks/schedule/loop`,
-      secret: generateCallbackSecret(),
-      payload,
-    });
-  } else if (
-    schedule.triggerType === "cron" ||
-    schedule.triggerType === "once"
-  ) {
-    const payload: ScheduleCronCallbackPayload = {
-      scheduleId: schedule.id,
-      ...(schedule.cronExpression && {
-        cronExpression: schedule.cronExpression,
-      }),
-      timezone: schedule.timezone,
+// Resolve the model context for a scheduled run: the thread model pin (org
+// default if unpinned) and the admitted provider. No user is present to receive
+// a model-config / credits error, so failures surface as run_error (normalized
+// to 400) feeding consecutiveFailures / the manual run-now response.
+async function resolveScheduleRunModelContext(args: {
+  readonly db: Db;
+  readonly schedule: typeof zeroAgentSchedules.$inferSelect;
+  readonly signal: AbortSignal;
+}): Promise<ScheduleRunModelContext> {
+  const threadModelPin = await resolveScheduleChatThreadModelPin({
+    db: args.db,
+    orgId: args.schedule.orgId,
+    userId: args.schedule.userId,
+    threadId: args.schedule.chatThreadId,
+  });
+  args.signal.throwIfAborted();
+  if ("status" in threadModelPin) {
+    return {
+      ok: false,
+      failure: {
+        kind: "run_error",
+        response: { status: 400, body: threadModelPin.body },
+      },
     };
-    callbacks.push({
-      url: `${internalApiBaseUrl()}/api/internal/callbacks/schedule/cron`,
-      secret: generateCallbackSecret(),
-      payload,
-    });
   }
 
-  // Also drive the chat callback so the run renders as a web-chat turn
-  // (summary/title/lifecycle + autoSend). The reschedule callback above is
-  // retained for next_run_at / consecutive-failure bookkeeping; only the chat
-  // callback writes the run summary (D9), so callback dispatch order is safe.
-  callbacks.push({
-    url: `${internalApiBaseUrl()}/api/internal/callbacks/chat`,
-    secret: generateCallbackSecret(),
-    payload: { threadId: schedule.chatThreadId, agentId: schedule.agentId },
+  const providerAdmission = await resolveModelFirstProviderAdmission({
+    db: args.db,
+    orgId: args.schedule.orgId,
+    userId: args.schedule.userId,
+    modelPin: threadModelPin,
+    requestedModelProvider: undefined,
   });
+  args.signal.throwIfAborted();
+  if (providerAdmission.error) {
+    return {
+      ok: false,
+      failure: { kind: "run_error", response: providerAdmission.error },
+    };
+  }
 
-  return callbacks;
-}
-
-function buildScheduleAppendSystemPrompt(
-  schedule: typeof zeroAgentSchedules.$inferSelect,
-): string {
-  const integrationContext = [
-    buildSchedulePrompt(schedule.triggerType),
-    "",
-    "This scheduled run is linked to a web chat thread. Everything you output is automatically shown to the user as a chat message in that thread.",
-  ].join("\n");
-  const baseAppendPrompt = schedule.appendSystemPrompt ?? undefined;
-  return baseAppendPrompt
-    ? `${integrationContext}\n\n${baseAppendPrompt}`
-    : integrationContext;
+  return {
+    ok: true,
+    modelPin: threadModelPin,
+    effectiveModelProvider: providerAdmission.effectiveModelProvider,
+  };
 }
 
 // Render the scheduled run as a web-chat turn in the linked thread. Model comes
@@ -1202,34 +1192,25 @@ export const runScheduleNow$ = command(
       }
     }
 
-    const threadModelPin = await resolveScheduleChatThreadModelPin({
+    const modelContext = await resolveScheduleRunModelContext({
       db,
-      orgId: schedule.orgId,
-      userId: schedule.userId,
-      threadId: schedule.chatThreadId,
+      schedule,
+      signal,
     });
-    signal.throwIfAborted();
-    if ("status" in threadModelPin) {
-      // No user is present to receive a model-config error; surface it as a
-      // run_error (normalized to 400) so it feeds consecutiveFailures / the
-      // manual run-now response.
-      return {
-        kind: "run_error",
-        response: { status: 400, body: threadModelPin.body },
-      };
+    if (!modelContext.ok) {
+      return modelContext.failure;
     }
+    const { modelPin, effectiveModelProvider } = modelContext;
 
-    const providerAdmission = await resolveModelFirstProviderAdmission({
-      db,
-      orgId: schedule.orgId,
-      userId: schedule.userId,
-      modelPin: threadModelPin,
-      requestedModelProvider: undefined,
+    // Depend on the interpreter seam (interface), keyed off the Automation's
+    // interpreterKind. Only the time-based interpreter exists today.
+    const automation: Automation = scheduleToAutomation(schedule);
+    const interpreter: AutomationInterpreter<TimeTriggerEvent> =
+      new TimeInterpreter();
+    const runInput = await interpreter.interpret(automation, {
+      scheduleId: schedule.id,
     });
     signal.throwIfAborted();
-    if (providerAdmission.error) {
-      return { kind: "run_error", response: providerAdmission.error };
-    }
 
     const result = await set(
       createZeroRun$,
@@ -1241,22 +1222,22 @@ export const runScheduleNow$ = command(
           tokenType: "session",
         },
         body: {
-          prompt: schedule.prompt,
-          agentId: schedule.agentId,
-          ...(providerAdmission.effectiveModelProvider
-            ? { modelProvider: providerAdmission.effectiveModelProvider }
+          prompt: runInput.prompt,
+          agentId: runInput.agentId,
+          ...(effectiveModelProvider
+            ? { modelProvider: effectiveModelProvider }
             : {}),
         },
         apiStartTime: args.apiStartTime,
         triggerSource: "schedule",
-        chatThreadId: schedule.chatThreadId,
-        modelProviderId: threadModelPin.modelProviderId ?? undefined,
+        chatThreadId: runInput.chatThreadId,
+        modelProviderId: modelPin.modelProviderId ?? undefined,
         modelProviderCredentialScope:
-          threadModelPin.modelProviderCredentialScope ?? undefined,
-        selectedModelOverride: threadModelPin.selectedModel ?? undefined,
-        appendSystemPrompt: buildScheduleAppendSystemPrompt(schedule),
-        callbacks: buildScheduleCallbacks(schedule),
-        zeroRunMetadata: { scheduleId: schedule.id },
+          modelPin.modelProviderCredentialScope ?? undefined,
+        selectedModelOverride: modelPin.selectedModel ?? undefined,
+        appendSystemPrompt: runInput.appendSystemPrompt,
+        callbacks: runInput.callbacks,
+        zeroRunMetadata: runInput.zeroRunMetadata,
       },
       signal,
     );
@@ -1281,11 +1262,10 @@ export const runScheduleNow$ = command(
     await db
       .update(zeroRuns)
       .set({
-        modelProvider: providerAdmission.effectiveModelProvider,
-        modelProviderId: threadModelPin.modelProviderId,
-        modelProviderCredentialScope:
-          threadModelPin.modelProviderCredentialScope,
-        selectedModel: threadModelPin.selectedModel,
+        modelProvider: effectiveModelProvider,
+        modelProviderId: modelPin.modelProviderId,
+        modelProviderCredentialScope: modelPin.modelProviderCredentialScope,
+        selectedModel: modelPin.selectedModel,
       })
       .where(eq(zeroRuns.id, result.body.runId));
     signal.throwIfAborted();


### PR DESCRIPTION
Closes #16641. Part of #16616. Stacked on #16645.

Behavior-preserving extraction of the AutomationInterpreter seam + single TimeInterpreter inside the schedule service. Interpreter keyed off the Automation (interpreterKind), async + trigger-event aware; runScheduleNow flows through it. No registry, no new table, no contract/route/CLI/UI/URL change, no secrets/vars/volumeVersions. New: apps/api/src/signals/services/automations/time-interpreter.ts. Tests: 86 schedule integration tests pass unchanged.