### PR TITLE
refactor(zero): extract TimeTrigger and route poller + callbacks through it

### DIFF
--- a/turbo/apps/api/src/signals/routes/internal-callbacks-schedule.ts
+++ b/turbo/apps/api/src/signals/routes/internal-callbacks-schedule.ts
@@ -16,11 +16,10 @@ import {
 import type { RouteEntry } from "../route";
 import { writeDb$ } from "../external/db";
 import { nowDate } from "../external/time";
-import { calculateNextRun } from "../services/zero-schedules.service";
+import { TimeTrigger } from "../services/automations/time-trigger";
 
 const MAX_CONSECUTIVE_FAILURES = 3;
 
-type ScheduleRow = typeof zeroAgentSchedules.$inferSelect;
 type SchedulePayload =
   | { readonly kind: "cron"; readonly data: ScheduleCronCallbackPayload }
   | { readonly kind: "loop"; readonly data: ScheduleLoopCallbackPayload };
@@ -55,27 +54,6 @@ function parseLoopPayload(payload: unknown): SchedulePayload | null {
   return { kind: "loop", data: result.data };
 }
 
-function nextRunAtForSchedule(
-  payload: SchedulePayload,
-  schedule: ScheduleRow,
-  completedAt: Date,
-): Date | null {
-  if (payload.kind === "cron") {
-    return payload.data.cronExpression
-      ? calculateNextRun(
-          payload.data.cronExpression,
-          schedule.timezone,
-          completedAt,
-        )
-      : null;
-  }
-
-  if (schedule.intervalSeconds === null) {
-    throw new Error("Loop schedule is missing intervalSeconds");
-  }
-  return new Date(completedAt.getTime() + schedule.intervalSeconds * 1000);
-}
-
 function createScheduleCallbackHandler(
   parsePayload: (payload: unknown) => SchedulePayload | null,
 ) {
@@ -106,9 +84,15 @@ function createScheduleCallbackHandler(
     const consecutiveFailures =
       callback.status === "completed" ? 0 : schedule.consecutiveFailures + 1;
     const shouldDisable = consecutiveFailures >= MAX_CONSECUTIVE_FAILURES;
-    const nextRunAt = shouldDisable
-      ? null
-      : nextRunAtForSchedule(payload, schedule, completedAt);
+    const nextRunAt = new TimeTrigger().advanceAfterCompletion({
+      triggerType: payload.kind,
+      cronExpression:
+        payload.kind === "cron" ? payload.data.cronExpression : undefined,
+      intervalSeconds: schedule.intervalSeconds,
+      timezone: schedule.timezone,
+      completedAt,
+      shouldDisable,
+    });
 
     await writeDb
       .update(zeroAgentSchedules)

--- a/turbo/apps/api/src/signals/services/automations/time-trigger.ts
+++ b/turbo/apps/api/src/signals/services/automations/time-trigger.ts
@@ -1,0 +1,163 @@
+import { zeroAgentSchedules } from "@vm0/db/schema/zero-agent-schedule";
+import { Cron } from "croner";
+import { and, eq } from "drizzle-orm";
+
+import type { Db } from "../../external/db";
+
+type ScheduleRow = typeof zeroAgentSchedules.$inferSelect;
+
+/**
+ * Computes the next fire time for a cron expression in the given timezone,
+ * starting the search from `fromDate`. Returns null when the expression has no
+ * further occurrences.
+ */
+export function calculateNextRun(
+  cronExpression: string,
+  timezone: string,
+  fromDate: Date,
+): Date | null {
+  return new Cron(cronExpression, { timezone }).nextRun(fromDate);
+}
+
+/**
+ * Deploy-time recurrence inputs needed to resolve a trigger's type and first
+ * run. A thin structural view of the deploy request so the trigger does not
+ * depend on the contract type.
+ */
+interface TriggerSpec {
+  readonly cronExpression?: string;
+  readonly atTime?: string;
+  readonly timezone: string;
+  readonly enabled?: boolean;
+}
+
+/**
+ * Resolved trigger shape for persistence at deploy time: the discriminating
+ * trigger type and the first `nextRunAt` (null when nothing is scheduled, e.g. a
+ * disabled loop).
+ */
+interface ResolvedTrigger {
+  readonly triggerType: "cron" | "once" | "loop";
+  readonly nextRunAt: Date | null;
+}
+
+/**
+ * Time-based trigger: owns the scheduling math (next-run calculation and the
+ * optimistic-lock claim) for `zero_agent_schedules` rows. The interpreter is
+ * keyed off the Automation; this trigger is keyed off time and is the only
+ * trigger implementation today (YAGNI — no registry).
+ */
+export class TimeTrigger {
+  /**
+   * Resolve the trigger type and first run from a deploy request. Cron resolves
+   * to the next cron occurrence; a one-time `atTime` resolves to that instant; a
+   * loop is due immediately when enabled, otherwise unscheduled.
+   */
+  resolve(spec: TriggerSpec, currentTime: Date): ResolvedTrigger {
+    if (spec.cronExpression) {
+      return {
+        triggerType: "cron",
+        nextRunAt: calculateNextRun(
+          spec.cronExpression,
+          spec.timezone,
+          currentTime,
+        ),
+      };
+    }
+    if (spec.atTime) {
+      return { triggerType: "once", nextRunAt: new Date(spec.atTime) };
+    }
+    return {
+      triggerType: "loop",
+      nextRunAt: spec.enabled ? currentTime : null,
+    };
+  }
+
+  /**
+   * Claim a due schedule row via an optimistic lock on `nextRunAt`: clear the
+   * next run, stamp `lastRunAt`, reset any retry marker, and disable one-time
+   * schedules. Returns the claimed row, or null when another invocation won the
+   * race (the row's `nextRunAt` already moved).
+   */
+  async evaluate(args: {
+    readonly db: Db;
+    readonly schedule: ScheduleRow;
+    readonly currentTime: Date;
+  }): Promise<ScheduleRow | null> {
+    const [claimed] = await args.db
+      .update(zeroAgentSchedules)
+      .set({
+        nextRunAt: null,
+        lastRunAt: args.currentTime,
+        retryStartedAt: null,
+        updatedAt: args.currentTime,
+        ...(args.schedule.triggerType === "once" ? { enabled: false } : {}),
+      })
+      .where(
+        and(
+          eq(zeroAgentSchedules.id, args.schedule.id),
+          eq(zeroAgentSchedules.nextRunAt, args.schedule.nextRunAt!),
+        ),
+      )
+      .returning();
+    return claimed ?? null;
+  }
+
+  /**
+   * Next run after a pre-run failure in the poller (the run was never created).
+   * Cron advances to the next occurrence; a loop advances by its interval when
+   * one is set; one-time and interval-less loops do not reschedule. Disabling
+   * collapses the next run to null.
+   */
+  advanceAfterPreRunFailure(args: {
+    readonly schedule: ScheduleRow;
+    readonly failureTime: Date;
+    readonly shouldDisable: boolean;
+  }): Date | null {
+    if (args.shouldDisable) {
+      return null;
+    }
+    if (args.schedule.triggerType === "cron" && args.schedule.cronExpression) {
+      return calculateNextRun(
+        args.schedule.cronExpression,
+        args.schedule.timezone,
+        args.failureTime,
+      );
+    }
+    if (args.schedule.triggerType === "loop" && args.schedule.intervalSeconds) {
+      return new Date(
+        args.failureTime.getTime() + args.schedule.intervalSeconds * 1000,
+      );
+    }
+    return null;
+  }
+
+  /**
+   * Next run after a completion callback (the run finished, success or failure).
+   * Cron advances from the cron expression captured at dispatch (null when the
+   * one-time callback carried no expression); a loop advances by the schedule's
+   * interval and requires one to be present. Disabling collapses the next run to
+   * null.
+   */
+  advanceAfterCompletion(args: {
+    readonly triggerType: "cron" | "loop";
+    readonly cronExpression: string | undefined;
+    readonly intervalSeconds: number | null;
+    readonly timezone: string;
+    readonly completedAt: Date;
+    readonly shouldDisable: boolean;
+  }): Date | null {
+    if (args.shouldDisable) {
+      return null;
+    }
+    if (args.triggerType === "cron") {
+      return args.cronExpression
+        ? calculateNextRun(args.cronExpression, args.timezone, args.completedAt)
+        : null;
+    }
+    if (args.intervalSeconds === null) {
+      throw new Error("Loop schedule is missing intervalSeconds");
+    }
+    return new Date(args.completedAt.getTime() + args.intervalSeconds * 1000);
+  }
+}

--- a/turbo/apps/api/src/signals/services/zero-schedules.service.ts
+++ b/turbo/apps/api/src/signals/services/zero-schedules.service.ts
@@ -12,7 +12,6 @@ import { chatThreads } from "@vm0/db/schema/chat-thread";
 import { zeroAgents } from "@vm0/db/schema/zero-agent";
 import { zeroAgentSchedules } from "@vm0/db/schema/zero-agent-schedule";
 import { zeroRuns } from "@vm0/db/schema/zero-run";
-import { Cron } from "croner";
 import { and, eq, inArray, lte } from "drizzle-orm";
 import { z } from "zod";
 
@@ -28,6 +27,7 @@ import {
   type AutomationInterpreter,
   type TimeTriggerEvent,
 } from "./automations/time-interpreter";
+import { calculateNextRun, TimeTrigger } from "./automations/time-trigger";
 import {
   resolveModelFirstProviderAdmission,
   type ModelFirstPin,
@@ -75,13 +75,9 @@ function scheduleResponse(
   };
 }
 
-export function calculateNextRun(
-  cronExpression: string,
-  timezone: string,
-  fromDate: Date,
-): Date | null {
-  return new Cron(cronExpression, { timezone }).nextRun(fromDate);
-}
+// Re-exported from the time trigger so existing callers (the reschedule
+// callback route and the schedule tests) keep importing it from the service.
+export { calculateNextRun };
 
 type DeployScheduleBody = z.infer<
   (typeof zeroSchedulesMainContract.deploy)["body"]
@@ -249,32 +245,6 @@ async function generateScheduleDescription(
   }
 
   return result.value ?? buildTemplateDescription(request, agentName);
-}
-
-function resolveTrigger(
-  request: DeployScheduleBody,
-  currentTime: Date,
-): {
-  readonly triggerType: "cron" | "once" | "loop";
-  readonly nextRunAt: Date | null;
-} {
-  if (request.cronExpression) {
-    return {
-      triggerType: "cron",
-      nextRunAt: calculateNextRun(
-        request.cronExpression,
-        request.timezone,
-        currentTime,
-      ),
-    };
-  }
-  if (request.atTime) {
-    return { triggerType: "once", nextRunAt: new Date(request.atTime) };
-  }
-  return {
-    triggerType: "loop",
-    nextRunAt: request.enabled ? currentTime : null,
-  };
 }
 
 function validateAtTimeNotPast(
@@ -675,7 +645,7 @@ export const deploySchedule$ = command(
         : effectiveBody;
     signal.throwIfAborted();
 
-    const { triggerType, nextRunAt } = resolveTrigger(
+    const { triggerType, nextRunAt } = new TimeTrigger().resolve(
       bodyWithDescription,
       currentTime,
     );
@@ -904,29 +874,6 @@ function isInsufficientCreditsFailure(error: unknown): boolean {
   );
 }
 
-function nextRunAfterPreRunFailure(args: {
-  readonly schedule: typeof zeroAgentSchedules.$inferSelect;
-  readonly failureTime: Date;
-  readonly shouldDisable: boolean;
-}): Date | null {
-  if (args.shouldDisable) {
-    return null;
-  }
-  if (args.schedule.triggerType === "cron" && args.schedule.cronExpression) {
-    return calculateNextRun(
-      args.schedule.cronExpression,
-      args.schedule.timezone,
-      args.failureTime,
-    );
-  }
-  if (args.schedule.triggerType === "loop" && args.schedule.intervalSeconds) {
-    return new Date(
-      args.failureTime.getTime() + args.schedule.intervalSeconds * 1000,
-    );
-  }
-  return null;
-}
-
 async function recordSchedulePreRunFailure(
   db: Db,
   schedule: typeof zeroAgentSchedules.$inferSelect,
@@ -952,7 +899,7 @@ async function recordSchedulePreRunFailure(
   const failureTime = nowDate();
   const newFailureCount = schedule.consecutiveFailures + 1;
   const shouldDisable = newFailureCount >= MAX_CONSECUTIVE_FAILURES;
-  const nextRunAt = nextRunAfterPreRunFailure({
+  const nextRunAt = new TimeTrigger().advanceAfterPreRunFailure({
     schedule,
     failureTime,
     shouldDisable,
@@ -1003,6 +950,7 @@ export const executeDueSchedules$ = command(
 
     let executed = 0;
     let skipped = 0;
+    const timeTrigger = new TimeTrigger();
 
     for (const schedule of dueSchedules) {
       if (schedule.lastRunId) {
@@ -1023,22 +971,7 @@ export const executeDueSchedules$ = command(
         }
       }
 
-      const [claimed] = await db
-        .update(zeroAgentSchedules)
-        .set({
-          nextRunAt: null,
-          lastRunAt: currentTime,
-          retryStartedAt: null,
-          updatedAt: currentTime,
-          ...(schedule.triggerType === "once" ? { enabled: false } : {}),
-        })
-        .where(
-          and(
-            eq(zeroAgentSchedules.id, schedule.id),
-            eq(zeroAgentSchedules.nextRunAt, schedule.nextRunAt!),
-          ),
-        )
-        .returning();
+      const claimed = await timeTrigger.evaluate({ db, schedule, currentTime });
       signal.throwIfAborted();
 
       if (!claimed) {


### PR DESCRIPTION
Closes #16637. Part of #16616. Stacked on #16672.

Behavior-preserving extraction of TimeTrigger (resolve/evaluate/advance) and rewire of the poller (executeDueSchedules) and reschedule callbacks through trigger.evaluate -> interpreter -> createZeroRun -> trigger.advance. Internal URLs unchanged. New: apps/api/src/signals/services/automations/time-trigger.ts. Tests: 86 schedule integration tests pass unchanged.