### PR TITLE
feat(zero): add Automations API and feature switch over shared service

### DIFF
--- a/turbo/apps/api/src/signals/route.ts
+++ b/turbo/apps/api/src/signals/route.ts
@@ -3,6 +3,7 @@ import { healthContract } from "@vm0/api-contracts/contracts/health";
 
 import { agentCheckpointsRoutes } from "./routes/agent-checkpoints-id";
 import { agentComposesByIdRoutes } from "./routes/agent-composes-id";
+import { automationsRoutes } from "./routes/automations";
 import { agentComposesMetadataRoutes } from "./routes/agent-composes-metadata";
 import { agentComposesReadRoutes } from "./routes/agent-composes-read";
 import { agentComposesRoutes } from "./routes/agent-composes";
@@ -192,6 +193,7 @@ export const ROUTES: readonly RouteEntry[] = [
     handler: apiHealth$,
   },
   ...authMeRoutes,
+  ...automationsRoutes,
   ...cliAuthRoutes,
   ...cliAuthTestRoutes,
   ...desktopAuthRoutes,

--- a/turbo/apps/api/src/signals/routes/__tests__/automations.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/automations.test.ts
@@ -1,0 +1,539 @@
+import { apiErrorSchema } from "@vm0/api-contracts/contracts/errors";
+import {
+  automationListResponseSchema,
+  automationMutationResponseSchema,
+  automationResponseSchema,
+} from "@vm0/api-contracts/contracts/automations";
+import { scheduleListResponseSchema } from "@vm0/api-contracts/contracts/zero-schedules";
+import { agentRunCallbacks } from "@vm0/db/schema/agent-run-callback";
+import { agentRuns } from "@vm0/db/schema/agent-run";
+import { chatMessages } from "@vm0/db/schema/chat-message";
+import { userFeatureSwitches } from "@vm0/db/schema/user-feature-switches";
+import { zeroAgentSchedules } from "@vm0/db/schema/zero-agent-schedule";
+import { zeroRuns } from "@vm0/db/schema/zero-run";
+import { FeatureSwitchKey } from "@vm0/connectors/feature-switch-key";
+import { createStore } from "ccstate";
+import { eq } from "drizzle-orm";
+import { z } from "zod";
+
+import { testContext } from "../../../__tests__/test-helpers";
+import { createApp } from "../../../app-factory";
+import { mockOptionalEnv } from "../../../lib/env";
+import { now } from "../../../lib/time";
+import { writeDb$ } from "../../external/db";
+import {
+  type SchedulesFixture,
+  type SchedulesScenarioValues,
+  deleteSchedulesScenario$,
+  seedSchedulesScenario$,
+} from "./helpers/zero-schedules";
+import {
+  createFixtureTracker,
+  createZeroRouteMocks,
+} from "./helpers/zero-route-test";
+
+const context = testContext();
+const store = createStore();
+const mocks = createZeroRouteMocks(context);
+const runResponseSchema = z.object({ runId: z.string() });
+
+const track = createFixtureTracker<SchedulesFixture>((fixture) => {
+  return store.set(deleteSchedulesScenario$, fixture, context.signal);
+});
+
+interface TestApiResponse {
+  readonly status: number;
+  readonly body: unknown;
+}
+
+async function requestJson(
+  path: string,
+  init: RequestInit,
+): Promise<TestApiResponse> {
+  const app = createApp({ signal: context.signal });
+  const response = await app.request(path, init);
+  return {
+    status: response.status,
+    body: await response.json(),
+  };
+}
+
+async function requestStatus(path: string, init: RequestInit): Promise<number> {
+  const app = createApp({ signal: context.signal });
+  const response = await app.request(path, init);
+  return response.status;
+}
+
+const SESSION_HEADERS = { authorization: "Bearer clerk-session" } as const;
+
+function jsonInit(method: string, body: unknown): RequestInit {
+  return {
+    method,
+    headers: { ...SESSION_HEADERS, "content-type": "application/json" },
+    body: JSON.stringify(body),
+  };
+}
+
+async function seedFixture(
+  values: Partial<SchedulesScenarioValues> = {},
+): Promise<SchedulesFixture> {
+  mockOptionalEnv("OPENROUTER_API_KEY", undefined);
+  mockOptionalEnv("RUNNER_DEFAULT_GROUP", "vm0/test");
+  context.mocks.s3.send.mockResolvedValue({});
+  const fixture = await track(
+    store.set(
+      seedSchedulesScenario$,
+      {
+        timezone: "America/Los_Angeles",
+        schedules: [],
+        ...values,
+      },
+      context.signal,
+    ),
+  );
+  mocks.clerk.session(fixture.userId, fixture.orgId);
+  return fixture;
+}
+
+async function enableAutomations(fixture: SchedulesFixture): Promise<void> {
+  const db = store.set(writeDb$);
+  await db.insert(userFeatureSwitches).values({
+    orgId: fixture.orgId,
+    userId: fixture.userId,
+    switches: { [FeatureSwitchKey.ZeroAutomations]: true },
+  });
+}
+
+function expectErrorCode(response: TestApiResponse): string {
+  return apiErrorSchema.parse(response.body).error.code;
+}
+
+interface RunArtifacts {
+  readonly prompt: string | null;
+  readonly appendSystemPrompt: string | null;
+  readonly triggerSource: string | null;
+  readonly scheduleId: string | null;
+  readonly chatThreadId: string | null;
+  readonly chatMessage: {
+    readonly content: string | null;
+    readonly role: string;
+  } | null;
+  readonly callbackPaths: readonly string[];
+}
+
+function callbackPath(url: string): string {
+  return new URL(url).pathname;
+}
+
+// The run is identified by the agent-run row; collect everything that
+// determines how it renders into the linked chat thread, normalized so two
+// runs produced from equivalent definitions compare equal.
+async function collectRunArtifacts(runId: string): Promise<RunArtifacts> {
+  const db = store.set(writeDb$);
+  const [run] = await db
+    .select({
+      prompt: agentRuns.prompt,
+      appendSystemPrompt: agentRuns.appendSystemPrompt,
+    })
+    .from(agentRuns)
+    .where(eq(agentRuns.id, runId));
+  const [zeroRun] = await db
+    .select({
+      triggerSource: zeroRuns.triggerSource,
+      scheduleId: zeroRuns.scheduleId,
+      chatThreadId: zeroRuns.chatThreadId,
+    })
+    .from(zeroRuns)
+    .where(eq(zeroRuns.id, runId));
+  const messages = await db
+    .select({
+      content: chatMessages.content,
+      role: chatMessages.role,
+    })
+    .from(chatMessages)
+    .where(eq(chatMessages.runId, runId));
+  const userMessage = messages.find((message) => {
+    return message.role === "user";
+  });
+  const callbacks = await db
+    .select({ url: agentRunCallbacks.url })
+    .from(agentRunCallbacks)
+    .where(eq(agentRunCallbacks.runId, runId));
+
+  return {
+    prompt: run?.prompt ?? null,
+    appendSystemPrompt: run?.appendSystemPrompt ?? null,
+    triggerSource: zeroRun?.triggerSource ?? null,
+    // scheduleId / chatThreadId differ per schedule row, so blank them out:
+    // parity is about the SHAPE of the rendering, not the row identity.
+    scheduleId: zeroRun?.scheduleId ? "<scheduleId>" : null,
+    chatThreadId: zeroRun?.chatThreadId ? "<chatThreadId>" : null,
+    chatMessage: userMessage
+      ? { content: userMessage.content, role: userMessage.role }
+      : null,
+    callbackPaths: callbacks
+      .map((callback) => {
+        return callbackPath(callback.url);
+      })
+      .sort(),
+  };
+}
+
+interface TriggerCase {
+  readonly label: string;
+  readonly cronExpression?: string;
+  // A future offset (ms from now) for `once` triggers; resolved inside the test
+  // with the mockable now() so the at-time is not in the past.
+  readonly atTimeOffsetMs?: number;
+  readonly intervalSeconds?: number;
+}
+
+const TRIGGER_CASES: readonly TriggerCase[] = [
+  { label: "cron", cronExpression: "0 9 * * *" },
+  { label: "once", atTimeOffsetMs: 60 * 60 * 1000 },
+  { label: "loop", intervalSeconds: 3600 },
+];
+
+describe("Automations API parity with the legacy schedule surface", () => {
+  it("create + list produce equivalent automation/schedule rows", async () => {
+    const fixture = await seedFixture();
+    await enableAutomations(fixture);
+
+    const oldResponse = await requestJson(
+      "/api/zero/schedules",
+      jsonInit("POST", {
+        name: "legacy-create",
+        agentId: fixture.composeId,
+        cronExpression: "0 9 * * *",
+        prompt: "Daily summary",
+        appendSystemPrompt: "Use the shared context.",
+        timezone: "UTC",
+        enabled: true,
+      }),
+    );
+    expect(oldResponse.status).toBe(201);
+
+    const newResponse = await requestJson(
+      "/api/automations",
+      jsonInit("POST", {
+        name: "automation-create",
+        agentId: fixture.composeId,
+        cronExpression: "0 9 * * *",
+        prompt: "Daily summary",
+        appendSystemPrompt: "Use the shared context.",
+        timezone: "UTC",
+        enabled: true,
+      }),
+    );
+    expect(newResponse.status).toBe(201);
+
+    const mutation = automationMutationResponseSchema.parse(newResponse.body);
+    expect(mutation.created).toBeTruthy();
+
+    // The new surface reports the SAME cleaned field set as the legacy deploy
+    // — comparing the persisted rows (minus identity columns) proves parity.
+    const db = store.set(writeDb$);
+    const rows = await db
+      .select({
+        name: zeroAgentSchedules.name,
+        triggerType: zeroAgentSchedules.triggerType,
+        cronExpression: zeroAgentSchedules.cronExpression,
+        intervalSeconds: zeroAgentSchedules.intervalSeconds,
+        timezone: zeroAgentSchedules.timezone,
+        prompt: zeroAgentSchedules.prompt,
+        appendSystemPrompt: zeroAgentSchedules.appendSystemPrompt,
+        enabled: zeroAgentSchedules.enabled,
+      })
+      .from(zeroAgentSchedules)
+      .where(eq(zeroAgentSchedules.agentId, fixture.composeId));
+    const legacyRow = rows.find((row) => {
+      return row.name === "legacy-create";
+    });
+    const automationRow = rows.find((row) => {
+      return row.name === "automation-create";
+    });
+    expect(legacyRow).toBeDefined();
+    expect(automationRow).toBeDefined();
+    const normalize = (row: NonNullable<typeof legacyRow>) => {
+      return { ...row, name: "<name>" };
+    };
+    expect(normalize(automationRow!)).toStrictEqual(normalize(legacyRow!));
+
+    // Both surfaces project the same rows; list output matches field-for-field.
+    const automationsList = automationListResponseSchema.parse(
+      (
+        await requestJson("/api/automations", {
+          method: "GET",
+          headers: SESSION_HEADERS,
+        })
+      ).body,
+    );
+    const schedulesList = scheduleListResponseSchema.parse(
+      (
+        await requestJson("/api/zero/schedules", {
+          method: "GET",
+          headers: SESSION_HEADERS,
+        })
+      ).body,
+    );
+    expect(automationsList.automations).toStrictEqual(schedulesList.schedules);
+  });
+
+  it.each(TRIGGER_CASES)(
+    "run-now renders identically for $label triggers",
+    async (triggerCase) => {
+      const atTime =
+        triggerCase.atTimeOffsetMs === undefined
+          ? undefined
+          : new Date(now() + triggerCase.atTimeOffsetMs);
+      const fixture = await seedFixture({
+        schedules: [
+          {
+            name: `${triggerCase.label}-old`,
+            prompt: "Run me",
+            appendSystemPrompt: "Shared run context.",
+            cronExpression: triggerCase.cronExpression,
+            atTime,
+            intervalSeconds: triggerCase.intervalSeconds,
+            enabled: true,
+          },
+          {
+            name: `${triggerCase.label}-new`,
+            prompt: "Run me",
+            appendSystemPrompt: "Shared run context.",
+            cronExpression: triggerCase.cronExpression,
+            atTime,
+            intervalSeconds: triggerCase.intervalSeconds,
+            enabled: true,
+          },
+        ],
+      });
+      await enableAutomations(fixture);
+
+      const oldScheduleId = fixture.scheduleIds[0];
+      const newScheduleId = fixture.scheduleIds[1];
+      if (!oldScheduleId || !newScheduleId) {
+        throw new Error("Expected two seeded schedules");
+      }
+
+      const oldRun = await requestJson(
+        "/api/zero/schedules/run",
+        jsonInit("POST", { scheduleId: oldScheduleId }),
+      );
+      expect(oldRun.status).toBe(201);
+      const oldRunId = runResponseSchema.parse(oldRun.body).runId;
+
+      const newRun = await requestJson(
+        "/api/automations/run",
+        jsonInit("POST", { automationId: newScheduleId }),
+      );
+      expect(newRun.status).toBe(201);
+      const newRunId = runResponseSchema.parse(newRun.body).runId;
+
+      const oldArtifacts = await collectRunArtifacts(oldRunId);
+      const newArtifacts = await collectRunArtifacts(newRunId);
+
+      // Same agent run + same chat-thread rendering for this trigger type.
+      expect(newArtifacts).toStrictEqual(oldArtifacts);
+      expect(newArtifacts.triggerSource).toBe("schedule");
+      expect(newArtifacts.callbackPaths).toContain(
+        "/api/internal/callbacks/chat",
+      );
+      const expectedReschedulePath =
+        triggerCase.label === "loop"
+          ? "/api/internal/callbacks/schedule/loop"
+          : "/api/internal/callbacks/schedule/cron";
+      expect(newArtifacts.callbackPaths).toContain(expectedReschedulePath);
+    },
+  );
+});
+
+describe("Automations API feature-switch gating", () => {
+  it("returns 404 on every automation endpoint when the switch is off", async () => {
+    const fixture = await seedFixture({
+      schedules: [
+        {
+          name: "gated",
+          prompt: "Run me",
+          cronExpression: "0 9 * * *",
+          enabled: true,
+        },
+      ],
+    });
+    const scheduleId = fixture.scheduleIds[0];
+    if (!scheduleId) {
+      throw new Error("Expected seeded schedule");
+    }
+
+    const create = await requestJson(
+      "/api/automations",
+      jsonInit("POST", {
+        name: "blocked",
+        agentId: fixture.composeId,
+        cronExpression: "0 9 * * *",
+        prompt: "Should not be created",
+      }),
+    );
+    expect(create.status).toBe(404);
+    expect(expectErrorCode(create)).toBe("NOT_FOUND");
+
+    const list = await requestJson("/api/automations", {
+      method: "GET",
+      headers: SESSION_HEADERS,
+    });
+    expect(list.status).toBe(404);
+
+    const update = await requestJson(
+      "/api/automations/gated",
+      jsonInit("PUT", {
+        agentId: fixture.composeId,
+        cronExpression: "0 10 * * *",
+        prompt: "Should not update",
+      }),
+    );
+    expect(update.status).toBe(404);
+
+    const enable = await requestJson(
+      "/api/automations/gated/enable",
+      jsonInit("POST", { agentId: fixture.composeId }),
+    );
+    expect(enable.status).toBe(404);
+
+    const disable = await requestJson(
+      "/api/automations/gated/disable",
+      jsonInit("POST", { agentId: fixture.composeId }),
+    );
+    expect(disable.status).toBe(404);
+
+    const run = await requestJson(
+      "/api/automations/run",
+      jsonInit("POST", { automationId: scheduleId }),
+    );
+    expect(run.status).toBe(404);
+
+    const del = await requestJson(
+      `/api/automations/gated?agentId=${fixture.composeId}`,
+      { method: "DELETE", headers: SESSION_HEADERS },
+    );
+    expect(del.status).toBe(404);
+
+    // The legacy surface is unaffected while the switch is off.
+    const legacyList = await requestJson("/api/zero/schedules", {
+      method: "GET",
+      headers: SESSION_HEADERS,
+    });
+    expect(legacyList.status).toBe(200);
+    const parsed = scheduleListResponseSchema.parse(legacyList.body);
+    expect(
+      parsed.schedules.some((schedule) => {
+        return schedule.name === "gated";
+      }),
+    ).toBeTruthy();
+  });
+});
+
+describe("Automations API behaviors", () => {
+  it("updates an existing automation by name via PUT", async () => {
+    const fixture = await seedFixture({
+      schedules: [
+        {
+          name: "editable",
+          prompt: "Original",
+          cronExpression: "0 9 * * *",
+          enabled: true,
+        },
+      ],
+    });
+    await enableAutomations(fixture);
+
+    const response = await requestJson(
+      "/api/automations/editable",
+      jsonInit("PUT", {
+        agentId: fixture.composeId,
+        cronExpression: "0 18 * * *",
+        prompt: "Updated prompt",
+        description: "Updated description",
+      }),
+    );
+    expect(response.status).toBe(200);
+    const mutation = automationMutationResponseSchema.parse(response.body);
+    expect(mutation.created).toBeFalsy();
+    expect(mutation.automation.prompt).toBe("Updated prompt");
+    expect(mutation.automation.cronExpression).toBe("0 18 * * *");
+
+    const db = store.set(writeDb$);
+    const [row] = await db
+      .select({
+        prompt: zeroAgentSchedules.prompt,
+        cronExpression: zeroAgentSchedules.cronExpression,
+      })
+      .from(zeroAgentSchedules)
+      .where(eq(zeroAgentSchedules.id, mutation.automation.id));
+    expect(row?.prompt).toBe("Updated prompt");
+    expect(row?.cronExpression).toBe("0 18 * * *");
+  });
+
+  it("enables and disables an automation by name", async () => {
+    const fixture = await seedFixture({
+      schedules: [
+        {
+          name: "toggle",
+          prompt: "Run me",
+          cronExpression: "0 9 * * *",
+          enabled: false,
+        },
+      ],
+    });
+    await enableAutomations(fixture);
+
+    const enabled = await requestJson(
+      "/api/automations/toggle/enable",
+      jsonInit("POST", { agentId: fixture.composeId }),
+    );
+    expect(enabled.status).toBe(200);
+    expect(automationResponseSchema.parse(enabled.body).enabled).toBeTruthy();
+
+    const disabled = await requestJson(
+      "/api/automations/toggle/disable",
+      jsonInit("POST", { agentId: fixture.composeId }),
+    );
+    expect(disabled.status).toBe(200);
+    expect(automationResponseSchema.parse(disabled.body).enabled).toBeFalsy();
+  });
+
+  it("deletes an automation by name", async () => {
+    const fixture = await seedFixture({
+      schedules: [
+        {
+          name: "removable",
+          prompt: "Run me",
+          cronExpression: "0 9 * * *",
+          enabled: true,
+        },
+      ],
+    });
+    await enableAutomations(fixture);
+
+    const delStatus = await requestStatus(
+      `/api/automations/removable?agentId=${fixture.composeId}`,
+      { method: "DELETE", headers: SESSION_HEADERS },
+    );
+    expect(delStatus).toBe(204);
+
+    const db = store.set(writeDb$);
+    const rows = await db
+      .select({ id: zeroAgentSchedules.id })
+      .from(zeroAgentSchedules)
+      .where(eq(zeroAgentSchedules.agentId, fixture.composeId));
+    expect(rows).toHaveLength(0);
+  });
+
+  it("returns 401 when unauthenticated", async () => {
+    const response = await requestJson("/api/automations", {
+      method: "GET",
+      headers: {},
+    });
+    expect(response.status).toBe(401);
+    expect(expectErrorCode(response)).toBe("UNAUTHORIZED");
+  });
+});

--- a/turbo/apps/api/src/signals/routes/automations.ts
+++ b/turbo/apps/api/src/signals/routes/automations.ts
@@ -1,0 +1,395 @@
+import { command, computed } from "ccstate";
+import {
+  automationRunContract,
+  automationsByNameContract,
+  automationsEnableContract,
+  automationsMainContract,
+  type AutomationListResponse,
+  type AutomationMutationResponse,
+  type AutomationResponse,
+} from "@vm0/api-contracts/contracts/automations";
+import type {
+  ScheduleListResponse,
+  ScheduleResponse,
+} from "@vm0/api-contracts/contracts/zero-schedules";
+import { FeatureSwitchKey } from "@vm0/connectors/feature-switch-key";
+import { isFeatureEnabled } from "@vm0/core/feature-switch";
+
+import { badRequestMessage, conflict, notFound } from "../../lib/error";
+import { organizationAuthContext$ } from "../auth/auth-context";
+import { authRoute } from "../auth/auth-route";
+import { bodyResultOf, pathParamsOf, queryOf } from "../context/request";
+import { userFeatureSwitchOverrides } from "../services/feature-switches.service";
+import {
+  deleteSchedule$,
+  deploySchedule$,
+  disableSchedule$,
+  enableSchedule$,
+  runScheduleNow$,
+  zeroScheduleList,
+} from "../services/zero-schedules.service";
+import { now } from "../external/time";
+import type { RouteEntry } from "../route";
+
+// The Automations surface and the legacy schedule surface share the same
+// service and the same cleaned field set, so a schedule projection IS the
+// automation projection — only the wrapper key differs.
+function toAutomation(schedule: ScheduleResponse): AutomationResponse {
+  return schedule;
+}
+
+function toAutomationList(list: ScheduleListResponse): AutomationListResponse {
+  return { automations: list.schedules.map(toAutomation) };
+}
+
+function toAutomationMutation(response: {
+  readonly schedule: ScheduleResponse;
+  readonly created: boolean;
+}): AutomationMutationResponse {
+  return {
+    automation: toAutomation(response.schedule),
+    created: response.created,
+  };
+}
+
+// The Automations API is gated behind the zeroAutomations switch. When off, the
+// surface is not reachable: handlers report not-found so the new paths are
+// indistinguishable from unmounted routes.
+const automationsEnabled$ = computed(async (get) => {
+  const auth = get(organizationAuthContext$);
+  const overrides = await get(
+    userFeatureSwitchOverrides(auth.orgId, auth.userId),
+  );
+  return isFeatureEnabled(FeatureSwitchKey.ZeroAutomations, {
+    orgId: auth.orgId,
+    userId: auth.userId,
+    overrides,
+  });
+});
+
+const createInner$ = command(async ({ get, set }, signal: AbortSignal) => {
+  if (!(await get(automationsEnabled$))) {
+    return notFound("Resource not found");
+  }
+  signal.throwIfAborted();
+  const auth = get(organizationAuthContext$);
+  const bodyResult = await get(bodyResultOf(automationsMainContract.create));
+  signal.throwIfAborted();
+  if (!bodyResult.ok) {
+    return bodyResult.response;
+  }
+
+  const result = await set(
+    deploySchedule$,
+    {
+      userId: auth.userId,
+      orgId: auth.orgId,
+      body: bodyResult.data,
+    },
+    signal,
+  );
+  signal.throwIfAborted();
+
+  if (result.kind === "not_found") {
+    return notFound(result.message);
+  }
+  if (result.kind === "bad_request") {
+    return badRequestMessage(result.message);
+  }
+  if (result.kind === "schedule_past") {
+    return {
+      status: 400 as const,
+      body: {
+        error: {
+          message: result.message,
+          code: "SCHEDULE_PAST",
+        },
+      },
+    };
+  }
+  return {
+    status: result.status,
+    body: toAutomationMutation(result.response),
+  };
+});
+
+const updateInner$ = command(async ({ get, set }, signal: AbortSignal) => {
+  if (!(await get(automationsEnabled$))) {
+    return notFound("Resource not found");
+  }
+  signal.throwIfAborted();
+  const auth = get(organizationAuthContext$);
+  const params = get(pathParamsOf(automationsByNameContract.update));
+  const bodyResult = await get(bodyResultOf(automationsByNameContract.update));
+  signal.throwIfAborted();
+  if (!bodyResult.ok) {
+    return bodyResult.response;
+  }
+
+  // Name is addressed by path; the deploy upsert is keyed on (agentId, name).
+  const result = await set(
+    deploySchedule$,
+    {
+      userId: auth.userId,
+      orgId: auth.orgId,
+      body: { ...bodyResult.data, name: params.name },
+    },
+    signal,
+  );
+  signal.throwIfAborted();
+
+  if (result.kind === "not_found") {
+    return notFound(result.message);
+  }
+  if (result.kind === "bad_request") {
+    return badRequestMessage(result.message);
+  }
+  if (result.kind === "schedule_past") {
+    return {
+      status: 400 as const,
+      body: {
+        error: {
+          message: result.message,
+          code: "SCHEDULE_PAST",
+        },
+      },
+    };
+  }
+  return {
+    status: result.status,
+    body: toAutomationMutation(result.response),
+  };
+});
+
+const listInner$ = command(async ({ get }, signal: AbortSignal) => {
+  if (!(await get(automationsEnabled$))) {
+    return notFound("Resource not found");
+  }
+  signal.throwIfAborted();
+  const auth = get(organizationAuthContext$);
+  const result = await get(
+    zeroScheduleList({ orgId: auth.orgId, userId: auth.userId }),
+  );
+  signal.throwIfAborted();
+  return { status: 200 as const, body: toAutomationList(result) };
+});
+
+const deleteInner$ = command(async ({ get, set }, signal: AbortSignal) => {
+  if (!(await get(automationsEnabled$))) {
+    return notFound("Resource not found");
+  }
+  signal.throwIfAborted();
+  const auth = get(organizationAuthContext$);
+  const params = get(pathParamsOf(automationsByNameContract.delete));
+  const query = get(queryOf(automationsByNameContract.delete));
+
+  const result = await set(
+    deleteSchedule$,
+    {
+      userId: auth.userId,
+      orgId: auth.orgId,
+      agentId: query.agentId,
+      name: params.name,
+    },
+    signal,
+  );
+  signal.throwIfAborted();
+
+  if (result.kind === "not_found") {
+    return notFound("Resource not found");
+  }
+  return { status: 204 as const, body: undefined };
+});
+
+const disableInner$ = command(async ({ get, set }, signal: AbortSignal) => {
+  if (!(await get(automationsEnabled$))) {
+    return notFound("Resource not found");
+  }
+  signal.throwIfAborted();
+  const auth = get(organizationAuthContext$);
+  const params = get(pathParamsOf(automationsEnableContract.disable));
+  const bodyResult = await get(bodyResultOf(automationsEnableContract.disable));
+  signal.throwIfAborted();
+  if (!bodyResult.ok) {
+    return bodyResult.response;
+  }
+
+  const result = await set(
+    disableSchedule$,
+    {
+      userId: auth.userId,
+      orgId: auth.orgId,
+      agentId: bodyResult.data.agentId,
+      name: params.name,
+    },
+    signal,
+  );
+  signal.throwIfAborted();
+
+  if (result.kind === "not_found") {
+    return notFound("Resource not found");
+  }
+  return {
+    status: 200 as const,
+    body: toAutomation(result.response),
+  };
+});
+
+const enableInner$ = command(async ({ get, set }, signal: AbortSignal) => {
+  if (!(await get(automationsEnabled$))) {
+    return notFound("Resource not found");
+  }
+  signal.throwIfAborted();
+  const auth = get(organizationAuthContext$);
+  const params = get(pathParamsOf(automationsEnableContract.enable));
+  const bodyResult = await get(bodyResultOf(automationsEnableContract.enable));
+  signal.throwIfAborted();
+  if (!bodyResult.ok) {
+    return bodyResult.response;
+  }
+
+  const result = await set(
+    enableSchedule$,
+    {
+      userId: auth.userId,
+      orgId: auth.orgId,
+      agentId: bodyResult.data.agentId,
+      name: params.name,
+    },
+    signal,
+  );
+  signal.throwIfAborted();
+
+  if (result.kind === "not_found") {
+    return notFound("Resource not found");
+  }
+  if (result.kind === "schedule_past") {
+    return {
+      status: 400 as const,
+      body: {
+        error: {
+          message: "Schedule time has already passed",
+          code: "SCHEDULE_PAST",
+        },
+      },
+    };
+  }
+  return {
+    status: 200 as const,
+    body: toAutomation(result.response),
+  };
+});
+
+const runNowInner$ = command(async ({ get, set }, signal: AbortSignal) => {
+  if (!(await get(automationsEnabled$))) {
+    return notFound("Resource not found");
+  }
+  signal.throwIfAborted();
+  const auth = get(organizationAuthContext$);
+  const bodyResult = await get(bodyResultOf(automationRunContract.run));
+  signal.throwIfAborted();
+  if (!bodyResult.ok) {
+    return bodyResult.response;
+  }
+
+  const result = await set(
+    runScheduleNow$,
+    {
+      body: { scheduleId: bodyResult.data.automationId },
+      orgId: auth.orgId,
+      apiStartTime: now(),
+    },
+    signal,
+  );
+  signal.throwIfAborted();
+
+  if (result.kind === "not_found") {
+    return notFound(result.message);
+  }
+  if (result.kind === "conflict") {
+    return conflict(result.message);
+  }
+  if (result.kind === "run_error") {
+    return result.response;
+  }
+  return { status: 201 as const, body: { runId: result.runId } };
+});
+
+export const automationsRoutes: readonly RouteEntry[] = [
+  {
+    route: automationsMainContract.create,
+    handler: authRoute(
+      {
+        requireOrganization: true,
+        missingOrganizationStatus: 401,
+        requiredCapability: "schedule:write",
+      },
+      createInner$,
+    ),
+  },
+  {
+    route: automationsMainContract.list,
+    handler: authRoute(
+      {
+        requireOrganization: true,
+        missingOrganizationStatus: 401,
+        requiredCapability: "schedule:read",
+      },
+      listInner$,
+    ),
+  },
+  {
+    route: automationsByNameContract.update,
+    handler: authRoute(
+      {
+        requireOrganization: true,
+        missingOrganizationStatus: 401,
+        requiredCapability: "schedule:write",
+      },
+      updateInner$,
+    ),
+  },
+  {
+    route: automationsByNameContract.delete,
+    handler: authRoute(
+      {
+        requireOrganization: true,
+        missingOrganizationStatus: 401,
+        requiredCapability: "schedule:delete",
+      },
+      deleteInner$,
+    ),
+  },
+  {
+    route: automationsEnableContract.disable,
+    handler: authRoute(
+      {
+        requireOrganization: true,
+        missingOrganizationStatus: 401,
+        requiredCapability: "schedule:write",
+      },
+      disableInner$,
+    ),
+  },
+  {
+    route: automationsEnableContract.enable,
+    handler: authRoute(
+      {
+        requireOrganization: true,
+        missingOrganizationStatus: 401,
+        requiredCapability: "schedule:write",
+      },
+      enableInner$,
+    ),
+  },
+  {
+    route: automationRunContract.run,
+    handler: authRoute(
+      {
+        requireOrganization: true,
+        missingOrganizationStatus: 401,
+      },
+      runNowInner$,
+    ),
+  },
+];

--- a/turbo/apps/web/api-backend-rewrites.js
+++ b/turbo/apps/web/api-backend-rewrites.js
@@ -53,6 +53,13 @@ const ZERO_SCHEDULES_DISABLE_PATH_RE =
   /^\/api\/zero\/schedules\/[^/]+\/disable$/;
 const ZERO_SCHEDULES_ENABLE_REWRITE_SOURCE = "/api/zero/schedules/:name/enable";
 const ZERO_SCHEDULES_ENABLE_PATH_RE = /^\/api\/zero\/schedules\/[^/]+\/enable$/;
+const AUTOMATIONS_RUN_REWRITE_SOURCE = "/api/automations/run";
+const AUTOMATIONS_BY_NAME_REWRITE_SOURCE = "/api/automations/:name";
+const AUTOMATIONS_BY_NAME_PATH_RE = /^\/api\/automations\/[^/]+$/;
+const AUTOMATIONS_DISABLE_REWRITE_SOURCE = "/api/automations/:name/disable";
+const AUTOMATIONS_DISABLE_PATH_RE = /^\/api\/automations\/[^/]+\/disable$/;
+const AUTOMATIONS_ENABLE_REWRITE_SOURCE = "/api/automations/:name/enable";
+const AUTOMATIONS_ENABLE_PATH_RE = /^\/api\/automations\/[^/]+\/enable$/;
 const ZERO_SKILLS_BY_NAME_REWRITE_SOURCE = "/api/zero/skills/:name";
 const ZERO_SKILLS_BY_NAME_PATH_RE = /^\/api\/zero\/skills\/[^/]+$/;
 const ZERO_ME_MODEL_PROVIDERS_REWRITE_SOURCE = "/api/zero/me/model-providers";
@@ -1107,6 +1114,23 @@ export const API_BACKEND_REWRITES = [
     ZERO_SCHEDULES_ENABLE_REWRITE_SOURCE,
     "/api/zero/schedules/:name/enable",
     ZERO_SCHEDULES_ENABLE_PATH_RE,
+  ],
+  ["/api/automations", "/api/automations"],
+  [AUTOMATIONS_RUN_REWRITE_SOURCE, "/api/automations/run"],
+  [
+    AUTOMATIONS_DISABLE_REWRITE_SOURCE,
+    "/api/automations/:name/disable",
+    AUTOMATIONS_DISABLE_PATH_RE,
+  ],
+  [
+    AUTOMATIONS_ENABLE_REWRITE_SOURCE,
+    "/api/automations/:name/enable",
+    AUTOMATIONS_ENABLE_PATH_RE,
+  ],
+  [
+    AUTOMATIONS_BY_NAME_REWRITE_SOURCE,
+    "/api/automations/:name",
+    AUTOMATIONS_BY_NAME_PATH_RE,
   ],
   ["/api/zero/memory", "/api/zero/memory"],
   ["/api/zero/memory/activity", "/api/zero/memory/activity"],

--- a/turbo/packages/api-contracts/src/contracts/automations.ts
+++ b/turbo/packages/api-contracts/src/contracts/automations.ts
@@ -1,0 +1,276 @@
+import { z } from "zod";
+import { authHeadersSchema, initContract } from "./base";
+import { apiErrorSchema } from "./errors";
+
+const c = initContract();
+
+/**
+ * Automations API surface (SI-3). A cleaned product view over the shared
+ * automation service that also backs the legacy `/api/zero/schedules` routes.
+ * The field set is the post-cleanup schedule set (no secrets / vars /
+ * volumeVersions); the two surfaces drive the same service and therefore the
+ * same agent run + chat-thread rendering. Gated behind the `zeroAutomations`
+ * feature switch — when off, these endpoints are not mounted (404).
+ */
+
+/**
+ * Automation response schema — shared by all automation endpoints. Mirrors the
+ * cleaned schedule projection of a `zero_agent_schedules` row.
+ */
+export const automationResponseSchema = z.object({
+  id: z.string().uuid(),
+  agentId: z.string().uuid(),
+  displayName: z.string().nullable(),
+  userId: z.string(),
+  name: z.string(),
+  triggerType: z.enum(["cron", "once", "loop"]),
+  cronExpression: z.string().nullable(),
+  atTime: z.string().nullable(),
+  intervalSeconds: z.number().nullable(),
+  timezone: z.string(),
+  prompt: z.string(),
+  description: z.string().nullable(),
+  appendSystemPrompt: z.string().nullable(),
+  enabled: z.boolean(),
+  nextRunAt: z.string().nullable(),
+  lastRunAt: z.string().nullable(),
+  retryStartedAt: z.string().nullable(),
+  consecutiveFailures: z.number(),
+  // Linked chat thread. Set at creation and immutable after (any chatThreadId
+  // supplied on update is ignored). Every automation is linked to a chat
+  // thread, so this is always present.
+  chatThreadId: z.string().uuid(),
+  createdAt: z.string(),
+  updatedAt: z.string(),
+});
+
+export const automationListResponseSchema = z.object({
+  automations: z.array(automationResponseSchema),
+});
+
+export const automationMutationResponseSchema = z.object({
+  automation: automationResponseSchema,
+  created: z.boolean(),
+});
+
+const automationTriggerRefinement = (data: {
+  readonly cronExpression?: string;
+  readonly atTime?: string;
+  readonly intervalSeconds?: number;
+}): boolean => {
+  const triggers = [
+    data.cronExpression,
+    data.atTime,
+    data.intervalSeconds,
+  ].filter((v) => {
+    return v !== undefined;
+  });
+  return triggers.length === 1;
+};
+
+const automationTriggerRefinementMessage = {
+  message:
+    "Exactly one of 'cronExpression', 'atTime', or 'intervalSeconds' must be specified",
+};
+
+/**
+ * Create request — requires agentId (compose UUID) and name. Exactly one
+ * trigger must be specified.
+ */
+const createAutomationRequestSchema = z
+  .object({
+    name: z.string().min(1).max(64, "Automation name max 64 chars"),
+    cronExpression: z.string().optional(),
+    atTime: z.string().optional(),
+    intervalSeconds: z.number().int().min(0).optional(),
+    timezone: z.string().default("UTC"),
+    prompt: z.string().min(1, "Prompt required"),
+    description: z.string().optional(),
+    appendSystemPrompt: z.string().optional(),
+    agentId: z.string().uuid("Invalid agent ID"),
+    enabled: z.boolean().optional(),
+    // Chat-thread linkage, honored only on creation. When provided, links the
+    // automation to an existing owned chat thread; when omitted, the server
+    // creates a web chat thread and links it.
+    chatThreadId: z.string().uuid("Invalid chat thread ID").optional(),
+  })
+  .refine(automationTriggerRefinement, automationTriggerRefinementMessage);
+
+/**
+ * Update request — the name is taken from the path; the body carries the agent
+ * and the new definition. The chat-thread link is immutable on update (any
+ * chatThreadId is silently ignored), matching the legacy schedule deploy.
+ */
+const updateAutomationRequestSchema = z
+  .object({
+    cronExpression: z.string().optional(),
+    atTime: z.string().optional(),
+    intervalSeconds: z.number().int().min(0).optional(),
+    timezone: z.string().default("UTC"),
+    prompt: z.string().min(1, "Prompt required"),
+    description: z.string().optional(),
+    appendSystemPrompt: z.string().optional(),
+    agentId: z.string().uuid("Invalid agent ID"),
+    enabled: z.boolean().optional(),
+  })
+  .refine(automationTriggerRefinement, automationTriggerRefinementMessage);
+
+/**
+ * Automations collection contract (GET/POST /api/automations).
+ */
+export const automationsMainContract = c.router({
+  create: {
+    method: "POST",
+    path: "/api/automations",
+    headers: authHeadersSchema,
+    body: createAutomationRequestSchema,
+    responses: {
+      200: automationMutationResponseSchema,
+      201: automationMutationResponseSchema,
+      400: apiErrorSchema,
+      401: apiErrorSchema,
+      403: apiErrorSchema,
+      404: apiErrorSchema,
+    },
+    summary: "Create an automation",
+  },
+  list: {
+    method: "GET",
+    path: "/api/automations",
+    headers: authHeadersSchema,
+    responses: {
+      200: automationListResponseSchema,
+      401: apiErrorSchema,
+      403: apiErrorSchema,
+    },
+    summary: "List all automations",
+  },
+});
+
+/**
+ * Automation by-name contract (PUT/DELETE /api/automations/:name).
+ */
+export const automationsByNameContract = c.router({
+  update: {
+    method: "PUT",
+    path: "/api/automations/:name",
+    headers: authHeadersSchema,
+    pathParams: z.object({
+      name: z.string().min(1, "Automation name required"),
+    }),
+    body: updateAutomationRequestSchema,
+    responses: {
+      200: automationMutationResponseSchema,
+      201: automationMutationResponseSchema,
+      400: apiErrorSchema,
+      401: apiErrorSchema,
+      403: apiErrorSchema,
+      404: apiErrorSchema,
+    },
+    summary: "Update an automation",
+  },
+  delete: {
+    method: "DELETE",
+    path: "/api/automations/:name",
+    headers: authHeadersSchema,
+    pathParams: z.object({
+      name: z.string().min(1, "Automation name required"),
+    }),
+    query: z.object({
+      agentId: z.string().uuid("Invalid agent ID"),
+    }),
+    responses: {
+      204: c.noBody(),
+      400: apiErrorSchema,
+      401: apiErrorSchema,
+      403: apiErrorSchema,
+      404: apiErrorSchema,
+    },
+    summary: "Delete an automation",
+  },
+});
+
+/**
+ * Automation enable/disable contract.
+ */
+export const automationsEnableContract = c.router({
+  enable: {
+    method: "POST",
+    path: "/api/automations/:name/enable",
+    headers: authHeadersSchema,
+    pathParams: z.object({
+      name: z.string().min(1, "Automation name required"),
+    }),
+    body: z.object({
+      agentId: z.string().uuid("Invalid agent ID"),
+    }),
+    responses: {
+      200: automationResponseSchema,
+      400: apiErrorSchema,
+      401: apiErrorSchema,
+      403: apiErrorSchema,
+      404: apiErrorSchema,
+    },
+    summary: "Enable an automation",
+  },
+  disable: {
+    method: "POST",
+    path: "/api/automations/:name/disable",
+    headers: authHeadersSchema,
+    pathParams: z.object({
+      name: z.string().min(1, "Automation name required"),
+    }),
+    body: z.object({
+      agentId: z.string().uuid("Invalid agent ID"),
+    }),
+    responses: {
+      200: automationResponseSchema,
+      400: apiErrorSchema,
+      401: apiErrorSchema,
+      403: apiErrorSchema,
+      404: apiErrorSchema,
+    },
+    summary: "Disable an automation",
+  },
+});
+
+/**
+ * Automation run-now contract (POST /api/automations/run).
+ */
+export const automationRunContract = c.router({
+  run: {
+    method: "POST",
+    path: "/api/automations/run",
+    headers: authHeadersSchema,
+    body: z.object({
+      automationId: z.string().uuid("Invalid automation ID"),
+    }),
+    responses: {
+      201: z.object({ runId: z.string() }),
+      400: apiErrorSchema,
+      401: apiErrorSchema,
+      402: apiErrorSchema,
+      403: apiErrorSchema,
+      404: apiErrorSchema,
+      409: apiErrorSchema,
+      429: apiErrorSchema,
+      503: apiErrorSchema,
+    },
+    summary: "Execute an automation immediately (run now)",
+  },
+});
+
+// Contract type exports
+export type AutomationsMainContract = typeof automationsMainContract;
+export type AutomationsByNameContract = typeof automationsByNameContract;
+export type AutomationsEnableContract = typeof automationsEnableContract;
+export type AutomationRunContract = typeof automationRunContract;
+
+// Inferred types from response schemas
+export type AutomationResponse = z.infer<typeof automationResponseSchema>;
+export type AutomationListResponse = z.infer<
+  typeof automationListResponseSchema
+>;
+export type AutomationMutationResponse = z.infer<
+  typeof automationMutationResponseSchema
+>;

--- a/turbo/packages/api-contracts/src/contracts/index.ts
+++ b/turbo/packages/api-contracts/src/contracts/index.ts
@@ -999,6 +999,22 @@ export {
   type DeployScheduleResponse,
 } from "./zero-schedules";
 export {
+  automationsMainContract,
+  automationsByNameContract,
+  automationsEnableContract,
+  automationRunContract,
+  automationResponseSchema,
+  automationListResponseSchema,
+  automationMutationResponseSchema,
+  type AutomationsMainContract,
+  type AutomationsByNameContract,
+  type AutomationsEnableContract,
+  type AutomationRunContract,
+  type AutomationResponse,
+  type AutomationListResponse,
+  type AutomationMutationResponse,
+} from "./automations";
+export {
   zeroModelProvidersMainContract,
   zeroModelProvidersByTypeContract,
   type ZeroModelProvidersMainContract,

--- a/turbo/packages/connectors/src/feature-switch-key.ts
+++ b/turbo/packages/connectors/src/feature-switch-key.ts
@@ -54,4 +54,5 @@ export enum FeatureSwitchKey {
   ChatRecommendedFollowups = "chatRecommendedFollowups",
   PresentationHtmlPptxDownload = "presentationHtmlPptxDownload",
   ExpiringPermissionGrants = "expiringPermissionGrants",
+  ZeroAutomations = "zeroAutomations",
 }

--- a/turbo/packages/core/src/feature-switch.ts
+++ b/turbo/packages/core/src/feature-switch.ts
@@ -311,6 +311,13 @@ const FEATURE_SWITCHES: Record<FeatureSwitchKey, FeatureSwitch> = {
     enabled: false,
     enabledOrgIdHashes: STAFF_ORG_ID_HASHES,
   },
+  [FeatureSwitchKey.ZeroAutomations]: {
+    maintainer: "lancy@vm0.ai",
+    description:
+      "Expose the Automations API surface (/api/automations) over the shared automation service. When disabled, the new endpoints 404 and only the legacy /api/zero/schedules surface is reachable.",
+    enabled: false,
+    enabledOrgIdHashes: STAFF_ORG_ID_HASHES,
+  },
 };
 
 interface ResolvedHashes {


### PR DESCRIPTION
Closes #16638. Part of #16616. Stacked on #16673.

New Automations API (/api/automations: create/list/update/delete/enable/disable/run-now) delegating to the shared schedule service, behind the zeroAutomations feature switch (404 when off). Legacy /api/zero/schedules untouched. Cleaned field set (no secrets/vars/volumeVersions). Adds the 5 /api/automations rewrites to apps/web/api-backend-rewrites.js per the API-migration boundary. Tests: parity (9 automations + 85 schedule/cron + 1 web-compat) pass.