### PR TITLE
feat(cli): add zero automation commands; keep zero schedule as compat

### DIFF
--- a/turbo/apps/cli/src/__tests__/zero.test.ts
+++ b/turbo/apps/cli/src/__tests__/zero.test.ts
@@ -24,6 +24,7 @@ describe("zero CLI program", () => {
       "search",
       "preference",
       "schedule",
+      "automation",
       "secret",
       "skill",
       "slack",
@@ -62,7 +63,7 @@ describe("zero CLI program", () => {
     }
   });
 
-  it("should have exactly 26 commands", () => {
-    expect(commandNames).toHaveLength(26);
+  it("should have exactly 27 commands", () => {
+    expect(commandNames).toHaveLength(27);
   });
 });

--- a/turbo/apps/cli/src/commands/zero/automation/__tests__/delete.test.ts
+++ b/turbo/apps/cli/src/commands/zero/automation/__tests__/delete.test.ts
@@ -1,0 +1,165 @@
+/**
+ * Tests for zero automation delete command
+ *
+ * Tests command-level behavior via parseAsync() following CLI testing principles:
+ * - Entry point: command.parseAsync()
+ * - Mock (external): Web API via MSW
+ * - Real (internal): All CLI code, formatters, validators
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { http, HttpResponse } from "msw";
+import { server } from "../../../../mocks/server";
+import { deleteCommand } from "../delete";
+import chalk from "chalk";
+
+const mockCompose = {
+  id: "compose-uuid-001",
+  name: "my-agent",
+  headVersionId: "ver-001",
+  content: null,
+  createdAt: "2026-03-23T00:00:00Z",
+  updatedAt: "2026-03-23T00:00:00Z",
+};
+
+const mockAutomation = {
+  id: "auto-001",
+  agentId: "compose-uuid-001",
+  userId: "user-001",
+  name: "default",
+  triggerType: "cron",
+  cronExpression: "0 9 * * *",
+  atTime: null,
+  intervalSeconds: null,
+  timezone: "UTC",
+  prompt: "run daily check",
+  description: null,
+  appendSystemPrompt: null,
+  enabled: true,
+  nextRunAt: "2026-03-24T09:00:00Z",
+  lastRunAt: null,
+  retryStartedAt: null,
+  consecutiveFailures: 0,
+  chatThreadId: "550e8400-e29b-41d4-a716-446655440099",
+  createdAt: "2026-03-23T00:00:00Z",
+  updatedAt: "2026-03-23T00:00:00Z",
+};
+
+describe("zero automation delete command", () => {
+  const mockExit = vi.spyOn(process, "exit").mockImplementation((() => {
+    throw new Error("process.exit called");
+  }) as never);
+  const mockConsoleLog = vi.spyOn(console, "log").mockImplementation(() => {});
+  const mockConsoleError = vi
+    .spyOn(console, "error")
+    .mockImplementation(() => {});
+
+  beforeEach(() => {
+    chalk.level = 0;
+    vi.stubEnv("VM0_API_URL", "http://localhost:3000");
+    vi.stubEnv("VM0_TOKEN", "test-token");
+  });
+
+  afterEach(() => {
+    mockExit.mockClear();
+    mockConsoleLog.mockClear();
+    mockConsoleError.mockClear();
+  });
+
+  describe("successful delete", () => {
+    it("should delete with --yes flag without prompting", async () => {
+      server.use(
+        http.get("http://localhost:3000/api/agent/composes", () => {
+          return HttpResponse.json(mockCompose);
+        }),
+        http.get("http://localhost:3000/api/automations", () => {
+          return HttpResponse.json({ automations: [mockAutomation] });
+        }),
+        http.delete("http://localhost:3000/api/automations/default", () => {
+          return new HttpResponse(null, { status: 204 });
+        }),
+      );
+
+      await deleteCommand.parseAsync(["node", "cli", "my-agent", "--yes"]);
+
+      const logCalls = mockConsoleLog.mock.calls.flat().join("\n");
+      expect(logCalls).toContain("Automation");
+      expect(logCalls).toContain("deleted");
+    });
+
+    it("should delete when agent identifier is a UUID", async () => {
+      const testUuid = "550e8400-e29b-41d4-a716-446655440000";
+      const uuidCompose = { ...mockCompose, id: testUuid };
+      const uuidAutomation = { ...mockAutomation, agentId: testUuid };
+
+      server.use(
+        http.get(
+          "http://localhost:3000/api/agent/composes/:id",
+          ({ params }) => {
+            if (params.id !== testUuid) {
+              return HttpResponse.json(
+                { error: { message: "Not found", code: "NOT_FOUND" } },
+                { status: 404 },
+              );
+            }
+            return HttpResponse.json(uuidCompose);
+          },
+        ),
+        http.get("http://localhost:3000/api/automations", () => {
+          return HttpResponse.json({ automations: [uuidAutomation] });
+        }),
+        http.delete("http://localhost:3000/api/automations/default", () => {
+          return new HttpResponse(null, { status: 204 });
+        }),
+      );
+
+      await deleteCommand.parseAsync(["node", "cli", testUuid, "--yes"]);
+
+      const logCalls = mockConsoleLog.mock.calls.flat().join("\n");
+      expect(logCalls).toContain("Automation");
+      expect(logCalls).toContain("deleted");
+    });
+  });
+
+  describe("error handling", () => {
+    it("should handle no automation found", async () => {
+      server.use(
+        http.get("http://localhost:3000/api/agent/composes", () => {
+          return HttpResponse.json(mockCompose);
+        }),
+        http.get("http://localhost:3000/api/automations", () => {
+          return HttpResponse.json({ automations: [] });
+        }),
+      );
+
+      await expect(async () => {
+        await deleteCommand.parseAsync(["node", "cli", "my-agent", "--yes"]);
+      }).rejects.toThrow("process.exit called");
+
+      expect(mockConsoleError).toHaveBeenCalledWith(
+        expect.stringContaining("No automation found"),
+      );
+      expect(mockExit).toHaveBeenCalledWith(1);
+    });
+
+    it("should require --yes in non-interactive mode", async () => {
+      server.use(
+        http.get("http://localhost:3000/api/agent/composes", () => {
+          return HttpResponse.json(mockCompose);
+        }),
+        http.get("http://localhost:3000/api/automations", () => {
+          return HttpResponse.json({ automations: [mockAutomation] });
+        }),
+      );
+
+      await expect(async () => {
+        await deleteCommand.parseAsync(["node", "cli", "my-agent"]);
+      }).rejects.toThrow("process.exit called");
+
+      expect(mockConsoleError).toHaveBeenCalledWith(
+        expect.stringContaining("--yes flag is required"),
+      );
+      expect(mockExit).toHaveBeenCalledWith(1);
+    });
+  });
+});

--- a/turbo/apps/cli/src/commands/zero/automation/__tests__/disable.test.ts
+++ b/turbo/apps/cli/src/commands/zero/automation/__tests__/disable.test.ts
@@ -1,0 +1,157 @@
+/**
+ * Tests for zero automation disable command
+ *
+ * Tests command-level behavior via parseAsync() following CLI testing principles:
+ * - Entry point: command.parseAsync()
+ * - Mock (external): Web API via MSW
+ * - Real (internal): All CLI code, formatters, validators
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { http, HttpResponse } from "msw";
+import { server } from "../../../../mocks/server";
+import { disableCommand } from "../disable";
+import chalk from "chalk";
+
+const mockCompose = {
+  id: "compose-uuid-001",
+  name: "my-agent",
+  headVersionId: "ver-001",
+  content: null,
+  createdAt: "2026-03-23T00:00:00Z",
+  updatedAt: "2026-03-23T00:00:00Z",
+};
+
+const mockAutomation = {
+  id: "auto-001",
+  agentId: "compose-uuid-001",
+  userId: "user-001",
+  name: "default",
+  triggerType: "cron",
+  cronExpression: "0 9 * * *",
+  atTime: null,
+  intervalSeconds: null,
+  timezone: "UTC",
+  prompt: "run daily check",
+  description: null,
+  appendSystemPrompt: null,
+  enabled: false,
+  nextRunAt: null,
+  lastRunAt: null,
+  retryStartedAt: null,
+  consecutiveFailures: 0,
+  chatThreadId: "550e8400-e29b-41d4-a716-446655440099",
+  createdAt: "2026-03-23T00:00:00Z",
+  updatedAt: "2026-03-23T00:00:00Z",
+};
+
+describe("zero automation disable command", () => {
+  const mockExit = vi.spyOn(process, "exit").mockImplementation((() => {
+    throw new Error("process.exit called");
+  }) as never);
+  const mockConsoleLog = vi.spyOn(console, "log").mockImplementation(() => {});
+  const mockConsoleError = vi
+    .spyOn(console, "error")
+    .mockImplementation(() => {});
+
+  beforeEach(() => {
+    chalk.level = 0;
+    vi.stubEnv("VM0_API_URL", "http://localhost:3000");
+    vi.stubEnv("VM0_TOKEN", "test-token");
+  });
+
+  afterEach(() => {
+    mockExit.mockClear();
+    mockConsoleLog.mockClear();
+    mockConsoleError.mockClear();
+  });
+
+  describe("successful disable", () => {
+    it("should disable an automation", async () => {
+      server.use(
+        http.get("http://localhost:3000/api/agent/composes", () => {
+          return HttpResponse.json(mockCompose);
+        }),
+        http.get("http://localhost:3000/api/automations", () => {
+          return HttpResponse.json({
+            automations: [{ ...mockAutomation, enabled: true }],
+          });
+        }),
+        http.post(
+          "http://localhost:3000/api/automations/default/disable",
+          () => {
+            return HttpResponse.json(mockAutomation);
+          },
+        ),
+      );
+
+      await disableCommand.parseAsync(["node", "cli", "my-agent"]);
+
+      const logCalls = mockConsoleLog.mock.calls.flat().join("\n");
+      expect(logCalls).toContain("Automation");
+      expect(logCalls).toContain("disabled");
+    });
+
+    it("should disable an automation when agent identifier is a UUID", async () => {
+      const testUuid = "550e8400-e29b-41d4-a716-446655440000";
+      const uuidCompose = { ...mockCompose, id: testUuid };
+      const uuidAutomation = {
+        ...mockAutomation,
+        agentId: testUuid,
+        enabled: true,
+      };
+
+      server.use(
+        http.get(
+          "http://localhost:3000/api/agent/composes/:id",
+          ({ params }) => {
+            if (params.id !== testUuid) {
+              return HttpResponse.json(
+                { error: { message: "Not found", code: "NOT_FOUND" } },
+                { status: 404 },
+              );
+            }
+            return HttpResponse.json(uuidCompose);
+          },
+        ),
+        http.get("http://localhost:3000/api/automations", () => {
+          return HttpResponse.json({ automations: [uuidAutomation] });
+        }),
+        http.post(
+          "http://localhost:3000/api/automations/default/disable",
+          () => {
+            return HttpResponse.json({ ...uuidAutomation, enabled: false });
+          },
+        ),
+      );
+
+      await disableCommand.parseAsync(["node", "cli", testUuid]);
+
+      const logCalls = mockConsoleLog.mock.calls.flat().join("\n");
+      expect(logCalls).toContain("Automation");
+      expect(logCalls).toContain("disabled");
+    });
+  });
+
+  describe("error handling", () => {
+    it("should handle no automation found", async () => {
+      server.use(
+        http.get("http://localhost:3000/api/agent/composes", () => {
+          return HttpResponse.json(mockCompose);
+        }),
+        http.get("http://localhost:3000/api/automations", () => {
+          return HttpResponse.json({ automations: [] });
+        }),
+      );
+
+      await expect(async () => {
+        await disableCommand.parseAsync(["node", "cli", "my-agent"]);
+      }).rejects.toThrow("process.exit called");
+
+      expect(mockConsoleError).toHaveBeenCalledWith(
+        expect.stringContaining("No automation found"),
+      );
+      expect(mockExit).toHaveBeenCalledWith(1);
+    });
+  });
+});

--- a/turbo/apps/cli/src/commands/zero/automation/__tests__/enable.test.ts
+++ b/turbo/apps/cli/src/commands/zero/automation/__tests__/enable.test.ts
@@ -1,0 +1,151 @@
+/**
+ * Tests for zero automation enable command
+ *
+ * Tests command-level behavior via parseAsync() following CLI testing principles:
+ * - Entry point: command.parseAsync()
+ * - Mock (external): Web API via MSW
+ * - Real (internal): All CLI code, formatters, validators
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { http, HttpResponse } from "msw";
+import { server } from "../../../../mocks/server";
+import { enableCommand } from "../enable";
+import chalk from "chalk";
+
+const mockCompose = {
+  id: "compose-uuid-001",
+  name: "my-agent",
+  headVersionId: "ver-001",
+  content: null,
+  createdAt: "2026-03-23T00:00:00Z",
+  updatedAt: "2026-03-23T00:00:00Z",
+};
+
+const mockAutomation = {
+  id: "auto-001",
+  agentId: "compose-uuid-001",
+  userId: "user-001",
+  name: "default",
+  triggerType: "cron",
+  cronExpression: "0 9 * * *",
+  atTime: null,
+  intervalSeconds: null,
+  timezone: "UTC",
+  prompt: "run daily check",
+  description: null,
+  appendSystemPrompt: null,
+  enabled: true,
+  nextRunAt: "2026-03-24T09:00:00Z",
+  lastRunAt: null,
+  retryStartedAt: null,
+  consecutiveFailures: 0,
+  chatThreadId: "550e8400-e29b-41d4-a716-446655440099",
+  createdAt: "2026-03-23T00:00:00Z",
+  updatedAt: "2026-03-23T00:00:00Z",
+};
+
+describe("zero automation enable command", () => {
+  const mockExit = vi.spyOn(process, "exit").mockImplementation((() => {
+    throw new Error("process.exit called");
+  }) as never);
+  const mockConsoleLog = vi.spyOn(console, "log").mockImplementation(() => {});
+  const mockConsoleError = vi
+    .spyOn(console, "error")
+    .mockImplementation(() => {});
+
+  beforeEach(() => {
+    chalk.level = 0;
+    vi.stubEnv("VM0_API_URL", "http://localhost:3000");
+    vi.stubEnv("VM0_TOKEN", "test-token");
+  });
+
+  afterEach(() => {
+    mockExit.mockClear();
+    mockConsoleLog.mockClear();
+    mockConsoleError.mockClear();
+  });
+
+  describe("successful enable", () => {
+    it("should enable an automation", async () => {
+      server.use(
+        http.get("http://localhost:3000/api/agent/composes", () => {
+          return HttpResponse.json(mockCompose);
+        }),
+        http.get("http://localhost:3000/api/automations", () => {
+          return HttpResponse.json({ automations: [mockAutomation] });
+        }),
+        http.post(
+          "http://localhost:3000/api/automations/default/enable",
+          () => {
+            return HttpResponse.json(mockAutomation);
+          },
+        ),
+      );
+
+      await enableCommand.parseAsync(["node", "cli", "my-agent"]);
+
+      const logCalls = mockConsoleLog.mock.calls.flat().join("\n");
+      expect(logCalls).toContain("Automation");
+      expect(logCalls).toContain("enabled");
+    });
+
+    it("should enable an automation when agent identifier is a UUID", async () => {
+      const testUuid = "550e8400-e29b-41d4-a716-446655440000";
+      const uuidCompose = { ...mockCompose, id: testUuid };
+      const uuidAutomation = { ...mockAutomation, agentId: testUuid };
+
+      server.use(
+        http.get(
+          "http://localhost:3000/api/agent/composes/:id",
+          ({ params }) => {
+            if (params.id !== testUuid) {
+              return HttpResponse.json(
+                { error: { message: "Not found", code: "NOT_FOUND" } },
+                { status: 404 },
+              );
+            }
+            return HttpResponse.json(uuidCompose);
+          },
+        ),
+        http.get("http://localhost:3000/api/automations", () => {
+          return HttpResponse.json({ automations: [uuidAutomation] });
+        }),
+        http.post(
+          "http://localhost:3000/api/automations/default/enable",
+          () => {
+            return HttpResponse.json(uuidAutomation);
+          },
+        ),
+      );
+
+      await enableCommand.parseAsync(["node", "cli", testUuid]);
+
+      const logCalls = mockConsoleLog.mock.calls.flat().join("\n");
+      expect(logCalls).toContain("Automation");
+      expect(logCalls).toContain("enabled");
+    });
+  });
+
+  describe("error handling", () => {
+    it("should handle no automation found", async () => {
+      server.use(
+        http.get("http://localhost:3000/api/agent/composes", () => {
+          return HttpResponse.json(mockCompose);
+        }),
+        http.get("http://localhost:3000/api/automations", () => {
+          return HttpResponse.json({ automations: [] });
+        }),
+      );
+
+      await expect(async () => {
+        await enableCommand.parseAsync(["node", "cli", "my-agent"]);
+      }).rejects.toThrow("process.exit called");
+
+      expect(mockConsoleError).toHaveBeenCalledWith(
+        expect.stringContaining("No automation found"),
+      );
+      expect(mockExit).toHaveBeenCalledWith(1);
+    });
+  });
+});

--- a/turbo/apps/cli/src/commands/zero/automation/__tests__/list.test.ts
+++ b/turbo/apps/cli/src/commands/zero/automation/__tests__/list.test.ts
@@ -1,0 +1,113 @@
+/**
+ * Tests for zero automation list command
+ *
+ * Tests command-level behavior via parseAsync() following CLI testing principles:
+ * - Entry point: command.parseAsync()
+ * - Mock (external): Web API via MSW
+ * - Real (internal): All CLI code, formatters, validators
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { http, HttpResponse } from "msw";
+import { server } from "../../../../mocks/server";
+import { listCommand } from "../list";
+import chalk from "chalk";
+
+const mockAutomation = {
+  id: "auto-001",
+  agentId: "my-agent",
+  userId: "user-001",
+  name: "default",
+  triggerType: "cron",
+  cronExpression: "0 9 * * *",
+  atTime: null,
+  intervalSeconds: null,
+  timezone: "UTC",
+  prompt: "run daily check",
+  description: null,
+  appendSystemPrompt: null,
+  enabled: true,
+  nextRunAt: "2026-03-24T09:00:00Z",
+  lastRunAt: null,
+  retryStartedAt: null,
+  consecutiveFailures: 0,
+  chatThreadId: "550e8400-e29b-41d4-a716-446655440099",
+  createdAt: "2026-03-23T00:00:00Z",
+  updatedAt: "2026-03-23T00:00:00Z",
+};
+
+describe("zero automation list command", () => {
+  const mockExit = vi.spyOn(process, "exit").mockImplementation((() => {
+    throw new Error("process.exit called");
+  }) as never);
+  const mockConsoleLog = vi.spyOn(console, "log").mockImplementation(() => {});
+  const mockConsoleError = vi
+    .spyOn(console, "error")
+    .mockImplementation(() => {});
+
+  beforeEach(() => {
+    chalk.level = 0;
+    vi.stubEnv("VM0_API_URL", "http://localhost:3000");
+    vi.stubEnv("VM0_TOKEN", "test-token");
+  });
+
+  afterEach(() => {
+    mockExit.mockClear();
+    mockConsoleLog.mockClear();
+    mockConsoleError.mockClear();
+  });
+
+  describe("successful list", () => {
+    it("should display automations in table format", async () => {
+      server.use(
+        http.get("http://localhost:3000/api/automations", () => {
+          return HttpResponse.json({ automations: [mockAutomation] });
+        }),
+      );
+
+      await listCommand.parseAsync(["node", "cli"]);
+
+      const logCalls = mockConsoleLog.mock.calls.flat().join("\n");
+      expect(logCalls).toContain("my-agent");
+      expect(logCalls).toContain("default");
+      expect(logCalls).toContain("0 9 * * *");
+      expect(logCalls).toContain("enabled");
+    });
+
+    it("should display empty state message when no automations", async () => {
+      server.use(
+        http.get("http://localhost:3000/api/automations", () => {
+          return HttpResponse.json({ automations: [] });
+        }),
+      );
+
+      await listCommand.parseAsync(["node", "cli"]);
+
+      const logCalls = mockConsoleLog.mock.calls.flat().join("\n");
+      expect(logCalls).toContain("No automations found");
+      expect(logCalls).toContain("zero automation setup");
+    });
+  });
+
+  describe("error handling", () => {
+    it("should handle authentication error", async () => {
+      server.use(
+        http.get("http://localhost:3000/api/automations", () => {
+          return HttpResponse.json(
+            { error: { message: "Not authenticated", code: "UNAUTHORIZED" } },
+            { status: 401 },
+          );
+        }),
+      );
+
+      await expect(async () => {
+        await listCommand.parseAsync(["node", "cli"]);
+      }).rejects.toThrow("process.exit called");
+
+      expect(mockConsoleError).toHaveBeenCalledWith(
+        expect.stringContaining("Not authenticated"),
+      );
+      expect(mockExit).toHaveBeenCalledWith(1);
+    });
+  });
+});

--- a/turbo/apps/cli/src/commands/zero/automation/__tests__/setup.test.ts
+++ b/turbo/apps/cli/src/commands/zero/automation/__tests__/setup.test.ts
@@ -1,0 +1,442 @@
+/**
+ * Tests for zero automation setup command
+ *
+ * Tests command-level behavior via parseAsync() following CLI testing principles:
+ * - Entry point: command.parseAsync()
+ * - Mock (external): Web API via MSW
+ * - Real (internal): All CLI code, formatters, validators
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { http, HttpResponse } from "msw";
+import { writeFileSync, mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { server } from "../../../../mocks/server";
+import { setupCommand } from "../setup";
+import chalk from "chalk";
+
+const mockCompose = {
+  id: "comp_abc123",
+  name: "my-agent",
+  headVersionId: "ver-001",
+  content: null,
+  createdAt: "2026-03-23T00:00:00Z",
+  updatedAt: "2026-03-23T00:00:00Z",
+};
+
+const mockDeployResponse = {
+  created: true,
+  automation: {
+    id: "auto-001",
+    agentId: "my-agent",
+    userId: "user-001",
+    name: "default",
+    triggerType: "cron",
+    cronExpression: "0 9 * * *",
+    atTime: null,
+    intervalSeconds: null,
+    timezone: "UTC",
+    prompt: "run daily check",
+    description: null,
+    appendSystemPrompt: null,
+    enabled: false,
+    nextRunAt: "2026-03-24T09:00:00Z",
+    lastRunAt: null,
+    retryStartedAt: null,
+    consecutiveFailures: 0,
+    chatThreadId: "550e8400-e29b-41d4-a716-446655440099",
+    createdAt: "2026-03-23T00:00:00Z",
+    updatedAt: "2026-03-23T00:00:00Z",
+  },
+};
+
+describe("zero automation setup command", () => {
+  const mockExit = vi.spyOn(process, "exit").mockImplementation((() => {
+    throw new Error("process.exit called");
+  }) as never);
+  const mockConsoleLog = vi.spyOn(console, "log").mockImplementation(() => {});
+  const mockConsoleError = vi
+    .spyOn(console, "error")
+    .mockImplementation(() => {});
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    chalk.level = 0;
+    vi.stubEnv("VM0_API_URL", "http://localhost:3000");
+    vi.stubEnv("VM0_TOKEN", "test-token");
+  });
+
+  describe("successful setup (non-interactive)", () => {
+    it("should create daily automation with all flags", async () => {
+      server.use(
+        http.get("http://localhost:3000/api/agent/composes", ({ request }) => {
+          const url = new URL(request.url);
+          if (url.searchParams.get("name") !== "my-agent") {
+            return HttpResponse.json(
+              { error: { message: "Not found", code: "NOT_FOUND" } },
+              { status: 404 },
+            );
+          }
+          return HttpResponse.json(mockCompose);
+        }),
+        http.get("http://localhost:3000/api/automations", () => {
+          return HttpResponse.json({ automations: [] });
+        }),
+        http.post("http://localhost:3000/api/automations", () => {
+          return HttpResponse.json(mockDeployResponse, { status: 201 });
+        }),
+      );
+
+      await setupCommand.parseAsync([
+        "node",
+        "cli",
+        "my-agent",
+        "--frequency",
+        "daily",
+        "--time",
+        "09:00",
+        "--timezone",
+        "UTC",
+        "--prompt",
+        "run daily check",
+      ]);
+
+      const logCalls = mockConsoleLog.mock.calls.flat().join("\n");
+      expect(logCalls).toContain("Automation");
+      expect(logCalls).toContain("created");
+      expect(logCalls).toContain("my-agent");
+    });
+
+    it("should create loop automation with interval flag", async () => {
+      const loopResponse = {
+        ...mockDeployResponse,
+        automation: {
+          ...mockDeployResponse.automation,
+          triggerType: "loop",
+          cronExpression: null,
+          intervalSeconds: 300,
+          nextRunAt: null,
+        },
+      };
+
+      server.use(
+        http.get("http://localhost:3000/api/agent/composes", ({ request }) => {
+          const url = new URL(request.url);
+          if (url.searchParams.get("name") !== "my-agent") {
+            return HttpResponse.json(
+              { error: { message: "Not found", code: "NOT_FOUND" } },
+              { status: 404 },
+            );
+          }
+          return HttpResponse.json(mockCompose);
+        }),
+        http.get("http://localhost:3000/api/automations", () => {
+          return HttpResponse.json({ automations: [] });
+        }),
+        http.post("http://localhost:3000/api/automations", () => {
+          return HttpResponse.json(loopResponse, { status: 201 });
+        }),
+      );
+
+      await setupCommand.parseAsync([
+        "node",
+        "cli",
+        "my-agent",
+        "--frequency",
+        "loop",
+        "--interval",
+        "300",
+        "--prompt",
+        "loop task",
+      ]);
+
+      const logCalls = mockConsoleLog.mock.calls.flat().join("\n");
+      expect(logCalls).toContain("Automation");
+      expect(logCalls).toContain("created");
+    });
+
+    it("should create automation when agent identifier is a UUID", async () => {
+      const testUuid = "550e8400-e29b-41d4-a716-446655440000";
+      const uuidCompose = { ...mockCompose, id: testUuid, name: "uuid-agent" };
+
+      server.use(
+        http.get(
+          "http://localhost:3000/api/agent/composes/:id",
+          ({ params }) => {
+            if (params.id !== testUuid) {
+              return HttpResponse.json(
+                { error: { message: "Not found", code: "NOT_FOUND" } },
+                { status: 404 },
+              );
+            }
+            return HttpResponse.json(uuidCompose);
+          },
+        ),
+        http.get("http://localhost:3000/api/automations", () => {
+          return HttpResponse.json({ automations: [] });
+        }),
+        http.post("http://localhost:3000/api/automations", () => {
+          return HttpResponse.json(mockDeployResponse, { status: 201 });
+        }),
+      );
+
+      await setupCommand.parseAsync([
+        "node",
+        "cli",
+        testUuid,
+        "--frequency",
+        "daily",
+        "--time",
+        "09:00",
+        "--timezone",
+        "UTC",
+        "--prompt",
+        "run daily check",
+      ]);
+
+      const logCalls = mockConsoleLog.mock.calls.flat().join("\n");
+      expect(logCalls).toContain("Automation");
+      expect(logCalls).toContain("created");
+    });
+
+    it("should update an existing automation via PUT", async () => {
+      const existingAutomation = {
+        ...mockDeployResponse.automation,
+        agentId: "comp_abc123",
+        prompt: "old prompt",
+        enabled: true,
+      };
+      const updateResponse = {
+        created: false,
+        automation: {
+          ...existingAutomation,
+          prompt: "run daily check",
+        },
+      };
+
+      let putHit = false;
+
+      server.use(
+        http.get("http://localhost:3000/api/agent/composes", ({ request }) => {
+          const url = new URL(request.url);
+          if (url.searchParams.get("name") !== "my-agent") {
+            return HttpResponse.json(
+              { error: { message: "Not found", code: "NOT_FOUND" } },
+              { status: 404 },
+            );
+          }
+          return HttpResponse.json(mockCompose);
+        }),
+        http.get("http://localhost:3000/api/automations", () => {
+          return HttpResponse.json({ automations: [existingAutomation] });
+        }),
+        http.put("http://localhost:3000/api/automations/default", () => {
+          putHit = true;
+          return HttpResponse.json(updateResponse, { status: 200 });
+        }),
+      );
+
+      await setupCommand.parseAsync([
+        "node",
+        "cli",
+        "my-agent",
+        "--frequency",
+        "daily",
+        "--time",
+        "09:00",
+        "--timezone",
+        "UTC",
+        "--prompt",
+        "run daily check",
+      ]);
+
+      expect(putHit).toBe(true);
+      const logCalls = mockConsoleLog.mock.calls.flat().join("\n");
+      expect(logCalls).toContain("Automation");
+      expect(logCalls).toContain("updated");
+    });
+  });
+
+  describe("prompt from file", () => {
+    let tmpDir: string;
+    let promptPath: string;
+
+    beforeEach(() => {
+      tmpDir = mkdtempSync(join(tmpdir(), "automation-prompt-"));
+      promptPath = join(tmpDir, "prompt.md");
+      writeFileSync(promptPath, "prompt loaded from file");
+    });
+
+    afterEach(() => {
+      rmSync(tmpDir, { recursive: true, force: true });
+    });
+
+    it("should send file content as prompt when --prompt-file is used", async () => {
+      let capturedPrompt: string | undefined;
+
+      server.use(
+        http.get("http://localhost:3000/api/agent/composes", ({ request }) => {
+          const url = new URL(request.url);
+          if (url.searchParams.get("name") !== "my-agent") {
+            return HttpResponse.json(
+              { error: { message: "Not found", code: "NOT_FOUND" } },
+              { status: 404 },
+            );
+          }
+          return HttpResponse.json(mockCompose);
+        }),
+        http.get("http://localhost:3000/api/automations", () => {
+          return HttpResponse.json({ automations: [] });
+        }),
+        http.post(
+          "http://localhost:3000/api/automations",
+          async ({ request }) => {
+            const body = (await request.json()) as { prompt: string };
+            capturedPrompt = body.prompt;
+            return HttpResponse.json(mockDeployResponse, { status: 201 });
+          },
+        ),
+      );
+
+      await setupCommand.parseAsync([
+        "node",
+        "cli",
+        "my-agent",
+        "--frequency",
+        "daily",
+        "--time",
+        "09:00",
+        "--timezone",
+        "UTC",
+        "--prompt-file",
+        promptPath,
+      ]);
+
+      expect(capturedPrompt).toBe("prompt loaded from file");
+      const logCalls = mockConsoleLog.mock.calls.flat().join("\n");
+      expect(logCalls).toContain("created");
+    });
+
+    it("should reject combining --prompt and --prompt-file", async () => {
+      server.use(
+        http.get("http://localhost:3000/api/agent/composes", ({ request }) => {
+          const url = new URL(request.url);
+          if (url.searchParams.get("name") !== "my-agent") {
+            return HttpResponse.json(
+              { error: { message: "Not found", code: "NOT_FOUND" } },
+              { status: 404 },
+            );
+          }
+          return HttpResponse.json(mockCompose);
+        }),
+        http.get("http://localhost:3000/api/automations", () => {
+          return HttpResponse.json({ automations: [] });
+        }),
+      );
+
+      await expect(async () => {
+        await setupCommand.parseAsync([
+          "node",
+          "cli",
+          "my-agent",
+          "--frequency",
+          "daily",
+          "--time",
+          "09:00",
+          "--timezone",
+          "UTC",
+          "--prompt",
+          "inline prompt",
+          "--prompt-file",
+          promptPath,
+        ]);
+      }).rejects.toThrow("process.exit called");
+
+      expect(mockConsoleError).toHaveBeenCalledWith(
+        expect.stringContaining(
+          "Cannot use --prompt and --prompt-file together",
+        ),
+      );
+      expect(mockExit).toHaveBeenCalledWith(1);
+    });
+  });
+
+  describe("help text", () => {
+    it("should include notification guidance in notes", () => {
+      // addHelpText content is not included in helpInformation(),
+      // so we capture it via the help event
+      let helpOutput = "";
+      setupCommand.configureOutput({
+        writeOut: (str: string) => {
+          helpOutput += str;
+        },
+      });
+      setupCommand.outputHelp();
+      expect(helpOutput).toContain("notified when an automation completes");
+      expect(helpOutput).toContain("web chat or Slack");
+    });
+  });
+
+  describe("error handling", () => {
+    it("should handle agent not found", async () => {
+      server.use(
+        http.get("http://localhost:3000/api/agent/composes", () => {
+          return HttpResponse.json(
+            { error: { message: "Agent not found", code: "NOT_FOUND" } },
+            { status: 404 },
+          );
+        }),
+      );
+
+      await expect(async () => {
+        await setupCommand.parseAsync([
+          "node",
+          "cli",
+          "missing",
+          "--frequency",
+          "daily",
+          "--time",
+          "09:00",
+          "--prompt",
+          "test",
+        ]);
+      }).rejects.toThrow("process.exit called");
+
+      expect(mockExit).toHaveBeenCalledWith(1);
+    });
+
+    it("should require --frequency in non-interactive mode", async () => {
+      server.use(
+        http.get("http://localhost:3000/api/agent/composes", ({ request }) => {
+          const url = new URL(request.url);
+          if (url.searchParams.get("name") !== "my-agent") {
+            return HttpResponse.json(
+              { error: { message: "Not found", code: "NOT_FOUND" } },
+              { status: 404 },
+            );
+          }
+          return HttpResponse.json(mockCompose);
+        }),
+        http.get("http://localhost:3000/api/automations", () => {
+          return HttpResponse.json({ automations: [] });
+        }),
+      );
+
+      await expect(async () => {
+        await setupCommand.parseAsync([
+          "node",
+          "cli",
+          "my-agent",
+          "--prompt",
+          "test",
+        ]);
+      }).rejects.toThrow("process.exit called");
+
+      expect(mockConsoleError).toHaveBeenCalledWith(
+        expect.stringContaining("--frequency is required"),
+      );
+      expect(mockExit).toHaveBeenCalledWith(1);
+    });
+  });
+});

--- a/turbo/apps/cli/src/commands/zero/automation/__tests__/status.test.ts
+++ b/turbo/apps/cli/src/commands/zero/automation/__tests__/status.test.ts
@@ -1,0 +1,233 @@
+/**
+ * Tests for zero automation status command
+ *
+ * Tests command-level behavior via parseAsync() following CLI testing principles:
+ * - Entry point: command.parseAsync()
+ * - Mock (external): Web API via MSW
+ * - Real (internal): All CLI code, formatters, validators
+ */
+
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { http, HttpResponse } from "msw";
+import { server } from "../../../../mocks/server";
+import { statusCommand } from "../status";
+import chalk from "chalk";
+
+const mockCompose = {
+  id: "compose-uuid-001",
+  name: "my-agent",
+  headVersionId: "ver-001",
+  content: null,
+  createdAt: "2026-03-23T00:00:00Z",
+  updatedAt: "2026-03-23T00:00:00Z",
+};
+
+const mockAutomation = {
+  id: "auto-001",
+  agentId: "compose-uuid-001",
+  userId: "user-001",
+  name: "default",
+  triggerType: "cron",
+  cronExpression: "0 9 * * *",
+  atTime: null,
+  intervalSeconds: null,
+  timezone: "UTC",
+  prompt: "run daily check",
+  description: null,
+  appendSystemPrompt: null,
+  enabled: true,
+  nextRunAt: "2026-03-24T09:00:00Z",
+  lastRunAt: null,
+  retryStartedAt: null,
+  consecutiveFailures: 0,
+  chatThreadId: "550e8400-e29b-41d4-a716-446655440099",
+  createdAt: "2026-03-23T00:00:00Z",
+  updatedAt: "2026-03-23T00:00:00Z",
+};
+
+describe("zero automation status command", () => {
+  const mockExit = vi.spyOn(process, "exit").mockImplementation((() => {
+    throw new Error("process.exit called");
+  }) as never);
+  const mockConsoleLog = vi.spyOn(console, "log").mockImplementation(() => {});
+  const mockConsoleError = vi
+    .spyOn(console, "error")
+    .mockImplementation(() => {});
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    chalk.level = 0;
+    vi.stubEnv("VM0_API_URL", "http://localhost:3000");
+    vi.stubEnv("VM0_TOKEN", "test-token");
+  });
+
+  describe("successful status", () => {
+    it("should display automation details", async () => {
+      server.use(
+        http.get("http://localhost:3000/api/agent/composes", () => {
+          return HttpResponse.json(mockCompose);
+        }),
+        http.get("http://localhost:3000/api/automations", () => {
+          return HttpResponse.json({ automations: [mockAutomation] });
+        }),
+      );
+
+      await statusCommand.parseAsync(["node", "cli", "my-agent"]);
+
+      const logCalls = mockConsoleLog.mock.calls.flat().join("\n");
+      expect(logCalls).toContain("my-agent");
+      expect(logCalls).toContain("enabled");
+      expect(logCalls).toContain("0 9 * * *");
+      expect(logCalls).toContain("run daily check");
+    });
+
+    it("should display automation with --name option", async () => {
+      const secondAutomation = {
+        ...mockAutomation,
+        name: "weekly",
+        cronExpression: "0 9 * * 1",
+      };
+      server.use(
+        http.get("http://localhost:3000/api/agent/composes", () => {
+          return HttpResponse.json(mockCompose);
+        }),
+        http.get("http://localhost:3000/api/automations", () => {
+          return HttpResponse.json({
+            automations: [mockAutomation, secondAutomation],
+          });
+        }),
+      );
+
+      await statusCommand.parseAsync([
+        "node",
+        "cli",
+        "my-agent",
+        "--name",
+        "weekly",
+      ]);
+
+      const logCalls = mockConsoleLog.mock.calls.flat().join("\n");
+      expect(logCalls).toContain("0 9 * * 1");
+    });
+
+    it("should show full prompt without truncation with --prompt flag", async () => {
+      const longPrompt =
+        "a".repeat(120) +
+        " this is clearly past the 60-character preview limit";
+      const longAutomation = { ...mockAutomation, prompt: longPrompt };
+
+      server.use(
+        http.get("http://localhost:3000/api/agent/composes", () => {
+          return HttpResponse.json(mockCompose);
+        }),
+        http.get("http://localhost:3000/api/automations", () => {
+          return HttpResponse.json({ automations: [longAutomation] });
+        }),
+      );
+
+      await statusCommand.parseAsync(["node", "cli", "my-agent", "--prompt"]);
+
+      const logCalls = mockConsoleLog.mock.calls.flat().join("\n");
+      expect(logCalls).toContain(longPrompt);
+      expect(logCalls).not.toMatch(/a{57}\.\.\./);
+    });
+
+    it("should truncate prompt preview without --prompt flag", async () => {
+      const longPrompt =
+        "a".repeat(120) +
+        " this is clearly past the 60-character preview limit";
+      const longAutomation = { ...mockAutomation, prompt: longPrompt };
+
+      server.use(
+        http.get("http://localhost:3000/api/agent/composes", () => {
+          return HttpResponse.json(mockCompose);
+        }),
+        http.get("http://localhost:3000/api/automations", () => {
+          return HttpResponse.json({ automations: [longAutomation] });
+        }),
+      );
+
+      await statusCommand.parseAsync(["node", "cli", "my-agent"]);
+
+      const logCalls = mockConsoleLog.mock.calls.flat().join("\n");
+      expect(logCalls).not.toContain(longPrompt);
+      expect(logCalls).toMatch(/a{57}\.\.\./);
+      expect(logCalls).toContain("--prompt");
+    });
+
+    it("should display automation when agent identifier is a UUID", async () => {
+      const testUuid = "550e8400-e29b-41d4-a716-446655440000";
+      const uuidCompose = { ...mockCompose, id: testUuid };
+      const uuidAutomation = { ...mockAutomation, agentId: testUuid };
+
+      server.use(
+        http.get(
+          "http://localhost:3000/api/agent/composes/:id",
+          ({ params }) => {
+            if (params.id !== testUuid) {
+              return HttpResponse.json(
+                { error: { message: "Not found", code: "NOT_FOUND" } },
+                { status: 404 },
+              );
+            }
+            return HttpResponse.json(uuidCompose);
+          },
+        ),
+        http.get("http://localhost:3000/api/automations", () => {
+          return HttpResponse.json({ automations: [uuidAutomation] });
+        }),
+      );
+
+      await statusCommand.parseAsync(["node", "cli", testUuid]);
+
+      const logCalls = mockConsoleLog.mock.calls.flat().join("\n");
+      expect(logCalls).toContain("0 9 * * *");
+      expect(logCalls).toContain("run daily check");
+    });
+  });
+
+  describe("error handling", () => {
+    it("should handle no automation found for agent", async () => {
+      server.use(
+        http.get("http://localhost:3000/api/agent/composes", () => {
+          return HttpResponse.json(mockCompose);
+        }),
+        http.get("http://localhost:3000/api/automations", () => {
+          return HttpResponse.json({ automations: [] });
+        }),
+      );
+
+      await expect(async () => {
+        await statusCommand.parseAsync(["node", "cli", "my-agent"]);
+      }).rejects.toThrow("process.exit called");
+
+      expect(mockConsoleError).toHaveBeenCalledWith(
+        expect.stringContaining("No automation found"),
+      );
+      expect(mockExit).toHaveBeenCalledWith(1);
+    });
+
+    it("should require --name when agent has multiple automations", async () => {
+      const secondAutomation = { ...mockAutomation, name: "weekly" };
+      server.use(
+        http.get("http://localhost:3000/api/agent/composes", () => {
+          return HttpResponse.json(mockCompose);
+        }),
+        http.get("http://localhost:3000/api/automations", () => {
+          return HttpResponse.json({
+            automations: [mockAutomation, secondAutomation],
+          });
+        }),
+      );
+
+      await expect(async () => {
+        await statusCommand.parseAsync(["node", "cli", "my-agent"]);
+      }).rejects.toThrow("process.exit called");
+
+      expect(mockConsoleError).toHaveBeenCalledWith(
+        expect.stringContaining("multiple automations"),
+      );
+      expect(mockExit).toHaveBeenCalledWith(1);
+    });
+  });
+});

--- a/turbo/apps/cli/src/commands/zero/automation/delete.ts
+++ b/turbo/apps/cli/src/commands/zero/automation/delete.ts
@@ -1,0 +1,60 @@
+import { Command } from "commander";
+import chalk from "chalk";
+import {
+  deleteZeroAutomation,
+  resolveZeroAutomationByAgent,
+} from "../../../lib/api";
+import { isInteractive, promptConfirm } from "../../../lib/utils/prompt-utils";
+import { withErrorHandler } from "../../../lib/command";
+
+export const deleteCommand = new Command()
+  .name("delete")
+  .alias("rm")
+  .description("Delete a zero automation")
+  .argument("<agent-id>", "Agent ID")
+  .option(
+    "-n, --name <automation-name>",
+    "Automation name (required when agent has multiple automations)",
+  )
+  .option("-y, --yes", "Skip confirmation prompt")
+  .addHelpText(
+    "after",
+    `
+Examples:
+  zero automation delete <agent-id>
+  zero automation delete <agent-id> -n my-automation -y
+
+Notes:
+  - Use -y to skip confirmation in non-interactive mode`,
+  )
+  .action(
+    withErrorHandler(
+      async (agentName: string, options: { name?: string; yes?: boolean }) => {
+        const resolved = await resolveZeroAutomationByAgent(
+          agentName,
+          options.name,
+        );
+
+        if (!options.yes) {
+          if (!isInteractive()) {
+            throw new Error("--yes flag is required in non-interactive mode");
+          }
+          const confirmed = await promptConfirm(
+            `Delete automation for agent ${chalk.cyan(agentName)}?`,
+            false,
+          );
+          if (!confirmed) {
+            console.log(chalk.dim("Cancelled"));
+            return;
+          }
+        }
+
+        await deleteZeroAutomation({
+          name: resolved.name,
+          agentId: resolved.agentId,
+        });
+
+        console.log(chalk.green(`✓ Automation "${resolved.name}" deleted`));
+      },
+    ),
+  );

--- a/turbo/apps/cli/src/commands/zero/automation/disable.ts
+++ b/turbo/apps/cli/src/commands/zero/automation/disable.ts
@@ -1,0 +1,38 @@
+import { Command } from "commander";
+import chalk from "chalk";
+import {
+  disableZeroAutomation,
+  resolveZeroAutomationByAgent,
+} from "../../../lib/api";
+import { withErrorHandler } from "../../../lib/command";
+
+export const disableCommand = new Command()
+  .name("disable")
+  .description("Disable a zero automation")
+  .argument("<agent-id>", "Agent ID")
+  .option(
+    "-n, --name <automation-name>",
+    "Automation name (required when agent has multiple automations)",
+  )
+  .addHelpText(
+    "after",
+    `
+Examples:
+  zero automation disable <agent-id>
+  zero automation disable <agent-id> -n my-automation`,
+  )
+  .action(
+    withErrorHandler(async (agentName: string, options: { name?: string }) => {
+      const resolved = await resolveZeroAutomationByAgent(
+        agentName,
+        options.name,
+      );
+
+      await disableZeroAutomation({
+        name: resolved.name,
+        agentId: resolved.agentId,
+      });
+
+      console.log(chalk.green(`✓ Automation "${resolved.name}" disabled`));
+    }),
+  );

--- a/turbo/apps/cli/src/commands/zero/automation/enable.ts
+++ b/turbo/apps/cli/src/commands/zero/automation/enable.ts
@@ -1,0 +1,38 @@
+import { Command } from "commander";
+import chalk from "chalk";
+import {
+  enableZeroAutomation,
+  resolveZeroAutomationByAgent,
+} from "../../../lib/api";
+import { withErrorHandler } from "../../../lib/command";
+
+export const enableCommand = new Command()
+  .name("enable")
+  .description("Enable a zero automation")
+  .argument("<agent-id>", "Agent ID")
+  .option(
+    "-n, --name <automation-name>",
+    "Automation name (required when agent has multiple automations)",
+  )
+  .addHelpText(
+    "after",
+    `
+Examples:
+  zero automation enable <agent-id>
+  zero automation enable <agent-id> -n my-automation`,
+  )
+  .action(
+    withErrorHandler(async (agentName: string, options: { name?: string }) => {
+      const resolved = await resolveZeroAutomationByAgent(
+        agentName,
+        options.name,
+      );
+
+      await enableZeroAutomation({
+        name: resolved.name,
+        agentId: resolved.agentId,
+      });
+
+      console.log(chalk.green(`✓ Automation "${resolved.name}" enabled`));
+    }),
+  );

--- a/turbo/apps/cli/src/commands/zero/automation/index.ts
+++ b/turbo/apps/cli/src/commands/zero/automation/index.ts
@@ -1,0 +1,28 @@
+import { Command } from "commander";
+import { setupCommand } from "./setup";
+import { listCommand } from "./list";
+import { statusCommand } from "./status";
+import { deleteCommand } from "./delete";
+import { enableCommand } from "./enable";
+import { disableCommand } from "./disable";
+
+export const zeroAutomationCommand = new Command()
+  .name("automation")
+  .description("Create or manage automations")
+  .addCommand(setupCommand)
+  .addCommand(listCommand)
+  .addCommand(statusCommand)
+  .addCommand(deleteCommand)
+  .addCommand(enableCommand)
+  .addCommand(disableCommand)
+  .addHelpText(
+    "after",
+    `
+Examples:
+  Create an automation:     zero automation setup --help
+  Check all automations:    zero automation list
+  Check automation status:  zero automation status <agent-id>
+  Pause an automation:      zero automation disable <agent-id>
+  Resume an automation:     zero automation enable <agent-id>
+  Delete an automation:     zero automation delete <agent-id>`,
+  );

--- a/turbo/apps/cli/src/commands/zero/automation/list.ts
+++ b/turbo/apps/cli/src/commands/zero/automation/list.ts
@@ -1,0 +1,82 @@
+import { Command } from "commander";
+import chalk from "chalk";
+import { listZeroAutomations } from "../../../lib/api";
+import { formatRelativeTime } from "../../../lib/domain/schedule-utils";
+import { withErrorHandler } from "../../../lib/command";
+
+export const listCommand = new Command()
+  .name("list")
+  .alias("ls")
+  .description("List all zero automations")
+  .addHelpText(
+    "after",
+    `
+Examples:
+  zero automation list`,
+  )
+  .action(
+    withErrorHandler(async () => {
+      const result = await listZeroAutomations();
+
+      if (result.automations.length === 0) {
+        console.log(chalk.dim("No automations found"));
+        console.log(
+          chalk.dim("  Create one with: zero automation setup <agent-id>"),
+        );
+        return;
+      }
+
+      const agentWidth = Math.max(
+        5,
+        ...result.automations.map((a) => {
+          return a.agentId.length;
+        }),
+      );
+      const automationWidth = Math.max(
+        10,
+        ...result.automations.map((a) => {
+          return a.name.length;
+        }),
+      );
+      const triggerWidth = Math.max(
+        7,
+        ...result.automations.map((a) => {
+          return a.cronExpression
+            ? a.cronExpression.length + a.timezone.length + 3
+            : a.atTime?.length || 0;
+        }),
+      );
+
+      const header = [
+        "AGENT".padEnd(agentWidth),
+        "AUTOMATION".padEnd(automationWidth),
+        "TRIGGER".padEnd(triggerWidth),
+        "STATUS".padEnd(8),
+        "NEXT RUN",
+      ].join("  ");
+      console.log(chalk.dim(header));
+
+      for (const automation of result.automations) {
+        const trigger = automation.cronExpression
+          ? `${automation.cronExpression} (${automation.timezone})`
+          : automation.atTime || "-";
+
+        const status = automation.enabled
+          ? chalk.green("enabled")
+          : chalk.yellow("disabled");
+
+        const nextRun = automation.enabled
+          ? formatRelativeTime(automation.nextRunAt)
+          : "-";
+
+        const row = [
+          automation.agentId.padEnd(agentWidth),
+          automation.name.padEnd(automationWidth),
+          trigger.padEnd(triggerWidth),
+          status.padEnd(8 + (automation.enabled ? 0 : 2)),
+          nextRun,
+        ].join("  ");
+        console.log(row);
+      }
+    }),
+  );

--- a/turbo/apps/cli/src/commands/zero/automation/setup.ts
+++ b/turbo/apps/cli/src/commands/zero/automation/setup.ts
@@ -1,0 +1,783 @@
+import { Command } from "commander";
+import { readFileSync } from "node:fs";
+import chalk from "chalk";
+import {
+  isInteractive,
+  promptText,
+  promptSelect,
+  promptConfirm,
+} from "../../../lib/utils/prompt-utils";
+import {
+  generateCronExpression,
+  detectTimezone,
+  validateTimeFormat,
+  validateDateFormat,
+  getTomorrowDateLocal,
+  getCurrentTimeLocal,
+  toISODateTime,
+  type ScheduleFrequency,
+} from "../../../lib/domain/schedule-utils";
+import {
+  resolveCompose,
+  deployZeroAutomation,
+  listZeroAutomations,
+  enableZeroAutomation,
+  getZeroUserPreferences,
+  ApiRequestError,
+} from "../../../lib/api";
+import { withErrorHandler } from "../../../lib/command";
+
+const FREQUENCY_CHOICES = [
+  { title: "Daily", value: "daily" as const, description: "Run every day" },
+  {
+    title: "Weekly",
+    value: "weekly" as const,
+    description: "Run once per week",
+  },
+  {
+    title: "Monthly",
+    value: "monthly" as const,
+    description: "Run once per month",
+  },
+  {
+    title: "One-time",
+    value: "once" as const,
+    description: "Run once at specific time",
+  },
+  {
+    title: "Loop",
+    value: "loop" as const,
+    description: "Run repeatedly at fixed intervals",
+  },
+];
+
+const DAY_OF_WEEK_CHOICES = [
+  { title: "Monday", value: 1 },
+  { title: "Tuesday", value: 2 },
+  { title: "Wednesday", value: 3 },
+  { title: "Thursday", value: 4 },
+  { title: "Friday", value: 5 },
+  { title: "Saturday", value: 6 },
+  { title: "Sunday", value: 0 },
+];
+
+function parseDayOption(
+  day: string,
+  frequency: ScheduleFrequency,
+): number | undefined {
+  if (frequency === "weekly") {
+    const dayMap: Record<string, number> = {
+      sun: 0,
+      mon: 1,
+      tue: 2,
+      wed: 3,
+      thu: 4,
+      fri: 5,
+      sat: 6,
+    };
+    return dayMap[day.toLowerCase()];
+  } else if (frequency === "monthly") {
+    const num = parseInt(day, 10);
+    if (num >= 1 && num <= 31) {
+      return num;
+    }
+  }
+  return undefined;
+}
+
+function formatInTimezone(isoDate: string, timezone: string): string {
+  const date = new Date(isoDate);
+  const parts = new Intl.DateTimeFormat("en-CA", {
+    timeZone: timezone,
+    year: "numeric",
+    month: "2-digit",
+    day: "2-digit",
+    hour: "2-digit",
+    minute: "2-digit",
+    hour12: false,
+  }).formatToParts(date);
+
+  const get = (type: string) => {
+    return (
+      parts.find((p) => {
+        return p.type === type;
+      })?.value ?? ""
+    );
+  };
+  return `${get("year")}-${get("month")}-${get("day")} ${get("hour")}:${get("minute")}`;
+}
+
+function parseFrequencyFromCron(
+  cron: string,
+): { frequency: ScheduleFrequency; day?: number; time: string } | null {
+  const parts = cron.split(" ");
+  if (parts.length !== 5) return null;
+
+  const [minute, hour, dayOfMonth, , dayOfWeek] = parts;
+  const time = `${hour!.padStart(2, "0")}:${minute!.padStart(2, "0")}`;
+
+  if (dayOfMonth === "*" && dayOfWeek === "*") {
+    return { frequency: "daily", time };
+  } else if (dayOfMonth === "*" && dayOfWeek !== "*") {
+    return { frequency: "weekly", day: parseInt(dayOfWeek!, 10), time };
+  } else if (dayOfMonth !== "*" && dayOfWeek === "*") {
+    return { frequency: "monthly", day: parseInt(dayOfMonth!, 10), time };
+  }
+
+  return null;
+}
+
+interface SetupOptions {
+  name?: string;
+  frequency?: string;
+  time?: string;
+  day?: string;
+  interval?: string;
+  timezone?: string;
+  prompt?: string;
+  promptFile?: string;
+  enable?: boolean;
+}
+
+interface ExistingAutomationDefaults {
+  frequency?: ScheduleFrequency;
+  day?: number;
+  time?: string;
+  intervalSeconds?: number;
+}
+
+interface AutomationListItem {
+  name: string;
+  agentId: string;
+  triggerType?: "cron" | "once" | "loop";
+  cronExpression?: string | null;
+  atTime?: string | null;
+  intervalSeconds?: number | null;
+  timezone: string;
+  prompt: string;
+  enabled?: boolean;
+}
+
+function getExistingDefaults(
+  existingAutomation: AutomationListItem | undefined,
+): ExistingAutomationDefaults {
+  const defaults: ExistingAutomationDefaults = {};
+
+  if (existingAutomation?.triggerType === "loop") {
+    defaults.frequency = "loop";
+    defaults.intervalSeconds = existingAutomation.intervalSeconds ?? undefined;
+  } else if (existingAutomation?.cronExpression) {
+    const parsed = parseFrequencyFromCron(existingAutomation.cronExpression);
+    if (parsed) {
+      defaults.frequency = parsed.frequency;
+      defaults.day = parsed.day;
+      defaults.time = parsed.time;
+    }
+  } else if (existingAutomation?.atTime) {
+    defaults.frequency = "once";
+  }
+
+  return defaults;
+}
+
+async function gatherFrequency(
+  optionFrequency: string | undefined,
+  existingFrequency: ScheduleFrequency | undefined,
+): Promise<ScheduleFrequency | null> {
+  let frequency = optionFrequency as ScheduleFrequency | undefined;
+
+  if (
+    frequency &&
+    ["daily", "weekly", "monthly", "once", "loop"].includes(frequency)
+  ) {
+    return frequency;
+  }
+
+  if (!isInteractive()) {
+    throw new Error("--frequency is required (daily|weekly|monthly|once|loop)");
+  }
+
+  const defaultIndex = existingFrequency
+    ? FREQUENCY_CHOICES.findIndex((c) => {
+        return c.value === existingFrequency;
+      })
+    : 0;
+
+  frequency = await promptSelect<ScheduleFrequency>(
+    "Automation frequency",
+    FREQUENCY_CHOICES,
+    defaultIndex >= 0 ? defaultIndex : 0,
+  );
+
+  return frequency || null;
+}
+
+async function gatherDay(
+  frequency: ScheduleFrequency,
+  optionDay: string | undefined,
+  existingDay: number | undefined,
+): Promise<number | null> {
+  if (frequency !== "weekly" && frequency !== "monthly") {
+    return null;
+  }
+
+  if (optionDay) {
+    const day = parseDayOption(optionDay, frequency);
+    if (day === undefined) {
+      throw new Error(
+        `Invalid day: ${optionDay}. Use mon-sun for weekly or 1-31 for monthly.`,
+      );
+    }
+    return day;
+  }
+
+  if (!isInteractive()) {
+    throw new Error("--day is required for weekly/monthly");
+  }
+
+  if (frequency === "weekly") {
+    const defaultDayIndex =
+      existingDay !== undefined
+        ? DAY_OF_WEEK_CHOICES.findIndex((c) => {
+            return c.value === existingDay;
+          })
+        : 0;
+    const day = await promptSelect(
+      "Day of week",
+      DAY_OF_WEEK_CHOICES,
+      defaultDayIndex >= 0 ? defaultDayIndex : 0,
+    );
+    return day ?? null;
+  }
+
+  const dayStr = await promptText(
+    "Day of month (1-31)",
+    existingDay?.toString() || "1",
+  );
+  if (!dayStr) return null;
+
+  const day = parseInt(dayStr, 10);
+  if (isNaN(day) || day < 1 || day > 31) {
+    throw new Error("Day must be between 1 and 31");
+  }
+  return day;
+}
+
+async function gatherRecurringTime(
+  optionTime: string | undefined,
+  existingTime: string | undefined,
+): Promise<string | undefined> {
+  if (optionTime) {
+    const validation = validateTimeFormat(optionTime);
+    if (validation !== true) {
+      throw new Error(`Invalid time: ${validation}`);
+    }
+    return optionTime;
+  }
+
+  if (!isInteractive()) {
+    throw new Error("--time is required (HH:MM format)");
+  }
+
+  return await promptText(
+    "Time (HH:MM)",
+    existingTime || "09:00",
+    validateTimeFormat,
+  );
+}
+
+async function gatherOneTimeSchedule(
+  optionDay: string | undefined,
+  optionTime: string | undefined,
+  existingTime: string | undefined,
+): Promise<string | null> {
+  if (optionDay && optionTime) {
+    if (!validateDateFormat(optionDay)) {
+      throw new Error(
+        `Invalid date format: ${optionDay}. Use YYYY-MM-DD format.`,
+      );
+    }
+    if (!validateTimeFormat(optionTime)) {
+      throw new Error(`Invalid time format: ${optionTime}. Use HH:MM format.`);
+    }
+    return `${optionDay} ${optionTime}`;
+  }
+
+  if (!isInteractive()) {
+    throw new Error("One-time automations require interactive mode", {
+      cause: new Error(
+        "Or provide --day (YYYY-MM-DD) and --time (HH:MM) flags",
+      ),
+    });
+  }
+
+  const tomorrowDate = getTomorrowDateLocal();
+  const date = await promptText(
+    "Date (YYYY-MM-DD, default tomorrow)",
+    tomorrowDate,
+    validateDateFormat,
+  );
+  if (!date) return null;
+
+  const currentTime = getCurrentTimeLocal();
+  const time = await promptText(
+    "Time (HH:MM)",
+    existingTime || currentTime,
+    validateTimeFormat,
+  );
+  if (!time) return null;
+
+  return `${date} ${time}`;
+}
+
+async function gatherTimezone(
+  optionTimezone: string | undefined,
+  existingTimezone: string | undefined | null,
+): Promise<string | undefined> {
+  if (optionTimezone) return optionTimezone;
+
+  let userTimezone: string | null = null;
+  try {
+    const prefs = await getZeroUserPreferences();
+    userTimezone = prefs.timezone;
+  } catch {
+    console.log(
+      chalk.dim("Could not fetch timezone preference, using detected timezone"),
+    );
+  }
+
+  const defaultTimezone = userTimezone || detectTimezone();
+
+  if (!isInteractive()) {
+    return defaultTimezone;
+  }
+
+  return await promptText("Timezone", existingTimezone || defaultTimezone);
+}
+
+async function gatherPromptText(
+  optionPrompt: string | undefined,
+  optionPromptFile: string | undefined,
+  existingPrompt: string | undefined | null,
+): Promise<string | undefined> {
+  if (optionPrompt && optionPromptFile) {
+    throw new Error("Cannot use --prompt and --prompt-file together");
+  }
+
+  if (optionPromptFile) {
+    return readFileSync(optionPromptFile, "utf-8");
+  }
+
+  if (optionPrompt) return optionPrompt;
+
+  if (!isInteractive()) {
+    throw new Error("--prompt or --prompt-file is required");
+  }
+
+  return await promptText(
+    "Prompt to run",
+    existingPrompt || "let's start working.",
+  );
+}
+
+async function gatherInterval(
+  optionInterval: string | undefined,
+  existingInterval: number | undefined,
+): Promise<number | null> {
+  if (optionInterval) {
+    const val = parseInt(optionInterval, 10);
+    if (isNaN(val) || val < 0) {
+      throw new Error(
+        "Invalid interval. Must be a non-negative integer (seconds)",
+      );
+    }
+    return val;
+  }
+
+  if (!isInteractive()) {
+    throw new Error("--interval is required for loop automations (seconds)");
+  }
+
+  const defaultVal =
+    existingInterval !== undefined ? String(existingInterval) : "300";
+  const result = await promptText(
+    "Interval in seconds (time between runs)",
+    defaultVal,
+    (v: string) => {
+      const n = parseInt(v, 10);
+      if (isNaN(n) || n < 0) return "Must be a non-negative integer";
+      return true;
+    },
+  );
+  if (!result) return null;
+  return parseInt(result, 10);
+}
+
+async function gatherTiming(
+  frequency: ScheduleFrequency,
+  options: SetupOptions,
+  defaults: ExistingAutomationDefaults,
+): Promise<{
+  day: number | undefined;
+  time: string | undefined;
+  atTime: string | undefined;
+  intervalSeconds: number | undefined;
+} | null> {
+  if (frequency === "loop") {
+    const intervalSeconds = await gatherInterval(
+      options.interval,
+      defaults.intervalSeconds,
+    );
+    if (intervalSeconds === null) return null;
+    return {
+      day: undefined,
+      time: undefined,
+      atTime: undefined,
+      intervalSeconds,
+    };
+  }
+
+  if (frequency === "once") {
+    const result = await gatherOneTimeSchedule(
+      options.day,
+      options.time,
+      defaults.time,
+    );
+    if (!result) return null;
+    return {
+      day: undefined,
+      time: undefined,
+      atTime: result,
+      intervalSeconds: undefined,
+    };
+  }
+
+  const day =
+    (await gatherDay(frequency, options.day, defaults.day)) ?? undefined;
+  if (day === null && (frequency === "weekly" || frequency === "monthly")) {
+    return null;
+  }
+
+  const time = await gatherRecurringTime(options.time, defaults.time);
+  if (!time) return null;
+
+  return { day, time, atTime: undefined, intervalSeconds: undefined };
+}
+
+async function findExistingAutomation(
+  agentId: string,
+  automationName: string,
+): Promise<AutomationListItem | undefined> {
+  const { automations } = await listZeroAutomations();
+  return automations.find((a) => {
+    return a.agentId === agentId && a.name === automationName;
+  });
+}
+
+interface DeployResult {
+  created: boolean;
+  automation: {
+    triggerType?: "cron" | "once" | "loop";
+    timezone: string;
+    cronExpression?: string | null;
+    nextRunAt?: string | null;
+    atTime?: string | null;
+    intervalSeconds?: number | null;
+  };
+}
+
+async function buildAndDeploy(params: {
+  automationName: string;
+  agentId: string;
+  agentName: string;
+  frequency: ScheduleFrequency;
+  time: string | undefined;
+  day: number | undefined;
+  atTime: string | undefined;
+  intervalSeconds: number | undefined;
+  timezone: string;
+  prompt: string;
+  existingEnabled: boolean | undefined;
+  chatThreadId: string | undefined;
+  isUpdate: boolean;
+}): Promise<DeployResult> {
+  let cronExpression: string | undefined;
+  let atTimeISO: string | undefined;
+
+  if (params.frequency === "loop") {
+    // Loop mode: intervalSeconds is passed directly
+  } else if (params.atTime) {
+    atTimeISO = toISODateTime(params.atTime);
+  } else if (params.time && params.frequency !== "once") {
+    cronExpression = generateCronExpression(
+      params.frequency,
+      params.time,
+      params.day,
+    );
+  }
+
+  console.log(
+    `\nDeploying automation for agent ${chalk.cyan(params.agentName)}...`,
+  );
+
+  // Preserve enabled state on update so loop automations don't lose nextRunAt.
+  // On create, existingEnabled is undefined → omit the field so the server
+  // applies its default (disabled; enable happens later via the enable flow).
+  return await deployZeroAutomation(
+    {
+      name: params.automationName,
+      agentId: params.agentId,
+      cronExpression,
+      atTime: atTimeISO,
+      intervalSeconds: params.intervalSeconds,
+      timezone: params.timezone,
+      prompt: params.prompt,
+      ...(params.existingEnabled !== undefined && {
+        enabled: params.existingEnabled,
+      }),
+      ...(params.chatThreadId !== undefined && {
+        chatThreadId: params.chatThreadId,
+      }),
+    },
+    { update: params.isUpdate },
+  );
+}
+
+function displayDeployResult(
+  automationName: string,
+  deployResult: DeployResult,
+): void {
+  if (deployResult.created) {
+    console.log(chalk.green(`✓ Automation "${automationName}" created`));
+  } else {
+    console.log(chalk.green(`✓ Automation "${automationName}" updated`));
+  }
+
+  console.log(chalk.dim(`  Timezone: ${deployResult.automation.timezone}`));
+
+  if (
+    deployResult.automation.triggerType === "loop" &&
+    deployResult.automation.intervalSeconds != null
+  ) {
+    console.log(
+      chalk.dim(
+        `  Mode: Loop (interval ${deployResult.automation.intervalSeconds}s)`,
+      ),
+    );
+  } else if (deployResult.automation.cronExpression) {
+    console.log(chalk.dim(`  Cron: ${deployResult.automation.cronExpression}`));
+    if (deployResult.automation.nextRunAt) {
+      const nextRun = formatInTimezone(
+        deployResult.automation.nextRunAt,
+        deployResult.automation.timezone,
+      );
+      console.log(chalk.dim(`  Next run: ${nextRun}`));
+    }
+  } else if (deployResult.automation.atTime) {
+    const atTimeFormatted = formatInTimezone(
+      deployResult.automation.atTime,
+      deployResult.automation.timezone,
+    );
+    console.log(chalk.dim(`  At: ${atTimeFormatted}`));
+  }
+}
+
+async function tryEnableAutomation(
+  automationName: string,
+  agentId: string,
+  agentName: string,
+): Promise<void> {
+  try {
+    await enableZeroAutomation({ name: automationName, agentId });
+    console.log(chalk.green(`✓ Automation "${automationName}" enabled`));
+  } catch (error) {
+    console.error(chalk.yellow("⚠ Failed to enable automation"));
+    if (error instanceof ApiRequestError) {
+      if (error.code === "SCHEDULE_PAST") {
+        console.error(chalk.dim("  Scheduled time has already passed"));
+      } else {
+        console.error(chalk.dim(`  ${error.message}`));
+      }
+    } else if (error instanceof Error) {
+      console.error(chalk.dim(`  ${error.message}`));
+    }
+    console.log(
+      `  To enable manually: ${chalk.cyan(`zero automation enable ${agentName}`)}`,
+    );
+  }
+}
+
+function showEnableHint(agentName: string): void {
+  console.log();
+  console.log(
+    `  To enable: ${chalk.cyan(`zero automation enable ${agentName}`)}`,
+  );
+}
+
+async function handleAutomationEnabling(params: {
+  automationName: string;
+  agentId: string;
+  agentName: string;
+  enableFlag: boolean;
+  shouldPromptEnable: boolean;
+}): Promise<void> {
+  const { automationName, agentId, agentName, enableFlag, shouldPromptEnable } =
+    params;
+
+  if (enableFlag) {
+    await tryEnableAutomation(automationName, agentId, agentName);
+    return;
+  }
+
+  if (shouldPromptEnable && isInteractive()) {
+    const enableNow = await promptConfirm("Enable this automation?", true);
+    if (enableNow) {
+      await tryEnableAutomation(automationName, agentId, agentName);
+    } else {
+      showEnableHint(agentName);
+    }
+    return;
+  }
+
+  if (shouldPromptEnable) {
+    showEnableHint(agentName);
+  }
+}
+
+export const setupCommand = new Command()
+  .name("setup")
+  .description("Create or edit an automation for a zero agent")
+  .argument("<agent-id>", "Agent ID")
+  .option(
+    "-n, --name <automation-name>",
+    'Automation name (default: "default")',
+  )
+  .option("-f, --frequency <type>", "Frequency: daily|weekly|monthly|once|loop")
+  .option("-t, --time <HH:MM>", "Time to run (24-hour format)")
+  .option("-d, --day <day>", "Day of week (mon-sun) or day of month (1-31)")
+  .option("-i, --interval <seconds>", "Interval in seconds for loop mode")
+  .option("-z, --timezone <tz>", "IANA timezone")
+  .option("-p, --prompt <text>", "Prompt to run")
+  .option(
+    "--prompt-file <path>",
+    "Read prompt from file (cannot be used with --prompt)",
+  )
+  .option("-e, --enable", "Enable automation immediately after creation")
+  .addHelpText(
+    "after",
+    `
+Examples:
+  Daily at 9am:          zero automation setup <agent-id> -f daily -t 09:00 -p "run report"
+  Weekly on Monday:      zero automation setup <agent-id> -f weekly -d mon -t 10:00 -p "weekly sync"
+  Monthly on the 1st:    zero automation setup <agent-id> -f monthly -d 1 -t 08:00 -p "monthly review"
+  One-time:              zero automation setup <agent-id> -f once -d 2026-04-01 -t 14:00 -p "one-off task"
+  Loop every 5 minutes:  zero automation setup <agent-id> -f loop -i 300 -p "poll for updates"
+  Prompt from file:      zero automation setup <agent-id> -f daily -t 09:00 --prompt-file ./prompt.md
+  Create and enable:     zero automation setup <agent-id> -f daily -t 09:00 -p "run report" --enable
+
+Notes:
+  - Re-running setup with the same agent updates the existing "default" automation
+  - Use -n to manage multiple named automations for the same agent
+  - All flags are required in non-interactive mode; interactive mode prompts for missing values
+  - If the user wants to be notified when an automation completes, ask them where they want to receive the notification: web chat or Slack, then include it in the prompt`,
+  )
+  .action(
+    withErrorHandler(async (agentIdentifier: string, options: SetupOptions) => {
+      // 1. Resolve agent identifier (UUID or name) to compose ID
+      const compose = await resolveCompose(agentIdentifier);
+      if (!compose) {
+        throw new Error(`Agent not found: ${agentIdentifier}`);
+      }
+      const agentId = compose.id;
+      const automationName = options.name || "default";
+
+      // 2. Check for existing automation
+      const existingAutomation = await findExistingAutomation(
+        agentId,
+        automationName,
+      );
+
+      const agentName = compose.name;
+      console.log(
+        chalk.dim(
+          existingAutomation
+            ? `Editing existing automation for agent ${agentName}`
+            : `Creating new automation for agent ${agentName}`,
+        ),
+      );
+
+      const defaults = getExistingDefaults(existingAutomation);
+
+      // 3. Gather frequency
+      const frequency = await gatherFrequency(
+        options.frequency,
+        defaults.frequency,
+      );
+      if (!frequency) {
+        console.log(chalk.dim("Cancelled"));
+        return;
+      }
+
+      // 4. Gather day and time
+      const timing = await gatherTiming(frequency, options, defaults);
+      if (!timing) {
+        console.log(chalk.dim("Cancelled"));
+        return;
+      }
+      const { day, time, atTime, intervalSeconds } = timing;
+
+      // 5. Gather timezone
+      const timezone = await gatherTimezone(
+        options.timezone,
+        existingAutomation?.timezone,
+      );
+      if (!timezone) {
+        console.log(chalk.dim("Cancelled"));
+        return;
+      }
+
+      // 6. Gather prompt
+      const promptText_ = await gatherPromptText(
+        options.prompt,
+        options.promptFile,
+        existingAutomation?.prompt,
+      );
+      if (!promptText_) {
+        console.log(chalk.dim("Cancelled"));
+        return;
+      }
+
+      // 7. Build trigger and deploy
+      const deployResult = await buildAndDeploy({
+        automationName,
+        agentId,
+        agentName,
+        frequency,
+        time,
+        day,
+        atTime,
+        intervalSeconds,
+        timezone,
+        prompt: promptText_,
+        existingEnabled: existingAutomation?.enabled,
+        chatThreadId: process.env.ZERO_CHAT_THREAD_ID,
+        isUpdate: existingAutomation !== undefined,
+      });
+
+      // 8. Display deployment result
+      displayDeployResult(automationName, deployResult);
+
+      // 9. Handle automation enabling
+      const shouldPromptEnable =
+        deployResult.created ||
+        (existingAutomation !== undefined && !existingAutomation.enabled);
+
+      await handleAutomationEnabling({
+        automationName,
+        agentId,
+        agentName,
+        enableFlag: options.enable ?? false,
+        shouldPromptEnable,
+      });
+    }),
+  );

--- a/turbo/apps/cli/src/commands/zero/automation/status.ts
+++ b/turbo/apps/cli/src/commands/zero/automation/status.ts
@@ -1,0 +1,130 @@
+import { Command } from "commander";
+import chalk from "chalk";
+import { resolveZeroAutomationByAgent } from "../../../lib/api";
+import {
+  formatDateTime,
+  detectTimezone,
+} from "../../../lib/domain/schedule-utils";
+import { withErrorHandler } from "../../../lib/command";
+import type { AutomationResponse } from "@vm0/api-contracts/contracts/automations";
+
+/**
+ * Format date with styled relative time (adds chalk formatting)
+ */
+function formatDateTimeStyled(dateStr: string | null): string {
+  if (!dateStr) return chalk.dim("-");
+  const formatted = formatDateTime(dateStr);
+  return formatted.replace(/\(([^)]+)\)$/, chalk.dim("($1)"));
+}
+
+/**
+ * Format trigger (cron or at) - timezone shown separately
+ */
+function formatTrigger(automation: AutomationResponse): string {
+  if (
+    automation.triggerType === "loop" &&
+    automation.intervalSeconds !== null
+  ) {
+    return `interval ${automation.intervalSeconds}s ${chalk.dim("(loop)")}`;
+  }
+  if (automation.cronExpression) {
+    return automation.cronExpression;
+  }
+  if (automation.atTime) {
+    return `${automation.atTime} ${chalk.dim("(one-time)")}`;
+  }
+  return chalk.dim("-");
+}
+
+/**
+ * Print run configuration section
+ */
+function printRunConfiguration(
+  automation: AutomationResponse,
+  showFullPrompt: boolean,
+): void {
+  const statusText = automation.enabled
+    ? chalk.green("enabled")
+    : chalk.yellow("disabled");
+  console.log(`${"Status:".padEnd(16)}${statusText}`);
+
+  console.log(`${"Agent:".padEnd(16)}${automation.agentId}`);
+
+  if (showFullPrompt) {
+    console.log(`${"Prompt:".padEnd(16)}${chalk.dim(automation.prompt)}`);
+  } else {
+    const truncated = automation.prompt.length > 60;
+    const promptPreview = truncated
+      ? automation.prompt.slice(0, 57) + "..."
+      : automation.prompt;
+    console.log(`${"Prompt:".padEnd(16)}${chalk.dim(promptPreview)}`);
+    if (truncated) {
+      console.log(
+        chalk.dim("                Run with --prompt (-p) to see full prompt"),
+      );
+    }
+  }
+}
+
+/**
+ * Print time schedule section
+ */
+function printTimeSchedule(automation: AutomationResponse): void {
+  console.log();
+  console.log(`${"Trigger:".padEnd(16)}${formatTrigger(automation)}`);
+  console.log(`${"Timezone:".padEnd(16)}${detectTimezone()}`);
+
+  if (automation.enabled) {
+    console.log(
+      `${"Next Run:".padEnd(16)}${formatDateTimeStyled(automation.nextRunAt)}`,
+    );
+  }
+
+  if (automation.triggerType === "loop" || automation.triggerType === "cron") {
+    const failureText =
+      automation.consecutiveFailures > 0
+        ? chalk.yellow(`${automation.consecutiveFailures}/3`)
+        : chalk.dim("0/3");
+    console.log(`${"Failures:".padEnd(16)}${failureText}`);
+  }
+}
+
+export const statusCommand = new Command()
+  .name("status")
+  .description("Show detailed status of a zero automation")
+  .argument("<agent-id>", "Agent ID")
+  .option(
+    "-n, --name <automation-name>",
+    "Automation name (required when agent has multiple automations)",
+  )
+  .option("-p, --prompt", "Show full prompt content without truncation")
+  .addHelpText(
+    "after",
+    `
+Examples:
+  zero automation status <agent-id>
+  zero automation status <agent-id> -n my-automation
+  zero automation status <agent-id> --prompt`,
+  )
+  .action(
+    withErrorHandler(
+      async (
+        agentName: string,
+        options: { name?: string; prompt?: boolean },
+      ) => {
+        const automation = await resolveZeroAutomationByAgent(
+          agentName,
+          options.name,
+        );
+
+        console.log();
+        console.log(`Automation for agent: ${chalk.cyan(agentName)}`);
+        console.log(chalk.dim("━".repeat(50)));
+
+        printRunConfiguration(automation, options.prompt ?? false);
+        printTimeSchedule(automation);
+
+        console.log();
+      },
+    ),
+  );

--- a/turbo/apps/cli/src/lib/api/domains/zero-automations.ts
+++ b/turbo/apps/cli/src/lib/api/domains/zero-automations.ts
@@ -1,0 +1,204 @@
+import { initClient } from "@ts-rest/core";
+import {
+  automationsMainContract,
+  automationsByNameContract,
+  automationsEnableContract,
+} from "@vm0/api-contracts/contracts/automations";
+import { getClientConfig, handleError } from "../core/client-factory";
+import type {
+  AutomationResponse,
+  AutomationListResponse,
+  AutomationMutationResponse,
+} from "@vm0/api-contracts/contracts/automations";
+import { resolveCompose } from "./composes";
+
+/**
+ * Deploy a zero automation.
+ *
+ * The Automations API splits the legacy schedule upsert into create
+ * (POST /api/automations) and update (PUT /api/automations/:name). The caller
+ * decides which one applies via the `update` flag; both endpoints return the
+ * same `{ automation, created }` mutation shape.
+ */
+export async function deployZeroAutomation(
+  body: {
+    name: string;
+    agentId: string;
+    cronExpression?: string;
+    atTime?: string;
+    intervalSeconds?: number;
+    timezone?: string;
+    prompt: string;
+    description?: string;
+    appendSystemPrompt?: string;
+    enabled?: boolean;
+    chatThreadId?: string;
+  },
+  options: { update: boolean },
+): Promise<AutomationMutationResponse> {
+  const config = await getClientConfig();
+
+  if (options.update) {
+    const client = initClient(automationsByNameContract, config);
+    const { name, ...rest } = body;
+    const result = await client.update({ params: { name }, body: rest });
+
+    if (result.status === 200 || result.status === 201) {
+      return result.body;
+    }
+
+    handleError(result, "Failed to update automation");
+  }
+
+  const client = initClient(automationsMainContract, config);
+  const result = await client.create({ body });
+
+  if (result.status === 200 || result.status === 201) {
+    return result.body;
+  }
+
+  handleError(result, "Failed to create automation");
+}
+
+/**
+ * List all zero automations
+ */
+export async function listZeroAutomations(): Promise<AutomationListResponse> {
+  const config = await getClientConfig();
+  const client = initClient(automationsMainContract, config);
+
+  const result = await client.list({ headers: {} });
+
+  if (result.status === 200) {
+    return result.body;
+  }
+
+  handleError(result, "Failed to list automations");
+}
+
+/**
+ * Delete zero automation by name
+ */
+export async function deleteZeroAutomation(params: {
+  name: string;
+  agentId: string;
+}): Promise<void> {
+  const config = await getClientConfig();
+  const client = initClient(automationsByNameContract, config);
+
+  const result = await client.delete({
+    params: { name: params.name },
+    query: { agentId: params.agentId },
+  });
+
+  if (result.status === 204) {
+    return;
+  }
+
+  handleError(result, `Automation "${params.name}" not found on remote`);
+}
+
+/**
+ * Enable zero automation
+ */
+export async function enableZeroAutomation(params: {
+  name: string;
+  agentId: string;
+}): Promise<AutomationResponse> {
+  const config = await getClientConfig();
+  const client = initClient(automationsEnableContract, config);
+
+  const result = await client.enable({
+    params: { name: params.name },
+    body: { agentId: params.agentId },
+  });
+
+  if (result.status === 200) {
+    return result.body;
+  }
+
+  handleError(result, `Failed to enable automation "${params.name}"`);
+}
+
+/**
+ * Disable zero automation
+ */
+export async function disableZeroAutomation(params: {
+  name: string;
+  agentId: string;
+}): Promise<AutomationResponse> {
+  const config = await getClientConfig();
+  const client = initClient(automationsEnableContract, config);
+
+  const result = await client.disable({
+    params: { name: params.name },
+    body: { agentId: params.agentId },
+  });
+
+  if (result.status === 200) {
+    return result.body;
+  }
+
+  handleError(result, `Failed to disable automation "${params.name}"`);
+}
+
+/**
+ * Resolve a zero automation by agent identifier (UUID or name) using the list
+ * API. Searches across all of the user's automations and finds by agentId.
+ *
+ * Returns the full AutomationResponse so callers can access any field.
+ * When an agent has multiple automations, automationName is required for
+ * disambiguation. When an agent has exactly one automation, automationName is
+ * optional.
+ *
+ * @throws Error if agent has no automation or disambiguation is needed
+ */
+export async function resolveZeroAutomationByAgent(
+  agentIdentifier: string,
+  automationName?: string,
+): Promise<AutomationResponse> {
+  const compose = await resolveCompose(agentIdentifier);
+  if (!compose) {
+    throw new Error(`Agent not found: ${agentIdentifier}`);
+  }
+
+  const { automations } = await listZeroAutomations();
+
+  const agentAutomations = automations.filter((a) => {
+    return a.agentId === compose.id;
+  });
+
+  if (agentAutomations.length === 0) {
+    throw new Error(`No automation found for agent "${agentIdentifier}"`);
+  }
+
+  if (automationName) {
+    const match = agentAutomations.find((a) => {
+      return a.name === automationName;
+    });
+    if (!match) {
+      const available = agentAutomations
+        .map((a) => {
+          return a.name;
+        })
+        .join(", ");
+      throw new Error(
+        `Automation "${automationName}" not found for agent "${agentIdentifier}". Available automations: ${available}`,
+      );
+    }
+    return match;
+  }
+
+  if (agentAutomations.length === 1) {
+    return agentAutomations[0]!;
+  }
+
+  const available = agentAutomations
+    .map((a) => {
+      return a.name;
+    })
+    .join(", ");
+  throw new Error(
+    `Agent "${agentIdentifier}" has multiple automations. Use --name to specify which one: ${available}`,
+  );
+}

--- a/turbo/apps/cli/src/lib/api/index.ts
+++ b/turbo/apps/cli/src/lib/api/index.ts
@@ -174,6 +174,16 @@ export {
   resolveZeroScheduleByAgent,
 } from "./domains/zero-schedules";
 
+// Domain modules - Zero Automations
+export {
+  deployZeroAutomation,
+  listZeroAutomations,
+  deleteZeroAutomation,
+  enableZeroAutomation,
+  disableZeroAutomation,
+  resolveZeroAutomationByAgent,
+} from "./domains/zero-automations";
+
 // Domain modules - Zero Runs
 export { getZeroRunAgentEvents } from "./domains/zero-runs";
 

--- a/turbo/apps/cli/src/zero.ts
+++ b/turbo/apps/cli/src/zero.ts
@@ -10,6 +10,7 @@ import { zeroCreditCommand } from "./commands/zero/credit";
 import { zeroDoctorCommand } from "./commands/zero/doctor";
 import { zeroPreferenceCommand } from "./commands/zero/preference";
 import { zeroScheduleCommand } from "./commands/zero/schedule";
+import { zeroAutomationCommand } from "./commands/zero/automation";
 import { zeroSecretCommand } from "./commands/zero/secret";
 import { zeroGithubCommand } from "./commands/zero/github";
 import { zeroSlackCommand } from "./commands/zero/slack";
@@ -49,6 +50,7 @@ const COMMAND_CAPABILITY_MAP: Record<
   skill: "agent:read",
   connector: "connector:read",
   schedule: "schedule:read",
+  automation: "schedule:read",
   doctor: null,
   credit: "billing:write",
   model: null,
@@ -79,6 +81,7 @@ const DEFAULT_COMMANDS: Command[] = [
   zeroDoctorCommand,
   zeroPreferenceCommand,
   zeroScheduleCommand,
+  zeroAutomationCommand,
   zeroSecretCommand,
   zeroGithubCommand,
   zeroSlackCommand,


### PR DESCRIPTION
Closes #16639. Part of #16616. Stacked on #16674.

New 'zero automation' CLI mirroring 'zero schedule', calling /api/automations; legacy 'zero schedule' stays on the legacy surface. Tests: 110 CLI tests (6 new automation suites + schedule suites unchanged).