### PR TITLE
feat(platform): render Automations surface behind feature switch

### DIFF
--- a/turbo/apps/platform/src/mocks/handlers/api-automations.ts
+++ b/turbo/apps/platform/src/mocks/handlers/api-automations.ts
@@ -1,0 +1,129 @@
+import {
+  automationsMainContract,
+  automationsByNameContract,
+  automationsEnableContract,
+  automationRunContract,
+} from "@vm0/api-contracts/contracts/automations";
+import type { ScheduleResponse } from "@vm0/api-contracts/contracts/zero-schedules";
+import { mockApi } from "../msw-contract.ts";
+import { getMockSchedules, setMockSchedules } from "./schedules-store.ts";
+
+// Mirrors the production Automations route: a thin product projection over the
+// very same schedule service, so these handlers operate on the shared schedule
+// store. An automation row IS a schedule row; only the wrapper key differs
+// (`automations` vs `schedules`, `automationId` vs `scheduleId`).
+
+function upsert(
+  body: {
+    readonly agentId: string;
+    readonly name: string;
+    readonly cronExpression?: string;
+    readonly atTime?: string;
+    readonly intervalSeconds?: number;
+    readonly timezone: string;
+    readonly prompt: string;
+    readonly description?: string;
+    readonly appendSystemPrompt?: string;
+    readonly enabled?: boolean;
+    readonly chatThreadId?: string;
+  },
+  name: string,
+): { automation: ScheduleResponse; created: boolean; status: 200 | 201 } {
+  const now = new Date().toISOString();
+  const automation: ScheduleResponse = {
+    id: crypto.randomUUID(),
+    agentId: body.agentId,
+    displayName: null,
+    userId: "test-user-123",
+    name,
+    triggerType: body.cronExpression ? "cron" : body.atTime ? "once" : "loop",
+    cronExpression: body.cronExpression ?? null,
+    atTime: body.atTime ?? null,
+    intervalSeconds: body.intervalSeconds ?? null,
+    timezone: body.timezone,
+    prompt: body.prompt,
+    description: body.description ?? null,
+    appendSystemPrompt: body.appendSystemPrompt ?? null,
+    enabled: body.enabled ?? true,
+    nextRunAt: null,
+    lastRunAt: null,
+    retryStartedAt: null,
+    consecutiveFailures: 0,
+    chatThreadId: body.chatThreadId ?? crypto.randomUUID(),
+    createdAt: now,
+    updatedAt: now,
+  };
+  const automations = getMockSchedules();
+  const existing = automations.find((s) => s.name === name);
+  if (existing) {
+    setMockSchedules(
+      automations.map((s) => (s.name === name ? automation : s)),
+    );
+    return { automation, created: false, status: 200 };
+  }
+  setMockSchedules([...automations, automation]);
+  return { automation, created: true, status: 201 };
+}
+
+export const apiAutomationsHandlers = [
+  // GET /api/automations
+  mockApi(automationsMainContract.list, ({ respond }) =>
+    respond(200, { automations: getMockSchedules() }),
+  ),
+
+  // POST /api/automations
+  mockApi(automationsMainContract.create, ({ body, respond }) => {
+    const { automation, created, status } = upsert(body, body.name);
+    return respond(status, { automation, created });
+  }),
+
+  // PUT /api/automations/:name
+  mockApi(automationsByNameContract.update, ({ params, body, respond }) => {
+    const { automation, created, status } = upsert(
+      { ...body, name: params.name },
+      params.name,
+    );
+    return respond(status, { automation, created });
+  }),
+
+  // DELETE /api/automations/:name
+  mockApi(automationsByNameContract.delete, ({ params, respond }) => {
+    setMockSchedules(getMockSchedules().filter((s) => s.name !== params.name));
+    return respond(204);
+  }),
+
+  // POST /api/automations/:name/enable
+  mockApi(automationsEnableContract.enable, ({ params, respond }) => {
+    const automation = getMockSchedules().find((s) => s.name === params.name);
+    if (!automation) {
+      return respond(404, {
+        error: { message: "Not found", code: "NOT_FOUND" },
+      });
+    }
+    const updated = { ...automation, enabled: true };
+    setMockSchedules(
+      getMockSchedules().map((s) => (s.name === params.name ? updated : s)),
+    );
+    return respond(200, updated);
+  }),
+
+  // POST /api/automations/:name/disable
+  mockApi(automationsEnableContract.disable, ({ params, respond }) => {
+    const automation = getMockSchedules().find((s) => s.name === params.name);
+    if (!automation) {
+      return respond(404, {
+        error: { message: "Not found", code: "NOT_FOUND" },
+      });
+    }
+    const updated = { ...automation, enabled: false };
+    setMockSchedules(
+      getMockSchedules().map((s) => (s.name === params.name ? updated : s)),
+    );
+    return respond(200, updated);
+  }),
+
+  // POST /api/automations/run
+  mockApi(automationRunContract.run, ({ respond }) =>
+    respond(201, { runId: crypto.randomUUID() }),
+  ),
+];

--- a/turbo/apps/platform/src/mocks/handlers/api-schedules.ts
+++ b/turbo/apps/platform/src/mocks/handlers/api-schedules.ts
@@ -6,8 +6,10 @@ import {
   type ScheduleResponse,
 } from "@vm0/api-contracts/contracts/zero-schedules";
 import { mockApi } from "../msw-contract.ts";
-
-let mockSchedules: ScheduleResponse[] = [];
+import {
+  getMockSchedules,
+  setMockSchedules as setStore,
+} from "./schedules-store.ts";
 
 const DEFAULT_CHAT_THREAD_ID = "d0000000-0000-4000-a000-000000000001";
 
@@ -40,18 +42,12 @@ export function createMockScheduleResponse(
   };
 }
 
-export function setMockSchedules(schedules: ScheduleResponse[]): void {
-  mockSchedules = schedules;
-}
-
-export function resetMockSchedules(): void {
-  mockSchedules = [];
-}
+export { setMockSchedules, resetMockSchedules } from "./schedules-store.ts";
 
 export const apiSchedulesHandlers = [
   // GET /api/zero/schedules
   mockApi(zeroSchedulesMainContract.list, ({ respond }) =>
-    respond(200, { schedules: mockSchedules }),
+    respond(200, { schedules: getMockSchedules() }),
   ),
 
   // POST /api/zero/schedules
@@ -80,49 +76,48 @@ export const apiSchedulesHandlers = [
       createdAt: now,
       updatedAt: now,
     };
-    const existing = mockSchedules.find((s) => s.name === body.name);
+    const schedules = getMockSchedules();
+    const existing = schedules.find((s) => s.name === body.name);
     if (existing) {
-      mockSchedules = mockSchedules.map((s) =>
-        s.name === body.name ? schedule : s,
-      );
+      setStore(schedules.map((s) => (s.name === body.name ? schedule : s)));
       return respond(200, { schedule, created: false });
     }
-    mockSchedules = [...mockSchedules, schedule];
+    setStore([...schedules, schedule]);
     return respond(201, { schedule, created: true });
   }),
 
   // DELETE /api/zero/schedules/:name
   mockApi(zeroSchedulesByNameContract.delete, ({ params, respond }) => {
-    mockSchedules = mockSchedules.filter((s) => s.name !== params.name);
+    setStore(getMockSchedules().filter((s) => s.name !== params.name));
     return respond(204);
   }),
 
   // POST /api/zero/schedules/:name/enable
   mockApi(zeroSchedulesEnableContract.enable, ({ params, respond }) => {
-    const schedule = mockSchedules.find((s) => s.name === params.name);
+    const schedule = getMockSchedules().find((s) => s.name === params.name);
     if (!schedule) {
       return respond(404, {
         error: { message: "Not found", code: "NOT_FOUND" },
       });
     }
     const updated = { ...schedule, enabled: true };
-    mockSchedules = mockSchedules.map((s) =>
-      s.name === params.name ? updated : s,
+    setStore(
+      getMockSchedules().map((s) => (s.name === params.name ? updated : s)),
     );
     return respond(200, updated);
   }),
 
   // POST /api/zero/schedules/:name/disable
   mockApi(zeroSchedulesEnableContract.disable, ({ params, respond }) => {
-    const schedule = mockSchedules.find((s) => s.name === params.name);
+    const schedule = getMockSchedules().find((s) => s.name === params.name);
     if (!schedule) {
       return respond(404, {
         error: { message: "Not found", code: "NOT_FOUND" },
       });
     }
     const updated = { ...schedule, enabled: false };
-    mockSchedules = mockSchedules.map((s) =>
-      s.name === params.name ? updated : s,
+    setStore(
+      getMockSchedules().map((s) => (s.name === params.name ? updated : s)),
     );
     return respond(200, updated);
   }),

--- a/turbo/apps/platform/src/mocks/handlers/index.ts
+++ b/turbo/apps/platform/src/mocks/handlers/index.ts
@@ -81,6 +81,7 @@ import {
 import { apiBillingHandlers, resetMockBilling } from "./api-billing.ts";
 import { apiAttributionHandlers } from "./api-attribution.ts";
 import { apiSchedulesHandlers, resetMockSchedules } from "./api-schedules.ts";
+import { apiAutomationsHandlers } from "./api-automations.ts";
 import { apiInsightsHandlers } from "./api-insights.ts";
 import { apiQueuePositionHandlers } from "./api-queue-position.ts";
 import {
@@ -125,6 +126,7 @@ export const handlers = [
   ...apiRealtimeHandlers,
   ...apiUserPermissionGrantsHandlers,
   ...apiSchedulesHandlers,
+  ...apiAutomationsHandlers,
   ...apiInsightsHandlers,
   ...apiQueuePositionHandlers,
   ...apiVoiceIoHandlers,

--- a/turbo/apps/platform/src/mocks/handlers/schedules-store.ts
+++ b/turbo/apps/platform/src/mocks/handlers/schedules-store.ts
@@ -1,0 +1,19 @@
+import type { ScheduleResponse } from "@vm0/api-contracts/contracts/zero-schedules";
+
+// Shared in-memory store for the schedule and automation mock handlers. Both
+// surfaces are backed by the same service in production, so the mocks share one
+// store too: a schedule created through `/api/zero/schedules` is visible through
+// `/api/automations` and vice versa.
+let mockSchedules: ScheduleResponse[] = [];
+
+export function getMockSchedules(): ScheduleResponse[] {
+  return mockSchedules;
+}
+
+export function setMockSchedules(schedules: ScheduleResponse[]): void {
+  mockSchedules = schedules;
+}
+
+export function resetMockSchedules(): void {
+  mockSchedules = [];
+}

--- a/turbo/apps/platform/src/signals/chat-page/header-schedule-menu.ts
+++ b/turbo/apps/platform/src/signals/chat-page/header-schedule-menu.ts
@@ -1,9 +1,11 @@
 import { command, computed, state } from "ccstate";
-import { zeroSchedulesMainContract } from "@vm0/api-contracts/contracts/zero-schedules";
 
-import { accept } from "../../lib/accept.ts";
 import { zeroClient$ } from "../api-client.ts";
 import { scheduleTitle } from "../zero-page/schedule-title.ts";
+import {
+  automationsModeEnabled$,
+  listSchedulesVia,
+} from "../zero-page/automations-mode.ts";
 
 export interface HeaderScheduleEntry {
   readonly id: string;
@@ -30,13 +32,12 @@ export const reloadHeaderScheduleMenu$ = command(({ get, set }) => {
 export const headerScheduleMenu$ = computed(
   async (get): Promise<readonly HeaderScheduleEntry[]> => {
     get(headerScheduleMenuReload$);
-    const client = get(zeroClient$)(zeroSchedulesMainContract);
-    const result = await accept(
-      client.list({ fetchOptions: { cache: "no-store" } }),
-      [200],
-      { toast: false },
+    const schedules = await listSchedulesVia(
+      get(zeroClient$),
+      get(automationsModeEnabled$),
+      { cache: "no-store" },
     );
-    return result.body.schedules.map((schedule) => {
+    return schedules.map((schedule) => {
       return {
         id: schedule.id,
         name: schedule.name,

--- a/turbo/apps/platform/src/signals/zero-page/automations-mode.ts
+++ b/turbo/apps/platform/src/signals/zero-page/automations-mode.ts
@@ -1,0 +1,165 @@
+import { computed } from "ccstate";
+import { FeatureSwitchKey } from "@vm0/connectors/feature-switch-key";
+import {
+  automationsMainContract,
+  automationsByNameContract,
+  automationsEnableContract,
+  automationRunContract,
+  type AutomationResponse,
+} from "@vm0/api-contracts/contracts/automations";
+import {
+  zeroSchedulesMainContract,
+  zeroSchedulesByNameContract,
+  zeroSchedulesEnableContract,
+  zeroScheduleRunContract,
+  type ScheduleResponse,
+} from "@vm0/api-contracts/contracts/zero-schedules";
+import { accept } from "../../lib/accept.ts";
+import { featureSwitch$ } from "../external/feature-switch.ts";
+import type { ZeroClientFactory } from "../api-client.ts";
+import type { ScheduleBody } from "./cron.ts";
+
+// ---------------------------------------------------------------------------
+// Surface-only gating for the Automations product view.
+//
+// The Automations API is a cleaned product projection over the very same
+// schedule service that backs the legacy `/api/zero/schedules` routes — the two
+// surfaces drive the same agent run + chat-thread rendering and share the same
+// field set (an `AutomationResponse` IS a `ScheduleResponse`; only the wrapper
+// key differs). When the `zeroAutomations` switch is on we talk to the
+// Automations endpoints and label the surface "Automations"; when off we stay
+// on the schedule endpoints and label it "Schedules". There is no execution
+// fork: these helpers only pick which equivalent endpoint the client hits and
+// normalize the response back to `ScheduleResponse` so callers are unchanged.
+// ---------------------------------------------------------------------------
+
+/** True when the Automations surface is enabled for the current identity. */
+export const automationsModeEnabled$ = computed((get) => {
+  return get(featureSwitch$)[FeatureSwitchKey.ZeroAutomations] ?? false;
+});
+
+// `AutomationResponse` and `ScheduleResponse` are the same shape; this keeps the
+// dependency direction explicit at the call boundary.
+function toSchedule(automation: AutomationResponse): ScheduleResponse {
+  return automation;
+}
+
+/** List schedules/automations, normalized to `ScheduleResponse[]`. */
+export async function listSchedulesVia(
+  client: ZeroClientFactory,
+  automationsMode: boolean,
+  fetchOptions?: RequestInit,
+): Promise<ScheduleResponse[]> {
+  if (automationsMode) {
+    const result = await accept(
+      client(automationsMainContract).list({ fetchOptions }),
+      [200],
+      { toast: false },
+    );
+    return result.body.automations.map(toSchedule);
+  }
+  const result = await accept(
+    client(zeroSchedulesMainContract).list({ fetchOptions }),
+    [200],
+    { toast: false },
+  );
+  return result.body.schedules;
+}
+
+/**
+ * Upsert a schedule/automation. The legacy schedule surface upserts through a
+ * single POST `deploy`; the Automations surface splits create (POST) from
+ * update (PUT `:name`), keyed on the schedule name. Returns the resulting id.
+ */
+export async function deployScheduleVia(
+  client: ZeroClientFactory,
+  automationsMode: boolean,
+  body: ScheduleBody,
+  isUpdate: boolean,
+): Promise<{ id: string; created: boolean }> {
+  if (automationsMode) {
+    if (isUpdate) {
+      const { name, ...rest } = body;
+      const result = await accept(
+        client(automationsByNameContract).update({
+          params: { name },
+          body: rest,
+        }),
+        [200, 201],
+      );
+      return {
+        id: result.body.automation.id,
+        created: result.body.created,
+      };
+    }
+    const result = await accept(
+      client(automationsMainContract).create({ body }),
+      [200, 201],
+    );
+    return { id: result.body.automation.id, created: result.body.created };
+  }
+  const result = await accept(
+    client(zeroSchedulesMainContract).deploy({ body }),
+    [200, 201],
+  );
+  return { id: result.body.schedule.id, created: result.body.created };
+}
+
+/** Enable or disable a schedule/automation by name. */
+export async function setScheduleEnabledVia(
+  client: ZeroClientFactory,
+  automationsMode: boolean,
+  params: { name: string; agentId: string; enabled: boolean },
+): Promise<void> {
+  const action = params.enabled ? "enable" : "disable";
+  const contract = automationsMode
+    ? automationsEnableContract
+    : zeroSchedulesEnableContract;
+  await accept(
+    client(contract)[action]({
+      params: { name: params.name },
+      body: { agentId: params.agentId },
+    }),
+    [200],
+  );
+}
+
+/** Delete a schedule/automation by name. */
+export async function deleteScheduleVia(
+  client: ZeroClientFactory,
+  automationsMode: boolean,
+  params: { name: string; agentId: string },
+): Promise<void> {
+  const contract = automationsMode
+    ? automationsByNameContract
+    : zeroSchedulesByNameContract;
+  await accept(
+    client(contract).delete({
+      params: { name: params.name },
+      query: { agentId: params.agentId },
+    }),
+    [204],
+  );
+}
+
+/** Execute a schedule/automation immediately; returns the created run id. */
+export async function runScheduleNowVia(
+  client: ZeroClientFactory,
+  automationsMode: boolean,
+  id: string,
+): Promise<string> {
+  if (automationsMode) {
+    const result = await accept(
+      client(automationRunContract).run({ body: { automationId: id } }),
+      [201],
+      { toast: false },
+    );
+    return result.body.runId;
+  }
+  const result = await accept(
+    client(zeroScheduleRunContract).run({ body: { scheduleId: id } }),
+    [201],
+    { toast: false },
+  );
+  return result.body.runId;
+}

--- a/turbo/apps/platform/src/signals/zero-page/job-detail/schedule.ts
+++ b/turbo/apps/platform/src/signals/zero-page/job-detail/schedule.ts
@@ -1,11 +1,5 @@
 import { command, computed, state } from "ccstate";
 import { toast } from "@vm0/ui/components/ui/sonner";
-import { accept } from "../../../lib/accept.ts";
-import {
-  zeroSchedulesMainContract,
-  zeroSchedulesByNameContract,
-  zeroSchedulesEnableContract,
-} from "@vm0/api-contracts/contracts/zero-schedules";
 import { zeroClient$ } from "../../api-client.ts";
 import { agentDetail$ } from "./detail.ts";
 import {
@@ -15,6 +9,13 @@ import {
   type ScheduleBody,
   type CronTimeOption,
 } from "../cron.ts";
+import {
+  automationsModeEnabled$,
+  listSchedulesVia,
+  deployScheduleVia,
+  setScheduleEnabledVia,
+  deleteScheduleVia,
+} from "../automations-mode.ts";
 import type { ScheduleEntry } from "../../../views/zero-page/zero-schedule-card.tsx";
 
 // ---------------------------------------------------------------------------
@@ -121,9 +122,11 @@ const rawSchedules$ = computed(async (get): Promise<ScheduleItem[]> => {
   if (!detail) {
     return [];
   }
-  const client = get(zeroClient$)(zeroSchedulesMainContract);
-  const result = await accept(client.list(), [200]);
-  return result.body.schedules.filter((s) => {
+  const schedules = await listSchedulesVia(
+    get(zeroClient$),
+    get(automationsModeEnabled$),
+  );
+  return schedules.filter((s) => {
     return s.agentId === detail.agentId;
   });
 });
@@ -230,8 +233,12 @@ export const saveAgentSchedule$ = command(
       body = { ...base, cronExpression };
     }
 
-    const client = get(zeroClient$)(zeroSchedulesMainContract);
-    await accept(client.deploy({ body }), [200, 201]);
+    await deployScheduleVia(
+      get(zeroClient$),
+      get(automationsModeEnabled$),
+      body,
+      params.editName !== undefined,
+    );
     signal.throwIfAborted();
 
     toast.success(params.editName ? "Schedule updated" : "Schedule created");
@@ -251,14 +258,14 @@ export const toggleAgentScheduleEnabled$ = command(
       throw new Error("No agent detail loaded");
     }
 
-    const client = get(zeroClient$)(zeroSchedulesEnableContract);
-    const action = params.enabled ? "enable" : "disable";
-    await accept(
-      client[action]({
-        params: { name: params.name },
-        body: { agentId: detail.agentId },
-      }),
-      [200],
+    await setScheduleEnabledVia(
+      get(zeroClient$),
+      get(automationsModeEnabled$),
+      {
+        name: params.name,
+        agentId: detail.agentId,
+        enabled: params.enabled,
+      },
     );
     signal.throwIfAborted();
 
@@ -274,14 +281,10 @@ export const deleteAgentSchedule$ = command(
       throw new Error("No agent detail loaded");
     }
 
-    const client = get(zeroClient$)(zeroSchedulesByNameContract);
-    await accept(
-      client.delete({
-        params: { name: scheduleName },
-        query: { agentId: detail.agentId },
-      }),
-      [204],
-    );
+    await deleteScheduleVia(get(zeroClient$), get(automationsModeEnabled$), {
+      name: scheduleName,
+      agentId: detail.agentId,
+    });
     signal.throwIfAborted();
 
     toast.success("Schedule deleted");

--- a/turbo/apps/platform/src/signals/zero-page/zero-schedule.ts
+++ b/turbo/apps/platform/src/signals/zero-page/zero-schedule.ts
@@ -6,13 +6,7 @@ import { command, computed, state } from "ccstate";
 import { toast } from "@vm0/ui/components/ui/sonner";
 import { createElement } from "react";
 import { Link } from "../../views/router/link.tsx";
-import {
-  zeroSchedulesMainContract,
-  zeroSchedulesByNameContract,
-  zeroSchedulesEnableContract,
-  zeroScheduleRunContract,
-  type ScheduleResponse,
-} from "@vm0/api-contracts/contracts/zero-schedules";
+import type { ScheduleResponse } from "@vm0/api-contracts/contracts/zero-schedules";
 import { zeroClient$ } from "../api-client.ts";
 import { zeroOnboardingStatus$ } from "./zero-onboarding.ts";
 import {
@@ -22,7 +16,15 @@ import {
   type ScheduleBody,
   type CronTimeOption,
 } from "./cron.ts";
-import { accept, ApiError } from "../../lib/accept.ts";
+import {
+  automationsModeEnabled$,
+  listSchedulesVia,
+  deployScheduleVia,
+  setScheduleEnabledVia,
+  deleteScheduleVia,
+  runScheduleNowVia,
+} from "./automations-mode.ts";
+import { ApiError } from "../../lib/accept.ts";
 import { markDetachedErrorHandled, throwIfAbort } from "../utils.ts";
 import { defaultAgentId$ } from "../agent.ts";
 
@@ -171,16 +173,15 @@ export const fetchZeroSchedules$ = command(
       return;
     }
 
-    const client = get(zeroClient$)(zeroSchedulesMainContract);
-    const result = await accept(
-      client.list({ fetchOptions: { signal } }),
-      [200],
-      { toast: false },
+    const schedules = await listSchedulesVia(
+      get(zeroClient$),
+      get(automationsModeEnabled$),
+      { signal },
     );
     signal.throwIfAborted();
 
     // Filter schedules for this agent's composeId
-    const agentSchedules = result.body.schedules.filter((s) => {
+    const agentSchedules = schedules.filter((s) => {
       return s.agentId === composeId;
     });
     set(internalSchedules$, agentSchedules);
@@ -271,8 +272,12 @@ export const saveZeroSchedule$ = command(
 
     const body = buildScheduleBody(defaultAgentId, params);
 
-    const client = get(zeroClient$)(zeroSchedulesMainContract);
-    await accept(client.deploy({ body }), [200, 201]);
+    await deployScheduleVia(
+      get(zeroClient$),
+      get(automationsModeEnabled$),
+      body,
+      params.editName !== undefined,
+    );
     signal.throwIfAborted();
 
     toast.success(params.editName ? "Schedule updated" : "Schedule created");
@@ -297,14 +302,14 @@ export const toggleZeroScheduleEnabled$ = command(
       throw new Error("No default agent configured");
     }
 
-    const client = get(zeroClient$)(zeroSchedulesEnableContract);
-    const action = params.enabled ? "enable" : "disable";
-    await accept(
-      client[action]({
-        params: { name: params.name },
-        body: { agentId: composeId },
-      }),
-      [200],
+    await setScheduleEnabledVia(
+      get(zeroClient$),
+      get(automationsModeEnabled$),
+      {
+        name: params.name,
+        agentId: composeId,
+        enabled: params.enabled,
+      },
     );
     signal.throwIfAborted();
 
@@ -332,14 +337,10 @@ export const deleteZeroSchedule$ = command(
       throw new Error("No default agent configured");
     }
 
-    const client = get(zeroClient$)(zeroSchedulesByNameContract);
-    await accept(
-      client.delete({
-        params: { name: scheduleName },
-        query: { agentId: composeId },
-      }),
-      [204],
-    );
+    await deleteScheduleVia(get(zeroClient$), get(automationsModeEnabled$), {
+      name: scheduleName,
+      agentId: composeId,
+    });
     signal.throwIfAborted();
 
     toast.success("Schedule deleted");
@@ -403,16 +404,15 @@ export const allOrgScheduleEntries$ = computed((get) => {
 
 export const fetchAllOrgSchedules$ = command(
   async ({ get, set }, signal: AbortSignal) => {
-    const client = get(zeroClient$)(zeroSchedulesMainContract);
-    const result = await accept(
-      client.list({ fetchOptions: { signal } }),
-      [200],
-      { toast: false },
+    const schedules = await listSchedulesVia(
+      get(zeroClient$),
+      get(automationsModeEnabled$),
+      { signal },
     ).finally(() => {
       set(internalAllSchedulesLoaded$, true);
     });
     signal.throwIfAborted();
-    set(internalAllSchedules$, result.body.schedules);
+    set(internalAllSchedules$, schedules);
   },
 );
 
@@ -426,10 +426,14 @@ export const saveOrgSchedule$ = command(
     try {
       const body = buildScheduleBody(params.agentId, params);
 
-      const client = get(zeroClient$)(zeroSchedulesMainContract);
-      const result = await accept(client.deploy({ body }), [200, 201]);
+      const result = await deployScheduleVia(
+        get(zeroClient$),
+        get(automationsModeEnabled$),
+        body,
+        params.editName !== undefined,
+      );
       signal.throwIfAborted();
-      scheduleId = result.body.schedule.id;
+      scheduleId = result.id;
     } catch (error: unknown) {
       throwIfAbort(error);
       if (!(error instanceof ApiError)) {
@@ -456,14 +460,14 @@ export const toggleOrgScheduleEnabled$ = command(
     params: { name: string; enabled: boolean; agentId: string },
     signal: AbortSignal,
   ) => {
-    const client = get(zeroClient$)(zeroSchedulesEnableContract);
-    const action = params.enabled ? "enable" : "disable";
-    await accept(
-      client[action]({
-        params: { name: params.name },
-        body: { agentId: params.agentId },
-      }),
-      [200],
+    await setScheduleEnabledVia(
+      get(zeroClient$),
+      get(automationsModeEnabled$),
+      {
+        name: params.name,
+        agentId: params.agentId,
+        enabled: params.enabled,
+      },
     );
     signal.throwIfAborted();
 
@@ -477,14 +481,10 @@ export const deleteOrgSchedule$ = command(
     params: { name: string; agentId: string },
     signal: AbortSignal,
   ) => {
-    const client = get(zeroClient$)(zeroSchedulesByNameContract);
-    await accept(
-      client.delete({
-        params: { name: params.name },
-        query: { agentId: params.agentId },
-      }),
-      [204],
-    );
+    await deleteScheduleVia(get(zeroClient$), get(automationsModeEnabled$), {
+      name: params.name,
+      agentId: params.agentId,
+    });
     signal.throwIfAborted();
 
     toast.success("Schedule deleted");
@@ -502,14 +502,14 @@ export const runScheduleNow$ = command(
     signal.addEventListener("abort", () => {
       return toast.dismiss(toastId);
     });
-    const client = get(zeroClient$)(zeroScheduleRunContract);
-    let data: { runId: string };
+    let runId: string;
     try {
-      const result = await accept(client.run({ body: { scheduleId } }), [201], {
-        toast: false,
-      });
+      runId = await runScheduleNowVia(
+        get(zeroClient$),
+        get(automationsModeEnabled$),
+        scheduleId,
+      );
       signal.throwIfAborted();
-      data = result.body;
     } catch (error: unknown) {
       const message = error instanceof Error ? error.message : "Run failed";
       toast.error(message, { id: toastId });
@@ -526,7 +526,7 @@ export const runScheduleNow$ = command(
           Link,
           {
             pathname: "/activities/:activityRunId" as const,
-            options: { pathParams: { activityRunId: data.runId } },
+            options: { pathParams: { activityRunId: runId } },
             className: "underline",
           },
           "View activity",
@@ -535,6 +535,6 @@ export const runScheduleNow$ = command(
       { id: toastId },
     );
 
-    return data.runId;
+    return runId;
   },
 );

--- a/turbo/apps/platform/src/views/zero-page/__tests__/zero-schedule-page-automations.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/zero-schedule-page-automations.test.tsx
@@ -1,0 +1,108 @@
+/**
+ * Tests for the zeroAutomations surface gating on zero-schedule-page.tsx.
+ *
+ * Surface-only gating: when the switch is OFF the page stays "Schedules" and
+ * talks to /api/zero/schedules; when ON it presents as "Automations" and talks
+ * to /api/automations. There is no execution-path fork — the two surfaces are
+ * the same service, so behavior is otherwise identical.
+ */
+
+import { describe, expect, it } from "vitest";
+import { screen, waitFor } from "@testing-library/react";
+import { server } from "../../../mocks/server.ts";
+import { testContext } from "../../../signals/__tests__/test-helpers.ts";
+import { detachedSetupPage } from "../../../__tests__/page-helper.ts";
+import {
+  setMockSchedules,
+  createMockScheduleResponse,
+} from "../../../mocks/handlers/api-schedules.ts";
+import { createMockApi } from "../../../mocks/msw-contract.ts";
+import {
+  automationsMainContract,
+  type AutomationResponse,
+} from "@vm0/api-contracts/contracts/automations";
+import {
+  zeroSchedulesMainContract,
+  type ScheduleResponse,
+} from "@vm0/api-contracts/contracts/zero-schedules";
+
+const context = testContext();
+const mockApi = createMockApi(context);
+
+function seededSchedule(): ScheduleResponse {
+  return createMockScheduleResponse({
+    id: "f0000001-0000-4000-a000-000000000001",
+    name: "morning-briefing",
+    cronExpression: "0 9 * * 1-5",
+    prompt: "Summarize yesterday's threads",
+  });
+}
+
+describe("zero schedule page - automations surface gating", () => {
+  it("stays labeled Schedules when the switch is OFF (AUTO-SURFACE-001)", async () => {
+    setMockSchedules([seededSchedule()]);
+    detachedSetupPage({ context, path: "/schedules" });
+
+    await waitFor(() => {
+      expect(screen.getByText("Scheduled tasks")).toBeInTheDocument();
+    });
+    expect(
+      screen.getByText(
+        "Automated tasks scheduled across all agents in your workspace.",
+      ),
+    ).toBeInTheDocument();
+    expect(screen.getByText("Add schedule")).toBeInTheDocument();
+    expect(screen.queryByText("Automations")).not.toBeInTheDocument();
+  });
+
+  it("presents as Automations when the switch is ON (AUTO-SURFACE-002)", async () => {
+    setMockSchedules([seededSchedule()]);
+    detachedSetupPage({
+      context,
+      path: "/schedules",
+      featureSwitches: { zeroAutomations: true },
+    });
+
+    await waitFor(() => {
+      expect(screen.getByText("Automations")).toBeInTheDocument();
+    });
+    expect(
+      screen.getByText(
+        "Automations running across all agents in your workspace.",
+      ),
+    ).toBeInTheDocument();
+    expect(screen.getByText("Add automation")).toBeInTheDocument();
+    expect(screen.queryByText("Scheduled tasks")).not.toBeInTheDocument();
+  });
+
+  it("loads entries from the automations endpoint when ON (AUTO-SURFACE-003)", async () => {
+    // Only the automations endpoint returns an entry; the legacy schedules
+    // endpoint returns nothing. The page must render the automation, proving it
+    // talks to /api/automations rather than /api/zero/schedules.
+    const automation: AutomationResponse = {
+      ...seededSchedule(),
+      name: "automation-only",
+      prompt: "Visible only via the automations endpoint",
+    };
+    server.use(
+      mockApi(automationsMainContract.list, ({ respond }) => {
+        return respond(200, { automations: [automation] });
+      }),
+      mockApi(zeroSchedulesMainContract.list, ({ respond }) => {
+        return respond(200, { schedules: [] });
+      }),
+    );
+
+    detachedSetupPage({
+      context,
+      path: "/schedules",
+      featureSwitches: { zeroAutomations: true },
+    });
+
+    await waitFor(() => {
+      expect(
+        screen.getAllByText("Visible only via the automations endpoint").length,
+      ).toBeGreaterThan(0);
+    });
+  });
+});

--- a/turbo/apps/platform/src/views/zero-page/zero-schedule-page.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-schedule-page.tsx
@@ -50,6 +50,7 @@ import {
   runScheduleNow$,
   type OrgScheduleEntry,
 } from "../../signals/zero-page/zero-schedule.ts";
+import { automationsModeEnabled$ } from "../../signals/zero-page/automations-mode.ts";
 import { zeroOnboardingStatus$ } from "../../signals/zero-page/zero-onboarding.ts";
 import { detachedNavigateTo$ } from "../../signals/route.ts";
 import {
@@ -515,10 +516,29 @@ function DeleteScheduleDialogContainer() {
 }
 
 // ---------------------------------------------------------------------------
+// Surface labels — the page is the same surface either way; only the product
+// noun changes when the `zeroAutomations` switch is on (see automations-mode).
+// ---------------------------------------------------------------------------
+
+const SCHEDULES_LABELS = {
+  title: "Scheduled tasks",
+  subtitle: "Automated tasks scheduled across all agents in your workspace.",
+  addButton: "Add schedule",
+} as const;
+
+const AUTOMATIONS_LABELS = {
+  title: "Automations",
+  subtitle: "Automations running across all agents in your workspace.",
+  addButton: "Add automation",
+} as const;
+
+// ---------------------------------------------------------------------------
 // Main page
 // ---------------------------------------------------------------------------
 
 export function ZeroSchedulePage() {
+  const automationsMode = useGet(automationsModeEnabled$);
+  const labels = automationsMode ? AUTOMATIONS_LABELS : SCHEDULES_LABELS;
   const statusLoadable = useLastLoadable(zeroOnboardingStatus$);
   const defaultComposeId =
     statusLoadable.state === "hasData"
@@ -608,10 +628,10 @@ export function ZeroSchedulePage() {
         <div className="mx-auto max-w-[900px] flex flex-wrap items-end justify-between gap-4">
           <div className="min-w-0 hidden md:block">
             <h1 className="text-lg font-semibold tracking-tight text-foreground">
-              Scheduled tasks
+              {labels.title}
             </h1>
             <p className="mt-0.5 text-sm text-muted-foreground">
-              Automated tasks scheduled across all agents in your workspace.
+              {labels.subtitle}
             </p>
           </div>
           <div className="flex items-center gap-2 shrink-0">
@@ -625,7 +645,7 @@ export function ZeroSchedulePage() {
               }}
             >
               <IconPlus size={14} stroke={2} />
-              Add schedule
+              {labels.addButton}
             </Button>
             <Tabs
               value={activeListTab}


### PR DESCRIPTION
Closes #16640. Part of #16616. Stacked on #16675.

Platform renders the Automations surface behind the zeroAutomations switch (surface-only; Schedules unchanged when off). Tests: component tests for both switch states.