### PR TITLE
feat: add presentation html redeploy endpoint

### DIFF
--- a/turbo/apps/api/src/__tests__/mocks.ts
+++ b/turbo/apps/api/src/__tests__/mocks.ts
@@ -371,6 +371,14 @@ const apiTestMocks: ApiTestMocks = vi.hoisted((): ApiTestMocks => {
 });
 
 vi.mock("@aws-sdk/client-s3", () => {
+  class CopyObjectCommand {
+    readonly input: unknown;
+
+    constructor(input: unknown) {
+      this.input = input;
+    }
+  }
+
   class GetObjectCommand {
     readonly input: unknown;
 
@@ -422,6 +430,7 @@ vi.mock("@aws-sdk/client-s3", () => {
   }
 
   return {
+    CopyObjectCommand,
     DeleteObjectsCommand,
     GetObjectCommand,
     HeadObjectCommand,

--- a/turbo/apps/api/src/signals/external/s3.ts
+++ b/turbo/apps/api/src/signals/external/s3.ts
@@ -1,5 +1,6 @@
 import { computed, type Computed } from "ccstate";
 import {
+  CopyObjectCommand,
   DeleteObjectsCommand,
   GetObjectCommand,
   HeadObjectCommand,
@@ -345,6 +346,28 @@ export function putHostedSitesS3Object(
     body,
     contentType,
   );
+}
+
+function s3CopySource(bucket: string, key: string): string {
+  const encodedKey = key.split("/").map(encodeURIComponent).join("/");
+  return `${bucket}/${encodedKey}`;
+}
+
+export function copyHostedSitesS3Object(
+  bucket: string,
+  sourceKey: string,
+  destinationKey: string,
+): Computed<Promise<void>> {
+  return computed(async (get): Promise<void> => {
+    const client = get(hostedSitesS3Client$);
+    await client.send(
+      new CopyObjectCommand({
+        Bucket: bucket,
+        CopySource: s3CopySource(bucket, sourceKey),
+        Key: destinationKey,
+      }),
+    );
+  });
 }
 
 export function downloadManifest(

--- a/turbo/apps/api/src/signals/routes/__tests__/zero-host.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/zero-host.test.ts
@@ -1,4 +1,4 @@
-import { randomUUID } from "node:crypto";
+import { createHash, randomUUID } from "node:crypto";
 
 import { createStore } from "ccstate";
 import { describe, expect, it } from "vitest";
@@ -78,6 +78,16 @@ function validFiles() {
       immutable: true,
     },
   ];
+}
+
+function fileForContent(path: string, content: string) {
+  const bytes = Buffer.from(content, "utf8");
+  return {
+    path,
+    size: bytes.byteLength,
+    sha256: createHash("sha256").update(bytes).digest("hex"),
+    contentType: "text/html; charset=utf-8",
+  };
 }
 
 function mockUploadedKeys(keys: readonly string[]) {
@@ -560,5 +570,157 @@ describe("POST /api/zero/host/deployments/:deploymentId/complete", () => {
       contentType: "text/html",
       url: completed.body.url,
     });
+  });
+});
+
+describe("POST /api/zero/host/presentation-html/redeploy", () => {
+  it("redeploys presentation HTML to the same hosted site URL", async () => {
+    const fixture = await seedHostedSiteFixture();
+    mocks.clerk.session(fixture.userId, fixture.orgId);
+
+    const client = setupApp({ context })(zeroHostContract);
+    const prepared = await accept(
+      client.prepare({
+        headers: { authorization: "Bearer clerk-session" },
+        body: {
+          site: "deck-site",
+          slugSuffix: "release-01",
+          artifactKind: "presentation-html",
+          spaFallback: true,
+          files: [
+            fileForContent("/index.html", "original"),
+            fileForContent("/assets/cat style.css", "body { color: black; }"),
+          ],
+        },
+      }),
+      [200],
+    );
+
+    mockUploadedKeys([
+      `sites/${prepared.body.publicSlug}/deployments/${prepared.body.deploymentId}/index.html`,
+      `sites/${prepared.body.publicSlug}/deployments/${prepared.body.deploymentId}/assets/cat style.css`,
+    ]);
+    await accept(
+      client.complete({
+        headers: { authorization: "Bearer clerk-session" },
+        params: { deploymentId: prepared.body.deploymentId },
+        body: {},
+      }),
+      [200],
+    );
+
+    const copied: string[] = [];
+    const copiedSources: string[] = [];
+    const puts: string[] = [];
+    context.mocks.s3.send.mockImplementation((command: unknown) => {
+      const commandName =
+        typeof command === "object" && command !== null
+          ? command.constructor.name
+          : "";
+      const input =
+        typeof command === "object" && command !== null && "input" in command
+          ? (command.input as { CopySource?: string; Key?: string })
+          : {};
+      if (commandName === "HeadObjectCommand") {
+        return Promise.resolve({});
+      }
+      if (commandName === "CopyObjectCommand" && input.Key) {
+        copied.push(input.Key);
+      }
+      if (commandName === "CopyObjectCommand" && input.CopySource) {
+        copiedSources.push(input.CopySource);
+      }
+      if (commandName === "PutObjectCommand" && input.Key) {
+        puts.push(input.Key);
+      }
+      return Promise.resolve({});
+    });
+
+    const redeployed = await accept(
+      client.redeployPresentationHtml({
+        headers: { authorization: "Bearer clerk-session" },
+        body: {
+          url: prepared.body.url,
+          html: "<!doctype html><html><body>edited</body></html>",
+        },
+      }),
+      [200],
+    );
+
+    expect(redeployed.body.url).toBe(prepared.body.url);
+    expect(redeployed.body.deploymentId).not.toBe(prepared.body.deploymentId);
+
+    const prefix = `sites/${prepared.body.publicSlug}/deployments/${redeployed.body.deploymentId}`;
+    expect(copied).toStrictEqual([`${prefix}/assets/cat style.css`]);
+    expect(copiedSources).toStrictEqual([
+      `test-hosted-sites/sites/${prepared.body.publicSlug}/deployments/${prepared.body.deploymentId}/assets/cat%20style.css`,
+    ]);
+    expect(puts).toStrictEqual([
+      `${prefix}/index.html`,
+      `${prefix}/manifest.json`,
+      `sites/${prepared.body.publicSlug}/active.json`,
+    ]);
+
+    const [site] = await store
+      .set(writeDb$)
+      .select()
+      .from(hostedSites)
+      .where(eq(hostedSites.id, prepared.body.siteId));
+    expect(site?.activeDeploymentId).toBe(redeployed.body.deploymentId);
+
+    const [deployment] = await store
+      .set(writeDb$)
+      .select()
+      .from(hostedDeployments)
+      .where(eq(hostedDeployments.id, redeployed.body.deploymentId));
+    expect(deployment?.spaFallback).toBeTruthy();
+    expect(deployment?.manifest.spaFallback).toBeTruthy();
+  });
+
+  it("rejects redeploying a non-presentation hosted site", async () => {
+    const fixture = await seedHostedSiteFixture();
+    mocks.clerk.session(fixture.userId, fixture.orgId);
+
+    const client = setupApp({ context })(zeroHostContract);
+    const prepared = await accept(
+      client.prepare({
+        headers: { authorization: "Bearer clerk-session" },
+        body: {
+          site: "plain-site",
+          slugSuffix: "release-01",
+          artifactKind: "hosted-site",
+          spaFallback: false,
+          files: [fileForContent("/index.html", "original")],
+        },
+      }),
+      [200],
+    );
+
+    mockUploadedKeys([
+      `sites/${prepared.body.publicSlug}/deployments/${prepared.body.deploymentId}/index.html`,
+    ]);
+    await accept(
+      client.complete({
+        headers: { authorization: "Bearer clerk-session" },
+        params: { deploymentId: prepared.body.deploymentId },
+        body: {},
+      }),
+      [200],
+    );
+
+    const redeployed = await accept(
+      client.redeployPresentationHtml({
+        headers: { authorization: "Bearer clerk-session" },
+        body: {
+          url: prepared.body.url,
+          html: "<!doctype html><html><body>edited</body></html>",
+        },
+      }),
+      [400],
+    );
+
+    expect(redeployed.body.error.message).toBe(
+      "Hosted site is not a presentation HTML artifact",
+    );
   });
 });

--- a/turbo/apps/api/src/signals/routes/zero-host.ts
+++ b/turbo/apps/api/src/signals/routes/zero-host.ts
@@ -7,6 +7,7 @@ import { bodyResultOf, pathParamsOf } from "../context/request";
 import {
   completeHostedSiteDeployment$,
   prepareHostedSiteDeployment$,
+  redeployPresentationHtml$,
 } from "../services/zero-host.service";
 import { rejectSuspendedOrg$ } from "../services/zero-org-suspension.service";
 import { badRequestMessage, conflict, notFound } from "../../lib/error";
@@ -62,6 +63,9 @@ const prepareInner$ = command(async ({ get, set }, signal: AbortSignal) => {
 });
 
 const completeParams$ = pathParamsOf(zeroHostContract.complete);
+const redeployPresentationHtmlBody$ = bodyResultOf(
+  zeroHostContract.redeployPresentationHtml,
+);
 const completeInner$ = command(async ({ get, set }, signal: AbortSignal) => {
   const auth = get(organizationAuthContext$);
 
@@ -97,6 +101,49 @@ const completeInner$ = command(async ({ get, set }, signal: AbortSignal) => {
   return { status: 200 as const, body: result.body };
 });
 
+const redeployPresentationHtmlInner$ = command(
+  async ({ get, set }, signal: AbortSignal) => {
+    const auth = get(organizationAuthContext$);
+
+    const bodyResult = await get(redeployPresentationHtmlBody$);
+    signal.throwIfAborted();
+    if (!bodyResult.ok) {
+      return bodyResult.response;
+    }
+
+    const suspended = await set(rejectSuspendedOrg$, auth.orgId, signal);
+    if (suspended) {
+      return suspended;
+    }
+
+    const result = await set(
+      redeployPresentationHtml$,
+      {
+        orgId: auth.orgId,
+        userId: auth.userId,
+        body: bodyResult.data,
+      },
+      signal,
+    );
+    signal.throwIfAborted();
+
+    if (result.status === "bad_request") {
+      return badRequestMessage(result.message);
+    }
+    if (result.status === "conflict") {
+      return conflict(result.message);
+    }
+    if (result.status === "not_found") {
+      return notFound(result.message);
+    }
+    if (result.status === "config_error") {
+      return internalError(result.message);
+    }
+
+    return { status: 200 as const, body: result.body };
+  },
+);
+
 export const zeroHostRoutes: readonly RouteEntry[] = [
   {
     route: zeroHostContract.prepare,
@@ -118,6 +165,17 @@ export const zeroHostRoutes: readonly RouteEntry[] = [
         missingOrganizationStatus: 401,
       },
       completeInner$,
+    ),
+  },
+  {
+    route: zeroHostContract.redeployPresentationHtml,
+    handler: authRoute(
+      {
+        requiredCapability: "host:write",
+        requireOrganization: true,
+        missingOrganizationStatus: 401,
+      },
+      redeployPresentationHtmlInner$,
     ),
   },
 ];

--- a/turbo/apps/api/src/signals/services/zero-host.service.ts
+++ b/turbo/apps/api/src/signals/services/zero-host.service.ts
@@ -4,6 +4,7 @@ import { command } from "ccstate";
 import type {
   HostedArtifactKind,
   HostedSitePrepareRequest,
+  HostedSiteRedeployPresentationHtmlRequest,
 } from "@vm0/api-contracts/contracts/zero-host";
 import {
   hostedDeployments,
@@ -16,6 +17,7 @@ import { and, eq, isNull } from "drizzle-orm";
 import { env } from "../../lib/env";
 import { type Db, writeDb$ } from "../external/db";
 import {
+  copyHostedSitesS3Object,
   generateHostedSitesPresignedPutUrl,
   hostedSitesS3ObjectExists,
   putHostedSitesS3Object,
@@ -38,6 +40,12 @@ interface PrepareDeploymentArgs {
 interface CompleteDeploymentArgs {
   readonly orgId: string;
   readonly deploymentId: string;
+}
+
+interface RedeployPresentationHtmlArgs {
+  readonly orgId: string;
+  readonly userId: string;
+  readonly body: HostedSiteRedeployPresentationHtmlRequest;
 }
 
 type PrepareDeploymentResult =
@@ -73,6 +81,17 @@ type CompleteDeploymentResult =
   | { readonly status: "conflict"; readonly message: string }
   | { readonly status: "bad_request"; readonly message: string }
   | { readonly status: "config_error"; readonly message: string };
+
+type RedeployPresentationHtmlResult = CompleteDeploymentResult;
+
+type RedeployPresentationTargetResult =
+  | {
+      readonly status: "ok";
+      readonly activeDeployment: HostedDeploymentRow;
+      readonly site: HostedSiteRow;
+    }
+  | { readonly status: "not_found"; readonly message: string }
+  | { readonly status: "bad_request"; readonly message: string };
 
 interface ActiveSitePointer {
   readonly version: 1;
@@ -142,6 +161,19 @@ function publicUrl(publicSlug: string): string {
   return `${env("ZERO_HOST_SCHEME")}://${publicSlug}.${env("ZERO_HOST_DOMAIN")}`;
 }
 
+function publicSlugFromHostedSiteUrl(value: string): string | null {
+  if (!URL.canParse(value)) {
+    return null;
+  }
+  const url = new URL(value);
+  const hostDomain = env("ZERO_HOST_DOMAIN");
+  if (url.hostname === hostDomain || !url.hostname.endsWith(`.${hostDomain}`)) {
+    return null;
+  }
+  const publicSlug = url.hostname.slice(0, -(hostDomain.length + ".".length));
+  return publicSlug || null;
+}
+
 function activePointerKey(publicSlug: string): string {
   return `sites/${publicSlug}/active.json`;
 }
@@ -202,6 +234,78 @@ function contentHash(files: readonly HostedSiteManifestFile[]): string {
     hash.update("\0");
   }
   return hash.digest("hex");
+}
+
+function hostedSiteFileForContent(
+  path: string,
+  content: string,
+  contentType: string,
+): HostedSitePrepareRequest["files"][number] {
+  const bytes = Buffer.from(content, "utf8");
+  return {
+    path,
+    size: bytes.byteLength,
+    sha256: createHash("sha256").update(bytes).digest("hex"),
+    contentType,
+  };
+}
+
+async function findPresentationRedeployTarget(
+  writeDb: Db,
+  args: {
+    readonly orgId: string;
+    readonly publicSlug: string;
+  },
+  signal: AbortSignal,
+): Promise<RedeployPresentationTargetResult> {
+  const [site] = await writeDb
+    .select()
+    .from(hostedSites)
+    .where(
+      and(
+        eq(hostedSites.publicSlug, args.publicSlug),
+        eq(hostedSites.orgId, args.orgId),
+        isNull(hostedSites.deletedAt),
+      ),
+    )
+    .limit(1);
+  signal.throwIfAborted();
+
+  if (!site) {
+    return { status: "not_found", message: "Hosted site not found" };
+  }
+  if (!site.activeDeploymentId) {
+    return {
+      status: "bad_request",
+      message: "Hosted site has no active deployment",
+    };
+  }
+
+  const [activeDeployment] = await writeDb
+    .select()
+    .from(hostedDeployments)
+    .where(
+      and(
+        eq(hostedDeployments.id, site.activeDeploymentId),
+        eq(hostedDeployments.orgId, args.orgId),
+      ),
+    )
+    .limit(1);
+  signal.throwIfAborted();
+
+  if (!activeDeployment) {
+    return {
+      status: "not_found",
+      message: "Active hosted deployment not found",
+    };
+  }
+  if (activeDeployment.manifest.artifactKind !== "presentation-html") {
+    return {
+      status: "bad_request",
+      message: "Hosted site is not a presentation HTML artifact",
+    };
+  }
+  return { status: "ok", activeDeployment, site };
 }
 
 function validateFiles(
@@ -598,5 +702,121 @@ export const completeHostedSiteDeployment$ = command(
         status: "ready",
       },
     };
+  },
+);
+
+export const redeployPresentationHtml$ = command(
+  async (
+    { get, set },
+    args: RedeployPresentationHtmlArgs,
+    signal: AbortSignal,
+  ): Promise<RedeployPresentationHtmlResult> => {
+    const hostedR2 = hostedR2Config();
+    if (hostedR2.status === "config_error") {
+      return hostedR2;
+    }
+
+    const publicSlug = publicSlugFromHostedSiteUrl(args.body.url);
+    if (!publicSlug) {
+      return {
+        status: "bad_request",
+        message: "URL is not a hosted site URL",
+      };
+    }
+
+    const writeDb = set(writeDb$);
+    const target = await findPresentationRedeployTarget(
+      writeDb,
+      {
+        orgId: args.orgId,
+        publicSlug,
+      },
+      signal,
+    );
+    if (target.status !== "ok") {
+      return target;
+    }
+    const { activeDeployment, site } = target;
+
+    const indexFile = hostedSiteFileForContent(
+      "/index.html",
+      args.body.html,
+      "text/html; charset=utf-8",
+    );
+    const files = [
+      indexFile,
+      ...Object.values(activeDeployment.manifest.files).filter((file) => {
+        return file.path !== indexFile.path;
+      }),
+    ];
+    const fileError = validateFiles(files);
+    if (fileError) {
+      return { status: "bad_request", message: fileError };
+    }
+
+    const now = nowDate();
+    const result = await createHostedSiteDeployment(
+      writeDb,
+      {
+        orgId: args.orgId,
+        userId: args.userId,
+        body: {
+          site: site.slug,
+          artifactKind: "presentation-html",
+          spaFallback: activeDeployment.spaFallback,
+          files,
+        },
+      },
+      {
+        now,
+        publicSlug,
+        url: publicUrl(publicSlug),
+        allowExistingPublicSlug: true,
+      },
+    );
+    signal.throwIfAborted();
+
+    if (result.kind === "slug_conflict") {
+      return {
+        status: "conflict",
+        message: `Hosted site slug is already in use: ${publicSlug}`,
+      };
+    }
+
+    await Promise.all(
+      files
+        .filter((file) => {
+          return file.path !== indexFile.path;
+        })
+        .map((file) => {
+          return get(
+            copyHostedSitesS3Object(
+              hostedR2.config.bucket,
+              fileKey(activeDeployment.r2Prefix, file.path),
+              fileKey(result.deployment.r2Prefix, file.path),
+            ),
+          );
+        }),
+    );
+    signal.throwIfAborted();
+
+    await get(
+      putHostedSitesS3Object(
+        hostedR2.config.bucket,
+        fileKey(result.deployment.r2Prefix, indexFile.path),
+        Buffer.from(args.body.html, "utf8"),
+        indexFile.contentType,
+      ),
+    );
+    signal.throwIfAborted();
+
+    return set(
+      completeHostedSiteDeployment$,
+      {
+        orgId: args.orgId,
+        deploymentId: result.deployment.id,
+      },
+      signal,
+    );
   },
 );

--- a/turbo/apps/web/__tests__/api-backend-rewrite-proxy.test.ts
+++ b/turbo/apps/web/__tests__/api-backend-rewrite-proxy.test.ts
@@ -1473,6 +1473,9 @@ describe("API backend rewrite proxy behavior", () => {
         "/api/zero/host/deployments/eca12aa0-4c26-48c7-85d8-b3af58d408c7/complete",
       ),
     ).toBe(true);
+    expect(
+      matchesApiBackendRewritePath("/api/zero/host/presentation-html/redeploy"),
+    ).toBe(true);
   });
 
   it("matches the email unsubscribe rewrite path exactly", () => {

--- a/turbo/apps/web/api-backend-rewrites.js
+++ b/turbo/apps/web/api-backend-rewrites.js
@@ -759,6 +759,10 @@ export const API_BACKEND_REWRITES = [
     "/api/zero/host/deployments/:deploymentId/complete",
   ],
   ["/api/zero/host/deployments/prepare", "/api/zero/host/deployments/prepare"],
+  [
+    "/api/zero/host/presentation-html/redeploy",
+    "/api/zero/host/presentation-html/redeploy",
+  ],
   [ZERO_ME_MODEL_PROVIDERS_REWRITE_SOURCE, "/api/zero/me/model-providers"],
   [
     ZERO_ME_MODEL_PROVIDER_TYPE_REWRITE_SOURCE,

--- a/turbo/packages/api-contracts/src/contracts/zero-host.ts
+++ b/turbo/packages/api-contracts/src/contracts/zero-host.ts
@@ -74,6 +74,11 @@ export const hostedSiteUploadSchema = z.object({
   uploadUrl: z.string().url(),
 });
 
+export const hostedSiteRedeployPresentationHtmlRequestSchema = z.object({
+  url: z.string().url(),
+  html: z.string().min(1),
+});
+
 export const hostedSitePrepareResponseSchema = z.object({
   siteId: z.string().uuid(),
   deploymentId: z.string().uuid(),
@@ -127,11 +132,31 @@ export const zeroHostContract = c.router({
     },
     summary: "Complete a static hosted-site deployment",
   },
+  redeployPresentationHtml: {
+    method: "POST",
+    path: "/api/zero/host/presentation-html/redeploy",
+    headers: authHeadersSchema,
+    body: hostedSiteRedeployPresentationHtmlRequestSchema,
+    responses: {
+      200: hostedSiteCompleteResponseSchema,
+      400: apiErrorSchema,
+      401: apiErrorSchema,
+      402: apiErrorSchema,
+      403: apiErrorSchema,
+      404: apiErrorSchema,
+      409: apiErrorSchema,
+      500: apiErrorSchema,
+    },
+    summary: "Redeploy an existing presentation HTML hosted site",
+  },
 });
 
 export type ZeroHostContract = typeof zeroHostContract;
 export type HostedSitePrepareRequest = z.infer<
   typeof hostedSitePrepareRequestSchema
+>;
+export type HostedSiteRedeployPresentationHtmlRequest = z.infer<
+  typeof hostedSiteRedeployPresentationHtmlRequestSchema
 >;
 export type HostedSitePrepareResponse = z.infer<
   typeof hostedSitePrepareResponseSchema


### PR DESCRIPTION
## Summary
- add the presentation HTML redeploy contract and API route
- redeploy by replacing /index.html while preserving existing hosted-site assets in a new deployment
- add web API backend rewrite coverage for the new route

## Split PR scope
This is the backend-first PR for the presentation HTML editor work. Platform editor UI changes are intentionally left out for a follow-up PR.

## Tests
- pnpm -F api exec tsc --noEmit
- pnpm -F web exec vitest run __tests__/api-backend-rewrite-proxy.test.ts
- pnpm -F api exec vitest run src/signals/routes/__tests__/zero-host.test.ts (blocked locally: PostgreSQL is not running, ECONNREFUSED 127.0.0.1:5432 / ::1:5432)