### PR TITLE
docs: fix stale apps/web paths after db and auth moved to @vm0/db and apps/api

### DIFF
--- a/.claude/skills/code-quality/SKILL.md
+++ b/.claude/skills/code-quality/SKILL.md
@@ -94,8 +94,8 @@ review "authentication changes"     # Review by description
    - Suggest static import alternatives
    - Zero tolerance unless truly justified
 
-   **Database Mocking in Web Tests (Bad Smell #7)**
-   - Flag globalThis.services mocking in apps/web tests
+   **Database Mocking in Route Tests (Bad Smell #7)**
+   - Flag database or internal-service mocking in apps/api route tests
    - Verify real database connections are used
 
    **Test Mock Cleanup (Bad Smell #8)**

--- a/.claude/skills/database-development/SKILL.md
+++ b/.claude/skills/database-development/SKILL.md
@@ -8,7 +8,7 @@ description: Database migrations and Drizzle ORM guidelines for the vm0 project
 ## Commands
 
 ```bash
-cd turbo/apps/web
+cd turbo/packages/db
 
 pnpm db:generate   # Generate migration from schema changes
 pnpm db:migrate    # Run pending migrations
@@ -20,7 +20,7 @@ pnpm db:studio     # Open Drizzle Studio UI
 ### Auto-Generated (simple changes)
 
 ```bash
-# 1. Edit schema in src/db/schema/
+# 1. Edit schema in src/schema/
 # 2. Generate migration (auto-updates _journal.json and snapshot)
 pnpm db:generate
 # 3. Run locally
@@ -47,7 +47,7 @@ When a data migration requires **external API calls** (e.g., reading from Clerk)
 it cannot be done in a SQL migration. These scripts live in:
 
 ```
-turbo/apps/web/scripts/migrations/NNN-description/
+turbo/packages/db/scripts/migrations/NNN-description/
 ├── backfill.ts   # (or sync.ts) — the migration script
 └── README.md     # Usage, prerequisites, verification steps
 ```
@@ -68,8 +68,8 @@ Pure data transforms that only touch the database should use regular SQL migrati
 
 Before committing:
 
-- [ ] Schema file updated in `src/db/schema/`
-- [ ] Schema exported in `src/db/db.ts` (if new table)
+- [ ] Schema file updated in `src/schema/`
+- [ ] Schema exported in `src/index.ts` (if new table)
 - [ ] Custom migrations created via `drizzle-kit generate --custom` (not manually)
 - [ ] `pnpm db:migrate` works locally
 - [ ] `pnpm test` passes

--- a/.claude/skills/feature-switch/SKILL.md
+++ b/.claude/skills/feature-switch/SKILL.md
@@ -123,7 +123,7 @@ myConnector: {
 
 #### Zero token capability gating
 
-In `turbo/apps/web/src/lib/auth/sandbox-token.ts`, add to `CONDITIONAL_CAPABILITIES`:
+In `turbo/apps/api/src/signals/auth/tokens.ts`, add to `CONDITIONAL_CAPABILITIES`:
 
 ```typescript
 const CONDITIONAL_CAPABILITIES: ReadonlyMap<ZeroCapability, FeatureSwitchKey> =
@@ -142,7 +142,7 @@ const CONDITIONAL_CAPABILITIES: ReadonlyMap<ZeroCapability, FeatureSwitchKey> =
 | `turbo/apps/platform/src/signals/external/feature-switch.ts` | Client-side reactive state with override layers |
 | `turbo/apps/platform/src/views/zero-page/zero-sidebar.tsx` | Sidebar nav items with `featureGate` |
 | `turbo/packages/core/src/contracts/connectors.ts` | Connector type definitions with `featureFlag` field |
-| `turbo/apps/web/src/lib/auth/sandbox-token.ts` | Token capability gating |
+| `turbo/apps/api/src/signals/auth/tokens.ts` | Token capability gating |
 
 ## Override Layers
 

--- a/.github/DEPLOYMENT_SETUP.md
+++ b/.github/DEPLOYMENT_SETUP.md
@@ -99,7 +99,7 @@ The workflow automatically pushes database schema to preview branches using:
 pnpm db:push
 ```
 
-This uses Drizzle Kit to push your schema defined in `turbo/apps/web/src/db/schema/` to the Neon database branch.
+This uses Drizzle Kit to push your schema defined in `turbo/packages/db/src/schema/` to the Neon database branch.
 
 ## Environment Variables Details
 


### PR DESCRIPTION
## Why

Follow-up to #16651. While auditing `apps/web` references during the API-routing doc cleanup, I found a **second** set of stale paths from a different migration: database schema, migrations, and Zero token capability gating moved out of `apps/web` into the `@vm0/db` package (`packages/db`) and `apps/api`. Several skill and deployment docs still pointed at the old `apps/web` locations.

Verified current locations:
- schema: `apps/web/src/db/schema/` → **`packages/db/src/schema/`** (`apps/web/src/db` no longer exists)
- schema barrel: `src/db/db.ts` → **`packages/db/src/index.ts`**
- data-migration scripts: `apps/web/scripts/migrations/` → **`packages/db/scripts/migrations/`**
- `db:generate` / `db:migrate` / `db:studio`: defined in **`packages/db/package.json`**
- `CONDITIONAL_CAPABILITIES`: `apps/web/src/lib/auth/sandbox-token.ts` → **`apps/api/src/signals/auth/tokens.ts`**
- `apps/web` no longer exposes a `globalThis.services` singleton

## Changes

- **`database-development` skill**: run db commands from `packages/db`; schema lives in `src/schema/` and is exported via `src/index.ts`; data-migration scripts live in `packages/db/scripts/migrations/`.
- **`feature-switch` skill**: point token capability gating at `apps/api/src/signals/auth/tokens.ts` (2 refs).
- **`code-quality` skill**: the "Database Mocking" bad-smell check now targets `apps/api` route tests (apps/web has no `globalThis.services` to mock anymore).
- **`.github/DEPLOYMENT_SETUP.md`**: Drizzle schema path is `packages/db/src/schema/`.

## Intentionally left untouched

- **`CONTRIBUTING.md`** (`apps/web/.env.local.tpl`) and **`DEPLOYMENT_SETUP.md`** Vercel root (`turbo/apps/web`) — still correct; the web app still exists and deploys.
- **`.github/workflows/release-please.yml`** references `apps/web/src/db/migrations/` on purpose: it looks up the *previous* release tag's migration files at their old path to compare them against the new location, i.e. deliberate transition-handling, not a stale path. Left as-is.

## Notes

Docs-only change, +10/−10. No code touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)