### PR TITLE
chore: preserve mixpanel connector icon color

### DIFF
--- a/turbo/apps/platform/src/views/zero-page/components/settings/connector-icons.tsx
+++ b/turbo/apps/platform/src/views/zero-page/components/settings/connector-icons.tsx
@@ -177,6 +177,7 @@ const CONNECTOR_ICON_COLORFUL = {
   minimax: true,
   minio: true,
   miro: true,
+  mixpanel: true,
   modal: true,
   monday: true,
   moss: true,


### PR DESCRIPTION
## Summary
- add `mixpanel` to `CONNECTOR_ICON_COLORFUL` so the existing purple SVG is not passed through the mono icon filter
- keep the existing SVG asset with explicit `#7856FF` fill
- avoid adding raster assets or `currentColor`

Closes #16662

## Sources
- https://mixpanel.com

## Checks
- `cd turbo && pnpm -F @vm0/db db:migrate`
- `cd turbo && pnpm exec prettier --check apps/platform/src/views/zero-page/components/settings/connector-icons.tsx`
- `git diff --check`
- SVG structural check: existing `mixpanel.svg` has explicit `#7856FF` fill, no `currentColor`, `<image>`, `data:image`, or raster references; only `mixpanel.svg` exists for the connector

## Note
- Local pre-commit was run and failed at the full repository `pnpm knip --cache` step because of existing unrelated findings in `apps/platform` (`dom-to-pptx` deep import), `packages/ui`, and `packages/eslint-config`. This icon PR keeps those unrelated cleanup items out of scope.