### PR TITLE
ci: prebuild app preview deployments

### DIFF
--- a/.github/workflows/turbo.yml
+++ b/.github/workflows/turbo.yml
@@ -1252,6 +1252,7 @@ jobs:
           vercel-project-id: ${{ vars.VERCEL_PROJECT_ID_APP }}
           environment: preview
           deployment-env: app
+          prebuilt: "true"
           environment-variables: |
             VITE_CLERK_PUBLISHABLE_KEY=${{ vars.CLERK_PUBLISHABLE_KEY }}
             VITE_VERCEL_ENV=preview


### PR DESCRIPTION
## Summary
- switch `vm0-app` preview deployments to the shared prebuilt Vercel deploy path
- keep uploads archived through the existing `vercel deploy --prebuilt --archive=tgz` path to avoid excessive small-file uploads

## Verification
- `git diff --check`
- parsed `.github/workflows/turbo.yml` with Ruby YAML loader

Full local tests were not run per vm0 PR preference for workflow-only changes.
