### PR TITLE
fix: coordinate cancellation with idle-pool transfer

### DIFF
--- a/crates/runner/src/cmd/start/job_discovery.rs
+++ b/crates/runner/src/cmd/start/job_discovery.rs
@@ -3,13 +3,12 @@
 //! `run()` owns the provider discovery future and reactor scheduling. This
 //! module owns the body that turns a discovered job into a claimed spawned job.
 
+use std::collections::BTreeMap;
 use std::collections::hash_map::Entry;
-use std::collections::{BTreeMap, HashMap};
 use std::sync::Arc;
 
 use sandbox::SandboxId;
 use tokio::task::JoinSet;
-use tokio_util::sync::CancellationToken;
 use tracing::{info, warn};
 
 use super::active_sessions::ActiveSessionGuard;
@@ -24,6 +23,7 @@ use crate::idle_pool::{IdlePoolSnapshot, IdleUnparkResult, ReusableIdleSandbox};
 use crate::ids::RunId;
 use crate::provider::{ClaimedJob, JobCandidate};
 use crate::resource_budget::{BudgetLease, ResourceBudget};
+use crate::run_cancellation::{RunCancellationHandle, SharedRunCancellationMap};
 use crate::status::{RunnerMode, StatusTracker};
 use crate::types::{ExecutionContext, SandboxReuseResult};
 
@@ -38,7 +38,7 @@ pub(super) struct DiscoveredJobContext<'a> {
     pub(super) idle_pool: &'a SharedIdlePool,
     pub(super) status: &'a StatusTracker,
     pub(super) mode_rx: &'a tokio::sync::watch::Receiver<RunnerMode>,
-    pub(super) cancel_tokens: &'a Arc<tokio::sync::Mutex<HashMap<RunId, CancellationToken>>>,
+    pub(super) cancel_tokens: &'a SharedRunCancellationMap,
     pub(super) spawn_ctx: &'a SpawnContext,
     pub(super) destroy_tasks: &'a mut JoinSet<bool>,
     pub(super) jobs: &'a mut JoinSet<Option<RunId>>,
@@ -47,20 +47,17 @@ pub(super) struct DiscoveredJobContext<'a> {
 struct LocalAdmission {
     run_id: RunId,
     budget_lease: BudgetLease,
-    cancel: CancellationToken,
+    cancel: RunCancellationHandle,
 }
 
 struct AdmittedClaim {
     claimed: ClaimedJob,
     budget_lease: BudgetLease,
-    cancel: CancellationToken,
+    cancel: RunCancellationHandle,
 }
 
 impl LocalAdmission {
-    async fn rollback(
-        self,
-        cancel_tokens: &Arc<tokio::sync::Mutex<HashMap<RunId, CancellationToken>>>,
-    ) {
+    async fn rollback(self, cancel_tokens: &SharedRunCancellationMap) {
         let Self {
             run_id,
             budget_lease,
@@ -180,7 +177,7 @@ async fn claim_with_local_admission(
     // (Ably supervisor for ApiProvider, `.cancel` scan for LocalProvider) can
     // find the active job. Skip duplicate discoveries; overwriting would break
     // cancel delivery for the executor.
-    let job_cancel = CancellationToken::new();
+    let job_cancel = RunCancellationHandle::new();
     {
         let mut tokens = ctx.cancel_tokens.lock().await;
         match tokens.entry(run_id) {
@@ -208,7 +205,7 @@ async fn claim_with_local_admission(
             return None;
         }
         RunnerMode::Stopping => {
-            admission.cancel.cancel();
+            admission.cancel.cancel().await;
         }
         RunnerMode::Stopped => {
             admission.rollback(ctx.cancel_tokens).await;

--- a/crates/runner/src/cmd/start/job_spawn.rs
+++ b/crates/runner/src/cmd/start/job_spawn.rs
@@ -4,7 +4,6 @@
 //! owns the spawned task body: executor orchestration, provider completion,
 //! deferred telemetry/network-log uploads, and outer-task panic cleanup.
 
-use std::collections::HashMap;
 use std::panic::AssertUnwindSafe;
 use std::sync::Arc;
 
@@ -34,6 +33,7 @@ use crate::network_log_drain::NetworkLogDrainCoordinator;
 use crate::network_logs;
 use crate::provider::{ClaimedJob, CompletionAuth, JobProvider};
 use crate::resource_budget::BudgetLease;
+use crate::run_cancellation::{RunCancellationHandle, SharedRunCancellationMap};
 use crate::status::StatusTracker;
 use crate::telemetry::JobTelemetry;
 use crate::types::{ExecutionContext, SandboxReuseResult};
@@ -48,7 +48,7 @@ pub(super) struct JobProfile {
     pub(super) restore_guest_state: bool,
     pub(super) device_rate_limits: Option<sandbox::DeviceRateLimits>,
     pub(super) factory: SharedFactory,
-    pub(super) cancel: CancellationToken,
+    pub(super) cancel: RunCancellationHandle,
 }
 
 /// Shared state passed to each spawned job task.
@@ -57,7 +57,7 @@ pub(super) struct SpawnContext {
     pub(super) exec_config: Arc<ExecutorConfig>,
     pub(super) idle_pool: SharedIdlePool,
     pub(super) status: Arc<StatusTracker>,
-    pub(super) cancel_tokens: Arc<tokio::sync::Mutex<HashMap<RunId, CancellationToken>>>,
+    pub(super) cancel_tokens: SharedRunCancellationMap,
     pub(super) orphaned_active_runs: OrphanedActiveRuns,
     /// Current lifecycle parking permission. This is checked at job
     /// completion so soft-drain/resume races do not depend on a stale
@@ -211,7 +211,7 @@ struct FinalizationPhase {
     park_notify: Arc<tokio::sync::Notify>,
     parking_gate: ParkingGate,
     network_log_drain: NetworkLogDrainCoordinator,
-    cancel: CancellationToken,
+    cancel: RunCancellationHandle,
     cleanup_state: RunCleanupState,
     #[cfg(test)]
     outer_job_panic: Option<OuterJobPanicPoint>,
@@ -274,8 +274,8 @@ impl FinalizationPhase {
             completion_auth,
         );
         // Cancellation can arrive after terminal logging or while
-        // `sandbox.park()` is in flight. Pass the live token so finalization
-        // can re-check immediately before idle-pool ownership transfer.
+        // `sandbox.park()` is in flight. Pass the live handle so finalization
+        // can synchronize the final idle-pool ownership transfer.
         let completion_ready = finalize_sandbox_for_completion(
             sandbox,
             ActiveBudgetLease::new(active_lease),
@@ -484,7 +484,7 @@ pub(super) fn spawn_job(
         factory: Arc::clone(&factory),
         reuse_entry,
         reuse_result,
-        cancel: job_cancel.clone(),
+        cancel: job_cancel.token(),
         sandbox_token: sandbox_token.clone(),
     };
     let finalization = FinalizationPhase {
@@ -668,7 +668,7 @@ fn is_info_level_job_failure(diagnostic: &FailureDiagnostic) -> bool {
 pub(super) async fn cleanup_panicked_job(
     run_id: RunId,
     sandbox_id: SandboxId,
-    cancel_tokens: Arc<tokio::sync::Mutex<HashMap<RunId, CancellationToken>>>,
+    cancel_tokens: SharedRunCancellationMap,
     status: Arc<StatusTracker>,
     idle_pool: SharedIdlePool,
     cleanup_state: RunCleanupState,
@@ -701,7 +701,7 @@ pub(super) async fn cleanup_panicked_job(
 /// Handle a completed job from the JoinSet, cleaning up cancel tokens.
 pub(super) async fn handle_job_result(
     result: Option<Result<Option<RunId>, tokio::task::JoinError>>,
-    cancel_tokens: &Arc<tokio::sync::Mutex<HashMap<RunId, CancellationToken>>>,
+    cancel_tokens: &SharedRunCancellationMap,
 ) {
     match result {
         Some(Ok(Some(run_id))) => {
@@ -727,7 +727,6 @@ mod tests {
     };
     use sandbox::{SandboxFactory, SandboxId};
     use sandbox_mock::{MockSandbox, MockSandboxFactory};
-    use tokio_util::sync::CancellationToken;
     use tracing::field::{Field, Visit};
     use tracing::{Event, Level, Subscriber};
     use tracing_subscriber::layer::{Context, Layer};
@@ -1006,7 +1005,7 @@ mod tests {
         status_path: std::path::PathBuf,
         status: Arc<StatusTracker>,
         idle_pool: SharedIdlePool,
-        tokens: Arc<tokio::sync::Mutex<HashMap<RunId, CancellationToken>>>,
+        tokens: SharedRunCancellationMap,
         orphans: OrphanedActiveRuns,
         _dir: tempfile::TempDir,
     }
@@ -1021,7 +1020,7 @@ mod tests {
                     default_timeout: Duration::from_secs(300),
                     max_idle: 10,
                 })));
-            let tokens: Arc<tokio::sync::Mutex<HashMap<RunId, CancellationToken>>> =
+            let tokens: SharedRunCancellationMap =
                 Arc::new(tokio::sync::Mutex::new(HashMap::new()));
             let orphans = OrphanedActiveRuns::new();
 
@@ -1069,7 +1068,7 @@ mod tests {
             .tokens
             .lock()
             .await
-            .insert(run_id, CancellationToken::new());
+            .insert(run_id, RunCancellationHandle::new());
         cleanup_state.mark_status_removed();
 
         fixture.cleanup(run_id, sandbox_id, cleanup_state).await;
@@ -1091,7 +1090,7 @@ mod tests {
             .tokens
             .lock()
             .await
-            .insert(run_id, CancellationToken::new());
+            .insert(run_id, RunCancellationHandle::new());
 
         fixture
             .cleanup(run_id, sandbox_id, RunCleanupState::new())
@@ -1115,7 +1114,7 @@ mod tests {
             .tokens
             .lock()
             .await
-            .insert(run_id, CancellationToken::new());
+            .insert(run_id, RunCancellationHandle::new());
         cleanup_state.mark_destroy_completed();
 
         fixture.cleanup(run_id, sandbox_id, cleanup_state).await;
@@ -1140,7 +1139,7 @@ mod tests {
             .tokens
             .lock()
             .await
-            .insert(run_id, CancellationToken::new());
+            .insert(run_id, RunCancellationHandle::new());
         cleanup_state.mark_destroy_completed();
 
         fixture
@@ -1184,7 +1183,7 @@ mod tests {
             .tokens
             .lock()
             .await
-            .insert(run_id, CancellationToken::new());
+            .insert(run_id, RunCancellationHandle::new());
         cleanup_state.mark_idle_pool_owned();
 
         fixture.cleanup(run_id, sandbox_id, cleanup_state).await;

--- a/crates/runner/src/cmd/start/mod.rs
+++ b/crates/runner/src/cmd/start/mod.rs
@@ -59,6 +59,7 @@ use crate::provider::{ApiProvider, JobProvider, LocalProvider};
 use crate::proxy;
 use crate::resource_budget::ResourceBudget;
 use crate::retry::{RetryState, recv_retry, sleep_until_retry};
+use crate::run_cancellation::SharedRunCancellationMap;
 use crate::status::{RunnerMode, StatusTracker};
 use crate::workspace_image_cache::SessionWorkspaceCache;
 
@@ -445,8 +446,7 @@ pub async fn run_start(
     })?;
     let name = runner_config.name;
     let group = runner_config.group;
-    let cancel_tokens: Arc<tokio::sync::Mutex<HashMap<RunId, CancellationToken>>> =
-        Arc::new(tokio::sync::Mutex::new(HashMap::new()));
+    let cancel_tokens: SharedRunCancellationMap = Arc::new(tokio::sync::Mutex::new(HashMap::new()));
     let (usage_flush_tx, usage_flush_rx) = mpsc::channel(1);
 
     let (provider, group_name): (Arc<dyn JobProvider>, String) = if args.local {
@@ -605,7 +605,7 @@ struct ProviderState {
     provider: Arc<dyn JobProvider>,
     /// Per-job cancel tokens shared with the provider for cancel events
     /// (Ably for ApiProvider, `.cancel` files for LocalProvider).
-    cancel_tokens: Arc<tokio::sync::Mutex<HashMap<RunId, CancellationToken>>>,
+    cancel_tokens: SharedRunCancellationMap,
     cancel: CancellationToken,
 }
 

--- a/crates/runner/src/cmd/start/sandbox_finalization.rs
+++ b/crates/runner/src/cmd/start/sandbox_finalization.rs
@@ -10,7 +10,6 @@ use std::sync::Arc;
 use chrono::SecondsFormat;
 use futures_util::FutureExt;
 use sandbox::{Sandbox, SandboxFactory, SandboxId};
-use tokio_util::sync::CancellationToken;
 use tracing::{info, warn};
 
 use super::idle_lifecycle::{
@@ -32,6 +31,7 @@ use crate::network_log_manager::NetworkLogSession;
 #[cfg(test)]
 use crate::provider::CompletionAuth;
 use crate::resource_budget::BudgetLease;
+use crate::run_cancellation::RunCancellationHandle;
 use crate::status::StatusTracker;
 use crate::workspace_image_cache::{
     WorkspaceCacheTerminalStatus, WorkspaceImageLease, WorkspaceImagePromotionRequest,
@@ -75,7 +75,7 @@ pub(super) struct FinalizeContext {
     pub(super) parking_gate: ParkingGate,
     pub(super) network_log_drain: NetworkLogDrainCoordinator,
     pub(super) exit_code: i32,
-    pub(super) cancel: CancellationToken,
+    pub(super) cancel: RunCancellationHandle,
     pub(super) cleanup_state: RunCleanupState,
     #[cfg(test)]
     pub(super) outer_job_panic: Option<OuterJobPanicPoint>,
@@ -241,102 +241,139 @@ pub(super) async fn finalize_sandbox_for_completion(
             close_network_log_session(run_id, network_log_session.take(), &network_log_drain).await;
             #[cfg(test)]
             test_observer.notify_before_idle_pool_ownership_transfer(run_id);
-            let mut pool = idle_pool.lock().await;
-            if cancel.is_cancelled() {
-                info!(
-                    run_id = %run_id,
-                    session_id,
-                    "job cancelled before idle pool ownership transfer, destroying VM"
-                );
-                drop(pool);
-                let (payload, budget_lease) = candidate.into_active_destroy_parts();
-                let destroy_result = destroy_active_owned_idle_payload(
-                    payload,
-                    budget_lease,
-                    "cancelled",
-                    destroy_bookkeeping,
-                )
-                .await;
-                return mark_session_affinity_refresh(
-                    CompletionReady::new(completion_payload, destroy_result.budget),
-                    destroy_result.workspace_cache_promoted,
-                    false,
-                );
-            }
-            let candidate = candidate.with_last_completed_at(completed_at.clone());
-            match pool.park(candidate) {
-                ParkResult::Parked => {
-                    info!(run_id = %run_id, session_id, "VM parked for reuse");
-                    cleanup_state.mark_idle_pool_owned();
-                    #[cfg(test)]
-                    maybe_panic_outer_job(
-                        outer_job_panic,
-                        OuterJobPanicPoint::IdlePoolOwned,
-                        run_id,
-                    );
-                    // Push fresh idle state to status.json BEFORE
-                    // conditional active-run removal (below) clears the run_id
-                    // from active_runs. Without this, doctor would
-                    // briefly see the FC as unknown (neither active
-                    // nor idle) until the next idle_cleanup tick
-                    // (~10s), producing transient false-positive
-                    // FirecrackerNotInStatus warnings.
-                    let snapshot = pool.status_snapshot();
+            loop {
+                let mut pool = idle_pool.lock().await;
+                // Let cancellation win while finalization is still waiting for
+                // the pool lock. Once the pool lock is held, only enter the
+                // final transfer boundary if the per-run gate is immediately
+                // available; otherwise release the pool lock before waiting.
+                let Some(transfer_guard) = cancel.try_transfer_guard() else {
                     drop(pool);
-                    let ownership = OwnershipTransitions::new(status.as_ref());
-                    ownership
-                        .publish_idle_status_after_pool_transfer(snapshot)
+                    let transfer_guard = cancel.transfer_guard().await;
+                    if cancel.is_cancelled() {
+                        info!(
+                            run_id = %run_id,
+                            session_id,
+                            "job cancelled before idle pool ownership transfer, destroying VM"
+                        );
+                        drop(transfer_guard);
+                        let (payload, budget_lease) = candidate.into_active_destroy_parts();
+                        let destroy_result = destroy_active_owned_idle_payload(
+                            payload,
+                            budget_lease,
+                            "cancelled",
+                            destroy_bookkeeping,
+                        )
                         .await;
-                    session_affinity_changed = true;
-                    session_affinity_refresh_sent = true;
-                    park_notify.notify_one();
-                    BudgetOwnership::idle_owned()
-                }
-                ParkResult::Replaced(evicted) => {
-                    info!(run_id = %run_id, session_id, "VM parked, evicting previous");
-                    cleanup_state.mark_idle_pool_owned();
-                    #[cfg(test)]
-                    maybe_panic_outer_job(
-                        outer_job_panic,
-                        OuterJobPanicPoint::IdlePoolOwned,
-                        run_id,
-                    );
-                    let snapshot = pool.status_snapshot();
-                    drop(pool);
-                    let ownership = OwnershipTransitions::new(status.as_ref());
-                    ownership
-                        .publish_idle_status_after_pool_transfer(snapshot)
-                        .await;
-                    session_affinity_changed = true;
-                    session_affinity_refresh_sent = true;
-                    park_notify.notify_one();
-                    // The replaced VM was park()ed when it entered the
-                    // pool; destroying a parked sandbox is safe — Drop
-                    // aborts any leftover handles and the FC process is
-                    // killed regardless of balloon state.
-                    if destroy_idle_jobs_and_wait(vec![evicted], "park_replaced").await {
-                        park_notify.notify_one();
+                        return mark_session_affinity_refresh(
+                            CompletionReady::new(completion_payload, destroy_result.budget),
+                            destroy_result.workspace_cache_promoted,
+                            false,
+                        );
                     }
-                    BudgetOwnership::idle_owned()
-                }
-                ParkResult::Rejected(rejected) => {
-                    info!(run_id = %run_id, session_id, "idle parking rejected, destroying VM");
+                    drop(transfer_guard);
+                    continue;
+                };
+                if cancel.is_cancelled() {
+                    info!(
+                        run_id = %run_id,
+                        session_id,
+                        "job cancelled before idle pool ownership transfer, destroying VM"
+                    );
+                    drop(transfer_guard);
                     drop(pool);
-                    // Pool unchanged (park rejected) — no status
-                    // update needed. The rejected sandbox was just
-                    // park()ed above; destroying a parked sandbox is
-                    // safe — see Replaced arm for rationale.
-                    let (payload, lease) = rejected.into_active_destroy_parts();
+                    let (payload, budget_lease) = candidate.into_active_destroy_parts();
                     let destroy_result = destroy_active_owned_idle_payload(
                         payload,
-                        lease,
-                        "park_rejected",
+                        budget_lease,
+                        "cancelled",
                         destroy_bookkeeping,
                     )
                     .await;
-                    session_affinity_changed |= destroy_result.workspace_cache_promoted;
-                    destroy_result.budget
+                    return mark_session_affinity_refresh(
+                        CompletionReady::new(completion_payload, destroy_result.budget),
+                        destroy_result.workspace_cache_promoted,
+                        false,
+                    );
                 }
+                let candidate = candidate.with_last_completed_at(completed_at.clone());
+                break match pool.park(candidate) {
+                    ParkResult::Parked => {
+                        info!(run_id = %run_id, session_id, "VM parked for reuse");
+                        cleanup_state.mark_idle_pool_owned();
+                        #[cfg(test)]
+                        maybe_panic_outer_job(
+                            outer_job_panic,
+                            OuterJobPanicPoint::IdlePoolOwned,
+                            run_id,
+                        );
+                        // Push fresh idle state to status.json BEFORE
+                        // conditional active-run removal (below) clears the run_id
+                        // from active_runs. Without this, doctor would
+                        // briefly see the FC as unknown (neither active
+                        // nor idle) until the next idle_cleanup tick
+                        // (~10s), producing transient false-positive
+                        // FirecrackerNotInStatus warnings.
+                        let snapshot = pool.status_snapshot();
+                        drop(transfer_guard);
+                        drop(pool);
+                        let ownership = OwnershipTransitions::new(status.as_ref());
+                        ownership
+                            .publish_idle_status_after_pool_transfer(snapshot)
+                            .await;
+                        session_affinity_changed = true;
+                        session_affinity_refresh_sent = true;
+                        park_notify.notify_one();
+                        BudgetOwnership::idle_owned()
+                    }
+                    ParkResult::Replaced(evicted) => {
+                        info!(run_id = %run_id, session_id, "VM parked, evicting previous");
+                        cleanup_state.mark_idle_pool_owned();
+                        #[cfg(test)]
+                        maybe_panic_outer_job(
+                            outer_job_panic,
+                            OuterJobPanicPoint::IdlePoolOwned,
+                            run_id,
+                        );
+                        let snapshot = pool.status_snapshot();
+                        drop(transfer_guard);
+                        drop(pool);
+                        let ownership = OwnershipTransitions::new(status.as_ref());
+                        ownership
+                            .publish_idle_status_after_pool_transfer(snapshot)
+                            .await;
+                        session_affinity_changed = true;
+                        session_affinity_refresh_sent = true;
+                        park_notify.notify_one();
+                        // The replaced VM was park()ed when it entered the
+                        // pool; destroying a parked sandbox is safe — Drop
+                        // aborts any leftover handles and the FC process is
+                        // killed regardless of balloon state.
+                        if destroy_idle_jobs_and_wait(vec![evicted], "park_replaced").await {
+                            park_notify.notify_one();
+                        }
+                        BudgetOwnership::idle_owned()
+                    }
+                    ParkResult::Rejected(rejected) => {
+                        info!(run_id = %run_id, session_id, "idle parking rejected, destroying VM");
+                        drop(transfer_guard);
+                        drop(pool);
+                        // Pool unchanged (park rejected) — no status
+                        // update needed. The rejected sandbox was just
+                        // park()ed above; destroying a parked sandbox is
+                        // safe — see Replaced arm for rationale.
+                        let (payload, lease) = rejected.into_active_destroy_parts();
+                        let destroy_result = destroy_active_owned_idle_payload(
+                            payload,
+                            lease,
+                            "park_rejected",
+                            destroy_bookkeeping,
+                        )
+                        .await;
+                        session_affinity_changed |= destroy_result.workspace_cache_promoted;
+                        destroy_result.budget
+                    }
+                };
             }
         }
     } else {
@@ -542,7 +579,6 @@ mod tests {
     use api_contracts::generated::constants::runners::paths::CANONICAL_WORKING_DIR;
     use sandbox::{ExecResult, SandboxFactory, SandboxId};
     use sandbox_mock::{MockLifecycleGate, MockSandbox, MockSandboxFactory};
-    use tokio_util::sync::CancellationToken;
 
     use super::super::idle_lifecycle::SharedIdlePool;
     use super::super::job_lifecycle::{
@@ -623,7 +659,7 @@ mod tests {
             sandbox_id: SandboxId,
             session_id: &str,
             network_log_session: NetworkLogSession,
-            cancel: CancellationToken,
+            cancel: RunCancellationHandle,
         ) -> FinalizeContext {
             FinalizeContext {
                 run_id,
@@ -745,7 +781,7 @@ mod tests {
                 sandbox_id,
                 "sess-network-log-park",
                 network_log_session,
-                CancellationToken::new(),
+                RunCancellationHandle::new(),
             ),
         )
         .await;
@@ -760,6 +796,58 @@ mod tests {
                 )
                 .await,
             "parked sandbox must not retain the previous run's network-log attribution",
+        );
+    }
+
+    #[tokio::test]
+    async fn finalizer_keeps_idle_pool_ownership_when_cancelled_after_transfer() {
+        let (_budget, lease) = test_budget_lease();
+        let fixture = FinalizeTestFixture::new().await;
+        let network_log_session = fixture.network_log_session().await;
+        let run_id = RunId::new_v4();
+        let sandbox_id = SandboxId::new_v4();
+        let cancel = RunCancellationHandle::new();
+        let cleanup_state = RunCleanupState::new();
+        let mut context = fixture.finalize_context(
+            run_id,
+            sandbox_id,
+            "sess-cancel-after-transfer",
+            network_log_session,
+            cancel.clone(),
+        );
+        context.cleanup_state = cleanup_state.clone();
+
+        let _completion_ready = finalize_sandbox_for_completion(
+            Some(Box::new(MockSandbox::new("cancel-after-transfer"))),
+            ActiveBudgetLease::new(lease),
+            CompletionPayload::new(
+                run_id,
+                0,
+                None,
+                sandbox_id,
+                SandboxReuseResult::PoolMiss,
+                CompletionAuth::local(),
+            ),
+            context,
+        )
+        .await;
+
+        assert_eq!(fixture.idle_pool.lock().await.len(), 1);
+        assert_eq!(
+            cleanup_state.disposition(),
+            RunCleanupDisposition::IdlePoolOwned,
+        );
+
+        assert!(cancel.cancel().await);
+
+        assert_eq!(
+            fixture.idle_pool.lock().await.len(),
+            1,
+            "late cancellation must not undo idle-pool ownership",
+        );
+        assert_eq!(
+            cleanup_state.disposition(),
+            RunCleanupDisposition::IdlePoolOwned,
         );
     }
 
@@ -938,7 +1026,7 @@ mod tests {
             sandbox_id,
             "unused-context-session",
             network_log_session,
-            CancellationToken::new(),
+            RunCancellationHandle::new(),
         );
         context.session_id = None;
         context.guest_session_id = Some("sess-guest".into());
@@ -1021,7 +1109,7 @@ mod tests {
             sandbox_id,
             "sess-new",
             network_log_session,
-            CancellationToken::new(),
+            RunCancellationHandle::new(),
         );
         context.workspace_image = Some(workspace_image);
         context.workspace_promotable = true;
@@ -1129,7 +1217,7 @@ mod tests {
             new_sandbox_id,
             session_id,
             network_log_session,
-            CancellationToken::new(),
+            RunCancellationHandle::new(),
         );
         context.park_notify = Arc::clone(&park_notify);
 
@@ -1177,8 +1265,8 @@ mod tests {
         let (_budget, lease) = test_budget_lease();
         let fixture = FinalizeTestFixture::new().await;
         let network_log_session = fixture.network_log_session().await;
-        let cancel = CancellationToken::new();
-        cancel.cancel();
+        let cancel = RunCancellationHandle::new();
+        cancel.cancel().await;
         let run_id = RunId::new_v4();
         let sandbox_id = SandboxId::new_v4();
 
@@ -1223,7 +1311,7 @@ mod tests {
         let network_log_session = fixture.network_log_session().await;
         let run_id = RunId::new_v4();
         let sandbox_id = SandboxId::new_v4();
-        let cancel = CancellationToken::new();
+        let cancel = RunCancellationHandle::new();
         let cleanup_state = RunCleanupState::new();
         let overrides = Arc::new(sandbox_mock::MockSandboxOverrides::new());
         let park_gate = MockLifecycleGate::new();
@@ -1262,7 +1350,7 @@ mod tests {
                 .expect("park should enter gate"),
             1
         );
-        cancel.cancel();
+        cancel.cancel().await;
         park_gate.release_one();
         assert_eq!(
             destroy_gate
@@ -1301,7 +1389,7 @@ mod tests {
         let network_log_session = fixture.network_log_session().await;
         let run_id = RunId::new_v4();
         let sandbox_id = SandboxId::new_v4();
-        let cancel = CancellationToken::new();
+        let cancel = RunCancellationHandle::new();
         let cleanup_state = RunCleanupState::new();
         let observer = StartLoopTestObserver::default();
         let overrides = Arc::new(sandbox_mock::MockSandboxOverrides::new());
@@ -1339,7 +1427,7 @@ mod tests {
         observer
             .wait_before_idle_pool_ownership_transfer(run_id, Duration::from_secs(5))
             .await;
-        cancel.cancel();
+        cancel.cancel().await;
         assert!(
             !fixture
                 .network_log_manager

--- a/crates/runner/src/cmd/start/signals.rs
+++ b/crates/runner/src/cmd/start/signals.rs
@@ -1,11 +1,8 @@
-use std::collections::HashMap;
-use std::sync::Arc;
-
 use tokio_util::sync::CancellationToken;
 use tracing::{info, warn};
 
 use crate::idle_pool::ParkingGate;
-use crate::ids::RunId;
+use crate::run_cancellation::SharedRunCancellationMap;
 use crate::status::RunnerMode;
 
 /// Pre-registered signal streams.
@@ -230,7 +227,7 @@ impl SignalController {
     /// construct a controller with no real handler task.
     pub(super) fn spawn(
         cancel: CancellationToken,
-        cancel_tokens: Arc<tokio::sync::Mutex<HashMap<RunId, CancellationToken>>>,
+        cancel_tokens: SharedRunCancellationMap,
         signals: EarlySignals,
         parking_gate: ParkingGate,
     ) -> Self {
@@ -308,7 +305,7 @@ pub(super) fn handle_resume_signal(lifecycle: &LifecycleController) {
 pub(super) async fn handle_stopping_signal(
     name: &str,
     cancel: &CancellationToken,
-    cancel_tokens: &Arc<tokio::sync::Mutex<HashMap<RunId, CancellationToken>>>,
+    cancel_tokens: &SharedRunCancellationMap,
     lifecycle: &LifecycleController,
 ) {
     if lifecycle.current_mode() == RunnerMode::Stopping {
@@ -322,22 +319,31 @@ pub(super) async fn handle_stopping_signal(
     // post-insert `mode_rx.borrow()` check catches any job claimed after
     // our iteration but before send would otherwise publish the state.
     lifecycle.hard_stop();
-    let tokens = cancel_tokens.lock().await;
-    let count = tokens.len();
-    for (run_id, token) in tokens.iter() {
+    let handles = {
+        let tokens = cancel_tokens.lock().await;
+        tokens
+            .iter()
+            .map(|(run_id, handle)| (*run_id, handle.clone()))
+            .collect::<Vec<_>>()
+    };
+    let count = handles.len();
+    for (run_id, handle) in handles {
         info!(run_id = %run_id, "cancelling active job for hard shutdown");
-        token.cancel();
+        handle.cancel().await;
     }
-    drop(tokens);
     info!(active_jobs = count, "dispatched per-job cancellations");
     cancel.cancel();
 }
 
 #[cfg(test)]
 mod tests {
+    use std::collections::HashMap;
+    use std::sync::Arc;
     use std::time::Duration;
 
     use super::*;
+    use crate::ids::RunId;
+    use crate::run_cancellation::RunCancellationHandle;
 
     /// Regression test for issue #10416: SIGUSR1 arriving between
     /// `EarlySignals::register()` and `SignalController::spawn` must still
@@ -540,8 +546,7 @@ mod tests {
         let (tx, _rx) = tokio::sync::watch::channel(RunnerMode::Running);
         let lifecycle = LifecycleController::new(tx, gate.clone());
         let cancel = CancellationToken::new();
-        let tokens: Arc<tokio::sync::Mutex<HashMap<RunId, CancellationToken>>> =
-            Arc::new(tokio::sync::Mutex::new(HashMap::new()));
+        let tokens: SharedRunCancellationMap = Arc::new(tokio::sync::Mutex::new(HashMap::new()));
 
         // First call: transitions, cancels main cancel.
         handle_stopping_signal("SIGTERM", &cancel, &tokens, &lifecycle).await;
@@ -551,18 +556,16 @@ mod tests {
 
         // Insert a sentinel token *after* the first call so we can prove
         // the repeat did not re-iterate the map.
-        let sentinel = CancellationToken::new();
-        tokens
-            .lock()
-            .await
-            .insert(RunId::new_v4(), sentinel.clone());
+        let sentinel = RunCancellationHandle::new();
+        let sentinel_token = sentinel.token();
+        tokens.lock().await.insert(RunId::new_v4(), sentinel);
 
         // Repeat call: must early-return on the already-Stopping guard.
         handle_stopping_signal("SIGTERM", &cancel, &tokens, &lifecycle).await;
         assert_eq!(lifecycle.current_mode(), RunnerMode::Stopping);
         assert_eq!(gate.state(), ParkingState::Closed);
         assert!(
-            !sentinel.is_cancelled(),
+            !sentinel_token.is_cancelled(),
             "repeat must not re-iterate cancel_tokens and cancel late-inserted sentinel",
         );
     }

--- a/crates/runner/src/cmd/start/tests/failure_recovery/create_destroy.rs
+++ b/crates/runner/src/cmd/start/tests/failure_recovery/create_destroy.rs
@@ -1,7 +1,7 @@
 use super::super::super::*;
 use super::super::support::{
     context_with_session, minimal_context, mock_run_config_with_overrides, push_job, shutdown,
-    status_idle_sessions_and_active_runs, test_profiles, wait_budget_count, wait_cancel_token,
+    status_idle_sessions_and_active_runs, test_profiles, wait_budget_count, wait_cancel_handle,
     wait_cancel_token_removed,
 };
 
@@ -93,9 +93,9 @@ async fn cancelled_job_not_parked() {
     );
 
     // Wait for the job to be claimed (cancel token inserted).
-    let token = wait_cancel_token(&cancel_tokens, run_id, Duration::from_secs(5)).await;
+    let cancel_handle = wait_cancel_handle(&cancel_tokens, run_id, Duration::from_secs(5)).await;
     // Cancel the job — executor's select! takes the cancelled branch.
-    token.cancel();
+    cancel_handle.cancel().await;
 
     let c = env
         .handle

--- a/crates/runner/src/cmd/start/tests/failure_recovery/parking_cleanup.rs
+++ b/crates/runner/src/cmd/start/tests/failure_recovery/parking_cleanup.rs
@@ -2,7 +2,8 @@ use super::super::super::*;
 use super::super::support::{
     context_with_session, context_with_workspace_image_cache_enabled,
     mock_run_config_with_overrides, push_job, seed_idle_pool, shutdown, test_profiles,
-    wait_budget_count, wait_cancel_token, wait_cancel_token_removed, wait_workspace_cache_sessions,
+    wait_budget_count, wait_cancel_handle, wait_cancel_token_removed,
+    wait_workspace_cache_sessions,
 };
 use super::support::assert_no_completion_for_run;
 
@@ -213,7 +214,7 @@ async fn assert_workspace_cache_after_late_cancellation(
     let run_id = RunId::new_v4();
     let context = context_with_workspace_image_cache_enabled(run_id, session_id);
     push_job(&env, run_id, "vm0/default", Some(context));
-    let token = wait_cancel_token(&cancel_tokens, run_id, Duration::from_secs(5)).await;
+    let cancel_handle = wait_cancel_handle(&cancel_tokens, run_id, Duration::from_secs(5)).await;
 
     wait_gate
         .wait_entered(1, Duration::from_secs(5))
@@ -242,7 +243,7 @@ async fn assert_workspace_cache_after_late_cancellation(
 
     match cancellation_point {
         LateCancellationPoint::DuringPark => {
-            token.cancel();
+            cancel_handle.cancel().await;
             park_gate.release_one();
         }
         LateCancellationPoint::BeforeIdlePoolTransfer => {
@@ -251,7 +252,7 @@ async fn assert_workspace_cache_after_late_cancellation(
             env.start_observer
                 .wait_before_idle_pool_ownership_transfer(run_id, Duration::from_secs(5))
                 .await;
-            token.cancel();
+            cancel_handle.cancel().await;
             drop(pool_guard);
         }
     }
@@ -494,7 +495,7 @@ async fn cancellation_while_waiting_for_idle_pool_lock_destroys_instead_of_parki
         "vm0/default",
         Some(context_with_session(run_id, "sess-cancel-while-locking")),
     );
-    let token = wait_cancel_token(&cancel_tokens, run_id, Duration::from_secs(5)).await;
+    let cancel_handle = wait_cancel_handle(&cancel_tokens, run_id, Duration::from_secs(5)).await;
 
     assert_eq!(
         park_gate
@@ -508,7 +509,7 @@ async fn cancellation_while_waiting_for_idle_pool_lock_destroys_instead_of_parki
     env.start_observer
         .wait_before_idle_pool_ownership_transfer(run_id, Duration::from_secs(5))
         .await;
-    token.cancel();
+    cancel_handle.cancel().await;
     drop(pool_guard);
 
     assert_eq!(
@@ -572,7 +573,7 @@ async fn cancellation_during_sandbox_park_destroys_instead_of_parking() {
         "vm0/default",
         Some(context_with_session(run_id, "sess-cancel-while-parking")),
     );
-    let token = wait_cancel_token(&cancel_tokens, run_id, Duration::from_secs(5)).await;
+    let cancel_handle = wait_cancel_handle(&cancel_tokens, run_id, Duration::from_secs(5)).await;
 
     assert_eq!(
         park_gate
@@ -583,7 +584,7 @@ async fn cancellation_during_sandbox_park_destroys_instead_of_parking() {
     );
     assert_eq!(counter.park_call_count(), 1);
 
-    token.cancel();
+    cancel_handle.cancel().await;
     park_gate.release_one();
 
     assert_eq!(

--- a/crates/runner/src/cmd/start/tests/support/env.rs
+++ b/crates/runner/src/cmd/start/tests/support/env.rs
@@ -6,6 +6,7 @@ use std::collections::BTreeMap;
 
 use crate::executor;
 use crate::provider::mock::{MockJobProvider, MockProviderHandle};
+use crate::run_cancellation::SharedRunCancellationMap;
 use sandbox_mock::MockSandboxRuntime;
 
 pub(in super::super) fn test_profiles() -> BTreeMap<String, config::ProfileConfig> {
@@ -33,7 +34,7 @@ pub(in super::super) struct MockRunEnv {
     pub(in super::super) parking_gate: ParkingGate,
     pub(in super::super) start_observer: StartLoopTestObserver,
     pub(in super::super) mode_tx: tokio::sync::watch::Sender<RunnerMode>,
-    pub(in super::super) cancel_tokens: Arc<tokio::sync::Mutex<HashMap<RunId, CancellationToken>>>,
+    pub(in super::super) cancel_tokens: SharedRunCancellationMap,
     pub(in super::super) cancel: CancellationToken,
     pub(in super::super) _temp_dir: tempfile::TempDir,
 }
@@ -148,8 +149,7 @@ fn build_mock_run_config_with_runtime(
     let parking_gate = ParkingGate::new_open();
     let lifecycle = LifecycleController::new(mode_tx, parking_gate.clone());
     let start_observer = StartLoopTestObserver::default();
-    let cancel_tokens: Arc<tokio::sync::Mutex<HashMap<RunId, CancellationToken>>> =
-        Arc::new(tokio::sync::Mutex::new(HashMap::new()));
+    let cancel_tokens: SharedRunCancellationMap = Arc::new(tokio::sync::Mutex::new(HashMap::new()));
 
     let home = HomePaths::with_root(temp_dir.path().to_path_buf());
     let registry_path = temp_dir.path().join("registry.json");

--- a/crates/runner/src/cmd/start/tests/support/mod.rs
+++ b/crates/runner/src/cmd/start/tests/support/mod.rs
@@ -22,8 +22,8 @@ pub(super) use self::status::{
     wait_status_mode,
 };
 pub(super) use self::wait::{
-    assert_run_exits_within, wait_budget_count, wait_budget_exhausted_reactor, wait_cancel_token,
-    wait_cancel_token_removed, wait_discover_entered,
+    assert_run_exits_within, wait_budget_count, wait_budget_exhausted_reactor, wait_cancel_handle,
+    wait_cancel_token, wait_cancel_token_removed, wait_discover_entered,
     wait_idle_cleanup_processed_with_expired_entries, wait_idle_pool_len,
     wait_idle_pool_session_states, wait_idle_pool_sessions, wait_parking_state,
     wait_sandbox_lifecycle_counts, wait_usage_flush_requested, wait_workspace_cache_sessions,

--- a/crates/runner/src/cmd/start/tests/support/wait.rs
+++ b/crates/runner/src/cmd/start/tests/support/wait.rs
@@ -3,6 +3,7 @@ use super::env::MockRunEnv;
 use std::future::Future;
 
 use crate::idle_pool::ParkingState;
+use crate::run_cancellation::{RunCancellationHandle, SharedRunCancellationMap};
 use crate::workspace_image_cache::SessionWorkspaceCache;
 
 const WAIT_POLL_INTERVAL: Duration = Duration::from_millis(10);
@@ -210,15 +211,15 @@ pub(in super::super) async fn wait_parking_state(
     .await;
 }
 
-pub(in super::super) async fn wait_cancel_token(
-    tokens: &Arc<tokio::sync::Mutex<HashMap<RunId, CancellationToken>>>,
+pub(in super::super) async fn wait_cancel_handle(
+    tokens: &SharedRunCancellationMap,
     run_id: RunId,
     timeout: Duration,
-) -> CancellationToken {
+) -> RunCancellationHandle {
     wait_for_probe(timeout, || async {
-        let token = tokens.lock().await.get(&run_id).cloned();
-        if let Some(token) = token {
-            WaitProbe::Ready(token)
+        let handle = tokens.lock().await.get(&run_id).cloned();
+        if let Some(handle) = handle {
+            WaitProbe::Ready(handle)
         } else {
             WaitProbe::Pending(format!(
                 "cancel token for {run_id} not found within {timeout:?}",
@@ -228,8 +229,16 @@ pub(in super::super) async fn wait_cancel_token(
     .await
 }
 
+pub(in super::super) async fn wait_cancel_token(
+    tokens: &SharedRunCancellationMap,
+    run_id: RunId,
+    timeout: Duration,
+) -> CancellationToken {
+    wait_cancel_handle(tokens, run_id, timeout).await.token()
+}
+
 pub(in super::super) async fn wait_cancel_token_removed(
-    tokens: &Arc<tokio::sync::Mutex<HashMap<RunId, CancellationToken>>>,
+    tokens: &SharedRunCancellationMap,
     run_id: RunId,
     timeout: Duration,
 ) {

--- a/crates/runner/src/main.rs
+++ b/crates/runner/src/main.rs
@@ -30,6 +30,7 @@ mod proxy;
 mod r2_cache;
 mod resource_budget;
 mod retry;
+mod run_cancellation;
 mod run_resolution;
 mod runner_dirname;
 mod runtime_overrides;

--- a/crates/runner/src/provider/api.rs
+++ b/crates/runner/src/provider/api.rs
@@ -1,7 +1,6 @@
 //! [`JobProvider`] backed by an Ably control plane + HTTP polling + REST API.
 
 use std::borrow::Cow;
-use std::collections::HashMap;
 use std::sync::Arc;
 use std::time::Duration;
 
@@ -17,6 +16,7 @@ use super::{ClaimedJob, CompletionAuth, CompletionAuthError, JobCandidate, JobPr
 use crate::error::{RunnerError, RunnerResult};
 use crate::http::HttpClient;
 use crate::ids::RunId;
+use crate::run_cancellation::SharedRunCancellationMap;
 use crate::types::{
     CompleteRequest, ExecutionContext, HeartbeatState, HeldSessionState, Job,
     MAX_HELD_SESSION_STATES, PollResponse, SandboxReuseResult,
@@ -85,7 +85,7 @@ impl ApiProvider {
         profiles: Vec<String>,
         runner_id: String,
         cancel: CancellationToken,
-        cancel_tokens: Arc<tokio::sync::Mutex<HashMap<RunId, CancellationToken>>>,
+        cancel_tokens: SharedRunCancellationMap,
     ) -> Arc<Self> {
         let api = ApiClient::new(http, token);
         let poll_wakeups = Arc::new(PollWakeups::new(false));

--- a/crates/runner/src/provider/api_ably_supervisor.rs
+++ b/crates/runner/src/provider/api_ably_supervisor.rs
@@ -9,6 +9,7 @@ use tracing::{error, info, warn};
 use super::api::ApiClient;
 use crate::ids::RunId;
 use crate::retry::{RetryState, recv_retry, sleep_until_retry};
+use crate::run_cancellation::{RunCancellationHandle, SharedRunCancellationMap};
 
 const ABLY_BACKOFF_INITIAL: Duration = Duration::from_secs(5);
 const ABLY_BACKOFF_MAX: Duration = Duration::from_secs(60);
@@ -378,7 +379,7 @@ impl AblySupervisor {
         group: String,
         runner_id: String,
         poll_wakeups: Arc<PollWakeups>,
-        cancel_tokens: Arc<Mutex<HashMap<RunId, CancellationToken>>>,
+        cancel_tokens: SharedRunCancellationMap,
         provider_cancel: CancellationToken,
     ) -> Self {
         let shutdown = CancellationToken::new();
@@ -438,7 +439,7 @@ async fn run_supervisor(
     group: String,
     runner_id: String,
     poll_wakeups: Arc<PollWakeups>,
-    cancel_tokens: Arc<Mutex<HashMap<RunId, CancellationToken>>>,
+    cancel_tokens: SharedRunCancellationMap,
     provider_cancel: CancellationToken,
     shutdown: CancellationToken,
 ) {
@@ -530,13 +531,13 @@ async fn handle_ably_message(
     msg: &ably_subscriber::Message,
     runner_id: &str,
     poll_wakeups: &PollWakeups,
-    cancel_tokens: &Mutex<HashMap<RunId, CancellationToken>>,
+    cancel_tokens: &Mutex<HashMap<RunId, RunCancellationHandle>>,
 ) {
     if let Some(run_id) = parse_cancel_notification(msg) {
-        let token = cancel_tokens.lock().await.get(&run_id).cloned();
-        if let Some(token) = token {
+        let handle = cancel_tokens.lock().await.get(&run_id).cloned();
+        if let Some(handle) = handle {
             info!(run_id = %run_id, "ably: cancel notification, killing job");
-            token.cancel();
+            handle.cancel().await;
         }
         return;
     }
@@ -1302,8 +1303,9 @@ mod tests {
     #[tokio::test]
     async fn cancel_notification_cancels_token_without_discovery() {
         let run_id: RunId = "00000000-0000-0000-0000-000000000002".parse().unwrap();
-        let token = CancellationToken::new();
-        let tokens = Mutex::new(HashMap::from([(run_id, token.clone())]));
+        let handle = RunCancellationHandle::new();
+        let token = handle.token();
+        let tokens = Mutex::new(HashMap::from([(run_id, handle)]));
         let wakeups = PollWakeups::new(true);
         let msg = make_message(Some("cancel"), serde_json::json!({ "runId": run_id }));
 

--- a/crates/runner/src/provider/local.rs
+++ b/crates/runner/src/provider/local.rs
@@ -6,7 +6,7 @@
 //! The winning runner executes the job and writes a group-wide
 //! `{job_id}.result` file that `submit` polls for.
 
-use std::collections::{HashMap, HashSet};
+use std::collections::HashSet;
 use std::path::PathBuf;
 use std::sync::Arc;
 use std::sync::atomic::{AtomicUsize, Ordering};
@@ -21,6 +21,7 @@ use crate::ids::RunId;
 #[cfg(test)]
 use crate::local_queue::{self, JobRequest, JobResponse};
 use crate::local_queue::{LocalClaimResult, LocalDiscoveredJob, LocalQueue};
+use crate::run_cancellation::SharedRunCancellationMap;
 use crate::types::{ExecutionContext, HeartbeatState, SandboxReuseResult};
 use sandbox::SandboxId;
 
@@ -51,7 +52,7 @@ impl LocalProvider {
         group_dir: PathBuf,
         supported_profiles: Vec<String>,
         cancel: CancellationToken,
-        cancel_tokens: Arc<tokio::sync::Mutex<HashMap<RunId, CancellationToken>>>,
+        cancel_tokens: SharedRunCancellationMap,
     ) -> Arc<Self> {
         Self::new_inner(group_dir, supported_profiles, cancel, cancel_tokens, true)
     }
@@ -60,7 +61,7 @@ impl LocalProvider {
         group_dir: PathBuf,
         mut supported_profiles: Vec<String>,
         cancel: CancellationToken,
-        cancel_tokens: Arc<tokio::sync::Mutex<HashMap<RunId, CancellationToken>>>,
+        cancel_tokens: SharedRunCancellationMap,
         start_cancel_watcher: bool,
     ) -> Arc<Self> {
         supported_profiles.sort();
@@ -93,7 +94,7 @@ impl LocalProvider {
         group_dir: PathBuf,
         supported_profiles: Vec<String>,
         cancel: CancellationToken,
-        cancel_tokens: Arc<tokio::sync::Mutex<HashMap<RunId, CancellationToken>>>,
+        cancel_tokens: SharedRunCancellationMap,
     ) -> Arc<Self> {
         Self::new_inner(group_dir, supported_profiles, cancel, cancel_tokens, false)
     }
@@ -282,10 +283,22 @@ impl JobProvider for LocalProvider {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::run_cancellation::RunCancellationHandle;
+    use std::collections::HashMap;
 
     /// Create a default empty cancel_tokens map for tests.
-    fn empty_cancel_tokens() -> Arc<tokio::sync::Mutex<HashMap<RunId, CancellationToken>>> {
+    fn empty_cancel_tokens() -> SharedRunCancellationMap {
         Arc::new(tokio::sync::Mutex::new(HashMap::new()))
+    }
+
+    async fn insert_cancel_handle(
+        tokens: &SharedRunCancellationMap,
+        run_id: RunId,
+    ) -> CancellationToken {
+        let handle = RunCancellationHandle::new();
+        let token = handle.token();
+        tokens.lock().await.insert(run_id, handle);
+        token
     }
 
     fn profiles(names: &[&str]) -> Vec<String> {
@@ -299,7 +312,7 @@ mod tests {
     fn default_provider(
         dir: &std::path::Path,
         cancel: CancellationToken,
-        tokens: Arc<tokio::sync::Mutex<HashMap<RunId, CancellationToken>>>,
+        tokens: SharedRunCancellationMap,
     ) -> Arc<LocalProvider> {
         LocalProvider::new_without_cancel_watcher(
             dir.to_path_buf(),
@@ -313,7 +326,7 @@ mod tests {
         dir: &std::path::Path,
         supported_profiles: &[&str],
         cancel: CancellationToken,
-        tokens: Arc<tokio::sync::Mutex<HashMap<RunId, CancellationToken>>>,
+        tokens: SharedRunCancellationMap,
     ) -> Arc<LocalProvider> {
         LocalProvider::new_without_cancel_watcher(
             dir.to_path_buf(),
@@ -680,8 +693,7 @@ mod tests {
         let tokens = empty_cancel_tokens();
 
         let run_id = RunId::new_v4();
-        let job_token = CancellationToken::new();
-        tokens.lock().await.insert(run_id, job_token.clone());
+        let job_token = insert_cancel_handle(&tokens, run_id).await;
 
         let provider = default_provider(dir.path(), cancel, tokens);
 
@@ -702,8 +714,7 @@ mod tests {
         let dir = tempfile::tempdir().unwrap();
         let tokens = empty_cancel_tokens();
         let run_id = RunId::new_v4();
-        let job_token = CancellationToken::new();
-        tokens.lock().await.insert(run_id, job_token.clone());
+        let job_token = insert_cancel_handle(&tokens, run_id).await;
         let provider = default_provider(dir.path(), CancellationToken::new(), tokens);
         write_job(dir.path(), run_id, "owned");
         let candidate = provider.discover().await.unwrap();
@@ -764,8 +775,7 @@ mod tests {
             "cancel file should survive before the token is inserted"
         );
 
-        let job_token = CancellationToken::new();
-        tokens.lock().await.insert(run_id, job_token.clone());
+        let job_token = insert_cancel_handle(&tokens, run_id).await;
         provider.claim(candidate).await.unwrap();
         let other_job = RunId::new_v4();
         write_job(dir.path(), other_job, "next job");
@@ -794,8 +804,7 @@ mod tests {
             Arc::clone(&tokens),
         );
         let run_id = RunId::new_v4();
-        let job_token = CancellationToken::new();
-        tokens.lock().await.insert(run_id, job_token.clone());
+        let job_token = insert_cancel_handle(&tokens, run_id).await;
         write_job(dir.path(), run_id, "owned");
         let candidate = provider.discover().await.unwrap();
         provider.claim(candidate).await.unwrap();

--- a/crates/runner/src/provider/local_cancel.rs
+++ b/crates/runner/src/provider/local_cancel.rs
@@ -10,6 +10,7 @@ use crate::ids::RunId;
 #[cfg(test)]
 use crate::local_queue;
 use crate::local_queue::{CancelTargetState, LocalQueue};
+use crate::run_cancellation::{RunCancellationHandle, SharedRunCancellationMap};
 
 /// Poll interval for scanning local cancel markers.
 const POLL_INTERVAL: Duration = Duration::from_millis(100);
@@ -17,7 +18,7 @@ const POLL_INTERVAL: Duration = Duration::from_millis(100);
 #[derive(Clone)]
 pub(super) struct LocalCancelScanner {
     queue: LocalQueue,
-    cancel_tokens: Arc<tokio::sync::Mutex<HashMap<RunId, CancellationToken>>>,
+    cancel_tokens: SharedRunCancellationMap,
     owned_claims: Arc<tokio::sync::Mutex<HashSet<RunId>>>,
 }
 
@@ -29,7 +30,7 @@ pub(super) struct LocalCancelWatcher {
 impl LocalCancelScanner {
     pub(super) fn new(
         queue: LocalQueue,
-        cancel_tokens: Arc<tokio::sync::Mutex<HashMap<RunId, CancellationToken>>>,
+        cancel_tokens: SharedRunCancellationMap,
         owned_claims: Arc<tokio::sync::Mutex<HashSet<RunId>>>,
     ) -> Self {
         Self {
@@ -71,10 +72,8 @@ impl LocalCancelScanner {
         let mut delete_cancel_ids = Vec::new();
         for marker in cancel_markers {
             let run_id = marker.run_id;
-            if let Some(token) = tokens.get(&run_id) {
-                let was_cancelled = token.is_cancelled();
-                token.cancel();
-                if !was_cancelled {
+            if let Some(handle) = tokens.get(&run_id) {
+                if handle.cancel().await {
                     info!(run_id = %run_id, "local: cancel file detected, cancelling job");
                 }
                 let should_delete = owned_claims.contains(&run_id)
@@ -102,7 +101,7 @@ impl LocalCancelScanner {
     async fn snapshot_cancel_tokens(
         &self,
         cancel_ids: &[RunId],
-    ) -> HashMap<RunId, CancellationToken> {
+    ) -> HashMap<RunId, RunCancellationHandle> {
         let tokens = self.cancel_tokens.lock().await;
         cancel_ids
             .iter()
@@ -223,19 +222,26 @@ impl Drop for LocalCancelWatcher {
 mod tests {
     use super::*;
 
-    fn empty_cancel_tokens() -> Arc<tokio::sync::Mutex<HashMap<RunId, CancellationToken>>> {
+    fn empty_cancel_tokens() -> SharedRunCancellationMap {
         Arc::new(tokio::sync::Mutex::new(HashMap::new()))
     }
 
-    fn scanner(
-        dir: &std::path::Path,
-        tokens: Arc<tokio::sync::Mutex<HashMap<RunId, CancellationToken>>>,
-    ) -> LocalCancelScanner {
+    fn scanner(dir: &std::path::Path, tokens: SharedRunCancellationMap) -> LocalCancelScanner {
         LocalCancelScanner::new(
             LocalQueue::new(dir.to_path_buf()),
             tokens,
             Arc::new(tokio::sync::Mutex::new(HashSet::new())),
         )
+    }
+
+    async fn insert_cancel_handle(
+        tokens: &SharedRunCancellationMap,
+        run_id: RunId,
+    ) -> CancellationToken {
+        let handle = RunCancellationHandle::new();
+        let token = handle.token();
+        tokens.lock().await.insert(run_id, handle);
+        token
     }
 
     fn write_job(dir: &std::path::Path, run_id: RunId) {
@@ -270,8 +276,7 @@ mod tests {
         let dir = tempfile::tempdir().unwrap();
         let tokens = empty_cancel_tokens();
         let run_id = RunId::new_v4();
-        let job_token = CancellationToken::new();
-        tokens.lock().await.insert(run_id, job_token.clone());
+        let job_token = insert_cancel_handle(&tokens, run_id).await;
         write_job(dir.path(), run_id);
         write_cancel(dir.path(), run_id);
 
@@ -285,8 +290,7 @@ mod tests {
         let dir = tempfile::tempdir().unwrap();
         let tokens = empty_cancel_tokens();
         let run_id = RunId::new_v4();
-        let job_token = CancellationToken::new();
-        tokens.lock().await.insert(run_id, job_token.clone());
+        let job_token = insert_cancel_handle(&tokens, run_id).await;
         write_job(dir.path(), run_id);
         let cancel_path = write_cancel(dir.path(), run_id);
         let scanner = scanner(dir.path(), tokens);
@@ -306,8 +310,7 @@ mod tests {
         let dir = tempfile::tempdir().unwrap();
         let tokens = empty_cancel_tokens();
         let run_id = RunId::new_v4();
-        let job_token = CancellationToken::new();
-        tokens.lock().await.insert(run_id, job_token.clone());
+        let job_token = insert_cancel_handle(&tokens, run_id).await;
         write_job(dir.path(), run_id);
         let cancel_path = write_cancel(dir.path(), run_id);
 
@@ -328,8 +331,7 @@ mod tests {
         let dir = tempfile::tempdir().unwrap();
         let tokens = empty_cancel_tokens();
         let run_id = RunId::new_v4();
-        let job_token = CancellationToken::new();
-        tokens.lock().await.insert(run_id, job_token.clone());
+        let job_token = insert_cancel_handle(&tokens, run_id).await;
         let cancel_path = write_cancel(dir.path(), run_id);
         write_claim(dir.path(), run_id);
 
@@ -350,8 +352,7 @@ mod tests {
         let dir = tempfile::tempdir().unwrap();
         let tokens = empty_cancel_tokens();
         let run_id = RunId::new_v4();
-        let job_token = CancellationToken::new();
-        tokens.lock().await.insert(run_id, job_token.clone());
+        let job_token = insert_cancel_handle(&tokens, run_id).await;
         let cancel_path = write_cancel(dir.path(), run_id);
 
         scanner(dir.path(), tokens).scan_cancel_files().await;
@@ -371,8 +372,7 @@ mod tests {
         let dir = tempfile::tempdir().unwrap();
         let tokens = empty_cancel_tokens();
         let run_id = RunId::new_v4();
-        let job_token = CancellationToken::new();
-        tokens.lock().await.insert(run_id, job_token.clone());
+        let job_token = insert_cancel_handle(&tokens, run_id).await;
         let cancel_path = write_cancel(dir.path(), run_id);
         write_result(dir.path(), run_id, b"terminal");
         write_claim(dir.path(), run_id);
@@ -395,8 +395,7 @@ mod tests {
         let tokens = empty_cancel_tokens();
         let scanner = scanner(dir.path(), Arc::clone(&tokens));
         let run_id = RunId::new_v4();
-        let job_token = CancellationToken::new();
-        tokens.lock().await.insert(run_id, job_token.clone());
+        let job_token = insert_cancel_handle(&tokens, run_id).await;
         write_job(dir.path(), run_id);
         write_cancel(dir.path(), run_id);
         scanner.mark_owned_claim(run_id).await;
@@ -427,7 +426,7 @@ mod tests {
         let dir = tempfile::tempdir().unwrap();
         let tokens = empty_cancel_tokens();
         let run_id = RunId::new_v4();
-        tokens.lock().await.insert(run_id, CancellationToken::new());
+        let _job_token = insert_cancel_handle(&tokens, run_id).await;
         let scanner = scanner(dir.path(), Arc::clone(&tokens));
         scanner.mark_owned_claim(run_id).await;
         assert!(
@@ -578,8 +577,7 @@ mod tests {
             "cancel file should survive while there is no token"
         );
 
-        let job_token = CancellationToken::new();
-        tokens.lock().await.insert(run_id, job_token.clone());
+        let job_token = insert_cancel_handle(&tokens, run_id).await;
         scanner.mark_owned_claim(run_id).await;
         scanner.scan_cancel_files().await;
 

--- a/crates/runner/src/run_cancellation.rs
+++ b/crates/runner/src/run_cancellation.rs
@@ -1,0 +1,54 @@
+use std::collections::HashMap;
+use std::sync::Arc;
+
+use tokio::sync::{Mutex, OwnedMutexGuard};
+use tokio_util::sync::CancellationToken;
+
+use crate::ids::RunId;
+
+pub(crate) type SharedRunCancellationMap = Arc<Mutex<HashMap<RunId, RunCancellationHandle>>>;
+
+#[derive(Clone, Debug)]
+pub(crate) struct RunCancellationHandle {
+    inner: Arc<RunCancellationInner>,
+}
+
+#[derive(Debug)]
+struct RunCancellationInner {
+    token: CancellationToken,
+    transfer_gate: Arc<Mutex<()>>,
+}
+
+impl RunCancellationHandle {
+    pub(crate) fn new() -> Self {
+        Self {
+            inner: Arc::new(RunCancellationInner {
+                token: CancellationToken::new(),
+                transfer_gate: Arc::new(Mutex::new(())),
+            }),
+        }
+    }
+
+    pub(crate) fn token(&self) -> CancellationToken {
+        self.inner.token.clone()
+    }
+
+    pub(crate) fn is_cancelled(&self) -> bool {
+        self.inner.token.is_cancelled()
+    }
+
+    pub(crate) async fn cancel(&self) -> bool {
+        let _transfer_guard = self.inner.transfer_gate.lock().await;
+        let was_cancelled = self.inner.token.is_cancelled();
+        self.inner.token.cancel();
+        !was_cancelled
+    }
+
+    pub(crate) async fn transfer_guard(&self) -> OwnedMutexGuard<()> {
+        self.inner.transfer_gate.clone().lock_owned().await
+    }
+
+    pub(crate) fn try_transfer_guard(&self) -> Option<OwnedMutexGuard<()>> {
+        self.inner.transfer_gate.clone().try_lock_owned().ok()
+    }
+}


### PR DESCRIPTION
## Summary
- replace the per-run raw cancellation-token map with a small cancellation handle that owns the observer token and transfer gate
- route Ably, local cancel files, hard shutdown, and stopping admission cancellation through the handle
- synchronize the final idle-pool ownership check with the synchronous pool transfer, while preserving cancellation during idle-pool lock wait

Fixes #16566

## Testing
- cargo fmt --manifest-path crates/Cargo.toml --all --check
- cargo test --manifest-path crates/Cargo.toml -p runner cmd::start::sandbox_finalization -- --nocapture
- cargo test --manifest-path crates/Cargo.toml -p runner cmd::start::tests::failure_recovery::parking_cleanup -- --nocapture
- cargo test --manifest-path crates/Cargo.toml -p runner cmd::start::signals -- --nocapture
- cargo test --manifest-path crates/Cargo.toml -p runner provider::local_cancel -- --nocapture
- cargo test --manifest-path crates/Cargo.toml -p runner provider::api_ably_supervisor -- --nocapture
- cargo test --manifest-path crates/Cargo.toml -p runner cmd::start -- --nocapture
- cargo test --manifest-path crates/Cargo.toml -p runner provider -- --nocapture
- cargo test --manifest-path crates/Cargo.toml -p runner -- --nocapture
- cargo clippy --manifest-path crates/Cargo.toml -p runner --tests
- pre-commit: crates cargo-fmt, cargo-clippy, cargo-doc