### PR TITLE
chore: improve novita connector icon fit

### DIFF
--- a/turbo/apps/platform/src/views/zero-page/components/settings/icons/novita.svg
+++ b/turbo/apps/platform/src/views/zero-page/components/settings/icons/novita.svg
@@ -1,5 +1,12 @@
-<svg width="24" height="24" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
-<g transform="translate(3 6.44) scale(0.75)">
-<path d="M24 14.8323V14.8326H14.3246L9.16716 9.67507V14.8326H0V14.8314L9.16716 5.66422V0H9.16774L24 14.8323Z" fill="#000000"/>
-</g>
+<svg
+  width="24"
+  height="24"
+  viewBox="0 -4.5837 24 24"
+  fill="none"
+  xmlns="http://www.w3.org/2000/svg"
+>
+  <path
+    d="M24 14.8323V14.8326H14.3246L9.16716 9.67507V14.8326H0V14.8314L9.16716 5.66422V0H9.16774L24 14.8323Z"
+    fill="#000000"
+  />
 </svg>


### PR DESCRIPTION
## Summary
- remove the extra `translate` / `scale(0.75)` wrapper from the Novita connector icon
- keep the official Novita symbol path and center it in the square SVG viewport so it fills the connector slot more effectively without distortion
- preserve the explicit black fill and mono dark-mode behavior

Closes #16687

## Sources
- https://novita.ai
- https://novita.ai/mainpage/media-logo.png
- https://novita.ai/favicon.ico
- https://novita.ai/favicon-dark.ico

## Checks
- `cd turbo && pnpm -F @vm0/db db:migrate`
- `cd turbo && pnpm exec prettier --parser html --check apps/platform/src/views/zero-page/components/settings/icons/novita.svg`
- `git diff --check`
- SVG structural check: one vector `path`, explicit `#000000` fill, no transform wrapper, no `currentColor`, `<image>`, `data:image`, `xlink:href`, or raster references; only `novita.svg` exists
