### PR TITLE
fix: harden runner lock and log files

### DIFF
--- a/crates/runner/src/cmd/start/mod.rs
+++ b/crates/runner/src/cmd/start/mod.rs
@@ -285,14 +285,12 @@ pub async fn run_start(
     }
 
     let log_paths = LogPaths::new(home.logs_dir());
-    tokio::fs::create_dir_all(log_paths.dir())
-        .await
-        .map_err(|e| {
-            RunnerError::Config(format!(
-                "create logs_dir {}: {e}",
-                log_paths.dir().display()
-            ))
-        })?;
+    crate::log_file::ensure_log_dir(log_paths.dir()).map_err(|e| {
+        RunnerError::Config(format!(
+            "create logs_dir {}: {e}",
+            log_paths.dir().display()
+        ))
+    })?;
 
     // Start background prefetch of snapshot memory for all profiles.
     let memory_prefetch =

--- a/crates/runner/src/executor/diagnostics.rs
+++ b/crates/runner/src/executor/diagnostics.rs
@@ -397,11 +397,7 @@ pub(super) async fn drain_stdout_to_file(
     mut rx: ProcessOutputReceiver,
     path: PathBuf,
 ) -> Result<StdoutDrainReport, StdoutDrainError> {
-    let file = tokio::fs::OpenOptions::new()
-        .create(true)
-        .append(true)
-        .open(&path)
-        .await;
+    let file = crate::log_file::open_append(&path, false).map(tokio::fs::File::from_std);
     let mut file = match file {
         Ok(f) => f,
         Err(e) => {
@@ -454,12 +450,7 @@ pub(super) async fn append_stdout_stream_diagnostics(
         return Ok(());
     }
 
-    let mut file = tokio::fs::OpenOptions::new()
-        .create(true)
-        .append(true)
-        .read(true)
-        .open(path)
-        .await?;
+    let mut file = tokio::fs::File::from_std(crate::log_file::open_append(path, true)?);
 
     if file.metadata().await?.len() > 0 {
         file.seek(SeekFrom::End(-1)).await?;
@@ -523,6 +514,17 @@ pub(super) async fn copy_guest_logs(
     };
 
     for (guest_path, host_path) in &files {
+        if let Err(e) = crate::log_file::validate_copy_destination(host_path) {
+            warn!(
+                run_id = %run_id,
+                error = %e,
+                guest_path = %guest_path,
+                host_path = %host_path.display(),
+                "skipping unsafe guest log destination"
+            );
+            continue;
+        }
+
         if let Err(e) = sandbox
             .copy_file(
                 guest_path,

--- a/crates/runner/src/executor/tests/diagnostics_tests.rs
+++ b/crates/runner/src/executor/tests/diagnostics_tests.rs
@@ -1,4 +1,6 @@
 use std::collections::HashMap;
+use std::os::unix::fs::{PermissionsExt, symlink};
+use std::path::Path;
 use std::path::PathBuf;
 
 use agent_diagnostics::{FAILURE_DIAGNOSTIC_SCHEMA_VERSION, FailureDiagnostic};
@@ -21,6 +23,10 @@ use super::super::{
 use super::support::{minimal_context, sandbox_exec_error, test_executor_config};
 use crate::ids::RunId;
 use crate::paths::LogPaths;
+
+fn mode(path: &Path) -> u32 {
+    std::fs::metadata(path).unwrap().permissions().mode() & 0o777
+}
 
 #[test]
 fn agent_env_diagnostics_sort_bounds_and_never_include_values() {
@@ -395,6 +401,40 @@ async fn copy_guest_logs_writes_files_to_host() {
 }
 
 #[tokio::test]
+async fn copy_guest_logs_skips_unsafe_destination_and_continues_other_logs() {
+    let dir = tempfile::tempdir().unwrap();
+    let log_paths = LogPaths::new(dir.path().to_path_buf());
+    let sandbox = MockSandbox::new("test");
+    let ctx = minimal_context();
+    let unsafe_target = dir.path().join("unsafe-target.log");
+    symlink(&unsafe_target, log_paths.system_log(ctx.run_id)).unwrap();
+
+    sandbox.push_copy_file_result(Ok(b"{\"cpu\":0.5}\n".to_vec()));
+    sandbox.push_copy_file_result(Ok(b"{\"action_type\":\"cleanup\"}\n".to_vec()));
+
+    copy_guest_logs(&sandbox, &ctx, &log_paths, false).await;
+
+    assert!(!unsafe_target.exists());
+    assert_eq!(
+        tokio::fs::read_to_string(log_paths.metrics_log(ctx.run_id))
+            .await
+            .unwrap(),
+        "{\"cpu\":0.5}\n"
+    );
+    assert_eq!(
+        tokio::fs::read_to_string(log_paths.sandbox_ops_log(ctx.run_id))
+            .await
+            .unwrap(),
+        "{\"action_type\":\"cleanup\"}\n"
+    );
+
+    let calls = sandbox.copy_file_calls();
+    assert_eq!(calls.len(), 2);
+    assert_eq!(calls[0].host_path, log_paths.metrics_log(ctx.run_id));
+    assert_eq!(calls[1].host_path, log_paths.sandbox_ops_log(ctx.run_id));
+}
+
+#[tokio::test]
 async fn copy_guest_logs_keeps_existing_logs_when_sandbox_ops_missing() {
     let dir = tempfile::tempdir().unwrap();
     let log_paths = LogPaths::new(dir.path().to_path_buf());
@@ -529,6 +569,7 @@ async fn drain_stdout_writes_chunks_to_file() {
     let content = tokio::fs::read_to_string(&path).await.unwrap();
     assert_eq!(content, "chunk 1\nchunk 2\n");
     assert!(!report.chunk_truncated);
+    assert_eq!(mode(&path), 0o600);
 }
 
 #[tokio::test]
@@ -612,4 +653,5 @@ async fn append_stdout_stream_diagnostics_writes_markers() {
     expected.extend_from_slice(STDOUT_STREAM_LIMIT_MARKER);
     expected.extend_from_slice(STDOUT_STREAM_OVERFLOW_MARKER);
     assert_eq!(content, expected);
+    assert_eq!(mode(&path), 0o600);
 }

--- a/crates/runner/src/host_file.rs
+++ b/crates/runner/src/host_file.rs
@@ -1,0 +1,476 @@
+//! Low-level host filesystem primitives for runner lock/log hardening.
+//! Keep policy-specific entry points in `lock.rs` and `log_file.rs`.
+
+use std::ffi::OsStr;
+use std::fs::File;
+use std::io;
+use std::os::fd::{AsFd, AsRawFd, OwnedFd};
+use std::os::unix::fs::OpenOptionsExt;
+use std::path::{Component, Path, PathBuf};
+
+use nix::fcntl::{OFlag, open, openat};
+use nix::sys::stat::{Mode, SFlag, fstat, mkdirat};
+
+pub(crate) const PRIVATE_DIR_MODE: u32 = 0o700;
+pub(crate) const PRIVATE_FILE_MODE: u32 = 0o600;
+
+const GROUP_OR_OTHER_WRITE_BITS: u32 = 0o022;
+const ROOT_UID: u32 = 0;
+const STICKY_BIT: u32 = 0o1000;
+
+#[derive(Clone, Copy)]
+pub(crate) enum DirMode {
+    Private,
+    TrustedParent,
+}
+
+struct DirWalk<'a> {
+    full_path: &'a Path,
+    mode: DirMode,
+    context: &'a str,
+    expected_uid: u32,
+    create_missing: bool,
+}
+
+pub(crate) fn ensure_dir(path: &Path, mode: DirMode, context: &str) -> io::Result<()> {
+    open_dir_components(path, mode, context, true).map(|_| ())
+}
+
+pub(crate) fn validate_dir(path: &Path, mode: DirMode, context: &str) -> io::Result<()> {
+    open_dir_components(path, mode, context, false).map(|_| ())
+}
+
+pub(crate) fn open_private_append_file(path: &Path, read: bool) -> io::Result<File> {
+    validate_file_parent(path, "log directory")?;
+
+    let mut options = File::options();
+    options
+        .create(true)
+        .append(true)
+        .read(read)
+        .mode(PRIVATE_FILE_MODE)
+        .custom_flags(private_file_open_flags());
+    let file = options
+        .open(path)
+        .map_err(|e| wrap_io(e, format!("open log file {}", path.display())))?;
+    secure_regular_private_file(&file, path, "log file")?;
+    Ok(file)
+}
+
+pub(crate) fn validate_private_file_destination(path: &Path, context: &str) -> io::Result<()> {
+    validate_file_parent(path, context)?;
+
+    let mut options = File::options();
+    options
+        .read(true)
+        .write(true)
+        .custom_flags(private_file_open_flags());
+    let file = match options.open(path) {
+        Ok(file) => file,
+        Err(e) if e.kind() == io::ErrorKind::NotFound => return Ok(()),
+        Err(e) => {
+            return Err(wrap_io(e, format!("open {context} {}", path.display())));
+        }
+    };
+    secure_regular_private_file(&file, path, context)
+}
+
+pub(crate) fn secure_regular_private_file<Fd: AsRawFd>(
+    file: &Fd,
+    path: &Path,
+    context: &str,
+) -> io::Result<()> {
+    let stat = fstat_raw(file, path, context)?;
+    let file_type = stat.st_mode & nix::libc::S_IFMT;
+    if file_type != nix::libc::S_IFREG {
+        return Err(permission_denied(format!(
+            "{} is not a regular {context}",
+            path.display()
+        )));
+    }
+
+    let expected_uid = nix::unistd::geteuid().as_raw();
+    if stat.st_uid != expected_uid {
+        return Err(permission_denied(format!(
+            "{} is owned by uid {}, but runner euid is {expected_uid}",
+            path.display(),
+            stat.st_uid
+        )));
+    }
+
+    let mode = stat.st_mode & 0o7777;
+    if mode & GROUP_OR_OTHER_WRITE_BITS != 0 {
+        return Err(permission_denied(format!(
+            "{} is group/other writable",
+            path.display()
+        )));
+    }
+    if mode != PRIVATE_FILE_MODE {
+        chmod_private_file_fd(file, path, context)?;
+    }
+    Ok(())
+}
+
+pub(crate) fn private_file_open_flags() -> i32 {
+    nix::libc::O_NOFOLLOW | nix::libc::O_CLOEXEC | nix::libc::O_NONBLOCK
+}
+
+pub(crate) fn validate_file_parent(path: &Path, context: &str) -> io::Result<()> {
+    let parent = file_parent(path);
+    validate_dir(parent, DirMode::TrustedParent, context)
+}
+
+pub(crate) fn file_parent(path: &Path) -> &Path {
+    path.parent()
+        .filter(|parent| !parent.as_os_str().is_empty())
+        .unwrap_or_else(|| Path::new("."))
+}
+
+fn open_dir_components(
+    path: &Path,
+    mode: DirMode,
+    context: &str,
+    create_missing: bool,
+) -> io::Result<OwnedFd> {
+    if path.as_os_str().is_empty() {
+        return Err(io::Error::new(
+            io::ErrorKind::InvalidInput,
+            format!("empty {context} path"),
+        ));
+    }
+
+    let expected_uid = nix::unistd::geteuid().as_raw();
+    let start = if path.is_absolute() {
+        Path::new("/")
+    } else {
+        Path::new(".")
+    };
+    let mut current = open(start, dir_open_flags(), Mode::empty()).map_err(|e| {
+        io::Error::other(format!("open {context} root for {}: {e}", path.display()))
+    })?;
+    let mut current_path = start.to_path_buf();
+    let mut components = path.components().peekable();
+    let mut saw_normal_component = false;
+    let walk = DirWalk {
+        full_path: path,
+        mode,
+        context,
+        expected_uid,
+        create_missing,
+    };
+
+    while let Some(component) = components.next() {
+        match component {
+            Component::RootDir | Component::CurDir => {}
+            Component::ParentDir => {
+                return Err(permission_denied(format!(
+                    "{} contains a parent directory segment",
+                    path.display()
+                )));
+            }
+            Component::Normal(name) => {
+                saw_normal_component = true;
+                let is_final = components.peek().is_none();
+                current = open_dir_component(&current, name, &current_path, &walk, is_final)?;
+                current_path = component_path(&current_path, name);
+            }
+            Component::Prefix(prefix) => {
+                return Err(io::Error::new(
+                    io::ErrorKind::InvalidInput,
+                    format!(
+                        "{} contains unsupported path prefix {}",
+                        path.display(),
+                        prefix.as_os_str().to_string_lossy()
+                    ),
+                ));
+            }
+        }
+    }
+
+    if !saw_normal_component {
+        secure_dir_component(
+            &current,
+            &current_path,
+            path,
+            mode,
+            context,
+            expected_uid,
+            true,
+        )?;
+    }
+
+    Ok(current)
+}
+
+fn open_dir_component(
+    parent: &(impl AsFd + AsRawFd),
+    name: &OsStr,
+    parent_path: &Path,
+    walk: &DirWalk<'_>,
+    is_final: bool,
+) -> io::Result<OwnedFd> {
+    ensure_parent_not_replaceable(
+        parent,
+        parent_path,
+        walk.full_path,
+        walk.context,
+        walk.expected_uid,
+    )?;
+    match openat(parent, name, dir_open_flags(), Mode::empty()) {
+        Ok(fd) => {
+            secure_dir_component(
+                &fd,
+                &component_path(parent_path, name),
+                walk.full_path,
+                walk.mode,
+                walk.context,
+                walk.expected_uid,
+                is_final,
+            )?;
+            Ok(fd)
+        }
+        Err(nix::errno::Errno::ENOENT) if walk.create_missing => {
+            create_and_open_dir_component(parent, name, parent_path, walk, is_final)
+        }
+        Err(e) => Err(dir_component_error(
+            "open",
+            name,
+            walk.full_path,
+            walk.context,
+            e,
+        )),
+    }
+}
+
+fn create_and_open_dir_component(
+    parent: &(impl AsFd + AsRawFd),
+    name: &OsStr,
+    parent_path: &Path,
+    walk: &DirWalk<'_>,
+    is_final: bool,
+) -> io::Result<OwnedFd> {
+    match mkdirat(parent, name, Mode::from_bits_truncate(PRIVATE_DIR_MODE)) {
+        Ok(()) | Err(nix::errno::Errno::EEXIST) => {}
+        Err(e) => {
+            return Err(io::Error::other(format!(
+                "create {} component {} for {}: {e}",
+                walk.context,
+                name.to_string_lossy(),
+                walk.full_path.display()
+            )));
+        }
+    }
+
+    let fd = openat(parent, name, dir_open_flags(), Mode::empty())
+        .map_err(|e| dir_component_error("open", name, walk.full_path, walk.context, e))?;
+    secure_dir_component(
+        &fd,
+        &component_path(parent_path, name),
+        walk.full_path,
+        walk.mode,
+        walk.context,
+        walk.expected_uid,
+        is_final,
+    )?;
+    Ok(fd)
+}
+
+fn ensure_parent_not_replaceable(
+    parent: &(impl AsFd + AsRawFd),
+    parent_path: &Path,
+    full_path: &Path,
+    context: &str,
+    expected_uid: u32,
+) -> io::Result<()> {
+    let stat = fstat(parent).map_err(|e| {
+        io::Error::other(format!(
+            "stat {context} parent {} for {}: {e}",
+            parent_path.display(),
+            full_path.display()
+        ))
+    })?;
+    let mode = (stat.st_mode as u32) & 0o7777;
+    if stat.st_uid != ROOT_UID && stat.st_uid != expected_uid {
+        return Err(permission_denied(format!(
+            "{context} parent {} is owned by untrusted uid {}",
+            parent_path.display(),
+            stat.st_uid
+        )));
+    }
+    if mode & GROUP_OR_OTHER_WRITE_BITS != 0 && mode & STICKY_BIT == 0 {
+        return Err(permission_denied(format!(
+            "{context} parent {} is group/other writable without the sticky bit",
+            parent_path.display()
+        )));
+    }
+    Ok(())
+}
+
+fn secure_dir_component(
+    fd: &(impl AsFd + AsRawFd),
+    component_path: &Path,
+    full_path: &Path,
+    mode: DirMode,
+    context: &str,
+    expected_uid: u32,
+    is_final: bool,
+) -> io::Result<()> {
+    let stat = fstat(fd).map_err(|e| {
+        io::Error::other(format!(
+            "stat {context} component {} for {}: {e}",
+            component_path.display(),
+            full_path.display()
+        ))
+    })?;
+    let fd_type = SFlag::from_bits_truncate(stat.st_mode & SFlag::S_IFMT.bits());
+    if fd_type != SFlag::S_IFDIR {
+        return Err(permission_denied(format!(
+            "{} is not a directory",
+            full_path.display()
+        )));
+    }
+
+    match mode {
+        DirMode::Private if is_final => {
+            if stat.st_uid != expected_uid {
+                return Err(permission_denied(format!(
+                    "{context} {} is owned by uid {}, but runner euid is {expected_uid}",
+                    component_path.display(),
+                    stat.st_uid
+                )));
+            }
+            chmod_private_dir_fd(fd, component_path, context)?;
+        }
+        DirMode::TrustedParent if is_final => {
+            validate_trusted_component_owner(stat.st_uid, expected_uid, context, component_path)?;
+            let component_mode = (stat.st_mode as u32) & 0o7777;
+            if component_mode & GROUP_OR_OTHER_WRITE_BITS != 0 {
+                return Err(permission_denied(format!(
+                    "{context} {} is group/other writable",
+                    component_path.display()
+                )));
+            }
+        }
+        _ => {
+            validate_trusted_component_owner(stat.st_uid, expected_uid, context, component_path)?;
+            let component_mode = (stat.st_mode as u32) & 0o7777;
+            if component_mode & GROUP_OR_OTHER_WRITE_BITS != 0 && component_mode & STICKY_BIT == 0 {
+                return Err(permission_denied(format!(
+                    "{context} component {} is group/other writable without the sticky bit",
+                    component_path.display()
+                )));
+            }
+        }
+    }
+
+    Ok(())
+}
+
+fn validate_trusted_component_owner(
+    actual_uid: u32,
+    expected_uid: u32,
+    context: &str,
+    path: &Path,
+) -> io::Result<()> {
+    if actual_uid != ROOT_UID && actual_uid != expected_uid {
+        return Err(permission_denied(format!(
+            "{context} component {} is owned by untrusted uid {actual_uid}",
+            path.display()
+        )));
+    }
+    Ok(())
+}
+
+fn component_path(parent_path: &Path, name: &OsStr) -> PathBuf {
+    let mut path = parent_path.to_path_buf();
+    path.push(Path::new(name));
+    path
+}
+
+fn fstat_raw<Fd: AsRawFd>(file: &Fd, path: &Path, context: &str) -> io::Result<nix::libc::stat> {
+    let mut stat = std::mem::MaybeUninit::<nix::libc::stat>::uninit();
+    // SAFETY: `stat` points to writable memory and `file` owns a live fd.
+    let result = unsafe { nix::libc::fstat(file.as_raw_fd(), stat.as_mut_ptr()) };
+    if result != 0 {
+        return Err(io::Error::other(format!(
+            "stat {context} {}: {}",
+            path.display(),
+            io::Error::last_os_error()
+        )));
+    }
+    // SAFETY: successful `fstat` initialized the full struct.
+    Ok(unsafe { stat.assume_init() })
+}
+
+fn chmod_private_file_fd<Fd: AsRawFd>(file: &Fd, path: &Path, context: &str) -> io::Result<()> {
+    // SAFETY: `fchmod` operates on the live fd and does not affect Rust aliasing.
+    let result =
+        unsafe { nix::libc::fchmod(file.as_raw_fd(), PRIVATE_FILE_MODE as nix::libc::mode_t) };
+    if result == 0 {
+        Ok(())
+    } else {
+        Err(io::Error::other(format!(
+            "chmod {context} {}: {}",
+            path.display(),
+            io::Error::last_os_error()
+        )))
+    }
+}
+
+#[cfg(target_os = "linux")]
+fn chmod_private_dir_fd<Fd: AsRawFd>(fd: &Fd, path: &Path, context: &str) -> io::Result<()> {
+    use std::os::unix::fs::PermissionsExt;
+
+    let fd_path = PathBuf::from(format!("/proc/self/fd/{}", fd.as_raw_fd()));
+    std::fs::set_permissions(&fd_path, std::fs::Permissions::from_mode(PRIVATE_DIR_MODE))
+        .map_err(|e| wrap_io(e, format!("chmod {context} {}", path.display())))
+}
+
+#[cfg(not(target_os = "linux"))]
+fn chmod_private_dir_fd<Fd: AsFd>(fd: &Fd, path: &Path, context: &str) -> io::Result<()> {
+    nix::sys::stat::fchmod(fd, Mode::from_bits_truncate(PRIVATE_DIR_MODE))
+        .map_err(|e| io::Error::other(format!("chmod {context} {}: {e}", path.display())))
+}
+
+#[cfg(target_os = "linux")]
+fn dir_open_flags() -> OFlag {
+    OFlag::O_PATH | OFlag::O_DIRECTORY | OFlag::O_NOFOLLOW | OFlag::O_CLOEXEC
+}
+
+#[cfg(not(target_os = "linux"))]
+fn dir_open_flags() -> OFlag {
+    OFlag::O_RDONLY | OFlag::O_DIRECTORY | OFlag::O_NOFOLLOW | OFlag::O_CLOEXEC
+}
+
+fn dir_component_error(
+    operation: &str,
+    name: &OsStr,
+    full_path: &Path,
+    context: &str,
+    error: nix::errno::Errno,
+) -> io::Error {
+    match error {
+        nix::errno::Errno::ELOOP => permission_denied(format!(
+            "{} contains symlink component {}; refusing to use it as {context}",
+            full_path.display(),
+            name.to_string_lossy()
+        )),
+        nix::errno::Errno::ENOTDIR => permission_denied(format!(
+            "{} is not a directory; refusing to use it as {context}",
+            full_path.display()
+        )),
+        _ => io::Error::other(format!(
+            "{operation} {context} component {} for {}: {error}",
+            name.to_string_lossy(),
+            full_path.display()
+        )),
+    }
+}
+
+fn permission_denied(message: String) -> io::Error {
+    io::Error::new(io::ErrorKind::PermissionDenied, message)
+}
+
+fn wrap_io(error: io::Error, context: String) -> io::Error {
+    io::Error::new(error.kind(), format!("{context}: {error}"))
+}

--- a/crates/runner/src/lock.rs
+++ b/crates/runner/src/lock.rs
@@ -1,27 +1,33 @@
 use std::fs::File;
-use std::os::unix::fs::MetadataExt;
+use std::os::unix::fs::{MetadataExt, OpenOptionsExt};
 use std::path::{Path, PathBuf};
 
 use nix::fcntl::{Flock, FlockArg};
 
 use crate::error::{RunnerError, RunnerResult};
+use crate::host_file::{self, DirMode, PRIVATE_FILE_MODE};
 
 const LOCK_BUSY_ERROR: &str = "lock is already held by another process";
+const LOCK_REPLACED_MAX_RETRIES: usize = 64;
 
 /// Open (or create) the lock file, creating parent directories as needed.
 pub(crate) fn open_lock_file(path: &Path) -> RunnerResult<File> {
-    if let Some(parent) = path.parent() {
-        std::fs::create_dir_all(parent).map_err(|e| {
-            RunnerError::Internal(format!("create lock dir {}: {e}", parent.display()))
-        })?;
-    }
-    File::options()
+    let parent = host_file::file_parent(path);
+    host_file::ensure_dir(parent, DirMode::TrustedParent, "lock directory")
+        .map_err(|e| RunnerError::Internal(format!("create lock dir {}: {e}", parent.display())))?;
+
+    let file = File::options()
         .create(true)
         .truncate(false)
         .read(true)
         .write(true)
+        .mode(PRIVATE_FILE_MODE)
+        .custom_flags(host_file::private_file_open_flags())
         .open(path)
-        .map_err(|e| RunnerError::Internal(format!("open lock {}: {e}", path.display())))
+        .map_err(|e| RunnerError::Internal(format!("open lock {}: {e}", path.display())))?;
+    host_file::secure_regular_private_file(&file, path, "lock file")
+        .map_err(|e| RunnerError::Internal(format!("validate lock {}: {e}", path.display())))?;
+    Ok(file)
 }
 
 /// Check whether the locked fd still refers to the file currently at `path`.
@@ -32,7 +38,7 @@ fn is_current_inode(lock: &Flock<File>, path: &Path) -> bool {
     let Ok(lock_meta) = lock.metadata() else {
         return true;
     };
-    let Ok(path_meta) = std::fs::metadata(path) else {
+    let Ok(path_meta) = std::fs::symlink_metadata(path) else {
         return false;
     };
     lock_meta.dev() == path_meta.dev() && lock_meta.ino() == path_meta.ino()
@@ -70,26 +76,37 @@ enum LockAcquire {
 }
 
 async fn acquire_result_with(path: PathBuf, mode: LockMode) -> RunnerResult<LockAcquire> {
-    tokio::task::spawn_blocking(move || {
-        loop {
-            let file = open_lock_file(&path)?;
-            let lock = match Flock::lock(file, mode.arg()) {
-                Ok(lock) => lock,
-                Err((_file, e))
-                    if matches!(mode, LockMode::TryExclusive)
-                        && e == nix::errno::Errno::EWOULDBLOCK =>
-                {
-                    return Ok(LockAcquire::Busy);
-                }
-                Err((_file, e)) => return Err(mode.map_error(&path, e)),
-            };
-            if is_current_inode(&lock, &path) {
-                return Ok(LockAcquire::Acquired(lock));
+    tokio::task::spawn_blocking(move || acquire_result_blocking(&path, mode, |_| Ok(())))
+        .await
+        .map_err(|e| RunnerError::Internal(format!("lock task: {e}")))?
+}
+
+fn acquire_result_blocking(
+    path: &Path,
+    mode: LockMode,
+    mut after_lock: impl FnMut(&Path) -> RunnerResult<()>,
+) -> RunnerResult<LockAcquire> {
+    for _ in 0..LOCK_REPLACED_MAX_RETRIES {
+        let file = open_lock_file(path)?;
+        let lock = match Flock::lock(file, mode.arg()) {
+            Ok(lock) => lock,
+            Err((_file, e))
+                if matches!(mode, LockMode::TryExclusive)
+                    && e == nix::errno::Errno::EWOULDBLOCK =>
+            {
+                return Ok(LockAcquire::Busy);
             }
+            Err((_file, e)) => return Err(mode.map_error(path, e)),
+        };
+        after_lock(path)?;
+        if is_current_inode(&lock, path) {
+            return Ok(LockAcquire::Acquired(lock));
         }
-    })
-    .await
-    .map_err(|e| RunnerError::Internal(format!("lock task: {e}")))?
+    }
+    Err(RunnerError::Internal(format!(
+        "lock {} was repeatedly replaced while acquiring",
+        path.display()
+    )))
 }
 
 async fn acquire_with(path: PathBuf, mode: LockMode) -> RunnerResult<Flock<File>> {
@@ -131,6 +148,11 @@ pub async fn try_acquire_or_busy(path: PathBuf) -> RunnerResult<TryLock> {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use std::os::unix::fs::{PermissionsExt, symlink};
+
+    fn mode(path: &Path) -> u32 {
+        std::fs::metadata(path).unwrap().permissions().mode() & 0o777
+    }
 
     #[tokio::test]
     async fn acquire_creates_lock_file() {
@@ -140,6 +162,148 @@ mod tests {
         let guard = acquire(path.clone()).await.unwrap();
         assert!(path.exists());
         drop(guard);
+    }
+
+    #[tokio::test]
+    async fn acquire_creates_private_lock_file() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("test.lock");
+
+        let guard = acquire(path.clone()).await.unwrap();
+
+        assert_eq!(mode(&path), 0o600);
+        drop(guard);
+    }
+
+    #[tokio::test]
+    async fn acquire_tightens_existing_safe_lock_file() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("test.lock");
+        std::fs::write(&path, b"base-dir").unwrap();
+        std::fs::set_permissions(&path, std::fs::Permissions::from_mode(0o644)).unwrap();
+
+        let guard = acquire(path.clone()).await.unwrap();
+
+        assert_eq!(mode(&path), 0o600);
+        drop(guard);
+    }
+
+    #[tokio::test]
+    async fn acquire_rejects_symlink_lock_path() {
+        let dir = tempfile::tempdir().unwrap();
+        let target = dir.path().join("target.lock");
+        let path = dir.path().join("test.lock");
+        std::fs::write(&target, b"target").unwrap();
+        symlink(&target, &path).unwrap();
+
+        let error = acquire(path).await.unwrap_err();
+
+        assert!(
+            error.to_string().contains("open lock"),
+            "unexpected error: {error}"
+        );
+        assert_eq!(std::fs::read(&target).unwrap(), b"target");
+    }
+
+    #[tokio::test]
+    async fn acquire_rejects_fifo_lock_path() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("test.lock");
+        nix::unistd::mkfifo(&path, nix::sys::stat::Mode::from_bits_truncate(0o600)).unwrap();
+
+        let error = acquire(path).await.unwrap_err();
+
+        assert!(
+            error.to_string().contains("regular lock file"),
+            "unexpected error: {error}"
+        );
+    }
+
+    #[tokio::test]
+    async fn acquire_rejects_directory_lock_path() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("test.lock");
+        std::fs::create_dir(&path).unwrap();
+
+        let error = acquire(path).await.unwrap_err();
+
+        assert!(
+            error.to_string().contains("open lock")
+                || error.to_string().contains("regular lock file"),
+            "unexpected error: {error}"
+        );
+    }
+
+    #[tokio::test]
+    async fn acquire_rejects_group_writable_direct_parent() {
+        let dir = tempfile::tempdir().unwrap();
+        let parent = dir.path().join("unsafe");
+        std::fs::create_dir(&parent).unwrap();
+        std::fs::set_permissions(&parent, std::fs::Permissions::from_mode(0o777)).unwrap();
+        let path = parent.join("test.lock");
+
+        let error = acquire(path.clone()).await.unwrap_err();
+
+        assert!(
+            error.to_string().contains("group/other writable"),
+            "unexpected error: {error}"
+        );
+        assert!(!path.exists());
+    }
+
+    #[tokio::test]
+    async fn acquire_allows_sticky_intermediate_parent_but_rejects_sticky_direct_parent() {
+        let dir = tempfile::tempdir().unwrap();
+        let sticky = dir.path().join("sticky");
+        std::fs::create_dir(&sticky).unwrap();
+        std::fs::set_permissions(&sticky, std::fs::Permissions::from_mode(0o1777)).unwrap();
+
+        let direct_path = sticky.join("direct.lock");
+        let error = acquire(direct_path.clone()).await.unwrap_err();
+        assert!(
+            error.to_string().contains("group/other writable"),
+            "unexpected error: {error}"
+        );
+        assert!(!direct_path.exists());
+
+        let nested_path = sticky.join("private").join("nested.lock");
+        let guard = acquire(nested_path.clone()).await.unwrap();
+        assert_eq!(mode(&nested_path), 0o600);
+        drop(guard);
+    }
+
+    #[test]
+    fn acquire_returns_bounded_error_when_lock_path_keeps_being_replaced() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("test.lock");
+        let mut replacements = 0;
+
+        let result = acquire_result_blocking(&path, LockMode::Exclusive, |path| {
+            replacements += 1;
+            match std::fs::remove_file(path) {
+                Ok(()) => {}
+                Err(e) if e.kind() == std::io::ErrorKind::NotFound => {}
+                Err(e) => {
+                    return Err(RunnerError::Internal(format!(
+                        "remove replaced lock {}: {e}",
+                        path.display()
+                    )));
+                }
+            }
+            std::fs::write(path, b"replacement").map_err(|e| {
+                RunnerError::Internal(format!("write replaced lock {}: {e}", path.display()))
+            })
+        });
+        let error = match result {
+            Ok(_) => panic!("lock acquisition should fail after repeated replacement"),
+            Err(error) => error,
+        };
+
+        assert_eq!(replacements, LOCK_REPLACED_MAX_RETRIES);
+        assert!(
+            error.to_string().contains("repeatedly replaced"),
+            "unexpected error: {error}"
+        );
     }
 
     #[tokio::test]

--- a/crates/runner/src/log_file.rs
+++ b/crates/runner/src/log_file.rs
@@ -1,0 +1,132 @@
+use std::io;
+use std::path::Path;
+
+use crate::host_file::{self, DirMode};
+
+pub(crate) fn ensure_log_dir(path: &Path) -> io::Result<()> {
+    host_file::ensure_dir(path, DirMode::Private, "log directory")
+}
+
+pub(crate) fn open_append(path: &Path, read: bool) -> io::Result<std::fs::File> {
+    host_file::open_private_append_file(path, read)
+}
+
+pub(crate) fn validate_copy_destination(path: &Path) -> io::Result<()> {
+    host_file::validate_private_file_destination(path, "guest log destination")
+}
+
+#[cfg(test)]
+mod tests {
+    use std::io::Write;
+    use std::os::unix::fs::{PermissionsExt, symlink};
+    use std::path::Path;
+
+    use super::*;
+
+    fn mode(path: &Path) -> u32 {
+        std::fs::metadata(path).unwrap().permissions().mode() & 0o777
+    }
+
+    #[test]
+    fn ensure_log_dir_tightens_existing_dir() {
+        let dir = tempfile::tempdir().unwrap();
+        let log_dir = dir.path().join("logs");
+        std::fs::create_dir(&log_dir).unwrap();
+        std::fs::set_permissions(&log_dir, std::fs::Permissions::from_mode(0o755)).unwrap();
+
+        ensure_log_dir(&log_dir).unwrap();
+
+        assert_eq!(mode(&log_dir), 0o700);
+    }
+
+    #[test]
+    fn ensure_log_dir_rejects_unsafe_parent_without_creating_dir() {
+        let dir = tempfile::tempdir().unwrap();
+        let parent = dir.path().join("unsafe");
+        std::fs::create_dir(&parent).unwrap();
+        std::fs::set_permissions(&parent, std::fs::Permissions::from_mode(0o777)).unwrap();
+        let log_dir = parent.join("logs");
+
+        let error = ensure_log_dir(&log_dir).unwrap_err();
+
+        assert!(
+            error.to_string().contains("group/other writable"),
+            "unexpected error: {error}"
+        );
+        assert!(!log_dir.exists());
+    }
+
+    #[test]
+    fn open_append_creates_private_file() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("network.jsonl");
+
+        let mut file = open_append(&path, false).unwrap();
+        file.write_all(b"line\n").unwrap();
+
+        assert_eq!(mode(&path), 0o600);
+        assert_eq!(std::fs::read(&path).unwrap(), b"line\n");
+    }
+
+    #[test]
+    fn open_append_rejects_symlink_destination() {
+        let dir = tempfile::tempdir().unwrap();
+        let target = dir.path().join("target.log");
+        let path = dir.path().join("network.jsonl");
+        symlink(&target, &path).unwrap();
+
+        let error = open_append(&path, false).unwrap_err();
+
+        assert!(
+            error.to_string().contains("open log file"),
+            "unexpected error: {error}"
+        );
+        assert!(!target.exists());
+    }
+
+    #[test]
+    fn open_append_rejects_fifo_destination() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("network.jsonl");
+        nix::unistd::mkfifo(&path, nix::sys::stat::Mode::from_bits_truncate(0o600)).unwrap();
+
+        let error = open_append(&path, false).unwrap_err();
+
+        assert!(
+            error.to_string().contains("open log file")
+                || error.to_string().contains("regular log file"),
+            "unexpected error: {error}"
+        );
+    }
+
+    #[test]
+    fn validate_copy_destination_rejects_directory_destination() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("system.log");
+        std::fs::create_dir(&path).unwrap();
+
+        let error = validate_copy_destination(&path).unwrap_err();
+
+        assert!(
+            error.to_string().contains("open guest log destination"),
+            "unexpected error: {error}"
+        );
+    }
+
+    #[test]
+    fn open_append_rejects_unsafe_parent_without_creating_file() {
+        let dir = tempfile::tempdir().unwrap();
+        let parent = dir.path().join("unsafe");
+        std::fs::create_dir(&parent).unwrap();
+        std::fs::set_permissions(&parent, std::fs::Permissions::from_mode(0o777)).unwrap();
+        let path = parent.join("network.jsonl");
+
+        let error = open_append(&path, false).unwrap_err();
+
+        assert!(
+            error.to_string().contains("group/other writable"),
+            "unexpected error: {error}"
+        );
+        assert!(!path.exists());
+    }
+}

--- a/crates/runner/src/main.rs
+++ b/crates/runner/src/main.rs
@@ -9,6 +9,7 @@ mod executor;
 mod group;
 mod host;
 mod host_env;
+mod host_file;
 mod http;
 mod idle_pool;
 mod ids;
@@ -17,6 +18,7 @@ mod io_limits;
 mod kmsg_log;
 mod local_queue;
 mod lock;
+mod log_file;
 mod network_log_drain;
 mod network_log_manager;
 mod network_logs;
@@ -153,7 +155,7 @@ fn init_tracing_with_file(
 ) -> Result<tracing_appender::non_blocking::WorkerGuard, Box<dyn std::error::Error>> {
     let home = paths::HomePaths::new()?;
     let log_dir = home.logs_dir();
-    std::fs::create_dir_all(&log_dir).map_err(|e| format!("create {}: {e}", log_dir.display()))?;
+    log_file::ensure_log_dir(&log_dir).map_err(|e| format!("create {}: {e}", log_dir.display()))?;
 
     let name = runner_name_from_config(config_path);
     let prefix = format!("runner-{name}");

--- a/crates/runner/src/network_log_manager.rs
+++ b/crates/runner/src/network_log_manager.rs
@@ -1,6 +1,5 @@
 use std::collections::HashMap;
 use std::io::Write;
-use std::os::unix::fs::OpenOptionsExt;
 use std::path::{Path, PathBuf};
 use std::sync::Arc;
 
@@ -373,17 +372,14 @@ impl NetworkLogManager {
 }
 
 fn append_line(path: &Path, line: &str) -> std::io::Result<()> {
-    std::fs::OpenOptions::new()
-        .create(true)
-        .append(true)
-        .mode(0o644)
-        .open(path)
-        .and_then(|mut f| f.write_all(line.as_bytes()))
+    crate::log_file::open_append(path, false).and_then(|mut f| f.write_all(line.as_bytes()))
 }
 
 #[cfg(test)]
 mod tests {
     use std::future::{Future, poll_fn};
+    use std::os::unix::fs::{PermissionsExt, symlink};
+    use std::path::Path;
     use std::task::Poll;
     use std::time::Duration;
 
@@ -393,6 +389,10 @@ mod tests {
     use crate::network_log_drain::{NetworkLogDrainCoordinator, NetworkLogDrainProducer};
 
     use super::*;
+
+    fn mode(path: &Path) -> u32 {
+        std::fs::metadata(path).unwrap().permissions().mode() & 0o777
+    }
 
     fn read_json_lines(path: &Path) -> Vec<serde_json::Value> {
         std::fs::read_to_string(path)
@@ -449,6 +449,30 @@ mod tests {
         assert_eq!(lines[0]["type"], "dns");
         assert_eq!(lines[0]["host"], "example.com");
         assert_eq!(lines[0]["port"], 53);
+        assert_eq!(mode(&path), 0o600);
+    }
+
+    #[tokio::test]
+    async fn append_for_ip_flushes_after_rejecting_unsafe_path() {
+        let dir = tempfile::tempdir().unwrap();
+        let target = dir.path().join("target.jsonl");
+        let path = dir.path().join("network.jsonl");
+        symlink(&target, &path).unwrap();
+        let manager = NetworkLogManager::new();
+
+        let _session = manager.register_source_ip("10.200.0.2", path.clone()).await;
+        assert!(
+            manager
+                .append_for_ip(
+                    "10.200.0.2",
+                    json!({"type":"dns","host":"example.com","port":53}),
+                )
+                .await
+        );
+
+        manager.flush_path(&path).await;
+
+        assert!(!target.exists());
     }
 
     #[tokio::test]

--- a/crates/vsock-host/src/file/copy.rs
+++ b/crates/vsock-host/src/file/copy.rs
@@ -1,4 +1,5 @@
 use std::io;
+use std::os::fd::AsRawFd;
 use std::path::{Path, PathBuf};
 use std::sync::atomic::{AtomicU64, Ordering};
 use std::time::Duration;
@@ -14,6 +15,8 @@ use crate::{
 use super::{file_operation_error_is_terminal, shell_quote};
 
 const COPY_TEMP_CREATE_ATTEMPTS: usize = 16;
+const COPY_TEMP_FILE_MODE: u32 = 0o600;
+const GROUP_OR_OTHER_WRITE_BITS: u32 = 0o022;
 const COPY_FILE_STREAM_CHUNK_LIMIT: u32 = 64 * 1024;
 pub(super) const COPY_FILE_STREAM_MAX_BYTES: u64 = 64 * 1024 * 1024;
 // Copying is the one built-in streaming consumer that must tolerate the host
@@ -149,10 +152,15 @@ async fn create_copy_temp_file(
         match tokio::fs::OpenOptions::new()
             .write(true)
             .create_new(true)
+            .mode(COPY_TEMP_FILE_MODE)
+            .custom_flags(nix::libc::O_NOFOLLOW | nix::libc::O_CLOEXEC | nix::libc::O_NONBLOCK)
             .open(&temp_path)
             .await
         {
-            Ok(file) => return Ok((temp_path, file)),
+            Ok(file) => {
+                secure_copy_temp_file(&file, &temp_path)?;
+                return Ok((temp_path, file));
+            }
             Err(err) if err.kind() == io::ErrorKind::AlreadyExists => continue,
             Err(err) => return Err(err),
         }
@@ -164,6 +172,61 @@ async fn create_copy_temp_file(
             "copy_file could not create a unique temp file after {COPY_TEMP_CREATE_ATTEMPTS} attempts"
         ),
     ))
+}
+
+fn secure_copy_temp_file(file: &tokio::fs::File, path: &Path) -> io::Result<()> {
+    let stat = fstat_copy_temp_file(file, path)?;
+    let file_type = stat.st_mode & nix::libc::S_IFMT;
+    if file_type != nix::libc::S_IFREG {
+        return Err(io::Error::new(
+            io::ErrorKind::PermissionDenied,
+            format!("copy temp file {} is not a regular file", path.display()),
+        ));
+    }
+    let expected_uid = unsafe { nix::libc::geteuid() };
+    if stat.st_uid != expected_uid {
+        return Err(io::Error::new(
+            io::ErrorKind::PermissionDenied,
+            format!(
+                "copy temp file {} is owned by uid {}, but euid is {expected_uid}",
+                path.display(),
+                stat.st_uid
+            ),
+        ));
+    }
+    if stat.st_mode & GROUP_OR_OTHER_WRITE_BITS != 0 {
+        return Err(io::Error::new(
+            io::ErrorKind::PermissionDenied,
+            format!("copy temp file {} is group/other writable", path.display()),
+        ));
+    }
+    // SAFETY: `fchmod` operates on the live fd and does not affect Rust aliasing.
+    let result =
+        unsafe { nix::libc::fchmod(file.as_raw_fd(), COPY_TEMP_FILE_MODE as nix::libc::mode_t) };
+    if result == 0 {
+        Ok(())
+    } else {
+        Err(io::Error::other(format!(
+            "chmod copy temp file {}: {}",
+            path.display(),
+            io::Error::last_os_error()
+        )))
+    }
+}
+
+fn fstat_copy_temp_file(file: &tokio::fs::File, path: &Path) -> io::Result<nix::libc::stat> {
+    let mut stat = std::mem::MaybeUninit::<nix::libc::stat>::uninit();
+    // SAFETY: `stat` points to writable memory and `file` owns a live fd.
+    let result = unsafe { nix::libc::fstat(file.as_raw_fd(), stat.as_mut_ptr()) };
+    if result != 0 {
+        return Err(io::Error::other(format!(
+            "stat copy temp file {}: {}",
+            path.display(),
+            io::Error::last_os_error()
+        )));
+    }
+    // SAFETY: successful `fstat` initialized the full struct.
+    Ok(unsafe { stat.assume_init() })
 }
 
 async fn write_copy_stream_event(

--- a/crates/vsock-host/src/file/copy.rs
+++ b/crates/vsock-host/src/file/copy.rs
@@ -146,6 +146,14 @@ async fn create_copy_temp_file(
     host_path: &Path,
     seq: u32,
 ) -> io::Result<(PathBuf, tokio::fs::File)> {
+    create_copy_temp_file_with_validator(host_path, seq, secure_copy_temp_file).await
+}
+
+async fn create_copy_temp_file_with_validator(
+    host_path: &Path,
+    seq: u32,
+    validate: impl Fn(&tokio::fs::File, &Path) -> io::Result<()>,
+) -> io::Result<(PathBuf, tokio::fs::File)> {
     for _ in 0..COPY_TEMP_CREATE_ATTEMPTS {
         let nonce = COPY_TEMP_NONCE.fetch_add(1, Ordering::Relaxed);
         let temp_path = copy_temp_path(host_path, std::process::id(), seq, nonce);
@@ -158,7 +166,11 @@ async fn create_copy_temp_file(
             .await
         {
             Ok(file) => {
-                secure_copy_temp_file(&file, &temp_path)?;
+                if let Err(err) = validate(&file, &temp_path) {
+                    drop(file);
+                    remove_temp_file(&temp_path).await;
+                    return Err(err);
+                }
                 return Ok((temp_path, file));
             }
             Err(err) if err.kind() == io::ErrorKind::AlreadyExists => continue,
@@ -581,6 +593,39 @@ mod tests {
         assert!(second_path.exists());
         drop(first_file);
         drop(second_file);
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    #[tokio::test]
+    async fn create_copy_temp_file_removes_temp_when_validation_fails() {
+        let unique = std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .unwrap()
+            .as_nanos();
+        let dir = std::env::temp_dir().join(format!(
+            "vsock-host-copy-temp-validation-{}-{unique}",
+            std::process::id()
+        ));
+        std::fs::create_dir_all(&dir).unwrap();
+        let host_path = dir.join("system.log");
+
+        let error = create_copy_temp_file_with_validator(&host_path, 7, |_file, _path| {
+            Err(io::Error::new(
+                io::ErrorKind::PermissionDenied,
+                "forced validation failure",
+            ))
+        })
+        .await
+        .unwrap_err();
+
+        assert_eq!(error.kind(), io::ErrorKind::PermissionDenied);
+        assert!(std::fs::read_dir(&dir).unwrap().all(|entry| {
+            !entry
+                .unwrap()
+                .file_name()
+                .to_string_lossy()
+                .contains("vm0tmp")
+        }));
         let _ = std::fs::remove_dir_all(&dir);
     }
 

--- a/crates/vsock-host/src/tests/file/copy.rs
+++ b/crates/vsock-host/src/tests/file/copy.rs
@@ -1,4 +1,5 @@
 use std::io;
+use std::os::unix::fs::PermissionsExt;
 use std::path::Path;
 use std::sync::Arc;
 
@@ -16,6 +17,10 @@ use super::support::{
 };
 use crate::file as file_impl;
 use crate::operation_tracker::NormalOperationReadiness;
+
+fn mode(path: &Path) -> u32 {
+    std::fs::metadata(path).unwrap().permissions().mode() & 0o777
+}
 
 #[tokio::test]
 async fn copy_file_rejects_max_bytes_above_stream_budget() {
@@ -102,6 +107,7 @@ async fn copy_file_streams_to_temp_then_renames() {
         NormalOperationReadiness::Idle
     );
     assert_eq!(std::fs::read(&host_path).unwrap(), b"line 1\nline 2\n");
+    assert_eq!(mode(&host_path), 0o600);
     temp_dir.assert_no_vm0tmp_files();
 }
 


### PR DESCRIPTION
## Summary
- harden runner lock parent creation/opening with no-follow directory walking, private lock file mode, fd validation, and bounded inode replacement retries
- add focused runner log file helpers for private log directories, private append logs, and guest log copy destination preflight
- create vsock-host copy temp files with private mode and fd validation so published copied logs inherit 0600

## Notes
- runner rolling logs are protected by ensuring the runner log directory is private before constructing tracing_appender; this avoids a process-wide umask change or replacing the tracing subsystem
- unsafe guest log destinations are skipped per file so other guest logs can still be copied

## Tests
- cargo test --manifest-path crates/Cargo.toml -p runner lock
- cargo test --manifest-path crates/Cargo.toml -p runner network_log_manager
- cargo test --manifest-path crates/Cargo.toml -p runner diagnostics
- cargo test --manifest-path crates/Cargo.toml -p vsock-host copy_file
- cargo test --manifest-path crates/Cargo.toml -p runner
- cargo test --manifest-path crates/Cargo.toml -p vsock-host
- cargo clippy --manifest-path crates/Cargo.toml -p runner --all-targets -- -D warnings
- cargo clippy --manifest-path crates/Cargo.toml -p vsock-host --all-targets -- -D warnings

Closes #16559