### PR TITLE
fix: support dark mode in credit usage popover

### DIFF
--- a/turbo/apps/platform/src/views/zero-page/__tests__/org-usage-tab.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/org-usage-tab.test.tsx
@@ -55,6 +55,32 @@ async function openUsageTab() {
   });
 }
 
+async function expectPopoverTokenTooltip(text: string) {
+  await waitFor(() => {
+    const tooltip = screen
+      .getAllByText(text)
+      .map((el) => {
+        let current: HTMLElement | null = el;
+        while (current) {
+          const style = current.getAttribute("style") ?? "";
+          if (
+            style.includes("background-color: hsl(var(--popover))") &&
+            style.includes("color: hsl(var(--popover-foreground))")
+          ) {
+            return current;
+          }
+          current = current.parentElement;
+        }
+        return null;
+      })
+      .find((el): el is HTMLElement => {
+        return el !== null;
+      });
+
+    expect(tooltip).toBeDefined();
+  });
+}
+
 describe("org usage tab - credit balance display", () => {
   it("should show credit balance for pro plan", async () => {
     setMockBillingStatus({
@@ -175,16 +201,36 @@ describe("org usage tab - credit balance display", () => {
     });
 
     await user.hover(screen.getByTestId("credit-grant-grant-pro"));
-    await waitFor(() => {
-      expect(
-        screen.getAllByText("Expires Apr 20, 2026").length,
-      ).toBeGreaterThan(0);
-    });
+    await expectPopoverTokenTooltip("Expires Apr 20, 2026");
 
     await user.click(screen.getByTestId("credit-grants-toggle"));
     expect(screen.getByTestId("credit-grants-section")).not.toHaveAttribute(
       "open",
     );
+  });
+
+  it("should use popover theme tokens for credit balance segment tooltips", async () => {
+    const user = userEvent.setup({
+      pointerEventsCheck: PointerEventsCheckLevel.Never,
+    });
+    setMockBillingStatus({
+      tier: "pro",
+      credits: 35_000,
+      subscriptionStatus: "active",
+      hasSubscription: true,
+      creditBreakdown: [
+        { category: "plan", label: "Pro plan", credits: 15_000, tier: "pro" },
+        { category: "payAsYouGo", label: "Pay as you go", credits: 20_000 },
+      ],
+      creditGrants: [],
+    });
+
+    setupMockAPIs([]);
+
+    await openUsageTab();
+
+    await user.hover(screen.getByTestId("credit-balance-segment-plan:pro"));
+    await expectPopoverTokenTooltip("Pro plan — 15,000");
   });
 
   it("should show non-expiring credit additions on hover", async () => {
@@ -221,9 +267,7 @@ describe("org usage tab - credit balance display", () => {
       "Added Mar 25, 2026",
     );
     await user.hover(screen.getByTestId("credit-grant-grant-payg"));
-    await waitFor(() => {
-      expect(screen.getAllByText("Never expires").length).toBeGreaterThan(0);
-    });
+    await expectPopoverTokenTooltip("Never expires");
   });
 });
 

--- a/turbo/apps/platform/src/views/zero-page/components/org-manage/org-usage-tab.tsx
+++ b/turbo/apps/platform/src/views/zero-page/components/org-manage/org-usage-tab.tsx
@@ -135,7 +135,10 @@ function CreditGrantRow({ grant }: { grant: CreditGrant }) {
       <TooltipContent
         side="top"
         sideOffset={8}
-        style={{ backgroundColor: "white", color: "inherit" }}
+        style={{
+          backgroundColor: "hsl(var(--popover))",
+          color: "hsl(var(--popover-foreground))",
+        }}
         className="border shadow-md"
       >
         <div className="font-medium text-foreground">{expiresLabel(grant)}</div>
@@ -248,7 +251,10 @@ function CreditBalanceChart({
                     <TooltipContent
                       side="top"
                       sideOffset={8}
-                      style={{ backgroundColor: "white", color: "inherit" }}
+                      style={{
+                        backgroundColor: "hsl(var(--popover))",
+                        color: "hsl(var(--popover-foreground))",
+                      }}
                       className="border shadow-md"
                     >
                       <div className="font-medium text-foreground">

--- a/turbo/apps/platform/src/views/zero-page/components/org-manage/org-usage-tab.tsx
+++ b/turbo/apps/platform/src/views/zero-page/components/org-manage/org-usage-tab.tsx
@@ -242,6 +242,7 @@ function CreditBalanceChart({
                   <Tooltip key={segmentKey(s)}>
                     <TooltipTrigger asChild>
                       <div
+                        data-testid={`credit-balance-segment-${segmentKey(s)}`}
                         className={`h-2.5 ${color} cursor-default first:rounded-l-full last:rounded-r-full ring-0 hover:ring-2 hover:ring-foreground/30 hover:z-10 transition-shadow`}
                         style={{
                           width: `${(s.credits / total) * 100}%`,


### PR DESCRIPTION
## Summary

Fixes #16718. The credit usage bar segment tooltip (and the credit-grant row tooltip) hardcoded `backgroundColor: "white"` with `color: inherit`, so in dark mode they rendered a light surface with low-contrast text inside the otherwise dark credit balance UI.

## Change

Replace the hardcoded inline styles on both `TooltipContent` instances in `org-usage-tab.tsx` with the theme-aware `--popover` / `--popover-foreground` design tokens. The popover now follows the active theme (white in light mode, dark surface in dark mode). The child text already uses `text-foreground` / `text-muted-foreground`, which adapt correctly.

Note: the base `TooltipContent` sets its background via an inline style, which overrides Tailwind classes — so the fix is applied via inline style with `hsl(var(--popover))` rather than a `bg-popover` class.

## Testing

Visual/token change only; relying on the PR pipeline for lint/type/test.

Closes #16718

🤖 Generated with [Claude Code](https://claude.com/claude-code)