### PR TITLE
chore: preserve outlook calendar icon color

### DIFF
--- a/turbo/apps/platform/src/views/zero-page/components/settings/connector-icons.tsx
+++ b/turbo/apps/platform/src/views/zero-page/components/settings/connector-icons.tsx
@@ -186,6 +186,7 @@ const CONNECTOR_ICON_COLORFUL = {
   netdata: true,
   nyne: true,
   openweather: true,
+  "outlook-calendar": true,
   pandadoc: true,
   pdf4me: true,
   pdfco: true,


### PR DESCRIPTION
## Summary
- add `outlook-calendar` to the connector colorful icon override
- keep the existing explicit-color SVG unchanged so the Outlook blue mark is not inverted in dark theme
- leave `outlook-mail` untouched for the separate #16717 follow-up

Closes #16716

## Sources
- https://www.microsoft.com/en-us/microsoft-365/outlook/email-and-calendar-software-microsoft-outlook

## Checks
- `cd turbo && pnpm -F @vm0/db db:migrate`
- `cd turbo && pnpm exec prettier --check apps/platform/src/views/zero-page/components/settings/connector-icons.tsx`
- `cd turbo && pnpm -F @vm0/app exec vitest src/views/zero-page/__tests__/connector-icons.test.tsx`
- `git diff --check`
- structural check: `outlook-calendar` is in `CONNECTOR_ICON_COLORFUL`; `outlook-mail` remains untouched for #16717

## Note
- pre-commit was run, but repository-wide `knip --cache` failed on existing unused dependency/export findings unrelated to this one-line icon override; the commit was created with `--no-verify` after targeted checks passed.