### PR TITLE
fix: remove scheduled run cards

### DIFF
--- a/turbo/apps/platform/src/views/zero-page/__tests__/zero-chat-thread-page-display.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/zero-chat-thread-page-display.test.tsx
@@ -232,75 +232,8 @@ describe("zero chat thread page display - schedule menu", () => {
   });
 });
 
-describe("zero chat thread page display - scheduled run card", () => {
-  it("collapses a scheduled run into a status card and opens assistant details", async () => {
-    const user = userEvent.setup();
-    mockChatLifecycle({
-      chatMessages: [
-        {
-          id: "msg-scheduled-user",
-          role: "user",
-          content: "Run the daily report",
-          runId: "run-scheduled-report",
-          scheduleId: "schedule-report",
-          scheduleTitle: "Daily report",
-          scheduleSnapshot: {
-            id: "schedule-report",
-            title: "Daily report",
-            description: "Daily revenue summary",
-          },
-          createdAt: "2026-03-10T00:00:00Z",
-        },
-        {
-          id: "msg-scheduled-assistant",
-          role: "assistant",
-          content: [
-            "I checked the latest numbers.",
-            "Revenue is up 4%.",
-            "Open issues are unchanged.",
-            "I prepared the report.",
-          ].join("\n"),
-          runId: "run-scheduled-report",
-          status: "completed",
-          createdAt: "2026-03-10T00:00:10Z",
-        },
-        {
-          id: "msg-scheduled-marker",
-          role: "assistant",
-          content: null,
-          runId: "run-scheduled-report",
-          runLifecycleEvent: "completed",
-          createdAt: "2026-03-10T00:00:11Z",
-        },
-      ],
-    });
-
-    detachedSetupPage({ context, path: "/chats/thread-test-1" });
-
-    const card = await screen.findByLabelText(
-      "Open scheduled run details for Daily revenue summary",
-    );
-    expect(card).toHaveTextContent("Triggered at");
-    expect(card).toHaveTextContent("Daily revenue summary");
-    expect(card).toHaveTextContent("Succeeded");
-    expect(card).toHaveTextContent("Revenue is up 4%.");
-    expect(card).toHaveTextContent("Open issues are unchanged.");
-    expect(card).toHaveTextContent("I prepared the report.");
-    expect(
-      screen.queryByText("I checked the latest numbers."),
-    ).not.toBeInTheDocument();
-
-    await user.click(card);
-
-    const dialog = await screen.findByRole("dialog");
-    expect(within(dialog).getByText("Scheduled run")).toBeInTheDocument();
-    expect(within(dialog).getByText("Succeeded")).toBeInTheDocument();
-    expect(
-      within(dialog).getByText(/I checked the latest numbers/),
-    ).toBeInTheDocument();
-  });
-
-  it("uses the original inline schedule display when the feature switch is disabled", async () => {
+describe("zero chat thread page display - scheduled run inline display", () => {
+  it("uses the original inline schedule display", async () => {
     mockChatLifecycle({
       chatMessages: [
         {
@@ -331,18 +264,12 @@ describe("zero chat thread page display - scheduled run card", () => {
     detachedSetupPage({
       context,
       path: "/chats/thread-test-1",
-      featureSwitches: { [FeatureSwitchKey.ChatScheduledRunCard]: false },
     });
 
     const scheduleLink = await screen.findByLabelText(
       "Open schedule Daily revenue summary",
     );
     expect(scheduleLink).toBeInTheDocument();
-    expect(
-      screen.queryByLabelText(
-        "Open scheduled run details for Daily revenue summary",
-      ),
-    ).not.toBeInTheDocument();
     const assistantMessage = await screen.findByText(
       "I checked the latest numbers and prepared the report.",
     );

--- a/turbo/apps/platform/src/views/zero-page/zero-chat-thread-page.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-chat-thread-page.tsx
@@ -55,13 +55,6 @@ import {
   TooltipProvider,
   TooltipTrigger,
 } from "@vm0/ui";
-import {
-  Dialog,
-  DialogContent,
-  DialogHeader,
-  DialogTitle,
-  DialogTrigger,
-} from "@vm0/ui/components/ui/dialog";
 import { RUN_ERROR_GUIDANCE } from "@vm0/api-contracts/contracts/errors";
 import type {
   ChatThreadArtifactFile,
@@ -2125,88 +2118,6 @@ function useGithubPrTrackingOpen(
   );
 }
 
-interface ScheduledRunDisplay {
-  userMessage: EnrichedChatMessage & { role: "user" };
-  assistantMessages: (EnrichedChatMessage & { role: "assistant" })[];
-  previewText: string | null;
-  status: ScheduledRunStatus;
-  statusLabel: string;
-  title: string;
-  triggerTime: string;
-}
-
-type ChatThreadDisplayEntry =
-  | { type: "group"; group: GroupedChatMessageGroup }
-  | { type: "scheduled-run"; run: ScheduledRunDisplay };
-
-function appendDisplayGroup(
-  entries: ChatThreadDisplayEntry[],
-  message: EnrichedChatMessage,
-): void {
-  const last = entries[entries.length - 1];
-  if (last?.type === "group" && last.group.role === message.role) {
-    last.group.messages.push(message);
-    return;
-  }
-  entries.push({
-    type: "group",
-    group: {
-      beginMessageId: message.id,
-      role: message.role,
-      messages: [message],
-    },
-  });
-}
-
-function buildChatThreadDisplayEntries(
-  groups: readonly GroupedChatMessageGroup[],
-  scheduledRunCardEnabled: boolean,
-): ChatThreadDisplayEntry[] {
-  if (!scheduledRunCardEnabled) {
-    return groups.map((group) => {
-      return { type: "group", group };
-    });
-  }
-
-  const entries: ChatThreadDisplayEntry[] = [];
-  const messages = groups.flatMap((group) => {
-    return group.messages;
-  });
-
-  for (let index = 0; index < messages.length; index++) {
-    const message = messages[index]!;
-    if (isScheduleUserMessage(message)) {
-      const assistantMessages: (EnrichedChatMessage & {
-        role: "assistant";
-      })[] = [];
-      let nextIndex = index + 1;
-      while (nextIndex < messages.length) {
-        const nextMessage = messages[nextIndex]!;
-        if (
-          message.runId !== undefined &&
-          nextMessage.role === "assistant" &&
-          nextMessage.runId === message.runId
-        ) {
-          assistantMessages.push(nextMessage);
-          nextIndex++;
-          continue;
-        }
-        break;
-      }
-      entries.push({
-        type: "scheduled-run",
-        run: createScheduledRunDisplay(message, assistantMessages),
-      });
-      index = nextIndex - 1;
-      continue;
-    }
-
-    appendDisplayGroup(entries, message);
-  }
-
-  return entries;
-}
-
 function ChatThreadMessagesMain({
   thread,
   groups,
@@ -2233,15 +2144,6 @@ function ChatThreadMessagesMain({
     groups.length === 0 &&
     !messagesLoading &&
     !skeletonVisible;
-  const features = useLastResolved(featureSwitch$);
-  const scheduledRunCardEnabled =
-    features?.[FeatureSwitchKey.ChatScheduledRunCard] ?? true;
-  const displayEntries = buildChatThreadDisplayEntries(
-    activeGroups,
-    scheduledRunCardEnabled,
-  );
-  const suppressThinkingIndicator =
-    displayEntries[displayEntries.length - 1]?.type === "scheduled-run";
 
   return (
     <main className={CHAT_THREAD_CONTENT_MAIN_CLASS}>
@@ -2284,27 +2186,16 @@ function ChatThreadMessagesMain({
             </p>
           </div>
         )}
-        {displayEntries.map((entry) => {
-          if (entry.type === "scheduled-run") {
-            return (
-              <ScheduledRunCard
-                key={entry.run.userMessage.id}
-                run={entry.run}
-                thread={thread}
-              />
-            );
-          }
+        {activeGroups.map((group) => {
           return (
             <PagedGroupRow
-              key={entry.group.beginMessageId}
-              group={entry.group}
+              key={group.beginMessageId}
+              group={group}
               thread={thread}
             />
           );
         })}
-        {!suppressThinkingIndicator && (
-          <ThinkingIndicator thread={thread} groups={activeGroups} />
-        )}
+        <ThinkingIndicator thread={thread} groups={activeGroups} />
       </div>
     </main>
   );
@@ -4380,8 +4271,6 @@ function PagedUserGroup({
   );
 }
 
-type ScheduledRunStatus = "running" | "succeeded" | "failed";
-
 function isScheduleUserMessage(
   message: EnrichedChatMessage,
 ): message is EnrichedChatMessage & { role: "user" } {
@@ -4401,265 +4290,6 @@ function scheduleMessageLabel(
     message.scheduleSnapshot?.title?.trim() ||
     message.scheduleTitle?.trim() ||
     "Scheduled run"
-  );
-}
-
-function scheduledRunTitle(
-  userMessage: EnrichedChatMessage & { role: "user" },
-): string {
-  return scheduleMessageLabel(userMessage);
-}
-
-function formatScheduledRunTriggerTime(value: string): string {
-  const date = new Date(value);
-  if (Number.isNaN(date.getTime())) {
-    return value;
-  }
-  return new Intl.DateTimeFormat(undefined, {
-    hour: "numeric",
-    minute: "2-digit",
-  }).format(date);
-}
-
-function resolveScheduledRunStatus(
-  assistantMessages: readonly (EnrichedChatMessage & { role: "assistant" })[],
-): ScheduledRunStatus {
-  const failed = assistantMessages.some((message) => {
-    return (
-      message.runLifecycleEvent === "failed" ||
-      message.runLifecycleEvent === "cancelled" ||
-      message.status === "failed" ||
-      message.status === "cancelled" ||
-      message.error !== undefined
-    );
-  });
-  if (failed) {
-    return "failed";
-  }
-
-  const succeeded = assistantMessages.some((message) => {
-    return (
-      message.runLifecycleEvent === "completed" ||
-      message.status === "completed"
-    );
-  });
-  return succeeded ? "succeeded" : "running";
-}
-
-function scheduledRunStatusLabel(status: ScheduledRunStatus): string {
-  switch (status) {
-    case "failed": {
-      return "Failed";
-    }
-    case "running": {
-      return "Running";
-    }
-    case "succeeded": {
-      return "Succeeded";
-    }
-  }
-}
-
-function scheduledRunStatusClassName(status: ScheduledRunStatus): string {
-  switch (status) {
-    case "failed": {
-      return "bg-destructive/10 text-destructive";
-    }
-    case "running": {
-      return "bg-amber-500/10 text-amber-700 dark:text-amber-400";
-    }
-    case "succeeded": {
-      return "bg-emerald-500/10 text-emerald-700 dark:text-emerald-400";
-    }
-  }
-}
-
-function ScheduledRunStatusIcon({ status }: { status: ScheduledRunStatus }) {
-  if (status === "running") {
-    return <IconLoader2 size={16} stroke={1.8} className="animate-spin" />;
-  }
-  if (status === "failed") {
-    return <IconAlertCircle size={16} stroke={1.8} />;
-  }
-  return <IconCheck size={16} stroke={1.8} />;
-}
-
-function latestRenderableAssistantMessage(
-  messages: readonly (EnrichedChatMessage & { role: "assistant" })[],
-): (EnrichedChatMessage & { role: "assistant" }) | undefined {
-  for (let index = messages.length - 1; index >= 0; index--) {
-    const message = messages[index]!;
-    if (hasRenderableAssistantContent(message)) {
-      return message;
-    }
-  }
-  return undefined;
-}
-
-function lastThreeAssistantLines(
-  messages: readonly (EnrichedChatMessage & { role: "assistant" })[],
-): string | null {
-  const message = latestRenderableAssistantMessage(messages);
-  const content = (message?.error ?? message?.content ?? "").trim();
-  if (!content) {
-    return null;
-  }
-
-  const lines = content
-    .split(/\r?\n/)
-    .map((line) => {
-      return line.trim();
-    })
-    .filter((line) => {
-      return line.length > 0;
-    });
-  const preview = lines.slice(-3).join("\n").trim();
-  return preview.length > 0 ? preview : null;
-}
-
-function createScheduledRunDisplay(
-  userMessage: EnrichedChatMessage & { role: "user" },
-  assistantMessages: (EnrichedChatMessage & { role: "assistant" })[],
-): ScheduledRunDisplay {
-  const title = scheduledRunTitle(userMessage);
-  const status = resolveScheduledRunStatus(assistantMessages);
-  return {
-    userMessage,
-    assistantMessages,
-    previewText: lastThreeAssistantLines(assistantMessages),
-    status,
-    statusLabel: scheduledRunStatusLabel(status),
-    title,
-    triggerTime: formatScheduledRunTriggerTime(userMessage.createdAt),
-  };
-}
-
-function hasRenderableAssistantContent(message: EnrichedChatMessage): boolean {
-  return (
-    message.role === "assistant" &&
-    (message.error !== undefined ||
-      message.blocks.length > 0 ||
-      (message.content?.trim().length ?? 0) > 0)
-  );
-}
-
-function ScheduledRunTranscript({
-  run,
-  thread,
-}: {
-  run: ScheduledRunDisplay;
-  thread: ChatThreadSignals;
-}) {
-  const messages = run.assistantMessages.filter(hasRenderableAssistantContent);
-
-  if (messages.length === 0) {
-    return (
-      <div className="rounded-xl border border-border bg-background px-4 py-8 text-center text-sm text-muted-foreground">
-        No assistant messages yet
-      </div>
-    );
-  }
-
-  return (
-    <div className="@container">
-      <PagedAssistantGroup
-        group={{
-          beginMessageId: messages[0]!.id,
-          role: "assistant",
-          messages,
-        }}
-        thread={thread}
-      />
-    </div>
-  );
-}
-
-function ScheduledRunCard({
-  run,
-  thread,
-}: {
-  run: ScheduledRunDisplay;
-  thread: ChatThreadSignals;
-}) {
-  const { previewText, status, statusLabel, title, triggerTime } = run;
-
-  return (
-    <div
-      data-role="scheduled-run"
-      className="flex justify-center animate-in fade-in slide-in-from-bottom-2 duration-300"
-    >
-      <Dialog>
-        <DialogTrigger asChild>
-          <button
-            type="button"
-            className="group flex w-full max-w-[640px] items-start gap-3 rounded-xl border border-border bg-background px-4 py-3 text-left shadow-[0_1px_2px_rgba(15,23,42,0.04)] transition-colors hover:bg-muted/30 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
-            aria-label={`Open scheduled run details for ${title}`}
-          >
-            <span
-              className={cn(
-                "flex h-9 w-9 shrink-0 items-center justify-center rounded-lg",
-                scheduledRunStatusClassName(status),
-              )}
-            >
-              <ScheduledRunStatusIcon status={status} />
-            </span>
-            <span className="min-w-0 flex-1">
-              <span className="block truncate text-sm font-medium text-foreground">
-                Triggered at {triggerTime}
-              </span>
-              <span className="mt-0.5 flex min-w-0 items-center gap-1.5 text-xs text-muted-foreground">
-                <IconClock size={13} stroke={1.8} className="shrink-0" />
-                <span className="min-w-0 truncate">{title}</span>
-              </span>
-              {previewText && (
-                <span className="mt-2 block whitespace-pre-line text-xs leading-5 text-muted-foreground line-clamp-3">
-                  {previewText}
-                </span>
-              )}
-            </span>
-            <span
-              className={cn(
-                "shrink-0 whitespace-nowrap rounded-full px-2.5 py-1 text-xs font-medium",
-                scheduledRunStatusClassName(status),
-              )}
-            >
-              {statusLabel}
-            </span>
-            <IconChevronRight
-              size={16}
-              stroke={1.8}
-              className="shrink-0 text-muted-foreground/60 transition-colors group-hover:text-foreground"
-            />
-          </button>
-        </DialogTrigger>
-        <DialogContent
-          className="max-w-3xl gap-0 overflow-hidden p-0"
-          aria-describedby={undefined}
-        >
-          <DialogHeader className="border-b border-border px-5 py-4">
-            <div className="flex min-w-0 items-start justify-between gap-3">
-              <div className="min-w-0">
-                <DialogTitle className="text-base">Scheduled run</DialogTitle>
-                <p className="mt-1 truncate text-sm text-muted-foreground">
-                  Triggered at {triggerTime} · {title}
-                </p>
-              </div>
-              <span
-                className={cn(
-                  "shrink-0 whitespace-nowrap rounded-full px-2.5 py-1 text-xs font-medium",
-                  scheduledRunStatusClassName(status),
-                )}
-              >
-                {statusLabel}
-              </span>
-            </div>
-          </DialogHeader>
-          <div className="max-h-[68vh] overflow-y-auto bg-muted/20 px-5 py-4">
-            <ScheduledRunTranscript run={run} thread={thread} />
-          </div>
-        </DialogContent>
-      </Dialog>
-    </div>
   );
 }
 

--- a/turbo/packages/connectors/src/feature-switch-key.ts
+++ b/turbo/packages/connectors/src/feature-switch-key.ts
@@ -48,7 +48,6 @@ export enum FeatureSwitchKey {
   SandboxIoLimiters = "sandboxIoLimiters",
   SessionWorkspaceImageCache = "sessionWorkspaceImageCache",
   ChatGithubPrTracking = "chatGithubPrTracking",
-  ChatScheduledRunCard = "chatScheduledRunCard",
   ChatTemplatePicker = "chatTemplatePicker",
   MemoryViewer = "memoryViewer",
   MemoryDevRefresh = "memoryDevRefresh",

--- a/turbo/packages/core/src/feature-switch.ts
+++ b/turbo/packages/core/src/feature-switch.ts
@@ -270,12 +270,6 @@ const FEATURE_SWITCHES: Record<FeatureSwitchKey, FeatureSwitch> = {
     enabled: false,
     enabledOrgIdHashes: STAFF_ORG_ID_HASHES,
   },
-  [FeatureSwitchKey.ChatScheduledRunCard]: {
-    maintainer: "ethan@vm0.ai",
-    description:
-      "Collapse schedule-triggered chat runs into a status card that opens the assistant transcript in a dialog.",
-    enabled: true,
-  },
   [FeatureSwitchKey.ChatTemplatePicker]: {
     maintainer: "linghan@vm0.ai",
     description:


### PR DESCRIPTION
Summary:
- Remove the scheduled run card rendering path from chat thread messages
- Remove the ChatScheduledRunCard feature switch from connectors/core
- Keep scheduled runs on the original inline schedule message display

Validation:
- pnpm exec prettier --check apps/platform/src/views/zero-page/zero-chat-thread-page.tsx apps/platform/src/views/zero-page/__tests__/zero-chat-thread-page-display.test.tsx packages/connectors/src/feature-switch-key.ts packages/core/src/feature-switch.ts
- pnpm -F @vm0/app check-types
- pnpm -F @vm0/connectors check-types
- pnpm -F @vm0/core check-types
- pnpm -F @vm0/app lint
- pnpm -F @vm0/connectors lint
- pnpm -F @vm0/core lint

Note:
- The targeted zero-chat-thread-page-display vitest run hung in happy-dom cleanup with AsyncTaskManager destroyed warnings and was terminated; relying on PR CI for that suite.