### PR TITLE
build(desktop): notarize local make artifacts

### DIFF
--- a/turbo/apps/desktop/README.md
+++ b/turbo/apps/desktop/README.md
@@ -53,6 +53,16 @@ Create a macOS artifact with:
 pnpm desktop:make
 ```
 
+This builds the production `Zero.app`, signs it with the local Developer ID
+Application identity, submits it to Apple's notary service, staples the
+notarization ticket, and writes the zip artifact under `apps/desktop/out/make`.
+Local notarized builds use the `notarytool` Keychain profile
+`vm0-desktop-notary` by default. Set `VM0_DESKTOP_NOTARIZE_KEYCHAIN_PROFILE` to
+override the profile and `VM0_DESKTOP_NOTARIZE_KEYCHAIN` to override the
+Keychain path, or set `VM0_DESKTOP_NOTARIZE_API_KEY_PATH`,
+`VM0_DESKTOP_NOTARIZE_API_KEY_ID`, and `VM0_DESKTOP_NOTARIZE_API_ISSUER` to use
+an API key file directly.
+
 The helper source lives under `apps/desktop/native/computer-use-helper`. Build
 output is copied to `apps/desktop/native/dist/native/computer-use-helper`, which
 is also the path included in packaged macOS artifacts.

--- a/turbo/apps/desktop/forge.config.js
+++ b/turbo/apps/desktop/forge.config.js
@@ -1,9 +1,17 @@
+const os = require("node:os");
 const path = require("node:path");
 
 const packageMetadata = require("./package.json");
 const desktopIdentities = require("./src/desktop-identities.json");
 
 const PRODUCTION_PLATFORM_HOSTNAME = "app.vm0.ai";
+const DEFAULT_NOTARIZE_KEYCHAIN_PROFILE = "vm0-desktop-notary";
+const DEFAULT_NOTARIZE_KEYCHAIN = path.join(
+  os.homedir(),
+  "Library",
+  "Keychains",
+  "login.keychain-db",
+);
 const DEVELOPER_ID_APPLICATION_IDENTITY =
   "Developer ID Application: Max & Zoe, Inc. (C5UWSXYB67)";
 const codeSigningIdentity =
@@ -21,6 +29,22 @@ function requiredEnv(name) {
 function desktopNotarizeOptions() {
   if (process.env.VM0_DESKTOP_NOTARIZE !== "true") {
     return undefined;
+  }
+
+  if (process.env.VM0_DESKTOP_NOTARIZE_KEYCHAIN_PROFILE?.trim()) {
+    return {
+      keychainProfile: process.env.VM0_DESKTOP_NOTARIZE_KEYCHAIN_PROFILE,
+      keychain:
+        process.env.VM0_DESKTOP_NOTARIZE_KEYCHAIN?.trim() ||
+        DEFAULT_NOTARIZE_KEYCHAIN,
+    };
+  }
+
+  if (!process.env.VM0_DESKTOP_NOTARIZE_API_KEY_PATH) {
+    return {
+      keychainProfile: DEFAULT_NOTARIZE_KEYCHAIN_PROFILE,
+      keychain: DEFAULT_NOTARIZE_KEYCHAIN,
+    };
   }
 
   return {

--- a/turbo/apps/desktop/package.json
+++ b/turbo/apps/desktop/package.json
@@ -19,7 +19,7 @@
     "dev": "pnpm build && electron-forge start",
     "dev:packaged": "pnpm package && node scripts/run-packaged-app.js",
     "lint": "oxlint src --deny-warnings",
-    "make": "pnpm build && electron-forge make --platform darwin",
+    "make": "pnpm build && VM0_DESKTOP_NOTARIZE=true electron-forge make --platform darwin",
     "package": "pnpm build && electron-forge package --platform darwin",
     "start": "electron-forge start",
     "test": "vitest run",


### PR DESCRIPTION
## Summary
- make `pnpm desktop:make` submit and staple notarization by default
- use the local `vm0-desktop-notary` notarytool Keychain profile when notarization API key env vars are not provided
- document the local notarized make credential options

## Verification
- `pnpm exec prettier --check apps/desktop/package.json apps/desktop/forge.config.js apps/desktop/README.md`
- `pnpm -F @vm0/desktop lint`
- `pnpm -F @vm0/desktop check-types`
- `pnpm -F @vm0/desktop test`
- `env -u VM0_DESKTOP_NOTARIZE_KEYCHAIN_PROFILE -u VM0_DESKTOP_NOTARIZE_KEYCHAIN -u VM0_DESKTOP_NOTARIZE_API_KEY_PATH -u VM0_DESKTOP_NOTARIZE_API_KEY_ID -u VM0_DESKTOP_NOTARIZE_API_ISSUER pnpm desktop:make`
- `codesign --verify --deep --strict --verbose=2 apps/desktop/out/Zero-darwin-arm64/Zero.app`
- `xcrun stapler validate apps/desktop/out/Zero-darwin-arm64/Zero.app`
- `spctl --assess --type execute --verbose=4 apps/desktop/out/Zero-darwin-arm64/Zero.app`