### PR TITLE
fix: keep credit balance dialog open when expanding Credit additions

### DIFF
--- a/turbo/apps/platform/src/views/zero-page/__tests__/org-usage-tab.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/org-usage-tab.test.tsx
@@ -183,13 +183,20 @@ describe("org usage tab - credit balance display", () => {
 
     await waitFor(() => {
       expect(screen.getByText("Credit additions")).toBeInTheDocument();
-      expect(screen.getByTestId("credit-grants-section")).not.toHaveAttribute(
-        "open",
+      expect(screen.getByTestId("credit-grants-toggle")).toHaveAttribute(
+        "aria-expanded",
+        "false",
       );
     });
+    expect(
+      screen.queryByTestId("credit-grant-grant-pro"),
+    ).not.toBeInTheDocument();
 
     await user.click(screen.getByTestId("credit-grants-toggle"));
-    expect(screen.getByTestId("credit-grants-section")).toHaveAttribute("open");
+    expect(screen.getByTestId("credit-grants-toggle")).toHaveAttribute(
+      "aria-expanded",
+      "true",
+    );
 
     await waitFor(() => {
       expect(screen.getByTestId("credit-grant-grant-pro")).toHaveTextContent(
@@ -204,9 +211,13 @@ describe("org usage tab - credit balance display", () => {
     await expectPopoverTokenTooltip("Expires Apr 20, 2026");
 
     await user.click(screen.getByTestId("credit-grants-toggle"));
-    expect(screen.getByTestId("credit-grants-section")).not.toHaveAttribute(
-      "open",
+    expect(screen.getByTestId("credit-grants-toggle")).toHaveAttribute(
+      "aria-expanded",
+      "false",
     );
+    expect(
+      screen.queryByTestId("credit-grant-grant-pro"),
+    ).not.toBeInTheDocument();
   });
 
   it("should use popover theme tokens for credit balance segment tooltips", async () => {

--- a/turbo/apps/platform/src/views/zero-page/components/org-manage/org-usage-tab.tsx
+++ b/turbo/apps/platform/src/views/zero-page/components/org-manage/org-usage-tab.tsx
@@ -1,3 +1,4 @@
+import { useState } from "react";
 import { useLoadable, useSet } from "ccstate-react";
 import type { OrgMember } from "@vm0/api-contracts/contracts/org-members";
 import type { BillingStatusResponse } from "@vm0/api-contracts/contracts/zero-billing";
@@ -151,37 +152,52 @@ function CreditGrantRow({ grant }: { grant: CreditGrant }) {
 }
 
 function CreditGrantList({ grants }: { grants: CreditGrant[] }) {
+  const [open, setOpen] = useState(false);
+
   if (grants.length === 0) {
     return null;
   }
 
   return (
-    <details
+    <div
       data-testid="credit-grants-section"
-      className="group mt-4 border-t border-border/50 pt-3"
+      data-open={open ? "" : undefined}
+      className="mt-4 border-t border-border/50 pt-3"
     >
-      <summary
+      <button
+        type="button"
         data-testid="credit-grants-toggle"
-        className="mb-1 cursor-pointer list-none px-2"
+        aria-expanded={open}
+        onClick={(event) => {
+          // A native <details>/<summary> toggle here was being interpreted by
+          // the surrounding settings dialog as an outside interaction, which
+          // dismissed the whole dialog. A controlled disclosure expands inline
+          // and the stopped click never reaches the dialog's dismiss handling.
+          event.stopPropagation();
+          setOpen((prev) => {
+            return !prev;
+          });
+        }}
+        className="mb-1 flex w-full cursor-pointer items-center gap-1.5 px-2 text-xs font-medium text-muted-foreground"
       >
-        <div className="flex items-center gap-1.5 text-xs font-medium text-muted-foreground">
-          <IconChevronRight
-            size={13}
-            stroke={2}
-            className="shrink-0 transition-transform group-open:rotate-90"
-          />
-          <span>Credit additions</span>
-          <span className="tabular-nums">({grants.length})</span>
-        </div>
-      </summary>
-      <TooltipProvider delayDuration={100}>
-        <div className="flex flex-col">
-          {grants.map((grant) => {
-            return <CreditGrantRow key={grant.id} grant={grant} />;
-          })}
-        </div>
-      </TooltipProvider>
-    </details>
+        <IconChevronRight
+          size={13}
+          stroke={2}
+          className={`shrink-0 transition-transform ${open ? "rotate-90" : ""}`}
+        />
+        <span>Credit additions</span>
+        <span className="tabular-nums">({grants.length})</span>
+      </button>
+      {open ? (
+        <TooltipProvider delayDuration={100}>
+          <div className="flex flex-col">
+            {grants.map((grant) => {
+              return <CreditGrantRow key={grant.id} grant={grant} />;
+            })}
+          </div>
+        </TooltipProvider>
+      ) : null}
+    </div>
   );
 }
 


### PR DESCRIPTION
## Problem

In the **Credit balance** settings section, clicking **Credit additions** to expand the credit-grant list dismissed the entire settings dialog ("the popup just disappears") instead of expanding inline.

Root cause: the disclosure was a native `<details>`/`<summary>`. Inside the Radix settings dialog, the native summary toggle was being treated as an outside interaction and tore the dialog down, so the grant list could never be opened.

## Fix

Replace the native `<details>`/`<summary>` with a controlled React disclosure (`useState` + a `<button>`):

- Expands/collapses the grant list inline, exactly as before visually (same chevron rotation, same labels/counts).
- `event.stopPropagation()` on the toggle keeps the click fully contained so it never reaches the dialog's dismiss handling.
- The dialog stays open while you browse Credit additions.

No behavior change for the rest of the Credit balance section.

## Tests

Updated `org-usage-tab.test.tsx` to assert the controlled semantics — `aria-expanded` on the toggle and grant rows mounting/unmounting — instead of the native `<details open>` attribute.

## Verification

Best verified on the per-PR app preview: open Settings → Credit balance, click **Credit additions**, confirm the list expands and the dialog stays open.

🤖 Generated with [Claude Code](https://claude.com/claude-code)