### PR TITLE
ci: cut per-job fixed overhead (postgres health-check) and test-web over-sharding

### DIFF
--- a/.github/workflows/turbo.yml
+++ b/.github/workflows/turbo.yml
@@ -418,7 +418,7 @@ jobs:
     if: needs.detect-turbo-ts-checks.outputs.turbo-ts-checks-needed == 'true'
     strategy:
       matrix:
-        shard: [1, 2, 3, 4, 5, 6, 7, 8]
+        shard: [1, 2]
     container:
       image: ghcr.io/vm0-ai/vm0-toolchain:20260525
     services:
@@ -426,9 +426,10 @@ jobs:
         image: postgres:17-alpine
         options: >-
           --health-cmd pg_isready
-          --health-interval 10s
+          --health-interval 2s
           --health-timeout 5s
           --health-retries 5
+          --health-start-period 3s
         env:
           POSTGRES_HOST_AUTH_METHOD: trust
     steps:
@@ -443,7 +444,7 @@ jobs:
         working-directory: turbo
         env:
           DATABASE_URL: postgresql://postgres@postgres:5432/postgres
-        run: pnpm vitest run --project=web --shard=${{ matrix.shard }}/8 --coverage.enabled --coverage.reporter=json
+        run: pnpm vitest run --project=web --shard=${{ matrix.shard }}/2 --coverage.enabled --coverage.reporter=json
       - name: Upload coverage to Codecov
         if: success() || failure()
         uses: codecov/codecov-action@v6
@@ -477,9 +478,10 @@ jobs:
         image: postgres:17-alpine
         options: >-
           --health-cmd pg_isready
-          --health-interval 10s
+          --health-interval 2s
           --health-timeout 5s
           --health-retries 5
+          --health-start-period 3s
         env:
           POSTGRES_HOST_AUTH_METHOD: trust
     steps:
@@ -521,9 +523,10 @@ jobs:
         image: postgres:17-alpine
         options: >-
           --health-cmd pg_isready
-          --health-interval 10s
+          --health-interval 2s
           --health-timeout 5s
           --health-retries 5
+          --health-start-period 3s
         env:
           POSTGRES_HOST_AUTH_METHOD: trust
     steps:
@@ -672,9 +675,10 @@ jobs:
         image: postgres:17-alpine
         options: >-
           --health-cmd pg_isready
-          --health-interval 10s
+          --health-interval 2s
           --health-timeout 5s
           --health-retries 5
+          --health-start-period 3s
         env:
           POSTGRES_HOST_AUTH_METHOD: trust
     steps:

--- a/.github/workflows/turbo.yml
+++ b/.github/workflows/turbo.yml
@@ -416,9 +416,6 @@ jobs:
     needs: detect-turbo-ts-checks
     runs-on: ubuntu-latest
     if: needs.detect-turbo-ts-checks.outputs.turbo-ts-checks-needed == 'true'
-    strategy:
-      matrix:
-        shard: [1, 2]
     container:
       image: ghcr.io/vm0-ai/vm0-toolchain:20260525
     services:
@@ -444,7 +441,7 @@ jobs:
         working-directory: turbo
         env:
           DATABASE_URL: postgresql://postgres@postgres:5432/postgres
-        run: pnpm vitest run --project=web --shard=${{ matrix.shard }}/2 --coverage.enabled --coverage.reporter=json
+        run: pnpm vitest run --project=web --coverage.enabled --coverage.reporter=json
       - name: Upload coverage to Codecov
         if: success() || failure()
         uses: codecov/codecov-action@v6


### PR DESCRIPTION
## What

Two cheap, safe cuts to **per-job fixed overhead** and **over-sharding** in the Turbo CI workflow.

Context: a drill-down on the slowest runs showed the "瓶颈 test-web(N) ~11min" label is misleading — a web shard runs only **~7s** of actual vitest; the ~11min is almost entirely **queue wait**. Total execution is ~70–104 min spread across 40–63 jobs, but effective parallelism caps at **~6–8×** (the runner pool), so wall time is gated by queue depth. The lever is therefore *fewer jobs / less fixed overhead per job*, not faster individual tests.

## Changes

**1. Postgres service readiness (4 blocks: test-web, bench-api, test-migrate, test-api)**
- `--health-interval 10s` → `2s`, plus `--health-start-period 3s`.
- `postgres:17-alpine` is ready in ~1s, but the 10s interval forced the first health probe to wait the full 10s. Measured: jobs *with* postgres spend ~26–29s in `Initialize containers` vs ~9–11s for jobs without it — so ~15s/job was pure health-check latency.

**2. test-web: remove sharding entirely (8 shards → 1 job)**
- Each old web shard ran ~7s of tests but paid ~70s of fixed overhead (image pull + `pnpm install` + coverage upload). The full web suite finishes well under a minute unsharded, so sharding bought **no** wall-time win while tying up 7 extra runner slots and worsening queue depth.
- The matrix is gone; the job is now plain `test-web` (no `(N)` suffix).
- `test-app` and `test-api` (~130s of real work per shard) are genuinely CPU-bound and left at 8.

## Deliberately *not* done: pnpm store cache
`pnpm install` is ~21s/job. Community baselines put a cold pnpm install at ~1m20s and a warm-cached one at ~40s+10s compression — but vm0's frozen install is already **21s**, faster than the community *cold* number. `actions/cache` for a pnpm store is also unreliable in monorepos (partial restore, silent misses, cache bloat) for marginal gain. Net value is negative, so left as a plain fresh install.

## Safety
- `ci-gate-turbo` depends on `test-web` (the job, not individual shards); dropping the matrix just renames the job from `test-web (N)` to `test-web`, and the gate still waits on it.
- ⚠️ If branch protection separately lists `test-web (1..8)` as required status checks, they must be dropped from the ruleset (and `test-web` added) — otherwise the merge queue will wait on now-nonexistent checks. Please confirm only `ci-gate-turbo` is required.

## Expected effect
Health-check latency removed from every postgres job + 7 freed runner slots from test-web → lower total execution and shallower queue → wall time comes down. No change to test coverage or what runs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)