### PR TITLE
fix(desktop): bundle updater dependency

### DIFF
--- a/turbo/apps/desktop/forge.config.js
+++ b/turbo/apps/desktop/forge.config.js
@@ -136,6 +136,7 @@ module.exports = {
       /^\/README\.md$/,
       /^\/forge\.config\.js$/,
       /^\/tsconfig\.json$/,
+      /^\/tsup\.electron\.config\.js$/,
       /^\/vite\.renderer\.config\.ts$/,
       /^\/vitest\.config\.ts$/,
     ],

--- a/turbo/apps/desktop/package.json
+++ b/turbo/apps/desktop/package.json
@@ -11,7 +11,7 @@
   "scripts": {
     "build": "pnpm build:native && pnpm build:electron && pnpm build:cli && pnpm build:renderer",
     "build:cli": "tsup src/vm0-computer.ts --format cjs --platform node --target node20 --out-dir dist --sourcemap --external electron && chmod +x dist/vm0-computer.js",
-    "build:electron": "tsup src/main.ts src/preload.ts --format cjs --platform node --target node20 --out-dir dist --sourcemap --clean --external electron",
+    "build:electron": "tsup --config tsup.electron.config.js",
     "build:native": "node scripts/build-native-helper.js",
     "build:renderer": "vite build --config vite.renderer.config.ts",
     "check-types": "tsc --noEmit",

--- a/turbo/apps/desktop/tsup.electron.config.js
+++ b/turbo/apps/desktop/tsup.electron.config.js
@@ -1,0 +1,13 @@
+const { defineConfig } = require("tsup");
+
+module.exports = defineConfig({
+  entry: ["src/main.ts", "src/preload.ts"],
+  format: ["cjs"],
+  platform: "node",
+  target: "node20",
+  outDir: "dist",
+  sourcemap: true,
+  clean: true,
+  external: ["electron"],
+  noExternal: ["update-electron-app"],
+});


### PR DESCRIPTION
## Summary
- add a dedicated Electron main-process tsup config
- bundle update-electron-app into dist/main.js while keeping electron external
- exclude the tsup config from packaged app contents

## Verification
- pnpm -F @vm0/desktop check-types
- pnpm -F @vm0/desktop lint
- pnpm knip --workspace @vm0/desktop
- pnpm -F @vm0/desktop test
- pnpm -F @vm0/desktop build
- VM0_DESKTOP_SIGNING_IDENTITY=- pnpm -F @vm0/desktop exec electron-forge package --platform darwin --arch arm64
- codesign --verify --deep --strict --verbose=2 apps/desktop/out/Zero-darwin-arm64/Zero.app
- verified packaged app has no node_modules and no runtime require("update-electron-app")