### PR TITLE
chore: preserve outlook mail connector icon color

### DIFF
--- a/turbo/apps/platform/src/views/zero-page/components/settings/connector-icons.tsx
+++ b/turbo/apps/platform/src/views/zero-page/components/settings/connector-icons.tsx
@@ -187,6 +187,7 @@ const CONNECTOR_ICON_COLORFUL = {
   nyne: true,
   openweather: true,
   "outlook-calendar": true,
+  "outlook-mail": true,
   pandadoc: true,
   pdf4me: true,
   pdfco: true,


### PR DESCRIPTION
## Summary
- add `outlook-mail` to `CONNECTOR_ICON_COLORFUL`
- preserve the existing Outlook Mail SVG's explicit blue brand fills in dark theme instead of applying `zero-icon-mono`

## Source
- https://www.microsoft.com/en-us/microsoft-365/outlook/email-and-calendar-software-microsoft-outlook

## Verification
- structural SVG check: confirms SVG-only, explicit Outlook blue fills, no raster/base64 references, no `currentColor`, and the colorful override entry
- `pnpm exec prettier --check apps/platform/src/views/zero-page/components/settings/connector-icons.tsx`
- `git diff --check`
- `pnpm -F @vm0/app exec vitest src/views/zero-page/__tests__/connector-icons.test.tsx`

## Notes
- Local pre-commit is currently blocked by an unrelated existing `knip --cache` baseline reporting unused dependencies/exports outside this PR. This change is scoped to the connector icon colorful override.

Closes #16717
