### PR TITLE
fix: harden runner setup artifact installs

### DIFF
--- a/crates/runner/src/cmd/setup.rs
+++ b/crates/runner/src/cmd/setup.rs
@@ -4,10 +4,15 @@
 //! layout, and installs the pinned Firecracker, kernel, and mitmdump artifacts
 //! used by sandbox startup.
 
-use std::io::Read;
-use std::os::unix::fs::PermissionsExt;
-use std::path::Path;
+use std::ffi::{OsStr, OsString};
+use std::fs::File;
+use std::io::{Read, Seek, SeekFrom};
+use std::os::fd::{AsFd, AsRawFd, OwnedFd};
+use std::os::unix::fs::OpenOptionsExt;
+use std::path::{Component, Path, PathBuf};
 
+use nix::fcntl::{OFlag, open, openat};
+use nix::sys::stat::{Mode, SFlag, fstat, mkdirat};
 use sha2::{Digest, Sha256};
 use tokio::io::AsyncWriteExt;
 
@@ -19,6 +24,15 @@ use crate::deps::{
 };
 use crate::error::{RunnerError, RunnerResult};
 use crate::paths::HomePaths;
+
+const SETUP_SHARED_DIR_MODE: u32 = 0o755;
+const SETUP_TEMP_ARTIFACT_MODE: u32 = 0o600;
+const SETUP_EXECUTABLE_ARTIFACT_MODE: u32 = 0o755;
+const SETUP_KERNEL_ARTIFACT_MODE: u32 = 0o644;
+const SETUP_TEMP_CREATE_ATTEMPTS: usize = 16;
+const GROUP_OR_OTHER_WRITE_BITS: u32 = 0o022;
+const ROOT_UID: u32 = 0;
+const STICKY_BIT: u32 = 0o1000;
 
 /// Run the host setup workflow for sandbox execution.
 ///
@@ -115,24 +129,546 @@ async fn create_directories(paths: &HomePaths) -> RunnerResult<()> {
         paths.runners_dir(),
     ];
     for dir in &dirs {
-        tokio::fs::create_dir_all(dir)
-            .await
-            .map_err(|e| RunnerError::Internal(format!("create {}: {e}", dir.display())))?;
+        ensure_setup_shared_dir(dir)?;
     }
     tracing::info!("[OK] directory structure created");
     Ok(())
+}
+
+fn ensure_setup_shared_dir(path: &Path) -> RunnerResult<()> {
+    if path.as_os_str().is_empty() {
+        return Err(RunnerError::Internal(
+            "empty setup directory path is not supported".into(),
+        ));
+    }
+
+    let expected_uid = nix::unistd::geteuid().as_raw();
+    let start = if path.is_absolute() {
+        Path::new("/")
+    } else {
+        Path::new(".")
+    };
+    let mut current = open(start, setup_dir_open_flags(), Mode::empty()).map_err(|e| {
+        RunnerError::Internal(format!(
+            "open setup directory root for {}: {e}",
+            path.display()
+        ))
+    })?;
+    let mut current_path = start.to_path_buf();
+    let mut components = path.components().peekable();
+    let mut saw_normal_component = false;
+
+    while let Some(component) = components.next() {
+        match component {
+            Component::RootDir | Component::CurDir => {}
+            Component::ParentDir => {
+                return Err(RunnerError::Internal(format!(
+                    "{} contains a parent directory segment",
+                    path.display()
+                )));
+            }
+            Component::Normal(name) => {
+                saw_normal_component = true;
+                let is_final = components.peek().is_none();
+                current = open_or_create_setup_dir_component(
+                    &current,
+                    name,
+                    &current_path,
+                    path,
+                    expected_uid,
+                    is_final,
+                )?;
+                current_path = path_component(&current_path, name);
+            }
+            Component::Prefix(prefix) => {
+                return Err(RunnerError::Internal(format!(
+                    "{} contains unsupported path prefix {}",
+                    path.display(),
+                    prefix.as_os_str().to_string_lossy()
+                )));
+            }
+        }
+    }
+
+    if !saw_normal_component {
+        secure_setup_dir_component(&current, &current_path, path, expected_uid, true, false)?;
+    }
+
+    Ok(())
+}
+
+fn open_or_create_setup_dir_component(
+    parent: &(impl AsFd + AsRawFd),
+    name: &OsStr,
+    parent_path: &Path,
+    full_path: &Path,
+    expected_uid: u32,
+    is_final: bool,
+) -> RunnerResult<OwnedFd> {
+    ensure_setup_parent_not_replaceable(parent, parent_path, full_path, expected_uid)?;
+    let component_path = path_component(parent_path, name);
+
+    match openat(parent, name, setup_dir_open_flags(), Mode::empty()) {
+        Ok(fd) => {
+            secure_setup_dir_component(
+                &fd,
+                &component_path,
+                full_path,
+                expected_uid,
+                is_final,
+                false,
+            )?;
+            Ok(fd)
+        }
+        Err(nix::errno::Errno::ENOENT) => {
+            match mkdirat(
+                parent,
+                name,
+                Mode::from_bits_truncate(SETUP_SHARED_DIR_MODE),
+            ) {
+                Ok(()) | Err(nix::errno::Errno::EEXIST) => {}
+                Err(e) => {
+                    return Err(RunnerError::Internal(format!(
+                        "create setup directory component {} for {}: {e}",
+                        name.to_string_lossy(),
+                        full_path.display()
+                    )));
+                }
+            }
+
+            let fd = openat(parent, name, setup_dir_open_flags(), Mode::empty())
+                .map_err(|e| setup_dir_component_error("open", name, full_path, e))?;
+            secure_setup_dir_component(
+                &fd,
+                &component_path,
+                full_path,
+                expected_uid,
+                is_final,
+                true,
+            )?;
+            Ok(fd)
+        }
+        Err(e) => Err(setup_dir_component_error("open", name, full_path, e)),
+    }
+}
+
+fn ensure_setup_parent_not_replaceable(
+    parent: &(impl AsFd + AsRawFd),
+    parent_path: &Path,
+    full_path: &Path,
+    expected_uid: u32,
+) -> RunnerResult<()> {
+    let stat = fstat(parent).map_err(|e| {
+        RunnerError::Internal(format!(
+            "stat setup directory parent {} for {}: {e}",
+            parent_path.display(),
+            full_path.display()
+        ))
+    })?;
+    let mode = (stat.st_mode as u32) & 0o7777;
+    if stat.st_uid != ROOT_UID && stat.st_uid != expected_uid {
+        return Err(RunnerError::Internal(format!(
+            "setup directory parent {} is owned by untrusted uid {}",
+            parent_path.display(),
+            stat.st_uid
+        )));
+    }
+    if mode & GROUP_OR_OTHER_WRITE_BITS != 0 && mode & STICKY_BIT == 0 {
+        return Err(RunnerError::Internal(format!(
+            "setup directory parent {} is group/other writable without the sticky bit",
+            parent_path.display()
+        )));
+    }
+    Ok(())
+}
+
+fn secure_setup_dir_component(
+    fd: &(impl AsFd + AsRawFd),
+    component_path: &Path,
+    full_path: &Path,
+    expected_uid: u32,
+    is_final: bool,
+    created: bool,
+) -> RunnerResult<()> {
+    let stat = fstat(fd).map_err(|e| {
+        RunnerError::Internal(format!(
+            "stat setup directory component {} for {}: {e}",
+            component_path.display(),
+            full_path.display()
+        ))
+    })?;
+    let file_type = SFlag::from_bits_truncate(stat.st_mode & SFlag::S_IFMT.bits());
+    if file_type != SFlag::S_IFDIR {
+        return Err(RunnerError::Internal(format!(
+            "{} is not a directory",
+            component_path.display()
+        )));
+    }
+    if stat.st_uid != ROOT_UID && stat.st_uid != expected_uid {
+        return Err(RunnerError::Internal(format!(
+            "setup directory component {} is owned by untrusted uid {}",
+            component_path.display(),
+            stat.st_uid
+        )));
+    }
+
+    let mode = (stat.st_mode as u32) & 0o7777;
+    if mode & GROUP_OR_OTHER_WRITE_BITS != 0 && (is_final || mode & STICKY_BIT == 0) {
+        return Err(RunnerError::Internal(format!(
+            "setup directory component {} is group/other writable",
+            component_path.display()
+        )));
+    }
+
+    if (created || is_final) && stat.st_uid == expected_uid && mode != SETUP_SHARED_DIR_MODE {
+        chmod_fd(fd, component_path, SETUP_SHARED_DIR_MODE, "setup directory")?;
+    }
+
+    Ok(())
+}
+
+fn setup_dir_component_error(
+    operation: &str,
+    name: &OsStr,
+    full_path: &Path,
+    error: nix::errno::Errno,
+) -> RunnerError {
+    match error {
+        nix::errno::Errno::ELOOP => RunnerError::Internal(format!(
+            "{} contains symlink component {}",
+            full_path.display(),
+            name.to_string_lossy()
+        )),
+        nix::errno::Errno::ENOTDIR => {
+            RunnerError::Internal(format!("{} is not a directory", full_path.display()))
+        }
+        _ => RunnerError::Internal(format!(
+            "{operation} setup directory component {} for {}: {error}",
+            name.to_string_lossy(),
+            full_path.display()
+        )),
+    }
+}
+
+fn path_component(parent_path: &Path, name: &OsStr) -> PathBuf {
+    let mut path = parent_path.to_path_buf();
+    path.push(Path::new(name));
+    path
+}
+
+fn setup_dir_open_flags() -> OFlag {
+    OFlag::O_RDONLY | OFlag::O_DIRECTORY | OFlag::O_NOFOLLOW | OFlag::O_CLOEXEC
+}
+
+fn create_setup_temp_file(target: &Path, kind: &str) -> RunnerResult<(PathBuf, File)> {
+    let parent = file_parent(target);
+    ensure_setup_shared_dir(parent)?;
+    let file_name = target.file_name().ok_or_else(|| {
+        RunnerError::Internal(format!(
+            "{} does not have a file name; refusing to create setup temp artifact",
+            target.display()
+        ))
+    })?;
+
+    for _ in 0..SETUP_TEMP_CREATE_ATTEMPTS {
+        let mut tmp_name = OsString::from(".");
+        tmp_name.push(file_name);
+        tmp_name.push(".");
+        tmp_name.push(kind);
+        tmp_name.push(".");
+        tmp_name.push(uuid::Uuid::new_v4().to_string());
+        tmp_name.push(".tmp");
+        let tmp_path = target.with_file_name(tmp_name);
+
+        match open_setup_temp_file_at(&tmp_path) {
+            Ok(file) => {
+                secure_setup_temp_file(&file, &tmp_path)?;
+                return Ok((tmp_path, file));
+            }
+            Err(error) if error.kind() == std::io::ErrorKind::AlreadyExists => continue,
+            Err(error) => {
+                return Err(RunnerError::Internal(format!(
+                    "create setup temp artifact {}: {error}",
+                    tmp_path.display()
+                )));
+            }
+        }
+    }
+
+    Err(RunnerError::Internal(format!(
+        "create setup temp artifact for {}: exhausted {SETUP_TEMP_CREATE_ATTEMPTS} attempts",
+        target.display()
+    )))
+}
+
+#[cfg(test)]
+fn create_setup_temp_file_at(path: &Path) -> RunnerResult<File> {
+    ensure_setup_shared_dir(file_parent(path))?;
+    let file = open_setup_temp_file_at(path).map_err(|e| {
+        RunnerError::Internal(format!(
+            "create setup temp artifact {}: {e}",
+            path.display()
+        ))
+    })?;
+    secure_setup_temp_file(&file, path)?;
+    Ok(file)
+}
+
+fn open_setup_temp_file_at(path: &Path) -> std::io::Result<File> {
+    let mut options = File::options();
+    options
+        .read(true)
+        .write(true)
+        .create_new(true)
+        .mode(SETUP_TEMP_ARTIFACT_MODE)
+        .custom_flags(setup_file_open_flags());
+    options.open(path)
+}
+
+fn secure_setup_temp_file(file: &File, path: &Path) -> RunnerResult<()> {
+    let stat = setup_file_stat(file, path, "setup temp artifact")?;
+    let file_type = stat.st_mode & libc::S_IFMT;
+    if file_type != libc::S_IFREG {
+        return Err(RunnerError::Internal(format!(
+            "{} is not a regular setup temp artifact",
+            path.display()
+        )));
+    }
+
+    let expected_uid = nix::unistd::geteuid().as_raw();
+    if stat.st_uid != expected_uid {
+        return Err(RunnerError::Internal(format!(
+            "{} is owned by uid {}, but runner euid is {expected_uid}",
+            path.display(),
+            stat.st_uid
+        )));
+    }
+
+    let mode = stat.st_mode & 0o7777;
+    if mode != SETUP_TEMP_ARTIFACT_MODE {
+        chmod_fd(file, path, SETUP_TEMP_ARTIFACT_MODE, "setup temp artifact")?;
+    }
+    Ok(())
+}
+
+fn install_temp_artifact(
+    tmp_path: &Path,
+    target: &Path,
+    expected_sha: &str,
+    mode: u32,
+) -> RunnerResult<()> {
+    let mut options = File::options();
+    options
+        .read(true)
+        .write(true)
+        .custom_flags(setup_file_open_flags());
+    let mut file = options.open(tmp_path).map_err(|e| {
+        RunnerError::Internal(format!(
+            "open setup temp artifact {}: {e}",
+            tmp_path.display()
+        ))
+    })?;
+    let stat = setup_file_stat(&file, tmp_path, "setup temp artifact")?;
+    validate_trusted_regular_setup_file(&stat, tmp_path, "setup temp artifact")?;
+    if (stat.st_mode & GROUP_OR_OTHER_WRITE_BITS) != 0 {
+        return Err(RunnerError::Internal(format!(
+            "{} is group/other writable",
+            tmp_path.display()
+        )));
+    }
+
+    let sha = file_sha256_open(&mut file, tmp_path)?;
+    if sha != expected_sha {
+        return Err(RunnerError::Internal(format!(
+            "setup temp artifact SHA256 mismatch for {}: expected {expected_sha}, got {sha}",
+            tmp_path.display()
+        )));
+    }
+
+    chmod_fd(&file, tmp_path, mode, "setup temp artifact")?;
+    drop(file);
+
+    std::fs::rename(tmp_path, target)
+        .map_err(|e| RunnerError::Internal(format!("rename to {}: {e}", target.display())))?;
+
+    if ensure_artifact_installed_blocking(target, expected_sha, mode)? {
+        Ok(())
+    } else {
+        Err(RunnerError::Internal(format!(
+            "installed setup artifact {} failed validation",
+            target.display()
+        )))
+    }
+}
+
+fn ensure_artifact_installed_blocking(
+    path: &Path,
+    expected_sha: &str,
+    mode: u32,
+) -> RunnerResult<bool> {
+    let Some(mut file) = open_existing_setup_artifact(path)? else {
+        return Ok(false);
+    };
+
+    let stat = setup_file_stat(&file, path, "setup artifact")?;
+    if (stat.st_mode & libc::S_IFMT) != libc::S_IFREG {
+        return Ok(false);
+    }
+    validate_trusted_setup_owner(&stat, path, "setup artifact")?;
+
+    let current_mode = stat.st_mode & 0o7777;
+    if current_mode & GROUP_OR_OTHER_WRITE_BITS != 0 {
+        return Ok(false);
+    }
+
+    if file_sha256_open(&mut file, path)? != expected_sha {
+        return Ok(false);
+    }
+
+    if current_mode != mode {
+        chmod_fd(&file, path, mode, "setup artifact")?;
+        let repaired = setup_file_stat(&file, path, "setup artifact")?;
+        if (repaired.st_mode & 0o7777) != mode {
+            return Ok(false);
+        }
+        if file_sha256_open(&mut file, path)? != expected_sha {
+            return Ok(false);
+        }
+    }
+
+    Ok(true)
+}
+
+fn open_existing_setup_artifact(path: &Path) -> RunnerResult<Option<File>> {
+    if !setup_artifact_path_is_regular(path)? {
+        return Ok(None);
+    }
+
+    let mut options = File::options();
+    options.read(true).custom_flags(setup_file_open_flags());
+    match options.open(path) {
+        Ok(file) => Ok(Some(file)),
+        Err(e) if e.kind() == std::io::ErrorKind::NotFound => Ok(None),
+        Err(e) if e.raw_os_error() == Some(libc::ELOOP) => Ok(None),
+        Err(e) => {
+            if !setup_artifact_path_is_regular(path)? {
+                return Ok(None);
+            }
+            Err(RunnerError::Internal(format!(
+                "open setup artifact {}: {e}",
+                path.display()
+            )))
+        }
+    }
+}
+
+fn setup_artifact_path_is_regular(path: &Path) -> RunnerResult<bool> {
+    match std::fs::symlink_metadata(path) {
+        Ok(metadata) => Ok(metadata.file_type().is_file()),
+        Err(e) if e.kind() == std::io::ErrorKind::NotFound => Ok(false),
+        Err(e) => Err(RunnerError::Internal(format!(
+            "stat setup artifact {}: {e}",
+            path.display()
+        ))),
+    }
+}
+
+fn file_sha256_open(file: &mut File, path: &Path) -> RunnerResult<String> {
+    file.seek(SeekFrom::Start(0))
+        .map_err(|e| RunnerError::Internal(format!("seek {}: {e}", path.display())))?;
+    let mut hasher = Sha256::new();
+    let mut buf = [0u8; 64 * 1024];
+    loop {
+        let n = file
+            .read(&mut buf)
+            .map_err(|e| RunnerError::Internal(format!("read {}: {e}", path.display())))?;
+        if n == 0 {
+            break;
+        }
+        let chunk = buf
+            .get(..n)
+            .ok_or_else(|| RunnerError::Internal("read returned invalid length".into()))?;
+        hasher.update(chunk);
+    }
+    Ok(hex::encode(hasher.finalize()))
+}
+
+fn setup_file_stat<Fd: AsRawFd>(file: &Fd, path: &Path, context: &str) -> RunnerResult<libc::stat> {
+    let mut stat = std::mem::MaybeUninit::<libc::stat>::uninit();
+    // SAFETY: `stat` points to writable memory and `file` owns a live fd.
+    let result = unsafe { libc::fstat(file.as_raw_fd(), stat.as_mut_ptr()) };
+    if result != 0 {
+        return Err(RunnerError::Internal(format!(
+            "stat {context} {}: {}",
+            path.display(),
+            std::io::Error::last_os_error()
+        )));
+    }
+    // SAFETY: successful `fstat` initialized the full struct.
+    Ok(unsafe { stat.assume_init() })
+}
+
+fn validate_trusted_regular_setup_file(
+    stat: &libc::stat,
+    path: &Path,
+    context: &str,
+) -> RunnerResult<()> {
+    if (stat.st_mode & libc::S_IFMT) != libc::S_IFREG {
+        return Err(RunnerError::Internal(format!(
+            "{} is not a regular {context}",
+            path.display()
+        )));
+    }
+    validate_trusted_setup_owner(stat, path, context)
+}
+
+fn validate_trusted_setup_owner(stat: &libc::stat, path: &Path, context: &str) -> RunnerResult<()> {
+    let expected_uid = nix::unistd::geteuid().as_raw();
+    if stat.st_uid != ROOT_UID && stat.st_uid != expected_uid {
+        return Err(RunnerError::Internal(format!(
+            "{context} {} is owned by untrusted uid {}",
+            path.display(),
+            stat.st_uid
+        )));
+    }
+    Ok(())
+}
+
+fn chmod_fd<Fd: AsRawFd>(file: &Fd, path: &Path, mode: u32, context: &str) -> RunnerResult<()> {
+    // SAFETY: `fchmod` operates on the live fd and does not affect Rust aliasing.
+    let result = unsafe { libc::fchmod(file.as_raw_fd(), mode as libc::mode_t) };
+    if result == 0 {
+        Ok(())
+    } else {
+        Err(RunnerError::Internal(format!(
+            "chmod {context} {}: {}",
+            path.display(),
+            std::io::Error::last_os_error()
+        )))
+    }
+}
+
+fn setup_file_open_flags() -> i32 {
+    libc::O_NOFOLLOW | libc::O_CLOEXEC | libc::O_NONBLOCK
+}
+
+fn file_parent(path: &Path) -> &Path {
+    path.parent()
+        .filter(|parent| !parent.as_os_str().is_empty())
+        .unwrap_or_else(|| Path::new("."))
 }
 
 // ---------------------------------------------------------------------------
 // Shared download helpers
 // ---------------------------------------------------------------------------
 
-/// Stream an HTTP response to a file, computing SHA256 incrementally.
+/// Stream an HTTP response to an opened temp file, computing SHA256 incrementally.
 /// Returns the hex-encoded digest.
-async fn stream_to_file(mut response: reqwest::Response, path: &Path) -> RunnerResult<String> {
-    let mut file = tokio::fs::File::create(path)
-        .await
-        .map_err(|e| RunnerError::Internal(format!("create {}: {e}", path.display())))?;
+async fn stream_to_file(
+    mut response: reqwest::Response,
+    mut file: tokio::fs::File,
+    path: &Path,
+) -> RunnerResult<String> {
     let mut hasher = Sha256::new();
 
     while let Some(chunk) = response
@@ -154,23 +690,34 @@ async fn stream_to_file(mut response: reqwest::Response, path: &Path) -> RunnerR
 }
 
 /// Download a URL to a temp file. Cleans up on failure. Returns hex SHA256.
-async fn download_to_temp(url: &str, tmp_path: &Path, label: &str) -> RunnerResult<String> {
-    let response = reqwest::get(url)
-        .await
-        .map_err(|e| RunnerError::Internal(format!("download {label}: {e}")))?;
+async fn download_to_temp(
+    url: &str,
+    target: &Path,
+    kind: &str,
+    label: &str,
+) -> RunnerResult<(PathBuf, String)> {
+    let (tmp_path, file) = create_setup_temp_file(target, kind)?;
+    let result = async {
+        let response = reqwest::get(url)
+            .await
+            .map_err(|e| RunnerError::Internal(format!("download {label}: {e}")))?;
 
-    if !response.status().is_success() {
-        return Err(RunnerError::Internal(format!(
-            "download {label}: HTTP {}",
-            response.status()
-        )));
+        if !response.status().is_success() {
+            return Err(RunnerError::Internal(format!(
+                "download {label}: HTTP {}",
+                response.status()
+            )));
+        }
+
+        stream_to_file(response, tokio::fs::File::from_std(file), &tmp_path).await
     }
+    .await;
 
-    match stream_to_file(response, tmp_path).await {
-        Ok(sha) => Ok(sha),
-        Err(e) => {
-            let _ = tokio::fs::remove_file(tmp_path).await;
-            Err(e)
+    match result {
+        Ok(sha) => Ok((tmp_path, sha)),
+        Err(error) => {
+            let _ = tokio::fs::remove_file(&tmp_path).await;
+            Err(error)
         }
     }
 }
@@ -181,32 +728,25 @@ async fn download_and_extract(
     url: &str,
     label: &str,
     entry_name: &str,
-    tarball_path: &Path,
-    tmp_path: &Path,
-) -> RunnerResult<String> {
+    target: &Path,
+) -> RunnerResult<(PathBuf, String)> {
     // Tarball SHA is intentionally discarded — we verify the extracted binary's SHA instead.
-    download_to_temp(url, tarball_path, label).await?;
+    let (tarball_path, _) = download_to_temp(url, target, "tarball", label).await?;
 
-    let result = extract_tar_entry(tarball_path, tmp_path, entry_name).await;
-    let _ = tokio::fs::remove_file(tarball_path).await;
-    match result {
-        Ok(sha) => Ok(sha),
-        Err(e) => {
-            let _ = tokio::fs::remove_file(tmp_path).await;
-            Err(e)
-        }
-    }
+    let result = extract_tar_entry(&tarball_path, target, entry_name).await;
+    let _ = tokio::fs::remove_file(&tarball_path).await;
+    result
 }
 
 /// Extract a named entry from a gzipped tarball, writing to tmp_path.
 /// Matches by file_name (last path component). Returns the SHA256 hex digest.
 async fn extract_tar_entry(
     tarball_path: &Path,
-    tmp_path: &Path,
+    target: &Path,
     entry_name: &str,
-) -> RunnerResult<String> {
+) -> RunnerResult<(PathBuf, String)> {
     let tarball = tarball_path.to_owned();
-    let tmp = tmp_path.to_owned();
+    let target = target.to_owned();
     let entry_name = entry_name.to_owned();
 
     tokio::task::spawn_blocking(move || {
@@ -233,16 +773,17 @@ async fn extract_tar_entry(
                 .unwrap_or_default();
 
             if file_name == entry_name {
-                let mut out = std::fs::File::create(&tmp)
-                    .map_err(|e| RunnerError::Internal(format!("create temp binary: {e}")))?;
+                let (tmp, mut out) = create_setup_temp_file(&target, "extract")?;
                 let mut hasher = Sha256::new();
                 let mut buf = [0u8; 64 * 1024];
-                loop {
+                let result = loop {
                     let n = entry
                         .read(&mut buf)
                         .map_err(|e| RunnerError::Internal(format!("read tar entry: {e}")))?;
                     if n == 0 {
-                        break;
+                        std::io::Write::flush(&mut out)
+                            .map_err(|e| RunnerError::Internal(format!("flush binary: {e}")))?;
+                        break Ok(hex::encode(hasher.finalize()));
                     }
                     let chunk = buf.get(..n).ok_or_else(|| {
                         RunnerError::Internal("read returned invalid length".into())
@@ -250,8 +791,11 @@ async fn extract_tar_entry(
                     hasher.update(chunk);
                     std::io::Write::write_all(&mut out, chunk)
                         .map_err(|e| RunnerError::Internal(format!("write binary: {e}")))?;
+                };
+                if result.is_err() {
+                    let _ = std::fs::remove_file(&tmp);
                 }
-                return Ok(hex::encode(hasher.finalize()));
+                return result.map(|sha| (tmp, sha));
             }
         }
 
@@ -263,7 +807,7 @@ async fn extract_tar_entry(
     .map_err(|e| RunnerError::Internal(format!("extract task failed: {e}")))?
 }
 
-/// Verify SHA256, set permissions, and atomically rename to target.
+/// Verify SHA256, set permissions through the temp fd, and atomically rename to target.
 /// A failed rename only counts as a concurrent install if the target verifies.
 async fn verify_and_install(
     sha_hex: &str,
@@ -271,14 +815,14 @@ async fn verify_and_install(
     label: &str,
     tmp_path: &Path,
     target: &Path,
-    mode: Option<u32>,
+    mode: u32,
 ) -> RunnerResult<()> {
     if let Err(e) = verify_sha256(sha_hex, expected_sha, label) {
         let _ = tokio::fs::remove_file(tmp_path).await;
         return Err(e);
     }
 
-    match atomic_rename(tmp_path, target, mode).await {
+    match atomic_rename(tmp_path, target, expected_sha, mode).await {
         Ok(()) => Ok(()),
         Err(e) => match ensure_artifact_installed(target, expected_sha, mode).await {
             Ok(true) => {
@@ -294,19 +838,21 @@ async fn verify_and_install(
     }
 }
 
-/// Set permissions then atomically rename. Cleans up temp on failure.
-async fn atomic_rename(tmp_path: &Path, target: &Path, mode: Option<u32>) -> RunnerResult<()> {
-    let result = async {
-        if let Some(mode) = mode {
-            tokio::fs::set_permissions(tmp_path, std::fs::Permissions::from_mode(mode))
-                .await
-                .map_err(|e| RunnerError::Internal(format!("chmod {}: {e}", target.display())))?;
-        }
-        tokio::fs::rename(tmp_path, target)
-            .await
-            .map_err(|e| RunnerError::Internal(format!("rename to {}: {e}", target.display())))
-    }
-    .await;
+/// Prepare temp artifact through its fd, then atomically rename. Cleans up temp on failure.
+async fn atomic_rename(
+    tmp_path: &Path,
+    target: &Path,
+    expected_sha: &str,
+    mode: u32,
+) -> RunnerResult<()> {
+    let tmp = tmp_path.to_owned();
+    let target = target.to_owned();
+    let expected_sha = expected_sha.to_owned();
+    let result = tokio::task::spawn_blocking(move || {
+        install_temp_artifact(&tmp, &target, &expected_sha, mode)
+    })
+    .await
+    .map_err(|e| RunnerError::Internal(format!("install task failed: {e}")))?;
 
     if result.is_err() {
         let _ = tokio::fs::remove_file(tmp_path).await;
@@ -338,26 +884,19 @@ fn verify_sha256(actual_hex: &str, expected_hex: &str, label: &str) -> RunnerRes
 // ---------------------------------------------------------------------------
 
 /// Compute SHA256 of an existing file. Returns hex digest.
+#[cfg(test)]
 async fn file_sha256(path: &Path) -> RunnerResult<String> {
     let path = path.to_owned();
     tokio::task::spawn_blocking(move || {
-        let mut file = std::fs::File::open(&path)
-            .map_err(|e| RunnerError::Internal(format!("open {}: {e}", path.display())))?;
-        let mut hasher = Sha256::new();
-        let mut buf = [0u8; 64 * 1024];
-        loop {
-            let n = file
-                .read(&mut buf)
-                .map_err(|e| RunnerError::Internal(format!("read {}: {e}", path.display())))?;
-            if n == 0 {
-                break;
-            }
-            let chunk = buf
-                .get(..n)
-                .ok_or_else(|| RunnerError::Internal("read returned invalid length".into()))?;
-            hasher.update(chunk);
-        }
-        Ok(hex::encode(hasher.finalize()))
+        let Some(mut file) = open_existing_setup_artifact(&path)? else {
+            return Err(RunnerError::Internal(format!(
+                "open {}: not found",
+                path.display()
+            )));
+        };
+        let stat = setup_file_stat(&file, &path, "setup artifact")?;
+        validate_trusted_regular_setup_file(&stat, &path, "setup artifact")?;
+        file_sha256_open(&mut file, &path)
     })
     .await
     .map_err(|e| RunnerError::Internal(format!("sha256 task failed: {e}")))?
@@ -367,55 +906,22 @@ async fn file_sha256(path: &Path) -> RunnerResult<String> {
 async fn ensure_artifact_installed(
     path: &Path,
     expected_sha: &str,
-    mode: Option<u32>,
+    mode: u32,
 ) -> RunnerResult<bool> {
-    let metadata = match tokio::fs::symlink_metadata(path).await {
-        Ok(metadata) => metadata,
-        Err(e) if e.kind() == std::io::ErrorKind::NotFound => return Ok(false),
-        Err(e) => {
-            return Err(RunnerError::Internal(format!(
-                "stat {}: {e}",
-                path.display()
-            )));
-        }
-    };
-
-    if !metadata.is_file() {
-        return Ok(false);
-    }
-
-    if file_sha256(path).await? != expected_sha {
-        return Ok(false);
-    }
-
-    let Some(mode) = mode else {
-        return Ok(true);
-    };
-
-    if (metadata.permissions().mode() & 0o7777) == mode {
-        return Ok(true);
-    }
-
-    tokio::fs::set_permissions(path, std::fs::Permissions::from_mode(mode))
-        .await
-        .map_err(|e| RunnerError::Internal(format!("chmod {}: {e}", path.display())))?;
-
-    let metadata = tokio::fs::symlink_metadata(path)
-        .await
-        .map_err(|e| RunnerError::Internal(format!("stat {}: {e}", path.display())))?;
-
-    if !metadata.is_file() || (metadata.permissions().mode() & 0o7777) != mode {
-        return Ok(false);
-    }
-
-    Ok(file_sha256(path).await? == expected_sha)
+    let path = path.to_owned();
+    let expected_sha = expected_sha.to_owned();
+    tokio::task::spawn_blocking(move || {
+        ensure_artifact_installed_blocking(&path, &expected_sha, mode)
+    })
+    .await
+    .map_err(|e| RunnerError::Internal(format!("artifact validation task failed: {e}")))?
 }
 
 async fn download_firecracker(paths: &HomePaths, arch: &str) -> RunnerResult<()> {
     let bin_path = paths.firecracker_bin(FIRECRACKER_VERSION);
     let expected_sha = select_sha(arch, FIRECRACKER_SHA256_X86_64, FIRECRACKER_SHA256_AARCH64);
 
-    if ensure_artifact_installed(&bin_path, expected_sha, Some(0o755)).await? {
+    if ensure_artifact_installed(&bin_path, expected_sha, SETUP_EXECUTABLE_ARTIFACT_MODE).await? {
         tracing::info!(
             "[OK] firecracker {FIRECRACKER_VERSION} already installed, skipping download"
         );
@@ -425,11 +931,9 @@ async fn download_firecracker(paths: &HomePaths, arch: &str) -> RunnerResult<()>
     let url = firecracker_url(arch);
     tracing::info!("downloading firecracker from {url}");
 
-    let tarball_path = bin_path.with_extension(format!("tgz.{}", std::process::id()));
-    let tmp_path = bin_path.with_extension(format!("tmp.{}", std::process::id()));
     let fc_entry = firecracker_tar_entry(arch);
-    let sha_hex =
-        download_and_extract(&url, "firecracker", &fc_entry, &tarball_path, &tmp_path).await?;
+    let (tmp_path, sha_hex) =
+        download_and_extract(&url, "firecracker", &fc_entry, &bin_path).await?;
 
     verify_and_install(
         &sha_hex,
@@ -437,7 +941,7 @@ async fn download_firecracker(paths: &HomePaths, arch: &str) -> RunnerResult<()>
         "firecracker",
         &tmp_path,
         &bin_path,
-        Some(0o755),
+        SETUP_EXECUTABLE_ARTIFACT_MODE,
     )
     .await?;
     tracing::info!("[OK] firecracker {FIRECRACKER_VERSION} installed");
@@ -448,7 +952,7 @@ async fn download_kernel(paths: &HomePaths, arch: &str) -> RunnerResult<()> {
     let kernel_path = paths.kernel_bin(FIRECRACKER_VERSION, KERNEL_VERSION);
     let expected_sha = select_sha(arch, KERNEL_SHA256_X86_64, KERNEL_SHA256_AARCH64);
 
-    if ensure_artifact_installed(&kernel_path, expected_sha, None).await? {
+    if ensure_artifact_installed(&kernel_path, expected_sha, SETUP_KERNEL_ARTIFACT_MODE).await? {
         tracing::info!("[OK] kernel vmlinux-{KERNEL_VERSION} already installed, skipping download");
         return Ok(());
     }
@@ -456,8 +960,7 @@ async fn download_kernel(paths: &HomePaths, arch: &str) -> RunnerResult<()> {
     let url = kernel_url(arch);
     tracing::info!("downloading kernel from {url}");
 
-    let tmp_path = kernel_path.with_extension(format!("tmp.{}", std::process::id()));
-    let sha_hex = download_to_temp(&url, &tmp_path, "kernel").await?;
+    let (tmp_path, sha_hex) = download_to_temp(&url, &kernel_path, "download", "kernel").await?;
 
     verify_and_install(
         &sha_hex,
@@ -465,7 +968,7 @@ async fn download_kernel(paths: &HomePaths, arch: &str) -> RunnerResult<()> {
         "kernel",
         &tmp_path,
         &kernel_path,
-        None,
+        SETUP_KERNEL_ARTIFACT_MODE,
     )
     .await?;
     tracing::info!("[OK] kernel vmlinux-{KERNEL_VERSION} installed");
@@ -476,7 +979,7 @@ async fn download_mitmdump(paths: &HomePaths, arch: &str) -> RunnerResult<()> {
     let bin_path = paths.mitmdump_bin(MITMPROXY_VERSION);
     let expected_sha = select_sha(arch, MITMDUMP_SHA256_X86_64, MITMDUMP_SHA256_AARCH64);
 
-    if ensure_artifact_installed(&bin_path, expected_sha, Some(0o755)).await? {
+    if ensure_artifact_installed(&bin_path, expected_sha, SETUP_EXECUTABLE_ARTIFACT_MODE).await? {
         tracing::info!("[OK] mitmdump {MITMPROXY_VERSION} already installed, skipping download");
         return Ok(());
     }
@@ -484,16 +987,8 @@ async fn download_mitmdump(paths: &HomePaths, arch: &str) -> RunnerResult<()> {
     let url = mitmdump_url(arch);
     tracing::info!("downloading mitmdump from {url}");
 
-    let tarball_path = bin_path.with_extension(format!("tgz.{}", std::process::id()));
-    let tmp_path = bin_path.with_extension(format!("tmp.{}", std::process::id()));
-    let sha_hex = download_and_extract(
-        &url,
-        "mitmdump",
-        MITMDUMP_TAR_ENTRY,
-        &tarball_path,
-        &tmp_path,
-    )
-    .await?;
+    let (tmp_path, sha_hex) =
+        download_and_extract(&url, "mitmdump", MITMDUMP_TAR_ENTRY, &bin_path).await?;
 
     verify_and_install(
         &sha_hex,
@@ -501,7 +996,7 @@ async fn download_mitmdump(paths: &HomePaths, arch: &str) -> RunnerResult<()> {
         "mitmdump",
         &tmp_path,
         &bin_path,
-        Some(0o755),
+        SETUP_EXECUTABLE_ARTIFACT_MODE,
     )
     .await?;
     tracing::info!("[OK] mitmdump {MITMPROXY_VERSION} installed");
@@ -546,6 +1041,12 @@ fn check_kvm() {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use std::os::unix::fs::{PermissionsExt, symlink};
+    use std::os::unix::net::UnixListener;
+
+    fn mode(path: &Path) -> u32 {
+        std::fs::metadata(path).unwrap().permissions().mode() & 0o777
+    }
 
     #[test]
     fn check_architecture_returns_current() {
@@ -602,6 +1103,102 @@ mod tests {
         }
     }
 
+    #[test]
+    fn ensure_setup_shared_dir_creates_shared_directory() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("setup").join("firecracker");
+
+        ensure_setup_shared_dir(&path).unwrap();
+
+        assert_eq!(mode(&path), SETUP_SHARED_DIR_MODE);
+        assert!(path.is_dir());
+    }
+
+    #[test]
+    fn ensure_setup_shared_dir_rejects_final_symlink() {
+        let dir = tempfile::tempdir().unwrap();
+        let target = dir.path().join("target");
+        let link = dir.path().join("link");
+        std::fs::create_dir(&target).unwrap();
+        symlink(&target, &link).unwrap();
+
+        let error = ensure_setup_shared_dir(&link).unwrap_err();
+
+        assert!(
+            error.to_string().contains("symlink") || error.to_string().contains("not a directory"),
+            "unexpected error: {error}"
+        );
+    }
+
+    #[test]
+    fn ensure_setup_shared_dir_rejects_intermediate_symlink() {
+        let dir = tempfile::tempdir().unwrap();
+        let target = dir.path().join("target");
+        let link = dir.path().join("link");
+        std::fs::create_dir(&target).unwrap();
+        symlink(&target, &link).unwrap();
+
+        let error = ensure_setup_shared_dir(&link.join("child")).unwrap_err();
+
+        assert!(
+            error.to_string().contains("symlink") || error.to_string().contains("not a directory"),
+            "unexpected error: {error}"
+        );
+        assert!(!target.join("child").exists());
+    }
+
+    #[test]
+    fn ensure_setup_shared_dir_rejects_unsafe_writable_parent() {
+        let dir = tempfile::tempdir().unwrap();
+        let parent = dir.path().join("unsafe");
+        std::fs::create_dir(&parent).unwrap();
+        std::fs::set_permissions(&parent, std::fs::Permissions::from_mode(0o777)).unwrap();
+
+        let error = ensure_setup_shared_dir(&parent.join("child")).unwrap_err();
+
+        assert!(
+            error.to_string().contains("group/other writable"),
+            "unexpected error: {error}"
+        );
+        assert!(!parent.join("child").exists());
+    }
+
+    #[test]
+    fn create_setup_temp_file_at_creates_private_file() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join(".artifact.tmp");
+
+        let file = create_setup_temp_file_at(&path).unwrap();
+        drop(file);
+
+        assert_eq!(mode(&path), SETUP_TEMP_ARTIFACT_MODE);
+    }
+
+    #[test]
+    fn create_setup_temp_file_at_rejects_stale_symlink_without_following() {
+        let dir = tempfile::tempdir().unwrap();
+        let outside = dir.path().join("outside");
+        let link = dir.path().join(".artifact.tmp");
+        std::fs::write(&outside, b"outside").unwrap();
+        symlink(&outside, &link).unwrap();
+
+        let error = create_setup_temp_file_at(&link).unwrap_err();
+
+        assert!(
+            error.to_string().contains("File exists")
+                || error.to_string().contains("file exists")
+                || error.to_string().contains("exists"),
+            "unexpected error: {error}"
+        );
+        assert_eq!(std::fs::read(&outside).unwrap(), b"outside");
+        assert!(
+            std::fs::symlink_metadata(&link)
+                .unwrap()
+                .file_type()
+                .is_symlink()
+        );
+    }
+
     #[tokio::test]
     async fn file_sha256_computes_correctly() {
         let dir = tempfile::tempdir().unwrap();
@@ -633,7 +1230,7 @@ mod tests {
         let dir = tempfile::tempdir().unwrap();
         let path = dir.path().join("nonexistent");
         assert!(
-            !ensure_artifact_installed(&path, "anything", None)
+            !ensure_artifact_installed(&path, "anything", SETUP_EXECUTABLE_ARTIFACT_MODE)
                 .await
                 .unwrap()
         );
@@ -645,19 +1242,28 @@ mod tests {
         let path = dir.path().join("file.bin");
         std::fs::write(&path, b"content").unwrap();
         assert!(
-            !ensure_artifact_installed(&path, "wrong_sha", None)
+            !ensure_artifact_installed(&path, "wrong_sha", SETUP_EXECUTABLE_ARTIFACT_MODE)
                 .await
                 .unwrap()
         );
     }
 
     #[tokio::test]
-    async fn ensure_artifact_installed_returns_true_for_matching_sha_without_mode() {
+    async fn ensure_artifact_installed_returns_true_for_matching_sha_and_kernel_mode() {
         let dir = tempfile::tempdir().unwrap();
         let path = dir.path().join("file.bin");
         std::fs::write(&path, b"content").unwrap();
+        std::fs::set_permissions(
+            &path,
+            std::fs::Permissions::from_mode(SETUP_KERNEL_ARTIFACT_MODE),
+        )
+        .unwrap();
         let sha = file_sha256(&path).await.unwrap();
-        assert!(ensure_artifact_installed(&path, &sha, None).await.unwrap());
+        assert!(
+            ensure_artifact_installed(&path, &sha, SETUP_KERNEL_ARTIFACT_MODE)
+                .await
+                .unwrap()
+        );
     }
 
     #[tokio::test]
@@ -669,7 +1275,7 @@ mod tests {
         let sha = file_sha256(&path).await.unwrap();
 
         assert!(
-            ensure_artifact_installed(&path, &sha, Some(0o755))
+            ensure_artifact_installed(&path, &sha, SETUP_EXECUTABLE_ARTIFACT_MODE)
                 .await
                 .unwrap()
         );
@@ -684,12 +1290,70 @@ mod tests {
         let sha = file_sha256(&path).await.unwrap();
 
         assert!(
-            ensure_artifact_installed(&path, &sha, Some(0o755))
+            ensure_artifact_installed(&path, &sha, SETUP_EXECUTABLE_ARTIFACT_MODE)
                 .await
                 .unwrap()
         );
-        let mode = std::fs::metadata(&path).unwrap().permissions().mode() & 0o777;
-        assert_eq!(mode, 0o755);
+        assert_eq!(mode(&path), SETUP_EXECUTABLE_ARTIFACT_MODE);
+    }
+
+    #[tokio::test]
+    async fn ensure_artifact_installed_repairs_readonly_trusted_file_mode() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("file.bin");
+        std::fs::write(&path, b"content").unwrap();
+        std::fs::set_permissions(&path, std::fs::Permissions::from_mode(0o444)).unwrap();
+        let sha = file_sha256(&path).await.unwrap();
+
+        assert!(
+            ensure_artifact_installed(&path, &sha, SETUP_KERNEL_ARTIFACT_MODE)
+                .await
+                .unwrap()
+        );
+        assert_eq!(mode(&path), SETUP_KERNEL_ARTIFACT_MODE);
+    }
+
+    #[tokio::test]
+    async fn ensure_artifact_installed_does_not_follow_symlink_artifact() {
+        let dir = tempfile::tempdir().unwrap();
+        let outside = dir.path().join("outside.bin");
+        let link = dir.path().join("file.bin");
+        std::fs::write(&outside, b"content").unwrap();
+        symlink(&outside, &link).unwrap();
+        let sha = file_sha256(&outside).await.unwrap();
+
+        assert!(
+            !ensure_artifact_installed(&link, &sha, SETUP_EXECUTABLE_ARTIFACT_MODE)
+                .await
+                .unwrap()
+        );
+        assert_eq!(std::fs::read(&outside).unwrap(), b"content");
+    }
+
+    #[tokio::test]
+    async fn ensure_artifact_installed_returns_false_for_fifo_without_blocking() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("file.bin");
+        nix::unistd::mkfifo(&path, Mode::from_bits_truncate(0o600)).unwrap();
+
+        assert!(
+            !ensure_artifact_installed(&path, "anything", SETUP_EXECUTABLE_ARTIFACT_MODE)
+                .await
+                .unwrap()
+        );
+    }
+
+    #[tokio::test]
+    async fn ensure_artifact_installed_returns_false_for_unix_socket() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("file.bin");
+        let _listener = UnixListener::bind(&path).unwrap();
+
+        assert!(
+            !ensure_artifact_installed(&path, "anything", SETUP_EXECUTABLE_ARTIFACT_MODE)
+                .await
+                .unwrap()
+        );
     }
 
     #[tokio::test]
@@ -699,7 +1363,7 @@ mod tests {
         std::fs::create_dir(&path).unwrap();
 
         assert!(
-            !ensure_artifact_installed(&path, "anything", Some(0o755))
+            !ensure_artifact_installed(&path, "anything", SETUP_EXECUTABLE_ARTIFACT_MODE)
                 .await
                 .unwrap()
         );
@@ -711,10 +1375,19 @@ mod tests {
         let tmp_path = dir.path().join("tmp.bin");
         let target = dir.path().join("target.bin");
         std::fs::write(&tmp_path, b"content").unwrap();
+        std::fs::set_permissions(&tmp_path, std::fs::Permissions::from_mode(0o600)).unwrap();
         std::fs::create_dir(&target).unwrap();
         let sha = file_sha256(&tmp_path).await.unwrap();
 
-        let result = verify_and_install(&sha, &sha, "test", &tmp_path, &target, None).await;
+        let result = verify_and_install(
+            &sha,
+            &sha,
+            "test",
+            &tmp_path,
+            &target,
+            SETUP_EXECUTABLE_ARTIFACT_MODE,
+        )
+        .await;
 
         assert!(result.is_err());
         assert!(target.is_dir());
@@ -727,14 +1400,23 @@ mod tests {
         let tmp_path = dir.path().join("tmp.bin");
         let target = dir.path().join("target.bin");
         std::fs::write(&tmp_path, b"new content").unwrap();
+        std::fs::set_permissions(&tmp_path, std::fs::Permissions::from_mode(0o600)).unwrap();
         std::fs::write(&target, b"old content").unwrap();
         let sha = file_sha256(&tmp_path).await.unwrap();
 
-        verify_and_install(&sha, &sha, "test", &tmp_path, &target, None)
-            .await
-            .unwrap();
+        verify_and_install(
+            &sha,
+            &sha,
+            "test",
+            &tmp_path,
+            &target,
+            SETUP_EXECUTABLE_ARTIFACT_MODE,
+        )
+        .await
+        .unwrap();
 
         assert_eq!(std::fs::read(&target).unwrap(), b"new content");
+        assert_eq!(mode(&target), SETUP_EXECUTABLE_ARTIFACT_MODE);
     }
 
     #[tokio::test]
@@ -743,11 +1425,23 @@ mod tests {
         let tmp_path = dir.path().join("missing-tmp.bin");
         let target = dir.path().join("target.bin");
         std::fs::write(&target, b"content").unwrap();
+        std::fs::set_permissions(
+            &target,
+            std::fs::Permissions::from_mode(SETUP_EXECUTABLE_ARTIFACT_MODE),
+        )
+        .unwrap();
         let sha = file_sha256(&target).await.unwrap();
 
-        verify_and_install(&sha, &sha, "test", &tmp_path, &target, None)
-            .await
-            .unwrap();
+        verify_and_install(
+            &sha,
+            &sha,
+            "test",
+            &tmp_path,
+            &target,
+            SETUP_EXECUTABLE_ARTIFACT_MODE,
+        )
+        .await
+        .unwrap();
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- harden runner setup shared directory creation with no-follow traversal and ownership/mode validation
- install Firecracker, kernel, and mitmdump through private same-directory temp files with fd-based hashing, chmod, atomic rename, and post-install validation
- treat symlink and non-regular existing artifacts as invalid without following or blocking, and add setup-focused regression tests

## Testing
- cargo fmt --manifest-path crates/Cargo.toml --all --check
- cargo test --manifest-path crates/Cargo.toml -p runner cmd::setup
- cargo clippy --manifest-path crates/Cargo.toml -p runner --all-targets -- -D warnings
- cargo test --manifest-path crates/Cargo.toml -p runner
- git diff --check

Closes #16560