### PR TITLE
refactor(runner): share network log drain loop

### DIFF
--- a/crates/runner/src/dns.rs
+++ b/crates/runner/src/dns.rs
@@ -18,13 +18,14 @@
 use std::{borrow::Cow, process::Stdio};
 
 use chrono::{DateTime, Utc};
-use tokio::io::{AsyncBufRead, AsyncBufReadExt};
+use tokio::io::AsyncBufRead;
 use tokio::sync::mpsc;
 use tokio_util::sync::CancellationToken;
 use tracing::{info, warn};
 
 use crate::network_log_drain::{
-    NetworkLogDrainProducer, NetworkLogDrainRequest, ReadyLine, poll_next_line_ready,
+    DrainableLineReaderExit, NetworkLogDrainProducer, NetworkLogDrainRequest,
+    run_drainable_line_reader,
 };
 use crate::network_log_manager::NetworkLogManager;
 
@@ -267,66 +268,37 @@ async fn tail_reader<R>(
     reader: R,
     network_log_manager: NetworkLogManager,
     cancel: CancellationToken,
-    mut drain_rx: mpsc::Receiver<NetworkLogDrainRequest>,
+    drain_rx: mpsc::Receiver<NetworkLogDrainRequest>,
 ) -> std::io::Result<()>
 where
     R: AsyncBufRead + Unpin,
 {
-    let mut lines = reader.lines();
-    loop {
-        tokio::select! {
-            _ = cancel.cancelled() => break,
-            request = drain_rx.recv() => {
-                let Some(request) = request else {
-                    break;
-                };
-                let outcome = drain_ready_lines(&mut lines, &network_log_manager).await;
-                request.ack();
-                if let DrainOutcome::Stop(result) = outcome {
-                    result?;
-                    break;
-                }
-            }
-            result = lines.next_line() => {
-                let line = match result {
-                    Ok(Some(l)) => l,
-                    Ok(None) => {
-                        if !cancel.is_cancelled() {
-                            warn!("dnsmasq exited unexpectedly (stderr EOF)");
-                        }
-                        break;
-                    }
-                    Err(e) => {
-                        warn!(error = %e, "dnsmasq stderr read error");
-                        break;
-                    }
-                };
-
-                handle_dns_line(&network_log_manager, &line).await;
-            }
+    let exit = run_drainable_line_reader(reader, cancel.clone(), drain_rx, move |line| {
+        let network_log_manager = network_log_manager.clone();
+        async move {
+            handle_dns_line(&network_log_manager, &line).await;
         }
-    }
-    Ok(())
-}
+    })
+    .await;
 
-enum DrainOutcome {
-    Continue,
-    Stop(std::io::Result<()>),
-}
-
-async fn drain_ready_lines<R>(
-    lines: &mut tokio::io::Lines<R>,
-    network_log_manager: &NetworkLogManager,
-) -> DrainOutcome
-where
-    R: AsyncBufRead + Unpin,
-{
-    loop {
-        match poll_next_line_ready(lines) {
-            Ok(ReadyLine::Line(line)) => handle_dns_line(network_log_manager, &line).await,
-            Ok(ReadyLine::Pending) => return DrainOutcome::Continue,
-            Ok(ReadyLine::Eof) => return DrainOutcome::Stop(Ok(())),
-            Err(e) => return DrainOutcome::Stop(Err(e)),
+    match exit {
+        DrainableLineReaderExit::Cancelled | DrainableLineReaderExit::DrainChannelClosed => Ok(()),
+        DrainableLineReaderExit::Eof { during_drain } => {
+            if !during_drain && !cancel.is_cancelled() {
+                warn!("dnsmasq exited unexpectedly (stderr EOF)");
+            }
+            Ok(())
+        }
+        DrainableLineReaderExit::ReadError {
+            during_drain,
+            error,
+        } => {
+            if during_drain {
+                Err(error)
+            } else {
+                warn!(error = %error, "dnsmasq stderr read error");
+                Ok(())
+            }
         }
     }
 }
@@ -554,9 +526,13 @@ fn network_log_row(entry: &DnsLogEntry<'_>, timestamp: DateTime<Utc>) -> serde_j
 #[cfg(test)]
 mod tests {
     use super::*;
+    use std::io;
+    use std::pin::Pin;
+    use std::task::{Context, Poll};
+
     use crate::ids::RunId;
     use crate::network_log_drain::NetworkLogDrainContext;
-    use tokio::io::AsyncWriteExt;
+    use tokio::io::{AsyncBufRead, AsyncRead, AsyncWriteExt, ReadBuf};
 
     fn assert_query_event(entry: &DnsLogEntry<'_>, expected_query_type: &str) {
         assert_eq!(entry.event.name(), "query");
@@ -946,6 +922,58 @@ mod tests {
         cancel.cancel();
         drop(writer);
         task.await.unwrap().unwrap();
+    }
+
+    #[tokio::test]
+    async fn tail_reader_returns_ok_on_normal_eof() {
+        let cancel = CancellationToken::new();
+        let (_producer, drain_rx) = NetworkLogDrainProducer::channel("dns-test");
+
+        let result = tail_reader(
+            tokio::io::BufReader::new(tokio::io::empty()),
+            NetworkLogManager::new(),
+            cancel,
+            drain_rx,
+        )
+        .await;
+
+        assert!(result.is_ok());
+    }
+
+    #[tokio::test]
+    async fn tail_reader_returns_ok_on_normal_read_error() {
+        let cancel = CancellationToken::new();
+        let (_producer, drain_rx) = NetworkLogDrainProducer::channel("dns-test");
+
+        let result = tail_reader(FailingReader, NetworkLogManager::new(), cancel, drain_rx).await;
+
+        assert!(result.is_ok());
+    }
+
+    struct FailingReader;
+
+    impl AsyncRead for FailingReader {
+        fn poll_read(
+            self: Pin<&mut Self>,
+            _cx: &mut Context<'_>,
+            _buf: &mut ReadBuf<'_>,
+        ) -> Poll<io::Result<()>> {
+            Poll::Ready(Err(io::Error::new(
+                io::ErrorKind::InvalidData,
+                "test read error",
+            )))
+        }
+    }
+
+    impl AsyncBufRead for FailingReader {
+        fn poll_fill_buf(self: Pin<&mut Self>, _cx: &mut Context<'_>) -> Poll<io::Result<&[u8]>> {
+            Poll::Ready(Err(io::Error::new(
+                io::ErrorKind::InvalidData,
+                "test read error",
+            )))
+        }
+
+        fn consume(self: Pin<&mut Self>, _amt: usize) {}
     }
 
     #[test]

--- a/crates/runner/src/kmsg_log.rs
+++ b/crates/runner/src/kmsg_log.rs
@@ -15,7 +15,7 @@ use tokio_util::sync::CancellationToken;
 use tracing::{info, warn};
 
 use crate::network_log_drain::{
-    NetworkLogDrainProducer, NetworkLogDrainRequest, ReadyLine, poll_next_line_ready,
+    NetworkLogDrainProducer, NetworkLogDrainRequest, run_drainable_line_reader,
 };
 use crate::network_log_manager::NetworkLogManager;
 
@@ -167,55 +167,17 @@ async fn run_reader<R>(
     network_log_manager: NetworkLogManager,
     cancel: CancellationToken,
     reader: R,
-    mut drain_rx: mpsc::Receiver<NetworkLogDrainRequest>,
+    drain_rx: mpsc::Receiver<NetworkLogDrainRequest>,
 ) where
     R: AsyncBufRead + Unpin,
 {
-    let mut lines = reader.lines();
-    loop {
-        tokio::select! {
-            _ = cancel.cancelled() => break,
-            request = drain_rx.recv() => {
-                let Some(request) = request else {
-                    break;
-                };
-                let stop = drain_ready_lines(&mut lines, &network_log_manager).await;
-                request.ack();
-                if stop {
-                    break;
-                }
-            }
-            result = lines.next_line() => {
-                let line = match result {
-                    Ok(Some(l)) => l,
-                    Ok(None) | Err(_) => break,
-                };
-
-                // Fast check before acquiring lock.
-                if !line.contains(LOG_PREFIX) {
-                    continue;
-                }
-
-                handle_kmsg_line(&network_log_manager, &line).await;
-            }
+    let _ = run_drainable_line_reader(reader, cancel, drain_rx, move |line| {
+        let network_log_manager = network_log_manager.clone();
+        async move {
+            handle_kmsg_line(&network_log_manager, &line).await;
         }
-    }
-}
-
-async fn drain_ready_lines<R>(
-    lines: &mut tokio::io::Lines<R>,
-    network_log_manager: &NetworkLogManager,
-) -> bool
-where
-    R: AsyncBufRead + Unpin,
-{
-    loop {
-        match poll_next_line_ready(lines) {
-            Ok(ReadyLine::Line(line)) => handle_kmsg_line(network_log_manager, &line).await,
-            Ok(ReadyLine::Pending) => return false,
-            Ok(ReadyLine::Eof) | Err(_) => return true,
-        }
-    }
+    })
+    .await;
 }
 
 async fn handle_kmsg_line(network_log_manager: &NetworkLogManager, line: &str) {

--- a/crates/runner/src/network_log_drain.rs
+++ b/crates/runner/src/network_log_drain.rs
@@ -6,9 +6,10 @@ use std::time::Duration;
 
 use futures_util::future::join_all;
 use futures_util::task::noop_waker_ref;
-use tokio::io::{AsyncBufRead, Lines};
+use tokio::io::{AsyncBufRead, AsyncBufReadExt, Lines};
 use tokio::sync::{mpsc, oneshot};
 use tokio::time::timeout;
+use tokio_util::sync::CancellationToken;
 use tracing::warn;
 
 use crate::ids::RunId;
@@ -161,6 +162,111 @@ pub(crate) enum ReadyLine {
     Pending,
 }
 
+#[derive(Debug)]
+pub(crate) enum DrainableLineReaderExit {
+    Cancelled,
+    DrainChannelClosed,
+    Eof {
+        during_drain: bool,
+    },
+    ReadError {
+        during_drain: bool,
+        error: std::io::Error,
+    },
+}
+
+#[derive(Debug)]
+enum DrainReadyLinesOutcome {
+    Continue,
+    Stop(DrainableLineReaderExit),
+}
+
+pub(crate) async fn run_drainable_line_reader<R, F, Fut>(
+    reader: R,
+    cancel: CancellationToken,
+    mut drain_rx: mpsc::Receiver<NetworkLogDrainRequest>,
+    mut on_line: F,
+) -> DrainableLineReaderExit
+where
+    R: AsyncBufRead + Unpin,
+    F: FnMut(String) -> Fut,
+    Fut: Future<Output = ()>,
+{
+    let mut lines = reader.lines();
+    loop {
+        tokio::select! {
+            _ = cancel.cancelled() => return DrainableLineReaderExit::Cancelled,
+            request = drain_rx.recv() => {
+                let Some(request) = request else {
+                    return DrainableLineReaderExit::DrainChannelClosed;
+                };
+                let outcome = process_drain_request(&mut lines, &mut on_line, request).await;
+                if let DrainReadyLinesOutcome::Stop(exit) = outcome {
+                    return exit;
+                }
+            }
+            result = lines.next_line() => {
+                let line = match result {
+                    Ok(Some(line)) => line,
+                    Ok(None) => return DrainableLineReaderExit::Eof {
+                        during_drain: false,
+                    },
+                    Err(e) => {
+                        return DrainableLineReaderExit::ReadError {
+                            during_drain: false,
+                            error: e,
+                        };
+                    }
+                };
+                on_line(line).await;
+            }
+        }
+    }
+}
+
+async fn process_drain_request<R, F, Fut>(
+    lines: &mut Lines<R>,
+    on_line: &mut F,
+    request: NetworkLogDrainRequest,
+) -> DrainReadyLinesOutcome
+where
+    R: AsyncBufRead + Unpin,
+    F: FnMut(String) -> Fut,
+    Fut: Future<Output = ()>,
+{
+    let outcome = drain_ready_lines(lines, on_line).await;
+    request.ack();
+    outcome
+}
+
+async fn drain_ready_lines<R, F, Fut>(
+    lines: &mut Lines<R>,
+    on_line: &mut F,
+) -> DrainReadyLinesOutcome
+where
+    R: AsyncBufRead + Unpin,
+    F: FnMut(String) -> Fut,
+    Fut: Future<Output = ()>,
+{
+    loop {
+        match poll_next_line_ready(lines) {
+            Ok(ReadyLine::Line(line)) => on_line(line).await,
+            Ok(ReadyLine::Pending) => return DrainReadyLinesOutcome::Continue,
+            Ok(ReadyLine::Eof) => {
+                return DrainReadyLinesOutcome::Stop(DrainableLineReaderExit::Eof {
+                    during_drain: true,
+                });
+            }
+            Err(e) => {
+                return DrainReadyLinesOutcome::Stop(DrainableLineReaderExit::ReadError {
+                    during_drain: true,
+                    error: e,
+                });
+            }
+        }
+    }
+}
+
 /// Poll `Lines::next_line` once without waiting for future readiness.
 ///
 /// `Lines::next_line` is cancellation-safe; when the poll returns `Pending`,
@@ -178,5 +284,269 @@ where
         Poll::Ready(Ok(None)) => Ok(ReadyLine::Eof),
         Poll::Ready(Err(e)) => Err(e),
         Poll::Pending => Ok(ReadyLine::Pending),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::io;
+    use std::path::Path;
+    use std::pin::Pin;
+    use std::sync::{Arc, Mutex};
+    use std::task::{Context, Poll};
+    use std::time::Duration;
+
+    use tokio::io::{AsyncBufRead, AsyncBufReadExt, AsyncRead, AsyncWriteExt, BufReader, ReadBuf};
+    use tokio::sync::oneshot;
+
+    use super::*;
+    use crate::ids::RunId;
+
+    fn drain_context(path: &Path) -> NetworkLogDrainContext<'_> {
+        NetworkLogDrainContext {
+            run_id: RunId::nil(),
+            source_ip: "10.0.0.1",
+            path,
+            generation: 1,
+        }
+    }
+
+    #[tokio::test]
+    async fn drainable_line_reader_processes_ready_line_before_ack() {
+        let path = Path::new("network.jsonl");
+        let cancel = CancellationToken::new();
+        let (producer, drain_rx) = NetworkLogDrainProducer::channel("reader-test");
+        let (mut writer, reader) = tokio::io::duplex(1024);
+        let handled = Arc::new(Mutex::new(Vec::new()));
+        let handled_for_task = handled.clone();
+        let task = tokio::spawn(run_drainable_line_reader(
+            BufReader::new(reader),
+            cancel.clone(),
+            drain_rx,
+            move |line| {
+                let handled = handled_for_task.clone();
+                async move {
+                    handled.lock().unwrap().push(line);
+                }
+            },
+        ));
+
+        writer.write_all(b"first\n").await.unwrap();
+
+        producer
+            .drain(drain_context(path), Duration::from_secs(1))
+            .await;
+
+        assert_eq!(handled.lock().unwrap().as_slice(), ["first"]);
+
+        cancel.cancel();
+        drop(writer);
+        assert!(matches!(
+            task.await.unwrap(),
+            DrainableLineReaderExit::Cancelled | DrainableLineReaderExit::Eof { .. }
+        ));
+    }
+
+    #[tokio::test]
+    async fn drainable_line_reader_returns_eof_on_normal_eof() {
+        let cancel = CancellationToken::new();
+        let (_producer, drain_rx) = NetworkLogDrainProducer::channel("reader-test");
+
+        let exit = run_drainable_line_reader(
+            BufReader::new(tokio::io::empty()),
+            cancel,
+            drain_rx,
+            |_| async {},
+        )
+        .await;
+
+        assert!(matches!(
+            exit,
+            DrainableLineReaderExit::Eof {
+                during_drain: false
+            }
+        ));
+    }
+
+    #[tokio::test]
+    async fn drainable_line_reader_acknowledges_eof_after_ready_lines() {
+        let handled = Arc::new(Mutex::new(Vec::new()));
+        let ack_seen_in_handler = Arc::new(Mutex::new(None));
+        let mut lines = TestReader::from_bytes(b"first\n").lines();
+        let (ack, ack_rx) = oneshot::channel();
+        let ack_rx = Arc::new(Mutex::new(ack_rx));
+        let request = NetworkLogDrainRequest { ack };
+
+        let outcome = process_drain_request(
+            &mut lines,
+            &mut |line| {
+                let handled = handled.clone();
+                let ack_seen_in_handler = ack_seen_in_handler.clone();
+                let ack_rx = ack_rx.clone();
+                async move {
+                    let ack_result = ack_rx.lock().unwrap().try_recv();
+                    *ack_seen_in_handler.lock().unwrap() = Some(ack_result.is_ok());
+                    handled.lock().unwrap().push(line);
+                }
+            },
+            request,
+        )
+        .await;
+
+        assert_eq!(*ack_seen_in_handler.lock().unwrap(), Some(false));
+        ack_rx.lock().unwrap().try_recv().unwrap();
+        assert_eq!(handled.lock().unwrap().as_slice(), ["first"]);
+        assert!(matches!(
+            outcome,
+            DrainReadyLinesOutcome::Stop(DrainableLineReaderExit::Eof { during_drain: true })
+        ));
+    }
+
+    #[tokio::test]
+    async fn drainable_line_reader_acknowledges_drain_read_error() {
+        let mut lines = TestReader::with_error(io::ErrorKind::Other).lines();
+        let (ack, ack_rx) = oneshot::channel();
+        let request = NetworkLogDrainRequest { ack };
+
+        let outcome = process_drain_request(&mut lines, &mut |_| async {}, request).await;
+
+        ack_rx.await.unwrap();
+        match outcome {
+            DrainReadyLinesOutcome::Stop(DrainableLineReaderExit::ReadError {
+                during_drain,
+                error,
+            }) => {
+                assert!(during_drain);
+                assert_eq!(error.kind(), io::ErrorKind::Other);
+            }
+            other => panic!("expected read error, got {other:?}"),
+        }
+    }
+
+    #[tokio::test]
+    async fn drainable_line_reader_returns_cancelled() {
+        let cancel = CancellationToken::new();
+        cancel.cancel();
+        let (_producer, drain_rx) = NetworkLogDrainProducer::channel("reader-test");
+
+        let exit = run_drainable_line_reader(PendingReader, cancel, drain_rx, |_| async {}).await;
+
+        assert!(matches!(exit, DrainableLineReaderExit::Cancelled));
+    }
+
+    #[tokio::test]
+    async fn drainable_line_reader_returns_drain_channel_closed() {
+        let cancel = CancellationToken::new();
+        let (producer, drain_rx) = NetworkLogDrainProducer::channel("reader-test");
+        drop(producer);
+
+        let exit = run_drainable_line_reader(PendingReader, cancel, drain_rx, |_| async {}).await;
+
+        assert!(matches!(exit, DrainableLineReaderExit::DrainChannelClosed));
+    }
+
+    #[tokio::test]
+    async fn drainable_line_reader_returns_normal_read_error() {
+        let cancel = CancellationToken::new();
+        let (_producer, drain_rx) = NetworkLogDrainProducer::channel("reader-test");
+
+        let exit = run_drainable_line_reader(
+            TestReader::with_error(io::ErrorKind::InvalidData),
+            cancel,
+            drain_rx,
+            |_| async {},
+        )
+        .await;
+
+        match exit {
+            DrainableLineReaderExit::ReadError {
+                during_drain,
+                error,
+            } => {
+                assert!(!during_drain);
+                assert_eq!(error.kind(), io::ErrorKind::InvalidData);
+            }
+            other => panic!("expected normal read error, got {other:?}"),
+        }
+    }
+
+    struct TestReader {
+        data: &'static [u8],
+        position: usize,
+        error: Option<io::ErrorKind>,
+    }
+
+    impl TestReader {
+        fn from_bytes(data: &'static [u8]) -> Self {
+            Self {
+                data,
+                position: 0,
+                error: None,
+            }
+        }
+
+        fn with_error(kind: io::ErrorKind) -> Self {
+            Self {
+                data: &[],
+                position: 0,
+                error: Some(kind),
+            }
+        }
+    }
+
+    impl AsyncRead for TestReader {
+        fn poll_read(
+            mut self: Pin<&mut Self>,
+            cx: &mut Context<'_>,
+            buf: &mut ReadBuf<'_>,
+        ) -> Poll<io::Result<()>> {
+            match self.as_mut().poll_fill_buf(cx) {
+                Poll::Ready(Ok(available)) => {
+                    let len = available.len().min(buf.remaining());
+                    buf.put_slice(&available[..len]);
+                    self.consume(len);
+                    Poll::Ready(Ok(()))
+                }
+                Poll::Ready(Err(e)) => Poll::Ready(Err(e)),
+                Poll::Pending => Poll::Pending,
+            }
+        }
+    }
+
+    impl AsyncBufRead for TestReader {
+        fn poll_fill_buf(
+            mut self: Pin<&mut Self>,
+            _cx: &mut Context<'_>,
+        ) -> Poll<io::Result<&[u8]>> {
+            if let Some(kind) = self.error.take() {
+                return Poll::Ready(Err(io::Error::new(kind, "test read error")));
+            }
+
+            Poll::Ready(Ok(&self.data[self.position..]))
+        }
+
+        fn consume(mut self: Pin<&mut Self>, amt: usize) {
+            self.position = self.position.saturating_add(amt).min(self.data.len());
+        }
+    }
+
+    struct PendingReader;
+
+    impl AsyncRead for PendingReader {
+        fn poll_read(
+            self: Pin<&mut Self>,
+            _cx: &mut Context<'_>,
+            _buf: &mut ReadBuf<'_>,
+        ) -> Poll<io::Result<()>> {
+            Poll::Pending
+        }
+    }
+
+    impl AsyncBufRead for PendingReader {
+        fn poll_fill_buf(self: Pin<&mut Self>, _cx: &mut Context<'_>) -> Poll<io::Result<&[u8]>> {
+            Poll::Pending
+        }
+
+        fn consume(self: Pin<&mut Self>, _amt: usize) {}
     }
 }


### PR DESCRIPTION
## Summary

- Extract the shared producer-side drainable line-reader loop into `network_log_drain.rs`.
- Update kmsg and DNS log readers to use the shared helper while keeping parsing and process lifecycle local.
- Add focused helper tests for drain ack ordering, EOF handling, and drain read-error handling.

## Non-goals

- No changes to dnsmasq startup timing, port probing, retries, or process management.
- No broad `NetworkLogProducer` lifecycle abstraction.
- No network-log schema or upload/finalization behavior changes.

## Tests

- `cargo fmt --manifest-path crates/Cargo.toml -p runner -- --check`
- `cargo clippy --manifest-path crates/Cargo.toml -p runner --tests`
- `cargo test --manifest-path crates/Cargo.toml -p runner network_log_drain`
- `cargo test --manifest-path crates/Cargo.toml -p runner drain_barrier_processes_queued_kmsg_line_before_ack`
- `cargo test --manifest-path crates/Cargo.toml -p runner drain_barrier_processes_queued_dns_line_before_ack`
- `cargo test --manifest-path crates/Cargo.toml -p runner`

Closes #16738
