### PR TITLE
ci: split heavy app type-checks into a parallel lint-types-apps job

### DIFF
--- a/.github/workflows/turbo.yml
+++ b/.github/workflows/turbo.yml
@@ -381,9 +381,38 @@ jobs:
     steps:
       - uses: actions/checkout@v6
       - uses: ./.github/actions/toolchain-init
-      - name: Type Check
+      # The three heavy app type-checks (api, web, @vm0/app ≈ 57% of the
+      # serial total) run in the separate lint-types-apps job below. Here we
+      # check everything else. Dependency packages resolve via source
+      # (exports point at src/*.ts, no build step), so the apps job can run
+      # its tsc standalone without re-running these — no duplicated work.
+      - name: Type Check (shared packages)
         working-directory: turbo
-        run: pnpm check-types
+        run: pnpm turbo run check-types --concurrency=1 --filter='!api' --filter='!web' --filter='!@vm0/app'
+
+  lint-types-apps:
+    needs: [detect-turbo-ts-checks]
+    runs-on: ubuntu-latest
+    if: needs.detect-turbo-ts-checks.outputs.turbo-ts-checks-needed == 'true'
+    container:
+      image: ghcr.io/vm0-ai/vm0-toolchain:20260525
+    steps:
+      - uses: actions/checkout@v6
+      - uses: ./.github/actions/toolchain-init
+      # Heaviest tsc projects, split off lint-types so they run on their own
+      # runner. Kept serial (one tsc at a time) to stay within runner memory —
+      # the same reason the root check-types uses --concurrency=1. Each app's
+      # check-types is invoked directly (pnpm --filter, not turbo) so turbo's
+      # dependsOn ^check-types does not re-run the shared packages here.
+      - name: Type Check (api)
+        working-directory: turbo
+        run: pnpm --filter api run check-types
+      - name: Type Check (@vm0/app)
+        working-directory: turbo
+        run: pnpm --filter @vm0/app run check-types
+      - name: Type Check (web)
+        working-directory: turbo
+        run: pnpm --filter web run check-types
 
   lint-format:
     needs: [detect-turbo-ts-checks]
@@ -2371,6 +2400,7 @@ jobs:
       - block-generated-firewalls
       - lint-eslint
       - lint-types
+      - lint-types-apps
       - lint-format
       - lint-knip
       - test-web
@@ -2454,6 +2484,7 @@ jobs:
           # detect-turbo-ts-checks classified this as a crates-only change set.
           check_result "lint-eslint" "${{ needs.lint-eslint.result }}" "$TS_CHECK_SKIP_ALLOWED"
           check_result "lint-types" "${{ needs.lint-types.result }}" "$TS_CHECK_SKIP_ALLOWED"
+          check_result "lint-types-apps" "${{ needs.lint-types-apps.result }}" "$TS_CHECK_SKIP_ALLOWED"
           check_result "lint-format" "${{ needs.lint-format.result }}" "$TS_CHECK_SKIP_ALLOWED"
           check_result "lint-knip" "${{ needs.lint-knip.result }}" "$TS_CHECK_SKIP_ALLOWED"
           check_result "test-web" "${{ needs.test-web.result }}" "$TS_CHECK_SKIP_ALLOWED"


### PR DESCRIPTION
## What

Split the three heavy app type-checks out of `lint-types` onto their own runner so they run in parallel instead of serially behind the shared packages.

## Why

`lint-types` runs `turbo run check-types --concurrency=1` — all 13 packages' `tsc` **one at a time**. Per-package timing from a real run (2m49s total):

- **api 44.3s** · **@vm0/app 32.1s** · **web 21.5s** → the top 3 are **57%** of the wall
- cli 17 · api-contracts 14 · core 13 · connectors 10 · db 7 · rest ~9s

## How

- **lint-types** (existing): now checks everything *except* the three apps — `turbo run check-types --concurrency=1 --filter='!api' --filter='!web' --filter='!@vm0/app'` (~72s).
- **lint-types-apps** (new): runs api / @vm0/app / web, each via `pnpm --filter <pkg> run check-types` (~97s, serial).

The apps job calls `pnpm --filter` directly instead of `turbo --filter` on purpose: turbo's `check-types` has `dependsOn: ["^check-types", "^build"]`, so a `turbo --filter=api` run would **re-run the whole shared-package check-types closure** — duplicating ~72s in both jobs and defeating the split. Going around turbo is safe here because:

- shared packages export `./src/*.ts` (e.g. `@vm0/core` → `./src/index.ts`), so dependents' `tsc` resolves their types **from source**;
- `@vm0/core` / `@vm0/db` / `@vm0/api-contracts` have **no `build` script** (the `^build` dep is already a no-op — it contributed ~0s to the existing run);
- apps/api `tsconfig` has no project references/paths.

So each app's standalone `tsc` is equivalent to today, and every package's `check-types` still runs **exactly once** across the two jobs — no duplicated compute.

Checks stay **serial within each job** (one `tsc` at a time) to respect runner memory — the same reason the root script pins `--concurrency=1`. Splitting across two runners is the memory-safe way to parallelize (each runner gets its own RAM).

## Effect & cost

- lint-types group wall: ~169s → ~`max(72s, 97s)` ≈ **97s** (~40% off the job).
- Cost: **+1 runner slot**. Kept to a single extra job (not 3) to avoid over-spending slots, since `lint-types` is usually *not* the run's wall-defining job.

## Gate
`ci-gate-turbo` updated: `lint-types-apps` added to `needs` and to the `check_result` validation, so it's enforced like the other lint jobs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)