### PR TITLE
feat(api): inbound webhook route + WebhookInterpreter + run submission

### DIFF
--- a/turbo/apps/api/src/signals/route.ts
+++ b/turbo/apps/api/src/signals/route.ts
@@ -62,6 +62,7 @@ import { webhooksAgentFirewallAuthRoutes } from "./routes/webhooks-agent-firewal
 import { webhooksAgentHealthUsageTelemetryRoutes } from "./routes/webhooks-agent-health-usage-telemetry";
 import { webhooksAgentStorageRoutes } from "./routes/webhooks-agent-storage";
 import { webhooksBuiltInGenerationRoutes } from "./routes/webhooks-built-in-generations";
+import { webhooksAutomationRoutes } from "./routes/webhooks-automation";
 import { webhooksClerkRoutes } from "./routes/webhooks-clerk";
 import { webhooksGithubRoutes } from "./routes/webhooks-github";
 import { webhooksStripeRoutes } from "./routes/webhooks-stripe";
@@ -217,6 +218,7 @@ export const ROUTES: readonly RouteEntry[] = [
   ...logsSearchRoutes,
   ...usageRoutes,
   ...userExportRoutes,
+  ...webhooksAutomationRoutes,
   ...webhooksClerkRoutes,
   ...webhooksBuiltInGenerationRoutes,
   ...webhooksGithubRoutes,

--- a/turbo/apps/api/src/signals/routes/__tests__/webhooks-automation.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/webhooks-automation.test.ts
@@ -1,0 +1,271 @@
+import { createHmac, randomUUID } from "node:crypto";
+
+import { agentRuns } from "@vm0/db/schema/agent-run";
+import { automations, automationTriggers } from "@vm0/db/schema/automation";
+import { chatMessages } from "@vm0/db/schema/chat-message";
+import { chatThreads } from "@vm0/db/schema/chat-thread";
+import { zeroRuns } from "@vm0/db/schema/zero-run";
+import { createStore } from "ccstate";
+import { eq } from "drizzle-orm";
+
+import { afterEach } from "vitest";
+
+import { createApp } from "../../../app-factory";
+import { testContext } from "../../../__tests__/test-helpers";
+import { mockOptionalEnv } from "../../../lib/env";
+import {
+  resetSecretKmsClientForTests,
+  setSecretKmsClientForTests,
+} from "../../services/crypto.utils";
+import { writeDb$ } from "../../external/db";
+import {
+  type SchedulesFixture,
+  deleteSchedulesScenario$,
+  seedSchedulesScenario$,
+} from "./helpers/zero-schedules";
+import { encryptSecretForTests } from "./helpers/encrypt-secret";
+import { fakeKmsClient } from "./helpers/fake-kms-client";
+import {
+  createFixtureTracker,
+  createZeroRouteMocks,
+} from "./helpers/zero-route-test";
+
+const context = testContext();
+const store = createStore();
+const mocks = createZeroRouteMocks(context);
+
+const SIGNATURE_HEADER = "x-vm0-signature-256";
+const WEBHOOK_SECRET = "automation-webhook-secret";
+
+afterEach(() => {
+  resetSecretKmsClientForTests();
+});
+
+interface AutomationFixture {
+  readonly schedules: SchedulesFixture;
+  readonly automationId: string;
+  readonly triggerId: string;
+  readonly threadId: string;
+  readonly token: string;
+}
+
+const trackSchedules = createFixtureTracker<SchedulesFixture>((fixture) => {
+  return store.set(deleteSchedulesScenario$, fixture, context.signal);
+});
+
+const trackAutomation = createFixtureTracker<AutomationFixture>(
+  async (fixture) => {
+    const db = store.set(writeDb$);
+    await db
+      .delete(automationTriggers)
+      .where(eq(automationTriggers.id, fixture.triggerId));
+    await db
+      .delete(automations)
+      .where(eq(automations.id, fixture.automationId));
+    await db.delete(chatThreads).where(eq(chatThreads.id, fixture.threadId));
+  },
+);
+
+function sign(body: string, secret: string = WEBHOOK_SECRET): string {
+  return `sha256=${createHmac("sha256", secret).update(body).digest("hex")}`;
+}
+
+async function seedAutomation(args?: {
+  readonly enabled?: boolean;
+}): Promise<AutomationFixture> {
+  mockOptionalEnv("RUNNER_DEFAULT_GROUP", "vm0/test");
+  context.mocks.s3.send.mockResolvedValue({});
+  setSecretKmsClientForTests(fakeKmsClient().client);
+
+  const schedules = await trackSchedules(
+    store.set(
+      seedSchedulesScenario$,
+      {
+        userName: "Automation Owner",
+        userEmail: "automation-owner@example.com",
+        schedules: [],
+      },
+      context.signal,
+    ),
+  );
+  mocks.clerk.session(schedules.userId, schedules.orgId);
+
+  const db = store.set(writeDb$);
+  const [thread] = await db
+    .insert(chatThreads)
+    .values({
+      userId: schedules.userId,
+      agentComposeId: schedules.composeId,
+      title: "automation thread",
+    })
+    .returning({ id: chatThreads.id });
+  if (!thread) {
+    throw new Error("seedAutomation: chat thread insert returned no row");
+  }
+
+  const [automation] = await db
+    .insert(automations)
+    .values({
+      orgId: schedules.orgId,
+      userId: schedules.userId,
+      name: "inbound-webhook",
+      instruction: "Summarize the incoming webhook event.",
+      agentId: schedules.composeId,
+      chatThreadId: thread.id,
+      interpreterKind: "webhook",
+      enabled: args?.enabled ?? true,
+    })
+    .returning({ id: automations.id });
+  if (!automation) {
+    throw new Error("seedAutomation: automation insert returned no row");
+  }
+
+  const token = `whk_${randomUUID().replace(/-/g, "")}`;
+  const [trigger] = await db
+    .insert(automationTriggers)
+    .values({
+      automationId: automation.id,
+      kind: "webhook",
+      webhookToken: token,
+      encryptedSecret: encryptSecretForTests(WEBHOOK_SECRET),
+    })
+    .returning({ id: automationTriggers.id });
+  if (!trigger) {
+    throw new Error("seedAutomation: trigger insert returned no row");
+  }
+
+  return await trackAutomation(
+    Promise.resolve({
+      schedules,
+      automationId: automation.id,
+      triggerId: trigger.id,
+      threadId: thread.id,
+      token,
+    }),
+  );
+}
+
+async function postWebhook(
+  token: string,
+  body: string,
+  headers: Record<string, string>,
+): Promise<{ readonly status: number; readonly text: string }> {
+  const app = createApp({ signal: context.signal });
+  const response = await app.request(`/api/automations/webhooks/${token}`, {
+    method: "POST",
+    headers: { "content-type": "application/json", ...headers },
+    body,
+  });
+  return { status: response.status, text: await response.text() };
+}
+
+describe("POST /api/automations/webhooks/:token", () => {
+  it("fires a signed webhook into a webhook-sourced run + chat message", async () => {
+    const fixture = await seedAutomation();
+    const body = JSON.stringify({ event: "ping", value: 42 });
+
+    const response = await postWebhook(fixture.token, body, {
+      [SIGNATURE_HEADER]: sign(body),
+      "x-custom-header": "header-value",
+    });
+
+    expect(response.status).toBe(200);
+
+    const db = store.set(writeDb$);
+    const [zeroRun] = await db
+      .select({
+        triggerSource: zeroRuns.triggerSource,
+        chatThreadId: zeroRuns.chatThreadId,
+      })
+      .from(zeroRuns)
+      .where(eq(zeroRuns.chatThreadId, fixture.threadId));
+    expect(zeroRun).toStrictEqual({
+      triggerSource: "webhook",
+      chatThreadId: fixture.threadId,
+    });
+
+    const [run] = await db
+      .select({
+        prompt: agentRuns.prompt,
+        appendSystemPrompt: agentRuns.appendSystemPrompt,
+      })
+      .from(agentRuns)
+      .innerJoin(zeroRuns, eq(agentRuns.id, zeroRuns.id))
+      .where(eq(zeroRuns.chatThreadId, fixture.threadId));
+    expect(run?.prompt).toBe("Summarize the incoming webhook event.");
+    // The webhook payload (headers + body) is rendered into the run context.
+    expect(run?.appendSystemPrompt).toContain(
+      "You are currently running inside: Webhook automation",
+    );
+    expect(run?.appendSystemPrompt).toContain('"event": "ping"');
+    expect(run?.appendSystemPrompt).toContain('"x-custom-header"');
+
+    // The instruction was posted as a user message bound to the run.
+    const messages = await db
+      .select({
+        content: chatMessages.content,
+        role: chatMessages.role,
+      })
+      .from(chatMessages)
+      .where(eq(chatMessages.chatThreadId, fixture.threadId));
+    expect(
+      messages.some((message) => {
+        return (
+          message.role === "user" &&
+          message.content === "Summarize the incoming webhook event."
+        );
+      }),
+    ).toBeTruthy();
+  });
+
+  it("rejects a payload with a bad signature", async () => {
+    const fixture = await seedAutomation();
+    const body = JSON.stringify({ event: "ping" });
+
+    const response = await postWebhook(fixture.token, body, {
+      [SIGNATURE_HEADER]: sign(body, "wrong-secret"),
+    });
+
+    expect(response.status).toBe(401);
+
+    const db = store.set(writeDb$);
+    const runs = await db
+      .select({ id: zeroRuns.id })
+      .from(zeroRuns)
+      .where(eq(zeroRuns.chatThreadId, fixture.threadId));
+    expect(runs).toHaveLength(0);
+  });
+
+  it("rejects a payload with no signature header", async () => {
+    const fixture = await seedAutomation();
+    const body = JSON.stringify({ event: "ping" });
+
+    const response = await postWebhook(fixture.token, body, {});
+
+    expect(response.status).toBe(401);
+  });
+
+  it("returns 404 for an unknown token", async () => {
+    await seedAutomation();
+    const body = JSON.stringify({ event: "ping" });
+
+    const response = await postWebhook(
+      `whk_${randomUUID().replace(/-/g, "")}`,
+      body,
+      { [SIGNATURE_HEADER]: sign(body) },
+    );
+
+    expect(response.status).toBe(404);
+  });
+
+  it("returns 404 for a disabled automation", async () => {
+    const fixture = await seedAutomation({ enabled: false });
+    const body = JSON.stringify({ event: "ping" });
+
+    const response = await postWebhook(fixture.token, body, {
+      [SIGNATURE_HEADER]: sign(body),
+    });
+
+    expect(response.status).toBe(404);
+  });
+});

--- a/turbo/apps/api/src/signals/routes/webhooks-automation.ts
+++ b/turbo/apps/api/src/signals/routes/webhooks-automation.ts
@@ -1,0 +1,69 @@
+import { command } from "ccstate";
+import { webhookAutomationInboundContract } from "@vm0/api-contracts/contracts/webhooks";
+
+import type { RouteEntry } from "../route";
+import { request$ } from "../context/hono";
+import { pathParamsOf } from "../context/request";
+import { now } from "../external/time";
+import {
+  dispatchAutomationWebhook$,
+  SIGNATURE_HEADER,
+} from "../services/webhooks-automation.service";
+
+const inboundPathParams$ = pathParamsOf(webhookAutomationInboundContract.post);
+
+function jsonError(message: string, status: 401 | 404 | 429): Response {
+  return Response.json({ error: message }, { status });
+}
+
+const postAutomationWebhook$ = command(
+  async ({ get, set }, signal: AbortSignal): Promise<Response> => {
+    const apiStartTime = now();
+    const params = get(inboundPathParams$);
+    const request = get(request$);
+
+    const headers = Object.fromEntries(request.raw.headers.entries());
+    const rawBody = await request.text();
+    signal.throwIfAborted();
+
+    const result = await set(
+      dispatchAutomationWebhook$,
+      {
+        token: params.token,
+        signature: request.raw.headers.get(SIGNATURE_HEADER),
+        headers,
+        rawBody,
+        apiStartTime,
+      },
+      signal,
+    );
+    signal.throwIfAborted();
+
+    switch (result.kind) {
+      case "ok": {
+        return new Response("OK", { status: 200 });
+      }
+      case "not_found": {
+        return jsonError("Not found", 404);
+      }
+      case "unauthorized": {
+        return jsonError("Invalid signature", 401);
+      }
+      case "rate_limited": {
+        return jsonError("Too many requests", 429);
+      }
+      case "run_error": {
+        // The caller authenticated; surface the failure to start the run as a
+        // rate-limit-style 429 so retries are throttled rather than hammering.
+        return jsonError(result.message, 429);
+      }
+    }
+  },
+);
+
+export const webhooksAutomationRoutes: readonly RouteEntry[] = [
+  {
+    route: webhookAutomationInboundContract.post,
+    handler: postAutomationWebhook$,
+  },
+];

--- a/turbo/apps/api/src/signals/routes/zero-chat-messages.ts
+++ b/turbo/apps/api/src/signals/routes/zero-chat-messages.ts
@@ -2120,6 +2120,46 @@ export async function postScheduleUserMessage(params: {
   await publishThreadListChanged(params.userId);
 }
 
+/**
+ * Post a webhook automation run's prompt as a user chat message into its linked
+ * thread and publish the realtime signals so the client surfaces the run.
+ * Generalizes `postScheduleUserMessage` for the events-first automation path:
+ * the prompt is the automation `instruction`, carrying no schedule snapshot.
+ * Like the schedule path it preserves the thread draft (the post is not
+ * user-initiated typing) and is awaited so the inbound route sees it persisted.
+ */
+export async function postAutomationUserMessage(params: {
+  readonly db: Db;
+  readonly threadId: string;
+  readonly userId: string;
+  readonly runId: string;
+  readonly prompt: string;
+  readonly appendQueueMarker: boolean;
+}): Promise<void> {
+  await appendAssociatedUserMessage({
+    db: params.db,
+    threadId: params.threadId,
+    userId: params.userId,
+    prompt: params.prompt,
+    runId: params.runId,
+    attachFiles: undefined,
+    clientMessageId: undefined,
+    revokesMessageId: undefined,
+    generationTemplate: undefined,
+    appendQueueMarker: params.appendQueueMarker,
+    clearDraft: false,
+  });
+  await publishUserSignal(
+    [params.userId],
+    `chatThreadMessageCreated:${params.threadId}`,
+  );
+  await publishUserSignal(
+    [params.userId],
+    `chatThreadRunCreated:${params.threadId}`,
+  );
+  await publishThreadListChanged(params.userId);
+}
+
 function scheduleCreatedChatRunSideEffects(params: {
   readonly db: Db;
   readonly body: NormalSendBody;

--- a/turbo/apps/api/src/signals/services/automations/time-interpreter.ts
+++ b/turbo/apps/api/src/signals/services/automations/time-interpreter.ts
@@ -42,30 +42,48 @@ interface RunCallback {
 }
 
 /**
+ * The run-identity metadata an interpreter attaches to its produced run. The
+ * time interpreter tags the originating schedule; the webhook interpreter tags
+ * the originating automation. Open for the run-create layer to thread either
+ * into `zeroRunMetadata`.
+ */
+export type ZeroRunInputMetadata =
+  | { readonly scheduleId: string }
+  | { readonly automationId: string };
+
+/**
  * The automation-derived portion of a Zero agent-run request: the parts an
  * interpreter constructs from the Automation definition (and trigger event).
  * Runtime concerns resolved from live state (model pin, provider admission) are
- * layered on by the caller, not by the interpreter.
+ * layered on by the caller, not by the interpreter. `Metadata` is the
+ * interpreter-specific run-identity shape (schedule vs automation).
  */
-export interface ZeroRunInput {
+export interface ZeroRunInput<
+  Metadata extends ZeroRunInputMetadata = ZeroRunInputMetadata,
+> {
   readonly prompt: string;
   readonly agentId: string;
   readonly chatThreadId: string;
   readonly appendSystemPrompt: string;
   readonly callbacks: readonly RunCallback[];
-  readonly zeroRunMetadata: { readonly scheduleId: string };
+  readonly zeroRunMetadata: Metadata;
 }
 
 /**
- * Builds the agent-run input for an Automation. Async and trigger-event aware
- * so it can later accommodate event triggers; the time interpreter ignores the
- * event payload beyond its identity.
+ * Builds the agent-run input for an Automation from its definition and a trigger
+ * event. Generic over both the automation projection an interpreter consumes
+ * (schedule-shaped for time, automation-shaped for webhook) and the trigger
+ * event, so each interpreter stays decoupled from the others' shapes.
  */
-export interface AutomationInterpreter<TriggerEvent> {
+export interface AutomationInterpreter<
+  AutomationProjection,
+  TriggerEvent,
+  Metadata extends ZeroRunInputMetadata = ZeroRunInputMetadata,
+> {
   interpret(
-    automation: Automation,
+    automation: AutomationProjection,
     triggerEvent: TriggerEvent,
-  ): Promise<ZeroRunInput>;
+  ): Promise<ZeroRunInput<Metadata>>;
 }
 
 /**
@@ -172,11 +190,15 @@ function buildCallbacks(automation: Automation): RunCallback[] {
  * its linked thread. Behavior-preserving extraction of the run-input
  * construction that used to be inline in `runScheduleNow$`.
  */
-export class TimeInterpreter implements AutomationInterpreter<TimeTriggerEvent> {
+export class TimeInterpreter implements AutomationInterpreter<
+  Automation,
+  TimeTriggerEvent,
+  { readonly scheduleId: string }
+> {
   interpret(
     automation: Automation,
     _triggerEvent: TimeTriggerEvent,
-  ): Promise<ZeroRunInput> {
+  ): Promise<ZeroRunInput<{ readonly scheduleId: string }>> {
     return Promise.resolve({
       prompt: automation.prompt,
       agentId: automation.agentId,

--- a/turbo/apps/api/src/signals/services/automations/webhook-interpreter.ts
+++ b/turbo/apps/api/src/signals/services/automations/webhook-interpreter.ts
@@ -1,0 +1,96 @@
+import { randomBytes } from "node:crypto";
+
+import { internalApiBaseUrl } from "../../../lib/internal-api-url";
+import type { AutomationInterpreter, ZeroRunInput } from "./time-interpreter";
+
+/**
+ * Domain view of a webhook Automation as the interpreter sees it: a thin
+ * projection of an `automations` row down to the fields needed to build an
+ * agent-run input. Unlike the schedule-shaped `Automation`, a webhook
+ * automation carries no recurrence; its prompt is the user `instruction` and
+ * the trigger event supplies the dynamic payload.
+ */
+export interface WebhookAutomation {
+  readonly id: string;
+  readonly agentId: string;
+  readonly chatThreadId: string;
+  readonly instruction: string;
+}
+
+/**
+ * Trigger event for a webhook Automation: the inbound request reduced to the
+ * parts the interpreter renders into the run context. `headers` is the request
+ * header map; `body` is the parsed JSON payload (an object/array/primitive) or
+ * the raw string when the body is not JSON.
+ */
+export interface WebhookTriggerEvent {
+  readonly headers: Record<string, string>;
+  readonly body: unknown;
+}
+
+type WebhookRunMetadata = { readonly automationId: string };
+
+function generateCallbackSecret(): string {
+  return randomBytes(32).toString("hex");
+}
+
+/**
+ * Render the webhook payload (headers + body) as a single fenced JSON block so
+ * the agent can read the trigger that fired it. v1 does no templating: the
+ * payload is passed through verbatim as run context (YAGNI — no JSONPath).
+ */
+function buildWebhookContextPrompt(event: WebhookTriggerEvent): string {
+  const payload = JSON.stringify(
+    { headers: event.headers, body: event.body },
+    null,
+    2,
+  );
+  return [
+    "# Current Integration",
+    "You are currently running inside: Webhook automation",
+    "",
+    "This automation was fired by an inbound webhook. The request that triggered it is below as JSON (request headers and body).",
+    "",
+    "```json",
+    payload,
+    "```",
+    "",
+    "This run is linked to a web chat thread. Everything you output is automatically shown to the user as a chat message in that thread.",
+  ].join("\n");
+}
+
+/**
+ * Webhook Automation interpreter: turns an inbound webhook request into an
+ * agent run. The prompt is the automation's user `instruction`; the request
+ * payload is placed into the run context as a fenced JSON block. The chat
+ * callback renders the run as a web-chat turn in the linked thread (mirroring
+ * the time interpreter), and the run is tagged with the originating automation.
+ */
+export class WebhookInterpreter implements AutomationInterpreter<
+  WebhookAutomation,
+  WebhookTriggerEvent,
+  WebhookRunMetadata
+> {
+  interpret(
+    automation: WebhookAutomation,
+    triggerEvent: WebhookTriggerEvent,
+  ): Promise<ZeroRunInput<WebhookRunMetadata>> {
+    return Promise.resolve({
+      prompt: automation.instruction,
+      agentId: automation.agentId,
+      chatThreadId: automation.chatThreadId,
+      appendSystemPrompt: buildWebhookContextPrompt(triggerEvent),
+      callbacks: [
+        {
+          url: `${internalApiBaseUrl()}/api/internal/callbacks/chat`,
+          secret: generateCallbackSecret(),
+          payload: {
+            threadId: automation.chatThreadId,
+            agentId: automation.agentId,
+          },
+        },
+      ],
+      zeroRunMetadata: { automationId: automation.id },
+    });
+  }
+}

--- a/turbo/apps/api/src/signals/services/webhooks-automation.service.ts
+++ b/turbo/apps/api/src/signals/services/webhooks-automation.service.ts
@@ -1,0 +1,216 @@
+import { createHmac, timingSafeEqual } from "node:crypto";
+
+import { command } from "ccstate";
+import { automations, automationTriggers } from "@vm0/db/schema/automation";
+import { agentRuns } from "@vm0/db/schema/agent-run";
+import { zeroRuns } from "@vm0/db/schema/zero-run";
+import { and, count, eq, gte } from "drizzle-orm";
+
+import { logger } from "../../lib/log";
+import { writeDb$ } from "../external/db";
+import { safeJsonParse, settle } from "../utils";
+import { decryptStoredSecretValue } from "./crypto.utils";
+import { createZeroRun$ } from "./zero-runs-create.service";
+import { postAutomationUserMessage } from "../routes/zero-chat-messages";
+import {
+  WebhookInterpreter,
+  type WebhookAutomation,
+  type WebhookTriggerEvent,
+} from "./automations/webhook-interpreter";
+
+const log = logger("api:webhooks:automation");
+
+/**
+ * Per-automation inbound rate limit: at most this many webhook runs may be
+ * created for one automation's linked thread within the rolling window. This is
+ * a minimal, bounded throttle (no external infra) guarding a billable endpoint;
+ * it counts recent `zero_runs` rather than reserving a quota.
+ */
+const RATE_LIMIT_WINDOW_MS = 60_000;
+const RATE_LIMIT_MAX_RUNS = 10;
+
+/** The HMAC signature header, `sha256=<hex>` (mirrors the GitHub webhook). */
+export const SIGNATURE_HEADER = "x-vm0-signature-256";
+
+/**
+ * Outcome of an inbound webhook dispatch, mapped to an HTTP response by the
+ * route. `not_found` collapses missing tokens and disabled automations so an
+ * unguessable token leaks nothing; `unauthorized` covers missing or mismatched
+ * signatures; `rate_limited` is the bounded per-automation throttle.
+ */
+type AutomationWebhookResult =
+  | { readonly kind: "ok"; readonly runId: string }
+  | { readonly kind: "not_found" }
+  | { readonly kind: "unauthorized" }
+  | { readonly kind: "rate_limited" }
+  | { readonly kind: "run_error"; readonly message: string };
+
+/**
+ * Verify an HMAC-SHA256 signature (`sha256=<hex>`) of the raw body against the
+ * automation's stored secret. `timingSafeEqual` throws when the buffers differ
+ * in length, so the comparison runs inside `settle` and a throw maps to a
+ * non-match (the GitHub webhook verify pattern).
+ */
+async function verifySignature(args: {
+  readonly secret: string;
+  readonly signature: string;
+  readonly body: string;
+}): Promise<boolean> {
+  const expected = `sha256=${createHmac("sha256", args.secret)
+    .update(args.body)
+    .digest("hex")}`;
+  const result = await settle(
+    (async (): Promise<boolean> => {
+      await Promise.resolve();
+      return timingSafeEqual(
+        Buffer.from(args.signature),
+        Buffer.from(expected),
+      );
+    })(),
+  );
+  return result.ok ? result.value : false;
+}
+
+/**
+ * Dispatch an inbound webhook: resolve the automation by trigger token, verify
+ * the HMAC signature, enforce the per-automation rate limit, then interpret the
+ * request into an agent run via `WebhookInterpreter` and render it into the
+ * linked chat thread. A write `command`: it creates a billable run.
+ */
+export const dispatchAutomationWebhook$ = command(
+  async (
+    { set },
+    args: {
+      readonly token: string;
+      readonly signature: string | null;
+      readonly headers: Record<string, string>;
+      readonly rawBody: string;
+      readonly apiStartTime: number;
+    },
+    signal: AbortSignal,
+  ): Promise<AutomationWebhookResult> => {
+    const db = set(writeDb$);
+
+    const [row] = await db
+      .select({
+        automationId: automations.id,
+        agentId: automations.agentId,
+        chatThreadId: automations.chatThreadId,
+        instruction: automations.instruction,
+        orgId: automations.orgId,
+        userId: automations.userId,
+        enabled: automations.enabled,
+        encryptedSecret: automationTriggers.encryptedSecret,
+      })
+      .from(automationTriggers)
+      .innerJoin(
+        automations,
+        eq(automationTriggers.automationId, automations.id),
+      )
+      .where(eq(automationTriggers.webhookToken, args.token))
+      .limit(1);
+    signal.throwIfAborted();
+
+    if (!row || !row.enabled) {
+      return { kind: "not_found" };
+    }
+
+    // Signature verification is required: a trigger without a stored secret can
+    // never authenticate a caller, so it is unreachable rather than open.
+    if (!row.encryptedSecret || !args.signature) {
+      return { kind: "unauthorized" };
+    }
+
+    const secret = await decryptStoredSecretValue(row.encryptedSecret);
+    signal.throwIfAborted();
+    const verified = await verifySignature({
+      secret,
+      signature: args.signature,
+      body: args.rawBody,
+    });
+    signal.throwIfAborted();
+    if (!verified) {
+      return { kind: "unauthorized" };
+    }
+
+    const windowStart = new Date(args.apiStartTime - RATE_LIMIT_WINDOW_MS);
+    const [recent] = await db
+      .select({ value: count() })
+      .from(zeroRuns)
+      .innerJoin(agentRuns, eq(zeroRuns.id, agentRuns.id))
+      .where(
+        and(
+          eq(zeroRuns.chatThreadId, row.chatThreadId),
+          eq(zeroRuns.triggerSource, "webhook"),
+          gte(agentRuns.createdAt, windowStart),
+        ),
+      );
+    signal.throwIfAborted();
+    if ((recent?.value ?? 0) >= RATE_LIMIT_MAX_RUNS) {
+      log.warn("Automation webhook rate limited", {
+        automationId: row.automationId,
+      });
+      return { kind: "rate_limited" };
+    }
+
+    const automation: WebhookAutomation = {
+      id: row.automationId,
+      agentId: row.agentId,
+      chatThreadId: row.chatThreadId,
+      instruction: row.instruction,
+    };
+    const triggerEvent: WebhookTriggerEvent = {
+      headers: args.headers,
+      body: safeJsonParse(args.rawBody) ?? args.rawBody,
+    };
+    const runInput = await new WebhookInterpreter().interpret(
+      automation,
+      triggerEvent,
+    );
+    signal.throwIfAborted();
+
+    const result = await set(
+      createZeroRun$,
+      {
+        auth: {
+          orgId: row.orgId,
+          orgRole: "member",
+          userId: row.userId,
+          tokenType: "session",
+        },
+        body: {
+          prompt: runInput.prompt,
+          agentId: runInput.agentId,
+        },
+        apiStartTime: args.apiStartTime,
+        triggerSource: "webhook",
+        chatThreadId: runInput.chatThreadId,
+        appendSystemPrompt: runInput.appendSystemPrompt,
+        callbacks: runInput.callbacks,
+        zeroRunMetadata: runInput.zeroRunMetadata,
+      },
+      signal,
+    );
+    signal.throwIfAborted();
+
+    if (result.status !== 201) {
+      log.error("Automation webhook run creation failed", {
+        automationId: row.automationId,
+        status: result.status,
+      });
+      return { kind: "run_error", message: "Failed to start automation run" };
+    }
+
+    await postAutomationUserMessage({
+      db,
+      threadId: runInput.chatThreadId,
+      userId: row.userId,
+      runId: result.body.runId,
+      prompt: runInput.prompt,
+      appendQueueMarker: result.body.status === "queued",
+    });
+    signal.throwIfAborted();
+
+    return { kind: "ok", runId: result.body.runId };
+  },
+);

--- a/turbo/apps/api/src/signals/services/zero-runs-create.service.ts
+++ b/turbo/apps/api/src/signals/services/zero-runs-create.service.ts
@@ -101,6 +101,7 @@ interface RunCallback {
 interface ZeroRunMetadata {
   readonly triggerAgentId?: string;
   readonly scheduleId?: string;
+  readonly automationId?: string;
 }
 
 function forbidden(message: string) {

--- a/turbo/apps/api/src/signals/services/zero-schedules.service.ts
+++ b/turbo/apps/api/src/signals/services/zero-schedules.service.ts
@@ -1154,8 +1154,11 @@ export const runScheduleNow$ = command(
     // Depend on the interpreter seam (interface), keyed off the Automation's
     // interpreterKind. Only the time-based interpreter exists today.
     const automation: Automation = scheduleToAutomation(schedule);
-    const interpreter: AutomationInterpreter<TimeTriggerEvent> =
-      new TimeInterpreter();
+    const interpreter: AutomationInterpreter<
+      Automation,
+      TimeTriggerEvent,
+      { readonly scheduleId: string }
+    > = new TimeInterpreter();
     const runInput = await interpreter.interpret(automation, {
       scheduleId: schedule.id,
     });

--- a/turbo/apps/platform/src/signals/zero-page/log-types.ts
+++ b/turbo/apps/platform/src/signals/zero-page/log-types.ts
@@ -18,6 +18,7 @@ export const TRIGGER_SOURCE_LABELS: Readonly<Record<TriggerSource, string>> = {
   github: "GitHub",
   cli: "CLI",
   agent: "Agent",
+  webhook: "Webhook",
 };
 
 /**

--- a/turbo/apps/web/api-backend-rewrites.js
+++ b/turbo/apps/web/api-backend-rewrites.js
@@ -60,6 +60,10 @@ const AUTOMATIONS_DISABLE_REWRITE_SOURCE = "/api/automations/:name/disable";
 const AUTOMATIONS_DISABLE_PATH_RE = /^\/api\/automations\/[^/]+\/disable$/;
 const AUTOMATIONS_ENABLE_REWRITE_SOURCE = "/api/automations/:name/enable";
 const AUTOMATIONS_ENABLE_PATH_RE = /^\/api\/automations\/[^/]+\/enable$/;
+const AUTOMATIONS_WEBHOOK_INBOUND_REWRITE_SOURCE =
+  "/api/automations/webhooks/:token";
+const AUTOMATIONS_WEBHOOK_INBOUND_PATH_RE =
+  /^\/api\/automations\/webhooks\/[^/]+$/;
 const ZERO_SKILLS_BY_NAME_REWRITE_SOURCE = "/api/zero/skills/:name";
 const ZERO_SKILLS_BY_NAME_PATH_RE = /^\/api\/zero\/skills\/[^/]+$/;
 const ZERO_ME_MODEL_PROVIDERS_REWRITE_SOURCE = "/api/zero/me/model-providers";
@@ -1119,6 +1123,11 @@ export const API_BACKEND_REWRITES = [
     ZERO_SCHEDULES_ENABLE_PATH_RE,
   ],
   ["/api/automations", "/api/automations"],
+  [
+    AUTOMATIONS_WEBHOOK_INBOUND_REWRITE_SOURCE,
+    "/api/automations/webhooks/:token",
+    AUTOMATIONS_WEBHOOK_INBOUND_PATH_RE,
+  ],
   [AUTOMATIONS_RUN_REWRITE_SOURCE, "/api/automations/run"],
   [
     AUTOMATIONS_DISABLE_REWRITE_SOURCE,

--- a/turbo/packages/api-contracts/src/contracts/logs.ts
+++ b/turbo/packages/api-contracts/src/contracts/logs.ts
@@ -49,6 +49,7 @@ export const triggerSourceSchema = z.enum([
   "github",
   "cli",
   "agent",
+  "webhook",
 ]);
 
 export type TriggerSource = z.infer<typeof triggerSourceSchema>;

--- a/turbo/packages/api-contracts/src/contracts/webhooks.ts
+++ b/turbo/packages/api-contracts/src/contracts/webhooks.ts
@@ -72,6 +72,34 @@ export const webhookStripeContract = c.router({
   },
 });
 
+/**
+ * Automation inbound webhook contract for
+ * /api/automations/webhooks/:token.
+ *
+ * No user session: the unguessable `:token` identifies the automation trigger,
+ * and a required HMAC signature over the raw body authenticates the caller. A
+ * correctly-signed POST fires the linked automation as an agent run. The raw
+ * body is taken as a string so the signature is verified against the exact
+ * bytes received (mirrors the GitHub/Stripe webhook contracts).
+ */
+export const webhookAutomationInboundContract = c.router({
+  post: {
+    method: "POST",
+    path: "/api/automations/webhooks/:token",
+    pathParams: z.object({
+      token: z.string().min(1),
+    }),
+    body: c.type<string>(),
+    responses: {
+      200: thirdPartyWebhookOkSchema,
+      401: thirdPartyWebhookErrorSchema,
+      404: thirdPartyWebhookErrorSchema,
+      429: thirdPartyWebhookErrorSchema,
+    },
+    summary: "Handle inbound automation webhooks",
+  },
+});
+
 export const webhookBuiltInGenerationFalContract = c.router({
   post: {
     method: "POST",
@@ -649,6 +677,8 @@ export type WebhookEventsContract = typeof webhookEventsContract;
 export type WebhookClerkContract = typeof webhookClerkContract;
 export type WebhookGithubContract = typeof webhookGithubContract;
 export type WebhookStripeContract = typeof webhookStripeContract;
+export type WebhookAutomationInboundContract =
+  typeof webhookAutomationInboundContract;
 export type WebhookBuiltInGenerationFalContract =
   typeof webhookBuiltInGenerationFalContract;
 export type WebhookBuiltInGenerationBytePlusContract =


### PR DESCRIPTION
Closes #16754. Part of #16616. Stacked on #16774.

Inbound `POST /api/automations/webhooks/:token`: token lookup -> required HMAC-SHA256 verify (github/stripe pattern, timing-safe) -> per-automation rate limit -> owner-derived AuthContext -> `WebhookInterpreter` (prompt=instruction, payload as fenced JSON context) -> `createZeroRun$` (triggerSource "webhook", zeroRunMetadata {automationId}, chatThreadId) -> rendered into the linked chat thread. Generalizes the `AutomationInterpreter` interface so schedule/webhook shapes decouple (TimeInterpreter behavior-preserving). Adds "webhook" to TriggerSource + automationId to ZeroRunMetadata. 5 new route tests + 128 regression green. Note: automationId is threaded through the run but not yet a dedicated zero_runs column (linkage via triggerSource+thread).