### PR TITLE
feat(api): manage webhook automations (create/list/delete) behind switch

### DIFF
--- a/turbo/apps/api/src/signals/route.ts
+++ b/turbo/apps/api/src/signals/route.ts
@@ -62,6 +62,7 @@ import { webhooksAgentFirewallAuthRoutes } from "./routes/webhooks-agent-firewal
 import { webhooksAgentHealthUsageTelemetryRoutes } from "./routes/webhooks-agent-health-usage-telemetry";
 import { webhooksAgentStorageRoutes } from "./routes/webhooks-agent-storage";
 import { webhooksBuiltInGenerationRoutes } from "./routes/webhooks-built-in-generations";
+import { webhookAutomationsRoutes } from "./routes/webhook-automations";
 import { webhooksAutomationRoutes } from "./routes/webhooks-automation";
 import { webhooksClerkRoutes } from "./routes/webhooks-clerk";
 import { webhooksGithubRoutes } from "./routes/webhooks-github";
@@ -197,6 +198,10 @@ export const ROUTES: readonly RouteEntry[] = [
   },
   ...authMeRoutes,
   ...automationsRoutes,
+  // Webhook-automation management (create/list/delete) on the new tables. Listed
+  // before the inbound webhook route so the management collection/by-id paths
+  // resolve ahead of the catch-all `:token` dispatch.
+  ...webhookAutomationsRoutes,
   ...cliAuthRoutes,
   ...cliAuthTestRoutes,
   ...desktopAuthRoutes,

--- a/turbo/apps/api/src/signals/routes/__tests__/webhook-automations.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/webhook-automations.test.ts
@@ -1,0 +1,447 @@
+import { createHmac } from "node:crypto";
+
+import { apiErrorSchema } from "@vm0/api-contracts/contracts/errors";
+import {
+  webhookAutomationCreateResponseSchema,
+  webhookAutomationListResponseSchema,
+} from "@vm0/api-contracts/contracts/webhook-automations";
+import { automations, automationTriggers } from "@vm0/db/schema/automation";
+import { chatThreads } from "@vm0/db/schema/chat-thread";
+import { userFeatureSwitches } from "@vm0/db/schema/user-feature-switches";
+import { zeroRuns } from "@vm0/db/schema/zero-run";
+import { FeatureSwitchKey } from "@vm0/connectors/feature-switch-key";
+import { createStore } from "ccstate";
+import { eq } from "drizzle-orm";
+import { afterEach } from "vitest";
+
+import { testContext } from "../../../__tests__/test-helpers";
+import { createApp } from "../../../app-factory";
+import { mockOptionalEnv } from "../../../lib/env";
+import {
+  resetSecretKmsClientForTests,
+  setSecretKmsClientForTests,
+} from "../../services/crypto.utils";
+import { writeDb$ } from "../../external/db";
+import {
+  type SchedulesFixture,
+  deleteSchedulesScenario$,
+  seedSchedulesScenario$,
+} from "./helpers/zero-schedules";
+import { decryptSecretForTests } from "./helpers/encrypt-secret";
+import { fakeKmsClient } from "./helpers/fake-kms-client";
+import {
+  createFixtureTracker,
+  createZeroRouteMocks,
+} from "./helpers/zero-route-test";
+
+const context = testContext();
+const store = createStore();
+const mocks = createZeroRouteMocks(context);
+
+const SESSION_HEADERS = { authorization: "Bearer clerk-session" } as const;
+const SIGNATURE_HEADER = "x-vm0-signature-256";
+
+afterEach(() => {
+  resetSecretKmsClientForTests();
+});
+
+const trackSchedules = createFixtureTracker<SchedulesFixture>((fixture) => {
+  return store.set(deleteSchedulesScenario$, fixture, context.signal);
+});
+
+// Webhook automations created through the API are not part of the schedule
+// fixture, so delete them by their (orgId, userId) scope after each test. The
+// trigger rows cascade with the automation; the linked chat threads are removed
+// explicitly.
+const trackCreatedAutomations = createFixtureTracker<SchedulesFixture>(
+  async (fixture) => {
+    const db = store.set(writeDb$);
+    const rows = await db
+      .select({ id: automations.id, chatThreadId: automations.chatThreadId })
+      .from(automations)
+      .where(eq(automations.orgId, fixture.orgId));
+    for (const row of rows) {
+      await db.delete(automations).where(eq(automations.id, row.id));
+      await db.delete(chatThreads).where(eq(chatThreads.id, row.chatThreadId));
+    }
+  },
+);
+
+interface TestApiResponse {
+  readonly status: number;
+  readonly body: unknown;
+}
+
+async function requestJson(
+  path: string,
+  init: RequestInit,
+): Promise<TestApiResponse> {
+  const app = createApp({ signal: context.signal });
+  const response = await app.request(path, init);
+  return { status: response.status, body: await response.json() };
+}
+
+async function requestStatus(path: string, init: RequestInit): Promise<number> {
+  const app = createApp({ signal: context.signal });
+  const response = await app.request(path, init);
+  return response.status;
+}
+
+function jsonInit(method: string, body: unknown): RequestInit {
+  return {
+    method,
+    headers: { ...SESSION_HEADERS, "content-type": "application/json" },
+    body: JSON.stringify(body),
+  };
+}
+
+async function seedFixture(): Promise<SchedulesFixture> {
+  mockOptionalEnv("RUNNER_DEFAULT_GROUP", "vm0/test");
+  context.mocks.s3.send.mockResolvedValue({});
+  setSecretKmsClientForTests(fakeKmsClient().client);
+  const fixture = await trackSchedules(
+    store.set(seedSchedulesScenario$, { schedules: [] }, context.signal),
+  );
+  await trackCreatedAutomations(Promise.resolve(fixture));
+  mocks.clerk.session(fixture.userId, fixture.orgId);
+  return fixture;
+}
+
+async function enableAutomations(fixture: SchedulesFixture): Promise<void> {
+  const db = store.set(writeDb$);
+  await db.insert(userFeatureSwitches).values({
+    orgId: fixture.orgId,
+    userId: fixture.userId,
+    switches: { [FeatureSwitchKey.ZeroAutomations]: true },
+  });
+}
+
+function expectErrorCode(response: TestApiResponse): string {
+  return apiErrorSchema.parse(response.body).error.code;
+}
+
+describe("Webhook automations management API", () => {
+  it("creates a webhook automation, returns the url + secret once, and persists rows", async () => {
+    const fixture = await seedFixture();
+    await enableAutomations(fixture);
+
+    const response = await requestJson(
+      "/api/automations/webhooks",
+      jsonInit("POST", {
+        name: "deploy-alerts",
+        instruction: "Summarize the incoming deploy event.",
+        description: "On deploy",
+        agentId: fixture.composeId,
+      }),
+    );
+    expect(response.status).toBe(201);
+
+    const created = webhookAutomationCreateResponseSchema.parse(response.body);
+    expect(created.secret).toMatch(/^[0-9a-f]{64}$/);
+    expect(created.automation.name).toBe("deploy-alerts");
+    expect(created.automation.instruction).toBe(
+      "Summarize the incoming deploy event.",
+    );
+    expect(created.automation.enabled).toBeTruthy();
+    expect(created.automation.webhookToken).toMatch(/^whk_[0-9a-f]{48}$/);
+    expect(created.automation.webhookUrl).toBe(
+      `http://localhost:3000/api/automations/webhooks/${created.automation.webhookToken}`,
+    );
+
+    // The automation row persists on the new table with the webhook interpreter.
+    const db = store.set(writeDb$);
+    const [automationRow] = await db
+      .select({
+        orgId: automations.orgId,
+        userId: automations.userId,
+        name: automations.name,
+        instruction: automations.instruction,
+        interpreterKind: automations.interpreterKind,
+        enabled: automations.enabled,
+        chatThreadId: automations.chatThreadId,
+      })
+      .from(automations)
+      .where(eq(automations.id, created.automation.id));
+    expect(automationRow).toStrictEqual({
+      orgId: fixture.orgId,
+      userId: fixture.userId,
+      name: "deploy-alerts",
+      instruction: "Summarize the incoming deploy event.",
+      interpreterKind: "webhook",
+      enabled: true,
+      chatThreadId: created.automation.chatThreadId,
+    });
+
+    // A server-created chat thread is linked to the automation's agent.
+    const [thread] = await db
+      .select({
+        userId: chatThreads.userId,
+        agentComposeId: chatThreads.agentComposeId,
+      })
+      .from(chatThreads)
+      .where(eq(chatThreads.id, created.automation.chatThreadId));
+    expect(thread).toStrictEqual({
+      userId: fixture.userId,
+      agentComposeId: fixture.composeId,
+    });
+
+    // The trigger row carries the token and the ENCRYPTED secret — the returned
+    // plaintext secret is never persisted as-is, but decrypts back to it.
+    const [trigger] = await db
+      .select({
+        kind: automationTriggers.kind,
+        webhookToken: automationTriggers.webhookToken,
+        encryptedSecret: automationTriggers.encryptedSecret,
+      })
+      .from(automationTriggers)
+      .where(eq(automationTriggers.automationId, created.automation.id));
+    expect(trigger?.kind).toBe("webhook");
+    expect(trigger?.webhookToken).toBe(created.automation.webhookToken);
+    expect(trigger?.encryptedSecret).not.toBeNull();
+    expect(trigger?.encryptedSecret).not.toContain(created.secret);
+    expect(decryptSecretForTests(trigger!.encryptedSecret!)).toBe(
+      created.secret,
+    );
+  });
+
+  it("links an existing owned chat thread when chatThreadId is supplied", async () => {
+    const fixture = await seedFixture();
+    await enableAutomations(fixture);
+
+    const db = store.set(writeDb$);
+    const [thread] = await db
+      .insert(chatThreads)
+      .values({
+        userId: fixture.userId,
+        agentComposeId: fixture.composeId,
+        title: "existing thread",
+      })
+      .returning({ id: chatThreads.id });
+
+    const response = await requestJson(
+      "/api/automations/webhooks",
+      jsonInit("POST", {
+        name: "linked",
+        instruction: "Handle it.",
+        agentId: fixture.composeId,
+        chatThreadId: thread!.id,
+      }),
+    );
+    expect(response.status).toBe(201);
+    const created = webhookAutomationCreateResponseSchema.parse(response.body);
+    expect(created.automation.chatThreadId).toBe(thread!.id);
+  });
+
+  it("rejects a chat thread that is not owned by the caller", async () => {
+    const fixture = await seedFixture();
+    await enableAutomations(fixture);
+
+    const db = store.set(writeDb$);
+    const [thread] = await db
+      .insert(chatThreads)
+      .values({
+        userId: "user_someone_else",
+        agentComposeId: fixture.composeId,
+        title: "foreign thread",
+      })
+      .returning({ id: chatThreads.id });
+
+    const response = await requestJson(
+      "/api/automations/webhooks",
+      jsonInit("POST", {
+        name: "bad-link",
+        instruction: "Handle it.",
+        agentId: fixture.composeId,
+        chatThreadId: thread!.id,
+      }),
+    );
+    expect(response.status).toBe(400);
+    expect(expectErrorCode(response)).toBe("BAD_REQUEST");
+
+    await db.delete(chatThreads).where(eq(chatThreads.id, thread!.id));
+  });
+
+  it("returns 404 when the target agent is not visible", async () => {
+    const fixture = await seedFixture();
+    await enableAutomations(fixture);
+
+    const response = await requestJson(
+      "/api/automations/webhooks",
+      jsonInit("POST", {
+        name: "no-agent",
+        instruction: "Handle it.",
+        agentId: "00000000-0000-0000-0000-000000000000",
+      }),
+    );
+    expect(response.status).toBe(404);
+    expect(expectErrorCode(response)).toBe("NOT_FOUND");
+  });
+
+  it("lists webhook automations without the secret", async () => {
+    const fixture = await seedFixture();
+    await enableAutomations(fixture);
+
+    const created = webhookAutomationCreateResponseSchema.parse(
+      (
+        await requestJson(
+          "/api/automations/webhooks",
+          jsonInit("POST", {
+            name: "listed",
+            instruction: "Summarize.",
+            agentId: fixture.composeId,
+          }),
+        )
+      ).body,
+    );
+
+    const listResponse = await requestJson("/api/automations/webhooks", {
+      method: "GET",
+      headers: SESSION_HEADERS,
+    });
+    expect(listResponse.status).toBe(200);
+    const list = webhookAutomationListResponseSchema.parse(listResponse.body);
+    expect(list.automations).toHaveLength(1);
+    const [item] = list.automations;
+    expect(item?.id).toBe(created.automation.id);
+    expect(item?.webhookToken).toBe(created.automation.webhookToken);
+    expect(item?.webhookUrl).toBe(created.automation.webhookUrl);
+    // The secret is never present on the list projection.
+    expect(Object.keys(item ?? {})).not.toContain("secret");
+  });
+
+  it("deletes a webhook automation and cascades the trigger", async () => {
+    const fixture = await seedFixture();
+    await enableAutomations(fixture);
+
+    const created = webhookAutomationCreateResponseSchema.parse(
+      (
+        await requestJson(
+          "/api/automations/webhooks",
+          jsonInit("POST", {
+            name: "removable",
+            instruction: "Summarize.",
+            agentId: fixture.composeId,
+          }),
+        )
+      ).body,
+    );
+
+    const delStatus = await requestStatus(
+      `/api/automations/webhooks/${created.automation.id}`,
+      { method: "DELETE", headers: SESSION_HEADERS },
+    );
+    expect(delStatus).toBe(204);
+
+    const db = store.set(writeDb$);
+    const automationRows = await db
+      .select({ id: automations.id })
+      .from(automations)
+      .where(eq(automations.id, created.automation.id));
+    expect(automationRows).toHaveLength(0);
+    const triggerRows = await db
+      .select({ id: automationTriggers.id })
+      .from(automationTriggers)
+      .where(eq(automationTriggers.automationId, created.automation.id));
+    expect(triggerRows).toHaveLength(0);
+  });
+
+  it("returns 404 deleting an automation owned by another scope", async () => {
+    const fixture = await seedFixture();
+    await enableAutomations(fixture);
+
+    const delStatus = await requestStatus(
+      "/api/automations/webhooks/00000000-0000-0000-0000-000000000000",
+      { method: "DELETE", headers: SESSION_HEADERS },
+    );
+    expect(delStatus).toBe(404);
+  });
+
+  it("accepts the minted token at the inbound webhook route end-to-end", async () => {
+    const fixture = await seedFixture();
+    await enableAutomations(fixture);
+
+    const created = webhookAutomationCreateResponseSchema.parse(
+      (
+        await requestJson(
+          "/api/automations/webhooks",
+          jsonInit("POST", {
+            name: "end-to-end",
+            instruction: "Summarize the incoming webhook event.",
+            agentId: fixture.composeId,
+          }),
+        )
+      ).body,
+    );
+
+    const body = JSON.stringify({ event: "ping", value: 7 });
+    const signature = `sha256=${createHmac("sha256", created.secret)
+      .update(body)
+      .digest("hex")}`;
+
+    const app = createApp({ signal: context.signal });
+    const inbound = await app.request(
+      `/api/automations/webhooks/${created.automation.webhookToken}`,
+      {
+        method: "POST",
+        headers: {
+          "content-type": "application/json",
+          [SIGNATURE_HEADER]: signature,
+        },
+        body,
+      },
+    );
+    expect(inbound.status).toBe(200);
+
+    // The inbound dispatch created a webhook-sourced run on the linked thread.
+    const db = store.set(writeDb$);
+    const [run] = await db
+      .select({
+        triggerSource: zeroRuns.triggerSource,
+        chatThreadId: zeroRuns.chatThreadId,
+      })
+      .from(zeroRuns)
+      .where(eq(zeroRuns.chatThreadId, created.automation.chatThreadId));
+    expect(run).toStrictEqual({
+      triggerSource: "webhook",
+      chatThreadId: created.automation.chatThreadId,
+    });
+  });
+});
+
+describe("Webhook automations management feature gating", () => {
+  it("returns 404 on every endpoint when the switch is off", async () => {
+    const fixture = await seedFixture();
+
+    const create = await requestJson(
+      "/api/automations/webhooks",
+      jsonInit("POST", {
+        name: "blocked",
+        instruction: "Should not be created.",
+        agentId: fixture.composeId,
+      }),
+    );
+    expect(create.status).toBe(404);
+    expect(expectErrorCode(create)).toBe("NOT_FOUND");
+
+    const list = await requestJson("/api/automations/webhooks", {
+      method: "GET",
+      headers: SESSION_HEADERS,
+    });
+    expect(list.status).toBe(404);
+
+    const del = await requestStatus(
+      "/api/automations/webhooks/00000000-0000-0000-0000-000000000000",
+      { method: "DELETE", headers: SESSION_HEADERS },
+    );
+    expect(del).toBe(404);
+  });
+
+  it("returns 401 when unauthenticated", async () => {
+    const response = await requestJson("/api/automations/webhooks", {
+      method: "GET",
+      headers: {},
+    });
+    expect(response.status).toBe(401);
+    expect(expectErrorCode(response)).toBe("UNAUTHORIZED");
+  });
+});

--- a/turbo/apps/api/src/signals/routes/webhook-automations.ts
+++ b/turbo/apps/api/src/signals/routes/webhook-automations.ts
@@ -1,0 +1,155 @@
+import { command, computed } from "ccstate";
+import {
+  webhookAutomationsByIdContract,
+  webhookAutomationsMainContract,
+  type WebhookAutomationResponse,
+} from "@vm0/api-contracts/contracts/webhook-automations";
+import { FeatureSwitchKey } from "@vm0/connectors/feature-switch-key";
+import { isFeatureEnabled } from "@vm0/core/feature-switch";
+
+import { badRequestMessage, notFound } from "../../lib/error";
+import { organizationAuthContext$ } from "../auth/auth-context";
+import { authRoute } from "../auth/auth-route";
+import { bodyResultOf, pathParamsOf } from "../context/request";
+import { userFeatureSwitchOverrides } from "../services/feature-switches.service";
+import {
+  createWebhookAutomation$,
+  deleteWebhookAutomation$,
+  listWebhookAutomations$,
+  type WebhookAutomationView,
+} from "../services/webhook-automations.service";
+import type { RouteEntry } from "../route";
+
+function toResponse(view: WebhookAutomationView): WebhookAutomationResponse {
+  return view;
+}
+
+// Webhook automations share the time-automation gate: when the zeroAutomations
+// switch is off the surface is unreachable, so handlers report not-found and the
+// new paths are indistinguishable from unmounted routes.
+const automationsEnabled$ = computed(async (get) => {
+  const auth = get(organizationAuthContext$);
+  const overrides = await get(
+    userFeatureSwitchOverrides(auth.orgId, auth.userId),
+  );
+  return isFeatureEnabled(FeatureSwitchKey.ZeroAutomations, {
+    orgId: auth.orgId,
+    userId: auth.userId,
+    overrides,
+  });
+});
+
+const createInner$ = command(async ({ get, set }, signal: AbortSignal) => {
+  if (!(await get(automationsEnabled$))) {
+    return notFound("Resource not found");
+  }
+  signal.throwIfAborted();
+  const auth = get(organizationAuthContext$);
+  const bodyResult = await get(
+    bodyResultOf(webhookAutomationsMainContract.create),
+  );
+  signal.throwIfAborted();
+  if (!bodyResult.ok) {
+    return bodyResult.response;
+  }
+
+  const result = await set(
+    createWebhookAutomation$,
+    {
+      userId: auth.userId,
+      orgId: auth.orgId,
+      body: bodyResult.data,
+    },
+    signal,
+  );
+  signal.throwIfAborted();
+
+  if (result.kind === "not_found") {
+    return notFound(result.message);
+  }
+  if (result.kind === "bad_request") {
+    return badRequestMessage(result.message);
+  }
+  return {
+    status: 201 as const,
+    body: {
+      automation: toResponse(result.automation),
+      secret: result.secret,
+    },
+  };
+});
+
+const listInner$ = command(async ({ get, set }, signal: AbortSignal) => {
+  if (!(await get(automationsEnabled$))) {
+    return notFound("Resource not found");
+  }
+  signal.throwIfAborted();
+  const auth = get(organizationAuthContext$);
+  const automations = await set(
+    listWebhookAutomations$,
+    { userId: auth.userId, orgId: auth.orgId },
+    signal,
+  );
+  signal.throwIfAborted();
+  return {
+    status: 200 as const,
+    body: { automations: automations.map(toResponse) },
+  };
+});
+
+const deleteInner$ = command(async ({ get, set }, signal: AbortSignal) => {
+  if (!(await get(automationsEnabled$))) {
+    return notFound("Resource not found");
+  }
+  signal.throwIfAborted();
+  const auth = get(organizationAuthContext$);
+  const params = get(pathParamsOf(webhookAutomationsByIdContract.delete));
+
+  const result = await set(
+    deleteWebhookAutomation$,
+    { userId: auth.userId, orgId: auth.orgId, id: params.id },
+    signal,
+  );
+  signal.throwIfAborted();
+
+  if (result.kind === "not_found") {
+    return notFound("Resource not found");
+  }
+  return { status: 204 as const, body: undefined };
+});
+
+export const webhookAutomationsRoutes: readonly RouteEntry[] = [
+  {
+    route: webhookAutomationsMainContract.create,
+    handler: authRoute(
+      {
+        requireOrganization: true,
+        missingOrganizationStatus: 401,
+        requiredCapability: "schedule:write",
+      },
+      createInner$,
+    ),
+  },
+  {
+    route: webhookAutomationsMainContract.list,
+    handler: authRoute(
+      {
+        requireOrganization: true,
+        missingOrganizationStatus: 401,
+        requiredCapability: "schedule:read",
+      },
+      listInner$,
+    ),
+  },
+  {
+    route: webhookAutomationsByIdContract.delete,
+    handler: authRoute(
+      {
+        requireOrganization: true,
+        missingOrganizationStatus: 401,
+        requiredCapability: "schedule:delete",
+      },
+      deleteInner$,
+    ),
+  },
+];

--- a/turbo/apps/api/src/signals/services/webhook-automations.service.ts
+++ b/turbo/apps/api/src/signals/services/webhook-automations.service.ts
@@ -1,0 +1,360 @@
+import { randomBytes } from "node:crypto";
+
+import { command } from "ccstate";
+import { agentComposes } from "@vm0/db/schema/agent-compose";
+import { automations, automationTriggers } from "@vm0/db/schema/automation";
+import { chatThreads } from "@vm0/db/schema/chat-thread";
+import { zeroAgents } from "@vm0/db/schema/zero-agent";
+import { and, desc, eq } from "drizzle-orm";
+
+import { internalApiBaseUrl } from "../../lib/internal-api-url";
+import { nowDate } from "../external/time";
+import { writeDb$, type Db } from "../external/db";
+import { encryptStoredSecretValue } from "./crypto.utils";
+import { visibleJoinedZeroAgentCondition } from "./zero-agent-data.service";
+
+/** Interpreter key persisted for webhook automations. */
+const WEBHOOK_INTERPRETER_KIND = "webhook";
+/** Trigger-kind discriminator for the webhook event source. */
+const WEBHOOK_TRIGGER_KIND = "webhook";
+
+/**
+ * Durable projection of a webhook automation joined to its trigger token. This
+ * is what list/create return; the HMAC secret is deliberately absent — it is
+ * surfaced once at creation by the service and never persisted in plaintext.
+ */
+export interface WebhookAutomationView {
+  readonly id: string;
+  readonly agentId: string;
+  readonly userId: string;
+  readonly name: string;
+  readonly instruction: string;
+  readonly description: string | null;
+  readonly enabled: boolean;
+  readonly chatThreadId: string;
+  readonly webhookToken: string;
+  readonly webhookUrl: string;
+  readonly createdAt: string;
+  readonly updatedAt: string;
+}
+
+interface AutomationRow {
+  readonly id: string;
+  readonly agentId: string;
+  readonly userId: string;
+  readonly name: string;
+  readonly instruction: string;
+  readonly description: string | null;
+  readonly enabled: boolean;
+  readonly chatThreadId: string;
+  readonly createdAt: Date;
+  readonly updatedAt: Date;
+}
+
+/** Full inbound URL a signed payload is POSTed to for the given token. */
+function webhookUrlForToken(token: string): string {
+  return `${internalApiBaseUrl()}/api/automations/webhooks/${token}`;
+}
+
+function toView(
+  row: AutomationRow,
+  webhookToken: string,
+): WebhookAutomationView {
+  return {
+    id: row.id,
+    agentId: row.agentId,
+    userId: row.userId,
+    name: row.name,
+    instruction: row.instruction,
+    description: row.description,
+    enabled: row.enabled,
+    chatThreadId: row.chatThreadId,
+    webhookToken,
+    webhookUrl: webhookUrlForToken(webhookToken),
+    createdAt: row.createdAt.toISOString(),
+    updatedAt: row.updatedAt.toISOString(),
+  };
+}
+
+// Columns of the `automations` row used to build a view. Kept to the
+// automations table only so it is valid both as an insert `.returning()` and as
+// the automation half of the list join (the trigger token is selected/passed
+// separately).
+const automationViewColumns = {
+  id: automations.id,
+  agentId: automations.agentId,
+  userId: automations.userId,
+  name: automations.name,
+  instruction: automations.instruction,
+  description: automations.description,
+  enabled: automations.enabled,
+  chatThreadId: automations.chatThreadId,
+  createdAt: automations.createdAt,
+  updatedAt: automations.updatedAt,
+} as const;
+
+/**
+ * Load an agent the user may target, scoped to the org and the user's
+ * visibility. Mirrors the schedule deploy's agent gate so webhook automations
+ * cannot be attached to agents the caller cannot see.
+ */
+async function loadTargetAgent(
+  db: Db,
+  args: {
+    readonly orgId: string;
+    readonly userId: string;
+    readonly agentId: string;
+  },
+): Promise<{ readonly id: string } | null> {
+  const [agent] = await db
+    .select({ id: agentComposes.id })
+    .from(agentComposes)
+    .leftJoin(zeroAgents, eq(agentComposes.id, zeroAgents.id))
+    .where(
+      and(
+        eq(agentComposes.orgId, args.orgId),
+        eq(agentComposes.id, args.agentId),
+        visibleJoinedZeroAgentCondition(args.userId),
+      ),
+    )
+    .limit(1);
+  return agent ?? null;
+}
+
+/**
+ * A chat thread may be linked to a webhook automation only if it exists, is
+ * owned by the same user, and belongs to the same agent. (Chat threads carry
+ * only a userId, so org isolation is enforced via the user — same rule the
+ * schedule surface applies.)
+ */
+async function isChatThreadLinkable(
+  db: Db,
+  args: {
+    readonly chatThreadId: string;
+    readonly userId: string;
+    readonly agentId: string;
+  },
+): Promise<boolean> {
+  const [thread] = await db
+    .select({
+      userId: chatThreads.userId,
+      agentComposeId: chatThreads.agentComposeId,
+    })
+    .from(chatThreads)
+    .where(eq(chatThreads.id, args.chatThreadId))
+    .limit(1);
+  return (
+    thread !== undefined &&
+    thread.userId === args.userId &&
+    thread.agentComposeId === args.agentId
+  );
+}
+
+interface CreateWebhookAutomationBody {
+  readonly name: string;
+  readonly instruction: string;
+  readonly description?: string;
+  readonly agentId: string;
+  readonly enabled?: boolean;
+  readonly chatThreadId?: string;
+}
+
+type CreateWebhookAutomationResult =
+  | {
+      readonly kind: "ok";
+      readonly automation: WebhookAutomationView;
+      readonly secret: string;
+    }
+  | { readonly kind: "not_found"; readonly message: string }
+  | { readonly kind: "bad_request"; readonly message: string };
+
+/**
+ * Create a webhook automation: validate the target agent, resolve a linked chat
+ * thread (an owned existing thread or a server-created one), mint an unguessable
+ * URL token and an HMAC signing secret, and persist `automations` plus a
+ * `automation_triggers(kind:"webhook")` row in one transaction. The signing
+ * secret is encrypted at rest and returned once to the caller; only the token
+ * (identity) is durable. A write `command`.
+ */
+export const createWebhookAutomation$ = command(
+  async (
+    { set },
+    args: {
+      readonly userId: string;
+      readonly orgId: string;
+      readonly body: CreateWebhookAutomationBody;
+    },
+    signal: AbortSignal,
+  ): Promise<CreateWebhookAutomationResult> => {
+    const db = set(writeDb$);
+
+    const agent = await loadTargetAgent(db, {
+      orgId: args.orgId,
+      userId: args.userId,
+      agentId: args.body.agentId,
+    });
+    signal.throwIfAborted();
+    if (!agent) {
+      return { kind: "not_found", message: "Agent not found" };
+    }
+
+    if (args.body.chatThreadId !== undefined) {
+      const linkable = await isChatThreadLinkable(db, {
+        chatThreadId: args.body.chatThreadId,
+        userId: args.userId,
+        agentId: args.body.agentId,
+      });
+      signal.throwIfAborted();
+      if (!linkable) {
+        return {
+          kind: "bad_request",
+          message:
+            "Chat thread not found, not owned by this user, or belongs to a different agent",
+        };
+      }
+    }
+
+    // Unguessable URL token (identity) and HMAC signing secret (authentication).
+    // The token is stored in the clear for O(1) inbound lookup; the secret is
+    // encrypted at rest and shown to the caller exactly once below. 24 random
+    // bytes (192 bits) render as a 48-char hex string; the `whk_` prefix keeps
+    // the whole token within the trigger's varchar(64) webhook_token column.
+    const webhookToken = `whk_${randomBytes(24).toString("hex")}`;
+    const secret = randomBytes(32).toString("hex");
+    const encryptedSecret = await encryptStoredSecretValue(secret);
+    signal.throwIfAborted();
+
+    const currentTime = nowDate();
+    const view = await db.transaction(async (tx) => {
+      let chatThreadId = args.body.chatThreadId;
+      if (chatThreadId === undefined) {
+        const [thread] = await tx
+          .insert(chatThreads)
+          .values({
+            userId: args.userId,
+            agentComposeId: args.body.agentId,
+            title: args.body.description ?? args.body.name,
+            lastMessageAt: currentTime,
+            createdAt: currentTime,
+            updatedAt: currentTime,
+          })
+          .returning({ id: chatThreads.id });
+        if (!thread) {
+          throw new Error("Failed to create chat thread");
+        }
+        chatThreadId = thread.id;
+      }
+
+      const [automation] = await tx
+        .insert(automations)
+        .values({
+          orgId: args.orgId,
+          userId: args.userId,
+          name: args.body.name,
+          description: args.body.description ?? null,
+          instruction: args.body.instruction,
+          agentId: args.body.agentId,
+          chatThreadId,
+          interpreterKind: WEBHOOK_INTERPRETER_KIND,
+          enabled: args.body.enabled ?? true,
+          createdAt: currentTime,
+          updatedAt: currentTime,
+        })
+        .returning(automationViewColumns);
+      if (!automation) {
+        throw new Error("Failed to create automation");
+      }
+
+      await tx.insert(automationTriggers).values({
+        automationId: automation.id,
+        kind: WEBHOOK_TRIGGER_KIND,
+        webhookToken,
+        encryptedSecret,
+        createdAt: currentTime,
+        updatedAt: currentTime,
+      });
+
+      return toView(automation, webhookToken);
+    });
+    signal.throwIfAborted();
+
+    return { kind: "ok", automation: view, secret };
+  },
+);
+
+/**
+ * List the caller's webhook automations on the new tables, scoped to (orgId,
+ * userId) and newest first. The signing secret is never projected — only the
+ * token and its inbound URL.
+ */
+export const listWebhookAutomations$ = command(
+  async (
+    { set },
+    args: { readonly userId: string; readonly orgId: string },
+    signal: AbortSignal,
+  ): Promise<readonly WebhookAutomationView[]> => {
+    const db = set(writeDb$);
+    const rows = await db
+      .select({
+        ...automationViewColumns,
+        webhookToken: automationTriggers.webhookToken,
+      })
+      .from(automations)
+      .innerJoin(
+        automationTriggers,
+        eq(automationTriggers.automationId, automations.id),
+      )
+      .where(
+        and(
+          eq(automations.orgId, args.orgId),
+          eq(automations.userId, args.userId),
+          eq(automations.interpreterKind, WEBHOOK_INTERPRETER_KIND),
+        ),
+      )
+      .orderBy(desc(automations.createdAt));
+    signal.throwIfAborted();
+    return rows.flatMap(({ webhookToken, ...row }) => {
+      // A webhook trigger always carries a token; skip any row without one
+      // rather than surface a tokenless (unusable) URL.
+      return webhookToken === null ? [] : [toView(row, webhookToken)];
+    });
+  },
+);
+
+type DeleteWebhookAutomationResult =
+  | { readonly kind: "ok" }
+  | { readonly kind: "not_found" };
+
+/**
+ * Delete a webhook automation by id, scoped to the caller. The trigger row is
+ * removed by the FK cascade. A write `command`.
+ */
+export const deleteWebhookAutomation$ = command(
+  async (
+    { set },
+    args: {
+      readonly userId: string;
+      readonly orgId: string;
+      readonly id: string;
+    },
+    signal: AbortSignal,
+  ): Promise<DeleteWebhookAutomationResult> => {
+    const db = set(writeDb$);
+    const [deleted] = await db
+      .delete(automations)
+      .where(
+        and(
+          eq(automations.id, args.id),
+          eq(automations.orgId, args.orgId),
+          eq(automations.userId, args.userId),
+          eq(automations.interpreterKind, WEBHOOK_INTERPRETER_KIND),
+        ),
+      )
+      .returning({ id: automations.id });
+    signal.throwIfAborted();
+    if (!deleted) {
+      return { kind: "not_found" };
+    }
+    return { kind: "ok" };
+  },
+);

--- a/turbo/packages/api-contracts/src/contracts/webhook-automations.ts
+++ b/turbo/packages/api-contracts/src/contracts/webhook-automations.ts
@@ -1,0 +1,137 @@
+import { z } from "zod";
+import { authHeadersSchema, initContract } from "./base";
+import { apiErrorSchema } from "./errors";
+
+const c = initContract();
+
+/**
+ * Webhook-automation management API. Creates/lists/deletes the events-first
+ * webhook automations that live on the new `automations` + `automation_triggers`
+ * tables (NOT `zero_agent_schedules`). Gated behind the `zeroAutomations`
+ * feature switch — when off, these endpoints are not mounted (404), matching the
+ * time-automation surface.
+ *
+ * A webhook automation pairs a user `instruction` with an agent and a linked
+ * chat thread. Creation mints an unguessable URL token plus an HMAC signing
+ * secret; an external signed POST to the inbound route then fires the automation
+ * as an agent run.
+ */
+
+/**
+ * Webhook-automation projection returned by list/create — the durable view of an
+ * `automations` row plus its webhook trigger token. The HMAC `secret` is NEVER
+ * part of this shape: it is returned once at creation and never again.
+ */
+export const webhookAutomationResponseSchema = z.object({
+  id: z.string().uuid(),
+  agentId: z.string().uuid(),
+  userId: z.string(),
+  name: z.string(),
+  instruction: z.string(),
+  description: z.string().nullable(),
+  enabled: z.boolean(),
+  chatThreadId: z.string().uuid(),
+  // Unguessable URL token identifying the inbound trigger. Identity only; the
+  // signing secret is separate and shown once at creation.
+  webhookToken: z.string(),
+  // Full inbound URL the caller POSTs signed payloads to.
+  webhookUrl: z.string(),
+  createdAt: z.string(),
+  updatedAt: z.string(),
+});
+
+export const webhookAutomationListResponseSchema = z.object({
+  automations: z.array(webhookAutomationResponseSchema),
+});
+
+/**
+ * Create response — the durable projection plus the HMAC `secret`, surfaced
+ * exactly once here. The secret is the only field absent from the list/get
+ * projection; callers must persist it on receipt because it is unrecoverable.
+ */
+export const webhookAutomationCreateResponseSchema = z.object({
+  automation: webhookAutomationResponseSchema,
+  secret: z.string(),
+});
+
+const createWebhookAutomationRequestSchema = z.object({
+  name: z.string().min(1).max(64, "Automation name max 64 chars"),
+  instruction: z.string().min(1, "Instruction required"),
+  description: z.string().optional(),
+  agentId: z.string().uuid("Invalid agent ID"),
+  enabled: z.boolean().optional(),
+  // Chat-thread linkage, honored only on creation. When provided, links the
+  // automation to an existing owned chat thread; when omitted, the server
+  // creates a web chat thread and links it.
+  chatThreadId: z.string().uuid("Invalid chat thread ID").optional(),
+});
+
+/**
+ * Webhook-automation collection contract (GET/POST /api/automations/webhooks).
+ */
+export const webhookAutomationsMainContract = c.router({
+  create: {
+    method: "POST",
+    path: "/api/automations/webhooks",
+    headers: authHeadersSchema,
+    body: createWebhookAutomationRequestSchema,
+    responses: {
+      201: webhookAutomationCreateResponseSchema,
+      400: apiErrorSchema,
+      401: apiErrorSchema,
+      403: apiErrorSchema,
+      404: apiErrorSchema,
+    },
+    summary: "Create a webhook automation",
+  },
+  list: {
+    method: "GET",
+    path: "/api/automations/webhooks",
+    headers: authHeadersSchema,
+    responses: {
+      200: webhookAutomationListResponseSchema,
+      401: apiErrorSchema,
+      403: apiErrorSchema,
+      404: apiErrorSchema,
+    },
+    summary: "List webhook automations",
+  },
+});
+
+/**
+ * Webhook-automation by-id contract (DELETE /api/automations/webhooks/:id).
+ * Deleting the automation cascades its trigger row (FK ON DELETE CASCADE).
+ */
+export const webhookAutomationsByIdContract = c.router({
+  delete: {
+    method: "DELETE",
+    path: "/api/automations/webhooks/:id",
+    headers: authHeadersSchema,
+    pathParams: z.object({
+      id: z.string().uuid("Invalid automation ID"),
+    }),
+    responses: {
+      204: c.noBody(),
+      400: apiErrorSchema,
+      401: apiErrorSchema,
+      403: apiErrorSchema,
+      404: apiErrorSchema,
+    },
+    summary: "Delete a webhook automation",
+  },
+});
+
+export type WebhookAutomationsMainContract =
+  typeof webhookAutomationsMainContract;
+export type WebhookAutomationsByIdContract =
+  typeof webhookAutomationsByIdContract;
+
+export type WebhookAutomationResponse = z.infer<
+  typeof webhookAutomationResponseSchema
+>;
+export type WebhookAutomationListResponse = z.infer<
+  typeof webhookAutomationListResponseSchema
+>;
+export type WebhookAutomationCreateResponse = z.infer<
+  typeof webhookAutomationCreateResponseSchema
+>;


### PR DESCRIPTION
Closes #16756. Part of #16616. Stacked on #16775.

Management API on the new tables, gated by `zeroAutomations` (404 when off). Create validates the agent via the schedule visibility gate, mints an unguessable token + HMAC secret (encrypted), inserts automations + automation_triggers(kind:webhook) in one tx (creates a web chat thread when none supplied), and returns the webhook URL + secret ONCE. List/delete are org/user-scoped; the secret is never re-projected. Existing schedule-backed time-automation endpoints untouched (dual-system). 10 new tests green.