### PR TITLE
feat(cli): add zero automation webhook trigger commands

### DIFF
--- a/turbo/apps/cli/src/commands/zero/automation/index.ts
+++ b/turbo/apps/cli/src/commands/zero/automation/index.ts
@@ -5,6 +5,7 @@ import { statusCommand } from "./status";
 import { deleteCommand } from "./delete";
 import { enableCommand } from "./enable";
 import { disableCommand } from "./disable";
+import { webhookCommand } from "./webhook";
 
 export const zeroAutomationCommand = new Command()
   .name("automation")
@@ -15,6 +16,7 @@ export const zeroAutomationCommand = new Command()
   .addCommand(deleteCommand)
   .addCommand(enableCommand)
   .addCommand(disableCommand)
+  .addCommand(webhookCommand)
   .addHelpText(
     "after",
     `
@@ -24,5 +26,6 @@ Examples:
   Check automation status:  zero automation status <agent-id>
   Pause an automation:      zero automation disable <agent-id>
   Resume an automation:     zero automation enable <agent-id>
-  Delete an automation:     zero automation delete <agent-id>`,
+  Delete an automation:     zero automation delete <agent-id>
+  Webhook-triggered:        zero automation webhook --help`,
   );

--- a/turbo/apps/cli/src/commands/zero/automation/webhook/__tests__/webhook.test.ts
+++ b/turbo/apps/cli/src/commands/zero/automation/webhook/__tests__/webhook.test.ts
@@ -1,0 +1,413 @@
+/**
+ * Tests for `zero automation webhook` commands (create / list / delete).
+ *
+ * Tests command-level behavior via parseAsync() following CLI testing
+ * principles:
+ * - Entry point: command.parseAsync()
+ * - Mock (external): Web API via MSW
+ * - Real (internal): All CLI code, formatters, validators
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { http, HttpResponse } from "msw";
+import { writeFileSync, mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { server } from "../../../../../mocks/server";
+import { webhookCommand } from "../index";
+import chalk from "chalk";
+
+const mockCompose = {
+  id: "550e8400-e29b-41d4-a716-446655440000",
+  name: "my-agent",
+  headVersionId: "ver-001",
+  content: null,
+  createdAt: "2026-03-23T00:00:00Z",
+  updatedAt: "2026-03-23T00:00:00Z",
+};
+
+const mockWebhookAutomation = {
+  id: "11111111-1111-4111-8111-111111111111",
+  agentId: "550e8400-e29b-41d4-a716-446655440000",
+  userId: "user-001",
+  name: "alerts",
+  instruction: "Summarize the incoming alert",
+  description: null,
+  enabled: true,
+  chatThreadId: "550e8400-e29b-41d4-a716-446655440099",
+  webhookToken: "whk_deadbeef",
+  webhookUrl: "http://localhost:3000/api/automations/webhooks/whk_deadbeef",
+  createdAt: "2026-03-23T00:00:00Z",
+  updatedAt: "2026-03-23T00:00:00Z",
+};
+
+const mockCreateResponse = {
+  automation: mockWebhookAutomation,
+  secret: "whsec_supersecretvalue",
+};
+
+function composeByNameHandler() {
+  return http.get("http://localhost:3000/api/agent/composes", ({ request }) => {
+    const url = new URL(request.url);
+    if (url.searchParams.get("name") !== "my-agent") {
+      return HttpResponse.json(
+        { error: { message: "Not found", code: "NOT_FOUND" } },
+        { status: 404 },
+      );
+    }
+    return HttpResponse.json(mockCompose);
+  });
+}
+
+describe("zero automation webhook command", () => {
+  const mockExit = vi.spyOn(process, "exit").mockImplementation((() => {
+    throw new Error("process.exit called");
+  }) as never);
+  const mockConsoleLog = vi.spyOn(console, "log").mockImplementation(() => {});
+  const mockConsoleError = vi
+    .spyOn(console, "error")
+    .mockImplementation(() => {});
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    chalk.level = 0;
+    vi.stubEnv("VM0_API_URL", "http://localhost:3000");
+    vi.stubEnv("VM0_TOKEN", "test-token");
+  });
+
+  afterEach(() => {
+    mockExit.mockClear();
+    mockConsoleLog.mockClear();
+    mockConsoleError.mockClear();
+  });
+
+  describe("create", () => {
+    it("should create a webhook automation and print URL + secret + curl", async () => {
+      let capturedBody:
+        | { name: string; instruction: string; agentId: string }
+        | undefined;
+
+      server.use(
+        composeByNameHandler(),
+        http.post(
+          "http://localhost:3000/api/automations/webhooks",
+          async ({ request }) => {
+            capturedBody = (await request.json()) as {
+              name: string;
+              instruction: string;
+              agentId: string;
+            };
+            return HttpResponse.json(mockCreateResponse, { status: 201 });
+          },
+        ),
+      );
+
+      await webhookCommand.parseAsync([
+        "node",
+        "cli",
+        "create",
+        "--agent-id",
+        "my-agent",
+        "--name",
+        "alerts",
+        "--prompt",
+        "Summarize the incoming alert",
+      ]);
+
+      expect(capturedBody).toEqual({
+        name: "alerts",
+        instruction: "Summarize the incoming alert",
+        agentId: "550e8400-e29b-41d4-a716-446655440000",
+      });
+
+      const logCalls = mockConsoleLog.mock.calls.flat().join("\n");
+      expect(logCalls).toContain("created");
+      // Inbound URL is surfaced.
+      expect(logCalls).toContain(
+        "http://localhost:3000/api/automations/webhooks/whk_deadbeef",
+      );
+      // Secret is shown once with guidance.
+      expect(logCalls).toContain("shown once");
+      expect(logCalls).toContain("whsec_supersecretvalue");
+      // A signed curl example is printed against the right signature header.
+      expect(logCalls).toContain("curl -X POST");
+      expect(logCalls).toContain("x-vm0-signature-256");
+      expect(logCalls).toContain("openssl dgst -sha256 -hmac");
+    });
+
+    it("should read the instruction from --prompt-file", async () => {
+      const tmpDir = mkdtempSync(join(tmpdir(), "webhook-prompt-"));
+      const promptPath = join(tmpDir, "instruction.md");
+      writeFileSync(promptPath, "instruction from file");
+
+      let capturedInstruction: string | undefined;
+
+      server.use(
+        composeByNameHandler(),
+        http.post(
+          "http://localhost:3000/api/automations/webhooks",
+          async ({ request }) => {
+            const body = (await request.json()) as { instruction: string };
+            capturedInstruction = body.instruction;
+            return HttpResponse.json(mockCreateResponse, { status: 201 });
+          },
+        ),
+      );
+
+      try {
+        await webhookCommand.parseAsync([
+          "node",
+          "cli",
+          "create",
+          "--agent-id",
+          "my-agent",
+          "--name",
+          "alerts",
+          "--prompt-file",
+          promptPath,
+        ]);
+      } finally {
+        rmSync(tmpDir, { recursive: true, force: true });
+      }
+
+      expect(capturedInstruction).toBe("instruction from file");
+    });
+
+    it("should emit raw JSON with the secret when --json is set", async () => {
+      server.use(
+        composeByNameHandler(),
+        http.post("http://localhost:3000/api/automations/webhooks", () => {
+          return HttpResponse.json(mockCreateResponse, { status: 201 });
+        }),
+      );
+
+      await webhookCommand.parseAsync([
+        "node",
+        "cli",
+        "create",
+        "--agent-id",
+        "my-agent",
+        "--name",
+        "alerts",
+        "--prompt",
+        "Summarize the incoming alert",
+        "--json",
+      ]);
+
+      const logCalls = mockConsoleLog.mock.calls.flat().join("\n");
+      const parsed = JSON.parse(logCalls);
+      expect(parsed.secret).toBe("whsec_supersecretvalue");
+      expect(parsed.automation.webhookUrl).toBe(
+        "http://localhost:3000/api/automations/webhooks/whk_deadbeef",
+      );
+    });
+
+    it("should reject combining --prompt and --prompt-file", async () => {
+      server.use(composeByNameHandler());
+
+      await expect(async () => {
+        await webhookCommand.parseAsync([
+          "node",
+          "cli",
+          "create",
+          "--agent-id",
+          "my-agent",
+          "--name",
+          "alerts",
+          "--prompt",
+          "inline",
+          "--prompt-file",
+          "/tmp/whatever.md",
+        ]);
+      }).rejects.toThrow("process.exit called");
+
+      expect(mockConsoleError).toHaveBeenCalledWith(
+        expect.stringContaining(
+          "Cannot use --prompt and --prompt-file together",
+        ),
+      );
+      expect(mockExit).toHaveBeenCalledWith(1);
+    });
+
+    it("should error when the agent is not found", async () => {
+      server.use(
+        http.get("http://localhost:3000/api/agent/composes", () => {
+          return HttpResponse.json(
+            { error: { message: "Not found", code: "NOT_FOUND" } },
+            { status: 404 },
+          );
+        }),
+      );
+
+      await expect(async () => {
+        await webhookCommand.parseAsync([
+          "node",
+          "cli",
+          "create",
+          "--agent-id",
+          "missing",
+          "--name",
+          "alerts",
+          "--prompt",
+          "do it",
+        ]);
+      }).rejects.toThrow("process.exit called");
+
+      expect(mockConsoleError).toHaveBeenCalledWith(
+        expect.stringContaining("Agent not found"),
+      );
+      expect(mockExit).toHaveBeenCalledWith(1);
+    });
+
+    it("should surface a not-found from the management API (switch off)", async () => {
+      server.use(
+        composeByNameHandler(),
+        http.post("http://localhost:3000/api/automations/webhooks", () => {
+          return HttpResponse.json(
+            { error: { message: "Not found", code: "NOT_FOUND" } },
+            { status: 404 },
+          );
+        }),
+      );
+
+      await expect(async () => {
+        await webhookCommand.parseAsync([
+          "node",
+          "cli",
+          "create",
+          "--agent-id",
+          "my-agent",
+          "--name",
+          "alerts",
+          "--prompt",
+          "do it",
+        ]);
+      }).rejects.toThrow("process.exit called");
+
+      expect(mockExit).toHaveBeenCalledWith(1);
+    });
+  });
+
+  describe("list", () => {
+    it("should display webhook automations in table format", async () => {
+      server.use(
+        http.get("http://localhost:3000/api/automations/webhooks", () => {
+          return HttpResponse.json({ automations: [mockWebhookAutomation] });
+        }),
+      );
+
+      await webhookCommand.parseAsync(["node", "cli", "list"]);
+
+      const logCalls = mockConsoleLog.mock.calls.flat().join("\n");
+      expect(logCalls).toContain("alerts");
+      expect(logCalls).toContain("550e8400-e29b-41d4-a716-446655440000");
+      expect(logCalls).toContain(
+        "http://localhost:3000/api/automations/webhooks/whk_deadbeef",
+      );
+      expect(logCalls).toContain("enabled");
+    });
+
+    it("should display an empty state when there are none", async () => {
+      server.use(
+        http.get("http://localhost:3000/api/automations/webhooks", () => {
+          return HttpResponse.json({ automations: [] });
+        }),
+      );
+
+      await webhookCommand.parseAsync(["node", "cli", "list"]);
+
+      const logCalls = mockConsoleLog.mock.calls.flat().join("\n");
+      expect(logCalls).toContain("No webhook automations found");
+      expect(logCalls).toContain("zero automation webhook create");
+    });
+
+    it("should print raw JSON when --json is set", async () => {
+      server.use(
+        http.get("http://localhost:3000/api/automations/webhooks", () => {
+          return HttpResponse.json({ automations: [mockWebhookAutomation] });
+        }),
+      );
+
+      await webhookCommand.parseAsync(["node", "cli", "list", "--json"]);
+
+      const logCalls = mockConsoleLog.mock.calls.flat().join("\n");
+      const parsed = JSON.parse(logCalls);
+      expect(parsed).toHaveLength(1);
+      expect(parsed[0].name).toBe("alerts");
+      // The list projection never carries the secret.
+      expect(parsed[0]).not.toHaveProperty("secret");
+    });
+
+    it("should handle an authentication error", async () => {
+      server.use(
+        http.get("http://localhost:3000/api/automations/webhooks", () => {
+          return HttpResponse.json(
+            { error: { message: "Not authenticated", code: "UNAUTHORIZED" } },
+            { status: 401 },
+          );
+        }),
+      );
+
+      await expect(async () => {
+        await webhookCommand.parseAsync(["node", "cli", "list"]);
+      }).rejects.toThrow("process.exit called");
+
+      expect(mockConsoleError).toHaveBeenCalledWith(
+        expect.stringContaining("Not authenticated"),
+      );
+      expect(mockExit).toHaveBeenCalledWith(1);
+    });
+  });
+
+  describe("delete", () => {
+    it("should delete by automation id", async () => {
+      let deleteHitId: string | undefined;
+
+      server.use(
+        http.delete(
+          "http://localhost:3000/api/automations/webhooks/:id",
+          ({ params }) => {
+            deleteHitId = params.id as string;
+            return new HttpResponse(null, { status: 204 });
+          },
+        ),
+      );
+
+      await webhookCommand.parseAsync([
+        "node",
+        "cli",
+        "delete",
+        "11111111-1111-4111-8111-111111111111",
+      ]);
+
+      expect(deleteHitId).toBe("11111111-1111-4111-8111-111111111111");
+      const logCalls = mockConsoleLog.mock.calls.flat().join("\n");
+      expect(logCalls).toContain("deleted");
+    });
+
+    it("should handle a not-found automation", async () => {
+      server.use(
+        http.delete(
+          "http://localhost:3000/api/automations/webhooks/:id",
+          () => {
+            return HttpResponse.json(
+              { error: { message: "Not found", code: "NOT_FOUND" } },
+              { status: 404 },
+            );
+          },
+        ),
+      );
+
+      await expect(async () => {
+        await webhookCommand.parseAsync([
+          "node",
+          "cli",
+          "delete",
+          "11111111-1111-4111-8111-111111111111",
+        ]);
+      }).rejects.toThrow("process.exit called");
+
+      expect(mockExit).toHaveBeenCalledWith(1);
+    });
+  });
+});

--- a/turbo/apps/cli/src/commands/zero/automation/webhook/index.ts
+++ b/turbo/apps/cli/src/commands/zero/automation/webhook/index.ts
@@ -1,0 +1,271 @@
+import { Command } from "commander";
+import { readFileSync } from "node:fs";
+import chalk from "chalk";
+import type { WebhookAutomationResponse } from "../../../../lib/api";
+import {
+  createWebhookAutomation,
+  listWebhookAutomations,
+  deleteWebhookAutomation,
+  resolveCompose,
+} from "../../../../lib/api";
+import { withErrorHandler } from "../../../../lib/command";
+
+/**
+ * `zero automation webhook` — the events-first generic-webhook trigger surface.
+ * These automations live on the new `automations` / `automation_triggers` tables
+ * and are independent of the schedule-backed `zero automation setup` flow and
+ * `zero schedule`. Creation mints an unguessable inbound URL plus an HMAC signing
+ * secret; an external signed POST then fires the automation as an agent run.
+ */
+
+// Header the inbound route verifies the HMAC-SHA256 body signature against
+// (mirrors the GitHub webhook: `sha256=<hex>`). Kept in sync with
+// SIGNATURE_HEADER in apps/api webhooks-automation.service.ts.
+const SIGNATURE_HEADER = "x-vm0-signature-256";
+
+function resolveInstruction(
+  prompt: string | undefined,
+  promptFile: string | undefined,
+): string {
+  if (prompt && promptFile) {
+    throw new Error("Cannot use --prompt and --prompt-file together");
+  }
+  if (promptFile) {
+    return readFileSync(promptFile, "utf-8");
+  }
+  if (prompt) {
+    return prompt;
+  }
+  throw new Error("--prompt or --prompt-file is required");
+}
+
+/**
+ * A copy-pasteable, signed `curl` that the caller can run to fire the webhook.
+ * The body is signed exactly the way the inbound route verifies it: an
+ * HMAC-SHA256 of the raw request body keyed by the secret, sent as
+ * `<header>: sha256=<hex>`.
+ */
+function signedCurlExample(webhookUrl: string, secret: string): string {
+  return [
+    `SECRET='${secret}'`,
+    `BODY='{"hello":"world"}'`,
+    `SIG="sha256=$(printf '%s' "$BODY" | openssl dgst -sha256 -hmac "$SECRET" | sed 's/^.* //')"`,
+    `curl -X POST '${webhookUrl}' \\`,
+    `  -H "Content-Type: application/json" \\`,
+    `  -H "${SIGNATURE_HEADER}: $SIG" \\`,
+    `  -d "$BODY"`,
+  ].join("\n");
+}
+
+function printCreated(
+  automation: WebhookAutomationResponse,
+  secret: string,
+): void {
+  console.log(chalk.green(`✓ Webhook automation "${automation.name}" created`));
+  console.log(chalk.dim(`  ID:      ${automation.id}`));
+  console.log(chalk.dim(`  Agent:   ${automation.agentId}`));
+  console.log(chalk.dim(`  Thread:  ${automation.chatThreadId}`));
+  console.log();
+  console.log(chalk.bold("  Inbound URL:"));
+  console.log(`    ${automation.webhookUrl}`);
+  console.log();
+  console.log(chalk.bold("  Signing secret (shown once — store it now):"));
+  console.log(`    ${secret}`);
+  console.log();
+  console.log(chalk.bold("  Example (signed curl):"));
+  for (const line of signedCurlExample(automation.webhookUrl, secret).split(
+    "\n",
+  )) {
+    console.log(`    ${line}`);
+  }
+}
+
+const createCommand = new Command()
+  .name("create")
+  .description("Create a webhook-triggered automation for a zero agent")
+  .requiredOption("--agent-id <id>", "Agent ID or name to run on webhook")
+  .requiredOption("-n, --name <name>", "Automation name")
+  .option("-p, --prompt <text>", "Instruction the agent runs on each webhook")
+  .option(
+    "--prompt-file <path>",
+    "Read the instruction from a file (cannot be used with --prompt)",
+  )
+  .option("--description <text>", "Optional description")
+  .option("--json", "Print raw JSON (includes the secret)")
+  .addHelpText(
+    "after",
+    `
+Examples:
+  Create:  zero automation webhook create --agent-id <agent-id> -n alerts -p "Summarize the incoming alert"
+  From file:  zero automation webhook create --agent-id <agent-id> -n alerts --prompt-file ./instruction.md
+
+Notes:
+  - The signing secret is shown ONCE on creation and never again — store it securely.
+  - Sign the raw request body with HMAC-SHA256 and send it as the ${SIGNATURE_HEADER} header.`,
+  )
+  .action(
+    withErrorHandler(
+      async (options: {
+        agentId: string;
+        name: string;
+        prompt?: string;
+        promptFile?: string;
+        description?: string;
+        json?: boolean;
+      }) => {
+        const instruction = resolveInstruction(
+          options.prompt,
+          options.promptFile,
+        );
+
+        const compose = await resolveCompose(options.agentId);
+        if (!compose) {
+          throw new Error(`Agent not found: ${options.agentId}`);
+        }
+
+        const result = await createWebhookAutomation({
+          name: options.name,
+          instruction,
+          agentId: compose.id,
+          description: options.description,
+        });
+
+        if (options.json) {
+          console.log(JSON.stringify(result));
+          return;
+        }
+
+        printCreated(result.automation, result.secret);
+      },
+    ),
+  );
+
+function printList(automations: readonly WebhookAutomationResponse[]): void {
+  if (automations.length === 0) {
+    console.log(chalk.dim("No webhook automations found"));
+    console.log(
+      chalk.dim(
+        "  Create one with: zero automation webhook create --agent-id <agent-id> -n <name> -p <prompt>",
+      ),
+    );
+    return;
+  }
+
+  const idWidth = Math.max(
+    2,
+    ...automations.map((a) => {
+      return a.id.length;
+    }),
+  );
+  const nameWidth = Math.max(
+    4,
+    ...automations.map((a) => {
+      return a.name.length;
+    }),
+  );
+  const agentWidth = Math.max(
+    5,
+    ...automations.map((a) => {
+      return a.agentId.length;
+    }),
+  );
+
+  console.log(
+    chalk.dim(
+      [
+        "ID".padEnd(idWidth),
+        "NAME".padEnd(nameWidth),
+        "AGENT".padEnd(agentWidth),
+        "STATUS".padEnd(8),
+        "WEBHOOK URL",
+      ].join("  "),
+    ),
+  );
+
+  for (const automation of automations) {
+    const status = automation.enabled
+      ? chalk.green("enabled")
+      : chalk.yellow("disabled");
+    console.log(
+      [
+        automation.id.padEnd(idWidth),
+        automation.name.padEnd(nameWidth),
+        automation.agentId.padEnd(agentWidth),
+        status.padEnd(8 + (automation.enabled ? 0 : 2)),
+        automation.webhookUrl,
+      ].join("  "),
+    );
+  }
+}
+
+const listCommand = new Command()
+  .name("list")
+  .alias("ls")
+  .description("List webhook automations")
+  .option("--json", "Print raw JSON")
+  .addHelpText(
+    "after",
+    `
+Examples:
+  zero automation webhook list`,
+  )
+  .action(
+    withErrorHandler(async (options: { json?: boolean }) => {
+      const result = await listWebhookAutomations();
+
+      if (options.json) {
+        console.log(JSON.stringify(result.automations));
+        return;
+      }
+
+      printList(result.automations);
+    }),
+  );
+
+const deleteCommand = new Command()
+  .name("delete")
+  .alias("rm")
+  .description("Delete a webhook automation by ID")
+  .argument("<automation-id>", "Webhook automation ID")
+  .option("--json", "Print raw JSON")
+  .addHelpText(
+    "after",
+    `
+Examples:
+  zero automation webhook delete <automation-id>`,
+  )
+  .action(
+    withErrorHandler(
+      async (automationId: string, options: { json?: boolean }) => {
+        await deleteWebhookAutomation(automationId);
+
+        if (options.json) {
+          console.log(JSON.stringify({ id: automationId, deleted: true }));
+          return;
+        }
+
+        console.log(
+          chalk.green(`✓ Webhook automation ${automationId} deleted`),
+        );
+      },
+    ),
+  );
+
+export const webhookCommand = new Command()
+  .name("webhook")
+  .description("Manage webhook-triggered automations")
+  .addCommand(createCommand)
+  .addCommand(listCommand)
+  .addCommand(deleteCommand)
+  .addHelpText(
+    "after",
+    `
+Examples:
+  Create:  zero automation webhook create --agent-id <agent-id> -n alerts -p "Summarize the alert"
+  List:    zero automation webhook list
+  Delete:  zero automation webhook delete <automation-id>
+
+Notes:
+  - Webhook automations are separate from the time/schedule automations created by "zero automation setup".
+  - On create, the inbound URL and a one-time signing secret are printed; store the secret securely.`,
+  );

--- a/turbo/apps/cli/src/lib/api/domains/webhook-automations.ts
+++ b/turbo/apps/cli/src/lib/api/domains/webhook-automations.ts
@@ -1,0 +1,79 @@
+import { initClient } from "@ts-rest/core";
+import {
+  webhookAutomationsMainContract,
+  webhookAutomationsByIdContract,
+} from "@vm0/api-contracts/contracts/webhook-automations";
+import { getClientConfig, handleError } from "../core/client-factory";
+import type {
+  WebhookAutomationResponse,
+  WebhookAutomationListResponse,
+  WebhookAutomationCreateResponse,
+} from "@vm0/api-contracts/contracts/webhook-automations";
+
+/**
+ * Webhook-automation CLI client. Targets the events-first webhook automations
+ * (new `automations` + `automation_triggers` tables) — distinct from the
+ * schedule-backed automations in `zero-automations.ts`. Create returns the HMAC
+ * secret exactly once; list/get never project it.
+ */
+
+/**
+ * Create a webhook automation. The response carries the durable projection
+ * (including the inbound `webhookUrl`/`webhookToken`) plus the signing `secret`,
+ * which is surfaced once and never returned again.
+ */
+export async function createWebhookAutomation(body: {
+  name: string;
+  instruction: string;
+  agentId: string;
+  description?: string;
+  enabled?: boolean;
+  chatThreadId?: string;
+}): Promise<WebhookAutomationCreateResponse> {
+  const config = await getClientConfig();
+  const client = initClient(webhookAutomationsMainContract, config);
+
+  const result = await client.create({ body });
+
+  if (result.status === 201) {
+    return result.body;
+  }
+
+  handleError(result, "Failed to create webhook automation");
+}
+
+/**
+ * List webhook automations for the active org/user. The signing secret is never
+ * part of this projection.
+ */
+export async function listWebhookAutomations(): Promise<WebhookAutomationListResponse> {
+  const config = await getClientConfig();
+  const client = initClient(webhookAutomationsMainContract, config);
+
+  const result = await client.list({ headers: {} });
+
+  if (result.status === 200) {
+    return result.body;
+  }
+
+  handleError(result, "Failed to list webhook automations");
+}
+
+/**
+ * Delete a webhook automation by id. Cascades its trigger row (FK ON DELETE
+ * CASCADE).
+ */
+export async function deleteWebhookAutomation(id: string): Promise<void> {
+  const config = await getClientConfig();
+  const client = initClient(webhookAutomationsByIdContract, config);
+
+  const result = await client.delete({ params: { id } });
+
+  if (result.status === 204) {
+    return;
+  }
+
+  handleError(result, "Failed to delete webhook automation");
+}
+
+export type { WebhookAutomationResponse };

--- a/turbo/apps/cli/src/lib/api/index.ts
+++ b/turbo/apps/cli/src/lib/api/index.ts
@@ -184,6 +184,14 @@ export {
   resolveZeroAutomationByAgent,
 } from "./domains/zero-automations";
 
+// Domain modules - Webhook Automations
+export {
+  createWebhookAutomation,
+  listWebhookAutomations,
+  deleteWebhookAutomation,
+  type WebhookAutomationResponse,
+} from "./domains/webhook-automations";
+
 // Domain modules - Zero Runs
 export { getZeroRunAgentEvents } from "./domains/zero-runs";
 


### PR DESCRIPTION
Closes #16757. Part of #16616. Stacked on #16776.

Adds a `zero automation webhook` subcommand group (create/list/delete) over the new management API; create prints the inbound URL + secret (shown once) and a signed-curl example. Separate client domain + subcommand from the schedule-backed `zero automation setup`/`zero schedule` (untouched). MSW integration tests at the command entries.