### PR TITLE
docs: document copy file semantics

### DIFF
--- a/crates/runner/src/executor/tests/support/sandbox.rs
+++ b/crates/runner/src/executor/tests/support/sandbox.rs
@@ -1,4 +1,5 @@
 use std::collections::VecDeque;
+use std::path::Path;
 use std::sync::{Arc, Mutex};
 use std::time::Duration;
 
@@ -9,6 +10,8 @@ use sandbox::{
     StartProcessRequest,
 };
 use sandbox_mock::MockSandboxFactory;
+
+const QUEUED_COPY_FILE_MAX_BYTES: u64 = 64 * 1024 * 1024;
 
 pub(in crate::executor::tests) struct DestroyPanicFactory {
     pub(in crate::executor::tests) inner: MockSandboxFactory,
@@ -54,6 +57,73 @@ pub(in crate::executor::tests) fn sandbox_write_file_error(
         reason: SandboxOperationReason::Guest,
         message: message.into(),
     }
+}
+
+fn queued_copy_file_error(message: impl Into<String>) -> SandboxError {
+    SandboxError::Operation {
+        operation: SandboxOperation::CopyFile,
+        reason: SandboxOperationReason::Other,
+        message: message.into(),
+    }
+}
+
+fn validate_queued_copy_guest_path(path: &str) -> sandbox::Result<()> {
+    if path.is_empty() {
+        return Err(queued_copy_file_error(
+            "test copy_file guest file path must not be empty",
+        ));
+    }
+    if path.as_bytes().contains(&0) {
+        return Err(queued_copy_file_error(
+            "test copy_file guest file path contains NUL bytes",
+        ));
+    }
+    Ok(())
+}
+
+fn validate_queued_copy_host_path(host_path: &Path) -> sandbox::Result<()> {
+    let path_text = host_path.as_os_str().to_string_lossy();
+    if path_text.is_empty() {
+        return Err(queued_copy_file_error(
+            "test copy_file host path must not be empty",
+        ));
+    }
+    if path_text.contains('\0') {
+        return Err(queued_copy_file_error(
+            "test copy_file host path contains NUL bytes",
+        ));
+    }
+    if host_path.file_name().is_none() || path_text.ends_with('/') || path_text.ends_with("/.") {
+        return Err(queued_copy_file_error(
+            "test copy_file host path must name a file",
+        ));
+    }
+    Ok(())
+}
+
+fn validate_queued_copy_options(
+    path: &str,
+    host_path: &Path,
+    options: CopyFileOptions,
+) -> sandbox::Result<()> {
+    validate_queued_copy_guest_path(path)?;
+    validate_queued_copy_host_path(host_path)?;
+    if options.max_bytes == 0 {
+        return Err(queued_copy_file_error(
+            "test copy_file max_bytes must be positive",
+        ));
+    }
+    if options.max_bytes > QUEUED_COPY_FILE_MAX_BYTES {
+        return Err(queued_copy_file_error(format!(
+            "test copy_file max_bytes must be at most {QUEUED_COPY_FILE_MAX_BYTES}"
+        )));
+    }
+    if options.timeout.is_zero() {
+        return Err(queued_copy_file_error(
+            "test copy_file timeout must be positive",
+        ));
+    }
+    Ok(())
 }
 
 pub(in crate::executor::tests) fn sandbox_create_error(message: impl Into<String>) -> SandboxError {
@@ -213,9 +283,10 @@ impl Sandbox for QueuedCopyFileSandbox {
     async fn copy_file(
         &self,
         path: &str,
-        host_path: &std::path::Path,
+        host_path: &Path,
         options: CopyFileOptions,
     ) -> sandbox::Result<sandbox::CopyFileResult> {
+        validate_queued_copy_options(path, host_path, options)?;
         if let Some(path) = &self.remove_path_before_copy {
             let _ = std::fs::remove_file(path);
         }
@@ -281,4 +352,102 @@ pub(in crate::executor::tests) async fn create_overridden_sandbox(
         })
         .await
         .unwrap()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn copy_options(max_bytes: u64, timeout: Duration) -> CopyFileOptions {
+        CopyFileOptions {
+            max_bytes,
+            timeout,
+            missing_ok: false,
+        }
+    }
+
+    fn assert_copy_file_error(error: SandboxError, expected_message: &str) {
+        match error {
+            SandboxError::Operation {
+                operation,
+                reason,
+                message,
+            } => {
+                assert_eq!(operation, SandboxOperation::CopyFile);
+                assert_eq!(reason, SandboxOperationReason::Other);
+                assert!(message.contains(expected_message), "{message}");
+            }
+            other => panic!("expected copy_file operation error, got {other:?}"),
+        }
+    }
+
+    #[tokio::test]
+    async fn queued_copy_file_validates_before_side_effect_or_queue() {
+        let dir = tempfile::tempdir().unwrap();
+        let side_effect_path = dir.path().join("proxy-registry.json");
+        std::fs::write(&side_effect_path, b"registry").unwrap();
+        let host_path = dir.path().join("nested/system.log");
+        let sandbox = QueuedCopyFileSandbox::new(
+            Box::new(sandbox_mock::MockSandbox::new("test-1")),
+            vec![b"queued log\n".to_vec()],
+        )
+        .with_remove_path_before_copy(side_effect_path.clone());
+
+        let invalid_calls = [
+            (
+                "",
+                host_path.as_path(),
+                copy_options(1024, Duration::from_secs(5)),
+                "guest file path",
+            ),
+            (
+                "/tmp/system.log",
+                Path::new(""),
+                copy_options(1024, Duration::from_secs(5)),
+                "host path",
+            ),
+            (
+                "/tmp/system.log",
+                host_path.as_path(),
+                copy_options(0, Duration::from_secs(5)),
+                "max_bytes must be positive",
+            ),
+            (
+                "/tmp/system.log",
+                host_path.as_path(),
+                copy_options(QUEUED_COPY_FILE_MAX_BYTES + 1, Duration::from_secs(5)),
+                "max_bytes must be at most",
+            ),
+            (
+                "/tmp/system.log",
+                host_path.as_path(),
+                copy_options(1024, Duration::ZERO),
+                "timeout must be positive",
+            ),
+        ];
+
+        for (guest_path, host_path, options, expected_message) in invalid_calls {
+            let err = sandbox
+                .copy_file(guest_path, host_path, options)
+                .await
+                .unwrap_err();
+            assert_copy_file_error(err, expected_message);
+            assert!(side_effect_path.exists());
+        }
+        assert!(!host_path.exists());
+        assert!(!host_path.parent().unwrap().exists());
+
+        let result = sandbox
+            .copy_file(
+                "/tmp/system.log",
+                &host_path,
+                copy_options(1024, Duration::from_secs(5)),
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(result.bytes_copied, 11);
+        assert!(!side_effect_path.exists());
+        assert_eq!(std::fs::read(&host_path).unwrap(), b"queued log\n");
+    }
 }

--- a/crates/sandbox-mock/src/lib.rs
+++ b/crates/sandbox-mock/src/lib.rs
@@ -972,9 +972,10 @@ impl MockSandbox {
     /// Return this sandbox's recorded copy-file calls.
     ///
     /// The returned vector is a cloned snapshot in recorded order. Calls are
-    /// recorded before mock validation errors such as zero `max_bytes`, zero
-    /// timeout, or invalid host paths are returned. Copy-file calls are sandbox-local; shared
-    /// overrides do not expose a copy-file call accessor.
+    /// recorded before mock validation errors such as invalid guest paths,
+    /// zero `max_bytes`, zero timeout, or invalid host paths are returned.
+    /// Copy-file calls are sandbox-local; shared overrides do not expose a
+    /// copy-file call accessor.
     pub fn copy_file_calls(&self) -> Vec<CopyFileCall> {
         self.copy_file_calls.lock_ignoring_poison().clone()
     }
@@ -2140,6 +2141,7 @@ mod tests {
         );
         assert!(!path.exists());
 
+        sandbox.push_copy_file_result(Ok(b"host ok\n".to_vec()));
         for invalid_host_path in ["", ".", "/tmp/", "/tmp/.", "/tmp/bad\0host.log"] {
             let err = sandbox
                 .copy_file(
@@ -2160,6 +2162,22 @@ mod tests {
                 "host path",
             );
         }
+
+        let result = sandbox
+            .copy_file(
+                "/tmp/system.log",
+                &path,
+                CopyFileOptions {
+                    max_bytes: 1024,
+                    timeout: Duration::from_secs(5),
+                    missing_ok: false,
+                },
+            )
+            .await
+            .unwrap();
+        assert_eq!(result.bytes_copied, 8);
+        assert_eq!(std::fs::read(&path).unwrap(), b"host ok\n");
+        std::fs::remove_file(&path).unwrap();
     }
 
     #[tokio::test]
@@ -2235,6 +2253,19 @@ mod tests {
             SandboxOperationReason::Other,
             "max_bytes must be positive",
         );
+
+        sandbox.push_read_file_result(Ok(Some(b"after invalid max\n".to_vec())));
+        let err = sandbox.read_file("/tmp/system.log", 0).await.unwrap_err();
+
+        assert_operation_error(
+            err,
+            SandboxOperation::ReadFile,
+            SandboxOperationReason::Other,
+            "max_bytes must be positive",
+        );
+
+        let result = sandbox.read_file("/tmp/system.log", 1024).await.unwrap();
+        assert_eq!(result.as_deref(), Some(&b"after invalid max\n"[..]));
     }
 
     #[tokio::test]

--- a/crates/sandbox-mock/src/lib.rs
+++ b/crates/sandbox-mock/src/lib.rs
@@ -132,7 +132,8 @@ pub struct CopyFileCall {
     pub max_bytes: u64,
     /// Timeout requested for the copy operation.
     pub timeout: Duration,
-    /// Whether a missing guest source should be accepted as a no-op.
+    /// Whether a backend-reported missing or non-regular guest source should
+    /// succeed without writing the host destination.
     pub missing_ok: bool,
 }
 
@@ -1934,6 +1935,33 @@ mod tests {
 
         assert_eq!(result.bytes_copied, 0);
         assert!(!path.exists());
+    }
+
+    #[tokio::test]
+    async fn sandbox_copy_file_missing_ok_default_preserves_existing_host_file() {
+        let sandbox = MockSandbox::new("test-1");
+        let path = std::env::temp_dir().join(format!(
+            "sandbox-mock-copy-missing-existing-{}",
+            uuid::Uuid::new_v4().simple()
+        ));
+        std::fs::write(&path, b"old host log").unwrap();
+
+        let result = sandbox
+            .copy_file(
+                "/tmp/missing.log",
+                &path,
+                CopyFileOptions {
+                    max_bytes: 1024,
+                    timeout: Duration::from_secs(5),
+                    missing_ok: true,
+                },
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(result.bytes_copied, 0);
+        assert_eq!(std::fs::read(&path).unwrap(), b"old host log");
+        let _ = std::fs::remove_file(path);
     }
 
     #[tokio::test]

--- a/crates/sandbox-mock/src/lib.rs
+++ b/crates/sandbox-mock/src/lib.rs
@@ -39,12 +39,39 @@ impl<T> LockIgnoringPoison<T> for Mutex<T> {
     }
 }
 
-fn mock_copy_file_error(message: impl Into<String>) -> SandboxError {
+fn mock_file_operation_error(
+    operation: SandboxOperation,
+    message: impl Into<String>,
+) -> SandboxError {
     SandboxError::Operation {
-        operation: SandboxOperation::CopyFile,
+        operation,
         reason: SandboxOperationReason::Other,
         message: message.into(),
     }
+}
+
+fn mock_copy_file_error(message: impl Into<String>) -> SandboxError {
+    mock_file_operation_error(SandboxOperation::CopyFile, message)
+}
+
+fn validate_mock_guest_file_path(
+    operation: SandboxOperation,
+    operation_name: &str,
+    path: &str,
+) -> Result<()> {
+    if path.is_empty() {
+        return Err(mock_file_operation_error(
+            operation,
+            format!("mock {operation_name} guest file path must not be empty"),
+        ));
+    }
+    if path.as_bytes().contains(&0) {
+        return Err(mock_file_operation_error(
+            operation,
+            format!("mock {operation_name} guest file path contains NUL bytes"),
+        ));
+    }
+    Ok(())
 }
 
 fn validate_mock_copy_host_path(host_path: &Path) -> Result<()> {
@@ -928,8 +955,8 @@ impl MockSandbox {
     /// Return this sandbox's recorded read-file calls.
     ///
     /// The returned vector is a cloned snapshot in recorded order. Calls are
-    /// recorded before mock validation errors such as zero `max_bytes` are
-    /// returned.
+    /// recorded before mock validation errors such as invalid guest paths or
+    /// zero `max_bytes` are returned.
     pub fn read_file_calls(&self) -> Vec<ReadFileCall> {
         self.read_file_calls.lock_ignoring_poison().clone()
     }
@@ -1125,6 +1152,7 @@ impl Sandbox for MockSandbox {
                 path: path.to_string(),
                 max_bytes,
             });
+        validate_mock_guest_file_path(SandboxOperation::ReadFile, "read_file", path)?;
         if max_bytes == 0 {
             return Err(SandboxError::Operation {
                 operation: SandboxOperation::ReadFile,
@@ -1173,6 +1201,7 @@ impl Sandbox for MockSandbox {
                 timeout: options.timeout,
                 missing_ok: options.missing_ok,
             });
+        validate_mock_guest_file_path(SandboxOperation::CopyFile, "copy_file", path)?;
         validate_mock_copy_host_path(host_path)?;
         if options.max_bytes == 0 {
             return Err(SandboxError::Operation {
@@ -2032,6 +2061,45 @@ mod tests {
             uuid::Uuid::new_v4().simple()
         ));
 
+        sandbox.push_copy_file_result(Ok(b"valid log\n".to_vec()));
+        for invalid_guest_path in ["", "/tmp/bad\0path.log"] {
+            let err = sandbox
+                .copy_file(
+                    invalid_guest_path,
+                    &path,
+                    CopyFileOptions {
+                        max_bytes: 1024,
+                        timeout: Duration::from_secs(5),
+                        missing_ok: true,
+                    },
+                )
+                .await
+                .unwrap_err();
+            assert_operation_error(
+                err,
+                SandboxOperation::CopyFile,
+                SandboxOperationReason::Other,
+                "guest file path",
+            );
+            assert!(!path.exists());
+        }
+
+        let result = sandbox
+            .copy_file(
+                "/tmp/system.log",
+                &path,
+                CopyFileOptions {
+                    max_bytes: 1024,
+                    timeout: Duration::from_secs(5),
+                    missing_ok: false,
+                },
+            )
+            .await
+            .unwrap();
+        assert_eq!(result.bytes_copied, 10);
+        assert_eq!(std::fs::read(&path).unwrap(), b"valid log\n");
+        std::fs::remove_file(&path).unwrap();
+
         let err = sandbox
             .copy_file(
                 "/tmp/system.log",
@@ -2138,8 +2206,26 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn sandbox_read_file_rejects_zero_max_bytes() {
+    async fn sandbox_read_file_rejects_invalid_options() {
         let sandbox = MockSandbox::new("test-1");
+        sandbox.push_read_file_result(Ok(Some(b"valid log\n".to_vec())));
+
+        for invalid_guest_path in ["", "/tmp/bad\0path.log"] {
+            let err = sandbox
+                .read_file(invalid_guest_path, 1024)
+                .await
+                .unwrap_err();
+
+            assert_operation_error(
+                err,
+                SandboxOperation::ReadFile,
+                SandboxOperationReason::Other,
+                "guest file path",
+            );
+        }
+
+        let result = sandbox.read_file("/tmp/system.log", 1024).await.unwrap();
+        assert_eq!(result.as_deref(), Some(&b"valid log\n"[..]));
 
         let err = sandbox.read_file("/tmp/system.log", 0).await.unwrap_err();
 

--- a/crates/sandbox-mock/src/lib.rs
+++ b/crates/sandbox-mock/src/lib.rs
@@ -25,6 +25,8 @@ use std::time::Duration;
 use async_trait::async_trait;
 use sandbox::*;
 
+const MOCK_COPY_FILE_MAX_BYTES: u64 = 64 * 1024 * 1024;
+
 /// Ignore mutex poisoning and take the lock anyway.
 ///
 /// Callers here are test doubles; surfacing a poison error would appear as
@@ -955,8 +957,8 @@ impl MockSandbox {
     /// Return this sandbox's recorded read-file calls.
     ///
     /// The returned vector is a cloned snapshot in recorded order. Calls are
-    /// recorded before mock validation errors such as invalid guest paths or
-    /// zero `max_bytes` are returned.
+    /// recorded before mock validation errors such as invalid guest paths,
+    /// oversized `max_bytes`, or zero `max_bytes` are returned.
     pub fn read_file_calls(&self) -> Vec<ReadFileCall> {
         self.read_file_calls.lock_ignoring_poison().clone()
     }
@@ -973,9 +975,9 @@ impl MockSandbox {
     ///
     /// The returned vector is a cloned snapshot in recorded order. Calls are
     /// recorded before mock validation errors such as invalid guest paths,
-    /// zero `max_bytes`, zero timeout, or invalid host paths are returned.
-    /// Copy-file calls are sandbox-local; shared overrides do not expose a
-    /// copy-file call accessor.
+    /// oversized `max_bytes`, zero `max_bytes`, zero timeout, or invalid host
+    /// paths are returned. Copy-file calls are sandbox-local; shared overrides
+    /// do not expose a copy-file call accessor.
     pub fn copy_file_calls(&self) -> Vec<CopyFileCall> {
         self.copy_file_calls.lock_ignoring_poison().clone()
     }
@@ -1154,6 +1156,13 @@ impl Sandbox for MockSandbox {
                 max_bytes,
             });
         validate_mock_guest_file_path(SandboxOperation::ReadFile, "read_file", path)?;
+        if max_bytes > u64::from(u32::MAX) {
+            return Err(SandboxError::Operation {
+                operation: SandboxOperation::ReadFile,
+                reason: SandboxOperationReason::Other,
+                message: "mock read_file max_bytes exceeds exec capture limit".into(),
+            });
+        }
         if max_bytes == 0 {
             return Err(SandboxError::Operation {
                 operation: SandboxOperation::ReadFile,
@@ -1209,6 +1218,15 @@ impl Sandbox for MockSandbox {
                 operation: SandboxOperation::CopyFile,
                 reason: SandboxOperationReason::Other,
                 message: "mock copy_file max_bytes must be positive".into(),
+            });
+        }
+        if options.max_bytes > MOCK_COPY_FILE_MAX_BYTES {
+            return Err(SandboxError::Operation {
+                operation: SandboxOperation::CopyFile,
+                reason: SandboxOperationReason::Other,
+                message: format!(
+                    "mock copy_file max_bytes must be at most {MOCK_COPY_FILE_MAX_BYTES}"
+                ),
             });
         }
         if options.timeout.is_zero() {
@@ -2142,6 +2160,26 @@ mod tests {
         );
         assert!(!path.exists());
 
+        let err = sandbox
+            .copy_file(
+                "/tmp/system.log",
+                &path,
+                CopyFileOptions {
+                    max_bytes: MOCK_COPY_FILE_MAX_BYTES + 1,
+                    timeout: Duration::from_secs(5),
+                    missing_ok: true,
+                },
+            )
+            .await
+            .unwrap_err();
+        assert_operation_error(
+            err,
+            SandboxOperation::CopyFile,
+            SandboxOperationReason::Other,
+            "max_bytes must be at most",
+        );
+        assert!(!path.exists());
+
         let result = sandbox
             .copy_file(
                 "/tmp/system.log",
@@ -2270,6 +2308,22 @@ mod tests {
             SandboxOperationReason::Other,
             "max_bytes must be positive",
         );
+
+        sandbox.push_read_file_result(Ok(Some(b"after oversized max\n".to_vec())));
+        let err = sandbox
+            .read_file("/tmp/system.log", u64::from(u32::MAX) + 1)
+            .await
+            .unwrap_err();
+
+        assert_operation_error(
+            err,
+            SandboxOperation::ReadFile,
+            SandboxOperationReason::Other,
+            "max_bytes exceeds exec capture limit",
+        );
+
+        let result = sandbox.read_file("/tmp/system.log", 1024).await.unwrap();
+        assert_eq!(result.as_deref(), Some(&b"after oversized max\n"[..]));
 
         sandbox.push_read_file_result(Ok(Some(b"after invalid max\n".to_vec())));
         let err = sandbox.read_file("/tmp/system.log", 0).await.unwrap_err();

--- a/crates/sandbox-mock/src/lib.rs
+++ b/crates/sandbox-mock/src/lib.rs
@@ -2101,6 +2101,7 @@ mod tests {
         assert_eq!(std::fs::read(&path).unwrap(), b"valid log\n");
         std::fs::remove_file(&path).unwrap();
 
+        sandbox.push_copy_file_result(Ok(b"opts ok\n".to_vec()));
         let err = sandbox
             .copy_file(
                 "/tmp/system.log",
@@ -2140,6 +2141,22 @@ mod tests {
             "timeout must be positive",
         );
         assert!(!path.exists());
+
+        let result = sandbox
+            .copy_file(
+                "/tmp/system.log",
+                &path,
+                CopyFileOptions {
+                    max_bytes: 1024,
+                    timeout: Duration::from_secs(5),
+                    missing_ok: false,
+                },
+            )
+            .await
+            .unwrap();
+        assert_eq!(result.bytes_copied, 8);
+        assert_eq!(std::fs::read(&path).unwrap(), b"opts ok\n");
+        std::fs::remove_file(&path).unwrap();
 
         sandbox.push_copy_file_result(Ok(b"host ok\n".to_vec()));
         for invalid_host_path in ["", ".", "/tmp/", "/tmp/.", "/tmp/bad\0host.log"] {

--- a/crates/sandbox-mock/src/lib.rs
+++ b/crates/sandbox-mock/src/lib.rs
@@ -18,6 +18,7 @@
 //! ```
 
 use std::collections::VecDeque;
+use std::os::unix::ffi::OsStrExt;
 use std::path::{Path, PathBuf};
 use std::sync::{Arc, Mutex, MutexGuard};
 use std::time::Duration;
@@ -37,6 +38,35 @@ impl<T> LockIgnoringPoison<T> for Mutex<T> {
     fn lock_ignoring_poison(&self) -> MutexGuard<'_, T> {
         self.lock().unwrap_or_else(|e| e.into_inner())
     }
+}
+
+fn mock_copy_file_error(message: impl Into<String>) -> SandboxError {
+    SandboxError::Operation {
+        operation: SandboxOperation::CopyFile,
+        reason: SandboxOperationReason::Other,
+        message: message.into(),
+    }
+}
+
+fn validate_mock_copy_host_path(host_path: &Path) -> Result<()> {
+    let path_bytes = host_path.as_os_str().as_bytes();
+    if path_bytes.is_empty() {
+        return Err(mock_copy_file_error(
+            "mock copy_file host path must not be empty",
+        ));
+    }
+    if path_bytes.contains(&0) {
+        return Err(mock_copy_file_error(
+            "mock copy_file host path contains NUL bytes",
+        ));
+    }
+    if host_path.file_name().is_none() || path_bytes.ends_with(b"/") || path_bytes.ends_with(b"/.")
+    {
+        return Err(mock_copy_file_error(
+            "mock copy_file host path must name a file",
+        ));
+    }
+    Ok(())
 }
 
 // ---------------------------------------------------------------------------
@@ -917,8 +947,8 @@ impl MockSandbox {
     /// Return this sandbox's recorded copy-file calls.
     ///
     /// The returned vector is a cloned snapshot in recorded order. Calls are
-    /// recorded before mock validation errors such as zero `max_bytes` or zero
-    /// timeout are returned. Copy-file calls are sandbox-local; shared
+    /// recorded before mock validation errors such as zero `max_bytes`, zero
+    /// timeout, or invalid host paths are returned. Copy-file calls are sandbox-local; shared
     /// overrides do not expose a copy-file call accessor.
     pub fn copy_file_calls(&self) -> Vec<CopyFileCall> {
         self.copy_file_calls.lock_ignoring_poison().clone()
@@ -1145,6 +1175,7 @@ impl Sandbox for MockSandbox {
                 timeout: options.timeout,
                 missing_ok: options.missing_ok,
             });
+        validate_mock_copy_host_path(host_path)?;
         if options.max_bytes == 0 {
             return Err(SandboxError::Operation {
                 operation: SandboxOperation::CopyFile,
@@ -2042,6 +2073,27 @@ mod tests {
             "timeout must be positive",
         );
         assert!(!path.exists());
+
+        for invalid_host_path in ["", ".", "/tmp/", "/tmp/.", "/tmp/bad\0host.log"] {
+            let err = sandbox
+                .copy_file(
+                    "/tmp/system.log",
+                    Path::new(invalid_host_path),
+                    CopyFileOptions {
+                        max_bytes: 1024,
+                        timeout: Duration::from_secs(5),
+                        missing_ok: true,
+                    },
+                )
+                .await
+                .unwrap_err();
+            assert_operation_error(
+                err,
+                SandboxOperation::CopyFile,
+                SandboxOperationReason::Other,
+                "host path",
+            );
+        }
     }
 
     #[tokio::test]

--- a/crates/sandbox-mock/src/lib.rs
+++ b/crates/sandbox-mock/src/lib.rs
@@ -18,7 +18,6 @@
 //! ```
 
 use std::collections::VecDeque;
-use std::os::unix::ffi::OsStrExt;
 use std::path::{Path, PathBuf};
 use std::sync::{Arc, Mutex, MutexGuard};
 use std::time::Duration;
@@ -49,19 +48,18 @@ fn mock_copy_file_error(message: impl Into<String>) -> SandboxError {
 }
 
 fn validate_mock_copy_host_path(host_path: &Path) -> Result<()> {
-    let path_bytes = host_path.as_os_str().as_bytes();
-    if path_bytes.is_empty() {
+    let path_text = host_path.as_os_str().to_string_lossy();
+    if path_text.is_empty() {
         return Err(mock_copy_file_error(
             "mock copy_file host path must not be empty",
         ));
     }
-    if path_bytes.contains(&0) {
+    if path_text.contains('\0') {
         return Err(mock_copy_file_error(
             "mock copy_file host path contains NUL bytes",
         ));
     }
-    if host_path.file_name().is_none() || path_bytes.ends_with(b"/") || path_bytes.ends_with(b"/.")
-    {
+    if host_path.file_name().is_none() || path_text.ends_with('/') || path_text.ends_with("/.") {
         return Err(mock_copy_file_error(
             "mock copy_file host path must name a file",
         ));

--- a/crates/sandbox/src/sandbox.rs
+++ b/crates/sandbox/src/sandbox.rs
@@ -206,10 +206,15 @@ pub trait Sandbox: Send + Sync + Any {
 
     /// Read a small file from the guest.
     ///
+    /// The guest path must be non-empty and must not contain NUL bytes.
+    /// `max_bytes` must be positive and is subject to the backend read limit.
+    ///
     /// Missing files return `Ok(None)`. Other read failures return an error.
     async fn read_file(&self, path: &str, max_bytes: u64) -> Result<Option<Vec<u8>>>;
 
     /// Stream a guest file to a host path and publish copied contents.
+    ///
+    /// The guest path must be non-empty and must not contain NUL bytes.
     ///
     /// If [`CopyFileOptions::missing_ok`] is enabled, a backend result that
     /// reports the path does not resolve to a regular file is treated as

--- a/crates/sandbox/src/sandbox.rs
+++ b/crates/sandbox/src/sandbox.rs
@@ -209,7 +209,14 @@ pub trait Sandbox: Send + Sync + Any {
     /// Missing files return `Ok(None)`. Other read failures return an error.
     async fn read_file(&self, path: &str, max_bytes: u64) -> Result<Option<Vec<u8>>>;
 
-    /// Stream a guest file to a host path and atomically publish it on success.
+    /// Stream a guest file to a host path and atomically publish copied
+    /// contents.
+    ///
+    /// If [`CopyFileOptions::missing_ok`] is enabled, a backend result that
+    /// reports the path does not resolve to a regular file is treated as
+    /// success with `bytes_copied == 0` without publishing a host file or
+    /// replacing an existing host file. Host-side setup and validation errors
+    /// can still fail the operation.
     async fn copy_file(
         &self,
         path: &str,

--- a/crates/sandbox/src/sandbox.rs
+++ b/crates/sandbox/src/sandbox.rs
@@ -209,8 +209,7 @@ pub trait Sandbox: Send + Sync + Any {
     /// Missing files return `Ok(None)`. Other read failures return an error.
     async fn read_file(&self, path: &str, max_bytes: u64) -> Result<Option<Vec<u8>>>;
 
-    /// Stream a guest file to a host path and atomically publish copied
-    /// contents.
+    /// Stream a guest file to a host path and publish copied contents.
     ///
     /// If [`CopyFileOptions::missing_ok`] is enabled, a backend result that
     /// reports the path does not resolve to a regular file is treated as

--- a/crates/sandbox/src/types.rs
+++ b/crates/sandbox/src/types.rs
@@ -131,8 +131,7 @@ impl ExecResult {
 pub struct CopyFileOptions {
     /// Maximum bytes to copy before failing.
     ///
-    /// This value must be positive and is subject to the backend copy stream
-    /// limit.
+    /// This value must be positive and is subject to the backend copy limit.
     pub max_bytes: u64,
     /// Guest-side copy command timeout.
     ///

--- a/crates/sandbox/src/types.rs
+++ b/crates/sandbox/src/types.rs
@@ -130,10 +130,20 @@ impl ExecResult {
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
 pub struct CopyFileOptions {
     /// Maximum bytes to copy before failing.
+    ///
+    /// This value must be positive and is subject to the backend copy stream
+    /// limit.
     pub max_bytes: u64,
     /// Guest-side copy command timeout.
+    ///
+    /// This value must be non-zero.
     pub timeout: Duration,
-    /// Treat a missing guest file as a successful zero-byte copy.
+    /// Treat a backend result that reports the path does not resolve to a
+    /// regular file as a successful copy result.
+    ///
+    /// When such a backend result is treated as success, the operation returns
+    /// `bytes_copied == 0` without creating an empty host file or replacing an
+    /// existing host file.
     pub missing_ok: bool,
 }
 
@@ -150,7 +160,12 @@ impl CopyFileOptions {
 /// Result of copying a guest file to a host path.
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
 pub struct CopyFileResult {
-    /// Number of bytes copied into the host file.
+    /// Number of bytes copied from the guest file.
+    ///
+    /// This is `0` for a present empty guest file, which still publishes an
+    /// empty host file. It is also `0` when `missing_ok` turns a backend
+    /// result that reports the path does not resolve to a regular file into
+    /// success; in that case no host file is published.
     pub bytes_copied: u64,
 }
 

--- a/crates/vsock-host/src/file/copy.rs
+++ b/crates/vsock-host/src/file/copy.rs
@@ -571,7 +571,17 @@ impl VsockHost {
             .map_err(CopyFileToTempError::terminal)?
         {
             CopyFileExecStatus::Present => {}
-            CopyFileExecStatus::Missing => return Ok(CopyFileOutcome::Missing),
+            CopyFileExecStatus::Missing => {
+                if bytes_copied != 0 {
+                    return Err(CopyFileToTempError::terminal(io::Error::new(
+                        io::ErrorKind::InvalidData,
+                        format!(
+                            "copy_file missing result for {path} streamed {bytes_copied} bytes"
+                        ),
+                    )));
+                }
+                return Ok(CopyFileOutcome::Missing);
+            }
         }
         temp_file
             .flush()

--- a/crates/vsock-host/src/file/copy.rs
+++ b/crates/vsock-host/src/file/copy.rs
@@ -401,6 +401,8 @@ impl VsockHost {
     /// without publishing a host file. Host-side setup and validation errors
     /// can still fail the operation.
     ///
+    /// The guest path must be non-empty and must not contain NUL bytes.
+    ///
     /// The host path must name a file destination. Empty host paths, paths
     /// containing NUL bytes, and paths that end in a directory marker are
     /// rejected before guest work starts.

--- a/crates/vsock-host/src/file/copy.rs
+++ b/crates/vsock-host/src/file/copy.rs
@@ -319,13 +319,16 @@ fn validate_copy_exec_result(
         exec_operation::append_diagnostic(&mut stderr, "stderr truncated");
     }
     match result.termination {
-        ExecTermination::Exited { exit_code: 0 } if !stderr_truncated => {
+        ExecTermination::Exited { exit_code: 0 } if stderr.is_empty() => {
             Ok(CopyFileExecStatus::Present)
         }
-        ExecTermination::Exited { exit_code: 0 } => Err(io::Error::other(format!(
-            "copy_file stderr exceeded diagnostic limit for {path}: {}",
-            String::from_utf8_lossy(&stderr)
-        ))),
+        ExecTermination::Exited { exit_code: 0 } => Err(io::Error::new(
+            io::ErrorKind::InvalidData,
+            format!(
+                "copy_file result for {path} included stderr: {}",
+                String::from_utf8_lossy(&stderr)
+            ),
+        )),
         ExecTermination::Exited { exit_code: 66 } if missing_ok && stderr.is_empty() => {
             Ok(CopyFileExecStatus::Missing)
         }

--- a/crates/vsock-host/src/file/copy.rs
+++ b/crates/vsock-host/src/file/copy.rs
@@ -17,7 +17,7 @@ use super::{file_operation_error_is_terminal, shell_quote};
 const COPY_TEMP_CREATE_ATTEMPTS: usize = 16;
 const COPY_TEMP_FILE_MODE: u32 = 0o600;
 const GROUP_OR_OTHER_WRITE_BITS: u32 = 0o022;
-const COPY_FILE_STREAM_CHUNK_LIMIT: u32 = 64 * 1024;
+pub(super) const COPY_FILE_STREAM_CHUNK_LIMIT: u32 = 64 * 1024;
 pub(super) const COPY_FILE_STREAM_MAX_BYTES: u64 = 64 * 1024 * 1024;
 // Copying is the one built-in streaming consumer that must tolerate the host
 // reader briefly outrunning the temp-file writer without failing the exec operation.
@@ -28,13 +28,34 @@ static COPY_TEMP_NONCE: AtomicU64 = AtomicU64::new(1);
 /// operation streaming.
 #[derive(Debug, Clone, Copy)]
 pub struct CopyFileOptions {
+    /// Maximum bytes to stream from the guest before the copy fails.
+    ///
+    /// This value must be positive and no larger than the host copy stream
+    /// limit. The copy fails if the streamed file contents exceed this byte
+    /// count.
     pub max_bytes: u64,
+    /// Guest-side copy exec timeout in milliseconds.
+    ///
+    /// This value must be positive.
     pub timeout_ms: u32,
+    /// Treat a guest helper result that reports the path does not resolve to a
+    /// regular file as a successful copy result.
+    ///
+    /// When such a helper result is treated as success, the operation returns
+    /// `bytes_copied == 0` without creating an empty host file or replacing an
+    /// existing host file.
     pub missing_ok: bool,
 }
 
+/// Result of copying a guest file to a host path.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct CopyFileResult {
+    /// Number of bytes copied from the guest file.
+    ///
+    /// This is `0` for a present empty guest file, which still publishes an
+    /// empty host file. It is also `0` when `missing_ok` turns a guest helper
+    /// result that reports the path does not resolve to a regular file into
+    /// success; in that case no host file is published.
     pub bytes_copied: u64,
 }
 
@@ -334,6 +355,12 @@ fn validate_copy_exec_result(
 impl VsockHost {
     /// Stream a guest file to a host path and atomically rename it into place
     /// after the exec operation exits successfully.
+    ///
+    /// Options are validated before guest work starts. When `missing_ok` is
+    /// enabled, a guest helper result that reports the path does not resolve
+    /// to a regular file is treated as success with `bytes_copied == 0`
+    /// without publishing a host file. Host-side setup and validation errors
+    /// can still fail the operation.
     pub async fn copy_file(
         &self,
         path: &str,
@@ -346,6 +373,9 @@ impl VsockHost {
 
     /// Stream a guest file to a host path and report when the helper exec
     /// frame is about to be written to the guest.
+    ///
+    /// This has the same copy semantics as `copy_file`, including option
+    /// validation and `missing_ok` handling.
     pub async fn copy_file_with_write_observer(
         &self,
         path: &str,

--- a/crates/vsock-host/src/file/copy.rs
+++ b/crates/vsock-host/src/file/copy.rs
@@ -12,7 +12,7 @@ use crate::{
     ExecStreamRequest, FrameWriteObserver, VsockHost, exec_operation,
 };
 
-use super::{file_operation_error_is_terminal, shell_quote};
+use super::{file_operation_error_is_terminal, read_regular_file_command};
 
 const COPY_TEMP_CREATE_ATTEMPTS: usize = 16;
 const COPY_TEMP_FILE_MODE: u32 = 0o600;
@@ -487,10 +487,7 @@ impl VsockHost {
             write_observer,
         } = request;
         const MISSING_FILE_EXIT_CODE: i32 = 66;
-        let command = format!(
-            "if test -f {path}; then cat < {path}; else exit {MISSING_FILE_EXIT_CODE}; fi",
-            path = shell_quote(path)
-        );
+        let command = read_regular_file_command(path, MISSING_FILE_EXIT_CODE);
         let expected_exit_codes: &[i32] = if missing_ok {
             &[MISSING_FILE_EXIT_CODE]
         } else {

--- a/crates/vsock-host/src/file/copy.rs
+++ b/crates/vsock-host/src/file/copy.rs
@@ -485,7 +485,7 @@ impl VsockHost {
         } = request;
         const MISSING_FILE_EXIT_CODE: i32 = 66;
         let command = format!(
-            "if test -f {path}; then cat -- {path}; else exit {MISSING_FILE_EXIT_CODE}; fi",
+            "if test -f {path}; then cat < {path}; else exit {MISSING_FILE_EXIT_CODE}; fi",
             path = shell_quote(path)
         );
         let expected_exit_codes: &[i32] = if missing_ok {

--- a/crates/vsock-host/src/file/copy.rs
+++ b/crates/vsock-host/src/file/copy.rs
@@ -12,7 +12,9 @@ use crate::{
     ExecStreamRequest, FrameWriteObserver, VsockHost, exec_operation,
 };
 
-use super::{file_operation_error_is_terminal, read_regular_file_command};
+use super::{
+    file_operation_error_is_terminal, read_regular_file_command, validate_guest_file_path,
+};
 
 const COPY_TEMP_CREATE_ATTEMPTS: usize = 16;
 const COPY_TEMP_FILE_MODE: u32 = 0o600;
@@ -395,6 +397,7 @@ impl VsockHost {
         options: CopyFileOptions,
         write_observer: FrameWriteObserver,
     ) -> io::Result<CopyFileResult> {
+        validate_guest_file_path(path)?;
         if options.max_bytes == 0 {
             return Err(io::Error::new(
                 io::ErrorKind::InvalidInput,

--- a/crates/vsock-host/src/file/copy.rs
+++ b/crates/vsock-host/src/file/copy.rs
@@ -1,5 +1,6 @@
 use std::io;
 use std::os::fd::AsRawFd;
+use std::os::unix::ffi::OsStrExt;
 use std::path::{Path, PathBuf};
 use std::sync::atomic::{AtomicU64, Ordering};
 use std::time::Duration;
@@ -155,6 +156,30 @@ fn copy_temp_path(host_path: &Path, process_id: u32, seq: u32, nonce: u64) -> Pa
         .map(|name| name.to_string_lossy())
         .unwrap_or_else(|| "copy".into());
     host_path.with_file_name(format!(".{file_name}.vm0tmp-{process_id}-{seq}-{nonce}"))
+}
+
+fn validate_copy_host_path(host_path: &Path) -> io::Result<()> {
+    let path_bytes = host_path.as_os_str().as_bytes();
+    if path_bytes.is_empty() {
+        return Err(io::Error::new(
+            io::ErrorKind::InvalidInput,
+            "copy_file host path must not be empty",
+        ));
+    }
+    if path_bytes.contains(&0) {
+        return Err(io::Error::new(
+            io::ErrorKind::InvalidInput,
+            "copy_file host path contains NUL bytes",
+        ));
+    }
+    if host_path.file_name().is_none() || path_bytes.ends_with(b"/") || path_bytes.ends_with(b"/.")
+    {
+        return Err(io::Error::new(
+            io::ErrorKind::InvalidInput,
+            "copy_file host path must name a file",
+        ));
+    }
+    Ok(())
 }
 
 async fn remove_temp_file(path: &Path) {
@@ -375,6 +400,10 @@ impl VsockHost {
     /// to a regular file is treated as success with `bytes_copied == 0`
     /// without publishing a host file. Host-side setup and validation errors
     /// can still fail the operation.
+    ///
+    /// The host path must name a file destination. Empty host paths, paths
+    /// containing NUL bytes, and paths that end in a directory marker are
+    /// rejected before guest work starts.
     pub async fn copy_file(
         &self,
         path: &str,
@@ -398,6 +427,7 @@ impl VsockHost {
         write_observer: FrameWriteObserver,
     ) -> io::Result<CopyFileResult> {
         validate_guest_file_path(path)?;
+        validate_copy_host_path(host_path)?;
         if options.max_bytes == 0 {
             return Err(io::Error::new(
                 io::ErrorKind::InvalidInput,

--- a/crates/vsock-host/src/file/copy.rs
+++ b/crates/vsock-host/src/file/copy.rs
@@ -326,7 +326,16 @@ fn validate_copy_exec_result(
             "copy_file stderr exceeded diagnostic limit for {path}: {}",
             String::from_utf8_lossy(&stderr)
         ))),
-        ExecTermination::Exited { exit_code: 66 } if missing_ok => Ok(CopyFileExecStatus::Missing),
+        ExecTermination::Exited { exit_code: 66 } if missing_ok && stderr.is_empty() => {
+            Ok(CopyFileExecStatus::Missing)
+        }
+        ExecTermination::Exited { exit_code: 66 } if missing_ok => Err(io::Error::new(
+            io::ErrorKind::InvalidData,
+            format!(
+                "copy_file missing result for {path} included stderr: {}",
+                String::from_utf8_lossy(&stderr)
+            ),
+        )),
         ExecTermination::Exited { exit_code: 66 } => Err(io::Error::new(
             io::ErrorKind::NotFound,
             format!("guest file not found: {path}"),

--- a/crates/vsock-host/src/file/copy.rs
+++ b/crates/vsock-host/src/file/copy.rs
@@ -328,7 +328,6 @@ fn copy_exec_stderr(result: &ExecOperationResult) -> io::Result<(Vec<u8>, bool)>
 fn validate_copy_exec_result(
     path: &str,
     result: ExecOperationResult,
-    missing_ok: bool,
 ) -> io::Result<CopyFileExecStatus> {
     if result.stream_overflowed {
         return Err(io::Error::other(
@@ -356,19 +355,15 @@ fn validate_copy_exec_result(
                 String::from_utf8_lossy(&stderr)
             ),
         )),
-        ExecTermination::Exited { exit_code: 66 } if missing_ok && stderr.is_empty() => {
+        ExecTermination::Exited { exit_code: 66 } if stderr.is_empty() => {
             Ok(CopyFileExecStatus::Missing)
         }
-        ExecTermination::Exited { exit_code: 66 } if missing_ok => Err(io::Error::new(
+        ExecTermination::Exited { exit_code: 66 } => Err(io::Error::new(
             io::ErrorKind::InvalidData,
             format!(
                 "copy_file missing result for {path} included stderr: {}",
                 String::from_utf8_lossy(&stderr)
             ),
-        )),
-        ExecTermination::Exited { exit_code: 66 } => Err(io::Error::new(
-            io::ErrorKind::NotFound,
-            format!("guest file not found: {path}"),
         )),
         ExecTermination::Exited { exit_code } => Err(io::Error::other(format!(
             "copy_file failed for {path} with exit code {exit_code}: {}",
@@ -611,9 +606,7 @@ impl VsockHost {
         if let Some(cancel_on_drop) = &mut cancel_on_drop {
             cancel_on_drop.disarm();
         }
-        match validate_copy_exec_result(path, result, missing_ok)
-            .map_err(CopyFileToTempError::terminal)?
-        {
+        match validate_copy_exec_result(path, result).map_err(CopyFileToTempError::terminal)? {
             CopyFileExecStatus::Present => {}
             CopyFileExecStatus::Missing => {
                 if bytes_copied != 0 {
@@ -624,7 +617,13 @@ impl VsockHost {
                         ),
                     )));
                 }
-                return Ok(CopyFileOutcome::Missing);
+                if missing_ok {
+                    return Ok(CopyFileOutcome::Missing);
+                }
+                return Err(CopyFileToTempError::terminal(io::Error::new(
+                    io::ErrorKind::NotFound,
+                    format!("guest file not found: {path}"),
+                )));
             }
         }
         temp_file

--- a/crates/vsock-host/src/file/mod.rs
+++ b/crates/vsock-host/src/file/mod.rs
@@ -23,6 +23,7 @@ fn file_operation_error_is_terminal(error: &io::Error) -> bool {
 
 #[cfg(test)]
 pub(crate) mod test_support {
+    pub(crate) const COPY_FILE_STREAM_CHUNK_LIMIT: u32 = super::copy::COPY_FILE_STREAM_CHUNK_LIMIT;
     pub(crate) const COPY_FILE_STREAM_MAX_BYTES: u64 = super::copy::COPY_FILE_STREAM_MAX_BYTES;
     pub(crate) const WRITE_FILE_CHUNK_LIMIT: usize = super::write::WRITE_FILE_CHUNK_LIMIT;
 }

--- a/crates/vsock-host/src/file/mod.rs
+++ b/crates/vsock-host/src/file/mod.rs
@@ -13,7 +13,7 @@ fn shell_quote(value: &str) -> String {
 fn read_regular_file_command(path: &str, missing_file_exit_code: i32) -> String {
     let path = shell_quote(path);
     format!(
-        "if test -f {path}; then cat < {path} 2>/dev/null || {{ test -f {path} || exit {missing_file_exit_code}; printf '%s\\n' 'failed to read file' >&2; exit 1; }}; else exit {missing_file_exit_code}; fi"
+        "if test -f {path}; then cat 2>/dev/null < {path} || {{ test -f {path} || exit {missing_file_exit_code}; printf '%s\\n' 'failed to read file' >&2; exit 1; }}; else exit {missing_file_exit_code}; fi"
     )
 }
 

--- a/crates/vsock-host/src/file/mod.rs
+++ b/crates/vsock-host/src/file/mod.rs
@@ -10,6 +10,16 @@ fn shell_quote(value: &str) -> String {
     format!("'{}'", value.replace('\'', "'\\''"))
 }
 
+fn validate_guest_file_path(path: &str) -> io::Result<()> {
+    if path.as_bytes().contains(&0) {
+        return Err(io::Error::new(
+            io::ErrorKind::InvalidInput,
+            "guest file path contains NUL bytes",
+        ));
+    }
+    Ok(())
+}
+
 fn read_regular_file_command(path: &str, missing_file_exit_code: i32) -> String {
     let path = shell_quote(path);
     format!(

--- a/crates/vsock-host/src/file/mod.rs
+++ b/crates/vsock-host/src/file/mod.rs
@@ -11,6 +11,12 @@ fn shell_quote(value: &str) -> String {
 }
 
 fn validate_guest_file_path(path: &str) -> io::Result<()> {
+    if path.is_empty() {
+        return Err(io::Error::new(
+            io::ErrorKind::InvalidInput,
+            "guest file path must not be empty",
+        ));
+    }
     if path.as_bytes().contains(&0) {
         return Err(io::Error::new(
             io::ErrorKind::InvalidInput,

--- a/crates/vsock-host/src/file/mod.rs
+++ b/crates/vsock-host/src/file/mod.rs
@@ -10,6 +10,13 @@ fn shell_quote(value: &str) -> String {
     format!("'{}'", value.replace('\'', "'\\''"))
 }
 
+fn read_regular_file_command(path: &str, missing_file_exit_code: i32) -> String {
+    let path = shell_quote(path);
+    format!(
+        "if test -f {path}; then cat < {path} 2>/dev/null || {{ test -f {path} || exit {missing_file_exit_code}; printf '%s\\n' 'failed to read file' >&2; exit 1; }}; else exit {missing_file_exit_code}; fi"
+    )
+}
+
 fn file_operation_error_is_terminal(error: &io::Error) -> bool {
     !matches!(
         error.kind(),

--- a/crates/vsock-host/src/file/read.rs
+++ b/crates/vsock-host/src/file/read.rs
@@ -79,12 +79,16 @@ impl VsockHost {
                     format!("read_file missing result for {path} included stdout"),
                 ));
             }
-            if result.stderr_truncated || !result.stderr.is_empty() {
+            let mut stderr = result.stderr;
+            if result.stderr_truncated {
+                exec_operation::append_diagnostic(&mut stderr, "stderr truncated");
+            }
+            if !stderr.is_empty() {
                 return Err(io::Error::new(
                     io::ErrorKind::InvalidData,
                     format!(
                         "read_file missing result for {path} included stderr: {}",
-                        String::from_utf8_lossy(&result.stderr)
+                        String::from_utf8_lossy(&stderr)
                     ),
                 ));
             }

--- a/crates/vsock-host/src/file/read.rs
+++ b/crates/vsock-host/src/file/read.rs
@@ -70,6 +70,21 @@ impl VsockHost {
             )
             .await?;
         if result.exit_code == MISSING_FILE_EXIT_CODE {
+            if result.stdout_truncated || !result.stdout.is_empty() {
+                return Err(io::Error::new(
+                    io::ErrorKind::InvalidData,
+                    format!("read_file missing result for {path} included stdout"),
+                ));
+            }
+            if result.stderr_truncated || !result.stderr.is_empty() {
+                return Err(io::Error::new(
+                    io::ErrorKind::InvalidData,
+                    format!(
+                        "read_file missing result for {path} included stderr: {}",
+                        String::from_utf8_lossy(&result.stderr)
+                    ),
+                ));
+            }
             return Ok(None);
         }
         if result.exit_code != 0 {

--- a/crates/vsock-host/src/file/read.rs
+++ b/crates/vsock-host/src/file/read.rs
@@ -3,7 +3,7 @@ use std::time::Duration;
 
 use crate::{ExecCaptureRequest, FrameWriteObserver, VsockHost, exec_operation};
 
-use super::read_regular_file_command;
+use super::{read_regular_file_command, validate_guest_file_path};
 
 impl VsockHost {
     /// Read a small file from the guest through exec capture.
@@ -34,6 +34,7 @@ impl VsockHost {
         timeout_ms: u32,
         write_observer: FrameWriteObserver,
     ) -> io::Result<Option<Vec<u8>>> {
+        validate_guest_file_path(path)?;
         let stdout_limit_bytes = u32::try_from(max_bytes).map_err(|_| {
             io::Error::new(
                 io::ErrorKind::InvalidInput,

--- a/crates/vsock-host/src/file/read.rs
+++ b/crates/vsock-host/src/file/read.rs
@@ -8,6 +8,9 @@ use super::{read_regular_file_command, validate_guest_file_path};
 impl VsockHost {
     /// Read a small file from the guest through exec capture.
     ///
+    /// The guest path must be non-empty and must not contain NUL bytes.
+    /// `max_bytes` must be positive and fit within the exec capture limit.
+    ///
     /// Missing files return `Ok(None)`. Files larger than `max_bytes` return
     /// an error instead of silently returning truncated bytes.
     pub async fn read_file(
@@ -27,6 +30,8 @@ impl VsockHost {
 
     /// Read a small file and report when the helper exec frame is about to be
     /// written to the guest.
+    ///
+    /// This has the same read semantics and input validation as `read_file`.
     pub async fn read_file_with_write_observer(
         &self,
         path: &str,

--- a/crates/vsock-host/src/file/read.rs
+++ b/crates/vsock-host/src/file/read.rs
@@ -3,7 +3,7 @@ use std::time::Duration;
 
 use crate::{ExecCaptureRequest, FrameWriteObserver, VsockHost, exec_operation};
 
-use super::shell_quote;
+use super::read_regular_file_command;
 
 impl VsockHost {
     /// Read a small file from the guest through exec capture.
@@ -48,10 +48,7 @@ impl VsockHost {
         }
 
         const MISSING_FILE_EXIT_CODE: i32 = 66;
-        let command = format!(
-            "if test -f {path}; then cat < {path}; else exit {MISSING_FILE_EXIT_CODE}; fi",
-            path = shell_quote(path)
-        );
+        let command = read_regular_file_command(path, MISSING_FILE_EXIT_CODE);
         let result = self
             .exec_capture_with_write_observer(
                 ExecCaptureRequest {

--- a/crates/vsock-host/src/file/read.rs
+++ b/crates/vsock-host/src/file/read.rs
@@ -49,7 +49,7 @@ impl VsockHost {
 
         const MISSING_FILE_EXIT_CODE: i32 = 66;
         let command = format!(
-            "if test -f {path}; then cat -- {path}; else exit {MISSING_FILE_EXIT_CODE}; fi",
+            "if test -f {path}; then cat < {path}; else exit {MISSING_FILE_EXIT_CODE}; fi",
             path = shell_quote(path)
         );
         let result = self

--- a/crates/vsock-host/src/file/read.rs
+++ b/crates/vsock-host/src/file/read.rs
@@ -74,9 +74,14 @@ impl VsockHost {
             .await?;
         if result.exit_code == MISSING_FILE_EXIT_CODE {
             if result.stdout_truncated || !result.stdout.is_empty() {
+                let stdout_detail = if result.stdout_truncated {
+                    "stdout truncated"
+                } else {
+                    "stdout"
+                };
                 return Err(io::Error::new(
                     io::ErrorKind::InvalidData,
-                    format!("read_file missing result for {path} included stdout"),
+                    format!("read_file missing result for {path} included {stdout_detail}"),
                 ));
             }
             let mut stderr = result.stderr;
@@ -95,9 +100,13 @@ impl VsockHost {
             return Ok(None);
         }
         if result.exit_code != 0 {
+            let mut stderr = result.stderr;
+            if result.stderr_truncated {
+                exec_operation::append_diagnostic(&mut stderr, "stderr truncated");
+            }
             return Err(io::Error::other(format!(
                 "failed to read file {path}: {}",
-                String::from_utf8_lossy(&result.stderr)
+                String::from_utf8_lossy(&stderr)
             )));
         }
         if result.stdout_truncated {

--- a/crates/vsock-host/src/file/read.rs
+++ b/crates/vsock-host/src/file/read.rs
@@ -98,10 +98,18 @@ impl VsockHost {
                 "file {path} exceeded {max_bytes} bytes"
             )));
         }
+        let mut stderr = result.stderr;
         if result.stderr_truncated {
-            return Err(io::Error::other(format!(
-                "stderr while reading file {path} exceeded diagnostic limit"
-            )));
+            exec_operation::append_diagnostic(&mut stderr, "stderr truncated");
+        }
+        if !stderr.is_empty() {
+            return Err(io::Error::new(
+                io::ErrorKind::InvalidData,
+                format!(
+                    "read_file result for {path} included stderr: {}",
+                    String::from_utf8_lossy(&stderr)
+                ),
+            ));
         }
         Ok(Some(result.stdout))
     }

--- a/crates/vsock-host/src/tests/file/copy.rs
+++ b/crates/vsock-host/src/tests/file/copy.rs
@@ -196,6 +196,13 @@ async fn copy_file_rejects_invalid_options_without_sending_frame_or_creating_par
     let host_path = temp_path.join("nested/system.log");
 
     let err = host
+        .copy_file("", &host_path, copy_options(1024, 5000, true))
+        .await
+        .unwrap_err();
+    assert_eq!(err.kind(), io::ErrorKind::InvalidInput);
+    assert!(!temp_path.path().exists());
+
+    let err = host
         .copy_file(
             "/tmp/bad\0path.log",
             &host_path,

--- a/crates/vsock-host/src/tests/file/copy.rs
+++ b/crates/vsock-host/src/tests/file/copy.rs
@@ -65,7 +65,7 @@ async fn copy_file_streams_to_temp_then_renames() {
     assert_eq!(start.label, "copy-file");
     assert_eq!(
         start.command,
-        "if test -f '/tmp/vm0-system-run.log'; then cat -- '/tmp/vm0-system-run.log'; else exit 66; fi"
+        "if test -f '/tmp/vm0-system-run.log'; then cat < '/tmp/vm0-system-run.log'; else exit 66; fi"
     );
     assert_eq!(
         start.stdout,
@@ -234,7 +234,7 @@ async fn copy_file_creates_parent_and_quotes_guest_path_with_single_quote() {
     let decoded = vsock_proto::decode_exec_start(&msg.payload).unwrap();
     assert_eq!(
         decoded.command,
-        "if test -f '/tmp/vm0-system-run'\\''s.log'; then cat -- '/tmp/vm0-system-run'\\''s.log'; else exit 66; fi"
+        "if test -f '/tmp/vm0-system-run'\\''s.log'; then cat < '/tmp/vm0-system-run'\\''s.log'; else exit 66; fi"
     );
     send_exec_output(
         &mut guest,

--- a/crates/vsock-host/src/tests/file/copy.rs
+++ b/crates/vsock-host/src/tests/file/copy.rs
@@ -620,7 +620,7 @@ async fn copy_file_missing_ok_preserves_existing_host_file() {
 }
 
 #[tokio::test]
-async fn copy_file_missing_ok_discards_streamed_output_and_preserves_existing_host_file() {
+async fn copy_file_rejects_missing_ok_result_with_streamed_output() {
     let (host, mut guest) = setup_host_and_guest().await;
     let host = Arc::new(host);
     let temp_dir = HostTempDir::new("vsock-host-copy-missing-output");
@@ -653,8 +653,9 @@ async fn copy_file_missing_ok_discards_streamed_output_and_preserves_existing_ho
     )
     .await;
 
-    let result = copy_task.await.unwrap().unwrap();
-    assert_eq!(result.bytes_copied, 0);
+    let err = copy_task.await.unwrap().unwrap_err();
+    assert_eq!(err.kind(), io::ErrorKind::InvalidData);
+    assert!(err.to_string().contains("missing result"));
     assert_eq!(std::fs::read(&host_path).unwrap(), b"old host log");
     temp_dir.assert_no_vm0tmp_files();
 }

--- a/crates/vsock-host/src/tests/file/copy.rs
+++ b/crates/vsock-host/src/tests/file/copy.rs
@@ -661,6 +661,38 @@ async fn copy_file_rejects_missing_ok_result_with_streamed_output() {
 }
 
 #[tokio::test]
+async fn copy_file_rejects_missing_ok_result_with_stderr() {
+    let (host, mut guest) = setup_host_and_guest().await;
+    let host = Arc::new(host);
+    let temp_dir = HostTempDir::new("vsock-host-copy-missing-stderr");
+    let host_path = temp_dir.join("system.log");
+    std::fs::write(&host_path, b"old host log").unwrap();
+    let copy_path = host_path.clone();
+
+    let copy_task = spawn_copy_file(
+        Arc::clone(&host),
+        "/tmp/missing.log",
+        copy_path,
+        copy_options(1024, 5000, true),
+    );
+
+    let msg = read_guest_message(&mut guest).await;
+    send_stream_exec_result(
+        &mut guest,
+        msg.seq,
+        ExecTermination::Exited { exit_code: 66 },
+        b"unexpected stderr",
+    )
+    .await;
+
+    let err = copy_task.await.unwrap().unwrap_err();
+    assert_eq!(err.kind(), io::ErrorKind::InvalidData);
+    assert!(err.to_string().contains("included stderr"));
+    assert_eq!(std::fs::read(&host_path).unwrap(), b"old host log");
+    temp_dir.assert_no_vm0tmp_files();
+}
+
+#[tokio::test]
 async fn copy_file_missing_without_missing_ok_preserves_existing_file_and_removes_temp() {
     let (host, mut guest) = setup_host_and_guest().await;
     let temp_dir = HostTempDir::new("vsock-host-copy-missing-error");

--- a/crates/vsock-host/src/tests/file/copy.rs
+++ b/crates/vsock-host/src/tests/file/copy.rs
@@ -65,7 +65,7 @@ async fn copy_file_streams_to_temp_then_renames() {
     assert_eq!(start.label, "copy-file");
     assert_eq!(
         start.command,
-        "if test -f '/tmp/vm0-system-run.log'; then cat < '/tmp/vm0-system-run.log'; else exit 66; fi"
+        "if test -f '/tmp/vm0-system-run.log'; then cat < '/tmp/vm0-system-run.log' 2>/dev/null || { test -f '/tmp/vm0-system-run.log' || exit 66; printf '%s\\n' 'failed to read file' >&2; exit 1; }; else exit 66; fi"
     );
     assert_eq!(
         start.stdout,
@@ -234,7 +234,7 @@ async fn copy_file_creates_parent_and_quotes_guest_path_with_single_quote() {
     let decoded = vsock_proto::decode_exec_start(&msg.payload).unwrap();
     assert_eq!(
         decoded.command,
-        "if test -f '/tmp/vm0-system-run'\\''s.log'; then cat < '/tmp/vm0-system-run'\\''s.log'; else exit 66; fi"
+        "if test -f '/tmp/vm0-system-run'\\''s.log'; then cat < '/tmp/vm0-system-run'\\''s.log' 2>/dev/null || { test -f '/tmp/vm0-system-run'\\''s.log' || exit 66; printf '%s\\n' 'failed to read file' >&2; exit 1; }; else exit 66; fi"
     );
     send_exec_output(
         &mut guest,

--- a/crates/vsock-host/src/tests/file/copy.rs
+++ b/crates/vsock-host/src/tests/file/copy.rs
@@ -213,6 +213,20 @@ async fn copy_file_rejects_invalid_options_without_sending_frame_or_creating_par
     assert_eq!(err.kind(), io::ErrorKind::InvalidInput);
     assert!(!temp_path.path().exists());
 
+    for invalid_host_path in ["", ".", "/tmp/", "/tmp/.", "/tmp/bad\0host.log"] {
+        let err = host
+            .copy_file(
+                "/tmp/system.log",
+                Path::new(invalid_host_path),
+                copy_options(1024, 5000, false),
+            )
+            .await
+            .unwrap_err();
+        assert_eq!(err.kind(), io::ErrorKind::InvalidInput);
+        assert_eq!(operation_count(&host), 0);
+        assert!(!temp_path.path().exists());
+    }
+
     let err = host
         .copy_file("/tmp/system.log", &host_path, copy_options(0, 5000, false))
         .await

--- a/crates/vsock-host/src/tests/file/copy.rs
+++ b/crates/vsock-host/src/tests/file/copy.rs
@@ -656,6 +656,10 @@ async fn copy_file_rejects_missing_ok_result_with_streamed_output() {
     let err = copy_task.await.unwrap().unwrap_err();
     assert_eq!(err.kind(), io::ErrorKind::InvalidData);
     assert!(err.to_string().contains("missing result"));
+    assert_eq!(
+        normal_operation_readiness(&host),
+        NormalOperationReadiness::Idle
+    );
     assert_eq!(std::fs::read(&host_path).unwrap(), b"old host log");
     temp_dir.assert_no_vm0tmp_files();
 }
@@ -688,6 +692,10 @@ async fn copy_file_rejects_missing_ok_result_with_stderr() {
     let err = copy_task.await.unwrap().unwrap_err();
     assert_eq!(err.kind(), io::ErrorKind::InvalidData);
     assert!(err.to_string().contains("included stderr"));
+    assert_eq!(
+        normal_operation_readiness(&host),
+        NormalOperationReadiness::Idle
+    );
     assert_eq!(std::fs::read(&host_path).unwrap(), b"old host log");
     temp_dir.assert_no_vm0tmp_files();
 }

--- a/crates/vsock-host/src/tests/file/copy.rs
+++ b/crates/vsock-host/src/tests/file/copy.rs
@@ -548,6 +548,51 @@ async fn copy_file_nonzero_exit_removes_temp_without_publishing_partial_output()
 }
 
 #[tokio::test]
+async fn copy_file_rejects_success_result_with_stderr() {
+    let (host, mut guest) = setup_host_and_guest().await;
+    let host = Arc::new(host);
+    let temp_dir = HostTempDir::new("vsock-host-copy-success-stderr");
+    let host_path = temp_dir.join("system.log");
+    std::fs::write(&host_path, b"old host log").unwrap();
+    let copy_path = host_path.clone();
+
+    let copy_task = spawn_copy_file(
+        Arc::clone(&host),
+        "/tmp/vm0-system-run.log",
+        copy_path,
+        default_copy_options(),
+    );
+
+    let msg = read_guest_message(&mut guest).await;
+    send_exec_output(
+        &mut guest,
+        msg.seq,
+        0,
+        ExecOutputStream::Stdout,
+        b"new host log",
+        false,
+    )
+    .await;
+    send_stream_exec_result(
+        &mut guest,
+        msg.seq,
+        ExecTermination::Exited { exit_code: 0 },
+        b"unexpected stderr",
+    )
+    .await;
+
+    let err = copy_task.await.unwrap().unwrap_err();
+    assert_eq!(err.kind(), io::ErrorKind::InvalidData);
+    assert!(err.to_string().contains("included stderr"));
+    assert_eq!(
+        normal_operation_readiness(&host),
+        NormalOperationReadiness::Idle
+    );
+    assert_eq!(std::fs::read(&host_path).unwrap(), b"old host log");
+    temp_dir.assert_no_vm0tmp_files();
+}
+
+#[tokio::test]
 async fn copy_file_missing_ok_leaves_no_final_or_temp_file() {
     let (host, mut guest) = setup_host_and_guest().await;
     let host = Arc::new(host);

--- a/crates/vsock-host/src/tests/file/copy.rs
+++ b/crates/vsock-host/src/tests/file/copy.rs
@@ -65,7 +65,7 @@ async fn copy_file_streams_to_temp_then_renames() {
     assert_eq!(start.label, "copy-file");
     assert_eq!(
         start.command,
-        "if test -f '/tmp/vm0-system-run.log'; then cat < '/tmp/vm0-system-run.log' 2>/dev/null || { test -f '/tmp/vm0-system-run.log' || exit 66; printf '%s\\n' 'failed to read file' >&2; exit 1; }; else exit 66; fi"
+        "if test -f '/tmp/vm0-system-run.log'; then cat 2>/dev/null < '/tmp/vm0-system-run.log' || { test -f '/tmp/vm0-system-run.log' || exit 66; printf '%s\\n' 'failed to read file' >&2; exit 1; }; else exit 66; fi"
     );
     assert_eq!(
         start.stdout,
@@ -234,7 +234,7 @@ async fn copy_file_creates_parent_and_quotes_guest_path_with_single_quote() {
     let decoded = vsock_proto::decode_exec_start(&msg.payload).unwrap();
     assert_eq!(
         decoded.command,
-        "if test -f '/tmp/vm0-system-run'\\''s.log'; then cat < '/tmp/vm0-system-run'\\''s.log' 2>/dev/null || { test -f '/tmp/vm0-system-run'\\''s.log' || exit 66; printf '%s\\n' 'failed to read file' >&2; exit 1; }; else exit 66; fi"
+        "if test -f '/tmp/vm0-system-run'\\''s.log'; then cat 2>/dev/null < '/tmp/vm0-system-run'\\''s.log' || { test -f '/tmp/vm0-system-run'\\''s.log' || exit 66; printf '%s\\n' 'failed to read file' >&2; exit 1; }; else exit 66; fi"
     );
     send_exec_output(
         &mut guest,

--- a/crates/vsock-host/src/tests/file/copy.rs
+++ b/crates/vsock-host/src/tests/file/copy.rs
@@ -620,6 +620,46 @@ async fn copy_file_missing_ok_preserves_existing_host_file() {
 }
 
 #[tokio::test]
+async fn copy_file_missing_ok_discards_streamed_output_and_preserves_existing_host_file() {
+    let (host, mut guest) = setup_host_and_guest().await;
+    let host = Arc::new(host);
+    let temp_dir = HostTempDir::new("vsock-host-copy-missing-output");
+    let host_path = temp_dir.join("system.log");
+    std::fs::write(&host_path, b"old host log").unwrap();
+    let copy_path = host_path.clone();
+
+    let copy_task = spawn_copy_file(
+        Arc::clone(&host),
+        "/tmp/missing.log",
+        copy_path,
+        copy_options(1024, 5000, true),
+    );
+
+    let msg = read_guest_message(&mut guest).await;
+    send_exec_output(
+        &mut guest,
+        msg.seq,
+        0,
+        ExecOutputStream::Stdout,
+        b"unexpected partial output",
+        false,
+    )
+    .await;
+    send_stream_exec_result(
+        &mut guest,
+        msg.seq,
+        ExecTermination::Exited { exit_code: 66 },
+        b"",
+    )
+    .await;
+
+    let result = copy_task.await.unwrap().unwrap();
+    assert_eq!(result.bytes_copied, 0);
+    assert_eq!(std::fs::read(&host_path).unwrap(), b"old host log");
+    temp_dir.assert_no_vm0tmp_files();
+}
+
+#[tokio::test]
 async fn copy_file_missing_without_missing_ok_preserves_existing_file_and_removes_temp() {
     let (host, mut guest) = setup_host_and_guest().await;
     let temp_dir = HostTempDir::new("vsock-host-copy-missing-error");

--- a/crates/vsock-host/src/tests/file/copy.rs
+++ b/crates/vsock-host/src/tests/file/copy.rs
@@ -809,6 +809,87 @@ async fn copy_file_missing_without_missing_ok_preserves_existing_file_and_remove
 }
 
 #[tokio::test]
+async fn copy_file_rejects_missing_without_missing_ok_after_streamed_output() {
+    let (host, mut guest) = setup_host_and_guest().await;
+    let host = Arc::new(host);
+    let temp_dir = HostTempDir::new("vsock-host-copy-missing-error-output");
+    let host_path = temp_dir.join("system.log");
+    std::fs::write(&host_path, b"old host log").unwrap();
+    let copy_path = host_path.clone();
+
+    let copy_task = spawn_copy_file(
+        Arc::clone(&host),
+        "/tmp/missing.log",
+        copy_path,
+        default_copy_options(),
+    );
+
+    let msg = read_guest_message(&mut guest).await;
+    send_exec_output(
+        &mut guest,
+        msg.seq,
+        0,
+        ExecOutputStream::Stdout,
+        b"unexpected output",
+        false,
+    )
+    .await;
+    send_stream_exec_result(
+        &mut guest,
+        msg.seq,
+        ExecTermination::Exited { exit_code: 66 },
+        b"",
+    )
+    .await;
+
+    let err = copy_task.await.unwrap().unwrap_err();
+    assert_eq!(err.kind(), io::ErrorKind::InvalidData);
+    assert!(err.to_string().contains("missing result"));
+    assert_eq!(
+        normal_operation_readiness(&host),
+        NormalOperationReadiness::Idle
+    );
+    assert_eq!(std::fs::read(&host_path).unwrap(), b"old host log");
+    temp_dir.assert_no_vm0tmp_files();
+}
+
+#[tokio::test]
+async fn copy_file_rejects_missing_without_missing_ok_with_stderr() {
+    let (host, mut guest) = setup_host_and_guest().await;
+    let host = Arc::new(host);
+    let temp_dir = HostTempDir::new("vsock-host-copy-missing-error-stderr");
+    let host_path = temp_dir.join("system.log");
+    std::fs::write(&host_path, b"old host log").unwrap();
+    let copy_path = host_path.clone();
+
+    let copy_task = spawn_copy_file(
+        Arc::clone(&host),
+        "/tmp/missing.log",
+        copy_path,
+        default_copy_options(),
+    );
+
+    let msg = read_guest_message(&mut guest).await;
+    send_stream_exec_result(
+        &mut guest,
+        msg.seq,
+        ExecTermination::Exited { exit_code: 66 },
+        b"unexpected stderr",
+    )
+    .await;
+
+    let err = copy_task.await.unwrap().unwrap_err();
+    assert_eq!(err.kind(), io::ErrorKind::InvalidData);
+    assert!(err.to_string().contains("included stderr"));
+    assert_eq!(
+        normal_operation_readiness(&host),
+        NormalOperationReadiness::Idle
+    );
+    assert_eq!(std::fs::read(&host_path).unwrap(), b"old host log");
+    temp_dir.assert_no_vm0tmp_files();
+}
+
+#[tokio::test]
 async fn copy_file_cancellation_cancels_guest_exec_operation_and_removes_temp() {
     let (host, mut guest) = setup_host_and_guest().await;
     let host = Arc::new(host);

--- a/crates/vsock-host/src/tests/file/copy.rs
+++ b/crates/vsock-host/src/tests/file/copy.rs
@@ -71,7 +71,7 @@ async fn copy_file_streams_to_temp_then_renames() {
         start.stdout,
         ExecOutputPolicy::Stream {
             limit_bytes: 1024,
-            chunk_limit_bytes: 64 * 1024,
+            chunk_limit_bytes: file_impl::test_support::COPY_FILE_STREAM_CHUNK_LIMIT,
         }
     );
     send_exec_output(
@@ -108,6 +108,83 @@ async fn copy_file_streams_to_temp_then_renames() {
     );
     assert_eq!(std::fs::read(&host_path).unwrap(), b"line 1\nline 2\n");
     assert_eq!(mode(&host_path), 0o600);
+    temp_dir.assert_no_vm0tmp_files();
+}
+
+#[tokio::test]
+async fn copy_file_empty_guest_file_publishes_empty_host_file() {
+    let (host, mut guest) = setup_host_and_guest().await;
+    let host = Arc::new(host);
+    let temp_dir = HostTempDir::new("vsock-host-copy-empty");
+    let host_path = temp_dir.join("empty.log");
+    let copy_path = host_path.clone();
+
+    let copy_task = spawn_copy_file(
+        Arc::clone(&host),
+        "/tmp/empty.log",
+        copy_path,
+        default_copy_options(),
+    );
+
+    let start = expect_exec_start(&mut guest).await;
+    send_stream_exec_result(
+        &mut guest,
+        start.seq(),
+        ExecTermination::Exited { exit_code: 0 },
+        b"",
+    )
+    .await;
+
+    let result = copy_task.await.unwrap().unwrap();
+    assert_eq!(result.bytes_copied, 0);
+    assert_eq!(std::fs::read(&host_path).unwrap(), b"");
+    assert_eq!(mode(&host_path), 0o600);
+    temp_dir.assert_no_vm0tmp_files();
+}
+
+#[tokio::test]
+async fn copy_file_allows_exact_max_bytes() {
+    let (host, mut guest) = setup_host_and_guest().await;
+    let host = Arc::new(host);
+    let temp_dir = HostTempDir::new("vsock-host-copy-exact-max");
+    let host_path = temp_dir.join("exact.log");
+    let copy_path = host_path.clone();
+
+    let copy_task = spawn_copy_file(
+        Arc::clone(&host),
+        "/tmp/exact.log",
+        copy_path,
+        copy_options(4, 5000, false),
+    );
+
+    let start = expect_exec_start(&mut guest).await;
+    assert_eq!(
+        start.stdout,
+        ExecOutputPolicy::Stream {
+            limit_bytes: 4,
+            chunk_limit_bytes: file_impl::test_support::COPY_FILE_STREAM_CHUNK_LIMIT,
+        }
+    );
+    send_exec_output(
+        &mut guest,
+        start.seq(),
+        0,
+        ExecOutputStream::Stdout,
+        b"1234",
+        false,
+    )
+    .await;
+    send_stream_exec_result(
+        &mut guest,
+        start.seq(),
+        ExecTermination::Exited { exit_code: 0 },
+        b"",
+    )
+    .await;
+
+    let result = copy_task.await.unwrap().unwrap();
+    assert_eq!(result.bytes_copied, 4);
+    assert_eq!(std::fs::read(&host_path).unwrap(), b"1234");
     temp_dir.assert_no_vm0tmp_files();
 }
 
@@ -508,6 +585,37 @@ async fn copy_file_missing_ok_leaves_no_final_or_temp_file() {
         NormalOperationReadiness::Idle
     );
     assert!(!host_path.exists());
+    temp_dir.assert_no_vm0tmp_files();
+}
+
+#[tokio::test]
+async fn copy_file_missing_ok_preserves_existing_host_file() {
+    let (host, mut guest) = setup_host_and_guest().await;
+    let host = Arc::new(host);
+    let temp_dir = HostTempDir::new("vsock-host-copy-missing-existing");
+    let host_path = temp_dir.join("system.log");
+    std::fs::write(&host_path, b"old host log").unwrap();
+    let copy_path = host_path.clone();
+
+    let copy_task = spawn_copy_file(
+        Arc::clone(&host),
+        "/tmp/missing.log",
+        copy_path,
+        copy_options(1024, 5000, true),
+    );
+
+    let msg = read_guest_message(&mut guest).await;
+    send_stream_exec_result(
+        &mut guest,
+        msg.seq,
+        ExecTermination::Exited { exit_code: 66 },
+        b"",
+    )
+    .await;
+
+    let result = copy_task.await.unwrap().unwrap();
+    assert_eq!(result.bytes_copied, 0);
+    assert_eq!(std::fs::read(&host_path).unwrap(), b"old host log");
     temp_dir.assert_no_vm0tmp_files();
 }
 

--- a/crates/vsock-host/src/tests/file/copy.rs
+++ b/crates/vsock-host/src/tests/file/copy.rs
@@ -196,6 +196,17 @@ async fn copy_file_rejects_invalid_options_without_sending_frame_or_creating_par
     let host_path = temp_path.join("nested/system.log");
 
     let err = host
+        .copy_file(
+            "/tmp/bad\0path.log",
+            &host_path,
+            copy_options(1024, 5000, false),
+        )
+        .await
+        .unwrap_err();
+    assert_eq!(err.kind(), io::ErrorKind::InvalidInput);
+    assert!(!temp_path.path().exists());
+
+    let err = host
         .copy_file("/tmp/system.log", &host_path, copy_options(0, 5000, false))
         .await
         .unwrap_err();

--- a/crates/vsock-host/src/tests/file/read.rs
+++ b/crates/vsock-host/src/tests/file/read.rs
@@ -169,7 +169,7 @@ async fn read_file_quotes_guest_path_with_single_quote() {
     let start = expect_exec_start(&mut guest).await;
     assert_eq!(
         start.command,
-        "if test -f '/tmp/session'\\''one.txt'; then cat < '/tmp/session'\\''one.txt'; else exit 66; fi"
+        "if test -f '/tmp/session'\\''one.txt'; then cat < '/tmp/session'\\''one.txt' 2>/dev/null || { test -f '/tmp/session'\\''one.txt' || exit 66; printf '%s\\n' 'failed to read file' >&2; exit 1; }; else exit 66; fi"
     );
     send_exec_result(
         &mut guest,

--- a/crates/vsock-host/src/tests/file/read.rs
+++ b/crates/vsock-host/src/tests/file/read.rs
@@ -78,6 +78,48 @@ async fn read_file_errors_on_truncated_stdout() {
 }
 
 #[tokio::test]
+async fn read_file_rejects_missing_result_with_output() {
+    let (host, mut guest) = setup_host_and_guest().await;
+    let read_task =
+        tokio::spawn(async move { host.read_file("/tmp/missing.txt", 1024, 5000).await });
+
+    let start = expect_exec_start(&mut guest).await;
+    send_exec_result(
+        &mut guest,
+        start.seq(),
+        ExecTermination::Exited { exit_code: 66 },
+        b"unexpected",
+        b"",
+    )
+    .await;
+
+    let err = read_task.await.unwrap().unwrap_err();
+    assert_eq!(err.kind(), io::ErrorKind::InvalidData);
+    assert!(err.to_string().contains("included stdout"));
+}
+
+#[tokio::test]
+async fn read_file_rejects_missing_result_with_stderr() {
+    let (host, mut guest) = setup_host_and_guest().await;
+    let read_task =
+        tokio::spawn(async move { host.read_file("/tmp/missing.txt", 1024, 5000).await });
+
+    let start = expect_exec_start(&mut guest).await;
+    send_exec_result(
+        &mut guest,
+        start.seq(),
+        ExecTermination::Exited { exit_code: 66 },
+        b"",
+        b"unexpected stderr",
+    )
+    .await;
+
+    let err = read_task.await.unwrap().unwrap_err();
+    assert_eq!(err.kind(), io::ErrorKind::InvalidData);
+    assert!(err.to_string().contains("included stderr"));
+}
+
+#[tokio::test]
 async fn read_file_rejects_invalid_max_bytes_without_sending_frame() {
     let (host, mut guest) = setup_host_and_guest().await;
     let host = Arc::new(host);

--- a/crates/vsock-host/src/tests/file/read.rs
+++ b/crates/vsock-host/src/tests/file/read.rs
@@ -78,6 +78,27 @@ async fn read_file_errors_on_truncated_stdout() {
 }
 
 #[tokio::test]
+async fn read_file_rejects_success_result_with_stderr() {
+    let (host, mut guest) = setup_host_and_guest().await;
+    let read_task =
+        tokio::spawn(async move { host.read_file("/tmp/session.txt", 1024, 5000).await });
+
+    let start = expect_exec_start(&mut guest).await;
+    send_exec_result(
+        &mut guest,
+        start.seq(),
+        ExecTermination::Exited { exit_code: 0 },
+        b"session-id\n",
+        b"unexpected stderr",
+    )
+    .await;
+
+    let err = read_task.await.unwrap().unwrap_err();
+    assert_eq!(err.kind(), io::ErrorKind::InvalidData);
+    assert!(err.to_string().contains("included stderr"));
+}
+
+#[tokio::test]
 async fn read_file_rejects_missing_result_with_output() {
     let (host, mut guest) = setup_host_and_guest().await;
     let read_task =

--- a/crates/vsock-host/src/tests/file/read.rs
+++ b/crates/vsock-host/src/tests/file/read.rs
@@ -149,6 +149,14 @@ async fn read_file_rejects_invalid_max_bytes_without_sending_frame() {
     let (host, mut guest) = setup_host_and_guest().await;
     let host = Arc::new(host);
 
+    let err = host
+        .read_file("/tmp/bad\0path.txt", 1024, 5000)
+        .await
+        .unwrap_err();
+
+    assert_eq!(err.kind(), io::ErrorKind::InvalidInput);
+    assert_eq!(operation_count(&host), 0);
+
     let err = host.read_file("/tmp/empty.txt", 0, 5000).await.unwrap_err();
 
     assert_eq!(err.kind(), io::ErrorKind::InvalidInput);

--- a/crates/vsock-host/src/tests/file/read.rs
+++ b/crates/vsock-host/src/tests/file/read.rs
@@ -145,6 +145,34 @@ async fn read_file_rejects_missing_result_with_stderr() {
 }
 
 #[tokio::test]
+async fn read_file_rejects_missing_result_with_truncated_stderr() {
+    let (host, mut guest) = setup_host_and_guest().await;
+    let read_task =
+        tokio::spawn(async move { host.read_file("/tmp/missing.txt", 1024, 5000).await });
+
+    let start = expect_exec_start(&mut guest).await;
+    let payload = vsock_proto::encode_exec_result(
+        ExecTermination::Exited { exit_code: 66 },
+        12,
+        ExecCapturedOutput::Captured {
+            bytes: b"",
+            truncated: false,
+        },
+        ExecCapturedOutput::Captured {
+            bytes: b"",
+            truncated: true,
+        },
+        "",
+    )
+    .unwrap();
+    send_raw_exec_result(&mut guest, start.seq(), payload).await;
+
+    let err = read_task.await.unwrap().unwrap_err();
+    assert_eq!(err.kind(), io::ErrorKind::InvalidData);
+    assert!(err.to_string().contains("stderr truncated"));
+}
+
+#[tokio::test]
 async fn read_file_rejects_invalid_max_bytes_without_sending_frame() {
     let (host, mut guest) = setup_host_and_guest().await;
     let host = Arc::new(host);

--- a/crates/vsock-host/src/tests/file/read.rs
+++ b/crates/vsock-host/src/tests/file/read.rs
@@ -20,7 +20,11 @@ async fn read_file_returns_content_and_missing() {
     };
     let start = expect_exec_start(&mut guest).await;
     assert_eq!(start.label, "read-file");
-    assert!(start.command.contains("cat < '/tmp/session.txt'"));
+    assert!(
+        start
+            .command
+            .contains("cat 2>/dev/null < '/tmp/session.txt'")
+    );
     assert_eq!(start.expected_exit_codes, vec![66]);
     send_exec_result(
         &mut guest,
@@ -169,7 +173,7 @@ async fn read_file_quotes_guest_path_with_single_quote() {
     let start = expect_exec_start(&mut guest).await;
     assert_eq!(
         start.command,
-        "if test -f '/tmp/session'\\''one.txt'; then cat < '/tmp/session'\\''one.txt' 2>/dev/null || { test -f '/tmp/session'\\''one.txt' || exit 66; printf '%s\\n' 'failed to read file' >&2; exit 1; }; else exit 66; fi"
+        "if test -f '/tmp/session'\\''one.txt'; then cat 2>/dev/null < '/tmp/session'\\''one.txt' || { test -f '/tmp/session'\\''one.txt' || exit 66; printf '%s\\n' 'failed to read file' >&2; exit 1; }; else exit 66; fi"
     );
     send_exec_result(
         &mut guest,

--- a/crates/vsock-host/src/tests/file/read.rs
+++ b/crates/vsock-host/src/tests/file/read.rs
@@ -124,6 +124,34 @@ async fn read_file_rejects_missing_result_with_output() {
 }
 
 #[tokio::test]
+async fn read_file_rejects_missing_result_with_truncated_stdout() {
+    let (host, mut guest) = setup_host_and_guest().await;
+    let read_task =
+        tokio::spawn(async move { host.read_file("/tmp/missing.txt", 1024, 5000).await });
+
+    let start = expect_exec_start(&mut guest).await;
+    let payload = vsock_proto::encode_exec_result(
+        ExecTermination::Exited { exit_code: 66 },
+        12,
+        ExecCapturedOutput::Captured {
+            bytes: b"",
+            truncated: true,
+        },
+        ExecCapturedOutput::Captured {
+            bytes: b"",
+            truncated: false,
+        },
+        "",
+    )
+    .unwrap();
+    send_raw_exec_result(&mut guest, start.seq(), payload).await;
+
+    let err = read_task.await.unwrap().unwrap_err();
+    assert_eq!(err.kind(), io::ErrorKind::InvalidData);
+    assert!(err.to_string().contains("stdout truncated"));
+}
+
+#[tokio::test]
 async fn read_file_rejects_missing_result_with_stderr() {
     let (host, mut guest) = setup_host_and_guest().await;
     let read_task =
@@ -169,6 +197,34 @@ async fn read_file_rejects_missing_result_with_truncated_stderr() {
 
     let err = read_task.await.unwrap().unwrap_err();
     assert_eq!(err.kind(), io::ErrorKind::InvalidData);
+    assert!(err.to_string().contains("stderr truncated"));
+}
+
+#[tokio::test]
+async fn read_file_preserves_truncated_stderr_on_nonzero_exit() {
+    let (host, mut guest) = setup_host_and_guest().await;
+    let read_task =
+        tokio::spawn(async move { host.read_file("/tmp/unreadable.txt", 1024, 5000).await });
+
+    let start = expect_exec_start(&mut guest).await;
+    let payload = vsock_proto::encode_exec_result(
+        ExecTermination::Exited { exit_code: 1 },
+        12,
+        ExecCapturedOutput::Captured {
+            bytes: b"",
+            truncated: false,
+        },
+        ExecCapturedOutput::Captured {
+            bytes: b"",
+            truncated: true,
+        },
+        "",
+    )
+    .unwrap();
+    send_raw_exec_result(&mut guest, start.seq(), payload).await;
+
+    let err = read_task.await.unwrap().unwrap_err();
+    assert_eq!(err.kind(), io::ErrorKind::Other);
     assert!(err.to_string().contains("stderr truncated"));
 }
 

--- a/crates/vsock-host/src/tests/file/read.rs
+++ b/crates/vsock-host/src/tests/file/read.rs
@@ -149,6 +149,11 @@ async fn read_file_rejects_invalid_max_bytes_without_sending_frame() {
     let (host, mut guest) = setup_host_and_guest().await;
     let host = Arc::new(host);
 
+    let err = host.read_file("", 1024, 5000).await.unwrap_err();
+
+    assert_eq!(err.kind(), io::ErrorKind::InvalidInput);
+    assert_eq!(operation_count(&host), 0);
+
     let err = host
         .read_file("/tmp/bad\0path.txt", 1024, 5000)
         .await

--- a/crates/vsock-host/src/tests/file/read.rs
+++ b/crates/vsock-host/src/tests/file/read.rs
@@ -20,7 +20,7 @@ async fn read_file_returns_content_and_missing() {
     };
     let start = expect_exec_start(&mut guest).await;
     assert_eq!(start.label, "read-file");
-    assert!(start.command.contains("cat -- '/tmp/session.txt'"));
+    assert!(start.command.contains("cat < '/tmp/session.txt'"));
     assert_eq!(start.expected_exit_codes, vec![66]);
     send_exec_result(
         &mut guest,
@@ -106,7 +106,7 @@ async fn read_file_quotes_guest_path_with_single_quote() {
     let start = expect_exec_start(&mut guest).await;
     assert_eq!(
         start.command,
-        "if test -f '/tmp/session'\\''one.txt'; then cat -- '/tmp/session'\\''one.txt'; else exit 66; fi"
+        "if test -f '/tmp/session'\\''one.txt'; then cat < '/tmp/session'\\''one.txt'; else exit 66; fi"
     );
     send_exec_result(
         &mut guest,


### PR DESCRIPTION
## Summary

- document `vsock_host::CopyFileOptions` validation and guest-helper-reported unresolved/non-regular path semantics
- document `vsock_host::CopyFileResult::bytes_copied`, including the empty-file edge case
- document guest file path and read `max_bytes` input validation for public read/copy file APIs
- align `sandbox` copy-file rustdoc with the same validation and backend-reported guest path contract, while clarifying host-side setup errors can still fail
- avoid overpromising atomic publish semantics at the abstract `Sandbox` trait layer
- reject inconsistent `vsock-host` copy results that report missing after streaming stdout or stderr, regardless of `missing_ok`
- harden `vsock-host` read/copy helper commands to read via shell redirection so a guest path named `-` is handled as a file path, not stdin
- classify read/copy helper paths that stop being regular before `cat` finishes as missing/no-op results instead of leaking shell stderr into `missing_ok` failures
- suppress shell redirection errors before opening the guest file so unreadable files use the helper diagnostic and raced missing paths stay quiet
- reject empty or NUL-containing guest file paths before sending an exec frame or creating host copy directories
- reject invalid guest file paths in `sandbox-mock` read/copy helpers so mock tests match `vsock-host` behavior and do not consume queued results
- reject invalid host copy destinations in `vsock-host` and `sandbox-mock` before creating temp files, sending guest exec frames, or returning `missing_ok` no-op results
- align `sandbox-mock` read/copy `max_bytes` limits with `vsock-host` so oversized option errors preserve queued results
- align runner queued copy-file test support with the same validation so invalid options do not trigger side effects or consume queued bytes
- reject inconsistent `vsock-host` read results that report missing while returning stdout or stderr
- preserve stdout/stderr truncation diagnostics when rejecting malformed `vsock-host` read results
- reject successful `vsock-host` read/copy helper results that include stderr
- add focused `vsock-host` copy-file tests for present empty guest files, exact `max_bytes`, and `missing_ok` preserving existing host files
- add `vsock-host` coverage for rejecting a `missing_ok` result that already streamed output or returned stderr
- add `sandbox-mock` coverage that `missing_ok` preserves an existing host file and validation errors preserve queued read/copy results

## Testing

- shell verification for regular files, missing paths, directories, unreadable files, and a file named `-`
- `cargo fmt --manifest-path crates/Cargo.toml --all --check`
- `cargo test --manifest-path crates/Cargo.toml -p vsock-host file::`
- `cargo test --manifest-path crates/Cargo.toml -p sandbox-mock`
- `cargo test --manifest-path crates/Cargo.toml -p runner queued_copy_file_validates_before_side_effect_or_queue`
- `cargo test --manifest-path crates/Cargo.toml -p runner execute_inner_preserves_system_stream_log_after_nonzero_exit_guest_copy`
- `cargo test --manifest-path crates/Cargo.toml -p runner execute_inner_proxy_unregister_failure_marks_successful_run_failed`
- `cargo doc --manifest-path crates/Cargo.toml -p vsock-host --no-deps`
- `cargo doc --manifest-path crates/Cargo.toml -p sandbox --no-deps`
- `cargo doc --manifest-path crates/Cargo.toml -p sandbox-mock --no-deps`
- `cargo doc --manifest-path crates/Cargo.toml -p runner --no-deps`
- pre-commit Rust hooks: cargo-fmt, cargo-clippy, cargo-doc

Closes #16741
