### PR TITLE
feat(cli): add zero video transcribe command with timestamped STT output

### DIFF
--- a/turbo/apps/api/src/signals/routes/__tests__/zero-voice-io-post.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/zero-voice-io-post.test.ts
@@ -755,7 +755,7 @@ describe("POST /api/zero/voice-io/*", () => {
         observedResponseFormat = form.get("response_format");
         return HttpResponse.json({
           text: "hello world",
-          segments: [{ start: 0.0, end: 1.5, text: " hello world" }],
+          segments: [{ start: 0, end: 1.5, text: " hello world" }],
         });
       }),
     );
@@ -770,7 +770,7 @@ describe("POST /api/zero/voice-io/*", () => {
     expect(response.status).toBe(200);
     await expect(response.json()).resolves.toStrictEqual({
       text: "hello world",
-      segments: [{ start: 0.0, end: 1.5, text: " hello world" }],
+      segments: [{ start: 0, end: 1.5, text: " hello world" }],
     });
     expect(observedModel).toBe("whisper-1");
     expect(observedResponseFormat).toBe("verbose_json");

--- a/turbo/apps/api/src/signals/routes/__tests__/zero-voice-io-post.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/zero-voice-io-post.test.ts
@@ -742,6 +742,40 @@ describe("POST /api/zero/voice-io/*", () => {
     expect(counts.get(sttDailyDurationKey())).toBe(2);
   });
 
+  it("uses whisper-1 and verbose_json when ?verbose=true, returns segments", async () => {
+    const fixture = await track(seedVoiceFixture({}));
+    mocks.clerk.session(fixture.userId, fixture.orgId);
+
+    let observedModel: FormDataEntryValue | null = null;
+    let observedResponseFormat: FormDataEntryValue | null = null;
+    server.use(
+      http.post(OPENAI_AUDIO_TRANSCRIPTIONS_URL, async ({ request }) => {
+        const form = await request.formData();
+        observedModel = form.get("model");
+        observedResponseFormat = form.get("response_format");
+        return HttpResponse.json({
+          text: "hello world",
+          segments: [{ start: 0.0, end: 1.5, text: " hello world" }],
+        });
+      }),
+    );
+
+    const app = createApp({ signal: context.signal });
+    const response = await app.request("/api/zero/voice-io/stt?verbose=true", {
+      method: "POST",
+      headers: authHeaders(),
+      body: sttForm(sttFile(wavBytes(2))),
+    });
+
+    expect(response.status).toBe(200);
+    await expect(response.json()).resolves.toStrictEqual({
+      text: "hello world",
+      segments: [{ start: 0.0, end: 1.5, text: " hello world" }],
+    });
+    expect(observedModel).toBe("whisper-1");
+    expect(observedResponseFormat).toBe("verbose_json");
+  });
+
   it("does not increment the legacy /stt free-tier counter for pro orgs", async () => {
     const fixture = await track(seedVoiceFixture({ tier: "pro" }));
     mocks.clerk.session(fixture.userId, fixture.orgId);

--- a/turbo/apps/api/src/signals/routes/zero-voice-io-stt.ts
+++ b/turbo/apps/api/src/signals/routes/zero-voice-io-stt.ts
@@ -27,7 +27,7 @@ const L = logger("ZeroVoiceIoStt");
 
 const postSttInner$ = command(async ({ get, set }, signal: AbortSignal) => {
   const request = get(request$);
-  const verbose = request.query["verbose"] === "true";
+  const verbose = request.query("verbose") === "true";
   const auth = get(organizationAuthContext$);
   const quota = await get(audioInputQuota(auth.orgId, auth.userId));
   signal.throwIfAborted();

--- a/turbo/apps/api/src/signals/routes/zero-voice-io-stt.ts
+++ b/turbo/apps/api/src/signals/routes/zero-voice-io-stt.ts
@@ -20,6 +20,7 @@ import {
   recordSttUsage$,
   sttDailyPolicy$,
   VOICE_IO_STT_MODEL,
+  VOICE_IO_STT_VERBOSE_MODEL,
 } from "../services/zero-voice-io-post.service";
 import { env } from "../../lib/env";
 
@@ -107,7 +108,10 @@ const postSttInner$ = command(async ({ get, set }, signal: AbortSignal) => {
 
   const openaiForm = new FormData();
   openaiForm.append("file", file, file.name || "audio.webm");
-  openaiForm.append("model", verbose ? "whisper-1" : VOICE_IO_STT_MODEL);
+  openaiForm.append(
+    "model",
+    verbose ? VOICE_IO_STT_VERBOSE_MODEL : VOICE_IO_STT_MODEL,
+  );
   openaiForm.append("response_format", verbose ? "verbose_json" : "json");
 
   const openaiResponse = await fetch(OPENAI_AUDIO_TRANSCRIPTIONS_URL, {

--- a/turbo/apps/api/src/signals/routes/zero-voice-io-stt.ts
+++ b/turbo/apps/api/src/signals/routes/zero-voice-io-stt.ts
@@ -107,7 +107,7 @@ const postSttInner$ = command(async ({ get, set }, signal: AbortSignal) => {
 
   const openaiForm = new FormData();
   openaiForm.append("file", file, file.name || "audio.webm");
-  openaiForm.append("model", VOICE_IO_STT_MODEL);
+  openaiForm.append("model", verbose ? "whisper-1" : VOICE_IO_STT_MODEL);
   openaiForm.append("response_format", verbose ? "verbose_json" : "json");
 
   const openaiResponse = await fetch(OPENAI_AUDIO_TRANSCRIPTIONS_URL, {

--- a/turbo/apps/api/src/signals/routes/zero-voice-io-stt.ts
+++ b/turbo/apps/api/src/signals/routes/zero-voice-io-stt.ts
@@ -13,6 +13,7 @@ import {
   internalError,
   isAllowedSttMimeType,
   isTranscriptionBody,
+  isVerboseTranscriptionSegment,
   MAX_STT_FILE_SIZE,
   MAX_STT_REQUEST_DURATION_SECONDS,
   OPENAI_AUDIO_TRANSCRIPTIONS_URL,
@@ -25,6 +26,8 @@ import { env } from "../../lib/env";
 const L = logger("ZeroVoiceIoStt");
 
 const postSttInner$ = command(async ({ get, set }, signal: AbortSignal) => {
+  const request = get(request$);
+  const verbose = request.query["verbose"] === "true";
   const auth = get(organizationAuthContext$);
   const quota = await get(audioInputQuota(auth.orgId, auth.userId));
   signal.throwIfAborted();
@@ -42,7 +45,6 @@ const postSttInner$ = command(async ({ get, set }, signal: AbortSignal) => {
     };
   }
 
-  const request = get(request$);
   const formData = await request.raw.formData();
   signal.throwIfAborted();
   const file = formData.get("file");
@@ -106,7 +108,7 @@ const postSttInner$ = command(async ({ get, set }, signal: AbortSignal) => {
   const openaiForm = new FormData();
   openaiForm.append("file", file, file.name || "audio.webm");
   openaiForm.append("model", VOICE_IO_STT_MODEL);
-  openaiForm.append("response_format", "json");
+  openaiForm.append("response_format", verbose ? "verbose_json" : "json");
 
   const openaiResponse = await fetch(OPENAI_AUDIO_TRANSCRIPTIONS_URL, {
     method: "POST",
@@ -142,7 +144,20 @@ const postSttInner$ = command(async ({ get, set }, signal: AbortSignal) => {
     signal,
   );
 
-  return { status: 200 as const, body: { text: result.text } };
+  const segments =
+    verbose && Array.isArray((result as Record<string, unknown>).segments)
+      ? ((result as Record<string, unknown>).segments as unknown[]).filter(
+          isVerboseTranscriptionSegment,
+        )
+      : undefined;
+
+  return {
+    status: 200 as const,
+    body: {
+      text: result.text,
+      ...(segments !== undefined && { segments }),
+    },
+  };
 });
 
 export const zeroVoiceIoSttRoutes: readonly RouteEntry[] = [

--- a/turbo/apps/api/src/signals/services/zero-voice-io-post.service.ts
+++ b/turbo/apps/api/src/signals/services/zero-voice-io-post.service.ts
@@ -203,9 +203,7 @@ export function isTranscriptionBody(
   return isRecord(value) && typeof value.text === "string";
 }
 
-export function isVerboseTranscriptionSegment(
-  value: unknown,
-): value is {
+export function isVerboseTranscriptionSegment(value: unknown): value is {
   readonly start: number;
   readonly end: number;
   readonly text: string;

--- a/turbo/apps/api/src/signals/services/zero-voice-io-post.service.ts
+++ b/turbo/apps/api/src/signals/services/zero-voice-io-post.service.ts
@@ -21,6 +21,9 @@ export const OPENAI_AUDIO_TRANSCRIPTIONS_URL =
   "https://api.openai.com/v1/audio/transcriptions";
 export const VOICE_IO_TTS_MODEL = "gpt-4o-mini-tts";
 export const VOICE_IO_STT_MODEL = "gpt-4o-mini-transcribe";
+// Verbose transcription (per-segment timestamps) requires whisper-1;
+// gpt-4o-mini-transcribe does not return segment timestamps.
+export const VOICE_IO_STT_VERBOSE_MODEL = "whisper-1";
 export const SPEECH_CONTENT_TYPE = "audio/wav";
 export const SPEECH_RESPONSE_FORMAT = "wav";
 export const TTS_RESPONSE_FORMAT = "pcm";

--- a/turbo/apps/api/src/signals/services/zero-voice-io-post.service.ts
+++ b/turbo/apps/api/src/signals/services/zero-voice-io-post.service.ts
@@ -205,7 +205,11 @@ export function isTranscriptionBody(
 
 export function isVerboseTranscriptionSegment(
   value: unknown,
-): value is { readonly start: number; readonly end: number; readonly text: string } {
+): value is {
+  readonly start: number;
+  readonly end: number;
+  readonly text: string;
+} {
   return (
     isRecord(value) &&
     typeof value.start === "number" &&

--- a/turbo/apps/api/src/signals/services/zero-voice-io-post.service.ts
+++ b/turbo/apps/api/src/signals/services/zero-voice-io-post.service.ts
@@ -203,6 +203,17 @@ export function isTranscriptionBody(
   return isRecord(value) && typeof value.text === "string";
 }
 
+export function isVerboseTranscriptionSegment(
+  value: unknown,
+): value is { readonly start: number; readonly end: number; readonly text: string } {
+  return (
+    isRecord(value) &&
+    typeof value.start === "number" &&
+    typeof value.end === "number" &&
+    typeof value.text === "string"
+  );
+}
+
 export function isAllowedSttMimeType(value: string): boolean {
   return ALLOWED_STT_MIME_TYPES.some((mimeType) => {
     return mimeType === value;

--- a/turbo/apps/cli/src/__tests__/zero.test.ts
+++ b/turbo/apps/cli/src/__tests__/zero.test.ts
@@ -37,6 +37,7 @@ describe("zero CLI program", () => {
       "computer-use",
       "generate",
       "web",
+      "video",
       "host",
       "maps",
       "banking",
@@ -63,7 +64,7 @@ describe("zero CLI program", () => {
     }
   });
 
-  it("should have exactly 27 commands", () => {
-    expect(commandNames).toHaveLength(27);
+  it("should have exactly 28 commands", () => {
+    expect(commandNames).toHaveLength(28);
   });
 });

--- a/turbo/apps/cli/src/commands/zero/github/download-file.ts
+++ b/turbo/apps/cli/src/commands/zero/github/download-file.ts
@@ -45,9 +45,10 @@ Output:
 
 How to read the downloaded file:
   - Images (png/jpg/gif/webp/svg): open the file path with your image viewing tool
-  - Videos (mp4/mov/webm): extract frames first with
+  - Videos (mp4/mov/webm): transcribe audio first with
+      zero video transcribe --url <download-url>
+    or extract frames with
       ffmpeg -i <path> -vf "fps=1" -q:v 2 /tmp/github_frame_%03d.jpg
-    then view the extracted frames
   - PDF/text/csv/json/markdown: read the file directly
 
 Notes:

--- a/turbo/apps/cli/src/commands/zero/phone/download-file.ts
+++ b/turbo/apps/cli/src/commands/zero/phone/download-file.ts
@@ -32,9 +32,10 @@ Output:
 
 How to read the downloaded file:
   - Images (png/jpg/gif/webp/svg): open the file path with your image viewing tool
-  - Videos (mp4/mov/webm): extract frames first with
+  - Videos (mp4/mov/webm): transcribe audio first with
+      zero video transcribe --url <download-url>
+    or extract frames with
       ffmpeg -i <path> -vf "fps=1" -q:v 2 /tmp/<file-id>_frame_%03d.jpg
-    then view the extracted frames
   - PDF/text/csv/json/markdown: read the file directly`,
   )
   .action(

--- a/turbo/apps/cli/src/commands/zero/slack/download-file.ts
+++ b/turbo/apps/cli/src/commands/zero/slack/download-file.ts
@@ -37,9 +37,10 @@ Output:
 
 How to read the downloaded file:
   - Images (png/jpg/gif/webp/svg): open the file path with your image viewing tool
-  - Videos (mp4/mov/webm): extract frames first with
+  - Videos (mp4/mov/webm): transcribe audio first with
+      zero video transcribe --url <download-url>
+    or extract frames with
       ffmpeg -i <path> -vf "fps=1" -q:v 2 /tmp/<file-id>_frame_%03d.jpg
-    then view the extracted frames
   - PDF/text/csv/json/markdown: read the file directly
 
 Notes:

--- a/turbo/apps/cli/src/commands/zero/telegram/download-file.ts
+++ b/turbo/apps/cli/src/commands/zero/telegram/download-file.ts
@@ -40,9 +40,10 @@ Output:
 
 How to read the downloaded file:
   - Images (png/jpg/gif/webp/svg): open the file path with your image viewing tool
-  - Videos (mp4/mov/webm): extract frames first with
+  - Videos (mp4/mov/webm): transcribe audio first with
+      zero video transcribe --url <download-url>
+    or extract frames with
       ffmpeg -i <path> -vf "fps=1" -q:v 2 /tmp/<file-id>_frame_%03d.jpg
-    then view the extracted frames
   - PDF/text/csv/json/markdown: read the file directly
 
 Notes:

--- a/turbo/apps/cli/src/commands/zero/video/__tests__/frames.test.ts
+++ b/turbo/apps/cli/src/commands/zero/video/__tests__/frames.test.ts
@@ -1,0 +1,116 @@
+/**
+ * Tests for zero video frames command.
+ *
+ * Uses vi.mock for child_process (curl/ffmpeg) and fs so the test does not
+ * require real binaries or touch the filesystem in CI.
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { execFileSync } from "child_process";
+import { framesCommand } from "../frames";
+
+vi.mock("child_process", () => {
+  return {
+    execFileSync: vi.fn(),
+  };
+});
+
+vi.mock("fs", () => {
+  return {
+    mkdirSync: vi.fn(),
+    unlinkSync: vi.fn(),
+  };
+});
+
+vi.mock("../../../../lib/api/domains/web", async (importOriginal) => {
+  const actual =
+    await importOriginal<typeof import("../../../../lib/api/domains/web")>();
+  return {
+    ...actual,
+    downloadWebFile: vi.fn().mockResolvedValue({
+      path: "/tmp/zero-video-test.mp4",
+      mimetype: "video/mp4",
+      size: 1024,
+    }),
+  };
+});
+
+const mockStdoutWrite = vi
+  .spyOn(process.stdout, "write")
+  .mockImplementation(() => {
+    return true;
+  });
+
+function readStdout(): string {
+  return mockStdoutWrite.mock.calls
+    .map((c) => {
+      return c[0];
+    })
+    .join("");
+}
+
+describe("zero video frames command", () => {
+  beforeEach(() => {
+    mockStdoutWrite.mockClear();
+  });
+
+  afterEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("extracts one frame per timestamp and prints JSON paths", async () => {
+    await framesCommand.parseAsync(
+      ["--url", "https://example.com/video.mp4", "--at", "00:21,01:40"],
+      { from: "user" },
+    );
+
+    const result = JSON.parse(readStdout()) as {
+      frames: { at: string; path: string }[];
+    };
+    expect(result.frames).toHaveLength(2);
+    expect(result.frames[0]?.at).toBe("00:21");
+    expect(result.frames[1]?.at).toBe("01:40");
+    expect(result.frames[0]?.path).toContain("frame-001.jpg");
+    expect(result.frames[1]?.path).toContain("frame-002.jpg");
+
+    const ffmpegCalls = vi.mocked(execFileSync).mock.calls.filter((c) => {
+      return c[0] === "ffmpeg";
+    });
+    expect(ffmpegCalls).toHaveLength(2);
+    expect(ffmpegCalls[0]?.[1]).toEqual(
+      expect.arrayContaining(["-ss", "00:21", "-frames:v", "1"]),
+    );
+    expect(ffmpegCalls[1]?.[1]).toEqual(
+      expect.arrayContaining(["-ss", "01:40"]),
+    );
+  });
+
+  it("downloads via downloadWebFile when --file-id is given", async () => {
+    const { downloadWebFile } = await import("../../../../lib/api/domains/web");
+
+    await framesCommand.parseAsync(["--file-id", "abc-123", "--at", "5"], {
+      from: "user",
+    });
+
+    expect(downloadWebFile).toHaveBeenCalledWith(
+      "abc-123",
+      expect.stringContaining("zero-video-"),
+    );
+    const result = JSON.parse(readStdout()) as {
+      frames: { at: string }[];
+    };
+    expect(result.frames[0]?.at).toBe("5");
+  });
+
+  it("exits with error when neither --url nor --file-id provided", async () => {
+    const mockExit = vi.spyOn(process, "exit").mockImplementation((() => {
+      throw new Error("process.exit called");
+    }) as never);
+
+    await expect(
+      framesCommand.parseAsync(["--at", "5"], { from: "user" }),
+    ).rejects.toThrow("process.exit called");
+
+    mockExit.mockRestore();
+  });
+});

--- a/turbo/apps/cli/src/commands/zero/video/__tests__/frames.test.ts
+++ b/turbo/apps/cli/src/commands/zero/video/__tests__/frames.test.ts
@@ -1,36 +1,38 @@
 /**
  * Tests for zero video frames command.
  *
- * Uses vi.mock for child_process (curl/ffmpeg) and fs so the test does not
- * require real binaries or touch the filesystem in CI.
+ * Mocks only external boundaries: the curl/ffmpeg binaries (via child_process,
+ * not available in CI) and HTTP (via MSW). The fake binaries write real bytes
+ * to their output paths (the arg after "-o" for curl, before "-y" for ffmpeg)
+ * so the command's real filesystem and real downloadWebFile code run unchanged.
  */
 
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 import { execFileSync } from "child_process";
+import { http, HttpResponse } from "msw";
+import { server } from "../../../../mocks/server";
 import { framesCommand } from "../frames";
 
-vi.mock("child_process", () => {
-  return {
-    execFileSync: vi.fn(),
-  };
-});
+const DOWNLOAD_URL = "http://localhost:3000/api/zero/web/download-file";
 
-vi.mock("fs", () => {
+vi.mock("child_process", async () => {
+  const { writeFileSync } = await vi.importActual<typeof import("fs")>("fs");
   return {
-    mkdirSync: vi.fn(),
-    unlinkSync: vi.fn(),
-  };
-});
-
-vi.mock("../../../../lib/api/domains/web", async (importOriginal) => {
-  const actual =
-    await importOriginal<typeof import("../../../../lib/api/domains/web")>();
-  return {
-    ...actual,
-    downloadWebFile: vi.fn().mockResolvedValue({
-      path: "/tmp/zero-video-test.mp4",
-      mimetype: "video/mp4",
-      size: 1024,
+    execFileSync: vi.fn((command: string, args: readonly string[]) => {
+      if (command === "curl") {
+        const i = args.indexOf("-o");
+        const outPath = i >= 0 ? args[i + 1] : undefined;
+        if (outPath) {
+          writeFileSync(outPath, Buffer.from("fake-video"));
+        }
+      } else if (command === "ffmpeg") {
+        const i = args.indexOf("-y");
+        const outPath = i > 0 ? args[i - 1] : undefined;
+        if (outPath) {
+          writeFileSync(outPath, Buffer.from("fake-frame"));
+        }
+      }
+      return Buffer.from("");
     }),
   };
 });
@@ -51,11 +53,14 @@ function readStdout(): string {
 
 describe("zero video frames command", () => {
   beforeEach(() => {
+    vi.stubEnv("VM0_API_URL", "http://localhost:3000");
+    vi.stubEnv("VM0_TOKEN", "test-token");
     mockStdoutWrite.mockClear();
   });
 
   afterEach(() => {
     vi.clearAllMocks();
+    vi.unstubAllEnvs();
   });
 
   it("extracts one frame per timestamp and prints JSON paths", async () => {
@@ -85,20 +90,23 @@ describe("zero video frames command", () => {
     );
   });
 
-  it("downloads via downloadWebFile when --file-id is given", async () => {
-    const { downloadWebFile } = await import("../../../../lib/api/domains/web");
+  it("downloads via the web file API when --file-id is given", async () => {
+    let requestedFileId: string | null = null;
+    server.use(
+      http.get(DOWNLOAD_URL, ({ request }) => {
+        requestedFileId = new URL(request.url).searchParams.get("file_id");
+        return new HttpResponse(new Uint8Array([1, 2, 3, 4]), {
+          headers: { "content-type": "video/mp4", "content-length": "4" },
+        });
+      }),
+    );
 
     await framesCommand.parseAsync(["--file-id", "abc-123", "--at", "5"], {
       from: "user",
     });
 
-    expect(downloadWebFile).toHaveBeenCalledWith(
-      "abc-123",
-      expect.stringContaining("zero-video-"),
-    );
-    const result = JSON.parse(readStdout()) as {
-      frames: { at: string }[];
-    };
+    expect(requestedFileId).toBe("abc-123");
+    const result = JSON.parse(readStdout()) as { frames: { at: string }[] };
     expect(result.frames[0]?.at).toBe("5");
   });
 

--- a/turbo/apps/cli/src/commands/zero/video/__tests__/transcribe.test.ts
+++ b/turbo/apps/cli/src/commands/zero/video/__tests__/transcribe.test.ts
@@ -12,14 +12,18 @@ import { transcribeCommand } from "../transcribe";
 
 const STT_URL = "http://localhost:3000/api/zero/voice-io/stt";
 
-vi.mock("child_process", () => ({
-  execFileSync: vi.fn(),
-}));
+vi.mock("child_process", () => {
+  return {
+    execFileSync: vi.fn(),
+  };
+});
 
-vi.mock("fs", async (importOriginal) => {
-  const actual = await importOriginal<typeof import("fs")>();
+vi.mock("node:fs", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("node:fs")>();
   return {
     ...actual,
+    readFileSync: vi.fn().mockReturnValue(Buffer.from("fake audio data")),
+    statSync: vi.fn().mockReturnValue({ size: 1024 }),
     unlinkSync: vi.fn(),
   };
 });
@@ -39,7 +43,9 @@ vi.mock("../../../../lib/api/domains/web", async (importOriginal) => {
 
 const mockStdoutWrite = vi
   .spyOn(process.stdout, "write")
-  .mockImplementation(() => true);
+  .mockImplementation(() => {
+    return true;
+  });
 
 describe("zero video transcribe command", () => {
   beforeEach(() => {
@@ -71,7 +77,11 @@ describe("zero video transcribe command", () => {
         { from: "user" },
       );
 
-      const output = mockStdoutWrite.mock.calls.map((c) => c[0]).join("");
+      const output = mockStdoutWrite.mock.calls
+        .map((c) => {
+          return c[0];
+        })
+        .join("");
       expect(output).toContain("## Transcript");
       expect(output).toContain("[00:02-00:05] Hello world.");
       expect(output).toContain("[00:06-00:07] Second sentence.");
@@ -95,7 +105,11 @@ describe("zero video transcribe command", () => {
         { from: "user" },
       );
 
-      const output = mockStdoutWrite.mock.calls.map((c) => c[0]).join("");
+      const output = mockStdoutWrite.mock.calls
+        .map((c) => {
+          return c[0];
+        })
+        .join("");
       expect(output).toContain("## Transcript");
       expect(output).toContain("Hello world. Second sentence.");
       expect(output).not.toMatch(/\[\d{2}:\d{2}-\d{2}:\d{2}\]/);
@@ -104,8 +118,9 @@ describe("zero video transcribe command", () => {
 
   describe("with --file-id", () => {
     it("should use downloadWebFile instead of curl", async () => {
-      const { downloadWebFile } =
-        await import("../../../../lib/api/domains/web");
+      const { downloadWebFile } = await import(
+        "../../../../lib/api/domains/web"
+      );
 
       server.use(
         http.post(STT_URL, () => {

--- a/turbo/apps/cli/src/commands/zero/video/__tests__/transcribe.test.ts
+++ b/turbo/apps/cli/src/commands/zero/video/__tests__/transcribe.test.ts
@@ -1,8 +1,11 @@
 /**
  * Tests for zero video transcribe command.
  *
- * Uses MSW to mock the STT API endpoint and child_process.execFileSync
- * to avoid requiring real ffmpeg/curl in CI.
+ * Mocks only external boundaries: the curl/ffmpeg binaries (via child_process,
+ * not available in CI) and HTTP (via MSW). The fake binaries write real bytes
+ * to their output paths (the arg after "-o" for curl, before "-y" for ffmpeg)
+ * so the command's real filesystem, real downloadWebFile, and real
+ * transcribeAudio code all run unchanged.
  */
 
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
@@ -11,32 +14,26 @@ import { server } from "../../../../mocks/server";
 import { transcribeCommand } from "../transcribe";
 
 const STT_URL = "http://localhost:3000/api/zero/voice-io/stt";
+const DOWNLOAD_URL = "http://localhost:3000/api/zero/web/download-file";
 
-vi.mock("child_process", () => {
+vi.mock("child_process", async () => {
+  const { writeFileSync } = await vi.importActual<typeof import("fs")>("fs");
   return {
-    execFileSync: vi.fn(),
-  };
-});
-
-vi.mock("node:fs", async (importOriginal) => {
-  const actual = await importOriginal<typeof import("node:fs")>();
-  return {
-    ...actual,
-    readFileSync: vi.fn().mockReturnValue(Buffer.from("fake audio data")),
-    statSync: vi.fn().mockReturnValue({ size: 1024 }),
-    unlinkSync: vi.fn(),
-  };
-});
-
-vi.mock("../../../../lib/api/domains/web", async (importOriginal) => {
-  const actual =
-    await importOriginal<typeof import("../../../../lib/api/domains/web")>();
-  return {
-    ...actual,
-    downloadWebFile: vi.fn().mockResolvedValue({
-      path: "/tmp/zero-video-test.mp4",
-      mimetype: "video/mp4",
-      size: 1024,
+    execFileSync: vi.fn((command: string, args: readonly string[]) => {
+      if (command === "curl") {
+        const i = args.indexOf("-o");
+        const outPath = i >= 0 ? args[i + 1] : undefined;
+        if (outPath) {
+          writeFileSync(outPath, Buffer.from("fake-video-bytes"));
+        }
+      } else if (command === "ffmpeg") {
+        const i = args.indexOf("-y");
+        const outPath = i > 0 ? args[i - 1] : undefined;
+        if (outPath) {
+          writeFileSync(outPath, Buffer.from("fake-audio-bytes"));
+        }
+      }
+      return Buffer.from("");
     }),
   };
 });
@@ -47,6 +44,14 @@ const mockStdoutWrite = vi
     return true;
   });
 
+function readStdout(): string {
+  return mockStdoutWrite.mock.calls
+    .map((c) => {
+      return c[0];
+    })
+    .join("");
+}
+
 describe("zero video transcribe command", () => {
   beforeEach(() => {
     vi.stubEnv("VM0_API_URL", "http://localhost:3000");
@@ -56,10 +61,11 @@ describe("zero video transcribe command", () => {
 
   afterEach(() => {
     vi.clearAllMocks();
+    vi.unstubAllEnvs();
   });
 
   describe("with timestamps (verbose mode)", () => {
-    it("should output structured Markdown with timestamp blocks", async () => {
+    it("outputs structured Markdown with timestamp blocks", async () => {
       server.use(
         http.post(STT_URL, () => {
           return HttpResponse.json({
@@ -77,11 +83,7 @@ describe("zero video transcribe command", () => {
         { from: "user" },
       );
 
-      const output = mockStdoutWrite.mock.calls
-        .map((c) => {
-          return c[0];
-        })
-        .join("");
+      const output = readStdout();
       expect(output).toContain("## Transcript");
       expect(output).toContain("[00:02-00:05] Hello world.");
       expect(output).toContain("[00:06-00:07] Second sentence.");
@@ -89,14 +91,11 @@ describe("zero video transcribe command", () => {
   });
 
   describe("without timestamps (--no-timestamps)", () => {
-    it("should output plain text transcript", async () => {
+    it("outputs plain text transcript", async () => {
       server.use(
         http.post(STT_URL, ({ request }) => {
-          const url = new URL(request.url);
-          expect(url.searchParams.get("verbose")).toBeNull();
-          return HttpResponse.json({
-            text: "Hello world. Second sentence.",
-          });
+          expect(new URL(request.url).searchParams.get("verbose")).toBeNull();
+          return HttpResponse.json({ text: "Hello world. Second sentence." });
         }),
       );
 
@@ -105,11 +104,7 @@ describe("zero video transcribe command", () => {
         { from: "user" },
       );
 
-      const output = mockStdoutWrite.mock.calls
-        .map((c) => {
-          return c[0];
-        })
-        .join("");
+      const output = readStdout();
       expect(output).toContain("## Transcript");
       expect(output).toContain("Hello world. Second sentence.");
       expect(output).not.toMatch(/\[\d{2}:\d{2}-\d{2}:\d{2}\]/);
@@ -117,11 +112,18 @@ describe("zero video transcribe command", () => {
   });
 
   describe("with --file-id", () => {
-    it("should use downloadWebFile instead of curl", async () => {
-      const { downloadWebFile } =
-        await import("../../../../lib/api/domains/web");
-
+    it("downloads via the web file API and transcribes", async () => {
+      let requestedFileId: string | null = null;
       server.use(
+        http.get(DOWNLOAD_URL, ({ request }) => {
+          requestedFileId = new URL(request.url).searchParams.get("file_id");
+          return new HttpResponse(new Uint8Array([1, 2, 3, 4]), {
+            headers: {
+              "content-type": "video/mp4",
+              "content-length": "4",
+            },
+          });
+        }),
         http.post(STT_URL, () => {
           return HttpResponse.json({ text: "File content." });
         }),
@@ -131,15 +133,13 @@ describe("zero video transcribe command", () => {
         from: "user",
       });
 
-      expect(downloadWebFile).toHaveBeenCalledWith(
-        "abc-123-def",
-        expect.stringContaining("zero-video-"),
-      );
+      expect(requestedFileId).toBe("abc-123-def");
+      expect(readStdout()).toContain("File content.");
     });
   });
 
   describe("missing arguments", () => {
-    it("should exit with error when neither --url nor --file-id provided", async () => {
+    it("exits with error when neither --url nor --file-id provided", async () => {
       const mockExit = vi.spyOn(process, "exit").mockImplementation((() => {
         throw new Error("process.exit called");
       }) as never);

--- a/turbo/apps/cli/src/commands/zero/video/__tests__/transcribe.test.ts
+++ b/turbo/apps/cli/src/commands/zero/video/__tests__/transcribe.test.ts
@@ -24,9 +24,9 @@ vi.mock("fs", async (importOriginal) => {
   };
 });
 
-vi.mock("../../../lib/api/domains/web", async (importOriginal) => {
+vi.mock("../../../../lib/api/domains/web", async (importOriginal) => {
   const actual =
-    await importOriginal<typeof import("../../../lib/api/domains/web")>();
+    await importOriginal<typeof import("../../../../lib/api/domains/web")>();
   return {
     ...actual,
     downloadWebFile: vi.fn().mockResolvedValue({
@@ -104,7 +104,8 @@ describe("zero video transcribe command", () => {
 
   describe("with --file-id", () => {
     it("should use downloadWebFile instead of curl", async () => {
-      const { downloadWebFile } = await import("../../../lib/api/domains/web");
+      const { downloadWebFile } =
+        await import("../../../../lib/api/domains/web");
 
       server.use(
         http.post(STT_URL, () => {
@@ -125,11 +126,9 @@ describe("zero video transcribe command", () => {
 
   describe("missing arguments", () => {
     it("should exit with error when neither --url nor --file-id provided", async () => {
-      const mockExit = vi
-        .spyOn(process, "exit")
-        .mockImplementation((() => {
-          throw new Error("process.exit called");
-        }) as never);
+      const mockExit = vi.spyOn(process, "exit").mockImplementation((() => {
+        throw new Error("process.exit called");
+      }) as never);
 
       await expect(
         transcribeCommand.parseAsync([], { from: "user" }),

--- a/turbo/apps/cli/src/commands/zero/video/__tests__/transcribe.test.ts
+++ b/turbo/apps/cli/src/commands/zero/video/__tests__/transcribe.test.ts
@@ -118,9 +118,8 @@ describe("zero video transcribe command", () => {
 
   describe("with --file-id", () => {
     it("should use downloadWebFile instead of curl", async () => {
-      const { downloadWebFile } = await import(
-        "../../../../lib/api/domains/web"
-      );
+      const { downloadWebFile } =
+        await import("../../../../lib/api/domains/web");
 
       server.use(
         http.post(STT_URL, () => {

--- a/turbo/apps/cli/src/commands/zero/video/__tests__/transcribe.test.ts
+++ b/turbo/apps/cli/src/commands/zero/video/__tests__/transcribe.test.ts
@@ -1,0 +1,141 @@
+/**
+ * Tests for zero video transcribe command.
+ *
+ * Uses MSW to mock the STT API endpoint and child_process.execFileSync
+ * to avoid requiring real ffmpeg/curl in CI.
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { http, HttpResponse } from "msw";
+import { server } from "../../../../mocks/server";
+import { transcribeCommand } from "../transcribe";
+
+const STT_URL = "http://localhost:3000/api/zero/voice-io/stt";
+
+vi.mock("child_process", () => ({
+  execFileSync: vi.fn(),
+}));
+
+vi.mock("fs", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("fs")>();
+  return {
+    ...actual,
+    unlinkSync: vi.fn(),
+  };
+});
+
+vi.mock("../../../lib/api/domains/web", async (importOriginal) => {
+  const actual =
+    await importOriginal<typeof import("../../../lib/api/domains/web")>();
+  return {
+    ...actual,
+    downloadWebFile: vi.fn().mockResolvedValue({
+      path: "/tmp/zero-video-test.mp4",
+      mimetype: "video/mp4",
+      size: 1024,
+    }),
+  };
+});
+
+const mockStdoutWrite = vi
+  .spyOn(process.stdout, "write")
+  .mockImplementation(() => true);
+
+describe("zero video transcribe command", () => {
+  beforeEach(() => {
+    vi.stubEnv("VM0_API_URL", "http://localhost:3000");
+    vi.stubEnv("VM0_TOKEN", "test-token");
+    mockStdoutWrite.mockClear();
+  });
+
+  afterEach(() => {
+    vi.clearAllMocks();
+  });
+
+  describe("with timestamps (verbose mode)", () => {
+    it("should output structured Markdown with timestamp blocks", async () => {
+      server.use(
+        http.post(STT_URL, () => {
+          return HttpResponse.json({
+            text: "Hello world. Second sentence.",
+            segments: [
+              { start: 2.52, end: 5.36, text: " Hello world." },
+              { start: 6.08, end: 7.4, text: " Second sentence." },
+            ],
+          });
+        }),
+      );
+
+      await transcribeCommand.parseAsync(
+        ["--url", "https://example.com/video.mp4"],
+        { from: "user" },
+      );
+
+      const output = mockStdoutWrite.mock.calls.map((c) => c[0]).join("");
+      expect(output).toContain("## Transcript");
+      expect(output).toContain("[00:02-00:05] Hello world.");
+      expect(output).toContain("[00:06-00:07] Second sentence.");
+    });
+  });
+
+  describe("without timestamps (--no-timestamps)", () => {
+    it("should output plain text transcript", async () => {
+      server.use(
+        http.post(STT_URL, ({ request }) => {
+          const url = new URL(request.url);
+          expect(url.searchParams.get("verbose")).toBeNull();
+          return HttpResponse.json({
+            text: "Hello world. Second sentence.",
+          });
+        }),
+      );
+
+      await transcribeCommand.parseAsync(
+        ["--url", "https://example.com/video.mp4", "--no-timestamps"],
+        { from: "user" },
+      );
+
+      const output = mockStdoutWrite.mock.calls.map((c) => c[0]).join("");
+      expect(output).toContain("## Transcript");
+      expect(output).toContain("Hello world. Second sentence.");
+      expect(output).not.toMatch(/\[\d{2}:\d{2}-\d{2}:\d{2}\]/);
+    });
+  });
+
+  describe("with --file-id", () => {
+    it("should use downloadWebFile instead of curl", async () => {
+      const { downloadWebFile } = await import("../../../lib/api/domains/web");
+
+      server.use(
+        http.post(STT_URL, () => {
+          return HttpResponse.json({ text: "File content." });
+        }),
+      );
+
+      await transcribeCommand.parseAsync(["--file-id", "abc-123-def"], {
+        from: "user",
+      });
+
+      expect(downloadWebFile).toHaveBeenCalledWith(
+        "abc-123-def",
+        expect.stringContaining("zero-video-"),
+      );
+    });
+  });
+
+  describe("missing arguments", () => {
+    it("should exit with error when neither --url nor --file-id provided", async () => {
+      const mockExit = vi
+        .spyOn(process, "exit")
+        .mockImplementation((() => {
+          throw new Error("process.exit called");
+        }) as never);
+
+      await expect(
+        transcribeCommand.parseAsync([], { from: "user" }),
+      ).rejects.toThrow("process.exit called");
+
+      mockExit.mockRestore();
+    });
+  });
+});

--- a/turbo/apps/cli/src/commands/zero/video/frames.ts
+++ b/turbo/apps/cli/src/commands/zero/video/frames.ts
@@ -20,17 +20,12 @@ export const framesCommand = new Command()
     "--at <timestamps>",
     "Comma-separated timestamps to capture (e.g. 00:21,01:40 or 12,95.5)",
   )
-  .option(
-    "--out-dir <dir>",
-    "Directory to write extracted frames (default: a temp dir)",
-  )
   .addHelpText(
     "after",
     `
 Examples:
   Frames at two moments:  zero video frames --url "https://..." --at 00:21,01:40
   From a web file:        zero video frames --file-id abc-123 --at 12,95.5
-  Custom output dir:      zero video frames --url "https://..." --at 00:05 --out-dir /tmp/shots
 
 Output:
   Prints a JSON object to stdout, one entry per timestamp:
@@ -47,12 +42,7 @@ Notes:
   )
   .action(
     withErrorHandler(
-      async (options: {
-        url?: string;
-        fileId?: string;
-        at: string;
-        outDir?: string;
-      }) => {
+      async (options: { url?: string; fileId?: string; at: string }) => {
         if (!options.url && !options.fileId) {
           process.stderr.write(
             "Error: provide --url <presigned-url> or --file-id <id>\n",
@@ -73,8 +63,7 @@ Notes:
           process.exit(1);
         }
 
-        const outDir =
-          options.outDir ?? join(tmpdir(), `zero-frames-${Date.now()}`);
+        const outDir = join(tmpdir(), `zero-frames-${Date.now()}`);
         mkdirSync(outDir, { recursive: true });
 
         const tmpVideo = join(tmpdir(), `zero-video-${Date.now()}.mp4`);

--- a/turbo/apps/cli/src/commands/zero/video/frames.ts
+++ b/turbo/apps/cli/src/commands/zero/video/frames.ts
@@ -1,0 +1,127 @@
+import { execFileSync } from "child_process";
+import { mkdirSync, unlinkSync } from "fs";
+import { tmpdir } from "os";
+import { join } from "path";
+import { Command } from "commander";
+import { withErrorHandler } from "../../../lib/command";
+import { downloadWebFile } from "../../../lib/api/domains/web";
+
+interface ExtractedFrame {
+  readonly at: string;
+  readonly path: string;
+}
+
+export const framesCommand = new Command()
+  .name("frames")
+  .description("Extract still frames from a video at the given timestamps")
+  .option("--url <presigned-url>", "Pre-signed or public URL of the video file")
+  .option("--file-id <id>", "Web file ID (alternative to --url)")
+  .requiredOption(
+    "--at <timestamps>",
+    "Comma-separated timestamps to capture (e.g. 00:21,01:40 or 12,95.5)",
+  )
+  .option(
+    "--out-dir <dir>",
+    "Directory to write extracted frames (default: a temp dir)",
+  )
+  .addHelpText(
+    "after",
+    `
+Examples:
+  Frames at two moments:  zero video frames --url "https://..." --at 00:21,01:40
+  From a web file:        zero video frames --file-id abc-123 --at 12,95.5
+  Custom output dir:      zero video frames --url "https://..." --at 00:05 --out-dir /tmp/shots
+
+Output:
+  Prints a JSON object to stdout, one entry per timestamp:
+    {"frames":[{"at":"00:21","path":"/tmp/zero-frames-.../frame-001.jpg"}]}
+
+Tip:
+  Pair with "zero video transcribe": read the timestamped transcript to find the
+  moments that matter, then extract just those frames here for a closer look.
+
+Notes:
+  - Requires ffmpeg on PATH for frame extraction
+  - Timestamps accept SS, MM:SS, or HH:MM:SS (fractions allowed, e.g. 95.5)
+  - Extracted frames are kept on disk; only the downloaded video is cleaned up`,
+  )
+  .action(
+    withErrorHandler(
+      async (options: {
+        url?: string;
+        fileId?: string;
+        at: string;
+        outDir?: string;
+      }) => {
+        if (!options.url && !options.fileId) {
+          process.stderr.write(
+            "Error: provide --url <presigned-url> or --file-id <id>\n",
+          );
+          process.exit(1);
+        }
+
+        const timestamps = options.at
+          .split(",")
+          .map((s) => {
+            return s.trim();
+          })
+          .filter((s) => {
+            return s.length > 0;
+          });
+        if (timestamps.length === 0) {
+          process.stderr.write("Error: --at requires at least one timestamp\n");
+          process.exit(1);
+        }
+
+        const outDir =
+          options.outDir ?? join(tmpdir(), `zero-frames-${Date.now()}`);
+        mkdirSync(outDir, { recursive: true });
+
+        const tmpVideo = join(tmpdir(), `zero-video-${Date.now()}.mp4`);
+
+        try {
+          if (options.url) {
+            execFileSync("curl", ["-sS", "-L", "-o", tmpVideo, options.url], {
+              stdio: ["ignore", "ignore", "pipe"],
+            });
+          } else {
+            await downloadWebFile(options.fileId as string, tmpVideo);
+          }
+
+          const frames: ExtractedFrame[] = timestamps.map((at, index) => {
+            const outPath = join(
+              outDir,
+              `frame-${String(index + 1).padStart(3, "0")}.jpg`,
+            );
+            execFileSync(
+              "ffmpeg",
+              [
+                "-ss",
+                at,
+                "-i",
+                tmpVideo,
+                "-frames:v",
+                "1",
+                "-q:v",
+                "2",
+                outPath,
+                "-y",
+                "-loglevel",
+                "error",
+              ],
+              { stdio: ["ignore", "ignore", "pipe"] },
+            );
+            return { at, path: outPath };
+          });
+
+          process.stdout.write(JSON.stringify({ frames }) + "\n");
+        } finally {
+          try {
+            unlinkSync(tmpVideo);
+          } catch {
+            // best-effort cleanup
+          }
+        }
+      },
+    ),
+  );

--- a/turbo/apps/cli/src/commands/zero/video/index.ts
+++ b/turbo/apps/cli/src/commands/zero/video/index.ts
@@ -1,0 +1,14 @@
+import { Command } from "commander";
+import { transcribeCommand } from "./transcribe";
+
+export const zeroVideoCommand = new Command()
+  .name("video")
+  .description("Video processing utilities")
+  .addCommand(transcribeCommand)
+  .addHelpText(
+    "after",
+    `
+Examples:
+  Transcribe a video:  zero video transcribe --url "https://..."
+  Web file:            zero video transcribe --file-id abc-123`,
+  );

--- a/turbo/apps/cli/src/commands/zero/video/index.ts
+++ b/turbo/apps/cli/src/commands/zero/video/index.ts
@@ -1,14 +1,21 @@
 import { Command } from "commander";
 import { transcribeCommand } from "./transcribe";
+import { framesCommand } from "./frames";
 
 export const zeroVideoCommand = new Command()
   .name("video")
   .description("Video processing utilities")
   .addCommand(transcribeCommand)
+  .addCommand(framesCommand)
   .addHelpText(
     "after",
     `
 Examples:
   Transcribe a video:  zero video transcribe --url "https://..."
-  Web file:            zero video transcribe --file-id abc-123`,
+  Web file:            zero video transcribe --file-id abc-123
+  Extract frames:      zero video frames --url "https://..." --at 00:21,01:40
+
+Tip (video understanding):
+  Transcribe first to get a timestamped index, then extract only the
+  frames worth seeing instead of watching the whole video.`,
   );

--- a/turbo/apps/cli/src/commands/zero/video/transcribe.ts
+++ b/turbo/apps/cli/src/commands/zero/video/transcribe.ts
@@ -1,0 +1,121 @@
+import { execFileSync } from "child_process";
+import { unlinkSync } from "fs";
+import { tmpdir } from "os";
+import { join } from "path";
+import { Command } from "commander";
+import { withErrorHandler } from "../../../lib/command";
+import { transcribeAudio } from "../../../lib/api/domains/web";
+import type { TranscribeAudioSegment } from "../../../lib/api/domains/web";
+import { downloadWebFile } from "../../../lib/api/domains/web";
+
+function formatTime(seconds: number): string {
+  const m = Math.floor(seconds / 60)
+    .toString()
+    .padStart(2, "0");
+  const s = Math.floor(seconds % 60)
+    .toString()
+    .padStart(2, "0");
+  return `${m}:${s}`;
+}
+
+function formatTranscript(
+  text: string,
+  segments: readonly TranscribeAudioSegment[] | undefined,
+): string {
+  if (!segments || segments.length === 0) {
+    return `## Transcript\n${text}`;
+  }
+  const lines = segments.map((s) => {
+    const start = formatTime(s.start);
+    const end = formatTime(s.end);
+    return `[${start}-${end}] ${s.text.trim()}`;
+  });
+  return `## Transcript\n${lines.join("\n")}`;
+}
+
+export const transcribeCommand = new Command()
+  .name("transcribe")
+  .description("Transcribe audio from a video file and output structured Markdown")
+  .option("--url <presigned-url>", "Pre-signed or public URL of the video file")
+  .option("--file-id <id>", "Web file ID (alternative to --url)")
+  .option("--no-timestamps", "Output plain text only, without per-segment timestamps")
+  .addHelpText(
+    "after",
+    `
+Examples:
+  Transcribe from URL:      zero video transcribe --url "https://..."
+  Transcribe a web file:    zero video transcribe --file-id abc-123-def
+  Plain text only:          zero video transcribe --url "https://..." --no-timestamps
+
+Output:
+  Structured Markdown printed to stdout:
+    ## Transcript
+    [00:02-00:05] First sentence here.
+    [00:06-00:07] Second sentence here.
+
+Notes:
+  - Requires ffmpeg on PATH for audio extraction
+  - Authenticates via ZERO_TOKEN
+  - Audio is extracted before upload to stay within the 25 MB size limit
+  - Uses the /api/zero/voice-io/stt endpoint (quota applies)`,
+  )
+  .action(
+    withErrorHandler(
+      async (options: {
+        url?: string;
+        fileId?: string;
+        timestamps: boolean;
+      }) => {
+        if (!options.url && !options.fileId) {
+          process.stderr.write(
+            "Error: provide --url <presigned-url> or --file-id <id>\n",
+          );
+          process.exit(1);
+        }
+
+        const tmpVideo = join(tmpdir(), `zero-video-${Date.now()}.mp4`);
+        const tmpAudio = join(tmpdir(), `zero-audio-${Date.now()}.mp3`);
+
+        try {
+          if (options.url) {
+            execFileSync("curl", ["-sS", "-L", "-o", tmpVideo, options.url], {
+              stdio: ["ignore", "ignore", "pipe"],
+            });
+          } else {
+            await downloadWebFile(options.fileId as string, tmpVideo);
+          }
+
+          execFileSync(
+            "ffmpeg",
+            [
+              "-i", tmpVideo,
+              "-vn",
+              "-ar", "16000",
+              "-ac", "1",
+              "-b:a", "64k",
+              tmpAudio,
+              "-y",
+              "-loglevel", "error",
+            ],
+            { stdio: ["ignore", "ignore", "pipe"] },
+          );
+
+          const result = await transcribeAudio(tmpAudio, {
+            verbose: options.timestamps !== false,
+          });
+
+          process.stdout.write(
+            formatTranscript(result.text, result.segments) + "\n",
+          );
+        } finally {
+          for (const path of [tmpVideo, tmpAudio]) {
+            try {
+              unlinkSync(path);
+            } catch {
+              // best-effort cleanup
+            }
+          }
+        }
+      },
+    ),
+  );

--- a/turbo/apps/cli/src/commands/zero/video/transcribe.ts
+++ b/turbo/apps/cli/src/commands/zero/video/transcribe.ts
@@ -4,9 +4,11 @@ import { tmpdir } from "os";
 import { join } from "path";
 import { Command } from "commander";
 import { withErrorHandler } from "../../../lib/command";
-import { transcribeAudio } from "../../../lib/api/domains/web";
-import type { TranscribeAudioSegment } from "../../../lib/api/domains/web";
-import { downloadWebFile } from "../../../lib/api/domains/web";
+import {
+  downloadWebFile,
+  transcribeAudio,
+  type TranscribeAudioSegment,
+} from "../../../lib/api/domains/web";
 
 function formatTime(seconds: number): string {
   const m = Math.floor(seconds / 60)
@@ -35,10 +37,15 @@ function formatTranscript(
 
 export const transcribeCommand = new Command()
   .name("transcribe")
-  .description("Transcribe audio from a video file and output structured Markdown")
+  .description(
+    "Transcribe audio from a video file and output structured Markdown",
+  )
   .option("--url <presigned-url>", "Pre-signed or public URL of the video file")
   .option("--file-id <id>", "Web file ID (alternative to --url)")
-  .option("--no-timestamps", "Output plain text only, without per-segment timestamps")
+  .option(
+    "--no-timestamps",
+    "Output plain text only, without per-segment timestamps",
+  )
   .addHelpText(
     "after",
     `
@@ -88,14 +95,19 @@ Notes:
           execFileSync(
             "ffmpeg",
             [
-              "-i", tmpVideo,
+              "-i",
+              tmpVideo,
               "-vn",
-              "-ar", "16000",
-              "-ac", "1",
-              "-b:a", "64k",
+              "-ar",
+              "16000",
+              "-ac",
+              "1",
+              "-b:a",
+              "64k",
               tmpAudio,
               "-y",
-              "-loglevel", "error",
+              "-loglevel",
+              "error",
             ],
             { stdio: ["ignore", "ignore", "pipe"] },
           );

--- a/turbo/apps/cli/src/commands/zero/web/download-file.ts
+++ b/turbo/apps/cli/src/commands/zero/web/download-file.ts
@@ -36,9 +36,10 @@ Output:
 
 How to read the downloaded file:
   - Images (png/jpg/gif/webp/svg): open the file path with your image viewing tool
-  - Videos (mp4/mov/webm): extract frames first with
+  - Videos (mp4/mov/webm): transcribe audio first with
+      zero video transcribe --url <download-url>
+    or extract frames with
       ffmpeg -i <path> -vf "fps=1" -q:v 2 /tmp/<file-id>_frame_%03d.jpg
-    then view the extracted frames
   - PDF/text/csv/json/markdown: read the file directly
 
 Notes:

--- a/turbo/apps/cli/src/lib/api/domains/web.ts
+++ b/turbo/apps/cli/src/lib/api/domains/web.ts
@@ -962,7 +962,7 @@ export interface TranscribeAudioSegment {
   readonly text: string;
 }
 
-export interface TranscribeAudioResult {
+interface TranscribeAudioResult {
   readonly text: string;
   readonly segments?: readonly TranscribeAudioSegment[];
 }
@@ -1003,11 +1003,7 @@ export async function transcribeAudio(
   const mimeType = mimeMap[ext] ?? "audio/mpeg";
 
   const formData = new FormData();
-  formData.append(
-    "file",
-    new Blob([audioData], { type: mimeType }),
-    filename,
-  );
+  formData.append("file", new Blob([audioData], { type: mimeType }), filename);
 
   const response = await fetch(url, {
     method: "POST",

--- a/turbo/apps/cli/src/lib/api/domains/web.ts
+++ b/turbo/apps/cli/src/lib/api/domains/web.ts
@@ -955,3 +955,73 @@ export async function generateWebVideo(
     fallback: "Failed to generate video",
   });
 }
+
+export interface TranscribeAudioSegment {
+  readonly start: number;
+  readonly end: number;
+  readonly text: string;
+}
+
+export interface TranscribeAudioResult {
+  readonly text: string;
+  readonly segments?: readonly TranscribeAudioSegment[];
+}
+
+export async function transcribeAudio(
+  audioPath: string,
+  options: { readonly verbose?: boolean } = {},
+): Promise<TranscribeAudioResult> {
+  const baseUrl = await getBaseUrl();
+  const token = await getActiveToken();
+  if (!token) {
+    throw new ApiRequestError("Not authenticated", "UNAUTHORIZED", 401);
+  }
+
+  const headers: Record<string, string> = {
+    Authorization: `Bearer ${token}`,
+  };
+  const bypassSecret = process.env.VERCEL_AUTOMATION_BYPASS_SECRET;
+  if (bypassSecret) {
+    headers["x-vercel-protection-bypass"] = bypassSecret;
+  }
+
+  const url = new URL("/api/zero/voice-io/stt", baseUrl);
+  if (options.verbose) {
+    url.searchParams.set("verbose", "true");
+  }
+
+  const audioData = readFileSync(audioPath);
+  const filename = basename(audioPath);
+  const ext = extname(filename).toLowerCase();
+  const mimeMap: Record<string, string> = {
+    ".mp3": "audio/mpeg",
+    ".mp4": "audio/mp4",
+    ".m4a": "audio/m4a",
+    ".wav": "audio/wav",
+    ".webm": "audio/webm",
+  };
+  const mimeType = mimeMap[ext] ?? "audio/mpeg";
+
+  const formData = new FormData();
+  formData.append(
+    "file",
+    new Blob([audioData], { type: mimeType }),
+    filename,
+  );
+
+  const response = await fetch(url, {
+    method: "POST",
+    headers,
+    body: formData,
+  });
+
+  if (!response.ok) {
+    const { message, code } = await parseErrorBody(
+      response,
+      "Transcription failed",
+    );
+    throw new ApiRequestError(message, code, response.status);
+  }
+
+  return (await response.json()) as TranscribeAudioResult;
+}

--- a/turbo/apps/cli/src/zero.ts
+++ b/turbo/apps/cli/src/zero.ts
@@ -30,6 +30,7 @@ import { zeroMapsCommand } from "./commands/zero/maps";
 import { zeroBankingCommand } from "./commands/zero/banking";
 import { zeroModelCommand } from "./commands/zero/model";
 import { zeroModelProviderCommand } from "./commands/zero/model-provider";
+import { zeroVideoCommand } from "./commands/zero/video";
 import {
   decodeZeroTokenPayload,
   type ZeroTokenPayload,
@@ -66,6 +67,7 @@ const COMMAND_CAPABILITY_MAP: Record<
   "computer-use": "computer-use:write",
   generate: null,
   web: null,
+  video: null,
   host: "host:write",
   maps: "maps:read",
   banking: "banking:read",
@@ -96,6 +98,7 @@ const DEFAULT_COMMANDS: Command[] = [
   zeroComputerUseCommand,
   generateCommand,
   zeroWebCommand,
+  zeroVideoCommand,
   zeroHostCommand,
   zeroMapsCommand,
   zeroBankingCommand,

--- a/turbo/packages/api-contracts/src/contracts/zero-voice-io-stt.ts
+++ b/turbo/packages/api-contracts/src/contracts/zero-voice-io-stt.ts
@@ -4,8 +4,15 @@ import { apiErrorSchema } from "./errors";
 
 const c = initContract();
 
+export const zeroVoiceIoSttSegmentSchema = z.object({
+  start: z.number(),
+  end: z.number(),
+  text: z.string(),
+});
+
 export const zeroVoiceIoSttResponseSchema = z.object({
   text: z.string(),
+  segments: z.array(zeroVoiceIoSttSegmentSchema).optional(),
 });
 
 export const zeroVoiceIoSttQuotaErrorSchema = apiErrorSchema.extend({
@@ -17,6 +24,7 @@ export const zeroVoiceIoSttQuotaErrorSchema = apiErrorSchema.extend({
     .optional(),
 });
 
+export type ZeroVoiceIoSttSegment = z.infer<typeof zeroVoiceIoSttSegmentSchema>;
 export type ZeroVoiceIoSttResponse = z.infer<
   typeof zeroVoiceIoSttResponseSchema
 >;
@@ -28,6 +36,9 @@ export const zeroVoiceIoSttContract = c.router({
     headers: authHeadersSchema,
     contentType: "multipart/form-data",
     body: c.type<FormData>(),
+    query: z.object({
+      verbose: z.coerce.boolean().optional().default(false),
+    }),
     responses: {
       200: zeroVoiceIoSttResponseSchema,
       400: apiErrorSchema,


### PR DESCRIPTION
## Summary

- **Phase 1**: Extend `/api/zero/voice-io/stt` with `?verbose=true` query param — switches OpenAI to `verbose_json` mode and returns `segments: [{start, end, text}]` alongside the full transcript text
- **Phase 2**: New `zero video transcribe` CLI command — downloads video, extracts audio via ffmpeg, calls the STT API, and prints structured Markdown with `[MM:SS-MM:SS]` timestamp blocks to stdout
- **Phase 3**: Update `download-file` help text across all channels (slack, web, telegram, github, phone) to suggest `zero video transcribe` as the primary video analysis path
- **Phase 4**: Unit tests for the transcribe command covering timestamped output, plain text mode, `--file-id` input, and missing-argument handling
- **Phase 5**: New `zero video frames` CLI command — extracts still frames at given timestamps (`--at 00:21,01:40`, accepts `SS`/`MM:SS`/`HH:MM:SS`) via ffmpeg, writes JPEGs and prints their paths as JSON. Pure local extraction (no STT call). Pairs with `transcribe`: read the timestamped transcript to locate the moments that matter, then pull only those frames. Includes integration tests (`--url`, `--file-id`, missing-arg).
- **Refactor**: Extract the verbose STT model (`whisper-1`) into a named `VOICE_IO_STT_VERBOSE_MODEL` constant instead of a hardcoded literal, next to `VOICE_IO_STT_MODEL`.

## Motivation

This completes a "video-use" loop for Zero: instead of dumping every frame into a multimodal model (slow and expensive), the agent gets a cheap, navigable **text index** of the video and zooms in only where it matters.

- `transcribe` turns the speech track into timestamped text — the index.
- The agent reads that text and decides which moments are worth seeing.
- `frames` extracts just those timestamps as images for a closer look.

Text to decide, a few frames to confirm — rather than watching the whole video. The two commands are deliberately decoupled (frames takes raw timestamps), but the timestamped transcript is what makes selective frame extraction possible.

## Test plan

- [ ] `zero video transcribe --url <mp4-url>` outputs timestamped Markdown
- [ ] `zero video transcribe --file-id <id>` works via web file download
- [ ] `zero video transcribe --no-timestamps` outputs plain text
- [ ] `zero video frames --url <mp4-url> --at 00:05,00:30` writes frames and prints JSON paths
- [ ] `zero video frames --file-id <id> --at 12` works via web file download
- [ ] `POST /api/zero/voice-io/stt?verbose=true` returns `segments` array
- [ ] `POST /api/zero/voice-io/stt` (no param) still returns `{ text }` only — no regression
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)
