### PR TITLE
fix: refresh org cache after onboarding rename

### DIFF
--- a/turbo/apps/api/src/signals/routes/__tests__/zero-onboarding-setup.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/zero-onboarding-setup.test.ts
@@ -11,6 +11,7 @@ import { and, eq } from "drizzle-orm";
 import { agentComposes } from "@vm0/db/schema/agent-compose";
 import { creditExpiresRecord } from "@vm0/db/schema/credit-expires-record";
 import { modelProviders } from "@vm0/db/schema/model-provider";
+import { orgCache } from "@vm0/db/schema/org-cache";
 import { orgMembersCache } from "@vm0/db/schema/org-members-cache";
 import { orgMembersMetadata } from "@vm0/db/schema/org-members-metadata";
 import { orgMetadata } from "@vm0/db/schema/org-metadata";
@@ -92,6 +93,8 @@ const deleteOnboardingSetupFixture$ = command(
     signal: AbortSignal,
   ): Promise<void> => {
     const db = set(writeDb$);
+    await db.delete(orgCache).where(eq(orgCache.orgId, fixture.orgId));
+    signal.throwIfAborted();
     await db
       .delete(userConnectors)
       .where(eq(userConnectors.orgId, fixture.orgId));
@@ -159,6 +162,28 @@ async function readOrgMetadata(orgId: string) {
     })
     .from(orgMetadata)
     .where(eq(orgMetadata.orgId, orgId));
+  return row;
+}
+
+async function seedOrgCache(orgId: string): Promise<void> {
+  const db = store.set(writeDb$);
+  await db.insert(orgCache).values({
+    orgId,
+    slug: "stale-workspace",
+    name: "Stale Workspace",
+  });
+}
+
+async function readOrgCache(orgId: string) {
+  const db = store.set(writeDb$);
+  const [row] = await db
+    .select({
+      slug: orgCache.slug,
+      name: orgCache.name,
+    })
+    .from(orgCache)
+    .where(eq(orgCache.orgId, orgId))
+    .limit(1);
   return row;
 }
 
@@ -524,9 +549,10 @@ describe("POST /api/zero/onboarding/setup", () => {
     });
   });
 
-  it("updates Clerk org name and slug for valid Latin workspace names", async () => {
+  it("updates Clerk org name and slug and refreshes org identity cache", async () => {
     const fixture = await track(createFixture());
     mockAdminSession(fixture);
+    await seedOrgCache(fixture.orgId);
 
     const response = await accept(
       apiClient().setup({
@@ -546,6 +572,7 @@ describe("POST /api/zero/onboarding/setup", () => {
       name: "My Workspace",
       slug: "my-workspace",
     });
+    await expect(readOrgCache(fixture.orgId)).resolves.toBeUndefined();
   });
 
   it("updates Clerk org name only for non-Latin workspace names", async () => {

--- a/turbo/apps/api/src/signals/services/onboarding.service.ts
+++ b/turbo/apps/api/src/signals/services/onboarding.service.ts
@@ -185,8 +185,18 @@ async function updateOrgNameAndSlugAndRefreshCache(
   orgId: string,
   workspaceName: string,
 ): Promise<void> {
-  await updateOrgNameAndSlug(client, orgId, workspaceName);
-  await db.delete(orgCache).where(eq(orgCache.orgId, orgId));
+  await tapError(
+    (async () => {
+      await updateOrgNameAndSlug(client, orgId, workspaceName);
+      await db.delete(orgCache).where(eq(orgCache.orgId, orgId));
+    })(),
+    (error) => {
+      L.warn("Failed to update org name/slug (non-blocking)", {
+        orgId,
+        error,
+      });
+    },
+  );
 }
 
 async function existingDefaultAgentId(
@@ -610,19 +620,11 @@ export const setupOnboarding$ = command(
 
     if (args.workspaceName?.trim()) {
       const client = get(clerk$);
-      await tapError(
-        updateOrgNameAndSlugAndRefreshCache(
-          client,
-          writeDb,
-          args.orgId,
-          args.workspaceName,
-        ),
-        (error) => {
-          L.warn("Failed to update org name/slug (non-blocking)", {
-            orgId: args.orgId,
-            error,
-          });
-        },
+      await updateOrgNameAndSlugAndRefreshCache(
+        client,
+        writeDb,
+        args.orgId,
+        args.workspaceName,
       );
       signal.throwIfAborted();
     }

--- a/turbo/apps/api/src/signals/services/onboarding.service.ts
+++ b/turbo/apps/api/src/signals/services/onboarding.service.ts
@@ -4,6 +4,7 @@ import type { OnboardingStatusResponse } from "@vm0/api-contracts/contracts/onbo
 import type { ConnectorType } from "@vm0/connectors/connectors";
 import { SEED_INSTRUCTIONS } from "@vm0/core/zero-seed-instructions";
 import { agentComposes } from "@vm0/db/schema/agent-compose";
+import { orgCache } from "@vm0/db/schema/org-cache";
 import { orgMembersCache } from "@vm0/db/schema/org-members-cache";
 import { orgMembersMetadata } from "@vm0/db/schema/org-members-metadata";
 import { orgMetadata } from "@vm0/db/schema/org-metadata";
@@ -176,6 +177,16 @@ async function updateOrgNameAndSlug(
   }
 
   await client.organizations.updateOrganization(orgId, { name });
+}
+
+async function updateOrgNameAndSlugAndRefreshCache(
+  client: ReturnType<typeof clerk$.read>,
+  db: Db,
+  orgId: string,
+  workspaceName: string,
+): Promise<void> {
+  await updateOrgNameAndSlug(client, orgId, workspaceName);
+  await db.delete(orgCache).where(eq(orgCache.orgId, orgId));
 }
 
 async function existingDefaultAgentId(
@@ -600,7 +611,12 @@ export const setupOnboarding$ = command(
     if (args.workspaceName?.trim()) {
       const client = get(clerk$);
       await tapError(
-        updateOrgNameAndSlug(client, args.orgId, args.workspaceName),
+        updateOrgNameAndSlugAndRefreshCache(
+          client,
+          writeDb,
+          args.orgId,
+          args.workspaceName,
+        ),
         (error) => {
           L.warn("Failed to update org name/slug (non-blocking)", {
             orgId: args.orgId,

--- a/turbo/apps/platform/src/views/zero-page/__tests__/zero-onboarding.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/zero-onboarding.test.tsx
@@ -153,6 +153,10 @@ describe("zero onboarding - organization switcher", () => {
     await waitFor(() => {
       expect(screen.getByText("Current Org")).toBeInTheDocument();
     });
+    expect(screen.getByTestId("onboarding-org-switcher-slot")).toHaveClass(
+      "top-6",
+      "left-4",
+    );
 
     click(screen.getByText("Current Org"));
 

--- a/turbo/apps/platform/src/views/zero-page/zero-onboarding.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-onboarding.tsx
@@ -1123,9 +1123,16 @@ function OnboardingIllustrationPanel() {
         )}
       </div>
 
-      {/* Org switcher + account dropdown — bottom-left of left panel */}
-      <div className="absolute bottom-6 left-4 z-20 flex w-[240px] flex-col gap-2">
+      {/* Org switcher — top-left of left panel */}
+      <div
+        data-testid="onboarding-org-switcher-slot"
+        className="absolute left-4 top-6 z-20 w-[240px]"
+      >
         <OnboardingOrgSwitcher />
+      </div>
+
+      {/* Account dropdown — bottom-left of left panel */}
+      <div className="absolute bottom-6 left-4 z-20 w-[240px]">
         <OnboardingAccountDropdown />
       </div>
     </div>


### PR DESCRIPTION
## Summary
- invalidate `org_cache` after onboarding updates the Clerk org name/slug
- keep the onboarding org switcher in the top-left and the account menu in the bottom-left
- add regression coverage for stale org cache during onboarding setup

## Tests
- `pnpm -F api exec vitest run src/signals/routes/__tests__/zero-onboarding-setup.test.ts`
- `pnpm -F @vm0/app exec vitest run src/views/zero-page/__tests__/zero-onboarding.test.tsx`
- `pnpm -F api exec eslint src/signals/services/onboarding.service.ts src/signals/routes/__tests__/zero-onboarding-setup.test.ts --max-warnings 0`
- `pnpm -F @vm0/app exec eslint src/views/zero-page/zero-onboarding.tsx src/views/zero-page/__tests__/zero-onboarding.test.tsx --max-warnings 0`
- `git diff --check`

## Notes
- Full `pnpm check-types` is currently failing locally on broad, unrelated latest-main `@vm0/app` ts-rest contract typing errors such as `body` being inferred as `never`, missing required args, and implicit anys outside this change set.
