### PR TITLE
fix(host-worker): add CORS headers to hosted site responses

### DIFF
--- a/turbo/apps/host-worker/src/index.ts
+++ b/turbo/apps/host-worker/src/index.ts
@@ -142,10 +142,22 @@ function cacheControl(file: ManifestFile): string {
 }
 
 async function serveHostedSite(request: Request, env: Env): Promise<Response> {
+  if (request.method === "OPTIONS") {
+    return new Response(null, {
+      status: 204,
+      headers: {
+        "Access-Control-Allow-Origin": "*",
+        "Access-Control-Allow-Methods": "GET, HEAD, OPTIONS",
+        "Access-Control-Allow-Headers": "*",
+        "Access-Control-Max-Age": "86400",
+      },
+    });
+  }
+
   if (request.method !== "GET" && request.method !== "HEAD") {
     return new Response("Method not allowed", {
       status: 405,
-      headers: { Allow: "GET, HEAD" },
+      headers: { Allow: "GET, HEAD, OPTIONS" },
     });
   }
 
@@ -199,6 +211,7 @@ async function serveHostedSite(request: Request, env: Env): Promise<Response> {
   headers.set("Cache-Control", cacheControl(file));
   headers.set("ETag", object.httpEtag);
   headers.set("X-Content-Type-Options", "nosniff");
+  headers.set("Access-Control-Allow-Origin", "*");
 
   return new Response(request.method === "HEAD" ? null : object.body, {
     status: 200,


### PR DESCRIPTION
## Summary

- `*.sites.vm0.io` hosted sites were missing `Access-Control-Allow-Origin` headers, causing browsers to block cross-origin `fetch()` calls with `ERR_FAILED 200 (OK)`
- This broke vm0's own `app.vm0.ai` from downloading or previewing hosted artifacts (the `[zero-attachment-url] downloadUrl: fetch failed` warning)
- Added `Access-Control-Allow-Origin: *` to all successful responses and a proper OPTIONS preflight handler

## Changes

**`turbo/apps/host-worker/src/index.ts`**
- Add `Access-Control-Allow-Origin: *` to the 200 response headers
- Add OPTIONS preflight handler returning 204 with full CORS headers (`Allow-Methods`, `Allow-Headers`, `Max-Age`)
- Update 405 `Allow` header to include `OPTIONS`

## Test plan

- [ ] `curl -I https://<slug>.sites.vm0.io/` includes `Access-Control-Allow-Origin: *`
- [ ] `curl -X OPTIONS https://<slug>.sites.vm0.io/` returns 204 with CORS headers
- [ ] `fetch()` from `app.vm0.ai` to a hosted site no longer throws `ERR_FAILED`
- [ ] Existing GET/HEAD file serving still works correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)