### PR TITLE
fix: clarify runner job timeout logs

### DIFF
--- a/crates/runner/src/axiom_layer.rs
+++ b/crates/runner/src/axiom_layer.rs
@@ -290,6 +290,13 @@ fn serialize_event(event: &Event<'_>) -> Value {
         fn record_u64(&mut self, f: &Field, v: u64) {
             self.0.insert(f.name().into(), v.into());
         }
+        fn record_u128(&mut self, f: &Field, v: u128) {
+            if let Ok(v) = u64::try_from(v) {
+                self.0.insert(f.name().into(), v.into());
+            } else {
+                self.0.insert(f.name().into(), Value::String(v.to_string()));
+            }
+        }
         fn record_f64(&mut self, f: &Field, v: f64) {
             self.0.insert(f.name().into(), v.into());
         }

--- a/crates/runner/src/cmd/start/job_spawn.rs
+++ b/crates/runner/src/cmd/start/job_spawn.rs
@@ -892,6 +892,44 @@ mod tests {
     }
 
     #[test]
+    fn generic_zero_exit_code_normalizes_to_generic_failure() {
+        let failure = executor::ExecutionFailure::new(0, "", None);
+
+        assert_eq!(failure.exit_code, 1);
+        assert_eq!(failure.error, "Agent exited with code 1");
+        assert_eq!(failure.kind, executor::ExecutionFailureKind::Generic);
+    }
+
+    #[test]
+    fn runner_job_timeout_zero_exit_code_normalizes_to_timeout_failure() {
+        let failure = executor::ExecutionFailure::runner_job_timeout(
+            0,
+            "",
+            None,
+            Duration::from_secs(7200),
+            Duration::from_secs(7201),
+            None,
+        );
+
+        assert_eq!(failure.exit_code, 124);
+        assert_eq!(failure.error, "Agent exited with code 124");
+        match failure.kind {
+            executor::ExecutionFailureKind::RunnerJobTimeout {
+                timeout_ms,
+                elapsed_ms,
+                guest_duration_ms,
+            } => {
+                assert_eq!(timeout_ms, 7_200_000);
+                assert_eq!(elapsed_ms, 7_201_000);
+                assert_eq!(guest_duration_ms, None);
+            }
+            executor::ExecutionFailureKind::Generic => {
+                panic!("expected runner job timeout failure kind")
+            }
+        }
+    }
+
+    #[test]
     fn expected_cli_failure_reasons_log_job_execution_failed_at_info() {
         for reason in [
             FailureReason::InsufficientCredits,

--- a/crates/runner/src/cmd/start/job_spawn.rs
+++ b/crates/runner/src/cmd/start/job_spawn.rs
@@ -620,16 +620,43 @@ fn log_job_execution_failed(
         guest_duration_ms,
     } = failure.kind
     {
-        error!(
-            run_id = %run_id,
-            exit_code,
-            reused,
-            error = %failure.error,
-            timeout_ms,
-            elapsed_ms,
-            guest_duration_ms,
-            "runner job timed out"
-        );
+        if let Some(diagnostic) = failure.diagnostic.as_ref() {
+            let failure_detail_source = diagnostic
+                .failure_detail_source
+                .map(|source| source.as_str());
+            let failure_reason = diagnostic.failure_reason.map(|reason| reason.as_str());
+            error!(
+                run_id = %run_id,
+                exit_code,
+                reused,
+                error = %failure.error,
+                timeout_ms,
+                elapsed_ms,
+                guest_duration_ms,
+                failure_class = diagnostic.failure_class.as_str(),
+                failure_framework = diagnostic.framework.as_str(),
+                failure_cli_exit_code = diagnostic.cli_exit_code,
+                failure_claude_num_turns = diagnostic.claude_num_turns,
+                failure_detail_source,
+                failure_reason,
+                session_history_status = diagnostic.session_history_status.as_str(),
+                prompt_shape = diagnostic.prompt_shape.as_str(),
+                prompt_bytes = diagnostic.prompt_bytes,
+                first_line_bytes = diagnostic.first_line_bytes,
+                "runner job timed out"
+            );
+        } else {
+            error!(
+                run_id = %run_id,
+                exit_code,
+                reused,
+                error = %failure.error,
+                timeout_ms,
+                elapsed_ms,
+                guest_duration_ms,
+                "runner job timed out"
+            );
+        }
         return;
     }
 
@@ -998,6 +1025,35 @@ mod tests {
         assert_field_eq(&event, "timeout_ms", "7200000");
         assert_field_eq(&event, "elapsed_ms", "7199949");
         assert_field_eq(&event, "guest_duration_ms", "7200084");
+    }
+
+    #[test]
+    fn runner_job_timeout_preserves_diagnostic_fields() {
+        let diagnostic = job_failure_diagnostic(Some(FailureReason::UsageLimit));
+        let failure = executor::ExecutionFailure::runner_job_timeout(
+            124,
+            "Timeout",
+            Some(diagnostic),
+            Duration::from_secs(7200),
+            Duration::from_millis(7_200_100),
+            Some(7_200_000),
+        );
+
+        let event = capture_job_failure_log(&failure);
+
+        assert_eq!(event.level, Level::ERROR);
+        assert_eq!(
+            event.fields.get("message").map(String::as_str),
+            Some("runner job timed out")
+        );
+        assert_field_eq(&event, "timeout_ms", "7200000");
+        assert_field_eq(&event, "elapsed_ms", "7200100");
+        assert_field_eq(&event, "guest_duration_ms", "7200000");
+        assert_field_eq(&event, "failure_reason", "usage_limit");
+        assert_field_eq(&event, "failure_class", "cli_nonzero");
+        assert_field_eq(&event, "failure_framework", "codex");
+        assert_field_eq(&event, "failure_detail_source", "codex_jsonl");
+        assert_field_eq(&event, "session_history_status", "not_applicable");
     }
 
     async fn status_idle_sessions_and_active_runs(

--- a/crates/runner/src/cmd/start/job_spawn.rs
+++ b/crates/runner/src/cmd/start/job_spawn.rs
@@ -26,7 +26,7 @@ use super::ownership::{OwnershipTransitions, RunSandbox};
 use super::sandbox_finalization::{FinalizeContext, finalize_sandbox_for_completion};
 #[cfg(test)]
 use super::{OuterJobPanicPoint, StartLoopTestObserver, maybe_panic_outer_job};
-use crate::executor::{self, ExecutorConfig};
+use crate::executor::{self, ExecutionFailureKind, ExecutorConfig};
 use crate::idle_pool::{ParkingGate, ReusableIdleSandbox, StorageFingerprints};
 use crate::ids::RunId;
 use crate::network_log_drain::NetworkLogDrainCoordinator;
@@ -614,6 +614,25 @@ fn log_job_execution_failed(
     reused: bool,
     failure: &executor::ExecutionFailure,
 ) {
+    if let ExecutionFailureKind::RunnerJobTimeout {
+        timeout_ms,
+        elapsed_ms,
+        guest_duration_ms,
+    } = failure.kind
+    {
+        error!(
+            run_id = %run_id,
+            exit_code,
+            reused,
+            error = %failure.error,
+            timeout_ms,
+            elapsed_ms,
+            guest_duration_ms,
+            "runner job timed out"
+        );
+        return;
+    }
+
     if let Some(diagnostic) = failure.diagnostic.as_ref() {
         let failure_detail_source = diagnostic
             .failure_detail_source
@@ -795,6 +814,11 @@ mod tests {
                 .insert(field.name().to_string(), value.to_string());
         }
 
+        fn record_u128(&mut self, field: &Field, value: u128) {
+            self.fields
+                .insert(field.name().to_string(), value.to_string());
+        }
+
         fn record_bool(&mut self, field: &Field, value: bool) {
             self.fields
                 .insert(field.name().to_string(), value.to_string());
@@ -948,6 +972,32 @@ mod tests {
             Some("job execution failed")
         );
         assert!(!event.fields.contains_key("failure_reason"));
+    }
+
+    #[test]
+    fn runner_job_timeout_logs_specific_terminal_message_and_fields() {
+        let failure = executor::ExecutionFailure::runner_job_timeout(
+            124,
+            "Timeout",
+            None,
+            Duration::from_secs(7200),
+            Duration::from_millis(7_199_949),
+            Some(7_200_084),
+        );
+
+        let event = capture_job_failure_log(&failure);
+
+        assert_eq!(event.level, Level::ERROR);
+        assert_eq!(
+            event.fields.get("message").map(String::as_str),
+            Some("runner job timed out")
+        );
+        assert_field_eq(&event, "exit_code", "124");
+        assert_field_eq(&event, "reused", "false");
+        assert_field_eq(&event, "error", "Timeout");
+        assert_field_eq(&event, "timeout_ms", "7200000");
+        assert_field_eq(&event, "elapsed_ms", "7199949");
+        assert_field_eq(&event, "guest_duration_ms", "7200084");
     }
 
     async fn status_idle_sessions_and_active_runs(

--- a/crates/runner/src/executor/agent_run.rs
+++ b/crates/runner/src/executor/agent_run.rs
@@ -23,7 +23,7 @@ use super::telemetry::record_api_latency;
 use super::{
     EXIT_SIGKILL, EXIT_SIGNAL_KILL, ExecutionFailure, ExecutorConfig, JOB_TIMEOUT,
     PROCESS_CANCEL_TIMEOUTS, RunnerResult, SandboxReuseResult, USER_ENV_FILE_ENV_KEY,
-    agent_exit_failure_message,
+    agent_exit_failure_message, normalize_failure_exit_code,
 };
 use crate::paths::guest;
 use crate::telemetry::JobTelemetry;
@@ -428,10 +428,12 @@ pub(super) async fn run_in_sandbox_with_process_cancel_timeouts(
         }
     }
 
+    let process_failed = exit.exit_code != 0 || exit.termination != ProcessTerminationKind::Exited;
     let failure = if wait_cancelled {
         // Skip guest file reads — sandbox hasn't been stopped yet.
         Some(ExecutionFailure::cancelled())
-    } else if exit.exit_code != 0 {
+    } else if process_failed {
+        let failure_exit_code = normalize_failure_exit_code(exit.exit_code);
         let stderr = String::from_utf8_lossy(&exit.stderr).to_string();
         let failure_diagnostic = read_guest_failure_diagnostic_file(sandbox, context.run_id).await;
         let guest_error = if stderr.is_empty() {
@@ -460,7 +462,7 @@ pub(super) async fn run_in_sandbox_with_process_cancel_timeouts(
                 context.run_id,
                 sandbox.id(),
                 start.reuse_result,
-                exit.exit_code,
+                failure_exit_code,
             )
             .await;
         }
@@ -470,11 +472,11 @@ pub(super) async fn run_in_sandbox_with_process_cancel_timeouts(
             // Stderr is empty (redirected to log file). Check for a structured
             // error file written by the guest-agent for final failure
             // handoff.
-            guest_error.unwrap_or_else(|| agent_exit_failure_message(exit.exit_code))
+            guest_error.unwrap_or_else(|| agent_exit_failure_message(failure_exit_code))
         };
         Some(if exit.termination == ProcessTerminationKind::TimedOut {
             ExecutionFailure::runner_job_timeout(
-                exit.exit_code,
+                failure_exit_code,
                 error,
                 failure_diagnostic,
                 JOB_TIMEOUT,
@@ -482,7 +484,7 @@ pub(super) async fn run_in_sandbox_with_process_cancel_timeouts(
                 exit.guest_duration_ms,
             )
         } else {
-            ExecutionFailure::new(exit.exit_code, error, failure_diagnostic)
+            ExecutionFailure::new(failure_exit_code, error, failure_diagnostic)
         })
     } else {
         None

--- a/crates/runner/src/executor/agent_run.rs
+++ b/crates/runner/src/executor/agent_run.rs
@@ -2,8 +2,8 @@ use std::time::{Duration, Instant};
 
 use agent_diagnostics::FailureDiagnostic;
 use sandbox::{
-    EXEC_OUTPUT_LIMIT_64_KIB, ExecRequest, ProcessControlMode, ProcessOutputMode, Sandbox,
-    StartProcessRequest,
+    EXEC_OUTPUT_LIMIT_64_KIB, ExecRequest, ProcessControlMode, ProcessOutputMode,
+    ProcessTerminationKind, Sandbox, StartProcessRequest,
 };
 use tokio_util::sync::CancellationToken;
 use tracing::{info, warn};
@@ -79,6 +79,7 @@ pub(super) fn cancelled_agent_process_exit(
     stream_overflowed: bool,
 ) -> sandbox::ProcessExit {
     let mut exit = sandbox::ProcessExit::new(pid, EXIT_SIGKILL, Vec::new(), Vec::new());
+    exit.termination = ProcessTerminationKind::Cancelled;
     exit.stream_overflowed = stream_overflowed;
     exit
 }
@@ -471,11 +472,18 @@ pub(super) async fn run_in_sandbox_with_process_cancel_timeouts(
             // handoff.
             guest_error.unwrap_or_else(|| agent_exit_failure_message(exit.exit_code))
         };
-        Some(ExecutionFailure::new(
-            exit.exit_code,
-            error,
-            failure_diagnostic,
-        ))
+        Some(if exit.termination == ProcessTerminationKind::TimedOut {
+            ExecutionFailure::runner_job_timeout(
+                exit.exit_code,
+                error,
+                failure_diagnostic,
+                JOB_TIMEOUT,
+                t.elapsed(),
+                exit.guest_duration_ms,
+            )
+        } else {
+            ExecutionFailure::new(exit.exit_code, error, failure_diagnostic)
+        })
     } else {
         None
     };

--- a/crates/runner/src/executor/agent_run.rs
+++ b/crates/runner/src/executor/agent_run.rs
@@ -24,6 +24,7 @@ use super::{
     EXIT_SIGKILL, EXIT_SIGNAL_KILL, ExecutionFailure, ExecutorConfig, JOB_TIMEOUT,
     JOB_TIMEOUT_EXIT_CODE, PROCESS_CANCEL_TIMEOUTS, RunnerResult, SandboxReuseResult,
     USER_ENV_FILE_ENV_KEY, agent_exit_failure_message, normalize_failure_exit_code,
+    normalize_timeout_failure_exit_code,
 };
 use crate::paths::guest;
 use crate::telemetry::JobTelemetry;
@@ -464,7 +465,11 @@ pub(super) async fn run_in_sandbox_with_process_cancel_timeouts(
         // Skip guest file reads — sandbox hasn't been stopped yet.
         Some(ExecutionFailure::cancelled())
     } else if process_failed {
-        let failure_exit_code = normalize_failure_exit_code(exit.exit_code);
+        let failure_exit_code = if exit.termination == ProcessTerminationKind::TimedOut {
+            normalize_timeout_failure_exit_code(exit.exit_code)
+        } else {
+            normalize_failure_exit_code(exit.exit_code)
+        };
         let stderr = String::from_utf8_lossy(&exit.stderr).to_string();
         let failure_diagnostic = read_guest_failure_diagnostic_file(sandbox, context.run_id).await;
         let guest_error = if stderr.is_empty() {

--- a/crates/runner/src/executor/agent_run.rs
+++ b/crates/runner/src/executor/agent_run.rs
@@ -22,8 +22,8 @@ use super::storage::{download_storages, filter_unchanged_storages};
 use super::telemetry::record_api_latency;
 use super::{
     EXIT_SIGKILL, EXIT_SIGNAL_KILL, ExecutionFailure, ExecutorConfig, JOB_TIMEOUT,
-    PROCESS_CANCEL_TIMEOUTS, RunnerResult, SandboxReuseResult, USER_ENV_FILE_ENV_KEY,
-    agent_exit_failure_message, normalize_failure_exit_code,
+    JOB_TIMEOUT_EXIT_CODE, PROCESS_CANCEL_TIMEOUTS, RunnerResult, SandboxReuseResult,
+    USER_ENV_FILE_ENV_KEY, agent_exit_failure_message, normalize_failure_exit_code,
 };
 use crate::paths::guest;
 use crate::telemetry::JobTelemetry;
@@ -82,6 +82,20 @@ pub(super) fn cancelled_agent_process_exit(
     exit.termination = ProcessTerminationKind::Cancelled;
     exit.stream_overflowed = stream_overflowed;
     exit
+}
+
+fn wait_process_timed_out(error: &sandbox::SandboxError) -> bool {
+    matches!(
+        error,
+        sandbox::SandboxError::Operation {
+            operation: sandbox::SandboxOperation::WaitProcess,
+            reason: sandbox::SandboxOperationReason::Timeout,
+            ..
+        }
+    ) || matches!(
+        error,
+        sandbox::SandboxError::Io(error) if error.kind() == std::io::ErrorKind::TimedOut
+    )
 }
 
 /// How this run is entering its sandbox. Each field feeds a distinct step:
@@ -351,6 +365,10 @@ pub(super) async fn run_in_sandbox_with_process_cancel_timeouts(
             }
         }
     }
+    let stdout_stream_diagnostics_on_wait_error = AgentStdoutStreamDiagnostics {
+        chunk_truncated: stdout_drain_report.chunk_truncated,
+        stream_overflowed: false,
+    };
     let exit = match result {
         Ok(exit) => exit,
         Err(e) => {
@@ -368,6 +386,19 @@ pub(super) async fn run_in_sandbox_with_process_cancel_timeouts(
             }
             let error = e.to_string();
             telemetry.record("agent_execute", t.elapsed(), false, Some(&error));
+            if wait_process_timed_out(&e) {
+                return Ok(AgentExecutionResult {
+                    failure: Some(ExecutionFailure::runner_job_timeout(
+                        JOB_TIMEOUT_EXIT_CODE,
+                        error,
+                        None,
+                        JOB_TIMEOUT,
+                        t.elapsed(),
+                        None,
+                    )),
+                    stdout_stream_diagnostics: stdout_stream_diagnostics_on_wait_error,
+                });
+            }
             return Err(e.into());
         }
     };

--- a/crates/runner/src/executor/diagnostics.rs
+++ b/crates/runner/src/executor/diagnostics.rs
@@ -132,7 +132,7 @@ pub(super) fn should_collect_agent_abnormal_exit_diagnostics(
     guest_error: Option<&str>,
 ) -> bool {
     !wait_cancelled
-        && exit.exit_code != 0
+        && (exit.exit_code != 0 || exit.termination != sandbox::ProcessTerminationKind::Exited)
         && exit.diagnostic.is_empty()
         && stderr.is_empty()
         && failure_diagnostic.is_none()

--- a/crates/runner/src/executor/mod.rs
+++ b/crates/runner/src/executor/mod.rs
@@ -206,6 +206,7 @@ impl ExecutionFailure {
         error: impl Into<String>,
         diagnostic: Option<FailureDiagnostic>,
     ) -> Self {
+        let exit_code = normalize_failure_exit_code(exit_code);
         let error = non_empty_failure_error(exit_code, error.into());
         Self {
             exit_code,
@@ -224,6 +225,7 @@ impl ExecutionFailure {
         elapsed: Duration,
         guest_duration_ms: Option<u32>,
     ) -> Self {
+        let exit_code = normalize_failure_exit_code(exit_code);
         let error = non_empty_failure_error(exit_code, error.into());
         Self {
             exit_code,
@@ -246,6 +248,10 @@ impl ExecutionFailure {
     pub fn cancelled() -> Self {
         Self::new(EXIT_SIGKILL, "cancelled by user", None)
     }
+}
+
+fn normalize_failure_exit_code(exit_code: i32) -> i32 {
+    if exit_code == 0 { 1 } else { exit_code }
 }
 
 fn non_empty_failure_error(exit_code: i32, error: String) -> String {

--- a/crates/runner/src/executor/mod.rs
+++ b/crates/runner/src/executor/mod.rs
@@ -186,6 +186,17 @@ pub struct ExecutionFailure {
     pub exit_code: i32,
     pub error: String,
     pub diagnostic: Option<FailureDiagnostic>,
+    pub kind: ExecutionFailureKind,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ExecutionFailureKind {
+    Generic,
+    RunnerJobTimeout {
+        timeout_ms: u128,
+        elapsed_ms: u128,
+        guest_duration_ms: Option<u32>,
+    },
 }
 
 impl ExecutionFailure {
@@ -200,6 +211,29 @@ impl ExecutionFailure {
             exit_code,
             error,
             diagnostic,
+            kind: ExecutionFailureKind::Generic,
+        }
+    }
+
+    #[must_use]
+    pub fn runner_job_timeout(
+        exit_code: i32,
+        error: impl Into<String>,
+        diagnostic: Option<FailureDiagnostic>,
+        timeout: Duration,
+        elapsed: Duration,
+        guest_duration_ms: Option<u32>,
+    ) -> Self {
+        let error = non_empty_failure_error(exit_code, error.into());
+        Self {
+            exit_code,
+            error,
+            diagnostic,
+            kind: ExecutionFailureKind::RunnerJobTimeout {
+                timeout_ms: timeout.as_millis(),
+                elapsed_ms: elapsed.as_millis(),
+                guest_duration_ms,
+            },
         }
     }
 

--- a/crates/runner/src/executor/mod.rs
+++ b/crates/runner/src/executor/mod.rs
@@ -208,7 +208,7 @@ impl ExecutionFailure {
         error: impl Into<String>,
         diagnostic: Option<FailureDiagnostic>,
     ) -> Self {
-        let exit_code = normalize_timeout_failure_exit_code(exit_code);
+        let exit_code = normalize_failure_exit_code(exit_code);
         let error = non_empty_failure_error(exit_code, error.into());
         Self {
             exit_code,
@@ -227,7 +227,7 @@ impl ExecutionFailure {
         elapsed: Duration,
         guest_duration_ms: Option<u32>,
     ) -> Self {
-        let exit_code = normalize_failure_exit_code(exit_code);
+        let exit_code = normalize_timeout_failure_exit_code(exit_code);
         let error = non_empty_failure_error(exit_code, error.into());
         Self {
             exit_code,

--- a/crates/runner/src/executor/mod.rs
+++ b/crates/runner/src/executor/mod.rs
@@ -47,6 +47,8 @@ use api_contracts::generated::constants::runners::paths::{
 
 /// Maximum wall-clock time for a single job (2 hours).
 const JOB_TIMEOUT: Duration = Duration::from_secs(7200);
+/// Exit code used when the runner's job timeout stops an agent process.
+const JOB_TIMEOUT_EXIT_CODE: i32 = 124;
 /// Maximum time to spend writing the guest cancel frame after a user cancel.
 const PROCESS_CANCEL_WRITE_TIMEOUT: Duration = Duration::from_secs(1);
 /// Grace period for the guest to report a terminal status after cancel is sent.

--- a/crates/runner/src/executor/mod.rs
+++ b/crates/runner/src/executor/mod.rs
@@ -208,7 +208,7 @@ impl ExecutionFailure {
         error: impl Into<String>,
         diagnostic: Option<FailureDiagnostic>,
     ) -> Self {
-        let exit_code = normalize_failure_exit_code(exit_code);
+        let exit_code = normalize_timeout_failure_exit_code(exit_code);
         let error = non_empty_failure_error(exit_code, error.into());
         Self {
             exit_code,
@@ -254,6 +254,14 @@ impl ExecutionFailure {
 
 fn normalize_failure_exit_code(exit_code: i32) -> i32 {
     if exit_code == 0 { 1 } else { exit_code }
+}
+
+fn normalize_timeout_failure_exit_code(exit_code: i32) -> i32 {
+    if exit_code == 0 {
+        JOB_TIMEOUT_EXIT_CODE
+    } else {
+        exit_code
+    }
 }
 
 fn non_empty_failure_error(exit_code: i32, error: String) -> String {

--- a/crates/runner/src/executor/tests/sandbox_run_tests.rs
+++ b/crates/runner/src/executor/tests/sandbox_run_tests.rs
@@ -938,8 +938,8 @@ async fn execute_inner_timeout_zero_code_is_failure() {
     .unwrap();
 
     let failure = outcome.failure.as_ref().expect("expected timeout failure");
-    assert_eq!(outcome.exit_code(), 1);
-    assert_eq!(failure.exit_code, 1);
+    assert_eq!(outcome.exit_code(), 124);
+    assert_eq!(failure.exit_code, 124);
     assert_eq!(failure.error, "Timeout");
     match failure.kind {
         ExecutionFailureKind::RunnerJobTimeout {

--- a/crates/runner/src/executor/tests/sandbox_run_tests.rs
+++ b/crates/runner/src/executor/tests/sandbox_run_tests.rs
@@ -780,9 +780,21 @@ async fn execute_inner_aborts_drain_task_on_wait_process_error() {
     .await
     .unwrap();
 
-    assert_eq!(outcome.exit_code(), 1);
-    let error = outcome.error().unwrap();
-    assert!(error.contains("wait timeout"), "got: {error}");
+    assert_eq!(outcome.exit_code(), 124);
+    let failure = outcome.failure.as_ref().expect("expected failure");
+    assert_eq!(failure.exit_code, 124);
+    assert!(failure.error.contains("wait timeout"), "got: {failure:?}");
+    match failure.kind {
+        ExecutionFailureKind::RunnerJobTimeout {
+            timeout_ms,
+            elapsed_ms: _,
+            guest_duration_ms,
+        } => {
+            assert_eq!(timeout_ms, 7_200_000);
+            assert_eq!(guest_duration_ms, None);
+        }
+        ExecutionFailureKind::Generic => panic!("expected runner job timeout failure kind"),
+    }
     assert!(
         outcome.sandbox.is_some(),
         "sandbox must be returned on post-start execution failure"

--- a/crates/runner/src/executor/tests/sandbox_run_tests.rs
+++ b/crates/runner/src/executor/tests/sandbox_run_tests.rs
@@ -7,7 +7,7 @@ use api_contracts::generated::constants::runners::paths::CANONICAL_WORKING_DIR;
 use api_contracts::generated::types::runners::storage::StorageManifest;
 use sandbox::{
     EXEC_OUTPUT_LIMIT_64_KIB, ExecResult, ProcessControlMode, ProcessExit, ProcessOutputChunk,
-    ProcessOutputMode, Sandbox, SandboxError, SandboxFactory, SandboxId,
+    ProcessOutputMode, ProcessTerminationKind, Sandbox, SandboxError, SandboxFactory, SandboxId,
 };
 use sandbox_mock::{MockSandbox, MockSandboxFactory};
 
@@ -18,9 +18,9 @@ use super::super::sandbox_run::{
     register_proxy,
 };
 use super::super::{
-    AGENT_ABNORMAL_EXIT_DIAGNOSTIC_TIMEOUT, EXIT_SIGKILL, JobParams, NewSandboxDispatch,
-    STDOUT_STREAM_LIMIT_MARKER, STDOUT_STREAM_OVERFLOW_MARKER, USER_ENV_FILE_ENV_KEY, execute_job,
-    execute_job_reuse,
+    AGENT_ABNORMAL_EXIT_DIAGNOSTIC_TIMEOUT, EXIT_SIGKILL, ExecutionFailureKind, JobParams,
+    NewSandboxDispatch, STDOUT_STREAM_LIMIT_MARKER, STDOUT_STREAM_OVERFLOW_MARKER,
+    USER_ENV_FILE_ENV_KEY, execute_job, execute_job_reuse,
 };
 use super::support::{
     DestroyPanicFactory, QueuedCopyFileSandbox, api_storage, assert_proxy_registry_empty,
@@ -810,6 +810,81 @@ async fn execute_inner_nonzero_without_guest_error_returns_failure_message() {
 
     assert_eq!(exit_code, 7);
     assert_eq!(error.as_deref(), Some("Agent exited with code 7"));
+}
+
+#[tokio::test]
+async fn execute_inner_guest_process_timeout_marks_failure_kind() {
+    let dir = tempfile::tempdir().unwrap();
+    let config = test_executor_config(dir.path()).await;
+    let overrides = Arc::new(sandbox_mock::MockSandboxOverrides::new());
+    let mut exit = ProcessExit::new(1, 124, Vec::new(), b"Timeout".to_vec());
+    exit.termination = ProcessTerminationKind::TimedOut;
+    exit.guest_duration_ms = Some(7_200_084);
+    overrides.push_wait_process_exit(exit);
+    let factory = sandbox_mock::MockSandboxFactory::with_overrides(overrides);
+    let ctx = minimal_context();
+    let mut telemetry = test_telemetry(&config, &ctx);
+
+    let outcome = execute_new_sandbox(
+        &factory,
+        &ctx,
+        NewSandboxDispatch {
+            id: SandboxId::new_v4(),
+            reuse_result: SandboxReuseResult::PoolMiss,
+        },
+        &config,
+        &default_params(),
+        &mut telemetry,
+        tokio_util::sync::CancellationToken::new(),
+    )
+    .await
+    .unwrap();
+
+    let failure = outcome.failure.as_ref().expect("expected timeout failure");
+    assert_eq!(failure.exit_code, 124);
+    assert_eq!(failure.error, "Timeout");
+    match failure.kind {
+        ExecutionFailureKind::RunnerJobTimeout {
+            timeout_ms,
+            elapsed_ms: _,
+            guest_duration_ms,
+        } => {
+            assert_eq!(timeout_ms, 7_200_000);
+            assert_eq!(guest_duration_ms, Some(7_200_084));
+        }
+        ExecutionFailureKind::Generic => panic!("expected runner job timeout failure kind"),
+    }
+}
+
+#[tokio::test]
+async fn execute_inner_ordinary_124_timeout_text_is_generic_failure() {
+    let dir = tempfile::tempdir().unwrap();
+    let config = test_executor_config(dir.path()).await;
+    let overrides = Arc::new(sandbox_mock::MockSandboxOverrides::new());
+    overrides.push_wait_process_exit(ProcessExit::new(1, 124, Vec::new(), b"Timeout".to_vec()));
+    let factory = sandbox_mock::MockSandboxFactory::with_overrides(overrides);
+    let ctx = minimal_context();
+    let mut telemetry = test_telemetry(&config, &ctx);
+
+    let outcome = execute_new_sandbox(
+        &factory,
+        &ctx,
+        NewSandboxDispatch {
+            id: SandboxId::new_v4(),
+            reuse_result: SandboxReuseResult::PoolMiss,
+        },
+        &config,
+        &default_params(),
+        &mut telemetry,
+        tokio_util::sync::CancellationToken::new(),
+    )
+    .await
+    .unwrap();
+
+    let failure = outcome.failure.as_ref().expect("expected failure");
+    assert_eq!(failure.exit_code, 124);
+    assert_eq!(failure.error, "Timeout");
+    assert_eq!(failure.kind, ExecutionFailureKind::Generic);
 }
 
 #[tokio::test]

--- a/crates/runner/src/executor/tests/sandbox_run_tests.rs
+++ b/crates/runner/src/executor/tests/sandbox_run_tests.rs
@@ -813,6 +813,47 @@ async fn execute_inner_nonzero_without_guest_error_returns_failure_message() {
 }
 
 #[tokio::test]
+async fn execute_inner_non_exited_zero_code_is_failure() {
+    let dir = tempfile::tempdir().unwrap();
+    let config = test_executor_config(dir.path()).await;
+    let overrides = Arc::new(sandbox_mock::MockSandboxOverrides::new());
+    let mut exit = ProcessExit::new(1, 0, Vec::new(), Vec::new());
+    exit.termination = ProcessTerminationKind::WaitFailed;
+    overrides.push_wait_process_exit(exit);
+    let factory = sandbox_mock::MockSandboxFactory::with_overrides(Arc::clone(&overrides));
+    let ctx = minimal_context();
+    let mut telemetry = test_telemetry(&config, &ctx);
+
+    let outcome = execute_new_sandbox(
+        &factory,
+        &ctx,
+        NewSandboxDispatch {
+            id: SandboxId::new_v4(),
+            reuse_result: SandboxReuseResult::PoolMiss,
+        },
+        &config,
+        &default_params(),
+        &mut telemetry,
+        tokio_util::sync::CancellationToken::new(),
+    )
+    .await
+    .unwrap();
+
+    let failure = outcome.failure.as_ref().expect("expected failure");
+    assert_eq!(outcome.exit_code(), 1);
+    assert_eq!(failure.exit_code, 1);
+    assert_eq!(failure.error, "Agent exited with code 1");
+    assert_eq!(failure.kind, ExecutionFailureKind::Generic);
+    assert!(outcome.guest_session_id.is_none());
+    assert!(
+        overrides
+            .exec_calls()
+            .iter()
+            .any(|call| call.cmd.contains("guest-agent-binary"))
+    );
+}
+
+#[tokio::test]
 async fn execute_inner_guest_process_timeout_marks_failure_kind() {
     let dir = tempfile::tempdir().unwrap();
     let config = test_executor_config(dir.path()).await;
@@ -842,6 +883,51 @@ async fn execute_inner_guest_process_timeout_marks_failure_kind() {
 
     let failure = outcome.failure.as_ref().expect("expected timeout failure");
     assert_eq!(failure.exit_code, 124);
+    assert_eq!(failure.error, "Timeout");
+    match failure.kind {
+        ExecutionFailureKind::RunnerJobTimeout {
+            timeout_ms,
+            elapsed_ms: _,
+            guest_duration_ms,
+        } => {
+            assert_eq!(timeout_ms, 7_200_000);
+            assert_eq!(guest_duration_ms, Some(7_200_084));
+        }
+        ExecutionFailureKind::Generic => panic!("expected runner job timeout failure kind"),
+    }
+}
+
+#[tokio::test]
+async fn execute_inner_timeout_zero_code_is_failure() {
+    let dir = tempfile::tempdir().unwrap();
+    let config = test_executor_config(dir.path()).await;
+    let overrides = Arc::new(sandbox_mock::MockSandboxOverrides::new());
+    let mut exit = ProcessExit::new(1, 0, Vec::new(), b"Timeout".to_vec());
+    exit.termination = ProcessTerminationKind::TimedOut;
+    exit.guest_duration_ms = Some(7_200_084);
+    overrides.push_wait_process_exit(exit);
+    let factory = sandbox_mock::MockSandboxFactory::with_overrides(overrides);
+    let ctx = minimal_context();
+    let mut telemetry = test_telemetry(&config, &ctx);
+
+    let outcome = execute_new_sandbox(
+        &factory,
+        &ctx,
+        NewSandboxDispatch {
+            id: SandboxId::new_v4(),
+            reuse_result: SandboxReuseResult::PoolMiss,
+        },
+        &config,
+        &default_params(),
+        &mut telemetry,
+        tokio_util::sync::CancellationToken::new(),
+    )
+    .await
+    .unwrap();
+
+    let failure = outcome.failure.as_ref().expect("expected timeout failure");
+    assert_eq!(outcome.exit_code(), 1);
+    assert_eq!(failure.exit_code, 1);
     assert_eq!(failure.error, "Timeout");
     match failure.kind {
         ExecutionFailureKind::RunnerJobTimeout {

--- a/crates/runner/tests/axiom_layer.rs
+++ b/crates/runner/tests/axiom_layer.rs
@@ -376,6 +376,52 @@ async fn u128_fields_serialize_as_numbers_when_in_u64_range() {
 }
 
 #[tokio::test]
+async fn none_option_fields_are_omitted_from_axiom_payload() {
+    let server = MockServer::start_async().await;
+
+    let event_mock = server
+        .mock_async(|when, then| {
+            when.method(POST)
+                .path("/v1/datasets/vm0-web-logs-test/ingest")
+                .body_includes(r#""message":"timeout without guest duration""#)
+                .body_includes(r#""timeout_ms":7200000"#);
+            then.status(200).body("{}");
+        })
+        .await;
+    let guest_duration_mock = server
+        .mock_async(|when, then| {
+            when.method(POST)
+                .path("/v1/datasets/vm0-web-logs-test/ingest")
+                .body_includes("guest_duration_ms");
+            then.status(200).body("{}");
+        })
+        .await;
+    let none_mock = server
+        .mock_async(|when, then| {
+            when.method(POST).body_includes("None");
+            then.status(200).body("{}");
+        })
+        .await;
+
+    let (layer, guard) = axiom_layer::init_with_base_url(&server.base_url(), "t", "test")
+        .expect("init must succeed");
+    let subscriber = tracing_subscriber::registry().with(axiom_layer::with_ingest_filter(layer));
+    {
+        let _sub = tracing::subscriber::set_default(subscriber);
+        tracing::error!(
+            timeout_ms = 7_200_000_u128,
+            guest_duration_ms = None::<u32>,
+            "timeout without guest duration"
+        );
+    }
+    guard.shutdown().await;
+
+    event_mock.assert_calls_async(1).await;
+    guest_duration_mock.assert_calls_async(0).await;
+    none_mock.assert_calls_async(0).await;
+}
+
+#[tokio::test]
 async fn burst_past_channel_cap_drops_without_blocking_or_feeding_back() {
     let server = MockServer::start_async().await;
 

--- a/crates/runner/tests/axiom_layer.rs
+++ b/crates/runner/tests/axiom_layer.rs
@@ -343,7 +343,8 @@ async fn u128_fields_serialize_as_numbers_when_in_u64_range() {
                 .path("/v1/datasets/vm0-web-logs-test/ingest")
                 .body_includes(r#""message":"timeout fields""#)
                 .body_includes(r#""timeout_ms":7200000"#)
-                .body_includes(r#""elapsed_ms":7200100"#);
+                .body_includes(r#""elapsed_ms":7200100"#)
+                .body_includes(r#""guest_duration_ms":7200084"#);
             then.status(200).body("{}");
         })
         .await;
@@ -364,6 +365,7 @@ async fn u128_fields_serialize_as_numbers_when_in_u64_range() {
         tracing::error!(
             timeout_ms = 7_200_000_u128,
             elapsed_ms = 7_200_100_u128,
+            guest_duration_ms = Some(7_200_084_u32),
             "timeout fields"
         );
     }

--- a/crates/runner/tests/axiom_layer.rs
+++ b/crates/runner/tests/axiom_layer.rs
@@ -334,6 +334,46 @@ async fn error_field_serializes_with_message_and_source_chain() {
 }
 
 #[tokio::test]
+async fn u128_fields_serialize_as_numbers_when_in_u64_range() {
+    let server = MockServer::start_async().await;
+
+    let numeric_mock = server
+        .mock_async(|when, then| {
+            when.method(POST)
+                .path("/v1/datasets/vm0-web-logs-test/ingest")
+                .body_includes(r#""message":"timeout fields""#)
+                .body_includes(r#""timeout_ms":7200000"#)
+                .body_includes(r#""elapsed_ms":7200100"#);
+            then.status(200).body("{}");
+        })
+        .await;
+    let string_mock = server
+        .mock_async(|when, then| {
+            when.method(POST)
+                .path("/v1/datasets/vm0-web-logs-test/ingest")
+                .body_includes(r#""timeout_ms":"7200000""#);
+            then.status(200).body("{}");
+        })
+        .await;
+
+    let (layer, guard) = axiom_layer::init_with_base_url(&server.base_url(), "t", "test")
+        .expect("init must succeed");
+    let subscriber = tracing_subscriber::registry().with(axiom_layer::with_ingest_filter(layer));
+    {
+        let _sub = tracing::subscriber::set_default(subscriber);
+        tracing::error!(
+            timeout_ms = 7_200_000_u128,
+            elapsed_ms = 7_200_100_u128,
+            "timeout fields"
+        );
+    }
+    guard.shutdown().await;
+
+    numeric_mock.assert_calls_async(1).await;
+    string_mock.assert_calls_async(0).await;
+}
+
+#[tokio::test]
 async fn burst_past_channel_cap_drops_without_blocking_or_feeding_back() {
     let server = MockServer::start_async().await;
 

--- a/crates/sandbox-fc/src/sandbox.rs
+++ b/crates/sandbox-fc/src/sandbox.rs
@@ -12,9 +12,9 @@ use async_trait::async_trait;
 use sandbox::{
     CopyFileOptions, CopyFileResult, ExecRequest, ExecResult, GuestProcessCancelHandle,
     GuestProcessControlHandle, GuestProcessHandle, GuestProcessWaiter, ProcessControlAck,
-    ProcessControlMode, ProcessExit, ProcessOutputChunk, ProcessOutputMode, Sandbox, SandboxConfig,
-    SandboxError, SandboxIdleTransition, SandboxInvalidStateContext, SandboxOperation,
-    SandboxOperationReason, StartProcessRequest,
+    ProcessControlMode, ProcessExit, ProcessOutputChunk, ProcessOutputMode, ProcessTerminationKind,
+    Sandbox, SandboxConfig, SandboxError, SandboxIdleTransition, SandboxInvalidStateContext,
+    SandboxOperation, SandboxOperationReason, StartProcessRequest,
 };
 use tokio::io::{AsyncBufReadExt, AsyncRead, BufReader};
 use tokio::sync::{mpsc, watch};
@@ -1527,6 +1527,13 @@ fn supervised_exec_result_to_process_exit(
 ) -> ProcessExit {
     let (stdout, stdout_truncated) = captured_output_bytes(result.stdout);
     let (mut stderr, stderr_truncated) = captured_output_bytes(result.stderr);
+    let termination = match result.termination {
+        ExecTermination::Exited { .. } => ProcessTerminationKind::Exited,
+        ExecTermination::TimedOut => ProcessTerminationKind::TimedOut,
+        ExecTermination::Cancelled => ProcessTerminationKind::Cancelled,
+        ExecTermination::StartFailed => ProcessTerminationKind::StartFailed,
+        ExecTermination::WaitFailed => ProcessTerminationKind::WaitFailed,
+    };
     let exit_code = match result.termination {
         ExecTermination::Exited { exit_code } => exit_code,
         ExecTermination::TimedOut => {
@@ -1550,6 +1557,8 @@ fn supervised_exec_result_to_process_exit(
 
     ProcessExit {
         pid,
+        termination,
+        guest_duration_ms: Some(result.duration_ms),
         exit_code,
         stdout,
         stderr,
@@ -4896,24 +4905,34 @@ mod tests {
 
     #[test]
     fn supervised_exec_result_to_process_exit_maps_terminal_edge_states() {
-        for (termination, diagnostic, expected_code, expected_stderr) in [
+        for (termination, diagnostic, expected_code, expected_stderr, expected_termination) in [
             (
                 ExecTermination::TimedOut,
                 "",
                 EXEC_TIMEOUT_EXIT_CODE,
                 "Timeout",
+                ProcessTerminationKind::TimedOut,
             ),
             (
                 ExecTermination::Cancelled,
                 "cancel diagnostic",
                 1,
                 "Cancelled\ncancel diagnostic",
+                ProcessTerminationKind::Cancelled,
             ),
             (
                 ExecTermination::StartFailed,
                 "spawn failed",
                 1,
                 "spawn failed",
+                ProcessTerminationKind::StartFailed,
+            ),
+            (
+                ExecTermination::WaitFailed,
+                "wait failed",
+                1,
+                "wait failed",
+                ProcessTerminationKind::WaitFailed,
             ),
         ] {
             let exit = supervised_exec_result_to_process_exit(
@@ -4932,6 +4951,8 @@ mod tests {
             );
 
             assert_eq!(exit.exit_code, expected_code);
+            assert_eq!(exit.termination, expected_termination);
+            assert_eq!(exit.guest_duration_ms, Some(10));
             assert_eq!(String::from_utf8(exit.stderr).unwrap(), expected_stderr);
             assert_eq!(exit.diagnostic, diagnostic);
         }

--- a/crates/sandbox/src/lib.rs
+++ b/crates/sandbox/src/lib.rs
@@ -46,5 +46,5 @@ pub use types::{
     EXEC_OUTPUT_LIMIT_64_KIB, ExecOutputLimits, ExecRequest, ExecResult, GuestProcessCancelHandle,
     GuestProcessControlHandle, GuestProcessHandle, GuestProcessWaiter, ProcessControlAck,
     ProcessControlMode, ProcessExit, ProcessOutputChunk, ProcessOutputMode, ProcessOutputReceiver,
-    StartProcessRequest,
+    ProcessTerminationKind, StartProcessRequest,
 };

--- a/crates/sandbox/src/types.rs
+++ b/crates/sandbox/src/types.rs
@@ -459,10 +459,34 @@ impl ProcessOutputMode {
     }
 }
 
+/// Terminal state reported by the process provider.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum ProcessTerminationKind {
+    /// The process exited with an ordinary exit code.
+    Exited,
+    /// The provider timed the process out.
+    TimedOut,
+    /// The provider cancelled the process.
+    Cancelled,
+    /// The provider failed to start the process.
+    StartFailed,
+    /// The provider failed while waiting for the process.
+    WaitFailed,
+}
+
 /// Terminal status and output metadata for a started guest process.
 pub struct ProcessExit {
     /// Guest process id reported by the provider.
     pub pid: u32,
+    /// Structured terminal state reported by the provider.
+    ///
+    /// This is separate from `exit_code`: providers still synthesize an exit
+    /// code for timeout, cancel, start, and wait failures so older callers can
+    /// continue using the existing completion code.
+    pub termination: ProcessTerminationKind,
+    /// Guest-reported wall-clock duration in milliseconds, when the provider has
+    /// terminal duration metadata.
+    pub guest_duration_ms: Option<u32>,
     /// Process exit code, or a provider-synthesized code for timeout, cancel,
     /// start, or wait failures.
     pub exit_code: i32,
@@ -495,12 +519,15 @@ pub struct ProcessExit {
 impl ProcessExit {
     /// Construct a process exit result with no truncation or stream metadata.
     ///
-    /// The returned value sets `stdout_truncated` and `stderr_truncated` to
-    /// `false`, `diagnostic` to an empty string, and `stream_overflowed` to
-    /// `false`.
+    /// The returned value sets `termination` to
+    /// [`ProcessTerminationKind::Exited`], `guest_duration_ms` to `None`,
+    /// `stdout_truncated` and `stderr_truncated` to `false`, `diagnostic` to an
+    /// empty string, and `stream_overflowed` to `false`.
     pub fn new(pid: u32, exit_code: i32, stdout: Vec<u8>, stderr: Vec<u8>) -> Self {
         Self {
             pid,
+            termination: ProcessTerminationKind::Exited,
+            guest_duration_ms: None,
             exit_code,
             stdout,
             stderr,
@@ -623,6 +650,8 @@ mod tests {
 
         assert_eq!(exit.pid, 42);
         assert_eq!(exit.exit_code, 7);
+        assert_eq!(exit.termination, ProcessTerminationKind::Exited);
+        assert_eq!(exit.guest_duration_ms, None);
         assert_eq!(exit.stdout, b"out");
         assert_eq!(exit.stderr, b"err");
         assert!(!exit.stdout_truncated);


### PR DESCRIPTION
## Summary
- carry structured process termination metadata from sandbox-fc into runner execution failures
- classify supervised guest job timeouts without relying on exit code or stderr text
- emit a dedicated `runner job timed out` log with configured timeout, runner elapsed time, and guest duration metadata

Fixes #16802

## Validation
- `cargo fmt --manifest-path crates/Cargo.toml --all --check`
- `cargo test --manifest-path crates/Cargo.toml -p sandbox`
- `cargo test --manifest-path crates/Cargo.toml -p sandbox-fc`
- `cargo test --manifest-path crates/Cargo.toml -p runner job_spawn`
- `cargo test --manifest-path crates/Cargo.toml -p runner executor`
- `cargo clippy --manifest-path crates/Cargo.toml -p sandbox -p sandbox-fc -p runner --all-targets`
- pre-commit cargo doc and cargo clippy hooks