### PR TITLE
ci: remove redundant build-api job

### DIFF
--- a/.github/workflows/turbo.yml
+++ b/.github/workflows/turbo.yml
@@ -1549,25 +1549,6 @@ jobs:
           retention-days: 7
           if-no-files-found: ignore
 
-  build-api:
-    runs-on: ubuntu-latest
-    timeout-minutes: 10
-    container:
-      image: ghcr.io/vm0-ai/vm0-toolchain:20260525
-    needs: [prepare]
-    if: |
-      (github.event_name != 'push' || !startsWith(github.event.head_commit.message, 'chore: release')) &&
-      needs.prepare.outputs.job-ref != '' && (
-        needs.prepare.outputs.api-changed == 'true' ||
-        needs.prepare.outputs.ci-changed == 'true'
-      )
-    steps:
-      - uses: actions/checkout@v6
-      - uses: ./.github/actions/toolchain-init
-      - name: Check API types
-        working-directory: turbo
-        run: pnpm --filter api check-types
-
   # Build CLI once and share via artifact — e2e jobs download instead of rebuilding
   build-cli:
     runs-on: ubuntu-latest
@@ -2436,7 +2417,6 @@ jobs:
       - test-app-browser
       - test-api
       - test-other
-      - build-api
       - deploy-api
       - deploy-web
       - deploy-app
@@ -2522,7 +2502,6 @@ jobs:
 
           # May-skip: 'success' or 'skipped' are both acceptable
           check_result "test-migrate" "${{ needs.test-migrate.result }}" "true"
-          check_result "build-api" "${{ needs.build-api.result }}" "true"
           check_result "deploy-api" "${{ needs.deploy-api.result }}" "true"
           check_result "deploy-web" "${{ needs.deploy-web.result }}" "$WEB_DEPLOY_SKIP_ALLOWED"
           check_result "deploy-app" "${{ needs.deploy-app.result }}" "true"


### PR DESCRIPTION
## What

Removes the `build-api` CI job, which has become a redundant duplicate.

## Why

`build-api`'s only step is:

```yaml
- name: Check API types
  run: pnpm --filter api check-types
```

PR #16771 ("ci: split heavy app type-checks into a parallel lint-types-apps job") added a `lint-types-apps` job that already runs the **identical** check:

```yaml
- name: Type Check (api)
  run: pnpm --filter api run check-types
```

So the api type-check now runs twice on the same change set.

It's not just a naming overlap — `build-api`'s trigger is a strict subset of `lint-types-apps`'s:

- `build-api` runs when `api-changed || ci-changed`.
- `lint-types-apps` runs whenever `turbo-ts-checks-needed` is true, i.e. on **every** change set that isn't crates-only — a superset of the above.

Every time `build-api` would run, `lint-types-apps` is already type-checking the api package. Keeping `build-api` just burns an extra runner per api/ci change with no added coverage.

> Note: the name `build-api` was always misleading — it never built anything (`vite build` lives in `deploy-api`); it was only ever a `tsc --noEmit` gate. With `lint-types-apps` now covering that gate, the job can simply be dropped.

## Changes

- Delete the `build-api` job.
- Remove it from the final aggregator's `needs:` list and its `check_result` line.

API type coverage is unchanged — still enforced by `lint-types-apps`.
