### PR TITLE
fix: avoid auth for built-in generation choices

### DIFF
--- a/turbo/apps/cli/src/commands/zero/generate/__tests__/lister.test.ts
+++ b/turbo/apps/cli/src/commands/zero/generate/__tests__/lister.test.ts
@@ -232,7 +232,10 @@ describe("zero generate lister", () => {
     await generateCommand.parseAsync(["node", "cli", "presentation"]);
 
     const text = output();
-    expect(text).toContain("Presentation generation choices for current agent");
+    expect(text).toContain("Presentation generation choices");
+    expect(text).not.toContain(
+      "Presentation generation choices for current agent",
+    );
     expect(text).not.toContain("Connectors:");
     expect(text).not.toContain(
       "No ready presentation generation connectors found.",
@@ -255,7 +258,8 @@ describe("zero generate lister", () => {
     await generateCommand.parseAsync(["node", "cli", "website"]);
 
     const text = output();
-    expect(text).toContain("Website generation choices for current agent");
+    expect(text).toContain("Website generation choices");
+    expect(text).not.toContain("Website generation choices for current agent");
     expect(text).not.toContain("Connectors:");
     expect(text).not.toContain("No ready website generation connectors found.");
     expect(text).toContain("Built-in command:");
@@ -275,6 +279,36 @@ describe("zero generate lister", () => {
     expect(text).not.toContain("Model: gpt-5.5");
     expect(text).not.toContain("Fallback option:");
     expect(text).not.toContain("Official provider:");
+  });
+
+  it("suggests the built-in website command with an invalid ZERO_TOKEN", async () => {
+    vi.stubEnv("VM0_TOKEN", undefined);
+    vi.stubEnv("ZERO_TOKEN", "expired-zero-token");
+
+    await generateCommand.parseAsync(["node", "cli", "website"]);
+
+    const text = output();
+    expect(text).toContain("Website generation choices");
+    expect(text).not.toContain("Website generation choices for current agent");
+    expect(text).toContain("Built-in command:");
+    expect(text).toContain("Built-in website generation");
+    expect(text).toContain("Use: zero generate website -h");
+    expect(mockConsoleError).not.toHaveBeenCalled();
+  });
+
+  it("suggests the built-in website command without authentication", async () => {
+    vi.stubEnv("VM0_TOKEN", undefined);
+    vi.stubEnv("ZERO_TOKEN", undefined);
+
+    await generateCommand.parseAsync(["node", "cli", "website"]);
+
+    const text = output();
+    expect(text).toContain("Website generation choices");
+    expect(text).not.toContain("Website generation choices for current agent");
+    expect(text).toContain("Built-in command:");
+    expect(text).toContain("Built-in website generation");
+    expect(text).toContain("Use: zero generate website -h");
+    expect(mockConsoleError).not.toHaveBeenCalled();
   });
 
   it.each([
@@ -300,7 +334,8 @@ describe("zero generate lister", () => {
     await generateCommand.parseAsync(["node", "cli", type]);
 
     const text = output();
-    expect(text).toContain(`${label} generation choices for current agent`);
+    expect(text).toContain(`${label} generation choices`);
+    expect(text).not.toContain(`${label} generation choices for current agent`);
     expect(text).not.toContain(`No ready ${type} generation connectors found.`);
     expect(text).toContain("Built-in command:");
     expect(text).toContain(commandLabel);

--- a/turbo/apps/cli/src/commands/zero/generate/lib/lister.ts
+++ b/turbo/apps/cli/src/commands/zero/generate/lib/lister.ts
@@ -533,22 +533,30 @@ function renderText(params: {
   ready: GenerationCandidate[];
   other: GenerationCandidate[];
   showAll: boolean;
+  usesConnectors: boolean;
 }): void {
-  const { generationType, agentId, ready, other, showAll } = params;
+  const { generationType, agentId, ready, other, showAll, usesConnectors } =
+    params;
   const label = GENERATION_TYPE_LABELS[generationType];
-  const scope = agentId ? "for current agent" : "(connected connectors)";
+  const scope = usesConnectors
+    ? agentId
+      ? " for current agent"
+      : " (connected connectors)"
+    : "";
 
-  console.log(`${label} generation choices ${scope}`);
+  console.log(`${label} generation choices${scope}`);
   console.log("");
 
-  if (agentId) {
-    console.log(`${"Agent:".padEnd(10)}${agentId}`);
-    console.log("");
-  } else {
-    console.log(
-      "ZERO_AGENT_ID is not set, so agent authorization could not be checked.",
-    );
-    console.log("");
+  if (usesConnectors) {
+    if (agentId) {
+      console.log(`${"Agent:".padEnd(10)}${agentId}`);
+      console.log("");
+    } else {
+      console.log(
+        "ZERO_AGENT_ID is not set, so agent authorization could not be checked.",
+      );
+      console.log("");
+    }
   }
 
   const hasBuiltInCommand = getBuiltInCommand(generationType) !== null;
@@ -584,6 +592,18 @@ export async function runLister(
 ): Promise<void> {
   const connectorGenerationType = getConnectorGenerationType(generationType);
   const agentId = process.env.ZERO_AGENT_ID;
+  if (connectorGenerationType === null) {
+    renderText({
+      generationType,
+      agentId,
+      ready: [],
+      other: [],
+      showAll: options.all === true,
+      usesConnectors: false,
+    });
+    return;
+  }
+
   const [connectorList, availableTypes, enabledTypes, platformOrigin] =
     await Promise.all([
       listZeroConnectors(),
@@ -598,22 +618,20 @@ export async function runLister(
   );
   const configuredTypes = new Set(connectorList.configuredTypes);
   const authorizedTypes = enabledTypes ? new Set(enabledTypes) : null;
-  const candidates = connectorGenerationType
-    ? getGenerationConnectors(connectorGenerationType).map(
-        ([connectorType, config]) => {
-          return toCandidate({
-            type: connectorType,
-            config,
-            connector: connectedMap.get(connectorType),
-            configuredTypes,
-            availableTypes,
-            authorizedTypes,
-            agentId,
-            platformOrigin,
-          });
-        },
-      )
-    : [];
+  const candidates = getGenerationConnectors(connectorGenerationType).map(
+    ([connectorType, config]) => {
+      return toCandidate({
+        type: connectorType,
+        config,
+        connector: connectedMap.get(connectorType),
+        configuredTypes,
+        availableTypes,
+        authorizedTypes,
+        agentId,
+        platformOrigin,
+      });
+    },
+  );
   const ready = candidates.filter((candidate) => {
     return candidate.status === "ready";
   });
@@ -626,6 +644,7 @@ export async function runLister(
     ready,
     other,
     showAll: options.all === true,
+    usesConnectors: true,
   });
 
   const shouldShowOtherHint =

--- a/turbo/apps/cli/src/commands/zero/generate/website.ts
+++ b/turbo/apps/cli/src/commands/zero/generate/website.ts
@@ -87,8 +87,8 @@ Output:
   With no --prompt and no piped input, prints the generation choices instead.
 
 Notes:
-  - Authenticates via ZERO_TOKEN
-  - The agent authors the HTML artifact and hosts it with zero host
+  - The command prints local authoring instructions and does not require authentication.
+  - The agent authors the HTML artifact and hosts it with zero host.
 
 Design Systems:
 ${formatRegistryListing(designSystems, "design systems")}


### PR DESCRIPTION
## Summary
- Skip connector API lookups for built-in-only `zero generate` choice listings such as `website`.
- Keep connector and agent hints only for generation types that actually use connectors.
- Clarify `zero generate website --help` so the no-prompt listing path is not described as requiring auth.

## Test plan
- `pnpm -F @vm0/cli exec vitest src/commands/zero/generate/__tests__/lister.test.ts src/commands/zero/generate/__tests__/website.test.ts --run`
- `pnpm format`
- `pnpm -F @vm0/cli lint`
- `pnpm -F @vm0/cli check-types`
- `pnpm -F @vm0/cli build`
- `env VM0_TOKEN= ZERO_TOKEN= node turbo/apps/cli/dist/zero.js generate website | sed -n '1,80p'`\n- `env ZERO_TOKEN=expired-zero-token VM0_TOKEN= node turbo/apps/cli/dist/zero.js generate website | sed -n '1,80p'`\n\n## Notes\n`npx -p @vm0/cli zero generate website` currently installs the published `@vm0/cli@9.184.0`, where the no-prompt listing path exits with `Not authenticated`. The prompted generation path works because it does not use the same lister code. This PR makes the built-in-only listing path local and auth-free.