### PR TITLE
fix: make replicate connector icon color explicit

### DIFF
--- a/turbo/apps/platform/src/views/zero-page/components/settings/icons/replicate.svg
+++ b/turbo/apps/platform/src/views/zero-page/components/settings/icons/replicate.svg
@@ -1,1 +1,18 @@
-<svg version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" xml:space="preserve" viewBox="0 0 1000 1000" width="32" height="32" fill="currentColor"><title>Replicate</title><g><polygon points="1000,427.6 1000,540.6 603.4,540.6 603.4,1000 477,1000 477,427.6"></polygon><polygon points="1000,213.8 1000,327 364.8,327 364.8,1000 238.4,1000 238.4,213.8"></polygon><polygon points="1000,0 1000,113.2 126.4,113.2 126.4,1000 0,1000 0,0"></polygon></g></svg>
+<svg
+  xmlns="http://www.w3.org/2000/svg"
+  viewBox="0 0 1000 1000"
+  width="32"
+  height="32"
+  fill="#000000"
+>
+  <title>Replicate</title>
+  <g>
+    <polygon
+      points="1000,427.6 1000,540.6 603.4,540.6 603.4,1000 477,1000 477,427.6"
+    />
+    <polygon
+      points="1000,213.8 1000,327 364.8,327 364.8,1000 238.4,1000 238.4,213.8"
+    />
+    <polygon points="1000,0 1000,113.2 126.4,113.2 126.4,1000 0,1000 0,0" />
+  </g>
+</svg>


### PR DESCRIPTION
## Summary

- Replace Replicate connector icon `currentColor` with explicit `#000000`.
- Keep the existing official Replicate mark geometry and square viewBox.
- Remove unused SVG metadata while preserving a pure vector asset.

Closes #16817

## Checks

- `pnpm -C turbo exec prettier --check --parser html apps/platform/src/views/zero-page/components/settings/icons/replicate.svg`
- `pnpm -C turbo -F @vm0/app lint`
