### PR TITLE
test: harden fresh usage executor cleanup

### DIFF
--- a/crates/runner/mitm-addon/tests/conftest.py
+++ b/crates/runner/mitm-addon/tests/conftest.py
@@ -16,7 +16,7 @@ Fixtures here exist for two reasons:
 import contextlib
 import json
 from collections.abc import Callable, Iterator
-from concurrent.futures import Future, ThreadPoolExecutor
+from concurrent.futures import Future
 from pathlib import Path
 from typing import Any
 from unittest.mock import AsyncMock, MagicMock, patch
@@ -32,7 +32,7 @@ import mitm_addon
 import registry
 import usage
 from tests.auth_state_helpers import clear_auth_state
-from tests.usage_helpers import UsageWebhookServer
+from tests.usage_helpers import UsageWebhookServer, fresh_usage_executor_context
 from usage.providers import connectors as _usage_connectors
 
 
@@ -398,23 +398,6 @@ def sync_usage_executor():
             usage.webhook.usage_executor = original
 
 
-@contextlib.contextmanager
-def _fresh_usage_executor_context() -> Iterator[ThreadPoolExecutor]:
-    original = usage.webhook.usage_executor
-    executor = ThreadPoolExecutor(max_workers=4, thread_name_prefix="usage-test")
-    usage.webhook.usage_executor = executor
-    try:
-        yield executor
-    finally:
-        try:
-            try:
-                usage.flush_usage_events(trigger="shutdown")
-            finally:
-                executor.shutdown(wait=True)
-        finally:
-            usage.webhook.usage_executor = original
-
-
 @pytest.fixture
 def fresh_usage_executor():
     """Swap ``usage.webhook.usage_executor`` for a throw-away pool for one test.
@@ -427,7 +410,7 @@ def fresh_usage_executor():
     ``ThreadPoolExecutor.shutdown`` is idempotent, so we always call it
     on the way out regardless of whether the test already did.
     """
-    with _fresh_usage_executor_context() as executor:
+    with fresh_usage_executor_context() as executor:
         yield executor
 
 

--- a/crates/runner/mitm-addon/tests/conftest.py
+++ b/crates/runner/mitm-addon/tests/conftest.py
@@ -398,6 +398,23 @@ def sync_usage_executor():
             usage.webhook.usage_executor = original
 
 
+@contextlib.contextmanager
+def _fresh_usage_executor_context() -> Iterator[ThreadPoolExecutor]:
+    original = usage.webhook.usage_executor
+    executor = ThreadPoolExecutor(max_workers=4, thread_name_prefix="usage-test")
+    usage.webhook.usage_executor = executor
+    try:
+        yield executor
+    finally:
+        try:
+            try:
+                usage.flush_usage_events(trigger="shutdown")
+            finally:
+                executor.shutdown(wait=True)
+        finally:
+            usage.webhook.usage_executor = original
+
+
 @pytest.fixture
 def fresh_usage_executor():
     """Swap ``usage.webhook.usage_executor`` for a throw-away pool for one test.
@@ -406,20 +423,12 @@ def fresh_usage_executor():
     reports need a fresh executor afterwards so later tests still see a
     live pool.  This fixture owns the lifecycle: a new
     :class:`ThreadPoolExecutor` is installed before the test and the
-    original is restored after.  ``ThreadPoolExecutor.shutdown`` is
-    idempotent, so we always call it on the way out regardless of
-    whether the test already did.
+    original is restored after a shutdown-triggered final flush.
+    ``ThreadPoolExecutor.shutdown`` is idempotent, so we always call it
+    on the way out regardless of whether the test already did.
     """
-    original = usage.webhook.usage_executor
-    usage.webhook.usage_executor = ThreadPoolExecutor(
-        max_workers=4, thread_name_prefix="usage-test"
-    )
-    try:
-        yield usage.webhook.usage_executor
-    finally:
-        usage.flush_usage_events(trigger="test")
-        usage.webhook.usage_executor.shutdown(wait=True)
-        usage.webhook.usage_executor = original
+    with _fresh_usage_executor_context() as executor:
+        yield executor
 
 
 @pytest.fixture

--- a/crates/runner/mitm-addon/tests/test_fresh_usage_executor.py
+++ b/crates/runner/mitm-addon/tests/test_fresh_usage_executor.py
@@ -6,7 +6,7 @@ from unittest.mock import patch
 import pytest
 
 import usage
-from tests.conftest import _fresh_usage_executor_context
+from tests.usage_helpers import fresh_usage_executor_context
 
 
 def test_fresh_usage_executor_restores_and_shuts_down_after_flush_failure():
@@ -14,7 +14,7 @@ def test_fresh_usage_executor_restores_and_shuts_down_after_flush_failure():
     executors: list[ThreadPoolExecutor] = []
 
     def use_fresh_executor() -> None:
-        with _fresh_usage_executor_context() as executor:
+        with fresh_usage_executor_context() as executor:
             assert usage.webhook.usage_executor is executor
             executors.append(executor)
 
@@ -45,7 +45,7 @@ def test_fresh_usage_executor_shuts_down_owned_executor_when_global_changes():
     try:
         with (
             patch.object(usage, "flush_usage_events", return_value=0) as flush,
-            _fresh_usage_executor_context() as executor,
+            fresh_usage_executor_context() as executor,
         ):
             executors.append(executor)
             usage.webhook.usage_executor = replacement

--- a/crates/runner/mitm-addon/tests/test_fresh_usage_executor.py
+++ b/crates/runner/mitm-addon/tests/test_fresh_usage_executor.py
@@ -1,13 +1,15 @@
 """Tests for the fresh usage executor fixture lifecycle."""
 
-from concurrent.futures import ThreadPoolExecutor
+from collections.abc import Callable
+from concurrent.futures import Future, ThreadPoolExecutor
+from typing import Any
 from unittest.mock import patch
 
 import pytest
 
 import usage
 import usage.buffer as usage_buffer
-from tests.usage_helpers import fresh_usage_executor_context
+from tests.usage_helpers import UsageWebhookServer, fresh_usage_executor_context
 
 
 def _event(source_key: str = "source-1") -> usage_buffer.UsageEvent:
@@ -18,6 +20,22 @@ def _event(source_key: str = "source-1") -> usage_buffer.UsageEvent:
         "category": "tokens.input",
         "quantity": 1,
     }
+
+
+class _RecordingExecutor:
+    def __init__(self) -> None:
+        self.submissions: list[tuple[Callable[..., Any], tuple[Any, ...], dict[str, Any]]] = []
+
+    def submit(
+        self,
+        fn: Callable[..., Any],
+        *args: Any,
+        **kwargs: Any,
+    ) -> Future[None]:
+        self.submissions.append((fn, args, kwargs))
+        future: Future[None] = Future()
+        future.set_result(None)
+        return future
 
 
 def test_fresh_usage_executor_restores_and_shuts_down_after_flush_failure(tmp_path):
@@ -52,28 +70,30 @@ def test_fresh_usage_executor_restores_and_shuts_down_after_flush_failure(tmp_pa
         executors[0].submit(lambda: None)
 
 
-def test_fresh_usage_executor_shuts_down_owned_executor_when_global_changes():
+def test_fresh_usage_executor_uses_owned_executor_when_global_changes(tmp_path):
     original = usage.webhook.usage_executor
-    replacement = ThreadPoolExecutor(
-        max_workers=1,
-        thread_name_prefix="usage-replacement-test",
-    )
+    replacement = _RecordingExecutor()
     executors: list[ThreadPoolExecutor] = []
+    server = UsageWebhookServer()
 
-    try:
-        with (
-            patch.object(usage, "flush_usage_events", wraps=usage.flush_usage_events) as flush,
-            fresh_usage_executor_context() as executor,
-        ):
-            executors.append(executor)
-            usage.webhook.usage_executor = replacement
+    with (
+        server.run(),
+        patch.object(usage, "flush_usage_events", wraps=usage.flush_usage_events) as flush,
+        fresh_usage_executor_context() as executor,
+    ):
+        executors.append(executor)
+        usage.webhook.usage_executor = replacement
+        usage.buffer_usage_events(
+            server.url(),
+            "token-a",
+            "run-1",
+            [_event()],
+            str(tmp_path / "proxy.jsonl"),
+        )
 
-        flush.assert_called_once_with(trigger="shutdown")
-        assert usage.webhook.usage_executor is original
-        with pytest.raises(RuntimeError, match="shutdown"):
-            executors[0].submit(lambda: None)
-
-        replacement_result = replacement.submit(lambda: "replacement-live")
-        assert replacement_result.result() == "replacement-live"
-    finally:
-        replacement.shutdown(wait=True)
+    flush.assert_called_once_with(trigger="shutdown")
+    assert len(server.usage_events()) == 1
+    assert replacement.submissions == []
+    assert usage.webhook.usage_executor is original
+    with pytest.raises(RuntimeError, match="shutdown"):
+        executors[0].submit(lambda: None)

--- a/crates/runner/mitm-addon/tests/test_fresh_usage_executor.py
+++ b/crates/runner/mitm-addon/tests/test_fresh_usage_executor.py
@@ -1,0 +1,61 @@
+"""Tests for the fresh usage executor fixture lifecycle."""
+
+from concurrent.futures import ThreadPoolExecutor
+from unittest.mock import patch
+
+import pytest
+
+import usage
+from tests.conftest import _fresh_usage_executor_context
+
+
+def test_fresh_usage_executor_restores_and_shuts_down_after_flush_failure():
+    original = usage.webhook.usage_executor
+    executors: list[ThreadPoolExecutor] = []
+
+    def use_fresh_executor() -> None:
+        with _fresh_usage_executor_context() as executor:
+            assert usage.webhook.usage_executor is executor
+            executors.append(executor)
+
+    with (
+        patch.object(
+            usage,
+            "flush_usage_events",
+            side_effect=RuntimeError("flush failed"),
+        ) as flush,
+        pytest.raises(RuntimeError, match="flush failed"),
+    ):
+        use_fresh_executor()
+
+    flush.assert_called_once_with(trigger="shutdown")
+    assert usage.webhook.usage_executor is original
+    with pytest.raises(RuntimeError, match="shutdown"):
+        executors[0].submit(lambda: None)
+
+
+def test_fresh_usage_executor_shuts_down_owned_executor_when_global_changes():
+    original = usage.webhook.usage_executor
+    replacement = ThreadPoolExecutor(
+        max_workers=1,
+        thread_name_prefix="usage-replacement-test",
+    )
+    executors: list[ThreadPoolExecutor] = []
+
+    try:
+        with (
+            patch.object(usage, "flush_usage_events", return_value=0) as flush,
+            _fresh_usage_executor_context() as executor,
+        ):
+            executors.append(executor)
+            usage.webhook.usage_executor = replacement
+
+        flush.assert_called_once_with(trigger="shutdown")
+        assert usage.webhook.usage_executor is original
+        with pytest.raises(RuntimeError, match="shutdown"):
+            executors[0].submit(lambda: None)
+
+        replacement_result = replacement.submit(lambda: "replacement-live")
+        assert replacement_result.result() == "replacement-live"
+    finally:
+        replacement.shutdown(wait=True)

--- a/crates/runner/mitm-addon/tests/test_fresh_usage_executor.py
+++ b/crates/runner/mitm-addon/tests/test_fresh_usage_executor.py
@@ -6,10 +6,21 @@ from unittest.mock import patch
 import pytest
 
 import usage
+import usage.buffer as usage_buffer
 from tests.usage_helpers import fresh_usage_executor_context
 
 
-def test_fresh_usage_executor_restores_and_shuts_down_after_flush_failure():
+def _event(source_key: str = "source-1") -> usage_buffer.UsageEvent:
+    return {
+        "idempotencyKey": source_key,
+        "kind": "model",
+        "provider": "claude-sonnet-4-6",
+        "category": "tokens.input",
+        "quantity": 1,
+    }
+
+
+def test_fresh_usage_executor_restores_and_shuts_down_after_flush_failure(tmp_path):
     original = usage.webhook.usage_executor
     executors: list[ThreadPoolExecutor] = []
 
@@ -17,18 +28,25 @@ def test_fresh_usage_executor_restores_and_shuts_down_after_flush_failure():
         with fresh_usage_executor_context() as executor:
             assert usage.webhook.usage_executor is executor
             executors.append(executor)
+            usage.buffer_usage_events(
+                "https://api.test/api/webhooks/agent/usage-event",
+                "token-a",
+                "run-1",
+                [_event()],
+                str(tmp_path / "proxy.jsonl"),
+            )
 
     with (
+        patch.object(usage, "flush_usage_events", wraps=usage.flush_usage_events) as flush,
         patch.object(
-            usage,
-            "flush_usage_events",
-            side_effect=RuntimeError("flush failed"),
-        ) as flush,
+            usage_buffer, "_enqueue_webhook", side_effect=RuntimeError("flush failed")
+        ) as enqueue,
         pytest.raises(RuntimeError, match="flush failed"),
     ):
         use_fresh_executor()
 
     flush.assert_called_once_with(trigger="shutdown")
+    enqueue.assert_called_once()
     assert usage.webhook.usage_executor is original
     with pytest.raises(RuntimeError, match="shutdown"):
         executors[0].submit(lambda: None)
@@ -44,7 +62,7 @@ def test_fresh_usage_executor_shuts_down_owned_executor_when_global_changes():
 
     try:
         with (
-            patch.object(usage, "flush_usage_events", return_value=0) as flush,
+            patch.object(usage, "flush_usage_events", wraps=usage.flush_usage_events) as flush,
             fresh_usage_executor_context() as executor,
         ):
             executors.append(executor)

--- a/crates/runner/mitm-addon/tests/usage_helpers.py
+++ b/crates/runner/mitm-addon/tests/usage_helpers.py
@@ -7,6 +7,7 @@ import json
 import threading
 from collections import deque
 from collections.abc import Callable, Iterator, Sequence
+from concurrent.futures import ThreadPoolExecutor
 from dataclasses import dataclass
 from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
 from typing import Any
@@ -40,6 +41,24 @@ def install_recording_usage_timer() -> list[RecordingTimer]:
 
     usage.reset_usage_buffer_for_tests(timer_enabled=True, timer_factory=timer_factory)
     return timers
+
+
+@contextlib.contextmanager
+def fresh_usage_executor_context() -> Iterator[ThreadPoolExecutor]:
+    """Install a temporary usage executor and restore the original on exit."""
+    original = usage.webhook.usage_executor
+    executor = ThreadPoolExecutor(max_workers=4, thread_name_prefix="usage-test")
+    usage.webhook.usage_executor = executor
+    try:
+        yield executor
+    finally:
+        try:
+            try:
+                usage.flush_usage_events(trigger="shutdown")
+            finally:
+                executor.shutdown(wait=True)
+        finally:
+            usage.webhook.usage_executor = original
 
 
 @dataclass(frozen=True)

--- a/crates/runner/mitm-addon/tests/usage_helpers.py
+++ b/crates/runner/mitm-addon/tests/usage_helpers.py
@@ -52,6 +52,7 @@ def fresh_usage_executor_context() -> Iterator[ThreadPoolExecutor]:
     try:
         yield executor
     finally:
+        usage.webhook.usage_executor = executor
         try:
             try:
                 usage.flush_usage_events(trigger="shutdown")


### PR DESCRIPTION
## Summary
- add a fresh usage executor context helper with shutdown-flush teardown semantics
- always shut down the captured temporary executor and restore the original global executor
- add regression coverage for flush failure cleanup and global executor replacement

Fixes #16748

## Tests
- `ruff check tests/conftest.py tests/usage_helpers.py tests/test_fresh_usage_executor.py`
- `ruff format --check tests/conftest.py tests/usage_helpers.py tests/test_fresh_usage_executor.py`
- `pytest tests/test_fresh_usage_executor.py tests/test_sync_usage_executor.py`
- `pytest tests/test_usage_buffer.py tests/test_webhook.py tests/test_model_provider_usage.py tests/test_counters.py`