### PR TITLE
fix(mitm-addon): encode connector usage idempotency keys

### DIFF
--- a/crates/runner/mitm-addon/src/usage/buffer.py
+++ b/crates/runner/mitm-addon/src/usage/buffer.py
@@ -33,7 +33,7 @@ from typing import Literal, Protocol, TypedDict
 from logging_utils import log_proxy_entry
 
 from .counters import set_buffered_usage_events
-from .idempotency import USAGE_EVENT_NAMESPACE_AGGREGATE, encode_uuid_name
+from .idempotency import USAGE_EVENT_NAMESPACE_AGGREGATE, derive_usage_idempotency_key
 from .webhook import _enqueue_webhook
 
 DEFAULT_FLUSH_INTERVAL_SECONDS = 30.0
@@ -543,23 +543,19 @@ class UsageEventBuffer:
         aggregate_key: _AggregateKey,
         flush_sequence: int,
     ) -> str:
-        return str(
-            uuid.uuid5(
-                USAGE_EVENT_NAMESPACE_AGGREGATE,
-                encode_uuid_name(
-                    (
-                        self._buffer_id,
-                        str(flush_sequence),
-                        destination.url,
-                        destination.sandbox_token,
-                        destination.proxy_log_path,
-                        aggregate_key.run_id,
-                        aggregate_key.kind,
-                        aggregate_key.provider,
-                        aggregate_key.category,
-                    )
-                ),
-            )
+        return derive_usage_idempotency_key(
+            USAGE_EVENT_NAMESPACE_AGGREGATE,
+            (
+                self._buffer_id,
+                str(flush_sequence),
+                destination.url,
+                destination.sandbox_token,
+                destination.proxy_log_path,
+                aggregate_key.run_id,
+                aggregate_key.kind,
+                aggregate_key.provider,
+                aggregate_key.category,
+            ),
         )
 
     @staticmethod

--- a/crates/runner/mitm-addon/src/usage/idempotency.py
+++ b/crates/runner/mitm-addon/src/usage/idempotency.py
@@ -24,3 +24,8 @@ USAGE_EVENT_NAMESPACE_AGGREGATE = uuid.UUID("4c4ee19a-b1b4-47e6-aef4-642d972cf4f
 
 def encode_uuid_name(parts: tuple[str, ...]) -> str:
     return "\0".join(f"{len(part.encode('utf-8'))}:{part}" for part in parts)
+
+
+def derive_usage_idempotency_key(namespace: uuid.UUID, parts: tuple[str, ...]) -> str:
+    """Return the stable UUIDv5 usage key for length-prefixed name parts."""
+    return str(uuid.uuid5(namespace, encode_uuid_name(parts)))

--- a/crates/runner/mitm-addon/src/usage/providers/connectors/x.py
+++ b/crates/runner/mitm-addon/src/usage/providers/connectors/x.py
@@ -7,7 +7,6 @@ through the X firewall and buffers them for aggregate platform upload.
 import json
 import re
 import urllib.parse
-import uuid
 from collections.abc import Callable, Iterable
 from typing import Literal, NamedTuple, TypedDict
 
@@ -19,7 +18,7 @@ from auth import get_api_url
 from logging_utils import log_proxy_entry
 
 from ...buffer import UsageEvent, buffer_usage_events
-from ...idempotency import USAGE_EVENT_NAMESPACE_CONNECTOR
+from ...idempotency import USAGE_EVENT_NAMESPACE_CONNECTOR, derive_usage_idempotency_key
 from ...json_selective import JsonExtractionResult, JsonSelectiveExtractor, ScalarField
 from .response_parser import ConnectorResponseParser
 from .x_billing import (
@@ -866,11 +865,9 @@ def report_usage(flow: http.HTTPFlow, run_id: str, original_url: str) -> None:
     for category, qty in billable_counts.items():
         # UUIDv5 from stable source inputs. The usage buffer uses this key to
         # dedupe duplicate response/error observations before aggregation.
-        idempotency_key = str(
-            uuid.uuid5(
-                USAGE_EVENT_NAMESPACE_CONNECTOR,
-                f"{run_id}:{flow.id}:{category}",
-            )
+        idempotency_key = derive_usage_idempotency_key(
+            USAGE_EVENT_NAMESPACE_CONNECTOR,
+            (run_id, flow.id, category),
         )
         events.append(
             {

--- a/crates/runner/mitm-addon/src/usage/providers/model_provider.py
+++ b/crates/runner/mitm-addon/src/usage/providers/model_provider.py
@@ -27,7 +27,7 @@ from ..buffer import UsageEvent, buffer_model_usage_observations, buffer_usage_e
 from ..idempotency import (
     USAGE_EVENT_NAMESPACE_MODEL,
     USAGE_OBSERVATION_NAMESPACE_MODEL,
-    encode_uuid_name,
+    derive_usage_idempotency_key,
 )
 from ..model_tokens import MODEL_USAGE_CATEGORIES
 
@@ -150,7 +150,10 @@ def _build_usage_events(
             continue
         events.append(
             {
-                "idempotencyKey": _derive_idempotency_key(namespace, run_id, source_id, category),
+                "idempotencyKey": derive_usage_idempotency_key(
+                    namespace,
+                    (run_id, source_id, category),
+                ),
                 "kind": MODEL_USAGE_KIND,
                 "provider": provider,
                 "category": category,
@@ -158,17 +161,6 @@ def _build_usage_events(
             }
         )
     return events
-
-
-def _derive_idempotency_key(
-    namespace: uuid.UUID, run_id: str, source_id: str, category: str
-) -> str:
-    return str(
-        uuid.uuid5(
-            namespace,
-            encode_uuid_name((run_id, source_id, category)),
-        )
-    )
 
 
 def _reported_model(flow: http.HTTPFlow, usage: dict) -> str:

--- a/crates/runner/mitm-addon/tests/test_usage_idempotency.py
+++ b/crates/runner/mitm-addon/tests/test_usage_idempotency.py
@@ -9,6 +9,7 @@ from usage.idempotency import (
     USAGE_EVENT_NAMESPACE_CONNECTOR,
     USAGE_EVENT_NAMESPACE_MODEL,
     USAGE_OBSERVATION_NAMESPACE_MODEL,
+    derive_usage_idempotency_key,
     encode_uuid_name,
 )
 
@@ -55,11 +56,47 @@ def test_encode_uuid_name_outputs_unique_uuid5_names_for_diverse_parts():
 
 def test_model_usage_idempotency_key_is_stable():
     assert (
-        str(
-            uuid.uuid5(
-                USAGE_EVENT_NAMESPACE_MODEL,
-                encode_uuid_name(("run-abc-123", "msg-usage-1", "tokens.input")),
-            )
+        derive_usage_idempotency_key(
+            USAGE_EVENT_NAMESPACE_MODEL,
+            ("run-abc-123", "msg-usage-1", "tokens.input"),
         )
         == "9461ab1d-30a7-5268-b8f1-84bb9152f7ba"
     )
+
+
+def test_model_usage_observation_idempotency_key_is_stable():
+    assert (
+        derive_usage_idempotency_key(
+            USAGE_OBSERVATION_NAMESPACE_MODEL,
+            ("run-abc-123", "msg-usage-1", "tokens.input"),
+        )
+        == "3a2e5512-9481-5f10-926b-3c35b487f71d"
+    )
+
+
+def test_connector_usage_idempotency_key_is_stable():
+    assert (
+        derive_usage_idempotency_key(
+            USAGE_EVENT_NAMESPACE_CONNECTOR,
+            ("run-abc-123", "flow-usage-1", "posts.read"),
+        )
+        == "73cfa2a9-1abd-5d93-b88d-89a46073fbde"
+    )
+
+
+def test_connector_usage_idempotency_key_uses_unambiguous_parts():
+    left_parts = ("run:a", "flow", "posts.read")
+    right_parts = ("run", "a:flow", "posts.read")
+
+    assert ":".join(left_parts) == ":".join(right_parts)
+    assert uuid.uuid5(USAGE_EVENT_NAMESPACE_CONNECTOR, ":".join(left_parts)) == uuid.uuid5(
+        USAGE_EVENT_NAMESPACE_CONNECTOR,
+        ":".join(right_parts),
+    )
+
+    left_key = derive_usage_idempotency_key(USAGE_EVENT_NAMESPACE_CONNECTOR, left_parts)
+    right_key = derive_usage_idempotency_key(USAGE_EVENT_NAMESPACE_CONNECTOR, right_parts)
+
+    assert left_key == "d59389eb-4f6d-5984-bfb1-c613cae770eb"
+    assert right_key == "23f606d4-2176-5ee8-addd-78bea9b15c77"
+    assert left_key != right_key

--- a/crates/runner/mitm-addon/tests/test_x_connector_usage.py
+++ b/crates/runner/mitm-addon/tests/test_x_connector_usage.py
@@ -157,6 +157,31 @@ class TestXConnectorUsage:
         assert by_cat["posts.read"]["quantity"] == 1
         assert by_cat["user.read"]["quantity"] == 1
 
+    def test_source_dedupe_handles_colon_bearing_run_and_flow_ids(self, tmp_path, real_flow):
+        body = json.dumps({"data": {"id": "1", "text": "hi"}}).encode()
+        first = self._make_x_flow(
+            real_flow, tmp_path, path="/2/tweets/1", body=body, rule="GET /2/tweets/{id}"
+        )
+        second = self._make_x_flow(
+            real_flow, tmp_path, path="/2/tweets/2", body=body, rule="GET /2/tweets/{id}"
+        )
+        first.id = "flow"
+        second.id = "a:flow"
+
+        with self._usage_webhook_api() as webhook:
+            usage.report_connector_usage(first, "run:a")
+            usage.report_connector_usage(second, "run")
+            usage.flush_usage_events(trigger="test")
+
+        events_by_run = {body["runId"]: body["events"] for body in webhook.json_bodies()}
+        assert set(events_by_run) == {"run", "run:a"}
+        assert sum(event["quantity"] for events in events_by_run.values() for event in events) == 2
+        assert {
+            (event["kind"], event["provider"], event["category"], event["quantity"])
+            for events in events_by_run.values()
+            for event in events
+        } == {("connector", "x", "posts.read", 1)}
+
     def test_bounds_unknown_include_categories_before_buffering(self, tmp_path, real_flow):
         """Unknown includes cannot create unbounded synthetic usage categories."""
         body = json.dumps(


### PR DESCRIPTION
## Summary

- add a shared `derive_usage_idempotency_key` helper for UUIDv5 usage keys
- route model, observation, aggregate, and X connector key derivation through the shared helper
- switch X connector source keys from colon-joined names to length-prefixed encoded parts
- add protocol and X connector regression coverage for colon-bearing source parts

Closes #16747

## Testing

- `cd crates/runner/mitm-addon && .venv/bin/python -m pytest tests/test_usage_idempotency.py`
- `cd crates/runner/mitm-addon && .venv/bin/python -m pytest tests/test_x_connector_usage.py`
- `cd crates/runner/mitm-addon && .venv/bin/python -m pytest tests/test_model_provider_usage.py`
- `cd crates/runner/mitm-addon && .venv/bin/python -m pytest tests/test_usage_buffer.py`
- `cd crates/runner/mitm-addon && .venv/bin/ruff check src/usage/idempotency.py src/usage/buffer.py src/usage/providers/model_provider.py src/usage/providers/connectors/x.py tests/test_usage_idempotency.py tests/test_x_connector_usage.py`
- `cd crates/runner/mitm-addon && .venv/bin/ruff format --check src/usage/idempotency.py src/usage/buffer.py src/usage/providers/model_provider.py src/usage/providers/connectors/x.py tests/test_usage_idempotency.py tests/test_x_connector_usage.py`
- `cd crates/runner/mitm-addon && .venv/bin/basedpyright src/usage/idempotency.py src/usage/buffer.py src/usage/providers/model_provider.py src/usage/providers/connectors/x.py tests/test_usage_idempotency.py tests/test_x_connector_usage.py`
- `cd crates/runner/mitm-addon && .venv/bin/python -m pytest tests/ --ignore=tests/test_x_billing.py`

`tests/test_x_billing.py` was excluded from the full addon run because `turbo/packages/connectors/src/firewalls/netdata.generated.ts` is missing in this workspace.

Pre-commit hooks also passed after running commit with the mitm-addon virtualenv on `PATH`.