### PR TITLE
fix: stabilize artifact download menu

### DIFF
--- a/turbo/apps/platform/src/signals/zero-page/zero-artifact-actions.ts
+++ b/turbo/apps/platform/src/signals/zero-page/zero-artifact-actions.ts
@@ -1,47 +1,17 @@
 import { command, computed, state } from "ccstate";
 
-const ARTIFACT_DOWNLOAD_MENU_CLOSE_DELAY_MS = 80;
-
 const internalArtifactDownloadMenuOpenKey$ = state<string | null>(null);
-const internalArtifactDownloadMenuCloseToken$ = state(0);
 
 export const artifactDownloadMenuOpenKey$ = computed((get) => {
   return get(internalArtifactDownloadMenuOpenKey$);
 });
 
-const closeArtifactDownloadMenuForToken$ = command(
-  ({ get, set }, value: { key: string; token: number }) => {
-    if (get(internalArtifactDownloadMenuCloseToken$) !== value.token) {
-      return;
-    }
-    if (get(internalArtifactDownloadMenuOpenKey$) === value.key) {
-      set(internalArtifactDownloadMenuOpenKey$, null);
-    }
-  },
-);
-
 export const openArtifactDownloadMenu$ = command(
   ({ set }, key: string | null) => {
-    set(internalArtifactDownloadMenuCloseToken$, (value) => {
-      return value + 1;
-    });
     set(internalArtifactDownloadMenuOpenKey$, key);
   },
 );
 
 export const closeArtifactDownloadMenu$ = command(({ set }) => {
-  set(internalArtifactDownloadMenuCloseToken$, (value) => {
-    return value + 1;
-  });
   set(internalArtifactDownloadMenuOpenKey$, null);
 });
-
-export const scheduleArtifactDownloadMenuClose$ = command(
-  ({ get, set }, key: string) => {
-    const token = get(internalArtifactDownloadMenuCloseToken$) + 1;
-    set(internalArtifactDownloadMenuCloseToken$, token);
-    window.setTimeout(() => {
-      set(closeArtifactDownloadMenuForToken$, { key, token });
-    }, ARTIFACT_DOWNLOAD_MENU_CLOSE_DELAY_MS);
-  },
-);

--- a/turbo/apps/platform/src/views/zero-page/__tests__/zero-chat-thread-page-display.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/zero-chat-thread-page-display.test.tsx
@@ -1514,9 +1514,14 @@ describe("zero chat thread page display - attachment video preview", () => {
     expect(video).toHaveAttribute("controls");
     expect((video as HTMLVideoElement).autoplay).toBeTruthy();
     expect(within(lightbox).getByLabelText("Share")).toBeInTheDocument();
-    expect(
-      within(lightbox).getByLabelText("Download options"),
-    ).toBeInTheDocument();
+    const downloadOptions = within(lightbox).getByLabelText("Download options");
+    expect(downloadOptions).toBeInTheDocument();
+    await userEvent.hover(downloadOptions);
+    expect(queryRoleByText("menuitem", "Download")).toBeUndefined();
+    await userEvent.click(downloadOptions);
+    await waitFor(() => {
+      expect(getRoleByText("menuitem", "Download")).toBeInTheDocument();
+    });
   });
 
   it("uses the padded artifact dialog stage for video previews", async () => {
@@ -2391,12 +2396,24 @@ describe("zero chat thread page display - artifact sidebar", () => {
 
     const downloadButton = screen.getByLabelText("Download artifact");
     await user.hover(downloadButton);
+    expect(
+      queryRoleByText("menuitem", "Upload to Google Drive"),
+    ).toBeUndefined();
+
+    await user.click(downloadButton);
     await waitFor(() => {
       expect(
         getRoleByText("menuitem", "Upload to Google Drive"),
       ).toBeInTheDocument();
     });
     fireEvent.pointerLeave(downloadButton);
+    await waitFor(() => {
+      expect(
+        getRoleByText("menuitem", "Upload to Google Drive"),
+      ).toBeInTheDocument();
+    });
+
+    await user.click(downloadButton);
     await waitFor(() => {
       expect(
         queryRoleByText("menuitem", "Upload to Google Drive"),

--- a/turbo/apps/platform/src/views/zero-page/__tests__/zero-chat-thread-page-display.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/zero-chat-thread-page-display.test.tsx
@@ -2498,6 +2498,62 @@ describe("zero chat thread page display - artifact sidebar", () => {
     expect(queryRoleByText("menuitem", "Download (.pptx)")).toBeUndefined();
   });
 
+  it("closes the artifact download menu from the dismiss layer above iframe previews", async () => {
+    const user = userEvent.setup();
+    const fileUrl = "https://example.com/report.html";
+    mockChatLifecycle({
+      chatMessages: [
+        {
+          role: "assistant",
+          content: "Generated report",
+          runId: "run-html-artifact",
+          createdAt: "2026-03-10T00:00:00Z",
+        },
+      ],
+    });
+    server.use(
+      mockApi(chatThreadArtifactsContract.list, ({ respond }) => {
+        return respond(200, {
+          runs: [
+            {
+              runId: "run-html-artifact",
+              files: [
+                {
+                  id: fileUrl,
+                  filename: "report.html",
+                  contentType: "text/html",
+                  size: 1024,
+                  url: fileUrl,
+                  createdAt: "2026-03-10T00:00:00Z",
+                },
+              ],
+            },
+          ],
+        });
+      }),
+    );
+
+    detachedSetupPage({
+      context,
+      path: "/chats/thread-test-1",
+    });
+
+    click(await screen.findByLabelText("Open artifacts"));
+    await user.click(await screen.findByLabelText("Open artifact report.html"));
+    const sidebar = await screen.findByTestId("artifact-sidebar");
+    await user.click(within(sidebar).getByLabelText("Download artifact"));
+
+    await waitFor(() => {
+      expect(queryRoleByText("menuitem", "Download")).toBeInTheDocument();
+    });
+    await user.click(
+      screen.getByTestId("artifact-download-menu-dismiss-layer"),
+    );
+    await waitFor(() => {
+      expect(queryRoleByText("menuitem", "Download")).toBeUndefined();
+    });
+  });
+
   it("ignores presentation editor query when the feature switch is disabled", async () => {
     const fileUrl = "https://demo-deck.sites.vm0.io";
     mockChatLifecycle({

--- a/turbo/apps/platform/src/views/zero-page/__tests__/zero-chat-thread-page-display.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/zero-chat-thread-page-display.test.tsx
@@ -2541,6 +2541,9 @@ describe("zero chat thread page display - artifact sidebar", () => {
     click(await screen.findByLabelText("Open artifacts"));
     await user.click(await screen.findByLabelText("Open artifact report.html"));
     const sidebar = await screen.findByTestId("artifact-sidebar");
+    const openExternal = within(sidebar).getByLabelText("Open in new tab");
+    expect(openExternal).toHaveAttribute("href", fileUrl);
+    expect(openExternal).toHaveAttribute("target", "_blank");
     await user.click(within(sidebar).getByLabelText("Download artifact"));
 
     await waitFor(() => {

--- a/turbo/apps/platform/src/views/zero-page/zero-artifact-actions.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-artifact-actions.tsx
@@ -7,8 +7,8 @@ import {
 import {
   cn,
   Popover,
-  PopoverAnchor,
   PopoverContent,
+  PopoverTrigger,
   Tooltip,
   TooltipContent,
   TooltipProvider,
@@ -32,7 +32,6 @@ import {
   artifactDownloadMenuOpenKey$,
   closeArtifactDownloadMenu$,
   openArtifactDownloadMenu$,
-  scheduleArtifactDownloadMenuClose$,
 } from "../../signals/zero-page/zero-artifact-actions.ts";
 import {
   type ArtifactGoogleDriveSyncFile,
@@ -288,11 +287,9 @@ function ArtifactDownloadMenuItem({
 
 function GoogleDriveMenuItem({
   closeMenu,
-  onHover,
   syncTarget,
 }: {
   closeMenu: () => void;
-  onHover: () => void;
   syncTarget?: ArtifactDownloadSyncTarget;
 }) {
   const connectorList = useLastResolved(connectors$);
@@ -369,14 +366,9 @@ function GoogleDriveMenuItem({
   }
 
   return (
-    <div
-      className="group/google-drive-connect relative"
-      onPointerEnter={onHover}
-    >
+    <div className="group/google-drive-connect relative">
       <ArtifactDownloadMenuItem
         className="text-muted-foreground"
-        onFocus={onHover}
-        onPointerEnter={onHover}
         onClick={syncOrConnect}
       >
         <IconBrandGoogleDrive size={14} stroke={1.5} />
@@ -420,7 +412,6 @@ export function ArtifactDownloadMenu({
   const openKey = useGet(artifactDownloadMenuOpenKey$);
   const openMenu = useSet(openArtifactDownloadMenu$);
   const closeMenu = useSet(closeArtifactDownloadMenu$);
-  const scheduleCloseMenu = useSet(scheduleArtifactDownloadMenuClose$);
   const pageSignal = useGet(pageSignal$);
   const features = useLastResolved(featureSwitch$);
   const open = openKey === menuKey;
@@ -432,14 +423,6 @@ export function ArtifactDownloadMenu({
     filename,
     url,
   );
-  const show = () => {
-    openMenu(menuKey);
-  };
-
-  const hide = () => {
-    scheduleCloseMenu(menuKey);
-  };
-
   const closeNow = () => {
     closeMenu();
   };
@@ -456,22 +439,17 @@ export function ArtifactDownloadMenu({
         closeMenu();
       }}
     >
-      <PopoverAnchor asChild>
+      <PopoverTrigger asChild>
         <button
           type="button"
           aria-label={ariaLabel}
           aria-haspopup="menu"
           aria-expanded={open}
           className={iconButtonClassName(className)}
-          onPointerEnter={show}
-          onPointerLeave={hide}
-          onFocus={show}
-          onBlur={hide}
-          onClick={show}
         >
           <IconDownload size={iconSize} stroke={1.5} />
         </button>
-      </PopoverAnchor>
+      </PopoverTrigger>
       <PopoverContent
         role="menu"
         align={align}
@@ -483,10 +461,6 @@ export function ArtifactDownloadMenu({
         onCloseAutoFocus={(event) => {
           event.preventDefault();
         }}
-        onPointerEnter={show}
-        onPointerLeave={hide}
-        onFocus={show}
-        onBlur={hide}
         className={cn(
           "pointer-events-auto w-56 p-1",
           ARTIFACT_FLOATING_LAYER_CLASS,
@@ -520,11 +494,7 @@ export function ArtifactDownloadMenu({
             Download (.pptx)
           </ArtifactDownloadMenuItem>
         )}
-        <GoogleDriveMenuItem
-          closeMenu={closeNow}
-          onHover={show}
-          syncTarget={syncTarget}
-        />
+        <GoogleDriveMenuItem closeMenu={closeNow} syncTarget={syncTarget} />
       </PopoverContent>
     </Popover>
   );

--- a/turbo/apps/platform/src/views/zero-page/zero-artifact-actions.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-artifact-actions.tsx
@@ -8,6 +8,7 @@ import {
   cn,
   Popover,
   PopoverContent,
+  PopoverOverlay,
   PopoverTrigger,
   Tooltip,
   TooltipContent,
@@ -450,6 +451,13 @@ export function ArtifactDownloadMenu({
           <IconDownload size={iconSize} stroke={1.5} />
         </button>
       </PopoverTrigger>
+      {open && (
+        <PopoverOverlay
+          data-testid="artifact-download-menu-dismiss-layer"
+          aria-label="Close download menu"
+          className="z-[9999]"
+        />
+      )}
       <PopoverContent
         role="menu"
         align={align}

--- a/turbo/apps/platform/src/views/zero-page/zero-artifact-sidebar.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-artifact-sidebar.tsx
@@ -5,6 +5,7 @@ import {
   IconArrowsDiagonal,
   IconArrowsDiagonalMinimize2,
   IconDots,
+  IconExternalLink,
   IconLoader2,
   IconPencil,
   IconZoomReset,
@@ -250,6 +251,7 @@ function ArtifactSidebarContent({
     >
       <ArtifactSidebarHeader
         title={display.filename}
+        kind={display.kind}
         artifactKind={display.artifactKind}
         subtitle={display.subtitle}
         syncTarget={syncTarget}
@@ -359,6 +361,7 @@ function resolveArtifactDisplay(
 
 function ArtifactSidebarHeader({
   title,
+  kind,
   artifactKind,
   subtitle,
   syncTarget,
@@ -370,6 +373,7 @@ function ArtifactSidebarHeader({
   onClose,
 }: {
   title: string;
+  kind?: ArtifactKindForBody;
   artifactKind?: ChatThreadArtifactFile["artifactKind"];
   subtitle: string;
   syncTarget?: ArtifactDownloadSyncTarget;
@@ -408,6 +412,7 @@ function ArtifactSidebarHeader({
         compactActions={compactActions}
         artifactKind={artifactKind}
         fullscreen={fullscreen}
+        kind={kind}
         onClose={onClose}
         onEditPresentation={onEditPresentation}
         onToggleFullscreen={onToggleFullscreen}
@@ -423,6 +428,7 @@ function ArtifactSidebarActions({
   artifactKind,
   compactActions,
   fullscreen,
+  kind,
   onClose,
   onEditPresentation,
   onToggleFullscreen,
@@ -433,6 +439,7 @@ function ArtifactSidebarActions({
   artifactKind?: ChatThreadArtifactFile["artifactKind"];
   compactActions: boolean;
   fullscreen: boolean;
+  kind?: ArtifactKindForBody;
   onClose: () => void;
   onEditPresentation?: () => void;
   onToggleFullscreen: () => void;
@@ -450,6 +457,7 @@ function ArtifactSidebarActions({
     <div className="flex shrink-0 items-center gap-1">
       {url && (
         <>
+          {kind === "html" && <ArtifactOpenExternalAction url={url} />}
           <ArtifactShareButton ariaLabel="Share artifact" url={url} />
           <ArtifactDownloadMenu
             ariaLabel="Download artifact"
@@ -490,6 +498,21 @@ function ArtifactEditPresentationAction({ onClick }: { onClick: () => void }) {
     >
       <IconPencil size={16} stroke={1.5} />
     </button>
+  );
+}
+
+function ArtifactOpenExternalAction({ url }: { url: string }) {
+  return (
+    <a
+      href={publicAttachmentUrl(url)}
+      target="_blank"
+      rel="noopener noreferrer"
+      aria-label="Open in new tab"
+      data-testid="artifact-sidebar-open-external"
+      className="inline-flex h-8 w-8 items-center justify-center rounded-md text-muted-foreground hover:bg-muted/60 hover:text-foreground"
+    >
+      <IconExternalLink size={16} />
+    </a>
   );
 }
 

--- a/turbo/apps/platform/src/views/zero-page/zero-artifact-sidebar.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-artifact-sidebar.tsx
@@ -5,7 +5,6 @@ import {
   IconArrowsDiagonal,
   IconArrowsDiagonalMinimize2,
   IconDots,
-  IconExternalLink,
   IconLoader2,
   IconPencil,
   IconZoomReset,
@@ -251,7 +250,6 @@ function ArtifactSidebarContent({
     >
       <ArtifactSidebarHeader
         title={display.filename}
-        kind={display.kind}
         artifactKind={display.artifactKind}
         subtitle={display.subtitle}
         syncTarget={syncTarget}
@@ -361,7 +359,6 @@ function resolveArtifactDisplay(
 
 function ArtifactSidebarHeader({
   title,
-  kind,
   artifactKind,
   subtitle,
   syncTarget,
@@ -373,7 +370,6 @@ function ArtifactSidebarHeader({
   onClose,
 }: {
   title: string;
-  kind?: ArtifactKindForBody;
   artifactKind?: ChatThreadArtifactFile["artifactKind"];
   subtitle: string;
   syncTarget?: ArtifactDownloadSyncTarget;
@@ -412,7 +408,6 @@ function ArtifactSidebarHeader({
         compactActions={compactActions}
         artifactKind={artifactKind}
         fullscreen={fullscreen}
-        kind={kind}
         onClose={onClose}
         onEditPresentation={onEditPresentation}
         onToggleFullscreen={onToggleFullscreen}
@@ -428,7 +423,6 @@ function ArtifactSidebarActions({
   artifactKind,
   compactActions,
   fullscreen,
-  kind,
   onClose,
   onEditPresentation,
   onToggleFullscreen,
@@ -439,7 +433,6 @@ function ArtifactSidebarActions({
   artifactKind?: ChatThreadArtifactFile["artifactKind"];
   compactActions: boolean;
   fullscreen: boolean;
-  kind?: ArtifactKindForBody;
   onClose: () => void;
   onEditPresentation?: () => void;
   onToggleFullscreen: () => void;
@@ -457,7 +450,6 @@ function ArtifactSidebarActions({
     <div className="flex shrink-0 items-center gap-1">
       {url && (
         <>
-          {kind === "html" && <ArtifactOpenExternalAction url={url} />}
           <ArtifactShareButton ariaLabel="Share artifact" url={url} />
           <ArtifactDownloadMenu
             ariaLabel="Download artifact"
@@ -498,21 +490,6 @@ function ArtifactEditPresentationAction({ onClick }: { onClick: () => void }) {
     >
       <IconPencil size={16} stroke={1.5} />
     </button>
-  );
-}
-
-function ArtifactOpenExternalAction({ url }: { url: string }) {
-  return (
-    <a
-      href={publicAttachmentUrl(url)}
-      target="_blank"
-      rel="noopener noreferrer"
-      aria-label="Open in new tab"
-      data-testid="artifact-sidebar-open-external"
-      className="inline-flex h-8 w-8 items-center justify-center rounded-md text-muted-foreground hover:bg-muted/60 hover:text-foreground"
-    >
-      <IconExternalLink size={16} />
-    </a>
   );
 }
 

--- a/turbo/packages/ui/src/components/ui/popover.tsx
+++ b/turbo/packages/ui/src/components/ui/popover.tsx
@@ -13,6 +13,41 @@ const PopoverAnchor = PopoverPrimitive.Anchor;
 
 const PopoverClose = PopoverPrimitive.Close;
 
+const PopoverOverlay = React.forwardRef<
+  HTMLButtonElement,
+  React.ComponentPropsWithoutRef<"button">
+>(
+  (
+    {
+      "aria-label": ariaLabel = "Close popover",
+      className,
+      tabIndex = -1,
+      type = "button",
+      ...props
+    },
+    ref,
+  ) => {
+    return (
+      <PopoverPrimitive.Portal>
+        <PopoverPrimitive.Close asChild>
+          <button
+            ref={ref}
+            type={type}
+            tabIndex={tabIndex}
+            aria-label={ariaLabel}
+            className={cn(
+              "fixed inset-0 z-40 cursor-default appearance-none border-0 bg-transparent p-0 outline-none",
+              className,
+            )}
+            {...props}
+          />
+        </PopoverPrimitive.Close>
+      </PopoverPrimitive.Portal>
+    );
+  },
+);
+PopoverOverlay.displayName = "PopoverOverlay";
+
 const PopoverContent = React.forwardRef<
   React.ComponentRef<typeof PopoverPrimitive.Content>,
   React.ComponentPropsWithoutRef<typeof PopoverPrimitive.Content>
@@ -39,4 +74,11 @@ const PopoverContent = React.forwardRef<
 });
 PopoverContent.displayName = PopoverPrimitive.Content.displayName;
 
-export { Popover, PopoverTrigger, PopoverContent, PopoverAnchor, PopoverClose };
+export {
+  Popover,
+  PopoverTrigger,
+  PopoverContent,
+  PopoverAnchor,
+  PopoverClose,
+  PopoverOverlay,
+};

--- a/turbo/packages/ui/src/index.ts
+++ b/turbo/packages/ui/src/index.ts
@@ -48,6 +48,7 @@ export {
   PopoverContent,
   PopoverAnchor,
   PopoverClose,
+  PopoverOverlay,
 } from "./components/ui/popover";
 export {
   Select,


### PR DESCRIPTION
## Summary
- make the artifact download control behave as a click-triggered menu button
- remove hover/focus open behavior and delayed pointer-leave close behavior
- add regression coverage for modal and sidebar artifact download menus

## Validation
- `pnpm -F @vm0/app exec vitest run src/views/zero-page/__tests__/zero-chat-thread-page-display.test.tsx`
- `pnpm format`
- `pnpm -F @vm0/app lint`
- `pnpm -F @vm0/app check-types`
- `pnpm turbo run lint`
- `pnpm check-types`
- `pnpm knip`
- `pnpm vitest` (fails locally only in `@vm0/desktop src/computer-use-native.test.ts`: 4 macOS native accessibility CLI cases report `accessibility_unavailable: Desktop Computer Use is currently implemented for macOS`; remaining 10542 tests passed)

Addresses #16600