### PR TITLE
feat: add staged connector permission reset

### DIFF
--- a/turbo/apps/api/src/signals/routes/__tests__/zero-user-permission-grants.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/zero-user-permission-grants.test.ts
@@ -5,8 +5,10 @@ import { and, eq, inArray } from "drizzle-orm";
 import { afterEach, describe, expect, it } from "vitest";
 
 import { zeroUserPermissionGrantsContract } from "@vm0/api-contracts/contracts/zero-user-permission-grants";
+import { FeatureSwitchKey } from "@vm0/connectors/feature-switch-key";
 import { UNKNOWN_PERMISSION_GRANT } from "@vm0/connectors/firewall-types";
 import { permissionGrantsToFirewallPolicies } from "@vm0/connectors/firewalls";
+import { userFeatureSwitches } from "@vm0/db/schema/user-feature-switches";
 import { userPermissionGrants } from "@vm0/db/schema/user-permission-grant";
 
 import { accept, setupApp, testContext } from "../../../__tests__/test-helpers";
@@ -93,6 +95,18 @@ async function readStoredGrant(args: {
   return row ?? null;
 }
 
+async function enableConnectorPermissionReset(args: {
+  readonly orgId: string;
+  readonly userId: string;
+}): Promise<void> {
+  const db = store.set(writeDb$);
+  await db.insert(userFeatureSwitches).values({
+    orgId: args.orgId,
+    userId: args.userId,
+    switches: { [FeatureSwitchKey.ConnectorPermissionReset]: true },
+  });
+}
+
 describe("zero user permission grants", () => {
   const fixtures: UsageInsightFixture[] = [];
   const trackedOrgIds: string[] = [];
@@ -122,6 +136,9 @@ describe("zero user permission grants", () => {
       await db
         .delete(userPermissionGrants)
         .where(inArray(userPermissionGrants.orgId, trackedOrgIds));
+      await db
+        .delete(userFeatureSwitches)
+        .where(inArray(userFeatureSwitches.orgId, trackedOrgIds));
       trackedOrgIds.length = 0;
     }
 
@@ -365,6 +382,193 @@ describe("zero user permission grants", () => {
       }),
     });
     expect(askResponse.status).toBe(400);
+  });
+
+  it("rejects connector reset when the feature switch is disabled", async () => {
+    const fixture = await createFixture();
+    const agentId = await seedAgent(fixture);
+    mocks.clerk.session(fixture.userId, fixture.orgId, "org:member");
+    const db = store.set(writeDb$);
+    await db.insert(userPermissionGrants).values({
+      orgId: fixture.orgId,
+      userId: fixture.userId,
+      agentId,
+      connectorRef: SLACK_CONNECTOR,
+      permission: SLACK_READ_PERMISSION,
+      action: "deny",
+    });
+    const client = setupApp({ context })(zeroUserPermissionGrantsContract);
+
+    const response = await accept(
+      client.reset({
+        query: { agentId, connectorRef: SLACK_CONNECTOR },
+        headers: AUTH_HEADERS,
+      }),
+      [403],
+    );
+
+    expect(response.body.error.code).toBe("FORBIDDEN");
+    const stored = await readStoredGrant({
+      orgId: fixture.orgId,
+      userId: fixture.userId,
+      agentId,
+      connectorRef: SLACK_CONNECTOR,
+      permission: SLACK_READ_PERMISSION,
+    });
+    expect(stored?.action).toBe("deny");
+  });
+
+  it("resets only the current user's selected connector grants", async () => {
+    const fixture = await createFixture();
+    const otherUserId = `user_${randomUUID()}`;
+    await seedMember({ orgId: fixture.orgId, userId: otherUserId });
+    const agentId = await seedAgent(fixture);
+    const otherAgentId = await seedAgent(fixture);
+    await enableConnectorPermissionReset(fixture);
+    mocks.clerk.session(fixture.userId, fixture.orgId, "org:member");
+    const db = store.set(writeDb$);
+    await db.insert(userPermissionGrants).values([
+      {
+        orgId: fixture.orgId,
+        userId: fixture.userId,
+        agentId,
+        connectorRef: SLACK_CONNECTOR,
+        permission: SLACK_READ_PERMISSION,
+        action: "deny",
+      },
+      {
+        orgId: fixture.orgId,
+        userId: fixture.userId,
+        agentId,
+        connectorRef: SLACK_CONNECTOR,
+        permission: SLACK_WRITE_PERMISSION,
+        action: "deny",
+      },
+      {
+        orgId: fixture.orgId,
+        userId: fixture.userId,
+        agentId,
+        connectorRef: "notion",
+        permission: "read_content",
+        action: "deny",
+      },
+      {
+        orgId: fixture.orgId,
+        userId: otherUserId,
+        agentId,
+        connectorRef: SLACK_CONNECTOR,
+        permission: SLACK_READ_PERMISSION,
+        action: "allow",
+      },
+      {
+        orgId: fixture.orgId,
+        userId: fixture.userId,
+        agentId: otherAgentId,
+        connectorRef: SLACK_CONNECTOR,
+        permission: SLACK_READ_PERMISSION,
+        action: "deny",
+      },
+    ]);
+    const client = setupApp({ context })(zeroUserPermissionGrantsContract);
+
+    await accept(
+      client.reset({
+        query: { agentId, connectorRef: SLACK_CONNECTOR },
+        headers: AUTH_HEADERS,
+      }),
+      [204],
+    );
+
+    await expect(
+      readStoredGrant({
+        orgId: fixture.orgId,
+        userId: fixture.userId,
+        agentId,
+        connectorRef: SLACK_CONNECTOR,
+        permission: SLACK_READ_PERMISSION,
+      }),
+    ).resolves.toBeNull();
+    await expect(
+      readStoredGrant({
+        orgId: fixture.orgId,
+        userId: fixture.userId,
+        agentId,
+        connectorRef: SLACK_CONNECTOR,
+        permission: SLACK_WRITE_PERMISSION,
+      }),
+    ).resolves.toBeNull();
+    await expect(
+      readStoredGrant({
+        orgId: fixture.orgId,
+        userId: fixture.userId,
+        agentId,
+        connectorRef: "notion",
+        permission: "read_content",
+      }),
+    ).resolves.toMatchObject({ action: "deny" });
+    await expect(
+      readStoredGrant({
+        orgId: fixture.orgId,
+        userId: otherUserId,
+        agentId,
+        connectorRef: SLACK_CONNECTOR,
+        permission: SLACK_READ_PERMISSION,
+      }),
+    ).resolves.toMatchObject({ action: "allow" });
+    await expect(
+      readStoredGrant({
+        orgId: fixture.orgId,
+        userId: fixture.userId,
+        agentId: otherAgentId,
+        connectorRef: SLACK_CONNECTOR,
+        permission: SLACK_READ_PERMISSION,
+      }),
+    ).resolves.toMatchObject({ action: "deny" });
+  });
+
+  it("validates connector refs for connector reset", async () => {
+    const fixture = await createFixture();
+    const agentId = await seedAgent(fixture);
+    await enableConnectorPermissionReset(fixture);
+    mocks.clerk.session(fixture.userId, fixture.orgId, "org:member");
+    const client = setupApp({ context })(zeroUserPermissionGrantsContract);
+
+    const response = await accept(
+      client.reset({
+        query: { agentId, connectorRef: "not-a-real-connector" },
+        headers: AUTH_HEADERS,
+      }),
+      [400],
+    );
+
+    expect(response.body.error.code).toBe("VALIDATION_ERROR");
+  });
+
+  it("rejects connector reset for invisible agents", async () => {
+    const owner = await createFixture();
+    const sameOrgUserId = `user_${randomUUID()}`;
+    await seedMember({ orgId: owner.orgId, userId: sameOrgUserId });
+    const privateAgentId = await seedAgent({
+      orgId: owner.orgId,
+      userId: owner.userId,
+      visibility: "private",
+    });
+    await enableConnectorPermissionReset({
+      orgId: owner.orgId,
+      userId: sameOrgUserId,
+    });
+    mocks.clerk.session(sameOrgUserId, owner.orgId, "org:member");
+    const client = setupApp({ context })(zeroUserPermissionGrantsContract);
+
+    const response = await accept(
+      client.reset({
+        query: { agentId: privateAgentId, connectorRef: SLACK_CONNECTOR },
+        headers: AUTH_HEADERS,
+      }),
+      [404],
+    );
+
+    expect(response.body.error.code).toBe("NOT_FOUND");
   });
 
   it("filters expired grants and folds active grants into legacy policies", async () => {

--- a/turbo/apps/api/src/signals/routes/zero-user-permission-grants.ts
+++ b/turbo/apps/api/src/signals/routes/zero-user-permission-grants.ts
@@ -1,12 +1,16 @@
 import { command } from "ccstate";
+import { FeatureSwitchKey } from "@vm0/connectors/feature-switch-key";
+import { isFeatureEnabled } from "@vm0/core/feature-switch";
 import { zeroUserPermissionGrantsContract } from "@vm0/api-contracts/contracts/zero-user-permission-grants";
 
 import { organizationAuthContext$ } from "../auth/auth-context";
 import { authRoute } from "../auth/auth-route";
 import { bodyResultOf, queryOf } from "../context/request";
 import type { RouteEntry } from "../route";
+import { userFeatureSwitchOverrides } from "../services/feature-switches.service";
 import {
   listUserPermissionGrants$,
+  resetUserPermissionGrants$,
   upsertUserPermissionGrant$,
 } from "../services/zero-user-permission-grants.service";
 
@@ -17,6 +21,29 @@ const userPermissionGrantAuthOptions = {
 
 const listQuery$ = queryOf(zeroUserPermissionGrantsContract.list);
 const upsertBody$ = bodyResultOf(zeroUserPermissionGrantsContract.upsert);
+const resetQuery$ = queryOf(zeroUserPermissionGrantsContract.reset);
+
+const connectorPermissionResetDisabled = Object.freeze({
+  status: 403 as const,
+  body: Object.freeze({
+    error: Object.freeze({
+      message: "Connector permission reset is not enabled",
+      code: "FORBIDDEN",
+    }),
+  }),
+});
+
+const connectorPermissionResetEnabled$ = command(async ({ get }) => {
+  const auth = get(organizationAuthContext$);
+  const overrides = await get(
+    userFeatureSwitchOverrides(auth.orgId, auth.userId),
+  );
+  return isFeatureEnabled(FeatureSwitchKey.ConnectorPermissionReset, {
+    orgId: auth.orgId,
+    userId: auth.userId,
+    overrides,
+  });
+});
 
 const listUserPermissionGrantsInner$ = command(
   async ({ get, set }, signal: AbortSignal) => {
@@ -67,6 +94,33 @@ const upsertUserPermissionGrantInner$ = command(
   },
 );
 
+const resetUserPermissionGrantsInner$ = command(
+  async ({ get, set }, signal: AbortSignal) => {
+    if (!(await set(connectorPermissionResetEnabled$))) {
+      return connectorPermissionResetDisabled;
+    }
+    signal.throwIfAborted();
+
+    const auth = get(organizationAuthContext$);
+    const query = get(resetQuery$);
+    const result = await set(
+      resetUserPermissionGrants$,
+      {
+        orgId: auth.orgId,
+        userId: auth.userId,
+        reset: query,
+      },
+      signal,
+    );
+    signal.throwIfAborted();
+
+    if ("kind" in result) {
+      return { status: 204 as const, body: undefined };
+    }
+    return result;
+  },
+);
+
 export const zeroUserPermissionGrantsRoutes: readonly RouteEntry[] = [
   {
     route: zeroUserPermissionGrantsContract.list,
@@ -80,6 +134,13 @@ export const zeroUserPermissionGrantsRoutes: readonly RouteEntry[] = [
     handler: authRoute(
       userPermissionGrantAuthOptions,
       upsertUserPermissionGrantInner$,
+    ),
+  },
+  {
+    route: zeroUserPermissionGrantsContract.reset,
+    handler: authRoute(
+      userPermissionGrantAuthOptions,
+      resetUserPermissionGrantsInner$,
     ),
   },
 ];

--- a/turbo/apps/api/src/signals/services/zero-user-permission-grants.service.ts
+++ b/turbo/apps/api/src/signals/services/zero-user-permission-grants.service.ts
@@ -8,6 +8,7 @@ import { userPermissionGrants } from "@vm0/db/schema/user-permission-grant";
 import { zeroAgents } from "@vm0/db/schema/zero-agent";
 import { and, asc, eq, gt, isNull, or } from "drizzle-orm";
 import type {
+  ResetUserPermissionGrantsQuery,
   UpsertUserPermissionGrantRequest,
   UserPermissionGrantExpiresIn,
   UserPermissionGrantResponse,
@@ -29,6 +30,12 @@ interface UpsertUserPermissionGrantArgs {
   readonly orgId: string;
   readonly userId: string;
   readonly grant: UpsertUserPermissionGrantRequest;
+}
+
+interface ResetUserPermissionGrantsArgs {
+  readonly orgId: string;
+  readonly userId: string;
+  readonly reset: ResetUserPermissionGrantsQuery;
 }
 
 type NotFoundResponse = ReturnType<typeof notFound>;
@@ -54,6 +61,13 @@ type UpsertUserPermissionGrantResult =
   | {
       readonly kind: "ok";
       readonly grant: UserPermissionGrantResponse;
+    }
+  | NotFoundResponse
+  | ValidationErrorResponse;
+
+type ResetUserPermissionGrantsResult =
+  | {
+      readonly kind: "ok";
     }
   | NotFoundResponse
   | ValidationErrorResponse;
@@ -130,6 +144,15 @@ function validateGrantTarget(
   }
 
   return null;
+}
+
+function validateConnectorRef(
+  connectorRef: string,
+): ValidationErrorResponse | null {
+  if (isFirewallConnectorType(connectorRef)) {
+    return null;
+  }
+  return validationError(`Unknown connector ref: ${connectorRef}`);
 }
 
 function validateGrantExpiration(
@@ -334,6 +357,34 @@ async function upsertVisibleGrantRow(
   });
 }
 
+async function resetVisibleConnectorGrantRows(
+  db: Db,
+  args: ResetUserPermissionGrantsArgs,
+): Promise<NotFoundResponse | null> {
+  return await db.transaction(async (tx) => {
+    const visibleAgent = await lockVisibleAgentForUpdate(tx, {
+      orgId: args.orgId,
+      userId: args.userId,
+      agentId: args.reset.agentId,
+    });
+    if (!visibleAgent) {
+      return notFound(`Agent not found: ${args.reset.agentId}`);
+    }
+
+    await tx
+      .delete(userPermissionGrants)
+      .where(
+        and(
+          eq(userPermissionGrants.orgId, args.orgId),
+          eq(userPermissionGrants.userId, args.userId),
+          eq(userPermissionGrants.agentId, args.reset.agentId),
+          eq(userPermissionGrants.connectorRef, args.reset.connectorRef),
+        ),
+      );
+    return null;
+  });
+}
+
 export const listUserPermissionGrants$ = command(
   async (
     { get },
@@ -387,5 +438,28 @@ export const upsertUserPermissionGrant$ = command(
       kind: "ok" as const,
       grant: formatUserPermissionGrant(row),
     };
+  },
+);
+
+export const resetUserPermissionGrants$ = command(
+  async (
+    { set },
+    args: ResetUserPermissionGrantsArgs,
+    signal: AbortSignal,
+  ): Promise<ResetUserPermissionGrantsResult> => {
+    const validation = validateConnectorRef(args.reset.connectorRef);
+    if (validation) {
+      return validation;
+    }
+
+    const writeDb = set(writeDb$);
+    const error = await resetVisibleConnectorGrantRows(writeDb, args);
+    signal.throwIfAborted();
+
+    if (error) {
+      return error;
+    }
+
+    return { kind: "ok" as const };
   },
 );

--- a/turbo/apps/platform/src/mocks/handlers/api-user-permission-grants.ts
+++ b/turbo/apps/platform/src/mocks/handlers/api-user-permission-grants.ts
@@ -106,4 +106,15 @@ export const apiUserPermissionGrantsHandlers = [
 
     return respond(200, grant);
   }),
+
+  mockApi(zeroUserPermissionGrantsContract.reset, ({ query, respond }) => {
+    mockUserPermissionGrants = mockUserPermissionGrants.filter((grant) => {
+      return (
+        grant.agentId !== query.agentId ||
+        grant.connectorRef !== query.connectorRef
+      );
+    });
+
+    return respond(204);
+  }),
 ];

--- a/turbo/apps/platform/src/signals/api-target-policy.ts
+++ b/turbo/apps/platform/src/signals/api-target-policy.ts
@@ -146,7 +146,10 @@ const API_ROUTE_ALLOWLIST: readonly ApiRouteAllowlistEntry[] = [
   { methods: ["GET"], pathname: "/api/zero/usage/insight" },
   { methods: ["GET"], pathname: "/api/zero/usage/members" },
   { methods: ["GET"], pathname: "/api/zero/usage/record" },
-  { methods: ["GET", "PUT"], pathname: "/api/zero/user-permission-grants" },
+  {
+    methods: ["GET", "PUT", "DELETE"],
+    pathname: "/api/zero/user-permission-grants",
+  },
   { methods: ["GET", "POST"], pathname: "/api/zero/user-preferences" },
   { methods: ["GET", "POST"], pathname: "/api/zero/variables" },
   { methods: ["DELETE"], pathname: "/api/zero/variables/:name" },

--- a/turbo/apps/platform/src/signals/permission-allow/permission-allow-signals.ts
+++ b/turbo/apps/platform/src/signals/permission-allow/permission-allow-signals.ts
@@ -197,3 +197,34 @@ export const upsertUserPermissionGrant$ = command(
     return result.body;
   },
 );
+
+export const resetUserPermissionGrants$ = command(
+  async (
+    { get, set },
+    params: {
+      agentId: string;
+      connectorRef: string;
+    },
+    signal: AbortSignal,
+  ): Promise<void> => {
+    const client = get(zeroClient$)(zeroUserPermissionGrantsContract);
+    await accept(
+      client.reset({
+        query: {
+          agentId: params.agentId,
+          connectorRef: params.connectorRef,
+        },
+        fetchOptions: { signal },
+      }),
+      [204],
+    );
+    signal.throwIfAborted();
+    set(internalUserPermissionGrantsReload$, (prev) => {
+      return prev + 1;
+    });
+    set(internalAgentReload$, (prev) => {
+      return prev + 1;
+    });
+    set(reloadAgentById$);
+  },
+);

--- a/turbo/apps/platform/src/signals/zero-page/settings/permissions-dialog.ts
+++ b/turbo/apps/platform/src/signals/zero-page/settings/permissions-dialog.ts
@@ -25,6 +25,10 @@ export const setPermissionUnknownPolicy$ = command(
 );
 
 const internalFormKey$ = state<string | null>(null);
+const internalResetPending$ = state(false);
+export const permissionConnectorResetPending$ = computed((get) => {
+  return get(internalResetPending$);
+});
 
 interface ApplyPermissionPoliciesOptions {
   formKey: string;
@@ -76,6 +80,25 @@ export const setPermissionGrantExpiration$ = command(
   },
 );
 
+export const stagePermissionConnectorReset$ = command(
+  (
+    { get, set },
+    formKey: string,
+    ref: string,
+    policies: Record<string, PermissionPolicy>,
+    unknownPolicy: FirewallPolicyValue,
+  ) => {
+    if (get(internalFormKey$) !== formKey) {
+      return;
+    }
+    const all = get(internalAllPolicies$);
+    set(internalAllPolicies$, { ...all, [ref]: policies });
+    set(internalUnknownPolicy$, unknownPolicy);
+    set(internalGrantExpirations$, {});
+    set(internalResetPending$, true);
+  },
+);
+
 // ---------------------------------------------------------------------------
 // Scroll tracking
 // ---------------------------------------------------------------------------
@@ -122,6 +145,7 @@ export const initPermissionPolicies$ = command(
     set(internalFormKey$, formKey);
     set(internalAllPolicies$, policies);
     set(internalUnknownPolicy$, unknownPolicy);
+    set(internalResetPending$, false);
     set(internalScrolled$, false);
     set(internalExpandedGroups$, new Set());
   },
@@ -149,6 +173,7 @@ export const resetPermissionPolicies$ = command(
     set(internalFormKey$, null);
     set(internalAllPolicies$, {});
     set(internalUnknownPolicy$, "allow");
+    set(internalResetPending$, false);
     set(internalScrolled$, false);
     set(internalExpandedGroups$, new Set());
   },
@@ -175,6 +200,7 @@ export const applyPermissionPolicies$ = command(
     onApply: (
       policies: Record<string, Record<string, PermissionPolicy>>,
       unknownPolicy: FirewallPolicyValue,
+      resetPending: boolean,
     ) => Promise<void>,
     onClose: () => void,
     _signal: AbortSignal,
@@ -187,7 +213,8 @@ export const applyPermissionPolicies$ = command(
       throw new Error("Permission policies form is missing connector state");
     }
     const unknownPolicy = get(internalUnknownPolicy$);
-    await onApply(policies, unknownPolicy);
+    const resetPending = get(internalResetPending$);
+    await onApply(policies, unknownPolicy, resetPending);
     onClose();
   },
 );

--- a/turbo/apps/platform/src/views/fw/__tests__/permissions-dialog.test.tsx
+++ b/turbo/apps/platform/src/views/fw/__tests__/permissions-dialog.test.tsx
@@ -209,6 +209,20 @@ function getUndoChangesButton(
   return button;
 }
 
+function queryButtonByText(text: string): HTMLElement | undefined {
+  return queryAllByRoleFast("button").find((el) => {
+    return el.textContent?.trim() === text;
+  });
+}
+
+function getButtonByText(text: string): HTMLElement {
+  const button = queryButtonByText(text);
+  if (!(button instanceof HTMLElement)) {
+    throw new Error(`Button not found: ${text}`);
+  }
+  return button;
+}
+
 async function selectAllowDuration(
   row: HTMLElement,
   permission: string,
@@ -226,6 +240,164 @@ async function selectAllowDuration(
 }
 
 describe("permissions dialog - flat list connector (Notion)", () => {
+  it("hides connector reset when the reset feature switch is disabled", async () => {
+    mockAPIs({ connectorType: "notion" });
+    detachedSetupPage({ context, path: "/agents/my-agent" });
+    await openPermissionsDrawer("Notion");
+
+    expect(queryButtonByText("Reset")).toBeUndefined();
+  });
+
+  it("stages connector reset and persists it only after Apply", async () => {
+    const resetQueries: unknown[] = [];
+    const upsertBodies: unknown[] = [];
+    mockAPIs({
+      connectorType: "notion",
+      userPermissionGrants: [mockGrant("notion", "insert_comments", "deny")],
+    });
+    server.use(
+      mockApi(zeroUserPermissionGrantsContract.reset, ({ query, respond }) => {
+        resetQueries.push(query);
+        return respond(204);
+      }),
+      mockApi(zeroUserPermissionGrantsContract.upsert, ({ body, respond }) => {
+        upsertBodies.push(body);
+        return respond(200, createMockUserPermissionGrantResponse(body));
+      }),
+    );
+    detachedSetupPage({
+      context,
+      path: "/agents/my-agent",
+      featureSwitches: { [FeatureSwitchKey.ConnectorPermissionReset]: true },
+    });
+    await openPermissionsDrawer("Notion");
+
+    const row = getPermissionRow("insert_comments");
+    expect(getPolicyButton(row, "Deny")).toHaveAttribute(
+      "aria-pressed",
+      "true",
+    );
+
+    click(getButtonByText("Reset"));
+    await waitFor(() => {
+      expect(getPolicyButton(row, "Allow")).toHaveAttribute(
+        "aria-pressed",
+        "true",
+      );
+    });
+    expect(resetQueries).toHaveLength(0);
+    expect(screen.getByText("Apply")).toBeEnabled();
+
+    click(screen.getByText("Apply"));
+
+    await waitFor(() => {
+      expect(resetQueries).toHaveLength(1);
+    });
+    expect(resetQueries[0]).toMatchObject({
+      agentId: AGENT_ID,
+      connectorRef: "notion",
+    });
+    expect(upsertBodies).toHaveLength(0);
+  });
+
+  it("discards staged connector reset when Cancel is clicked", async () => {
+    mockAPIs({
+      connectorType: "notion",
+      userPermissionGrants: [mockGrant("notion", "insert_comments", "deny")],
+    });
+    detachedSetupPage({
+      context,
+      path: "/agents/my-agent",
+      featureSwitches: { [FeatureSwitchKey.ConnectorPermissionReset]: true },
+    });
+    await openPermissionsDrawer("Notion");
+
+    click(getButtonByText("Reset"));
+    click(screen.getByText("Cancel"));
+    await waitFor(() => {
+      expect(
+        screen.queryByRole("heading", { name: /Notion permissions/i }),
+      ).not.toBeInTheDocument();
+    });
+
+    await openPermissionsDrawer("Notion");
+    expect(
+      getPolicyButton(getPermissionRow("insert_comments"), "Deny"),
+    ).toHaveAttribute("aria-pressed", "true");
+  });
+
+  it("clears pending expiration selections during connector reset", async () => {
+    mockAPIs({
+      connectorType: "notion",
+      userPermissionGrants: [
+        createMockUserPermissionGrantResponse({
+          agentId: AGENT_ID,
+          connectorRef: "notion",
+          permission: "insert_comments",
+          action: "allow",
+          expiresAt: new Date(Date.now() + 30 * 60 * 1000).toISOString(),
+        }),
+      ],
+    });
+    detachedSetupPage({
+      context,
+      path: "/agents/my-agent",
+      featureSwitches: {
+        [FeatureSwitchKey.ConnectorPermissionReset]: true,
+        [FeatureSwitchKey.ExpiringPermissionGrants]: true,
+      },
+    });
+    await openPermissionsDrawer("Notion");
+    await waitFor(() => {
+      expect(screen.getByText("< 1 hour")).toBeInTheDocument();
+    });
+
+    click(getButtonByText("Reset"));
+
+    await waitFor(() => {
+      expect(screen.queryByText("< 1 hour")).not.toBeInTheDocument();
+    });
+  });
+
+  it("resets first and then upserts final edits after connector reset", async () => {
+    const events: string[] = [];
+    mockAPIs({
+      connectorType: "notion",
+      userPermissionGrants: [mockGrant("notion", "insert_comments", "deny")],
+    });
+    server.use(
+      mockApi(zeroUserPermissionGrantsContract.reset, ({ respond }) => {
+        events.push("reset");
+        return respond(204);
+      }),
+      mockApi(zeroUserPermissionGrantsContract.upsert, ({ body, respond }) => {
+        events.push(`upsert:${body.permission}:${body.action}`);
+        return respond(200, createMockUserPermissionGrantResponse(body));
+      }),
+    );
+    detachedSetupPage({
+      context,
+      path: "/agents/my-agent",
+      featureSwitches: { [FeatureSwitchKey.ConnectorPermissionReset]: true },
+    });
+    await openPermissionsDrawer("Notion");
+
+    const row = getPermissionRow("insert_comments");
+    click(getButtonByText("Reset"));
+    await waitFor(() => {
+      expect(getPolicyButton(row, "Allow")).toHaveAttribute(
+        "aria-pressed",
+        "true",
+      );
+    });
+    click(getPolicyButton(row, "Deny"));
+    click(screen.getByText("Apply"));
+
+    await waitFor(() => {
+      expect(events).toStrictEqual(["reset", "upsert:insert_comments:deny"]);
+    });
+  });
+
   it("renders permission names and descriptions in flat list (FW-D-031)", async () => {
     mockAPIs({ connectorType: "notion" });
     detachedSetupPage({ context, path: "/agents/my-agent" });
@@ -549,6 +721,38 @@ describe("permissions dialog - flat list connector (Notion)", () => {
 });
 
 describe("permissions dialog - grouped connector (Slack)", () => {
+  it("resets grouped permissions to selective connector defaults", async () => {
+    mockAPIs({
+      connectorType: "slack",
+      userPermissionGrants: [mockGrant("slack", "admin", "allow")],
+    });
+    detachedSetupPage({
+      context,
+      path: "/agents/my-agent",
+      featureSwitches: { [FeatureSwitchKey.ConnectorPermissionReset]: true },
+    });
+    await openPermissionsDrawer("Slack");
+
+    click(screen.getByText(/Admin \(\d+\)/i));
+    await waitFor(() => {
+      expect(screen.getByText("admin")).toBeInTheDocument();
+    });
+    const adminRow = getPermissionRow("admin");
+    expect(getPolicyButton(adminRow, "Allow")).toHaveAttribute(
+      "aria-pressed",
+      "true",
+    );
+
+    click(getButtonByText("Reset"));
+
+    await waitFor(() => {
+      expect(getPolicyButton(adminRow, "Deny")).toHaveAttribute(
+        "aria-pressed",
+        "true",
+      );
+    });
+  });
+
   it("reinitializes grant policies and only writes changed connector grants", async () => {
     const grantBodies: unknown[] = [];
     mockAPIs({

--- a/turbo/apps/platform/src/views/fw/__tests__/permissions-dialog.test.tsx
+++ b/turbo/apps/platform/src/views/fw/__tests__/permissions-dialog.test.tsx
@@ -248,6 +248,67 @@ describe("permissions dialog - flat list connector (Notion)", () => {
     expect(queryButtonByText("Reset")).toBeUndefined();
   });
 
+  it("disables connector reset when there is no persisted or draft state to reset", async () => {
+    mockAPIs({ connectorType: "notion" });
+    detachedSetupPage({
+      context,
+      path: "/agents/my-agent",
+      featureSwitches: { [FeatureSwitchKey.ConnectorPermissionReset]: true },
+    });
+    await openPermissionsDrawer("Notion");
+
+    expect(getButtonByText("Reset")).toBeDisabled();
+    expect(screen.getByText("Apply")).toBeDisabled();
+  });
+
+  it("allows applying reset when an explicit grant matches the visible default state", async () => {
+    const resetQueries: unknown[] = [];
+    const upsertBodies: unknown[] = [];
+    mockAPIs({
+      connectorType: "notion",
+      userPermissionGrants: [mockGrant("notion", "insert_comments", "allow")],
+    });
+    server.use(
+      mockApi(zeroUserPermissionGrantsContract.reset, ({ query, respond }) => {
+        resetQueries.push(query);
+        return respond(204);
+      }),
+      mockApi(zeroUserPermissionGrantsContract.upsert, ({ body, respond }) => {
+        upsertBodies.push(body);
+        return respond(200, createMockUserPermissionGrantResponse(body));
+      }),
+    );
+    detachedSetupPage({
+      context,
+      path: "/agents/my-agent",
+      featureSwitches: { [FeatureSwitchKey.ConnectorPermissionReset]: true },
+    });
+    await openPermissionsDrawer("Notion");
+
+    const row = getPermissionRow("insert_comments");
+    expect(getPolicyButton(row, "Allow")).toHaveAttribute(
+      "aria-pressed",
+      "true",
+    );
+    expect(screen.getByText("Apply")).toBeDisabled();
+
+    click(getButtonByText("Reset"));
+
+    await waitFor(() => {
+      expect(screen.getByText("Apply")).toBeEnabled();
+    });
+    click(screen.getByText("Apply"));
+
+    await waitFor(() => {
+      expect(resetQueries).toHaveLength(1);
+    });
+    expect(resetQueries[0]).toMatchObject({
+      agentId: AGENT_ID,
+      connectorRef: "notion",
+    });
+    expect(upsertBodies).toHaveLength(0);
+  });
+
   it("stages connector reset and persists it only after Apply", async () => {
     const resetQueries: unknown[] = [];
     const upsertBodies: unknown[] = [];
@@ -382,20 +443,44 @@ describe("permissions dialog - flat list connector (Notion)", () => {
     });
     await openPermissionsDrawer("Notion");
 
-    const row = getPermissionRow("insert_comments");
     click(getButtonByText("Reset"));
     await waitFor(() => {
-      expect(getPolicyButton(row, "Allow")).toHaveAttribute(
-        "aria-pressed",
-        "true",
-      );
+      expect(
+        getPolicyButton(getPermissionRow("insert_comments"), "Allow"),
+      ).toHaveAttribute("aria-pressed", "true");
     });
-    click(getPolicyButton(row, "Deny"));
+    click(getPolicyButton(getPermissionRow("read_content"), "Deny"));
     click(screen.getByText("Apply"));
 
     await waitFor(() => {
-      expect(events).toStrictEqual(["reset", "upsert:insert_comments:deny"]);
+      expect(events).toStrictEqual(["reset", "upsert:read_content:deny"]);
     });
+  });
+
+  it("disables Apply when reset edits return to the original explicit grant state", async () => {
+    mockAPIs({
+      connectorType: "notion",
+      userPermissionGrants: [mockGrant("notion", "insert_comments", "deny")],
+    });
+    detachedSetupPage({
+      context,
+      path: "/agents/my-agent",
+      featureSwitches: { [FeatureSwitchKey.ConnectorPermissionReset]: true },
+    });
+    await openPermissionsDrawer("Notion");
+
+    click(getButtonByText("Reset"));
+    await waitFor(() => {
+      expect(
+        getPolicyButton(getPermissionRow("insert_comments"), "Allow"),
+      ).toHaveAttribute("aria-pressed", "true");
+    });
+    click(getPolicyButton(getPermissionRow("insert_comments"), "Deny"));
+
+    expect(
+      getPolicyButton(getPermissionRow("insert_comments"), "Deny"),
+    ).toHaveAttribute("aria-pressed", "true");
+    expect(screen.getByText("Apply")).toBeDisabled();
   });
 
   it("renders permission names and descriptions in flat list (FW-D-031)", async () => {

--- a/turbo/apps/platform/src/views/fw/__tests__/permissions-dialog.test.tsx
+++ b/turbo/apps/platform/src/views/fw/__tests__/permissions-dialog.test.tsx
@@ -245,7 +245,7 @@ describe("permissions dialog - flat list connector (Notion)", () => {
     detachedSetupPage({ context, path: "/agents/my-agent" });
     await openPermissionsDrawer("Notion");
 
-    expect(queryButtonByText("Reset")).toBeUndefined();
+    expect(queryButtonByText("Restore")).toBeUndefined();
   });
 
   it("disables connector reset when there is no persisted or draft state to reset", async () => {
@@ -257,7 +257,7 @@ describe("permissions dialog - flat list connector (Notion)", () => {
     });
     await openPermissionsDrawer("Notion");
 
-    expect(getButtonByText("Reset")).toBeDisabled();
+    expect(getButtonByText("Restore")).toBeDisabled();
     expect(screen.getByText("Apply")).toBeDisabled();
   });
 
@@ -292,7 +292,7 @@ describe("permissions dialog - flat list connector (Notion)", () => {
     );
     expect(screen.getByText("Apply")).toBeDisabled();
 
-    click(getButtonByText("Reset"));
+    click(getButtonByText("Restore"));
 
     await waitFor(() => {
       expect(screen.getByText("Apply")).toBeEnabled();
@@ -339,7 +339,7 @@ describe("permissions dialog - flat list connector (Notion)", () => {
       "true",
     );
 
-    click(getButtonByText("Reset"));
+    click(getButtonByText("Restore"));
     await waitFor(() => {
       expect(getPolicyButton(row, "Allow")).toHaveAttribute(
         "aria-pressed",
@@ -373,7 +373,7 @@ describe("permissions dialog - flat list connector (Notion)", () => {
     });
     await openPermissionsDrawer("Notion");
 
-    click(getButtonByText("Reset"));
+    click(getButtonByText("Restore"));
     click(screen.getByText("Cancel"));
     await waitFor(() => {
       expect(
@@ -413,7 +413,7 @@ describe("permissions dialog - flat list connector (Notion)", () => {
       expect(screen.getByText("< 1 hour")).toBeInTheDocument();
     });
 
-    click(getButtonByText("Reset"));
+    click(getButtonByText("Restore"));
 
     await waitFor(() => {
       expect(screen.queryByText("< 1 hour")).not.toBeInTheDocument();
@@ -443,7 +443,7 @@ describe("permissions dialog - flat list connector (Notion)", () => {
     });
     await openPermissionsDrawer("Notion");
 
-    click(getButtonByText("Reset"));
+    click(getButtonByText("Restore"));
     await waitFor(() => {
       expect(
         getPolicyButton(getPermissionRow("insert_comments"), "Allow"),
@@ -469,7 +469,7 @@ describe("permissions dialog - flat list connector (Notion)", () => {
     });
     await openPermissionsDrawer("Notion");
 
-    click(getButtonByText("Reset"));
+    click(getButtonByText("Restore"));
     await waitFor(() => {
       expect(
         getPolicyButton(getPermissionRow("insert_comments"), "Allow"),
@@ -828,7 +828,7 @@ describe("permissions dialog - grouped connector (Slack)", () => {
       "true",
     );
 
-    click(getButtonByText("Reset"));
+    click(getButtonByText("Restore"));
 
     await waitFor(() => {
       expect(getPolicyButton(adminRow, "Deny")).toHaveAttribute(

--- a/turbo/apps/platform/src/views/team-page/zero-job-detail-page.tsx
+++ b/turbo/apps/platform/src/views/team-page/zero-job-detail-page.tsx
@@ -91,6 +91,7 @@ import noConnectorImg from "../zero-page/assets/no-connector.webp";
 import { JobCustomConnectorsSection } from "./job-custom-connectors-section.tsx";
 import { hasConnectorPermissions } from "../../signals/zero-page/settings/permissions.ts";
 import {
+  resetUserPermissionGrants$,
   upsertUserPermissionGrant$,
   userPermissionGrantsByAgent,
 } from "../../signals/permission-allow/permission-allow-signals.ts";
@@ -117,6 +118,8 @@ import {
   type FirewallPolicyValue,
 } from "@vm0/connectors/firewall-types";
 import {
+  getDefaultFirewallPolicies,
+  isFirewallConnectorType,
   permissionGrantsToFirewallPolicies,
   resolveFirewallPolicies,
 } from "@vm0/connectors/firewalls";
@@ -136,6 +139,14 @@ type UpsertUserPermissionGrant = (
   },
   signal: AbortSignal,
 ) => Promise<UserPermissionGrantResponse>;
+
+type ResetUserPermissionGrants = (
+  params: {
+    agentId: string;
+    connectorRef: string;
+  },
+  signal: AbortSignal,
+) => Promise<void>;
 
 // ---------------------------------------------------------------------------
 // Page shell: skeleton, error, header
@@ -677,6 +688,17 @@ function changedUserGrantPolicies({
   return [...changes.values()];
 }
 
+function defaultFirewallPoliciesForConnector(
+  connectorType: ConnectorType,
+): FirewallPolicies {
+  if (!isFirewallConnectorType(connectorType)) {
+    throw new Error(`Cannot reset permissions for ${connectorType}`);
+  }
+  return {
+    [connectorType]: getDefaultFirewallPolicies(connectorType),
+  };
+}
+
 async function saveUserGrantPolicies({
   agentId,
   connectorType,
@@ -685,7 +707,9 @@ async function saveUserGrantPolicies({
   policies,
   expirationEnabled,
   expiresInByPermission,
+  resetPending,
   pageSignal,
+  resetGrantPolicies,
   upsertGrant,
 }: {
   agentId: string;
@@ -695,13 +719,30 @@ async function saveUserGrantPolicies({
   policies: FirewallPolicies;
   expirationEnabled: boolean;
   expiresInByPermission: GrantExpirationSelections;
+  resetPending: boolean;
   pageSignal: AbortSignal;
+  resetGrantPolicies: ResetUserPermissionGrants;
   upsertGrant: UpsertUserPermissionGrant;
 }): Promise<void> {
+  if (resetPending) {
+    await resetGrantPolicies(
+      {
+        agentId,
+        connectorRef: connectorType,
+      },
+      pageSignal,
+    );
+  }
+
+  const basePolicies = resetPending
+    ? defaultFirewallPoliciesForConnector(connectorType)
+    : initialPolicies;
+  const baseGrants = resetPending ? [] : initialGrants;
+
   for (const { permission, action, expiresIn } of changedUserGrantPolicies({
     connectorType,
-    initialPolicies,
-    initialGrants,
+    initialPolicies: basePolicies,
+    initialGrants: baseGrants,
     policies,
     expirationEnabled,
     expiresInByPermission,
@@ -727,7 +768,9 @@ async function saveDrawerPolicies({
   policies,
   expirationEnabled,
   expiresInByPermission,
+  resetPending,
   pageSignal,
+  resetGrantPolicies,
   upsertGrant,
 }: {
   agentId: string;
@@ -737,7 +780,9 @@ async function saveDrawerPolicies({
   policies: FirewallPolicies;
   expirationEnabled: boolean;
   expiresInByPermission: GrantExpirationSelections;
+  resetPending: boolean;
   pageSignal: AbortSignal;
+  resetGrantPolicies: ResetUserPermissionGrants;
   upsertGrant: UpsertUserPermissionGrant;
 }): Promise<void> {
   await saveUserGrantPolicies({
@@ -748,7 +793,9 @@ async function saveDrawerPolicies({
     policies,
     expirationEnabled,
     expiresInByPermission,
+    resetPending,
     pageSignal,
+    resetGrantPolicies,
     upsertGrant,
   });
 }
@@ -943,6 +990,7 @@ function AgentPermissionsDrawer({
   initialPolicies,
   initialGrants,
   expirationEnabled,
+  resetEnabled,
   readOnly,
   onApply,
   onClose,
@@ -953,10 +1001,12 @@ function AgentPermissionsDrawer({
   initialPolicies: FirewallPolicies;
   initialGrants: readonly UserPermissionGrantResponse[];
   expirationEnabled: boolean;
+  resetEnabled: boolean;
   readOnly: boolean;
   onApply: (
     policies: FirewallPolicies,
     expiresInByPermission: GrantExpirationSelections,
+    options: { readonly resetConnectorGrants: boolean },
   ) => Promise<void>;
   onClose: () => void;
 }) {
@@ -971,6 +1021,7 @@ function AgentPermissionsDrawer({
       initialPolicies={initialPolicies}
       initialGrants={initialGrants}
       expirationEnabled={expirationEnabled}
+      resetEnabled={resetEnabled}
       readOnly={readOnly}
       onApply={onApply}
       onClose={onClose}
@@ -1015,7 +1066,10 @@ function JobPermissionsTab({
   const features = useLastResolved(featureSwitch$);
   const expirationEnabled =
     features?.[FeatureSwitchKey.ExpiringPermissionGrants] ?? false;
+  const resetEnabled =
+    features?.[FeatureSwitchKey.ConnectorPermissionReset] ?? false;
   const [, upsertGrant] = useLoadableSet(upsertUserPermissionGrant$);
+  const [, resetGrantPolicies] = useLoadableSet(resetUserPermissionGrants$);
   const connectorType = useGet(permConnectorType$);
   const setConnectorType = useSet(setPermConnectorType$);
   const search = useGet(permSearch$);
@@ -1095,8 +1149,13 @@ function JobPermissionsTab({
             initialPolicies={drawerInitialPolicies}
             initialGrants={userGrants}
             expirationEnabled={expirationEnabled}
+            resetEnabled={resetEnabled}
             readOnly={!canManagePermissions}
-            onApply={async (policies, expiresInByPermission) => {
+            onApply={async (
+              policies,
+              expiresInByPermission,
+              { resetConnectorGrants },
+            ) => {
               if (connectorType === null) {
                 throw new Error("Cannot save permissions without a connector");
               }
@@ -1108,7 +1167,9 @@ function JobPermissionsTab({
                 policies,
                 expirationEnabled,
                 expiresInByPermission,
+                resetPending: resetConnectorGrants,
                 pageSignal,
+                resetGrantPolicies,
                 upsertGrant,
               });
               toast.success("Permissions updated");

--- a/turbo/apps/platform/src/views/zero-page/components/settings/permission-grant-reset-state.ts
+++ b/turbo/apps/platform/src/views/zero-page/components/settings/permission-grant-reset-state.ts
@@ -1,0 +1,254 @@
+import type {
+  UserPermissionGrantExpiresIn,
+  UserPermissionGrantResponse,
+} from "@vm0/api-contracts/contracts/zero-user-permission-grants";
+import {
+  UNKNOWN_PERMISSION_GRANT,
+  type FirewallPolicyValue,
+} from "@vm0/connectors/firewall-types";
+
+import type { PermissionPolicy } from "../../../../signals/zero-page/settings/permissions.ts";
+
+interface PermissionGrantFingerprint {
+  readonly permission: string;
+  readonly action: UserPermissionGrantResponse["action"];
+  readonly expiration: string;
+}
+
+function permissionPoliciesEqual(
+  a: Record<string, PermissionPolicy>,
+  b: Record<string, PermissionPolicy>,
+): boolean {
+  const aKeys = Object.keys(a);
+  if (aKeys.length !== Object.keys(b).length) {
+    return false;
+  }
+  for (const key of aKeys) {
+    if (a[key] !== b[key]) {
+      return false;
+    }
+  }
+  return true;
+}
+
+export function connectorDraftDiffersFromDefault({
+  currentPolicies,
+  defaultPolicies,
+  currentUnknownPolicy,
+  defaultUnknownPolicy,
+}: {
+  currentPolicies: Record<string, PermissionPolicy> | undefined;
+  defaultPolicies: Record<string, PermissionPolicy>;
+  currentUnknownPolicy: FirewallPolicyValue;
+  defaultUnknownPolicy: FirewallPolicyValue;
+}): boolean {
+  if (currentPolicies === undefined) {
+    return false;
+  }
+  if (currentUnknownPolicy !== defaultUnknownPolicy) {
+    return true;
+  }
+  return !permissionPoliciesEqual(currentPolicies, defaultPolicies);
+}
+
+function grantExpirationFingerprint(
+  grant: UserPermissionGrantResponse,
+): string {
+  return grant.action === "allow" && grant.expiresAt
+    ? `at:${grant.expiresAt}`
+    : "always";
+}
+
+function selectedExpirationFingerprint(
+  action: UserPermissionGrantResponse["action"],
+  expirationEnabled: boolean,
+  selected: UserPermissionGrantExpiresIn | undefined,
+): string {
+  return action === "allow" &&
+    expirationEnabled &&
+    selected !== undefined &&
+    selected !== "always"
+    ? `duration:${selected}`
+    : "always";
+}
+
+function grantAction(
+  policy: FirewallPolicyValue,
+): UserPermissionGrantResponse["action"] | null {
+  switch (policy) {
+    case "allow":
+    case "deny": {
+      return policy;
+    }
+    case "ask": {
+      return null;
+    }
+  }
+}
+
+function comparePermissionGrantFingerprints(
+  a: PermissionGrantFingerprint,
+  b: PermissionGrantFingerprint,
+): number {
+  const permissionCompare = a.permission.localeCompare(b.permission);
+  if (permissionCompare !== 0) {
+    return permissionCompare;
+  }
+  const actionCompare = a.action.localeCompare(b.action);
+  if (actionCompare !== 0) {
+    return actionCompare;
+  }
+  return a.expiration.localeCompare(b.expiration);
+}
+
+function currentPermissionGrantFingerprint({
+  permission,
+  currentPolicy,
+  defaultPolicy,
+  selected,
+  expirationEnabled,
+}: {
+  permission: string;
+  currentPolicy: FirewallPolicyValue;
+  defaultPolicy: FirewallPolicyValue;
+  selected: UserPermissionGrantExpiresIn | undefined;
+  expirationEnabled: boolean;
+}): PermissionGrantFingerprint | null {
+  const currentAction = grantAction(currentPolicy);
+  const defaultAction = grantAction(defaultPolicy);
+  if (!currentAction || !defaultAction) {
+    return null;
+  }
+  const hasExpiringDefaultAllowGrant =
+    currentAction === "allow" &&
+    currentAction === defaultAction &&
+    expirationEnabled &&
+    selected !== undefined &&
+    selected !== "always";
+  if (currentAction === defaultAction && !hasExpiringDefaultAllowGrant) {
+    return null;
+  }
+  return {
+    permission,
+    action: currentAction,
+    expiration: selectedExpirationFingerprint(
+      currentAction,
+      expirationEnabled,
+      selected,
+    ),
+  };
+}
+
+function currentConnectorGrantFingerprints({
+  permissionNames,
+  policies,
+  unknownPolicy,
+  defaultPolicies,
+  defaultUnknownPolicy,
+  expirationEnabled,
+  selections,
+}: {
+  permissionNames: readonly string[];
+  policies: Record<string, PermissionPolicy>;
+  unknownPolicy: FirewallPolicyValue;
+  defaultPolicies: Record<string, PermissionPolicy>;
+  defaultUnknownPolicy: FirewallPolicyValue;
+  expirationEnabled: boolean;
+  selections: Readonly<Record<string, UserPermissionGrantExpiresIn>>;
+}): readonly PermissionGrantFingerprint[] {
+  const fingerprints: PermissionGrantFingerprint[] = [];
+  for (const name of permissionNames) {
+    const fingerprint = currentPermissionGrantFingerprint({
+      permission: name,
+      currentPolicy: policies[name] ?? defaultPolicies[name] ?? "allow",
+      defaultPolicy: defaultPolicies[name] ?? "allow",
+      selected: selections[name],
+      expirationEnabled,
+    });
+    if (fingerprint) {
+      fingerprints.push(fingerprint);
+    }
+  }
+  const unknownFingerprint = currentPermissionGrantFingerprint({
+    permission: UNKNOWN_PERMISSION_GRANT,
+    currentPolicy: unknownPolicy,
+    defaultPolicy: defaultUnknownPolicy,
+    selected: selections[UNKNOWN_PERMISSION_GRANT],
+    expirationEnabled,
+  });
+  if (unknownFingerprint) {
+    fingerprints.push(unknownFingerprint);
+  }
+  return fingerprints.sort(comparePermissionGrantFingerprints);
+}
+
+function explicitGrantFingerprints(
+  explicitGrants: Map<string, UserPermissionGrantResponse>,
+): readonly PermissionGrantFingerprint[] {
+  return [...explicitGrants.entries()]
+    .map(([permission, grant]) => {
+      return {
+        permission,
+        action: grant.action,
+        expiration: grantExpirationFingerprint(grant),
+      };
+    })
+    .sort(comparePermissionGrantFingerprints);
+}
+
+function permissionGrantFingerprintsEqual(
+  a: readonly PermissionGrantFingerprint[],
+  b: readonly PermissionGrantFingerprint[],
+): boolean {
+  if (a.length !== b.length) {
+    return false;
+  }
+  return a.every((item, index) => {
+    const other = b[index];
+    return (
+      item.permission === other.permission &&
+      item.action === other.action &&
+      item.expiration === other.expiration
+    );
+  });
+}
+
+export function hasConnectorResetPersistedEffect({
+  resetPending,
+  explicitGrants,
+  permissionNames,
+  policies,
+  unknownPolicy,
+  defaultPolicies,
+  defaultUnknownPolicy,
+  expirationEnabled,
+  selections,
+}: {
+  resetPending: boolean;
+  explicitGrants: Map<string, UserPermissionGrantResponse>;
+  permissionNames: readonly string[];
+  policies: Record<string, PermissionPolicy>;
+  unknownPolicy: FirewallPolicyValue;
+  defaultPolicies: Record<string, PermissionPolicy>;
+  defaultUnknownPolicy: FirewallPolicyValue;
+  expirationEnabled: boolean;
+  selections: Readonly<Record<string, UserPermissionGrantExpiresIn>>;
+}): boolean {
+  if (!resetPending) {
+    return false;
+  }
+  const initialFingerprints = explicitGrantFingerprints(explicitGrants);
+  const currentFingerprints = currentConnectorGrantFingerprints({
+    permissionNames,
+    policies,
+    unknownPolicy,
+    defaultPolicies,
+    defaultUnknownPolicy,
+    expirationEnabled,
+    selections,
+  });
+  return !permissionGrantFingerprintsEqual(
+    initialFingerprints,
+    currentFingerprints,
+  );
+}

--- a/turbo/apps/platform/src/views/zero-page/components/settings/permissions-dialog.tsx
+++ b/turbo/apps/platform/src/views/zero-page/components/settings/permissions-dialog.tsx
@@ -43,6 +43,10 @@ import type {
   UserPermissionGrantResponse,
 } from "@vm0/api-contracts/contracts/zero-user-permission-grants";
 import { ConnectorIcon } from "./connector-icons.tsx";
+import {
+  connectorDraftDiffersFromDefault,
+  hasConnectorResetPersistedEffect,
+} from "./permission-grant-reset-state.ts";
 import { permissionGrantExpiryText } from "../../../../signals/permission-allow/permission-grant-expiration.ts";
 import type { PermissionPolicy } from "../../../../signals/zero-page/settings/permissions.ts";
 import {
@@ -108,6 +112,7 @@ interface PermissionsDrawerFooterProps {
   readonly readOnly?: boolean;
   readonly resetEnabled?: boolean;
   readonly canReset: boolean;
+  readonly resetAvailable: boolean;
   readonly saving: boolean;
   readonly canApply: boolean;
   readonly onReset: () => void;
@@ -1171,6 +1176,7 @@ function PermissionsDrawerFooter({
   readOnly,
   resetEnabled,
   canReset,
+  resetAvailable,
   saving,
   canApply,
   onReset,
@@ -1183,7 +1189,11 @@ function PermissionsDrawerFooter({
     <SheetFooter className="gap-2 sm:justify-between sm:space-x-0">
       <div>
         {showReset && (
-          <Button variant="outline" onClick={onReset} disabled={saving}>
+          <Button
+            variant="outline"
+            onClick={onReset}
+            disabled={saving || !resetAvailable}
+          >
             Reset
           </Button>
         )}
@@ -1264,6 +1274,12 @@ export function PermissionsDrawer({
     currentUnknownPolicy: unknownPolicy,
     initialUnknownPolicy,
   });
+  const hasDefaultPolicyChanges = connectorDraftDiffersFromDefault({
+    currentPolicies: policiesForRef,
+    defaultPolicies: defaultPolicyState.policies,
+    currentUnknownPolicy: unknownPolicy,
+    defaultUnknownPolicy: defaultPolicyState.unknownPolicy,
+  });
   const hasExpirationChanges = hasGrantExpirationChanges({
     expirationEnabled,
     explicitGrants: effectiveExplicitGrants,
@@ -1271,10 +1287,30 @@ export function PermissionsDrawer({
     unknownPolicy,
     selections: expirationSelections,
   });
+  const hasExpirationDraftSelections =
+    Object.keys(expirationSelections).length > 0;
+  const hasResetPersistedEffect = hasConnectorResetPersistedEffect({
+    resetPending,
+    explicitGrants,
+    permissionNames: permissions.map((permission) => {
+      return permission.name;
+    }),
+    policies,
+    unknownPolicy,
+    defaultPolicies: defaultPolicyState.policies,
+    defaultUnknownPolicy: defaultPolicyState.unknownPolicy,
+    expirationEnabled,
+    selections: expirationSelections,
+  });
+  const resetAvailable =
+    explicitGrants.size > 0 ||
+    hasDefaultPolicyChanges ||
+    hasExpirationDraftSelections;
   const canApply = canApplyPermissionPolicies({
     config,
     saving,
-    hasChanges: hasPermissionChanges || hasExpirationChanges || resetPending,
+    hasChanges:
+      hasPermissionChanges || hasExpirationChanges || hasResetPersistedEffect,
   });
   const unknownGrant = effectiveExplicitGrants.get(UNKNOWN_PERMISSION_GRANT);
   const unknownSelectedExpiration =
@@ -1489,6 +1525,7 @@ export function PermissionsDrawer({
           readOnly={readOnly}
           resetEnabled={resetEnabled}
           canReset={config !== null}
+          resetAvailable={resetAvailable}
           saving={saving}
           canApply={canApply}
           onReset={handleResetConnector}

--- a/turbo/apps/platform/src/views/zero-page/components/settings/permissions-dialog.tsx
+++ b/turbo/apps/platform/src/views/zero-page/components/settings/permissions-dialog.tsx
@@ -1185,18 +1185,31 @@ function PermissionsDrawerFooter({
 }: PermissionsDrawerFooterProps) {
   const showReset = !readOnly && resetEnabled && canReset;
 
+  if (!showReset) {
+    return (
+      <SheetFooter>
+        <Button variant="outline" onClick={onClose}>
+          {readOnly ? "Close" : "Cancel"}
+        </Button>
+        {!readOnly && (
+          <Button onClick={onApply} disabled={!canApply}>
+            {saving ? "Saving..." : "Apply"}
+          </Button>
+        )}
+      </SheetFooter>
+    );
+  }
+
   return (
     <SheetFooter className="gap-2 sm:justify-between sm:space-x-0">
       <div>
-        {showReset && (
-          <Button
-            variant="outline"
-            onClick={onReset}
-            disabled={saving || !resetAvailable}
-          >
-            Restore
-          </Button>
-        )}
+        <Button
+          variant="outline"
+          onClick={onReset}
+          disabled={saving || !resetAvailable}
+        >
+          Restore
+        </Button>
       </div>
       <div className="flex flex-col-reverse gap-2 sm:flex-row sm:justify-end">
         <Button variant="outline" onClick={onClose}>

--- a/turbo/apps/platform/src/views/zero-page/components/settings/permissions-dialog.tsx
+++ b/turbo/apps/platform/src/views/zero-page/components/settings/permissions-dialog.tsx
@@ -27,6 +27,7 @@ import {
 } from "@vm0/connectors/connectors";
 import {
   getConnectorFirewall,
+  getDefaultFirewallPolicies,
   groupPermissionsByCategory,
   isFirewallConnectorType,
   resolveFirewallPolicies,
@@ -57,10 +58,12 @@ import {
   applyPermissionPolicies$,
   permissionUnknownPolicy$,
   setPermissionUnknownPolicy$,
+  permissionConnectorResetPending$,
   permissionGrantExpirations$,
   setPermissionGrantExpiration$,
   initPermissionGrantExpirations$,
   resetPermissionGrantExpirations$,
+  stagePermissionConnectorReset$,
 } from "../../../../signals/zero-page/settings/permissions-dialog.ts";
 import {
   IconCheck,
@@ -85,14 +88,31 @@ interface PermissionsDrawerProps {
   initialPolicies: FirewallPolicies;
   initialGrants: readonly UserPermissionGrantResponse[];
   expirationEnabled: boolean;
+  resetEnabled?: boolean;
   readOnly?: boolean;
   onApply: (
     policies: FirewallPolicies,
     expiresInByPermission: Readonly<
       Record<string, UserPermissionGrantExpiresIn>
     >,
+    options: PermissionDrawerApplyOptions,
   ) => Promise<void>;
   onClose: () => void;
+}
+
+interface PermissionDrawerApplyOptions {
+  readonly resetConnectorGrants: boolean;
+}
+
+interface PermissionsDrawerFooterProps {
+  readonly readOnly?: boolean;
+  readonly resetEnabled?: boolean;
+  readonly canReset: boolean;
+  readonly saving: boolean;
+  readonly canApply: boolean;
+  readonly onReset: () => void;
+  readonly onClose: () => void;
+  readonly onApply: () => void;
 }
 
 function extractPermissions(config: FirewallConfig): ConnectorPermission[] {
@@ -266,6 +286,27 @@ function buildInitialPolicies(
   }
   result[ref] = refPolicies;
   return result;
+}
+
+function buildDefaultPolicyState(
+  ref: ConnectorType,
+  config: FirewallConfig | null,
+): {
+  readonly policies: Record<string, PermissionPolicy>;
+  readonly unknownPolicy: FirewallPolicyValue;
+} {
+  if (!config || !isFirewallConnectorType(ref)) {
+    return { policies: {}, unknownPolicy: "allow" };
+  }
+  const defaults = getDefaultFirewallPolicies(ref);
+  const policies: Record<string, PermissionPolicy> = {};
+  for (const permission of extractPermissions(config)) {
+    policies[permission.name] = defaults.policies[permission.name] ?? "allow";
+  }
+  return {
+    policies,
+    unknownPolicy: defaults.unknownPolicy ?? "allow",
+  };
 }
 
 function mergeDrawerPolicies({
@@ -1126,6 +1167,41 @@ function PermissionRow({
   );
 }
 
+function PermissionsDrawerFooter({
+  readOnly,
+  resetEnabled,
+  canReset,
+  saving,
+  canApply,
+  onReset,
+  onClose,
+  onApply,
+}: PermissionsDrawerFooterProps) {
+  const showReset = !readOnly && resetEnabled && canReset;
+
+  return (
+    <SheetFooter className="gap-2 sm:justify-between sm:space-x-0">
+      <div>
+        {showReset && (
+          <Button variant="outline" onClick={onReset} disabled={saving}>
+            Reset
+          </Button>
+        )}
+      </div>
+      <div className="flex flex-col-reverse gap-2 sm:flex-row sm:justify-end">
+        <Button variant="outline" onClick={onClose}>
+          {readOnly ? "Close" : "Cancel"}
+        </Button>
+        {!readOnly && (
+          <Button onClick={onApply} disabled={!canApply}>
+            {saving ? "Saving..." : "Apply"}
+          </Button>
+        )}
+      </div>
+    </SheetFooter>
+  );
+}
+
 export function PermissionsDrawer({
   agentId,
   connectorType,
@@ -1133,6 +1209,7 @@ export function PermissionsDrawer({
   initialPolicies,
   initialGrants,
   expirationEnabled,
+  resetEnabled,
   readOnly,
   onApply,
   onClose,
@@ -1143,6 +1220,7 @@ export function PermissionsDrawer({
 
   const initialUnknownPolicy = initialPolicies[ref]?.unknownPolicy ?? "allow";
   const initialPolicyState = buildInitialPolicies(ref, config, initialPolicies);
+  const defaultPolicyState = buildDefaultPolicyState(ref, config);
   const explicitGrants = buildExplicitGrantMap(ref, initialGrants);
   const grantStateKey = explicitGrantStateKey(explicitGrants);
   const initialPolicyKey = `${agentId}\u0000${ref}\u0000${initialUnknownPolicy}\u0000${JSON.stringify(initialPolicyState[ref] ?? {})}\u0000${grantStateKey}`;
@@ -1156,6 +1234,10 @@ export function PermissionsDrawer({
   const allPolicies = useGet(permissionAllPolicies$);
   const unknownPolicy = useGet(permissionUnknownPolicy$);
   const setUnknownPolicy = useSet(setPermissionUnknownPolicy$);
+  const resetPending = useGet(permissionConnectorResetPending$);
+  const effectiveExplicitGrants = resetPending
+    ? new Map<string, UserPermissionGrantResponse>()
+    : explicitGrants;
   const scrolled = useGet(permissionScrolled$);
   const setScrolled = useSet(setPermissionScrolled$);
   const expandedGroups = useGet(permissionExpandedGroups$);
@@ -1166,6 +1248,7 @@ export function PermissionsDrawer({
   const setGrantExpiration = useSet(setPermissionGrantExpiration$);
   const resetPermissionPolicies = useSet(resetPermissionPolicies$);
   const resetGrantExpirations = useSet(resetPermissionGrantExpirations$);
+  const stageConnectorReset = useSet(stagePermissionConnectorReset$);
   const [applyLoadable, applyFn] = useLoadableSet(applyPermissionPolicies$);
   const saving = applyLoadable.state === "loading";
   const pageSignal = useGet(pageSignal$);
@@ -1183,7 +1266,7 @@ export function PermissionsDrawer({
   });
   const hasExpirationChanges = hasGrantExpirationChanges({
     expirationEnabled,
-    explicitGrants,
+    explicitGrants: effectiveExplicitGrants,
     policies,
     unknownPolicy,
     selections: expirationSelections,
@@ -1191,9 +1274,9 @@ export function PermissionsDrawer({
   const canApply = canApplyPermissionPolicies({
     config,
     saving,
-    hasChanges: hasPermissionChanges || hasExpirationChanges,
+    hasChanges: hasPermissionChanges || hasExpirationChanges || resetPending,
   });
-  const unknownGrant = explicitGrants.get(UNKNOWN_PERMISSION_GRANT);
+  const unknownGrant = effectiveExplicitGrants.get(UNKNOWN_PERMISSION_GRANT);
   const unknownSelectedExpiration =
     expirationSelections[UNKNOWN_PERMISSION_GRANT];
 
@@ -1237,6 +1320,15 @@ export function PermissionsDrawer({
     setGrantExpiration(UNKNOWN_PERMISSION_GRANT, null);
   };
 
+  const handleResetConnector = () => {
+    stageConnectorReset(
+      initialPolicyKey,
+      ref,
+      defaultPolicyState.policies,
+      defaultPolicyState.unknownPolicy,
+    );
+  };
+
   const handleClose = () => {
     resetPermissionPolicies(initialPolicyKey);
     resetGrantExpirations(initialPolicyKey);
@@ -1247,6 +1339,7 @@ export function PermissionsDrawer({
     const wrappedApply = async (
       perms: Record<string, Record<string, PermissionPolicy>>,
       unknownFlag: FirewallPolicyValue,
+      resetConnectorGrants: boolean,
     ): Promise<void> => {
       await onApply(
         mergeDrawerPolicies({
@@ -1256,6 +1349,7 @@ export function PermissionsDrawer({
           unknownPolicy: unknownFlag,
         }),
         expirationSelections,
+        { resetConnectorGrants },
       );
     };
     detach(
@@ -1333,7 +1427,7 @@ export function PermissionsDrawer({
                 initialPolicies={initialPoliciesForRef}
                 policies={policies}
                 expandedGroups={expandedGroups}
-                explicitGrants={explicitGrants}
+                explicitGrants={effectiveExplicitGrants}
                 expirationSelections={expirationSelections}
                 expirationEnabled={expirationEnabled}
                 readOnly={readOnly}
@@ -1391,16 +1485,16 @@ export function PermissionsDrawer({
           </div>
         )}
 
-        <SheetFooter>
-          <Button variant="outline" onClick={handleClose}>
-            {readOnly ? "Close" : "Cancel"}
-          </Button>
-          {!readOnly && (
-            <Button onClick={handleApply} disabled={!canApply}>
-              {saving ? "Saving..." : "Apply"}
-            </Button>
-          )}
-        </SheetFooter>
+        <PermissionsDrawerFooter
+          readOnly={readOnly}
+          resetEnabled={resetEnabled}
+          canReset={config !== null}
+          saving={saving}
+          canApply={canApply}
+          onReset={handleResetConnector}
+          onClose={handleClose}
+          onApply={handleApply}
+        />
       </SheetContent>
     </Sheet>
   );

--- a/turbo/apps/platform/src/views/zero-page/components/settings/permissions-dialog.tsx
+++ b/turbo/apps/platform/src/views/zero-page/components/settings/permissions-dialog.tsx
@@ -1194,7 +1194,7 @@ function PermissionsDrawerFooter({
             onClick={onReset}
             disabled={saving || !resetAvailable}
           >
-            Reset
+            Restore
           </Button>
         )}
       </div>

--- a/turbo/packages/api-contracts/src/contracts/zero-user-permission-grants.ts
+++ b/turbo/packages/api-contracts/src/contracts/zero-user-permission-grants.ts
@@ -30,6 +30,11 @@ export const listUserPermissionGrantsQuerySchema = z.object({
   agentId: agentIdSchema,
 });
 
+export const resetUserPermissionGrantsQuerySchema = z.object({
+  agentId: agentIdSchema,
+  connectorRef: connectorRefSchema,
+});
+
 const upsertUserPermissionGrantBaseRequestSchema = z.object({
   agentId: agentIdSchema,
   connectorRef: connectorRefSchema,
@@ -79,6 +84,20 @@ export const zeroUserPermissionGrantsContract = c.router({
     },
     summary: "Upsert current user's permission grant for an agent",
   },
+  reset: {
+    method: "DELETE",
+    path: "/api/zero/user-permission-grants",
+    headers: authHeadersSchema,
+    query: resetUserPermissionGrantsQuerySchema,
+    responses: {
+      204: c.noBody(),
+      400: apiErrorSchema,
+      401: apiErrorSchema,
+      403: apiErrorSchema,
+      404: apiErrorSchema,
+    },
+    summary: "Reset current user's connector permission grants for an agent",
+  },
 });
 
 export type UserPermissionGrantAction = z.infer<
@@ -92,6 +111,9 @@ export type UserPermissionGrantResponse = z.infer<
 >;
 export type ListUserPermissionGrantsQuery = z.infer<
   typeof listUserPermissionGrantsQuerySchema
+>;
+export type ResetUserPermissionGrantsQuery = z.infer<
+  typeof resetUserPermissionGrantsQuerySchema
 >;
 export type UpsertUserPermissionGrantRequest = z.infer<
   typeof upsertUserPermissionGrantRequestSchema

--- a/turbo/packages/connectors/src/feature-switch-key.ts
+++ b/turbo/packages/connectors/src/feature-switch-key.ts
@@ -56,5 +56,6 @@ export enum FeatureSwitchKey {
   PresentationHtmlPptxDownload = "presentationHtmlPptxDownload",
   ChatInlineFeedback = "chatInlineFeedback",
   ExpiringPermissionGrants = "expiringPermissionGrants",
+  ConnectorPermissionReset = "connectorPermissionReset",
   ZeroAutomations = "zeroAutomations",
 }

--- a/turbo/packages/core/src/feature-switch.ts
+++ b/turbo/packages/core/src/feature-switch.ts
@@ -324,6 +324,13 @@ const FEATURE_SWITCHES: Record<FeatureSwitchKey, FeatureSwitch> = {
     enabled: false,
     enabledOrgIdHashes: STAFF_ORG_ID_HASHES,
   },
+  [FeatureSwitchKey.ConnectorPermissionReset]: {
+    maintainer: "liangyou@vm0.ai",
+    description:
+      "Show staged connector-level reset controls for current-user permission grants.",
+    enabled: false,
+    enabledOrgIdHashes: STAFF_ORG_ID_HASHES,
+  },
   [FeatureSwitchKey.ZeroAutomations]: {
     maintainer: "lancy@vm0.ai",
     description:


### PR DESCRIPTION
## Summary

- add a ConnectorPermissionReset feature switch and a gated DELETE user-permission-grants API
- add staged drawer reset state that restores connector defaults locally and only persists on Apply
- persist reset by deleting current-user grants for one agent + connector, then upserting final overrides after reset edits
- cover reset API scoping plus UI reset/cancel/expiration/selective-default behavior

Closes #16829

## Verification

- pnpm format
- pnpm check-types
- pnpm turbo run lint
- pnpm knip
- pnpm -F api exec vitest src/signals/routes/__tests__/zero-user-permission-grants.test.ts
- pnpm -F @vm0/app exec vitest src/views/fw/__tests__/permissions-dialog.test.tsx
- pnpm -F @vm0/app exec vitest src/views/zero-page/__tests__/permissions-dialog.test.tsx

## Notes

- pnpm vitest was also run. It completed with unrelated local failures: @vm0/desktop native CLI tests require macOS in this Linux container, and one API model-provider assertion failed only in the full concurrent run but passed when rerun in isolation.