### PR TITLE
fix: expose api url to sandbox cli child

### DIFF
--- a/crates/guest-agent/src/cli/child_env.rs
+++ b/crates/guest-agent/src/cli/child_env.rs
@@ -4,6 +4,12 @@ use crate::env;
 
 const DEFAULT_PATH: &str = "/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin";
 const DEFAULT_SHELL: &str = "/bin/bash";
+const RUNNER_VISIBLE_CHILD_ENV_KEYS: &[&str] = &[
+    // The sandbox CLI needs the same API origin as the guest-agent in local
+    // development. Keep this list intentionally narrow: tokens and other VM0
+    // bootstrap controls must stay private to the guest-agent.
+    "VM0_API_URL",
+];
 const OPTIONAL_BASE_ENV_KEYS: &[&str] = &[
     "USER",
     "LOGNAME",
@@ -29,6 +35,9 @@ pub(super) fn apply_to_tokio_command(cmd: &mut tokio::process::Command) {
     for (key, value) in env::user_env() {
         cmd.env(key, value);
     }
+    apply_runner_visible_env(|key, value| {
+        cmd.env(key, value);
+    });
 }
 
 pub(super) fn apply_to_std_command(cmd: &mut std::process::Command) {
@@ -39,6 +48,9 @@ pub(super) fn apply_to_std_command(cmd: &mut std::process::Command) {
     for (key, value) in env::user_env() {
         cmd.env(key, value);
     }
+    apply_runner_visible_env(|key, value| {
+        cmd.env(key, value);
+    });
 }
 
 fn base_child_env() -> Vec<(&'static str, String)> {
@@ -68,6 +80,16 @@ fn base_child_env() -> Vec<(&'static str, String)> {
     }
 
     base
+}
+
+fn apply_runner_visible_env(mut apply: impl FnMut(&'static str, String)) {
+    for key in RUNNER_VISIBLE_CHILD_ENV_KEYS {
+        if let Ok(value) = std::env::var(key)
+            && !value.is_empty()
+        {
+            apply(key, value);
+        }
+    }
 }
 
 #[cfg(test)]

--- a/crates/guest-agent/tests/cli_child_env.rs
+++ b/crates/guest-agent/tests/cli_child_env.rs
@@ -33,6 +33,9 @@ async fn execute_cli_injects_user_env_without_runner_owned_bootstrap_env()
         std::env::set_var("REQUESTS_CA_BUNDLE", "/etc/ssl/certs/ca-certificates.crt");
         std::env::set_var("CARGO_HTTP_CAINFO", "/etc/ssl/certs/ca-certificates.crt");
         std::env::set_var("NPM_CONFIG_UPDATE_NOTIFIER", "false");
+        std::env::set_var("CLI_AGENT_TYPE", "claude-code");
+        std::env::set_var("VM0_APPEND_SYSTEM_PROMPT", "runner append prompt");
+        std::env::set_var("VM0_FEATURE_FLAGS", r#"{"flag":true}"#);
     }
 
     let run_id = std::env::var("VM0_RUN_ID")?;
@@ -45,6 +48,7 @@ async fn execute_cli_injects_user_env_without_runner_owned_bootstrap_env()
         serde_json::to_vec(&serde_json::json!({
             "CUSTOM_USER_ENV": "visible-to-cli",
             "BASH_ENV": "/tmp/user-bash-env",
+            "VM0_API_URL": "https://user-env.example.invalid",
             "OPENAI_API_KEY": "sk-user",
             "HOME": user_home_str,
             "NODE_EXTRA_CA_CERTS": "/tmp/user-ca.pem",
@@ -82,6 +86,10 @@ async fn execute_cli_injects_user_env_without_runner_owned_bootstrap_env()
         Some("sk-user")
     );
     assert_eq!(
+        cli_env.get("VM0_API_URL").map(String::as_str),
+        Some("http://127.0.0.1:1")
+    );
+    assert_eq!(
         cli_env.get("HOME").map(String::as_str),
         Some(user_home_str.as_str())
     );
@@ -111,6 +119,13 @@ async fn execute_cli_injects_user_env_without_runner_owned_bootstrap_env()
 
     assert!(!cli_env.contains_key("VM0_SECRET_VALUES"));
     assert!(!cli_env.contains_key("VM0_USER_ENV_FILE"));
+    assert!(!cli_env.contains_key("VM0_RUN_ID"));
+    assert!(!cli_env.contains_key("VM0_PROMPT"));
+    assert!(!cli_env.contains_key("VM0_APPEND_SYSTEM_PROMPT"));
+    assert!(!cli_env.contains_key("VM0_SANDBOX_ID"));
+    assert!(!cli_env.contains_key("VM0_SANDBOX_REUSE_RESULT"));
+    assert!(!cli_env.contains_key("VM0_FEATURE_FLAGS"));
+    assert!(!cli_env.contains_key("CLI_AGENT_TYPE"));
     assert!(!cli_env.contains_key(process_control_ipc::BOOTSTRAP_ENV));
 
     Ok(())


### PR DESCRIPTION
## Summary
- pass VM0_API_URL from the guest-agent bootstrap environment into sandbox CLI child processes
- keep the runner-visible child env allowlist narrow so tokens and runner control metadata stay private to the guest-agent
- extend the CLI child env regression test to cover VM0_API_URL visibility and runner control env isolation

## Testing
- cargo fmt --package guest-agent
- cargo test -p guest-agent --test cli_child_env
- pre-commit hooks: cargo doc, cargo clippy