### PR TITLE
feat(platform): add presentation speaker notes export

### DIFF
--- a/turbo/apps/platform/package.json
+++ b/turbo/apps/platform/package.json
@@ -39,6 +39,7 @@
     "dom-to-pptx": "1.1.10",
     "highlight.js": "^11.11.1",
     "idb": "~8.0.3",
+    "jszip": "^3.10.1",
     "katex": "^0.17.0",
     "lowlight": "^3.3.0",
     "path-to-regexp": "^8.4.0",

--- a/turbo/apps/platform/src/signals/zero-page/settings/connectors.ts
+++ b/turbo/apps/platform/src/signals/zero-page/settings/connectors.ts
@@ -1362,7 +1362,7 @@ function waitForOAuthAuthCodePopupClosed(
 
   const deferred = Promise.withResolvers<"popupClosed">();
   let settled = false;
-  let intervalId: ReturnType<typeof window.setInterval> | undefined;
+  let intervalId: number | undefined;
 
   function cleanup() {
     if (intervalId !== undefined) {

--- a/turbo/apps/platform/src/views/zero-page/__tests__/presentation-html-pptx-download.test.ts
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/presentation-html-pptx-download.test.ts
@@ -81,6 +81,20 @@ function presentationHtmlResponse(html: string) {
   });
 }
 
+function isRequestedPresentationUrl(
+  requestedUrl: string | null,
+  fileUrl: string,
+): boolean {
+  if (!requestedUrl) {
+    return false;
+  }
+  const actual = new URL(requestedUrl);
+  const expected = new URL(fileUrl);
+  return (
+    actual.origin === expected.origin && actual.pathname === expected.pathname
+  );
+}
+
 test("downloads presentation HTML as PPTX through an export iframe", async () => {
   const fileUrl = "https://demo-deck.sites.vm0.io";
   let presentationHtmlRequested = false;
@@ -215,7 +229,7 @@ test("injects presentation speaker notes into the downloaded PPTX blob", async (
           : request.url;
       if (
         requestUrl.hostname !== "demo-deck.sites.vm0.io" &&
-        !requestedUrl?.startsWith(fileUrl)
+        !isRequestedPresentationUrl(requestedUrl, fileUrl)
       ) {
         return new HttpResponse(null, { status: 404 });
       }
@@ -321,7 +335,7 @@ test("maps speaker notes using presentation slide order instead of slide file nu
           : request.url;
       if (
         requestUrl.hostname !== "demo-deck.sites.vm0.io" &&
-        !requestedUrl?.startsWith(fileUrl)
+        !isRequestedPresentationUrl(requestedUrl, fileUrl)
       ) {
         return new HttpResponse(null, { status: 404 });
       }

--- a/turbo/apps/platform/src/views/zero-page/__tests__/presentation-html-pptx-download.test.ts
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/presentation-html-pptx-download.test.ts
@@ -1,12 +1,97 @@
-import { expect, test } from "vitest";
+import { expect, test, vi } from "vitest";
 import { waitFor } from "@testing-library/react";
 import { http, HttpResponse } from "msw";
+import JSZip from "jszip";
 import { server } from "../../../mocks/server.ts";
-import { downloadPresentationHtmlPptx } from "../presentation-html-pptx-download.ts";
+import {
+  downloadPresentationHtmlPptx,
+  presentationSpeakerNotesFromHtml,
+} from "../presentation-html-pptx-download.ts";
+
+const contentTypesNs =
+  "http://schemas.openxmlformats.org/package/2006/content-types";
+const packageRelationshipsNs =
+  "http://schemas.openxmlformats.org/package/2006/relationships";
+const presentationNs =
+  "http://schemas.openxmlformats.org/presentationml/2006/main";
+const relationshipNs =
+  "http://schemas.openxmlformats.org/officeDocument/2006/relationships";
+
+async function minimalPptxBlob(
+  slideNumbers: readonly number[] = [1, 2],
+): Promise<Blob> {
+  const zip = new JSZip();
+  const slideRelationshipEntries = slideNumbers
+    .map((slideNumber, index) => {
+      return `<Relationship Id="rId${index + 1}" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/slide" Target="slides/slide${slideNumber}.xml"/>`;
+    })
+    .join("\n  ");
+  const slideIdEntries = slideNumbers
+    .map((_, index) => {
+      return `    <p:sldId id="${256 + index}" r:id="rId${index + 1}"/>`;
+    })
+    .join("\n");
+  const slideContentTypeEntries = slideNumbers
+    .map((slideNumber) => {
+      return `  <Override PartName="/ppt/slides/slide${slideNumber}.xml" ContentType="application/vnd.openxmlformats-officedocument.presentationml.slide+xml"/>`;
+    })
+    .join("\n");
+  zip.file(
+    "[Content_Types].xml",
+    `<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<Types xmlns="${contentTypesNs}">
+  <Default Extension="rels" ContentType="application/vnd.openxmlformats-package.relationships+xml"/>
+  <Default Extension="xml" ContentType="application/xml"/>
+  <Override PartName="/ppt/presentation.xml" ContentType="application/vnd.openxmlformats-officedocument.presentationml.presentation.main+xml"/>
+${slideContentTypeEntries}
+</Types>`,
+  );
+  zip.file(
+    "ppt/presentation.xml",
+    `<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<p:presentation xmlns:p="${presentationNs}" xmlns:r="${relationshipNs}">
+  <p:sldIdLst>
+${slideIdEntries}
+  </p:sldIdLst>
+</p:presentation>`,
+  );
+  zip.file(
+    "ppt/_rels/presentation.xml.rels",
+    `<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<Relationships xmlns="${packageRelationshipsNs}">
+  ${slideRelationshipEntries}
+</Relationships>`,
+  );
+  for (const slideNumber of slideNumbers) {
+    zip.file(
+      `ppt/slides/slide${String(slideNumber)}.xml`,
+      `<?xml version="1.0" encoding="UTF-8" standalone="yes"?><p:sld xmlns:p="${presentationNs}"><p:cSld/></p:sld>`,
+    );
+    zip.file(
+      `ppt/slides/_rels/slide${String(slideNumber)}.xml.rels`,
+      `<?xml version="1.0" encoding="UTF-8" standalone="yes"?><Relationships xmlns="${packageRelationshipsNs}"/>`,
+    );
+  }
+  return zip.generateAsync({ type: "blob" });
+}
+
+function presentationHtmlResponse(html: string) {
+  return HttpResponse.text(html, {
+    headers: { "Content-Type": "text/html; charset=utf-8" },
+  });
+}
 
 test("downloads presentation HTML as PPTX through an export iframe", async () => {
   const fileUrl = "https://demo-deck.sites.vm0.io";
   let presentationHtmlRequested = false;
+  let downloadedBlob: Blob | null = null;
+  vi.spyOn(URL, "createObjectURL").mockImplementation((blob) => {
+    downloadedBlob = blob as Blob;
+    return "blob:pptx-download";
+  });
+  vi.spyOn(URL, "revokeObjectURL").mockImplementation(() => {
+    return;
+  });
   server.use(
     http.get("/__vm0-dev-artifact-fetch", ({ request }) => {
       const requestUrl = new URL(request.url);
@@ -14,7 +99,7 @@ test("downloads presentation HTML as PPTX through an export iframe", async () =>
         return new HttpResponse(null, { status: 404 });
       }
       presentationHtmlRequested = true;
-      return HttpResponse.html(`
+      return presentationHtmlResponse(`
         <!doctype html>
         <html>
           <head><title>Demo deck</title></head>
@@ -51,6 +136,7 @@ test("downloads presentation HTML as PPTX through an export iframe", async () =>
   );
   expect(exportFrame.srcdoc).toContain("window.domToPptx.exportToPptx");
   expect(exportFrame.srcdoc).toContain("demo-deck.pptx");
+  expect(exportFrame.srcdoc).toContain('"skipDownload":true');
 
   window.dispatchEvent(
     new MessageEvent("message", {
@@ -58,10 +144,244 @@ test("downloads presentation HTML as PPTX through an export iframe", async () =>
       data: {
         type: "vm0-presentation-pptx-export",
         status: "success",
+        blob: await minimalPptxBlob(),
       },
     }),
   );
 
   await download;
   expect(exportFrame).not.toBeInTheDocument();
+  expect(downloadedBlob).toBeInstanceOf(Blob);
+});
+
+test("extracts speaker notes from presentation HTML metadata in slide order", () => {
+  expect(
+    presentationSpeakerNotesFromHtml(`
+      <!doctype html>
+      <html>
+        <body>
+          <section class="slide" data-slide-id="intro"></section>
+          <section class="slide" data-slide-id="closing"></section>
+          <script type="application/json" id="vm0-deck-metadata">
+            {
+              "kind": "presentation-html",
+              "slides": {
+                "closing": { "speakerNotes": "Closing note" },
+                "intro": { "speakerNotes": "Intro note" }
+              }
+            }
+          </script>
+        </body>
+      </html>
+    `),
+  ).toStrictEqual([
+    { slideNumber: 1, notes: "Intro note" },
+    { slideNumber: 2, notes: "Closing note" },
+  ]);
+});
+
+test("ignores malformed presentation metadata when extracting speaker notes", () => {
+  expect(
+    presentationSpeakerNotesFromHtml(`
+      <!doctype html>
+      <html>
+        <body>
+          <section class="slide" data-slide-id="intro"></section>
+          <script type="application/json" id="vm0-deck-metadata">
+            { not-json
+          </script>
+        </body>
+      </html>
+    `),
+  ).toStrictEqual([{ slideNumber: 1, notes: "" }]);
+});
+
+test("injects presentation speaker notes into the downloaded PPTX blob", async () => {
+  const fileUrl = "https://demo-deck.sites.vm0.io";
+  let downloadedBlob: Blob | null = null;
+  vi.spyOn(URL, "createObjectURL").mockImplementation((blob) => {
+    downloadedBlob = blob as Blob;
+    return "blob:pptx-download";
+  });
+  vi.spyOn(URL, "revokeObjectURL").mockImplementation(() => {
+    return;
+  });
+  server.use(
+    http.get("*", ({ request }) => {
+      const requestUrl = new URL(request.url);
+      const requestedUrl =
+        requestUrl.pathname === "/__vm0-dev-artifact-fetch"
+          ? requestUrl.searchParams.get("url")
+          : request.url;
+      if (
+        requestUrl.hostname !== "demo-deck.sites.vm0.io" &&
+        !requestedUrl?.startsWith(fileUrl)
+      ) {
+        return new HttpResponse(null, { status: 404 });
+      }
+      return presentationHtmlResponse(`
+        <!doctype html>
+        <html>
+          <body>
+            <section data-vm0-slide data-slide-id="slide-1">
+              <h1>First</h1>
+            </section>
+            <section data-vm0-slide data-slide-id="slide-2">
+              <h1>Second</h1>
+            </section>
+            <script type="application/json" id="vm0-deck-metadata">
+              {
+                "kind": "presentation-html",
+                "slides": {
+                  "slide-1": { "speakerNotes": "First <note> & detail" },
+                  "slide-2": { "speakerNotes": "Second note" }
+                }
+              }
+            </script>
+          </body>
+        </html>
+      `);
+    }),
+  );
+
+  const download = downloadPresentationHtmlPptx({
+    filename: "demo-deck.html",
+    signal: AbortSignal.any([]),
+    url: fileUrl,
+  });
+  const exportFrame = await waitFor(() => {
+    const frame = document.querySelector<HTMLIFrameElement>(
+      'iframe[title="Presentation PPTX export"]',
+    );
+    expect(frame).not.toBeNull();
+    return frame;
+  });
+  if (!exportFrame) {
+    throw new Error("Presentation export iframe was not created");
+  }
+
+  window.dispatchEvent(
+    new MessageEvent("message", {
+      source: exportFrame.contentWindow,
+      data: {
+        type: "vm0-presentation-pptx-export",
+        status: "success",
+        blob: await minimalPptxBlob(),
+      },
+    }),
+  );
+  await download;
+
+  if (!downloadedBlob) {
+    throw new Error("PPTX was not downloaded");
+  }
+  const zip = await JSZip.loadAsync(downloadedBlob);
+  await expect(
+    zip.file("ppt/notesSlides/notesSlide1.xml")?.async("string"),
+  ).resolves.toContain("First &lt;note&gt; &amp; detail");
+  await expect(
+    zip.file("ppt/notesSlides/notesSlide2.xml")?.async("string"),
+  ).resolves.toContain("Second note");
+  await expect(
+    zip.file("ppt/slides/_rels/slide1.xml.rels")?.async("string"),
+  ).resolves.toContain("notesSlide1.xml");
+  await expect(
+    zip.file("[Content_Types].xml")?.async("string"),
+  ).resolves.toContain("/ppt/notesMasters/notesMaster1.xml");
+  const presentationXml = await zip
+    .file("ppt/presentation.xml")
+    ?.async("string");
+  expect(presentationXml?.indexOf("<p:sldIdLst>")).toBeGreaterThan(-1);
+  expect(presentationXml?.indexOf("<p:notesMasterIdLst>")).toBeGreaterThan(-1);
+  expect(
+    presentationXml!.indexOf("<p:sldIdLst>") <
+      presentationXml!.indexOf("<p:notesMasterIdLst>"),
+  ).toBeTruthy();
+  await expect(
+    zip.file("ppt/notesMasters/_rels/notesMaster1.xml.rels")?.async("string"),
+  ).resolves.toContain("relationships/theme");
+});
+
+test("maps speaker notes using presentation slide order instead of slide file numbers", async () => {
+  const fileUrl = "https://demo-deck.sites.vm0.io";
+  let downloadedBlob: Blob | null = null;
+  vi.spyOn(URL, "createObjectURL").mockImplementation((blob) => {
+    downloadedBlob = blob as Blob;
+    return "blob:pptx-download";
+  });
+  vi.spyOn(URL, "revokeObjectURL").mockImplementation(() => {
+    return;
+  });
+  server.use(
+    http.get("*", ({ request }) => {
+      const requestUrl = new URL(request.url);
+      const requestedUrl =
+        requestUrl.pathname === "/__vm0-dev-artifact-fetch"
+          ? requestUrl.searchParams.get("url")
+          : request.url;
+      if (
+        requestUrl.hostname !== "demo-deck.sites.vm0.io" &&
+        !requestedUrl?.startsWith(fileUrl)
+      ) {
+        return new HttpResponse(null, { status: 404 });
+      }
+      return presentationHtmlResponse(`
+        <!doctype html>
+        <html>
+          <body>
+            <section data-vm0-slide data-slide-id="slide-1"></section>
+            <section data-vm0-slide data-slide-id="slide-2"></section>
+            <script type="application/json" id="vm0-deck-metadata">
+              {
+                "kind": "presentation-html",
+                "slides": {
+                  "slide-1": { "speakerNotes": "First note" },
+                  "slide-2": { "speakerNotes": "Second note" }
+                }
+              }
+            </script>
+          </body>
+        </html>
+      `);
+    }),
+  );
+
+  const download = downloadPresentationHtmlPptx({
+    filename: "demo-deck.html",
+    signal: AbortSignal.any([]),
+    url: fileUrl,
+  });
+  const exportFrame = await waitFor(() => {
+    const frame = document.querySelector<HTMLIFrameElement>(
+      'iframe[title="Presentation PPTX export"]',
+    );
+    expect(frame).not.toBeNull();
+    return frame;
+  });
+  if (!exportFrame) {
+    throw new Error("Presentation export iframe was not created");
+  }
+
+  window.dispatchEvent(
+    new MessageEvent("message", {
+      source: exportFrame.contentWindow,
+      data: {
+        type: "vm0-presentation-pptx-export",
+        status: "success",
+        blob: await minimalPptxBlob([2, 5]),
+      },
+    }),
+  );
+  await download;
+
+  if (!downloadedBlob) {
+    throw new Error("PPTX was not downloaded");
+  }
+  const zip = await JSZip.loadAsync(downloadedBlob);
+  await expect(
+    zip.file("ppt/notesSlides/notesSlide2.xml")?.async("string"),
+  ).resolves.toContain("First note");
+  await expect(
+    zip.file("ppt/notesSlides/notesSlide5.xml")?.async("string"),
+  ).resolves.toContain("Second note");
 });

--- a/turbo/apps/platform/src/views/zero-page/__tests__/presentation-html-pptx-download.test.ts
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/presentation-html-pptx-download.test.ts
@@ -17,7 +17,7 @@ const presentationNs =
 const relationshipNs =
   "http://schemas.openxmlformats.org/officeDocument/2006/relationships";
 
-async function minimalPptxBlob(
+function minimalPptxBlob(
   slideNumbers: readonly number[] = [1, 2],
 ): Promise<Blob> {
   const zip = new JSZip();

--- a/turbo/apps/platform/src/views/zero-page/presentation-html-editor.tsx
+++ b/turbo/apps/platform/src/views/zero-page/presentation-html-editor.tsx
@@ -140,6 +140,19 @@ function updateBlockText(
   });
 }
 
+function updateSlideNotes(
+  slides: readonly PresentationSlideDraft[],
+  slideId: string,
+  notes: string,
+): readonly PresentationSlideDraft[] {
+  return slides.map((slide) => {
+    if (slide.id === slideId) {
+      return { ...slide, notes };
+    }
+    return slide;
+  });
+}
+
 function editSignature(params: {
   readonly blocks: readonly PresentationEditBlock[];
   readonly slides: readonly PresentationSlideDraft[];
@@ -667,6 +680,18 @@ function updateSlideThumbnail(params: {
   }
 }
 
+function syncNotesPanel(slide: PresentationSlideDraft | undefined): void {
+  const textarea = document.querySelector<HTMLTextAreaElement>(
+    "[data-presentation-notes-input]",
+  );
+  if (textarea) {
+    textarea.dataset.presentationNotesSlideId = slide?.id ?? "";
+    if (textarea.value !== (slide?.notes ?? "")) {
+      textarea.value = slide?.notes ?? "";
+    }
+  }
+}
+
 async function ensurePresentationRedeployed(params: {
   readonly buildEditedHtml: () => string;
   readonly createClient: ZeroClientFactory;
@@ -737,6 +762,7 @@ function PresentationEditorWorkspace({
   previewHtml,
   queueSlideThumbnailUpdate,
   showSlide,
+  slidesRef,
   slides,
 }: {
   activeSlide: PresentationSlideDraft | undefined;
@@ -748,9 +774,10 @@ function PresentationEditorWorkspace({
   previewHtml: string | null;
   queueSlideThumbnailUpdate: (slideId: string) => void;
   showSlide: (slideId: string) => void;
+  slidesRef: MutableValue<readonly PresentationSlideDraft[]>;
   slides: readonly PresentationSlideDraft[];
 }) {
-  if (slides.length === 0 || blocksRef.current.length === 0 || !activeSlide) {
+  if (slides.length === 0 || !activeSlide) {
     return <UnsupportedPresentation />;
   }
   const slidePreviewHtml = (slideId: string) => {
@@ -768,20 +795,52 @@ function PresentationEditorWorkspace({
         setActiveSlideId={showSlide}
         slides={slides}
       />
-      <PreviewPane
-        html={previewHtml}
-        iframeRef={previewFrameRef}
-        updateText={(slideId, editId, text) => {
-          const block = blocksRef.current.find((candidate) => {
-            return candidate.slideId === slideId && candidate.editId === editId;
-          });
-          if (block) {
-            blocksRef.current = updateBlockText(blocksRef.current, block, text);
-            markDirty();
-            queueSlideThumbnailUpdate(slideId);
-          }
-        }}
-      />
+      <div className="grid min-h-0 grid-rows-[minmax(0,1fr)_180px] overflow-hidden">
+        <PreviewPane
+          html={previewHtml}
+          iframeRef={previewFrameRef}
+          updateText={(slideId, editId, text) => {
+            const block = blocksRef.current.find((candidate) => {
+              return (
+                candidate.slideId === slideId && candidate.editId === editId
+              );
+            });
+            if (block) {
+              blocksRef.current = updateBlockText(
+                blocksRef.current,
+                block,
+                text,
+              );
+              markDirty();
+              queueSlideThumbnailUpdate(slideId);
+            }
+          }}
+        />
+        <section className="flex min-h-0 flex-col border-t border-border/60 bg-background">
+          <textarea
+            aria-label="Speaker notes"
+            data-presentation-notes-input="true"
+            data-presentation-notes-slide-id={activeSlide.id}
+            defaultValue={activeSlide.notes}
+            placeholder="Add speaker notes"
+            spellCheck={false}
+            onChange={(event) => {
+              const slideId =
+                event.currentTarget.dataset.presentationNotesSlideId;
+              if (!slideId) {
+                return;
+              }
+              slidesRef.current = updateSlideNotes(
+                slidesRef.current,
+                slideId,
+                event.currentTarget.value,
+              );
+              markDirty();
+            }}
+            className="min-h-0 flex-1 resize-none bg-background px-4 py-3 text-sm leading-6 text-foreground outline-none placeholder:text-muted-foreground focus:bg-muted/20"
+          />
+        </section>
+      </div>
     </div>
   );
 }
@@ -798,11 +857,12 @@ function createPresentationEditorController(params: {
   readonly publishedSignatureRef: MutableValue<string>;
   readonly publishingRef: MutableValue<boolean>;
   readonly refreshPresentationHtmlPreviews: () => void;
+  readonly slidesRef: MutableValue<readonly PresentationSlideDraft[]>;
   readonly sourceUrl: string;
   readonly statusRef: MutableValue<HTMLDivElement | null>;
   readonly thumbnailUpdateFrameRef: MutableValue<number | null>;
 }) {
-  const slides = params.draft.slides;
+  const slides = params.slidesRef.current;
   const activeSlideId = params.activeSlideIdRef.current;
   const activeSlide = slides.find((slide) => {
     return slide.id === activeSlideId;
@@ -811,11 +871,14 @@ function createPresentationEditorController(params: {
     return buildPresentationEditorHtml({
       blocks: params.blocksRef.current,
       draft: params.draft,
-      slides,
+      slides: params.slidesRef.current,
     });
   };
   const currentSignature = () => {
-    return editSignature({ blocks: params.blocksRef.current, slides });
+    return editSignature({
+      blocks: params.blocksRef.current,
+      slides: params.slidesRef.current,
+    });
   };
   const setStatus = (value: string) => {
     setEditorStatus(params.statusRef, value);
@@ -870,6 +933,11 @@ function createPresentationEditorController(params: {
   };
   const showSlide = (slideId: string) => {
     params.activeSlideIdRef.current = slideId;
+    syncNotesPanel(
+      params.slidesRef.current.find((slide) => {
+        return slide.id === slideId;
+      }),
+    );
     showPresentationSlide({
       buildEditedHtml,
       previewFrameRef: params.previewFrameRef,
@@ -919,6 +987,8 @@ function PresentationEditorReady({
   const blocksRef = mutableValue<readonly PresentationEditBlock[]>(
     draft.blocks,
   );
+  const slidesRef =
+    mutableValue<readonly PresentationSlideDraft[]>(initialSlides);
   const activeSlideIdRef = mutableValue(initialSlides[0]?.id ?? "");
   const publishedSignatureRef = mutableValue(
     editSignature({ blocks: draft.blocks, slides: initialSlides }),
@@ -941,6 +1011,7 @@ function PresentationEditorReady({
     publishedSignatureRef,
     publishingRef,
     refreshPresentationHtmlPreviews,
+    slidesRef,
     sourceUrl,
     statusRef,
     thumbnailUpdateFrameRef,
@@ -1009,6 +1080,7 @@ function PresentationEditorReady({
         previewHtml={controller.previewHtml}
         queueSlideThumbnailUpdate={controller.queueSlideThumbnailUpdate}
         showSlide={controller.showSlide}
+        slidesRef={slidesRef}
         slides={controller.slides}
       />
     </div>

--- a/turbo/apps/platform/src/views/zero-page/presentation-html-pptx-download.ts
+++ b/turbo/apps/platform/src/views/zero-page/presentation-html-pptx-download.ts
@@ -727,9 +727,14 @@ async function zipText(zip: JSZip, path: string): Promise<string | null> {
 }
 
 function xmlTagAttribute(tag: string, attribute: string): string | null {
-  const escapedAttribute = attribute.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
-  const match = new RegExp(`\\b${escapedAttribute}="([^"]+)"`).exec(tag);
-  return match?.[1] ?? null;
+  const prefix = `${attribute}="`;
+  const start = tag.indexOf(prefix);
+  if (start < 0) {
+    return null;
+  }
+  const valueStart = start + prefix.length;
+  const valueEnd = tag.indexOf('"', valueStart);
+  return valueEnd < 0 ? null : tag.slice(valueStart, valueEnd);
 }
 
 async function presentationSlideNumbers(

--- a/turbo/apps/platform/src/views/zero-page/presentation-html-pptx-download.ts
+++ b/turbo/apps/platform/src/views/zero-page/presentation-html-pptx-download.ts
@@ -64,7 +64,7 @@ type ExportFrameMessage =
       readonly type: "vm0-presentation-pptx-export";
     };
 
-export interface PresentationPptxSpeakerNote {
+interface PresentationPptxSpeakerNote {
   readonly notes: string;
   readonly slideNumber: number;
 }
@@ -729,12 +729,12 @@ async function zipText(zip: JSZip, path: string): Promise<string | null> {
 function xmlTagAttribute(tag: string, attribute: string): string | null {
   const prefix = `${attribute}="`;
   const start = tag.indexOf(prefix);
-  if (start < 0) {
+  if (start === -1) {
     return null;
   }
   const valueStart = start + prefix.length;
   const valueEnd = tag.indexOf('"', valueStart);
-  return valueEnd < 0 ? null : tag.slice(valueStart, valueEnd);
+  return valueEnd === -1 ? null : tag.slice(valueStart, valueEnd);
 }
 
 async function presentationSlideNumbers(
@@ -926,7 +926,11 @@ function ensureNotesMasterIdList(doc: Document, relationshipId: string): void {
       return node instanceof Element && node.localName === "sldIdLst";
     });
     if (sldIdLst) {
-      presentation.insertBefore(list, sldIdLst.nextSibling);
+      if (sldIdLst.nextSibling) {
+        sldIdLst.nextSibling.before(list);
+      } else {
+        presentation.append(list);
+      }
       return;
     }
     presentation.append(list);

--- a/turbo/apps/platform/src/views/zero-page/presentation-html-pptx-download.ts
+++ b/turbo/apps/platform/src/views/zero-page/presentation-html-pptx-download.ts
@@ -1,13 +1,37 @@
 import { publicAttachmentUrl } from "./zero-attachment-url.ts";
 import domToPptxBundleUrl from "../../../node_modules/dom-to-pptx/dist/dom-to-pptx.bundle.js?url";
+import JSZip from "jszip";
 import {
   createDeferredPromise,
+  jsonParseOr,
   settle,
   withCleanup,
 } from "../../signals/utils.ts";
 
 const EXPORT_FONT_READY_TIMEOUT_MS = 800;
 const DEV_ARTIFACT_FETCH_PROXY_PATH = "/__vm0-dev-artifact-fetch";
+const METADATA_SCRIPT_ID = "vm0-deck-metadata";
+const CONTENT_TYPES_PATH = "[Content_Types].xml";
+const PRESENTATION_PATH = "ppt/presentation.xml";
+const PRESENTATION_RELS_PATH = "ppt/_rels/presentation.xml.rels";
+const CONTENT_TYPES_NS =
+  "http://schemas.openxmlformats.org/package/2006/content-types";
+const PACKAGE_RELATIONSHIPS_NS =
+  "http://schemas.openxmlformats.org/package/2006/relationships";
+const DRAWING_NS = "http://schemas.openxmlformats.org/drawingml/2006/main";
+const PRESENTATION_NS =
+  "http://schemas.openxmlformats.org/presentationml/2006/main";
+const RELATIONSHIP_NS =
+  "http://schemas.openxmlformats.org/officeDocument/2006/relationships";
+const NOTES_MASTER_REL_TYPE =
+  "http://schemas.openxmlformats.org/officeDocument/2006/relationships/notesMaster";
+const NOTES_SLIDE_REL_TYPE =
+  "http://schemas.openxmlformats.org/officeDocument/2006/relationships/notesSlide";
+const NOTES_MASTER_CONTENT_TYPE =
+  "application/vnd.openxmlformats-officedocument.presentationml.notesMaster+xml";
+const NOTES_SLIDE_CONTENT_TYPE =
+  "application/vnd.openxmlformats-officedocument.presentationml.notesSlide+xml";
+const NOTES_MASTER_REL_TARGET = "notesMasters/notesMaster1.xml";
 const SLIDE_SELECTORS = [
   "[data-vm0-slide]",
   "[data-slide]",
@@ -24,11 +48,13 @@ const SLIDE_SELECTORS = [
 type DomToPptxOptions = {
   readonly fileName: string;
   readonly layout: "LAYOUT_WIDE";
+  readonly skipDownload: boolean;
   readonly svgAsVector: boolean;
 };
 
 type ExportFrameMessage =
   | {
+      readonly blob?: unknown;
       readonly status: "success";
       readonly type: "vm0-presentation-pptx-export";
     }
@@ -37,6 +63,19 @@ type ExportFrameMessage =
       readonly status: "error";
       readonly type: "vm0-presentation-pptx-export";
     };
+
+export interface PresentationPptxSpeakerNote {
+  readonly notes: string;
+  readonly slideNumber: number;
+}
+
+interface DeckMetadataSlide {
+  readonly speakerNotes?: string;
+}
+
+interface DeckMetadata {
+  readonly slides?: Record<string, DeckMetadataSlide>;
+}
 
 function pptxFilename(filename: string): string {
   const base = filename
@@ -47,7 +86,10 @@ function pptxFilename(filename: string): string {
 }
 
 function domToPptxScriptUrl(): string {
-  return new URL(domToPptxBundleUrl, window.location.origin).toString();
+  const origin = URL.canParse(window.location.origin)
+    ? window.location.origin
+    : "http://localhost";
+  return new URL(domToPptxBundleUrl, origin).toString();
 }
 
 function canUseDevArtifactFetchProxy(): boolean {
@@ -95,6 +137,15 @@ function isExportFrameMessage(value: unknown): value is ExportFrameMessage {
     candidate.type === "vm0-presentation-pptx-export" &&
     (candidate.status === "success" ||
       (candidate.status === "error" && typeof candidate.message === "string"))
+  );
+}
+
+function isBlobLike(value: unknown): value is Blob {
+  return (
+    typeof value === "object" &&
+    value !== null &&
+    typeof (value as Blob).arrayBuffer === "function" &&
+    typeof (value as Blob).size === "number"
   );
 }
 
@@ -503,8 +554,8 @@ function createExportRunnerScript(): string {
     }
     revealSlideNodes(nodes);
     await waitForExportReadiness(nodes);
-    await window.domToPptx.exportToPptx(nodes, options);
-    post({ status: "success" });
+    const blob = await window.domToPptx.exportToPptx(nodes, options);
+    post({ status: "success", blob });
   })().catch((error) => {
     post({
       status: "error",
@@ -525,12 +576,11 @@ function createExportScript(options: DomToPptxOptions): string {
 }
 
 async function htmlWithExportScript(
-  html: string,
+  doc: Document,
   baseUrl: string,
   options: DomToPptxOptions,
   signal: AbortSignal,
 ): Promise<string> {
-  const doc = new DOMParser().parseFromString(html, "text/html");
   await inlineFetchableImages(doc, baseUrl, signal);
   for (const script of doc.querySelectorAll("script")) {
     script.remove();
@@ -571,8 +621,8 @@ function createExportFrame(html: string): HTMLIFrameElement {
 function waitForExportFrameMessage(
   frame: HTMLIFrameElement,
   signal: AbortSignal,
-): Promise<void> {
-  const deferred = createDeferredPromise<void>(signal);
+): Promise<Blob> {
+  const deferred = createDeferredPromise<Blob>(signal);
   const onMessage = (event: MessageEvent<unknown>) => {
     if (
       event.source !== frame.contentWindow ||
@@ -582,7 +632,11 @@ function waitForExportFrameMessage(
       return;
     }
     if (event.data.status === "success") {
-      deferred.resolve();
+      if (isBlobLike(event.data.blob)) {
+        deferred.resolve(event.data.blob);
+        return;
+      }
+      deferred.reject(new Error("dom-to-pptx did not return a PPTX blob"));
       return;
     }
     deferred.reject(new Error(event.data.message));
@@ -591,6 +645,494 @@ function waitForExportFrameMessage(
   return withCleanup(deferred.promise, () => {
     window.removeEventListener("message", onMessage);
   });
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function parseHtml(html: string): Document {
+  return new DOMParser().parseFromString(html, "text/html");
+}
+
+function parseDeckMetadata(doc: Document): DeckMetadata {
+  const script = doc.getElementById(METADATA_SCRIPT_ID);
+  if (!script?.textContent) {
+    return {};
+  }
+  const parsed = jsonParseOr<unknown>(script.textContent, null);
+  if (!isRecord(parsed) || !isRecord(parsed.slides)) {
+    return {};
+  }
+  const slides: Record<string, DeckMetadataSlide> = {};
+  for (const [slideId, value] of Object.entries(parsed.slides)) {
+    if (!isRecord(value)) {
+      continue;
+    }
+    const notes = value.speakerNotes;
+    slides[slideId] = typeof notes === "string" ? { speakerNotes: notes } : {};
+  }
+  return { slides };
+}
+
+function selectSlideElements(doc: Document): Element[] {
+  for (const selector of SLIDE_SELECTORS) {
+    const slides = Array.from(doc.querySelectorAll(selector));
+    if (slides.length > 0) {
+      return slides;
+    }
+  }
+  return doc.body ? [doc.body] : [];
+}
+
+function slideIdForElement(slide: Element, index: number): string {
+  return slide instanceof HTMLElement
+    ? (slide.dataset.slideId ?? `slide-${index + 1}`)
+    : `slide-${index + 1}`;
+}
+
+export function presentationSpeakerNotesFromHtml(
+  html: string,
+): readonly PresentationPptxSpeakerNote[] {
+  return presentationSpeakerNotesFromDocument(parseHtml(html));
+}
+
+function presentationSpeakerNotesFromDocument(
+  doc: Document,
+): readonly PresentationPptxSpeakerNote[] {
+  const metadata = parseDeckMetadata(doc);
+  return selectSlideElements(doc).map((slide, index) => {
+    const slideId = slideIdForElement(slide, index);
+    return {
+      slideNumber: index + 1,
+      notes: metadata.slides?.[slideId]?.speakerNotes ?? "",
+    };
+  });
+}
+
+function serializeXml(doc: Document): string {
+  return new XMLSerializer().serializeToString(doc);
+}
+
+function parseXml(xml: string, title: string): Document {
+  const doc = new DOMParser().parseFromString(xml, "text/xml");
+  if (doc.getElementsByTagName("parsererror").length > 0) {
+    throw new Error(`${title} is not valid XML`);
+  }
+  return doc;
+}
+
+async function zipText(zip: JSZip, path: string): Promise<string | null> {
+  return (await zip.file(path)?.async("string")) ?? null;
+}
+
+function xmlTagAttribute(tag: string, attribute: string): string | null {
+  const escapedAttribute = attribute.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+  const match = new RegExp(`\\b${escapedAttribute}="([^"]+)"`).exec(tag);
+  return match?.[1] ?? null;
+}
+
+async function presentationSlideNumbers(
+  zip: JSZip,
+): Promise<readonly number[]> {
+  const [presentationXml, relationshipsXml] = await Promise.all([
+    zipText(zip, PRESENTATION_PATH),
+    zipText(zip, PRESENTATION_RELS_PATH),
+  ]);
+  if (!presentationXml || !relationshipsXml) {
+    throw new Error("PPTX presentation structure is missing slide metadata");
+  }
+  const slideTargetsByRelationshipId = new Map(
+    Array.from(relationshipsXml.matchAll(/<Relationship\b[^>]*\/?>/g))
+      .map((match) => {
+        const relationship = match[0];
+        const id = xmlTagAttribute(relationship, "Id");
+        const type = xmlTagAttribute(relationship, "Type");
+        const target = xmlTagAttribute(relationship, "Target");
+        if (
+          !id ||
+          type !==
+            "http://schemas.openxmlformats.org/officeDocument/2006/relationships/slide" ||
+          !target
+        ) {
+          return null;
+        }
+        return [id, target] as const;
+      })
+      .filter((entry): entry is readonly [string, string] => {
+        return entry !== null;
+      }),
+  );
+  return Array.from(
+    presentationXml.matchAll(/<(?:[\w.-]+:)?sldId\b[^>]*\br:id="([^"]+)"/g),
+  )
+    .map((slideIdMatch) => {
+      const relationshipId = slideIdMatch[1];
+      const target = relationshipId
+        ? slideTargetsByRelationshipId.get(relationshipId)
+        : null;
+      const slideTargetMatch = target ? /slide(\d+)\.xml$/.exec(target) : null;
+      return slideTargetMatch ? Number(slideTargetMatch[1]) : null;
+    })
+    .filter((slideNumber): slideNumber is number => {
+      return slideNumber !== null;
+    });
+}
+
+function relationshipIdNumber(value: string): number | null {
+  const match = /^rId(\d+)$/.exec(value);
+  return match ? Number(match[1]) : null;
+}
+
+function nextRelationshipId(doc: Document): string {
+  const max = Array.from(doc.getElementsByTagName("Relationship")).reduce(
+    (current, rel) => {
+      const id = rel.getAttribute("Id");
+      const number = id ? relationshipIdNumber(id) : null;
+      return number && number > current ? number : current;
+    },
+    0,
+  );
+  return `rId${max + 1}`;
+}
+
+function removeRelationshipsByType(doc: Document, type: string): void {
+  for (const rel of Array.from(doc.getElementsByTagName("Relationship"))) {
+    if (rel.getAttribute("Type") === type) {
+      rel.remove();
+    }
+  }
+}
+
+function addRelationship(params: {
+  readonly doc: Document;
+  readonly id: string;
+  readonly target: string;
+  readonly type: string;
+}): void {
+  const relationships = params.doc.documentElement;
+  const rel = params.doc.createElementNS(
+    PACKAGE_RELATIONSHIPS_NS,
+    "Relationship",
+  );
+  rel.setAttribute("Id", params.id);
+  rel.setAttribute("Type", params.type);
+  rel.setAttribute("Target", params.target);
+  relationships.append(rel);
+}
+
+function ensureContentTypeOverride(params: {
+  readonly contentType: string;
+  readonly doc: Document;
+  readonly partName: string;
+}): void {
+  const existing = Array.from(params.doc.getElementsByTagName("Override")).some(
+    (override) => {
+      return override.getAttribute("PartName") === params.partName;
+    },
+  );
+  if (existing) {
+    return;
+  }
+  const override = params.doc.createElementNS(CONTENT_TYPES_NS, "Override");
+  override.setAttribute("PartName", params.partName);
+  override.setAttribute("ContentType", params.contentType);
+  params.doc.documentElement.append(override);
+}
+
+async function ensureNotesContentTypes(
+  zip: JSZip,
+  slideNumbers: readonly number[],
+): Promise<void> {
+  const xml = await zipText(zip, CONTENT_TYPES_PATH);
+  if (!xml) {
+    throw new Error("PPTX content types file is missing");
+  }
+  const doc = parseXml(xml, CONTENT_TYPES_PATH);
+  ensureContentTypeOverride({
+    contentType: NOTES_MASTER_CONTENT_TYPE,
+    doc,
+    partName: "/ppt/notesMasters/notesMaster1.xml",
+  });
+  for (const slideNumber of slideNumbers) {
+    ensureContentTypeOverride({
+      contentType: NOTES_SLIDE_CONTENT_TYPE,
+      doc,
+      partName: `/ppt/notesSlides/notesSlide${slideNumber}.xml`,
+    });
+  }
+  zip.file(CONTENT_TYPES_PATH, serializeXml(doc));
+}
+
+async function ensurePresentationNotesMasterRelationship(
+  zip: JSZip,
+): Promise<string> {
+  const xml = await zipText(zip, PRESENTATION_RELS_PATH);
+  if (!xml) {
+    throw new Error("PPTX presentation relationships file is missing");
+  }
+  const doc = parseXml(xml, PRESENTATION_RELS_PATH);
+  const existing = Array.from(doc.getElementsByTagName("Relationship")).find(
+    (rel) => {
+      return (
+        rel.getAttribute("Type") === NOTES_MASTER_REL_TYPE &&
+        rel.getAttribute("Target") === NOTES_MASTER_REL_TARGET
+      );
+    },
+  );
+  if (existing) {
+    const id = existing.getAttribute("Id");
+    if (id) {
+      return id;
+    }
+  }
+  const id = nextRelationshipId(doc);
+  addRelationship({
+    doc,
+    id,
+    target: NOTES_MASTER_REL_TARGET,
+    type: NOTES_MASTER_REL_TYPE,
+  });
+  zip.file(PRESENTATION_RELS_PATH, serializeXml(doc));
+  return id;
+}
+
+function ensureNotesMasterIdList(doc: Document, relationshipId: string): void {
+  const presentation = doc.documentElement;
+  const existing = Array.from(presentation.childNodes).find((node) => {
+    return node instanceof Element && node.localName === "notesMasterIdLst";
+  });
+  const list =
+    existing instanceof Element
+      ? existing
+      : doc.createElementNS(PRESENTATION_NS, "p:notesMasterIdLst");
+  let id: Element | undefined = Array.from(list.childNodes).find(
+    (node): node is Element => {
+      return node instanceof Element && node.localName === "notesMasterId";
+    },
+  );
+  if (!id) {
+    id = doc.createElementNS(PRESENTATION_NS, "p:notesMasterId");
+    list.append(id);
+  }
+  id.setAttributeNS(RELATIONSHIP_NS, "r:id", relationshipId);
+  if (!existing) {
+    const sldIdLst = Array.from(presentation.childNodes).find((node) => {
+      return node instanceof Element && node.localName === "sldIdLst";
+    });
+    if (sldIdLst) {
+      presentation.insertBefore(list, sldIdLst.nextSibling);
+      return;
+    }
+    presentation.append(list);
+  }
+}
+
+function ensureNotesSize(doc: Document): void {
+  const presentation = doc.documentElement;
+  const existing = Array.from(presentation.childNodes).some((node) => {
+    return node instanceof Element && node.localName === "notesSz";
+  });
+  if (existing) {
+    return;
+  }
+  const notesSize = doc.createElementNS(PRESENTATION_NS, "p:notesSz");
+  notesSize.setAttribute("cx", "6858000");
+  notesSize.setAttribute("cy", "9144000");
+  presentation.append(notesSize);
+}
+
+async function ensurePresentationNotesMetadata(
+  zip: JSZip,
+  relationshipId: string,
+): Promise<void> {
+  const xml = await zipText(zip, PRESENTATION_PATH);
+  if (!xml) {
+    throw new Error("PPTX presentation file is missing");
+  }
+  const doc = parseXml(xml, PRESENTATION_PATH);
+  ensureNotesMasterIdList(doc, relationshipId);
+  ensureNotesSize(doc);
+  zip.file(PRESENTATION_PATH, serializeXml(doc));
+}
+
+async function ensureSlideNotesRelationship(
+  zip: JSZip,
+  slideNumber: number,
+): Promise<void> {
+  const path = `ppt/slides/_rels/slide${slideNumber}.xml.rels`;
+  const xml = await zipText(zip, path);
+  if (!xml) {
+    return;
+  }
+  const doc = parseXml(xml, path);
+  removeRelationshipsByType(doc, NOTES_SLIDE_REL_TYPE);
+  addRelationship({
+    doc,
+    id: nextRelationshipId(doc),
+    target: `../notesSlides/notesSlide${slideNumber}.xml`,
+    type: NOTES_SLIDE_REL_TYPE,
+  });
+  zip.file(path, serializeXml(doc));
+}
+
+function xmlText(value: string): string {
+  return value
+    .replace(/&/g, "&amp;")
+    .replace(/</g, "&lt;")
+    .replace(/>/g, "&gt;");
+}
+
+function noteParagraphXml(notes: string): string {
+  const lines = notes.split(/\r\n|\r|\n/);
+  return lines
+    .map((line) => {
+      const text = xmlText(line);
+      return `<a:p><a:r><a:rPr lang="en-US" dirty="0"/><a:t>${text}</a:t></a:r><a:endParaRPr lang="en-US" dirty="0"/></a:p>`;
+    })
+    .join("");
+}
+
+function emptyGroupTransformXml(): string {
+  return '<a:xfrm><a:off x="0" y="0"/><a:ext cx="0" cy="0"/><a:chOff x="0" y="0"/><a:chExt cx="0" cy="0"/></a:xfrm>';
+}
+
+function notesMasterShapeTreeXml(): string {
+  return [
+    "<p:spTree>",
+    '<p:nvGrpSpPr><p:cNvPr id="1" name=""/><p:cNvGrpSpPr/><p:nvPr/></p:nvGrpSpPr>',
+    `<p:grpSpPr>${emptyGroupTransformXml()}</p:grpSpPr>`,
+    '<p:sp><p:nvSpPr><p:cNvPr id="2" name="Notes Placeholder 1"/><p:cNvSpPr><a:spLocks noGrp="1"/></p:cNvSpPr><p:nvPr><p:ph type="body" idx="1"/></p:nvPr></p:nvSpPr><p:spPr/><p:txBody><a:bodyPr/><a:lstStyle/><a:p><a:endParaRPr lang="en-US"/></a:p></p:txBody></p:sp>',
+    "</p:spTree>",
+  ].join("");
+}
+
+function notesMasterXml(): string {
+  return `<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<p:notesMaster xmlns:a="${DRAWING_NS}" xmlns:r="${RELATIONSHIP_NS}" xmlns:p="${PRESENTATION_NS}">
+  <p:cSld>
+    ${notesMasterShapeTreeXml()}
+  </p:cSld>
+  <p:clrMap bg1="lt1" tx1="dk1" bg2="lt2" tx2="dk2" accent1="accent1" accent2="accent2" accent3="accent3" accent4="accent4" accent5="accent5" accent6="accent6" hlink="hlink" folHlink="folHlink"/>
+  <p:notesStyle><a:lvl1pPr algn="l"><a:defRPr sz="1200"/></a:lvl1pPr></p:notesStyle>
+</p:notesMaster>`;
+}
+
+function notesMasterRelationshipXml(): string {
+  return `<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<Relationships xmlns="${PACKAGE_RELATIONSHIPS_NS}">
+  <Relationship Id="rId1" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/theme" Target="../theme/theme1.xml"/>
+</Relationships>`;
+}
+
+function notesSlideRelationshipXml(slideNumber: number): string {
+  return `<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<Relationships xmlns="${PACKAGE_RELATIONSHIPS_NS}">
+  <Relationship Id="rId1" Type="${NOTES_MASTER_REL_TYPE}" Target="../notesMasters/notesMaster1.xml"/>
+  <Relationship Id="rId2" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/slide" Target="../slides/slide${slideNumber}.xml"/>
+</Relationships>`;
+}
+
+function slideImagePlaceholderXml(): string {
+  return '<p:sp><p:nvSpPr><p:cNvPr id="2" name="Slide Image Placeholder 1"/><p:cNvSpPr><a:spLocks noGrp="1" noRot="1" noChangeAspect="1"/></p:cNvSpPr><p:nvPr><p:ph type="sldImg"/></p:nvPr></p:nvSpPr><p:spPr/></p:sp>';
+}
+
+function noteBodyPlaceholderXml(notes: string): string {
+  return `<p:sp><p:nvSpPr><p:cNvPr id="3" name="Notes Placeholder 2"/><p:cNvSpPr><a:spLocks noGrp="1"/></p:cNvSpPr><p:nvPr><p:ph type="body" idx="1"/></p:nvPr></p:nvSpPr><p:spPr/><p:txBody><a:bodyPr/><a:lstStyle/>${noteParagraphXml(notes)}</p:txBody></p:sp>`;
+}
+
+function slideNumberPlaceholderXml(displaySlideNumber: number): string {
+  return `<p:sp><p:nvSpPr><p:cNvPr id="4" name="Slide Number Placeholder 3"/><p:cNvSpPr><a:spLocks noGrp="1"/></p:cNvSpPr><p:nvPr><p:ph type="sldNum" idx="10"/></p:nvPr></p:nvSpPr><p:spPr/><p:txBody><a:bodyPr/><a:lstStyle/><a:p><a:fld id="{CE5E9CC1-C706-0F49-92D6-E571CC5EEA8F}" type="slidenum"><a:rPr lang="en-US"/><a:t>${displaySlideNumber}</a:t></a:fld><a:endParaRPr lang="en-US"/></a:p></p:txBody></p:sp>`;
+}
+
+function notesSlideShapeTreeXml(params: {
+  readonly displaySlideNumber: number;
+  readonly notes: string;
+}): string {
+  return [
+    "<p:spTree>",
+    '<p:nvGrpSpPr><p:cNvPr id="1" name=""/><p:cNvGrpSpPr/><p:nvPr/></p:nvGrpSpPr>',
+    `<p:grpSpPr>${emptyGroupTransformXml()}</p:grpSpPr>`,
+    slideImagePlaceholderXml(),
+    noteBodyPlaceholderXml(params.notes),
+    slideNumberPlaceholderXml(params.displaySlideNumber),
+    "</p:spTree>",
+  ].join("");
+}
+
+function notesSlideXml(params: {
+  readonly displaySlideNumber: number;
+  readonly notes: string;
+}): string {
+  return `<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<p:notes xmlns:a="${DRAWING_NS}" xmlns:r="${RELATIONSHIP_NS}" xmlns:p="${PRESENTATION_NS}">
+  <p:cSld>
+    ${notesSlideShapeTreeXml(params)}
+  </p:cSld>
+  <p:clrMapOvr><a:masterClrMapping/></p:clrMapOvr>
+</p:notes>`;
+}
+
+async function addSpeakerNotesToPptxBlob(params: {
+  readonly blob: Blob;
+  readonly notes: readonly PresentationPptxSpeakerNote[];
+}): Promise<Blob> {
+  const notesBySlide = new Map(
+    params.notes.map((note) => {
+      return [note.slideNumber, note.notes];
+    }),
+  );
+  const hasAnyNotes = Array.from(notesBySlide.values()).some((note) => {
+    return note.trim().length > 0;
+  });
+  if (!hasAnyNotes) {
+    return params.blob;
+  }
+  const zip = await JSZip.loadAsync(params.blob);
+  const slideNumbers = await presentationSlideNumbers(zip);
+  if (slideNumbers.length === 0) {
+    return params.blob;
+  }
+  await ensureNotesContentTypes(zip, slideNumbers);
+  const relationshipId = await ensurePresentationNotesMasterRelationship(zip);
+  await ensurePresentationNotesMetadata(zip, relationshipId);
+  zip.file("ppt/notesMasters/notesMaster1.xml", notesMasterXml());
+  zip.file(
+    "ppt/notesMasters/_rels/notesMaster1.xml.rels",
+    notesMasterRelationshipXml(),
+  );
+  for (let index = 0; index < slideNumbers.length; index += 1) {
+    const slideNumber = slideNumbers[index];
+    const displaySlideNumber = index + 1;
+    await ensureSlideNotesRelationship(zip, slideNumber);
+    zip.file(
+      `ppt/notesSlides/notesSlide${slideNumber}.xml`,
+      notesSlideXml({
+        displaySlideNumber,
+        notes: notesBySlide.get(displaySlideNumber) ?? "",
+      }),
+    );
+    zip.file(
+      `ppt/notesSlides/_rels/notesSlide${slideNumber}.xml.rels`,
+      notesSlideRelationshipXml(slideNumber),
+    );
+  }
+  return zip.generateAsync({
+    type: "blob",
+    compression: "DEFLATE",
+    compressionOptions: { level: 6 },
+  });
+}
+
+function downloadBlob(blob: Blob, filename: string): void {
+  const url = URL.createObjectURL(blob);
+  const anchor = document.createElement("a");
+  anchor.href = url;
+  anchor.download = filename;
+  document.body.append(anchor);
+  anchor.click();
+  anchor.remove();
+  URL.revokeObjectURL(url);
 }
 
 export async function downloadPresentationHtmlPptx(params: {
@@ -625,17 +1167,30 @@ export async function downloadPresentationHtmlStringPptx(params: {
 }): Promise<void> {
   const options = {
     fileName: pptxFilename(params.filename),
+    skipDownload: true,
     svgAsVector: true,
     layout: "LAYOUT_WIDE",
   } satisfies DomToPptxOptions;
+  const doc = parseHtml(params.html);
+  const notes = presentationSpeakerNotesFromDocument(doc);
   const exportHtml = await htmlWithExportScript(
-    params.html,
+    doc,
     params.baseUrl,
     options,
     params.signal,
   );
   const frame = createExportFrame(exportHtml);
-  await withCleanup(waitForExportFrameMessage(frame, params.signal), () => {
-    frame.remove();
+  const pptxBlob = await withCleanup(
+    waitForExportFrameMessage(frame, params.signal),
+    () => {
+      frame.remove();
+    },
+  );
+  params.signal.throwIfAborted();
+  const finalBlob = await addSpeakerNotesToPptxBlob({
+    blob: pptxBlob,
+    notes,
   });
+  params.signal.throwIfAborted();
+  downloadBlob(finalBlob, options.fileName);
 }

--- a/turbo/pnpm-lock.yaml
+++ b/turbo/pnpm-lock.yaml
@@ -562,6 +562,9 @@ importers:
       idb:
         specifier: ~8.0.3
         version: 8.0.3
+      jszip:
+        specifier: ^3.10.1
+        version: 3.10.1
       katex:
         specifier: ^0.17.0
         version: 0.17.0


### PR DESCRIPTION
## Summary
- add speaker notes editing to the presentation HTML editor with a notes textarea below the slide preview
- export PPTX as a blob and post-process it with JSZip to inject PowerPoint speaker notes parts and relationships
- add regression coverage for metadata note extraction and PPTX notes injection structure

## Testing
- pnpm -F @vm0/app exec eslint src/views/zero-page/presentation-html-editor.tsx --max-warnings 0
- pnpm -F @vm0/app exec vitest run src/views/zero-page/__tests__/presentation-html-pptx-download.test.ts
- pnpm -F @vm0/app exec vitest run src/views/zero-page/__tests__/presentation-html-edit-protocol.test.ts