### PR TITLE
fix: update serpapi connector icon

### DIFF
--- a/turbo/apps/platform/src/views/zero-page/components/settings/icons/serpapi.svg
+++ b/turbo/apps/platform/src/views/zero-page/components/settings/icons/serpapi.svg
@@ -1,18 +1,25 @@
-<svg aria-hidden="true" width="32" height="32" viewBox="0 0 200 200" fill="none" xmlns="http://www.w3.org/2000/svg">
+<svg
+  role="img"
+  viewBox="0 0 726.53998 726.53998"
+  fill="none"
+  xmlns="http://www.w3.org/2000/svg"
+>
+  <title>SerpApi</title>
+  <path
+    d="m 141.299,530.374 c 8.977,31.839 35.67,56.769 69.397,64.614 V 726.54 H 208.88 C 97.7879,726.54 6.95296,639.815 0.381836,530.374 Z m 69.397,-398.823 c -41.703,9.701 -72.653,45.522 -72.653,88.227 0,50.157 42.693,90.818 95.358,90.818 52.665,0 95.359,-40.661 95.359,-90.818 0,-42.705 -30.951,-78.526 -72.655,-88.227 V 0 H 517.66 C 629.366,2.23588e-4 720.592,87.6865 726.261,197.982 H 583.916 c -10.25,-39.63 -47.818,-69.021 -92.594,-69.021 -52.665,0 -95.358,40.66 -95.358,90.817 0,42.706 30.951,78.526 72.654,88.227 v 110.529 c -41.703,9.701 -72.654,45.522 -72.654,88.228 0,42.705 30.951,78.526 72.654,88.226 V 726.54 H 256.105 V 594.988 c 41.704,-9.701 72.655,-45.521 72.655,-88.226 0,-50.157 -42.694,-90.817 -95.359,-90.818 -44.776,0 -82.343,29.392 -92.593,69.022 H 0 V 208.88 C 1.97918e-4,93.5188 93.5188,1.97969e-4 208.88,0 h 1.816 z M 726.54,517.66 c 0,115.361 -93.519,208.88 -208.88,208.88 h -3.633 V 594.988 c 41.703,-9.701 72.654,-45.521 72.654,-88.226 0,-42.706 -30.95,-78.527 -72.654,-88.228 V 308.005 c 33.728,-7.846 60.421,-32.775 69.398,-64.614 H 726.54 Z"
+    fill="url(#serpapi-gradient)"
+  />
   <defs>
-    <linearGradient id="serpapi-gradient" x1="0" y1="200" x2="200" y2="0" gradientUnits="userSpaceOnUse">
-      <stop stop-color="#2F8EEA"/>
-      <stop offset="1" stop-color="#8D45EF"/>
+    <linearGradient
+      id="serpapi-gradient"
+      x1="73.562202"
+      y1="719.27502"
+      x2="653.88599"
+      y2="63.572201"
+      gradientUnits="userSpaceOnUse"
+    >
+      <stop stop-color="#377FEA" />
+      <stop offset="1" stop-color="#8C45EF" />
     </linearGradient>
   </defs>
-  <rect width="200" height="200" rx="58" fill="url(#serpapi-gradient)"/>
-  <rect x="58" width="12" height="62" fill="#FFFFFF"/>
-  <rect y="128" width="64" height="14" fill="#FFFFFF"/>
-  <rect x="58" y="137" width="14" height="63" fill="#FFFFFF"/>
-  <rect x="138" y="54" width="62" height="14" fill="#FFFFFF"/>
-  <rect x="132" y="63" width="14" height="137" fill="#FFFFFF"/>
-  <circle cx="64" cy="59.5" r="26.5" fill="#FFFFFF"/>
-  <circle cx="138" cy="59.5" r="26.5" fill="#FFFFFF"/>
-  <circle cx="64" cy="136.5" r="26.5" fill="#FFFFFF"/>
-  <circle cx="138" cy="136.5" r="26.5" fill="#FFFFFF"/>
 </svg>


### PR DESCRIPTION
## Summary
- replace the previous SerpApi icon recreation with the official compact logo SVG from `serpapi/media-kit`
- preserve the official SVG gradient colors (`#377FEA` to `#8C45EF`)
- keep the existing `serpapi` colorful icon mapping so the gradient is preserved in the connector UI

Reference: https://github.com/serpapi/media-kit/blob/master/serpapi-logo/logo.svg

Closes #16843

## Checks
- pnpm -C turbo exec prettier --write --parser html apps/platform/src/views/zero-page/components/settings/icons/serpapi.svg
- pnpm -C turbo exec prettier --check --parser html apps/platform/src/views/zero-page/components/settings/icons/serpapi.svg
- pnpm -C turbo exec prettier --check apps/platform/src/views/zero-page/components/settings/connector-icons.tsx
- pnpm -C turbo -F @vm0/app lint
- pnpm -C turbo -F @vm0/app check-types
