### PR TITLE
chore(ci): remove lighthouse-app job from turbo workflow

### DIFF
--- a/.github/workflows/turbo.yml
+++ b/.github/workflows/turbo.yml
@@ -2316,81 +2316,6 @@ jobs:
           header: lighthouse-web
           message: ${{ steps.lighthouse-comment-web.outputs.body }}
 
-  # Lighthouse CI audit for app homepage (failure blocks merge, skip is allowed)
-  lighthouse-app:
-    runs-on: ubuntu-latest
-    timeout-minutes: 15
-    concurrency:
-      group: lighthouse-app-${{ needs.prepare.outputs.job-ref }}
-      cancel-in-progress: true
-    needs: [prepare, deploy-api, deploy-web, deploy-app]
-    if: |
-      (github.event_name != 'push' || !startsWith(github.event.head_commit.message, 'chore: release')) &&
-      needs.prepare.outputs.job-ref != '' && (
-        needs.prepare.outputs.web-changed == 'true' ||
-        needs.prepare.outputs.cli-changed == 'true' ||
-        needs.prepare.outputs.ci-changed == 'true' ||
-        needs.prepare.outputs.platform-changed == 'true'
-      )
-    steps:
-      - uses: actions/checkout@v6
-      - uses: actions/setup-node@v6
-        with:
-          node-version: 22
-      - name: Install Chrome for Puppeteer
-        run: npx --yes --package @puppeteer/browsers@2.10.13 browsers install chrome
-      - name: Install LHCI CLI
-        run: npm install -g @lhci/cli
-      - name: Run Lighthouse CI (app)
-        continue-on-error: true
-        working-directory: e2e/lighthouse
-        run: |
-          lhci collect \
-            --config=lighthouserc-app.json \
-            --url="${APP_URL}" &&
-          lhci upload \
-            --config=lighthouserc-app.json
-        env:
-          WEB_URL: ${{ needs.deploy-web.outputs.preview-url }}
-          APP_URL: ${{ needs.prepare.outputs.app-preview-url }}
-          VERCEL_AUTOMATION_BYPASS_SECRET: ${{ secrets.VERCEL_AUTOMATION_BYPASS_SECRET }}
-          E2E_SERIAL_EMAIL: ${{ needs.prepare.outputs.job-ref }}+clerk_test+serial@vm0-e2e.ai
-      - name: Locate LHCI output (app)
-        id: lhci-dir-app
-        if: always()
-        run: |
-          for d in e2e/lighthouse/.lighthouseci .lighthouseci; do
-            if [ -d "$d" ] && ls "$d"/lhr-*.json >/dev/null 2>&1; then
-              echo "dir=$d" >> "$GITHUB_OUTPUT"
-              exit 0
-            fi
-          done
-          echo "dir=" >> "$GITHUB_OUTPUT"
-      - name: Upload Lighthouse report (app)
-        if: always() && steps.lhci-dir-app.outputs.dir != ''
-        uses: actions/upload-artifact@v7
-        with:
-          name: lighthouse-report-app
-          path: ${{ steps.lhci-dir-app.outputs.dir }}/
-          retention-days: 7
-      - name: Format Lighthouse comment (app)
-        if: success() && github.event_name == 'pull_request' && steps.lhci-dir-app.outputs.dir != ''
-        id: lighthouse-comment-app
-        run: |
-          comment=$(node e2e/lighthouse/format-report.cjs "App" "${{ steps.lhci-dir-app.outputs.dir }}")
-          {
-            echo "body<<LIGHTHOUSE_EOF"
-            echo "$comment"
-            echo "LIGHTHOUSE_EOF"
-          } >> "$GITHUB_OUTPUT"
-      - name: Post Lighthouse comment (app)
-        if: steps.lighthouse-comment-app.outcome == 'success'
-        continue-on-error: true
-        uses: marocchino/sticky-pull-request-comment@v3
-        with:
-          header: lighthouse-app
-          message: ${{ steps.lighthouse-comment-app.outputs.body }}
-
   # CI Gate: single required check for merge queue
   # Aggregates all job results — must ALWAYS run to report explicit success/failure.
   # Using !failure() or !cancelled() would cause the gate to be skipped when
@@ -2431,7 +2356,6 @@ jobs:
       - e2e-runner-bootstrap
       - cli-e2e-03-runner
       - lighthouse-web
-      - lighthouse-app
     # Always run so the gate reports an explicit result (not "skipped").
     # Release-please PRs skip CI jobs — auto-pass the gate for them.
     if: always()
@@ -2517,7 +2441,6 @@ jobs:
           check_result "cli-e2e-03-runner" "${{ needs.cli-e2e-03-runner.result }}" "$RUNNER_E2E_SKIP_ALLOWED"
           # Informational: any result is acceptable (not a merge blocker)
           check_result "lighthouse-web" "${{ needs.lighthouse-web.result }}" "informational"
-          check_result "lighthouse-app" "${{ needs.lighthouse-app.result }}" "informational"
 
           echo "::endgroup::"
           exit $FAILED

--- a/.github/workflows/turbo.yml
+++ b/.github/workflows/turbo.yml
@@ -1386,7 +1386,11 @@ jobs:
     concurrency:
       group: deploy-stripe-listener-${{ needs.prepare.outputs.job-ref }}
       cancel-in-progress: true
-    needs: [prepare, deploy-api]
+    # Runs in parallel with deploy-api: the forward URL is the deterministic
+    # prepare.outputs.api-preview-url (a stable alias, not a deploy-api output),
+    # and Stripe webhooks only fire during e2e payment tests, which run after
+    # deploy-api has succeeded — so the listener never forwards to a dead API.
+    needs: [prepare]
     if: |
       always() &&
       github.event_name != 'push' &&
@@ -1395,8 +1399,7 @@ jobs:
         needs.prepare.outputs.cli-changed == 'true' ||
         needs.prepare.outputs.ci-changed == 'true' ||
         needs.prepare.outputs.e2e-changed == 'true'
-      ) &&
-      needs.deploy-api.result == 'success'
+      )
     steps:
       - uses: actions/checkout@v6
 

--- a/.github/workflows/turbo.yml
+++ b/.github/workflows/turbo.yml
@@ -1273,7 +1273,7 @@ jobs:
       cancel-in-progress: true
     container:
       image: ghcr.io/vm0-ai/vm0-toolchain:20260525
-    needs: [prepare, deploy-api]
+    needs: [prepare]
     # Deploy if job-ref is set (PR or main), not a release-please commit, and platform/e2e/ci changed
     if: >-
       ${{
@@ -1305,7 +1305,7 @@ jobs:
           environment-variables: |
             VITE_CLERK_PUBLISHABLE_KEY=${{ vars.CLERK_PUBLISHABLE_KEY }}
             VITE_VERCEL_ENV=preview
-            VITE_API_URL=${{ needs.deploy-api.outputs.preview-url }}
+            VITE_API_URL=${{ needs.prepare.outputs.api-preview-url }}
             PUBLIC_ARTIFACTS_BASE_URL=${{ vars.PUBLIC_ARTIFACTS_BASE_URL_DEV || vars.PUBLIC_ARTIFACTS_BASE_URL }}
             VITE_ZERO_HOST_DOMAIN=${{ vars.ZERO_HOST_DOMAIN }}
             VITE_VAPID_PUBLIC_KEY=${{ vars.VAPID_PUBLIC_KEY }}

--- a/turbo/apps/api/src/index.ts
+++ b/turbo/apps/api/src/index.ts
@@ -6,6 +6,8 @@ import { createApp } from "./app-factory";
 // Node entry used by `pnpm dev` / `pnpm start`. Vercel can't host the
 // realtime relay WebSocket — Epic #12128 pivoted to Plan D (browser-direct
 // to OpenAI), and the WS scaffolding has since been retired.
+//
+// (no-op touch to exercise the full Turbo build pipeline)
 
 const app = (() => {
   const instanceAbortController = new AbortController();


### PR DESCRIPTION
Three "trim the CI critical path" changes, plus a no-op touch to exercise the full pipeline.

## 1. Remove the `lighthouse-app` job

Analysis of the last 10 merge-group Turbo runs shows `lighthouse-app` sits at the tail of the critical path:
- `needs: [prepare, deploy-api, deploy-web, deploy-app]`, so it can only start after the entire deploy chain finishes (~328s into the run), then runs ~98s — it is the last job to finish before `ci-gate-turbo`.
- It is **informational** in the gate (`check_result ... "informational"`), so it never blocks merge — it only adds latency.

Removed: the job definition, its entry in `ci-gate-turbo` `needs`, and the `check_result` line in the gate. `lighthouse-web` is left untouched.

## 2. Run `deploy-app` in parallel with `deploy-api`

`deploy-app` previously had `needs: [prepare, deploy-api]`. The only reason it waited on `deploy-api` was to read `VITE_API_URL` (baked into the Vite build at build time). But when `PREVIEW_DOMAIN` (= `vm6.ai`) is set, that URL is a deterministic stable alias `https://${job-ref}-api.vm6.ai`, which `prepare` already computes during the prepare step (~37s) as `prepare.outputs.api-preview-url`.

Changes:
- `needs: [prepare, deploy-api]` → `needs: [prepare]`
- `VITE_API_URL=${{ needs.deploy-api.outputs.preview-url }}` → `${{ needs.prepare.outputs.api-preview-url }}`

The build never calls the API — it only bakes in the URL string. The e2e/browser tests that actually hit the API still `needs: deploy-api` and gate on `deploy-api.result == 'success'`, so API readiness is unaffected.

## 3. Run `deploy-stripe-listener` in parallel with `deploy-api`

Same reasoning: `deploy-stripe-listener` already reads the forward URL from the deterministic `prepare.outputs.api-preview-url` (a stable alias, not a `deploy-api` output). It previously gated on `needs.deploy-api.result == 'success'`, but Stripe webhooks only fire during the e2e payment tests, which run after `deploy-api` has succeeded — so the listener never forwards to a dead API.

Changes:
- `needs: [prepare, deploy-api]` → `needs: [prepare]`
- Dropped the `&& needs.deploy-api.result == 'success'` clause from the job `if` (it can only reference jobs listed in `needs`).

Its sole consumer, `cli-e2e-02-playwright`, keeps its own `deploy-api.result == 'success'` gate, so the API-readiness guarantee for the payment tests is preserved.

## 4. No-op touch

A one-line comment in `turbo/apps/api/src/index.ts` to trigger this PR's full build pipeline and validate the changes above.

## Verification

An earlier full run (before change 3) passed (`ci-gate-turbo: success`, 58 jobs, no failures) and confirmed `deploy-app`/`deploy-api` ran fully in parallel, `lighthouse-app` was gone, and wall time dropped to ~5m18s from the typical ~6m30s. Change 3 is being validated by the pipeline run triggered on this push.

🤖 Generated with [Claude Code](https://claude.com/claude-code)