### PR TITLE
fix: clarify permission change undo copy

### DIFF
--- a/turbo/apps/platform/src/views/fw/__tests__/permissions-dialog.test.tsx
+++ b/turbo/apps/platform/src/views/fw/__tests__/permissions-dialog.test.tsx
@@ -196,15 +196,15 @@ function getAllowOptionsButton(
   return button;
 }
 
-function getResetChangesButton(
+function getUndoChangesButton(
   row: HTMLElement,
   permission: string,
 ): HTMLElement {
   const button = queryAllByRoleFast("button", row).find((el) => {
-    return el.getAttribute("aria-label") === `Reset ${permission} changes`;
+    return el.getAttribute("aria-label") === `Undo ${permission} changes`;
   });
   if (!(button instanceof HTMLElement)) {
-    throw new Error(`Reset changes button not found: ${permission}`);
+    throw new Error(`Undo changes button not found: ${permission}`);
   }
   return button;
 }
@@ -500,7 +500,7 @@ describe("permissions dialog - flat list connector (Notion)", () => {
     expect(within(row).getByText("24h")).toBeInTheDocument();
     expect(screen.getByText("Apply")).toBeEnabled();
 
-    click(getResetChangesButton(row, "insert_comments"));
+    click(getUndoChangesButton(row, "insert_comments"));
 
     expect(getPolicyButton(row, "Deny")).toHaveAttribute(
       "aria-pressed",
@@ -656,7 +656,7 @@ describe("permissions dialog - grouped connector (Slack)", () => {
     );
     expect(within(channelsReadRow).getByText("24h")).toBeInTheDocument();
 
-    click(getResetChangesButton(readGroup, "Read"));
+    click(getUndoChangesButton(readGroup, "Read"));
     expect(getPolicyButton(channelsReadRow, "Allow")).toHaveTextContent(
       "Allow",
     );

--- a/turbo/apps/platform/src/views/zero-page/components/settings/permissions-dialog.tsx
+++ b/turbo/apps/platform/src/views/zero-page/components/settings/permissions-dialog.tsx
@@ -590,7 +590,7 @@ function PermissionGrantResetButton({
               <button
                 type="button"
                 disabled={disabled}
-                aria-label={`Reset ${permission} changes`}
+                aria-label={`Undo ${permission} changes`}
                 onClick={() => {
                   onReset();
                 }}
@@ -603,7 +603,7 @@ function PermissionGrantResetButton({
                 <IconArrowBackUp size={13} stroke={2.2} />
               </button>
             </TooltipTrigger>
-            <TooltipContent side="top">Reset changes</TooltipContent>
+            <TooltipContent side="top">Undo changes</TooltipContent>
           </Tooltip>
         </TooltipProvider>
       )}


### PR DESCRIPTION
## Summary
- Rename the per-permission reset affordance copy from "Reset changes" to "Undo changes"
- Update permission drawer tests to use the new accessible label

## Notes
- This branch is based on main and only covers the existing per-permission undo affordance. The connector-level reset footer copy lives in the separate reset PR.

## Tests
- cd turbo && pnpm -F @vm0/app exec vitest src/views/fw/__tests__/permissions-dialog.test.tsx
- cd turbo && pnpm -F @vm0/app lint
- cd turbo && pnpm -F @vm0/app check-types
- cd turbo && pnpm format
- pre-commit: prettier, knip, check-types, commitlint