### PR TITLE
feat: add desktop tray status menu

### DIFF
--- a/turbo/apps/desktop/src/desktop-tray-menu.test.ts
+++ b/turbo/apps/desktop/src/desktop-tray-menu.test.ts
@@ -1,0 +1,333 @@
+import type { DesktopAuthState } from "./desktop-bridge";
+import type {
+  ComputerUseHostRuntimeState,
+  ComputerUseLocalCommandLogEntry,
+  DesktopComputerUseState,
+} from "./computer-use-types";
+import {
+  buildDesktopTrayMenuItems,
+  type DesktopTrayMenuActions,
+  type DesktopTrayMenuItem,
+} from "./desktop-tray-menu";
+
+const baseHostState: ComputerUseHostRuntimeState = {
+  status: "idle",
+  hostId: null,
+  lastHeartbeatAt: null,
+  lastCommandAt: null,
+  lastError: null,
+  recentAuditEvents: [],
+  localCommandLog: [],
+};
+
+const signedInAuth: DesktopAuthState = {
+  status: "signed_in",
+  user: {
+    userId: "user_1",
+    email: "user@example.com",
+  },
+  organization: {
+    id: "org_1",
+    name: "Max & Zoe",
+    slug: "max-zoe",
+  },
+};
+
+function computerUseState(
+  host: Partial<ComputerUseHostRuntimeState> = {},
+  permissions: DesktopComputerUseState["permissions"] = {
+    accessibility: true,
+    screenRecording: true,
+  },
+): DesktopComputerUseState {
+  return {
+    featureSwitchKey: "computerUse",
+    platform: "darwin",
+    supported: true,
+    permissions,
+    host: {
+      ...baseHostState,
+      ...host,
+    },
+  };
+}
+
+function commandEntry(index: number): ComputerUseLocalCommandLogEntry {
+  return {
+    commandId: `cmd-${index}`,
+    kind: `command-${index}`,
+    app: `App ${index}`,
+    status: index % 2 === 0 ? "succeeded" : "running",
+    payload: {},
+    result: null,
+    error: null,
+    startedAt: `2026-06-09T04:0${index}:00.000Z`,
+    completedAt: index % 2 === 0 ? `2026-06-09T04:0${index}:01.000Z` : null,
+    durationMs: index % 2 === 0 ? 1_000 : null,
+  };
+}
+
+function trayActions(
+  overrides: Partial<DesktopTrayMenuActions> = {},
+): DesktopTrayMenuActions {
+  return {
+    showMainWindow: vi.fn(),
+    startComputerUse: vi.fn(),
+    refreshStatus: vi.fn(),
+    openSignIn: vi.fn(),
+    switchWorkspace: vi.fn(),
+    openAccessibilitySettings: vi.fn(),
+    openScreenRecordingSettings: vi.fn(),
+    quit: vi.fn(),
+    ...overrides,
+  };
+}
+
+function findItem(
+  items: readonly DesktopTrayMenuItem[],
+  label: string,
+): DesktopTrayMenuItem {
+  const item = items.find((candidate) => {
+    return candidate.label === label;
+  });
+  if (!item) {
+    throw new Error(`No menu item found for ${label}`);
+  }
+  return item;
+}
+
+function submenu(item: DesktopTrayMenuItem): readonly DesktopTrayMenuItem[] {
+  if (!item.submenu) {
+    throw new Error(`Menu item ${item.label ?? "unknown"} has no submenu`);
+  }
+  return item.submenu;
+}
+
+function click(item: DesktopTrayMenuItem): void {
+  if (!item.click) {
+    throw new Error(
+      `Menu item ${item.label ?? "unknown"} has no click handler`,
+    );
+  }
+  item.click();
+}
+
+describe("desktop tray menu", () => {
+  it("shows the main window, status submenus, recent commands, and quit", () => {
+    const menu = buildDesktopTrayMenuItems(
+      {
+        computerUse: computerUseState({ status: "online" }),
+        auth: signedInAuth,
+        authError: null,
+      },
+      trayActions(),
+    );
+
+    expect(findItem(menu, "Show Main Window")).toBeDefined();
+    expect(findItem(menu, "Computer Use: Online")).toBeDefined();
+    expect(findItem(menu, "Workspace: Max & Zoe")).toBeDefined();
+    expect(findItem(menu, "No Recent Commands")).toStrictEqual({
+      label: "No Recent Commands",
+      enabled: false,
+    });
+    expect(findItem(menu, "Quit")).toBeDefined();
+  });
+
+  it("enables starting Computer Use when idle and signed in", () => {
+    const startComputerUse = vi.fn();
+    const menu = buildDesktopTrayMenuItems(
+      {
+        computerUse: computerUseState({ status: "idle" }),
+        auth: signedInAuth,
+        authError: null,
+      },
+      trayActions({ startComputerUse }),
+    );
+
+    const computerUseMenu = submenu(findItem(menu, "Computer Use: Idle"));
+    const startItem = findItem(computerUseMenu, "Start Computer Use");
+
+    expect(startItem.enabled).toBe(true);
+    click(startItem);
+    expect(startComputerUse).toHaveBeenCalledOnce();
+  });
+
+  it("shows sign-in next to disabled start when Computer Use needs auth", () => {
+    const openSignIn = vi.fn();
+    const menu = buildDesktopTrayMenuItems(
+      {
+        computerUse: computerUseState({ status: "idle" }),
+        auth: {
+          status: "signed_out",
+          user: null,
+          organization: null,
+        },
+        authError: null,
+      },
+      trayActions({ openSignIn }),
+    );
+
+    const computerUseMenu = submenu(findItem(menu, "Computer Use: Idle"));
+
+    expect(findItem(computerUseMenu, "Start Computer Use").enabled).toBe(false);
+    click(findItem(computerUseMenu, "Sign in to Zero"));
+    expect(openSignIn).toHaveBeenCalledOnce();
+  });
+
+  it("shows permission actions when Computer Use is blocked locally", () => {
+    const openAccessibilitySettings = vi.fn();
+    const openScreenRecordingSettings = vi.fn();
+    const menu = buildDesktopTrayMenuItems(
+      {
+        computerUse: computerUseState(
+          { status: "idle" },
+          { accessibility: false, screenRecording: false },
+        ),
+        auth: signedInAuth,
+        authError: null,
+      },
+      trayActions({
+        openAccessibilitySettings,
+        openScreenRecordingSettings,
+      }),
+    );
+
+    const computerUseMenu = submenu(
+      findItem(menu, "Computer Use: Needs permissions"),
+    );
+    click(findItem(computerUseMenu, "Accessibility Settings"));
+    click(findItem(computerUseMenu, "Screen Recording Settings"));
+
+    expect(openAccessibilitySettings).toHaveBeenCalledOnce();
+    expect(openScreenRecordingSettings).toHaveBeenCalledOnce();
+  });
+
+  it("shows signed-in account and workspace actions", () => {
+    const switchWorkspace = vi.fn();
+    const menu = buildDesktopTrayMenuItems(
+      {
+        computerUse: computerUseState(),
+        auth: signedInAuth,
+        authError: null,
+      },
+      trayActions({ switchWorkspace }),
+    );
+
+    const authMenu = submenu(findItem(menu, "Workspace: Max & Zoe"));
+
+    expect(findItem(authMenu, "Signed in as user@example.com").enabled).toBe(
+      false,
+    );
+    expect(findItem(authMenu, "Workspace: Max & Zoe").enabled).toBe(false);
+    click(findItem(authMenu, "Switch Workspace"));
+    expect(switchWorkspace).toHaveBeenCalledOnce();
+  });
+
+  it("shows sign-in action when signed out", () => {
+    const openSignIn = vi.fn();
+    const menu = buildDesktopTrayMenuItems(
+      {
+        computerUse: computerUseState(),
+        auth: {
+          status: "signed_out",
+          user: null,
+          organization: null,
+        },
+        authError: null,
+      },
+      trayActions({ openSignIn }),
+    );
+
+    const authMenu = submenu(findItem(menu, "Sign in to Zero"));
+    click(findItem(authMenu, "Sign in to Zero"));
+
+    expect(openSignIn).toHaveBeenCalledOnce();
+  });
+
+  it("keeps sign-in actionable when auth status is unavailable", () => {
+    const openSignIn = vi.fn();
+    const refreshStatus = vi.fn();
+    const menu = buildDesktopTrayMenuItems(
+      {
+        computerUse: computerUseState(),
+        auth: null,
+        authError: "Desktop auth status failed: 500",
+      },
+      trayActions({ openSignIn, refreshStatus }),
+    );
+
+    const authMenu = submenu(findItem(menu, "Sign in to Zero"));
+    expect(
+      menu.some((item) => {
+        return item.label?.includes("Unknown") ?? false;
+      }),
+    ).toBe(false);
+    click(findItem(authMenu, "Sign in to Zero"));
+    click(findItem(authMenu, "Refresh Account Status"));
+
+    expect(openSignIn).toHaveBeenCalledOnce();
+    expect(refreshStatus).toHaveBeenCalledOnce();
+  });
+
+  it("does not show stale workspace when auth refresh fails", () => {
+    const menu = buildDesktopTrayMenuItems(
+      {
+        computerUse: computerUseState(),
+        auth: signedInAuth,
+        authError: "Desktop auth status failed: 500",
+      },
+      trayActions(),
+    );
+
+    expect(findItem(menu, "Sign in to Zero")).toBeDefined();
+    expect(
+      menu.some((item) => {
+        return item.label === "Workspace: Max & Zoe";
+      }),
+    ).toBe(false);
+  });
+
+  it("limits recent commands to five and opens the main window from each row", () => {
+    const showMainWindow = vi.fn();
+    const menu = buildDesktopTrayMenuItems(
+      {
+        computerUse: computerUseState({
+          localCommandLog: [0, 1, 2, 3, 4, 5].map(commandEntry),
+        }),
+        auth: signedInAuth,
+        authError: null,
+      },
+      trayActions({ showMainWindow }),
+    );
+
+    const commandItems = menu.filter((item) => {
+      return item.label?.includes("command-") ?? false;
+    });
+
+    expect(findItem(menu, "Recent Commands").enabled).toBe(false);
+    expect(commandItems).toHaveLength(5);
+    expect(commandItems[0]?.label).toContain("command-0 - App 0");
+    expect(commandItems[0]?.label).toMatch(/ - Succeeded$/);
+    expect(commandItems[1]?.label).toMatch(/ - Running$/);
+    expect(commandItems[4]?.label).toContain("command-4 - App 4");
+    expect(commandItems[4]?.label).toMatch(/ - Succeeded$/);
+    expect(
+      commandItems.some((item) => {
+        return item.label?.includes("Done") ?? false;
+      }),
+    ).toBe(false);
+    expect(
+      commandItems.some((item) => {
+        return item.label?.includes("command-5") ?? false;
+      }),
+    ).toBe(false);
+
+    const firstCommandItem = commandItems[0];
+    if (!firstCommandItem) {
+      throw new Error("Expected at least one command menu item");
+    }
+
+    click(firstCommandItem);
+    expect(showMainWindow).toHaveBeenCalledOnce();
+  });
+});

--- a/turbo/apps/desktop/src/desktop-tray-menu.ts
+++ b/turbo/apps/desktop/src/desktop-tray-menu.ts
@@ -1,0 +1,284 @@
+import type { DesktopAuthState } from "./desktop-bridge";
+import {
+  hasRequiredComputerUsePermissions,
+  type ComputerUseHostRuntimeStatus,
+  type ComputerUseLocalCommandLogEntry,
+  type DesktopComputerUseState,
+} from "./computer-use-types";
+
+const HOST_STATUS_LABELS = {
+  idle: "Idle",
+  connecting: "Connecting",
+  online: "Online",
+  unauthenticated: "Signed out",
+  needs_organization: "Select workspace",
+  disabled: "Disabled",
+  error: "Error",
+} as const satisfies Record<ComputerUseHostRuntimeStatus, string>;
+
+const COMMAND_STATUS_LABELS = {
+  running: "Running",
+  succeeded: "Succeeded",
+  failed: "Failed",
+} as const satisfies Record<ComputerUseLocalCommandLogEntry["status"], string>;
+
+const MAX_RECENT_COMMANDS = 5;
+const MAX_COMMAND_LABEL_LENGTH = 90;
+
+export interface DesktopTrayMenuItem {
+  readonly label?: string;
+  readonly type?: "separator";
+  readonly enabled?: boolean;
+  readonly submenu?: readonly DesktopTrayMenuItem[];
+  readonly click?: () => void;
+}
+
+export interface DesktopTrayMenuActions {
+  readonly showMainWindow: () => void;
+  readonly startComputerUse: () => void;
+  readonly refreshStatus: () => void;
+  readonly openSignIn: () => void;
+  readonly switchWorkspace: () => void;
+  readonly openAccessibilitySettings: () => void;
+  readonly openScreenRecordingSettings: () => void;
+  readonly quit: () => void;
+}
+
+interface DesktopTrayMenuState {
+  readonly computerUse: DesktopComputerUseState;
+  readonly auth: DesktopAuthState | null;
+  readonly authError: string | null;
+}
+
+function separator(): DesktopTrayMenuItem {
+  return { type: "separator" };
+}
+
+function disabledLabel(label: string): DesktopTrayMenuItem {
+  return { label, enabled: false };
+}
+
+function computerUseStatusLabel(state: DesktopComputerUseState): string {
+  if (!state.supported) {
+    return "Unsupported";
+  }
+  if (!hasRequiredComputerUsePermissions(state.permissions)) {
+    return "Needs permissions";
+  }
+  return HOST_STATUS_LABELS[state.host.status];
+}
+
+function isAuthReady(auth: DesktopAuthState | null): boolean {
+  return auth?.status === "signed_in" && auth.organization !== null;
+}
+
+function canStartComputerUse(state: DesktopTrayMenuState): boolean {
+  return (
+    state.computerUse.supported &&
+    hasRequiredComputerUsePermissions(state.computerUse.permissions) &&
+    isAuthReady(state.auth) &&
+    state.computerUse.host.status !== "connecting" &&
+    state.computerUse.host.status !== "online"
+  );
+}
+
+function authActionForComputerUse(
+  state: DesktopTrayMenuState,
+  actions: DesktopTrayMenuActions,
+): DesktopTrayMenuItem | null {
+  if (state.computerUse.host.status === "online") {
+    return null;
+  }
+  if (state.auth?.status === "signed_in") {
+    if (!state.auth.organization) {
+      return { label: "Select Workspace", click: actions.switchWorkspace };
+    }
+    return null;
+  }
+  if (state.auth?.status === "signing_in") {
+    return disabledLabel("Signing in...");
+  }
+  return { label: "Sign in to Zero", click: actions.openSignIn };
+}
+
+function buildComputerUseSubmenu(
+  state: DesktopTrayMenuState,
+  actions: DesktopTrayMenuActions,
+): readonly DesktopTrayMenuItem[] {
+  const items: DesktopTrayMenuItem[] = [
+    disabledLabel(`Status: ${computerUseStatusLabel(state.computerUse)}`),
+  ];
+
+  if (!state.computerUse.supported) {
+    return [
+      ...items,
+      separator(),
+      { label: "Refresh Status", click: actions.refreshStatus },
+    ];
+  }
+
+  if (!hasRequiredComputerUsePermissions(state.computerUse.permissions)) {
+    return [
+      ...items,
+      separator(),
+      {
+        label: "Accessibility Settings",
+        click: actions.openAccessibilitySettings,
+      },
+      {
+        label: "Screen Recording Settings",
+        click: actions.openScreenRecordingSettings,
+      },
+      separator(),
+      { label: "Refresh Status", click: actions.refreshStatus },
+    ];
+  }
+
+  const authAction = authActionForComputerUse(state, actions);
+  const startItems: DesktopTrayMenuItem[] = [
+    ...items,
+    separator(),
+    {
+      label: "Start Computer Use",
+      enabled: canStartComputerUse(state),
+      click: actions.startComputerUse,
+    },
+  ];
+  if (authAction) {
+    startItems.push(authAction);
+  }
+  startItems.push({ label: "Refresh Status", click: actions.refreshStatus });
+  return startItems;
+}
+
+function authStatusLabel(state: DesktopTrayMenuState): string {
+  if (state.authError) {
+    return "Sign in to Zero";
+  }
+  if (!state.auth) {
+    return "Sign in to Zero";
+  }
+  if (state.auth.status === "signing_in") {
+    return "Signing in to Zero...";
+  }
+  if (state.auth.status === "signed_out") {
+    return "Sign in to Zero";
+  }
+  if (!state.auth.organization) {
+    return "Select Workspace";
+  }
+  return `Workspace: ${state.auth.organization.name}`;
+}
+
+function buildAuthSubmenu(
+  state: DesktopTrayMenuState,
+  actions: DesktopTrayMenuActions,
+): readonly DesktopTrayMenuItem[] {
+  if (state.authError || !state.auth || state.auth.status === "signed_out") {
+    return [
+      disabledLabel("Not signed in"),
+      { label: "Sign in to Zero", click: actions.openSignIn },
+      { label: "Refresh Account Status", click: actions.refreshStatus },
+    ];
+  }
+
+  if (state.auth.status === "signing_in") {
+    return [disabledLabel("Signing in...")];
+  }
+
+  return [
+    disabledLabel(`Signed in as ${state.auth.user.email}`),
+    disabledLabel(
+      `Workspace: ${state.auth.organization?.name ?? "Not selected"}`,
+    ),
+    separator(),
+    { label: "Switch Workspace", click: actions.switchWorkspace },
+    { label: "Sign in again", click: actions.openSignIn },
+  ];
+}
+
+function padTimePart(value: number): string {
+  return value.toString().padStart(2, "0");
+}
+
+function formatTrayTime(value: string | null): string {
+  if (!value) {
+    return "running";
+  }
+  const date = new Date(value);
+  if (Number.isNaN(date.getTime())) {
+    return value;
+  }
+  return `${padTimePart(date.getHours())}:${padTimePart(date.getMinutes())}`;
+}
+
+function truncateMenuLabel(value: string): string {
+  if (value.length <= MAX_COMMAND_LABEL_LENGTH) {
+    return value;
+  }
+  return `${value.slice(0, MAX_COMMAND_LABEL_LENGTH - 3)}...`;
+}
+
+function formatRecentCommandLabel(
+  entry: ComputerUseLocalCommandLogEntry,
+): string {
+  const target = entry.app ? ` - ${entry.app}` : "";
+  const timestamp = formatTrayTime(entry.completedAt ?? entry.startedAt);
+  return truncateMenuLabel(
+    `${entry.kind}${target} - ${timestamp} - ${COMMAND_STATUS_LABELS[entry.status]}`,
+  );
+}
+
+function buildRecentCommandItems(
+  state: DesktopTrayMenuState,
+  actions: DesktopTrayMenuActions,
+): readonly DesktopTrayMenuItem[] {
+  const commands = state.computerUse.host.localCommandLog.slice(
+    0,
+    MAX_RECENT_COMMANDS,
+  );
+
+  if (commands.length === 0) {
+    return [disabledLabel("No Recent Commands")];
+  }
+
+  return commands.map((entry) => {
+    return {
+      label: formatRecentCommandLabel(entry),
+      click: actions.showMainWindow,
+    };
+  });
+}
+
+function buildRecentCommandSection(
+  state: DesktopTrayMenuState,
+  actions: DesktopTrayMenuActions,
+): readonly DesktopTrayMenuItem[] {
+  const commands = buildRecentCommandItems(state, actions);
+  if (commands.length === 1 && commands[0]?.enabled === false) {
+    return commands;
+  }
+  return [disabledLabel("Recent Commands"), ...commands];
+}
+
+export function buildDesktopTrayMenuItems(
+  state: DesktopTrayMenuState,
+  actions: DesktopTrayMenuActions,
+): readonly DesktopTrayMenuItem[] {
+  return [
+    { label: "Show Main Window", click: actions.showMainWindow },
+    separator(),
+    {
+      label: `Computer Use: ${computerUseStatusLabel(state.computerUse)}`,
+      submenu: buildComputerUseSubmenu(state, actions),
+    },
+    {
+      label: authStatusLabel(state),
+      submenu: buildAuthSubmenu(state, actions),
+    },
+    separator(),
+    ...buildRecentCommandSection(state, actions),
+    separator(),
+    { label: "Quit", click: actions.quit },
+  ];
+}

--- a/turbo/apps/desktop/src/desktop-tray.ts
+++ b/turbo/apps/desktop/src/desktop-tray.ts
@@ -1,0 +1,216 @@
+import {
+  Menu,
+  Tray,
+  nativeImage,
+  type MenuItemConstructorOptions,
+  type NativeImage,
+} from "electron";
+import type { DesktopAuthState } from "./desktop-bridge";
+import type { DesktopComputerUseState } from "./computer-use-types";
+import {
+  buildDesktopTrayMenuItems,
+  type DesktopTrayMenuActions,
+  type DesktopTrayMenuItem,
+} from "./desktop-tray-menu";
+
+interface DesktopTrayControllerOptions {
+  readonly displayName: string;
+  readonly iconPath: string;
+  readonly getComputerUseState: () => DesktopComputerUseState;
+  readonly getAuthState: () => Promise<DesktopAuthState>;
+  readonly showMainWindow: () => Promise<void>;
+  readonly startComputerUse: () => Promise<void>;
+  readonly refreshStatus: () => Promise<void>;
+  readonly openSignIn: () => void;
+  readonly switchWorkspace: () => Promise<void>;
+  readonly openAccessibilitySettings: () => void;
+  readonly openScreenRecordingSettings: () => void;
+  readonly quit: () => void;
+}
+
+function desktopTrayIcon(iconPath: string): NativeImage {
+  const image = nativeImage.createFromPath(iconPath);
+  if (process.platform !== "darwin") {
+    return image;
+  }
+
+  const resized = image.resize({ width: 18, height: 18 });
+  resized.setTemplateImage(true);
+  return resized;
+}
+
+function electronMenuItem(
+  item: DesktopTrayMenuItem,
+): MenuItemConstructorOptions {
+  const template: MenuItemConstructorOptions = {};
+  if (item.type) {
+    template.type = item.type;
+  }
+  if (item.label) {
+    template.label = item.label;
+  }
+  if (item.enabled !== undefined) {
+    template.enabled = item.enabled;
+  }
+  if (item.click) {
+    template.click = item.click;
+  }
+  if (item.submenu) {
+    template.submenu = item.submenu.map(electronMenuItem);
+  }
+  return template;
+}
+
+function electronMenuTemplate(
+  items: readonly DesktopTrayMenuItem[],
+): MenuItemConstructorOptions[] {
+  return items.map(electronMenuItem);
+}
+
+export class DesktopTrayController {
+  private readonly options: DesktopTrayControllerOptions;
+  private tray: Tray | null = null;
+  private authState: DesktopAuthState | null = null;
+  private authError: string | null = null;
+  private authRefreshVersion = 0;
+  private menuSignature: string | null = null;
+
+  constructor(options: DesktopTrayControllerOptions) {
+    this.options = options;
+  }
+
+  install(): void {
+    if (this.tray) {
+      return;
+    }
+
+    this.tray = new Tray(desktopTrayIcon(this.options.iconPath));
+    this.tray.setToolTip(this.options.displayName);
+    this.refresh();
+    this.refreshAuth();
+  }
+
+  refresh(): void {
+    const tray = this.tray;
+    if (!tray) {
+      return;
+    }
+
+    const actions = this.menuActions();
+    const items = buildDesktopTrayMenuItems(
+      {
+        computerUse: this.options.getComputerUseState(),
+        auth: this.authState,
+        authError: this.authError,
+      },
+      actions,
+    );
+    const signature = JSON.stringify(items, (_key, value: unknown) => {
+      return typeof value === "function" ? "[function]" : value;
+    });
+    if (signature === this.menuSignature) {
+      return;
+    }
+    this.menuSignature = signature;
+    tray.setContextMenu(Menu.buildFromTemplate(electronMenuTemplate(items)));
+  }
+
+  refreshAuth(): void {
+    const version = this.authRefreshVersion + 1;
+    this.authRefreshVersion = version;
+    void this.options
+      .getAuthState()
+      .then((authState) => {
+        if (version !== this.authRefreshVersion) {
+          return;
+        }
+        this.authState = authState;
+        this.authError = null;
+        this.refresh();
+      })
+      .catch((error: unknown) => {
+        if (version !== this.authRefreshVersion) {
+          return;
+        }
+        this.authError = error instanceof Error ? error.message : String(error);
+        this.authState = null;
+        this.refresh();
+      });
+  }
+
+  private menuActions(): DesktopTrayMenuActions {
+    return {
+      showMainWindow: this.runAction("show main window", () => {
+        return this.options.showMainWindow();
+      }),
+      startComputerUse: this.runAction("start Computer Use", () => {
+        return this.options.startComputerUse();
+      }),
+      refreshStatus: this.runAction(
+        "refresh status",
+        async () => {
+          await this.options.refreshStatus();
+        },
+        { refreshAuth: true },
+      ),
+      openSignIn: this.runAction(
+        "open sign in",
+        () => {
+          this.options.openSignIn();
+        },
+        { refreshAuth: true },
+      ),
+      switchWorkspace: this.runAction(
+        "switch workspace",
+        () => {
+          return this.options.switchWorkspace();
+        },
+        { refreshAuth: true },
+      ),
+      openAccessibilitySettings: this.runAction(
+        "open Accessibility Settings",
+        () => {
+          this.options.openAccessibilitySettings();
+        },
+      ),
+      openScreenRecordingSettings: this.runAction(
+        "open Screen Recording Settings",
+        () => {
+          this.options.openScreenRecordingSettings();
+        },
+      ),
+      quit: () => {
+        this.options.quit();
+      },
+    };
+  }
+
+  private runAction(
+    label: string,
+    action: () => Promise<void> | void,
+    options: { readonly refreshAuth?: boolean } = {},
+  ): () => void {
+    return () => {
+      void Promise.resolve()
+        .then(action)
+        .catch((error: unknown) => {
+          console.error("Desktop tray action failed", label, error);
+        })
+        .finally(() => {
+          if (options.refreshAuth) {
+            this.refreshAuth();
+            return;
+          }
+          this.refresh();
+        });
+    };
+  }
+}
+
+export function installDesktopTray(
+  options: DesktopTrayControllerOptions,
+): DesktopTrayController {
+  const controller = new DesktopTrayController(options);
+  controller.install();
+  return controller;
+}

--- a/turbo/apps/desktop/src/main.ts
+++ b/turbo/apps/desktop/src/main.ts
@@ -43,6 +43,7 @@ import { createComputerUseNativeBackend } from "./computer-use-native";
 import { resolveDesktopConfig } from "./config";
 import { installDesktopAutoUpdates } from "./desktop-auto-updates";
 import { createDesktopComputerUseSessionFetch } from "./desktop-computer-use-api";
+import { installDesktopTray, type DesktopTrayController } from "./desktop-tray";
 import { DesktopAuthSession } from "./desktop-auth-session";
 import {
   installDesktopAuthIpc,
@@ -88,16 +89,39 @@ const localRendererUrl = desktopRendererUrl();
 const noAllowedAppOrigins: ReadonlySet<string> = new Set();
 const ELECTRON_ERR_ABORTED = -3;
 const COMPUTER_USE_QUIT_STOP_TIMEOUT_MS = 1_000;
+const MAC_ACCESSIBILITY_SETTINGS_URL =
+  "x-apple.systempreferences:com.apple.preference.security?Privacy_Accessibility";
+const MAC_SCREEN_RECORDING_SETTINGS_URL =
+  "x-apple.systempreferences:com.apple.preference.security?Privacy_ScreenCapture";
 let mainWindow: BrowserWindow | null = null;
 let appIsQuitting = false;
 let computerUseQuitStopStarted = false;
 let computerUseNativeBackendDisposed = false;
+let desktopTray: DesktopTrayController | null = null;
 const desktopAuthStartGate = createDesktopAuthStartGate();
 let computerUseRuntime: ComputerUseHostRuntime | null = null;
 let computerUseBlockedHostState: ComputerUseHostRuntimeState | null = null;
 const computerUseSnapshotStore = new ComputerUseSnapshotStore();
 const computerUseNativeBackend = createComputerUseNativeBackend();
 setComputerUsePermissionNativeBackend(computerUseNativeBackend);
+
+function refreshDesktopTray(): void {
+  desktopTray?.refresh();
+}
+
+function refreshDesktopTrayAuth(): void {
+  desktopTray?.refreshAuth();
+}
+
+function notifyComputerUseChanged(): void {
+  notifyDesktopComputerUseChanged();
+  refreshDesktopTray();
+}
+
+function notifyAuthChanged(): void {
+  notifyDesktopAuthChanged();
+  refreshDesktopTrayAuth();
+}
 
 async function runAuthWindow(request: {
   readonly url: string;
@@ -139,7 +163,7 @@ function getAuthSession(): DesktopAuthSession {
     consumeUrl: (code) => buildDesktopAuthConsumeUrl(config.webUrl, code),
     selectOrgUrl: desktopAuthSelectOrgUrl,
     runAuthWindow,
-    onChange: notifyDesktopAuthChanged,
+    onChange: notifyAuthChanged,
     onAuthCompleted: maybeStartComputerUseAfterAuth,
   });
 
@@ -227,7 +251,7 @@ async function startComputerUseRuntime(): Promise<DesktopComputerUseState> {
     }
     computerUseBlockedHostState =
       startupGate.status === "blocked" ? startupGate.host : null;
-    notifyDesktopComputerUseChanged();
+    notifyComputerUseChanged();
     return getComputerUseBridgeState();
   }
 
@@ -254,7 +278,7 @@ async function startComputerUseRuntime(): Promise<DesktopComputerUseState> {
           snapshotStore: computerUseSnapshotStore,
         });
       },
-      onChange: notifyDesktopComputerUseChanged,
+      onChange: notifyComputerUseChanged,
     });
   }
   await computerUseRuntime.start();
@@ -263,13 +287,13 @@ async function startComputerUseRuntime(): Promise<DesktopComputerUseState> {
 
 async function requestComputerUsePermission(): Promise<DesktopComputerUseState> {
   await requestComputerUseAccessibilityPermission();
-  notifyDesktopComputerUseChanged();
+  notifyComputerUseChanged();
   return getComputerUseBridgeState();
 }
 
 async function requestComputerUseScreenRecording(): Promise<DesktopComputerUseState> {
   await requestComputerUseScreenRecordingPermission();
-  notifyDesktopComputerUseChanged();
+  notifyComputerUseChanged();
   return getComputerUseBridgeState();
 }
 
@@ -278,7 +302,7 @@ async function refreshComputerUsePermissions(): Promise<DesktopComputerUseState>
   if (!hasRequiredComputerUsePermissions(permissions)) {
     computerUseBlockedHostState = null;
   }
-  notifyDesktopComputerUseChanged();
+  notifyComputerUseChanged();
   return getComputerUseBridgeState();
 }
 
@@ -301,7 +325,7 @@ function refreshComputerUsePermissionsForState(): void {
       console.warn("Unable to refresh native Computer Use permissions", error);
     })
     .finally(() => {
-      notifyDesktopComputerUseChanged();
+      notifyComputerUseChanged();
     });
 }
 
@@ -351,6 +375,37 @@ function installDesktopAuth(): void {
       allowedAppOrigins: config.allowedAppOrigins,
     },
   );
+}
+
+function installTray(): void {
+  desktopTray = installDesktopTray({
+    displayName: config.identity.displayName,
+    iconPath: appIconPath(),
+    getComputerUseState: getComputerUseBridgeState,
+    getAuthState: () => getAuthSession().getAuthState(),
+    showMainWindow: async () => {
+      await createMainWindow();
+    },
+    startComputerUse: async () => {
+      await startComputerUseRuntime();
+    },
+    refreshStatus: async () => {
+      await refreshComputerUsePermissions();
+    },
+    openSignIn: () => {
+      openExternal(desktopAuthStartUrl);
+    },
+    switchWorkspace: () => getAuthSession().selectOrganization(),
+    openAccessibilitySettings: () => {
+      openExternal(MAC_ACCESSIBILITY_SETTINGS_URL);
+    },
+    openScreenRecordingSettings: () => {
+      openExternal(MAC_SCREEN_RECORDING_SETTINGS_URL);
+    },
+    quit: () => {
+      app.quit();
+    },
+  });
 }
 
 function applyApplicationMenu(): void {
@@ -661,10 +716,10 @@ async function maybeStartComputerUseAfterAuth(): Promise<void> {
   computerUseRuntime = null;
   computerUseBlockedHostState = null;
   await runtime?.stop();
-  notifyDesktopAuthChanged();
-  notifyDesktopComputerUseChanged();
+  notifyAuthChanged();
+  notifyComputerUseChanged();
   const permissions = await refreshComputerUsePermissionState();
-  notifyDesktopComputerUseChanged();
+  notifyComputerUseChanged();
   if (hasRequiredComputerUsePermissions(permissions)) {
     await startComputerUseRuntime();
   }
@@ -779,6 +834,7 @@ if (!hasSingleInstanceLock) {
     refreshComputerUsePermissionsForState();
     const desktopAuthSession = getAuthSession();
     installDesktopAuth();
+    installTray();
     queueDesktopAuthCallbackArgv(process.argv);
 
     const pendingCode = desktopAuthSession.takePendingCode();


### PR DESCRIPTION
## Summary
- add a macOS menu bar status item for Zero Desktop
- surface Computer Use and account status with native submenus and direct actions
- show up to five recent local command log entries with compact text summaries

## Testing
- pnpm -C turbo -F @vm0/desktop check-types
- pnpm -C turbo -F @vm0/desktop lint
- pnpm -C turbo -F @vm0/desktop test
- pnpm desktop:dev
