### PR TITLE
fix: refresh watchdog process tree target before kill

### DIFF
--- a/crates/vsock-guest/src/lib.rs
+++ b/crates/vsock-guest/src/lib.rs
@@ -17,6 +17,8 @@ mod process;
 mod quiesce;
 mod shell_command;
 mod shutdown;
+#[cfg(test)]
+mod test_support;
 mod threading;
 mod user;
 mod wait;

--- a/crates/vsock-guest/src/process.rs
+++ b/crates/vsock-guest/src/process.rs
@@ -94,6 +94,11 @@ impl ProcessTreeKillTarget {
     pub(crate) fn child_id(self) -> u32 {
         self.child_id
     }
+
+    fn child_pgid_to_signal(self) -> Option<u32> {
+        self.child_pgid
+            .filter(|pgid| *pgid > 1 && *pgid != self.child_id)
+    }
 }
 
 /// Snapshot process-tree kill targets while the direct child is still alive.
@@ -151,11 +156,9 @@ pub(crate) unsafe fn kill_process_tree_target(target: ProcessTreeKillTarget) -> 
 
     // Kill the session/process group created by su's child after setsid().
     // Skip if the child is in the same group (no setsid happened, e.g. debug builds).
-    // Guard pgid != 0: kill(0, sig) sends to the calling process's own group.
-    if let Some(pgid) = target.child_pgid
-        && pgid != 0
-        && pgid != target.child_id
-    {
+    // Guard pgid > 1: kill(0, sig) targets the caller's group, and kill(-1, sig)
+    // broadcasts to every process the caller may signal.
+    if let Some(pgid) = target.child_pgid_to_signal() {
         let ret = unsafe { libc::kill(-(pgid as i32), libc::SIGKILL) };
         if ret == 0 {
             signalled = true;
@@ -325,6 +328,50 @@ mod tests {
     #[test]
     fn parse_stat_ppid_pgid_no_closing_paren() {
         assert_eq!(parse_stat_ppid_pgid("1 bash S 10 42 42"), None);
+    }
+
+    #[test]
+    fn child_pgid_to_signal_skips_reserved_and_self_targets() {
+        assert_eq!(
+            ProcessTreeKillTarget {
+                child_id: 42,
+                child_pgid: None
+            }
+            .child_pgid_to_signal(),
+            None
+        );
+        assert_eq!(
+            ProcessTreeKillTarget {
+                child_id: 42,
+                child_pgid: Some(0)
+            }
+            .child_pgid_to_signal(),
+            None
+        );
+        assert_eq!(
+            ProcessTreeKillTarget {
+                child_id: 42,
+                child_pgid: Some(1)
+            }
+            .child_pgid_to_signal(),
+            None
+        );
+        assert_eq!(
+            ProcessTreeKillTarget {
+                child_id: 42,
+                child_pgid: Some(42)
+            }
+            .child_pgid_to_signal(),
+            None
+        );
+        assert_eq!(
+            ProcessTreeKillTarget {
+                child_id: 42,
+                child_pgid: Some(43)
+            }
+            .child_pgid_to_signal(),
+            Some(43)
+        );
     }
 
     #[cfg(target_os = "linux")]

--- a/crates/vsock-guest/src/process.rs
+++ b/crates/vsock-guest/src/process.rs
@@ -210,6 +210,8 @@ mod tests {
     use std::process::{Command, Stdio};
     use std::time::{Duration, Instant, SystemTime, UNIX_EPOCH};
 
+    #[cfg(target_os = "linux")]
+    use crate::test_support::{kill_pidfd_and_wait, open_pidfd, wait_for_pidfd_exit};
     use crate::wait::{WaitOutcome, wait_with_kill_timeout};
 
     struct TempDirGuard(PathBuf);
@@ -351,101 +353,10 @@ mod tests {
     }
 
     #[cfg(target_os = "linux")]
-    fn open_pidfd(pid: libc::pid_t) -> std::io::Result<std::os::fd::OwnedFd> {
-        use std::os::fd::FromRawFd;
-
-        // SAFETY: `pidfd_open` does not dereference user pointers. On success
-        // it returns a new file descriptor owned by this process.
-        let fd = unsafe { libc::syscall(libc::SYS_pidfd_open, pid, 0) };
-        if fd < 0 {
-            return Err(std::io::Error::last_os_error());
-        }
-
-        // SAFETY: `fd` is a fresh descriptor returned by `pidfd_open` above.
-        Ok(unsafe { std::os::fd::OwnedFd::from_raw_fd(fd as std::os::fd::RawFd) })
-    }
-
-    #[cfg(target_os = "linux")]
-    fn wait_for_pidfd_exit(
-        pidfd: &std::os::fd::OwnedFd,
-        timeout: Duration,
-    ) -> std::io::Result<bool> {
-        let deadline = Instant::now() + timeout;
-        loop {
-            let remaining = deadline.saturating_duration_since(Instant::now());
-            if remaining.is_zero() {
-                return Ok(false);
-            }
-            let timeout_ms = remaining.as_millis().clamp(1, i32::MAX as u128) as i32;
-            let mut pollfd = libc::pollfd {
-                fd: std::os::fd::AsRawFd::as_raw_fd(pidfd),
-                events: libc::POLLIN,
-                revents: 0,
-            };
-            // SAFETY: `pollfd` points to one initialized descriptor entry.
-            let result = unsafe { libc::poll(&mut pollfd, 1, timeout_ms) };
-            if result > 0 {
-                let revents = pollfd.revents;
-                if revents & (libc::POLLERR | libc::POLLNVAL) != 0 {
-                    return Err(std::io::Error::other("pidfd became invalid while polling"));
-                }
-                if revents & (libc::POLLIN | libc::POLLHUP) != 0 {
-                    return Ok(true);
-                }
-                return Err(std::io::Error::other(format!(
-                    "unexpected pidfd poll revents: {revents:#x}"
-                )));
-            }
-            if result == 0 {
-                return Ok(false);
-            }
-            let err = std::io::Error::last_os_error();
-            if err.kind() != std::io::ErrorKind::Interrupted {
-                return Err(err);
-            }
-        }
-    }
-
-    #[cfg(target_os = "linux")]
     fn kill_spawned_child(child: &mut Option<Child>) {
         if let Some(child) = child.take() {
             kill_and_reap_child(child);
         }
-    }
-
-    #[cfg(target_os = "linux")]
-    fn signal_pidfd(pidfd: &std::os::fd::OwnedFd, signal: libc::c_int) -> std::io::Result<()> {
-        // SAFETY: best-effort cleanup of a test-owned background process.
-        let result = unsafe {
-            libc::syscall(
-                libc::SYS_pidfd_send_signal,
-                std::os::fd::AsRawFd::as_raw_fd(pidfd),
-                signal,
-                std::ptr::null::<libc::siginfo_t>(),
-                0,
-            )
-        };
-        if result == 0 {
-            return Ok(());
-        }
-        let err = std::io::Error::last_os_error();
-        if err.raw_os_error() == Some(libc::ESRCH) {
-            return Ok(());
-        }
-        Err(err)
-    }
-
-    #[cfg(target_os = "linux")]
-    fn kill_pidfd_and_wait(pidfd: &std::os::fd::OwnedFd) -> std::io::Result<()> {
-        signal_pidfd(pidfd, libc::SIGKILL)?;
-        if wait_for_pidfd_exit(pidfd, Duration::from_secs(1))? {
-            return Ok(());
-        }
-
-        Err(std::io::Error::new(
-            std::io::ErrorKind::TimedOut,
-            "timed out waiting for pidfd process to exit after SIGKILL",
-        ))
     }
 
     #[cfg(target_os = "linux")]

--- a/crates/vsock-guest/src/test_support.rs
+++ b/crates/vsock-guest/src/test_support.rs
@@ -1,0 +1,96 @@
+#[cfg(target_os = "linux")]
+pub(crate) fn open_pidfd(pid: libc::pid_t) -> std::io::Result<std::os::fd::OwnedFd> {
+    use std::os::fd::FromRawFd;
+
+    // SAFETY: `pidfd_open` does not dereference user pointers. On success it
+    // returns a new file descriptor owned by this process.
+    let fd = unsafe { libc::syscall(libc::SYS_pidfd_open, pid, 0) };
+    if fd < 0 {
+        return Err(std::io::Error::last_os_error());
+    }
+
+    // SAFETY: `fd` is a fresh descriptor returned by `pidfd_open` above.
+    Ok(unsafe { std::os::fd::OwnedFd::from_raw_fd(fd as std::os::fd::RawFd) })
+}
+
+#[cfg(target_os = "linux")]
+pub(crate) fn wait_for_pidfd_exit(
+    pidfd: &std::os::fd::OwnedFd,
+    timeout: std::time::Duration,
+) -> std::io::Result<bool> {
+    use std::os::fd::AsRawFd;
+    use std::time::Instant;
+
+    let deadline = Instant::now() + timeout;
+    loop {
+        let remaining = deadline.saturating_duration_since(Instant::now());
+        if remaining.is_zero() {
+            return Ok(false);
+        }
+        let timeout_ms = remaining.as_millis().clamp(1, i32::MAX as u128) as i32;
+        let mut pollfd = libc::pollfd {
+            fd: pidfd.as_raw_fd(),
+            events: libc::POLLIN,
+            revents: 0,
+        };
+        // SAFETY: `pollfd` points to one initialized descriptor entry.
+        let result = unsafe { libc::poll(&mut pollfd, 1, timeout_ms) };
+        if result > 0 {
+            let revents = pollfd.revents;
+            if revents & (libc::POLLERR | libc::POLLNVAL) != 0 {
+                return Err(std::io::Error::other("pidfd became invalid while polling"));
+            }
+            if revents & (libc::POLLIN | libc::POLLHUP) != 0 {
+                return Ok(true);
+            }
+            return Err(std::io::Error::other(format!(
+                "unexpected pidfd poll revents: {revents:#x}"
+            )));
+        }
+        if result == 0 {
+            return Ok(false);
+        }
+        let err = std::io::Error::last_os_error();
+        if err.kind() != std::io::ErrorKind::Interrupted {
+            return Err(err);
+        }
+    }
+}
+
+#[cfg(target_os = "linux")]
+fn signal_pidfd(pidfd: &std::os::fd::OwnedFd, signal: libc::c_int) -> std::io::Result<()> {
+    use std::os::fd::AsRawFd;
+
+    // SAFETY: best-effort cleanup of a test-owned background process.
+    let result = unsafe {
+        libc::syscall(
+            libc::SYS_pidfd_send_signal,
+            pidfd.as_raw_fd(),
+            signal,
+            std::ptr::null::<libc::siginfo_t>(),
+            0,
+        )
+    };
+    if result == 0 {
+        return Ok(());
+    }
+
+    let err = std::io::Error::last_os_error();
+    if err.raw_os_error() == Some(libc::ESRCH) {
+        return Ok(());
+    }
+    Err(err)
+}
+
+#[cfg(target_os = "linux")]
+pub(crate) fn kill_pidfd_and_wait(pidfd: &std::os::fd::OwnedFd) -> std::io::Result<()> {
+    signal_pidfd(pidfd, libc::SIGKILL)?;
+    if wait_for_pidfd_exit(pidfd, std::time::Duration::from_secs(1))? {
+        return Ok(());
+    }
+
+    Err(std::io::Error::new(
+        std::io::ErrorKind::TimedOut,
+        "timed out waiting for pidfd process to exit after SIGKILL",
+    ))
+}

--- a/crates/vsock-guest/src/wait.rs
+++ b/crates/vsock-guest/src/wait.rs
@@ -441,8 +441,10 @@ mod tests {
             .arg("-c")
             .arg(
                 "mkfifo \"$FIFO\"; \
+                 exec 3<> \"$FIFO\"; \
                  : > \"$READY\"; \
-                 read _ < \"$FIFO\"; \
+                 read _ <&3; \
+                 exec 3>&-; \
                  setsid sh -c 'printf %s \"$$\" > \"$CHILD_PID\"; sleep 60' & \
                  wait",
             )
@@ -503,7 +505,12 @@ mod tests {
         };
 
         let watchdog_kill = kill_child(stale_target, KillReason::Timeout);
-        assert!(watchdog_kill.killed);
+        if !watchdog_kill.killed {
+            kill_spawned_child_with_watchdog(&mut child);
+            kill_pidfd_and_wait(&child_pidfd)
+                .unwrap_or_else(|e| panic!("failed to clean up setsid child pidfd: {e}"));
+            panic!("watchdog kill should signal at least one process target");
+        }
         assert!(matches!(watchdog_kill.reason, KillReason::Timeout));
         let _ = child.take().unwrap().wait().unwrap();
 

--- a/crates/vsock-guest/src/wait.rs
+++ b/crates/vsock-guest/src/wait.rs
@@ -219,18 +219,21 @@ fn wait_done(done_rx: &mpsc::Receiver<()>) -> bool {
 
 fn kill_child_unless_done(
     done_rx: &mpsc::Receiver<()>,
-    kill_target: ProcessTreeKillTarget,
+    mut kill_target: ProcessTreeKillTarget,
     reason: KillReason,
 ) -> Option<WatchdogKill> {
     if wait_done(done_rx) {
         None
     } else {
+        refresh_process_tree_kill_target(&mut kill_target);
+        if wait_done(done_rx) {
+            return None;
+        }
         Some(kill_child(kill_target, reason))
     }
 }
 
-fn kill_child(mut kill_target: ProcessTreeKillTarget, reason: KillReason) -> WatchdogKill {
-    refresh_process_tree_kill_target(&mut kill_target);
+fn kill_child(kill_target: ProcessTreeKillTarget, reason: KillReason) -> WatchdogKill {
     let child_id = kill_target.child_id();
     // SAFETY: kill_target comes from a PID returned by Command::spawn.
     let tree_killed = unsafe { kill_process_tree_target(kill_target) };
@@ -504,7 +507,9 @@ mod tests {
             }
         };
 
-        let watchdog_kill = kill_child(stale_target, KillReason::Timeout);
+        let (_done_tx, done_rx) = mpsc::channel::<()>();
+        let watchdog_kill = kill_child_unless_done(&done_rx, stale_target, KillReason::Timeout)
+            .expect("watchdog should kill when done is not signalled");
         if !watchdog_kill.killed {
             kill_spawned_child_with_watchdog(&mut child);
             kill_pidfd_and_wait(&child_pidfd)

--- a/crates/vsock-guest/src/wait.rs
+++ b/crates/vsock-guest/src/wait.rs
@@ -229,7 +229,8 @@ fn kill_child_unless_done(
     }
 }
 
-fn kill_child(kill_target: ProcessTreeKillTarget, reason: KillReason) -> WatchdogKill {
+fn kill_child(mut kill_target: ProcessTreeKillTarget, reason: KillReason) -> WatchdogKill {
+    refresh_process_tree_kill_target(&mut kill_target);
     let child_id = kill_target.child_id();
     // SAFETY: kill_target comes from a PID returned by Command::spawn.
     let tree_killed = unsafe { kill_process_tree_target(kill_target) };
@@ -242,8 +243,69 @@ fn kill_child(kill_target: ProcessTreeKillTarget, reason: KillReason) -> Watchdo
 #[cfg(test)]
 mod tests {
     use super::*;
+    #[cfg(target_os = "linux")]
+    use std::io::Write;
+    #[cfg(target_os = "linux")]
+    use std::os::unix::fs::PermissionsExt;
+    #[cfg(target_os = "linux")]
+    use std::os::unix::process::CommandExt;
+    #[cfg(target_os = "linux")]
+    use std::path::{Path, PathBuf};
+    #[cfg(target_os = "linux")]
+    use std::process::Child;
     use std::process::{Command, Stdio};
     use std::sync::Arc;
+    #[cfg(target_os = "linux")]
+    use std::time::{SystemTime, UNIX_EPOCH};
+
+    #[cfg(target_os = "linux")]
+    use crate::test_support::{kill_pidfd_and_wait, open_pidfd, wait_for_pidfd_exit};
+
+    #[cfg(target_os = "linux")]
+    struct TempDirGuard(PathBuf);
+
+    #[cfg(target_os = "linux")]
+    impl Drop for TempDirGuard {
+        fn drop(&mut self) {
+            let _ = std::fs::remove_dir_all(&self.0);
+        }
+    }
+
+    #[cfg(target_os = "linux")]
+    fn temp_dir(label: &str) -> (PathBuf, TempDirGuard) {
+        let dir = std::env::temp_dir().join(format!(
+            "vsock-guest-{label}-{}-{}",
+            std::process::id(),
+            SystemTime::now()
+                .duration_since(UNIX_EPOCH)
+                .unwrap()
+                .as_nanos()
+        ));
+        std::fs::create_dir_all(&dir).unwrap();
+        std::fs::set_permissions(&dir, std::fs::Permissions::from_mode(0o700)).unwrap();
+        let guard = TempDirGuard(dir.clone());
+        (dir, guard)
+    }
+
+    #[cfg(target_os = "linux")]
+    fn wait_for_path(path: &Path, timeout: Duration) -> bool {
+        let deadline = Instant::now() + timeout;
+        while Instant::now() < deadline {
+            if path.exists() {
+                return true;
+            }
+            std::thread::sleep(Duration::from_millis(10));
+        }
+        path.exists()
+    }
+
+    #[cfg(target_os = "linux")]
+    fn kill_spawned_child_with_watchdog(child: &mut Option<Child>) {
+        if let Some(mut child) = child.take() {
+            kill_child(process_tree_kill_target(child.id()), KillReason::Cancelled);
+            let _ = child.wait();
+        }
+    }
 
     #[test]
     fn fast_exit_wait_does_not_pay_cancel_poll_interval_per_child() {
@@ -364,5 +426,102 @@ mod tests {
         );
 
         assert!(outcome.is_none());
+    }
+
+    #[cfg(target_os = "linux")]
+    #[test]
+    fn watchdog_kill_refreshes_stale_process_tree_target_before_signal() {
+        let (dir, _guard) = temp_dir("watchdog-refresh");
+        let fifo = dir.join("parent-fifo");
+        let ready = dir.join("ready");
+        let child_pid_path = dir.join("setsid-child-pid");
+
+        let mut command = Command::new("sh");
+        command
+            .arg("-c")
+            .arg(
+                "mkfifo \"$FIFO\"; \
+                 : > \"$READY\"; \
+                 read _ < \"$FIFO\"; \
+                 setsid sh -c 'printf %s \"$$\" > \"$CHILD_PID\"; sleep 60' & \
+                 wait",
+            )
+            .env("FIFO", &fifo)
+            .env("READY", &ready)
+            .env("CHILD_PID", &child_pid_path)
+            .stdout(Stdio::null())
+            .stderr(Stdio::null());
+        command.process_group(0);
+
+        let mut child = Some(command.spawn().unwrap());
+        if !wait_for_path(&ready, Duration::from_secs(2)) {
+            kill_spawned_child_with_watchdog(&mut child);
+            panic!("parent should block before spawning the setsid child");
+        }
+
+        let stale_target = process_tree_kill_target(child.as_ref().unwrap().id());
+        {
+            let mut fifo_writer = match std::fs::OpenOptions::new().write(true).open(&fifo) {
+                Ok(writer) => writer,
+                Err(e) => {
+                    kill_spawned_child_with_watchdog(&mut child);
+                    panic!("failed to open parent fifo: {e}");
+                }
+            };
+            if let Err(e) = writeln!(fifo_writer, "go") {
+                kill_spawned_child_with_watchdog(&mut child);
+                panic!("failed to write parent fifo: {e}");
+            }
+        }
+
+        if !wait_for_path(&child_pid_path, Duration::from_secs(2)) {
+            kill_spawned_child_with_watchdog(&mut child);
+            panic!("setsid child should publish its pid before watchdog kill");
+        }
+        let child_pid_text = match std::fs::read_to_string(&child_pid_path) {
+            Ok(pid) => pid,
+            Err(e) => {
+                kill_spawned_child_with_watchdog(&mut child);
+                panic!("failed to read setsid child pid: {e}");
+            }
+        };
+        let child_pid: libc::pid_t = match child_pid_text.trim().parse() {
+            Ok(pid) => pid,
+            Err(e) => {
+                kill_spawned_child_with_watchdog(&mut child);
+                panic!("failed to parse setsid child pid {child_pid_text:?}: {e}");
+            }
+        };
+        let child_pidfd = match open_pidfd(child_pid) {
+            Ok(pidfd) => pidfd,
+            Err(e) => {
+                kill_spawned_child_with_watchdog(&mut child);
+                // SAFETY: best-effort cleanup of a test-owned process.
+                let _ = unsafe { libc::kill(child_pid, libc::SIGKILL) };
+                panic!("failed to open pidfd for setsid child pid {child_pid}: {e}");
+            }
+        };
+
+        let watchdog_kill = kill_child(stale_target, KillReason::Timeout);
+        assert!(watchdog_kill.killed);
+        assert!(matches!(watchdog_kill.reason, KillReason::Timeout));
+        let _ = child.take().unwrap().wait().unwrap();
+
+        match wait_for_pidfd_exit(&child_pidfd, Duration::from_secs(2)) {
+            Ok(true) => {}
+            Ok(false) => {
+                kill_pidfd_and_wait(&child_pidfd)
+                    .unwrap_or_else(|e| panic!("failed to clean up setsid child pidfd: {e}"));
+                panic!(
+                    "watchdog kill should terminate delayed setsid child pid {child_pid} after refreshing stale target"
+                );
+            }
+            Err(e) => {
+                let cleanup = kill_pidfd_and_wait(&child_pidfd);
+                panic!(
+                    "failed to wait for delayed setsid child pid {child_pid} exit: {e}; cleanup={cleanup:?}"
+                );
+            }
+        }
     }
 }


### PR DESCRIPTION
## Summary

- refresh the watchdog-owned process-tree kill target immediately before signalling on timeout/cancel
- keep `kill_process_tree_target` as a snapshot-based kill primitive
- add a deterministic Linux regression test for a stale target that gains a delayed `setsid` child
- move pidfd test helpers into a test-only support module for reuse

## Tests

- `cargo test --manifest-path crates/Cargo.toml -p vsock-guest watchdog_kill_refreshes_stale_process_tree_target_before_signal`
- `cargo test --manifest-path crates/Cargo.toml -p vsock-guest wait::tests`
- `cargo test --manifest-path crates/Cargo.toml -p vsock-guest process::tests`
- `cargo test --manifest-path crates/Cargo.toml -p vsock-guest`
- `cargo clippy --manifest-path crates/Cargo.toml -p vsock-guest --all-targets --all-features`
- `cargo fmt --manifest-path crates/Cargo.toml --all -- --check`

Closes #16783