### PR TITLE
feat: add aws sigv4 firewall auth runtime

### DIFF
--- a/crates/runner/mitm-addon/src/auth.py
+++ b/crates/runner/mitm-addon/src/auth.py
@@ -408,8 +408,6 @@ def _parse_optional_aws_sigv4_credentials(
         access_key_id=access_key_id,
         secret_access_key=secret_access_key,
         session_token=_parse_optional_string(value, "sessionToken"),
-        default_region=_parse_optional_string(value, "defaultRegion"),
-        default_service=_parse_optional_string(value, "defaultService"),
     )
 
 

--- a/crates/runner/mitm-addon/src/auth.py
+++ b/crates/runner/mitm-addon/src/auth.py
@@ -28,6 +28,7 @@ from auth_base_forwarder import (
     header_pairs,
     trusted_request_header_pairs,
 )
+from aws_sigv4 import AwsSigV4Credentials, AwsSigV4SigningError, sign_request
 from logging_utils import log_proxy_entry
 from url_utils import build_rewrite_url
 
@@ -103,6 +104,7 @@ class _FirewallAuthPayload:
     resolved_secrets: list[str] = field(default_factory=list)
     base: str | None = None
     query: dict[str, str] | None = None
+    aws_sigv4: AwsSigV4Credentials | None = None
 
 
 @dataclass
@@ -366,6 +368,17 @@ def _parse_optional_string_map(
     return _parse_string_map(value, field_name)
 
 
+def _parse_optional_string(decoded: dict[object, object], field_name: str) -> str | None:
+    value = decoded.get(field_name)
+    if value is None:
+        return None
+    if not isinstance(value, str):
+        raise _malformed_firewall_auth_success(f"{field_name} must be a string")
+    if value == "":
+        raise _malformed_firewall_auth_success(f"{field_name} must not be empty")
+    return value
+
+
 def _parse_optional_string_list(decoded: dict[object, object], field_name: str) -> list[str]:
     value = decoded.get(field_name)
     if value is None:
@@ -375,6 +388,29 @@ def _parse_optional_string_list(decoded: dict[object, object], field_name: str) 
     if not all(isinstance(item, str) for item in value):
         raise _malformed_firewall_auth_success(f"{field_name} values must be strings")
     return list(value)
+
+
+def _parse_optional_aws_sigv4_credentials(
+    decoded: dict[object, object],
+) -> AwsSigV4Credentials | None:
+    value = decoded.get("awsSigv4")
+    if value is None:
+        return None
+    if not isinstance(value, dict):
+        raise _malformed_firewall_auth_success("awsSigv4 must be an object")
+    access_key_id = value.get("accessKeyId")
+    secret_access_key = value.get("secretAccessKey")
+    if not isinstance(access_key_id, str) or not access_key_id:
+        raise _malformed_firewall_auth_success("awsSigv4.accessKeyId is required")
+    if not isinstance(secret_access_key, str) or not secret_access_key:
+        raise _malformed_firewall_auth_success("awsSigv4.secretAccessKey is required")
+    return AwsSigV4Credentials(
+        access_key_id=access_key_id,
+        secret_access_key=secret_access_key,
+        session_token=_parse_optional_string(value, "sessionToken"),
+        default_region=_parse_optional_string(value, "defaultRegion"),
+        default_service=_parse_optional_string(value, "defaultService"),
+    )
 
 
 def _parse_firewall_auth_success(decoded: object) -> _FirewallAuthSuccess:
@@ -393,11 +429,13 @@ def _parse_firewall_auth_success(decoded: object) -> _FirewallAuthSuccess:
     refreshed_connectors = _parse_optional_string_list(decoded_map, "refreshedConnectors")
     refreshed_secrets = _parse_optional_string_list(decoded_map, "refreshedSecrets")
     query = _parse_optional_string_map(decoded_map, "query")
+    aws_sigv4 = _parse_optional_aws_sigv4_credentials(decoded_map)
     payload = _FirewallAuthPayload(
         headers=headers,
         resolved_secrets=resolved_secrets,
         base=base,
         query=query,
+        aws_sigv4=aws_sigv4,
     )
     return _FirewallAuthSuccess(
         payload=payload,
@@ -418,6 +456,7 @@ def _fetch_firewall_headers_sync(
     vars_map: dict | None = None,
     auth_base: str | None = None,
     auth_query: dict | None = None,
+    auth_aws_sigv4: dict | None = None,
     firewall_billable: bool = False,
     force_refresh: bool = False,
 ) -> _FirewallAuthSuccess:
@@ -432,6 +471,8 @@ def _fetch_firewall_headers_sync(
         body["authBase"] = auth_base
     if auth_query:
         body["authQuery"] = auth_query
+    if auth_aws_sigv4:
+        body["authAwsSigv4"] = auth_aws_sigv4
     if secret_connector_map:
         body["secretConnectorMap"] = secret_connector_map
     if secret_connector_metadata_map:
@@ -487,6 +528,7 @@ async def fetch_firewall_headers(
     vars_map: dict | None = None,
     auth_base: str | None = None,
     auth_query: dict | None = None,
+    auth_aws_sigv4: dict | None = None,
     firewall_billable: bool = False,
     force_refresh: bool = False,
 ) -> _FirewallAuthSuccess:
@@ -524,6 +566,7 @@ async def fetch_firewall_headers(
         vars_map=vars_map,
         auth_base=auth_base,
         auth_query=auth_query,
+        auth_aws_sigv4=auth_aws_sigv4,
         firewall_billable=firewall_billable,
         force_refresh=force_refresh,
     )
@@ -569,6 +612,8 @@ def _build_token_meta(
         token_meta["base"] = payload.base
     if payload.query is not None:
         token_meta["query"] = payload.query
+    if payload.aws_sigv4 is not None:
+        token_meta["aws_sigv4"] = payload.aws_sigv4
     return token_meta
 
 
@@ -598,6 +643,7 @@ async def get_firewall_headers(
     vars_map: dict | None = None,
     auth_base: str | None = None,
     auth_query: dict | None = None,
+    auth_aws_sigv4: dict | None = None,
     firewall_billable: bool = False,
 ) -> dict:
     """Get firewall auth headers with TTL-based caching.
@@ -647,6 +693,7 @@ async def get_firewall_headers(
             vars_map=vars_map,
             auth_base=auth_base,
             auth_query=auth_query,
+            auth_aws_sigv4=auth_aws_sigv4,
             firewall_billable=firewall_billable,
             force_refresh=force_refresh,
         )
@@ -695,6 +742,40 @@ def _apply_header_query_injection(
     if resolved_query:
         for key, value in resolved_query.items():
             flow.request.query[key] = value
+
+
+def _sign_flow_request_with_aws_sigv4(
+    flow: http.HTTPFlow,
+    credentials: AwsSigV4Credentials,
+) -> None:
+    signed_url, signed_headers = sign_request(
+        method=flow.request.method,
+        url=flow.request.url,
+        headers=header_pairs(flow.request.headers),
+        body=flow.request.raw_content,
+        credentials=credentials,
+    )
+    flow.request.url = signed_url
+    flow.request.headers = http.Headers(
+        [(name.encode(), value.encode()) for name, value in signed_headers]
+    )
+
+
+def _sign_forwarded_request_with_aws_sigv4(
+    *,
+    method: str,
+    url: str,
+    headers: list[tuple[str, str]],
+    body: bytes | None,
+    credentials: AwsSigV4Credentials,
+) -> tuple[str, list[tuple[str, str]]]:
+    return sign_request(
+        method=method,
+        url=url,
+        headers=headers,
+        body=body,
+        credentials=credentials,
+    )
 
 
 def _set_url_rewrite_forward_failed(
@@ -764,6 +845,7 @@ async def _apply_url_rewrite(
     resolved_base: str,
     headers: dict[str, str],
     resolved_query: dict | None,
+    aws_sigv4: AwsSigV4Credentials | None,
     firewall_base: str,
     proxy_log_path: str,
 ) -> FirewallAuthHandlingResult:
@@ -789,6 +871,25 @@ async def _apply_url_rewrite(
     # intentionally replace any client-supplied value with the same name.
     req_headers = _merge_auth_headers(forwarded_request_header_pairs(flow.request.headers), headers)
     req_body = flow.request.raw_content if flow.request.raw_content is not None else None
+    if aws_sigv4 is not None:
+        try:
+            new_url, req_headers = _sign_forwarded_request_with_aws_sigv4(
+                method=flow.request.method,
+                url=new_url,
+                headers=req_headers,
+                body=req_body,
+                credentials=aws_sigv4,
+            )
+        except AwsSigV4SigningError as e:
+            _set_matched_firewall_failure_response(
+                flow,
+                status=502,
+                action="ALLOW",
+                error_code="aws_sigv4_auth_failed",
+                message=str(e),
+                permission=allow.name,
+            )
+            return FirewallAuthHandlingResult.LOCAL_RESPONSE
 
     try:
         status, resp_body, resp_headers = await forward_request(
@@ -839,6 +940,7 @@ async def _apply_resolved_firewall_auth(
     headers = token_meta["headers"]
     resolved_query = token_meta.get("query")
     resolved_base = token_meta.get("base")
+    aws_sigv4 = token_meta.get("aws_sigv4")
 
     if resolved_base:
         return await _apply_url_rewrite(
@@ -847,6 +949,7 @@ async def _apply_resolved_firewall_auth(
             resolved_base=resolved_base,
             headers=headers,
             resolved_query=resolved_query,
+            aws_sigv4=aws_sigv4,
             firewall_base=firewall_base,
             proxy_log_path=proxy_log_path,
         )
@@ -856,6 +959,19 @@ async def _apply_resolved_firewall_auth(
         headers=headers,
         resolved_query=resolved_query,
     )
+    if aws_sigv4 is not None:
+        try:
+            _sign_flow_request_with_aws_sigv4(flow, aws_sigv4)
+        except AwsSigV4SigningError as e:
+            _set_matched_firewall_failure_response(
+                flow,
+                status=502,
+                action="ALLOW",
+                error_code="aws_sigv4_auth_failed",
+                message=str(e),
+                permission=allow.name,
+            )
+            return FirewallAuthHandlingResult.LOCAL_RESPONSE
     return FirewallAuthHandlingResult.CONTINUE_UPSTREAM
 
 
@@ -874,6 +990,7 @@ async def handle_firewall_request(
     auth_headers = api_entry.get("auth", {}).get("headers", {})
     auth_base = api_entry.get("auth", {}).get("base")
     auth_query = api_entry.get("auth", {}).get("query")
+    auth_aws_sigv4 = api_entry.get("auth", {}).get("awsSigv4")
     secret_connector_map = vm_info.get("secretConnectorMap")
     secret_connector_metadata_map = vm_info.get("secretConnectorMetadataMap")
     vars_map = vm_info.get("vars")
@@ -919,6 +1036,7 @@ async def handle_firewall_request(
             vars_map=vars_map,
             auth_base=auth_base,
             auth_query=auth_query,
+            auth_aws_sigv4=auth_aws_sigv4,
             firewall_billable=firewall_billable,
         )
     except ConnectorNotConfiguredError as e:

--- a/crates/runner/mitm-addon/src/aws_sigv4.py
+++ b/crates/runner/mitm-addon/src/aws_sigv4.py
@@ -261,7 +261,7 @@ def _sign_query_request(
     context: _SigningContext,
     is_s3: bool,
 ) -> tuple[str, list[tuple[str, str]]]:
-    clean_headers = _without_headers(headers, {"authorization"})
+    clean_headers = _without_headers(headers, {"authorization", "x-amz-security-token"})
     clean_headers = _upsert_header(clean_headers, "host", _host_header_value(url))
     signed_headers = frozenset(set(context.signed_headers) | {"host"})
     payload_hash = _query_payload_hash(headers, body, is_s3)

--- a/crates/runner/mitm-addon/src/aws_sigv4.py
+++ b/crates/runner/mitm-addon/src/aws_sigv4.py
@@ -21,6 +21,8 @@ _AUTH_PARAM_RE = re.compile(r"([A-Za-z]+)=([^,]+)")
 _SCOPE_DATE_RE = re.compile(r"^\d{8}$")
 _SCOPE_REGION_RE = re.compile(r"^(?:[A-Za-z0-9._-]+|\*)$")
 _SCOPE_SERVICE_RE = re.compile(r"^[A-Za-z0-9._-]+$")
+_AMZ_DATE_RE = re.compile(r"^\d{8}T\d{6}Z$")
+_PRESIGN_EXPIRES_RE = re.compile(r"^[1-9]\d*$")
 _ACCESS_KEY_ID_RE = re.compile(r"^[A-Za-z0-9]+$")
 _ASCII_CONTROL_MAX = 0x1F
 _ASCII_DELETE = 0x7F
@@ -131,6 +133,7 @@ def _classify_header_request(
     amz_date = _first_header(headers, "x-amz-date")
     if not amz_date:
         raise AwsSigV4SigningError("AWS SigV4 header auth requires x-amz-date")
+    _validate_amz_date(amz_date, scope)
     return _SigningContext(
         location=_AuthLocation.HEADER,
         algorithm=algorithm,
@@ -152,6 +155,9 @@ def _classify_query_request(
     if not credential or not signed_headers or not amz_date or not expires or not signature:
         raise AwsSigV4SigningError("Malformed AWS presigned query")
     scope = _parse_credential_scope(credential)
+    _validate_amz_date(amz_date, scope)
+    if not _PRESIGN_EXPIRES_RE.fullmatch(expires):
+        raise AwsSigV4SigningError("Malformed AWS presigned query expiry")
     return _SigningContext(
         location=_AuthLocation.QUERY,
         algorithm=algorithm,
@@ -195,6 +201,13 @@ def _parse_signed_headers(value: str) -> frozenset[str]:
     if "host" not in headers:
         raise AwsSigV4SigningError("AWS signed headers must include host")
     return headers
+
+
+def _validate_amz_date(amz_date: str, scope: _CredentialScope) -> None:
+    if not _AMZ_DATE_RE.fullmatch(amz_date):
+        raise AwsSigV4SigningError("Malformed AWS signing date")
+    if not amz_date.startswith(scope.date):
+        raise AwsSigV4SigningError("AWS signing date does not match credential scope")
 
 
 def _sign_header_request(

--- a/crates/runner/mitm-addon/src/aws_sigv4.py
+++ b/crates/runner/mitm-addon/src/aws_sigv4.py
@@ -35,6 +35,7 @@ _SCOPE_SERVICE_RE = re.compile(r"^[A-Za-z0-9._-]+$")
 _AMZ_DATE_RE = re.compile(r"^\d{8}T\d{6}Z$")
 _PRESIGN_EXPIRES_RE = re.compile(r"^[1-9]\d*$")
 _ACCESS_KEY_ID_RE = re.compile(r"^[A-Za-z0-9]+$")
+_SIGNED_HEADER_NAME_RE = re.compile(r"^[A-Za-z0-9!#$%&'*+.^_`|~-]+$")
 _ASCII_CONTROL_MAX = 0x1F
 _ASCII_DELETE = 0x7F
 
@@ -228,7 +229,14 @@ def _parse_credential(credential: str) -> tuple[str, _CredentialScope]:
 
 
 def _parse_signed_headers(value: str) -> frozenset[str]:
-    headers = frozenset(part.strip().lower() for part in value.split(";") if part.strip())
+    parts = [part.strip().lower() for part in value.split(";")]
+    if (
+        not parts
+        or any(not part or not _SIGNED_HEADER_NAME_RE.fullmatch(part) for part in parts)
+        or len(parts) != len(set(parts))
+    ):
+        raise AwsSigV4SigningError("Malformed AWS signed headers")
+    headers = frozenset(parts)
     if "host" not in headers:
         raise AwsSigV4SigningError("AWS signed headers must include host")
     return headers

--- a/crates/runner/mitm-addon/src/aws_sigv4.py
+++ b/crates/runner/mitm-addon/src/aws_sigv4.py
@@ -37,6 +37,7 @@ _ACCESS_KEY_ID_RE = re.compile(r"^[A-Za-z0-9]+$")
 _SIGNED_HEADER_NAME_RE = re.compile(r"^[A-Za-z0-9!#$%&'*+.^_`|~-]+$")
 _ASCII_CONTROL_MAX = 0x1F
 _ASCII_DELETE = 0x7F
+_DEFAULT_PORTS = {"http": 80, "https": 443}
 
 
 class AwsSigV4SigningError(Exception):
@@ -613,6 +614,15 @@ def _upsert_header(
 
 def _host_header_value(url: str) -> str:
     parts = urllib.parse.urlsplit(url)
-    if not parts.netloc:
+    if not parts.netloc or not parts.hostname:
         raise AwsSigV4SigningError("AWS request URL must include a host")
-    return parts.netloc.rsplit("@", maxsplit=1)[-1]
+    host = parts.hostname
+    if ":" in host and not host.startswith("["):
+        host = f"[{host}]"
+    try:
+        port = parts.port
+    except ValueError as e:
+        raise AwsSigV4SigningError("AWS request URL has an invalid port") from e
+    if port is not None and port != _DEFAULT_PORTS.get(parts.scheme.lower()):
+        host = f"{host}:{port}"
+    return host

--- a/crates/runner/mitm-addon/src/aws_sigv4.py
+++ b/crates/runner/mitm-addon/src/aws_sigv4.py
@@ -8,7 +8,6 @@ import posixpath
 import re
 import urllib.parse
 from dataclasses import dataclass
-from datetime import UTC, datetime
 from enum import Enum
 
 _AWS4_REQUEST = "aws4_request"
@@ -126,7 +125,9 @@ def _classify_header_request(
     if not credential or not signed_headers:
         raise AwsSigV4SigningError("Malformed AWS authorization header")
     scope = _parse_credential_scope(credential, credentials)
-    amz_date = _first_header(headers, "x-amz-date") or _fallback_amz_date(scope.date)
+    amz_date = _first_header(headers, "x-amz-date")
+    if not amz_date:
+        raise AwsSigV4SigningError("AWS SigV4 header auth requires x-amz-date")
     return _SigningContext(
         location=_AuthLocation.HEADER,
         algorithm=algorithm,
@@ -188,12 +189,6 @@ def _parse_signed_headers(value: str) -> frozenset[str]:
     if "host" not in headers:
         raise AwsSigV4SigningError("AWS signed headers must include host")
     return headers
-
-
-def _fallback_amz_date(scope_date: str) -> str:
-    if re.fullmatch(r"\d{8}", scope_date):
-        return f"{scope_date}T000000Z"
-    return datetime.now(UTC).strftime("%Y%m%dT%H%M%SZ")
 
 
 def _sign_header_request(

--- a/crates/runner/mitm-addon/src/aws_sigv4.py
+++ b/crates/runner/mitm-addon/src/aws_sigv4.py
@@ -17,7 +17,18 @@ _S3_SIGNING_NAMES = frozenset(("s3", "s3-outposts", "s3-object-lambda"))
 _UNSUPPORTED_S3_EXPRESS_SIGNING_NAME = "s3express"
 _STREAMING_PAYLOAD_PREFIX = "STREAMING-"
 _CREDENTIAL_SCOPE_PARTS = 5
-_AUTH_PARAM_RE = re.compile(r"([A-Za-z]+)=([^,]+)")
+_AUTH_HEADER_PARAM_NAMES = frozenset(("Credential", "SignedHeaders", "Signature"))
+_QUERY_SIGNING_PARAM_NAMES = frozenset(
+    (
+        "X-Amz-Algorithm",
+        "X-Amz-Credential",
+        "X-Amz-Date",
+        "X-Amz-Expires",
+        "X-Amz-SignedHeaders",
+        "X-Amz-Security-Token",
+        "X-Amz-Signature",
+    )
+)
 _SCOPE_DATE_RE = re.compile(r"^\d{8}$")
 _SCOPE_REGION_RE = re.compile(r"^(?:[A-Za-z0-9._-]+|\*)$")
 _SCOPE_SERVICE_RE = re.compile(r"^[A-Za-z0-9._-]+$")
@@ -110,9 +121,13 @@ def _classify_request(
     url: str,
     headers: list[tuple[str, str]],
 ) -> _SigningContext:
-    auth_header = _first_header(headers, "authorization")
+    auth_header = _unique_header_value(
+        headers,
+        "authorization",
+        "Malformed AWS authorization header",
+    )
     query_pairs = _parse_query_pairs(urllib.parse.urlsplit(url).query)
-    query_algorithm = _first_query_value(query_pairs, "X-Amz-Algorithm")
+    query_algorithm = _unique_query_value(query_pairs, "X-Amz-Algorithm")
     if auth_header and query_algorithm:
         raise AwsSigV4SigningError("Ambiguous AWS auth location")
     if query_algorithm:
@@ -133,7 +148,11 @@ def _classify_header_request(
     if not credential or not signed_headers or not signature:
         raise AwsSigV4SigningError("Malformed AWS authorization header")
     source_access_key_id, scope = _parse_credential(credential)
-    amz_date = _first_header(headers, "x-amz-date")
+    amz_date = _unique_header_value(
+        headers,
+        "x-amz-date",
+        "AWS SigV4 header auth requires a single x-amz-date",
+    )
     if not amz_date:
         raise AwsSigV4SigningError("AWS SigV4 header auth requires x-amz-date")
     _validate_amz_date(amz_date, scope)
@@ -151,11 +170,11 @@ def _classify_query_request(
     query_pairs: list[tuple[str, str]],
     algorithm: str,
 ) -> _SigningContext:
-    credential = _first_query_value(query_pairs, "X-Amz-Credential")
-    signed_headers = _first_query_value(query_pairs, "X-Amz-SignedHeaders")
-    amz_date = _first_query_value(query_pairs, "X-Amz-Date")
-    expires = _first_query_value(query_pairs, "X-Amz-Expires")
-    signature = _first_query_value(query_pairs, "X-Amz-Signature")
+    credential = _unique_query_value(query_pairs, "X-Amz-Credential")
+    signed_headers = _unique_query_value(query_pairs, "X-Amz-SignedHeaders")
+    amz_date = _unique_query_value(query_pairs, "X-Amz-Date")
+    expires = _unique_query_value(query_pairs, "X-Amz-Expires")
+    signature = _unique_query_value(query_pairs, "X-Amz-Signature")
     if not credential or not signed_headers or not amz_date or not expires or not signature:
         raise AwsSigV4SigningError("Malformed AWS presigned query")
     source_access_key_id, scope = _parse_credential(credential)
@@ -175,11 +194,15 @@ def _classify_query_request(
 
 def _parse_authorization_header(value: str) -> tuple[str, dict[str, str]]:
     algorithm, sep, remainder = value.partition(" ")
-    if not sep:
+    if not sep or not algorithm or not remainder.strip():
         raise AwsSigV4SigningError("Malformed AWS authorization header")
-    params = {
-        match.group(1): match.group(2).strip() for match in _AUTH_PARAM_RE.finditer(remainder)
-    }
+    params: dict[str, str] = {}
+    for raw_param in remainder.split(","):
+        key, param_sep, raw_param_value = raw_param.strip().partition("=")
+        param_value = raw_param_value.strip()
+        if not param_sep or key not in _AUTH_HEADER_PARAM_NAMES or not param_value or key in params:
+            raise AwsSigV4SigningError("Malformed AWS authorization header")
+        params[key] = param_value
     return algorithm, params
 
 
@@ -387,7 +410,11 @@ def _normalize_header_value(value: str) -> str:
 
 
 def _payload_hash(headers: list[tuple[str, str]], body: bytes | None) -> str:
-    header_value = _first_header(headers, "x-amz-content-sha256")
+    header_value = _unique_header_value(
+        headers,
+        "x-amz-content-sha256",
+        "AWS content hash header is ambiguous",
+    )
     if header_value:
         if header_value.startswith(_STREAMING_PAYLOAD_PREFIX):
             raise AwsSigV4SigningError("AWS streaming payload signing is not supported")
@@ -396,7 +423,11 @@ def _payload_hash(headers: list[tuple[str, str]], body: bytes | None) -> str:
 
 
 def _query_payload_hash(headers: list[tuple[str, str]], body: bytes | None, is_s3: bool) -> str:
-    header_value = _first_header(headers, "x-amz-content-sha256")
+    header_value = _unique_header_value(
+        headers,
+        "x-amz-content-sha256",
+        "AWS content hash header is ambiguous",
+    )
     if header_value:
         if header_value.startswith(_STREAMING_PAYLOAD_PREFIX):
             raise AwsSigV4SigningError("AWS streaming payload signing is not supported")
@@ -452,16 +483,7 @@ def _replace_query_signing_params(
     filtered = [
         (key, value)
         for key, value in _parse_query_pairs(parts.query)
-        if key
-        not in {
-            "X-Amz-Algorithm",
-            "X-Amz-Credential",
-            "X-Amz-Date",
-            "X-Amz-Expires",
-            "X-Amz-SignedHeaders",
-            "X-Amz-Security-Token",
-            "X-Amz-Signature",
-        }
+        if key not in _QUERY_SIGNING_PARAM_NAMES
     ]
     filtered.extend(
         [
@@ -517,19 +539,33 @@ def _has_ascii_control(value: str) -> bool:
     return any(ord(char) <= _ASCII_CONTROL_MAX or ord(char) == _ASCII_DELETE for char in value)
 
 
-def _first_header(headers: list[tuple[str, str]], name: str) -> str | None:
+def _unique_header_value(
+    headers: list[tuple[str, str]],
+    name: str,
+    duplicate_message: str,
+) -> str | None:
     lower_name = name.lower()
+    result: str | None = None
+    found = False
     for header_name, value in headers:
         if header_name.lower() == lower_name:
-            return value
-    return None
+            if found:
+                raise AwsSigV4SigningError(duplicate_message)
+            found = True
+            result = value
+    return result
 
 
-def _first_query_value(pairs: list[tuple[str, str]], name: str) -> str | None:
+def _unique_query_value(pairs: list[tuple[str, str]], name: str) -> str | None:
+    result: str | None = None
+    found = False
     for key, value in pairs:
         if key == name:
-            return value
-    return None
+            if found:
+                raise AwsSigV4SigningError("Malformed AWS presigned query")
+            found = True
+            result = value
+    return result
 
 
 def _without_headers(

--- a/crates/runner/mitm-addon/src/aws_sigv4.py
+++ b/crates/runner/mitm-addon/src/aws_sigv4.py
@@ -55,6 +55,7 @@ class _CredentialScope:
 class _SigningContext:
     location: _AuthLocation
     algorithm: str
+    source_access_key_id: str
     scope: _CredentialScope
     signed_headers: frozenset[str]
     amz_date: str
@@ -76,6 +77,8 @@ def sign_request(
         raise AwsSigV4SigningError("SigV4A is not supported by this runner")
     if context.algorithm != _HMAC_ALGORITHM:
         raise AwsSigV4SigningError("Unsupported AWS signing algorithm")
+    if context.source_access_key_id == credentials.access_key_id:
+        raise AwsSigV4SigningError("AWS request must use a placeholder access key ID")
     if context.scope.region == "*":
         raise AwsSigV4SigningError("Wildcard AWS signing region requires SigV4A")
     if context.scope.service == _UNSUPPORTED_S3_EXPRESS_SIGNING_NAME:
@@ -129,7 +132,7 @@ def _classify_header_request(
     signature = params.get("Signature")
     if not credential or not signed_headers or not signature:
         raise AwsSigV4SigningError("Malformed AWS authorization header")
-    scope = _parse_credential_scope(credential)
+    source_access_key_id, scope = _parse_credential(credential)
     amz_date = _first_header(headers, "x-amz-date")
     if not amz_date:
         raise AwsSigV4SigningError("AWS SigV4 header auth requires x-amz-date")
@@ -137,6 +140,7 @@ def _classify_header_request(
     return _SigningContext(
         location=_AuthLocation.HEADER,
         algorithm=algorithm,
+        source_access_key_id=source_access_key_id,
         scope=scope,
         signed_headers=_parse_signed_headers(signed_headers),
         amz_date=amz_date,
@@ -154,13 +158,14 @@ def _classify_query_request(
     signature = _first_query_value(query_pairs, "X-Amz-Signature")
     if not credential or not signed_headers or not amz_date or not expires or not signature:
         raise AwsSigV4SigningError("Malformed AWS presigned query")
-    scope = _parse_credential_scope(credential)
+    source_access_key_id, scope = _parse_credential(credential)
     _validate_amz_date(amz_date, scope)
     if not _PRESIGN_EXPIRES_RE.fullmatch(expires):
         raise AwsSigV4SigningError("Malformed AWS presigned query expiry")
     return _SigningContext(
         location=_AuthLocation.QUERY,
         algorithm=algorithm,
+        source_access_key_id=source_access_key_id,
         scope=scope,
         signed_headers=_parse_signed_headers(signed_headers),
         amz_date=amz_date,
@@ -178,22 +183,25 @@ def _parse_authorization_header(value: str) -> tuple[str, dict[str, str]]:
     return algorithm, params
 
 
-def _parse_credential_scope(credential: str) -> _CredentialScope:
+def _parse_credential(credential: str) -> tuple[str, _CredentialScope]:
     parts = urllib.parse.unquote(credential).split("/")
     if len(parts) != _CREDENTIAL_SCOPE_PARTS or parts[-1] != _AWS4_REQUEST:
         raise AwsSigV4SigningError("Malformed AWS credential scope")
+    access_key_id = parts[0]
     date = parts[1]
     region = parts[2]
     service = parts[3]
-    if not date or not region or not service:
+    if not access_key_id or not date or not region or not service:
         raise AwsSigV4SigningError("Incomplete AWS credential scope")
     if (
-        not _SCOPE_DATE_RE.fullmatch(date)
+        not _ACCESS_KEY_ID_RE.fullmatch(access_key_id)
+        or _has_ascii_control(access_key_id)
+        or not _SCOPE_DATE_RE.fullmatch(date)
         or not _SCOPE_REGION_RE.fullmatch(region)
         or not _SCOPE_SERVICE_RE.fullmatch(service)
     ):
         raise AwsSigV4SigningError("Malformed AWS credential scope")
-    return _CredentialScope(date=date, region=region, service=service)
+    return access_key_id, _CredentialScope(date=date, region=region, service=service)
 
 
 def _parse_signed_headers(value: str) -> frozenset[str]:

--- a/crates/runner/mitm-addon/src/aws_sigv4.py
+++ b/crates/runner/mitm-addon/src/aws_sigv4.py
@@ -529,9 +529,11 @@ def _parse_query_pairs(query: str) -> list[tuple[str, str]]:
 def _validate_credentials(credentials: AwsSigV4Credentials) -> None:
     if not _ACCESS_KEY_ID_RE.fullmatch(credentials.access_key_id):
         raise AwsSigV4SigningError("Invalid AWS access key ID")
-    if _has_ascii_control(credentials.secret_access_key):
+    if not credentials.secret_access_key or _has_ascii_control(credentials.secret_access_key):
         raise AwsSigV4SigningError("Invalid AWS secret access key")
-    if credentials.session_token is not None and _has_ascii_control(credentials.session_token):
+    if credentials.session_token is not None and (
+        not credentials.session_token or _has_ascii_control(credentials.session_token)
+    ):
         raise AwsSigV4SigningError("Invalid AWS session token")
 
 

--- a/crates/runner/mitm-addon/src/aws_sigv4.py
+++ b/crates/runner/mitm-addon/src/aws_sigv4.py
@@ -122,7 +122,8 @@ def _classify_header_request(
     algorithm, params = _parse_authorization_header(auth_header)
     credential = params.get("Credential")
     signed_headers = params.get("SignedHeaders")
-    if not credential or not signed_headers:
+    signature = params.get("Signature")
+    if not credential or not signed_headers or not signature:
         raise AwsSigV4SigningError("Malformed AWS authorization header")
     scope = _parse_credential_scope(credential, credentials)
     amz_date = _first_header(headers, "x-amz-date")
@@ -146,7 +147,8 @@ def _classify_query_request(
     signed_headers = _first_query_value(query_pairs, "X-Amz-SignedHeaders")
     amz_date = _first_query_value(query_pairs, "X-Amz-Date")
     expires = _first_query_value(query_pairs, "X-Amz-Expires")
-    if not credential or not signed_headers or not amz_date or not expires:
+    signature = _first_query_value(query_pairs, "X-Amz-Signature")
+    if not credential or not signed_headers or not amz_date or not expires or not signature:
         raise AwsSigV4SigningError("Malformed AWS presigned query")
     scope = _parse_credential_scope(credential, credentials)
     return _SigningContext(

--- a/crates/runner/mitm-addon/src/aws_sigv4.py
+++ b/crates/runner/mitm-addon/src/aws_sigv4.py
@@ -18,6 +18,12 @@ _UNSUPPORTED_S3_EXPRESS_SIGNING_NAME = "s3express"
 _STREAMING_PAYLOAD_PREFIX = "STREAMING-"
 _CREDENTIAL_SCOPE_PARTS = 5
 _AUTH_PARAM_RE = re.compile(r"([A-Za-z]+)=([^,]+)")
+_SCOPE_DATE_RE = re.compile(r"^\d{8}$")
+_SCOPE_REGION_RE = re.compile(r"^(?:[A-Za-z0-9._-]+|\*)$")
+_SCOPE_SERVICE_RE = re.compile(r"^[A-Za-z0-9._-]+$")
+_ACCESS_KEY_ID_RE = re.compile(r"^[A-Za-z0-9]+$")
+_ASCII_CONTROL_MAX = 0x1F
+_ASCII_DELETE = 0x7F
 
 
 class AwsSigV4SigningError(Exception):
@@ -62,11 +68,14 @@ def sign_request(
     credentials: AwsSigV4Credentials,
 ) -> tuple[str, list[tuple[str, str]]]:
     """Return a URL/header pair re-signed with real AWS credentials."""
+    _validate_credentials(credentials)
     context = _classify_request(url, headers)
     if context.algorithm == _ASYMMETRIC_ALGORITHM:
         raise AwsSigV4SigningError("SigV4A is not supported by this runner")
     if context.algorithm != _HMAC_ALGORITHM:
         raise AwsSigV4SigningError("Unsupported AWS signing algorithm")
+    if context.scope.region == "*":
+        raise AwsSigV4SigningError("Wildcard AWS signing region requires SigV4A")
     if context.scope.service == _UNSUPPORTED_S3_EXPRESS_SIGNING_NAME:
         raise AwsSigV4SigningError("S3 Express signing is not supported by this runner")
 
@@ -97,10 +106,7 @@ def _classify_request(
     headers: list[tuple[str, str]],
 ) -> _SigningContext:
     auth_header = _first_header(headers, "authorization")
-    query_pairs = urllib.parse.parse_qsl(
-        urllib.parse.urlsplit(url).query,
-        keep_blank_values=True,
-    )
+    query_pairs = _parse_query_pairs(urllib.parse.urlsplit(url).query)
     query_algorithm = _first_query_value(query_pairs, "X-Amz-Algorithm")
     if auth_header and query_algorithm:
         raise AwsSigV4SigningError("Ambiguous AWS auth location")
@@ -175,6 +181,12 @@ def _parse_credential_scope(credential: str) -> _CredentialScope:
     service = parts[3]
     if not date or not region or not service:
         raise AwsSigV4SigningError("Incomplete AWS credential scope")
+    if (
+        not _SCOPE_DATE_RE.fullmatch(date)
+        or not _SCOPE_REGION_RE.fullmatch(region)
+        or not _SCOPE_SERVICE_RE.fullmatch(service)
+    ):
+        raise AwsSigV4SigningError("Malformed AWS credential scope")
     return _CredentialScope(date=date, region=region, service=service)
 
 
@@ -324,7 +336,7 @@ def _canonical_uri(path: str, *, is_s3: bool) -> str:
 
 
 def _canonical_query_string(query: str) -> str:
-    pairs = urllib.parse.parse_qsl(query, keep_blank_values=True)
+    pairs = _parse_query_pairs(query)
     encoded = [(_aws_quote(key), _aws_quote(value)) for key, value in pairs]
     encoded.sort()
     return "&".join(f"{key}={value}" for key, value in encoded)
@@ -418,7 +430,7 @@ def _replace_query_signing_params(
     parts = urllib.parse.urlsplit(url)
     filtered = [
         (key, value)
-        for key, value in urllib.parse.parse_qsl(parts.query, keep_blank_values=True)
+        for key, value in _parse_query_pairs(parts.query)
         if key
         not in {
             "X-Amz-Algorithm",
@@ -456,6 +468,32 @@ def _encode_query_pairs(pairs: list[tuple[str, str]]) -> str:
 
 def _aws_quote(value: str) -> str:
     return urllib.parse.quote(value, safe="-_.~")
+
+
+def _parse_query_pairs(query: str) -> list[tuple[str, str]]:
+    if not query:
+        return []
+
+    pairs: list[tuple[str, str]] = []
+    for raw_pair in query.split("&"):
+        if not raw_pair:
+            continue
+        raw_key, _separator, raw_value = raw_pair.partition("=")
+        pairs.append((urllib.parse.unquote(raw_key), urllib.parse.unquote(raw_value)))
+    return pairs
+
+
+def _validate_credentials(credentials: AwsSigV4Credentials) -> None:
+    if not _ACCESS_KEY_ID_RE.fullmatch(credentials.access_key_id):
+        raise AwsSigV4SigningError("Invalid AWS access key ID")
+    if _has_ascii_control(credentials.secret_access_key):
+        raise AwsSigV4SigningError("Invalid AWS secret access key")
+    if credentials.session_token is not None and _has_ascii_control(credentials.session_token):
+        raise AwsSigV4SigningError("Invalid AWS session token")
+
+
+def _has_ascii_control(value: str) -> bool:
+    return any(ord(char) <= _ASCII_CONTROL_MAX or ord(char) == _ASCII_DELETE for char in value)
 
 
 def _first_header(headers: list[tuple[str, str]], name: str) -> str | None:

--- a/crates/runner/mitm-addon/src/aws_sigv4.py
+++ b/crates/runner/mitm-addon/src/aws_sigv4.py
@@ -4,7 +4,6 @@ from __future__ import annotations
 
 import hashlib
 import hmac
-import posixpath
 import re
 import urllib.parse
 from dataclasses import dataclass
@@ -378,13 +377,27 @@ def _canonical_uri(path: str, *, is_s3: bool) -> str:
     raw_path = path or "/"
     if is_s3:
         return raw_path
-    decoded = urllib.parse.unquote(raw_path)
-    normalized = posixpath.normpath(decoded)
-    if decoded.endswith("/") and not normalized.endswith("/"):
-        normalized += "/"
-    if not normalized.startswith("/"):
-        normalized = f"/{normalized}"
+    normalized = _remove_dot_segments(raw_path)
     return urllib.parse.quote(normalized, safe="/~")
+
+
+def _remove_dot_segments(path: str) -> str:
+    if not path:
+        return "/"
+
+    output: list[str] = []
+    for segment in path.split("/"):
+        if not segment or segment == ".":
+            continue
+        if segment == "..":
+            if output:
+                output.pop()
+            continue
+        output.append(segment)
+
+    leading_slash = "/" if path.startswith("/") else ""
+    trailing_slash = "/" if path.endswith("/") and output else ""
+    return f"{leading_slash}{'/'.join(output)}{trailing_slash}"
 
 
 def _canonical_query_string(query: str) -> str:

--- a/crates/runner/mitm-addon/src/aws_sigv4.py
+++ b/crates/runner/mitm-addon/src/aws_sigv4.py
@@ -1,0 +1,511 @@
+"""AWS SigV4 request re-signing for connector firewall auth."""
+
+from __future__ import annotations
+
+import hashlib
+import hmac
+import posixpath
+import re
+import urllib.parse
+from dataclasses import dataclass
+from datetime import UTC, datetime
+from enum import Enum
+
+_AWS4_REQUEST = "aws4_request"
+_HMAC_ALGORITHM = "AWS4-HMAC-SHA256"
+_ASYMMETRIC_ALGORITHM = "AWS4-ECDSA-P256-SHA256"
+_S3_SIGNING_NAMES = frozenset(("s3", "s3-outposts", "s3-object-lambda"))
+_UNSUPPORTED_S3_EXPRESS_SIGNING_NAME = "s3express"
+_STREAMING_PAYLOAD_PREFIX = "STREAMING-"
+_CREDENTIAL_SCOPE_PARTS = 5
+_AUTH_PARAM_RE = re.compile(r"([A-Za-z]+)=([^,]+)")
+
+
+class AwsSigV4SigningError(Exception):
+    """Raised when a request cannot be safely re-signed."""
+
+
+class _AuthLocation(Enum):
+    HEADER = "header"
+    QUERY = "query"
+
+
+@dataclass(frozen=True)
+class AwsSigV4Credentials:
+    access_key_id: str
+    secret_access_key: str
+    session_token: str | None = None
+    default_region: str | None = None
+    default_service: str | None = None
+
+
+@dataclass(frozen=True)
+class _CredentialScope:
+    date: str
+    region: str
+    service: str
+
+
+@dataclass(frozen=True)
+class _SigningContext:
+    location: _AuthLocation
+    algorithm: str
+    scope: _CredentialScope
+    signed_headers: frozenset[str]
+    amz_date: str
+    expires: str | None = None
+
+
+def sign_request(
+    *,
+    method: str,
+    url: str,
+    headers: list[tuple[str, str]],
+    body: bytes | None,
+    credentials: AwsSigV4Credentials,
+) -> tuple[str, list[tuple[str, str]]]:
+    """Return a URL/header pair re-signed with real AWS credentials."""
+    context = _classify_request(url, headers, credentials)
+    if context.algorithm == _ASYMMETRIC_ALGORITHM:
+        raise AwsSigV4SigningError("SigV4A is not supported by this runner")
+    if context.algorithm != _HMAC_ALGORITHM:
+        raise AwsSigV4SigningError("Unsupported AWS signing algorithm")
+    if context.scope.service == _UNSUPPORTED_S3_EXPRESS_SIGNING_NAME:
+        raise AwsSigV4SigningError("S3 Express signing is not supported by this runner")
+
+    is_s3 = context.scope.service in _S3_SIGNING_NAMES
+    if context.location is _AuthLocation.QUERY:
+        return _sign_query_request(
+            method=method,
+            url=url,
+            headers=headers,
+            body=body,
+            credentials=credentials,
+            context=context,
+            is_s3=is_s3,
+        )
+    return _sign_header_request(
+        method=method,
+        url=url,
+        headers=headers,
+        body=body,
+        credentials=credentials,
+        context=context,
+        is_s3=is_s3,
+    )
+
+
+def _classify_request(
+    url: str,
+    headers: list[tuple[str, str]],
+    credentials: AwsSigV4Credentials,
+) -> _SigningContext:
+    auth_header = _first_header(headers, "authorization")
+    query_pairs = urllib.parse.parse_qsl(
+        urllib.parse.urlsplit(url).query,
+        keep_blank_values=True,
+    )
+    query_algorithm = _first_query_value(query_pairs, "X-Amz-Algorithm")
+    if auth_header and query_algorithm:
+        raise AwsSigV4SigningError("Ambiguous AWS auth location")
+    if query_algorithm:
+        return _classify_query_request(query_pairs, query_algorithm, credentials)
+    if auth_header:
+        return _classify_header_request(auth_header, headers, credentials)
+    raise AwsSigV4SigningError("Missing AWS SigV4 auth metadata")
+
+
+def _classify_header_request(
+    auth_header: str,
+    headers: list[tuple[str, str]],
+    credentials: AwsSigV4Credentials,
+) -> _SigningContext:
+    algorithm, params = _parse_authorization_header(auth_header)
+    credential = params.get("Credential")
+    signed_headers = params.get("SignedHeaders")
+    if not credential or not signed_headers:
+        raise AwsSigV4SigningError("Malformed AWS authorization header")
+    scope = _parse_credential_scope(credential, credentials)
+    amz_date = _first_header(headers, "x-amz-date") or _fallback_amz_date(scope.date)
+    return _SigningContext(
+        location=_AuthLocation.HEADER,
+        algorithm=algorithm,
+        scope=scope,
+        signed_headers=_parse_signed_headers(signed_headers),
+        amz_date=amz_date,
+    )
+
+
+def _classify_query_request(
+    query_pairs: list[tuple[str, str]],
+    algorithm: str,
+    credentials: AwsSigV4Credentials,
+) -> _SigningContext:
+    credential = _first_query_value(query_pairs, "X-Amz-Credential")
+    signed_headers = _first_query_value(query_pairs, "X-Amz-SignedHeaders")
+    amz_date = _first_query_value(query_pairs, "X-Amz-Date")
+    expires = _first_query_value(query_pairs, "X-Amz-Expires")
+    if not credential or not signed_headers or not amz_date or not expires:
+        raise AwsSigV4SigningError("Malformed AWS presigned query")
+    scope = _parse_credential_scope(credential, credentials)
+    return _SigningContext(
+        location=_AuthLocation.QUERY,
+        algorithm=algorithm,
+        scope=scope,
+        signed_headers=_parse_signed_headers(signed_headers),
+        amz_date=amz_date,
+        expires=expires,
+    )
+
+
+def _parse_authorization_header(value: str) -> tuple[str, dict[str, str]]:
+    algorithm, sep, remainder = value.partition(" ")
+    if not sep:
+        raise AwsSigV4SigningError("Malformed AWS authorization header")
+    params = {
+        match.group(1): match.group(2).strip() for match in _AUTH_PARAM_RE.finditer(remainder)
+    }
+    return algorithm, params
+
+
+def _parse_credential_scope(
+    credential: str,
+    credentials: AwsSigV4Credentials,
+) -> _CredentialScope:
+    parts = urllib.parse.unquote(credential).split("/")
+    if len(parts) != _CREDENTIAL_SCOPE_PARTS or parts[-1] != _AWS4_REQUEST:
+        raise AwsSigV4SigningError("Malformed AWS credential scope")
+    date = parts[1]
+    region = parts[2] or credentials.default_region
+    service = parts[3] or credentials.default_service
+    if not date or not region or not service:
+        raise AwsSigV4SigningError("Incomplete AWS credential scope")
+    return _CredentialScope(date=date, region=region, service=service)
+
+
+def _parse_signed_headers(value: str) -> frozenset[str]:
+    headers = frozenset(part.strip().lower() for part in value.split(";") if part.strip())
+    if "host" not in headers:
+        raise AwsSigV4SigningError("AWS signed headers must include host")
+    return headers
+
+
+def _fallback_amz_date(scope_date: str) -> str:
+    if re.fullmatch(r"\d{8}", scope_date):
+        return f"{scope_date}T000000Z"
+    return datetime.now(UTC).strftime("%Y%m%dT%H%M%SZ")
+
+
+def _sign_header_request(
+    *,
+    method: str,
+    url: str,
+    headers: list[tuple[str, str]],
+    body: bytes | None,
+    credentials: AwsSigV4Credentials,
+    context: _SigningContext,
+    is_s3: bool,
+) -> tuple[str, list[tuple[str, str]]]:
+    payload_hash = _payload_hash(headers, body)
+    clean_headers = _without_headers(headers, {"authorization", "x-amz-security-token"})
+    clean_headers = _upsert_header(clean_headers, "host", _host_header_value(url))
+    clean_headers = _upsert_header(clean_headers, "x-amz-date", context.amz_date)
+    if credentials.session_token:
+        clean_headers = _upsert_header(
+            clean_headers,
+            "x-amz-security-token",
+            credentials.session_token,
+        )
+
+    signed_headers = set(context.signed_headers)
+    signed_headers.add("host")
+    signed_headers.add("x-amz-date")
+    if credentials.session_token:
+        signed_headers.add("x-amz-security-token")
+    for name, _value in clean_headers:
+        lower_name = name.lower()
+        if lower_name.startswith("x-amz-"):
+            signed_headers.add(lower_name)
+
+    canonical_request, signed_header_names = _canonical_request(
+        method=method,
+        url=url,
+        headers=clean_headers,
+        signed_headers=frozenset(signed_headers),
+        payload_hash=payload_hash,
+        is_s3=is_s3,
+    )
+    signature = _signature(
+        canonical_request=canonical_request,
+        credentials=credentials,
+        scope=context.scope,
+        amz_date=context.amz_date,
+    )
+    authorization = (
+        f"{_HMAC_ALGORITHM} "
+        f"Credential={credentials.access_key_id}/{_scope_string(context.scope)}, "
+        f"SignedHeaders={signed_header_names}, "
+        f"Signature={signature}"
+    )
+    return url, _upsert_header(clean_headers, "authorization", authorization)
+
+
+def _sign_query_request(
+    *,
+    method: str,
+    url: str,
+    headers: list[tuple[str, str]],
+    body: bytes | None,
+    credentials: AwsSigV4Credentials,
+    context: _SigningContext,
+    is_s3: bool,
+) -> tuple[str, list[tuple[str, str]]]:
+    clean_headers = _without_headers(headers, {"authorization"})
+    clean_headers = _upsert_header(clean_headers, "host", _host_header_value(url))
+    signed_headers = frozenset(set(context.signed_headers) | {"host"})
+    payload_hash = _query_payload_hash(headers, body, is_s3)
+    unsigned_url = _replace_query_signing_params(
+        url,
+        credentials=credentials,
+        context=context,
+        signed_headers=signed_headers,
+        signature=None,
+    )
+    canonical_request, signed_header_names = _canonical_request(
+        method=method,
+        url=unsigned_url,
+        headers=clean_headers,
+        signed_headers=signed_headers,
+        payload_hash=payload_hash,
+        is_s3=is_s3,
+    )
+    signature = _signature(
+        canonical_request=canonical_request,
+        credentials=credentials,
+        scope=context.scope,
+        amz_date=context.amz_date,
+    )
+    signed_url = _replace_query_signing_params(
+        url,
+        credentials=credentials,
+        context=context,
+        signed_headers=frozenset(signed_header_names.split(";")),
+        signature=signature,
+    )
+    return signed_url, clean_headers
+
+
+def _canonical_request(
+    *,
+    method: str,
+    url: str,
+    headers: list[tuple[str, str]],
+    signed_headers: frozenset[str],
+    payload_hash: str,
+    is_s3: bool,
+) -> tuple[str, str]:
+    parts = urllib.parse.urlsplit(url)
+    canonical_uri = _canonical_uri(parts.path, is_s3=is_s3)
+    canonical_query = _canonical_query_string(parts.query)
+    canonical_headers, signed_header_names = _canonical_headers(headers, signed_headers)
+    request = "\n".join(
+        [
+            method.upper(),
+            canonical_uri,
+            canonical_query,
+            canonical_headers,
+            signed_header_names,
+            payload_hash,
+        ]
+    )
+    return request, signed_header_names
+
+
+def _canonical_uri(path: str, *, is_s3: bool) -> str:
+    raw_path = path or "/"
+    if is_s3:
+        return raw_path
+    decoded = urllib.parse.unquote(raw_path)
+    normalized = posixpath.normpath(decoded)
+    if decoded.endswith("/") and not normalized.endswith("/"):
+        normalized += "/"
+    if not normalized.startswith("/"):
+        normalized = f"/{normalized}"
+    return urllib.parse.quote(normalized, safe="/~")
+
+
+def _canonical_query_string(query: str) -> str:
+    pairs = urllib.parse.parse_qsl(query, keep_blank_values=True)
+    encoded = [(_aws_quote(key), _aws_quote(value)) for key, value in pairs]
+    encoded.sort()
+    return "&".join(f"{key}={value}" for key, value in encoded)
+
+
+def _canonical_headers(
+    headers: list[tuple[str, str]],
+    signed_headers: frozenset[str],
+) -> tuple[str, str]:
+    values: dict[str, list[str]] = {}
+    for name, value in headers:
+        lower_name = name.lower()
+        if lower_name in signed_headers:
+            values.setdefault(lower_name, []).append(_normalize_header_value(value))
+
+    missing = signed_headers.difference(values)
+    if missing:
+        raise AwsSigV4SigningError("AWS signed header is missing")
+
+    signed_header_names = ";".join(sorted(signed_headers))
+    canonical = "".join(f"{name}:{','.join(values[name])}\n" for name in sorted(signed_headers))
+    return canonical, signed_header_names
+
+
+def _normalize_header_value(value: str) -> str:
+    return " ".join(value.strip().split())
+
+
+def _payload_hash(headers: list[tuple[str, str]], body: bytes | None) -> str:
+    header_value = _first_header(headers, "x-amz-content-sha256")
+    if header_value:
+        if header_value.startswith(_STREAMING_PAYLOAD_PREFIX):
+            raise AwsSigV4SigningError("AWS streaming payload signing is not supported")
+        return header_value
+    return hashlib.sha256(body or b"").hexdigest()
+
+
+def _query_payload_hash(headers: list[tuple[str, str]], body: bytes | None, is_s3: bool) -> str:
+    header_value = _first_header(headers, "x-amz-content-sha256")
+    if header_value:
+        if header_value.startswith(_STREAMING_PAYLOAD_PREFIX):
+            raise AwsSigV4SigningError("AWS streaming payload signing is not supported")
+        return header_value
+    if is_s3:
+        return "UNSIGNED-PAYLOAD"
+    return hashlib.sha256(body or b"").hexdigest()
+
+
+def _signature(
+    *,
+    canonical_request: str,
+    credentials: AwsSigV4Credentials,
+    scope: _CredentialScope,
+    amz_date: str,
+) -> str:
+    string_to_sign = "\n".join(
+        [
+            _HMAC_ALGORITHM,
+            amz_date,
+            _scope_string(scope),
+            hashlib.sha256(canonical_request.encode()).hexdigest(),
+        ]
+    )
+    signing_key = _signing_key(credentials.secret_access_key, scope)
+    return hmac.new(signing_key, string_to_sign.encode(), hashlib.sha256).hexdigest()
+
+
+def _signing_key(secret_access_key: str, scope: _CredentialScope) -> bytes:
+    date_key = _hmac_digest(f"AWS4{secret_access_key}".encode(), scope.date)
+    region_key = _hmac_digest(date_key, scope.region)
+    service_key = _hmac_digest(region_key, scope.service)
+    return _hmac_digest(service_key, _AWS4_REQUEST)
+
+
+def _hmac_digest(key: bytes, value: str) -> bytes:
+    return hmac.new(key, value.encode(), hashlib.sha256).digest()
+
+
+def _scope_string(scope: _CredentialScope) -> str:
+    return f"{scope.date}/{scope.region}/{scope.service}/{_AWS4_REQUEST}"
+
+
+def _replace_query_signing_params(
+    url: str,
+    *,
+    credentials: AwsSigV4Credentials,
+    context: _SigningContext,
+    signed_headers: frozenset[str],
+    signature: str | None,
+) -> str:
+    parts = urllib.parse.urlsplit(url)
+    filtered = [
+        (key, value)
+        for key, value in urllib.parse.parse_qsl(parts.query, keep_blank_values=True)
+        if key
+        not in {
+            "X-Amz-Algorithm",
+            "X-Amz-Credential",
+            "X-Amz-Date",
+            "X-Amz-Expires",
+            "X-Amz-SignedHeaders",
+            "X-Amz-Security-Token",
+            "X-Amz-Signature",
+        }
+    ]
+    filtered.extend(
+        [
+            ("X-Amz-Algorithm", _HMAC_ALGORITHM),
+            (
+                "X-Amz-Credential",
+                f"{credentials.access_key_id}/{_scope_string(context.scope)}",
+            ),
+            ("X-Amz-Date", context.amz_date),
+            ("X-Amz-Expires", context.expires or "3600"),
+            ("X-Amz-SignedHeaders", ";".join(sorted(signed_headers))),
+        ]
+    )
+    if credentials.session_token:
+        filtered.append(("X-Amz-Security-Token", credentials.session_token))
+    if signature:
+        filtered.append(("X-Amz-Signature", signature))
+    query = _encode_query_pairs(filtered)
+    return urllib.parse.urlunsplit((parts.scheme, parts.netloc, parts.path, query, parts.fragment))
+
+
+def _encode_query_pairs(pairs: list[tuple[str, str]]) -> str:
+    return "&".join(f"{_aws_quote(key)}={_aws_quote(value)}" for key, value in pairs)
+
+
+def _aws_quote(value: str) -> str:
+    return urllib.parse.quote(value, safe="-_.~")
+
+
+def _first_header(headers: list[tuple[str, str]], name: str) -> str | None:
+    lower_name = name.lower()
+    for header_name, value in headers:
+        if header_name.lower() == lower_name:
+            return value
+    return None
+
+
+def _first_query_value(pairs: list[tuple[str, str]], name: str) -> str | None:
+    for key, value in pairs:
+        if key == name:
+            return value
+    return None
+
+
+def _without_headers(
+    headers: list[tuple[str, str]],
+    names: set[str],
+) -> list[tuple[str, str]]:
+    return [(name, value) for name, value in headers if name.lower() not in names]
+
+
+def _upsert_header(
+    headers: list[tuple[str, str]],
+    name: str,
+    value: str,
+) -> list[tuple[str, str]]:
+    lower_name = name.lower()
+    filtered = [
+        (header_name, item) for header_name, item in headers if header_name.lower() != lower_name
+    ]
+    filtered.append((name, value))
+    return filtered
+
+
+def _host_header_value(url: str) -> str:
+    parts = urllib.parse.urlsplit(url)
+    if not parts.netloc:
+        raise AwsSigV4SigningError("AWS request URL must include a host")
+    return parts.netloc.rsplit("@", maxsplit=1)[-1]

--- a/crates/runner/mitm-addon/src/aws_sigv4.py
+++ b/crates/runner/mitm-addon/src/aws_sigv4.py
@@ -34,8 +34,6 @@ class AwsSigV4Credentials:
     access_key_id: str
     secret_access_key: str
     session_token: str | None = None
-    default_region: str | None = None
-    default_service: str | None = None
 
 
 @dataclass(frozen=True)
@@ -64,7 +62,7 @@ def sign_request(
     credentials: AwsSigV4Credentials,
 ) -> tuple[str, list[tuple[str, str]]]:
     """Return a URL/header pair re-signed with real AWS credentials."""
-    context = _classify_request(url, headers, credentials)
+    context = _classify_request(url, headers)
     if context.algorithm == _ASYMMETRIC_ALGORITHM:
         raise AwsSigV4SigningError("SigV4A is not supported by this runner")
     if context.algorithm != _HMAC_ALGORITHM:
@@ -97,7 +95,6 @@ def sign_request(
 def _classify_request(
     url: str,
     headers: list[tuple[str, str]],
-    credentials: AwsSigV4Credentials,
 ) -> _SigningContext:
     auth_header = _first_header(headers, "authorization")
     query_pairs = urllib.parse.parse_qsl(
@@ -108,16 +105,15 @@ def _classify_request(
     if auth_header and query_algorithm:
         raise AwsSigV4SigningError("Ambiguous AWS auth location")
     if query_algorithm:
-        return _classify_query_request(query_pairs, query_algorithm, credentials)
+        return _classify_query_request(query_pairs, query_algorithm)
     if auth_header:
-        return _classify_header_request(auth_header, headers, credentials)
+        return _classify_header_request(auth_header, headers)
     raise AwsSigV4SigningError("Missing AWS SigV4 auth metadata")
 
 
 def _classify_header_request(
     auth_header: str,
     headers: list[tuple[str, str]],
-    credentials: AwsSigV4Credentials,
 ) -> _SigningContext:
     algorithm, params = _parse_authorization_header(auth_header)
     credential = params.get("Credential")
@@ -125,7 +121,7 @@ def _classify_header_request(
     signature = params.get("Signature")
     if not credential or not signed_headers or not signature:
         raise AwsSigV4SigningError("Malformed AWS authorization header")
-    scope = _parse_credential_scope(credential, credentials)
+    scope = _parse_credential_scope(credential)
     amz_date = _first_header(headers, "x-amz-date")
     if not amz_date:
         raise AwsSigV4SigningError("AWS SigV4 header auth requires x-amz-date")
@@ -141,7 +137,6 @@ def _classify_header_request(
 def _classify_query_request(
     query_pairs: list[tuple[str, str]],
     algorithm: str,
-    credentials: AwsSigV4Credentials,
 ) -> _SigningContext:
     credential = _first_query_value(query_pairs, "X-Amz-Credential")
     signed_headers = _first_query_value(query_pairs, "X-Amz-SignedHeaders")
@@ -150,7 +145,7 @@ def _classify_query_request(
     signature = _first_query_value(query_pairs, "X-Amz-Signature")
     if not credential or not signed_headers or not amz_date or not expires or not signature:
         raise AwsSigV4SigningError("Malformed AWS presigned query")
-    scope = _parse_credential_scope(credential, credentials)
+    scope = _parse_credential_scope(credential)
     return _SigningContext(
         location=_AuthLocation.QUERY,
         algorithm=algorithm,
@@ -171,16 +166,13 @@ def _parse_authorization_header(value: str) -> tuple[str, dict[str, str]]:
     return algorithm, params
 
 
-def _parse_credential_scope(
-    credential: str,
-    credentials: AwsSigV4Credentials,
-) -> _CredentialScope:
+def _parse_credential_scope(credential: str) -> _CredentialScope:
     parts = urllib.parse.unquote(credential).split("/")
     if len(parts) != _CREDENTIAL_SCOPE_PARTS or parts[-1] != _AWS4_REQUEST:
         raise AwsSigV4SigningError("Malformed AWS credential scope")
     date = parts[1]
-    region = parts[2] or credentials.default_region
-    service = parts[3] or credentials.default_service
+    region = parts[2]
+    service = parts[3]
     if not date or not region or not service:
         raise AwsSigV4SigningError("Incomplete AWS credential scope")
     return _CredentialScope(date=date, region=region, service=service)

--- a/crates/runner/mitm-addon/src/matching.py
+++ b/crates/runner/mitm-addon/src/matching.py
@@ -785,12 +785,33 @@ def _auth_config_is_valid(api_entry: dict) -> bool:
 
     if "headers" in raw_auth and not _is_string_record(raw_auth["headers"]):
         return False
+    if "query" in raw_auth and not _is_string_record(raw_auth["query"]):
+        return False
+    if "awsSigv4" in raw_auth:
+        raw_aws_sigv4 = raw_auth["awsSigv4"]
+        if not isinstance(raw_aws_sigv4, dict):
+            return False
+        if not isinstance(raw_aws_sigv4.get("accessKeyId"), str):
+            return False
+        if not raw_aws_sigv4["accessKeyId"]:
+            return False
+        if not isinstance(raw_aws_sigv4.get("secretAccessKey"), str):
+            return False
+        if not raw_aws_sigv4["secretAccessKey"]:
+            return False
+        for optional_key in ("sessionToken", "defaultRegion", "defaultService"):
+            optional_value = raw_aws_sigv4.get(optional_key)
+            if optional_value is not None and not isinstance(optional_value, str):
+                return False
+            if optional_value == "":
+                return False
+        if raw_auth.get("headers"):
+            return False
+        if raw_auth.get("query"):
+            return False
     if "base" in raw_auth and not isinstance(raw_auth["base"], str):
         return False
-    if "base" in raw_auth and not _static_auth_base_is_valid(raw_auth["base"]):
-        return False
-
-    return "query" not in raw_auth or _is_string_record(raw_auth["query"])
+    return "base" not in raw_auth or _static_auth_base_is_valid(raw_auth["base"])
 
 
 def _path_specificity(

--- a/crates/runner/mitm-addon/src/matching.py
+++ b/crates/runner/mitm-addon/src/matching.py
@@ -791,6 +791,8 @@ def _auth_config_is_valid(api_entry: dict) -> bool:
         raw_aws_sigv4 = raw_auth["awsSigv4"]
         if not isinstance(raw_aws_sigv4, dict):
             return False
+        if set(raw_aws_sigv4) - {"accessKeyId", "secretAccessKey", "sessionToken"}:
+            return False
         if not isinstance(raw_aws_sigv4.get("accessKeyId"), str):
             return False
         if not raw_aws_sigv4["accessKeyId"]:
@@ -799,12 +801,11 @@ def _auth_config_is_valid(api_entry: dict) -> bool:
             return False
         if not raw_aws_sigv4["secretAccessKey"]:
             return False
-        for optional_key in ("sessionToken", "defaultRegion", "defaultService"):
-            optional_value = raw_aws_sigv4.get(optional_key)
-            if optional_value is not None and not isinstance(optional_value, str):
-                return False
-            if optional_value == "":
-                return False
+        optional_value = raw_aws_sigv4.get("sessionToken")
+        if optional_value is not None and not isinstance(optional_value, str):
+            return False
+        if optional_value == "":
+            return False
         if raw_auth.get("headers"):
             return False
         if raw_auth.get("query"):

--- a/crates/runner/mitm-addon/tests/auth_state_helpers.py
+++ b/crates/runner/mitm-addon/tests/auth_state_helpers.py
@@ -1,6 +1,7 @@
 """Helpers for setting up auth state in mitm-addon tests."""
 
 import auth
+from aws_sigv4 import AwsSigV4Credentials
 
 
 def clear_auth_state() -> None:
@@ -19,6 +20,7 @@ def set_cached_headers(
     resolved_secrets: list | None = None,
     base: str | None = None,
     query: dict | None = None,
+    aws_sigv4: AwsSigV4Credentials | None = None,
 ) -> None:
     auth._get_auth_state(cache_key).cache = auth._FirewallHeaderCacheEntry(
         payload=auth._FirewallAuthPayload(
@@ -26,6 +28,7 @@ def set_cached_headers(
             resolved_secrets=resolved_secrets or [],
             base=base,
             query=query,
+            aws_sigv4=aws_sigv4,
         ),
         expires_at=expires_at,
     )

--- a/crates/runner/mitm-addon/tests/test_firewall_auth.py
+++ b/crates/runner/mitm-addon/tests/test_firewall_auth.py
@@ -12,6 +12,7 @@ import pytest
 
 import auth
 import matching
+from aws_sigv4 import AwsSigV4Credentials
 from tests.auth_endpoint_helpers import FakeAuthEndpoint
 from tests.auth_state_helpers import (
     cached_headers,
@@ -47,6 +48,7 @@ def _auth_success(
     refreshed_secrets: list[str] | None = None,
     base: str | None = None,
     query: dict[str, str] | None = None,
+    aws_sigv4: AwsSigV4Credentials | None = None,
 ) -> auth._FirewallAuthSuccess:
     return auth._FirewallAuthSuccess(
         payload=auth._FirewallAuthPayload(
@@ -54,6 +56,7 @@ def _auth_success(
             resolved_secrets=resolved_secrets or [],
             base=base,
             query=query,
+            aws_sigv4=aws_sigv4,
         ),
         expires_at=expires_at,
         refreshed_connectors=refreshed_connectors or [],
@@ -202,6 +205,7 @@ class TestGetFirewallHeaders:
             "vars_map": None,
             "auth_base": None,
             "auth_query": None,
+            "auth_aws_sigv4": None,
             "firewall_billable": False,
             "force_refresh": False,
         }
@@ -1309,6 +1313,13 @@ class TestFetchFirewallHeaders:
                 },
                 "base": "https://example.com/webhook/secret",
                 "query": {"api_key": "resolved-key"},
+                "awsSigv4": {
+                    "accessKeyId": "access-key-id",
+                    "secretAccessKey": "secret-access-key",
+                    "sessionToken": "session-token",
+                    "defaultRegion": "us-east-1",
+                    "defaultService": "sts",
+                },
                 "expiresAt": expires_at,
                 "resolvedSecrets": ["API_TOKEN"],
                 "refreshedConnectors": ["notion"],
@@ -1330,6 +1341,13 @@ class TestFetchFirewallHeaders:
         }
         assert result.payload.base == "https://example.com/webhook/secret"
         assert result.payload.query == {"api_key": "resolved-key"}
+        assert result.payload.aws_sigv4 == AwsSigV4Credentials(
+            "access-key-id",
+            "secret-access-key",
+            "session-token",
+            "us-east-1",
+            "sts",
+        )
         assert result.expires_at == expires_at
         assert result.payload.resolved_secrets == ["API_TOKEN"]
         assert result.refreshed_connectors == ["notion"]
@@ -1354,6 +1372,13 @@ class TestFetchFirewallHeaders:
                 vars_map={"TEAM": "vm0"},
                 auth_base="${{ secrets.WEBHOOK_URL }}",
                 auth_query={"api_key": "${{ secrets.API_KEY }}"},
+                auth_aws_sigv4={
+                    "accessKeyId": "${{ secrets.AWS_ACCESS_KEY_ID }}",
+                    "secretAccessKey": "${{ secrets.AWS_SECRET_ACCESS_KEY }}",
+                    "sessionToken": "${{ secrets.AWS_SESSION_TOKEN }}",
+                    "defaultRegion": "${{ vars.AWS_REGION }}",
+                    "defaultService": "sts",
+                },
                 firewall_billable=True,
                 force_refresh=True,
             )
@@ -1366,6 +1391,13 @@ class TestFetchFirewallHeaders:
         assert body["vars"] == {"TEAM": "vm0"}
         assert body["authBase"] == "${{ secrets.WEBHOOK_URL }}"
         assert body["authQuery"] == {"api_key": "${{ secrets.API_KEY }}"}
+        assert body["authAwsSigv4"] == {
+            "accessKeyId": "${{ secrets.AWS_ACCESS_KEY_ID }}",
+            "secretAccessKey": "${{ secrets.AWS_SECRET_ACCESS_KEY }}",
+            "sessionToken": "${{ secrets.AWS_SESSION_TOKEN }}",
+            "defaultRegion": "${{ vars.AWS_REGION }}",
+            "defaultService": "sts",
+        }
         assert body["firewallBillable"] is True
         assert body["forceRefresh"] is True
         assert "firewallName" not in body

--- a/crates/runner/mitm-addon/tests/test_firewall_auth.py
+++ b/crates/runner/mitm-addon/tests/test_firewall_auth.py
@@ -1317,8 +1317,6 @@ class TestFetchFirewallHeaders:
                     "accessKeyId": "access-key-id",
                     "secretAccessKey": "secret-access-key",
                     "sessionToken": "session-token",
-                    "defaultRegion": "us-east-1",
-                    "defaultService": "sts",
                 },
                 "expiresAt": expires_at,
                 "resolvedSecrets": ["API_TOKEN"],
@@ -1345,8 +1343,6 @@ class TestFetchFirewallHeaders:
             "access-key-id",
             "secret-access-key",
             "session-token",
-            "us-east-1",
-            "sts",
         )
         assert result.expires_at == expires_at
         assert result.payload.resolved_secrets == ["API_TOKEN"]
@@ -1376,8 +1372,6 @@ class TestFetchFirewallHeaders:
                     "accessKeyId": "${{ secrets.AWS_ACCESS_KEY_ID }}",
                     "secretAccessKey": "${{ secrets.AWS_SECRET_ACCESS_KEY }}",
                     "sessionToken": "${{ secrets.AWS_SESSION_TOKEN }}",
-                    "defaultRegion": "${{ vars.AWS_REGION }}",
-                    "defaultService": "sts",
                 },
                 firewall_billable=True,
                 force_refresh=True,
@@ -1395,8 +1389,6 @@ class TestFetchFirewallHeaders:
             "accessKeyId": "${{ secrets.AWS_ACCESS_KEY_ID }}",
             "secretAccessKey": "${{ secrets.AWS_SECRET_ACCESS_KEY }}",
             "sessionToken": "${{ secrets.AWS_SESSION_TOKEN }}",
-            "defaultRegion": "${{ vars.AWS_REGION }}",
-            "defaultService": "sts",
         }
         assert body["firewallBillable"] is True
         assert body["forceRefresh"] is True

--- a/crates/runner/mitm-addon/tests/test_firewall_aws_sigv4_auth.py
+++ b/crates/runner/mitm-addon/tests/test_firewall_aws_sigv4_auth.py
@@ -212,6 +212,44 @@ async def test_re_signs_query_sigv4_request(real_flow, tmp_path, mitm_ctx):
     assert "PLACEHOLDER" not in flow.request.url
 
 
+async def test_re_signs_query_sigv4_request_strips_session_token_header(
+    real_flow,
+    headers,
+    tmp_path,
+    mitm_ctx,
+):
+    endpoint = FakeAuthEndpoint()
+    endpoint.queue_json_response(_auth_response())
+    placeholder_credential = urllib.parse.quote(
+        "PLACEHOLDER/20260101/us-east-1/sts/aws4_request",
+        safe="",
+    )
+    flow = real_flow(
+        with_response=False,
+        host="sts.amazonaws.com",
+        path=(
+            "/?Action=GetCallerIdentity&Version=2011-06-15"
+            "&X-Amz-Algorithm=AWS4-HMAC-SHA256"
+            f"&X-Amz-Credential={placeholder_credential}"
+            "&X-Amz-Date=20260101T000000Z"
+            "&X-Amz-Expires=60"
+            "&X-Amz-SignedHeaders=host"
+            "&X-Amz-Signature=placeholder"
+        ),
+        method="GET",
+        request_headers=headers(("X-Amz-Security-Token", "placeholder-session-token")),
+    )
+    flow.metadata["vm_run_id"] = "run-1"
+
+    with endpoint.run(), mitm_ctx(api_url=endpoint.api_url):
+        result = await auth.handle_firewall_request(flow, _allow(_api_entry()), _vm_info(tmp_path))
+
+    assert result is auth.FirewallAuthHandlingResult.CONTINUE_UPSTREAM
+    assert "x-amz-security-token" not in flow.request.headers
+    query = dict(urllib.parse.parse_qsl(urllib.parse.urlsplit(flow.request.url).query))
+    assert query["X-Amz-Security-Token"] == "real-session-token"
+
+
 async def test_re_signs_query_sigv4_request_preserves_literal_plus(
     real_flow,
     tmp_path,

--- a/crates/runner/mitm-addon/tests/test_firewall_aws_sigv4_auth.py
+++ b/crates/runner/mitm-addon/tests/test_firewall_aws_sigv4_auth.py
@@ -429,6 +429,43 @@ async def test_header_sigv4_with_invalid_resolved_access_key_fails_closed(
     assert "Invalid AWS access key ID" in flow.response.json()["message"]
 
 
+async def test_header_sigv4_with_real_source_access_key_fails_closed(
+    real_flow,
+    headers,
+    tmp_path,
+    mitm_ctx,
+):
+    endpoint = FakeAuthEndpoint()
+    endpoint.queue_json_response(_auth_response())
+    flow = real_flow(
+        with_response=False,
+        host="sts.amazonaws.com",
+        path="/",
+        method="POST",
+        request_headers=headers(
+            ("Host", "sts.amazonaws.com"),
+            ("X-Amz-Date", "20260101T000000Z"),
+            (
+                "Authorization",
+                "AWS4-HMAC-SHA256 "
+                "Credential=AKIDEXAMPLE/20260101/us-east-1/sts/aws4_request, "
+                "SignedHeaders=host;x-amz-date, "
+                "Signature=placeholder",
+            ),
+        ),
+    )
+    flow.metadata["vm_run_id"] = "run-1"
+
+    with endpoint.run(), mitm_ctx(api_url=endpoint.api_url):
+        result = await auth.handle_firewall_request(flow, _allow(_api_entry()), _vm_info(tmp_path))
+
+    assert result is auth.FirewallAuthHandlingResult.LOCAL_RESPONSE
+    assert flow.response is not None
+    assert flow.response.status_code == 502
+    assert flow.response.json()["error"] == "aws_sigv4_auth_failed"
+    assert "placeholder access key ID" in flow.response.json()["message"]
+
+
 async def test_header_sigv4_without_signature_fails_closed(
     real_flow,
     headers,
@@ -605,6 +642,39 @@ async def test_query_sigv4_without_signature_fails_closed(real_flow, tmp_path, m
     assert flow.response.status_code == 502
     assert flow.response.json()["error"] == "aws_sigv4_auth_failed"
     assert "Malformed AWS presigned query" in flow.response.json()["message"]
+
+
+async def test_query_sigv4_with_real_source_access_key_fails_closed(real_flow, tmp_path, mitm_ctx):
+    endpoint = FakeAuthEndpoint()
+    endpoint.queue_json_response(_auth_response())
+    source_credential = urllib.parse.quote(
+        "AKIDEXAMPLE/20260101/us-east-1/sts/aws4_request",
+        safe="",
+    )
+    flow = real_flow(
+        with_response=False,
+        host="sts.amazonaws.com",
+        path=(
+            "/?Action=GetCallerIdentity&Version=2011-06-15"
+            "&X-Amz-Algorithm=AWS4-HMAC-SHA256"
+            f"&X-Amz-Credential={source_credential}"
+            "&X-Amz-Date=20260101T000000Z"
+            "&X-Amz-Expires=60"
+            "&X-Amz-SignedHeaders=host"
+            "&X-Amz-Signature=placeholder"
+        ),
+        method="GET",
+    )
+    flow.metadata["vm_run_id"] = "run-1"
+
+    with endpoint.run(), mitm_ctx(api_url=endpoint.api_url):
+        result = await auth.handle_firewall_request(flow, _allow(_api_entry()), _vm_info(tmp_path))
+
+    assert result is auth.FirewallAuthHandlingResult.LOCAL_RESPONSE
+    assert flow.response is not None
+    assert flow.response.status_code == 502
+    assert flow.response.json()["error"] == "aws_sigv4_auth_failed"
+    assert "placeholder access key ID" in flow.response.json()["message"]
 
 
 async def test_query_sigv4_with_malformed_expiry_fails_closed(real_flow, tmp_path, mitm_ctx):

--- a/crates/runner/mitm-addon/tests/test_firewall_aws_sigv4_auth.py
+++ b/crates/runner/mitm-addon/tests/test_firewall_aws_sigv4_auth.py
@@ -254,6 +254,75 @@ async def test_re_signs_header_sigv4_request_with_encoded_path(
     )
 
 
+async def test_re_signs_header_sigv4_request_with_normalized_host(
+    real_flow,
+    headers,
+    tmp_path,
+    mitm_ctx,
+):
+    endpoint = FakeAuthEndpoint()
+    endpoint.queue_json_response(
+        {
+            "headers": {},
+            "awsSigv4": {
+                "accessKeyId": "AKIDEXAMPLE",
+                "secretAccessKey": "wJalrXUtnFEMI/K7MDENG+bPxRfiCYEXAMPLEKEY",
+            },
+            "expiresAt": 1_800_000_000,
+            "resolvedSecrets": [
+                "AWS_ACCESS_KEY_ID",
+                "AWS_SECRET_ACCESS_KEY",
+            ],
+            "refreshedConnectors": [],
+            "refreshedSecrets": [],
+        }
+    )
+    api_entry = {
+        "base": "https://iam.amazonaws.com",
+        "auth": {
+            "headers": {},
+            "awsSigv4": {
+                "accessKeyId": "${{ secrets.AWS_ACCESS_KEY_ID }}",
+                "secretAccessKey": "${{ secrets.AWS_SECRET_ACCESS_KEY }}",
+            },
+        },
+    }
+    flow = real_flow(
+        with_response=False,
+        host="IAM.AMAZONAWS.COM",
+        path="/",
+        method="GET",
+        request_headers=headers(
+            ("Host", "IAM.AMAZONAWS.COM:443"),
+            ("X-Amz-Date", "20150830T123600Z"),
+            (
+                "Authorization",
+                "AWS4-HMAC-SHA256 "
+                "Credential=PLACEHOLDER/20150830/us-east-1/iam/aws4_request, "
+                "SignedHeaders=host;x-amz-date, "
+                "Signature=placeholder",
+            ),
+        ),
+    )
+    flow.metadata["vm_run_id"] = "run-1"
+
+    with endpoint.run(), mitm_ctx(api_url=endpoint.api_url):
+        result = await auth.handle_firewall_request(
+            flow,
+            matching.FirewallAllow(api_entry, "aws", "normalized-host", {}, "GET /", "/"),
+            _vm_info(tmp_path),
+        )
+
+    assert result is auth.FirewallAuthHandlingResult.CONTINUE_UPSTREAM
+    assert flow.request.headers["host"] == "iam.amazonaws.com"
+    assert flow.request.headers["authorization"] == (
+        "AWS4-HMAC-SHA256 "
+        "Credential=AKIDEXAMPLE/20150830/us-east-1/iam/aws4_request, "
+        "SignedHeaders=host;x-amz-date, "
+        "Signature=91fb24346d00546d6da247c85eb79148080a6e3ae1ac9aa8eae9ccdabfd70b33"
+    )
+
+
 async def test_re_signs_query_sigv4_request(real_flow, tmp_path, mitm_ctx):
     endpoint = FakeAuthEndpoint()
     endpoint.queue_json_response(_auth_response())

--- a/crates/runner/mitm-addon/tests/test_firewall_aws_sigv4_auth.py
+++ b/crates/runner/mitm-addon/tests/test_firewall_aws_sigv4_auth.py
@@ -16,8 +16,6 @@ def _api_entry() -> dict:
                 "accessKeyId": "${{ secrets.AWS_ACCESS_KEY_ID }}",
                 "secretAccessKey": "${{ secrets.AWS_SECRET_ACCESS_KEY }}",
                 "sessionToken": "${{ secrets.AWS_SESSION_TOKEN }}",
-                "defaultRegion": "${{ vars.AWS_REGION }}",
-                "defaultService": "sts",
             },
         },
     }
@@ -52,8 +50,6 @@ def _auth_response() -> dict[str, object]:
             "accessKeyId": "AKIDEXAMPLE",
             "secretAccessKey": "wJalrXUtnFEMI/K7MDENG+bPxRfiCYEXAMPLEKEY",
             "sessionToken": "real-session-token",
-            "defaultRegion": "us-east-1",
-            "defaultService": "sts",
         },
         "expiresAt": 1_800_000_000,
         "resolvedSecrets": [
@@ -123,8 +119,6 @@ async def test_re_signs_header_sigv4_request_to_reference_signature(
             "awsSigv4": {
                 "accessKeyId": "AKIDEXAMPLE",
                 "secretAccessKey": "wJalrXUtnFEMI/K7MDENG+bPxRfiCYEXAMPLEKEY",
-                "defaultRegion": "us-east-1",
-                "defaultService": "iam",
             },
             "expiresAt": 1_800_000_000,
             "resolvedSecrets": [
@@ -142,8 +136,6 @@ async def test_re_signs_header_sigv4_request_to_reference_signature(
             "awsSigv4": {
                 "accessKeyId": "${{ secrets.AWS_ACCESS_KEY_ID }}",
                 "secretAccessKey": "${{ secrets.AWS_SECRET_ACCESS_KEY }}",
-                "defaultRegion": "${{ vars.AWS_REGION }}",
-                "defaultService": "iam",
             },
         },
     }

--- a/crates/runner/mitm-addon/tests/test_firewall_aws_sigv4_auth.py
+++ b/crates/runner/mitm-addon/tests/test_firewall_aws_sigv4_auth.py
@@ -4,7 +4,9 @@ import urllib.parse
 
 import auth
 import matching
+from aws_sigv4 import AwsSigV4Credentials
 from tests.auth_endpoint_helpers import FakeAuthEndpoint
+from tests.auth_state_helpers import set_cached_headers
 
 
 def _api_entry() -> dict:
@@ -427,6 +429,90 @@ async def test_header_sigv4_with_invalid_resolved_access_key_fails_closed(
     assert flow.response.status_code == 502
     assert flow.response.json()["error"] == "aws_sigv4_auth_failed"
     assert "Invalid AWS access key ID" in flow.response.json()["message"]
+
+
+async def test_header_sigv4_with_empty_resolved_secret_key_fails_closed(
+    real_flow,
+    headers,
+    tmp_path,
+    mitm_ctx,
+):
+    flow = real_flow(
+        with_response=False,
+        host="sts.amazonaws.com",
+        path="/",
+        method="POST",
+        request_headers=headers(
+            ("Host", "sts.amazonaws.com"),
+            ("X-Amz-Date", "20260101T000000Z"),
+            (
+                "Authorization",
+                "AWS4-HMAC-SHA256 "
+                "Credential=PLACEHOLDER/20260101/us-east-1/sts/aws4_request, "
+                "SignedHeaders=host;x-amz-date, "
+                "Signature=placeholder",
+            ),
+        ),
+    )
+    flow.metadata["vm_run_id"] = "run-1"
+    set_cached_headers(
+        ("run-1", "https://sts.amazonaws.com"),
+        headers={},
+        aws_sigv4=AwsSigV4Credentials("AKIDEXAMPLE", ""),
+    )
+
+    with mitm_ctx():
+        result = await auth.handle_firewall_request(flow, _allow(_api_entry()), _vm_info(tmp_path))
+
+    assert result is auth.FirewallAuthHandlingResult.LOCAL_RESPONSE
+    assert flow.response is not None
+    assert flow.response.status_code == 502
+    assert flow.response.json()["error"] == "aws_sigv4_auth_failed"
+    assert "Invalid AWS secret access key" in flow.response.json()["message"]
+
+
+async def test_header_sigv4_with_empty_resolved_session_token_fails_closed(
+    real_flow,
+    headers,
+    tmp_path,
+    mitm_ctx,
+):
+    flow = real_flow(
+        with_response=False,
+        host="sts.amazonaws.com",
+        path="/",
+        method="POST",
+        request_headers=headers(
+            ("Host", "sts.amazonaws.com"),
+            ("X-Amz-Date", "20260101T000000Z"),
+            (
+                "Authorization",
+                "AWS4-HMAC-SHA256 "
+                "Credential=PLACEHOLDER/20260101/us-east-1/sts/aws4_request, "
+                "SignedHeaders=host;x-amz-date, "
+                "Signature=placeholder",
+            ),
+        ),
+    )
+    flow.metadata["vm_run_id"] = "run-1"
+    set_cached_headers(
+        ("run-1", "https://sts.amazonaws.com"),
+        headers={},
+        aws_sigv4=AwsSigV4Credentials(
+            "AKIDEXAMPLE",
+            "wJalrXUtnFEMI/K7MDENG+bPxRfiCYEXAMPLEKEY",
+            "",
+        ),
+    )
+
+    with mitm_ctx():
+        result = await auth.handle_firewall_request(flow, _allow(_api_entry()), _vm_info(tmp_path))
+
+    assert result is auth.FirewallAuthHandlingResult.LOCAL_RESPONSE
+    assert flow.response is not None
+    assert flow.response.status_code == 502
+    assert flow.response.json()["error"] == "aws_sigv4_auth_failed"
+    assert "Invalid AWS session token" in flow.response.json()["message"]
 
 
 async def test_header_sigv4_with_real_source_access_key_fails_closed(

--- a/crates/runner/mitm-addon/tests/test_firewall_aws_sigv4_auth.py
+++ b/crates/runner/mitm-addon/tests/test_firewall_aws_sigv4_auth.py
@@ -466,6 +466,82 @@ async def test_header_sigv4_with_real_source_access_key_fails_closed(
     assert "placeholder access key ID" in flow.response.json()["message"]
 
 
+async def test_header_sigv4_with_duplicate_credential_fails_closed(
+    real_flow,
+    headers,
+    tmp_path,
+    mitm_ctx,
+):
+    endpoint = FakeAuthEndpoint()
+    endpoint.queue_json_response(_auth_response())
+    flow = real_flow(
+        with_response=False,
+        host="sts.amazonaws.com",
+        path="/",
+        method="POST",
+        request_headers=headers(
+            ("Host", "sts.amazonaws.com"),
+            ("X-Amz-Date", "20260101T000000Z"),
+            (
+                "Authorization",
+                "AWS4-HMAC-SHA256 "
+                "Credential=AKIDEXAMPLE/20260101/us-east-1/sts/aws4_request, "
+                "Credential=PLACEHOLDER/20260101/us-east-1/sts/aws4_request, "
+                "SignedHeaders=host;x-amz-date, "
+                "Signature=placeholder",
+            ),
+        ),
+    )
+    flow.metadata["vm_run_id"] = "run-1"
+
+    with endpoint.run(), mitm_ctx(api_url=endpoint.api_url):
+        result = await auth.handle_firewall_request(flow, _allow(_api_entry()), _vm_info(tmp_path))
+
+    assert result is auth.FirewallAuthHandlingResult.LOCAL_RESPONSE
+    assert flow.response is not None
+    assert flow.response.status_code == 502
+    assert flow.response.json()["error"] == "aws_sigv4_auth_failed"
+    assert "Malformed AWS authorization header" in flow.response.json()["message"]
+
+
+async def test_header_sigv4_with_duplicate_authorization_headers_fails_closed(
+    real_flow,
+    headers,
+    tmp_path,
+    mitm_ctx,
+):
+    endpoint = FakeAuthEndpoint()
+    endpoint.queue_json_response(_auth_response())
+    authorization = (
+        "AWS4-HMAC-SHA256 "
+        "Credential=PLACEHOLDER/20260101/us-east-1/sts/aws4_request, "
+        "SignedHeaders=host;x-amz-date, "
+        "Signature=placeholder"
+    )
+    flow = real_flow(
+        with_response=False,
+        host="sts.amazonaws.com",
+        path="/",
+        method="POST",
+        request_headers=headers(
+            ("Host", "sts.amazonaws.com"),
+            ("X-Amz-Date", "20260101T000000Z"),
+            ("Authorization", authorization),
+            ("Authorization", authorization),
+        ),
+    )
+    flow.metadata["vm_run_id"] = "run-1"
+
+    with endpoint.run(), mitm_ctx(api_url=endpoint.api_url):
+        result = await auth.handle_firewall_request(flow, _allow(_api_entry()), _vm_info(tmp_path))
+
+    assert result is auth.FirewallAuthHandlingResult.LOCAL_RESPONSE
+    assert flow.response is not None
+    assert flow.response.status_code == 502
+    assert flow.response.json()["error"] == "aws_sigv4_auth_failed"
+    assert "Malformed AWS authorization header" in flow.response.json()["message"]
+
+
 async def test_header_sigv4_without_signature_fails_closed(
     real_flow,
     headers,
@@ -612,6 +688,84 @@ async def test_header_sigv4_with_scope_date_mismatch_fails_closed(
     assert "AWS signing date does not match credential scope" in flow.response.json()["message"]
 
 
+async def test_header_sigv4_with_duplicate_amz_date_fails_closed(
+    real_flow,
+    headers,
+    tmp_path,
+    mitm_ctx,
+):
+    endpoint = FakeAuthEndpoint()
+    endpoint.queue_json_response(_auth_response())
+    flow = real_flow(
+        with_response=False,
+        host="sts.amazonaws.com",
+        path="/",
+        method="POST",
+        request_headers=headers(
+            ("Host", "sts.amazonaws.com"),
+            ("X-Amz-Date", "20260101T000000Z"),
+            ("X-Amz-Date", "20260101T000001Z"),
+            (
+                "Authorization",
+                "AWS4-HMAC-SHA256 "
+                "Credential=PLACEHOLDER/20260101/us-east-1/sts/aws4_request, "
+                "SignedHeaders=host;x-amz-date, "
+                "Signature=placeholder",
+            ),
+        ),
+    )
+    flow.metadata["vm_run_id"] = "run-1"
+
+    with endpoint.run(), mitm_ctx(api_url=endpoint.api_url):
+        result = await auth.handle_firewall_request(flow, _allow(_api_entry()), _vm_info(tmp_path))
+
+    assert result is auth.FirewallAuthHandlingResult.LOCAL_RESPONSE
+    assert flow.response is not None
+    assert flow.response.status_code == 502
+    assert flow.response.json()["error"] == "aws_sigv4_auth_failed"
+    assert "requires a single x-amz-date" in flow.response.json()["message"]
+
+
+async def test_header_sigv4_with_duplicate_content_hash_fails_closed(
+    real_flow,
+    headers,
+    tmp_path,
+    mitm_ctx,
+):
+    endpoint = FakeAuthEndpoint()
+    endpoint.queue_json_response(_auth_response())
+    flow = real_flow(
+        with_response=False,
+        host="sts.amazonaws.com",
+        path="/",
+        method="POST",
+        request_body=b"Action=GetCallerIdentity&Version=2011-06-15",
+        request_headers=headers(
+            ("Host", "sts.amazonaws.com"),
+            ("X-Amz-Date", "20260101T000000Z"),
+            ("X-Amz-Content-Sha256", "placeholder-hash-1"),
+            ("X-Amz-Content-Sha256", "placeholder-hash-2"),
+            (
+                "Authorization",
+                "AWS4-HMAC-SHA256 "
+                "Credential=PLACEHOLDER/20260101/us-east-1/sts/aws4_request, "
+                "SignedHeaders=host;x-amz-content-sha256;x-amz-date, "
+                "Signature=placeholder",
+            ),
+        ),
+    )
+    flow.metadata["vm_run_id"] = "run-1"
+
+    with endpoint.run(), mitm_ctx(api_url=endpoint.api_url):
+        result = await auth.handle_firewall_request(flow, _allow(_api_entry()), _vm_info(tmp_path))
+
+    assert result is auth.FirewallAuthHandlingResult.LOCAL_RESPONSE
+    assert flow.response is not None
+    assert flow.response.status_code == 502
+    assert flow.response.json()["error"] == "aws_sigv4_auth_failed"
+    assert "AWS content hash header is ambiguous" in flow.response.json()["message"]
+
+
 async def test_query_sigv4_without_signature_fails_closed(real_flow, tmp_path, mitm_ctx):
     endpoint = FakeAuthEndpoint()
     endpoint.queue_json_response(_auth_response())
@@ -675,6 +829,44 @@ async def test_query_sigv4_with_real_source_access_key_fails_closed(real_flow, t
     assert flow.response.status_code == 502
     assert flow.response.json()["error"] == "aws_sigv4_auth_failed"
     assert "placeholder access key ID" in flow.response.json()["message"]
+
+
+async def test_query_sigv4_with_duplicate_credential_fails_closed(real_flow, tmp_path, mitm_ctx):
+    endpoint = FakeAuthEndpoint()
+    endpoint.queue_json_response(_auth_response())
+    placeholder_credential = urllib.parse.quote(
+        "PLACEHOLDER/20260101/us-east-1/sts/aws4_request",
+        safe="",
+    )
+    real_credential = urllib.parse.quote(
+        "AKIDEXAMPLE/20260101/us-east-1/sts/aws4_request",
+        safe="",
+    )
+    flow = real_flow(
+        with_response=False,
+        host="sts.amazonaws.com",
+        path=(
+            "/?Action=GetCallerIdentity&Version=2011-06-15"
+            "&X-Amz-Algorithm=AWS4-HMAC-SHA256"
+            f"&X-Amz-Credential={placeholder_credential}"
+            f"&X-Amz-Credential={real_credential}"
+            "&X-Amz-Date=20260101T000000Z"
+            "&X-Amz-Expires=60"
+            "&X-Amz-SignedHeaders=host"
+            "&X-Amz-Signature=placeholder"
+        ),
+        method="GET",
+    )
+    flow.metadata["vm_run_id"] = "run-1"
+
+    with endpoint.run(), mitm_ctx(api_url=endpoint.api_url):
+        result = await auth.handle_firewall_request(flow, _allow(_api_entry()), _vm_info(tmp_path))
+
+    assert result is auth.FirewallAuthHandlingResult.LOCAL_RESPONSE
+    assert flow.response is not None
+    assert flow.response.status_code == 502
+    assert flow.response.json()["error"] == "aws_sigv4_auth_failed"
+    assert "Malformed AWS presigned query" in flow.response.json()["message"]
 
 
 async def test_query_sigv4_with_malformed_expiry_fails_closed(real_flow, tmp_path, mitm_ctx):

--- a/crates/runner/mitm-addon/tests/test_firewall_aws_sigv4_auth.py
+++ b/crates/runner/mitm-addon/tests/test_firewall_aws_sigv4_auth.py
@@ -110,6 +110,80 @@ async def test_re_signs_header_sigv4_request(real_flow, headers, tmp_path, mitm_
     assert body["authAwsSigv4"] == _api_entry()["auth"]["awsSigv4"]
 
 
+async def test_re_signs_header_sigv4_request_to_reference_signature(
+    real_flow,
+    headers,
+    tmp_path,
+    mitm_ctx,
+):
+    endpoint = FakeAuthEndpoint()
+    endpoint.queue_json_response(
+        {
+            "headers": {},
+            "awsSigv4": {
+                "accessKeyId": "AKIDEXAMPLE",
+                "secretAccessKey": "wJalrXUtnFEMI/K7MDENG+bPxRfiCYEXAMPLEKEY",
+                "defaultRegion": "us-east-1",
+                "defaultService": "iam",
+            },
+            "expiresAt": 1_800_000_000,
+            "resolvedSecrets": [
+                "AWS_ACCESS_KEY_ID",
+                "AWS_SECRET_ACCESS_KEY",
+            ],
+            "refreshedConnectors": [],
+            "refreshedSecrets": [],
+        }
+    )
+    api_entry = {
+        "base": "https://iam.amazonaws.com",
+        "auth": {
+            "headers": {},
+            "awsSigv4": {
+                "accessKeyId": "${{ secrets.AWS_ACCESS_KEY_ID }}",
+                "secretAccessKey": "${{ secrets.AWS_SECRET_ACCESS_KEY }}",
+                "defaultRegion": "${{ vars.AWS_REGION }}",
+                "defaultService": "iam",
+            },
+        },
+    }
+    flow = real_flow(
+        with_response=False,
+        host="iam.amazonaws.com",
+        path="/?Action=ListUsers&Version=2010-05-08",
+        method="GET",
+        request_headers=headers(
+            ("Host", "iam.amazonaws.com"),
+            ("Content-Type", "application/x-www-form-urlencoded; charset=utf-8"),
+            ("X-Amz-Date", "20150830T123600Z"),
+            (
+                "Authorization",
+                "AWS4-HMAC-SHA256 "
+                "Credential=PLACEHOLDER/20150830/us-east-1/iam/aws4_request, "
+                "SignedHeaders=content-type;host;x-amz-date, "
+                "Signature=placeholder",
+            ),
+        ),
+    )
+    flow.metadata["vm_run_id"] = "run-1"
+
+    with endpoint.run(), mitm_ctx(api_url=endpoint.api_url):
+        result = await auth.handle_firewall_request(
+            flow,
+            matching.FirewallAllow(api_entry, "aws", "list-users", {}, "GET /", "/"),
+            _vm_info(tmp_path),
+        )
+
+    assert result is auth.FirewallAuthHandlingResult.CONTINUE_UPSTREAM
+    assert flow.request.headers["authorization"] == (
+        "AWS4-HMAC-SHA256 "
+        "Credential=AKIDEXAMPLE/20150830/us-east-1/iam/aws4_request, "
+        "SignedHeaders=content-type;host;x-amz-date, "
+        "Signature=5d672d79c15b13162d9279b0855cfba6789a8edb4c82c400e06b5924a6f2b5d7"
+    )
+    assert "x-amz-security-token" not in flow.request.headers
+
+
 async def test_re_signs_query_sigv4_request(real_flow, tmp_path, mitm_ctx):
     endpoint = FakeAuthEndpoint()
     endpoint.queue_json_response(_auth_response())

--- a/crates/runner/mitm-addon/tests/test_firewall_aws_sigv4_auth.py
+++ b/crates/runner/mitm-addon/tests/test_firewall_aws_sigv4_auth.py
@@ -212,6 +212,44 @@ async def test_re_signs_query_sigv4_request(real_flow, tmp_path, mitm_ctx):
     assert "PLACEHOLDER" not in flow.request.url
 
 
+async def test_re_signs_query_sigv4_request_preserves_literal_plus(
+    real_flow,
+    tmp_path,
+    mitm_ctx,
+):
+    endpoint = FakeAuthEndpoint()
+    endpoint.queue_json_response(_auth_response())
+    placeholder_credential = urllib.parse.quote(
+        "PLACEHOLDER/20260101/us-east-1/sts/aws4_request",
+        safe="",
+    )
+    flow = real_flow(
+        with_response=False,
+        host="sts.amazonaws.com",
+        path=(
+            "/?Action=GetCallerIdentity&LiteralPlus=a+b&EncodedPlus=c%2Bd"
+            "&X-Amz-Algorithm=AWS4-HMAC-SHA256"
+            f"&X-Amz-Credential={placeholder_credential}"
+            "&X-Amz-Date=20260101T000000Z"
+            "&X-Amz-Expires=60"
+            "&X-Amz-SignedHeaders=host"
+            "&X-Amz-Signature=placeholder"
+        ),
+        method="GET",
+    )
+    flow.metadata["vm_run_id"] = "run-1"
+
+    with endpoint.run(), mitm_ctx(api_url=endpoint.api_url):
+        result = await auth.handle_firewall_request(flow, _allow(_api_entry()), _vm_info(tmp_path))
+
+    assert result is auth.FirewallAuthHandlingResult.CONTINUE_UPSTREAM
+    raw_query = urllib.parse.urlsplit(flow.request.url).query
+    assert "LiteralPlus=a%2Bb" in raw_query
+    query = dict(urllib.parse.parse_qsl(raw_query))
+    assert query["LiteralPlus"] == "a+b"
+    assert query["EncodedPlus"] == "c+d"
+
+
 async def test_sigv4a_request_fails_closed(real_flow, headers, tmp_path, mitm_ctx):
     endpoint = FakeAuthEndpoint()
     endpoint.queue_json_response(_auth_response())
@@ -241,6 +279,116 @@ async def test_sigv4a_request_fails_closed(real_flow, headers, tmp_path, mitm_ct
     assert flow.response.status_code == 502
     assert flow.response.json()["error"] == "aws_sigv4_auth_failed"
     assert "SigV4A is not supported" in flow.response.json()["message"]
+
+
+async def test_hmac_sigv4_wildcard_region_fails_closed(real_flow, headers, tmp_path, mitm_ctx):
+    endpoint = FakeAuthEndpoint()
+    endpoint.queue_json_response(_auth_response())
+    flow = real_flow(
+        with_response=False,
+        host="s3.amazonaws.com",
+        path="/bucket/key",
+        request_headers=headers(
+            ("Host", "s3.amazonaws.com"),
+            ("X-Amz-Date", "20260101T000000Z"),
+            (
+                "Authorization",
+                "AWS4-HMAC-SHA256 "
+                "Credential=PLACEHOLDER/20260101/*/s3/aws4_request, "
+                "SignedHeaders=host;x-amz-date, "
+                "Signature=placeholder",
+            ),
+        ),
+    )
+    flow.metadata["vm_run_id"] = "run-1"
+
+    with endpoint.run(), mitm_ctx(api_url=endpoint.api_url):
+        result = await auth.handle_firewall_request(flow, _allow(_api_entry()), _vm_info(tmp_path))
+
+    assert result is auth.FirewallAuthHandlingResult.LOCAL_RESPONSE
+    assert flow.response is not None
+    assert flow.response.status_code == 502
+    assert flow.response.json()["error"] == "aws_sigv4_auth_failed"
+    assert "Wildcard AWS signing region requires SigV4A" in flow.response.json()["message"]
+
+
+async def test_header_sigv4_with_malformed_scope_fails_closed(
+    real_flow,
+    headers,
+    tmp_path,
+    mitm_ctx,
+):
+    endpoint = FakeAuthEndpoint()
+    endpoint.queue_json_response(_auth_response())
+    flow = real_flow(
+        with_response=False,
+        host="sts.amazonaws.com",
+        path="/",
+        method="POST",
+        request_headers=headers(
+            ("Host", "sts.amazonaws.com"),
+            ("X-Amz-Date", "20260101T000000Z"),
+            (
+                "Authorization",
+                "AWS4-HMAC-SHA256 "
+                "Credential=PLACEHOLDER/20260101/us-east-1%0d%0aX-Bad:x/sts/aws4_request, "
+                "SignedHeaders=host;x-amz-date, "
+                "Signature=placeholder",
+            ),
+        ),
+    )
+    flow.metadata["vm_run_id"] = "run-1"
+
+    with endpoint.run(), mitm_ctx(api_url=endpoint.api_url):
+        result = await auth.handle_firewall_request(flow, _allow(_api_entry()), _vm_info(tmp_path))
+
+    assert result is auth.FirewallAuthHandlingResult.LOCAL_RESPONSE
+    assert flow.response is not None
+    assert flow.response.status_code == 502
+    assert flow.response.json()["error"] == "aws_sigv4_auth_failed"
+    assert "Malformed AWS credential scope" in flow.response.json()["message"]
+
+
+async def test_header_sigv4_with_invalid_resolved_access_key_fails_closed(
+    real_flow,
+    headers,
+    tmp_path,
+    mitm_ctx,
+):
+    endpoint = FakeAuthEndpoint()
+    response = _auth_response()
+    response["awsSigv4"] = {
+        "accessKeyId": "AKID/EXAMPLE",
+        "secretAccessKey": "wJalrXUtnFEMI/K7MDENG+bPxRfiCYEXAMPLEKEY",
+    }
+    endpoint.queue_json_response(response)
+    flow = real_flow(
+        with_response=False,
+        host="sts.amazonaws.com",
+        path="/",
+        method="POST",
+        request_headers=headers(
+            ("Host", "sts.amazonaws.com"),
+            ("X-Amz-Date", "20260101T000000Z"),
+            (
+                "Authorization",
+                "AWS4-HMAC-SHA256 "
+                "Credential=PLACEHOLDER/20260101/us-east-1/sts/aws4_request, "
+                "SignedHeaders=host;x-amz-date, "
+                "Signature=placeholder",
+            ),
+        ),
+    )
+    flow.metadata["vm_run_id"] = "run-1"
+
+    with endpoint.run(), mitm_ctx(api_url=endpoint.api_url):
+        result = await auth.handle_firewall_request(flow, _allow(_api_entry()), _vm_info(tmp_path))
+
+    assert result is auth.FirewallAuthHandlingResult.LOCAL_RESPONSE
+    assert flow.response is not None
+    assert flow.response.status_code == 502
+    assert flow.response.json()["error"] == "aws_sigv4_auth_failed"
+    assert "Invalid AWS access key ID" in flow.response.json()["message"]
 
 
 async def test_header_sigv4_without_signature_fails_closed(

--- a/crates/runner/mitm-addon/tests/test_firewall_aws_sigv4_auth.py
+++ b/crates/runner/mitm-addon/tests/test_firewall_aws_sigv4_auth.py
@@ -177,6 +177,42 @@ async def test_sigv4a_request_fails_closed(real_flow, headers, tmp_path, mitm_ct
     assert "SigV4A is not supported" in flow.response.json()["message"]
 
 
+async def test_header_sigv4_without_signature_fails_closed(
+    real_flow,
+    headers,
+    tmp_path,
+    mitm_ctx,
+):
+    endpoint = FakeAuthEndpoint()
+    endpoint.queue_json_response(_auth_response())
+    flow = real_flow(
+        with_response=False,
+        host="sts.amazonaws.com",
+        path="/",
+        method="POST",
+        request_headers=headers(
+            ("Host", "sts.amazonaws.com"),
+            ("X-Amz-Date", "20260101T000000Z"),
+            (
+                "Authorization",
+                "AWS4-HMAC-SHA256 "
+                "Credential=PLACEHOLDER/20260101/us-east-1/sts/aws4_request, "
+                "SignedHeaders=host;x-amz-date",
+            ),
+        ),
+    )
+    flow.metadata["vm_run_id"] = "run-1"
+
+    with endpoint.run(), mitm_ctx(api_url=endpoint.api_url):
+        result = await auth.handle_firewall_request(flow, _allow(_api_entry()), _vm_info(tmp_path))
+
+    assert result is auth.FirewallAuthHandlingResult.LOCAL_RESPONSE
+    assert flow.response is not None
+    assert flow.response.status_code == 502
+    assert flow.response.json()["error"] == "aws_sigv4_auth_failed"
+    assert "Malformed AWS authorization header" in flow.response.json()["message"]
+
+
 async def test_header_sigv4_without_amz_date_fails_closed(
     real_flow,
     headers,
@@ -211,3 +247,35 @@ async def test_header_sigv4_without_amz_date_fails_closed(
     assert flow.response.status_code == 502
     assert flow.response.json()["error"] == "aws_sigv4_auth_failed"
     assert "requires x-amz-date" in flow.response.json()["message"]
+
+
+async def test_query_sigv4_without_signature_fails_closed(real_flow, tmp_path, mitm_ctx):
+    endpoint = FakeAuthEndpoint()
+    endpoint.queue_json_response(_auth_response())
+    placeholder_credential = urllib.parse.quote(
+        "PLACEHOLDER/20260101/us-east-1/sts/aws4_request",
+        safe="",
+    )
+    flow = real_flow(
+        with_response=False,
+        host="sts.amazonaws.com",
+        path=(
+            "/?Action=GetCallerIdentity&Version=2011-06-15"
+            "&X-Amz-Algorithm=AWS4-HMAC-SHA256"
+            f"&X-Amz-Credential={placeholder_credential}"
+            "&X-Amz-Date=20260101T000000Z"
+            "&X-Amz-Expires=60"
+            "&X-Amz-SignedHeaders=host"
+        ),
+        method="GET",
+    )
+    flow.metadata["vm_run_id"] = "run-1"
+
+    with endpoint.run(), mitm_ctx(api_url=endpoint.api_url):
+        result = await auth.handle_firewall_request(flow, _allow(_api_entry()), _vm_info(tmp_path))
+
+    assert result is auth.FirewallAuthHandlingResult.LOCAL_RESPONSE
+    assert flow.response is not None
+    assert flow.response.status_code == 502
+    assert flow.response.json()["error"] == "aws_sigv4_auth_failed"
+    assert "Malformed AWS presigned query" in flow.response.json()["message"]

--- a/crates/runner/mitm-addon/tests/test_firewall_aws_sigv4_auth.py
+++ b/crates/runner/mitm-addon/tests/test_firewall_aws_sigv4_auth.py
@@ -1,0 +1,177 @@
+"""Firewall AWS SigV4 auth re-signing tests."""
+
+import urllib.parse
+
+import auth
+import matching
+from tests.auth_endpoint_helpers import FakeAuthEndpoint
+
+
+def _api_entry() -> dict:
+    return {
+        "base": "https://sts.amazonaws.com",
+        "auth": {
+            "headers": {},
+            "awsSigv4": {
+                "accessKeyId": "${{ secrets.AWS_ACCESS_KEY_ID }}",
+                "secretAccessKey": "${{ secrets.AWS_SECRET_ACCESS_KEY }}",
+                "sessionToken": "${{ secrets.AWS_SESSION_TOKEN }}",
+                "defaultRegion": "${{ vars.AWS_REGION }}",
+                "defaultService": "sts",
+            },
+        },
+    }
+
+
+def _allow(api_entry: dict) -> matching.FirewallAllow:
+    return matching.FirewallAllow(
+        api_entry,
+        "aws",
+        "identity",
+        {},
+        "POST /",
+        "/",
+    )
+
+
+def _vm_info(tmp_path, *, encrypted_secrets: str = "iv:tag:data") -> dict:
+    return {
+        "runId": "run-1",
+        "sandboxToken": "sandbox-token",
+        "encryptedSecrets": encrypted_secrets,
+        "networkLogPath": str(tmp_path / "network.jsonl"),
+        "billableFirewalls": [],
+        "vars": {"AWS_REGION": "us-east-1"},
+    }
+
+
+def _auth_response() -> dict[str, object]:
+    return {
+        "headers": {},
+        "awsSigv4": {
+            "accessKeyId": "AKIDEXAMPLE",
+            "secretAccessKey": "wJalrXUtnFEMI/K7MDENG+bPxRfiCYEXAMPLEKEY",
+            "sessionToken": "real-session-token",
+            "defaultRegion": "us-east-1",
+            "defaultService": "sts",
+        },
+        "expiresAt": 1_800_000_000,
+        "resolvedSecrets": [
+            "AWS_ACCESS_KEY_ID",
+            "AWS_SECRET_ACCESS_KEY",
+            "AWS_SESSION_TOKEN",
+        ],
+        "refreshedConnectors": ["aws"],
+        "refreshedSecrets": ["AWS_SESSION_TOKEN"],
+    }
+
+
+async def test_re_signs_header_sigv4_request(real_flow, headers, tmp_path, mitm_ctx):
+    endpoint = FakeAuthEndpoint()
+    endpoint.queue_json_response(_auth_response())
+    flow = real_flow(
+        with_response=False,
+        host="sts.amazonaws.com",
+        path="/",
+        method="POST",
+        request_body=b"Action=GetCallerIdentity&Version=2011-06-15",
+        request_headers=headers(
+            ("Host", "sts.amazonaws.com"),
+            ("Content-Type", "application/x-www-form-urlencoded"),
+            ("X-Amz-Date", "20260101T000000Z"),
+            (
+                "Authorization",
+                "AWS4-HMAC-SHA256 "
+                "Credential=PLACEHOLDER/20260101/us-east-1/sts/aws4_request, "
+                "SignedHeaders=content-type;host;x-amz-date, "
+                "Signature=placeholder",
+            ),
+        ),
+    )
+    flow.metadata["vm_run_id"] = "run-1"
+
+    with endpoint.run(), mitm_ctx(api_url=endpoint.api_url):
+        result = await auth.handle_firewall_request(flow, _allow(_api_entry()), _vm_info(tmp_path))
+
+    assert result is auth.FirewallAuthHandlingResult.CONTINUE_UPSTREAM
+    assert flow.response is None
+    authorization = flow.request.headers["authorization"]
+    assert authorization.startswith("AWS4-HMAC-SHA256 Credential=AKIDEXAMPLE/")
+    assert "PLACEHOLDER" not in authorization
+    assert "Signature=placeholder" not in authorization
+    assert flow.request.headers["x-amz-security-token"] == "real-session-token"
+    assert flow.metadata["auth_resolved_secrets"] == [
+        "AWS_ACCESS_KEY_ID",
+        "AWS_SECRET_ACCESS_KEY",
+        "AWS_SESSION_TOKEN",
+    ]
+
+    body = endpoint.requests[0].json_body()
+    assert body["authAwsSigv4"] == _api_entry()["auth"]["awsSigv4"]
+
+
+async def test_re_signs_query_sigv4_request(real_flow, tmp_path, mitm_ctx):
+    endpoint = FakeAuthEndpoint()
+    endpoint.queue_json_response(_auth_response())
+    placeholder_credential = urllib.parse.quote(
+        "PLACEHOLDER/20260101/us-east-1/sts/aws4_request",
+        safe="",
+    )
+    flow = real_flow(
+        with_response=False,
+        host="sts.amazonaws.com",
+        path=(
+            "/?Action=GetCallerIdentity&Version=2011-06-15"
+            "&X-Amz-Algorithm=AWS4-HMAC-SHA256"
+            f"&X-Amz-Credential={placeholder_credential}"
+            "&X-Amz-Date=20260101T000000Z"
+            "&X-Amz-Expires=60"
+            "&X-Amz-SignedHeaders=host"
+            "&X-Amz-Signature=placeholder"
+        ),
+        method="GET",
+    )
+    flow.metadata["vm_run_id"] = "run-1"
+
+    with endpoint.run(), mitm_ctx(api_url=endpoint.api_url):
+        result = await auth.handle_firewall_request(flow, _allow(_api_entry()), _vm_info(tmp_path))
+
+    assert result is auth.FirewallAuthHandlingResult.CONTINUE_UPSTREAM
+    assert "authorization" not in flow.request.headers
+    query = dict(urllib.parse.parse_qsl(urllib.parse.urlsplit(flow.request.url).query))
+    assert query["X-Amz-Algorithm"] == "AWS4-HMAC-SHA256"
+    assert query["X-Amz-Credential"] == "AKIDEXAMPLE/20260101/us-east-1/sts/aws4_request"
+    assert query["X-Amz-Security-Token"] == "real-session-token"
+    assert query["X-Amz-Signature"] != "placeholder"
+    assert "PLACEHOLDER" not in flow.request.url
+
+
+async def test_sigv4a_request_fails_closed(real_flow, headers, tmp_path, mitm_ctx):
+    endpoint = FakeAuthEndpoint()
+    endpoint.queue_json_response(_auth_response())
+    flow = real_flow(
+        with_response=False,
+        host="s3.amazonaws.com",
+        path="/bucket/key",
+        request_headers=headers(
+            ("Host", "s3.amazonaws.com"),
+            ("X-Amz-Date", "20260101T000000Z"),
+            (
+                "Authorization",
+                "AWS4-ECDSA-P256-SHA256 "
+                "Credential=PLACEHOLDER/20260101/*/s3/aws4_request, "
+                "SignedHeaders=host;x-amz-date, "
+                "Signature=placeholder",
+            ),
+        ),
+    )
+    flow.metadata["vm_run_id"] = "run-1"
+
+    with endpoint.run(), mitm_ctx(api_url=endpoint.api_url):
+        result = await auth.handle_firewall_request(flow, _allow(_api_entry()), _vm_info(tmp_path))
+
+    assert result is auth.FirewallAuthHandlingResult.LOCAL_RESPONSE
+    assert flow.response is not None
+    assert flow.response.status_code == 502
+    assert flow.response.json()["error"] == "aws_sigv4_auth_failed"
+    assert "SigV4A is not supported" in flow.response.json()["message"]

--- a/crates/runner/mitm-addon/tests/test_firewall_aws_sigv4_auth.py
+++ b/crates/runner/mitm-addon/tests/test_firewall_aws_sigv4_auth.py
@@ -664,6 +664,80 @@ async def test_header_sigv4_without_signature_fails_closed(
     assert "Malformed AWS authorization header" in flow.response.json()["message"]
 
 
+async def test_header_sigv4_with_duplicate_signed_header_fails_closed(
+    real_flow,
+    headers,
+    tmp_path,
+    mitm_ctx,
+):
+    endpoint = FakeAuthEndpoint()
+    endpoint.queue_json_response(_auth_response())
+    flow = real_flow(
+        with_response=False,
+        host="sts.amazonaws.com",
+        path="/",
+        method="POST",
+        request_headers=headers(
+            ("Host", "sts.amazonaws.com"),
+            ("X-Amz-Date", "20260101T000000Z"),
+            (
+                "Authorization",
+                "AWS4-HMAC-SHA256 "
+                "Credential=PLACEHOLDER/20260101/us-east-1/sts/aws4_request, "
+                "SignedHeaders=host;host;x-amz-date, "
+                "Signature=placeholder",
+            ),
+        ),
+    )
+    flow.metadata["vm_run_id"] = "run-1"
+
+    with endpoint.run(), mitm_ctx(api_url=endpoint.api_url):
+        result = await auth.handle_firewall_request(flow, _allow(_api_entry()), _vm_info(tmp_path))
+
+    assert result is auth.FirewallAuthHandlingResult.LOCAL_RESPONSE
+    assert flow.response is not None
+    assert flow.response.status_code == 502
+    assert flow.response.json()["error"] == "aws_sigv4_auth_failed"
+    assert "Malformed AWS signed headers" in flow.response.json()["message"]
+
+
+async def test_header_sigv4_with_empty_signed_header_segment_fails_closed(
+    real_flow,
+    headers,
+    tmp_path,
+    mitm_ctx,
+):
+    endpoint = FakeAuthEndpoint()
+    endpoint.queue_json_response(_auth_response())
+    flow = real_flow(
+        with_response=False,
+        host="sts.amazonaws.com",
+        path="/",
+        method="POST",
+        request_headers=headers(
+            ("Host", "sts.amazonaws.com"),
+            ("X-Amz-Date", "20260101T000000Z"),
+            (
+                "Authorization",
+                "AWS4-HMAC-SHA256 "
+                "Credential=PLACEHOLDER/20260101/us-east-1/sts/aws4_request, "
+                "SignedHeaders=host;;x-amz-date, "
+                "Signature=placeholder",
+            ),
+        ),
+    )
+    flow.metadata["vm_run_id"] = "run-1"
+
+    with endpoint.run(), mitm_ctx(api_url=endpoint.api_url):
+        result = await auth.handle_firewall_request(flow, _allow(_api_entry()), _vm_info(tmp_path))
+
+    assert result is auth.FirewallAuthHandlingResult.LOCAL_RESPONSE
+    assert flow.response is not None
+    assert flow.response.status_code == 502
+    assert flow.response.json()["error"] == "aws_sigv4_auth_failed"
+    assert "Malformed AWS signed headers" in flow.response.json()["message"]
+
+
 async def test_header_sigv4_without_amz_date_fails_closed(
     real_flow,
     headers,
@@ -953,6 +1027,44 @@ async def test_query_sigv4_with_duplicate_credential_fails_closed(real_flow, tmp
     assert flow.response.status_code == 502
     assert flow.response.json()["error"] == "aws_sigv4_auth_failed"
     assert "Malformed AWS presigned query" in flow.response.json()["message"]
+
+
+async def test_query_sigv4_with_duplicate_signed_header_fails_closed(
+    real_flow,
+    tmp_path,
+    mitm_ctx,
+):
+    endpoint = FakeAuthEndpoint()
+    endpoint.queue_json_response(_auth_response())
+    placeholder_credential = urllib.parse.quote(
+        "PLACEHOLDER/20260101/us-east-1/sts/aws4_request",
+        safe="",
+    )
+    signed_headers = urllib.parse.quote("host;host", safe="")
+    flow = real_flow(
+        with_response=False,
+        host="sts.amazonaws.com",
+        path=(
+            "/?Action=GetCallerIdentity&Version=2011-06-15"
+            "&X-Amz-Algorithm=AWS4-HMAC-SHA256"
+            f"&X-Amz-Credential={placeholder_credential}"
+            "&X-Amz-Date=20260101T000000Z"
+            "&X-Amz-Expires=60"
+            f"&X-Amz-SignedHeaders={signed_headers}"
+            "&X-Amz-Signature=placeholder"
+        ),
+        method="GET",
+    )
+    flow.metadata["vm_run_id"] = "run-1"
+
+    with endpoint.run(), mitm_ctx(api_url=endpoint.api_url):
+        result = await auth.handle_firewall_request(flow, _allow(_api_entry()), _vm_info(tmp_path))
+
+    assert result is auth.FirewallAuthHandlingResult.LOCAL_RESPONSE
+    assert flow.response is not None
+    assert flow.response.status_code == 502
+    assert flow.response.json()["error"] == "aws_sigv4_auth_failed"
+    assert "Malformed AWS signed headers" in flow.response.json()["message"]
 
 
 async def test_query_sigv4_with_malformed_expiry_fails_closed(real_flow, tmp_path, mitm_ctx):

--- a/crates/runner/mitm-addon/tests/test_firewall_aws_sigv4_auth.py
+++ b/crates/runner/mitm-addon/tests/test_firewall_aws_sigv4_auth.py
@@ -501,6 +501,80 @@ async def test_header_sigv4_without_amz_date_fails_closed(
     assert "requires x-amz-date" in flow.response.json()["message"]
 
 
+async def test_header_sigv4_with_malformed_amz_date_fails_closed(
+    real_flow,
+    headers,
+    tmp_path,
+    mitm_ctx,
+):
+    endpoint = FakeAuthEndpoint()
+    endpoint.queue_json_response(_auth_response())
+    flow = real_flow(
+        with_response=False,
+        host="sts.amazonaws.com",
+        path="/",
+        method="POST",
+        request_headers=headers(
+            ("Host", "sts.amazonaws.com"),
+            ("X-Amz-Date", "not-a-date"),
+            (
+                "Authorization",
+                "AWS4-HMAC-SHA256 "
+                "Credential=PLACEHOLDER/20260101/us-east-1/sts/aws4_request, "
+                "SignedHeaders=host;x-amz-date, "
+                "Signature=placeholder",
+            ),
+        ),
+    )
+    flow.metadata["vm_run_id"] = "run-1"
+
+    with endpoint.run(), mitm_ctx(api_url=endpoint.api_url):
+        result = await auth.handle_firewall_request(flow, _allow(_api_entry()), _vm_info(tmp_path))
+
+    assert result is auth.FirewallAuthHandlingResult.LOCAL_RESPONSE
+    assert flow.response is not None
+    assert flow.response.status_code == 502
+    assert flow.response.json()["error"] == "aws_sigv4_auth_failed"
+    assert "Malformed AWS signing date" in flow.response.json()["message"]
+
+
+async def test_header_sigv4_with_scope_date_mismatch_fails_closed(
+    real_flow,
+    headers,
+    tmp_path,
+    mitm_ctx,
+):
+    endpoint = FakeAuthEndpoint()
+    endpoint.queue_json_response(_auth_response())
+    flow = real_flow(
+        with_response=False,
+        host="sts.amazonaws.com",
+        path="/",
+        method="POST",
+        request_headers=headers(
+            ("Host", "sts.amazonaws.com"),
+            ("X-Amz-Date", "20260102T000000Z"),
+            (
+                "Authorization",
+                "AWS4-HMAC-SHA256 "
+                "Credential=PLACEHOLDER/20260101/us-east-1/sts/aws4_request, "
+                "SignedHeaders=host;x-amz-date, "
+                "Signature=placeholder",
+            ),
+        ),
+    )
+    flow.metadata["vm_run_id"] = "run-1"
+
+    with endpoint.run(), mitm_ctx(api_url=endpoint.api_url):
+        result = await auth.handle_firewall_request(flow, _allow(_api_entry()), _vm_info(tmp_path))
+
+    assert result is auth.FirewallAuthHandlingResult.LOCAL_RESPONSE
+    assert flow.response is not None
+    assert flow.response.status_code == 502
+    assert flow.response.json()["error"] == "aws_sigv4_auth_failed"
+    assert "AWS signing date does not match credential scope" in flow.response.json()["message"]
+
+
 async def test_query_sigv4_without_signature_fails_closed(real_flow, tmp_path, mitm_ctx):
     endpoint = FakeAuthEndpoint()
     endpoint.queue_json_response(_auth_response())
@@ -531,3 +605,36 @@ async def test_query_sigv4_without_signature_fails_closed(real_flow, tmp_path, m
     assert flow.response.status_code == 502
     assert flow.response.json()["error"] == "aws_sigv4_auth_failed"
     assert "Malformed AWS presigned query" in flow.response.json()["message"]
+
+
+async def test_query_sigv4_with_malformed_expiry_fails_closed(real_flow, tmp_path, mitm_ctx):
+    endpoint = FakeAuthEndpoint()
+    endpoint.queue_json_response(_auth_response())
+    placeholder_credential = urllib.parse.quote(
+        "PLACEHOLDER/20260101/us-east-1/sts/aws4_request",
+        safe="",
+    )
+    flow = real_flow(
+        with_response=False,
+        host="sts.amazonaws.com",
+        path=(
+            "/?Action=GetCallerIdentity&Version=2011-06-15"
+            "&X-Amz-Algorithm=AWS4-HMAC-SHA256"
+            f"&X-Amz-Credential={placeholder_credential}"
+            "&X-Amz-Date=20260101T000000Z"
+            "&X-Amz-Expires=sixty"
+            "&X-Amz-SignedHeaders=host"
+            "&X-Amz-Signature=placeholder"
+        ),
+        method="GET",
+    )
+    flow.metadata["vm_run_id"] = "run-1"
+
+    with endpoint.run(), mitm_ctx(api_url=endpoint.api_url):
+        result = await auth.handle_firewall_request(flow, _allow(_api_entry()), _vm_info(tmp_path))
+
+    assert result is auth.FirewallAuthHandlingResult.LOCAL_RESPONSE
+    assert flow.response is not None
+    assert flow.response.status_code == 502
+    assert flow.response.json()["error"] == "aws_sigv4_auth_failed"
+    assert "Malformed AWS presigned query expiry" in flow.response.json()["message"]

--- a/crates/runner/mitm-addon/tests/test_firewall_aws_sigv4_auth.py
+++ b/crates/runner/mitm-addon/tests/test_firewall_aws_sigv4_auth.py
@@ -178,6 +178,82 @@ async def test_re_signs_header_sigv4_request_to_reference_signature(
     assert "x-amz-security-token" not in flow.request.headers
 
 
+async def test_re_signs_header_sigv4_request_with_encoded_path(
+    real_flow,
+    headers,
+    tmp_path,
+    mitm_ctx,
+):
+    endpoint = FakeAuthEndpoint()
+    endpoint.queue_json_response(
+        {
+            "headers": {},
+            "awsSigv4": {
+                "accessKeyId": "AKIDEXAMPLE",
+                "secretAccessKey": "wJalrXUtnFEMI/K7MDENG+bPxRfiCYEXAMPLEKEY",
+            },
+            "expiresAt": 1_800_000_000,
+            "resolvedSecrets": [
+                "AWS_ACCESS_KEY_ID",
+                "AWS_SECRET_ACCESS_KEY",
+            ],
+            "refreshedConnectors": [],
+            "refreshedSecrets": [],
+        }
+    )
+    api_entry = {
+        "base": "https://iam.amazonaws.com",
+        "auth": {
+            "headers": {},
+            "awsSigv4": {
+                "accessKeyId": "${{ secrets.AWS_ACCESS_KEY_ID }}",
+                "secretAccessKey": "${{ secrets.AWS_SECRET_ACCESS_KEY }}",
+            },
+        },
+    }
+    flow = real_flow(
+        with_response=False,
+        host="iam.amazonaws.com",
+        path="/a/../long/path%20name/",
+        method="GET",
+        request_headers=headers(
+            ("Host", "iam.amazonaws.com"),
+            ("X-Amz-Date", "20150830T123600Z"),
+            (
+                "Authorization",
+                "AWS4-HMAC-SHA256 "
+                "Credential=PLACEHOLDER/20150830/us-east-1/iam/aws4_request, "
+                "SignedHeaders=host;x-amz-date, "
+                "Signature=placeholder",
+            ),
+        ),
+    )
+    flow.metadata["vm_run_id"] = "run-1"
+
+    with endpoint.run(), mitm_ctx(api_url=endpoint.api_url):
+        result = await auth.handle_firewall_request(
+            flow,
+            matching.FirewallAllow(
+                api_entry,
+                "aws",
+                "encoded-path",
+                {},
+                "GET /{path+}",
+                "/a/../long/path%20name/",
+            ),
+            _vm_info(tmp_path),
+        )
+
+    assert result is auth.FirewallAuthHandlingResult.CONTINUE_UPSTREAM
+    assert flow.request.url == "https://iam.amazonaws.com/a/../long/path%20name/"
+    assert flow.request.headers["authorization"] == (
+        "AWS4-HMAC-SHA256 "
+        "Credential=AKIDEXAMPLE/20150830/us-east-1/iam/aws4_request, "
+        "SignedHeaders=host;x-amz-date, "
+        "Signature=f1e30e1649dd37a25de158bbc35c722f3c513f7b1051cb50ec2d351a468824ff"
+    )
+
+
 async def test_re_signs_query_sigv4_request(real_flow, tmp_path, mitm_ctx):
     endpoint = FakeAuthEndpoint()
     endpoint.queue_json_response(_auth_response())

--- a/crates/runner/mitm-addon/tests/test_firewall_aws_sigv4_auth.py
+++ b/crates/runner/mitm-addon/tests/test_firewall_aws_sigv4_auth.py
@@ -175,3 +175,39 @@ async def test_sigv4a_request_fails_closed(real_flow, headers, tmp_path, mitm_ct
     assert flow.response.status_code == 502
     assert flow.response.json()["error"] == "aws_sigv4_auth_failed"
     assert "SigV4A is not supported" in flow.response.json()["message"]
+
+
+async def test_header_sigv4_without_amz_date_fails_closed(
+    real_flow,
+    headers,
+    tmp_path,
+    mitm_ctx,
+):
+    endpoint = FakeAuthEndpoint()
+    endpoint.queue_json_response(_auth_response())
+    flow = real_flow(
+        with_response=False,
+        host="sts.amazonaws.com",
+        path="/",
+        method="POST",
+        request_headers=headers(
+            ("Host", "sts.amazonaws.com"),
+            (
+                "Authorization",
+                "AWS4-HMAC-SHA256 "
+                "Credential=PLACEHOLDER/20260101/us-east-1/sts/aws4_request, "
+                "SignedHeaders=host, "
+                "Signature=placeholder",
+            ),
+        ),
+    )
+    flow.metadata["vm_run_id"] = "run-1"
+
+    with endpoint.run(), mitm_ctx(api_url=endpoint.api_url):
+        result = await auth.handle_firewall_request(flow, _allow(_api_entry()), _vm_info(tmp_path))
+
+    assert result is auth.FirewallAuthHandlingResult.LOCAL_RESPONSE
+    assert flow.response is not None
+    assert flow.response.status_code == 502
+    assert flow.response.json()["error"] == "aws_sigv4_auth_failed"
+    assert "requires x-amz-date" in flow.response.json()["message"]

--- a/crates/runner/mitm-addon/tests/test_firewall_matching.py
+++ b/crates/runner/mitm-addon/tests/test_firewall_matching.py
@@ -54,6 +54,62 @@ class TestCompiledFirewallRequest:
         assert result.params == {"owner": "octocat", "repo": "hello"}
         assert result.rule == "GET /repos/{owner}/{repo}"
 
+    def test_aws_sigv4_auth_config_allows_matching(self, headers):
+        fw_configs = wrap_firewalls(
+            [
+                {
+                    "base": "https://sts.amazonaws.com",
+                    "auth": {
+                        "headers": {},
+                        "awsSigv4": {
+                            "accessKeyId": "${{ secrets.AWS_ACCESS_KEY_ID }}",
+                            "secretAccessKey": "${{ secrets.AWS_SECRET_ACCESS_KEY }}",
+                            "sessionToken": "${{ secrets.AWS_SESSION_TOKEN }}",
+                            "defaultRegion": "${{ vars.AWS_REGION }}",
+                            "defaultService": "sts",
+                        },
+                    },
+                    "permissions": [{"name": "identity", "rules": ["POST /"]}],
+                }
+            ],
+            name="aws",
+        )
+        result = match_request_with_raw_firewalls(
+            "https://sts.amazonaws.com/",
+            "POST",
+            fw_configs,
+            network_policies=grant_all(fw_configs),
+        )
+        assert isinstance(result, matching.FirewallAllow)
+        assert result.name == "aws"
+        assert result.permission == "identity"
+
+    def test_malformed_aws_sigv4_auth_config_does_not_match(self, headers):
+        fw_configs = wrap_firewalls(
+            [
+                {
+                    "base": "https://sts.amazonaws.com",
+                    "auth": {
+                        "headers": {"Authorization": "Bearer ${{ secrets.TOKEN }}"},
+                        "awsSigv4": {
+                            "accessKeyId": "${{ secrets.AWS_ACCESS_KEY_ID }}",
+                            "secretAccessKey": "${{ secrets.AWS_SECRET_ACCESS_KEY }}",
+                        },
+                    },
+                    "permissions": [{"name": "identity", "rules": ["POST /"]}],
+                }
+            ],
+            name="aws",
+        )
+        result = match_request_with_raw_firewalls(
+            "https://sts.amazonaws.com/",
+            "POST",
+            fw_configs,
+            network_policies=grant_all(fw_configs),
+        )
+        assert isinstance(result, matching.FirewallBlock)
+        assert result.reason == "malformed_firewall_config"
+
     def test_any_method_matches(self, headers):
         fw_configs = wrap_firewalls(
             [

--- a/crates/runner/mitm-addon/tests/test_firewall_matching.py
+++ b/crates/runner/mitm-addon/tests/test_firewall_matching.py
@@ -65,8 +65,6 @@ class TestCompiledFirewallRequest:
                             "accessKeyId": "${{ secrets.AWS_ACCESS_KEY_ID }}",
                             "secretAccessKey": "${{ secrets.AWS_SECRET_ACCESS_KEY }}",
                             "sessionToken": "${{ secrets.AWS_SESSION_TOKEN }}",
-                            "defaultRegion": "${{ vars.AWS_REGION }}",
-                            "defaultService": "sts",
                         },
                     },
                     "permissions": [{"name": "identity", "rules": ["POST /"]}],
@@ -94,6 +92,32 @@ class TestCompiledFirewallRequest:
                         "awsSigv4": {
                             "accessKeyId": "${{ secrets.AWS_ACCESS_KEY_ID }}",
                             "secretAccessKey": "${{ secrets.AWS_SECRET_ACCESS_KEY }}",
+                        },
+                    },
+                    "permissions": [{"name": "identity", "rules": ["POST /"]}],
+                }
+            ],
+            name="aws",
+        )
+        result = match_request_with_raw_firewalls(
+            "https://sts.amazonaws.com/",
+            "POST",
+            fw_configs,
+            network_policies=grant_all(fw_configs),
+        )
+        assert isinstance(result, matching.FirewallBlock)
+        assert result.reason == "malformed_firewall_config"
+
+    def test_aws_sigv4_auth_config_rejects_unsupported_defaults(self, headers):
+        fw_configs = wrap_firewalls(
+            [
+                {
+                    "base": "https://sts.amazonaws.com",
+                    "auth": {
+                        "awsSigv4": {
+                            "accessKeyId": "${{ secrets.AWS_ACCESS_KEY_ID }}",
+                            "secretAccessKey": "${{ secrets.AWS_SECRET_ACCESS_KEY }}",
+                            "defaultRegion": "${{ vars.AWS_REGION }}",
                         },
                     },
                     "permissions": [{"name": "identity", "rules": ["POST /"]}],

--- a/crates/runner/mitm-addon/tests/test_firewall_rewrite_forwarding.py
+++ b/crates/runner/mitm-addon/tests/test_firewall_rewrite_forwarding.py
@@ -7,6 +7,7 @@ from urllib.parse import parse_qs, urlparse
 
 import auth
 import auth_base_forwarder as forwarder
+from aws_sigv4 import AwsSigV4Credentials
 from tests.firewall_rewrite_helpers import make_forwarding_rewrite_inputs
 
 
@@ -152,6 +153,69 @@ class TestAuthBaseUrlRewriteForwarding:
         assert ("Authorization", "Bearer real") in req_headers
         assert ("X-Injected", "trusted") in req_headers
         assert ("X-Keep", "client") in req_headers
+
+    async def test_forward_request_signs_rewritten_aws_sigv4_request(
+        self,
+        headers,
+        real_flow,
+        mitm_ctx,
+        tmp_path,
+    ):
+        """auth.base forwarding signs the rewritten upstream URL, not the placeholder."""
+        placeholder_authorization = (
+            "AWS4-HMAC-SHA256 "
+            "Credential=PLACEHOLDER/20260101/us-east-1/sts/aws4_request, "
+            "SignedHeaders=content-type;host;x-amz-date, "
+            "Signature=placeholder"
+        )
+        flow, allow, vm_info, token_meta = make_forwarding_rewrite_inputs(
+            real_flow,
+            tmp_path,
+            resolved_base="https://sts.amazonaws.com/",
+            method="POST",
+            request_body=b"Action=GetCallerIdentity&Version=2011-06-15",
+            request_headers=headers(
+                ("Host", "firewall-placeholder.vm3.ai"),
+                ("Content-Type", "application/x-www-form-urlencoded"),
+                ("X-Amz-Date", "20260101T000000Z"),
+                ("Authorization", placeholder_authorization),
+            ),
+            auth_overrides={
+                "awsSigv4": {
+                    "accessKeyId": "${{ secrets.AWS_ACCESS_KEY_ID }}",
+                    "secretAccessKey": "${{ secrets.AWS_SECRET_ACCESS_KEY }}",
+                    "sessionToken": "${{ secrets.AWS_SESSION_TOKEN }}",
+                    "defaultRegion": "${{ vars.AWS_REGION }}",
+                    "defaultService": "sts",
+                },
+            },
+            token_overrides={
+                "aws_sigv4": AwsSigV4Credentials(
+                    "AKIDEXAMPLE",
+                    "wJalrXUtnFEMI/K7MDENG+bPxRfiCYEXAMPLEKEY",
+                    "real-session-token",
+                    "us-east-1",
+                    "sts",
+                ),
+            },
+        )
+        mock_forward = AsyncMock(return_value=(200, b"ok", {}))
+        with (
+            patch.object(auth, "get_firewall_headers", AsyncMock(return_value=token_meta)),
+            patch.object(auth, "forward_request", mock_forward),
+            mitm_ctx(),
+        ):
+            await auth.handle_firewall_request(flow, allow, vm_info)
+
+        forwarded_url = mock_forward.call_args[0][0]
+        req_headers = mock_forward.call_args[0][2]
+        authorization = dict(req_headers)["authorization"]
+        assert forwarded_url == "https://sts.amazonaws.com/"
+        assert ("host", "sts.amazonaws.com") in req_headers
+        assert "Credential=AKIDEXAMPLE/20260101/us-east-1/sts/aws4_request" in authorization
+        assert "Signature=placeholder" not in authorization
+        assert ("x-amz-security-token", "real-session-token") in req_headers
+        assert flow.request.headers["Authorization"] == placeholder_authorization
 
     async def test_forward_request_uses_raw_body_for_any_method(
         self, real_flow, mitm_ctx, tmp_path

--- a/crates/runner/mitm-addon/tests/test_firewall_rewrite_forwarding.py
+++ b/crates/runner/mitm-addon/tests/test_firewall_rewrite_forwarding.py
@@ -171,7 +171,7 @@ class TestAuthBaseUrlRewriteForwarding:
         flow, allow, vm_info, token_meta = make_forwarding_rewrite_inputs(
             real_flow,
             tmp_path,
-            resolved_base="https://sts.amazonaws.com/",
+            resolved_base="https://STS.AMAZONAWS.COM:443/",
             method="POST",
             request_body=b"Action=GetCallerIdentity&Version=2011-06-15",
             request_headers=headers(
@@ -206,10 +206,13 @@ class TestAuthBaseUrlRewriteForwarding:
         forwarded_url = mock_forward.call_args[0][0]
         req_headers = mock_forward.call_args[0][2]
         authorization = dict(req_headers)["authorization"]
-        assert forwarded_url == "https://sts.amazonaws.com/"
+        assert forwarded_url == "https://sts.amazonaws.com:443/"
         assert ("host", "sts.amazonaws.com") in req_headers
         assert "Credential=AKIDEXAMPLE/20260101/us-east-1/sts/aws4_request" in authorization
-        assert "Signature=placeholder" not in authorization
+        assert (
+            "Signature=d58b7e131d8f54e75a6ee98fd426242a7bab02e04a9e7eaec5dfad94425ab4ae"
+            in authorization
+        )
         assert ("x-amz-security-token", "real-session-token") in req_headers
         assert flow.request.headers["Authorization"] == placeholder_authorization
 

--- a/crates/runner/mitm-addon/tests/test_firewall_rewrite_forwarding.py
+++ b/crates/runner/mitm-addon/tests/test_firewall_rewrite_forwarding.py
@@ -185,8 +185,6 @@ class TestAuthBaseUrlRewriteForwarding:
                     "accessKeyId": "${{ secrets.AWS_ACCESS_KEY_ID }}",
                     "secretAccessKey": "${{ secrets.AWS_SECRET_ACCESS_KEY }}",
                     "sessionToken": "${{ secrets.AWS_SESSION_TOKEN }}",
-                    "defaultRegion": "${{ vars.AWS_REGION }}",
-                    "defaultService": "sts",
                 },
             },
             token_overrides={
@@ -194,8 +192,6 @@ class TestAuthBaseUrlRewriteForwarding:
                     "AKIDEXAMPLE",
                     "wJalrXUtnFEMI/K7MDENG+bPxRfiCYEXAMPLEKEY",
                     "real-session-token",
-                    "us-east-1",
-                    "sts",
                 ),
             },
         )

--- a/turbo/apps/api/src/signals/routes/__tests__/webhooks-agent-firewall-auth.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/webhooks-agent-firewall-auth.test.ts
@@ -1462,6 +1462,45 @@ describe("POST /api/webhooks/agent/firewall/auth", () => {
     });
   });
 
+  it("resolves aws sigv4 auth templates with vars", async () => {
+    const fixture = await track(seedFixture());
+
+    const response = await accept(
+      firewallClient().resolve({
+        body: {
+          encryptedSecrets: encryptedSecrets({
+            AWS_SECRET_ACCESS_KEY: "secret-access-key",
+            AWS_SESSION_TOKEN: "session-token",
+          }),
+          authHeaders: {},
+          authAwsSigv4: {
+            accessKeyId: varTemplate("AWS_ACCESS_KEY_ID"),
+            secretAccessKey: secretTemplate("AWS_SECRET_ACCESS_KEY"),
+            sessionToken: secretTemplate("AWS_SESSION_TOKEN"),
+          },
+          vars: {
+            AWS_ACCESS_KEY_ID: "access-key-id",
+          },
+        },
+        headers: authHeaders(fixture),
+      }),
+      [200],
+    );
+
+    expect(response.body).toStrictEqual({
+      headers: {},
+      awsSigv4: {
+        accessKeyId: "access-key-id",
+        secretAccessKey: "secret-access-key",
+        sessionToken: "session-token",
+      },
+      expiresAt: null,
+      resolvedSecrets: ["AWS_SECRET_ACCESS_KEY", "AWS_SESSION_TOKEN"],
+      refreshedConnectors: [],
+      refreshedSecrets: [],
+    });
+  });
+
   it("returns connector-not-configured for empty resolved aws sigv4 credentials", async () => {
     const fixture = await track(seedFixture());
     const cases: readonly {

--- a/turbo/apps/api/src/signals/routes/__tests__/webhooks-agent-firewall-auth.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/webhooks-agent-firewall-auth.test.ts
@@ -1437,11 +1437,6 @@ describe("POST /api/webhooks/agent/firewall/auth", () => {
             accessKeyId: secretTemplate("AWS_ACCESS_KEY_ID"),
             secretAccessKey: secretTemplate("AWS_SECRET_ACCESS_KEY"),
             sessionToken: secretTemplate("AWS_SESSION_TOKEN"),
-            defaultRegion: varTemplate("AWS_REGION"),
-            defaultService: "sts",
-          },
-          vars: {
-            AWS_REGION: "us-east-1",
           },
         },
         headers: authHeaders(fixture),
@@ -1455,8 +1450,6 @@ describe("POST /api/webhooks/agent/firewall/auth", () => {
         accessKeyId: "access-key-id",
         secretAccessKey: "secret-access-key",
         sessionToken: "session-token",
-        defaultRegion: "us-east-1",
-        defaultService: "sts",
       },
       expiresAt: null,
       resolvedSecrets: [

--- a/turbo/apps/api/src/signals/routes/__tests__/webhooks-agent-firewall-auth.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/webhooks-agent-firewall-auth.test.ts
@@ -1421,6 +1421,54 @@ describe("POST /api/webhooks/agent/firewall/auth", () => {
     });
   });
 
+  it("resolves aws sigv4 auth templates", async () => {
+    const fixture = await track(seedFixture());
+
+    const response = await accept(
+      firewallClient().resolve({
+        body: {
+          encryptedSecrets: encryptedSecrets({
+            AWS_ACCESS_KEY_ID: "access-key-id",
+            AWS_SECRET_ACCESS_KEY: "secret-access-key",
+            AWS_SESSION_TOKEN: "session-token",
+          }),
+          authHeaders: {},
+          authAwsSigv4: {
+            accessKeyId: secretTemplate("AWS_ACCESS_KEY_ID"),
+            secretAccessKey: secretTemplate("AWS_SECRET_ACCESS_KEY"),
+            sessionToken: secretTemplate("AWS_SESSION_TOKEN"),
+            defaultRegion: varTemplate("AWS_REGION"),
+            defaultService: "sts",
+          },
+          vars: {
+            AWS_REGION: "us-east-1",
+          },
+        },
+        headers: authHeaders(fixture),
+      }),
+      [200],
+    );
+
+    expect(response.body).toStrictEqual({
+      headers: {},
+      awsSigv4: {
+        accessKeyId: "access-key-id",
+        secretAccessKey: "secret-access-key",
+        sessionToken: "session-token",
+        defaultRegion: "us-east-1",
+        defaultService: "sts",
+      },
+      expiresAt: null,
+      resolvedSecrets: [
+        "AWS_ACCESS_KEY_ID",
+        "AWS_SECRET_ACCESS_KEY",
+        "AWS_SESSION_TOKEN",
+      ],
+      refreshedConnectors: [],
+      refreshedSecrets: [],
+    });
+  });
+
   it("resolves query, vars, pass-through, and omitted query template cases", async () => {
     const fixture = await track(seedFixture());
 

--- a/turbo/apps/api/src/signals/routes/__tests__/webhooks-agent-firewall-auth.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/webhooks-agent-firewall-auth.test.ts
@@ -1462,6 +1462,72 @@ describe("POST /api/webhooks/agent/firewall/auth", () => {
     });
   });
 
+  it("returns connector-not-configured for empty resolved aws sigv4 credentials", async () => {
+    const fixture = await track(seedFixture());
+    const cases: readonly {
+      readonly secrets: Record<string, string>;
+      readonly authAwsSigv4: {
+        readonly accessKeyId: string;
+        readonly secretAccessKey: string;
+        readonly sessionToken?: string;
+      };
+    }[] = [
+      {
+        secrets: {
+          AWS_ACCESS_KEY_ID: "",
+          AWS_SECRET_ACCESS_KEY: "secret-access-key",
+        },
+        authAwsSigv4: {
+          accessKeyId: secretTemplate("AWS_ACCESS_KEY_ID"),
+          secretAccessKey: secretTemplate("AWS_SECRET_ACCESS_KEY"),
+        },
+      },
+      {
+        secrets: {
+          AWS_ACCESS_KEY_ID: "access-key-id",
+          AWS_SECRET_ACCESS_KEY: "",
+        },
+        authAwsSigv4: {
+          accessKeyId: secretTemplate("AWS_ACCESS_KEY_ID"),
+          secretAccessKey: secretTemplate("AWS_SECRET_ACCESS_KEY"),
+        },
+      },
+      {
+        secrets: {
+          AWS_ACCESS_KEY_ID: "access-key-id",
+          AWS_SECRET_ACCESS_KEY: "secret-access-key",
+          AWS_SESSION_TOKEN: "",
+        },
+        authAwsSigv4: {
+          accessKeyId: secretTemplate("AWS_ACCESS_KEY_ID"),
+          secretAccessKey: secretTemplate("AWS_SECRET_ACCESS_KEY"),
+          sessionToken: secretTemplate("AWS_SESSION_TOKEN"),
+        },
+      },
+    ];
+
+    for (const testCase of cases) {
+      const response = await accept(
+        firewallClient().resolve({
+          body: {
+            encryptedSecrets: encryptedSecrets(testCase.secrets),
+            authHeaders: {},
+            authAwsSigv4: testCase.authAwsSigv4,
+          },
+          headers: authHeaders(fixture),
+        }),
+        [424],
+      );
+
+      expect(response.body).toStrictEqual({
+        error: {
+          message: "Connector not configured",
+          code: "CONNECTOR_NOT_CONFIGURED",
+        },
+      });
+    }
+  });
+
   it("resolves query, vars, pass-through, and omitted query template cases", async () => {
     const fixture = await track(seedFixture());
 

--- a/turbo/apps/api/src/signals/services/agent-webhook-firewall-auth.service.ts
+++ b/turbo/apps/api/src/signals/services/agent-webhook-firewall-auth.service.ts
@@ -123,8 +123,6 @@ interface FirewallAwsSigv4AuthConfig {
   readonly accessKeyId: string;
   readonly secretAccessKey: string;
   readonly sessionToken?: string;
-  readonly defaultRegion?: string;
-  readonly defaultService?: string;
 }
 
 interface RefreshResult {
@@ -3494,12 +3492,6 @@ function resolveTemplates(args: ResolveTemplatesArgs): {
         secretAccessKey: resolveSimple(args.authAwsSigv4.secretAccessKey),
         ...(args.authAwsSigv4.sessionToken
           ? { sessionToken: resolveSimple(args.authAwsSigv4.sessionToken) }
-          : {}),
-        ...(args.authAwsSigv4.defaultRegion
-          ? { defaultRegion: resolveSimple(args.authAwsSigv4.defaultRegion) }
-          : {}),
-        ...(args.authAwsSigv4.defaultService
-          ? { defaultService: resolveSimple(args.authAwsSigv4.defaultService) }
           : {}),
       } satisfies FirewallAwsSigv4AuthConfig)
     : undefined;

--- a/turbo/apps/api/src/signals/services/agent-webhook-firewall-auth.service.ts
+++ b/turbo/apps/api/src/signals/services/agent-webhook-firewall-auth.service.ts
@@ -111,11 +111,20 @@ interface FirewallAuthBody {
   readonly authHeaders: Record<string, string>;
   readonly authBase?: string;
   readonly authQuery?: Record<string, string>;
+  readonly authAwsSigv4?: FirewallAwsSigv4AuthConfig;
   readonly secretConnectorMap?: Record<string, string>;
   readonly secretConnectorMetadataMap?: Record<string, SecretConnectorMetadata>;
   readonly vars?: Record<string, string>;
   readonly firewallBillable?: boolean;
   readonly forceRefresh?: boolean;
+}
+
+interface FirewallAwsSigv4AuthConfig {
+  readonly accessKeyId: string;
+  readonly secretAccessKey: string;
+  readonly sessionToken?: string;
+  readonly defaultRegion?: string;
+  readonly defaultService?: string;
 }
 
 interface RefreshResult {
@@ -150,6 +159,7 @@ interface ResolveResult {
     readonly headers: Record<string, string>;
     readonly base?: string;
     readonly query?: Record<string, string>;
+    readonly awsSigv4?: FirewallAwsSigv4AuthConfig;
     readonly expiresAt: number | null;
     readonly resolvedSecrets: readonly string[];
     readonly refreshedConnectors: readonly string[];
@@ -2754,6 +2764,7 @@ async function prepareFirewallAuthResolutionContext(args: {
     args.body.authHeaders,
     args.body.authBase,
     args.body.authQuery,
+    args.body.authAwsSigv4,
   );
   const vars = args.body.vars ?? {};
   if (
@@ -3304,6 +3315,7 @@ function collectReferencedKeys(
   authHeaders: Record<string, string>,
   authBase?: string,
   authQuery?: Record<string, string>,
+  authAwsSigv4?: FirewallAwsSigv4AuthConfig,
 ): ReferencedAuthKeys {
   const secretKeys = new Set<string>();
   const varKeys = new Set<string>();
@@ -3326,6 +3338,13 @@ function collectReferencedKeys(
   if (authQuery) {
     for (const template of Object.values(authQuery)) {
       collectSimpleReferencedKeys(template, addKey);
+    }
+  }
+  if (authAwsSigv4) {
+    for (const template of Object.values(authAwsSigv4)) {
+      if (template) {
+        collectSimpleReferencedKeys(template, addKey);
+      }
     }
   }
 
@@ -3409,17 +3428,21 @@ function getOwnValue(
   return Object.hasOwn(values, key) ? values[key] : undefined;
 }
 
-function resolveTemplates(
-  authHeaders: Record<string, string>,
-  secrets: Record<string, string>,
-  vars: Record<string, string>,
-  authBase?: string,
-  authQuery?: Record<string, string>,
-): {
+interface ResolveTemplatesArgs {
+  readonly authHeaders: Record<string, string>;
+  readonly secrets: Record<string, string>;
+  readonly vars: Record<string, string>;
+  readonly authBase?: string;
+  readonly authQuery?: Record<string, string>;
+  readonly authAwsSigv4?: FirewallAwsSigv4AuthConfig;
+}
+
+function resolveTemplates(args: ResolveTemplatesArgs): {
   readonly headers: Record<string, string>;
   readonly resolvedSecrets: readonly string[];
   readonly base?: string;
   readonly query?: Record<string, string>;
+  readonly awsSigv4?: FirewallAwsSigv4AuthConfig;
 } {
   const resolvedKeys = new Set<string>();
 
@@ -3429,26 +3452,26 @@ function resolveTemplates(
       (_match, namespace: string, key: string) => {
         if (namespace === "secrets") {
           resolvedKeys.add(key);
-          return getOwnValue(secrets, key) ?? "";
+          return getOwnValue(args.secrets, key) ?? "";
         }
-        return getOwnValue(vars, key) ?? "";
+        return getOwnValue(args.vars, key) ?? "";
       },
     );
   };
 
   const headers: Record<string, string> = {};
-  for (const [name, template] of Object.entries(authHeaders)) {
+  for (const [name, template] of Object.entries(args.authHeaders)) {
     let resolved = replaceBasicAuthTemplates(template, (match) => {
       const user = resolveBasicArg({
         ...match.first,
-        secrets,
-        vars,
+        secrets: args.secrets,
+        vars: args.vars,
         resolvedKeys,
       });
       const pass = resolveBasicArg({
         ...match.second,
-        secrets,
-        vars,
+        secrets: args.secrets,
+        vars: args.vars,
         resolvedKeys,
       });
       return `Basic ${Buffer.from(`${user}:${pass}`).toString("base64")}`;
@@ -3457,13 +3480,28 @@ function resolveTemplates(
     headers[name] = resolved;
   }
 
-  const base = authBase ? resolveSimple(authBase) : undefined;
-  const query = authQuery
+  const base = args.authBase ? resolveSimple(args.authBase) : undefined;
+  const query = args.authQuery
     ? Object.fromEntries(
-        Object.entries(authQuery).map(([key, value]) => {
+        Object.entries(args.authQuery).map(([key, value]) => {
           return [key, resolveSimple(value)];
         }),
       )
+    : undefined;
+  const awsSigv4 = args.authAwsSigv4
+    ? ({
+        accessKeyId: resolveSimple(args.authAwsSigv4.accessKeyId),
+        secretAccessKey: resolveSimple(args.authAwsSigv4.secretAccessKey),
+        ...(args.authAwsSigv4.sessionToken
+          ? { sessionToken: resolveSimple(args.authAwsSigv4.sessionToken) }
+          : {}),
+        ...(args.authAwsSigv4.defaultRegion
+          ? { defaultRegion: resolveSimple(args.authAwsSigv4.defaultRegion) }
+          : {}),
+        ...(args.authAwsSigv4.defaultService
+          ? { defaultService: resolveSimple(args.authAwsSigv4.defaultService) }
+          : {}),
+      } satisfies FirewallAwsSigv4AuthConfig)
     : undefined;
 
   return {
@@ -3471,6 +3509,7 @@ function resolveTemplates(
     resolvedSecrets: [...resolvedKeys].sort(),
     base,
     query,
+    awsSigv4,
   };
 }
 
@@ -3566,13 +3605,14 @@ export async function resolveFirewallAuth(
     );
   }
 
-  const resolved = resolveTemplates(
-    body.authHeaders,
-    decryptedSecrets,
+  const resolved = resolveTemplates({
+    authHeaders: body.authHeaders,
+    secrets: decryptedSecrets,
     vars,
-    body.authBase,
-    body.authQuery,
-  );
+    authBase: body.authBase,
+    authQuery: body.authQuery,
+    authAwsSigv4: body.authAwsSigv4,
+  });
 
   return {
     status: 200,
@@ -3580,6 +3620,7 @@ export async function resolveFirewallAuth(
       headers: resolved.headers,
       base: resolved.base,
       query: resolved.query,
+      awsSigv4: resolved.awsSigv4,
       expiresAt: mergeExpiresAt(expiresAt, billableCacheExpiry.expiresAt),
       resolvedSecrets: resolved.resolvedSecrets,
       refreshedConnectors,

--- a/turbo/apps/api/src/signals/services/agent-webhook-firewall-auth.service.ts
+++ b/turbo/apps/api/src/signals/services/agent-webhook-firewall-auth.service.ts
@@ -3505,6 +3505,17 @@ function resolveTemplates(args: ResolveTemplatesArgs): {
   };
 }
 
+function hasEmptyAwsSigv4Credential(
+  credentials: FirewallAwsSigv4AuthConfig | undefined,
+): boolean {
+  return (
+    credentials !== undefined &&
+    (credentials.accessKeyId === "" ||
+      credentials.secretAccessKey === "" ||
+      credentials.sessionToken === "")
+  );
+}
+
 export async function resolveFirewallAuth(
   db: Db,
   auth: SandboxAuth,
@@ -3605,6 +3616,9 @@ export async function resolveFirewallAuth(
     authQuery: body.authQuery,
     authAwsSigv4: body.authAwsSigv4,
   });
+  if (hasEmptyAwsSigv4Credential(resolved.awsSigv4)) {
+    return connectorNotConfigured();
+  }
 
   return {
     status: 200,

--- a/turbo/packages/api-contracts/src/contracts/webhooks.ts
+++ b/turbo/packages/api-contracts/src/contracts/webhooks.ts
@@ -212,13 +212,13 @@ const firewallAuthErrorSchema = z.object({
   }),
 });
 
-const firewallAwsSigv4AuthSchema = z.object({
-  accessKeyId: z.string().min(1),
-  secretAccessKey: z.string().min(1),
-  sessionToken: z.string().min(1).optional(),
-  defaultRegion: z.string().min(1).optional(),
-  defaultService: z.string().min(1).optional(),
-});
+const firewallAwsSigv4AuthSchema = z
+  .object({
+    accessKeyId: z.string().min(1),
+    secretAccessKey: z.string().min(1),
+    sessionToken: z.string().min(1).optional(),
+  })
+  .strict();
 
 const firewallAuthResponseSchema = z.object({
   headers: z.record(z.string(), z.string()),

--- a/turbo/packages/api-contracts/src/contracts/webhooks.ts
+++ b/turbo/packages/api-contracts/src/contracts/webhooks.ts
@@ -212,10 +212,19 @@ const firewallAuthErrorSchema = z.object({
   }),
 });
 
+const firewallAwsSigv4AuthSchema = z.object({
+  accessKeyId: z.string().min(1),
+  secretAccessKey: z.string().min(1),
+  sessionToken: z.string().min(1).optional(),
+  defaultRegion: z.string().min(1).optional(),
+  defaultService: z.string().min(1).optional(),
+});
+
 const firewallAuthResponseSchema = z.object({
   headers: z.record(z.string(), z.string()),
   base: z.string().optional(),
   query: z.record(z.string(), z.string()).optional(),
+  awsSigv4: firewallAwsSigv4AuthSchema.optional(),
   // Effective addon cache expiry as Unix seconds. Access token expiry is the
   // normal source; billable firewall auth can shorten it to force credit
   // re-authorization. Null means non-expiring only for non-billable auth.
@@ -241,6 +250,7 @@ export const webhookFirewallAuthContract = c.router({
       authHeaders: z.record(z.string(), z.string()),
       authBase: z.string().optional(),
       authQuery: z.record(z.string(), z.string()).optional(),
+      authAwsSigv4: firewallAwsSigv4AuthSchema.optional(),
       // Maps firewall auth secret env aliases (the `NAME` in `${{ secrets.NAME }}`)
       // to the connector or provider owner that can refresh/resolve access.
       secretConnectorMap: z.record(z.string(), z.string()).optional(),

--- a/turbo/packages/connectors/src/__tests__/firewall-auth-base.test.ts
+++ b/turbo/packages/connectors/src/__tests__/firewall-auth-base.test.ts
@@ -120,8 +120,6 @@ describe("extractSecretNamesFromApis with auth.base and auth.query", () => {
             accessKeyId: "${{ secrets.AWS_ACCESS_KEY_ID }}",
             secretAccessKey: "${{ secrets.AWS_SECRET_ACCESS_KEY }}",
             sessionToken: "${{ secrets.AWS_SESSION_TOKEN }}",
-            defaultRegion: "${{ vars.AWS_REGION }}",
-            defaultService: "sts",
           },
         },
       },
@@ -138,7 +136,7 @@ describe("extractSecretNamesFromApis with auth.base and auth.query", () => {
         "AWS_SECRET_ACCESS_KEY",
         "AWS_SESSION_TOKEN",
       ],
-      vars: ["AWS_REGION"],
+      vars: [],
     });
   });
 

--- a/turbo/packages/connectors/src/__tests__/firewall-auth-base.test.ts
+++ b/turbo/packages/connectors/src/__tests__/firewall-auth-base.test.ts
@@ -140,6 +140,27 @@ describe("extractSecretNamesFromApis with auth.base and auth.query", () => {
     });
   });
 
+  it("extracts vars from auth.awsSigv4 references", () => {
+    const apis = [
+      {
+        base: "https://sts.amazonaws.com",
+        auth: {
+          headers: {},
+          awsSigv4: {
+            accessKeyId: "${{ vars.AWS_ACCESS_KEY_ID }}",
+            secretAccessKey: "${{ secrets.AWS_SECRET_ACCESS_KEY }}",
+          },
+        },
+      },
+    ];
+
+    expect(extractSecretNamesFromApis(apis)).toEqual(["AWS_SECRET_ACCESS_KEY"]);
+    expect(extractFirewallTemplateReferences(apis)).toStrictEqual({
+      secrets: ["AWS_SECRET_ACCESS_KEY"],
+      vars: ["AWS_ACCESS_KEY_ID"],
+    });
+  });
+
   it("skips auth.query when not present", () => {
     const apis = [
       {

--- a/turbo/packages/connectors/src/__tests__/firewall-auth-base.test.ts
+++ b/turbo/packages/connectors/src/__tests__/firewall-auth-base.test.ts
@@ -110,6 +110,38 @@ describe("extractSecretNamesFromApis with auth.base and auth.query", () => {
     expect(result).toHaveLength(2);
   });
 
+  it("extracts secrets from auth.awsSigv4", () => {
+    const apis = [
+      {
+        base: "https://sts.amazonaws.com",
+        auth: {
+          headers: {},
+          awsSigv4: {
+            accessKeyId: "${{ secrets.AWS_ACCESS_KEY_ID }}",
+            secretAccessKey: "${{ secrets.AWS_SECRET_ACCESS_KEY }}",
+            sessionToken: "${{ secrets.AWS_SESSION_TOKEN }}",
+            defaultRegion: "${{ vars.AWS_REGION }}",
+            defaultService: "sts",
+          },
+        },
+      },
+    ];
+
+    expect(extractSecretNamesFromApis(apis)).toEqual([
+      "AWS_ACCESS_KEY_ID",
+      "AWS_SECRET_ACCESS_KEY",
+      "AWS_SESSION_TOKEN",
+    ]);
+    expect(extractFirewallTemplateReferences(apis)).toStrictEqual({
+      secrets: [
+        "AWS_ACCESS_KEY_ID",
+        "AWS_SECRET_ACCESS_KEY",
+        "AWS_SESSION_TOKEN",
+      ],
+      vars: ["AWS_REGION"],
+    });
+  });
+
   it("skips auth.query when not present", () => {
     const apis = [
       {

--- a/turbo/packages/connectors/src/__tests__/firewall-rule-matcher.test.ts
+++ b/turbo/packages/connectors/src/__tests__/firewall-rule-matcher.test.ts
@@ -1249,6 +1249,64 @@ describe("findMatchingPermissions", () => {
     ).toEqual([]);
   });
 
+  it("accepts awsSigv4 auth configs", () => {
+    const config: FirewallConfig = {
+      name: "aws",
+      apis: [
+        {
+          base: "https://sts.amazonaws.com",
+          auth: {
+            headers: {},
+            awsSigv4: {
+              accessKeyId: "${{ secrets.AWS_ACCESS_KEY_ID }}",
+              secretAccessKey: "${{ secrets.AWS_SECRET_ACCESS_KEY }}",
+              sessionToken: "${{ secrets.AWS_SESSION_TOKEN }}",
+              defaultRegion: "${{ vars.AWS_REGION }}",
+              defaultService: "sts",
+            },
+          },
+          permissions: [{ name: "identity", rules: ["GET /"] }],
+        },
+      ],
+    };
+
+    expect(findMatchingPermissions("GET", "/", config)).toEqual(["identity"]);
+  });
+
+  it("ignores malformed awsSigv4 auth configs", () => {
+    const config: FirewallConfig = {
+      name: "aws",
+      apis: [
+        {
+          base: "https://sts.amazonaws.com",
+          auth: {
+            headers: {
+              Authorization: "Bearer ${{ secrets.TOKEN }}",
+            },
+            awsSigv4: {
+              accessKeyId: "${{ secrets.AWS_ACCESS_KEY_ID }}",
+              secretAccessKey: "${{ secrets.AWS_SECRET_ACCESS_KEY }}",
+            },
+          },
+          permissions: [{ name: "mixed", rules: ["GET /"] }],
+        },
+        {
+          base: "https://iam.amazonaws.com",
+          auth: {
+            headers: {},
+            awsSigv4: {
+              accessKeyId: "${{ secrets.AWS_ACCESS_KEY_ID }}",
+              secretAccessKey: "",
+            },
+          },
+          permissions: [{ name: "missing", rules: ["GET /"] }],
+        },
+      ],
+    };
+
+    expect(findMatchingPermissions("GET", "/", config)).toEqual([]);
+  });
+
   it("ignores malformed top-level firewall shapes", () => {
     const nullConfig = null as unknown as FirewallConfig;
     const arrayConfig = [] as unknown as FirewallConfig;

--- a/turbo/packages/connectors/src/__tests__/firewall-rule-matcher.test.ts
+++ b/turbo/packages/connectors/src/__tests__/firewall-rule-matcher.test.ts
@@ -1261,8 +1261,6 @@ describe("findMatchingPermissions", () => {
               accessKeyId: "${{ secrets.AWS_ACCESS_KEY_ID }}",
               secretAccessKey: "${{ secrets.AWS_SECRET_ACCESS_KEY }}",
               sessionToken: "${{ secrets.AWS_SESSION_TOKEN }}",
-              defaultRegion: "${{ vars.AWS_REGION }}",
-              defaultService: "sts",
             },
           },
           permissions: [{ name: "identity", rules: ["GET /"] }],
@@ -1303,6 +1301,27 @@ describe("findMatchingPermissions", () => {
         },
       ],
     };
+
+    expect(findMatchingPermissions("GET", "/", config)).toEqual([]);
+  });
+
+  it("ignores awsSigv4 auth configs with unsupported defaults", () => {
+    const config: FirewallConfig = {
+      name: "aws",
+      apis: [
+        {
+          base: "https://sts.amazonaws.com",
+          auth: {
+            awsSigv4: {
+              accessKeyId: "${{ secrets.AWS_ACCESS_KEY_ID }}",
+              secretAccessKey: "${{ secrets.AWS_SECRET_ACCESS_KEY }}",
+              defaultRegion: "${{ vars.AWS_REGION }}",
+            },
+          },
+          permissions: [{ name: "identity", rules: ["GET /"] }],
+        },
+      ],
+    } as unknown as FirewallConfig;
 
     expect(findMatchingPermissions("GET", "/", config)).toEqual([]);
   });

--- a/turbo/packages/connectors/src/firewall-rule-matcher.ts
+++ b/turbo/packages/connectors/src/firewall-rule-matcher.ts
@@ -234,7 +234,11 @@ function isValidAwsSigv4AuthConfig(value: unknown): boolean {
     "secretAccessKey",
     "sessionToken",
   ]);
-  if (Object.keys(value).some((key) => !allowedKeys.has(key))) {
+  if (
+    Object.keys(value).some((key) => {
+      return !allowedKeys.has(key);
+    })
+  ) {
     return false;
   }
   if (typeof value.accessKeyId !== "string" || value.accessKeyId === "") {

--- a/turbo/packages/connectors/src/firewall-rule-matcher.ts
+++ b/turbo/packages/connectors/src/firewall-rule-matcher.ts
@@ -223,14 +223,60 @@ function isStringRecord(value: unknown): value is Record<string, string> {
   });
 }
 
+function hasEntries(value: Record<string, string> | undefined): boolean {
+  return value !== undefined && Object.keys(value).length > 0;
+}
+
+function isValidAwsSigv4AuthConfig(value: unknown): boolean {
+  if (!isObjectRecord(value)) return false;
+  if (typeof value.accessKeyId !== "string" || value.accessKeyId === "") {
+    return false;
+  }
+  if (
+    typeof value.secretAccessKey !== "string" ||
+    value.secretAccessKey === ""
+  ) {
+    return false;
+  }
+  for (const optionalKey of [
+    "sessionToken",
+    "defaultRegion",
+    "defaultService",
+  ]) {
+    const optionalValue = value[optionalKey];
+    if (
+      optionalValue !== undefined &&
+      (typeof optionalValue !== "string" || optionalValue === "")
+    ) {
+      return false;
+    }
+  }
+  return true;
+}
+
 function isValidAuthConfig(auth: unknown, serviceName: string): boolean {
   if (!isObjectRecord(auth)) return false;
   if (auth.headers !== undefined && !isStringRecord(auth.headers)) return false;
+  if (auth.query !== undefined && !isStringRecord(auth.query)) return false;
+  if (
+    auth.awsSigv4 !== undefined &&
+    !isValidAwsSigv4AuthConfig(auth.awsSigv4)
+  ) {
+    return false;
+  }
+  if (auth.awsSigv4 !== undefined) {
+    if (hasEntries(auth.headers as Record<string, string> | undefined)) {
+      return false;
+    }
+    if (hasEntries(auth.query as Record<string, string> | undefined)) {
+      return false;
+    }
+  }
   if (auth.base !== undefined) {
     if (typeof auth.base !== "string") return false;
     validateAuthBaseUrl(auth.base, serviceName);
   }
-  return auth.query === undefined || isStringRecord(auth.query);
+  return true;
 }
 
 function isValidApiEntry(

--- a/turbo/packages/connectors/src/firewall-rule-matcher.ts
+++ b/turbo/packages/connectors/src/firewall-rule-matcher.ts
@@ -229,6 +229,14 @@ function hasEntries(value: Record<string, string> | undefined): boolean {
 
 function isValidAwsSigv4AuthConfig(value: unknown): boolean {
   if (!isObjectRecord(value)) return false;
+  const allowedKeys = new Set([
+    "accessKeyId",
+    "secretAccessKey",
+    "sessionToken",
+  ]);
+  if (Object.keys(value).some((key) => !allowedKeys.has(key))) {
+    return false;
+  }
   if (typeof value.accessKeyId !== "string" || value.accessKeyId === "") {
     return false;
   }
@@ -238,18 +246,12 @@ function isValidAwsSigv4AuthConfig(value: unknown): boolean {
   ) {
     return false;
   }
-  for (const optionalKey of [
-    "sessionToken",
-    "defaultRegion",
-    "defaultService",
-  ]) {
-    const optionalValue = value[optionalKey];
-    if (
-      optionalValue !== undefined &&
-      (typeof optionalValue !== "string" || optionalValue === "")
-    ) {
-      return false;
-    }
+  const optionalValue = value.sessionToken;
+  if (
+    optionalValue !== undefined &&
+    (typeof optionalValue !== "string" || optionalValue === "")
+  ) {
+    return false;
   }
   return true;
 }

--- a/turbo/packages/connectors/src/firewall-types.ts
+++ b/turbo/packages/connectors/src/firewall-types.ts
@@ -23,16 +23,47 @@ export const firewallPermissionSchema = z.object({
   rules: z.array(z.string()),
 });
 
+export const firewallAwsSigv4AuthSchema = z.object({
+  accessKeyId: z.string().min(1),
+  secretAccessKey: z.string().min(1),
+  sessionToken: z.string().min(1).optional(),
+  defaultRegion: z.string().min(1).optional(),
+  defaultService: z.string().min(1).optional(),
+});
+
+const firewallAuthSchema = z
+  .object({
+    headers: z.record(z.string(), z.string()).optional(),
+    base: z.string().optional(),
+    query: z.record(z.string(), z.string()).optional(),
+    awsSigv4: firewallAwsSigv4AuthSchema.optional(),
+  })
+  .superRefine((auth, ctx) => {
+    if (!auth.awsSigv4) {
+      return;
+    }
+    if (auth.headers && Object.keys(auth.headers).length > 0) {
+      ctx.addIssue({
+        code: "custom",
+        path: ["headers"],
+        message: "auth.headers cannot be combined with auth.awsSigv4",
+      });
+    }
+    if (auth.query && Object.keys(auth.query).length > 0) {
+      ctx.addIssue({
+        code: "custom",
+        path: ["query"],
+        message: "auth.query cannot be combined with auth.awsSigv4",
+      });
+    }
+  });
+
 /**
  * Firewall API entry — a base URL with optional auth headers/query/base and permissions.
  */
 export const firewallApiSchema = z.object({
   base: z.string(),
-  auth: z.object({
-    headers: z.record(z.string(), z.string()).optional(),
-    base: z.string().optional(),
-    query: z.record(z.string(), z.string()).optional(),
-  }),
+  auth: firewallAuthSchema,
   permissions: z.array(firewallPermissionSchema).optional(),
 });
 
@@ -523,6 +554,14 @@ export function extractSecretNamesFromApis(
         }
       }
     }
+    if (entry.auth.awsSigv4) {
+      for (const value of Object.values(entry.auth.awsSigv4)) {
+        if (!value) continue;
+        for (const match of value.matchAll(AUTH_SECRET_PATTERN)) {
+          names.add(match[1]!);
+        }
+      }
+    }
   }
   return [...names];
 }
@@ -568,6 +607,11 @@ export function extractFirewallTemplateReferences(
     }
     for (const value of Object.values(entry.auth.query ?? {})) {
       collectFirewallTemplateReferencesFromValue(value, references);
+    }
+    for (const value of Object.values(entry.auth.awsSigv4 ?? {})) {
+      if (value) {
+        collectFirewallTemplateReferencesFromValue(value, references);
+      }
     }
   }
 

--- a/turbo/packages/connectors/src/firewall-types.ts
+++ b/turbo/packages/connectors/src/firewall-types.ts
@@ -23,13 +23,13 @@ export const firewallPermissionSchema = z.object({
   rules: z.array(z.string()),
 });
 
-export const firewallAwsSigv4AuthSchema = z.object({
-  accessKeyId: z.string().min(1),
-  secretAccessKey: z.string().min(1),
-  sessionToken: z.string().min(1).optional(),
-  defaultRegion: z.string().min(1).optional(),
-  defaultService: z.string().min(1).optional(),
-});
+export const firewallAwsSigv4AuthSchema = z
+  .object({
+    accessKeyId: z.string().min(1),
+    secretAccessKey: z.string().min(1),
+    sessionToken: z.string().min(1).optional(),
+  })
+  .strict();
 
 const firewallAuthSchema = z
   .object({

--- a/turbo/packages/connectors/src/firewalls/index.ts
+++ b/turbo/packages/connectors/src/firewalls/index.ts
@@ -723,8 +723,8 @@ export function groupPermissionsByCategory<T extends { name: string }>(
  */
 export type NonFirewallConnectorType =
   // Signature-based auth — requires computing signatures, not simple header injection
-  // AWS is feature-gated while SigV4 firewall auth is pending; do not treat it
-  // as a full firewall connector until request signing is handled by firewall auth.
+  // AWS SigV4 signing is supported by firewall auth, but AWS stays out of the
+  // builtin firewall registry until a reviewed AWS firewall config is added.
   | "aws"
   | "cloudinary" // SHA signature in form body + api_key param
   | "minio" // AWS Signature V4


### PR DESCRIPTION
## Summary

- add a typed `auth.awsSigv4` firewall auth variant and API `/firewall/auth` request/response payloads
- resolve/refresh AWS signing credential templates in the API and carry structured credentials through the mitm auth cache
- add proxy-side HMAC SigV4/S3v4 header and query re-signing with fail-closed handling for SigV4A, S3 Express, malformed auth, missing placeholder signatures, and streaming payloads
- keep AWS as a non-firewall connector until the remaining SigV4-family modes are intentionally supported

Refs #16809

## Tests

- `cd turbo && pnpm -F @vm0/connectors exec vitest src/__tests__/firewall-auth-base.test.ts src/__tests__/firewall-rule-matcher.test.ts`
- `cd turbo && pnpm -F api exec vitest src/signals/routes/__tests__/webhooks-agent-firewall-auth.test.ts`
- `cd turbo && pnpm -F @vm0/connectors lint`
- `cd turbo && pnpm -F @vm0/connectors check-types`
- `cd turbo && pnpm -F @vm0/api-contracts lint`
- `cd turbo && pnpm -F @vm0/api-contracts check-types`
- `cd turbo && pnpm -F api lint`
- `cd turbo && pnpm -F api check-types`
- `cd crates/runner/mitm-addon && python3 -m ruff check src/aws_sigv4.py src/auth.py src/matching.py tests/test_firewall_aws_sigv4_auth.py tests/test_firewall_auth.py tests/test_firewall_matching.py tests/test_firewall_rewrite_forwarding.py`
- `cd crates/runner/mitm-addon && python3 -m ruff format --check src/aws_sigv4.py src/auth.py src/matching.py tests/test_firewall_aws_sigv4_auth.py tests/test_firewall_auth.py tests/test_firewall_matching.py tests/test_firewall_rewrite_forwarding.py`
- `cd crates/runner/mitm-addon && python3 -m pytest tests/test_firewall_auth.py tests/test_firewall_aws_sigv4_auth.py tests/test_firewall_matching.py tests/test_firewall_rewrite_forwarding.py`
- pre-commit: `cd turbo && pnpm check-types` via lefthook
