### PR TITLE
docs: document idna hostname normalization policy

### DIFF
--- a/crates/runner/mitm-addon/src/host_normalization.py
+++ b/crates/runner/mitm-addon/src/host_normalization.py
@@ -391,10 +391,10 @@ def _normalize_label(label: str) -> str:
 def normalize_idna_label(label: str) -> str:
     """Normalize one hostname label with vm0's shared IDNA policy.
 
-    Returns a lowercase ASCII label under this policy. Non-ASCII input is
-    returned as canonical ``xn--`` A-labels. The function accepts exactly one
-    label; it does not split hostnames, translate IDNA dot variants, or remove
-    trailing dots.
+    Returns a lowercase ASCII label under this policy. Accepted non-ASCII input
+    is returned as a canonical ``xn--`` A-label. The function accepts exactly
+    one label; it does not split hostnames, translate IDNA dot variants, or
+    remove trailing dots.
 
     Raises ``UnsafeIdnaCompatibilityMappingError`` when direct Unicode input
     would obscure the label's host identity. Raises ``UnicodeError`` for
@@ -408,10 +408,10 @@ def normalize_idna_label(label: str) -> str:
 def normalize_idna_hostname(host: str) -> str:
     """Normalize one hostname with vm0's shared IDNA policy.
 
-    Returns a dot-separated lowercase ASCII host identity. Unicode labels are
-    returned as canonical ``xn--`` A-labels. For non-IPv4 hostnames, IDNA dot
-    variants are translated to ASCII ``.`` and one optional trailing dot is
-    removed. Empty hostnames raise ``ValueError``; empty labels, multiple
+    Returns a dot-separated lowercase ASCII host identity. Accepted Unicode
+    labels are returned as canonical ``xn--`` A-labels. For non-IPv4 hostnames,
+    IDNA dot variants are translated to ASCII ``.`` and one optional trailing dot
+    is removed. Empty hostnames raise ``ValueError``; empty labels, multiple
     trailing dots, and invalid labels raise ``UnicodeError``. Direct Unicode
     unsafe compatibility aliases raise ``UnsafeIdnaCompatibilityMappingError``,
     a ``UnicodeError`` subclass; invalid or non-canonical A-labels raise

--- a/crates/runner/mitm-addon/src/host_normalization.py
+++ b/crates/runner/mitm-addon/src/host_normalization.py
@@ -396,11 +396,11 @@ def normalize_idna_label(label: str) -> str:
     label; it does not split hostnames, translate IDNA dot variants, or remove
     trailing dots.
 
-    Raises ``UnsafeIdnaCompatibilityMappingError`` when compatibility processing
+    Raises ``UnsafeIdnaCompatibilityMappingError`` when direct Unicode input
     would obscure the label's host identity. Raises ``UnicodeError`` for
-    ordinary invalid labels, including empty labels, invalid A-labels, labels
-    that normalize to forbidden text, and labels that exceed the DNS label
-    length limit.
+    ordinary invalid labels, including empty labels, invalid or non-canonical
+    A-labels, labels that normalize to forbidden text, and labels that exceed
+    the DNS label length limit.
     """
     return _normalize_label(label)
 
@@ -412,8 +412,9 @@ def normalize_idna_hostname(host: str) -> str:
     returned as canonical ``xn--`` A-labels. IDNA dot variants are translated to
     ASCII ``.``, and one optional trailing dot is removed. Empty hostnames raise
     ``ValueError``; empty labels, multiple trailing dots, and invalid labels
-    raise ``UnicodeError``. Unsafe compatibility aliases raise
-    ``UnsafeIdnaCompatibilityMappingError``, a ``UnicodeError`` subclass.
+    raise ``UnicodeError``. Direct Unicode unsafe compatibility aliases raise
+    ``UnsafeIdnaCompatibilityMappingError``, a ``UnicodeError`` subclass;
+    invalid or non-canonical A-labels raise ordinary ``UnicodeError``.
 
     IPv4-literal-like input is accepted only when it is already a canonical
     dotted quad: four decimal octets, ASCII dots, no non-decimal forms, no

--- a/crates/runner/mitm-addon/src/host_normalization.py
+++ b/crates/runner/mitm-addon/src/host_normalization.py
@@ -409,12 +409,13 @@ def normalize_idna_hostname(host: str) -> str:
     """Normalize one hostname with vm0's shared IDNA policy.
 
     Returns a dot-separated lowercase ASCII host identity. Unicode labels are
-    returned as canonical ``xn--`` A-labels. IDNA dot variants are translated to
-    ASCII ``.``, and one optional trailing dot is removed. Empty hostnames raise
-    ``ValueError``; empty labels, multiple trailing dots, and invalid labels
-    raise ``UnicodeError``. Direct Unicode unsafe compatibility aliases raise
-    ``UnsafeIdnaCompatibilityMappingError``, a ``UnicodeError`` subclass;
-    invalid or non-canonical A-labels raise ordinary ``UnicodeError``.
+    returned as canonical ``xn--`` A-labels. For non-IPv4 hostnames, IDNA dot
+    variants are translated to ASCII ``.`` and one optional trailing dot is
+    removed. Empty hostnames raise ``ValueError``; empty labels, multiple
+    trailing dots, and invalid labels raise ``UnicodeError``. Direct Unicode
+    unsafe compatibility aliases raise ``UnsafeIdnaCompatibilityMappingError``,
+    a ``UnicodeError`` subclass; invalid or non-canonical A-labels raise
+    ordinary ``UnicodeError``.
 
     IPv4-literal-like input is accepted only when it is already a canonical
     dotted quad: four decimal octets, ASCII dots, no non-decimal forms, no

--- a/crates/runner/mitm-addon/src/host_normalization.py
+++ b/crates/runner/mitm-addon/src/host_normalization.py
@@ -3,7 +3,7 @@
 This module defines the ASCII identity used when untrusted SNI/Host input is
 validated before firewall auth injection, when firewall bases are matched, and
 when X billing detects URL-like bare domains. It is intentionally stricter than
-generic compatibility normalization: labels that would fold into another host
+generic compatibility normalization: labels that would fold or obscure host
 identity are rejected instead of being treated as equivalent.
 
 The public helpers document caller-visible behavior only. Private tables and
@@ -112,13 +112,13 @@ _UNSAFE_UTS46_IGNORABLE_RANGES = (
 
 
 class UnsafeIdnaCompatibilityMappingError(UnicodeError):
-    """Raised when unsafe IDNA compatibility mapping would collapse identity.
+    """Raised when unsafe IDNA compatibility mapping would obscure identity.
 
     This is not an ordinary malformed-label signal. It marks input that can look
-    URL-like after compatibility processing but would fold into a different
-    ASCII/IDNA hostname. Security callers should reject it as invalid authority;
-    conservative billing callers may catch it before generic ``UnicodeError``
-    and classify the candidate as ambiguous.
+    URL-like after compatibility processing but would fold into, disappear from,
+    or be confused with a different ASCII/IDNA hostname. Security callers should
+    reject it as invalid authority; conservative billing callers may catch it
+    before generic ``UnicodeError`` and classify the candidate as ambiguous.
     """
 
 
@@ -397,10 +397,10 @@ def normalize_idna_label(label: str) -> str:
     trailing dots.
 
     Raises ``UnsafeIdnaCompatibilityMappingError`` when compatibility processing
-    would collapse the label into another host identity. Raises ``UnicodeError``
-    for ordinary invalid labels, including empty labels, invalid A-labels,
-    labels that normalize to forbidden text, and labels that exceed the DNS
-    label length limit.
+    would obscure the label's host identity. Raises ``UnicodeError`` for
+    ordinary invalid labels, including empty labels, invalid A-labels, labels
+    that normalize to forbidden text, and labels that exceed the DNS label
+    length limit.
     """
     return _normalize_label(label)
 

--- a/crates/runner/mitm-addon/src/host_normalization.py
+++ b/crates/runner/mitm-addon/src/host_normalization.py
@@ -410,8 +410,9 @@ def normalize_idna_hostname(host: str) -> str:
     Returns a dot-separated lowercase ASCII hostname. Unicode labels are
     returned as canonical ``xn--`` A-labels. IDNA dot variants are translated to
     ASCII ``.``, and one optional trailing dot is removed. Empty hostnames raise
-    ``ValueError``; empty labels, multiple trailing dots, invalid labels, and
-    unsafe compatibility aliases raise ``UnicodeError``.
+    ``ValueError``; empty labels, multiple trailing dots, and invalid labels
+    raise ``UnicodeError``. Unsafe compatibility aliases raise
+    ``UnsafeIdnaCompatibilityMappingError``, a ``UnicodeError`` subclass.
 
     IPv4-literal-like input is accepted only when it is already a canonical
     dotted quad: four decimal octets, no non-decimal forms, no leading zeroes

--- a/crates/runner/mitm-addon/src/host_normalization.py
+++ b/crates/runner/mitm-addon/src/host_normalization.py
@@ -391,9 +391,10 @@ def _normalize_label(label: str) -> str:
 def normalize_idna_label(label: str) -> str:
     """Normalize one hostname label with vm0's shared IDNA policy.
 
-    Returns a lowercase ASCII DNS label. Non-ASCII labels are returned as
-    canonical ``xn--`` A-labels. The function accepts exactly one label; it does
-    not split hostnames, translate IDNA dot variants, or remove trailing dots.
+    Returns a lowercase ASCII label under this policy. Non-ASCII input is
+    returned as canonical ``xn--`` A-labels. The function accepts exactly one
+    label; it does not split hostnames, translate IDNA dot variants, or remove
+    trailing dots.
 
     Raises ``UnsafeIdnaCompatibilityMappingError`` when compatibility processing
     would collapse the label into another host identity. Raises ``UnicodeError``
@@ -407,7 +408,7 @@ def normalize_idna_label(label: str) -> str:
 def normalize_idna_hostname(host: str) -> str:
     """Normalize one hostname with vm0's shared IDNA policy.
 
-    Returns a dot-separated lowercase ASCII hostname. Unicode labels are
+    Returns a dot-separated lowercase ASCII host identity. Unicode labels are
     returned as canonical ``xn--`` A-labels. IDNA dot variants are translated to
     ASCII ``.``, and one optional trailing dot is removed. Empty hostnames raise
     ``ValueError``; empty labels, multiple trailing dots, and invalid labels
@@ -416,10 +417,9 @@ def normalize_idna_hostname(host: str) -> str:
 
     IPv4-literal-like input is accepted only when it is already a canonical
     dotted quad: four decimal octets, ASCII dots, no non-decimal forms, no
-    leading zeroes except ``0``, and each octet at most 255. One trailing ASCII
-    dot is allowed, but IDNA dot variants inside an IPv4-literal-like spelling
-    are non-canonical. Other IPv4-literal-like spellings raise ``UnicodeError``
-    instead of being normalized to a different address.
+    leading zeroes except ``0``, and each octet at most 255. One trailing dot is
+    allowed only when it is also an ASCII dot. Other IPv4-literal-like spellings
+    raise ``UnicodeError`` instead of being normalized to a different address.
 
     Python's built-in codec is IDNA2003 and maps labels such as ``faß`` to
     ``fass``. WHATWG URL parsing keeps those as A-labels instead, so this helper

--- a/crates/runner/mitm-addon/src/host_normalization.py
+++ b/crates/runner/mitm-addon/src/host_normalization.py
@@ -1,4 +1,14 @@
-"""Shared hostname normalization helpers."""
+"""Shared hostname identity policy for MITM authority, firewall, and billing flows.
+
+This module defines the ASCII identity used when untrusted SNI/Host input is
+validated before firewall auth injection, when firewall bases are matched, and
+when X billing detects URL-like bare domains. It is intentionally stricter than
+generic compatibility normalization: labels that would fold into another host
+identity are rejected instead of being treated as equivalent.
+
+The public helpers document caller-visible behavior only. Private tables and
+normalization steps are implementation details, not a complete WHATWG/IDNA API.
+"""
 
 from unicodedata import bidirectional, category, normalize
 
@@ -102,7 +112,14 @@ _UNSAFE_UTS46_IGNORABLE_RANGES = (
 
 
 class UnsafeIdnaCompatibilityMappingError(UnicodeError):
-    """Raised when IDNA normalization would fold an unsafe compatibility alias."""
+    """Raised when unsafe IDNA compatibility mapping would collapse identity.
+
+    This is not an ordinary malformed-label signal. It marks input that can look
+    URL-like after compatibility processing but would fold into a different
+    ASCII/IDNA hostname. Security callers should reject it as invalid authority;
+    conservative billing callers may catch it before generic ``UnicodeError``
+    and classify the candidate as ambiguous.
+    """
 
 
 def _is_ascii(value: str) -> bool:
@@ -372,16 +389,38 @@ def _normalize_label(label: str) -> str:
 
 
 def normalize_idna_label(label: str) -> str:
-    """Normalize one hostname label with the shared IDNA policy."""
+    """Normalize one hostname label with vm0's shared IDNA policy.
+
+    Returns a lowercase ASCII DNS label. Non-ASCII labels are returned as
+    canonical ``xn--`` A-labels. The function accepts exactly one label; it does
+    not split hostnames, translate IDNA dot variants, or remove trailing dots.
+
+    Raises ``UnsafeIdnaCompatibilityMappingError`` when compatibility processing
+    would collapse the label into another host identity. Raises ``UnicodeError``
+    for ordinary invalid labels, including empty labels, invalid A-labels,
+    labels that normalize to forbidden text, and labels that exceed the DNS
+    label length limit.
+    """
     return _normalize_label(label)
 
 
 def normalize_idna_hostname(host: str) -> str:
-    """Normalize hostnames without accepting ASCII-only compatibility aliases.
+    """Normalize one hostname with vm0's shared IDNA policy.
+
+    Returns a dot-separated lowercase ASCII hostname. Unicode labels are
+    returned as canonical ``xn--`` A-labels. IDNA dot variants are translated to
+    ASCII ``.``, and one optional trailing dot is removed. Empty hostnames raise
+    ``ValueError``; empty labels, multiple trailing dots, invalid labels, and
+    unsafe compatibility aliases raise ``UnicodeError``.
+
+    IPv4-literal-like input is accepted only when it is already a canonical
+    dotted quad: four decimal octets, no non-decimal forms, no leading zeroes
+    except ``0``, and each octet at most 255. Other IPv4-literal-like spellings
+    raise ``UnicodeError`` instead of being normalized to a different address.
 
     Python's built-in codec is IDNA2003 and maps labels such as ``faß`` to
-    ``fass``.  WHATWG URL parsing keeps those as A-labels instead, so encode
-    non-ASCII labels directly and reject compatibility folds that collapse to a
+    ``fass``. WHATWG URL parsing keeps those as A-labels instead, so this helper
+    encodes non-ASCII labels and rejects compatibility folds that collapse to a
     plain ASCII label such as fullwidth Latin text.
     """
     normalized = _normalize_hostname_dots(host)

--- a/crates/runner/mitm-addon/src/host_normalization.py
+++ b/crates/runner/mitm-addon/src/host_normalization.py
@@ -425,8 +425,9 @@ def normalize_idna_hostname(host: str) -> str:
 
     Python's built-in codec is IDNA2003 and maps labels such as ``faß`` to
     ``fass``. WHATWG URL parsing keeps those as A-labels instead, so this helper
-    encodes non-ASCII labels and rejects compatibility folds that collapse to a
-    plain ASCII label such as fullwidth Latin text.
+    encodes accepted non-ASCII labels and rejects unsafe compatibility mappings
+    that would obscure host identity, including folds to plain ASCII labels such
+    as fullwidth Latin text.
     """
     normalized = _normalize_hostname_dots(host)
     if not normalized:

--- a/crates/runner/mitm-addon/src/host_normalization.py
+++ b/crates/runner/mitm-addon/src/host_normalization.py
@@ -415,9 +415,11 @@ def normalize_idna_hostname(host: str) -> str:
     ``UnsafeIdnaCompatibilityMappingError``, a ``UnicodeError`` subclass.
 
     IPv4-literal-like input is accepted only when it is already a canonical
-    dotted quad: four decimal octets, no non-decimal forms, no leading zeroes
-    except ``0``, and each octet at most 255. Other IPv4-literal-like spellings
-    raise ``UnicodeError`` instead of being normalized to a different address.
+    dotted quad: four decimal octets, ASCII dots, no non-decimal forms, no
+    leading zeroes except ``0``, and each octet at most 255. One trailing ASCII
+    dot is allowed, but IDNA dot variants inside an IPv4-literal-like spelling
+    are non-canonical. Other IPv4-literal-like spellings raise ``UnicodeError``
+    instead of being normalized to a different address.
 
     Python's built-in codec is IDNA2003 and maps labels such as ``faß`` to
     ``fass``. WHATWG URL parsing keeps those as A-labels instead, so this helper


### PR DESCRIPTION
## Summary

- Expand `host_normalization.py` module docs to describe the shared MITM hostname identity policy.
- Document `UnsafeIdnaCompatibilityMappingError` as the compatibility-alias signal that security paths reject and billing can classify as ambiguous.
- Document label and hostname normalization contracts, including returned forms, trailing-dot handling, IPv4 literal handling, and exception categories.

Fixes #16803

## Testing

- `ruff format --check src/host_normalization.py`
- `ruff check src/host_normalization.py`
- `pytest tests/test_request_handler_authority_validation.py::test_accepts_authority_host_normalization_equivalence tests/test_request_handler_authority_validation.py::test_rejects_idna_compatibility_sni_alias_before_firewall_auth tests/test_request_handler_authority_validation.py::test_rejects_multiple_trailing_dot_sni_before_firewall_auth tests/test_request_handler_authority_validation.py::test_rejects_idna_compatibility_host_alias_before_firewall_auth tests/test_matching_base_url_static.py::TestMatchBaseUrl::test_static_base_idna_authority_matches_runtime_host tests/test_matching_base_url_static.py::TestMatchBaseUrl::test_static_base_rejects_idna_compatibility_aliases tests/test_matching_base_url_parameterized.py::TestMatchBaseUrl::test_parameterized_base_idna_authority_matches_runtime_host tests/test_matching_base_url_parameterized.py::TestMatchBaseUrl::test_parameterized_base_rejects_idna_compatibility_aliases tests/test_compiled_firewall_base_matching.py::test_compiled_rejects_request_idna_compatibility_aliases tests/test_compiled_firewall_base_matching.py::test_compiled_rejects_base_idna_compatibility_aliases tests/test_x_connector_usage.py::TestXConnectorUsage::test_tweet_create_with_url_stays_on_with_url_bucket tests/test_x_connector_usage.py::TestXConnectorUsage::test_tweet_create_url_like_non_links_downgrade_to_content_create`