### PR TITLE
fix: normalize square connector icon

### DIFF
--- a/turbo/apps/platform/src/views/zero-page/components/settings/icons/square.svg
+++ b/turbo/apps/platform/src/views/zero-page/components/settings/icons/square.svg
@@ -1,17 +1,6 @@
-<?xml version="1.0" encoding="utf-8"?>
-<!-- Generator: Adobe Illustrator 16.0.3, SVG Export Plug-In . SVG Version: 6.00 Build 0)  -->
-<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
-<svg version="1.1"
-	 id="svg2" xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:cc="http://creativecommons.org/ns#" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:svg="http://www.w3.org/2000/svg" xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd" xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape" sodipodi:docname="Square, Inc. logo.svg" inkscape:version="0.48.2 r9819"
-	 xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" x="0px" y="0px" width="53.201px"
-	 height="53.199px" viewBox="1 0.901 53.201 53.199" enable-background="new 1 0.901 53.201 53.199" xml:space="preserve">
-<g id="layer3" inkscape:label="2016-rev" inkscape:groupmode="layer">
-	<g id="g3486">
-		<path id="path3010" inkscape:connector-curvature="0" d="M45.333,0.901H9.868C4.992,0.901,1,4.891,1,9.769v35.466
-			C1,50.109,4.992,54.1,9.868,54.1h35.466c4.876,0,8.868-3.99,8.868-8.865V9.769C54.201,4.891,50.209,0.901,45.333,0.901
-			 M44.527,41.609c0,1.55-1.269,2.815-2.82,2.815H13.492c-1.55,0-2.82-1.266-2.82-2.815V13.395c0-1.55,1.27-2.82,2.82-2.82h28.215
-			c1.551,0,2.82,1.27,2.82,2.82V41.609z M34.857,33.143c0,0.889-0.726,1.612-1.61,1.612H21.962c-0.887,0-1.61-0.724-1.61-1.612
-			V21.859c0-0.887,0.723-1.611,1.61-1.611h11.284c0.885,0,1.61,0.725,1.61,1.611V33.143z"/>
-	</g>
-</g>
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="1 0.901 53.201 53.199">
+  <path
+    fill="#000000"
+    d="M45.333 0.901H9.868C4.992 0.901 1 4.891 1 9.769v35.466C1 50.109 4.992 54.1 9.868 54.1h35.466c4.876 0 8.868-3.99 8.868-8.865V9.769C54.201 4.891 50.209 0.901 45.333 0.901M44.527 41.609c0 1.55-1.269 2.815-2.82 2.815H13.492c-1.55 0-2.82-1.266-2.82-2.815V13.395c0-1.55 1.27-2.82 2.82-2.82h28.215c1.551 0 2.82 1.27 2.82 2.82v28.214zM34.857 33.143c0 0.889-0.726 1.612-1.61 1.612H21.962c-0.887 0-1.61-0.724-1.61-1.612V21.859c0-0.887 0.723-1.611 1.61-1.611h11.284c0.885 0 1.61 0.725 1.61 1.611v11.284z"
+  />
 </svg>


### PR DESCRIPTION
## Summary

- Normalize the Square connector icon to a minimal raw SVG.
- Remove XML/DOCTYPE declarations, editor metadata, unused namespaces, and wrapper groups.
- Preserve the nested-square mark with explicit `#000000` fill.

Closes #16873

## Verification

- `pnpm exec prettier --parser html --check apps/platform/src/views/zero-page/components/settings/icons/square.svg`
- `git diff --check`
- Rendered `square.svg` to `/tmp/square-render-white.png` with CairoSVG to verify the nested-square mark still renders correctly.