### PR TITLE
fix: rename desktop app to zero computer use

### DIFF
--- a/.github/workflows/desktop.yml
+++ b/.github/workflows/desktop.yml
@@ -89,7 +89,7 @@ jobs:
 
           desktop_dir="$PWD/apps/desktop"
           version=$(node -p "require('./apps/desktop/package.json').version")
-          forge_zip="$desktop_dir/out/make/zip/darwin/arm64/Zero-darwin-arm64-$version.zip"
+          forge_zip="$desktop_dir/out/make/zip/darwin/arm64/Zero Computer Use-darwin-arm64-$version.zip"
           artifact_path="apps/desktop/out/Zero-darwin-arm64.zip"
 
           if [ ! -f "$forge_zip" ]; then
@@ -104,7 +104,7 @@ jobs:
       - name: Verify production artifact
         run: |
           artifact_path=apps/desktop/out/Zero-darwin-arm64.zip
-          app_dir=apps/desktop/out/Zero-darwin-arm64/Zero.app
+          app_dir="apps/desktop/out/Zero Computer Use-darwin-arm64/Zero Computer Use.app"
           plist="$app_dir/Contents/Info.plist"
           if [ ! -f "$artifact_path" ]; then
             echo "No desktop zip artifact found"
@@ -141,9 +141,9 @@ jobs:
             exit 1
           fi
 
-          /usr/libexec/PlistBuddy -c "Print :CFBundleExecutable" "$plist" | grep -qx "Zero"
-          /usr/libexec/PlistBuddy -c "Print :CFBundleName" "$plist" | grep -qx "Zero"
-          /usr/libexec/PlistBuddy -c "Print :CFBundleDisplayName" "$plist" | grep -qx "Zero"
+          /usr/libexec/PlistBuddy -c "Print :CFBundleExecutable" "$plist" | grep -qx "Zero Computer Use"
+          /usr/libexec/PlistBuddy -c "Print :CFBundleName" "$plist" | grep -qx "Zero Computer Use"
+          /usr/libexec/PlistBuddy -c "Print :CFBundleDisplayName" "$plist" | grep -qx "Zero Computer Use"
           /usr/libexec/PlistBuddy -c "Print :CFBundleIdentifier" "$plist" | grep -qx "ai.vm0.zero.desktop"
           /usr/libexec/PlistBuddy -c "Print :CFBundleIconFile" "$plist" | grep -qx "icon.icns"
           /usr/libexec/PlistBuddy -c "Print :CFBundleURLTypes:0:CFBundleURLName" "$plist" | grep -qx "Zero Desktop Auth"
@@ -151,11 +151,11 @@ jobs:
           cmp -s apps/desktop/assets/icon.icns "$app_dir/Contents/Resources/icon.icns"
           cmp -s apps/desktop/assets/icon.png "$app_dir/Contents/Resources/app/assets/icon.png"
 
-          unzip -l "$artifact_path" | grep -q "Zero.app/Contents/MacOS/Zero"
-          unzip -l "$artifact_path" | grep -q "Zero.app/Contents/Resources/icon.icns"
-          unzip -l "$artifact_path" | grep -q "Zero.app/Contents/Resources/native/computer-use-helper"
-          unzip -l "$artifact_path" | grep -q "Zero.app/Contents/Resources/app/dist/main.js"
-          unzip -l "$artifact_path" | grep -q "Zero.app/Contents/Resources/app/assets/icon.png"
+          unzip -l "$artifact_path" | grep -q "Zero Computer Use.app/Contents/MacOS/Zero Computer Use"
+          unzip -l "$artifact_path" | grep -q "Zero Computer Use.app/Contents/Resources/icon.icns"
+          unzip -l "$artifact_path" | grep -q "Zero Computer Use.app/Contents/Resources/native/computer-use-helper"
+          unzip -l "$artifact_path" | grep -q "Zero Computer Use.app/Contents/Resources/app/dist/main.js"
+          unzip -l "$artifact_path" | grep -q "Zero Computer Use.app/Contents/Resources/app/assets/icon.png"
 
       - name: Upload unsigned macOS artifact
         uses: actions/upload-artifact@v7

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -201,7 +201,7 @@ jobs:
           node apps/desktop/scripts/run-forge-make-with-retry.js --platform darwin --arch arm64
 
           desktop_dir="$PWD/apps/desktop"
-          forge_zip="$desktop_dir/out/make/zip/darwin/arm64/Zero-darwin-arm64-$DESKTOP_VERSION.zip"
+          forge_zip="$desktop_dir/out/make/zip/darwin/arm64/Zero Computer Use-darwin-arm64-$DESKTOP_VERSION.zip"
           artifact_path="apps/desktop/out/Zero-darwin-arm64-$DESKTOP_VERSION.zip"
 
           if [ ! -f "$forge_zip" ]; then
@@ -216,7 +216,7 @@ jobs:
       - name: Verify signed and notarized macOS artifact
         run: |
           artifact_path="apps/desktop/out/Zero-darwin-arm64-$DESKTOP_VERSION.zip"
-          app_dir=apps/desktop/out/Zero-darwin-arm64/Zero.app
+          app_dir="apps/desktop/out/Zero Computer Use-darwin-arm64/Zero Computer Use.app"
           plist="$app_dir/Contents/Info.plist"
 
           if [ ! -f "$artifact_path" ]; then
@@ -234,14 +234,14 @@ jobs:
             exit 1
           fi
 
-          /usr/libexec/PlistBuddy -c "Print :CFBundleExecutable" "$plist" | grep -qx "Zero"
-          /usr/libexec/PlistBuddy -c "Print :CFBundleName" "$plist" | grep -qx "Zero"
-          /usr/libexec/PlistBuddy -c "Print :CFBundleDisplayName" "$plist" | grep -qx "Zero"
+          /usr/libexec/PlistBuddy -c "Print :CFBundleExecutable" "$plist" | grep -qx "Zero Computer Use"
+          /usr/libexec/PlistBuddy -c "Print :CFBundleName" "$plist" | grep -qx "Zero Computer Use"
+          /usr/libexec/PlistBuddy -c "Print :CFBundleDisplayName" "$plist" | grep -qx "Zero Computer Use"
           /usr/libexec/PlistBuddy -c "Print :CFBundleIdentifier" "$plist" | grep -qx "ai.vm0.zero.desktop"
           codesign --verify --deep --strict --verbose=2 "$app_dir"
           codesign --display --verbose=4 "$app_dir" 2>&1 | grep -F "Authority=$VM0_DESKTOP_SIGNING_IDENTITY"
           xcrun stapler validate "$app_dir"
-          unzip -l "$artifact_path" | grep -q "Zero.app/Contents/MacOS/Zero"
+          unzip -l "$artifact_path" | grep -q "Zero Computer Use.app/Contents/MacOS/Zero Computer Use"
 
       - name: Upload Desktop artifact to GitHub Release
         env:

--- a/turbo/apps/api/src/signals/routes/__tests__/desktop-updates.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/desktop-updates.test.ts
@@ -31,7 +31,7 @@ function stableManifest(
 function darwinArm64Release(version: string, url: string) {
   return {
     version,
-    name: `Zero ${version}`,
+    name: `Zero Computer Use ${version}`,
     notes: `Release ${version}`,
     pubDate: "2026-06-08T00:00:00.000Z",
     platforms: {
@@ -69,7 +69,7 @@ describe("desktop update routes", () => {
         {
           version: "0.2.1",
           updateTo: {
-            name: "Zero 0.2.1",
+            name: "Zero Computer Use 0.2.1",
             version: "0.2.1",
             pub_date: "2026-06-08T00:00:00.000Z",
             url: zipUrl,

--- a/turbo/apps/desktop/README.md
+++ b/turbo/apps/desktop/README.md
@@ -53,7 +53,7 @@ Create a macOS artifact with:
 pnpm desktop:make
 ```
 
-This builds the production `Zero.app`, signs it with the local Developer ID
+This builds the production `Zero Computer Use.app`, signs it with the local Developer ID
 Application identity, submits it to Apple's notary service, staples the
 notarization ticket, and writes the zip artifact under `apps/desktop/out/make`.
 Local notarized builds use the `notarytool` Keychain profile
@@ -125,14 +125,14 @@ testing. Run the workflow manually from GitHub Actions, then download the
 `zero-desktop-macos-arm64-unsigned` artifact.
 
 The downloaded GitHub artifact contains `Zero-darwin-arm64.zip`. Unzip both
-layers, then open `Zero.app`.
+layers, then open `Zero Computer Use.app`.
 
 These artifacts are ad-hoc signed, not Developer ID signed, and not notarized.
 macOS Gatekeeper may require right-clicking the app and choosing Open, or
 removing quarantine locally:
 
 ```bash
-xattr -dr com.apple.quarantine Zero.app
+xattr -dr com.apple.quarantine "Zero Computer Use.app"
 ```
 
 ## Release artifacts
@@ -144,9 +144,9 @@ Desktop releases are versioned by release-please. Changes under
 
 When release-please creates the `desktop-vX.Y.Z` GitHub Release, the
 `build-desktop-release` job in the release-please workflow checks out the
-matching tag, builds the production `Zero.app`, signs it with the Developer ID
-Application certificate, notarizes it for direct distribution outside the Mac
-App Store, validates the stapled ticket, uploads
+matching tag, builds the production `Zero Computer Use.app`, signs it with the
+Developer ID Application certificate, notarizes it for direct distribution
+outside the Mac App Store, validates the stapled ticket, uploads
 `Zero-darwin-arm64-X.Y.Z.zip` to the matching GitHub Release, and updates the
 Desktop update manifest.
 

--- a/turbo/apps/desktop/package.json
+++ b/turbo/apps/desktop/package.json
@@ -2,7 +2,7 @@
   "name": "@vm0/desktop",
   "version": "0.3.1",
   "private": true,
-  "productName": "Zero",
+  "productName": "Zero Computer Use",
   "description": "Zero desktop shell",
   "main": "dist/main.js",
   "bin": {

--- a/turbo/apps/desktop/scripts/update-desktop-release-manifest.mjs
+++ b/turbo/apps/desktop/scripts/update-desktop-release-manifest.mjs
@@ -76,7 +76,7 @@ platforms[platform] = platformAssets;
 manifest.releases[version] = {
   ...currentRelease,
   version,
-  name: currentRelease.name ?? `Zero ${version}`,
+  name: currentRelease.name ?? `Zero Computer Use ${version}`,
   notes: currentRelease.notes ?? "",
   pubDate,
   platforms,

--- a/turbo/apps/desktop/src/desktop-auto-updates.ts
+++ b/turbo/apps/desktop/src/desktop-auto-updates.ts
@@ -28,7 +28,8 @@ async function promptToRestartForUpdate(
     cancelId: 1,
     title: "Update Ready",
     message: info.releaseName,
-    detail: "A new version has been downloaded. Restart Zero to install it.",
+    detail:
+      "A new version has been downloaded. Restart Zero Computer Use to install it.",
   });
 
   if (result.response !== 0) {

--- a/turbo/apps/desktop/src/desktop-identities.json
+++ b/turbo/apps/desktop/src/desktop-identities.json
@@ -1,6 +1,6 @@
 {
   "production": {
-    "displayName": "Zero",
+    "displayName": "Zero Computer Use",
     "bundleId": "ai.vm0.zero.desktop",
     "authProtocolName": "Zero Desktop Auth",
     "authScheme": "ai.vm0.zero.desktop"

--- a/turbo/apps/desktop/src/window-policy.test.ts
+++ b/turbo/apps/desktop/src/window-policy.test.ts
@@ -185,7 +185,7 @@ describe("resolveDesktopConfig", () => {
     expect(config.webUrl.toString()).toBe("https://www.vm0.ai/");
     expect(config.environment).toBe("production");
     expect(config.identity).toMatchObject({
-      displayName: "Zero",
+      displayName: "Zero Computer Use",
       bundleId: "ai.vm0.zero.desktop",
       authScheme: "ai.vm0.zero.desktop",
     });


### PR DESCRIPTION
## Summary
- rename the production Desktop app display/product name to Zero Computer Use
- update Desktop CI/release bundle assertions for the renamed .app while keeping bundle id and URL scheme unchanged
- update auto-update release naming, targeted tests, and Desktop docs for the new app name

## Validation
- pnpm exec prettier --write --ignore-unknown ../.github/workflows/desktop.yml ../.github/workflows/desktop-release.yml apps/api/src/signals/routes/__tests__/desktop-updates.test.ts apps/desktop/README.md apps/desktop/package.json apps/desktop/scripts/update-desktop-release-manifest.mjs apps/desktop/src/desktop-auto-updates.ts apps/desktop/src/desktop-identities.json apps/desktop/src/window-policy.test.ts
- pnpm -F @vm0/desktop lint
- pnpm -F @vm0/desktop check-types
- pnpm -F @vm0/desktop exec vitest run src/window-policy.test.ts src/desktop-renderer-url.test.ts
- pnpm -F api exec vitest run src/signals/routes/__tests__/desktop-updates.test.ts
- pnpm -F @vm0/desktop build
- VM0_DESKTOP_SIGNING_IDENTITY=- node apps/desktop/scripts/run-forge-make-with-retry.js --platform darwin --arch arm64
- verified generated Info.plist fields and zip contents for Zero Computer Use.app
- pnpm -F @vm0/desktop test

Note: scripts/prepare.sh installed dependencies but could not complete migrations/seed locally because DATABASE_URL and 1Password CLI are not configured in this worktree.