### PR TITLE
fix: rename desktop development app

### DIFF
--- a/.github/workflows/desktop.yml
+++ b/.github/workflows/desktop.yml
@@ -195,8 +195,8 @@ jobs:
 
           desktop_dir="$PWD/apps/desktop"
           version=$(node -p "require('./apps/desktop/package.json').version")
-          forge_zip="$desktop_dir/out/make/zip/darwin/arm64/Zero Dev-darwin-arm64-$version.zip"
-          artifact_path="apps/desktop/out/ZeroDev-darwin-arm64-preview.zip"
+          forge_zip="$desktop_dir/out/make/zip/darwin/arm64/Zero CU Dev-darwin-arm64-$version.zip"
+          artifact_path="apps/desktop/out/ZeroCUDev-darwin-arm64-preview.zip"
 
           if [ ! -f "$forge_zip" ]; then
             echo "No Forge preview zip artifact found: $forge_zip"
@@ -212,8 +212,8 @@ jobs:
         env:
           EXPECTED_PLATFORM_URL: ${{ steps.preview.outputs.platform-url }}
         run: |
-          artifact_path=apps/desktop/out/ZeroDev-darwin-arm64-preview.zip
-          app_dir="apps/desktop/out/Zero Dev-darwin-arm64/Zero Dev.app"
+          artifact_path=apps/desktop/out/ZeroCUDev-darwin-arm64-preview.zip
+          app_dir="apps/desktop/out/Zero CU Dev-darwin-arm64/Zero CU Dev.app"
           plist="$app_dir/Contents/Info.plist"
           runtime_config="$app_dir/Contents/Resources/app/desktop-runtime-config.json"
           if [ ! -f "$artifact_path" ]; then
@@ -265,22 +265,22 @@ jobs:
           }
           NODE
 
-          /usr/libexec/PlistBuddy -c "Print :CFBundleExecutable" "$plist" | grep -qx "Zero Dev"
-          /usr/libexec/PlistBuddy -c "Print :CFBundleName" "$plist" | grep -qx "Zero Dev"
-          /usr/libexec/PlistBuddy -c "Print :CFBundleDisplayName" "$plist" | grep -qx "Zero Dev"
+          /usr/libexec/PlistBuddy -c "Print :CFBundleExecutable" "$plist" | grep -qx "Zero CU Dev"
+          /usr/libexec/PlistBuddy -c "Print :CFBundleName" "$plist" | grep -qx "Zero CU Dev"
+          /usr/libexec/PlistBuddy -c "Print :CFBundleDisplayName" "$plist" | grep -qx "Zero CU Dev"
           /usr/libexec/PlistBuddy -c "Print :CFBundleIdentifier" "$plist" | grep -qx "ai.vm0.zero.desktop.dev"
           /usr/libexec/PlistBuddy -c "Print :CFBundleIconFile" "$plist" | grep -qx "icon.icns"
-          /usr/libexec/PlistBuddy -c "Print :CFBundleURLTypes:0:CFBundleURLName" "$plist" | grep -qx "Zero Dev Desktop Auth"
+          /usr/libexec/PlistBuddy -c "Print :CFBundleURLTypes:0:CFBundleURLName" "$plist" | grep -qx "Zero CU Dev Desktop Auth"
           /usr/libexec/PlistBuddy -c "Print :CFBundleURLTypes:0:CFBundleURLSchemes:0" "$plist" | grep -qx "ai.vm0.zero.desktop.dev"
           cmp -s apps/desktop/assets/icon.icns "$app_dir/Contents/Resources/icon.icns"
           cmp -s apps/desktop/assets/icon.png "$app_dir/Contents/Resources/app/assets/icon.png"
 
-          unzip -l "$artifact_path" | grep -q "Zero Dev.app/Contents/MacOS/Zero Dev"
-          unzip -l "$artifact_path" | grep -q "Zero Dev.app/Contents/Resources/icon.icns"
-          unzip -l "$artifact_path" | grep -q "Zero Dev.app/Contents/Resources/native/computer-use-helper"
-          unzip -l "$artifact_path" | grep -q "Zero Dev.app/Contents/Resources/app/dist/main.js"
-          unzip -l "$artifact_path" | grep -q "Zero Dev.app/Contents/Resources/app/assets/icon.png"
-          unzip -l "$artifact_path" | grep -q "Zero Dev.app/Contents/Resources/app/desktop-runtime-config.json"
+          unzip -l "$artifact_path" | grep -q "Zero CU Dev.app/Contents/MacOS/Zero CU Dev"
+          unzip -l "$artifact_path" | grep -q "Zero CU Dev.app/Contents/Resources/icon.icns"
+          unzip -l "$artifact_path" | grep -q "Zero CU Dev.app/Contents/Resources/native/computer-use-helper"
+          unzip -l "$artifact_path" | grep -q "Zero CU Dev.app/Contents/Resources/app/dist/main.js"
+          unzip -l "$artifact_path" | grep -q "Zero CU Dev.app/Contents/Resources/app/assets/icon.png"
+          unzip -l "$artifact_path" | grep -q "Zero CU Dev.app/Contents/Resources/app/desktop-runtime-config.json"
 
       - name: Upload unsigned PR preview macOS artifact
         if: github.event_name == 'pull_request'

--- a/turbo/apps/desktop/README.md
+++ b/turbo/apps/desktop/README.md
@@ -34,7 +34,7 @@ with:
 pnpm desktop:dev
 ```
 
-This packages and runs `Zero Dev.app` with `VM0_DESKTOP_PLATFORM_URL` set to the
+This packages and runs `Zero CU Dev.app` with `VM0_DESKTOP_PLATFORM_URL` set to the
 local proxy. Use it for sign-in callback, URL scheme, and permission testing.
 Non-CI packaged desktop builds require the `Developer ID Application: Max &
 Zoe, Inc. (C5UWSXYB67)` signing identity in the local keychain. This keeps the

--- a/turbo/apps/desktop/src/desktop-identities.json
+++ b/turbo/apps/desktop/src/desktop-identities.json
@@ -6,9 +6,9 @@
     "authScheme": "ai.vm0.zero.desktop"
   },
   "development": {
-    "displayName": "Zero Dev",
+    "displayName": "Zero CU Dev",
     "bundleId": "ai.vm0.zero.desktop.dev",
-    "authProtocolName": "Zero Dev Desktop Auth",
+    "authProtocolName": "Zero CU Dev Desktop Auth",
     "authScheme": "ai.vm0.zero.desktop.dev"
   }
 }

--- a/turbo/apps/desktop/src/window-policy.test.ts
+++ b/turbo/apps/desktop/src/window-policy.test.ts
@@ -203,7 +203,7 @@ describe("resolveDesktopConfig", () => {
     expect(config.environment).toBe("staging");
     expect(config.webUrl.toString()).toBe("https://staging-www.vm6.ai/");
     expect(config.identity).toMatchObject({
-      displayName: "Zero Dev",
+      displayName: "Zero CU Dev",
       bundleId: "ai.vm0.zero.desktop.dev",
       authScheme: "ai.vm0.zero.desktop.dev",
     });
@@ -225,7 +225,7 @@ describe("resolveDesktopConfig", () => {
     expect(config.environment).toBe("development");
     expect(config.webUrl.toString()).toBe("https://www.vm7.ai:8443/");
     expect(config.identity).toMatchObject({
-      displayName: "Zero Dev",
+      displayName: "Zero CU Dev",
       bundleId: "ai.vm0.zero.desktop.dev",
       authScheme: "ai.vm0.zero.desktop.dev",
     });
@@ -241,7 +241,7 @@ describe("resolveDesktopConfig", () => {
     expect(config.environment).toBe("development");
     expect(config.webUrl.toString()).toBe("https://pr-123-www.vm6.ai/");
     expect(config.identity).toMatchObject({
-      displayName: "Zero Dev",
+      displayName: "Zero CU Dev",
       bundleId: "ai.vm0.zero.desktop.dev",
       authScheme: "ai.vm0.zero.desktop.dev",
     });


### PR DESCRIPTION
## Summary
- rename the development Desktop app from Zero Dev to Zero CU Dev
- update the development auth protocol display name and README wording
- update config expectations in Desktop tests

## Tests
- pnpm -F @vm0/desktop exec vitest src/window-policy.test.ts