### PR TITLE
feat: support connector output variables

### DIFF
--- a/turbo/apps/api/src/signals/routes/__tests__/agent-runs-create.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/agent-runs-create.test.ts
@@ -1357,6 +1357,80 @@ describe("POST /api/agent/runs", () => {
     });
   });
 
+  it("loads connector token output variables into runtime environment", async () => {
+    const fx = await fixture();
+    const db = store.set(writeDb$);
+    await db.insert(userFeatureSwitches).values({
+      orgId: fx.orgId,
+      userId: fx.userId,
+      switches: { [FeatureSwitchKey.TestOauthConnector]: true },
+    });
+    await db.insert(connectors).values({
+      orgId: fx.orgId,
+      userId: fx.userId,
+      type: "test-oauth",
+      authMethod: "api",
+    });
+    await db.insert(secretsTable).values({
+      orgId: fx.orgId,
+      userId: fx.userId,
+      name: "TEST_OAUTH_API_ACCESS_TOKEN",
+      encryptedValue: encryptSecretForTests("test-oauth-api-token"),
+      type: "connector",
+    });
+    await db.insert(variables).values({
+      orgId: fx.orgId,
+      userId: fx.userId,
+      name: "TEST_OAUTH_API_TENANT_ID",
+      value: "tenant-from-token-output",
+      type: "connector",
+    });
+    const compose = await createCompose({ fixture: fx });
+
+    const response = await accept(
+      runsClient().create({
+        headers: { authorization: "Bearer clerk-session" },
+        body: {
+          agentComposeId: compose.composeId,
+          prompt: "Use test OAuth",
+        },
+      }),
+      [201],
+    );
+
+    const [run] = await db
+      .select({ vars: agentRuns.vars })
+      .from(agentRuns)
+      .where(eq(agentRuns.id, response.body.runId));
+    expect(run?.vars ?? {}).not.toHaveProperty("TEST_OAUTH_API_TENANT_ID");
+
+    const [job] = await db
+      .select({ executionContext: runnerJobQueue.executionContext })
+      .from(runnerJobQueue)
+      .where(eq(runnerJobQueue.runId, response.body.runId));
+    const executionContext = job?.executionContext as {
+      readonly environment: Record<string, string>;
+      readonly encryptedSecrets: string | null;
+      readonly firewalls: readonly { readonly name: string }[];
+    };
+    expect(executionContext.environment.TEST_OAUTH_TENANT_ID).toBe(
+      "tenant-from-token-output",
+    );
+    expect(executionContext.environment.TEST_OAUTH_TOKEN).toBe(
+      "testoauth_placeholder_token",
+    );
+    expect(
+      decryptSecretsMapForTests(executionContext.encryptedSecrets),
+    ).toMatchObject({
+      TEST_OAUTH_TOKEN: "test-oauth-api-token",
+    });
+    expect(
+      executionContext.firewalls.some((firewall) => {
+        return firewall.name === "test-oauth";
+      }),
+    ).toBeTruthy();
+  });
+
   it("maps non-refreshable runtime secret aliases for refresh-token connectors", async () => {
     const fx = await fixture();
     const db = store.set(writeDb$);

--- a/turbo/apps/api/src/signals/routes/__tests__/agent-runs-create.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/agent-runs-create.test.ts
@@ -1411,7 +1411,10 @@ describe("POST /api/agent/runs", () => {
     const executionContext = job?.executionContext as {
       readonly environment: Record<string, string>;
       readonly encryptedSecrets: string | null;
-      readonly firewalls: readonly { readonly name: string }[];
+      readonly firewalls: readonly {
+        readonly name: string;
+        readonly apis: readonly { readonly base: string }[];
+      }[];
     };
     expect(executionContext.environment.TEST_OAUTH_TENANT_ID).toBe(
       "tenant-from-token-output",
@@ -1424,11 +1427,12 @@ describe("POST /api/agent/runs", () => {
     ).toMatchObject({
       TEST_OAUTH_TOKEN: "test-oauth-api-token",
     });
-    expect(
-      executionContext.firewalls.some((firewall) => {
-        return firewall.name === "test-oauth";
-      }),
-    ).toBeTruthy();
+    const firewall = executionContext.firewalls.find((entry) => {
+      return entry.name === "test-oauth";
+    });
+    expect(firewall?.apis[0]?.base).toBe(
+      "https://tenant-from-token-output.{pr}.vm6.ai/api/test/oauth-provider",
+    );
   });
 
   it("maps non-refreshable runtime secret aliases for refresh-token connectors", async () => {

--- a/turbo/apps/api/src/signals/routes/__tests__/cli-auth.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/cli-auth.test.ts
@@ -1973,6 +1973,13 @@ describe("CLI auth routes", () => {
           name: "TEST_OAUTH_REFRESH_TOKEN",
         }),
       ).resolves.toBe("test-oauth-refresh-token");
+      await expect(
+        findConnectorVariable({
+          orgId,
+          userId,
+          name: "TEST_OAUTH_API_TENANT_ID",
+        }),
+      ).resolves.toBe("test-oauth-oauth-tenantId");
     });
 
     it("maps legacy test token fields to method-specific grant outputs", async () => {

--- a/turbo/apps/api/src/signals/routes/__tests__/cli-auth.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/cli-auth.test.ts
@@ -25,6 +25,7 @@ import { orgMembersCache } from "@vm0/db/schema/org-members-cache";
 import { orgMetadata } from "@vm0/db/schema/org-metadata";
 import { secrets } from "@vm0/db/schema/secret";
 import { userConnectors } from "@vm0/db/schema/user-connector";
+import { variables } from "@vm0/db/schema/variable";
 import { zeroAgents } from "@vm0/db/schema/zero-agent";
 import { createStore } from "ccstate";
 import { and, eq, inArray } from "drizzle-orm";
@@ -549,6 +550,28 @@ describe("CLI auth routes", () => {
     return row ? decryptSecretForTests(row.encryptedValue) : undefined;
   }
 
+  async function findConnectorVariable(args: {
+    readonly orgId: string;
+    readonly userId: string;
+    readonly name: string;
+  }): Promise<string | undefined> {
+    const writeDb = store.set(writeDb$);
+    const [row] = await writeDb
+      .select({ value: variables.value })
+      .from(variables)
+      .where(
+        and(
+          eq(variables.orgId, args.orgId),
+          eq(variables.userId, args.userId),
+          eq(variables.name, args.name),
+          eq(variables.type, "connector"),
+        ),
+      )
+      .limit(1);
+
+    return row?.value;
+  }
+
   async function readConnectorState(args: {
     readonly orgId: string;
     readonly userId: string;
@@ -699,6 +722,7 @@ describe("CLI auth routes", () => {
         .delete(modelProviders)
         .where(inArray(modelProviders.orgId, orgIds));
       await writeDb.delete(secrets).where(inArray(secrets.orgId, orgIds));
+      await writeDb.delete(variables).where(inArray(variables.orgId, orgIds));
       await writeDb
         .delete(creditExpiresRecord)
         .where(inArray(creditExpiresRecord.orgId, orgIds));
@@ -2000,6 +2024,13 @@ describe("CLI auth routes", () => {
           name: "TEST_OAUTH_API_REFRESH_TOKEN",
         }),
       ).resolves.toBe("test-oauth-api-refresh-token");
+      await expect(
+        findConnectorVariable({
+          orgId,
+          userId,
+          name: "TEST_OAUTH_API_TENANT_ID",
+        }),
+      ).resolves.toBe("test-oauth-api-tenantId");
       await expect(
         findConnectorSecret({
           orgId,

--- a/turbo/apps/api/src/signals/routes/__tests__/connectors-type-callback.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/connectors-type-callback.test.ts
@@ -2360,6 +2360,69 @@ describe("GET /api/connectors/:type/callback", () => {
     ).resolves.toBeUndefined();
   });
 
+  it("rejects method-specific grant responses missing required variable outputs", async () => {
+    const originalExchangeCode = testOauthApiProvider.grant.exchangeCode;
+    const malformedResult = {
+      ...dynamicTestOAuthApiExchangeResult(),
+      outputs: {
+        initialAccessToken: "dynamic-access-token",
+        initialRefreshToken: "dynamic-refresh-token",
+      },
+    };
+    testOauthApiProvider.grant.exchangeCode = () => {
+      return Promise.resolve(
+        malformedResult as DynamicTestOAuthApiExchangeResult,
+      );
+    };
+    restoreDynamicTestOAuthExchange = () => {
+      testOauthApiProvider.grant.exchangeCode = originalExchangeCode;
+    };
+
+    const orgId = `org_${randomUUID()}`;
+    const userId = `user_${randomUUID()}`;
+    orgIds.push(orgId);
+    authenticate({ userId, orgId });
+    await seedTrackedOauthState({
+      type: "test-oauth",
+      authMethod: "api",
+      userId,
+      orgId,
+      state: "state-123",
+    });
+
+    const response = await requestCallback({
+      type: "test-oauth",
+      query: { code: "code-123", state: "state-123" },
+      headers: callbackHeaders({ stateCookie: "state-123" }),
+    });
+
+    expectConnectorErrorRedirect(response, {
+      type: "test-oauth",
+      message: "OAuth authorization failed. Please try again.",
+    });
+    await expect(
+      findConnector({
+        orgId,
+        userId,
+        type: "test-oauth",
+      }),
+    ).resolves.toBeUndefined();
+    await expect(
+      findSecret({
+        orgId,
+        userId,
+        name: "TEST_OAUTH_API_ACCESS_TOKEN",
+      }),
+    ).resolves.toBeUndefined();
+    await expect(
+      findVariable({
+        orgId,
+        userId,
+        name: "TEST_OAUTH_API_TENANT_ID",
+      }),
+    ).resolves.toBeUndefined();
+  });
+
   it("deletes legacy manual grant rows only for the stored auth method", async () => {
     restoreTestOauthManualGrantAuthMethods =
       configureTestOauthManualGrantAuthMethods();

--- a/turbo/apps/api/src/signals/routes/__tests__/connectors-type-callback.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/connectors-type-callback.test.ts
@@ -12,14 +12,14 @@ import {
   connectorAuthMethodHasGrantKind,
   getConnectorAuthMethod,
   getConnectorAuthMethodGrantMetadata,
-  getConnectorGrantOutputSecretName,
+  getConnectorGrantOutputTarget,
+  type ConnectorOutputTarget,
 } from "@vm0/connectors/connector-utils";
 import {
   testOauthApiProvider,
   testOauthProvider,
 } from "@vm0/connectors/auth-providers/connectors/test-oauth/provider";
 import type { AuthCodeConnectorAuthProvider } from "@vm0/connectors/auth-providers/types";
-import type { exchangeConnectorAuthCode } from "@vm0/connectors/auth-providers";
 import { agentComposes } from "@vm0/db/schema/agent-compose";
 import { connectors } from "@vm0/db/schema/connector";
 import { connectorOauthStates } from "@vm0/db/schema/connector-oauth-state";
@@ -45,9 +45,11 @@ const context = testContext();
 const store = createStore();
 const mocks = createZeroRouteMocks(context);
 
-type ConnectorAuthCodeExchangeResult = Awaited<
-  ReturnType<typeof exchangeConnectorAuthCode>
->;
+function connectorSecretTargetName(
+  target: ConnectorOutputTarget | undefined,
+): string | undefined {
+  return target?.kind === "connector-secret" ? target.name : undefined;
+}
 
 const BASE_URL = "https://app.vm0.test";
 const API_ORIGIN = "https://api.vm0.ai";
@@ -252,6 +254,7 @@ type DynamicTestOAuthApiExchangeResult = Omit<
   readonly outputs: {
     readonly initialAccessToken: string;
     readonly initialRefreshToken: string;
+    readonly tenantId: string;
   };
 };
 
@@ -318,6 +321,7 @@ function dynamicTestOAuthApiExchangeResult(): DynamicTestOAuthApiExchangeResult 
     outputs: {
       initialAccessToken: "dynamic-access-token",
       initialRefreshToken: "dynamic-refresh-token",
+      tenantId: "dynamic-tenant-id",
     },
     expiresIn: 3600,
     scopes: ["read"],
@@ -1243,9 +1247,11 @@ function accessTokenSecretNameForAuthCodeMethod(
   authMethod: ConnectorAuthMethodId,
 ): string {
   const grantMetadata = getConnectorAuthMethodGrantMetadata(type, authMethod);
-  const secretName =
-    grantMetadata &&
-    getConnectorGrantOutputSecretName(grantMetadata, "accessToken");
+  const secretName = grantMetadata
+    ? connectorSecretTargetName(
+        getConnectorGrantOutputTarget(grantMetadata, "accessToken"),
+      )
+    : undefined;
   if (!secretName) {
     throw new Error(`${type}: auth-code auth method has no access output`);
   }
@@ -1258,7 +1264,9 @@ function refreshTokenSecretNameForAuthCodeMethod(
 ): string | undefined {
   const grantMetadata = getConnectorAuthMethodGrantMetadata(type, authMethod);
   return grantMetadata
-    ? getConnectorGrantOutputSecretName(grantMetadata, "refreshToken")
+    ? connectorSecretTargetName(
+        getConnectorGrantOutputTarget(grantMetadata, "refreshToken"),
+      )
     : undefined;
 }
 
@@ -2272,6 +2280,16 @@ describe("GET /api/connectors/:type/callback", () => {
       }),
     ).resolves.toBe("dynamic-refresh-token");
     await expect(
+      findVariable({
+        orgId,
+        userId,
+        name: "TEST_OAUTH_API_TENANT_ID",
+      }),
+    ).resolves.toMatchObject({
+      value: "dynamic-tenant-id",
+      type: "connector",
+    });
+    await expect(
       findSecret({
         orgId,
         userId,
@@ -2287,7 +2305,7 @@ describe("GET /api/connectors/:type/callback", () => {
       outputs: {
         initialRefreshToken: "dynamic-refresh-token",
       },
-    } satisfies ConnectorAuthCodeExchangeResult;
+    };
     testOauthApiProvider.grant.exchangeCode = () => {
       return Promise.resolve(
         malformedResult as DynamicTestOAuthApiExchangeResult,

--- a/turbo/apps/api/src/signals/routes/__tests__/connectors-type-callback.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/connectors-type-callback.test.ts
@@ -237,6 +237,7 @@ type DynamicTestOAuthExchangeResult = {
   readonly outputs: {
     readonly accessToken: string;
     readonly refreshToken: string;
+    readonly tenantId: string;
   };
   readonly expiresIn: number;
   readonly scopes: string[];
@@ -305,6 +306,7 @@ function dynamicTestOAuthExchangeResult(): DynamicTestOAuthExchangeResult {
     outputs: {
       accessToken: "dynamic-access-token",
       refreshToken: "dynamic-refresh-token",
+      tenantId: "dynamic-tenant-id",
     },
     expiresIn: 3600,
     scopes: ["read"],
@@ -2225,6 +2227,16 @@ describe("GET /api/connectors/:type/callback", () => {
     expect(decryptSecretForTests(secret!.encryptedValue)).toBe(
       "dynamic-access-token",
     );
+    await expect(
+      findVariable({
+        orgId,
+        userId,
+        name: "TEST_OAUTH_API_TENANT_ID",
+      }),
+    ).resolves.toMatchObject({
+      value: "dynamic-tenant-id",
+      type: "connector",
+    });
   });
 
   it("stores tokens through method-specific grant output names", async () => {

--- a/turbo/apps/api/src/signals/routes/__tests__/webhooks-agent-firewall-auth.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/webhooks-agent-firewall-auth.test.ts
@@ -390,6 +390,27 @@ async function readSecret(args: {
   return row ? decryptSecretForTests(row.encryptedValue) : null;
 }
 
+async function readConnectorVariable(args: {
+  readonly orgId: string;
+  readonly userId: string;
+  readonly name: string;
+}): Promise<string | null> {
+  const db = store.set(writeDb$);
+  const [row] = await db
+    .select({ value: variables.value })
+    .from(variables)
+    .where(
+      and(
+        eq(variables.orgId, args.orgId),
+        eq(variables.userId, args.userId),
+        eq(variables.name, args.name),
+        eq(variables.type, "connector"),
+      ),
+    )
+    .limit(1);
+  return row?.value ?? null;
+}
+
 async function seedNotionConnector(
   fixture: FirewallFixture,
   args: {
@@ -811,6 +832,7 @@ type TestOAuthApiRefreshOutputs = {
   readonly refreshedAccessToken: string;
   readonly refreshedRefreshToken?: string;
   readonly secondaryToken?: string;
+  readonly refreshedTenantId?: string;
 };
 
 function useDynamicTestOAuthRefresh(): {
@@ -905,6 +927,7 @@ function configureDynamicTestOAuthApiRefresh(
   outputs: TestOAuthApiRefreshOutputs = {
     refreshedAccessToken: "fresh-test-oauth-api-token",
     secondaryToken: "fresh-test-oauth-api-secondary-token",
+    refreshedTenantId: "fresh-test-oauth-api-tenant-id",
   },
 ): () => void {
   const method = getConnectorAuthMethod("test-oauth", "api");
@@ -2612,6 +2635,55 @@ describe("POST /api/webhooks/agent/firewall/auth", () => {
         type: "connector",
       }),
     ).resolves.toBe("test-oauth-api-refresh-token");
+    await expect(
+      readConnectorVariable({
+        orgId: fixture.orgId,
+        userId: fixture.userId,
+        name: "TEST_OAUTH_API_TENANT_ID",
+      }),
+    ).resolves.toBe("fresh-test-oauth-api-tenant-id");
+  });
+
+  it("refreshes connector access when an optional variable output is omitted", async () => {
+    const dynamicOAuth = useDynamicTestOAuthApiRefresh({
+      outputs: {
+        refreshedAccessToken: "fresh-test-oauth-api-token",
+        secondaryToken: "fresh-test-oauth-api-secondary-token",
+      },
+    });
+    restoreDynamicTestOAuthRefresh = dynamicOAuth.restore;
+    const fixture = await track(seedFixture());
+    await seedExpiredTestOAuthApiConnector(fixture);
+
+    const response = await accept(
+      firewallClient().resolve({
+        body: {
+          encryptedSecrets: encryptedSecrets({
+            TEST_OAUTH_TOKEN: "stale-test-oauth-api-token",
+          }),
+          authHeaders: {
+            Authorization: `Bearer ${secretTemplate("TEST_OAUTH_TOKEN")}`,
+          },
+          secretConnectorMap: {
+            TEST_OAUTH_TOKEN: "test-oauth",
+          },
+        },
+        headers: authHeaders(fixture),
+      }),
+      [200],
+    );
+
+    expect(response.body.headers.Authorization).toBe(
+      "Bearer fresh-test-oauth-api-token",
+    );
+    expect(response.body.refreshedSecrets).toStrictEqual(["TEST_OAUTH_TOKEN"]);
+    await expect(
+      readConnectorVariable({
+        orgId: fixture.orgId,
+        userId: fixture.userId,
+        name: "TEST_OAUTH_API_TENANT_ID",
+      }),
+    ).resolves.toBe("tenant-123");
   });
 
   it("resolves a missing input-only connector access secret through refresh metadata", async () => {

--- a/turbo/apps/api/src/signals/routes/__tests__/webhooks-agent-firewall-auth.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/webhooks-agent-firewall-auth.test.ts
@@ -555,6 +555,12 @@ async function seedExpiredTestOAuthConnector(
     value: "test-oauth-refresh-token",
     type: "connector",
   });
+  await seedVariable({
+    orgId: fixture.orgId,
+    userId: fixture.userId,
+    name: "TEST_OAUTH_API_TENANT_ID",
+    value: "test-oauth-tenant-123",
+  });
 }
 
 async function seedExpiredTestOAuthApiConnector(
@@ -652,6 +658,13 @@ async function seedTestOAuthApiTokenConnector(
       value: inputVariable,
     });
   }
+
+  await seedVariable({
+    orgId: fixture.orgId,
+    userId: fixture.userId,
+    name: "TEST_OAUTH_API_TENANT_ID",
+    value: "test-oauth-api-token-tenant-123",
+  });
 
   if (args.accessToken !== undefined) {
     await seedSecret({

--- a/turbo/apps/api/src/signals/routes/cli-auth-test.ts
+++ b/turbo/apps/api/src/signals/routes/cli-auth-test.ts
@@ -17,6 +17,7 @@ import {
   getConnectorAuthMethodAccessMetadata,
   getConnectorAuthMethodGrantMetadata,
   getConnectorAuthMethodRuntimeMetadata,
+  type ConnectorOutputTarget,
 } from "@vm0/connectors/connector-utils";
 import { agentComposes } from "@vm0/db/schema/agent-compose";
 import { deviceCodes } from "@vm0/db/schema/device-codes";
@@ -79,6 +80,10 @@ function connectorTypeHasSelectedAuthGrant(
   return grantKind === "auth-code" || grantKind === "device-auth";
 }
 
+function connectorOutputTargetKey(target: ConnectorOutputTarget): string {
+  return `${target.kind}:${target.name}`;
+}
+
 function testConnectorTokenOutputs(args: {
   readonly connectorType: AuthGrantConnectorType;
   readonly authMethod: ConnectorAuthMethodId;
@@ -99,15 +104,15 @@ function testConnectorTokenOutputs(args: {
     );
   }
 
-  const outputNameBySecretName = new Map(
+  const outputNameByTargetKey = new Map(
     Object.entries(grantMetadata.outputs).map(([outputName, output]) => {
-      return [output.secretName, outputName];
+      return [connectorOutputTargetKey(output.target), outputName];
     }),
   );
   const accessOutputName = runtimeMetadata.runtimeBindings
     .flatMap((binding) => {
       return binding.source.kind === "connector-secret"
-        ? [outputNameBySecretName.get(binding.source.name)]
+        ? [outputNameByTargetKey.get(connectorOutputTargetKey(binding.source))]
         : [];
     })
     .find((outputName) => {
@@ -122,6 +127,15 @@ function testConnectorTokenOutputs(args: {
   const outputs: Record<string, string> = {
     [accessOutputName]: args.accessToken,
   };
+  for (const [outputName, output] of Object.entries(grantMetadata.outputs)) {
+    if (
+      output.target.kind === "connector-variable" &&
+      outputs[outputName] === undefined
+    ) {
+      outputs[outputName] =
+        `${args.connectorType}-${args.authMethod}-${outputName}`;
+    }
+  }
   if (!args.refreshToken) {
     return outputs;
   }
@@ -137,7 +151,7 @@ function testConnectorTokenOutputs(args: {
   const refreshOutputName = Object.values(accessMetadata.inputs)
     .flatMap((input) => {
       return input.source.kind === "connector-secret"
-        ? [outputNameBySecretName.get(input.source.name)]
+        ? [outputNameByTargetKey.get(connectorOutputTargetKey(input.source))]
         : [];
     })
     .find((outputName) => {

--- a/turbo/apps/api/src/signals/services/agent-webhook-firewall-auth.service.ts
+++ b/turbo/apps/api/src/signals/services/agent-webhook-firewall-auth.service.ts
@@ -21,6 +21,7 @@ import {
   type ConnectorRefreshTokenInputMetadata,
   type ConnectorAuthMethodRuntimeMetadata,
   type ConnectorAuthClientForMethod,
+  type ConnectorOutputTarget,
 } from "@vm0/connectors/connector-utils";
 import {
   type ConnectorAuthClientConfigForMethod,
@@ -329,7 +330,7 @@ type RefreshInputSource =
 
 interface RefreshTokenContext {
   readonly inputSources: Readonly<Record<string, RefreshInputSource>>;
-  readonly outputSecrets: Readonly<Record<string, string>>;
+  readonly outputTargets: Readonly<Record<string, RefreshOutputTarget>>;
   readonly runtimeOutputSecrets: Readonly<Record<string, string>>;
   readonly secretUserId: string;
 }
@@ -351,9 +352,19 @@ interface RefreshStateRow {
 }
 
 interface ValidatedRefreshOutput {
-  readonly secretName: string;
+  readonly target: RefreshOutputTarget;
   readonly value: string;
 }
+
+type RefreshOutputTarget =
+  | {
+      readonly kind: "secret";
+      readonly name: string;
+    }
+  | {
+      readonly kind: "connector-variable";
+      readonly name: string;
+    };
 
 type PreparedRefreshTokenContext =
   | ConnectorPreparedRefreshTokenContext
@@ -847,6 +858,40 @@ async function upsertSecretValue(
     });
 }
 
+async function upsertConnectorVariableValue(
+  db: Db,
+  args: {
+    readonly orgId: string;
+    readonly userId: string;
+    readonly name: string;
+    readonly value: string;
+  },
+): Promise<void> {
+  await db
+    .insert(variablesTable)
+    .values({
+      orgId: args.orgId,
+      userId: args.userId,
+      name: args.name,
+      value: args.value,
+      description: null,
+      type: "connector",
+    })
+    .onConflictDoUpdate({
+      target: [
+        variablesTable.orgId,
+        variablesTable.userId,
+        variablesTable.type,
+        variablesTable.name,
+      ],
+      set: {
+        value: args.value,
+        description: null,
+        updatedAt: nowDate(),
+      },
+    });
+}
+
 function modelProviderRuntimeSecretName(args: {
   readonly key: string;
   readonly connectorType: string;
@@ -1072,15 +1117,36 @@ function connectorRefreshInputSources(
   );
 }
 
-function connectorRefreshOutputSecrets(
+function connectorRefreshOutputTargets(
   accessMetadata: Extract<
     ConnectorAuthMethodAccessMetadata,
     { readonly kind: "refresh-token" }
   >,
-): Record<string, string> {
+): Record<string, RefreshOutputTarget> {
   return Object.fromEntries(
     Object.entries(accessMetadata.outputs).map(([outputName, metadata]) => {
-      return [outputName, metadata.secretName];
+      return [
+        outputName,
+        refreshOutputTargetFromConnectorTarget(metadata.target),
+      ];
+    }),
+  );
+}
+
+function refreshOutputTargetFromConnectorTarget(
+  target: ConnectorOutputTarget,
+): RefreshOutputTarget {
+  return target.kind === "connector-secret"
+    ? { kind: "secret", name: target.name }
+    : target;
+}
+
+function modelProviderRefreshOutputTargets(
+  outputs: Readonly<Record<string, string>>,
+): Record<string, RefreshOutputTarget> {
+  return Object.fromEntries(
+    Object.entries(outputs).map(([outputName, secretName]) => {
+      return [outputName, { kind: "secret" as const, name: secretName }];
     }),
   );
 }
@@ -1286,7 +1352,7 @@ function prepareRefreshTokenContext(
           return [inputName, { kind: "secret" as const, name: secretName }];
         }),
       ),
-      outputSecrets: secretMetadata.outputs,
+      outputTargets: modelProviderRefreshOutputTargets(secretMetadata.outputs),
       runtimeOutputSecrets,
       secretUserId: resolveSecretUserId(
         args.sourceType,
@@ -1334,7 +1400,7 @@ function prepareRefreshTokenContext(
 
   const context: RefreshTokenContext = {
     inputSources: connectorRefreshInputSources(accessMetadata),
-    outputSecrets: connectorRefreshOutputSecrets(accessMetadata),
+    outputTargets: connectorRefreshOutputTargets(accessMetadata),
     runtimeOutputSecrets,
     secretUserId: resolveSecretUserId(
       args.sourceType,
@@ -1736,16 +1802,35 @@ async function markRefreshSuccess(
   expiresIn: number | undefined,
 ): Promise<Record<string, string>> {
   const returnedSecretValues = new Map<string, string>();
-  for (const { secretName, value } of outputs) {
-    await upsertSecretValue(args.db, {
-      orgId: args.orgId,
-      userId: context.secretUserId,
-      name: secretName,
-      value,
-      type: args.sourceType,
-      featureSwitchContext: args.featureSwitchContext,
-    });
-    returnedSecretValues.set(secretName, value);
+  for (const { target, value } of outputs) {
+    switch (target.kind) {
+      case "secret": {
+        await upsertSecretValue(args.db, {
+          orgId: args.orgId,
+          userId: context.secretUserId,
+          name: target.name,
+          value,
+          type: args.sourceType,
+          featureSwitchContext: args.featureSwitchContext,
+        });
+        returnedSecretValues.set(target.name, value);
+        break;
+      }
+      case "connector-variable": {
+        if (args.sourceType !== "connector") {
+          throw new Error(
+            "Model provider refresh cannot write connector variables",
+          );
+        }
+        await upsertConnectorVariableValue(args.db, {
+          orgId: args.orgId,
+          userId: context.secretUserId,
+          name: target.name,
+          value,
+        });
+        break;
+      }
+    }
   }
 
   const expiresAt = new Date(
@@ -2004,15 +2089,17 @@ function validateRefreshResultOutputs(args: {
     if (value === undefined) {
       continue;
     }
-    const secretName = args.context.outputSecrets[outputName];
-    if (!secretName) {
+    const target = args.context.outputTargets[outputName];
+    if (!target) {
       return {
         ok: false,
         message: `${args.connectorType} token refresh returned undeclared output ${outputName}`,
       };
     }
-    returnedSecretValues.add(secretName);
-    outputs.push({ secretName, value });
+    if (target.kind === "secret") {
+      returnedSecretValues.add(target.name);
+    }
+    outputs.push({ target, value });
   }
 
   for (const secretName of requiredRuntimeOutputSecretNames(args.context)) {

--- a/turbo/apps/api/src/signals/services/zero-connector-data.service.ts
+++ b/turbo/apps/api/src/signals/services/zero-connector-data.service.ts
@@ -21,6 +21,7 @@ import {
   type ConnectorAuthMethodRef,
   type ConnectorAuthMethodRefByRevokeKind,
   type ConnectorManualGrantFieldNames,
+  type ConnectorOutputTarget,
 } from "@vm0/connectors/connector-utils";
 import { revokeConnectorAuthMethodAccessToken } from "@vm0/connectors/auth-providers";
 import {
@@ -88,7 +89,7 @@ interface PreparedManualGrantField {
 }
 
 interface ConnectorTokenOutputMetadata {
-  readonly outputSecretNames: Readonly<Record<string, string>>;
+  readonly outputTargets: Readonly<Record<string, ConnectorOutputTarget>>;
   readonly requiredOutputNames: readonly string[];
   readonly requiredExtraSecretNames: readonly string[];
   readonly isRefreshable: boolean;
@@ -129,7 +130,17 @@ interface EncryptedConnectorTokenSecret {
   readonly description: string;
 }
 
-interface ConnectorTokenSecretRequirements {
+interface PreparedConnectorTokenVariable {
+  readonly name: string;
+  readonly value: string;
+}
+
+interface PreparedConnectorTokenState {
+  readonly secrets: readonly EncryptedConnectorTokenSecret[];
+  readonly variables: readonly PreparedConnectorTokenVariable[];
+}
+
+interface ConnectorTokenOutputRequirements {
   readonly requiredOutputNames: readonly string[];
   readonly requiredExtraSecretNames: readonly string[];
 }
@@ -848,7 +859,7 @@ async function upsertManualGrantConnectorSecret(
     });
 }
 
-async function upsertManualGrantConnectorVariable(
+async function upsertConnectorVariable(
   db: Db,
   args: {
     readonly orgId: string;
@@ -1176,7 +1187,7 @@ export const connectManualGrantConnector$ = command(
       }
 
       for (const field of preparedResult.prepared.variableValues) {
-        await upsertManualGrantConnectorVariable(tx, {
+        await upsertConnectorVariable(tx, {
           orgId: args.orgId,
           userId: args.userId,
           name: field.name,
@@ -1309,20 +1320,20 @@ function connectorTokenOutputMetadataForAuthMethod(args: {
     case "auth-code":
     case "external-code":
     case "device-auth": {
-      const outputSecretNames = Object.fromEntries(
+      const outputTargets = Object.fromEntries(
         Object.entries(grantMetadata.outputs).map(([outputName, output]) => {
-          return [outputName, output.secretName];
+          return [outputName, output.target];
         }),
       );
-      const secretRequirements = requiredConnectorTokenSecretRequirements({
+      const outputRequirements = requiredConnectorTokenOutputRequirements({
         type: args.type,
         authMethod: args.authMethod,
-        outputSecretNames,
+        outputTargets,
       });
       return {
-        outputSecretNames,
-        requiredOutputNames: secretRequirements.requiredOutputNames,
-        requiredExtraSecretNames: secretRequirements.requiredExtraSecretNames,
+        outputTargets,
+        requiredOutputNames: outputRequirements.requiredOutputNames,
+        requiredExtraSecretNames: outputRequirements.requiredExtraSecretNames,
         isRefreshable: method.access.kind === "refresh-token",
       };
     }
@@ -1334,11 +1345,11 @@ function connectorTokenOutputMetadataForAuthMethod(args: {
   }
 }
 
-function requiredConnectorTokenSecretRequirements(args: {
+function requiredConnectorTokenOutputRequirements(args: {
   readonly type: ConnectorType;
   readonly authMethod: string;
-  readonly outputSecretNames: Readonly<Record<string, string>>;
-}): ConnectorTokenSecretRequirements {
+  readonly outputTargets: Readonly<Record<string, ConnectorOutputTarget>>;
+}): ConnectorTokenOutputRequirements {
   const runtimeMetadata = getConnectorAuthMethodRuntimeMetadata(
     args.type,
     args.authMethod,
@@ -1347,9 +1358,9 @@ function requiredConnectorTokenSecretRequirements(args: {
     return { requiredOutputNames: [], requiredExtraSecretNames: [] };
   }
 
-  const outputNameBySecretName = new Map(
-    Object.entries(args.outputSecretNames).map(([outputName, secretName]) => {
-      return [secretName, outputName];
+  const outputNameByTargetKey = new Map(
+    Object.entries(args.outputTargets).map(([outputName, target]) => {
+      return [connectorOutputTargetKey(target), outputName];
     }),
   );
   const requiredOutputNames = new Set<string>();
@@ -1358,20 +1369,40 @@ function requiredConnectorTokenSecretRequirements(args: {
     if (binding.optional) {
       continue;
     }
-    if (binding.source.kind !== "connector-secret") {
-      continue;
-    }
-    const outputName = outputNameBySecretName.get(binding.source.name);
-    if (outputName) {
-      requiredOutputNames.add(outputName);
-    } else {
-      requiredExtraSecretNames.add(binding.source.name);
+    switch (binding.source.kind) {
+      case "connector-secret": {
+        const outputName = outputNameByTargetKey.get(
+          connectorOutputTargetKey(binding.source),
+        );
+        if (outputName) {
+          requiredOutputNames.add(outputName);
+        } else {
+          requiredExtraSecretNames.add(binding.source.name);
+        }
+        break;
+      }
+      case "connector-variable": {
+        const outputName = outputNameByTargetKey.get(
+          connectorOutputTargetKey(binding.source),
+        );
+        if (outputName) {
+          requiredOutputNames.add(outputName);
+        }
+        break;
+      }
+      case "platform-secret": {
+        break;
+      }
     }
   }
   return {
     requiredOutputNames: [...requiredOutputNames],
     requiredExtraSecretNames: [...requiredExtraSecretNames],
   };
+}
+
+function connectorOutputTargetKey(target: ConnectorOutputTarget): string {
+  return `${target.kind}:${target.name}`;
 }
 
 function validateRequiredConnectorTokenSecrets(args: {
@@ -1416,16 +1447,16 @@ function allowedConnectorTokenSecretNames(
 
 function isPrimaryConnectorTokenSecret(args: {
   readonly name: string;
-  readonly outputSecretNames: ReadonlySet<string>;
+  readonly primaryOutputSecretNames: ReadonlySet<string>;
 }): boolean {
-  return args.outputSecretNames.has(args.name);
+  return args.primaryOutputSecretNames.has(args.name);
 }
 
 function validateExtraConnectorTokenSecrets(args: {
   readonly type: AuthGrantConnectorType;
   readonly authMethod: ConnectorAuthMethodId;
   readonly extraConnectorSecrets: Readonly<Record<string, string>> | undefined;
-  readonly outputSecretNames: Readonly<Record<string, string>>;
+  readonly outputTargets: Readonly<Record<string, ConnectorOutputTarget>>;
 }): readonly (readonly [string, string])[] {
   const extraSecrets = Object.entries(args.extraConnectorSecrets ?? {});
   if (extraSecrets.length === 0) {
@@ -1436,12 +1467,14 @@ function validateExtraConnectorTokenSecrets(args: {
     args.type,
     args.authMethod,
   );
-  const outputSecretNames = new Set(Object.values(args.outputSecretNames));
+  const primaryOutputSecretNames = connectorOutputSecretNames(
+    args.outputTargets,
+  );
   for (const [name] of extraSecrets) {
     if (
       isPrimaryConnectorTokenSecret({
         name,
-        outputSecretNames,
+        primaryOutputSecretNames,
       })
     ) {
       throw new Error(
@@ -1456,6 +1489,18 @@ function validateExtraConnectorTokenSecrets(args: {
   }
 
   return extraSecrets;
+}
+
+function connectorOutputSecretNames(
+  outputTargets: Readonly<Record<string, ConnectorOutputTarget>>,
+): Set<string> {
+  const secretNames = new Set<string>();
+  for (const target of Object.values(outputTargets)) {
+    if (target.kind === "connector-secret") {
+      secretNames.add(target.name);
+    }
+  }
+  return secretNames;
 }
 
 async function encryptExtraConnectorTokenSecrets(args: {
@@ -1479,16 +1524,16 @@ async function encryptExtraConnectorTokenSecrets(args: {
   return encryptedSecrets;
 }
 
-async function encryptConnectorTokenSecretSet(args: {
+async function prepareConnectorTokenState(args: {
   readonly type: AuthGrantConnectorType;
-  readonly outputSecretNames: Readonly<Record<string, string>>;
+  readonly outputTargets: Readonly<Record<string, ConnectorOutputTarget>>;
   readonly requiredOutputNames: readonly string[];
   readonly requiredExtraSecretNames: readonly string[];
   readonly outputs: ConnectorTokenOutputValues;
   readonly extraSecrets: readonly (readonly [string, string])[];
   readonly featureSwitchContext: FeatureSwitchContext;
   readonly signal: AbortSignal;
-}): Promise<readonly EncryptedConnectorTokenSecret[]> {
+}): Promise<PreparedConnectorTokenState> {
   validateRequiredConnectorTokenSecrets({
     type: args.type,
     outputs: args.outputs,
@@ -1498,24 +1543,29 @@ async function encryptConnectorTokenSecretSet(args: {
   });
 
   const encryptedConnectorTokenSecrets: EncryptedConnectorTokenSecret[] = [];
+  const connectorTokenVariables: PreparedConnectorTokenVariable[] = [];
   for (const [outputName, value] of Object.entries(args.outputs)) {
     if (!value) {
       continue;
     }
-    const secretName = args.outputSecretNames[outputName];
-    if (!secretName) {
+    const target = args.outputTargets[outputName];
+    if (!target) {
       throw new Error(
         `${args.type} connector provider returned undeclared token output ${outputName}`,
       );
     }
-    encryptedConnectorTokenSecrets.push(
-      await encryptedConnectorTokenSecret({
-        name: secretName,
-        value,
-        description: `Connector token output for ${args.type}: ${secretName}`,
-        featureSwitchContext: args.featureSwitchContext,
-      }),
-    );
+    if (target.kind === "connector-secret") {
+      encryptedConnectorTokenSecrets.push(
+        await encryptedConnectorTokenSecret({
+          name: target.name,
+          value,
+          description: `Connector token output for ${args.type}: ${target.name}`,
+          featureSwitchContext: args.featureSwitchContext,
+        }),
+      );
+    } else {
+      connectorTokenVariables.push({ name: target.name, value });
+    }
     args.signal.throwIfAborted();
   }
 
@@ -1527,7 +1577,10 @@ async function encryptConnectorTokenSecretSet(args: {
       signal: args.signal,
     })),
   );
-  return encryptedConnectorTokenSecrets;
+  return {
+    secrets: encryptedConnectorTokenSecrets,
+    variables: connectorTokenVariables,
+  };
 }
 
 async function upsertConnectorTokenSecrets(args: {
@@ -1551,6 +1604,47 @@ async function upsertConnectorTokenSecrets(args: {
     });
     args.signal.throwIfAborted();
   }
+}
+
+async function upsertConnectorTokenVariables(args: {
+  readonly db: Db;
+  readonly orgId: string;
+  readonly userId: string;
+  readonly variables: readonly PreparedConnectorTokenVariable[];
+  readonly signal: AbortSignal;
+}): Promise<void> {
+  for (const variable of args.variables) {
+    await upsertConnectorVariable(args.db, {
+      orgId: args.orgId,
+      userId: args.userId,
+      name: variable.name,
+      value: variable.value,
+    });
+    args.signal.throwIfAborted();
+  }
+}
+
+async function upsertPreparedConnectorTokenState(args: {
+  readonly db: Db;
+  readonly orgId: string;
+  readonly userId: string;
+  readonly state: PreparedConnectorTokenState;
+  readonly signal: AbortSignal;
+}): Promise<void> {
+  await upsertConnectorTokenSecrets({
+    db: args.db,
+    orgId: args.orgId,
+    userId: args.userId,
+    secrets: args.state.secrets,
+    signal: args.signal,
+  });
+  await upsertConnectorTokenVariables({
+    db: args.db,
+    orgId: args.orgId,
+    userId: args.userId,
+    variables: args.state.variables,
+    signal: args.signal,
+  });
 }
 
 async function loadExistingConnectorAuthMethod(
@@ -1722,25 +1816,23 @@ export const upsertConnectorTokenConnection$ = command(
       type: args.type,
       authMethod: args.authMethod,
       extraConnectorSecrets: args.extraConnectorSecrets,
-      outputSecretNames: outputMetadata.outputSecretNames,
+      outputTargets: outputMetadata.outputTargets,
     });
     const featureSwitchContext = await get(
       userFeatureSwitchContext(args.orgId, args.userId),
     );
     signal.throwIfAborted();
 
-    const encryptedConnectorTokenSecrets = await encryptConnectorTokenSecretSet(
-      {
-        type: args.type,
-        outputSecretNames: outputMetadata.outputSecretNames,
-        requiredOutputNames: outputMetadata.requiredOutputNames,
-        requiredExtraSecretNames: outputMetadata.requiredExtraSecretNames,
-        outputs: args.outputs,
-        extraSecrets,
-        featureSwitchContext,
-        signal,
-      },
-    );
+    const connectorTokenState = await prepareConnectorTokenState({
+      type: args.type,
+      outputTargets: outputMetadata.outputTargets,
+      requiredOutputNames: outputMetadata.requiredOutputNames,
+      requiredExtraSecretNames: outputMetadata.requiredExtraSecretNames,
+      outputs: args.outputs,
+      extraSecrets,
+      featureSwitchContext,
+      signal,
+    });
     signal.throwIfAborted();
 
     let postCommitAbort: unknown = null;
@@ -1759,11 +1851,11 @@ export const upsertConnectorTokenConnection$ = command(
         signal,
       });
 
-      await upsertConnectorTokenSecrets({
+      await upsertPreparedConnectorTokenState({
         db: tx,
         orgId: args.orgId,
         userId: args.userId,
-        secrets: encryptedConnectorTokenSecrets,
+        state: connectorTokenState,
         signal,
       });
       signal.throwIfAborted();

--- a/turbo/apps/api/src/signals/services/zero-connector-data.service.ts
+++ b/turbo/apps/api/src/signals/services/zero-connector-data.service.ts
@@ -1405,7 +1405,7 @@ function connectorOutputTargetKey(target: ConnectorOutputTarget): string {
   return `${target.kind}:${target.name}`;
 }
 
-function validateRequiredConnectorTokenSecrets(args: {
+function validateConnectorTokenOutputRequirements(args: {
   readonly type: AuthGrantConnectorType;
   readonly outputs: ConnectorTokenOutputValues;
   readonly requiredOutputNames: readonly string[];
@@ -1534,7 +1534,7 @@ async function prepareConnectorTokenState(args: {
   readonly featureSwitchContext: FeatureSwitchContext;
   readonly signal: AbortSignal;
 }): Promise<PreparedConnectorTokenState> {
-  validateRequiredConnectorTokenSecrets({
+  validateConnectorTokenOutputRequirements({
     type: args.type,
     outputs: args.outputs,
     requiredOutputNames: args.requiredOutputNames,

--- a/turbo/apps/cli/src/commands/zero/doctor/__tests__/check-connector.test.ts
+++ b/turbo/apps/cli/src/commands/zero/doctor/__tests__/check-connector.test.ts
@@ -115,6 +115,7 @@ describe("zero doctor check-connector command", () => {
     .mockImplementation(() => {});
 
   beforeEach(() => {
+    vi.unstubAllEnvs();
     vi.clearAllMocks();
     chalk.level = 0;
     vi.stubEnv("GH_TOKEN", "");
@@ -1044,8 +1045,15 @@ describe("zero doctor check-connector command", () => {
                 name: "test-oauth",
                 apis: [
                   {
-                    base: "https://{pr}.vm6.ai/api/test/oauth-provider",
-                    permissions: [],
+                    base: "https://tenant-123.{pr}.vm6.ai/api/test/oauth-provider",
+                    permissions: [
+                      {
+                        name: "echo",
+                        description:
+                          "Test echo endpoint used to verify token injection",
+                        rules: ["GET /echo"],
+                      },
+                    ],
                   },
                 ],
               },
@@ -1066,13 +1074,13 @@ describe("zero doctor check-connector command", () => {
         "node",
         "cli",
         "--url",
-        "https://pr-123.vm6.ai/api/test/oauth-provider/echo?debug=1#fragment",
+        "https://tenant-123.pr-123.vm6.ai/api/test/oauth-provider/echo?debug=1#fragment",
       ]);
 
       const output = getOutput();
       expect(output).toContain("matches the Test OAuth (internal) connector");
       expect(output).toContain(
-        "Matched base URL: https://{pr}.vm6.ai/api/test/oauth-provider",
+        "Matched base URL: https://tenant-123.{pr}.vm6.ai/api/test/oauth-provider",
       );
       expect(output).toContain("Relative path:    /echo");
       expect(output).toContain("Matched permissions: [echo]");

--- a/turbo/apps/cli/src/commands/zero/doctor/check-connector.ts
+++ b/turbo/apps/cli/src/commands/zero/doctor/check-connector.ts
@@ -13,12 +13,15 @@ import {
   findMatchingPermissions,
   matchFirewallBaseUrl,
 } from "@vm0/connectors/firewall-rule-matcher";
-import { extractSecretNamesFromApis } from "@vm0/connectors/firewall-types";
+import {
+  extractSecretNamesFromApis,
+  type FirewallConfig,
+  type NetworkPolicies,
+} from "@vm0/connectors/firewall-types";
 import {
   getConnectorFirewall,
   isFirewallConnectorType,
 } from "@vm0/connectors/firewalls";
-import type { NetworkPolicies } from "@vm0/connectors/firewall-types";
 import type { RunContextResponse } from "@vm0/api-contracts/contracts/zero-runs";
 import { getApiUrl } from "../../../lib/api/config";
 import {
@@ -52,6 +55,7 @@ interface UrlLookupResult {
   envName: string;
   matchedBase: string;
   relativePath: string;
+  permissionConfig?: FirewallConfig;
 }
 
 function isConnectorType(type: string): type is ConnectorType {
@@ -110,6 +114,71 @@ function resolveConnectorFromUrl(url: string): UrlLookupResult | null {
     matchedBase: bestMatch.match.displayBase,
     relativePath: bestMatch.match.relativePath,
   };
+}
+
+function runContextFirewallPermissionConfig(
+  firewall: RunContextResponse["firewalls"][number],
+): FirewallConfig {
+  return {
+    name: firewall.name,
+    apis: firewall.apis.map((api) => {
+      return {
+        base: api.base,
+        auth: {},
+        permissions: api.permissions,
+      };
+    }),
+  };
+}
+
+function resolveConnectorFromRunContext(
+  url: string,
+  runContext: RunContextResponse,
+): UrlLookupResult | null {
+  let bestMatch: {
+    connectorType: string;
+    match: FirewallBaseUrlMatch;
+    permissionConfig: FirewallConfig;
+  } | null = null;
+
+  for (const firewall of runContext.firewalls) {
+    if (!isConnectorType(firewall.name)) continue;
+    if (!isFirewallConnectorType(firewall.name)) continue;
+    for (const api of firewall.apis) {
+      const match = matchFirewallBaseUrl(url, api.base);
+      if (match === null) continue;
+      if (!bestMatch || match.score > bestMatch.match.score) {
+        bestMatch = {
+          connectorType: firewall.name,
+          match,
+          permissionConfig: runContextFirewallPermissionConfig(firewall),
+        };
+      }
+    }
+  }
+
+  if (!bestMatch) return null;
+
+  const envBindingEntries = getConnectorEnvBindingEntries(
+    bestMatch.connectorType as ConnectorType,
+  );
+  const envName = envBindingEntries[0]?.envName;
+  if (!envName) return null;
+
+  return {
+    connectorType: bestMatch.connectorType,
+    envName,
+    matchedBase: bestMatch.match.displayBase,
+    relativePath: bestMatch.match.relativePath,
+    permissionConfig: bestMatch.permissionConfig,
+  };
+}
+
+async function getCurrentRunContext(): Promise<RunContextResponse | null> {
+  const payload = decodeZeroTokenPayload();
+  const runId = payload?.runId;
+  if (!runId) return null;
+  return await getZeroRunContext(runId);
 }
 
 function checkEnvName(ctx: DiagContext): boolean {
@@ -227,6 +296,7 @@ async function checkConnectorStatus(ctx: DiagContext): Promise<{
 
 async function checkConnectorDomains(
   ctx: DiagContext,
+  preloadedRunContext?: RunContextResponse | null,
 ): Promise<NetworkPolicies | null> {
   // 2c: Registered base URLs — connector defines which URL prefixes get credential replacement
   console.log(
@@ -234,18 +304,17 @@ async function checkConnectorDomains(
   );
   console.log("");
 
-  const payload = decodeZeroTokenPayload();
-  const runId = payload?.runId;
-
-  if (!runId) {
+  const runContext =
+    preloadedRunContext === undefined
+      ? await getCurrentRunContext()
+      : preloadedRunContext;
+  if (!runContext) {
     console.log(
       "Cannot determine run ID from ZERO_TOKEN — skipping base URL check.",
     );
     console.log("");
     return null;
   }
-
-  const runContext = await getZeroRunContext(runId);
 
   printConnectorDomains(ctx, runContext);
   console.log("");
@@ -362,6 +431,7 @@ function resolvePermissionFromUrl(
   method: string,
   relativePath: string,
   matchedBase: string,
+  permissionConfig: FirewallConfig | undefined,
   networkPolicies: NetworkPolicies | null,
 ): void {
   console.log("## Step 3: Permission policy check (auto-detected from URL)");
@@ -379,7 +449,7 @@ function resolvePermissionFromUrl(
     return;
   }
 
-  const config = getConnectorFirewall(connectorType);
+  const config = permissionConfig ?? getConnectorFirewall(connectorType);
   const matchedPermissions = findMatchingPermissions(
     method,
     relativePath,
@@ -499,9 +569,16 @@ How connectors work:
       let envName: string;
       let connectorType: string;
       let urlLookup: UrlLookupResult | null = null;
+      let runContext: RunContextResponse | null | undefined;
 
       if (opts.url) {
         urlLookup = resolveConnectorFromUrl(opts.url);
+        if (!urlLookup) {
+          runContext = await getCurrentRunContext();
+          if (runContext) {
+            urlLookup = resolveConnectorFromRunContext(opts.url, runContext);
+          }
+        }
         if (!urlLookup) {
           throw new Error(
             `No connector found for URL: ${opts.url} — no registered base URL matches this URL`,
@@ -550,7 +627,7 @@ How connectors work:
       checkEnvName(ctx);
       const { isConnected, isExpired, hasPermission } =
         await checkConnectorStatus(ctx);
-      const networkPolicies = await checkConnectorDomains(ctx);
+      const networkPolicies = await checkConnectorDomains(ctx, runContext);
 
       // Summary for Step 2
       if (isConnected && !isExpired && hasPermission) {
@@ -569,6 +646,7 @@ How connectors work:
           opts.method,
           urlLookup.relativePath,
           urlLookup.matchedBase,
+          urlLookup.permissionConfig,
           networkPolicies,
         );
       } else if (opts.checkPermission) {

--- a/turbo/packages/connectors/src/__tests__/connectors.test.ts
+++ b/turbo/packages/connectors/src/__tests__/connectors.test.ts
@@ -126,6 +126,10 @@ function connectorSecretTargetName(
 ): string | undefined {
   return target?.kind === "connector-secret" ? target.name : undefined;
 }
+
+function connectorOutputTargetKey(target: ConnectorOutputTarget): string {
+  return `${target.kind}:${target.name}`;
+}
 const SLOCK_ACCESS_TOKEN_TTL_SECONDS = 900;
 const STRIPE_CLI_AUTH_URL = "https://dashboard.stripe.com/stripecli/auth";
 const STRIPE_CLI_BROWSER_URL =
@@ -3171,6 +3175,73 @@ describe("getConnectorAuthMethodGrantMetadata", () => {
         },
       },
     });
+  });
+
+  it("initializes provider grant connector variables needed by runtime or refresh", () => {
+    for (const type of connectorTypeSchema.options) {
+      for (const authMethod of getConfiguredConnectorAuthMethodIds(type)) {
+        const method = getConnectorAuthMethod(type, authMethod);
+        if (
+          !method ||
+          !(
+            method.grant.kind === "auth-code" ||
+            method.grant.kind === "external-code" ||
+            method.grant.kind === "device-auth"
+          )
+        ) {
+          continue;
+        }
+
+        const grantMetadata = getConnectorAuthMethodGrantMetadata(
+          type,
+          authMethod,
+        );
+        const runtimeMetadata = getConnectorAuthMethodRuntimeMetadata(
+          type,
+          authMethod,
+        );
+        if (!grantMetadata || !runtimeMetadata) {
+          throw new Error(`${type}/${authMethod}: missing connector metadata`);
+        }
+
+        const grantOutputTargetKeys = new Set(
+          Object.values(grantMetadata.outputs).map((output) => {
+            return connectorOutputTargetKey(output.target);
+          }),
+        );
+
+        for (const binding of runtimeMetadata.runtimeBindings) {
+          if (
+            binding.optional ||
+            binding.source.kind !== "connector-variable"
+          ) {
+            continue;
+          }
+          expect(
+            grantOutputTargetKeys,
+            `${type}/${authMethod}: required runtime variable ${binding.source.name} must be initialized by a grant output`,
+          ).toContain(connectorOutputTargetKey(binding.source));
+        }
+
+        const accessMetadata = getConnectorAuthMethodAccessMetadata(
+          type,
+          authMethod,
+        );
+        if (accessMetadata?.kind !== "refresh-token") {
+          continue;
+        }
+
+        for (const input of Object.values(accessMetadata.inputs)) {
+          if (input.source.kind !== "connector-variable") {
+            continue;
+          }
+          expect(
+            grantOutputTargetKeys,
+            `${type}/${authMethod}: refresh input variable ${input.source.name} must be initialized by a grant output`,
+          ).toContain(connectorOutputTargetKey(input.source));
+        }
+      }
+    }
   });
 });
 

--- a/turbo/packages/connectors/src/__tests__/connectors.test.ts
+++ b/turbo/packages/connectors/src/__tests__/connectors.test.ts
@@ -918,9 +918,16 @@ describe("connector selected auth method capability checks", () => {
       TEST_OAUTH_TENANT_ID: "$vars.TEST_OAUTH_API_TENANT_ID",
     });
     expect(
+      getConnectorAuthMethodEnvBindings("test-oauth", "oauth"),
+    ).toStrictEqual({
+      TEST_OAUTH_TOKEN: "$secrets.TEST_OAUTH_ACCESS_TOKEN",
+      TEST_OAUTH_TENANT_ID: "$vars.TEST_OAUTH_API_TENANT_ID",
+    });
+    expect(
       getConnectorAuthMethodEnvBindings("test-oauth", "api-token"),
     ).toStrictEqual({
       TEST_OAUTH_API_TOKEN: "$secrets.TEST_OAUTH_API_TOKEN_ACCESS_TOKEN",
+      TEST_OAUTH_TENANT_ID: "$vars.TEST_OAUTH_API_TENANT_ID",
     });
 
     const authClient = resolveConnectorAuthClientForMethod(
@@ -2786,6 +2793,7 @@ describe("getConnectorAuthMethodAccessMetadata", () => {
       refreshableSecrets: ["TEST_OAUTH_API_TOKEN_ACCESS_TOKEN"],
       envBindings: {
         TEST_OAUTH_API_TOKEN: "$secrets.TEST_OAUTH_API_TOKEN_ACCESS_TOKEN",
+        TEST_OAUTH_TENANT_ID: "$vars.TEST_OAUTH_API_TENANT_ID",
       },
       platformSecrets: [],
     });

--- a/turbo/packages/connectors/src/__tests__/connectors.test.ts
+++ b/turbo/packages/connectors/src/__tests__/connectors.test.ts
@@ -52,8 +52,8 @@ import {
   getConnectorAuthMethodDeviceAuthStartOptionsConfig,
   getConnectorAuthMethodAccessMetadata,
   getConnectorAuthMethodRuntimeMetadata,
-  getConnectorGrantOutputSecretName,
-  getConnectorRefreshOutputSecretName,
+  getConnectorGrantOutputTarget,
+  getConnectorRefreshOutputTarget,
   getConnectorStoredSecretDisplayInfo,
   getDiagnosticConnectorTypeForRuntimeEnvName,
   resolveConnectorAuthClientForMethod,
@@ -75,6 +75,7 @@ import {
   type ConnectorAuthClientForMethod,
   type ConnectorAuthMethodRef,
   type ConnectorEnvReader,
+  type ConnectorOutputTarget,
 } from "../connector-utils";
 import { FeatureSwitchKey } from "../feature-switch-key";
 import {
@@ -119,6 +120,12 @@ function hasConnectorAuthorizationGrant(type: ConnectorType): boolean {
 }
 
 const server = setupServer();
+
+function connectorSecretTargetName(
+  target: ConnectorOutputTarget | undefined,
+): string | undefined {
+  return target?.kind === "connector-secret" ? target.name : undefined;
+}
 const SLOCK_ACCESS_TOKEN_TTL_SECONDS = 900;
 const STRIPE_CLI_AUTH_URL = "https://dashboard.stripe.com/stripecli/auth";
 const STRIPE_CLI_BROWSER_URL =
@@ -904,6 +911,7 @@ describe("connector selected auth method capability checks", () => {
       getConnectorAuthMethodEnvBindings("test-oauth", "api"),
     ).toStrictEqual({
       TEST_OAUTH_TOKEN: "$secrets.TEST_OAUTH_API_ACCESS_TOKEN",
+      TEST_OAUTH_TENANT_ID: "$vars.TEST_OAUTH_API_TENANT_ID",
     });
     expect(
       getConnectorAuthMethodEnvBindings("test-oauth", "api-token"),
@@ -1269,11 +1277,11 @@ describe("connector selected auth method capability checks", () => {
   it("keeps test OAuth device provider access secrets method-specific", () => {
     expect(
       getConnectorAuthMethodGrantMetadata("test-oauth-device", "oauth")?.outputs
-        .accessToken?.secretName,
+        .accessToken?.target.name,
     ).toBe(TEST_OAUTH_DEVICE_ACCESS_SECRET_NAME);
     expect(
       getConnectorAuthMethodGrantMetadata("test-oauth-device", "api")?.outputs
-        .accessToken?.secretName,
+        .accessToken?.target.name,
     ).toBe(TEST_OAUTH_DEVICE_API_ACCESS_SECRET_NAME);
   });
 
@@ -2525,11 +2533,17 @@ describe("getConnectorAuthMethodAccessMetadata", () => {
       outputs: {
         accessToken: {
           valueRef: "$secrets.STRIPE_ACCESS_TOKEN",
-          secretName: "STRIPE_ACCESS_TOKEN",
+          target: {
+            kind: "connector-secret",
+            name: "STRIPE_ACCESS_TOKEN",
+          },
         },
         refreshToken: {
           valueRef: "$secrets.STRIPE_REFRESH_TOKEN",
-          secretName: "STRIPE_REFRESH_TOKEN",
+          target: {
+            kind: "connector-secret",
+            name: "STRIPE_REFRESH_TOKEN",
+          },
         },
       },
       refreshableSecrets: ["STRIPE_ACCESS_TOKEN"],
@@ -2593,19 +2607,31 @@ describe("getConnectorAuthMethodAccessMetadata", () => {
       outputs: {
         refreshToken: {
           valueRef: "$secrets.AWS_LOGIN_REFRESH_TOKEN",
-          secretName: "AWS_LOGIN_REFRESH_TOKEN",
+          target: {
+            kind: "connector-secret",
+            name: "AWS_LOGIN_REFRESH_TOKEN",
+          },
         },
         accessKeyId: {
           valueRef: "$secrets.AWS_ACCESS_KEY_ID",
-          secretName: "AWS_ACCESS_KEY_ID",
+          target: {
+            kind: "connector-secret",
+            name: "AWS_ACCESS_KEY_ID",
+          },
         },
         secretAccessKey: {
           valueRef: "$secrets.AWS_SECRET_ACCESS_KEY",
-          secretName: "AWS_SECRET_ACCESS_KEY",
+          target: {
+            kind: "connector-secret",
+            name: "AWS_SECRET_ACCESS_KEY",
+          },
         },
         sessionToken: {
           valueRef: "$secrets.AWS_SESSION_TOKEN",
-          secretName: "AWS_SESSION_TOKEN",
+          target: {
+            kind: "connector-secret",
+            name: "AWS_SESSION_TOKEN",
+          },
         },
       },
       refreshableSecrets: [
@@ -2641,11 +2667,17 @@ describe("getConnectorAuthMethodAccessMetadata", () => {
       outputs: {
         accessToken: {
           valueRef: "$secrets.GOOGLE_ADS_ACCESS_TOKEN",
-          secretName: "GOOGLE_ADS_ACCESS_TOKEN",
+          target: {
+            kind: "connector-secret",
+            name: "GOOGLE_ADS_ACCESS_TOKEN",
+          },
         },
         refreshToken: {
           valueRef: "$secrets.GOOGLE_ADS_REFRESH_TOKEN",
-          secretName: "GOOGLE_ADS_REFRESH_TOKEN",
+          target: {
+            kind: "connector-secret",
+            name: "GOOGLE_ADS_REFRESH_TOKEN",
+          },
         },
       },
       refreshableSecrets: ["GOOGLE_ADS_ACCESS_TOKEN"],
@@ -2681,20 +2713,37 @@ describe("getConnectorAuthMethodAccessMetadata", () => {
       outputs: {
         refreshedAccessToken: {
           valueRef: "$secrets.TEST_OAUTH_API_ACCESS_TOKEN",
-          secretName: "TEST_OAUTH_API_ACCESS_TOKEN",
+          target: {
+            kind: "connector-secret",
+            name: "TEST_OAUTH_API_ACCESS_TOKEN",
+          },
         },
         refreshedRefreshToken: {
           valueRef: "$secrets.TEST_OAUTH_API_REFRESH_TOKEN",
-          secretName: "TEST_OAUTH_API_REFRESH_TOKEN",
+          target: {
+            kind: "connector-secret",
+            name: "TEST_OAUTH_API_REFRESH_TOKEN",
+          },
         },
         secondaryToken: {
           valueRef: "$secrets.TEST_OAUTH_API_SECONDARY_TOKEN",
-          secretName: "TEST_OAUTH_API_SECONDARY_TOKEN",
+          target: {
+            kind: "connector-secret",
+            name: "TEST_OAUTH_API_SECONDARY_TOKEN",
+          },
+        },
+        refreshedTenantId: {
+          valueRef: "$vars.TEST_OAUTH_API_TENANT_ID",
+          target: {
+            kind: "connector-variable",
+            name: "TEST_OAUTH_API_TENANT_ID",
+          },
         },
       },
       refreshableSecrets: ["TEST_OAUTH_API_ACCESS_TOKEN"],
       envBindings: {
         TEST_OAUTH_TOKEN: "$secrets.TEST_OAUTH_API_ACCESS_TOKEN",
+        TEST_OAUTH_TENANT_ID: "$vars.TEST_OAUTH_API_TENANT_ID",
       },
       platformSecrets: [],
     });
@@ -2724,7 +2773,10 @@ describe("getConnectorAuthMethodAccessMetadata", () => {
       outputs: {
         accessToken: {
           valueRef: "$secrets.TEST_OAUTH_API_TOKEN_ACCESS_TOKEN",
-          secretName: "TEST_OAUTH_API_TOKEN_ACCESS_TOKEN",
+          target: {
+            kind: "connector-secret",
+            name: "TEST_OAUTH_API_TOKEN_ACCESS_TOKEN",
+          },
         },
       },
       refreshableSecrets: ["TEST_OAUTH_API_TOKEN_ACCESS_TOKEN"],
@@ -2771,7 +2823,10 @@ describe("getConnectorAuthMethodAccessMetadata", () => {
       outputs: {
         accessToken: {
           valueRef: "$secrets.LARK_ACCESS_TOKEN",
-          secretName: "LARK_ACCESS_TOKEN",
+          target: {
+            kind: "connector-secret",
+            name: "LARK_ACCESS_TOKEN",
+          },
         },
       },
       refreshableSecrets: ["LARK_ACCESS_TOKEN"],
@@ -2836,10 +2891,12 @@ describe("getConnectorAuthMethodAccessMetadata", () => {
         }
         if (accessMetadata.kind === "refresh-token") {
           for (const output of Object.values(accessMetadata.outputs)) {
-            expect(
-              platformSecretNames.has(output.secretName),
-              `${type}/${authMethod}: refresh output storage must stay connector-owned`,
-            ).toBe(false);
+            if (output.target.kind === "connector-secret") {
+              expect(
+                platformSecretNames.has(output.target.name),
+                `${type}/${authMethod}: refresh output storage must stay connector-owned`,
+              ).toBe(false);
+            }
           }
         }
       }
@@ -3092,7 +3149,7 @@ describe("getConnectorAuthMethodRuntimeMetadata", () => {
 });
 
 describe("getConnectorAuthMethodGrantMetadata", () => {
-  it("returns provider output secret mappings for OAuth grants", () => {
+  it("returns provider output target mappings for OAuth grants", () => {
     expect(
       getConnectorAuthMethodGrantMetadata("linear", "oauth"),
     ).toStrictEqual({
@@ -3100,11 +3157,17 @@ describe("getConnectorAuthMethodGrantMetadata", () => {
       outputs: {
         accessToken: {
           valueRef: "$secrets.LINEAR_ACCESS_TOKEN",
-          secretName: "LINEAR_ACCESS_TOKEN",
+          target: {
+            kind: "connector-secret",
+            name: "LINEAR_ACCESS_TOKEN",
+          },
         },
         refreshToken: {
           valueRef: "$secrets.LINEAR_REFRESH_TOKEN",
-          secretName: "LINEAR_REFRESH_TOKEN",
+          target: {
+            kind: "connector-secret",
+            name: "LINEAR_REFRESH_TOKEN",
+          },
         },
       },
     });
@@ -3270,9 +3333,8 @@ describe("getConnectorEnvBindingEntries", () => {
       if (!grantMetadata) {
         throw new Error(`${type}: missing OAuth grant metadata`);
       }
-      const accessSecretName = getConnectorGrantOutputSecretName(
-        grantMetadata,
-        "accessToken",
+      const accessSecretName = connectorSecretTargetName(
+        getConnectorGrantOutputTarget(grantMetadata, "accessToken"),
       );
       expect(
         accessSecretName,
@@ -3300,11 +3362,15 @@ describe("getConnectorEnvBindingEntries", () => {
           oauthAuthMethodRef.authMethod,
         );
         expect(
-          getConnectorGrantOutputSecretName(grantMetadata, "refreshToken"),
+          connectorSecretTargetName(
+            getConnectorGrantOutputTarget(grantMetadata, "refreshToken"),
+          ),
           `${type}: grant must declare refresh token storage`,
         ).toBe(refreshSecretName);
         expect(
-          getConnectorRefreshOutputSecretName(accessMetadata, "refreshToken"),
+          connectorSecretTargetName(
+            getConnectorRefreshOutputTarget(accessMetadata, "refreshToken"),
+          ),
           `${type}: refresh-token access must declare refresh token storage`,
         ).toBe(refreshSecretName);
         expect(

--- a/turbo/packages/connectors/src/auth-providers/connectors/__tests__/google-ads.test.ts
+++ b/turbo/packages/connectors/src/auth-providers/connectors/__tests__/google-ads.test.ts
@@ -4,7 +4,7 @@ import {
   connectorAuthClientIdentity,
   getConnectorAuthMethodAuthCodeGrantConfig,
   getConnectorAuthMethodAccessMetadata,
-  getConnectorRefreshOutputSecretName,
+  getConnectorRefreshOutputTarget,
   resolveConnectorAuthClientForMethod,
   type StaticConfidentialConnectorAuthClient,
 } from "../../../connector-utils";
@@ -80,8 +80,11 @@ describe("connector/providers/google-ads", () => {
       );
 
       expect(
-        getConnectorRefreshOutputSecretName(accessMetadata, "accessToken"),
-      ).toBe("GOOGLE_ADS_ACCESS_TOKEN");
+        getConnectorRefreshOutputTarget(accessMetadata, "accessToken"),
+      ).toStrictEqual({
+        kind: "connector-secret",
+        name: "GOOGLE_ADS_ACCESS_TOKEN",
+      });
     });
 
     it("declares GOOGLE_ADS_REFRESH_TOKEN as the refresh token input and output", () => {
@@ -98,8 +101,11 @@ describe("connector/providers/google-ads", () => {
         },
       });
       expect(
-        getConnectorRefreshOutputSecretName(accessMetadata, "refreshToken"),
-      ).toBe("GOOGLE_ADS_REFRESH_TOKEN");
+        getConnectorRefreshOutputTarget(accessMetadata, "refreshToken"),
+      ).toStrictEqual({
+        kind: "connector-secret",
+        name: "GOOGLE_ADS_REFRESH_TOKEN",
+      });
     });
 
     it("refreshToken is defined (uses shared Google token refresh)", () => {

--- a/turbo/packages/connectors/src/auth-providers/connectors/test-oauth/provider.ts
+++ b/turbo/packages/connectors/src/auth-providers/connectors/test-oauth/provider.ts
@@ -18,6 +18,7 @@ import type {
 type TestOAuthGrantResult = ConnectorAuthProviderGrantResult<{
   readonly accessToken: string;
   readonly refreshToken: string | null;
+  readonly tenantId: string;
 }>;
 
 type TestOAuthApiGrantResult = ConnectorAuthProviderGrantResult<{
@@ -83,6 +84,7 @@ async function exchangeTestOauthGrant(args: {
     outputs: {
       accessToken: token.accessToken,
       refreshToken: token.refreshToken,
+      tenantId: token.userInfo.id,
     },
     expiresIn: token.expiresIn,
     scopes: token.scopes,

--- a/turbo/packages/connectors/src/auth-providers/connectors/test-oauth/provider.ts
+++ b/turbo/packages/connectors/src/auth-providers/connectors/test-oauth/provider.ts
@@ -23,12 +23,14 @@ type TestOAuthGrantResult = ConnectorAuthProviderGrantResult<{
 type TestOAuthApiGrantResult = ConnectorAuthProviderGrantResult<{
   readonly initialAccessToken: string;
   readonly initialRefreshToken: string | null;
+  readonly tenantId: string;
 }>;
 
 interface TestOAuthApiRefreshResult {
   readonly outputs: {
     readonly refreshedAccessToken: string;
     readonly refreshedRefreshToken?: string;
+    readonly refreshedTenantId?: string;
   };
   readonly expiresIn?: number;
 }
@@ -99,6 +101,7 @@ async function exchangeTestOauthApiGrant(args: {
     outputs: {
       initialAccessToken: token.accessToken,
       initialRefreshToken: token.refreshToken,
+      tenantId: token.userInfo.id,
     },
     expiresIn: token.expiresIn,
     scopes: token.scopes,
@@ -192,6 +195,7 @@ function createTestOauthApiAccess(): RefreshTokenAccessProvider<
       const providerResult: TestOAuthApiRefreshResult = {
         outputs: {
           refreshedAccessToken: result.accessToken,
+          refreshedTenantId: refreshArgs.inputs.tenantId,
           ...(result.refreshToken
             ? { refreshedRefreshToken: result.refreshToken }
             : {}),

--- a/turbo/packages/connectors/src/connector-utils.ts
+++ b/turbo/packages/connectors/src/connector-utils.ts
@@ -39,6 +39,7 @@ import {
   type ConnectorRevokeInputBindings,
   type ConnectorRevokeKind,
   type ConnectorSecretValueRef,
+  type ConnectorOutputValueRef,
   type ConnectorVariableValueRef,
   type ConnectorEnvBindingValue,
   type ConnectorType,
@@ -321,7 +322,7 @@ export interface ConnectorRefreshTokenInputMetadata {
 
 export interface ConnectorRefreshTokenOutputMetadata {
   readonly valueRef: string;
-  readonly secretName: string;
+  readonly target: ConnectorOutputTarget;
 }
 
 export interface ConnectorRefreshTokenMetadata {
@@ -334,7 +335,7 @@ export interface ConnectorRefreshTokenMetadata {
 
 export interface ConnectorGrantOutputMetadata {
   readonly valueRef: string;
-  readonly secretName: string;
+  readonly target: ConnectorOutputTarget;
 }
 
 export type ConnectorAuthMethodGrantMetadata =
@@ -376,6 +377,16 @@ export type ConnectorRuntimeBindingSource =
       readonly name: ConnectorPlatformSecretName;
     };
 
+export type ConnectorOutputTarget =
+  | {
+      readonly kind: "connector-secret";
+      readonly name: string;
+    }
+  | {
+      readonly kind: "connector-variable";
+      readonly name: string;
+    };
+
 export interface ConnectorRuntimeBindingEntry {
   readonly envName: string;
   readonly valueRef: string;
@@ -392,7 +403,7 @@ export interface ConnectorAuthMethodRuntimeMetadata {
 }
 
 function isConnectorSecretValueRef(
-  valueRef: ConnectorRefreshTokenInputValueRef,
+  valueRef: ConnectorOutputValueRef,
 ): valueRef is ConnectorSecretValueRef {
   return valueRef.startsWith(CONNECTOR_SECRET_REF_PREFIX);
 }
@@ -430,15 +441,34 @@ function connectorRefreshInputMetadata(
 }
 
 function connectorRefreshOutputMetadata(
-  valueRef: ConnectorSecretValueRef,
+  valueRef: ConnectorOutputValueRef,
 ): ConnectorRefreshTokenOutputMetadata {
-  return { valueRef, secretName: connectorSecretNameFromValueRef(valueRef) };
+  return {
+    valueRef,
+    target: connectorOutputTargetFromValueRef(valueRef),
+  };
 }
 
 function connectorGrantOutputMetadata(
-  valueRef: ConnectorSecretValueRef,
+  valueRef: ConnectorOutputValueRef,
 ): ConnectorGrantOutputMetadata {
   return connectorRefreshOutputMetadata(valueRef);
+}
+
+function connectorOutputTargetFromValueRef(
+  valueRef: ConnectorOutputValueRef,
+): ConnectorOutputTarget {
+  if (isConnectorSecretValueRef(valueRef)) {
+    return {
+      kind: "connector-secret",
+      name: connectorSecretNameFromValueRef(valueRef),
+    };
+  }
+
+  return {
+    kind: "connector-variable",
+    name: connectorVariableNameFromValueRef(valueRef),
+  };
 }
 
 function connectorRevokeInputMetadata(
@@ -544,11 +574,11 @@ export function getConnectorAuthMethodGrantMetadata(
   }
 }
 
-export function getConnectorGrantOutputSecretName(
+export function getConnectorGrantOutputTarget(
   metadata: ConnectorAuthMethodGrantMetadata,
   outputName: string,
-): string | undefined {
-  return metadata.outputs[outputName]?.secretName;
+): ConnectorOutputTarget | undefined {
+  return metadata.outputs[outputName]?.target;
 }
 
 function connectorRevokeInputMetadataMap(
@@ -584,12 +614,12 @@ export function getConnectorAuthMethodRevokeMetadata(
   }
 }
 
-export function getConnectorRefreshOutputSecretName(
+export function getConnectorRefreshOutputTarget(
   metadata: ConnectorAuthMethodAccessMetadata,
   outputName: string,
-): string | undefined {
+): ConnectorOutputTarget | undefined {
   return metadata.kind === "refresh-token"
-    ? metadata.outputs[outputName]?.secretName
+    ? metadata.outputs[outputName]?.target
     : undefined;
 }
 

--- a/turbo/packages/connectors/src/connectors.ts
+++ b/turbo/packages/connectors/src/connectors.ts
@@ -402,6 +402,9 @@ export type ConnectorPlatformSecretName =
 
 export type ConnectorSecretValueRef = `$secrets.${string}`;
 export type ConnectorVariableValueRef = `$vars.${string}`;
+export type ConnectorOutputValueRef =
+  | ConnectorSecretValueRef
+  | ConnectorVariableValueRef;
 export type ConnectorRefreshTokenInputValueRef =
   | ConnectorSecretValueRef
   | ConnectorVariableValueRef;
@@ -415,7 +418,7 @@ export type ConnectorEnvBindings = Record<string, ConnectorEnvBindingValue>;
 
 export type ConnectorGrantOutputBindings = Record<
   string,
-  ConnectorSecretValueRef
+  ConnectorOutputValueRef
 >;
 export type ConnectorRevokeInputBindings = Record<
   string,
@@ -446,7 +449,7 @@ export type ConnectorRefreshTokenInputBindings = Record<
 >;
 export type ConnectorRefreshTokenOutputBindings = Record<
   string,
-  ConnectorSecretValueRef
+  ConnectorOutputValueRef
 >;
 
 export interface ConnectorRefreshTokenAccessConfig extends ConnectorEnvBindingAccessConfigBase {
@@ -701,8 +704,9 @@ type ConnectorRefreshInputValueRef<Storage> =
   | `$secrets.${ConnectorStorageSecretName<Storage>}`
   | `$vars.${ConnectorStorageVariableName<Storage>}`;
 
-type ConnectorRefreshOutputValueRef<Storage> =
-  `$secrets.${ConnectorStorageSecretName<Storage>}`;
+type ConnectorStorageOutputValueRef<Storage> =
+  | `$secrets.${ConnectorStorageSecretName<Storage>}`
+  | `$vars.${ConnectorStorageVariableName<Storage>}`;
 
 type ConnectorRevokeInputValueRef<Storage> =
   `$secrets.${ConnectorStorageSecretName<Storage>}`;
@@ -742,15 +746,15 @@ type ValidatedConnectorRefreshInputs<Inputs, Storage> = {
 };
 
 type ValidatedConnectorRefreshOutputs<Outputs, Storage> = {
-  readonly [OutputName in keyof Outputs]: Outputs[OutputName] extends ConnectorRefreshOutputValueRef<Storage>
+  readonly [OutputName in keyof Outputs]: Outputs[OutputName] extends ConnectorStorageOutputValueRef<Storage>
     ? Outputs[OutputName]
-    : ConnectorRefreshOutputValueRef<Storage>;
+    : ConnectorStorageOutputValueRef<Storage>;
 };
 
 type ValidatedConnectorGrantOutputs<Outputs, Storage> = {
-  readonly [OutputName in keyof Outputs]: Outputs[OutputName] extends ConnectorRefreshOutputValueRef<Storage>
+  readonly [OutputName in keyof Outputs]: Outputs[OutputName] extends ConnectorStorageOutputValueRef<Storage>
     ? Outputs[OutputName]
-    : ConnectorRefreshOutputValueRef<Storage>;
+    : ConnectorStorageOutputValueRef<Storage>;
 };
 
 type ValidatedConnectorRevokeInputs<Inputs, Storage> = {
@@ -776,8 +780,16 @@ type ConnectorRefreshableSecretName<
     ? Extract<SecretName, string>
     : never;
 
-type ConnectorRefreshOutputSecretNameFromRef<Ref> =
-  Ref extends `$secrets.${infer Name}` ? Name : never;
+type ConnectorRequiredRefreshOutputNameFromRef<
+  Type extends ConnectorType,
+  Method extends ConnectorAuthMethodIds<Type>,
+  OutputName,
+  Ref,
+> = Ref extends `$secrets.${infer Name}`
+  ? Name extends ConnectorRefreshableSecretName<Type, Method>
+    ? OutputName
+    : never
+  : never;
 
 type ConnectorRequiredRefreshOutputName<
   Type extends ConnectorType,
@@ -786,11 +798,12 @@ type ConnectorRequiredRefreshOutputName<
   readonly [OutputName in keyof ConnectorRefreshOutputsFor<
     Type,
     Method
-  >]: ConnectorRefreshOutputSecretNameFromRef<
+  >]: ConnectorRequiredRefreshOutputNameFromRef<
+    Type,
+    Method,
+    OutputName,
     ConnectorRefreshOutputsFor<Type, Method>[OutputName]
-  > extends ConnectorRefreshableSecretName<Type, Method>
-    ? OutputName
-    : never;
+  >;
 }[keyof ConnectorRefreshOutputsFor<Type, Method>];
 
 type ValidatedConnectorRefreshableSecrets<Secrets, Outputs> =

--- a/turbo/packages/connectors/src/connectors/test-oauth.ts
+++ b/turbo/packages/connectors/src/connectors/test-oauth.ts
@@ -29,6 +29,7 @@ const TEST_OAUTH_API_AUTH_CODE_GRANT = {
   outputs: {
     initialAccessToken: "$secrets.TEST_OAUTH_API_ACCESS_TOKEN",
     initialRefreshToken: "$secrets.TEST_OAUTH_API_REFRESH_TOKEN",
+    tenantId: "$vars.TEST_OAUTH_API_TENANT_ID",
   },
 } as const satisfies ConnectorAuthCodeGrantConfig;
 
@@ -109,10 +110,12 @@ export const testOauth = {
             refreshedAccessToken: "$secrets.TEST_OAUTH_API_ACCESS_TOKEN",
             refreshedRefreshToken: "$secrets.TEST_OAUTH_API_REFRESH_TOKEN",
             secondaryToken: "$secrets.TEST_OAUTH_API_SECONDARY_TOKEN",
+            refreshedTenantId: "$vars.TEST_OAUTH_API_TENANT_ID",
           },
           refreshableSecrets: ["TEST_OAUTH_API_ACCESS_TOKEN"],
           envBindings: {
             TEST_OAUTH_TOKEN: "$secrets.TEST_OAUTH_API_ACCESS_TOKEN",
+            TEST_OAUTH_TENANT_ID: "$vars.TEST_OAUTH_API_TENANT_ID",
           },
         },
         revoke: TEST_OAUTH_REVOKE,

--- a/turbo/packages/connectors/src/connectors/test-oauth.ts
+++ b/turbo/packages/connectors/src/connectors/test-oauth.ts
@@ -20,6 +20,7 @@ const TEST_OAUTH_AUTH_CODE_GRANT = {
   outputs: {
     accessToken: "$secrets.TEST_OAUTH_ACCESS_TOKEN",
     refreshToken: "$secrets.TEST_OAUTH_REFRESH_TOKEN",
+    tenantId: "$vars.TEST_OAUTH_API_TENANT_ID",
   },
 } as const satisfies ConnectorAuthCodeGrantConfig;
 
@@ -47,6 +48,12 @@ const TEST_OAUTH_API_TOKEN_MANUAL_GRANT = {
       placeholder: "test-input-variable",
       storage: "variable",
     },
+    TEST_OAUTH_API_TENANT_ID: {
+      label: "Tenant ID",
+      required: true,
+      placeholder: "test-oauth-tenant",
+      storage: "variable",
+    },
   },
 } as const satisfies ConnectorManualGrantConfig;
 
@@ -66,7 +73,7 @@ export const testOauth = {
         client: TEST_OAUTH_CLIENT,
         storage: {
           secrets: ["TEST_OAUTH_ACCESS_TOKEN", "TEST_OAUTH_REFRESH_TOKEN"],
-          variables: [],
+          variables: ["TEST_OAUTH_API_TENANT_ID"],
         },
         grant: TEST_OAUTH_AUTH_CODE_GRANT,
         access: {
@@ -81,6 +88,7 @@ export const testOauth = {
           refreshableSecrets: ["TEST_OAUTH_ACCESS_TOKEN"],
           envBindings: {
             TEST_OAUTH_TOKEN: "$secrets.TEST_OAUTH_ACCESS_TOKEN",
+            TEST_OAUTH_TENANT_ID: "$vars.TEST_OAUTH_API_TENANT_ID",
           },
         },
         revoke: TEST_OAUTH_REVOKE,
@@ -127,7 +135,10 @@ export const testOauth = {
           "Test-only manual method used to exercise refreshable access without a platform auth client.",
         storage: {
           secrets: ["TEST_OAUTH_TOKEN", "TEST_OAUTH_API_TOKEN_ACCESS_TOKEN"],
-          variables: ["TEST_OAUTH_API_TOKEN_INPUT_VAR"],
+          variables: [
+            "TEST_OAUTH_API_TOKEN_INPUT_VAR",
+            "TEST_OAUTH_API_TENANT_ID",
+          ],
         },
         grant: TEST_OAUTH_API_TOKEN_MANUAL_GRANT,
         access: {
@@ -142,6 +153,7 @@ export const testOauth = {
           refreshableSecrets: ["TEST_OAUTH_API_TOKEN_ACCESS_TOKEN"],
           envBindings: {
             TEST_OAUTH_API_TOKEN: "$secrets.TEST_OAUTH_API_TOKEN_ACCESS_TOKEN",
+            TEST_OAUTH_TENANT_ID: "$vars.TEST_OAUTH_API_TENANT_ID",
           },
         },
         revoke: TEST_OAUTH_REVOKE,

--- a/turbo/packages/firewalls-generator/src/test-oauth.ts
+++ b/turbo/packages/firewalls-generator/src/test-oauth.ts
@@ -11,6 +11,10 @@
  * resolve to). Production `vm0.ai` is intentionally NOT matched — there is
  * no test-oauth upstream to hit in production, and the isTestEndpointAllowed
  * guard on the echo route would 404 regardless.
+ *
+ * Keep the tenant-scoped entry first for connector variable output coverage.
+ * The plain preview-host entry is what runner E2E uses because vm6 preview TLS
+ * is only valid for the concrete preview API host, not nested tenant hosts.
  */
 
 import { writeOutput } from "./codegen";
@@ -33,6 +37,21 @@ function generateTypeScript(): string {
     "  apis: [",
     "    {",
     '      base: "https://${{ vars.TEST_OAUTH_TENANT_ID }}.{pr}.vm6.ai/api/test/oauth-provider",',
+    "      auth: {",
+    "        headers: {",
+    '          Authorization: "Bearer ${{ secrets.TEST_OAUTH_TOKEN }}",',
+    "        },",
+    "      },",
+    "      permissions: [",
+    "        {",
+    '          name: "echo",',
+    '          description: "Test echo endpoint used to verify token injection",',
+    '          rules: ["GET /echo"],',
+    "        },",
+    "      ],",
+    "    },",
+    "    {",
+    '      base: "https://{pr}.vm6.ai/api/test/oauth-provider",',
     "      auth: {",
     "        headers: {",
     '          Authorization: "Bearer ${{ secrets.TEST_OAUTH_TOKEN }}",',

--- a/turbo/packages/firewalls-generator/src/test-oauth.ts
+++ b/turbo/packages/firewalls-generator/src/test-oauth.ts
@@ -32,7 +32,7 @@ function generateTypeScript(): string {
     "  },",
     "  apis: [",
     "    {",
-    '      base: "https://{pr}.vm6.ai/api/test/oauth-provider",',
+    '      base: "https://${{ vars.TEST_OAUTH_TENANT_ID }}.{pr}.vm6.ai/api/test/oauth-provider",',
     "      auth: {",
     "        headers: {",
     '          Authorization: "Bearer ${{ secrets.TEST_OAUTH_TOKEN }}",',


### PR DESCRIPTION
## Summary
- allow connector grant and refresh outputs to target connector-owned variables as well as secrets
- persist variable-backed provider outputs during grant and refresh without changing production connector configs
- extend test-oauth coverage for grant, refresh, CLI auth, and runtime env injection

## Verification
- pnpm -F @vm0/connectors exec vitest src/__tests__/connectors.test.ts src/auth-providers/connectors/__tests__/google-ads.test.ts
- pnpm -F api exec vitest src/signals/routes/__tests__/connectors-type-callback.test.ts src/signals/routes/__tests__/webhooks-agent-firewall-auth.test.ts src/signals/routes/__tests__/cli-auth.test.ts src/signals/routes/__tests__/agent-runs-create.test.ts
- pnpm check-types
- pnpm -F @vm0/connectors lint
- pnpm -F api lint

Closes #16887