### PR TITLE
feat(api): add dormant trigger-table time poller executeDueTriggers

### DIFF
--- a/turbo/apps/api/src/signals/services/automations/__tests__/trigger-poller.test.ts
+++ b/turbo/apps/api/src/signals/services/automations/__tests__/trigger-poller.test.ts
@@ -1,0 +1,427 @@
+import { randomUUID } from "node:crypto";
+
+import { agentComposes } from "@vm0/db/schema/agent-compose";
+import { agentRuns } from "@vm0/db/schema/agent-run";
+import { agentSessions } from "@vm0/db/schema/agent-session";
+import { automations, automationTriggers } from "@vm0/db/schema/automation";
+import { chatThreads } from "@vm0/db/schema/chat-thread";
+import { zeroRuns } from "@vm0/db/schema/zero-run";
+import { createStore } from "ccstate";
+import { desc, eq } from "drizzle-orm";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+
+import { testContext } from "../../../../__tests__/test-helpers";
+import { mockEnv, mockOptionalEnv } from "../../../../lib/env";
+import { clearMockNow, mockNow, nowDate } from "../../../../lib/time";
+import { writeDb$ } from "../../../external/db";
+import {
+  deleteSchedulesScenario$,
+  seedSchedulesScenario$,
+  type SchedulesFixture,
+} from "../../../routes/__tests__/helpers/zero-schedules";
+import { createFixtureTracker } from "../../../routes/__tests__/helpers/zero-route-test";
+import { executeDueTriggers$ } from "../trigger-poller";
+
+const context = testContext();
+const store = createStore();
+
+const BASE_TIME = Date.parse("2000-01-01T08:00:00.000Z");
+const DUE_TIME = Date.parse("2000-01-01T09:01:00.000Z");
+
+interface TriggerSeed {
+  readonly kind: "cron" | "once" | "loop";
+  readonly cronExpression?: string;
+  readonly atTime?: Date;
+  readonly intervalSeconds?: number;
+  readonly nextRunAt?: Date | null;
+  readonly enabled?: boolean;
+  readonly consecutiveFailures?: number;
+  readonly lastRunId?: string | null;
+}
+
+interface AutomationFixture {
+  readonly schedules: SchedulesFixture;
+  readonly automationId: string;
+  readonly triggerId: string;
+  readonly threadId: string;
+}
+
+const trackSchedules = createFixtureTracker<SchedulesFixture>((fixture) => {
+  return store.set(deleteSchedulesScenario$, fixture, context.signal);
+});
+
+const trackAutomation = createFixtureTracker<AutomationFixture>(
+  async (fixture) => {
+    const db = store.set(writeDb$);
+    await db
+      .delete(automationTriggers)
+      .where(eq(automationTriggers.id, fixture.triggerId));
+    await db
+      .delete(automations)
+      .where(eq(automations.id, fixture.automationId));
+    await db.delete(chatThreads).where(eq(chatThreads.id, fixture.threadId));
+  },
+);
+
+function dueDate(): Date {
+  return new Date(DUE_TIME - 60 * 1000);
+}
+
+async function seedAutomationTrigger(
+  seed: TriggerSeed,
+  options?: { readonly automationEnabled?: boolean },
+): Promise<AutomationFixture> {
+  mockOptionalEnv("RUNNER_DEFAULT_GROUP", "vm0/test");
+  context.mocks.s3.send.mockResolvedValue({});
+
+  const schedules = await trackSchedules(
+    store.set(
+      seedSchedulesScenario$,
+      {
+        userName: "Automation Owner",
+        userEmail: "automation-owner@example.com",
+        schedules: [],
+      },
+      context.signal,
+    ),
+  );
+
+  const db = store.set(writeDb$);
+  const [thread] = await db
+    .insert(chatThreads)
+    .values({
+      userId: schedules.userId,
+      agentComposeId: schedules.composeId,
+      title: "automation thread",
+    })
+    .returning({ id: chatThreads.id });
+  if (!thread) {
+    throw new Error(
+      "seedAutomationTrigger: chat thread insert returned no row",
+    );
+  }
+
+  const [automation] = await db
+    .insert(automations)
+    .values({
+      orgId: schedules.orgId,
+      userId: schedules.userId,
+      name: `time-automation-${randomUUID().slice(0, 8)}`,
+      instruction: "Summarize the latest project status.",
+      agentId: schedules.composeId,
+      chatThreadId: thread.id,
+      interpreterKind: "time",
+      enabled: options?.automationEnabled ?? true,
+    })
+    .returning({ id: automations.id });
+  if (!automation) {
+    throw new Error("seedAutomationTrigger: automation insert returned no row");
+  }
+
+  const [trigger] = await db
+    .insert(automationTriggers)
+    .values({
+      automationId: automation.id,
+      kind: seed.kind,
+      cronExpression: seed.cronExpression ?? null,
+      atTime: seed.atTime ?? null,
+      intervalSeconds: seed.intervalSeconds ?? null,
+      nextRunAt: seed.nextRunAt ?? null,
+      enabled: seed.enabled ?? true,
+      consecutiveFailures: seed.consecutiveFailures ?? 0,
+      lastRunId: seed.lastRunId ?? null,
+    })
+    .returning({ id: automationTriggers.id });
+  if (!trigger) {
+    throw new Error("seedAutomationTrigger: trigger insert returned no row");
+  }
+
+  return await trackAutomation(
+    Promise.resolve({
+      schedules,
+      automationId: automation.id,
+      triggerId: trigger.id,
+      threadId: thread.id,
+    }),
+  );
+}
+
+async function findTrigger(triggerId: string) {
+  const db = store.set(writeDb$);
+  const [trigger] = await db
+    .select()
+    .from(automationTriggers)
+    .where(eq(automationTriggers.id, triggerId));
+  return trigger;
+}
+
+async function findAutomationRuns(automationId: string) {
+  const db = store.set(writeDb$);
+  return await db
+    .select({
+      id: agentRuns.id,
+      status: agentRuns.status,
+      prompt: agentRuns.prompt,
+      appendSystemPrompt: agentRuns.appendSystemPrompt,
+      triggerSource: zeroRuns.triggerSource,
+      automationId: zeroRuns.automationId,
+      triggerId: zeroRuns.triggerId,
+    })
+    .from(agentRuns)
+    .innerJoin(zeroRuns, eq(agentRuns.id, zeroRuns.id))
+    .where(eq(zeroRuns.automationId, automationId))
+    .orderBy(desc(agentRuns.createdAt));
+}
+
+async function composeHeadVersionId(composeId: string): Promise<string> {
+  const db = store.set(writeDb$);
+  const [compose] = await db
+    .select({ headVersionId: agentComposes.headVersionId })
+    .from(agentComposes)
+    .where(eq(agentComposes.id, composeId));
+  if (!compose?.headVersionId) {
+    throw new Error("composeHeadVersionId: missing headVersionId");
+  }
+  return compose.headVersionId;
+}
+
+async function insertBlockingRun(fixture: AutomationFixture): Promise<string> {
+  const db = store.set(writeDb$);
+  const [session] = await db
+    .insert(agentSessions)
+    .values({
+      userId: fixture.schedules.userId,
+      orgId: fixture.schedules.orgId,
+      agentComposeId: fixture.schedules.composeId,
+    })
+    .returning({ id: agentSessions.id });
+  if (!session) {
+    throw new Error("insertBlockingRun: session insert returned no row");
+  }
+
+  const headVersionId = await composeHeadVersionId(fixture.schedules.composeId);
+  const [run] = await db
+    .insert(agentRuns)
+    .values({
+      userId: fixture.schedules.userId,
+      orgId: fixture.schedules.orgId,
+      agentComposeVersionId: headVersionId,
+      sessionId: session.id,
+      status: "running",
+      prompt: `Blocking run ${randomUUID()}`,
+      createdAt: nowDate(),
+    })
+    .returning({ id: agentRuns.id });
+  if (!run) {
+    throw new Error("insertBlockingRun: run insert returned no row");
+  }
+  return run.id;
+}
+
+async function clearComposeHeadVersion(composeId: string): Promise<void> {
+  const db = store.set(writeDb$);
+  await db
+    .update(agentComposes)
+    .set({ headVersionId: null })
+    .where(eq(agentComposes.id, composeId));
+}
+
+describe("executeDueTriggers$ (dormant automation time poller)", () => {
+  beforeEach(() => {
+    mockEnv("VM0_API_URL", "https://api.example.test");
+    mockOptionalEnv("OPENROUTER_API_KEY", undefined);
+    mockOptionalEnv("RUNNER_DEFAULT_GROUP", "vm0/test");
+    context.mocks.s3.send.mockResolvedValue({});
+    mockNow(BASE_TIME);
+  });
+
+  afterEach(() => {
+    clearMockNow();
+  });
+
+  it("ignores triggers whose next run is in the future", async () => {
+    const fixture = await seedAutomationTrigger({
+      kind: "cron",
+      cronExpression: "0 9 * * *",
+      nextRunAt: new Date("2000-01-02T09:00:00.000Z"),
+    });
+    mockNow(DUE_TIME);
+
+    const result = await store.set(executeDueTriggers$, context.signal);
+
+    expect(result).toStrictEqual({ executed: 0, skipped: 0 });
+    const runs = await findAutomationRuns(fixture.automationId);
+    expect(runs).toHaveLength(0);
+  });
+
+  it("executes a due cron trigger, advances next run, and tags provenance", async () => {
+    const fixture = await seedAutomationTrigger({
+      kind: "cron",
+      cronExpression: "0 9 * * *",
+      nextRunAt: dueDate(),
+    });
+    mockNow(DUE_TIME);
+
+    const result = await store.set(executeDueTriggers$, context.signal);
+
+    expect(result.executed).toBe(1);
+    const trigger = await findTrigger(fixture.triggerId);
+    expect(trigger?.enabled).toBeTruthy();
+    expect(trigger?.lastRunAt).not.toBeNull();
+    // Cron advances to the next occurrence (next day 09:00 UTC).
+    expect(trigger?.nextRunAt).toStrictEqual(
+      new Date("2000-01-02T09:00:00.000Z"),
+    );
+    expect(trigger?.lastRunId).not.toBeNull();
+
+    const runs = await findAutomationRuns(fixture.automationId);
+    expect(runs).toHaveLength(1);
+    expect(runs[0]?.prompt).toBe("Summarize the latest project status.");
+    expect(runs[0]?.triggerSource).toBe("schedule");
+    expect(runs[0]?.automationId).toBe(fixture.automationId);
+    expect(runs[0]?.triggerId).toBe(fixture.triggerId);
+    expect(runs[0]?.appendSystemPrompt).toContain(
+      "# Current Integration\nYou are currently running inside: Schedule",
+    );
+    expect(runs[0]?.appendSystemPrompt).toContain("Trigger type: cron");
+  });
+
+  it("executes and disables a due one-time trigger", async () => {
+    const fixture = await seedAutomationTrigger({
+      kind: "once",
+      atTime: dueDate(),
+      nextRunAt: dueDate(),
+    });
+    mockNow(DUE_TIME);
+
+    const result = await store.set(executeDueTriggers$, context.signal);
+
+    expect(result.executed).toBe(1);
+    const trigger = await findTrigger(fixture.triggerId);
+    expect(trigger?.enabled).toBeFalsy();
+    expect(trigger?.nextRunAt).toBeNull();
+    expect(trigger?.lastRunAt).not.toBeNull();
+    const runs = await findAutomationRuns(fixture.automationId);
+    expect(runs).toHaveLength(1);
+  });
+
+  it("executes a due loop trigger and advances by its interval", async () => {
+    const fixture = await seedAutomationTrigger({
+      kind: "loop",
+      intervalSeconds: 300,
+      nextRunAt: dueDate(),
+    });
+    mockNow(DUE_TIME);
+
+    const result = await store.set(executeDueTriggers$, context.signal);
+
+    expect(result.executed).toBe(1);
+    const trigger = await findTrigger(fixture.triggerId);
+    expect(trigger?.enabled).toBeTruthy();
+    expect(trigger?.lastRunAt).not.toBeNull();
+    expect(trigger?.nextRunAt).toStrictEqual(new Date(DUE_TIME + 300_000));
+    const runs = await findAutomationRuns(fixture.automationId);
+    expect(runs).toHaveLength(1);
+  });
+
+  it("does not create duplicate runs for concurrent invocations", async () => {
+    const fixture = await seedAutomationTrigger({
+      kind: "cron",
+      cronExpression: "0 9 * * *",
+      nextRunAt: dueDate(),
+    });
+    mockNow(DUE_TIME);
+
+    const [first, second] = await Promise.all([
+      store.set(executeDueTriggers$, context.signal),
+      store.set(executeDueTriggers$, context.signal),
+    ]);
+
+    expect(first.executed + second.executed).toBe(1);
+    const runs = await findAutomationRuns(fixture.automationId);
+    expect(runs).toHaveLength(1);
+  });
+
+  it("skips a due trigger while its previous run is still active", async () => {
+    const fixture = await seedAutomationTrigger({
+      kind: "cron",
+      cronExpression: "0 9 * * *",
+      nextRunAt: dueDate(),
+    });
+    const activeRunId = await insertBlockingRun(fixture);
+    const db = store.set(writeDb$);
+    await db
+      .update(automationTriggers)
+      .set({ lastRunId: activeRunId })
+      .where(eq(automationTriggers.id, fixture.triggerId));
+    mockNow(DUE_TIME);
+
+    const result = await store.set(executeDueTriggers$, context.signal);
+
+    expect(result).toMatchObject({ executed: 0, skipped: 1 });
+    const trigger = await findTrigger(fixture.triggerId);
+    // Not claimed: next run unchanged.
+    expect(trigger?.nextRunAt).toStrictEqual(dueDate());
+    const runs = await findAutomationRuns(fixture.automationId);
+    expect(runs).toHaveLength(0);
+  });
+
+  it("skips a due trigger whose automation is disabled", async () => {
+    const fixture = await seedAutomationTrigger(
+      {
+        kind: "cron",
+        cronExpression: "0 9 * * *",
+        nextRunAt: dueDate(),
+      },
+      { automationEnabled: false },
+    );
+    mockNow(DUE_TIME);
+
+    const result = await store.set(executeDueTriggers$, context.signal);
+
+    expect(result).toMatchObject({ executed: 0, skipped: 1 });
+    const trigger = await findTrigger(fixture.triggerId);
+    expect(trigger?.nextRunAt).toStrictEqual(dueDate());
+    const runs = await findAutomationRuns(fixture.automationId);
+    expect(runs).toHaveLength(0);
+  });
+
+  it("advances a cron trigger after a pre-run failure", async () => {
+    const fixture = await seedAutomationTrigger({
+      kind: "cron",
+      cronExpression: "0 9 * * *",
+      nextRunAt: dueDate(),
+    });
+    await clearComposeHeadVersion(fixture.schedules.composeId);
+    mockNow(DUE_TIME);
+
+    const result = await store.set(executeDueTriggers$, context.signal);
+
+    expect(result).toMatchObject({ executed: 0, skipped: 1 });
+    const trigger = await findTrigger(fixture.triggerId);
+    expect(trigger?.consecutiveFailures).toBe(1);
+    expect(trigger?.enabled).toBeTruthy();
+    expect(trigger?.nextRunAt?.getTime()).toBeGreaterThan(DUE_TIME);
+    const runs = await findAutomationRuns(fixture.automationId);
+    expect(runs).toHaveLength(0);
+  });
+
+  it("auto-disables a trigger after three consecutive pre-run failures", async () => {
+    const fixture = await seedAutomationTrigger({
+      kind: "cron",
+      cronExpression: "0 9 * * *",
+      nextRunAt: dueDate(),
+      consecutiveFailures: 2,
+    });
+    await clearComposeHeadVersion(fixture.schedules.composeId);
+    mockNow(DUE_TIME);
+
+    const result = await store.set(executeDueTriggers$, context.signal);
+
+    expect(result).toMatchObject({ executed: 0, skipped: 1 });
+    const trigger = await findTrigger(fixture.triggerId);
+    expect(trigger?.consecutiveFailures).toBe(3);
+    expect(trigger?.enabled).toBeFalsy();
+    expect(trigger?.nextRunAt).toBeNull();
+  });
+});

--- a/turbo/apps/api/src/signals/services/automations/default-interpreter.ts
+++ b/turbo/apps/api/src/signals/services/automations/default-interpreter.ts
@@ -99,11 +99,28 @@ export interface WebhookTriggerEvent {
 }
 
 /**
- * The trigger that fired an Automation. A time fire carries only the schedule
- * identity; a webhook fire carries the raw inbound payload. The interpreter
- * keys its context/callbacks/metadata off this discriminant.
+ * Trigger event for an automation-table time fire (the dormant trigger poller,
+ * U4). Like the schedule time fire it is instruction-only — no inbound payload —
+ * but it tags the run with the originating automation + the firing
+ * `automation_triggers` row (run provenance, U3) instead of a schedule id, and
+ * attaches no reschedule callback because the poller advances `next_run_at`
+ * inline. `triggerId` is the firing trigger row.
  */
-type TriggerEvent = TimeTriggerEvent | WebhookTriggerEvent;
+interface AutomationTimeTriggerEvent {
+  readonly kind: "automation-time";
+  readonly triggerId: string;
+}
+
+/**
+ * The trigger that fired an Automation. A schedule time fire carries only the
+ * schedule identity; an automation-table time fire carries the firing trigger
+ * identity; a webhook fire carries the raw inbound payload. The interpreter keys
+ * its context/callbacks/metadata off this discriminant.
+ */
+type TriggerEvent =
+  | TimeTriggerEvent
+  | AutomationTimeTriggerEvent
+  | WebhookTriggerEvent;
 
 /**
  * Maps a `zero_agent_schedules` row to the Automation view the interpreter
@@ -154,6 +171,39 @@ export function webhookRowToAutomation(row: {
     triggerType: "webhook",
     cronExpression: null,
     timezone: "UTC",
+  };
+}
+
+/**
+ * Maps an `automations` row (joined with its firing time trigger) to the
+ * Automation view the interpreter consumes for an automation-table time fire
+ * (the dormant trigger poller). The recurrence lives on the trigger row, so its
+ * `kind` (cron/once/loop) and `cronExpression`/`timezone` are threaded in here.
+ * Counterpart to `scheduleToAutomation` for the events-first time path.
+ */
+export function automationRowToTimeAutomation(row: {
+  readonly id: string;
+  readonly agentId: string;
+  readonly orgId: string;
+  readonly userId: string;
+  readonly chatThreadId: string;
+  readonly instruction: string;
+  readonly triggerType: "cron" | "once" | "loop";
+  readonly cronExpression: string | null;
+  readonly timezone: string;
+}): Automation {
+  return {
+    interpreterKind: "time",
+    id: row.id,
+    agentId: row.agentId,
+    orgId: row.orgId,
+    userId: row.userId,
+    chatThreadId: row.chatThreadId,
+    prompt: row.instruction,
+    appendSystemPrompt: null,
+    triggerType: row.triggerType,
+    cronExpression: row.cronExpression,
+    timezone: row.timezone,
   };
 }
 
@@ -292,6 +342,24 @@ export class DefaultInterpreter {
         agentId: automation.agentId,
         chatThreadId: automation.chatThreadId,
         appendSystemPrompt: buildWebhookAppendSystemPrompt(triggerEvent),
+        callbacks: [buildChatCallback(automation)],
+        zeroRunMetadata: {
+          automationId: automation.id,
+          triggerId: triggerEvent.triggerId,
+        },
+      });
+    }
+
+    if (triggerEvent.kind === "automation-time") {
+      // Automation-table time fire (dormant trigger poller): same instruction-only
+      // schedule context as the schedule fire, but tagged with the automation +
+      // firing trigger (provenance) and carrying no reschedule callback — the
+      // poller advances next_run_at itself.
+      return Promise.resolve({
+        prompt: automation.prompt,
+        agentId: automation.agentId,
+        chatThreadId: automation.chatThreadId,
+        appendSystemPrompt: buildScheduleAppendSystemPrompt(automation),
         callbacks: [buildChatCallback(automation)],
         zeroRunMetadata: {
           automationId: automation.id,

--- a/turbo/apps/api/src/signals/services/automations/time-trigger.ts
+++ b/turbo/apps/api/src/signals/services/automations/time-trigger.ts
@@ -1,3 +1,4 @@
+import { automationTriggers } from "@vm0/db/schema/automation";
 import { zeroAgentSchedules } from "@vm0/db/schema/zero-agent-schedule";
 import { Cron } from "croner";
 import { and, eq } from "drizzle-orm";
@@ -5,6 +6,7 @@ import { and, eq } from "drizzle-orm";
 import type { Db } from "../../external/db";
 
 type ScheduleRow = typeof zeroAgentSchedules.$inferSelect;
+type TriggerRow = typeof automationTriggers.$inferSelect;
 
 /**
  * Computes the next fire time for a cron expression in the given timezone,
@@ -159,5 +161,83 @@ export class TimeTrigger {
       throw new Error("Loop schedule is missing intervalSeconds");
     }
     return new Date(args.completedAt.getTime() + args.intervalSeconds * 1000);
+  }
+
+  /**
+   * Next recurrence for an `automation_triggers` time row, computed from its kind:
+   * cron advances to the next occurrence; loop advances by its interval; once does
+   * not recur. The same math the schedule path uses, applied to a trigger row.
+   * `null` is returned when the kind cannot recur (once, or a malformed time row).
+   */
+  private static nextTriggerRun(
+    trigger: TriggerRow,
+    fromDate: Date,
+  ): Date | null {
+    if (trigger.kind === "cron" && trigger.cronExpression) {
+      return calculateNextRun(
+        trigger.cronExpression,
+        trigger.timezone,
+        fromDate,
+      );
+    }
+    if (trigger.kind === "loop" && trigger.intervalSeconds) {
+      return new Date(fromDate.getTime() + trigger.intervalSeconds * 1000);
+    }
+    return null;
+  }
+
+  /**
+   * Claim a due `automation_triggers` time row via an optimistic lock on
+   * `nextRunAt` — the trigger-table counterpart of `evaluate`. Mirrors the live
+   * schedule claim's atomicity (a concurrent poller whose `nextRunAt` already
+   * moved loses the race and returns null), but because the trigger poller is
+   * self-contained (no reschedule callback in this slice) the claim folds in the
+   * recurrence advance: cron/loop advance to their next run, once disables. Stamps
+   * `lastRunAt` and clears any retry marker, exactly as the schedule claim does.
+   */
+  async evaluateTrigger(args: {
+    readonly db: Db;
+    readonly trigger: TriggerRow;
+    readonly currentTime: Date;
+  }): Promise<TriggerRow | null> {
+    const nextRunAt = TimeTrigger.nextTriggerRun(
+      args.trigger,
+      args.currentTime,
+    );
+    const [claimed] = await args.db
+      .update(automationTriggers)
+      .set({
+        nextRunAt,
+        lastRunAt: args.currentTime,
+        retryStartedAt: null,
+        updatedAt: args.currentTime,
+        ...(args.trigger.kind === "once" ? { enabled: false } : {}),
+      })
+      .where(
+        and(
+          eq(automationTriggers.id, args.trigger.id),
+          eq(automationTriggers.nextRunAt, args.trigger.nextRunAt!),
+        ),
+      )
+      .returning();
+    return claimed ?? null;
+  }
+
+  /**
+   * Next run for an `automation_triggers` time row after a pre-run failure in the
+   * poller (the run was never created) — the trigger-table counterpart of
+   * `advanceAfterPreRunFailure`. Cron advances to the next occurrence; a loop
+   * advances by its interval; once and interval-less loops do not reschedule.
+   * Disabling collapses the next run to null.
+   */
+  advanceTriggerAfterPreRunFailure(args: {
+    readonly trigger: TriggerRow;
+    readonly failureTime: Date;
+    readonly shouldDisable: boolean;
+  }): Date | null {
+    if (args.shouldDisable) {
+      return null;
+    }
+    return TimeTrigger.nextTriggerRun(args.trigger, args.failureTime);
   }
 }

--- a/turbo/apps/api/src/signals/services/automations/trigger-poller.ts
+++ b/turbo/apps/api/src/signals/services/automations/trigger-poller.ts
@@ -1,0 +1,476 @@
+import { agentRuns } from "@vm0/db/schema/agent-run";
+import { automations, automationTriggers } from "@vm0/db/schema/automation";
+import { zeroRuns } from "@vm0/db/schema/zero-run";
+import { command } from "ccstate";
+import { and, eq, inArray, lte } from "drizzle-orm";
+
+import { logger } from "../../../lib/log";
+import { writeDb$, type Db } from "../../external/db";
+import { now, nowDate } from "../../external/time";
+import { settle } from "../../utils";
+import {
+  postAutomationUserMessage,
+  resolveScheduleChatThreadModelPin,
+} from "../../routes/zero-chat-messages";
+import {
+  resolveModelFirstProviderAdmission,
+  type ModelFirstPin,
+} from "../zero-model-selection.service";
+import { createZeroRun$ } from "../zero-runs-create.service";
+import {
+  automationRowToTimeAutomation,
+  DefaultInterpreter,
+} from "./default-interpreter";
+import { TimeTrigger } from "./time-trigger";
+
+const log = logger("api:automations:trigger-poller");
+
+const MAX_CONSECUTIVE_FAILURES = 3;
+
+/** The time-trigger kinds the poller scans; webhook triggers are not time-driven. */
+const TIME_TRIGGER_KINDS = ["cron", "once", "loop"] as const;
+
+type TriggerRow = typeof automationTriggers.$inferSelect;
+
+/**
+ * The trigger row joined with its owning automation: everything the poller needs
+ * to claim the recurrence (trigger columns) and build the run (automation
+ * identity + instruction + linked thread). Mirrors the schedule row the live
+ * poller reads, split across the two events-first tables.
+ */
+interface DueTrigger {
+  readonly trigger: TriggerRow;
+  readonly automation: {
+    readonly id: string;
+    readonly agentId: string;
+    readonly orgId: string;
+    readonly userId: string;
+    readonly chatThreadId: string;
+    readonly instruction: string;
+  };
+}
+
+interface ExecuteDueTriggersResult {
+  readonly executed: number;
+  readonly skipped: number;
+}
+
+type RunTriggerErrorResponse = {
+  readonly status: 400 | 402 | 403 | 404 | 429 | 503;
+  readonly body: {
+    readonly error: {
+      readonly message: string;
+      readonly code: string;
+    };
+  };
+};
+
+type RunTriggerNowResult =
+  | { readonly kind: "ok"; readonly runId: string }
+  | { readonly kind: "not_found"; readonly message: string }
+  | { readonly kind: "conflict"; readonly message: string }
+  | { readonly kind: "run_error"; readonly response: RunTriggerErrorResponse };
+
+type RunTriggerFailure = Exclude<RunTriggerNowResult, { kind: "ok" }>;
+
+type TriggerRunModelContext =
+  | {
+      readonly ok: true;
+      readonly modelPin: ModelFirstPin;
+      readonly effectiveModelProvider: string | null | undefined;
+    }
+  | { readonly ok: false; readonly failure: RunTriggerFailure };
+
+function isActivePreviousRunStatus(status: string): boolean {
+  return status === "pending" || status === "running";
+}
+
+function isRunTriggerFailure(error: unknown): error is RunTriggerFailure {
+  return (
+    typeof error === "object" &&
+    error !== null &&
+    "kind" in error &&
+    (error.kind === "not_found" ||
+      error.kind === "conflict" ||
+      error.kind === "run_error")
+  );
+}
+
+function triggerFailureMessage(error: unknown): string {
+  if (!isRunTriggerFailure(error)) {
+    return error instanceof Error ? error.message : String(error);
+  }
+  if (error.kind === "run_error") {
+    return `${error.response.status} ${error.response.body.error.code}: ${error.response.body.error.message}`;
+  }
+  return error.message;
+}
+
+function isInsufficientCreditsFailure(error: unknown): boolean {
+  return (
+    isRunTriggerFailure(error) &&
+    error.kind === "run_error" &&
+    error.response.body.error.code === "INSUFFICIENT_CREDITS"
+  );
+}
+
+// Resolve the model context for a triggered run: the linked thread's model pin
+// (org default if unpinned) and the admitted provider. No user is present to
+// receive a model-config / credits error, so failures surface as run_error
+// (normalized to 400) feeding consecutiveFailures — the schedule poller's policy.
+async function resolveTriggerRunModelContext(args: {
+  readonly db: Db;
+  readonly orgId: string;
+  readonly userId: string;
+  readonly chatThreadId: string;
+  readonly signal: AbortSignal;
+}): Promise<TriggerRunModelContext> {
+  const threadModelPin = await resolveScheduleChatThreadModelPin({
+    db: args.db,
+    orgId: args.orgId,
+    userId: args.userId,
+    threadId: args.chatThreadId,
+  });
+  args.signal.throwIfAborted();
+  if ("status" in threadModelPin) {
+    return {
+      ok: false,
+      failure: {
+        kind: "run_error",
+        response: { status: 400, body: threadModelPin.body },
+      },
+    };
+  }
+
+  const providerAdmission = await resolveModelFirstProviderAdmission({
+    db: args.db,
+    orgId: args.orgId,
+    userId: args.userId,
+    modelPin: threadModelPin,
+    requestedModelProvider: undefined,
+  });
+  args.signal.throwIfAborted();
+  if (providerAdmission.error) {
+    return {
+      ok: false,
+      failure: { kind: "run_error", response: providerAdmission.error },
+    };
+  }
+
+  return {
+    ok: true,
+    modelPin: threadModelPin,
+    effectiveModelProvider: providerAdmission.effectiveModelProvider,
+  };
+}
+
+async function recordTriggerPreRunFailure(
+  db: Db,
+  due: DueTrigger,
+  error: unknown,
+  signal: AbortSignal,
+): Promise<void> {
+  const isCreditError = isInsufficientCreditsFailure(error);
+  const failureMessage = triggerFailureMessage(error);
+  const failureContext = {
+    triggerId: due.trigger.id,
+    automationId: due.automation.id,
+    orgId: due.automation.orgId,
+    userId: due.automation.userId,
+    error: failureMessage,
+    stack: error instanceof Error ? error.stack : undefined,
+  };
+  if (isCreditError) {
+    log.warn("Trigger skipped: insufficient credits", failureContext);
+  } else {
+    log.error("Trigger pre-run failed", failureContext);
+  }
+
+  const failureTime = nowDate();
+  const newFailureCount = due.trigger.consecutiveFailures + 1;
+  const shouldDisable = newFailureCount >= MAX_CONSECUTIVE_FAILURES;
+  const nextRunAt = new TimeTrigger().advanceTriggerAfterPreRunFailure({
+    trigger: due.trigger,
+    failureTime,
+    shouldDisable,
+  });
+
+  await db
+    .update(automationTriggers)
+    .set({
+      consecutiveFailures: newFailureCount,
+      ...(shouldDisable ? { enabled: false } : {}),
+      nextRunAt,
+      updatedAt: failureTime,
+    })
+    .where(eq(automationTriggers.id, due.trigger.id));
+  signal.throwIfAborted();
+
+  if (shouldDisable) {
+    log.warn("Trigger auto-disabled after consecutive pre-run failures", {
+      triggerId: due.trigger.id,
+      automationId: due.automation.id,
+      orgId: due.automation.orgId,
+      userId: due.automation.userId,
+      consecutiveFailures: newFailureCount,
+      reason: isCreditError ? "insufficient_credits" : "pre_run_failure",
+    });
+  }
+}
+
+// Render a triggered run as a web-chat turn in the automation's linked thread.
+// Model comes from the thread pin (org default if unpinned); the session is
+// always fresh (no sessionId); the run is tagged with the automation + firing
+// trigger (run provenance). The poller advances next_run_at on claim, so there
+// is no reschedule callback here.
+const runTriggerNow$ = command(
+  async (
+    { set },
+    args: {
+      readonly due: DueTrigger;
+      readonly apiStartTime: number;
+    },
+    signal: AbortSignal,
+  ): Promise<RunTriggerNowResult> => {
+    const db = set(writeDb$);
+    const { trigger, automation } = args.due;
+
+    if (trigger.lastRunId) {
+      const [lastRun] = await db
+        .select({ status: agentRuns.status })
+        .from(agentRuns)
+        .where(eq(agentRuns.id, trigger.lastRunId))
+        .limit(1);
+      signal.throwIfAborted();
+
+      if (lastRun && isActivePreviousRunStatus(lastRun.status)) {
+        return { kind: "conflict", message: "Previous run is still active" };
+      }
+    }
+
+    const modelContext = await resolveTriggerRunModelContext({
+      db,
+      orgId: automation.orgId,
+      userId: automation.userId,
+      chatThreadId: automation.chatThreadId,
+      signal,
+    });
+    if (!modelContext.ok) {
+      return modelContext.failure;
+    }
+    const { modelPin, effectiveModelProvider } = modelContext;
+
+    // The single default interpreter handles every Automation kind, keyed off an
+    // automation-table time trigger event here (provenance + no reschedule
+    // callback). The registry is deferred to the first fetching interpreter.
+    const runInput = await new DefaultInterpreter().interpret(
+      automationRowToTimeAutomation({
+        id: automation.id,
+        agentId: automation.agentId,
+        orgId: automation.orgId,
+        userId: automation.userId,
+        chatThreadId: automation.chatThreadId,
+        instruction: automation.instruction,
+        triggerType: trigger.kind as "cron" | "once" | "loop",
+        cronExpression: trigger.cronExpression,
+        timezone: trigger.timezone,
+      }),
+      { kind: "automation-time", triggerId: trigger.id },
+    );
+    signal.throwIfAborted();
+
+    const result = await set(
+      createZeroRun$,
+      {
+        auth: {
+          orgId: automation.orgId,
+          orgRole: "member",
+          userId: automation.userId,
+          tokenType: "session",
+        },
+        body: {
+          prompt: runInput.prompt,
+          agentId: runInput.agentId,
+          ...(effectiveModelProvider
+            ? { modelProvider: effectiveModelProvider }
+            : {}),
+        },
+        apiStartTime: args.apiStartTime,
+        triggerSource: "schedule",
+        chatThreadId: runInput.chatThreadId,
+        modelProviderId: modelPin.modelProviderId ?? undefined,
+        modelProviderCredentialScope:
+          modelPin.modelProviderCredentialScope ?? undefined,
+        selectedModelOverride: modelPin.selectedModel ?? undefined,
+        appendSystemPrompt: runInput.appendSystemPrompt,
+        callbacks: runInput.callbacks,
+        zeroRunMetadata: runInput.zeroRunMetadata,
+      },
+      signal,
+    );
+    signal.throwIfAborted();
+
+    if (result.status !== 201) {
+      return { kind: "run_error", response: result };
+    }
+
+    await postAutomationUserMessage({
+      db,
+      threadId: automation.chatThreadId,
+      userId: automation.userId,
+      runId: result.body.runId,
+      prompt: runInput.prompt,
+      appendQueueMarker: result.body.status === "queued",
+    });
+    signal.throwIfAborted();
+
+    await db
+      .update(zeroRuns)
+      .set({
+        modelProvider: effectiveModelProvider,
+        modelProviderId: modelPin.modelProviderId,
+        modelProviderCredentialScope: modelPin.modelProviderCredentialScope,
+        selectedModel: modelPin.selectedModel,
+      })
+      .where(eq(zeroRuns.id, result.body.runId));
+    signal.throwIfAborted();
+
+    await db
+      .update(automationTriggers)
+      .set({ lastRunId: result.body.runId })
+      .where(eq(automationTriggers.id, trigger.id));
+    signal.throwIfAborted();
+
+    return { kind: "ok", runId: result.body.runId };
+  },
+);
+
+/**
+ * Dormant time poller over `automation_triggers` — the events-first counterpart
+ * of `executeDueSchedules$`, built for the (later, gated) cutover and NOT wired
+ * to any live cron route in this slice. It mirrors the schedule poller's
+ * semantics 1:1: scan enabled time triggers whose `next_run_at` is due, skip any
+ * whose previous run is still active, optimistic-lock claim the due row (which
+ * also advances cron/loop or disables once), then create the run via the default
+ * interpreter (tagged with automation + trigger provenance) and auto-disable a
+ * trigger after consecutive pre-run failures. Nothing here changes live
+ * execution; `executeDueSchedules$` remains the only schedule executor.
+ */
+export const executeDueTriggers$ = command(
+  async ({ set }, signal: AbortSignal): Promise<ExecuteDueTriggersResult> => {
+    const db = set(writeDb$);
+    const currentTime = nowDate();
+    log.debug("Checking for due triggers", {
+      currentTime: currentTime.toISOString(),
+    });
+
+    const rows = await db
+      .select({
+        trigger: automationTriggers,
+        automationId: automations.id,
+        agentId: automations.agentId,
+        orgId: automations.orgId,
+        userId: automations.userId,
+        chatThreadId: automations.chatThreadId,
+        instruction: automations.instruction,
+        automationEnabled: automations.enabled,
+      })
+      .from(automationTriggers)
+      .innerJoin(
+        automations,
+        eq(automationTriggers.automationId, automations.id),
+      )
+      .where(
+        and(
+          eq(automationTriggers.enabled, true),
+          inArray(automationTriggers.kind, [...TIME_TRIGGER_KINDS]),
+          lte(automationTriggers.nextRunAt, currentTime),
+        ),
+      )
+      .limit(10);
+    signal.throwIfAborted();
+
+    let executed = 0;
+    let skipped = 0;
+    const timeTrigger = new TimeTrigger();
+
+    for (const row of rows) {
+      // A disabled automation suspends all its triggers without touching their
+      // own enabled flag (mirrors the webhook dispatch's automation gate).
+      if (!row.automationEnabled) {
+        log.debug("Skipping trigger: automation disabled", {
+          triggerId: row.trigger.id,
+          automationId: row.automationId,
+        });
+        skipped++;
+        continue;
+      }
+
+      const due: DueTrigger = {
+        trigger: row.trigger,
+        automation: {
+          id: row.automationId,
+          agentId: row.agentId,
+          orgId: row.orgId,
+          userId: row.userId,
+          chatThreadId: row.chatThreadId,
+          instruction: row.instruction,
+        },
+      };
+
+      if (row.trigger.lastRunId) {
+        const [lastRun] = await db
+          .select({ status: agentRuns.status })
+          .from(agentRuns)
+          .where(eq(agentRuns.id, row.trigger.lastRunId))
+          .limit(1);
+        signal.throwIfAborted();
+
+        if (lastRun && isActivePreviousRunStatus(lastRun.status)) {
+          log.debug("Skipping trigger: previous run still active", {
+            triggerId: row.trigger.id,
+            automationId: row.automationId,
+          });
+          skipped++;
+          continue;
+        }
+      }
+
+      const claimed = await timeTrigger.evaluateTrigger({
+        db,
+        trigger: row.trigger,
+        currentTime,
+      });
+      signal.throwIfAborted();
+
+      if (!claimed) {
+        log.debug("Skipping trigger: already claimed", {
+          triggerId: row.trigger.id,
+          automationId: row.automationId,
+        });
+        skipped++;
+        continue;
+      }
+
+      const runResult = await settle(
+        set(runTriggerNow$, { due, apiStartTime: now() }, signal),
+      );
+      signal.throwIfAborted();
+      if (!runResult.ok) {
+        await recordTriggerPreRunFailure(db, due, runResult.error, signal);
+        skipped++;
+        continue;
+      }
+      const result = runResult.value;
+      if (result.kind !== "ok") {
+        await recordTriggerPreRunFailure(db, due, result, signal);
+        skipped++;
+        continue;
+      }
+      executed++;
+    }
+
+    log.debug("Executed due triggers", { executed, skipped });
+    return { executed, skipped };
+  },
+);


### PR DESCRIPTION
Closes #16852. Part of #16847 (Slice 1). DORMANT — not wired to the live cron route; changes no live execution.

Adds `executeDueTriggers$`: scans `automation_triggers` (time kinds) for due rows, optimistic-lock claims, runs via the `DefaultInterpreter` → `createZeroRun$` with `automationId` + `triggerId`, advances `nextRunAt`/auto-disables — mirroring `executeDueSchedules$` 1:1. The live `/api/cron/execute-schedules` route still calls `executeDueSchedules$` (unchanged), so this poller is built and tested but inert until the later gated cutover. Reuses `TimeTrigger`. Integration test exercises it directly.
