### PR TITLE
fix(mitm-addon): handle registry json parser failures

### DIFF
--- a/crates/runner/mitm-addon/src/registry.py
+++ b/crates/runner/mitm-addon/src/registry.py
@@ -280,7 +280,12 @@ def load_registry_state(registry_path: str) -> RegistryState:
                 state.read_error_key = key
                 ctx.log.warn(f"Failed to read proxy registry: {message}")
             return _mark_unavailable(state, reason="read_failed", message=message)
-        except (json.JSONDecodeError, UnicodeDecodeError, _RegistryFormatError) as e:
+        except (
+            json.JSONDecodeError,
+            UnicodeDecodeError,
+            RecursionError,
+            _RegistryFormatError,
+        ) as e:
             message = str(e)
             state.failed_key = key
             state.read_error_key = None

--- a/crates/runner/mitm-addon/src/registry.py
+++ b/crates/runner/mitm-addon/src/registry.py
@@ -280,12 +280,7 @@ def load_registry_state(registry_path: str) -> RegistryState:
                 state.read_error_key = key
                 ctx.log.warn(f"Failed to read proxy registry: {message}")
             return _mark_unavailable(state, reason="read_failed", message=message)
-        except (
-            json.JSONDecodeError,
-            UnicodeDecodeError,
-            RecursionError,
-            _RegistryFormatError,
-        ) as e:
+        except (ValueError, RecursionError) as e:
             message = str(e)
             state.failed_key = key
             state.read_error_key = None

--- a/crates/runner/mitm-addon/tests/test_registry.py
+++ b/crates/runner/mitm-addon/tests/test_registry.py
@@ -391,11 +391,28 @@ class TestLoadRegistry:
         assert log.warn.call_count == 1
         assert "Failed to parse" in log.warn.call_args_list[0].args[0]
 
-    def test_json_recursion_error_after_success_marks_registry_unavailable(self, registry_file):
+    @pytest.mark.parametrize(
+        "registry_payload",
+        [
+            pytest.param(
+                b'{"vms":' + b"[" * 10000 + b"0" + b"]" * 10000 + b"}",
+                id="decoder-recursion",
+            ),
+            pytest.param(
+                b'{"vms":' + b"1" * 10000 + b"}",
+                id="integer-digit-limit",
+            ),
+        ],
+    )
+    def test_json_parser_failure_after_success_marks_registry_unavailable(
+        self,
+        registry_file,
+        registry_payload,
+    ):
         loaded = registry.load_registry(str(registry_file))
         assert loaded["10.200.0.1"]["runId"] == "run-abc-123"
 
-        registry_file.write_text('{"vms":' + "[" * 10000 + "0" + "]" * 10000 + "}")
+        registry_file.write_bytes(registry_payload)
 
         log = MagicMock()
         with (

--- a/crates/runner/mitm-addon/tests/test_registry.py
+++ b/crates/runner/mitm-addon/tests/test_registry.py
@@ -391,6 +391,30 @@ class TestLoadRegistry:
         assert log.warn.call_count == 1
         assert "Failed to parse" in log.warn.call_args_list[0].args[0]
 
+    def test_json_recursion_error_after_success_marks_registry_unavailable(self, registry_file):
+        loaded = registry.load_registry(str(registry_file))
+        assert loaded["10.200.0.1"]["runId"] == "run-abc-123"
+
+        registry_file.write_text('{"vms":' + "[" * 10000 + "0" + "]" * 10000 + "}")
+
+        log = MagicMock()
+        with (
+            patch.object(registry.ctx, "log", log, create=True),
+            patch.object(registry.json, "loads", wraps=registry.json.loads) as spy,
+        ):
+            state1 = registry.load_registry_state(str(registry_file))
+            state2 = registry.load_registry_state(str(registry_file))
+            vm_info = registry.get_vm_info("10.200.0.1", str(registry_file))
+
+        assert isinstance(state1, registry.RegistryUnavailable)
+        assert isinstance(state2, registry.RegistryUnavailable)
+        assert state1.reason == "parse_failed"
+        assert state2.reason == "parse_failed"
+        assert vm_info is None
+        assert spy.call_count == 1
+        assert log.warn.call_count == 1
+        assert "Failed to parse" in log.warn.call_args_list[0].args[0]
+
     def test_non_object_vms_after_success_marks_registry_unavailable(self, registry_file):
         registry.load_registry(str(registry_file))
         registry_file.write_text(json.dumps({"vms": ["broken"], "updatedAt": 0}))


### PR DESCRIPTION
## Summary

- Treat Python JSON decoder `RecursionError` as a registry parse failure in `load_registry_state()`.
- Keep the catch scope limited to the existing read/decode/parse/top-level-shape block.
- Add a regression test using a real deeply nested registry JSON file after a prior successful registry snapshot.

Fixes #16805

## Testing

- `python3 -m pytest tests/test_registry.py::TestLoadRegistry::test_json_recursion_error_after_success_marks_registry_unavailable -v`
- `python3 -m pytest tests/test_registry.py -v`
- `ruff check .`
- `ruff format --check .`
- `basedpyright -p .`
- `pnpm -F @vm0/firewalls-generator --dir turbo run --if-present generate`
- `python3 -m pytest tests/test_x_billing.py -v`
- `python3 -m pytest tests/ -v`
