### PR TITLE
feat(desktop): start in menu bar without main window

### DIFF
--- a/turbo/apps/desktop/src/desktop-window-lifecycle.test.ts
+++ b/turbo/apps/desktop/src/desktop-window-lifecycle.test.ts
@@ -1,6 +1,8 @@
 import {
+  hideDockForHiddenMainWindow,
   shouldHideMainWindowOnClose,
   showAndFocusWindow,
+  showDockForVisibleMainWindow,
 } from "./desktop-window-lifecycle";
 import { buildDesktopWindowChromeOptions } from "./desktop-window-chrome";
 
@@ -26,6 +28,52 @@ describe("desktop window lifecycle", () => {
     expect(
       shouldHideMainWindowOnClose({ platform: "linux", isQuitting: false }),
     ).toBe(false);
+  });
+
+  it("hides the dock on macOS when the main window is hidden", () => {
+    const dock = {
+      hide: vi.fn(),
+      show: vi.fn(async () => {}),
+    };
+
+    hideDockForHiddenMainWindow({ platform: "darwin", dock });
+
+    expect(dock.hide).toHaveBeenCalledOnce();
+    expect(dock.show).not.toHaveBeenCalled();
+  });
+
+  it("does not hide the dock outside macOS", () => {
+    const dock = {
+      hide: vi.fn(),
+      show: vi.fn(async () => {}),
+    };
+
+    hideDockForHiddenMainWindow({ platform: "linux", dock });
+
+    expect(dock.hide).not.toHaveBeenCalled();
+  });
+
+  it("shows the dock on macOS when the main window is visible", async () => {
+    const dock = {
+      hide: vi.fn(),
+      show: vi.fn(async () => {}),
+    };
+
+    await showDockForVisibleMainWindow({ platform: "darwin", dock });
+
+    expect(dock.show).toHaveBeenCalledOnce();
+    expect(dock.hide).not.toHaveBeenCalled();
+  });
+
+  it("does not show the dock outside macOS", async () => {
+    const dock = {
+      hide: vi.fn(),
+      show: vi.fn(async () => {}),
+    };
+
+    await showDockForVisibleMainWindow({ platform: "linux", dock });
+
+    expect(dock.show).not.toHaveBeenCalled();
   });
 
   it("restores, shows, and focuses a hidden minimized window", () => {

--- a/turbo/apps/desktop/src/desktop-window-lifecycle.ts
+++ b/turbo/apps/desktop/src/desktop-window-lifecycle.ts
@@ -6,11 +6,36 @@ interface FocusableWindow {
   readonly focus: () => void;
 }
 
+interface DockController {
+  readonly hide: () => void;
+  readonly show: () => Promise<void>;
+}
+
 export function shouldHideMainWindowOnClose(params: {
   readonly platform: NodeJS.Platform;
   readonly isQuitting: boolean;
 }): boolean {
   return params.platform === "darwin" && !params.isQuitting;
+}
+
+export function hideDockForHiddenMainWindow(params: {
+  readonly platform: NodeJS.Platform;
+  readonly dock: DockController | null | undefined;
+}): void {
+  if (params.platform !== "darwin") {
+    return;
+  }
+  params.dock?.hide();
+}
+
+export async function showDockForVisibleMainWindow(params: {
+  readonly platform: NodeJS.Platform;
+  readonly dock: DockController | null | undefined;
+}): Promise<void> {
+  if (params.platform !== "darwin") {
+    return;
+  }
+  await params.dock?.show();
 }
 
 export function showAndFocusWindow(window: FocusableWindow): void {

--- a/turbo/apps/desktop/src/main.ts
+++ b/turbo/apps/desktop/src/main.ts
@@ -63,8 +63,10 @@ import {
   parseDesktopAuthCallbackArgv,
 } from "./desktop-auth";
 import {
+  hideDockForHiddenMainWindow,
   shouldHideMainWindowOnClose,
   showAndFocusWindow,
+  showDockForVisibleMainWindow,
 } from "./desktop-window-lifecycle";
 import { buildDesktopWindowChromeOptions } from "./desktop-window-chrome";
 import {
@@ -216,6 +218,20 @@ function applyDockIcon(): void {
   if (process.platform === "darwin" && app.dock) {
     app.dock.setIcon(appIconPath());
   }
+}
+
+function hideDockForInactiveMainWindow(): void {
+  hideDockForHiddenMainWindow({
+    platform: process.platform,
+    dock: app.dock,
+  });
+}
+
+async function showDockForActiveMainWindow(): Promise<void> {
+  await showDockForVisibleMainWindow({
+    platform: process.platform,
+    dock: app.dock,
+  });
 }
 
 function installDesktopRendererProtocol(): void {
@@ -568,10 +584,12 @@ function installMainWindowPolicy(window: BrowserWindow): void {
 
 async function createMainWindow(): Promise<BrowserWindow> {
   if (mainWindow && !mainWindow.isDestroyed()) {
+    await showDockForActiveMainWindow();
     showAndFocusWindow(mainWindow);
     return mainWindow;
   }
 
+  await showDockForActiveMainWindow();
   const window = new BrowserWindow({
     ...browserWindowOptions(),
     width: 1280,
@@ -590,6 +608,7 @@ async function createMainWindow(): Promise<BrowserWindow> {
     ) {
       event.preventDefault();
       window.hide();
+      hideDockForInactiveMainWindow();
     }
   });
   window.on("closed", () => {
@@ -826,6 +845,7 @@ if (!hasSingleInstanceLock) {
 
   void app.whenReady().then(async () => {
     applyDockIcon();
+    hideDockForInactiveMainWindow();
     applyApplicationMenu();
     registerDesktopAuthProtocol();
     installDesktopRendererProtocol();
@@ -842,7 +862,6 @@ if (!hasSingleInstanceLock) {
     queueDesktopAuthCallbackArgv(process.argv);
 
     const pendingCode = desktopAuthSession.takePendingCode();
-    await createMainWindow();
     if (pendingCode) {
       void desktopAuthSession
         .consumeCode(pendingCode)


### PR DESCRIPTION
## Summary

- keep the desktop app in the menu bar on startup instead of opening the main window
- show the macOS Dock icon when the main window is shown, then hide it again when the main window is closed/hidden
- add lifecycle tests for platform-scoped Dock visibility behavior

## Tests

- `cd turbo && pnpm -F @vm0/desktop test`
- `cd turbo && pnpm -F @vm0/desktop check-types`
- `cd turbo && pnpm -F @vm0/desktop lint`
- `cd turbo && pnpm exec prettier --write apps/desktop/src/main.ts apps/desktop/src/desktop-window-lifecycle.ts apps/desktop/src/desktop-window-lifecycle.test.ts`
