### PR TITLE
fix: update strava connector icon

### DIFF
--- a/turbo/apps/platform/src/views/zero-page/components/settings/icons/strava.svg
+++ b/turbo/apps/platform/src/views/zero-page/components/settings/icons/strava.svg
@@ -1,1 +1,14 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64"><path d="M41.03 47.852l-5.572-10.976h-8.172L41.03 64l13.736-27.124h-8.18" fill="#f9b797"/><path d="M27.898 21.944l7.564 14.928h11.124L27.898 0 9.234 36.876H20.35" fill="#f05222"/></svg>
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64">
+  <rect width="64" height="64" fill="#FC5200" />
+  <g transform="translate(7.22 7) scale(0.767)">
+    <path
+      fill="#fff"
+      fill-opacity="0.5"
+      d="m41.03 47.852-5.572-10.976h-8.172L41.03 64l13.736-27.124h-8.18z"
+    />
+    <path
+      fill="#fff"
+      d="m27.898 21.944 7.564 14.928h11.124L27.898 0 9.234 36.876H20.35z"
+    />
+  </g>
+</svg>


### PR DESCRIPTION
## Summary
- replace the off-palette transparent Strava mark with a square app-icon style SVG
- use official Strava orange `#FC5200` with white symbol layers
- keep `strava` in colorful mode

## Sources
- https://developers.strava.com/guidelines/
- https://www.strava.com/favicon.ico
- https://d3nn82uaxijpm6.cloudfront.net/icon-strava-chrome-192.png?v=dLlWydWlG8

Fixes #16875

## Tests
- `pnpm exec prettier --parser html --check apps/platform/src/views/zero-page/components/settings/icons/strava.svg`
- SVG XML/structure validation
- `git diff --check`