### PR TITLE
fix: confirm desktop quit

### DIFF
--- a/turbo/apps/desktop/src/desktop-quit-confirmation.test.ts
+++ b/turbo/apps/desktop/src/desktop-quit-confirmation.test.ts
@@ -1,0 +1,111 @@
+import {
+  DesktopQuitConfirmationController,
+  buildDesktopQuitConfirmationOptions,
+  isDesktopQuitConfirmed,
+} from "./desktop-quit-confirmation";
+
+interface DeferredQuitConfirmation {
+  readonly promise: Promise<boolean>;
+  readonly resolve: (confirmed: boolean) => void;
+}
+
+function createDeferredQuitConfirmation(): DeferredQuitConfirmation {
+  let resolveConfirmation: (confirmed: boolean) => void = () => {
+    throw new Error("Quit confirmation resolved before initialization");
+  };
+  const promise = new Promise<boolean>((resolve) => {
+    resolveConfirmation = resolve;
+  });
+  return { promise, resolve: resolveConfirmation };
+}
+
+describe("desktop quit confirmation", () => {
+  it("builds a cancel-default quit confirmation dialog", () => {
+    expect(
+      buildDesktopQuitConfirmationOptions("Zero Computer Use"),
+    ).toStrictEqual({
+      type: "question",
+      buttons: ["Quit", "Cancel"],
+      defaultId: 1,
+      cancelId: 1,
+      title: "Quit Zero Computer Use?",
+      message: "Quit Zero Computer Use?",
+      detail: "Computer Use will stop running until you reopen the app.",
+    });
+  });
+
+  it("maps the quit button response to confirmed", () => {
+    expect(isDesktopQuitConfirmed(0)).toBe(true);
+    expect(isDesktopQuitConfirmed(1)).toBe(false);
+  });
+
+  it("keeps the app running when the user cancels", async () => {
+    const quit = vi.fn();
+    const controller = new DesktopQuitConfirmationController({
+      confirmQuit: async () => {
+        return false;
+      },
+      quit,
+    });
+
+    await controller.requestQuit();
+
+    expect(controller.isQuitAllowed()).toBe(false);
+    expect(quit).not.toHaveBeenCalled();
+  });
+
+  it("allows quit and calls app quit after confirmation", async () => {
+    const quit = vi.fn();
+    const controller = new DesktopQuitConfirmationController({
+      confirmQuit: async () => {
+        return true;
+      },
+      quit,
+    });
+
+    await controller.requestQuit();
+
+    expect(controller.isQuitAllowed()).toBe(true);
+    expect(quit).toHaveBeenCalledOnce();
+  });
+
+  it("deduplicates concurrent quit confirmations", async () => {
+    const confirmation = createDeferredQuitConfirmation();
+    const confirmQuit = vi.fn(() => {
+      return confirmation.promise;
+    });
+    const quit = vi.fn();
+    const controller = new DesktopQuitConfirmationController({
+      confirmQuit,
+      quit,
+    });
+
+    const firstRequest = controller.requestQuit();
+    const secondRequest = controller.requestQuit();
+
+    expect(firstRequest).toBe(secondRequest);
+    expect(confirmQuit).toHaveBeenCalledOnce();
+    confirmation.resolve(true);
+    await firstRequest;
+
+    expect(controller.isQuitAllowed()).toBe(true);
+    expect(quit).toHaveBeenCalledOnce();
+  });
+
+  it("allows programmatic quit without prompting", async () => {
+    const confirmQuit = vi.fn(async () => {
+      return true;
+    });
+    const quit = vi.fn();
+    const controller = new DesktopQuitConfirmationController({
+      confirmQuit,
+      quit,
+    });
+
+    controller.allowQuitWithoutConfirmation();
+    await controller.requestQuit();
+
+    expect(confirmQuit).not.toHaveBeenCalled();
+    expect(quit).toHaveBeenCalledOnce();
+  });
+});

--- a/turbo/apps/desktop/src/desktop-quit-confirmation.ts
+++ b/turbo/apps/desktop/src/desktop-quit-confirmation.ts
@@ -1,0 +1,73 @@
+import type { MessageBoxOptions } from "electron";
+
+const QUIT_BUTTON_INDEX = 0;
+const CANCEL_BUTTON_INDEX = 1;
+
+interface DesktopQuitConfirmationControllerOptions {
+  readonly confirmQuit: () => Promise<boolean>;
+  readonly quit: () => void;
+}
+
+export class DesktopQuitConfirmationController {
+  private quitAllowed = false;
+  private pendingConfirmation: Promise<void> | null = null;
+
+  constructor(
+    private readonly options: DesktopQuitConfirmationControllerOptions,
+  ) {}
+
+  isQuitAllowed(): boolean {
+    return this.quitAllowed;
+  }
+
+  allowQuitWithoutConfirmation(): void {
+    this.quitAllowed = true;
+  }
+
+  requestQuit(): Promise<void> {
+    if (this.quitAllowed) {
+      this.options.quit();
+      return Promise.resolve();
+    }
+
+    if (this.pendingConfirmation) {
+      return this.pendingConfirmation;
+    }
+
+    const confirmation = this.options
+      .confirmQuit()
+      .then((confirmed) => {
+        if (!confirmed) {
+          return;
+        }
+
+        this.quitAllowed = true;
+        this.options.quit();
+      })
+      .finally(() => {
+        if (this.pendingConfirmation === confirmation) {
+          this.pendingConfirmation = null;
+        }
+      });
+    this.pendingConfirmation = confirmation;
+    return confirmation;
+  }
+}
+
+export function buildDesktopQuitConfirmationOptions(
+  displayName: string,
+): MessageBoxOptions {
+  return {
+    type: "question",
+    buttons: ["Quit", "Cancel"],
+    defaultId: CANCEL_BUTTON_INDEX,
+    cancelId: CANCEL_BUTTON_INDEX,
+    title: `Quit ${displayName}?`,
+    message: `Quit ${displayName}?`,
+    detail: "Computer Use will stop running until you reopen the app.",
+  };
+}
+
+export function isDesktopQuitConfirmed(response: number): boolean {
+  return response === QUIT_BUTTON_INDEX;
+}

--- a/turbo/apps/desktop/src/main.ts
+++ b/turbo/apps/desktop/src/main.ts
@@ -3,6 +3,7 @@ import { pathToFileURL } from "node:url";
 import {
   app,
   BrowserWindow,
+  dialog,
   Menu,
   net,
   protocol,
@@ -43,6 +44,11 @@ import { createComputerUseNativeBackend } from "./computer-use-native";
 import { resolveDesktopConfig } from "./config";
 import { installDesktopAutoUpdates } from "./desktop-auto-updates";
 import { createDesktopComputerUseSessionFetch } from "./desktop-computer-use-api";
+import {
+  DesktopQuitConfirmationController,
+  buildDesktopQuitConfirmationOptions,
+  isDesktopQuitConfirmed,
+} from "./desktop-quit-confirmation";
 import { installDesktopTray, type DesktopTrayController } from "./desktop-tray";
 import { DesktopAuthSession } from "./desktop-auth-session";
 import {
@@ -104,6 +110,12 @@ let computerUseBlockedHostState: ComputerUseHostRuntimeState | null = null;
 const computerUseSnapshotStore = new ComputerUseSnapshotStore();
 const computerUseNativeBackend = createComputerUseNativeBackend();
 setComputerUsePermissionNativeBackend(computerUseNativeBackend);
+const quitConfirmation = new DesktopQuitConfirmationController({
+  confirmQuit: confirmDesktopQuit,
+  quit: () => {
+    app.quit();
+  },
+});
 
 function refreshDesktopTray(): void {
   desktopTray?.refresh();
@@ -356,6 +368,7 @@ function disposeComputerUseNativeBackend(): void {
 }
 
 async function prepareForQuitAndInstall(): Promise<void> {
+  quitConfirmation.allowQuitWithoutConfirmation();
   appIsQuitting = true;
   if (!computerUseQuitStopStarted) {
     computerUseQuitStopStarted = true;
@@ -407,8 +420,14 @@ function installTray(): void {
       openExternal(MAC_SCREEN_RECORDING_SETTINGS_URL);
     },
     quit: () => {
-      app.quit();
+      requestDesktopQuit();
     },
+  });
+}
+
+function requestDesktopQuit(): void {
+  void quitConfirmation.requestQuit().catch((error) => {
+    console.error("Desktop quit confirmation failed", error);
   });
 }
 
@@ -416,7 +435,15 @@ function applyApplicationMenu(): void {
   const menu = Menu.buildFromTemplate([
     {
       label: config.identity.displayName,
-      submenu: [{ role: "about" }, { type: "separator" }, { role: "quit" }],
+      submenu: [
+        { role: "about" },
+        { type: "separator" },
+        {
+          label: `Quit ${config.identity.displayName}`,
+          accelerator: "CommandOrControl+Q",
+          click: requestDesktopQuit,
+        },
+      ],
     },
     {
       label: "Edit",
@@ -436,6 +463,20 @@ function applyApplicationMenu(): void {
     },
   ]);
   Menu.setApplicationMenu(menu);
+}
+
+async function confirmDesktopQuit(): Promise<boolean> {
+  const options = buildDesktopQuitConfirmationOptions(
+    config.identity.displayName,
+  );
+  const window =
+    mainWindow && !mainWindow.isDestroyed() && mainWindow.isVisible()
+      ? mainWindow
+      : undefined;
+  const result = window
+    ? await dialog.showMessageBox(window, options)
+    : await dialog.showMessageBox(options);
+  return isDesktopQuitConfirmed(result.response);
 }
 
 function openExternal(url: string): void {
@@ -811,6 +852,12 @@ if (!hasSingleInstanceLock) {
   });
 
   app.on("before-quit", (event) => {
+    if (!quitConfirmation.isQuitAllowed()) {
+      event.preventDefault();
+      requestDesktopQuit();
+      return;
+    }
+
     appIsQuitting = true;
     if (!computerUseRuntime || computerUseQuitStopStarted) {
       disposeComputerUseNativeBackend();


### PR DESCRIPTION
## Summary
- add a native confirmation dialog before user-initiated Desktop quit
- route CommandOrControl+Q and tray Quit through the shared quit confirmation flow
- bypass the extra confirmation for update restart installs after the update prompt

## Validation
- pnpm -F @vm0/desktop test
- pnpm -F @vm0/desktop check-types
- pnpm -F @vm0/desktop lint
- pnpm knip --workspace @vm0/desktop

Note: scripts/prepare.sh installed dependencies but could not complete migrations/seed because DATABASE_URL and synced env values are unavailable in this local environment.