### PR TITLE
feat: show desktop tray permission status

### DIFF
--- a/turbo/apps/desktop/src/desktop-tray-menu.test.ts
+++ b/turbo/apps/desktop/src/desktop-tray-menu.test.ts
@@ -76,6 +76,8 @@ function trayActions(
     refreshStatus: vi.fn(),
     openSignIn: vi.fn(),
     switchWorkspace: vi.fn(),
+    requestAccessibilityPermission: vi.fn(),
+    requestScreenRecordingPermission: vi.fn(),
     openAccessibilitySettings: vi.fn(),
     openScreenRecordingSettings: vi.fn(),
     quit: vi.fn(),
@@ -133,7 +135,7 @@ describe("desktop tray menu", () => {
     expect(findItem(menu, "Quit")).toBeDefined();
   });
 
-  it("enables starting Computer Use when idle and signed in", () => {
+  it("enables starting Computer Use when ready and signed in", () => {
     const startComputerUse = vi.fn();
     const menu = buildDesktopTrayMenuItems(
       {
@@ -144,7 +146,7 @@ describe("desktop tray menu", () => {
       trayActions({ startComputerUse }),
     );
 
-    const computerUseMenu = submenu(findItem(menu, "Computer Use: Idle"));
+    const computerUseMenu = submenu(findItem(menu, "Computer Use: Ready"));
     const startItem = findItem(computerUseMenu, "Start Computer Use");
 
     expect(startItem.enabled).toBe(true);
@@ -167,7 +169,9 @@ describe("desktop tray menu", () => {
       trayActions({ openSignIn }),
     );
 
-    const computerUseMenu = submenu(findItem(menu, "Computer Use: Idle"));
+    const computerUseMenu = submenu(
+      findItem(menu, "Computer Use: Sign in required"),
+    );
 
     expect(findItem(computerUseMenu, "Start Computer Use").enabled).toBe(false);
     click(findItem(computerUseMenu, "Sign in to Zero"));
@@ -175,6 +179,8 @@ describe("desktop tray menu", () => {
   });
 
   it("shows permission actions when Computer Use is blocked locally", () => {
+    const requestAccessibilityPermission = vi.fn();
+    const requestScreenRecordingPermission = vi.fn();
     const openAccessibilitySettings = vi.fn();
     const openScreenRecordingSettings = vi.fn();
     const menu = buildDesktopTrayMenuItems(
@@ -187,6 +193,8 @@ describe("desktop tray menu", () => {
         authError: null,
       },
       trayActions({
+        requestAccessibilityPermission,
+        requestScreenRecordingPermission,
         openAccessibilitySettings,
         openScreenRecordingSettings,
       }),
@@ -195,6 +203,41 @@ describe("desktop tray menu", () => {
     const computerUseMenu = submenu(
       findItem(menu, "Computer Use: Needs permissions"),
     );
+    click(findItem(computerUseMenu, "Request Accessibility Permission"));
+    click(findItem(computerUseMenu, "Accessibility Settings"));
+    click(findItem(computerUseMenu, "Request Screen Recording Permission"));
+    click(findItem(computerUseMenu, "Screen Recording Settings"));
+
+    expect(requestAccessibilityPermission).toHaveBeenCalledOnce();
+    expect(requestScreenRecordingPermission).toHaveBeenCalledOnce();
+    expect(openAccessibilitySettings).toHaveBeenCalledOnce();
+    expect(openScreenRecordingSettings).toHaveBeenCalledOnce();
+  });
+
+  it("shows ready permissions and keeps settings available", () => {
+    const openAccessibilitySettings = vi.fn();
+    const openScreenRecordingSettings = vi.fn();
+    const menu = buildDesktopTrayMenuItems(
+      {
+        computerUse: computerUseState({ status: "idle" }),
+        auth: signedInAuth,
+        authError: null,
+      },
+      trayActions({
+        openAccessibilitySettings,
+        openScreenRecordingSettings,
+      }),
+    );
+
+    const computerUseMenu = submenu(findItem(menu, "Computer Use: Ready"));
+    expect(findItem(computerUseMenu, "Status: Ready").enabled).toBe(false);
+    expect(findItem(computerUseMenu, "Accessibility: Ready").enabled).toBe(
+      false,
+    );
+    expect(findItem(computerUseMenu, "Screen Recording: Ready").enabled).toBe(
+      false,
+    );
+
     click(findItem(computerUseMenu, "Accessibility Settings"));
     click(findItem(computerUseMenu, "Screen Recording Settings"));
 

--- a/turbo/apps/desktop/src/desktop-tray-menu.ts
+++ b/turbo/apps/desktop/src/desktop-tray-menu.ts
@@ -7,10 +7,10 @@ import {
 } from "./computer-use-types";
 
 const HOST_STATUS_LABELS = {
-  idle: "Idle",
-  connecting: "Connecting",
+  idle: "Ready",
+  connecting: "Starting...",
   online: "Online",
-  unauthenticated: "Signed out",
+  unauthenticated: "Sign in required",
   needs_organization: "Select workspace",
   disabled: "Disabled",
   error: "Error",
@@ -39,6 +39,8 @@ export interface DesktopTrayMenuActions {
   readonly refreshStatus: () => void;
   readonly openSignIn: () => void;
   readonly switchWorkspace: () => void;
+  readonly requestAccessibilityPermission: () => void;
+  readonly requestScreenRecordingPermission: () => void;
   readonly openAccessibilitySettings: () => void;
   readonly openScreenRecordingSettings: () => void;
   readonly quit: () => void;
@@ -58,14 +60,26 @@ function disabledLabel(label: string): DesktopTrayMenuItem {
   return { label, enabled: false };
 }
 
-function computerUseStatusLabel(state: DesktopComputerUseState): string {
-  if (!state.supported) {
+function computerUseStatusLabel(state: DesktopTrayMenuState): string {
+  if (!state.computerUse.supported) {
     return "Unsupported";
   }
-  if (!hasRequiredComputerUsePermissions(state.permissions)) {
+  if (!hasRequiredComputerUsePermissions(state.computerUse.permissions)) {
     return "Needs permissions";
   }
-  return HOST_STATUS_LABELS[state.host.status];
+  if (state.computerUse.host.status !== "idle") {
+    return HOST_STATUS_LABELS[state.computerUse.host.status];
+  }
+  if (state.auth?.status === "signing_in") {
+    return "Signing in...";
+  }
+  if (state.auth?.status !== "signed_in") {
+    return "Sign in required";
+  }
+  if (!state.auth.organization) {
+    return "Select workspace";
+  }
+  return HOST_STATUS_LABELS[state.computerUse.host.status];
 }
 
 function isAuthReady(auth: DesktopAuthState | null): boolean {
@@ -106,7 +120,7 @@ function buildComputerUseSubmenu(
   actions: DesktopTrayMenuActions,
 ): readonly DesktopTrayMenuItem[] {
   const items: DesktopTrayMenuItem[] = [
-    disabledLabel(`Status: ${computerUseStatusLabel(state.computerUse)}`),
+    disabledLabel(`Status: ${computerUseStatusLabel(state)}`),
   ];
 
   if (!state.computerUse.supported) {
@@ -117,18 +131,11 @@ function buildComputerUseSubmenu(
     ];
   }
 
+  items.push(separator(), ...buildPermissionItems(state, actions));
+
   if (!hasRequiredComputerUsePermissions(state.computerUse.permissions)) {
     return [
       ...items,
-      separator(),
-      {
-        label: "Accessibility Settings",
-        click: actions.openAccessibilitySettings,
-      },
-      {
-        label: "Screen Recording Settings",
-        click: actions.openScreenRecordingSettings,
-      },
       separator(),
       { label: "Refresh Status", click: actions.refreshStatus },
     ];
@@ -149,6 +156,41 @@ function buildComputerUseSubmenu(
   }
   startItems.push({ label: "Refresh Status", click: actions.refreshStatus });
   return startItems;
+}
+
+function buildPermissionItems(
+  state: DesktopTrayMenuState,
+  actions: DesktopTrayMenuActions,
+): readonly DesktopTrayMenuItem[] {
+  const items: DesktopTrayMenuItem[] = [];
+
+  if (state.computerUse.permissions.accessibility) {
+    items.push(disabledLabel("Accessibility: Ready"));
+  } else {
+    items.push({
+      label: "Request Accessibility Permission",
+      click: actions.requestAccessibilityPermission,
+    });
+  }
+  items.push({
+    label: "Accessibility Settings",
+    click: actions.openAccessibilitySettings,
+  });
+
+  if (state.computerUse.permissions.screenRecording) {
+    items.push(disabledLabel("Screen Recording: Ready"));
+  } else {
+    items.push({
+      label: "Request Screen Recording Permission",
+      click: actions.requestScreenRecordingPermission,
+    });
+  }
+  items.push({
+    label: "Screen Recording Settings",
+    click: actions.openScreenRecordingSettings,
+  });
+
+  return items;
 }
 
 function authStatusLabel(state: DesktopTrayMenuState): string {
@@ -269,7 +311,7 @@ export function buildDesktopTrayMenuItems(
     { label: "Show Main Window", click: actions.showMainWindow },
     separator(),
     {
-      label: `Computer Use: ${computerUseStatusLabel(state.computerUse)}`,
+      label: `Computer Use: ${computerUseStatusLabel(state)}`,
       submenu: buildComputerUseSubmenu(state, actions),
     },
     {

--- a/turbo/apps/desktop/src/desktop-tray.ts
+++ b/turbo/apps/desktop/src/desktop-tray.ts
@@ -23,6 +23,8 @@ interface DesktopTrayControllerOptions {
   readonly refreshStatus: () => Promise<void>;
   readonly openSignIn: () => void;
   readonly switchWorkspace: () => Promise<void>;
+  readonly requestAccessibilityPermission: () => Promise<void>;
+  readonly requestScreenRecordingPermission: () => Promise<void>;
   readonly openAccessibilitySettings: () => void;
   readonly openScreenRecordingSettings: () => void;
   readonly quit: () => void;
@@ -163,6 +165,18 @@ export class DesktopTrayController {
           return this.options.switchWorkspace();
         },
         { refreshAuth: true },
+      ),
+      requestAccessibilityPermission: this.runAction(
+        "request Accessibility permission",
+        () => {
+          return this.options.requestAccessibilityPermission();
+        },
+      ),
+      requestScreenRecordingPermission: this.runAction(
+        "request Screen Recording permission",
+        () => {
+          return this.options.requestScreenRecordingPermission();
+        },
       ),
       openAccessibilitySettings: this.runAction(
         "open Accessibility Settings",

--- a/turbo/apps/desktop/src/main.ts
+++ b/turbo/apps/desktop/src/main.ts
@@ -400,6 +400,12 @@ function installTray(): void {
       openExternal(desktopAuthStartUrl);
     },
     switchWorkspace: () => getAuthSession().selectOrganization(),
+    requestAccessibilityPermission: async () => {
+      await requestComputerUsePermission();
+    },
+    requestScreenRecordingPermission: async () => {
+      await requestComputerUseScreenRecording();
+    },
     openAccessibilitySettings: () => {
       openExternal(MAC_ACCESSIBILITY_SETTINGS_URL);
     },


### PR DESCRIPTION
## Summary
- replace the visible Computer Use idle tray label with readiness-oriented labels
- show per-permission Request/Ready rows in the Desktop tray menu
- keep Accessibility and Screen Recording settings available from the tray after permissions are granted

## Tests
- pnpm -F @vm0/desktop exec vitest run src/desktop-tray-menu.test.ts
- pnpm -F @vm0/desktop check-types
- pnpm -F @vm0/desktop lint
- pnpm -F @vm0/desktop test
