### PR TITLE
fix: bound auth base forwarding workers

### DIFF
--- a/crates/runner/mitm-addon/src/auth_base_forwarder.py
+++ b/crates/runner/mitm-addon/src/auth_base_forwarder.py
@@ -13,7 +13,8 @@ import ipaddress
 import socket
 import ssl
 import urllib.parse
-from concurrent.futures import ThreadPoolExecutor
+from concurrent.futures import Future, ThreadPoolExecutor
+from contextlib import suppress
 from typing import NamedTuple
 
 from mitmproxy import http
@@ -38,17 +39,28 @@ MAX_CONCURRENT_AUTH_BASE_FORWARDS = 4
 NAT64_WELL_KNOWN_PREFIX = ipaddress.IPv6Network("64:ff9b::/96")
 
 _forward_request_executor_state: tuple[int, ThreadPoolExecutor] | None = None
+_forward_request_admission_state: (
+    tuple[asyncio.AbstractEventLoop, int, asyncio.Semaphore] | None
+) = None
+_forward_request_accepting = True
 
 
 def reset_forward_request_state_for_tests() -> None:
     """Reset forwarder worker state between tests."""
+    global _forward_request_accepting
+
     shutdown_forward_request_executor(wait=True)
+    _forward_request_accepting = True
 
 
 def shutdown_forward_request_executor(*, wait: bool) -> None:
     """Shut down auth.base forwarding workers."""
     global _forward_request_executor_state
+    global _forward_request_admission_state
+    global _forward_request_accepting
 
+    _forward_request_accepting = False
+    _forward_request_admission_state = None
     state = _forward_request_executor_state
     _forward_request_executor_state = None
     if state is not None:
@@ -356,6 +368,8 @@ def _forward_request_sync(
 def _get_forward_request_executor() -> ThreadPoolExecutor:
     global _forward_request_executor_state
 
+    if not _forward_request_accepting:
+        raise RuntimeError("auth.base forwarding executor is shut down")
     max_workers = MAX_CONCURRENT_AUTH_BASE_FORWARDS
     if _forward_request_executor_state is None or _forward_request_executor_state[0] != max_workers:
         state = _forward_request_executor_state
@@ -369,6 +383,43 @@ def _get_forward_request_executor() -> ThreadPoolExecutor:
         if state is not None:
             state[1].shutdown(wait=True, cancel_futures=True)
     return _forward_request_executor_state[1]
+
+
+def _get_forward_request_admission_semaphore() -> asyncio.Semaphore:
+    global _forward_request_admission_state
+
+    if not _forward_request_accepting:
+        raise RuntimeError("auth.base forwarding executor is shut down")
+    loop = asyncio.get_running_loop()
+    max_workers = MAX_CONCURRENT_AUTH_BASE_FORWARDS
+    if (
+        _forward_request_admission_state is None
+        or _forward_request_admission_state[0] is not loop
+        or _forward_request_admission_state[1] != max_workers
+    ):
+        _forward_request_admission_state = (
+            loop,
+            max_workers,
+            asyncio.Semaphore(max_workers),
+        )
+    return _forward_request_admission_state[2]
+
+
+def _can_submit_forward_request(semaphore: asyncio.Semaphore) -> bool:
+    return (
+        _forward_request_accepting
+        and _forward_request_admission_state is not None
+        and _forward_request_admission_state[2] is semaphore
+    )
+
+
+def _release_forward_request_slot(
+    loop: asyncio.AbstractEventLoop,
+    semaphore: asyncio.Semaphore,
+    _future: Future[tuple[int, bytes, http.Headers]],
+) -> None:
+    with suppress(RuntimeError):
+        loop.call_soon_threadsafe(semaphore.release)
 
 
 def _forward_request_sync_in_context(
@@ -390,13 +441,33 @@ async def forward_request(
     """Async wrapper for _forward_request_sync."""
     _validate_request_body_size(body)
     loop = asyncio.get_running_loop()
+    semaphore = _get_forward_request_admission_semaphore()
     context = contextvars.copy_context()
-    return await loop.run_in_executor(
-        _get_forward_request_executor(),
-        _forward_request_sync_in_context,
-        context,
-        url,
-        method,
-        headers,
-        body,
+    await semaphore.acquire()
+    if not _can_submit_forward_request(semaphore):
+        semaphore.release()
+        raise RuntimeError("auth.base forwarding executor is shut down")
+    try:
+        future = _get_forward_request_executor().submit(
+            _forward_request_sync_in_context,
+            context,
+            url,
+            method,
+            headers,
+            body,
+        )
+    except Exception:
+        semaphore.release()
+        raise
+    future.add_done_callback(
+        lambda completed_future: _release_forward_request_slot(
+            loop,
+            semaphore,
+            completed_future,
+        )
     )
+    try:
+        return await asyncio.wrap_future(future, loop=loop)
+    except asyncio.CancelledError:
+        future.cancel()
+        raise

--- a/crates/runner/mitm-addon/src/auth_base_forwarder.py
+++ b/crates/runner/mitm-addon/src/auth_base_forwarder.py
@@ -6,12 +6,14 @@ the low-level HTTP details for that forward path.
 """
 
 import asyncio
+import contextvars
 import errno
 import http.client as http_client
 import ipaddress
 import socket
 import ssl
 import urllib.parse
+from concurrent.futures import ThreadPoolExecutor
 from typing import NamedTuple
 
 from mitmproxy import http
@@ -35,14 +37,17 @@ MAX_AUTH_BASE_RESPONSE_BODY_BYTES = 32 * 1024 * 1024
 MAX_CONCURRENT_AUTH_BASE_FORWARDS = 4
 NAT64_WELL_KNOWN_PREFIX = ipaddress.IPv6Network("64:ff9b::/96")
 
-_forward_request_semaphore_state: tuple[asyncio.AbstractEventLoop, asyncio.Semaphore] | None = None
+_forward_request_executor_state: tuple[int, ThreadPoolExecutor] | None = None
 
 
 def reset_forward_request_state_for_tests() -> None:
-    """Reset per-loop forwarder state between tests."""
-    global _forward_request_semaphore_state
+    """Reset forwarder worker state between tests."""
+    global _forward_request_executor_state
 
-    _forward_request_semaphore_state = None
+    state = _forward_request_executor_state
+    _forward_request_executor_state = None
+    if state is not None:
+        state[1].shutdown(wait=True, cancel_futures=True)
 
 
 class ForwardedResponseTooLargeError(Exception):
@@ -343,16 +348,32 @@ def _forward_request_sync(
         conn.close()
 
 
-def _get_forward_request_semaphore() -> asyncio.Semaphore:
-    global _forward_request_semaphore_state
+def _get_forward_request_executor() -> ThreadPoolExecutor:
+    global _forward_request_executor_state
 
-    loop = asyncio.get_running_loop()
-    if _forward_request_semaphore_state is None or _forward_request_semaphore_state[0] is not loop:
-        _forward_request_semaphore_state = (
-            loop,
-            asyncio.Semaphore(MAX_CONCURRENT_AUTH_BASE_FORWARDS),
+    max_workers = MAX_CONCURRENT_AUTH_BASE_FORWARDS
+    if _forward_request_executor_state is None or _forward_request_executor_state[0] != max_workers:
+        state = _forward_request_executor_state
+        _forward_request_executor_state = (
+            max_workers,
+            ThreadPoolExecutor(
+                max_workers=max_workers,
+                thread_name_prefix="auth-base-forward",
+            ),
         )
-    return _forward_request_semaphore_state[1]
+        if state is not None:
+            state[1].shutdown(wait=True, cancel_futures=True)
+    return _forward_request_executor_state[1]
+
+
+def _forward_request_sync_in_context(
+    context: contextvars.Context,
+    url: str,
+    method: str,
+    headers: list[tuple[str, str]],
+    body: bytes | None,
+) -> tuple[int, bytes, http.Headers]:
+    return context.run(_forward_request_sync, url, method, headers, body)
 
 
 async def forward_request(
@@ -363,5 +384,14 @@ async def forward_request(
 ) -> tuple[int, bytes, http.Headers]:
     """Async wrapper for _forward_request_sync."""
     _validate_request_body_size(body)
-    async with _get_forward_request_semaphore():
-        return await asyncio.to_thread(_forward_request_sync, url, method, headers, body)
+    loop = asyncio.get_running_loop()
+    context = contextvars.copy_context()
+    return await loop.run_in_executor(
+        _get_forward_request_executor(),
+        _forward_request_sync_in_context,
+        context,
+        url,
+        method,
+        headers,
+        body,
+    )

--- a/crates/runner/mitm-addon/src/auth_base_forwarder.py
+++ b/crates/runner/mitm-addon/src/auth_base_forwarder.py
@@ -42,12 +42,17 @@ _forward_request_executor_state: tuple[int, ThreadPoolExecutor] | None = None
 
 def reset_forward_request_state_for_tests() -> None:
     """Reset forwarder worker state between tests."""
+    shutdown_forward_request_executor(wait=True)
+
+
+def shutdown_forward_request_executor(*, wait: bool) -> None:
+    """Shut down auth.base forwarding workers."""
     global _forward_request_executor_state
 
     state = _forward_request_executor_state
     _forward_request_executor_state = None
     if state is not None:
-        state[1].shutdown(wait=True, cancel_futures=True)
+        state[1].shutdown(wait=wait, cancel_futures=True)
 
 
 class ForwardedResponseTooLargeError(Exception):

--- a/crates/runner/mitm-addon/src/mitm_addon.py
+++ b/crates/runner/mitm-addon/src/mitm_addon.py
@@ -30,14 +30,17 @@ from mitmproxy.addonmanager import Loader
 
 # --- Sub-module imports ---
 #
-# Usage/body_utils/matching/registry/response_streaming are imported by module
+# auth_base_forwarder/body_utils/matching/registry/response_streaming/usage
+# are imported by module
 # (not selective `from X import ...`)
 # so that:
-#   1. Cross-module calls read as ``usage.X(...)`` / ``body_utils.X(...)`` /
-#      ``matching.X(...)`` / ``registry.X(...)`` / ``response_streaming.X(...)``,
+#   1. Cross-module calls read as ``auth_base_forwarder.X(...)`` /
+#      ``body_utils.X(...)`` / ``matching.X(...)`` / ``registry.X(...)`` /
+#      ``response_streaming.X(...)`` / ``usage.X(...)``,
 #      making the module boundary visible at call sites.
 #   2. Tests can patch names on the owning module object and affect all
 #      callers — no mock-placement pitfalls from copied function bindings.
+import auth_base_forwarder
 import body_utils
 import flow_metadata_keys as metadata_keys
 import matching
@@ -1090,13 +1093,15 @@ def error(flow: http.HTTPFlow) -> None:
 
 
 def done():
-    """Flush pending usage reports before mitmproxy exits.
+    """Flush pending usage reports and forwarding workers before mitmproxy exits.
 
     Runner-triggered flush workers and shutdown flush share
     ``_usage_flush_signal_lock``. Waiting here keeps shutdown from closing the
     executor while a SIGUSR1 worker is still converting buffered usage into
     webhook reports. After that, ``shutdown(wait=True)`` drains submitted
-    webhook futures during graceful stop.
+    webhook futures during graceful stop. Auth.base forwarding does not need
+    to finish queued work during shutdown, so its executor cancels queued
+    futures without waiting for slow upstream responses.
     """
     try:
         # Wait for any in-flight runner-triggered flush before closing the
@@ -1107,7 +1112,10 @@ def done():
         try:
             usage.webhook.usage_executor.shutdown(wait=True)
         finally:
-            shutdown_log_writer()
+            try:
+                auth_base_forwarder.shutdown_forward_request_executor(wait=False)
+            finally:
+                shutdown_log_writer()
 
 
 # ============================================================================

--- a/crates/runner/mitm-addon/tests/test_auth_base_forwarder.py
+++ b/crates/runner/mitm-addon/tests/test_auth_base_forwarder.py
@@ -996,6 +996,78 @@ class TestForwardRequestAsyncWrapper:
         assert response_summaries == [(200, b"ok", [])] * task_count
         assert max_active == cap
 
+    async def test_cancelled_await_does_not_release_running_forward_slot(self):
+        active = 0
+        max_active = 0
+        started = 0
+        lock = threading.Lock()
+        first_entered = threading.Event()
+        second_entered = threading.Event()
+        release_first = threading.Event()
+
+        def create_connection(_address, _timeout, _source_address):
+            nonlocal active
+            nonlocal max_active
+            nonlocal started
+
+            with lock:
+                active += 1
+                started += 1
+                current = started
+                max_active = max(max_active, active)
+                if current == 1:
+                    first_entered.set()
+                elif current == 2:
+                    second_entered.set()
+            try:
+                if current == 1 and not release_first.wait(timeout=5):
+                    raise TimeoutError("test did not release first forward")
+                return _FakeSocket(_http_response())
+            finally:
+                with lock:
+                    active -= 1
+
+        second_task = None
+        with (
+            patch.object(forwarder, "MAX_CONCURRENT_AUTH_BASE_FORWARDS", 1),
+            _fake_forwarder_upstream(create_connection=create_connection),
+        ):
+            first_task = asyncio.create_task(
+                forwarder.forward_request("https://example.com", "GET", [], None)
+            )
+            try:
+                first_started = await asyncio.to_thread(first_entered.wait, 2)
+                assert first_started
+
+                first_task.cancel()
+                with pytest.raises(asyncio.CancelledError):
+                    await asyncio.wait_for(first_task, timeout=1)
+
+                second_task = asyncio.create_task(
+                    forwarder.forward_request("https://example.com", "GET", [], None)
+                )
+                second_started_before_release = await asyncio.to_thread(
+                    second_entered.wait,
+                    0.2,
+                )
+                assert not second_started_before_release
+
+                release_first.set()
+                second_started_after_release = await asyncio.to_thread(second_entered.wait, 2)
+                assert second_started_after_release
+
+                status, body, headers = await asyncio.wait_for(second_task, timeout=2)
+            finally:
+                release_first.set()
+                await asyncio.gather(first_task, return_exceptions=True)
+                if second_task is not None:
+                    await asyncio.gather(second_task, return_exceptions=True)
+
+        assert status == 200
+        assert body == b"ok"
+        assert list(headers.items(multi=True)) == []
+        assert max_active == 1
+
     async def test_offloads_request_work_from_event_loop_thread(self):
         event_loop_thread_id = threading.get_ident()
         forwarding_thread_ids: list[int] = []

--- a/crates/runner/mitm-addon/tests/test_auth_base_forwarder.py
+++ b/crates/runner/mitm-addon/tests/test_auth_base_forwarder.py
@@ -1068,6 +1068,133 @@ class TestForwardRequestAsyncWrapper:
         assert list(headers.items(multi=True)) == []
         assert max_active == 1
 
+    async def test_cancelled_waiting_forward_does_not_leak_forward_slot(self):
+        active = 0
+        max_active = 0
+        started = 0
+        lock = threading.Lock()
+        first_entered = threading.Event()
+        second_entered = threading.Event()
+        release_first = threading.Event()
+
+        def create_connection(_address, _timeout, _source_address):
+            nonlocal active
+            nonlocal max_active
+            nonlocal started
+
+            with lock:
+                active += 1
+                started += 1
+                current = started
+                max_active = max(max_active, active)
+                if current == 1:
+                    first_entered.set()
+                elif current == 2:
+                    second_entered.set()
+            try:
+                if current == 1 and not release_first.wait(timeout=5):
+                    raise TimeoutError("test did not release first forward")
+                return _FakeSocket(_http_response())
+            finally:
+                with lock:
+                    active -= 1
+
+        third_task = None
+        with (
+            patch.object(forwarder, "MAX_CONCURRENT_AUTH_BASE_FORWARDS", 1),
+            _fake_forwarder_upstream(create_connection=create_connection),
+        ):
+            first_task = asyncio.create_task(
+                forwarder.forward_request("https://example.com", "GET", [], None)
+            )
+            waiting_task = asyncio.create_task(
+                forwarder.forward_request("https://example.com", "GET", [], None)
+            )
+            try:
+                first_started = await asyncio.to_thread(first_entered.wait, 2)
+                assert first_started
+
+                waiting_task.cancel()
+                with pytest.raises(asyncio.CancelledError):
+                    await asyncio.wait_for(waiting_task, timeout=1)
+
+                third_task = asyncio.create_task(
+                    forwarder.forward_request("https://example.com", "GET", [], None)
+                )
+                second_started_before_release = await asyncio.to_thread(
+                    second_entered.wait,
+                    0.2,
+                )
+                assert not second_started_before_release
+
+                release_first.set()
+                second_started_after_release = await asyncio.to_thread(second_entered.wait, 2)
+                assert second_started_after_release
+
+                status, body, headers = await asyncio.wait_for(third_task, timeout=2)
+            finally:
+                release_first.set()
+                await asyncio.gather(first_task, waiting_task, return_exceptions=True)
+                if third_task is not None:
+                    await asyncio.gather(third_task, return_exceptions=True)
+
+        assert status == 200
+        assert body == b"ok"
+        assert list(headers.items(multi=True)) == []
+        assert started == 2
+        assert max_active == 1
+
+    async def test_shutdown_rejects_waiting_forward_without_restarting_executor(self):
+        started = 0
+        lock = threading.Lock()
+        first_entered = threading.Event()
+        second_entered = threading.Event()
+        release_first = threading.Event()
+
+        def create_connection(_address, _timeout, _source_address):
+            nonlocal started
+
+            with lock:
+                started += 1
+                current = started
+                if current == 1:
+                    first_entered.set()
+                elif current == 2:
+                    second_entered.set()
+            if current == 1 and not release_first.wait(timeout=5):
+                raise TimeoutError("test did not release first forward")
+            return _FakeSocket(_http_response())
+
+        with (
+            patch.object(forwarder, "MAX_CONCURRENT_AUTH_BASE_FORWARDS", 1),
+            _fake_forwarder_upstream(create_connection=create_connection),
+        ):
+            first_task = asyncio.create_task(
+                forwarder.forward_request("https://example.com", "GET", [], None)
+            )
+            waiting_task = asyncio.create_task(
+                forwarder.forward_request("https://example.com", "GET", [], None)
+            )
+            try:
+                first_started = await asyncio.to_thread(first_entered.wait, 2)
+                assert first_started
+
+                forwarder.shutdown_forward_request_executor(wait=False)
+                release_first.set()
+
+                status, body, headers = await asyncio.wait_for(first_task, timeout=2)
+                with pytest.raises(RuntimeError, match="executor is shut down"):
+                    await asyncio.wait_for(waiting_task, timeout=2)
+            finally:
+                release_first.set()
+                await asyncio.gather(first_task, waiting_task, return_exceptions=True)
+
+        assert status == 200
+        assert body == b"ok"
+        assert list(headers.items(multi=True)) == []
+        assert not second_entered.is_set()
+        assert started == 1
+
     async def test_offloads_request_work_from_event_loop_thread(self):
         event_loop_thread_id = threading.get_ident()
         forwarding_thread_ids: list[int] = []

--- a/crates/runner/mitm-addon/tests/test_connection_hooks.py
+++ b/crates/runner/mitm-addon/tests/test_connection_hooks.py
@@ -62,12 +62,17 @@ class TestDoneHook:
         with (
             patch.object(usage, "flush_usage_events") as flush_usage_events,
             patch.object(usage.webhook, "usage_executor", mock_executor),
+            patch.object(
+                mitm_addon.auth_base_forwarder,
+                "shutdown_forward_request_executor",
+            ) as shutdown_forward_request_executor,
             patch.object(mitm_addon, "shutdown_log_writer") as shutdown_log_writer,
         ):
             mitm_addon.done()
         flush_usage_events.assert_called_once_with(trigger="shutdown")
         # concurrent.futures boundary: done() must gracefully shut down the pool (#9991).
         mock_executor.shutdown.assert_called_once_with(wait=True)
+        shutdown_forward_request_executor.assert_called_once_with(wait=False)
         shutdown_log_writer.assert_called_once_with()
 
     def test_done_waits_for_runner_flush_before_executor_shutdown(self):
@@ -119,6 +124,11 @@ class TestDoneHook:
             patch.object(mitm_addon, "_usage_flush_signal_lock", lock),
             patch.object(usage, "flush_usage_events", side_effect=flush_usage_events),
             patch.object(usage.webhook, "usage_executor", mock_executor),
+            patch.object(
+                mitm_addon.auth_base_forwarder,
+                "shutdown_forward_request_executor",
+                lambda *, wait: calls.append(f"auth-base:shutdown:{wait}"),
+            ),
             patch.object(mitm_addon, "shutdown_log_writer", lambda: calls.append("jsonl:shutdown")),
         ):
             mitm_addon._handle_runner_usage_flush_signal(0, None)
@@ -133,7 +143,13 @@ class TestDoneHook:
             done_thread.join(timeout=1)
 
         assert not done_thread.is_alive()
-        assert calls == ["flush:runner", "flush:shutdown", "shutdown:True", "jsonl:shutdown"]
+        assert calls == [
+            "flush:runner",
+            "flush:shutdown",
+            "shutdown:True",
+            "auth-base:shutdown:False",
+            "jsonl:shutdown",
+        ]
 
     def test_done_shuts_down_executor_when_flush_fails(self):
         mock_executor = MagicMock()
@@ -145,6 +161,10 @@ class TestDoneHook:
                 side_effect=RuntimeError("flush failed"),
             ) as flush_usage_events,
             patch.object(usage.webhook, "usage_executor", mock_executor),
+            patch.object(
+                mitm_addon.auth_base_forwarder,
+                "shutdown_forward_request_executor",
+            ) as shutdown_forward_request_executor,
             patch.object(mitm_addon, "shutdown_log_writer") as shutdown_log_writer,
             pytest.raises(RuntimeError, match="flush failed"),
         ):
@@ -152,6 +172,7 @@ class TestDoneHook:
 
         flush_usage_events.assert_called_once_with(trigger="shutdown")
         mock_executor.shutdown.assert_called_once_with(wait=True)
+        shutdown_forward_request_executor.assert_called_once_with(wait=False)
         shutdown_log_writer.assert_called_once_with()
 
 


### PR DESCRIPTION
## Summary

- Replace the auth.base forwarding semaphore with a dedicated `ThreadPoolExecutor` capped by `MAX_CONCURRENT_AUTH_BASE_FORWARDS`.
- Preserve `asyncio.to_thread` context propagation by running the synchronous forwarder inside a copied `contextvars.Context`.
- Reset and shut down auth.base forwarding worker state between tests.
- Add a cancellation regression test proving a cancelled awaiter does not let a second worker enter while the first worker is still active.

Closes #16807

## Testing

- `python3 -m pytest tests/test_auth_base_forwarder.py::TestForwardRequestAsyncWrapper::test_cancelled_await_does_not_release_running_forward_slot -q`
  - Failed before the implementation, passed after the fix.
- `python3 -m pytest tests/test_auth_base_forwarder.py -q`
- `ruff check .`
- `ruff format --check .`
- `basedpyright -p .`
- `./scripts/prepare.sh`
- `python3 -m pytest tests/ -q`
