### PR TITLE
fix: comment when github labels start runs

### DIFF
--- a/turbo/apps/api/src/signals/routes/__tests__/webhooks-third-party.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/webhooks-third-party.test.ts
@@ -282,7 +282,8 @@ function mockGitHubAppCredentials(): void {
 function setupGitHubApiMocks(args: {
   readonly installationId: string;
   readonly comments?: readonly GitHubApiComment[];
-}): void {
+}): { readonly capturedComments: readonly CapturedGitHubIssueComment[] } {
+  const capturedComments: CapturedGitHubIssueComment[] = [];
   server.use(
     http.post(
       `https://api.github.com/app/installations/${args.installationId}/access_tokens`,
@@ -301,7 +302,9 @@ function setupGitHubApiMocks(args: {
     ),
     http.post(
       "https://api.github.com/repos/:owner/:repo/issues/:issueNumber/comments",
-      () => {
+      async ({ request }) => {
+        const body = (await request.json()) as { readonly body: string };
+        capturedComments.push({ body: body.body });
         return HttpResponse.json({ id: 9876 });
       },
     ),
@@ -312,6 +315,7 @@ function setupGitHubApiMocks(args: {
       },
     ),
   );
+  return { capturedComments };
 }
 
 function gitHubWebhookHeaders(args: {
@@ -1421,6 +1425,11 @@ describe("POST /api/webhooks/github", () => {
       store.set(seedGitHubWebhookFixture$, undefined, context.signal),
     );
     mockGitHubWebhookEnv();
+    mockGitHubAppCredentials();
+    const { capturedComments } = setupGitHubApiMocks({
+      installationId: fixture.remoteInstallationId,
+      comments: [],
+    });
 
     const response = await postGitHubWebhook({
       event: "issues",
@@ -1441,6 +1450,13 @@ describe("POST /api/webhooks/github", () => {
     const runs = await selectGitHubRuns(fixture);
     expect(runs).toHaveLength(1);
     expect(runs[0]?.prompt).toBe("Handle this labeled GitHub work");
+    expect(capturedComments).toHaveLength(1);
+    expect(capturedComments[0]?.body).toContain(
+      `Zero received the "${GITHUB_APP_SLUG}" label and started working.`,
+    );
+    expect(capturedComments[0]?.body).toContain(
+      `Audit: http://localhost:3002/activities/${runs[0]?.id}`,
+    );
   });
 
   it("starts a new session for label triggers on a GitHub issue with an existing session", async () => {

--- a/turbo/apps/api/src/signals/services/webhooks-github.service.ts
+++ b/turbo/apps/api/src/signals/services/webhooks-github.service.ts
@@ -319,6 +319,20 @@ function formatGithubConnectPrompt(args: {
   return `To use ${args.agentName}, connect your GitHub account first.\n\n[Connect GitHub](${args.connectUrl})`;
 }
 
+function buildGithubRunAuditUrl(runId: string): string {
+  return `${env("APP_URL").replace(/\/$/u, "")}/activities/${encodeURIComponent(runId)}`;
+}
+
+function formatGithubLabelTriggerStartedComment(args: {
+  readonly labelName: string;
+  readonly auditUrl: string;
+}): string {
+  return [
+    `Zero received the "${args.labelName}" label and started working.`,
+    `Audit: ${args.auditUrl}`,
+  ].join("\n\n");
+}
+
 function formatGithubContextSender(args: {
   readonly login: string;
   readonly type: string;
@@ -896,6 +910,30 @@ async function maybeAddCommentReaction(args: {
   });
 }
 
+async function postGithubLabelTriggerStartedComment(args: {
+  readonly token: string | undefined;
+  readonly repo: string;
+  readonly issueNumber: number;
+  readonly labelName: string | undefined;
+  readonly runId: string | undefined;
+  readonly signal: AbortSignal;
+}): Promise<void> {
+  if (!args.token || !args.labelName || !args.runId) {
+    return;
+  }
+
+  await postGithubIssueCommentBestEffort({
+    token: args.token,
+    repo: args.repo,
+    issueNumber: args.issueNumber,
+    body: formatGithubLabelTriggerStartedComment({
+      labelName: args.labelName,
+      auditUrl: buildGithubRunAuditUrl(args.runId),
+    }),
+    signal: args.signal,
+  });
+}
+
 async function loadGitHubRunTarget(args: {
   readonly db: Db;
   readonly composeId: string;
@@ -1031,6 +1069,25 @@ async function updateExistingSessionComment(args: {
         eq(githubIssueSessions.issueNumber, args.issueNumber),
       ),
     );
+}
+
+async function finalizeSuccessfulGithubDispatch(args: {
+  readonly db: Db;
+  readonly installationDbId: string;
+  readonly repo: string;
+  readonly issueNumber: number;
+  readonly existingSessionId: string | undefined;
+  readonly commentId: string | undefined;
+  readonly token: string | undefined;
+  readonly labelName: string | undefined;
+  readonly runId: string | undefined;
+  readonly signal: AbortSignal;
+}): Promise<void> {
+  await postGithubLabelTriggerStartedComment(args);
+  args.signal.throwIfAborted();
+
+  await updateExistingSessionComment(args);
+  args.signal.throwIfAborted();
 }
 
 const runAgentForGitHub$ = command(
@@ -1595,15 +1652,18 @@ const dispatchGithubAgentRun$ = command(
       issueNumber,
     });
 
-    await updateExistingSessionComment({
+    await finalizeSuccessfulGithubDispatch({
       db,
       installationDbId: installation.id,
       repo: params.repo,
       issueNumber,
       existingSessionId,
       commentId: params.commentId,
+      token,
+      labelName: params.matchedLabelName,
+      runId: dispatchResult.runId,
+      signal,
     });
-    signal.throwIfAborted();
   },
 );
 


### PR DESCRIPTION
## Summary

- post a best-effort GitHub issue comment when a configured label dispatch starts a Zero run
- include the audit link to `/activities/:runId` in that acknowledgement
- cover the label dispatch comment in the GitHub webhook integration test

## Verification

- `pnpm format`
- `pnpm lint`
- `pnpm check-types`
- `pnpm -F api exec vitest src/signals/routes/__tests__/webhooks-third-party.test.ts`
- `pnpm knip`
- `pnpm test` failed in this Linux container on `@vm0/desktop src/computer-use-native.test.ts`; `vm0-computer` reports `accessibility_unavailable: Desktop Computer Use is currently implemented for macOS`