### PR TITLE
fix: rebuild streak connector icon

### DIFF
--- a/turbo/apps/platform/src/views/zero-page/components/settings/icons/streak.svg
+++ b/turbo/apps/platform/src/views/zero-page/components/settings/icons/streak.svg
@@ -1,18 +1,309 @@
-<svg width="32" height="32" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
-<rect width="24" height="24" rx="2" fill="url(#g)"/>
-<mask id="m" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="3" y="3" width="21" height="21">
-<rect x="3" y="3" width="21" height="21" fill="white"/>
-</mask>
-<g mask="url(#m)">
-<path fillRule="evenodd" clipRule="evenodd" d="M16 -2L3 11L8 16L3 21L11.5 29.5L16.5 24.5L19.9706 27.9706L32.9706 14.9706L16 -2Z" fill="rgba(193,53,0,0.08)"/>
-</g>
-<rect x="16" y="14" width="5" height="7" fill="#FAFAFA"/>
-<rect x="3" y="14" width="10" height="7" fill="#FAFAFA"/>
-<rect x="3" y="3" width="18" height="8" fill="#FAFAFA"/>
-<defs>
-<radialGradient id="g" cx="0" cy="0" r="1" gradientUnits="userSpaceOnUse" gradientTransform="rotate(45) scale(33.9411)">
-<stop stopColor="#FF9805"/>
-<stop offset="1" stopColor="#F74C55"/>
-</radialGradient>
-</defs>
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24">
+  <g filter="url(#streak-bg-filter)">
+    <rect width="24" height="24" rx="2" fill="url(#streak-bg-gradient)" />
+  </g>
+  <mask
+    id="streak-symbol-mask"
+    mask-type="luminance"
+    maskUnits="userSpaceOnUse"
+    x="3"
+    y="3"
+    width="21"
+    height="21"
+  >
+    <rect x="3" y="3" width="21" height="21" fill="#FFFFFF" />
+  </mask>
+  <g mask="url(#streak-symbol-mask)">
+    <path
+      fill-rule="evenodd"
+      clip-rule="evenodd"
+      d="M16-2 3 11l5 5-5 5 8.5 8.5 5-5 3.4706 3.4706 13-13z"
+      fill="url(#streak-shadow-gradient)"
+    />
+  </g>
+  <g filter="url(#streak-bar-right-filter)">
+    <rect x="16" y="14" width="5" height="7" fill="#FAFAFA" />
+  </g>
+  <g filter="url(#streak-bar-left-filter)">
+    <rect x="3" y="14" width="10" height="7" fill="#FAFAFA" />
+  </g>
+  <g filter="url(#streak-bar-top-filter)">
+    <rect x="3" y="3" width="18" height="8" fill="#FAFAFA" />
+  </g>
+  <rect width="24" height="24" rx="2" fill="url(#streak-overlay-gradient)" />
+  <defs>
+    <filter
+      id="streak-bg-filter"
+      x="0"
+      y="0"
+      width="24"
+      height="24"
+      filterUnits="userSpaceOnUse"
+      color-interpolation-filters="sRGB"
+    >
+      <feFlood flood-opacity="0" result="BackgroundImageFix" />
+      <feBlend
+        mode="normal"
+        in="SourceGraphic"
+        in2="BackgroundImageFix"
+        result="shape"
+      />
+      <feColorMatrix
+        in="SourceAlpha"
+        type="matrix"
+        values="0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 127 0"
+        result="hardAlpha"
+      />
+      <feOffset dy="-0.25" />
+      <feComposite in2="hardAlpha" operator="arithmetic" k2="-1" k3="1" />
+      <feColorMatrix
+        type="matrix"
+        values="0 0 0 0 0.756863 0 0 0 0 0.207843 0 0 0 0 0 0 0 0 0.2 0"
+      />
+      <feBlend mode="normal" in2="shape" result="effect1_innerShadow" />
+      <feColorMatrix
+        in="SourceAlpha"
+        type="matrix"
+        values="0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 127 0"
+        result="hardAlpha"
+      />
+      <feOffset dy="0.25" />
+      <feComposite in2="hardAlpha" operator="arithmetic" k2="-1" k3="1" />
+      <feColorMatrix
+        type="matrix"
+        values="0 0 0 0 1 0 0 0 0 1 0 0 0 0 1 0 0 0 0.2 0"
+      />
+      <feBlend
+        mode="normal"
+        in2="effect1_innerShadow"
+        result="effect2_innerShadow"
+      />
+    </filter>
+    <filter
+      id="streak-bar-right-filter"
+      x="15"
+      y="14"
+      width="7"
+      height="9"
+      filterUnits="userSpaceOnUse"
+      color-interpolation-filters="sRGB"
+    >
+      <feFlood flood-opacity="0" result="BackgroundImageFix" />
+      <feColorMatrix
+        in="SourceAlpha"
+        type="matrix"
+        values="0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 127 0"
+        result="hardAlpha"
+      />
+      <feOffset dy="1" />
+      <feGaussianBlur stdDeviation="0.5" />
+      <feColorMatrix
+        type="matrix"
+        values="0 0 0 0 0.756863 0 0 0 0 0.207843 0 0 0 0 0 0 0 0 0.2 0"
+      />
+      <feBlend
+        mode="normal"
+        in2="BackgroundImageFix"
+        result="effect1_dropShadow"
+      />
+      <feBlend
+        mode="normal"
+        in="SourceGraphic"
+        in2="effect1_dropShadow"
+        result="shape"
+      />
+      <feColorMatrix
+        in="SourceAlpha"
+        type="matrix"
+        values="0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 127 0"
+        result="hardAlpha"
+      />
+      <feOffset dy="0.25" />
+      <feComposite in2="hardAlpha" operator="arithmetic" k2="-1" k3="1" />
+      <feColorMatrix
+        type="matrix"
+        values="0 0 0 0 1 0 0 0 0 1 0 0 0 0 1 0 0 0 0.4 0"
+      />
+      <feBlend mode="normal" in2="shape" result="effect2_innerShadow" />
+      <feColorMatrix
+        in="SourceAlpha"
+        type="matrix"
+        values="0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 127 0"
+        result="hardAlpha"
+      />
+      <feOffset dy="-0.25" />
+      <feComposite in2="hardAlpha" operator="arithmetic" k2="-1" k3="1" />
+      <feColorMatrix
+        type="matrix"
+        values="0 0 0 0 0.129412 0 0 0 0 0.129412 0 0 0 0 0.129412 0 0 0 0.1 0"
+      />
+      <feBlend
+        mode="normal"
+        in2="effect2_innerShadow"
+        result="effect3_innerShadow"
+      />
+    </filter>
+    <filter
+      id="streak-bar-left-filter"
+      x="2"
+      y="14"
+      width="12"
+      height="9"
+      filterUnits="userSpaceOnUse"
+      color-interpolation-filters="sRGB"
+    >
+      <feFlood flood-opacity="0" result="BackgroundImageFix" />
+      <feColorMatrix
+        in="SourceAlpha"
+        type="matrix"
+        values="0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 127 0"
+        result="hardAlpha"
+      />
+      <feOffset dy="1" />
+      <feGaussianBlur stdDeviation="0.5" />
+      <feColorMatrix
+        type="matrix"
+        values="0 0 0 0 0.756863 0 0 0 0 0.207843 0 0 0 0 0 0 0 0 0.2 0"
+      />
+      <feBlend
+        mode="normal"
+        in2="BackgroundImageFix"
+        result="effect1_dropShadow"
+      />
+      <feBlend
+        mode="normal"
+        in="SourceGraphic"
+        in2="effect1_dropShadow"
+        result="shape"
+      />
+      <feColorMatrix
+        in="SourceAlpha"
+        type="matrix"
+        values="0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 127 0"
+        result="hardAlpha"
+      />
+      <feOffset dy="0.25" />
+      <feComposite in2="hardAlpha" operator="arithmetic" k2="-1" k3="1" />
+      <feColorMatrix
+        type="matrix"
+        values="0 0 0 0 1 0 0 0 0 1 0 0 0 0 1 0 0 0 0.4 0"
+      />
+      <feBlend mode="normal" in2="shape" result="effect2_innerShadow" />
+      <feColorMatrix
+        in="SourceAlpha"
+        type="matrix"
+        values="0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 127 0"
+        result="hardAlpha"
+      />
+      <feOffset dy="-0.25" />
+      <feComposite in2="hardAlpha" operator="arithmetic" k2="-1" k3="1" />
+      <feColorMatrix
+        type="matrix"
+        values="0 0 0 0 0.129412 0 0 0 0 0.129412 0 0 0 0 0.129412 0 0 0 0.1 0"
+      />
+      <feBlend
+        mode="normal"
+        in2="effect2_innerShadow"
+        result="effect3_innerShadow"
+      />
+    </filter>
+    <filter
+      id="streak-bar-top-filter"
+      x="2"
+      y="3"
+      width="20"
+      height="10"
+      filterUnits="userSpaceOnUse"
+      color-interpolation-filters="sRGB"
+    >
+      <feFlood flood-opacity="0" result="BackgroundImageFix" />
+      <feColorMatrix
+        in="SourceAlpha"
+        type="matrix"
+        values="0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 127 0"
+        result="hardAlpha"
+      />
+      <feOffset dy="1" />
+      <feGaussianBlur stdDeviation="0.5" />
+      <feColorMatrix
+        type="matrix"
+        values="0 0 0 0 0.756863 0 0 0 0 0.207843 0 0 0 0 0 0 0 0 0.2 0"
+      />
+      <feBlend
+        mode="normal"
+        in2="BackgroundImageFix"
+        result="effect1_dropShadow"
+      />
+      <feBlend
+        mode="normal"
+        in="SourceGraphic"
+        in2="effect1_dropShadow"
+        result="shape"
+      />
+      <feColorMatrix
+        in="SourceAlpha"
+        type="matrix"
+        values="0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 127 0"
+        result="hardAlpha"
+      />
+      <feOffset dy="0.25" />
+      <feComposite in2="hardAlpha" operator="arithmetic" k2="-1" k3="1" />
+      <feColorMatrix
+        type="matrix"
+        values="0 0 0 0 1 0 0 0 0 1 0 0 0 0 1 0 0 0 0.4 0"
+      />
+      <feBlend mode="normal" in2="shape" result="effect2_innerShadow" />
+      <feColorMatrix
+        in="SourceAlpha"
+        type="matrix"
+        values="0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 127 0"
+        result="hardAlpha"
+      />
+      <feOffset dy="-0.25" />
+      <feComposite in2="hardAlpha" operator="arithmetic" k2="-1" k3="1" />
+      <feColorMatrix
+        type="matrix"
+        values="0 0 0 0 0.129412 0 0 0 0 0.129412 0 0 0 0 0.129412 0 0 0 0.1 0"
+      />
+      <feBlend
+        mode="normal"
+        in2="effect2_innerShadow"
+        result="effect3_innerShadow"
+      />
+    </filter>
+    <radialGradient
+      id="streak-bg-gradient"
+      cx="0"
+      cy="0"
+      r="1"
+      gradientUnits="userSpaceOnUse"
+      gradientTransform="rotate(45) scale(33.9411)"
+    >
+      <stop stop-color="#FF9805" />
+      <stop offset="1" stop-color="#F74C55" />
+    </radialGradient>
+    <radialGradient
+      id="streak-shadow-gradient"
+      cx="0"
+      cy="0"
+      r="1"
+      gradientUnits="userSpaceOnUse"
+      gradientTransform="translate(10.8641 6.61222) rotate(35.5671) scale(35.3934 36.0071)"
+    >
+      <stop stop-color="#C13500" stop-opacity="0.2" />
+      <stop offset="0.617846" stop-color="#C13500" stop-opacity="0.02" />
+      <stop offset="1" stop-color="#C13500" stop-opacity="0.01" />
+    </radialGradient>
+    <radialGradient
+      id="streak-overlay-gradient"
+      cx="0"
+      cy="0"
+      r="1"
+      gradientUnits="userSpaceOnUse"
+      gradientTransform="translate(17.0462 17.0462) rotate(-135) scale(24.107)"
+    >
+      <stop stop-color="#FFFFFF" stop-opacity="0.01" />
+      <stop offset="1" stop-color="#FFFFFF" stop-opacity="0.1" />
+    </radialGradient>
+  </defs>
 </svg>


### PR DESCRIPTION
## Summary
- rebuild the Streak connector icon from the square symbol portion of the official Streak logo SVG
- preserve the official background filter, shadow overlay, bar filters, and highlight gradient
- normalize raw SVG attributes and colors, including `fill-rule`, `clip-rule`, `mask-type`, and `#FFFFFF`

## Source
- https://cdn.prod.website-files.com/6744e71b115ff83278f43fd3/6844e1be16a4f64c8ef68273_logo_streak-dark.svg

Fixes #16877

## Tests
- `pnpm exec prettier --parser html --check apps/platform/src/views/zero-page/components/settings/icons/streak.svg`
- SVG XML/structure validation
- `git diff --check`