### PR TITLE
feat(app): require supported browser versions

### DIFF
--- a/turbo/apps/platform/index.html
+++ b/turbo/apps/platform/index.html
@@ -3,6 +3,154 @@
   <head>
     <title>Zero</title>
     <meta charset="UTF-8" />
+    <style>
+      .browser-upgrade {
+        display: none;
+      }
+
+      [data-browser-supported="false"] body {
+        margin: 0;
+      }
+
+      [data-browser-supported="false"] #root {
+        display: none;
+      }
+
+      [data-browser-supported="false"] .browser-upgrade {
+        background: #fafbfc;
+        color: #14171d;
+        display: table;
+        font-family:
+          system-ui,
+          -apple-system,
+          BlinkMacSystemFont,
+          "Segoe UI",
+          sans-serif;
+        min-height: 100vh;
+        width: 100%;
+      }
+
+      .browser-upgrade__center {
+        display: table-cell;
+        padding: 32px 20px;
+        vertical-align: middle;
+      }
+
+      .browser-upgrade__panel {
+        background: #ffffff;
+        border: 1px solid #dce1e8;
+        border-radius: 8px;
+        box-shadow: 0 24px 80px rgba(20, 23, 29, 0.12);
+        margin: 0 auto;
+        max-width: 520px;
+        padding: 32px;
+      }
+
+      .browser-upgrade__brand {
+        color: #ed4e01;
+        font-size: 13px;
+        font-weight: 700;
+        line-height: 20px;
+        margin: 0 0 18px;
+        text-transform: uppercase;
+      }
+
+      .browser-upgrade h1 {
+        font-size: 28px;
+        line-height: 36px;
+        margin: 0;
+      }
+
+      .browser-upgrade p {
+        color: #525b68;
+        font-size: 16px;
+        line-height: 24px;
+        margin: 16px 0 0;
+      }
+
+      .browser-upgrade__actions {
+        margin-top: 28px;
+      }
+
+      .browser-upgrade a {
+        background: #ed4e01;
+        border: 1px solid #ed4e01;
+        border-radius: 8px;
+        color: #ffffff;
+        display: inline-block;
+        font-size: 14px;
+        font-weight: 600;
+        line-height: 20px;
+        margin: 0 12px 12px 0;
+        min-height: 20px;
+        padding: 10px 16px;
+        text-align: center;
+        text-decoration: none;
+      }
+
+      .browser-upgrade a.secondary {
+        background: #ffffff;
+        border-color: #c5ccd7;
+        color: #14171d;
+      }
+
+      @media (max-width: 520px) {
+        .browser-upgrade__panel {
+          padding: 24px;
+        }
+
+        .browser-upgrade h1 {
+          font-size: 24px;
+          line-height: 32px;
+        }
+
+        .browser-upgrade a {
+          display: block;
+          margin-right: 0;
+        }
+      }
+    </style>
+    <script>
+      (function () {
+        var ua = navigator.userAgent || "";
+        var supported = true;
+        var iosPattern = /\b(?:iPhone|iPad|iPod)\b.*\bOS (\d+)(?:_(\d+))?/;
+        var iosMatch = iosPattern.exec(ua);
+        var chromeMatch = /\b(?:Chrome|CriOS)\/(\d+)/.exec(ua);
+
+        if (iosMatch) {
+          var iosMajor = parseInt(iosMatch[1], 10);
+          var iosMinor = iosMatch[2] ? parseInt(iosMatch[2], 10) : 0;
+          if (!isNaN(iosMajor) && !isNaN(iosMinor)) {
+            supported = iosMajor > 16 || (iosMajor === 16 && iosMinor >= 4);
+          }
+        } else if (chromeMatch && !/\b(?:Edg|OPR|SamsungBrowser)\//.test(ua)) {
+          var chromeMajor = parseInt(chromeMatch[1], 10);
+          if (!isNaN(chromeMajor)) {
+            supported = chromeMajor >= 111;
+          }
+        } else {
+          var safariMatch = /\bVersion\/(\d+)(?:\.(\d+))?.*\bSafari\//.exec(ua);
+          if (
+            safariMatch &&
+            !/\b(?:Chrome|CriOS|Chromium|Edg|OPR|FxiOS)\//.test(ua)
+          ) {
+            var safariMajor = parseInt(safariMatch[1], 10);
+            var safariMinor = safariMatch[2] ? parseInt(safariMatch[2], 10) : 0;
+            if (!isNaN(safariMajor) && !isNaN(safariMinor)) {
+              supported =
+                safariMajor > 16 || (safariMajor === 16 && safariMinor >= 4);
+            }
+          }
+        }
+
+        window.__vm0BrowserSupported = supported;
+        if (!supported) {
+          var html = document.documentElement;
+          html.setAttribute("data-browser-supported", "false");
+        }
+      })();
+    </script>
     <script>
       (function () {
         if ("%VITE_VERCEL_ENV%" !== "production") return;
@@ -127,7 +275,11 @@
         if (t === "dark") document.documentElement.classList.add("dark");
       })();
     </script>
-    <script type="module" src="/src/main.ts" defer></script>
+    <script type="module">
+      if (window.__vm0BrowserSupported !== false) {
+        import("/src/main.ts");
+      }
+    </script>
     <script>
       function __initPlausible() {
         var url = "%VITE_PLAUSIBLE_SCRIPT_URL%";
@@ -165,6 +317,24 @@
     </script>
   </head>
   <body>
+    <div class="browser-upgrade" role="status" aria-live="polite">
+      <div class="browser-upgrade__center">
+        <div class="browser-upgrade__panel">
+          <p class="browser-upgrade__brand">Zero</p>
+          <h1>Update your browser to continue</h1>
+          <p>
+            Zero supports Chrome 111+, Safari 16.4+, and iOS 16.4+. Please
+            upgrade your browser, then reload this page.
+          </p>
+          <div class="browser-upgrade__actions">
+            <a href="https://www.google.com/chrome/">Update Chrome</a>
+            <a class="secondary" href="https://support.apple.com/safari">
+              Update Safari
+            </a>
+          </div>
+        </div>
+      </div>
+    </div>
     <div id="root">
       <style>
         body {

--- a/turbo/apps/platform/index.html
+++ b/turbo/apps/platform/index.html
@@ -4,109 +4,148 @@
     <title>Zero</title>
     <meta charset="UTF-8" />
     <style>
-      .browser-upgrade {
-        display: none;
-      }
-
-      [data-browser-supported="false"] body {
+      body {
         margin: 0;
       }
 
-      [data-browser-supported="false"] #root {
+      #root {
         display: none;
       }
 
-      [data-browser-supported="false"] .browser-upgrade {
-        background: #fafbfc;
+      .browser-upgrade {
+        background: #ffffff;
+        box-sizing: border-box;
         color: #14171d;
-        display: table;
+        display: flex;
         font-family:
+          "Noto Sans",
           system-ui,
           -apple-system,
           BlinkMacSystemFont,
           "Segoe UI",
           sans-serif;
+        align-items: center;
+        justify-content: center;
         min-height: 100vh;
+        overflow: hidden;
+        padding: 24px;
+        position: relative;
         width: 100%;
       }
 
+      .browser-upgrade * {
+        box-sizing: border-box;
+      }
+
+      .browser-upgrade::before {
+        background-image: radial-gradient(
+          ellipse 120% 80% at 50% -20%,
+          rgba(248, 249, 251, 0.9),
+          transparent 50%
+        );
+        background-size: 100% 100%;
+        content: "";
+        inset: 0;
+        position: absolute;
+        z-index: 0;
+      }
+
+      [data-browser-supported="true"] #root {
+        display: block;
+      }
+
+      [data-browser-supported="true"] .browser-upgrade {
+        display: none;
+      }
+
       .browser-upgrade__center {
-        display: table-cell;
-        padding: 32px 20px;
-        vertical-align: middle;
+        position: relative;
+        width: 100%;
+        z-index: 1;
       }
 
       .browser-upgrade__panel {
         background: #ffffff;
-        border: 1px solid #dce1e8;
-        border-radius: 8px;
-        box-shadow: 0 24px 80px rgba(20, 23, 29, 0.12);
+        border: 0.7px solid #dce1e8;
+        border-radius: 16px;
+        box-shadow:
+          0 2px 12px rgba(113, 120, 133, 0.04),
+          0 0 0 0.5px rgba(113, 120, 133, 0.02);
+        display: flex;
+        flex-direction: column;
+        gap: 24px;
+        align-items: center;
         margin: 0 auto;
-        max-width: 520px;
+        max-width: 384px;
         padding: 32px;
+        text-align: center;
       }
 
-      .browser-upgrade__brand {
-        color: #ed4e01;
-        font-size: 13px;
-        font-weight: 700;
-        line-height: 20px;
-        margin: 0 0 18px;
-        text-transform: uppercase;
+      .browser-upgrade__icon {
+        align-items: center;
+        display: flex;
+        height: 40px;
+        justify-content: center;
+        width: 40px;
+      }
+
+      .browser-upgrade__icon img {
+        display: block;
+        height: 40px;
+        width: 40px;
+      }
+
+      .browser-upgrade__copy {
+        display: flex;
+        flex-direction: column;
+        gap: 6px;
       }
 
       .browser-upgrade h1 {
-        font-size: 28px;
-        line-height: 36px;
+        color: #14171d;
+        font-size: 16px;
+        font-weight: 600;
+        letter-spacing: 0;
+        line-height: 24px;
         margin: 0;
       }
 
       .browser-upgrade p {
-        color: #525b68;
-        font-size: 16px;
-        line-height: 24px;
-        margin: 16px 0 0;
+        color: #5d6572;
+        font-size: 14px;
+        line-height: 22px;
+        margin: 0;
       }
 
       .browser-upgrade__actions {
-        margin-top: 28px;
+        width: 100%;
       }
 
       .browser-upgrade a {
         background: #ed4e01;
         border: 1px solid #ed4e01;
         border-radius: 8px;
+        box-sizing: border-box;
         color: #ffffff;
         display: inline-block;
         font-size: 14px;
         font-weight: 600;
         line-height: 20px;
-        margin: 0 12px 12px 0;
-        min-height: 20px;
-        padding: 10px 16px;
+        min-height: 40px;
+        padding: 9px 14px;
         text-align: center;
         text-decoration: none;
+        width: 100%;
       }
 
-      .browser-upgrade a.secondary {
-        background: #ffffff;
-        border-color: #c5ccd7;
-        color: #14171d;
+      .browser-upgrade a:hover {
+        background: #d94600;
+        border-color: #d94600;
       }
 
       @media (max-width: 520px) {
         .browser-upgrade__panel {
-          padding: 24px;
-        }
-
-        .browser-upgrade h1 {
-          font-size: 24px;
-          line-height: 32px;
-        }
-
-        .browser-upgrade a {
-          display: block;
-          margin-right: 0;
+          padding: 24px 20px;
         }
       }
     </style>
@@ -114,17 +153,38 @@
       (function () {
         var ua = navigator.userAgent || "";
         var supported = true;
+        var upgradeTarget = {
+          actionLabel: "Update browser",
+          actionUrl: "https://www.google.com/chrome/",
+          description:
+            "Zero does not support your current browser version. Update your browser to continue.",
+          title: "Update your browser to continue",
+        };
         var iosPattern = /\b(?:iPhone|iPad|iPod)\b.*\bOS (\d+)(?:_(\d+))?/;
         var iosMatch = iosPattern.exec(ua);
-        var chromeMatch = /\b(?:Chrome|CriOS)\/(\d+)/.exec(ua);
+        var chromeMatch = /\b(?:Chrome|CriOS|HeadlessChrome)\/(\d+)/.exec(ua);
 
         if (iosMatch) {
+          upgradeTarget = {
+            actionLabel: "Update iOS",
+            actionUrl: "https://support.apple.com/HT204204",
+            description:
+              "Zero does not support your current browser version. Update iOS to continue.",
+            title: "Update iOS to continue",
+          };
           var iosMajor = parseInt(iosMatch[1], 10);
           var iosMinor = iosMatch[2] ? parseInt(iosMatch[2], 10) : 0;
           if (!isNaN(iosMajor) && !isNaN(iosMinor)) {
             supported = iosMajor > 16 || (iosMajor === 16 && iosMinor >= 4);
           }
         } else if (chromeMatch && !/\b(?:Edg|OPR|SamsungBrowser)\//.test(ua)) {
+          upgradeTarget = {
+            actionLabel: "Update Chrome",
+            actionUrl: "https://www.google.com/chrome/",
+            description:
+              "Zero does not support your current browser version. Update Chrome to continue.",
+            title: "Update Chrome to continue",
+          };
           var chromeMajor = parseInt(chromeMatch[1], 10);
           if (!isNaN(chromeMajor)) {
             supported = chromeMajor >= 111;
@@ -135,6 +195,13 @@
             safariMatch &&
             !/\b(?:Chrome|CriOS|Chromium|Edg|OPR|FxiOS)\//.test(ua)
           ) {
+            upgradeTarget = {
+              actionLabel: "Update Safari",
+              actionUrl: "https://support.apple.com/safari",
+              description:
+                "Zero does not support your current browser version. Update Safari to continue.",
+              title: "Update Safari to continue",
+            };
             var safariMajor = parseInt(safariMatch[1], 10);
             var safariMinor = safariMatch[2] ? parseInt(safariMatch[2], 10) : 0;
             if (!isNaN(safariMajor) && !isNaN(safariMinor)) {
@@ -144,11 +211,12 @@
           }
         }
 
+        window.__vm0BrowserUpgrade = upgradeTarget;
         window.__vm0BrowserSupported = supported;
-        if (!supported) {
-          var html = document.documentElement;
-          html.setAttribute("data-browser-supported", "false");
-        }
+        document.documentElement.setAttribute(
+          "data-browser-supported",
+          supported ? "true" : "false",
+        );
       })();
     </script>
     <script>
@@ -276,7 +344,7 @@
       })();
     </script>
     <script type="module">
-      if (window.__vm0BrowserSupported !== false) {
+      if (window.__vm0BrowserSupported === true) {
         import("/src/main.ts");
       }
     </script>
@@ -320,21 +388,46 @@
     <div class="browser-upgrade" role="status" aria-live="polite">
       <div class="browser-upgrade__center">
         <div class="browser-upgrade__panel">
-          <p class="browser-upgrade__brand">Zero</p>
-          <h1>Update your browser to continue</h1>
-          <p>
-            Zero supports Chrome 111+, Safari 16.4+, and iOS 16.4+. Please
-            upgrade your browser, then reload this page.
-          </p>
+          <div class="browser-upgrade__icon" aria-hidden="true">
+            <img src="/icon.svg" alt="" />
+          </div>
+          <div class="browser-upgrade__copy">
+            <h1 id="browser-upgrade-title">Update your browser to continue</h1>
+            <p id="browser-upgrade-description">
+              Zero does not support your current browser version. Update your
+              browser to continue.
+            </p>
+          </div>
           <div class="browser-upgrade__actions">
-            <a href="https://www.google.com/chrome/">Update Chrome</a>
-            <a class="secondary" href="https://support.apple.com/safari">
-              Update Safari
+            <a
+              id="browser-upgrade-action"
+              href="https://www.google.com/chrome/"
+            >
+              Update browser
             </a>
           </div>
         </div>
       </div>
     </div>
+    <script>
+      (function () {
+        var target = window.__vm0BrowserUpgrade;
+        if (!target) return;
+
+        var title = document.getElementById("browser-upgrade-title");
+        var description = document.getElementById(
+          "browser-upgrade-description",
+        );
+        var action = document.getElementById("browser-upgrade-action");
+
+        if (title) title.textContent = target.title;
+        if (description) description.textContent = target.description;
+        if (action) {
+          action.textContent = target.actionLabel;
+          action.href = target.actionUrl;
+        }
+      })();
+    </script>
     <div id="root">
       <style>
         body {

--- a/turbo/apps/platform/src/__tests__/index-html.test.ts
+++ b/turbo/apps/platform/src/__tests__/index-html.test.ts
@@ -1,6 +1,13 @@
 import { describe, expect, it } from "vitest";
 import indexHtml from "../../index.html?raw";
 
+type BrowserUpgradeTarget = {
+  actionLabel: string;
+  actionUrl: string;
+  description: string;
+  title: string;
+};
+
 const browserSupportScript = Array.from(
   indexHtml.matchAll(/<script>([\s\S]*?)<\/script>/g),
 )
@@ -13,9 +20,18 @@ if (!browserSupportScript) {
 
 const getBrowserSupportResult = (
   userAgent: string,
-): { blocked: boolean; supported: boolean | undefined } => {
+): {
+  browserSupportedAttribute: string | undefined;
+  blocked: boolean;
+  supported: boolean | undefined;
+  upgradeTarget: BrowserUpgradeTarget | undefined;
+} => {
+  let browserSupportedAttribute: string | undefined;
   let blocked = false;
-  const windowState: { __vm0BrowserSupported?: boolean } = {};
+  const windowState: {
+    __vm0BrowserUpgrade?: BrowserUpgradeTarget;
+    __vm0BrowserSupported?: boolean;
+  } = {};
   const runBrowserSupportScript = new Function(
     "document",
     "navigator",
@@ -27,7 +43,12 @@ const getBrowserSupportResult = (
     {
       documentElement: {
         setAttribute(name: string, value: string) {
-          blocked = name === "data-browser-supported" && value === "false";
+          if (name !== "data-browser-supported") {
+            return;
+          }
+
+          browserSupportedAttribute = value;
+          blocked = value === "false";
         },
       },
     },
@@ -35,7 +56,12 @@ const getBrowserSupportResult = (
     windowState,
   );
 
-  return { blocked, supported: windowState.__vm0BrowserSupported };
+  return {
+    browserSupportedAttribute,
+    blocked,
+    supported: windowState.__vm0BrowserSupported,
+    upgradeTarget: windowState.__vm0BrowserUpgrade,
+  };
 };
 
 // The platform app is an English-only admin UI. Browser auto-translation
@@ -77,16 +103,18 @@ describe("platform index.html browser support gate", () => {
     expect(indexHtml).not.toMatch(
       /<script[^>]*\btype="module"[^>]*\bsrc="\/src\/main\.ts"/,
     );
-    expect(indexHtml).toContain("window.__vm0BrowserSupported !== false");
+    expect(indexHtml).toContain("window.__vm0BrowserSupported === true");
     expect(indexHtml).toContain('import("/src/main.ts")');
   });
 
   it("shows an upgrade page for browsers below the app CSS target", () => {
     expect(indexHtml).toContain("data-browser-supported");
+    expect(indexHtml).toContain('[data-browser-supported="true"] #root');
     expect(indexHtml).toContain("Update your browser to continue");
-    expect(indexHtml).toContain("Chrome 111+");
-    expect(indexHtml).toContain("Safari 16.4+");
-    expect(indexHtml).toContain("iOS 16.4+");
+    expect(indexHtml).toContain(
+      "Zero does not support your current browser version",
+    );
+    expect(indexHtml.match(/<a\b/g)).toHaveLength(1);
   });
 
   it.each([
@@ -126,9 +154,43 @@ describe("platform index.html browser support gate", () => {
       true,
     ],
   ])("classifies %s support from the user agent", (_, userAgent, expected) => {
-    expect(getBrowserSupportResult(userAgent)).toStrictEqual({
+    expect(getBrowserSupportResult(userAgent)).toMatchObject({
+      browserSupportedAttribute: String(expected),
       blocked: !expected,
       supported: expected,
     });
   });
+
+  it.each([
+    [
+      "Chrome",
+      "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/110.0.0.0 Safari/537.36",
+      "Update Chrome",
+    ],
+    [
+      "HeadlessChrome",
+      "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) HeadlessChrome/147.0.0.0 Safari/537.36",
+      "Update Chrome",
+    ],
+    [
+      "Safari",
+      "Mozilla/5.0 (Macintosh; Intel Mac OS X 13_2) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/16.3 Safari/605.1.15",
+      "Update Safari",
+    ],
+    [
+      "iOS",
+      "Mozilla/5.0 (iPhone; CPU iPhone OS 16_3 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) CriOS/112.0.0.0 Mobile/15E148 Safari/604.1",
+      "Update iOS",
+    ],
+  ])(
+    "sets a single %s-specific upgrade action",
+    (_, userAgent, actionLabel) => {
+      expect(getBrowserSupportResult(userAgent).upgradeTarget).toMatchObject({
+        actionLabel,
+        description: expect.stringContaining(
+          "Zero does not support your current browser version",
+        ),
+      });
+    },
+  );
 });

--- a/turbo/apps/platform/src/__tests__/index-html.test.ts
+++ b/turbo/apps/platform/src/__tests__/index-html.test.ts
@@ -1,6 +1,43 @@
 import { describe, expect, it } from "vitest";
 import indexHtml from "../../index.html?raw";
 
+const browserSupportScript = Array.from(
+  indexHtml.matchAll(/<script>([\s\S]*?)<\/script>/g),
+)
+  .map((scriptMatch) => scriptMatch[1])
+  .find((scriptContent) => scriptContent.includes("__vm0BrowserSupported"));
+
+if (!browserSupportScript) {
+  throw new Error("Browser support gate script is missing from index.html");
+}
+
+const getBrowserSupportResult = (
+  userAgent: string,
+): { blocked: boolean; supported: boolean | undefined } => {
+  let blocked = false;
+  const windowState: { __vm0BrowserSupported?: boolean } = {};
+  const runBrowserSupportScript = new Function(
+    "document",
+    "navigator",
+    "window",
+    browserSupportScript,
+  );
+
+  runBrowserSupportScript(
+    {
+      documentElement: {
+        setAttribute(name: string, value: string) {
+          blocked = name === "data-browser-supported" && value === "false";
+        },
+      },
+    },
+    { userAgent },
+    windowState,
+  );
+
+  return { blocked, supported: windowState.__vm0BrowserSupported };
+};
+
 // The platform app is an English-only admin UI. Browser auto-translation
 // (notably Chrome Mobile on zh-TW locales) wraps text nodes in <font>
 // elements, desyncing React 19's fiber tree from the real DOM and producing
@@ -32,5 +69,66 @@ describe("platform index.html marketing scripts", () => {
     expect(indexHtml).not.toMatch(
       /<noscript[\s\S]*px\.ads\.linkedin\.com\/collect/,
     );
+  });
+});
+
+describe("platform index.html browser support gate", () => {
+  it("loads the app entry only after the browser support check passes", () => {
+    expect(indexHtml).not.toMatch(
+      /<script[^>]*\btype="module"[^>]*\bsrc="\/src\/main\.ts"/,
+    );
+    expect(indexHtml).toContain("window.__vm0BrowserSupported !== false");
+    expect(indexHtml).toContain('import("/src/main.ts")');
+  });
+
+  it("shows an upgrade page for browsers below the app CSS target", () => {
+    expect(indexHtml).toContain("data-browser-supported");
+    expect(indexHtml).toContain("Update your browser to continue");
+    expect(indexHtml).toContain("Chrome 111+");
+    expect(indexHtml).toContain("Safari 16.4+");
+    expect(indexHtml).toContain("iOS 16.4+");
+  });
+
+  it.each([
+    [
+      "Chrome 110",
+      "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/110.0.0.0 Safari/537.36",
+      false,
+    ],
+    [
+      "Chrome 111",
+      "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/111.0.0.0 Safari/537.36",
+      true,
+    ],
+    [
+      "Safari 16.3",
+      "Mozilla/5.0 (Macintosh; Intel Mac OS X 13_2) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/16.3 Safari/605.1.15",
+      false,
+    ],
+    [
+      "Safari 16.4",
+      "Mozilla/5.0 (Macintosh; Intel Mac OS X 13_3) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/16.4 Safari/605.1.15",
+      true,
+    ],
+    [
+      "Chrome on iOS 16.3",
+      "Mozilla/5.0 (iPhone; CPU iPhone OS 16_3 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) CriOS/112.0.0.0 Mobile/15E148 Safari/604.1",
+      false,
+    ],
+    [
+      "Chrome on iOS 16.4",
+      "Mozilla/5.0 (iPhone; CPU iPhone OS 16_4 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) CriOS/112.0.0.0 Mobile/15E148 Safari/604.1",
+      true,
+    ],
+    [
+      "unknown browser",
+      "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 CustomBrowser/1.0",
+      true,
+    ],
+  ])("classifies %s support from the user agent", (_, userAgent, expected) => {
+    expect(getBrowserSupportResult(userAgent)).toStrictEqual({
+      blocked: !expected,
+      supported: expected,
+    });
   });
 });

--- a/turbo/apps/platform/src/__tests__/index-html.test.ts
+++ b/turbo/apps/platform/src/__tests__/index-html.test.ts
@@ -9,7 +9,7 @@ type BrowserUpgradeTarget = {
 };
 
 const browserSupportScript = Array.from(
-  indexHtml.matchAll(/<script>([\s\S]*?)<\/script>/g),
+  indexHtml.matchAll(/<script\b[^>]*>([\s\S]*?)<\/script>/giu),
 )
   .map((scriptMatch) => scriptMatch[1])
   .find((scriptContent) => scriptContent.includes("__vm0BrowserSupported"));

--- a/turbo/apps/platform/src/__tests__/index-html.test.ts
+++ b/turbo/apps/platform/src/__tests__/index-html.test.ts
@@ -8,10 +8,11 @@ type BrowserUpgradeTarget = {
   title: string;
 };
 
+const indexDocument = new DOMParser().parseFromString(indexHtml, "text/html");
 const browserSupportScript = Array.from(
-  indexHtml.matchAll(/<script\b[^>]*>([\s\S]*?)<\/script>/giu),
+  indexDocument.querySelectorAll("script"),
 )
-  .map((scriptMatch) => scriptMatch[1])
+  .map((script) => script.textContent ?? "")
   .find((scriptContent) => scriptContent.includes("__vm0BrowserSupported"));
 
 if (!browserSupportScript) {


### PR DESCRIPTION
## Summary
- Add an early browser support gate to the platform app HTML before Vite bootstraps the React app.
- Require Chrome 111+, Safari 16.4+, and iOS 16.4+; unsupported browsers see a conservative upgrade page and `/src/main.ts` is not loaded.
- Add index.html tests that execute the inline UA gate for Chrome, Safari, iOS, and unknown browser cases.

## Validation
- `pnpm format`
- `pnpm turbo run lint`
- `pnpm check-types`
- `pnpm knip`
- `pnpm -F @vm0/app lint`
- `pnpm -F @vm0/app check-types`
- `pnpm -F @vm0/app exec vitest run src/__tests__/index-html.test.ts`
- `pnpm -F @vm0/app test`
- `pnpm -F @vm0/app build`
- `pnpm -F api exec vitest run src/signals/routes/__tests__/zero-chat-messages.test.ts -t "runs VM0 GPT model-first routes with the Codex runtime framework"`
- `pnpm vitest` fails locally only in `@vm0/desktop` `src/computer-use-native.test.ts`: 4 macOS-only `vm0-computer` native CLI cases return `accessibility_unavailable: Desktop Computer Use is currently implemented for macOS`. This branch only changes `apps/platform`.
