### PR TITLE
fix: normalize stripe connector icon colors

### DIFF
--- a/turbo/apps/platform/src/views/zero-page/components/settings/icons/stripe.svg
+++ b/turbo/apps/platform/src/views/zero-page/components/settings/icons/stripe.svg
@@ -1,11 +1,11 @@
 <svg width="512" height="512" viewBox="0 0 512 512" fill="none" xmlns="http://www.w3.org/2000/svg">
 <g clip-path="url(#clip0_159_20)">
 <rect width="512" height="512" fill="#533AFD"/>
-<path fill-rule="evenodd" clip-rule="evenodd" d="M120 392L392 334.317V120L120 178.357V392Z" fill="white"/>
+<path fill-rule="evenodd" clip-rule="evenodd" d="M120 392L392 334.317V120L120 178.357V392Z" fill="#FFFFFF"/>
 </g>
 <defs>
 <clipPath id="clip0_159_20">
-<rect width="512" height="512" rx="64" fill="white"/>
+<rect width="512" height="512" rx="64" fill="#FFFFFF"/>
 </clipPath>
 </defs>
 </svg>


### PR DESCRIPTION
## Summary
- Replace keyword `white` fills in the Stripe connector SVG with explicit `#FFFFFF` values.
- Preserve the official Stripe favicon geometry, `#533AFD` background, and existing colorful icon handling.

Fixes #16915

## Checks
- `pnpm exec prettier --check --ignore-unknown apps/platform/src/views/zero-page/components/settings/icons/stripe.svg`
- XML/color assertion for `stripe.svg`
- `git diff --check`
