### PR TITLE
fix(platform): generate complete presentation scripts

### DIFF
--- a/turbo/apps/api/src/signals/routes/__tests__/zero-host.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/zero-host.test.ts
@@ -3,6 +3,7 @@ import { createHash, randomUUID } from "node:crypto";
 import { createStore } from "ccstate";
 import { describe, expect, it } from "vitest";
 import { eq, sql } from "drizzle-orm";
+import { http, HttpResponse } from "msw";
 
 import { zeroHostContract } from "@vm0/api-contracts/contracts/zero-host";
 import { hostedDeployments, hostedSites } from "@vm0/db/schema/hosted-site";
@@ -10,6 +11,8 @@ import { orgMetadata } from "@vm0/db/schema/org-metadata";
 import { runUploadedFiles } from "@vm0/db/schema/run-uploaded-file";
 
 import { accept, setupApp, testContext } from "../../../__tests__/test-helpers";
+import { mockOptionalEnv } from "../../../lib/env";
+import { server } from "../../../mocks/server";
 import { writeDb$ } from "../../external/db";
 import {
   createFixtureTracker,
@@ -721,6 +724,114 @@ describe("POST /api/zero/host/presentation-html/redeploy", () => {
 
     expect(redeployed.body.error.message).toBe(
       "Hosted site is not a presentation HTML artifact",
+    );
+  });
+});
+
+describe("POST /api/zero/host/presentation-html/speaker-notes", () => {
+  it("returns structured speaker notes patches from the configured model", async () => {
+    const fixture = await seedHostedSiteFixture();
+    mocks.clerk.session(fixture.userId, fixture.orgId);
+    mockOptionalEnv("OPENROUTER_API_KEY", "speaker-notes-api-key");
+    let upstreamAuthorization: string | null = null;
+    let upstreamPrompt: string | null = null;
+    server.use(
+      http.post(
+        "https://openrouter.ai/api/v1/chat/completions",
+        async ({ request }) => {
+          upstreamAuthorization = request.headers.get("authorization");
+          const body = (await request.json()) as {
+            readonly messages?: readonly { readonly content?: string }[];
+          };
+          upstreamPrompt = body.messages?.at(-1)?.content ?? null;
+          return HttpResponse.json({
+            choices: [
+              {
+                finish_reason: "stop",
+                message: {
+                  content: JSON.stringify({
+                    kind: "presentation-speaker-notes-patch",
+                    version: 1,
+                    slides: [
+                      {
+                        slideId: "slide-2",
+                        speakerNotes: "Talk through the key transition.",
+                      },
+                      {
+                        slideId: "slide-3",
+                        speakerNotes: "Connect the examples back to the theme.",
+                      },
+                    ],
+                  }),
+                },
+              },
+            ],
+          });
+        },
+      ),
+    );
+
+    const client = setupApp({ context })(zeroHostContract);
+    const response = await accept(
+      client.generatePresentationSpeakerNotes({
+        headers: { authorization: "Bearer clerk-session" },
+        body: {
+          html: '<!doctype html><html><body><section data-slide-id="slide-2">Roadmap</section></body></html>',
+          mode: "fill-empty",
+        },
+      }),
+      [200],
+    );
+
+    expect(upstreamAuthorization).toBe("Bearer speaker-notes-api-key");
+    expect(upstreamPrompt).toContain("slide-2");
+    expect(response.body).toStrictEqual({
+      kind: "presentation-speaker-notes-patch",
+      version: 1,
+      slides: [
+        {
+          slideId: "slide-2",
+          speakerNotes: "Talk through the key transition.",
+        },
+        {
+          slideId: "slide-3",
+          speakerNotes: "Connect the examples back to the theme.",
+        },
+      ],
+    });
+  });
+
+  it("rejects invalid model output", async () => {
+    const fixture = await seedHostedSiteFixture();
+    mocks.clerk.session(fixture.userId, fixture.orgId);
+    mockOptionalEnv("OPENROUTER_API_KEY", "speaker-notes-api-key");
+    server.use(
+      http.post("https://openrouter.ai/api/v1/chat/completions", () => {
+        return HttpResponse.json({
+          choices: [
+            {
+              finish_reason: "stop",
+              message: { content: "not json" },
+            },
+          ],
+        });
+      }),
+    );
+
+    const client = setupApp({ context })(zeroHostContract);
+    const response = await accept(
+      client.generatePresentationSpeakerNotes({
+        headers: { authorization: "Bearer clerk-session" },
+        body: {
+          html: "<!doctype html><html><body><section>Roadmap</section></body></html>",
+          mode: "fill-empty",
+        },
+      }),
+      [400],
+    );
+
+    expect(response.body.error.message).toBe(
+      "Speaker notes generation returned invalid JSON",
     );
   });
 });

--- a/turbo/apps/api/src/signals/routes/zero-host.ts
+++ b/turbo/apps/api/src/signals/routes/zero-host.ts
@@ -6,6 +6,7 @@ import { authRoute } from "../auth/auth-route";
 import { bodyResultOf, pathParamsOf } from "../context/request";
 import {
   completeHostedSiteDeployment$,
+  generatePresentationSpeakerNotes$,
   prepareHostedSiteDeployment$,
   redeployPresentationHtml$,
 } from "../services/zero-host.service";
@@ -65,6 +66,9 @@ const prepareInner$ = command(async ({ get, set }, signal: AbortSignal) => {
 const completeParams$ = pathParamsOf(zeroHostContract.complete);
 const redeployPresentationHtmlBody$ = bodyResultOf(
   zeroHostContract.redeployPresentationHtml,
+);
+const generateSpeakerNotesBody$ = bodyResultOf(
+  zeroHostContract.generatePresentationSpeakerNotes,
 );
 const completeInner$ = command(async ({ get, set }, signal: AbortSignal) => {
   const auth = get(organizationAuthContext$);
@@ -144,6 +148,39 @@ const redeployPresentationHtmlInner$ = command(
   },
 );
 
+const generateSpeakerNotesInner$ = command(
+  async ({ get, set }, signal: AbortSignal) => {
+    const auth = get(organizationAuthContext$);
+
+    const bodyResult = await get(generateSpeakerNotesBody$);
+    signal.throwIfAborted();
+    if (!bodyResult.ok) {
+      return bodyResult.response;
+    }
+
+    const suspended = await set(rejectSuspendedOrg$, auth.orgId, signal);
+    if (suspended) {
+      return suspended;
+    }
+
+    const result = await set(
+      generatePresentationSpeakerNotes$,
+      { body: bodyResult.data },
+      signal,
+    );
+    signal.throwIfAborted();
+
+    if (result.status === "bad_request") {
+      return badRequestMessage(result.message);
+    }
+    if (result.status === "config_error") {
+      return internalError(result.message);
+    }
+
+    return { status: 200 as const, body: result.body };
+  },
+);
+
 export const zeroHostRoutes: readonly RouteEntry[] = [
   {
     route: zeroHostContract.prepare,
@@ -176,6 +213,17 @@ export const zeroHostRoutes: readonly RouteEntry[] = [
         missingOrganizationStatus: 401,
       },
       redeployPresentationHtmlInner$,
+    ),
+  },
+  {
+    route: zeroHostContract.generatePresentationSpeakerNotes,
+    handler: authRoute(
+      {
+        requiredCapability: "host:write",
+        requireOrganization: true,
+        missingOrganizationStatus: 401,
+      },
+      generateSpeakerNotesInner$,
     ),
   },
 ];

--- a/turbo/apps/api/src/signals/services/zero-host.service.ts
+++ b/turbo/apps/api/src/signals/services/zero-host.service.ts
@@ -1,14 +1,14 @@
 import { createHash } from "node:crypto";
 
 import { command } from "ccstate";
-import type {
-  GeneratePresentationSpeakerNotesRequest,
-  HostedArtifactKind,
-  HostedSitePrepareRequest,
-  HostedSiteRedeployPresentationHtmlRequest,
-  PresentationSpeakerNotesPatch,
+import {
+  type GeneratePresentationSpeakerNotesRequest,
+  type HostedArtifactKind,
+  type HostedSitePrepareRequest,
+  type HostedSiteRedeployPresentationHtmlRequest,
+  type PresentationSpeakerNotesPatch,
+  presentationSpeakerNotesPatchSchema,
 } from "@vm0/api-contracts/contracts/zero-host";
-import { presentationSpeakerNotesPatchSchema } from "@vm0/api-contracts/contracts/zero-host";
 import {
   hostedDeployments,
   hostedSites,

--- a/turbo/apps/api/src/signals/services/zero-host.service.ts
+++ b/turbo/apps/api/src/signals/services/zero-host.service.ts
@@ -210,8 +210,11 @@ ${html}`,
 
 function jsonObjectText(value: string): string {
   const trimmed = value.trim();
-  if (trimmed.startsWith("{") && trimmed.endsWith("}")) {
+  try {
+    JSON.parse(trimmed);
     return trimmed;
+  } catch {
+    // fall through to extraction
   }
   const start = trimmed.indexOf("{");
   const end = trimmed.lastIndexOf("}");

--- a/turbo/apps/api/src/signals/services/zero-host.service.ts
+++ b/turbo/apps/api/src/signals/services/zero-host.service.ts
@@ -210,11 +210,8 @@ ${html}`,
 
 function jsonObjectText(value: string): string {
   const trimmed = value.trim();
-  try {
-    JSON.parse(trimmed);
+  if (safeJsonParse(trimmed) !== null) {
     return trimmed;
-  } catch {
-    // fall through to extraction
   }
   const start = trimmed.indexOf("{");
   const end = trimmed.lastIndexOf("}");

--- a/turbo/apps/api/src/signals/services/zero-host.service.ts
+++ b/turbo/apps/api/src/signals/services/zero-host.service.ts
@@ -2,10 +2,13 @@ import { createHash } from "node:crypto";
 
 import { command } from "ccstate";
 import type {
+  GeneratePresentationSpeakerNotesRequest,
   HostedArtifactKind,
   HostedSitePrepareRequest,
   HostedSiteRedeployPresentationHtmlRequest,
+  PresentationSpeakerNotesPatch,
 } from "@vm0/api-contracts/contracts/zero-host";
+import { presentationSpeakerNotesPatchSchema } from "@vm0/api-contracts/contracts/zero-host";
 import {
   hostedDeployments,
   hostedSites,
@@ -16,6 +19,7 @@ import { and, eq, isNull } from "drizzle-orm";
 
 import { env } from "../../lib/env";
 import { type Db, writeDb$ } from "../external/db";
+import { generateText } from "../external/openrouter";
 import {
   copyHostedSitesS3Object,
   generateHostedSitesPresignedPutUrl,
@@ -23,12 +27,14 @@ import {
   putHostedSitesS3Object,
 } from "../external/s3";
 import { nowDate } from "../external/time";
+import { safeJsonParse } from "../utils";
 import { recordHostedSiteArtifact$ } from "./run-uploaded-files.service";
 
 const PUT_URL_TTL_SECONDS = 3600;
 const MAX_HOSTED_SITE_TOTAL_BYTES = 512 * 1024 * 1024;
 const MAX_HOSTED_SITE_FILE_BYTES = 100 * 1024 * 1024;
 const MAX_PUBLIC_SLUG_ATTEMPTS = 5;
+const PRESENTATION_SPEAKER_NOTES_MODEL = "openai/gpt-4.1-mini";
 
 interface PrepareDeploymentArgs {
   readonly orgId: string;
@@ -46,6 +52,10 @@ interface RedeployPresentationHtmlArgs {
   readonly orgId: string;
   readonly userId: string;
   readonly body: HostedSiteRedeployPresentationHtmlRequest;
+}
+
+interface GeneratePresentationSpeakerNotesArgs {
+  readonly body: GeneratePresentationSpeakerNotesRequest;
 }
 
 type PrepareDeploymentResult =
@@ -83,6 +93,11 @@ type CompleteDeploymentResult =
   | { readonly status: "config_error"; readonly message: string };
 
 type RedeployPresentationHtmlResult = CompleteDeploymentResult;
+
+type GeneratePresentationSpeakerNotesResult =
+  | { readonly status: "ok"; readonly body: PresentationSpeakerNotesPatch }
+  | { readonly status: "bad_request"; readonly message: string }
+  | { readonly status: "config_error"; readonly message: string };
 
 type RedeployPresentationTargetResult =
   | {
@@ -156,6 +171,62 @@ function hostedR2Config(): HostedR2ConfigResult {
     };
   }
   return { status: "ok", config: { bucket } };
+}
+
+function presentationSpeakerNotesPrompt(html: string): readonly {
+  readonly role: "system" | "user";
+  readonly content: string;
+}[] {
+  return [
+    {
+      role: "system",
+      content:
+        "You add speaker notes to the user's own HTML presentation. Treat the HTML as read-only context. Return valid JSON matching the requested schema. Write speaker notes as spoken presenter scripts in the same primary language as each slide.",
+    },
+    {
+      role: "user",
+      content: `Generate speaker notes only for empty notes in this existing HTML presentation.
+
+Output:
+- Return only JSON.
+- Output shape: {"kind":"presentation-speaker-notes-patch","version":1,"slides":[{"slideId":"...","speakerNotes":"..."}]}.
+- Use slide IDs from data-slide-id when present.
+- If a slide has no data-slide-id, use its 1-based DOM order fallback: slide-1, slide-2, etc.
+- Include every slide whose speaker notes are empty or missing.
+- Leave slides with existing non-empty speaker notes out of the response.
+
+Writing brief:
+- Write each speakerNotes value as a presenter script the user can read aloud.
+- Start directly with what the speaker would say.
+- For cover or title slides, write a natural opening that introduces the topic, scope, and why it matters.
+- For content slides, turn the visible details into a coherent spoken explanation.
+- Match each slide's primary language and tone. Use plain text.
+
+HTML:
+${html}`,
+    },
+  ];
+}
+
+function jsonObjectText(value: string): string {
+  const trimmed = value.trim();
+  if (trimmed.startsWith("{") && trimmed.endsWith("}")) {
+    return trimmed;
+  }
+  const start = trimmed.indexOf("{");
+  const end = trimmed.lastIndexOf("}");
+  if (start === -1 || end === -1 || end <= start) {
+    return trimmed;
+  }
+  return trimmed.slice(start, end + 1);
+}
+
+function parsePresentationSpeakerNotesPatch(
+  text: string,
+): PresentationSpeakerNotesPatch | null {
+  const parsed = safeJsonParse(jsonObjectText(text));
+  const result = presentationSpeakerNotesPatchSchema.safeParse(parsed);
+  return result.success ? result.data : null;
 }
 
 function publicUrl(publicSlug: string): string {
@@ -819,5 +890,34 @@ export const redeployPresentationHtml$ = command(
       },
       signal,
     );
+  },
+);
+
+export const generatePresentationSpeakerNotes$ = command(
+  async (
+    _,
+    args: GeneratePresentationSpeakerNotesArgs,
+    signal: AbortSignal,
+  ): Promise<GeneratePresentationSpeakerNotesResult> => {
+    const generated = await generateText(
+      PRESENTATION_SPEAKER_NOTES_MODEL,
+      presentationSpeakerNotesPrompt(args.body.html),
+      4096,
+    );
+    signal.throwIfAborted();
+    if (!generated) {
+      return {
+        status: "config_error",
+        message: "Speaker notes generation is not configured",
+      };
+    }
+    const patch = parsePresentationSpeakerNotesPatch(generated);
+    if (!patch) {
+      return {
+        status: "bad_request",
+        message: "Speaker notes generation returned invalid JSON",
+      };
+    }
+    return { status: "ok", body: patch };
   },
 );

--- a/turbo/apps/platform/src/views/zero-page/__tests__/presentation-html-edit-protocol.test.ts
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/presentation-html-edit-protocol.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from "vitest";
 import {
+  applyPresentationSpeakerNotesPatch,
   parsePresentationEditDraft,
   patchPresentationHtml,
   previewPresentationHtml,
@@ -115,6 +116,39 @@ describe("presentation HTML edit protocol", () => {
     expect(patched).toContain("New &lt;unsafe&gt; title");
     expect(patched).toContain('"speakerNotes": "Second slide notes"');
     expect(patched).toContain('"kind": "presentation-html"');
+  });
+
+  it("fills only empty speaker notes from a structured patch", () => {
+    const result = applyPresentationSpeakerNotesPatch({
+      slides: [
+        { id: "slide-1", title: "Old title", notes: "Old notes" },
+        { id: "slide-2", title: "Second", notes: "" },
+        { id: "slide-3", title: "Third", notes: "" },
+        { id: "slide-4", title: "Fourth", notes: "" },
+      ],
+      patch: {
+        kind: "presentation-speaker-notes-patch",
+        version: 1,
+        slides: [
+          {
+            slideId: "slide-1",
+            speakerNotes: "Should not overwrite existing notes",
+          },
+          { slideId: "slide-2", speakerNotes: "Generated notes" },
+          { slideId: "slide-3", speakerNotes: "Third notes" },
+          { slideId: "slide-4", speakerNotes: "   Trimmed notes   " },
+          { slideId: "unknown-slide", speakerNotes: "Ignored notes" },
+        ],
+      },
+    });
+
+    expect(result.appliedCount).toBe(3);
+    expect(result.slides).toStrictEqual([
+      { id: "slide-1", title: "Old title", notes: "Old notes" },
+      { id: "slide-2", title: "Second", notes: "Generated notes" },
+      { id: "slide-3", title: "Third", notes: "Third notes" },
+      { id: "slide-4", title: "Fourth", notes: "Trimmed notes" },
+    ]);
   });
 
   it("preserves nested markup in unchanged editable blocks", () => {

--- a/turbo/apps/platform/src/views/zero-page/presentation-html-edit-protocol.ts
+++ b/turbo/apps/platform/src/views/zero-page/presentation-html-edit-protocol.ts
@@ -1,3 +1,5 @@
+import type { PresentationSpeakerNotesPatch } from "@vm0/api-contracts/contracts/zero-host";
+
 const EDITABLE_SELECTOR = '[data-vm0-editable="text"]';
 const METADATA_SCRIPT_ID = "vm0-deck-metadata";
 const SLIDE_SELECTORS = [
@@ -319,6 +321,37 @@ export function patchPresentationHtml(params: {
   }
   ensureMetadataScript(doc).textContent = JSON.stringify(metadata, null, 2);
   return serializeDoc(doc);
+}
+
+export function applyPresentationSpeakerNotesPatch(params: {
+  readonly patch: PresentationSpeakerNotesPatch;
+  readonly slides: readonly PresentationSlideDraft[];
+}): {
+  readonly appliedCount: number;
+  readonly slides: readonly PresentationSlideDraft[];
+} {
+  const notesBySlideId = new Map<string, string>();
+  for (const item of params.patch.slides) {
+    const notes = item.speakerNotes.trim();
+    if (notes) {
+      notesBySlideId.set(item.slideId, notes);
+    }
+  }
+
+  let appliedCount = 0;
+  const slides = params.slides.map((slide) => {
+    if (slide.notes.trim()) {
+      return slide;
+    }
+    const notes = notesBySlideId.get(slide.id);
+    if (!notes) {
+      return slide;
+    }
+    appliedCount += 1;
+    return { ...slide, notes };
+  });
+
+  return { appliedCount, slides };
 }
 
 export function previewPresentationHtml(params: {

--- a/turbo/apps/platform/src/views/zero-page/presentation-html-editor.tsx
+++ b/turbo/apps/platform/src/views/zero-page/presentation-html-editor.tsx
@@ -1,13 +1,13 @@
 import type { ReactNode, Ref } from "react";
 import {
   IconDownload,
-  IconFileTypeHtml,
   IconLoader2,
   IconPresentation,
+  IconSparkles,
   IconX,
 } from "@tabler/icons-react";
-import { zeroHostContract } from "@vm0/api-contracts/contracts/zero-host";
 import { cn } from "@vm0/ui";
+import { zeroHostContract } from "@vm0/api-contracts/contracts/zero-host";
 import { toast } from "@vm0/ui/components/ui/sonner";
 import { useGet, useLoadable, useSet } from "ccstate-react";
 import { accept } from "../../lib/accept.ts";
@@ -24,6 +24,7 @@ import {
   readablePresentationResourceUrl,
 } from "./presentation-html-pptx-download.ts";
 import {
+  applyPresentationSpeakerNotesPatch,
   parsePresentationEditDraft,
   patchPresentationHtml,
   previewPresentationHtml,
@@ -110,21 +111,25 @@ async function redeployPresentationHtml(params: {
   return completed.body.url;
 }
 
-function htmlFilename(filename: string): string {
-  return filename.replace(/\.(html?|xhtml)$/i, "") + ".html";
-}
-
-function downloadHtml(html: string, filename: string): void {
-  const blob = new Blob([html], { type: "text/html;charset=utf-8" });
-  const anchor = document.createElement("a");
-  anchor.href = URL.createObjectURL(blob);
-  anchor.download = htmlFilename(filename);
-  document.body.append(anchor);
-  anchor.click();
-  anchor.remove();
-  window.setTimeout(() => {
-    URL.revokeObjectURL(anchor.href);
-  }, 0);
+async function generatePresentationSpeakerNotes(params: {
+  readonly createClient: ZeroClientFactory;
+  readonly html: string;
+  readonly signal: AbortSignal;
+}) {
+  params.signal.throwIfAborted();
+  const client = params.createClient(zeroHostContract, { apiBase: "api" });
+  const completed = await accept(
+    client.generatePresentationSpeakerNotes({
+      body: {
+        html: params.html,
+        mode: "fill-empty",
+      },
+      fetchOptions: { signal: params.signal },
+    }),
+    [200],
+    { toast: false },
+  );
+  return completed.body;
 }
 
 function updateBlockText(
@@ -177,15 +182,15 @@ function editSignature(params: {
 function PresentationEditorHeader({
   busyRef,
   onClose,
-  onDownloadHtml,
   onDownloadPptx,
+  onGenerateSpeakerNotes,
   statusRef,
   title,
 }: {
   busyRef?: Ref<SVGSVGElement>;
   onClose: () => void;
-  onDownloadHtml: (() => void) | undefined;
   onDownloadPptx: (() => void) | undefined;
+  onGenerateSpeakerNotes: (() => void) | undefined;
   statusRef?: Ref<HTMLDivElement>;
   title: string;
 }) {
@@ -213,17 +218,6 @@ function PresentationEditorHeader({
       <button
         type="button"
         data-presentation-editor-action="true"
-        aria-label="Download edited HTML"
-        disabled={!onDownloadHtml}
-        onClick={onDownloadHtml}
-        className="inline-flex h-8 items-center gap-2 rounded-md px-2 text-sm text-muted-foreground transition-colors hover:bg-muted/60 hover:text-foreground disabled:pointer-events-none disabled:opacity-50"
-      >
-        <IconFileTypeHtml size={16} stroke={1.5} />
-        HTML
-      </button>
-      <button
-        type="button"
-        data-presentation-editor-action="true"
         aria-label="Download edited PPTX"
         disabled={!onDownloadPptx}
         onClick={onDownloadPptx}
@@ -231,6 +225,17 @@ function PresentationEditorHeader({
       >
         <IconDownload size={16} stroke={1.5} />
         PPTX
+      </button>
+      <button
+        type="button"
+        data-presentation-editor-action="true"
+        aria-label="Generate PPT script"
+        title="Generate PPT script"
+        disabled={!onGenerateSpeakerNotes}
+        onClick={onGenerateSpeakerNotes}
+        className="inline-flex h-8 w-8 items-center justify-center rounded-md text-muted-foreground transition-colors hover:bg-muted/60 hover:text-foreground disabled:pointer-events-none disabled:opacity-50"
+      >
+        <IconSparkles size={16} stroke={1.5} />
       </button>
       <button
         type="button"
@@ -258,8 +263,8 @@ function PresentationEditorShell({
     <div className="flex h-full min-w-0 flex-1 flex-col bg-background">
       <PresentationEditorHeader
         onClose={onClose}
-        onDownloadHtml={undefined}
         onDownloadPptx={undefined}
+        onGenerateSpeakerNotes={undefined}
         title={title}
       />
       {children}
@@ -931,6 +936,63 @@ function createPresentationEditorController(params: {
       sourceUrl: params.sourceUrl,
     });
   };
+  const fillEmptySpeakerNotes = async () => {
+    if (
+      !params.slidesRef.current.some((slide) => {
+        return slide.notes.trim().length === 0;
+      })
+    ) {
+      toast.info("All speaker notes are filled");
+      return;
+    }
+
+    setPublishing(true);
+    setStatus("Generating speaker notes");
+    const generated = await tapError(
+      generatePresentationSpeakerNotes({
+        createClient: params.createClient,
+        html: buildEditedHtml(),
+        signal: params.pageSignal,
+      }).finally(() => {
+        setPublishing(false);
+        markDirty();
+      }),
+      (error) => {
+        if (!(error instanceof DOMException && error.name === "AbortError")) {
+          toast.error(
+            error instanceof Error
+              ? error.message
+              : "Speaker notes generation failed",
+          );
+        }
+      },
+    );
+    if (!generated) {
+      return;
+    }
+
+    const result = applyPresentationSpeakerNotesPatch({
+      patch: generated,
+      slides: params.slidesRef.current,
+    });
+    if (result.appliedCount === 0) {
+      toast.info("No speaker notes were added");
+      return;
+    }
+
+    params.slidesRef.current = result.slides;
+    syncNotesPanel(
+      params.slidesRef.current.find((slide) => {
+        return slide.id === params.activeSlideIdRef.current;
+      }),
+    );
+    markDirty();
+    toast.success(
+      `Added speaker notes to ${String(result.appliedCount)} slide${
+        result.appliedCount === 1 ? "" : "s"
+      }`,
+    );
+  };
   const showSlide = (slideId: string) => {
     params.activeSlideIdRef.current = slideId;
     syncNotesPanel(
@@ -957,6 +1019,7 @@ function createPresentationEditorController(params: {
     activeSlideId,
     buildEditedHtml,
     ensureRedeployed,
+    fillEmptySpeakerNotes,
     markDirty,
     previewHtml,
     queueSlideThumbnailUpdate,
@@ -1036,18 +1099,6 @@ function PresentationEditorReady({
           busyRef.current = node;
         }}
         onClose={closeAfterPublish}
-        onDownloadHtml={() => {
-          runEditorTaskIfIdle({
-            publishingRef,
-            reason: "presentation html editor html download",
-            task: async () => {
-              if (!(await controller.ensureRedeployed())) {
-                return;
-              }
-              downloadHtml(controller.buildEditedHtml(), filename);
-            },
-          });
-        }}
         onDownloadPptx={() => {
           runEditorTaskIfIdle({
             publishingRef,
@@ -1063,6 +1114,13 @@ function PresentationEditorReady({
                 signal: pageSignal,
               });
             },
+          });
+        }}
+        onGenerateSpeakerNotes={() => {
+          runEditorTaskIfIdle({
+            publishingRef,
+            reason: "presentation html editor speaker notes generation",
+            task: controller.fillEmptySpeakerNotes,
           });
         }}
         statusRef={(node) => {

--- a/turbo/apps/platform/src/views/zero-page/presentation-html-editor.tsx
+++ b/turbo/apps/platform/src/views/zero-page/presentation-html-editor.tsx
@@ -850,6 +850,76 @@ function PresentationEditorWorkspace({
   );
 }
 
+async function runFillEmptySpeakerNotes(ctx: {
+  readonly buildEditedHtml: () => string;
+  readonly markDirty: () => void;
+  readonly params: {
+    readonly activeSlideIdRef: MutableValue<string>;
+    readonly createClient: ZeroClientFactory;
+    readonly pageSignal: AbortSignal;
+    readonly slidesRef: MutableValue<readonly PresentationSlideDraft[]>;
+  };
+  readonly setPublishing: (publishing: boolean) => void;
+  readonly setStatus: (value: string) => void;
+}): Promise<void> {
+  const { params } = ctx;
+  if (
+    !params.slidesRef.current.some((slide) => {
+      return slide.notes.trim().length === 0;
+    })
+  ) {
+    toast.info("All speaker notes are filled");
+    return;
+  }
+
+  ctx.setPublishing(true);
+  ctx.setStatus("Generating speaker notes");
+  const generated = await tapError(
+    generatePresentationSpeakerNotes({
+      createClient: params.createClient,
+      html: ctx.buildEditedHtml(),
+      signal: params.pageSignal,
+    }).finally(() => {
+      ctx.setPublishing(false);
+      ctx.markDirty();
+    }),
+    (error) => {
+      if (!(error instanceof DOMException && error.name === "AbortError")) {
+        toast.error(
+          error instanceof Error
+            ? error.message
+            : "Speaker notes generation failed",
+        );
+      }
+    },
+  );
+  if (!generated) {
+    return;
+  }
+
+  const result = applyPresentationSpeakerNotesPatch({
+    patch: generated,
+    slides: params.slidesRef.current,
+  });
+  if (result.appliedCount === 0) {
+    toast.info("No speaker notes were added");
+    return;
+  }
+
+  params.slidesRef.current = result.slides;
+  syncNotesPanel(
+    params.slidesRef.current.find((slide) => {
+      return slide.id === params.activeSlideIdRef.current;
+    }),
+  );
+  ctx.markDirty();
+  toast.success(
+    `Added speaker notes to ${String(result.appliedCount)} slide${
+      result.appliedCount === 1 ? "" : "s"
+    }`,
+  );
+}
+
 function createPresentationEditorController(params: {
   readonly activeSlideIdRef: MutableValue<string>;
   readonly blocksRef: MutableValue<readonly PresentationEditBlock[]>;
@@ -936,62 +1006,14 @@ function createPresentationEditorController(params: {
       sourceUrl: params.sourceUrl,
     });
   };
-  const fillEmptySpeakerNotes = async () => {
-    if (
-      !params.slidesRef.current.some((slide) => {
-        return slide.notes.trim().length === 0;
-      })
-    ) {
-      toast.info("All speaker notes are filled");
-      return;
-    }
-
-    setPublishing(true);
-    setStatus("Generating speaker notes");
-    const generated = await tapError(
-      generatePresentationSpeakerNotes({
-        createClient: params.createClient,
-        html: buildEditedHtml(),
-        signal: params.pageSignal,
-      }).finally(() => {
-        setPublishing(false);
-        markDirty();
-      }),
-      (error) => {
-        if (!(error instanceof DOMException && error.name === "AbortError")) {
-          toast.error(
-            error instanceof Error
-              ? error.message
-              : "Speaker notes generation failed",
-          );
-        }
-      },
-    );
-    if (!generated) {
-      return;
-    }
-
-    const result = applyPresentationSpeakerNotesPatch({
-      patch: generated,
-      slides: params.slidesRef.current,
+  const fillEmptySpeakerNotes = () => {
+    return runFillEmptySpeakerNotes({
+      buildEditedHtml,
+      markDirty,
+      params,
+      setPublishing,
+      setStatus,
     });
-    if (result.appliedCount === 0) {
-      toast.info("No speaker notes were added");
-      return;
-    }
-
-    params.slidesRef.current = result.slides;
-    syncNotesPanel(
-      params.slidesRef.current.find((slide) => {
-        return slide.id === params.activeSlideIdRef.current;
-      }),
-    );
-    markDirty();
-    toast.success(
-      `Added speaker notes to ${String(result.appliedCount)} slide${
-        result.appliedCount === 1 ? "" : "s"
-      }`,
-    );
   };
   const showSlide = (slideId: string) => {
     params.activeSlideIdRef.current = slideId;

--- a/turbo/apps/platform/src/views/zero-page/presentation-html-editor.tsx
+++ b/turbo/apps/platform/src/views/zero-page/presentation-html-editor.tsx
@@ -881,7 +881,6 @@ async function runFillEmptySpeakerNotes(ctx: {
       signal: params.pageSignal,
     }).finally(() => {
       ctx.setPublishing(false);
-      ctx.markDirty();
     }),
     (error) => {
       if (!(error instanceof DOMException && error.name === "AbortError")) {

--- a/turbo/apps/web/api-backend-rewrites.js
+++ b/turbo/apps/web/api-backend-rewrites.js
@@ -794,6 +794,10 @@ export const API_BACKEND_REWRITES = [
     "/api/zero/host/presentation-html/redeploy",
     "/api/zero/host/presentation-html/redeploy",
   ],
+  [
+    "/api/zero/host/presentation-html/speaker-notes",
+    "/api/zero/host/presentation-html/speaker-notes",
+  ],
   [ZERO_ME_MODEL_PROVIDERS_REWRITE_SOURCE, "/api/zero/me/model-providers"],
   [
     ZERO_ME_MODEL_PROVIDER_TYPE_REWRITE_SOURCE,

--- a/turbo/packages/api-contracts/src/contracts/zero-host.ts
+++ b/turbo/packages/api-contracts/src/contracts/zero-host.ts
@@ -79,6 +79,24 @@ export const hostedSiteRedeployPresentationHtmlRequestSchema = z.object({
   html: z.string().min(1),
 });
 
+export const presentationSpeakerNotesPatchSchema = z.object({
+  kind: z.literal("presentation-speaker-notes-patch"),
+  version: z.literal(1),
+  slides: z
+    .array(
+      z.object({
+        slideId: z.string().min(1),
+        speakerNotes: z.string().min(1),
+      }),
+    )
+    .max(500),
+});
+
+export const generatePresentationSpeakerNotesRequestSchema = z.object({
+  html: z.string().min(1).max(500_000),
+  mode: z.literal("fill-empty"),
+});
+
 export const hostedSitePrepareResponseSchema = z.object({
   siteId: z.string().uuid(),
   deploymentId: z.string().uuid(),
@@ -149,6 +167,21 @@ export const zeroHostContract = c.router({
     },
     summary: "Redeploy an existing presentation HTML hosted site",
   },
+  generatePresentationSpeakerNotes: {
+    method: "POST",
+    path: "/api/zero/host/presentation-html/speaker-notes",
+    headers: authHeadersSchema,
+    body: generatePresentationSpeakerNotesRequestSchema,
+    responses: {
+      200: presentationSpeakerNotesPatchSchema,
+      400: apiErrorSchema,
+      401: apiErrorSchema,
+      402: apiErrorSchema,
+      403: apiErrorSchema,
+      500: apiErrorSchema,
+    },
+    summary: "Generate speaker notes for an existing presentation HTML",
+  },
 });
 
 export type ZeroHostContract = typeof zeroHostContract;
@@ -157,6 +190,12 @@ export type HostedSitePrepareRequest = z.infer<
 >;
 export type HostedSiteRedeployPresentationHtmlRequest = z.infer<
   typeof hostedSiteRedeployPresentationHtmlRequestSchema
+>;
+export type GeneratePresentationSpeakerNotesRequest = z.infer<
+  typeof generatePresentationSpeakerNotesRequestSchema
+>;
+export type PresentationSpeakerNotesPatch = z.infer<
+  typeof presentationSpeakerNotesPatchSchema
 >;
 export type HostedSitePrepareResponse = z.infer<
   typeof hostedSitePrepareResponseSchema


### PR DESCRIPTION
## Summary
- add an API route and contract for generating speaker-note patches for existing presentation HTML
- generate full presenter-script notes for every slide with empty notes, matching each slide language
- wire the presentation editor to fill notes from the generated patch and remove the HTML download action

## Checks
- pnpm -F @vm0/app exec vitest run src/views/zero-page/__tests__/presentation-html-edit-protocol.test.ts
- pnpm -F @vm0/api-contracts check-types
- pnpm -F api check-types
- pnpm -F @vm0/app check-types
- targeted eslint for touched api/platform/api-contracts files

## Notes
- The previous presentation notes export PR was already merged; this PR is based on latest origin/main and contains the follow-up AI generation changes only.