### PR TITLE
fix: preserve testrail connector icon color

### DIFF
--- a/turbo/apps/platform/src/views/zero-page/components/settings/connector-icons.tsx
+++ b/turbo/apps/platform/src/views/zero-page/components/settings/connector-icons.tsx
@@ -236,6 +236,7 @@ const CONNECTOR_ICON_COLORFUL = {
   streak: true,
   stripe: true,
   supabase: true,
+  testrail: true,
   ticketmaster: true,
   tldv: true,
   todoist: true,


### PR DESCRIPTION
## Summary
- Add `testrail` to `CONNECTOR_ICON_COLORFUL` so the official TestRail green mark is not inverted in dark mode.
- Preserve the existing official TestRail SVG asset unchanged.

Fixes #16919

## Checks
- `pnpm exec prettier --check --ignore-unknown apps/platform/src/views/zero-page/components/settings/connector-icons.tsx`
- `pnpm -F @vm0/app check-types`
- `git diff --check`
- `pnpm exec commitlint --from HEAD~1 --to HEAD`
- `pnpm knip --cache` currently fails on unrelated baseline issues in `packages/ui` and eslint config; this PR only changes the TestRail colorful override.
