### PR TITLE
fix: harden mock codex session persistence

### DIFF
--- a/crates/Cargo.lock
+++ b/crates/Cargo.lock
@@ -1290,6 +1290,7 @@ dependencies = [
  "thiserror 2.0.18",
  "tokio",
  "tokio-util",
+ "uuid",
  "vsock-guest",
  "vsock-host",
  "vsock-proto",

--- a/crates/guest-agent/Cargo.toml
+++ b/crates/guest-agent/Cargo.toml
@@ -27,6 +27,7 @@ thiserror.workspace = true
 tar.workspace = true
 tokio = { workspace = true, features = ["rt-multi-thread", "macros", "time", "process", "io-util", "fs", "sync", "net"] }
 tokio-util.workspace = true
+uuid.workspace = true
 zstd.workspace = true
 
 [dev-dependencies]

--- a/crates/guest-agent/src/events.rs
+++ b/crates/guest-agent/src/events.rs
@@ -13,6 +13,7 @@ use crate::paths;
 use agent_diagnostics::FailureReason;
 use guest_common::{log_error, log_info};
 use serde_json::{Map, Value, json};
+use std::path::{Component, Path};
 
 const LOG_TAG: &str = "sandbox:guest-agent";
 const FAILURE_DIAGNOSTIC_MAX_BYTES: usize = 4096;
@@ -433,7 +434,7 @@ fn write_session_history_marker(history_path_payload: &str) {
 
 fn history_path_payload_for_session_id(session_id: &str) -> Option<String> {
     match Framework::from_env() {
-        Framework::ClaudeCode => Some(claude_history_path_payload(session_id)),
+        Framework::ClaudeCode => claude_history_path_payload(session_id),
         Framework::Codex => {
             let thread_id = crate::session_history::canonical_codex_thread_id(session_id)?;
             Some(codex_history_marker_payload(&thread_id))
@@ -453,20 +454,39 @@ fn extract_claude_session_id(event: &Value) -> Option<(String, String)> {
     if session_id.is_empty() {
         return None;
     }
+    let history_path_payload = claude_history_path_payload(session_id)?;
 
-    Some((
-        session_id.to_string(),
-        claude_history_path_payload(session_id),
-    ))
+    Some((session_id.to_string(), history_path_payload))
 }
 
-fn claude_history_path_payload(session_id: &str) -> String {
+fn claude_history_path_payload(session_id: &str) -> Option<String> {
+    if !is_valid_session_history_id(session_id) {
+        return None;
+    }
+
     let home = env::home_dir();
     let project_name = paths::CANONICAL_WORKING_DIR
         .strip_prefix('/')
         .unwrap_or(paths::CANONICAL_WORKING_DIR)
         .replace('/', "-");
-    format!("{home}/.claude/projects/-{project_name}/{session_id}.jsonl")
+    Some(format!(
+        "{home}/.claude/projects/-{project_name}/{session_id}.jsonl"
+    ))
+}
+
+fn is_valid_session_history_id(session_id: &str) -> bool {
+    if session_id.is_empty()
+        || session_id == "."
+        || session_id == ".."
+        || session_id.contains('/')
+        || session_id.contains('\\')
+        || session_id.chars().any(char::is_control)
+    {
+        return false;
+    }
+
+    let mut components = Path::new(session_id).components();
+    matches!(components.next(), Some(Component::Normal(_))) && components.next().is_none()
 }
 
 /// Codex variant — matches `thread.started` and emits a `CODEX_SEARCH:`

--- a/crates/guest-agent/src/events.rs
+++ b/crates/guest-agent/src/events.rs
@@ -312,8 +312,7 @@ pub(crate) fn extract_claude_tool_info(event: &Value) -> Vec<ClaudeToolEvent<'_>
     results
 }
 
-/// If this is a session-start event, capture the session id and persist the
-/// session-history-path metadata files for checkpoint use.
+/// Capture or repair the session metadata files needed by checkpoint.
 ///
 /// Both frameworks emit a single id-bearing event near the top of their
 /// JSONL stream:
@@ -331,6 +330,7 @@ pub(crate) fn capture_session_metadata(event: &Value) {
         Framework::Codex => extract_codex_thread_id(event),
     };
     let Some((session_id, history_path_payload)) = parsed else {
+        repair_missing_session_history_marker_from_existing_session();
         return;
     };
 
@@ -371,11 +371,49 @@ pub(crate) fn capture_session_metadata(event: &Value) {
     write_session_history_marker(&history_path_payload);
 }
 
-fn ensure_session_history_marker(history_path_payload: &str) {
-    if std::path::Path::new(paths::session_history_path_file()).exists() {
+fn repair_missing_session_history_marker_from_existing_session() {
+    if !should_write_session_history_marker() {
         return;
     }
-    write_session_history_marker(history_path_payload);
+    let session_id = match std::fs::read_to_string(paths::session_id_file()) {
+        Ok(session_id) => session_id.trim().to_string(),
+        Err(e) if e.kind() == std::io::ErrorKind::NotFound => return,
+        Err(e) => {
+            log_error!(
+                LOG_TAG,
+                "Failed to read existing session ID from {}: {e}",
+                paths::session_id_file()
+            );
+            return;
+        }
+    };
+    if session_id.is_empty() {
+        return;
+    }
+    if let Some(history_path_payload) = history_path_payload_for_session_id(&session_id) {
+        write_session_history_marker(&history_path_payload);
+    }
+}
+
+fn ensure_session_history_marker(history_path_payload: &str) {
+    if should_write_session_history_marker() {
+        write_session_history_marker(history_path_payload);
+    }
+}
+
+fn should_write_session_history_marker() -> bool {
+    match std::fs::read_to_string(paths::session_history_path_file()) {
+        Ok(existing) => existing.trim().is_empty(),
+        Err(e) if e.kind() == std::io::ErrorKind::NotFound => true,
+        Err(e) => {
+            log_error!(
+                LOG_TAG,
+                "Failed to read existing session history marker from {}: {e}",
+                paths::session_history_path_file()
+            );
+            false
+        }
+    }
 }
 
 fn write_session_history_marker(history_path_payload: &str) {
@@ -393,6 +431,16 @@ fn write_session_history_marker(history_path_payload: &str) {
     }
 }
 
+fn history_path_payload_for_session_id(session_id: &str) -> Option<String> {
+    match Framework::from_env() {
+        Framework::ClaudeCode => Some(claude_history_path_payload(session_id)),
+        Framework::Codex => {
+            let thread_id = crate::session_history::canonical_codex_thread_id(session_id)?;
+            Some(codex_history_marker_payload(&thread_id))
+        }
+    }
+}
+
 /// Claude variant — matches `system/init` and computes the project-scoped
 /// jsonl path under `$HOME/.claude/projects/-{cwd}/`.
 fn extract_claude_session_id(event: &Value) -> Option<(String, String)> {
@@ -406,13 +454,19 @@ fn extract_claude_session_id(event: &Value) -> Option<(String, String)> {
         return None;
     }
 
+    Some((
+        session_id.to_string(),
+        claude_history_path_payload(session_id),
+    ))
+}
+
+fn claude_history_path_payload(session_id: &str) -> String {
     let home = env::home_dir();
     let project_name = paths::CANONICAL_WORKING_DIR
         .strip_prefix('/')
         .unwrap_or(paths::CANONICAL_WORKING_DIR)
         .replace('/', "-");
-    let history_path = format!("{home}/.claude/projects/-{project_name}/{session_id}.jsonl");
-    Some((session_id.to_string(), history_path))
+    format!("{home}/.claude/projects/-{project_name}/{session_id}.jsonl")
 }
 
 /// Codex variant — matches `thread.started` and emits a `CODEX_SEARCH:`
@@ -424,10 +478,14 @@ fn extract_codex_thread_id(event: &Value) -> Option<(String, String)> {
     }
     let thread_id = event.get("thread_id").and_then(|v| v.as_str())?;
     let thread_id = crate::session_history::canonical_codex_thread_id(thread_id)?;
+    let marker = codex_history_marker_payload(&thread_id);
 
-    let home = env::home_dir();
-    let marker = format!("CODEX_SEARCH:{home}/.codex/sessions:{thread_id}");
     Some((thread_id, marker))
+}
+
+fn codex_history_marker_payload(thread_id: &str) -> String {
+    let home = env::home_dir();
+    format!("CODEX_SEARCH:{home}/.codex/sessions:{thread_id}")
 }
 
 #[cfg(test)]

--- a/crates/guest-agent/src/events.rs
+++ b/crates/guest-agent/src/events.rs
@@ -396,11 +396,11 @@ fn extract_codex_thread_id(event: &Value) -> Option<(String, String)> {
         return None;
     }
     let thread_id = event.get("thread_id").and_then(|v| v.as_str())?;
-    crate::session_history::normalize_codex_thread_id(thread_id)?;
+    let thread_id = crate::session_history::canonical_codex_thread_id(thread_id)?;
 
     let home = env::home_dir();
     let marker = format!("CODEX_SEARCH:{home}/.codex/sessions:{thread_id}");
-    Some((thread_id.to_string(), marker))
+    Some((thread_id, marker))
 }
 
 #[cfg(test)]

--- a/crates/guest-agent/src/events.rs
+++ b/crates/guest-agent/src/events.rs
@@ -334,9 +334,25 @@ pub(crate) fn capture_session_metadata(event: &Value) {
         return;
     };
 
-    // Idempotency: only the first id-bearing event of the run wins.
-    if std::path::Path::new(paths::session_id_file()).exists() {
-        return;
+    // Idempotency: only the first id-bearing event of the run wins, but allow
+    // a retry of the same session to repair a missing history marker after a
+    // partial metadata write.
+    match std::fs::read_to_string(paths::session_id_file()) {
+        Ok(existing_session_id) => {
+            if existing_session_id.trim() == session_id {
+                ensure_session_history_marker(&history_path_payload);
+            }
+            return;
+        }
+        Err(e) if e.kind() == std::io::ErrorKind::NotFound => {}
+        Err(e) => {
+            log_error!(
+                LOG_TAG,
+                "Failed to read existing session ID from {}: {e}",
+                paths::session_id_file()
+            );
+            return;
+        }
     }
 
     log_info!(LOG_TAG, "Captured session ID: {session_id}");
@@ -352,7 +368,18 @@ pub(crate) fn capture_session_metadata(event: &Value) {
             paths::session_id_file()
         ),
     }
-    match paths::write_private(paths::session_history_path_file(), &history_path_payload) {
+    write_session_history_marker(&history_path_payload);
+}
+
+fn ensure_session_history_marker(history_path_payload: &str) {
+    if std::path::Path::new(paths::session_history_path_file()).exists() {
+        return;
+    }
+    write_session_history_marker(history_path_payload);
+}
+
+fn write_session_history_marker(history_path_payload: &str) {
+    match paths::write_private(paths::session_history_path_file(), history_path_payload) {
         Ok(()) => log_info!(
             LOG_TAG,
             "Session history marker written to {}: {history_path_payload}",

--- a/crates/guest-agent/src/session_history.rs
+++ b/crates/guest-agent/src/session_history.rs
@@ -98,11 +98,11 @@ fn read_codex_session_history_impl(
     thread_id: &str,
     id_norm: &str,
 ) -> Result<Option<Vec<u8>>, AgentError> {
-    if !std::fs::symlink_metadata(sessions_dir)
-        .ok()
-        .is_some_and(|metadata| metadata.file_type().is_dir())
-    {
-        return Ok(None);
+    match std::fs::symlink_metadata(sessions_dir) {
+        Ok(metadata) if metadata.file_type().is_dir() => {}
+        Ok(_) => return Ok(None),
+        Err(err) if should_skip_unusable_codex_entry(&err) => return Ok(None),
+        Err(err) => return Err(read_history_error(sessions_dir, err)),
     }
 
     let mut found = None;
@@ -124,14 +124,23 @@ fn find_codex_session_file_recursive(
     id_norm: &str,
     found: &mut Option<ResolvedCodexSession>,
 ) -> Result<(), AgentError> {
-    let Ok(entries) = std::fs::read_dir(dir) else {
-        return Ok(());
+    let entries = match std::fs::read_dir(dir) {
+        Ok(entries) => entries,
+        Err(err) if should_skip_unusable_codex_entry(&err) => return Ok(()),
+        Err(err) => return Err(read_history_error(dir, err)),
     };
-    for entry in entries.flatten() {
-        let Ok(file_type) = entry.file_type() else {
-            continue;
+    for entry in entries {
+        let entry = match entry {
+            Ok(entry) => entry,
+            Err(err) if should_skip_unusable_codex_entry(&err) => continue,
+            Err(err) => return Err(read_history_error(dir, err)),
         };
         let path = entry.path();
+        let file_type = match entry.file_type() {
+            Ok(file_type) => file_type,
+            Err(err) if should_skip_unusable_codex_entry(&err) => continue,
+            Err(err) => return Err(read_history_error(&path, err)),
+        };
         if file_type.is_dir() {
             find_codex_session_file_recursive(root, &path, thread_id, id_norm, found)?;
         } else if file_type.is_file()
@@ -160,8 +169,10 @@ fn read_codex_session_history_impl(
     thread_id: &str,
     id_norm: &str,
 ) -> Result<Option<Vec<u8>>, AgentError> {
-    let Ok(root) = Dir::open(sessions_dir) else {
-        return Ok(None);
+    let root = match Dir::open(sessions_dir) {
+        Ok(root) => root,
+        Err(err) if should_skip_unusable_codex_entry(&err) => return Ok(None),
+        Err(err) => return Err(read_history_error(sessions_dir, err)),
     };
     let mut found = None;
     find_and_read_codex_session_file_recursive(
@@ -186,19 +197,30 @@ fn find_and_read_codex_session_file_recursive(
     id_norm: &str,
     found: &mut Option<ResolvedCodexSession>,
 ) -> Result<(), AgentError> {
-    let Ok(entries) = dir.read_dir() else {
-        return Ok(());
+    let entries = match dir.read_dir() {
+        Ok(entries) => entries,
+        Err(err) if should_skip_unusable_codex_entry(&err) => return Ok(()),
+        Err(err) => return Err(read_history_error(dir_path, err)),
     };
 
-    for entry in entries.flatten() {
-        let name = entry.file_name();
-        let Ok(file_type) = entry.file_type() else {
-            continue;
+    for entry in entries {
+        let entry = match entry {
+            Ok(entry) => entry,
+            Err(err) if should_skip_unusable_codex_entry(&err) => continue,
+            Err(err) => return Err(read_history_error(dir_path, err)),
         };
+        let name = entry.file_name();
         let path = dir_path.join(&name);
+        let file_type = match entry.file_type() {
+            Ok(file_type) => file_type,
+            Err(err) if should_skip_unusable_codex_entry(&err) => continue,
+            Err(err) => return Err(read_history_error(&path, err)),
+        };
         if file_type.is_dir() {
-            let Ok(child) = dir.open_child_dir(&name) else {
-                continue;
+            let child = match dir.open_child_dir(&name) {
+                Ok(child) => child,
+                Err(err) if should_skip_unusable_codex_entry(&err) => continue,
+                Err(err) => return Err(read_history_error(&path, err)),
             };
             find_and_read_codex_session_file_recursive(
                 &child, root_path, &path, thread_id, id_norm, found,
@@ -206,7 +228,7 @@ fn find_and_read_codex_session_file_recursive(
         } else if file_type.is_file() && codex_session_filename_matches(&name, id_norm) {
             let file = match dir.open_child_file(&name) {
                 Ok(file) => file,
-                Err(e) if should_skip_raced_codex_entry(&e) => continue,
+                Err(e) if should_skip_unusable_codex_entry(&e) => continue,
                 Err(e) => return Err(read_history_error(&path, e)),
             };
             if !file
@@ -261,12 +283,21 @@ fn codex_session_filename_matches(name: &OsStr, id_norm: &str) -> bool {
     name_norm.contains(id_norm)
 }
 
-#[cfg(target_os = "linux")]
-fn should_skip_raced_codex_entry(err: &io::Error) -> bool {
+fn should_skip_unusable_codex_entry(err: &io::Error) -> bool {
     matches!(
         err.kind(),
         io::ErrorKind::NotFound | io::ErrorKind::NotADirectory
-    ) || err.raw_os_error() == Some(libc::ELOOP)
+    ) || is_filesystem_loop_error(err)
+}
+
+#[cfg(target_os = "linux")]
+fn is_filesystem_loop_error(err: &io::Error) -> bool {
+    err.raw_os_error() == Some(libc::ELOOP)
+}
+
+#[cfg(not(target_os = "linux"))]
+fn is_filesystem_loop_error(_: &io::Error) -> bool {
+    false
 }
 
 /// Read the bytes at `path`, decompressing legacy zstd files if the extension is `.zst`.

--- a/crates/guest-agent/src/session_history.rs
+++ b/crates/guest-agent/src/session_history.rs
@@ -105,7 +105,9 @@ fn read_codex_session_history_impl(
 
     let mut found = None;
     find_codex_session_file_recursive(sessions_dir, sessions_dir, thread_id, id_norm, &mut found)?;
-    Ok(found.map(|session| session.bytes))
+    found
+        .map(|session| read_history_bytes(&session.path))
+        .transpose()
 }
 
 #[cfg(not(target_os = "linux"))]
@@ -143,8 +145,7 @@ fn find_codex_session_file_recursive(
                     &path,
                 ));
             }
-            let bytes = read_history_bytes(&path)?;
-            *found = Some(ResolvedCodexSession { path, bytes });
+            *found = Some(ResolvedCodexSession { path });
         }
     }
 
@@ -169,7 +170,9 @@ fn read_codex_session_history_impl(
         id_norm,
         &mut found,
     )?;
-    Ok(found.map(|session| session.bytes))
+    found
+        .map(|session| read_history_bytes_from_file(&session.path, session.file))
+        .transpose()
 }
 
 #[cfg(target_os = "linux")]
@@ -219,8 +222,7 @@ fn find_and_read_codex_session_file_recursive(
                     &path,
                 ));
             }
-            let bytes = read_history_bytes_from_file(&path, file)?;
-            *found = Some(ResolvedCodexSession { path, bytes });
+            *found = Some(ResolvedCodexSession { path, file });
         }
     }
 
@@ -229,7 +231,8 @@ fn find_and_read_codex_session_file_recursive(
 
 struct ResolvedCodexSession {
     path: PathBuf,
-    bytes: Vec<u8>,
+    #[cfg(target_os = "linux")]
+    file: File,
 }
 
 fn duplicate_codex_session_error(

--- a/crates/guest-agent/src/session_history.rs
+++ b/crates/guest-agent/src/session_history.rs
@@ -231,11 +231,10 @@ fn find_and_read_codex_session_file_recursive(
                 Err(e) if should_skip_unusable_codex_entry(&e) => continue,
                 Err(e) => return Err(read_history_error(&path, e)),
             };
-            if !file
+            let metadata = file
                 .metadata()
-                .ok()
-                .is_some_and(|metadata| metadata.file_type().is_file())
-            {
+                .map_err(|err| read_history_error(&path, err))?;
+            if !metadata.file_type().is_file() {
                 continue;
             }
             if let Some(existing) = found.as_ref() {

--- a/crates/guest-agent/src/session_history.rs
+++ b/crates/guest-agent/src/session_history.rs
@@ -79,7 +79,7 @@ fn read_codex_session_history(
     let Some(id_norm) = normalize_codex_thread_id(thread_id) else {
         return Ok(None);
     };
-    read_codex_session_history_impl(sessions_dir, &id_norm)
+    read_codex_session_history_impl(sessions_dir, thread_id, &id_norm)
 }
 
 pub(crate) fn normalize_codex_thread_id(thread_id: &str) -> Option<String> {
@@ -93,6 +93,7 @@ pub(crate) fn normalize_codex_thread_id(thread_id: &str) -> Option<String> {
 #[cfg(not(target_os = "linux"))]
 fn read_codex_session_history_impl(
     sessions_dir: &Path,
+    thread_id: &str,
     id_norm: &str,
 ) -> Result<Option<Vec<u8>>, AgentError> {
     if !std::fs::symlink_metadata(sessions_dir)
@@ -102,20 +103,25 @@ fn read_codex_session_history_impl(
         return Ok(None);
     }
 
-    let Some(path) = find_codex_session_file_recursive(sessions_dir, id_norm) else {
-        return Ok(None);
-    };
-    read_history_bytes(&path).map(Some)
+    let mut found = None;
+    find_codex_session_file_recursive(sessions_dir, sessions_dir, thread_id, id_norm, &mut found)?;
+    Ok(found.map(|session| session.bytes))
 }
 
 #[cfg(not(target_os = "linux"))]
-/// DFS walk of `dir`, returning the first matching real file. Symlinks
+/// DFS walk of `dir`, recording a single matching real file. Symlinks
 /// are skipped because the Codex sessions tree is user-controlled
 /// filesystem state and checkpoint lookup must not follow it outside the
 /// expected history directory.
-fn find_codex_session_file_recursive(dir: &Path, id_norm: &str) -> Option<PathBuf> {
+fn find_codex_session_file_recursive(
+    root: &Path,
+    dir: &Path,
+    thread_id: &str,
+    id_norm: &str,
+    found: &mut Option<ResolvedCodexSession>,
+) -> Result<(), AgentError> {
     let Ok(entries) = std::fs::read_dir(dir) else {
-        return None;
+        return Ok(());
     };
     for entry in entries.flatten() {
         let Ok(file_type) = entry.file_type() else {
@@ -123,40 +129,60 @@ fn find_codex_session_file_recursive(dir: &Path, id_norm: &str) -> Option<PathBu
         };
         let path = entry.path();
         if file_type.is_dir() {
-            if let Some(found) = find_codex_session_file_recursive(&path, id_norm) {
-                return Some(found);
-            }
+            find_codex_session_file_recursive(root, &path, thread_id, id_norm, found)?;
         } else if file_type.is_file()
             && path
                 .file_name()
                 .is_some_and(|name| codex_session_filename_matches(name, id_norm))
         {
-            return Some(path);
+            if let Some(existing) = found.as_ref() {
+                return Err(duplicate_codex_session_error(
+                    root,
+                    thread_id,
+                    &existing.path,
+                    &path,
+                ));
+            }
+            let bytes = read_history_bytes(&path)?;
+            *found = Some(ResolvedCodexSession { path, bytes });
         }
     }
 
-    None
+    Ok(())
 }
 
 #[cfg(target_os = "linux")]
 fn read_codex_session_history_impl(
     sessions_dir: &Path,
+    thread_id: &str,
     id_norm: &str,
 ) -> Result<Option<Vec<u8>>, AgentError> {
     let Ok(root) = Dir::open(sessions_dir) else {
         return Ok(None);
     };
-    find_and_read_codex_session_file_recursive(&root, sessions_dir, id_norm)
+    let mut found = None;
+    find_and_read_codex_session_file_recursive(
+        &root,
+        sessions_dir,
+        sessions_dir,
+        thread_id,
+        id_norm,
+        &mut found,
+    )?;
+    Ok(found.map(|session| session.bytes))
 }
 
 #[cfg(target_os = "linux")]
 fn find_and_read_codex_session_file_recursive(
     dir: &Dir,
+    root_path: &Path,
     dir_path: &Path,
+    thread_id: &str,
     id_norm: &str,
-) -> Result<Option<Vec<u8>>, AgentError> {
+    found: &mut Option<ResolvedCodexSession>,
+) -> Result<(), AgentError> {
     let Ok(entries) = dir.read_dir() else {
-        return Ok(None);
+        return Ok(());
     };
 
     for entry in entries.flatten() {
@@ -169,10 +195,9 @@ fn find_and_read_codex_session_file_recursive(
             let Ok(child) = dir.open_child_dir(&name) else {
                 continue;
             };
-            if let Some(found) = find_and_read_codex_session_file_recursive(&child, &path, id_norm)?
-            {
-                return Ok(Some(found));
-            }
+            find_and_read_codex_session_file_recursive(
+                &child, root_path, &path, thread_id, id_norm, found,
+            )?;
         } else if file_type.is_file() && codex_session_filename_matches(&name, id_norm) {
             let file = match dir.open_child_file(&name) {
                 Ok(file) => file,
@@ -186,11 +211,39 @@ fn find_and_read_codex_session_file_recursive(
             {
                 continue;
             }
-            return read_history_bytes_from_file(&path, file).map(Some);
+            if let Some(existing) = found.as_ref() {
+                return Err(duplicate_codex_session_error(
+                    root_path,
+                    thread_id,
+                    &existing.path,
+                    &path,
+                ));
+            }
+            let bytes = read_history_bytes_from_file(&path, file)?;
+            *found = Some(ResolvedCodexSession { path, bytes });
         }
     }
 
-    Ok(None)
+    Ok(())
+}
+
+struct ResolvedCodexSession {
+    path: PathBuf,
+    bytes: Vec<u8>,
+}
+
+fn duplicate_codex_session_error(
+    root: &Path,
+    thread_id: &str,
+    first: &Path,
+    second: &Path,
+) -> AgentError {
+    AgentError::Checkpoint(format!(
+        "Multiple Codex session files found under {} for thread_id {thread_id}: {}, {}",
+        root.display(),
+        first.display(),
+        second.display()
+    ))
 }
 
 fn codex_session_filename_matches(name: &OsStr, id_norm: &str) -> bool {

--- a/crates/guest-agent/src/session_history.rs
+++ b/crates/guest-agent/src/session_history.rs
@@ -83,11 +83,13 @@ fn read_codex_session_history(
 }
 
 pub(crate) fn normalize_codex_thread_id(thread_id: &str) -> Option<String> {
-    let id_norm = thread_id.replace('-', "");
-    if id_norm.len() != 32 || !id_norm.bytes().all(|byte| byte.is_ascii_hexdigit()) {
-        return None;
-    }
-    Some(id_norm.to_ascii_lowercase())
+    Some(canonical_codex_thread_id(thread_id)?.replace('-', ""))
+}
+
+pub(crate) fn canonical_codex_thread_id(thread_id: &str) -> Option<String> {
+    uuid::Uuid::parse_str(thread_id)
+        .ok()
+        .map(|uuid| uuid.to_string())
 }
 
 #[cfg(not(target_os = "linux"))]

--- a/crates/guest-agent/src/session_history.rs
+++ b/crates/guest-agent/src/session_history.rs
@@ -79,6 +79,9 @@ fn read_codex_session_history(
     let Some(id_norm) = normalize_codex_thread_id(thread_id) else {
         return Ok(None);
     };
+    if !codex_sessions_parent_is_usable(sessions_dir)? {
+        return Ok(None);
+    }
     read_codex_session_history_impl(sessions_dir, thread_id, &id_norm)
 }
 
@@ -90,6 +93,20 @@ pub(crate) fn canonical_codex_thread_id(thread_id: &str) -> Option<String> {
     uuid::Uuid::parse_str(thread_id)
         .ok()
         .map(|uuid| uuid.to_string())
+}
+
+fn codex_sessions_parent_is_usable(sessions_dir: &Path) -> Result<bool, AgentError> {
+    let Some(parent) = sessions_dir.parent() else {
+        return Ok(true);
+    };
+    if parent.as_os_str().is_empty() {
+        return Ok(true);
+    }
+    match std::fs::symlink_metadata(parent) {
+        Ok(metadata) => Ok(metadata.file_type().is_dir()),
+        Err(err) if should_skip_unusable_codex_entry(&err) => Ok(false),
+        Err(err) => Err(read_history_error(parent, err)),
+    }
 }
 
 #[cfg(not(target_os = "linux"))]

--- a/crates/guest-agent/tests/codex_session_resume.rs
+++ b/crates/guest-agent/tests/codex_session_resume.rs
@@ -338,6 +338,46 @@ async fn read_session_history_rejects_duplicate_jsonl_and_zstd_matches() {
 }
 
 #[tokio::test]
+async fn read_session_history_rejects_duplicate_before_reading_corrupt_zstd() {
+    setup_env_once();
+    let _guard = TEST_MUTEX.lock().unwrap();
+    reset_session_files();
+
+    let tmp = tempfile::tempdir().unwrap();
+    let sessions_dir = tmp.path().join("sessions");
+    let thread_id = "0193abcd-ef01-7234-89ab-cdef01234567";
+    write_session_file(
+        &sessions_dir,
+        &["2026", "04", "28"],
+        &format!("{thread_id}.jsonl.zst"),
+        b"not zstd",
+    )
+    .unwrap();
+    write_session_file(
+        &sessions_dir,
+        &["2026", "04", "29"],
+        &format!("rollout-2026-04-29T11-22-37-{thread_id}.jsonl.zst"),
+        b"also not zstd",
+    )
+    .unwrap();
+
+    let path_file = tmp.path().join("path.txt");
+    let marker = format!(
+        "CODEX_SEARCH:{}:{thread_id}",
+        sessions_dir.to_string_lossy()
+    );
+    std::fs::write(&path_file, marker.as_bytes()).unwrap();
+
+    let err = guest_agent::session_history::read_session_history(path_file.to_str().unwrap())
+        .expect_err("duplicate codex sessions must fail before decoding any candidate");
+    let msg = err.to_string();
+    assert!(
+        msg.contains("Multiple Codex session files found"),
+        "expected duplicate-session error, got: {msg}"
+    );
+}
+
+#[tokio::test]
 async fn read_session_history_resolves_dash_stripped_filename() {
     // Real codex CLI prefixes filenames with `rollout-{ts}-` and the
     // concatenation strips the UUID dashes — the substring matcher must

--- a/crates/guest-agent/tests/codex_session_resume.rs
+++ b/crates/guest-agent/tests/codex_session_resume.rs
@@ -10,10 +10,9 @@
 //! process. Splitting codex coverage into a separate test binary gives
 //! it a fresh `LazyLock` state with `CLI_AGENT_TYPE=codex`.
 //!
-//! Each `#[tokio::test]` in this binary still serialises behind a
-//! `std::sync::Mutex` because they share that single set of LazyLocks
-//! and because they touch the same on-disk session-id / history-path
-//! files (run-id-scoped under `/tmp`).
+//! Each test still serialises behind a `std::sync::Mutex` because they share
+//! that single set of LazyLocks and because they touch the same on-disk
+//! session-id / history-path files (run-id-scoped under `/tmp`).
 //!
 //! # Coverage
 //!
@@ -26,8 +25,6 @@
 //!   history-path file.
 //! - Negative path: a codex marker pointing at an empty sessions dir
 //!   surfaces the "file not found" error rather than a silent fallback.
-
-#![allow(clippy::await_holding_lock)]
 
 use serde_json::json;
 use std::path::Path;
@@ -71,6 +68,18 @@ macro_rules! http_client {
     };
 }
 
+fn send_event_for_test(
+    event: serde_json::Value,
+    seq: u32,
+    masker: &SecretMasker,
+) -> Result<(), guest_agent::error::AgentError> {
+    let runtime = tokio::runtime::Builder::new_current_thread()
+        .enable_all()
+        .build()?;
+    let http = http_client!();
+    runtime.block_on(guest_agent::events::send_event(&http, event, seq, masker))
+}
+
 /// Wipe the per-run session-id / history-path files so each test starts
 /// from a clean slate. `capture_session_metadata` is idempotent (first id wins),
 /// so leaving stale files would mask real failures.
@@ -100,8 +109,8 @@ fn write_session_file(
     Ok(())
 }
 
-#[tokio::test]
-async fn send_event_extracts_codex_thread_id_and_writes_marker() {
+#[test]
+fn send_event_extracts_codex_thread_id_and_writes_marker() {
     setup_env_once();
     let _guard = TEST_MUTEX.lock().unwrap();
     reset_session_files();
@@ -114,7 +123,7 @@ async fn send_event_extracts_codex_thread_id_and_writes_marker() {
 
     // No API token → send_event skips the HTTP POST but still captures
     // session metadata, which is the part we want to assert.
-    let result = guest_agent::events::send_event(&http_client!(), event, 1, &masker).await;
+    let result = send_event_for_test(event, 1, &masker);
     assert!(
         result.is_ok(),
         "send_event should succeed when no API token"
@@ -140,8 +149,8 @@ async fn send_event_extracts_codex_thread_id_and_writes_marker() {
     );
 }
 
-#[tokio::test]
-async fn send_event_canonicalizes_codex_thread_id_before_writing_marker() {
+#[test]
+fn send_event_canonicalizes_codex_thread_id_before_writing_marker() {
     setup_env_once();
     let _guard = TEST_MUTEX.lock().unwrap();
     reset_session_files();
@@ -153,7 +162,7 @@ async fn send_event_canonicalizes_codex_thread_id_before_writing_marker() {
     });
     let expected = "0193abcd-ef01-7234-89ab-cdef01234567";
 
-    let result = guest_agent::events::send_event(&http_client!(), event, 1, &masker).await;
+    let result = send_event_for_test(event, 1, &masker);
     assert!(
         result.is_ok(),
         "send_event should succeed when no API token"
@@ -171,8 +180,8 @@ async fn send_event_canonicalizes_codex_thread_id_before_writing_marker() {
     );
 }
 
-#[tokio::test]
-async fn send_event_repairs_missing_codex_history_marker_after_later_event() {
+#[test]
+fn send_event_repairs_missing_codex_history_marker_after_later_event() {
     setup_env_once();
     let _guard = TEST_MUTEX.lock().unwrap();
 
@@ -194,7 +203,7 @@ async fn send_event_repairs_missing_codex_history_marker_after_later_event() {
         let masker = SecretMasker::from_raw("");
         let event = json!({"type": "turn.completed"});
 
-        let result = guest_agent::events::send_event(&http_client!(), event, 1, &masker).await;
+        let result = send_event_for_test(event, 1, &masker);
         assert!(result.is_ok());
 
         let stored_id = std::fs::read_to_string(guest_agent::paths::session_id_file())
@@ -209,15 +218,15 @@ async fn send_event_repairs_missing_codex_history_marker_after_later_event() {
     }
 }
 
-#[tokio::test]
-async fn send_event_codex_ignores_non_thread_started_event() {
+#[test]
+fn send_event_codex_ignores_non_thread_started_event() {
     setup_env_once();
     let _guard = TEST_MUTEX.lock().unwrap();
     reset_session_files();
 
     let masker = SecretMasker::from_raw("");
     let event = json!({"type": "turn.completed"});
-    let result = guest_agent::events::send_event(&http_client!(), event, 1, &masker).await;
+    let result = send_event_for_test(event, 1, &masker);
     assert!(result.is_ok());
 
     assert!(
@@ -226,15 +235,15 @@ async fn send_event_codex_ignores_non_thread_started_event() {
     );
 }
 
-#[tokio::test]
-async fn send_event_codex_ignores_empty_thread_id() {
+#[test]
+fn send_event_codex_ignores_empty_thread_id() {
     setup_env_once();
     let _guard = TEST_MUTEX.lock().unwrap();
     reset_session_files();
 
     let masker = SecretMasker::from_raw("");
     let event = json!({"type": "thread.started", "thread_id": ""});
-    let result = guest_agent::events::send_event(&http_client!(), event, 1, &masker).await;
+    let result = send_event_for_test(event, 1, &masker);
     assert!(result.is_ok());
 
     assert!(
@@ -243,8 +252,8 @@ async fn send_event_codex_ignores_empty_thread_id() {
     );
 }
 
-#[tokio::test]
-async fn send_event_codex_ignores_malformed_thread_id() {
+#[test]
+fn send_event_codex_ignores_malformed_thread_id() {
     setup_env_once();
     let _guard = TEST_MUTEX.lock().unwrap();
 
@@ -253,7 +262,7 @@ async fn send_event_codex_ignores_malformed_thread_id() {
 
         let masker = SecretMasker::from_raw("");
         let event = json!({"type": "thread.started", "thread_id": thread_id});
-        let result = guest_agent::events::send_event(&http_client!(), event, 1, &masker).await;
+        let result = send_event_for_test(event, 1, &masker);
         assert!(result.is_ok());
 
         assert!(
@@ -263,8 +272,8 @@ async fn send_event_codex_ignores_malformed_thread_id() {
     }
 }
 
-#[tokio::test]
-async fn read_session_history_resolves_codex_marker_end_to_end() {
+#[test]
+fn read_session_history_resolves_codex_marker_end_to_end() {
     setup_env_once();
     let _guard = TEST_MUTEX.lock().unwrap();
     reset_session_files();
@@ -297,8 +306,8 @@ async fn read_session_history_resolves_codex_marker_end_to_end() {
     assert_eq!(bytes, history);
 }
 
-#[tokio::test]
-async fn read_session_history_decodes_legacy_zstd_session() {
+#[test]
+fn read_session_history_decodes_legacy_zstd_session() {
     setup_env_once();
     let _guard = TEST_MUTEX.lock().unwrap();
     reset_session_files();
@@ -328,8 +337,8 @@ async fn read_session_history_decodes_legacy_zstd_session() {
     assert_eq!(bytes, history);
 }
 
-#[tokio::test]
-async fn read_session_history_rejects_duplicate_codex_matches() {
+#[test]
+fn read_session_history_rejects_duplicate_codex_matches() {
     setup_env_once();
     let _guard = TEST_MUTEX.lock().unwrap();
     reset_session_files();
@@ -368,8 +377,8 @@ async fn read_session_history_rejects_duplicate_codex_matches() {
     );
 }
 
-#[tokio::test]
-async fn read_session_history_rejects_duplicate_jsonl_and_zstd_matches() {
+#[test]
+fn read_session_history_rejects_duplicate_jsonl_and_zstd_matches() {
     setup_env_once();
     let _guard = TEST_MUTEX.lock().unwrap();
     reset_session_files();
@@ -409,8 +418,8 @@ async fn read_session_history_rejects_duplicate_jsonl_and_zstd_matches() {
     );
 }
 
-#[tokio::test]
-async fn read_session_history_rejects_duplicate_before_reading_corrupt_zstd() {
+#[test]
+fn read_session_history_rejects_duplicate_before_reading_corrupt_zstd() {
     setup_env_once();
     let _guard = TEST_MUTEX.lock().unwrap();
     reset_session_files();
@@ -449,8 +458,8 @@ async fn read_session_history_rejects_duplicate_before_reading_corrupt_zstd() {
     );
 }
 
-#[tokio::test]
-async fn read_session_history_resolves_dash_stripped_filename() {
+#[test]
+fn read_session_history_resolves_dash_stripped_filename() {
     // Real codex CLI prefixes filenames with `rollout-{ts}-` and the
     // concatenation strips the UUID dashes — the substring matcher must
     // handle that. Bug-prone enough to deserve its own integration case.
@@ -483,8 +492,8 @@ async fn read_session_history_resolves_dash_stripped_filename() {
     assert_eq!(bytes, history);
 }
 
-#[tokio::test]
-async fn read_session_history_codex_marker_with_no_match_fails_fast() {
+#[test]
+fn read_session_history_codex_marker_with_no_match_fails_fast() {
     // Verifies the post-fix behaviour (#11430 review feedback): when no
     // filename matches the dash-stripped UUID, return a "not found"
     // error instead of silently picking some unrelated recent file.
@@ -521,8 +530,8 @@ async fn read_session_history_codex_marker_with_no_match_fails_fast() {
     );
 }
 
-#[tokio::test]
-async fn read_session_history_codex_marker_rejects_dash_only_thread_id() {
+#[test]
+fn read_session_history_codex_marker_rejects_dash_only_thread_id() {
     setup_env_once();
     let _guard = TEST_MUTEX.lock().unwrap();
     reset_session_files();
@@ -550,8 +559,8 @@ async fn read_session_history_codex_marker_rejects_dash_only_thread_id() {
     );
 }
 
-#[tokio::test]
-async fn read_session_history_codex_marker_rejects_short_thread_id() {
+#[test]
+fn read_session_history_codex_marker_rejects_short_thread_id() {
     setup_env_once();
     let _guard = TEST_MUTEX.lock().unwrap();
     reset_session_files();
@@ -580,8 +589,8 @@ async fn read_session_history_codex_marker_rejects_short_thread_id() {
 }
 
 #[cfg(unix)]
-#[tokio::test]
-async fn read_session_history_codex_marker_skips_symlinks() {
+#[test]
+fn read_session_history_codex_marker_skips_symlinks() {
     use std::os::unix::fs::symlink;
 
     setup_env_once();
@@ -627,8 +636,8 @@ async fn read_session_history_codex_marker_skips_symlinks() {
 }
 
 #[cfg(unix)]
-#[tokio::test]
-async fn read_session_history_codex_marker_rejects_symlinked_sessions_root() {
+#[test]
+fn read_session_history_codex_marker_rejects_symlinked_sessions_root() {
     use std::os::unix::fs::symlink;
 
     setup_env_once();
@@ -665,8 +674,8 @@ async fn read_session_history_codex_marker_rejects_symlinked_sessions_root() {
 }
 
 #[cfg(unix)]
-#[tokio::test]
-async fn read_session_history_codex_marker_rejects_symlinked_codex_home_parent() {
+#[test]
+fn read_session_history_codex_marker_rejects_symlinked_codex_home_parent() {
     use std::os::unix::fs::symlink;
 
     setup_env_once();
@@ -704,8 +713,8 @@ async fn read_session_history_codex_marker_rejects_symlinked_codex_home_parent()
 }
 
 #[cfg(unix)]
-#[tokio::test]
-async fn read_session_history_codex_marker_skips_special_files() {
+#[test]
+fn read_session_history_codex_marker_skips_special_files() {
     use std::os::unix::net::UnixListener;
 
     setup_env_once();
@@ -736,8 +745,8 @@ async fn read_session_history_codex_marker_skips_special_files() {
 }
 
 #[cfg(unix)]
-#[tokio::test]
-async fn read_session_history_codex_marker_reports_unreadable_directory() {
+#[test]
+fn read_session_history_codex_marker_reports_unreadable_directory() {
     use std::os::unix::fs::PermissionsExt;
 
     // SAFETY: `geteuid` only reads the current process credential.
@@ -778,8 +787,8 @@ async fn read_session_history_codex_marker_reports_unreadable_directory() {
     );
 }
 
-#[tokio::test]
-async fn read_session_history_resolves_claude_literal_path() {
+#[test]
+fn read_session_history_resolves_claude_literal_path() {
     // Claude path goes through the same public entry but uses a literal
     // jsonl path rather than a marker. Covered here because the Claude-
     // side integration test in `tests/integration/mod.rs` only asserts the

--- a/crates/guest-agent/tests/codex_session_resume.rs
+++ b/crates/guest-agent/tests/codex_session_resume.rs
@@ -628,6 +628,45 @@ async fn read_session_history_codex_marker_rejects_symlinked_sessions_root() {
 
 #[cfg(unix)]
 #[tokio::test]
+async fn read_session_history_codex_marker_rejects_symlinked_codex_home_parent() {
+    use std::os::unix::fs::symlink;
+
+    setup_env_once();
+    let _guard = TEST_MUTEX.lock().unwrap();
+    reset_session_files();
+
+    let tmp = tempfile::tempdir().unwrap();
+    let real_codex_home = tmp.path().join("real-codex-home");
+    let codex_home_link = tmp.path().join(".codex");
+    let real_sessions_dir = real_codex_home.join("sessions");
+    std::fs::create_dir_all(&real_sessions_dir).unwrap();
+
+    let thread_id = "0193abcd-ef01-7234-89ab-cdef01234567";
+    std::fs::write(
+        real_sessions_dir.join(format!("{thread_id}.jsonl")),
+        b"outside-parent-history\n",
+    )
+    .unwrap();
+    symlink(&real_codex_home, &codex_home_link).unwrap();
+
+    let path_file = tmp.path().join("path.txt");
+    let marker = format!(
+        "CODEX_SEARCH:{}:{thread_id}",
+        codex_home_link.join("sessions").to_string_lossy()
+    );
+    std::fs::write(&path_file, marker.as_bytes()).unwrap();
+
+    let err = guest_agent::session_history::read_session_history(path_file.to_str().unwrap())
+        .expect_err("codex lookup must not follow a symlinked codex home parent");
+    let msg = err.to_string();
+    assert!(
+        msg.contains("Codex session file not found"),
+        "expected symlinked codex home parent to be ignored, got: {msg}"
+    );
+}
+
+#[cfg(unix)]
+#[tokio::test]
 async fn read_session_history_codex_marker_skips_special_files() {
     use std::os::unix::net::UnixListener;
 

--- a/crates/guest-agent/tests/codex_session_resume.rs
+++ b/crates/guest-agent/tests/codex_session_resume.rs
@@ -658,6 +658,49 @@ async fn read_session_history_codex_marker_skips_special_files() {
     );
 }
 
+#[cfg(unix)]
+#[tokio::test]
+async fn read_session_history_codex_marker_reports_unreadable_directory() {
+    use std::os::unix::fs::PermissionsExt;
+
+    // SAFETY: `geteuid` only reads the current process credential.
+    if unsafe { libc::geteuid() } == 0 {
+        return;
+    }
+
+    setup_env_once();
+    let _guard = TEST_MUTEX.lock().unwrap();
+    reset_session_files();
+
+    let tmp = tempfile::tempdir().unwrap();
+    let sessions_dir = tmp.path().join("sessions");
+    let blocked_dir = sessions_dir.join("blocked");
+    std::fs::create_dir_all(&blocked_dir).unwrap();
+    std::fs::set_permissions(&blocked_dir, std::fs::Permissions::from_mode(0o000)).unwrap();
+
+    let thread_id = "0193abcd-ef01-7234-89ab-cdef01234567";
+    let path_file = tmp.path().join("path.txt");
+    let marker = format!(
+        "CODEX_SEARCH:{}:{thread_id}",
+        sessions_dir.to_string_lossy()
+    );
+    std::fs::write(&path_file, marker.as_bytes()).unwrap();
+
+    let result = guest_agent::session_history::read_session_history(path_file.to_str().unwrap());
+    std::fs::set_permissions(&blocked_dir, std::fs::Permissions::from_mode(0o700)).unwrap();
+
+    let err = result.expect_err("unreadable codex directories must surface as read errors");
+    let msg = err.to_string();
+    assert!(
+        msg.contains("Failed to read session history"),
+        "expected directory read error, got: {msg}"
+    );
+    assert!(
+        msg.contains("Permission denied"),
+        "expected permission failure to be preserved, got: {msg}"
+    );
+}
+
 #[tokio::test]
 async fn read_session_history_resolves_claude_literal_path() {
     // Claude path goes through the same public entry but uses a literal

--- a/crates/guest-agent/tests/codex_session_resume.rs
+++ b/crates/guest-agent/tests/codex_session_resume.rs
@@ -141,6 +141,37 @@ async fn send_event_extracts_codex_thread_id_and_writes_marker() {
 }
 
 #[tokio::test]
+async fn send_event_canonicalizes_codex_thread_id_before_writing_marker() {
+    setup_env_once();
+    let _guard = TEST_MUTEX.lock().unwrap();
+    reset_session_files();
+
+    let masker = SecretMasker::from_raw("");
+    let event = json!({
+        "type": "thread.started",
+        "thread_id": "0193ABCDEF01723489ABCDEF01234567"
+    });
+    let expected = "0193abcd-ef01-7234-89ab-cdef01234567";
+
+    let result = guest_agent::events::send_event(&http_client!(), event, 1, &masker).await;
+    assert!(
+        result.is_ok(),
+        "send_event should succeed when no API token"
+    );
+
+    let stored_id =
+        std::fs::read_to_string(guest_agent::paths::session_id_file()).expect("session id written");
+    assert_eq!(stored_id, expected);
+
+    let marker = std::fs::read_to_string(guest_agent::paths::session_history_path_file())
+        .expect("history-path file written");
+    assert!(
+        marker.ends_with(&format!(":{expected}")),
+        "marker should use canonical thread id, got: {marker}"
+    );
+}
+
+#[tokio::test]
 async fn send_event_codex_ignores_non_thread_started_event() {
     setup_env_once();
     let _guard = TEST_MUTEX.lock().unwrap();
@@ -178,17 +209,20 @@ async fn send_event_codex_ignores_empty_thread_id() {
 async fn send_event_codex_ignores_malformed_thread_id() {
     setup_env_once();
     let _guard = TEST_MUTEX.lock().unwrap();
-    reset_session_files();
 
-    let masker = SecretMasker::from_raw("");
-    let event = json!({"type": "thread.started", "thread_id": "abc"});
-    let result = guest_agent::events::send_event(&http_client!(), event, 1, &masker).await;
-    assert!(result.is_ok());
+    for thread_id in ["abc", "0193-abcd-ef01-7234-89abcdef01234567"] {
+        reset_session_files();
 
-    assert!(
-        !Path::new(guest_agent::paths::session_id_file()).exists(),
-        "malformed thread_id must not be persisted"
-    );
+        let masker = SecretMasker::from_raw("");
+        let event = json!({"type": "thread.started", "thread_id": thread_id});
+        let result = guest_agent::events::send_event(&http_client!(), event, 1, &masker).await;
+        assert!(result.is_ok());
+
+        assert!(
+            !Path::new(guest_agent::paths::session_id_file()).exists(),
+            "malformed thread_id must not be persisted: {thread_id}"
+        );
+    }
 }
 
 #[tokio::test]

--- a/crates/guest-agent/tests/codex_session_resume.rs
+++ b/crates/guest-agent/tests/codex_session_resume.rs
@@ -172,37 +172,41 @@ async fn send_event_canonicalizes_codex_thread_id_before_writing_marker() {
 }
 
 #[tokio::test]
-async fn send_event_repairs_missing_codex_history_marker_for_existing_session() {
+async fn send_event_repairs_missing_codex_history_marker_after_later_event() {
     setup_env_once();
     let _guard = TEST_MUTEX.lock().unwrap();
-    reset_session_files();
 
     let thread_id = "0193abcd-ef01-7234-89ab-cdef01234567";
-    guest_agent::paths::write_private(guest_agent::paths::session_id_file(), thread_id)
-        .expect("seed existing session id");
-    assert!(
-        !Path::new(guest_agent::paths::session_history_path_file()).exists(),
-        "history marker should start missing"
-    );
+    for seed_empty_marker in [false, true] {
+        reset_session_files();
+        guest_agent::paths::write_private(guest_agent::paths::session_id_file(), thread_id)
+            .expect("seed existing session id");
+        if seed_empty_marker {
+            guest_agent::paths::write_private(guest_agent::paths::session_history_path_file(), "")
+                .expect("seed empty history marker");
+        } else {
+            assert!(
+                !Path::new(guest_agent::paths::session_history_path_file()).exists(),
+                "history marker should start missing"
+            );
+        }
 
-    let masker = SecretMasker::from_raw("");
-    let event = json!({
-        "type": "thread.started",
-        "thread_id": thread_id
-    });
+        let masker = SecretMasker::from_raw("");
+        let event = json!({"type": "turn.completed"});
 
-    let result = guest_agent::events::send_event(&http_client!(), event, 1, &masker).await;
-    assert!(result.is_ok());
+        let result = guest_agent::events::send_event(&http_client!(), event, 1, &masker).await;
+        assert!(result.is_ok());
 
-    let stored_id =
-        std::fs::read_to_string(guest_agent::paths::session_id_file()).expect("session id kept");
-    assert_eq!(stored_id, thread_id);
-    let marker = std::fs::read_to_string(guest_agent::paths::session_history_path_file())
-        .expect("history marker repaired");
-    assert!(
-        marker.ends_with(&format!(":{thread_id}")),
-        "repaired marker should point at the existing thread id, got: {marker}"
-    );
+        let stored_id = std::fs::read_to_string(guest_agent::paths::session_id_file())
+            .expect("session id kept");
+        assert_eq!(stored_id, thread_id);
+        let marker = std::fs::read_to_string(guest_agent::paths::session_history_path_file())
+            .expect("history marker repaired");
+        assert!(
+            marker.ends_with(&format!(":{thread_id}")),
+            "repaired marker should point at the existing thread id, got: {marker}"
+        );
+    }
 }
 
 #[tokio::test]

--- a/crates/guest-agent/tests/codex_session_resume.rs
+++ b/crates/guest-agent/tests/codex_session_resume.rs
@@ -257,6 +257,87 @@ async fn read_session_history_decodes_legacy_zstd_session() {
 }
 
 #[tokio::test]
+async fn read_session_history_rejects_duplicate_codex_matches() {
+    setup_env_once();
+    let _guard = TEST_MUTEX.lock().unwrap();
+    reset_session_files();
+
+    let tmp = tempfile::tempdir().unwrap();
+    let sessions_dir = tmp.path().join("sessions");
+    let thread_id = "0193abcd-ef01-7234-89ab-cdef01234567";
+    write_session_file(
+        &sessions_dir,
+        &["2026", "04", "28"],
+        &format!("{thread_id}.jsonl"),
+        b"first\n",
+    )
+    .unwrap();
+    write_session_file(
+        &sessions_dir,
+        &["2026", "04", "29"],
+        &format!("rollout-2026-04-29T11-22-37-{thread_id}.jsonl"),
+        b"second\n",
+    )
+    .unwrap();
+
+    let path_file = tmp.path().join("path.txt");
+    let marker = format!(
+        "CODEX_SEARCH:{}:{thread_id}",
+        sessions_dir.to_string_lossy()
+    );
+    std::fs::write(&path_file, marker.as_bytes()).unwrap();
+
+    let err = guest_agent::session_history::read_session_history(path_file.to_str().unwrap())
+        .expect_err("duplicate codex sessions must fail clearly");
+    let msg = err.to_string();
+    assert!(
+        msg.contains("Multiple Codex session files found"),
+        "expected duplicate-session error, got: {msg}"
+    );
+}
+
+#[tokio::test]
+async fn read_session_history_rejects_duplicate_jsonl_and_zstd_matches() {
+    setup_env_once();
+    let _guard = TEST_MUTEX.lock().unwrap();
+    reset_session_files();
+
+    let tmp = tempfile::tempdir().unwrap();
+    let sessions_dir = tmp.path().join("sessions");
+    let thread_id = "0193abcd-ef01-7234-89ab-cdef01234567";
+    write_session_file(
+        &sessions_dir,
+        &["2026", "04", "28"],
+        &format!("{thread_id}.jsonl"),
+        b"jsonl\n",
+    )
+    .unwrap();
+    let compressed = zstd::encode_all(b"zstd\n".as_slice(), 0).unwrap();
+    write_session_file(
+        &sessions_dir,
+        &["2026", "04", "29"],
+        &format!("{thread_id}.jsonl.zst"),
+        &compressed,
+    )
+    .unwrap();
+
+    let path_file = tmp.path().join("path.txt");
+    let marker = format!(
+        "CODEX_SEARCH:{}:{thread_id}",
+        sessions_dir.to_string_lossy()
+    );
+    std::fs::write(&path_file, marker.as_bytes()).unwrap();
+
+    let err = guest_agent::session_history::read_session_history(path_file.to_str().unwrap())
+        .expect_err("duplicate codex sessions must include zstd matches");
+    let msg = err.to_string();
+    assert!(
+        msg.contains("Multiple Codex session files found"),
+        "expected duplicate-session error, got: {msg}"
+    );
+}
+
+#[tokio::test]
 async fn read_session_history_resolves_dash_stripped_filename() {
     // Real codex CLI prefixes filenames with `rollout-{ts}-` and the
     // concatenation strips the UUID dashes — the substring matcher must

--- a/crates/guest-agent/tests/codex_session_resume.rs
+++ b/crates/guest-agent/tests/codex_session_resume.rs
@@ -172,6 +172,40 @@ async fn send_event_canonicalizes_codex_thread_id_before_writing_marker() {
 }
 
 #[tokio::test]
+async fn send_event_repairs_missing_codex_history_marker_for_existing_session() {
+    setup_env_once();
+    let _guard = TEST_MUTEX.lock().unwrap();
+    reset_session_files();
+
+    let thread_id = "0193abcd-ef01-7234-89ab-cdef01234567";
+    guest_agent::paths::write_private(guest_agent::paths::session_id_file(), thread_id)
+        .expect("seed existing session id");
+    assert!(
+        !Path::new(guest_agent::paths::session_history_path_file()).exists(),
+        "history marker should start missing"
+    );
+
+    let masker = SecretMasker::from_raw("");
+    let event = json!({
+        "type": "thread.started",
+        "thread_id": thread_id
+    });
+
+    let result = guest_agent::events::send_event(&http_client!(), event, 1, &masker).await;
+    assert!(result.is_ok());
+
+    let stored_id =
+        std::fs::read_to_string(guest_agent::paths::session_id_file()).expect("session id kept");
+    assert_eq!(stored_id, thread_id);
+    let marker = std::fs::read_to_string(guest_agent::paths::session_history_path_file())
+        .expect("history marker repaired");
+    assert!(
+        marker.ends_with(&format!(":{thread_id}")),
+        "repaired marker should point at the existing thread id, got: {marker}"
+    );
+}
+
+#[tokio::test]
 async fn send_event_codex_ignores_non_thread_started_event() {
     setup_env_once();
     let _guard = TEST_MUTEX.lock().unwrap();

--- a/crates/guest-agent/tests/integration/events.rs
+++ b/crates/guest-agent/tests/integration/events.rs
@@ -209,6 +209,55 @@ async fn send_event_keeps_existing_session_metadata() {
     mock.delete_async().await;
 }
 
+#[tokio::test]
+async fn send_event_repairs_missing_claude_history_marker_after_later_event() {
+    let _guard = TEST_MUTEX.lock().unwrap();
+    let server = &*MOCK_SERVER;
+    let _session_files = SessionCheckpointFilesGuard::new();
+
+    let sid_file = guest_agent::paths::session_id_file();
+    let hist_file = guest_agent::paths::session_history_path_file();
+    let session_id = "session-repair";
+
+    let mock = server.mock(|when, then| {
+        when.method(POST).path("/api/webhooks/agent/events");
+        then.status(200);
+    });
+
+    for seed_empty_marker in [false, true] {
+        let _ = std::fs::remove_file(sid_file);
+        let _ = std::fs::remove_file(hist_file);
+        guest_agent::paths::write_private(sid_file, session_id).unwrap();
+        if seed_empty_marker {
+            guest_agent::paths::write_private(hist_file, "").unwrap();
+        } else {
+            assert!(
+                !std::path::Path::new(hist_file).exists(),
+                "history marker should start missing"
+            );
+        }
+
+        let masker = SecretMasker::from_raw("");
+        let event = json!({"type": "assistant", "data": "later"});
+        let result = guest_agent::events::send_event(&http_client!(), event, 1, &masker).await;
+
+        assert!(result.is_ok());
+        assert_eq!(
+            std::fs::read_to_string(sid_file).unwrap(),
+            session_id,
+            "later events must keep the existing session id"
+        );
+        let history = std::fs::read_to_string(hist_file).unwrap();
+        assert!(
+            history.ends_with(&format!("/{session_id}.jsonl")),
+            "repaired history marker should point at the existing session id, got: {history}"
+        );
+    }
+
+    mock.assert_calls_async(2).await;
+    mock.delete_async().await;
+}
+
 // =========================================================================
 // Session ID extraction
 // =========================================================================

--- a/crates/guest-agent/tests/integration/events.rs
+++ b/crates/guest-agent/tests/integration/events.rs
@@ -312,6 +312,48 @@ async fn send_event_extracts_claude_session_id() {
 }
 
 #[tokio::test]
+async fn send_event_rejects_unsafe_claude_session_id() {
+    let _guard = TEST_MUTEX.lock().unwrap();
+    let server = &*MOCK_SERVER;
+    let _session_files = SessionCheckpointFilesGuard::new();
+
+    let sid_file = guest_agent::paths::session_id_file();
+    let hist_file = guest_agent::paths::session_history_path_file();
+    let invalid_session_ids = ["../escape", "nested/id", "nested\\id", ".", "..", "bad\nid"];
+
+    let mock = server.mock(|when, then| {
+        when.method(POST).path("/api/webhooks/agent/events");
+        then.status(200);
+    });
+
+    for session_id in invalid_session_ids {
+        let _ = std::fs::remove_file(sid_file);
+        let _ = std::fs::remove_file(hist_file);
+
+        let masker = SecretMasker::from_raw("");
+        let event = json!({
+            "type": "system",
+            "subtype": "init",
+            "session_id": session_id
+        });
+        let result = guest_agent::events::send_event(&http_client!(), event, 1, &masker).await;
+
+        assert!(result.is_ok());
+        assert!(
+            !std::path::Path::new(sid_file).exists(),
+            "unsafe session_id must not be persisted: {session_id:?}"
+        );
+        assert!(
+            !std::path::Path::new(hist_file).exists(),
+            "unsafe session_id must not write a history marker: {session_id:?}"
+        );
+    }
+
+    mock.assert_calls_async(invalid_session_ids.len()).await;
+    mock.delete_async().await;
+}
+
+#[tokio::test]
 async fn send_event_skips_session_id_for_non_init() {
     let _guard = TEST_MUTEX.lock().unwrap();
     let server = &*MOCK_SERVER;

--- a/crates/guest-mock-codex/src/fixtures.rs
+++ b/crates/guest-mock-codex/src/fixtures.rs
@@ -2,10 +2,7 @@ use chrono::Utc;
 use serde_json::Value;
 use std::io;
 
-use crate::session::{
-    build_session_path, codex_home, emit_events, ensure_runtime_session_path_usable,
-    write_session_file,
-};
+use crate::session::{codex_home, emit_events, persist_new_session};
 
 /// Embedded JSONL fixtures selectable via `MOCK_CODEX_FIXTURE=<name>`.
 ///
@@ -34,8 +31,8 @@ pub fn lookup_fixture(name: &str) -> Option<&'static str> {
 }
 
 /// Run a fixture: parse JSONL, extract thread id from `thread.started`,
-/// emit events to stdout, and persist the session file under `$CODEX_HOME`
-/// so checkpoint reads see the same content the CLI saw.
+/// persist the session file under `$CODEX_HOME`, and then emit the same
+/// events to stdout so checkpoint reads see the same content the CLI saw.
 pub fn run_fixture(content: &str) -> io::Result<()> {
     let events = parse_fixture_events(content)?;
     let thread_id = extract_thread_id(&events).ok_or_else(|| {
@@ -45,13 +42,10 @@ pub fn run_fixture(content: &str) -> io::Result<()> {
         )
     })?;
     let home = codex_home();
-    let path = build_session_path(&home, Utc::now().date_naive(), &thread_id)?;
-    ensure_runtime_session_path_usable(&home, &path)?;
+    persist_new_session(&home, Utc::now().date_naive(), &thread_id, &events)?;
 
     let mut stdout = io::stdout().lock();
-    emit_events(&mut stdout, &events)?;
-
-    write_session_file(&path, &events)
+    emit_events(&mut stdout, &events)
 }
 
 /// Parse JSONL fixture content into a vector of `Value`. Empty lines

--- a/crates/guest-mock-codex/src/lib.rs
+++ b/crates/guest-mock-codex/src/lib.rs
@@ -32,25 +32,19 @@ pub fn run_resume(thread_id: &str, prompt: &str) -> io::Result<()> {
     run_turn(thread_id, prompt, true)
 }
 
-/// Emit the three-event synthetic turn on stdout, then persist or append it
+/// Persist the three-event synthetic turn, then emit it on stdout
 /// under `$CODEX_HOME`.
 fn run_turn(thread_id: &str, prompt: &str, is_resume: bool) -> io::Result<()> {
     let home = codex_home();
     let today = Utc::now().date_naive();
-    let path = if is_resume {
-        session::build_resume_session_path(&home, today, thread_id)?
-    } else {
-        build_session_path(&home, today, thread_id)?
-    };
-    session::ensure_runtime_session_path_usable(&home, &path)?;
     let events = build_events(thread_id, prompt);
 
-    let mut stdout = io::stdout().lock();
-    emit_events(&mut stdout, &events)?;
-
     if is_resume {
-        append_session_file(&path, &events)
+        session::persist_resume_session(&home, today, thread_id, &events)?;
     } else {
-        write_session_file(&path, &events)
+        session::persist_new_session(&home, today, thread_id, &events)?;
     }
+
+    let mut stdout = io::stdout().lock();
+    emit_events(&mut stdout, &events)
 }

--- a/crates/guest-mock-codex/src/lib.rs
+++ b/crates/guest-mock-codex/src/lib.rs
@@ -1,8 +1,11 @@
 //! Reusable mock Codex contract used by the `guest-mock-codex` binary and tests.
 //!
 //! The mock emits Codex `exec --json` protocol events on stdout and persists a
-//! JSONL session file using the same layout as the real Codex CLI:
+//! JSONL session file under Codex's date-partitioned session tree:
 //! `$CODEX_HOME/sessions/YYYY/MM/DD/<thread_id>.jsonl`.
+//!
+//! Resume can also append to runner-restored rollout filenames, matching the
+//! real Codex CLI's filesystem resume candidates.
 
 use chrono::Utc;
 use std::io;

--- a/crates/guest-mock-codex/src/main.rs
+++ b/crates/guest-mock-codex/src/main.rs
@@ -1,8 +1,11 @@
 //! Mock Codex CLI for testing.
 //!
 //! Emits Codex `exec --json` protocol events on stdout and persists a JSONL
-//! session file at the same path layout the real Codex CLI uses
+//! session file under Codex's date-partitioned session tree
 //! (`$CODEX_HOME/sessions/YYYY/MM/DD/<thread_id>.jsonl`).
+//!
+//! Resume can also append to runner-restored rollout filenames, matching the
+//! real Codex CLI's filesystem resume candidates.
 //!
 //! Activated in guest VMs via `USE_MOCK_CODEX=true` (handled by guest-agent).
 //! This binary itself runs whenever it's invoked — the env-var dispatch lives

--- a/crates/guest-mock-codex/src/session.rs
+++ b/crates/guest-mock-codex/src/session.rs
@@ -2,13 +2,15 @@ use chrono::NaiveDate;
 use serde_json::Value;
 use std::ffi::{OsStr, OsString};
 use std::fs;
-use std::io::{self, Read, Write};
+use std::io::{self, Write};
 use std::path::{Path, PathBuf};
 use std::sync::atomic::{AtomicU64, Ordering};
 use uuid::Uuid;
 
 #[cfg(unix)]
 use std::ffi::CString;
+#[cfg(unix)]
+use std::io::Read;
 #[cfg(unix)]
 use std::os::fd::{AsRawFd, FromRawFd};
 #[cfg(unix)]

--- a/crates/guest-mock-codex/src/session.rs
+++ b/crates/guest-mock-codex/src/session.rs
@@ -406,7 +406,7 @@ pub fn session_artifacts(codex_home: &Path) -> io::Result<Vec<PathBuf>> {
 }
 
 fn walk_existing_root(dir: &Path, f: &mut dyn FnMut(&Path)) -> io::Result<()> {
-    walk_entries(fs::read_dir(dir)?, f)
+    walk(dir, f)
 }
 
 fn walk(dir: &Path, f: &mut dyn FnMut(&Path)) -> io::Result<()> {

--- a/crates/guest-mock-codex/src/session.rs
+++ b/crates/guest-mock-codex/src/session.rs
@@ -1,10 +1,22 @@
 use chrono::NaiveDate;
 use serde_json::Value;
-use std::ffi::OsStr;
+use std::ffi::{OsStr, OsString};
 use std::fs;
-use std::io::{self, Write};
+use std::io::{self, Read, Write};
 use std::path::{Path, PathBuf};
+use std::sync::atomic::{AtomicU64, Ordering};
 use uuid::Uuid;
+
+#[cfg(unix)]
+use std::ffi::CString;
+#[cfg(unix)]
+use std::os::fd::{AsRawFd, FromRawFd};
+#[cfg(unix)]
+use std::os::unix::ffi::OsStrExt;
+#[cfg(unix)]
+use std::os::unix::fs::OpenOptionsExt;
+
+static TEMP_COUNTER: AtomicU64 = AtomicU64::new(0);
 
 /// Resolve the Codex home directory, mirroring real Codex CLI precedence:
 /// `$CODEX_HOME` > `$HOME/.codex` > `/home/user/.codex`.
@@ -38,15 +50,36 @@ pub fn build_session_path(
         .join(format!("{thread_id}.jsonl")))
 }
 
-pub(crate) fn build_resume_session_path(
+pub(crate) fn persist_new_session(
     codex_home: &Path,
     today: NaiveDate,
     thread_id: &str,
-) -> io::Result<PathBuf> {
-    if let Some(path) = find_session_file_for_thread(codex_home, thread_id)? {
-        return Ok(path);
-    }
-    build_session_path(codex_home, today, thread_id)
+    events: &[Value],
+) -> io::Result<()> {
+    validate_thread_id(thread_id)?;
+    let _lock = lock_session(codex_home, thread_id)?;
+    let path = build_session_path(codex_home, today, thread_id)?;
+    let mut buf = Vec::new();
+    append_events_to_jsonl_bytes(&mut buf, events)?;
+    write_session_bytes_in_store(codex_home, &path, buf)
+}
+
+pub(crate) fn persist_resume_session(
+    codex_home: &Path,
+    today: NaiveDate,
+    thread_id: &str,
+    events: &[Value],
+) -> io::Result<()> {
+    validate_thread_id(thread_id)?;
+    let _lock = lock_session(codex_home, thread_id)?;
+    let path = if let Some(path) = find_session_file_for_thread(codex_home, thread_id)? {
+        path
+    } else {
+        build_session_path(codex_home, today, thread_id)?
+    };
+    let mut existing = read_session_bytes_for_append_in_store(codex_home, &path)?;
+    append_events_to_jsonl_bytes(&mut existing, events)?;
+    write_session_bytes_in_store(codex_home, &path, existing)
 }
 
 fn validate_thread_id(thread_id: &str) -> io::Result<()> {
@@ -84,15 +117,24 @@ fn write_session_bytes(path: &Path, buf: Vec<u8>) -> io::Result<()> {
     if let Some(parent) = path.parent() {
         fs::create_dir_all(parent)?;
     }
-    let tmp = session_temp_path(path);
-    remove_existing_session_temp_file(&tmp)?;
-    let mut file = fs::OpenOptions::new()
-        .write(true)
-        .create_new(true)
-        .open(&tmp)?;
-    file.write_all(&buf)?;
+    ensure_final_session_file_usable(path)?;
+    let parent = path
+        .parent()
+        .ok_or_else(|| invalid_session_file_error(path))?;
+    let final_name = path
+        .file_name()
+        .ok_or_else(|| invalid_session_file_error(path))?;
+    let (tmp, mut file) = create_unique_path_temp_file(parent, final_name)?;
+    if let Err(err) = file.write_all(&buf) {
+        let _ = fs::remove_file(&tmp);
+        return Err(err);
+    }
     drop(file);
-    fs::rename(&tmp, path)
+    if let Err(err) = fs::rename(&tmp, path) {
+        let _ = fs::remove_file(&tmp);
+        return Err(err);
+    }
+    Ok(())
 }
 
 fn append_events_to_jsonl_bytes(buf: &mut Vec<u8>, events: &[Value]) -> io::Result<()> {
@@ -132,87 +174,112 @@ pub fn append_session_file(path: &Path, new_events: &[Value]) -> io::Result<()> 
 fn read_session_bytes_for_append(path: &Path) -> io::Result<Vec<u8>> {
     match path.symlink_metadata() {
         Ok(metadata) if metadata.file_type().is_file() => fs::read(path),
-        Ok(metadata) if metadata.file_type().is_symlink() => Ok(Vec::new()),
         Ok(_) => Err(invalid_session_file_error(path)),
         Err(err) if err.kind() == io::ErrorKind::NotFound => Ok(Vec::new()),
         Err(err) => Err(err),
     }
 }
 
-pub(crate) fn ensure_runtime_session_path_usable(codex_home: &Path, path: &Path) -> io::Result<()> {
-    let root = codex_home.join("sessions");
-    let Some(parent) = path.parent() else {
-        return Ok(());
+#[cfg(unix)]
+fn read_session_bytes_for_append_in_store(codex_home: &Path, path: &Path) -> io::Result<Vec<u8>> {
+    let parent = StoreDir::open_or_create_parent(codex_home, path)?;
+    let final_name = path
+        .file_name()
+        .ok_or_else(|| invalid_session_file_error(path))?;
+    let mut file = match parent.open_child_file(final_name) {
+        Ok(file) => file,
+        Err(err) if err.kind() == io::ErrorKind::NotFound => return Ok(Vec::new()),
+        Err(err) if is_filesystem_loop_error(&err) => return Err(invalid_session_file_error(path)),
+        Err(err) => return Err(err),
     };
-    let Ok(relative_parent) = parent.strip_prefix(&root) else {
-        return Ok(());
-    };
-
-    if !ensure_existing_real_session_dir(&root)? {
-        return Ok(());
+    if !file
+        .metadata()
+        .ok()
+        .is_some_and(|metadata| metadata.file_type().is_file())
+    {
+        return Err(invalid_session_file_error(path));
     }
+    let mut buf = Vec::new();
+    file.read_to_end(&mut buf)?;
+    Ok(buf)
+}
 
-    let mut current = root;
-    for component in relative_parent.components() {
-        current.push(component.as_os_str());
-        if !ensure_existing_real_session_dir(&current)? {
-            return Ok(());
-        }
+#[cfg(not(unix))]
+fn read_session_bytes_for_append_in_store(_codex_home: &Path, path: &Path) -> io::Result<Vec<u8>> {
+    read_session_bytes_for_append(path)
+}
+
+#[cfg(unix)]
+fn write_session_bytes_in_store(codex_home: &Path, path: &Path, buf: Vec<u8>) -> io::Result<()> {
+    let parent = StoreDir::open_or_create_parent(codex_home, path)?;
+    let final_name = path
+        .file_name()
+        .ok_or_else(|| invalid_session_file_error(path))?;
+    parent.ensure_child_file_usable(final_name, path)?;
+    let (tmp_name, mut file) = parent.create_unique_temp_file(final_name)?;
+    if let Err(err) = file.write_all(&buf) {
+        let _ = parent.unlink_child_file(&tmp_name);
+        return Err(err);
     }
-
-    ensure_final_session_file_usable(path)?;
-    ensure_session_temp_file_usable(&session_temp_path(path))?;
-
+    drop(file);
+    if let Err(err) = parent.rename_child(&tmp_name, final_name) {
+        let _ = parent.unlink_child_file(&tmp_name);
+        return Err(err);
+    }
     Ok(())
 }
 
-fn session_temp_path(path: &Path) -> PathBuf {
-    path.with_extension("jsonl.tmp")
+#[cfg(not(unix))]
+fn write_session_bytes_in_store(_codex_home: &Path, path: &Path, buf: Vec<u8>) -> io::Result<()> {
+    write_session_bytes(path, buf)
 }
 
 fn ensure_final_session_file_usable(path: &Path) -> io::Result<()> {
     match path.symlink_metadata() {
-        Ok(metadata) if metadata.file_type().is_file() || metadata.file_type().is_symlink() => {
-            Ok(())
-        }
+        Ok(metadata) if metadata.file_type().is_file() => Ok(()),
         Ok(_) => Err(invalid_session_file_error(path)),
         Err(err) if err.kind() == io::ErrorKind::NotFound => Ok(()),
         Err(err) => Err(err),
     }
 }
 
-fn ensure_session_temp_file_usable(path: &Path) -> io::Result<()> {
-    match path.symlink_metadata() {
-        Ok(metadata) if metadata.file_type().is_file() => Ok(()),
-        Ok(_) => Err(invalid_session_temp_file_error(path)),
-        Err(err) if err.kind() == io::ErrorKind::NotFound => Ok(()),
-        Err(err) => Err(err),
+fn create_unique_path_temp_file(
+    parent: &Path,
+    final_name: &OsStr,
+) -> io::Result<(PathBuf, fs::File)> {
+    for _ in 0..100 {
+        let tmp = parent.join(unique_session_temp_name(final_name));
+        match fs::OpenOptions::new()
+            .write(true)
+            .create_new(true)
+            .open(&tmp)
+        {
+            Ok(file) => return Ok((tmp, file)),
+            Err(err) if err.kind() == io::ErrorKind::AlreadyExists => continue,
+            Err(err) => return Err(err),
+        }
     }
+    Err(io::Error::new(
+        io::ErrorKind::AlreadyExists,
+        format!(
+            "failed to create unique session temp file in {}",
+            parent.display()
+        ),
+    ))
 }
 
-fn remove_existing_session_temp_file(path: &Path) -> io::Result<()> {
-    match path.symlink_metadata() {
-        Ok(metadata) if metadata.file_type().is_file() => fs::remove_file(path),
-        Ok(_) => Err(invalid_session_temp_file_error(path)),
-        Err(err) if err.kind() == io::ErrorKind::NotFound => Ok(()),
-        Err(err) => Err(err),
-    }
+fn unique_session_temp_name(final_name: &OsStr) -> OsString {
+    let counter = TEMP_COUNTER.fetch_add(1, Ordering::Relaxed);
+    let mut name = OsString::from(".");
+    name.push(final_name);
+    name.push(format!(".{}.{}.tmp", std::process::id(), counter));
+    name
 }
 
 fn invalid_session_file_error(path: &Path) -> io::Error {
     io::Error::new(
         io::ErrorKind::InvalidInput,
         format!("session path is not a regular file: {}", path.display()),
-    )
-}
-
-fn invalid_session_temp_file_error(path: &Path) -> io::Error {
-    io::Error::new(
-        io::ErrorKind::InvalidInput,
-        format!(
-            "session temp path is not a regular file: {}",
-            path.display()
-        ),
     )
 }
 
@@ -224,7 +291,7 @@ pub fn find_session_file(codex_home: &Path) -> io::Result<Option<PathBuf>> {
 fn find_session_file_for_thread(codex_home: &Path, thread_id: &str) -> io::Result<Option<PathBuf>> {
     validate_thread_id(thread_id)?;
     let id_norm = thread_id.replace('-', "");
-    let mut matches = session_artifacts_for_resume(codex_home)?
+    let matches = session_artifacts_for_resume(codex_home)?
         .into_iter()
         .filter(|path| {
             path.file_name()
@@ -236,7 +303,10 @@ fn find_session_file_for_thread(codex_home: &Path, thread_id: &str) -> io::Resul
             Err(err) => Some(Err(err)),
         })
         .collect::<io::Result<Vec<_>>>()?;
-    Ok(matches.pop())
+    if matches.len() > 1 {
+        return Err(ambiguous_session_files_error(thread_id, &matches));
+    }
+    Ok(matches.into_iter().next())
 }
 
 fn codex_jsonl_session_filename_matches(name: &OsStr, id_norm: &str) -> bool {
@@ -271,11 +341,23 @@ pub fn session_files(codex_home: &Path) -> io::Result<Vec<PathBuf>> {
 }
 
 fn is_jsonl_file_candidate(path: &Path) -> io::Result<bool> {
-    match fs::metadata(path) {
-        Ok(metadata) => Ok(metadata.is_file()),
+    match path.symlink_metadata() {
+        Ok(metadata) => Ok(metadata.file_type().is_file()),
         Err(err) if should_skip_unusable_session_entry(&err) => Ok(false),
         Err(err) => Err(err),
     }
+}
+
+fn ambiguous_session_files_error(thread_id: &str, matches: &[PathBuf]) -> io::Error {
+    let paths = matches
+        .iter()
+        .map(|path| path.display().to_string())
+        .collect::<Vec<_>>()
+        .join(", ");
+    io::Error::new(
+        io::ErrorKind::InvalidData,
+        format!("multiple session files found for thread id {thread_id}: {paths}"),
+    )
 }
 
 fn session_artifacts_for_resume(codex_home: &Path) -> io::Result<Vec<PathBuf>> {
@@ -374,6 +456,233 @@ fn is_filesystem_loop_error(err: &io::Error) -> bool {
 #[cfg(not(unix))]
 fn is_filesystem_loop_error(_: &io::Error) -> bool {
     false
+}
+
+#[cfg(unix)]
+struct StoreDir {
+    file: fs::File,
+}
+
+#[cfg(unix)]
+impl StoreDir {
+    fn open_or_create_parent(codex_home: &Path, path: &Path) -> io::Result<Self> {
+        fs::create_dir_all(codex_home)?;
+        let mut dir = Self::open_existing(codex_home)?;
+        let mut current = codex_home.to_path_buf();
+        let parent = path
+            .parent()
+            .ok_or_else(|| invalid_session_file_error(path))?;
+        let relative = parent
+            .strip_prefix(codex_home)
+            .map_err(|_| invalid_session_file_error(path))?;
+        for component in relative.components() {
+            let std::path::Component::Normal(name) = component else {
+                return Err(invalid_child_name_error(component.as_os_str()));
+            };
+            current.push(name);
+            dir = dir
+                .open_or_create_child_dir(name)
+                .map_err(|err| map_session_dir_open_error(err, &current))?;
+        }
+        Ok(dir)
+    }
+
+    fn open_existing(path: &Path) -> io::Result<Self> {
+        fs::OpenOptions::new()
+            .read(true)
+            .custom_flags(libc::O_DIRECTORY | libc::O_NOFOLLOW | libc::O_CLOEXEC)
+            .open(path)
+            .map(|file| Self { file })
+    }
+
+    fn open_or_create_child_dir(&self, name: &OsStr) -> io::Result<Self> {
+        let name = cstring_child_name(name)?;
+        // SAFETY: `self.file` is an open directory fd, `name` is a validated
+        // NUL-terminated basename, and `mkdirat` does not retain pointers.
+        let mkdir_result = unsafe { libc::mkdirat(self.file.as_raw_fd(), name.as_ptr(), 0o700) };
+        if mkdir_result < 0 {
+            let err = io::Error::last_os_error();
+            if err.kind() != io::ErrorKind::AlreadyExists {
+                return Err(err);
+            }
+        }
+        self.open_child_dir_by_cstr(&name)
+    }
+
+    fn open_child_dir_by_cstr(&self, name: &CString) -> io::Result<Self> {
+        let flags = libc::O_RDONLY | libc::O_DIRECTORY | libc::O_NOFOLLOW | libc::O_CLOEXEC;
+        // SAFETY: `self.file` is an open directory fd, `name` is a validated
+        // NUL-terminated child basename, and the flags do not require a mode.
+        let fd = unsafe { libc::openat(self.file.as_raw_fd(), name.as_ptr(), flags) };
+        if fd < 0 {
+            return Err(io::Error::last_os_error());
+        }
+        // SAFETY: a non-negative `openat` return is a newly owned fd.
+        let file = unsafe { fs::File::from_raw_fd(fd) };
+        Ok(Self { file })
+    }
+
+    fn open_child_file(&self, name: &OsStr) -> io::Result<fs::File> {
+        let name = cstring_child_name(name)?;
+        let flags = libc::O_RDONLY | libc::O_NOFOLLOW | libc::O_CLOEXEC;
+        // SAFETY: `self.file` is an open directory fd, `name` is a validated
+        // NUL-terminated child basename, and the flags do not require a mode.
+        let fd = unsafe { libc::openat(self.file.as_raw_fd(), name.as_ptr(), flags) };
+        if fd < 0 {
+            return Err(io::Error::last_os_error());
+        }
+        // SAFETY: a non-negative `openat` return is a newly owned fd.
+        Ok(unsafe { fs::File::from_raw_fd(fd) })
+    }
+
+    fn ensure_child_file_usable(&self, name: &OsStr, path: &Path) -> io::Result<()> {
+        let file = match self.open_child_file(name) {
+            Ok(file) => file,
+            Err(err) if err.kind() == io::ErrorKind::NotFound => return Ok(()),
+            Err(err) if is_filesystem_loop_error(&err) => {
+                return Err(invalid_session_file_error(path));
+            }
+            Err(err) => return Err(err),
+        };
+        if file
+            .metadata()
+            .ok()
+            .is_some_and(|metadata| metadata.file_type().is_file())
+        {
+            Ok(())
+        } else {
+            Err(invalid_session_file_error(path))
+        }
+    }
+
+    fn create_unique_temp_file(&self, final_name: &OsStr) -> io::Result<(OsString, fs::File)> {
+        for _ in 0..100 {
+            let tmp_name = unique_session_temp_name(final_name);
+            match self.create_child_file_exclusive(&tmp_name) {
+                Ok(file) => return Ok((tmp_name, file)),
+                Err(err) if err.kind() == io::ErrorKind::AlreadyExists => continue,
+                Err(err) => return Err(err),
+            }
+        }
+        Err(io::Error::new(
+            io::ErrorKind::AlreadyExists,
+            "failed to create unique session temp file",
+        ))
+    }
+
+    fn create_child_file_exclusive(&self, name: &OsStr) -> io::Result<fs::File> {
+        let name = cstring_child_name(name)?;
+        let flags = libc::O_WRONLY | libc::O_CREAT | libc::O_EXCL | libc::O_CLOEXEC;
+        // SAFETY: `self.file` is an open directory fd, `name` is a validated
+        // NUL-terminated child basename, and a mode is supplied because
+        // `O_CREAT` is set.
+        let fd = unsafe { libc::openat(self.file.as_raw_fd(), name.as_ptr(), flags, 0o600) };
+        if fd < 0 {
+            return Err(io::Error::last_os_error());
+        }
+        // SAFETY: a non-negative `openat` return is a newly owned fd.
+        Ok(unsafe { fs::File::from_raw_fd(fd) })
+    }
+
+    fn rename_child(&self, from: &OsStr, to: &OsStr) -> io::Result<()> {
+        let from = cstring_child_name(from)?;
+        let to = cstring_child_name(to)?;
+        // SAFETY: both directory fds are the same open directory fd, and both
+        // names are validated NUL-terminated child basenames.
+        let result = unsafe {
+            libc::renameat(
+                self.file.as_raw_fd(),
+                from.as_ptr(),
+                self.file.as_raw_fd(),
+                to.as_ptr(),
+            )
+        };
+        if result < 0 {
+            return Err(io::Error::last_os_error());
+        }
+        Ok(())
+    }
+
+    fn unlink_child_file(&self, name: &OsStr) -> io::Result<()> {
+        let name = cstring_child_name(name)?;
+        // SAFETY: `self.file` is an open directory fd and `name` is a validated
+        // NUL-terminated child basename.
+        let result = unsafe { libc::unlinkat(self.file.as_raw_fd(), name.as_ptr(), 0) };
+        if result < 0 {
+            return Err(io::Error::last_os_error());
+        }
+        Ok(())
+    }
+}
+
+#[cfg(unix)]
+fn cstring_child_name(name: &OsStr) -> io::Result<CString> {
+    let bytes = name.as_bytes();
+    if bytes.is_empty() || bytes == b"." || bytes == b".." || bytes.contains(&b'/') {
+        return Err(invalid_child_name_error(name));
+    }
+    CString::new(bytes).map_err(|err| io::Error::new(io::ErrorKind::InvalidInput, err))
+}
+
+#[cfg(unix)]
+fn invalid_child_name_error(name: &OsStr) -> io::Error {
+    io::Error::new(
+        io::ErrorKind::InvalidInput,
+        format!(
+            "session child name is not a basename: {}",
+            name.to_string_lossy()
+        ),
+    )
+}
+
+#[cfg(unix)]
+fn invalid_session_dir_error(path: &Path) -> io::Error {
+    io::Error::new(
+        io::ErrorKind::NotADirectory,
+        format!("sessions path is not a real directory: {}", path.display()),
+    )
+}
+
+#[cfg(unix)]
+fn map_session_dir_open_error(err: io::Error, path: &Path) -> io::Error {
+    if err.kind() == io::ErrorKind::NotADirectory || is_filesystem_loop_error(&err) {
+        invalid_session_dir_error(path)
+    } else {
+        err
+    }
+}
+
+#[cfg(unix)]
+struct SessionLock {
+    _file: fs::File,
+}
+
+#[cfg(not(unix))]
+struct SessionLock;
+
+#[cfg(unix)]
+fn lock_session(codex_home: &Path, thread_id: &str) -> io::Result<SessionLock> {
+    let lock_dir = codex_home.join(".session-locks");
+    fs::create_dir_all(&lock_dir)?;
+    let lock_path = lock_dir.join(format!("{thread_id}.lock"));
+    let file = fs::OpenOptions::new()
+        .read(true)
+        .write(true)
+        .create(true)
+        .custom_flags(libc::O_CLOEXEC | libc::O_NOFOLLOW)
+        .open(lock_path)?;
+    // SAFETY: `file.as_raw_fd()` is an open fd owned by `file`, and `flock`
+    // only affects the advisory lock associated with that fd.
+    let result = unsafe { libc::flock(file.as_raw_fd(), libc::LOCK_EX) };
+    if result < 0 {
+        return Err(io::Error::last_os_error());
+    }
+    Ok(SessionLock { _file: file })
+}
+
+#[cfg(not(unix))]
+fn lock_session(_codex_home: &Path, _thread_id: &str) -> io::Result<SessionLock> {
+    Ok(SessionLock)
 }
 
 #[cfg(test)]

--- a/crates/guest-mock-codex/src/session.rs
+++ b/crates/guest-mock-codex/src/session.rs
@@ -526,7 +526,7 @@ impl StoreDir {
 
     fn open_child_file(&self, name: &OsStr) -> io::Result<fs::File> {
         let name = cstring_child_name(name)?;
-        let flags = libc::O_RDONLY | libc::O_NOFOLLOW | libc::O_CLOEXEC;
+        let flags = libc::O_RDONLY | libc::O_NOFOLLOW | libc::O_CLOEXEC | libc::O_NONBLOCK;
         // SAFETY: `self.file` is an open directory fd, `name` is a validated
         // NUL-terminated child basename, and the flags do not require a mode.
         let fd = unsafe { libc::openat(self.file.as_raw_fd(), name.as_ptr(), flags) };

--- a/crates/guest-mock-codex/src/session.rs
+++ b/crates/guest-mock-codex/src/session.rs
@@ -537,6 +537,20 @@ impl StoreDir {
         Ok(unsafe { fs::File::from_raw_fd(fd) })
     }
 
+    fn open_or_create_child_file(&self, name: &OsStr) -> io::Result<fs::File> {
+        let name = cstring_child_name(name)?;
+        let flags = libc::O_RDWR | libc::O_CREAT | libc::O_NOFOLLOW | libc::O_CLOEXEC;
+        // SAFETY: `self.file` is an open directory fd, `name` is a validated
+        // NUL-terminated child basename, and a mode is supplied because
+        // `O_CREAT` is set.
+        let fd = unsafe { libc::openat(self.file.as_raw_fd(), name.as_ptr(), flags, 0o600) };
+        if fd < 0 {
+            return Err(io::Error::last_os_error());
+        }
+        // SAFETY: a non-negative `openat` return is a newly owned fd.
+        Ok(unsafe { fs::File::from_raw_fd(fd) })
+    }
+
     fn ensure_child_file_usable(&self, name: &OsStr, path: &Path) -> io::Result<()> {
         let file = match self.open_child_file(name) {
             Ok(file) => file,
@@ -664,15 +678,21 @@ struct SessionLock;
 
 #[cfg(unix)]
 fn lock_session(codex_home: &Path, thread_id: &str) -> io::Result<SessionLock> {
-    let lock_dir = codex_home.join(".session-locks");
-    fs::create_dir_all(&lock_dir)?;
-    let lock_path = lock_dir.join(format!("{thread_id}.lock"));
-    let file = fs::OpenOptions::new()
-        .read(true)
-        .write(true)
-        .create(true)
-        .custom_flags(libc::O_CLOEXEC | libc::O_NOFOLLOW)
-        .open(lock_path)?;
+    let lock_path = codex_home
+        .join(".session-locks")
+        .join(format!("{thread_id}.lock"));
+    let lock_dir = StoreDir::open_or_create_parent(codex_home, &lock_path)?;
+    let lock_name = lock_path
+        .file_name()
+        .ok_or_else(|| invalid_session_file_error(&lock_path))?;
+    let file = lock_dir.open_or_create_child_file(lock_name)?;
+    if !file
+        .metadata()
+        .ok()
+        .is_some_and(|metadata| metadata.file_type().is_file())
+    {
+        return Err(invalid_session_file_error(&lock_path));
+    }
     // SAFETY: `file.as_raw_fd()` is an open fd owned by `file`, and `flock`
     // only affects the advisory lock associated with that fd.
     let result = unsafe { libc::flock(file.as_raw_fd(), libc::LOCK_EX) };

--- a/crates/guest-mock-codex/src/session.rs
+++ b/crates/guest-mock-codex/src/session.rs
@@ -194,11 +194,7 @@ fn read_session_bytes_for_append_in_store(codex_home: &Path, path: &Path) -> io:
         Err(err) if is_filesystem_loop_error(&err) => return Err(invalid_session_file_error(path)),
         Err(err) => return Err(err),
     };
-    if !file
-        .metadata()
-        .ok()
-        .is_some_and(|metadata| metadata.file_type().is_file())
-    {
+    if !file.metadata()?.file_type().is_file() {
         return Err(invalid_session_file_error(path));
     }
     let mut buf = Vec::new();
@@ -561,11 +557,7 @@ impl StoreDir {
             }
             Err(err) => return Err(err),
         };
-        if file
-            .metadata()
-            .ok()
-            .is_some_and(|metadata| metadata.file_type().is_file())
-        {
+        if file.metadata()?.file_type().is_file() {
             Ok(())
         } else {
             Err(invalid_session_file_error(path))
@@ -687,11 +679,7 @@ fn lock_session(codex_home: &Path, thread_id: &str) -> io::Result<SessionLock> {
         .file_name()
         .ok_or_else(|| invalid_session_file_error(&lock_path))?;
     let file = lock_dir.open_or_create_child_file(lock_name)?;
-    if !file
-        .metadata()
-        .ok()
-        .is_some_and(|metadata| metadata.file_type().is_file())
-    {
+    if !file.metadata()?.file_type().is_file() {
         return Err(invalid_session_file_error(&lock_path));
     }
     // SAFETY: `file.as_raw_fd()` is an open fd owned by `file`, and `flock`

--- a/crates/guest-mock-codex/src/session.rs
+++ b/crates/guest-mock-codex/src/session.rs
@@ -539,7 +539,8 @@ impl StoreDir {
 
     fn open_or_create_child_file(&self, name: &OsStr) -> io::Result<fs::File> {
         let name = cstring_child_name(name)?;
-        let flags = libc::O_RDWR | libc::O_CREAT | libc::O_NOFOLLOW | libc::O_CLOEXEC;
+        let flags =
+            libc::O_RDWR | libc::O_CREAT | libc::O_NOFOLLOW | libc::O_CLOEXEC | libc::O_NONBLOCK;
         // SAFETY: `self.file` is an open directory fd, `name` is a validated
         // NUL-terminated child basename, and a mode is supplied because
         // `O_CREAT` is set.

--- a/crates/guest-mock-codex/tests/integration.rs
+++ b/crates/guest-mock-codex/tests/integration.rs
@@ -4,8 +4,9 @@
 //! Cover the contract guest-agent will rely on: stdout JSONL shape, the
 //! on-disk session file path / format, and resume semantics.
 
+use std::collections::BTreeSet;
 use std::path::{Path, PathBuf};
-use std::process::Command;
+use std::process::{Child, Command, Stdio};
 
 use chrono::{Datelike, Utc};
 use guest_mock_codex::{
@@ -60,6 +61,14 @@ fn run_with_env(
         status: output.status.code().unwrap_or(-1),
         stderr,
     })
+}
+
+fn spawn(codex_home: &Path, args: &[&str]) -> std::io::Result<Child> {
+    let mut cmd = Command::new(BIN);
+    cmd.env("CODEX_HOME", codex_home).args(args);
+    cmd.env_remove("MOCK_CODEX_FIXTURE");
+    cmd.stdout(Stdio::null()).stderr(Stdio::null());
+    cmd.spawn()
 }
 
 fn assert_invalid_resume_rejected(codex_home: &Path, out: &RunOutput) -> std::io::Result<()> {
@@ -320,7 +329,7 @@ fn resume_appends_restored_rollout_session_without_parsing_history() -> std::io:
 
 #[cfg(unix)]
 #[test]
-fn resume_replaces_today_symlinked_fallback_without_reading_target() -> std::io::Result<()> {
+fn resume_rejects_today_symlinked_fallback_without_events() -> std::io::Result<()> {
     let dir = TempDir::new().unwrap();
     let thread_id = "0199a213-81c0-7800-8aa1-bbab2a035a53";
     let outside_path = dir.path().join("outside.jsonl");
@@ -332,19 +341,115 @@ fn resume_replaces_today_symlinked_fallback_without_reading_target() -> std::io:
     std::os::unix::fs::symlink(&outside_path, &session_path)?;
 
     let out = run(dir.path(), &["exec", "resume", thread_id, "--", "turn-2"])?;
-    assert_eq!(out.status, 0);
-    assert_eq!(out.events[0]["thread_id"], thread_id);
+
+    assert_ne!(out.status, 0);
+    assert!(
+        out.events.is_empty(),
+        "symlinked fallback should fail before emitting events: {:?}",
+        out.events
+    );
+    assert!(
+        out.stderr.contains("session path is not a regular file"),
+        "resume should report the symlinked session path: {:?}",
+        out.stderr
+    );
 
     let outside_events = read_session_file(&outside_path)?;
     assert_eq!(outside_events.len(), 3);
     assert_eq!(outside_events[1]["item"]["text"], "outside-turn");
     assert!(
-        session_path.symlink_metadata()?.file_type().is_file(),
-        "resume should replace the symlinked fallback path with a real file"
+        session_path.symlink_metadata()?.file_type().is_symlink(),
+        "resume should leave the symlink in place"
     );
-    let resume_events = read_session_file(&session_path)?;
-    assert_eq!(resume_events.len(), 3);
-    assert_eq!(resume_events[1]["item"]["text"], "turn-2");
+    Ok(())
+}
+
+#[test]
+fn resume_rejects_duplicate_matching_sessions_without_events() -> std::io::Result<()> {
+    let dir = TempDir::new().unwrap();
+    let thread_id = "0199a213-81c0-7800-8aa1-bbab2a035a53";
+    let first_path = dir
+        .path()
+        .join(format!("sessions/2001/01/01/{thread_id}.jsonl"));
+    let second_path = dir.path().join(format!(
+        "sessions/2001/01/02/rollout-restored-{thread_id}.jsonl"
+    ));
+    write_session_file(&first_path, &build_events(thread_id, "first"))?;
+    write_session_file(&second_path, &build_events(thread_id, "second"))?;
+
+    let out = run(dir.path(), &["exec", "resume", thread_id, "--", "turn-3"])?;
+
+    assert_ne!(out.status, 0);
+    assert!(
+        out.events.is_empty(),
+        "duplicate sessions should fail before emitting events: {:?}",
+        out.events
+    );
+    assert!(
+        out.stderr.contains("multiple session files found"),
+        "resume should report duplicate session files: {:?}",
+        out.stderr
+    );
+    assert_eq!(read_session_file(&first_path)?.len(), 3);
+    assert_eq!(read_session_file(&second_path)?.len(), 3);
+    Ok(())
+}
+
+#[test]
+fn resume_preserves_stale_fixed_temp_file() -> std::io::Result<()> {
+    let dir = TempDir::new().unwrap();
+    let thread_id = "0199a213-81c0-7800-8aa1-bbab2a035a53";
+    let session_path = build_session_path(dir.path(), Utc::now().date_naive(), thread_id)?;
+    if let Some(parent) = session_path.parent() {
+        std::fs::create_dir_all(parent)?;
+    }
+    let stale_temp_path = session_path.with_extension("jsonl.tmp");
+    std::fs::write(&stale_temp_path, "stale temp must survive")?;
+
+    let out = run(dir.path(), &["exec", "resume", thread_id, "--", "turn-1"])?;
+
+    assert_eq!(out.status, 0);
+    assert_eq!(
+        std::fs::read_to_string(&stale_temp_path)?,
+        "stale temp must survive"
+    );
+    let events = read_session_file(&session_path)?;
+    assert_eq!(events.len(), 3);
+    assert_eq!(events[1]["item"]["text"], "turn-1");
+    Ok(())
+}
+
+#[test]
+fn concurrent_resume_writes_preserve_all_turns() -> std::io::Result<()> {
+    let dir = TempDir::new().unwrap();
+    let first = run(dir.path(), &["exec", "--json", "--", "turn-0"])?;
+    assert_eq!(first.status, 0);
+    let thread_id = first.events[0]["thread_id"].as_str().unwrap();
+
+    let mut children = Vec::new();
+    for prompt in ["turn-1", "turn-2", "turn-3", "turn-4", "turn-5"] {
+        children.push(spawn(
+            dir.path(),
+            &["exec", "resume", thread_id, "--", prompt],
+        )?);
+    }
+
+    for mut child in children {
+        let status = child.wait()?;
+        assert!(status.success(), "resume child failed with {status}");
+    }
+
+    let session_path = require_session_file(dir.path())?;
+    let events = read_session_file(&session_path)?;
+    let prompts: BTreeSet<&str> = events
+        .iter()
+        .filter_map(|event| event.pointer("/item/text").and_then(Value::as_str))
+        .collect();
+    assert_eq!(
+        prompts,
+        BTreeSet::from(["turn-0", "turn-1", "turn-2", "turn-3", "turn-4", "turn-5"])
+    );
+    assert_eq!(events.len(), 18);
     Ok(())
 }
 
@@ -372,32 +477,26 @@ fn resume_rejects_final_session_directory_without_events() -> std::io::Result<()
 }
 
 #[test]
-fn resume_rejects_temp_session_directory_without_events() -> std::io::Result<()> {
+fn resume_ignores_stale_fixed_temp_directory() -> std::io::Result<()> {
     let dir = TempDir::new().unwrap();
     let thread_id = "0199a213-81c0-7800-8aa1-bbab2a035a53";
     let session_path = build_session_path(dir.path(), Utc::now().date_naive(), thread_id)?;
-    std::fs::create_dir_all(session_path.with_extension("jsonl.tmp"))?;
+    let stale_temp_path = session_path.with_extension("jsonl.tmp");
+    std::fs::create_dir_all(&stale_temp_path)?;
 
     let out = run(dir.path(), &["exec", "resume", thread_id, "--", "hi"])?;
 
-    assert_ne!(out.status, 0);
-    assert!(
-        out.events.is_empty(),
-        "unusable temp session path should fail before emitting events: {:?}",
-        out.events
-    );
-    assert!(
-        out.stderr
-            .contains("session temp path is not a regular file"),
-        "resume should report the unusable temp session path: {:?}",
-        out.stderr
-    );
+    assert_eq!(out.status, 0);
+    assert!(stale_temp_path.is_dir());
+    let resume_events = read_session_file(&session_path)?;
+    assert_eq!(resume_events.len(), 3);
+    assert_eq!(resume_events[1]["item"]["text"], "hi");
     Ok(())
 }
 
 #[cfg(unix)]
 #[test]
-fn resume_rejects_temp_session_symlink_without_events() -> std::io::Result<()> {
+fn resume_ignores_stale_fixed_temp_symlink() -> std::io::Result<()> {
     let dir = TempDir::new().unwrap();
     let thread_id = "0199a213-81c0-7800-8aa1-bbab2a035a53";
     let session_path = build_session_path(dir.path(), Utc::now().date_naive(), thread_id)?;
@@ -411,26 +510,18 @@ fn resume_rejects_temp_session_symlink_without_events() -> std::io::Result<()> {
 
     let out = run(dir.path(), &["exec", "resume", thread_id, "--", "hi"])?;
 
-    assert_ne!(out.status, 0);
-    assert!(
-        out.events.is_empty(),
-        "symlinked temp session path should fail before emitting events: {:?}",
-        out.events
-    );
-    assert!(
-        out.stderr
-            .contains("session temp path is not a regular file"),
-        "resume should report the symlinked temp session path: {:?}",
-        out.stderr
-    );
+    assert_eq!(out.status, 0);
     assert_eq!(std::fs::read_to_string(&outside_path)?, "outside");
     assert!(temp_path.symlink_metadata()?.file_type().is_symlink());
+    let resume_events = read_session_file(&session_path)?;
+    assert_eq!(resume_events.len(), 3);
+    assert_eq!(resume_events[1]["item"]["text"], "hi");
     Ok(())
 }
 
 #[cfg(unix)]
 #[test]
-fn resume_replaces_hardlinked_temp_without_mutating_target() -> std::io::Result<()> {
+fn resume_ignores_stale_fixed_temp_hardlink() -> std::io::Result<()> {
     let dir = TempDir::new().unwrap();
     let thread_id = "0199a213-81c0-7800-8aa1-bbab2a035a53";
     let session_path = build_session_path(dir.path(), Utc::now().date_naive(), thread_id)?;
@@ -448,8 +539,8 @@ fn resume_replaces_hardlinked_temp_without_mutating_target() -> std::io::Result<
 
     assert_eq!(std::fs::read_to_string(&outside_path)?, "outside");
     assert!(
-        !temp_path.exists(),
-        "temp path should be renamed away after successful session write"
+        temp_path.exists(),
+        "stale fixed temp path should not be renamed away"
     );
     let resume_events = read_session_file(&session_path)?;
     assert_eq!(resume_events.len(), 3);
@@ -896,7 +987,7 @@ fn thread_id_is_uuid_v7_shape() {
 
 #[cfg(unix)]
 #[test]
-fn session_files_include_symlinked_files_without_recursing_symlinked_dirs() -> std::io::Result<()> {
+fn session_files_skip_symlinked_files_and_dirs() -> std::io::Result<()> {
     let dir = TempDir::new().unwrap();
     let sessions = dir.path().join("sessions");
     let day_dir = sessions.join("2026/06/09");
@@ -908,7 +999,8 @@ fn session_files_include_symlinked_files_without_recursing_symlinked_dirs() -> s
     std::os::unix::fs::symlink(&sessions, sessions.join("loop"))?;
 
     let files = session_files(dir.path())?;
-    assert_eq!(files, vec![real_file, linked_file]);
+    assert_eq!(files, vec![real_file]);
+    assert!(linked_file.symlink_metadata()?.file_type().is_symlink());
     Ok(())
 }
 

--- a/crates/guest-mock-codex/tests/integration.rs
+++ b/crates/guest-mock-codex/tests/integration.rs
@@ -193,6 +193,62 @@ fn new_rejects_symlinked_session_parent_without_events() -> std::io::Result<()> 
     Ok(())
 }
 
+#[cfg(unix)]
+#[test]
+fn new_rejects_symlinked_codex_home_without_lock_artifacts() -> std::io::Result<()> {
+    let dir = TempDir::new().unwrap();
+    let outside_home = dir.path().join("outside-home");
+    let codex_home = dir.path().join("codex-home");
+    std::fs::create_dir_all(&outside_home)?;
+    std::os::unix::fs::symlink(&outside_home, &codex_home)?;
+
+    let out = run(&codex_home, &["exec", "--json", "--", "hi"])?;
+
+    assert_ne!(out.status, 0);
+    assert!(
+        out.events.is_empty(),
+        "symlinked codex home should fail before emitting events: {:?}",
+        out.events
+    );
+    assert!(
+        codex_home.symlink_metadata()?.file_type().is_symlink(),
+        "mock should leave the CODEX_HOME symlink in place"
+    );
+    assert!(
+        !outside_home.join(".session-locks").exists(),
+        "mock should not create lock files through a symlinked CODEX_HOME"
+    );
+    assert!(
+        !outside_home.join("sessions").exists(),
+        "mock should not create session files through a symlinked CODEX_HOME"
+    );
+    Ok(())
+}
+
+#[cfg(unix)]
+#[test]
+fn resume_rejects_special_lock_file_without_events() -> std::io::Result<()> {
+    let dir = TempDir::new().unwrap();
+    let thread_id = "0199a213-81c0-7800-8aa1-bbab2a035a53";
+    let lock_dir = dir.path().join(".session-locks");
+    std::fs::create_dir_all(&lock_dir)?;
+    mkfifo(&lock_dir.join(format!("{thread_id}.lock")))?;
+
+    let out = run(dir.path(), &["exec", "resume", thread_id, "--", "hi"])?;
+
+    assert_ne!(out.status, 0);
+    assert!(
+        out.events.is_empty(),
+        "special lock file should fail before emitting events: {:?}",
+        out.events
+    );
+    assert!(
+        session_artifacts(dir.path())?.is_empty(),
+        "special lock file should prevent session writes"
+    );
+    Ok(())
+}
+
 #[test]
 fn fixture_rejects_sessions_file_root_without_events() -> std::io::Result<()> {
     let dir = TempDir::new().unwrap();
@@ -1068,5 +1124,21 @@ fn session_artifacts_skip_symlinked_root_dir() -> std::io::Result<()> {
 
     assert!(session_artifacts(dir.path())?.is_empty());
     assert!(session_files(dir.path())?.is_empty());
+    Ok(())
+}
+
+#[cfg(unix)]
+fn mkfifo(path: &Path) -> std::io::Result<()> {
+    use std::ffi::CString;
+    use std::os::unix::ffi::OsStrExt;
+
+    let c_path = CString::new(path.as_os_str().as_bytes())
+        .map_err(|err| std::io::Error::new(std::io::ErrorKind::InvalidInput, err))?;
+    // SAFETY: `c_path` is a valid NUL-terminated path and `mkfifo` does not
+    // retain the pointer after returning.
+    let result = unsafe { libc::mkfifo(c_path.as_ptr(), 0o600) };
+    if result < 0 {
+        return Err(std::io::Error::last_os_error());
+    }
     Ok(())
 }

--- a/crates/guest-mock-codex/tests/integration.rs
+++ b/crates/guest-mock-codex/tests/integration.rs
@@ -249,6 +249,33 @@ fn resume_rejects_special_lock_file_without_events() -> std::io::Result<()> {
     Ok(())
 }
 
+#[cfg(unix)]
+#[test]
+fn resume_rejects_special_session_file_without_hanging() -> std::io::Result<()> {
+    let dir = TempDir::new().unwrap();
+    let thread_id = "0199a213-81c0-7800-8aa1-bbab2a035a53";
+    let session_path = build_session_path(dir.path(), Utc::now().date_naive(), thread_id)?;
+    if let Some(parent) = session_path.parent() {
+        std::fs::create_dir_all(parent)?;
+    }
+    mkfifo(&session_path)?;
+
+    let out = run(dir.path(), &["exec", "resume", thread_id, "--", "hi"])?;
+
+    assert_ne!(out.status, 0);
+    assert!(
+        out.events.is_empty(),
+        "special session file should fail before emitting events: {:?}",
+        out.events
+    );
+    assert!(
+        out.stderr.contains("session path is not a regular file"),
+        "special session file should be reported: {:?}",
+        out.stderr
+    );
+    Ok(())
+}
+
 #[test]
 fn fixture_rejects_sessions_file_root_without_events() -> std::io::Result<()> {
     let dir = TempDir::new().unwrap();

--- a/crates/runner/src/executor/env.rs
+++ b/crates/runner/src/executor/env.rs
@@ -3,6 +3,7 @@ use std::collections::HashMap;
 use api_contracts::generated::constants::model_provider_env::placeholders as model_provider_placeholders;
 use sandbox::{EXEC_OUTPUT_LIMIT_64_KIB, ExecRequest, Sandbox};
 
+use super::session_restore::canonical_codex_thread_id;
 use super::storage::format_guest_exec_failure;
 use super::{
     DEFAULT_EXEC_TIMEOUT, GUEST_AGENT_TUNING_ENV_KEYS, GUEST_USER_ENV_DIR_NAME,
@@ -314,7 +315,16 @@ pub(super) fn build_env_json_with_host_env(
 
     // Resume session ID
     if let Some(session) = &context.resume_session {
-        env.insert("VM0_RESUME_SESSION_ID".into(), session.session_id.clone());
+        let session_id = if effective_cli_framework(&context.cli_agent_type)
+            == EffectiveCliFramework::Codex
+        {
+            canonical_codex_thread_id(&session.session_id).ok_or_else(|| {
+                RunnerError::Internal(format!("invalid codex session_id: {}", session.session_id))
+            })?
+        } else {
+            session.session_id.clone()
+        };
+        env.insert("VM0_RESUME_SESSION_ID".into(), session_id);
     }
 
     // Note: Connector placeholder env vars (e.g., GITHUB_TOKEN=gho_CoffeeSafeLocal...)

--- a/crates/runner/src/executor/session_restore.rs
+++ b/crates/runner/src/executor/session_restore.rs
@@ -134,20 +134,14 @@ pub(super) async fn restore_codex_session(
     context: &ExecutionContext,
     session: &ResumeSession,
 ) -> RunnerResult<()> {
-    if !is_valid_codex_thread_id(&session.session_id) {
-        return Err(RunnerError::Internal(format!(
-            "invalid codex session_id: {}",
-            session.session_id
-        )));
-    }
+    let session_id = canonical_codex_thread_id(&session.session_id).ok_or_else(|| {
+        RunnerError::Internal(format!("invalid codex session_id: {}", session.session_id))
+    })?;
 
-    let session_path = codex_restore_rollout_path(
-        &session.session_id,
-        &session.session_history,
-        chrono::Utc::now(),
-    );
+    let session_path =
+        codex_restore_rollout_path(&session_id, &session.session_history, chrono::Utc::now());
 
-    cleanup_existing_codex_session_files(sandbox, context, &session.session_id).await?;
+    cleanup_existing_codex_session_files(sandbox, context, &session_id).await?;
 
     sandbox
         .write_file(&session_path, session.session_history.as_bytes())
@@ -211,6 +205,9 @@ pub(super) fn is_valid_session_id(id: &str) -> bool {
             .all(|c| c.is_ascii_alphanumeric() || c == '-' || c == '_')
 }
 
-fn is_valid_codex_thread_id(id: &str) -> bool {
-    uuid::Uuid::parse_str(id).is_ok_and(|uuid| uuid.to_string() == id)
+pub(super) fn canonical_codex_thread_id(id: &str) -> Option<String> {
+    if !is_valid_session_id(id) {
+        return None;
+    }
+    uuid::Uuid::parse_str(id).ok().map(|uuid| uuid.to_string())
 }

--- a/crates/runner/src/executor/session_restore.rs
+++ b/crates/runner/src/executor/session_restore.rs
@@ -1,9 +1,10 @@
 //! CLI session restore helpers for guest agent frameworks.
 
-use sandbox::Sandbox;
+use sandbox::{EXEC_OUTPUT_LIMIT_64_KIB, ExecRequest, Sandbox};
 use tracing::{info, warn};
 
-use super::{RunnerError, RunnerResult};
+use super::storage::format_guest_exec_failure;
+use super::{DEFAULT_EXEC_TIMEOUT, RunnerError, RunnerResult};
 use crate::types::{ExecutionContext, ResumeSession};
 use api_contracts::generated::constants::runners::paths::CANONICAL_WORKING_DIR;
 
@@ -139,6 +140,8 @@ pub(super) async fn restore_codex_session(
         chrono::Utc::now(),
     );
 
+    cleanup_existing_codex_session_files(sandbox, context, &session.session_id).await?;
+
     sandbox
         .write_file(&session_path, session.session_history.as_bytes())
         .await?;
@@ -148,6 +151,47 @@ pub(super) async fn restore_codex_session(
         path = %session_path,
         bytes_in = session.session_history.len(),
         "restored codex session history",
+    );
+    Ok(())
+}
+
+async fn cleanup_existing_codex_session_files(
+    sandbox: &dyn Sandbox,
+    context: &ExecutionContext,
+    session_id: &str,
+) -> RunnerResult<()> {
+    let cleanup_cmd = r#"root=/home/user/.codex/sessions
+if [ -d "$root" ]; then
+  id="$VM0_CODEX_RESTORE_SESSION_ID"
+  id_no_dashes="$(printf '%s' "$id" | tr -d '-')"
+  find "$root" -type f \( \
+    -name "*${id}*.jsonl" -o \
+    -name "*${id}*.jsonl.zst" -o \
+    -name "*${id_no_dashes}*.jsonl" -o \
+    -name "*${id_no_dashes}*.jsonl.zst" \
+  \) -delete
+fi"#;
+    let env = [("VM0_CODEX_RESTORE_SESSION_ID", session_id)];
+    let result = sandbox
+        .exec(&ExecRequest {
+            cmd: cleanup_cmd,
+            timeout: DEFAULT_EXEC_TIMEOUT,
+            env: &env,
+            sudo: false,
+            stdin_bytes: None,
+            output_limits: EXEC_OUTPUT_LIMIT_64_KIB,
+        })
+        .await?;
+    if result.exit_code != 0 {
+        return Err(RunnerError::Internal(format_guest_exec_failure(
+            "codex session cleanup",
+            &result,
+        )));
+    }
+    info!(
+        run_id = %context.run_id,
+        session_id = %session_id,
+        "cleaned up existing codex session files before restore",
     );
     Ok(())
 }

--- a/crates/runner/src/executor/session_restore.rs
+++ b/crates/runner/src/executor/session_restore.rs
@@ -165,7 +165,7 @@ async fn cleanup_existing_codex_session_files(
 if [ -d "$root" ]; then
   id="$VM0_CODEX_RESTORE_SESSION_ID"
   id_no_dashes="$(printf '%s' "$id" | tr -d '-')"
-  find "$root" -type f \( \
+  find "$root" \( -type f -o -type l \) \( \
     -iname "*${id}*.jsonl" -o \
     -iname "*${id}*.jsonl.zst" -o \
     -iname "*${id_no_dashes}*.jsonl" -o \

--- a/crates/runner/src/executor/session_restore.rs
+++ b/crates/runner/src/executor/session_restore.rs
@@ -162,7 +162,8 @@ async fn cleanup_existing_codex_session_files(
     session_id: &str,
     session_path: &str,
 ) -> RunnerResult<()> {
-    let cleanup_cmd = r#"root=/home/user/.codex/sessions
+    let cleanup_cmd = r#"codex_home=/home/user/.codex
+root="$codex_home/sessions"
 restore_path="$VM0_CODEX_RESTORE_SESSION_PATH"
 restore_dir="${restore_path%/*}"
 case "$restore_dir" in
@@ -183,6 +184,7 @@ check_restore_dir_component() {
     exit 1
   fi
 }
+check_restore_dir_component "$codex_home"
 check_restore_dir_component "$root"
 root_prefix="$root/"
 relative_dir="${restore_dir#$root_prefix}"

--- a/crates/runner/src/executor/session_restore.rs
+++ b/crates/runner/src/executor/session_restore.rs
@@ -166,10 +166,10 @@ if [ -d "$root" ]; then
   id="$VM0_CODEX_RESTORE_SESSION_ID"
   id_no_dashes="$(printf '%s' "$id" | tr -d '-')"
   find "$root" -type f \( \
-    -name "*${id}*.jsonl" -o \
-    -name "*${id}*.jsonl.zst" -o \
-    -name "*${id_no_dashes}*.jsonl" -o \
-    -name "*${id_no_dashes}*.jsonl.zst" \
+    -iname "*${id}*.jsonl" -o \
+    -iname "*${id}*.jsonl.zst" -o \
+    -iname "*${id_no_dashes}*.jsonl" -o \
+    -iname "*${id_no_dashes}*.jsonl.zst" \
   \) -delete
 fi"#;
     let env = [("VM0_CODEX_RESTORE_SESSION_ID", session_id)];

--- a/crates/runner/src/executor/session_restore.rs
+++ b/crates/runner/src/executor/session_restore.rs
@@ -30,9 +30,9 @@ pub(super) async fn restore_session(
             warn!(
                 run_id = %context.run_id,
                 framework = %other,
-                "skipping session restore for unknown framework"
+                "restoring session as claude-code for unknown framework"
             );
-            Ok(())
+            restore_claude_session(sandbox, context, session).await
         }
     }
 }

--- a/crates/runner/src/executor/session_restore.rs
+++ b/crates/runner/src/executor/session_restore.rs
@@ -141,7 +141,7 @@ pub(super) async fn restore_codex_session(
     let session_path =
         codex_restore_rollout_path(&session_id, &session.session_history, chrono::Utc::now());
 
-    cleanup_existing_codex_session_files(sandbox, context, &session_id).await?;
+    cleanup_existing_codex_session_files(sandbox, context, &session_id, &session_path).await?;
 
     sandbox
         .write_file(&session_path, session.session_history.as_bytes())
@@ -160,8 +160,46 @@ async fn cleanup_existing_codex_session_files(
     sandbox: &dyn Sandbox,
     context: &ExecutionContext,
     session_id: &str,
+    session_path: &str,
 ) -> RunnerResult<()> {
     let cleanup_cmd = r#"root=/home/user/.codex/sessions
+restore_path="$VM0_CODEX_RESTORE_SESSION_PATH"
+restore_dir="${restore_path%/*}"
+case "$restore_dir" in
+  "$root"/*/*/*) ;;
+  *)
+    echo "invalid codex restore directory: $restore_dir" >&2
+    exit 1
+    ;;
+esac
+check_restore_dir_component() {
+  path="$1"
+  if [ -L "$path" ]; then
+    echo "codex restore directory is a symlink: $path" >&2
+    exit 1
+  fi
+  if [ -e "$path" ] && [ ! -d "$path" ]; then
+    echo "codex restore path component is not a directory: $path" >&2
+    exit 1
+  fi
+}
+check_restore_dir_component "$root"
+root_prefix="$root/"
+relative_dir="${restore_dir#$root_prefix}"
+current="$root"
+old_ifs="$IFS"
+IFS=/
+for component in $relative_dir; do
+  case "$component" in
+    ""|"."|"..")
+      echo "invalid codex restore path component: $component" >&2
+      exit 1
+      ;;
+  esac
+  current="$current/$component"
+  check_restore_dir_component "$current"
+done
+IFS="$old_ifs"
 if [ -d "$root" ]; then
   id="$VM0_CODEX_RESTORE_SESSION_ID"
   id_no_dashes="$(printf '%s' "$id" | tr -d '-')"
@@ -172,7 +210,10 @@ if [ -d "$root" ]; then
     -iname "*${id_no_dashes}*.jsonl.zst" \
   \) -delete
 fi"#;
-    let env = [("VM0_CODEX_RESTORE_SESSION_ID", session_id)];
+    let env = [
+        ("VM0_CODEX_RESTORE_SESSION_ID", session_id),
+        ("VM0_CODEX_RESTORE_SESSION_PATH", session_path),
+    ];
     let result = sandbox
         .exec(&ExecRequest {
             cmd: cleanup_cmd,

--- a/crates/runner/src/executor/session_restore.rs
+++ b/crates/runner/src/executor/session_restore.rs
@@ -134,6 +134,13 @@ pub(super) async fn restore_codex_session(
     context: &ExecutionContext,
     session: &ResumeSession,
 ) -> RunnerResult<()> {
+    if !is_valid_codex_thread_id(&session.session_id) {
+        return Err(RunnerError::Internal(format!(
+            "invalid codex session_id: {}",
+            session.session_id
+        )));
+    }
+
     let session_path = codex_restore_rollout_path(
         &session.session_id,
         &session.session_history,
@@ -202,4 +209,8 @@ pub(super) fn is_valid_session_id(id: &str) -> bool {
         && id
             .chars()
             .all(|c| c.is_ascii_alphanumeric() || c == '-' || c == '_')
+}
+
+fn is_valid_codex_thread_id(id: &str) -> bool {
+    uuid::Uuid::parse_str(id).is_ok_and(|uuid| uuid.to_string() == id)
 }

--- a/crates/runner/src/executor/session_restore.rs
+++ b/crates/runner/src/executor/session_restore.rs
@@ -206,8 +206,12 @@ if [ -d "$root" ]; then
   find "$root" \( -type f -o -type l \) \( \
     -iname "*${id}*.jsonl" -o \
     -iname "*${id}*.jsonl.zst" -o \
+    -iname "*${id}*.jsonl.vm0tmp-*" -o \
+    -iname "*${id}*.jsonl.zst.vm0tmp-*" -o \
     -iname "*${id_no_dashes}*.jsonl" -o \
-    -iname "*${id_no_dashes}*.jsonl.zst" \
+    -iname "*${id_no_dashes}*.jsonl.zst" -o \
+    -iname "*${id_no_dashes}*.jsonl.vm0tmp-*" -o \
+    -iname "*${id_no_dashes}*.jsonl.zst.vm0tmp-*" \
   \) -delete
 fi"#;
     let env = [

--- a/crates/runner/src/executor/tests/env_tests.rs
+++ b/crates/runner/src/executor/tests/env_tests.rs
@@ -409,7 +409,7 @@ fn build_env_json_codex_keeps_shared_runner_env() {
     ctx.cli_agent_type = "codex".into();
     ctx.append_system_prompt = Some("Use terse answers.".into());
     ctx.resume_session = Some(ResumeSession {
-        session_id: "sess-123".into(),
+        session_id: "019E9154C30470F0ADDE36EFB1BE1701".into(),
         session_history: "{}".into(),
     });
 
@@ -419,8 +419,30 @@ fn build_env_json_codex_keeps_shared_runner_env() {
         env.get("VM0_APPEND_SYSTEM_PROMPT").unwrap(),
         "Use terse answers."
     );
-    assert_eq!(env.get("VM0_RESUME_SESSION_ID").unwrap(), "sess-123");
+    assert_eq!(
+        env.get("VM0_RESUME_SESSION_ID").unwrap(),
+        "019e9154-c304-70f0-adde-36efb1be1701"
+    );
     assert!(!env.contains_key("VM0_WORKING_DIR"));
+}
+
+#[test]
+fn build_env_json_rejects_invalid_codex_resume_session_id() {
+    for session_id in ["abc", "urn:uuid:019e9154-c304-70f0-adde-36efb1be1701"] {
+        let mut ctx = minimal_context();
+        ctx.cli_agent_type = "codex".into();
+        ctx.resume_session = Some(ResumeSession {
+            session_id: session_id.into(),
+            session_history: "{}".into(),
+        });
+
+        let error = build_env_for_test_result(&ctx, "http://localhost").unwrap_err();
+
+        assert!(
+            error.to_string().contains("invalid codex session_id"),
+            "got: {error}"
+        );
+    }
 }
 
 #[test]

--- a/crates/runner/src/executor/tests/session_restore_tests.rs
+++ b/crates/runner/src/executor/tests/session_restore_tests.rs
@@ -166,6 +166,31 @@ async fn restore_session_writes_codex_session_with_canonical_fallback_filename()
 }
 
 #[tokio::test]
+async fn restore_session_canonicalizes_codex_session_id() {
+    let sandbox = MockSandbox::new("test");
+    let mut ctx = minimal_context();
+    ctx.cli_agent_type = "codex".into();
+    let session = ResumeSession {
+        session_id: "019E9154C30470F0ADDE36EFB1BE1701".into(),
+        session_history: "{}\n".into(),
+    };
+
+    restore_session(&sandbox, &ctx, &session).await.unwrap();
+
+    assert_codex_cleanup_call(&sandbox);
+
+    let writes = sandbox.write_file_calls();
+    assert_eq!(writes.len(), 1);
+    assert!(
+        writes[0]
+            .path
+            .ends_with("-019e9154-c304-70f0-adde-36efb1be1701.jsonl"),
+        "codex restore path must use canonical thread id, got {}",
+        writes[0].path
+    );
+}
+
+#[tokio::test]
 async fn restore_session_rejects_invalid_codex_session_id() {
     // Path-traversal validation runs before framework dispatch, so codex
     // shares the same allow-list as claude-code.

--- a/crates/runner/src/executor/tests/session_restore_tests.rs
+++ b/crates/runner/src/executor/tests/session_restore_tests.rs
@@ -181,6 +181,26 @@ async fn restore_session_rejects_invalid_codex_session_id() {
 }
 
 #[tokio::test]
+async fn restore_session_rejects_short_codex_session_id_without_cleanup() {
+    let sandbox = MockSandbox::new("test");
+    let mut ctx = minimal_context();
+    ctx.cli_agent_type = "codex".into();
+    let session = ResumeSession {
+        session_id: "abc".into(),
+        session_history: "{}".into(),
+    };
+
+    let err = restore_session(&sandbox, &ctx, &session).await.unwrap_err();
+
+    assert!(
+        err.to_string().contains("invalid codex session_id"),
+        "got: {err}"
+    );
+    assert!(sandbox.exec_calls().is_empty());
+    assert!(sandbox.write_file_calls().is_empty());
+}
+
+#[tokio::test]
 async fn restore_session_fails_when_codex_cleanup_fails() {
     let sandbox = MockSandbox::new("test");
     let mut ctx = minimal_context();

--- a/crates/runner/src/executor/tests/session_restore_tests.rs
+++ b/crates/runner/src/executor/tests/session_restore_tests.rs
@@ -274,11 +274,20 @@ fn assert_codex_cleanup_call(sandbox: &MockSandbox) {
     assert_eq!(exec_calls.len(), 1);
     assert_eq!(
         exec_calls[0].env_keys,
-        ["VM0_CODEX_RESTORE_SESSION_ID".to_string()]
+        [
+            "VM0_CODEX_RESTORE_SESSION_ID".to_string(),
+            "VM0_CODEX_RESTORE_SESSION_PATH".to_string()
+        ]
     );
     assert!(!exec_calls[0].sudo);
     assert!(exec_calls[0].stdin_bytes.is_none());
     assert!(exec_calls[0].cmd.contains("/home/user/.codex/sessions"));
+    assert!(exec_calls[0].cmd.contains("check_restore_dir_component"));
+    assert!(
+        exec_calls[0]
+            .cmd
+            .contains("codex restore directory is a symlink")
+    );
     assert!(
         exec_calls[0]
             .cmd

--- a/crates/runner/src/executor/tests/session_restore_tests.rs
+++ b/crates/runner/src/executor/tests/session_restore_tests.rs
@@ -2,7 +2,7 @@ use sandbox::ExecResult;
 use sandbox_mock::MockSandbox;
 
 use super::super::session_restore::{is_valid_session_id, restore_session};
-use super::support::{minimal_context, sandbox_exec_error, sandbox_write_file_error};
+use super::support::{minimal_context, sandbox_write_file_error};
 use crate::types::ResumeSession;
 
 #[test]
@@ -58,7 +58,7 @@ async fn restore_session_rejects_invalid_session_id() {
 }
 
 #[tokio::test]
-async fn restore_session_skips_unknown_framework() {
+async fn restore_session_unknown_framework_uses_claude_fallback() {
     let sandbox = MockSandbox::new("test");
     let mut ctx = minimal_context();
     ctx.cli_agent_type = "custom-agent".into();
@@ -66,11 +66,16 @@ async fn restore_session_skips_unknown_framework() {
         session_id: "sess-1".into(),
         session_history: "data".into(),
     };
-    // Unknown frameworks must no-op silently (warn-and-skip) so a typo in
-    // CLI_AGENT_TYPE does not block the run. Pushing an exec error detects
-    // any accidental fallthrough into either framework's restore path.
-    sandbox.push_exec_result(Err(sandbox_exec_error("should not be called")));
+
     restore_session(&sandbox, &ctx, &session).await.unwrap();
+
+    let writes = sandbox.write_file_calls();
+    assert_eq!(writes.len(), 1);
+    assert_eq!(
+        writes[0].path,
+        "/home/user/.claude/projects/-home-user-workspace/sess-1.jsonl"
+    );
+    assert_eq!(writes[0].content, b"data");
 }
 
 #[tokio::test]

--- a/crates/runner/src/executor/tests/session_restore_tests.rs
+++ b/crates/runner/src/executor/tests/session_restore_tests.rs
@@ -280,6 +280,7 @@ fn assert_codex_cleanup_call(sandbox: &MockSandbox) {
     assert!(exec_calls[0].stdin_bytes.is_none());
     assert!(exec_calls[0].cmd.contains("/home/user/.codex/sessions"));
     assert!(exec_calls[0].cmd.contains("find \"$root\" -type f"));
+    assert!(exec_calls[0].cmd.contains("-iname"));
     assert!(exec_calls[0].cmd.contains(".jsonl.zst"));
     assert!(exec_calls[0].cmd.contains("id_no_dashes"));
     assert!(exec_calls[0].cmd.contains("-delete"));

--- a/crates/runner/src/executor/tests/session_restore_tests.rs
+++ b/crates/runner/src/executor/tests/session_restore_tests.rs
@@ -295,6 +295,7 @@ fn assert_codex_cleanup_call(sandbox: &MockSandbox) {
     );
     assert!(exec_calls[0].cmd.contains("-iname"));
     assert!(exec_calls[0].cmd.contains(".jsonl.zst"));
+    assert!(exec_calls[0].cmd.contains(".jsonl.vm0tmp-*"));
     assert!(exec_calls[0].cmd.contains("id_no_dashes"));
     assert!(exec_calls[0].cmd.contains("-delete"));
 }

--- a/crates/runner/src/executor/tests/session_restore_tests.rs
+++ b/crates/runner/src/executor/tests/session_restore_tests.rs
@@ -281,8 +281,14 @@ fn assert_codex_cleanup_call(sandbox: &MockSandbox) {
     );
     assert!(!exec_calls[0].sudo);
     assert!(exec_calls[0].stdin_bytes.is_none());
-    assert!(exec_calls[0].cmd.contains("/home/user/.codex/sessions"));
+    assert!(exec_calls[0].cmd.contains("codex_home=/home/user/.codex"));
+    assert!(exec_calls[0].cmd.contains("root=\"$codex_home/sessions\""));
     assert!(exec_calls[0].cmd.contains("check_restore_dir_component"));
+    assert!(
+        exec_calls[0]
+            .cmd
+            .contains("check_restore_dir_component \"$codex_home\"")
+    );
     assert!(
         exec_calls[0]
             .cmd

--- a/crates/runner/src/executor/tests/session_restore_tests.rs
+++ b/crates/runner/src/executor/tests/session_restore_tests.rs
@@ -1,3 +1,4 @@
+use sandbox::ExecResult;
 use sandbox_mock::MockSandbox;
 
 use super::super::session_restore::{is_valid_session_id, restore_session};
@@ -112,6 +113,9 @@ async fn restore_session_writes_codex_session() {
         ),
     };
     restore_session(&sandbox, &ctx, &session).await.unwrap();
+
+    assert_codex_cleanup_call(&sandbox);
+
     let writes = sandbox.write_file_calls();
     assert_eq!(writes.len(), 1);
     assert!(
@@ -135,6 +139,8 @@ async fn restore_session_writes_codex_session_with_canonical_fallback_filename()
     };
 
     restore_session(&sandbox, &ctx, &session).await.unwrap();
+
+    assert_codex_cleanup_call(&sandbox);
 
     let writes = sandbox.write_file_calls();
     assert_eq!(writes.len(), 1);
@@ -175,6 +181,32 @@ async fn restore_session_rejects_invalid_codex_session_id() {
 }
 
 #[tokio::test]
+async fn restore_session_fails_when_codex_cleanup_fails() {
+    let sandbox = MockSandbox::new("test");
+    let mut ctx = minimal_context();
+    ctx.cli_agent_type = "codex".into();
+    let session = ResumeSession {
+        session_id: "019e9154-c304-70f0-adde-36efb1be1701".into(),
+        session_history: "{}\n".into(),
+    };
+    sandbox.push_exec_result(Ok(ExecResult::new(
+        1,
+        b"cleanup stdout".to_vec(),
+        b"cleanup failed".to_vec(),
+    )));
+
+    let err = restore_session(&sandbox, &ctx, &session).await.unwrap_err();
+
+    let message = err.to_string();
+    assert!(
+        message.contains("codex session cleanup failed"),
+        "got: {message}"
+    );
+    assert!(message.contains("cleanup failed"), "got: {message}");
+    assert!(sandbox.write_file_calls().is_empty());
+}
+
+#[tokio::test]
 async fn restore_session_fails_on_write_file_error() {
     let sandbox = MockSandbox::new("test");
     let ctx = minimal_context();
@@ -185,4 +217,20 @@ async fn restore_session_fails_on_write_file_error() {
     sandbox.push_write_file_result(Err(sandbox_write_file_error("disk full")));
     let err = restore_session(&sandbox, &ctx, &session).await.unwrap_err();
     assert!(err.to_string().contains("disk full"), "got: {err}");
+}
+
+fn assert_codex_cleanup_call(sandbox: &MockSandbox) {
+    let exec_calls = sandbox.exec_calls();
+    assert_eq!(exec_calls.len(), 1);
+    assert_eq!(
+        exec_calls[0].env_keys,
+        ["VM0_CODEX_RESTORE_SESSION_ID".to_string()]
+    );
+    assert!(!exec_calls[0].sudo);
+    assert!(exec_calls[0].stdin_bytes.is_none());
+    assert!(exec_calls[0].cmd.contains("/home/user/.codex/sessions"));
+    assert!(exec_calls[0].cmd.contains("find \"$root\" -type f"));
+    assert!(exec_calls[0].cmd.contains(".jsonl.zst"));
+    assert!(exec_calls[0].cmd.contains("id_no_dashes"));
+    assert!(exec_calls[0].cmd.contains("-delete"));
 }

--- a/crates/runner/src/executor/tests/session_restore_tests.rs
+++ b/crates/runner/src/executor/tests/session_restore_tests.rs
@@ -279,7 +279,11 @@ fn assert_codex_cleanup_call(sandbox: &MockSandbox) {
     assert!(!exec_calls[0].sudo);
     assert!(exec_calls[0].stdin_bytes.is_none());
     assert!(exec_calls[0].cmd.contains("/home/user/.codex/sessions"));
-    assert!(exec_calls[0].cmd.contains("find \"$root\" -type f"));
+    assert!(
+        exec_calls[0]
+            .cmd
+            .contains("find \"$root\" \\( -type f -o -type l \\)")
+    );
     assert!(exec_calls[0].cmd.contains("-iname"));
     assert!(exec_calls[0].cmd.contains(".jsonl.zst"));
     assert!(exec_calls[0].cmd.contains("id_no_dashes"));

--- a/e2e/tests/03-runner/t-codex-resume.bats
+++ b/e2e/tests/03-runner/t-codex-resume.bats
@@ -3,10 +3,10 @@
 # Codex resume test — verifies vm0 run continue resumes a codex thread
 # via the framework-aware checkpoint scan path.
 #
-# The first turn writes a session file at
+# The first turn writes a mock session file at
 # `$CODEX_HOME/sessions/YYYY/MM/DD/<thread_id>.jsonl`. Continue
-# rehydrates from the agent session, calls codex with `exec resume`, and
-# the mock-codex appends another turn to the same file.
+# rehydrates from the agent session into Codex's rollout filename shape,
+# calls codex with `exec resume`, and renders the next turn.
 
 load '../../helpers/setup'
 
@@ -51,7 +51,7 @@ teardown_file() {
 }
 
 @test "t-codex-resume-1: continue resumes codex thread from session" {
-    # Initial turn: creates a codex thread and writes the session file.
+    # Initial turn: creates a codex thread and writes the first mock session file.
     run $VM0_CLI run "$AGENT_NAME" \
         "first turn"
     assert_success
@@ -72,8 +72,8 @@ teardown_file() {
     echo "# Agent session: $session_id"
 
     # Continue the run: framework-aware restore_session resolves the
-    # codex thread_id from the prior session, mock-codex appends to the
-    # existing session file, and a new turn renders.
+    # codex thread_id from the prior session, restores that history into
+    # Codex's rollout filename shape, and the next turn renders.
     run $VM0_CLI run continue "$session_id" \
         "second turn"
     assert_success


### PR DESCRIPTION
Fixes #16899

## Summary
- persist mock Codex sessions before emitting stdout so failed persistence does not produce misleading events
- serialize resume writes with a per-thread lock and unique temp files, using no-follow directory/file operations on Unix
- reject ambiguous duplicate Codex session matches in both guest-mock-codex and guest-agent readers
- extend coverage for duplicate matches, symlinked paths, stale fixed temp files, and concurrent resume writes

## Testing
- `cargo test -p guest-mock-codex -- --nocapture`
- `cargo test -p guest-agent --test codex_session_resume -- --nocapture`
- `cargo clippy -p guest-mock-codex -p guest-agent --all-targets -- -D warnings`
- `cargo fmt --package guest-mock-codex --package guest-agent -- --check`
- `git diff --check`
- `pnpm turbo run lint`
- `pnpm check-types`
- `pnpm format`
- `pnpm knip`
- `pnpm -F @vm0/db exec vitest src/__tests__/migrations/0418_remove_poor_agent_backend_models.test.ts`
- `pnpm -F api exec vitest src/lib/callback-route/__tests__/callback-route.test.ts`

## Notes
- A full local `pnpm vitest` run was attempted. It failed in this Linux container because the local DB schema was stale at the time of the run and because `@vm0/desktop` includes macOS-only native computer-use tests. After running `pnpm -F @vm0/db db:migrate`, representative DB/API failures passed as listed above.