### PR TITLE
fix: normalize vercel connector icon

### DIFF
--- a/turbo/apps/platform/src/views/zero-page/components/settings/icons/vercel.svg
+++ b/turbo/apps/platform/src/views/zero-page/components/settings/icons/vercel.svg
@@ -1,1 +1,1 @@
-<svg fill="#000" viewBox="0 0 512 512" xmlns="http://www.w3.org/2000/svg"><path fillRule="evenodd" d="M256 48 496 464H16z"/></svg>
+<svg fill="#000000" viewBox="0 0 512 512" xmlns="http://www.w3.org/2000/svg"><path fill-rule="evenodd" d="M256 48 496 464H16z"/></svg>


### PR DESCRIPTION
## Summary
- normalize the Vercel connector SVG from React-style `fillRule` to raw SVG `fill-rule`
- replace shorthand `#000` with explicit `#000000`
- preserve the official monochrome triangle geometry without adding a colorful override

## Verification
- `pnpm -F @vm0/db db:migrate`
- `git diff --check`
- `pnpm exec prettier --check --ignore-unknown apps/platform/src/views/zero-page/components/settings/icons/vercel.svg`
- targeted SVG checks for raw `fill-rule`, explicit color, no `currentColor`, and no raster embed

Tests were not run because this is an icon asset-only change.

Official source checked:
- https://vercel.com/

Closes #16934
