### PR TITLE
fix: store aws connector regions as variables

### DIFF
--- a/turbo/apps/api/src/signals/routes/__tests__/agent-runs-create.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/agent-runs-create.test.ts
@@ -1467,11 +1467,13 @@ describe("POST /api/agent/runs", () => {
         encryptedValue: encryptSecretForTests("aws-session-token"),
         type: "connector",
       },
+    ]);
+    await db.insert(variables).values([
       {
         orgId: fx.orgId,
         userId: fx.userId,
         name: "AWS_REGION",
-        encryptedValue: encryptSecretForTests("us-west-2"),
+        value: "us-west-2",
         type: "connector",
       },
     ]);
@@ -1503,15 +1505,24 @@ describe("POST /api/agent/runs", () => {
       AWS_ACCESS_KEY_ID: "aws",
       AWS_SECRET_ACCESS_KEY: "aws",
       AWS_SESSION_TOKEN: "aws",
-      AWS_REGION: "aws",
-      AWS_DEFAULT_REGION: "aws",
     });
-    expect(
-      decryptSecretsMapForTests(executionContext.encryptedSecrets),
-    ).toMatchObject({
+    expect(executionContext.secretConnectorMap).not.toHaveProperty(
+      "AWS_REGION",
+    );
+    expect(executionContext.secretConnectorMap).not.toHaveProperty(
+      "AWS_DEFAULT_REGION",
+    );
+    const decryptedSecrets = decryptSecretsMapForTests(
+      executionContext.encryptedSecrets,
+    );
+    expect(decryptedSecrets).toMatchObject({
       AWS_ACCESS_KEY_ID: "aws-access-key-id",
       AWS_SECRET_ACCESS_KEY: "aws-secret-access-key",
       AWS_SESSION_TOKEN: "aws-session-token",
+    });
+    expect(decryptedSecrets).not.toHaveProperty("AWS_REGION");
+    expect(decryptedSecrets).not.toHaveProperty("AWS_DEFAULT_REGION");
+    expect(executionContext.environment).toMatchObject({
       AWS_REGION: "us-west-2",
       AWS_DEFAULT_REGION: "us-west-2",
     });

--- a/turbo/apps/api/src/signals/routes/__tests__/webhooks-agent-firewall-auth.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/webhooks-agent-firewall-auth.test.ts
@@ -510,19 +510,17 @@ async function seedExpiredAwsConnector(
     value: "stale-aws-session-token",
     type: "connector",
   });
-  await seedSecret({
+  await seedVariable({
     orgId: fixture.orgId,
     userId: fixture.userId,
     name: "AWS_SIGNIN_REGION",
     value: "us-east-1",
-    type: "connector",
   });
-  await seedSecret({
+  await seedVariable({
     orgId: fixture.orgId,
     userId: fixture.userId,
     name: "AWS_REGION",
     value: "us-west-2",
-    type: "connector",
   });
 }
 
@@ -1963,22 +1961,22 @@ describe("POST /api/webhooks/agent/firewall/auth", () => {
             AWS_ACCESS_KEY_ID: STALE_ENCRYPTED_AWS_CREDENTIAL_ID,
             AWS_SECRET_ACCESS_KEY: "stale-encrypted-aws-secret-access-key",
             AWS_SESSION_TOKEN: "stale-encrypted-aws-session-token",
-            AWS_REGION: "stale-encrypted-aws-region",
-            AWS_DEFAULT_REGION: "stale-encrypted-aws-default-region",
           }),
           authHeaders: {
             "X-Aws-Access-Key-Id": secretTemplate("AWS_ACCESS_KEY_ID"),
             "X-Aws-Secret-Access-Key": secretTemplate("AWS_SECRET_ACCESS_KEY"),
             "X-Aws-Session-Token": secretTemplate("AWS_SESSION_TOKEN"),
-            "X-Aws-Region": secretTemplate("AWS_REGION"),
-            "X-Aws-Default-Region": secretTemplate("AWS_DEFAULT_REGION"),
+            "X-Aws-Region": varTemplate("AWS_REGION"),
+            "X-Aws-Default-Region": varTemplate("AWS_DEFAULT_REGION"),
           },
           secretConnectorMap: {
             AWS_ACCESS_KEY_ID: "aws",
             AWS_SECRET_ACCESS_KEY: "aws",
             AWS_SESSION_TOKEN: "aws",
-            AWS_REGION: "aws",
-            AWS_DEFAULT_REGION: "aws",
+          },
+          vars: {
+            AWS_REGION: "us-west-2",
+            AWS_DEFAULT_REGION: "us-west-2",
           },
         },
         headers: authHeaders(fixture),
@@ -1995,6 +1993,11 @@ describe("POST /api/webhooks/agent/firewall/auth", () => {
     });
     expect(response.body.refreshedConnectors).toStrictEqual(["aws"]);
     expect(response.body.refreshedSecrets).toStrictEqual([
+      "AWS_ACCESS_KEY_ID",
+      "AWS_SECRET_ACCESS_KEY",
+      "AWS_SESSION_TOKEN",
+    ]);
+    expect(response.body.resolvedSecrets).toStrictEqual([
       "AWS_ACCESS_KEY_ID",
       "AWS_SECRET_ACCESS_KEY",
       "AWS_SESSION_TOKEN",
@@ -2016,13 +2019,28 @@ describe("POST /api/webhooks/agent/firewall/auth", () => {
       }),
     ).resolves.toBe("rotated-aws-refresh-token");
     await expect(
+      readConnectorVariable({
+        orgId: fixture.orgId,
+        userId: fixture.userId,
+        name: "AWS_REGION",
+      }),
+    ).resolves.toBe("us-west-2");
+    await expect(
+      readSecret({
+        orgId: fixture.orgId,
+        userId: fixture.userId,
+        name: "AWS_SIGNIN_REGION",
+        type: "connector",
+      }),
+    ).resolves.toBeNull();
+    await expect(
       readSecret({
         orgId: fixture.orgId,
         userId: fixture.userId,
         name: "AWS_REGION",
         type: "connector",
       }),
-    ).resolves.toBe("us-west-2");
+    ).resolves.toBeNull();
   });
 
   it("serializes concurrent connector OAuth refreshes for rotated refresh tokens", async () => {

--- a/turbo/apps/api/src/signals/routes/__tests__/zero-connectors-external-code.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/zero-connectors-external-code.test.ts
@@ -11,6 +11,7 @@ import { zeroConnectorExternalCodeSessionContract } from "@vm0/api-contracts/con
 import { connectorExternalCodeSessions } from "@vm0/db/schema/connector-external-code-session";
 import { connectors } from "@vm0/db/schema/connector";
 import { secrets } from "@vm0/db/schema/secret";
+import { variables } from "@vm0/db/schema/variable";
 import { createStore } from "ccstate";
 import { and, eq } from "drizzle-orm";
 import { http, HttpResponse } from "msw";
@@ -103,6 +104,9 @@ async function cleanupUser(userId: string, orgId: string) {
   await db
     .delete(secrets)
     .where(and(eq(secrets.userId, userId), eq(secrets.orgId, orgId)));
+  await db
+    .delete(variables)
+    .where(and(eq(variables.userId, userId), eq(variables.orgId, orgId)));
 }
 
 async function storedSecret(args: {
@@ -122,6 +126,26 @@ async function storedSecret(args: {
       ),
     );
   return secret ? await decryptStoredSecretValue(secret.encryptedValue) : null;
+}
+
+async function storedVariable(args: {
+  readonly orgId: string;
+  readonly userId: string;
+  readonly name: string;
+}): Promise<string | null> {
+  const [variable] = await store
+    .set(writeDb$)
+    .select({ value: variables.value })
+    .from(variables)
+    .where(
+      and(
+        eq(variables.orgId, args.orgId),
+        eq(variables.userId, args.userId),
+        eq(variables.name, args.name),
+        eq(variables.type, "connector"),
+      ),
+    );
+  return variable?.value ?? null;
 }
 
 function awsTokenEndpointResponseBody() {
@@ -491,11 +515,17 @@ describe("external-code connector routes", () => {
       storedSecret({ orgId, userId, name: "AWS_SESSION_TOKEN" }),
     ).resolves.toBe("aws-session-token");
     await expect(
-      storedSecret({ orgId, userId, name: "AWS_SIGNIN_REGION" }),
+      storedVariable({ orgId, userId, name: "AWS_SIGNIN_REGION" }),
     ).resolves.toBe("us-east-1");
     await expect(
-      storedSecret({ orgId, userId, name: "AWS_REGION" }),
+      storedVariable({ orgId, userId, name: "AWS_REGION" }),
     ).resolves.toBe("us-east-1");
+    await expect(
+      storedSecret({ orgId, userId, name: "AWS_SIGNIN_REGION" }),
+    ).resolves.toBeNull();
+    await expect(
+      storedSecret({ orgId, userId, name: "AWS_REGION" }),
+    ).resolves.toBeNull();
 
     const replay = await accept(
       client.complete({

--- a/turbo/packages/connectors/src/__tests__/connectors.test.ts
+++ b/turbo/packages/connectors/src/__tests__/connectors.test.ts
@@ -2608,9 +2608,9 @@ describe("getConnectorAuthMethodAccessMetadata", () => {
           },
         },
         signinRegion: {
-          valueRef: "$secrets.AWS_SIGNIN_REGION",
+          valueRef: "$vars.AWS_SIGNIN_REGION",
           source: {
-            kind: "connector-secret",
+            kind: "connector-variable",
             name: "AWS_SIGNIN_REGION",
           },
         },
@@ -2654,8 +2654,8 @@ describe("getConnectorAuthMethodAccessMetadata", () => {
         AWS_ACCESS_KEY_ID: "$secrets.AWS_ACCESS_KEY_ID",
         AWS_SECRET_ACCESS_KEY: "$secrets.AWS_SECRET_ACCESS_KEY",
         AWS_SESSION_TOKEN: "$secrets.AWS_SESSION_TOKEN",
-        AWS_REGION: "$secrets.AWS_REGION",
-        AWS_DEFAULT_REGION: "$secrets.AWS_REGION",
+        AWS_REGION: "$vars.AWS_REGION",
+        AWS_DEFAULT_REGION: "$vars.AWS_REGION",
       },
       platformSecrets: [],
     });
@@ -3893,8 +3893,8 @@ describe("connector OAuth lifecycle grant helpers", () => {
           accessKeyId: "$secrets.AWS_ACCESS_KEY_ID",
           secretAccessKey: "$secrets.AWS_SECRET_ACCESS_KEY",
           sessionToken: "$secrets.AWS_SESSION_TOKEN",
-          signinRegion: "$secrets.AWS_SIGNIN_REGION",
-          runtimeRegion: "$secrets.AWS_REGION",
+          signinRegion: "$vars.AWS_SIGNIN_REGION",
+          runtimeRegion: "$vars.AWS_REGION",
         },
       },
     );

--- a/turbo/packages/connectors/src/connectors/aws.ts
+++ b/turbo/packages/connectors/src/connectors/aws.ts
@@ -27,10 +27,8 @@ export const aws = {
             "AWS_ACCESS_KEY_ID",
             "AWS_SECRET_ACCESS_KEY",
             "AWS_SESSION_TOKEN",
-            "AWS_SIGNIN_REGION",
-            "AWS_REGION",
           ],
-          variables: [],
+          variables: ["AWS_SIGNIN_REGION", "AWS_REGION"],
         },
         grant: {
           kind: "external-code",
@@ -41,8 +39,8 @@ export const aws = {
             accessKeyId: "$secrets.AWS_ACCESS_KEY_ID",
             secretAccessKey: "$secrets.AWS_SECRET_ACCESS_KEY",
             sessionToken: "$secrets.AWS_SESSION_TOKEN",
-            signinRegion: "$secrets.AWS_SIGNIN_REGION",
-            runtimeRegion: "$secrets.AWS_REGION",
+            signinRegion: "$vars.AWS_SIGNIN_REGION",
+            runtimeRegion: "$vars.AWS_REGION",
           },
         },
         access: {
@@ -50,7 +48,7 @@ export const aws = {
           inputs: {
             refreshToken: "$secrets.AWS_LOGIN_REFRESH_TOKEN",
             dpopKey: "$secrets.AWS_LOGIN_DPOP_KEY",
-            signinRegion: "$secrets.AWS_SIGNIN_REGION",
+            signinRegion: "$vars.AWS_SIGNIN_REGION",
           },
           outputs: {
             refreshToken: "$secrets.AWS_LOGIN_REFRESH_TOKEN",
@@ -67,8 +65,8 @@ export const aws = {
             AWS_ACCESS_KEY_ID: "$secrets.AWS_ACCESS_KEY_ID",
             AWS_SECRET_ACCESS_KEY: "$secrets.AWS_SECRET_ACCESS_KEY",
             AWS_SESSION_TOKEN: "$secrets.AWS_SESSION_TOKEN",
-            AWS_REGION: "$secrets.AWS_REGION",
-            AWS_DEFAULT_REGION: "$secrets.AWS_REGION",
+            AWS_REGION: "$vars.AWS_REGION",
+            AWS_DEFAULT_REGION: "$vars.AWS_REGION",
           },
         },
         revoke: { kind: "none" },


### PR DESCRIPTION
## Summary
- store AWS signin/runtime regions as connector variables instead of connector secrets
- keep AWS credential material as connector secrets
- update connector metadata, external-code, firewall auth, and run creation tests for variable-backed regions

## Tests
- pnpm -F @vm0/connectors exec vitest run src/__tests__/connectors.test.ts
- pnpm -F api exec vitest run src/signals/routes/__tests__/zero-connectors-external-code.test.ts src/signals/routes/__tests__/webhooks-agent-firewall-auth.test.ts src/signals/routes/__tests__/agent-runs-create.test.ts
- pnpm -F @vm0/connectors check-types
- pnpm -F api check-types
- pnpm -F @vm0/connectors lint
- pnpm -F api lint
- pre-commit: prettier, knip --cache, turbo run check-types --concurrency=1