### PR TITLE
fix: replace weread connector icon

### DIFF
--- a/turbo/apps/platform/src/views/zero-page/components/settings/icons/weread.svg
+++ b/turbo/apps/platform/src/views/zero-page/components/settings/icons/weread.svg
@@ -1,14 +1,33 @@
-<svg width="48" height="48" viewBox="0 0 48 48" fill="none" xmlns="http://www.w3.org/2000/svg">
-  <rect width="48" height="48" rx="11" fill="#4CA2F5"/>
-  <g fill="#FFFFFF">
-    <path d="M24 16.5C20 14 14.3 13.4 9.8 14.4C9 14.6 8.4 15.3 8.4 16.1L8.4 31.5C8.4 32.5 9.4 33.2 10.4 33C14.3 32.2 19.5 32.7 23.1 34.8C23.5 35 24 34.7 24 34.3Z"/>
-    <path d="M24 16.5C28 14 33.7 13.4 38.2 14.4C39 14.6 39.6 15.3 39.6 16.1L39.6 31.5C39.6 32.5 38.6 33.2 37.6 33C33.7 32.2 28.5 32.7 24.9 34.8C24.5 35 24 34.7 24 34.3Z"/>
-  </g>
-  <path d="M24 16.8L24 34" stroke="#4CA2F5" stroke-width="1.8" stroke-linecap="round"/>
-  <g stroke="#9BC8F7" stroke-width="1.6" stroke-linecap="round">
-    <path d="M12.6 19.4C15 18.9 17.8 18.9 20.4 19.7"/>
-    <path d="M12.6 24.1C15 23.6 17.8 23.6 20.4 24.4"/>
-    <path d="M27.6 19.7C30.2 18.9 33 18.9 35.4 19.4"/>
-    <path d="M27.6 24.4C30.2 23.6 33 23.6 35.4 24.1"/>
-  </g>
+<svg
+  width="48"
+  height="48"
+  viewBox="0 0 48 48"
+  fill="none"
+  xmlns="http://www.w3.org/2000/svg"
+>
+  <rect width="48" height="48" rx="7.5" fill="url(#weread-bg)" />
+  <path
+    fill="#FFFFFF"
+    d="M0 41.05h20.25c2.35 0 3.45 1.75 3.75 5.2.3-3.45 1.4-5.2 3.75-5.2H48V48H0z"
+  />
+  <path
+    fill="#FFFFFF"
+    d="M38.6 27.45c4.05 0 7.25 2.45 7.25 5.55s-3.2 5.55-7.25 5.55c-1.2 0-2.35-.2-3.35-.6l-3.2 1.25.9-2.55c-1.2-.95-1.9-2.2-1.9-3.65 0-3.1 3.25-5.55 7.55-5.55Z"
+  />
+  <circle cx="36.55" cy="32.55" r="0.75" fill="#35A8FF" />
+  <circle cx="40.6" cy="32.55" r="0.75" fill="#35A8FF" />
+  <defs>
+    <linearGradient
+      id="weread-bg"
+      x1="0"
+      y1="0"
+      x2="48"
+      y2="48"
+      gradientUnits="userSpaceOnUse"
+    >
+      <stop stop-color="#4CBEFF" />
+      <stop offset="0.45" stop-color="#35A8FF" />
+      <stop offset="1" stop-color="#2DA3FF" />
+    </linearGradient>
+  </defs>
 </svg>


### PR DESCRIPTION
## Summary

- replace the WeRead connector icon with an SVG recreation of the official blue square chat-bubble mark
- remove the previous open-book drawing that did not match the official site/app icon
- keep explicit SVG colors and avoid embedded raster assets

## Verification

- `python3 - <<'PY' ... ET.parse('turbo/apps/platform/src/views/zero-page/components/settings/icons/weread.svg') ... PY`
- `pnpm -C turbo exec prettier --check --parser html apps/platform/src/views/zero-page/components/settings/icons/weread.svg`
- `rg` check for `currentColor`, `<image>`, base64, and raster references in `weread.svg`
- `git diff --check`

Rendering note: local Playwright browser binaries are not installed in this workspace, so I could not capture a browser screenshot without downloading them.

Closes #16945
