### PR TITLE
chore(rust): update dependencies

### DIFF
--- a/crates/Cargo.lock
+++ b/crates/Cargo.lock
@@ -2446,9 +2446,9 @@ dependencies = [
 
 [[package]]
 name = "regex"
-version = "1.12.3"
+version = "1.12.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e10754a14b9137dd7b1e3e5b0493cc9171fdd105e0ab477f51b72e7f3ac0e276"
+checksum = "f1292b7759ae1cb9ec195452d1390a074f0cd8541ab7a5a8c31cd6db45d4a6ba"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -2475,9 +2475,9 @@ checksum = "cab834c73d247e67f4fae452806d17d3c7501756d98c8808d7c9c7aa7d18f973"
 
 [[package]]
 name = "regex-syntax"
-version = "0.8.10"
+version = "0.8.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dc897dd8d9e8bd1ed8cdad82b5966c3e0ecae09fb1907d58efaa013543185d0a"
+checksum = "d6f6ff9a378485b298a5286656da665ba74413d36db0979633275d2e708145d4"
 
 [[package]]
 name = "reqwest"
@@ -3653,9 +3653,9 @@ checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
 
 [[package]]
 name = "uuid"
-version = "1.23.2"
+version = "1.23.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d258b83ceec21034727ecee8c382cfa6c3e133699b0742c64571814fb420c9f7"
+checksum = "144d6b123cef80b301b8f72a9e2ca4370ddec21950d0a103dd22c437006d2db7"
 dependencies = [
  "getrandom 0.4.2",
  "js-sys",
@@ -4345,18 +4345,18 @@ dependencies = [
 
 [[package]]
 name = "zerocopy"
-version = "0.8.50"
+version = "0.8.52"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3b065d4f0e55f82fae73202e189638116a87c55ab6b8e6c2721e13dd9d854ad1"
+checksum = "ce1022995ff5ff5d841ad7d994facc23098cd40152f2c1d11cd607c6f530653f"
 dependencies = [
  "zerocopy-derive",
 ]
 
 [[package]]
 name = "zerocopy-derive"
-version = "0.8.50"
+version = "0.8.52"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0b631b19d36a892ab55420c92dbc83ccd79274f25be714855d3074aa71cab639"
+checksum = "1ae7f38b72ec2a254e2b87ef277cf2cd4fb97cbebf944faa6f33354da0867930"
 dependencies = [
  "proc-macro2",
  "quote",


### PR DESCRIPTION
## Summary
- Updated the Rust workspace lockfile under `crates/` with `cargo +stable update --verbose`.
- Updated 5 package entries:
  - `regex` `1.12.3` -> `1.12.4`
  - `regex-syntax` `0.8.10` -> `0.8.11`
  - `uuid` `1.23.2` -> `1.23.3`
  - `zerocopy` `0.8.50` -> `0.8.52`
  - `zerocopy-derive` `0.8.50` -> `0.8.52`

## Dependencies not updated
- `generic-array` remains at `0.14.7` although `0.14.9` is available. `cargo update -p generic-array --precise 0.14.9` fails because upstream `crypto-common v0.1.7` requires `generic-array =0.14.7`; this is a transitive constraint, not a vm0 `Cargo.toml` pin.

## Manual version bumps
- None. No safe direct minor/patch `Cargo.toml` version specifier bumps were identified; the update is lockfile-only.

## Test status
- PASS: `cargo +stable test --workspace --jobs 1`
- Test environment used `CARGO_TARGET_DIR=/home/user/workspace/vm0-rust-deps-target-lowmem`, `CARGO_BUILD_JOBS=1`, `CARGO_PROFILE_TEST_DEBUG=0`, `TMPDIR=/home/user/workspace/t`, and `umask 0022` to avoid local runtime disk/linker/temp-dir limitations.
- Earlier attempts exposed environment constraints only: `/tmp` ran out of space, the default linker was killed while linking the large `runner` test binary, and the default `umask 0002` made temp dirs group-writable, which runner security tests reject. The final workspace test run passed with the settings above.
