### PR TITLE
fix: show desktop tray auth loading status

### DIFF
--- a/turbo/apps/desktop/src/desktop-tray-menu.test.ts
+++ b/turbo/apps/desktop/src/desktop-tray-menu.test.ts
@@ -33,6 +33,12 @@ const signedInAuth: DesktopAuthState = {
   },
 };
 
+const signingInAuth: DesktopAuthState = {
+  status: "signing_in",
+  user: null,
+  organization: null,
+};
+
 function computerUseState(
   host: Partial<ComputerUseHostRuntimeState> = {},
   permissions: DesktopComputerUseState["permissions"] = {
@@ -176,6 +182,47 @@ describe("desktop tray menu", () => {
     expect(findItem(computerUseMenu, "Start Computer Use").enabled).toBe(false);
     click(findItem(computerUseMenu, "Sign in to Zero"));
     expect(openSignIn).toHaveBeenCalledOnce();
+  });
+
+  it("shows signing in and disables start while auth is signing in", () => {
+    const menu = buildDesktopTrayMenuItems(
+      {
+        computerUse: computerUseState({ status: "idle" }),
+        auth: signingInAuth,
+        authError: null,
+      },
+      trayActions(),
+    );
+
+    const computerUseMenu = submenu(
+      findItem(menu, "Computer Use: Signing in..."),
+    );
+    expect(findItem(computerUseMenu, "Status: Signing in...").enabled).toBe(
+      false,
+    );
+    expect(findItem(computerUseMenu, "Start Computer Use").enabled).toBe(false);
+    expect(findItem(computerUseMenu, "Signing in...").enabled).toBe(false);
+  });
+
+  it("keeps stale signed-in auth from showing ready while auth is loading", () => {
+    const menu = buildDesktopTrayMenuItems(
+      {
+        computerUse: computerUseState({ status: "idle" }),
+        auth: signedInAuth,
+        authLoading: true,
+        authError: null,
+      },
+      trayActions(),
+    );
+
+    const computerUseMenu = submenu(
+      findItem(menu, "Computer Use: Signing in..."),
+    );
+    expect(findItem(computerUseMenu, "Status: Signing in...").enabled).toBe(
+      false,
+    );
+    expect(findItem(computerUseMenu, "Start Computer Use").enabled).toBe(false);
+    expect(findItem(menu, "Signing in to Zero...")).toBeDefined();
   });
 
   it("shows permission actions when Computer Use is blocked locally", () => {

--- a/turbo/apps/desktop/src/desktop-tray-menu.ts
+++ b/turbo/apps/desktop/src/desktop-tray-menu.ts
@@ -49,6 +49,7 @@ export interface DesktopTrayMenuActions {
 interface DesktopTrayMenuState {
   readonly computerUse: DesktopComputerUseState;
   readonly auth: DesktopAuthState | null;
+  readonly authLoading?: boolean;
   readonly authError: string | null;
 }
 
@@ -70,7 +71,7 @@ function computerUseStatusLabel(state: DesktopTrayMenuState): string {
   if (state.computerUse.host.status !== "idle") {
     return HOST_STATUS_LABELS[state.computerUse.host.status];
   }
-  if (state.auth?.status === "signing_in") {
+  if (isAuthLoading(state)) {
     return "Signing in...";
   }
   if (state.auth?.status !== "signed_in") {
@@ -86,10 +87,15 @@ function isAuthReady(auth: DesktopAuthState | null): boolean {
   return auth?.status === "signed_in" && auth.organization !== null;
 }
 
+function isAuthLoading(state: DesktopTrayMenuState): boolean {
+  return state.authLoading === true || state.auth?.status === "signing_in";
+}
+
 function canStartComputerUse(state: DesktopTrayMenuState): boolean {
   return (
     state.computerUse.supported &&
     hasRequiredComputerUsePermissions(state.computerUse.permissions) &&
+    !isAuthLoading(state) &&
     isAuthReady(state.auth) &&
     state.computerUse.host.status !== "connecting" &&
     state.computerUse.host.status !== "online"
@@ -103,14 +109,14 @@ function authActionForComputerUse(
   if (state.computerUse.host.status === "online") {
     return null;
   }
+  if (isAuthLoading(state)) {
+    return disabledLabel("Signing in...");
+  }
   if (state.auth?.status === "signed_in") {
     if (!state.auth.organization) {
       return { label: "Select Workspace", click: actions.switchWorkspace };
     }
     return null;
-  }
-  if (state.auth?.status === "signing_in") {
-    return disabledLabel("Signing in...");
   }
   return { label: "Sign in to Zero", click: actions.openSignIn };
 }
@@ -194,14 +200,14 @@ function buildPermissionItems(
 }
 
 function authStatusLabel(state: DesktopTrayMenuState): string {
+  if (isAuthLoading(state)) {
+    return "Signing in to Zero...";
+  }
   if (state.authError) {
     return "Sign in to Zero";
   }
   if (!state.auth) {
     return "Sign in to Zero";
-  }
-  if (state.auth.status === "signing_in") {
-    return "Signing in to Zero...";
   }
   if (state.auth.status === "signed_out") {
     return "Sign in to Zero";
@@ -216,6 +222,10 @@ function buildAuthSubmenu(
   state: DesktopTrayMenuState,
   actions: DesktopTrayMenuActions,
 ): readonly DesktopTrayMenuItem[] {
+  if (isAuthLoading(state)) {
+    return [disabledLabel("Signing in...")];
+  }
+
   if (state.authError || !state.auth || state.auth.status === "signed_out") {
     return [
       disabledLabel("Not signed in"),

--- a/turbo/apps/desktop/src/desktop-tray.ts
+++ b/turbo/apps/desktop/src/desktop-tray.ts
@@ -70,6 +70,7 @@ export class DesktopTrayController {
   private readonly options: DesktopTrayControllerOptions;
   private tray: Tray | null = null;
   private authState: DesktopAuthState | null = null;
+  private authLoading = true;
   private authError: string | null = null;
   private authRefreshVersion = 0;
   private menuSignature: string | null = null;
@@ -100,6 +101,7 @@ export class DesktopTrayController {
       {
         computerUse: this.options.getComputerUseState(),
         auth: this.authState,
+        authLoading: this.authLoading,
         authError: this.authError,
       },
       actions,
@@ -117,6 +119,8 @@ export class DesktopTrayController {
   refreshAuth(): void {
     const version = this.authRefreshVersion + 1;
     this.authRefreshVersion = version;
+    this.authLoading = true;
+    this.refresh();
     void this.options
       .getAuthState()
       .then((authState) => {
@@ -124,6 +128,7 @@ export class DesktopTrayController {
           return;
         }
         this.authState = authState;
+        this.authLoading = false;
         this.authError = null;
         this.refresh();
       })
@@ -133,6 +138,7 @@ export class DesktopTrayController {
         }
         this.authError = error instanceof Error ? error.message : String(error);
         this.authState = null;
+        this.authLoading = false;
         this.refresh();
       });
   }


### PR DESCRIPTION
## Summary
- show `Computer Use: Signing in...` while the tray is refreshing or consuming Desktop auth
- prevent stale signed-in auth from enabling `Start Computer Use` during auth loading
- add tray menu coverage for signing-in and auth-loading states

## Tests
- pnpm -F @vm0/desktop exec vitest run src/desktop-tray-menu.test.ts
- pnpm -F @vm0/desktop check-types
- pnpm -F @vm0/desktop lint
- pnpm -F @vm0/desktop test
