### PR TITLE
fix: dismiss chat feedback popover on pointer leave

### DIFF
--- a/turbo/apps/platform/src/views/zero-page/zero-chat-feedback-selection.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-chat-feedback-selection.tsx
@@ -94,10 +94,12 @@ function FeedbackToolbar({
   copied,
   onCopy,
   onProvideFeedback,
+  onPointerLeave,
 }: {
   copied: boolean;
   onCopy: () => void;
   onProvideFeedback: () => void;
+  onPointerLeave: () => void;
 }) {
   return (
     <PopoverContent
@@ -107,6 +109,9 @@ function FeedbackToolbar({
       onOpenAutoFocus={(event) => {
         return event.preventDefault();
       }}
+      // Dismiss once the pointer leaves the toolbar — fires only on leaving the
+      // outer box, so hovering its buttons keeps it open.
+      onMouseLeave={onPointerLeave}
       className="w-auto rounded-xl border-0 bg-foreground p-1 text-background shadow-lg"
     >
       <div className="flex items-center gap-0.5">
@@ -142,12 +147,14 @@ function FeedbackComposer({
   onCommentChange,
   onSubmit,
   onDismiss,
+  onPointerLeave,
 }: {
   quote: string;
   comment: string;
   onCommentChange: (value: string) => void;
   onSubmit: () => void;
   onDismiss: () => void;
+  onPointerLeave: () => void;
 }) {
   const handleKeyDown = (event: ReactKeyboardEvent<HTMLTextAreaElement>) => {
     // Enter sends, Shift+Enter inserts a newline — matching the main composer.
@@ -164,6 +171,9 @@ function FeedbackComposer({
       side="top"
       align="center"
       sideOffset={8}
+      // Same leave-to-dismiss as the toolbar; scrolling the quote or focusing
+      // the textarea keeps the pointer inside, so it stays open while in use.
+      onMouseLeave={onPointerLeave}
       className="w-80 rounded-xl p-3"
     >
       <div className="mb-2 flex items-center justify-between">
@@ -236,6 +246,15 @@ export function ChatFeedbackSelection({
     dismiss();
   };
 
+  // Leaving the popup closes it, except while the composer holds a typed note —
+  // that still needs an explicit Send / Cancel / X so the draft isn't lost.
+  const handlePointerLeave = () => {
+    if (mode === "composer" && comment.trim().length > 0) {
+      return;
+    }
+    dismiss();
+  };
+
   return (
     <>
       <span ref={selectionListenersRef(capture, dismissOnScroll)} hidden />
@@ -258,6 +277,7 @@ export function ChatFeedbackSelection({
                 return detach(copy(rootSignal), Reason.DomCallback);
               }}
               onProvideFeedback={openComposer}
+              onPointerLeave={handlePointerLeave}
             />
           ) : (
             <FeedbackComposer
@@ -266,6 +286,7 @@ export function ChatFeedbackSelection({
               onCommentChange={setComment}
               onSubmit={handleSubmit}
               onDismiss={dismiss}
+              onPointerLeave={handlePointerLeave}
             />
           )}
         </Popover>


### PR DESCRIPTION
## Problem

The text-selection feedback popup (Copy / Provide feedback toolbar, and the feedback composer) is a Radix `Popover`. Radix popovers only dismiss on **click-outside**, **Escape**, or **scroll** — they intentionally ignore *mouse-leave*. So once it appears, moving the pointer away leaves it lingering on screen, and the composer's **X** button ends up feeling like the only way to close it.

## Fix

Dismiss the popup on `onMouseLeave`.

- `onMouseLeave` fires only when the pointer leaves the popup's **outer box** — moving between the quote, the buttons, the textarea, or dragging the quote's scrollbar all keep the pointer *inside*, so the popup stays open while you're actually using it (the scrollable quote still works).
- The **composer is exempt while it holds a typed note** — if you've started writing feedback, leaving the popup won't discard the draft; it still needs an explicit **Send / Cancel / X**. An empty composer and the toolbar both close on leave.

## Scope

One file: `turbo/apps/platform/src/views/zero-page/zero-chat-feedback-selection.tsx`. No signal/state changes — reuses the existing `dismissFeedback$` command.

🤖 Generated with [Claude Code](https://claude.com/claude-code)