### PR TITLE
feat: add desktop keep-awake setting

### DIFF
--- a/turbo/apps/desktop/src/computer-use-electron.ts
+++ b/turbo/apps/desktop/src/computer-use-electron.ts
@@ -14,6 +14,7 @@ interface ComputerUseNativeApi {
   readonly start: () => Promise<DesktopComputerUseState>;
   readonly requestAccessibilityPermission: () => Promise<DesktopComputerUseState>;
   readonly requestScreenRecordingPermission: () => Promise<DesktopComputerUseState>;
+  readonly setKeepAwakeEnabled: (enabled: boolean) => DesktopComputerUseState;
 }
 
 export function notifyDesktopComputerUseChanged(): void {
@@ -63,6 +64,16 @@ export function installComputerUseIpc(
     (event) => {
       assertComputerUsePage(event);
       return api.requestScreenRecordingPermission();
+    },
+  );
+  ipcMain.handle(
+    COMPUTER_USE_CHANNELS.setKeepAwakeEnabled,
+    (event, enabled: unknown) => {
+      assertComputerUsePage(event);
+      if (typeof enabled !== "boolean") {
+        throw new Error("Desktop keep-awake enabled state must be a boolean");
+      }
+      return api.setKeepAwakeEnabled(enabled);
     },
   );
   ipcMain.handle(

--- a/turbo/apps/desktop/src/computer-use-ipc-channels.ts
+++ b/turbo/apps/desktop/src/computer-use-ipc-channels.ts
@@ -4,6 +4,7 @@ export const COMPUTER_USE_CHANNELS = {
   start: "computer-use:start",
   requestAccessibilityPermission: "computer-use:request-accessibility",
   requestScreenRecordingPermission: "computer-use:request-screen-recording",
+  setKeepAwakeEnabled: "computer-use:set-keep-awake-enabled",
   openAccessibilitySettings: "computer-use:open-accessibility-settings",
   openScreenRecordingSettings: "computer-use:open-screen-recording-settings",
   changed: "computer-use:changed",

--- a/turbo/apps/desktop/src/computer-use-types.ts
+++ b/turbo/apps/desktop/src/computer-use-types.ts
@@ -52,12 +52,18 @@ export interface ComputerUseHostRuntimeState {
   readonly localCommandLog: readonly ComputerUseLocalCommandLogEntry[];
 }
 
+export interface DesktopKeepAwakeState {
+  readonly enabled: boolean;
+  readonly active: boolean;
+}
+
 export interface DesktopComputerUseState {
   readonly featureSwitchKey: typeof COMPUTER_USE_FEATURE_SWITCH_KEY;
   readonly platform: NodeJS.Platform;
   readonly supported: boolean;
   readonly permissions: ComputerUsePermissionState;
   readonly host: ComputerUseHostRuntimeState;
+  readonly keepAwake: DesktopKeepAwakeState;
 }
 
 export function hasRequiredComputerUsePermissions(

--- a/turbo/apps/desktop/src/desktop-bridge.ts
+++ b/turbo/apps/desktop/src/desktop-bridge.ts
@@ -44,6 +44,9 @@ export interface DesktopComputerUseApi {
   readonly start: () => Promise<DesktopComputerUseState>;
   readonly requestAccessibilityPermission: () => Promise<DesktopComputerUseState>;
   readonly requestScreenRecordingPermission: () => Promise<DesktopComputerUseState>;
+  readonly setKeepAwakeEnabled: (
+    enabled: boolean,
+  ) => Promise<DesktopComputerUseState>;
   readonly openAccessibilitySettings: () => Promise<void>;
   readonly openScreenRecordingSettings: () => Promise<void>;
   readonly subscribe: (callback: () => void) => () => void;

--- a/turbo/apps/desktop/src/desktop-keep-awake.test.ts
+++ b/turbo/apps/desktop/src/desktop-keep-awake.test.ts
@@ -1,0 +1,154 @@
+import { mkdtemp, readFile, rm } from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { describe, expect, it, vi } from "vitest";
+import {
+  DesktopKeepAwakeController,
+  type DesktopKeepAwakeBlocker,
+} from "./desktop-keep-awake";
+
+function createBlocker(): {
+  readonly blocker: DesktopKeepAwakeBlocker;
+  readonly start: ReturnType<typeof vi.fn>;
+  readonly stop: ReturnType<typeof vi.fn>;
+} {
+  let nextId = 1;
+  const activeIds = new Set<number>();
+  const start = vi.fn(() => {
+    const id = nextId;
+    nextId += 1;
+    activeIds.add(id);
+    return id;
+  });
+  const stop = vi.fn((id: number) => {
+    activeIds.delete(id);
+  });
+  return {
+    start,
+    stop,
+    blocker: {
+      start,
+      stop,
+      isStarted: (id) => activeIds.has(id),
+    },
+  };
+}
+
+async function createPreferencesPath(): Promise<{
+  readonly directory: string;
+  readonly preferencesPath: string;
+}> {
+  const directory = await mkdtemp(path.join(os.tmpdir(), "vm0-desktop-"));
+  return {
+    directory,
+    preferencesPath: path.join(directory, "desktop-preferences.json"),
+  };
+}
+
+describe("DesktopKeepAwakeController", () => {
+  it("defaults to disabled when no local preference exists", async () => {
+    const { directory, preferencesPath } = await createPreferencesPath();
+    const { blocker, start } = createBlocker();
+    const onChange = vi.fn();
+    const controller = new DesktopKeepAwakeController({
+      preferencesPath,
+      blocker,
+      onChange,
+    });
+
+    try {
+      expect(controller.load()).toStrictEqual({
+        enabled: false,
+        active: false,
+      });
+      expect(start).not.toHaveBeenCalled();
+      expect(onChange).not.toHaveBeenCalled();
+    } finally {
+      await rm(directory, { recursive: true, force: true });
+    }
+  });
+
+  it("starts the system sleep blocker and persists the setting", async () => {
+    const { directory, preferencesPath } = await createPreferencesPath();
+    const { blocker, start } = createBlocker();
+    const onChange = vi.fn();
+    const controller = new DesktopKeepAwakeController({
+      preferencesPath,
+      blocker,
+      onChange,
+    });
+    controller.load();
+
+    try {
+      expect(controller.setEnabled(true)).toStrictEqual({
+        enabled: true,
+        active: true,
+      });
+      expect(start).toHaveBeenCalledWith("prevent-app-suspension");
+      expect(JSON.parse(await readFile(preferencesPath, "utf8"))).toMatchObject(
+        {
+          keepAwakeEnabled: true,
+        },
+      );
+      expect(onChange).toHaveBeenCalledOnce();
+    } finally {
+      await rm(directory, { recursive: true, force: true });
+    }
+  });
+
+  it("restores the blocker from persisted preferences", async () => {
+    const { directory, preferencesPath } = await createPreferencesPath();
+    const { blocker, start } = createBlocker();
+    const firstController = new DesktopKeepAwakeController({
+      preferencesPath,
+      blocker,
+      onChange: vi.fn(),
+    });
+    firstController.load();
+    firstController.setEnabled(true);
+    firstController.release();
+
+    const secondController = new DesktopKeepAwakeController({
+      preferencesPath,
+      blocker,
+      onChange: vi.fn(),
+    });
+
+    try {
+      expect(secondController.load()).toStrictEqual({
+        enabled: true,
+        active: true,
+      });
+      expect(start).toHaveBeenCalledTimes(2);
+    } finally {
+      await rm(directory, { recursive: true, force: true });
+    }
+  });
+
+  it("releases the blocker without clearing the saved preference", async () => {
+    const { directory, preferencesPath } = await createPreferencesPath();
+    const { blocker, stop } = createBlocker();
+    const controller = new DesktopKeepAwakeController({
+      preferencesPath,
+      blocker,
+      onChange: vi.fn(),
+    });
+    controller.load();
+    controller.setEnabled(true);
+
+    try {
+      expect(controller.release()).toStrictEqual({
+        enabled: true,
+        active: false,
+      });
+      expect(stop).toHaveBeenCalledOnce();
+      expect(JSON.parse(await readFile(preferencesPath, "utf8"))).toMatchObject(
+        {
+          keepAwakeEnabled: true,
+        },
+      );
+    } finally {
+      await rm(directory, { recursive: true, force: true });
+    }
+  });
+});

--- a/turbo/apps/desktop/src/desktop-keep-awake.ts
+++ b/turbo/apps/desktop/src/desktop-keep-awake.ts
@@ -1,0 +1,122 @@
+import { existsSync, mkdirSync, readFileSync, writeFileSync } from "node:fs";
+import path from "node:path";
+import type { DesktopKeepAwakeState } from "./computer-use-types";
+
+const KEEP_AWAKE_BLOCKER_TYPE = "prevent-app-suspension";
+
+export interface DesktopKeepAwakeBlocker {
+  readonly start: (type: typeof KEEP_AWAKE_BLOCKER_TYPE) => number;
+  readonly stop: (id: number) => void;
+  readonly isStarted: (id: number) => boolean;
+}
+
+interface DesktopKeepAwakeControllerOptions {
+  readonly preferencesPath: string;
+  readonly blocker: DesktopKeepAwakeBlocker;
+  readonly onChange: () => void;
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function readPreferenceRecord(filePath: string): Record<string, unknown> {
+  if (!existsSync(filePath)) {
+    return {};
+  }
+  const parsed: unknown = JSON.parse(readFileSync(filePath, "utf8"));
+  return isRecord(parsed) ? parsed : {};
+}
+
+function readKeepAwakeEnabled(filePath: string): boolean {
+  const value = readPreferenceRecord(filePath).keepAwakeEnabled;
+  return typeof value === "boolean" ? value : false;
+}
+
+function writeKeepAwakeEnabled(filePath: string, enabled: boolean): void {
+  const preferences = readPreferenceRecord(filePath);
+  mkdirSync(path.dirname(filePath), { recursive: true });
+  writeFileSync(
+    filePath,
+    `${JSON.stringify({ ...preferences, keepAwakeEnabled: enabled }, null, 2)}\n`,
+    "utf8",
+  );
+}
+
+export class DesktopKeepAwakeController {
+  private readonly options: DesktopKeepAwakeControllerOptions;
+  private enabled = false;
+  private blockerId: number | null = null;
+
+  constructor(options: DesktopKeepAwakeControllerOptions) {
+    this.options = options;
+  }
+
+  load(): DesktopKeepAwakeState {
+    this.enabled = readKeepAwakeEnabled(this.options.preferencesPath);
+    this.apply();
+    return this.getState();
+  }
+
+  getState(): DesktopKeepAwakeState {
+    return {
+      enabled: this.enabled,
+      active: this.isActive(),
+    };
+  }
+
+  setEnabled(enabled: boolean): DesktopKeepAwakeState {
+    const previous = this.getState();
+    if (this.enabled !== enabled) {
+      this.enabled = enabled;
+      writeKeepAwakeEnabled(this.options.preferencesPath, enabled);
+    }
+    this.apply();
+    return this.notifyIfChanged(previous);
+  }
+
+  release(): DesktopKeepAwakeState {
+    const previous = this.getState();
+    this.stopBlocker();
+    return this.notifyIfChanged(previous);
+  }
+
+  private apply(): void {
+    if (this.enabled) {
+      this.startBlocker();
+      return;
+    }
+    this.stopBlocker();
+  }
+
+  private startBlocker(): void {
+    if (this.isActive()) {
+      return;
+    }
+    this.blockerId = this.options.blocker.start(KEEP_AWAKE_BLOCKER_TYPE);
+  }
+
+  private stopBlocker(): void {
+    const blockerId = this.blockerId;
+    this.blockerId = null;
+    if (blockerId !== null && this.options.blocker.isStarted(blockerId)) {
+      this.options.blocker.stop(blockerId);
+    }
+  }
+
+  private isActive(): boolean {
+    return (
+      this.blockerId !== null && this.options.blocker.isStarted(this.blockerId)
+    );
+  }
+
+  private notifyIfChanged(
+    previous: DesktopKeepAwakeState,
+  ): DesktopKeepAwakeState {
+    const next = this.getState();
+    if (previous.enabled !== next.enabled || previous.active !== next.active) {
+      this.options.onChange();
+    }
+    return next;
+  }
+}

--- a/turbo/apps/desktop/src/desktop-tray-menu.test.ts
+++ b/turbo/apps/desktop/src/desktop-tray-menu.test.ts
@@ -45,6 +45,10 @@ function computerUseState(
     platform: "darwin",
     supported: true,
     permissions,
+    keepAwake: {
+      enabled: false,
+      active: false,
+    },
     host: {
       ...baseHostState,
       ...host,
@@ -80,6 +84,7 @@ function trayActions(
     requestScreenRecordingPermission: vi.fn(),
     openAccessibilitySettings: vi.fn(),
     openScreenRecordingSettings: vi.fn(),
+    setKeepAwakeEnabled: vi.fn(),
     quit: vi.fn(),
     ...overrides,
   };
@@ -126,6 +131,12 @@ describe("desktop tray menu", () => {
     );
 
     expect(findItem(menu, "Show Main Window")).toBeDefined();
+    expect(findItem(menu, "Keep Mac Awake")).toStrictEqual({
+      label: "Keep Mac Awake",
+      type: "checkbox",
+      checked: false,
+      click: expect.any(Function),
+    });
     expect(findItem(menu, "Computer Use: Online")).toBeDefined();
     expect(findItem(menu, "Workspace: Max & Zoe")).toBeDefined();
     expect(findItem(menu, "No Recent Commands")).toStrictEqual({
@@ -133,6 +144,31 @@ describe("desktop tray menu", () => {
       enabled: false,
     });
     expect(findItem(menu, "Quit")).toBeDefined();
+  });
+
+  it("toggles keep-awake from the top-level menu", () => {
+    const setKeepAwakeEnabled = vi.fn();
+    const menu = buildDesktopTrayMenuItems(
+      {
+        computerUse: {
+          ...computerUseState({ status: "online" }),
+          keepAwake: {
+            enabled: true,
+            active: true,
+          },
+        },
+        auth: signedInAuth,
+        authError: null,
+      },
+      trayActions({ setKeepAwakeEnabled }),
+    );
+
+    const keepAwakeItem = findItem(menu, "Keep Mac Awake");
+
+    expect(keepAwakeItem.type).toBe("checkbox");
+    expect(keepAwakeItem.checked).toBe(true);
+    click(keepAwakeItem);
+    expect(setKeepAwakeEnabled).toHaveBeenCalledWith(false);
   });
 
   it("enables starting Computer Use when ready and signed in", () => {

--- a/turbo/apps/desktop/src/desktop-tray-menu.ts
+++ b/turbo/apps/desktop/src/desktop-tray-menu.ts
@@ -27,7 +27,8 @@ const MAX_COMMAND_LABEL_LENGTH = 90;
 
 export interface DesktopTrayMenuItem {
   readonly label?: string;
-  readonly type?: "separator";
+  readonly type?: "checkbox" | "separator";
+  readonly checked?: boolean;
   readonly enabled?: boolean;
   readonly submenu?: readonly DesktopTrayMenuItem[];
   readonly click?: () => void;
@@ -43,6 +44,7 @@ export interface DesktopTrayMenuActions {
   readonly requestScreenRecordingPermission: () => void;
   readonly openAccessibilitySettings: () => void;
   readonly openScreenRecordingSettings: () => void;
+  readonly setKeepAwakeEnabled: (enabled: boolean) => void;
   readonly quit: () => void;
 }
 
@@ -309,6 +311,14 @@ export function buildDesktopTrayMenuItems(
 ): readonly DesktopTrayMenuItem[] {
   return [
     { label: "Show Main Window", click: actions.showMainWindow },
+    {
+      label: "Keep Mac Awake",
+      type: "checkbox",
+      checked: state.computerUse.keepAwake.enabled,
+      click: () => {
+        actions.setKeepAwakeEnabled(!state.computerUse.keepAwake.enabled);
+      },
+    },
     separator(),
     {
       label: `Computer Use: ${computerUseStatusLabel(state)}`,

--- a/turbo/apps/desktop/src/desktop-tray.ts
+++ b/turbo/apps/desktop/src/desktop-tray.ts
@@ -27,6 +27,7 @@ interface DesktopTrayControllerOptions {
   readonly requestScreenRecordingPermission: () => Promise<void>;
   readonly openAccessibilitySettings: () => void;
   readonly openScreenRecordingSettings: () => void;
+  readonly setKeepAwakeEnabled: (enabled: boolean) => Promise<void>;
   readonly quit: () => void;
 }
 
@@ -50,6 +51,9 @@ function electronMenuItem(
   }
   if (item.enabled !== undefined) {
     template.enabled = item.enabled;
+  }
+  if (item.checked !== undefined) {
+    template.checked = item.checked;
   }
   if (item.click) {
     template.click = item.click;
@@ -190,6 +194,11 @@ export class DesktopTrayController {
           this.options.openScreenRecordingSettings();
         },
       ),
+      setKeepAwakeEnabled: (enabled) => {
+        this.runAction("set keep-awake enabled", () => {
+          return this.options.setKeepAwakeEnabled(enabled);
+        })();
+      },
       quit: () => {
         this.options.quit();
       },

--- a/turbo/apps/desktop/src/main.ts
+++ b/turbo/apps/desktop/src/main.ts
@@ -6,6 +6,7 @@ import {
   dialog,
   Menu,
   net,
+  powerSaveBlocker,
   protocol,
   session,
   shell,
@@ -44,6 +45,7 @@ import { createComputerUseNativeBackend } from "./computer-use-native";
 import { resolveDesktopConfig } from "./config";
 import { installDesktopAutoUpdates } from "./desktop-auto-updates";
 import { createDesktopComputerUseSessionFetch } from "./desktop-computer-use-api";
+import { DesktopKeepAwakeController } from "./desktop-keep-awake";
 import {
   DesktopQuitConfirmationController,
   buildDesktopQuitConfirmationOptions,
@@ -106,6 +108,7 @@ let appIsQuitting = false;
 let computerUseQuitStopStarted = false;
 let computerUseNativeBackendDisposed = false;
 let desktopTray: DesktopTrayController | null = null;
+let keepAwakeController: DesktopKeepAwakeController | null = null;
 const desktopAuthStartGate = createDesktopAuthStartGate();
 let computerUseRuntime: ComputerUseHostRuntime | null = null;
 let computerUseBlockedHostState: ComputerUseHostRuntimeState | null = null;
@@ -221,6 +224,10 @@ function trayIconPath(): string {
   return path.join(__dirname, "..", "assets", "tray-iconTemplate.png");
 }
 
+function desktopPreferencesPath(): string {
+  return path.join(app.getPath("userData"), "desktop-preferences.json");
+}
+
 function applyAppName(): void {
   app.setName(config.identity.displayName);
   app.name = config.identity.displayName;
@@ -266,7 +273,32 @@ function getComputerUseBridgeState(): DesktopComputerUseState {
       computerUseRuntime?.getState() ??
       computerUseBlockedHostState ??
       IDLE_COMPUTER_USE_HOST_STATE,
+    keepAwake: keepAwakeController?.getState() ?? {
+      enabled: false,
+      active: false,
+    },
   };
+}
+
+function installKeepAwake(): void {
+  keepAwakeController = new DesktopKeepAwakeController({
+    preferencesPath: desktopPreferencesPath(),
+    blocker: powerSaveBlocker,
+    onChange: notifyComputerUseChanged,
+  });
+  keepAwakeController.load();
+}
+
+function setKeepAwakeEnabled(enabled: boolean): DesktopComputerUseState {
+  if (!keepAwakeController) {
+    throw new Error("Desktop keep-awake settings are unavailable");
+  }
+  keepAwakeController.setEnabled(enabled);
+  return getComputerUseBridgeState();
+}
+
+function releaseKeepAwake(): void {
+  keepAwakeController?.release();
 }
 
 async function startComputerUseRuntime(): Promise<DesktopComputerUseState> {
@@ -346,6 +378,7 @@ function installComputerUse(): void {
       start: startComputerUseRuntime,
       requestAccessibilityPermission: requestComputerUsePermission,
       requestScreenRecordingPermission: requestComputerUseScreenRecording,
+      setKeepAwakeEnabled,
     },
     { rendererUrl: localRendererUrl },
   );
@@ -386,6 +419,7 @@ function disposeComputerUseNativeBackend(): void {
 async function prepareForQuitAndInstall(): Promise<void> {
   quitConfirmation.allowQuitWithoutConfirmation();
   appIsQuitting = true;
+  releaseKeepAwake();
   if (!computerUseQuitStopStarted) {
     computerUseQuitStopStarted = true;
     await stopComputerUseRuntimeForQuit();
@@ -440,6 +474,9 @@ function installTray(): void {
     },
     openScreenRecordingSettings: () => {
       openExternal(MAC_SCREEN_RECORDING_SETTINGS_URL);
+    },
+    setKeepAwakeEnabled: async (enabled) => {
+      setKeepAwakeEnabled(enabled);
     },
     quit: () => {
       requestDesktopQuit();
@@ -884,6 +921,7 @@ if (!hasSingleInstanceLock) {
     }
 
     appIsQuitting = true;
+    releaseKeepAwake();
     if (!computerUseRuntime || computerUseQuitStopStarted) {
       disposeComputerUseNativeBackend();
       return;
@@ -907,6 +945,7 @@ if (!hasSingleInstanceLock) {
       apiBaseUrl: desktopApiBaseUrl,
       prepareForQuitAndInstall,
     });
+    installKeepAwake();
     installComputerUse();
     refreshComputerUsePermissionsForState();
     const desktopAuthSession = getAuthSession();

--- a/turbo/apps/desktop/src/preload.ts
+++ b/turbo/apps/desktop/src/preload.ts
@@ -48,6 +48,12 @@ const desktopComputerUseApi: DesktopComputerUseApi = {
       COMPUTER_USE_CHANNELS.requestScreenRecordingPermission,
     );
   },
+  setKeepAwakeEnabled(enabled: boolean): Promise<DesktopComputerUseState> {
+    return ipcRenderer.invoke(
+      COMPUTER_USE_CHANNELS.setKeepAwakeEnabled,
+      enabled,
+    );
+  },
   openAccessibilitySettings(): Promise<void> {
     return ipcRenderer.invoke(COMPUTER_USE_CHANNELS.openAccessibilitySettings);
   },

--- a/turbo/apps/desktop/src/renderer/App.tsx
+++ b/turbo/apps/desktop/src/renderer/App.tsx
@@ -35,6 +35,7 @@ import {
   refreshComputerUse$,
   requestAccessibilityPermission$,
   requestScreenRecordingPermission$,
+  setKeepAwakeEnabled$,
   setupComputerUseBridge$,
   startComputerUse$,
 } from "./computer-use-state";
@@ -125,6 +126,40 @@ function IconButton({
       {icon}
       <span>{children}</span>
     </button>
+  );
+}
+
+function CheckboxRow({
+  checked,
+  disabled,
+  meta,
+  onChange,
+  subtitle,
+  title,
+}: {
+  readonly checked: boolean;
+  readonly disabled?: boolean;
+  readonly meta: string;
+  readonly onChange: (checked: boolean) => void;
+  readonly subtitle: string;
+  readonly title: string;
+}) {
+  return (
+    <label className="checkbox-row">
+      <input
+        type="checkbox"
+        checked={checked}
+        disabled={disabled}
+        onChange={(event) => {
+          onChange(event.currentTarget.checked);
+        }}
+      />
+      <span className="checkbox-row-copy">
+        <span className="row-title">{title}</span>
+        <span className="row-meta">{subtitle}</span>
+      </span>
+      <span className="checkbox-row-meta">{meta}</span>
+    </label>
   );
 }
 
@@ -426,6 +461,8 @@ function RuntimePanel({
   const [startLoadable, start] = useLoadableSet(startComputerUse$);
   const [refreshLoadable, refresh] = useLoadableSet(refreshComputerUse$);
   const [signInLoadable, signIn] = useLoadableSet(openDesktopSignIn$);
+  const [keepAwakeLoadable, setKeepAwakeEnabled] =
+    useLoadableSet(setKeepAwakeEnabled$);
   const [orgSelectionLoadable, selectOrg] = useLoadableSet(
     openDesktopOrgSelection$,
   );
@@ -468,6 +505,16 @@ function RuntimePanel({
           <strong>{formatTimestamp(state.host.lastCommandAt)}</strong>
         </div>
       </div>
+      <CheckboxRow
+        title="Keep Mac awake"
+        subtitle="Prevents automatic system sleep. Display may still turn off."
+        meta={state.keepAwake.active ? "Active" : "Off"}
+        checked={state.keepAwake.enabled}
+        disabled={keepAwakeLoadable.state === "loading"}
+        onChange={(enabled) => {
+          void setKeepAwakeEnabled(enabled);
+        }}
+      />
       {state.host.lastError && (
         <div className="inline-alert">
           <IconAlertCircle size={16} />

--- a/turbo/apps/desktop/src/renderer/computer-use-state.test.ts
+++ b/turbo/apps/desktop/src/renderer/computer-use-state.test.ts
@@ -14,6 +14,10 @@ function computerUseState(
     platform: "darwin",
     supported: true,
     permissions: { accessibility: true, screenRecording: true },
+    keepAwake: {
+      enabled: false,
+      active: false,
+    },
     host: {
       status: "idle",
       hostId: null,

--- a/turbo/apps/desktop/src/renderer/computer-use-state.ts
+++ b/turbo/apps/desktop/src/renderer/computer-use-state.ts
@@ -137,6 +137,13 @@ export const requestScreenRecordingPermission$ = command(async ({ set }) => {
   set(reloadComputerUse$);
 });
 
+export const setKeepAwakeEnabled$ = command(
+  async ({ set }, enabled: boolean) => {
+    await desktopComputerUseApi().setKeepAwakeEnabled(enabled);
+    set(reloadComputerUse$);
+  },
+);
+
 export const openAccessibilitySettings$ = command(async () => {
   await desktopComputerUseApi().openAccessibilitySettings();
 });

--- a/turbo/apps/desktop/src/renderer/styles.css
+++ b/turbo/apps/desktop/src/renderer/styles.css
@@ -353,6 +353,45 @@ button {
   background: rgba(249, 250, 251, 0.76);
 }
 
+.checkbox-row {
+  min-height: 58px;
+  border: 1px solid rgba(30, 38, 52, 0.08);
+  border-radius: 7px;
+  padding: 10px;
+  display: grid;
+  grid-template-columns: 20px minmax(0, 1fr) auto;
+  align-items: center;
+  gap: 10px;
+  background: rgba(249, 250, 251, 0.76);
+  cursor: pointer;
+}
+
+.checkbox-row input {
+  width: 16px;
+  height: 16px;
+  margin: 0;
+  accent-color: #2563eb;
+}
+
+.checkbox-row:has(input:disabled) {
+  cursor: not-allowed;
+  opacity: 0.62;
+}
+
+.checkbox-row-copy {
+  min-width: 0;
+  display: grid;
+  gap: 2px;
+}
+
+.checkbox-row-meta {
+  color: #3d4a5c;
+  font-size: 12px;
+  line-height: 1.2;
+  font-weight: 650;
+  white-space: nowrap;
+}
+
 .command-log-list {
   gap: 10px;
 }
@@ -788,6 +827,14 @@ button {
   .permission-row {
     align-items: flex-start;
     flex-direction: column;
+  }
+
+  .checkbox-row {
+    grid-template-columns: 20px minmax(0, 1fr);
+  }
+
+  .checkbox-row-meta {
+    grid-column: 2;
   }
 
   .command-log-summary {


### PR DESCRIPTION
Summary
- Add a Desktop keep-awake controller that persists keepAwakeEnabled and manages Electron powerSaveBlocker while Zero Desktop is running.
- Expose the setting through Electron IPC, preload, renderer state, and the desktop tray.
- Add controller, tray, and renderer state coverage for the new keep-awake path.

Testing
- pnpm format
- pnpm turbo run lint
- pnpm check-types
- pnpm -F @vm0/desktop lint
- pnpm -F @vm0/desktop check-types
- pnpm -F @vm0/desktop test
- pnpm knip --workspace @vm0/desktop
- git diff --cached --check
- pnpm vitest (fails locally: Desktop tests pass, but the full repo reports 217 failed files, 1845 failed tests, and repeated invalid --localstorage-file / localStorage.getItem is not a function errors, plus unrelated API cleanup and timeout failures)
- pnpm knip (fails locally on existing repo-wide unused files, devDependencies, and exports; desktop workspace knip passes)
- scripts/prepare.sh (installs dependencies, then fails local setup because 1Password CLI and DATABASE_URL are unavailable)