### PR TITLE
feat: add desktop sign out

### DIFF
--- a/turbo/apps/desktop/src/desktop-auth-electron.ts
+++ b/turbo/apps/desktop/src/desktop-auth-electron.ts
@@ -13,6 +13,7 @@ interface DesktopAuthNativeApi {
   readonly getState: () => Promise<DesktopAuthState> | DesktopAuthState;
   readonly openSignIn: () => void;
   readonly openOrgSelection: () => Promise<void>;
+  readonly signOut: () => Promise<void>;
   readonly completeSignIn: (token: string) => Promise<void> | void;
 }
 
@@ -79,6 +80,10 @@ export function installDesktopAuthIpc(
   ipcMain.handle(DESKTOP_AUTH_CHANNELS.openOrgSelection, async (event) => {
     assertDesktopRenderer(event);
     await api.openOrgSelection();
+  });
+  ipcMain.handle(DESKTOP_AUTH_CHANNELS.signOut, async (event) => {
+    assertDesktopRenderer(event);
+    await api.signOut();
   });
   ipcMain.handle(
     DESKTOP_AUTH_CHANNELS.completeSignIn,

--- a/turbo/apps/desktop/src/desktop-auth-ipc-channels.ts
+++ b/turbo/apps/desktop/src/desktop-auth-ipc-channels.ts
@@ -2,6 +2,7 @@ export const DESKTOP_AUTH_CHANNELS = {
   getState: "desktop-auth:get-state",
   openSignIn: "desktop-auth:open-sign-in",
   openOrgSelection: "desktop-auth:open-org-selection",
+  signOut: "desktop-auth:sign-out",
   completeSignIn: "desktop-auth:complete-sign-in",
   changed: "desktop-auth:changed",
 } as const;

--- a/turbo/apps/desktop/src/desktop-auth-session.test.ts
+++ b/turbo/apps/desktop/src/desktop-auth-session.test.ts
@@ -82,10 +82,7 @@ describe("DesktopAuthSession", () => {
     session.signOut();
     session.completeSignIn("late");
     const fetch = vi.fn(async () => new Response(null, { status: 401 }));
-    vi.stubGlobal(
-      "fetch",
-      fetch,
-    );
+    vi.stubGlobal("fetch", fetch);
 
     expect(session.getCachedToken()).toBeNull();
     expect(await session.getToken({ forceRefresh: true })).toBeNull();

--- a/turbo/apps/desktop/src/desktop-auth-session.test.ts
+++ b/turbo/apps/desktop/src/desktop-auth-session.test.ts
@@ -76,6 +76,41 @@ describe("DesktopAuthSession", () => {
     expect(await session.getToken()).toBe("tok");
   });
 
+  it("clears cached auth and suppresses hidden refresh after sign out", async () => {
+    const { session, runAuthWindow, onChange } = createSession();
+    session.completeSignIn("cached");
+    session.signOut();
+    session.completeSignIn("late");
+    const fetch = vi.fn(async () => new Response(null, { status: 401 }));
+    vi.stubGlobal(
+      "fetch",
+      fetch,
+    );
+
+    expect(session.getCachedToken()).toBeNull();
+    expect(await session.getToken({ forceRefresh: true })).toBeNull();
+    expect(await session.getAuthState()).toEqual({
+      status: "signed_out",
+      user: null,
+      organization: null,
+    });
+    expect(fetch).not.toHaveBeenCalled();
+    expect(runAuthWindow).not.toHaveBeenCalled();
+    expect(onChange).toHaveBeenCalledTimes(2);
+  });
+
+  it("accepts sign-in completions after a new consume flow starts", async () => {
+    const { session, runAuthWindow } = createSession();
+    session.signOut();
+    runAuthWindow.mockImplementation(async () => {
+      session.completeSignIn("fresh");
+    });
+
+    await session.consumeCode("code-123");
+
+    expect(session.getCachedToken()).toBe("fresh");
+  });
+
   it("returns the freshly delivered token on a forced refresh", async () => {
     const { session, runAuthWindow } = createSession();
     runAuthWindow.mockImplementation(async () => {

--- a/turbo/apps/desktop/src/desktop-auth-session.ts
+++ b/turbo/apps/desktop/src/desktop-auth-session.ts
@@ -95,6 +95,7 @@ export class DesktopAuthSession {
   private tokenRefresh: Promise<string | null> | null = null;
   private pendingCode: string | null = null;
   private signingIn = false;
+  private acceptsSignInCompletions = true;
 
   constructor(options: DesktopAuthSessionOptions) {
     this.apiBaseUrl = options.apiBaseUrl;
@@ -114,6 +115,9 @@ export class DesktopAuthSession {
     if (!options?.forceRefresh && this.token) {
       return this.token;
     }
+    if (!this.acceptsSignInCompletions) {
+      return null;
+    }
     return await this.refresh();
   }
 
@@ -124,6 +128,9 @@ export class DesktopAuthSession {
   async getAuthState(): Promise<DesktopAuthState> {
     if (this.signingIn) {
       return signingInDesktopAuthState();
+    }
+    if (!this.acceptsSignInCompletions) {
+      return signedOutDesktopAuthState();
     }
 
     const state = await this.fetchAuthState();
@@ -177,11 +184,24 @@ export class DesktopAuthSession {
   }
 
   completeSignIn(token: string): void {
+    if (!this.acceptsSignInCompletions) {
+      return;
+    }
     this.token = token;
     this.onChange();
   }
 
+  signOut(): void {
+    this.token = null;
+    this.tokenRefresh = null;
+    this.pendingCode = null;
+    this.signingIn = false;
+    this.acceptsSignInCompletions = false;
+    this.onChange();
+  }
+
   async consumeCode(code: string): Promise<void> {
+    this.acceptsSignInCompletions = true;
     this.setSigningIn(true);
     try {
       await this.runAuthWindow({
@@ -197,6 +217,7 @@ export class DesktopAuthSession {
   }
 
   async selectOrganization(): Promise<void> {
+    this.acceptsSignInCompletions = true;
     await this.runAuthWindow({
       url: this.selectOrgUrl,
       visible: true,

--- a/turbo/apps/desktop/src/desktop-bridge.ts
+++ b/turbo/apps/desktop/src/desktop-bridge.ts
@@ -32,6 +32,7 @@ export interface DesktopAuthApi {
   readonly getState: () => Promise<DesktopAuthState>;
   readonly openSignIn: () => Promise<void>;
   readonly openOrgSelection: () => Promise<void>;
+  readonly signOut: () => Promise<void>;
   readonly completeSignIn: (params: {
     readonly token: string;
   }) => Promise<void>;

--- a/turbo/apps/desktop/src/desktop-tray-menu.test.ts
+++ b/turbo/apps/desktop/src/desktop-tray-menu.test.ts
@@ -86,6 +86,7 @@ function trayActions(
     refreshStatus: vi.fn(),
     openSignIn: vi.fn(),
     switchWorkspace: vi.fn(),
+    signOut: vi.fn(),
     requestAccessibilityPermission: vi.fn(),
     requestScreenRecordingPermission: vi.fn(),
     openAccessibilitySettings: vi.fn(),
@@ -330,13 +331,14 @@ describe("desktop tray menu", () => {
 
   it("shows signed-in account and workspace actions", () => {
     const switchWorkspace = vi.fn();
+    const signOut = vi.fn();
     const menu = buildDesktopTrayMenuItems(
       {
         computerUse: computerUseState(),
         auth: signedInAuth,
         authError: null,
       },
-      trayActions({ switchWorkspace }),
+      trayActions({ switchWorkspace, signOut }),
     );
 
     const authMenu = submenu(findItem(menu, "Workspace: Max & Zoe"));
@@ -346,7 +348,14 @@ describe("desktop tray menu", () => {
     );
     expect(findItem(authMenu, "Workspace: Max & Zoe").enabled).toBe(false);
     click(findItem(authMenu, "Switch Workspace"));
+    click(findItem(authMenu, "Sign out"));
     expect(switchWorkspace).toHaveBeenCalledOnce();
+    expect(signOut).toHaveBeenCalledOnce();
+    expect(
+      authMenu.some((item) => {
+        return item.label === "Sign in again";
+      }),
+    ).toBe(false);
   });
 
   it("shows sign-in action when signed out", () => {

--- a/turbo/apps/desktop/src/desktop-tray-menu.ts
+++ b/turbo/apps/desktop/src/desktop-tray-menu.ts
@@ -40,6 +40,7 @@ export interface DesktopTrayMenuActions {
   readonly refreshStatus: () => void;
   readonly openSignIn: () => void;
   readonly switchWorkspace: () => void;
+  readonly signOut: () => void;
   readonly requestAccessibilityPermission: () => void;
   readonly requestScreenRecordingPermission: () => void;
   readonly openAccessibilitySettings: () => void;
@@ -247,7 +248,7 @@ function buildAuthSubmenu(
     ),
     separator(),
     { label: "Switch Workspace", click: actions.switchWorkspace },
-    { label: "Sign in again", click: actions.openSignIn },
+    { label: "Sign out", click: actions.signOut },
   ];
 }
 

--- a/turbo/apps/desktop/src/desktop-tray.ts
+++ b/turbo/apps/desktop/src/desktop-tray.ts
@@ -23,6 +23,7 @@ interface DesktopTrayControllerOptions {
   readonly refreshStatus: () => Promise<void>;
   readonly openSignIn: () => void;
   readonly switchWorkspace: () => Promise<void>;
+  readonly signOut: () => Promise<void>;
   readonly requestAccessibilityPermission: () => Promise<void>;
   readonly requestScreenRecordingPermission: () => Promise<void>;
   readonly openAccessibilitySettings: () => void;
@@ -173,6 +174,13 @@ export class DesktopTrayController {
         "switch workspace",
         () => {
           return this.options.switchWorkspace();
+        },
+        { refreshAuth: true },
+      ),
+      signOut: this.runAction(
+        "sign out",
+        () => {
+          return this.options.signOut();
         },
         { refreshAuth: true },
       ),

--- a/turbo/apps/desktop/src/main.ts
+++ b/turbo/apps/desktop/src/main.ts
@@ -99,6 +99,13 @@ const localRendererUrl = desktopRendererUrl();
 const noAllowedAppOrigins: ReadonlySet<string> = new Set();
 const ELECTRON_ERR_ABORTED = -3;
 const COMPUTER_USE_QUIT_STOP_TIMEOUT_MS = 1_000;
+const DESKTOP_SIGN_OUT_STORAGES = [
+  "cookies",
+  "localstorage",
+  "indexdb",
+  "serviceworkers",
+  "cachestorage",
+] as const;
 const MAC_ACCESSIBILITY_SETTINGS_URL =
   "x-apple.systempreferences:com.apple.preference.security?Privacy_Accessibility";
 const MAC_SCREEN_RECORDING_SETTINGS_URL =
@@ -427,6 +434,25 @@ async function prepareForQuitAndInstall(): Promise<void> {
   disposeComputerUseNativeBackend();
 }
 
+async function clearDesktopAuthStorage(): Promise<void> {
+  await session.fromPartition(config.sessionPartition).clearStorageData({
+    storages: [...DESKTOP_SIGN_OUT_STORAGES],
+  });
+}
+
+async function signOutDesktopSession(): Promise<void> {
+  await clearDesktopAuthStorage();
+  getAuthSession().signOut();
+  const runtime = computerUseRuntime;
+  computerUseRuntime = null;
+  computerUseBlockedHostState = null;
+  try {
+    await runtime?.stop();
+  } finally {
+    notifyComputerUseChanged();
+  }
+}
+
 function installDesktopAuth(): void {
   installDesktopAuthIpc(
     {
@@ -435,6 +461,7 @@ function installDesktopAuth(): void {
         openExternal(desktopAuthStartUrl);
       },
       openOrgSelection: () => getAuthSession().selectOrganization(),
+      signOut: signOutDesktopSession,
       completeSignIn: (token) => getAuthSession().completeSignIn(token),
     },
     {
@@ -463,6 +490,7 @@ function installTray(): void {
       openExternal(desktopAuthStartUrl);
     },
     switchWorkspace: () => getAuthSession().selectOrganization(),
+    signOut: signOutDesktopSession,
     requestAccessibilityPermission: async () => {
       await requestComputerUsePermission();
     },

--- a/turbo/apps/desktop/src/preload.ts
+++ b/turbo/apps/desktop/src/preload.ts
@@ -14,6 +14,9 @@ const desktopAuthApi: DesktopAuthApi = {
   openOrgSelection(): Promise<void> {
     return ipcRenderer.invoke(DESKTOP_AUTH_CHANNELS.openOrgSelection);
   },
+  signOut(): Promise<void> {
+    return ipcRenderer.invoke(DESKTOP_AUTH_CHANNELS.signOut);
+  },
   completeSignIn(params): Promise<void> {
     return ipcRenderer.invoke(DESKTOP_AUTH_CHANNELS.completeSignIn, params);
   },

--- a/turbo/apps/desktop/src/renderer/App.tsx
+++ b/turbo/apps/desktop/src/renderer/App.tsx
@@ -9,6 +9,7 @@ import {
   IconCode,
   IconExternalLink,
   IconHistory,
+  IconLogout,
   IconMaximize,
   IconPhoto,
   IconPlayerPlay,
@@ -36,6 +37,7 @@ import {
   requestAccessibilityPermission$,
   requestScreenRecordingPermission$,
   setKeepAwakeEnabled$,
+  signOutDesktop$,
   setupComputerUseBridge$,
   startComputerUse$,
 } from "./computer-use-state";
@@ -990,15 +992,19 @@ function AccountMenu({
   loading,
   onSelectOrg,
   onSignIn,
+  onSignOut,
   orgSelectionLoading,
   signInLoading,
+  signOutLoading,
 }: {
   readonly authState: DesktopAuthState | null;
   readonly loading: boolean;
   readonly onSelectOrg: () => void;
   readonly onSignIn: () => void;
+  readonly onSignOut: () => void;
   readonly orgSelectionLoading: boolean;
   readonly signInLoading: boolean;
+  readonly signOutLoading: boolean;
 }) {
   if (
     !authState ||
@@ -1052,11 +1058,11 @@ function AccountMenu({
         <button
           type="button"
           className="account-menu-item"
-          onClick={onSignIn}
-          disabled={signInLoading}
+          onClick={onSignOut}
+          disabled={signOutLoading}
         >
-          <IconExternalLink size={15} />
-          <span>Sign in again</span>
+          <IconLogout size={15} />
+          <span>Sign out</span>
         </button>
       </div>
     </details>
@@ -1069,6 +1075,7 @@ function Header() {
   const [orgSelectionLoadable, selectOrg] = useLoadableSet(
     openDesktopOrgSelection$,
   );
+  const [signOutLoadable, signOut] = useLoadableSet(signOutDesktop$);
   const authState = authLoadable.state === "hasData" ? authLoadable.data : null;
   const authLoading = authLoadable.state === "loading";
   return (
@@ -1084,11 +1091,15 @@ function Header() {
             onSignIn={() => {
               void signIn();
             }}
+            onSignOut={() => {
+              void signOut();
+            }}
             onSelectOrg={() => {
               void selectOrg();
             }}
             orgSelectionLoading={orgSelectionLoadable.state === "loading"}
             signInLoading={signInLoadable.state === "loading"}
+            signOutLoading={signOutLoadable.state === "loading"}
           />
         )}
       </div>

--- a/turbo/apps/desktop/src/renderer/computer-use-state.ts
+++ b/turbo/apps/desktop/src/renderer/computer-use-state.ts
@@ -162,3 +162,10 @@ export const openDesktopOrgSelection$ = command(async ({ set }) => {
   set(refreshDesktopAuth$);
   set(reloadComputerUse$);
 });
+
+export const signOutDesktop$ = command(async ({ set }) => {
+  await desktopAuthApi().signOut();
+  set(autoStartAttempted$, false);
+  set(refreshDesktopAuth$);
+  set(reloadComputerUse$);
+});


### PR DESCRIPTION
## Summary

- replace the signed-in Desktop `Sign in again` action with `Sign out` in the main window and tray
- add a real Desktop auth sign-out IPC path that clears cached auth, browser auth storage, and active Computer Use runtime state
- cover explicit sign-out behavior in Desktop auth session and tray menu tests

Closes #16988

## Validation

- `pnpm -F @vm0/desktop exec vitest run src/desktop-auth-session.test.ts src/desktop-tray-menu.test.ts`
- `pnpm -F @vm0/desktop check-types`
- `pnpm -F @vm0/desktop lint`
- `pnpm -F @vm0/desktop test`
- `pnpm -F @vm0/desktop build`
- `pnpm knip --workspace @vm0/desktop`
- `pnpm format`
