### PR TITLE
fix: close settings dialog when clicking a credit-balance usage row

### DIFF
--- a/turbo/apps/platform/src/views/zero-page/__tests__/credit-balance-section.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/credit-balance-section.test.tsx
@@ -1,5 +1,5 @@
-import { beforeEach, describe, expect, it } from "vitest";
-import { screen, waitFor, within } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { fireEvent, screen, waitFor, within } from "@testing-library/react";
 import type {
   UsageRecordResponse,
   UsageRecordRow,
@@ -116,6 +116,45 @@ describe("credit balance settings section", () => {
     await waitFor(() => {
       expect(screen.queryByRole("dialog")).not.toBeInTheDocument();
     });
+  });
+
+  it("keeps the settings dialog open when a usage row is opened in a new tab", async () => {
+    setMockOrg({ role: "member" });
+    setUsageRows([
+      usageRow({ title: "Member chat", source: "chat", index: 1 }),
+    ]);
+
+    const openSpy = vi.spyOn(window, "open").mockImplementation(() => {
+      return null;
+    });
+
+    try {
+      const dialog = await openCreditBalanceSection();
+
+      await waitFor(() => {
+        expect(within(dialog).getByText("Member chat")).toBeInTheDocument();
+      });
+
+      const rowLink = within(dialog).getByText("Member chat").closest("a");
+      expect(rowLink).not.toBeNull();
+
+      fireEvent.click(rowLink as HTMLElement, { metaKey: true });
+
+      await waitFor(() => {
+        expect(openSpy).toHaveBeenCalledWith(
+          expect.stringContaining(
+            "/chats/00000000-0000-4000-a000-000000000001",
+          ),
+          "_blank",
+        );
+      });
+      expect(screen.getByRole("dialog")).toBeInTheDocument();
+      expect(
+        within(screen.getByRole("dialog")).getByText("Member chat"),
+      ).toBeInTheDocument();
+    } finally {
+      openSpy.mockRestore();
+    }
   });
 
   it("loads additional personal rows and filters by source", async () => {

--- a/turbo/apps/platform/src/views/zero-page/__tests__/credit-balance-section.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/credit-balance-section.test.tsx
@@ -99,6 +99,25 @@ describe("credit balance settings section", () => {
     expect(within(dialog).queryByText("Team usage")).not.toBeInTheDocument();
   });
 
+  it("closes the settings dialog when a usage row is clicked", async () => {
+    setMockOrg({ role: "member" });
+    setUsageRows([
+      usageRow({ title: "Member chat", source: "chat", index: 1 }),
+    ]);
+
+    const dialog = await openCreditBalanceSection();
+
+    await waitFor(() => {
+      expect(within(dialog).getByText("Member chat")).toBeInTheDocument();
+    });
+
+    click(within(dialog).getByText("Member chat"));
+
+    await waitFor(() => {
+      expect(screen.queryByRole("dialog")).not.toBeInTheDocument();
+    });
+  });
+
   it("loads additional personal rows and filters by source", async () => {
     setMockOrg({ role: "member" });
     setUsageRows([

--- a/turbo/apps/platform/src/views/zero-page/components/preferences/personal-usage-record.tsx
+++ b/turbo/apps/platform/src/views/zero-page/components/preferences/personal-usage-record.tsx
@@ -1,3 +1,4 @@
+import type { MouseEvent } from "react";
 import { useGet, useLastLoadable, useSet } from "ccstate-react";
 import {
   IconBrandGithub,
@@ -27,6 +28,9 @@ import {
   usageRecordAsync$,
   usageSourceFilter$,
 } from "../../../../signals/zero-page/settings/personal-usage-record.ts";
+import { setSettingsDialogOpen$ } from "../../../../signals/zero-page/settings/settings-dialog.ts";
+import { pageSignal$ } from "../../../../signals/page-signal.ts";
+import { detach, Reason } from "../../../../signals/utils.ts";
 import { Link } from "../../../router/link.tsx";
 
 const CARD_BORDER = "0.7px solid hsl(var(--gray-400))";
@@ -133,8 +137,19 @@ export function SourceFilter({
 }
 
 function UsageRow({ row }: { row: UsageRecordRow }) {
+  const closeSettings = useSet(setSettingsDialogOpen$);
+  const pageSignal = useGet(pageSignal$);
   const { label, Icon } = SOURCE_META[row.source];
   const title = row.title && row.title.length > 0 ? row.title : "Untitled";
+
+  // Close the settings dialog so the navigated chat/activity is visible.
+  // Keep it open for new-tab clicks, which don't change the current page.
+  const closeOnNavigate = (e: MouseEvent<HTMLAnchorElement>) => {
+    if (e.metaKey || e.ctrlKey || e.shiftKey) {
+      return;
+    }
+    detach(closeSettings(false, pageSignal), Reason.DomCallback);
+  };
   const credits = `${formatCredits(row.credits)} credits`;
   const inner = (
     <>
@@ -163,6 +178,7 @@ function UsageRow({ row }: { row: UsageRecordRow }) {
         pathname="/chats/:threadId"
         options={{ pathParams: { threadId: row.threadId } }}
         className={ROW_CLASS}
+        onClick={closeOnNavigate}
       >
         {inner}
       </Link>
@@ -174,6 +190,7 @@ function UsageRow({ row }: { row: UsageRecordRow }) {
         pathname="/activities/:activityRunId"
         options={{ pathParams: { activityRunId: row.runId } }}
         className={ROW_CLASS}
+        onClick={closeOnNavigate}
       >
         {inner}
       </Link>


### PR DESCRIPTION
## Problem

In the **Credit balance** settings dialog, clicking a chat/activity row in the "My usage" list navigated to the target thread but left the settings dialog open on top, so the user couldn't see where they landed.

## Fix

`UsageRow` now closes the settings dialog when its link is clicked. To preserve expected behavior, the dialog stays open for new-tab clicks (⌘/Ctrl/Shift), which don't change the current page.

- Only personal usage rows (`PersonalUsageRecord`) are clickable links; the Team usage tab has no links, so no change is needed there.
- Reuses the existing `setSettingsDialogOpen$` / `pageSignal$` / `detach` pattern already used by `SettingsDialogMount`.

## Test

Added a case in `credit-balance-section.test.tsx` asserting the dialog closes when a usage row is clicked.

🤖 Generated with [Claude Code](https://claude.com/claude-code)