### PR TITLE
test: refactor guest-download scheduling fixtures

### DIFF
--- a/crates/guest-download/tests/integration/scheduling.rs
+++ b/crates/guest-download/tests/integration/scheduling.rs
@@ -1,6 +1,7 @@
 use crate::support::{create_tar_gz, run_guest_download, write_manifest};
 use httpmock::prelude::*;
 use httpmock::{HttpMockRequest, HttpMockResponse, Mock};
+use std::path::Path;
 use std::sync::atomic::{AtomicUsize, Ordering};
 use std::sync::{Arc, Condvar, Mutex, mpsc};
 use std::time::{Duration, Instant};
@@ -22,6 +23,12 @@ fn error_response(status: u16, body: String) -> HttpMockResponse {
         .status(status)
         .body(body)
         .build()
+}
+
+fn path_to_string(path: &Path) -> std::io::Result<String> {
+    path.to_str().map(str::to_owned).ok_or_else(|| {
+        std::io::Error::new(std::io::ErrorKind::InvalidData, "path is not valid UTF-8")
+    })
 }
 
 #[derive(Clone)]
@@ -337,10 +344,7 @@ fn create_numbered_storages(
         }
 
         let mount = dir.path().join(format!("mount_{i}"));
-        storages.push((
-            mount.to_string_lossy().into_owned(),
-            server.url("/storage.tar.gz"),
-        ));
+        storages.push((path_to_string(&mount)?, server.url("/storage.tar.gz")));
         servers.push(server);
     }
 
@@ -359,7 +363,7 @@ fn spawn_guest_download(
         .map(|(mount, url)| (mount.as_str(), Some(url.as_str())))
         .collect();
     let manifest = write_manifest(dir, &storage_refs, None)?;
-    let manifest_path = manifest.to_string_lossy().into_owned();
+    let manifest_path = path_to_string(&manifest)?;
     Ok(std::thread::spawn(move || {
         run_guest_download(&manifest_path)
     }))
@@ -490,10 +494,10 @@ fn queued_conflict_does_not_block_later_independent_download() {
     let url_child = child_server.url("/child.tar.gz");
     let url_independent = independent_server.url("/independent.tar.gz");
     let storages = vec![
-        (parent_mount.to_string_lossy().into_owned(), url_parent),
-        (child_mount.to_string_lossy().into_owned(), url_child),
+        (parent_mount.to_str().unwrap().to_owned(), url_parent),
+        (child_mount.to_str().unwrap().to_owned(), url_child),
         (
-            independent_mount.to_string_lossy().into_owned(),
+            independent_mount.to_str().unwrap().to_owned(),
             url_independent,
         ),
     ];
@@ -578,8 +582,8 @@ fn parent_child_mount_paths_are_serialized_for_overlapping_archives() {
     let url_parent = parent_server.url("/parent.tar.gz");
     let url_child = child_server.url("/child.tar.gz");
     let storages = vec![
-        (parent_mount.to_string_lossy().into_owned(), url_parent),
-        (child_mount.to_string_lossy().into_owned(), url_child),
+        (parent_mount.to_str().unwrap().to_owned(), url_parent),
+        (child_mount.to_str().unwrap().to_owned(), url_child),
     ];
     let handle = spawn_guest_download(&dir, &storages).unwrap();
 

--- a/crates/guest-download/tests/integration/scheduling.rs
+++ b/crates/guest-download/tests/integration/scheduling.rs
@@ -1,9 +1,13 @@
 use crate::support::{create_tar_gz, run_guest_download, write_manifest};
 use httpmock::prelude::*;
-use httpmock::{HttpMockRequest, HttpMockResponse};
+use httpmock::{HttpMockRequest, HttpMockResponse, Mock};
 use std::sync::atomic::{AtomicUsize, Ordering};
-use std::sync::{Arc, Mutex, mpsc};
+use std::sync::{Arc, Condvar, Mutex, mpsc};
 use std::time::{Duration, Instant};
+
+const REQUEST_START_TIMEOUT: Duration = Duration::from_secs(5);
+const BLOCKED_REQUEST_TIMEOUT: Duration = Duration::from_secs(10);
+const NEGATIVE_START_TIMEOUT: Duration = Duration::from_millis(300);
 
 fn gzip_response(body: Vec<u8>) -> HttpMockResponse {
     HttpMockResponse::builder()
@@ -11,6 +15,19 @@ fn gzip_response(body: Vec<u8>) -> HttpMockResponse {
         .header("content-type", "application/gzip")
         .body(body)
         .build()
+}
+
+fn error_response(status: u16, body: String) -> HttpMockResponse {
+    HttpMockResponse::builder()
+        .status(status)
+        .body(body)
+        .build()
+}
+
+#[derive(Clone)]
+struct ActiveRequestCounter {
+    active: Arc<AtomicUsize>,
+    max_active: Arc<AtomicUsize>,
 }
 
 struct ActiveRequestGuard {
@@ -23,21 +40,36 @@ impl Drop for ActiveRequestGuard {
     }
 }
 
-fn track_active_request(
-    active: &Arc<AtomicUsize>,
-    max_active: &Arc<AtomicUsize>,
-) -> ActiveRequestGuard {
-    let current = active.fetch_add(1, Ordering::SeqCst) + 1;
-    let mut observed = max_active.load(Ordering::SeqCst);
-    while current > observed {
-        match max_active.compare_exchange(observed, current, Ordering::SeqCst, Ordering::SeqCst) {
-            Ok(_) => break,
-            Err(actual) => observed = actual,
+impl ActiveRequestCounter {
+    fn new() -> Self {
+        Self {
+            active: Arc::new(AtomicUsize::new(0)),
+            max_active: Arc::new(AtomicUsize::new(0)),
         }
     }
 
-    ActiveRequestGuard {
-        active: Arc::clone(active),
+    fn track(&self) -> ActiveRequestGuard {
+        let current = self.active.fetch_add(1, Ordering::SeqCst) + 1;
+        let mut observed = self.max_active.load(Ordering::SeqCst);
+        while current > observed {
+            match self.max_active.compare_exchange(
+                observed,
+                current,
+                Ordering::SeqCst,
+                Ordering::SeqCst,
+            ) {
+                Ok(_) => break,
+                Err(actual) => observed = actual,
+            }
+        }
+
+        ActiveRequestGuard {
+            active: Arc::clone(&self.active),
+        }
+    }
+
+    fn max_active(&self) -> usize {
+        self.max_active.load(Ordering::SeqCst)
     }
 }
 
@@ -107,32 +139,163 @@ fn wait_for_events(
     Ok(events)
 }
 
-struct ReleaseOnDrop {
-    sender: mpsc::Sender<()>,
-    count: usize,
+struct ReleaseGate {
+    inner: Arc<ReleaseStateMonitor>,
 }
 
-impl Drop for ReleaseOnDrop {
-    fn drop(&mut self) {
-        for _ in 0..self.count {
-            let _ = self.sender.send(());
+#[derive(Clone)]
+struct ReleaseWaiter {
+    inner: Arc<ReleaseStateMonitor>,
+}
+
+struct ReleaseStateMonitor {
+    state: Mutex<ReleaseState>,
+    released: Condvar,
+}
+
+struct ReleaseState {
+    permits: usize,
+    closed: bool,
+}
+
+impl ReleaseGate {
+    fn new() -> Self {
+        Self {
+            inner: Arc::new(ReleaseStateMonitor {
+                state: Mutex::new(ReleaseState {
+                    permits: 0,
+                    closed: false,
+                }),
+                released: Condvar::new(),
+            }),
+        }
+    }
+
+    fn waiter(&self) -> ReleaseWaiter {
+        ReleaseWaiter {
+            inner: Arc::clone(&self.inner),
+        }
+    }
+
+    fn release_one(&self) {
+        self.release_many(1);
+    }
+
+    fn release_many(&self, count: usize) {
+        let mut state = self.lock_state();
+        state.permits += count;
+        drop(state);
+        self.inner.released.notify_all();
+    }
+
+    fn lock_state(&self) -> std::sync::MutexGuard<'_, ReleaseState> {
+        match self.inner.state.lock() {
+            Ok(state) => state,
+            Err(poisoned) => poisoned.into_inner(),
         }
     }
 }
 
-#[test]
-fn queued_independent_download_starts_when_slot_frees() {
-    let dir = tempfile::tempdir().unwrap();
-    let (event_tx, event_rx) = mpsc::channel();
-    let (slow_release_tx, slow_release_rx) = mpsc::channel();
-    let _slow_release_guard = ReleaseOnDrop {
-        sender: slow_release_tx.clone(),
-        count: 1,
-    };
-    let slow_release_rx = Arc::new(Mutex::new(slow_release_rx));
-    let active = Arc::new(AtomicUsize::new(0));
-    let max_active = Arc::new(AtomicUsize::new(0));
+impl Drop for ReleaseGate {
+    fn drop(&mut self) {
+        let mut state = self.lock_state();
+        state.closed = true;
+        drop(state);
+        self.inner.released.notify_all();
+    }
+}
 
+impl ReleaseWaiter {
+    fn wait(&self, request_name: &str) -> Result<(), String> {
+        let deadline = Instant::now() + BLOCKED_REQUEST_TIMEOUT;
+        let mut state = match self.inner.state.lock() {
+            Ok(state) => state,
+            Err(poisoned) => poisoned.into_inner(),
+        };
+
+        loop {
+            if state.closed {
+                return Ok(());
+            }
+
+            if state.permits > 0 {
+                state.permits -= 1;
+                return Ok(());
+            }
+
+            let now = Instant::now();
+            if now >= deadline {
+                return Err(format!("timed out waiting to release {request_name}"));
+            }
+
+            let wait_result = self.inner.released.wait_timeout(state, deadline - now);
+            let (next_state, wait_status) = match wait_result {
+                Ok(result) => result,
+                Err(poisoned) => poisoned.into_inner(),
+            };
+            state = next_state;
+
+            if wait_status.timed_out() && state.permits == 0 && !state.closed {
+                return Err(format!("timed out waiting to release {request_name}"));
+            }
+        }
+    }
+}
+
+fn serve_archive<'server>(
+    server: &'server MockServer,
+    path: &'static str,
+    body: Vec<u8>,
+    on_start: impl Fn() -> Result<(), String> + Send + Sync + 'static,
+    active_requests: Option<ActiveRequestCounter>,
+) -> Mock<'server> {
+    server.mock(move |when, then| {
+        when.method(GET).path(path);
+        then.respond_with(move |_req: &HttpMockRequest| {
+            let _active_guard = active_requests.as_ref().map(ActiveRequestCounter::track);
+            if let Err(error) = on_start() {
+                return error_response(409, error);
+            }
+            gzip_response(body.clone())
+        });
+    })
+}
+
+fn serve_blocked_archive<'server>(
+    server: &'server MockServer,
+    path: &'static str,
+    body: Vec<u8>,
+    on_start: impl Fn() -> Result<(), String> + Send + Sync + 'static,
+    release: ReleaseWaiter,
+    request_name: String,
+    active_requests: Option<ActiveRequestCounter>,
+) -> Mock<'server> {
+    server.mock(move |when, then| {
+        when.method(GET).path(path);
+        then.respond_with(move |_req: &HttpMockRequest| {
+            let _active_guard = active_requests.as_ref().map(ActiveRequestCounter::track);
+            if let Err(error) = on_start() {
+                return error_response(409, error);
+            }
+            if let Err(error) = release.wait(&request_name) {
+                return error_response(408, error);
+            }
+            gzip_response(body.clone())
+        });
+    })
+}
+
+struct NumberedStorages {
+    _servers: Vec<MockServer>,
+    storages: Vec<(String, String)>,
+}
+
+fn create_numbered_storages(
+    dir: &tempfile::TempDir,
+    event_tx: &mpsc::Sender<String>,
+    mut blocked_request: impl FnMut(usize) -> Option<ReleaseWaiter>,
+    active_requests: Option<ActiveRequestCounter>,
+) -> std::io::Result<NumberedStorages> {
     let mut servers = Vec::new();
     let mut storages = Vec::new();
 
@@ -140,65 +303,104 @@ fn queued_independent_download_starts_when_slot_frees() {
         let server = MockServer::start();
         let filename = format!("file_{i}.txt");
         let content = format!("content_{i}");
-        let body = Arc::new(create_tar_gz(&[(&filename, content.as_bytes())]).unwrap());
+        let body = create_tar_gz(&[(&filename, content.as_bytes())])?;
         let event_tx = event_tx.clone();
-        let active = Arc::clone(&active);
-        let max_active = Arc::clone(&max_active);
-        let slow_release_rx = Arc::clone(&slow_release_rx);
+        let event = format!("start-{i}");
+        let active_requests = active_requests.clone();
 
-        server.mock(move |when, then| {
-            when.method(GET).path("/storage.tar.gz");
-            then.respond_with(move |_req: &HttpMockRequest| {
-                let _active_guard = track_active_request(&active, &max_active);
-                let _ = event_tx.send(format!("start-{i}"));
-                if i == 0 {
-                    slow_release_rx
-                        .lock()
-                        .unwrap()
-                        .recv_timeout(Duration::from_secs(10))
-                        .expect("timed out waiting to release slow request");
-                }
-                gzip_response((*body).clone())
-            });
-        });
+        if let Some(release) = blocked_request(i) {
+            serve_blocked_archive(
+                &server,
+                "/storage.tar.gz",
+                body,
+                move || {
+                    event_tx
+                        .send(event.clone())
+                        .map_err(|e| format!("failed to send {event}: {e}"))
+                },
+                release,
+                format!("request {i}"),
+                active_requests,
+            );
+        } else {
+            serve_archive(
+                &server,
+                "/storage.tar.gz",
+                body,
+                move || {
+                    event_tx
+                        .send(event.clone())
+                        .map_err(|e| format!("failed to send {event}: {e}"))
+                },
+                active_requests,
+            );
+        }
 
         let mount = dir.path().join(format!("mount_{i}"));
         storages.push((
-            mount.to_str().unwrap().to_owned(),
+            mount.to_string_lossy().into_owned(),
             server.url("/storage.tar.gz"),
         ));
         servers.push(server);
     }
 
+    Ok(NumberedStorages {
+        _servers: servers,
+        storages,
+    })
+}
+
+fn spawn_guest_download(
+    dir: &tempfile::TempDir,
+    storages: &[(String, String)],
+) -> std::io::Result<std::thread::JoinHandle<bool>> {
     let storage_refs: Vec<(&str, Option<&str>)> = storages
         .iter()
         .map(|(mount, url)| (mount.as_str(), Some(url.as_str())))
         .collect();
-    let manifest = write_manifest(&dir, &storage_refs, None).unwrap();
-    let manifest_path = manifest.to_str().unwrap().to_owned();
-    let handle = std::thread::spawn(move || run_guest_download(&manifest_path));
+    let manifest = write_manifest(dir, &storage_refs, None)?;
+    let manifest_path = manifest.to_string_lossy().into_owned();
+    Ok(std::thread::spawn(move || {
+        run_guest_download(&manifest_path)
+    }))
+}
+
+#[test]
+fn queued_independent_download_starts_when_slot_frees() {
+    let dir = tempfile::tempdir().unwrap();
+    let (event_tx, event_rx) = mpsc::channel();
+    let slow_release = ReleaseGate::new();
+    let active_requests = ActiveRequestCounter::new();
+    let numbered = create_numbered_storages(
+        &dir,
+        &event_tx,
+        |i| (i == 0).then(|| slow_release.waiter()),
+        Some(active_requests.clone()),
+    )
+    .unwrap();
+    let handle = spawn_guest_download(&dir, &numbered.storages).unwrap();
 
     let mut seen_events = Vec::new();
     let slow_started = wait_for_event(
         &event_rx,
         &mut seen_events,
         "start-0",
-        Duration::from_secs(5),
+        REQUEST_START_TIMEOUT,
     );
     let queued_started = wait_for_event(
         &event_rx,
         &mut seen_events,
         "start-4",
-        Duration::from_secs(5),
+        REQUEST_START_TIMEOUT,
     );
-    slow_release_tx.send(()).unwrap();
+    slow_release.release_one();
     let result = handle.join().unwrap();
 
     slow_started.unwrap();
     queued_started.unwrap();
     assert!(result);
     assert!(
-        max_active.load(Ordering::SeqCst) <= 4,
+        active_requests.max_active() <= 4,
         "observed more than 4 active downloads"
     );
 
@@ -213,57 +415,14 @@ fn queued_independent_download_starts_when_slot_frees() {
 fn download_concurrency_cap_limits_initial_starts() {
     let dir = tempfile::tempdir().unwrap();
     let (event_tx, event_rx) = mpsc::channel();
-    let (release_tx, release_rx) = mpsc::channel();
-    let _release_guard = ReleaseOnDrop {
-        sender: release_tx.clone(),
-        count: 5,
-    };
-    let release_rx = Arc::new(Mutex::new(release_rx));
-    let mut servers = Vec::new();
-    let mut storages = Vec::new();
+    let release = ReleaseGate::new();
+    let numbered =
+        create_numbered_storages(&dir, &event_tx, |_| Some(release.waiter()), None).unwrap();
+    let handle = spawn_guest_download(&dir, &numbered.storages).unwrap();
 
-    for i in 0..5 {
-        let server = MockServer::start();
-        let filename = format!("file_{i}.txt");
-        let content = format!("content_{i}");
-        let body = Arc::new(create_tar_gz(&[(&filename, content.as_bytes())]).unwrap());
-        let event_tx = event_tx.clone();
-        let release_rx = Arc::clone(&release_rx);
-
-        server.mock(move |when, then| {
-            when.method(GET).path("/storage.tar.gz");
-            then.respond_with(move |_req: &HttpMockRequest| {
-                let _ = event_tx.send(format!("start-{i}"));
-                release_rx
-                    .lock()
-                    .unwrap()
-                    .recv_timeout(Duration::from_secs(10))
-                    .expect("timed out waiting to release blocked request");
-                gzip_response((*body).clone())
-            });
-        });
-
-        let mount = dir.path().join(format!("mount_{i}"));
-        storages.push((
-            mount.to_str().unwrap().to_owned(),
-            server.url("/storage.tar.gz"),
-        ));
-        servers.push(server);
-    }
-
-    let storage_refs: Vec<(&str, Option<&str>)> = storages
-        .iter()
-        .map(|(mount, url)| (mount.as_str(), Some(url.as_str())))
-        .collect();
-    let manifest = write_manifest(&dir, &storage_refs, None).unwrap();
-    let manifest_path = manifest.to_str().unwrap().to_owned();
-    let handle = std::thread::spawn(move || run_guest_download(&manifest_path));
-
-    let initial_starts = wait_for_events(&event_rx, 4, Duration::from_secs(5));
-    let fifth_before_release = event_rx.recv_timeout(Duration::from_millis(300));
-    for _ in 0..5 {
-        release_tx.send(()).unwrap();
-    }
+    let initial_starts = wait_for_events(&event_rx, 4, REQUEST_START_TIMEOUT);
+    let fifth_before_release = event_rx.recv_timeout(NEGATIVE_START_TIMEOUT);
+    release.release_many(5);
     let result = handle.join().unwrap();
 
     assert_eq!(initial_starts.unwrap().len(), 4);
@@ -289,60 +448,64 @@ fn queued_conflict_does_not_block_later_independent_download() {
     let (parent_started_tx, parent_started_rx) = mpsc::channel();
     let (child_started_tx, child_started_rx) = mpsc::channel();
     let (independent_started_tx, independent_started_rx) = mpsc::channel();
-    let (parent_release_tx, parent_release_rx) = mpsc::channel();
-    let _parent_release_guard = ReleaseOnDrop {
-        sender: parent_release_tx.clone(),
-        count: 1,
-    };
-    let parent_release_rx = Arc::new(Mutex::new(parent_release_rx));
+    let parent_release = ReleaseGate::new();
 
-    let parent_release_rx_for_mock = Arc::clone(&parent_release_rx);
-    parent_server.mock(move |when, then| {
-        when.method(GET).path("/parent.tar.gz");
-        then.respond_with(move |_req: &HttpMockRequest| {
-            parent_started_tx.send(()).unwrap();
-            parent_release_rx_for_mock
-                .lock()
-                .unwrap()
-                .recv_timeout(Duration::from_secs(10))
-                .expect("timed out waiting to release parent request");
-            gzip_response(parent_tar.clone())
-        });
-    });
-    child_server.mock(move |when, then| {
-        when.method(GET).path("/child.tar.gz");
-        then.respond_with(move |_req: &HttpMockRequest| {
-            child_started_tx.send(()).unwrap();
-            gzip_response(child_tar.clone())
-        });
-    });
-    independent_server.mock(move |when, then| {
-        when.method(GET).path("/independent.tar.gz");
-        then.respond_with(move |_req: &HttpMockRequest| {
-            independent_started_tx.send(()).unwrap();
-            gzip_response(independent_tar.clone())
-        });
-    });
+    serve_blocked_archive(
+        &parent_server,
+        "/parent.tar.gz",
+        parent_tar,
+        move || {
+            parent_started_tx
+                .send(())
+                .map_err(|e| format!("failed to send parent start event: {e}"))
+        },
+        parent_release.waiter(),
+        "parent request".to_owned(),
+        None,
+    );
+    serve_archive(
+        &child_server,
+        "/child.tar.gz",
+        child_tar,
+        move || {
+            child_started_tx
+                .send(())
+                .map_err(|e| format!("failed to send child start event: {e}"))
+        },
+        None,
+    );
+    serve_archive(
+        &independent_server,
+        "/independent.tar.gz",
+        independent_tar,
+        move || {
+            independent_started_tx
+                .send(())
+                .map_err(|e| format!("failed to send independent start event: {e}"))
+        },
+        None,
+    );
 
     let url_parent = parent_server.url("/parent.tar.gz");
     let url_child = child_server.url("/child.tar.gz");
     let url_independent = independent_server.url("/independent.tar.gz");
-    let storages: Vec<(&str, Option<&str>)> = vec![
-        (parent_mount.to_str().unwrap(), Some(&url_parent)),
-        (child_mount.to_str().unwrap(), Some(&url_child)),
-        (independent_mount.to_str().unwrap(), Some(&url_independent)),
+    let storages = vec![
+        (parent_mount.to_string_lossy().into_owned(), url_parent),
+        (child_mount.to_string_lossy().into_owned(), url_child),
+        (
+            independent_mount.to_string_lossy().into_owned(),
+            url_independent,
+        ),
     ];
-    let manifest = write_manifest(&dir, &storages, None).unwrap();
-    let manifest_path = manifest.to_str().unwrap().to_owned();
-    let handle = std::thread::spawn(move || run_guest_download(&manifest_path));
+    let handle = spawn_guest_download(&dir, &storages).unwrap();
 
-    let parent_started = parent_started_rx.recv_timeout(Duration::from_secs(5));
-    let independent_started = independent_started_rx.recv_timeout(Duration::from_secs(5));
-    let child_before_release = child_started_rx.recv_timeout(Duration::from_millis(300));
-    parent_release_tx.send(()).unwrap();
+    let parent_started = parent_started_rx.recv_timeout(REQUEST_START_TIMEOUT);
+    let independent_started = independent_started_rx.recv_timeout(REQUEST_START_TIMEOUT);
+    let child_before_release = child_started_rx.recv_timeout(NEGATIVE_START_TIMEOUT);
+    parent_release.release_one();
     let child_after_release =
         if matches!(child_before_release, Err(mpsc::RecvTimeoutError::Timeout)) {
-            child_started_rx.recv_timeout(Duration::from_secs(5))
+            child_started_rx.recv_timeout(REQUEST_START_TIMEOUT)
         } else {
             Ok(())
         };
@@ -385,50 +548,47 @@ fn parent_child_mount_paths_are_serialized_for_overlapping_archives() {
     let child_tar = create_tar_gz(&[("skill.json", b"child skill")]).unwrap();
     let (parent_started_tx, parent_started_rx) = mpsc::channel();
     let (child_started_tx, child_started_rx) = mpsc::channel();
-    let (parent_release_tx, parent_release_rx) = mpsc::channel();
-    let _parent_release_guard = ReleaseOnDrop {
-        sender: parent_release_tx.clone(),
-        count: 1,
-    };
-    let parent_release_rx = Arc::new(Mutex::new(parent_release_rx));
+    let parent_release = ReleaseGate::new();
 
-    let parent_release_rx_for_mock = Arc::clone(&parent_release_rx);
-    let m_parent = parent_server.mock(move |when, then| {
-        when.method(GET).path("/parent.tar.gz");
-        then.respond_with(move |_req: &HttpMockRequest| {
-            parent_started_tx.send(()).unwrap();
-            parent_release_rx_for_mock
-                .lock()
-                .unwrap()
-                .recv_timeout(Duration::from_secs(10))
-                .expect("timed out waiting to release parent request");
-            gzip_response(parent_tar.clone())
-        });
-    });
-    let m_child = child_server.mock(move |when, then| {
-        when.method(GET).path("/child.tar.gz");
-        then.respond_with(move |_req: &HttpMockRequest| {
-            child_started_tx.send(()).unwrap();
-            gzip_response(child_tar.clone())
-        });
-    });
+    let m_parent = serve_blocked_archive(
+        &parent_server,
+        "/parent.tar.gz",
+        parent_tar,
+        move || {
+            parent_started_tx
+                .send(())
+                .map_err(|e| format!("failed to send parent start event: {e}"))
+        },
+        parent_release.waiter(),
+        "parent request".to_owned(),
+        None,
+    );
+    let m_child = serve_archive(
+        &child_server,
+        "/child.tar.gz",
+        child_tar,
+        move || {
+            child_started_tx
+                .send(())
+                .map_err(|e| format!("failed to send child start event: {e}"))
+        },
+        None,
+    );
 
     let url_parent = parent_server.url("/parent.tar.gz");
     let url_child = child_server.url("/child.tar.gz");
-    let storages: Vec<(&str, Option<&str>)> = vec![
-        (parent_mount.to_str().unwrap(), Some(&url_parent)),
-        (child_mount.to_str().unwrap(), Some(&url_child)),
+    let storages = vec![
+        (parent_mount.to_string_lossy().into_owned(), url_parent),
+        (child_mount.to_string_lossy().into_owned(), url_child),
     ];
-    let manifest = write_manifest(&dir, &storages, None).unwrap();
-    let manifest_path = manifest.to_str().unwrap().to_owned();
-    let handle = std::thread::spawn(move || run_guest_download(&manifest_path));
+    let handle = spawn_guest_download(&dir, &storages).unwrap();
 
-    let parent_started = parent_started_rx.recv_timeout(Duration::from_secs(5));
-    let child_before_release = child_started_rx.recv_timeout(Duration::from_millis(300));
-    parent_release_tx.send(()).unwrap();
+    let parent_started = parent_started_rx.recv_timeout(REQUEST_START_TIMEOUT);
+    let child_before_release = child_started_rx.recv_timeout(NEGATIVE_START_TIMEOUT);
+    parent_release.release_one();
     let child_after_release =
         if matches!(child_before_release, Err(mpsc::RecvTimeoutError::Timeout)) {
-            child_started_rx.recv_timeout(Duration::from_secs(5))
+            child_started_rx.recv_timeout(REQUEST_START_TIMEOUT)
         } else {
             Ok(())
         };


### PR DESCRIPTION
## Summary

- add a local scheduling test harness for blocked archive responses and release gates
- factor repeated numbered storage setup and background guest-download runner setup
- keep parent/child mount topology and timing assertions visible in each scheduling test

Closes #16971

## Tests

- cargo fmt --all --check (from crates/)
- cargo clippy --manifest-path crates/Cargo.toml -p guest-download --tests
- cargo test --manifest-path crates/Cargo.toml -p guest-download
- cargo test --manifest-path crates/Cargo.toml -p guest-download scheduling -- --nocapture
