### PR TITLE
perf: bulk ingest agent telemetry sandbox operations

### DIFF
--- a/turbo/apps/api/src/signals/external/sandbox-op-log.ts
+++ b/turbo/apps/api/src/signals/external/sandbox-op-log.ts
@@ -24,6 +24,8 @@ interface SandboxOperationAttrs {
   readonly dimensions?: Record<string, unknown>;
 }
 
+export const SANDBOX_OP_LOG_DATASET = "sandbox-op-log";
+
 const telemetryAxiomClient = singleton((): Axiom => {
   return new Axiom({ token: env("AXIOM_TOKEN_TELEMETRY") });
 });
@@ -36,28 +38,34 @@ function hasIngest(client: Axiom): client is Axiom & AxiomIngestClient {
   );
 }
 
+export function sandboxOperationAxiomEvent(
+  attrs: SandboxOperationAttrs,
+): Record<string, unknown> {
+  return {
+    _time: attrs.timestamp ?? nowDate().toISOString(),
+    source: "api",
+    op_type: attrs.actionType,
+    sandbox_type: attrs.sandboxType,
+    duration_ms: attrs.durationMs,
+    success: attrs.success,
+    run_id: attrs.runId,
+    ...attrs.dimensions,
+  };
+}
+
 export function recordSandboxOperation(attrs: SandboxOperationAttrs): void {
   const client = telemetryAxiomClient();
   if (!hasIngest(client)) {
     return;
   }
 
-  const dataset = `vm0-sandbox-op-log-${env("AXIOM_DATASET_SUFFIX")}`;
+  const dataset = `vm0-${SANDBOX_OP_LOG_DATASET}-${env(
+    "AXIOM_DATASET_SUFFIX",
+  )}`;
   waitUntil(
     tapError(
       Promise.resolve(
-        client.ingest(dataset, [
-          {
-            _time: attrs.timestamp ?? nowDate().toISOString(),
-            source: "api",
-            op_type: attrs.actionType,
-            sandbox_type: attrs.sandboxType,
-            duration_ms: attrs.durationMs,
-            success: attrs.success,
-            run_id: attrs.runId,
-            ...attrs.dimensions,
-          },
-        ]),
+        client.ingest(dataset, [sandboxOperationAxiomEvent(attrs)]),
       ),
       (error) => {
         L.warn("Failed to ingest sandbox operation log", { error });

--- a/turbo/apps/api/src/signals/routes/__tests__/webhooks-agent-health-usage-telemetry.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/webhooks-agent-health-usage-telemetry.test.ts
@@ -1310,7 +1310,18 @@ describe("POST /api/webhooks/agent/telemetry", () => {
 
     const response = await accept(
       client.send({
-        body: { runId: randomUUID(), systemLog: "boot ok" },
+        body: {
+          runId: randomUUID(),
+          systemLog: "boot ok",
+          sandboxOperations: [
+            {
+              ts: "2026-05-14T01:00:02.000Z",
+              action_type: "codex_exec",
+              duration_ms: 123,
+              success: true,
+            },
+          ],
+        },
         headers: {},
       }),
       [401],
@@ -1324,6 +1335,7 @@ describe("POST /api/webhooks/agent/telemetry", () => {
     });
     expect(context.mocks.axiom.ingest).not.toHaveBeenCalled();
     expect(context.mocks.axiom.flush).not.toHaveBeenCalled();
+    expect(context.mocks.axiom.sdkIngest).not.toHaveBeenCalled();
   });
 
   it("rejects missing runId before ingesting telemetry", async () => {
@@ -1341,6 +1353,7 @@ describe("POST /api/webhooks/agent/telemetry", () => {
     expect(JSON.stringify(response.body)).toContain("runId");
     expect(context.mocks.axiom.ingest).not.toHaveBeenCalled();
     expect(context.mocks.axiom.flush).not.toHaveBeenCalled();
+    expect(context.mocks.axiom.sdkIngest).not.toHaveBeenCalled();
   });
 
   it("returns 404 when the authenticated run no longer exists", async () => {
@@ -1364,6 +1377,7 @@ describe("POST /api/webhooks/agent/telemetry", () => {
     });
     expect(context.mocks.axiom.ingest).not.toHaveBeenCalled();
     expect(context.mocks.axiom.flush).not.toHaveBeenCalled();
+    expect(context.mocks.axiom.sdkIngest).not.toHaveBeenCalled();
   });
 
   it("returns 404 for a run owned by a different user", async () => {
@@ -1387,6 +1401,7 @@ describe("POST /api/webhooks/agent/telemetry", () => {
     });
     expect(context.mocks.axiom.ingest).not.toHaveBeenCalled();
     expect(context.mocks.axiom.flush).not.toHaveBeenCalled();
+    expect(context.mocks.axiom.sdkIngest).not.toHaveBeenCalled();
   });
 
   it("ingests sandbox telemetry and flushes uploaded telemetry", async () => {
@@ -1474,25 +1489,212 @@ describe("POST /api/webhooks/agent/telemetry", () => {
         },
       ],
     );
+    expect(context.mocks.axiom.ingest).toHaveBeenCalledWith("sandbox-op-log", [
+      expect.objectContaining({
+        _time: "2026-05-14T01:00:02.000Z",
+        source: "sandbox",
+        op_type: "codex_exec",
+        sandbox_type: "runner",
+        duration_ms: 123,
+        success: false,
+        run_id: fixture.runId,
+        error: "exit 1",
+      }),
+    ]);
     expect(context.mocks.axiom.flush).toHaveBeenCalledWith({
       client: "telemetry",
       throwOnError: true,
     });
-    expect(context.mocks.axiom.sdkIngest).toHaveBeenCalledWith(
-      "vm0-sandbox-op-log-dev",
-      [
-        expect.objectContaining({
-          _time: "2026-05-14T01:00:02.000Z",
-          source: "sandbox",
-          op_type: "codex_exec",
-          sandbox_type: "runner",
-          duration_ms: 123,
-          success: false,
-          run_id: fixture.runId,
-          error: "exit 1",
-        }),
-      ],
+    expect(context.mocks.axiom.sdkIngest).not.toHaveBeenCalled();
+  });
+
+  it("bulk ingests multiple sandbox operations with one telemetry flush", async () => {
+    const fixture = await track(seedFixture());
+    const client = setupApp({ context })(webhookTelemetryContract);
+
+    const response = await accept(
+      client.send({
+        body: {
+          runId: fixture.runId,
+          sandboxOperations: [
+            {
+              ts: "2026-05-14T01:00:02.000Z",
+              action_type: "codex_exec",
+              duration_ms: 123,
+              success: true,
+            },
+            {
+              ts: "2026-05-14T01:00:03.000Z",
+              action_type: "storage_checkpoint",
+              duration_ms: 456,
+              success: false,
+              error: "checkpoint failed",
+            },
+          ],
+        },
+        headers: authHeaders(fixture),
+      }),
+      [200],
     );
+
+    expect(response.body).toStrictEqual({
+      success: true,
+      id: fixture.runId,
+    });
+    expect(context.mocks.axiom.ingest).toHaveBeenCalledTimes(1);
+    expect(context.mocks.axiom.ingest).toHaveBeenCalledWith("sandbox-op-log", [
+      {
+        _time: "2026-05-14T01:00:02.000Z",
+        source: "sandbox",
+        op_type: "codex_exec",
+        sandbox_type: "runner",
+        duration_ms: 123,
+        success: true,
+        run_id: fixture.runId,
+      },
+      {
+        _time: "2026-05-14T01:00:03.000Z",
+        source: "sandbox",
+        op_type: "storage_checkpoint",
+        sandbox_type: "runner",
+        duration_ms: 456,
+        success: false,
+        run_id: fixture.runId,
+        error: "checkpoint failed",
+      },
+    ]);
+    expect(context.mocks.axiom.flush).toHaveBeenCalledTimes(1);
+    expect(context.mocks.axiom.flush).toHaveBeenCalledWith({
+      client: "telemetry",
+      throwOnError: true,
+    });
+    expect(context.mocks.axiom.sdkIngest).not.toHaveBeenCalled();
+  });
+
+  it("rejects sandbox operation telemetry when Axiom flush fails", async () => {
+    const fixture = await track(seedFixture());
+    const client = setupApp({ context })(webhookTelemetryContract);
+    const error = new Error("flush failed");
+    context.mocks.axiom.flush.mockRejectedValueOnce(error);
+
+    const response = await accept(
+      client.send({
+        body: {
+          runId: fixture.runId,
+          sandboxOperations: [
+            {
+              ts: "2026-05-14T01:00:02.000Z",
+              action_type: "codex_exec",
+              duration_ms: 123,
+              success: true,
+            },
+          ],
+        },
+        headers: authHeaders(fixture),
+      }),
+      [500],
+    );
+
+    expect(response.body).toStrictEqual({ error: "Internal server error" });
+    expect(context.mocks.axiom.ingest).toHaveBeenCalledWith(
+      "sandbox-op-log",
+      expect.any(Array),
+    );
+    expect(context.mocks.axiom.flush).toHaveBeenCalledWith({
+      client: "telemetry",
+      throwOnError: true,
+    });
+    expect(context.mocks.axiomLogging.warn).toHaveBeenCalledWith(
+      "Agent telemetry Axiom flush failed",
+      expect.objectContaining({
+        runId: fixture.runId,
+        sandboxOperationCount: 1,
+        axiomDatasetFamilies: ["sandbox_operations"],
+        axiomFailureCategory: "flush",
+        error,
+      }),
+    );
+  });
+
+  it("emits safe telemetry observability metadata", async () => {
+    const fixture = await track(seedFixture());
+    const client = setupApp({ context })(webhookTelemetryContract);
+    const rawSystemLog = "secret system log";
+    const rawNetworkUrl = "https://api.example.com/secret-token";
+    const rawSandboxError = "secret sandbox failure";
+
+    await accept(
+      client.send({
+        body: {
+          runId: fixture.runId,
+          systemLog: rawSystemLog,
+          metrics: [
+            {
+              ts: "2026-05-14T01:00:00.000Z",
+              cpu: 10,
+              mem_used: 100,
+              mem_total: 200,
+              disk_used: 300,
+              disk_total: 400,
+            },
+          ],
+          networkLogs: [
+            {
+              timestamp: "2026-05-14T01:00:01.000Z",
+              action: "ALLOW",
+              url: rawNetworkUrl,
+              port: 443,
+            },
+          ],
+          sandboxOperations: [
+            {
+              ts: "2026-05-14T01:00:02.000Z",
+              action_type: "codex_exec",
+              duration_ms: 123,
+              success: false,
+              error: rawSandboxError,
+            },
+          ],
+        },
+        headers: authHeaders(fixture),
+      }),
+      [200],
+    );
+
+    expect(context.mocks.axiomLogging.debug).toHaveBeenCalledWith(
+      "Agent telemetry ingested",
+      expect.objectContaining({
+        context: "webhooks:agent",
+        runId: fixture.runId,
+        hasSystemLog: true,
+        hasMetrics: true,
+        hasNetworkLogs: true,
+        hasSandboxOperations: true,
+        metricsCount: 1,
+        networkLogCount: 1,
+        sandboxOperationCount: 1,
+        sandboxOperationErrorCount: 1,
+        approxPayloadBytes: expect.any(Number),
+        approxPayloadSizeBucket: expect.any(String),
+        axiomDatasetFamilies: [
+          "system",
+          "metrics",
+          "network",
+          "sandbox_operations",
+        ],
+        axiomLatencyMs: expect.any(Number),
+        telemetryBuffered: true,
+      }),
+    );
+    const successLog = context.mocks.axiomLogging.debug.mock.calls.find(
+      (call) => {
+        return call[0] === "Agent telemetry ingested";
+      },
+    );
+    const serializedLogFields = JSON.stringify(successLog?.[1]);
+    expect(serializedLogFields).not.toContain(rawSystemLog);
+    expect(serializedLogFields).not.toContain(rawNetworkUrl);
+    expect(serializedLogFields).not.toContain(rawSandboxError);
   });
 
   it("accepts multiple telemetry uploads for the same run", async () => {

--- a/turbo/apps/api/src/signals/routes/__tests__/webhooks-agent-health-usage-telemetry.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/webhooks-agent-health-usage-telemetry.test.ts
@@ -1562,16 +1562,24 @@ describe("POST /api/webhooks/agent/telemetry", () => {
     ]);
     expect(context.mocks.axiom.flush).not.toHaveBeenCalled();
     expect(context.mocks.axiom.sdkIngest).not.toHaveBeenCalled();
+    expect(
+      context.mocks.axiomLogging.debug.mock.calls.some((call) => {
+        return call[0] === "Agent telemetry ingested";
+      }),
+    ).toBeFalsy();
   });
 
-  it("emits safe telemetry observability metadata", async () => {
+  it("emits safe telemetry observability metadata when Axiom ingest is skipped", async () => {
     const fixture = await track(seedFixture());
     const client = setupApp({ context })(webhookTelemetryContract);
     const rawSystemLog = "secret system log";
     const rawNetworkUrl = "https://api.example.com/secret-token";
     const rawSandboxError = "secret sandbox failure";
+    context.mocks.axiom.ingest.mockImplementation((dataset) => {
+      return dataset !== "sandbox-op-log";
+    });
 
-    await accept(
+    const response = await accept(
       client.send({
         body: {
           runId: fixture.runId,
@@ -1609,8 +1617,13 @@ describe("POST /api/webhooks/agent/telemetry", () => {
       [200],
     );
 
-    expect(context.mocks.axiomLogging.debug).toHaveBeenCalledWith(
-      "Agent telemetry ingested",
+    expect(response.body).toStrictEqual({
+      success: true,
+      id: fixture.runId,
+    });
+    expect(context.mocks.axiomLogging.warn).toHaveBeenCalledTimes(1);
+    expect(context.mocks.axiomLogging.warn).toHaveBeenCalledWith(
+      "Agent telemetry Axiom ingest skipped",
       expect.objectContaining({
         context: "webhooks:agent",
         runId: fixture.runId,
@@ -1624,24 +1637,50 @@ describe("POST /api/webhooks/agent/telemetry", () => {
         sandboxOperationErrorCount: 1,
         approxPayloadBytes: expect.any(Number),
         approxPayloadSizeBucket: expect.any(String),
-        axiomDatasetFamilies: [
-          "system",
-          "metrics",
-          "network",
-          "sandbox_operations",
-        ],
-        telemetryAccepted: true,
+        axiomDatasetFamily: "sandbox_operations",
+        axiomFailureCategory: "ingest_skipped",
       }),
     );
-    const successLog = context.mocks.axiomLogging.debug.mock.calls.find(
-      (call) => {
+    expect(
+      context.mocks.axiomLogging.debug.mock.calls.some((call) => {
         return call[0] === "Agent telemetry ingested";
+      }),
+    ).toBeFalsy();
+    const skippedLog = context.mocks.axiomLogging.warn.mock.calls.find(
+      (call) => {
+        return call[0] === "Agent telemetry Axiom ingest skipped";
       },
     );
-    const serializedLogFields = JSON.stringify(successLog?.[1]);
+    const serializedLogFields = JSON.stringify(skippedLog?.[1]);
     expect(serializedLogFields).not.toContain(rawSystemLog);
     expect(serializedLogFields).not.toContain(rawNetworkUrl);
     expect(serializedLogFields).not.toContain(rawSandboxError);
+  });
+
+  it("does not emit per-request success logs for successful ingestion", async () => {
+    const fixture = await track(seedFixture());
+    const client = setupApp({ context })(webhookTelemetryContract);
+
+    await accept(
+      client.send({
+        body: { runId: fixture.runId, systemLog: "First batch" },
+        headers: authHeaders(fixture),
+      }),
+      [200],
+    );
+
+    expect(context.mocks.axiom.ingest).toHaveBeenCalledWith(
+      "sandbox-telemetry-system",
+      [
+        expect.objectContaining({
+          runId: fixture.runId,
+          userId: fixture.userId,
+          log: "First batch",
+        }),
+      ],
+    );
+    expect(context.mocks.axiomLogging.debug).not.toHaveBeenCalled();
+    expect(context.mocks.axiomLogging.warn).not.toHaveBeenCalled();
   });
 
   it("accepts multiple telemetry uploads for the same run", async () => {

--- a/turbo/apps/api/src/signals/routes/__tests__/webhooks-agent-health-usage-telemetry.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/webhooks-agent-health-usage-telemetry.test.ts
@@ -24,6 +24,7 @@ import { verifyHmacSignature } from "../../../lib/event-consumer/hmac";
 import { now } from "../../../lib/time";
 import { writeDb$ } from "../../external/db";
 import { signSandboxJwtForTests } from "../../auth/tokens";
+import { clearAllDetached } from "../../utils";
 import { seedAgentRunCallback$ } from "./helpers/agent-run-callback";
 import {
   deleteUsageInsightFixture$,
@@ -1571,7 +1572,7 @@ describe("POST /api/webhooks/agent/telemetry", () => {
     expect(context.mocks.axiom.sdkIngest).not.toHaveBeenCalled();
   });
 
-  it("rejects sandbox operation telemetry when Axiom flush fails", async () => {
+  it("accepts sandbox operation telemetry when Axiom flush fails", async () => {
     const fixture = await track(seedFixture());
     const client = setupApp({ context })(webhookTelemetryContract);
     const error = new Error("flush failed");
@@ -1592,10 +1593,13 @@ describe("POST /api/webhooks/agent/telemetry", () => {
         },
         headers: authHeaders(fixture),
       }),
-      [500],
+      [200],
     );
 
-    expect(response.body).toStrictEqual({ error: "Internal server error" });
+    expect(response.body).toStrictEqual({
+      success: true,
+      id: fixture.runId,
+    });
     expect(context.mocks.axiom.ingest).toHaveBeenCalledWith(
       "sandbox-op-log",
       expect.any(Array),
@@ -1604,6 +1608,7 @@ describe("POST /api/webhooks/agent/telemetry", () => {
       client: "telemetry",
       throwOnError: true,
     });
+    await clearAllDetached();
     expect(context.mocks.axiomLogging.warn).toHaveBeenCalledWith(
       "Agent telemetry Axiom flush failed",
       expect.objectContaining({
@@ -1682,7 +1687,7 @@ describe("POST /api/webhooks/agent/telemetry", () => {
           "network",
           "sandbox_operations",
         ],
-        axiomLatencyMs: expect.any(Number),
+        axiomFlushQueued: true,
         telemetryBuffered: true,
       }),
     );

--- a/turbo/apps/api/src/signals/routes/__tests__/webhooks-agent-health-usage-telemetry.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/webhooks-agent-health-usage-telemetry.test.ts
@@ -24,7 +24,6 @@ import { verifyHmacSignature } from "../../../lib/event-consumer/hmac";
 import { now } from "../../../lib/time";
 import { writeDb$ } from "../../external/db";
 import { signSandboxJwtForTests } from "../../auth/tokens";
-import { clearAllDetached } from "../../utils";
 import { seedAgentRunCallback$ } from "./helpers/agent-run-callback";
 import {
   deleteUsageInsightFixture$,
@@ -1405,7 +1404,7 @@ describe("POST /api/webhooks/agent/telemetry", () => {
     expect(context.mocks.axiom.sdkIngest).not.toHaveBeenCalled();
   });
 
-  it("ingests sandbox telemetry and flushes uploaded telemetry", async () => {
+  it("ingests sandbox telemetry through the telemetry Axiom client", async () => {
     const fixture = await track(seedFixture());
     const client = setupApp({ context })(webhookTelemetryContract);
     context.mocks.axiom.sdkIngest.mockReset();
@@ -1502,14 +1501,11 @@ describe("POST /api/webhooks/agent/telemetry", () => {
         error: "exit 1",
       }),
     ]);
-    expect(context.mocks.axiom.flush).toHaveBeenCalledWith({
-      client: "telemetry",
-      throwOnError: true,
-    });
+    expect(context.mocks.axiom.flush).not.toHaveBeenCalled();
     expect(context.mocks.axiom.sdkIngest).not.toHaveBeenCalled();
   });
 
-  it("bulk ingests multiple sandbox operations with one telemetry flush", async () => {
+  it("bulk queues multiple sandbox operations in one Axiom ingest call", async () => {
     const fixture = await track(seedFixture());
     const client = setupApp({ context })(webhookTelemetryContract);
 
@@ -1564,61 +1560,8 @@ describe("POST /api/webhooks/agent/telemetry", () => {
         error: "checkpoint failed",
       },
     ]);
-    expect(context.mocks.axiom.flush).toHaveBeenCalledTimes(1);
-    expect(context.mocks.axiom.flush).toHaveBeenCalledWith({
-      client: "telemetry",
-      throwOnError: true,
-    });
+    expect(context.mocks.axiom.flush).not.toHaveBeenCalled();
     expect(context.mocks.axiom.sdkIngest).not.toHaveBeenCalled();
-  });
-
-  it("accepts sandbox operation telemetry when Axiom flush fails", async () => {
-    const fixture = await track(seedFixture());
-    const client = setupApp({ context })(webhookTelemetryContract);
-    const error = new Error("flush failed");
-    context.mocks.axiom.flush.mockRejectedValueOnce(error);
-
-    const response = await accept(
-      client.send({
-        body: {
-          runId: fixture.runId,
-          sandboxOperations: [
-            {
-              ts: "2026-05-14T01:00:02.000Z",
-              action_type: "codex_exec",
-              duration_ms: 123,
-              success: true,
-            },
-          ],
-        },
-        headers: authHeaders(fixture),
-      }),
-      [200],
-    );
-
-    expect(response.body).toStrictEqual({
-      success: true,
-      id: fixture.runId,
-    });
-    expect(context.mocks.axiom.ingest).toHaveBeenCalledWith(
-      "sandbox-op-log",
-      expect.any(Array),
-    );
-    expect(context.mocks.axiom.flush).toHaveBeenCalledWith({
-      client: "telemetry",
-      throwOnError: true,
-    });
-    await clearAllDetached();
-    expect(context.mocks.axiomLogging.warn).toHaveBeenCalledWith(
-      "Agent telemetry Axiom flush failed",
-      expect.objectContaining({
-        runId: fixture.runId,
-        sandboxOperationCount: 1,
-        axiomDatasetFamilies: ["sandbox_operations"],
-        axiomFailureCategory: "flush",
-        error,
-      }),
-    );
   });
 
   it("emits safe telemetry observability metadata", async () => {
@@ -1687,8 +1630,7 @@ describe("POST /api/webhooks/agent/telemetry", () => {
           "network",
           "sandbox_operations",
         ],
-        axiomFlushQueued: true,
-        telemetryBuffered: true,
+        telemetryAccepted: true,
       }),
     );
     const successLog = context.mocks.axiomLogging.debug.mock.calls.find(
@@ -1753,14 +1695,6 @@ describe("POST /api/webhooks/agent/telemetry", () => {
         }),
       ],
     );
-    expect(context.mocks.axiom.flush).toHaveBeenCalledTimes(2);
-    expect(context.mocks.axiom.flush).toHaveBeenNthCalledWith(1, {
-      client: "telemetry",
-      throwOnError: true,
-    });
-    expect(context.mocks.axiom.flush).toHaveBeenNthCalledWith(2, {
-      client: "telemetry",
-      throwOnError: true,
-    });
+    expect(context.mocks.axiom.flush).not.toHaveBeenCalled();
   });
 });

--- a/turbo/apps/api/src/signals/routes/webhooks-agent-health-usage-telemetry.ts
+++ b/turbo/apps/api/src/signals/routes/webhooks-agent-health-usage-telemetry.ts
@@ -30,7 +30,7 @@ import {
 } from "../external/sandbox-op-log";
 import type { RouteEntry } from "../route";
 import { dispatchProgressCallbacks$ } from "../services/agent-run-callbacks.service";
-import { settle } from "../utils";
+import { settle, tapError } from "../utils";
 import {
   getSandboxAuthForRun,
   unauthorizedRunMismatch,
@@ -520,36 +520,34 @@ const telemetry$ = command(async ({ get }, signal: AbortSignal) => {
   }
 
   const telemetrySummary = summarizeTelemetryPayload(body);
-  const axiomStartedAt = now();
   const { telemetryBuffered, axiomDatasetFamilies } = ingestTelemetryPayload({
     body,
     userId: auth.userId,
     summary: telemetrySummary,
   });
 
-  let axiomLatencyMs = 0;
   if (telemetryBuffered) {
-    const flushResult = await settle(
-      flushAxiom({ client: "telemetry", throwOnError: true }),
+    const axiomStartedAt = now();
+    waitUntil(
+      tapError(
+        flushAxiom({ client: "telemetry", throwOnError: true }),
+        (error) => {
+          L.warn("Agent telemetry Axiom flush failed", {
+            ...telemetrySummary,
+            axiomDatasetFamilies,
+            axiomFailureCategory: "flush",
+            axiomLatencyMs: now() - axiomStartedAt,
+            error,
+          });
+        },
+      ),
     );
-    signal.throwIfAborted();
-    axiomLatencyMs = now() - axiomStartedAt;
-    if (!flushResult.ok) {
-      L.warn("Agent telemetry Axiom flush failed", {
-        ...telemetrySummary,
-        axiomDatasetFamilies,
-        axiomFailureCategory: "flush",
-        axiomLatencyMs,
-        error: flushResult.error,
-      });
-      throw flushResult.error;
-    }
   }
 
   L.debug("Agent telemetry ingested", {
     ...telemetrySummary,
     axiomDatasetFamilies,
-    axiomLatencyMs,
+    axiomFlushQueued: telemetryBuffered,
     telemetryBuffered,
   });
 

--- a/turbo/apps/api/src/signals/routes/webhooks-agent-health-usage-telemetry.ts
+++ b/turbo/apps/api/src/signals/routes/webhooks-agent-health-usage-telemetry.ts
@@ -1,4 +1,5 @@
 import { command } from "ccstate";
+import type { z } from "zod";
 import {
   webhookHeartbeatContract,
   webhookModelUsageObservationContract,
@@ -17,13 +18,16 @@ import {
 
 import { notFound } from "../../lib/error";
 import { logger } from "../../lib/log";
-import { nowDate } from "../../lib/time";
+import { now, nowDate } from "../../lib/time";
 import { authorization$ } from "../context/hono";
 import { bodyResultOf } from "../context/request";
 import { waitUntil } from "../context/wait-until";
 import { db$, writeDb$ } from "../external/db";
 import { flushAxiom, getDatasetName, ingestToAxiom } from "../external/axiom";
-import { recordSandboxOperation } from "../external/sandbox-op-log";
+import {
+  SANDBOX_OP_LOG_DATASET,
+  sandboxOperationAxiomEvent,
+} from "../external/sandbox-op-log";
 import type { RouteEntry } from "../route";
 import { dispatchProgressCallbacks$ } from "../services/agent-run-callbacks.service";
 import { settle } from "../utils";
@@ -40,6 +44,33 @@ const MODEL_USAGE_KIND = "model";
 
 const L = logger("webhooks:agent");
 
+type TelemetryDatasetFamily =
+  | "system"
+  | "metrics"
+  | "network"
+  | "sandbox_operations";
+
+interface TelemetryPayloadSummary {
+  readonly runId: string;
+  readonly hasSystemLog: boolean;
+  readonly hasMetrics: boolean;
+  readonly hasNetworkLogs: boolean;
+  readonly hasSandboxOperations: boolean;
+  readonly metricsCount: number;
+  readonly networkLogCount: number;
+  readonly sandboxOperationCount: number;
+  readonly sandboxOperationErrorCount: number;
+  readonly approxPayloadBytes: number;
+  readonly approxPayloadSizeBucket: string;
+}
+
+type TelemetryBody = z.infer<typeof webhookTelemetryContract.send.body>;
+
+interface TelemetryIngestResult {
+  readonly telemetryBuffered: boolean;
+  readonly axiomDatasetFamilies: readonly TelemetryDatasetFamily[];
+}
+
 function isForeignKeyViolation(error: unknown): boolean {
   if (!(error instanceof Error)) {
     return false;
@@ -51,6 +82,222 @@ function isForeignKeyViolation(error: unknown): boolean {
   }
 
   return cause.code === PG_FOREIGN_KEY_VIOLATION;
+}
+
+function estimateTelemetryPayloadBytes(value: unknown): number {
+  if (typeof value === "string") {
+    return value.length;
+  }
+  if (typeof value === "number") {
+    return value.toString().length;
+  }
+  if (typeof value === "boolean") {
+    return value ? 4 : 5;
+  }
+  if (Array.isArray(value)) {
+    return value.reduce((total, item) => {
+      return total + estimateTelemetryPayloadBytes(item);
+    }, 2);
+  }
+  if (typeof value === "object" && value !== null) {
+    const record = value as Record<string, unknown>;
+    return Object.keys(record).reduce((total, key) => {
+      return total + key.length + estimateTelemetryPayloadBytes(record[key]);
+    }, 2);
+  }
+  return 0;
+}
+
+function payloadSizeBucket(bytes: number): string {
+  if (bytes < 1024) {
+    return "lt_1kb";
+  }
+  if (bytes < 10 * 1024) {
+    return "1kb_10kb";
+  }
+  if (bytes < 100 * 1024) {
+    return "10kb_100kb";
+  }
+  if (bytes < 1024 * 1024) {
+    return "100kb_1mb";
+  }
+  return "gte_1mb";
+}
+
+function summarizeTelemetryPayload(body: {
+  readonly runId: string;
+  readonly systemLog?: string;
+  readonly metrics?: readonly unknown[];
+  readonly networkLogs?: readonly unknown[];
+  readonly sandboxOperations?: readonly {
+    readonly error?: string;
+  }[];
+}): TelemetryPayloadSummary {
+  const metricsCount = body.metrics?.length ?? 0;
+  const networkLogCount = body.networkLogs?.length ?? 0;
+  const sandboxOperationCount = body.sandboxOperations?.length ?? 0;
+  const approxPayloadBytes = estimateTelemetryPayloadBytes(body);
+
+  return {
+    runId: body.runId,
+    hasSystemLog: Boolean(body.systemLog),
+    hasMetrics: metricsCount > 0,
+    hasNetworkLogs: networkLogCount > 0,
+    hasSandboxOperations: sandboxOperationCount > 0,
+    metricsCount,
+    networkLogCount,
+    sandboxOperationCount,
+    sandboxOperationErrorCount:
+      body.sandboxOperations?.filter((operation) => {
+        return operation.error !== undefined;
+      }).length ?? 0,
+    approxPayloadBytes,
+    approxPayloadSizeBucket: payloadSizeBucket(approxPayloadBytes),
+  };
+}
+
+function ingestTelemetryRows(args: {
+  readonly dataset: string;
+  readonly family: TelemetryDatasetFamily;
+  readonly events: readonly Record<string, unknown>[];
+  readonly summary: TelemetryPayloadSummary;
+}): boolean {
+  const buffered = ingestToAxiom(args.dataset, args.events);
+  if (!buffered) {
+    L.warn("Agent telemetry Axiom ingest skipped", {
+      ...args.summary,
+      axiomDatasetFamily: args.family,
+      axiomFailureCategory: "ingest_skipped",
+    });
+  }
+  return buffered;
+}
+
+function systemTelemetryEvents(
+  body: TelemetryBody,
+  userId: string,
+): readonly Record<string, unknown>[] {
+  return [
+    {
+      _time: nowDate().toISOString(),
+      runId: body.runId,
+      userId,
+      log: body.systemLog,
+    },
+  ];
+}
+
+function metricTelemetryEvents(
+  body: TelemetryBody,
+  userId: string,
+): readonly Record<string, unknown>[] {
+  return (
+    body.metrics?.map((metric) => {
+      return {
+        _time: metric.ts,
+        runId: body.runId,
+        userId,
+        cpu: metric.cpu,
+        mem_used: metric.mem_used,
+        mem_total: metric.mem_total,
+        disk_used: metric.disk_used,
+        disk_total: metric.disk_total,
+      };
+    }) ?? []
+  );
+}
+
+function networkTelemetryEvents(
+  body: TelemetryBody,
+  userId: string,
+): readonly Record<string, unknown>[] {
+  return (
+    body.networkLogs?.map(({ timestamp, ...rest }) => {
+      return {
+        ...rest,
+        _time: timestamp,
+        runId: body.runId,
+        userId,
+      };
+    }) ?? []
+  );
+}
+
+function sandboxOperationTelemetryEvents(
+  body: TelemetryBody,
+): readonly Record<string, unknown>[] {
+  return (
+    body.sandboxOperations?.map((op) => {
+      return sandboxOperationAxiomEvent({
+        actionType: op.action_type,
+        sandboxType: "runner",
+        durationMs: op.duration_ms,
+        success: op.success,
+        runId: body.runId,
+        timestamp: op.ts,
+        dimensions: {
+          source: "sandbox",
+          ...(op.error ? { error: op.error } : {}),
+        },
+      });
+    }) ?? []
+  );
+}
+
+function ingestTelemetryPayload(args: {
+  readonly body: TelemetryBody;
+  readonly userId: string;
+  readonly summary: TelemetryPayloadSummary;
+}): TelemetryIngestResult {
+  const axiomDatasetFamilies: TelemetryDatasetFamily[] = [];
+  let telemetryBuffered = false;
+  const recordIngest = (
+    family: TelemetryDatasetFamily,
+    dataset: string,
+    events: readonly Record<string, unknown>[],
+  ): void => {
+    const buffered = ingestTelemetryRows({
+      dataset,
+      family,
+      events,
+      summary: args.summary,
+    });
+    telemetryBuffered = buffered || telemetryBuffered;
+    if (buffered) {
+      axiomDatasetFamilies.push(family);
+    }
+  };
+
+  if (args.body.systemLog) {
+    recordIngest(
+      "system",
+      getDatasetName(SANDBOX_TELEMETRY_SYSTEM_DATASET),
+      systemTelemetryEvents(args.body, args.userId),
+    );
+  }
+  if (args.body.metrics && args.body.metrics.length > 0) {
+    recordIngest(
+      "metrics",
+      getDatasetName(SANDBOX_TELEMETRY_METRICS_DATASET),
+      metricTelemetryEvents(args.body, args.userId),
+    );
+  }
+  if (args.body.networkLogs && args.body.networkLogs.length > 0) {
+    recordIngest(
+      "network",
+      getDatasetName(SANDBOX_TELEMETRY_NETWORK_DATASET),
+      networkTelemetryEvents(args.body, args.userId),
+    );
+  }
+  if (args.body.sandboxOperations && args.body.sandboxOperations.length > 0) {
+    recordIngest(
+      "sandbox_operations",
+      getDatasetName(SANDBOX_OP_LOG_DATASET),
+      sandboxOperationTelemetryEvents(args.body),
+    );
+  }
+
+  return { telemetryBuffered, axiomDatasetFamilies };
 }
 
 const heartbeatBody$ = bodyResultOf(webhookHeartbeatContract.send);
@@ -272,75 +519,39 @@ const telemetry$ = command(async ({ get }, signal: AbortSignal) => {
     return notFound("Agent run not found");
   }
 
-  let telemetryBuffered = false;
+  const telemetrySummary = summarizeTelemetryPayload(body);
+  const axiomStartedAt = now();
+  const { telemetryBuffered, axiomDatasetFamilies } = ingestTelemetryPayload({
+    body,
+    userId: auth.userId,
+    summary: telemetrySummary,
+  });
 
-  if (body.systemLog) {
-    telemetryBuffered =
-      ingestToAxiom(getDatasetName(SANDBOX_TELEMETRY_SYSTEM_DATASET), [
-        {
-          _time: nowDate().toISOString(),
-          runId: body.runId,
-          userId: auth.userId,
-          log: body.systemLog,
-        },
-      ]) || telemetryBuffered;
-  }
-
-  if (body.metrics && body.metrics.length > 0) {
-    telemetryBuffered =
-      ingestToAxiom(
-        getDatasetName(SANDBOX_TELEMETRY_METRICS_DATASET),
-        body.metrics.map((metric) => {
-          return {
-            _time: metric.ts,
-            runId: body.runId,
-            userId: auth.userId,
-            cpu: metric.cpu,
-            mem_used: metric.mem_used,
-            mem_total: metric.mem_total,
-            disk_used: metric.disk_used,
-            disk_total: metric.disk_total,
-          };
-        }),
-      ) || telemetryBuffered;
-  }
-
-  if (body.networkLogs && body.networkLogs.length > 0) {
-    telemetryBuffered =
-      ingestToAxiom(
-        getDatasetName(SANDBOX_TELEMETRY_NETWORK_DATASET),
-        body.networkLogs.map(({ timestamp, ...rest }) => {
-          return {
-            ...rest,
-            _time: timestamp,
-            runId: body.runId,
-            userId: auth.userId,
-          };
-        }),
-      ) || telemetryBuffered;
-  }
-
+  let axiomLatencyMs = 0;
   if (telemetryBuffered) {
-    await flushAxiom({ client: "telemetry", throwOnError: true });
+    const flushResult = await settle(
+      flushAxiom({ client: "telemetry", throwOnError: true }),
+    );
     signal.throwIfAborted();
-  }
-
-  if (body.sandboxOperations && body.sandboxOperations.length > 0) {
-    for (const op of body.sandboxOperations) {
-      recordSandboxOperation({
-        actionType: op.action_type,
-        sandboxType: "runner",
-        durationMs: op.duration_ms,
-        success: op.success,
-        runId: body.runId,
-        timestamp: op.ts,
-        dimensions: {
-          source: "sandbox",
-          ...(op.error ? { error: op.error } : {}),
-        },
+    axiomLatencyMs = now() - axiomStartedAt;
+    if (!flushResult.ok) {
+      L.warn("Agent telemetry Axiom flush failed", {
+        ...telemetrySummary,
+        axiomDatasetFamilies,
+        axiomFailureCategory: "flush",
+        axiomLatencyMs,
+        error: flushResult.error,
       });
+      throw flushResult.error;
     }
   }
+
+  L.debug("Agent telemetry ingested", {
+    ...telemetrySummary,
+    axiomDatasetFamilies,
+    axiomLatencyMs,
+    telemetryBuffered,
+  });
 
   return {
     status: 200 as const,

--- a/turbo/apps/api/src/signals/routes/webhooks-agent-health-usage-telemetry.ts
+++ b/turbo/apps/api/src/signals/routes/webhooks-agent-health-usage-telemetry.ts
@@ -18,19 +18,19 @@ import {
 
 import { notFound } from "../../lib/error";
 import { logger } from "../../lib/log";
-import { now, nowDate } from "../../lib/time";
+import { nowDate } from "../../lib/time";
 import { authorization$ } from "../context/hono";
 import { bodyResultOf } from "../context/request";
 import { waitUntil } from "../context/wait-until";
 import { db$, writeDb$ } from "../external/db";
-import { flushAxiom, getDatasetName, ingestToAxiom } from "../external/axiom";
+import { getDatasetName, ingestToAxiom } from "../external/axiom";
 import {
   SANDBOX_OP_LOG_DATASET,
   sandboxOperationAxiomEvent,
 } from "../external/sandbox-op-log";
 import type { RouteEntry } from "../route";
 import { dispatchProgressCallbacks$ } from "../services/agent-run-callbacks.service";
-import { settle, tapError } from "../utils";
+import { settle } from "../utils";
 import {
   getSandboxAuthForRun,
   unauthorizedRunMismatch,
@@ -67,7 +67,7 @@ interface TelemetryPayloadSummary {
 type TelemetryBody = z.infer<typeof webhookTelemetryContract.send.body>;
 
 interface TelemetryIngestResult {
-  readonly telemetryBuffered: boolean;
+  readonly telemetryAccepted: boolean;
   readonly axiomDatasetFamilies: readonly TelemetryDatasetFamily[];
 }
 
@@ -149,7 +149,7 @@ function summarizeTelemetryPayload(body: {
     sandboxOperationCount,
     sandboxOperationErrorCount:
       body.sandboxOperations?.filter((operation) => {
-        return operation.error !== undefined;
+        return Boolean(operation.error);
       }).length ?? 0,
     approxPayloadBytes,
     approxPayloadSizeBucket: payloadSizeBucket(approxPayloadBytes),
@@ -250,7 +250,7 @@ function ingestTelemetryPayload(args: {
   readonly summary: TelemetryPayloadSummary;
 }): TelemetryIngestResult {
   const axiomDatasetFamilies: TelemetryDatasetFamily[] = [];
-  let telemetryBuffered = false;
+  let telemetryAccepted = false;
   const recordIngest = (
     family: TelemetryDatasetFamily,
     dataset: string,
@@ -262,7 +262,7 @@ function ingestTelemetryPayload(args: {
       events,
       summary: args.summary,
     });
-    telemetryBuffered = buffered || telemetryBuffered;
+    telemetryAccepted = buffered || telemetryAccepted;
     if (buffered) {
       axiomDatasetFamilies.push(family);
     }
@@ -297,7 +297,7 @@ function ingestTelemetryPayload(args: {
     );
   }
 
-  return { telemetryBuffered, axiomDatasetFamilies };
+  return { telemetryAccepted, axiomDatasetFamilies };
 }
 
 const heartbeatBody$ = bodyResultOf(webhookHeartbeatContract.send);
@@ -520,35 +520,16 @@ const telemetry$ = command(async ({ get }, signal: AbortSignal) => {
   }
 
   const telemetrySummary = summarizeTelemetryPayload(body);
-  const { telemetryBuffered, axiomDatasetFamilies } = ingestTelemetryPayload({
+  const { telemetryAccepted, axiomDatasetFamilies } = ingestTelemetryPayload({
     body,
     userId: auth.userId,
     summary: telemetrySummary,
   });
 
-  if (telemetryBuffered) {
-    const axiomStartedAt = now();
-    waitUntil(
-      tapError(
-        flushAxiom({ client: "telemetry", throwOnError: true }),
-        (error) => {
-          L.warn("Agent telemetry Axiom flush failed", {
-            ...telemetrySummary,
-            axiomDatasetFamilies,
-            axiomFailureCategory: "flush",
-            axiomLatencyMs: now() - axiomStartedAt,
-            error,
-          });
-        },
-      ),
-    );
-  }
-
   L.debug("Agent telemetry ingested", {
     ...telemetrySummary,
     axiomDatasetFamilies,
-    axiomFlushQueued: telemetryBuffered,
-    telemetryBuffered,
+    telemetryAccepted,
   });
 
   return {

--- a/turbo/apps/api/src/signals/routes/webhooks-agent-health-usage-telemetry.ts
+++ b/turbo/apps/api/src/signals/routes/webhooks-agent-health-usage-telemetry.ts
@@ -66,11 +66,6 @@ interface TelemetryPayloadSummary {
 
 type TelemetryBody = z.infer<typeof webhookTelemetryContract.send.body>;
 
-interface TelemetryIngestResult {
-  readonly telemetryAccepted: boolean;
-  readonly axiomDatasetFamilies: readonly TelemetryDatasetFamily[];
-}
-
 function isForeignKeyViolation(error: unknown): boolean {
   if (!(error instanceof Error)) {
     return false;
@@ -160,17 +155,16 @@ function ingestTelemetryRows(args: {
   readonly dataset: string;
   readonly family: TelemetryDatasetFamily;
   readonly events: readonly Record<string, unknown>[];
-  readonly summary: TelemetryPayloadSummary;
-}): boolean {
+  readonly getSummary: () => TelemetryPayloadSummary;
+}): void {
   const buffered = ingestToAxiom(args.dataset, args.events);
   if (!buffered) {
     L.warn("Agent telemetry Axiom ingest skipped", {
-      ...args.summary,
+      ...args.getSummary(),
       axiomDatasetFamily: args.family,
       axiomFailureCategory: "ingest_skipped",
     });
   }
-  return buffered;
 }
 
 function systemTelemetryEvents(
@@ -247,25 +241,19 @@ function sandboxOperationTelemetryEvents(
 function ingestTelemetryPayload(args: {
   readonly body: TelemetryBody;
   readonly userId: string;
-  readonly summary: TelemetryPayloadSummary;
-}): TelemetryIngestResult {
-  const axiomDatasetFamilies: TelemetryDatasetFamily[] = [];
-  let telemetryAccepted = false;
+  readonly getSummary: () => TelemetryPayloadSummary;
+}): void {
   const recordIngest = (
     family: TelemetryDatasetFamily,
     dataset: string,
     events: readonly Record<string, unknown>[],
   ): void => {
-    const buffered = ingestTelemetryRows({
+    ingestTelemetryRows({
       dataset,
       family,
       events,
-      summary: args.summary,
+      getSummary: args.getSummary,
     });
-    telemetryAccepted = buffered || telemetryAccepted;
-    if (buffered) {
-      axiomDatasetFamilies.push(family);
-    }
   };
 
   if (args.body.systemLog) {
@@ -296,8 +284,6 @@ function ingestTelemetryPayload(args: {
       sandboxOperationTelemetryEvents(args.body),
     );
   }
-
-  return { telemetryAccepted, axiomDatasetFamilies };
 }
 
 const heartbeatBody$ = bodyResultOf(webhookHeartbeatContract.send);
@@ -519,17 +505,16 @@ const telemetry$ = command(async ({ get }, signal: AbortSignal) => {
     return notFound("Agent run not found");
   }
 
-  const telemetrySummary = summarizeTelemetryPayload(body);
-  const { telemetryAccepted, axiomDatasetFamilies } = ingestTelemetryPayload({
+  let telemetrySummary: TelemetryPayloadSummary | undefined;
+  ingestTelemetryPayload({
     body,
     userId: auth.userId,
-    summary: telemetrySummary,
-  });
-
-  L.debug("Agent telemetry ingested", {
-    ...telemetrySummary,
-    axiomDatasetFamilies,
-    telemetryAccepted,
+    getSummary: () => {
+      if (!telemetrySummary) {
+        telemetrySummary = summarizeTelemetryPayload(body);
+      }
+      return telemetrySummary;
+    },
   });
 
   return {


### PR DESCRIPTION
## Summary

- bulk queue sandbox operation telemetry into the Axiom SDK telemetry batch instead of calling the sandbox-op helper once per operation
- share the sandbox operation Axiom row mapper so existing direct logging keeps the same dataset shape
- rely on the Axiom SDK telemetry buffer instead of flushing Axiom once per telemetry request
- avoid per-request telemetry success web logs; emit bounded skip metadata without raw telemetry contents when Axiom ingest is unavailable

Closes #16483

## Testing

- `pnpm -F @vm0/db db:migrate`
- `pnpm format`
- `pnpm -F api lint`
- `pnpm check-types`
- `pnpm knip`
- `pnpm -F api exec vitest run src/signals/routes/__tests__/webhooks-agent-health-usage-telemetry.test.ts`
- Earlier full `pnpm vitest` failed on unrelated existing local tests: `@vm0/desktop` macOS-only native CLI tests in the Linux container and several `@vm0/app` UI tests timing out under `src/views/conn` and `src/views/zero-page`
