### PR TITLE
feat(cli): re-land zero video transcribe + frames with sandbox STT access

### DIFF
--- a/turbo/apps/api/src/signals/routes/__tests__/zero-voice-io-post.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/zero-voice-io-post.test.ts
@@ -742,6 +742,40 @@ describe("POST /api/zero/voice-io/*", () => {
     expect(counts.get(sttDailyDurationKey())).toBe(2);
   });
 
+  it("uses whisper-1 and verbose_json when ?verbose=true, returns segments", async () => {
+    const fixture = await track(seedVoiceFixture({}));
+    mocks.clerk.session(fixture.userId, fixture.orgId);
+
+    let observedModel: FormDataEntryValue | null = null;
+    let observedResponseFormat: FormDataEntryValue | null = null;
+    server.use(
+      http.post(OPENAI_AUDIO_TRANSCRIPTIONS_URL, async ({ request }) => {
+        const form = await request.formData();
+        observedModel = form.get("model");
+        observedResponseFormat = form.get("response_format");
+        return HttpResponse.json({
+          text: "hello world",
+          segments: [{ start: 0, end: 1.5, text: " hello world" }],
+        });
+      }),
+    );
+
+    const app = createApp({ signal: context.signal });
+    const response = await app.request("/api/zero/voice-io/stt?verbose=true", {
+      method: "POST",
+      headers: authHeaders(),
+      body: sttForm(sttFile(wavBytes(2))),
+    });
+
+    expect(response.status).toBe(200);
+    await expect(response.json()).resolves.toStrictEqual({
+      text: "hello world",
+      segments: [{ start: 0, end: 1.5, text: " hello world" }],
+    });
+    expect(observedModel).toBe("whisper-1");
+    expect(observedResponseFormat).toBe("verbose_json");
+  });
+
   it("does not increment the legacy /stt free-tier counter for pro orgs", async () => {
     const fixture = await track(seedVoiceFixture({ tier: "pro" }));
     mocks.clerk.session(fixture.userId, fixture.orgId);

--- a/turbo/apps/api/src/signals/routes/__tests__/zero-voice-io-post.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/zero-voice-io-post.test.ts
@@ -215,6 +215,7 @@ async function deleteSpeechPricing(): Promise<void> {
 }
 
 async function seedVoiceFixture(options: {
+  readonly audioInputEnabled?: boolean;
   readonly audioOutputEnabled?: boolean;
   readonly credits?: number;
   readonly tier?: OrgTier;
@@ -239,11 +240,18 @@ async function seedVoiceFixture(options: {
     userId,
   });
 
+  const switches: Record<string, boolean> = {};
+  if (options.audioInputEnabled) {
+    switches[FeatureSwitchKey.AudioInput] = true;
+  }
   if (options.audioOutputEnabled) {
+    switches[FeatureSwitchKey.AudioOutput] = true;
+  }
+  if (Object.keys(switches).length > 0) {
     await writeDb.insert(userFeatureSwitches).values({
       orgId,
       userId,
-      switches: { [FeatureSwitchKey.AudioOutput]: true },
+      switches,
     });
   }
 
@@ -743,7 +751,7 @@ describe("POST /api/zero/voice-io/*", () => {
   });
 
   it("uses whisper-1 and verbose_json when ?verbose=true, returns segments", async () => {
-    const fixture = await track(seedVoiceFixture({}));
+    const fixture = await track(seedVoiceFixture({ audioInputEnabled: true }));
     mocks.clerk.session(fixture.userId, fixture.orgId);
 
     let observedModel: FormDataEntryValue | null = null;
@@ -774,6 +782,85 @@ describe("POST /api/zero/voice-io/*", () => {
     });
     expect(observedModel).toBe("whisper-1");
     expect(observedResponseFormat).toBe("verbose_json");
+  });
+
+  it("falls back to plain transcription when ?verbose=true but AudioInput is off", async () => {
+    const fixture = await track(seedVoiceFixture({}));
+    mocks.clerk.session(fixture.userId, fixture.orgId);
+
+    let observedModel: FormDataEntryValue | null = null;
+    let observedResponseFormat: FormDataEntryValue | null = null;
+    server.use(
+      http.post(OPENAI_AUDIO_TRANSCRIPTIONS_URL, async ({ request }) => {
+        const form = await request.formData();
+        observedModel = form.get("model");
+        observedResponseFormat = form.get("response_format");
+        return HttpResponse.json({ text: "hello world" });
+      }),
+    );
+
+    const app = createApp({ signal: context.signal });
+    const response = await app.request("/api/zero/voice-io/stt?verbose=true", {
+      method: "POST",
+      headers: authHeaders(),
+      body: sttForm(sttFile(wavBytes(2))),
+    });
+
+    expect(response.status).toBe(200);
+    await expect(response.json()).resolves.toStrictEqual({
+      text: "hello world",
+    });
+    expect(observedModel).toBe(VOICE_IO_STT_MODEL);
+    expect(observedResponseFormat).toBe("json");
+  });
+
+  it("authorizes a sandbox token carrying file:write on /stt", async () => {
+    const fixture = await track(seedVoiceFixture({}));
+    const token = zeroToken({
+      userId: fixture.userId,
+      orgId: fixture.orgId,
+      runId: `run_${randomUUID()}`,
+    });
+    server.use(
+      http.post(OPENAI_AUDIO_TRANSCRIPTIONS_URL, () => {
+        return HttpResponse.json({ text: "from agent" });
+      }),
+    );
+
+    const app = createApp({ signal: context.signal });
+    const response = await app.request("/api/zero/voice-io/stt", {
+      method: "POST",
+      headers: { authorization: `Bearer ${token}` },
+      body: sttForm(sttFile(wavBytes(2))),
+    });
+
+    expect(response.status).toBe(200);
+    await expect(response.json()).resolves.toStrictEqual({
+      text: "from agent",
+    });
+  });
+
+  it("rejects a sandbox token without file:write on /stt", async () => {
+    const fixture = await track(seedVoiceFixture({}));
+    const seconds = currentSecond();
+    const token = signSandboxJwtForTests({
+      scope: "zero",
+      userId: fixture.userId,
+      orgId: fixture.orgId,
+      runId: `run_${randomUUID()}`,
+      capabilities: [],
+      iat: seconds,
+      exp: seconds + 60,
+    });
+
+    const app = createApp({ signal: context.signal });
+    const response = await app.request("/api/zero/voice-io/stt", {
+      method: "POST",
+      headers: { authorization: `Bearer ${token}` },
+      body: sttForm(sttFile(wavBytes(2))),
+    });
+
+    expect(response.status).toBe(403);
   });
 
   it("does not increment the legacy /stt free-tier counter for pro orgs", async () => {

--- a/turbo/apps/api/src/signals/routes/zero-voice-io-stt.ts
+++ b/turbo/apps/api/src/signals/routes/zero-voice-io-stt.ts
@@ -13,18 +13,22 @@ import {
   internalError,
   isAllowedSttMimeType,
   isTranscriptionBody,
+  isVerboseTranscriptionSegment,
   MAX_STT_FILE_SIZE,
   MAX_STT_REQUEST_DURATION_SECONDS,
   OPENAI_AUDIO_TRANSCRIPTIONS_URL,
   recordSttUsage$,
   sttDailyPolicy$,
   VOICE_IO_STT_MODEL,
+  VOICE_IO_STT_VERBOSE_MODEL,
 } from "../services/zero-voice-io-post.service";
 import { env } from "../../lib/env";
 
 const L = logger("ZeroVoiceIoStt");
 
 const postSttInner$ = command(async ({ get, set }, signal: AbortSignal) => {
+  const request = get(request$);
+  const verbose = request.query("verbose") === "true";
   const auth = get(organizationAuthContext$);
   const quota = await get(audioInputQuota(auth.orgId, auth.userId));
   signal.throwIfAborted();
@@ -42,7 +46,6 @@ const postSttInner$ = command(async ({ get, set }, signal: AbortSignal) => {
     };
   }
 
-  const request = get(request$);
   const formData = await request.raw.formData();
   signal.throwIfAborted();
   const file = formData.get("file");
@@ -105,8 +108,11 @@ const postSttInner$ = command(async ({ get, set }, signal: AbortSignal) => {
 
   const openaiForm = new FormData();
   openaiForm.append("file", file, file.name || "audio.webm");
-  openaiForm.append("model", VOICE_IO_STT_MODEL);
-  openaiForm.append("response_format", "json");
+  openaiForm.append(
+    "model",
+    verbose ? VOICE_IO_STT_VERBOSE_MODEL : VOICE_IO_STT_MODEL,
+  );
+  openaiForm.append("response_format", verbose ? "verbose_json" : "json");
 
   const openaiResponse = await fetch(OPENAI_AUDIO_TRANSCRIPTIONS_URL, {
     method: "POST",
@@ -142,7 +148,20 @@ const postSttInner$ = command(async ({ get, set }, signal: AbortSignal) => {
     signal,
   );
 
-  return { status: 200 as const, body: { text: result.text } };
+  const segments =
+    verbose && Array.isArray((result as Record<string, unknown>).segments)
+      ? ((result as Record<string, unknown>).segments as unknown[]).filter(
+          isVerboseTranscriptionSegment,
+        )
+      : undefined;
+
+  return {
+    status: 200 as const,
+    body: {
+      text: result.text,
+      ...(segments !== undefined && { segments }),
+    },
+  };
 });
 
 export const zeroVoiceIoSttRoutes: readonly RouteEntry[] = [

--- a/turbo/apps/api/src/signals/routes/zero-voice-io-stt.ts
+++ b/turbo/apps/api/src/signals/routes/zero-voice-io-stt.ts
@@ -1,9 +1,12 @@
 import { command } from "ccstate";
 import { zeroVoiceIoSttContract } from "@vm0/api-contracts/contracts/zero-voice-io-stt";
+import { FeatureSwitchKey } from "@vm0/connectors/feature-switch-key";
+import { isFeatureEnabled } from "@vm0/core/feature-switch";
 
 import { organizationAuthContext$ } from "../auth/auth-context";
 import { authRoute } from "../auth/auth-route";
 import { request$ } from "../context/hono";
+import { userFeatureSwitchOverrides } from "../services/feature-switches.service";
 import { logger } from "../../lib/log";
 import type { RouteEntry } from "../route";
 import { audioInputQuota } from "../services/voice-io.service";
@@ -26,10 +29,31 @@ import { env } from "../../lib/env";
 
 const L = logger("ZeroVoiceIoStt");
 
+// Whether verbose (timestamped-segment) transcription is enabled for the
+// caller. This is the new, switch-gated path; when off, the route falls back
+// to plain transcription so the base STT endpoint keeps working for everyone.
+const audioInputVerboseEnabled$ = command(
+  async ({ get }, signal: AbortSignal): Promise<boolean> => {
+    const auth = get(organizationAuthContext$);
+    const overrides = await get(
+      userFeatureSwitchOverrides(auth.orgId, auth.userId),
+    );
+    signal.throwIfAborted();
+    return isFeatureEnabled(FeatureSwitchKey.AudioInput, {
+      orgId: auth.orgId,
+      userId: auth.userId,
+      overrides,
+    });
+  },
+);
+
 const postSttInner$ = command(async ({ get, set }, signal: AbortSignal) => {
   const request = get(request$);
-  const verbose = request.query("verbose") === "true";
   const auth = get(organizationAuthContext$);
+  const verbose =
+    request.query("verbose") === "true" &&
+    (await set(audioInputVerboseEnabled$, signal));
+
   const quota = await get(audioInputQuota(auth.orgId, auth.userId));
   signal.throwIfAborted();
   if (!quota.allowed) {
@@ -168,7 +192,11 @@ export const zeroVoiceIoSttRoutes: readonly RouteEntry[] = [
   {
     route: zeroVoiceIoSttContract.post,
     handler: authRoute(
-      { requireOrganization: true, missingOrganizationStatus: 401 },
+      {
+        requireOrganization: true,
+        requiredCapability: "file:write",
+        missingOrganizationStatus: 401,
+      },
       postSttInner$,
     ),
   },

--- a/turbo/apps/api/src/signals/services/zero-voice-io-post.service.ts
+++ b/turbo/apps/api/src/signals/services/zero-voice-io-post.service.ts
@@ -21,6 +21,9 @@ export const OPENAI_AUDIO_TRANSCRIPTIONS_URL =
   "https://api.openai.com/v1/audio/transcriptions";
 export const VOICE_IO_TTS_MODEL = "gpt-4o-mini-tts";
 export const VOICE_IO_STT_MODEL = "gpt-4o-mini-transcribe";
+// Verbose transcription (per-segment timestamps) requires whisper-1;
+// gpt-4o-mini-transcribe does not return segment timestamps.
+export const VOICE_IO_STT_VERBOSE_MODEL = "whisper-1";
 export const SPEECH_CONTENT_TYPE = "audio/wav";
 export const SPEECH_RESPONSE_FORMAT = "wav";
 export const TTS_RESPONSE_FORMAT = "pcm";
@@ -201,6 +204,19 @@ export function isTranscriptionBody(
   value: unknown,
 ): value is { readonly text: string } {
   return isRecord(value) && typeof value.text === "string";
+}
+
+export function isVerboseTranscriptionSegment(value: unknown): value is {
+  readonly start: number;
+  readonly end: number;
+  readonly text: string;
+} {
+  return (
+    isRecord(value) &&
+    typeof value.start === "number" &&
+    typeof value.end === "number" &&
+    typeof value.text === "string"
+  );
 }
 
 export function isAllowedSttMimeType(value: string): boolean {

--- a/turbo/apps/cli/src/__tests__/zero.test.ts
+++ b/turbo/apps/cli/src/__tests__/zero.test.ts
@@ -37,6 +37,7 @@ describe("zero CLI program", () => {
       "computer-use",
       "generate",
       "web",
+      "video",
       "host",
       "maps",
       "banking",
@@ -63,7 +64,7 @@ describe("zero CLI program", () => {
     }
   });
 
-  it("should have exactly 27 commands", () => {
-    expect(commandNames).toHaveLength(27);
+  it("should have exactly 28 commands", () => {
+    expect(commandNames).toHaveLength(28);
   });
 });

--- a/turbo/apps/cli/src/commands/zero/github/download-file.ts
+++ b/turbo/apps/cli/src/commands/zero/github/download-file.ts
@@ -45,9 +45,10 @@ Output:
 
 How to read the downloaded file:
   - Images (png/jpg/gif/webp/svg): open the file path with your image viewing tool
-  - Videos (mp4/mov/webm): extract frames first with
+  - Videos (mp4/mov/webm): transcribe audio first with
+      zero video transcribe --url <download-url>
+    or extract frames with
       ffmpeg -i <path> -vf "fps=1" -q:v 2 /tmp/github_frame_%03d.jpg
-    then view the extracted frames
   - PDF/text/csv/json/markdown: read the file directly
 
 Notes:

--- a/turbo/apps/cli/src/commands/zero/phone/download-file.ts
+++ b/turbo/apps/cli/src/commands/zero/phone/download-file.ts
@@ -32,9 +32,10 @@ Output:
 
 How to read the downloaded file:
   - Images (png/jpg/gif/webp/svg): open the file path with your image viewing tool
-  - Videos (mp4/mov/webm): extract frames first with
+  - Videos (mp4/mov/webm): transcribe audio first with
+      zero video transcribe --url <download-url>
+    or extract frames with
       ffmpeg -i <path> -vf "fps=1" -q:v 2 /tmp/<file-id>_frame_%03d.jpg
-    then view the extracted frames
   - PDF/text/csv/json/markdown: read the file directly`,
   )
   .action(

--- a/turbo/apps/cli/src/commands/zero/slack/download-file.ts
+++ b/turbo/apps/cli/src/commands/zero/slack/download-file.ts
@@ -37,9 +37,10 @@ Output:
 
 How to read the downloaded file:
   - Images (png/jpg/gif/webp/svg): open the file path with your image viewing tool
-  - Videos (mp4/mov/webm): extract frames first with
+  - Videos (mp4/mov/webm): transcribe audio first with
+      zero video transcribe --url <download-url>
+    or extract frames with
       ffmpeg -i <path> -vf "fps=1" -q:v 2 /tmp/<file-id>_frame_%03d.jpg
-    then view the extracted frames
   - PDF/text/csv/json/markdown: read the file directly
 
 Notes:

--- a/turbo/apps/cli/src/commands/zero/telegram/download-file.ts
+++ b/turbo/apps/cli/src/commands/zero/telegram/download-file.ts
@@ -40,9 +40,10 @@ Output:
 
 How to read the downloaded file:
   - Images (png/jpg/gif/webp/svg): open the file path with your image viewing tool
-  - Videos (mp4/mov/webm): extract frames first with
+  - Videos (mp4/mov/webm): transcribe audio first with
+      zero video transcribe --url <download-url>
+    or extract frames with
       ffmpeg -i <path> -vf "fps=1" -q:v 2 /tmp/<file-id>_frame_%03d.jpg
-    then view the extracted frames
   - PDF/text/csv/json/markdown: read the file directly
 
 Notes:

--- a/turbo/apps/cli/src/commands/zero/video/__tests__/frames.test.ts
+++ b/turbo/apps/cli/src/commands/zero/video/__tests__/frames.test.ts
@@ -1,0 +1,124 @@
+/**
+ * Tests for zero video frames command.
+ *
+ * Mocks only external boundaries: the curl/ffmpeg binaries (via child_process,
+ * not available in CI) and HTTP (via MSW). The fake binaries write real bytes
+ * to their output paths (the arg after "-o" for curl, before "-y" for ffmpeg)
+ * so the command's real filesystem and real downloadWebFile code run unchanged.
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { execFileSync } from "child_process";
+import { http, HttpResponse } from "msw";
+import { server } from "../../../../mocks/server";
+import { framesCommand } from "../frames";
+
+const DOWNLOAD_URL = "http://localhost:3000/api/zero/web/download-file";
+
+vi.mock("child_process", async () => {
+  const { writeFileSync } = await vi.importActual<typeof import("fs")>("fs");
+  return {
+    execFileSync: vi.fn((command: string, args: readonly string[]) => {
+      if (command === "curl") {
+        const i = args.indexOf("-o");
+        const outPath = i >= 0 ? args[i + 1] : undefined;
+        if (outPath) {
+          writeFileSync(outPath, Buffer.from("fake-video"));
+        }
+      } else if (command === "ffmpeg") {
+        const i = args.indexOf("-y");
+        const outPath = i > 0 ? args[i - 1] : undefined;
+        if (outPath) {
+          writeFileSync(outPath, Buffer.from("fake-frame"));
+        }
+      }
+      return Buffer.from("");
+    }),
+  };
+});
+
+const mockStdoutWrite = vi
+  .spyOn(process.stdout, "write")
+  .mockImplementation(() => {
+    return true;
+  });
+
+function readStdout(): string {
+  return mockStdoutWrite.mock.calls
+    .map((c) => {
+      return c[0];
+    })
+    .join("");
+}
+
+describe("zero video frames command", () => {
+  beforeEach(() => {
+    vi.stubEnv("VM0_API_URL", "http://localhost:3000");
+    vi.stubEnv("VM0_TOKEN", "test-token");
+    mockStdoutWrite.mockClear();
+  });
+
+  afterEach(() => {
+    vi.clearAllMocks();
+    vi.unstubAllEnvs();
+  });
+
+  it("extracts one frame per timestamp and prints JSON paths", async () => {
+    await framesCommand.parseAsync(
+      ["--url", "https://example.com/video.mp4", "--at", "00:21,01:40"],
+      { from: "user" },
+    );
+
+    const result = JSON.parse(readStdout()) as {
+      frames: { at: string; path: string }[];
+    };
+    expect(result.frames).toHaveLength(2);
+    expect(result.frames[0]?.at).toBe("00:21");
+    expect(result.frames[1]?.at).toBe("01:40");
+    expect(result.frames[0]?.path).toContain("frame-001.jpg");
+    expect(result.frames[1]?.path).toContain("frame-002.jpg");
+
+    const ffmpegCalls = vi.mocked(execFileSync).mock.calls.filter((c) => {
+      return c[0] === "ffmpeg";
+    });
+    expect(ffmpegCalls).toHaveLength(2);
+    expect(ffmpegCalls[0]?.[1]).toEqual(
+      expect.arrayContaining(["-ss", "00:21", "-frames:v", "1"]),
+    );
+    expect(ffmpegCalls[1]?.[1]).toEqual(
+      expect.arrayContaining(["-ss", "01:40"]),
+    );
+  });
+
+  it("downloads via the web file API when --file-id is given", async () => {
+    let requestedFileId: string | null = null;
+    server.use(
+      http.get(DOWNLOAD_URL, ({ request }) => {
+        requestedFileId = new URL(request.url).searchParams.get("file_id");
+        return new HttpResponse(new Uint8Array([1, 2, 3, 4]), {
+          headers: { "content-type": "video/mp4", "content-length": "4" },
+        });
+      }),
+    );
+
+    await framesCommand.parseAsync(["--file-id", "abc-123", "--at", "5"], {
+      from: "user",
+    });
+
+    expect(requestedFileId).toBe("abc-123");
+    const result = JSON.parse(readStdout()) as { frames: { at: string }[] };
+    expect(result.frames[0]?.at).toBe("5");
+  });
+
+  it("exits with error when neither --url nor --file-id provided", async () => {
+    const mockExit = vi.spyOn(process, "exit").mockImplementation((() => {
+      throw new Error("process.exit called");
+    }) as never);
+
+    await expect(
+      framesCommand.parseAsync(["--at", "5"], { from: "user" }),
+    ).rejects.toThrow("process.exit called");
+
+    mockExit.mockRestore();
+  });
+});

--- a/turbo/apps/cli/src/commands/zero/video/__tests__/transcribe.test.ts
+++ b/turbo/apps/cli/src/commands/zero/video/__tests__/transcribe.test.ts
@@ -1,0 +1,154 @@
+/**
+ * Tests for zero video transcribe command.
+ *
+ * Mocks only external boundaries: the curl/ffmpeg binaries (via child_process,
+ * not available in CI) and HTTP (via MSW). The fake binaries write real bytes
+ * to their output paths (the arg after "-o" for curl, before "-y" for ffmpeg)
+ * so the command's real filesystem, real downloadWebFile, and real
+ * transcribeAudio code all run unchanged.
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { http, HttpResponse } from "msw";
+import { server } from "../../../../mocks/server";
+import { transcribeCommand } from "../transcribe";
+
+const STT_URL = "http://localhost:3000/api/zero/voice-io/stt";
+const DOWNLOAD_URL = "http://localhost:3000/api/zero/web/download-file";
+
+vi.mock("child_process", async () => {
+  const { writeFileSync } = await vi.importActual<typeof import("fs")>("fs");
+  return {
+    execFileSync: vi.fn((command: string, args: readonly string[]) => {
+      if (command === "curl") {
+        const i = args.indexOf("-o");
+        const outPath = i >= 0 ? args[i + 1] : undefined;
+        if (outPath) {
+          writeFileSync(outPath, Buffer.from("fake-video-bytes"));
+        }
+      } else if (command === "ffmpeg") {
+        const i = args.indexOf("-y");
+        const outPath = i > 0 ? args[i - 1] : undefined;
+        if (outPath) {
+          writeFileSync(outPath, Buffer.from("fake-audio-bytes"));
+        }
+      }
+      return Buffer.from("");
+    }),
+  };
+});
+
+const mockStdoutWrite = vi
+  .spyOn(process.stdout, "write")
+  .mockImplementation(() => {
+    return true;
+  });
+
+function readStdout(): string {
+  return mockStdoutWrite.mock.calls
+    .map((c) => {
+      return c[0];
+    })
+    .join("");
+}
+
+describe("zero video transcribe command", () => {
+  beforeEach(() => {
+    vi.stubEnv("VM0_API_URL", "http://localhost:3000");
+    vi.stubEnv("VM0_TOKEN", "test-token");
+    mockStdoutWrite.mockClear();
+  });
+
+  afterEach(() => {
+    vi.clearAllMocks();
+    vi.unstubAllEnvs();
+  });
+
+  describe("with timestamps (verbose mode)", () => {
+    it("outputs structured Markdown with timestamp blocks", async () => {
+      server.use(
+        http.post(STT_URL, () => {
+          return HttpResponse.json({
+            text: "Hello world. Second sentence.",
+            segments: [
+              { start: 2.52, end: 5.36, text: " Hello world." },
+              { start: 6.08, end: 7.4, text: " Second sentence." },
+            ],
+          });
+        }),
+      );
+
+      await transcribeCommand.parseAsync(
+        ["--url", "https://example.com/video.mp4"],
+        { from: "user" },
+      );
+
+      const output = readStdout();
+      expect(output).toContain("## Transcript");
+      expect(output).toContain("[00:02-00:05] Hello world.");
+      expect(output).toContain("[00:06-00:07] Second sentence.");
+    });
+  });
+
+  describe("without timestamps (--no-timestamps)", () => {
+    it("outputs plain text transcript", async () => {
+      server.use(
+        http.post(STT_URL, ({ request }) => {
+          expect(new URL(request.url).searchParams.get("verbose")).toBeNull();
+          return HttpResponse.json({ text: "Hello world. Second sentence." });
+        }),
+      );
+
+      await transcribeCommand.parseAsync(
+        ["--url", "https://example.com/video.mp4", "--no-timestamps"],
+        { from: "user" },
+      );
+
+      const output = readStdout();
+      expect(output).toContain("## Transcript");
+      expect(output).toContain("Hello world. Second sentence.");
+      expect(output).not.toMatch(/\[\d{2}:\d{2}-\d{2}:\d{2}\]/);
+    });
+  });
+
+  describe("with --file-id", () => {
+    it("downloads via the web file API and transcribes", async () => {
+      let requestedFileId: string | null = null;
+      server.use(
+        http.get(DOWNLOAD_URL, ({ request }) => {
+          requestedFileId = new URL(request.url).searchParams.get("file_id");
+          return new HttpResponse(new Uint8Array([1, 2, 3, 4]), {
+            headers: {
+              "content-type": "video/mp4",
+              "content-length": "4",
+            },
+          });
+        }),
+        http.post(STT_URL, () => {
+          return HttpResponse.json({ text: "File content." });
+        }),
+      );
+
+      await transcribeCommand.parseAsync(["--file-id", "abc-123-def"], {
+        from: "user",
+      });
+
+      expect(requestedFileId).toBe("abc-123-def");
+      expect(readStdout()).toContain("File content.");
+    });
+  });
+
+  describe("missing arguments", () => {
+    it("exits with error when neither --url nor --file-id provided", async () => {
+      const mockExit = vi.spyOn(process, "exit").mockImplementation((() => {
+        throw new Error("process.exit called");
+      }) as never);
+
+      await expect(
+        transcribeCommand.parseAsync([], { from: "user" }),
+      ).rejects.toThrow("process.exit called");
+
+      mockExit.mockRestore();
+    });
+  });
+});

--- a/turbo/apps/cli/src/commands/zero/video/frames.ts
+++ b/turbo/apps/cli/src/commands/zero/video/frames.ts
@@ -1,0 +1,116 @@
+import { execFileSync } from "child_process";
+import { mkdirSync, unlinkSync } from "fs";
+import { tmpdir } from "os";
+import { join } from "path";
+import { Command } from "commander";
+import { withErrorHandler } from "../../../lib/command";
+import { downloadWebFile } from "../../../lib/api/domains/web";
+
+interface ExtractedFrame {
+  readonly at: string;
+  readonly path: string;
+}
+
+export const framesCommand = new Command()
+  .name("frames")
+  .description("Extract still frames from a video at the given timestamps")
+  .option("--url <presigned-url>", "Pre-signed or public URL of the video file")
+  .option("--file-id <id>", "Web file ID (alternative to --url)")
+  .requiredOption(
+    "--at <timestamps>",
+    "Comma-separated timestamps to capture (e.g. 00:21,01:40 or 12,95.5)",
+  )
+  .addHelpText(
+    "after",
+    `
+Examples:
+  Frames at two moments:  zero video frames --url "https://..." --at 00:21,01:40
+  From a web file:        zero video frames --file-id abc-123 --at 12,95.5
+
+Output:
+  Prints a JSON object to stdout, one entry per timestamp:
+    {"frames":[{"at":"00:21","path":"/tmp/zero-frames-.../frame-001.jpg"}]}
+
+Tip:
+  Pair with "zero video transcribe": read the timestamped transcript to find the
+  moments that matter, then extract just those frames here for a closer look.
+
+Notes:
+  - Requires ffmpeg on PATH for frame extraction
+  - Timestamps accept SS, MM:SS, or HH:MM:SS (fractions allowed, e.g. 95.5)
+  - Extracted frames are kept on disk; only the downloaded video is cleaned up`,
+  )
+  .action(
+    withErrorHandler(
+      async (options: { url?: string; fileId?: string; at: string }) => {
+        if (!options.url && !options.fileId) {
+          process.stderr.write(
+            "Error: provide --url <presigned-url> or --file-id <id>\n",
+          );
+          process.exit(1);
+        }
+
+        const timestamps = options.at
+          .split(",")
+          .map((s) => {
+            return s.trim();
+          })
+          .filter((s) => {
+            return s.length > 0;
+          });
+        if (timestamps.length === 0) {
+          process.stderr.write("Error: --at requires at least one timestamp\n");
+          process.exit(1);
+        }
+
+        const outDir = join(tmpdir(), `zero-frames-${Date.now()}`);
+        mkdirSync(outDir, { recursive: true });
+
+        const tmpVideo = join(tmpdir(), `zero-video-${Date.now()}.mp4`);
+
+        try {
+          if (options.url) {
+            execFileSync("curl", ["-sS", "-L", "-o", tmpVideo, options.url], {
+              stdio: ["ignore", "ignore", "pipe"],
+            });
+          } else {
+            await downloadWebFile(options.fileId as string, tmpVideo);
+          }
+
+          const frames: ExtractedFrame[] = timestamps.map((at, index) => {
+            const outPath = join(
+              outDir,
+              `frame-${String(index + 1).padStart(3, "0")}.jpg`,
+            );
+            execFileSync(
+              "ffmpeg",
+              [
+                "-ss",
+                at,
+                "-i",
+                tmpVideo,
+                "-frames:v",
+                "1",
+                "-q:v",
+                "2",
+                outPath,
+                "-y",
+                "-loglevel",
+                "error",
+              ],
+              { stdio: ["ignore", "ignore", "pipe"] },
+            );
+            return { at, path: outPath };
+          });
+
+          process.stdout.write(JSON.stringify({ frames }) + "\n");
+        } finally {
+          try {
+            unlinkSync(tmpVideo);
+          } catch {
+            // best-effort cleanup
+          }
+        }
+      },
+    ),
+  );

--- a/turbo/apps/cli/src/commands/zero/video/index.ts
+++ b/turbo/apps/cli/src/commands/zero/video/index.ts
@@ -1,0 +1,21 @@
+import { Command } from "commander";
+import { transcribeCommand } from "./transcribe";
+import { framesCommand } from "./frames";
+
+export const zeroVideoCommand = new Command()
+  .name("video")
+  .description("Video processing utilities")
+  .addCommand(transcribeCommand)
+  .addCommand(framesCommand)
+  .addHelpText(
+    "after",
+    `
+Examples:
+  Transcribe a video:  zero video transcribe --url "https://..."
+  Web file:            zero video transcribe --file-id abc-123
+  Extract frames:      zero video frames --url "https://..." --at 00:21,01:40
+
+Tip (video understanding):
+  Transcribe first to get a timestamped index, then extract only the
+  frames worth seeing instead of watching the whole video.`,
+  );

--- a/turbo/apps/cli/src/commands/zero/video/transcribe.ts
+++ b/turbo/apps/cli/src/commands/zero/video/transcribe.ts
@@ -1,0 +1,133 @@
+import { execFileSync } from "child_process";
+import { unlinkSync } from "fs";
+import { tmpdir } from "os";
+import { join } from "path";
+import { Command } from "commander";
+import { withErrorHandler } from "../../../lib/command";
+import {
+  downloadWebFile,
+  transcribeAudio,
+  type TranscribeAudioSegment,
+} from "../../../lib/api/domains/web";
+
+function formatTime(seconds: number): string {
+  const m = Math.floor(seconds / 60)
+    .toString()
+    .padStart(2, "0");
+  const s = Math.floor(seconds % 60)
+    .toString()
+    .padStart(2, "0");
+  return `${m}:${s}`;
+}
+
+function formatTranscript(
+  text: string,
+  segments: readonly TranscribeAudioSegment[] | undefined,
+): string {
+  if (!segments || segments.length === 0) {
+    return `## Transcript\n${text}`;
+  }
+  const lines = segments.map((s) => {
+    const start = formatTime(s.start);
+    const end = formatTime(s.end);
+    return `[${start}-${end}] ${s.text.trim()}`;
+  });
+  return `## Transcript\n${lines.join("\n")}`;
+}
+
+export const transcribeCommand = new Command()
+  .name("transcribe")
+  .description(
+    "Transcribe audio from a video file and output structured Markdown",
+  )
+  .option("--url <presigned-url>", "Pre-signed or public URL of the video file")
+  .option("--file-id <id>", "Web file ID (alternative to --url)")
+  .option(
+    "--no-timestamps",
+    "Output plain text only, without per-segment timestamps",
+  )
+  .addHelpText(
+    "after",
+    `
+Examples:
+  Transcribe from URL:      zero video transcribe --url "https://..."
+  Transcribe a web file:    zero video transcribe --file-id abc-123-def
+  Plain text only:          zero video transcribe --url "https://..." --no-timestamps
+
+Output:
+  Structured Markdown printed to stdout:
+    ## Transcript
+    [00:02-00:05] First sentence here.
+    [00:06-00:07] Second sentence here.
+
+Notes:
+  - Requires ffmpeg on PATH for audio extraction
+  - Authenticates via ZERO_TOKEN
+  - Audio is extracted before upload to stay within the 25 MB size limit
+  - Uses the /api/zero/voice-io/stt endpoint (quota applies)`,
+  )
+  .action(
+    withErrorHandler(
+      async (options: {
+        url?: string;
+        fileId?: string;
+        timestamps: boolean;
+      }) => {
+        if (!options.url && !options.fileId) {
+          process.stderr.write(
+            "Error: provide --url <presigned-url> or --file-id <id>\n",
+          );
+          process.exit(1);
+        }
+
+        const tmpVideo = join(tmpdir(), `zero-video-${Date.now()}.mp4`);
+        const tmpAudio = join(tmpdir(), `zero-audio-${Date.now()}.mp3`);
+
+        try {
+          if (options.url) {
+            execFileSync("curl", ["-sS", "-L", "-o", tmpVideo, options.url], {
+              stdio: ["ignore", "ignore", "pipe"],
+            });
+          } else {
+            await downloadWebFile(options.fileId as string, tmpVideo);
+          }
+
+          execFileSync(
+            "ffmpeg",
+            [
+              "-i",
+              tmpVideo,
+              "-vn",
+              "-ar",
+              "16000",
+              "-ac",
+              "1",
+              "-b:a",
+              "64k",
+              tmpAudio,
+              "-y",
+              "-loglevel",
+              "error",
+            ],
+            { stdio: ["ignore", "ignore", "pipe"] },
+          );
+
+          const result = await transcribeAudio(tmpAudio, {
+            verbose: options.timestamps !== false,
+          });
+
+          process.stdout.write(
+            formatTranscript(result.text, result.segments) + "\n",
+          );
+        } finally {
+          for (const path of [tmpVideo, tmpAudio]) {
+            try {
+              unlinkSync(path);
+            } catch {
+              // best-effort cleanup
+            }
+          }
+        }
+      },
+    ),
+  );

--- a/turbo/apps/cli/src/commands/zero/web/download-file.ts
+++ b/turbo/apps/cli/src/commands/zero/web/download-file.ts
@@ -36,9 +36,10 @@ Output:
 
 How to read the downloaded file:
   - Images (png/jpg/gif/webp/svg): open the file path with your image viewing tool
-  - Videos (mp4/mov/webm): extract frames first with
+  - Videos (mp4/mov/webm): transcribe audio first with
+      zero video transcribe --url <download-url>
+    or extract frames with
       ffmpeg -i <path> -vf "fps=1" -q:v 2 /tmp/<file-id>_frame_%03d.jpg
-    then view the extracted frames
   - PDF/text/csv/json/markdown: read the file directly
 
 Notes:

--- a/turbo/apps/cli/src/lib/api/domains/web.ts
+++ b/turbo/apps/cli/src/lib/api/domains/web.ts
@@ -955,3 +955,69 @@ export async function generateWebVideo(
     fallback: "Failed to generate video",
   });
 }
+
+export interface TranscribeAudioSegment {
+  readonly start: number;
+  readonly end: number;
+  readonly text: string;
+}
+
+interface TranscribeAudioResult {
+  readonly text: string;
+  readonly segments?: readonly TranscribeAudioSegment[];
+}
+
+export async function transcribeAudio(
+  audioPath: string,
+  options: { readonly verbose?: boolean } = {},
+): Promise<TranscribeAudioResult> {
+  const baseUrl = await getBaseUrl();
+  const token = await getActiveToken();
+  if (!token) {
+    throw new ApiRequestError("Not authenticated", "UNAUTHORIZED", 401);
+  }
+
+  const headers: Record<string, string> = {
+    Authorization: `Bearer ${token}`,
+  };
+  const bypassSecret = process.env.VERCEL_AUTOMATION_BYPASS_SECRET;
+  if (bypassSecret) {
+    headers["x-vercel-protection-bypass"] = bypassSecret;
+  }
+
+  const url = new URL("/api/zero/voice-io/stt", baseUrl);
+  if (options.verbose) {
+    url.searchParams.set("verbose", "true");
+  }
+
+  const audioData = readFileSync(audioPath);
+  const filename = basename(audioPath);
+  const ext = extname(filename).toLowerCase();
+  const mimeMap: Record<string, string> = {
+    ".mp3": "audio/mpeg",
+    ".mp4": "audio/mp4",
+    ".m4a": "audio/m4a",
+    ".wav": "audio/wav",
+    ".webm": "audio/webm",
+  };
+  const mimeType = mimeMap[ext] ?? "audio/mpeg";
+
+  const formData = new FormData();
+  formData.append("file", new Blob([audioData], { type: mimeType }), filename);
+
+  const response = await fetch(url, {
+    method: "POST",
+    headers,
+    body: formData,
+  });
+
+  if (!response.ok) {
+    const { message, code } = await parseErrorBody(
+      response,
+      "Transcription failed",
+    );
+    throw new ApiRequestError(message, code, response.status);
+  }
+
+  return (await response.json()) as TranscribeAudioResult;
+}

--- a/turbo/apps/cli/src/zero.ts
+++ b/turbo/apps/cli/src/zero.ts
@@ -30,6 +30,7 @@ import { zeroMapsCommand } from "./commands/zero/maps";
 import { zeroBankingCommand } from "./commands/zero/banking";
 import { zeroModelCommand } from "./commands/zero/model";
 import { zeroModelProviderCommand } from "./commands/zero/model-provider";
+import { zeroVideoCommand } from "./commands/zero/video";
 import {
   decodeZeroTokenPayload,
   type ZeroTokenPayload,
@@ -66,6 +67,7 @@ const COMMAND_CAPABILITY_MAP: Record<
   "computer-use": "computer-use:write",
   generate: null,
   web: null,
+  video: null,
   host: "host:write",
   maps: "maps:read",
   banking: "banking:read",
@@ -96,6 +98,7 @@ const DEFAULT_COMMANDS: Command[] = [
   zeroComputerUseCommand,
   generateCommand,
   zeroWebCommand,
+  zeroVideoCommand,
   zeroHostCommand,
   zeroMapsCommand,
   zeroBankingCommand,

--- a/turbo/packages/api-contracts/src/contracts/zero-voice-io-stt.ts
+++ b/turbo/packages/api-contracts/src/contracts/zero-voice-io-stt.ts
@@ -4,8 +4,15 @@ import { apiErrorSchema } from "./errors";
 
 const c = initContract();
 
+export const zeroVoiceIoSttSegmentSchema = z.object({
+  start: z.number(),
+  end: z.number(),
+  text: z.string(),
+});
+
 export const zeroVoiceIoSttResponseSchema = z.object({
   text: z.string(),
+  segments: z.array(zeroVoiceIoSttSegmentSchema).optional(),
 });
 
 export const zeroVoiceIoSttQuotaErrorSchema = apiErrorSchema.extend({
@@ -17,6 +24,7 @@ export const zeroVoiceIoSttQuotaErrorSchema = apiErrorSchema.extend({
     .optional(),
 });
 
+export type ZeroVoiceIoSttSegment = z.infer<typeof zeroVoiceIoSttSegmentSchema>;
 export type ZeroVoiceIoSttResponse = z.infer<
   typeof zeroVoiceIoSttResponseSchema
 >;
@@ -28,6 +36,9 @@ export const zeroVoiceIoSttContract = c.router({
     headers: authHeadersSchema,
     contentType: "multipart/form-data",
     body: c.type<FormData>(),
+    query: z.object({
+      verbose: z.coerce.boolean().optional().default(false),
+    }),
     responses: {
       200: zeroVoiceIoSttResponseSchema,
       400: apiErrorSchema,

--- a/turbo/packages/connectors/src/feature-switch-key.ts
+++ b/turbo/packages/connectors/src/feature-switch-key.ts
@@ -35,6 +35,7 @@ export enum FeatureSwitchKey {
   Banking = "banking",
   Lab = "lab",
   AuditLink = "auditLink",
+  AudioInput = "audioInput",
   AudioOutput = "audioOutput",
   SkillsViewer = "skillsViewer",
   TestOauthConnector = "testOauthConnector",

--- a/turbo/packages/core/src/feature-switch.ts
+++ b/turbo/packages/core/src/feature-switch.ts
@@ -195,6 +195,12 @@ const FEATURE_SWITCHES: Record<FeatureSwitchKey, FeatureSwitch> = {
     description: "Show audit log links in integration replies",
     enabled: false,
   },
+  [FeatureSwitchKey.AudioInput]: {
+    maintainer: "bingjie@vm0.ai",
+    description:
+      "Enable verbose (timestamped-segment) speech-to-text on /api/zero/voice-io/stt; when off, transcription falls back to plain text",
+    enabled: false,
+  },
   [FeatureSwitchKey.AudioOutput]: {
     maintainer: "lancy@vm0.ai",
     description:


### PR DESCRIPTION
## Re-land of #16799 (reverted by #16980)

#16799 (zero video transcribe + frames) was merged then reverted by #16980. This re-lands the feature together with the fixes made afterward — most importantly, making the command actually usable by zero agents.

## Original feature (#16799)

- **`zero video transcribe`** — downloads a video, extracts audio via ffmpeg, calls `/api/zero/voice-io/stt`, and prints structured Markdown with `[MM:SS-MM:SS]` timestamp blocks
- **`zero video frames --at <ts,...>`** — extracts still frames at given timestamps (the other half of "video-use": read the transcript to locate moments, then grab only those frames)
- **`/api/zero/voice-io/stt?verbose=true`** — verbose_json transcription returning `segments: [{start, end, text}]`
- `download-file` help across channels (web/slack/telegram/github/phone) suggesting transcribe

## Added in this re-land

- **Sandbox-token access on STT (key fix)** — the route declared no sandbox capability, so zero agent (sandbox) tokens got `403 "not available for sandbox tokens"`; `zero video transcribe` was unusable for agents. Added `requiredCapability: "file:write"`, matching the speech/image/video media routes.
- **`AudioInput` feature switch** (default off) gating the verbose path — when off, `?verbose=true` falls back to plain transcription, so the base STT endpoint keeps working for everyone (gradual rollout per the feature-switch guideline).
- **Path-traversal fix** — dropped `--out-dir` from `frames` (Semgrep finding); frames write to a temp dir with controlled, index-based filenames.
- **Test-boundary fix** — video command tests mock only external boundaries (`child_process` + MSW), not the internal `lib/api/domains/web` module.
- **`whisper-1` → named constant** `VOICE_IO_STT_VERBOSE_MODEL`.

## Test plan

- [ ] CI green
- [ ] `zero video transcribe --url <mp4>` returns timestamped Markdown (AudioInput switch on)
- [ ] `zero video frames --url <mp4> --at 00:05,00:30` writes frames and prints JSON paths
- [ ] A zero agent (sandbox token with `file:write`) can call `/api/zero/voice-io/stt` — no 403
- [ ] `?verbose=true` with AudioInput off falls back to plain text; base STT unaffected
- [ ] `POST /api/zero/voice-io/stt` (no param) unchanged — no regression

🤖 Generated with [Claude Code](https://claude.com/claude-code)
