### PR TITLE
feat: batch inline chat feedback in a docked tray with scrollable quotes

### DIFF
--- a/turbo/apps/platform/src/signals/zero-page/chat-feedback.ts
+++ b/turbo/apps/platform/src/signals/zero-page/chat-feedback.ts
@@ -35,6 +35,7 @@ const feedbackActive$ = state<boolean>(false);
 const feedbackComments$ = state<readonly FeedbackComment[]>([]);
 const feedbackDraft$ = state<FeedbackDraft | null>(null);
 const feedbackEditingId$ = state<number | null>(null);
+const feedbackExpanded$ = state<boolean>(false);
 const feedbackNextId$ = state<number>(1);
 const feedbackCopied$ = state<boolean>(false);
 const feedbackCopiedTimerId$ = state<number | null>(null);
@@ -57,6 +58,10 @@ export const feedbackDraftValue$ = computed((get) => {
 
 export const feedbackEditingIdValue$ = computed((get) => {
   return get(feedbackEditingId$);
+});
+
+export const feedbackExpandedValue$ = computed((get) => {
+  return get(feedbackExpanded$);
 });
 
 export const feedbackCopiedValue$ = computed((get) => {
@@ -194,6 +199,10 @@ export const setFeedbackDraftNote$ = command(({ get, set }, note: string) => {
   set(feedbackDraft$, { ...draft, note });
 });
 
+export const toggleFeedbackExpanded$ = command(({ get, set }) => {
+  set(feedbackExpanded$, !get(feedbackExpanded$));
+});
+
 export const editFeedbackComment$ = command(({ get, set }, id: number) => {
   set(commitDraft$);
   const comment = get(feedbackComments$).find((item) => {
@@ -241,6 +250,7 @@ export const dismissFeedback$ = command(({ get, set }) => {
   set(feedbackComments$, []);
   set(feedbackDraft$, null);
   set(feedbackEditingId$, null);
+  set(feedbackExpanded$, false);
   set(feedbackCopied$, false);
 });
 

--- a/turbo/apps/platform/src/signals/zero-page/chat-feedback.ts
+++ b/turbo/apps/platform/src/signals/zero-page/chat-feedback.ts
@@ -17,11 +17,25 @@ export interface FeedbackSelection {
   readonly rect: FeedbackSelectionRect;
 }
 
-type FeedbackMode = "toolbar" | "composer";
+// A passage the user has selected together with the note they attached to it.
+export interface FeedbackComment {
+  readonly id: number;
+  readonly quote: string;
+  readonly note: string;
+}
+
+// The passage currently being commented on, before it is added to the list.
+interface FeedbackDraft {
+  readonly quote: string;
+  readonly note: string;
+}
 
 const feedbackSelection$ = state<FeedbackSelection | null>(null);
-const feedbackMode$ = state<FeedbackMode>("toolbar");
-const feedbackComment$ = state<string>("");
+const feedbackActive$ = state<boolean>(false);
+const feedbackComments$ = state<readonly FeedbackComment[]>([]);
+const feedbackDraft$ = state<FeedbackDraft | null>(null);
+const feedbackEditingId$ = state<number | null>(null);
+const feedbackNextId$ = state<number>(1);
 const feedbackCopied$ = state<boolean>(false);
 const feedbackCopiedTimerId$ = state<number | null>(null);
 
@@ -29,16 +43,35 @@ export const feedbackSelectionValue$ = computed((get) => {
   return get(feedbackSelection$);
 });
 
-export const feedbackModeValue$ = computed((get) => {
-  return get(feedbackMode$);
+export const feedbackActiveValue$ = computed((get) => {
+  return get(feedbackActive$);
 });
 
-export const feedbackCommentValue$ = computed((get) => {
-  return get(feedbackComment$);
+export const feedbackCommentsValue$ = computed((get) => {
+  return get(feedbackComments$);
+});
+
+export const feedbackDraftValue$ = computed((get) => {
+  return get(feedbackDraft$);
+});
+
+export const feedbackEditingIdValue$ = computed((get) => {
+  return get(feedbackEditingId$);
 });
 
 export const feedbackCopiedValue$ = computed((get) => {
   return get(feedbackCopied$);
+});
+
+// What "Send" will dispatch: every committed comment, plus the draft when it
+// carries a not-yet-added note. While editing, the draft mirrors a comment that
+// is still in the list, so it is not counted twice.
+export const feedbackSendCountValue$ = computed((get) => {
+  const committed = get(feedbackComments$).length;
+  const draft = get(feedbackDraft$);
+  const editing = get(feedbackEditingId$) !== null;
+  const draftHasNote = (draft?.note.trim().length ?? 0) > 0;
+  return committed + (!editing && draftHasNote ? 1 : 0);
 });
 
 function resolveSelectionBubble(range: Range): Element | null {
@@ -47,31 +80,104 @@ function resolveSelectionBubble(range: Range): Element | null {
   return element?.closest(ASSISTANT_BUBBLE_SELECTOR) ?? null;
 }
 
-// Read the live document selection and, when it sits inside an assistant
-// message, snapshot its text and viewport rect. Skipped while the composer is
-// open — typing there moves the selection and would tear the popover down.
-export const captureFeedbackSelection$ = command(({ get, set }) => {
-  if (get(feedbackMode$) === "composer") {
-    return;
-  }
+// Read the live document selection when it sits inside an assistant message.
+function readAssistantSelection(): { text: string; range: Range } | null {
   const selection = window.getSelection();
   if (!selection || selection.isCollapsed || selection.rangeCount === 0) {
-    if (get(feedbackSelection$) !== null) {
-      set(feedbackSelection$, null);
-    }
-    return;
+    return null;
   }
   const text = selection.toString().trim();
+  if (!text) {
+    return null;
+  }
   const range = selection.getRangeAt(0);
-  if (!text || !resolveSelectionBubble(range)) {
+  if (!resolveSelectionBubble(range)) {
+    return null;
+  }
+  return { text, range };
+}
+
+// Compose every comment into a single follow-up turn, each passage quoted above
+// the note that belongs to it.
+function formatFeedbackPrompt(comments: readonly FeedbackComment[]): string {
+  const blocks = comments.map((comment) => {
+    const quoted = comment.quote
+      .split("\n")
+      .map((line) => {
+        return `> ${line}`;
+      })
+      .join("\n");
+    return `${quoted}\n\n${comment.note}`;
+  });
+  const intro =
+    comments.length === 1
+      ? "Feedback on this part of your reply:"
+      : `Feedback on ${comments.length} parts of your reply:`;
+  return `${intro}\n\n${blocks.join("\n\n---\n\n")}`;
+}
+
+// Commit the draft: update the comment being edited in place, or append a new
+// one. A blank note is a no-op so empty cards never appear.
+const commitDraft$ = command(({ get, set }) => {
+  const draft = get(feedbackDraft$);
+  if (!draft || draft.note.trim().length === 0) {
+    return;
+  }
+  const note = draft.note.trim();
+  const editingId = get(feedbackEditingId$);
+  if (editingId !== null) {
+    set(
+      feedbackComments$,
+      get(feedbackComments$).map((comment) => {
+        return comment.id === editingId
+          ? { ...comment, quote: draft.quote, note }
+          : comment;
+      }),
+    );
+  } else {
+    const id = get(feedbackNextId$);
+    set(feedbackNextId$, id + 1);
+    set(feedbackComments$, [
+      ...get(feedbackComments$),
+      { id, quote: draft.quote, note },
+    ]);
+  }
+  set(feedbackDraft$, null);
+  set(feedbackEditingId$, null);
+});
+
+export const addFeedbackComment$ = command(({ set }) => {
+  set(commitDraft$);
+});
+
+// A newly selected passage becomes the next draft; any in-progress note is
+// committed first so it is never lost.
+const loadDraftFromSelection$ = command(({ set }, quote: string) => {
+  set(commitDraft$);
+  set(feedbackDraft$, { quote, note: "" });
+  set(feedbackEditingId$, null);
+});
+
+// Watch the document selection. While the tray is open, a fresh selection
+// becomes the next draft passage; otherwise it drives the floating toolbar.
+export const captureFeedbackSelection$ = command(({ get, set }) => {
+  const found = readAssistantSelection();
+  if (get(feedbackActive$)) {
+    if (found) {
+      set(loadDraftFromSelection$, found.text);
+      window.getSelection()?.removeAllRanges();
+    }
+    return;
+  }
+  if (!found) {
     if (get(feedbackSelection$) !== null) {
       set(feedbackSelection$, null);
     }
     return;
   }
-  const rect = range.getBoundingClientRect();
+  const rect = found.range.getBoundingClientRect();
   set(feedbackSelection$, {
-    text,
+    text: found.text,
     rect: {
       top: rect.top,
       left: rect.left,
@@ -81,12 +187,60 @@ export const captureFeedbackSelection$ = command(({ get, set }) => {
   });
 });
 
-export const setFeedbackComment$ = command(({ set }, value: string) => {
-  set(feedbackComment$, value);
+// Open the tray and seed the draft with the passage under the toolbar.
+export const startFeedback$ = command(({ get, set }) => {
+  const selection = get(feedbackSelection$);
+  if (!selection) {
+    return;
+  }
+  set(feedbackActive$, true);
+  set(feedbackDraft$, { quote: selection.text, note: "" });
+  set(feedbackEditingId$, null);
+  set(feedbackSelection$, null);
 });
 
-export const openFeedbackComposer$ = command(({ set }) => {
-  set(feedbackMode$, "composer");
+export const setFeedbackDraftNote$ = command(({ get, set }, note: string) => {
+  const draft = get(feedbackDraft$);
+  if (!draft) {
+    return;
+  }
+  set(feedbackDraft$, { ...draft, note });
+});
+
+export const editFeedbackComment$ = command(({ get, set }, id: number) => {
+  set(commitDraft$);
+  const comment = get(feedbackComments$).find((item) => {
+    return item.id === id;
+  });
+  if (!comment) {
+    return;
+  }
+  set(feedbackDraft$, { quote: comment.quote, note: comment.note });
+  set(feedbackEditingId$, id);
+});
+
+export const removeFeedbackComment$ = command(({ get, set }, id: number) => {
+  set(
+    feedbackComments$,
+    get(feedbackComments$).filter((item) => {
+      return item.id !== id;
+    }),
+  );
+  if (get(feedbackEditingId$) === id) {
+    set(feedbackDraft$, null);
+    set(feedbackEditingId$, null);
+  }
+});
+
+// Flush a non-empty draft, then compose every comment into one prompt. Returns
+// null when there is nothing to send.
+export const submitFeedback$ = command(({ get, set }): string | null => {
+  set(commitDraft$);
+  const comments = get(feedbackComments$);
+  if (comments.length === 0) {
+    return null;
+  }
+  return formatFeedbackPrompt(comments);
 });
 
 export const dismissFeedback$ = command(({ get, set }) => {
@@ -96,18 +250,23 @@ export const dismissFeedback$ = command(({ get, set }) => {
     set(feedbackCopiedTimerId$, null);
   }
   set(feedbackSelection$, null);
-  set(feedbackMode$, "toolbar");
-  set(feedbackComment$, "");
+  set(feedbackActive$, false);
+  set(feedbackComments$, []);
+  set(feedbackDraft$, null);
+  set(feedbackEditingId$, null);
   set(feedbackCopied$, false);
 });
 
-// Scrolling the thread detaches the viewport rect from its passage, so close
-// the popover rather than let it drift. No-op when nothing is open.
+// Scrolling detaches the toolbar from its passage, so hide it. The docked tray
+// is pinned above the composer, not to the selection, so it stays put.
 export const dismissFeedbackOnScroll$ = command(({ get, set }) => {
+  if (get(feedbackActive$)) {
+    return;
+  }
   if (get(feedbackSelection$) === null) {
     return;
   }
-  set(dismissFeedback$);
+  set(feedbackSelection$, null);
 });
 
 export const copyFeedbackSelection$ = command(

--- a/turbo/apps/platform/src/signals/zero-page/chat-feedback.ts
+++ b/turbo/apps/platform/src/signals/zero-page/chat-feedback.ts
@@ -146,29 +146,11 @@ const commitDraft$ = command(({ get, set }) => {
   set(feedbackEditingId$, null);
 });
 
-export const addFeedbackComment$ = command(({ set }) => {
-  set(commitDraft$);
-});
-
-// A newly selected passage becomes the next draft; any in-progress note is
-// committed first so it is never lost.
-const loadDraftFromSelection$ = command(({ set }, quote: string) => {
-  set(commitDraft$);
-  set(feedbackDraft$, { quote, note: "" });
-  set(feedbackEditingId$, null);
-});
-
-// Watch the document selection. While the tray is open, a fresh selection
-// becomes the next draft passage; otherwise it drives the floating toolbar.
+// Watch the document selection and drive the floating toolbar. The toolbar
+// shows whether or not the tray is open — selecting another passage and
+// clicking "Provide feedback" again is how a further comment is added.
 export const captureFeedbackSelection$ = command(({ get, set }) => {
   const found = readAssistantSelection();
-  if (get(feedbackActive$)) {
-    if (found) {
-      set(loadDraftFromSelection$, found.text);
-      window.getSelection()?.removeAllRanges();
-    }
-    return;
-  }
   if (!found) {
     if (get(feedbackSelection$) !== null) {
       set(feedbackSelection$, null);
@@ -187,11 +169,16 @@ export const captureFeedbackSelection$ = command(({ get, set }) => {
   });
 });
 
-// Open the tray and seed the draft with the passage under the toolbar.
+// "Provide feedback" on a passage. When the tray is already open, commit the
+// in-progress note first (so nothing is lost) and make this passage the new
+// draft; otherwise open the tray seeded with it.
 export const startFeedback$ = command(({ get, set }) => {
   const selection = get(feedbackSelection$);
   if (!selection) {
     return;
+  }
+  if (get(feedbackActive$)) {
+    set(commitDraft$);
   }
   set(feedbackActive$, true);
   set(feedbackDraft$, { quote: selection.text, note: "" });

--- a/turbo/apps/platform/src/signals/zero-page/chat-feedback.ts
+++ b/turbo/apps/platform/src/signals/zero-page/chat-feedback.ts
@@ -257,9 +257,6 @@ export const dismissFeedback$ = command(({ get, set }) => {
 // Scrolling detaches the toolbar from its passage, so hide it. The docked tray
 // is pinned above the composer, not to the selection, so it stays put.
 export const dismissFeedbackOnScroll$ = command(({ get, set }) => {
-  if (get(feedbackActive$)) {
-    return;
-  }
   if (get(feedbackSelection$) === null) {
     return;
   }

--- a/turbo/apps/platform/src/views/zero-page/zero-chat-feedback-selection.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-chat-feedback-selection.tsx
@@ -3,7 +3,6 @@ import type {
   KeyboardEvent as ReactKeyboardEvent,
   RefCallback,
 } from "react";
-import { useState } from "react";
 import {
   IconArrowUp,
   IconCheck,
@@ -35,12 +34,14 @@ import {
   feedbackCopiedValue$,
   feedbackDraftValue$,
   feedbackEditingIdValue$,
+  feedbackExpandedValue$,
   feedbackSelectionValue$,
   feedbackSendCountValue$,
   removeFeedbackComment$,
   setFeedbackDraftNote$,
   startFeedback$,
   submitFeedback$,
+  toggleFeedbackExpanded$,
   type FeedbackComment,
   type FeedbackSelection,
 } from "../../signals/zero-page/chat-feedback.ts";
@@ -183,6 +184,64 @@ function FeedbackCommentCard({
   );
 }
 
+// Committed comments collapse to a one-line summary so the tray stays short and
+// the reply behind it stays visible. Expanding (or editing) reveals the bounded,
+// scrollable list.
+function FeedbackCommentSummary({
+  comments,
+  editingId,
+  expanded,
+  onToggle,
+  onEdit,
+  onRemove,
+}: {
+  comments: readonly FeedbackComment[];
+  editingId: number | null;
+  expanded: boolean;
+  onToggle: () => void;
+  onEdit: (id: number) => void;
+  onRemove: (id: number) => void;
+}) {
+  const showList = expanded || editingId !== null;
+  return (
+    <div className="mb-2">
+      <button
+        type="button"
+        onClick={onToggle}
+        className="flex w-full items-center justify-between rounded-lg bg-gray-50 px-3 py-2 text-xs font-medium text-muted-foreground transition-colors hover:bg-muted"
+      >
+        <span>
+          {comments.length === 1 ? "1 comment" : `${comments.length} comments`}
+        </span>
+        {showList ? (
+          <IconChevronDown size={15} stroke={2} />
+        ) : (
+          <IconChevronRight size={15} stroke={2} />
+        )}
+      </button>
+      {showList ? (
+        <div className="mt-2 flex max-h-44 flex-col gap-2 overflow-y-auto pr-0.5">
+          {comments.map((comment) => {
+            return (
+              <FeedbackCommentCard
+                key={comment.id}
+                comment={comment}
+                editing={editingId === comment.id}
+                onEdit={() => {
+                  return onEdit(comment.id);
+                }}
+                onRemove={() => {
+                  return onRemove(comment.id);
+                }}
+              />
+            );
+          })}
+        </div>
+      ) : null}
+    </div>
+  );
+}
+
 // Mounts the selection listeners and the floating Copy / Provide feedback
 // toolbar anchored to the highlighted passage.
 export function ChatFeedbackSelection() {
@@ -236,20 +295,17 @@ export function ChatFeedbackTray({
   const draft = useGet(feedbackDraftValue$);
   const editingId = useGet(feedbackEditingIdValue$);
   const sendCount = useGet(feedbackSendCountValue$);
+  const expanded = useGet(feedbackExpandedValue$);
   const setNote = useSet(setFeedbackDraftNote$);
   const editComment = useSet(editFeedbackComment$);
   const removeComment = useSet(removeFeedbackComment$);
+  const toggleExpanded = useSet(toggleFeedbackExpanded$);
   const submit = useSet(submitFeedback$);
   const dismiss = useSet(dismissFeedback$);
-  const [expanded, setExpanded] = useState(false);
 
   if (!active) {
     return null;
   }
-
-  // Collapse committed comments into a one-line summary by default so the tray
-  // stays short and Zero's reply stays visible; expand (or edit) to see them.
-  const showList = expanded || editingId !== null;
 
   const handleSubmit = () => {
     const prompt = submit();
@@ -292,47 +348,14 @@ export function ChatFeedbackTray({
           </div>
 
           {comments.length > 0 ? (
-            <div className="mb-2">
-              <button
-                type="button"
-                onClick={() => {
-                  return setExpanded((value) => {
-                    return !value;
-                  });
-                }}
-                className="flex w-full items-center justify-between rounded-lg bg-gray-50 px-3 py-2 text-xs font-medium text-muted-foreground transition-colors hover:bg-muted"
-              >
-                <span>
-                  {comments.length === 1
-                    ? "1 comment"
-                    : `${comments.length} comments`}
-                </span>
-                {showList ? (
-                  <IconChevronDown size={15} stroke={2} />
-                ) : (
-                  <IconChevronRight size={15} stroke={2} />
-                )}
-              </button>
-              {showList ? (
-                <div className="mt-2 flex max-h-44 flex-col gap-2 overflow-y-auto pr-0.5">
-                  {comments.map((comment) => {
-                    return (
-                      <FeedbackCommentCard
-                        key={comment.id}
-                        comment={comment}
-                        editing={editingId === comment.id}
-                        onEdit={() => {
-                          return editComment(comment.id);
-                        }}
-                        onRemove={() => {
-                          return removeComment(comment.id);
-                        }}
-                      />
-                    );
-                  })}
-                </div>
-              ) : null}
-            </div>
+            <FeedbackCommentSummary
+              comments={comments}
+              editingId={editingId}
+              expanded={expanded}
+              onToggle={toggleExpanded}
+              onEdit={editComment}
+              onRemove={removeComment}
+            />
           ) : null}
 
           {draft ? (

--- a/turbo/apps/platform/src/views/zero-page/zero-chat-feedback-selection.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-chat-feedback-selection.tsx
@@ -8,11 +8,13 @@ import {
   IconCheck,
   IconCopy,
   IconMessageCircle,
+  IconPlus,
   IconX,
 } from "@tabler/icons-react";
 import { useGet, useSet } from "ccstate-react";
 import {
   Button,
+  cn,
   Popover,
   PopoverAnchor,
   PopoverContent,
@@ -21,33 +23,30 @@ import {
 import { rootSignal$ } from "../../signals/root-signal.ts";
 import { detach, Reason } from "../../signals/utils.ts";
 import {
+  addFeedbackComment$,
   captureFeedbackSelection$,
   copyFeedbackSelection$,
   dismissFeedback$,
   dismissFeedbackOnScroll$,
-  feedbackCommentValue$,
+  editFeedbackComment$,
+  feedbackActiveValue$,
+  feedbackCommentsValue$,
   feedbackCopiedValue$,
-  feedbackModeValue$,
+  feedbackDraftValue$,
+  feedbackEditingIdValue$,
   feedbackSelectionValue$,
-  openFeedbackComposer$,
-  setFeedbackComment$,
+  feedbackSendCountValue$,
+  removeFeedbackComment$,
+  setFeedbackDraftNote$,
+  startFeedback$,
+  submitFeedback$,
+  type FeedbackComment,
   type FeedbackSelection,
 } from "../../signals/zero-page/chat-feedback.ts";
 
-// Compose the quoted passage and the user's note into a single follow-up turn.
-function formatFeedbackPrompt(quote: string, comment: string): string {
-  const quoted = quote
-    .split("\n")
-    .map((line) => {
-      return `> ${line}`;
-    })
-    .join("\n");
-  return `Feedback on this part of your reply:\n\n${quoted}\n\n${comment}`;
-}
-
-// Watches document selection (and dismisses on scroll) for the whole thread,
-// via a ref on a persistent hidden node — the platform's listener-lifecycle
-// idiom in place of an effect.
+// Watches document selection (and dismisses the toolbar on scroll) for the
+// whole thread, via a ref on a persistent hidden node — the platform's
+// listener-lifecycle idiom in place of an effect.
 function selectionListenersRef(
   capture: () => void,
   dismissOnScroll: () => void,
@@ -136,105 +135,64 @@ function FeedbackToolbar({
   );
 }
 
-function FeedbackComposer({
-  quote,
+// A committed comment: its quoted passage above the note. Clicking reopens it
+// for editing; the × removes it.
+function FeedbackCommentCard({
   comment,
-  onCommentChange,
-  onSubmit,
-  onDismiss,
+  editing,
+  onEdit,
+  onRemove,
 }: {
-  quote: string;
-  comment: string;
-  onCommentChange: (value: string) => void;
-  onSubmit: () => void;
-  onDismiss: () => void;
+  comment: FeedbackComment;
+  editing: boolean;
+  onEdit: () => void;
+  onRemove: () => void;
 }) {
-  const handleKeyDown = (event: ReactKeyboardEvent<HTMLTextAreaElement>) => {
-    // Enter sends, Shift+Enter inserts a newline — matching the main composer.
-    if (matchShortcut("enter", event)) {
-      event.preventDefault();
-      onSubmit();
-    } else if (matchShortcut("escape", event)) {
-      event.preventDefault();
-      onDismiss();
-    }
-  };
   return (
-    <PopoverContent
-      side="top"
-      align="center"
-      sideOffset={8}
-      className="w-80 rounded-xl p-3"
+    <div
+      className={cn(
+        "group relative rounded-lg border bg-background transition-colors",
+        editing
+          ? "border-[hsl(var(--gray-400))] bg-gray-50"
+          : "border-border hover:bg-gray-50",
+      )}
     >
-      <div className="mb-2 flex items-center justify-between">
-        <span className="text-xs font-semibold text-foreground">
-          Provide feedback
+      <button
+        type="button"
+        onClick={onEdit}
+        className="block w-full px-3 py-2 text-left"
+      >
+        <span className="mb-1 line-clamp-2 border-l-2 border-border pl-2 text-[11px] italic leading-snug text-muted-foreground">
+          {comment.quote}
         </span>
-        <button
-          type="button"
-          onClick={onDismiss}
-          aria-label="Dismiss"
-          className="rounded-md p-0.5 text-muted-foreground/60 transition-colors hover:bg-muted hover:text-foreground"
-        >
-          <IconX size={14} stroke={2} />
-        </button>
-      </div>
-      <blockquote className="mb-3 max-h-24 overflow-y-auto rounded-r-md border-l-[3px] border-border bg-muted/40 px-3 py-2 text-xs italic leading-5 text-muted-foreground">
-        {quote}
-      </blockquote>
-      <textarea
-        ref={focusOnMountRef}
-        value={comment}
-        onChange={(event) => {
-          return onCommentChange(event.target.value);
-        }}
-        onKeyDown={handleKeyDown}
-        rows={2}
-        placeholder="What should change about this?"
-        className="w-full resize-none rounded-lg border-[0.7px] border-[hsl(var(--gray-400))] bg-input px-3 py-2 text-sm text-foreground placeholder:text-muted-foreground/40 focus:border-primary focus:outline-none focus:ring-[3px] focus:ring-primary/10"
-      />
-      <div className="mt-3 flex items-center justify-end gap-2">
-        <Button variant="ghost" size="sm" onClick={onDismiss}>
-          Cancel
-        </Button>
-        <Button
-          size="sm"
-          onClick={onSubmit}
-          disabled={comment.trim().length === 0}
-          className="gap-1.5"
-        >
-          <IconArrowUp size={14} stroke={2} />
-          Send feedback
-        </Button>
-      </div>
-    </PopoverContent>
+        <span className="block pr-6 text-[13px] leading-snug text-foreground">
+          {comment.note}
+        </span>
+      </button>
+      <button
+        type="button"
+        onClick={onRemove}
+        aria-label="Remove comment"
+        title="Remove comment"
+        className="absolute right-1.5 top-1.5 inline-flex h-7 w-7 items-center justify-center rounded-md text-muted-foreground opacity-0 transition-colors hover:bg-muted hover:text-foreground focus-visible:opacity-100 group-hover:opacity-100"
+      >
+        <IconX size={15} stroke={2} />
+      </button>
+    </div>
   );
 }
 
-export function ChatFeedbackSelection({
-  onSubmit,
-}: {
-  onSubmit: (prompt: string) => void;
-}) {
+// Mounts the selection listeners and the floating Copy / Provide feedback
+// toolbar anchored to the highlighted passage.
+export function ChatFeedbackSelection() {
   const selection = useGet(feedbackSelectionValue$);
-  const mode = useGet(feedbackModeValue$);
-  const comment = useGet(feedbackCommentValue$);
   const copied = useGet(feedbackCopiedValue$);
   const rootSignal = useGet(rootSignal$);
   const capture = useSet(captureFeedbackSelection$);
   const dismissOnScroll = useSet(dismissFeedbackOnScroll$);
+  const startFeedback = useSet(startFeedback$);
   const dismiss = useSet(dismissFeedback$);
-  const openComposer = useSet(openFeedbackComposer$);
-  const setComment = useSet(setFeedbackComment$);
   const copy = useSet(copyFeedbackSelection$);
-
-  const handleSubmit = () => {
-    if (!selection || comment.trim().length === 0) {
-      return;
-    }
-    onSubmit(formatFeedbackPrompt(selection.text, comment.trim()));
-    dismiss();
-  };
 
   return (
     <>
@@ -251,25 +209,165 @@ export function ChatFeedbackSelection({
           <PopoverAnchor asChild>
             <div style={anchorStyle(selection)} aria-hidden />
           </PopoverAnchor>
-          {mode === "toolbar" ? (
-            <FeedbackToolbar
-              copied={copied}
-              onCopy={() => {
-                return detach(copy(rootSignal), Reason.DomCallback);
-              }}
-              onProvideFeedback={openComposer}
-            />
-          ) : (
-            <FeedbackComposer
-              quote={selection.text}
-              comment={comment}
-              onCommentChange={setComment}
-              onSubmit={handleSubmit}
-              onDismiss={dismiss}
-            />
-          )}
+          <FeedbackToolbar
+            copied={copied}
+            onCopy={() => {
+              return detach(copy(rootSignal), Reason.DomCallback);
+            }}
+            onProvideFeedback={startFeedback}
+          />
         </Popover>
       ) : null}
     </>
+  );
+}
+
+// The docked feedback tray: accumulated comment cards, the draft editor for the
+// current passage, and a single "Send" that dispatches them as one turn. Sits
+// above the composer and survives thread scrolling.
+export function ChatFeedbackTray({
+  onSubmit,
+}: {
+  onSubmit: (prompt: string) => void;
+}) {
+  const active = useGet(feedbackActiveValue$);
+  const comments = useGet(feedbackCommentsValue$);
+  const draft = useGet(feedbackDraftValue$);
+  const editingId = useGet(feedbackEditingIdValue$);
+  const sendCount = useGet(feedbackSendCountValue$);
+  const setNote = useSet(setFeedbackDraftNote$);
+  const addComment = useSet(addFeedbackComment$);
+  const editComment = useSet(editFeedbackComment$);
+  const removeComment = useSet(removeFeedbackComment$);
+  const submit = useSet(submitFeedback$);
+  const dismiss = useSet(dismissFeedback$);
+
+  if (!active) {
+    return null;
+  }
+
+  const draftHasNote = (draft?.note.trim().length ?? 0) > 0;
+
+  const handleSubmit = () => {
+    const prompt = submit();
+    if (prompt === null) {
+      return;
+    }
+    onSubmit(prompt);
+    dismiss();
+  };
+
+  const handleKeyDown = (event: ReactKeyboardEvent<HTMLTextAreaElement>) => {
+    // Enter adds the comment, Shift+Enter inserts a newline — matching the main
+    // composer. Escape closes the tray.
+    if (matchShortcut("enter", event)) {
+      event.preventDefault();
+      addComment();
+    } else if (matchShortcut("escape", event)) {
+      event.preventDefault();
+      dismiss();
+    }
+  };
+
+  return (
+    <div className="shrink-0 px-4 pb-1 pt-2 sm:px-6">
+      <div className="mx-auto max-w-[900px]">
+        <div className="rounded-xl border border-border bg-popover p-3 shadow-lg">
+          <div className="mb-2 flex items-center justify-between">
+            <span className="text-xs font-semibold text-foreground">
+              Feedback on this reply
+            </span>
+            <div className="flex items-center gap-1.5">
+              {comments.length > 0 ? (
+                <span className="rounded-full bg-gray-50 px-2 py-0.5 text-xs font-medium text-muted-foreground">
+                  {comments.length === 1
+                    ? "1 comment"
+                    : `${comments.length} comments`}
+                </span>
+              ) : null}
+              <button
+                type="button"
+                onClick={dismiss}
+                aria-label="Close"
+                title="Close"
+                className="inline-flex h-8 w-8 shrink-0 items-center justify-center rounded-md text-muted-foreground transition-colors hover:bg-muted hover:text-foreground"
+              >
+                <IconX size={18} stroke={1.8} />
+              </button>
+            </div>
+          </div>
+
+          {comments.length > 0 ? (
+            <div className="mb-2 flex max-h-44 flex-col gap-2 overflow-y-auto pr-0.5">
+              {comments.map((comment) => {
+                return (
+                  <FeedbackCommentCard
+                    key={comment.id}
+                    comment={comment}
+                    editing={editingId === comment.id}
+                    onEdit={() => {
+                      return editComment(comment.id);
+                    }}
+                    onRemove={() => {
+                      return removeComment(comment.id);
+                    }}
+                  />
+                );
+              })}
+            </div>
+          ) : null}
+
+          {draft ? (
+            <>
+              <blockquote className="mb-2 max-h-28 overflow-y-auto rounded-r-md border-l-[3px] border-border bg-muted/40 px-3 py-2 text-xs italic leading-5 text-muted-foreground">
+                {draft.quote}
+              </blockquote>
+              <textarea
+                key={draft.quote}
+                ref={focusOnMountRef}
+                value={draft.note}
+                onChange={(event) => {
+                  return setNote(event.target.value);
+                }}
+                onKeyDown={handleKeyDown}
+                rows={2}
+                placeholder="What should change about this?"
+                className="w-full resize-none rounded-lg border-[0.7px] border-[hsl(var(--gray-400))] bg-input px-3 py-2 text-sm text-foreground placeholder:text-muted-foreground/40 focus:border-primary focus:outline-none focus:ring-[3px] focus:ring-primary/10"
+              />
+            </>
+          ) : (
+            <div className="rounded-lg border border-dashed border-border bg-gray-50 px-3 py-3 text-center text-xs text-muted-foreground">
+              Select any text in the reply to add another comment
+            </div>
+          )}
+
+          <div className="mt-3 flex items-center justify-between">
+            <Button
+              variant="ghost"
+              size="sm"
+              onClick={addComment}
+              disabled={!draftHasNote}
+              className="gap-1.5"
+            >
+              <IconPlus size={14} stroke={2} />
+              {editingId !== null ? "Save comment" : "Add comment"}
+            </Button>
+            <Button
+              size="sm"
+              onClick={handleSubmit}
+              disabled={sendCount === 0}
+              className="gap-1.5"
+            >
+              <IconArrowUp size={14} stroke={2} />
+              {sendCount === 0
+                ? "Send"
+                : sendCount === 1
+                  ? "Send 1 comment"
+                  : `Send ${sendCount} comments`}
+            </Button>
+          </div>
+        </div>
+      </div>
+    </div>
   );
 }

--- a/turbo/apps/platform/src/views/zero-page/zero-chat-feedback-selection.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-chat-feedback-selection.tsx
@@ -3,9 +3,12 @@ import type {
   KeyboardEvent as ReactKeyboardEvent,
   RefCallback,
 } from "react";
+import { useState } from "react";
 import {
   IconArrowUp,
   IconCheck,
+  IconChevronDown,
+  IconChevronRight,
   IconCopy,
   IconMessageCircle,
   IconX,
@@ -238,10 +241,15 @@ export function ChatFeedbackTray({
   const removeComment = useSet(removeFeedbackComment$);
   const submit = useSet(submitFeedback$);
   const dismiss = useSet(dismissFeedback$);
+  const [expanded, setExpanded] = useState(false);
 
   if (!active) {
     return null;
   }
+
+  // Collapse committed comments into a one-line summary by default so the tray
+  // stays short and Zero's reply stays visible; expand (or edit) to see them.
+  const showList = expanded || editingId !== null;
 
   const handleSubmit = () => {
     const prompt = submit();
@@ -272,43 +280,58 @@ export function ChatFeedbackTray({
             <span className="text-xs font-semibold text-foreground">
               Feedback on this reply
             </span>
-            <div className="flex items-center gap-1.5">
-              {comments.length > 0 ? (
-                <span className="rounded-full bg-gray-50 px-2 py-0.5 text-xs font-medium text-muted-foreground">
+            <button
+              type="button"
+              onClick={dismiss}
+              aria-label="Close"
+              title="Close"
+              className="inline-flex h-8 w-8 shrink-0 items-center justify-center rounded-md text-muted-foreground transition-colors hover:bg-muted hover:text-foreground"
+            >
+              <IconX size={18} stroke={1.8} />
+            </button>
+          </div>
+
+          {comments.length > 0 ? (
+            <div className="mb-2">
+              <button
+                type="button"
+                onClick={() => {
+                  return setExpanded((value) => {
+                    return !value;
+                  });
+                }}
+                className="flex w-full items-center justify-between rounded-lg bg-gray-50 px-3 py-2 text-xs font-medium text-muted-foreground transition-colors hover:bg-muted"
+              >
+                <span>
                   {comments.length === 1
                     ? "1 comment"
                     : `${comments.length} comments`}
                 </span>
-              ) : null}
-              <button
-                type="button"
-                onClick={dismiss}
-                aria-label="Close"
-                title="Close"
-                className="inline-flex h-8 w-8 shrink-0 items-center justify-center rounded-md text-muted-foreground transition-colors hover:bg-muted hover:text-foreground"
-              >
-                <IconX size={18} stroke={1.8} />
+                {showList ? (
+                  <IconChevronDown size={15} stroke={2} />
+                ) : (
+                  <IconChevronRight size={15} stroke={2} />
+                )}
               </button>
-            </div>
-          </div>
-
-          {comments.length > 0 ? (
-            <div className="mb-2 flex max-h-44 flex-col gap-2 overflow-y-auto pr-0.5">
-              {comments.map((comment) => {
-                return (
-                  <FeedbackCommentCard
-                    key={comment.id}
-                    comment={comment}
-                    editing={editingId === comment.id}
-                    onEdit={() => {
-                      return editComment(comment.id);
-                    }}
-                    onRemove={() => {
-                      return removeComment(comment.id);
-                    }}
-                  />
-                );
-              })}
+              {showList ? (
+                <div className="mt-2 flex max-h-44 flex-col gap-2 overflow-y-auto pr-0.5">
+                  {comments.map((comment) => {
+                    return (
+                      <FeedbackCommentCard
+                        key={comment.id}
+                        comment={comment}
+                        editing={editingId === comment.id}
+                        onEdit={() => {
+                          return editComment(comment.id);
+                        }}
+                        onRemove={() => {
+                          return removeComment(comment.id);
+                        }}
+                      />
+                    );
+                  })}
+                </div>
+              ) : null}
             </div>
           ) : null}
 

--- a/turbo/apps/platform/src/views/zero-page/zero-chat-feedback-selection.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-chat-feedback-selection.tsx
@@ -8,7 +8,6 @@ import {
   IconCheck,
   IconCopy,
   IconMessageCircle,
-  IconPlus,
   IconX,
 } from "@tabler/icons-react";
 import { useGet, useSet } from "ccstate-react";
@@ -23,7 +22,6 @@ import {
 import { rootSignal$ } from "../../signals/root-signal.ts";
 import { detach, Reason } from "../../signals/utils.ts";
 import {
-  addFeedbackComment$,
   captureFeedbackSelection$,
   copyFeedbackSelection$,
   dismissFeedback$,
@@ -236,7 +234,6 @@ export function ChatFeedbackTray({
   const editingId = useGet(feedbackEditingIdValue$);
   const sendCount = useGet(feedbackSendCountValue$);
   const setNote = useSet(setFeedbackDraftNote$);
-  const addComment = useSet(addFeedbackComment$);
   const editComment = useSet(editFeedbackComment$);
   const removeComment = useSet(removeFeedbackComment$);
   const submit = useSet(submitFeedback$);
@@ -245,8 +242,6 @@ export function ChatFeedbackTray({
   if (!active) {
     return null;
   }
-
-  const draftHasNote = (draft?.note.trim().length ?? 0) > 0;
 
   const handleSubmit = () => {
     const prompt = submit();
@@ -258,11 +253,11 @@ export function ChatFeedbackTray({
   };
 
   const handleKeyDown = (event: ReactKeyboardEvent<HTMLTextAreaElement>) => {
-    // Enter adds the comment, Shift+Enter inserts a newline — matching the main
-    // composer. Escape closes the tray.
+    // Enter sends, Shift+Enter inserts a newline — matching the main composer.
+    // Escape closes the tray.
     if (matchShortcut("enter", event)) {
       event.preventDefault();
-      addComment();
+      handleSubmit();
     } else if (matchShortcut("escape", event)) {
       event.preventDefault();
       dismiss();
@@ -319,7 +314,7 @@ export function ChatFeedbackTray({
 
           {draft ? (
             <>
-              <blockquote className="mb-2 max-h-28 overflow-y-auto rounded-r-md border-l-[3px] border-border bg-muted/40 px-3 py-2 text-xs italic leading-5 text-muted-foreground">
+              <blockquote className="mb-3 max-h-28 overflow-y-auto rounded-r-md border-l-[3px] border-border bg-muted/40 px-3 py-2 text-xs italic leading-5 text-muted-foreground">
                 {draft.quote}
               </blockquote>
               <textarea
@@ -335,28 +330,17 @@ export function ChatFeedbackTray({
                 className="w-full resize-none rounded-lg border-[0.7px] border-[hsl(var(--gray-400))] bg-input px-3 py-2 text-sm text-foreground placeholder:text-muted-foreground/40 focus:border-primary focus:outline-none focus:ring-[3px] focus:ring-primary/10"
               />
             </>
-          ) : (
-            <div className="rounded-lg border border-dashed border-border bg-gray-50 px-3 py-3 text-center text-xs text-muted-foreground">
-              Select any text in the reply to add another comment
-            </div>
-          )}
+          ) : null}
 
-          <div className="mt-3 flex items-center justify-between">
-            <Button
-              variant="ghost"
-              size="sm"
-              onClick={addComment}
-              disabled={!draftHasNote}
-              className="gap-1.5"
-            >
-              <IconPlus size={14} stroke={2} />
-              {editingId !== null ? "Save comment" : "Add comment"}
-            </Button>
+          <div className="mt-3 flex items-center justify-between gap-3">
+            <span className="text-xs leading-snug text-muted-foreground">
+              Select more text and click Provide feedback to add another comment
+            </span>
             <Button
               size="sm"
               onClick={handleSubmit}
               disabled={sendCount === 0}
-              className="gap-1.5"
+              className="shrink-0 gap-1.5"
             >
               <IconArrowUp size={14} stroke={2} />
               {sendCount === 0

--- a/turbo/apps/platform/src/views/zero-page/zero-chat-thread-page.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-chat-thread-page.tsx
@@ -176,7 +176,10 @@ import {
   ZeroChatComposer,
   type QueuedComposerItem,
 } from "./zero-chat-composer.tsx";
-import { ChatFeedbackSelection } from "./zero-chat-feedback-selection.tsx";
+import {
+  ChatFeedbackSelection,
+  ChatFeedbackTray,
+} from "./zero-chat-feedback-selection.tsx";
 import {
   setThreadGenerationTemplate$,
   threadGenerationTemplate$,
@@ -2396,15 +2399,16 @@ function ChatThreadContent({ thread }: { thread: ChatThreadSignals }) {
             />
           </div>
 
+          {inlineFeedbackEnabled && (
+            <ChatFeedbackTray onSubmit={onSubmitFeedback} />
+          )}
           <ChatThreadComposer thread={thread} />
         </div>
 
         {githubPrTrackingOpen && <GithubPrTrackingDock thread={thread} />}
       </div>
 
-      {inlineFeedbackEnabled && (
-        <ChatFeedbackSelection onSubmit={onSubmitFeedback} />
-      )}
+      {inlineFeedbackEnabled && <ChatFeedbackSelection />}
     </>
   );
 }


### PR DESCRIPTION
## What

Reworks the inline chat feedback flow (behind the `ChatInlineFeedback` switch) from a single quote + single note popover into a **docked tray that batches multiple comments** and sends them as one follow-up turn.

This is the implementation of the docked-tray direction we prototyped and reviewed.

**Interactive prototype:** https://zero-feedback-tray-715f6d07-e7fafdc2.sites.vm0.io

![feedback tray](https://cdn.vm0.io/artifacts/user_36PnTFtD4dBQ9zg5jj6E5r918aV/bf89159e-cfe2-4c58-a626-b0f6116deb09/pr-shot.png)

## Why

The old popover only allowed one comment per send, and because it was anchored to the selection's viewport rect, **scrolling the thread tore it down** — so you couldn't comment on passages in different parts of a long reply. The quoted passage was also capped at 96px inside a fixed-width popover and felt clipped.

## Changes

- **Batch comments.** Selecting a passage and choosing *Provide feedback* opens a tray docked above the composer. Each passage + note becomes a comment card. Selecting another passage auto-commits the in-progress note (never silently dropped), then loads the new passage as the next draft. *Send N comments* composes every card into one turn.
- **Scrollable quote + persistent tray.** The quoted passage scrolls comfortably, and the tray is pinned above the composer rather than to the selection, so it survives thread scrolling. `dismissFeedbackOnScroll$` now only hides the floating toolbar, not the tray.
- **Editable / removable cards.** Click a card to reopen it for editing; the × removes it.
- **Design tweaks from review.** The comment counter is a neutral gray pill (no brand color); the close control uses the standard `h-8 w-8` icon-button size.

## Files

- `signals/zero-page/chat-feedback.ts` — batch state model (committed comments, draft, editing id) and commands (`startFeedback$`, `addFeedbackComment$`, `editFeedbackComment$`, `removeFeedbackComment$`, `submitFeedback$`).
- `views/zero-page/zero-chat-feedback-selection.tsx` — splits into `ChatFeedbackSelection` (selection toolbar) and `ChatFeedbackTray` (docked tray).
- `views/zero-page/zero-chat-thread-page.tsx` — mounts the tray in the chat column above the composer.

## Notes

- No backend or API changes; the composed prompt format is unchanged in spirit (quoted passage + note), now joined across comments.
- No tests referenced the old strings; behavior stays behind the existing feature switch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)