### PR TITLE
feat: add desktop computer use stop action

### DIFF
--- a/turbo/apps/desktop/src/computer-use-electron.ts
+++ b/turbo/apps/desktop/src/computer-use-electron.ts
@@ -11,10 +11,21 @@ interface ComputerUseIpcOptions {
 interface ComputerUseNativeApi {
   readonly getState: () => DesktopComputerUseState;
   readonly refreshPermissions: () => Promise<DesktopComputerUseState>;
-  readonly start: () => Promise<DesktopComputerUseState>;
+  readonly start: (options: {
+    readonly userInitiated: boolean;
+  }) => Promise<DesktopComputerUseState>;
+  readonly stop: () => Promise<DesktopComputerUseState>;
   readonly requestAccessibilityPermission: () => Promise<DesktopComputerUseState>;
   readonly requestScreenRecordingPermission: () => Promise<DesktopComputerUseState>;
   readonly setKeepAwakeEnabled: (enabled: boolean) => DesktopComputerUseState;
+}
+
+function isComputerUseStartOptions(
+  value: unknown,
+): value is { readonly userInitiated?: unknown } {
+  return (
+    typeof value === "object" && value !== null && "userInitiated" in value
+  );
 }
 
 export function notifyDesktopComputerUseChanged(): void {
@@ -39,6 +50,14 @@ export function installComputerUseIpc(
       throw new Error("Desktop Computer Use is unavailable on this page");
     }
   };
+  const startOptions = (
+    value: unknown,
+  ): { readonly userInitiated: boolean } => {
+    return {
+      userInitiated:
+        isComputerUseStartOptions(value) && value.userInitiated === true,
+    };
+  };
 
   ipcMain.handle(COMPUTER_USE_CHANNELS.getState, (event) => {
     assertComputerUsePage(event);
@@ -48,9 +67,13 @@ export function installComputerUseIpc(
     assertComputerUsePage(event);
     return api.refreshPermissions();
   });
-  ipcMain.handle(COMPUTER_USE_CHANNELS.start, async (event) => {
+  ipcMain.handle(COMPUTER_USE_CHANNELS.start, async (event, options) => {
     assertComputerUsePage(event);
-    return api.start();
+    return api.start(startOptions(options));
+  });
+  ipcMain.handle(COMPUTER_USE_CHANNELS.stop, async (event) => {
+    assertComputerUsePage(event);
+    return api.stop();
   });
   ipcMain.handle(
     COMPUTER_USE_CHANNELS.requestAccessibilityPermission,

--- a/turbo/apps/desktop/src/computer-use-ipc-channels.ts
+++ b/turbo/apps/desktop/src/computer-use-ipc-channels.ts
@@ -2,6 +2,7 @@ export const COMPUTER_USE_CHANNELS = {
   getState: "computer-use:get-state",
   refreshPermissions: "computer-use:refresh-permissions",
   start: "computer-use:start",
+  stop: "computer-use:stop",
   requestAccessibilityPermission: "computer-use:request-accessibility",
   requestScreenRecordingPermission: "computer-use:request-screen-recording",
   setKeepAwakeEnabled: "computer-use:set-keep-awake-enabled",

--- a/turbo/apps/desktop/src/desktop-bridge.ts
+++ b/turbo/apps/desktop/src/desktop-bridge.ts
@@ -42,7 +42,10 @@ export interface DesktopAuthApi {
 export interface DesktopComputerUseApi {
   readonly getState: () => Promise<DesktopComputerUseState>;
   readonly refreshPermissions: () => Promise<DesktopComputerUseState>;
-  readonly start: () => Promise<DesktopComputerUseState>;
+  readonly start: (options?: {
+    readonly userInitiated?: boolean;
+  }) => Promise<DesktopComputerUseState>;
+  readonly stop: () => Promise<DesktopComputerUseState>;
   readonly requestAccessibilityPermission: () => Promise<DesktopComputerUseState>;
   readonly requestScreenRecordingPermission: () => Promise<DesktopComputerUseState>;
   readonly setKeepAwakeEnabled: (

--- a/turbo/apps/desktop/src/desktop-tray-menu.test.ts
+++ b/turbo/apps/desktop/src/desktop-tray-menu.test.ts
@@ -83,6 +83,7 @@ function trayActions(
   return {
     showMainWindow: vi.fn(),
     startComputerUse: vi.fn(),
+    stopComputerUse: vi.fn(),
     refreshStatus: vi.fn(),
     openSignIn: vi.fn(),
     switchWorkspace: vi.fn(),
@@ -193,8 +194,29 @@ describe("desktop tray menu", () => {
     const startItem = findItem(computerUseMenu, "Start Computer Use");
 
     expect(startItem.enabled).toBe(true);
+    expect(findItem(computerUseMenu, "Stop Computer Use").enabled).toBe(false);
     click(startItem);
     expect(startComputerUse).toHaveBeenCalledOnce();
+  });
+
+  it("enables stopping Computer Use while online", () => {
+    const stopComputerUse = vi.fn();
+    const menu = buildDesktopTrayMenuItems(
+      {
+        computerUse: computerUseState({ status: "online" }),
+        auth: signedInAuth,
+        authError: null,
+      },
+      trayActions({ stopComputerUse }),
+    );
+
+    const computerUseMenu = submenu(findItem(menu, "Computer Use: Online"));
+    const stopItem = findItem(computerUseMenu, "Stop Computer Use");
+
+    expect(findItem(computerUseMenu, "Start Computer Use").enabled).toBe(false);
+    expect(stopItem.enabled).toBe(true);
+    click(stopItem);
+    expect(stopComputerUse).toHaveBeenCalledOnce();
   });
 
   it("shows sign-in next to disabled start when Computer Use needs auth", () => {

--- a/turbo/apps/desktop/src/desktop-tray-menu.ts
+++ b/turbo/apps/desktop/src/desktop-tray-menu.ts
@@ -37,6 +37,7 @@ export interface DesktopTrayMenuItem {
 export interface DesktopTrayMenuActions {
   readonly showMainWindow: () => void;
   readonly startComputerUse: () => void;
+  readonly stopComputerUse: () => void;
   readonly refreshStatus: () => void;
   readonly openSignIn: () => void;
   readonly switchWorkspace: () => void;
@@ -105,6 +106,12 @@ function canStartComputerUse(state: DesktopTrayMenuState): boolean {
   );
 }
 
+function canStopComputerUse(state: DesktopTrayMenuState): boolean {
+  return (
+    state.computerUse.supported && state.computerUse.host.status === "online"
+  );
+}
+
 function authActionForComputerUse(
   state: DesktopTrayMenuState,
   actions: DesktopTrayMenuActions,
@@ -158,6 +165,11 @@ function buildComputerUseSubmenu(
       label: "Start Computer Use",
       enabled: canStartComputerUse(state),
       click: actions.startComputerUse,
+    },
+    {
+      label: "Stop Computer Use",
+      enabled: canStopComputerUse(state),
+      click: actions.stopComputerUse,
     },
   ];
   if (authAction) {

--- a/turbo/apps/desktop/src/desktop-tray.ts
+++ b/turbo/apps/desktop/src/desktop-tray.ts
@@ -20,6 +20,7 @@ interface DesktopTrayControllerOptions {
   readonly getAuthState: () => Promise<DesktopAuthState>;
   readonly showMainWindow: () => Promise<void>;
   readonly startComputerUse: () => Promise<void>;
+  readonly stopComputerUse: () => Promise<void>;
   readonly refreshStatus: () => Promise<void>;
   readonly openSignIn: () => void;
   readonly switchWorkspace: () => Promise<void>;
@@ -155,6 +156,9 @@ export class DesktopTrayController {
       }),
       startComputerUse: this.runAction("start Computer Use", () => {
         return this.options.startComputerUse();
+      }),
+      stopComputerUse: this.runAction("stop Computer Use", () => {
+        return this.options.stopComputerUse();
       }),
       refreshStatus: this.runAction(
         "refresh status",

--- a/turbo/apps/desktop/src/main.ts
+++ b/turbo/apps/desktop/src/main.ts
@@ -113,6 +113,7 @@ const MAC_SCREEN_RECORDING_SETTINGS_URL =
 let mainWindow: BrowserWindow | null = null;
 let appIsQuitting = false;
 let computerUseQuitStopStarted = false;
+let computerUseManualStopRequested = false;
 let computerUseNativeBackendDisposed = false;
 let desktopTray: DesktopTrayController | null = null;
 let keepAwakeController: DesktopKeepAwakeController | null = null;
@@ -308,7 +309,14 @@ function releaseKeepAwake(): void {
   keepAwakeController?.release();
 }
 
-async function startComputerUseRuntime(): Promise<DesktopComputerUseState> {
+async function startComputerUseRuntime(
+  options: { readonly userInitiated?: boolean } = {},
+): Promise<DesktopComputerUseState> {
+  if (computerUseManualStopRequested && options.userInitiated !== true) {
+    return getComputerUseBridgeState();
+  }
+  computerUseManualStopRequested = false;
+
   const permissions = await refreshComputerUsePermissionState();
   let startupGate: ComputerUseStartupGate = { status: "missing_permissions" };
   if (hasRequiredComputerUsePermissions(permissions)) {
@@ -356,6 +364,13 @@ async function startComputerUseRuntime(): Promise<DesktopComputerUseState> {
   return getComputerUseBridgeState();
 }
 
+async function stopComputerUseRuntime(): Promise<DesktopComputerUseState> {
+  computerUseManualStopRequested = true;
+  await computerUseRuntime?.stop();
+  notifyComputerUseChanged();
+  return getComputerUseBridgeState();
+}
+
 async function requestComputerUsePermission(): Promise<DesktopComputerUseState> {
   await requestComputerUseAccessibilityPermission();
   notifyComputerUseChanged();
@@ -383,6 +398,7 @@ function installComputerUse(): void {
       getState: getComputerUseBridgeState,
       refreshPermissions: refreshComputerUsePermissions,
       start: startComputerUseRuntime,
+      stop: stopComputerUseRuntime,
       requestAccessibilityPermission: requestComputerUsePermission,
       requestScreenRecordingPermission: requestComputerUseScreenRecording,
       setKeepAwakeEnabled,
@@ -481,7 +497,10 @@ function installTray(): void {
       await createMainWindow();
     },
     startComputerUse: async () => {
-      await startComputerUseRuntime();
+      await startComputerUseRuntime({ userInitiated: true });
+    },
+    stopComputerUse: async () => {
+      await stopComputerUseRuntime();
     },
     refreshStatus: async () => {
       await refreshComputerUsePermissions();
@@ -856,7 +875,7 @@ async function maybeStartComputerUseAfterAuth(): Promise<void> {
   const permissions = await refreshComputerUsePermissionState();
   notifyComputerUseChanged();
   if (hasRequiredComputerUsePermissions(permissions)) {
-    await startComputerUseRuntime();
+    await startComputerUseRuntime({ userInitiated: true });
   }
 }
 

--- a/turbo/apps/desktop/src/preload.ts
+++ b/turbo/apps/desktop/src/preload.ts
@@ -38,8 +38,11 @@ const desktopComputerUseApi: DesktopComputerUseApi = {
   refreshPermissions(): Promise<DesktopComputerUseState> {
     return ipcRenderer.invoke(COMPUTER_USE_CHANNELS.refreshPermissions);
   },
-  start(): Promise<DesktopComputerUseState> {
-    return ipcRenderer.invoke(COMPUTER_USE_CHANNELS.start);
+  start(options): Promise<DesktopComputerUseState> {
+    return ipcRenderer.invoke(COMPUTER_USE_CHANNELS.start, options);
+  },
+  stop(): Promise<DesktopComputerUseState> {
+    return ipcRenderer.invoke(COMPUTER_USE_CHANNELS.stop);
   },
   requestAccessibilityPermission(): Promise<DesktopComputerUseState> {
     return ipcRenderer.invoke(

--- a/turbo/apps/desktop/src/renderer/App.tsx
+++ b/turbo/apps/desktop/src/renderer/App.tsx
@@ -13,6 +13,7 @@ import {
   IconMaximize,
   IconPhoto,
   IconPlayerPlay,
+  IconPlayerStop,
   IconRefresh,
   IconShieldCheck,
   IconUserCircle,
@@ -40,6 +41,7 @@ import {
   signOutDesktop$,
   setupComputerUseBridge$,
   startComputerUse$,
+  stopComputerUse$,
 } from "./computer-use-state";
 
 type HostStatus = DesktopComputerUseState["host"]["status"];
@@ -461,6 +463,7 @@ function RuntimePanel({
   readonly state: DesktopComputerUseState;
 }) {
   const [startLoadable, start] = useLoadableSet(startComputerUse$);
+  const [stopLoadable, stop] = useLoadableSet(stopComputerUse$);
   const [refreshLoadable, refresh] = useLoadableSet(refreshComputerUse$);
   const [signInLoadable, signIn] = useLoadableSet(openDesktopSignIn$);
   const [keepAwakeLoadable, setKeepAwakeEnabled] =
@@ -484,6 +487,8 @@ function RuntimePanel({
     state.host.status === "connecting" ||
     state.host.status === "online" ||
     startLoadable.state === "loading";
+  const stopDisabled =
+    state.host.status !== "online" || stopLoadable.state === "loading";
 
   return (
     <Panel title="Runtime" icon={<IconActivityHeartbeat size={18} />}>
@@ -533,6 +538,16 @@ function RuntimePanel({
           disabled={startDisabled}
         >
           Start
+        </IconButton>
+        <IconButton
+          tone="danger"
+          icon={<IconPlayerStop size={15} />}
+          onClick={() => {
+            void stop();
+          }}
+          disabled={stopDisabled}
+        >
+          Stop
         </IconButton>
         <IconButton
           icon={<IconRefresh size={15} />}

--- a/turbo/apps/desktop/src/renderer/computer-use-state.test.ts
+++ b/turbo/apps/desktop/src/renderer/computer-use-state.test.ts
@@ -98,6 +98,9 @@ describe("shouldAutoStartComputerUse", () => {
         signedInAuth,
       ),
     ).toBe(false);
+    expect(
+      shouldAutoStartComputerUse(computerUseState(), signedInAuth, true),
+    ).toBe(false);
   });
 
   it("does not restart active or terminal runtime states", () => {

--- a/turbo/apps/desktop/src/renderer/computer-use-state.ts
+++ b/turbo/apps/desktop/src/renderer/computer-use-state.ts
@@ -13,6 +13,7 @@ import {
 const reloadComputerUseState$ = state(0);
 const reloadDesktopAuthState$ = state(0);
 const autoStartAttempted$ = state(false);
+const autoStartSuppressed$ = state(false);
 
 function desktopComputerUseApi(): DesktopComputerUseApi {
   const api = window.vm0DesktopComputerUse;
@@ -41,8 +42,10 @@ export function hasDesktopAuthBridge(): boolean {
 export function shouldAutoStartComputerUse(
   stateValue: DesktopComputerUseState,
   authState: DesktopAuthState | null,
+  autoStartSuppressed = false,
 ): boolean {
   return (
+    !autoStartSuppressed &&
     stateValue.supported &&
     hasReadyDesktopAuth(authState) &&
     hasRequiredComputerUsePermissions(stateValue.permissions) &&
@@ -87,6 +90,7 @@ export const setupComputerUseBridge$ = command(
     });
     const unsubscribeAuth = window.vm0DesktopAuth?.subscribe(() => {
       set(autoStartAttempted$, false);
+      set(autoStartSuppressed$, false);
       set(refreshDesktopAuth$);
       set(reloadComputerUse$);
     });
@@ -105,7 +109,14 @@ export const setupComputerUseBridge$ = command(
 );
 
 export const startComputerUse$ = command(async ({ set }) => {
-  await desktopComputerUseApi().start();
+  set(autoStartSuppressed$, false);
+  await desktopComputerUseApi().start({ userInitiated: true });
+  set(reloadComputerUse$);
+});
+
+export const stopComputerUse$ = command(async ({ set }) => {
+  set(autoStartSuppressed$, true);
+  await desktopComputerUseApi().stop();
   set(reloadComputerUse$);
 });
 
@@ -117,12 +128,16 @@ export const maybeAutoStartComputerUse$ = command(
   ) => {
     if (
       get(autoStartAttempted$) ||
-      !shouldAutoStartComputerUse(stateValue, authState)
+      !shouldAutoStartComputerUse(
+        stateValue,
+        authState,
+        get(autoStartSuppressed$),
+      )
     ) {
       return;
     }
     set(autoStartAttempted$, true);
-    await desktopComputerUseApi().start();
+    await desktopComputerUseApi().start({ userInitiated: false });
     set(reloadComputerUse$);
   },
 );
@@ -159,6 +174,7 @@ export const openDesktopSignIn$ = command(async () => {
 export const openDesktopOrgSelection$ = command(async ({ set }) => {
   await desktopAuthApi().openOrgSelection();
   set(autoStartAttempted$, false);
+  set(autoStartSuppressed$, false);
   set(refreshDesktopAuth$);
   set(reloadComputerUse$);
 });


### PR DESCRIPTION
## Summary
- add a Desktop Computer Use stop IPC path from renderer/preload through the Electron main process
- add Stop controls in the Runtime panel and tray menu
- prevent automatic restart immediately after a user-initiated stop while keeping manual start and auth-completion restart available

## Tests
- pnpm -F @vm0/desktop exec vitest run src/desktop-tray-menu.test.ts src/renderer/computer-use-state.test.ts
- pnpm -F @vm0/desktop check-types
- pnpm -F @vm0/desktop lint
- pnpm -F @vm0/desktop test
