### PR TITLE
feat: redesign desktop main window setup flow

### DIFF
--- a/turbo/apps/desktop/src/renderer/App.tsx
+++ b/turbo/apps/desktop/src/renderer/App.tsx
@@ -22,7 +22,10 @@ import { useLastLoadable, useSet } from "ccstate-react";
 import { useLoadableSet } from "ccstate-react/experimental";
 import type { DesktopAuthState } from "../desktop-bridge";
 import { hasReadyDesktopAuth } from "../computer-use-startup-gate";
-import type { DesktopComputerUseState } from "../computer-use-types";
+import {
+  hasRequiredComputerUsePermissions,
+  type DesktopComputerUseState,
+} from "../computer-use-types";
 import {
   computerUseData$,
   desktopAuthData$,
@@ -356,9 +359,199 @@ function KeyValueList({
   );
 }
 
-function PermissionsPanel({
+function StepIndex({
+  step,
+  tone = "active",
+}: {
+  readonly step: number;
+  readonly tone?: "active" | "pending" | "ready";
+}) {
+  return (
+    <span className={`step-index step-index-${tone}`}>
+      {tone === "ready" ? <IconCheck size={14} /> : step}
+    </span>
+  );
+}
+
+function AuthStepCard({
+  authLoading,
+  authState,
+}: {
+  readonly authLoading: boolean;
+  readonly authState: DesktopAuthState | null;
+}) {
+  const [signInLoadable, signIn] = useLoadableSet(openDesktopSignIn$);
+  const [orgSelectionLoadable, selectOrg] = useLoadableSet(
+    openDesktopOrgSelection$,
+  );
+  const [signOutLoadable, signOut] = useLoadableSet(signOutDesktop$);
+  const signedInAuth = authState?.status === "signed_in" ? authState : null;
+  const activeOrganization = signedInAuth?.organization ?? null;
+  const signingIn =
+    authState?.status === "signing_in" || signInLoadable.state === "loading";
+  const authBridgeAvailable = hasDesktopAuthBridge();
+
+  if (signedInAuth && activeOrganization) {
+    return (
+      <section className="step-card step-card-compact">
+        <div className="compact-step-main">
+          <StepIndex step={1} tone="ready" />
+          <IconUserCircle size={17} />
+          <span className="compact-step-copy">
+            <strong>Signed in</strong>
+            <span>
+              {signedInAuth.user.email} - {activeOrganization.name}
+            </span>
+          </span>
+        </div>
+        <div className="row-actions">
+          <IconButton
+            icon={<IconBuilding size={15} />}
+            onClick={() => {
+              void selectOrg();
+            }}
+            disabled={orgSelectionLoadable.state === "loading"}
+          >
+            Switch workspace
+          </IconButton>
+          <IconButton
+            tone="danger"
+            icon={<IconLogout size={15} />}
+            onClick={() => {
+              void signOut();
+            }}
+            disabled={signOutLoadable.state === "loading"}
+          >
+            Sign out
+          </IconButton>
+        </div>
+      </section>
+    );
+  }
+
+  const title = authLoading
+    ? "Checking sign-in"
+    : signedInAuth
+      ? "Select a workspace"
+      : signingIn
+        ? "Finish signing in"
+        : "Sign in to Zero";
+  const description = signedInAuth
+    ? "Choose the workspace that should receive this Mac as a Computer Use runtime."
+    : "Connect this Mac to a Zero account before Computer Use can register a runtime.";
+
+  return (
+    <section className="step-card step-card-expanded">
+      <div className="step-card-main">
+        <div className="step-kicker">
+          <StepIndex step={1} />
+          <span>Account</span>
+        </div>
+        <div className="step-heading">
+          <h2>{title}</h2>
+          <p>{description}</p>
+        </div>
+        <div className="step-actions">
+          {signedInAuth ? (
+            <>
+              <IconButton
+                tone="primary"
+                icon={<IconBuilding size={15} />}
+                onClick={() => {
+                  void selectOrg();
+                }}
+                disabled={orgSelectionLoadable.state === "loading"}
+              >
+                Select workspace
+              </IconButton>
+              <IconButton
+                tone="danger"
+                icon={<IconLogout size={15} />}
+                onClick={() => {
+                  void signOut();
+                }}
+                disabled={signOutLoadable.state === "loading"}
+              >
+                Sign out
+              </IconButton>
+            </>
+          ) : (
+            <IconButton
+              tone="primary"
+              icon={<IconExternalLink size={15} />}
+              onClick={() => {
+                void signIn();
+              }}
+              disabled={authLoading || signingIn || !authBridgeAvailable}
+            >
+              {signingIn ? "Signing in..." : "Sign in"}
+            </IconButton>
+          )}
+        </div>
+      </div>
+      <aside className="step-guidance">
+        <strong>Next</strong>
+        <span>
+          After the account and workspace are ready, Zero will ask for the macOS
+          permissions needed by Computer Use.
+        </span>
+      </aside>
+    </section>
+  );
+}
+
+function PermissionSetupRow({
+  granted,
+  meta,
+  onOpenSettings,
+  onRequest,
+  requestLoading,
+  title,
+}: {
+  readonly granted: boolean;
+  readonly meta: string;
+  readonly onOpenSettings: () => void;
+  readonly onRequest: () => void;
+  readonly requestLoading: boolean;
+  readonly title: string;
+}) {
+  return (
+    <div className="permission-row">
+      <div>
+        <div className="row-title">{title}</div>
+        <div className="row-meta">{granted ? "Granted" : meta}</div>
+      </div>
+      <div className="row-actions">
+        {granted ? (
+          <span className="check-pill">
+            <IconCheck size={14} />
+            Ready
+          </span>
+        ) : (
+          <IconButton
+            icon={<IconShieldCheck size={15} />}
+            onClick={onRequest}
+            disabled={requestLoading}
+          >
+            Request
+          </IconButton>
+        )}
+        <IconButton
+          icon={<IconExternalLink size={15} />}
+          onClick={onOpenSettings}
+        >
+          Settings
+        </IconButton>
+      </div>
+    </div>
+  );
+}
+
+function PermissionsStepCard({
+  authReady,
   state,
 }: {
+  readonly authReady: boolean;
   readonly state: DesktopComputerUseState;
 }) {
   const [requestLoadable, requestPermission] = useLoadableSet(
@@ -368,119 +561,128 @@ function PermissionsPanel({
     useLoadableSet(requestScreenRecordingPermission$);
   const [, openAccessibility] = useLoadableSet(openAccessibilitySettings$);
   const [, openScreenRecording] = useLoadableSet(openScreenRecordingSettings$);
+  const [refreshLoadable, refresh] = useLoadableSet(refreshComputerUse$);
   const accessibilityGranted = state.permissions.accessibility;
   const screenRecordingGranted = state.permissions.screenRecording;
+  const permissionsReady = hasRequiredComputerUsePermissions(state.permissions);
+
+  if (!authReady) {
+    return (
+      <section className="step-card step-card-locked">
+        <div className="step-card-main">
+          <div className="step-kicker">
+            <StepIndex step={2} tone="pending" />
+            <span>Permissions</span>
+          </div>
+          <div className="step-heading">
+            <h2>Allow Computer Use permissions</h2>
+            <p>Sign in and select a workspace first.</p>
+          </div>
+        </div>
+      </section>
+    );
+  }
+
+  if (permissionsReady) {
+    return (
+      <section className="step-card step-card-compact">
+        <div className="compact-step-main">
+          <StepIndex step={2} tone="ready" />
+          <IconShieldCheck size={17} />
+          <span className="compact-step-copy">
+            <strong>Permissions ready</strong>
+            <span>Accessibility and Screen Recording granted</span>
+          </span>
+        </div>
+        <div className="row-actions">
+          <IconButton
+            icon={<IconExternalLink size={15} />}
+            onClick={() => {
+              void openAccessibility();
+            }}
+          >
+            Accessibility Settings
+          </IconButton>
+          <IconButton
+            icon={<IconExternalLink size={15} />}
+            onClick={() => {
+              void openScreenRecording();
+            }}
+          >
+            Screen Recording Settings
+          </IconButton>
+          <IconButton
+            icon={<IconRefresh size={15} />}
+            onClick={() => {
+              void refresh();
+            }}
+            disabled={refreshLoadable.state === "loading"}
+          >
+            Refresh
+          </IconButton>
+        </div>
+      </section>
+    );
+  }
 
   return (
-    <Panel title="Permissions" icon={<IconShieldCheck size={18} />}>
-      <div className="permission-list">
-        <div className="permission-row">
-          <div>
-            <div className="row-title">Accessibility</div>
-            <div className="row-meta">
-              {accessibilityGranted ? "Granted" : "Required for UI control"}
-            </div>
-          </div>
-          <div className="row-actions">
-            {accessibilityGranted ? (
-              <span className="check-pill">
-                <IconCheck size={14} />
-                Ready
-              </span>
-            ) : (
-              <>
-                <IconButton
-                  icon={<IconShieldCheck size={15} />}
-                  onClick={() => {
-                    void requestPermission();
-                  }}
-                  disabled={requestLoadable.state === "loading"}
-                >
-                  Request
-                </IconButton>
-                <IconButton
-                  icon={<IconExternalLink size={15} />}
-                  onClick={() => {
-                    void openAccessibility();
-                  }}
-                >
-                  Settings
-                </IconButton>
-              </>
-            )}
-          </div>
+    <section className="step-card step-card-expanded">
+      <div className="step-card-main">
+        <div className="step-kicker">
+          <StepIndex step={2} />
+          <span>Permissions</span>
         </div>
-        <div className="permission-row">
-          <div>
-            <div className="row-title">Screen Recording</div>
-            <div className="row-meta">
-              {screenRecordingGranted ? "Granted" : "Required for screenshots"}
-            </div>
-          </div>
-          <div className="row-actions">
-            {screenRecordingGranted ? (
-              <span className="check-pill">
-                <IconCheck size={14} />
-                Ready
-              </span>
-            ) : (
-              <>
-                <IconButton
-                  icon={<IconShieldCheck size={15} />}
-                  onClick={() => {
-                    void requestScreenRecording();
-                  }}
-                  disabled={screenRecordingRequestLoadable.state === "loading"}
-                >
-                  Request
-                </IconButton>
-                <IconButton
-                  icon={<IconExternalLink size={15} />}
-                  onClick={() => {
-                    void openScreenRecording();
-                  }}
-                >
-                  Settings
-                </IconButton>
-              </>
-            )}
-          </div>
+        <div className="step-heading">
+          <h2>Allow Computer Use permissions</h2>
+          <p>
+            Zero needs macOS permission to inspect the screen and control UI
+            elements on this Mac.
+          </p>
+        </div>
+        <div className="permission-list">
+          <PermissionSetupRow
+            title="Accessibility"
+            meta="Required for clicking, typing, and reading UI structure"
+            granted={accessibilityGranted}
+            requestLoading={requestLoadable.state === "loading"}
+            onRequest={() => {
+              void requestPermission();
+            }}
+            onOpenSettings={() => {
+              void openAccessibility();
+            }}
+          />
+          <PermissionSetupRow
+            title="Screen Recording"
+            meta="Required for screenshots and visual context"
+            granted={screenRecordingGranted}
+            requestLoading={screenRecordingRequestLoadable.state === "loading"}
+            onRequest={() => {
+              void requestScreenRecording();
+            }}
+            onOpenSettings={() => {
+              void openScreenRecording();
+            }}
+          />
         </div>
       </div>
-    </Panel>
+      <aside className="step-guidance">
+        <strong>Runtime is hidden</strong>
+        <span>
+          Runtime status and command history appear after both permissions are
+          ready.
+        </span>
+      </aside>
+    </section>
   );
 }
 
-function RuntimePanel({
-  authLoading,
-  authState,
-  state,
-}: {
-  readonly authLoading: boolean;
-  readonly authState: DesktopAuthState | null;
-  readonly state: DesktopComputerUseState;
-}) {
+function RuntimePanel({ state }: { readonly state: DesktopComputerUseState }) {
   const [startLoadable, start] = useLoadableSet(startComputerUse$);
   const [refreshLoadable, refresh] = useLoadableSet(refreshComputerUse$);
-  const [signInLoadable, signIn] = useLoadableSet(openDesktopSignIn$);
   const [keepAwakeLoadable, setKeepAwakeEnabled] =
     useLoadableSet(setKeepAwakeEnabled$);
-  const [orgSelectionLoadable, selectOrg] = useLoadableSet(
-    openDesktopOrgSelection$,
-  );
-  const missingPermissions =
-    !state.permissions.accessibility || !state.permissions.screenRecording;
-  const signedOut =
-    !authLoading && (!authState || authState.status === "signed_out");
-  const signingIn = authState?.status === "signing_in";
-  const needsOrganization =
-    !authLoading &&
-    authState?.status === "signed_in" &&
-    authState.organization === null;
   const startDisabled =
-    authLoading ||
-    !hasReadyDesktopAuth(authState) ||
-    missingPermissions ||
     state.host.status === "connecting" ||
     state.host.status === "online" ||
     startLoadable.state === "loading";
@@ -543,30 +745,6 @@ function RuntimePanel({
         >
           Refresh
         </IconButton>
-        {(signedOut || state.host.status === "unauthenticated") &&
-          hasDesktopAuthBridge() && (
-            <IconButton
-              icon={<IconExternalLink size={15} />}
-              onClick={() => {
-                void signIn();
-              }}
-              disabled={signingIn || signInLoadable.state === "loading"}
-            >
-              {signingIn ? "Signing in..." : "Sign in"}
-            </IconButton>
-          )}
-        {(needsOrganization || state.host.status === "needs_organization") &&
-          hasDesktopAuthBridge() && (
-            <IconButton
-              icon={<IconBuilding size={15} />}
-              onClick={() => {
-                void selectOrg();
-              }}
-              disabled={orgSelectionLoadable.state === "loading"}
-            >
-              Select workspace
-            </IconButton>
-          )}
       </div>
     </Panel>
   );
@@ -921,6 +1099,9 @@ function ComputerUseContent({
   readonly authState: DesktopAuthState | null;
   readonly state: DesktopComputerUseState;
 }) {
+  const authReady = hasReadyDesktopAuth(authState);
+  const permissionsReady = hasRequiredComputerUsePermissions(state.permissions);
+
   return (
     <>
       <AutoStartRuntime authState={authState} state={state} />
@@ -928,13 +1109,14 @@ function ComputerUseContent({
         <UnsupportedPanel platform={state.platform} />
       ) : (
         <>
-          <PermissionsPanel state={state} />
-          <RuntimePanel
-            authLoading={authLoading}
-            authState={authState}
-            state={state}
-          />
-          <CommandLogPanel state={state} />
+          <AuthStepCard authLoading={authLoading} authState={authState} />
+          <PermissionsStepCard authReady={authReady} state={state} />
+          {authReady && permissionsReady && (
+            <>
+              <RuntimePanel state={state} />
+              <CommandLogPanel state={state} />
+            </>
+          )}
         </>
       )}
     </>
@@ -987,121 +1169,11 @@ function ComputerUsePage() {
   );
 }
 
-function AccountMenu({
-  authState,
-  loading,
-  onSelectOrg,
-  onSignIn,
-  onSignOut,
-  orgSelectionLoading,
-  signInLoading,
-  signOutLoading,
-}: {
-  readonly authState: DesktopAuthState | null;
-  readonly loading: boolean;
-  readonly onSelectOrg: () => void;
-  readonly onSignIn: () => void;
-  readonly onSignOut: () => void;
-  readonly orgSelectionLoading: boolean;
-  readonly signInLoading: boolean;
-  readonly signOutLoading: boolean;
-}) {
-  if (
-    !authState ||
-    authState.status === "signed_out" ||
-    authState.status === "signing_in"
-  ) {
-    const signingIn =
-      authState?.status === "signing_in" || signInLoading === true;
-    return (
-      <IconButton
-        icon={<IconExternalLink size={15} />}
-        onClick={onSignIn}
-        disabled={loading || signingIn}
-      >
-        {signingIn ? "Signing in..." : loading ? "Checking" : "Sign in"}
-      </IconButton>
-    );
-  }
-
-  const workspaceLabel = authState.organization?.name ?? "Select workspace";
-
-  return (
-    <details className="account-menu">
-      <summary className="account-summary">
-        <IconUserCircle size={17} />
-        <span className="account-copy">
-          <span className="account-email">{authState.user.email}</span>
-        </span>
-        <IconChevronDown size={14} />
-      </summary>
-      <div className="account-popover">
-        <div className="account-popover-heading">
-          <span>Signed in as</span>
-          <strong>{authState.user.email}</strong>
-        </div>
-        <div className="account-popover-heading">
-          <span>Workspace</span>
-          <strong>{workspaceLabel}</strong>
-        </div>
-        <button
-          type="button"
-          className="account-menu-item"
-          onClick={onSelectOrg}
-          disabled={orgSelectionLoading}
-        >
-          <IconBuilding size={15} />
-          <span>
-            {authState.organization ? "Switch workspace" : "Select workspace"}
-          </span>
-        </button>
-        <button
-          type="button"
-          className="account-menu-item"
-          onClick={onSignOut}
-          disabled={signOutLoading}
-        >
-          <IconLogout size={15} />
-          <span>Sign out</span>
-        </button>
-      </div>
-    </details>
-  );
-}
-
 function Header() {
-  const authLoadable = useLastLoadable(desktopAuthData$);
-  const [signInLoadable, signIn] = useLoadableSet(openDesktopSignIn$);
-  const [orgSelectionLoadable, selectOrg] = useLoadableSet(
-    openDesktopOrgSelection$,
-  );
-  const [signOutLoadable, signOut] = useLoadableSet(signOutDesktop$);
-  const authState = authLoadable.state === "hasData" ? authLoadable.data : null;
-  const authLoading = authLoadable.state === "loading";
   return (
     <header className="app-header">
       <div className="titlebar-title">
         <h1>Zero Computer Use</h1>
-      </div>
-      <div className="header-actions">
-        {hasDesktopAuthBridge() && (
-          <AccountMenu
-            authState={authState}
-            loading={authLoading}
-            onSignIn={() => {
-              void signIn();
-            }}
-            onSignOut={() => {
-              void signOut();
-            }}
-            onSelectOrg={() => {
-              void selectOrg();
-            }}
-            orgSelectionLoading={orgSelectionLoadable.state === "loading"}
-            signInLoading={signInLoadable.state === "loading"}
-            signOutLoading={signOutLoadable.state === "loading"}
-          />
-        )}
       </div>
     </header>
   );

--- a/turbo/apps/desktop/src/renderer/styles.css
+++ b/turbo/apps/desktop/src/renderer/styles.css
@@ -63,7 +63,7 @@ button {
   padding: 0 16px 0 var(--desktop-titlebar-left-inset);
   display: flex;
   align-items: center;
-  justify-content: space-between;
+  justify-content: flex-start;
   gap: 12px;
   border-bottom: 1px solid rgba(30, 38, 52, 0.1);
   background: rgba(248, 249, 251, 0.82);
@@ -88,7 +88,6 @@ button {
   text-overflow: ellipsis;
 }
 
-.header-actions,
 .panel-actions,
 .row-actions {
   -webkit-app-region: no-drag;
@@ -96,129 +95,6 @@ button {
   align-items: center;
   gap: 8px;
   flex-wrap: wrap;
-}
-
-.app-header .header-actions {
-  flex-wrap: nowrap;
-}
-
-.app-header .button {
-  min-height: 28px;
-  padding: 0 9px;
-  border-radius: 6px;
-  font-size: 12px;
-  line-height: 1;
-}
-
-.app-header .button span {
-  white-space: nowrap;
-}
-
-.account-menu {
-  -webkit-app-region: no-drag;
-  position: relative;
-}
-
-.account-summary {
-  min-height: 30px;
-  min-width: 0;
-  max-width: min(360px, calc(100vw - 160px));
-  border: 1px solid rgba(30, 38, 52, 0.14);
-  border-radius: 6px;
-  padding: 0 9px;
-  display: flex;
-  align-items: center;
-  gap: 7px;
-  color: #2e3645;
-  background: #ffffff;
-  cursor: pointer;
-  list-style: none;
-}
-
-.account-summary::-webkit-details-marker {
-  display: none;
-}
-
-.account-summary:hover {
-  border-color: rgba(30, 38, 52, 0.25);
-  background: #f4f6f8;
-}
-
-.account-copy {
-  min-width: 0;
-  display: block;
-}
-
-.account-email {
-  display: block;
-  overflow: hidden;
-  text-overflow: ellipsis;
-  white-space: nowrap;
-  color: #202631;
-  font-size: 12px;
-  line-height: 1.2;
-  font-weight: 650;
-}
-
-.account-popover {
-  position: absolute;
-  top: calc(100% + 8px);
-  right: 0;
-  z-index: 30;
-  width: 286px;
-  border: 1px solid rgba(30, 38, 52, 0.12);
-  border-radius: 8px;
-  padding: 8px;
-  display: grid;
-  gap: 6px;
-  background: #ffffff;
-  box-shadow: 0 18px 45px rgba(17, 24, 39, 0.16);
-}
-
-.account-popover-heading {
-  min-width: 0;
-  padding: 6px 7px;
-  display: grid;
-  gap: 2px;
-}
-
-.account-popover-heading span,
-.account-popover-heading small {
-  color: #667085;
-  font-size: 11px;
-  line-height: 1.25;
-}
-
-.account-popover-heading strong {
-  min-width: 0;
-  color: #202631;
-  font-size: 12px;
-  line-height: 1.3;
-  font-weight: 650;
-  overflow-wrap: anywhere;
-}
-
-.account-menu-item {
-  min-height: 34px;
-  border: 0;
-  border-radius: 6px;
-  padding: 0 7px;
-  display: flex;
-  align-items: center;
-  gap: 8px;
-  color: #2e3645;
-  background: transparent;
-  cursor: pointer;
-  text-align: left;
-}
-
-.account-menu-item:hover:not(:disabled) {
-  background: #f4f6f8;
-}
-
-.account-menu-item:disabled {
-  cursor: not-allowed;
-  opacity: 0.55;
 }
 
 .content {
@@ -244,6 +120,158 @@ button {
   border: 1px solid rgba(30, 38, 52, 0.1);
   background: rgba(255, 255, 255, 0.86);
   box-shadow: 0 12px 34px rgba(17, 24, 39, 0.07);
+}
+
+.step-card {
+  border: 1px solid rgba(30, 38, 52, 0.1);
+  border-radius: 8px;
+  display: grid;
+  gap: 14px;
+  background: rgba(255, 255, 255, 0.9);
+  box-shadow: 0 12px 34px rgba(17, 24, 39, 0.07);
+}
+
+.step-card-expanded {
+  min-height: 224px;
+  padding: 18px;
+  grid-template-columns: minmax(0, 1fr) minmax(260px, 340px);
+  align-items: stretch;
+}
+
+.step-card-compact {
+  min-height: 58px;
+  padding: 9px 12px;
+  grid-template-columns: minmax(0, 1fr) auto;
+  align-items: center;
+}
+
+.step-card-locked {
+  min-height: 128px;
+  padding: 16px;
+  color: #667085;
+  background: rgba(255, 255, 255, 0.64);
+  box-shadow: none;
+}
+
+.step-card-main {
+  min-width: 0;
+  display: grid;
+  align-content: start;
+  gap: 12px;
+}
+
+.step-kicker {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  color: #475467;
+  font-size: 12px;
+  line-height: 1.2;
+  font-weight: 700;
+  text-transform: uppercase;
+}
+
+.step-index {
+  width: 24px;
+  height: 24px;
+  border-radius: 50%;
+  display: inline-grid;
+  place-items: center;
+  color: #ffffff;
+  background: #2563eb;
+  font-size: 12px;
+  line-height: 1;
+  font-weight: 750;
+}
+
+.step-index-ready {
+  background: #067647;
+}
+
+.step-index-pending {
+  color: #7a4a12;
+  background: #fef0c7;
+}
+
+.step-heading {
+  display: grid;
+  gap: 6px;
+}
+
+.step-heading h2 {
+  margin: 0;
+  color: #202631;
+  font-size: 20px;
+  line-height: 1.16;
+  font-weight: 720;
+  letter-spacing: 0;
+}
+
+.step-heading p {
+  max-width: 640px;
+  margin: 0;
+  color: #667085;
+  font-size: 14px;
+  line-height: 1.45;
+}
+
+.step-actions {
+  -webkit-app-region: no-drag;
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  flex-wrap: wrap;
+}
+
+.step-guidance {
+  border: 1px solid rgba(37, 99, 235, 0.16);
+  border-radius: 8px;
+  padding: 14px;
+  display: grid;
+  align-content: start;
+  gap: 10px;
+  background: #eff8ff;
+}
+
+.step-guidance strong {
+  color: #175cd3;
+  font-size: 13px;
+  line-height: 1.25;
+}
+
+.step-guidance span {
+  color: #475467;
+  font-size: 13px;
+  line-height: 1.4;
+}
+
+.compact-step-main {
+  min-width: 0;
+  display: flex;
+  align-items: center;
+  gap: 10px;
+}
+
+.compact-step-copy {
+  min-width: 0;
+  display: grid;
+  gap: 2px;
+}
+
+.compact-step-copy strong {
+  color: #202631;
+  font-size: 13px;
+  line-height: 1.2;
+  font-weight: 700;
+}
+
+.compact-step-copy span {
+  color: #667085;
+  font-size: 12px;
+  line-height: 1.25;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
 }
 
 .runtime-grid span {
@@ -301,6 +329,10 @@ button {
     background 120ms ease,
     border-color 120ms ease,
     color 120ms ease;
+}
+
+.button span {
+  white-space: nowrap;
 }
 
 .button:hover:not(:disabled) {
@@ -818,6 +850,23 @@ button {
 
   .content {
     padding: 14px 12px 24px;
+  }
+
+  .step-card-expanded,
+  .step-card-compact {
+    grid-template-columns: 1fr;
+  }
+
+  .step-card-expanded {
+    min-height: 0;
+  }
+
+  .compact-step-main {
+    align-items: flex-start;
+  }
+
+  .compact-step-copy span {
+    white-space: normal;
   }
 
   .runtime-grid {


### PR DESCRIPTION
## Summary
- Replace the Desktop main window with a staged account and permissions setup flow.
- Collapse completed account and permission steps into compact top cards.
- Gate Runtime and Command Log behind completed account/workspace selection and required macOS permissions.
- Remove the top-right account/status controls from the titlebar so setup actions live in the cards.

## Validation
- `pnpm -F @vm0/desktop check-types`
- `pnpm -F @vm0/desktop lint`
- `pnpm -F @vm0/desktop exec vitest run src/renderer/computer-use-state.test.ts src/computer-use-startup-gate.test.ts`
- `pnpm -F @vm0/desktop build:renderer`
- `pnpm -F @vm0/desktop test`
- `pnpm knip --workspace @vm0/desktop`
- Verified the built renderer with a local mocked Desktop bridge for signed-out, workspace selection, permission setup, and ready states.

## Notes
- `scripts/prepare.sh` installed dependencies but could not complete env sync, DB migration, or seed locally because this worktree does not have 1Password CLI or `DATABASE_URL` configured.
