### PR TITLE
fix(api): make schedule dual-write mirror best-effort

### DIFF
--- a/turbo/apps/api/src/signals/services/automations/__tests__/schedule-dual-write.test.ts
+++ b/turbo/apps/api/src/signals/services/automations/__tests__/schedule-dual-write.test.ts
@@ -1,5 +1,6 @@
 import { agentRuns } from "@vm0/db/schema/agent-run";
 import { automations, automationTriggers } from "@vm0/db/schema/automation";
+import { chatThreads } from "@vm0/db/schema/chat-thread";
 import { zeroAgentSchedules } from "@vm0/db/schema/zero-agent-schedule";
 import { createStore } from "ccstate";
 import { and, eq } from "drizzle-orm";
@@ -330,6 +331,57 @@ describe("schedule dual-write to events-first tables", () => {
     }
 
     await expect(runCountForOrg(fixture.orgId)).resolves.toBe(0);
+  });
+
+  it("deploys the schedule even when the mirror write hits a name collision", async () => {
+    // A natively-created (webhook) automation already occupies the
+    // (agent, name, org, user) slot the mirror insert will want — the
+    // idx_automations_agent_name_org_user unique index makes the mirror
+    // insert throw. Best-effort dual-write must swallow it.
+    const db = store.set(writeDb$);
+    const [thread] = await db
+      .insert(chatThreads)
+      .values({ userId: fixture.userId, agentComposeId: fixture.composeId })
+      .returning({ id: chatThreads.id });
+    expect(thread).toBeDefined();
+    if (!thread) {
+      return;
+    }
+    await db.insert(automations).values({
+      orgId: fixture.orgId,
+      userId: fixture.userId,
+      name: "collide",
+      instruction: "Native webhook automation",
+      agentId: fixture.composeId,
+      chatThreadId: thread.id,
+      interpreterKind: "webhook",
+    });
+
+    const result = await store.set(
+      deploySchedule$,
+      {
+        userId: fixture.userId,
+        orgId: fixture.orgId,
+        body: {
+          agentId: fixture.composeId,
+          name: "collide",
+          cronExpression: "0 9 * * *",
+          timezone: "UTC",
+          prompt: "Collide with native automation",
+          enabled: true,
+        },
+      },
+      context.signal,
+    );
+
+    // The schedule deploy itself succeeds; only the mirror is missing.
+    expect(result.kind).toBe("ok");
+    if (result.kind !== "ok") {
+      return;
+    }
+    const scheduleId = result.response.schedule.id;
+    await expect(loadSchedule(scheduleId)).resolves.toBeDefined();
+    await expect(readMirror(scheduleId)).resolves.toBeNull();
   });
 
   it("is a no-op delete when the schedule has no mirror", async () => {

--- a/turbo/apps/api/src/signals/services/automations/schedule-dual-write.ts
+++ b/turbo/apps/api/src/signals/services/automations/schedule-dual-write.ts
@@ -2,10 +2,23 @@ import { automations, automationTriggers } from "@vm0/db/schema/automation";
 import type { zeroAgentSchedules } from "@vm0/db/schema/zero-agent-schedule";
 import { eq } from "drizzle-orm";
 
+import { logger } from "../../../lib/log";
 import type { Db } from "../../external/db";
+import { tapError } from "../../utils";
+
+const log = logger("api:automations:schedule-dual-write");
 
 /** Interpreter key persisted for schedule-mirrored automations. */
 const TIME_INTERPRETER_KIND = "time";
+
+/**
+ * Postgres unique-constraint violation (SQLSTATE 23505). The known collision:
+ * `idx_automations_agent_name_org_user` when a schedule shares its name with a
+ * natively-created (e.g. webhook) automation on the same agent.
+ */
+function isUniqueViolation(error: unknown): boolean {
+  return error instanceof Error && "code" in error && error.code === "23505";
+}
 
 type ScheduleRow = typeof zeroAgentSchedules.$inferSelect;
 
@@ -95,7 +108,7 @@ function triggerValuesFromSchedule(
  * but NEVER creates a run (the live `executeDueSchedules$` poller remains the
  * only schedule executor; the trigger poller is dormant).
  */
-export async function syncScheduleToAutomation(
+async function syncScheduleToAutomation(
   db: Db,
   schedule: ScheduleRow,
 ): Promise<void> {
@@ -134,16 +147,57 @@ export async function syncScheduleToAutomation(
 }
 
 /**
+ * Best-effort `syncScheduleToAutomation`: the mirror is a transition aid, so a
+ * mirror-write failure must never fail the user's schedule operation — the
+ * primary `zero_agent_schedules` write has already committed by the time this
+ * runs. Failures are logged (with a `uniqueConflict` flag for the known
+ * agent+name+org+user collision with natively-created automations) and
+ * swallowed; aborts still propagate.
+ */
+export async function syncScheduleToAutomationSafely(
+  db: Db,
+  schedule: ScheduleRow,
+): Promise<void> {
+  await tapError(syncScheduleToAutomation(db, schedule), (error) => {
+    log.error("Schedule mirror sync failed; schedule operation unaffected", {
+      scheduleId: schedule.id,
+      agentId: schedule.agentId,
+      scheduleName: schedule.name,
+      uniqueConflict: isUniqueViolation(error),
+      error,
+    });
+  });
+}
+
+/**
  * Remove the events-first mirror of a schedule: delete the `automations` row
  * keyed on `sourceScheduleId` (its time trigger row is removed by the FK
  * cascade). Idempotent — a no-op when no mirror exists. Counterpart to
  * `syncScheduleToAutomation` for the schedule-delete path.
  */
-export async function deleteScheduleAutomation(
+async function deleteScheduleAutomation(
   db: Db,
   scheduleId: string,
 ): Promise<void> {
   await db
     .delete(automations)
     .where(eq(automations.sourceScheduleId, scheduleId));
+}
+
+/**
+ * Best-effort `deleteScheduleAutomation`: same contract as
+ * `syncScheduleToAutomationSafely` — a mirror-delete failure must never fail
+ * the user's schedule delete. Failures are logged and swallowed; aborts still
+ * propagate.
+ */
+export async function deleteScheduleAutomationSafely(
+  db: Db,
+  scheduleId: string,
+): Promise<void> {
+  await tapError(deleteScheduleAutomation(db, scheduleId), (error) => {
+    log.error("Schedule mirror delete failed; schedule delete unaffected", {
+      scheduleId,
+      error,
+    });
+  });
 }

--- a/turbo/apps/api/src/signals/services/zero-schedules.service.ts
+++ b/turbo/apps/api/src/signals/services/zero-schedules.service.ts
@@ -27,8 +27,8 @@ import {
   type Automation,
 } from "./automations/default-interpreter";
 import {
-  deleteScheduleAutomation,
-  syncScheduleToAutomation,
+  deleteScheduleAutomationSafely,
+  syncScheduleToAutomationSafely,
 } from "./automations/schedule-dual-write";
 import { calculateNextRun, TimeTrigger } from "./automations/time-trigger";
 import {
@@ -689,7 +689,8 @@ export const deploySchedule$ = command(
 
     // Dual-write the schedule into the events-first tables (data-sync only; no
     // run is created). Keyed on automations.sourceScheduleId for idempotency.
-    await syncScheduleToAutomation(db, schedule);
+    // Best-effort: a mirror failure never fails the deploy.
+    await syncScheduleToAutomationSafely(db, schedule);
     signal.throwIfAborted();
 
     // Notify the linked chat thread so its header schedule menu refreshes the
@@ -744,8 +745,9 @@ export const disableSchedule$ = command(
       return { kind: "not_found" };
     }
 
-    // Mirror the disabled state into the events-first tables (data-sync only).
-    await syncScheduleToAutomation(db, updated);
+    // Mirror the disabled state into the events-first tables (data-sync only,
+    // best-effort).
+    await syncScheduleToAutomationSafely(db, updated);
     signal.throwIfAborted();
 
     await publishChatThreadSchedulesChangedSafely(
@@ -791,8 +793,9 @@ export const deleteSchedule$ = command(
     }
 
     // Drop the events-first mirror of the schedule (its time trigger row is
-    // removed by the FK cascade). Idempotent — a no-op when no mirror exists.
-    await deleteScheduleAutomation(db, ownership.schedule.id);
+    // removed by the FK cascade). Idempotent — a no-op when no mirror exists;
+    // best-effort: a mirror failure never fails the delete.
+    await deleteScheduleAutomationSafely(db, ownership.schedule.id);
     signal.throwIfAborted();
 
     // Notify the linked chat thread so its header schedule menu drops the
@@ -859,8 +862,8 @@ export const enableSchedule$ = command(
     }
 
     // Mirror the enabled state + recomputed nextRunAt into the events-first
-    // tables (data-sync only; no run is created).
-    await syncScheduleToAutomation(db, updated);
+    // tables (data-sync only, best-effort; no run is created).
+    await syncScheduleToAutomationSafely(db, updated);
     signal.throwIfAborted();
 
     await publishChatThreadSchedulesChangedSafely(


### PR DESCRIPTION
## Summary

Phase 0 of the #16847 cutover plan (finding **C1** from the [status review](https://github.com/vm0-ai/vm0/issues/16847#issuecomment-4666020631)).

`syncScheduleToAutomation` / `deleteScheduleAutomation` were unguarded `await`s inside the live schedule CRUD paths (`deploySchedule$` / `disableSchedule$` / `enableSchedule$` / `deleteSchedule$`). A mirror-write failure would 5xx the user's schedule operation **after** the primary `zero_agent_schedules` write had already committed.

Concrete collision: `automations` has the unique `idx_automations_agent_name_org_user` index, so deploying a schedule that shares a name with an existing webhook automation on the same agent threw on the mirror insert and failed the deploy.

## Changes

- Guard both mirror writes with `tapError` inside `schedule-dual-write.ts`, exported as `syncScheduleToAutomationSafely` / `deleteScheduleAutomationSafely` (the repo's `*Safely` best-effort convention). The strict implementations stay private.
- Failures are logged via `api:automations:schedule-dual-write` with `scheduleId`, `agentId`, `scheduleName`, and a `uniqueConflict` flag (SQLSTATE 23505) for the known name-collision case; aborts still propagate.
- New integration test: deploying a schedule whose name collides with a natively-created automation succeeds, with no mirror created.

## Why best-effort is safe

The mirror is a transition aid only — the live poller still runs exclusively on `zero_agent_schedules`. A missing/stale mirror row is repaired by the upcoming refresh backfill (phase 1 of the cutover plan) before the poller flip; a failed user operation is not recoverable.

Part of #16847.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
