### PR TITLE
fix: restore web chat queue indicator

### DIFF
--- a/turbo/apps/api/src/signals/services/zero-chat-thread.service.ts
+++ b/turbo/apps/api/src/signals/services/zero-chat-thread.service.ts
@@ -107,6 +107,7 @@ type ChatMessageRow = {
   readonly role: string;
   readonly content: string | null;
   readonly runId: string | null;
+  readonly runEventId: string | null;
   readonly error: string | null;
   readonly runLifecycleEvent: string | null;
   readonly sequenceNumber: number | null;
@@ -212,6 +213,7 @@ const messageColumns = {
   role: chatMessages.role,
   content: chatMessages.content,
   runId: effectiveChatMessageRunId(),
+  runEventId: chatMessages.runEventId,
   error: chatMessages.error,
   runLifecycleEvent: chatMessages.runLifecycleEvent,
   sequenceNumber: chatMessages.sequenceNumber,
@@ -635,6 +637,7 @@ function toPagedMessage(
       role,
       content: row.content,
       runId: row.runId ?? undefined,
+      runEventId: row.runEventId ?? undefined,
       revokesMessageId: row.revokesMessageId ?? undefined,
       interruptsRunId: row.interruptsRunId ?? undefined,
       error: effectiveError,

--- a/turbo/apps/platform/src/signals/chat-page/__tests__/latest-run-status.test.ts
+++ b/turbo/apps/platform/src/signals/chat-page/__tests__/latest-run-status.test.ts
@@ -91,6 +91,7 @@ describe("latestRunStatus$", () => {
               role: "assistant",
               content: "Waiting in queue...",
               runId,
+              runEventId: "queue:queued",
               createdAt: "2026-04-13T00:00:01Z",
             },
           ],
@@ -127,6 +128,72 @@ describe("latestRunStatus$", () => {
     });
   });
 
+  it("does not infer queued from assistant text without the queue event id", async () => {
+    const threadId = "thread-queue-copy-only-1";
+    const runId = "run-queue-copy-only-1";
+
+    server.use(
+      mockApi(chatThreadsContract.list, ({ respond }) => {
+        return respond(200, {
+          pinned: [],
+          threads: [],
+          hasMore: false,
+          nextCursor: null,
+          totalCount: 0,
+        });
+      }),
+      mockApi(chatThreadMessagesContract.list, ({ respond }) => {
+        return respond(200, {
+          messages: [
+            {
+              id: "msg-assistant-copy",
+              role: "assistant",
+              content: "Waiting in queue...",
+              runId,
+              createdAt: "2026-04-13T00:00:01Z",
+            },
+            {
+              id: "msg-assistant-completed",
+              role: "assistant",
+              content: null,
+              runId,
+              runLifecycleEvent: "completed",
+              createdAt: "2026-04-13T00:00:02Z",
+            },
+          ],
+        });
+      }),
+      mockApi(chatThreadByIdContract.get, ({ params, respond }) => {
+        return respond(200, {
+          id: params.id,
+          title: null,
+          agentId: "c0000000-0000-4000-a000-000000000001",
+          latestSessionId: null,
+          activeRunIds: [],
+          activeRuns: [],
+          draftContent: null,
+          draftAttachments: null,
+          createdAt: "2026-04-13T00:00:00Z",
+          updatedAt: "2026-04-13T00:00:00Z",
+        });
+      }),
+    );
+
+    detachedSetupPage({
+      context,
+      path: `/chats/${threadId}`,
+      withoutRender: true,
+    });
+
+    const thread = createThreadSignals(threadId);
+
+    await vi.waitFor(async () => {
+      await expect(
+        context.store.get(thread.latestRunStatus$),
+      ).resolves.toBeNull();
+    });
+  });
+
   it("keeps queued when the run user message precedes an active queue marker", async () => {
     const threadId = "thread-user-before-queue-marker-1";
     const runId = "run-user-before-queue-marker-1";
@@ -156,6 +223,7 @@ describe("latestRunStatus$", () => {
               role: "assistant",
               content: "Waiting in queue...",
               runId,
+              runEventId: "queue:queued",
               createdAt: "2026-04-13T00:00:02Z",
             },
           ],
@@ -214,6 +282,7 @@ describe("latestRunStatus$", () => {
               role: "assistant",
               content: "Waiting in queue...",
               runId,
+              runEventId: "queue:queued",
               createdAt: "2026-04-13T00:00:01Z",
             },
             {
@@ -280,6 +349,7 @@ describe("latestRunStatus$", () => {
               role: "assistant",
               content: "Waiting in queue...",
               runId,
+              runEventId: "queue:queued",
               createdAt: "2026-04-13T00:00:01Z",
             },
             {

--- a/turbo/apps/platform/src/signals/chat-page/__tests__/latest-run-status.test.ts
+++ b/turbo/apps/platform/src/signals/chat-page/__tests__/latest-run-status.test.ts
@@ -127,7 +127,72 @@ describe("latestRunStatus$", () => {
     });
   });
 
-  it("treats assistant output as running even when thread data still says queued", async () => {
+  it("keeps queued when the run user message precedes an active queue marker", async () => {
+    const threadId = "thread-user-before-queue-marker-1";
+    const runId = "run-user-before-queue-marker-1";
+
+    server.use(
+      mockApi(chatThreadsContract.list, ({ respond }) => {
+        return respond(200, {
+          pinned: [],
+          threads: [],
+          hasMore: false,
+          nextCursor: null,
+          totalCount: 0,
+        });
+      }),
+      mockApi(chatThreadMessagesContract.list, ({ respond }) => {
+        return respond(200, {
+          messages: [
+            {
+              id: "msg-queued-user",
+              role: "user",
+              content: "wait behind active run",
+              runId,
+              createdAt: "2026-04-13T00:00:01Z",
+            },
+            {
+              id: "msg-queue-marker-active",
+              role: "assistant",
+              content: "Waiting in queue...",
+              runId,
+              createdAt: "2026-04-13T00:00:02Z",
+            },
+          ],
+        });
+      }),
+      mockApi(chatThreadByIdContract.get, ({ params, respond }) => {
+        return respond(200, {
+          id: params.id,
+          title: null,
+          agentId: "c0000000-0000-4000-a000-000000000001",
+          latestSessionId: null,
+          activeRunIds: [runId],
+          activeRuns: [{ id: runId, status: "queued" }],
+          draftContent: null,
+          draftAttachments: null,
+          createdAt: "2026-04-13T00:00:00Z",
+          updatedAt: "2026-04-13T00:00:00Z",
+        });
+      }),
+    );
+
+    detachedSetupPage({
+      context,
+      path: `/chats/${threadId}`,
+      withoutRender: true,
+    });
+
+    const thread = createThreadSignals(threadId);
+
+    await vi.waitFor(async () => {
+      await expect(context.store.get(thread.latestRunStatus$)).resolves.toBe(
+        "queued",
+      );
+    });
+  });
+
+  it("treats assistant output after a queue marker as running even when thread data still says queued", async () => {
     const threadId = "thread-assistant-running-1";
     const runId = "run-assistant-running-1";
 
@@ -145,11 +210,18 @@ describe("latestRunStatus$", () => {
         return respond(200, {
           messages: [
             {
+              id: "msg-queue-marker-active",
+              role: "assistant",
+              content: "Waiting in queue...",
+              runId,
+              createdAt: "2026-04-13T00:00:01Z",
+            },
+            {
               id: "msg-assistant-started",
               role: "assistant",
               content: "The local-agent job is running...",
               runId,
-              createdAt: "2026-04-13T00:00:01Z",
+              createdAt: "2026-04-13T00:00:02Z",
             },
           ],
         });

--- a/turbo/apps/platform/src/signals/chat-page/create-chat-thread.ts
+++ b/turbo/apps/platform/src/signals/chat-page/create-chat-thread.ts
@@ -312,14 +312,13 @@ function deriveRunIndicatorState(
   return hasQueued ? "queued" : null;
 }
 
-function hasActiveQueueMarker(
+function hasUnresolvedQueueMarker(
   raw: readonly ChatMessageProjectionEntry[],
 ): boolean {
-  const queueMarkerIds = new Set(
-    raw.flatMap((entry) => {
-      return isQueueMarkerMessage(entry.message) ? [entry.message.id] : [];
-    }),
-  );
+  const queueMarkers = new Map<
+    string,
+    { readonly runId: string; readonly index: number }
+  >();
   const revokedIds = new Set(
     raw.flatMap((entry) => {
       return entry.message.revokesMessageId
@@ -327,8 +326,47 @@ function hasActiveQueueMarker(
         : [];
     }),
   );
-  for (const markerId of queueMarkerIds) {
-    if (!revokedIds.has(markerId)) {
+  const lastAssistantOutputIndexByRunId = new Map<string, number>();
+  const lastTerminalIndexByRunId = new Map<string, number>();
+  const lastInterruptIndexByRunId = new Map<string, number>();
+
+  raw.forEach((entry, index) => {
+    const { message } = entry;
+    if (isQueueMarkerMessage(message) && message.runId !== undefined) {
+      queueMarkers.set(message.id, { runId: message.runId, index });
+      return;
+    }
+    if (message.interruptsRunId !== undefined) {
+      lastInterruptIndexByRunId.set(message.interruptsRunId, index);
+    }
+    if (message.role !== "assistant" || message.runId === undefined) {
+      return;
+    }
+    if (message.runLifecycleEvent !== undefined) {
+      lastTerminalIndexByRunId.set(message.runId, index);
+      return;
+    }
+    if (message.content !== null) {
+      lastAssistantOutputIndexByRunId.set(message.runId, index);
+    }
+  });
+
+  for (const [markerId, marker] of queueMarkers) {
+    if (revokedIds.has(markerId)) {
+      continue;
+    }
+    const laterAssistantOutputIndex =
+      lastAssistantOutputIndexByRunId.get(marker.runId) ?? -1;
+    const laterTerminalIndex = lastTerminalIndexByRunId.get(marker.runId) ?? -1;
+    const laterInterruptIndex =
+      lastInterruptIndexByRunId.get(marker.runId) ?? -1;
+    if (
+      Math.max(
+        laterAssistantOutputIndex,
+        laterTerminalIndex,
+        laterInterruptIndex,
+      ) <= marker.index
+    ) {
       return true;
     }
   }
@@ -1409,12 +1447,15 @@ function createLatestRunStatus(
   rawMessages$: Computed<Promise<ChatMessageProjectionEntry[]>>,
 ) {
   return computed(async (get): Promise<string | null> => {
+    if (hasUnresolvedQueueMarker(await get(rawMessages$))) {
+      return "queued";
+    }
     const messages = await get(allMessages$);
     const stateFromMessages = deriveRunIndicatorState(messages);
     if (stateFromMessages !== null) {
       return stateFromMessages;
     }
-    return hasActiveQueueMarker(await get(rawMessages$)) ? "queued" : null;
+    return null;
   });
 }
 

--- a/turbo/apps/platform/src/signals/chat-page/create-chat-thread.ts
+++ b/turbo/apps/platform/src/signals/chat-page/create-chat-thread.ts
@@ -330,26 +330,26 @@ function hasUnresolvedQueueMarker(
   const lastTerminalIndexByRunId = new Map<string, number>();
   const lastInterruptIndexByRunId = new Map<string, number>();
 
-  raw.forEach((entry, index) => {
+  for (const [index, entry] of raw.entries()) {
     const { message } = entry;
     if (isQueueMarkerMessage(message) && message.runId !== undefined) {
       queueMarkers.set(message.id, { runId: message.runId, index });
-      return;
+      continue;
     }
     if (message.interruptsRunId !== undefined) {
       lastInterruptIndexByRunId.set(message.interruptsRunId, index);
     }
     if (message.role !== "assistant" || message.runId === undefined) {
-      return;
+      continue;
     }
     if (message.runLifecycleEvent !== undefined) {
       lastTerminalIndexByRunId.set(message.runId, index);
-      return;
+      continue;
     }
     if (message.content !== null) {
       lastAssistantOutputIndexByRunId.set(message.runId, index);
     }
-  });
+  }
 
   for (const [markerId, marker] of queueMarkers) {
     if (revokedIds.has(markerId)) {

--- a/turbo/apps/platform/src/signals/chat-page/create-chat-thread.ts
+++ b/turbo/apps/platform/src/signals/chat-page/create-chat-thread.ts
@@ -82,7 +82,7 @@ export type { DraftSignals } from "../zero-page/chat-draft.ts";
 
 const L = logger("ChatThread");
 
-const QUEUED_RUN_ASSISTANT_MESSAGE = "Waiting in queue...";
+const QUEUED_RUN_MARKER_EVENT_ID = "queue:queued";
 
 function isRecallControlMessage(msg: PagedChatMessage): boolean {
   return (
@@ -95,7 +95,7 @@ function isRecallControlMessage(msg: PagedChatMessage): boolean {
 function isQueueMarkerMessage(msg: PagedChatMessage): boolean {
   return (
     msg.role === "assistant" &&
-    msg.content === QUEUED_RUN_ASSISTANT_MESSAGE &&
+    msg.runEventId === QUEUED_RUN_MARKER_EVENT_ID &&
     msg.runId !== undefined
   );
 }

--- a/turbo/apps/platform/src/views/zero-page/__tests__/chat-queue-message.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/chat-queue-message.test.tsx
@@ -265,6 +265,7 @@ describe("chat queued user messages", () => {
           role: "assistant",
           content: "Waiting in queue...",
           runId: "run-queued",
+          runEventId: "queue:queued",
           status: "queued",
           createdAt: "2026-03-10T00:00:02Z",
         },

--- a/turbo/apps/platform/src/views/zero-page/__tests__/chat-queue-message.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/chat-queue-message.test.tsx
@@ -6,6 +6,7 @@ import {
   click,
   detachedSetupPage,
   fill,
+  queryAllByRoleFast,
 } from "../../../__tests__/page-helper.ts";
 import { createDeferredPromise } from "../../../signals/utils.ts";
 import { optimisticChatThread$ } from "../../../signals/chat-page/optimistic-chat-thread-state.ts";
@@ -247,6 +248,41 @@ describe("chat queued user messages", () => {
     ]);
     expect(appendedContents).toStrictEqual(["first queued", "second queued"]);
     expect(new Set(appendedClientIds).size).toBe(2);
+  });
+
+  it("shows the queue indicator when a queued run has a user message and queue marker", async () => {
+    mockChatLifecycle({
+      chatMessages: [
+        {
+          id: "msg-queued-user",
+          role: "user",
+          content: "wait behind active run",
+          runId: "run-queued",
+          createdAt: "2026-03-10T00:00:01Z",
+        },
+        {
+          id: "msg-queue-marker",
+          role: "assistant",
+          content: "Waiting in queue...",
+          runId: "run-queued",
+          status: "queued",
+          createdAt: "2026-03-10T00:00:02Z",
+        },
+      ],
+    });
+
+    detachedSetupPage({
+      context,
+      path: CHAT_PATH,
+    });
+
+    await waitFor(() => {
+      const queueButton = queryAllByRoleFast("button").find((button) => {
+        return button.textContent?.trim() === "queue...";
+      });
+      expect(queueButton).toBeDefined();
+      expect(queueButton).toBeVisible();
+    });
   });
 
   it("recalls a queued message back into the composer", async () => {

--- a/turbo/packages/api-contracts/src/contracts/chat-threads.ts
+++ b/turbo/packages/api-contracts/src/contracts/chat-threads.ts
@@ -175,6 +175,7 @@ const pagedChatMessageBaseSchema = z.object({
   id: z.string(),
   content: z.string().nullable(),
   runId: z.string().optional(),
+  runEventId: z.string().optional(),
   revokesMessageId: z.string().optional(),
   interruptsRunId: z.string().optional(),
   error: z.string().optional(),


### PR DESCRIPTION
## Summary
- detect unresolved chat queue markers before treating visible run messages as running
- keep stale queue protection by ignoring markers that were revoked or followed by assistant output, terminal, or interrupt events
- add signal and UI regressions for the real user-message-then-queue-marker ordering

## Tests
- `pnpm -F @vm0/app exec eslint src/signals/chat-page/create-chat-thread.ts src/signals/chat-page/__tests__/latest-run-status.test.ts src/views/zero-page/__tests__/chat-queue-message.test.tsx --max-warnings 0`
- `pnpm -F @vm0/app exec vitest run src/signals/chat-page/__tests__/latest-run-status.test.ts`
- `pnpm -F @vm0/app exec vitest run src/views/zero-page/__tests__/chat-queue-message.test.tsx`
- `git diff --check`

## Notes
- `pnpm -F @vm0/app check-types` still fails locally on broad latest-main contract typing issues outside this change set, primarily `body` inferred as `never`, missing `headers`, and implicit anys across existing platform files.
