### PR TITLE
feat(api): trigger completion callbacks restore live schedule semantics

### DIFF
--- a/turbo/apps/api/src/signals/route.ts
+++ b/turbo/apps/api/src/signals/route.ts
@@ -45,6 +45,7 @@ import { internalCallbacksGithubIssuesRoutes } from "./routes/internal-callbacks
 import { internalCallbacksScheduleRoutes } from "./routes/internal-callbacks-schedule";
 import { internalCallbacksSlackOrgRoutes } from "./routes/internal-callbacks-slack-org";
 import { internalCallbacksTelegramRoutes } from "./routes/internal-callbacks-telegram";
+import { internalCallbacksTriggerRoutes } from "./routes/internal-callbacks-trigger";
 import { internalEventConsumerAgentPhoneTypingRoutes } from "./routes/internal-event-consumers-agentphone-typing";
 import { internalEventConsumerAxiomRoutes } from "./routes/internal-event-consumers-axiom";
 import { internalEventConsumerChatAssistantRoutes } from "./routes/internal-event-consumers-chat-assistant";
@@ -216,6 +217,7 @@ export const ROUTES: readonly RouteEntry[] = [
   ...internalCallbacksScheduleRoutes,
   ...internalCallbacksSlackOrgRoutes,
   ...internalCallbacksTelegramRoutes,
+  ...internalCallbacksTriggerRoutes,
   ...internalEventConsumerAgentPhoneTypingRoutes,
   ...internalEventConsumerAxiomRoutes,
   ...internalEventConsumerChatAssistantRoutes,

--- a/turbo/apps/api/src/signals/routes/__tests__/internal-callbacks-trigger.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/internal-callbacks-trigger.test.ts
@@ -1,0 +1,558 @@
+import { randomUUID } from "node:crypto";
+
+import { createStore } from "ccstate";
+import { eq } from "drizzle-orm";
+import { afterEach, describe, expect, it } from "vitest";
+import { automations, automationTriggers } from "@vm0/db/schema/automation";
+import { chatThreads } from "@vm0/db/schema/chat-thread";
+import { zeroRuns } from "@vm0/db/schema/zero-run";
+
+import { createApp } from "../../../app-factory";
+import { testContext } from "../../../__tests__/test-helpers";
+import { computeHmacSignature } from "../../../lib/event-consumer/hmac";
+import { clearMockNow, mockNow, now } from "../../../lib/time";
+import { writeDb$ } from "../../external/db";
+import { calculateNextRun } from "../../services/automations/time-trigger";
+import { seedAgentRunCallback$ } from "./helpers/agent-run-callback";
+import { createFixtureTracker } from "./helpers/zero-route-test";
+import {
+  deleteUsageInsightFixture$,
+  seedCompose$,
+  seedRun$,
+  seedUsageInsightFixture$,
+  type UsageInsightFixture,
+} from "./helpers/zero-usage-insight";
+
+const context = testContext();
+const store = createStore();
+
+const CRON_PATH = "/api/internal/callbacks/trigger/cron";
+const LOOP_PATH = "/api/internal/callbacks/trigger/loop";
+const TEST_CALLBACK_SECRET = "test-callback-secret";
+
+interface TriggerCallbackFixture extends UsageInsightFixture {
+  readonly composeId: string;
+}
+
+type TriggerKind = "cron" | "loop";
+
+interface TriggerSeedOptions {
+  readonly kind: TriggerKind;
+  readonly enabled?: boolean;
+  readonly consecutiveFailures?: number;
+  readonly intervalSeconds?: number;
+  readonly cronExpression?: string;
+}
+
+interface CallbackSeedOptions {
+  readonly path: string;
+  readonly triggerId: string;
+  readonly payload: Record<string, unknown>;
+}
+
+async function deleteFixture(fixture: TriggerCallbackFixture): Promise<void> {
+  await store.set(deleteUsageInsightFixture$, fixture, context.signal);
+}
+
+async function seedFixture(): Promise<TriggerCallbackFixture> {
+  const base = await store.set(
+    seedUsageInsightFixture$,
+    undefined,
+    context.signal,
+  );
+  const { composeId } = await store.set(
+    seedCompose$,
+    {
+      orgId: base.orgId,
+      userId: base.userId,
+      name: `trigger-callback-${randomUUID().slice(0, 8)}`,
+    },
+    context.signal,
+  );
+  return { ...base, composeId };
+}
+
+// Seed an automation with one time trigger in the claimed state (next_run_at
+// null) — what the row looks like while its run is in flight and the completion
+// callback is pending.
+async function seedTrigger(
+  fixture: TriggerCallbackFixture,
+  options: TriggerSeedOptions,
+): Promise<string> {
+  const writeDb = store.set(writeDb$);
+  const isCron = options.kind === "cron";
+  const [thread] = await writeDb
+    .insert(chatThreads)
+    .values({ userId: fixture.userId, agentComposeId: fixture.composeId })
+    .returning({ id: chatThreads.id });
+  if (!thread) {
+    throw new Error("seedTrigger: chat thread insert returned no row");
+  }
+  const [automation] = await writeDb
+    .insert(automations)
+    .values({
+      orgId: fixture.orgId,
+      userId: fixture.userId,
+      name: `automation-${randomUUID().slice(0, 8)}`,
+      instruction: `${options.kind} task`,
+      agentId: fixture.composeId,
+      chatThreadId: thread.id,
+      interpreterKind: "time",
+    })
+    .returning({ id: automations.id });
+  if (!automation) {
+    throw new Error("seedTrigger: automation insert returned no row");
+  }
+  const [row] = await writeDb
+    .insert(automationTriggers)
+    .values({
+      automationId: automation.id,
+      kind: options.kind,
+      cronExpression: isCron ? (options.cronExpression ?? "0 9 * * *") : null,
+      intervalSeconds: isCron ? null : (options.intervalSeconds ?? 300),
+      timezone: "UTC",
+      nextRunAt: null,
+      enabled: options.enabled ?? true,
+      consecutiveFailures: options.consecutiveFailures ?? 0,
+    })
+    .returning({ id: automationTriggers.id });
+  if (!row) {
+    throw new Error("seedTrigger: trigger insert returned no row");
+  }
+  return row.id;
+}
+
+async function seedRunAndCallback(
+  fixture: TriggerCallbackFixture,
+  options: CallbackSeedOptions,
+): Promise<{ readonly runId: string; readonly callbackId: string }> {
+  const { runId } = await store.set(
+    seedRun$,
+    {
+      orgId: fixture.orgId,
+      userId: fixture.userId,
+      composeId: fixture.composeId,
+      triggerSource: "schedule",
+      prompt: "Triggered task",
+    },
+    context.signal,
+  );
+  const { callbackId } = await store.set(
+    seedAgentRunCallback$,
+    {
+      runId,
+      url: `http://localhost${options.path}`,
+      payload: options.payload,
+    },
+    context.signal,
+  );
+  return { runId, callbackId };
+}
+
+function signedHeaders(rawBody: string): Record<string, string> {
+  const timestamp = Math.floor(now() / 1000);
+  return {
+    "Content-Type": "application/json",
+    "X-VM0-Signature": computeHmacSignature(
+      rawBody,
+      TEST_CALLBACK_SECRET,
+      timestamp,
+    ),
+    "X-VM0-Timestamp": String(timestamp),
+  };
+}
+
+async function postSignedCallback(
+  path: string,
+  body: Record<string, unknown>,
+  invalidSignature = false,
+): Promise<Response> {
+  const rawBody = JSON.stringify(body);
+  const app = createApp({ signal: context.signal });
+  return await app.request(path, {
+    method: "POST",
+    headers: invalidSignature
+      ? {
+          ...signedHeaders(rawBody),
+          "X-VM0-Signature": "invalid-signature",
+        }
+      : signedHeaders(rawBody),
+    body: rawBody,
+  });
+}
+
+async function triggerById(triggerId: string) {
+  const writeDb = store.set(writeDb$);
+  const [row] = await writeDb
+    .select()
+    .from(automationTriggers)
+    .where(eq(automationTriggers.id, triggerId))
+    .limit(1);
+  return row;
+}
+
+async function updateTrigger(
+  triggerId: string,
+  values: Partial<typeof automationTriggers.$inferInsert>,
+): Promise<void> {
+  const writeDb = store.set(writeDb$);
+  await writeDb
+    .update(automationTriggers)
+    .set(values)
+    .where(eq(automationTriggers.id, triggerId));
+}
+
+async function deleteTrigger(triggerId: string): Promise<void> {
+  const writeDb = store.set(writeDb$);
+  await writeDb
+    .delete(automationTriggers)
+    .where(eq(automationTriggers.id, triggerId));
+}
+
+async function runSummary(runId: string): Promise<string | null> {
+  const writeDb = store.set(writeDb$);
+  const [row] = await writeDb
+    .select({ summary: zeroRuns.summary })
+    .from(zeroRuns)
+    .where(eq(zeroRuns.id, runId))
+    .limit(1);
+  return row?.summary ?? null;
+}
+
+afterEach(() => {
+  clearMockNow();
+});
+
+describe("POST /api/internal/callbacks/trigger/*", () => {
+  const track = createFixtureTracker<TriggerCallbackFixture>((fixture) => {
+    return deleteFixture(fixture);
+  });
+
+  it("rejects cron callbacks with invalid signatures", async () => {
+    const fixture = await track(seedFixture());
+    const triggerId = await seedTrigger(fixture, { kind: "cron" });
+    const { runId } = await seedRunAndCallback(fixture, {
+      path: CRON_PATH,
+      triggerId,
+      payload: { triggerId, cronExpression: "0 9 * * *", timezone: "UTC" },
+    });
+
+    const response = await postSignedCallback(
+      CRON_PATH,
+      {
+        runId,
+        status: "completed",
+        payload: { triggerId, cronExpression: "0 9 * * *", timezone: "UTC" },
+      },
+      true,
+    );
+
+    expect(response.status).toBe(401);
+  });
+
+  it("rejects invalid cron payloads", async () => {
+    const fixture = await track(seedFixture());
+    const triggerId = await seedTrigger(fixture, { kind: "cron" });
+    const { runId, callbackId } = await seedRunAndCallback(fixture, {
+      path: CRON_PATH,
+      triggerId,
+      payload: { triggerId, cronExpression: "0 9 * * *", timezone: "UTC" },
+    });
+
+    const response = await postSignedCallback(CRON_PATH, {
+      callbackId,
+      runId,
+      status: "completed",
+      payload: { triggerId },
+    });
+
+    expect(response.status).toBe(400);
+    await expect(response.json()).resolves.toStrictEqual({
+      error: "Invalid or missing payload",
+    });
+  });
+
+  it("rejects invalid loop payloads", async () => {
+    const fixture = await track(seedFixture());
+    const triggerId = await seedTrigger(fixture, { kind: "loop" });
+    const { runId, callbackId } = await seedRunAndCallback(fixture, {
+      path: LOOP_PATH,
+      triggerId,
+      payload: { triggerId },
+    });
+
+    const response = await postSignedCallback(LOOP_PATH, {
+      callbackId,
+      runId,
+      status: "completed",
+      payload: {},
+    });
+
+    expect(response.status).toBe(400);
+    await expect(response.json()).resolves.toStrictEqual({
+      error: "Invalid or missing payload",
+    });
+  });
+
+  it("skips progress callbacks without mutating triggers", async () => {
+    const fixture = await track(seedFixture());
+    const triggerId = await seedTrigger(fixture, {
+      kind: "loop",
+      consecutiveFailures: 2,
+    });
+    const { runId, callbackId } = await seedRunAndCallback(fixture, {
+      path: LOOP_PATH,
+      triggerId,
+      payload: { triggerId },
+    });
+
+    const response = await postSignedCallback(LOOP_PATH, {
+      callbackId,
+      runId,
+      status: "progress",
+      payload: { triggerId },
+    });
+
+    expect(response.status).toBe(200);
+    await expect(response.json()).resolves.toStrictEqual({
+      success: true,
+      skipped: true,
+    });
+    const updated = await triggerById(triggerId);
+    expect(updated?.consecutiveFailures).toBe(2);
+    expect(updated?.enabled).toBeTruthy();
+    expect(updated?.nextRunAt).toBeNull();
+  });
+
+  it("uses the current DB interval when completing loop callbacks", async () => {
+    mockNow(new Date("2026-05-13T04:00:00.000Z"));
+    const fixture = await track(seedFixture());
+    const triggerId = await seedTrigger(fixture, {
+      kind: "loop",
+      consecutiveFailures: 2,
+      intervalSeconds: 300,
+    });
+    await updateTrigger(triggerId, { intervalSeconds: 600 });
+    const { runId, callbackId } = await seedRunAndCallback(fixture, {
+      path: LOOP_PATH,
+      triggerId,
+      payload: { triggerId },
+    });
+
+    const response = await postSignedCallback(LOOP_PATH, {
+      callbackId,
+      runId,
+      status: "completed",
+      payload: { triggerId },
+    });
+
+    expect(response.status).toBe(200);
+    await expect(response.json()).resolves.toStrictEqual({ success: true });
+    const updated = await triggerById(triggerId);
+    expect(updated?.consecutiveFailures).toBe(0);
+    expect(updated?.enabled).toBeTruthy();
+    expect(updated?.nextRunAt?.toISOString()).toBe("2026-05-13T04:10:00.000Z");
+    // The chat callback owns the run summary; the reschedule callback must not
+    // write one.
+    await expect(runSummary(runId)).resolves.toBeNull();
+  });
+
+  it("increments loop failure counters before the auto-disable threshold", async () => {
+    const failedAt = new Date("2026-05-13T04:00:00.000Z");
+    mockNow(failedAt);
+    const fixture = await track(seedFixture());
+    const triggerId = await seedTrigger(fixture, { kind: "loop" });
+    const { runId, callbackId } = await seedRunAndCallback(fixture, {
+      path: LOOP_PATH,
+      triggerId,
+      payload: { triggerId },
+    });
+
+    const response = await postSignedCallback(LOOP_PATH, {
+      callbackId,
+      runId,
+      status: "failed",
+      error: "Agent crashed",
+      payload: { triggerId },
+    });
+
+    expect(response.status).toBe(200);
+    await expect(response.json()).resolves.toStrictEqual({ success: true });
+    const updated = await triggerById(triggerId);
+    expect(updated?.consecutiveFailures).toBe(1);
+    expect(updated?.enabled).toBeTruthy();
+    expect(updated?.nextRunAt?.toISOString()).toBe("2026-05-13T04:05:00.000Z");
+  });
+
+  it("auto-disables loop triggers after the third consecutive failure", async () => {
+    const fixture = await track(seedFixture());
+    const triggerId = await seedTrigger(fixture, {
+      kind: "loop",
+      consecutiveFailures: 2,
+    });
+    const { runId, callbackId } = await seedRunAndCallback(fixture, {
+      path: LOOP_PATH,
+      triggerId,
+      payload: { triggerId },
+    });
+
+    const response = await postSignedCallback(LOOP_PATH, {
+      callbackId,
+      runId,
+      status: "failed",
+      error: "Agent crashed",
+      payload: { triggerId },
+    });
+
+    expect(response.status).toBe(200);
+    await expect(response.json()).resolves.toStrictEqual({ success: true });
+    const updated = await triggerById(triggerId);
+    expect(updated?.consecutiveFailures).toBe(3);
+    expect(updated?.enabled).toBeFalsy();
+    expect(updated?.nextRunAt).toBeNull();
+  });
+
+  it("advances cron callbacks from the dispatched expression on completion", async () => {
+    const completedAt = new Date("2026-05-13T04:00:00.000Z");
+    mockNow(completedAt);
+    const fixture = await track(seedFixture());
+    const triggerId = await seedTrigger(fixture, {
+      kind: "cron",
+      consecutiveFailures: 2,
+    });
+    const { runId, callbackId } = await seedRunAndCallback(fixture, {
+      path: CRON_PATH,
+      triggerId,
+      payload: { triggerId, cronExpression: "0 9 * * *", timezone: "UTC" },
+    });
+
+    const response = await postSignedCallback(CRON_PATH, {
+      callbackId,
+      runId,
+      status: "completed",
+      payload: { triggerId, cronExpression: "0 9 * * *", timezone: "UTC" },
+    });
+
+    expect(response.status).toBe(200);
+    await expect(response.json()).resolves.toStrictEqual({ success: true });
+    const updated = await triggerById(triggerId);
+    expect(updated?.consecutiveFailures).toBe(0);
+    expect(updated?.enabled).toBeTruthy();
+    expect(updated?.nextRunAt?.toISOString()).toBe(
+      calculateNextRun("0 9 * * *", "UTC", completedAt)?.toISOString(),
+    );
+    await expect(runSummary(runId)).resolves.toBeNull();
+  });
+
+  it("increments cron failure counters before the auto-disable threshold", async () => {
+    const failedAt = new Date("2026-05-13T04:00:00.000Z");
+    mockNow(failedAt);
+    const fixture = await track(seedFixture());
+    const triggerId = await seedTrigger(fixture, { kind: "cron" });
+    const { runId, callbackId } = await seedRunAndCallback(fixture, {
+      path: CRON_PATH,
+      triggerId,
+      payload: { triggerId, cronExpression: "0 9 * * *", timezone: "UTC" },
+    });
+
+    const response = await postSignedCallback(CRON_PATH, {
+      callbackId,
+      runId,
+      status: "failed",
+      error: "Agent crashed",
+      payload: { triggerId, cronExpression: "0 9 * * *", timezone: "UTC" },
+    });
+
+    expect(response.status).toBe(200);
+    await expect(response.json()).resolves.toStrictEqual({ success: true });
+    const updated = await triggerById(triggerId);
+    expect(updated?.consecutiveFailures).toBe(1);
+    expect(updated?.enabled).toBeTruthy();
+    expect(updated?.nextRunAt?.toISOString()).toBe(
+      calculateNextRun("0 9 * * *", "UTC", failedAt)?.toISOString(),
+    );
+  });
+
+  it("auto-disables cron triggers after the third consecutive failure", async () => {
+    const fixture = await track(seedFixture());
+    const triggerId = await seedTrigger(fixture, {
+      kind: "cron",
+      consecutiveFailures: 2,
+    });
+    const { runId, callbackId } = await seedRunAndCallback(fixture, {
+      path: CRON_PATH,
+      triggerId,
+      payload: { triggerId, cronExpression: "0 9 * * *", timezone: "UTC" },
+    });
+
+    const response = await postSignedCallback(CRON_PATH, {
+      callbackId,
+      runId,
+      status: "failed",
+      error: "Agent crashed",
+      payload: { triggerId, cronExpression: "0 9 * * *", timezone: "UTC" },
+    });
+
+    expect(response.status).toBe(200);
+    await expect(response.json()).resolves.toStrictEqual({ success: true });
+    const updated = await triggerById(triggerId);
+    expect(updated?.consecutiveFailures).toBe(3);
+    expect(updated?.enabled).toBeFalsy();
+    expect(updated?.nextRunAt).toBeNull();
+  });
+
+  it("skips completed callbacks for deleted triggers", async () => {
+    const fixture = await track(seedFixture());
+    const triggerId = await seedTrigger(fixture, { kind: "cron" });
+    const { runId, callbackId } = await seedRunAndCallback(fixture, {
+      path: CRON_PATH,
+      triggerId,
+      payload: { triggerId, cronExpression: "0 9 * * *", timezone: "UTC" },
+    });
+    await deleteTrigger(triggerId);
+
+    const response = await postSignedCallback(CRON_PATH, {
+      callbackId,
+      runId,
+      status: "completed",
+      payload: { triggerId, cronExpression: "0 9 * * *", timezone: "UTC" },
+    });
+
+    expect(response.status).toBe(200);
+    await expect(response.json()).resolves.toStrictEqual({
+      success: true,
+      skipped: true,
+    });
+  });
+
+  it("skips completed callbacks for disabled triggers (once after claim)", async () => {
+    const fixture = await track(seedFixture());
+    // A once trigger is disabled at claim time, so its completion callback must
+    // land in the disabled-skip branch — live schedule parity.
+    const triggerId = await seedTrigger(fixture, {
+      kind: "cron",
+      enabled: false,
+    });
+    const { runId, callbackId } = await seedRunAndCallback(fixture, {
+      path: CRON_PATH,
+      triggerId,
+      payload: { triggerId, timezone: "UTC" },
+    });
+
+    const response = await postSignedCallback(CRON_PATH, {
+      callbackId,
+      runId,
+      status: "completed",
+      payload: { triggerId, timezone: "UTC" },
+    });
+
+    expect(response.status).toBe(200);
+    await expect(response.json()).resolves.toStrictEqual({
+      success: true,
+      skipped: true,
+    });
+    const updated = await triggerById(triggerId);
+    expect(updated?.enabled).toBeFalsy();
+    expect(updated?.consecutiveFailures).toBe(0);
+  });
+});

--- a/turbo/apps/api/src/signals/routes/internal-callbacks-trigger.ts
+++ b/turbo/apps/api/src/signals/routes/internal-callbacks-trigger.ts
@@ -1,0 +1,138 @@
+import { command } from "ccstate";
+import {
+  internalCallbacksTriggerContract,
+  triggerCronCallbackPayloadSchema,
+  triggerLoopCallbackPayloadSchema,
+  type TriggerCronCallbackPayload,
+  type TriggerLoopCallbackPayload,
+} from "@vm0/api-contracts/contracts/internal-callbacks-trigger";
+import { automationTriggers } from "@vm0/db/schema/automation";
+import { eq } from "drizzle-orm";
+
+import {
+  callbackPayload$,
+  callbackRoute,
+} from "../../lib/callback-route/callback-route";
+import type { RouteEntry } from "../route";
+import { writeDb$ } from "../external/db";
+import { nowDate } from "../external/time";
+import { TimeTrigger } from "../services/automations/time-trigger";
+
+const MAX_CONSECUTIVE_FAILURES = 3;
+
+type TriggerPayload =
+  | { readonly kind: "cron"; readonly data: TriggerCronCallbackPayload }
+  | { readonly kind: "loop"; readonly data: TriggerLoopCallbackPayload };
+
+function successResponse(skipped?: true): {
+  readonly status: 200;
+  readonly body: { readonly success: true; readonly skipped?: true };
+} {
+  return { status: 200, body: { success: true, ...(skipped && { skipped }) } };
+}
+
+function errorResponse(message: string): {
+  readonly status: 400;
+  readonly body: { readonly error: string };
+} {
+  return { status: 400, body: { error: message } };
+}
+
+function parseCronPayload(payload: unknown): TriggerPayload | null {
+  const result = triggerCronCallbackPayloadSchema.safeParse(payload);
+  if (!result.success) {
+    return null;
+  }
+  return { kind: "cron", data: result.data };
+}
+
+function parseLoopPayload(payload: unknown): TriggerPayload | null {
+  const result = triggerLoopCallbackPayloadSchema.safeParse(payload);
+  if (!result.success) {
+    return null;
+  }
+  return { kind: "loop", data: result.data };
+}
+
+/**
+ * Completion callback for `automation_triggers` time rows — mirrors the schedule
+ * callback's semantics 1:1, keyed on `trigger_id`: a completed run resets the
+ * consecutive-failure counter, a failed run increments it (auto-disable at the
+ * threshold), and the recurrence advances from completion time. The poller's
+ * claim cleared `next_run_at`, so this callback is what reschedules the trigger.
+ * `once` triggers were disabled at claim, so their callback lands in the
+ * disabled-skip branch — same as the live schedule path.
+ */
+function createTriggerCallbackHandler(
+  parsePayload: (payload: unknown) => TriggerPayload | null,
+) {
+  return command(async ({ get, set }, signal: AbortSignal) => {
+    const callback = get(callbackPayload$);
+    const payload = parsePayload(callback.payload);
+    if (!payload) {
+      return errorResponse("Invalid or missing payload");
+    }
+
+    if (callback.status === "progress") {
+      return successResponse(true);
+    }
+
+    const writeDb = set(writeDb$);
+    const [trigger] = await writeDb
+      .select()
+      .from(automationTriggers)
+      .where(eq(automationTriggers.id, payload.data.triggerId))
+      .limit(1);
+    signal.throwIfAborted();
+
+    if (!trigger || !trigger.enabled) {
+      return successResponse(true);
+    }
+
+    const completedAt = nowDate();
+    const consecutiveFailures =
+      callback.status === "completed" ? 0 : trigger.consecutiveFailures + 1;
+    const shouldDisable = consecutiveFailures >= MAX_CONSECUTIVE_FAILURES;
+    const nextRunAt = new TimeTrigger().advanceAfterCompletion({
+      triggerType: payload.kind,
+      cronExpression:
+        payload.kind === "cron" ? payload.data.cronExpression : undefined,
+      intervalSeconds: trigger.intervalSeconds,
+      timezone: trigger.timezone,
+      completedAt,
+      shouldDisable,
+    });
+
+    await writeDb
+      .update(automationTriggers)
+      .set({
+        consecutiveFailures,
+        ...(shouldDisable && { enabled: false }),
+        nextRunAt,
+        updatedAt: completedAt,
+      })
+      .where(eq(automationTriggers.id, payload.data.triggerId));
+    signal.throwIfAborted();
+
+    // The run summary is owned by the chat callback (triggerSource "chat"); this
+    // reschedule callback only advances next_run_at / consecutive-failure
+    // bookkeeping and must NOT write a second summary (D9).
+    return successResponse();
+  });
+}
+
+const handleCronTriggerCallback$ =
+  createTriggerCallbackHandler(parseCronPayload);
+const handleLoopTriggerCallback$ =
+  createTriggerCallbackHandler(parseLoopPayload);
+
+export const internalCallbacksTriggerRoutes: readonly RouteEntry[] = [
+  {
+    route: internalCallbacksTriggerContract.cron,
+    handler: callbackRoute(handleCronTriggerCallback$),
+  },
+  {
+    route: internalCallbacksTriggerContract.loop,
+    handler: callbackRoute(handleLoopTriggerCallback$),
+  },
+];

--- a/turbo/apps/api/src/signals/services/automations/__tests__/trigger-poller.test.ts
+++ b/turbo/apps/api/src/signals/services/automations/__tests__/trigger-poller.test.ts
@@ -2,6 +2,7 @@ import { randomUUID } from "node:crypto";
 
 import { agentComposes } from "@vm0/db/schema/agent-compose";
 import { agentRuns } from "@vm0/db/schema/agent-run";
+import { agentRunCallbacks } from "@vm0/db/schema/agent-run-callback";
 import { agentSessions } from "@vm0/db/schema/agent-session";
 import { automations, automationTriggers } from "@vm0/db/schema/automation";
 import { chatThreads } from "@vm0/db/schema/chat-thread";
@@ -155,6 +156,17 @@ async function findTrigger(triggerId: string) {
   return trigger;
 }
 
+async function findRunCallbackUrls(runId: string): Promise<string[]> {
+  const db = store.set(writeDb$);
+  const rows = await db
+    .select({ url: agentRunCallbacks.url })
+    .from(agentRunCallbacks)
+    .where(eq(agentRunCallbacks.runId, runId));
+  return rows.map((row) => {
+    return row.url;
+  });
+}
+
 async function findAutomationRuns(automationId: string) {
   const db = store.set(writeDb$);
   return await db
@@ -254,7 +266,7 @@ describe("executeDueTriggers$ (dormant automation time poller)", () => {
     expect(runs).toHaveLength(0);
   });
 
-  it("executes a due cron trigger, advances next run, and tags provenance", async () => {
+  it("executes a due cron trigger, clears next run for the callback, and tags provenance", async () => {
     const fixture = await seedAutomationTrigger({
       kind: "cron",
       cronExpression: "0 9 * * *",
@@ -268,10 +280,9 @@ describe("executeDueTriggers$ (dormant automation time poller)", () => {
     const trigger = await findTrigger(fixture.triggerId);
     expect(trigger?.enabled).toBeTruthy();
     expect(trigger?.lastRunAt).not.toBeNull();
-    // Cron advances to the next occurrence (next day 09:00 UTC).
-    expect(trigger?.nextRunAt).toStrictEqual(
-      new Date("2000-01-02T09:00:00.000Z"),
-    );
+    // The claim clears next_run_at; the trigger completion callback advances it
+    // when the run finishes (live schedule parity).
+    expect(trigger?.nextRunAt).toBeNull();
     expect(trigger?.lastRunId).not.toBeNull();
 
     const runs = await findAutomationRuns(fixture.automationId);
@@ -284,6 +295,24 @@ describe("executeDueTriggers$ (dormant automation time poller)", () => {
       "# Current Integration\nYou are currently running inside: Schedule",
     );
     expect(runs[0]?.appendSystemPrompt).toContain("Trigger type: cron");
+
+    // The run carries the trigger-keyed reschedule callback + the chat callback.
+    const runId = runs[0]?.id;
+    expect(runId).toBeDefined();
+    if (!runId) {
+      return;
+    }
+    const callbackUrls = await findRunCallbackUrls(runId);
+    expect(
+      callbackUrls.some((url) => {
+        return url.endsWith("/api/internal/callbacks/trigger/cron");
+      }),
+    ).toBeTruthy();
+    expect(
+      callbackUrls.some((url) => {
+        return url.endsWith("/api/internal/callbacks/chat");
+      }),
+    ).toBeTruthy();
   });
 
   it("executes and disables a due one-time trigger", async () => {
@@ -305,7 +334,7 @@ describe("executeDueTriggers$ (dormant automation time poller)", () => {
     expect(runs).toHaveLength(1);
   });
 
-  it("executes a due loop trigger and advances by its interval", async () => {
+  it("executes a due loop trigger, clearing next run for the callback", async () => {
     const fixture = await seedAutomationTrigger({
       kind: "loop",
       intervalSeconds: 300,
@@ -319,9 +348,22 @@ describe("executeDueTriggers$ (dormant automation time poller)", () => {
     const trigger = await findTrigger(fixture.triggerId);
     expect(trigger?.enabled).toBeTruthy();
     expect(trigger?.lastRunAt).not.toBeNull();
-    expect(trigger?.nextRunAt).toStrictEqual(new Date(DUE_TIME + 300_000));
+    // The claim clears next_run_at; the loop completion callback advances it by
+    // the interval from completion time (live schedule parity).
+    expect(trigger?.nextRunAt).toBeNull();
     const runs = await findAutomationRuns(fixture.automationId);
     expect(runs).toHaveLength(1);
+    const runId = runs[0]?.id;
+    expect(runId).toBeDefined();
+    if (!runId) {
+      return;
+    }
+    const callbackUrls = await findRunCallbackUrls(runId);
+    expect(
+      callbackUrls.some((url) => {
+        return url.endsWith("/api/internal/callbacks/trigger/loop");
+      }),
+    ).toBeTruthy();
   });
 
   it("does not create duplicate runs for concurrent invocations", async () => {

--- a/turbo/apps/api/src/signals/services/automations/default-interpreter.ts
+++ b/turbo/apps/api/src/signals/services/automations/default-interpreter.ts
@@ -4,6 +4,10 @@ import type {
   ScheduleCronCallbackPayload,
   ScheduleLoopCallbackPayload,
 } from "@vm0/api-contracts/contracts/internal-callbacks-schedule";
+import type {
+  TriggerCronCallbackPayload,
+  TriggerLoopCallbackPayload,
+} from "@vm0/api-contracts/contracts/internal-callbacks-trigger";
 import type { zeroAgentSchedules } from "@vm0/db/schema/zero-agent-schedule";
 
 import { internalApiBaseUrl } from "../../../lib/internal-api-url";
@@ -103,8 +107,9 @@ export interface WebhookTriggerEvent {
  * U4). Like the schedule time fire it is instruction-only — no inbound payload —
  * but it tags the run with the originating automation + the firing
  * `automation_triggers` row (run provenance, U3) instead of a schedule id, and
- * attaches no reschedule callback because the poller advances `next_run_at`
- * inline. `triggerId` is the firing trigger row.
+ * attaches the trigger-keyed reschedule callback (the claim cleared
+ * `next_run_at`; the callback advances it). `triggerId` is the firing trigger
+ * row.
  */
 interface AutomationTimeTriggerEvent {
   readonly kind: "automation-time";
@@ -315,6 +320,49 @@ function buildScheduleCallbacks(automation: Automation): RunCallback[] {
 }
 
 /**
+ * Trigger-table time-fire callbacks: the recurrence-specific reschedule
+ * callback keyed on the firing `automation_triggers` row (next_run_at /
+ * consecutive-failure bookkeeping in the trigger callback route) plus the chat
+ * callback — the events-first counterpart of `buildScheduleCallbacks`. Only the
+ * chat callback writes the run summary (D9), so callback dispatch order is safe.
+ */
+function buildTriggerCallbacks(
+  automation: Automation,
+  triggerId: string,
+): RunCallback[] {
+  const callbacks: RunCallback[] = [];
+
+  if (automation.triggerType === "loop") {
+    const payload: TriggerLoopCallbackPayload = { triggerId };
+    callbacks.push({
+      url: `${internalApiBaseUrl()}/api/internal/callbacks/trigger/loop`,
+      secret: generateCallbackSecret(),
+      payload,
+    });
+  } else if (
+    automation.triggerType === "cron" ||
+    automation.triggerType === "once"
+  ) {
+    const payload: TriggerCronCallbackPayload = {
+      triggerId,
+      ...(automation.cronExpression && {
+        cronExpression: automation.cronExpression,
+      }),
+      timezone: automation.timezone,
+    };
+    callbacks.push({
+      url: `${internalApiBaseUrl()}/api/internal/callbacks/trigger/cron`,
+      secret: generateCallbackSecret(),
+      payload,
+    });
+  }
+
+  callbacks.push(buildChatCallback(automation));
+
+  return callbacks;
+}
+
+/**
  * The single default Automation interpreter. It builds the agent-run input from
  * `(automation, triggerEvent)`:
  *
@@ -353,14 +401,14 @@ export class DefaultInterpreter {
     if (triggerEvent.kind === "automation-time") {
       // Automation-table time fire (dormant trigger poller): same instruction-only
       // schedule context as the schedule fire, but tagged with the automation +
-      // firing trigger (provenance) and carrying no reschedule callback — the
-      // poller advances next_run_at itself.
+      // firing trigger (provenance) and carrying the trigger-keyed reschedule
+      // callback — the claim cleared next_run_at, the callback advances it.
       return Promise.resolve({
         prompt: automation.prompt,
         agentId: automation.agentId,
         chatThreadId: automation.chatThreadId,
         appendSystemPrompt: buildScheduleAppendSystemPrompt(automation),
-        callbacks: [buildChatCallback(automation)],
+        callbacks: buildTriggerCallbacks(automation, triggerEvent.triggerId),
         zeroRunMetadata: {
           automationId: automation.id,
           triggerId: triggerEvent.triggerId,

--- a/turbo/apps/api/src/signals/services/automations/time-trigger.ts
+++ b/turbo/apps/api/src/signals/services/automations/time-trigger.ts
@@ -188,26 +188,23 @@ export class TimeTrigger {
 
   /**
    * Claim a due `automation_triggers` time row via an optimistic lock on
-   * `nextRunAt` — the trigger-table counterpart of `evaluate`. Mirrors the live
-   * schedule claim's atomicity (a concurrent poller whose `nextRunAt` already
-   * moved loses the race and returns null), but because the trigger poller is
-   * self-contained (no reschedule callback in this slice) the claim folds in the
-   * recurrence advance: cron/loop advance to their next run, once disables. Stamps
-   * `lastRunAt` and clears any retry marker, exactly as the schedule claim does.
+   * `nextRunAt` — the trigger-table counterpart of `evaluate`, mirroring the
+   * live schedule claim 1:1: clear the next run, stamp `lastRunAt`, reset any
+   * retry marker, and disable one-time triggers. The recurrence advance happens
+   * in the trigger completion callback (or `advanceTriggerAfterPreRunFailure`
+   * when the run was never created), exactly like the schedule path. Returns
+   * the claimed row, or null when another invocation won the race (the row's
+   * `nextRunAt` already moved).
    */
   async evaluateTrigger(args: {
     readonly db: Db;
     readonly trigger: TriggerRow;
     readonly currentTime: Date;
   }): Promise<TriggerRow | null> {
-    const nextRunAt = TimeTrigger.nextTriggerRun(
-      args.trigger,
-      args.currentTime,
-    );
     const [claimed] = await args.db
       .update(automationTriggers)
       .set({
-        nextRunAt,
+        nextRunAt: null,
         lastRunAt: args.currentTime,
         retryStartedAt: null,
         updatedAt: args.currentTime,

--- a/turbo/apps/api/src/signals/services/automations/trigger-poller.ts
+++ b/turbo/apps/api/src/signals/services/automations/trigger-poller.ts
@@ -221,8 +221,8 @@ async function recordTriggerPreRunFailure(
 // Render a triggered run as a web-chat turn in the automation's linked thread.
 // Model comes from the thread pin (org default if unpinned); the session is
 // always fresh (no sessionId); the run is tagged with the automation + firing
-// trigger (run provenance). The poller advances next_run_at on claim, so there
-// is no reschedule callback here.
+// trigger (run provenance). The claim cleared next_run_at; the interpreter
+// attaches the trigger-keyed reschedule callback that advances it on completion.
 const runTriggerNow$ = command(
   async (
     { set },
@@ -261,8 +261,9 @@ const runTriggerNow$ = command(
     const { modelPin, effectiveModelProvider } = modelContext;
 
     // The single default interpreter handles every Automation kind, keyed off an
-    // automation-table time trigger event here (provenance + no reschedule
-    // callback). The registry is deferred to the first fetching interpreter.
+    // automation-table time trigger event here (provenance + trigger-keyed
+    // reschedule callback). The registry is deferred to the first fetching
+    // interpreter.
     const runInput = await new DefaultInterpreter().interpret(
       automationRowToTimeAutomation({
         id: automation.id,
@@ -350,9 +351,10 @@ const runTriggerNow$ = command(
  * of `executeDueSchedules$`, built for the (later, gated) cutover and NOT wired
  * to any live cron route in this slice. It mirrors the schedule poller's
  * semantics 1:1: scan enabled time triggers whose `next_run_at` is due, skip any
- * whose previous run is still active, optimistic-lock claim the due row (which
- * also advances cron/loop or disables once), then create the run via the default
- * interpreter (tagged with automation + trigger provenance) and auto-disable a
+ * whose previous run is still active, optimistic-lock claim the due row (clears
+ * `next_run_at`; disables once-triggers), then create the run via the default
+ * interpreter (tagged with automation + trigger provenance, carrying the
+ * trigger completion callback that advances the recurrence) and auto-disable a
  * trigger after consecutive pre-run failures. Nothing here changes live
  * execution; `executeDueSchedules$` remains the only schedule executor.
  */

--- a/turbo/apps/web/api-backend-rewrites.js
+++ b/turbo/apps/web/api-backend-rewrites.js
@@ -610,6 +610,14 @@ export const API_BACKEND_REWRITES = [
     "/api/internal/callbacks/schedule/loop",
     "/api/internal/callbacks/schedule/loop",
   ],
+  [
+    "/api/internal/callbacks/trigger/cron",
+    "/api/internal/callbacks/trigger/cron",
+  ],
+  [
+    "/api/internal/callbacks/trigger/loop",
+    "/api/internal/callbacks/trigger/loop",
+  ],
   ["/api/internal/callbacks/slack/org", "/api/internal/callbacks/slack/org"],
   ["/api/internal/callbacks/telegram", "/api/internal/callbacks/telegram"],
   ["/api/internal/callbacks/agentphone", "/api/internal/callbacks/agentphone"],

--- a/turbo/packages/api-contracts/src/contracts/index.ts
+++ b/turbo/packages/api-contracts/src/contracts/index.ts
@@ -1413,6 +1413,14 @@ export {
   type ScheduleLoopCallbackPayload,
 } from "./internal-callbacks-schedule";
 export {
+  internalCallbacksTriggerContract,
+  triggerCronCallbackPayloadSchema,
+  triggerLoopCallbackPayloadSchema,
+  type InternalCallbacksTriggerContract,
+  type TriggerCronCallbackPayload,
+  type TriggerLoopCallbackPayload,
+} from "./internal-callbacks-trigger";
+export {
   internalCallbackBodySchema,
   internalCallbackErrorSchema,
   internalCallbackHeadersSchema,

--- a/turbo/packages/api-contracts/src/contracts/internal-callbacks-trigger.ts
+++ b/turbo/packages/api-contracts/src/contracts/internal-callbacks-trigger.ts
@@ -1,0 +1,73 @@
+import { z } from "zod";
+
+import { initContract } from "./base";
+import {
+  internalCallbackBodySchema,
+  internalCallbackErrorSchema,
+  internalCallbackHeadersSchema,
+  internalCallbackSuccessWithSkippedSchema,
+} from "./internal-callbacks-shared";
+
+const c = initContract();
+
+export const triggerLoopCallbackPayloadSchema = z
+  .object({
+    triggerId: z.string(),
+  })
+  .passthrough();
+
+export const triggerCronCallbackPayloadSchema = triggerLoopCallbackPayloadSchema
+  .extend({
+    timezone: z.string(),
+    cronExpression: z.string().optional(),
+  })
+  .passthrough();
+
+/**
+ * Completion callbacks for `automation_triggers` time rows — the trigger-table
+ * counterpart of the schedule callbacks. The poller claims a due trigger by
+ * clearing `next_run_at`; this callback advances the recurrence after the run
+ * finishes and owns the consecutive-failure bookkeeping (reset on success,
+ * increment on failure, auto-disable at the threshold).
+ */
+export const internalCallbacksTriggerContract = c.router({
+  cron: {
+    method: "POST",
+    path: "/api/internal/callbacks/trigger/cron",
+    headers: internalCallbackHeadersSchema,
+    body: internalCallbackBodySchema.extend({
+      payload: triggerCronCallbackPayloadSchema,
+    }),
+    responses: {
+      200: internalCallbackSuccessWithSkippedSchema,
+      400: internalCallbackErrorSchema,
+      401: internalCallbackErrorSchema,
+      404: internalCallbackErrorSchema,
+    },
+    summary: "Handle terminal callbacks for cron/once automation triggers",
+  },
+  loop: {
+    method: "POST",
+    path: "/api/internal/callbacks/trigger/loop",
+    headers: internalCallbackHeadersSchema,
+    body: internalCallbackBodySchema.extend({
+      payload: triggerLoopCallbackPayloadSchema,
+    }),
+    responses: {
+      200: internalCallbackSuccessWithSkippedSchema,
+      400: internalCallbackErrorSchema,
+      401: internalCallbackErrorSchema,
+      404: internalCallbackErrorSchema,
+    },
+    summary: "Handle terminal callbacks for loop automation triggers",
+  },
+});
+
+export type InternalCallbacksTriggerContract =
+  typeof internalCallbacksTriggerContract;
+export type TriggerCronCallbackPayload = z.infer<
+  typeof triggerCronCallbackPayloadSchema
+>;
+export type TriggerLoopCallbackPayload = z.infer<
+  typeof triggerLoopCallbackPayloadSchema
+>;


### PR DESCRIPTION
## Summary

Phase 1 of the #16847 cutover plan — fixes blocker **A1** and implements decision **B1** (restore callback semantics for 1:1 live parity) from the [status review](https://github.com/vm0-ai/vm0/issues/16847#issuecomment-4666020631).

The dormant trigger poller (`executeDueTriggers$`, #16852) advanced `next_run_at` inside the optimistic-lock claim and attached no completion callback. Two consequences:

- **`consecutive_failures` never reset on success** — 3 transient pre-run failures accumulated over any time span would permanently disable a trigger.
- **Run failures were never counted** — a run that was created but then failed never incremented the counter, so a permanently-failing cron would never auto-disable and would burn credits forever.

It also changed recurrence semantics vs live (claim-time advance instead of completion-time advance), which we decided not to ship at cutover (B1).

## Changes

- **New contract + route `/api/internal/callbacks/trigger/{cron,loop}`** — mirrors `internal-callbacks-schedule` 1:1, keyed on `trigger_id`: completed → reset `consecutive_failures` to 0; failed → increment, auto-disable at 3; recurrence advances from completion time via the existing `TimeTrigger.advanceAfterCompletion` (cron from the expression captured at dispatch, loop from the current DB interval).
- **`evaluateTrigger` claim reverted to live semantics** — clears `next_run_at`, stamps `lastRunAt`, disables `once` triggers; no inline advance.
- **`DefaultInterpreter`** — `automation-time` fires now attach the trigger-keyed reschedule callback (counterpart of `buildScheduleCallbacks`), plus the existing chat callback.

`once` parity note: a once trigger is disabled at claim, so its completion callback lands in the disabled-skip branch — identical to the live schedule path.

No live-execution change: the trigger poller remains dormant (not wired to the live cron route).

## Tests

- New `internal-callbacks-trigger.test.ts` mirroring the schedule callback suite (signature rejection, invalid payloads, progress skip, loop/cron advance, failure counters, auto-disable at 3, deleted/disabled skip).
- `trigger-poller.test.ts` updated to the claim-clears-next-run semantics and asserts the reschedule + chat callbacks are attached to created runs.

Part of #16847.

🤖 Generated with [Claude Code](https://claude.com/claude-code)