### PR TITLE
fix: surface claude rate limits in integrations

### DIFF
--- a/turbo/apps/api/src/signals/services/__tests__/integration-run-errors.service.test.ts
+++ b/turbo/apps/api/src/signals/services/__tests__/integration-run-errors.service.test.ts
@@ -1,0 +1,26 @@
+import { createStore } from "ccstate";
+import { describe, expect, it } from "vitest";
+
+import { formatIntegrationRunError$ } from "../integration-run-errors.service";
+
+const store = createStore();
+
+describe("formatIntegrationRunError$", () => {
+  it("preserves Claude Code rate limit messages for integration dispatchers", async () => {
+    const message =
+      "Claude Code rate limit reached. Your 5-hour limit has been reached; resets 12:50pm (Asia/Shanghai).";
+
+    await expect(
+      store.set(
+        formatIntegrationRunError$,
+        {
+          orgId: "org_integration_rate_limit",
+          userId: "user_integration_rate_limit",
+          code: "UNKNOWN",
+          message,
+        },
+        new AbortController().signal,
+      ),
+    ).resolves.toBe(message);
+  });
+});

--- a/turbo/packages/api-contracts/src/contracts/__tests__/errors.test.ts
+++ b/turbo/packages/api-contracts/src/contracts/__tests__/errors.test.ts
@@ -90,6 +90,45 @@ describe("formatRunErrorForExternalSurface", () => {
     ).toBe(weeklyLimit);
   });
 
+  it("shows Claude Code five-hour rate limit errors verbatim", () => {
+    const rateLimit =
+      "Claude Code rate limit reached. Your 5-hour limit has been reached; resets 12:50pm (Asia/Shanghai).";
+    expect(
+      formatRunErrorForExternalSurface({
+        code: "UNKNOWN",
+        message: rateLimit,
+      }),
+    ).toBe(rateLimit);
+    expect(isActionableRunError(rateLimit)).toBe(true);
+    expect(isGenericRunErrorForDisplay(rateLimit)).toBe(false);
+  });
+
+  it("keeps unrelated rate limit errors generic", () => {
+    const unrelatedRateLimit =
+      "GitHub API rate limit exceeded while fetching repository context.";
+    expect(
+      formatRunErrorForExternalSurface({
+        code: "UNKNOWN",
+        message: unrelatedRateLimit,
+      }),
+    ).toBe(CHAT_RUN_TRANSIENT_ERROR_MESSAGE);
+    expect(isActionableRunError(unrelatedRateLimit)).toBe(false);
+    expect(isGenericRunErrorForDisplay(unrelatedRateLimit)).toBe(true);
+  });
+
+  it("keeps unrelated Claude limit errors generic", () => {
+    const unrelatedClaudeLimit =
+      "Claude process memory limit reached while preparing the sandbox.";
+    expect(
+      formatRunErrorForExternalSurface({
+        code: "UNKNOWN",
+        message: unrelatedClaudeLimit,
+      }),
+    ).toBe(CHAT_RUN_TRANSIENT_ERROR_MESSAGE);
+    expect(isActionableRunError(unrelatedClaudeLimit)).toBe(false);
+    expect(isGenericRunErrorForDisplay(unrelatedClaudeLimit)).toBe(true);
+  });
+
   it("falls back to the Web generic message for unallowlisted errors", () => {
     expect(
       formatRunErrorForExternalSurface({

--- a/turbo/packages/api-contracts/src/contracts/errors.ts
+++ b/turbo/packages/api-contracts/src/contracts/errors.ts
@@ -122,6 +122,20 @@ export const CHAT_RUN_TRANSIENT_ERROR_MESSAGE =
 const CODEX_OAUTH_RECONNECT_REQUIRED_MESSAGE =
   "ChatGPT session needs reconnection. Reconnect ChatGPT (Codex) in Model Providers, then retry.";
 
+const CLAUDE_CODE_LIMIT_SNIPPETS = [
+  "usage limit",
+  "usage_limit",
+  "usage-limit",
+  "rate limit",
+  "rate_limit",
+  "rate-limit",
+  "subscription limit",
+  "ai limit reached",
+  "code limit reached",
+  "5-hour limit",
+  "five-hour limit",
+] as const;
+
 const codexOAuthReconnectRequiredRunErrorBodySchema = z.object({
   error: z.literal("TOKEN_REFRESH_FAILED"),
   connectors: z.tuple([z.literal("codex-oauth-token")]),
@@ -275,9 +289,21 @@ function hasActionableRunErrorSnippet(errorMessage: string): boolean {
   });
 }
 
+function isClaudeCodeLimitError(errorMessage: string): boolean {
+  const normalized = errorMessage.toLowerCase();
+  if (!normalized.includes("claude")) {
+    return false;
+  }
+
+  return CLAUDE_CODE_LIMIT_SNIPPETS.some((snippet) => {
+    return normalized.includes(snippet);
+  });
+}
+
 export function isActionableRunError(errorMessage: string): boolean {
   return (
     isCodexOAuthReconnectRequiredRunError(errorMessage) ||
+    isClaudeCodeLimitError(errorMessage) ||
     hasActionableRunErrorSnippet(errorMessage)
   );
 }
@@ -326,7 +352,7 @@ export function formatRunErrorForExternalSurface(params: {
     return CODEX_OAUTH_RECONNECT_REQUIRED_MESSAGE;
   }
 
-  return hasActionableRunErrorSnippet(errorMessage)
+  return isActionableRunError(errorMessage)
     ? errorMessage
     : CHAT_RUN_TRANSIENT_ERROR_MESSAGE;
 }


### PR DESCRIPTION
## Summary
- Preserve Claude/Claude Code usage, rate, subscription, and five-hour limit messages through the shared run-error formatter.
- Keep unrelated rate-limit and Claude internal-limit errors on the generic fallback.
- Add API integration error service coverage so Slack, Telegram, GitHub, AgentPhone, and other integration dispatchers that call the shared formatter get the same behavior.

Fixes #15357.

## Test plan
- `pnpm -F @vm0/api-contracts exec vitest run src/contracts/__tests__/errors.test.ts`
- `pnpm -F api exec vitest run src/signals/services/__tests__/integration-run-errors.service.test.ts`
- `pnpm format`
- `pnpm -F @vm0/api-contracts lint`
- `pnpm -F @vm0/api-contracts check-types`
- `pnpm -F api lint`
- `pnpm -F api check-types`
- pre-commit: `pnpm knip`, full `pnpm check-types`