### PR TITLE
fix: escape json-ld script payloads

### DIFF
--- a/turbo/apps/web/app/[locale]/blog/page.tsx
+++ b/turbo/apps/web/app/[locale]/blog/page.tsx
@@ -11,6 +11,7 @@ import {
 import { BlogContent } from "../../components/blog";
 import { Footer } from "../../components/Footer";
 import { isBlogEnabled } from "../../../src/env";
+import { serializeJsonLd } from "../../../src/lib/json-ld";
 import type { Locale } from "../../../i18n";
 import { buildLocaleAlternates } from "../../lib/seo/alternates";
 
@@ -97,7 +98,7 @@ export default async function BlogPage({ params }: BlogPageProps) {
       <script
         type="application/ld+json"
         suppressHydrationWarning
-        dangerouslySetInnerHTML={{ __html: JSON.stringify(breadcrumbJsonLd) }}
+        dangerouslySetInnerHTML={{ __html: serializeJsonLd(breadcrumbJsonLd) }}
       />
       <Suspense
         fallback={

--- a/turbo/apps/web/app/[locale]/docs/[...slug]/page.tsx
+++ b/turbo/apps/web/app/[locale]/docs/[...slug]/page.tsx
@@ -17,6 +17,7 @@ import {
 import { buildLocaleAlternates } from "../../../lib/seo/alternates";
 import { locales, type Locale } from "../../../../i18n";
 import { Link } from "../../../../navigation";
+import { serializeJsonLd } from "../../../../src/lib/json-ld";
 
 interface DocsPageProps {
   params: Promise<{ locale: string; slug: string[] }>;
@@ -166,12 +167,12 @@ export default async function DocsPage({
       <script
         type="application/ld+json"
         suppressHydrationWarning
-        dangerouslySetInnerHTML={{ __html: JSON.stringify(breadcrumbJsonLd) }}
+        dangerouslySetInnerHTML={{ __html: serializeJsonLd(breadcrumbJsonLd) }}
       />
       <script
         type="application/ld+json"
         suppressHydrationWarning
-        dangerouslySetInnerHTML={{ __html: JSON.stringify(articleJsonLd) }}
+        dangerouslySetInnerHTML={{ __html: serializeJsonLd(articleJsonLd) }}
       />
       <Particles />
       <DocsShell

--- a/turbo/apps/web/app/[locale]/docs/page.tsx
+++ b/turbo/apps/web/app/[locale]/docs/page.tsx
@@ -13,6 +13,7 @@ import {
 import { buildLocaleAlternates } from "../../lib/seo/alternates";
 import { type Locale } from "../../../i18n";
 import { Link } from "../../../navigation";
+import { serializeJsonLd } from "../../../src/lib/json-ld";
 
 const BASE_URL = "https://www.vm0.ai";
 
@@ -100,7 +101,7 @@ export default async function DocsIndexPage({
       <script
         type="application/ld+json"
         suppressHydrationWarning
-        dangerouslySetInnerHTML={{ __html: JSON.stringify(breadcrumbJsonLd) }}
+        dangerouslySetInnerHTML={{ __html: serializeJsonLd(breadcrumbJsonLd) }}
       />
       <Particles />
       <DocsShell navigation={navigation} homeLabel={t("home")} draft={draft}>

--- a/turbo/apps/web/app/[locale]/security/page.tsx
+++ b/turbo/apps/web/app/[locale]/security/page.tsx
@@ -3,6 +3,7 @@ import { getTranslations } from "next-intl/server";
 import Script from "next/script";
 import { SecurityPage } from "./SecurityPage";
 import type { Locale } from "../../../i18n";
+import { serializeJsonLd } from "../../../src/lib/json-ld";
 import { buildLocaleAlternates } from "../../lib/seo/alternates";
 
 const BASE_URL = "https://www.vm0.ai";
@@ -75,7 +76,7 @@ export default async function SecurityPageServer({ params }: PageProps) {
       <Script
         id="json-ld-breadcrumb"
         type="application/ld+json"
-        dangerouslySetInnerHTML={{ __html: JSON.stringify(breadcrumbJsonLd) }}
+        dangerouslySetInnerHTML={{ __html: serializeJsonLd(breadcrumbJsonLd) }}
       />
       <SecurityPage />
     </>

--- a/turbo/apps/web/app/layout.tsx
+++ b/turbo/apps/web/app/layout.tsx
@@ -14,6 +14,7 @@ import {
   getClerkPublishableKey,
 } from "../src/lib/shared/clerk-config";
 import { getAllowedRedirectOrigins, getAppUrl } from "../src/lib/zero/url";
+import { serializeJsonLd } from "../src/lib/json-ld";
 import { SafeGoogleOneTap } from "./components/SafeGoogleOneTap";
 import { ThemeProvider } from "./components/ThemeProvider";
 import { AttributionCapture } from "./components/AttributionCapture";
@@ -255,7 +256,7 @@ export default async function RootLayout({
             type="application/ld+json"
             suppressHydrationWarning
             dangerouslySetInnerHTML={{
-              __html: JSON.stringify({
+              __html: serializeJsonLd({
                 "@context": "https://schema.org",
                 "@type": "Organization",
                 name: "VM0",
@@ -282,7 +283,7 @@ export default async function RootLayout({
             type="application/ld+json"
             suppressHydrationWarning
             dangerouslySetInnerHTML={{
-              __html: JSON.stringify({
+              __html: serializeJsonLd({
                 "@context": "https://schema.org",
                 "@type": "WebSite",
                 name: "VM0",
@@ -296,7 +297,7 @@ export default async function RootLayout({
             type="application/ld+json"
             suppressHydrationWarning
             dangerouslySetInnerHTML={{
-              __html: JSON.stringify({
+              __html: serializeJsonLd({
                 "@context": "https://schema.org",
                 "@type": "SoftwareApplication",
                 name: "VM0",

--- a/turbo/apps/web/src/__tests__/json-ld.test.ts
+++ b/turbo/apps/web/src/__tests__/json-ld.test.ts
@@ -1,0 +1,44 @@
+import { describe, expect, it } from "vitest";
+import { serializeJsonLd } from "../lib/json-ld";
+
+describe("serializeJsonLd", () => {
+  it("escapes script-breaking and HTML-significant characters", () => {
+    const lineSeparator = String.fromCharCode(0x2028);
+    const paragraphSeparator = String.fromCharCode(0x2029);
+    const payload = {
+      "@context": "https://schema.org",
+      "@type": "BreadcrumbList",
+      name: `</script><img src=x onerror=alert(1)> & ${lineSeparator}${paragraphSeparator}`,
+    };
+
+    const serialized = serializeJsonLd(payload);
+
+    expect(serialized).toContain("\\u003c/script\\u003e");
+    expect(serialized).toContain("\\u003cimg src=x onerror=alert(1)\\u003e");
+    expect(serialized).toContain("\\u0026");
+    expect(serialized).toContain("\\u2028");
+    expect(serialized).toContain("\\u2029");
+    expect(serialized).not.toContain("</script>");
+    expect(serialized).not.toContain("<");
+    expect(serialized).not.toContain(">");
+    expect(serialized).not.toContain("&");
+    expect(serialized).not.toContain(lineSeparator);
+    expect(serialized).not.toContain(paragraphSeparator);
+    expect(JSON.parse(serialized)).toStrictEqual(payload);
+  });
+
+  it("keeps existing structured data semantics unchanged", () => {
+    const payload = {
+      "@context": "https://schema.org",
+      "@type": "Organization",
+      name: "VM0",
+      sameAs: ["https://github.com/vm0-ai/vm0"],
+      contactPoint: {
+        "@type": "ContactPoint",
+        email: "support@vm0.ai",
+      },
+    };
+
+    expect(serializeJsonLd(payload)).toBe(JSON.stringify(payload));
+  });
+});

--- a/turbo/apps/web/src/lib/json-ld.ts
+++ b/turbo/apps/web/src/lib/json-ld.ts
@@ -1,0 +1,29 @@
+const JSON_LD_SCRIPT_ESCAPE_PATTERN = /[<>&\u2028\u2029]/gu;
+
+function escapeJsonLdScriptCharacter(character: string): string {
+  switch (character) {
+    case "<":
+      return "\\u003c";
+    case ">":
+      return "\\u003e";
+    case "&":
+      return "\\u0026";
+    case "\u2028":
+      return "\\u2028";
+    case "\u2029":
+      return "\\u2029";
+    default:
+      return character;
+  }
+}
+
+export function serializeJsonLd(value: unknown): string {
+  const json = JSON.stringify(value);
+  if (json === undefined) {
+    throw new TypeError("JSON-LD payload must be JSON-serializable");
+  }
+  return json.replace(
+    JSON_LD_SCRIPT_ESCAPE_PATTERN,
+    escapeJsonLdScriptCharacter,
+  );
+}


### PR DESCRIPTION
## Summary
- add a shared JSON-LD serializer for script bodies
- escape script-breaking and HTML-significant characters before assigning JSON-LD via dangerouslySetInnerHTML
- replace JSON-LD dangerous HTML call sites in docs, blog, security, and root layout

## Validation
- `pnpm -F web exec vitest run src/__tests__/json-ld.test.ts`
- `pnpm prettier --write --ignore-unknown 'apps/web/app/[locale]/blog/page.tsx' 'apps/web/app/[locale]/docs/[...slug]/page.tsx' 'apps/web/app/[locale]/docs/page.tsx' 'apps/web/app/[locale]/security/page.tsx' apps/web/app/layout.tsx apps/web/src/lib/json-ld.ts apps/web/src/__tests__/json-ld.test.ts`
- `pnpm -F web lint`
- `pnpm -F web check-types`
- pre-commit: `pnpm knip --cache`, `pnpm check-types`

Closes #16367