### PR TITLE
feat: add desktop auth startup loading state

### DIFF
--- a/turbo/apps/desktop/src/renderer/App.tsx
+++ b/turbo/apps/desktop/src/renderer/App.tsx
@@ -9,6 +9,7 @@ import {
   IconCode,
   IconExternalLink,
   IconHistory,
+  IconLoader2,
   IconLogout,
   IconMaximize,
   IconPhoto,
@@ -1105,6 +1106,20 @@ function UnsupportedPanel({ platform }: { readonly platform: string }) {
   );
 }
 
+function StartupLoadingScreen() {
+  return (
+    <section className="startup-loading" aria-live="polite">
+      <div className="startup-loading-mark" aria-hidden="true">
+        <IconLoader2 size={22} />
+      </div>
+      <div className="startup-loading-copy">
+        <h2>Preparing Computer Use</h2>
+        <p>Checking your Zero account and workspace before setup begins.</p>
+      </div>
+    </section>
+  );
+}
+
 function ComputerUseContent({
   authLoading,
   authState,
@@ -1143,6 +1158,7 @@ function ComputerUsePage() {
   const authLoadable = useLastLoadable(desktopAuthData$);
   const authState = authLoadable.state === "hasData" ? authLoadable.data : null;
   const authLoading = authLoadable.state === "loading";
+  const authInitialLoading = authLoading && authState === null;
 
   if (!hasDesktopComputerUseBridge()) {
     return (
@@ -1153,6 +1169,10 @@ function ComputerUsePage() {
   }
 
   if (loadable.state === "hasData") {
+    if (authInitialLoading) {
+      return <StartupLoadingScreen />;
+    }
+
     return (
       <ComputerUseContent
         authLoading={authLoading}

--- a/turbo/apps/desktop/src/renderer/styles.css
+++ b/turbo/apps/desktop/src/renderer/styles.css
@@ -766,6 +766,57 @@ button {
   line-height: 1.45;
 }
 
+.startup-loading {
+  min-height: min(460px, calc(100vh - 144px));
+  display: grid;
+  place-items: center;
+  gap: 14px;
+  text-align: center;
+}
+
+.startup-loading-mark {
+  width: 42px;
+  height: 42px;
+  border: 1px solid rgba(37, 99, 235, 0.16);
+  border-radius: 50%;
+  display: grid;
+  place-items: center;
+  color: #2563eb;
+  background: #eff8ff;
+}
+
+.startup-loading-mark svg {
+  animation: startup-loading-spin 900ms linear infinite;
+}
+
+.startup-loading-copy {
+  max-width: 360px;
+  display: grid;
+  gap: 6px;
+}
+
+.startup-loading-copy h2 {
+  margin: 0;
+  color: #202631;
+  font-size: 18px;
+  line-height: 1.2;
+  font-weight: 700;
+  letter-spacing: 0;
+}
+
+.startup-loading-copy p {
+  margin: 0;
+  color: #667085;
+  font-size: 13px;
+  line-height: 1.45;
+}
+
+@keyframes startup-loading-spin {
+  to {
+    transform: rotate(360deg);
+  }
+}
+
 .screenshot-lightbox {
   position: fixed;
   inset: 0;


### PR DESCRIPTION
## Summary
- show a standalone startup loading state while the desktop auth state is still being checked
- keep the Account and Permissions setup cards hidden until auth state resolves
- add a small animated loading treatment for the startup check

## Copy alternatives
- Preparing Computer Use / Checking your Zero account and workspace before setup begins.
- Checking your Zero account / We are looking for an existing session before showing setup steps.
- Getting Computer Use ready / Verifying your account and workspace before continuing.
- Loading your desktop session / Checking whether this Mac is already connected to Zero.

## Tests
- pnpm -F @vm0/desktop check-types
- pnpm -F @vm0/desktop lint
- pnpm -F @vm0/desktop build:renderer
- pnpm format