### PR TITLE
feat: add hosted site content access

### DIFF
--- a/turbo/apps/api/src/signals/external/s3.ts
+++ b/turbo/apps/api/src/signals/external/s3.ts
@@ -300,8 +300,24 @@ export function generatePresignedGetUrl(
   filename?: string,
   usePublicEndpoint = false,
 ): Computed<Promise<string>> {
+  return generatePresignedGetUrlWithClient(
+    s3ClientForBucket(bucket, usePublicEndpoint),
+    bucket,
+    key,
+    expiresIn,
+    filename,
+  );
+}
+
+function generatePresignedGetUrlWithClient(
+  client$: Computed<S3Client>,
+  bucket: string,
+  key: string,
+  expiresIn: number,
+  filename?: string,
+): Computed<Promise<string>> {
   return computed((get): Promise<string> => {
-    const client = get(s3ClientForBucket(bucket, usePublicEndpoint));
+    const client = get(client$);
     const command = new GetObjectCommand({
       Bucket: bucket,
       Key: key,

--- a/turbo/apps/api/src/signals/routes/__tests__/zero-host.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/zero-host.test.ts
@@ -576,6 +576,134 @@ describe("POST /api/zero/host/deployments/:deploymentId/complete", () => {
   });
 });
 
+describe("GET /api/zero/host/sites/:publicSlug/files", () => {
+  it("returns active file metadata for an owned hosted site", async () => {
+    const fixture = await seedHostedSiteFixture();
+    mocks.clerk.session(fixture.userId, fixture.orgId);
+
+    const client = setupApp({ context })(zeroHostContract);
+    const prepared = await accept(
+      client.prepare({
+        headers: { authorization: "Bearer clerk-session" },
+        body: {
+          site: "demo-site",
+          slugSuffix: "release-01",
+          spaFallback: true,
+          files: validFiles(),
+        },
+      }),
+      [200],
+    );
+
+    const prefix = `sites/${prepared.body.publicSlug}/deployments/${prepared.body.deploymentId}`;
+    mockUploadedKeys([
+      `${prefix}/index.html`,
+      `${prefix}/assets/index-a1b2c3d4.js`,
+    ]);
+    await accept(
+      client.complete({
+        params: { deploymentId: prepared.body.deploymentId },
+        headers: { authorization: "Bearer clerk-session" },
+        body: {},
+      }),
+      [200],
+    );
+
+    context.mocks.s3.getSignedUrl.mockClear();
+
+    const response = await accept(
+      client.files({
+        params: { publicSlug: prepared.body.publicSlug },
+        headers: { authorization: "Bearer clerk-session" },
+      }),
+      [200],
+    );
+
+    expect(response.body).toMatchObject({
+      siteId: prepared.body.siteId,
+      deploymentId: prepared.body.deploymentId,
+      publicSlug: prepared.body.publicSlug,
+      url: prepared.body.url,
+      fileCount: 2,
+      size: 540,
+    });
+    expect(
+      response.body.files.map((file) => {
+        return {
+          path: file.path,
+          size: file.size,
+          contentType: file.contentType,
+        };
+      }),
+    ).toStrictEqual([
+      {
+        path: "/assets/index-a1b2c3d4.js",
+        size: 420,
+        contentType: "application/javascript; charset=utf-8",
+      },
+      {
+        path: "/index.html",
+        size: 120,
+        contentType: "text/html; charset=utf-8",
+      },
+    ]);
+    expect(context.mocks.s3.getSignedUrl).not.toHaveBeenCalled();
+  });
+
+  it("returns 404 for a hosted site owned by another org", async () => {
+    const owner = await seedHostedSiteFixture();
+    mocks.clerk.session(owner.userId, owner.orgId);
+
+    const client = setupApp({ context })(zeroHostContract);
+    const prepared = await accept(
+      client.prepare({
+        headers: { authorization: "Bearer clerk-session" },
+        body: {
+          site: "private-site",
+          slugSuffix: "release-01",
+          spaFallback: false,
+          files: validFiles(),
+        },
+      }),
+      [200],
+    );
+
+    const prefix = `sites/${prepared.body.publicSlug}/deployments/${prepared.body.deploymentId}`;
+    mockUploadedKeys([
+      `${prefix}/index.html`,
+      `${prefix}/assets/index-a1b2c3d4.js`,
+    ]);
+    await accept(
+      client.complete({
+        params: { deploymentId: prepared.body.deploymentId },
+        headers: { authorization: "Bearer clerk-session" },
+        body: {},
+      }),
+      [200],
+    );
+
+    context.mocks.s3.getSignedUrl.mockClear();
+    const other = await seedHostedSiteFixture();
+    mocks.clerk.session(other.userId, other.orgId);
+
+    const response = await accept(
+      client.files({
+        params: { publicSlug: prepared.body.publicSlug },
+        headers: { authorization: "Bearer clerk-session" },
+      }),
+      [404],
+    );
+
+    expect(response.body).toStrictEqual({
+      error: {
+        message: "Hosted site not found",
+        code: "NOT_FOUND",
+      },
+    });
+    expect(context.mocks.s3.getSignedUrl).not.toHaveBeenCalled();
+  });
+});
+
 describe("POST /api/zero/host/presentation-html/redeploy", () => {
   it("redeploys presentation HTML to the same hosted site URL", async () => {
     const fixture = await seedHostedSiteFixture();

--- a/turbo/apps/api/src/signals/routes/zero-host.ts
+++ b/turbo/apps/api/src/signals/routes/zero-host.ts
@@ -7,6 +7,7 @@ import { bodyResultOf, pathParamsOf } from "../context/request";
 import {
   completeHostedSiteDeployment$,
   generatePresentationSpeakerNotes$,
+  getHostedSiteFiles$,
   prepareHostedSiteDeployment$,
   redeployPresentationHtml$,
 } from "../services/zero-host.service";
@@ -64,6 +65,7 @@ const prepareInner$ = command(async ({ get, set }, signal: AbortSignal) => {
 });
 
 const completeParams$ = pathParamsOf(zeroHostContract.complete);
+const filesParams$ = pathParamsOf(zeroHostContract.files);
 const redeployPresentationHtmlBody$ = bodyResultOf(
   zeroHostContract.redeployPresentationHtml,
 );
@@ -100,6 +102,30 @@ const completeInner$ = command(async ({ get, set }, signal: AbortSignal) => {
   }
   if (result.status === "config_error") {
     return internalError(result.message);
+  }
+
+  return { status: 200 as const, body: result.body };
+});
+
+const filesInner$ = command(async ({ get, set }, signal: AbortSignal) => {
+  const auth = get(organizationAuthContext$);
+  const params = get(filesParams$);
+
+  const result = await set(
+    getHostedSiteFiles$,
+    {
+      orgId: auth.orgId,
+      publicSlug: params.publicSlug,
+    },
+    signal,
+  );
+  signal.throwIfAborted();
+
+  if (result.status === "conflict") {
+    return conflict(result.message);
+  }
+  if (result.status === "not_found") {
+    return notFound(result.message);
   }
 
   return { status: 200 as const, body: result.body };
@@ -202,6 +228,17 @@ export const zeroHostRoutes: readonly RouteEntry[] = [
         missingOrganizationStatus: 401,
       },
       completeInner$,
+    ),
+  },
+  {
+    route: zeroHostContract.files,
+    handler: authRoute(
+      {
+        requiredCapability: "host:read",
+        requireOrganization: true,
+        missingOrganizationStatus: 401,
+      },
+      filesInner$,
     ),
   },
   {

--- a/turbo/apps/api/src/signals/services/zero-host.service.ts
+++ b/turbo/apps/api/src/signals/services/zero-host.service.ts
@@ -4,6 +4,7 @@ import { command } from "ccstate";
 import {
   type GeneratePresentationSpeakerNotesRequest,
   type HostedArtifactKind,
+  type HostedSiteFilesResponse,
   type HostedSitePrepareRequest,
   type HostedSiteRedeployPresentationHtmlRequest,
   type PresentationSpeakerNotesPatch,
@@ -58,6 +59,11 @@ interface GeneratePresentationSpeakerNotesArgs {
   readonly body: GeneratePresentationSpeakerNotesRequest;
 }
 
+interface GetHostedSiteFilesArgs {
+  readonly orgId: string;
+  readonly publicSlug: string;
+}
+
 type PrepareDeploymentResult =
   | {
       readonly status: "ok";
@@ -98,6 +104,14 @@ type GeneratePresentationSpeakerNotesResult =
   | { readonly status: "ok"; readonly body: PresentationSpeakerNotesPatch }
   | { readonly status: "bad_request"; readonly message: string }
   | { readonly status: "config_error"; readonly message: string };
+
+type GetHostedSiteFilesResult =
+  | {
+      readonly status: "ok";
+      readonly body: HostedSiteFilesResponse;
+    }
+  | { readonly status: "not_found"; readonly message: string }
+  | { readonly status: "conflict"; readonly message: string };
 
 type RedeployPresentationTargetResult =
   | {
@@ -772,6 +786,82 @@ export const completeHostedSiteDeployment$ = command(
         publicSlug: deployment.manifest.publicSlug,
         url: deployment.url,
         status: "ready",
+      },
+    };
+  },
+);
+
+export const getHostedSiteFiles$ = command(
+  async (
+    { set },
+    args: GetHostedSiteFilesArgs,
+    signal: AbortSignal,
+  ): Promise<GetHostedSiteFilesResult> => {
+    const writeDb = set(writeDb$);
+    const [site] = await writeDb
+      .select()
+      .from(hostedSites)
+      .where(
+        and(
+          eq(hostedSites.publicSlug, args.publicSlug),
+          eq(hostedSites.orgId, args.orgId),
+          isNull(hostedSites.deletedAt),
+        ),
+      )
+      .limit(1);
+    signal.throwIfAborted();
+
+    if (!site) {
+      return { status: "not_found", message: "Hosted site not found" };
+    }
+    if (!site.activeDeploymentId) {
+      return {
+        status: "conflict",
+        message: "Hosted site has no active deployment",
+      };
+    }
+
+    const [deployment] = await writeDb
+      .select()
+      .from(hostedDeployments)
+      .where(
+        and(
+          eq(hostedDeployments.id, site.activeDeploymentId),
+          eq(hostedDeployments.siteId, site.id),
+          eq(hostedDeployments.orgId, args.orgId),
+        ),
+      )
+      .limit(1);
+    signal.throwIfAborted();
+
+    if (!deployment) {
+      return {
+        status: "not_found",
+        message: "Active hosted deployment not found",
+      };
+    }
+    if (deployment.status !== "ready") {
+      return {
+        status: "conflict",
+        message: `Hosted deployment is ${deployment.status}`,
+      };
+    }
+
+    const files = Object.values(deployment.manifest.files).sort((a, b) => {
+      return a.path.localeCompare(b.path);
+    });
+    signal.throwIfAborted();
+
+    return {
+      status: "ok",
+      body: {
+        siteId: site.id,
+        deploymentId: deployment.id,
+        publicSlug: site.publicSlug,
+        url: deployment.url,
+        fileCount: deployment.fileCount,
+        size: deployment.sizeBytes,
+        files,
       },
     };
   },

--- a/turbo/apps/cli/src/__tests__/zero-capability-visibility.test.ts
+++ b/turbo/apps/cli/src/__tests__/zero-capability-visibility.test.ts
@@ -361,6 +361,19 @@ describe("registerZeroCommands", () => {
     expect(visibleCommandNames(prog)).toContain("whoami");
   });
 
+  it("should show host when host:read capability is present", () => {
+    const token = buildZeroToken({
+      scope: "zero",
+      capabilities: ["host:read"],
+    });
+    vi.stubEnv("ZERO_TOKEN", token);
+
+    const prog = buildProgram();
+
+    expect(visibleCommandNames(prog)).toContain("host");
+    expect(visibleCommandNames(prog)).toContain("whoami");
+  });
+
   it("should show generate when file capabilities are missing", () => {
     const token = buildZeroToken({
       scope: "zero",
@@ -526,6 +539,20 @@ describe("registerZeroCommands", () => {
     );
   });
 
+  it("should show the hosted site clone help example when host:read capability is present", () => {
+    const token = buildZeroToken({
+      scope: "zero",
+      capabilities: ["host:read"],
+    });
+
+    expect(buildZeroHelpText(decodeZeroTokenPayload(token))).toContain(
+      "Clone hosted site?",
+    );
+    expect(buildZeroHelpText(decodeZeroTokenPayload(token))).not.toContain(
+      "Host a static site?",
+    );
+  });
+
   it("should show the website help example", () => {
     const token = buildZeroToken({
       scope: "zero",
@@ -557,6 +584,9 @@ describe("registerZeroCommands", () => {
 
     expect(buildZeroHelpText(decodeZeroTokenPayload(token))).not.toContain(
       "Host a static site?",
+    );
+    expect(buildZeroHelpText(decodeZeroTokenPayload(token))).not.toContain(
+      "Clone hosted site?",
     );
   });
 

--- a/turbo/apps/cli/src/commands/zero/host/__tests__/clone.test.ts
+++ b/turbo/apps/cli/src/commands/zero/host/__tests__/clone.test.ts
@@ -1,0 +1,217 @@
+import { createHash } from "node:crypto";
+import {
+  existsSync,
+  mkdirSync,
+  readFileSync,
+  rmSync,
+  writeFileSync,
+} from "node:fs";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+
+import chalk from "chalk";
+import { http, HttpResponse } from "msw";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import { server } from "../../../../mocks/server";
+import { zeroHostCommand } from "../index";
+
+const FILES_URL = "http://localhost:3000/api/zero/host/sites/:publicSlug/files";
+const HOSTED_SITE_URL =
+  "https://demo-site-a1b2c3d4-release-01.sites.example.com";
+
+function sha256(bytes: Buffer): string {
+  return createHash("sha256").update(bytes).digest("hex");
+}
+
+describe("zero host clone command", () => {
+  const mockExit = vi.spyOn(process, "exit").mockImplementation((() => {
+    throw new Error("process.exit called");
+  }) as never);
+  const mockConsoleLog = vi.spyOn(console, "log").mockImplementation(() => {});
+  const mockConsoleError = vi
+    .spyOn(console, "error")
+    .mockImplementation(() => {});
+
+  let tempDir: string;
+
+  beforeEach(() => {
+    chalk.level = 0;
+    vi.stubEnv("VM0_API_URL", "http://localhost:3000");
+    vi.stubEnv("VM0_TOKEN", "test-token");
+    tempDir = join(tmpdir(), `zero-host-clone-${Date.now()}`);
+    mkdirSync(tempDir, { recursive: true });
+  });
+
+  afterEach(() => {
+    rmSync(tempDir, { recursive: true, force: true });
+    mockExit.mockClear();
+    mockConsoleLog.mockClear();
+    mockConsoleError.mockClear();
+    vi.unstubAllEnvs();
+  });
+
+  it("downloads hosted site files to the destination directory", async () => {
+    const index = Buffer.from("<!doctype html><h1>Hello</h1>");
+    const script = Buffer.from("console.log('hello');");
+    const destination = join(tempDir, "site");
+
+    server.use(
+      http.get(FILES_URL, ({ params, request }) => {
+        expect(params.publicSlug).toBe("demo-site-a1b2c3d4-release-01");
+        expect(request.headers.get("authorization")).toBe("Bearer test-token");
+        return HttpResponse.json({
+          siteId: "00000000-0000-4000-8000-000000000001",
+          deploymentId: "00000000-0000-4000-8000-000000000002",
+          publicSlug: "demo-site-a1b2c3d4-release-01",
+          url: HOSTED_SITE_URL,
+          fileCount: 2,
+          size: index.byteLength + script.byteLength,
+          files: [
+            {
+              path: "/index.html",
+              size: index.byteLength,
+              sha256: sha256(index),
+              contentType: "text/html; charset=utf-8",
+            },
+            {
+              path: "/assets/app.js",
+              size: script.byteLength,
+              sha256: sha256(script),
+              contentType: "application/javascript; charset=utf-8",
+              immutable: true,
+            },
+          ],
+        });
+      }),
+      http.get(`${HOSTED_SITE_URL}/index.html`, () => {
+        return new HttpResponse(index);
+      }),
+      http.get(`${HOSTED_SITE_URL}/assets/app.js`, () => {
+        return new HttpResponse(script);
+      }),
+    );
+
+    await zeroHostCommand.parseAsync([
+      "node",
+      "cli",
+      "clone",
+      HOSTED_SITE_URL,
+      destination,
+      "--json",
+    ]);
+
+    expect(readFileSync(join(destination, "index.html")).equals(index)).toBe(
+      true,
+    );
+    expect(
+      readFileSync(join(destination, "assets", "app.js")).equals(script),
+    ).toBe(true);
+
+    const stdout = mockConsoleLog.mock.calls.flat().join("\n");
+    const parsed = JSON.parse(stdout) as Record<string, unknown>;
+    expect(parsed).toMatchObject({
+      publicSlug: "demo-site-a1b2c3d4-release-01",
+      destination,
+      fileCount: 2,
+    });
+  });
+
+  it("uses the public slug as the default destination", async () => {
+    const index = Buffer.from("<!doctype html>");
+
+    server.use(
+      http.get(FILES_URL, () => {
+        return HttpResponse.json({
+          siteId: "00000000-0000-4000-8000-000000000001",
+          deploymentId: "00000000-0000-4000-8000-000000000002",
+          publicSlug: "demo-site-a1b2c3d4-release-01",
+          url: HOSTED_SITE_URL,
+          fileCount: 1,
+          size: index.byteLength,
+          files: [
+            {
+              path: "/index.html",
+              size: index.byteLength,
+              sha256: sha256(index),
+              contentType: "text/html; charset=utf-8",
+            },
+          ],
+        });
+      }),
+      http.get(`${HOSTED_SITE_URL}/index.html`, () => {
+        return new HttpResponse(index);
+      }),
+    );
+
+    const originalCwd = process.cwd();
+    process.chdir(tempDir);
+    try {
+      await zeroHostCommand.parseAsync([
+        "node",
+        "cli",
+        "clone",
+        "demo-site-a1b2c3d4-release-01",
+        "--json",
+      ]);
+    } finally {
+      process.chdir(originalCwd);
+    }
+
+    expect(
+      existsSync(join(tempDir, "demo-site-a1b2c3d4-release-01", "index.html")),
+    ).toBe(true);
+  });
+
+  it("fails when the destination directory is not empty", async () => {
+    const destination = join(tempDir, "existing");
+    mkdirSync(destination, { recursive: true });
+    writeFileSync(join(destination, "file.txt"), "content");
+
+    await expect(async () => {
+      await zeroHostCommand.parseAsync([
+        "node",
+        "cli",
+        "clone",
+        "demo-site-a1b2c3d4-release-01",
+        destination,
+      ]);
+    }).rejects.toThrow("process.exit called");
+
+    expect(mockConsoleError).toHaveBeenCalledWith(
+      expect.stringContaining("is not empty"),
+    );
+    expect(mockExit).toHaveBeenCalledWith(1);
+  });
+
+  it("surfaces hosted site access errors", async () => {
+    server.use(
+      http.get(FILES_URL, () => {
+        return HttpResponse.json(
+          {
+            error: {
+              message: "Hosted site not found",
+              code: "NOT_FOUND",
+            },
+          },
+          { status: 404 },
+        );
+      }),
+    );
+
+    await expect(async () => {
+      await zeroHostCommand.parseAsync([
+        "node",
+        "cli",
+        "clone",
+        "missing-site-a1b2c3d4-release-01",
+        join(tempDir, "missing"),
+      ]);
+    }).rejects.toThrow("process.exit called");
+
+    expect(mockConsoleError).toHaveBeenCalledWith(
+      expect.stringContaining("Hosted site not found"),
+    );
+    expect(mockExit).toHaveBeenCalledWith(1);
+  });
+});

--- a/turbo/apps/cli/src/commands/zero/host/clone.ts
+++ b/turbo/apps/cli/src/commands/zero/host/clone.ts
@@ -1,0 +1,86 @@
+import { Command } from "commander";
+import chalk from "chalk";
+
+import { withErrorHandler } from "../../../lib/command";
+import {
+  cloneHostedSite,
+  publicSlugFromSite,
+} from "../../../lib/host/clone-hosted-site";
+import { formatBytes } from "../../../lib/utils/file-utils";
+
+interface CloneOptions {
+  readonly json?: boolean;
+}
+
+function jsonOption(options: CloneOptions, command: Command): boolean {
+  const parentOptions = command.parent?.opts<CloneOptions>();
+  return Boolean(options.json || parentOptions?.json);
+}
+
+export const cloneHostedSiteCommand = new Command()
+  .name("clone")
+  .description("Clone an owned hosted site's active files to a local directory")
+  .argument("<site>", "Hosted site public slug or URL")
+  .argument("[destination]", "Destination directory (default: public slug)")
+  .option("--json", "Output only the final result as JSON")
+  .addHelpText(
+    "after",
+    `
+Examples:
+  Clone by public slug:  zero host clone my-site-a1b2c3d4-release-01
+  Clone by hosted URL:   zero host clone https://my-site-a1b2c3d4-release-01.sites.example.com ./site
+  Machine readable:      zero host clone my-site-a1b2c3d4-release-01 --json
+
+Notes:
+  - Authenticates via ZERO_TOKEN (requires host:read capability)
+  - Only hosted sites owned by the active org can be cloned
+  - Downloads files from the public hosted site URL and verifies size/hash
+  - The destination directory must be empty or not exist`,
+  )
+  .action(
+    withErrorHandler(
+      async (
+        site: string,
+        destination: string | undefined,
+        options: CloneOptions,
+        command: Command,
+      ) => {
+        const json = jsonOption(options, command);
+        const targetDir = destination ?? publicSlugFromSite(site);
+        const result = await cloneHostedSite({
+          site,
+          destination: targetDir,
+          onProgress: json
+            ? undefined
+            : (progress) => {
+                if (progress.phase === "checking") {
+                  console.log(chalk.dim("Checking hosted site..."));
+                  return;
+                }
+                if (progress.phase === "creating") {
+                  console.log(
+                    chalk.dim(
+                      `Preparing ${progress.fileCount?.toLocaleString() ?? 0} files...`,
+                    ),
+                  );
+                  return;
+                }
+                console.log(chalk.dim(`Downloading ${progress.path}`));
+              },
+        });
+
+        if (json) {
+          console.log(JSON.stringify(result));
+          return;
+        }
+
+        console.log(chalk.green("✓ Hosted site cloned"));
+        console.log(chalk.dim(`  Site: ${result.publicSlug}`));
+        console.log(chalk.dim(`  Deployment: ${result.deploymentId}`));
+        console.log(chalk.dim(`  Files: ${result.fileCount.toLocaleString()}`));
+        console.log(chalk.dim(`  Size: ${formatBytes(result.size)}`));
+        console.log(chalk.dim(`  Location: ${result.destination}/`));
+        console.log(`  URL: ${result.url}`);
+      },
+    ),
+  );

--- a/turbo/apps/cli/src/commands/zero/host/index.ts
+++ b/turbo/apps/cli/src/commands/zero/host/index.ts
@@ -6,9 +6,10 @@ import {
 } from "@vm0/api-contracts/contracts/zero-host";
 import { withErrorHandler } from "../../../lib/command";
 import { publishStaticSite } from "../../../lib/host/publish-static-site";
+import { cloneHostedSiteCommand } from "./clone";
 
 interface HostOptions {
-  readonly site: string;
+  readonly site?: string;
   readonly slugSuffix?: string;
   readonly artifactKind?: HostedArtifactKind;
   readonly spa?: boolean;
@@ -27,9 +28,9 @@ function formatBytes(bytes: number): string {
 
 export const zeroHostCommand = new Command()
   .name("host")
-  .description("Publish a built static site and print its public URL")
+  .description("Publish static sites and clone owned hosted site files")
   .argument("<dir>", "Static build directory, for example ./dist")
-  .requiredOption("--site <slug>", "Public site slug, e.g. my-product-demo")
+  .option("--site <slug>", "Public site slug, e.g. my-product-demo")
   .option("--slug-suffix <suffix>", "Reuse a generated site URL suffix")
   .option(
     "--artifact-kind <kind>",
@@ -38,22 +39,27 @@ export const zeroHostCommand = new Command()
   )
   .option("--spa", "Serve unknown HTML navigation paths from index.html")
   .option("--json", "Output only the final result as JSON")
+  .addCommand(cloneHostedSiteCommand)
   .addHelpText(
     "after",
     `
 Examples:
   Publish a Vite build:  zero host ./dist --site my-product-demo --spa
   Redeploy a URL:       zero host ./dist --site my-product-demo --slug-suffix a1b2c3d4 --spa
+  Clone a hosted site:   zero host clone my-product-demo-a1b2c3d4-release-01 ./site
   Machine readable:     zero host ./dist --site my-product-demo --spa --json
 
 Notes:
-  - Authenticates via ZERO_TOKEN (requires host:write capability)
+  - Authenticates via ZERO_TOKEN (publish requires host:write; clone requires host:read)
   - Reusing both --site and --slug-suffix keeps the same URL
   - The directory must include index.html
   - Local HTML/CSS asset references must point at files inside the directory`,
   )
   .action(
     withErrorHandler(async (dir: string, options: HostOptions) => {
+      if (!options.site) {
+        throw new Error("--site is required when publishing a hosted site");
+      }
       const result = await publishStaticSite({
         dir,
         site: options.site,

--- a/turbo/apps/cli/src/lib/api/domains/zero-host.ts
+++ b/turbo/apps/cli/src/lib/api/domains/zero-host.ts
@@ -2,15 +2,21 @@ import type {
   HostedSitePrepareRequest,
   HostedSitePrepareResponse,
   HostedSiteCompleteResponse,
+  HostedSiteFilesResponse,
 } from "@vm0/api-contracts/contracts/zero-host";
 import { ApiRequestError, getBaseUrl } from "../core/client-factory";
 import { getActiveToken } from "../config";
 
-function authHeaders(token: string): Record<string, string> {
+function authHeaders(
+  token: string,
+  options: { readonly json?: boolean } = {},
+): Record<string, string> {
   const headers: Record<string, string> = {
     Authorization: `Bearer ${token}`,
-    "Content-Type": "application/json",
   };
+  if (options.json) {
+    headers["Content-Type"] = "application/json";
+  }
   const bypassSecret = process.env.VERCEL_AUTOMATION_BYPASS_SECRET;
   if (bypassSecret) {
     headers["x-vercel-protection-bypass"] = bypassSecret;
@@ -56,7 +62,7 @@ export async function prepareHostedSite(
     new URL("/api/zero/host/deployments/prepare", baseUrl),
     {
       method: "POST",
-      headers: authHeaders(token),
+      headers: authHeaders(token, { json: true }),
       body: JSON.stringify(body),
     },
   );
@@ -81,7 +87,7 @@ export async function completeHostedSite(
     ),
     {
       method: "POST",
-      headers: authHeaders(token),
+      headers: authHeaders(token, { json: true }),
       body: JSON.stringify({}),
     },
   );
@@ -93,4 +99,28 @@ export async function completeHostedSite(
     throw new ApiRequestError(message, code, response.status);
   }
   return (await response.json()) as HostedSiteCompleteResponse;
+}
+
+export async function getHostedSiteFiles(
+  publicSlug: string,
+): Promise<HostedSiteFilesResponse> {
+  const { baseUrl, token } = await getAuthContext();
+  const response = await fetch(
+    new URL(
+      `/api/zero/host/sites/${encodeURIComponent(publicSlug)}/files`,
+      baseUrl,
+    ),
+    {
+      method: "GET",
+      headers: authHeaders(token),
+    },
+  );
+  if (!response.ok) {
+    const { message, code } = await parseErrorBody(
+      response,
+      "Failed to get hosted-site files",
+    );
+    throw new ApiRequestError(message, code, response.status);
+  }
+  return (await response.json()) as HostedSiteFilesResponse;
 }

--- a/turbo/apps/cli/src/lib/api/index.ts
+++ b/turbo/apps/cli/src/lib/api/index.ts
@@ -247,4 +247,8 @@ export {
 } from "./domains/web";
 
 // Domain modules - Zero Host
-export { prepareHostedSite, completeHostedSite } from "./domains/zero-host";
+export {
+  prepareHostedSite,
+  completeHostedSite,
+  getHostedSiteFiles,
+} from "./domains/zero-host";

--- a/turbo/apps/cli/src/lib/host/clone-hosted-site.ts
+++ b/turbo/apps/cli/src/lib/host/clone-hosted-site.ts
@@ -1,0 +1,148 @@
+import { createHash } from "node:crypto";
+import { mkdir, writeFile } from "node:fs/promises";
+import { dirname, isAbsolute, relative, resolve, sep } from "node:path";
+
+import type { HostedSiteFilesResponse } from "@vm0/api-contracts/contracts/zero-host";
+import { getHostedSiteFiles } from "../api";
+import { checkDirectoryStatus } from "../utils/file-utils";
+
+interface CloneHostedSiteProgress {
+  readonly phase: "checking" | "creating" | "downloading";
+  readonly fileCount?: number;
+  readonly path?: string;
+}
+
+interface CloneHostedSiteResult {
+  readonly siteId: string;
+  readonly deploymentId: string;
+  readonly publicSlug: string;
+  readonly url: string;
+  readonly destination: string;
+  readonly fileCount: number;
+  readonly size: number;
+}
+
+interface CloneHostedSiteOptions {
+  readonly site: string;
+  readonly destination: string;
+  readonly onProgress?: (progress: CloneHostedSiteProgress) => void;
+}
+
+export function publicSlugFromSite(value: string): string {
+  const trimmed = value.trim();
+  if (URL.canParse(trimmed)) {
+    const url = new URL(trimmed);
+    return url.hostname.split(".")[0] ?? trimmed;
+  }
+  if (trimmed.includes(".")) {
+    return trimmed.split(".")[0] ?? trimmed;
+  }
+  return trimmed;
+}
+
+function isInsideDirectory(parent: string, target: string): boolean {
+  const relativePath = relative(parent, target);
+  return (
+    relativePath === "" ||
+    (!relativePath.startsWith(`..${sep}`) &&
+      relativePath !== ".." &&
+      !isAbsolute(relativePath))
+  );
+}
+
+function outputPathForHostedFile(
+  destination: string,
+  hostedPath: string,
+): string {
+  if (
+    !hostedPath.startsWith("/") ||
+    hostedPath.startsWith("//") ||
+    hostedPath.includes("\\") ||
+    hostedPath.includes("\0")
+  ) {
+    throw new Error(`Invalid hosted-site path: ${hostedPath}`);
+  }
+
+  const segments = hostedPath.split("/").filter((segment) => {
+    return segment.length > 0;
+  });
+  if (
+    segments.length === 0 ||
+    segments.some((segment) => {
+      return segment === "." || segment === "..";
+    })
+  ) {
+    throw new Error(`Invalid hosted-site path: ${hostedPath}`);
+  }
+
+  const destinationRoot = resolve(destination);
+  const outputPath = resolve(destinationRoot, ...segments);
+  if (!isInsideDirectory(destinationRoot, outputPath)) {
+    throw new Error(`Invalid hosted-site path: ${hostedPath}`);
+  }
+
+  return outputPath;
+}
+
+function sha256(bytes: Buffer): string {
+  return createHash("sha256").update(bytes).digest("hex");
+}
+
+async function downloadHostedFile(
+  file: HostedSiteFilesResponse["files"][number],
+  siteUrl: string,
+  destination: string,
+): Promise<void> {
+  const response = await fetch(new URL(file.path, siteUrl));
+  if (!response.ok) {
+    throw new Error(
+      `Failed to download ${file.path} (HTTP ${response.status})`,
+    );
+  }
+
+  const bytes = Buffer.from(await response.arrayBuffer());
+  if (bytes.byteLength !== file.size) {
+    throw new Error(`Downloaded size mismatch for ${file.path}`);
+  }
+  if (sha256(bytes) !== file.sha256) {
+    throw new Error(`Downloaded hash mismatch for ${file.path}`);
+  }
+
+  const outputPath = outputPathForHostedFile(destination, file.path);
+  await mkdir(dirname(outputPath), { recursive: true });
+  await writeFile(outputPath, bytes);
+}
+
+export async function cloneHostedSite(
+  options: CloneHostedSiteOptions,
+): Promise<CloneHostedSiteResult> {
+  const publicSlug = publicSlugFromSite(options.site);
+  const dirStatus = checkDirectoryStatus(options.destination);
+  if (dirStatus.exists && !dirStatus.empty) {
+    throw new Error(`Directory "${options.destination}" is not empty`);
+  }
+
+  options.onProgress?.({ phase: "checking" });
+  const hostedSite = await getHostedSiteFiles(publicSlug);
+
+  options.onProgress?.({
+    phase: "creating",
+    fileCount: hostedSite.fileCount,
+  });
+  await mkdir(options.destination, { recursive: true });
+
+  for (const file of hostedSite.files) {
+    options.onProgress?.({ phase: "downloading", path: file.path });
+    await downloadHostedFile(file, hostedSite.url, options.destination);
+  }
+
+  return {
+    siteId: hostedSite.siteId,
+    deploymentId: hostedSite.deploymentId,
+    publicSlug: hostedSite.publicSlug,
+    url: hostedSite.url,
+    destination: options.destination,
+    fileCount: hostedSite.fileCount,
+    size: hostedSite.size,
+  };
+}

--- a/turbo/apps/cli/src/zero.ts
+++ b/turbo/apps/cli/src/zero.ts
@@ -68,7 +68,7 @@ const COMMAND_CAPABILITY_MAP: Record<
   generate: null,
   web: null,
   video: null,
-  host: "host:write",
+  host: ["host:read", "host:write"],
   maps: "maps:read",
   banking: "banking:read",
 };
@@ -123,6 +123,8 @@ function shouldHideCommand(
 export function buildZeroHelpText(
   payload: ZeroTokenPayload | undefined = decodeZeroTokenPayload(),
 ): string {
+  const canReadHost = !payload || payload.capabilities.includes("host:read");
+  const canWriteHost = !payload || payload.capabilities.includes("host:write");
   const examples = [
     "  Check a connector?     zero doctor check-connector --env-name <ENV_NAME>",
     ...(payload && !payload.capabilities.includes("billing:read")
@@ -150,9 +152,12 @@ export function buildZeroHelpText(
     '  Generate image?        zero generate image --prompt "..."',
     '  Generate website?      zero generate website --prompt "..."',
     '  Generate voice?        zero generate voice --prompt "..."',
-    ...(shouldHideCommand("host", payload)
-      ? []
-      : ["  Host a static site?    zero host ./dist --site my-site --spa"]),
+    ...(canWriteHost
+      ? ["  Host a static site?    zero host ./dist --site my-site --spa"]
+      : []),
+    ...(canReadHost
+      ? ["  Clone hosted site?     zero host clone <public-slug>"]
+      : []),
     ...(shouldHideCommand("maps", payload)
       ? []
       : [

--- a/turbo/apps/web/__tests__/api-backend-rewrite-proxy.test.ts
+++ b/turbo/apps/web/__tests__/api-backend-rewrite-proxy.test.ts
@@ -1476,6 +1476,16 @@ describe("API backend rewrite proxy behavior", () => {
     expect(
       matchesApiBackendRewritePath("/api/zero/host/presentation-html/redeploy"),
     ).toBe(true);
+    expect(
+      matchesApiBackendRewritePath(
+        "/api/zero/host/sites/demo-site-a1b2c3d4-release-01/files",
+      ),
+    ).toBe(true);
+    expect(
+      matchesApiBackendRewritePath(
+        "/api/zero/host/sites/demo-site-a1b2c3d4-release-01/files/extra",
+      ),
+    ).toBe(false);
   });
 
   it("matches the email unsubscribe rewrite path exactly", () => {

--- a/turbo/apps/web/api-backend-rewrites.js
+++ b/turbo/apps/web/api-backend-rewrites.js
@@ -37,6 +37,9 @@ const ZERO_RUNS_AGENT_EVENTS_REWRITE_SOURCE = `/api/zero/runs/:id(${UUID_PATH_SE
 const ZERO_RUNS_AGENT_EVENTS_PATH_RE = new RegExp(
   `^/api/zero/runs/${UUID_PATH_SEGMENT_PATTERN}/telemetry/agent$`,
 );
+const ZERO_HOST_SITE_FILES_REWRITE_SOURCE =
+  "/api/zero/host/sites/:publicSlug/files";
+const ZERO_HOST_SITE_FILES_PATH_RE = /^\/api\/zero\/host\/sites\/[^/]+\/files$/;
 const ZERO_LOGS_BY_ID_REWRITE_SOURCE = `/api/zero/logs/:id(${UUID_PATH_SEGMENT_PATTERN})`;
 const ZERO_LOGS_BY_ID_PATH_RE = new RegExp(
   `^/api/zero/logs/${UUID_PATH_SEGMENT_PATTERN}$`,
@@ -805,6 +808,11 @@ export const API_BACKEND_REWRITES = [
   [
     "/api/zero/host/presentation-html/speaker-notes",
     "/api/zero/host/presentation-html/speaker-notes",
+  ],
+  [
+    ZERO_HOST_SITE_FILES_REWRITE_SOURCE,
+    "/api/zero/host/sites/:publicSlug/files",
+    ZERO_HOST_SITE_FILES_PATH_RE,
   ],
   [ZERO_ME_MODEL_PROVIDERS_REWRITE_SOURCE, "/api/zero/me/model-providers"],
   [

--- a/turbo/packages/api-contracts/src/contracts/zero-host.ts
+++ b/turbo/packages/api-contracts/src/contracts/zero-host.ts
@@ -35,6 +35,16 @@ export const hostedSiteSlugSuffixSchema = z
     "Site slug suffix must use lowercase letters, numbers, and hyphens, and must start and end with a letter or number",
   );
 
+export const hostedSitePublicSlugSchema = z
+  .string()
+  .trim()
+  .min(3)
+  .max(MAX_HOSTED_SITE_PUBLIC_SLUG_LENGTH)
+  .regex(
+    /^[a-z0-9](?:[a-z0-9-]*[a-z0-9])?$/,
+    "Hosted site public slug must use lowercase letters, numbers, and hyphens, and must start and end with a letter or number",
+  );
+
 export const hostedSiteFileSchema = z.object({
   path: z.string().min(1).max(1024).regex(/^\//, "File path must start with /"),
   size: z.number().int().nonnegative(),
@@ -113,6 +123,16 @@ export const hostedSiteCompleteResponseSchema = z.object({
   status: z.literal("ready"),
 });
 
+export const hostedSiteFilesResponseSchema = z.object({
+  siteId: z.string().uuid(),
+  deploymentId: z.string().uuid(),
+  publicSlug: hostedSitePublicSlugSchema,
+  url: z.string().url(),
+  fileCount: z.number().int().nonnegative(),
+  size: z.number().int().nonnegative(),
+  files: z.array(hostedSiteFileSchema),
+});
+
 export const zeroHostContract = c.router({
   prepare: {
     method: "POST",
@@ -149,6 +169,24 @@ export const zeroHostContract = c.router({
       500: apiErrorSchema,
     },
     summary: "Complete a static hosted-site deployment",
+  },
+  files: {
+    method: "GET",
+    path: "/api/zero/host/sites/:publicSlug/files",
+    pathParams: z.object({
+      publicSlug: hostedSitePublicSlugSchema,
+    }),
+    headers: authHeadersSchema,
+    responses: {
+      200: hostedSiteFilesResponseSchema,
+      400: apiErrorSchema,
+      401: apiErrorSchema,
+      403: apiErrorSchema,
+      404: apiErrorSchema,
+      409: apiErrorSchema,
+      500: apiErrorSchema,
+    },
+    summary: "List active hosted-site files for an owned site",
   },
   redeployPresentationHtml: {
     method: "POST",
@@ -202,4 +240,7 @@ export type HostedSitePrepareResponse = z.infer<
 >;
 export type HostedSiteCompleteResponse = z.infer<
   typeof hostedSiteCompleteResponseSchema
+>;
+export type HostedSiteFilesResponse = z.infer<
+  typeof hostedSiteFilesResponseSchema
 >;


### PR DESCRIPTION
## Summary
- Add an authenticated `host:read` API endpoint that returns the active hosted-site deployment manifest for sites owned by the active org.
- Add `zero host clone <site> [destination]` so hosted-site content can be cloned locally.
- Download file content from the public hosted-site URL, then validate paths, byte sizes, and SHA-256 hashes from the authenticated manifest.
- Update ZERO token host capability visibility/help for read access.

## Notes
- This does not configure anti-bot rules.
- The CLI read path no longer uses presigned R2 GET URLs; the API is only used for ownership checks and the active file manifest.

## Testing
- `pnpm -F @vm0/db db:migrate`
- `pnpm -F @vm0/firewalls-generator generate`
- `pnpm -F api exec vitest run src/signals/routes/__tests__/zero-host.test.ts`
- `pnpm -F @vm0/cli exec vitest run src/commands/zero/host/__tests__/clone.test.ts`
- `pnpm -F @vm0/cli exec vitest run src/__tests__/zero-capability-visibility.test.ts src/__tests__/zero.test.ts`
- `pnpm -F api lint`
- `pnpm -F @vm0/cli lint`
- `pnpm -F @vm0/api-contracts lint`
- `pnpm -F api check-types`
- `pnpm -F @vm0/api-contracts check-types`
- `pnpm -F @vm0/cli check-types`
- `pnpm check-types`
- pre-commit hook: prettier, knip, check-types