### PR TITLE
fix: make bubblemaps icon svg valid

### DIFF
--- a/turbo/apps/platform/src/views/zero-page/components/settings/icons/bubblemaps.svg
+++ b/turbo/apps/platform/src/views/zero-page/components/settings/icons/bubblemaps.svg
@@ -1,7 +1,7 @@
-<!-- Official brand asset source: https://bubblemaps.io/safari-pinned-tab.svg?v=2 -->
 <?xml version="1.0" standalone="no"?>
 <!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 20010904//EN"
  "http://www.w3.org/TR/2001/REC-SVG-20010904/DTD/svg10.dtd">
+<!-- Official brand asset source: https://bubblemaps.io/safari-pinned-tab.svg?v=2 -->
 <svg version="1.0" xmlns="http://www.w3.org/2000/svg"
  width="888.000000pt" height="888.000000pt" viewBox="0 0 888.000000 888.000000"
  preserveAspectRatio="xMidYMid meet">


### PR DESCRIPTION
## Summary

- Move the Bubblemaps icon source comment after the XML declaration and DOCTYPE so strict SVG parsers accept the file.
- Keep the official mark geometry and explicit black fill unchanged.

Closes #17016

## Verification

- `npx --yes sharp-cli -i turbo/apps/platform/src/views/zero-page/components/settings/icons/bubblemaps.svg -o /tmp/vm0-bubblemaps-fixed.png resize 256 256`
- `git diff --check`

Full test suite not run; this is an SVG header-only asset fix.