### PR TITLE
feat: add meta ads oauth connector

### DIFF
--- a/turbo/apps/api/src/signals/routes/__tests__/zero-runs-create.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/zero-runs-create.test.ts
@@ -2365,6 +2365,79 @@ describe("POST /api/zero/runs", () => {
     ).toContain("google-ads");
   });
 
+  it("adds the Meta Ads token and firewall for authorized connector runs", async () => {
+    const fx = await fixture();
+    const db = store.set(writeDb$);
+    const agent = await seedRunnableZeroAgent({ fixture: fx });
+    await db.insert(userConnectors).values({
+      orgId: fx.orgId,
+      userId: fx.userId,
+      agentId: agent.agentId,
+      connectorType: "meta-ads",
+    });
+    await db.insert(connectors).values({
+      orgId: fx.orgId,
+      userId: fx.userId,
+      type: "meta-ads",
+      authMethod: "oauth",
+    });
+    await db.insert(secrets).values([
+      {
+        orgId: fx.orgId,
+        userId: fx.userId,
+        name: "META_ADS_ACCESS_TOKEN",
+        encryptedValue: encryptSecretForTests("meta-ads-access"),
+        type: "connector",
+      },
+      {
+        orgId: fx.orgId,
+        userId: fx.userId,
+        name: "META_ADS_REFRESH_TOKEN",
+        encryptedValue: encryptSecretForTests("meta-ads-refresh"),
+        type: "connector",
+      },
+    ]);
+
+    const response = await accept(
+      zeroRunsClient().create({
+        headers: { authorization: "Bearer clerk-session" },
+        body: { prompt: "meta ads connector", agentId: agent.agentId },
+      }),
+      [201],
+    );
+
+    const [job] = await db
+      .select({ executionContext: runnerJobQueue.executionContext })
+      .from(runnerJobQueue)
+      .where(eq(runnerJobQueue.runId, response.body.runId));
+    const executionContext = job?.executionContext as {
+      readonly encryptedSecrets: string | null;
+      readonly secretConnectorMap: Record<string, string> | null;
+      readonly firewalls: readonly {
+        readonly name: string;
+        readonly apis: readonly {
+          readonly auth?: {
+            readonly headers?: Record<string, string>;
+          };
+        }[];
+      }[];
+    };
+    expect(
+      decryptSecretsMapForTests(executionContext.encryptedSecrets),
+    ).toMatchObject({
+      META_ADS_TOKEN: "meta-ads-access",
+    });
+    expect(executionContext.secretConnectorMap).toStrictEqual({
+      META_ADS_TOKEN: "meta-ads",
+    });
+    const firewall = executionContext.firewalls.find((candidate) => {
+      return candidate.name === "meta-ads";
+    });
+    expect(firewall?.apis[0]?.auth?.headers).toStrictEqual({
+      Authorization: ["Bearer $", "{{ secrets.META_ADS_TOKEN }}"].join(""),
+    });
+  });
+
   it("injects authorized custom connector firewalls and secrets", async () => {
     const fx = await fixture();
     const db = store.set(writeDb$);

--- a/turbo/apps/api/src/signals/services/__tests__/zero-connector-data.service.test.ts
+++ b/turbo/apps/api/src/signals/services/__tests__/zero-connector-data.service.test.ts
@@ -204,6 +204,59 @@ describe("zeroConnectorList", () => {
     );
   });
 
+  it("reports Meta Ads OAuth runtime token binding", async () => {
+    const orgId = `org_${randomUUID()}`;
+    const userId = `user_${randomUUID()}`;
+
+    await writeDb.insert(connectors).values({
+      orgId,
+      userId,
+      type: "meta-ads",
+      authMethod: "oauth",
+    });
+    await writeDb.insert(userFeatureSwitches).values({
+      orgId,
+      userId,
+      switches: {
+        [FeatureSwitchKey.MetaAdsConnector]: true,
+      },
+    });
+    await writeDb.insert(secrets).values([
+      {
+        orgId,
+        userId,
+        name: "META_ADS_ACCESS_TOKEN",
+        encryptedValue: "encrypted_meta_ads_access_token",
+        type: "connector",
+      },
+      {
+        orgId,
+        userId,
+        name: "META_ADS_REFRESH_TOKEN",
+        encryptedValue: "encrypted_meta_ads_refresh_token",
+        type: "connector",
+      },
+    ]);
+
+    const list = await store.get(zeroConnectorList({ orgId, userId }));
+
+    expect(list.connectorProvidedBindings).toStrictEqual(
+      expect.arrayContaining([
+        {
+          connectorType: "meta-ads",
+          authMethod: "oauth",
+          namespace: "secrets",
+          name: "META_ADS_TOKEN",
+          optional: false,
+          source: {
+            kind: "connector-secret",
+            name: "META_ADS_ACCESS_TOKEN",
+          },
+        },
+      ]),
+    );
+  });
+
   it("reports variable-backed connector env names as structured provided bindings", async () => {
     const orgId = `org_${randomUUID()}`;
     const userId = `user_${randomUUID()}`;

--- a/turbo/apps/platform/src/signals/zero-page/settings/__tests__/google-ads-connector.test.ts
+++ b/turbo/apps/platform/src/signals/zero-page/settings/__tests__/google-ads-connector.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, it } from "vitest";
+import { FeatureSwitchKey } from "@vm0/connectors/feature-switch-key";
 import { setupPage } from "../../../../__tests__/page-helper.ts";
 import { testContext } from "../../../__tests__/test-helpers.ts";
 import { allConnectorTypes$ } from "../connectors.ts";
@@ -20,5 +21,37 @@ describe("google ads connector", () => {
 
     expect(googleAds?.label).toBe("Google Ads");
     expect(googleAds?.availableAuthMethods).toStrictEqual(["oauth"]);
+  });
+
+  it("hides Meta Ads by default", async () => {
+    await setupPage({
+      context,
+      path: "/",
+      withoutRender: true,
+    });
+
+    const connectors = await context.store.get(allConnectorTypes$);
+    const metaAds = connectors.find((connector) => {
+      return connector.type === "meta-ads";
+    });
+
+    expect(metaAds).toBeUndefined();
+  });
+
+  it("shows Meta Ads when its feature switch is enabled", async () => {
+    await setupPage({
+      context,
+      path: "/",
+      featureSwitches: { [FeatureSwitchKey.MetaAdsConnector]: true },
+      withoutRender: true,
+    });
+
+    const connectors = await context.store.get(allConnectorTypes$);
+    const metaAds = connectors.find((connector) => {
+      return connector.type === "meta-ads";
+    });
+
+    expect(metaAds?.label).toBe("Meta Ads");
+    expect(metaAds?.availableAuthMethods).toStrictEqual(["oauth"]);
   });
 });

--- a/turbo/apps/platform/src/signals/zero-page/settings/connectors.ts
+++ b/turbo/apps/platform/src/signals/zero-page/settings/connectors.ts
@@ -446,6 +446,7 @@ const EXTERNAL_ADOPTED_ONBOARDING_TYPES: readonly string[] = [
   "fal",
   "firecrawl",
   "google-ads",
+  "meta-ads",
   "google-meet",
   "heygen",
   "hubspot",

--- a/turbo/packages/connectors/src/__tests__/connectors.test.ts
+++ b/turbo/packages/connectors/src/__tests__/connectors.test.ts
@@ -2474,6 +2474,17 @@ describe("getAvailableConnectorAuthMethodIds", () => {
     ).toStrictEqual(["api-token"]);
   });
 
+  it("exposes Meta Ads OAuth only when its switch is enabled", () => {
+    expect(getAvailableConnectorAuthMethodIds("meta-ads", {})).toStrictEqual(
+      [],
+    );
+    expect(
+      getAvailableConnectorAuthMethodIds("meta-ads", {
+        [FeatureSwitchKey.MetaAdsConnector]: true,
+      }),
+    ).toStrictEqual(["oauth"]);
+  });
+
   it("exposes Ashby API-token auth without a feature switch", () => {
     expect(getAvailableConnectorAuthMethodIds("ashby", {})).toStrictEqual([
       "api-token",
@@ -2700,6 +2711,44 @@ describe("getConnectorAuthMethodAccessMetadata", () => {
     });
   });
 
+  it("returns long-lived access token refresh metadata for Meta Ads", () => {
+    expect(
+      getConnectorAuthMethodAccessMetadata("meta-ads", "oauth"),
+    ).toStrictEqual({
+      kind: "refresh-token",
+      inputs: {
+        refreshToken: {
+          valueRef: "$secrets.META_ADS_REFRESH_TOKEN",
+          source: {
+            kind: "connector-secret",
+            name: "META_ADS_REFRESH_TOKEN",
+          },
+        },
+      },
+      outputs: {
+        accessToken: {
+          valueRef: "$secrets.META_ADS_ACCESS_TOKEN",
+          target: {
+            kind: "connector-secret",
+            name: "META_ADS_ACCESS_TOKEN",
+          },
+        },
+        refreshToken: {
+          valueRef: "$secrets.META_ADS_REFRESH_TOKEN",
+          target: {
+            kind: "connector-secret",
+            name: "META_ADS_REFRESH_TOKEN",
+          },
+        },
+      },
+      refreshableSecrets: ["META_ADS_ACCESS_TOKEN"],
+      envBindings: {
+        META_ADS_TOKEN: "$secrets.META_ADS_ACCESS_TOKEN",
+      },
+      platformSecrets: [],
+    });
+  });
+
   it("supports multi-input and multi-output refresh metadata", () => {
     expect(
       getConnectorAuthMethodAccessMetadata("test-oauth", "api"),
@@ -2921,6 +2970,13 @@ describe("getConnectorAuthMethodAccessMetadata", () => {
       "GOOGLE_ADS_REFRESH_TOKEN",
     ]);
   });
+
+  it("keeps Meta Ads runtime token connector-owned", () => {
+    expect(getConnectorOwnedSecretNames("meta-ads", "oauth")).toStrictEqual([
+      "META_ADS_ACCESS_TOKEN",
+      "META_ADS_REFRESH_TOKEN",
+    ]);
+  });
 });
 
 describe("getConnectorAuthMethodRuntimeMetadata", () => {
@@ -3059,6 +3115,28 @@ describe("getConnectorAuthMethodRuntimeMetadata", () => {
           source: {
             kind: "platform-secret",
             name: "GOOGLE_ADS_DEVELOPER_TOKEN",
+          },
+        },
+      ],
+    });
+  });
+
+  it("returns Meta Ads runtime token binding metadata", () => {
+    expect(
+      getConnectorAuthMethodRuntimeMetadata("meta-ads", "oauth"),
+    ).toStrictEqual({
+      storage: {
+        secrets: ["META_ADS_ACCESS_TOKEN", "META_ADS_REFRESH_TOKEN"],
+        variables: [],
+      },
+      runtimeBindings: [
+        {
+          envName: "META_ADS_TOKEN",
+          valueRef: "$secrets.META_ADS_ACCESS_TOKEN",
+          optional: false,
+          source: {
+            kind: "connector-secret",
+            name: "META_ADS_ACCESS_TOKEN",
           },
         },
       ],

--- a/turbo/packages/connectors/src/auth-providers/connector-auth.ts
+++ b/turbo/packages/connectors/src/auth-providers/connector-auth.ts
@@ -504,7 +504,7 @@ const CONNECTOR_AUTH_METHOD_PROVIDERS = {
   todoist: { oauth: authCodeProviderEntry(todoistProvider) },
   vercel: { oauth: authCodeProviderEntry(vercelProvider) },
   webflow: { oauth: authCodeProviderEntry(webflowProvider) },
-  "meta-ads": { oauth: authCodeProviderEntry(metaAdsProvider) },
+  "meta-ads": { oauth: authCodeRefreshProviderEntry(metaAdsProvider) },
   x: { oauth: authCodeRefreshProviderEntry(xProvider) },
   xero: { oauth: authCodeRefreshProviderEntry(xeroProvider) },
   zoom: { oauth: authCodeRefreshProviderEntry(zoomProvider) },

--- a/turbo/packages/connectors/src/auth-providers/connectors/__tests__/meta-ads.test.ts
+++ b/turbo/packages/connectors/src/auth-providers/connectors/__tests__/meta-ads.test.ts
@@ -10,6 +10,7 @@ import {
   buildMetaAdsAuthorizationUrl,
   exchangeMetaAdsCode,
   getMetaAdsSecretName,
+  refreshMetaAdsLongLivedToken,
 } from "../meta-ads/oauth";
 import { metaAdsProvider } from "../meta-ads/provider";
 import { server } from "../../__tests__/test-server";
@@ -149,6 +150,38 @@ describe("connector/providers/meta-ads", () => {
     });
   });
 
+  describe("refreshMetaAdsLongLivedToken", () => {
+    it("refreshes a long-lived access token through fb_exchange_token", async () => {
+      const handler = http.get(TOKEN_URL, ({ request }) => {
+        const url = new URL(request.url);
+        expect(url.searchParams.get("grant_type")).toBe("fb_exchange_token");
+        expect(url.searchParams.get("client_id")).toBe("client-id");
+        expect(url.searchParams.get("client_secret")).toBe("client-secret");
+        expect(url.searchParams.get("fb_exchange_token")).toBe(
+          "current-long-lived-token",
+        );
+        return HttpResponse.json({
+          access_token: "refreshed-long-lived-token",
+          token_type: "bearer",
+          expires_in: 5184000,
+        });
+      });
+      server.use(handler);
+
+      await expect(
+        refreshMetaAdsLongLivedToken(
+          "client-id",
+          "client-secret",
+          "current-long-lived-token",
+          new AbortController().signal,
+        ),
+      ).resolves.toStrictEqual({
+        accessToken: "refreshed-long-lived-token",
+        expiresIn: 5184000,
+      });
+    });
+  });
+
   describe("getMetaAdsSecretName", () => {
     it("returns the expected secret name", () => {
       expect(getMetaAdsSecretName()).toBe("META_ADS_ACCESS_TOKEN");
@@ -187,8 +220,31 @@ describe("connector/providers/meta-ads", () => {
       });
     });
 
-    it("refreshToken is not registered (Meta uses long-lived token exchange)", () => {
-      expect(metaAdsProvider.access.kind).toBe("none");
+    it("refreshes the stored long-lived access token", async () => {
+      const handler = http.get(TOKEN_URL, () => {
+        return HttpResponse.json({
+          access_token: "provider-refreshed-token",
+          token_type: "bearer",
+          expires_in: 5184000,
+        });
+      });
+      server.use(handler);
+
+      await expect(
+        metaAdsProvider.access.refresh({
+          authClient: testAuthClient,
+          inputs: {
+            refreshToken: "current-long-lived-token",
+          },
+          signal: new AbortController().signal,
+        }),
+      ).resolves.toStrictEqual({
+        outputs: {
+          accessToken: "provider-refreshed-token",
+          refreshToken: "provider-refreshed-token",
+        },
+        expiresIn: 5184000,
+      });
     });
   });
 });

--- a/turbo/packages/connectors/src/auth-providers/connectors/meta-ads/oauth.ts
+++ b/turbo/packages/connectors/src/auth-providers/connectors/meta-ads/oauth.ts
@@ -122,17 +122,19 @@ export async function exchangeMetaAdsCode(
 async function exchangeForLongLivedToken(
   clientId: string,
   clientSecret: string,
-  shortLivedToken: string,
+  token: string,
+  signal?: AbortSignal,
 ): Promise<{ accessToken: string; expiresIn?: number }> {
   const params = new URLSearchParams({
     grant_type: "fb_exchange_token",
     client_id: clientId,
     client_secret: clientSecret,
-    fb_exchange_token: shortLivedToken,
+    fb_exchange_token: token,
   });
 
   const response = await fetch(
     `https://graph.facebook.com/v22.0/oauth/access_token?${params.toString()}`,
+    signal ? { signal } : undefined,
   );
 
   if (!response.ok) {
@@ -166,6 +168,15 @@ async function exchangeForLongLivedToken(
     accessToken: data.access_token,
     expiresIn: data.expires_in,
   };
+}
+
+export async function refreshMetaAdsLongLivedToken(
+  clientId: string,
+  clientSecret: string,
+  accessToken: string,
+  signal: AbortSignal,
+): Promise<{ accessToken: string; expiresIn?: number }> {
+  return exchangeForLongLivedToken(clientId, clientSecret, accessToken, signal);
 }
 
 /**

--- a/turbo/packages/connectors/src/auth-providers/connectors/meta-ads/provider.ts
+++ b/turbo/packages/connectors/src/auth-providers/connectors/meta-ads/provider.ts
@@ -1,5 +1,10 @@
 import type { AuthCodeConnectorAuthProvider } from "../../types";
-import { buildMetaAdsAuthorizationUrl, exchangeMetaAdsCode } from "./oauth";
+import {
+  buildMetaAdsAuthorizationUrl,
+  exchangeMetaAdsCode,
+  refreshMetaAdsLongLivedToken,
+} from "./oauth";
+
 export const metaAdsProvider: AuthCodeConnectorAuthProvider<"meta-ads"> = {
   grant: {
     kind: "auth-code",
@@ -26,6 +31,7 @@ export const metaAdsProvider: AuthCodeConnectorAuthProvider<"meta-ads"> = {
       return {
         outputs: {
           accessToken: result.accessToken,
+          refreshToken: result.accessToken,
         },
         expiresIn: result.expiresIn,
         scopes: result.scopes,
@@ -38,7 +44,23 @@ export const metaAdsProvider: AuthCodeConnectorAuthProvider<"meta-ads"> = {
     },
   },
   access: {
-    kind: "none",
+    kind: "refresh-token",
+    refresh: async (args) => {
+      const { clientId, clientSecret } = args.authClient;
+      const result = await refreshMetaAdsLongLivedToken(
+        clientId,
+        clientSecret,
+        args.inputs.refreshToken,
+        args.signal,
+      );
+      return {
+        outputs: {
+          accessToken: result.accessToken,
+          refreshToken: result.accessToken,
+        },
+        expiresIn: result.expiresIn,
+      };
+    },
   },
   revoke: { kind: "none" },
 };

--- a/turbo/packages/connectors/src/connectors/meta-ads.ts
+++ b/turbo/packages/connectors/src/connectors/meta-ads.ts
@@ -10,6 +10,7 @@ export const metaAds = {
     authMethods: {
       oauth: {
         featureFlag: FeatureSwitchKey.MetaAdsConnector,
+        showExperimentalLabel: false,
         label: "OAuth (Recommended)",
         helpText: "Sign in with Facebook to grant access to Ads Manager.",
         client: {
@@ -19,7 +20,7 @@ export const metaAds = {
           clientSecretEnv: "META_ADS_OAUTH_CLIENT_SECRET",
         },
         storage: {
-          secrets: ["META_ADS_ACCESS_TOKEN"],
+          secrets: ["META_ADS_ACCESS_TOKEN", "META_ADS_REFRESH_TOKEN"],
           variables: [],
         },
         grant: {
@@ -27,10 +28,19 @@ export const metaAds = {
           scopes: ["ads_management", "ads_read", "business_management"],
           outputs: {
             accessToken: "$secrets.META_ADS_ACCESS_TOKEN",
+            refreshToken: "$secrets.META_ADS_REFRESH_TOKEN",
           },
         },
         access: {
-          kind: "static",
+          kind: "refresh-token",
+          inputs: {
+            refreshToken: "$secrets.META_ADS_REFRESH_TOKEN",
+          },
+          outputs: {
+            accessToken: "$secrets.META_ADS_ACCESS_TOKEN",
+            refreshToken: "$secrets.META_ADS_REFRESH_TOKEN",
+          },
+          refreshableSecrets: ["META_ADS_ACCESS_TOKEN"],
           envBindings: {
             META_ADS_TOKEN: "$secrets.META_ADS_ACCESS_TOKEN",
           },


### PR DESCRIPTION
## Summary
- add Meta Ads OAuth runtime access metadata behind the MetaAdsConnector feature switch
- refresh Meta long-lived access tokens through the fb_exchange_token flow while exposing META_ADS_TOKEN at runtime
- cover connector metadata, provider refresh, UI visibility, API connector list, and run firewall injection behavior

## Tests
- pnpm prettier --write packages/connectors/src/feature-switch-key.ts packages/core/src/feature-switch.ts packages/connectors/src/connectors/meta-ads.ts packages/connectors/src/__tests__/connectors.test.ts apps/platform/src/signals/zero-page/settings/__tests__/google-ads-connector.test.ts apps/api/src/signals/services/__tests__/zero-connector-data.service.test.ts
- pnpm vitest --run packages/connectors/src/auth-providers/connectors/__tests__/meta-ads.test.ts packages/connectors/src/__tests__/connectors.test.ts apps/platform/src/signals/zero-page/settings/__tests__/google-ads-connector.test.ts
- pnpm -F @vm0/connectors check-types
- pnpm -F @vm0/core check-types
- pnpm -F @vm0/app check-types
- NODE_OPTIONS=--max-old-space-size=4096 pnpm -F api check-types
- pnpm -F @vm0/connectors lint
- pnpm -F @vm0/core lint
- pnpm -F @vm0/app lint
- pnpm -F api lint
- DATABASE_URL=postgresql://user@localhost:5432/vm0_test pnpm vitest --run apps/api/src/signals/services/__tests__/zero-connector-data.service.test.ts apps/api/src/signals/routes/__tests__/zero-runs-create.test.ts